### PR TITLE
Fix shared project vault value resolution

### DIFF
--- a/backend/app/core/project.py
+++ b/backend/app/core/project.py
@@ -234,6 +234,44 @@ async def validate_project_read_for_caller(
     return project_id
 
 
+async def project_ids_readable_by_user(
+    db: AsyncSession,
+    user_id: UUID,
+) -> list[UUID]:
+    """Return owned + shared Project ids for a user.
+
+    This is the account-level read set. `project_ids_visible_to`
+    wraps it with auth-token blast-radius constraints for env-bound
+    Agent keys.
+    """
+    from app.models.project_membership import ProjectMembership
+
+    owned_ids = list(
+        (await db.execute(select(Project.id).where(Project.user_id == user_id))).scalars().all()
+    )
+    shared_ids = list(
+        (
+            await db.execute(
+                select(ProjectMembership.project_id).where(
+                    ProjectMembership.member_user_id == user_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    # Owned ordering preserved; shared appended deterministically.
+    # Membership rows could in theory dupe an owned project (e.g. if
+    # a stale row survived an ownership transfer); de-dup defensively.
+    seen = set(owned_ids)
+    result_ids = list(owned_ids)
+    for sid in shared_ids:
+        if sid not in seen:
+            result_ids.append(sid)
+            seen.add(sid)
+    return result_ids
+
+
 async def project_ids_visible_to(
     db: AsyncSession,
     auth: AuthContext,
@@ -272,34 +310,5 @@ async def project_ids_visible_to(
         return [env_project]
 
     # Clerk JWT and unbound CLI key: owned projects UNION projects the
-    # user joined as a viewer member. Two separate queries (one
-    # owned, one shared) keeps the SQL readable; both hit indexed
-    # columns and run sub-millisecond.
-    from app.models.project_membership import ProjectMembership
-
-    owned_ids = list(
-        (await db.execute(select(Project.id).where(Project.user_id == auth.user_id)))
-        .scalars()
-        .all()
-    )
-    shared_ids = list(
-        (
-            await db.execute(
-                select(ProjectMembership.project_id).where(
-                    ProjectMembership.member_user_id == auth.user_id
-                )
-            )
-        )
-        .scalars()
-        .all()
-    )
-    # Owned ordering preserved; shared appended deterministically.
-    # Membership rows could in theory dupe an owned project (e.g. if
-    # a stale row survived an ownership transfer); de-dup defensively.
-    seen = set(owned_ids)
-    result_ids = list(owned_ids)
-    for sid in shared_ids:
-        if sid not in seen:
-            result_ids.append(sid)
-            seen.add(sid)
-    return result_ids
+    # user joined as a member.
+    return await project_ids_readable_by_user(db, auth.user_id)

--- a/backend/app/routes/vault.py
+++ b/backend/app/routes/vault.py
@@ -424,10 +424,10 @@ async def resolve_vault(
 ) -> dict:
     """Resolve all vault items to plaintext. CLI-only (requires ApiKey auth).
 
-    User-level CLI auth can resolve shared Project plaintext because Project
-    membership grants read access. A bound Agent API key is capped to its
-    default-write Project unless resolving through its own `agent_id`, where
-    the Agent Project plus explicit attached Projects define runtime reads.
+    Project membership grants CLI/API-key callers read access to vault values.
+    A bound Agent API key is capped to its default-write Project unless
+    resolving through its own `agent_id`, where the Agent Project plus explicit
+    attached Projects define runtime reads.
     """
     if project_id is not None and agent_id is not None:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "pass project_id or agent_id, not both")

--- a/backend/app/routes/vault.py
+++ b/backend/app/routes/vault.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.auth import AuthContext, require_user_auth, require_user_cli
 from app.core.database import get_session
 from app.core.project import (
+    project_ids_readable_by_user,
     project_ids_visible_to,
     resolve_default_write_project,
     resolve_for_parent,
@@ -56,9 +57,8 @@ async def list_vaults(
     # Dropped the `Vault.user_id == auth.user_id` filter that was
     # here pre-sharing — it would have blocked viewer members from
     # seeing shared-project vault slugs (and the key names inside).
-    # Plaintext resolution (`/api/vault/resolve`) keeps the
-    # Clerk-auth-only gate so a leaked anonymous share-token can't
-    # exfiltrate secrets.
+    # Plaintext resolution (`/api/vault/resolve`) keeps the CLI/API-key
+    # gate so a leaked anonymous share-token can't exfiltrate secrets.
     selected_project_id = project_id
     if selected_project_id is not None:
         visible_project_ids = list(await resolve_for_parent(db, auth, selected_project_id))
@@ -271,24 +271,16 @@ def _env_key(section: str, item_name: str) -> str:
 async def _plaintext_project_ids(db: AsyncSession, auth: AuthContext) -> list[UUID]:
     """Projects whose vault plaintext may be resolved by this CLI caller.
 
-    Shared memberships intentionally do not participate here. Shared project
-    viewers may see vault metadata/key names through read APIs, but plaintext
-    resolution is owner-only.
+    User-level CLI auth can read vault plaintext for every Project the
+    account can read, including shared Projects. Env-bound Agent keys stay
+    capped to their default Project unless the caller resolves through the
+    matching Agent runtime boundary (`agent_id`), where explicit Project
+    attachments define the read set.
     """
     if auth.is_cli and auth.api_key is not None and auth.api_key.environment_id is not None:
         return [await resolve_default_write_project(db, auth)]
 
-    return list(
-        (
-            await db.execute(
-                select(Project.id).where(
-                    Project.user_id == auth.user_id,
-                )
-            )
-        )
-        .scalars()
-        .all()
-    )
+    return await project_ids_readable_by_user(db, auth.user_id)
 
 
 async def _project_precedence(
@@ -333,7 +325,12 @@ async def _agent_project_precedence(
         raise HTTPException(status.HTTP_403_FORBIDDEN, "api key bound to a different agent")
 
     agent = await get_owned_agent_or_404(db, user_id=auth.user_id, agent_id=agent_id)
-    allowed = set(await _plaintext_project_ids(db, auth))
+    # Agent runtime reads are computed at the Agent boundary: the key
+    # must either be user-level or bound to this exact Agent, then the
+    # explicit primary/context bindings decide which Projects participate.
+    # This lets attached shared Projects contribute vault env values while
+    # preserving the bound-key blast radius: no attachment, no access.
+    allowed = set(await project_ids_readable_by_user(db, auth.user_id))
     rows = (
         await db.execute(
             select(AgentProjectBinding, Project)
@@ -427,9 +424,10 @@ async def resolve_vault(
 ) -> dict:
     """Resolve all vault items to plaintext. CLI-only (requires ApiKey auth).
 
-    Plaintext is owner-only. Shared project memberships widen metadata/read
-    surfaces, but never decrypt another user's vault values. A bound Agent API
-    key is further capped to its default-write project.
+    User-level CLI auth can resolve shared Project plaintext because Project
+    membership grants read access. A bound Agent API key is capped to its
+    default-write Project unless resolving through its own `agent_id`, where
+    the Agent Project plus explicit attached Projects define runtime reads.
     """
     if project_id is not None and agent_id is not None:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "pass project_id or agent_id, not both")

--- a/backend/tests/test_project_visibility_shared.py
+++ b/backend/tests/test_project_visibility_shared.py
@@ -1,7 +1,7 @@
 """project_ids_visible_to widens to include shared memberships for
-Clerk JWT + unbound-CLI callers. Agent API keys keep their
-single-project ceiling regardless of memberships (deploy-key blast
-radius boundary)."""
+Clerk JWT + unbound-CLI callers. Env-bound Agent API keys keep their
+single-project ceiling on explicit project reads, but may read attached
+shared Projects through the matching Agent runtime boundary."""
 
 import uuid
 from datetime import UTC, datetime
@@ -278,12 +278,12 @@ async def test_recipient_viewer_cannot_write_shared_project_resources(
 
 
 @pytest.mark.asyncio
-async def test_recipient_cli_cannot_resolve_shared_project_vault_plaintext(
+async def test_recipient_cli_resolves_shared_project_vault_plaintext(
     cli_client,
     db_session,
     seed_user,
 ):
-    """Unbound CLI keys may read shared metadata, but not owner plaintext."""
+    """Unbound CLI keys may resolve shared Project vault plaintext."""
     from app.models.agent_project_binding import AgentProjectBinding
     from app.models.project import PROJECT_KIND_WORKSPACE, Project
     from app.models.project_membership import ProjectMembership
@@ -359,15 +359,148 @@ async def test_recipient_cli_cannot_resolve_shared_project_vault_plaintext(
 
     try:
         explicit = await cli_client.post(f"/api/vault/resolve?key=TOKEN&project_id={shared.id}")
-        assert explicit.status_code == 404, explicit.text
+        assert explicit.status_code == 200, explicit.text
+        explicit_body = explicit.json()
+        assert explicit_body["value"] == "owner-secret-value"
+        assert explicit_body["source_project_id"] == str(shared.id)
 
         attached_key = await cli_client.post(f"/api/vault/resolve?key=TOKEN&agent_id={env.id}")
-        assert attached_key.status_code == 404, attached_key.text
+        assert attached_key.status_code == 200, attached_key.text
+        attached_body = attached_key.json()
+        assert attached_body["value"] == "owner-secret-value"
+        assert attached_body["source_binding_type"] == "context"
 
         attached_env = await cli_client.post(f"/api/vault/resolve?agent_id={env.id}")
         assert attached_env.status_code == 200, attached_env.text
-        assert "TOKEN" not in attached_env.json()
+        assert attached_env.json()["TOKEN"] == "owner-secret-value"
     finally:
+        await db_session.delete(shared)
+        await db_session.delete(owner)
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_env_bound_agent_key_resolves_attached_shared_project_vault_plaintext(
+    db_session,
+    seed_user,
+):
+    """A bound Agent key can resolve shared Project vault plaintext only
+    through its own Agent attachment boundary."""
+    import httpx
+    from httpx import ASGITransport
+
+    from app.core.auth import get_auth
+    from app.core.database import get_session
+    from app.main import app
+    from app.models.agent_project_binding import AgentProjectBinding
+    from app.models.api_key import ApiKey
+    from app.models.project import PROJECT_KIND_WORKSPACE, Project
+    from app.models.project_membership import ProjectMembership
+    from app.models.user import User
+    from app.models.vault import Vault, VaultItem
+    from app.services.vault_crypto import encrypt
+    from tests.conftest import create_env_with_project
+
+    nonce = uuid.uuid4().hex[:8]
+    owner = User(
+        clerk_id=f"bound_vo_{nonce}",
+        email=f"bound_vo_{nonce}@test.dev",
+        name="Bound Vault Owner",
+    )
+    db_session.add(owner)
+    await db_session.flush()
+
+    shared = Project(
+        user_id=owner.id,
+        name="shared agent vault boundary",
+        slug=f"shared-agent-vault-boundary-{nonce}",
+        kind=PROJECT_KIND_WORKSPACE,
+    )
+    db_session.add(shared)
+    await db_session.flush()
+    db_session.add(
+        ProjectMembership(
+            project_id=shared.id,
+            member_user_id=seed_user.id,
+            role="viewer",
+            joined_via="link",
+            joined_at=datetime.now(UTC),
+            resolved_owner_handle=f"bound-vo-{nonce}",
+        )
+    )
+
+    vault = Vault(
+        user_id=owner.id,
+        project_id=shared.id,
+        slug=f"owner-agent-secret-{nonce}",
+        name="Owner Agent Secret",
+    )
+    db_session.add(vault)
+    await db_session.flush()
+    ciphertext, nonce_bytes = encrypt("attached-secret-value")
+    db_session.add(
+        VaultItem(
+            vault_id=vault.id,
+            section="",
+            item_name="TOKEN",
+            encrypted_value=ciphertext,
+            nonce=nonce_bytes,
+        )
+    )
+
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"bound-viewer-{nonce}",
+        machine_name="Bound Viewer Agent",
+    )
+    db_session.add(
+        AgentProjectBinding(
+            agent_id=env.id,
+            project_id=shared.id,
+            binding_type="context",
+            priority=1,
+            default_write_enabled=False,
+            created_by_user_id=seed_user.id,
+        )
+    )
+    api_key = ApiKey(
+        user_id=seed_user.id,
+        key_hash=("b" + nonce + "x" * (64 - len(nonce) - 1)),
+        key_prefix=f"clawdi_b{nonce[:3]}",
+        label="bound-agent",
+        environment_id=env.id,
+        scopes=None,
+    )
+    db_session.add(api_key)
+    await db_session.commit()
+
+    async def _override_get_session():
+        yield db_session
+
+    async def _override_get_auth():
+        return AuthContext(user=seed_user, api_key=api_key)
+
+    app.dependency_overrides[get_session] = _override_get_session
+    app.dependency_overrides[get_auth] = _override_get_auth
+    try:
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as ac:
+            explicit = await ac.post(f"/api/vault/resolve?key=TOKEN&project_id={shared.id}")
+            assert explicit.status_code == 404, explicit.text
+
+            attached_key = await ac.post(f"/api/vault/resolve?key=TOKEN&agent_id={env.id}")
+            assert attached_key.status_code == 200, attached_key.text
+            assert attached_key.json()["value"] == "attached-secret-value"
+
+            attached_env = await ac.post(f"/api/vault/resolve?agent_id={env.id}")
+            assert attached_env.status_code == 200, attached_env.text
+            assert attached_env.json()["TOKEN"] == "attached-secret-value"
+    finally:
+        app.dependency_overrides.clear()
+        await db_session.delete(api_key)
         await db_session.delete(shared)
         await db_session.delete(owner)
         await db_session.commit()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,7 +58,7 @@ All keyed off Clerk `user_id`:
 | `agent_project_bindings` | Runtime Agent composition: one fixed `primary` Agent Project row plus ordered `context` attachments | `clawdi setup`, `clawdi agent projects ...` |
 | `sessions` | Per-conversation metadata: `environment_id`, `local_session_id`, `project_path`, token counts, model, summary, status. **Raw transcript body is in the file store**, keyed by `file_key` | `clawdi push` |
 | `skills` | Per-skill metadata + tar.gz body in file store | CLI `skill add / install`, dashboard upload |
-| `vaults` + `vault_items` | Three-level secrets: vault → section → field. Values are AES-256-GCM encrypted. `/vault/resolve` decrypts and returns plain values for readable Projects; CLI/API-key only | `clawdi vault set` |
+| `vaults` + `vault_items` | Three-level secrets: vault → section → field. Values are AES-256-GCM encrypted. `/vault/resolve` decrypts readable Project values for CLI/API-key callers | `clawdi vault set` |
 | `memories` | Long-term recall. `content` (text), `category`, `tags`, plus three search columns (`content_tsv` generated tsvector, `embedding vector(768)`) | CLI and MCP `memory_add` |
 | `user_settings` | Opaque JSONB per-user prefs: `memory_provider` (`builtin` / `mem0`), `mem0_api_key` | `PATCH /api/settings` |
 
@@ -165,7 +165,7 @@ clawdi://prod/database/url
 Values encrypted with AES-256-GCM (`vault_encryption_key` env var is the master key). The backend has two vault surfaces:
 
 - `/api/vault/*` — CRUD, accessible from the web dashboard, but **never returns plain values**
-- `/api/vault/resolve` — returns `{ KEY: plain_value, ... }` or one resolved key, **only accepts CLI API keys**, rejects Clerk JWTs at the auth layer. Project members can resolve shared Project values just like owners. It can resolve a single readable Project via `project_id` or an Agent's ordered Project set via `agent_id`; env-bound Agent keys only read attached shared Projects through the matching Agent boundary.
+- `/api/vault/resolve` — returns `{ KEY: plain_value, ... }` or one resolved key, **only accepts CLI API keys**, rejects Clerk JWTs at the auth layer. Project membership grants read access to vault values, so members can resolve shared Project values through CLI/API-key flows. It can resolve a single readable Project via `project_id` or an Agent's ordered Project set via `agent_id`; env-bound Agent keys only read attached shared Projects through the matching Agent boundary.
 
 `clawdi run -- <cmd>` hits `/vault/resolve`, merges the returned env into the child process's environment, and `exec`s. `clawdi run --project <project> -- <cmd>` resolves from that explicit cloud Project. Without `--project`, a local `clawdi project folder link --project <project>` can select the Project for the current folder or a parent folder. Folder links are local CLI selection hints only: they do not grant Project access, attach Projects to Agents, or compose Projects.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,7 +58,7 @@ All keyed off Clerk `user_id`:
 | `agent_project_bindings` | Runtime Agent composition: one fixed `primary` Agent Project row plus ordered `context` attachments | `clawdi setup`, `clawdi agent projects ...` |
 | `sessions` | Per-conversation metadata: `environment_id`, `local_session_id`, `project_path`, token counts, model, summary, status. **Raw transcript body is in the file store**, keyed by `file_key` | `clawdi push` |
 | `skills` | Per-skill metadata + tar.gz body in file store | CLI `skill add / install`, dashboard upload |
-| `vaults` + `vault_items` | Three-level secrets: vault → section → field. Values are AES-256-GCM encrypted. `/vault/resolve` decrypts and returns plain values; CLI-only | `clawdi vault set` |
+| `vaults` + `vault_items` | Three-level secrets: vault → section → field. Values are AES-256-GCM encrypted. `/vault/resolve` decrypts and returns plain values for readable Projects; CLI/API-key only | `clawdi vault set` |
 | `memories` | Long-term recall. `content` (text), `category`, `tags`, plus three search columns (`content_tsv` generated tsvector, `embedding vector(768)`) | CLI and MCP `memory_add` |
 | `user_settings` | Opaque JSONB per-user prefs: `memory_provider` (`builtin` / `mem0`), `mem0_api_key` | `PATCH /api/settings` |
 
@@ -165,7 +165,7 @@ clawdi://prod/database/url
 Values encrypted with AES-256-GCM (`vault_encryption_key` env var is the master key). The backend has two vault surfaces:
 
 - `/api/vault/*` — CRUD, accessible from the web dashboard, but **never returns plain values**
-- `/api/vault/resolve` — returns `{ KEY: plain_value, ... }` or one resolved key, **only accepts CLI API keys**, rejects Clerk JWTs at the auth layer. It can resolve a single Project via `project_id` or an Agent's ordered Project set via `agent_id`.
+- `/api/vault/resolve` — returns `{ KEY: plain_value, ... }` or one resolved key, **only accepts CLI API keys**, rejects Clerk JWTs at the auth layer. Project members can resolve shared Project values just like owners. It can resolve a single readable Project via `project_id` or an Agent's ordered Project set via `agent_id`; env-bound Agent keys only read attached shared Projects through the matching Agent boundary.
 
 `clawdi run -- <cmd>` hits `/vault/resolve`, merges the returned env into the child process's environment, and `exec`s. `clawdi run --project <project> -- <cmd>` resolves from that explicit cloud Project. Without `--project`, a local `clawdi project folder link --project <project>` can select the Project for the current folder or a parent folder. Folder links are local CLI selection hints only: they do not grant Project access, attach Projects to Agents, or compose Projects.
 

--- a/docs/scenarios/project-sharing-agent-bindings-demo.md
+++ b/docs/scenarios/project-sharing-agent-bindings-demo.md
@@ -6,7 +6,7 @@
 ## Product Model
 
 - Project is a shared library object with resources, membership, and access controls.
-- Project resources include skills and vault key names. Secret values are never shown in this demo.
+- Project resources include skills, vault key names, and vault env values for CLI/API-key runtime reads.
 - Agent has one fixed Agent Project for default writes.
 - Agent can attach multiple Projects for reads during runs.
 - Sharing grants Project membership only. It does not attach the Project to an agent.
@@ -59,7 +59,7 @@ to the separate web PR. Folder links are CLI-only local preferences:
 | Local operator | Link a folder to a Project for `run` env selection | `clawdi project folder link`, `status`, `unlink` | None |
 | Local operator | Run with linked or explicit Project vault env | `clawdi run`, `run --project`, `run --no-project-folder` | None |
 | Security | Agent API keys cannot manage sharing | sharing routes reject Agent API keys | API guard display |
-| Security | Plaintext vault values stay CLI/API-key only | web/JWT cannot call `vault resolve` | API guard display |
+| Security | Plaintext vault values stay CLI/API-key only, but Project members read them like owners | web/JWT cannot call `vault resolve`; members can resolve via CLI/API key | API guard display |
 | Revoke/conflict | Conflict block/allow and access cleanup | `vault resolve --agent`, unshare/leave/remove | Error copy / stale attachment cleanup |
 
 ## Role Logic Review
@@ -92,7 +92,7 @@ Expected:
 - Link listings show the prefix, label, timestamps, accepts, and revoke affordance.
 - Revoking a share link stops future accepts only; accepted viewers stay members until
   `project members --remove`, `project leave`, or `project unshare` changes membership.
-- No secret plaintext is shown.
+- Secret plaintext is not shown in dashboard/web flows. CLI/API-key runtime paths can resolve shared Project vault values for members.
 
 Web PR follow-up: Projects list/detail and Share dialog should mirror
 the same People / Access, Invites, and Links state.
@@ -113,6 +113,7 @@ Expected:
 - Project access is accepted as viewer access.
 - The project appears under Shared with me with `@alice/engineering`.
 - Skills and vault key names are readable; writes stay disabled.
+- Vault env values resolve through CLI/API-key runtime paths; web/JWT still cannot read plaintext.
 - Human CLI output names the exact follow-up command:
   `clawdi agent projects attach <agent-id> --project @alice/engineering`.
 - No Project is attached to an Agent unless Bob passes `--agent`.
@@ -265,7 +266,7 @@ Security branch:
 
 - Web/JWT auth cannot call `vault resolve`.
 - Agent API keys cannot manage sharing or invitations.
-- Plaintext vault resolution remains CLI/API-key only.
+- Plaintext vault resolution remains CLI/API-key only, and Project members can resolve shared Project values like owners.
 
 ## Flow 8: Skills, Pull, And Push Project Flags
 

--- a/docs/scenarios/project-sharing-agent-bindings-demo.md
+++ b/docs/scenarios/project-sharing-agent-bindings-demo.md
@@ -59,7 +59,7 @@ to the separate web PR. Folder links are CLI-only local preferences:
 | Local operator | Link a folder to a Project for `run` env selection | `clawdi project folder link`, `status`, `unlink` | None |
 | Local operator | Run with linked or explicit Project vault env | `clawdi run`, `run --project`, `run --no-project-folder` | None |
 | Security | Agent API keys cannot manage sharing | sharing routes reject Agent API keys | API guard display |
-| Security | Plaintext vault values stay CLI/API-key only, but Project members read them like owners | web/JWT cannot call `vault resolve`; members can resolve via CLI/API key | API guard display |
+| Security | Vault plaintext stays CLI/API-key only; Project members get owner-equivalent read access | web/JWT cannot call `vault resolve`; members can resolve via CLI/API key | API guard display |
 | Revoke/conflict | Conflict block/allow and access cleanup | `vault resolve --agent`, unshare/leave/remove | Error copy / stale attachment cleanup |
 
 ## Role Logic Review
@@ -266,7 +266,7 @@ Security branch:
 
 - Web/JWT auth cannot call `vault resolve`.
 - Agent API keys cannot manage sharing or invitations.
-- Plaintext vault resolution remains CLI/API-key only, and Project members can resolve shared Project values like owners.
+- Plaintext vault resolution remains CLI/API-key only, and Project members have owner-equivalent read access to shared Project values.
 
 ## Flow 8: Skills, Pull, And Push Project Flags
 

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1142,10 +1142,10 @@ export interface paths {
          * Resolve Vault
          * @description Resolve all vault items to plaintext. CLI-only (requires ApiKey auth).
          *
-         *     User-level CLI auth can resolve shared Project plaintext because Project
-         *     membership grants read access. A bound Agent API key is capped to its
-         *     default-write Project unless resolving through its own `agent_id`, where
-         *     the Agent Project plus explicit attached Projects define runtime reads.
+         *     Project membership grants CLI/API-key callers read access to vault values.
+         *     A bound Agent API key is capped to its default-write Project unless
+         *     resolving through its own `agent_id`, where the Agent Project plus explicit
+         *     attached Projects define runtime reads.
          */
         post: operations["resolve_vault_api_vault_resolve_post"];
         delete?: never;

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1142,9 +1142,10 @@ export interface paths {
          * Resolve Vault
          * @description Resolve all vault items to plaintext. CLI-only (requires ApiKey auth).
          *
-         *     Plaintext is owner-only. Shared project memberships widen metadata/read
-         *     surfaces, but never decrypt another user's vault values. A bound Agent API
-         *     key is further capped to its default-write project.
+         *     User-level CLI auth can resolve shared Project plaintext because Project
+         *     membership grants read access. A bound Agent API key is capped to its
+         *     default-write Project unless resolving through its own `agent_id`, where
+         *     the Agent Project plus explicit attached Projects define runtime reads.
          */
         post: operations["resolve_vault_api_vault_resolve_post"];
         delete?: never;


### PR DESCRIPTION
## Summary
- allow Project members to resolve shared Project vault plaintext through user-level CLI/API-key reads
- keep env-bound Agent keys constrained to their default Project unless resolving through the matching `agent_id` attachment boundary
- update sharing/vault docs and regression tests to match the intended Project read model

## Tests
- `pdm run ruff check app/core/project.py app/routes/vault.py tests/test_project_visibility_shared.py`
- `DATABASE_URL=postgresql+asyncpg://clawdi:clawdi_dev@127.0.0.1:42897/clawdi pdm test -- tests/test_project_visibility_shared.py`
- `DATABASE_URL=postgresql+asyncpg://clawdi:clawdi_dev@127.0.0.1:42897/clawdi pdm test -- tests/test_vault.py tests/test_project_agent_role_paths.py`

Note: full `pdm lint` is still blocked by existing Alembic migration lint issues unrelated to this change.
