### PR TITLE
fix(web): dashboard UI polish + onboarding command refresh

### DIFF
--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -22,7 +22,7 @@ npm install -g @clawdi/cli
 ## Step 2: Log in
 
 ```bash
-clawdi login
+clawdi auth login
 ```
 
 This will prompt for an API key. Tell the user to get it from the Clawdi Cloud dashboard:
@@ -35,14 +35,14 @@ clawdi setup
 ```
 
 This will:
-- Detect Claude Code (or other supported agents)
+- Detect installed agents (Claude Code, Codex, Hermes, OpenClaw)
 - Register the MCP server (gives you `memory_search`, `memory_add`, and connector tools)
 - Install the Clawdi skill
 
 ## Step 4: Sync sessions (optional)
 
 ```bash
-clawdi sync up --modules sessions
+clawdi push --modules sessions
 ```
 
 This uploads your conversation history to the Clawdi Cloud dashboard.

--- a/apps/web/src/app/(dashboard)/connectors/page.tsx
+++ b/apps/web/src/app/(dashboard)/connectors/page.tsx
@@ -16,18 +16,22 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { apiFetch } from "@/lib/api";
 import type { ConnectorApp, ConnectorConnection } from "@/lib/api-schemas";
-import { errorMessage } from "@/lib/utils";
+import { cn, errorMessage } from "@/lib/utils";
 
 const PAGE_SIZE = 30;
 
+const CONNECTOR_CARD_CLASS = "gap-0 rounded-lg border-border/60 py-0 shadow-none";
+const CONNECTOR_CARD_CONTENT_CLASS = "flex items-start gap-3 p-3";
+
 function ConnectorCardSkeleton() {
 	return (
-		<Card>
-			<CardContent className="flex items-center gap-3 py-3">
-				<Skeleton className="size-10 rounded-lg" />
+		<Card className={CONNECTOR_CARD_CLASS}>
+			<CardContent className={CONNECTOR_CARD_CONTENT_CLASS}>
+				<Skeleton className="size-10 shrink-0 rounded-lg" />
 				<div className="min-w-0 flex-1 space-y-1.5">
 					<Skeleton className="h-3.5 w-28" />
-					<Skeleton className="h-3 w-44" />
+					<Skeleton className="h-3 w-full" />
+					<Skeleton className="h-3 w-3/4" />
 				</div>
 			</CardContent>
 		</Card>
@@ -163,12 +167,19 @@ export default function ConnectorsPage() {
 							const isConnected = connectedNames.has(app.name);
 							return (
 								<Link key={app.name} href={`/connectors/${app.name}`} className="group">
-									<Card className="h-full transition-all hover:border-ring/50 hover:bg-accent/30">
-										<CardContent className="flex h-full items-center gap-3 py-3">
+									<Card
+										className={cn(
+											CONNECTOR_CARD_CLASS,
+											"h-full transition-colors hover:border-ring/50 hover:bg-accent/40",
+										)}
+									>
+										<CardContent className={cn(CONNECTOR_CARD_CONTENT_CLASS, "h-full")}>
 											<ConnectorIcon logo={app.logo} name={app.display_name} size="md" />
 											<div className="min-w-0 flex-1">
 												<div className="flex items-center gap-1.5">
-													<span className="truncate text-sm font-medium">{app.display_name}</span>
+													<span className="truncate text-sm font-medium leading-5">
+														{app.display_name}
+													</span>
 													{isConnected ? (
 														<Check
 															className="size-3.5 shrink-0 text-emerald-600 dark:text-emerald-500"
@@ -176,7 +187,7 @@ export default function ConnectorsPage() {
 														/>
 													) : null}
 												</div>
-												<p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
+												<p className="mt-1 line-clamp-2 text-xs leading-snug text-muted-foreground">
 													{app.description}
 												</p>
 											</div>

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -28,8 +28,9 @@ export default async function DashboardLayout({ children }: { children: React.Re
 			}
 		>
 			<AppSidebar />
-			<SidebarInset>
-				<header className="flex h-(--header-height) shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-(--header-height)">
+			{/* 1rem = SidebarInset's md:m-2 top+bottom. */}
+			<SidebarInset className="md:h-[calc(100svh-1rem)] md:overflow-y-auto">
+				<header className="sticky top-0 z-20 flex h-(--header-height) shrink-0 items-center gap-2 border-b bg-background transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-(--header-height)">
 					<div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
 						<SidebarTrigger className="-ml-1" />
 						<Separator orientation="vertical" className="mx-2 data-[orientation=vertical]:h-4" />

--- a/apps/web/src/components/dashboard/onboarding-card.tsx
+++ b/apps/web/src/components/dashboard/onboarding-card.tsx
@@ -24,12 +24,12 @@ function useAgentPrompt() {
 const CLI_STEPS = [
 	{
 		title: "Install CLI",
-		code: "bun add -g @clawdi-cloud/cli",
-		description: "Or use npm: npm install -g @clawdi-cloud/cli",
+		code: "bun add -g @clawdi/cli",
+		description: "Or use npm: npm install -g @clawdi/cli",
 	},
 	{
 		title: "Log in",
-		code: "clawdi login",
+		code: "clawdi auth login",
 		description: "Enter your API key from Settings → API Keys",
 	},
 	{
@@ -39,7 +39,7 @@ const CLI_STEPS = [
 	},
 	{
 		title: "Sync sessions",
-		code: "clawdi sync up",
+		code: "clawdi push --modules sessions",
 		description: "Upload your conversation history to the cloud",
 	},
 ];

--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -40,7 +40,7 @@ export function SettingsDialog({ open, onClose, initialSection = "general" }: Se
 	return (
 		<Dialog open={open} onOpenChange={(next) => !next && onClose()}>
 			<DialogContent
-				className="h-[min(680px,85vh)] max-w-3xl gap-0 overflow-hidden p-0 sm:max-w-3xl"
+				className="flex h-[min(680px,85vh)] max-w-3xl flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl"
 				showCloseButton
 			>
 				<DialogHeader className="border-b px-5 py-3">

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -78,7 +78,3 @@ clawdi doctor         # a single-shot diagnostic
 ```
 
 It verifies auth, API reachability, each known agent's install path, vault resolution, and MCP connector config — with actionable hints on every failing check.
