### PR TITLE
fix(workflow): drop `--provenance`, bump cli to 0.1.2

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -88,6 +88,11 @@ jobs:
       # `prepublishOnly` would re-run the build. We pass `--ignore-scripts`
       # because the step above already built everything; rerunning wastes
       # ~10s of CI time and risks a silent re-bundle with stale env.
-      - name: Publish to npm with provenance
+      #
+      # `--provenance` is intentionally omitted: npm requires the source
+      # repository to be public to verify provenance attestations, and
+      # `Clawdi-AI/clawdi` is internal. If the repo ever goes public, add
+      # `--provenance` back and the OIDC + sigstore flow takes over.
+      - name: Publish to npm
         if: steps.check.outputs.skip != 'true'
-        run: npm publish --access public --provenance --ignore-scripts
+        run: npm publish --access public --ignore-scripts

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "SEE LICENSE IN LICENSE",
 	"type": "module",


### PR DESCRIPTION
npm rejects `--provenance` when the source repo is internal:

    422 Unprocessable Entity
    Error verifying sigstore provenance bundle:
    Unsupported GitHub Actions source repository visibility: "internal".
    Only public source repositories are supported when publishing with provenance.

The repo will likely go public eventually; until then keep the OIDC
trusted-publisher flow (no NPM_TOKEN needed) but stop signing the
attestation. The comment in cli-publish.yml flags the one-line revert
(`--provenance` back) for whenever visibility flips.

Bump version to 0.1.2 because v0.1.1 already minted (and rejected) a
sigstore provenance entry — re-publishing the same version risks a
mismatch where sigstore claims 0.1.1 was built but npm has it without
the attestation. 0.1.2 is a clean slate.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
