### PR TITLE
fix(cli): clear heartbeat last_error on oversized skill drop

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.5.5",
+	"version": "0.5.6",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -1022,6 +1022,16 @@ async function drainQueueLoop(
 					item: redactItem(item),
 					error: msg,
 				});
+				// Override the eager `setLastError(msg)` at the top of
+				// this catch — pre-fix the dashboard surfaced "API
+				// error 413: Skill tarball exceeds 26214400 bytes /
+				// It will keep retrying" because the raw msg leaked
+				// into the heartbeat. The dropped-events counter
+				// (incremented below) is the right signal for "we
+				// skipped some content"; the heartbeat last_error
+				// should stay clean so the user only sees alarms
+				// for things that actually need attention.
+				setLastError(null);
 				queue.recordPermanentDrop();
 				clearInFlight(item);
 				queue.markDoneIfVersion(item);


### PR DESCRIPTION
## Summary
PR #72 (oversized soft-skip) was supposed to keep the dashboard quiet about skills that exceed the 25 MB cap. Reality: users still saw the dashboard banner

> Sync hit an error  
> API error 413: {\"detail\":\"Skill tarball exceeds 26214400 bytes\"}  
> It will keep retrying.

even though the daemon was correctly dropping (not retrying) the item at warn level.

## Root cause
The catch block in \`drainQueueLoop\` does:

\`\`\`ts
} catch (e) {
    const msg = toErrorMessage(e);
    setLastError(msg);     // ← eagerly poisons heartbeat
    ...
    if (isOversizedUploadError(e)) { /* drop without overriding */ }
    else if (isPermanentUploadError(e)) { setLastError(\`permanent: \${msg}\`); }
    ...
}
\`\`\`

The oversize branch dropped the queue item silently but never cleared \`lastError\`, so the raw 413 message stayed in the heartbeat → dashboard.

## Fix
\`setLastError(null)\` in the oversize branch. The dropped-events counter (already incremented) is the right signal that \"we skipped some content\"; the heartbeat last_error should stay clean.

## Test plan
- [x] Verified locally on v0.5.6: daemon logs \`engine.queue_drop_oversized\` at warn, dashboard heartbeat banner clears on next tick.
- [x] \`bun run typecheck\` clean.
- [x] No regression on other catch branches (auth, permanent, retry_exhausted, retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)