### PR TITLE
fix(web): stop /access-denied auto-redirecting back to /

### DIFF
--- a/apps/web/src/app/access-denied/page.tsx
+++ b/apps/web/src/app/access-denied/page.tsx
@@ -1,9 +1,6 @@
 import { SignOutButton } from "@clerk/nextjs";
-import { currentUser } from "@clerk/nextjs/server";
 import { ShieldAlert } from "lucide-react";
-import { redirect } from "next/navigation";
 import { Button } from "@/components/ui/button";
-import { allowlistIsActive, isEmailAllowed } from "@/lib/email-allowlist";
 
 /**
  * Generic denial page. Deliberately does not leak *why* — no allowed-domain
@@ -11,21 +8,13 @@ import { allowlistIsActive, isEmailAllowed } from "@/lib/email-allowlist";
  * a sign-out button. Users who can't see the app shouldn't learn anything
  * from this screen.
  *
- * Self-redirects to `/` when the gate is off or when the signed-in user
- * actually *is* allowed (covers someone typing /access-denied in the URL
- * bar directly).
+ * Renders unconditionally: never redirects back to `/`. The dashboard layout
+ * is the only path that should land a user here. A self-redirect turned any
+ * cross-render disagreement between `currentUser()` calls into an infinite
+ * `/` ↔ `/access-denied` loop in production, so the convenience of auto-
+ * returning allowed users who typed the URL directly is not worth the risk.
  */
-export default async function AccessDeniedPage() {
-	if (!allowlistIsActive()) {
-		redirect("/");
-	}
-	const user = await currentUser();
-	const primaryEmail = user?.emailAddresses.find(
-		(e) => e.id === user.primaryEmailAddressId,
-	)?.emailAddress;
-	if (isEmailAllowed(primaryEmail)) {
-		redirect("/");
-	}
+export default function AccessDeniedPage() {
 	return (
 		<main className="mx-auto flex min-h-dvh max-w-sm flex-col items-center justify-center gap-6 px-6 text-center">
 			<ShieldAlert className="size-12 text-muted-foreground" aria-hidden />


### PR DESCRIPTION
## Summary
- Production `https://cloud.clawdi.ai/` was stuck in `ERR_TOO_MANY_REDIRECTS`, ping-ponging between `/` and `/access-denied`.
- The email-domain gate lives in two places that each ran `currentUser()` and made their own redirect decision: `(dashboard)/layout.tsx` sent disallowed users to `/access-denied`, and `/access-denied` auto-returned allowed users to `/`. Any cross-render disagreement about who the user is — plausible given `.clawdi.ai` cookies shared with the sibling Clerk app, and Edge-middleware vs Node-server-component session validation differences — flipped the decision and looped.
- Render the denial screen unconditionally. The dashboard layout is now the only path into this route; no server-side redirect can bounce back out. Allowed users who type the URL directly see the page until they navigate away — an accepted trade-off for eliminating the loop structurally.

## Test plan
- [ ] `bun run typecheck` ✓ (verified locally)
- [ ] `bun run check` ✓ (verified locally)
- [ ] Local: with `ALLOWED_EMAIL_DOMAINS` unset, sign in → `/` renders the dashboard; type `/access-denied` → denial page renders (previously would redirect to `/`).
- [ ] Local: with `ALLOWED_EMAIL_DOMAINS` set to a domain other than your email's, sign in → `/` redirects once to `/access-denied` which renders and stays.
- [ ] Prod smoke after deploy: fresh incognito → `https://cloud.clawdi.ai/` completes with at most one redirect hop.
- [ ] Separately verify on Vercel that Clerk keys match the Clerk app that owns `clawdi.ai`, that `cloud.clawdi.ai` is in its allowed origins, and that `ALLOWED_EMAIL_DOMAINS` is set as expected — the loop can't recur with this fix, but the underlying Clerk/session inconsistency that triggered it is worth ruling out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)