### PR TITLE
feat(connectors): server-side pagination + single-app endpoint + regen types

### DIFF
--- a/apps/web/src/app/(dashboard)/connectors/[name]/page.tsx
+++ b/apps/web/src/app/(dashboard)/connectors/[name]/page.tsx
@@ -30,9 +30,17 @@ export default function ConnectorDetailPage() {
 	const api = useApi();
 	const queryClient = useQueryClient();
 
-	const { data: apps, isLoading: isAppsLoading } = useQuery({
-		queryKey: ["available-apps"],
-		queryFn: async () => unwrap(await api.GET("/api/connectors/available")),
+	// One app's metadata via the single-app endpoint — not the full
+	// paginated catalog. Detail pages shouldn't pay for 1000+ entries
+	// just to render one display name.
+	const { data: app, isLoading: isAppLoading } = useQuery({
+		queryKey: ["available-app", name],
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/api/connectors/available/{app_name}", {
+					params: { path: { app_name: name } },
+				}),
+			),
 	});
 
 	const { data: connections, isLoading: isConnectionsLoading } = useQuery({
@@ -105,10 +113,9 @@ export default function ConnectorDetailPage() {
 		onError: (e) => toast.error("Failed to disconnect", { description: errorMessage(e) }),
 	});
 
-	const app = apps?.find((a) => a.name === name);
 	const activeConnections = connections?.filter((c) => c.app_name === name) ?? [];
 	const isConnected = activeConnections.length > 0;
-	const isLoading = isAppsLoading || isConnectionsLoading;
+	const isLoading = isAppLoading || isConnectionsLoading;
 
 	const displayName = app?.display_name || formatName(name);
 

--- a/apps/web/src/app/(dashboard)/connectors/page.tsx
+++ b/apps/web/src/app/(dashboard)/connectors/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { AlertCircle, Check, ChevronLeft, ChevronRight, Plug } from "lucide-react";
 import Link from "next/link";
-import { useDeferredValue, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ConnectorIcon } from "@/components/connectors/connector-icon";
 import { EmptyState } from "@/components/empty-state";
 import { PageHeader } from "@/components/page-header";
@@ -14,6 +14,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { SearchInput } from "@/components/ui/search-input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { unwrap, useApi } from "@/lib/api";
+import { useDebouncedValue } from "@/lib/use-debounced";
 import { cn, errorMessage } from "@/lib/utils";
 
 // Multiple of 12 (LCM of 1/2/3/4 col grid breakpoints) so the last row is
@@ -41,21 +42,38 @@ function ConnectorCardSkeleton() {
 export default function ConnectorsPage() {
 	const api = useApi();
 	const [query, setQuery] = useState("");
-	const [page, setPage] = useState(0);
-	const deferredQuery = useDeferredValue(query);
+	const [page, setPage] = useState(1);
+	const debouncedQuery = useDebouncedValue(query, 250);
 
 	const { data: connections } = useQuery({
 		queryKey: ["connections"],
 		queryFn: async () => unwrap(await api.GET("/api/connectors")),
 	});
 
+	// Server pagination: send page + search to the backend so we only
+	// ship one page (24 cards) over the wire instead of all 1000+.
+	// `keepPreviousData` prevents the grid from flashing to skeleton on
+	// every page-flip — old cards stay visible until the new ones load.
 	const {
-		data: availableApps,
+		data: pageData,
 		isLoading,
+		isFetching,
 		error,
 	} = useQuery({
-		queryKey: ["available-apps"],
-		queryFn: async () => unwrap(await api.GET("/api/connectors/available")),
+		queryKey: ["available-apps", { page, search: debouncedQuery }],
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/api/connectors/available", {
+					params: {
+						query: {
+							page,
+							page_size: PAGE_SIZE,
+							...(debouncedQuery ? { search: debouncedQuery } : {}),
+						},
+					},
+				}),
+			),
+		placeholderData: keepPreviousData,
 	});
 
 	const connectedNames = useMemo(
@@ -63,38 +81,27 @@ export default function ConnectorsPage() {
 		[connections],
 	);
 
-	const filtered = useMemo(() => {
-		if (!availableApps) return [];
-		let items = [...availableApps];
-		if (deferredQuery) {
-			const q = deferredQuery.toLowerCase();
-			items = items.filter(
-				(a) =>
-					a.name.toLowerCase().includes(q) ||
-					a.display_name.toLowerCase().includes(q) ||
-					a.description.toLowerCase().includes(q),
-			);
-		}
-		// Stable sort: connected → everyone else, preserving Composio's
-		// own default order (`/v1/apps` returns gmail / github / slack /
-		// notion / … which is curated by popularity upstream). JavaScript's
-		// Array.prototype.sort is stable since ES2019, so equal keys keep
-		// their input order.
-		items.sort((a, b) => {
+	// Reset to page 1 when the search term changes — staying on page 5
+	// of "github" while typing a different query would show empty results
+	// because the new query has fewer total pages.
+	useEffect(() => {
+		setPage(1);
+	}, [debouncedQuery]);
+
+	const items = pageData?.items ?? [];
+	const total = pageData?.total ?? 0;
+	const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+	// Connected-first within the page, preserving Composio's upstream
+	// popularity order via stable sort.
+	const sorted = useMemo(() => {
+		const arr = [...items];
+		arr.sort((a, b) => {
 			const ac = connectedNames.has(a.name) ? 0 : 1;
 			const bc = connectedNames.has(b.name) ? 0 : 1;
 			return ac - bc;
 		});
-		return items;
-	}, [availableApps, deferredQuery, connectedNames]);
-
-	// Reset pagination whenever the debounced query changes.
-	useEffect(() => {
-		setPage(0);
-	}, [deferredQuery]);
-
-	const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
-	const paged = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+		return arr;
+	}, [items, connectedNames]);
 
 	return (
 		<div className="space-y-5 px-4 lg:px-6">
@@ -103,8 +110,8 @@ export default function ConnectorsPage() {
 				description="Connect apps so your agents can use external tools."
 				actions={
 					<>
-						{availableApps ? (
-							<Badge variant="secondary">{availableApps.length} available</Badge>
+						{total > 0 ? (
+							<Badge variant="secondary">{total.toLocaleString()} available</Badge>
 						) : null}
 						{connections && connections.length > 0 ? (
 							<Badge>{connections.length} active</Badge>
@@ -127,7 +134,7 @@ export default function ConnectorsPage() {
 						<ConnectorCardSkeleton key={i} />
 					))}
 				</div>
-			) : filtered.length === 0 ? (
+			) : sorted.length === 0 ? (
 				<EmptyState
 					icon={Plug}
 					title={query ? "No matches" : "No connectors available"}
@@ -139,8 +146,13 @@ export default function ConnectorsPage() {
 				/>
 			) : (
 				<>
-					<div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-						{paged.map((app) => {
+					<div
+						className={cn(
+							"grid grid-cols-1 gap-2.5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4",
+							isFetching && "opacity-60 transition-opacity",
+						)}
+					>
+						{sorted.map((app) => {
 							const isConnected = connectedNames.has(app.name);
 							return (
 								<Link key={app.name} href={`/connectors/${app.name}`} className="group">
@@ -180,21 +192,21 @@ export default function ConnectorsPage() {
 							<Button
 								variant="outline"
 								size="icon-sm"
-								onClick={() => setPage((p) => Math.max(0, p - 1))}
-								disabled={page === 0}
+								onClick={() => setPage((p) => Math.max(1, p - 1))}
+								disabled={page <= 1}
 								aria-label="Previous page"
 							>
 								<ChevronLeft className="size-4" />
 							</Button>
 							<span className="px-3 text-xs tabular-nums text-muted-foreground">
-								{page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, filtered.length)} of{" "}
-								{filtered.length.toLocaleString()}
+								{(page - 1) * PAGE_SIZE + 1}–{Math.min(page * PAGE_SIZE, total)} of{" "}
+								{total.toLocaleString()}
 							</span>
 							<Button
 								variant="outline"
 								size="icon-sm"
-								onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-								disabled={page >= totalPages - 1}
+								onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+								disabled={page >= totalPages}
 								aria-label="Next page"
 							>
 								<ChevronRight className="size-4" />

--- a/backend/app/routes/connectors.py
+++ b/backend/app/routes/connectors.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from app.core.auth import AuthContext, get_auth
 from app.core.config import settings
+from app.schemas.common import Paginated
 from app.schemas.connector import (
     ConnectorAvailableAppResponse,
     ConnectorConnectionResponse,
@@ -15,6 +16,7 @@ from app.services.composio import (
     create_connect_link,
     create_proxy_token,
     disconnect_account,
+    get_app_by_name,
     get_app_tools,
     get_available_apps,
     get_connected_accounts,
@@ -38,12 +40,41 @@ async def list_connections(
 async def list_available_apps(
     auth: AuthContext = Depends(get_auth),
     search: str | None = Query(default=None, max_length=100),
-) -> list[ConnectorAvailableAppResponse]:
-    """List all available Composio apps."""
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=24, ge=1, le=100),
+) -> Paginated[ConnectorAvailableAppResponse]:
+    """Paginated Composio app catalog. Server holds the full list in a
+    5-min in-process cache and slices per request, so paginating doesn't
+    cost a Composio roundtrip per page and the browser only ships one
+    page at a time. Search is substring across slug, display name, and
+    description (server-side, before pagination)."""
     if not settings.composio_api_key:
-        return []
-    apps = await get_available_apps(search=search)
-    return [ConnectorAvailableAppResponse.model_validate(app) for app in apps]
+        return Paginated[ConnectorAvailableAppResponse](
+            items=[], total=0, page=page, page_size=page_size
+        )
+    page_data = await get_available_apps(search=search, page=page, page_size=page_size)
+    return Paginated[ConnectorAvailableAppResponse](
+        items=[ConnectorAvailableAppResponse.model_validate(a) for a in page_data["items"]],
+        total=page_data["total"],
+        page=page_data["page"],
+        page_size=page_data["page_size"],
+    )
+
+
+@router.get("/available/{app_name}")
+async def get_available_app(
+    app_name: str,
+    auth: AuthContext = Depends(get_auth),
+) -> ConnectorAvailableAppResponse:
+    """Single-app metadata lookup — used by the detail page so it doesn't
+    have to page through the whole catalog to find one app's display name.
+    Re-uses the cache that `/available` populates."""
+    if not settings.composio_api_key:
+        raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "Composio not configured")
+    app = await get_app_by_name(app_name)
+    if app is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Connector not found")
+    return ConnectorAvailableAppResponse.model_validate(app)
 
 
 @router.post("/{app_name}/connect")

--- a/backend/app/services/composio.py
+++ b/backend/app/services/composio.py
@@ -230,8 +230,30 @@ def _extract_display_name(slug: str, description: str) -> str:
     return spaced.title()
 
 
-async def get_available_apps(search: str | None = None) -> list[dict]:
-    """List available Composio apps."""
+_apps_cache: list[dict] | None = None
+_apps_cache_at: datetime | None = None
+_APPS_CACHE_TTL = timedelta(minutes=5)
+
+
+async def _get_all_apps() -> list[dict]:
+    """Fetch and cache the full Composio app catalog.
+
+    The catalog is ~1000 entries and changes rarely; loading it on every
+    page-flip wastes both Composio's quota and our request latency. Cache
+    in process for 5 minutes — short enough that newly-published apps
+    show up the same hour, long enough that paginating through doesn't
+    cost a roundtrip per page.
+
+    Order is preserved from Composio's `/v1/apps` response — that IS the
+    popularity-curated ordering they ship (gmail / github / slack /
+    notion / …). Do NOT alphabetize.
+    """
+    global _apps_cache, _apps_cache_at
+    now = datetime.now(UTC)
+    if _apps_cache is not None and _apps_cache_at is not None:
+        if (now - _apps_cache_at) < _APPS_CACHE_TTL:
+            return _apps_cache
+
     client = get_composio_client()
 
     def _list():
@@ -244,12 +266,6 @@ async def get_available_apps(search: str | None = None) -> list[dict]:
             display = _extract_display_name(key, app.description or "")
             logo = app.logo or ""
             desc = app.description or ""
-            if (
-                search
-                and search.lower() not in key.lower()
-                and search.lower() not in display.lower()
-            ):
-                continue
             result.append(
                 {
                     "name": key,
@@ -258,6 +274,53 @@ async def get_available_apps(search: str | None = None) -> list[dict]:
                     "description": desc[:200] if desc else "",
                 }
             )
-        return sorted(result, key=lambda x: x["display_name"].lower())
+        return result
 
-    return await run_in_threadpool(_list)
+    fresh = await run_in_threadpool(_list)
+    _apps_cache = fresh
+    _apps_cache_at = now
+    return fresh
+
+
+async def get_app_by_name(name: str) -> dict | None:
+    """Look up a single app by Composio slug. Used by the detail page so
+    it doesn't have to fetch the entire paginated catalog just to learn
+    one app's display name + logo. Re-uses the same in-process cache."""
+    items = await _get_all_apps()
+    for app in items:
+        if app["name"] == name:
+            return app
+    return None
+
+
+async def get_available_apps(
+    search: str | None = None,
+    page: int = 1,
+    page_size: int = 24,
+) -> dict:
+    """Paginated catalog query.
+
+    Caching the full list and slicing locally avoids the dual problem of
+    (a) shipping 1000+ entries to every browser and (b) hitting Composio
+    per page while the user paginates. Search is substring across slug /
+    display name / description — the same fields the v1 SDK exposes.
+    """
+    items = await _get_all_apps()
+    if search:
+        q = search.lower()
+        items = [
+            a
+            for a in items
+            if q in a["name"].lower()
+            or q in a["display_name"].lower()
+            or q in a["description"].lower()
+        ]
+    total = len(items)
+    start = max(0, (page - 1) * page_size)
+    end = start + page_size
+    return {
+        "items": items[start:end],
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+    }

--- a/packages/shared/src/api/generated.ts
+++ b/packages/shared/src/api/generated.ts
@@ -593,9 +593,35 @@ export interface paths {
 		};
 		/**
 		 * List Available Apps
-		 * @description List all available Composio apps.
+		 * @description Paginated Composio app catalog. Server holds the full list in a
+		 *     5-min in-process cache and slices per request, so paginating doesn't
+		 *     cost a Composio roundtrip per page and the browser only ships one
+		 *     page at a time. Search is substring across slug, display name, and
+		 *     description (server-side, before pagination).
 		 */
 		get: operations["list_available_apps_api_connectors_available_get"];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	"/api/connectors/available/{app_name}": {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Get Available App
+		 * @description Single-app metadata lookup — used by the detail page so it doesn't
+		 *     have to page through the whole catalog to find one app's display name.
+		 *     Re-uses the cache that `/available` populates.
+		 */
+		get: operations["get_available_app_api_connectors_available__app_name__get"];
 		put?: never;
 		post?: never;
 		delete?: never;
@@ -1119,6 +1145,17 @@ export interface components {
 			access_count?: number | null;
 			/** Created At */
 			created_at?: string | null;
+		};
+		/** Paginated[ConnectorAvailableAppResponse] */
+		Paginated_ConnectorAvailableAppResponse_: {
+			/** Items */
+			items: components["schemas"]["ConnectorAvailableAppResponse"][];
+			/** Total */
+			total: number;
+			/** Page */
+			page: number;
+			/** Page Size */
+			page_size: number;
 		};
 		/** Paginated[MemoryResponse] */
 		Paginated_MemoryResponse_: {
@@ -2862,6 +2899,8 @@ export interface operations {
 		parameters: {
 			query?: {
 				search?: string | null;
+				page?: number;
+				page_size?: number;
 			};
 			header?: never;
 			path?: never;
@@ -2875,7 +2914,38 @@ export interface operations {
 					[name: string]: unknown;
 				};
 				content: {
-					"application/json": components["schemas"]["ConnectorAvailableAppResponse"][];
+					"application/json": components["schemas"]["Paginated_ConnectorAvailableAppResponse_"];
+				};
+			};
+			/** @description Validation Error */
+			422: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					"application/json": components["schemas"]["HTTPValidationError"];
+				};
+			};
+		};
+	};
+	get_available_app_api_connectors_available__app_name__get: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				app_name: string;
+			};
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Successful Response */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					"application/json": components["schemas"]["ConnectorAvailableAppResponse"];
 				};
 			};
 			/** @description Validation Error */


### PR DESCRIPTION
User caught it: frontend was pulling all 1029 apps in one request and paginating client-side.

**Backend**:
- `/api/connectors/available` accepts `page` + `page_size` + `search`, returns `Paginated[…]`
- 5-minute in-process cache so paginating doesn't roundtrip to Composio per page
- Preserves Composio's default popularity order (gmail/github/slack/…) — removed the alphabetical sort that was destroying it
- New `GET /api/connectors/available/{app_name}` for the detail page

**Frontend**:
- `/connectors`: TanStack Query with `{page, search}` keys, `keepPreviousData` so page-flip doesn't flash skeleton
- `/connectors/[name]`: queries the new single-app endpoint directly (no more 1029-row trip just to read display_name)
- Search already debounced 250ms; `useDeferredValue` already on the tools-filter

**Types**: regenerated `packages/shared/src/api/generated.ts` against the new OpenAPI shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)