### PR TITLE
fix(backend): graceful fallback when memory_provider=mem0 but mem0ai missing

### DIFF
--- a/backend/app/services/memory_provider.py
+++ b/backend/app/services/memory_provider.py
@@ -535,6 +535,26 @@ async def get_memory_provider(user_id: str, db: AsyncSession) -> MemoryProvider:
         except (ValueError, RuntimeError, TypeError) as e:
             log.error("failed to decrypt mem0_api_key, falling back to builtin: %s", e)
             return BuiltinProvider(db, embedder=resolve_embedder())
-        return Mem0Provider(api_key=api_key)
+        # Mem0 is an OPTIONAL integration — `mem0ai` is not in
+        # `pyproject.toml` because most deployments use the builtin
+        # pgvector provider and Mem0 brings a heavy dependency
+        # tree. Existing user_settings rows can carry
+        # `memory_provider=mem0` from before the package was
+        # removed (or from a deployment that had it installed).
+        # Without this guard, GET /api/memories 500s for every
+        # such user with `ModuleNotFoundError: 'mem0'` —
+        # observed in prod after #66 deployed against a venv
+        # that doesn't ship mem0ai. Fall back to builtin and
+        # warn so the user can either install the optional dep
+        # or update their setting.
+        try:
+            return Mem0Provider(api_key=api_key)
+        except ImportError as e:
+            log.warning(
+                "memory_provider=mem0 but mem0ai is not installed in this "
+                "deployment, falling back to builtin: %s",
+                e,
+            )
+            return BuiltinProvider(db, embedder=resolve_embedder())
 
     return BuiltinProvider(db, embedder=resolve_embedder())

