### PR TITLE
fix: normalize Clawdi MCP setup for Hermes and OpenClaw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.8.3
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.8.3
+
+Package: `clawdi@0.8.3`
+
+### Fixed
+
+- Agent MCP setup now converges on the local `clawdi mcp` stdio server for
+  Hermes and OpenClaw. Hermes setup removes stale `clawdi-mcp` HTTP entries and
+  mixed HTTP/stdio blocks that could create duplicate or confusing Clawdi tool
+  namespaces; OpenClaw setup now writes the matching `clawdi` MCP server through
+  `openclaw mcp set`.
+
 ## Clawdi CLI v0.8.2
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.8.2

--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.8.2",
+	"version": "0.8.3",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -302,35 +302,14 @@ async function registerHermesMcp() {
 	const { readFileSync: readFs, writeFileSync: writeFs } = await import("node:fs");
 	const content = readFs(configPath, "utf-8");
 
-	// Clawdi entry already present under mcp_servers.
-	if (/^mcp_servers:/m.test(content) && /^\s+clawdi:/m.test(content)) {
-		console.log(chalk.gray("✓ MCP server already registered in Hermes"));
-		return;
-	}
-
-	const clawdiChild = `  clawdi:\n    command: "clawdi"\n    args: ["mcp"]`;
-	const newSection = `mcp_servers:\n${clawdiChild}\n`;
-
 	try {
-		const HEADER_RE = /^mcp_servers:\s*(.*)$/m;
-		const headerMatch = content.match(HEADER_RE);
-
-		let updated: string;
-		if (!headerMatch) {
-			// No mcp_servers section at all — append a fresh block.
-			updated = `${content.trimEnd()}\n\n${newSection}`;
-		} else {
-			const inlineValue = (headerMatch[1] ?? "").trim();
-			if (inlineValue.startsWith("{") && inlineValue !== "{}") {
-				// Inline flow map with existing entries — too risky to patch.
-				throw new Error("mcp_servers uses inline flow map; edit config.yaml manually.");
-			}
-			// For empty map ({}, ~, null) or block map with children:
-			// replace the header line with a block-style header followed by our child.
-			// The regex's `m` flag anchors to line start, avoiding false matches like
-			// `other_mcp_servers:`. Existing block children after the header line are
-			// preserved because only the matched line is substituted.
-			updated = content.replace(HEADER_RE, `mcp_servers:\n${clawdiChild}`);
+		// Hermes has `hermes mcp add`, but it is discovery-first: it probes the
+		// server and can prompt for overwrite/tool selection. For setup we need a
+		// non-interactive, idempotent upsert that also cleans stale mixed blocks.
+		const updated = upsertHermesStdioClawdiMcp(content);
+		if (updated === content) {
+			console.log(chalk.gray("✓ MCP server already registered in Hermes"));
+			return;
 		}
 
 		writeFs(configPath, updated);
@@ -338,8 +317,58 @@ async function registerHermesMcp() {
 	} catch (e) {
 		console.log(chalk.yellow(`⚠ Could not register MCP server in Hermes config: ${errMessage(e)}`));
 		console.log(chalk.gray(`  Edit ${configPath} and add under mcp_servers:`));
-		console.log(chalk.gray(clawdiChild));
+		console.log(chalk.gray(HERMES_CLAUDI_MCP_CHILD));
 	}
+}
+
+const HERMES_CLAUDI_MCP_CHILD = `  clawdi:\n    command: "clawdi"\n    args: ["mcp"]`;
+
+function upsertHermesStdioClawdiMcp(content: string): string {
+	const newSection = `mcp_servers:\n${HERMES_CLAUDI_MCP_CHILD}\n`;
+	const HEADER_RE = /^mcp_servers:[ \t]*(.*)$/m;
+	const headerMatch = content.match(HEADER_RE);
+
+	if (!headerMatch) {
+		return `${content.trimEnd()}\n\n${newSection}`;
+	}
+
+	const inlineValue = (headerMatch[1] ?? "").trim();
+	if (!["", "{}", "~", "null"].includes(inlineValue)) {
+		throw new Error("mcp_servers uses inline value; edit config.yaml manually.");
+	}
+
+	const blockContent = content.replace(HEADER_RE, "mcp_servers:");
+	const section = getYamlBlock(blockContent, "mcp_servers");
+	if (!section) return blockContent;
+
+	// `clawdi mcp` is the canonical Hermes integration. Remove stale cloud HTTP
+	// (`clawdi-mcp`) and any mixed/duplicate `clawdi` blocks, then insert one
+	// stdio block so repeated setup runs converge to a single transport.
+	let normalizedSection = removeAllYamlBlocks(section, "clawdi-mcp");
+	normalizedSection = removeAllYamlBlocks(normalizedSection, "clawdi");
+	normalizedSection = normalizedSection.replace(
+		/^mcp_servers:[ \t]*\n?/,
+		`mcp_servers:\n${HERMES_CLAUDI_MCP_CHILD}\n`,
+	);
+
+	return blockContent.replace(section, normalizedSection);
+}
+
+function removeAllYamlBlocks(content: string, key: string): string {
+	let updated = content;
+	while (true) {
+		const block = getYamlBlock(updated, key);
+		if (!block) return updated;
+		updated = updated.replace(block, "");
+	}
+}
+
+function getYamlBlock(content: string, key: string): string | null {
+	const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const match = content.match(
+		new RegExp(`^([ \\t]*)${escaped}:[ \\t]*\\n((?:\\1[ \\t]+.*\\n?)*)`, "m"),
+	);
+	return match?.[0] ?? null;
 }
 
 function registerCodexMcp() {
@@ -363,13 +392,18 @@ function registerCodexMcp() {
 }
 
 function registerOpenClawMcp() {
-	// OpenClaw's ACP bridge rejects per-session mcpServers and delegates MCP
-	// registration to whatever downstream agent it wraps (typically Claude Code
-	// via --mcp-config). There's no clawdi-safe config file to patch here.
-	console.log(chalk.yellow("⚠ OpenClaw has no native MCP registration point."));
-	console.log(chalk.gray("  If you also run `clawdi setup --agent claude_code` on this machine,"));
-	console.log(chalk.gray("  OpenClaw will inherit the clawdi MCP server through Claude Code."));
-	console.log(
-		chalk.gray("  Otherwise, add the clawdi MCP server to your OpenClaw gateway config manually."),
-	);
+	const mcpConfig = JSON.stringify({
+		command: "clawdi",
+		args: ["mcp"],
+	});
+
+	try {
+		// OpenClaw exposes a non-interactive config setter, so prefer its native
+		// CLI over editing ~/.openclaw/openclaw.json directly.
+		execSync(`openclaw mcp set clawdi '${mcpConfig}'`, { stdio: "pipe", env: process.env });
+		console.log(chalk.green("✓ MCP server registered in OpenClaw"));
+	} catch {
+		console.log(chalk.yellow("⚠ Could not auto-register MCP server in OpenClaw."));
+		console.log(chalk.gray(`  Run manually: openclaw mcp set clawdi '${mcpConfig}'`));
+	}
 }

--- a/packages/cli/src/commands/teardown.ts
+++ b/packages/cli/src/commands/teardown.ts
@@ -154,16 +154,12 @@ async function unregisterMcpServer(agentType: AgentType) {
 		return unregisterViaCli("Claude Code", "claude mcp remove clawdi");
 	if (agentType === "codex") return unregisterViaCli("Codex", "codex mcp remove clawdi");
 	if (agentType === "hermes") return unregisterHermesMcp();
-	if (agentType === "openclaw") {
-		// Symmetric with setup: OpenClaw has no native MCP registration point,
-		// so there's nothing to unregister here.
-		p.log.info("OpenClaw: no native MCP registration to remove (handled by the wrapped agent).");
-	}
+	if (agentType === "openclaw") return unregisterViaCli("OpenClaw", "openclaw mcp unset clawdi");
 }
 
 function unregisterViaCli(label: string, cmd: string) {
 	try {
-		execSync(cmd, { stdio: "pipe" });
+		execSync(cmd, { stdio: "pipe", env: process.env });
 		p.log.success(`${label}: removed MCP server registration`);
 	} catch {
 		// `mcp remove` returns non-zero if the entry didn't exist — that's fine.
@@ -180,26 +176,34 @@ function unregisterHermesMcp() {
 
 	const content = readFileSync(configPath, "utf-8");
 
-	// Match the clawdi child block we install in setup.ts:
-	//   clawdi:
-	//     command: "clawdi"
-	//     args: ["mcp"]
-	// The `\1[ \t]+` lookahead forces every absorbed child line to be indented
-	// STRICTLY DEEPER than the clawdi: header itself — without this guard, a
-	// permissive `[ \t]+.*` would eat sibling mcp_servers entries that follow
-	// at the same indent level.
-	const CLAWDI_BLOCK_RE = /^([ \t]*)clawdi:[ \t]*\n((?:\1[ \t]+.*\n?)*)/m;
-	if (!CLAWDI_BLOCK_RE.test(content)) {
+	const updated = removeAllYamlBlocks(removeAllYamlBlocks(content, "clawdi-mcp"), "clawdi");
+	if (updated === content) {
 		p.log.info("Hermes: clawdi entry not present in config.yaml");
 		return;
 	}
 
 	try {
-		const updated = content.replace(CLAWDI_BLOCK_RE, "");
 		writeFileSync(configPath, updated);
 		p.log.success("Hermes: removed MCP server entry from config.yaml");
 	} catch (e) {
 		p.log.warn(`Hermes: could not edit config.yaml (${errMessage(e)})`);
 		p.log.info(`  Edit ${configPath} manually and remove the clawdi block under mcp_servers`);
 	}
+}
+
+function removeAllYamlBlocks(content: string, key: string): string {
+	let updated = content;
+	while (true) {
+		const block = getYamlBlock(updated, key);
+		if (!block) return updated;
+		updated = updated.replace(block, "");
+	}
+}
+
+function getYamlBlock(content: string, key: string): string | null {
+	const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const match = content.match(
+		new RegExp(`^([ \\t]*)${escaped}:[ \\t]*\\n((?:\\1[ \\t]+.*\\n?)*)`, "m"),
+	);
+	return match?.[0] ?? null;
 }

--- a/packages/cli/tests/commands/setup.test.ts
+++ b/packages/cli/tests/commands/setup.test.ts
@@ -66,6 +66,10 @@ beforeEach(() => {
 	const stubDir = join(home, "bin");
 	mkdirSync(stubDir, { recursive: true });
 	writeExecutable(join(stubDir, "codex"), "#!/bin/sh\nexit 0\n");
+	writeExecutable(
+		join(stubDir, "openclaw"),
+		'#!/bin/sh\nprintf "%s\\n" "$@" > "$HOME/openclaw-mcp-args"\nexit 0\n',
+	);
 	writeExecutable(join(stubDir, "systemctl"), "#!/bin/sh\nexit 0\n");
 	writeExecutable(join(stubDir, "launchctl"), "#!/bin/sh\nexit 0\n");
 	process.env.PATH = `${stubDir}:${envSnapshot.PATH ?? ""}`;
@@ -138,6 +142,117 @@ describe("setup daemon install", () => {
 	});
 });
 
+describe("setup Hermes MCP registration", () => {
+	it("replaces cloud HTTP clawdi-mcp with canonical stdio clawdi", async () => {
+		const configPath = prepareHermesConfig(
+			[
+				"model:",
+				"  provider: custom",
+				"mcp_servers:",
+				"  clawdi-mcp:",
+				"    url: https://backend.example.test/composio/mcp",
+				"    headers:",
+				"      Authorization: placeholder",
+				"",
+			].join("\n"),
+		);
+		installEnvironmentMock("env-hermes-test");
+
+		await setup({ agent: "hermes", yes: true, daemon: false });
+
+		const after = readFileSync(configPath, "utf-8");
+		expect(after).not.toContain("  clawdi-mcp:");
+		expect(after).not.toContain("    url: https://backend.example.test/composio/mcp");
+		expect(after).not.toContain("      Authorization: placeholder");
+		expect(after).toContain("  clawdi:");
+		expect(after).toContain('    command: "clawdi"');
+		expect(after).toContain('    args: ["mcp"]');
+	});
+
+	it("normalizes a mixed clawdi block back to stdio-only", async () => {
+		const configPath = prepareHermesConfig(
+			[
+				"mcp_servers:",
+				"  clawdi:",
+				'    command: "clawdi"',
+				'    args: ["mcp"]',
+				"    url: https://backend.example.test/composio/mcp",
+				"    headers:",
+				"      Authorization: placeholder",
+				"  other:",
+				'    command: "other"',
+				"",
+			].join("\n"),
+		);
+		installEnvironmentMock("env-hermes-test");
+
+		await setup({ agent: "hermes", yes: true, daemon: false });
+
+		const after = readFileSync(configPath, "utf-8");
+		expect(after).toContain("  clawdi:");
+		expect(after).toContain('    command: "clawdi"');
+		expect(after).toContain('    args: ["mcp"]');
+		expect(after).not.toContain("    url: https://backend.example.test/composio/mcp");
+		expect(after).not.toContain("    headers:");
+		expect(after).toContain("  other:");
+		expect(after).toContain('    command: "other"');
+	});
+
+	it("removes duplicate HTTP sibling when stdio clawdi is already present", async () => {
+		const configPath = prepareHermesConfig(
+			[
+				"mcp_servers:",
+				"  clawdi-mcp:",
+				"    url: https://backend.example.test/composio/mcp",
+				"    headers:",
+				"      Authorization: placeholder",
+				"  clawdi:",
+				'    command: "clawdi"',
+				'    args: ["mcp"]',
+				"  other:",
+				'    command: "other"',
+				"",
+			].join("\n"),
+		);
+		installEnvironmentMock("env-hermes-test");
+
+		await setup({ agent: "hermes", yes: true, daemon: false });
+
+		const after = readFileSync(configPath, "utf-8");
+		expect(after).not.toContain("  clawdi-mcp:");
+		expect(after).not.toContain("    url: https://backend.example.test/composio/mcp");
+		expect(after.match(/^ {2}clawdi:/gm)?.length).toBe(1);
+		expect(after).toContain('    command: "clawdi"');
+		expect(after).toContain('    args: ["mcp"]');
+		expect(after).toContain("  other:");
+		expect(after).toContain('    command: "other"');
+	});
+
+	it("keeps installing legacy stdio for local Hermes configs without HTTP MCP", async () => {
+		const configPath = prepareHermesConfig(["model:", "  provider: custom", ""].join("\n"));
+		installEnvironmentMock("env-hermes-test");
+
+		await setup({ agent: "hermes", yes: true, daemon: false });
+
+		const after = readFileSync(configPath, "utf-8");
+		expect(after).toContain("mcp_servers:");
+		expect(after).toContain("  clawdi:");
+		expect(after).toContain('    command: "clawdi"');
+		expect(after).toContain('    args: ["mcp"]');
+	});
+});
+
+describe("setup OpenClaw MCP registration", () => {
+	it("registers canonical stdio clawdi through OpenClaw MCP config", async () => {
+		installEnvironmentMock("env-openclaw-test");
+
+		await setup({ agent: "openclaw", yes: true, daemon: false });
+
+		const args = readFileSync(join(home, "openclaw-mcp-args"), "utf-8").trim().split("\n");
+		expect(args).toEqual(["mcp", "set", "clawdi", '{"command":"clawdi","args":["mcp"]}']);
+	});
+});
+
 function installEnvironmentMock(envId: string) {
 	const mock = mockFetch([
 		{
@@ -160,6 +275,15 @@ function installFailingEnvironmentMock() {
 	]);
 	restoreFetch = mock.restore;
 	return mock;
+}
+
+function prepareHermesConfig(configYaml: string): string {
+	const hermesHome = join(home, ".hermes");
+	process.env.HERMES_HOME = hermesHome;
+	const configPath = join(hermesHome, "config.yaml");
+	mkdirSync(hermesHome, { recursive: true });
+	writeFileSync(configPath, configYaml);
+	return configPath;
 }
 
 function seedAuth(): void {

--- a/packages/cli/tests/commands/teardown.test.ts
+++ b/packages/cli/tests/commands/teardown.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { teardown } from "../../src/commands/teardown";
 import { cleanupTmp, copyFixtureToTmp } from "../adapters/helpers";
@@ -20,6 +20,8 @@ const AGENT_TYPE: Record<AgentKey, string> = {
 
 let tmpHome: string;
 let origHome: string | undefined;
+let origPath: string | undefined;
+let origPathSet = false;
 let origHomeOverrides: AgentHomeOverrideSnapshot = {};
 let origIsTTY: boolean | undefined;
 
@@ -31,6 +33,7 @@ function setup(agent: AgentKey): {
 	origHomeOverrides = snapshotAndClearAgentHomeOverrides();
 	tmpHome = copyFixtureToTmp(agent);
 	process.env.HOME = tmpHome;
+	process.env.HERMES_HOME = join(tmpHome, ".hermes");
 	seedAuthAndEnv(tmpHome, AGENT_TYPE[agent]);
 
 	const envPath = join(tmpHome, ".clawdi", "environments", `${AGENT_TYPE[agent]}.json`);
@@ -53,6 +56,12 @@ function setup(agent: AgentKey): {
 afterEach(() => {
 	if (origHome) process.env.HOME = origHome;
 	else delete process.env.HOME;
+	if (origPathSet) {
+		if (origPath !== undefined) process.env.PATH = origPath;
+		else delete process.env.PATH;
+		origPath = undefined;
+		origPathSet = false;
+	}
 	restoreAgentHomeOverrides(origHomeOverrides);
 	origHomeOverrides = {};
 	process.exitCode = 0;
@@ -71,6 +80,27 @@ function makeNonInteractive() {
 	const desc = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
 	origIsTTY = desc?.value;
 	Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+}
+
+function installOpenClawStub(): string {
+	if (!origPathSet) {
+		origPath = process.env.PATH;
+		origPathSet = true;
+	}
+	const stubDir = join(tmpHome, "bin");
+	const argsPath = join(tmpHome, "openclaw-mcp-args");
+	mkdirSync(stubDir, { recursive: true });
+	const openclawPath = join(stubDir, "openclaw");
+	writeFileSync(
+		openclawPath,
+		'#!/bin/sh\nprintf "%s\\n" "$@" > "$HOME/openclaw-mcp-args"\nexit 0\n',
+		{
+			mode: 0o755,
+		},
+	);
+	chmodSync(openclawPath, 0o755);
+	process.env.PATH = `${stubDir}:${origPath ?? ""}`;
+	return argsPath;
 }
 
 describe("teardown — basic round-trip per agent", () => {
@@ -99,12 +129,13 @@ describe("teardown — basic round-trip per agent", () => {
 		expect(existsSync(skillPath)).toBe(false);
 	});
 
-	it("OpenClaw: removes env file + bundled skill", async () => {
+	it("OpenClaw: removes env file + bundled skill + MCP registration", async () => {
 		const { envPath, skillPath } = setup("openclaw");
-		// OpenClaw has no native MCP, so keepMcp is moot — should still pass cleanly.
+		const argsPath = installOpenClawStub();
 		await teardown({ agent: "openclaw", yes: true });
 		expect(existsSync(envPath)).toBe(false);
 		expect(existsSync(skillPath)).toBe(false);
+		expect(readFileSync(argsPath, "utf-8").trim().split("\n")).toEqual(["mcp", "unset", "clawdi"]);
 	});
 });
 
@@ -223,5 +254,31 @@ describe("teardown — Hermes config.yaml MCP removal", () => {
 		const after = readFileSync(configPath, "utf-8");
 		// Untouched.
 		expect(after).toContain("  other:");
+	});
+
+	it("removes stale clawdi-mcp HTTP entries too", async () => {
+		setup("hermes");
+		const configPath = join(tmpHome, ".hermes", "config.yaml");
+		writeFileSync(
+			configPath,
+			[
+				"mcp_servers:",
+				"  clawdi-mcp:",
+				"    url: https://backend.example.test/composio/mcp",
+				"    headers:",
+				"      Authorization: placeholder",
+				"  other:",
+				'    command: "other"',
+				"",
+			].join("\n"),
+		);
+
+		await teardown({ agent: "hermes", yes: true });
+
+		const after = readFileSync(configPath, "utf-8");
+		expect(after).not.toContain("clawdi-mcp:");
+		expect(after).not.toContain("https://backend.example.test/composio/mcp");
+		expect(after).toContain("  other:");
+		expect(after).toContain('    command: "other"');
 	});
 });


### PR DESCRIPTION
## Summary
- Converge `clawdi setup --agent hermes` on one local stdio MCP server named `clawdi`, removing stale `clawdi-mcp` HTTP entries and mixed HTTP/stdio blocks.
- Register OpenClaw through its native non-interactive `openclaw mcp set` command so OpenClaw also gets the same canonical `clawdi -> clawdi mcp` server.
- Keep Claude Code and Codex on their existing native MCP registration paths.
- Add setup/teardown regression coverage and isolate agent homes in tests.

## Root cause
The broken config could contain both cloud HTTP MCP shape (`url`/`headers`, often under `clawdi-mcp`) and local stdio shape (`command`/`args`, under `clawdi`). Hermes treats one server containing both transport shapes as invalid/confusing and can produce duplicate/confusing Clawdi tool namespaces.

During review we also verified local OpenClaw source: OpenClaw has a real non-interactive `openclaw mcp set <name> <json>` config setter, so Clawdi should use that instead of treating OpenClaw as manual/inherited-only.

## Fix
- Hermes: direct-edit `config.yaml` intentionally, because `hermes mcp add` is discovery-first and can prompt for overwrite/tool selection; it is not a safe non-interactive idempotent upsert. Normalize to exactly:

```yaml
mcp_servers:
  clawdi:
    command: "clawdi"
    args: ["mcp"]
```

- OpenClaw: call `openclaw mcp set clawdi '{"command":"clawdi","args":["mcp"]}'` during setup and `openclaw mcp unset clawdi` during teardown.
- Teardown removes stale Hermes `clawdi-mcp` entries as well as `clawdi`.
- Release prep: bump CLI to `0.8.3` and add changelog entry.

## Test plan
- `bunx biome check --write packages/cli/src/commands/setup.ts packages/cli/src/commands/teardown.ts packages/cli/tests/commands/setup.test.ts packages/cli/tests/commands/teardown.test.ts CHANGELOG.md`
- `cd packages/cli && bun test tests/commands/setup.test.ts tests/commands/teardown.test.ts` — 22 pass, 0 fail
- `bun run check`
- `bun run typecheck`
- `bun run test` — CLI 425 pass, web 103 pass, 0 fail