### PR TITLE
fix(web): wrap long inline code in session messages

### DIFF
--- a/apps/web/src/components/sessions/message-list.tsx
+++ b/apps/web/src/components/sessions/message-list.tsx
@@ -146,7 +146,12 @@ function MessageBlock({
 					</div>
 				) : null}
 
-				<div className="text-sm">
+				{/* `wrap-anywhere` (overflow-wrap: anywhere) lets long unbroken runs
+				    — typically inline `<code>` like `clawdi.memory_search({...})` —
+				    wrap inside the flex column instead of pushing the page wider
+				    than the viewport. Affects min-content sizing too, so the
+				    enclosing flex chain shrinks correctly on narrow screens. */}
+				<div className="text-sm wrap-anywhere">
 					{isUser ? (
 						<UserMessageBody content={message.content} />
 					) : (


### PR DESCRIPTION
## Summary
- Long unbroken runs in messages (typically inline `<code>` like `clawdi.memory_search({"query":"..."})`) had no break opportunity and pushed both the dashboard `/sessions/[id]` and the public `/s/[id]` pages wider than the viewport.
- Add `wrap-anywhere` (`overflow-wrap: anywhere`) on the message body so those tokens break inside the flex column and the horizontal scrollbar goes away on both pages.

## Test plan
- [ ] Open a session containing a message with long inline code (e.g. `clawdi.memory_search({...})`) on `/sessions/[id]` — no horizontal scrollbar; long token wraps within the column.
- [ ] Open the same session at `/s/[id]` — same behavior.
- [ ] Resize the window narrow; verify content keeps wrapping instead of overflowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)