### PR TITLE
fix(web): make public share page mobile-friendly

### DIFF
--- a/apps/web/src/app/s/[id]/page.tsx
+++ b/apps/web/src/app/s/[id]/page.tsx
@@ -187,8 +187,21 @@ export default async function PublicSharePage({ params }: { params: Promise<Para
 	return (
 		<>
 			<ShareHeader />
-			<div className="mx-auto max-w-4xl space-y-5 px-4 py-6 lg:px-6">
-				<div className="flex items-start justify-between gap-3">
+			{/* `w-full` pins this div to the body's cross-axis width even
+			    though it's a flex item with `mx-auto`. Without it,
+			    `mx-auto` (= `margin-inline: auto`) absorbs the cross-axis
+			    free space and the item shrinks to fit its **content** —
+			    which lets a `<pre>` rendered by `<Markdown>` push the
+			    wrapper past the viewport and trigger page-level horizontal
+			    scroll on narrow screens. `w-full` (`width: 100%`) restores
+			    the "fill body, capped at max-w-4xl, then centered"
+			    behavior that the visual design already assumed. */}
+			<div className="mx-auto w-full max-w-4xl space-y-5 px-4 py-6 lg:px-6">
+				{/* Below `sm` (640px), controls drop under the title block —
+				    a long summary then claims the full row instead of fighting
+				    two icon buttons for ~80px on a 320px screen. Reverts to
+				    the original side-by-side at `sm:` and up. */}
+				<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
 					<div className="min-w-0 flex-1 space-y-2">
 						<DetailTitle>{summaryText}</DetailTitle>
 						<DetailMeta>
@@ -196,7 +209,18 @@ export default async function PublicSharePage({ params }: { params: Promise<Para
 							{share.project_path ? (
 								<>
 									<span>·</span>
-									<span className="truncate font-mono">{share.project_path}</span>
+									{/* `truncate` alone (= `white-space:nowrap`) lets the
+									    span grow to its content inside a `flex-wrap`
+									    parent — `max-w-full` caps it at the row's
+									    content box and `min-w-0` breaks the flex
+									    `min-width:auto` default so the ellipsis can
+									    actually engage. */}
+									<span
+										className="min-w-0 max-w-full truncate font-mono"
+										title={share.project_path}
+									>
+										{share.project_path}
+									</span>
 								</>
 							) : null}
 							<span>·</span>
@@ -216,7 +240,9 @@ export default async function PublicSharePage({ params }: { params: Promise<Para
 							) : null}
 						</DetailMeta>
 					</div>
-					<PublicShareControls sessionId={share.id} />
+					<div className="sm:shrink-0">
+						<PublicShareControls sessionId={share.id} />
+					</div>
 				</div>
 
 				<SessionSidebar relatedRefs={share.related_refs} />
@@ -245,7 +271,12 @@ export default async function PublicSharePage({ params }: { params: Promise<Para
 				)}
 
 				{truncated ? (
-					<p className="text-xs text-muted-foreground">
+					// `wrap-anywhere` breaks the long `/s/{uuid}.md|json` URLs at
+					// any character — without it browsers treat the URL as one
+					// atomic word and push the page wider than the viewport at
+					// the `sm` breakpoint (where the available width is still
+					// only ~640px). Same trick we use in `MessageBlock` bodies.
+					<p className="text-xs text-muted-foreground wrap-anywhere">
 						Showing first {messagesPage.items.length} of {messagesPage.total} messages. Fetch the
 						full conversation via{" "}
 						<Link href={mdUrl} className="underline">

--- a/apps/web/src/app/s/layout.tsx
+++ b/apps/web/src/app/s/layout.tsx
@@ -1,4 +1,17 @@
+import type { Viewport } from "next";
 import { Toaster } from "@/components/ui/sonner";
+
+/**
+ * Explicit viewport for the public share routes. Next.js 15 doesn't
+ * inject a viewport meta by default — without `initial-scale=1`, iOS
+ * Safari can apply its own zoom-fit heuristics, which throws off the
+ * Tailwind breakpoints we rely on for the mobile layout under `/s/*`
+ * (and the `[format]` export sub-route).
+ */
+export const viewport: Viewport = {
+	width: "device-width",
+	initialScale: 1,
+};
 
 /**
  * Share-route layout — exists solely to mount `<Toaster />`. The

--- a/apps/web/src/components/sessions/message-list.tsx
+++ b/apps/web/src/components/sessions/message-list.tsx
@@ -117,8 +117,12 @@ function MessageBlock({
 						<AgentIcon agent={agentType} size="lg" shape="circle" />
 					)
 				) : message.timestamp ? (
+					// Hover-reveal on pointer devices; always-on for touch
+					// (`hover: none`) — `group-hover` never fires from a tap,
+					// so without this fallback mobile users lose the
+					// timestamp entirely on grouped continuation rows.
 					<div
-						className="hidden h-5 w-8 items-center justify-end pr-1 text-[10px] tabular-nums text-muted-foreground/60 group-hover:flex"
+						className="hidden h-5 w-8 items-center justify-end pr-1 text-[10px] tabular-nums text-muted-foreground/60 group-hover:flex [@media(hover:none)]:flex"
 						title={formatAbsoluteTooltip(message.timestamp)}
 					>
 						{new Date(message.timestamp).toLocaleTimeString([], {
@@ -132,12 +136,18 @@ function MessageBlock({
 			{/* Content */}
 			<div className="min-w-0 flex-1">
 				{isGroupStart ? (
-					<div className="mb-1 flex items-center gap-2">
+					// `flex-wrap` is what keeps long header rows
+					// (`username · Opus 4.7 · 5/13/26, 15:30`) inside a
+					// narrow viewport. Without it, a 320px screen forces
+					// the whole page into horizontal scroll. The timestamp
+					// keeps `whitespace-nowrap` so it doesn't split
+					// mid-string when it wraps to its own line.
+					<div className="mb-1 flex flex-wrap items-center gap-x-2 gap-y-0.5">
 						<span className="text-sm font-medium">{isUser ? userName : agentName}</span>
 						{isUser ? null : <ModelBadge modelId={message.model} />}
 						{message.timestamp ? (
 							<span
-								className="text-xs text-muted-foreground"
+								className="whitespace-nowrap text-xs text-muted-foreground"
 								title={formatAbsoluteTooltip(message.timestamp)}
 							>
 								{formatGroupHeaderTime(message.timestamp)}

--- a/apps/web/src/components/share/public-share-controls.tsx
+++ b/apps/web/src/components/share/public-share-controls.tsx
@@ -41,7 +41,9 @@ function CopyLinkButton({ url }: { url: string }) {
 		<Button
 			variant="outline"
 			size="icon"
-			className={cn("size-8", copied && "text-emerald-600")}
+			// 36px on mobile (matches Button's default `size="icon"`), 32px
+			// at `sm:` and up — denser desktop cluster, thumb-safe phone.
+			className={cn("size-9 sm:size-8", copied && "text-emerald-600")}
 			onClick={copy}
 			aria-label="Copy share link"
 			title="Copy share link"
@@ -62,7 +64,7 @@ function ExportMenu({ url }: { url: string }) {
 				<Button
 					variant="outline"
 					size="icon"
-					className="size-8"
+					className="size-9 sm:size-8"
 					aria-label="More options"
 					title="More options"
 				>


### PR DESCRIPTION
## Summary

- Root-causes a long-standing page-level horizontal scroll on `/s/{id}` at narrow viewports: `mx-auto` on the wrapper (a flex item of `<body class="flex flex-col">`) absorbs cross-axis free space and defeats `align-items: stretch`, so the wrapper sized to its content's max-content — a single `<pre>` from `<Markdown>` was enough to push the page past the viewport. Adding `w-full` pins the wrapper to body width so `overflow-x: auto` on `<pre>` finally engages.
- Adds focused mobile adjustments verified at 320 / 375 / 640 / 1024 viewports: explicit `viewport` export, message-header `flex-wrap`, touch-fallback continuation timestamps, vertical title/controls stack below `sm:`, `project_path` truncation, `wrap-anywhere` on long share URLs, thumb-safe 36px tap targets.
- No JS-based mobile branching introduced; pure CSS / structural changes. `MessageList` is shared with the dashboard but the changes are inert on wide layouts (no regression).

## Test plan

- [x] Playwright at 320×568, 375×667, 640×900, 1024×768 — 30/30 assertions pass (no horizontal scroll, message header wraps, project_path truncates with `title` attr, controls 36px → 32px at `sm`, touch fallback shows continuation timestamps under `hasTouch: true`).
- [x] `bun run typecheck` + `bun run check` clean.
- [x] Visual diff at 1024px confirms no desktop regression.
- [ ] Manual smoke on a real phone (iOS Safari + Android Chrome) on a long-conversation share link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)