### PR TITLE
fix(cli): demote oversized-skill drop to warn-level silent skip

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ApiError } from "../lib/api-client";
-import { isAuthFailure, resolveOwningSkillKey } from "./sync-engine";
+import { isAuthFailure, isOversizedUploadError, resolveOwningSkillKey } from "./sync-engine";
 
 describe("isAuthFailure", () => {
 	// Pull-side and push-side both rely on this classifier to decide
@@ -193,5 +193,29 @@ describe("resolveOwningSkillKey — Windows path separator", () => {
 		// Windows clients can produce mixed separators (e.g.
 		// path.join joining a path that already had `/`).
 		expect(resolveOwningSkillKey(tmp, "gstack/.agents\\skills/foo")).toBeNull();
+	});
+});
+
+describe("isOversizedUploadError", () => {
+	// The drain loop branches on this to demote oversize drops from
+	// `error` to `warn` (no heartbeat poison). Misclassifying a 400
+	// validation error as oversized would silently swallow real bugs.
+	it("treats ApiError(413) as oversized", () => {
+		expect(isOversizedUploadError(new ApiError({ status: 413, body: "", hint: "" }))).toBe(true);
+	});
+
+	it("treats pre-flight 'Skill tarball exceeds' as oversized", () => {
+		expect(isOversizedUploadError(new Error("Skill tarball exceeds 26214400 bytes"))).toBe(true);
+	});
+
+	it("does not treat other 4xx as oversized", () => {
+		for (const status of [400, 404, 422]) {
+			expect(isOversizedUploadError(new ApiError({ status, body: "", hint: "" }))).toBe(false);
+		}
+	});
+
+	it("does not treat unrelated Errors as oversized", () => {
+		expect(isOversizedUploadError(new Error("symlink(s) pointing outside"))).toBe(false);
+		expect(isOversizedUploadError(new Error("boom"))).toBe(false);
 	});
 });

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -916,6 +916,22 @@ function isPermanentUploadError(e: unknown): boolean {
 	return false;
 }
 
+/**
+ * Subset of permanent failures that mean "the skill is just too big
+ * to sync" (server 413 or pre-flight size guard). These aren't user
+ * misconfigurations — they're a known capacity limit. We still drop
+ * the queue item (retrying won't shrink the tar) but at `warn` level
+ * and without poisoning the heartbeat with `permanent:` — the
+ * dashboard shouldn't scream at the user about a skill they didn't
+ * ask to upload (e.g. the gstack meta-skill ships a 60 MB bundled
+ * binary that's larger than the cap).
+ */
+export function isOversizedUploadError(e: unknown): boolean {
+	if (e instanceof ApiError && e.status === 413) return true;
+	if (e instanceof Error && e.message.includes("Skill tarball exceeds")) return true;
+	return false;
+}
+
 async function drainQueueLoop(
 	opts: EngineOpts,
 	api: ApiClient,
@@ -995,12 +1011,25 @@ async function drainQueueLoop(
 			// drop decision tied to the item we actually processed.
 			const newAttempts = item.attempts + 1;
 			queue.bumpAttempts(item);
-			if (isPermanentUploadError(e)) {
-				// 4xx that won't change on retry — the skill is too
-				// big, malformed, or rejected by validation. Retrying
-				// 30 times costs the user 7.5 minutes of log spam and
-				// network for guaranteed-zero-progress; drop now and
-				// surface the reason once so the user can fix it.
+			if (isOversizedUploadError(e)) {
+				// Skill bigger than the server cap. Not a bug, not a
+				// user misconfiguration — just a capacity limit. Drop
+				// quietly (warn-level, no heartbeat poison) so the
+				// dashboard doesn't scream and the daemon's queue
+				// doesn't spin retrying a tar that will never shrink.
+				log.warn("engine.queue_drop_oversized", {
+					item: redactItem(item),
+					error: msg,
+				});
+				queue.recordPermanentDrop();
+				clearInFlight(item);
+				queue.markDoneIfVersion(item);
+			} else if (isPermanentUploadError(e)) {
+				// 4xx that won't change on retry — malformed body,
+				// schema validation, etc. Retrying 30 times costs the
+				// user 7.5 minutes of log spam and network for
+				// guaranteed-zero-progress; drop now and surface the
+				// reason once so the user can fix it.
 				log.error("engine.queue_drop_permanent", {
 					item: redactItem(item),
 					error: msg,


### PR DESCRIPTION
## Summary
- Skills exceeding the server tarball cap now drop quietly at warn level instead of spamming `engine.queue_drop_permanent` at error level
- The 25 MB cap is a known capacity limit (gstack ships a 60 MB bundled binary), not a user misconfiguration — no need to scream at the dashboard
- Still drops from the queue (retrying won't shrink the tar), just without the heartbeat poison

## Why
Post-#71 prod logs showed both local daemons logging:

\`\`\`
{"level":"error","event":"engine.queue_drop_permanent","skill_key":"gstack","error":"API error 413: Skill tarball exceeds 26214400 bytes"}
\`\`\`

That's not a bug — gstack's `bin/gstack-global-discover` is a 60 MB bundled bun binary, and `browse/test/fixtures/security-bench-haiku-responses.json` is a 27 MB LLM eval replay. After all SKILL_TAR_EXCLUDE entries apply, the tar is still 33 MB. These aren't build artifacts — they're legitimate skill content that just happens to exceed the cap.

The right behavior for "skill too big" is silent skip, not error spam. User can fix the source if they care; daemon shouldn't pretend the world is on fire.

## Changes
- New `isOversizedUploadError(e)` helper that returns true for HTTP 413 and pre-flight `Skill tarball exceeds` errors
- New `engine.queue_drop_oversized` log event at warn level, no `setLastError`
- Other 4xx (validation, schema) keep the existing `engine.queue_drop_permanent` error path
- 4 unit tests for the classifier (413 → true, 400/404/422 → false, pre-flight string match, unrelated errors → false)
- Bump CLI to 0.5.2

## Test plan
- [x] `bun test src/serve/sync-engine.test.ts` — 27 pass
- [x] `bun run typecheck` — clean
- [x] Locally installed v0.5.2 + restarted both daemons → gstack now drops at warn-level with `engine.queue_drop_oversized` instead of error-level `queue_drop_permanent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)