--- a/backend/tests/test_memory_provider_fallback.py
+++ b/backend/tests/test_memory_provider_fallback.py
@@ -1,0 +1,130 @@
+"""Memory provider fallback tests.
+
+After PR #66 deployed to a venv without `mem0ai`, every
+`GET /api/memories` for a user whose `user_settings.settings`
+carries `memory_provider == "mem0"` 500'd with
+`ModuleNotFoundError: 'mem0'`. The provider factory now catches
+the ImportError and falls back to BuiltinProvider so a stale
+setting (or an opt-in optional dep that wasn't installed in this
+deployment) doesn't 500 every memory request.
+
+This file pins the fallback behavior. Two cases:
+  1. `memory_provider=mem0` set + decryptable api_key + mem0ai
+     installed → returns Mem0Provider (happy path).
+  2. `memory_provider=mem0` set + decryptable api_key + mem0ai
+     NOT installed → returns BuiltinProvider, logs a warning.
+"""
+
+from __future__ import annotations
+
+import builtins
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User, UserSetting
+from app.services.memory_provider import (
+    BuiltinProvider,
+    Mem0Provider,
+    get_memory_provider,
+)
+from app.services.vault_crypto import encrypt_field
+
+
+@pytest.mark.asyncio
+async def test_get_memory_provider_falls_back_to_builtin_when_mem0ai_missing(
+    db_session: AsyncSession, seed_user: User, monkeypatch
+):
+    """Round-r66-postship P1: prod observed
+    `ModuleNotFoundError: 'mem0'` 500-ing every /api/memories
+    request for users with stale `memory_provider=mem0` in
+    user_settings. Falls back to builtin on ImportError instead
+    of crashing the request.
+    """
+    setting = UserSetting(
+        user_id=seed_user.id,
+        settings={
+            "memory_provider": "mem0",
+            "mem0_api_key": encrypt_field("mock-api-key"),
+        },
+    )
+    db_session.add(setting)
+    await db_session.commit()
+
+    # Simulate `mem0ai` not installed: monkeypatch __import__ to
+    # raise ImportError on `from mem0 import MemoryClient`. This
+    # is what Mem0Provider.__init__ does internally; the factory
+    # must catch it.
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "mem0":
+            raise ImportError("No module named 'mem0'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    provider = await get_memory_provider(str(seed_user.id), db_session)
+
+    assert isinstance(provider, BuiltinProvider), (
+        f"expected BuiltinProvider fallback when mem0 missing, got {type(provider).__name__}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_memory_provider_uses_mem0_when_installed_and_configured(
+    db_session: AsyncSession, seed_user: User, monkeypatch
+):
+    """Happy path: settings request mem0, mem0 imports cleanly,
+    factory returns Mem0Provider. Locks the contract that the
+    fallback ONLY fires on ImportError (not silently overriding
+    a working mem0 setup)."""
+    setting = UserSetting(
+        user_id=seed_user.id,
+        settings={
+            "memory_provider": "mem0",
+            "mem0_api_key": encrypt_field("mock-api-key"),
+        },
+    )
+    db_session.add(setting)
+    await db_session.commit()
+
+    # Stub `Mem0Provider.__init__` so the test doesn't actually
+    # need mem0ai installed at test time. The factory's fallback
+    # logic is gated on ImportError, not on mem0ai being present
+    # in CI's venv — letting Mem0Provider be constructable
+    # exercises the success path.
+    constructed: list = []
+
+    def fake_init(self, api_key):
+        constructed.append(api_key)
+
+    monkeypatch.setattr(Mem0Provider, "__init__", fake_init)
+
+    provider = await get_memory_provider(str(seed_user.id), db_session)
+
+    assert isinstance(provider, Mem0Provider)
+    assert constructed == ["mock-api-key"]
+
+
+@pytest.mark.asyncio
+async def test_get_memory_provider_uses_builtin_when_no_setting(
+    db_session: AsyncSession, seed_user: User
+):
+    """No setting row, no mem0 preference → builtin, no
+    fallback path involved. Sanity check the default."""
+    # Note: don't insert any UserSetting row — the lookup hits
+    # the empty path.
+    provider = await get_memory_provider(str(seed_user.id), db_session)
+    assert isinstance(provider, BuiltinProvider)
+
+
+@pytest.mark.asyncio
+async def test_get_memory_provider_handles_unknown_user_id(db_session: AsyncSession):
+    """A user_id with no row in either users or user_settings
+    should not crash — the factory just looks up settings.
+    Returns builtin (no setting → default path)."""
+    fake_id = str(uuid.uuid4())
+    provider = await get_memory_provider(fake_id, db_session)
+    assert isinstance(provider, BuiltinProvider)


### PR DESCRIPTION
## Why

Prod observed: `GET /api/memories?page=1&page_size=25` returns **500 Internal Server Error** for users whose `user_settings.settings.memory_provider == "mem0"`. Spotted while reviewing post-#66 prod logs.

```
ModuleNotFoundError: No module named 'mem0'
  File ".../app/services/memory_provider.py", line 265, in __init__
    from mem0 import MemoryClient
```

5+ user_settings rows in current prod data carry `memory_provider=mem0`.

## Real cause (corrected)

`Mem0Provider` was added to `app/services/memory_provider.py` in commit `d358921` and refactored in `fbbfa9c`. **`mem0ai` was never added to `pyproject.toml` or `uv.lock` in any commit.** The class lazy-imports `from mem0 import MemoryClient` inside `__init__`, so any call path that tries to instantiate it raises `ImportError`.

This means **`Mem0Provider` has been broken since the day it was written** — not a regression from #66. The 5 users with `memory_provider=mem0` (likely set via a dashboard settings UI that doesn't depend on the package) have been hitting 500s on `/api/memories` for months. We just noticed it now while inspecting post-#66 prod logs.

## Fix

`get_memory_provider` already has a fallback for decrypt failures two lines above this (a precedent for "swallow + warn + use builtin"). Add the same shape for ImportError when constructing Mem0Provider — fall back to BuiltinProvider with a warning log instead of 500-ing the request.

Users with stale `memory_provider=mem0` setting silently get builtin behavior. Their existing memories live in PG (BuiltinProvider's storage) and load fine — none of them was ever actually using mem0 SaaS for storage because the package was never installed to talk to it.

Operators who DO want mem0 in this deployment can `uv add mem0ai` and the fallback stops firing.

## Tests

4 new test cases:
- ImportError → BuiltinProvider fallback (with monkeypatched `__import__`)
- Mem0Provider constructable (stubbed `__init__`) → returns Mem0Provider (happy path locks the contract that fallback only fires on ImportError)
- No user_settings row → BuiltinProvider default
- Unknown user_id → BuiltinProvider, no crash

Backend tests: 134 (was 130).

## Deployment

After merge:
```sh
ssh clawdi
cd /opt/clawdi-cloud && git pull origin main
sudo supervisorctl restart 'clawdi-cloud-backend:*'
```

No migration. No CLI changes. Just backend code.

## Test plan
- [x] Backend test suite passes
- [x] Ruff check + format clean
- [ ] Confirm prod `/api/memories` returns 200 post-deploy for affected users

🤖 Generated with [Claude Code](https://claude.com/claude-code)