### PR TITLE
feat(cli+web+backend): onboarding redesign + session/skill sync overhaul

### DIFF
--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -1,11 +1,11 @@
 ---
 name: clawdi-setup
-description: "Set up Clawdi Cloud CLI for the current user. Follow these steps exactly."
+description: "Set up Clawdi Cloud CLI for the current user. Follow these steps exactly — onboarding is not done until this user's local sessions are visible in the dashboard."
 ---
 
 # Clawdi Cloud Setup
 
-Help the user connect to Clawdi Cloud. Follow these steps in order.
+Help the user connect to Clawdi Cloud. The end state of onboarding is the user's local agent sessions appearing in the Clawdi Cloud dashboard. **Do not skip Step 4. Do not declare onboarding complete before sessions have been uploaded** (or the user has explicitly chosen to skip Step 4).
 
 ## Step 1: Install CLI
 
@@ -13,76 +13,172 @@ Help the user connect to Clawdi Cloud. Follow these steps in order.
 bun add -g clawdi
 ```
 
-If bun is not available, use npm:
+If bun is not available:
 
 ```bash
 npm install -g clawdi
 ```
 
-## Step 2: Log in (two steps)
+## Step 2: Log in (two phases)
 
-This is a two-step flow so the agent never blocks waiting for the user.
+This is a two-phase flow so the agent never blocks waiting on the user.
 
-**Step 2a — start the authorization:**
+**Phase 2a — start authorization:**
 
 ```bash
 clawdi auth login
 ```
 
-The command exits immediately after printing a **verification URL** and a short **user code**. **Show both to the user in chat** and ask them to:
+The command prints a **verification URL** and a short **user code**, then exits. Show both to the user in chat and ask them to:
 
 1. Open the URL.
 2. Confirm the code matches.
 3. Click approve.
-4. **Reply "done" (or anything similar) here when finished** — you need that reply before moving to Step 2b.
+4. Reply "done" here when finished — wait for that reply before Phase 2b.
 
-The CLI tries to open their browser too, but in agent/sandboxed environments that usually no-ops silently — so they need the link.
-
-**Step 2b — after the user confirms they approved:**
+**Phase 2b — after the user replies:**
 
 ```bash
 clawdi auth complete
 ```
 
-This finishes the handshake (typically in a second or two) and writes credentials to `~/.clawdi/auth.json`. The pending authorization is valid for **10 minutes** from when `clawdi auth login` was run.
+If this exits with **"Still waiting for approval"** (exit code 2), the user hasn't approved yet — ask them to finish in the browser, then re-run `clawdi auth complete`. The 10-minute window starts at Phase 2a; if it expires, restart from Phase 2a.
 
-If `clawdi auth complete` exits with **"Still waiting for approval"** (exit code 2), the user hasn't approved yet — ask them to finish approving in the browser, then re-run `clawdi auth complete`. It's safe to re-run as many times as needed within the 10-minute window. If the window expires, start over from Step 2a.
+Do **not** pass `--manual` — it requires a TTY and will fail in agent sessions.
 
-Do not use `--manual` here: that flag requires an interactive password prompt (TTY) and will fail in an agent session.
-
-## Step 3: Set up agent
+## Step 3: Register agents on this machine
 
 ```bash
 clawdi setup
 ```
 
-This will:
-- Detect installed agents (Claude Code, Codex, Hermes, OpenClaw)
-- Register the MCP server (gives you `memory_search`, `memory_add`, and connector tools)
-- Install the Clawdi skill
+This auto-detects every installed agent (Claude Code, Codex, Hermes, OpenClaw), registers each with the cloud, installs the MCP server, and drops the bundled `clawdi` skill into each agent's home. In non-interactive contexts (you), it picks all detected agents automatically. **Do not pass `--agent`** — register everything that's installed so Step 4 can sync from all of them.
 
-## Step 4: Verify
+## Step 4: Upload sessions to the dashboard (REQUIRED)
+
+This is the step that gives the user something to see in the dashboard. Do not mark setup complete before this finishes.
+
+**Ask the user once, exactly one question:**
+
+> Want me to upload your existing agent sessions to the Clawdi Cloud dashboard?
+>
+> **(a) Upload everything** from every agent on this machine — recommended, takes a minute or two.
+>
+> **(b) Show me a summary first** — I'll show how many sessions are where, and you can pick a constraint (skip a sensitive project, only upload one agent, etc.).
+>
+> **skip** — don't upload now (you can run `clawdi push` later).
+>
+> Reply "a", "b", or "skip".
+
+Wait for the reply. Branch on it:
+
+### Branch (a) — upload everything
+
+Run:
+
+```bash
+clawdi push --modules sessions --all-agents --all --yes
+```
+
+Flags:
+- `--all-agents` — iterate every registered agent (Claude Code, Codex, Hermes, OpenClaw — whichever are registered).
+- `--all` — disable the cwd project filter; scan every project's sessions. **Critical**: without this, the CLI would only scan the directory you're invoked from, which is rarely where the user's history lives.
+- `--yes` — skip the interactive confirmation (you have already confirmed with the user).
+
+Note the "Pushed N session(s)" total from the output — you'll cite it in Step 5.
+
+If it prints "0 sessions to upload", that's not necessarily an error — the user may have just installed the agent. Tell them so, then continue to Step 5.
+
+### Branch (b) — summary, then targeted push
+
+First run:
+
+```bash
+clawdi sessions list --all-agents --all --json
+```
+
+**Do not paste the raw JSON or list every session back to the user.** Most users have dozens of sessions; a flat list is noise and asking them to pick by id is more friction than just "upload all". Instead, parse the JSON yourself, group by `agent` then by `project`, count, and render a compact summary like:
+
+```
+Claude Code: 47 sessions
+  ~/work/clawdi-cloud       23
+  ~/work/client-acme        12
+  ~/personal/blog            8
+  ~/scratch                  4
+
+Codex: 12 sessions
+  ~/work/clawdi-cloud        7
+  ~/work/client-acme         5
+
+59 sessions total. Upload everything (recommended), or restrict by agent / project / time?
+```
+
+In your message, **explicitly recommend "upload everything"** — most "show me first" users don't actually need to exclude anything; they just wanted the transparency. Only branch when they name a real constraint (sensitive project, agent they don't use, recency window).
+
+Translate the user's reply by **dimension** (never by id):
+
+| user said | command |
+|---|---|
+| "all", "go", "ok", "looks good" | `clawdi push --modules sessions --all-agents --all --yes` |
+| "only Claude Code" | `clawdi push --modules sessions --agent claude_code --all --yes` |
+| "only ~/work/foo" | `clawdi push --modules sessions --all-agents --project ~/work/foo --yes` |
+| "exclude ~/scratch" | `clawdi push --modules sessions --all-agents --all --exclude-project ~/scratch --yes` |
+| "exclude ~/scratch and ~/work/acme" | `clawdi push --modules sessions --all-agents --all --exclude-project ~/scratch --exclude-project ~/work/acme --yes` |
+| "last week only" | `clawdi push --modules sessions --all-agents --all --since <ISO date 7d ago> --yes` |
+
+Resolve `~` to an absolute path before passing to the CLI. Note the "Pushed N session(s)" total from the output — you'll cite it in Step 5.
+
+### Branch — "skip"
+
+Tell the user: *"Skipped. Run `clawdi push --modules sessions --all-agents --all` whenever you want to sync."* Continue to Step 5.
+
+## Step 5: Confirm
 
 ```bash
 clawdi doctor
 ```
 
-Confirms auth, API reachability, agent installation, and MCP wiring. Resolve any failing check before continuing.
+All checks should be green. Then tell the user:
 
-## Step 5: Sync sessions (optional)
+> Open the Clawdi Cloud dashboard — you should see N sessions across {registered agents} synced from this machine.
+
+Where **N** is the total from Step 4's "Pushed N session(s)" line and **{registered agents}** is the list from Step 3.
+
+If Step 4 was the skip branch, just say all setup checks passed and remind them how to push later.
+
+## Done
+
+After setup the user has:
+- **Memory tools** (`memory_search`, `memory_add`) for cross-agent recall
+- **Connector tools** (Gmail, GitHub, Notion, etc.) — they connect services in the dashboard
+- **Session sync** — uploaded today; future sessions sync via `clawdi push`
+- **Vault** — encrypted secrets injected via `clawdi run`
+
+## Troubleshooting
+
+**Step 4 says "0 sessions" but the user has history**
+Re-run with an explicit cutoff:
 
 ```bash
-clawdi push --modules sessions
+clawdi push --modules sessions --all-agents --all --since 2020-01-01 --yes
 ```
 
-This uploads your conversation history to the Clawdi Cloud dashboard.
+This bypasses the per-agent incremental cursor in `~/.clawdi/state.json`.
 
-## Done!
+**Older CLI doesn't recognize `--all-agents`**
+Loop manually over each registered agent — Step 3's output told you which were registered:
 
-After setup, you have access to:
-- **Memory tools**: `memory_search` and `memory_add` for cross-agent recall
-- **Connector tools**: Gmail, GitHub, Notion, etc. (connect services in the dashboard)
-- **Session sync**: Upload conversations to view in the dashboard
-- **Vault**: Encrypted secrets injected via `clawdi run`
+```bash
+clawdi push --modules sessions --agent claude_code --all --yes
+clawdi push --modules sessions --agent codex --all --yes
+# etc.
+```
 
-Tell the user setup is complete and they can visit the dashboard to see their data.
+**Older CLI doesn't recognize `--exclude-project`**
+Drop that flag and tell the user: *"Your CLI is too old to skip a specific project. Either upgrade (`bun add -g clawdi` again), upload everything, or upload only one project at a time with `--project <path>`."*
+
+**Older CLI doesn't have `clawdi sessions list`**
+For Branch (b), fall back to `clawdi push --modules sessions --all-agents --all --dry-run` — it prints scan totals per agent (without per-project breakdown). Less rich, but enough to tell the user "Claude Code: N sessions, Codex: M sessions" before they confirm.
+
+**`clawdi auth complete` keeps saying "Still waiting for approval"**
+The user hasn't clicked approve in the browser yet. Re-running is safe within the 10-minute window. If the window expired, restart from Phase 2a.

--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -121,6 +121,26 @@ Resolve `~` to an absolute path before passing to the CLI.
 
 Note the "X new, Y updated, Z unchanged" total from the push output — you'll cite it next.
 
+## Sync skills (optional)
+
+If the user has authored custom skills under `~/.claude/skills/`, `~/.codex/skills/`, etc., back them up to the cloud:
+
+```bash
+clawdi push --modules skills --all-agents --yes
+```
+
+Most users have zero or a handful of authored skills — no preview needed (unlike sessions, skills are deliberately created and don't have privacy concerns). The bundled `clawdi` skill that `clawdi setup` installs is automatically excluded. Re-running this is a no-op for unchanged skills.
+
+If the user is on a new machine and already has skills in their Clawdi Cloud account, pull them down:
+
+```bash
+clawdi pull --modules skills --all-agents --yes
+```
+
+This installs cloud skills into every registered agent's home directory. Like push, it's idempotent — running again is a no-op when nothing's new.
+
+If the user has zero authored skills, both commands are no-ops. Run them anyway to confirm; the output makes it obvious.
+
 ## Verify
 
 ```bash
@@ -142,6 +162,7 @@ After this their account has:
 - **Memory** — `memory_search` and `memory_add` MCP tools for long-term cross-agent recall.
 - **Connectors** — Gmail, GitHub, Notion, etc. They enable services in the dashboard; tools appear automatically in any registered agent.
 - **Session sync** — pushed today; future sessions sync via `clawdi push`.
+- **Skill sync** — authored skills backed up to the cloud and available across registered agents via `clawdi pull --modules skills`.
 - **Vault** — encrypted secrets injected into commands via `clawdi run`.
 
 ## Troubleshooting

--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -1,184 +1,163 @@
 ---
-name: clawdi-setup
-description: "Set up Clawdi Cloud CLI for the current user. Follow these steps exactly — onboarding is not done until this user's local sessions are visible in the dashboard."
+name: clawdi-onboarding
+version: 1
+description: First-time setup walkthrough for connecting this machine to Clawdi Cloud.
+homepage: https://cloud.clawdi.ai
 ---
 
 # Clawdi Cloud Setup
 
-Help the user connect to Clawdi Cloud. The end state of onboarding is the user's local agent sessions appearing in the Clawdi Cloud dashboard. **Do not skip Step 4. Do not declare onboarding complete before sessions have been uploaded** (or the user has explicitly chosen to skip Step 4).
+You're helping the user connect this machine to Clawdi Cloud — a centralized dashboard for AI agent sessions, skills, memory, and secrets across machines.
 
-## Step 1: Install CLI
+This walkthrough takes 2-3 minutes. The end state: the user's existing session history shows up at their Clawdi Cloud dashboard. If you stop earlier, the dashboard stays empty and they assume the product is broken.
+
+## Install the CLI
 
 ```bash
 bun add -g clawdi
 ```
 
-If bun is not available:
+If `bun` isn't installed on the system, fall back to npm:
 
 ```bash
 npm install -g clawdi
 ```
 
-## Step 2: Log in (two phases)
+Verify it landed:
 
-This is a two-phase flow so the agent never blocks waiting on the user.
+```bash
+clawdi --version
+```
 
-**Phase 2a — start authorization:**
+## Authenticate
+
+The CLI hands the user a verification URL; they approve in their browser; you complete the handshake. Two phases because you can't block waiting for a browser click.
+
+Start the authorization:
 
 ```bash
 clawdi auth login
 ```
 
-The command prints a **verification URL** and a short **user code**, then exits. Show both to the user in chat and ask them to:
+This prints a verification URL and a short user code, then exits immediately. Show both to the user in chat. Tell them: open the URL, confirm the code matches, click approve, and reply when they're done.
 
-1. Open the URL.
-2. Confirm the code matches.
-3. Click approve.
-4. Reply "done" here when finished — wait for that reply before Phase 2b.
-
-**Phase 2b — after the user replies:**
+When they reply, finish the handshake:
 
 ```bash
 clawdi auth complete
 ```
 
-If this exits with **"Still waiting for approval"** (exit code 2), the user hasn't approved yet — ask them to finish in the browser, then re-run `clawdi auth complete`. The 10-minute window starts at Phase 2a; if it expires, restart from Phase 2a.
+If it prints "Still waiting for approval" (exit code 2), the user hasn't clicked approve yet. Ask them to finish in the browser, then re-run `clawdi auth complete`. The 10-minute window starts at `auth login`; if it expires, restart from there.
 
-Do **not** pass `--manual` — it requires a TTY and will fail in agent sessions.
+⚠️ Don't pass `--manual` to `auth login` — that flag wants an interactive TTY password prompt and fails in agent contexts.
 
-## Step 3: Register agents on this machine
+## Register agents on this machine
 
 ```bash
 clawdi setup
 ```
 
-This auto-detects every installed agent (Claude Code, Codex, Hermes, OpenClaw), registers each with the cloud, installs the MCP server, and drops the bundled `clawdi` skill into each agent's home. In non-interactive contexts (you), it picks all detected agents automatically. **Do not pass `--agent`** — register everything that's installed so Step 4 can sync from all of them.
+Auto-detects every installed AI agent (Claude Code, Codex, Hermes, OpenClaw), registers each with the cloud, and installs the Clawdi MCP server in each agent's home. Without an `--agent` flag it picks up everything detected — which is what you want, so the next step can sync from all of them.
 
-## Step 4: Upload sessions to the dashboard (REQUIRED)
+## Sync the user's sessions
 
-This is the step that gives the user something to see in the dashboard. Do not mark setup complete before this finishes.
+This step fills the dashboard with the user's conversation history. Don't ask them to make a decision in the abstract — show them what's actually on their machine first, then ask. Like `git status` before `git commit`.
 
-**Ask the user once, exactly one question:**
-
-> Want me to upload your existing agent sessions to the Clawdi Cloud dashboard?
->
-> **(a) Upload everything** from every agent on this machine — recommended, takes a minute or two.
->
-> **(b) Show me a summary first** — I'll show how many sessions are where, and you can pick a constraint (skip a sensitive project, only upload one agent, etc.).
->
-> **skip** — don't upload now (you can run `clawdi push` later).
->
-> Reply "a", "b", or "skip".
-
-Wait for the reply. Branch on it:
-
-### Branch (a) — upload everything
-
-Run:
+### Scan first
 
 ```bash
-clawdi push --modules sessions --all-agents --all --yes
+clawdi session list --all-agents --all --limit 10000 --json
 ```
 
-Flags:
-- `--all-agents` — iterate every registered agent (Claude Code, Codex, Hermes, OpenClaw — whichever are registered).
-- `--all` — disable the cwd project filter; scan every project's sessions. **Critical**: without this, the CLI would only scan the directory you're invoked from, which is rarely where the user's history lives.
-- `--yes` — skip the interactive confirmation (you have already confirmed with the user).
+`--limit 10000` is important — the default is 100, which would silently truncate any user with more sessions and you'd aggregate from a partial set.
 
-Note the "Pushed N session(s)" total from the output — you'll cite it in Step 5.
+If this fails (network error, no agents registered, etc.), tell the user *"I couldn't list your local sessions — going ahead with the default upload, let me know if you want to stop."* and skip to running `clawdi push --modules sessions --all-agents --all --yes`. Don't halt onboarding for this.
 
-If it prints "0 sessions to upload", that's not necessarily an error — the user may have just installed the agent. Tell them so, then continue to Step 5.
+If the JSON is empty (`[]`), tell the user *"No sessions found on this machine — nothing to sync. Run `clawdi push` later if you start using one of the supported agents."* and continue to the next step. Skip the upload entirely.
 
-### Branch (b) — summary, then targeted push
+### Show a bounded summary, then ask
 
-First run:
+Parse the JSON locally. Group by `agent`, then by `project`. Count sessions per project. Sort by count descending.
 
-```bash
-clawdi sessions list --all-agents --all --json
-```
+**Cap the displayed projects per agent at top 5.** A user with 100 active projects would otherwise produce a 100-line wall of text that buries the question. If there are more than 5, append a single `…and N more projects` line so they know the list is truncated. Always state the per-agent total counts (sessions and projects) so the scale is visible.
 
-**Do not paste the raw JSON or list every session back to the user.** Most users have dozens of sessions; a flat list is noise and asking them to pick by id is more friction than just "upload all". Instead, parse the JSON yourself, group by `agent` then by `project`, count, and render a compact summary like:
+Render something like (use the user's actual paths and counts, not these numbers):
 
-```
-Claude Code: 47 sessions
-  ~/work/clawdi-cloud       23
-  ~/work/client-acme        12
-  ~/personal/blog            8
-  ~/scratch                  4
+> I found 215 sessions on this machine:
+>
+> **Claude Code** (180 sessions across 47 projects):
+> - `~/work/clawdi-cloud` — 23 sessions
+> - `~/work/client-acme` — 18 sessions
+> - `~/personal/blog` — 12 sessions
+> - `~/work/api-gateway` — 9 sessions
+> - `~/scratch` — 7 sessions
+> - …and 42 more projects
+>
+> **Codex** (35 sessions across 8 projects):
+> - `~/work/clawdi-cloud` — 11 sessions
+> - `~/work/client-acme` — 8 sessions
+> - `~/work/api-gateway` — 6 sessions
+> - `~/personal/blog` — 5 sessions
+> - `~/scratch` — 3 sessions
+> - …and 3 more projects
+>
+> Want me to upload all of them to your Clawdi Cloud dashboard? Or are there any projects you'd rather skip — anything client-confidential, NDA work, etc.? You can name a project even if it's not in the list above.
 
-Codex: 12 sessions
-  ~/work/clawdi-cloud        7
-  ~/work/client-acme         5
+The closing line about "even if it's not in the list above" is important: the cap might hide a low-session-count NDA repo the user actually cares about excluding. Accept any project path they name, listed or not.
 
-59 sessions total. Upload everything (recommended), or restrict by agent / project / time?
-```
+### Translate the answer to a push command
 
-In your message, **explicitly recommend "upload everything"** — most "show me first" users don't actually need to exclude anything; they just wanted the transparency. Only branch when they name a real constraint (sensitive project, agent they don't use, recency window).
+The user references real project names from the summary you just showed them. Match their reply to a command:
 
-Translate the user's reply by **dimension** (never by id):
-
-| user said | command |
-|---|---|
-| "all", "go", "ok", "looks good" | `clawdi push --modules sessions --all-agents --all --yes` |
+| User says | Command |
+| --- | --- |
+| "all" / "go ahead" / "upload everything" | `clawdi push --modules sessions --all-agents --all --yes` |
+| "skip client-acme" | `clawdi push --modules sessions --all-agents --all --exclude-project ~/work/client-acme --yes` |
+| "skip client-acme and scratch" | `clawdi push --modules sessions --all-agents --all --exclude-project ~/work/client-acme --exclude-project ~/scratch --yes` |
 | "only Claude Code" | `clawdi push --modules sessions --agent claude_code --all --yes` |
-| "only ~/work/foo" | `clawdi push --modules sessions --all-agents --project ~/work/foo --yes` |
-| "exclude ~/scratch" | `clawdi push --modules sessions --all-agents --all --exclude-project ~/scratch --yes` |
-| "exclude ~/scratch and ~/work/acme" | `clawdi push --modules sessions --all-agents --all --exclude-project ~/scratch --exclude-project ~/work/acme --yes` |
-| "last week only" | `clawdi push --modules sessions --all-agents --all --since <ISO date 7d ago> --yes` |
+| "only ~/work/clawdi-cloud" | `clawdi push --modules sessions --all-agents --project ~/work/clawdi-cloud --yes` |
+| "skip entirely" / "not now" | (skip — tell them *"Run `clawdi push --modules sessions --all-agents --all` whenever you want to sync."* and continue) |
 
-Resolve `~` to an absolute path before passing to the CLI. Note the "Pushed N session(s)" total from the output — you'll cite it in Step 5.
+Resolve `~` to an absolute path before passing to the CLI.
 
-### Branch — "skip"
+Note the "X new, Y updated, Z unchanged" total from the push output — you'll cite it next.
 
-Tell the user: *"Skipped. Run `clawdi push --modules sessions --all-agents --all` whenever you want to sync."* Continue to Step 5.
-
-## Step 5: Confirm
+## Verify
 
 ```bash
 clawdi doctor
 ```
 
-All checks should be green. Then tell the user:
+Every check should be green. Then point the user at their dashboard:
 
-> Open the Clawdi Cloud dashboard — you should see N sessions across {registered agents} synced from this machine.
+> All set. Open your Clawdi Cloud dashboard — you should see N sessions from this machine across {agents}.
 
-Where **N** is the total from Step 4's "Pushed N session(s)" line and **{registered agents}** is the list from Step 3.
+Where N = `new + updated + unchanged` from the previous step, and {agents} is the list registered in setup.
 
-If Step 4 was the skip branch, just say all setup checks passed and remind them how to push later.
+If they opted out of session upload, just confirm setup checks passed and remind them how to push later.
 
-## Done
+## What the user got
 
-After setup the user has:
-- **Memory tools** (`memory_search`, `memory_add`) for cross-agent recall
-- **Connector tools** (Gmail, GitHub, Notion, etc.) — they connect services in the dashboard
-- **Session sync** — uploaded today; future sessions sync via `clawdi push`
-- **Vault** — encrypted secrets injected via `clawdi run`
+After this their account has:
+
+- **Memory** — `memory_search` and `memory_add` MCP tools for long-term cross-agent recall.
+- **Connectors** — Gmail, GitHub, Notion, etc. They enable services in the dashboard; tools appear automatically in any registered agent.
+- **Session sync** — pushed today; future sessions sync via `clawdi push`.
+- **Vault** — encrypted secrets injected into commands via `clawdi run`.
 
 ## Troubleshooting
 
-**Step 4 says "0 sessions" but the user has history**
-Re-run with an explicit cutoff:
+**Push reports "0 sessions" but the user has history.** The local hash cache may have drifted from the cloud (e.g. after a server-side data restore). Reset it and re-push:
 
 ```bash
-clawdi push --modules sessions --all-agents --all --since 2020-01-01 --yes
+rm -f ~/.clawdi/sessions-lock.json
+clawdi push --modules sessions --all-agents --all --yes
 ```
 
-This bypasses the per-agent incremental cursor in `~/.clawdi/state.json`.
+**`clawdi auth complete` keeps saying "Still waiting for approval".** The user hasn't clicked approve yet. Re-running is safe within the 10-minute window. If it expired, restart from `clawdi auth login`.
 
-**Older CLI doesn't recognize `--all-agents`**
-Loop manually over each registered agent — Step 3's output told you which were registered:
+**Older CLI doesn't recognize `--all-agents`.** Loop manually over the agents that registered in setup: `clawdi push --modules sessions --agent claude_code --all --yes`, then `--agent codex`, and so on.
 
-```bash
-clawdi push --modules sessions --agent claude_code --all --yes
-clawdi push --modules sessions --agent codex --all --yes
-# etc.
-```
+**Older CLI doesn't recognize `--exclude-project`.** Tell the user to upgrade (`bun add -g clawdi` again) or accept the limitation — without it, only positive selection (`--project`) works.
 
-**Older CLI doesn't recognize `--exclude-project`**
-Drop that flag and tell the user: *"Your CLI is too old to skip a specific project. Either upgrade (`bun add -g clawdi` again), upload everything, or upload only one project at a time with `--project <path>`."*
-
-**Older CLI doesn't have `clawdi sessions list`**
-For Branch (b), fall back to `clawdi push --modules sessions --all-agents --all --dry-run` — it prints scan totals per agent (without per-project breakdown). Less rich, but enough to tell the user "Claude Code: N sessions, Codex: M sessions" before they confirm.
-
-**`clawdi auth complete` keeps saying "Still waiting for approval"**
-The user hasn't clicked approve in the browser yet. Re-running is safe within the 10-minute window. If the window expired, restart from Phase 2a.
+**Older CLI doesn't have `clawdi session list`.** Use `clawdi push --modules sessions --all-agents --all --dry-run` — it prints scan totals per agent without the per-project breakdown.

--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -1,6 +1,5 @@
 ---
 name: clawdi-onboarding
-version: 1
 description: First-time setup walkthrough for connecting this machine to Clawdi Cloud.
 homepage: https://cloud.clawdi.ai
 ---

--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -141,6 +141,44 @@ This installs cloud skills into every registered agent's home directory. Like pu
 
 If the user has zero authored skills, both commands are no-ops. Run them anyway to confirm; the output makes it obvious.
 
