### PR TITLE
fix(cli/tests): align stale tests with API changes from earlier rounds

### DIFF
--- a/packages/cli/tests/adapters/claude-code.test.ts
+++ b/packages/cli/tests/adapters/claude-code.test.ts
@@ -96,18 +96,11 @@ describe("ClaudeCodeAdapter.collectSessions", () => {
 		expect(texts).toEqual(["hello", "world", "one more", "done"]);
 	});
 
-	it("filters by since", async () => {
-		const a = new ClaudeCodeAdapter();
-		// fixture starts at 2026-04-20T10:00:00Z
-		const future = new Date("2026-05-01T00:00:00Z");
-		expect(await a.collectSessions(future)).toHaveLength(0);
-	});
-
 	it("filters by projectFilter (matching cwd → encoded dir)", async () => {
 		const a = new ClaudeCodeAdapter();
-		const matched = await a.collectSessions(undefined, "/Users/fixture/project");
+		const matched = await a.collectSessions({ projectFilter: "/Users/fixture/project" });
 		expect(matched).toHaveLength(1);
-		const notMatched = await a.collectSessions(undefined, "/Users/other/project");
+		const notMatched = await a.collectSessions({ projectFilter: "/Users/other/project" });
 		expect(notMatched).toHaveLength(0);
 	});
 

--- a/packages/cli/tests/adapters/codex.test.ts
+++ b/packages/cli/tests/adapters/codex.test.ts
@@ -66,8 +66,8 @@ describe("CodexAdapter.collectSessions", () => {
 
 	it("filters by projectFilter", async () => {
 		const a = new CodexAdapter();
-		expect(await a.collectSessions(undefined, "/Users/fixture/project")).toHaveLength(1);
-		expect(await a.collectSessions(undefined, "/Users/other/project")).toHaveLength(0);
+		expect(await a.collectSessions({ projectFilter: "/Users/fixture/project" })).toHaveLength(1);
+		expect(await a.collectSessions({ projectFilter: "/Users/other/project" })).toHaveLength(0);
 	});
 
 	it("returns empty when sessions dir is missing", async () => {

--- a/packages/cli/tests/adapters/hermes.test.ts
+++ b/packages/cli/tests/adapters/hermes.test.ts
@@ -77,14 +77,6 @@ describe("HermesAdapter.collectSessions", () => {
 		expect(sessions.map((s) => s.localSessionId)).toEqual(["s-json", "s-plain"]);
 	});
 
-	it("filters by since (exclusive of older sessions)", async () => {
-		const a = new HermesAdapter();
-		// s-plain starts at t (1776247200), s-json at t+10. since between them keeps only s-json.
-		const since = new Date((1776247200 + 5) * 1000);
-		const sessions = await a.collectSessions(since);
-		expect(sessions.map((s) => s.localSessionId)).toEqual(["s-json"]);
-	});
-
 	it("projectPath is null for every Hermes session (by design)", async () => {
 		const a = new HermesAdapter();
 		const sessions = await a.collectSessions();

--- a/packages/cli/tests/adapters/openclaw.test.ts
+++ b/packages/cli/tests/adapters/openclaw.test.ts
@@ -133,16 +133,10 @@ describe("OpenClawAdapter.collectSessions", () => {
 		expect(s.summary).toBe("Fixture session");
 	});
 
-	it("filters by since (based on updatedAt)", async () => {
-		const a = new OpenClawAdapter();
-		const future = new Date("2026-05-01T00:00:00Z");
-		expect(await a.collectSessions(future)).toHaveLength(0);
-	});
-
 	it("filters by projectFilter matching acp.cwd", async () => {
 		const a = new OpenClawAdapter();
-		expect(await a.collectSessions(undefined, "/Users/fixture/project")).toHaveLength(1);
-		expect(await a.collectSessions(undefined, "/Users/other/project")).toHaveLength(0);
+		expect(await a.collectSessions({ projectFilter: "/Users/fixture/project" })).toHaveLength(1);
+		expect(await a.collectSessions({ projectFilter: "/Users/other/project" })).toHaveLength(0);
 	});
 
 	it("returns empty when sessions.json is missing", async () => {

--- a/packages/cli/tests/commands/pull.test.ts
+++ b/packages/cli/tests/commands/pull.test.ts
@@ -71,7 +71,7 @@ content
 		]);
 
 		try {
-			await pull({ agent: "hermes" });
+			await pull({ agent: "hermes", modules: "skills" });
 		} finally {
 			restore();
 		}
@@ -96,7 +96,7 @@ content
 			},
 		]);
 		try {
-			await pull({ agent: "hermes", dryRun: true });
+			await pull({ agent: "hermes", modules: "skills", dryRun: true });
 		} finally {
 			restore();
 		}
@@ -117,7 +117,7 @@ content
 			{ method: "GET", path: "/api/skills", response: () => jsonResponse({ items: [] }) },
 		]);
 		try {
-			await pull({ agent: "hermes" });
+			await pull({ agent: "hermes", modules: "skills" });
 		} finally {
 			restore();
 		}
@@ -129,7 +129,7 @@ content
 		rmSync(join(tmpHome, ".clawdi", "auth.json"));
 		const { captured, restore } = mockFetch([]);
 		try {
-			await pull({ agent: "hermes" });
+			await pull({ agent: "hermes", modules: "skills" });
 		} finally {
 			restore();
 		}
@@ -162,7 +162,7 @@ description: new
 			},
 		]);
 		try {
-			await pull({ agent: "claude_code" });
+			await pull({ agent: "claude_code", modules: "skills" });
 		} finally {
 			restore();
 		}
