### PR TITLE
fix(cli): push includes sessions launched from subdirectories

### DIFF
--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -64,11 +64,19 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 			d.isDirectory(),
 		);
 
+		let absFilter: string | null = null;
 		if (projectFilter) {
 			const { resolve } = await import("node:path");
-			const absPath = resolve(projectFilter);
-			const targetDir = this.pathToProjectDir(absPath);
-			projectDirs = projectDirs.filter((d) => d.name === targetDir);
+			absFilter = resolve(projectFilter);
+			const targetDir = this.pathToProjectDir(absFilter);
+			// Coarse pre-filter on the encoded dir name: keep the target and any
+			// dir whose name starts with "target-". Because "/" and in-segment "-"
+			// both encode as "-", this superset may include sibling repos like
+			// "clawdi-cloud" when the target is "clawdi" — those false positives
+			// are dropped below using each session's real cwd.
+			projectDirs = projectDirs.filter(
+				(d) => d.name === targetDir || d.name.startsWith(`${targetDir}-`),
+			);
 		}
 
 		for (const projectDir of projectDirs) {
@@ -84,6 +92,12 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 					if (!parsed) continue;
 
 					if (since && parsed.startedAt < since) continue;
+
+					if (absFilter) {
+						const cwd = parsed.projectPath;
+						if (!cwd) continue;
+						if (cwd !== absFilter && !cwd.startsWith(`${absFilter}/`)) continue;
+					}
 
 					sessions.push({ ...parsed, localSessionId: sessionId, rawFilePath: filePath });
 				} catch {

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -208,7 +208,7 @@ export class CodexAdapter implements AgentAdapter {
 
 			if (absFilter) {
 				if (!projectPath) continue;
-				if (projectPath !== absFilter) continue;
+				if (projectPath !== absFilter && !projectPath.startsWith(`${absFilter}/`)) continue;
 			}
 
 			if (!endedAt) endedAt = startedAt;

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -122,7 +122,7 @@ export class OpenClawAdapter implements AgentAdapter {
 			const projectPath = entry.acp?.cwd ?? null;
 			if (absFilter) {
 				if (!projectPath) continue;
-				if (projectPath !== absFilter) continue;
+				if (projectPath !== absFilter && !projectPath.startsWith(`${absFilter}/`)) continue;
 			}
 
 			const transcriptPath = entry.sessionFile

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -70,12 +70,25 @@ export async function push(opts: {
 
 	// 2. Scan data
 	const moduleState = readModuleState();
+	const sinceSource: "flag" | "state" | "none" = opts.since
+		? "flag"
+		: moduleState.sessions?.lastActivityAt
+			? "state"
+			: "none";
 	const since = opts.since
 		? new Date(opts.since)
 		: moduleState.sessions?.lastActivityAt
 			? new Date(moduleState.sessions.lastActivityAt)
 			: undefined;
 	const projectFilter = opts.all ? undefined : (opts.project ?? process.cwd());
+
+	if (modules.includes("sessions")) {
+		const scope = projectFilter ? `project ${projectFilter}` : "all projects";
+		const sinceLabel = since
+			? `since ${since.toISOString()}${sinceSource === "state" ? " (from last push)" : ""}`
+			: "no since cutoff";
+		p.log.info(chalk.gray(`Scanning ${scope}, ${sinceLabel}`));
+	}
 
 	if (
 		adapter.agentType === "hermes" &&
@@ -104,6 +117,13 @@ export async function push(opts: {
 	// 3. Summary
 	if (modules.includes("sessions")) {
 		p.log.message(chalk.gray(`Sessions: ${sessions.length} to upload`));
+		if (sessions.length === 0 && projectFilter) {
+			p.log.info(
+				chalk.gray(
+					"No sessions matched. Try --all to scan every project, or --since <date> to override the last-push cutoff.",
+				),
+			);
+		}
 	}
 	if (modules.includes("skills")) {
 		p.log.message(chalk.gray(`Skills:   ${skills.length} to upload`));


### PR DESCRIPTION
## Summary

- **Claude Code / Codex / OpenClaw**: \`clawdi push\` was exact-matching cwd against each session's recorded project path, so any session launched from a subdirectory of the current project was silently dropped (e.g., running from the repo root missed all sessions launched from \`apps/web/\`, \`backend/\`, etc.). Match \`cwd\` and any descendant path instead.
- **Claude Code specifically**: the on-disk key is an encoded dir name where \`/\` and in-segment \`-\` both encode as \`-\`, so a pure prefix match on the encoded name would leak sibling repos (\`clawdi\` → \`clawdi-cloud\`). Use a coarse encoded-dir prefix as a cheap pre-filter, then do a precise cwd prefix check per session using the \`cwd\` field in each JSONL.
- **Observability**: log the resolved \`projectFilter\` and the \`since\` cutoff (flagging when it came from the last-push state). When nothing matches, print a hint pointing at \`--all\` and \`--since\`.
- Hermes and the state cursor behaviour are unchanged (out of scope — see the plan).

## Verification

Dry-runs performed locally against real \`~/.claude/projects/\` state:

| Scope | Before | After |
|---|---|---|
| \`~/workspace/clawdi-cloud\` (no subdir launches) | 32 | 32 |
| \`~/workspace/clawdi\` (launched from root + 4 subdirs) | 46 (root only) | 55 (all 5 dirs, no sibling-repo leaks) |
| \`~/workspace/clawdi/apps/web\` | 0 | 1 (scoped) |

## Test plan

- [ ] \`cd <repo-root> && clawdi push --agent claude_code --modules sessions --since 2000-01-01 --dry-run\` — count matches root + all subdir launches, no sessions from sibling repos with a shared dash prefix.
- [ ] Same from a subdirectory — stays scoped to that subdirectory and deeper.
- [ ] Repeat with \`--agent codex\` and \`--agent openclaw\` against real data.
- [ ] \`cd /tmp && clawdi push --modules sessions --dry-run\` — hint about \`--all\` / \`--since\` appears when there are no matches.
- [ ] \`bun run check && bun test\` from \`packages/cli\`.