### PR TITLE
fix(sessions): prevent lone-surrogate 500 in batch upsert

### DIFF
--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -5,6 +5,18 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field, StringConstraints, field_validator
 
+# Lone UTF-16 surrogates (U+D800..U+DFFF) are valid Python `str`
+# but cannot be encoded as UTF-8, so asyncpg rejects the bound
+# parameter and 500s the whole batch. The CLI used to truncate
+# `summary` with JS `.slice` (UTF-16 code units), which split an
+# emoji's surrogate pair and left a lone high surrogate at the
+# cut. The CLI now truncates by codepoint, but a stuck daemon
+# retried the bad payload ~34k times in prod before we shipped
+# the fix — strip on ingest so one bad record can't take the
+# batch down again.
+_LONE_SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
+
+
 # local_session_id flows straight into a file-store key
 # (`sessions/{user_id}/{local_session_id}.json`). Restrict to a safe charset
 # so a malicious client can't smuggle `/` or `..` and escape their own tenant
@@ -57,6 +69,13 @@ class SessionCreate(BaseModel):
     # Optional so old clients that don't compute hashes still get inserted;
     # legacy rows with NULL hash are always treated as "needs content".
     content_hash: str | None = None
+
+    @field_validator("summary", mode="after")
+    @classmethod
+    def _strip_summary_surrogates(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        return _LONE_SURROGATE_RE.sub("", v)
 
     @field_validator("started_at", "ended_at", "last_activity_at", mode="after")
     @classmethod

--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { basename, join } from "node:path";
+import { safeTruncate } from "../lib/sanitize";
 import { extractTarGz } from "../lib/tar";
 import type {
 	AgentAdapter,
@@ -208,11 +209,11 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 				if (role === "user" && !firstUserMessage) {
 					const c = msg?.content;
 					if (typeof c === "string") {
-						firstUserMessage = c.slice(0, 200);
+						firstUserMessage = safeTruncate(c, 200);
 					} else if (Array.isArray(c)) {
 						const textBlock = c.find((b) => b.type === "text" && b.text);
 						if (textBlock?.text) {
-							firstUserMessage = textBlock.text.slice(0, 200);
+							firstUserMessage = safeTruncate(textBlock.text, 200);
 						}
 					}
 				}

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -1,5 +1,6 @@
 import { type Dirent, existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { safeTruncate } from "../lib/sanitize";
 import { extractTarGz } from "../lib/tar";
 import type {
 	AgentAdapter,
@@ -211,7 +212,7 @@ export class CodexAdapter implements AgentAdapter {
 			const firstRealUser = messages.find(
 				(m) => m.role === "user" && !m.content.startsWith("<environment_context>"),
 			);
-			const summary = firstRealUser?.content.slice(0, 200) ?? null;
+			const summary = firstRealUser ? safeTruncate(firstRealUser.content, 200) : null;
 
 			sessions.push({
 				localSessionId: sessionId,

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { join, relative } from "node:path";
+import { safeTruncate } from "../lib/sanitize";
 import { extractTarGz } from "../lib/tar";
 import type {
 	AgentAdapter,
@@ -158,7 +159,7 @@ export class HermesAdapter implements AgentAdapter {
 				let summary = row.title;
 				if (!summary || summary === "New Chat" || summary.startsWith("New Chat #")) {
 					const firstUser = messages.find((m) => m.role === "user");
-					summary = firstUser?.content.slice(0, 200) ?? null;
+					summary = firstUser ? safeTruncate(firstUser.content, 200) : null;
 				}
 
 				if (messages.length === 0) continue;

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { isAbsolute, join } from "node:path";
+import { safeTruncate } from "../lib/sanitize";
 import { extractTarGz } from "../lib/tar";
 import type {
 	AgentAdapter,
@@ -268,12 +269,12 @@ export class OpenClawAdapter implements AgentAdapter {
 
 				const durationSeconds = Math.floor((endedAt.getTime() - startedAt.getTime()) / 1000);
 
+				const firstUserContent = messages.find((m) => m.role === "user")?.content;
 				const summary =
 					entry.displayName ??
 					entry.subject ??
 					entry.label ??
-					messages.find((m) => m.role === "user")?.content.slice(0, 200) ??
-					null;
+					(firstUserContent === undefined ? null : safeTruncate(firstUserContent, 200));
 
 				sessions.push({
 					localSessionId: sessionId,

--- a/packages/cli/src/lib/sanitize.ts
+++ b/packages/cli/src/lib/sanitize.ts
@@ -48,6 +48,21 @@ export function sanitizeMetadata(str: string): string {
 }
 
 /**
+ * Truncate `str` to at most `n` Unicode codepoints.
+ *
+ * `String#slice` operates on UTF-16 code units and can cut between the
+ * halves of an emoji's surrogate pair, leaving a lone surrogate that
+ * isn't valid UTF-8 — PostgreSQL/asyncpg then rejects the row. Spreading
+ * via `[...str]` iterates by codepoint so the cut always lands on a
+ * valid boundary.
+ */
+export function safeTruncate(str: string, n: number): string {
+	const codepoints = [...str];
+	if (codepoints.length <= n) return str;
+	return codepoints.slice(0, n).join("");
+}
+
+/**
  * Sanitize a subpath to prevent path traversal.
  * Throws if any segment is literally "..".
  */


### PR DESCRIPTION
## Summary

`POST /api/sessions/batch` was returning 500 for affected users — prod logs show **34,947 errors / 83,523 stack traces from a single stuck session**, all with the same root cause:

```
asyncpg.exceptions.DataError: invalid input for query argument $16:
'... 客户 \ud83d' ('utf-8' codec can't encode character '\ud83d' ...
surrogates not allowed)
```

CLI adapters truncated `summary` with `String#slice(0, 200)`, which operates on UTF-16 code units and can split an emoji's surrogate pair. The leftover lone high surrogate isn't valid UTF-8, asyncpg rejects the bound parameter, and the daemon retries the bad payload forever.

## Changes

- **`packages/cli/src/lib/sanitize.ts`**: add `safeTruncate(str, n)` — uses `[...str]` codepoint iteration so the cut never lands inside a surrogate pair.
- **CLI adapters** (`claude-code.ts`, `codex.ts`, `hermes.ts`, `openclaw.ts`): replace `.slice(0, 200)` on summary derivation. Behavior preserved (e.g. openclaw still falls back to `null` when no user message exists, returns `""` for empty content).
- **`backend/app/schemas/session.py`**: strip lone surrogates from `summary` in the `SessionCreate` validator as a boundary defense — same convention as the file's existing `_coerce_to_utc`, `ge=0`, and `local_session_id` regex.

Scoped tightly: backend strips only `summary` (the proven failure path), not every text field — `project_path`, `model`, `tags` etc. are never truncated by CLI, so defending them would be over-engineering.

## Test plan

- [ ] `bun run typecheck` (CLI) passes
- [ ] `bun run check` (Biome) passes
- [ ] Verified regex `[\ud800-\udfff]` empirically: strips lone surrogates (high + low), leaves valid emoji untouched (paired surrogates already merged by JSON decoder before validator runs), does not match boundary chars U+D7FF / U+E000
- [ ] After deploy, check prod log for `POST /api/sessions/batch` 500 rate dropping to ~0
- [ ] Re-push a known-bad session from the affected user — should now upsert successfully with `summary` ending mid-text (no `\ud83d`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)