### PR TITLE
feat(web): read-only share controls on public session page

### DIFF
--- a/apps/web/src/app/s/[id]/page.tsx
+++ b/apps/web/src/app/s/[id]/page.tsx
@@ -13,6 +13,7 @@ import { MessageList } from "@/components/sessions/message-list";
 import { SessionSidebar } from "@/components/sessions/session-sidebar";
 import { ShareHeaderUser } from "@/components/share/header-user";
 import { NoAccess } from "@/components/share/no-access";
+import { PublicShareControls } from "@/components/share/public-share-controls";
 import { SignInToView } from "@/components/share/sign-in-to-view";
 import type { SessionMessage } from "@/lib/api-schemas";
 import { env } from "@/lib/env";
@@ -31,9 +32,10 @@ import {
  * don't run JavaScript. Mirrors the dashboard `/sessions/[id]` layout
  * (DetailTitle / DetailMeta / SessionSidebar / DetailStats / message
  * stream) so a visitor's view of a session looks the same as the owner's
- * — minus owner-only chrome (no share controls, no breadcrumb, no
+ * — minus owner-only chrome (no visibility toggle, no breadcrumb, no
  * direction toggle, no infinite-pagination — first page is enough for
- * the visit-then-leave use case).
+ * the visit-then-leave use case). Read-only share affordances (copy
+ * link, copy Markdown/JSON URLs) live in `PublicShareControls`.
  *
  * Auth: optional. JWT is forwarded so the backend can identify the
  * session owner — owner sees the same view as a visitor (no extra
@@ -186,32 +188,35 @@ export default async function PublicSharePage({ params }: { params: Promise<Para
 		<>
 			<ShareHeader />
 			<div className="mx-auto max-w-4xl space-y-5 px-4 py-6 lg:px-6">
-				<div className="space-y-2">
-					<DetailTitle>{summaryText}</DetailTitle>
-					<DetailMeta>
-						<AgentInline machineName={null} type={share.agent_type} />
-						{share.project_path ? (
-							<>
-								<span>·</span>
-								<span className="truncate font-mono">{share.project_path}</span>
-							</>
-						) : null}
-						<span>·</span>
-						<span title={formatAbsoluteTooltip(share.started_at)}>
-							Started {relativeTime(share.started_at)}
-						</span>
-						{Math.abs(
-							new Date(share.last_activity_at).getTime() - new Date(share.started_at).getTime(),
-						) >
-						5 * 60_000 ? (
-							<>
-								<span>·</span>
-								<span title={formatAbsoluteTooltip(share.last_activity_at)}>
-									Last activity {relativeTime(share.last_activity_at)}
-								</span>
-							</>
-						) : null}
-					</DetailMeta>
+				<div className="flex items-start justify-between gap-3">
+					<div className="min-w-0 flex-1 space-y-2">
+						<DetailTitle>{summaryText}</DetailTitle>
+						<DetailMeta>
+							<AgentInline machineName={null} type={share.agent_type} />
+							{share.project_path ? (
+								<>
+									<span>·</span>
+									<span className="truncate font-mono">{share.project_path}</span>
+								</>
+							) : null}
+							<span>·</span>
+							<span title={formatAbsoluteTooltip(share.started_at)}>
+								Started {relativeTime(share.started_at)}
+							</span>
+							{Math.abs(
+								new Date(share.last_activity_at).getTime() - new Date(share.started_at).getTime(),
+							) >
+							5 * 60_000 ? (
+								<>
+									<span>·</span>
+									<span title={formatAbsoluteTooltip(share.last_activity_at)}>
+										Last activity {relativeTime(share.last_activity_at)}
+									</span>
+								</>
+							) : null}
+						</DetailMeta>
+					</div>
+					<PublicShareControls sessionId={share.id} />
 				</div>
 
 				<SessionSidebar relatedRefs={share.related_refs} />

--- a/apps/web/src/app/s/layout.tsx
+++ b/apps/web/src/app/s/layout.tsx
@@ -1,0 +1,17 @@
+import { Toaster } from "@/components/ui/sonner";
+
+/**
+ * Share-route layout — exists solely to mount `<Toaster />`. The
+ * top-level `app/layout.tsx` is auth/provider-shell only; the dashboard
+ * group mounts its own Toaster, so client interactions outside that
+ * group (notably the public share page's copy-URL controls) need their
+ * own mount, otherwise `toast.*()` calls silently no-op.
+ */
+export default function ShareLayout({ children }: { children: React.ReactNode }) {
+	return (
+		<>
+			{children}
+			<Toaster />
+		</>
+	);
+}

--- a/apps/web/src/components/share/public-share-controls.tsx
+++ b/apps/web/src/components/share/public-share-controls.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { Check, FileJson, FileText, Link2, MoreHorizontal } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn, errorMessage } from "@/lib/utils";
+
+/**
+ * Read-only share affordances for the public share page (`/s/{id}`).
+ * Mirrors the owner-side `SessionShareControls` chrome but without the
+ * visibility toggle — viewers may not be the owner, and the link already
+ * works (server-side gate handles auth/permissions). The Markdown / JSON
+ * URLs are the canonical agent-fetch entry points (see
+ * `apps/web/src/app/s/[id]/[format]/route.ts`).
+ */
+export function PublicShareControls({ sessionId }: { sessionId: string }) {
+	const url = buildShareUrl(sessionId);
+	return (
+		<div className="flex items-center gap-1">
+			<CopyLinkButton url={url} />
+			<ExportMenu url={url} />
+		</div>
+	);
+}
+
+function buildShareUrl(sessionId: string): string {
+	const origin = typeof window !== "undefined" ? window.location.origin : "";
+	return `${origin}/s/${sessionId}`;
+}
+
+function CopyLinkButton({ url }: { url: string }) {
+	const { copied, copy } = useCopyToClipboard(url, "Link");
+	return (
+		<Button
+			variant="outline"
+			size="icon"
+			className={cn("size-8", copied && "text-emerald-600")}
+			onClick={copy}
+			aria-label="Copy share link"
+			title="Copy share link"
+		>
+			{copied ? <Check className="size-3.5" /> : <Link2 className="size-3.5" />}
+		</Button>
+	);
+}
+
+function ExportMenu({ url }: { url: string }) {
+	const mdUrl = `${url}.md`;
+	const jsonUrl = `${url}.json`;
+	const { copy: copyMd } = useCopyToClipboard(mdUrl, "Markdown URL");
+	const { copy: copyJson } = useCopyToClipboard(jsonUrl, "JSON URL");
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant="outline"
+					size="icon"
+					className="size-8"
+					aria-label="More options"
+					title="More options"
+				>
+					<MoreHorizontal className="size-3.5" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end" className="w-52">
+				<DropdownMenuItem onClick={copyMd}>
+					<FileText className="size-3.5" />
+					Copy Markdown URL
+				</DropdownMenuItem>
+				<DropdownMenuItem onClick={copyJson}>
+					<FileJson className="size-3.5" />
+					Copy JSON URL
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
+function useCopyToClipboard(url: string, label: string) {
+	const [copied, setCopied] = useState(false);
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(
+		() => () => {
+			if (timerRef.current) clearTimeout(timerRef.current);
+		},
+		[],
+	);
+
+	async function copy() {
+		try {
+			await navigator.clipboard.writeText(url);
+			setCopied(true);
+			if (timerRef.current) clearTimeout(timerRef.current);
+			timerRef.current = setTimeout(() => setCopied(false), 1500);
+			toast.success(`${label} copied`);
+		} catch (e) {
+			toast.error(errorMessage(e));
+		}
+	}
+
+	return { copied, copy };
+}


### PR DESCRIPTION
## Summary
- Add `PublicShareControls` next to the session title on `/s/{id}` — copy-link icon + dropdown for Markdown/JSON URLs, mirroring the owner-side share cluster minus the visibility toggle.
- Wrap title + meta in a `flex justify-between` row so the controls sit on the right edge without breaking the existing truncation of project paths.
- Add `apps/web/src/app/s/layout.tsx` solely to mount `<Toaster />`: root layout has none, dashboard's Toaster doesn't apply outside that group, so without this the new `toast.*()` calls would silently no-op.

## Test plan
- [ ] Open `/s/{id}` for a public session — verify Copy link button, dropdown with Markdown/JSON URL items.
- [ ] Click each item and confirm the toast fires and the correct URL lands on the clipboard.
- [ ] Verify `/s/{id}` (no auth), `/s/{id}` (signed in non-owner with grant), and `/s/{id}` (owner) all render the controls identically.
- [ ] Sign-in-required and 403 branches still short-circuit before the controls render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)