### PR TITLE
fix(cli/tests): explicitly reset `process.exitCode` to 0 in afterEach

### DIFF
--- a/packages/cli/tests/commands/doctor.test.ts
+++ b/packages/cli/tests/commands/doctor.test.ts
@@ -5,11 +5,9 @@ import { jsonResponse, mockFetch, seedAuthAndEnv } from "./helpers";
 
 let tmpHome: string;
 let origHome: string | undefined;
-let origExitCode: number | string | undefined;
 
 beforeEach(() => {
 	origHome = process.env.HOME;
-	origExitCode = process.exitCode;
 	tmpHome = copyFixtureToTmp("hermes");
 	process.env.HOME = tmpHome;
 });
@@ -17,7 +15,7 @@ beforeEach(() => {
 afterEach(() => {
 	if (origHome) process.env.HOME = origHome;
 	else delete process.env.HOME;
-	process.exitCode = origExitCode;
+	process.exitCode = 0;
 	if (tmpHome) cleanupTmp(tmpHome);
 });
 

--- a/packages/cli/tests/commands/pull.test.ts
+++ b/packages/cli/tests/commands/pull.test.ts
@@ -17,11 +17,9 @@ const AGENT_TYPE: Record<AgentKey, string> = {
 
 let tmpHome: string;
 let origHome: string | undefined;
-let origExitCode: number | string | undefined;
 
 function setup(agent: AgentKey) {
 	origHome = process.env.HOME;
-	origExitCode = process.exitCode;
 	tmpHome = copyFixtureToTmp(agent);
 	process.env.HOME = tmpHome;
 	seedAuthAndEnv(tmpHome, AGENT_TYPE[agent]);
@@ -30,7 +28,7 @@ function setup(agent: AgentKey) {
 afterEach(() => {
 	if (origHome) process.env.HOME = origHome;
 	else delete process.env.HOME;
-	process.exitCode = origExitCode;
+	process.exitCode = 0;
 	if (tmpHome) cleanupTmp(tmpHome);
 });
 

--- a/packages/cli/tests/commands/push.test.ts
+++ b/packages/cli/tests/commands/push.test.ts
@@ -29,14 +29,12 @@ const AGENT_TYPE: Record<AgentKey, string> = {
 
 let tmpHome: string;
 let origHome: string | undefined;
-let origExitCode: number | string | undefined;
 
 function setup(agent: AgentKey): {
 	sent: ReturnType<typeof mockFetch>["captured"];
 	restore: () => void;
 } {
 	origHome = process.env.HOME;
-	origExitCode = process.exitCode;
 	tmpHome = copyFixtureToTmp(agent);
 	process.env.HOME = tmpHome;
 	seedAuthAndEnv(tmpHome, AGENT_TYPE[agent]);
@@ -46,9 +44,10 @@ function setup(agent: AgentKey): {
 afterEach(() => {
 	if (origHome) process.env.HOME = origHome;
 	else delete process.env.HOME;
-	// push/pull now set process.exitCode=1 on abort paths — reset so a later
-	// test file's `bun test` result isn't polluted.
-	process.exitCode = origExitCode;
+	// `push` sets `process.exitCode = 1` on abort paths (not logged in,
+	// no env). Reset to 0 so subsequent test files start clean —
+	// `bun test` (1.3.13+) inherits the file's final exitCode.
+	process.exitCode = 0;
 	if (tmpHome) cleanupTmp(tmpHome);
 });
 

--- a/packages/cli/tests/commands/teardown.test.ts
+++ b/packages/cli/tests/commands/teardown.test.ts
@@ -15,7 +15,6 @@ const AGENT_TYPE: Record<AgentKey, string> = {
 
 let tmpHome: string;
 let origHome: string | undefined;
-let origExitCode: number | string | undefined;
 let origIsTTY: boolean | undefined;
 
 function setup(agent: AgentKey): {
@@ -23,7 +22,6 @@ function setup(agent: AgentKey): {
 	skillPath: string;
 } {
 	origHome = process.env.HOME;
-	origExitCode = process.exitCode;
 	tmpHome = copyFixtureToTmp(agent);
 	process.env.HOME = tmpHome;
 	seedAuthAndEnv(tmpHome, AGENT_TYPE[agent]);
@@ -48,7 +46,7 @@ function setup(agent: AgentKey): {
 afterEach(() => {
 	if (origHome) process.env.HOME = origHome;
 	else delete process.env.HOME;
-	process.exitCode = origExitCode;
+	process.exitCode = 0;
 	if (origIsTTY !== undefined) {
 		Object.defineProperty(process.stdin, "isTTY", { value: origIsTTY, configurable: true });
 		origIsTTY = undefined;


### PR DESCRIPTION
bun 1.3.13 (used in CI) treats a non-zero `process.exitCode` set by
test code as the runner's final exit code, even when all tests pass.
bun 1.3.12 (local) didn't, which is how this slipped past pre-publish
checks. The OIDC-published v0.1.1 workflow run failed: 158 pass / 0 fail
but `Process completed with exit code 1`.

The four test files that exercise CLI abort paths (`push`, `pull`,
`doctor`, `teardown`) assert `expect(process.exitCode).toBe(1)` and
relied on `afterEach` to write back the captured `origExitCode`. That
captured value was `undefined`, and assigning `undefined` no longer
clears `exitCode` on bun 1.3.13.

Drop the captured-and-restored dance entirely and just set
`process.exitCode = 0` after each test. Same intent (don't leak abort
state across files), one fewer dead variable, version-portable.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
