### PR TITLE
fix(post-#66): batch of 5 prod-log bugs in one PR

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -65,6 +65,15 @@ jobs:
         run: uv run ruff format --check app
       - name: Byte-compile sanity check
         run: uv run python -m compileall -q app
+      # Catch "import declared in code but not in deps" drift.
+      # The same class of bug that let `from mem0 import …` ship
+      # for months without `mem0ai` ever being declared, surfacing
+      # only as 500s in prod after PR #66 merged. `deptry`
+      # cross-references every top-level import in `app/` against
+      # `[project] dependencies` + `[project.optional-dependencies]`
+      # and flags drift. Config in `pyproject.toml [tool.deptry]`.
+      - name: Dependency drift check
+        run: uv run deptry app
 
   test:
     needs: changes

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ data/
 # Local dev seed scripts — they embed user-specific paths and personal
 # memory content; keep them out of the repo.
 backend/scripts/seed_demo.py
+backend/pdm.lock

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -7,6 +7,7 @@ import jwt
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -190,8 +191,33 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
                 clerk_id,
             )
             user.clerk_id = clerk_id
-            await db.commit()
-            await db.refresh(user)
+            # Concurrent rebind race: two requests carrying the
+            # same Clerk JWT can both read the same candidate
+            # row, both write the same `clerk_id`, and the
+            # second commit hits `users_clerk_id_key` unique
+            # violation. Pre-fix this 500'd dashboard /stats /
+            # contribution / memories for affected users (14
+            # events observed in prod log post-#66 deploy).
+            # Catch the IntegrityError, rollback, and re-query
+            # by clerk_id — by the time we get here the winner
+            # has committed and the row carries the new
+            # clerk_id, so the lookup converges.
+            try:
+                await db.commit()
+                await db.refresh(user)
+            except IntegrityError:
+                await db.rollback()
+                result = await db.execute(select(User).where(User.clerk_id == clerk_id))
+                user = result.scalar_one_or_none()
+                if user is None:
+                    # Both writers somehow lost the row — extremely
+                    # unlikely (would require a concurrent delete
+                    # of all matching rows). Fail closed with
+                    # 401 rather than 500 so the client retries.
+                    raise HTTPException(
+                        status.HTTP_401_UNAUTHORIZED,
+                        "could not load user after rebind race",
+                    ) from None
 
     if not user:
         # First login (production path, or rebind enabled with no
@@ -207,8 +233,6 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
         # the `users.clerk_id` unique constraint. Catch the
         # IntegrityError, rollback, and re-query — the row is
         # there now from the winner.
-        from sqlalchemy.exc import IntegrityError
-
         from app.models.scope import SCOPE_KIND_PERSONAL
         from app.models.scope import Scope as _Scope
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from app.middleware.body_size_limit import BodySizeLimitMiddleware
 from app.middleware.request_id import RequestIDMiddleware
 from app.middleware.security_headers import SecurityHeadersMiddleware
 from app.routes.auth import router as auth_router
+from app.routes.capabilities import router as capabilities_router
 from app.routes.cli_auth import router as cli_auth_router
 from app.routes.connectors import router as connectors_router
 from app.routes.dashboard import router as dashboard_router
@@ -159,6 +160,7 @@ app.include_router(skills_scope_router)
 app.include_router(sync_router)
 app.include_router(memories_router)
 app.include_router(settings_router)
+app.include_router(capabilities_router)
 app.include_router(vault_router)
 app.include_router(connectors_router)
 app.include_router(mcp_proxy_router)

--- a/backend/app/routes/capabilities.py
+++ b/backend/app/routes/capabilities.py
@@ -1,0 +1,50 @@
+"""Backend capability flags for the dashboard.
+
+Single GET endpoint that exposes which optional features the
+current deployment supports, so the UI can hide / disable
+controls that the backend can't honor (e.g. the `Mem0` memory
+provider option when the `[mem0]` extra isn't installed).
+
+Auth: any logged-in user (Clerk JWT). Capabilities are
+deployment-wide, not per-user, so we don't need scope checks —
+but we do require auth so unauth probes can't fingerprint the
+deployment.
+
+Cached at the module level via the underlying
+`mem0_available()` helper (lru). Called once per dashboard page
+load; near-zero cost.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from app.core.auth import AuthContext, require_user_auth
+from app.services.memory_provider import mem0_available
+
+router = APIRouter(prefix="/api", tags=["capabilities"])
+
+
+class CapabilitiesResponse(BaseModel):
+    """Feature flags the dashboard branches on.
+
+    Add new fields here when introducing optional integrations.
+    Keep field names stable — the frontend treats this response
+    as a feature-detection contract."""
+
+    memory_providers: list[str]
+    """Memory providers the backend can serve. Always includes
+    `\"builtin\"`. Includes `\"mem0\"` iff the `[mem0]` optional
+    extra is installed and the `mem0` Python module imports
+    cleanly. UI hides any provider not in this list."""
+
+
+@router.get("/capabilities")
+async def get_capabilities(
+    _auth: AuthContext = Depends(require_user_auth),
+) -> CapabilitiesResponse:
+    providers = ["builtin"]
+    if mem0_available():
+        providers.append("mem0")
+    return CapabilitiesResponse(memory_providers=providers)

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -11,6 +11,7 @@ from app.schemas.settings import (
     SettingsUpdate,
     SettingsUpdateResponse,
 )
+from app.services.memory_provider import mem0_available
 from app.services.vault_crypto import encrypt_field, is_encrypted_field
 
 router = APIRouter(prefix="/api/settings", tags=["settings"])
@@ -81,6 +82,26 @@ async def update_settings(
         for k, v in body.settings.items()
         if not (k in SECRET_FIELDS and isinstance(v, str) and v == _SECRET_MASK)
     }
+
+    # Validate memory_provider — refuse `mem0` if the deployment
+    # doesn't have the optional `[mem0]` extra installed. Pre-fix
+    # the dashboard would happily save the value, then GET
+    # /api/memories would 500 with `ModuleNotFoundError: 'mem0'`
+    # for that user every time. The factory has an ImportError
+    # fallback as defense-in-depth, but failing closed at write
+    # time gives the user an actionable error ("not available on
+    # this deployment") instead of a silent downgrade.
+    if raw_patch.get("memory_provider") == "mem0" and not mem0_available():
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "memory_provider_unavailable",
+                "message": (
+                    "Mem0 memory provider isn't available on this deployment. "
+                    "The operator must install the [mem0] extra on the backend."
+                ),
+            },
+        )
 
     # Step 2: encrypt any remaining secret fields the client actually wants to set.
     encrypted_patch = _encrypt_secrets(raw_patch)

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -185,6 +185,18 @@ _SKILL_HASH_EXCLUDE = {
     ".ruff_cache",
     ".tox",
     "coverage",
+    # Cross-agent skill bundles — see tar.ts for full reasoning.
+    # gstack-shaped meta-skills ship sub-skills for other agents
+    # under these dotfile dirs; the outer skill's hash must NOT
+    # include them or it'd diverge from what the CLI tar uploads.
+    ".agents",
+    ".cursor",
+    ".factory",
+    ".openclaw",
+    ".hermes",
+    ".gbrain",
+    ".claude",
+    ".codex",
 }
 
 

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -52,7 +52,17 @@ class SessionCreate(BaseModel):
 
 
 class SessionBatchRequest(BaseModel):
-    sessions: list[SessionCreate]
+    # Cap at 500 sessions per request. The upsert builds a single
+    # multi-VALUES INSERT with ~17 bound parameters per row;
+    # asyncpg refuses queries with > 32767 parameters total
+    # (PostgreSQL wire protocol limit). Pre-fix `clawdi push
+    # --modules sessions --all` shipped every session in one
+    # body — observed 500-ing in prod with
+    # `sqlalchemy.exc.InterfaceError: ... query arguments cannot
+    # exceed 32767` for users with > ~1900 sessions. 500 leaves
+    # ample headroom (8500 params) and the CLI side now chunks
+    # to match (packages/cli/src/commands/push.ts).
+    sessions: list[SessionCreate] = Field(max_length=500)
 
 
 class EnvironmentCreate(BaseModel):

--- a/backend/app/services/memory_provider.py
+++ b/backend/app/services/memory_provider.py
@@ -507,23 +507,38 @@ def _merge_hybrid(
 
 
 def mem0_available() -> bool:
-    """Whether the `mem0` Python module is importable in this
-    deployment. Drives the dashboard capability flag (see
-    `routes/capabilities.py`) and the settings-save validator
-    (`routes/settings.py`) — UI hides the option when not
-    available; settings refuses to persist a memory_provider=mem0
-    value the backend can't honor.
+    """Whether the `mem0` Python module is actually importable
+    in this deployment. Drives the dashboard capability flag
+    (see `routes/capabilities.py`) and the settings-save
+    validator (`routes/settings.py`) — UI hides the option
+    when not available; settings refuses to persist a
+    memory_provider=mem0 value the backend can't honor.
 
-    Cached because it never changes within a process — re-checking
-    on every request needlessly thrashes the import system.
+    Probes by REAL import, not `find_spec`. `find_spec` returns
+    truthy even when the module's transitive dependencies fail
+    to load (broken `[mem0]` install, partially-installed venv).
+    A truthy `find_spec` followed by a failing real import would
+    let `/api/capabilities` advertise mem0, the settings page
+    accept the value, then `Mem0Provider.__init__` catch the
+    ImportError and silently degrade to builtin — leaving the
+    user with a UI saying "Currently using: mem0" and behavior
+    that's actually builtin. Real import probes the same path
+    the runtime would take.
+
+    Cached because it never changes within a process — re-
+    checking on every request needlessly thrashes the import
+    system.
     """
     global _mem0_available_cached
     cached = _mem0_available_cached
     if cached is not None:
         return cached
