### PR TITLE
feat(cli): make push/pull agent-friendly with a unified scan flow

### DIFF
--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -70,7 +70,7 @@ clawdi session list --all-agents --all --limit 10000 --json
 
 `--limit 10000` is important — the default is 100, which would silently truncate any user with more sessions and you'd aggregate from a partial set.
 
-If this fails (network error, no agents registered, etc.), tell the user *"I couldn't list your local sessions — going ahead with the default upload, let me know if you want to stop."* and skip to running `clawdi push --modules sessions --all-agents --all --yes`. Don't halt onboarding for this.
+If this fails (network error, no agents registered, etc.), tell the user *"I couldn't list your local sessions — going ahead with the default upload, let me know if you want to stop."* and skip to running `clawdi push --modules sessions --all-agents --all`. Don't halt onboarding for this.
 
 If the JSON is empty (`[]`), tell the user *"No sessions found on this machine — nothing to sync. Run `clawdi push` later if you start using one of the supported agents."* and continue to the next step. Skip the upload entirely.
 
@@ -112,11 +112,11 @@ The user references real project names from the summary you just showed them. Ma
 
 | User says | Command |
 | --- | --- |
-| "y" / "yes" / "ok" / "all" | `clawdi push --modules sessions --all-agents --all --yes` |
-| "skip client-acme" | `clawdi push --modules sessions --all-agents --all --exclude-project ~/work/client-acme --yes` |
-| "skip client-acme and scratch" | `clawdi push --modules sessions --all-agents --all --exclude-project ~/work/client-acme --exclude-project ~/scratch --yes` |
-| "only Claude Code" | `clawdi push --modules sessions --agent claude_code --all --yes` |
-| "only ~/work/clawdi-cloud" | `clawdi push --modules sessions --all-agents --project ~/work/clawdi-cloud --yes` |
+| "y" / "yes" / "ok" / "all" | `clawdi push --modules sessions --all-agents --all` |
+| "skip client-acme" | `clawdi push --modules sessions --all-agents --all --exclude-project ~/work/client-acme` |
+| "skip client-acme and scratch" | `clawdi push --modules sessions --all-agents --all --exclude-project ~/work/client-acme --exclude-project ~/scratch` |
+| "only Claude Code" | `clawdi push --modules sessions --agent claude_code --all` |
+| "only ~/work/clawdi-cloud" | `clawdi push --modules sessions --all-agents --project ~/work/clawdi-cloud` |
 | "n" / "no" / "skip" / "not now" | (skip — tell them *"Run `clawdi push --modules sessions --all-agents --all` whenever you want to sync."* and continue) |
 
 Resolve `~` to an absolute path before passing to the CLI.
