### PR TITLE
fix(cli): skill sync handles symlinks, node_modules, and partial failures

### DIFF
--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, mkdirSync, rmSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, basename } from "node:path";
 import * as tar from "tar";
@@ -201,8 +201,17 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 		const skills: RawSkill[] = [];
 
 		for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
-			if (!entry.isDirectory()) continue;
 			const dirPath = join(skillsDir, entry.name);
+			// Accept real directories AND symlinks that resolve to directories (plugin-installed skills).
+			let isDir = entry.isDirectory();
+			if (!isDir && entry.isSymbolicLink()) {
+				try {
+					isDir = statSync(dirPath).isDirectory();
+				} catch {
+					isDir = false;
+				}
+			}
+			if (!isDir) continue;
 			const skillMd = join(dirPath, "SKILL.md");
 			if (!existsSync(skillMd)) continue;
 

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -233,10 +233,19 @@ export class CodexAdapter implements AgentAdapter {
 
 		const skills: RawSkill[] = [];
 		for (const entry of readdirSync(SKILLS_DIR, { withFileTypes: true })) {
-			if (!entry.isDirectory()) continue;
 			// Skip dot-dirs (e.g. `.system/` holds Codex's built-in skills, not user-authored ones).
 			if (entry.name.startsWith(".")) continue;
 			const dirPath = join(SKILLS_DIR, entry.name);
+			// Follow symlinks that resolve to directories (plugin-installed skills).
+			let isDir = entry.isDirectory();
+			if (!isDir && entry.isSymbolicLink()) {
+				try {
+					isDir = statSync(dirPath).isDirectory();
+				} catch {
+					isDir = false;
+				}
+			}
+			if (!isDir) continue;
 			const skillMd = join(dirPath, "SKILL.md");
 			if (!existsSync(skillMd)) continue;
 

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, mkdirSync, rmSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, relative } from "node:path";
 import { Database } from "bun:sqlite";
@@ -137,8 +137,17 @@ export class HermesAdapter implements AgentAdapter {
 	 */
 	private _scanSkillsDir(dir: string, results: RawSkill[]): void {
 		for (const entry of readdirSync(dir, { withFileTypes: true })) {
-			if (!entry.isDirectory()) continue;
 			const fullPath = join(dir, entry.name);
+			// Follow symlinks that resolve to directories (plugin-installed skills).
+			let isDir = entry.isDirectory();
+			if (!isDir && entry.isSymbolicLink()) {
+				try {
+					isDir = statSync(fullPath).isDirectory();
+				} catch {
+					isDir = false;
+				}
+			}
+			if (!isDir) continue;
 			const skillMd = join(fullPath, "SKILL.md");
 
 			if (existsSync(skillMd)) {

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, mkdirSync, rmSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import * as tar from "tar";
@@ -210,8 +210,17 @@ export class OpenClawAdapter implements AgentAdapter {
 
 		const skills: RawSkill[] = [];
 		for (const entry of readdirSync(SKILLS_DIR, { withFileTypes: true })) {
-			if (!entry.isDirectory()) continue;
 			const dirPath = join(SKILLS_DIR, entry.name);
+			// Follow symlinks that resolve to directories (plugin-installed skills).
+			let isDir = entry.isDirectory();
+			if (!isDir && entry.isSymbolicLink()) {
+				try {
+					isDir = statSync(dirPath).isDirectory();
+				} catch {
+					isDir = false;
+				}
+			}
+			if (!isDir) continue;
 			const skillMd = join(dirPath, "SKILL.md");
 			if (!existsSync(skillMd)) continue;
 

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -463,8 +463,9 @@ export async function syncUp(opts: {
 	if (skills.length > 0) {
 		console.log(chalk.cyan(`→ Uploading ${skills.length} skills...`));
 		let synced = 0;
-		try {
-			for (const skill of skills) {
+		const failed: { key: string; error: string }[] = [];
+		for (const skill of skills) {
+			try {
 				const tarBytes = await tarSkillDir(skill.directoryPath);
 				await api.uploadFile(
 					"/api/skills/upload",
@@ -473,10 +474,15 @@ export async function syncUp(opts: {
 					`${skill.skillKey}.tar.gz`,
 				);
 				synced++;
+			} catch (e: any) {
+				failed.push({ key: skill.skillKey, error: e?.message ?? String(e) });
 			}
-			console.log(chalk.green(`  ✓ Synced ${synced} skill${synced === 1 ? "" : "s"}`));
-		} catch (e: any) {
-			console.log(chalk.red(`  ✗ Failed after ${synced} skills: ${e.message}`));
+		}
+		console.log(
+			chalk.green(`  ✓ Synced ${synced}/${skills.length} skill${skills.length === 1 ? "" : "s"}`),
+		);
+		for (const f of failed) {
+			console.log(chalk.red(`  ✗ ${f.key}: ${f.error}`));
 		}
 		syncState.skills = { lastSyncedAt: new Date().toISOString() };
 	}

--- a/packages/cli/src/lib/tar-helpers.ts
+++ b/packages/cli/src/lib/tar-helpers.ts
@@ -10,7 +10,18 @@ export async function tarSkillDir(dirPath: string): Promise<Buffer> {
 
 	const chunks: Buffer[] = [];
 	await tar
-		.create({ gzip: true, cwd: parentDir }, [dirName])
+		.create(
+			{
+				gzip: true,
+				cwd: parentDir,
+				follow: true,
+				filter: (path) => {
+					const parts = path.split("/");
+					return !parts.includes("node_modules") && !parts.includes(".git");
+				},
+			},
+			[dirName],
+		)
 		.on("data", (chunk: Buffer) => chunks.push(chunk))
 		.promise();
 	return Buffer.concat(chunks);


### PR DESCRIPTION
## Summary

`clawdi sync up --modules skills` silently dropped the majority of a user's skills whenever those skills were plugin-installed (via symlinks) or contained `node_modules/`. This PR fixes three compounding issues.

## Problem

For a Claude Code user with a typical plugin-based skill layout:

```
~/.claude/skills/
├── gstack/              # real dir; contains node_modules/ with internal symlinks
├── browse -> gstack/browse    # symlink
├── careful -> gstack/careful  # symlink
├── (18 more symlinks...)
└── clawdi/              # real dir
```

Running `clawdi sync up --modules skills --agent claude_code` reported:

```
Summary
  Skills:   3 to upload                         # should be ~24
...
  ✗ Failed after 2 skills: API error 400:
    {"detail":"Symlinks not allowed: gstack/node_modules/.bin/playwright-core"}
```

## Root causes

1. **Adapters reject symlinked skill dirs.** Every adapter (`claude-code`, `codex`, `openclaw`, `hermes`) uses `entry.isDirectory()` on a `Dirent`, which returns `false` for symlinks even when the target is a directory with a valid `SKILL.md`.
2. **`tarSkillDir` includes `node_modules/` verbatim.** Any skill that bundles a JS runtime (playwright, anthropic SDK, etc.) ships with internal npm-generated symlinks in `node_modules/.bin/`. The upload endpoint rejects any tarball containing a symlink.
3. **Sync loop aborts on first failure.** `sync.ts` wraps the entire `for (const skill of skills)` body in one `try/catch`. One bad skill drops all remaining uploads.

## Fix

### 1. Accept symlinks that resolve to directories (all four adapters)

```ts
let isDir = entry.isDirectory();
if (!isDir && entry.isSymbolicLink()) {
    try { isDir = statSync(dirPath).isDirectory(); } catch { isDir = false; }
}
if (!isDir) continue;
```

Broken symlinks are still skipped. Unchanged: the `SKILL.md` existence check still filters non-skill directories.

### 2. Exclude `node_modules/` and `.git/` from the tarball + resolve remaining symlinks

```ts
await tar.create(
    {
        gzip: true,
        cwd: parentDir,
        follow: true,
        filter: (path) => {
            const parts = path.split('/');
            return !parts.includes('node_modules') && !parts.includes('.git');
        },
    },
    [dirName],
);
```

`follow: true` resolves any remaining symlinks to their targets at archive time, so the server-side "no symlinks" policy is upheld without rejecting the whole skill.

### 3. Continue past individual skill failures

```ts
const failed: { key: string; error: string }[] = [];
for (const skill of skills) {
    try {
        await api.uploadFile(...);
        synced++;
    } catch (e: any) {
        failed.push({ key: skill.skillKey, error: e?.message ?? String(e) });
    }
}
console.log(chalk.green(`  ✓ Synced ${synced}/${skills.length} skill(s)`));
for (const f of failed) console.log(chalk.red(`  ✗ ${f.key}: ${f.error}`));
```

Now users see exactly which skills failed and which succeeded, and a single bad skill doesn't prevent everything else from syncing.

## Verification

Local reproduction before the fix:

```
→ Uploading 3 skills...
  ✗ Failed after 2 skills: API error 400: {"detail":"Symlinks not allowed: gstack/node_modules/.bin/playwright-core"}
```

After:

```
→ Uploading 24 skills...
  ✓ Synced 24/24 skills
```

Server now lists all 24 skills including large nested ones like `gstack` (203 files).

Closes #2.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run build` clean
- [x] Fresh `clawdi sync up --modules skills --agent claude_code` on a machine with 20+ symlinked skills → all discovered and uploaded
- [x] `gstack` skill (real dir, contains `node_modules/.bin/playwright-core` symlink) uploads successfully (tarball no longer includes node_modules)
- [x] Server-side listing (`GET /api/skills`) matches local count post-sync
- [ ] (Not verified, would appreciate reviewer sanity-check) Non-Claude-Code adapters (`codex`, `openclaw`, `hermes`) — changes are mechanical ports of the same pattern, but I only have a Claude Code install to test against