### PR TITLE
Add Paseo worktree config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__/
 .env
 .env.local
 .clawdi.env
+.paseo/
 
 # File Store (local dev)
 data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,15 @@
-name: clawdi-dev
+name: ${COMPOSE_PROJECT_NAME:-clawdi-dev}
 
 # Dev-only infrastructure. Brings up a Postgres 16 image with pgvector +
 # pg_trgm so local dev doesn't have to install those extensions by hand.
 #
+# Paseo overrides COMPOSE_PROJECT_NAME and INFRA_POSTGRES_PORT per worktree.
+# Outside Paseo, this preserves the repo's normal 5433 dev port.
+#
 # Usage:
-#   docker compose up -d            # start postgres in the background
-#   docker compose down             # stop (keeps data volume)
-#   docker compose down -v          # stop AND wipe the data volume
+#   docker compose up -d postgres            # start postgres in the background
+#   docker compose down                      # stop (keeps data volume)
+#   docker compose down -v                   # stop AND wipe the data volume
 #
 # The backend itself runs locally via `pdm dev` — this file intentionally
 # does NOT bake a backend container for dev, because you want hot reload
@@ -19,18 +22,17 @@ services:
     # the upstream postgres image, so pg_trgm is still available via the
     # standard `CREATE EXTENSION` call wired in app/core/database.py.
     image: pgvector/pgvector:pg16
-    container_name: clawdi-pg
     restart: unless-stopped
     environment:
-      POSTGRES_DB: clawdi
-      POSTGRES_USER: clawdi
-      POSTGRES_PASSWORD: clawdi_dev
+      POSTGRES_DB: ${INFRA_POSTGRES_DB:-clawdi}
+      POSTGRES_USER: ${INFRA_POSTGRES_USER:-clawdi}
+      POSTGRES_PASSWORD: ${INFRA_POSTGRES_PASSWORD:-clawdi_dev}
     ports:
-      - "5433:5432"
+      - "${INFRA_POSTGRES_HOST:-127.0.0.1}:${INFRA_POSTGRES_PORT:-5433}:5432"
     volumes:
       - pg_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U clawdi -d clawdi"]
