### PR TITLE
feat(wiki): personal wiki MVP — schema, sanitizer, slug resolver, API, dashboard

### DIFF
--- a/apps/web/src/app/(dashboard)/wiki/[slug]/page.tsx
+++ b/apps/web/src/app/(dashboard)/wiki/[slug]/page.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useAuth } from "@clerk/nextjs";
+import { useQuery } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  Brain,
+  Clock,
+  FileText,
+  Key,
+  Link2,
+  Sparkles,
+} from "lucide-react";
+import Link from "next/link";
+import { notFound, useParams } from "next/navigation";
+import { Skeleton } from "@/components/ui/skeleton";
+import { apiFetch } from "@/lib/api";
+import { cn, relativeTime } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Types — match backend WikiPageDetail
+// ---------------------------------------------------------------------------
+
+type WikiLinkOut = {
+  id: string;
+  link_type: string;
+  confidence: number | null;
+  to_page_id: string | null;
+  to_page_slug: string | null;
+  to_page_title: string | null;
+  source_type: string | null;
+  source_ref: string | null;
+};
+
+type WikiPageDetail = {
+  id: string;
+  slug: string;
+  title: string;
+  kind: string;
+  compiled_truth: string | null;
+  frontmatter: Record<string, unknown> | null;
+  source_count: number;
+  stale: boolean;
+  last_synthesis_at: string | null;
+  created_at: string;
+  updated_at: string;
+  outgoing_links: WikiLinkOut[];
+  backlinks: WikiLinkOut[];
+};
+
+const SOURCE_ICONS: Record<string, typeof Brain> = {
+  memory: Brain,
+  skill: Sparkles,
+  session: FileText,
+  vault: Key,
+};
+
+const SOURCE_COLORS: Record<string, string> = {
+  memory: "text-blue-600 dark:text-blue-400",
+  skill: "text-purple-600 dark:text-purple-400",
+  session: "text-green-600 dark:text-green-400",
+  vault: "text-amber-600 dark:text-amber-400",
+};
+
+export default function WikiPageView() {
+  const { getToken } = useAuth();
+  const params = useParams<{ slug: string }>();
+  const slug = params?.slug;
+
+  const { data, isLoading, error } = useQuery<WikiPageDetail>({
+    queryKey: ["wiki", "page", slug],
+    queryFn: async () => {
+      const token = await getToken();
+      return apiFetch<WikiPageDetail>(
+        `/api/wiki/pages/${encodeURIComponent(slug!)}`,
+        token!,
+      );
+    },
+    enabled: !!slug,
+    retry: (count, err: Error) =>
+      // Don't retry 404s — they're expected when a slug doesn't exist.
+      !err.message.includes("404") && count < 2,
+  });
+
+  if (error?.message.includes("404")) {
+    notFound();
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+      <Link
+        href="/wiki"
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ArrowLeft className="size-4" />
+        Back to wiki
+      </Link>
+
+      {isLoading ? (
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/2" />
+          <Skeleton className="h-4 w-1/3" />
+          <Skeleton className="h-32 w-full" />
+        </div>
+      ) : data ? (
+        <PageContent page={data} />
+      ) : null}
+    </div>
+  );
+}
+
+function PageContent({ page }: { page: WikiPageDetail }) {
+  // Group outgoing links by whether they point to another page (graph
+  // edges) or to a source item (memory/skill/session/vault evidence).
+  const outgoingPageLinks = page.outgoing_links.filter((l) => l.to_page_id);
+  const sourceLinks = page.outgoing_links.filter((l) => l.source_type);
+
+  // Group source links by domain so the panel reads like a clean ledger.
+  const sourcesByDomain = sourceLinks.reduce<Record<string, WikiLinkOut[]>>(
+    (acc, l) => {
+      const k = l.source_type!;
+      (acc[k] = acc[k] ?? []).push(l);
+      return acc;
+    },
+    {},
+  );
+
+  return (
+    <article className="space-y-8">
+      <header className="space-y-3">
+        <div className="flex items-center gap-3 flex-wrap">
+          <h1 className="text-3xl font-semibold">{page.title}</h1>
+          <span className="text-[10px] px-1.5 py-0.5 rounded uppercase tracking-wide font-medium bg-muted text-muted-foreground">
+            {page.kind}
+          </span>
+          {page.stale && (
+            <span className="text-[10px] px-2 py-0.5 rounded uppercase tracking-wide font-medium bg-orange-500/10 text-orange-700 dark:text-orange-400 inline-flex items-center gap-1">
+              <AlertTriangle className="size-3" />
+              Stale
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-4 text-xs text-muted-foreground font-mono">
+          <span>{page.slug}</span>
+          <span>·</span>
+          <span>
+            {page.source_count} source
+            {page.source_count === 1 ? "" : "s"}
+          </span>
+          {page.last_synthesis_at && (
+            <>
+              <span>·</span>
+              <span className="inline-flex items-center gap-1">
+                <Clock className="size-3" />
+                synthesized {relativeTime(page.last_synthesis_at)}
+              </span>
+            </>
+          )}
+        </div>
+      </header>
+
+      {/* Compiled truth */}
+      <section className="rounded-xl border bg-card p-6">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-3">
+          Compiled truth
+        </h2>
+        {page.compiled_truth ? (
+          <p className="text-base leading-relaxed whitespace-pre-wrap">
+            {page.compiled_truth}
+          </p>
+        ) : (
+          <p className="text-sm text-muted-foreground italic">
+            No synthesis yet — the synthesis pipeline runs after at least
+            one source links to this page.
+          </p>
+        )}
+      </section>
+
+      {/* Sources panel */}
+      {sourceLinks.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Sources
+          </h2>
+          <div className="space-y-4">
+            {Object.entries(sourcesByDomain).map(([domain, links]) => {
+              const Icon = SOURCE_ICONS[domain] ?? FileText;
+              const color = SOURCE_COLORS[domain] ?? "text-muted-foreground";
+              return (
+                <div key={domain} className="space-y-1.5">
+                  <div className={cn("text-xs font-medium inline-flex items-center gap-1.5", color)}>
+                    <Icon className="size-3.5" />
+                    {domain} ({links.length})
+                  </div>
+                  <ul className="space-y-1 pl-5">
+                    {links.map((l) => (
+                      <li
+                        key={l.id}
+                        className="text-sm font-mono text-muted-foreground"
+                      >
+                        {l.source_ref}
+                        {l.confidence != null && (
+                          <span className="ml-2 text-[10px] opacity-60">
+                            ({Math.round(l.confidence * 100)}%)
+                          </span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {/* Related pages (outgoing graph edges) */}
+      {outgoingPageLinks.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground inline-flex items-center gap-1.5">
+            <Link2 className="size-3.5" />
+            Related pages
+          </h2>
+          <ul className="space-y-1">
+            {outgoingPageLinks.map((l) => (
+              <li key={l.id}>
+                <Link
+                  href={`/wiki/${l.to_page_slug}`}
+                  className="text-sm hover:underline inline-flex items-center gap-2"
+                >
+                  <span>{l.to_page_title}</span>
+                  <span className="text-xs text-muted-foreground">
+                    ({l.link_type})
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* Backlinks */}
+      {page.backlinks.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Linked from
+          </h2>
+          <ul className="space-y-1">
+            {page.backlinks.map((l) => (
+              <li key={l.id}>
+                <Link
+                  href={`/wiki/${l.to_page_slug}`}
+                  className="text-sm hover:underline inline-flex items-center gap-2"
+                >
+                  <span>← {l.to_page_title}</span>
+                  <span className="text-xs text-muted-foreground">
+                    ({l.link_type})
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </article>
+  );
+}

--- a/apps/web/src/app/(dashboard)/wiki/page.tsx
+++ b/apps/web/src/app/(dashboard)/wiki/page.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useAuth } from "@clerk/nextjs";
+import { useQuery } from "@tanstack/react-query";
+import { BookOpen, FileText, Loader2, Search } from "lucide-react";
+import Link from "next/link";
+import { useDeferredValue, useState } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { apiFetch } from "@/lib/api";
+import { cn, relativeTime } from "@/lib/utils";
+
+// ---------------------------------------------------------------------------
+// Types — match backend WikiPageSummary / PageList
+// ---------------------------------------------------------------------------
+
+type WikiPageSummary = {
+  id: string;
+  slug: string;
+  title: string;
+  kind: string;
+  source_count: number;
+  stale: boolean;
+  last_synthesis_at: string | null;
+  updated_at: string;
+};
+
+type PageList = {
+  items: WikiPageSummary[];
+  total: number;
+  page: number;
+  page_size: number;
+};
+
+const KIND_FILTERS = [
+  { value: "", label: "All" },
+  { value: "entity", label: "Entities" },
+  { value: "concept", label: "Concepts" },
+  { value: "synthesis", label: "Syntheses" },
+] as const;
+
+const KIND_COLORS: Record<string, string> = {
+  entity: "bg-blue-500/10 text-blue-700 dark:text-blue-400",
+  concept: "bg-purple-500/10 text-purple-700 dark:text-purple-400",
+  synthesis: "bg-amber-500/10 text-amber-700 dark:text-amber-400",
+};
+
+export default function WikiIndexPage() {
+  const { getToken } = useAuth();
+  const [searchQuery, setSearchQuery] = useState("");
+  const [kind, setKind] = useState<string>("");
+  const deferredQuery = useDeferredValue(searchQuery);
+
+  const { data, isLoading, isFetching } = useQuery<PageList>({
+    queryKey: ["wiki", "pages", { kind }],
+    queryFn: async () => {
+      const token = await getToken();
+      const params = new URLSearchParams({ page_size: "200" });
+      if (kind) params.set("kind", kind);
+      return apiFetch<PageList>(
+        `/api/wiki/pages?${params.toString()}`,
+        token!,
+      );
+    },
+  });
+
+  // Client-side filter on title/slug — server-side text search comes after
+  // the synthesis pipeline lands and we can index compiled_truth.
+  const filtered = (data?.items ?? []).filter((p) => {
+    if (!deferredQuery) return true;
+    const q = deferredQuery.toLowerCase();
+    return p.title.toLowerCase().includes(q) || p.slug.toLowerCase().includes(q);
+  });
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-6">
+      <header className="space-y-2">
+        <div className="flex items-center gap-2">
+          <BookOpen className="size-6 text-muted-foreground" />
+          <h1 className="text-2xl font-semibold">Wiki</h1>
+          {data && (
+            <span className="text-sm text-muted-foreground ml-2">
+              {data.total} {data.total === 1 ? "page" : "pages"}
+            </span>
+          )}
+        </div>
+        <p className="text-sm text-muted-foreground max-w-prose">
+          Synthesized knowledge across your memory, skills, sessions, and
+          vault. Pages are auto-generated as your data grows; each one
+          aggregates everything we know about one entity, project, or
+          concept.
+        </p>
+      </header>
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative flex-1 min-w-[16rem]">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+          <input
+            type="search"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Filter by title or slug…"
+            className="w-full pl-9 pr-3 py-2 text-sm rounded-lg border bg-background focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </div>
+        <div className="flex items-center gap-1 rounded-lg bg-muted/50 p-0.5">
+          {KIND_FILTERS.map((f) => (
+            <button
+              key={f.value}
+              type="button"
+              onClick={() => setKind(f.value)}
+              className={cn(
+                "px-3 py-1.5 text-xs font-medium rounded-md transition-colors",
+                kind === f.value
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+        {isFetching && !isLoading && (
+          <Loader2 className="size-4 text-muted-foreground animate-spin" />
+        )}
+      </div>
+
+      {/* List */}
+      {isLoading ? (
+        <div className="space-y-2">
+          {[...Array(5)].map((_, i) => (
+            <Skeleton key={i} className="h-20 rounded-lg" />
+          ))}
+        </div>
+      ) : filtered.length === 0 ? (
+        <EmptyState query={deferredQuery} hasAny={(data?.total ?? 0) > 0} />
+      ) : (
+        <ul className="space-y-2">
+          {filtered.map((page) => (
+            <li key={page.id}>
+              <Link
+                href={`/wiki/${page.slug}`}
+                className="block group rounded-lg border bg-card hover:border-foreground/20 hover:bg-accent/30 transition-colors"
+              >
+                <div className="p-4 flex items-start gap-4">
+                  <div className="size-10 rounded-lg bg-muted/50 flex items-center justify-center text-muted-foreground shrink-0">
+                    <FileText className="size-5" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <h3 className="font-medium group-hover:underline">
+                        {page.title}
+                      </h3>
+                      <span
+                        className={cn(
+                          "text-[10px] px-1.5 py-0.5 rounded uppercase tracking-wide font-medium",
+                          KIND_COLORS[page.kind] ?? "bg-muted text-muted-foreground",
+                        )}
+                      >
+                        {page.kind}
+                      </span>
+                      {page.stale && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded uppercase tracking-wide font-medium bg-orange-500/10 text-orange-700 dark:text-orange-400">
+                          Stale
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-xs text-muted-foreground mt-1 font-mono">
+                      {page.slug}
+                    </div>
+                  </div>
+                  <div className="text-xs text-muted-foreground text-right shrink-0 space-y-0.5">
+                    <div>
+                      {page.source_count} source
+                      {page.source_count === 1 ? "" : "s"}
+                    </div>
+                    <div>{relativeTime(page.updated_at)}</div>
+                  </div>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function EmptyState({ query, hasAny }: { query: string; hasAny: boolean }) {
+  if (query) {
+    return (
+      <div className="text-center py-16 text-muted-foreground">
+        <FileText className="size-10 mx-auto mb-3 opacity-30" />
+        <p className="text-sm">No pages matching &ldquo;{query}&rdquo;.</p>
+      </div>
+    );
+  }
+  if (hasAny) {
+    return (
+      <div className="text-center py-16 text-muted-foreground">
+        <FileText className="size-10 mx-auto mb-3 opacity-30" />
+        <p className="text-sm">No pages match the current filter.</p>
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-xl border border-dashed bg-card/50 p-10 text-center">
+      <BookOpen className="size-10 mx-auto mb-4 text-muted-foreground opacity-50" />
+      <h3 className="font-medium">Your wiki is empty.</h3>
+      <p className="text-sm text-muted-foreground mt-2 max-w-md mx-auto">
+        As your synced memory and sessions grow, Clawdi will auto-generate
+        wiki pages — one per real-world entity, project, or concept. Each
+        page aggregates evidence across all four domains.
+      </p>
+      <p className="text-xs text-muted-foreground mt-4">
+        The synthesis pipeline runs nightly. You&rsquo;ll see your first
+        pages within 24 hours of your next push.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -3,6 +3,7 @@
 import { useClerk, useUser } from "@clerk/nextjs";
 import {
 	BarChart3,
+	BookOpen,
 	Brain,
 	ChevronsUpDown,
 	CircleHelp,
@@ -60,6 +61,7 @@ import {
 
 const navItems = [
 	{ href: "/", label: "Overview", icon: LayoutDashboard },
+	{ href: "/wiki", label: "Wiki", icon: BookOpen },
 	{ href: "/sessions", label: "Sessions", icon: BarChart3 },
 	{ href: "/memories", label: "Memories", icon: Brain },
 	{ href: "/skills", label: "Skills", icon: Sparkles },

--- a/backend/alembic/versions/f0a1b2c3d4e5_add_wiki_tables.py
+++ b/backend/alembic/versions/f0a1b2c3d4e5_add_wiki_tables.py
@@ -1,0 +1,216 @@
+"""add wiki tables (pages, links, log)
+
+Revision ID: f0a1b2c3d4e5
+Revises: 672acd66fc7d
+Create Date: 2026-04-28 00:00:00.000000
+
+Adds the personal wiki layer — synthesized entity pages aggregated across
+memory, skills, sessions, and vault scopes. See app/models/wiki.py for the
+design rationale.
+
+Three tables:
+- wiki_pages: one row per canonical entity per user; stores compiled_truth
+- wiki_links: typed edges between pages or to source items (memory/skill/
+  session/vault); CHECK constraint enforces exactly one target type
+- wiki_log: chronological log of every wiki mutation for activity feed +
+  pipeline debugging
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "f0a1b2c3d4e5"
+down_revision: Union[str, Sequence[str], None] = "672acd66fc7d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "wiki_pages",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("slug", sa.String(length=200), nullable=False),
+        sa.Column("title", sa.String(length=200), nullable=False),
+        sa.Column(
+            "kind", sa.String(length=50), server_default="entity", nullable=False
+        ),
+        sa.Column("compiled_truth", sa.Text(), nullable=True),
+        sa.Column(
+            "frontmatter",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column(
+            "source_count", sa.Integer(), server_default="0", nullable=False
+        ),
+        sa.Column(
+            "last_synthesis_at", sa.DateTime(timezone=True), nullable=True
+        ),
+        sa.Column(
+            "stale", sa.Boolean(), server_default="false", nullable=False
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id", "slug", name="wiki_pages_user_slug_unique"
+        ),
+    )
+    op.create_index(
+        op.f("ix_wiki_pages_user_id"), "wiki_pages", ["user_id"], unique=False
+    )
+    # Frequent dashboard query: list pages by kind for a user.
+    op.create_index(
+        "ix_wiki_pages_user_kind",
+        "wiki_pages",
+        ["user_id", "kind"],
+        unique=False,
+    )
+    # Activity feed / "recently updated" view.
+    op.create_index(
+        "ix_wiki_pages_user_updated",
+        "wiki_pages",
+        ["user_id", sa.text("updated_at DESC")],
+        unique=False,
+    )
+
+    op.create_table(
+        "wiki_links",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("from_page_id", sa.UUID(), nullable=False),
+        sa.Column("to_page_id", sa.UUID(), nullable=True),
+        sa.Column("source_type", sa.String(length=20), nullable=True),
+        sa.Column("source_ref", sa.String(length=200), nullable=True),
+        sa.Column("link_type", sa.String(length=50), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["from_page_id"], ["wiki_pages.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["to_page_id"], ["wiki_pages.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.CheckConstraint(
+            "(to_page_id IS NOT NULL AND source_type IS NULL) OR "
+            "(to_page_id IS NULL AND source_type IS NOT NULL "
+            "AND source_ref IS NOT NULL)",
+            name="wiki_links_target_check",
+        ),
+    )
+    op.create_index(
+        op.f("ix_wiki_links_user_id"),
+        "wiki_links",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_wiki_links_from_page_id"),
+        "wiki_links",
+        ["from_page_id"],
+        unique=False,
+    )
+    # Backlinks lookup (what pages point to this page) — graph traversal.
+    op.create_index(
+        "ix_wiki_links_to_page",
+        "wiki_links",
+        ["to_page_id"],
+        unique=False,
+        postgresql_where=sa.text("to_page_id IS NOT NULL"),
+    )
+    # Reverse lookup: given an external source item (memory/skill/session/
+    # vault), find pages that reference it. Used by the synthesis job to
+    # propagate updates when a memory changes.
+    op.create_index(
+        "ix_wiki_links_source",
+        "wiki_links",
+        ["source_type", "source_ref"],
+        unique=False,
+        postgresql_where=sa.text("source_type IS NOT NULL"),
+    )
+
+    op.create_table(
+        "wiki_log",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("page_id", sa.UUID(), nullable=True),
+        sa.Column("action", sa.String(length=50), nullable=False),
+        sa.Column("source_type", sa.String(length=20), nullable=True),
+        sa.Column("source_ref", sa.String(length=200), nullable=True),
+        sa.Column(
+            "metadata",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column(
+            "ts",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["page_id"], ["wiki_pages.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_wiki_log_user_id"),
+        "wiki_log",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_wiki_log_page_id"),
+        "wiki_log",
+        ["page_id"],
+        unique=False,
+    )
+    # Activity feed query: per-user newest first.
+    op.create_index(
+        "ix_wiki_log_user_ts",
+        "wiki_log",
+        ["user_id", sa.text("ts DESC")],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_wiki_log_user_ts", table_name="wiki_log")
+    op.drop_index(op.f("ix_wiki_log_page_id"), table_name="wiki_log")
+    op.drop_index(op.f("ix_wiki_log_user_id"), table_name="wiki_log")
+    op.drop_table("wiki_log")
+
+    op.drop_index("ix_wiki_links_source", table_name="wiki_links")
+    op.drop_index("ix_wiki_links_to_page", table_name="wiki_links")
+    op.drop_index(
+        op.f("ix_wiki_links_from_page_id"), table_name="wiki_links"
+    )
+    op.drop_index(op.f("ix_wiki_links_user_id"), table_name="wiki_links")
+    op.drop_table("wiki_links")
+
+    op.drop_index("ix_wiki_pages_user_updated", table_name="wiki_pages")
+    op.drop_index("ix_wiki_pages_user_kind", table_name="wiki_pages")
+    op.drop_index(op.f("ix_wiki_pages_user_id"), table_name="wiki_pages")
+    op.drop_table("wiki_pages")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,6 +23,7 @@ from app.routes.sessions import router as sessions_router
 from app.routes.settings import router as settings_router
 from app.routes.skills import router as skills_router
 from app.routes.vault import router as vault_router
+from app.routes.wiki import router as wiki_router
 from app.services.embedding import LocalEmbedder
 
 logging.basicConfig(level=logging.INFO)
@@ -115,6 +116,7 @@ app.include_router(vault_router)
 app.include_router(connectors_router)
 app.include_router(mcp_proxy_router)
 app.include_router(search_router)
+app.include_router(wiki_router)
 
 
 @app.get("/health")

--- a/backend/app/models/wiki.py
+++ b/backend/app/models/wiki.py
@@ -1,0 +1,160 @@
+"""Personal wiki — synthesized entity pages aggregated across memory, skills,
+sessions, and vault.
+
+The wiki layer sits ON TOP of the four atomic stores. It does not replace
+them. Each entity that recurs across the user's data gets one wiki page
+with a Compiled-Truth synthesis (LLM-rewritable summary) and a Timeline
+(append-only evidence). Pages link back to source items — never copy them.
+
+Design notes:
+- Pages are user-scoped (multi-tenant). Slugs are unique per user, not globally.
+- Compiled truth is regenerated incrementally on new evidence; timeline is
+  append-only.
+- Vault keys are linked by NAME ONLY. Values are NEVER copied into pages
+  or compiled_truth. The synthesis pipeline runs through a sanitizer.
+- Source links can point to another wiki page (graph edge) or to an
+  external item (memory uuid / skill_key / session uuid / vault scope).
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class WikiPage(Base, TimestampMixin):
+    __tablename__ = "wiki_pages"
+    __table_args__ = (
+        UniqueConstraint("user_id", "slug", name="wiki_pages_user_slug_unique"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False, index=True
+    )
+    # Lowercase canonical slug, e.g. "polymarket", "twilio-voice-agent".
+    # Resolver maps "Polymarket" / "poly market" / "PolyMarket" → same slug.
+    slug: Mapped[str] = mapped_column(String(200), nullable=False)
+    # Display title with original casing, e.g. "Polymarket".
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    # entity (default) — concrete thing: a tool, project, person, service.
+    # concept — abstract topic that aggregates across entities.
+    # synthesis — meta-page summarizing a query result that's worth keeping.
+    kind: Mapped[str] = mapped_column(String(50), server_default="entity")
+    # LLM-synthesized 1–2 paragraph "what we know" snapshot. Rewritable.
+    # NEVER contains vault values — sanitizer enforces this.
+    compiled_truth: Mapped[str | None] = mapped_column(Text)
+    # Typed metadata: {aliases: ["Polymarket", "poly"], confidence: 0.9, ...}
+    frontmatter: Mapped[dict | None] = mapped_column(JSONB)
+    # Number of unique source items this page aggregates (memories + skills
+    # + sessions + vault scopes). Derived; updated on link insert/delete.
+    source_count: Mapped[int] = mapped_column(Integer, server_default="0")
+    # When compiled_truth was last regenerated. Used to skip work in the
+    # synthesis job if no new evidence has arrived since.
+    last_synthesis_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # Marked when sources are removed, contradictions are flagged, or no
+    # new evidence in N months. Surfaced in the dashboard as a stale badge.
+    stale: Mapped[bool] = mapped_column(Boolean, server_default="false")
+
+
+class WikiLink(Base):
+    """Edge: from a page to either another page (graph) or a source item.
+
+    Exactly one of {to_page_id, (source_type, source_ref)} must be set.
+    """
+
+    __tablename__ = "wiki_links"
+    __table_args__ = (
+        CheckConstraint(
+            "(to_page_id IS NOT NULL AND source_type IS NULL) OR "
+            "(to_page_id IS NULL AND source_type IS NOT NULL "
+            "AND source_ref IS NOT NULL)",
+            name="wiki_links_target_check",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False, index=True
+    )
+    from_page_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("wiki_pages.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # Edge to another page (graph traversal).
+    to_page_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("wiki_pages.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    # Edge to an external source item.
+    # source_type ∈ {memory, skill, session, vault}.
+    # source_ref: memory.id (uuid), skill.skill_key, session.id (uuid),
+    #             vault scope slug.
+    source_type: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    source_ref: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    # Typed link semantics: mentions, uses, references, related_to,
+    # contradicts, supersedes.
+    link_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    # Confidence of the extraction (0..1). Low-confidence links surface
+    # in the HITL queue rather than auto-applying.
+    confidence: Mapped[float | None] = mapped_column(Float, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+
+
+class WikiLogEntry(Base):
+    """Chronological log — every action that touched a page.
+
+    Equivalent to llm_wiki's log.md / gbrain's timeline. Used to show
+    activity in the dashboard and for debugging the synthesis pipeline.
+    """
+
+    __tablename__ = "wiki_log"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False, index=True
+    )
+    page_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("wiki_pages.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    # action ∈ {created, synthesized, merged, flagged_stale, link_added,
+    #           link_removed, contradicted, deleted}
+    action: Mapped[str] = mapped_column(String(50), nullable=False)
+    # Trigger source: 'memory' / 'session' / 'manual' / 'cron' / 'extraction'
+    source_type: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    source_ref: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    # Free-form metadata: {model: "claude-haiku-4-5", input_tokens: 234, ...}
+    metadata_: Mapped[dict | None] = mapped_column("metadata", JSONB)
+    ts: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )

--- a/backend/app/routes/wiki.py
+++ b/backend/app/routes/wiki.py
@@ -1,0 +1,330 @@
+"""Personal wiki — read-only API.
+
+Three endpoints today:
+- GET /api/wiki/pages          → paginated list of pages (filter by kind)
+- GET /api/wiki/pages/{slug}   → one page + its backlinks + outgoing links
+- GET /api/wiki/log            → chronological activity feed
+
+Write-side endpoints (page creation, evidence linking, manual stale flag)
+land alongside the entity extraction pipeline. For now, these read-only
+endpoints serve the dashboard MVP — the dashboard renders correctly with
+an empty wiki, then lights up as the pipeline starts producing pages.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import AuthContext, get_auth
+from app.core.database import get_session
+from app.models.wiki import WikiLink, WikiLogEntry, WikiPage
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/wiki", tags=["wiki"])
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+
+class WikiPageSummary(BaseModel):
+    id: uuid.UUID
+    slug: str
+    title: str
+    kind: str
+    source_count: int
+    stale: bool
+    last_synthesis_at: datetime | None
+    updated_at: datetime
+
+
+class WikiLinkOut(BaseModel):
+    """Outgoing or incoming edge from/to a page."""
+
+    id: uuid.UUID
+    link_type: str
+    confidence: float | None
+    # Exactly one of (to_page_*) or (source_*) is populated.
+    to_page_id: uuid.UUID | None
+    to_page_slug: str | None
+    to_page_title: str | None
+    source_type: str | None
+    source_ref: str | None
+
+
+class WikiPageDetail(BaseModel):
+    id: uuid.UUID
+    slug: str
+    title: str
+    kind: str
+    compiled_truth: str | None
+    frontmatter: dict | None
+    source_count: int
+    stale: bool
+    last_synthesis_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+    outgoing_links: list[WikiLinkOut]
+    backlinks: list[WikiLinkOut]
+
+
+class WikiLogOut(BaseModel):
+    id: uuid.UUID
+    page_id: uuid.UUID | None
+    page_slug: str | None
+    action: str
+    source_type: str | None
+    source_ref: str | None
+    metadata: dict | None
+    ts: datetime
+
+
+class PageList(BaseModel):
+    items: list[WikiPageSummary]
+    total: int
+    page: int
+    page_size: int
+
+
+class LogList(BaseModel):
+    items: list[WikiLogOut]
+    total: int
+    page: int
+    page_size: int
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.get("/pages", response_model=PageList)
+async def list_pages(
+    auth: AuthContext = Depends(get_auth),
+    db: AsyncSession = Depends(get_session),
+    kind: Literal["entity", "concept", "synthesis"] | None = Query(default=None),
+    stale: bool | None = Query(
+        default=None, description="Filter by stale flag. Omit to include both."
+    ),
+    sort: Literal["updated_at", "title", "source_count"] = Query(
+        default="updated_at"
+    ),
+    order: Literal["asc", "desc"] = Query(default="desc"),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=50, ge=1, le=200),
+) -> PageList:
+    """List wiki pages for the current user, paginated.
+
+    Default ordering shows most-recently-updated first, matching dashboard
+    expectations for an "activity" view.
+    """
+    base_filters = [WikiPage.user_id == auth.user_id]
+    if kind is not None:
+        base_filters.append(WikiPage.kind == kind)
+    if stale is not None:
+        base_filters.append(WikiPage.stale == stale)
+
+    sort_col = {
+        "updated_at": WikiPage.updated_at,
+        "title": WikiPage.title,
+        "source_count": WikiPage.source_count,
+    }[sort]
+    sort_clause = sort_col.desc() if order == "desc" else sort_col.asc()
+
+    total = (
+        await db.scalar(select(func.count(WikiPage.id)).where(*base_filters))
+    ) or 0
+
+    rows = (
+        await db.execute(
+            select(WikiPage)
+            .where(*base_filters)
+            .order_by(sort_clause)
+            .limit(page_size)
+            .offset((page - 1) * page_size)
+        )
+    ).scalars().all()
+
+    return PageList(
+        items=[
+            WikiPageSummary(
+                id=p.id,
+                slug=p.slug,
+                title=p.title,
+                kind=p.kind,
+                source_count=p.source_count,
+                stale=p.stale,
+                last_synthesis_at=p.last_synthesis_at,
+                updated_at=p.updated_at,
+            )
+            for p in rows
+        ],
+        total=int(total),
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get("/pages/{slug}", response_model=WikiPageDetail)
+async def get_page(
+    slug: str,
+    auth: AuthContext = Depends(get_auth),
+    db: AsyncSession = Depends(get_session),
+) -> WikiPageDetail:
+    """Fetch one page, its outgoing links, and its backlinks."""
+    page = (
+        await db.execute(
+            select(WikiPage).where(
+                WikiPage.user_id == auth.user_id,
+                WikiPage.slug == slug,
+            )
+        )
+    ).scalar_one_or_none()
+    if page is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Wiki page not found: {slug}",
+        )
+
+    # Outgoing edges from this page. If the edge points to another page,
+    # join to fetch its slug/title for display.
+    outgoing_rows = (
+        await db.execute(
+            select(WikiLink, WikiPage.slug, WikiPage.title)
+            .outerjoin(
+                WikiPage,
+                WikiPage.id == WikiLink.to_page_id,
+            )
+            .where(
+                WikiLink.user_id == auth.user_id,
+                WikiLink.from_page_id == page.id,
+            )
+        )
+    ).all()
+
+    outgoing = [
+        WikiLinkOut(
+            id=link.id,
+            link_type=link.link_type,
+            confidence=link.confidence,
+            to_page_id=link.to_page_id,
+            to_page_slug=to_slug,
+            to_page_title=to_title,
+            source_type=link.source_type,
+            source_ref=link.source_ref,
+        )
+        for link, to_slug, to_title in outgoing_rows
+    ]
+
+    # Incoming edges (backlinks) — only from-page-to-page edges. We don't
+    # display "memory X mentions this page" as a backlink because that's
+    # captured by the source_count + outgoing_links from the source side.
+    backlink_rows = (
+        await db.execute(
+            select(WikiLink, WikiPage.slug, WikiPage.title)
+            .join(WikiPage, WikiPage.id == WikiLink.from_page_id)
+            .where(
+                WikiLink.user_id == auth.user_id,
+                WikiLink.to_page_id == page.id,
+            )
+        )
+    ).all()
+
+    backlinks = [
+        WikiLinkOut(
+            id=link.id,
+            link_type=link.link_type,
+            confidence=link.confidence,
+            # For backlinks we surface the SOURCE page (i.e. the from
+            # side) under the to_page_* fields so the UI can render
+            # "← linked from <title>" uniformly.
+            to_page_id=link.from_page_id,
+            to_page_slug=from_slug,
+            to_page_title=from_title,
+            source_type=None,
+            source_ref=None,
+        )
+        for link, from_slug, from_title in backlink_rows
+    ]
+
+    return WikiPageDetail(
+        id=page.id,
+        slug=page.slug,
+        title=page.title,
+        kind=page.kind,
+        compiled_truth=page.compiled_truth,
+        frontmatter=page.frontmatter,
+        source_count=page.source_count,
+        stale=page.stale,
+        last_synthesis_at=page.last_synthesis_at,
+        created_at=page.created_at,
+        updated_at=page.updated_at,
+        outgoing_links=outgoing,
+        backlinks=backlinks,
+    )
+
+
+@router.get("/log", response_model=LogList)
+async def list_log(
+    auth: AuthContext = Depends(get_auth),
+    db: AsyncSession = Depends(get_session),
+    page_id: uuid.UUID | None = Query(
+        default=None, description="Filter to events on a single page."
+    ),
+    action: str | None = Query(
+        default=None,
+        description="Filter to a specific action, e.g. 'synthesized', 'flagged_stale'.",
+    ),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=50, ge=1, le=200),
+) -> LogList:
+    """Chronological wiki activity feed for the current user."""
+    filters = [WikiLogEntry.user_id == auth.user_id]
+    if page_id is not None:
+        filters.append(WikiLogEntry.page_id == page_id)
+    if action is not None:
+        filters.append(WikiLogEntry.action == action)
+
+    total = (
+        await db.scalar(select(func.count(WikiLogEntry.id)).where(*filters))
+    ) or 0
+
+    rows = (
+        await db.execute(
+            select(WikiLogEntry, WikiPage.slug)
+            .outerjoin(WikiPage, WikiPage.id == WikiLogEntry.page_id)
+            .where(*filters)
+            .order_by(WikiLogEntry.ts.desc())
+            .limit(page_size)
+            .offset((page - 1) * page_size)
+        )
+    ).all()
+
+    return LogList(
+        items=[
+            WikiLogOut(
+                id=entry.id,
+                page_id=entry.page_id,
+                page_slug=page_slug,
+                action=entry.action,
+                source_type=entry.source_type,
+                source_ref=entry.source_ref,
+                metadata=entry.metadata_,
+                ts=entry.ts,
+            )
+            for entry, page_slug in rows
+        ],
+        total=int(total),
+        page=page,
+        page_size=page_size,
+    )

--- a/backend/app/services/slug_resolver.py
+++ b/backend/app/services/slug_resolver.py
@@ -1,0 +1,138 @@
+"""Slug resolver — canonicalize entity names → wiki page slugs.
+
+Same real-world entity reaches the wiki under many spellings:
+  "Polymarket" / "polymarket" / "poly market" / "poly-market" / "PolyMarket"
+All five must map to one canonical slug ("polymarket"). Otherwise we
+get duplicate pages and the dashboard fragments.
+
+Two-stage resolution:
+
+1. **Normalize** (pure function): lowercase, whitespace/underscore →
+   hyphen, drop non-alphanumeric, collapse repeated hyphens. Cheap and
+   deterministic — covers 80% of variants.
+
+2. **Fuzzy match** (DB-bound): if normalized form doesn't already exist
+   for this user, search existing user slugs via pg_trgm similarity.
+   If a near-match is found above threshold, return that existing slug
+   instead of creating a new page. Catches typos and edit-distance
+   variants the normalizer misses (e.g. "polymrket" → "polymarket").
+
+Returns `(slug, exists)`. Caller decides whether to insert a new
+WikiPage or attach evidence to the existing one.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.wiki import WikiPage
+
+
+# pg_trgm similarity score required to consider a fuzzy match an alias
+# of an existing page rather than a new page. Tuned conservatively —
+# we'd rather create one extra page than silently merge unrelated
+# entities. The synthesis pipeline can propose merges later.
+DEFAULT_SIMILARITY_THRESHOLD = 0.6
+
+# Max slug length matches the wiki_pages.slug column (200). Names longer
+# than this get truncated; the original is preserved in title.
+MAX_SLUG_LENGTH = 200
+
+
+def normalize(name: str) -> str:
+    """Deterministic name → slug. Pure function, no DB.
+
+    Examples:
+        "Polymarket"        → "polymarket"
+        "Poly Market"       → "poly-market"
+        "POLY_MARKET"       → "poly-market"
+        "poly--market"      → "poly-market"
+        "Poly's Market!"    → "polys-market"
+        "  spaced  "        → "spaced"
+        ""                  → ""
+    """
+    if not name:
+        return ""
+    s = name.lower().strip()
+    # Whitespace and underscores → hyphen.
+    s = re.sub(r"[\s_]+", "-", s)
+    # Drop anything that's not alphanumeric or hyphen.
+    s = re.sub(r"[^a-z0-9-]", "", s)
+    # Collapse runs of hyphens.
+    s = re.sub(r"-+", "-", s)
+    s = s.strip("-")
+    if len(s) > MAX_SLUG_LENGTH:
+        s = s[:MAX_SLUG_LENGTH].rstrip("-")
+    return s
+
+
+class SlugResolver:
+    """User-scoped slug resolution against existing wiki pages.
+
+    Construct once per request (or extraction batch) for a given user,
+    then call `resolve` for each entity name encountered.
+    """
+
+    def __init__(
+        self,
+        db: AsyncSession,
+        user_id: uuid.UUID,
+        similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+    ) -> None:
+        self.db = db
+        self.user_id = user_id
+        self.similarity_threshold = similarity_threshold
+
+    async def resolve(self, name: str) -> tuple[str, bool]:
+        """Resolve an entity name → (canonical_slug, exists_already).
+
+        - exists_already=True means a wiki_pages row already exists for
+          this user with that slug (exact or fuzzy match). Caller should
+          attach evidence to that page.
+        - exists_already=False means caller should insert a new page
+          using the returned slug.
+
+        Raises ValueError if the name normalizes to empty.
+        """
+        candidate = normalize(name)
+        if not candidate:
+            raise ValueError(f"Cannot derive slug from name: {name!r}")
+
+        # Exact match: cheapest path.
+        existing = await self.db.scalar(
+            select(WikiPage.slug).where(
+                WikiPage.user_id == self.user_id,
+                WikiPage.slug == candidate,
+            )
+        )
+        if existing:
+            return existing, True
+
+        # Fuzzy match via pg_trgm. Requires the pg_trgm extension —
+        # already installed for the memories table.
+        result = await self.db.execute(
+            text(
+                """
+                SELECT slug, similarity(slug, :candidate) AS score
+                FROM wiki_pages
+                WHERE user_id = :user_id
+                  AND similarity(slug, :candidate) > :threshold
+                ORDER BY score DESC
+                LIMIT 1
+                """
+            ),
+            {
+                "candidate": candidate,
+                "user_id": self.user_id,
+                "threshold": self.similarity_threshold,
+            },
+        )
+        row = result.first()
+        if row is not None:
+            return row.slug, True
+
+        return candidate, False

--- a/backend/app/services/wiki_sanitizer.py
+++ b/backend/app/services/wiki_sanitizer.py
@@ -1,0 +1,86 @@
+"""Wiki output sanitizer — defense-in-depth against vault value leakage.
+
+The wiki synthesis pipeline reads memory, skills, sessions, and vault
+*scopes/names* (never values). But because LLMs can emit anything, every
+piece of wiki-bound text passes through this sanitizer before being
+written to wiki_pages.compiled_truth or wiki_links.
+
+Strategy:
+- Load all vault VALUES for the user once at the start of a synthesis run.
+- Scan candidate text for any value as a literal substring.
+- A short value (< MIN_LENGTH chars) is skipped to avoid false positives
+  on short tokens that naturally appear in prose. Real secret keys are
+  always longer than that.
+- check() returns the list of leaked values (for logging by length, never
+  by content). assert_clean() raises. redact() replaces inline.
+
+This is a *defensive* layer — the synthesis pipeline must also avoid
+passing vault values into the LLM in the first place. Both must hold.
+"""
+
+from __future__ import annotations
+
+
+class VaultLeakError(Exception):
+    """Raised when sanitized content still contains a vault value.
+
+    The message NEVER includes the leaked content. We log lengths and
+    counts only — including the value would defeat the purpose.
+    """
+
+
+# Vault values shorter than this are skipped during scanning.
+# Rationale: short literals like "abc" or numeric IDs would match too much
+# prose and produce false positives. Real secrets (API keys, JWTs, OAuth
+# tokens) are universally longer than 12 chars; the median is 32+.
+MIN_LENGTH = 12
+
+
+class WikiSanitizer:
+    """Catches vault values that have leaked into wiki-bound text.
+
+    Construct once per synthesis run with the user's full set of vault
+    values, then call check / assert_clean / redact on each LLM output
+    before persisting.
+    """
+
+    def __init__(self, vault_values: set[str] | list[str]) -> None:
+        self._values: set[str] = {v for v in vault_values if len(v) >= MIN_LENGTH}
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def check(self, text: str) -> list[str]:
+        """Return the list of vault values found in `text`. Empty if clean.
+
+        Caller must NOT log or surface the returned values directly. Use
+        for length/count metrics only, or pass to assert_clean / redact.
+        """
+        if not text or not self._values:
+            return []
+        return [v for v in self._values if v in text]
+
+    def assert_clean(self, text: str, context: str = "") -> None:
+        """Raise VaultLeakError if `text` contains any vault value."""
+        leaks = self.check(text)
+        if leaks:
+            ctx = f" in {context}" if context else ""
+            raise VaultLeakError(
+                f"Sanitizer detected {len(leaks)} vault value leak(s){ctx}. "
+                f"Leak lengths: {sorted(len(v) for v in leaks)}."
+            )
+
+    def redact(self, text: str) -> str:
+        """Replace any vault values in `text` with [REDACTED:N] (N = length).
+
+        Use only when you must persist text that might contain a value
+        and a hard fail would be worse. Prefer assert_clean for the
+        synthesis pipeline so leaks fail loudly instead of silently
+        being scrubbed.
+        """
+        if not text:
+            return text
+        out = text
+        for v in self._values:
+            out = out.replace(v, f"[REDACTED:{len(v)}]")
+        return out

--- a/backend/scripts/test_slug_resolver.py
+++ b/backend/scripts/test_slug_resolver.py
@@ -1,0 +1,128 @@
+"""Self-test for app.services.slug_resolver.
+
+Run from backend dir:
+    uv run python scripts/test_slug_resolver.py
+
+Tests the pure `normalize` function only. The DB-aware `SlugResolver.resolve`
+is exercised end-to-end by the entity extraction job's integration tests
+once that pipeline lands.
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.services.slug_resolver import normalize  # noqa: E402
+
+
+def case(label: str, fn) -> bool:
+    try:
+        fn()
+        print(f"  PASS  {label}")
+        return True
+    except AssertionError:
+        print(f"  FAIL  {label}")
+        traceback.print_exc()
+        return False
+    except Exception as e:
+        print(f"  ERROR {label}: {type(e).__name__}: {e}")
+        traceback.print_exc()
+        return False
+
+
+def main() -> int:
+    print("# Slug resolver self-test (normalize)\n")
+    results: list[bool] = []
+
+    EXPECTED = [
+        # input → expected
+        ("Polymarket", "polymarket"),
+        ("polymarket", "polymarket"),
+        ("POLYMARKET", "polymarket"),
+        ("Poly Market", "poly-market"),
+        ("poly market", "poly-market"),
+        ("POLY_MARKET", "poly-market"),
+        ("poly-market", "poly-market"),
+        ("poly--market", "poly-market"),
+        ("Poly's Market!", "polys-market"),
+        ("  spaced  ", "spaced"),
+        ("hyphens---collapse", "hyphens-collapse"),
+        ("---leading-trailing---", "leading-trailing"),
+        ("Mix3d_C4se Stuff", "mix3d-c4se-stuff"),
+        # Realistic shapes from the user's actual data:
+        ("Twilio Voice Agent", "twilio-voice-agent"),
+        ("clawdi-backend", "clawdi-backend"),
+        ("Hermes + OpenClaw", "hermes-openclaw"),
+        ("phala-metrics-analyser-redpill-api", "phala-metrics-analyser-redpill-api"),
+        # Edge cases:
+        ("", ""),
+        ("   ", ""),
+        ("!!!", ""),
+        ("---", ""),
+        ("a", "a"),  # single char preserved
+    ]
+
+    def deterministic_mapping():
+        for raw, expected in EXPECTED:
+            got = normalize(raw)
+            assert got == expected, (
+                f"normalize({raw!r}) → {got!r}, expected {expected!r}"
+            )
+
+    def idempotent():
+        # normalize(normalize(x)) == normalize(x) for all inputs
+        for raw, _ in EXPECTED:
+            once = normalize(raw)
+            twice = normalize(once)
+            assert once == twice, (
+                f"not idempotent: {raw!r} → {once!r} → {twice!r}"
+            )
+
+    def case_only_aliases_collapse_to_same_slug():
+        # Pure normalize handles only case/whitespace/punct-only variants.
+        # Cross-word-boundary aliases ("Poly Market" vs "Polymarket") are
+        # the DB-fuzzy-match's responsibility, tested via pg_trgm at
+        # SlugResolver.resolve integration time.
+        aliases = ["Polymarket", "polymarket", "POLYMARKET", "Polymarket  "]
+        slugs = {normalize(a) for a in aliases}
+        assert slugs == {"polymarket"}, f"case-only aliases produced {slugs}"
+
+    def whitespace_aliases_collapse_to_same_slug():
+        aliases = ["Poly Market", "Poly  Market", "POLY_MARKET", "poly-market", "poly--market"]
+        slugs = {normalize(a) for a in aliases}
+        assert slugs == {"poly-market"}, f"whitespace aliases produced {slugs}"
+
+    def long_input_truncated():
+        long_name = "a" * 250
+        out = normalize(long_name)
+        assert len(out) <= 200, f"length {len(out)} exceeds MAX_SLUG_LENGTH=200"
+
+    cases = [
+        ("normalize: deterministic mapping (22 cases)", deterministic_mapping),
+        ("normalize: idempotent", idempotent),
+        (
+            "normalize: case-only aliases collapse to one slug",
+            case_only_aliases_collapse_to_same_slug,
+        ),
+        (
+            "normalize: whitespace/underscore aliases collapse to one slug",
+            whitespace_aliases_collapse_to_same_slug,
+        ),
+        ("normalize: input over 200 chars is truncated", long_input_truncated),
+    ]
+
+    for label, fn in cases:
+        results.append(case(label, fn))
+
+    n_pass = sum(results)
+    n_total = len(results)
+    print(f"\n{n_pass}/{n_total} passed")
+    return 0 if n_pass == n_total else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/test_wiki_sanitizer.py
+++ b/backend/scripts/test_wiki_sanitizer.py
@@ -1,0 +1,228 @@
+"""Self-test for app.services.wiki_sanitizer.
+
+Run from backend dir:
+    uv run python scripts/test_wiki_sanitizer.py
+
+Exits non-zero on any assertion failure. Intended for CI: import as a
+module, run via pytest later, or invoke directly today.
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+from pathlib import Path
+
+# Allow running this script directly (uv run python scripts/...) without
+# installing the backend as a package. Once the project is set up with a
+# proper test runner (pytest), this can go away.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.services.wiki_sanitizer import (  # noqa: E402
+    MIN_LENGTH,
+    VaultLeakError,
+    WikiSanitizer,
+)
+
+
+def case(label: str, fn) -> bool:
+    """Run a single test case, print PASS/FAIL, return success bool."""
+    try:
+        fn()
+        print(f"  PASS  {label}")
+        return True
+    except AssertionError as e:
+        print(f"  FAIL  {label}")
+        traceback.print_exc()
+        return False
+    except Exception as e:
+        print(f"  ERROR {label}: {type(e).__name__}: {e}")
+        traceback.print_exc()
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Sentinel values for the test corpus.
+#
+# Carefully chosen so that:
+#   1. Each is >= MIN_LENGTH chars to exercise the length threshold.
+#   2. None matches GitHub secret-scanning regexes (no `sk_live_`,
+#      `sk-ant-`, `eyJhbG…`, `xoxb-`, etc. prefixes).
+#   3. The realistic-test cases later use a clearly synthetic shape that
+#      still demonstrates "long opaque token containing a value the
+#      sanitizer must catch".
+# ---------------------------------------------------------------------------
+
+# Synthetic strings only — these are intentionally NOT shaped like any
+# real secret so the secret scanner won't flag the file.
+STRIPE_LIKE = "TESTSENTINEL-STRIPE-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+ANTHROPIC_LIKE = "TESTSENTINEL-ANTHROPIC-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+OPENAI_LIKE = "TESTSENTINEL-OPENAI-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
+GENERIC_TOKEN = "TESTSENTINEL-GENERIC-DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"
+
+ALL_SECRETS = {STRIPE_LIKE, ANTHROPIC_LIKE, OPENAI_LIKE, GENERIC_TOKEN}
+
+# Sentinel short values that should be IGNORED (below MIN_LENGTH).
+SHORT_VALUE = "abc123"  # 6 chars, below threshold
+
+
+def main() -> int:
+    print(f"# Wiki sanitizer self-test (MIN_LENGTH={MIN_LENGTH})\n")
+    results: list[bool] = []
+
+    # ---- check() ----
+
+    def check_clean_returns_empty():
+        s = WikiSanitizer(ALL_SECRETS)
+        clean = "Marvin uses Stripe with a live key configured in vault scope clawdi-backend."
+        assert s.check(clean) == [], "clean text should return []"
+
+    def check_finds_single_leak():
+        s = WikiSanitizer(ALL_SECRETS)
+        leaky = f"Use the key {STRIPE_LIKE} for charges."
+        leaks = s.check(leaky)
+        assert len(leaks) == 1, f"expected 1 leak, got {len(leaks)}"
+        assert STRIPE_LIKE in leaks
+
+    def check_finds_multiple_leaks():
+        s = WikiSanitizer(ALL_SECRETS)
+        leaky = f"stripe={STRIPE_LIKE} anthropic={ANTHROPIC_LIKE} openai={OPENAI_LIKE}"
+        leaks = s.check(leaky)
+        assert len(leaks) == 3, f"expected 3 leaks, got {len(leaks)}"
+
+    def check_handles_empty_text():
+        s = WikiSanitizer(ALL_SECRETS)
+        assert s.check("") == []
+        assert s.check(None) == []  # type: ignore[arg-type]
+
+    def check_handles_empty_vault():
+        s = WikiSanitizer(set())
+        assert s.check(f"This contains {STRIPE_LIKE}") == []
+        assert len(s) == 0
+
+    # ---- MIN_LENGTH threshold ----
+
+    def short_values_skipped():
+        s = WikiSanitizer({SHORT_VALUE, STRIPE_LIKE})
+        # short_value should NOT be tracked
+        assert len(s) == 1, f"expected 1 tracked value, got {len(s)}"
+        # text containing only short_value should be clean
+        assert s.check(f"some prose {SHORT_VALUE} more prose") == []
+        # text containing the long secret should leak
+        assert STRIPE_LIKE in s.check(f"key={STRIPE_LIKE}")
+
+    # ---- assert_clean() ----
+
+    def assert_clean_passes_clean_text():
+        s = WikiSanitizer(ALL_SECRETS)
+        s.assert_clean("Marvin works at Phala Network on Clawdi.")  # no raise
+
+    def assert_clean_raises_on_leak():
+        s = WikiSanitizer(ALL_SECRETS)
+        try:
+            s.assert_clean(f"key={STRIPE_LIKE}", context="compiled_truth")
+            raise AssertionError("expected VaultLeakError, got nothing")
+        except VaultLeakError as e:
+            msg = str(e)
+            # Error message must NOT include the leaked value.
+            assert STRIPE_LIKE not in msg, (
+                f"VaultLeakError message leaked the value: {msg}"
+            )
+            # Should mention the context.
+            assert "compiled_truth" in msg
+
+    def assert_clean_message_does_not_contain_secret():
+        s = WikiSanitizer(ALL_SECRETS)
+        try:
+            s.assert_clean(f"a={STRIPE_LIKE} b={ANTHROPIC_LIKE}")
+            raise AssertionError("expected VaultLeakError")
+        except VaultLeakError as e:
+            msg = str(e)
+            # Hard rule: error never contains secret content.
+            for v in (STRIPE_LIKE, ANTHROPIC_LIKE, OPENAI_LIKE, GENERIC_TOKEN):
+                assert v not in msg, f"error message leaked {v[:8]}…"
+
+    # ---- redact() ----
+
+    def redact_replaces_with_marker():
+        s = WikiSanitizer(ALL_SECRETS)
+        out = s.redact(f"Use key {STRIPE_LIKE} carefully.")
+        assert STRIPE_LIKE not in out
+        assert "[REDACTED:" in out
+
+    def redact_includes_length():
+        s = WikiSanitizer(ALL_SECRETS)
+        out = s.redact(STRIPE_LIKE)
+        assert out == f"[REDACTED:{len(STRIPE_LIKE)}]"
+
+    def redact_handles_multiple():
+        s = WikiSanitizer(ALL_SECRETS)
+        out = s.redact(f"{STRIPE_LIKE} and {OPENAI_LIKE}")
+        assert STRIPE_LIKE not in out
+        assert OPENAI_LIKE not in out
+        assert out.count("[REDACTED:") == 2
+
+    def redact_handles_empty():
+        s = WikiSanitizer(ALL_SECRETS)
+        assert s.redact("") == ""
+
+    # ---- realistic compiled_truth scenarios ----
+
+    def realistic_compiled_truth_safe():
+        """Simulated good output: mentions vault scope NAMES only."""
+        s = WikiSanitizer(ALL_SECRETS)
+        synthesized = (
+            "Marvin's Stripe integration uses a live restricted key configured "
+            "in vault scope `clawdi-backend` (`STRIPE_LIKE_KEY`). The "
+            "`research/polymarket` skill provides prediction-market data."
+        )
+        s.assert_clean(synthesized, context="compiled_truth")
+
+    def realistic_compiled_truth_unsafe():
+        """Simulated bad output: LLM hallucinated and inlined the value."""
+        s = WikiSanitizer(ALL_SECRETS)
+        synthesized = (
+            f"Marvin's Stripe live key is {STRIPE_LIKE}, used to charge "
+            "subscriptions for the Clawdi Max product."
+        )
+        try:
+            s.assert_clean(synthesized, context="compiled_truth")
+            raise AssertionError("expected VaultLeakError on bad output")
+        except VaultLeakError:
+            pass  # Good — this is exactly what should fail.
+
+    cases = [
+        ("check: clean text returns []", check_clean_returns_empty),
+        ("check: finds single leak", check_finds_single_leak),
+        ("check: finds multiple leaks", check_finds_multiple_leaks),
+        ("check: handles empty text/None", check_handles_empty_text),
+        ("check: handles empty vault", check_handles_empty_vault),
+        ("MIN_LENGTH: short values skipped", short_values_skipped),
+        ("assert_clean: passes clean text", assert_clean_passes_clean_text),
+        ("assert_clean: raises on leak", assert_clean_raises_on_leak),
+        (
+            "assert_clean: error message never contains the secret",
+            assert_clean_message_does_not_contain_secret,
+        ),
+        ("redact: replaces with [REDACTED:N]", redact_replaces_with_marker),
+        ("redact: marker includes length", redact_includes_length),
+        ("redact: handles multiple values", redact_handles_multiple),
+        ("redact: handles empty input", redact_handles_empty),
+        ("realistic: clean compiled_truth passes", realistic_compiled_truth_safe),
+        (
+            "realistic: leaky compiled_truth fails (this is the regression test)",
+            realistic_compiled_truth_unsafe,
+        ),
+    ]
+
+    for label, fn in cases:
+        results.append(case(label, fn))
+
+    n_pass = sum(results)
+    n_total = len(results)
+    print(f"\n{n_pass}/{n_total} passed")
+    return 0 if n_pass == n_total else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The read-side of the personal wiki — synthesizes the user's memory, skills, sessions, and vault into navigable entity pages, one per real-world thing. The extraction + synthesis pipeline (LLM-bound, biggest piece) lands in a follow-up PR; this PR ships the schema, safety guardrails, API, and dashboard so everything is ready to render the moment the pipeline produces data.

Empty wiki today → "Polymarket" / "Twilio Voice Agent" / "Clawdi Backend" pages tomorrow.

## What's in this PR (vertical slice)

### Backend

- **Three new tables** (Alembic migration `f0a1b2c3d4e5`):
  - `wiki_pages` — user-scoped (`slug`, `title`, `kind`, `compiled_truth`, `frontmatter`, `source_count`, `last_synthesis_at`, `stale`)
  - `wiki_links` — typed edges, either page→page (graph) or page→source item (memory uuid / skill_key / session uuid / vault scope), with a CHECK constraint enforcing exactly one target type
  - `wiki_log` — chronological activity feed for dashboard + pipeline debug
  - Indexes tuned for the dashboard's frequent queries: per-user list by kind, per-user "recently updated", backlinks lookup, source-ref reverse lookup for synthesis-job propagation

- **`WikiSanitizer` service** — defense-in-depth against vault VALUE leakage into `compiled_truth`. Loads all vault values for the user, scans LLM output, raises `VaultLeakError` on any literal match (length ≥ 12 to skip false positives). 15-test self-test (`scripts/test_wiki_sanitizer.py`) including a regression test that LLM output containing a vault value fails loudly. **Error messages NEVER include the leaked content.**

- **`SlugResolver` service** — pure `normalize()` + DB-fuzzy `resolve()` using pg_trgm. Maps "Polymarket" / "polymarket" / "POLY_MARKET" / "Poly Market" to one canonical slug. 5-test self-test for the pure function; DB-bound resolve will be tested at integration time once the extraction pipeline lands.

- **3 read-only API routes**:
  - `GET /api/wiki/pages` — paginated list with `kind` and `stale` filters
  - `GET /api/wiki/pages/{slug}` — page + outgoing links + backlinks
  - `GET /api/wiki/log` — chronological activity feed

### Frontend

- New "Wiki" entry in dashboard sidebar (`BookOpen` icon)
- `/wiki` — index list with kind filter, client-side title/slug filter, loading skeletons, copy-rich empty state explaining what the pipeline will produce
- `/wiki/[slug]` — detail view rendering `compiled_truth`, sources grouped by domain (memory / skill / session / vault) with confidence indicators, related pages (graph edges), and backlinks. Stale and kind badges visible inline.

## Why this order — read-side first, write-side second

- **Schema + sanitizer + resolver land first** so the WRITE-side pipeline (in the follow-up PR) has a guarded surface to write into. Vault values must NEVER reach `compiled_truth` — the sanitizer enforces this at the `assert_clean` boundary AND the synthesis pipeline must avoid passing values to the LLM (defense-in-depth, not single-point).
- **Read API + dashboard land in this PR** so the empty state is immediately visible and the synthesis pipeline can be benchmarked end-to-end (data → page → render) the moment it lands. No "where does this data show up?" guessing.

## Test plan

- [x] Migration up/down clean against dev DB; all 3 tables + indexes verified via information_schema
- [x] Sanitizer self-test: 15/15 passing (covers `check`, `assert_clean`, `redact`, `MIN_LENGTH` threshold, error messages never leak the secret, realistic compiled_truth scenarios)
- [x] Slug resolver self-test: 5/5 passing (deterministic mapping, idempotency, alias collapsing, length truncation)
- [x] API routes registered (verified via FastAPI route inspection: `/api/wiki/log`, `/api/wiki/pages`, `/api/wiki/pages/{slug}`)
- [x] Dashboard typechecks cleanly
- [ ] End-to-end with real data (gated on the extraction pipeline PR)

## Sentinel values note

The sanitizer test uses opaque `TESTSENTINEL-*` strings rather than realistic-shaped tokens. Realistic shapes (`sk_live_*`, etc.) would have triggered GitHub secret-scanning even on FAKE values. The test still exercises the full sanitizer path.

## Spec

Marvin's harness UX + wiki workstream tracker (in the related monorepo): `docs/plans/harness-and-wiki.md`. This PR closes B1.1 / B1.3 / B1.5 / B1.6 / B1.7. B1.2 + B1.4 (extraction + synthesis) ship next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)