### PR TITLE
fix(cli): walk past dotfile components in resolveOwningSkillKey

### DIFF
--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { ApiError } from "../lib/api-client";
 import { isAuthFailure } from "./sync-engine";
 
@@ -93,5 +93,81 @@ describe("addInFlight / releaseInFlight refcount", () => {
 		releaseInFlight(m, "a");
 		expect(m.has("a")).toBe(false);
 		expect(m.has("b")).toBe(true);
+	});
+});
+
+describe("resolveOwningSkillKey — dotfile-component skip", () => {
+	// Reported in prod after the v0.5.0 daemon rollout: the codex
+	// adapter watches `~/.codex/skills/` recursively. gstack ships
+	// its own bundled sub-skills FOR OTHER AGENTS at paths like
+	// `~/.codex/skills/gstack/.agents/skills/<sub>/SKILL.md`.
+	// When the user (re)installs gstack, fs.watch fires for those
+	// nested SKILL.md writes, the resolver greedily returned
+	// `gstack/.agents/skills/<sub>` as the skill_key, daemon
+	// enqueued a push, server's SKILL_KEY_PATTERN rejected with
+	// 422 (every component must start with [A-Za-z0-9]), and the
+	// log accumulated 700+ permanent drops. The correct behavior
+	// is to keep walking up — the OUTERMOST non-dotfile ancestor
+	// (here `gstack`) IS the real skill on the codex adapter.
+	const { resolveOwningSkillKey } = require("./sync-engine") as {
+		resolveOwningSkillKey: (root: string, pathFromRoot: string) => string | null;
+	};
+
+	const fs = require("node:fs");
+	const path = require("node:path");
+	const os = require("node:os");
+
+	let tmp: string;
+	beforeEach(() => {
+		tmp = fs.mkdtempSync(path.join(os.tmpdir(), "skill-key-resolve-"));
+	});
+	afterEach(() => {
+		fs.rmSync(tmp, { recursive: true, force: true });
+	});
+
+	function makeSkillMd(...segments: string[]) {
+		const dir = path.join(tmp, ...segments);
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(path.join(dir, "SKILL.md"), "---\nname: x\n---\n");
+	}
+
+	it("returns the outer skill_key when a dotfile-nested SKILL.md exists", () => {
+		// Mirrors gstack's bundled-sub-skills layout: top-level
+		// `gstack/SKILL.md` is the real skill, `gstack/.agents/skills/<sub>/SKILL.md`
+		// are bundled artifacts that aren't standalone codex skills.
+		makeSkillMd("gstack");
+		makeSkillMd("gstack", ".agents", "skills", "gstack-autoplan");
+
+		// fs.watch fires on the deep nested file; resolver should
+		// walk up past the dotfile branch and report `gstack`.
+		expect(resolveOwningSkillKey(tmp, "gstack/.agents/skills/gstack-autoplan")).toBe("gstack");
+	});
+
+	it("returns null if every ancestor in the chain has a dotfile component", () => {
+		// `gstack/.agents/skills/<sub>` exists but `gstack/SKILL.md`
+		// does NOT — pathological case where the only skill candidate
+		// fails the regex. Resolver returns null so daemon doesn't
+		// enqueue anything.
+		makeSkillMd("gstack", ".agents", "skills", "gstack-autoplan");
+		expect(resolveOwningSkillKey(tmp, "gstack/.agents/skills/gstack-autoplan")).toBeNull();
+	});
+
+	it("returns the deepest valid skill_key for nested layouts (Hermes-style)", () => {
+		// Hermes nests `category/foo/SKILL.md` without a `category/SKILL.md`.
+		// Resolver should still pick the deepest match.
+		makeSkillMd("category", "foo");
+		expect(resolveOwningSkillKey(tmp, "category/foo")).toBe("category/foo");
+		expect(resolveOwningSkillKey(tmp, "category/foo/references")).toBe("category/foo");
+	});
+
+	it("returns the top-level dir for flat layouts (Claude Code / Codex)", () => {
+		makeSkillMd("autoplan");
+		expect(resolveOwningSkillKey(tmp, "autoplan")).toBe("autoplan");
+		expect(resolveOwningSkillKey(tmp, "autoplan/references/pattern.md")).toBe("autoplan");
+	});
+
+	it("returns null for a path with no SKILL.md ancestor", () => {
+		expect(resolveOwningSkillKey(tmp, "no-skill-here")).toBeNull();
+		expect(resolveOwningSkillKey(tmp, "deep/nested/no-skill")).toBeNull();
 	});
 });

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -1962,14 +1962,33 @@ async function rescanLocalSkillsForChanges(
  * ancestor has SKILL.md (e.g. a brand-new category dir before
  * its first nested skill is committed).
  */
-function resolveOwningSkillKey(rootDir: string, pathFromRoot: string): string | null {
+export function resolveOwningSkillKey(rootDir: string, pathFromRoot: string): string | null {
 	let cur = pathFromRoot;
 	// Bound the walk: 6 levels is more than the regex permits
 	// (4 components) so we'll always terminate even if the input
 	// is pathological.
 	for (let i = 0; i < 6; i++) {
 		if (!cur || cur === "." || cur === "/") return null;
-		if (existsSync(join(rootDir, cur, "SKILL.md"))) return cur;
+		if (existsSync(join(rootDir, cur, "SKILL.md"))) {
+			// Skip candidates with a dotfile-prefixed path
+			// component. Server's SKILL_KEY_PATTERN requires every
+			// component to start with `[A-Za-z0-9]`; a nested
+			// SKILL.md under a dotfile dir (e.g. gstack ships its
+			// own bundled sub-skills for other agents at
+			// `~/.codex/skills/gstack/.agents/skills/<sub>/SKILL.md`)
+			// would otherwise resolve to `gstack/.agents/skills/<sub>`
+			// and 422-spam the server. Walk up to the next
+			// candidate — typically the outermost real skill
+			// (`gstack`) which DOES have its own SKILL.md.
+			//
+			// This intentionally treats the dotfile match as
+			// "not a skill on this adapter" rather than returning
+			// null immediately, because the underlying file edit
+			// IS something we want to push — just under the
+			// correct outer skill_key, not the inner dotfile path.
+			const hasDotfileSegment = cur.split("/").some((seg) => seg.startsWith("."));
+			if (!hasDotfileSegment) return cur;
+		}
 		const parent = dirname(cur);
 		if (parent === cur) return null;
 		cur = parent;


### PR DESCRIPTION
## Why

After v0.5.0 daemon rolled to prod (#66), the codex daemon log showed **728 `engine.queue_drop_permanent` events** with HTTP 422 `SKILL_KEY_PATTERN` rejections for keys like `gstack/.agents/skills/gstack-autoplan`.

Root cause: gstack ships its own bundled sub-skills FOR OTHER AGENTS at `~/.codex/skills/gstack/.agents/skills/<sub>/SKILL.md`. fs.watch fires for those, and `resolveOwningSkillKey` greedily returned the deepest SKILL.md match. Server's regex requires every path component to start with `[A-Za-z0-9]`, so each push 422'd → permanent drop → dashboard error log spam.

## Fix

Walk up past dotfile-prefixed components, picking the first SKILL.md-bearing ancestor whose path is regex-clean. For codex `gstack/.agents/skills/<sub>/SKILL.md` → returns `gstack` (the real top-level skill). If no clean ancestor exists, return null (no enqueue).

## Tests

5 new test cases:
- Dotfile-nested case (gstack shape) → returns outer skill_key
- All-dotfile chain (no clean ancestor) → returns null
- Hermes-style nested layouts → still resolves correctly
- Flat top-level layout (Claude Code / Codex) → still resolves correctly
- No SKILL.md path → returns null

CLI tests: 236 (was 231).

## Test plan
- [x] CLI test suite passes
- [x] Type check + lint clean
- [ ] Real prod daemon (post-deploy): no more 422 spam in `~/.clawdi/serve/logs/codex.stderr.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)