### PR TITLE
fix(cli): openclaw adapter recognizes production sessions index

### DIFF
--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { extractTarGz } from "../lib/tar";
 import type { AgentAdapter, RawSession, RawSkill, SessionMessage } from "./base";
 import { getOpenClawHome, SKIP_DIRS } from "./paths";
@@ -60,8 +60,14 @@ function listAgentDirs(): string[] {
 }
 
 interface SessionEntry {
-	sessionId: string;
+	// Real openclaw indexes key entries by composite strings like
+	// `agent:main:main` or `agent:main:telegram:group:-100…:topic:1`, with
+	// the actual UUID stored in this field. Treat the index key as a label
+	// only and trust `sessionId` for the localSessionId we publish.
+	sessionId?: string;
 	updatedAt?: number;
+	// May be absolute (production openclaw writes the full `/data/openclaw/…`
+	// path) or relative to the agent's `sessions/` dir (older fixtures).
 	sessionFile?: string;
 	model?: string;
 	modelProvider?: string;
@@ -164,7 +170,11 @@ export class OpenClawAdapter implements AgentAdapter {
 				continue;
 			}
 
-			for (const [sessionId, entry] of Object.entries(index)) {
+			for (const [indexKey, entry] of Object.entries(index)) {
+				// Prefer the entry's own `sessionId` (real UUID); fall back to
+				// the index key only for legacy fixtures that use the UUID as
+				// the key directly.
+				const sessionId = entry.sessionId ?? indexKey;
 				const updatedAt = entry.updatedAt ?? entry.acp?.lastActivityAt;
 				if (!updatedAt) continue;
 				if (updatedAt < sinceMs) continue;
@@ -176,7 +186,9 @@ export class OpenClawAdapter implements AgentAdapter {
 				}
 
 				const transcriptPath = entry.sessionFile
-					? join(sessionsDirForAgent, entry.sessionFile)
+					? isAbsolute(entry.sessionFile)
+						? entry.sessionFile
+						: join(sessionsDirForAgent, entry.sessionFile)
 					: join(sessionsDirForAgent, `${sessionId}.jsonl`);
 
 				const messages: SessionMessage[] = [];
@@ -186,7 +198,15 @@ export class OpenClawAdapter implements AgentAdapter {
 				if (entry.model) modelsUsed.add(entry.model);
 				let currentModel = entry.model ?? null;
 
-				if (existsSync(transcriptPath)) {
+				if (!existsSync(transcriptPath)) {
+					if (entry.sessionFile) {
+						// Index points at an absolute or relative transcript that we
+						// can't reach from this process (different mount, stale path,
+						// path-join bug regression). Surface it instead of silently
+						// dropping the session.
+						console.warn(`[openclaw] transcript missing for ${sessionId}: ${transcriptPath}`);
+					}
+				} else {
 					try {
 						const lines = readFileSync(transcriptPath, "utf-8").split("\n").filter(Boolean);
 						for (const line of lines) {

--- a/packages/cli/tests/adapters/openclaw.test.ts
+++ b/packages/cli/tests/adapters/openclaw.test.ts
@@ -167,6 +167,58 @@ describe("OpenClawAdapter.collectSessions", () => {
 		expect(ids).toEqual(["oc-financial-001", "oc-session-001"]);
 	});
 
+	it("handles production schema: composite index keys + absolute sessionFile", async () => {
+		// Mirror what real openclaw writes: index keyed by `agent:main:…`
+		// composite strings, with the UUID in `entry.sessionId` and an
+		// absolute `sessionFile` path. Earlier code used the index key as
+		// `localSessionId` and `path.join`-ed the absolute sessionFile onto
+		// the sessions dir, which produced a non-existent path and silently
+		// dropped every entry.
+		const sessionsDir = join(tmpHome, ".openclaw", "agents", "main", "sessions");
+		const uuid = "11111111-2222-3333-4444-555555555555";
+		const transcriptAbs = join(sessionsDir, `${uuid}.jsonl`);
+		writeFileSync(
+			join(sessionsDir, "sessions.json"),
+			JSON.stringify({
+				"agent:main:main": {
+					sessionId: uuid,
+					updatedAt: 1776247205000,
+					sessionFile: transcriptAbs,
+					model: "claude-opus-4-7",
+					inputTokens: 4,
+					outputTokens: 2,
+					cacheRead: 1,
+					displayName: "Telegram chat",
+					acp: { cwd: "/Users/fixture/project", lastActivityAt: 1776247205000 },
+				},
+			}),
+		);
+		writeFileSync(
+			transcriptAbs,
+			[
+				JSON.stringify({
+					type: "message",
+					timestamp: 1776247200000,
+					message: { role: "user", content: "hi" },
+				}),
+				JSON.stringify({
+					type: "message",
+					timestamp: 1776247205000,
+					message: { role: "assistant", content: "hello" },
+				}),
+			].join("\n"),
+		);
+
+		const a = new OpenClawAdapter();
+		const sessions = await a.collectSessions();
+		expect(sessions).toHaveLength(1);
+		const s = sessions[0]!;
+		// localSessionId must be the UUID, not the composite index key.
+		expect(s.localSessionId).toBe(uuid);
+		expect(s.messageCount).toBe(2);
+		expect(s.summary).toBe("Telegram chat");
+	});
+
 	it("OPENCLAW_AGENT_ID still narrows to a single agent", async () => {
 		addFinancialAgent(join(tmpHome, ".openclaw"));
 		process.env.OPENCLAW_AGENT_ID = "financial";


### PR DESCRIPTION
## Summary

`clawdi push --agent openclaw` finds **0 sessions** on a real openclaw install even when the agent has hundreds of transcripts on disk. Two stacking bugs in `OpenClawAdapter.collectSessions`:

1. **`sessionFile` may be absolute.** Real openclaw writes `"sessionFile": "/data/openclaw/agents/main/sessions/<uuid>.jsonl"`. The adapter did `path.join(sessionsDirForAgent, entry.sessionFile)` — Node's `join` does **not** short-circuit on absolute second args, so the resolved path becomes a non-existent `<sessionsDir>/data/openclaw/agents/main/sessions/<uuid>.jsonl`. Every transcript `existsSync`-ed `false`, every entry then hit the `messages.length === 0` silent skip at line 235, and the agent looked empty.
2. **Index keys are not UUIDs.** Real keys look like `agent:main:main` or `agent:main:telegram:group:-1003833123805:topic:1`. The UUID lives in `entry.sessionId`. The adapter used the key for both the fallback transcript path and the published `localSessionId`.

The silent `continue` on `messages.length === 0` is what hid this on real installs.

## What changed

- `entry.sessionId` is read for `localSessionId`; the index key is treated as a label and used only as a back-compat fallback for legacy fixtures (existing fixture keys by UUID — kept passing).
- `sessionFile` is resolved with `isAbsolute(...) ? sessionFile : join(sessionsDirForAgent, sessionFile)`.
- Added a `console.warn` when an entry declares `sessionFile` but the transcript can't be read, so the next path-resolution mismatch fails loud.
- Added a regression test that mirrors the production schema (composite index key + UUID in `sessionId` + absolute `sessionFile`).

## Test plan

- [x] `bun test` in `packages/cli` — 173/173 pass (was 168 — the new `handles production schema: composite index keys + absolute sessionFile` test plus existing 14).
- [x] `tsc --noEmit` clean.
- [x] `biome ci` clean.
- [x] Built tarball, copied via `phala cp` + `docker cp` into a real openclaw container, installed at `/opt/clawdi-patched` (system `/root/.bun/bin/clawdi` left untouched), ran `clawdi push --agent openclaw --all --dry-run`. Released 0.3.2 = 0 sessions; this branch = **26 sessions, 1 skill** scanned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)