### PR TITLE
chore(cli): re-enable --provenance + bump 0.3.2

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -89,10 +89,14 @@ jobs:
       # because the step above already built everything; rerunning wastes
       # ~10s of CI time and risks a silent re-bundle with stale env.
       #
-      # `--provenance` is intentionally omitted: npm requires the source
-      # repository to be public to verify provenance attestations, and
-      # `Clawdi-AI/clawdi` is internal. If the repo ever goes public, add
-      # `--provenance` back and the OIDC + sigstore flow takes over.
+      # `--provenance` attaches a SLSA provenance attestation. Requires:
+      #   - `repository.url` in package.json points at a public GitHub repo
+      #     (Clawdi-AI/clawdi — confirmed public)
+      #   - workflow has `id-token: write` (above) for OIDC token minting
+      #   - npm trusted-publisher OIDC enabled for the package (env: npm)
+      # Once published, `npm view clawdi --json` shows a `dist.attestations`
+      # block, and the package page on npmjs.com gets the green "provenance"
+      # badge linking back to this exact workflow run.
       - name: Publish to npm
         if: steps.check.outputs.skip != 'true'
-        run: npm publish --access public --ignore-scripts
+        run: npm publish --access public --provenance --ignore-scripts

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Repo is public now ([Clawdi-AI/clawdi](https://github.com/Clawdi-AI/clawdi) → PUBLIC), so npm's provenance verification works again. Original drop (cc59efc) was while the source repo was internal — no longer applies.

Workflow already had the OIDC pieces (`id-token: write`, `environment: npm`, public `repository.url`). Adding `--provenance` makes npm attach a SLSA attestation linking the tarball back to this workflow run. Users get the provenance badge on npmjs.com and `npm view clawdi --json` shows `dist.attestations`.

Bumping to 0.3.2 so the publish workflow actually fires. No code change — pure provenance toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)