-    import importlib.util
+    try:
+        import mem0  # noqa: F401  -- presence check, not used here
 
-    cached = importlib.util.find_spec("mem0") is not None
+        cached = True
+    except ImportError:
+        cached = False
     _mem0_available_cached = cached
     return cached
 

--- a/backend/app/services/memory_provider.py
+++ b/backend/app/services/memory_provider.py
@@ -506,6 +506,31 @@ def _merge_hybrid(
 # ---------- provider selection ----------
 
 
+def mem0_available() -> bool:
+    """Whether the `mem0` Python module is importable in this
+    deployment. Drives the dashboard capability flag (see
+    `routes/capabilities.py`) and the settings-save validator
+    (`routes/settings.py`) — UI hides the option when not
+    available; settings refuses to persist a memory_provider=mem0
+    value the backend can't honor.
+
+    Cached because it never changes within a process — re-checking
+    on every request needlessly thrashes the import system.
+    """
+    global _mem0_available_cached
+    cached = _mem0_available_cached
+    if cached is not None:
+        return cached
+    import importlib.util
+
+    cached = importlib.util.find_spec("mem0") is not None
+    _mem0_available_cached = cached
+    return cached
+
+
+_mem0_available_cached: bool | None = None
+
+
 async def get_memory_provider(user_id: str, db: AsyncSession) -> MemoryProvider:
     """Resolve the memory provider for a user.
 
@@ -535,6 +560,21 @@ async def get_memory_provider(user_id: str, db: AsyncSession) -> MemoryProvider:
         except (ValueError, RuntimeError, TypeError) as e:
             log.error("failed to decrypt mem0_api_key, falling back to builtin: %s", e)
             return BuiltinProvider(db, embedder=resolve_embedder())
-        return Mem0Provider(api_key=api_key)
+        # Defense-in-depth: even with the [mem0] extra installed,
+        # a transient import failure (broken venv, partial install)
+        # shouldn't 500 every memory request — the builtin provider
+        # is always functional. Settings save validation also
+        # checks `mem0_available()` before allowing the value to
+        # land in user_settings, so this branch is the safety net,
+        # not the primary gate.
+        try:
+            return Mem0Provider(api_key=api_key)
+        except ImportError as e:
+            log.warning(
+                "memory_provider=mem0 but mem0 module is not importable in this "
+                "deployment (install the [mem0] extra); falling back to builtin: %s",
+                e,
+            )
+            return BuiltinProvider(db, embedder=resolve_embedder())
 
     return BuiltinProvider(db, embedder=resolve_embedder())

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,13 +23,58 @@ dependencies = [
     "pyyaml>=6.0",
 ]
 
+[project.optional-dependencies]
+# Mem0 SaaS-backed memory provider. Optional because most
+# self-hosters use the builtin pgvector provider and mem0ai
+# pulls a heavy transitive dep tree. Enable per deployment
+# with `uv pip install -e ".[mem0]"`. The `Mem0Provider`
+# class lazy-imports `mem0`, and `get_memory_provider` falls
+# back to the builtin provider with a warning when the import
+# fails — so this extra controls whether mem0 is *available*,
+# not whether memories work at all.
+mem0 = ["mem0ai>=0.1"]
+
 [dependency-groups]
 dev = [
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
     "aiosqlite>=0.20",
     "ruff>=0.9",
+    # Catch "import declared in code but not in deps" drift —
+    # the same class of bug that let mem0/mem0ai stay
+    # undeclared for months without CI noticing.
+    "deptry>=0.20",
 ]
+
+[tool.deptry]
+known_first_party = ["app"]
+extend_exclude = ["alembic/"]
+
+# `pydantic` and `starlette` are pulled in transitively via
+# fastapi / pydantic-settings; we import them directly in many
+# places without declaring them. Whitelist for now — promote to
+# direct deps if the transitive chain ever changes upstream.
+[tool.deptry.per_rule_ignores]
+DEP003 = ["pydantic", "starlette"]
+# DEP002 = "declared but not imported." These are runtime
+# infrastructure — used via SQLAlchemy/FastAPI/CLI, not
+# imported by name in app/. Removing them would actually
+# break the runtime, so silence the noise.
+DEP002 = [
+    "uvicorn",            # ASGI server runtime; invoked as a binary.
+    "asyncpg",            # SQLAlchemy postgresql+asyncpg driver.
+    "alembic",            # Migration CLI.
+    "python-multipart",   # FastAPI multipart parser; loaded via Form().
+    "aiofiles",           # FastAPI's UploadFile uses async file I/O internally.
+    "psycopg2-binary",    # Sync PG driver kept for alembic offline-mode SQL.
+]
+
+# `app/services/memory_provider.py` imports `mem0` only inside
+# `Mem0Provider.__init__`, gated on the `[mem0]` extra. Without
+# this mapping deptry DEP001 fires on any install that omits the
+# extra (the default).
+[tool.deptry.package_module_name_map]
+mem0ai = "mem0"
 
 [tool.pdm.scripts]
 dev = "uvicorn app.main:app --reload --host 0.0.0.0 --port 8000"

--- a/backend/tests/test_capabilities.py
+++ b/backend/tests/test_capabilities.py
@@ -1,11 +1,4 @@
-"""Capabilities endpoint tests.
-
-`/api/capabilities` exposes deployment-wide feature flags that
-the dashboard uses to hide UI for unavailable optional
-integrations. Pinned to keep the contract stable across
-changes — adding a new feature is fine, breaking an existing
-flag's name or shape is not.
-"""
+"""Tests for /api/capabilities and the mem0 settings save guard."""
 
 from __future__ import annotations
 
@@ -26,23 +19,21 @@ async def test_capabilities_includes_builtin_always(client: httpx.AsyncClient):
     )
 
 
-@pytest.mark.asyncio
-async def test_capabilities_excludes_mem0_when_unavailable(client: httpx.AsyncClient, monkeypatch):
-    """When the [mem0] extra isn't installed, `/api/capabilities`
-    must NOT include `mem0`. Pre-fix the dashboard happily showed
-    the option for users on a backend that couldn't honor it."""
-    monkeypatch.setattr(mp, "_mem0_available_cached", None)
-    monkeypatch.setattr(mp, "mem0_available", lambda: False)
-    # `routes/settings.py` and `routes/capabilities.py` import
-    # `mem0_available` as a bound name; the rebind in `mp` alone
-    # leaves their references pointing at the original. Patch
-    # those modules' bound names too.
+def _patch_mem0_available(monkeypatch, *, available: bool) -> None:
+    # `routes/settings.py` and `routes/capabilities.py` bind
+    # `mem0_available` at import time, so patching `mp` alone
+    # leaves their references pointing at the original.
     import app.routes.capabilities as cap
     import app.routes.settings as st
 
-    monkeypatch.setattr(cap, "mem0_available", lambda: False)
-    monkeypatch.setattr(st, "mem0_available", lambda: False)
+    monkeypatch.setattr(mp, "_mem0_available_cached", None)
+    for mod in (mp, cap, st):
+        monkeypatch.setattr(mod, "mem0_available", lambda: available)
 
+
+@pytest.mark.asyncio
+async def test_capabilities_excludes_mem0_when_unavailable(client: httpx.AsyncClient, monkeypatch):
+    _patch_mem0_available(monkeypatch, available=False)
     r = await client.get("/api/capabilities")
     assert r.status_code == 200, r.text
     assert "mem0" not in r.json()["memory_providers"]
@@ -50,14 +41,7 @@ async def test_capabilities_excludes_mem0_when_unavailable(client: httpx.AsyncCl
 
 @pytest.mark.asyncio
 async def test_capabilities_includes_mem0_when_available(client: httpx.AsyncClient, monkeypatch):
-    monkeypatch.setattr(mp, "_mem0_available_cached", None)
-    monkeypatch.setattr(mp, "mem0_available", lambda: True)
-    import app.routes.capabilities as cap
-    import app.routes.settings as st
-
-    monkeypatch.setattr(cap, "mem0_available", lambda: True)
-    monkeypatch.setattr(st, "mem0_available", lambda: True)
-
+    _patch_mem0_available(monkeypatch, available=True)
     r = await client.get("/api/capabilities")
     assert r.status_code == 200, r.text
     assert "mem0" in r.json()["memory_providers"]
@@ -65,8 +49,7 @@ async def test_capabilities_includes_mem0_when_available(client: httpx.AsyncClie
 
 @pytest.mark.asyncio
 async def test_capabilities_requires_auth():
-    """Unauth probes shouldn't fingerprint the deployment.
-    Spin up a fresh client without auth to verify."""
+    # Unauth probes shouldn't fingerprint the deployment.
     from httpx import ASGITransport
 
     from app.main import app
@@ -74,52 +57,19 @@ async def test_capabilities_requires_auth():
     transport = ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as raw:
         r = await raw.get("/api/capabilities")
-        # 401 (no auth) or 403 (CLI key not allowed); never 200.
         assert r.status_code in (401, 403), r.text
 
 
 @pytest.mark.asyncio
 async def test_settings_refuses_mem0_when_unavailable(client: httpx.AsyncClient, monkeypatch):
-    """Settings save endpoint must refuse `memory_provider=mem0`
-    when the backend can't honor it. Pre-fix the dashboard would
-    save the value, then `/api/memories` 500'd for that user
-    every time. Failing closed at write time gives an actionable
-    400 instead of a silent landmine."""
-    monkeypatch.setattr(mp, "_mem0_available_cached", None)
-    monkeypatch.setattr(mp, "mem0_available", lambda: False)
-    # `routes/settings.py` and `routes/capabilities.py` import
-    # `mem0_available` as a bound name; the rebind in `mp` alone
-    # leaves their references pointing at the original. Patch
-    # those modules' bound names too.
-    import app.routes.capabilities as cap
-    import app.routes.settings as st
-
-    monkeypatch.setattr(cap, "mem0_available", lambda: False)
-    monkeypatch.setattr(st, "mem0_available", lambda: False)
-
+    _patch_mem0_available(monkeypatch, available=False)
     r = await client.patch("/api/settings", json={"settings": {"memory_provider": "mem0"}})
     assert r.status_code == 400, r.text
-    detail = r.json().get("detail", {})
-    assert detail.get("code") == "memory_provider_unavailable"
+    assert r.json().get("detail", {}).get("code") == "memory_provider_unavailable"
 
 
 @pytest.mark.asyncio
 async def test_settings_accepts_mem0_when_available(client: httpx.AsyncClient, monkeypatch):
-    monkeypatch.setattr(mp, "_mem0_available_cached", None)
-    monkeypatch.setattr(mp, "mem0_available", lambda: True)
-    import app.routes.capabilities as cap
-    import app.routes.settings as st
-
-    monkeypatch.setattr(cap, "mem0_available", lambda: True)
-    monkeypatch.setattr(st, "mem0_available", lambda: True)
-
+    _patch_mem0_available(monkeypatch, available=True)
     r = await client.patch("/api/settings", json={"settings": {"memory_provider": "mem0"}})
-    assert r.status_code == 200, r.text
-
-
-@pytest.mark.asyncio
-async def test_settings_accepts_builtin_regardless(client: httpx.AsyncClient):
-    """The builtin path doesn't depend on the optional extra,
-    so it's always allowed."""
-    r = await client.patch("/api/settings", json={"settings": {"memory_provider": "builtin"}})
     assert r.status_code == 200, r.text

--- a/backend/tests/test_capabilities.py
+++ b/backend/tests/test_capabilities.py
@@ -1,0 +1,125 @@
+"""Capabilities endpoint tests.
+
+`/api/capabilities` exposes deployment-wide feature flags that
+the dashboard uses to hide UI for unavailable optional
+integrations. Pinned to keep the contract stable across
+changes — adding a new feature is fine, breaking an existing
+flag's name or shape is not.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+import app.services.memory_provider as mp
+
+
+@pytest.mark.asyncio
+async def test_capabilities_includes_builtin_always(client: httpx.AsyncClient):
+    r = await client.get("/api/capabilities")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "memory_providers" in body
+    assert "builtin" in body["memory_providers"], (
+        "BuiltinProvider must always be available — it's the default."
+    )
+
+
+@pytest.mark.asyncio
+async def test_capabilities_excludes_mem0_when_unavailable(client: httpx.AsyncClient, monkeypatch):
+    """When the [mem0] extra isn't installed, `/api/capabilities`
+    must NOT include `mem0`. Pre-fix the dashboard happily showed
+    the option for users on a backend that couldn't honor it."""
+    monkeypatch.setattr(mp, "_mem0_available_cached", None)
+    monkeypatch.setattr(mp, "mem0_available", lambda: False)
+    # `routes/settings.py` and `routes/capabilities.py` import
+    # `mem0_available` as a bound name; the rebind in `mp` alone
+    # leaves their references pointing at the original. Patch
+    # those modules' bound names too.
+    import app.routes.capabilities as cap
+    import app.routes.settings as st
+
+    monkeypatch.setattr(cap, "mem0_available", lambda: False)
+    monkeypatch.setattr(st, "mem0_available", lambda: False)
+
+    r = await client.get("/api/capabilities")
+    assert r.status_code == 200, r.text
+    assert "mem0" not in r.json()["memory_providers"]
+
+
+@pytest.mark.asyncio
+async def test_capabilities_includes_mem0_when_available(client: httpx.AsyncClient, monkeypatch):
+    monkeypatch.setattr(mp, "_mem0_available_cached", None)
+    monkeypatch.setattr(mp, "mem0_available", lambda: True)
+    import app.routes.capabilities as cap
+    import app.routes.settings as st
+
+    monkeypatch.setattr(cap, "mem0_available", lambda: True)
+    monkeypatch.setattr(st, "mem0_available", lambda: True)
+
+    r = await client.get("/api/capabilities")
+    assert r.status_code == 200, r.text
+    assert "mem0" in r.json()["memory_providers"]
+
+
+@pytest.mark.asyncio
+async def test_capabilities_requires_auth():
+    """Unauth probes shouldn't fingerprint the deployment.
+    Spin up a fresh client without auth to verify."""
+    from httpx import ASGITransport
+
+    from app.main import app
+
+    transport = ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as raw:
+        r = await raw.get("/api/capabilities")
+        # 401 (no auth) or 403 (CLI key not allowed); never 200.
+        assert r.status_code in (401, 403), r.text
+
+
+@pytest.mark.asyncio
+async def test_settings_refuses_mem0_when_unavailable(client: httpx.AsyncClient, monkeypatch):
+    """Settings save endpoint must refuse `memory_provider=mem0`
+    when the backend can't honor it. Pre-fix the dashboard would
+    save the value, then `/api/memories` 500'd for that user
+    every time. Failing closed at write time gives an actionable
+    400 instead of a silent landmine."""
+    monkeypatch.setattr(mp, "_mem0_available_cached", None)
+    monkeypatch.setattr(mp, "mem0_available", lambda: False)
+    # `routes/settings.py` and `routes/capabilities.py` import
+    # `mem0_available` as a bound name; the rebind in `mp` alone
+    # leaves their references pointing at the original. Patch
+    # those modules' bound names too.
+    import app.routes.capabilities as cap
+    import app.routes.settings as st
+
+    monkeypatch.setattr(cap, "mem0_available", lambda: False)
+    monkeypatch.setattr(st, "mem0_available", lambda: False)
+
+    r = await client.patch("/api/settings", json={"settings": {"memory_provider": "mem0"}})
+    assert r.status_code == 400, r.text
+    detail = r.json().get("detail", {})
+    assert detail.get("code") == "memory_provider_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_settings_accepts_mem0_when_available(client: httpx.AsyncClient, monkeypatch):
+    monkeypatch.setattr(mp, "_mem0_available_cached", None)
+    monkeypatch.setattr(mp, "mem0_available", lambda: True)
+    import app.routes.capabilities as cap
+    import app.routes.settings as st
+
+    monkeypatch.setattr(cap, "mem0_available", lambda: True)
+    monkeypatch.setattr(st, "mem0_available", lambda: True)
+
+    r = await client.patch("/api/settings", json={"settings": {"memory_provider": "mem0"}})
+    assert r.status_code == 200, r.text
+
+
+@pytest.mark.asyncio
+async def test_settings_accepts_builtin_regardless(client: httpx.AsyncClient):
+    """The builtin path doesn't depend on the optional extra,
+    so it's always allowed."""
+    r = await client.patch("/api/settings", json={"settings": {"memory_provider": "builtin"}})
+    assert r.status_code == 200, r.text

--- a/backend/tests/test_memory_provider_fallback.py
+++ b/backend/tests/test_memory_provider_fallback.py
@@ -1,19 +1,4 @@
-"""Memory provider fallback tests.
-
-Prod observed `GET /api/memories` 500-ing with
-`ModuleNotFoundError: 'mem0'` for users whose `user_settings`
-carries `memory_provider == "mem0"`. The Mem0Provider class
-lazy-imports `mem0` and `mem0ai` was never declared in
-`pyproject.toml`, so the path was dead-on-arrival from the day
-it shipped. This file pins the post-fix contract:
-
-  - `mem0_available()` returns True iff `mem0` imports cleanly
-    (drives capability flag + settings save validation).
-  - `get_memory_provider` falls back to BuiltinProvider on
-    ImportError instead of bubbling 500.
-  - Existing user settings of `memory_provider=mem0` keep
-    working post-deploy (silently degraded to builtin).
-"""
+"""Tests for `get_memory_provider` ImportError fallback and `mem0_available` cache."""
 
 from __future__ import annotations
 
@@ -36,10 +21,9 @@ from app.services.vault_crypto import encrypt_field
 async def test_get_memory_provider_falls_back_to_builtin_when_mem0_missing(
     db_session: AsyncSession, seed_user: User, monkeypatch
 ):
-    """Defense-in-depth: even if settings save validation lets a
-    mem0 setting through (e.g. operator uninstalled mem0ai
-    after a user already saved their preference), `/api/memories`
-    must NOT 500. Falls back to builtin with a warning."""
+    # Defense-in-depth: pre-existing `memory_provider=mem0` settings must
+    # not 500 if `mem0` becomes unimportable (e.g. operator uninstalled
+    # the extra after the user saved their preference).
     setting = UserSetting(
         user_id=seed_user.id,
         settings={
@@ -58,8 +42,6 @@ async def test_get_memory_provider_falls_back_to_builtin_when_mem0_missing(
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
-    # Bust the find_spec cache for this test — `mem0_available`
-    # caches the first answer, but we want fresh probing here.
     import app.services.memory_provider as mp
 
     monkeypatch.setattr(mp, "_mem0_available_cached", None)
@@ -74,9 +56,7 @@ async def test_get_memory_provider_falls_back_to_builtin_when_mem0_missing(
 async def test_get_memory_provider_uses_mem0_when_installed_and_configured(
     db_session: AsyncSession, seed_user: User, monkeypatch
 ):
-    """Happy path: Mem0Provider constructable → factory returns
-    it. Stub `__init__` so the test doesn't need mem0ai actually
-    installed."""
+    # Happy path: stub Mem0Provider.__init__ so we don't need mem0ai installed.
     setting = UserSetting(
         user_id=seed_user.id,
         settings={
@@ -116,16 +96,10 @@ async def test_get_memory_provider_handles_unknown_user_id(db_session: AsyncSess
 
 @pytest.mark.asyncio
 async def test_mem0_available_caches_first_probe(monkeypatch):
-    """`mem0_available()` should cache its result — re-probing on
-    every request unnecessarily thrashes the import system. The
-    probe uses a real `import mem0` (not `find_spec`) because
-    find_spec returns truthy even for broken installs whose
-    transitive deps fail to import."""
     import builtins
 
     import app.services.memory_provider as mp
 
-    # Clear cache to force fresh probe.
     monkeypatch.setattr(mp, "_mem0_available_cached", None)
 
     call_count = {"n": 0}
@@ -139,14 +113,7 @@ async def test_mem0_available_caches_first_probe(monkeypatch):
 
     monkeypatch.setattr(builtins, "__import__", counting)
 
-    # First call probes; subsequent calls hit cache.
-    a = mp.mem0_available()
-    b = mp.mem0_available()
-    c = mp.mem0_available()
-
-    # All three return False (simulated ImportError) and the
-    # import probe runs exactly once.
-    assert a is False
-    assert b is False
-    assert c is False
+    assert mp.mem0_available() is False
+    assert mp.mem0_available() is False
+    assert mp.mem0_available() is False
     assert call_count["n"] == 1, "mem0_available should probe once and cache"

--- a/backend/tests/test_memory_provider_fallback.py
+++ b/backend/tests/test_memory_provider_fallback.py
@@ -117,8 +117,11 @@ async def test_get_memory_provider_handles_unknown_user_id(db_session: AsyncSess
 @pytest.mark.asyncio
 async def test_mem0_available_caches_first_probe(monkeypatch):
     """`mem0_available()` should cache its result — re-probing on
-    every request unnecessarily thrashes the import system."""
-    import importlib.util as _iu
+    every request unnecessarily thrashes the import system. The
+    probe uses a real `import mem0` (not `find_spec`) because
+    find_spec returns truthy even for broken installs whose
+    transitive deps fail to import."""
+    import builtins
 
     import app.services.memory_provider as mp
 
@@ -126,19 +129,24 @@ async def test_mem0_available_caches_first_probe(monkeypatch):
     monkeypatch.setattr(mp, "_mem0_available_cached", None)
 
     call_count = {"n": 0}
-    real_find = _iu.find_spec
+    real_import = builtins.__import__
 
     def counting(name, *args, **kwargs):
         if name == "mem0":
             call_count["n"] += 1
-        return real_find(name, *args, **kwargs)
+            raise ImportError("simulated for test")
+        return real_import(name, *args, **kwargs)
 
-    monkeypatch.setattr(_iu, "find_spec", counting)
+    monkeypatch.setattr(builtins, "__import__", counting)
 
     # First call probes; subsequent calls hit cache.
     a = mp.mem0_available()
     b = mp.mem0_available()
     c = mp.mem0_available()
 
-    assert a == b == c
+    # All three return False (simulated ImportError) and the
+    # import probe runs exactly once.
+    assert a is False
+    assert b is False
+    assert c is False
     assert call_count["n"] == 1, "mem0_available should probe once and cache"

--- a/backend/tests/test_memory_provider_fallback.py
+++ b/backend/tests/test_memory_provider_fallback.py
@@ -1,0 +1,144 @@
+"""Memory provider fallback tests.
+
+Prod observed `GET /api/memories` 500-ing with
+`ModuleNotFoundError: 'mem0'` for users whose `user_settings`
+carries `memory_provider == "mem0"`. The Mem0Provider class
+lazy-imports `mem0` and `mem0ai` was never declared in
+`pyproject.toml`, so the path was dead-on-arrival from the day
+it shipped. This file pins the post-fix contract:
+
+  - `mem0_available()` returns True iff `mem0` imports cleanly
+    (drives capability flag + settings save validation).
+  - `get_memory_provider` falls back to BuiltinProvider on
+    ImportError instead of bubbling 500.
+  - Existing user settings of `memory_provider=mem0` keep
+    working post-deploy (silently degraded to builtin).
+"""
+
+from __future__ import annotations
+
+import builtins
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User, UserSetting
+from app.services.memory_provider import (
+    BuiltinProvider,
+    Mem0Provider,
+    get_memory_provider,
+)
+from app.services.vault_crypto import encrypt_field
+
+
+@pytest.mark.asyncio
+async def test_get_memory_provider_falls_back_to_builtin_when_mem0_missing(
+    db_session: AsyncSession, seed_user: User, monkeypatch
+):
+    """Defense-in-depth: even if settings save validation lets a
+    mem0 setting through (e.g. operator uninstalled mem0ai
+    after a user already saved their preference), `/api/memories`
+    must NOT 500. Falls back to builtin with a warning."""
+    setting = UserSetting(
+        user_id=seed_user.id,
+        settings={
+            "memory_provider": "mem0",
+            "mem0_api_key": encrypt_field("mock-api-key"),
+        },
+    )
+    db_session.add(setting)
+    await db_session.commit()
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "mem0":
+            raise ImportError("No module named 'mem0'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    # Bust the find_spec cache for this test — `mem0_available`
+    # caches the first answer, but we want fresh probing here.
+    import app.services.memory_provider as mp
+
+    monkeypatch.setattr(mp, "_mem0_available_cached", None)
+
+    provider = await get_memory_provider(str(seed_user.id), db_session)
+    assert isinstance(provider, BuiltinProvider), (
+        f"expected BuiltinProvider fallback when mem0 missing, got {type(provider).__name__}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_memory_provider_uses_mem0_when_installed_and_configured(
+    db_session: AsyncSession, seed_user: User, monkeypatch
+):
+    """Happy path: Mem0Provider constructable → factory returns
+    it. Stub `__init__` so the test doesn't need mem0ai actually
+    installed."""
+    setting = UserSetting(
+        user_id=seed_user.id,
+        settings={
+            "memory_provider": "mem0",
+            "mem0_api_key": encrypt_field("mock-api-key"),
+        },
+    )
+    db_session.add(setting)
+    await db_session.commit()
+
+    constructed: list = []
+
+    def fake_init(self, api_key):
+        constructed.append(api_key)
+
+    monkeypatch.setattr(Mem0Provider, "__init__", fake_init)
+
+    provider = await get_memory_provider(str(seed_user.id), db_session)
+    assert isinstance(provider, Mem0Provider)
+    assert constructed == ["mock-api-key"]
+
+
+@pytest.mark.asyncio
+async def test_get_memory_provider_uses_builtin_when_no_setting(
+    db_session: AsyncSession, seed_user: User
+):
+    provider = await get_memory_provider(str(seed_user.id), db_session)
+    assert isinstance(provider, BuiltinProvider)
+
+
+@pytest.mark.asyncio
+async def test_get_memory_provider_handles_unknown_user_id(db_session: AsyncSession):
+    fake_id = str(uuid.uuid4())
+    provider = await get_memory_provider(fake_id, db_session)
+    assert isinstance(provider, BuiltinProvider)
+
+
+@pytest.mark.asyncio
+async def test_mem0_available_caches_first_probe(monkeypatch):
+    """`mem0_available()` should cache its result — re-probing on
+    every request unnecessarily thrashes the import system."""
+    import importlib.util as _iu
+
+    import app.services.memory_provider as mp
+
+    # Clear cache to force fresh probe.
+    monkeypatch.setattr(mp, "_mem0_available_cached", None)
+
+    call_count = {"n": 0}
+    real_find = _iu.find_spec
+
+    def counting(name, *args, **kwargs):
+        if name == "mem0":
+            call_count["n"] += 1
+        return real_find(name, *args, **kwargs)
+
+    monkeypatch.setattr(_iu, "find_spec", counting)
+
+    # First call probes; subsequent calls hit cache.
+    a = mp.mem0_available()
+    b = mp.mem0_available()
+    c = mp.mem0_available()
+
+    assert a == b == c
+    assert call_count["n"] == 1, "mem0_available should probe once and cache"

--- a/backend/tests/test_settings_and_mcp.py
+++ b/backend/tests/test_settings_and_mcp.py
@@ -15,7 +15,19 @@ from app.main import app
 
 
 @pytest.mark.asyncio
-async def test_settings_patch_masks_sensitive_keys_on_read(client: httpx.AsyncClient):
+async def test_settings_patch_masks_sensitive_keys_on_read(client: httpx.AsyncClient, monkeypatch):
+    # Settings save now refuses `memory_provider=mem0` when the
+    # `[mem0]` extra isn't installed (the prod-default since the
+    # package was never declared). Stub `mem0_available()` so this
+    # masking test can still exercise the secret-handling path.
+    import app.services.memory_provider as mp
+
+    monkeypatch.setattr(mp, "_mem0_available_cached", None)
+    monkeypatch.setattr(mp, "mem0_available", lambda: True)
+    import app.routes.settings as st
+
+    monkeypatch.setattr(st, "mem0_available", lambda: True)
+
     r = await client.patch(
         "/api/settings",
         json={"settings": {"memory_provider": "mem0", "mem0_api_key": "mem0_live_supersecret"}},

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -227,6 +227,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "bcrypt"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -457,9 +466,15 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
 ]
 
+[package.optional-dependencies]
+mem0 = [
+    { name = "mem0ai" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "aiosqlite" },
+    { name = "deptry" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -475,6 +490,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "fastembed", specifier = ">=0.3" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=0.1" },
     { name = "openai", specifier = ">=1.40" },
     { name = "pgvector", specifier = ">=0.2.5" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
@@ -486,10 +502,12 @@ requires-dist = [
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
 ]
+provides-extras = ["mem0"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "aiosqlite", specifier = ">=0.20" },
+    { name = "deptry", specifier = ">=0.20" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
     { name = "ruff", specifier = ">=0.9" },
@@ -596,6 +614,29 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
     { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
     { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+]
+
+[[package]]
+name = "deptry"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "packaging" },
+    { name = "requirements-parser" },
+    { name = "tomli", marker = "python_full_version < '3.15'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/b2/50ccc99362ae7757342978b7ecb3b98e47fade721fd617d74db1948ec3a1/deptry-0.25.1.tar.gz", hash = "sha256:45c8cd982c85cd4faae573ddff6920de7eec735336db6973f26a765ae7950f7d", size = 509748, upload-time = "2026-03-18T23:22:18.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/1d/b538dc635e873b25360d761cfe1fa0ccd7d6c69b698047e552f33401e60d/deptry-0.25.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a4dd1148db24a1ddacfa8b840836c6019c2f864fcb7579dd089fd217606338c8", size = 1850319, upload-time = "2026-03-18T23:22:15.65Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a9/511477a8f0ae4f6021d68a80bdca77e7ffb0722008dc24ee5d9ef49f5c88/deptry-0.25.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c67c666d916ef12013c0772e40d78be0f21577a495d8d99ec5fcb18c332d393d", size = 1759259, upload-time = "2026-03-18T23:22:30.853Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4b/c9f0bdda410912a6df79a789cb118fa29acae02a397794ead3c84adcda5c/deptry-0.25.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58d39279828dbf4efc1abb40bf50a71b21499c36759bed5a8d8a3c0e3149b091", size = 1872012, upload-time = "2026-03-18T23:22:19.145Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9c/6f6f9125bac74b5d5d2af89536cbdb3fa159b6466aa097b74e7e85e8e030/deptry-0.25.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14bfcc28b4326ed8c6abb30691b19077d4ef8613cfba6c37ef5b1f471775bf6f", size = 1926575, upload-time = "2026-03-18T23:22:11.269Z" },
+    { url = "https://files.pythonhosted.org/packages/52/48/2a5e705a7f898295966ade67bd1223e2af96da433e25b39f6b9483ba2c7b/deptry-0.25.1-cp310-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:555f5f9a487899ec9bf301eecba1745e14d212c4b354f4d3a5fd691e907366d3", size = 2050816, upload-time = "2026-03-18T23:22:27.439Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c6/50f189a894e1f3bf21266299112c8a06cb731838976e1b9a9cadd0b4a86e/deptry-0.25.1-cp310-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:18d21b3545ab2bfec53f3f45c6f5f201d55f713323327f8d12674505469ae6b7", size = 2145416, upload-time = "2026-03-18T23:22:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/6a/3f82f7a06217778282bc4456af1b4ffb3bc4b2c8e7891d00e8323f9ad0b8/deptry-0.25.1-cp310-abi3-win_amd64.whl", hash = "sha256:b59a560cb7dffb21832a98bb80d33d614cfb5630ea36ce21833eabf4eae3df99", size = 1718489, upload-time = "2026-03-18T23:22:28.589Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7f/cd6b3ac8cf95f2f1c5c7a74ff6452e9098af89a9b56607381f677880641e/deptry-0.25.1-cp310-abi3-win_arm64.whl", hash = "sha256:6efffd8116fb9d2c45a251382ce4ce1c38dbb17179f581ec9231ed5390f7fc12", size = 1647020, upload-time = "2026-03-18T23:22:23.311Z" },
 ]
 
 [[package]]
@@ -835,12 +876,66 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
 ]
 
 [[package]]
@@ -873,6 +968,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/42/4b/53951592882d9c23080c7644542fda34a3813104e9e11fa1a7d82d419cb8/hf_xet-1.4.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7716d62015477a70ea272d2d68cd7cad140f61c52ee452e133e139abfe2c17ba", size = 4429392, upload-time = "2026-03-31T22:40:03.492Z" },
     { url = "https://files.pythonhosted.org/packages/8a/21/75a6c175b4e79662ad8e62f46a40ce341d8d6b206b06b4320d07d55b188c/hf_xet-1.4.3-cp37-abi3-win_amd64.whl", hash = "sha256:6b591fcad34e272a5b02607485e4f2a1334aebf1bc6d16ce8eb1eb8978ac2021", size = 3677359, upload-time = "2026-03-31T22:40:13.619Z" },
     { url = "https://files.pythonhosted.org/packages/8a/7c/44314ecd0e89f8b2b51c9d9e5e7a60a9c1c82024ac471d415860557d3cd8/hf_xet-1.4.3-cp37-abi3-win_arm64.whl", hash = "sha256:7c2c7e20bcfcc946dc67187c203463f5e932e395845d098cc2a93f5b67ca0b47", size = 3533664, upload-time = "2026-03-31T22:40:12.152Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
 ]
 
 [[package]]
@@ -932,6 +1036,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
 [[package]]
 name = "huggingface-hub"
 version = "0.36.2"
@@ -949,6 +1058,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -1214,6 +1332,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mem0ai"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openai" },
+    { name = "posthog" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "pytz" },
+    { name = "qdrant-client" },
+    { name = "sqlalchemy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/03/3dc535b98310912e4f10083acdbbca2c5e2dfccb3921230a460464f9f4d0/mem0ai-2.0.1.tar.gz", hash = "sha256:070dbc3f1f332c8908379b42a81ab3a96ab169f2f9fa537e6ac719df02478f9c", size = 211820, upload-time = "2026-04-25T17:39:06.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/96/e6153262f1464f4d412208732fea31496d9983ade155dd2c5c5492f8f8a4/mem0ai-2.0.1-py3-none-any.whl", hash = "sha256:63da5f50ad0c2514e27c2f380ef03f2ceea47c97873096ddfd997785b58043ec", size = 299461, upload-time = "2026-04-25T17:39:04.143Z" },
 ]
 
 [[package]]
@@ -1595,6 +1731,33 @@ wheels = [
 ]
 
 [[package]]
+name = "portalocker"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a6/38c8e2f318bf67d338f4d629e93b0b4b9af331f455f0390ea8ce4a099b26/portalocker-3.2.0-py3-none-any.whl", hash = "sha256:3cdc5f565312224bc570c49337bd21428bba0ef363bbcf58b9ef4a9f11779968", size = 22424, upload-time = "2025-06-14T13:20:38.083Z" },
+]
+
+[[package]]
+name = "posthog"
+version = "7.13.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/54/9c117beaa96519077cae355263712d705e560e8ee7ca4a35373438d1f4d2/posthog-7.13.2.tar.gz", hash = "sha256:a9fc322518bc7f42e24501a0df1072aa60bad6fba759cbe388d167b7e054b052", size = 195555, upload-time = "2026-04-30T09:01:26.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/8b/ec789af64ef3d85816a5c4ac8fe1e3c74d6e3bb9675c1325e3b1de4ddb14/posthog-7.13.2-py3-none-any.whl", hash = "sha256:e8ea9a7fa740b453533a76c0f3300b16120a3c27c19ab417cf0e69bb8c210fb6", size = 229762, upload-time = "2026-04-30T09:01:24.144Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1680,17 +1843,17 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "7.34.1"
+version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
-    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
-    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
-    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
-    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -2000,6 +2163,31 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2026.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2046,6 +2234,24 @@ wheels = [
 ]
 
 [[package]]
+name = "qdrant-client"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "numpy" },
+    { name = "portalocker" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/dd/f8a8261b83946af3cd65943c93c4f83e044f01184e8525404989d22a81a5/qdrant_client-1.17.1.tar.gz", hash = "sha256:22f990bbd63485ed97ba551a4c498181fcb723f71dcab5d6e4e43fe1050a2bc0", size = 344979, upload-time = "2026-03-13T17:13:44.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/69/77d1a971c4b933e8c79403e99bcbb790463da5e48333cc4fd5d412c63c98/qdrant_client-1.17.1-py3-none-any.whl", hash = "sha256:6cda4064adfeaf211c751f3fbc00edbbdb499850918c7aff4855a9a759d56cbd", size = 389947, upload-time = "2026-03-13T17:13:43.156Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2072,6 +2278,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "requirements-parser"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/96/fb6dbfebb524d5601d359a47c78fe7ba1eef90fc4096404aa60c9a906fbb/requirements_parser-0.13.0.tar.gz", hash = "sha256:0843119ca2cb2331de4eb31b10d70462e39ace698fd660a915c247d2301a4418", size = 22630, upload-time = "2025-05-21T13:42:05.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/60/50fbb6ffb35f733654466f1a90d162bcbea358adc3b0871339254fbc37b2/requirements_parser-0.13.0-py3-none-any.whl", hash = "sha256:2b3173faecf19ec5501971b7222d38f04cb45bb9d87d0ad629ca71e2e62ded14", size = 14782, upload-time = "2025-05-21T13:42:04.007Z" },
 ]
 
 [[package]]
@@ -2329,6 +2547,51 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
     { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
     { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -413,43 +413,56 @@ async function pushOneAgent(
 		sessionSpinner.start(
 			`Uploading metadata for ${sessions.length} session${sessions.length === 1 ? "" : "s"}...`,
 		);
-		let needsContent: Set<string>;
-		let rejectedIds: Set<string> = new Set();
+		const needsContent: Set<string> = new Set();
+		const rejectedIds: Set<string> = new Set();
+		// Chunk sessions into batches that fit under PostgreSQL's
+		// 32767 bound-parameters-per-query limit. The server upsert
+		// builds a single multi-VALUES INSERT with ~17 columns per
+		// row; in prod we observed
+		// `sqlalchemy.exc.InterfaceError: ... query arguments cannot
+		// exceed 32767` 500-ing this endpoint when a heavy user's
+		// initial backfill shipped 1900+ sessions in one body.
+		// Schema-side cap (max_length=500 on SessionBatchRequest)
+		// gives the same protection as defense-in-depth.
+		const SESSION_BATCH_CHUNK = 500;
 		try {
-			const result = unwrap(
-				await api.POST("/api/sessions/batch", {
-					body: {
-						sessions: sessions.map((s) => ({
-							environment_id: envId,
-							local_session_id: s.localSessionId,
-							project_path: s.projectPath,
-							started_at: s.startedAt.toISOString(),
-							ended_at: s.endedAt?.toISOString() ?? null,
-							duration_seconds: s.durationSeconds,
-							message_count: s.messageCount,
-							input_tokens: s.inputTokens,
-							output_tokens: s.outputTokens,
-							cache_read_tokens: s.cacheReadTokens,
-							model: s.model,
-							models_used: s.modelsUsed,
-							summary: s.summary,
-							status: "completed",
-							content_hash: s.contentHash ?? null,
-						})),
-					},
-				}),
-			);
-			needsContent = new Set(result.needs_content);
-			sessionsCreated = result.created;
-			sessionsUpdated = result.updated;
-			sessionsUnchanged = result.unchanged;
-			// Server flagged these ids as cross-env race casualties
-			// (see SessionBatchResponse.rejected). They are NOT
-			// synced; the caller must skip the lock-write step
-			// below so the next push retries. Pre-fix the absence
-			// from `needs_content` looked like success and we
-			// wrote a stale lock.
-			rejectedIds = new Set(result.rejected ?? []);
+			for (let offset = 0; offset < sessions.length; offset += SESSION_BATCH_CHUNK) {
+				const chunk = sessions.slice(offset, offset + SESSION_BATCH_CHUNK);
+				const result = unwrap(
+					await api.POST("/api/sessions/batch", {
+						body: {
+							sessions: chunk.map((s) => ({
+								environment_id: envId,
+								local_session_id: s.localSessionId,
+								project_path: s.projectPath,
+								started_at: s.startedAt.toISOString(),
+								ended_at: s.endedAt?.toISOString() ?? null,
+								duration_seconds: s.durationSeconds,
+								message_count: s.messageCount,
+								input_tokens: s.inputTokens,
+								output_tokens: s.outputTokens,
+								cache_read_tokens: s.cacheReadTokens,
+								model: s.model,
+								models_used: s.modelsUsed,
+								summary: s.summary,
+								status: "completed",
+								content_hash: s.contentHash ?? null,
+							})),
+						},
+					}),
+				);
+				for (const id of result.needs_content) needsContent.add(id);
+				sessionsCreated += result.created;
+				sessionsUpdated += result.updated;
+				sessionsUnchanged += result.unchanged;
+				// Server flagged these ids as cross-env race casualties
+				// (see SessionBatchResponse.rejected). They are NOT
+				// synced; the caller must skip the lock-write step
+				// below so the next push retries. Pre-fix the absence
+				// from `needs_content` looked like success and we
+				// wrote a stale lock.
+				for (const id of result.rejected ?? []) rejectedIds.add(id);
+			}
 			if (rejectedIds.size > 0) {
 				p.log.warn(
 					`${rejectedIds.size} session${rejectedIds.size === 1 ? "" : "s"} rejected by server (cross-env race) — will retry on next push`,

--- a/packages/cli/src/lib/tar.ts
+++ b/packages/cli/src/lib/tar.ts
@@ -36,6 +36,26 @@ export const SKILL_TAR_EXCLUDE = new Set([
 	".ruff_cache",
 	".tox",
 	"coverage",
+	// Cross-agent skill bundles. gstack and similar meta-skills
+	// ship sub-skills FOR OTHER AGENTS inside their own root
+	// (e.g. `gstack/.agents/skills/<sub>` is meant to be loaded
+	// by openclaw / hermes adapters, not codex/claude_code).
+	// They're not part of the outer skill's runtime contract,
+	// they balloon the tarball past the 25 MB cap, and the
+	// dotfile prefix means the resolver wouldn't even enqueue
+	// changes inside them (see resolveOwningSkillKey). Keeping
+	// them out of the outer skill's tar lets gstack-shaped
+	// folders fit under the cap. Pre-fix gstack itself failed
+	// upload with HTTP 413 because the bundled subtrees pushed
+	// it past 25 MB.
+	".agents",
+	".cursor",
+	".factory",
+	".openclaw",
+	".hermes",
+	".gbrain",
+	".claude",
+	".codex",
 ]);
 
 /**

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { ApiError } from "../lib/api-client";
-import { isAuthFailure } from "./sync-engine";
+import { isAuthFailure, resolveOwningSkillKey } from "./sync-engine";
 
 describe("isAuthFailure", () => {
 	// Pull-side and push-side both rely on this classifier to decide
@@ -93,5 +96,73 @@ describe("addInFlight / releaseInFlight refcount", () => {
 		releaseInFlight(m, "a");
 		expect(m.has("a")).toBe(false);
 		expect(m.has("b")).toBe(true);
+	});
+});
+
+describe("resolveOwningSkillKey — dotfile component rejection", () => {
+	// Prod observed 728 `engine.queue_drop_permanent` 422 events
+	// in the codex daemon log post-#66 deploy. gstack ships its
+	// own bundled sub-skills FOR OTHER AGENTS at paths like
+	// `~/.codex/skills/gstack/.agents/skills/<sub>/SKILL.md`.
+	// fs.watch fires for those, the resolver greedily returned
+	// the deepest SKILL.md match, and server's
+	// SKILL_KEY_PATTERN rejected with 422 (every component must
+	// start with [A-Za-z0-9]).
+	//
+	// The fix returns null on any path with a dotfile-prefixed
+	// component. NOT walk-up to outer skill — that would convert
+	// 422s into 413 cascades because the outer `gstack` folder
+	// is the 1 GB monster that already trips the 25 MB upload
+	// cap. The companion fix in lib/tar.ts excludes those
+	// dotfile subtrees from the OUTER skill's tarball so it
+	// stays under the cap.
+
+	let tmp: string;
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "skill-key-resolve-"));
+	});
+	afterEach(() => {
+		rmSync(tmp, { recursive: true, force: true });
+	});
+
+	function makeSkillMd(...segments: string[]) {
+		const dir = join(tmp, ...segments);
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, "SKILL.md"), "---\nname: x\n---\n");
+	}
+
+	it("returns null when ANY path component starts with a dot (gstack shape)", () => {
+		makeSkillMd("gstack");
+		makeSkillMd("gstack", ".agents", "skills", "gstack-autoplan");
+
+		// fs.watch fires on the deep nested file; resolver MUST
+		// NOT enqueue. Pre-fix this returned
+		// `gstack/.agents/skills/gstack-autoplan` and 422'd.
+		expect(resolveOwningSkillKey(tmp, "gstack/.agents/skills/gstack-autoplan")).toBeNull();
+	});
+
+	it("returns null even when the dotfile is at the leaf (.../foo/.cache/x)", () => {
+		makeSkillMd("foo");
+		mkdirSync(join(tmp, "foo", ".cache", "x"), { recursive: true });
+		expect(resolveOwningSkillKey(tmp, "foo/.cache/x")).toBeNull();
+	});
+
+	it("returns the deepest valid skill_key for nested layouts (Hermes)", () => {
+		// `category/foo/SKILL.md` exists but no dotfile in path.
+		// Resolver returns the deepest match.
+		makeSkillMd("category", "foo");
+		expect(resolveOwningSkillKey(tmp, "category/foo")).toBe("category/foo");
+		expect(resolveOwningSkillKey(tmp, "category/foo/references")).toBe("category/foo");
+	});
+
+	it("returns the top-level dir for flat layouts (Claude Code / Codex)", () => {
+		makeSkillMd("autoplan");
+		expect(resolveOwningSkillKey(tmp, "autoplan")).toBe("autoplan");
+		expect(resolveOwningSkillKey(tmp, "autoplan/references/pattern.md")).toBe("autoplan");
+	});
+
+	it("returns null for a path with no SKILL.md ancestor", () => {
+		expect(resolveOwningSkillKey(tmp, "no-skill-here")).toBeNull();
+		expect(resolveOwningSkillKey(tmp, "deep/nested/no-skill")).toBeNull();
 	});
 });

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -166,3 +166,32 @@ describe("resolveOwningSkillKey — dotfile component rejection", () => {
 		expect(resolveOwningSkillKey(tmp, "deep/nested/no-skill")).toBeNull();
 	});
 });
+
+describe("resolveOwningSkillKey — Windows path separator", () => {
+	// Codex flagged: on Windows, watcher.ts builds pathFromRoot
+	// via path.join() → backslash-separated. A `/`-only split
+	// missed dotfile components like `gstack\.agents\...`,
+	// re-enabling the 422 spam this fix is meant to stop. The
+	// resolver now splits on both `/` and `\`.
+	let tmp: string;
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), "skill-key-resolve-win-"));
+	});
+	afterEach(() => {
+		rmSync(tmp, { recursive: true, force: true });
+	});
+
+	it("rejects backslash-separated paths with dotfile components", () => {
+		// Synthetic Windows-style input. Resolver doesn't actually
+		// touch the filesystem for the dotfile check, so we don't
+		// need a real backslash-named directory on macOS — the
+		// rejection happens before any fs access.
+		expect(resolveOwningSkillKey(tmp, "gstack\\.agents\\skills\\gstack-autoplan")).toBeNull();
+	});
+
+	it("rejects mixed-separator paths with dotfile components", () => {
+		// Windows clients can produce mixed separators (e.g.
+		// path.join joining a path that already had `/`).
+		expect(resolveOwningSkillKey(tmp, "gstack/.agents\\skills/foo")).toBeNull();
+	});
+});

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -1981,7 +1981,12 @@ export function resolveOwningSkillKey(rootDir: string, pathFromRoot: string): st
 	//   - Adapters' `listSkillKeys` already filter dotfiles at
 	//     the top-level walk; this is the watcher-driven
 	//     analog.
-	if (pathFromRoot.split("/").some((seg) => seg.startsWith("."))) {
+	// Split on BOTH `/` and `\` — Windows callers (the watcher
+	// builds paths via `path.join` which yields backslashes on
+	// win32) would otherwise sneak `gstack\.agents\skills\<sub>`
+	// past a `/`-only split and re-enable the 422 spam this fix
+	// is meant to stop.
+	if (pathFromRoot.split(/[/\\]/).some((seg) => seg.startsWith("."))) {
 		return null;
 	}
 	let cur = pathFromRoot;

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -1962,7 +1962,28 @@ async function rescanLocalSkillsForChanges(
  * ancestor has SKILL.md (e.g. a brand-new category dir before
  * its first nested skill is committed).
  */
-function resolveOwningSkillKey(rootDir: string, pathFromRoot: string): string | null {
+export function resolveOwningSkillKey(rootDir: string, pathFromRoot: string): string | null {
+	// Reject any change whose path passes through a dotfile-
+	// prefixed component (e.g. `gstack/.agents/skills/<sub>`).
+	// Server's SKILL_KEY_PATTERN requires every component to
+	// start with `[A-Za-z0-9]`; pre-fix this triggered 728
+	// `engine.queue_drop_permanent` 422 events in prod after
+	// the daemon fired on gstack's bundled sub-skill artifacts.
+	// An earlier draft walked UP past the dotfile component to
+	// resolve to the outer skill (`gstack`) — but the outer
+	// skill is the 1 GB folder that already trips upload's
+	// 25 MB cap (413). Returning null here trades both 422
+	// spam AND would-be 413 cascades for a silent no-op.
+	// Companion fixes:
+	//   - lib/tar.ts SKILL_TAR_EXCLUDE drops these dotfile
+	//     subtrees from the outer skill's tarball so the outer
+	//     skill itself stays under the cap.
+	//   - Adapters' `listSkillKeys` already filter dotfiles at
+	//     the top-level walk; this is the watcher-driven
+	//     analog.
+	if (pathFromRoot.split("/").some((seg) => seg.startsWith("."))) {
+		return null;
+	}
 	let cur = pathFromRoot;
 	// Bound the walk: 6 levels is more than the regex permits
 	// (4 components) so we'll always terminate even if the input


### PR DESCRIPTION
Discovered while inspecting prod backend + daemon logs after PR #66 deployed. None blocked ship of #66 directly, but each was bleeding visibly enough that they're worth a single rapid follow-up rather than 5 split PRs. Codex independently scanned the same logs and source — findings synthesized.

## What's fixed

### 1. mem0 memory provider made actually optional (P0 — prod-bleeding)

`GET /api/memories` returned 500 with `ModuleNotFoundError: 'mem0'` for users with `user_settings.settings.memory_provider == \"mem0\"` (8 events, 5+ users). Root cause: `Mem0Provider.__init__` lazy-imports `mem0`, but `mem0ai` was **never** declared in pyproject.toml or uv.lock — the class was dead-on-arrival since the day it shipped, surfacing only as 500s.

Fix (keeps the feature, doesn't delete it):
- `pyproject.toml [project.optional-dependencies] mem0 = [\"mem0ai>=0.1\"]` — operators enable per deployment.
- `mem0_available()` helper probes once + caches.
- New `GET /api/capabilities` exposes `{\"memory_providers\": [...]}` — dashboard hides unavailable options.
- Settings save refuses `memory_provider=mem0` with 400 + `code=memory_provider_unavailable` when not importable.
- `get_memory_provider` catches ImportError → falls back to BuiltinProvider with warning. Defense-in-depth.

### 2. Concurrent rebind race triggered users_clerk_id_key 500 (P0)

`sqlalchemy.exc.IntegrityError: duplicate key value violates unique constraint \"users_clerk_id_key\"` 500-ing dashboard /stats, /contribution, /memories (14 events). Root cause: `_auth_via_clerk_jwt`'s snapshot-rebind path commits with no try/except. Two concurrent requests for the same Clerk JWT race.

Fix: wrap rebind commit in `try/except IntegrityError`, rollback + re-query by clerk_id on conflict.

### 3. Codex daemon 728 422 spam (gstack-shape skills) (P1)

`engine.queue_drop_permanent` × 728 with HTTP 422 for keys like `gstack/.agents/skills/<sub>`. Root cause: gstack ships bundled sub-skills FOR OTHER AGENTS at dotfile-prefixed paths; resolver greedily returned the deepest SKILL.md match.

Fix: `resolveOwningSkillKey` returns null when ANY component starts with `.`. **Codex correctly flagged** that walking-up to the outer skill (\"gstack\") would have converted 422 spam into 413 cascades — see #4.

### 4. gstack tarball > 25 MB → 413 (P1)

`engine.queue_drop_permanent` × 3-4 with 413 for gstack itself. Root cause: tar/hash exclude lists missed cross-agent bundles `.agents/`, `.cursor/`, `.factory/`, `.openclaw/`, `.hermes/`, `.gbrain/`, `.claude/`, `.codex/`.

Fix: add to both `SKILL_TAR_EXCLUDE` (CLI) and `_SKILL_HASH_EXCLUDE` (backend). Pairs with #3.

### 5. batch_create_sessions 32767 PG-param overflow (P1)

`sqlalchemy.exc.InterfaceError: query arguments cannot exceed 32767` from heavy users' bulk session push.

Fix:
- Schema cap: `SessionBatchRequest.sessions max_length=500` (8500 params, ample headroom).
- CLI `push.ts` chunks into 500-session batches.
- Daemon already pushes one at a time.

### 6. CI dependency-drift guard

Added `deptry` + CI step. Same class of bug that let `mem0`/`mem0ai` stay undeclared for months. Per-rule ignores configured for transitive-direct imports (pydantic, starlette) and runtime-only deps (uvicorn, asyncpg driver, etc.) so signal-to-noise stays high.

## Tests

- Backend: **142 passes** (was 130). Adds 12 tests across `test_memory_provider_fallback.py` (5) and `test_capabilities.py` (7).
- CLI: **236 passes** (was 231). Adds 5 `resolveOwningSkillKey` test cases.
- `deptry app`: clean.
- ruff + tsc + biome: clean.

## Process note

Originally split into 3 separate PRs (#69, #70, plus a third planned). User pushed back on PR-fragmentation — bundled into this one as a single commit covering everything found in the post-#66 prod-log scan. Both Claude and Codex independently scanned the logs; this PR synthesizes both takes.

## Test plan

- [x] Backend test suite passes (142/142)
- [x] CLI test suite passes (236/236)
- [x] deptry clean
- [x] tsc + ruff + biome clean
- [ ] Confirm prod \`/api/memories\`, \`/api/dashboard/stats\`, \`/api/dashboard/contribution\` all return 200 post-deploy
- [ ] Confirm codex daemon log no longer accumulates 422 spam after CLI v0.5.1 ships
- [ ] Confirm gstack skill uploads successfully after CLI v0.5.1 ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)