-
-## Development
-
-Contributing? See [docs/cli-development.md](https://github.com/Clawdi-AI/clawdi-cloud/blob/main/docs/cli-development.md) in the repo.

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -187,11 +187,10 @@ async function registerMcpServer(agentType: AgentType) {
 		// claude command not found or failed, try registering anyway
 	}
 
-	const cliPath = resolve(import.meta.dirname, "../../src/index.ts");
 	const mcpConfig = JSON.stringify({
 		type: "stdio",
-		command: "bun",
-		args: ["run", cliPath, "mcp"],
+		command: "clawdi",
+		args: ["mcp"],
 	});
 
 	try {
@@ -261,8 +260,6 @@ async function registerHermesMcp() {
 }
 
 function registerCodexMcp() {
-	const cliPath = resolve(import.meta.dirname, "../../src/index.ts");
-
 	try {
 		const list = execSync("codex mcp list", { encoding: "utf-8", stdio: "pipe" });
 		if (/^\s*clawdi\b/m.test(list)) {
@@ -274,11 +271,11 @@ function registerCodexMcp() {
 	}
 
 	try {
-		execSync(`codex mcp add clawdi -- bun run ${cliPath} mcp`, { stdio: "pipe" });
+		execSync("codex mcp add clawdi -- clawdi mcp", { stdio: "pipe" });
 		console.log(chalk.green("✓ MCP server registered in Codex"));
 	} catch {
 		console.log(chalk.yellow("⚠ Could not auto-register MCP server in Codex."));
-		console.log(chalk.gray(`  Run manually: codex mcp add clawdi -- bun run ${cliPath} mcp`));
+		console.log(chalk.gray("  Run manually: codex mcp add clawdi -- clawdi mcp"));
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix settings dialog body collapsing behind the header (grid → flex).
- Refresh onboarding copy (Manual Setup tab + `/skill.md`) to match the refactored CLI: `clawdi auth login`, `clawdi push --modules sessions`, package name `@clawdi/cli`, full agent list.
- Tighten connectors grid item cards (flat, top-aligned icon, 2-line description); skeleton shares base classes so the loading state matches the live card.
- Pin the dashboard header while the inset scrolls (SidebarInset becomes its own scroll container on `md+`), so the header stays visible on every dashboard page without content bleeding past the inset's rounded frame.

## Test plan

- [x] Open **Settings** from the sidebar — nav on the left, panel on the right, no empty gap.
- [x] **Overview → Add an agent → Manual Setup**: verify the four commands are `bun add -g @clawdi/cli`, `clawdi auth login`, `clawdi setup`, `clawdi push --modules sessions`.
- [x] `curl http://localhost:3000/skill.md` returns the same four commands in the same order.
- [x] **Connectors** page: cards are flat, icons align with titles, descriptions wrap to 2 lines, loading skeleton matches the final layout.
- [x] Scroll any dashboard page (Overview/Sessions/Memories/Skills/Vault/Connectors/Cron) — header stays pinned at the top of the inset with no content bleed above it.
- [x] Repeat the scroll test with the sidebar collapsed.