### PR TITLE
feat(web): env cleanup + email-domain access gate

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,14 @@
+# Clerk (required — app won't start without these).
+# Dev instance keys: https://dashboard.clerk.com → pick the application that
+# owns clawdi.ai → API keys.
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...
+CLERK_SECRET_KEY=sk_test_...
+
+# Backend base URL (required in prod; dev falls back to http://localhost:8000
+# if unset). Production Vercel value: https://cloud-api.clawdi.ai
+NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# Optional — comma-separated email-domain allowlist. Users with emails
+# outside these domains are redirected to /access-denied after sign-in.
+# Unset or empty = no restriction (anyone signed in via Clerk gets in).
+ALLOWED_EMAIL_DOMAINS=

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -1,10 +1,23 @@
+import { currentUser } from "@clerk/nextjs/server";
+import { redirect } from "next/navigation";
 import { AppBreadcrumb } from "@/components/app-breadcrumb";
 import { AppSidebar } from "@/components/app-sidebar";
 import { Separator } from "@/components/ui/separator";
 import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { Toaster } from "@/components/ui/sonner";
+import { isEmailAllowed } from "@/lib/email-allowlist";
 
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
+	// Private-beta gate. Only runs when ALLOWED_EMAIL_DOMAINS is set; otherwise
+	// isEmailAllowed returns true for everyone. See lib/email-allowlist.ts.
+	const user = await currentUser();
+	const primaryEmail = user?.emailAddresses.find(
+		(e) => e.id === user.primaryEmailAddressId,
+	)?.emailAddress;
+	if (!isEmailAllowed(primaryEmail)) {
+		redirect("/access-denied");
+	}
+
 	return (
 		<SidebarProvider
 			style={

--- a/apps/web/src/app/access-denied/page.tsx
+++ b/apps/web/src/app/access-denied/page.tsx
@@ -1,0 +1,38 @@
+import { SignOutButton } from "@clerk/nextjs";
+import { currentUser } from "@clerk/nextjs/server";
+import { ShieldAlert } from "lucide-react";
+import { redirect } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { allowlistIsActive, isEmailAllowed } from "@/lib/email-allowlist";
+
+/**
+ * Generic denial page. Deliberately does not leak *why* — no allowed-domain
+ * list, no "request access" affordance, no marketing copy. Just "nope" and
+ * a sign-out button. Users who can't see the app shouldn't learn anything
+ * from this screen.
+ *
+ * Self-redirects to `/` when the gate is off or when the signed-in user
+ * actually *is* allowed (covers someone typing /access-denied in the URL
+ * bar directly).
+ */
+export default async function AccessDeniedPage() {
+	if (!allowlistIsActive()) {
+		redirect("/");
+	}
+	const user = await currentUser();
+	const primaryEmail = user?.emailAddresses.find(
+		(e) => e.id === user.primaryEmailAddressId,
+	)?.emailAddress;
+	if (isEmailAllowed(primaryEmail)) {
+		redirect("/");
+	}
+	return (
+		<main className="mx-auto flex min-h-dvh max-w-sm flex-col items-center justify-center gap-6 px-6 text-center">
+			<ShieldAlert className="size-12 text-muted-foreground" aria-hidden />
+			<h1 className="text-xl font-semibold tracking-tight">Access denied</h1>
+			<SignOutButton>
+				<Button variant="outline">Sign out</Button>
+			</SignOutButton>
+		</main>
+	);
+}

--- a/apps/web/src/lib/email-allowlist.ts
+++ b/apps/web/src/lib/email-allowlist.ts
@@ -1,0 +1,39 @@
+/**
+ * Email-domain allowlist for the dashboard. Comma-separated
+ * `ALLOWED_EMAIL_DOMAINS` drives it; unset or empty means "no restriction".
+ *
+ *   ALLOWED_EMAIL_DOMAINS=example.com,another.org
+ *
+ * Kept here as a pure function (no Clerk imports) so tests can exercise
+ * it without mocking the auth stack.
+ */
+
+function parseAllowlist(raw: string | undefined): ReadonlySet<string> {
+	return new Set(
+		(raw ?? "")
+			.split(",")
+			.map((d) => d.trim().toLowerCase())
+			.filter(Boolean),
+	);
+}
+
+const ALLOWED_DOMAINS = parseAllowlist(process.env.ALLOWED_EMAIL_DOMAINS);
+
+/**
+ * Return true when the given email (primary email from Clerk) is allowed
+ * into the dashboard. Falsy emails are rejected — we never want an
+ * unverified or missing address sliding past the gate. When the allowlist
+ * is empty we pass everyone through so local dev doesn't need the var.
+ */
+export function isEmailAllowed(email: string | null | undefined): boolean {
+	if (ALLOWED_DOMAINS.size === 0) return true;
+	if (!email) return false;
+	const at = email.lastIndexOf("@");
+	if (at < 0) return false;
+	const domain = email.slice(at + 1).toLowerCase();
+	return ALLOWED_DOMAINS.has(domain);
+}
+
+export function allowlistIsActive(): boolean {
+	return ALLOWED_DOMAINS.size > 0;
+}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -9,11 +9,19 @@ import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 // the "Send to Agent" onboarding flow and have no Clerk session yet.
 const isPublicRoute = createRouteMatcher(["/sign-in(.*)", "/sign-up(.*)", "/skill.md"]);
 
-export default clerkMiddleware(async (auth, request) => {
-	if (!isPublicRoute(request)) {
-		await auth.protect();
-	}
-});
+// signInUrl / signUpUrl must live here — they tell auth.protect() where
+// to send unauth'd users. Without them, Clerk falls back to its hosted
+// page at <instance>.accounts.dev/sign-in, not our in-app /sign-in.
+// Middleware runs outside the React tree, so ClerkProvider props don't
+// reach it; the config lives on the middleware call itself.
+export default clerkMiddleware(
+	async (auth, request) => {
+		if (!isPublicRoute(request)) {
+			await auth.protect();
+		}
+	},
+	{ signInUrl: "/sign-in", signUpUrl: "/sign-up" },
+);
 
 export const config = {
 	matcher: [

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -137,15 +137,19 @@ Dashboard ships to Vercel from `apps/web/`. Once:
 
 1. In the Vercel dashboard, import the repo.
 2. **Root Directory** = `apps/web`. Framework preset = Next.js.
-3. Environment variables (Production scope):
+3. Environment variables (Production scope; see `apps/web/.env.example` for the canonical list):
 
     ```
     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_...   # shared Clerk instance
     CLERK_SECRET_KEY=sk_live_...
-    NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
-    NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
     NEXT_PUBLIC_API_URL=https://cloud-api.clawdi.ai
+
+    # Optional — restrict dashboard access to listed email domains
+    # (comma-separated). Unset or blank = any signed-in user allowed.
+    ALLOWED_EMAIL_DOMAINS=
     ```
+
+    Clerk's `/sign-in` + `/sign-up` paths are wired via `ClerkProvider` props in `apps/web/src/app/layout.tsx` — no env vars needed.
 
 4. Add `cloud.clawdi.ai` as a custom domain; Vercel handles TLS.
 5. Every push to `main` auto-deploys preview; promote to prod from the PR.


### PR DESCRIPTION
Two changes bundled:

1. Hardcode signInUrl/signUpUrl in ClerkProvider instead of carrying them
   through NEXT_PUBLIC_CLERK_SIGN_{IN,UP}_URL env vars. Both apps use
   primary-mode and the paths are always /sign-in and /sign-up — the env
   vars were cargo-culted from satellite-mode docs. Shrinks prod env from
   5 to 3 required keys. Matching cleanup in apps/web/.env.local.

   Also adds apps/web/.env.example (parallels backend/.env.example) with
   the real required keys and inline comments, and un-gitignores it so
   the file is tracked. Without an example, new contributors have to
   reverse-engineer the env from Clerk docs.

2. ALLOWED_EMAIL_DOMAINS gate for the dashboard.

   - lib/email-allowlist.ts — pure function reading the comma-separated
     env once at module load. Empty / unset = allow everyone so local dev
     doesn't need the var.
   - (dashboard)/layout.tsx — async server component, resolves Clerk
     primary email via currentUser(), redirects to /access-denied when
     the gate rejects. Runs on every dashboard request.
   - /access-denied — standalone page outside the (dashboard) group so
     the layout gate doesn't bounce the user back. Deliberately generic:
     no allowed-domain list, no "request access" link, no explanation.
     Self-redirects to / when the gate is inactive or when the signed-in
     user is actually allowed (covers the URL-bar-typer edge case).
   - docs/deploy.md Vercel section updated: drop the 2 Clerk URL vars,
     document ALLOWED_EMAIL_DOMAINS as optional.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
