### PR TITLE
docs: add Project MCP Packs plan

### DIFF
--- a/docs/plans/project-mcp-packs.html
+++ b/docs/plans/project-mcp-packs.html
@@ -1,0 +1,450 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Project MCP Packs</title>
+  <style>
+    :root {
+      --bg: #faf9f5;
+      --fg: #202523;
+      --muted: #68726e;
+      --line: #d9ddd8;
+      --panel: #ffffff;
+      --soft: #f1eee6;
+      --accent: #0f766e;
+      --warn: #9f4a2f;
+      --mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+      --sans: "Segoe UI", Aptos, sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--fg);
+      font: 16px/1.55 var(--sans);
+    }
+
+    main {
+      width: min(1120px, calc(100% - 36px));
+      margin: 0 auto;
+      padding: 42px 0 72px;
+    }
+
+    header {
+      padding: 28px 0 36px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    h1, h2, h3 { margin: 0; line-height: 1.12; }
+    h1 { font-size: clamp(42px, 8vw, 84px); letter-spacing: -0.03em; }
+    h2 { margin-bottom: 12px; font-size: clamp(28px, 4vw, 42px); letter-spacing: -0.02em; }
+    h3 { margin-bottom: 8px; font-size: 18px; }
+
+    p { margin: 0 0 14px; }
+    a { color: var(--accent); }
+    code, pre { font-family: var(--mono); }
+    code { padding: 1px 5px; border: 1px solid var(--line); border-radius: 4px; background: var(--soft); }
+    pre { overflow: auto; margin: 0; padding: 14px; border-radius: 8px; background: #1f2523; color: #f5f5ee; font-size: 13px; }
+    pre code { padding: 0; border: 0; background: transparent; color: inherit; }
+
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 2;
+      border-bottom: 1px solid var(--line);
+      background: rgb(250 249 245 / 94%);
+      backdrop-filter: blur(10px);
+    }
+
+    nav div {
+      display: flex;
+      gap: 8px;
+      width: min(1120px, calc(100% - 36px));
+      margin: 0 auto;
+      overflow-x: auto;
+      padding: 10px 0;
+    }
+
+    nav a {
+      flex: 0 0 auto;
+      padding: 6px 9px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      color: var(--fg);
+      font: 700 12px/1 var(--mono);
+      text-decoration: none;
+    }
+
+    section {
+      padding: 38px 0;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin: 22px 0 0;
+    }
+
+    .pill {
+      padding: 6px 9px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: var(--panel);
+      color: var(--muted);
+      font: 700 12px/1 var(--mono);
+    }
+
+    .lead {
+      max-width: 820px;
+      margin-top: 18px;
+      color: var(--muted);
+      font-size: 20px;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 14px;
+    }
+
+    .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+
+    .card {
+      padding: 16px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--panel);
+    }
+
+    .card p,
+    li {
+      color: var(--muted);
+    }
+
+    .flow {
+      display: grid;
+      gap: 10px;
+      margin-top: 18px;
+    }
+
+    .row {
+      display: grid;
+      grid-template-columns: 120px repeat(4, minmax(0, 1fr));
+      gap: 10px;
+      align-items: stretch;
+    }
+
+    .lane {
+      display: grid;
+      place-items: center;
+      border: 1px solid var(--fg);
+      border-radius: 8px;
+      background: var(--soft);
+      font: 800 12px/1.2 var(--mono);
+      text-align: center;
+      text-transform: uppercase;
+    }
+
+    .step {
+      min-height: 96px;
+      padding: 12px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--panel);
+    }
+
+    .step b {
+      display: block;
+      margin-bottom: 6px;
+      color: var(--accent);
+      font: 800 12px/1.2 var(--mono);
+      text-transform: uppercase;
+    }
+
+    .diagram {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      gap: 10px;
+      margin-top: 18px;
+    }
+
+    .node {
+      position: relative;
+      min-height: 112px;
+      padding: 14px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--panel);
+    }
+
+    .node:not(:last-child)::after {
+      position: absolute;
+      top: 50%;
+      right: -9px;
+      color: var(--warn);
+      font: 900 16px/1 var(--mono);
+      transform: translateY(-50%);
+      content: ">";
+    }
+
+    .node strong { display: block; margin-bottom: 6px; }
+    .node span, .step span { color: var(--muted); font-size: 14px; }
+    .node.accent { border-color: #8cc5bd; background: #eff8f6; }
+    .node.warn { border-color: #d6a290; background: #fff4ef; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      border: 1px solid var(--line);
+      background: var(--panel);
+      font-size: 14px;
+    }
+
+    th, td {
+      padding: 10px;
+      border-bottom: 1px solid var(--line);
+      vertical-align: top;
+      text-align: left;
+    }
+
+    th {
+      background: var(--soft);
+      font: 800 12px/1.2 var(--mono);
+      text-transform: uppercase;
+    }
+
+    tr:last-child td { border-bottom: 0; }
+
+    ul { margin: 0; padding-left: 19px; }
+
+    @media (max-width: 850px) {
+      .grid,
+      .grid.two,
+      .diagram,
+      .row {
+        grid-template-columns: 1fr;
+      }
+
+      .node:not(:last-child)::after {
+        display: none;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <main>
+      <h1>Project MCP Packs</h1>
+      <p class="lead">
+        A first-class Clawdi resource for sharing MCP configuration through
+        Projects, resolving credentials from Project Vault, and exposing one
+        combined <code>clawdi mcp</code> server to local agents.
+      </p>
+      <div class="meta">
+        <span class="pill">Status: plan</span>
+        <span class="pill">Updated: 2026-05-19</span>
+        <span class="pill">Owner: product + platform</span>
+        <span class="pill">MVP: local aggregator</span>
+      </div>
+    </main>
+  </header>
+
+  <nav>
+    <div>
+      <a href="#summary">Summary</a>
+      <a href="#flow">User flow</a>
+      <a href="#architecture">Architecture</a>
+      <a href="#config">Config</a>
+      <a href="#security">Security</a>
+      <a href="#data">Data</a>
+      <a href="#api">API</a>
+      <a href="#roadmap">Roadmap</a>
+    </div>
+  </nav>
+
+  <main>
+    <section id="summary">
+      <h2>Summary</h2>
+      <div class="grid">
+        <article class="card">
+          <h3>Define once</h3>
+          <p>MCP server definitions and Packs are top-level resources for catalog, custom servers, and future provider catalogs.</p>
+        </article>
+        <article class="card">
+          <h3>Install into Projects</h3>
+          <p>Project MCP installations bind definitions to one Project with aliases, overrides, tool policy, and credential bindings.</p>
+        </article>
+        <article class="card">
+          <h3>Run through Clawdi</h3>
+          <p><code>clawdi mcp</code> fetches runtime config, resolves Vault bindings, starts/connects upstream MCP servers, and exposes namespaced tools.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="flow">
+      <h2>User flow</h2>
+      <p class="lead">Owner configures the shared tool setup. Member attaches the Project to an Agent. The agent sees one Clawdi MCP server.</p>
+
+      <div class="flow">
+        <div class="row">
+          <div class="lane">Owner</div>
+          <div class="step"><b>1. Choose Project</b><span>Start from Project MCP tab, top-level MCP page, or CLI.</span></div>
+          <div class="step"><b>2. Select source</b><span>Catalog, Pack, custom server, or imported <code>.mcp.json</code>.</span></div>
+          <div class="step"><b>3. Bind Vault</b><span>Map secret env/header/arg/url values to Project Vault items.</span></div>
+          <div class="step"><b>4. Install</b><span>Discover tools, disable risky tools, save Project installation.</span></div>
+        </div>
+        <div class="row">
+          <div class="lane">Member</div>
+          <div class="step"><b>1. Accept share</b><span>Project appears in the member inventory.</span></div>
+          <div class="step"><b>2. Inspect MCP</b><span>View metadata, health, enabled tools, and redacted Vault refs.</span></div>
+          <div class="step"><b>3. Attach Project</b><span>Add shared Project as Agent context.</span></div>
+          <div class="step"><b>4. Use tools</b><span>Agent calls namespaced tools through local <code>clawdi mcp</code>.</span></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="architecture">
+      <h2>Runtime architecture</h2>
+      <p class="lead">Ship local aggregation first. Keep the existing Composio Tool Router bridge as a dedicated connector path, not as the generic third-party MCP proxy.</p>
+      <div class="diagram">
+        <div class="node"><strong>Cloud metadata</strong><span>MCP servers, Packs, Project installations, tool policies.</span></div>
+        <div class="node"><strong>Project Vault</strong><span>Encrypted credential values and structured bindings.</span></div>
+        <div class="node"><strong>Runtime config</strong><span><code>/api/mcp/runtime-config?agent_id=...</code>, CLI/API-key only.</span></div>
+        <div class="node accent"><strong>Local <code>clawdi mcp</code></strong><span>Starts stdio servers, connects remote servers, registers tools, and forwards connector tools.</span></div>
+        <div class="node"><strong>Composio bridge</strong><span><code>/api/mcp/composio</code> forwards to user-scoped Tool Router sessions.</span></div>
+        <div class="node"><strong>Agent client</strong><span>Claude Code, Codex, Hermes, OpenClaw.</span></div>
+      </div>
+      <div class="grid two" style="margin-top: 14px;">
+        <article class="card">
+          <h3>Existing fit</h3>
+          <ul>
+            <li>Projects and memberships already define sharing.</li>
+            <li>Agent Project bindings already define runtime Project order.</li>
+            <li>Vault plaintext resolution already requires CLI/API-key auth.</li>
+            <li>Connector MCP now uses a backend Composio bridge and preserves upstream tool names and <code>inputSchema</code>.</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h3>CLI modules</h3>
+          <ul>
+            <li><code>native-tools.ts</code>, <code>connector-bridge.ts</code></li>
+            <li><code>runtime-config.ts</code>, <code>upstream-manager.ts</code></li>
+            <li><code>tool-registry.ts</code>, <code>secret-redaction.ts</code></li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section id="config">
+      <h2>Config coverage</h2>
+      <table>
+        <thead><tr><th>Config shape</th><th>Plan</th></tr></thead>
+        <tbody>
+          <tr><td>stdio <code>command</code>, <code>args</code>, <code>env</code></td><td>MVP support. Secrets come from Vault bindings.</td></tr>
+          <tr><td>stdio <code>cwd</code> and workspace variables</td><td>Add constrained <code>cwd_template</code>.</td></tr>
+          <tr><td>remote Streamable HTTP <code>url</code>, <code>headers</code></td><td>MVP support through the local aggregator. Keep legacy <code>sse</code> compatibility.</td></tr>
+          <tr><td>Composio connector tools</td><td>Reuse the existing <code>/api/mcp/composio</code> bridge; do not model it as a custom server command.</td></tr>
+          <tr><td>OAuth-protected remote MCP</td><td>Model now with <code>auth_config_json</code>; implement separately from the Composio bridge.</td></tr>
+          <tr><td><code>inputs</code>, local env, env files</td><td>Import and model explicitly. Shared credentials must use Vault.</td></tr>
+          <tr><td>disabled tools, auto-approve, risk policy</td><td>Map to <code>project_mcp_tool_policies</code>.</td></tr>
+          <tr><td>prompts, resources, roots, sampling, elicitation</td><td>Store capability metadata now. Proxy after tools MVP with explicit policy.</td></tr>
+          <tr><td>Docker/container servers</td><td>Represent source in v1. Structured sandbox/network policy later.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="security">
+      <h2>Security boundaries</h2>
+      <div class="grid two">
+        <article class="card">
+          <h3>Required invariants</h3>
+          <ul>
+            <li>Dashboard shows metadata and redacted Vault refs only.</li>
+            <li>Plaintext credentials only leave through CLI/API-key runtime endpoints.</li>
+            <li>Agent-bound keys can render only their own Agent and attached Projects.</li>
+            <li>Viewer members can use shared credentials at runtime but cannot edit in v1.</li>
+            <li>Composio API keys and Tool Router session headers never leave the backend bridge.</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h3>Explicit risk</h3>
+          <ul>
+            <li>Local stdio MCP servers are executable code.</li>
+            <li>Injected secrets can be exfiltrated by a malicious upstream server.</li>
+            <li>Do not support shared shell-based credential helpers.</li>
+            <li>Generic hosted proxy still requires separate OAuth, sandbox, revocation, and audit work.</li>
+            <li>Composio bridge tokens are user-scoped connector access, not Project-share authorization.</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section id="data">
+      <h2>Data model</h2>
+      <div class="grid">
+        <article class="card"><h3><code>mcp_servers</code></h3><p>Top-level definitions: source, transport, runtime mode, default command/url, auth config, capabilities, discovery cache.</p></article>
+        <article class="card"><h3><code>mcp_packs</code></h3><p>Reusable bundles of server definitions with aliases, tool prefixes, enabled defaults, and version pins.</p></article>
+        <article class="card"><h3><code>project_mcp_installations</code></h3><p>Project usage layer with aliases, overrides, env/header templates, timeouts, and pack provenance.</p></article>
+        <article class="card"><h3><code>project_mcp_credential_bindings</code></h3><p>Structured mapping from injection targets to value sources: Vault, local env, input, connector. No plaintext literal values.</p></article>
+        <article class="card"><h3><code>project_mcp_tool_policies</code></h3><p>Per-tool enabled state, risk label, and approval policy.</p></article>
+        <article class="card"><h3><code>mcp_runtime_events</code></h3><p>Post-MVP audit surface for project, installation, tool, status, and latency.</p></article>
+      </div>
+    </section>
+
+    <section id="api">
+      <h2>API surface</h2>
+      <div class="grid two">
+        <pre><code>GET    /api/mcp/servers
+POST   /api/mcp/servers
+GET    /api/mcp/servers/{server_id}
+PATCH  /api/mcp/servers/{server_id}
+DELETE /api/mcp/servers/{server_id}
+
+GET    /api/mcp/packs
+POST   /api/mcp/packs
+GET    /api/mcp/packs/{pack_id}
+PATCH  /api/mcp/packs/{pack_id}
+DELETE /api/mcp/packs/{pack_id}</code></pre>
+        <pre><code>GET    /api/projects/{project_id}/mcp
+POST   /api/projects/{project_id}/mcp/installations
+GET    /api/projects/{project_id}/mcp/installations/{installation_id}
+PATCH  /api/projects/{project_id}/mcp/installations/{installation_id}
+DELETE /api/projects/{project_id}/mcp/installations/{installation_id}
+
+PUT    /api/projects/{project_id}/mcp/installations/{installation_id}/bindings
+PUT    /api/projects/{project_id}/mcp/installations/{installation_id}/tools</code></pre>
+      </div>
+      <pre style="margin-top: 14px;"><code>GET /api/mcp/runtime-config?agent_id={agent_id}
+GET /api/mcp/runtime-config?project_id={project_id}
+GET /api/mcp/runtime-health?agent_id={agent_id}</code></pre>
+    </section>
+
+    <section id="roadmap">
+      <h2>Roadmap</h2>
+      <div class="grid">
+        <article class="card"><h3>0. Plan</h3><p>Finalize terminology, resource split, and v1 credential scope.</p></article>
+        <article class="card"><h3>1. Metadata</h3><p>Add tables, schemas, CRUD routes, Project validators, and sharing tests.</p></article>
+        <article class="card"><h3>2. Runtime config</h3><p>Render Vault-backed config through Project and Agent runtime boundaries, plus connector bridge references.</p></article>
+        <article class="card"><h3>3. CLI multiplexer</h3><p>Connect upstream MCP servers, aggregate tools, apply policy, sanitize errors, and reuse the Composio bridge.</p></article>
+        <article class="card"><h3>4. Authoring UX</h3><p>Add web and CLI flows for install, bind, discover, enable/disable, and health.</p></article>
+        <article class="card"><h3>5+. Hardening</h3><p>Add audit, doctor checks, import/export, cache policy, and hosted gateway later.</p></article>
+      </div>
+    </section>
+
+    <section id="references">
+      <h2>References</h2>
+      <ul>
+        <li><a href="https://modelcontextprotocol.io/specification/2025-06-18/basic/transports">MCP transports</a>, <a href="https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle">lifecycle</a>, <a href="https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization">authorization</a></li>
+        <li><a href="https://modelcontextprotocol.io/specification/2025-06-18/server/tools">MCP tools</a>, <a href="https://modelcontextprotocol.io/specification/2025-06-18/server/prompts">prompts</a>, <a href="https://modelcontextprotocol.io/specification/2025-06-18/server/resources">resources</a></li>
+        <li><a href="https://code.claude.com/docs/en/mcp">Claude Code MCP</a> and <a href="https://code.visualstudio.com/docs/copilot/reference/mcp-configuration">VS Code MCP config</a></li>
+        <li><a href="https://docs.docker.com/ai/mcp-catalog-and-toolkit/mcp-gateway/">Docker MCP Gateway</a>, <a href="https://docs.composio.dev/reference/api-reference/mcp">Composio MCP APIs</a>, <a href="https://pipedream.com/docs/connect/mcp">Pipedream MCP</a></li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a concise HTML design document for Project MCP Packs
- rebase the plan onto the latest Composio Tool Router MCP bridge implementation
- clarify that `/api/mcp/composio` remains a dedicated connector bridge, not the generic third-party MCP proxy
- remove plaintext literal credential binding from the plan and align with Vault/local-env/input/connector sources
- cover user flow, local aggregator architecture, config coverage, security boundaries, data model, API surface, and roadmap

## Verification
- `git diff --check`
- Checked the HTML file is ASCII-only

## Notes
- This is documentation only; no product code paths are changed.