+## Extract memories from sessions (optional)
+
+Seed the user's Memory module by extracting facts, preferences, and decisions from the sessions they just pushed. The cloud's configured LLM does the extraction — the agent loops over recent sessions and calls the per-session endpoint via the CLI.
+
+If the user opted out of session upload above, skip this step entirely (there's nothing in the cloud to extract from).
+
+### List recent sessions
+
+```bash
+clawdi session list --all-agents --limit 5 --json
+```
+
+Parse the JSON. Take the `id` of each session (these are the local session ids — the same key the upload endpoint uses).
+
+If the JSON is empty (`[]`), tell the user *"No recent sessions to extract from — skipping memory bootstrap."* and continue to Verify.
+
+### Extract per session
+
+For each session id from the list above, run:
+
+```bash
+clawdi session extract <id> --json
+```
+
+Each call returns `{session_id, memories_created}`. Sum `memories_created` across all 5 calls.
+
+**Stop the loop early if the FIRST call exits with code 2** — that means the deployment hasn't configured memory extraction. Tell the user *"Memory extraction isn't configured on this deployment — skipping."* and continue to Verify.
+
+For other failures (5xx, network), keep going — one bad session shouldn't halt the batch. Note the failure count for the summary.
+
+### Report
+
+Tell the user:
+
+> ✓ Extracted N memories from M sessions{P failed if any}
+
+If extraction was unconfigured, say that instead. Either way, continue to Verify.
+
 ## Verify
 
 ```bash
@@ -159,7 +197,7 @@ If they opted out of session upload, just confirm setup checks passed and remind
 
 After this their account has:
 
-- **Memory** — `memory_search` and `memory_add` MCP tools for long-term cross-agent recall.
+- **Memory** — `memory_search` and `memory_add` MCP tools for long-term cross-agent recall. Seeded with extractions from the sessions just pushed (if memory extraction was configured).
 - **Connectors** — Gmail, GitHub, Notion, etc. They enable services in the dashboard; tools appear automatically in any registered agent.
 - **Session sync** — pushed today; future sessions sync via `clawdi push`.
 - **Skill sync** — authored skills backed up to the cloud and available across registered agents via `clawdi pull --modules skills`.

--- a/apps/web/src/app/(dashboard)/skills/[key]/page.tsx
+++ b/apps/web/src/app/(dashboard)/skills/[key]/page.tsx
@@ -14,6 +14,15 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { unwrap, useApi } from "@/lib/api";
 import { errorMessage, relativeTime } from "@/lib/utils";
 
+// Strip the leading `---\n...\n---` YAML frontmatter so the markdown
+// renderer doesn't show "name:" / "description:" lines (already
+// rendered above as DetailTitle + description) and so the closing
+// `---` doesn't render as a stray `<hr>` next to the Separator.
+function stripFrontmatter(raw: string): string {
+	const m = raw.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?([\s\S]*)$/);
+	return m ? (m[1] ?? "") : raw;
+}
+
 export default function SkillDetailPage() {
 	const { key } = useParams<{ key: string }>();
 	const router = useRouter();
@@ -109,7 +118,7 @@ export default function SkillDetailPage() {
 						<>
 							<Separator />
 							<div className="prose prose-sm max-w-none dark:prose-invert">
-								<Markdown content={skill.content} />
+								<Markdown content={stripFrontmatter(skill.content)} />
 							</div>
 						</>
 					) : null}

--- a/apps/web/src/components/sessions/session-columns.tsx
+++ b/apps/web/src/components/sessions/session-columns.tsx
@@ -49,16 +49,19 @@ const agentColumn: ColumnDef<SessionListItem> = {
 	size: 180,
 };
 
-const startedColumn: ColumnDef<SessionListItem> = {
-	id: "started_at",
-	accessorKey: "started_at",
-	header: "Started",
+const lastActivityColumn: ColumnDef<SessionListItem> = {
+	id: "updated_at",
+	accessorKey: "updated_at",
+	header: "Last activity",
 	cell: ({ row }) => (
-		<span className="whitespace-nowrap text-sm text-muted-foreground">
-			{relativeTime(row.original.started_at)}
+		<span
+			className="whitespace-nowrap text-sm text-muted-foreground"
+			title={`Started ${relativeTime(row.original.started_at)}`}
+		>
+			{relativeTime(row.original.updated_at)}
 		</span>
 	),
-	size: 110,
+	size: 120,
 };
 
 const projectColumn: ColumnDef<SessionListItem> = {
@@ -109,7 +112,7 @@ export const sessionColumns: ColumnDef<SessionListItem>[] = [
 	projectColumn,
 	messagesColumn,
 	tokensColumn,
-	startedColumn,
+	lastActivityColumn,
 ];
 
 // Compact 3-col layout for the Overview "Recent sessions" widget. Sum of
@@ -117,5 +120,5 @@ export const sessionColumns: ColumnDef<SessionListItem>[] = [
 export const sessionColumnsCompact: ColumnDef<SessionListItem>[] = [
 	summaryColumn,
 	agentColumn,
-	startedColumn,
+	lastActivityColumn,
 ];

--- a/apps/web/src/components/sessions/session-row.tsx
+++ b/apps/web/src/components/sessions/session-row.tsx
@@ -34,7 +34,12 @@ export function SessionRow({ session }: { session: SessionListItem }) {
 					<Stat icon={Zap} label={`${formatNumber(totalTokens)} tokens`} />
 				</div>
 			</div>
-			<span className="shrink-0 text-xs text-muted-foreground">{relativeTime(s.started_at)}</span>
+			<span
+				className="shrink-0 text-xs text-muted-foreground"
+				title={`Started ${relativeTime(s.started_at)}`}
+			>
+				{relativeTime(s.updated_at)}
+			</span>
 		</Link>
 	);
 }

--- a/backend/alembic/versions/672acd66fc7d_add_session_content_hash_and_content_.py
+++ b/backend/alembic/versions/672acd66fc7d_add_session_content_hash_and_content_.py
@@ -1,0 +1,57 @@
+"""add session content_hash and content_uploaded_at
+
+Revision ID: 672acd66fc7d
+Revises: 6dee7134c53f
+Create Date: 2026-04-28 13:14:09.069562
+
+Adds two columns to `sessions` to support content-hash-based sync:
+
+- `content_hash`: SHA-256 hex of the messages JSON the CLI uploaded. The
+  batch endpoint uses it to skip content re-upload when local is unchanged.
+  `clawdi pull` uses it to diff cloud vs. local sidecars without fetching
+  the body.
+- `content_uploaded_at`: when the upload endpoint last wrote bytes to the
+  file store. Useful for tooling/admin that wants to spot rows with
+  metadata but no content.
+
+Both columns are nullable. After deploying this migration, run:
+
+    pdm run python -m scripts.backfill_session_content_hash --all
+
+That walks every row with `file_key IS NOT NULL AND content_hash IS NULL`,
+fetches the body from the file store, hashes it, and writes the column.
+Without it, `clawdi pull` would re-download legacy rows on every run
+(NULL hash on the remote means "always re-download" in the diff logic),
+and the data only self-heals via push from the originating machine —
+which doesn't help users on a different device or after a wipe.
+
+The script is idempotent and skips rows whose file is missing from the
+store (logs a warning rather than aborting). Safe to re-run.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "672acd66fc7d"
+down_revision: Union[str, Sequence[str], None] = "6dee7134c53f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sessions",
+        sa.Column("content_hash", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "sessions",
+        sa.Column("content_uploaded_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("sessions", "content_uploaded_at")
+    op.drop_column("sessions", "content_hash")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -66,5 +66,17 @@ class Settings(BaseSettings):
     memory_embedding_base_url: str = ""
     memory_embedding_model: str = "text-embedding-3-small"
 
+    # Shared LLM credentials for any feature that needs chat completions
+    # (memory extraction today; session summarization, auto-tagging, etc.
+    # tomorrow). OpenAI-compatible endpoint — works with OpenAI itself,
+    # OpenRouter, Anthropic-via-proxy, local llama.cpp, etc. Empty
+    # `api_key` is the disable signal — features that depend on the LLM
+    # return 503 with a clear hint when it's missing. `llm_model` is a
+    # process-wide default; individual features can override at the call
+    # site if they need a stronger/cheaper model.
+    llm_base_url: str = ""
+    llm_api_key: str = ""
+    llm_model: str = "gpt-4o-mini"
+
 
 settings = Settings()

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -53,3 +53,8 @@ class Session(Base, TimestampMixin):
     tags: Mapped[list[str] | None] = mapped_column(ARRAY(String))
     status: Mapped[str] = mapped_column(String(20), server_default="completed")
     file_key: Mapped[str | None] = mapped_column(Text)
+    # SHA-256 hex of the messages JSON the CLI uploaded. Used by the batch
+    # endpoint to skip content re-upload when the local copy is unchanged,
+    # and by `clawdi pull` to diff cloud state against local sidecars.
+    content_hash: Mapped[str | None] = mapped_column(String(64))
+    content_uploaded_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -1,10 +1,11 @@
+import hashlib
 import json
 import logging
 from datetime import UTC, datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, HTTPException, Path, Query, UploadFile, status
-from sqlalchemy import func, or_, select
+from sqlalchemy import case, func, or_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -150,12 +151,13 @@ async def batch_create_sessions(
 ) -> SessionBatchResponse:
     """Ingest a batch of sessions from a CLI sync.
 
-    Relies on the `uq_sessions_user_local` unique constraint plus Postgres
-    `ON CONFLICT DO NOTHING` for idempotency — safe under concurrent
-    invocations and a single round-trip to the DB regardless of batch size.
+    Upserts every row by `(user_id, local_session_id)`. The response tells
+    the client which sessions still need a content upload — either because
+    the stored hash differs from the one just sent, or because no content
+    has ever been uploaded for that row (`file_key IS NULL`).
     """
     if not body.sessions:
-        return SessionBatchResponse(synced=0)
+        return SessionBatchResponse(created=0, updated=0, unchanged=0, needs_content=[])
 
     # Reject any environment_id the caller doesn't own. Without this check the
     # CLI's local cache (a stale env id from a previous account / a deleted
@@ -190,6 +192,26 @@ async def batch_create_sessions(
             },
         )
 
+    # Pre-fetch the existing rows for diffing. One indexed lookup against
+    # `uq_sessions_user_local` per batch — cheap, and keeps the diff logic
+    # in Python where it's testable. Doing the diff via a CTE on the upsert
+    # would be slightly faster but much harder to read and harder to keep
+    # in lockstep with the SessionBatchResponse contract.
+    incoming_ids = [s.local_session_id for s in body.sessions]
+    existing_rows = (
+        await db.execute(
+            select(
+                Session.local_session_id,
+                Session.content_hash,
+                Session.file_key,
+            ).where(
+                Session.user_id == auth.user_id,
+                Session.local_session_id.in_(incoming_ids),
+            )
+        )
+    ).all()
+    existing_by_id = {row.local_session_id: row for row in existing_rows}
+
     rows = [
         {
             "user_id": auth.user_id,
@@ -208,29 +230,55 @@ async def batch_create_sessions(
             "summary": s.summary,
             "tags": s.tags,
             "status": s.status,
+            "content_hash": s.content_hash,
         }
         for s in body.sessions
     ]
 
-    stmt = (
-        pg_insert(Session)
-        .values(rows)
-        .on_conflict_do_nothing(constraint="uq_sessions_user_local")
-        .returning(Session.id)
+    insert_stmt = pg_insert(Session).values(rows)
+    # Refresh every metadata field on conflict. Identity (`id`, `user_id`,
+    # `local_session_id`, `created_at`) is preserved, and `file_key` /
+    # `content_uploaded_at` belong to the upload endpoint — don't clobber.
+    upsert_stmt = insert_stmt.on_conflict_do_update(
+        constraint="uq_sessions_user_local",
+        set_={
+            "environment_id": insert_stmt.excluded.environment_id,
+            "project_path": insert_stmt.excluded.project_path,
+            "started_at": insert_stmt.excluded.started_at,
+            "ended_at": insert_stmt.excluded.ended_at,
+            "duration_seconds": insert_stmt.excluded.duration_seconds,
+            "message_count": insert_stmt.excluded.message_count,
+            "input_tokens": insert_stmt.excluded.input_tokens,
+            "output_tokens": insert_stmt.excluded.output_tokens,
+            "cache_read_tokens": insert_stmt.excluded.cache_read_tokens,
+            "model": insert_stmt.excluded.model,
+            "models_used": insert_stmt.excluded.models_used,
+            "summary": insert_stmt.excluded.summary,
+            "tags": insert_stmt.excluded.tags,
+            "status": insert_stmt.excluded.status,
+            "content_hash": insert_stmt.excluded.content_hash,
+            # Only bump `updated_at` when the content actually changed.
+            # Without this, a re-push of unchanged sessions (e.g. empty
+            # client cache, multi-machine sync, manual cache reset) would
+            # touch every row and reshuffle the dashboard's "Last activity"
+            # sort to "everything happened just now". `IS DISTINCT FROM` is
+            # NULL-safe so legacy rows with content_hash IS NULL also
+            # behave correctly: they get a real bump on first proper push.
+            "updated_at": case(
+                (
+                    Session.content_hash.is_distinct_from(insert_stmt.excluded.content_hash),
+                    func.now(),
+                ),
+                else_=Session.updated_at,
+            ),
+        },
     )
-    # The pre-flight check above closes the common case, but there's still
-    # a window between the SELECT and this INSERT where another request can
-    # `DELETE /api/environments/{id}`. The FK + `ON DELETE SET NULL` lets us
-    # detect that here as an IntegrityError → 400, instead of bubbling a 500.
-    #
-    # Narrow to FK violations specifically (PG sqlstate 23503). Without this
-    # guard a future check/exclude/unique constraint failure would land in
-    # the same branch and get mislabeled as `unknown_environment`. The
-    # `uq_sessions_user_local` unique constraint can't trip here because
-    # `on_conflict_do_nothing` swallows it on the way in.
+    # Concurrent `DELETE /api/environments/{id}` between the pre-flight
+    # SELECT and this UPSERT can still race the FK. PG sqlstate 23503 means
+    # FK violation specifically; anything else (we no longer hit unique
+    # collisions because of the upsert) bubbles as a plain 500.
     try:
-        result = await db.execute(stmt)
-        inserted = result.scalars().all()
+        await db.execute(upsert_stmt)
         await db.commit()
     except IntegrityError as e:
         await db.rollback()
@@ -247,7 +295,38 @@ async def batch_create_sessions(
                 ),
             },
         ) from e
-    return SessionBatchResponse(synced=len(inserted))
+
+    # Categorize each row by comparing the pre-fetch snapshot against the
+    # incoming payload. The pre-fetch sees the row as it was BEFORE this
+    # batch, so we get clean created / updated / unchanged buckets without
+    # needing a second round-trip or PG's `xmax` trick.
+    created = 0
+    updated = 0
+    unchanged = 0
+    needs_content: list[str] = []
+    for s in body.sessions:
+        prev = existing_by_id.get(s.local_session_id)
+        if prev is None:
+            created += 1
+            needs_content.append(s.local_session_id)
+        elif prev.file_key is None:
+            # Row existed but never had content uploaded (e.g. previous
+            # upload failed mid-flight). Treat as updated — metadata may
+            # have changed too, and definitely needs content.
+            updated += 1
+            needs_content.append(s.local_session_id)
+        elif prev.content_hash is None or prev.content_hash != s.content_hash:
+            updated += 1
+            needs_content.append(s.local_session_id)
+        else:
+            unchanged += 1
+
+    return SessionBatchResponse(
+        created=created,
+        updated=updated,
+        unchanged=unchanged,
+        needs_content=needs_content,
+    )
 
 
 # Allow-list of columns the client can sort by. Hard-coded to avoid SQL
@@ -255,6 +334,12 @@ async def batch_create_sessions(
 # Note: `tokens` is a synthetic key — the UI shows total tokens (in + out) so
 # sort by the sum expression, not just one column.
 _SESSION_SORT_COLUMNS = {
+    # `updated_at` is the default — the upsert path bumps it whenever a
+    # session's metadata or content_hash changes, so this orders newest-
+    # activity-first across both first-push and append-message flows.
+    # Sorting by `started_at` would freeze a session in its original spot
+    # forever, even after dozens of new messages.
+    "updated_at": Session.updated_at,
     "started_at": Session.started_at,
     "message_count": Session.message_count,
     "tokens": Session.input_tokens + Session.output_tokens,
@@ -268,7 +353,10 @@ async def list_sessions(
     q: str | None = Query(default=None, description="Fuzzy search on summary/project/id"),
     agent: str | None = Query(default=None, description="Filter by agent_type"),
     environment_id: UUID | None = Query(default=None, description="Filter by agent environment"),
-    sort: str = Query(default="started_at", pattern=r"^(started_at|message_count|tokens)$"),
+    sort: str = Query(
+        default="updated_at",
+        pattern=r"^(updated_at|started_at|message_count|tokens)$",
+    ),
     order: str = Query(default="desc", pattern=r"^(asc|desc)$"),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=25, ge=1, le=200),
@@ -358,13 +446,22 @@ async def upload_session_content(
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
 
     data = await file.read()
+    # Hash the bytes we're about to store so the row's `content_hash`
+    # always describes the actual stored object — not whatever the client
+    # claimed in the batch payload. This is what closes the historical
+    # DB↔file-store drift: even if a multipart proxy mangles bytes, the
+    # hash on disk matches the hash in the row.
+    content_hash = hashlib.sha256(data).hexdigest()
+
     fk = f"sessions/{auth.user_id}/{local_session_id}.json"
     await file_store.put(fk, data)
 
     session.file_key = fk
+    session.content_hash = content_hash
+    session.content_uploaded_at = datetime.now(UTC)
     await db.commit()
 
-    return SessionUploadResponse(status="uploaded", file_key=fk)
+    return SessionUploadResponse(status="uploaded", file_key=fk, content_hash=content_hash)
 
 
 @router.get("/api/sessions/{session_id}/content")
@@ -422,6 +519,7 @@ def _session_to_response(
         machine_name=machine_name,
         started_at=s.started_at,
         ended_at=s.ended_at,
+        updated_at=s.updated_at,
         duration_seconds=s.duration_seconds,
         message_count=s.message_count,
         input_tokens=s.input_tokens,
@@ -432,4 +530,5 @@ def _session_to_response(
         summary=s.summary,
         tags=s.tags,
         status=s.status,
+        content_hash=s.content_hash,
     )

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -11,6 +11,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import AuthContext, get_auth
+from app.core.config import settings
 from app.core.database import get_session
 from app.core.query_utils import like_needle
 from app.models.session import AgentEnvironment, Session
@@ -22,11 +23,14 @@ from app.schemas.session import (
     SessionBatchRequest,
     SessionBatchResponse,
     SessionDetailResponse,
+    SessionExtractResponse,
     SessionListItemResponse,
     SessionMessageResponse,
     SessionUploadResponse,
 )
 from app.services.file_store import get_file_store
+from app.services.memory_extraction import extract_memories_from_session
+from app.services.memory_provider import get_memory_provider
 
 router = APIRouter(tags=["sessions"])
 log = logging.getLogger(__name__)
@@ -504,6 +508,93 @@ async def get_session_content(
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Internal server error")
 
     return [SessionMessageResponse.model_validate(m) for m in raw]
+
+
+@router.post("/api/sessions/{local_session_id}/extract")
+async def extract_session_memories(
+    local_session_id: str = Path(..., pattern=r"^[A-Za-z0-9][A-Za-z0-9._\-]{0,199}$"),
+    auth: AuthContext = Depends(get_auth),
+    db: AsyncSession = Depends(get_session),
+) -> SessionExtractResponse:
+    """Extract memories from a session's content via the configured LLM.
+
+    Uses `local_session_id` for path lookup (mirrors the upload endpoint
+    pattern) — `uq_sessions_user_local` makes that a unique index.
+
+    Not idempotent — every call hits the LLM. Onboarding loops over
+    each session exactly once; the future dashboard button is a
+    user-initiated single click. Tracking "already extracted" state
+    on the server would force us to also reason about session updates
+    (re-pushed content with new turns), which is more complexity than
+    a one-shot $0.001 LLM call is worth.
+    """
+    if not settings.llm_api_key:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "LLM is not configured on this deployment",
+        )
+
+    session = (
+        await db.execute(
+            select(Session).where(
+                Session.user_id == auth.user_id,
+                Session.local_session_id == local_session_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if not session:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Session not found")
+    if not session.file_key:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "Session content has not been uploaded",
+        )
+
+    try:
+        data = await file_store.get(session.file_key)
+    except Exception:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Session content file not found")
+
+    try:
+        messages = json.loads(data)
+    except json.JSONDecodeError:
+        log.exception("session %s content is not valid JSON", session.id)
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Internal server error")
+    if not isinstance(messages, list):
+        log.error(
+            "session %s content is not a JSON array (got %s)",
+            session.id,
+            type(messages).__name__,
+        )
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "Internal server error")
+
+    # Local import keeps the openai SDK off the cold-start critical path
+    # for routes that don't need it.
+    from openai import AsyncOpenAI
+
+    client = AsyncOpenAI(
+        base_url=settings.llm_base_url or None,
+        api_key=settings.llm_api_key,
+    )
+    extracted = await extract_memories_from_session(
+        messages,
+        project_path=session.project_path,
+        client=client,
+        model=settings.llm_model,
+    )
+
+    provider = await get_memory_provider(str(auth.user_id), db)
+    for m in extracted:
+        await provider.add(
+            user_id=str(auth.user_id),
+            content=m.content,
+            category=m.category,
+            source="session",
+            tags=m.tags or None,
+            source_session_id=session.id,
+        )
+
+    return SessionExtractResponse(memories_created=len(extracted))
 
 
 def _session_to_response(

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -84,16 +84,22 @@ def _compute_file_tree_hash(tar_bytes: bytes) -> str:
             if not member.isfile():
                 continue
             # Names are like "<skill_key>/foo/bar.txt" — drop the first
-            # segment (the skill dir itself), then check remaining
-            # segments against the exclude set. Same shape as tar.ts's
-            # filter.
+            # segment (the skill dir itself) so the relative path matches
+            # the TS side, which hashes paths from the skill dir's POV
+            # (e.g. "SKILL.md" not "<skill_key>/SKILL.md"). Without this,
+            # the same content produces different hashes on each side and
+            # the backwards-compat fallback / marketplace-install path
+            # would diverge from client hashes forever.
             parts = member.name.split("/")
             if any(p in _SKILL_HASH_EXCLUDE for p in parts[1:]):
+                continue
+            relative_path = "/".join(parts[1:])
+            if not relative_path:
                 continue
             extracted = tf.extractfile(member)
             if extracted is None:
                 continue
-            files.append((member.name, extracted.read()))
+            files.append((relative_path, extracted.read()))
 
     files.sort(key=lambda x: x[0])
     h = hashlib.sha256()

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -1,4 +1,6 @@
 import hashlib
+import io
+import tarfile
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
 from fastapi.responses import Response
@@ -32,12 +34,73 @@ router = APIRouter(prefix="/api/skills", tags=["skills"])
 file_store = get_file_store()
 
 
-def _content_hash(data: bytes) -> str:
-    return hashlib.sha256(data).hexdigest()
-
-
 def _file_key(user_id, skill_key: str) -> str:
     return f"skills/{user_id}/{skill_key}.tar.gz"
+
+
+# Mirror of SKILL_TAR_EXCLUDE in packages/cli/src/lib/tar.ts:12-30. The two
+# MUST match — what's hashed must equal what's tarred. If you change one,
+# change the other in the same commit. The TS file's filter at
+# tar.ts:82-85 uses the same shape: skip if any path segment after the
+# skill-key root is in this set.
+_SKILL_HASH_EXCLUDE = {
+    "node_modules",
+    ".git",
+    ".turbo",
+    ".next",
+    ".cache",
+    "dist",
+    "build",
+    "out",
+    "target",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".tox",
+    "coverage",
+}
+
+
+def _compute_file_tree_hash(tar_bytes: bytes) -> str:
+    """File-tree content hash of a skill tar.gz.
+
+    Walks each file in the archive (skipping directories and any path
+    whose segments include the exclude set above), sorts by relative
+    path, then sha256 over `path + content` per file. Mirrors the TS
+    `computeSkillFolderHash` in `packages/cli/src/lib/skills-lock.ts` so
+    server-side and client-side hashes are identical for the same tar.
+
+    Used in two places:
+    - `upload_skill` fallback when the client (CLI <= 0.3.3) doesn't send
+      `content_hash`.
+    - `install_skill` for marketplace tars fetched from GitHub.
+    """
+    files: list[tuple[str, bytes]] = []
+    with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:gz") as tf:
+        for member in tf.getmembers():
+            if not member.isfile():
+                continue
+            # Names are like "<skill_key>/foo/bar.txt" — drop the first
+            # segment (the skill dir itself), then check remaining
+            # segments against the exclude set. Same shape as tar.ts's
+            # filter.
+            parts = member.name.split("/")
+            if any(p in _SKILL_HASH_EXCLUDE for p in parts[1:]):
+                continue
+            extracted = tf.extractfile(member)
+            if extracted is None:
+                continue
+            files.append((member.name, extracted.read()))
+
+    files.sort(key=lambda x: x[0])
+    h = hashlib.sha256()
+    for path, content in files:
+        h.update(path.encode("utf-8"))
+        h.update(content)
+    return h.hexdigest()
 
 
 # ---------------------------------------------------------------------------
@@ -155,6 +218,17 @@ async def get_skill(
 async def upload_skill(
     skill_key: str = Form(...),
     file: UploadFile = File(...),
+    # Optional for backwards compat with CLI <= 0.3.3 that doesn't send
+    # this field. New clients (>= 0.3.4) compute the file-tree hash and
+    # send it; the server trusts it (sync optimization, not a security
+    # boundary). When absent, server falls back to computing it from the
+    # uploaded tar so the rest of the flow still gates on a real hash.
+    content_hash: str | None = Form(
+        None,
+        min_length=64,
+        max_length=64,
+        pattern=r"^[a-f0-9]{64}$",
+    ),
     auth: AuthContext = Depends(get_auth),
     db: AsyncSession = Depends(get_session),
 ) -> SkillUploadResponse:
@@ -174,7 +248,28 @@ async def upload_skill(
     name = fm.get("name", skill_key)
     description = fm.get("description", "")
 
-    content_hash = _content_hash(data)
+    if content_hash is None:
+        content_hash = _compute_file_tree_hash(data)
+
+    # Pre-fetch existing row so we can skip both file_store.put AND the
+    # upsert when the bytes are identical to what's already stored. Saves
+    # an R2/S3 PUT and prevents the cosmetic version+1 bump.
+    existing_result = await db.execute(
+        select(Skill).where(
+            Skill.user_id == auth.user_id,
+            Skill.skill_key == skill_key,
+        )
+    )
+    existing = existing_result.scalar_one_or_none()
+
+    if existing and existing.content_hash == content_hash:
+        return SkillUploadResponse(
+            skill_key=existing.skill_key,
+            name=existing.name,
+            version=existing.version,
+            file_count=file_count,
+        )
+
     fk = _file_key(auth.user_id, skill_key)
     await file_store.put(fk, data)
 
@@ -280,7 +375,7 @@ async def install_skill(
     except ValueError as e:
         raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
 
-    content_hash = _content_hash(fetched.tar_bytes)
+    content_hash = _compute_file_tree_hash(fetched.tar_bytes)
     skill_key = fetched.name.lower().replace(" ", "-")
     fk = _file_key(auth.user_id, skill_key)
     await file_store.put(fk, fetched.tar_bytes)
@@ -332,6 +427,14 @@ async def _upsert_skill(
     skill = result.scalar_one_or_none()
 
     if skill:
+        if skill.content_hash == content_hash:
+            # Defense in depth — even if the upload endpoint's pre-fetch
+            # gets bypassed by a future caller, the upsert won't bump
+            # `version + 1` or refresh fields when nothing changed.
+            # `updated_at` only advances on actual UPDATE statements
+            # (TimestampMixin's `onupdate`), so an early return preserves
+            # the original timestamp too.
+            return skill
         skill.name = name
         skill.description = description
         skill.content_hash = content_hash

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -40,6 +40,11 @@ class SessionCreate(BaseModel):
     summary: str | None = None
     tags: list[str] | None = None
     status: str = "completed"
+    # SHA-256 hex of the JSON-serialized messages array. Server compares
+    # against the stored value to decide whether content needs reupload.
+    # Optional so old clients that don't compute hashes still get inserted;
+    # legacy rows with NULL hash are always treated as "needs content".
+    content_hash: str | None = None
 
 
 class SessionBatchRequest(BaseModel):
@@ -68,7 +73,17 @@ class EnvironmentResponse(BaseModel):
 
 
 class SessionBatchResponse(BaseModel):
-    synced: int
+    # Rows that didn't exist before the batch.
+    created: int
+    # Rows that existed but were modified — either metadata changed,
+    # the content hash differs, or the row had no `file_key` yet.
+    updated: int
+    # Rows whose hash matched and `file_key` was already set — no work to do.
+    unchanged: int
+    # local_session_ids that need a follow-up content upload. Always a
+    # superset of `created` (new rows have no content yet); also includes
+    # any updated row whose stored bytes are stale.
+    needs_content: list[str]
 
 
 class SessionListItemResponse(BaseModel):
@@ -79,6 +94,10 @@ class SessionListItemResponse(BaseModel):
     machine_name: str | None = None
     started_at: datetime
     ended_at: datetime | None
+    # Last time the row's metadata or content was touched on the server.
+    # Bumped on every batch upsert and content upload. The dashboard sorts
+    # by this so sessions with new messages bubble to the top.
+    updated_at: datetime
     duration_seconds: int | None
     message_count: int
     input_tokens: int
@@ -89,6 +108,9 @@ class SessionListItemResponse(BaseModel):
     summary: str | None
     tags: list[str] | None
     status: str
+    # Surfaced so `clawdi pull` can diff cloud vs. local sidecar without
+    # downloading the content body.
+    content_hash: str | None = None
 
 
 class SessionDetailResponse(SessionListItemResponse):
@@ -98,6 +120,10 @@ class SessionDetailResponse(SessionListItemResponse):
 class SessionUploadResponse(BaseModel):
     status: Literal["uploaded"]
     file_key: str
+    # Hash of the bytes the server just stored. Lets the client confirm the
+    # round-trip matched what it computed locally — divergence here would
+    # indicate a multipart corruption or a charset issue worth surfacing.
+    content_hash: str
 
 
 class SessionMessageResponse(BaseModel):

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -126,6 +126,12 @@ class SessionUploadResponse(BaseModel):
     content_hash: str
 
 
+class SessionExtractResponse(BaseModel):
+    """Result of `POST /api/sessions/{local_session_id}/extract`."""
+
+    memories_created: int
+
+
 class SessionMessageResponse(BaseModel):
     """One agent message inside a session content file.
 

--- a/backend/app/services/memory_extraction.py
+++ b/backend/app/services/memory_extraction.py
@@ -1,3 +1,9 @@
+# ruff: noqa: E501
+# This module contains a long-form system prompt where each line is a
+# natural-language paragraph. Hard-wrapping at 100 chars would chop
+# sentences mid-thought without changing what the model actually sees
+# (which is a single string of tokens — source line breaks don't matter
+# unless explicit `\n` characters are present).
 """LLM-driven extraction of memory entries from a session's messages.
 
 The prompt does the heavy lifting — we lean on concrete ✅/❌ examples per

--- a/backend/app/services/memory_extraction.py
+++ b/backend/app/services/memory_extraction.py
@@ -1,0 +1,220 @@
+"""LLM-driven extraction of memory entries from a session's messages.
+
+The prompt does the heavy lifting — we lean on concrete ✅/❌ examples per
+category (borrowed from `/Users/paco/workspace/claude-mem`'s playbook) so
+the model self-filters trivial signal at generation time. No post-LLM
+dedup or similarity gating; if the model returns junk the bar in the
+prompt is too low, fix the prompt rather than add a filter pass.
+
+OpenAI's structured-output `response_format=json_schema` enforces the
+`ExtractionResult` shape so we don't defensively parse — bad output
+raises and the caller (`POST /api/sessions/{id}/extract`) bubbles it as
+5xx.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Literal
+
+from openai import AsyncOpenAI
+from pydantic import BaseModel, Field
+
+log = logging.getLogger(__name__)
+
+
+# Tail-truncate to this many messages per session. Most useful signal
+# (decisions, conclusions, settled preferences) lands at the end of a
+# conversation — head context is usually scaffolding. 80 keeps a typical
+# session under ~30k tokens for the LLM call.
+MAX_MESSAGES = 80
+
+Category = Literal["fact", "preference", "pattern", "decision", "context"]
+
+
+class ExtractedMemory(BaseModel):
+    content: str = Field(..., min_length=1, max_length=2000)
+    category: Category
+    tags: list[str] = Field(default_factory=list, max_length=10)
+
+
+class ExtractionResult(BaseModel):
+    # Loose ceiling, not meant to bind in normal use — the prompt asks
+    # for selectivity ("most sessions yield 0-5"). 20 only catches a
+    # model that's gone off the rails (one memory per message, etc.).
+    memories: list[ExtractedMemory] = Field(default_factory=list, max_length=20)
+
+
+# json_schema for OpenAI structured output. Mirrored from `ExtractionResult`
+# but written by hand because Pydantic-generated schemas use `$ref`/`$defs`
+# which OpenAI's strict mode rejects (must be fully inlined).
+_RESPONSE_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["memories"],
+    "properties": {
+        "memories": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["content", "category", "tags"],
+                "properties": {
+                    "content": {"type": "string"},
+                    "category": {
+                        "type": "string",
+                        "enum": ["fact", "preference", "pattern", "decision", "context"],
+                    },
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+        }
+    },
+}
+
+
+_SYSTEM_PROMPT = """You extract durable memories from a developer's past Claude Code conversation. The memories you produce will be available in *future* sessions across any agent the developer uses, so optimize for things that will actually help future-them — not for summarizing what just happened.
+
+# What to record
+
+Focus on durable signal that survives this session:
+
+- What the system NOW DOES differently after this conversation (new behavior, new capabilities, configurations that changed)
+- Decisions the developer settled on, with rationale, that are expected to stick
+- Repeated preferences that govern how they work (tooling, code style, process)
+- Conventions and patterns established or confirmed during this conversation
+- Concrete debugging findings — things they learned about how a system actually behaves under failure or edge cases (queue stalls, race conditions, surprising defaults, missing env wiring). These count as durable signal even when no code changed.
+
+Use verbs like: implemented, fixed, deployed, configured, migrated, optimized, added, refactored, discovered, confirmed, traced, established, ruled out, settled on.
+
+# Categories
+
+Each memory belongs to exactly one of these. ✅ shows the bar; ❌ shows what NOT to record:
+
+- **fact** — A stable piece of truth about the developer's stack, environment, or world. Includes "the system now does X" findings.
+  ✅ "Production deploys live at app.example.com; staging at staging.example.com"
+  ✅ "Hermes adapter under Node uses better-sqlite3 because node:sqlite isn't available pre-22.5"
+  ❌ "User asked about deployment URLs"
+
+- **preference** — A repeated, durable choice the developer makes when given options.
+  ✅ "Prefers `bun` over `npm` for monorepo dependency management"
+  ✅ "Wants commit messages to focus on the WHY, never on the WHAT"
+  ❌ "Used npm in this session"
+
+- **pattern** — A reusable code, architectural, or workflow convention they follow.
+  ✅ "Error responses follow `{error: {code, message, hint}}` shape across all routes"
+  ✅ "Backend tests hit a real Postgres (not mocks) because mocks diverged from prod last time"
+  ❌ "Wrote an API endpoint"
+
+- **decision** — A choice made with explicit rationale that's expected to stick.
+  ✅ "Adopted Drizzle over Prisma for type inference quality on partial selects"
+  ✅ "Stopped using --no-verify in commits after a hook regression slipped to prod"
+  ❌ "Added a database query"
+
+- **context** — High-level fact about what the developer is working on or who they are.
+  ✅ "Working on internal billing portal — payments via Stripe Connect, multi-tenant by org_id"
+  ✅ "Senior engineer; treats explanations as peer-to-peer, not tutorial"
+  ❌ "Opened billing.ts"
+
+# What NOT to record
+
+- The model's own actions ("analyzed the codebase", "wrote a function then revised it"). Record what the developer did or learned, not what you (the assistant) did.
+- Questions the user asked that didn't reach a settled answer in this conversation
+- Topics that came up but were left in mid-exploration
+- Trivial single-session events with no future relevance ("ran `npm install`", "fixed a typo", "renamed a local variable")
+- Anything you'd have to invent or guess at — only record things actually established by the conversation
+
+# How to write a memory
+
+- Single self-contained sentence written from the developer's perspective ("User prefers X" / "X happens because Y" / "The auth middleware now does Z")
+- Specific over abstract — "user cares about types" is useless; "user reviews each function for type-narrowing opportunities before merging" is useful
+- Self-contained — no "as discussed earlier" or "the X we just changed". Future-them won't have this conversation in front of them.
+
+# Worked example
+
+Input excerpt:
+[user] switch this from prisma to drizzle?
+[assistant] sure. why drizzle over prisma?
+[user] better partial-select inference, and the team's more familiar with it
+[assistant] migrating now...
+
+Output:
+{"memories": [{
+  "content": "Adopted Drizzle over Prisma for type inference quality on partial selects and team familiarity",
+  "category": "decision",
+  "tags": ["orm", "database"]
+}]}
+
+# Selectivity
+
+Most sessions yield 0-5 durable memories; many yield 0. An empty `memories` array is often the right answer — the conversation might be mostly scaffolding, exploration without conclusions, or one-off trivia. Returning many low-quality memories is strictly worse than returning none.
+
+Return JSON only. Do not explain why the array is empty. Do not narrate your reasoning. Just the JSON object.
+"""
+
+
+def _format_messages_for_prompt(
+    messages: list[dict[str, Any]],
+    project_path: str | None,
+    total: int,
+) -> str:
+    lines: list[str] = []
+    header = f"project: {project_path or 'unknown'}\nmessages: {len(messages)} of {total} (tail-truncated, oldest dropped)"
+    lines.append(header)
+    lines.append("")
+    for m in messages:
+        role = str(m.get("role", "?"))
+        content = m.get("content", "")
+        # Some messages may have non-string content (tool_use blocks etc).
+        # Stringify defensively — the LLM is fine with JSON snippets in-line.
+        if not isinstance(content, str):
+            try:
+                content = json.dumps(content, ensure_ascii=False)
+            except (TypeError, ValueError):
+                content = str(content)
+        lines.append(f"[{role}] {content}")
+    return "\n".join(lines)
+
+
+async def extract_memories_from_session(
+    messages: list[dict[str, Any]],
+    *,
+    project_path: str | None,
+    client: AsyncOpenAI,
+    model: str,
+) -> list[ExtractedMemory]:
+    """Run extraction over a session's messages.
+
+    Tail-truncates to `MAX_MESSAGES` and asks the LLM for a JSON-schema
+    constrained `ExtractionResult`. Returns the parsed list, possibly
+    empty. Any LLM/network/parsing error propagates to the caller.
+    """
+    if not messages:
+        return []
+
+    total = len(messages)
+    truncated = messages[-MAX_MESSAGES:] if total > MAX_MESSAGES else messages
+
+    user_content = _format_messages_for_prompt(truncated, project_path, total)
+
+    response = await client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": user_content},
+        ],
+        response_format={
+            "type": "json_schema",
+            "json_schema": {
+                "name": "ExtractionResult",
+                "strict": True,
+                "schema": _RESPONSE_SCHEMA,
+            },
+        },
+        temperature=0.2,
+    )
+
+    raw = response.choices[0].message.content or "{}"
+    parsed = ExtractionResult.model_validate_json(raw)
+    return parsed.memories

--- a/backend/app/services/memory_provider.py
+++ b/backend/app/services/memory_provider.py
@@ -26,6 +26,7 @@ class MemoryProvider(Protocol):
         category: str = "fact",
         source: str = "manual",
         tags: list[str] | None = None,
+        source_session_id: uuid.UUID | None = None,
     ) -> dict: ...
 
     async def search(
@@ -65,6 +66,7 @@ class BuiltinProvider:
         category: str = "fact",
         source: str = "manual",
         tags: list[str] | None = None,
+        source_session_id: uuid.UUID | None = None,
     ) -> dict:
         vec: list[float] | None = None
         if self.embedder is not None:
@@ -82,6 +84,7 @@ class BuiltinProvider:
             category=category,
             source=source,
             tags=tags,
+            source_session_id=source_session_id,
             embedding=vec,
         )
         self.db.add(memory)
@@ -270,11 +273,17 @@ class Mem0Provider:
         category: str = "fact",
         source: str = "manual",
         tags: list[str] | None = None,
+        source_session_id: uuid.UUID | None = None,
     ) -> dict:
+        # Mem0 has no native column for `source_session_id`; persist it in
+        # metadata so the linkage isn't lost across providers.
+        metadata: dict = {"category": category, "source": source, "tags": tags or []}
+        if source_session_id is not None:
+            metadata["source_session_id"] = str(source_session_id)
         result = self.client.add(
             [{"role": "user", "content": content}],
             user_id=user_id,
-            metadata={"category": category, "source": source, "tags": tags or []},
+            metadata=metadata,
         )
         mem_id = result[0]["id"] if result else str(uuid.uuid4())
         return {"id": mem_id}

--- a/backend/scripts/backfill_session_content_hash.py
+++ b/backend/scripts/backfill_session_content_hash.py
@@ -1,0 +1,146 @@
+"""Backfill `sessions.content_hash` for rows uploaded before the column existed.
+
+Runs once after deploying migration 672acd66fc7d. Without it, legacy rows
+have `file_key IS NOT NULL` but `content_hash IS NULL`, which means the
+pull side's diff (`remote.content_hash !== sidecar.content_hash`) always
+sees NULL on the remote and re-downloads the body forever — pull never
+converges for those rows.
+
+The script is idempotent: it only touches rows where `content_hash IS NULL`,
+so re-running just no-ops. A row whose file is missing from the store
+(e.g. a stale row from a wiped bucket) gets skipped with a warning rather
+than aborting the run; orphaned rows are diagnosed separately.
+
+Usage:
+    pdm run python -m scripts.backfill_session_content_hash --all
+    pdm run python -m scripts.backfill_session_content_hash --user-id <uuid>
+    pdm run python -m scripts.backfill_session_content_hash --all --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import logging
+import sys
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.core.database import engine
+from app.models.session import Session
+from app.services.file_store import get_file_store
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("backfill-session-hash")
+
+# Process rows in chunks so a multi-GB file store doesn't load every Session
+# row into memory at once. The chunk size is small because each row triggers
+# a file_store.get; the network round-trip dominates.
+CHUNK_SIZE = 50
+
+
+async def backfill(user_id: uuid.UUID | None, dry_run: bool) -> None:
+    file_store = get_file_store()
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    # Snapshot the target ids up-front. A live select would re-walk the
+    # table after each commit and skip rows whose `content_hash` we just
+    # set — wastes time but isn't a correctness issue. Snapshot is just
+    # cleaner.
+    async with SessionLocal() as db:
+        id_query = select(Session.id).where(
+            Session.file_key.is_not(None),
+            Session.content_hash.is_(None),
+        )
+        if user_id is not None:
+            id_query = id_query.where(Session.user_id == user_id)
+        id_query = id_query.order_by(Session.created_at.asc())
+        target_ids = (await db.execute(id_query)).scalars().all()
+
+    log.info("found %d session(s) needing backfill", len(target_ids))
+    if not target_ids:
+        return
+    if dry_run:
+        log.info("dry-run: would backfill %d row(s); no writes performed", len(target_ids))
+        return
+
+    processed = 0
+    skipped_missing = 0
+    skipped_error = 0
+
+    for i in range(0, len(target_ids), CHUNK_SIZE):
+        chunk_ids = target_ids[i : i + CHUNK_SIZE]
+        async with SessionLocal() as db:
+            rows = (
+                (await db.execute(select(Session).where(Session.id.in_(chunk_ids)))).scalars().all()
+            )
+            for row in rows:
+                if not row.file_key:
+                    # Could happen if another writer cleared file_key
+                    # between the snapshot and now. Defensive; not expected.
+                    skipped_missing += 1
+                    continue
+                try:
+                    data = await file_store.get(row.file_key)
+                except Exception as e:
+                    # File store may be missing the object (stale row, wiped
+                    # bucket, permissions). Skip and let a separate orphan
+                    # check deal with it.
+                    log.warning("file_store.get failed for %s (%s): %s", row.id, row.file_key, e)
+                    skipped_error += 1
+                    continue
+
+                row.content_hash = hashlib.sha256(data).hexdigest()
+                # We don't know exactly when content was uploaded for legacy
+                # rows. `updated_at` would be the closest signal, but it's
+                # been bumped by every subsequent metadata change. Stamping
+                # `now()` here is honest about the meaning: "this is when
+                # we recorded the hash", not when bytes hit storage.
+                row.content_uploaded_at = datetime.now(UTC)
+                processed += 1
+            await db.commit()
+        log.info(
+            "progress: %d/%d processed (skipped: %d missing, %d errors)",
+            processed,
+            len(target_ids),
+            skipped_missing,
+            skipped_error,
+        )
+
+    log.info(
+        "done: processed=%d skipped_missing=%d skipped_error=%d",
+        processed,
+        skipped_missing,
+        skipped_error,
+    )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--user-id", type=str, help="Backfill a single user by UUID.")
+    g.add_argument("--all", action="store_true", help="Backfill every user with legacy rows.")
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be backfilled without writing.",
+    )
+    args = ap.parse_args()
+
+    user_id: uuid.UUID | None = None
+    if args.user_id:
+        try:
+            user_id = uuid.UUID(args.user_id)
+        except ValueError:
+            log.error("invalid --user-id; expected a UUID")
+            sys.exit(2)
+
+    asyncio.run(backfill(user_id=user_id, dry_run=args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -36,7 +36,7 @@ async def test_environment_register_is_idempotent(client: httpx.AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_session_batch_dedupes_by_local_session_id(client: httpx.AsyncClient):
+async def test_session_batch_upserts_and_returns_needs_content(client: httpx.AsyncClient):
     env_id = await _register_env(client)
     started = datetime.now(UTC).isoformat()
     payload = {
@@ -47,6 +47,7 @@ async def test_session_batch_dedupes_by_local_session_id(client: httpx.AsyncClie
                 "started_at": started,
                 "message_count": 3,
                 "model": "claude-opus-4",
+                "content_hash": "a" * 64,
             },
             {
                 "environment_id": env_id,
@@ -54,21 +55,244 @@ async def test_session_batch_dedupes_by_local_session_id(client: httpx.AsyncClie
                 "started_at": started,
                 "message_count": 7,
                 "model": "claude-sonnet-4",
+                "content_hash": "b" * 64,
             },
         ]
     }
     r = await client.post("/api/sessions/batch", json=payload)
     assert r.status_code == 200, r.text
-    assert r.json() == {"synced": 2}
+    body = r.json()
+    # Both rows are brand new — no `file_key` yet, so both must be in
+    # needs_content and counted as `created`.
+    assert body["created"] == 2
+    assert body["updated"] == 0
+    assert body["unchanged"] == 0
+    assert set(body["needs_content"]) == {"sess-abc", "sess-xyz"}
 
-    # Re-posting identical rows should sync 0 — dedupe is by local_session_id,
-    # which is the client's offline idempotency key.
-    r2 = await client.post("/api/sessions/batch", json=payload)
-    assert r2.json() == {"synced": 0}
-
+    # Listing the rows surfaces the metadata we just upserted.
     listing = (await client.get("/api/sessions")).json()
     assert listing["total"] == 2
     assert {s["local_session_id"] for s in listing["items"]} == {"sess-abc", "sess-xyz"}
+
+
+@pytest.mark.asyncio
+async def test_session_batch_unchanged_when_hash_matches_and_content_uploaded(
+    client: httpx.AsyncClient,
+):
+    env_id = await _register_env(client)
+    started = datetime.now(UTC).isoformat()
+    body_bytes = b'[{"role":"user","content":"hi"}]'
+    import hashlib
+
+    expected_hash = hashlib.sha256(body_bytes).hexdigest()
+
+    # 1. First push declares the hash; row is new, content needed.
+    first = await client.post(
+        "/api/sessions/batch",
+        json={
+            "sessions": [
+                {
+                    "environment_id": env_id,
+                    "local_session_id": "sess-stable",
+                    "started_at": started,
+                    "message_count": 1,
+                    "content_hash": expected_hash,
+                }
+            ]
+        },
+    )
+    assert first.json()["needs_content"] == ["sess-stable"]
+
+    # 2. Upload content. The endpoint hashes the bytes and stores it on
+    # the row, so subsequent batches with the same hash will be unchanged.
+    upload = await client.post(
+        "/api/sessions/sess-stable/upload",
+        files={"file": ("sess-stable.json", body_bytes, "application/json")},
+    )
+    assert upload.status_code == 200, upload.text
+    assert upload.json()["content_hash"] == expected_hash
+
+    # 3. Re-push with the same hash → unchanged, content not requested.
+    second = await client.post(
+        "/api/sessions/batch",
+        json={
+            "sessions": [
+                {
+                    "environment_id": env_id,
+                    "local_session_id": "sess-stable",
+                    "started_at": started,
+                    "message_count": 1,
+                    "content_hash": expected_hash,
+                }
+            ]
+        },
+    )
+    body = second.json()
+    assert body["unchanged"] == 1
+    assert body["created"] == 0
+    assert body["updated"] == 0
+    assert body["needs_content"] == []
+
+
+@pytest.mark.asyncio
+async def test_unchanged_repush_does_not_bump_updated_at(client: httpx.AsyncClient):
+    """The dashboard sorts by `updated_at`. A re-push of unchanged sessions
+    (e.g. empty client cache, fresh machine restoring from cloud) must NOT
+    refresh `updated_at` — that would reshuffle the entire list to
+    "everything happened just now" and bury the user's actual recent work.
+    """
+    env_id = await _register_env(client)
+    started = datetime.now(UTC).isoformat()
+    body_bytes = b'[{"role":"user","content":"hi"}]'
+    import asyncio
+    import hashlib
+
+    expected_hash = hashlib.sha256(body_bytes).hexdigest()
+
+    # Initial push + content upload.
+    await client.post(
+        "/api/sessions/batch",
+        json={
+            "sessions": [
+                {
+                    "environment_id": env_id,
+                    "local_session_id": "sess-quiet",
+                    "started_at": started,
+                    "message_count": 1,
+                    "content_hash": expected_hash,
+                }
+            ]
+        },
+    )
+    await client.post(
+        "/api/sessions/sess-quiet/upload",
+        files={"file": ("sess-quiet.json", body_bytes, "application/json")},
+    )
+
+    before = (await client.get("/api/sessions")).json()
+    before_ts = next(
+        s["updated_at"] for s in before["items"] if s["local_session_id"] == "sess-quiet"
+    )
+
+    # Sleep long enough that any wall-clock bump would be visible at
+    # millisecond resolution.
+    await asyncio.sleep(0.05)
+
+    # Re-push with identical hash — server should treat as unchanged
+    # and leave updated_at alone.
+    await client.post(
+        "/api/sessions/batch",
+        json={
+            "sessions": [
+                {
+                    "environment_id": env_id,
+                    "local_session_id": "sess-quiet",
+                    "started_at": started,
+                    "message_count": 1,
+                    "content_hash": expected_hash,
+                }
+            ]
+        },
+    )
+
+    after = (await client.get("/api/sessions")).json()
+    after_ts = next(
+        s["updated_at"] for s in after["items"] if s["local_session_id"] == "sess-quiet"
+    )
+    assert after_ts == before_ts, "updated_at must not advance for unchanged re-push"
+
+
+@pytest.mark.asyncio
+async def test_session_batch_hash_change_triggers_needs_content(
+    client: httpx.AsyncClient,
+):
+    env_id = await _register_env(client)
+    started = datetime.now(UTC).isoformat()
+
+    # Insert + upload some content.
+    await client.post(
+        "/api/sessions/batch",
+        json={
+            "sessions": [
+                {
+                    "environment_id": env_id,
+                    "local_session_id": "sess-mut",
+                    "started_at": started,
+                    "message_count": 1,
+                    "content_hash": "a" * 64,
+                }
+            ]
+        },
+    )
+    await client.post(
+        "/api/sessions/sess-mut/upload",
+        files={"file": ("sess-mut.json", b'[{"role":"user","content":"v1"}]', "application/json")},
+    )
+
+    # Re-push with a DIFFERENT hash — simulates the user appending a message.
+    r = await client.post(
+        "/api/sessions/batch",
+        json={
+            "sessions": [
+                {
+                    "environment_id": env_id,
+                    "local_session_id": "sess-mut",
+                    "started_at": started,
+                    "message_count": 2,
+                    "content_hash": "c" * 64,
+                }
+            ]
+        },
+    )
+    body = r.json()
+    assert body["needs_content"] == ["sess-mut"]
+    assert body["created"] == 0
+    assert body["updated"] == 1
+    assert body["unchanged"] == 0
+
+    # Metadata refreshed too (message_count went 1 → 2).
+    listing = (await client.get("/api/sessions")).json()
+    items = {s["local_session_id"]: s for s in listing["items"]}
+    assert items["sess-mut"]["message_count"] == 2
+    assert items["sess-mut"]["content_hash"] == "c" * 64
+
+
+@pytest.mark.asyncio
+async def test_session_upload_records_content_hash_and_uploaded_at(
+    client: httpx.AsyncClient,
+):
+    """Round-trip the upload endpoint: hash the bytes, write to the file
+    store, persist the hash and timestamp on the row."""
+    env_id = await _register_env(client)
+    started = datetime.now(UTC).isoformat()
+    await client.post(
+        "/api/sessions/batch",
+        json={
+            "sessions": [
+                {
+                    "environment_id": env_id,
+                    "local_session_id": "sess-up",
+                    "started_at": started,
+                    "message_count": 1,
+                    "content_hash": "deadbeef" * 8,
+                }
+            ]
+        },
+    )
+
+    body_bytes = b'[{"role":"user","content":"x"}]'
+    r = await client.post(
+        "/api/sessions/sess-up/upload",
+        files={"file": ("sess-up.json", body_bytes, "application/json")},
+    )
+    assert r.status_code == 200, r.text
+    payload = r.json()
+
+    import hashlib
+
+    assert payload["content_hash"] == hashlib.sha256(body_bytes).hexdigest()
+    assert payload["status"] == "uploaded"
+    assert payload["file_key"].startswith("sessions/")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -486,3 +486,106 @@ async def test_delete_environment_orphans_sessions_via_fk(
 async def test_delete_environment_404_for_unknown(client: httpx.AsyncClient):
     r = await client.delete(f"/api/environments/{uuid.uuid4()}")
     assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /api/sessions/{local_session_id}/extract
+# ---------------------------------------------------------------------------
+
+
+async def _seed_session_with_content(
+    client: httpx.AsyncClient, local_id: str, *, content: bytes | None = None
+) -> str:
+    """Register env + create a session row + upload content. Returns
+    `local_session_id` (path key for the extract endpoint)."""
+    env_id = await _register_env(client)
+    started = datetime.now(UTC).isoformat()
+    await client.post(
+        "/api/sessions/batch",
+        json={
+            "sessions": [
+                {
+                    "environment_id": env_id,
+                    "local_session_id": local_id,
+                    "started_at": started,
+                    "message_count": 2,
+                    "content_hash": "c" * 64,
+                }
+            ]
+        },
+    )
+    body = content or b'[{"role":"user","content":"hi"},{"role":"assistant","content":"hello"}]'
+    await client.post(
+        f"/api/sessions/{local_id}/upload",
+        files={"file": (f"{local_id}.json", body, "application/json")},
+    )
+    return local_id
+
+
+@pytest.mark.asyncio
+async def test_extract_creates_memories_linked_to_session(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Happy path: stub the LLM call to return 2 memories; assert they
+    land in the DB with `source="session"` and `source_session_id` set."""
+    from app.core.config import settings as app_settings
+    from app.models.memory import Memory
+    from app.services import memory_extraction
+
+    monkeypatch.setattr(app_settings, "llm_api_key", "test-key")
+
+    async def fake_extract(messages, *, project_path, client, model):
+        return [
+            memory_extraction.ExtractedMemory(
+                content="User prefers bun over npm", category="preference", tags=["tooling"]
+            ),
+            memory_extraction.ExtractedMemory(
+                content="Adopted Drizzle for type inference", category="decision", tags=[]
+            ),
+        ]
+
+    monkeypatch.setattr(
+        "app.routes.sessions.extract_memories_from_session", fake_extract
+    )
+
+    local_id = "sess-extract-1"
+    await _seed_session_with_content(client, local_id)
+
+    r = await client.post(f"/api/sessions/{local_id}/extract")
+    assert r.status_code == 200, r.text
+    assert r.json() == {"memories_created": 2}
+
+    # Verify the rows landed with the right source + linkage.
+    # Scope the lookup to this test's user — Memory has no FK cascade so
+    # rows from other tests can outlive their user fixture.
+    from sqlalchemy import select
+
+    rows = (
+        await db_session.execute(select(Memory).where(Memory.user_id == seed_user.id))
+    ).scalars().all()
+    assert len(rows) == 2
+    assert {m.source for m in rows} == {"session"}
+    assert all(m.source_session_id is not None for m in rows)
+    contents = {m.content for m in rows}
+    assert "User prefers bun over npm" in contents
+
+
+@pytest.mark.asyncio
+async def test_extract_503_when_not_configured(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+):
+    """503 with a clear hint when the deployment hasn't supplied an LLM
+    key — onboarding skill watches for this to skip the step cleanly."""
+    from app.core.config import settings as app_settings
+
+    monkeypatch.setattr(app_settings, "llm_api_key", "")
+
+    local_id = "sess-extract-noconf"
+    await _seed_session_with_content(client, local_id)
+
+    r = await client.post(f"/api/sessions/{local_id}/extract")
+    assert r.status_code == 503
+    assert "not configured" in r.json()["detail"].lower()

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -30,14 +30,109 @@ async def test_skill_upload_happy_path(client: httpx.AsyncClient):
     assert body["file_count"] == 1
     assert body["version"] == 1
 
-    # Re-uploading bumps version rather than creating a duplicate row.
+    # Re-uploading IDENTICAL bytes is a no-op — same version, no duplicate row.
+    # See test_skill_upload_changed_content_bumps_version below for the
+    # bump-on-real-change case.
     r2 = await client.post("/api/skills/upload", data={"skill_key": "hello"}, files=files)
     assert r2.status_code == 200, r2.text
-    assert r2.json()["version"] == 2
+    assert r2.json()["version"] == 1, "identical re-upload must not bump version"
 
     # Detail endpoint returns the SKILL.md content extracted on the server.
     detail = (await client.get("/api/skills/hello")).json()
     assert "# Hello" in (detail["content"] or "")
+
+
+@pytest.mark.asyncio
+async def test_skill_upload_unchanged_does_not_bump_version(client: httpx.AsyncClient):
+    """A re-upload of byte-identical content must not bump `version` or
+    `updated_at`. The dashboard would otherwise inflate version numbers
+    on every push from every machine, regardless of whether anything
+    actually changed."""
+    import asyncio
+
+    content = "---\nname: stable\ndescription: stable skill\n---\n# Stable\n"
+    tar_bytes, _ = tar_from_content("stable", content)
+    files = {"file": ("stable.tar.gz", tar_bytes, "application/gzip")}
+
+    first = await client.post("/api/skills/upload", data={"skill_key": "stable"}, files=files)
+    assert first.json()["version"] == 1
+    first_updated_at = (await client.get("/api/skills/stable")).json().get("updated_at")
+    # Detail endpoint may or may not surface updated_at; if not, fall back
+    # to listing.
+    if first_updated_at is None:
+        listing = (await client.get("/api/skills")).json()
+        first_updated_at = next(
+            s for s in listing["items"] if s["skill_key"] == "stable"
+        )["updated_at"]
+
+    await asyncio.sleep(0.05)
+
+    second = await client.post(
+        "/api/skills/upload", data={"skill_key": "stable"}, files=files
+    )
+    assert second.status_code == 200
+    assert second.json()["version"] == 1, "version must not bump on identical re-upload"
+
+    listing = (await client.get("/api/skills")).json()
+    after_updated_at = next(
+        s for s in listing["items"] if s["skill_key"] == "stable"
+    )["updated_at"]
+    assert after_updated_at == first_updated_at, (
+        "updated_at must not advance on identical re-upload"
+    )
+
+
+@pytest.mark.asyncio
+async def test_skill_upload_changed_content_bumps_version(client: httpx.AsyncClient):
+    """When the SKILL.md content actually changes, version goes up and
+    `updated_at` advances."""
+    v1_content = "---\nname: mut\ndescription: v1\n---\n# v1\n"
+    v1_tar, _ = tar_from_content("mut", v1_content)
+    files_v1 = {"file": ("mut.tar.gz", v1_tar, "application/gzip")}
+
+    first = await client.post("/api/skills/upload", data={"skill_key": "mut"}, files=files_v1)
+    assert first.json()["version"] == 1
+
+    v2_content = "---\nname: mut\ndescription: v2\n---\n# v2\n"
+    v2_tar, _ = tar_from_content("mut", v2_content)
+    files_v2 = {"file": ("mut.tar.gz", v2_tar, "application/gzip")}
+
+    second = await client.post(
+        "/api/skills/upload", data={"skill_key": "mut"}, files=files_v2
+    )
+    assert second.status_code == 200
+    assert second.json()["version"] == 2, "real content change must bump version"
+
+
+@pytest.mark.asyncio
+async def test_skill_upload_accepts_client_supplied_hash(client: httpx.AsyncClient):
+    """New CLIs (>= 0.3.4) compute a file-tree hash and send it as a form
+    field. Server should trust it and skip its own hashing.
+
+    Backwards-compat is exercised by `test_skill_upload_happy_path` which
+    intentionally omits the field.
+    """
+    import hashlib
+
+    content = "---\nname: hashed\ndescription: hashed skill\n---\n# Hashed\n"
+    tar_bytes, _ = tar_from_content("hashed", content)
+    files = {"file": ("hashed.tar.gz", tar_bytes, "application/gzip")}
+
+    # Send a phony hash. Server should trust it (sync optimization, not
+    # security boundary). The test verifies that two pushes with the
+    # SAME phony hash skip the bump — proving the field actually got used.
+    fake_hash = hashlib.sha256(b"client-says-this").hexdigest()
+    data = {"skill_key": "hashed", "content_hash": fake_hash}
+
+    first = await client.post("/api/skills/upload", data=data, files=files)
+    assert first.status_code == 200, first.text
+    assert first.json()["version"] == 1
+
+    second = await client.post("/api/skills/upload", data=data, files=files)
+    assert second.status_code == 200, second.text
+    assert second.json()["version"] == 1, (
+        "second push with same client-supplied hash must skip the bump"
+    )
 
 
 @pytest.mark.asyncio

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.3.3",
+	"version": "0.4.0",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/adapters/base.ts
+++ b/packages/cli/src/adapters/base.ts
@@ -22,6 +22,24 @@ export interface RawSession {
 	summary: string | null;
 	messages: SessionMessage[];
 	rawFilePath: string;
+	// Set by `pushOneAgent` after collection — sha256 hex of the JSON
+	// the CLI is about to upload. Adapters do not populate this.
+	contentHash?: string;
+}
+
+/**
+ * Options for `AgentAdapter.collectSessions`.
+ *
+ * `projectFilter` restricts to sessions whose stored `cwd` / project path
+ * equals or is under the given absolute path. Hermes ignores this — its
+ * data model has no project linkage.
+ *
+ * Adapters always do a full scan and return every session that matches
+ * the project filter. Whether to actually push a session to the server
+ * is decided in `pushOneAgent` against `~/.clawdi/sessions-lock.json`.
+ */
+export interface CollectSessionsOptions {
+	projectFilter?: string;
 }
 
 export interface RawSkill {
@@ -39,7 +57,7 @@ export interface AgentAdapter {
 	detect(): Promise<boolean>;
 	getVersion(): Promise<string | null>;
 
-	collectSessions(since?: Date, projectFilter?: string): Promise<RawSession[]>;
+	collectSessions(opts?: CollectSessionsOptions): Promise<RawSession[]>;
 	collectSkills(): Promise<RawSkill[]>;
 
 	getSkillPath(key: string): string;

--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -1,7 +1,13 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { basename, join } from "node:path";
 import { extractTarGz } from "../lib/tar";
-import type { AgentAdapter, RawSession, RawSkill, SessionMessage } from "./base";
+import type {
+	AgentAdapter,
+	CollectSessionsOptions,
+	RawSession,
+	RawSkill,
+	SessionMessage,
+} from "./base";
 import { getClaudeHome, SKIP_DIRS } from "./paths";
 
 function claudeDir() {
@@ -68,8 +74,10 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 		return absPath.replace(/\//g, "-");
 	}
 
-	async collectSessions(since?: Date, projectFilter?: string): Promise<RawSession[]> {
+	async collectSessions(opts: CollectSessionsOptions = {}): Promise<RawSession[]> {
 		if (!existsSync(projectsDir())) return [];
+
+		const { projectFilter } = opts;
 
 		const sessions: RawSession[] = [];
 		let projectDirs = readdirSync(projectsDir(), { withFileTypes: true }).filter((d) =>
@@ -102,8 +110,6 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 				try {
 					const parsed = this.parseSessionJsonl(filePath, projectDir.name);
 					if (!parsed) continue;
-
-					if (since && parsed.startedAt < since) continue;
 
 					if (absFilter) {
 						const cwd = parsed.projectPath;

--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -242,6 +242,12 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 		for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
 			if (!entry.isDirectory()) continue;
 			if (SKIP_DIRS.has(entry.name)) continue;
+			// Bundled by `clawdi setup` — not user-authored content. Without
+			// this filter every user's `clawdi push --modules skills` would
+			// upload the bundled skill to their cloud account, and pulling
+			// on another machine would re-download it on top of what
+			// `clawdi setup` already installs there.
+			if (entry.name === "clawdi") continue;
 			const dirPath = join(skillsDir, entry.name);
 			const skillMd = join(dirPath, "SKILL.md");
 			if (!existsSync(skillMd)) continue;

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -1,15 +1,13 @@
-import {
-	type Dirent,
-	existsSync,
-	mkdirSync,
-	readdirSync,
-	readFileSync,
-	rmSync,
-	statSync,
-} from "node:fs";
+import { type Dirent, existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { extractTarGz } from "../lib/tar";
-import type { AgentAdapter, RawSession, RawSkill, SessionMessage } from "./base";
+import type {
+	AgentAdapter,
+	CollectSessionsOptions,
+	RawSession,
+	RawSkill,
+	SessionMessage,
+} from "./base";
 import { getCodexHome, SKIP_DIRS } from "./paths";
 
 function codexDir() {
@@ -56,14 +54,13 @@ function extractMessageText(content: unknown): string {
 		.join("\n");
 }
 
-function collectJsonlFiles(root: string, since?: Date): string[] {
+function collectJsonlFiles(root: string): string[] {
 	const results: string[] = [];
 	if (!existsSync(root)) return results;
 
-	const sinceTime = since?.getTime() ?? 0;
-
-	// Directory layout: YYYY/MM/DD/rollout-*.jsonl. Walk lexicographically so the
-	// since cursor can prune whole day directories cheaply.
+	// Directory layout: YYYY/MM/DD/rollout-*.jsonl. Full walk every push —
+	// the content-hash cache in `lib/sessions-lock.ts` decides which files
+	// to actually upload, so there's no point pruning at the FS level.
 	const walk = (dir: string) => {
 		let entries: Dirent[];
 		try {
@@ -78,14 +75,6 @@ function collectJsonlFiles(root: string, since?: Date): string[] {
 			if (entry.isDirectory()) {
 				walk(full);
 			} else if (entry.isFile() && entry.name.endsWith(".jsonl")) {
-				if (since) {
-					try {
-						const stats = statSync(full);
-						if (stats.mtimeMs < sinceTime) continue;
-					} catch {
-						// fall through — include the file
-					}
-				}
 				results.push(full);
 			}
 		}
@@ -116,8 +105,10 @@ export class CodexAdapter implements AgentAdapter {
 		}
 	}
 
-	async collectSessions(since?: Date, projectFilter?: string): Promise<RawSession[]> {
+	async collectSessions(opts: CollectSessionsOptions = {}): Promise<RawSession[]> {
 		if (!existsSync(sessionsDir())) return [];
+
+		const { projectFilter } = opts;
 
 		let absFilter: string | null = null;
 		if (projectFilter) {
@@ -125,7 +116,7 @@ export class CodexAdapter implements AgentAdapter {
 			absFilter = resolve(projectFilter);
 		}
 
-		const files = collectJsonlFiles(sessionsDir(), since);
+		const files = collectJsonlFiles(sessionsDir());
 		const sessions: RawSession[] = [];
 
 		for (const filePath of files) {
@@ -207,8 +198,6 @@ export class CodexAdapter implements AgentAdapter {
 			}
 
 			if (!sessionId || messages.length === 0 || !startedAt) continue;
-
-			if (since && startedAt < since) continue;
 
 			if (absFilter) {
 				if (!projectPath) continue;

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -242,6 +242,9 @@ export class CodexAdapter implements AgentAdapter {
 			// Skip dot-dirs (e.g. `.system/` holds Codex's built-in skills, not user-authored ones).
 			if (entry.name.startsWith(".")) continue;
 			if (SKIP_DIRS.has(entry.name)) continue;
+			// Bundled by `clawdi setup`, not user-authored. See claude-code.ts
+			// for the full reasoning.
+			if (entry.name === "clawdi") continue;
 			const dirPath = join(skillsDir(), entry.name);
 			const skillMd = join(dirPath, "SKILL.md");
 			if (!existsSync(skillMd)) continue;

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -207,6 +207,11 @@ export class HermesAdapter implements AgentAdapter {
 		for (const entry of readdirSync(dir, { withFileTypes: true })) {
 			if (!entry.isDirectory()) continue;
 			if (SKIP_DIRS.has(entry.name)) continue;
+			// Bundled by `clawdi setup`, not user-authored. See claude-code.ts
+			// for the full reasoning. Hermes only filters at the top level
+			// — nested skills with the literal name "clawdi" deeper in the
+			// tree are an unlikely edge case not worth handling.
+			if (dir === skillsDir() && entry.name === "clawdi") continue;
 			const fullPath = join(dir, entry.name);
 			const skillMd = join(fullPath, "SKILL.md");
 

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -1,7 +1,13 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { join, relative } from "node:path";
 import { extractTarGz } from "../lib/tar";
-import type { AgentAdapter, RawSession, RawSkill, SessionMessage } from "./base";
+import type {
+	AgentAdapter,
+	CollectSessionsOptions,
+	RawSession,
+	RawSkill,
+	SessionMessage,
+} from "./base";
 import { getHermesHome, SKIP_DIRS } from "./paths";
 
 /**
@@ -86,13 +92,15 @@ export class HermesAdapter implements AgentAdapter {
 		}
 	}
 
-	async collectSessions(since?: Date, _projectFilter?: string): Promise<RawSession[]> {
+	async collectSessions(_opts: CollectSessionsOptions = {}): Promise<RawSession[]> {
+		// Hermes' SQLite is a single file with no per-row stat info, so we
+		// always scan the whole `sessions` table. Cost is negligible
+		// (dozens to hundreds of rows). `projectFilter` has no analogue
+		// in Hermes' data model and is silently ignored.
 		if (!existsSync(stateDbPath())) return [];
 
 		const db = await openHermesDb(stateDbPath());
 		try {
-			const sinceEpoch = since ? since.getTime() / 1000 : 0;
-
 			interface SessionRow {
 				id: string;
 				source: string | null;
@@ -116,10 +124,9 @@ export class HermesAdapter implements AgentAdapter {
 					SELECT id, source, model, title, started_at, ended_at,
 					       message_count, input_tokens, output_tokens, cache_read_tokens
 					FROM sessions
-					WHERE started_at >= ?
 					ORDER BY started_at DESC
 				`)
