### PR TITLE
chore(cli): bump to 0.1.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "SEE LICENSE IN LICENSE",
 	"type": "module",


### PR DESCRIPTION
Smoke-test the auto-publish workflow now that clawdi@0.1.0 is live and
npm trusted-publisher OIDC is configured. No code changes — just a
version bump to verify .github/workflows/cli-publish.yml's full path
(skip-check → install → typecheck → build → test → publish --provenance)
runs end-to-end on a real package.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
