### PR TITLE
feat(web): add hosted-only PostHog analytics

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -22,3 +22,8 @@ NEXT_PUBLIC_DEPLOY_API_URL=http://localhost:50021
 # CTA in the sidebar. OSS / self-host instances should leave this
 # unset.
 NEXT_PUBLIC_CLAWDI_HOSTED=
+
+# Hosted-only analytics (optional). When set alongside
+# `NEXT_PUBLIC_CLAWDI_HOSTED=true`, PostHog initializes with a
+# first-party proxy at `/_cdi/px`.
+NEXT_PUBLIC_POSTHOG_TOKEN=

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -1,0 +1,8 @@
+const initHostedPostHog =
+	process.env.NEXT_PUBLIC_CLAWDI_HOSTED === "true"
+		? () => import("@/hosted/posthog").then((m) => m.initHostedPostHog())
+		: null;
+
+if (initHostedPostHog) {
+	void initHostedPostHog();
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,13 @@
 import type { NextConfig } from "next";
 
+const isHostedBuild = process.env.NEXT_PUBLIC_CLAWDI_HOSTED === "true";
+const posthogProxyPath = "/_cdi/px";
+
 const nextConfig: NextConfig = {
 	transpilePackages: ["@clawdi/shared"],
+	// PostHog uses trailing slashes in capture endpoints (e.g. `/e/`).
+	// Redirecting these breaks payload delivery.
+	skipTrailingSlashRedirect: isHostedBuild,
 	images: {
 		remotePatterns: [{ hostname: "img.clerk.com" }],
 	},
@@ -14,10 +20,25 @@ const nextConfig: NextConfig = {
 	// `[format]` segment that a single route handler covers. The browser
 	// still sees `/s/abc.md` in the URL bar — the rewrite is internal.
 	async rewrites() {
-		return [
+		const rewrites = [
 			{ source: "/s/:id.md", destination: "/s/:id/md" },
 			{ source: "/s/:id.json", destination: "/s/:id/json" },
 		];
+
+		if (isHostedBuild) {
+			rewrites.push(
+				{
+					source: `${posthogProxyPath}/static/:path*`,
+					destination: "https://us-assets.i.posthog.com/static/:path*",
+				},
+				{
+					source: `${posthogProxyPath}/:path*`,
+					destination: "https://us.i.posthog.com/:path*",
+				},
+			);
+		}
+
+		return rewrites;
 	},
 };
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,6 +29,7 @@
 		"next-themes": "^0.4.6",
 		"nuqs": "^2.8.9",
 		"openapi-fetch": "^0.17.0",
+		"posthog-js": "^1.360.1",
 		"radix-ui": "^1.4.3",
 		"react": "catalog:",
 		"react-dom": "catalog:",

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -3,6 +3,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { useState } from "react";
+import { AnalyticsProvider } from "@/components/providers/analytics-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
@@ -12,7 +13,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
 		<ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
 			<NuqsAdapter>
 				<QueryClientProvider client={queryClient}>
-					<TooltipProvider delayDuration={200}>{children}</TooltipProvider>
+					<AnalyticsProvider>
+						<TooltipProvider delayDuration={200}>{children}</TooltipProvider>
+					</AnalyticsProvider>
 				</QueryClientProvider>
 			</NuqsAdapter>
 		</ThemeProvider>

--- a/apps/web/src/components/providers/analytics-provider.logic.test.ts
+++ b/apps/web/src/components/providers/analytics-provider.logic.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildHostedPersonProperties,
+	resolveHostedAuthIdentityAction,
+} from "@/components/providers/analytics-provider.logic";
+
+describe("resolveHostedAuthIdentityAction", () => {
+	test("identifies when signed in with a new user id", () => {
+		const result = resolveHostedAuthIdentityAction({
+			isSignedIn: true,
+			userId: "user_123",
+			lastIdentifiedUserId: null,
+		});
+
+		expect(result).toEqual({
+			action: { type: "identify", userId: "user_123" },
+			nextIdentifiedUserId: "user_123",
+		});
+	});
+
+	test("does not re-identify the same user id", () => {
+		const result = resolveHostedAuthIdentityAction({
+			isSignedIn: true,
+			userId: "user_123",
+			lastIdentifiedUserId: "user_123",
+		});
+
+		expect(result).toEqual({
+			action: { type: "none" },
+			nextIdentifiedUserId: "user_123",
+		});
+	});
+
+	test("resets when user signs out after being identified", () => {
+		const result = resolveHostedAuthIdentityAction({
+			isSignedIn: false,
+			userId: null,
+			lastIdentifiedUserId: "user_123",
+		});
+
+		expect(result).toEqual({
+			action: { type: "reset" },
+			nextIdentifiedUserId: null,
+		});
+	});
+
+	test("does nothing while signed out with no identified user", () => {
+		const result = resolveHostedAuthIdentityAction({
+			isSignedIn: false,
+			userId: null,
+			lastIdentifiedUserId: null,
+		});
+
+		expect(result).toEqual({
+			action: { type: "none" },
+			nextIdentifiedUserId: null,
+		});
+	});
+});
+
+describe("buildHostedPersonProperties", () => {
+	test("returns null until full user record is loaded", () => {
+		const result = buildHostedPersonProperties({
+			isSignedIn: true,
+			userId: "user_123",
+			user: null,
+		});
+
+		expect(result).toBeNull();
+	});
+
+	test("builds enrichment payload from Clerk user", () => {
+		const result = buildHostedPersonProperties({
+			isSignedIn: true,
+			userId: "user_123",
+			user: {
+				fullName: "Ada Lovelace",
+				primaryEmailAddress: { emailAddress: "ada@example.com" },
+			},
+		});
+
+		expect(result).toEqual({
+			clerk_id: "user_123",
+			email: "ada@example.com",
+			name: "Ada Lovelace",
+		});
+	});
+
+	test("includes clerk_id even when name/email are missing", () => {
+		const result = buildHostedPersonProperties({
+			isSignedIn: true,
+			userId: "user_123",
+			user: {
+				fullName: null,
+				primaryEmailAddress: null,
+			},
+		});
+
+		expect(result).toEqual({
+			clerk_id: "user_123",
+			email: undefined,
+			name: undefined,
+		});
+	});
+});

--- a/apps/web/src/components/providers/analytics-provider.logic.ts
+++ b/apps/web/src/components/providers/analytics-provider.logic.ts
@@ -1,0 +1,74 @@
+export type HostedAuthIdentityAction =
+	| { type: "identify"; userId: string }
+	| { type: "reset" }
+	| { type: "none" };
+
+export function resolveHostedAuthIdentityAction({
+	isSignedIn,
+	userId,
+	lastIdentifiedUserId,
+}: {
+	isSignedIn: boolean;
+	userId: string | null | undefined;
+	lastIdentifiedUserId: string | null;
+}): {
+	action: HostedAuthIdentityAction;
+	nextIdentifiedUserId: string | null;
+} {
+	if (isSignedIn && userId) {
+		if (lastIdentifiedUserId === userId) {
+			return {
+				action: { type: "none" },
+				nextIdentifiedUserId: lastIdentifiedUserId,
+			};
+		}
+		return {
+			action: { type: "identify", userId },
+			nextIdentifiedUserId: userId,
+		};
+	}
+
+	if (lastIdentifiedUserId !== null) {
+		return {
+			action: { type: "reset" },
+			nextIdentifiedUserId: null,
+		};
+	}
+
+	return {
+		action: { type: "none" },
+		nextIdentifiedUserId: null,
+	};
+}
+
+export type HostedClerkUser = {
+	fullName: string | null;
+	primaryEmailAddress: {
+		emailAddress: string;
+	} | null;
+};
+
+export function buildHostedPersonProperties({
+	isSignedIn,
+	userId,
+	user,
+}: {
+	isSignedIn: boolean;
+	userId: string | null | undefined;
+	user: HostedClerkUser | null;
+}): {
+	clerk_id: string;
+	email: string | undefined;
+	name: string | undefined;
+} | null {
+	if (!isSignedIn || !userId || user === null) return null;
+
+	const email = user.primaryEmailAddress?.emailAddress?.trim();
+	const name = user.fullName?.trim();
+
+	return {
+		clerk_id: userId,
+		email: email && email.length > 0 ? email : undefined,
+		name: name && name.length > 0 ? name : undefined,
+	};
+}

--- a/apps/web/src/components/providers/analytics-provider.tsx
+++ b/apps/web/src/components/providers/analytics-provider.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useAuth, useUser } from "@clerk/nextjs";
+import { useEffect, useRef } from "react";
+import {
+	buildHostedPersonProperties,
+	resolveHostedAuthIdentityAction,
+} from "@/components/providers/analytics-provider.logic";
+import { IS_HOSTED } from "@/lib/hosted";
+
+const loadHostedPostHog = IS_HOSTED ? () => import("@/hosted/posthog") : null;
+
+export function AnalyticsProvider({ children }: { children: React.ReactNode }) {
+	const { isSignedIn, userId } = useAuth();
+	const { user, isLoaded: isUserLoaded } = useUser();
+	const identifiedUserIdRef = useRef<string | null>(null);
+
+	useEffect(() => {
+		const transition = resolveHostedAuthIdentityAction({
+			isSignedIn: Boolean(isSignedIn),
+			userId,
+			lastIdentifiedUserId: identifiedUserIdRef.current,
+		});
+		identifiedUserIdRef.current = transition.nextIdentifiedUserId;
+
+		if (!loadHostedPostHog) return;
+		if (transition.action.type === "identify") {
+			const identifyUserId = transition.action.userId;
+			void loadHostedPostHog().then((mod) => {
+				mod.identifyHostedUser(identifyUserId);
+			});
+			return;
+		}
+		if (transition.action.type === "reset") {
+			void loadHostedPostHog().then((mod) => {
+				mod.resetHostedPostHog();
+			});
+		}
+	}, [isSignedIn, userId]);
+
+	const userEmail = user?.primaryEmailAddress?.emailAddress ?? null;
+	const userFullName = user?.fullName ?? null;
+	const userLoaded = isUserLoaded && user !== null;
+
+	useEffect(() => {
+		const personProperties = buildHostedPersonProperties({
+			isSignedIn: Boolean(isSignedIn),
+			userId,
+			user: userLoaded
+				? {
+						fullName: userFullName,
+						primaryEmailAddress: userEmail ? { emailAddress: userEmail } : null,
+					}
+				: null,
+		});
+		if (!personProperties || !loadHostedPostHog) return;
+
+		void loadHostedPostHog().then((mod) => {
+			mod.enrichHostedUser(personProperties);
+		});
+	}, [isSignedIn, userId, userLoaded, userEmail, userFullName]);
+
+	return <>{children}</>;
+}

--- a/apps/web/src/hosted/README.md
+++ b/apps/web/src/hosted/README.md
@@ -53,6 +53,9 @@ OSS users running their own clawdi-cloud see none of this UI.
 - `use-hosted-agent-tiles.ts` — Lists the user's deployed agents on
   clawdi.ai, polled while any tile is in a transient state.
 - `deploy-trigger.tsx` — Sidebar entry that opens the Deploy flow.
+- `posthog.ts` — Hosted-only PostHog init helpers (called from
+  `apps/web/instrumentation-client.ts` through a compile-time hosted
+  gate (`NEXT_PUBLIC_CLAWDI_HOSTED === "true"`) plus dynamic import).
 
 The connector flow used to live here too (`use-hosted-connectors.ts`)
 but was removed once cloud-api adopted Clerk-id-based Composio

--- a/apps/web/src/hosted/oss-clean.test.ts
+++ b/apps/web/src/hosted/oss-clean.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
 /**
@@ -191,5 +191,86 @@ describe("dynamic @/hosted/* imports are gated by IS_HOSTED", () => {
 				`Ungated dynamic imports of @/hosted/* leak the hosted chunk into OSS bundles:\n  ${offenders.join("\n  ")}\nWrap each in \`const X = IS_HOSTED ? dynamic(…) : null\`.`,
 			);
 		}
+	});
+});
+
+describe("posthog-js is hosted-only", () => {
+	test("non-hosted source files do not import posthog-js", () => {
+		const offenders: string[] = [];
+		const posthogImport =
+			/(?:^\s*import\s+[^"']+\s+from\s+["']posthog-js["'])|(?:\bimport\s*\(\s*["']posthog-js["']\s*\))/m;
+
+		for (const file of walkSrcExceptHosted(SRC_DIR)) {
+			const src = readFileSync(file, "utf8");
+			if (posthogImport.test(src)) offenders.push(relative(SRC_DIR, file));
+		}
+
+		const instrumentationClient = join(SRC_DIR, "..", "instrumentation-client.ts");
+		if (existsSync(instrumentationClient)) {
+			const src = readFileSync(instrumentationClient, "utf8");
+			if (posthogImport.test(src)) {
+				offenders.push(relative(SRC_DIR, instrumentationClient));
+			}
+		}
+
+		if (offenders.length > 0) {
+			throw new Error(
+				`posthog-js must stay hosted-only. Move imports under src/hosted and reach them via IS_HOSTED-gated dynamic import:\n  ${offenders.join("\n  ")}`,
+			);
+		}
+	});
+});
+
+describe("instrumentation-client hosted imports", () => {
+	test("hosted dynamic imports are gated by compile-time hosted checks", () => {
+		const instrumentationClient = join(SRC_DIR, "..", "instrumentation-client.ts");
+		if (!existsSync(instrumentationClient)) return;
+
+		const src = readFileSync(instrumentationClient, "utf8");
+		const offenders: string[] = [];
+		const hostedDynamic = /import\s*\(\s*["']@\/hosted\/[^"']+["']\s*\)/g;
+		const compileTimeHostedGate = /\bprocess\.env\.NEXT_PUBLIC_CLAWDI_HOSTED\s*===\s*["']true["']/;
+
+		for (const match of src.matchAll(hostedDynamic)) {
+			const idx = match.index ?? 0;
+			const lookbehind = src.slice(Math.max(0, idx - 200), idx);
+			if (!/\bIS_HOSTED\b/.test(lookbehind) && !compileTimeHostedGate.test(lookbehind)) {
+				offenders.push(`${relative(SRC_DIR, instrumentationClient)} — ${match[0]}`);
+			}
+		}
+
+		if (offenders.length > 0) {
+			throw new Error(
+				`instrumentation-client.ts may only reach @/hosted/* behind compile-time hosted gates (IS_HOSTED or process.env.NEXT_PUBLIC_CLAWDI_HOSTED === "true"):\n  ${offenders.join("\n  ")}`,
+			);
+		}
+	});
+});
+
+describe("PostHog proxy route boundaries", () => {
+	test("next.config.ts gates PostHog rewrites behind hosted builds", () => {
+		const nextConfig = join(SRC_DIR, "..", "next.config.ts");
+		if (!existsSync(nextConfig)) return;
+
+		const src = readFileSync(nextConfig, "utf8");
+		expect(src).toMatch(
+			/\bconst\s+isHostedBuild\s*=\s*process\.env\.NEXT_PUBLIC_CLAWDI_HOSTED\s*===\s*["']true["']/,
+		);
+		expect(src).toMatch(/if\s*\(\s*!isHostedBuild\s*\)\s*return\s*\[\s*\]/);
+		expect(src).toMatch(/source:\s*`\$\{posthogProxyPath\}\/:path\*`/);
+	});
+
+	test("proxy.ts only exposes /_cdi/px as public in hosted builds", () => {
+		const proxyFile = join(SRC_DIR, "proxy.ts");
+		if (!existsSync(proxyFile)) return;
+
+		const src = readFileSync(proxyFile, "utf8");
+		expect(src).toMatch(
+			/\bconst\s+isHostedBuild\s*=\s*process\.env\.NEXT_PUBLIC_CLAWDI_HOSTED\s*===\s*["']true["']/,
+		);
+		expect(src).toMatch(
+			/if\s*\(\s*isHostedBuild\s*\)\s*\{[\s\S]*publicRoutes\.push\(\s*["']\/_cdi\/px\(\.\*\)["']\s*\)/,
+		);
+		expect(src).not.toMatch(/createRouteMatcher\s*\(\s*\[[\s\S]*["']\/_cdi\/px\(\.\*\)["']/);
 	});
 });

--- a/apps/web/src/hosted/oss-clean.test.ts
+++ b/apps/web/src/hosted/oss-clean.test.ts
@@ -108,6 +108,90 @@ function stripComments(src: string): string {
 	return out;
 }
 
+function findMatchingBrace(src: string, openBraceIndex: number): number {
+	let depth = 0;
+	let inSingleQuote = false;
+	let inDoubleQuote = false;
+	let inTemplate = false;
+	let inLineComment = false;
+	let inBlockComment = false;
+
+	for (let i = openBraceIndex; i < src.length; i++) {
+		const c = src[i];
+		const n = src[i + 1];
+
+		if (inLineComment) {
+			if (c === "\n") inLineComment = false;
+			continue;
+		}
+		if (inBlockComment) {
+			if (c === "*" && n === "/") {
+				inBlockComment = false;
+				i++;
+			}
+			continue;
+		}
+		if (inSingleQuote) {
+			if (c === "\\") {
+				i++;
+				continue;
+			}
+			if (c === "'") inSingleQuote = false;
+			continue;
+		}
+		if (inDoubleQuote) {
+			if (c === "\\") {
+				i++;
+				continue;
+			}
+			if (c === '"') inDoubleQuote = false;
+			continue;
+		}
+		if (inTemplate) {
+			if (c === "\\") {
+				i++;
+				continue;
+			}
+			if (c === "`") inTemplate = false;
+			continue;
+		}
+
+		if (c === "/" && n === "/") {
+			inLineComment = true;
+			i++;
+			continue;
+		}
+		if (c === "/" && n === "*") {
+			inBlockComment = true;
+			i++;
+			continue;
+		}
+		if (c === "'") {
+			inSingleQuote = true;
+			continue;
+		}
+		if (c === '"') {
+			inDoubleQuote = true;
+			continue;
+		}
+		if (c === "`") {
+			inTemplate = true;
+			continue;
+		}
+
+		if (c === "{") {
+			depth++;
+			continue;
+		}
+		if (c === "}") {
+			depth--;
+			if (depth === 0) return i;
+		}
+	}
+
+	return -1;
+}
+
 describe("hosted/ directory invariants", () => {
 	test('every .tsx file sets data-hosted="true" on its root', () => {
 		const files = listHostedTsx();
@@ -256,8 +340,37 @@ describe("PostHog proxy route boundaries", () => {
 		expect(src).toMatch(
 			/\bconst\s+isHostedBuild\s*=\s*process\.env\.NEXT_PUBLIC_CLAWDI_HOSTED\s*===\s*["']true["']/,
 		);
-		expect(src).toMatch(/if\s*\(\s*!isHostedBuild\s*\)\s*return\s*\[\s*\]/);
-		expect(src).toMatch(/source:\s*`\$\{posthogProxyPath\}\/:path\*`/);
+		expect(src).toMatch(/source:\s*["']\/s\/:id\.md["']\s*,\s*destination:\s*["']\/s\/:id\/md["']/);
+		expect(src).toMatch(
+			/source:\s*["']\/s\/:id\.json["']\s*,\s*destination:\s*["']\/s\/:id\/json["']/,
+		);
+
+		const hostedIfMatch = /\bif\s*\(\s*isHostedBuild\s*\)\s*\{/.exec(src);
+		expect(hostedIfMatch).not.toBeNull();
+		if (!hostedIfMatch) return;
+
+		const hostedIfOpenBrace = src.indexOf("{", hostedIfMatch.index);
+		expect(hostedIfOpenBrace).toBeGreaterThanOrEqual(0);
+		if (hostedIfOpenBrace < 0) return;
+
+		const hostedIfCloseBrace = findMatchingBrace(src, hostedIfOpenBrace);
+		expect(hostedIfCloseBrace).toBeGreaterThan(hostedIfOpenBrace);
+		if (hostedIfCloseBrace <= hostedIfOpenBrace) return;
+
+		const hostedPosthogBlock = src.slice(hostedIfOpenBrace + 1, hostedIfCloseBrace);
+		expect(hostedPosthogBlock).toMatch(/rewrites\.push\s*\(/);
+		expect(hostedPosthogBlock).toMatch(/source:\s*`\$\{posthogProxyPath\}\/static\/:path\*`/);
+		expect(hostedPosthogBlock).toMatch(/source:\s*`\$\{posthogProxyPath\}\/:path\*`/);
+
+		const posthogRewriteSources = [
+			...src.matchAll(/source:\s*`\$\{posthogProxyPath\}\/(?:static\/)?:path\*`/g),
+		];
+		expect(posthogRewriteSources.length).toBe(2);
+		for (const sourceMatch of posthogRewriteSources) {
+			const sourceIndex = sourceMatch.index ?? -1;
+			expect(sourceIndex).toBeGreaterThanOrEqual(hostedIfOpenBrace + 1);
+			expect(sourceIndex).toBeLessThan(hostedIfCloseBrace);
+		}
 	});
 
 	test("proxy.ts only exposes /_cdi/px as public in hosted builds", () => {

--- a/apps/web/src/hosted/posthog.test.ts
+++ b/apps/web/src/hosted/posthog.test.ts
@@ -1,5 +1,29 @@
-import { describe, expect, test } from "bun:test";
-import { isHostedPostHogEnabled, normalizePostHogToken } from "@/hosted/posthog";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import posthog from "posthog-js";
+import {
+	enrichHostedUser,
+	identifyHostedUser,
+	isHostedPostHogEnabled,
+	normalizePostHogToken,
+	resetHostedPostHog,
+} from "@/hosted/posthog";
+
+type MutablePostHog = {
+	identify?: (distinctId: string, properties?: Record<string, unknown>) => void;
+	reset?: () => void;
+	setPersonProperties?: (properties: Record<string, unknown>) => void;
+};
+
+const sdk = posthog as MutablePostHog;
+const originalIdentify = sdk.identify;
+const originalReset = sdk.reset;
+const originalSetPersonProperties = sdk.setPersonProperties;
+
+afterEach(() => {
+	sdk.identify = originalIdentify;
+	sdk.reset = originalReset;
+	sdk.setPersonProperties = originalSetPersonProperties;
+});
 
 describe("normalizePostHogToken", () => {
 	test("returns null for undefined", () => {
@@ -28,5 +52,60 @@ describe("isHostedPostHogEnabled", () => {
 	test("is true only when hosted and token is non-empty", () => {
 		expect(isHostedPostHogEnabled({ isHosted: true, token: "phc_test_123" })).toBe(true);
 		expect(isHostedPostHogEnabled({ isHosted: true, token: "  phc_test_123  " })).toBe(true);
+	});
+});
+
+describe("hosted identity helpers", () => {
+	test("identifyHostedUser identifies with clerk_id when hosted posthog is enabled", () => {
+		const identify = mock(() => {});
+		sdk.identify = identify;
+
+		const called = identifyHostedUser("user_123", { isHosted: true, token: "phc_test_123" });
+
+		expect(called).toBe(true);
+		expect(identify).toHaveBeenCalledTimes(1);
+		expect(identify).toHaveBeenCalledWith("user_123", { clerk_id: "user_123" });
+	});
+
+	test("identifyHostedUser is a no-op when posthog is disabled", () => {
+		const identify = mock(() => {});
+		sdk.identify = identify;
+
+		const called = identifyHostedUser("user_123", { isHosted: false, token: "phc_test_123" });
+
+		expect(called).toBe(false);
+		expect(identify).not.toHaveBeenCalled();
+	});
+
+	test("resetHostedPostHog resets on sign-out when enabled", () => {
+		const reset = mock(() => {});
+		sdk.reset = reset;
+
+		const called = resetHostedPostHog({ isHosted: true, token: "phc_test_123" });
+
+		expect(called).toBe(true);
+		expect(reset).toHaveBeenCalledTimes(1);
+	});
+
+	test("enrichHostedUser sets person properties with email/name/clerk_id", () => {
+		const setPersonProperties = mock(() => {});
+		sdk.setPersonProperties = setPersonProperties;
+
+		const called = enrichHostedUser(
+			{
+				clerk_id: "user_123",
+				email: "ada@example.com",
+				name: "Ada Lovelace",
+			},
+			{ isHosted: true, token: "phc_test_123" },
+		);
+
+		expect(called).toBe(true);
+		expect(setPersonProperties).toHaveBeenCalledTimes(1);
+		expect(setPersonProperties).toHaveBeenCalledWith({
+			clerk_id: "user_123",
+			email: "ada@example.com",
+			name: "Ada Lovelace",
+		});
 	});
 });

--- a/apps/web/src/hosted/posthog.test.ts
+++ b/apps/web/src/hosted/posthog.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { isHostedPostHogEnabled, normalizePostHogToken } from "@/hosted/posthog";
+
+describe("normalizePostHogToken", () => {
+	test("returns null for undefined", () => {
+		expect(normalizePostHogToken(undefined)).toBeNull();
+	});
+
+	test("returns null for blank strings", () => {
+		expect(normalizePostHogToken("")).toBeNull();
+		expect(normalizePostHogToken("   ")).toBeNull();
+	});
+
+	test("trims and returns non-empty tokens", () => {
+		expect(normalizePostHogToken("  phc_test_123  ")).toBe("phc_test_123");
+	});
+});
+
+describe("isHostedPostHogEnabled", () => {
+	test("is false in OSS builds even with a token", () => {
+		expect(isHostedPostHogEnabled({ isHosted: false, token: "phc_test_123" })).toBe(false);
+	});
+
+	test("is false in hosted builds when token is missing", () => {
+		expect(isHostedPostHogEnabled({ isHosted: true, token: undefined })).toBe(false);
+	});
+
+	test("is true only when hosted and token is non-empty", () => {
+		expect(isHostedPostHogEnabled({ isHosted: true, token: "phc_test_123" })).toBe(true);
+		expect(isHostedPostHogEnabled({ isHosted: true, token: "  phc_test_123  " })).toBe(true);
+	});
+});

--- a/apps/web/src/hosted/posthog.ts
+++ b/apps/web/src/hosted/posthog.ts
@@ -1,11 +1,21 @@
 import posthog from "posthog-js";
-import { env } from "@/lib/env";
-import { IS_HOSTED } from "@/lib/hosted";
 
 const POSTHOG_PROXY_PATH = "/_cdi/px";
 const POSTHOG_PROPERTY_DENYLIST = ["auth", "cookie", "password", "secret"];
+const HOSTED_BUILD_FLAG = process.env.NEXT_PUBLIC_CLAWDI_HOSTED === "true";
+const DEFAULT_POSTHOG_TOKEN = process.env.NEXT_PUBLIC_POSTHOG_TOKEN;
 
 type PostHogClient = typeof posthog & { __loaded?: boolean };
+type HostedPostHogOptions = {
+	isHosted?: boolean;
+	token?: string;
+};
+
+export type HostedUserPersonProperties = {
+	clerk_id: string;
+	email?: string;
+	name?: string;
+};
 
 export function normalizePostHogToken(token: string | undefined): string | null {
 	if (typeof token !== "string") return null;
@@ -14,8 +24,8 @@ export function normalizePostHogToken(token: string | undefined): string | null 
 }
 
 export function isHostedPostHogEnabled({
-	isHosted = IS_HOSTED,
-	token = env.NEXT_PUBLIC_POSTHOG_TOKEN,
+	isHosted = HOSTED_BUILD_FLAG,
+	token = DEFAULT_POSTHOG_TOKEN,
 }: {
 	isHosted?: boolean;
 	token?: string;
@@ -24,12 +34,9 @@ export function isHostedPostHogEnabled({
 }
 
 export function initHostedPostHog({
-	isHosted = IS_HOSTED,
-	token = env.NEXT_PUBLIC_POSTHOG_TOKEN,
-}: {
-	isHosted?: boolean;
-	token?: string;
-} = {}): boolean {
+	isHosted = HOSTED_BUILD_FLAG,
+	token = DEFAULT_POSTHOG_TOKEN,
+}: HostedPostHogOptions = {}): boolean {
 	const normalizedToken = normalizePostHogToken(token);
 	if (!isHosted || !normalizedToken) return false;
 
@@ -45,5 +52,36 @@ export function initHostedPostHog({
 		autocapture: true,
 		property_denylist: POSTHOG_PROPERTY_DENYLIST,
 	});
+	sdk.__loaded = true;
+	return true;
+}
+
+export function identifyHostedUser(
+	userId: string,
+	{ isHosted = HOSTED_BUILD_FLAG, token = DEFAULT_POSTHOG_TOKEN }: HostedPostHogOptions = {},
+): boolean {
+	if (!isHostedPostHogEnabled({ isHosted, token })) return false;
+	const distinctId = userId.trim();
+	if (distinctId.length === 0) return false;
+
+	posthog.identify(distinctId, { clerk_id: distinctId });
+	return true;
+}
+
+export function resetHostedPostHog({
+	isHosted = HOSTED_BUILD_FLAG,
+	token = DEFAULT_POSTHOG_TOKEN,
+}: HostedPostHogOptions = {}): boolean {
+	if (!isHostedPostHogEnabled({ isHosted, token })) return false;
+	posthog.reset();
+	return true;
+}
+
+export function enrichHostedUser(
+	personProperties: HostedUserPersonProperties,
+	{ isHosted = HOSTED_BUILD_FLAG, token = DEFAULT_POSTHOG_TOKEN }: HostedPostHogOptions = {},
+): boolean {
+	if (!isHostedPostHogEnabled({ isHosted, token })) return false;
+	posthog.setPersonProperties(personProperties);
 	return true;
 }

--- a/apps/web/src/hosted/posthog.ts
+++ b/apps/web/src/hosted/posthog.ts
@@ -1,0 +1,49 @@
+import posthog from "posthog-js";
+import { env } from "@/lib/env";
+import { IS_HOSTED } from "@/lib/hosted";
+
+const POSTHOG_PROXY_PATH = "/_cdi/px";
+const POSTHOG_PROPERTY_DENYLIST = ["auth", "cookie", "password", "secret"];
+
+type PostHogClient = typeof posthog & { __loaded?: boolean };
+
+export function normalizePostHogToken(token: string | undefined): string | null {
+	if (typeof token !== "string") return null;
+	const cleaned = token.trim();
+	return cleaned.length > 0 ? cleaned : null;
+}
+
+export function isHostedPostHogEnabled({
+	isHosted = IS_HOSTED,
+	token = env.NEXT_PUBLIC_POSTHOG_TOKEN,
+}: {
+	isHosted?: boolean;
+	token?: string;
+} = {}): boolean {
+	return isHosted && normalizePostHogToken(token) !== null;
+}
+
+export function initHostedPostHog({
+	isHosted = IS_HOSTED,
+	token = env.NEXT_PUBLIC_POSTHOG_TOKEN,
+}: {
+	isHosted?: boolean;
+	token?: string;
+} = {}): boolean {
+	const normalizedToken = normalizePostHogToken(token);
+	if (!isHosted || !normalizedToken) return false;
+
+	const sdk = posthog as PostHogClient;
+	if (sdk.__loaded) return false;
+
+	posthog.init(normalizedToken, {
+		api_host: POSTHOG_PROXY_PATH,
+		defaults: "2026-01-30",
+		person_profiles: "identified_only",
+		capture_pageview: "history_change",
+		capture_pageleave: true,
+		autocapture: true,
+		property_denylist: POSTHOG_PROPERTY_DENYLIST,
+	});
+	return true;
+}

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -53,6 +53,10 @@ export const env = createEnv({
 			.string()
 			.optional()
 			.transform((v) => v === "true"),
+
+		// Hosted-only analytics token. Optional so OSS and hosted-without-
+		// analytics both validate cleanly.
+		NEXT_PUBLIC_POSTHOG_TOKEN: z.string().min(1).optional(),
 	},
 	runtimeEnv: {
 		VERCEL_PROJECT_PRODUCTION_URL: process.env.VERCEL_PROJECT_PRODUCTION_URL,
@@ -63,6 +67,7 @@ export const env = createEnv({
 		NEXT_PUBLIC_DEPLOY_DASHBOARD_URL: process.env.NEXT_PUBLIC_DEPLOY_DASHBOARD_URL,
 		NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
 		NEXT_PUBLIC_CLAWDI_HOSTED: process.env.NEXT_PUBLIC_CLAWDI_HOSTED,
+		NEXT_PUBLIC_POSTHOG_TOKEN: process.env.NEXT_PUBLIC_POSTHOG_TOKEN,
 	},
 	// `bun test` preloads `test-setup.ts` to seed required vars, so
 	// validation runs in tests too — this preserves the schema's

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,5 +1,7 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
+const isHostedBuild = process.env.NEXT_PUBLIC_CLAWDI_HOSTED === "true";
+
 // Protection is "everything not on this list". A positive-allowlist for
 // protected routes would default new pages to PUBLIC if someone forgets
 // to update it — the opposite of what we want for a dashboard. Keep
@@ -15,7 +17,14 @@ import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 // but explicitly carves `.json` *out* of the `.js` exclusion, so without
 // this entry `/s/{token}.json` would 307 to /sign-in. Share access is
 // gated by the token, not the user's Clerk session.
-const isPublicRoute = createRouteMatcher(["/sign-in(.*)", "/sign-up(.*)", "/skill.md", "/s/(.*)"]);
+const publicRoutes = ["/sign-in(.*)", "/sign-up(.*)", "/skill.md", "/s/(.*)"];
+
+if (isHostedBuild) {
+	// PostHog first-party proxy path is hosted-only.
+	publicRoutes.push("/_cdi/px(.*)");
+}
+
+const isPublicRoute = createRouteMatcher(publicRoutes);
 
 // signInUrl / signUpUrl must live here — they tell auth.protect() where
 // to send unauth'd users. Without them, Clerk falls back to its hosted

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "next-themes": "^0.4.6",
         "nuqs": "^2.8.9",
         "openapi-fetch": "^0.17.0",
+        "posthog-js": "^1.360.1",
         "radix-ui": "^1.4.3",
         "react": "catalog:",
         "react-dom": "catalog:",
@@ -236,6 +237,52 @@
     "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow=="],
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.4", "", { "os": "win32", "cpu": "x64" }, "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.208.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.2.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw=="],
+
+    "@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.208.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-exporter-base": "0.208.0", "@opentelemetry/otlp-transformer": "0.208.0", "@opentelemetry/sdk-logs": "0.208.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg=="],
+
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.208.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/otlp-transformer": "0.208.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.208.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/sdk-logs": "0.208.0", "@opentelemetry/sdk-metrics": "2.2.0", "@opentelemetry/sdk-trace-base": "2.2.0", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.208.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.208.0", "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/resources": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
+
+    "@posthog/core": ["@posthog/core@1.29.1", "", { "dependencies": { "@posthog/types": "1.373.4" } }, "sha512-q+/t/DZALr50YTE0dFgfGSS9EgwcyAlqsn+JS61wLkwdcDM5yu/YTDM8oMKmJupsyjSZlVkDuHZAMd4ab7AxzQ=="],
+
+    "@posthog/types": ["@posthog/types@1.373.4", "", {}, "sha512-n+0AbGRYYsbi+CQXQi2rF1lwTSyASlaogcw4YSkzB5KeMa4Y6nhNb7+TTnu9aVor+BycsQYCa2OsBrMMbaTekw=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.1", "", {}, "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -443,6 +490,8 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
@@ -521,6 +570,8 @@
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
+    "core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
+
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
@@ -540,6 +591,8 @@
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "dompurify": ["dompurify@3.4.2", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -584,6 +637,8 @@
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.1.6", "", { "dependencies": { "fast-string-width": "^1.1.0" } }, "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w=="],
+
+    "fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
@@ -708,6 +763,8 @@
     "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
@@ -865,11 +922,19 @@
 
     "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
+    "posthog-js": ["posthog-js@1.373.4", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/api-logs": "^0.208.0", "@opentelemetry/exporter-logs-otlp-http": "^0.208.0", "@opentelemetry/resources": "^2.2.0", "@opentelemetry/sdk-logs": "^0.208.0", "@posthog/core": "1.29.1", "@posthog/types": "1.373.4", "core-js": "^3.38.1", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.28.2", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.1.0" } }, "sha512-6DueUS5KOGZlKsQlelLURmtp9PA52rdCxt/IvuoYKAErlkh2LczogMopUIpeqbwfOnGDQEf8gmDh4z/IFeU4CQ=="],
+
+    "preact": ["preact@10.29.1", "", {}, "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg=="],
+
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "protobufjs": ["protobufjs@7.5.8", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.1", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
 
     "radix-ui": ["radix-ui@1.4.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-accessible-icon": "1.1.7", "@radix-ui/react-accordion": "1.2.12", "@radix-ui/react-alert-dialog": "1.1.15", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-aspect-ratio": "1.1.7", "@radix-ui/react-avatar": "1.1.10", "@radix-ui/react-checkbox": "1.3.3", "@radix-ui/react-collapsible": "1.1.12", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-context-menu": "2.2.16", "@radix-ui/react-dialog": "1.1.15", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-dropdown-menu": "2.1.16", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-form": "0.1.8", "@radix-ui/react-hover-card": "1.1.15", "@radix-ui/react-label": "2.1.7", "@radix-ui/react-menu": "2.1.16", "@radix-ui/react-menubar": "1.1.16", "@radix-ui/react-navigation-menu": "1.2.14", "@radix-ui/react-one-time-password-field": "0.1.8", "@radix-ui/react-password-toggle-field": "0.1.3", "@radix-ui/react-popover": "1.1.15", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-progress": "1.1.7", "@radix-ui/react-radio-group": "1.3.8", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-scroll-area": "1.2.10", "@radix-ui/react-select": "2.2.6", "@radix-ui/react-separator": "1.1.7", "@radix-ui/react-slider": "1.3.6", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-switch": "1.2.6", "@radix-ui/react-tabs": "1.1.13", "@radix-ui/react-toast": "1.2.15", "@radix-ui/react-toggle": "1.1.10", "@radix-ui/react-toggle-group": "1.1.11", "@radix-ui/react-toolbar": "1.1.11", "@radix-ui/react-tooltip": "1.2.8", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-escape-keydown": "1.1.1", "@radix-ui/react-use-is-hydrated": "0.1.0", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA=="],
 
@@ -1015,6 +1080,8 @@
 
     "web": ["web@workspace:apps/web"],
 
+    "web-vitals": ["web-vitals@5.2.0", "", {}, "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
@@ -1034,6 +1101,16 @@
     "@clerk/shared/@tanstack/query-core": ["@tanstack/query-core@5.90.16", "", {}, "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww=="],
 
     "@clerk/themes/@clerk/shared": ["@clerk/shared@3.47.5", "", { "dependencies": { "csstype": "3.1.3", "dequal": "2.0.3", "glob-to-regexp": "0.4.1", "js-cookie": "3.0.5", "std-env": "^3.9.0", "swr": "2.3.4" }, "peerDependencies": { "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0", "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-rDVe73/VN2NZXhtrLRHshkUpQDrevAqDRxeXUl2M0IBEBkcl+VMHlV7fep53cVWo0b3gIqLk82pmmi+WoyF/xg=="],
+
+    "@opentelemetry/otlp-transformer/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
+
+    "@opentelemetry/resources/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/sdk-logs/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
+
+    "@opentelemetry/sdk-metrics/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
+
+    "@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@2.2.0", "", { "dependencies": { "@opentelemetry/core": "2.2.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 


### PR DESCRIPTION
## Summary
- Add hosted-only PostHog initialization for the web app via `instrumentation-client.ts` and `src/hosted/posthog.ts`
- Add hosted-only first-party PostHog proxy rewrites gated by `NEXT_PUBLIC_CLAWDI_HOSTED === "true"`
- Add hosted auth analytics provider that identifies PostHog users immediately from Clerk `userId`, resets on sign-out, and later enriches person properties with `clerk_id`, `email`, and `name`
- Keep OSS clean by ensuring `posthog-js` imports and the `/_cdi/px` public route are only reachable from hosted-gated paths
- Document the hosted PostHog boundary and add static/unit regression tests

## Test Plan
- `git diff --check`
- `bun test apps/web/src/components/providers/analytics-provider.logic.test.ts apps/web/src/hosted/posthog.test.ts apps/web/src/hosted/oss-clean.test.ts`
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_dummy_for_checks npm run lint --workspace apps/web`
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_dummy_for_checks npm run typecheck --workspace apps/web`
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_dummy_for_checks npm run test --workspace apps/web`
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_dummy_for_build NEXT_PUBLIC_CLAWDI_HOSTED= npm run build --workspace apps/web`

## Notes
- `NEXT_PUBLIC_POSTHOG_TOKEN` is optional and intentionally only activates when `NEXT_PUBLIC_CLAWDI_HOSTED=true`.
- The PostHog proxy route remains gated out of OSS builds.
- The identify path is split from Clerk profile enrichment so first-touch/pageview attribution can attach to the stable Clerk id before `useUser()` finishes loading.