-				.all(sinceEpoch) as SessionRow[];
+				.all() as SessionRow[];
 
 			const msgStmt = db.prepare(`
 				SELECT role, content, timestamp

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -314,6 +314,9 @@ export class OpenClawAdapter implements AgentAdapter {
 			for (const entry of readdirSync(dir, { withFileTypes: true })) {
 				if (!entry.isDirectory()) continue;
 				if (SKIP_DIRS.has(entry.name)) continue;
+				// Bundled by `clawdi setup`, not user-authored. See claude-code.ts
+				// for the full reasoning.
+				if (entry.name === "clawdi") continue;
 				const dirPath = join(dir, entry.name);
 				const skillMd = join(dirPath, "SKILL.md");
 				if (!existsSync(skillMd)) continue;

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -1,7 +1,13 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { isAbsolute, join } from "node:path";
 import { extractTarGz } from "../lib/tar";
-import type { AgentAdapter, RawSession, RawSkill, SessionMessage } from "./base";
+import type {
+	AgentAdapter,
+	CollectSessionsOptions,
+	RawSession,
+	RawSkill,
+	SessionMessage,
+} from "./base";
 import { getOpenClawHome, SKIP_DIRS } from "./paths";
 
 function openclawDir() {
@@ -145,11 +151,11 @@ export class OpenClawAdapter implements AgentAdapter {
 		}
 	}
 
-	async collectSessions(since?: Date, projectFilter?: string): Promise<RawSession[]> {
+	async collectSessions(opts: CollectSessionsOptions = {}): Promise<RawSession[]> {
 		const agentDirs = listAgentDirs();
 		if (agentDirs.length === 0) return [];
 
-		const sinceMs = since?.getTime() ?? 0;
+		const { projectFilter } = opts;
 		let absFilter: string | null = null;
 		if (projectFilter) {
 			const { resolve } = await import("node:path");
@@ -177,7 +183,6 @@ export class OpenClawAdapter implements AgentAdapter {
 				const sessionId = entry.sessionId ?? indexKey;
 				const updatedAt = entry.updatedAt ?? entry.acp?.lastActivityAt;
 				if (!updatedAt) continue;
-				if (updatedAt < sinceMs) continue;
 
 				const projectPath = entry.acp?.cwd ?? null;
 				if (absFilter) {

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -1,21 +1,30 @@
-import { existsSync } from "node:fs";
-import { dirname } from "node:path";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import * as p from "@clack/prompts";
 import chalk from "chalk";
-import { adapterRegistry } from "../adapters/registry";
+import { type AgentType, adapterRegistry } from "../adapters/registry";
 import { ApiClient, unwrap } from "../lib/api-client";
-import type { SkillSummary } from "../lib/api-schemas";
-import { isLoggedIn } from "../lib/config";
+import type { SessionListItem, SkillSummary } from "../lib/api-schemas";
+import { getClawdiDir, isLoggedIn } from "../lib/config";
 import { errMessage } from "../lib/errors";
 import { askMulti, askYesNo, parseModules } from "../lib/prompts";
 import { sanitizeMetadata } from "../lib/sanitize";
-import { selectAdapter } from "../lib/select-adapter";
+import { adapterForType, resolveTargetAgentTypes } from "../lib/select-adapter";
 
 const DOWN_MODULES = [
 	{ value: "skills", label: "Skills", hint: "pull skill archives to agent directories" },
+	{ value: "sessions", label: "Sessions", hint: "mirror cloud sessions to ~/.clawdi/sessions/" },
 ];
 
-export async function pull(opts: { modules?: string; dryRun?: boolean; agent?: string }) {
+interface PullOpts {
+	modules?: string;
+	dryRun?: boolean;
+	agent?: string;
+	allAgents?: boolean;
+	yes?: boolean;
+}
+
+export async function pull(opts: PullOpts) {
 	p.intro(chalk.bold("clawdi pull"));
 
 	if (!isLoggedIn()) {
@@ -25,8 +34,8 @@ export async function pull(opts: { modules?: string; dryRun?: boolean; agent?: s
 		return;
 	}
 
-	const adapter = await selectAdapter(opts.agent);
-	if (!adapter) {
+	const targetTypes = await resolveTargetAgentTypes(opts.agent, !!opts.allAgents);
+	if (targetTypes.length === 0) {
 		p.outro(chalk.red("Aborted."));
 		process.exitCode = 1;
 		return;
@@ -50,51 +59,77 @@ export async function pull(opts: { modules?: string; dryRun?: boolean; agent?: s
 		return;
 	}
 
-	p.log.info(`Agent:   ${adapterRegistry[adapter.agentType].displayName}`);
-	p.log.info(`Modules: ${modules.join(", ")}`);
+	if (targetTypes.length > 1) {
+		p.log.info(`Targets: ${targetTypes.map((t) => adapterRegistry[t].displayName).join(", ")}`);
+	}
 
+	const totals = { skills: 0, sessionsNew: 0, sessionsUpdated: 0, sessionsUnchanged: 0 };
 	const api = new ApiClient();
 
-	let cloudSkills: SkillSummary[] = [];
+	for (const agentType of targetTypes) {
+		if (targetTypes.length > 1) {
+			p.log.step(chalk.bold(`▶ ${adapterRegistry[agentType].displayName}`));
+		}
 
-	const fetchSpinner = p.spinner();
-	fetchSpinner.start("Fetching from cloud...");
-	if (modules.includes("skills")) {
-		const page = unwrap(await api.GET("/api/skills", { params: { query: { page_size: 200 } } }));
-		cloudSkills = page.items;
-	}
-	fetchSpinner.stop(
-		`Found ${cloudSkills.length} skill${cloudSkills.length === 1 ? "" : "s"} in cloud`,
-	);
+		if (modules.includes("skills")) {
+			const pulled = await pullSkills(api, agentType, opts);
+			totals.skills += pulled;
+		}
 
-	if (modules.includes("skills")) {
-		const newCount = cloudSkills.filter(
-			(s) => !existsSync(adapter.getSkillPath(s.skill_key)),
-		).length;
-		const existingCount = cloudSkills.length - newCount;
-		p.log.message(chalk.gray(`${newCount} new, ${existingCount} existing`));
-	}
-
-	if (cloudSkills.length === 0) {
-		p.outro(chalk.gray("Nothing to download."));
-		return;
+		if (modules.includes("sessions")) {
+			const counts = await pullSessions(api, agentType, opts);
+			totals.sessionsNew += counts.fresh;
+			totals.sessionsUpdated += counts.updated;
+			totals.sessionsUnchanged += counts.unchanged;
+		}
 	}
 
 	if (opts.dryRun) {
 		p.outro(chalk.gray("Dry run complete."));
 		return;
 	}
-	const ok = await askYesNo("Proceed with download?");
-	if (!ok) {
-		p.outro(chalk.gray("Cancelled."));
-		return;
+
+	const parts: string[] = [];
+	if (modules.includes("skills"))
+		parts.push(`${totals.skills} skill${totals.skills === 1 ? "" : "s"}`);
+	if (modules.includes("sessions")) {
+		parts.push(
+			`${totals.sessionsNew} new sessions, ${totals.sessionsUpdated} updated, ${totals.sessionsUnchanged} unchanged`,
+		);
+	}
+	p.outro(chalk.green(`✓ Pull complete — ${parts.join(", ")}`));
+}
+
+async function pullSkills(api: ApiClient, agentType: AgentType, opts: PullOpts): Promise<number> {
+	const adapter = adapterForType(agentType);
+	if (!adapter) return 0;
+
+	const fetchSpinner = p.spinner();
+	fetchSpinner.start("Fetching skills...");
+	const page = unwrap(await api.GET("/api/skills", { params: { query: { page_size: 200 } } }));
+	const cloudSkills: SkillSummary[] = page.items;
+	fetchSpinner.stop(
+		`Found ${cloudSkills.length} skill${cloudSkills.length === 1 ? "" : "s"} in cloud`,
+	);
+
+	if (cloudSkills.length === 0) return 0;
+
+	const newCount = cloudSkills.filter((s) => !existsSync(adapter.getSkillPath(s.skill_key))).length;
+	const existingCount = cloudSkills.length - newCount;
+	p.log.message(chalk.gray(`${newCount} new, ${existingCount} existing`));
+
+	if (opts.dryRun) return 0;
+
+	if (!opts.yes) {
+		const ok = await askYesNo("Proceed with skill download?");
+		if (!ok) return 0;
 	}
 
 	let pulled = 0;
 	for (const skill of cloudSkills) {
 		const safeKey = sanitizeMetadata(skill.skill_key);
 		const dest = adapter.getSkillPath(skill.skill_key);
-		if (existsSync(dest)) {
+		if (existsSync(dest) && !opts.yes) {
 			const overwrite = await askYesNo(`${safeKey} already exists. Overwrite?`, false);
 			if (!overwrite) {
 				p.log.info(`${safeKey} skipped`);
@@ -112,5 +147,165 @@ export async function pull(opts: { modules?: string; dryRun?: boolean; agent?: s
 			p.log.warn(`${safeKey} failed: ${errMessage(e)}`);
 		}
 	}
-	p.outro(chalk.green(`✓ Pulled ${pulled} skill${pulled === 1 ? "" : "s"}`));
+	return pulled;
+}
+
+interface SessionMirrorMeta {
+	id: string;
+	local_session_id: string;
+	agent_type: string | null;
+	machine_name: string | null;
+	project_path: string | null;
+	started_at: string;
+	ended_at: string | null;
+	message_count: number;
+	model: string | null;
+	summary: string | null;
+	content_hash: string | null;
+}
+
+interface SessionPullCounts {
+	fresh: number;
+	updated: number;
+	unchanged: number;
+}
+
+async function pullSessions(
+	api: ApiClient,
+	agentType: AgentType,
+	opts: PullOpts,
+): Promise<SessionPullCounts> {
+	// Page through every session for this agent. Server side already sorts
+	// by started_at desc; order doesn't matter for our diff anyway.
+	const cloudSessions: SessionListItem[] = [];
+	const fetchSpinner = p.spinner();
+	fetchSpinner.start(`Fetching ${adapterRegistry[agentType].displayName} sessions...`);
+	let page = 1;
+	const pageSize = 200;
+	for (;;) {
+		const result = unwrap(
+			await api.GET("/api/sessions", {
+				params: { query: { agent: agentType, page, page_size: pageSize } },
+			}),
+		);
+		cloudSessions.push(...result.items);
+		if (result.items.length < pageSize) break;
+		page++;
+	}
+	fetchSpinner.stop(
+		`Found ${cloudSessions.length} session${cloudSessions.length === 1 ? "" : "s"} in cloud`,
+	);
+
+	const mirrorDir = sessionMirrorDir(agentType);
+
+	const toDownload: { remote: SessionListItem; reason: "new" | "updated" }[] = [];
+	let unchanged = 0;
+	for (const remote of cloudSessions) {
+		const sidecar = readSidecar(mirrorDir, remote.local_session_id);
+		if (!sidecar) {
+			toDownload.push({ remote, reason: "new" });
+			continue;
+		}
+		// Treat null/missing remote hash as "must download" — legacy rows
+		// pre-dating the column have no way to compare.
+		if (!remote.content_hash || sidecar.content_hash !== remote.content_hash) {
+			toDownload.push({ remote, reason: "updated" });
+			continue;
+		}
+		unchanged++;
+	}
+
+	const fresh = toDownload.filter((d) => d.reason === "new").length;
+	const updated = toDownload.length - fresh;
+	p.log.message(chalk.gray(`${fresh} new, ${updated} updated, ${unchanged} unchanged`));
+
+	if (opts.dryRun || toDownload.length === 0) {
+		return { fresh, updated, unchanged };
+	}
+
+	if (!opts.yes) {
+		const ok = await askYesNo(
+			`Download ${toDownload.length} session${toDownload.length === 1 ? "" : "s"}?`,
+		);
+		if (!ok) {
+			// Cancelled — report only what's actually in sync. The pending
+			// downloads stay pending; counting them as "unchanged" would lie.
+			return { fresh: 0, updated: 0, unchanged };
+		}
+	}
+
+	mkdirSync(mirrorDir, { recursive: true });
+
+	const dlSpinner = p.spinner();
+	dlSpinner.start(`Downloading content (0/${toDownload.length})...`);
+	let freshDone = 0;
+	let updatedDone = 0;
+	let failed = 0;
+	for (const { remote, reason } of toDownload) {
+		try {
+			const body = await api.getSessionContent(remote.id);
+			writeMirrorAtomic(mirrorDir, remote, body);
+			if (reason === "new") freshDone++;
+			else updatedDone++;
+			dlSpinner.message(`Downloading content (${freshDone + updatedDone}/${toDownload.length})...`);
+		} catch (e) {
+			failed++;
+			p.log.warn(`${remote.local_session_id} failed: ${errMessage(e)}`);
+		}
+	}
+	const done = freshDone + updatedDone;
+	dlSpinner.stop(
+		failed > 0
+			? `Downloaded ${done}, ${failed} failed`
+			: `Downloaded ${done} session${done === 1 ? "" : "s"}`,
+	);
+
+	return { fresh: freshDone, updated: updatedDone, unchanged };
+}
+
+function sessionMirrorDir(agentType: AgentType): string {
+	return join(getClawdiDir(), "sessions", agentType);
+}
+
+function readSidecar(mirrorDir: string, localSessionId: string): SessionMirrorMeta | null {
+	const path = join(mirrorDir, `${localSessionId}.meta.json`);
+	if (!existsSync(path)) return null;
+	try {
+		return JSON.parse(readFileSync(path, "utf-8")) as SessionMirrorMeta;
+	} catch {
+		// Corrupt sidecar → treat as missing, force re-download.
+		return null;
+	}
+}
+
+function writeMirrorAtomic(mirrorDir: string, remote: SessionListItem, body: Buffer) {
+	// Write to a temp path first and rename into place — keeps a half-
+	// downloaded body from leaving behind a sidecar that says "I have
+	// this, hash X" while the .json is corrupt or missing.
+	const contentPath = join(mirrorDir, `${remote.local_session_id}.json`);
+	const metaPath = join(mirrorDir, `${remote.local_session_id}.meta.json`);
+	const contentTmp = `${contentPath}.tmp`;
+	const metaTmp = `${metaPath}.tmp`;
+
+	writeFileSync(contentTmp, body, { mode: 0o600 });
+	const meta: SessionMirrorMeta = {
+		id: remote.id,
+		local_session_id: remote.local_session_id,
+		agent_type: remote.agent_type,
+		machine_name: remote.machine_name ?? null,
+		project_path: remote.project_path,
+		started_at: remote.started_at,
+		ended_at: remote.ended_at,
+		message_count: remote.message_count,
+		model: remote.model,
+		summary: remote.summary,
+		content_hash: remote.content_hash ?? null,
+	};
+	writeFileSync(metaTmp, `${JSON.stringify(meta, null, 2)}\n`, { mode: 0o600 });
+
+	// Rename content first, then meta. If we crash between the two, the
+	// next pull sees no sidecar and re-downloads — never the inverse
+	// (sidecar without content) which would falsely report "synced".
+	renameSync(contentTmp, contentPath);
+	renameSync(metaTmp, metaPath);
 }

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -10,6 +10,7 @@ import { errMessage } from "../lib/errors";
 import { askMulti, askYesNo, parseModules } from "../lib/prompts";
 import { sanitizeMetadata } from "../lib/sanitize";
 import { adapterForType, resolveTargetAgentTypes } from "../lib/select-adapter";
+import { readSkillsLock, type SkillsLock, writeSkillsLock } from "../lib/skills-lock";
 
 const DOWN_MODULES = [
 	{ value: "skills", label: "Skills", hint: "pull skill archives to agent directories" },
@@ -63,17 +64,28 @@ export async function pull(opts: PullOpts) {
 		p.log.info(`Targets: ${targetTypes.map((t) => adapterRegistry[t].displayName).join(", ")}`);
 	}
 
-	const totals = { skills: 0, sessionsNew: 0, sessionsUpdated: 0, sessionsUnchanged: 0 };
+	const totals = {
+		skills: 0,
+		skillsAlreadyInSync: 0,
+		sessionsNew: 0,
+		sessionsUpdated: 0,
+		sessionsUnchanged: 0,
+	};
 	const api = new ApiClient();
+	// Read once before the loop, mutate as we go, persist once at the end —
+	// matches the push-side pattern. Lost work on partial failure is safe
+	// (re-running a pull is idempotent: cloud diff just kicks in again).
+	const skillsLock = modules.includes("skills") ? readSkillsLock() : null;
 
 	for (const agentType of targetTypes) {
 		if (targetTypes.length > 1) {
 			p.log.step(chalk.bold(`▶ ${adapterRegistry[agentType].displayName}`));
 		}
 
-		if (modules.includes("skills")) {
-			const pulled = await pullSkills(api, agentType, opts);
-			totals.skills += pulled;
+		if (modules.includes("skills") && skillsLock) {
+			const counts = await pullSkills(api, agentType, opts, skillsLock);
+			totals.skills += counts.pulled;
+			totals.skillsAlreadyInSync += counts.alreadyInSync;
 		}
 
 		if (modules.includes("sessions")) {
@@ -84,14 +96,21 @@ export async function pull(opts: PullOpts) {
 		}
 	}
 
+	if (!opts.dryRun && skillsLock) writeSkillsLock(skillsLock);
+
 	if (opts.dryRun) {
 		p.outro(chalk.gray("Dry run complete."));
 		return;
 	}
 
 	const parts: string[] = [];
-	if (modules.includes("skills"))
-		parts.push(`${totals.skills} skill${totals.skills === 1 ? "" : "s"}`);
+	if (modules.includes("skills")) {
+		const skillsLabel =
+			totals.skillsAlreadyInSync > 0
+				? `${totals.skills} skill${totals.skills === 1 ? "" : "s"} downloaded, ${totals.skillsAlreadyInSync} already in sync`
+				: `${totals.skills} skill${totals.skills === 1 ? "" : "s"}`;
+		parts.push(skillsLabel);
+	}
 	if (modules.includes("sessions")) {
 		parts.push(
 			`${totals.sessionsNew} new sessions, ${totals.sessionsUpdated} updated, ${totals.sessionsUnchanged} unchanged`,
@@ -100,9 +119,19 @@ export async function pull(opts: PullOpts) {
 	p.outro(chalk.green(`✓ Pull complete — ${parts.join(", ")}`));
 }
 
-async function pullSkills(api: ApiClient, agentType: AgentType, opts: PullOpts): Promise<number> {
+interface SkillPullCounts {
+	pulled: number;
+	alreadyInSync: number;
+}
+
+async function pullSkills(
+	api: ApiClient,
+	agentType: AgentType,
+	opts: PullOpts,
+	skillsLock: SkillsLock,
+): Promise<SkillPullCounts> {
 	const adapter = adapterForType(agentType);
-	if (!adapter) return 0;
+	if (!adapter) return { pulled: 0, alreadyInSync: 0 };
 
 	const fetchSpinner = p.spinner();
 	fetchSpinner.start("Fetching skills...");
@@ -112,21 +141,39 @@ async function pullSkills(api: ApiClient, agentType: AgentType, opts: PullOpts):
 		`Found ${cloudSkills.length} skill${cloudSkills.length === 1 ? "" : "s"} in cloud`,
 	);
 
-	if (cloudSkills.length === 0) return 0;
+	if (cloudSkills.length === 0) return { pulled: 0, alreadyInSync: 0 };
 
-	const newCount = cloudSkills.filter((s) => !existsSync(adapter.getSkillPath(s.skill_key))).length;
-	const existingCount = cloudSkills.length - newCount;
-	p.log.message(chalk.gray(`${newCount} new, ${existingCount} existing`));
+	// Diff: a skill is "in sync" iff its cloud `content_hash` matches our
+	// cached hash AND we have a local file for it. The local-file check
+	// catches the case where the user wiped `~/.claude/skills/` but kept
+	// the lock file — we'd otherwise silently skip and never restore.
+	const toDownload: SkillSummary[] = [];
+	let alreadyInSync = 0;
+	for (const skill of cloudSkills) {
+		const cached = skillsLock.skills[skill.skill_key]?.hash;
+		const localExists = existsSync(adapter.getSkillPath(skill.skill_key));
+		if (cached && cached === skill.content_hash && localExists) {
+			alreadyInSync++;
+			continue;
+		}
+		toDownload.push(skill);
+	}
 
-	if (opts.dryRun) return 0;
+	const newCount = toDownload.filter((s) => !existsSync(adapter.getSkillPath(s.skill_key))).length;
+	const updatedCount = toDownload.length - newCount;
+	p.log.message(
+		chalk.gray(`${newCount} new, ${updatedCount} updated, ${alreadyInSync} already in sync`),
+	);
+
+	if (opts.dryRun || toDownload.length === 0) return { pulled: 0, alreadyInSync };
 
 	if (!opts.yes) {
 		const ok = await askYesNo("Proceed with skill download?");
-		if (!ok) return 0;
+		if (!ok) return { pulled: 0, alreadyInSync };
 	}
 
 	let pulled = 0;
-	for (const skill of cloudSkills) {
+	for (const skill of toDownload) {
 		const safeKey = sanitizeMetadata(skill.skill_key);
 		const dest = adapter.getSkillPath(skill.skill_key);
 		if (existsSync(dest) && !opts.yes) {
@@ -140,6 +187,7 @@ async function pullSkills(api: ApiClient, agentType: AgentType, opts: PullOpts):
 		try {
 			const tarBytes = await api.getBytes(`/api/skills/${skill.skill_key}/download`);
 			await adapter.writeSkillArchive(skill.skill_key, tarBytes);
+			skillsLock.skills[skill.skill_key] = { hash: skill.content_hash };
 			const skillDir = dirname(adapter.getSkillPath(skill.skill_key));
 			p.log.success(`${safeKey} → ${skillDir}/ (${tarBytes.length} bytes)`);
 			pulled++;
@@ -147,7 +195,7 @@ async function pullSkills(api: ApiClient, agentType: AgentType, opts: PullOpts):
 			p.log.warn(`${safeKey} failed: ${errMessage(e)}`);
 		}
 	}
-	return pulled;
+	return { pulled, alreadyInSync };
 }
 
 interface SessionMirrorMeta {

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -1,14 +1,23 @@
+import { homedir } from "node:os";
+import { resolve as resolvePath } from "node:path";
 import * as p from "@clack/prompts";
 import chalk from "chalk";
-import type { RawSession, RawSkill } from "../adapters/base";
+import type { AgentAdapter, RawSession, RawSkill } from "../adapters/base";
 import { adapterRegistry } from "../adapters/registry";
 import { ApiClient, ApiError, unwrap } from "../lib/api-client";
 import { isLoggedIn } from "../lib/config";
 import { errMessage } from "../lib/errors";
 import { askMulti, askYesNo, parseModules } from "../lib/prompts";
-import { getEnvIdByAgent, selectAdapter } from "../lib/select-adapter";
-import { readModuleState, writeModuleState } from "../lib/state";
+import { adapterForType, getEnvIdByAgent, resolveTargetAgentTypes } from "../lib/select-adapter";
+import {
+	type ModuleState,
+	readModuleState,
+	readSessionCursor,
+	writeModuleState,
+	writeSessionCursor,
+} from "../lib/state";
 import { tarSkillDir } from "../lib/tar";
+import { isInteractive } from "../lib/tty";
 
 const RESETUP_HINT =
 	"This machine's environment is no longer registered. Run `clawdi setup` again.";
@@ -18,14 +27,25 @@ const UP_MODULES = [
 	{ value: "skills", label: "Skills", hint: "skill directories as tar.gz" },
 ];
 
-export async function push(opts: {
+interface PushOpts {
 	modules?: string;
 	since?: string;
 	project?: string;
+	excludeProject?: string[];
 	all?: boolean;
+	allAgents?: boolean;
 	dryRun?: boolean;
 	agent?: string;
-}) {
+	yes?: boolean;
+}
+
+interface AgentPushResult {
+	sessionsPushed: number;
+	contentUploaded: number;
+	skillsPushed: number;
+}
+
+export async function push(opts: PushOpts) {
 	p.intro(chalk.bold("clawdi push"));
 
 	if (!opts.dryRun && !isLoggedIn()) {
@@ -35,53 +55,20 @@ export async function push(opts: {
 		return;
 	}
 
-	const adapter = await selectAdapter(opts.agent);
-	if (!adapter) {
+	if (opts.project && opts.excludeProject && opts.excludeProject.length > 0) {
+		p.log.error(
+			"--project and --exclude-project cannot be combined (--project is positive selection, --exclude-project is subtractive).",
+		);
 		p.outro(chalk.red("Aborted."));
 		process.exitCode = 1;
 		return;
 	}
 
-	const envId = getEnvIdByAgent(adapter.agentType);
-	if (!opts.dryRun && !envId) {
-		p.log.error("No environment registered. Run `clawdi setup` first.");
+	const targetTypes = await resolveTargetAgentTypes(opts.agent, !!opts.allAgents);
+	if (targetTypes.length === 0) {
 		p.outro(chalk.red("Aborted."));
 		process.exitCode = 1;
 		return;
-	}
-
-	// Probe the cached env_id before doing any local work. The CLI keeps a
-	// per-agent file under ~/.clawdi/environments/, but the corresponding row
-	// can disappear server-side (account switch, prod reset, env teardown).
-	// Catching that here means the user runs `clawdi setup` once and is back
-	// in business — instead of pushing 60 sessions that all show up as
-	// "Unknown" in the dashboard.
-	if (!opts.dryRun && envId) {
-		const probe = new ApiClient();
-		try {
-			const res = await probe.GET("/api/environments/{environment_id}", {
-				params: { path: { environment_id: envId } },
-			});
-			if (res.error || !res.data) {
-				const status = res.response?.status ?? 0;
-				if (status === 404) {
-					p.log.error(RESETUP_HINT);
-					p.outro(chalk.red("Aborted."));
-					process.exitCode = 1;
-					return;
-				}
-				// Anything else (401, network, 5xx) — let the actual upload bubble
-				// up the proper error; don't double-report here.
-			}
-		} catch (e) {
-			if (e instanceof ApiError && e.status === 404) {
-				p.log.error(RESETUP_HINT);
-				p.outro(chalk.red("Aborted."));
-				process.exitCode = 1;
-				return;
-			}
-			// Same reasoning as above — fall through and let upload surface it.
-		}
 	}
 
 	let modules: string[];
@@ -102,22 +89,113 @@ export async function push(opts: {
 		return;
 	}
 
-	p.log.info(`Agent:   ${adapterRegistry[adapter.agentType].displayName}`);
-	p.log.info(`Modules: ${modules.join(", ")}`);
+	if (targetTypes.length > 1) {
+		p.log.info(`Targets: ${targetTypes.map((t) => adapterRegistry[t].displayName).join(", ")}`);
+	}
 
-	// 2. Scan data
 	const moduleState = readModuleState();
-	const sinceSource: "flag" | "state" | "none" = opts.since
-		? "flag"
-		: moduleState.sessions?.lastActivityAt
-			? "state"
-			: "none";
-	const since = opts.since
-		? new Date(opts.since)
-		: moduleState.sessions?.lastActivityAt
-			? new Date(moduleState.sessions.lastActivityAt)
-			: undefined;
+	const totals = { sessions: 0, content: 0, skills: 0 };
+	let aborted = false;
+
+	for (const agentType of targetTypes) {
+		const adapter = adapterForType(agentType);
+		if (!adapter) continue;
+		if (targetTypes.length > 1) {
+			p.log.step(chalk.bold(`▶ ${adapterRegistry[agentType].displayName}`));
+		}
+		const result = await pushOneAgent(adapter, modules, opts, moduleState);
+		if (result === "aborted") {
+			aborted = true;
+			break;
+		}
+		if (result === "skipped") continue;
+		totals.sessions += result.sessionsPushed;
+		totals.content += result.contentUploaded;
+		totals.skills += result.skillsPushed;
+	}
+
+	if (!opts.dryRun) writeModuleState(moduleState);
+
+	if (aborted) {
+		p.outro(chalk.red("Aborted."));
+		process.exitCode = 1;
+		return;
+	}
+
+	if (opts.dryRun) {
+		p.outro(chalk.gray("Dry run complete."));
+		return;
+	}
+
+	const parts: string[] = [];
+	if (modules.includes("sessions")) {
+		parts.push(`${totals.sessions} session${totals.sessions === 1 ? "" : "s"}`);
+		parts.push(`${totals.content} content blob${totals.content === 1 ? "" : "s"}`);
+	}
+	if (modules.includes("skills")) {
+		parts.push(`${totals.skills} skill${totals.skills === 1 ? "" : "s"}`);
+	}
+	parts.push(`across ${targetTypes.length} agent${targetTypes.length === 1 ? "" : "s"}`);
+	p.outro(chalk.green(`✓ Push complete — ${parts.join(", ")}`));
+}
+
+async function pushOneAgent(
+	adapter: AgentAdapter,
+	modules: string[],
+	opts: PushOpts,
+	moduleState: ModuleState,
+): Promise<AgentPushResult | "aborted" | "skipped"> {
+	const agentType = adapter.agentType;
+	const envId = getEnvIdByAgent(agentType);
+
+	if (!opts.dryRun && !envId) {
+		p.log.error(
+			`No environment registered for ${adapterRegistry[agentType].displayName}. Run \`clawdi setup\` first.`,
+		);
+		return "aborted";
+	}
+
+	// Probe the cached env_id before doing any local work. The CLI keeps a
+	// per-agent file under ~/.clawdi/environments/, but the corresponding row
+	// can disappear server-side (account switch, prod reset, env teardown).
+	// Catching that here means the user runs `clawdi setup` once and is back
+	// in business — instead of pushing 60 sessions that all show up as
+	// "Unknown" in the dashboard.
+	if (!opts.dryRun && envId) {
+		const probe = new ApiClient();
+		try {
+			const res = await probe.GET("/api/environments/{environment_id}", {
+				params: { path: { environment_id: envId } },
+			});
+			if (res.error || !res.data) {
+				const status = res.response?.status ?? 0;
+				if (status === 404) {
+					p.log.error(RESETUP_HINT);
+					return "aborted";
+				}
+				// Anything else (401, network, 5xx) — let the actual upload bubble
+				// up the proper error; don't double-report here.
+			}
+		} catch (e) {
+			if (e instanceof ApiError && e.status === 404) {
+				p.log.error(RESETUP_HINT);
+				return "aborted";
+			}
+			// Same reasoning as above — fall through and let upload surface it.
+		}
+	}
+
+	const cursorStr = readSessionCursor(moduleState, agentType);
+	const sinceSource: "flag" | "state" | "none" = opts.since ? "flag" : cursorStr ? "state" : "none";
+	const since = opts.since ? new Date(opts.since) : cursorStr ? new Date(cursorStr) : undefined;
+
+	// Project filter: explicit --all wins, then explicit --project, else cwd.
+	const usedCwdDefault = !opts.all && !opts.project;
 	const projectFilter = opts.all ? undefined : (opts.project ?? process.cwd());
