### PR TITLE
fix(backend): 500 on GET /api/memories/{id} from ORM validation

### DIFF
--- a/backend/app/routes/memories.py
+++ b/backend/app/routes/memories.py
@@ -17,7 +17,7 @@ from app.schemas.memory import (
     MemoryResponse,
 )
 from app.services.embedding import resolve_embedder
-from app.services.memory_provider import get_memory_provider
+from app.services.memory_provider import get_memory_provider, memory_to_dict
 
 log = logging.getLogger(__name__)
 
@@ -85,7 +85,7 @@ async def get_memory(
     memory = result.scalar_one_or_none()
     if not memory:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Memory not found")
-    return MemoryResponse.model_validate(memory)
+    return MemoryResponse.model_validate(memory_to_dict(memory))
 
 
 @router.post("")

--- a/backend/app/services/memory_provider.py
+++ b/backend/app/services/memory_provider.py
@@ -188,7 +188,7 @@ class BuiltinProvider:
             )
         out: list[dict] = []
         for mem, dist in rows:
-            d = _memory_to_dict(mem)
+            d = memory_to_dict(mem)
             # cosine distance ∈ [0, 2]; convert to similarity ∈ [0, 1].
             sim = max(0.0, 1.0 - float(dist))
             d["vector_score"] = sim
@@ -232,7 +232,7 @@ class BuiltinProvider:
         order_col = Memory.created_at.asc() if order == "asc" else Memory.created_at.desc()
         q = q.order_by(order_col).limit(limit).offset(offset)
         result = await self.db.execute(q)
-        return [_memory_to_dict(m) for m in result.scalars().all()]
+        return [memory_to_dict(m) for m in result.scalars().all()]
 
     async def count(self, user_id: str, category: str | None = None) -> int:
         from sqlalchemy import func as sqlfunc
@@ -343,7 +343,7 @@ class Mem0Provider:
 # ---------- helpers ----------
 
 
-def _memory_to_dict(m: Memory) -> dict:
+def memory_to_dict(m: Memory) -> dict:
     return {
         "id": str(m.id),
         "content": m.content,


### PR DESCRIPTION
## Summary
- `GET /api/memories/{id}` was returning 500 because `get_memory` passed a SQLAlchemy `Memory` ORM object directly to `MemoryResponse.model_validate(...)`, but the schema has no `from_attributes=True` and its fields are typed as `str` (not `UUID`/`datetime`).
- The list/search path already converts via the private `_memory_to_dict` helper. Renamed it to `memory_to_dict` and routed the single-get endpoint through it for one consistent serialization path.

## Test plan
- [ ] Restart backend and `GET /api/memories/{id}` for an existing memory → 200 with the same shape returned by the list endpoint
- [ ] `GET /api/memories/{id}` for a non-existent / other-user id → 404
- [ ] `GET /api/memories` (list) and search still return identical payload shape (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)