### PR TITLE
feat(cli): extra skill paths per agent + clawdi skill source command

### DIFF
--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -2,6 +2,8 @@ import { existsSync, readdirSync, readFileSync, mkdirSync, rmSync } from "node:f
 import { homedir } from "node:os";
 import { join, basename } from "node:path";
 import * as tar from "tar";
+import { getExtraSkillPaths } from "../lib/config";
+import { dedupeByKey, scanFlatSkillsDir } from "../lib/skill-scan";
 import type { AgentAdapter, RawSession, RawSkill, SessionMessage } from "./base";
 
 const CLAUDE_DIR = join(homedir(), ".claude");
@@ -195,32 +197,11 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 	}
 
 	async collectSkills(): Promise<RawSkill[]> {
-		const skillsDir = join(CLAUDE_DIR, "skills");
-		if (!existsSync(skillsDir)) return [];
-
-		const skills: RawSkill[] = [];
-
-		for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
-			if (!entry.isDirectory()) continue;
-			const dirPath = join(skillsDir, entry.name);
-			const skillMd = join(dirPath, "SKILL.md");
-			if (!existsSync(skillMd)) continue;
-
-			const content = readFileSync(skillMd, "utf-8");
-			// Check if directory has more than just SKILL.md
-			const fileCount = readdirSync(dirPath, { recursive: true }).length;
-
-			skills.push({
-				skillKey: entry.name,
-				name: entry.name,
-				content,
-				filePath: skillMd,
-				directoryPath: dirPath,
-				isDirectory: fileCount > 1,
-			});
+		const skills = scanFlatSkillsDir(join(CLAUDE_DIR, "skills"));
+		for (const extra of getExtraSkillPaths(this.agentType)) {
+			skills.push(...scanFlatSkillsDir(extra));
 		}
-
-		return skills;
+		return dedupeByKey(skills);
 	}
 
 	getSkillPath(key: string): string {

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -2,6 +2,8 @@ import { existsSync, readdirSync, readFileSync, mkdirSync, rmSync, statSync, typ
 import { homedir } from "node:os";
 import { join } from "node:path";
 import * as tar from "tar";
+import { getExtraSkillPaths } from "../lib/config";
+import { dedupeByKey, scanFlatSkillsDir } from "../lib/skill-scan";
 import type { AgentAdapter, RawSession, RawSkill, SessionMessage } from "./base";
 
 const CODEX_DIR = process.env.CODEX_HOME || join(homedir(), ".codex");
@@ -229,30 +231,12 @@ export class CodexAdapter implements AgentAdapter {
 	}
 
 	async collectSkills(): Promise<RawSkill[]> {
-		if (!existsSync(SKILLS_DIR)) return [];
-
-		const skills: RawSkill[] = [];
-		for (const entry of readdirSync(SKILLS_DIR, { withFileTypes: true })) {
-			if (!entry.isDirectory()) continue;
-			// Skip dot-dirs (e.g. `.system/` holds Codex's built-in skills, not user-authored ones).
-			if (entry.name.startsWith(".")) continue;
-			const dirPath = join(SKILLS_DIR, entry.name);
-			const skillMd = join(dirPath, "SKILL.md");
-			if (!existsSync(skillMd)) continue;
-
-			const content = readFileSync(skillMd, "utf-8");
-			const fileCount = readdirSync(dirPath, { recursive: true }).length;
-
-			skills.push({
-				skillKey: entry.name,
-				name: entry.name,
-				content,
-				filePath: skillMd,
-				directoryPath: dirPath,
-				isDirectory: fileCount > 1,
-			});
+		// Skip `.system/` — Codex's built-in skills, not user-authored.
+		const skills = scanFlatSkillsDir(SKILLS_DIR, { skipDotDirs: true });
+		for (const extra of getExtraSkillPaths(this.agentType)) {
+			skills.push(...scanFlatSkillsDir(extra, { skipDotDirs: true }));
 		}
-		return skills;
+		return dedupeByKey(skills);
 	}
 
 	getSkillPath(key: string): string {

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -3,6 +3,8 @@ import { homedir } from "node:os";
 import { join, relative } from "node:path";
 import { Database } from "bun:sqlite";
 import * as tar from "tar";
+import { getExtraSkillPaths } from "../lib/config";
+import { dedupeByKey, scanFlatSkillsDir } from "../lib/skill-scan";
 import type { AgentAdapter, RawSession, RawSkill, SessionMessage } from "./base";
 
 const HERMES_DIR = process.env.HERMES_HOME || join(homedir(), ".hermes");
@@ -124,11 +126,17 @@ export class HermesAdapter implements AgentAdapter {
 	}
 
 	async collectSkills(): Promise<RawSkill[]> {
-		if (!existsSync(SKILLS_DIR)) return [];
-
 		const skills: RawSkill[] = [];
-		this._scanSkillsDir(SKILLS_DIR, skills);
-		return skills;
+		if (existsSync(SKILLS_DIR)) {
+			this._scanSkillsDir(SKILLS_DIR, skills);
+		}
+		// Extras are scanned one level deep — nested category layouts (Hermes's
+		// native form) are only assumed for the default SKILLS_DIR. Users who
+		// need nesting in extras can add each category path explicitly.
+		for (const extra of getExtraSkillPaths(this.agentType)) {
+			skills.push(...scanFlatSkillsDir(extra));
+		}
+		return dedupeByKey(skills);
 	}
 
 	/**

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -2,6 +2,8 @@ import { existsSync, readdirSync, readFileSync, mkdirSync, rmSync } from "node:f
 import { homedir } from "node:os";
 import { join } from "node:path";
 import * as tar from "tar";
+import { getExtraSkillPaths } from "../lib/config";
+import { dedupeByKey, scanFlatSkillsDir } from "../lib/skill-scan";
 import type { AgentAdapter, RawSession, RawSkill, SessionMessage } from "./base";
 
 const OPENCLAW_DIR = process.env.OPENCLAW_STATE_DIR || join(homedir(), ".openclaw");
@@ -206,28 +208,11 @@ export class OpenClawAdapter implements AgentAdapter {
 	}
 
 	async collectSkills(): Promise<RawSkill[]> {
-		if (!existsSync(SKILLS_DIR)) return [];
-
-		const skills: RawSkill[] = [];
-		for (const entry of readdirSync(SKILLS_DIR, { withFileTypes: true })) {
-			if (!entry.isDirectory()) continue;
-			const dirPath = join(SKILLS_DIR, entry.name);
-			const skillMd = join(dirPath, "SKILL.md");
-			if (!existsSync(skillMd)) continue;
-
-			const content = readFileSync(skillMd, "utf-8");
-			const fileCount = readdirSync(dirPath, { recursive: true }).length;
-
-			skills.push({
-				skillKey: entry.name,
-				name: entry.name,
-				content,
-				filePath: skillMd,
-				directoryPath: dirPath,
-				isDirectory: fileCount > 1,
-			});
+		const skills = scanFlatSkillsDir(SKILLS_DIR);
+		for (const extra of getExtraSkillPaths(this.agentType)) {
+			skills.push(...scanFlatSkillsDir(extra));
 		}
-		return skills;
+		return dedupeByKey(skills);
 	}
 
 	getSkillPath(key: string): string {

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -1,14 +1,21 @@
 import chalk from "chalk";
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
-import { AGENT_LABELS } from "@clawdi-cloud/shared/consts";
+import { AGENT_LABELS, AGENT_TYPES, type AgentType } from "@clawdi-cloud/shared/consts";
 import { ClaudeCodeAdapter } from "../adapters/claude-code";
 import { CodexAdapter } from "../adapters/codex";
 import { HermesAdapter } from "../adapters/hermes";
 import { OpenClawAdapter } from "../adapters/openclaw";
 import type { AgentAdapter } from "../adapters/base";
 import { ApiClient } from "../lib/api-client";
-import { getClawdiDir, isLoggedIn } from "../lib/config";
+import {
+	addExtraSkillPath,
+	getClawdiDir,
+	isKnownAgent,
+	isLoggedIn,
+	listExtraSkillPaths,
+	removeExtraSkillPath,
+} from "../lib/config";
 import { tarSkillDir, tarSingleFile } from "../lib/tar-helpers";
 
 function requireAuth() {
@@ -132,4 +139,59 @@ export async function skillsRm(key: string) {
 	const api = new ApiClient();
 	await api.delete(`/api/skills/${key}`);
 	console.log(chalk.green(`✓ Removed ${key}`));
+}
+
+function unknownAgentMessage(agent: string): void {
+	console.log(chalk.red(`Unknown agent: ${agent}`));
+	console.log(chalk.gray(`  Valid: ${AGENT_TYPES.join(", ")}`));
+}
+
+export function skillSourceList() {
+	const all = listExtraSkillPaths();
+	const entries = Object.entries(all) as [AgentType, string[]][];
+	if (entries.length === 0) {
+		console.log(chalk.gray("No extra skill paths configured."));
+		console.log(
+			chalk.gray(
+				"  Add one with: clawdi skill source add <agent> <path>\n" +
+					"  Supported agents: " +
+					AGENT_TYPES.join(", "),
+			),
+		);
+		return;
+	}
+	for (const [agent, paths] of entries) {
+		console.log(chalk.cyan(AGENT_LABELS[agent] ?? agent));
+		for (const p of paths ?? []) {
+			const marker = existsSync(p) ? chalk.green("✓") : chalk.yellow("!");
+			const note = existsSync(p) ? "" : chalk.gray(" (missing)");
+			console.log(`  ${marker} ${p}${note}`);
+		}
+	}
+}
+
+export function skillSourceAdd(agent: string, path: string) {
+	if (!isKnownAgent(agent)) {
+		unknownAgentMessage(agent);
+		process.exit(1);
+	}
+	const resolved = resolve(path);
+	if (!existsSync(resolved)) {
+		console.log(chalk.yellow(`Warning: ${resolved} does not exist (added anyway).`));
+	}
+	addExtraSkillPath(agent, resolved);
+	console.log(chalk.green(`✓ Added ${resolved} to ${agent} skill sources`));
+}
+
+export function skillSourceRemove(agent: string, path: string) {
+	if (!isKnownAgent(agent)) {
+		unknownAgentMessage(agent);
+		process.exit(1);
+	}
+	const removed = removeExtraSkillPath(agent, path);
+	if (!removed) {
+		console.log(chalk.yellow(`${path} was not configured for ${agent}.`));
+		process.exit(1);
+	}
+	console.log(chalk.green(`✓ Removed ${path} from ${agent} skill sources`));
 }

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -463,8 +463,9 @@ export async function syncUp(opts: {
 	if (skills.length > 0) {
 		console.log(chalk.cyan(`→ Uploading ${skills.length} skills...`));
 		let synced = 0;
-		try {
-			for (const skill of skills) {
+		const failed: { key: string; error: string }[] = [];
+		for (const skill of skills) {
+			try {
 				const tarBytes = await tarSkillDir(skill.directoryPath);
 				await api.uploadFile(
 					"/api/skills/upload",
@@ -473,10 +474,15 @@ export async function syncUp(opts: {
 					`${skill.skillKey}.tar.gz`,
 				);
 				synced++;
+			} catch (e: any) {
+				failed.push({ key: skill.skillKey, error: e?.message ?? String(e) });
 			}
-			console.log(chalk.green(`  ✓ Synced ${synced} skill${synced === 1 ? "" : "s"}`));
-		} catch (e: any) {
-			console.log(chalk.red(`  ✗ Failed after ${synced} skills: ${e.message}`));
+		}
+		console.log(
+			chalk.green(`  ✓ Synced ${synced}/${skills.length} skill${skills.length === 1 ? "" : "s"}`),
+		);
+		for (const f of failed) {
+			console.log(chalk.red(`  ✗ ${f.key}: ${f.error}`));
 		}
 		syncState.skills = { lastSyncedAt: new Date().toISOString() };
 	}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -164,6 +164,35 @@ skillsCmd
 		await skillsRm(key);
 	});
 
+const skillSourceCmd = skillsCmd
+	.command("source")
+	.description("Manage extra skill scan paths per agent");
+
+skillSourceCmd
+	.command("list")
+	.description("List configured extra skill paths")
+	.action(async () => {
+		const { skillSourceList } = await import("./commands/skills.js");
+		skillSourceList();
+	});
+
+skillSourceCmd
+	.command("add <agent> <path>")
+	.description("Add an extra skill directory for an agent")
+	.action(async (agent, path) => {
+		const { skillSourceAdd } = await import("./commands/skills.js");
+		skillSourceAdd(agent, path);
+	});
+
+skillSourceCmd
+	.command("remove <agent> <path>")
+	.alias("rm")
+	.description("Remove an extra skill directory for an agent")
+	.action(async (agent, path) => {
+		const { skillSourceRemove } = await import("./commands/skills.js");
+		skillSourceRemove(agent, path);
+	});
+
 const memoriesCmd = program
 	.command("memory")
 	.alias("mem")

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve as resolvePath } from "node:path";
+import { AGENT_TYPES, type AgentType } from "@clawdi-cloud/shared/consts";
 
 const CLAWDI_DIR = join(homedir(), ".clawdi");
 const CONFIG_FILE = join(CLAWDI_DIR, "config.json");
@@ -9,6 +10,14 @@ const SYNC_FILE = join(CLAWDI_DIR, "sync.json");
 
 export interface ClawdiConfig {
 	apiUrl: string;
+	/**
+	 * Per-agent additional directories to scan for skills, in addition to the
+	 * adapter's default location (e.g. ~/.claude/skills). Typically project-
+	 * scoped dirs like /path/to/project/.claude/skills or ad-hoc personal
+	 * libraries. Each path is scanned flat: a direct child is a skill if it
+	 * contains SKILL.md.
+	 */
+	extraSkillPaths?: Partial<Record<AgentType, string[]>>;
 }
 
 // Keys accepted by `clawdi config set/get/unset`. Add a new entry here
@@ -90,4 +99,64 @@ export function isLoggedIn(): boolean {
 
 export function getClawdiDir(): string {
 	return CLAWDI_DIR;
+}
+
+/**
+ * Return the effective extra skill paths for an agent, merged from:
+ *   - env var CLAWDI_EXTRA_SKILL_PATHS_<AGENT_UPPER> (colon-separated)
+ *   - ~/.clawdi/config.json → extraSkillPaths[agent]
+ *
+ * Paths are absolutized; order preserved (env first, then config); duplicates
+ * collapsed. Silently returns [] for unknown/unset configuration — callers
+ * don't need to guard.
+ */
+export function getExtraSkillPaths(agent: AgentType): string[] {
+	const envKey = `CLAWDI_EXTRA_SKILL_PATHS_${agent.toUpperCase()}`;
+	const fromEnv = (process.env[envKey] ?? "")
+		.split(":")
+		.map((s) => s.trim())
+		.filter(Boolean);
+	const stored = getStoredConfig().extraSkillPaths?.[agent] ?? [];
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const p of [...fromEnv, ...stored]) {
+		const abs = resolvePath(p.replace(/^~(?=\/|$)/, homedir()));
+		if (seen.has(abs)) continue;
+		seen.add(abs);
+		out.push(abs);
+	}
+	return out;
+}
+
+export function isKnownAgent(s: string): s is AgentType {
+	return (AGENT_TYPES as readonly string[]).includes(s);
+}
+
+/** Append a path to extraSkillPaths[agent]; idempotent. */
+export function addExtraSkillPath(agent: AgentType, path: string): void {
+	const current = getStoredConfig();
+	const byAgent = { ...(current.extraSkillPaths ?? {}) };
+	const abs = resolvePath(path.replace(/^~(?=\/|$)/, homedir()));
+	const list = byAgent[agent] ?? [];
+	if (!list.includes(abs)) list.push(abs);
+	byAgent[agent] = list;
+	writeJson(CONFIG_FILE, { ...current, extraSkillPaths: byAgent });
+}
+
+/** Remove a path from extraSkillPaths[agent]; tolerates non-existent entries. */
+export function removeExtraSkillPath(agent: AgentType, path: string): boolean {
+	const current = getStoredConfig();
+	const byAgent = { ...(current.extraSkillPaths ?? {}) };
+	const list = byAgent[agent] ?? [];
+	const abs = resolvePath(path.replace(/^~(?=\/|$)/, homedir()));
+	const next = list.filter((p) => p !== abs && p !== path);
+	if (next.length === list.length) return false;
+	if (next.length === 0) delete byAgent[agent];
+	else byAgent[agent] = next;
+	writeJson(CONFIG_FILE, { ...current, extraSkillPaths: byAgent });
+	return true;
+}
+
+export function listExtraSkillPaths(): Partial<Record<AgentType, string[]>> {
+	return getStoredConfig().extraSkillPaths ?? {};
 }

--- a/packages/cli/src/lib/skill-scan.ts
+++ b/packages/cli/src/lib/skill-scan.ts
@@ -1,0 +1,66 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { RawSkill } from "../adapters/base";
+
+export interface ScanOptions {
+	/** Skip entries whose name starts with `.` (e.g. Codex's `.system/`). */
+	skipDotDirs?: boolean;
+}
+
+/**
+ * Scan a directory one level deep for skill bundles.
+ *
+ * A direct child is treated as a skill if:
+ *   - it's a directory (or a symlink resolving to one — plugin-installed
+ *     skills are symlinks into a shared bundle), and
+ *   - it contains a SKILL.md.
+ *
+ * Missing directories, broken symlinks, and non-skill children are silently
+ * skipped. Safe to call with a path that doesn't exist.
+ */
+export function scanFlatSkillsDir(dir: string, opts: ScanOptions = {}): RawSkill[] {
+	if (!existsSync(dir)) return [];
+	const out: RawSkill[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if (opts.skipDotDirs && entry.name.startsWith(".")) continue;
+		const dirPath = join(dir, entry.name);
+		let isDir = entry.isDirectory();
+		if (!isDir && entry.isSymbolicLink()) {
+			try {
+				isDir = statSync(dirPath).isDirectory();
+			} catch {
+				isDir = false;
+			}
+		}
+		if (!isDir) continue;
+		const skillMd = join(dirPath, "SKILL.md");
+		if (!existsSync(skillMd)) continue;
+		const content = readFileSync(skillMd, "utf-8");
+		const fileCount = readdirSync(dirPath, { recursive: true }).length;
+		out.push({
+			skillKey: entry.name,
+			name: entry.name,
+			content,
+			filePath: skillMd,
+			directoryPath: dirPath,
+			isDirectory: fileCount > 1,
+		});
+	}
+	return out;
+}
+
+/**
+ * Merge skill lists, keeping the first occurrence of each skillKey. Used to
+ * combine a default adapter directory with user-configured extra paths
+ * without uploading duplicates when a skill is reachable from both.
+ */
+export function dedupeByKey(skills: RawSkill[]): RawSkill[] {
+	const seen = new Set<string>();
+	const out: RawSkill[] = [];
+	for (const s of skills) {
+		if (seen.has(s.skillKey)) continue;
+		seen.add(s.skillKey);
+		out.push(s);
+	}
+	return out;
+}

--- a/packages/cli/src/lib/tar-helpers.ts
+++ b/packages/cli/src/lib/tar-helpers.ts
@@ -10,7 +10,22 @@ export async function tarSkillDir(dirPath: string): Promise<Buffer> {
 
 	const chunks: Buffer[] = [];
 	await tar
-		.create({ gzip: true, cwd: parentDir }, [dirName])
+		.create(
+			{
+				gzip: true,
+				cwd: parentDir,
+				// Resolve symlinks at archive time so plugin-installed skills (which
+				// use a symlink into a shared bundle) ship their real contents, and
+				// the server's "no symlinks in tarball" rule is upheld without
+				// rejecting the whole skill.
+				follow: true,
+				filter: (path) => {
+					const parts = path.split("/");
+					return !parts.includes("node_modules") && !parts.includes(".git");
+				},
+			},
+			[dirName],
+		)
 		.on("data", (chunk: Buffer) => chunks.push(chunk))
 		.promise();
 	return Buffer.concat(chunks);


### PR DESCRIPTION
## Summary

Adapters previously scanned a single hardcoded directory per agent (`~/.claude/skills`, `~/.codex/skills`, etc.). Users whose skills live in project repos (`<project>/.claude/skills`) or custom workspaces had no way to sync them — those directories were invisible to `clawdi sync up`.

This PR adds per-agent **extra skill paths** via config, a `clawdi skill source` subcommand to manage them, and a small shared scanner to keep all four adapters consistent.

Concretely: one user with ~200 project-scoped skills across ten repos went from syncing 26 skills to syncing 93 with no ad-hoc scripts — just configure the paths once and `clawdi sync up` picks them up.

## UX

```
$ clawdi skill source list
No extra skill paths configured.
  Add one with: clawdi skill source add <agent> <path>

$ clawdi skill source add claude_code ~/my-project/.claude/skills
✓ Added /Users/me/my-project/.claude/skills to claude_code skill sources

$ clawdi skill source list
Claude Code
  ✓ /Users/me/my-project/.claude/skills

$ clawdi sync up --modules skills --agent claude_code
→ Uploading 47 skills...      # 24 default + 23 from the extra path
  ✓ Synced 47/47 skills
```

Env override for scripted / CI use: `CLAWDI_EXTRA_SKILL_PATHS_<AGENT>` (colon-separated, merged with config).

## Storage

New optional field in `~/.clawdi/config.json`:

```json
{
  "apiUrl": "http://localhost:8001",
  "extraSkillPaths": {
    "claude_code": [
      "/Users/me/clawdi/.claude/skills",
      "/Users/me/phala-cloud-monorepo/.claude/skills"
    ],
    "openclaw": [
      "/Users/me/openclaw-phala/.agents/skills"
    ]
  }
}
```

Paths are absolutized on add; duplicates collapsed; `~/` expansion supported.

## Implementation

### `lib/skill-scan.ts` (new)

One small helper that each adapter reuses:

```ts
scanFlatSkillsDir(dir: string, opts?: { skipDotDirs?: boolean }): RawSkill[]
dedupeByKey(skills: RawSkill[]): RawSkill[]
```

- Treats a direct child as a skill when it's a directory (or symlink resolving to one, for plugin-installed skills) and contains `SKILL.md`.
- Missing dirs, broken symlinks, non-skill children: silently skipped.

### Adapters

Each `collectSkills()` becomes:

```ts
async collectSkills(): Promise<RawSkill[]> {
    const skills = scanFlatSkillsDir(DEFAULT_DIR /*, { skipDotDirs: true } for Codex */);
    for (const extra of getExtraSkillPaths(this.agentType)) {
        skills.push(...scanFlatSkillsDir(extra));
    }
    return dedupeByKey(skills);
}
```

Hermes keeps its recursive category-aware scanner for the default dir (that's its native layout) — extras are scanned flat to keep the contract predictable and composable. Users who want nested categories in an extra path can add each category as its own entry.

### Bundled fixes for end-to-end correctness

Without these, the feature fails on realistic data and is indistinguishable from broken. These overlap with #2 / #5 — if #5 lands first, this PR rebases cleanly:

- `tar-helpers.tarSkillDir`: exclude `node_modules/` and `.git/` from the archive; enable `follow: true` so internal symlinks (e.g. `gstack/node_modules/.bin/playwright-core`, or a symlinked skill dir itself) ship as their target contents rather than as symlinks the server rejects.
- `sync.ts` skill upload loop: per-skill try/catch with a collected `failed[]` summary, instead of one outer try/catch that aborts on first error. Partial success now persists.

## Verification

Machine with:
- 24 default Claude Code skills + 58 project-scoped across 10 extra paths (`phala-cloud-monorepo/.claude/skills`, `clawdi/.claude/skills`, `moltworker/skills`, `.easyclaw/workspace-*/skills`, etc.)
- 1 default OpenClaw skill + 10 across 2 extra paths (`openclaw-phala/.agents/skills`, `openclaw-phala/extensions/feishu/skills`)

```
$ clawdi skill source add claude_code /Users/marvin/clawdi/.claude/skills
... (× 10)
$ clawdi skill source add openclaw /Users/marvin/openclaw-phala/.agents/skills
... (× 2)

$ clawdi sync up --modules skills --agent claude_code
→ Uploading 82 skills...
  ✓ Synced 82/82 skills

$ clawdi sync up --modules skills --agent openclaw
→ Uploading 11 skills...
  ✓ Synced 11/11 skills

$ curl .../api/skills | jq length
92    # was 26 before
```

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run build` clean
- [x] `clawdi skill source list` on fresh install (empty state)
- [x] `clawdi skill source add claude_code /path` persists to `~/.clawdi/config.json`
- [x] `clawdi skill source add <bad-agent> /path` rejects with known-agents hint
- [x] `clawdi skill source remove` reports when path wasn't configured
- [x] `clawdi sync up --modules skills` picks up the configured extras
- [x] Default dir takes precedence when a skillKey appears in both default and extras (dedupe)
- [x] Missing extra path is silently skipped, not an error
- [x] Symlinked skill directories are followed and archived as their target contents
- [ ] Hermes adapter: only default dir tested (no Hermes install on my machine); extras code path is the same shared helper, but appreciate a reviewer sanity-check

## Related

- Same root issue discussion as #2 / #5 for the `tar-helpers` + sync-loop fixes bundled here.