@@ -158,7 +158,7 @@ clawdi serve --agent claude_code
 If the user has authored custom skills under `~/.claude/skills/`, `~/.codex/skills/`, etc., back them up to the cloud:
 
 ```bash
-clawdi push --modules skills --all-agents --yes
+clawdi push --modules skills --all-agents
 ```
 
 Most users have zero or a handful of authored skills — no preview needed (unlike sessions, skills are deliberately created and don't have privacy concerns). The bundled `clawdi` skill that `clawdi setup` installs is automatically excluded. Re-running this is a no-op for unchanged skills.
@@ -166,7 +166,7 @@ Most users have zero or a handful of authored skills — no preview needed (unli
 If the user is on a new machine and already has skills in their Clawdi Cloud account, pull them down:
 
 ```bash
-clawdi pull --modules skills --all-agents --yes
+clawdi pull --modules skills --all-agents
 ```
 
 This installs cloud skills into every registered agent's home directory. Like push, it's idempotent — running again is a no-op when nothing's new.
@@ -241,12 +241,12 @@ After this their account has:
 
 ```bash
 rm -f ~/.clawdi/sessions-lock.json
-clawdi push --modules sessions --all-agents --all --yes
+clawdi push --modules sessions --all-agents --all
 ```
 
 **`clawdi auth complete` keeps saying "Still waiting for approval".** The user hasn't clicked approve yet. Re-running is safe within the 10-minute window. If it expired, restart from `clawdi auth login`.
 
-**Older CLI doesn't recognize `--all-agents`.** Loop manually over the agents that registered in setup: `clawdi push --modules sessions --agent claude_code --all --yes`, then `--agent codex`, and so on.
+**Older CLI doesn't recognize `--all-agents`.** Loop manually over the agents that registered in setup: `clawdi push --modules sessions --agent claude_code --all`, then `--agent codex`, and so on.
 
 **Older CLI doesn't recognize `--exclude-project`.** Tell the user to upgrade (`bun add -g clawdi` again) or accept the limitation — without it, only positive selection (`--project`) works.
 

--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/using-clawdi-with-claude-code.md
+++ b/docs/using-clawdi-with-claude-code.md
@@ -224,18 +224,18 @@ Proceed with upload? [Y/n] y
 ✓ Sync complete
 ```
 
-Only sessions from the current project are pushed by default (uses `cwd` at invocation time). To sync everything:
+Only sessions from the current project are pushed by default (uses `cwd` at invocation time). To sync everything — every module, every registered agent, every project — pass `--all` (and `--yes` if you don't want the confirmation prompt):
 
 ```bash
-$ clawdi push --all
+$ clawdi push --all --yes
 ```
 
-Other useful flags:
+Each axis can still be narrowed back down with the corresponding flag:
 
 ```bash
 $ clawdi push --modules sessions      # only sessions, skip skills
-$ clawdi push --since 2026-04-01      # manual cursor
-$ clawdi push --agent claude_code     # skip the agent picker on multi-agent machines
+$ clawdi push --agent claude_code     # only this agent (multi-agent machines)
+$ clawdi push --all --project ~/foo   # every module / every agent, but only this project
 $ clawdi push --dry-run               # preview, no uploads
 ```
 
@@ -293,17 +293,13 @@ If you also have Codex / Hermes / OpenClaw installed on this machine:
 $ clawdi setup                   # auto-detects and asks to register each one
 ```
 
-Any memory you add from Claude Code is visible from every other agent you've registered, and vice-versa. `clawdi push` then prompts you to pick which agent's sessions/skills to push:
+Any memory you add from Claude Code is visible from every other agent you've registered, and vice-versa. `clawdi push` on a multi-agent machine targets every registered agent by default and prints a one-line notice so you know:
 
 ```
-Multiple agents registered. Select one:
-  [1] Claude Code
-  [2] Codex
-  [3] Hermes
-Choice: 1
+Targets: claude_code, codex, hermes (use --agent to narrow)
 ```
 
-Or skip the prompt with `--agent`:
+Narrow to one agent with `--agent`:
 
 ```bash
 $ clawdi push --agent codex

--- a/docs/using-clawdi-with-claude-code.md
+++ b/docs/using-clawdi-with-claude-code.md
@@ -224,10 +224,10 @@ Proceed with upload? [Y/n] y
 ✓ Sync complete
 ```
 
-Only sessions from the current project are pushed by default (uses `cwd` at invocation time). To sync everything — every module, every registered agent, every project — pass `--all` (and `--yes` if you don't want the confirmation prompt):
+Only sessions from the current project are pushed by default (uses `cwd` at invocation time). To sync everything — every module, every registered agent, every project — pass `--all`:
 
 ```bash
-$ clawdi push --all --yes
+$ clawdi push --all
 ```
 
 Each axis can still be narrowed back down with the corresponding flag:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.5.8",
+	"version": "0.5.9",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/adapters/base.ts
+++ b/packages/cli/src/adapters/base.ts
@@ -64,6 +64,9 @@ export interface RawSkill {
 	filePath: string;
 	directoryPath: string;
 	isDirectory: boolean;
+	// Set by `push` during the scan phase — the skill folder hash used to
+	// diff against the skills-lock. Adapters do not populate this.
+	contentHash?: string;
 }
 
 export interface AgentAdapter {

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -7,7 +7,7 @@ import { ApiClient, unwrap } from "../lib/api-client";
 import type { SessionListItem, SkillSummary } from "../lib/api-schemas";
 import { getClawdiDir, isLoggedIn } from "../lib/config";
 import { errMessage } from "../lib/errors";
-import { askYesNo, parseModules } from "../lib/prompts";
+import { parseModules } from "../lib/prompts";
 import { sanitizeMetadata } from "../lib/sanitize";
 import {
 	adapterForType,
@@ -30,7 +30,6 @@ interface PullOpts {
 	agent?: string;
 	allAgents?: boolean;
 	all?: boolean;
-	yes?: boolean;
 }
 
 /**
@@ -145,15 +144,6 @@ export async function pull(opts: PullOpts) {
 			),
 		);
 		return;
-	}
-
-	// One confirmation covering every agent, after the full summary.
-	if (toDownload.length > 0 && !opts.yes) {
-		const ok = await askYesNo("Proceed with download?");
-		if (!ok) {
-			p.outro(chalk.gray("Cancelled."));
-			return;
-		}
 	}
 
 	const totals = {

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -7,7 +7,7 @@ import { ApiClient, unwrap } from "../lib/api-client";
 import type { SessionListItem, SkillSummary } from "../lib/api-schemas";
 import { getClawdiDir, isLoggedIn } from "../lib/config";
 import { errMessage } from "../lib/errors";
-import { askMulti, askYesNo, parseModules } from "../lib/prompts";
+import { askYesNo, parseModules } from "../lib/prompts";
 import { sanitizeMetadata } from "../lib/sanitize";
 import {
 	adapterForType,
@@ -22,17 +22,46 @@ import {
 	writeSkillsLock,
 } from "../lib/skills-lock";
 
-const DOWN_MODULES = [
-	{ value: "skills", label: "Skills", hint: "pull skill archives to agent directories" },
-	{ value: "sessions", label: "Sessions", hint: "mirror cloud sessions to ~/.clawdi/sessions/" },
-];
+const DOWN_MODULES = ["skills", "sessions"] as const;
 
 interface PullOpts {
 	modules?: string;
 	dryRun?: boolean;
 	agent?: string;
 	allAgents?: boolean;
+	all?: boolean;
 	yes?: boolean;
+}
+
+/**
+ * What `scanOneAgent` found for a single agent: the skills and sessions
+ * staged for download. Splitting scan from download lets `pull` show a
+ * combined, per-agent summary across every target agent and ask for ONE
+ * confirmation — the same shape as `clawdi push`.
+ */
+interface AgentPullScan {
+	agentType: AgentType;
+	/** Scope to download skills from; null when skills aren't being
+	 * pulled or the agent has no registered environment. */
+	skillScopeId: string | null;
+	skills: SkillSummary[];
+	skillsInSync: number;
+	sessions: { remote: SessionListItem; reason: "new" | "updated" }[];
+	sessionsUnchanged: number;
+	/** Per-agent advisories rendered under the agent in the summary. */
+	notes: string[];
+}
+
+/** What `downloadOneAgent` actually pulled for a single agent. */
+interface AgentPullResult {
+	skillsPulled: number;
+	sessionsNew: number;
+	sessionsUpdated: number;
+}
+
+/** Whether a scan turned up anything to actually download. */
+function scanHasWork(scan: AgentPullScan): boolean {
+	return scan.skills.length > 0 || scan.sessions.length > 0;
 }
 
 export async function pull(opts: PullOpts) {
@@ -45,6 +74,13 @@ export async function pull(opts: PullOpts) {
 		return;
 	}
 
+	// `--all` widens every axis it can. Pull only has modules + agents
+	// (no project axis); explicit narrowing via --agent or --modules
+	// still wins.
+	if (opts.all && !opts.agent && !opts.allAgents) {
+		opts.allAgents = true;
+	}
+
 	const targetTypes = await resolveTargetAgentTypes(opts.agent, !!opts.allAgents);
 	if (targetTypes.length === 0) {
 		p.outro(chalk.red("Aborted."));
@@ -52,74 +88,106 @@ export async function pull(opts: PullOpts) {
 		return;
 	}
 
-	let modules: string[];
-	if (opts.modules) {
-		const parsed = parseModules(opts.modules, DOWN_MODULES);
-		if (!parsed) return;
-		modules = parsed;
-	} else {
-		const picked = await askMulti("Modules to download:", DOWN_MODULES);
-		if (!picked) {
-			p.outro(chalk.gray("Cancelled."));
-			return;
+	// Module default: when --modules is omitted, take every module —
+	// no multi-select prompt to block an agent harness on.
+	const modules = parseModules(opts.modules, DOWN_MODULES);
+	if (!modules) return;
+
+	const api = new ApiClient();
+	// Read once before the loop, mutate as downloads land, persist once at
+	// the end. Lost work on partial failure is safe — re-running a pull is
+	// idempotent (the cloud diff just kicks in again).
+	const skillsLock = modules.includes("skills") ? readSkillsLock() : null;
+
+	// Scan every agent first — one spinner, one combined summary — so a
+	// multi-agent pull reads as a single scan, matching `clawdi push`.
+	const scanSpinner = p.spinner();
+	scanSpinner.start(
+		`Scanning ${targetTypes.length} agent${targetTypes.length === 1 ? "" : "s"}...`,
+	);
+	const scans: AgentPullScan[] = [];
+	try {
+		for (const agentType of targetTypes) {
+			scans.push(await scanOneAgent(api, agentType, modules, skillsLock));
 		}
-		modules = picked;
+	} catch (e) {
+		scanSpinner.stop("Scan failed.");
+		throw e;
 	}
-	if (modules.length === 0) {
-		p.outro(chalk.gray("Nothing to download."));
+	scanSpinner.stop("Scan complete.");
+
+	// Combined per-agent summary, visible in full before the confirmation.
+	for (const scan of scans) {
+		const name = adapterRegistry[scan.agentType].displayName;
+		const bits: string[] = [];
+		if (modules.includes("skills")) {
+			const sync = scan.skillsInSync > 0 ? ` (${scan.skillsInSync} in sync)` : "";
+			bits.push(`${scan.skills.length} skill${scan.skills.length === 1 ? "" : "s"}${sync}`);
+		}
+		if (modules.includes("sessions")) {
+			const sync = scan.sessionsUnchanged > 0 ? ` (${scan.sessionsUnchanged} unchanged)` : "";
+			bits.push(`${scan.sessions.length} session${scan.sessions.length === 1 ? "" : "s"}${sync}`);
+		}
+		p.log.message(`${chalk.bold(name)} — ${bits.join(", ")} to download`);
+		for (const note of scan.notes) {
+			p.log.message(chalk.gray(`  ${note}`));
+		}
+	}
+
+	const toDownload = scans.filter(scanHasWork);
+
+	if (opts.dryRun) {
+		p.outro(
+			chalk.gray(
+				toDownload.length > 0
+					? "Dry run complete."
+					: "Dry run — nothing to pull, everything already in sync.",
+			),
+		);
 		return;
 	}
 
-	if (targetTypes.length > 1) {
-		p.log.info(`Targets: ${targetTypes.map((t) => adapterRegistry[t].displayName).join(", ")}`);
+	// One confirmation covering every agent, after the full summary.
+	if (toDownload.length > 0 && !opts.yes) {
+		const ok = await askYesNo("Proceed with download?");
+		if (!ok) {
+			p.outro(chalk.gray("Cancelled."));
+			return;
+		}
 	}
 
 	const totals = {
 		skills: 0,
-		skillsAlreadyInSync: 0,
+		skillsInSync: 0,
 		sessionsNew: 0,
 		sessionsUpdated: 0,
 		sessionsUnchanged: 0,
 	};
-	const api = new ApiClient();
-	// Read once before the loop, mutate as we go, persist once at the end —
-	// matches the push-side pattern. Lost work on partial failure is safe
-	// (re-running a pull is idempotent: cloud diff just kicks in again).
-	const skillsLock = modules.includes("skills") ? readSkillsLock() : null;
-
-	for (const agentType of targetTypes) {
-		if (targetTypes.length > 1) {
-			p.log.step(chalk.bold(`▶ ${adapterRegistry[agentType].displayName}`));
+	for (const scan of scans) {
+		// "In sync" / "unchanged" are scan facts — fold them in regardless
+		// of whether this agent goes on to download anything.
+		totals.skillsInSync += scan.skillsInSync;
+		totals.sessionsUnchanged += scan.sessionsUnchanged;
+		if (!scanHasWork(scan)) continue;
+		// Header only when more than one agent actually downloads.
+		if (toDownload.length > 1) {
+			p.log.step(chalk.bold(`▶ ${adapterRegistry[scan.agentType].displayName}`));
 		}
-
-		if (modules.includes("skills") && skillsLock) {
-			const counts = await pullSkills(api, agentType, opts, skillsLock);
-			totals.skills += counts.pulled;
-			totals.skillsAlreadyInSync += counts.alreadyInSync;
-		}
-
-		if (modules.includes("sessions")) {
-			const counts = await pullSessions(api, agentType, opts);
-			totals.sessionsNew += counts.fresh;
-			totals.sessionsUpdated += counts.updated;
-			totals.sessionsUnchanged += counts.unchanged;
-		}
+		const result = await downloadOneAgent(api, scan, skillsLock);
+		totals.skills += result.skillsPulled;
+		totals.sessionsNew += result.sessionsNew;
+		totals.sessionsUpdated += result.sessionsUpdated;
 	}
 
-	if (!opts.dryRun && skillsLock) writeSkillsLock(skillsLock);
-
-	if (opts.dryRun) {
-		p.outro(chalk.gray("Dry run complete."));
-		return;
-	}
+	if (skillsLock) writeSkillsLock(skillsLock);
 
 	const parts: string[] = [];
 	if (modules.includes("skills")) {
-		const skillsLabel =
-			totals.skillsAlreadyInSync > 0
-				? `${totals.skills} skill${totals.skills === 1 ? "" : "s"} downloaded, ${totals.skillsAlreadyInSync} already in sync`
-				: `${totals.skills} skill${totals.skills === 1 ? "" : "s"}`;
-		parts.push(skillsLabel);
+		parts.push(
+			totals.skillsInSync > 0
+				? `${totals.skills} skill${totals.skills === 1 ? "" : "s"} downloaded, ${totals.skillsInSync} already in sync`
+				: `${totals.skills} skill${totals.skills === 1 ? "" : "s"}`,
+		);
 	}
 	if (modules.includes("sessions")) {
 		parts.push(
@@ -129,114 +197,153 @@ export async function pull(opts: PullOpts) {
 	p.outro(chalk.green(`✓ Pull complete — ${parts.join(", ")}`));
 }
 
-interface SkillPullCounts {
-	pulled: number;
-	alreadyInSync: number;
-}
-
-async function pullSkills(
+/**
+ * Scan one agent against the cloud and stage what would be downloaded.
+ * Prints nothing — advisories go into `notes` for the combined summary.
+ * Does network reads (skill listing, session paging) but writes nothing.
+ */
+async function scanOneAgent(
 	api: ApiClient,
 	agentType: AgentType,
-	opts: PullOpts,
-	skillsLock: SkillsLock,
-): Promise<SkillPullCounts> {
-	const adapter = adapterForType(agentType);
-	if (!adapter) return { pulled: 0, alreadyInSync: 0 };
+	modules: string[],
+	skillsLock: SkillsLock | null,
+): Promise<AgentPullScan> {
+	const notes: string[] = [];
+	let skillScopeId: string | null = null;
+	const skills: SkillSummary[] = [];
+	let skillsInSync = 0;
 
-	// Resolve the target agent's scope upfront. Without this, the
-	// listing below returns every scope's skills and the loop
-	// installs sibling-agent skills into this adapter's directory
-	// — `pull --all-agents` on a multi-agent unbound key would
-	// duplicate every codex skill into claude_code's home and
-	// vice versa. The download URL ALSO needs the scope_id so
-	// duplicate-key skills resolve to the right bytes.
-	const envId = getEnvIdByAgent(agentType);
-	if (!envId) {
-		p.log.warn(
-			`No environment registered for ${adapterRegistry[agentType].displayName}; skip. Run \`clawdi setup\` first.`,
-		);
-		return { pulled: 0, alreadyInSync: 0 };
-	}
-	const scopeId = await fetchScopeIdForEnv(api, envId);
-
-	const fetchSpinner = p.spinner();
-	fetchSpinner.start("Fetching skills...");
-	const page = unwrap(
-		await api.GET("/api/skills", {
-			params: { query: { page_size: 200, scope_id: scopeId } },
-		}),
-	);
-	const cloudSkills: SkillSummary[] = page.items;
-	fetchSpinner.stop(
-		`Found ${cloudSkills.length} skill${cloudSkills.length === 1 ? "" : "s"} in cloud`,
-	);
-
-	if (cloudSkills.length === 0) return { pulled: 0, alreadyInSync: 0 };
-
-	// Diff: a skill is "in sync" iff its cloud `content_hash` matches our
-	// cached hash AND we have a local file for it. The local-file check
-	// catches the case where the user wiped `~/.claude/skills/` but kept
-	// the lock file — we'd otherwise silently skip and never restore.
-	const toDownload: SkillSummary[] = [];
-	let alreadyInSync = 0;
-	for (const skill of cloudSkills) {
-		// Cache key partitioned by `(agentType, skill_key)` so a multi-
-		// agent pull doesn't share state across agents — each agent's
-		// scope is independent.
-		const cached = skillsLock.skills[skillCacheKey(agentType, skill.skill_key)]?.hash;
-		const localExists = existsSync(adapter.getSkillPath(skill.skill_key));
-		if (cached && cached === skill.content_hash && localExists) {
-			alreadyInSync++;
-			continue;
-		}
-		toDownload.push(skill);
-	}
-
-	const newCount = toDownload.filter((s) => !existsSync(adapter.getSkillPath(s.skill_key))).length;
-	const updatedCount = toDownload.length - newCount;
-	p.log.message(
-		chalk.gray(`${newCount} new, ${updatedCount} updated, ${alreadyInSync} already in sync`),
-	);
-
-	if (opts.dryRun || toDownload.length === 0) return { pulled: 0, alreadyInSync };
-
-	if (!opts.yes) {
-		const ok = await askYesNo("Proceed with skill download?");
-		if (!ok) return { pulled: 0, alreadyInSync };
-	}
-
-	let pulled = 0;
-	for (const skill of toDownload) {
-		const safeKey = sanitizeMetadata(skill.skill_key);
-		const dest = adapter.getSkillPath(skill.skill_key);
-		if (existsSync(dest) && !opts.yes) {
-			const overwrite = await askYesNo(`${safeKey} already exists. Overwrite?`, false);
-			if (!overwrite) {
-				p.log.info(`${safeKey} skipped`);
-				continue;
+	if (modules.includes("skills") && skillsLock) {
+		const adapter = adapterForType(agentType);
+		const envId = getEnvIdByAgent(agentType);
+		if (adapter && !envId) {
+			// Sessions still pull fine (they query by agent type), but
+			// skills need the env's scope — skip them with a notice.
+			notes.push("No environment registered — skipping skills. Run `clawdi setup`.");
+		} else if (adapter && envId) {
+			// Resolve THIS agent's scope so a multi-agent account doesn't
+			// install sibling-agent skills into this adapter's directory.
+			skillScopeId = await fetchScopeIdForEnv(api, envId);
+			const page = unwrap(
+				await api.GET("/api/skills", {
+					params: { query: { page_size: 200, scope_id: skillScopeId } },
+				}),
+			);
+			for (const skill of page.items) {
+				// A skill is "in sync" iff its cloud content_hash matches
+				// our cached hash AND a local file exists — the local
+				// check restores skills the user wiped but kept the lock.
+				const cached = skillsLock.skills[skillCacheKey(agentType, skill.skill_key)]?.hash;
+				const localExists = existsSync(adapter.getSkillPath(skill.skill_key));
+				if (cached && cached === skill.content_hash && localExists) skillsInSync++;
+				else skills.push(skill);
 			}
 		}
+	}
 
-		try {
-			// Scope-explicit download so a multi-agent account where
-			// the same skill_key exists in two scopes resolves to the
-			// right bytes for THIS agent, not whichever was most-
-			// recently-updated across visible scopes.
-			const tarBytes = await api.getBytes(
-				`/api/scopes/${encodeURIComponent(scopeId)}/skills/${encodeURIComponent(skill.skill_key)}/download`,
-			);
-			await adapter.writeSkillArchive(skill.skill_key, tarBytes);
-			skillsLock.skills[skillCacheKey(agentType, skill.skill_key)] = {
-				hash: skill.content_hash,
-			};
-			const skillDir = dirname(adapter.getSkillPath(skill.skill_key));
-			p.log.success(`${safeKey} → ${skillDir}/ (${tarBytes.length} bytes)`);
-			pulled++;
-		} catch (e) {
-			p.log.warn(`${safeKey} failed: ${errMessage(e)}`);
+	const sessions: { remote: SessionListItem; reason: "new" | "updated" }[] = [];
+	let sessionsUnchanged = 0;
+	if (modules.includes("sessions")) {
+		const mirrorDir = sessionMirrorDir(agentType);
+		for (const remote of await fetchCloudSessions(api, agentType)) {
+			const sidecar = readSidecar(mirrorDir, remote.local_session_id);
+			if (!sidecar) {
+				sessions.push({ remote, reason: "new" });
+			} else if (!remote.content_hash || sidecar.content_hash !== remote.content_hash) {
+				// Null/missing remote hash → must download (legacy rows
+				// pre-dating the column have nothing to compare).
+				sessions.push({ remote, reason: "updated" });
+			} else {
+				sessionsUnchanged++;
+			}
 		}
 	}
-	return { pulled, alreadyInSync };
+
+	return { agentType, skillScopeId, skills, skillsInSync, sessions, sessionsUnchanged, notes };
+}
+
+/** Download one agent's scanned skills + sessions. Mutates `skillsLock`. */
+async function downloadOneAgent(
+	api: ApiClient,
+	scan: AgentPullScan,
+	skillsLock: SkillsLock | null,
+): Promise<AgentPullResult> {
+	let skillsPulled = 0;
+	if (scan.skills.length > 0 && scan.skillScopeId && skillsLock) {
+		const adapter = adapterForType(scan.agentType);
+		if (adapter) {
+			for (const skill of scan.skills) {
+				const safeKey = sanitizeMetadata(skill.skill_key);
+				try {
+					// Scope-explicit download so a duplicate skill_key across
+					// two scopes resolves to the right bytes for THIS agent.
+					const tarBytes = await api.getBytes(
+						`/api/scopes/${encodeURIComponent(scan.skillScopeId)}/skills/${encodeURIComponent(skill.skill_key)}/download`,
+					);
+					await adapter.writeSkillArchive(skill.skill_key, tarBytes);
+					skillsLock.skills[skillCacheKey(scan.agentType, skill.skill_key)] = {
+						hash: skill.content_hash,
+					};
+					const skillDir = dirname(adapter.getSkillPath(skill.skill_key));
+					p.log.success(`${safeKey} → ${skillDir}/ (${tarBytes.length} bytes)`);
+					skillsPulled++;
+				} catch (e) {
+					p.log.warn(`${safeKey} failed: ${errMessage(e)}`);
+				}
+			}
+		}
+	}
+
+	let sessionsNew = 0;
+	let sessionsUpdated = 0;
+	if (scan.sessions.length > 0) {
+		const mirrorDir = sessionMirrorDir(scan.agentType);
+		mkdirSync(mirrorDir, { recursive: true });
+		const dlSpinner = p.spinner();
+		dlSpinner.start(`Downloading content (0/${scan.sessions.length})...`);
+		let failed = 0;
+		for (const { remote, reason } of scan.sessions) {
+			try {
+				const body = await api.getSessionContent(remote.id);
+				writeMirrorAtomic(mirrorDir, remote, body);
+				if (reason === "new") sessionsNew++;
+				else sessionsUpdated++;
+				dlSpinner.message(
+					`Downloading content (${sessionsNew + sessionsUpdated}/${scan.sessions.length})...`,
+				);
+			} catch (e) {
+				failed++;
+				p.log.warn(`${remote.local_session_id} failed: ${errMessage(e)}`);
+			}
+		}
+		const done = sessionsNew + sessionsUpdated;
+		dlSpinner.stop(
+			failed > 0
+				? `Downloaded ${done}, ${failed} failed`
+				: `Downloaded ${done} session${done === 1 ? "" : "s"}`,
+		);
+	}
+
+	return { skillsPulled, sessionsNew, sessionsUpdated };
+}
+
+/** Page through every cloud session for one agent. */
+async function fetchCloudSessions(
+	api: ApiClient,
+	agentType: AgentType,
+): Promise<SessionListItem[]> {
+	const all: SessionListItem[] = [];
+	const pageSize = 200;
+	for (let page = 1; ; page++) {
+		const result = unwrap(
+			await api.GET("/api/sessions", {
+				params: { query: { agent: agentType, page, page_size: pageSize } },
+			}),
+		);
+		all.push(...result.items);
+		if (result.items.length < pageSize) break;
+	}
+	return all;
 }
 
 interface SessionMirrorMeta {
@@ -251,105 +358,6 @@ interface SessionMirrorMeta {
 	model: string | null;
 	summary: string | null;
 	content_hash: string | null;
-}
-
-interface SessionPullCounts {
-	fresh: number;
-	updated: number;
-	unchanged: number;
-}
-
-async function pullSessions(
-	api: ApiClient,
-	agentType: AgentType,
-	opts: PullOpts,
-): Promise<SessionPullCounts> {
-	// Page through every session for this agent. Server side already sorts
-	// by started_at desc; order doesn't matter for our diff anyway.
-	const cloudSessions: SessionListItem[] = [];
-	const fetchSpinner = p.spinner();
-	fetchSpinner.start(`Fetching ${adapterRegistry[agentType].displayName} sessions...`);
-	let page = 1;
-	const pageSize = 200;
-	for (;;) {
-		const result = unwrap(
-			await api.GET("/api/sessions", {
-				params: { query: { agent: agentType, page, page_size: pageSize } },
-			}),
-		);
-		cloudSessions.push(...result.items);
-		if (result.items.length < pageSize) break;
-		page++;
-	}
-	fetchSpinner.stop(
-		`Found ${cloudSessions.length} session${cloudSessions.length === 1 ? "" : "s"} in cloud`,
-	);
-
-	const mirrorDir = sessionMirrorDir(agentType);
-
-	const toDownload: { remote: SessionListItem; reason: "new" | "updated" }[] = [];
-	let unchanged = 0;
-	for (const remote of cloudSessions) {
-		const sidecar = readSidecar(mirrorDir, remote.local_session_id);
-		if (!sidecar) {
-			toDownload.push({ remote, reason: "new" });
-			continue;
-		}
-		// Treat null/missing remote hash as "must download" — legacy rows
-		// pre-dating the column have no way to compare.
-		if (!remote.content_hash || sidecar.content_hash !== remote.content_hash) {
-			toDownload.push({ remote, reason: "updated" });
-			continue;
-		}
-		unchanged++;
-	}
-
-	const fresh = toDownload.filter((d) => d.reason === "new").length;
-	const updated = toDownload.length - fresh;
-	p.log.message(chalk.gray(`${fresh} new, ${updated} updated, ${unchanged} unchanged`));
-
-	if (opts.dryRun || toDownload.length === 0) {
-		return { fresh, updated, unchanged };
-	}
-
-	if (!opts.yes) {
-		const ok = await askYesNo(
-			`Download ${toDownload.length} session${toDownload.length === 1 ? "" : "s"}?`,
-		);
-		if (!ok) {
-			// Cancelled — report only what's actually in sync. The pending
-			// downloads stay pending; counting them as "unchanged" would lie.
-			return { fresh: 0, updated: 0, unchanged };
-		}
-	}
-
-	mkdirSync(mirrorDir, { recursive: true });
-
-	const dlSpinner = p.spinner();
-	dlSpinner.start(`Downloading content (0/${toDownload.length})...`);
-	let freshDone = 0;
-	let updatedDone = 0;
-	let failed = 0;
-	for (const { remote, reason } of toDownload) {
-		try {
-			const body = await api.getSessionContent(remote.id);
-			writeMirrorAtomic(mirrorDir, remote, body);
-			if (reason === "new") freshDone++;
-			else updatedDone++;
-			dlSpinner.message(`Downloading content (${freshDone + updatedDone}/${toDownload.length})...`);
-		} catch (e) {
-			failed++;
-			p.log.warn(`${remote.local_session_id} failed: ${errMessage(e)}`);
-		}
-	}
-	const done = freshDone + updatedDone;
-	dlSpinner.stop(
-		failed > 0
-			? `Downloaded ${done}, ${failed} failed`
-			: `Downloaded ${done} session${done === 1 ? "" : "s"}`,
-	);
-
-	return { fresh: freshDone, updated: updatedDone, unchanged };
 }
 
 function sessionMirrorDir(agentType: AgentType): string {

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -8,7 +8,7 @@ import { ApiClient, ApiError, unwrap } from "../lib/api-client";
 import { isLoggedIn } from "../lib/config";
 import { errMessage } from "../lib/errors";
 import { sha256Hex } from "../lib/hash";
-import { askYesNo, parseModules } from "../lib/prompts";
+import { parseModules } from "../lib/prompts";
 import {
 	adapterForType,
 	fetchScopeIdForEnv,
@@ -45,7 +45,6 @@ interface PushOpts {
 	allAgents?: boolean;
 	dryRun?: boolean;
 	agent?: string;
-	yes?: boolean;
 }
 
 /** What `uploadOneAgent` actually pushed for a single agent. */
@@ -209,15 +208,6 @@ export async function push(opts: PushOpts) {
 			),
 		);
 		return;
-	}
-
-	// One confirmation covering every agent, after the full summary.
-	if (toUpload.length > 0 && !opts.yes) {
-		const ok = await askYesNo("Proceed with upload?");
-		if (!ok) {
-			p.outro(chalk.gray("Cancelled."));
-			return;
-		}
 	}
 
 	const totals = {

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -3,12 +3,12 @@ import { resolve as resolvePath } from "node:path";
 import * as p from "@clack/prompts";
 import chalk from "chalk";
 import type { AgentAdapter, RawSession, RawSkill } from "../adapters/base";
-import { adapterRegistry } from "../adapters/registry";
+import { type AgentType, adapterRegistry } from "../adapters/registry";
 import { ApiClient, ApiError, unwrap } from "../lib/api-client";
 import { isLoggedIn } from "../lib/config";
 import { errMessage } from "../lib/errors";
 import { sha256Hex } from "../lib/hash";
-import { askMulti, askYesNo, parseModules } from "../lib/prompts";
+import { askYesNo, parseModules } from "../lib/prompts";
 import {
 	adapterForType,
 	fetchScopeIdForEnv,
@@ -31,15 +31,11 @@ import {
 } from "../lib/skills-lock";
 import { type ModuleState, readModuleState, writeModuleState } from "../lib/state";
 import { tarSkillDir } from "../lib/tar";
-import { isInteractive } from "../lib/tty";
 
 const RESETUP_HINT =
 	"This machine's environment is no longer registered. Run `clawdi setup` again.";
 
-const UP_MODULES = [
-	{ value: "sessions", label: "Sessions", hint: "agent conversation history" },
-	{ value: "skills", label: "Skills", hint: "skill directories as tar.gz" },
-];
+const UP_MODULES = ["sessions", "skills"] as const;
 
 interface PushOpts {
 	modules?: string;
@@ -52,14 +48,40 @@ interface PushOpts {
 	yes?: boolean;
 }
 
-interface AgentPushResult {
-	sessionsCacheSkipped: number;
+/** What `uploadOneAgent` actually pushed for a single agent. */
+interface AgentUploadResult {
 	sessionsCreated: number;
 	sessionsUpdated: number;
 	sessionsUnchanged: number;
 	contentUploaded: number;
-	skillsCacheSkipped: number;
 	skillsPushed: number;
+}
+
+/**
+ * What `scanOneAgent` found for a single agent: the sessions and skills
+ * staged for upload. Splitting scan from upload lets `push` show a
+ * combined, per-agent summary across every target agent and ask for ONE
+ * confirmation — instead of confirming each agent before the next is even
+ * scanned (which made a multi-agent `clawdi push` look like it had only
+ * picked the first agent).
+ */
+interface AgentScanResult {
+	agentType: AgentType;
+	envId: string | null;
+	sessions: RawSession[];
+	skills: RawSkill[];
+	sessionsCacheSkipped: number;
+	skillsCacheSkipped: number;
+	/** Per-agent advisories (hermes filter notice, first-run hint,
+	 * exclusion summary) — collected during the scan and rendered
+	 * under the agent in the unified summary instead of being printed
+	 * mid-scan, so the scan reads as one operation across all agents. */
+	notes: string[];
+}
+
+/** Whether a scan turned up anything to actually upload. */
+function scanHasWork(scan: AgentScanResult): boolean {
+	return scan.sessions.length > 0 || scan.skills.length > 0;
 }
 
 export async function push(opts: PushOpts) {
@@ -81,6 +103,14 @@ export async function push(opts: PushOpts) {
 		return;
 	}
 
+	// `--all` widens every axis it can. Explicit narrowing flags
+	// (--agent, --modules, --project, --exclude-project) still win
+	// per-axis — `--all --agent codex` means "all modules, all
+	// projects, but only codex".
+	if (opts.all && !opts.agent && !opts.allAgents) {
+		opts.allAgents = true;
+	}
+
 	const targetTypes = await resolveTargetAgentTypes(opts.agent, !!opts.allAgents);
 	if (targetTypes.length === 0) {
 		p.outro(chalk.red("Aborted."));
@@ -88,31 +118,108 @@ export async function push(opts: PushOpts) {
 		return;
 	}
 
-	let modules: string[];
-	if (opts.modules) {
-		const parsed = parseModules(opts.modules, UP_MODULES);
-		if (!parsed) return;
-		modules = parsed;
-	} else {
-		const picked = await askMulti("Modules to upload:", UP_MODULES);
-		if (!picked) {
-			p.outro(chalk.gray("Cancelled."));
-			return;
-		}
-		modules = picked;
-	}
-	if (modules.length === 0) {
-		p.outro(chalk.gray("Nothing to push."));
-		return;
-	}
-
-	if (targetTypes.length > 1) {
-		p.log.info(`Targets: ${targetTypes.map((t) => adapterRegistry[t].displayName).join(", ")}`);
-	}
+	// Module default: when --modules is omitted, take every module.
+	// `parseModules(undefined, …)` already returns the full list — no
+	// multi-select prompt to block an agent harness on.
+	const modules = parseModules(opts.modules, UP_MODULES);
+	if (!modules) return;
 
 	const moduleState = readModuleState();
 	const sessionsLock = readSessionsLock();
 	const skillsLock = readSkillsLock();
+
+	// Project scope is agent-independent (derived only from flags), so
+	// resolve it once and report it once — not per agent.
+	const projectFilter = opts.project ?? (opts.all ? undefined : process.cwd());
+	if (modules.includes("sessions")) {
+		const scope = projectFilter ? `project ${projectFilter}` : "all projects";
+		p.log.info(chalk.gray(`Scanning ${scope}`));
+	}
+
+	// Scan every agent first — one spinner, one combined summary — so a
+	// multi-agent push reads as a single scan, not a per-agent block
+	// sequence that looks like only the first agent was picked.
+	const scanSpinner = p.spinner();
+	scanSpinner.start(
+		`Scanning ${targetTypes.length} agent${targetTypes.length === 1 ? "" : "s"}...`,
+	);
+	const scans: AgentScanResult[] = [];
+	let scanError: string | null = null;
+	try {
+		for (const agentType of targetTypes) {
+			const adapter = adapterForType(agentType);
+			if (!adapter) continue;
+			const scan = await scanOneAgent(
+				adapter,
+				modules,
+				opts,
+				projectFilter,
+				sessionsLock,
+				skillsLock,
+			);
+			if ("error" in scan) {
+				scanError = scan.error;
+				break;
+			}
+			scans.push(scan);
+		}
+	} catch (e) {
+		// A genuine throw (adapter scan / skill hashing failed) — stop the
+		// spinner before the error bubbles to `handleError`.
+		scanSpinner.stop("Scan failed.");
+		throw e;
+	}
+	scanSpinner.stop(scanError ? "Scan failed." : "Scan complete.");
+
+	if (scanError) {
+		// Scan phase mutates no caches — nothing to persist.
+		p.log.error(scanError);
+		p.outro(chalk.red("Aborted."));
+		process.exitCode = 1;
+		return;
+	}
+
+	// Combined per-agent summary: every target agent, its counts, and
+	// any advisories — visible in full before the confirmation.
+	for (const scan of scans) {
+		const name = adapterRegistry[scan.agentType].displayName;
+		const bits: string[] = [];
+		if (modules.includes("sessions")) {
+			const sync = scan.sessionsCacheSkipped > 0 ? ` (${scan.sessionsCacheSkipped} in sync)` : "";
+			bits.push(`${scan.sessions.length} session${scan.sessions.length === 1 ? "" : "s"}${sync}`);
+		}
+		if (modules.includes("skills")) {
+			const sync = scan.skillsCacheSkipped > 0 ? ` (${scan.skillsCacheSkipped} in sync)` : "";
+			bits.push(`${scan.skills.length} skill${scan.skills.length === 1 ? "" : "s"}${sync}`);
+		}
+		p.log.message(`${chalk.bold(name)} — ${bits.join(", ")} to upload`);
+		for (const note of scan.notes) {
+			p.log.message(chalk.gray(`  ${note}`));
+		}
+	}
+
+	const toUpload = scans.filter(scanHasWork);
+
+	if (opts.dryRun) {
+		p.outro(
+			chalk.gray(
+				toUpload.length > 0
+					? "Dry run complete."
+					: "Dry run — nothing to push, everything already in sync.",
+			),
+		);
+		return;
+	}
+
+	// One confirmation covering every agent, after the full summary.
+	if (toUpload.length > 0 && !opts.yes) {
+		const ok = await askYesNo("Proceed with upload?");
+		if (!ok) {
+			p.outro(chalk.gray("Cancelled."));
+			return;
+		}
+	}
+
 	const totals = {
 		cacheSkipped: 0,
 		created: 0,
@@ -123,52 +230,39 @@ export async function push(opts: PushOpts) {
 		skills: 0,
 	};
 	let aborted = false;
-
-	for (const agentType of targetTypes) {
-		const adapter = adapterForType(agentType);
-		if (!adapter) continue;
-		if (targetTypes.length > 1) {
-			p.log.step(chalk.bold(`▶ ${adapterRegistry[agentType].displayName}`));
+	for (const scan of scans) {
+		// Cache-skip counts are scan facts — fold them in regardless of
+		// whether this agent goes on to upload anything.
+		totals.cacheSkipped += scan.sessionsCacheSkipped;
+		totals.skillsCacheSkipped += scan.skillsCacheSkipped;
+		if (!scanHasWork(scan)) continue;
+		// Header only when more than one agent actually uploads — a
+		// lone upload block needs no disambiguating label.
+		if (toUpload.length > 1) {
+			p.log.step(chalk.bold(`▶ ${adapterRegistry[scan.agentType].displayName}`));
 		}
-		const result = await pushOneAgent(
-			adapter,
-			modules,
-			opts,
-			moduleState,
-			sessionsLock,
-			skillsLock,
-		);
+		const result = await uploadOneAgent(scan, moduleState, sessionsLock, skillsLock);
 		if (result === "aborted") {
 			aborted = true;
 			break;
 		}
-		if (result === "skipped") continue;
-		totals.cacheSkipped += result.sessionsCacheSkipped;
 		totals.created += result.sessionsCreated;
 		totals.updated += result.sessionsUpdated;
 		totals.unchanged += result.sessionsUnchanged;
 		totals.content += result.contentUploaded;
-		totals.skillsCacheSkipped += result.skillsCacheSkipped;
 		totals.skills += result.skillsPushed;
 	}
 
-	if (!opts.dryRun) {
-		writeModuleState(moduleState);
-		// Persist content-hash caches once per push command, even if the
-		// loop aborted partway — entries we mutated for successful agents
-		// are still valid and would otherwise be lost on the next push.
-		writeSessionsLock(sessionsLock);
-		writeSkillsLock(skillsLock);
-	}
+	writeModuleState(moduleState);
+	// Persist content-hash caches once per push command, even if the
+	// loop aborted partway — entries we mutated for successful agents
+	// are still valid and would otherwise be lost on the next push.
+	writeSessionsLock(sessionsLock);
+	writeSkillsLock(skillsLock);
 
 	if (aborted) {
 		p.outro(chalk.red("Aborted."));
 		process.exitCode = 1;
-		return;
-	}
-
-	if (opts.dryRun) {
-		p.outro(chalk.gray("Dry run complete."));
 		return;
 	}
 
@@ -193,22 +287,32 @@ export async function push(opts: PushOpts) {
 	p.outro(chalk.green(`✓ Push complete — ${parts.join(", ")}`));
 }
 
-async function pushOneAgent(
+/**
+ * Scan one agent's local data and stage what would be uploaded. Prints
+ * nothing and mutates nothing (no cache writes, no network writes —
+ * only reads the sessions-lock to diff). Advisories go into the
+ * returned `notes` so the caller can render one combined summary
+ * across every agent. Returns `{ error }` on an unrecoverable env
+ * problem so the caller can surface it after stopping the scan spinner.
+ */
+async function scanOneAgent(
 	adapter: AgentAdapter,
 	modules: string[],
 	opts: PushOpts,
-	moduleState: ModuleState,
+	projectFilter: string | undefined,
 	sessionsLock: SessionsLock,
 	skillsLock: SkillsLock,
-): Promise<AgentPushResult | "aborted" | "skipped"> {
+): Promise<AgentScanResult | { error: string }> {
 	const agentType = adapter.agentType;
 	const envId = getEnvIdByAgent(agentType);
+	// True when `projectFilter` came from the cwd default rather than an
+	// explicit --project — drives whether "--all" is a useful hint.
+	const usedCwdDefault = !opts.all && !opts.project;
 
 	if (!opts.dryRun && !envId) {
-		p.log.error(
-			`No environment registered for ${adapterRegistry[agentType].displayName}. Run \`clawdi setup\` first.`,
-		);
-		return "aborted";
+		return {
+			error: `No environment registered for ${adapterRegistry[agentType].displayName}. Run \`clawdi setup\` first.`,
+		};
 	}
 
 	// Probe the cached env_id before doing any local work. The CLI keeps a
@@ -225,61 +329,51 @@ async function pushOneAgent(
 			});
 			if (res.error || !res.data) {
 				const status = res.response?.status ?? 0;
-				if (status === 404) {
-					p.log.error(RESETUP_HINT);
-					return "aborted";
-				}
+				if (status === 404) return { error: RESETUP_HINT };
 				// Anything else (401, network, 5xx) — let the actual upload bubble
 				// up the proper error; don't double-report here.
 			}
 		} catch (e) {
-			if (e instanceof ApiError && e.status === 404) {
-				p.log.error(RESETUP_HINT);
-				return "aborted";
-			}
+			if (e instanceof ApiError && e.status === 404) return { error: RESETUP_HINT };
 			// Same reasoning as above — fall through and let upload surface it.
 		}
 	}
 
-	// Project filter: explicit --all wins, then explicit --project, else cwd.
-	const usedCwdDefault = !opts.all && !opts.project;
-	const projectFilter = opts.all ? undefined : (opts.project ?? process.cwd());
-
+	const notes: string[] = [];
 	const excludeSet = new Set<string>(
 		(opts.excludeProject ?? []).map((path) => normalizeProject(path)),
 	);
 
-	if (modules.includes("sessions")) {
-		const scope = projectFilter ? `project ${projectFilter}` : "all projects";
-		p.log.info(chalk.gray(`Scanning ${scope}`));
-	}
-
 	if (agentType === "hermes" && modules.includes("sessions") && projectFilter !== undefined) {
-		p.log.warn("Hermes does not support project filtering; pushing all sessions.");
-		p.log.info("Use --all to suppress this notice.");
+		// `--all` (alone) clears projectFilter, so suggesting it only
+		// helps when the filter came from the cwd default.
+		notes.push(
+			usedCwdDefault
+				? "Hermes ignores project filters — pushing all sessions. Use --all to suppress."
+				: "Hermes ignores project filters — pushing all sessions.",
+		);
 	}
 
 	let sessions: RawSession[] = [];
-	let skills: RawSkill[] = [];
-	let dedupedCount = 0;
-
-	const scanSpinner = p.spinner();
-	scanSpinner.start("Scanning local data...");
+	const skills: RawSkill[] = [];
+	let skillsCacheSkipped = 0;
 	if (modules.includes("sessions")) {
-		const result = await adapter.collectSessions({ projectFilter });
-		sessions = result.sessions;
-		dedupedCount = result.dedupedCount;
+		// `collectSessions` also reports a `dedupedCount` (resume chains it
+		// collapsed). That's internal housekeeping — not actionable and not
+		// perceptible to the user — so it isn't surfaced.
+		sessions = (await adapter.collectSessions({ projectFilter })).sessions;
 	}
 	if (modules.includes("skills")) {
-		skills = await adapter.collectSkills();
+		// Hash each skill's file tree and diff against the skills-lock here,
+		// in the scan — the same per-entity cache check sessions get below —
+		// so the summary's skill count reflects what will actually upload.
+		for (const skill of await adapter.collectSkills()) {
+			skill.contentHash = await computeSkillFolderHash(skill.directoryPath);
+			const cached = skillsLock.skills[skillCacheKey(agentType, skill.skillKey)]?.hash;
+			if (cached === skill.contentHash) skillsCacheSkipped++;
+			else skills.push(skill);
+		}
 	}
-	const dedupeNote =
-		dedupedCount > 0
-			? ` (deduped ${dedupedCount} resume chain${dedupedCount === 1 ? "" : "s"})`
-			: "";
-	scanSpinner.stop(
-		`Scanned ${sessions.length} session${sessions.length === 1 ? "" : "s"}${dedupeNote}, ${skills.length} skill${skills.length === 1 ? "" : "s"}`,
-	);
 
 	// Fingerprint each session's content. The server's batch endpoint
 	// compares this against the stored `content_hash` to decide whether
@@ -305,15 +399,13 @@ async function pushOneAgent(
 		});
 		const removed = before - sessions.length;
 		if (removed > 0) {
-			p.log.info(
-				chalk.gray(
-					`Excluded ${removed} session${removed === 1 ? "" : "s"} from ${matchedExcludes.size} project${matchedExcludes.size === 1 ? "" : "s"}`,
-				),
+			notes.push(
+				`Excluded ${removed} session${removed === 1 ? "" : "s"} from ${matchedExcludes.size} project${matchedExcludes.size === 1 ? "" : "s"}.`,
 			);
 		}
 		for (const requested of excludeSet) {
 			if (!matchedExcludes.has(requested)) {
-				p.log.warn(`--exclude-project ${requested} did not match any local sessions; ignoring`);
+				notes.push(`--exclude-project ${requested} matched no local sessions; ignored.`);
 			}
 		}
 	}
@@ -332,77 +424,44 @@ async function pushOneAgent(
 		sessionsCacheSkipped = before - sessions.length;
 	}
 
-	if (modules.includes("sessions")) {
-		const tail = sessionsCacheSkipped > 0 ? ` (${sessionsCacheSkipped} already in sync)` : "";
-		p.log.message(chalk.gray(`Sessions: ${sessions.length} to upload${tail}`));
-		if (sessions.length === 0 && sessionsCacheSkipped === 0) {
-			// Nothing scanned at all — guide first-run cwd-default users.
-			const isFirstRun = !Object.keys(sessionsLock.sessions).some((k) =>
-				k.startsWith(`${agentType}:`),
+	// Guidance when nothing matched at all.
+	if (modules.includes("sessions") && sessions.length === 0 && sessionsCacheSkipped === 0) {
+		const isFirstRun = !Object.keys(sessionsLock.sessions).some((k) =>
+			k.startsWith(`${agentType}:`),
+		);
+		if (excludeSet.size > 0) {
+			notes.push("Nothing left to push after exclusions.");
+		} else if (usedCwdDefault && isFirstRun) {
+			notes.push(
+				`No sessions in ${process.cwd()} — looks like a first run. Use --all to scan every project.`,
 			);
-			if (usedCwdDefault && isFirstRun && !isInteractive()) {
-				p.log.info(
-					chalk.gray(
-						`No sessions matched in ${process.cwd()}. This looks like a first run — re-run with --all to scan every project, or pass --project <abs-path> if your sessions live elsewhere.`,
-					),
-				);
-			} else if (projectFilter) {
-				p.log.info(
-					chalk.gray(
-						"No sessions matched. Try --all to scan every project, or pass --project <abs-path> for a different scope.",
-					),
-				);
-			}
+		} else if (projectFilter) {
+			// Don't suggest --all if the user already passed it (explicit
+			// --project alongside --all): --all wouldn't widen anything,
+			// the project just didn't match.
+			notes.push(
+				opts.all
+					? "No sessions matched that project — check the --project path."
+					: "No sessions matched. Use --all to scan every project, or --project <abs-path>.",
+			);
 		}
-	}
-	if (modules.includes("skills")) {
-		p.log.message(chalk.gray(`Skills:   ${skills.length} to upload`));
 	}
 
-	if (sessions.length === 0 && skills.length === 0) {
-		if (sessionsCacheSkipped > 0) {
-			// Cache covered everything. Surface the count to the top-level
-			// totals so the user sees a non-zero "skipped (cache)" number.
-			return {
-				sessionsCacheSkipped,
-				sessionsCreated: 0,
-				sessionsUpdated: 0,
-				sessionsUnchanged: 0,
-				contentUploaded: 0,
-				skillsCacheSkipped: 0,
-				skillsPushed: 0,
-			};
-		}
-		if (excludeSet.size > 0 && modules.includes("sessions")) {
-			p.log.message(chalk.gray("Nothing left to push after exclusions."));
-		}
-		return "skipped";
-	}
+	return { agentType, envId, sessions, skills, sessionsCacheSkipped, skillsCacheSkipped, notes };
+}
 
-	if (opts.dryRun) {
-		// Dry-run reports the local scan size — we can't know which sessions
-		// the server already has without actually hitting the batch endpoint.
-		return {
-			sessionsCacheSkipped,
-			sessionsCreated: sessions.length,
-			sessionsUpdated: 0,
-			sessionsUnchanged: 0,
-			contentUploaded: sessions.length,
-			skillsCacheSkipped: 0,
-			skillsPushed: skills.length,
-		};
-	}
-
-	// `--yes` skips the confirmation. `askYesNo` already returns true in
-	// non-interactive contexts (CI / agent), so explicit `--yes` is mostly
-	// a no-op in those, but keeps the skill's command line self-documenting.
-	if (!opts.yes) {
-		const ok = await askYesNo("Proceed with upload?");
-		if (!ok) {
-			p.log.info(chalk.gray("Cancelled."));
-			return "skipped";
-		}
-	}
+/**
+ * Upload one agent's scanned data. Mutates `moduleState` and both lock
+ * caches as uploads land. Returns "aborted" if the server reports the
+ * environment vanished mid-batch.
+ */
+async function uploadOneAgent(
+	scan: AgentScanResult,
+	moduleState: ModuleState,
+	sessionsLock: SessionsLock,
+	skillsLock: SkillsLock,
+): Promise<AgentUploadResult | "aborted"> {
+	const { agentType, envId, sessions, skills } = scan;
 
 	if (!envId) {
 		p.log.error("Environment id missing — rerun `clawdi setup`.");
@@ -541,46 +600,26 @@ async function pushOneAgent(
 		moduleState[`sessions:${agentType}`] = { lastActivityAt: new Date().toISOString() };
 	}
 
-	let skillsCacheSkipped = 0;
 	if (skills.length > 0) {
-		// Phase-2: skill upload uses scope-explicit URLs. Resolve
-		// THIS agent's env's default_scope_id directly — not the
-		// auth key's "most recently active env" heuristic. With a
-		// multi-agent setup on an unbound CLI key, the latter would
-		// route a `claude_code` push under whichever env was
-		// touched last (often `codex` from the previous push),
-		// while sessions still wrote correctly to `envId`. The
-		// `claude_code` daemon would never see these skills because
-		// its reconcile listing is scoped to its own env.
-		if (!envId) {
-			throw new Error(
-				`internal error: skill push without envId for ${agentType}; the early-return guard above should have caught this`,
-			);
-		}
+		// Skill upload uses scope-explicit URLs. Resolve THIS agent's
+		// env's default_scope_id directly — not the auth key's "most
+		// recently active env" heuristic. With a multi-agent setup on
+		// an unbound CLI key, the latter would route a `claude_code`
+		// push under whichever env was touched last (often `codex`
+		// from the previous push), while sessions still wrote
+		// correctly to `envId`. The `claude_code` daemon would never
+		// see these skills because its reconcile listing is scoped to
+		// its own env.
 		const skillScopeId = await fetchScopeIdForEnv(api, envId);
 
+		// `skills` is already the to-upload set — the scan phase hashed
+		// every skill and dropped the ones already in sync.
 		const skillSpinner = p.spinner();
-		skillSpinner.start(`Hashing ${skills.length} skill${skills.length === 1 ? "" : "s"}...`);
+		skillSpinner.start(`Uploading ${skills.length} skill${skills.length === 1 ? "" : "s"}...`);
 		let pushed = 0;
 		const skipped: { key: string; reason: string }[] = [];
 		try {
 			for (const skill of skills) {
-				// Compute the file-tree hash first. Cheap (no tar build) — if
-				// it matches the cache, we skip the whole upload path.
-				// Cache key is partitioned by `(agentType, skillKey)`: in
-				// multi-agent push, agent A and agent B can have the same
-				// `foo` content under different scopes; a flat skill_key
-				// cache would say "B already in sync" the moment A pushed,
-				// leaving B's scope missing the skill.
-				const computedHash = await computeSkillFolderHash(skill.directoryPath);
-				const cacheK = skillCacheKey(agentType, skill.skillKey);
-				if (skillsLock.skills[cacheK]?.hash === computedHash) {
-					skillsCacheSkipped++;
-					skillSpinner.message(
-						`Hashing skills (${pushed + skipped.length + skillsCacheSkipped}/${skills.length})...`,
-					);
-					continue;
-				}
 				// Pass skill_key so nested Hermes layouts archive
 				// entries under `category/foo/...` (matching the
 				// cloud key), not just `foo/...` which would
@@ -592,10 +631,19 @@ async function pushOneAgent(
 						skill.skillKey,
 						tarBytes,
 						`${skill.skillKey}.tar.gz`,
-						computedHash,
+						skill.contentHash,
 					);
 					pushed++;
-					skillsLock.skills[cacheK] = { hash: computedHash };
+					// Cache key is partitioned by `(agentType, skillKey)`: in
+					// multi-agent push, agent A and agent B can have the same
+					// `foo` content under different scopes; a flat skill_key
+					// cache would say "B already in sync" the moment A pushed,
+					// leaving B's scope missing the skill.
+					if (skill.contentHash) {
+						skillsLock.skills[skillCacheKey(agentType, skill.skillKey)] = {
+							hash: skill.contentHash,
+						};
+					}
 				} catch (e) {
 					// 413 = upstream (Cloudflare / nginx) refused the body. Almost
 					// always a single oversized skill; skip it and keep going so
@@ -616,14 +664,9 @@ async function pushOneAgent(
 					const mb = (tarBytes.length / 1024 / 1024).toFixed(1);
 					skipped.push({ key: skill.skillKey, reason: `${mb} MB exceeds upload limit` });
 				}
-				skillSpinner.message(
-					`Uploading skills (${pushed + skipped.length + skillsCacheSkipped}/${skills.length})...`,
-				);
+				skillSpinner.message(`Uploading skills (${pushed + skipped.length}/${skills.length})...`);
 			}
 			const summary = [`Pushed ${pushed} skill${pushed === 1 ? "" : "s"}`];
-			if (skillsCacheSkipped > 0) {
-				summary.push(`${skillsCacheSkipped} already in sync`);
-			}
 			if (skipped.length > 0) {
 				summary.push(`skipped ${skipped.length} (too large)`);
 			}
@@ -640,12 +683,10 @@ async function pushOneAgent(
 	}
 
 	return {
-		sessionsCacheSkipped,
 		sessionsCreated,
 		sessionsUpdated,
 		sessionsUnchanged,
 		contentUploaded,
-		skillsCacheSkipped,
 		skillsPushed,
 	};
 }

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -246,7 +246,7 @@ export async function skillAdd(path: string, opts: { yes?: boolean; agent?: stri
 
 export async function skillInstall(
 	repoInput: string,
-	opts: { agent?: string; list?: boolean; yes?: boolean } = {},
+	opts: { agent?: string; yes?: boolean } = {},
 ) {
 	requireAuth();
 
@@ -267,18 +267,6 @@ export async function skillInstall(
 
 	const repo = `${parsed.owner}/${parsed.repo}`;
 	const path = parsed.path;
-
-	// --list mode: we don't have a backend endpoint that merely lists; the install
-	// endpoint actually performs the install. Until a dedicated list endpoint
-	// exists, surface this clearly rather than silently installing.
-	if (opts.list) {
-		console.log(
-			chalk.yellow(
-				"--list is not supported yet. The backend installs in a single call; a preview endpoint is planned.",
-			),
-		);
-		process.exit(2);
-	}
 
 	console.log(chalk.cyan(`Fetching from ${repo}${path ? `/${path}` : ""}...`));
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -169,40 +169,6 @@ export async function update(opts: { json?: boolean; check?: boolean } = {}) {
 	console.log(chalk.green(`✓ clawdi v${latest} installed.`));
 }
 
-/**
- * Non-blocking background check used at the end of commands.
- * Returns quickly on cache hit, fires a background fetch otherwise.
- */
-export async function maybeNotifyOutdated(): Promise<void> {
-	if (process.env.CLAWDI_NO_UPDATE_CHECK) return;
-	if (!process.stdout.isTTY) return;
-
-	const current = getCliVersion();
-	const cached = readCache();
-	const now = Date.now();
-
-	if (cached?.latest && now - new Date(cached.checkedAt).getTime() < CACHE_TTL_MS) {
-		if (isNewer(cached.latest, current)) {
-			console.log();
-			console.log(
-				chalk.gray(
-					`  (v${cached.latest} available — run \`clawdi update\` or \`npm i -g clawdi\`)`,
-				),
-			);
-		}
-		return;
-	}
-
-	// Cache stale — refresh in the background; don't block caller.
-	fetchLatest()
-		.then((latest) => {
-			if (latest) writeCache(latest);
-		})
-		.catch(() => {
-			// best-effort
-		});
-}
-
 const LAST_VERSION_FILE = "last-version";
 
 function lastVersionPath(): string {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,8 +17,8 @@ Examples:
   $ clawdi auth login               Authenticate with Clawdi Cloud
   $ clawdi setup                    Detect agents and register the current machine
   $ clawdi session list             Preview local sessions before pushing
-  $ clawdi push --all --yes         Upload everything (every agent, project, module) without prompts
-  $ clawdi pull --all --yes         Download everything from the cloud without prompts
+  $ clawdi push --all               Upload everything (every agent, project, module)
+  $ clawdi pull --all               Download everything from the cloud
   $ clawdi skill list --json        Machine-readable skill listing
   $ clawdi memory search "redis"    Search memories by text
   $ clawdi vault set OPENAI_API_KEY Store a secret
@@ -184,17 +184,16 @@ program
 	.option("--agent <type>", "Narrow to one agent (claude_code, codex, hermes, openclaw)")
 	.option("--all-agents", "Push from every registered agent on this machine (implied by --all)")
 	.option("--dry-run", "Preview without uploading")
-	.option("-y, --yes", "Skip the upload confirmation prompt")
 	.addHelpText(
 		"after",
 		`
 Examples:
-  $ clawdi push --all --yes                Push everything, no prompts (canonical agent invocation)
+  $ clawdi push --all                      Push everything (every agent, project, module)
   $ clawdi push                            Push cwd project for the registered agent (or all of them if multiple)
   $ clawdi push --modules skills           Push only skills (cwd project, registered agent(s))
   $ clawdi push --agent claude_code --dry-run
   $ clawdi push --all --project ~/foo      Push every module / every agent for one specific project
-  $ clawdi push --all --exclude-project ~/scratch --yes`,
+  $ clawdi push --all --exclude-project ~/scratch`,
 	)
 	.action(async (opts) => {
 		const { push } = await import("./commands/push.js");
@@ -220,14 +219,13 @@ program
 		"--dry-run",
 		"Preview without downloading. Use to check which skills will be overwritten locally.",
 	)
-	.option("-y, --yes", "Skip confirmation prompts")
 	.addHelpText(
 		"after",
 		`
 Examples:
-  $ clawdi pull --all --yes              Pull everything, no prompts (canonical agent invocation)
+  $ clawdi pull --all                    Pull everything (every agent, every module)
   $ clawdi pull                          Pull for the registered agent (or all of them if multiple)
-  $ clawdi pull --modules sessions --yes
+  $ clawdi pull --modules sessions
   $ clawdi pull --agent claude_code --dry-run`,
 	)
 	.action(async (opts) => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,8 +17,8 @@ Examples:
   $ clawdi auth login               Authenticate with Clawdi Cloud
   $ clawdi setup                    Detect agents and register the current machine
   $ clawdi session list             Preview local sessions before pushing
-  $ clawdi push --modules sessions --all-agents --all  Upload everything
-  $ clawdi pull                     Download cloud skills to registered agents
+  $ clawdi push --all --yes         Upload everything (every agent, project, module) without prompts
+  $ clawdi pull --all --yes         Download everything from the cloud without prompts
   $ clawdi skill list --json        Machine-readable skill listing
   $ clawdi memory search "redis"    Search memories by text
   $ clawdi vault set OPENAI_API_KEY Store a secret
@@ -166,28 +166,35 @@ Examples:
 program
 	.command("push")
 	.description("Push local data (sessions, skills) to the cloud")
-	.option("--modules <modules>", "Comma-separated: sessions,skills")
-	.option("--project <path>", "Push a specific project's data (default: current directory)")
+	.option(
+		"--modules <modules>",
+		"Narrow to specific modules (comma-separated: sessions,skills). Default: all.",
+	)
+	.option("--project <path>", "Narrow to one project's data (default: current directory)")
 	.option(
 		"--exclude-project <path>",
 		"Exclude a project path (repeatable, mutex with --project)",
 		(value: string, prev: string[] = []) => prev.concat(value),
 		[] as string[],
 	)
-	.option("--all", "Push data from all projects")
-	.option("--agent <type>", "Target agent (claude_code, codex, hermes, openclaw)")
-	.option("--all-agents", "Push from every registered agent on this machine")
+	.option(
+		"--all",
+		"Push everything: every module, every registered agent, every project (each axis still narrowable via --modules / --agent / --project)",
+	)
+	.option("--agent <type>", "Narrow to one agent (claude_code, codex, hermes, openclaw)")
+	.option("--all-agents", "Push from every registered agent on this machine (implied by --all)")
 	.option("--dry-run", "Preview without uploading")
 	.option("-y, --yes", "Skip the upload confirmation prompt")
 	.addHelpText(
 		"after",
 		`
 Examples:
-  $ clawdi push
-  $ clawdi push --modules skills
+  $ clawdi push --all --yes                Push everything, no prompts (canonical agent invocation)
+  $ clawdi push                            Push cwd project for the registered agent (or all of them if multiple)
+  $ clawdi push --modules skills           Push only skills (cwd project, registered agent(s))
   $ clawdi push --agent claude_code --dry-run
-  $ clawdi push --modules sessions --all-agents --all --yes
-  $ clawdi push --modules sessions --all-agents --all --exclude-project ~/scratch --yes`,
+  $ clawdi push --all --project ~/foo      Push every module / every agent for one specific project
+  $ clawdi push --all --exclude-project ~/scratch --yes`,
 	)
 	.action(async (opts) => {
 		const { push } = await import("./commands/push.js");
@@ -199,17 +206,28 @@ program
 	.description(
 		"Pull cloud data — `skills` writes archives to agent dirs; `sessions` mirrors to ~/.clawdi/sessions/",
 	)
-	.option("--modules <modules>", "Comma-separated: skills,sessions")
-	.option("--agent <type>", "Target agent (claude_code, codex, hermes, openclaw)")
-	.option("--all-agents", "Pull for every registered agent on this machine")
-	.option("--dry-run", "Preview without downloading")
+	.option(
+		"--modules <modules>",
+		"Narrow to specific modules (comma-separated: skills,sessions). Default: all.",
+	)
+	.option("--agent <type>", "Narrow to one agent (claude_code, codex, hermes, openclaw)")
+	.option(
+		"--all",
+		"Pull everything: every module, every registered agent (still narrowable via --modules / --agent)",
+	)
+	.option("--all-agents", "Pull for every registered agent on this machine (implied by --all)")
+	.option(
+		"--dry-run",
+		"Preview without downloading. Use to check which skills will be overwritten locally.",
+	)
 	.option("-y, --yes", "Skip confirmation prompts")
 	.addHelpText(
 		"after",
 		`
 Examples:
-  $ clawdi pull
-  $ clawdi pull --modules sessions --all-agents --yes
+  $ clawdi pull --all --yes              Pull everything, no prompts (canonical agent invocation)
+  $ clawdi pull                          Pull for the registered agent (or all of them if multiple)
+  $ clawdi pull --modules sessions --yes
   $ clawdi pull --agent claude_code --dry-run`,
 	)
 	.action(async (opts) => {
@@ -295,7 +313,6 @@ skillCmd
 	.command("install <repo>")
 	.description("Install a skill from GitHub (owner/repo or owner/repo/path)")
 	.option("-a, --agent <type>", "Install to a single agent (claude_code, codex, hermes, openclaw)")
-	.option("-l, --list", "List skills in the repo without installing (planned)")
 	.option("-y, --yes", "Skip confirmation prompts")
 	.addHelpText(
 		"after",

--- a/packages/cli/src/lib/prompts.ts
+++ b/packages/cli/src/lib/prompts.ts
@@ -56,20 +56,26 @@ export async function askOne<T extends string>(
 	return result;
 }
 
+/**
+ * Resolve a `--modules` value against the allowed module names. Returns
+ * the full list when `input` is undefined, the parsed subset otherwise,
+ * or `null` on an unknown name (after printing the reason). Never
+ * returns an empty array.
+ */
 export function parseModules(
 	input: string | undefined,
-	available: Array<{ value: string }>,
+	available: readonly string[],
 ): string[] | null {
-	if (!input) return available.map((o) => o.value);
+	if (!input) return [...available];
 	const chosen = input
 		.split(",")
 		.map((s) => s.trim())
 		.filter(Boolean);
-	const valid = new Set(available.map((o) => o.value));
+	const valid = new Set(available);
 	const invalid = chosen.filter((c) => !valid.has(c));
 	if (invalid.length > 0) {
 		console.log(chalk.red(`Unknown module(s): ${invalid.join(", ")}`));
-		console.log(chalk.gray(`  Valid: ${available.map((o) => o.value).join(", ")}`));
+		console.log(chalk.gray(`  Valid: ${available.join(", ")}`));
 		return null;
 	}
 	if (chosen.length === 0) return null;

--- a/packages/cli/src/lib/select-adapter.ts
+++ b/packages/cli/src/lib/select-adapter.ts
@@ -5,13 +5,10 @@ import type { AgentAdapter } from "../adapters/base";
 import {
 	AGENT_TYPES,
 	type AgentType,
-	adapterRegistry,
 	allAdapterEntries,
 	getAdapterEntry,
 } from "../adapters/registry";
 import { getClawdiDir } from "./config";
-import { askOne } from "./prompts";
-import { isInteractive } from "./tty";
 
 export function getEnvIdByAgent(agentType: string): string | null {
 	const envPath = join(getClawdiDir(), "environments", `${agentType}.json`);
@@ -88,11 +85,15 @@ export function listRegisteredAgentTypes(): AgentType[] {
 }
 
 /**
- * Resolve the agent adapter to operate on. Prints a specific error message
- * to stdout before returning null so callers can simply abort — distinguishing
- * "no agents found" from "ambiguous, can't pick without a prompt" is critical
- * in non-interactive contexts (CI, AI agents, piped stdout) where the user
- * sees a misleading "no supported agent" message if we collapse the cases.
+ * Resolve a SINGLE agent adapter to operate on. Prints a specific error
+ * message before returning null so callers can simply abort. Never
+ * prompts — an ambiguous machine (multiple registered, or multiple
+ * detected but none registered) aborts with instructions, identically
+ * in TTY and non-TTY, so agent harnesses never stall on a picker.
+ *
+ * Multi-agent commands (`push`, `pull`, `session list`) should call
+ * `resolveTargetAgentTypes` instead — it defaults an ambiguous machine
+ * to "all registered agents" rather than aborting.
  */
 export async function selectAdapter(agentOpt?: string): Promise<AgentAdapter | null> {
 	// 1. Explicit --agent wins.
@@ -114,18 +115,16 @@ export async function selectAdapter(agentOpt?: string): Promise<AgentAdapter | n
 	const registered = listRegisteredAgentTypes();
 	if (registered.length === 1 && registered[0]) return adapterForType(registered[0]);
 	if (registered.length > 1) {
-		if (!isInteractive()) {
-			console.log(chalk.red("Multiple agents are registered on this machine."));
-			console.log(
-				chalk.gray(`Pass --agent <type> to choose one. Registered: ${registered.join(", ")}`),
-			);
-			return null;
-		}
-		const picked = await askOne<AgentType>(
-			"Multiple agents registered. Select one:",
-			registered.map((t) => ({ value: t, label: adapterRegistry[t].displayName })),
+		// Multi-agent ambiguity is handled by `resolveTargetAgentTypes`
+		// (it defaults to all registered agents). Single-target callers
+		// via this path have no good "pick all" semantics, so keep the
+		// abort here — but match TTY and non-TTY so agent harnesses get
+		// the same message regardless of how they're run.
+		console.log(chalk.red("Multiple agents are registered on this machine."));
+		console.log(
+			chalk.gray(`Pass --agent <type> to choose one. Registered: ${registered.join(", ")}`),
 		);
-		return picked ? adapterForType(picked) : null;
+		return null;
 	}
 
 	// 3. Fall back to detection.
@@ -141,20 +140,19 @@ export async function selectAdapter(agentOpt?: string): Promise<AgentAdapter | n
 		return null;
 	}
 	if (detected.length === 1 && detected[0]) return detected[0];
-	if (!isInteractive()) {
-		const types = detected.map((a) => a.agentType);
-		console.log(chalk.red("Multiple agents detected on this machine."));
-		console.log(chalk.gray(`Pass --agent <type> to choose one. Detected: ${types.join(", ")}`));
-		return null;
-	}
-	const picked = await askOne<AgentType>(
-		"Multiple agents detected. Select one:",
-		detected.map((a) => ({
-			value: a.agentType,
-			label: adapterRegistry[a.agentType].displayName,
-		})),
+	// Multiple detected but none registered: this is a one-time
+	// "which agent gets paired with my Clawdi account?" decision the
+	// user must make via `clawdi setup`, not something to prompt for
+	// at push/pull time. Same abort message in TTY and non-TTY so
+	// agent harnesses see the path forward instead of a stalled prompt.
+	const types = detected.map((a) => a.agentType);
+	console.log(chalk.red("Multiple agents detected on this machine."));
+	console.log(
+		chalk.gray(
+			`Run \`clawdi setup\` to register one, or pass --agent <type>. Detected: ${types.join(", ")}`,
+		),
 	);
-	return picked ? adapterForType(picked) : null;
+	return null;
 }
 
 /**
@@ -168,7 +166,8 @@ export async function selectAdapter(agentOpt?: string): Promise<AgentAdapter | n
  *   --all-agents          → every type with a file under ~/.clawdi/environments/
  *   --agent <type>        → exactly that one (validated)
  *   neither, single match → the single registered/detected adapter (via selectAdapter)
- *   neither, ambiguous    → null in non-interactive contexts; prompt otherwise
+ *   neither, multi match  → every registered agent (the flagless default)
+ *   neither, none usable  → empty array (selectAdapter printed the reason)
  */
 export async function resolveTargetAgentTypes(
 	agentOpt: string | undefined,
@@ -187,6 +186,22 @@ export async function resolveTargetAgentTypes(
 			return [];
 		}
 		return registered;
+	}
+
+	// No --agent and no --all-agents: with multiple registered, default
+	// to all of them. Today's behavior was to prompt in TTY (blocking
+	// agent harnesses) or abort in CI; the new default matches the "do
+	// the obvious thing" intent of a flagless invocation and keeps
+	// all-agents users from having to type --all-agents every time.
+	// Callers render their own per-agent output (push's combined scan
+	// summary, pull's per-agent steps), so no notice is printed here.
+	// Single-registered users hit the standard selectAdapter path below
+	// and see no change.
+	if (!agentOpt) {
+		const registered = listRegisteredAgentTypes();
+		if (registered.length > 1) {
+			return registered;
+		}
 	}
 
 	const adapter = await selectAdapter(agentOpt);

--- a/packages/cli/tests/commands/push.test.ts
+++ b/packages/cli/tests/commands/push.test.ts
@@ -387,7 +387,7 @@ describe("push — --all flag fan-out", () => {
 			},
 		]);
 		try {
-			await push({ agent: "claude_code", modules: "sessions", all: true, yes: true });
+			await push({ agent: "claude_code", modules: "sessions", all: true });
 		} finally {
 			restore();
 		}
@@ -414,7 +414,6 @@ describe("push — --all flag fan-out", () => {
 				modules: "sessions",
 				all: true,
 				project: "/Users/no-such-project",
-				yes: true,
 			});
 		} finally {
 			restore();
@@ -439,10 +438,10 @@ describe("push — --all flag fan-out", () => {
 			},
 		]);
 		try {
-			// No --modules, no --agent, no --project — just --all + --yes.
+			// No --modules, no --agent, no --project — just --all.
 			// Should reach both modules: the fixture session via batch,
 			// and the fixture skills via the skills/upload endpoint.
-			await push({ all: true, yes: true });
+			await push({ all: true });
 		} finally {
 			restore();
 		}
@@ -476,7 +475,7 @@ describe("push — --all flag fan-out", () => {
 			},
 		]);
 		try {
-			await push({ modules: "sessions", all: true, yes: true });
+			await push({ modules: "sessions", all: true });
 		} finally {
 			restore();
 		}

--- a/packages/cli/tests/commands/push.test.ts
+++ b/packages/cli/tests/commands/push.test.ts
@@ -146,6 +146,34 @@ describe("push — Hermes fixture", () => {
 		expect(uploads[0]?.isMultipart).toBe(true);
 	});
 
+	it("a skill already in the skills-lock is skipped on the next push", async () => {
+		setup("hermes");
+		const scopeId = "00000000-0000-0000-0000-000000000099";
+		const { captured, restore } = mockFetch([
+			okEnvironmentProbe(),
+			{
+				method: "POST",
+				path: `/api/scopes/${scopeId}/skills/upload`,
+				response: () => jsonResponse({ skill_key: "core/demo", version: 1, file_count: 1 }),
+			},
+		]);
+		const uploadCount = () =>
+			captured.filter((c) => c.path === `/api/scopes/${scopeId}/skills/upload`).length;
+		try {
+			// First push computes the skill's folder hash, uploads it, and
+			// records the hash in the skills-lock.
+			await push({ agent: "hermes", modules: "skills", all: true });
+			expect(uploadCount()).toBe(1);
+
+			// Second push: the skill is unchanged, so the scan-phase hash
+			// matches the skills-lock entry — it must NOT upload again.
+			await push({ agent: "hermes", modules: "skills", all: true });
+			expect(uploadCount()).toBe(1);
+		} finally {
+			restore();
+		}
+	});
+
 	it("corrupt state.json is tolerated (warning, not crash)", async () => {
 		setup("hermes");
 		writeFileSync(join(tmpHome, ".clawdi", "state.json"), "{ not valid json");
@@ -338,5 +366,128 @@ describe("push — preflight checks", () => {
 		}
 		expect(captured).toHaveLength(0);
 		expect(process.exitCode).toBe(1);
+	});
+});
+
+describe("push — --all flag fan-out", () => {
+	it("--all + explicit --agent narrows to that agent (explicit wins)", async () => {
+		setup("claude-code");
+		// Seed a second env so the only way "claude_code" gets selected
+		// is if the explicit --agent flag overrides --all's broadening.
+		writeFileSync(
+			join(tmpHome, ".clawdi", "environments", "codex.json"),
+			JSON.stringify({ id: "env-codex", agentType: "codex" }),
+		);
+		const { captured, restore } = mockFetch([
+			okEnvironmentProbe(),
+			{
+				method: "POST",
+				path: "/api/sessions/batch",
+				response: () => jsonResponse({ created: 1, updated: 0, unchanged: 0, needs_content: [] }),
+			},
+		]);
+		try {
+			await push({ agent: "claude_code", modules: "sessions", all: true, yes: true });
+		} finally {
+			restore();
+		}
+		// One batch call with the claude_code session — codex was NOT
+		// pulled in despite --all, because --agent narrowed.
+		const batches = captured.filter((c) => c.path === "/api/sessions/batch");
+		expect(batches).toHaveLength(1);
+		const sessions = batchSessions(batches[0]);
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0]?.local_session_id).toBe("11111111-2222-3333-4444-555555555555");
+	});
+
+	it("--all + --project narrows project (silent-precedence bug fix)", async () => {
+		setup("claude-code");
+		const { captured, restore } = mockFetch([okEnvironmentProbe()]);
+		try {
+			// Project that no fixture session lives in. Old behavior:
+			// --all silently overrode --project and the lone fixture
+			// session got uploaded anyway. New behavior: --project
+			// narrows to a non-matching path, batch gets zero sessions,
+			// no upload.
+			await push({
+				agent: "claude_code",
+				modules: "sessions",
+				all: true,
+				project: "/Users/no-such-project",
+				yes: true,
+			});
+		} finally {
+			restore();
+		}
+		expect(captured.find((c) => c.path === "/api/sessions/batch")).toBeUndefined();
+	});
+
+	it("--all alone reaches all axes for a single registered agent", async () => {
+		setup("claude-code");
+		const scopeId = "00000000-0000-0000-0000-000000000099";
+		const { captured, restore } = mockFetch([
+			okEnvironmentProbe(),
+			{
+				method: "POST",
+				path: "/api/sessions/batch",
+				response: () => jsonResponse({ created: 1, updated: 0, unchanged: 0, needs_content: [] }),
+			},
+			{
+				method: "POST",
+				path: `/api/scopes/${scopeId}/skills/upload`,
+				response: () => jsonResponse({ skill_key: "demo", version: 1, file_count: 1 }),
+			},
+		]);
+		try {
+			// No --modules, no --agent, no --project — just --all + --yes.
+			// Should reach both modules: the fixture session via batch,
+			// and the fixture skills via the skills/upload endpoint.
+			await push({ all: true, yes: true });
+		} finally {
+			restore();
+		}
+		const batch = captured.find((c) => c.path === "/api/sessions/batch");
+		expect(batch).toBeDefined();
+		expect(batchSessions(batch)).toHaveLength(1);
+		// Skill axis was also exercised — proves --all defaults modules
+		// to the full set when --modules isn't passed.
+		const skillUploads = captured.filter((c) => c.path === `/api/scopes/${scopeId}/skills/upload`);
+		expect(skillUploads.length).toBeGreaterThan(0);
+	});
+
+	it("multi-agent push scans every agent then uploads (scan/upload split)", async () => {
+		setup("claude-code");
+		// Two registered agents. The claude-code fixture only has
+		// claude_code session data; codex has an env file but no
+		// session dir — it scans empty. The push must still iterate
+		// both agents (scan phase) and upload the one with data,
+		// without the codex empty-scan aborting the run.
+		writeFileSync(
+			join(tmpHome, ".clawdi", "environments", "codex.json"),
+			JSON.stringify({ id: "env-codex", agentType: "codex" }),
+		);
+		const { captured, restore } = mockFetch([
+			okEnvironmentProbe("env-test"),
+			okEnvironmentProbe("env-codex"),
+			{
+				method: "POST",
+				path: "/api/sessions/batch",
+				response: () => jsonResponse({ created: 1, updated: 0, unchanged: 0, needs_content: [] }),
+			},
+		]);
+		try {
+			await push({ modules: "sessions", all: true, yes: true });
+		} finally {
+			restore();
+		}
+		// Both env probes happened — proof the scan phase visited both
+		// agents before any upload.
+		expect(captured.some((c) => c.path === "/api/environments/env-test")).toBe(true);
+		expect(captured.some((c) => c.path === "/api/environments/env-codex")).toBe(true);
+		// claude_code's session uploaded; codex contributed nothing but
+		// didn't abort the run.
+		const batches = captured.filter((c) => c.path === "/api/sessions/batch");
+		expect(batches).toHaveLength(1);
+		expect(batchSessions(batches[0])).toHaveLength(1);
 	});
 });

--- a/packages/cli/tests/commands/update.test.ts
+++ b/packages/cli/tests/commands/update.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { maybeAutoUpdate, maybeNotifyOutdated, update } from "../../src/commands/update";
+import { maybeAutoUpdate, update } from "../../src/commands/update";
 import { jsonResponse, mockFetch } from "./helpers";
 
 let tmpHome: string;
@@ -106,48 +106,6 @@ describe("update --json", () => {
 		const result = JSON.parse(captured) as { latest: string | null; upgradeAvailable: boolean };
 		expect(result.latest).toBeNull();
 		expect(result.upgradeAvailable).toBe(false);
-	});
-});
-
-describe("maybeNotifyOutdated", () => {
-	it("short-circuits when CLAWDI_NO_UPDATE_CHECK is set", async () => {
-		process.env.CLAWDI_NO_UPDATE_CHECK = "1";
-		const { captured, restore } = mockFetch([]);
-		try {
-			await maybeNotifyOutdated();
-		} finally {
-			restore();
-		}
-		expect(captured).toHaveLength(0);
-	});
-
-	it("short-circuits when stdout is not a TTY", async () => {
-		// In `bun test` stdout.isTTY is typically undefined/false anyway
-		const { captured, restore } = mockFetch([]);
-		try {
-			await maybeNotifyOutdated();
-		} finally {
-			restore();
-		}
-		expect(captured).toHaveLength(0);
-	});
-
-	it("reads from the cache when it is fresh and upgrade is available", async () => {
-		// Force TTY semantics false anyway; this test exercises the cache-read path
-		// indirectly by verifying no fetch fires. In non-TTY env the function
-		// returns early regardless — the important contract is 'no network'.
-		const cachePath = join(tmpHome, ".clawdi", "update.json");
-		writeFileSync(
-			cachePath,
-			JSON.stringify({ checkedAt: new Date().toISOString(), latest: "999.0.0" }),
-		);
-		const { captured, restore } = mockFetch([]);
-		try {
-			await maybeNotifyOutdated();
-		} finally {
-			restore();
-		}
-		expect(captured).toHaveLength(0);
 	});
 });
 


### PR DESCRIPTION
## What

`clawdi push --all` is the canonical "push everything" invocation: `--all` widens every axis — modules, agents, projects — and explicit `--agent` / `--modules` / `--project` still narrow per-axis. `clawdi pull` gets the same treatment. Neither command prompts — there is no confirmation step.

Previously "push everything" needed four flags in a precise combination (`--modules sessions,skills --all-agents --all --yes`); miss one and you'd hit an interactive prompt that blocks agent harnesses, or silently push the wrong scope.

## How

`push` and `pull` share one shape: **scan every agent under a single spinner → one combined per-agent summary → upload/download**. This replaces the old confirm-per-agent flow, which made a multi-agent `clawdi push` look like it had only picked the first agent.

`pushOneAgent` was split into `scanOneAgent` (read-only, returns staged data) + `uploadOneAgent` (write-only); `pull` mirrors it with `scanOneAgent` / `downloadOneAgent`.

## Changes

- `--all` widens modules + agents + projects (was: projects only)
- drop the interactive module multi-select — default to all modules
- multi-agent with no flag targets all registered agents (no prompt, no abort)
- scan all agents under one spinner, show one combined per-agent summary
- skills are cache-filtered in the **scan** phase, so the summary's skill count reflects what will actually upload (matches sessions)
- **remove the `Proceed?` confirmation from push/pull** — these are non-destructive syncs to your own private cloud account (server hash-dedup, lock cache, dashboard deletion); `git push` doesn't confirm either. The combined summary + `--dry-run` is the review surface.
- **remove the now-vestigial `-y, --yes` flag from push/pull** — with no confirmation it would just be a compat shim. `setup` / `teardown` / `skill add` / `skill install` keep `--yes`; they still have real confirmations (destructive / third-party-code / config-modifying).
- **fix:** `--all --project X` now narrows to project X (was silently ignored)
- remove dead code: `update.ts` `maybeNotifyOutdated`, `skill install --list` (unimplemented "planned" flag), unused module-constant fields
- bump CLI to 0.5.9; `docs/` + onboarding skill (`apps/web/public/skill.md`) updated to the new flag set

## Test plan

- `bun run typecheck` + `bun run check` — clean
- `bun --filter @clawdi/cli test` — 272/272 pass, incl. new coverage for the `--all` fan-out, multi-agent scan/upload, and the skill cache-skip round-trip
- manual: `clawdi push --all --dry-run`, `push --all --project ~/x --dry-run`, `pull --all --dry-run` — zero prompts in a TTY

🤖 Generated with [Claude Code](https://claude.com/claude-code)