### PR TITLE
fix(cli): serve subcommands honor --agent + status lists every daemon

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.5.2",
+	"version": "0.5.3",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/serve-cli-options.test.ts
+++ b/packages/cli/src/commands/serve-cli-options.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "bun:test";
+import { Command } from "commander";
+
+describe("serve subcommand option scoping", () => {
+	// Regression test for the v0.5.2 bug: parent `serveCmd` defined
+	// `--agent` (for `clawdi serve --agent X` running the daemon
+	// foreground), and install/uninstall/status redefined the same
+	// `--agent` on each subcommand. Commander's default action binding
+	// hands the subcommand action only the child-scoped opts, so
+	// `clawdi serve install --agent codex` silently dropped the agent
+	// and installed the default.
+	//
+	// The fix uses `cmd.optsWithGlobals()` inside each subcommand's
+	// action to merge parent + child options. These tests pin the
+	// invariant: regardless of which side of the subcommand `--agent`
+	// is passed on, the action sees it.
+
+	function buildServeTree(captured: { opts: Record<string, unknown> | null }): Command {
+		const program = new Command();
+		const serve = program
+			.command("serve")
+			.option("--agent <type>", "agent")
+			.option("--environment-id <id>", "env id");
+
+		serve
+			.command("install")
+			.option("--agent <type>", "agent")
+			.option("--all", "install for every agent")
+			.option("--environment-id <id>", "env id")
+			.action((_opts, cmd) => {
+				captured.opts = cmd.optsWithGlobals();
+			});
+
+		serve
+			.command("uninstall")
+			.option("--agent <type>", "agent")
+			.option("--all", "uninstall every agent")
+			.action((_opts, cmd) => {
+				captured.opts = cmd.optsWithGlobals();
+			});
+
+		serve
+			.command("status")
+			.option("--agent <type>", "agent")
+			.action((_opts, cmd) => {
+				captured.opts = cmd.optsWithGlobals();
+			});
+
+		return program;
+	}
+
+	it("install --agent codex (child-side) reaches the action", () => {
+		const cap = { opts: null as Record<string, unknown> | null };
+		buildServeTree(cap).parse(["node", "clawdi", "serve", "install", "--agent", "codex"]);
+		expect(cap.opts?.agent).toBe("codex");
+	});
+
+	it("install with --agent on parent side also reaches the action", () => {
+		// `clawdi serve --agent codex install` — the user passed
+		// --agent before the subcommand. Without optsWithGlobals,
+		// the action received `agent: undefined`.
+		const cap = { opts: null as Record<string, unknown> | null };
+		buildServeTree(cap).parse(["node", "clawdi", "serve", "--agent", "codex", "install"]);
+		expect(cap.opts?.agent).toBe("codex");
+	});
+
+	it("uninstall --all is visible to action", () => {
+		const cap = { opts: null as Record<string, unknown> | null };
+		buildServeTree(cap).parse(["node", "clawdi", "serve", "uninstall", "--all"]);
+		expect(cap.opts?.all).toBe(true);
+		expect(cap.opts?.agent).toBeUndefined();
+	});
+
+	it("status --agent claude_code (child-side) reaches the action", () => {
+		const cap = { opts: null as Record<string, unknown> | null };
+		buildServeTree(cap).parse(["node", "clawdi", "serve", "status", "--agent", "claude_code"]);
+		expect(cap.opts?.agent).toBe("claude_code");
+	});
+
+	it("status without --agent gives undefined (caller defaults to all)", () => {
+		// `serveStatus` branches on `opts.agent` being falsy to list
+		// every registered daemon. This test pins that the parser
+		// hands the action `agent: undefined` (not e.g. an empty
+		// string), so the falsy check works.
+		const cap = { opts: null as Record<string, unknown> | null };
+		buildServeTree(cap).parse(["node", "clawdi", "serve", "status"]);
+		expect(cap.opts?.agent).toBeUndefined();
+	});
+
+	it("install --environment-id flows through too", () => {
+		const cap = { opts: null as Record<string, unknown> | null };
+		buildServeTree(cap).parse([
+			"node",
+			"clawdi",
+			"serve",
+			"install",
+			"--agent",
+			"codex",
+			"--environment-id",
+			"env_123",
+		]);
+		expect(cap.opts?.agent).toBe("codex");
+		expect(cap.opts?.environmentId).toBe("env_123");
+	});
+});

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -206,6 +206,37 @@ export async function serveInstall(opts: ServeInstallOpts): Promise<void> {
 }
 
 export async function serveUninstall(opts: ServeInstallOpts): Promise<void> {
+	if (opts.all) {
+		// Symmetric with `install --all` — one invocation, every
+		// daemon gone. Pre-fix users had to loop in the shell
+		// (`for a in claude_code codex; do clawdi serve uninstall --agent $a`),
+		// which is exactly the friction `install --all` exists to
+		// remove.
+		const registered = listRegisteredAgentTypes();
+		if (registered.length === 0) {
+			console.log("No agents registered.");
+			return;
+		}
+		let removed = 0;
+		let failed = 0;
+		for (const agentType of registered) {
+			try {
+				const result = uninstallService({ agent: agentType });
+				if (result.removed) {
+					console.log(`✓ ${agentType}: removed`);
+					removed += 1;
+				} else {
+					console.log(`(${agentType}: no daemon unit installed)`);
+				}
+			} catch (e) {
+				console.error(`✗ ${agentType}: ${toErrorMessage(e)}`);
+				failed += 1;
+			}
+		}
+		console.log(`\n${removed} removed, ${failed} failed.`);
+		if (failed > 0) process.exit(1);
+		return;
+	}
 	const { agentType } = pickAgent(opts.agent);
 	try {
 		const result = uninstallService({ agent: agentType });
@@ -221,16 +252,35 @@ export async function serveUninstall(opts: ServeInstallOpts): Promise<void> {
 }
 
 export async function serveStatus(opts: ServeInstallOpts): Promise<void> {
-	const { agentType } = pickAgent(opts.agent);
+	// Without --agent, list every registered daemon — `serve install
+	// --all` is the recommended path on multi-agent machines and
+	// status should mirror that. Falling through `pickAgent` here used
+	// to silently hide all-but-one daemon's state behind a warning,
+	// which made debugging multi-agent setups (the actual common case)
+	// confusing. With --agent, scope to that one daemon.
+	const targets: AgentType[] = opts.agent
+		? [pickAgent(opts.agent).agentType]
+		: listRegisteredAgentTypes();
+	if (targets.length === 0) {
+		console.log("No agents registered yet — run `clawdi setup` first.");
+		return;
+	}
+	for (const [i, agentType] of targets.entries()) {
+		if (i > 0) console.log("");
+		printAgentStatus(agentType);
+	}
+}
+
+function printAgentStatus(agentType: AgentType): void {
 	const stateDir = getServeStateDir(agentType);
 	const health = readHealth(stateDir);
 	console.log(`agent:   ${agentType}`);
 	console.log(`state:   ${stateDir}`);
 	if (health.exists) {
-		const fresh = health.ageSeconds !== null && health.ageSeconds < 90;
 		// The 90s cutoff matches the dashboard's "online/offline"
 		// freshness window. A daemon writing `health` more recently
 		// than that AND posting heartbeats is what we call "live".
+		const fresh = health.ageSeconds !== null && health.ageSeconds < 90;
 		console.log(`health:  ${fresh ? "✓ live" : "stale"} (last write ${health.ageSeconds}s ago)`);
 	} else {
 		console.log("health:  (no health file — daemon never ran or wrote elsewhere)");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -260,36 +260,44 @@ serveCmd
 		"--environment-id <id>",
 		"Pin a specific environment id into the unit (single-agent only; ignored with --all)",
 	)
-	.action(async (opts) => {
+	// `optsWithGlobals` merges parent (`serveCmd`) options with this
+	// subcommand's. Without it, `--agent` defined on both the parent
+	// (`clawdi serve --agent X`) and the child (`clawdi serve install
+	// --agent X`) makes commander hand the child action ONLY the
+	// child-scoped opts, so `clawdi serve install --agent codex` lost
+	// the agent and silently installed the default. Same fix applied
+	// to uninstall + status below.
+	.action(async (_opts, cmd) => {
 		const { serveInstall } = await import("./commands/serve.js");
-		await serveInstall(opts);
+		await serveInstall(cmd.optsWithGlobals());
 	});
 
 serveCmd
 	.command("uninstall")
 	.description("Remove the per-user OS service unit and stop the daemon")
 	.option("--agent <type>", "Agent to uninstall (defaults to the only registered agent)")
-	.action(async (opts) => {
+	.option("--all", "Uninstall the daemon unit for every registered agent on this machine")
+	.action(async (_opts, cmd) => {
 		const { serveUninstall } = await import("./commands/serve.js");
-		await serveUninstall(opts);
+		await serveUninstall(cmd.optsWithGlobals());
 	});
 
 serveCmd
 	.command("status")
 	.description("Show daemon health (last heartbeat) and supervisor state")
-	.option("--agent <type>", "Agent to check (defaults to the only registered agent)")
-	.action(async (opts) => {
+	.option("--agent <type>", "Agent to check (defaults to all registered agents)")
+	.action(async (_opts, cmd) => {
 		const { serveStatus } = await import("./commands/serve.js");
-		await serveStatus(opts);
+		await serveStatus(cmd.optsWithGlobals());
 	});
 
 serveCmd
 	.command("doctor")
 	.description("Snapshot every registered agent's daemon state — for support handoff")
 	.option("--json", "Emit machine-readable JSON instead of human-readable lines")
-	.action(async (opts) => {
+	.action(async (_opts, cmd) => {
 		const { serveDoctor } = await import("./commands/serve.js");
-		await serveDoctor(opts);
+		await serveDoctor(cmd.optsWithGlobals());
 	});
 
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Three closely related bugs in \`clawdi serve\` subcommands. Two of them share a root cause: parent \`serveCmd\` defines \`--agent\` (for the foreground daemon), and so do install/uninstall/status. Commander's default action binding hands the subcommand action ONLY the child-scoped opts, so \`clawdi serve install --agent codex\` lost the agent and silently installed the default.

### Bugs fixed
1. **\`serve install --agent X\` was silently installing the default agent** — same parent/child option scoping bug. Affected anyone who ran \`clawdi serve install --agent <something>\` since v1.
2. **\`serve uninstall\` had no \`--all\`** symmetric with \`install --all\`, so multi-agent machines needed a shell loop.
3. **\`serve status\` without \`--agent\` picked one daemon and warned \`multiple_agents_detected\`**, hiding all-but-one daemon's state. Status is a diagnostic command and should mirror \`install --all\` (the recommended path on multi-agent machines): list every registered daemon. \`--agent X\` still scopes to one.

### Fix
\`cmd.optsWithGlobals()\` in each subcommand action merges parent + child options, so \`clawdi serve --agent X install\` and \`clawdi serve install --agent X\` work identically.

## Verified locally
\`\`\`
$ clawdi serve status              # lists both
agent:   claude_code
agent:   codex

$ clawdi serve status --agent codex
agent:   codex                     # only codex

$ clawdi serve install --agent codex
✓ Installed daemon unit: ai.clawdi.serve.codex.plist  # actually codex now
\`\`\`

## Test plan
- [x] 6 regression tests in \`serve-cli-options.test.ts\` — pin \`optsWithGlobals\` invariant
- [x] \`bun test\` — 248 pass
- [x] \`bun run typecheck\` — clean
- [x] Locally rebuilt + manually verified all three commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)