### PR TITLE
feat(mcp): expose skills, sessions, vault to agents via 6 new tools

### DIFF
--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -1,50 +1,132 @@
 ---
 name: clawdi
-description: "Cross-agent long-term memory for the current user: their preferences, coding habits, named projects / repos / tools, past bugs and architecture decisions, and anything they reference with 'my', 'I usually', 'like last time', 'the one we set up', etc. Surface this skill BEFORE answering any question about the user themselves, their work, or their history — even when phrased abstractly (e.g. 'what do I usually use for X'). Also provides connected-service tools (Gmail, GitHub, Notion, Drive, Calendar, etc.)."
+description: "Cross-agent personal memory + skills + sessions + vault for the current user. Surface this skill BEFORE answering any question that references the user themselves, their work, their history, or any task that might already be a skill they've built. Triggers include possessives ('my X'), habit phrases ('I usually', 'I always'), callbacks ('like last time', 'as I mentioned', 'the one I set up'), how-to questions ('how do I X'), action verbs that map to common workflows (deploy, ship, QA, post, message, send, browse), and any named external service the user might have credentials for. Also provides connected-service tools (Gmail, GitHub, Notion, Drive, Calendar, etc.)."
 ---
 
 # Clawdi Cloud
 
-You have access to Clawdi Cloud tools via the `clawdi` MCP server. Use them aggressively — memory retrieval is the highest-leverage tool you have here.
+You have access to the user's Clawdi Cloud — their cross-agent personal memory, skills, sessions, and vault. Most agents fail by NOT reaching for this when they should. The single most common failure mode is "the user has the answer pre-built in their cloud and the agent answered from general knowledge instead." Don't be that agent.
 
-## Memory
+## What's in Clawdi
 
-Three tools for cross-agent memory:
+Four domains, all queryable through MCP tools. Use the right tool for the right shape of data:
 
-- `memory_search` — Search long-term memory by natural-language query (any language).
-- `memory_add` — Save a durable memory for cross-agent recall. Categories: `fact` (technical facts, API details, config values), `preference` (user preferences, coding style, workflow choices), `pattern` (recurring patterns, pitfalls, team conventions), `decision` (architecture decisions and their reasoning), `context` (project context, deadlines, ongoing work).
-- `memory_extract` — Batch-extract durable memories from the CURRENT conversation. Call this when the user says "extract memories", "save what we discussed", "remember this conversation", or equivalent. The tool returns instructions that walk you through a list-then-confirm flow using `memory_search` and `memory_add` — follow them exactly, including **waiting for the user's approval before writing anything**. Never skip the confirmation step, never save more than 5 memories in one invocation, and do not narrate your internal workflow to the user.
+| Domain | What it stores | Tool to query |
+|---|---|---|
+| **Memory** | Atomic durable facts: preferences, decisions, patterns, project context | `memory_search`, `memory_add`, `memory_extract` |
+| **Skills** | Executable procedures with full instructions ("how to deploy", "how to post to Twitter") | `skill_search`, `skill_get` |
+| **Sessions** | Past conversation transcripts across all agents (Claude Code, Codex, OpenClaw, Hermes) | `session_search`, `session_get` |
+| **Vault** | Credential names (NOT values) — Stripe keys, API tokens, OAuth secrets | `vault_list` |
+| *Cross-domain* | When you don't know which domain | `clawdi_search` |
 
-### When to search — bias toward calling
+## The dispatcher: which tool, when
 
-**Default assumption: the user has stored context you don't have. Call `memory_search` BEFORE answering any question about them, their project, their preferences, or their history. A call that returns empty costs ~100ms; a missed hit makes you look amnesic and forces them to re-teach you every session.**
+Match the user's question shape to the right first call. **Pick one — don't fan out across all tools when one is clearly right.**
 