+      test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/paseo.json
+++ b/paseo.json
@@ -1,0 +1,68 @@
+{
+	"worktree": {
+		"setup": [
+			"command -v bun >/dev/null || { echo 'bun is required. Install Bun >= 1.3 before creating a Paseo worktree.'; exit 1; }",
+			"command -v uv >/dev/null || { echo 'uv is required for backend dependencies.'; exit 1; }",
+			"bun install --frozen-lockfile",
+			"cd backend && uv sync --all-groups",
+			"if [ -f \"$PASEO_SOURCE_CHECKOUT_PATH/apps/web/.env.local\" ]; then cp \"$PASEO_SOURCE_CHECKOUT_PATH/apps/web/.env.local\" apps/web/.env.local; elif [ -f \"$PASEO_SOURCE_CHECKOUT_PATH/apps/web/.env\" ]; then cp \"$PASEO_SOURCE_CHECKOUT_PATH/apps/web/.env\" apps/web/.env.local; elif [ -f apps/web/.env.example ]; then cp apps/web/.env.example apps/web/.env.local; fi",
+			"if [ -f \"$PASEO_SOURCE_CHECKOUT_PATH/backend/.env\" ]; then cp \"$PASEO_SOURCE_CHECKOUT_PATH/backend/.env\" backend/.env; elif [ -f backend/.env.example ]; then cp backend/.env.example backend/.env; fi",
+			"python3 - <<'PY'\nfrom pathlib import Path\nimport os\npath = Path('backend/.env')\nif path.exists():\n    lines = path.read_text().splitlines()\n    changed = False\n    for key in ('VAULT_ENCRYPTION_KEY', 'ENCRYPTION_KEY'):\n        if any(line.startswith(f'{key}=') and line.split('=', 1)[1].strip() for line in lines):\n            continue\n        token = os.urandom(32).hex()\n        for i, line in enumerate(lines):\n            if line.startswith(f'{key}='):\n                lines[i] = f'{key}={token}'\n                changed = True\n                break\n        else:\n            lines.append(f'{key}={token}')\n            changed = True\n    if changed:\n        path.write_text('\\n'.join(lines) + '\\n')\nPY"
+		],
+		"teardown": [
+			"rm -rf .turbo apps/web/.next apps/web/next-env.d.ts packages/cli/dist backend/.pytest_cache backend/.ruff_cache backend/.venv .pytest_cache"
+		]
+	},
+	"scripts": {
+		"web": {
+			"type": "service",
+			"command": "cd apps/web && NEXT_PUBLIC_API_URL=\"${PASEO_SERVICE_API_URL:-http://localhost:8000}\" bun run dev -- --hostname \"${HOST:-127.0.0.1}\" --port \"$PASEO_PORT\""
+		},
+		"api": {
+			"type": "service",
+			"command": "cd backend && DEBUG=true PUBLIC_API_URL=\"$PASEO_URL\" WEB_ORIGIN=\"${PASEO_SERVICE_WEB_URL:-http://localhost:3000}\" CORS_ORIGINS=\"[\\\"${PASEO_SERVICE_WEB_URL:-http://localhost:3000}\\\"]\" uv run uvicorn app.main:app --reload --host \"${HOST:-127.0.0.1}\" --port \"$PASEO_PORT\""
+		},
+		"install": {
+			"command": "bun install --frozen-lockfile && cd backend && uv sync --all-groups"
+		},
+		"infra:up": {
+			"command": "docker compose up -d postgres"
+		},
+		"infra:down": {
+			"command": "docker compose down"
+		},
+		"migrate": {
+			"command": "cd backend && uv run alembic upgrade head"
+		},
+		"generate-api": {
+			"command": "API_URL=\"${API_URL:-http://localhost:8000}\"; bun x openapi-typescript \"$API_URL/openapi.json\" -o packages/shared/src/api/api.generated.ts"
+		},
+		"typecheck": {
+			"command": "bun run typecheck"
+		},
+		"test": {
+			"command": "bun run test && cd backend && uv run pytest -q"
+		},
+		"check": {
+			"command": "bun run check && cd backend && uv run ruff check ."
+		},
+		"lint": {
+			"command": "bun run lint && cd backend && uv run ruff check ."
+		},
+		"build": {
+			"command": "bun run build"
+		},
+		"backend:test": {
+			"command": "cd backend && uv run pytest -q"
+		},
+		"backend:lint": {
+			"command": "cd backend && uv run ruff check ."
+		},
+		"cli:test": {
+			"command": "cd packages/cli && bun test"
+		},
+		"cli:build": {
+			"command": "cd packages/cli && bun run build:dev"
+		}
+	}
+}

