### PR TITLE
fix(web): proper Next Link + DataTable middle-click + agents 404 + inline actions

### DIFF
--- a/apps/web/src/app/(dashboard)/agents/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/agents/[id]/page.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import { agentTypeLabel } from "@/components/dashboard/agent-label";
-import { DetailActions, DetailMeta, DetailNotFound, DetailTitle } from "@/components/detail/layout";
+import { DetailMeta, DetailNotFound, DetailTitle } from "@/components/detail/layout";
 import { sessionColumns } from "@/components/sessions/session-columns";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
@@ -97,21 +97,6 @@ export default function AgentDetailPage() {
 
 	return (
 		<div className="space-y-5 px-4 lg:px-6">
-			<DetailActions>
-				{agent && !isLoading ? (
-					<Button
-						variant="outline"
-						size="sm"
-						onClick={onRemove}
-						disabled={remove.isPending}
-						className="text-destructive hover:text-destructive"
-					>
-						<Trash2 />
-						Remove agent
-					</Button>
-				) : null}
-			</DetailActions>
-
 			{error ? (
 				<DetailNotFound title="Agent not found" message={errorMessage(error)} />
 			) : isLoading ? (
@@ -121,14 +106,26 @@ export default function AgentDetailPage() {
 				</div>
 			) : agent ? (
 				<>
-					{/* Same flat header as sessions/skills/memories. The big
-					    AgentLabel + bordered dl was visually heavy for a
-					    page that's mostly the sessions table below it. */}
+					{/* Title row pairs the h1 with the destructive action so the
+					    button doesn't float on its own line. items-start so a
+					    long machine name wrapping doesn't drag the button down. */}
 					<div className="space-y-2">
-						<DetailTitle className="inline-flex items-center gap-2">
-							<AgentIcon agent={agent.agent_type} className="size-7 rounded" />
-							{agent.machine_name || agentTypeLabel(agent.agent_type)}
-						</DetailTitle>
+						<div className="flex items-start justify-between gap-3">
+							<DetailTitle className="inline-flex items-center gap-2">
+								<AgentIcon agent={agent.agent_type} className="size-7 rounded" />
+								{agent.machine_name || agentTypeLabel(agent.agent_type)}
+							</DetailTitle>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={onRemove}
+								disabled={remove.isPending}
+								className="shrink-0 text-destructive hover:text-destructive"
+							>
+								<Trash2 />
+								Remove agent
+							</Button>
+						</div>
 						<DetailMeta>
 							<span>{agentTypeLabel(agent.agent_type)}</span>
 							{agent.agent_version ? (
@@ -163,7 +160,8 @@ export default function AgentDetailPage() {
 							columns={sessionColumns}
 							data={sessionsPage?.items ?? []}
 							isLoading={sessionsLoading}
-							onRowClick={(s) => router.push(`/sessions/${s.id}`)}
+							getRowHref={(s) => `/sessions/${s.id}`}
+							rowAriaLabel={(s) => `Open session ${s.local_session_id}`}
 							emptyMessage="No sessions synced from this agent yet."
 						/>
 					</section>

--- a/apps/web/src/app/(dashboard)/agents/page.tsx
+++ b/apps/web/src/app/(dashboard)/agents/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from "next/navigation";
+
+/**
+ * Agents are surfaced through the Overview page (Agents card) — there's no
+ * dedicated `/agents` list view by design. Without this redirect, deep
+ * links from the breadcrumb's "Agents" segment 404. Send the user to the
+ * Overview where the agent grid lives.
+ */
+export default function AgentsIndexPage(): never {
+	redirect("/");
+}

--- a/apps/web/src/app/(dashboard)/memories/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/memories/[id]/page.tsx
@@ -5,7 +5,7 @@ import { Brain, Trash2 } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
-import { DetailActions, DetailMeta, DetailNotFound, DetailTitle } from "@/components/detail/layout";
+import { DetailMeta, DetailNotFound, DetailTitle } from "@/components/detail/layout";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -51,21 +51,6 @@ export default function MemoryDetailPage() {
 
 	return (
 		<div className="space-y-5 px-4 lg:px-6">
-			<DetailActions>
-				{memory && !isLoading ? (
-					<Button
-						variant="outline"
-						size="sm"
-						onClick={() => deleteMemory.mutate()}
-						disabled={deleteMemory.isPending}
-						className="text-destructive hover:text-destructive"
-					>
-						<Trash2 />
-						Delete
-					</Button>
-				) : null}
-			</DetailActions>
-
 			{error ? (
 				<DetailNotFound title="Memory not found" message={errorMessage(error)} />
 			) : isLoading ? (
@@ -77,7 +62,21 @@ export default function MemoryDetailPage() {
 			) : memory ? (
 				<>
 					<div className="space-y-2">
-						<DetailTitle className="whitespace-pre-wrap leading-snug">{memory.content}</DetailTitle>
+						<div className="flex items-start justify-between gap-3">
+							<DetailTitle className="whitespace-pre-wrap leading-snug">
+								{memory.content}
+							</DetailTitle>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={() => deleteMemory.mutate()}
+								disabled={deleteMemory.isPending}
+								className="shrink-0 text-destructive hover:text-destructive"
+							>
+								<Trash2 />
+								Delete
+							</Button>
+						</div>
 						<DetailMeta>
 							<Badge
 								variant="secondary"

--- a/apps/web/src/app/(dashboard)/memories/page.tsx
+++ b/apps/web/src/app/(dashboard)/memories/page.tsx
@@ -2,7 +2,6 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertCircle, Brain, Database, Key, Plus } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { makeMemoryColumns } from "@/components/memories/memory-columns";
@@ -47,7 +46,6 @@ const ALL = "all";
 export default function MemoriesPage() {
 	const api = useApi();
 	const queryClient = useQueryClient();
-	const router = useRouter();
 	const [search, setSearch] = useState("");
 	const [category, setCategory] = useState<string>(ALL);
 	const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 25 });
@@ -160,7 +158,8 @@ export default function MemoriesPage() {
 					columns={columns}
 					data={memories ?? []}
 					isLoading={isLoading}
-					onRowClick={(m) => router.push(`/memories/${m.id}`)}
+					getRowHref={(m) => `/memories/${m.id}`}
+					rowAriaLabel={(m) => `Open memory ${m.id.slice(0, 8)}`}
 					emptyMessage={
 						debouncedSearch || apiCategory
 							? "No matches — try a different search or category."

--- a/apps/web/src/app/(dashboard)/page.tsx
+++ b/apps/web/src/app/(dashboard)/page.tsx
@@ -3,7 +3,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { ArrowRight } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { AgentsCard } from "@/components/dashboard/agents-card";
 import { ContributionGraph } from "@/components/dashboard/contribution-graph";
 import { OnboardingCard } from "@/components/dashboard/onboarding-card";
@@ -21,7 +20,6 @@ const RECENT_SESSIONS_LIMIT = 15;
 
 export default function DashboardPage() {
 	const api = useApi();
-	const router = useRouter();
 
 	const { data: stats } = useQuery({
 		queryKey: ["dashboard-stats"],
@@ -112,7 +110,8 @@ export default function DashboardPage() {
 							columns={sessionColumnsCompact}
 							data={sessions ?? []}
 							isLoading={sessionsLoading}
-							onRowClick={(s) => router.push(`/sessions/${s.id}`)}
+							getRowHref={(s) => `/sessions/${s.id}`}
+							rowAriaLabel={(s) => `Open session ${s.local_session_id}`}
 							emptyMessage={
 								<>
 									No sessions yet. Run{" "}

--- a/apps/web/src/app/(dashboard)/sessions/page.tsx
+++ b/apps/web/src/app/(dashboard)/sessions/page.tsx
@@ -2,7 +2,6 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { AlertCircle } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { PageHeader } from "@/components/page-header";
 import { sessionColumns } from "@/components/sessions/session-columns";
@@ -17,7 +16,6 @@ import { errorMessage } from "@/lib/utils";
 
 export default function SessionsPage() {
 	const api = useApi();
-	const router = useRouter();
 	const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 25 });
 	const [search, setSearch] = useState("");
 	const debouncedSearch = useDebouncedValue(search, 250);
@@ -71,7 +69,8 @@ export default function SessionsPage() {
 							? "No sessions match your search."
 							: "No sessions yet. Run clawdi push on a connected agent."
 					}
-					onRowClick={(s) => router.push(`/sessions/${s.id}`)}
+					getRowHref={(s) => `/sessions/${s.id}`}
+					rowAriaLabel={(s) => `Open session ${s.local_session_id}`}
 					pagination={pagination}
 					onPaginationChange={setPagination}
 					pageCount={pageCount}

--- a/apps/web/src/app/(dashboard)/skills/[key]/page.tsx
+++ b/apps/web/src/app/(dashboard)/skills/[key]/page.tsx
@@ -5,13 +5,7 @@ import { ExternalLink, FileText, Tag, Trash2 } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
-import {
-	DetailActions,
-	DetailMeta,
-	DetailNotFound,
-	DetailStats,
-	DetailTitle,
-} from "@/components/detail/layout";
+import { DetailMeta, DetailNotFound, DetailStats, DetailTitle } from "@/components/detail/layout";
 import { Markdown } from "@/components/markdown";
 import { Stat } from "@/components/meta/stat";
 import { Button } from "@/components/ui/button";
@@ -51,21 +45,6 @@ export default function SkillDetailPage() {
 
 	return (
 		<div className="space-y-5 px-4 lg:px-6">
-			<DetailActions>
-				{skill && !isLoading ? (
-					<Button
-						variant="outline"
-						size="sm"
-						onClick={() => uninstall.mutate()}
-						disabled={uninstall.isPending}
-						className="text-destructive hover:text-destructive"
-					>
-						<Trash2 />
-						Uninstall
-					</Button>
-				) : null}
-			</DetailActions>
-
 			{error ? (
 				<DetailNotFound title="Skill not found" message={errorMessage(error)} />
 			) : isLoading ? (
@@ -76,7 +55,19 @@ export default function SkillDetailPage() {
 			) : skill ? (
 				<>
 					<div className="space-y-2">
-						<DetailTitle className="truncate">{skill.name}</DetailTitle>
+						<div className="flex items-start justify-between gap-3">
+							<DetailTitle className="truncate">{skill.name}</DetailTitle>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={() => uninstall.mutate()}
+								disabled={uninstall.isPending}
+								className="shrink-0 text-destructive hover:text-destructive"
+							>
+								<Trash2 />
+								Uninstall
+							</Button>
+						</div>
 						<DetailMeta>
 							<span>{skill.source}</span>
 							{skill.source_repo ? (

--- a/apps/web/src/components/app-breadcrumb.tsx
+++ b/apps/web/src/components/app-breadcrumb.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useBreadcrumbTitle } from "@/components/breadcrumb-title";
 import {
@@ -67,7 +68,13 @@ export function AppBreadcrumb() {
 								{isLast ? (
 									<BreadcrumbPage className="max-w-[420px] truncate">{label}</BreadcrumbPage>
 								) : (
-									<BreadcrumbLink href={href}>{label}</BreadcrumbLink>
+									// asChild + next/link: shadcn's default BreadcrumbLink is
+									// a raw <a> which forces a full page reload + drops
+									// prefetch. asChild lets us pass our own anchor — Next's
+									// Link gives SPA navigation and hover-prefetch.
+									<BreadcrumbLink asChild>
+										<Link href={href}>{label}</Link>
+									</BreadcrumbLink>
 								)}
 							</BreadcrumbItem>
 							{!isLast ? <BreadcrumbSeparator /> : null}

--- a/apps/web/src/components/detail/layout.tsx
+++ b/apps/web/src/components/detail/layout.tsx
@@ -18,13 +18,6 @@ import { AlertCircle } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { cn } from "@/lib/utils";
 
-/** Right-aligned action button slot at the top of a detail page.
- * Render nothing if no children (a `null` child collapses to nothing). */
-export function DetailActions({ children }: { children?: React.ReactNode }) {
-	if (!children) return null;
-	return <div className="flex items-center justify-end gap-2">{children}</div>;
-}
-
 /** h1 used by detail pages. Centralized so the size/weight stays in one
  * place. Wrapping is the default — callers that want a single-line
  * truncation pass `className="truncate"` (skills detail does, memories

--- a/apps/web/src/components/ui/data-table.tsx
+++ b/apps/web/src/components/ui/data-table.tsx
@@ -9,6 +9,7 @@ import {
 	useReactTable,
 	type VisibilityState,
 } from "@tanstack/react-table";
+import Link from "next/link";
 import { useState } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -19,6 +20,7 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
 
 const SKELETON_ROWS = Array.from({ length: 5 }, (_, i) => `row-${i}`);
 
@@ -32,6 +34,17 @@ interface DataTableProps<TData, TValue> {
 	data: TData[];
 	isLoading?: boolean;
 	emptyMessage?: React.ReactNode;
+	/**
+	 * Make every row clickable and navigable. Preferred over `onRowClick`
+	 * for *navigation* — the row gets a stretched Next.js `<Link>` overlay
+	 * so middle-click opens a new tab, hover triggers prefetch, and
+	 * keyboard tab-order works. Use `onRowClick` only for non-nav side
+	 * effects (selection, expand-in-place, etc).
+	 */
+	getRowHref?: (row: TData) => string;
+	/** Used as the stretched link's aria-label so screen readers know
+	 * what activating the row does. Required when `getRowHref` is set. */
+	rowAriaLabel?: (row: TData) => string;
 	onRowClick?: (row: TData) => void;
 
 	// Server-mode state. All required together — DataTable no longer keeps
@@ -52,6 +65,8 @@ export function DataTable<TData, TValue>({
 	data,
 	isLoading,
 	emptyMessage = "No results.",
+	getRowHref,
+	rowAriaLabel,
 	onRowClick,
 	sorting,
 	onSortingChange,
@@ -110,21 +125,40 @@ export function DataTable<TData, TValue>({
 								</TableRow>
 							))
 						) : table.getRowModel().rows.length ? (
-							table.getRowModel().rows.map((row) => (
-								<TableRow
-									key={row.id}
-									onClick={onRowClick ? () => onRowClick(row.original) : undefined}
-									// `group` lets column cells do group-hover tricks (e.g. a
-									// delete icon that reveals only on row hover).
-									className={onRowClick ? "group cursor-pointer" : "group"}
-								>
-									{row.getVisibleCells().map((cell) => (
-										<TableCell key={cell.id}>
-											{flexRender(cell.column.columnDef.cell, cell.getContext())}
-										</TableCell>
-									))}
-								</TableRow>
-							))
+							table.getRowModel().rows.map((row) => {
+								const href = getRowHref?.(row.original);
+								const interactive = !!href || !!onRowClick;
+								return (
+									<TableRow
+										key={row.id}
+										onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+										// `group` lets cells do group-hover tricks (e.g. a delete
+										// icon that reveals only on row hover).
+										// `relative` hosts the stretched <Link> overlay below.
+										className={cn("group", interactive && "cursor-pointer", href && "relative")}
+									>
+										{row.getVisibleCells().map((cell, idx) => (
+											<TableCell key={cell.id}>
+												{idx === 0 && href ? (
+													// Stretched-link pattern: an absolute anchor
+													// covers the whole row so middle-click opens a
+													// new tab and hover triggers Next.js prefetch.
+													// Sits behind cell content; cells are static-
+													// positioned so their text doesn't intercept the
+													// click. Interactive elements inside cells need
+													// `relative z-10` to escape the link's hit area.
+													<Link
+														href={href}
+														aria-label={rowAriaLabel?.(row.original) ?? "Open"}
+														className="absolute inset-0"
+													/>
+												) : null}
+												{flexRender(cell.column.columnDef.cell, cell.getContext())}
+											</TableCell>
+										))}
+									</TableRow>
+								);
+							})
 						) : (
 							<TableRow className="hover:bg-transparent">
 								<TableCell


### PR DESCRIPTION
## Summary

Audit of internal navigation found four real issues — all fixed.

**Breadcrumb segments forced full page reload.** `<BreadcrumbLink>` shipped as a raw `<a>`. Now uses `asChild` + `<Link>` for SPA navigation + prefetch.

**DataTable rows lost middle-click and prefetch.** `onRowClick + router.push` is button semantics, not link semantics. Added `getRowHref` + `rowAriaLabel` props that render a stretched `<Link>` overlay per row. All four callsites migrated. `onRowClick` kept for non-nav side effects.

**`/agents` was a 404.** Only `agents/[id]` existed. Added `agents/page.tsx` redirecting to `/` since Agents live in the Overview's agents card by design.

**Destructive actions floated alone above the title.** Remove agent / Uninstall / Delete sat in their own row. Inlined next to the h1 via `flex justify-between`. `DetailActions` removed (was the wrapper).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run check` (biome ci) clean
- [x] `bun run build` green
- [ ] After deploy: middle-click any session row in `/sessions` opens new tab
- [ ] After deploy: `/agents` redirects to `/` instead of 404
- [ ] After deploy: agent detail Remove button is on the same line as the machine name

🤖 Generated with [Claude Code](https://claude.com/claude-code)