-The single most common failure mode is NOT calling memory_search on abstract self-referential questions. If the user's message has any of these shapes, you MUST call it — no judgment, no exceptions:
+```
+"how do I X" / action verb         → skill_search
+"what did I/we do about X"         → session_search
+"my X" / "the one I" / "like last  → memory_search   (most cases)
+  time" / "as I mentioned"           clawdi_search    (when domain unclear)
+"I usually X" / habit/preference   → memory_search
+named service ("Twitter", "Stripe", "Notion")
+  + action ("post", "set up")      → vault_list      (then skill_search)
+self-reference: "tell me about myself"  → memory_search
+ambiguous topic ("polymarket", "redpill metrics")  → clawdi_search
 
-1. **Preference / habit questions**, even without a specific entity named.
-   Examples: "what do I usually use for X", "how do I normally do Y", "what's my preferred tool for Z", "what's my coding style". Pass a short paraphrase as the query.
-2. **Callbacks to prior context.** "as I mentioned", "like last time", "you know the one", "we discussed before", "what was that X we set up".
-3. **Named entities specific to this user.** Their project / repo / service / team / tool name. A person by name.
-4. **Past bugs, decisions, investigations, design choices.**
-5. **Start of a new session where they reference anything about themselves or their work.**
+after fixing a non-obvious bug    → memory_add
+after making an architecture decision → memory_add
+user says "remember this"         → memory_add (or memory_extract for batch)
+"save what we discussed"          → memory_extract
+```
 
-Do NOT search for:
-- Purely textbook programming questions with no user-specific signal ("how does `useEffect` work", "what is the time complexity of quicksort").
-- Questions the current code already answers directly.
+When in doubt: **`clawdi_search`** — fan-out across all 4, take the highest-ranked few.
 
-**When unsure, search.** Empty results cost you nothing. Missing the user's context costs you their trust.
+## The 6 rules
 
-### When to save
+These are the rules every Clawdi-aware agent must follow.
 
-- After fixing a non-obvious bug (save root cause + fix)
-- After making an architecture decision (save reasoning)
-- After discovering a useful pattern or workaround
-- When the user explicitly says "remember this" / "save this"
-- After learning a user preference you'd otherwise have to re-ask ("I prefer rg", "I always use pnpm")
+### Rule 1 — Bias toward calling
 
-Write memories as standalone sentences with full context — include names, not pronouns. A future session will read this without knowing today's conversation.
+A search that returns empty costs ~150ms. A missed call makes you look amnesic and forces the user to re-paste context every session. **When unsure, search.**
 
-Do NOT save trivial facts that are obvious from the code itself, or generic programming knowledge.
+The user has 130+ memories, 150+ skills, 90+ sessions, 490+ vault keys synced to the cloud. The probability that anything they reference exists in there is high. Default to assuming it does until search proves otherwise.
+
+### Rule 2 — Skill-first
+
+Before suggesting a manual approach for any task that could be a skill, call `skill_search`. The user has built skills for:
+- Deployment, QA, code review, shipping (`gstack/*`)
+- ML/data ops and metrics (`mlops/*`)
+- External services: Twitter, Slack, Notion, Polymarket, GitHub, Apple Notes/Reminders/iMessage/FindMy
+- Delegation to other AI agents (claude-code, codex, hermes)
+- Investigation, design review, retros, brainstorming
+
+If a skill exists for the task, **read it (`skill_get`) and follow it** rather than improvising. The user already iterated on it.
+
+### Rule 3 — Vault visibility, not values
+
+When a task needs credentials, **call `vault_list` first** to see what the user already has stored. Then suggest "I see you have `STRIPE_SECRET_KEY` configured — use it?" instead of asking "do you have a Stripe key?"
+
+`vault_list` returns names only. Values are NEVER exposed through any tool. If the user asks for a value, refuse and point them to the dashboard. This is a hard security boundary — do not work around it.
+
+### Rule 4 — Cite-or-abstain
+
+If you used a retrieved memory, skill, session, or vault key in your answer, **name its ID/key** so the user can verify and refine.
+
+Examples:
+- ✅ "Per memory `8b83f845…` (Voice Call Twilio Setup), the webhook URL is …"
+- ✅ "Following the `research/polymarket` skill, querying the markets endpoint…"
+- ❌ "Based on what I remember, …" (← which memory? unfalsifiable)
+- ❌ "I see you have a Twitter setup, let me post…" (← which skill? which keys?)
+
+This forces you to actually integrate retrieved content instead of paraphrasing it away. It also lets the user spot stale memories and update them.
+
+### Rule 5 — Zero-result protocol
+
+If a search returns nothing, **say so out loud** — don't silently fall back to general knowledge.
+
+✅ "I don't see any memory or session about the audit log table. Want me to add one when we set it up?"
+❌ "*makes something up that sounds plausible*"
+
+The user's trust depends on knowing whether you're using their context or fabricating. Being honest about gaps is part of the contract.
+
+### Rule 6 — Writeback discipline
+
+After significant moments, save to memory. The user-side flow is moving to server-side LLM extraction from sessions, so for now your job is to reach for `memory_add` at these moments:
+
+- **After fixing a non-obvious bug** — save root cause + fix, not just "bug fixed"
+- **After making an architecture decision** — save the decision AND the reasoning
+- **After learning a user preference** — so neither you nor the next agent re-asks
+- **When the user explicitly says "remember this"** — always honor
+
+For batch save at session end (user says "save what we discussed"), use `memory_extract` and follow its list-then-confirm flow. Never save without confirmation.
+
+Write content as **standalone sentences with proper nouns** (not pronouns). A future session will read it without today's context. Examples:
+- ✅ "Marvin prefers `rg` over `grep` and `fd` over `find`."
+- ❌ "User likes rg." (no proper noun, future-self ambiguous)
+
+Do NOT save: trivia readable from current code, generic programming knowledge, ephemeral conversation noise.
+
+## Memory categories
+
+When calling `memory_add`, pick:
+- **`fact`** — technical facts, API details, config values
+- **`preference`** — user preferences, coding style, workflow choices
+- **`pattern`** — recurring patterns, pitfalls, team conventions
+- **`decision`** — architecture decisions and their reasoning
+- **`context`** — project context, deadlines, ongoing work
+
+Default if unsure: `fact`.
+
+## Anti-hallucination clause
+
+A retrieved memory naming a specific function, file, or flag is a claim that it existed *when the memory was written*. It may have been renamed, removed, or never merged. Before recommending it:
+
+- If the memory names a file path: verify it exists.
+- If the memory names a function or flag: grep for it.
+- If the user is about to act on your recommendation: verify first.
+
+"The memory says X exists" is not the same as "X exists now."
 
 ## Connectors
 
