### PR TITLE
fix(web): allow md/txt static files through Clerk middleware

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -13,7 +13,7 @@ export default clerkMiddleware(async (auth, request) => {
 
 export const config = {
   matcher: [
-    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest|md|txt)).*)",
     "/(api|trpc)(.*)",
   ],
 };


### PR DESCRIPTION
## Summary

Adds `md` and `txt` to the Clerk middleware bypass matcher in `apps/web/src/middleware.ts` so `/skill.md` (and any future markdown/text assets under `public/`) are served without requiring a Clerk session.

## Problem

`apps/web/public/skill.md` is the onboarding entrypoint — users point their agent at `http://<dashboard>/skill.md` and the agent follows the steps. In practice the URL 404s because the extension isn't in the middleware whitelist, so Clerk's `protect-rewrite` rule catches it for any client without a session cookie — which is every agent.

```
$ curl -sI http://localhost:3000/skill.md
HTTP/1.1 404 Not Found
x-clerk-auth-reason: protect-rewrite, dev-browser-missing
x-middleware-rewrite: /clerk_...
```

## Fix

One-line regex tweak:

```diff
-"/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)"
+"/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest|md|txt)).*)"
```

## Verification

```
$ curl -sI http://localhost:3001/skill.md
HTTP/1.1 200 OK
Content-Type: text/markdown; charset=UTF-8
```

Closes #1.

## Test plan
- [x] `curl /skill.md` returns 200 + `Content-Type: text/markdown`
- [x] Authenticated dashboard routes still protected (verified via browser — still redirects to sign-in)
- [x] Other static extensions (`/clawdi.svg`) unaffected