### PR TITLE
fix(cli): selectAdapter reports the right error in non-interactive mode

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -52,7 +52,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -27,7 +27,6 @@ export async function pull(opts: { modules?: string; dryRun?: boolean; agent?: s
 
 	const adapter = await selectAdapter(opts.agent);
 	if (!adapter) {
-		p.log.error("No supported agent detected on this machine.");
 		p.outro(chalk.red("Aborted."));
 		process.exitCode = 1;
 		return;

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -37,7 +37,6 @@ export async function push(opts: {
 
 	const adapter = await selectAdapter(opts.agent);
 	if (!adapter) {
-		p.log.error("No supported agent detected on this machine.");
 		p.outro(chalk.red("Aborted."));
 		process.exitCode = 1;
 		return;

--- a/packages/cli/src/lib/select-adapter.ts
+++ b/packages/cli/src/lib/select-adapter.ts
@@ -11,6 +11,7 @@ import {
 } from "../adapters/registry";
 import { getClawdiDir } from "./config";
 import { askOne } from "./prompts";
+import { isInteractive } from "./tty";
 
 export function getEnvIdByAgent(agentType: string): string | null {
 	const envPath = join(getClawdiDir(), "environments", `${agentType}.json`);
@@ -34,6 +35,13 @@ export function listRegisteredAgentTypes(): AgentType[] {
 	return types;
 }
 
+/**
+ * Resolve the agent adapter to operate on. Prints a specific error message
+ * to stdout before returning null so callers can simply abort — distinguishing
+ * "no agents found" from "ambiguous, can't pick without a prompt" is critical
+ * in non-interactive contexts (CI, AI agents, piped stdout) where the user
+ * sees a misleading "no supported agent" message if we collapse the cases.
+ */
 export async function selectAdapter(agentOpt?: string): Promise<AgentAdapter | null> {
 	// 1. Explicit --agent wins.
 	if (agentOpt) {
@@ -54,6 +62,13 @@ export async function selectAdapter(agentOpt?: string): Promise<AgentAdapter | n
 	const registered = listRegisteredAgentTypes();
 	if (registered.length === 1 && registered[0]) return adapterForType(registered[0]);
 	if (registered.length > 1) {
+		if (!isInteractive()) {
+			console.log(chalk.red("Multiple agents are registered on this machine."));
+			console.log(
+				chalk.gray(`Pass --agent <type> to choose one. Registered: ${registered.join(", ")}`),
+			);
+			return null;
+		}
 		const picked = await askOne<AgentType>(
 			"Multiple agents registered. Select one:",
 			registered.map((t) => ({ value: t, label: adapterRegistry[t].displayName })),
@@ -66,8 +81,20 @@ export async function selectAdapter(agentOpt?: string): Promise<AgentAdapter | n
 	const detected = (
 		await Promise.all(allAdapters.map(async (a) => ((await a.detect()) ? a : null)))
 	).filter((a): a is AgentAdapter => a !== null);
-	if (detected.length === 0) return null;
+	if (detected.length === 0) {
+		console.log(chalk.red("No supported agent detected on this machine."));
+		console.log(
+			chalk.gray(`Install one or pass --agent <type>. Available types: ${AGENT_TYPES.join(", ")}`),
+		);
+		return null;
+	}
 	if (detected.length === 1 && detected[0]) return detected[0];
+	if (!isInteractive()) {
+		const types = detected.map((a) => a.agentType);
+		console.log(chalk.red("Multiple agents detected on this machine."));
+		console.log(chalk.gray(`Pass --agent <type> to choose one. Detected: ${types.join(", ")}`));
+		return null;
+	}
 	const picked = await askOne<AgentType>(
 		"Multiple agents detected. Select one:",
 		detected.map((a) => ({


### PR DESCRIPTION
## Summary

`clawdi push` and `clawdi pull` were printing **\"No supported agent detected on this machine.\"** in non-interactive shells (CI, AI agents, piped stdout) — even when the user had multiple agents registered or detected. The interactive shell would have shown a selection menu in the same scenario.

The root cause was in \`selectAdapter\`: three different failure scenarios all returned \`null\`, and the caller printed a generic \"no agent detected\" message regardless of which scenario actually occurred.

## What changed

\`selectAdapter\` now distinguishes the three cases and prints the correct diagnostic itself before returning null:

| Scenario | Old message | New message |
|---|---|---|
| Truly no agents anywhere | \"No supported agent detected on this machine.\" | Same, plus list of valid \`--agent\` values |
| Multiple **registered**, can't prompt | \"No supported agent detected on this machine.\" ❌ | \"Multiple agents are registered on this machine. Pass --agent <type> to choose one. Registered: …\" |
| Multiple **detected**, can't prompt | \"No supported agent detected on this machine.\" ❌ | \"Multiple agents detected on this machine. Pass --agent <type> to choose one. Detected: …\" |

Callers (\`push.ts\`, \`pull.ts\`) now just abort silently when the adapter is null — the redundant generic message that was masking the real cause is gone.

## Why now

This bug bites the AI-agent onboarding flow that #39 just shipped: when an agent runs \`clawdi push --modules sessions --all --dry-run\` after \`clawdi setup\` has registered multiple agents, the user got an actively misleading error.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run build:dev\` builds
- [x] Local repro: 2 fake env files in \`~/.clawdi/environments/\` → non-interactive push now prints the correct \"Multiple agents are registered\" message
- [x] \`--agent <type>\` short-circuits as before
- [x] Truly empty env dir + no detected agents → still prints \"No supported agent detected\" (paired with the new helpful list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)