--- a/paseo.json
+++ b/paseo.json
@@ -1,68 +1,11 @@
 {
 	"worktree": {
-		"setup": [
-			"command -v bun >/dev/null || { echo 'bun is required. Install Bun >= 1.3 before creating a Paseo worktree.'; exit 1; }",
-			"command -v uv >/dev/null || { echo 'uv is required for backend dependencies.'; exit 1; }",
-			"bun install --frozen-lockfile",
-			"cd backend && uv sync --all-groups",
-			"if [ -f \"$PASEO_SOURCE_CHECKOUT_PATH/apps/web/.env.local\" ]; then cp \"$PASEO_SOURCE_CHECKOUT_PATH/apps/web/.env.local\" apps/web/.env.local; elif [ -f \"$PASEO_SOURCE_CHECKOUT_PATH/apps/web/.env\" ]; then cp \"$PASEO_SOURCE_CHECKOUT_PATH/apps/web/.env\" apps/web/.env.local; elif [ -f apps/web/.env.example ]; then cp apps/web/.env.example apps/web/.env.local; fi",
-			"if [ -f \"$PASEO_SOURCE_CHECKOUT_PATH/backend/.env\" ]; then cp \"$PASEO_SOURCE_CHECKOUT_PATH/backend/.env\" backend/.env; elif [ -f backend/.env.example ]; then cp backend/.env.example backend/.env; fi",
-			"python3 - <<'PY'\nfrom pathlib import Path\nimport os\npath = Path('backend/.env')\nif path.exists():\n    lines = path.read_text().splitlines()\n    changed = False\n    for key in ('VAULT_ENCRYPTION_KEY', 'ENCRYPTION_KEY'):\n        if any(line.startswith(f'{key}=') and line.split('=', 1)[1].strip() for line in lines):\n            continue\n        token = os.urandom(32).hex()\n        for i, line in enumerate(lines):\n            if line.startswith(f'{key}='):\n                lines[i] = f'{key}={token}'\n                changed = True\n                break\n        else:\n            lines.append(f'{key}={token}')\n            changed = True\n    if changed:\n        path.write_text('\\n'.join(lines) + '\\n')\nPY"
-		],
-		"teardown": [
-			"rm -rf .turbo apps/web/.next apps/web/next-env.d.ts packages/cli/dist backend/.pytest_cache backend/.ruff_cache backend/.venv .pytest_cache"
-		]
+		"setup": ["bash scripts/paseo/setup.sh"],
+		"teardown": ["bash scripts/paseo/teardown.sh"]
 	},
 	"scripts": {
-		"web": {
-			"type": "service",
-			"command": "cd apps/web && NEXT_PUBLIC_API_URL=\"${PASEO_SERVICE_API_URL:-http://localhost:8000}\" bun run dev -- --hostname \"${HOST:-127.0.0.1}\" --port \"$PASEO_PORT\""
-		},
-		"api": {
-			"type": "service",
-			"command": "cd backend && DEBUG=true PUBLIC_API_URL=\"$PASEO_URL\" WEB_ORIGIN=\"${PASEO_SERVICE_WEB_URL:-http://localhost:3000}\" CORS_ORIGINS=\"[\\\"${PASEO_SERVICE_WEB_URL:-http://localhost:3000}\\\"]\" uv run uvicorn app.main:app --reload --host \"${HOST:-127.0.0.1}\" --port \"$PASEO_PORT\""
-		},
-		"install": {
-			"command": "bun install --frozen-lockfile && cd backend && uv sync --all-groups"
-		},
-		"infra:up": {
-			"command": "docker compose up -d postgres"
-		},
-		"infra:down": {
-			"command": "docker compose down"
-		},
-		"migrate": {
-			"command": "cd backend && uv run alembic upgrade head"
-		},
-		"generate-api": {
-			"command": "API_URL=\"${API_URL:-http://localhost:8000}\"; bun x openapi-typescript \"$API_URL/openapi.json\" -o packages/shared/src/api/api.generated.ts"
-		},
-		"typecheck": {
-			"command": "bun run typecheck"
-		},
-		"test": {
-			"command": "bun run test && cd backend && uv run pytest -q"
-		},
-		"check": {
-			"command": "bun run check && cd backend && uv run ruff check ."
-		},
-		"lint": {
-			"command": "bun run lint && cd backend && uv run ruff check ."
-		},
-		"build": {
-			"command": "bun run build"
-		},
-		"backend:test": {
-			"command": "cd backend && uv run pytest -q"
-		},
-		"backend:lint": {
-			"command": "cd backend && uv run ruff check ."
-		},
-		"cli:test": {
-			"command": "cd packages/cli && bun test"
-		},
-		"cli:build": {
-			"command": "cd packages/cli && bun run build:dev"
+		"dev": {
+			"command": "bash scripts/paseo/dev.sh"
 		}
 	}
 }

--- a/scripts/paseo/common.sh
+++ b/scripts/paseo/common.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+require_paseo_setup() {
+  local missing=()
+
+  [ -f .paseo/ports.env ] || missing+=(".paseo/ports.env")
+  [ -f apps/web/.env.local ] || missing+=("apps/web/.env.local")
+  [ -f backend/.env ] || missing+=("backend/.env")
+
+  if [ "${#missing[@]}" -gt 0 ]; then
+    echo "Paseo setup has not been run for this worktree." >&2
+    echo "Missing: ${missing[*]}" >&2
+    echo "Run: bash scripts/paseo/setup.sh" >&2
+    exit 1
+  fi
+}
+
+load_paseo_ports() {
+  if [ -f .paseo/ports.env ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . .paseo/ports.env
+    set +a
+  fi
+
+  DEV_PORT="${DEV_PORT:-${WEB_PORT:-3000}}"
+  WEB_PORT="${WEB_PORT:-$DEV_PORT}"
+  BACKEND_PORT="${BACKEND_PORT:-$((WEB_PORT + 1))}"
+  PG_PORT="${PG_PORT:-$((WEB_PORT + 2))}"
+  COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-clawdi-cloud-${WEB_PORT}}"
+}
+
+json_string_array() {
+  python3 - "$@" <<'PY'
+import json
+import sys
+
+seen = set()
+values = []
+for value in sys.argv[1:]:
+    value = value.strip()
+    if not value or value in seen:
+        continue
+    seen.add(value)
+    values.append(value)
+
+print(json.dumps(values, separators=(",", ":")))
+PY
+}
+
+run_backend_migrations() {
+  (cd backend && DATABASE_URL="$DATABASE_URL" uv run alembic upgrade head)
+}

--- a/scripts/paseo/dev.sh
+++ b/scripts/paseo/dev.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# shellcheck source=scripts/paseo/common.sh
+. "$SCRIPT_DIR/common.sh"
+require_paseo_setup
+load_paseo_ports
+
+WEB_RUNTIME_PORT="${WEB_PORT}"
+BACKEND_RUNTIME_PORT="${BACKEND_PORT}"
+WEB_BIND_HOST="${HOST:-0.0.0.0}"
+API_BIND_HOST="${HOST:-0.0.0.0}"
+WEB_URL="${WEB_PUBLIC_URL:-http://localhost:${WEB_RUNTIME_PORT}}"
+API_URL="${API_PUBLIC_URL:-http://localhost:${BACKEND_RUNTIME_PORT}}"
+CORS_ORIGINS="$(
+  json_string_array \
+    "$WEB_URL" \
+    "http://localhost:${WEB_RUNTIME_PORT}" \
+    "http://127.0.0.1:${WEB_RUNTIME_PORT}"
+)"
+DATABASE_URL="postgresql+asyncpg://clawdi:clawdi_dev@127.0.0.1:${PG_PORT}/clawdi"
+
+export COMPOSE_PROJECT_NAME
+export INFRA_POSTGRES_HOST=127.0.0.1
+export INFRA_POSTGRES_PORT="${PG_PORT}"
+export INFRA_POSTGRES_DB=clawdi
+export INFRA_POSTGRES_USER=clawdi
+export INFRA_POSTGRES_PASSWORD=clawdi_dev
+
+export DATABASE_URL
+export DEBUG=true
+export PUBLIC_API_URL="$API_URL"
+export WEB_ORIGIN="$WEB_URL"
+export CORS_ORIGINS
+export NEXT_PUBLIC_API_URL="$API_URL"
+
+docker compose up -d --wait postgres
+run_backend_migrations
+
+pids=()
+
+cleanup() {
+  trap - EXIT INT TERM
+  if [ "${#pids[@]}" -gt 0 ]; then
+    kill "${pids[@]}" >/dev/null 2>&1 || true
+    wait "${pids[@]}" >/dev/null 2>&1 || true
+  fi
+  docker compose down >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+(
+  cd apps/web
+  NEXT_PUBLIC_API_URL="$API_URL" bun run dev -- --hostname "$WEB_BIND_HOST" --port "$WEB_RUNTIME_PORT"
+) &
+pids+=("$!")
+
+(
+  cd backend
+  DATABASE_URL="$DATABASE_URL" \
+    DEBUG=true \
+    PUBLIC_API_URL="$API_URL" \
+    WEB_ORIGIN="$WEB_URL" \
+    CORS_ORIGINS="$CORS_ORIGINS" \
+    uv run uvicorn app.main:app --reload --host "$API_BIND_HOST" --port "$BACKEND_RUNTIME_PORT"
+) &
+pids+=("$!")
+
+set +e
+wait -n "${pids[@]}"
+status=$?
+set -e
+exit "$status"

--- a/scripts/paseo/setup.sh
+++ b/scripts/paseo/setup.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# shellcheck source=scripts/paseo/common.sh
+. "$SCRIPT_DIR/common.sh"
+
+WORKSPACE="${PASEO_BRANCH_NAME:-$(basename "$REPO_ROOT")}"
+
+find_source_root() {
+  python3 - "$REPO_ROOT" <<'PY'
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+repo_root = Path(sys.argv[1]).resolve()
+override = (
+    os.environ.get("PASEO_SOURCE_CHECKOUT_PATH")
+    or os.environ.get("PASEO_ROOT_PATH")
+)
+
+
+def has_source_env(path: Path) -> bool:
+    return (
+        (path / "backend/.env").is_file()
+        or (path / "apps/web/.env.local").is_file()
+        or (path / "apps/web/.env").is_file()
+    )
+
+
+if override:
+    print(Path(override).expanduser().resolve())
+    raise SystemExit(0)
+
+if has_source_env(repo_root):
+    print(repo_root)
+    raise SystemExit(0)
+
+try:
+    output = subprocess.check_output(
+        ["git", "-C", str(repo_root), "worktree", "list", "--porcelain"],
+        text=True,
+        stderr=subprocess.DEVNULL,
+    )
+except Exception:
+    print(repo_root)
+    raise SystemExit(0)
+
+for line in output.splitlines():
+    if not line.startswith("worktree "):
+        continue
+    path = Path(line.removeprefix("worktree ")).resolve()
+    if path != repo_root and has_source_env(path):
+        print(path)
+        raise SystemExit(0)
+
+print(repo_root)
+PY
+}
+
+require_command() {
+  local name="$1"
+  local message="$2"
+
+  if ! command -v "$name" >/dev/null 2>&1; then
+    echo "$message" >&2
+    exit 1
+  fi
+}
+
+require_command bun "bun is required. Install Bun >= 1.3 before creating a Paseo worktree."
+require_command node "Node.js is required to run the web app in Paseo."
+require_command uv "uv is required for backend dependencies."
+require_command docker "Docker is required for local PostgreSQL."
+
+if ! node --version >/dev/null 2>&1; then
+  echo "Node.js is required but 'node --version' failed." >&2
+  echo "Fix the local Node/Volta environment before creating a Paseo worktree." >&2
+  exit 1
+fi
+
+if ! docker compose version >/dev/null 2>&1; then
+  echo "docker compose is required for local PostgreSQL." >&2
+  exit 1
+fi
+
+BASE="${PASEO_WORKTREE_PORT:-}"
+if [ -z "$BASE" ]; then
+  echo "PASEO_WORKTREE_PORT is required. Create this workspace with Paseo so it can assign the port." >&2
+  exit 1
+fi
+
+if ! [[ "$BASE" =~ ^[0-9]+$ ]]; then
+  echo "Invalid base port: ${BASE}" >&2
+  exit 1
+fi
+
+WEB_PORT=$((BASE))
+BACKEND_PORT=$((BASE + 1))
+PG_PORT=$((BASE + 2))
+COMPOSE_PROJECT="clawdi-cloud-${BASE}"
+WEB_PUBLIC_URL="${WEB_PUBLIC_URL:-http://localhost:${WEB_PORT}}"
+API_PUBLIC_URL="${API_PUBLIC_URL:-http://localhost:${BACKEND_PORT}}"
+CORS_ORIGINS_VALUE="$(
+  json_string_array \
+    "$WEB_PUBLIC_URL" \
+    "http://localhost:${WEB_PORT}" \
+    "http://127.0.0.1:${WEB_PORT}"
+)"
+
+ROOT="$(find_source_root)"
+
+mkdir -p .paseo
+{
+  printf 'DEV_PORT=%s\n' "$BASE"
+  printf 'WEB_PORT=%s\n' "$WEB_PORT"
+  printf 'BACKEND_PORT=%s\n' "$BACKEND_PORT"
+  printf 'PG_PORT=%s\n' "$PG_PORT"
+  printf 'COMPOSE_PROJECT_NAME=%s\n' "$COMPOSE_PROJECT"
+  printf 'PASEO_WORKTREE_PORT=%s\n' "$BASE"
+  printf 'PASEO_WORKTREE_PATH=%q\n' "$REPO_ROOT"
+  printf 'PASEO_SOURCE_CHECKOUT_PATH=%q\n' "$ROOT"
+  printf 'PASEO_ROOT_PATH=%q\n' "$ROOT"
+  printf 'PASEO_BRANCH_NAME=%q\n' "${PASEO_BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || basename "$REPO_ROOT")}"
+  printf 'WEB_PUBLIC_URL=%q\n' "$WEB_PUBLIC_URL"
+  printf 'API_PUBLIC_URL=%q\n' "$API_PUBLIC_URL"
+} > .paseo/ports.env
+
+cat > .paseo/ports.json <<EOF
+{
+  "ports": [
+    { "port": ${WEB_PORT}, "label": "Frontend Dev Server" },
+    { "port": ${BACKEND_PORT}, "label": "Backend API" },
+    { "port": ${PG_PORT}, "label": "PostgreSQL" }
+  ]
+}
+EOF
+
+first_existing() {
+  local path
+  for path in "$@"; do
+    if [ -f "$path" ]; then
+      printf '%s\n' "$path"
+      return 0
+    fi
+  done
+  return 1
+}
+
+write_env_file() {
+  local source_env="$1"
+  local example_env="$2"
+  local target_env="$3"
+  local overrides="$4"
+
+  SOURCE_ENV="$source_env" \
+  EXAMPLE_ENV="$example_env" \
+  TARGET_ENV="$target_env" \
+  OVERRIDES="$overrides" \
+  python3 <<'PY'
+import os
+import re
+from pathlib import Path
+
+source_path = Path(os.environ["SOURCE_ENV"]) if os.environ["SOURCE_ENV"] else None
+example_path = Path(os.environ["EXAMPLE_ENV"])
+target_path = Path(os.environ["TARGET_ENV"])
+overrides_raw = os.environ.get("OVERRIDES", "")
+key_re = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=")
+
+
+def parse_env(path):
+    if path is None or not path.exists():
+        return {}
+
+    lines = path.read_text().splitlines()
+    values = {}
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if not line.strip() or line.lstrip().startswith("#"):
+            i += 1
+            continue
+
+        match = key_re.match(line)
+        if not match:
+            i += 1
+            continue
+
+        key = match.group(1)
+        value = line.split("=", 1)[1]
+        if value.startswith('"') and not value.endswith('"'):
+            i += 1
+            while i < len(lines):
+                value += "\n" + lines[i]
+                if lines[i].endswith('"'):
+                    break
+                i += 1
+
+        values[key] = value
+        i += 1
+
+    return values
+
+
+values = parse_env(source_path)
+for line in overrides_raw.splitlines():
+    if not line or "=" not in line:
+        continue
+    key, value = line.split("=", 1)
+    values[key] = value
+
+if not example_path.exists():
+    raise SystemExit(f"Missing env example: {example_path}")
+
+example_lines = example_path.read_text().splitlines()
+output = []
+seen = set()
+i = 0
+while i < len(example_lines):
+    line = example_lines[i]
+    match = key_re.match(line)
+    if match and match.group(1) in values:
+        key = match.group(1)
+        output.append(f"{key}={values[key]}")
+        seen.add(key)
+
+        old_value = line.split("=", 1)[1]
+        if old_value.startswith('"') and not old_value.endswith('"'):
+            i += 1
+            while i < len(example_lines):
+                if example_lines[i].endswith('"'):
+                    break
+                i += 1
+        i += 1
+        continue
+
+    output.append(line)
+    i += 1
+
+for key, value in values.items():
+    if key not in seen:
+        output.append(f"{key}={value}")
+
+target_path.parent.mkdir(parents=True, exist_ok=True)
+target_path.write_text("\n".join(output).rstrip() + "\n")
+PY
+}
+
+backend_source_env="$(first_existing "$ROOT/backend/.env" || true)"
+backend_overrides="$(cat <<EOF
+DATABASE_URL=postgresql+asyncpg://clawdi:clawdi_dev@127.0.0.1:${PG_PORT}/clawdi
+CORS_ORIGINS=${CORS_ORIGINS_VALUE}
+PUBLIC_API_URL=${API_PUBLIC_URL}
+WEB_ORIGIN=${WEB_PUBLIC_URL}
+EOF
+)"
+write_env_file "$backend_source_env" backend/.env.example backend/.env "$backend_overrides"
+
+python3 <<'PY'
+from pathlib import Path
+import os
+
+path = Path("backend/.env")
+lines = path.read_text().splitlines()
+changed = False
+for key in ("VAULT_ENCRYPTION_KEY", "ENCRYPTION_KEY"):
+    if any(line.startswith(f"{key}=") and line.split("=", 1)[1].strip() for line in lines):
+        continue
+    token = os.urandom(32).hex()
+    for index, line in enumerate(lines):
+        if line.startswith(f"{key}="):
+            lines[index] = f"{key}={token}"
+            changed = True
+            break
+    else:
+        lines.append(f"{key}={token}")
+        changed = True
+
+if changed:
+    path.write_text("\n".join(lines) + "\n")
+PY
+
+web_source_env="$(first_existing "$ROOT/apps/web/.env.local" "$ROOT/apps/web/.env" || true)"
+web_overrides="$(cat <<EOF
+NEXT_PUBLIC_API_URL=${API_PUBLIC_URL}
+EOF
+)"
+write_env_file "$web_source_env" apps/web/.env.example apps/web/.env.local "$web_overrides"
+
+echo "Clawdi ports for Paseo workspace '${WORKSPACE}' (base=${BASE}):"
+echo "  Web:        ${WEB_PORT}"
+echo "  Backend:    ${BACKEND_PORT}"
+echo "  PostgreSQL: ${PG_PORT}"
+
+bun install --frozen-lockfile
+(cd backend && uv sync --all-groups)
+
+echo "Setup complete. Run 'bash scripts/paseo/dev.sh' to start infra and app services."