+
+	const excludeSet = new Set<string>(
+		(opts.excludeProject ?? []).map((path) => normalizeProject(path)),
+	);
 
 	if (modules.includes("sessions")) {
 		const scope = projectFilter ? `project ${projectFilter}` : "all projects";
@@ -127,11 +205,7 @@ export async function push(opts: {
 		p.log.info(chalk.gray(`Scanning ${scope}, ${sinceLabel}`));
 	}
 
-	if (
-		adapter.agentType === "hermes" &&
-		modules.includes("sessions") &&
-		projectFilter !== undefined
-	) {
+	if (agentType === "hermes" && modules.includes("sessions") && projectFilter !== undefined) {
 		p.log.warn("Hermes does not support project filtering; pushing all sessions.");
 		p.log.info("Use --all to suppress this notice.");
 	}
@@ -151,15 +225,53 @@ export async function push(opts: {
 		`Scanned ${sessions.length} session${sessions.length === 1 ? "" : "s"}, ${skills.length} skill${skills.length === 1 ? "" : "s"}`,
 	);
 
-	// 3. Summary
-	if (modules.includes("sessions")) {
-		p.log.message(chalk.gray(`Sessions: ${sessions.length} to upload`));
-		if (sessions.length === 0 && projectFilter) {
+	// Apply --exclude-project after scan. Exact-equality match on normalized
+	// absolute paths — `~/work` does NOT exclude `~/work/foo` (users say what
+	// they mean; prefix-match would silently drop sibling repos).
+	if (excludeSet.size > 0 && sessions.length > 0) {
+		const before = sessions.length;
+		const matchedExcludes = new Set<string>();
+		sessions = sessions.filter((s) => {
+			if (!s.projectPath) return true;
+			const normalized = normalizeProject(s.projectPath);
+			if (excludeSet.has(normalized)) {
+				matchedExcludes.add(normalized);
+				return false;
+			}
+			return true;
+		});
+		const removed = before - sessions.length;
+		if (removed > 0) {
 			p.log.info(
 				chalk.gray(
-					"No sessions matched. Try --all to scan every project, or --since <date> to override the last-push cutoff.",
+					`Excluded ${removed} session${removed === 1 ? "" : "s"} from ${matchedExcludes.size} project${matchedExcludes.size === 1 ? "" : "s"}`,
 				),
 			);
+		}
+		for (const requested of excludeSet) {
+			if (!matchedExcludes.has(requested)) {
+				p.log.warn(`--exclude-project ${requested} did not match any local sessions; ignoring`);
+			}
+		}
+	}
+
+	if (modules.includes("sessions")) {
+		p.log.message(chalk.gray(`Sessions: ${sessions.length} to upload`));
+		if (sessions.length === 0) {
+			const isFirstRun = !readSessionCursor(moduleState, agentType);
+			if (usedCwdDefault && isFirstRun && !isInteractive()) {
+				p.log.info(
+					chalk.gray(
+						`No sessions matched in ${process.cwd()}. This looks like a first run — re-run with --all to scan every project, or pass --project <abs-path> if your sessions live elsewhere.`,
+					),
+				);
+			} else if (projectFilter) {
+				p.log.info(
+					chalk.gray(
+						"No sessions matched. Try --all to scan every project, or --since <date> to override the last-push cutoff.",
+					),
+				);
+			}
 		}
 	}
 	if (modules.includes("skills")) {
@@ -167,28 +279,40 @@ export async function push(opts: {
 	}
 
 	if (sessions.length === 0 && skills.length === 0) {
-		p.outro(chalk.gray("Nothing to push."));
-		return;
+		if (excludeSet.size > 0 && modules.includes("sessions")) {
+			p.log.message(chalk.gray("Nothing left to push after exclusions."));
+		}
+		return "skipped";
 	}
 
-	// 4. Confirm
 	if (opts.dryRun) {
-		p.outro(chalk.gray("Dry run complete."));
-		return;
-	}
-	const ok = await askYesNo("Proceed with upload?");
-	if (!ok) {
-		p.outro(chalk.gray("Cancelled."));
-		return;
+		return {
+			sessionsPushed: sessions.length,
+			contentUploaded: sessions.length,
+			skillsPushed: skills.length,
+		};
 	}
 
-	// 5. Execute — `envId` was guarded against null up-front, but the narrowing
-	// is gone by now. Re-check so TS can forward it into the batch body.
+	// `--yes` skips the confirmation. `askYesNo` already returns true in
+	// non-interactive contexts (CI / agent), so explicit `--yes` is mostly
+	// a no-op in those, but keeps the skill's command line self-documenting.
+	if (!opts.yes) {
+		const ok = await askYesNo("Proceed with upload?");
+		if (!ok) {
+			p.log.info(chalk.gray("Cancelled."));
+			return "skipped";
+		}
+	}
+
 	if (!envId) {
 		p.log.error("Environment id missing — rerun `clawdi setup`.");
-		return;
+		return "aborted";
 	}
+
 	const api = new ApiClient();
+	let sessionsPushed = 0;
+	let contentUploaded = 0;
+	let skillsPushed = 0;
 
 	if (sessions.length > 0) {
 		const sessionSpinner = p.spinner();
@@ -219,18 +343,20 @@ export async function push(opts: {
 				}),
 			);
 			sessionSpinner.stop(`Pushed ${result.synced} session${result.synced === 1 ? "" : "s"}`);
+			sessionsPushed = result.synced;
 
 			if (result.synced > 0) {
 				const contentSpinner = p.spinner();
 				contentSpinner.start("Uploading session content...");
-				let uploaded = 0;
 				for (const s of sessions) {
 					if (s.messages.length === 0) continue;
 					try {
 						const content = Buffer.from(JSON.stringify(s.messages), "utf-8");
 						await api.uploadSessionContent(s.localSessionId, content, `${s.localSessionId}.json`);
-						uploaded++;
-						contentSpinner.message(`Uploading session content (${uploaded}/${result.synced})...`);
+						contentUploaded++;
+						contentSpinner.message(
+							`Uploading session content (${contentUploaded}/${result.synced})...`,
+						);
 					} catch (e) {
 						// Content upload is best-effort — the session header was
 						// already committed in the batch POST above. Surface the
@@ -239,11 +365,11 @@ export async function push(opts: {
 						p.log.warn(`Content upload skipped for ${s.localSessionId}: ${errMessage(e)}`);
 					}
 				}
-				contentSpinner.stop(`Uploaded ${uploaded} session content${uploaded === 1 ? "" : "s"}`);
+				contentSpinner.stop(
+					`Uploaded ${contentUploaded} session content${contentUploaded === 1 ? "" : "s"}`,
+				);
 			}
 		} catch (e) {
-			// Stop the spinner with a plain "failed" message — handleError
-			// will render the final red error box, so we avoid double-red.
 			sessionSpinner.stop("Session upload failed.");
 			// Translate the backend's "unknown_environment" 400 into the same
 			// re-setup hint the up-front probe uses. The probe catches the
@@ -251,13 +377,11 @@ export async function push(opts: {
 			// between probe and batch.
 			if (e instanceof ApiError && e.status === 400 && e.body.includes("unknown_environment")) {
 				p.log.error(RESETUP_HINT);
-				p.outro(chalk.red("Aborted."));
-				process.exitCode = 1;
-				return;
+				return "aborted";
 			}
 			throw e;
 		}
-		moduleState.sessions = { lastActivityAt: new Date().toISOString() };
+		writeSessionCursor(moduleState, agentType, new Date().toISOString());
 	}
 
 	if (skills.length > 0) {
@@ -293,14 +417,15 @@ export async function push(opts: {
 				}
 				skillSpinner.message(`Uploading skills (${pushed + skipped.length}/${skills.length})...`);
 			}
-			const parts = [`Pushed ${pushed} skill${pushed === 1 ? "" : "s"}`];
+			const summary = [`Pushed ${pushed} skill${pushed === 1 ? "" : "s"}`];
 			if (skipped.length > 0) {
-				parts.push(`skipped ${skipped.length} (too large)`);
+				summary.push(`skipped ${skipped.length} (too large)`);
 			}
-			skillSpinner.stop(parts.join(", "));
+			skillSpinner.stop(summary.join(", "));
 			for (const s of skipped) {
 				p.log.warn(`Skipped ${s.key} — ${s.reason}`);
 			}
+			skillsPushed = pushed;
 		} catch (e) {
 			skillSpinner.stop(`Failed after ${pushed} skill${pushed === 1 ? "" : "s"}.`);
 			throw e;
@@ -308,6 +433,15 @@ export async function push(opts: {
 		moduleState.skills = { lastActivityAt: new Date().toISOString() };
 	}
 
-	writeModuleState(moduleState);
-	p.outro(chalk.green("✓ Push complete"));
+	return { sessionsPushed, contentUploaded, skillsPushed };
+}
+
+function normalizeProject(input: string): string {
+	// Expand `~` ourselves — `path.resolve` doesn't do tilde expansion, so a
+	// shell-less caller (e.g. an agent invoking the CLI directly) that passes
+	// `~/scratch` would otherwise get `<cwd>/~/scratch`, which never matches.
+	let expanded = input;
+	if (expanded === "~") expanded = homedir();
+	else if (expanded.startsWith("~/")) expanded = `${homedir()}${expanded.slice(1)}`;
+	return resolvePath(expanded);
 }

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -7,15 +7,16 @@ import { adapterRegistry } from "../adapters/registry";
 import { ApiClient, ApiError, unwrap } from "../lib/api-client";
 import { isLoggedIn } from "../lib/config";
 import { errMessage } from "../lib/errors";
+import { sha256Hex } from "../lib/hash";
 import { askMulti, askYesNo, parseModules } from "../lib/prompts";
 import { adapterForType, getEnvIdByAgent, resolveTargetAgentTypes } from "../lib/select-adapter";
 import {
-	type ModuleState,
-	readModuleState,
-	readSessionCursor,
-	writeModuleState,
-	writeSessionCursor,
-} from "../lib/state";
+	cacheKey,
+	readSessionsLock,
+	type SessionsLock,
+	writeSessionsLock,
+} from "../lib/sessions-lock";
+import { type ModuleState, readModuleState, writeModuleState } from "../lib/state";
 import { tarSkillDir } from "../lib/tar";
 import { isInteractive } from "../lib/tty";
 
@@ -29,7 +30,6 @@ const UP_MODULES = [
 
 interface PushOpts {
 	modules?: string;
-	since?: string;
 	project?: string;
 	excludeProject?: string[];
 	all?: boolean;
@@ -40,7 +40,10 @@ interface PushOpts {
 }
 
 interface AgentPushResult {
-	sessionsPushed: number;
+	sessionsCacheSkipped: number;
+	sessionsCreated: number;
+	sessionsUpdated: number;
+	sessionsUnchanged: number;
 	contentUploaded: number;
 	skillsPushed: number;
 }
@@ -94,7 +97,15 @@ export async function push(opts: PushOpts) {
 	}
 
 	const moduleState = readModuleState();
-	const totals = { sessions: 0, content: 0, skills: 0 };
+	const sessionsLock = readSessionsLock();
+	const totals = {
+		cacheSkipped: 0,
+		created: 0,
+		updated: 0,
+		unchanged: 0,
+		content: 0,
+		skills: 0,
+	};
 	let aborted = false;
 
 	for (const agentType of targetTypes) {
@@ -103,18 +114,27 @@ export async function push(opts: PushOpts) {
 		if (targetTypes.length > 1) {
 			p.log.step(chalk.bold(`▶ ${adapterRegistry[agentType].displayName}`));
 		}
-		const result = await pushOneAgent(adapter, modules, opts, moduleState);
+		const result = await pushOneAgent(adapter, modules, opts, moduleState, sessionsLock);
 		if (result === "aborted") {
 			aborted = true;
 			break;
 		}
 		if (result === "skipped") continue;
-		totals.sessions += result.sessionsPushed;
+		totals.cacheSkipped += result.sessionsCacheSkipped;
+		totals.created += result.sessionsCreated;
+		totals.updated += result.sessionsUpdated;
+		totals.unchanged += result.sessionsUnchanged;
 		totals.content += result.contentUploaded;
 		totals.skills += result.skillsPushed;
 	}
 
-	if (!opts.dryRun) writeModuleState(moduleState);
+	if (!opts.dryRun) {
+		writeModuleState(moduleState);
+		// Persist content-hash cache once per push command, even if the
+		// loop aborted partway — entries we mutated for successful agents
+		// are still valid and would otherwise be lost on the next push.
+		writeSessionsLock(sessionsLock);
+	}
 
 	if (aborted) {
 		p.outro(chalk.red("Aborted."));
@@ -129,8 +149,13 @@ export async function push(opts: PushOpts) {
 
 	const parts: string[] = [];
 	if (modules.includes("sessions")) {
-		parts.push(`${totals.sessions} session${totals.sessions === 1 ? "" : "s"}`);
-		parts.push(`${totals.content} content blob${totals.content === 1 ? "" : "s"}`);
+		// Merge `cacheSkipped` into `unchanged` for display — they mean the
+		// same thing to the user ("this session didn't need any work"). The
+		// distinction (client cache hit vs. server hash match) is purely an
+		// internal perf metric and only confuses non-technical users.
+		const unchangedTotal = totals.cacheSkipped + totals.unchanged;
+		parts.push(`${totals.created} new, ${totals.updated} updated, ${unchangedTotal} unchanged`);
+		parts.push(`${totals.content} content upload${totals.content === 1 ? "" : "s"}`);
 	}
 	if (modules.includes("skills")) {
 		parts.push(`${totals.skills} skill${totals.skills === 1 ? "" : "s"}`);
@@ -144,6 +169,7 @@ async function pushOneAgent(
 	modules: string[],
 	opts: PushOpts,
 	moduleState: ModuleState,
+	sessionsLock: SessionsLock,
 ): Promise<AgentPushResult | "aborted" | "skipped"> {
 	const agentType = adapter.agentType;
 	const envId = getEnvIdByAgent(agentType);
@@ -185,10 +211,6 @@ async function pushOneAgent(
 		}
 	}
 
-	const cursorStr = readSessionCursor(moduleState, agentType);
-	const sinceSource: "flag" | "state" | "none" = opts.since ? "flag" : cursorStr ? "state" : "none";
-	const since = opts.since ? new Date(opts.since) : cursorStr ? new Date(cursorStr) : undefined;
-
 	// Project filter: explicit --all wins, then explicit --project, else cwd.
 	const usedCwdDefault = !opts.all && !opts.project;
 	const projectFilter = opts.all ? undefined : (opts.project ?? process.cwd());
@@ -199,10 +221,7 @@ async function pushOneAgent(
 
 	if (modules.includes("sessions")) {
 		const scope = projectFilter ? `project ${projectFilter}` : "all projects";
-		const sinceLabel = since
-			? `since ${since.toISOString()}${sinceSource === "state" ? " (from last push)" : ""}`
-			: "no since cutoff";
-		p.log.info(chalk.gray(`Scanning ${scope}, ${sinceLabel}`));
+		p.log.info(chalk.gray(`Scanning ${scope}`));
 	}
 
 	if (agentType === "hermes" && modules.includes("sessions") && projectFilter !== undefined) {
@@ -216,7 +235,7 @@ async function pushOneAgent(
 	const scanSpinner = p.spinner();
 	scanSpinner.start("Scanning local data...");
 	if (modules.includes("sessions")) {
-		sessions = await adapter.collectSessions(since, projectFilter);
+		sessions = await adapter.collectSessions({ projectFilter });
 	}
 	if (modules.includes("skills")) {
 		skills = await adapter.collectSkills();
@@ -224,6 +243,13 @@ async function pushOneAgent(
 	scanSpinner.stop(
 		`Scanned ${sessions.length} session${sessions.length === 1 ? "" : "s"}, ${skills.length} skill${skills.length === 1 ? "" : "s"}`,
 	);
+
+	// Fingerprint each session's content. The server's batch endpoint
+	// compares this against the stored `content_hash` to decide whether
+	// the body needs reupload, so we hash exactly the bytes we'd send.
+	for (const s of sessions) {
+		s.contentHash = sha256Hex(JSON.stringify(s.messages));
+	}
 
 	// Apply --exclude-project after scan. Exact-equality match on normalized
 	// absolute paths — `~/work` does NOT exclude `~/work/foo` (users say what
@@ -255,10 +281,28 @@ async function pushOneAgent(
 		}
 	}
 
+	// Filter against the sessions-lock cache: any session whose hash matches
+	// the stored value can be skipped — the server already has it. This is
+	// the per-entity diff that replaces the old global mtime cursor; scope
+	// filters can't pollute it because each session has its own entry.
+	let sessionsCacheSkipped = 0;
 	if (modules.includes("sessions")) {
-		p.log.message(chalk.gray(`Sessions: ${sessions.length} to upload`));
-		if (sessions.length === 0) {
-			const isFirstRun = !readSessionCursor(moduleState, agentType);
+		const before = sessions.length;
+		sessions = sessions.filter((s) => {
+			const cached = sessionsLock.sessions[cacheKey(agentType, s.localSessionId)];
+			return cached?.hash !== s.contentHash;
+		});
+		sessionsCacheSkipped = before - sessions.length;
+	}
+
+	if (modules.includes("sessions")) {
+		const tail = sessionsCacheSkipped > 0 ? ` (${sessionsCacheSkipped} already in sync)` : "";
+		p.log.message(chalk.gray(`Sessions: ${sessions.length} to upload${tail}`));
+		if (sessions.length === 0 && sessionsCacheSkipped === 0) {
+			// Nothing scanned at all — guide first-run cwd-default users.
+			const isFirstRun = !Object.keys(sessionsLock.sessions).some((k) =>
+				k.startsWith(`${agentType}:`),
+			);
 			if (usedCwdDefault && isFirstRun && !isInteractive()) {
 				p.log.info(
 					chalk.gray(
@@ -268,7 +312,7 @@ async function pushOneAgent(
 			} else if (projectFilter) {
 				p.log.info(
 					chalk.gray(
-						"No sessions matched. Try --all to scan every project, or --since <date> to override the last-push cutoff.",
+						"No sessions matched. Try --all to scan every project, or pass --project <abs-path> for a different scope.",
 					),
 				);
 			}
@@ -279,6 +323,18 @@ async function pushOneAgent(
 	}
 
 	if (sessions.length === 0 && skills.length === 0) {
+		if (sessionsCacheSkipped > 0) {
+			// Cache covered everything. Surface the count to the top-level
+			// totals so the user sees a non-zero "skipped (cache)" number.
+			return {
+				sessionsCacheSkipped,
+				sessionsCreated: 0,
+				sessionsUpdated: 0,
+				sessionsUnchanged: 0,
+				contentUploaded: 0,
+				skillsPushed: 0,
+			};
+		}
 		if (excludeSet.size > 0 && modules.includes("sessions")) {
 			p.log.message(chalk.gray("Nothing left to push after exclusions."));
 		}
@@ -286,8 +342,13 @@ async function pushOneAgent(
 	}
 
 	if (opts.dryRun) {
+		// Dry-run reports the local scan size — we can't know which sessions
+		// the server already has without actually hitting the batch endpoint.
 		return {
-			sessionsPushed: sessions.length,
+			sessionsCacheSkipped,
+			sessionsCreated: sessions.length,
+			sessionsUpdated: 0,
+			sessionsUnchanged: 0,
 			contentUploaded: sessions.length,
 			skillsPushed: skills.length,
 		};
@@ -310,15 +371,18 @@ async function pushOneAgent(
 	}
 
 	const api = new ApiClient();
-	let sessionsPushed = 0;
+	let sessionsCreated = 0;
+	let sessionsUpdated = 0;
+	let sessionsUnchanged = 0;
 	let contentUploaded = 0;
 	let skillsPushed = 0;
 
 	if (sessions.length > 0) {
 		const sessionSpinner = p.spinner();
 		sessionSpinner.start(
-			`Uploading ${sessions.length} session${sessions.length === 1 ? "" : "s"}...`,
+			`Uploading metadata for ${sessions.length} session${sessions.length === 1 ? "" : "s"}...`,
 		);
+		let needsContent: Set<string>;
 		try {
 			const result = unwrap(
 				await api.POST("/api/sessions/batch", {
@@ -338,39 +402,20 @@ async function pushOneAgent(
 							models_used: s.modelsUsed,
 							summary: s.summary,
 							status: "completed",
+							content_hash: s.contentHash ?? null,
 						})),
 					},
 				}),
 			);
-			sessionSpinner.stop(`Pushed ${result.synced} session${result.synced === 1 ? "" : "s"}`);
-			sessionsPushed = result.synced;
-
-			if (result.synced > 0) {
-				const contentSpinner = p.spinner();
-				contentSpinner.start("Uploading session content...");
-				for (const s of sessions) {
-					if (s.messages.length === 0) continue;
-					try {
-						const content = Buffer.from(JSON.stringify(s.messages), "utf-8");
-						await api.uploadSessionContent(s.localSessionId, content, `${s.localSessionId}.json`);
-						contentUploaded++;
-						contentSpinner.message(
-							`Uploading session content (${contentUploaded}/${result.synced})...`,
-						);
-					} catch (e) {
-						// Content upload is best-effort — the session header was
-						// already committed in the batch POST above. Surface the
-						// reason so misconfigured file stores don't appear to
-						// succeed silently.
-						p.log.warn(`Content upload skipped for ${s.localSessionId}: ${errMessage(e)}`);
-					}
-				}
-				contentSpinner.stop(
-					`Uploaded ${contentUploaded} session content${contentUploaded === 1 ? "" : "s"}`,
-				);
-			}
+			needsContent = new Set(result.needs_content);
+			sessionsCreated = result.created;
+			sessionsUpdated = result.updated;
+			sessionsUnchanged = result.unchanged;
+			sessionSpinner.stop(
+				`Metadata: ${sessionsCreated} new, ${sessionsUpdated} updated, ${sessionsUnchanged} unchanged`,
+			);
 		} catch (e) {
-			sessionSpinner.stop("Session upload failed.");
+			sessionSpinner.stop("Session metadata upload failed.");
 			// Translate the backend's "unknown_environment" 400 into the same
 			// re-setup hint the up-front probe uses. The probe catches the
 			// common case; this catches a race where the env was deleted
@@ -381,7 +426,51 @@ async function pushOneAgent(
 			}
 			throw e;
 		}
-		writeSessionCursor(moduleState, agentType, new Date().toISOString());
+
+		// Track which uploads actually landed bytes on the server. Caching
+		// a hash for a session whose upload threw would be a silent footgun:
+		// next push sees cache hit → skips → server still has metadata
+		// without file_key → forever broken until cache is wiped.
+		const uploadedIds = new Set<string>();
+		if (needsContent.size > 0) {
+			const contentSpinner = p.spinner();
+			contentSpinner.start(
+				`Uploading content for ${needsContent.size} session${needsContent.size === 1 ? "" : "s"}...`,
+			);
+			for (const s of sessions) {
+				if (!needsContent.has(s.localSessionId)) continue;
+				if (s.messages.length === 0) continue;
+				try {
+					const content = Buffer.from(JSON.stringify(s.messages), "utf-8");
+					await api.uploadSessionContent(s.localSessionId, content, `${s.localSessionId}.json`);
+					uploadedIds.add(s.localSessionId);
+					contentUploaded++;
+					contentSpinner.message(`Uploading content (${contentUploaded}/${needsContent.size})...`);
+				} catch (e) {
+					// Content upload is best-effort — the metadata row was
+					// already committed in the batch POST above. Surface the
+					// reason so misconfigured file stores don't appear to
+					// succeed silently.
+					p.log.warn(`Content upload skipped for ${s.localSessionId}: ${errMessage(e)}`);
+				}
+			}
+			contentSpinner.stop(
+				`Uploaded ${contentUploaded} content blob${contentUploaded === 1 ? "" : "s"}`,
+			);
+		}
+
+		// Update the per-session lock for sessions that are genuinely in
+		// sync with the server now: either the server already had matching
+		// content (not in `needs_content`), or we just delivered the bytes
+		// (id in `uploadedIds`). Sessions whose upload failed stay un-cached
+		// so the next push retries.
+		for (const s of sessions) {
+			if (!s.contentHash) continue;
+			const id = s.localSessionId;
+			if (needsContent.has(id) && !uploadedIds.has(id)) continue;
+			sessionsLock.sessions[cacheKey(agentType, id)] = { hash: s.contentHash };
+		}
+		moduleState[`sessions:${agentType}`] = { lastActivityAt: new Date().toISOString() };
 	}
 
 	if (skills.length > 0) {
@@ -433,7 +522,14 @@ async function pushOneAgent(
 		moduleState.skills = { lastActivityAt: new Date().toISOString() };
 	}
 
-	return { sessionsPushed, contentUploaded, skillsPushed };
+	return {
+		sessionsCacheSkipped,
+		sessionsCreated,
+		sessionsUpdated,
+		sessionsUnchanged,
+		contentUploaded,
+		skillsPushed,
+	};
 }
 
 function normalizeProject(input: string): string {

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -16,6 +16,12 @@ import {
 	type SessionsLock,
 	writeSessionsLock,
 } from "../lib/sessions-lock";
+import {
+	computeSkillFolderHash,
+	readSkillsLock,
+	type SkillsLock,
+	writeSkillsLock,
+} from "../lib/skills-lock";
 import { type ModuleState, readModuleState, writeModuleState } from "../lib/state";
 import { tarSkillDir } from "../lib/tar";
 import { isInteractive } from "../lib/tty";
@@ -45,6 +51,7 @@ interface AgentPushResult {
 	sessionsUpdated: number;
 	sessionsUnchanged: number;
 	contentUploaded: number;
+	skillsCacheSkipped: number;
 	skillsPushed: number;
 }
 
@@ -98,12 +105,14 @@ export async function push(opts: PushOpts) {
 
 	const moduleState = readModuleState();
 	const sessionsLock = readSessionsLock();
+	const skillsLock = readSkillsLock();
 	const totals = {
 		cacheSkipped: 0,
 		created: 0,
 		updated: 0,
 		unchanged: 0,
 		content: 0,
+		skillsCacheSkipped: 0,
 		skills: 0,
 	};
 	let aborted = false;
@@ -114,7 +123,14 @@ export async function push(opts: PushOpts) {
 		if (targetTypes.length > 1) {
 			p.log.step(chalk.bold(`▶ ${adapterRegistry[agentType].displayName}`));
 		}
-		const result = await pushOneAgent(adapter, modules, opts, moduleState, sessionsLock);
+		const result = await pushOneAgent(
+			adapter,
+			modules,
+			opts,
+			moduleState,
+			sessionsLock,
+			skillsLock,
+		);
 		if (result === "aborted") {
 			aborted = true;
 			break;
@@ -125,15 +141,17 @@ export async function push(opts: PushOpts) {
 		totals.updated += result.sessionsUpdated;
 		totals.unchanged += result.sessionsUnchanged;
 		totals.content += result.contentUploaded;
+		totals.skillsCacheSkipped += result.skillsCacheSkipped;
 		totals.skills += result.skillsPushed;
 	}
 
 	if (!opts.dryRun) {
 		writeModuleState(moduleState);
-		// Persist content-hash cache once per push command, even if the
+		// Persist content-hash caches once per push command, even if the
 		// loop aborted partway — entries we mutated for successful agents
 		// are still valid and would otherwise be lost on the next push.
 		writeSessionsLock(sessionsLock);
+		writeSkillsLock(skillsLock);
 	}
 
 	if (aborted) {
@@ -158,7 +176,11 @@ export async function push(opts: PushOpts) {
 		parts.push(`${totals.content} content upload${totals.content === 1 ? "" : "s"}`);
 	}
 	if (modules.includes("skills")) {
-		parts.push(`${totals.skills} skill${totals.skills === 1 ? "" : "s"}`);
+		const skillsLabel =
+			totals.skillsCacheSkipped > 0
+				? `${totals.skills} skill${totals.skills === 1 ? "" : "s"} uploaded, ${totals.skillsCacheSkipped} already in sync`
+				: `${totals.skills} skill${totals.skills === 1 ? "" : "s"}`;
+		parts.push(skillsLabel);
 	}
 	parts.push(`across ${targetTypes.length} agent${targetTypes.length === 1 ? "" : "s"}`);
 	p.outro(chalk.green(`✓ Push complete — ${parts.join(", ")}`));
@@ -170,6 +192,7 @@ async function pushOneAgent(
 	opts: PushOpts,
 	moduleState: ModuleState,
 	sessionsLock: SessionsLock,
+	skillsLock: SkillsLock,
 ): Promise<AgentPushResult | "aborted" | "skipped"> {
 	const agentType = adapter.agentType;
 	const envId = getEnvIdByAgent(agentType);
@@ -332,6 +355,7 @@ async function pushOneAgent(
 				sessionsUpdated: 0,
 				sessionsUnchanged: 0,
 				contentUploaded: 0,
+				skillsCacheSkipped: 0,
 				skillsPushed: 0,
 			};
 		}
@@ -350,6 +374,7 @@ async function pushOneAgent(
 			sessionsUpdated: 0,
 			sessionsUnchanged: 0,
 			contentUploaded: sessions.length,
+			skillsCacheSkipped: 0,
 			skillsPushed: skills.length,
 		};
 	}
@@ -473,17 +498,29 @@ async function pushOneAgent(
 		moduleState[`sessions:${agentType}`] = { lastActivityAt: new Date().toISOString() };
 	}
 
+	let skillsCacheSkipped = 0;
 	if (skills.length > 0) {
 		const skillSpinner = p.spinner();
-		skillSpinner.start(`Uploading ${skills.length} skill${skills.length === 1 ? "" : "s"}...`);
+		skillSpinner.start(`Hashing ${skills.length} skill${skills.length === 1 ? "" : "s"}...`);
 		let pushed = 0;
 		const skipped: { key: string; reason: string }[] = [];
 		try {
 			for (const skill of skills) {
+				// Compute the file-tree hash first. Cheap (no tar build) — if
+				// it matches the cache, we skip the whole upload path.
+				const computedHash = await computeSkillFolderHash(skill.directoryPath);
+				if (skillsLock.skills[skill.skillKey]?.hash === computedHash) {
+					skillsCacheSkipped++;
+					skillSpinner.message(
+						`Hashing skills (${pushed + skipped.length + skillsCacheSkipped}/${skills.length})...`,
+					);
+					continue;
+				}
 				const tarBytes = await tarSkillDir(skill.directoryPath);
 				try {
-					await api.uploadSkill(skill.skillKey, tarBytes, `${skill.skillKey}.tar.gz`);
+					await api.uploadSkill(skill.skillKey, tarBytes, `${skill.skillKey}.tar.gz`, computedHash);
 					pushed++;
+					skillsLock.skills[skill.skillKey] = { hash: computedHash };
 				} catch (e) {
 					// 413 = upstream (Cloudflare / nginx) refused the body. Almost
 					// always a single oversized skill; skip it and keep going so
@@ -504,9 +541,14 @@ async function pushOneAgent(
 					const mb = (tarBytes.length / 1024 / 1024).toFixed(1);
 					skipped.push({ key: skill.skillKey, reason: `${mb} MB exceeds upload limit` });
 				}
-				skillSpinner.message(`Uploading skills (${pushed + skipped.length}/${skills.length})...`);
+				skillSpinner.message(
+					`Uploading skills (${pushed + skipped.length + skillsCacheSkipped}/${skills.length})...`,
+				);
 			}
 			const summary = [`Pushed ${pushed} skill${pushed === 1 ? "" : "s"}`];
+			if (skillsCacheSkipped > 0) {
+				summary.push(`${skillsCacheSkipped} already in sync`);
+			}
 			if (skipped.length > 0) {
 				summary.push(`skipped ${skipped.length} (too large)`);
 			}
@@ -528,6 +570,7 @@ async function pushOneAgent(
 		sessionsUpdated,
 		sessionsUnchanged,
 		contentUploaded,
+		skillsCacheSkipped,
 		skillsPushed,
 	};
 }

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -8,7 +8,7 @@ import {
 	resolveTargetAgentTypes,
 } from "../lib/select-adapter";
 
-interface SessionsListOpts {
+interface SessionListOpts {
 	agent?: string;
 	allAgents?: boolean;
 	project?: string;
@@ -30,7 +30,7 @@ interface ListedSession {
 	summary: string | null;
 }
 
-export async function sessionsList(opts: SessionsListOpts) {
+export async function sessionList(opts: SessionListOpts) {
 	// Default to "all registered agents" when neither flag is given. This
 	// command is informational — restricting to a single prompted adapter
 	// would hide history the user wants to see.
@@ -42,7 +42,7 @@ export async function sessionsList(opts: SessionsListOpts) {
 		return;
 	}
 
-	// `sessions list` defaults to no project filter — hiding history would
+	// `session list` defaults to no project filter — hiding history would
 	// defeat the point of the command. `--project` opts back into a filter.
 	const projectFilter = opts.all ? undefined : opts.project;
 	const since = opts.since ? new Date(opts.since) : undefined;
@@ -54,11 +54,15 @@ export async function sessionsList(opts: SessionsListOpts) {
 		if (!adapter) continue;
 		let sessions: RawSession[];
 		try {
-			sessions = await adapter.collectSessions(since, projectFilter);
+			sessions = await adapter.collectSessions({ projectFilter });
 		} catch {
 			continue;
 		}
 		for (const s of sessions) {
+			// `--since` is a post-filter for the listing UX — adapters no
+			// longer filter sessions by session-time (only by file mtime,
+			// internally as a perf hint).
+			if (since && s.startedAt < since) continue;
 			collected.push({
 				id: s.localSessionId,
 				agent: agentType,

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -2,6 +2,8 @@ import { homedir } from "node:os";
 import chalk from "chalk";
 import type { RawSession } from "../adapters/base";
 import { type AgentType, adapterRegistry } from "../adapters/registry";
+import { ApiClient, ApiError, unwrap } from "../lib/api-client";
+import { isLoggedIn } from "../lib/config";
 import {
 	adapterForType,
 	listRegisteredAgentTypes,
@@ -158,4 +160,56 @@ function relativeTime(then: Date): string {
 	if (mon < 12) return `${mon}mo ago`;
 	const yr = Math.floor(mon / 12);
 	return `${yr}y ago`;
+}
+
+interface SessionExtractOpts {
+	json?: boolean;
+}
+
+/** Thin 1:1 wrapper around `POST /api/sessions/{local_session_id}/extract`.
+ *
+ * No orchestration, no idempotency. The route always calls the LLM;
+ * callers (onboarding skill, future dashboard button) decide which
+ * sessions to feed in. 503 is the special "extraction not configured"
+ * signal the onboarding skill watches for to skip the step cleanly.
+ */
+export async function sessionExtract(sessionId: string, opts: SessionExtractOpts = {}) {
+	if (!isLoggedIn()) {
+		console.log(chalk.red("Not logged in. Run `clawdi auth login` first."));
+		process.exit(1);
+	}
+	const api = new ApiClient();
+	try {
+		const result = unwrap(
+			await api.POST("/api/sessions/{local_session_id}/extract", {
+				params: { path: { local_session_id: sessionId } },
+			}),
+		);
+
+		if (opts.json || !process.stdout.isTTY) {
+			console.log(JSON.stringify({ session_id: sessionId, ...result }));
+			return;
+		}
+
+		const n = result.memories_created;
+		console.log(chalk.green(`✓ ${n} memor${n === 1 ? "y" : "ies"} extracted from ${sessionId}`));
+	} catch (e) {
+		// 503 means the deployment hasn't configured a memory-extraction LLM.
+		// Exit 2 so onboarding scripts can branch on it without parsing stderr.
+		if (e instanceof ApiError && e.status === 503) {
+			if (opts.json || !process.stdout.isTTY) {
+				console.log(
+					JSON.stringify({
+						session_id: sessionId,
+						error: "not_configured",
+						message: e.body || e.hint,
+					}),
+				);
+			} else {
+				console.log(chalk.yellow(`Memory extraction is not configured on this deployment.`));
+			}
+			process.exit(2);
+		}
+		throw e;
+	}
 }

--- a/packages/cli/src/commands/sessions.ts
+++ b/packages/cli/src/commands/sessions.ts
@@ -1,0 +1,157 @@
+import { homedir } from "node:os";
+import chalk from "chalk";
+import type { RawSession } from "../adapters/base";
+import { type AgentType, adapterRegistry } from "../adapters/registry";
+import {
+	adapterForType,
+	listRegisteredAgentTypes,
+	resolveTargetAgentTypes,
+} from "../lib/select-adapter";
+
+interface SessionsListOpts {
+	agent?: string;
+	allAgents?: boolean;
+	project?: string;
+	all?: boolean;
+	since?: string;
+	limit?: string;
+	json?: boolean;
+}
+
+interface ListedSession {
+	id: string;
+	agent: AgentType;
+	project: string | null;
+	started_at: string;
+	ended_at: string | null;
+	message_count: number;
+	duration_seconds: number | null;
+	model: string | null;
+	summary: string | null;
+}
+
+export async function sessionsList(opts: SessionsListOpts) {
+	// Default to "all registered agents" when neither flag is given. This
+	// command is informational — restricting to a single prompted adapter
+	// would hide history the user wants to see.
+	const wantAllAgents = opts.allAgents || !opts.agent;
+	const targetTypes = await resolveTargetAgentTypes(opts.agent, wantAllAgents);
+	if (targetTypes.length === 0) {
+		// resolveTargetAgentTypes already printed the explanation
+		process.exitCode = 1;
+		return;
+	}
+
+	// `sessions list` defaults to no project filter — hiding history would
+	// defeat the point of the command. `--project` opts back into a filter.
+	const projectFilter = opts.all ? undefined : opts.project;
+	const since = opts.since ? new Date(opts.since) : undefined;
+	const limit = opts.limit ? Number.parseInt(opts.limit, 10) : 100;
+
+	const collected: ListedSession[] = [];
+	for (const agentType of targetTypes) {
+		const adapter = adapterForType(agentType);
+		if (!adapter) continue;
+		let sessions: RawSession[];
+		try {
+			sessions = await adapter.collectSessions(since, projectFilter);
+		} catch {
+			continue;
+		}
+		for (const s of sessions) {
+			collected.push({
+				id: s.localSessionId,
+				agent: agentType,
+				project: s.projectPath,
+				started_at: s.startedAt.toISOString(),
+				ended_at: s.endedAt?.toISOString() ?? null,
+				message_count: s.messageCount,
+				duration_seconds: s.durationSeconds,
+				model: s.model,
+				summary: s.summary,
+			});
+		}
+	}
+
+	collected.sort((a, b) => b.started_at.localeCompare(a.started_at));
+	const truncated = collected.length > limit;
+	const shown = collected.slice(0, limit);
+
+	if (opts.json) {
+		console.log(JSON.stringify(shown, null, 2));
+		return;
+	}
+
+	if (shown.length === 0) {
+		console.log(chalk.gray("No sessions found."));
+		const registered = listRegisteredAgentTypes();
+		if (registered.length === 0) {
+			console.log(chalk.gray("Run `clawdi setup` to register agents on this machine."));
+		}
+		return;
+	}
+
+	const grouped = new Map<AgentType, ListedSession[]>();
+	for (const s of shown) {
+		const existing = grouped.get(s.agent) ?? [];
+		existing.push(s);
+		grouped.set(s.agent, existing);
+	}
+
+	const home = homedir();
+	for (const [agentType, list] of grouped) {
+		console.log();
+		console.log(chalk.bold(`${adapterRegistry[agentType].displayName} (${list.length})`));
+		for (const s of list) {
+			const id = s.id.length > 10 ? `${s.id.slice(0, 8)}…` : s.id;
+			const project = s.project ? prettyPath(s.project, home) : chalk.gray("—");
+			const when = relativeTime(new Date(s.started_at));
+			const msgs = `${s.message_count} msg${s.message_count === 1 ? "" : "s"}`;
+			const summary = s.summary ? `"${truncate(s.summary, 60)}"` : "";
+			console.log(
+				`  ${chalk.dim(id)}  ${project}  ${chalk.gray(when)}  ${chalk.gray(msgs)}  ${chalk.gray(summary)}`,
+			);
+		}
+	}
+	console.log();
+	const summary = `${shown.length} session${shown.length === 1 ? "" : "s"} across ${grouped.size} agent${grouped.size === 1 ? "" : "s"}`;
+	console.log(
+		truncated
+			? chalk.gray(`${summary} (${collected.length} total — pass --limit to see more)`)
+			: chalk.gray(summary),
+	);
+
+	// Telegraph the next obvious action for users who came here as a preview
+	// step before push.
+	console.log();
+	console.log(
+		chalk.gray("Push with: ") + chalk.cyan("clawdi push --modules sessions --all-agents --all"),
+	);
+}
+
+function prettyPath(abs: string, home: string): string {
+	if (abs === home) return "~";
+	if (abs.startsWith(`${home}/`)) return `~/${abs.slice(home.length + 1)}`;
+	return abs;
+}
+
+function truncate(s: string, n: number): string {
+	const flat = s.replace(/\s+/g, " ").trim();
+	return flat.length > n ? `${flat.slice(0, n - 1)}…` : flat;
+}
+
+function relativeTime(then: Date): string {
+	const diffMs = Date.now() - then.getTime();
+	const sec = Math.floor(diffMs / 1000);
+	if (sec < 60) return "just now";
+	const min = Math.floor(sec / 60);
+	if (min < 60) return `${min}m ago`;
+	const hr = Math.floor(min / 60);
+	if (hr < 24) return `${hr}h ago`;
+	const day = Math.floor(hr / 24);
+	if (day < 30) return `${day}d ago`;
+	const mon = Math.floor(day / 30);
+	if (mon < 12) return `${mon}mo ago`;
+	const yr = Math.floor(mon / 12);
+	return `${yr}y ago`;
+}

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -9,6 +9,7 @@ import { getClawdiDir, isLoggedIn } from "../lib/config";
 import { errMessage } from "../lib/errors";
 import { parseFrontmatter } from "../lib/frontmatter";
 import { sanitizeMetadata, sanitizeName } from "../lib/sanitize";
+import { computeSkillFolderHash } from "../lib/skills-lock";
 import { type ParsedSource, parseSource } from "../lib/source-parser";
 import { tarSingleFile, tarSkillDir } from "../lib/tar";
 import { isInteractive } from "../lib/tty";
@@ -84,6 +85,11 @@ export async function skillAdd(path: string, opts: { yes?: boolean } = {}) {
 	let skillDescription: string | undefined;
 	let fileCount: number | undefined;
 	let skillMdSource: string;
+	// File-tree hash for the directory case so the server can early-return
+	// on identical re-uploads. Single-file case omits the hash and lets the
+	// server compute its own from the synthesized tar — the saving doesn't
+	// matter for one-shot ad-hoc uploads.
+	let contentHash: string | undefined;
 
 	if (stat.isDirectory()) {
 		const skillMdPath = join(resolved, "SKILL.md");
@@ -95,6 +101,7 @@ export async function skillAdd(path: string, opts: { yes?: boolean } = {}) {
 		skillKey = sanitizeName(basename(resolved));
 		fileCount = countFiles(resolved);
 		tarBytes = await tarSkillDir(resolved);
+		contentHash = await computeSkillFolderHash(resolved);
 	} else {
 		skillMdSource = readFileSync(resolved, "utf-8");
 		skillKey = sanitizeName(basename(resolved, ".md"));
@@ -131,7 +138,7 @@ export async function skillAdd(path: string, opts: { yes?: boolean } = {}) {
 		}
 	}
 
-	const result = await api.uploadSkill(skillKey, tarBytes, `${skillKey}.tar.gz`);
+	const result = await api.uploadSkill(skillKey, tarBytes, `${skillKey}.tar.gz`, contentHash);
 
 	console.log(
 		chalk.green(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,7 +15,8 @@ program
 Examples:
   $ clawdi auth login               Authenticate with Clawdi Cloud
   $ clawdi setup                    Detect agents and register the current machine
-  $ clawdi push                     Upload local sessions/skills to the cloud
+  $ clawdi sessions list            Preview local sessions before pushing
+  $ clawdi push --modules sessions --all-agents --all  Upload everything
   $ clawdi pull                     Download cloud skills to registered agents
   $ clawdi skill list --json        Machine-readable skill listing
   $ clawdi memory search "redis"    Search memories by text
@@ -167,9 +168,17 @@ program
 	.option("--modules <modules>", "Comma-separated: sessions,skills")
 	.option("--since <date>", "Only push data modified after this date")
 	.option("--project <path>", "Push a specific project's data (default: current directory)")
+	.option(
+		"--exclude-project <path>",
+		"Exclude a project path (repeatable, mutex with --project)",
+		(value: string, prev: string[] = []) => prev.concat(value),
+		[] as string[],
+	)
 	.option("--all", "Push data from all projects")
 	.option("--agent <type>", "Target agent (claude_code, codex, hermes, openclaw)")
+	.option("--all-agents", "Push from every registered agent on this machine")
 	.option("--dry-run", "Preview without uploading")
+	.option("-y, --yes", "Skip the upload confirmation prompt")
 	.addHelpText(
 		"after",
 		`
@@ -177,7 +186,9 @@ Examples:
   $ clawdi push
   $ clawdi push --modules skills
   $ clawdi push --agent claude_code --dry-run
-  $ clawdi push --since 2026-01-01 --all`,
+  $ clawdi push --since 2026-01-01 --all
+  $ clawdi push --modules sessions --all-agents --all --yes
+  $ clawdi push --modules sessions --all-agents --all --exclude-project ~/scratch --yes`,
 	)
 	.action(async (opts) => {
 		const { push } = await import("./commands/push.js");
@@ -298,6 +309,34 @@ skillCmd
 	.action(async (name) => {
 		const { skillInit } = await import("./commands/skill.js");
 		skillInit(name);
+	});
+
+// ─────────────────────────────────────────────────────────────
+// sessions
+// ─────────────────────────────────────────────────────────────
+const sessionsCmd = program.command("sessions").description("Inspect local agent sessions");
+
+sessionsCmd
+	.command("list")
+	.description("List local agent sessions (use before `clawdi push` to preview)")
+	.option("--agent <type>", "Single agent (claude_code, codex, hermes, openclaw)")
+	.option("--all-agents", "List sessions from every registered agent (default)")
+	.option("--project <path>", "Restrict to one project path")
+	.option("--all", "List sessions from all projects (default when --project not set)")
+	.option("--since <date>", "Only list sessions started after this date")
+	.option("--limit <n>", "Cap results", "100")
+	.option("--json", "Output as JSON")
+	.addHelpText(
+		"after",
+		`
+Examples:
+  $ clawdi sessions list
+  $ clawdi sessions list --json
+  $ clawdi sessions list --agent claude_code --project ~/work/foo`,
+	)
+	.action(async (opts) => {
+		const { sessionsList } = await import("./commands/sessions.js");
+		await sessionsList(opts);
 	});
 
 // ─────────────────────────────────────────────────────────────

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -342,6 +342,26 @@ Examples:
 		await sessionList(opts);
 	});
 
+sessionCmd
+	.command("extract <session-id>")
+	.description("Extract memories from a session via the cloud's configured LLM")
+	.option("--json", "Output result as JSON")
+	.addHelpText(
+		"after",
+		`
+Examples:
+  $ clawdi session extract a1b2c3d4-...
+  $ clawdi session extract a1b2c3d4-... --json
+  # Loop the recent 10 sessions (the onboarding skill does this):
+  $ clawdi session list --limit 10 --json | \\
+      jq -r '.[].id' | \\
+      xargs -I{} clawdi session extract {} --json`,
+	)
+	.action(async (sessionId, opts) => {
+		const { sessionExtract } = await import("./commands/session.js");
+		await sessionExtract(sessionId, opts);
+	});
+
 // ─────────────────────────────────────────────────────────────
 // memory
 // ─────────────────────────────────────────────────────────────

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,7 +15,7 @@ program
 Examples:
   $ clawdi auth login               Authenticate with Clawdi Cloud
   $ clawdi setup                    Detect agents and register the current machine
-  $ clawdi sessions list            Preview local sessions before pushing
+  $ clawdi session list             Preview local sessions before pushing
   $ clawdi push --modules sessions --all-agents --all  Upload everything
   $ clawdi pull                     Download cloud skills to registered agents
   $ clawdi skill list --json        Machine-readable skill listing
@@ -166,7 +166,6 @@ program
 	.command("push")
 	.description("Push local data (sessions, skills) to the cloud")
 	.option("--modules <modules>", "Comma-separated: sessions,skills")
-	.option("--since <date>", "Only push data modified after this date")
 	.option("--project <path>", "Push a specific project's data (default: current directory)")
 	.option(
 		"--exclude-project <path>",
@@ -186,7 +185,6 @@ Examples:
   $ clawdi push
   $ clawdi push --modules skills
   $ clawdi push --agent claude_code --dry-run
-  $ clawdi push --since 2026-01-01 --all
   $ clawdi push --modules sessions --all-agents --all --yes
   $ clawdi push --modules sessions --all-agents --all --exclude-project ~/scratch --yes`,
 	)
@@ -197,15 +195,20 @@ Examples:
 
 program
 	.command("pull")
-	.description("Pull cloud data (skills) to registered agents")
-	.option("--modules <modules>", "Comma-separated: skills")
+	.description(
+		"Pull cloud data — `skills` writes archives to agent dirs; `sessions` mirrors to ~/.clawdi/sessions/",
+	)
+	.option("--modules <modules>", "Comma-separated: skills,sessions")
 	.option("--agent <type>", "Target agent (claude_code, codex, hermes, openclaw)")
+	.option("--all-agents", "Pull for every registered agent on this machine")
 	.option("--dry-run", "Preview without downloading")
+	.option("-y, --yes", "Skip confirmation prompts")
 	.addHelpText(
 		"after",
 		`
 Examples:
   $ clawdi pull
+  $ clawdi pull --modules sessions --all-agents --yes
   $ clawdi pull --agent claude_code --dry-run`,
 	)
 	.action(async (opts) => {
@@ -312,11 +315,11 @@ skillCmd
 	});
 
 // ─────────────────────────────────────────────────────────────
-// sessions
+// session
 // ─────────────────────────────────────────────────────────────
-const sessionsCmd = program.command("sessions").description("Inspect local agent sessions");
+const sessionCmd = program.command("session").description("Inspect local agent sessions");
 
-sessionsCmd
+sessionCmd
 	.command("list")
 	.description("List local agent sessions (use before `clawdi push` to preview)")
 	.option("--agent <type>", "Single agent (claude_code, codex, hermes, openclaw)")
@@ -330,13 +333,13 @@ sessionsCmd
 		"after",
 		`
 Examples:
-  $ clawdi sessions list
-  $ clawdi sessions list --json
-  $ clawdi sessions list --agent claude_code --project ~/work/foo`,
+  $ clawdi session list
+  $ clawdi session list --json
+  $ clawdi session list --agent claude_code --project ~/work/foo`,
 	)
 	.action(async (opts) => {
-		const { sessionsList } = await import("./commands/sessions.js");
-		await sessionsList(opts);
+		const { sessionList } = await import("./commands/session.js");
+		await sessionList(opts);
 	});
 
 // ─────────────────────────────────────────────────────────────

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -179,13 +179,14 @@ export class ApiClient {
 		skillKey: string,
 		file: Buffer,
 		filename: string,
+		contentHash?: string,
 	): Promise<SkillUploadResponse> {
-		return this.multipartPost<SkillUploadResponse>(
-			"/api/skills/upload",
-			{ skill_key: skillKey },
-			file,
-			filename,
-		);
+		// `content_hash` is optional server-side (added 0.3.4). Omit the
+		// field entirely when the caller doesn't have one — server falls
+		// back to computing it from the uploaded tar.
+		const fields: Record<string, string> = { skill_key: skillKey };
+		if (contentHash) fields.content_hash = contentHash;
+		return this.multipartPost<SkillUploadResponse>("/api/skills/upload", fields, file, filename);
 	}
 
 	/** Upload per-session content JSON to `/api/sessions/{id}/upload`. */

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -202,6 +202,11 @@ export class ApiClient {
 		);
 	}
 
+	/** Download session content (an array of messages) from the cloud. */
+	async getSessionContent(sessionId: string): Promise<Buffer> {
+		return this.getBytes(`/api/sessions/${encodeURIComponent(sessionId)}/content`);
+	}
+
 	/** Shared multipart POST; never retried (non-idempotent). */
 	private async multipartPost<T>(
 		path: string,

--- a/packages/cli/src/lib/api-schemas.ts
+++ b/packages/cli/src/lib/api-schemas.ts
@@ -10,6 +10,7 @@ export type Memory = Schemas["MemoryResponse"];
 export type SkillSummary = Schemas["SkillSummaryResponse"];
 export type SkillDetail = Schemas["SkillDetailResponse"];
 export type ConnectorMcpConfig = Schemas["ConnectorMcpConfigResponse"];
+export type SessionListItem = Schemas["SessionListItemResponse"];
 
 // ── Write responses ───────────────────────────────────────────────────────
 export type MemoryCreated = Schemas["MemoryCreatedResponse"];
@@ -22,4 +23,5 @@ export type VaultSections = Schemas["VaultSectionsResponse"];
 // ── Pagination ────────────────────────────────────────────────────────────
 export type PaginatedMemories = Schemas["Paginated_MemoryResponse_"];
 export type PaginatedSkills = Schemas["Paginated_SkillSummaryResponse_"];
+export type PaginatedSessions = Schemas["Paginated_SessionListItemResponse_"];
 export type PaginatedVaults = Schemas["Paginated_VaultResponse_"];

--- a/packages/cli/src/lib/hash.ts
+++ b/packages/cli/src/lib/hash.ts
@@ -1,0 +1,11 @@
+import { createHash } from "node:crypto";
+
+/**
+ * SHA-256 hex digest of the input. Used by `clawdi push` to fingerprint
+ * each session's serialized messages so the backend can decide whether
+ * to skip content reupload, and by `clawdi pull` to diff cloud state
+ * against local sidecar files.
+ */
+export function sha256Hex(input: string | Buffer): string {
+	return createHash("sha256").update(input).digest("hex");
+}

--- a/packages/cli/src/lib/select-adapter.ts
+++ b/packages/cli/src/lib/select-adapter.ts
@@ -104,3 +104,39 @@ export async function selectAdapter(agentOpt?: string): Promise<AgentAdapter | n
 	);
 	return picked ? adapterForType(picked) : null;
 }
+
+/**
+ * Resolve a list of agent targets for commands that operate across multiple
+ * agents at once (`push --all-agents`, `sessions list --all-agents`).
+ *
+ * Returns the empty array when the caller should abort — same convention as
+ * `selectAdapter`. The caller has already printed an explanatory message in
+ * the failure cases this function handles.
+ *
+ *   --all-agents          → every type with a file under ~/.clawdi/environments/
+ *   --agent <type>        → exactly that one (validated)
+ *   neither, single match → the single registered/detected adapter (via selectAdapter)
+ *   neither, ambiguous    → null in non-interactive contexts; prompt otherwise
+ */
+export async function resolveTargetAgentTypes(
+	agentOpt: string | undefined,
+	allAgents: boolean,
+): Promise<AgentType[]> {
+	if (agentOpt && allAgents) {
+		console.log(chalk.red("Pass either --agent or --all-agents, not both."));
+		return [];
+	}
+
+	if (allAgents) {
+		const registered = listRegisteredAgentTypes();
+		if (registered.length === 0) {
+			console.log(chalk.red("No agents are registered on this machine."));
+			console.log(chalk.gray("Run `clawdi setup` first."));
+			return [];
+		}
+		return registered;
+	}
+
+	const adapter = await selectAdapter(agentOpt);
+	return adapter ? [adapter.agentType] : [];
+}

--- a/packages/cli/src/lib/select-adapter.ts
+++ b/packages/cli/src/lib/select-adapter.ts
@@ -107,7 +107,7 @@ export async function selectAdapter(agentOpt?: string): Promise<AgentAdapter | n
 
 /**
  * Resolve a list of agent targets for commands that operate across multiple
- * agents at once (`push --all-agents`, `sessions list --all-agents`).
+ * agents at once (`push --all-agents`, `session list --all-agents`).
  *
  * Returns the empty array when the caller should abort — same convention as
  * `selectAdapter`. The caller has already printed an explanatory message in

--- a/packages/cli/src/lib/sessions-lock.ts
+++ b/packages/cli/src/lib/sessions-lock.ts
@@ -1,0 +1,72 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import chalk from "chalk";
+import type { AgentType } from "../adapters/registry";
+import { getClawdiDir } from "./config";
+
+/**
+ * Per-session content-hash cache used by `clawdi push` to decide which
+ * sessions are already in sync with the cloud. Modeled after the Vercel
+ * skills CLI's `skills-lock.json` (`/Users/paco/workspace/skills/src/local-lock.ts`)
+ * — single JSON file, flat key/value, version-stamped for forward compat.
+ *
+ * Authoritative state is the cloud. This file is purely an optimization;
+ * deleting it just forces the next push to re-confirm every session
+ * against the server, which is safe (server is source of truth on
+ * what's already stored).
+ */
+export interface SessionsLock {
+	version: 1;
+	// Key is `cacheKey(agentType, localSessionId)`. Flat namespace so a
+	// single-session change yields a one-line JSON diff. Value is the
+	// content hash that was last successfully synced with the server.
+	sessions: Record<string, { hash: string }>;
+}
+
+const LOCK_FILE = "sessions-lock.json";
+const CURRENT_VERSION = 1;
+
+/**
+ * Composite key combining agent type and local session id. Local session
+ * ids alone are NOT globally unique across agents (Claude Code's UUID
+ * scheme can collide with Codex's), so we namespace by agent type.
+ */
+export function cacheKey(agentType: AgentType, localSessionId: string): string {
+	return `${agentType}:${localSessionId}`;
+}
+
+/**
+ * Read `~/.clawdi/sessions-lock.json`. Returns an empty cache when the
+ * file is missing, corrupt, or written by a future version. The next
+ * push will re-warm the cache from server hash diffs — no harm done.
+ */
+export function readSessionsLock(): SessionsLock {
+	const path = join(getClawdiDir(), LOCK_FILE);
+	if (!existsSync(path)) return emptyLock();
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf-8")) as SessionsLock;
+		if (parsed.version !== CURRENT_VERSION || !parsed.sessions) return emptyLock();
+		return parsed;
+	} catch {
+		console.log(chalk.yellow(`⚠ ~/.clawdi/${LOCK_FILE} is corrupted; resetting.`));
+		return emptyLock();
+	}
+}
+
+export function writeSessionsLock(lock: SessionsLock): void {
+	const path = join(getClawdiDir(), LOCK_FILE);
+	// Sort keys for deterministic output — keeps `git diff` readable when
+	// the file is committed (some users do this for VCS-backed clawdi
+	// state) and stabilizes any future test snapshots.
+	const sortedSessions: Record<string, { hash: string }> = {};
+	for (const key of Object.keys(lock.sessions).sort()) {
+		const entry = lock.sessions[key];
+		if (entry) sortedSessions[key] = entry;
+	}
+	const sorted: SessionsLock = { version: lock.version, sessions: sortedSessions };
+	writeFileSync(path, `${JSON.stringify(sorted, null, 2)}\n`, { mode: 0o600 });
+}
+
+function emptyLock(): SessionsLock {
+	return { version: CURRENT_VERSION, sessions: {} };
+}

--- a/packages/cli/src/lib/skills-lock.ts
+++ b/packages/cli/src/lib/skills-lock.ts
@@ -47,7 +47,14 @@ const CURRENT_VERSION = 1;
 export async function computeSkillFolderHash(skillDir: string): Promise<string> {
 	const files: Array<{ relativePath: string; content: Buffer }> = [];
 	await collectFiles(skillDir, skillDir, files);
-	files.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+	// Codepoint sort, NOT localeCompare — Python's default `list.sort()` is
+	// codepoint-based, so the server-side mirror in
+	// `backend/app/routes/skills.py:_compute_file_tree_hash` would diverge
+	// (e.g. "SKILL.md" vs "reference/notes.md" reorders by case under
+	// localeCompare). Both sides MUST sort identically or hashes drift.
+	files.sort((a, b) =>
+		a.relativePath < b.relativePath ? -1 : a.relativePath > b.relativePath ? 1 : 0,
+	);
 
 	const hash = createHash("sha256");
 	for (const f of files) {

--- a/packages/cli/src/lib/skills-lock.ts
+++ b/packages/cli/src/lib/skills-lock.ts
@@ -1,0 +1,116 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import chalk from "chalk";
+import { getClawdiDir } from "./config";
+import { SKILL_TAR_EXCLUDE } from "./tar";
+
+/**
+ * Per-skill content-hash cache used by `clawdi push --modules skills` to
+ * decide which skills are already in sync with the cloud. Mirrors the
+ * Vercel skills CLI's `skills-lock.json` pattern (see
+ * `/Users/paco/workspace/skills/src/local-lock.ts`) and shares the same
+ * file-tree hashing algorithm so server and client agree on what's
+ * "the same skill."
+ *
+ * Lives at `~/.clawdi/skills-lock.json` — single file, version-stamped,
+ * corrupt-tolerant. Authoritative state is the cloud; this cache is just
+ * an optimization. Deleting it forces the next push to re-confirm every
+ * skill against the server, which is safe.
+ */
+export interface SkillsLock {
+	version: 1;
+	// Key is `skill_key` (skills are user-scoped, no agent partition needed —
+	// a skill with a given key is conceptually the same skill regardless of
+	// which agent's home it lives in).
+	skills: Record<string, { hash: string }>;
+}
+
+const LOCK_FILE = "skills-lock.json";
+const CURRENT_VERSION = 1;
+
+/**
+ * SHA-256 over the file tree of a skill directory. Walks every file
+ * (skipping excluded dirs), sorts by relative path, then hashes
+ * `path + content` per file into a single digest.
+ *
+ * Direct port of Vercel's `computeSkillFolderHash`
+ * (`/Users/paco/workspace/skills/src/local-lock.ts:100-115`). The
+ * exclude set is wider than Vercel's (which only skips `.git` and
+ * `node_modules`) — see `tar.ts:SKILL_TAR_EXCLUDE` for why. Server-side
+ * mirror lives at `backend/app/routes/skills.py:_compute_file_tree_hash`.
+ *
+ * Cheap: no tar build needed. Deterministic: same input directory
+ * always produces the same hash regardless of mtimes or build order.
+ */
+export async function computeSkillFolderHash(skillDir: string): Promise<string> {
+	const files: Array<{ relativePath: string; content: Buffer }> = [];
+	await collectFiles(skillDir, skillDir, files);
+	files.sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+
+	const hash = createHash("sha256");
+	for (const f of files) {
+		hash.update(f.relativePath);
+		hash.update(f.content);
+	}
+	return hash.digest("hex");
+}
+
+async function collectFiles(
+	base: string,
+	dir: string,
+	out: Array<{ relativePath: string; content: Buffer }>,
+): Promise<void> {
+	const entries = await readdir(dir, { withFileTypes: true });
+	for (const entry of entries) {
+		if (SKILL_TAR_EXCLUDE.has(entry.name)) continue;
+		const full = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			await collectFiles(base, full, out);
+		} else if (entry.isFile()) {
+			out.push({
+				// Normalize separators to POSIX so hashes are stable across
+				// platforms (Windows would otherwise diverge from Unix).
+				relativePath: relative(base, full).split("\\").join("/"),
+				content: await readFile(full),
+			});
+		}
+	}
+}
+
+/**
+ * Read `~/.clawdi/skills-lock.json`. Returns an empty cache when the
+ * file is missing, corrupt, or written by a future version. The next
+ * push re-confirms with the server and re-warms the cache — safe.
+ */
+export function readSkillsLock(): SkillsLock {
+	const path = join(getClawdiDir(), LOCK_FILE);
+	if (!existsSync(path)) return emptyLock();
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf-8")) as SkillsLock;
+		if (parsed.version !== CURRENT_VERSION || !parsed.skills) return emptyLock();
+		return parsed;
+	} catch {
+		console.log(chalk.yellow(`⚠ ~/.clawdi/${LOCK_FILE} is corrupted; resetting.`));
+		return emptyLock();
+	}
+}
+
+export function writeSkillsLock(lock: SkillsLock): void {
+	const path = join(getClawdiDir(), LOCK_FILE);
+	// Sort keys for deterministic output — keeps `git diff` readable when
+	// users commit the file alongside their dotfiles, and stabilizes test
+	// snapshots.
+	const sortedSkills: Record<string, { hash: string }> = {};
+	for (const key of Object.keys(lock.skills).sort()) {
+		const entry = lock.skills[key];
+		if (entry) sortedSkills[key] = entry;
+	}
+	const sorted: SkillsLock = { version: lock.version, skills: sortedSkills };
+	writeFileSync(path, `${JSON.stringify(sorted, null, 2)}\n`, { mode: 0o600 });
+}
+
+function emptyLock(): SkillsLock {
+	return { version: CURRENT_VERSION, skills: {} };
+}

--- a/packages/cli/src/lib/state.ts
+++ b/packages/cli/src/lib/state.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import chalk from "chalk";
+import type { AgentType } from "../adapters/registry";
 import { getClawdiDir } from "./config";
 
 /**
@@ -36,4 +37,19 @@ export function readModuleState(): ModuleState {
 export function writeModuleState(state: ModuleState) {
 	const path = join(getClawdiDir(), STATE_FILE);
 	writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+}
+
+/**
+ * Per-agent session sync cursor. Earlier versions stored a single shared
+ * `sessions.lastActivityAt` across all agents — Claude Code's push would
+ * advance Codex's cursor. Now each agent's cursor lives under
+ * `sessions:<agentType>`. Reads fall back to the legacy key for users
+ * upgrading from the shared-cursor era.
+ */
+export function readSessionCursor(state: ModuleState, agentType: AgentType): string | undefined {
+	return state[`sessions:${agentType}`]?.lastActivityAt ?? state.sessions?.lastActivityAt;
+}
+
+export function writeSessionCursor(state: ModuleState, agentType: AgentType, isoTs: string) {
+	state[`sessions:${agentType}`] = { lastActivityAt: isoTs };
 }

--- a/packages/cli/src/lib/state.ts
+++ b/packages/cli/src/lib/state.ts
@@ -1,18 +1,19 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import chalk from "chalk";
-import type { AgentType } from "../adapters/registry";
 import { getClawdiDir } from "./config";
 
 /**
- * Per-module activity timestamps tracked in `~/.clawdi/state.json`.
- * Both `push` and `pull` update the relevant module's `lastActivityAt`.
- * `push --since` uses it as an incremental cursor when no explicit
- * `--since` is supplied.
+ * Per-module activity tracked in `~/.clawdi/state.json`.
+ *
+ * `lastActivityAt` is informational — surfaced by `clawdi status` so users
+ * know when a module last did anything. The session sync's content-hash
+ * cache lives separately in `~/.clawdi/sessions-lock.json`; see
+ * `lib/sessions-lock.ts`.
  */
 export interface ModuleState {
 	[module: string]: {
-		lastActivityAt: string;
+		lastActivityAt?: string;
 	};
 }
 
@@ -37,19 +38,4 @@ export function readModuleState(): ModuleState {
 export function writeModuleState(state: ModuleState) {
 	const path = join(getClawdiDir(), STATE_FILE);
 	writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
-}
-
-/**
- * Per-agent session sync cursor. Earlier versions stored a single shared
- * `sessions.lastActivityAt` across all agents — Claude Code's push would
- * advance Codex's cursor. Now each agent's cursor lives under
- * `sessions:<agentType>`. Reads fall back to the legacy key for users
- * upgrading from the shared-cursor era.
- */
-export function readSessionCursor(state: ModuleState, agentType: AgentType): string | undefined {
-	return state[`sessions:${agentType}`]?.lastActivityAt ?? state.sessions?.lastActivityAt;
-}
-
-export function writeSessionCursor(state: ModuleState, agentType: AgentType, isoTs: string) {
-	state[`sessions:${agentType}`] = { lastActivityAt: isoTs };
 }

--- a/packages/cli/src/lib/tar.ts
+++ b/packages/cli/src/lib/tar.ts
@@ -8,8 +8,16 @@ import * as tar from "tar";
  * recipient anyway. Mirrors `SKIP_DIRS` from `adapters/paths.ts` (kept
  * duplicated to avoid an adapter→tar import edge) and extends it with
  * ecosystem dirs that the adapters' enumeration doesn't otherwise filter.
+ *
+ * Exported because `lib/skills-lock.ts`'s file-tree hash function MUST
+ * filter the same set — what we hash has to equal what we'd tar, otherwise
+ * the cache could "match" while the actual archive contains different
+ * bytes. See lib/skills-lock.ts for the hash-side use. The Python side
+ * (`backend/app/routes/skills.py:_SKILL_HASH_EXCLUDE`) mirrors this list
+ * with a comment pointing back here; if you add a directory, add it in
+ * both places.
  */
-const SKILL_TAR_EXCLUDE = new Set([
+export const SKILL_TAR_EXCLUDE = new Set([
 	"node_modules",
 	".git",
 	".turbo",

--- a/packages/shared/src/api/generated.ts
+++ b/packages/shared/src/api/generated.ts
@@ -198,9 +198,10 @@ export interface paths {
 		 * Batch Create Sessions
 		 * @description Ingest a batch of sessions from a CLI sync.
 		 *
-		 *     Relies on the `uq_sessions_user_local` unique constraint plus Postgres
-		 *     `ON CONFLICT DO NOTHING` for idempotency — safe under concurrent
-		 *     invocations and a single round-trip to the DB regardless of batch size.
+		 *     Upserts every row by `(user_id, local_session_id)`. The response tells
+		 *     the client which sessions still need a content upload — either because
+		 *     the stored hash differs from the one just sent, or because no content
+		 *     has ever been uploaded for that row (`file_key IS NULL`).
 		 */
 		post: operations["batch_create_sessions_api_sessions_batch_post"];
 		delete?: never;
@@ -1231,8 +1232,14 @@ export interface components {
 		};
 		/** SessionBatchResponse */
 		SessionBatchResponse: {
-			/** Synced */
-			synced: number;
+			/** Created */
+			created: number;
+			/** Updated */
+			updated: number;
+			/** Unchanged */
+			unchanged: number;
+			/** Needs Content */
+			needs_content: string[];
 		};
 		/** SessionCreate */
 		SessionCreate: {
@@ -1287,6 +1294,8 @@ export interface components {
 			 * @default completed
 			 */
 			status: string;
+			/** Content Hash */
+			content_hash?: string | null;
 		};
 		/** SessionDetailResponse */
 		SessionDetailResponse: {
@@ -1307,6 +1316,11 @@ export interface components {
 			started_at: string;
 			/** Ended At */
 			ended_at: string | null;
+			/**
+			 * Updated At
+			 * Format: date-time
+			 */
+			updated_at: string;
 			/** Duration Seconds */
 			duration_seconds: number | null;
 			/** Message Count */
@@ -1327,6 +1341,8 @@ export interface components {
 			tags: string[] | null;
 			/** Status */
 			status: string;
+			/** Content Hash */
+			content_hash?: string | null;
 			/** Has Content */
 			has_content: boolean;
 		};
@@ -1349,6 +1365,11 @@ export interface components {
 			started_at: string;
 			/** Ended At */
 			ended_at: string | null;
+			/**
+			 * Updated At
+			 * Format: date-time
+			 */
+			updated_at: string;
 			/** Duration Seconds */
 			duration_seconds: number | null;
 			/** Message Count */
@@ -1369,6 +1390,8 @@ export interface components {
 			tags: string[] | null;
 			/** Status */
 			status: string;
+			/** Content Hash */
+			content_hash?: string | null;
 		};
 		/**
 		 * SessionMessageResponse
@@ -1401,6 +1424,8 @@ export interface components {
 			status: "uploaded";
 			/** File Key */
 			file_key: string;
+			/** Content Hash */
+			content_hash: string;
 		};
 		/** SettingsResponse */
 		SettingsResponse: {

--- a/packages/shared/src/api/generated.ts
+++ b/packages/shared/src/api/generated.ts
@@ -284,6 +284,36 @@ export interface paths {
 		patch?: never;
 		trace?: never;
 	};
+	"/api/sessions/{local_session_id}/extract": {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * Extract Session Memories
+		 * @description Extract memories from a session's content via the configured LLM.
+		 *
+		 *     Uses `local_session_id` for path lookup (mirrors the upload endpoint
+		 *     pattern) — `uq_sessions_user_local` makes that a unique index.
+		 *
+		 *     Not idempotent — every call hits the LLM. Onboarding loops over
+		 *     each session exactly once; the future dashboard button is a
+		 *     user-initiated single click. Tracking "already extracted" state
+		 *     on the server would force us to also reason about session updates
+		 *     (re-pushed content with new turns), which is more complexity than
+		 *     a one-shot $0.001 LLM call is worth.
+		 */
+		post: operations["extract_session_memories_api_sessions__local_session_id__extract_post"];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 	"/api/dashboard/stats": {
 		parameters: {
 			query?: never;
@@ -862,6 +892,8 @@ export interface components {
 			skill_key: string;
 			/** File */
 			file: string;
+			/** Content Hash */
+			content_hash?: string | null;
 		};
 		/** ConnectRequest */
 		ConnectRequest: {
@@ -1345,6 +1377,14 @@ export interface components {
 			content_hash?: string | null;
 			/** Has Content */
 			has_content: boolean;
+		};
+		/**
+		 * SessionExtractResponse
+		 * @description Result of `POST /api/sessions/{local_session_id}/extract`.
+		 */
+		SessionExtractResponse: {
+			/** Memories Created */
+			memories_created: number;
 		};
 		/** SessionListItemResponse */
 		SessionListItemResponse: {
@@ -2196,6 +2236,37 @@ export interface operations {
 				};
 				content: {
 					"application/json": components["schemas"]["SessionMessageResponse"][];
+				};
+			};
+			/** @description Validation Error */
+			422: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					"application/json": components["schemas"]["HTTPValidationError"];
+				};
+			};
+		};
+	};
+	extract_session_memories_api_sessions__local_session_id__extract_post: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				local_session_id: string;
+			};
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Successful Response */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					"application/json": components["schemas"]["SessionExtractResponse"];
 				};
 			};
 			/** @description Validation Error */


### PR DESCRIPTION
## Summary

This PR has grown across 4 rounds of work into a comprehensive sync + onboarding redesign covering sessions, skills, memory extraction, the CLI, and the backend. Each commit standalone-reviewable:

### Round 1 — Onboarding redesign (sessions) — `d8122d6`

- **`apps/web/public/skill.md`** — Step 4 (session upload) made REQUIRED with a single (a) all / (b) preview / skip branch. Both branches converge on `clawdi push --modules sessions --all-agents --all`. Branch (b) tells the agent to aggregate the JSON itself and ask by dimension (agent / project / time / exclude), never by id.
- **CLI: `push --all-agents` and `push --exclude-project <path>`** — `push` iterates every registered agent in one invocation, with per-agent `state.json` cursor (`sessions:<agentType>`) so Claude Code's push no longer advances Codex's cursor. `--exclude-project` is repeatable, mutex with `--project`, and expands `~`.
- **CLI: new `clawdi sessions list`** — informational command walking adapters' `collectSessions` across registered agents. Text + `--json` output. Used by the skill's Branch (b) preview path.

### Round 2 — Session sync content-hash cache — `4e013dc` + `0161b15`

Sessions previously had no idempotency: every push re-uploaded every session. Now per-session content-hash cache at `~/.clawdi/sessions-lock.json`:

- **Backend**: `_upsert_session` early-return on `content_hash` match (no `version` bump, no `updated_at` advance). Backwards-compat fallback when CLI doesn't supply hash.
- **CLI push**: hash before tar/upload; skip cache hits; persist hash on success. Output reads `N uploaded, M already in sync` instead of just `N synced`.
- **Onboarding skill**: drop unused `version` frontmatter field; minor cleanup.

### Round 3 — Skill sync redesign + onboarding integration — `7a2a5ff` + `6119bde`

Skills suffered the same anti-patterns as pre-Round-2 sessions, plus the onboarding flow had no skill-sync step at all. Applied the same content-hash + per-entity-cache pattern:

- **Backend (`backend/app/routes/skills.py`)** — `upload_skill` accepts optional `content_hash` Form field (CLI 0.3.3 backwards compat: server falls back to file-tree hash when absent). Pre-fetch + early-return when hash matches → skips both `file_store.put` and the version bump. `_upsert_skill` adds defense-in-depth early-return. Dead `_content_hash` function removed; replaced with `_compute_file_tree_hash` used by both `upload_skill` fallback and `install_skill` (marketplace path) so all paths produce consistent hashes.
- **CLI (`packages/cli/src/lib/skills-lock.ts`, NEW)** — `computeSkillFolderHash` walks the file tree, skips excluded dirs, sorts by relative path (codepoint), sha256 over `path + content`. Direct port of Vercel skills CLI's pattern. Lock file at `~/.clawdi/skills-lock.json`.
- **CLI push/pull** — push hashes before tarring; pull diffs cached hash against cloud `content_hash` from `SkillSummaryResponse`. Cache-hit path touches no tar lib and no network.
- **`SKILL_TAR_EXCLUDE` is single source of truth** — the same set is used for hashing AND tarring; what's hashed must equal what's archived, otherwise the cache could match while the tarball bytes diverge.
- **Bundled `clawdi` skill filtered** — installed by `clawdi setup`, so it's filtered out of `collectSkills()` in all 4 adapters. Otherwise users would push the bundled skill into their own cloud account.
- **Onboarding skill** — new "Sync skills (optional)" section after sessions sync. Brief and optional; no scan-first preview pattern (skills are deliberate, not historical).
- **Hash parity bug fix (`6119bde`)** — caught during self-review before merge: TS used `localeCompare` (locale-aware) while Python used codepoint sort, AND Python included the skill-key root segment while TS used skill-relative paths. Either bug alone would have made the backwards-compat path and marketplace install path produce server-side hashes that no new TS client could ever match → endless re-uploads. Both fixed and verified for single-file + multi-file tarballs.

### Round 4 — Memory extraction from sessions — `4b4acf5`

After session sync (Round 1+2) and skill sync (Round 3), a fresh user reaches the dashboard with **populated sessions/skills tabs but an empty Memory tab**. Round 4 closes that gap: extract memories from the user's pushed sessions via an OpenAI-compatible LLM during onboarding.

- **Backend `POST /api/sessions/{local_session_id}/extract`** — fetches session content, tail-truncates to last 80 messages, asks the LLM for structured memories in 5 categories (fact / preference / pattern / decision / context). Uses OpenAI JSON-schema structured output so bad responses bubble as 5xx instead of being defensively parsed.
- **Prompt design** — borrowed from `/Users/paco/workspace/claude-mem`'s "let the prompt do the filtering" playbook: per-category ✅/❌ examples, an explicit verb list, "what NOT to record" skip rules, and a worked input→output example. No post-LLM dedup or similarity gating.
- **Shared LLM config** — `LLM_BASE_URL`/`LLM_API_KEY`/`LLM_MODEL` (not `MEMORY_EXTRACTION_*`) so future LLM-using features (session summarization, auto-tagging, etc.) reuse the same credentials. Empty `LLM_API_KEY` → 503; CLI surfaces it as exit code 2 so onboarding skips cleanly.
- **Not idempotent on purpose** — single $0.001 LLM call, user-initiated. Tracking "already extracted" state on the server would force reasoning about session updates (re-pushed content with new turns) and isn't worth a new column + migration.
- **CLI `clawdi session extract <local-session-id> [--json]`** — thin 1:1 endpoint wrapper, no orchestration. JSON-by-default in non-TTY so the onboarding skill can pipe results through `jq`.
- **Onboarding skill** — new "Extract memories from sessions (optional)" section. Agent lists the 5 most-recent local sessions, loops the per-session endpoint, aggregates memory counts. The "5" lives in the prompt, not the CLI binary, so tuning is prompt-edit speed not release speed.
- **Memory linkage** — extracted memories carry `source="session"` + existing `source_session_id` column for dashboard click-through (no schema change).
- **Dashboard frontmatter render fix (`82ad90e`)** — caught alongside this work: the skill detail page rendered SKILL.md raw, so the closing `---` of YAML frontmatter rendered as a stray `<hr>` next to the Separator. Stripped before passing to `<Markdown>`.

## Why

- **Onboarding**: old skill labeled session sync as Step 5 (optional) and many agents skipped it → new users opened the dashboard to find it empty. Multi-agent flag missing meant only one agent's history got pushed.
- **Sync idempotency**: without content-hash gating, every push and every pull repeated all the work. Sessions: ~constant network + DB churn. Skills: tar build + upload + version bump on every invocation. Re-running `clawdi push` should be cheap.
- **Backwards compat (Round 3)**: CLI 0.3.3 is in users' hands. The `content_hash` Form field is optional with a server-side fallback; old clients keep working unmodified.
- **Memory bootstrap (Round 4)**: Memory is a headline feature but the post-onboarding state was an empty tab. With the sessions already on the server, a single LLM call per session puts real content in front of the user from day one.

## Test plan

### Onboarding

- [ ] Fresh machine: paste the dashboard prompt into Claude Code, accept default ("a"). Dashboard session count == local jsonl count across `~/.claude/projects/**` + Codex sessions dir.
- [ ] Reply "b": agent renders per-agent / per-project counts (not raw ids), takes a constraint and translates correctly.
- [ ] After session upload, agent runs the skill-sync step; output reads cleanly even with 0 authored skills.
- [ ] Memory extraction step runs; dashboard `/memories` populated with `source="session"` entries linked to the originating sessions.

### Session sync

- [ ] `clawdi push --modules sessions --all-agents --all --yes` twice in a row: second invocation reports `0 uploaded, N already in sync`.
- [ ] `clawdi push --modules sessions --all-agents --all --exclude-project ~/scratch --yes` excludes that project, pushes the rest.
- [ ] `clawdi push --project /tmp --exclude-project /tmp` errors clearly.
- [ ] `clawdi push --all-agents --agent claude_code` errors clearly.
- [ ] Pre-existing `~/.clawdi/state.json` with `sessions.lastActivityAt`: first new push respects legacy cursor (no surprise full re-push).
- [ ] `clawdi sessions list --all-agents --all --json | jq 'length'` matches local file count.

### Skill sync

- [ ] `rm -f ~/.clawdi/skills-lock.json && clawdi push --modules skills --all-agents --yes`: N skills uploaded.
- [ ] Re-run: `0 uploaded, N already in sync` (no tar built, no network roundtrip).
- [ ] `rm -f ~/.clawdi/skills-lock.json && clawdi pull --modules skills --agent claude_code --yes`: M skills downloaded. Re-run: `0 downloaded, M already in sync`.
- [ ] `clawdi setup --agent claude_code` installs bundled `clawdi` skill; `clawdi push --modules skills --agent claude_code --dry-run` does NOT include it.
- [ ] CLI 0.3.3 backwards compat: published-CLI push (no `content_hash` field) succeeds; new CLI later pulls and the cached hash matches what a fresh local hash would compute (no spurious re-upload on next push).
- [ ] TS/Python hash parity holds for single-file and multi-file tarballs.

### Memory extraction

- [ ] With `LLM_API_KEY` set: `clawdi session extract <local-id>` returns `✓ N memories extracted from <id>`. Dashboard `/memories` shows entries with `source="session"`.
- [ ] Without `LLM_API_KEY`: same command exits with code 2 and structured JSON `{error: "not_configured"}`.
- [ ] Onboarding skill loop: `session list --limit 5 --json | jq -r '.[].id' | xargs -I{} clawdi session extract {} --json` aggregates correctly across multiple sessions; exits early on first 503.
- [ ] Re-running extract on the same session DOES re-call the LLM (intentionally non-idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)