@@ -52,5 +134,14 @@ Connected service tools (Gmail, GitHub, Notion, etc.) are dynamically registered
 
 - These tools are already authenticated — no OAuth needed at runtime
 - If a tool call fails with "No connected account", tell the user to connect the service in the Clawdi Cloud dashboard
-- File downloads from connectors return signed URLs — download them with `curl` or `fetch` before processing
-- Confirm with the user before side-effecting operations (sending email, creating issues, etc.)
+- File downloads from connectors return signed URLs — download with `curl` or `fetch` before processing
+- Confirm with the user before side-effecting operations (sending email, creating issues, posting tweets)
+
+## When NOT to use Clawdi tools
+
+Skip the search/recall flow when:
+- The question is purely textbook programming with zero user-specific signal ("how does `useEffect` work", "explain quicksort")
+- The current code or open file already answers the question directly
+- The user explicitly says "ignore memory" or "don't use my saved context"
+
+When in doubt: **search**. Empty results are cheap; missing the user's context costs their trust.

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -213,6 +213,355 @@ export async function startMcpServer() {
 		}),
 	);
 
+	// --- Cross-domain tools: skills, sessions, vault, unified search ---
+
+	server.tool(
+		"clawdi_search",
+		"ALWAYS call this BEFORE answering when the user references their own context but the domain is unclear — could be memory, a skill, a session, or a vault key. This is the cross-domain umbrella: one query → ranked results across all 4 domains.\n\nMUST call when the user's message contains ANY of:\n- Vague self-reference where domain is ambiguous: \"the one I set up\", \"like last time\", \"my X\" without naming X's type\n- A topic that could be a skill, vault scope, or memory: \"polymarket\", \"clawdi backend\", \"phala website\", \"my Twitter\"\n- Cross-cutting questions: \"what do I have for X\", \"anything about Y in my stuff\"\n\nReturns mixed types. Each result has type (memory/skill/session/vault), id, title, and href. After getting results, READ the relevant items via skill_get / session_get / memory_search for full content. CITE the IDs in your response — do not paraphrase results away.\n\nDo NOT call for purely textbook programming questions or when the user's intent is unambiguously a single domain (call that domain's tool directly).\n\nFailure mode if skipped: agent answers from general knowledge while the user has the exact answer in their cloud. Looks amnesic; forces the user to re-paste context.",
+		{
+			query: z.string().describe("Natural-language query in any language."),
+			limit: z
+				.number()
+				.optional()
+				.describe("Max results per domain (default 5)."),
+		},
+		async ({ query, limit }) => {
+			try {
+				const data = await api.get<{
+					query: string;
+					results: Array<{
+						type: string;
+						id: string;
+						title: string;
+						subtitle: string | null;
+						href: string;
+					}>;
+				}>(`/api/search?q=${encodeURIComponent(query)}`);
+				if (!data.results.length) {
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: "No results across memory, skills, sessions, or vault. (Empty result is real — say so to the user instead of falling back to general knowledge.)",
+							},
+						],
+					};
+				}
+				const byType: Record<string, typeof data.results> = {};
+				for (const hit of data.results) {
+					(byType[hit.type] ||= []).push(hit);
+				}
+				const cap = limit ?? 5;
+				const lines: string[] = [];
+				for (const [type, hits] of Object.entries(byType)) {
+					lines.push(`## ${type} (${hits.length})`);
+					for (const h of hits.slice(0, cap)) {
+						const sub = h.subtitle ? ` — ${h.subtitle}` : "";
+						lines.push(`  [${h.id}] ${h.title}${sub}`);
+					}
+				}
+				return {
+					content: [{ type: "text" as const, text: lines.join("\n") }],
+				};
+			} catch (e: any) {
+				return {
+					content: [{ type: "text" as const, text: `Error: ${e.message}` }],
+				};
+			}
+		},
+	);
+
+	server.tool(
+		"skill_search",
+		"ALWAYS call this BEFORE writing custom code or suggesting a manual approach for any task that might already be a skill. The user has many skills (often 100+) covering deploy, QA, browser automation, voice/SMS, social posting, prediction markets, code review, and more. Skill descriptions are explicit about when to use them — let the search find the right one.\n\nMUST call when the user's request matches ANY of these patterns:\n- \"How do I X\" / \"how can I X\" / \"show me how to X\" — a skill very likely exists\n- Action verbs that map to common workflows: deploy, ship, test, QA, review, browse, post, message, send, search, find, fetch, analyze, draft, summarize\n- Named external services: Twitter, Slack, Notion, Stripe, Polymarket, GitHub, iMessage, Apple Notes/Reminders/FindMy\n- Delegation requests: \"delegate this to claude-code / codex / hermes\" — those are skills\n- Workflow steps: \"investigate this bug\", \"review the plan\", \"do a retro\"\n\nReturns ranked skills (key, name, description, version). After finding the right one, call skill_get(key) to load the full instructions before executing.\n\nDo NOT call for trivial code questions, agent self-questions, or when the user has just told you not to use a skill.\n\nFailure mode if skipped: you write a worse, ad-hoc version of something the user has already built and refined. Cite the skill key when you use one.",
+		{
+			query: z.string().describe("Natural-language query — what the user wants to do."),
+			category: z
+				.string()
+				.optional()
+				.describe(
+					'Filter by top-level category (e.g. "gstack", "mlops", "apple", "research", "github").',
+				),
+			limit: z.number().optional().describe("Max results (default 5)."),
+		},
+		async ({ query, category, limit }) => {
+			try {
+				const params = new URLSearchParams({
+					q: query,
+					page_size: String(limit ?? 5),
+				});
+				const data = await api.get<{
+					items: Array<{
+						skill_key: string;
+						name: string;
+						description: string;
+						version: number;
+					}>;
+					total: number;
+				}>(`/api/skills?${params.toString()}`);
+				let items = data.items;
+				if (category) {
+					items = items.filter((s) =>
+						s.skill_key.startsWith(`${category}/`),
+					);
+				}
+				if (!items.length) {
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `No skills matched "${query}"${category ? ` in category "${category}"` : ""}.`,
+							},
+						],
+					};
+				}
+				const lines = items.map(
+					(s) =>
+						`[${s.skill_key}] ${s.name} (v${s.version}) — ${s.description}`,
+				);
+				return {
+					content: [{ type: "text" as const, text: lines.join("\n\n") }],
+				};
+			} catch (e: any) {
+				return {
+					content: [{ type: "text" as const, text: `Error: ${e.message}` }],
+				};
+			}
+		},
+	);
+
+	server.tool(
+		"skill_get",
+		"Call after skill_search to load the full skill instructions before executing. The search returns descriptions only; the body has the actual procedure, tool calls, and constraints.\n\nMUST call before invoking any procedure that depends on a skill — never wing it from the description alone.\n\nReturns the full SKILL.md content (frontmatter + body). Read it once at the start of the task; you don't need to re-load on every step.\n\nFailure mode if skipped: you execute based on the 150-character description and miss critical details (auth setup, ordering, edge cases) that are in the body.",
+		{
+			skill_key: z
+				.string()
+				.describe(
+					'Skill key, e.g. "research/polymarket", "gstack/qa", "apple/imessage".',
+				),
+		},
+		async ({ skill_key }) => {
+			try {
+				// Backend's /api/skills/{skill_key} currently 404s for skill_keys
+				// containing "/" — fall through the list endpoint with include_content
+				// and match by exact skill_key. Switch to the direct GET when backend
+				// fixes routing for slash-bearing keys.
+				const params = new URLSearchParams({
+					q: skill_key.split("/").pop() ?? skill_key,
+					include_content: "true",
+					page_size: "20",
+				});
+				const data = await api.get<{
+					items: Array<{
+						skill_key: string;
+						name: string;
+						description: string;
+						content?: string;
+					}>;
+				}>(`/api/skills?${params.toString()}`);
+				const match = data.items.find((s) => s.skill_key === skill_key);
+				if (!match) {
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `Skill "${skill_key}" not found.${data.items.length ? ` Did you mean: ${data.items.slice(0, 3).map((s) => s.skill_key).join(", ")}?` : ""}`,
+							},
+						],
+					};
+				}
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text:
+								match.content ??
+								"(skill body not available — backend did not return content)",
+						},
+					],
+				};
+			} catch (e: any) {
+				return {
+					content: [{ type: "text" as const, text: `Error: ${e.message}` }],
+				};
+			}
+		},
+	);
+
+	server.tool(
+		"session_search",
+		"Call when the user references prior conversation work — \"what did I figure out\", \"where did we leave off\", \"what was that thing about X\". Searches summary across all your past sessions on Clawdi (across every agent: Claude Code, Codex, OpenClaw, Hermes).\n\nMUST call when:\n- \"What did I/we do/figure out about X\" — past-tense recall\n- \"Continue from where we left off\" / \"pick up where we stopped\"\n- \"Show me that conversation about X\"\n- \"Last week / last month, when I was working on X\"\n\nReturns sessions ranked by relevance (id, agent_type, started_at, summary). After finding the right session, call session_get(id) only if the summary isn't enough.\n\nDo NOT call for the current session — you can already see that.\n\nFailure mode if skipped: you re-derive a decision the user already made, or re-do investigation work that's already done. Wasted effort + looks amnesic.",
+		{
+			query: z.string().describe("Natural-language query."),
+			agent: z
+				.enum(["claude_code", "codex", "openclaw", "hermes"])
+				.optional()
+				.describe("Filter to one agent."),
+			since: z
+				.string()
+				.optional()
+				.describe('ISO date — limit to recent sessions, e.g. "2026-04-01".'),
+			limit: z.number().optional().describe("Max results (default 5)."),
+		},
+		async ({ query, agent, since, limit }) => {
+			try {
+				const params = new URLSearchParams({
+					q: query,
+					page_size: String(limit ?? 5),
+				});
+				if (agent) params.set("agent", agent);
+				if (since) params.set("since", since);
+				const data = await api.get<{
+					items: Array<{
+						id: string;
+						agent_type: string;
+						summary: string | null;
+						started_at: string;
+						message_count: number;
+					}>;
+					total: number;
+				}>(`/api/sessions?${params.toString()}`);
+				if (!data.items.length) {
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `No sessions matched "${query}". (Backend currently uses substring match — try a single keyword. Note: many session summaries are still being re-distilled; recall quality will improve.)`,
+							},
+						],
+					};
+				}
+				const lines = data.items.map((s) => {
+					const date = s.started_at.slice(0, 10);
+					const summary = (s.summary ?? "(no summary)").slice(0, 200);
+					return `[${s.id.slice(0, 8)}] ${date} ${s.agent_type} (${s.message_count} msg) — ${summary}`;
+				});
+				return {
+					content: [{ type: "text" as const, text: lines.join("\n\n") }],
+				};
+			} catch (e: any) {
+				return {
+					content: [{ type: "text" as const, text: `Error: ${e.message}` }],
+				};
+			}
+		},
+	);
+
+	server.tool(
+		"session_get",
+		'Call after session_search if the summary isn\'t enough and you need the full message-by-message transcript. Expensive — sessions can be 100+ messages. Use sparingly.\n\nMUST call only when the user explicitly asks "show me the full session" or when the summary genuinely doesn\'t contain the detail you need (e.g. you need an exact code snippet they wrote).\n\nPrefer session summary first. If that\'s enough, do NOT call this.\n\nFailure mode if over-called: blows context budget on transcript noise.',
+		{
+			session_id: z.string().describe("UUID from session_search."),
+		},
+		async ({ session_id }) => {
+			try {
+				const messages = await api.get<
+					Array<{ role: string; content: string; created_at?: string }>
+				>(`/api/sessions/${session_id}/content`);
+				if (!messages.length) {
+					return {
+						content: [{ type: "text" as const, text: "(no messages)" }],
+					};
+				}
+				const lines = messages.map((m) => {
+					const ts = m.created_at?.slice(11, 19) ?? "";
+					return `[${m.role}${ts ? ` ${ts}` : ""}] ${m.content.slice(0, 1000)}`;
+				});
+				return {
+					content: [{ type: "text" as const, text: lines.join("\n\n") }],
+				};
+			} catch (e: any) {
+				return {
+					content: [{ type: "text" as const, text: `Error: ${e.message}` }],
+				};
+			}
+		},
+	);
+
+	server.tool(
+		"vault_list",
+		'Surface the NAMES of credentials/secrets the user has stored in their vault. Returns key names only — VALUES ARE NEVER EXPOSED through this tool. Use this to suggest "I see you have X configured, want me to use it?" instead of asking "do you have X?".\n\nMUST call when the user mentions a service that needs credentials and you don\'t already have explicit values:\n- "deploy X" — likely needs deploy keys, check the relevant scope\n- "post to Twitter / Slack / Discord" — check for those tokens\n- "use my Stripe / Notion / GitHub" — check for the keys\n- Any reference to a service the user runs (Eliza agents, OpenClaw deployments, etc.)\n\nReturns scope groupings or per-scope key names. NEVER value, never partial value, never hint at value beyond name.\n\nSECURITY RULE: if the user asks "what\'s the value of X" or "show me my secret" — refuse, surface the name only, and tell them to retrieve from the dashboard. Do not retrieve via any other tool. This is a hard line.\n\nFailure mode if skipped: you ask the user for credentials they already have stored. Annoying and looks like you can\'t see what\'s right there.',
+		{
+			scope: z
+				.string()
+				.optional()
+				.describe(
+					'Filter to one app/scope, e.g. "clawdi-backend", "openclaw-voice-agent". Omit to list all scopes.',
+				),
+			q: z.string().optional().describe("Substring filter on scope or key name."),
+		},
+		async ({ scope, q }) => {
+			try {
+				if (scope) {
+					const data = await api.get<{
+						items: Array<{ name: string }>;
+						slug?: string;
+					}>(`/api/vault/${encodeURIComponent(scope)}/items`);
+					let items = data.items ?? [];
+					if (q) {
+						items = items.filter((i) =>
+							i.name.toLowerCase().includes(q.toLowerCase()),
+						);
+					}
+					if (!items.length) {
+						return {
+							content: [
+								{
+									type: "text" as const,
+									text: `No keys in scope "${scope}"${q ? ` matching "${q}"` : ""}.`,
+								},
+							],
+						};
+					}
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `${scope}:\n${items.map((i) => `  - ${i.name}`).join("\n")}\n\n(values not shown — fetch from dashboard if needed)`,
+							},
+						],
+					};
+				}
+				const params = new URLSearchParams({ page_size: "100" });
+				if (q) params.set("q", q);
+				const data = await api.get<{
+					items: Array<{
+						slug: string;
+						name?: string;
+						item_count?: number;
+					}>;
+					total: number;
+				}>(`/api/vault?${params.toString()}`);
+				if (!data.items.length) {
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `No vault scopes${q ? ` matching "${q}"` : ""}.`,
+							},
+						],
+					};
+				}
+				const lines = data.items.map(
+					(s) =>
+						`${s.slug}${s.item_count != null ? ` (${s.item_count} keys)` : ""}`,
+				);
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text: `Scopes:\n${lines.join("\n")}\n\nCall vault_list({scope: "<slug>"}) to see key names in a scope.`,
+						},
+					],
+				};
+			} catch (e: any) {
+				return {
+					content: [{ type: "text" as const, text: `Error: ${e.message}` }],
+				};
+			}
+		},
+	);
+
 	// --- Dynamically registered connector tools (from Composio via backend) ---
 
 	if (mcpConfig && remoteTools.length > 0) {


### PR DESCRIPTION
## Summary

Takes the MCP server tool surface from 3 (memory only) to 9 (cross-domain) by adding `clawdi_search`, `skill_search`, `skill_get`, `session_search`, `session_get`, and `vault_list`. Rewrites the bundled `clawdi` skill as a RESOLVER dispatcher covering all 4 domains.

## Why

Production data audit on 2026-04-27 showed every agent on Clawdi (Claude Code, Codex, OpenClaw, Hermes) sees only `memory_search` via MCP. The user has **153 skills, ~98 sessions, and 492 vault keys** synced to the cloud — all invisible to the agent.

Canonical demo: `research/polymarket` is a purpose-built skill for "Query Polymarket prediction market data." When the user asks *"check polymarket on whether X happens"*, agents fall back to general knowledge because `skill_search` doesn't exist on the tool surface. They literally cannot see the skill that perfectly matches the request.

After this change, `clawdi_search("polymarket")` returns the 2 perfect-match skills alongside memory hits. The agent can finally see what's there.

## What's in this PR

- **6 new tool registrations** in `packages/cli/src/mcp/server.ts`, each with verbose descriptions matching the existing `memory_search` style (explicit MUST/MUST NOT triggers, failure-mode framing, example queries)
- **Rewritten bundled skill** at `packages/cli/skills/clawdi/SKILL.md` — now a RESOLVER dispatcher with 6 rules: bias-toward-calling, skill-first, vault visibility (names only, never values), cite-or-abstain, zero-result protocol, writeback discipline

## Tool surface after this PR

| Tool | Purpose |
|---|---|
| `memory_search` / `memory_add` / `memory_extract` | (existing) |
| `clawdi_search` | Cross-domain umbrella — fan out across all 4 domains, RRF-style |
| `skill_search` | Find a skill by intent ("how do I post to twitter") |
| `skill_get` | Load full skill body before executing |
| `session_search` | Recall past conversation work across all agents |
| `session_get` | Load full transcript when summary isn't enough |
| `vault_list` | Surface credential **names** (never values) |

## Backend issues surfaced (for follow-up)

These don't block this PR — the tool surface registers correctly — but should be addressed in the related backend work:

- `/api/skills/{skill_key}` returns 404 for both UUID and slug forms. Routing likely missing `:path` converter for keys containing `/`. **Worked around** in `skill_get` by using the list endpoint with `?include_content=true`. Switch to the proper endpoint when fixed.
- `/api/vault/{slug}/items` returns 0 items for known scopes. `vault_list` is registered but won't return key names until backend fix lands.

## Test plan

Local stdio probe against production API after `bun run build`:

- [x] All 9 tools appear in `tools/list`
- [x] `clawdi_search("polymarket")` returns memories + the 2 perfect-match skills (canonical demo case fixed)
- [x] `skill_search("voice")` returns hermes-agent + linkedin-engagement
- [x] `skill_get("truth-search")` returns full SKILL.md body
- [x] `session_search("voice")` returns the matching session
- [x] `memory_*` tools unchanged
- [ ] `vault_list(scope=...)` (pending backend fix)
- [ ] Manual loop on each agent (Claude Code / Codex / OpenClaw / Hermes) post-merge

## Spec

Detailed plan + benchmarks lives in the monorepo (Marvin's harness-UX workstream):
- Master plan: `docs/plans/cross-domain-agent-harness.md`
- Subplan + tracker: `docs/plans/harness-and-wiki.md`
- Tool description drafts: `docs/plans/harness-and-wiki/tool-descriptions.md`
- Benchmark seeds: `docs/plans/harness-and-wiki/queries.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)