### PR TITLE
auth: email-rebind fallback for snapshot-loaded preview environments

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 from datetime import UTC, datetime, timedelta
 
+import httpx
 import jwt
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -65,6 +66,62 @@ async def _auth_via_api_key(token: str, db: AsyncSession) -> AuthContext | None:
     return AuthContext(user=user, api_key=api_key)
 
 
+async def _fetch_clerk_primary_email(clerk_user_id: str) -> str | None:
+    """Look up a Clerk user's verified primary email via the Backend API.
+
+    Returns the email only if Clerk explicitly marks it as the user's primary
+    AND its verification status is "verified". Returns None for any other
+    outcome (network failure, non-200, malformed payload, no primary marked,
+    primary unverified). This is identity-binding: callers use the result to
+    decide which existing user row to take over, so we refuse to guess.
+    """
+    url = f"https://api.clerk.com/v1/users/{clerk_user_id}"
+    # Clerk's API is fronted by Cloudflare, which serves a 403 (error 1010)
+    # for requests lacking a recognizable User-Agent — including httpx's
+    # default. Set an explicit one.
+    headers = {
+        "Authorization": f"Bearer {settings.clerk_secret_key}",
+        "User-Agent": "clawdi-backend/1.0",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(url, headers=headers)
+        if resp.status_code != 200:
+            logger.warning(
+                "clerk backend api returned %s for user %s",
+                resp.status_code,
+                clerk_user_id,
+            )
+            return None
+        data = resp.json()
+    except (httpx.HTTPError, ValueError) as e:
+        logger.warning("clerk backend api lookup failed for %s: %s", clerk_user_id, e)
+        return None
+
+    primary_id = data.get("primary_email_address_id")
+    if not primary_id:
+        logger.warning("clerk user %s has no primary_email_address_id", clerk_user_id)
+        return None
+    for entry in data.get("email_addresses") or []:
+        if entry.get("id") != primary_id:
+            continue
+        verification = entry.get("verification") or {}
+        if verification.get("status") != "verified":
+            logger.warning(
+                "clerk primary email for %s is not verified (status=%s)",
+                clerk_user_id,
+                verification.get("status"),
+            )
+            return None
+        return entry.get("email_address")
+    logger.warning(
+        "clerk user %s primary_email_address_id %s not in email_addresses",
+        clerk_user_id,
+        primary_id,
+    )
+    return None
+
+
 async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | None:
     if not settings.clerk_pem_public_key:
         raise HTTPException(
@@ -88,11 +145,60 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
     result = await db.execute(select(User).where(User.clerk_id == clerk_id))
     user = result.scalar_one_or_none()
 
+    email = payload.get("email") or payload.get("email_address")
+
+    # Sub miss + snapshot-rebind opted in: try to attach to an existing
+    # snapshot row by verified email. We deliberately fail closed if any
+    # part of the identity proof is missing or ambiguous — a flaky Clerk
+    # API or a duplicate-email row must NOT silently fall through to
+    # auto-create, because the resulting empty row would then match this
+    # Clerk sub on every subsequent login and permanently shadow the
+    # real snapshot row.
+    if not user and settings.enable_snapshot_email_rebind:
+        if not email and settings.clerk_secret_key:
+            email = await _fetch_clerk_primary_email(clerk_id)
+        if not email:
+            logger.warning(
+                "snapshot rebind: refusing sign-in for clerk_id %s — no verified email",
+                clerk_id,
+            )
+            raise HTTPException(
+                status.HTTP_401_UNAUTHORIZED,
+                "Could not verify account identity for snapshot rebind.",
+            )
+
+        # `users.email` is not unique in the schema (production allows
+        # duplicates). Refuse to pick one if the result is ambiguous —
+        # whoever signs in first would otherwise get to choose which
+        # row they take over.
+        result = await db.execute(
+            select(User).where(User.email == email).order_by(User.created_at).limit(2)
+        )
+        candidates = list(result.scalars())
+        if len(candidates) > 1:
+            logger.error("snapshot rebind: ambiguous email match for %s (>=2 users)", email)
+            raise HTTPException(
+                status.HTTP_401_UNAUTHORIZED,
+                "Multiple accounts match this email; cannot rebind.",
+            )
+        if candidates:
+            user = candidates[0]
+            logger.info(
+                "snapshot rebind: user %s clerk_id %s -> %s (email match)",
+                user.id,
+                user.clerk_id,
+                clerk_id,
+            )
+            user.clerk_id = clerk_id
+            await db.commit()
+            await db.refresh(user)
+
     if not user:
-        # Auto-create user on first login
+        # First login (production path, or rebind enabled with no match):
+        # create a fresh user row bound to this Clerk sub.
         user = User(
             clerk_id=clerk_id,
-            email=payload.get("email") or payload.get("email_address"),
+            email=email,
             name=payload.get("name"),
         )
         db.add(user)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -19,6 +19,19 @@ class Settings(BaseSettings):
             return ""
         return v
 
+    @field_validator("clerk_secret_key", "clerk_pem_public_key", mode="before")
+    @classmethod
+    def _strip_wrapping_quotes(cls, v: object) -> object:
+        # Coolify's UI sometimes round-trips secret values with literal
+        # surrounding quotes (e.g. `'sk_test_...'`). When that env reaches us
+        # raw, the quotes end up baked into the Authorization header / JWT
+        # public key and Clerk rejects the request with a confusing 401 or
+        # signature-verification error. Strip a single matched pair on load
+        # so downstream code never has to think about it.
+        if isinstance(v, str) and len(v) >= 2 and v[0] == v[-1] and v[0] in ("'", '"'):
+            return v[1:-1]
+        return v
+
     app_name: str = "clawdi"
     environment: str = "development"  # development | staging | production
     debug: bool = False
@@ -44,6 +57,25 @@ class Settings(BaseSettings):
     sentry_traces_sample_rate: float = 0.0
 
     clerk_pem_public_key: str = ""
+    # Optional: Clerk Backend API secret. Used by the snapshot-email-rebind
+    # path to fetch a user's verified primary email when the session token
+    # doesn't carry an `email` claim. Only consulted when
+    # `enable_snapshot_email_rebind` is true.
+    clerk_secret_key: str = ""
+
+    # Opt-in for the email-rebind authentication path. When true, an
+    # incoming Clerk JWT whose `sub` doesn't match any existing user is
+    # rebound onto an existing row by exact email match (using the JWT's
+    # email claim, or falling back to a Clerk Backend API lookup if
+    # `clerk_secret_key` is set). Designed for preview deployments fed
+    # from a production snapshot whose users were issued by a different
+    # Clerk instance — sign-in needs to reattach to the snapshot row.
+    #
+    # Must NEVER be true in production: the rebind treats email as an
+    # identity claim, which is only safe when (a) the rebind is gated to
+    # snapshot data the operator already trusts, and (b) account takeover
+    # is bounded by that snapshot's contents.
+    enable_snapshot_email_rebind: bool = False
 
     vault_encryption_key: str = ""
     encryption_key: str = ""  # For JWT signing (MCP proxy tokens)

--- a/backend/tests/test_auth_email_rebind.py
+++ b/backend/tests/test_auth_email_rebind.py
@@ -1,0 +1,487 @@
+"""Snapshot-email-rebind path of ``_auth_via_clerk_jwt``.
+
+When a preview environment is fronted by a Clerk instance that's distinct
+from production's (e.g. a snapshot of a prod app loaded into a separate
+preview deployment that uses its own Clerk app), the JWTs from that
+instance carry a `sub` (clerk_id) that doesn't exist in the snapshot's
+`users` table. Without this path, sign-in auto-creates a fresh empty
+row and the operator sees an empty dashboard.
+
+The rebind is gated by ``settings.enable_snapshot_email_rebind`` — an
+explicit opt-in, NOT a function of `environment`. When enabled, the
+auth path:
+1. Tries the JWT's `email` claim. If absent and `clerk_secret_key` is
+   set, calls Clerk's Backend API to fetch the verified primary email.
+2. Refuses sign-in (401) if no verified email is available — fail
+   closed, because creating an empty row would permanently shadow the
+   real snapshot row on every future login (sub-match wins first).
+3. Looks up by email. If exactly one user matches, swaps its
+   `clerk_id` to the JWT's sub. If >1 match, refuses (401) — `users.email`
+   is not unique and we won't gamble on which row to take over.
+4. Otherwise (no match), creates a fresh row bound to the verified email.
+
+When the flag is off, behavior is identical to the legacy path: sub
+miss → fresh user, no Clerk-API call, no email matching.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import HTTPException
+from sqlalchemy import select
+
+from app.core import auth as auth_module
+from app.core.auth import _auth_via_clerk_jwt
+from app.core.config import settings
+from app.models.user import User
+
+
+def _rsa_keypair() -> tuple[str, str]:
+    """Throwaway RS256 keypair for signing test JWTs."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    ).decode()
+    public_pem = (
+        key.public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    return private_pem, public_pem
+
+
+@pytest.fixture
+def signing_key(monkeypatch):
+    """Install a test RS256 key into settings.clerk_pem_public_key.
+
+    Yields the private PEM so tests can sign JWTs that the auth path will
+    accept as valid.
+    """
+    private_pem, public_pem = _rsa_keypair()
+    monkeypatch.setattr(settings, "clerk_pem_public_key", public_pem)
+    yield private_pem
+
+
+def _sign(private_pem: str, sub: str, email: str | None) -> str:
+    return jwt.encode(
+        {"sub": sub, **({"email": email} if email else {})},
+        private_pem,
+        algorithm="RS256",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rebind enabled
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rebind_swaps_clerk_id_when_jwt_email_matches(db_session, signing_key, monkeypatch):
+    monkeypatch.setattr(settings, "enable_snapshot_email_rebind", True)
+    email = f"rebind_{uuid.uuid4().hex[:8]}@example.test"
+    original = User(clerk_id=f"orig_{uuid.uuid4().hex[:8]}", email=email, name="Rebind")
+    db_session.add(original)
+    await db_session.commit()
+    await db_session.refresh(original)
+    original_id = original.id
+
+    new_sub = f"new_{uuid.uuid4().hex[:8]}"
+    token = _sign(signing_key, sub=new_sub, email=email)
+    ctx = await _auth_via_clerk_jwt(token, db_session)
+
+    assert ctx is not None
+    assert ctx.user.id == original_id  # same row, snapshot data still attached
+    assert ctx.user.clerk_id == new_sub  # rebound to new Clerk's sub
+
+    await db_session.delete(ctx.user)
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_rebind_falls_back_to_clerk_api_when_jwt_lacks_email(
+    db_session, signing_key, monkeypatch
+):
+    """When the JWT carries no `email` claim, the rebind path consults the
+    Clerk Backend API for the verified primary email, then runs the normal
+    email-match rebind.
+    """
+    monkeypatch.setattr(settings, "enable_snapshot_email_rebind", True)
+    monkeypatch.setattr(settings, "clerk_secret_key", "sk_test_dummy")
+
+    email = f"clerkapi_{uuid.uuid4().hex[:8]}@example.test"
+    original = User(clerk_id=f"orig_{uuid.uuid4().hex[:8]}", email=email, name="ClerkAPI")
+    db_session.add(original)
+    await db_session.commit()
+    await db_session.refresh(original)
+    original_id = original.id
+
+    new_sub = f"new_{uuid.uuid4().hex[:8]}"
+    fetched: list[str] = []
+
+    async def fake_fetch(clerk_user_id: str):
+        fetched.append(clerk_user_id)
+        return email
+
+    monkeypatch.setattr(auth_module, "_fetch_clerk_primary_email", fake_fetch)
+
+    token = _sign(signing_key, sub=new_sub, email=None)
+    ctx = await _auth_via_clerk_jwt(token, db_session)
+
+    assert fetched == [new_sub]
+    assert ctx is not None
+    assert ctx.user.id == original_id
+    assert ctx.user.clerk_id == new_sub
+
+    await db_session.delete(ctx.user)
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_rebind_with_no_email_match_creates_fresh_user(db_session, signing_key, monkeypatch):
+    """Rebind enabled, JWT carries an email, but no existing row matches —
+    a fresh user is created bound to that email. New sign-ups in a preview
+    environment are still allowed; rebind is best-effort, not exclusive.
+    """
+    monkeypatch.setattr(settings, "enable_snapshot_email_rebind", True)
+    new_sub = f"new_{uuid.uuid4().hex[:8]}"
+    new_email = f"newuser_{uuid.uuid4().hex[:8]}@example.test"
+    token = _sign(signing_key, sub=new_sub, email=new_email)
+    ctx = await _auth_via_clerk_jwt(token, db_session)
+
+    assert ctx is not None
+    assert ctx.user.clerk_id == new_sub
+    assert ctx.user.email == new_email
+
+    await db_session.delete(ctx.user)
+    await db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Rebind enabled — fail-closed paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rebind_refuses_when_no_email_anywhere(db_session, signing_key, monkeypatch):
+    """If the JWT has no email AND no Clerk secret is set (or the API call
+    returns nothing), the rebind path raises 401 instead of auto-creating an
+    unbound empty row. That row would otherwise become a permanent identity
+    squatter — every subsequent login matches it on clerk_id and the real
+    snapshot row never gets considered again.
+    """
+    monkeypatch.setattr(settings, "enable_snapshot_email_rebind", True)
+    monkeypatch.setattr(settings, "clerk_secret_key", "")  # no API fallback
+
+    new_sub = f"new_{uuid.uuid4().hex[:8]}"
+    token = _sign(signing_key, sub=new_sub, email=None)
+
+    with pytest.raises(HTTPException) as exc:
+        await _auth_via_clerk_jwt(token, db_session)
+    assert exc.value.status_code == 401
+
+    # No user row was persisted for this sub.
+    leaked = (
+        await db_session.execute(select(User).where(User.clerk_id == new_sub))
+    ).scalar_one_or_none()
+    assert leaked is None
+
+
+@pytest.mark.asyncio
+async def test_rebind_refuses_when_clerk_api_returns_none(db_session, signing_key, monkeypatch):
+    """A transient Clerk API failure (timeout, 5xx, unverified primary) makes
+    the helper return None. The rebind path must refuse — see the
+    no-email-anywhere test for why.
+    """
+    monkeypatch.setattr(settings, "enable_snapshot_email_rebind", True)
+    monkeypatch.setattr(settings, "clerk_secret_key", "sk_test_dummy")
+
+    async def fake_fetch(clerk_user_id: str):
+        return None  # simulate any failure mode
+
+    monkeypatch.setattr(auth_module, "_fetch_clerk_primary_email", fake_fetch)
+
+    new_sub = f"new_{uuid.uuid4().hex[:8]}"
+    token = _sign(signing_key, sub=new_sub, email=None)
+
+    with pytest.raises(HTTPException) as exc:
+        await _auth_via_clerk_jwt(token, db_session)
+    assert exc.value.status_code == 401
+
+    leaked = (
+        await db_session.execute(select(User).where(User.clerk_id == new_sub))
+    ).scalar_one_or_none()
+    assert leaked is None
+
+
+@pytest.mark.asyncio
+async def test_rebind_refuses_ambiguous_email_match(db_session, signing_key, monkeypatch):
+    """`users.email` is not unique in the schema — production allows multiple
+    rows with the same email under different clerk_ids. If a sub-miss rebind
+    finds more than one candidate, refuse rather than silently picking one
+    (whoever signs in first would otherwise pre-empt the other rows).
+    """
+    monkeypatch.setattr(settings, "enable_snapshot_email_rebind", True)
+    email = f"dup_{uuid.uuid4().hex[:8]}@example.test"
+    a = User(clerk_id=f"a_{uuid.uuid4().hex[:8]}", email=email, name="A")
+    b = User(clerk_id=f"b_{uuid.uuid4().hex[:8]}", email=email, name="B")
+    db_session.add(a)
+    db_session.add(b)
+    await db_session.commit()
+
+    new_sub = f"new_{uuid.uuid4().hex[:8]}"
+    token = _sign(signing_key, sub=new_sub, email=email)
+
+    with pytest.raises(HTTPException) as exc:
+        await _auth_via_clerk_jwt(token, db_session)
+    assert exc.value.status_code == 401
+
+    # Neither candidate was rebound; no new row was created.
+    rows = (await db_session.execute(select(User).where(User.email == email))).scalars().all()
+    assert {u.clerk_id for u in rows} == {a.clerk_id, b.clerk_id}
+
+    await db_session.delete(a)
+    await db_session.delete(b)
+    await db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Rebind disabled (default / production)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rebind_disabled_creates_fresh_user_on_sub_miss(db_session, signing_key, monkeypatch):
+    """Default behavior — no rebind, no email matching, no Clerk-API call.
+    A sub miss creates a fresh user row, even if an existing row shares
+    the email. The original row's clerk_id stays untouched.
+    """
+    monkeypatch.setattr(settings, "enable_snapshot_email_rebind", False)
+    email = f"nopreview_{uuid.uuid4().hex[:8]}@example.test"
+    existing = User(clerk_id=f"orig_{uuid.uuid4().hex[:8]}", email=email, name="Existing")
+    db_session.add(existing)
+    await db_session.commit()
+    await db_session.refresh(existing)
+    existing_id = existing.id
+    existing_clerk_id = existing.clerk_id
+
+    different_sub = f"different_{uuid.uuid4().hex[:8]}"
+    token = _sign(signing_key, sub=different_sub, email=email)
+    ctx = await _auth_via_clerk_jwt(token, db_session)
+
+    assert ctx is not None
+    assert ctx.user.id != existing_id  # fresh row
+    assert ctx.user.clerk_id == different_sub
+
+    refreshed = (await db_session.execute(select(User).where(User.id == existing_id))).scalar_one()
+    assert refreshed.clerk_id == existing_clerk_id
+
+    await db_session.delete(ctx.user)
+    await db_session.delete(refreshed)
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_rebind_disabled_does_not_call_clerk_api(db_session, signing_key, monkeypatch):
+    """The Clerk Backend API lookup is gated on the rebind flag — even if
+    `clerk_secret_key` is configured (e.g. left over from a misconfigured
+    prod env), it must not fire when the flag is off.
+    """
+    monkeypatch.setattr(settings, "enable_snapshot_email_rebind", False)
+    monkeypatch.setattr(settings, "clerk_secret_key", "sk_test_dummy")
+
+    called = False
+
+    async def fake_fetch(clerk_user_id: str):
+        nonlocal called
+        called = True
+        return "should-not-be-used@example.test"
+
+    monkeypatch.setattr(auth_module, "_fetch_clerk_primary_email", fake_fetch)
+
+    new_sub = f"new_{uuid.uuid4().hex[:8]}"
+    token = _sign(signing_key, sub=new_sub, email=None)
+    ctx = await _auth_via_clerk_jwt(token, db_session)
+
+    assert called is False
+    assert ctx is not None
+    assert ctx.user.clerk_id == new_sub
+    assert ctx.user.email is None
+
+    await db_session.delete(ctx.user)
+    await db_session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Helper: _fetch_clerk_primary_email
+# ---------------------------------------------------------------------------
+
+
+def _clerk_user_response(*, primary_id: str | None, addresses: list[dict]) -> dict:
+    return {"primary_email_address_id": primary_id, "email_addresses": addresses}
+
+
+@pytest.mark.asyncio
+async def test_clerk_helper_returns_verified_primary(monkeypatch):
+    monkeypatch.setattr(settings, "clerk_secret_key", "sk_test_dummy")
+
+    payload = _clerk_user_response(
+        primary_id="idn_1",
+        addresses=[
+            {
+                "id": "idn_1",
+                "email_address": "alice@example.test",
+                "verification": {"status": "verified"},
+            },
+            {
+                "id": "idn_2",
+                "email_address": "alice+alt@example.test",
+                "verification": {"status": "verified"},
+            },
+        ],
+    )
+
+    class FakeResp:
+        status_code = 200
+
+        def json(self):
+            return payload
+
+    class FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def get(self, *a, **kw):
+            return FakeResp()
+
+    monkeypatch.setattr(auth_module.httpx, "AsyncClient", FakeClient)
+
+    got = await auth_module._fetch_clerk_primary_email("user_x")
+    assert got == "alice@example.test"
+
+
+@pytest.mark.asyncio
+async def test_clerk_helper_refuses_unverified_primary(monkeypatch):
+    monkeypatch.setattr(settings, "clerk_secret_key", "sk_test_dummy")
+
+    payload = _clerk_user_response(
+        primary_id="idn_1",
+        addresses=[
+            {
+                "id": "idn_1",
+                "email_address": "alice@example.test",
+                "verification": {"status": "unverified"},
+            },
+        ],
+    )
+
+    class FakeResp:
+        status_code = 200
+
+        def json(self):
+            return payload
+
+    class FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def get(self, *a, **kw):
+            return FakeResp()
+
+    monkeypatch.setattr(auth_module.httpx, "AsyncClient", FakeClient)
+
+    got = await auth_module._fetch_clerk_primary_email("user_x")
+    assert got is None
+
+
+@pytest.mark.asyncio
+async def test_clerk_helper_returns_none_when_no_primary_marked(monkeypatch):
+    """No primary_email_address_id — refuse to guess. Identity binding must
+    not silently pick the first address.
+    """
+    monkeypatch.setattr(settings, "clerk_secret_key", "sk_test_dummy")
+
+    payload = _clerk_user_response(
+        primary_id=None,
+        addresses=[
+            {
+                "id": "idn_1",
+                "email_address": "alice@example.test",
+                "verification": {"status": "verified"},
+            },
+        ],
+    )
+
+    class FakeResp:
+        status_code = 200
+
+        def json(self):
+            return payload
+
+    class FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def get(self, *a, **kw):
+            return FakeResp()
+
+    monkeypatch.setattr(auth_module.httpx, "AsyncClient", FakeClient)
+
+    got = await auth_module._fetch_clerk_primary_email("user_x")
+    assert got is None
+
+
+@pytest.mark.asyncio
+async def test_clerk_helper_returns_none_on_non_200(monkeypatch):
+    monkeypatch.setattr(settings, "clerk_secret_key", "sk_test_dummy")
+
+    class FakeResp:
+        status_code = 503
+
+        def json(self):
+            return {}
+
+    class FakeClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return None
+
+        async def get(self, *a, **kw):
+            return FakeResp()
+
+    monkeypatch.setattr(auth_module.httpx, "AsyncClient", FakeClient)
+
+    got = await auth_module._fetch_clerk_primary_email("user_x")
+    assert got is None

--- a/deploy/preview/docker-compose.yml
+++ b/deploy/preview/docker-compose.yml
@@ -110,6 +110,14 @@ services:
       # production tracker's value, not the PR-specific one.)
       ALLOWED_EMAIL_DOMAINS: ${ALLOWED_EMAIL_DOMAINS:-@example.com}
       CLERK_PEM_PUBLIC_KEY: ${CLERK_PEM_PUBLIC_KEY}
+      # Snapshot-rebind: opt-in path that reattaches a sign-in to an
+      # existing snapshot user row by verified email when the JWT's
+      # Clerk sub doesn't match (necessary because the preview's Clerk
+      # instance is distinct from the one that issued the snapshot).
+      # CLERK_SECRET_KEY is only consulted by this path and only when
+      # the JWT itself lacks an email claim.
+      ENABLE_SNAPSHOT_EMAIL_REBIND: "true"
+      CLERK_SECRET_KEY: ${CLERK_SECRET_KEY:-}
       VAULT_ENCRYPTION_KEY: ${VAULT_ENCRYPTION_KEY}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}
       COMPOSIO_API_KEY: ${COMPOSIO_API_KEY:-}


### PR DESCRIPTION
## Summary

Unblocks preview deployments whose Clerk instance is distinct from the one that issued the snapshot's user rows (e.g. a snapshot of a prod app loaded into a separate preview deployment with its own Clerk app). Without this, sign-in auto-creates a fresh empty user and the operator sees an empty dashboard despite the snapshot data being right there in PG.

## Behavior

Gated behind a new opt-in setting, `enable_snapshot_email_rebind` (defaults to `false`). When the flag is `true` and an incoming Clerk JWT misses on `sub`:

1. **JWT email** — try the JWT's `email` / `email_address` claim.
2. **Clerk Backend API** — if the JWT lacks an email AND `clerk_secret_key` is set, call `GET https://api.clerk.com/v1/users/{id}` for the primary email. Require an explicit `primary_email_address_id` AND `verification.status == "verified"` — no fallback-to-first heuristic; identity binding does not guess. (The helper sends a User-Agent because Clerk's API is fronted by Cloudflare which 403s default httpx requests.)
3. **Fail closed** — if no verified email is available, raise 401. Don't create an unbound row: it would match this Clerk sub on every subsequent login and permanently shadow the real snapshot row.
4. **Ambiguity check** — `SELECT … LIMIT 2`; if more than one user matches, raise 401. `users.email` has no `UNIQUE` constraint and we won't gamble on which row to take over.
5. **Rebind** — on a single match, swap that row's `clerk_id` to the JWT's sub. All user-owned tables (sessions, memories, vaults, skills, api_keys, …) join via `users.id` so snapshot data immediately attaches.
6. **Fresh user** — on no match, fall through to the standard fresh-user creation bound to the verified email; new sign-ups in a preview are still allowed.

When the flag is `false` (production default) the auth path is identical to the legacy behavior: sub miss → fresh user, no email matching, no Clerk API call even if `clerk_secret_key` is configured.

## Pieces

- `backend/app/core/auth.py` — `_fetch_clerk_primary_email()` helper + the layered fallback in `_auth_via_clerk_jwt`.
- `backend/app/core/config.py` — `clerk_secret_key`, `enable_snapshot_email_rebind`, and a small validator that strips wrapping single/double quotes from `clerk_secret_key` and `clerk_pem_public_key` (some env-var UIs round-trip secret values with literal `'…'` around them).
- `backend/tests/test_auth_email_rebind.py` — 12 tests covering all branches above plus helper-level cases.
- `deploy/preview/docker-compose.yml` — sets `ENABLE_SNAPSHOT_EMAIL_REBIND: "true"` and pipes `CLERK_SECRET_KEY` through to the api service.

## Test plan

- [x] `cd backend && uv run pytest tests/test_auth_email_rebind.py` → 12 passed
- [x] `bun run check` (Biome) clean
- [x] `bun run typecheck` (turbo) clean
- [x] Verified end-to-end on a snapshot-loaded preview: sign-in with a Clerk instance that omits the email claim now matches the snapshot user and restores the dashboard data