--- a/scripts/paseo/teardown.sh
+++ b/scripts/paseo/teardown.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+if [ -f .paseo/ports.env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . .paseo/ports.env
+  set +a
+fi
+
+COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-clawdi-cloud-${PASEO_WORKTREE_PORT:-$(basename "$REPO_ROOT")}}"
+INFRA_POSTGRES_PORT="${PG_PORT:-1}" COMPOSE_PROJECT_NAME="$COMPOSE_PROJECT_NAME" docker compose down -v --remove-orphans || true


### PR DESCRIPTION
## Summary
- Keep `paseo.json` as a thin repo-root entrypoint that delegates setup, teardown, and dev lifecycle to `scripts/paseo/*`.
- Add Paseo worktree setup that derives per-worktree web/backend/Postgres ports, writes `.paseo/ports.env` and `.paseo/ports.json`, copies local env files from the source checkout, and applies worktree-specific DB/CORS/public URL overrides.
- Make the root Docker Compose Postgres service work for both normal local dev and isolated Paseo worktrees by parameterizing project name and host port while preserving the default `5433` local flow.
- Add a dev runner that starts Postgres, runs backend migrations, launches web/backend services, and cleans up the compose project on exit.

## Design Notes
- Mirrors the Clawdi monorepo pattern: keep Paseo config declarative and move lifecycle logic into scripts.
- Scoped to this repo's actual infra: Postgres only, no Redis, no `backend/infra.env`, no Payload-specific env or seed logic.
- Defaults are generic `localhost` / `127.0.0.1`; there are no machine-specific hostnames or Volta workarounds in repo config.
- Setup gates the tools this repo actually needs: Bun, Node, uv, Docker Compose.

## Verification
- `bun run check`
- `python3 -m json.tool paseo.json`
- `bash -n scripts/paseo/setup.sh scripts/paseo/common.sh scripts/paseo/dev.sh scripts/paseo/teardown.sh`
- `docker compose config`
- `COMPOSE_PROJECT_NAME=clawdi-cloud-49200 INFRA_POSTGRES_PORT=49202 docker compose config`
- `git diff --check`
- Isolated setup smoke test with mocked `bun`, `node`, `uv`, and `docker` binaries verifying generated ports/env files.
