### PR TITLE
fix(cli): make update actually install + shorten autoupdate cache to 1h

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "SEE LICENSE IN LICENSE",
 	"type": "module",

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -6,7 +6,12 @@ import { getClawdiDir, getStoredConfig } from "../lib/config";
 import { getCliVersion } from "../lib/version";
 
 const REGISTRY_URL = "https://registry.npmjs.org/clawdi";
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 h
+// 1 hour: short enough that a fresh release reaches users within an hour of
+// publication, long enough that we don't hammer the npm registry on every
+// CLI invocation. Originally 24h — that meant a new release could sit
+// invisible to active users for a full day, which made `--auto-update`
+// feel broken whenever a fix shipped.
+const CACHE_TTL_MS = 60 * 60 * 1000;
 
 interface UpdateCache {
 	checkedAt: string;
@@ -77,9 +82,13 @@ function isNewer(latest: string, current: string): boolean {
 }
 
 /**
- * Manual `clawdi update` command — forces a registry fetch and prints result.
+ * Manual `clawdi update` — forces a registry fetch and, if a newer version
+ * exists, installs it inline (foreground, blocking, with the installer's
+ * own progress output). Pass `--check` to keep the old "diagnose only"
+ * behavior. JSON / non-TTY runs always stay diagnose-only because piping
+ * into a script and silently mutating the global install would surprise.
  */
-export async function update(opts: { json?: boolean } = {}) {
+export async function update(opts: { json?: boolean; check?: boolean } = {}) {
 	const current = getCliVersion();
 	const latest = await fetchLatest();
 
@@ -107,16 +116,57 @@ export async function update(opts: { json?: boolean } = {}) {
 
 	console.log(chalk.gray(`current:  ${current}`));
 	console.log(chalk.gray(`latest:   ${latest}`));
-	if (isNewer(latest, current)) {
+
+	if (!isNewer(latest, current)) {
+		console.log(chalk.green("\n✓ You're up to date."));
+		return;
+	}
+
+	// `--check` keeps the old display-only behavior for users who scripted
+	// against it (CI guards, custom dashboards). Default is now to install.
+	if (opts.check) {
 		console.log();
 		console.log(
 			chalk.cyan(`A newer version is available. Install with:`) +
 				"\n  " +
 				chalk.white("npm i -g clawdi"),
 		);
-	} else {
-		console.log(chalk.green("\n✓ You're up to date."));
+		return;
 	}
+
+	const installer = detectInstaller();
+	if (!installer) {
+		console.log();
+		console.log(
+			chalk.yellow("Neither bun nor npm is on PATH; install manually:") +
+				"\n  " +
+				chalk.white("npm i -g clawdi"),
+		);
+		return;
+	}
+
+	const args = installer === "bun" ? ["add", "-g", "clawdi@latest"] : ["i", "-g", "clawdi@latest"];
+	console.log();
+	console.log(chalk.cyan(`Installing v${latest} via ${installer}…`));
+	const result = spawnSync(installer, args, { stdio: "inherit" });
+	if (result.status !== 0) {
+		console.log();
+		console.log(
+			chalk.red(`Install failed (${installer} exited ${result.status}). Try manually:`) +
+				"\n  " +
+				chalk.white("npm i -g clawdi"),
+		);
+		process.exitCode = result.status ?? 1;
+		return;
+	}
+	// Update last-version so the post-install run prints "Updated to v…".
+	try {
+		writeFileSync(lastVersionPath(), current, { mode: 0o644 });
+	} catch {
+		// best-effort
+	}
+	console.log();
+	console.log(chalk.green(`✓ clawdi v${latest} installed.`));
 }
 
 /**

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -358,7 +358,8 @@ program
 
 program
 	.command("update")
-	.description("Check for a newer CLI version on npm")
+	.description("Install the latest CLI from npm (--check to only diagnose)")
+	.option("--check", "Only check for updates, don't install")
 	.option("--json", "Output as JSON")
 	.action(async (opts) => {
 		const { update } = await import("./commands/update.js");


### PR DESCRIPTION
## Summary

Two papercuts the user hit immediately after \`clawdi@0.2.1\` shipped:

1. **\`clawdi update\` only printed a hint, didn't install.** Counter-intuitive — typing \`update\` should update. Now installs in foreground via the same \`bun add -g\` / \`npm i -g\` codepath as the background updater, with the installer's own progress streamed. \`--check\` keeps the old display-only mode (for CI / scripts). Non-TTY and \`--json\` invocations stay diagnose-only — silently mutating a global install when piped into a script would be hostile.

2. **24h cache TTL meant a fresh release was invisible for up to a day.** With auto-update default-on this made the feature feel broken right after every release — current 0.2.0, latest 0.2.1, but cache (filled hours pre-release) said 0.2.0 → no action. Cut TTL to 1h.

Bumps to \`0.2.2\`.

## Test plan

- [x] \`bun test\` — 172 pass
- [x] \`bun run typecheck\`
- [x] \`bun run check\` (biome)
- [ ] After merge + npm publish: run \`clawdi update\` on a stale install → should install \`@latest\` inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)