@@ -194,7 +194,7 @@ description: new
 			},
 		]);
 		try {
-			await pull({ agent: "codex" });
+			await pull({ agent: "codex", modules: "skills" });
 		} finally {
 			restore();
 		}
@@ -226,7 +226,7 @@ description: new
 			},
 		]);
 		try {
-			await pull({ agent: "openclaw" });
+			await pull({ agent: "openclaw", modules: "skills" });
 		} finally {
 			restore();
 		}

--- a/packages/cli/tests/commands/push.test.ts
+++ b/packages/cli/tests/commands/push.test.ts
@@ -62,7 +62,21 @@ describe("push — Hermes fixture", () => {
 		setup("hermes");
 		const { captured, restore } = mockFetch([
 			okEnvironmentProbe(),
-			{ method: "POST", path: "/api/sessions/batch", response: () => jsonResponse({ synced: 2 }) },
+			{
+				method: "POST",
+				path: "/api/sessions/batch",
+				// Round 2 (commit 4e013dc) replaced `{ synced: int }` with this
+				// 4-field response. The CLI reads `needs_content` to decide
+				// which sessions still need a content upload after batch — so
+				// this mock must list both ids or no follow-up uploads happen.
+				response: () =>
+					jsonResponse({
+						created: 2,
+						updated: 0,
+						unchanged: 0,
+						needs_content: ["s-json", "s-plain"],
+					}),
+			},
 			{ method: "POST", path: "/api/sessions/", response: () => jsonResponse({}) },
 		]);
 
@@ -87,9 +101,11 @@ describe("push — Hermes fixture", () => {
 		expect(uploads).toHaveLength(2);
 		for (const u of uploads) expect(u.isMultipart).toBe(true);
 
-		// state.json updated
+		// state.json updated. Round 1 (commit d8122d6) switched the cursor
+		// key from global `sessions` to per-agent `sessions:<agentType>` so
+		// pushing one agent doesn't advance another agent's cursor.
 		const state = JSON.parse(readFileSync(join(tmpHome, ".clawdi", "state.json"), "utf-8"));
-		expect(state.sessions.lastActivityAt).toBeDefined();
+		expect(state["sessions:hermes"]?.lastActivityAt).toBeDefined();
 	});
 
 	it("--dry-run makes zero fetch calls", async () => {
@@ -128,7 +144,17 @@ describe("push — Hermes fixture", () => {
 		writeFileSync(join(tmpHome, ".clawdi", "state.json"), "{ not valid json");
 		const { restore } = mockFetch([
 			okEnvironmentProbe(),
-			{ method: "POST", path: "/api/sessions/batch", response: () => jsonResponse({ synced: 2 }) },
+			{
+				method: "POST",
+				path: "/api/sessions/batch",
+				response: () =>
+					jsonResponse({
+						created: 2,
+						updated: 0,
+						unchanged: 0,
+						needs_content: ["s-json", "s-plain"],
+					}),
+			},
 			{ method: "POST", path: "/api/sessions/", response: () => jsonResponse({}) },
 		]);
 		try {
@@ -146,7 +172,11 @@ describe("push — Claude Code fixture", () => {
 		setup("claude-code");
 		const { captured, restore } = mockFetch([
 			okEnvironmentProbe(),
-			{ method: "POST", path: "/api/sessions/batch", response: () => jsonResponse({ synced: 1 }) },
+			{
+				method: "POST",
+				path: "/api/sessions/batch",
+				response: () => jsonResponse({ created: 1, updated: 0, unchanged: 0, needs_content: [] }),
+			},
 			{ method: "POST", path: "/api/sessions/", response: () => jsonResponse({}) },
 		]);
 		try {
@@ -171,7 +201,11 @@ describe("push — Codex fixture", () => {
 		setup("codex");
 		const { captured, restore } = mockFetch([
 			okEnvironmentProbe(),
-			{ method: "POST", path: "/api/sessions/batch", response: () => jsonResponse({ synced: 1 }) },
+			{
+				method: "POST",
+				path: "/api/sessions/batch",
+				response: () => jsonResponse({ created: 1, updated: 0, unchanged: 0, needs_content: [] }),
+			},
 			{ method: "POST", path: "/api/sessions/", response: () => jsonResponse({}) },
 		]);
 		try {
@@ -195,7 +229,11 @@ describe("push — OpenClaw fixture", () => {
 		setup("openclaw");
 		const { captured, restore } = mockFetch([
 			okEnvironmentProbe(),
-			{ method: "POST", path: "/api/sessions/batch", response: () => jsonResponse({ synced: 1 }) },
+			{
+				method: "POST",
+				path: "/api/sessions/batch",
+				response: () => jsonResponse({ created: 1, updated: 0, unchanged: 0, needs_content: [] }),
+			},
 			{ method: "POST", path: "/api/sessions/", response: () => jsonResponse({}) },
 		]);
 		try {


### PR DESCRIPTION
Three groups of pre-existing failures, surfaced when cli-publish.yml runs `bun test` (the regular client-ci.yml only runs biome + typecheck, not tests):

- Adapter `since` filter tests deleted: Round 1 moved `since` from the adapter API into a post-filter at the `session list` command layer. Adapters no longer accept `since`, so those tests were testing removed functionality.
- Adapter `projectFilter` tests rewritten to use the options-object signature `collectSessions({ projectFilter })` after Round 2 changed from positional args.
- Pull tests scoped to `modules: "skills"` — the default-all-modules flow now also tries to pull sessions, but tests only mock the skills endpoints and 404 on the unmocked /api/sessions.
- Push test mocks updated from old `{ synced: int }` response to the Round 2 shape `{ created, updated, unchanged, needs_content }`. The CLI reads `needs_content` to drive content uploads; without listing ids there, no upload happens and the test's upload assertion fails.
- Push test's `state.sessions.lastActivityAt` assertion updated to `state["sessions:hermes"].lastActivityAt` after Round 1 switched the cursor from a global key to per-agent keys.