### PR TITLE
feat: add Project MCP metadata

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -9,6 +9,7 @@ from app.models import (  # noqa: F401 - register models
     api_key,
     device_authorization,
     memory,
+    mcp,
     project,
     project_invitation,
     project_membership,

--- a/backend/alembic/versions/e3a1c0f8b9d2_project_mcp_metadata.py
+++ b/backend/alembic/versions/e3a1c0f8b9d2_project_mcp_metadata.py
@@ -1,0 +1,424 @@
+"""project mcp metadata
+
+Revision ID: e3a1c0f8b9d2
+Revises: 91d2c0f4e8a3
+Create Date: 2026-05-19 00:00:00.000000
+
+Adds the metadata layer for Project MCP Packs:
+  - top-level MCP server definitions
+  - top-level MCP packs and pack entries
+  - Project MCP installations
+  - Project MCP credential bindings
+  - Project MCP tool policies
+
+The migration intentionally does not add hosted runtime proxy tables yet.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "e3a1c0f8b9d2"
+down_revision: str | Sequence[str] | None = "91d2c0f4e8a3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _timestamps() -> list[sa.Column]:
+    return [
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+    ]
+
+
+def _uuid_pk() -> sa.Column:
+    return sa.Column(
+        "id",
+        postgresql.UUID(as_uuid=True),
+        primary_key=True,
+        server_default=sa.text("gen_random_uuid()"),
+    )
+
+
+def upgrade() -> None:
+    op.create_table(
+        "mcp_servers",
+        _uuid_pk(),
+        sa.Column(
+            "owner_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("slug", sa.String(120), nullable=False),
+        sa.Column("name", sa.String(200), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("visibility", sa.String(20), nullable=False, server_default="private"),
+        sa.Column("source_type", sa.String(32), nullable=False, server_default="custom"),
+        sa.Column("source_ref", sa.Text(), nullable=True),
+        sa.Column("transport", sa.String(32), nullable=False),
+        sa.Column("runtime_mode", sa.String(32), nullable=False, server_default="local"),
+        sa.Column("default_command", sa.Text(), nullable=True),
+        sa.Column("default_args_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("default_cwd_template", sa.Text(), nullable=True),
+        sa.Column("default_url", sa.Text(), nullable=True),
+        sa.Column("required_inputs_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("auth_config_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("runtime_config_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("capabilities_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("discovery_cache_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("risk_metadata_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        *_timestamps(),
+        sa.CheckConstraint(
+            "visibility IN ('catalog', 'private')",
+            name="ck_mcp_servers_visibility_v1",
+        ),
+        sa.CheckConstraint(
+            "source_type IN ('catalog', 'custom', 'composio', 'pipedream', 'docker')",
+            name="ck_mcp_servers_source_type_v1",
+        ),
+        sa.CheckConstraint(
+            "transport IN ('stdio', 'http', 'sse', 'streamable_http')",
+            name="ck_mcp_servers_transport_v1",
+        ),
+        sa.CheckConstraint(
+            "runtime_mode IN ('local', 'remote')",
+            name="ck_mcp_servers_runtime_mode_v1",
+        ),
+    )
+    op.create_index("ix_mcp_servers_owner_user_id", "mcp_servers", ["owner_user_id"])
+    op.create_index(
+        "uq_mcp_servers_catalog_slug_active",
+        "mcp_servers",
+        ["slug"],
+        unique=True,
+        postgresql_where=sa.text("visibility = 'catalog' AND archived_at IS NULL"),
+    )
+    op.create_index(
+        "uq_mcp_servers_owner_slug_active",
+        "mcp_servers",
+        ["owner_user_id", "slug"],
+        unique=True,
+        postgresql_where=sa.text("owner_user_id IS NOT NULL AND archived_at IS NULL"),
+    )
+
+    op.create_table(
+        "mcp_packs",
+        _uuid_pk(),
+        sa.Column(
+            "owner_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("slug", sa.String(120), nullable=False),
+        sa.Column("name", sa.String(200), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("visibility", sa.String(20), nullable=False, server_default="private"),
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        *_timestamps(),
+        sa.CheckConstraint(
+            "visibility IN ('catalog', 'private')",
+            name="ck_mcp_packs_visibility_v1",
+        ),
+    )
+    op.create_index("ix_mcp_packs_owner_user_id", "mcp_packs", ["owner_user_id"])
+    op.create_index(
+        "uq_mcp_packs_catalog_slug_active",
+        "mcp_packs",
+        ["slug"],
+        unique=True,
+        postgresql_where=sa.text("visibility = 'catalog' AND archived_at IS NULL"),
+    )
+    op.create_index(
+        "uq_mcp_packs_owner_slug_active",
+        "mcp_packs",
+        ["owner_user_id", "slug"],
+        unique=True,
+        postgresql_where=sa.text("owner_user_id IS NOT NULL AND archived_at IS NULL"),
+    )
+
+    op.create_table(
+        "mcp_pack_entries",
+        _uuid_pk(),
+        sa.Column(
+            "pack_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("mcp_packs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "mcp_server_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("mcp_servers.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("server_alias", sa.String(120), nullable=False),
+        sa.Column("default_tool_prefix", sa.String(120), nullable=True),
+        sa.Column("default_enabled", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("version_pin", sa.String(200), nullable=True),
+        *_timestamps(),
+    )
+    op.create_index("ix_mcp_pack_entries_pack_id", "mcp_pack_entries", ["pack_id"])
+    op.create_index(
+        "ix_mcp_pack_entries_mcp_server_id",
+        "mcp_pack_entries",
+        ["mcp_server_id"],
+    )
+    op.create_index(
+        "uq_mcp_pack_entries_pack_alias",
+        "mcp_pack_entries",
+        ["pack_id", "server_alias"],
+        unique=True,
+    )
+
+    op.create_table(
+        "project_mcp_installations",
+        _uuid_pk(),
+        sa.Column(
+            "project_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "mcp_server_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("mcp_servers.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "source_pack_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("mcp_packs.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "installed_by_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("server_alias", sa.String(120), nullable=False),
+        sa.Column("tool_prefix", sa.String(120), nullable=True),
+        sa.Column("version_pin", sa.String(200), nullable=True),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("command_override", sa.Text(), nullable=True),
+        sa.Column("args_override_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("cwd_template_override", sa.Text(), nullable=True),
+        sa.Column("url_override", sa.Text(), nullable=True),
+        sa.Column("env_template_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("headers_template_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("auth_override_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("timeout_ms", sa.Integer(), nullable=True),
+        sa.Column("startup_timeout_ms", sa.Integer(), nullable=True),
+        sa.Column("restart_policy", sa.String(32), nullable=False, server_default="none"),
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        *_timestamps(),
+        sa.CheckConstraint(
+            "restart_policy IN ('none', 'on_failure')",
+            name="ck_project_mcp_installations_restart_policy_v1",
+        ),
+    )
+    op.create_index(
+        "ix_project_mcp_installations_project_id",
+        "project_mcp_installations",
+        ["project_id"],
+    )
+    op.create_index(
+        "ix_project_mcp_installations_mcp_server_id",
+        "project_mcp_installations",
+        ["mcp_server_id"],
+    )
+    op.create_index(
+        "ix_project_mcp_installations_source_pack_id",
+        "project_mcp_installations",
+        ["source_pack_id"],
+    )
+    op.create_index(
+        "ix_project_mcp_installations_installed_by_user_id",
+        "project_mcp_installations",
+        ["installed_by_user_id"],
+    )
+    op.create_index(
+        "uq_project_mcp_installations_project_alias_active",
+        "project_mcp_installations",
+        ["project_id", "server_alias"],
+        unique=True,
+        postgresql_where=sa.text("archived_at IS NULL"),
+    )
+
+    op.create_table(
+        "project_mcp_credential_bindings",
+        _uuid_pk(),
+        sa.Column(
+            "installation_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("project_mcp_installations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("target_kind", sa.String(32), nullable=False),
+        sa.Column("target_name", sa.String(200), nullable=False),
+        sa.Column("value_source", sa.String(32), nullable=False, server_default="vault"),
+        sa.Column(
+            "vault_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("vaults.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "vault_item_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("vault_items.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("display_vault_uri", sa.Text(), nullable=True),
+        sa.Column("local_env_name", sa.String(200), nullable=True),
+        sa.Column("input_id", sa.String(200), nullable=True),
+        sa.Column("connector_ref", sa.String(300), nullable=True),
+        sa.Column("required", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("redact_in_logs", sa.Boolean(), nullable=False, server_default="true"),
+        *_timestamps(),
+        sa.CheckConstraint(
+            "target_kind IN ('env', 'header', 'arg', 'url', 'oauth', 'config_file')",
+            name="ck_project_mcp_credential_bindings_target_kind_v1",
+        ),
+        sa.CheckConstraint(
+            "value_source IN ('vault', 'local_env', 'input', 'connector')",
+            name="ck_project_mcp_credential_bindings_value_source_v1",
+        ),
+    )
+    op.create_index(
+        "ix_project_mcp_credential_bindings_installation_id",
+        "project_mcp_credential_bindings",
+        ["installation_id"],
+    )
+    op.create_index(
+        "ix_project_mcp_credential_bindings_vault_id",
+        "project_mcp_credential_bindings",
+        ["vault_id"],
+    )
+    op.create_index(
+        "ix_project_mcp_credential_bindings_vault_item_id",
+        "project_mcp_credential_bindings",
+        ["vault_item_id"],
+    )
+    op.create_index(
+        "uq_project_mcp_credential_bindings_target",
+        "project_mcp_credential_bindings",
+        ["installation_id", "target_kind", "target_name"],
+        unique=True,
+    )
+
+    op.create_table(
+        "project_mcp_tool_policies",
+        _uuid_pk(),
+        sa.Column(
+            "installation_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("project_mcp_installations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("tool_name", sa.String(300), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("risk_level", sa.String(32), nullable=False, server_default="unknown"),
+        sa.Column("approval_policy", sa.String(32), nullable=False, server_default="default"),
+        *_timestamps(),
+        sa.CheckConstraint(
+            "risk_level IN ('read', 'write', 'destructive', 'unknown')",
+            name="ck_project_mcp_tool_policies_risk_level_v1",
+        ),
+        sa.CheckConstraint(
+            "approval_policy IN ('default', 'always_ask', 'never_allow')",
+            name="ck_project_mcp_tool_policies_approval_policy_v1",
+        ),
+    )
+    op.create_index(
+        "ix_project_mcp_tool_policies_installation_id",
+        "project_mcp_tool_policies",
+        ["installation_id"],
+    )
+    op.create_index(
+        "uq_project_mcp_tool_policies_tool",
+        "project_mcp_tool_policies",
+        ["installation_id", "tool_name"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_project_mcp_tool_policies_tool", table_name="project_mcp_tool_policies")
+    op.drop_index(
+        "ix_project_mcp_tool_policies_installation_id",
+        table_name="project_mcp_tool_policies",
+    )
+    op.drop_table("project_mcp_tool_policies")
+
+    op.drop_index(
+        "uq_project_mcp_credential_bindings_target",
+        table_name="project_mcp_credential_bindings",
+    )
+    op.drop_index(
+        "ix_project_mcp_credential_bindings_vault_item_id",
+        table_name="project_mcp_credential_bindings",
+    )
+    op.drop_index(
+        "ix_project_mcp_credential_bindings_vault_id",
+        table_name="project_mcp_credential_bindings",
+    )
+    op.drop_index(
+        "ix_project_mcp_credential_bindings_installation_id",
+        table_name="project_mcp_credential_bindings",
+    )
+    op.drop_table("project_mcp_credential_bindings")
+
+    op.drop_index(
+        "uq_project_mcp_installations_project_alias_active",
+        table_name="project_mcp_installations",
+    )
+    op.drop_index(
+        "ix_project_mcp_installations_installed_by_user_id",
+        table_name="project_mcp_installations",
+    )
+    op.drop_index(
+        "ix_project_mcp_installations_source_pack_id",
+        table_name="project_mcp_installations",
+    )
+    op.drop_index(
+        "ix_project_mcp_installations_mcp_server_id",
+        table_name="project_mcp_installations",
+    )
+    op.drop_index(
+        "ix_project_mcp_installations_project_id",
+        table_name="project_mcp_installations",
+    )
+    op.drop_table("project_mcp_installations")
+
+    op.drop_index("uq_mcp_pack_entries_pack_alias", table_name="mcp_pack_entries")
+    op.drop_index("ix_mcp_pack_entries_mcp_server_id", table_name="mcp_pack_entries")
+    op.drop_index("ix_mcp_pack_entries_pack_id", table_name="mcp_pack_entries")
+    op.drop_table("mcp_pack_entries")
+
+    op.drop_index("uq_mcp_packs_owner_slug_active", table_name="mcp_packs")
+    op.drop_index("uq_mcp_packs_catalog_slug_active", table_name="mcp_packs")
+    op.drop_index("ix_mcp_packs_owner_user_id", table_name="mcp_packs")
+    op.drop_table("mcp_packs")
+
+    op.drop_index("uq_mcp_servers_owner_slug_active", table_name="mcp_servers")
+    op.drop_index("uq_mcp_servers_catalog_slug_active", table_name="mcp_servers")
+    op.drop_index("ix_mcp_servers_owner_user_id", table_name="mcp_servers")
+    op.drop_table("mcp_servers")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,8 @@ from app.routes.capabilities import router as capabilities_router
 from app.routes.cli_auth import router as cli_auth_router
 from app.routes.connectors import router as connectors_router
 from app.routes.dashboard import router as dashboard_router
+from app.routes.mcp import project_router as mcp_project_router
+from app.routes.mcp import router as mcp_router
 from app.routes.mcp_bridge import router as mcp_bridge_router
 from app.routes.me import router as me_router
 from app.routes.memories import router as memories_router
@@ -177,6 +179,8 @@ app.include_router(settings_router)
 app.include_router(capabilities_router)
 app.include_router(vault_router)
 app.include_router(connectors_router)
+app.include_router(mcp_router)
+app.include_router(mcp_project_router)
 app.include_router(mcp_bridge_router)
 app.include_router(search_router)
 app.include_router(share_redeem_router)

--- a/backend/app/models/mcp.py
+++ b/backend/app/models/mcp.py
@@ -1,0 +1,293 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, CheckConstraint, DateTime, ForeignKey, Index, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+from app.models.project import Project  # noqa: F401 - FK target
+from app.models.user import User  # noqa: F401 - FK target
+from app.models.vault import Vault, VaultItem  # noqa: F401 - FK targets
+
+MCP_SERVER_VISIBILITIES = ("catalog", "private")
+MCP_SOURCE_TYPES = ("catalog", "custom", "composio", "pipedream", "docker")
+MCP_TRANSPORTS = ("stdio", "http", "sse", "streamable_http")
+MCP_RUNTIME_MODES = ("local", "remote")
+MCP_RESTART_POLICIES = ("none", "on_failure")
+MCP_BINDING_TARGET_KINDS = ("env", "header", "arg", "url", "oauth", "config_file")
+MCP_BINDING_VALUE_SOURCES = ("vault", "local_env", "input", "connector")
+MCP_TOOL_RISK_LEVELS = ("read", "write", "destructive", "unknown")
+MCP_TOOL_APPROVAL_POLICIES = ("default", "always_ask", "never_allow")
+
+
+def _values(values: tuple[str, ...]) -> str:
+    return ", ".join(f"'{value}'" for value in values)
+
+
+class McpServer(Base, TimestampMixin):
+    __tablename__ = "mcp_servers"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    owner_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        index=True,
+    )
+    slug: Mapped[str] = mapped_column(String(120), nullable=False)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text)
+    visibility: Mapped[str] = mapped_column(String(20), nullable=False, server_default="private")
+    source_type: Mapped[str] = mapped_column(String(32), nullable=False, server_default="custom")
+    source_ref: Mapped[str | None] = mapped_column(Text)
+    transport: Mapped[str] = mapped_column(String(32), nullable=False)
+    runtime_mode: Mapped[str] = mapped_column(String(32), nullable=False, server_default="local")
+    default_command: Mapped[str | None] = mapped_column(Text)
+    default_args_json: Mapped[list | None] = mapped_column(JSONB)
+    default_cwd_template: Mapped[str | None] = mapped_column(Text)
+    default_url: Mapped[str | None] = mapped_column(Text)
+    required_inputs_json: Mapped[dict | None] = mapped_column(JSONB)
+    auth_config_json: Mapped[dict | None] = mapped_column(JSONB)
+    runtime_config_json: Mapped[dict | None] = mapped_column(JSONB)
+    capabilities_json: Mapped[dict | None] = mapped_column(JSONB)
+    discovery_cache_json: Mapped[dict | None] = mapped_column(JSONB)
+    risk_metadata_json: Mapped[dict | None] = mapped_column(JSONB)
+    archived_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    __table_args__ = (
+        CheckConstraint(
+            f"visibility IN ({_values(MCP_SERVER_VISIBILITIES)})",
+            name="ck_mcp_servers_visibility_v1",
+        ),
+        CheckConstraint(
+            f"source_type IN ({_values(MCP_SOURCE_TYPES)})",
+            name="ck_mcp_servers_source_type_v1",
+        ),
+        CheckConstraint(
+            f"transport IN ({_values(MCP_TRANSPORTS)})",
+            name="ck_mcp_servers_transport_v1",
+        ),
+        CheckConstraint(
+            f"runtime_mode IN ({_values(MCP_RUNTIME_MODES)})",
+            name="ck_mcp_servers_runtime_mode_v1",
+        ),
+        Index(
+            "uq_mcp_servers_catalog_slug_active",
+            "slug",
+            unique=True,
+            postgresql_where="visibility = 'catalog' AND archived_at IS NULL",
+        ),
+        Index(
+            "uq_mcp_servers_owner_slug_active",
+            "owner_user_id",
+            "slug",
+            unique=True,
+            postgresql_where="owner_user_id IS NOT NULL AND archived_at IS NULL",
+        ),
+    )
+
+
+class McpPack(Base, TimestampMixin):
+    __tablename__ = "mcp_packs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    owner_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        index=True,
+    )
+    slug: Mapped[str] = mapped_column(String(120), nullable=False)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text)
+    visibility: Mapped[str] = mapped_column(String(20), nullable=False, server_default="private")
+    archived_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    __table_args__ = (
+        CheckConstraint(
+            f"visibility IN ({_values(MCP_SERVER_VISIBILITIES)})",
+            name="ck_mcp_packs_visibility_v1",
+        ),
+        Index(
+            "uq_mcp_packs_catalog_slug_active",
+            "slug",
+            unique=True,
+            postgresql_where="visibility = 'catalog' AND archived_at IS NULL",
+        ),
+        Index(
+            "uq_mcp_packs_owner_slug_active",
+            "owner_user_id",
+            "slug",
+            unique=True,
+            postgresql_where="owner_user_id IS NOT NULL AND archived_at IS NULL",
+        ),
+    )
+
+
+class McpPackEntry(Base, TimestampMixin):
+    __tablename__ = "mcp_pack_entries"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    pack_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("mcp_packs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    mcp_server_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("mcp_servers.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    server_alias: Mapped[str] = mapped_column(String(120), nullable=False)
+    default_tool_prefix: Mapped[str | None] = mapped_column(String(120))
+    default_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
+    version_pin: Mapped[str | None] = mapped_column(String(200))
+
+    __table_args__ = (
+        Index("uq_mcp_pack_entries_pack_alias", "pack_id", "server_alias", unique=True),
+    )
+
+
+class ProjectMcpInstallation(Base, TimestampMixin):
+    __tablename__ = "project_mcp_installations"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    mcp_server_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("mcp_servers.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    source_pack_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("mcp_packs.id", ondelete="SET NULL"),
+        index=True,
+    )
+    installed_by_user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    server_alias: Mapped[str] = mapped_column(String(120), nullable=False)
+    tool_prefix: Mapped[str | None] = mapped_column(String(120))
+    version_pin: Mapped[str | None] = mapped_column(String(200))
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
+    command_override: Mapped[str | None] = mapped_column(Text)
+    args_override_json: Mapped[list | None] = mapped_column(JSONB)
+    cwd_template_override: Mapped[str | None] = mapped_column(Text)
+    url_override: Mapped[str | None] = mapped_column(Text)
+    env_template_json: Mapped[dict | None] = mapped_column(JSONB)
+    headers_template_json: Mapped[dict | None] = mapped_column(JSONB)
+    auth_override_json: Mapped[dict | None] = mapped_column(JSONB)
+    timeout_ms: Mapped[int | None] = mapped_column(Integer)
+    startup_timeout_ms: Mapped[int | None] = mapped_column(Integer)
+    restart_policy: Mapped[str] = mapped_column(String(32), nullable=False, server_default="none")
+    archived_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    __table_args__ = (
+        CheckConstraint(
+            f"restart_policy IN ({_values(MCP_RESTART_POLICIES)})",
+            name="ck_project_mcp_installations_restart_policy_v1",
+        ),
+        Index(
+            "uq_project_mcp_installations_project_alias_active",
+            "project_id",
+            "server_alias",
+            unique=True,
+            postgresql_where="archived_at IS NULL",
+        ),
+    )
+
+
+class ProjectMcpCredentialBinding(Base, TimestampMixin):
+    __tablename__ = "project_mcp_credential_bindings"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    installation_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("project_mcp_installations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    target_kind: Mapped[str] = mapped_column(String(32), nullable=False)
+    target_name: Mapped[str] = mapped_column(String(200), nullable=False)
+    value_source: Mapped[str] = mapped_column(String(32), nullable=False, server_default="vault")
+    vault_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("vaults.id", ondelete="SET NULL"),
+        index=True,
+    )
+    vault_item_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("vault_items.id", ondelete="SET NULL"),
+        index=True,
+    )
+    display_vault_uri: Mapped[str | None] = mapped_column(Text)
+    local_env_name: Mapped[str | None] = mapped_column(String(200))
+    input_id: Mapped[str | None] = mapped_column(String(200))
+    connector_ref: Mapped[str | None] = mapped_column(String(300))
+    required: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
+    redact_in_logs: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
+
+    __table_args__ = (
+        CheckConstraint(
+            f"target_kind IN ({_values(MCP_BINDING_TARGET_KINDS)})",
+            name="ck_project_mcp_credential_bindings_target_kind_v1",
+        ),
+        CheckConstraint(
+            f"value_source IN ({_values(MCP_BINDING_VALUE_SOURCES)})",
+            name="ck_project_mcp_credential_bindings_value_source_v1",
+        ),
+        Index(
+            "uq_project_mcp_credential_bindings_target",
+            "installation_id",
+            "target_kind",
+            "target_name",
+            unique=True,
+        ),
+    )
+
+
+class ProjectMcpToolPolicy(Base, TimestampMixin):
+    __tablename__ = "project_mcp_tool_policies"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    installation_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("project_mcp_installations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    tool_name: Mapped[str] = mapped_column(String(300), nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
+    risk_level: Mapped[str] = mapped_column(String(32), nullable=False, server_default="unknown")
+    approval_policy: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        server_default="default",
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            f"risk_level IN ({_values(MCP_TOOL_RISK_LEVELS)})",
+            name="ck_project_mcp_tool_policies_risk_level_v1",
+        ),
+        CheckConstraint(
+            f"approval_policy IN ({_values(MCP_TOOL_APPROVAL_POLICIES)})",
+            name="ck_project_mcp_tool_policies_approval_policy_v1",
+        ),
+        Index(
+            "uq_project_mcp_tool_policies_tool",
+            "installation_id",
+            "tool_name",
+            unique=True,
+        ),
+    )

--- a/backend/app/routes/mcp.py
+++ b/backend/app/routes/mcp.py
@@ -1,0 +1,878 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import delete, or_, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import AuthContext, require_user_auth, require_user_auth_unbound
+from app.core.database import get_session
+from app.core.project import validate_project_for_caller, validate_project_read_for_caller
+from app.models.mcp import (
+    McpPack,
+    McpPackEntry,
+    McpServer,
+    ProjectMcpCredentialBinding,
+    ProjectMcpInstallation,
+    ProjectMcpToolPolicy,
+)
+from app.models.vault import Vault, VaultItem, VaultProjectAttachment
+from app.schemas.mcp import (
+    McpPackCreate,
+    McpPackEntriesPut,
+    McpPackEntryInput,
+    McpPackEntryResponse,
+    McpPackResponse,
+    McpPackUpdate,
+    McpServerCreate,
+    McpServerResponse,
+    McpServerUpdate,
+    ProjectMcpCredentialBindingInput,
+    ProjectMcpCredentialBindingResponse,
+    ProjectMcpCredentialBindingsPut,
+    ProjectMcpInstallationCreate,
+    ProjectMcpInstallationResponse,
+    ProjectMcpInstallationUpdate,
+    ProjectMcpToolPoliciesPut,
+    ProjectMcpToolPolicyResponse,
+)
+
+router = APIRouter(prefix="/api/mcp", tags=["mcp"])
+project_router = APIRouter(prefix="/api/projects/{project_id}/mcp", tags=["project-mcp"])
+
+
+def _uuid(value: str, field: str) -> UUID:
+    try:
+        return UUID(value)
+    except ValueError as err:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, f"invalid {field}") from err
+
+
+def _server_response(server: McpServer) -> McpServerResponse:
+    return McpServerResponse(
+        id=str(server.id),
+        owner_user_id=str(server.owner_user_id) if server.owner_user_id else None,
+        slug=server.slug,
+        name=server.name,
+        description=server.description,
+        visibility=server.visibility,
+        source_type=server.source_type,
+        source_ref=server.source_ref,
+        transport=server.transport,
+        runtime_mode=server.runtime_mode,
+        default_command=server.default_command,
+        default_args=server.default_args_json,
+        default_cwd_template=server.default_cwd_template,
+        default_url=server.default_url,
+        required_inputs=server.required_inputs_json,
+        auth_config=server.auth_config_json,
+        runtime_config=server.runtime_config_json,
+        capabilities=server.capabilities_json,
+        discovery_cache=server.discovery_cache_json,
+        risk_metadata=server.risk_metadata_json,
+        archived_at=server.archived_at,
+        created_at=server.created_at,
+        updated_at=server.updated_at,
+    )
+
+
+def _pack_entry_response(entry: McpPackEntry, server: McpServer) -> McpPackEntryResponse:
+    return McpPackEntryResponse(
+        id=str(entry.id),
+        pack_id=str(entry.pack_id),
+        mcp_server_id=str(entry.mcp_server_id),
+        server_alias=entry.server_alias,
+        default_tool_prefix=entry.default_tool_prefix,
+        default_enabled=entry.default_enabled,
+        version_pin=entry.version_pin,
+        created_at=entry.created_at,
+        updated_at=entry.updated_at,
+        server=_server_response(server),
+    )
+
+
+def _pack_response(
+    pack: McpPack,
+    *,
+    entries: list[McpPackEntryResponse] | None = None,
+) -> McpPackResponse:
+    return McpPackResponse(
+        id=str(pack.id),
+        owner_user_id=str(pack.owner_user_id) if pack.owner_user_id else None,
+        slug=pack.slug,
+        name=pack.name,
+        description=pack.description,
+        visibility=pack.visibility,
+        archived_at=pack.archived_at,
+        created_at=pack.created_at,
+        updated_at=pack.updated_at,
+        entries=entries or [],
+    )
+
+
+def _binding_response(binding: ProjectMcpCredentialBinding) -> ProjectMcpCredentialBindingResponse:
+    return ProjectMcpCredentialBindingResponse(
+        id=str(binding.id),
+        installation_id=str(binding.installation_id),
+        target_kind=binding.target_kind,
+        target_name=binding.target_name,
+        value_source=binding.value_source,
+        vault_id=str(binding.vault_id) if binding.vault_id else None,
+        vault_item_id=str(binding.vault_item_id) if binding.vault_item_id else None,
+        display_vault_uri=binding.display_vault_uri,
+        local_env_name=binding.local_env_name,
+        input_id=binding.input_id,
+        connector_ref=binding.connector_ref,
+        required=binding.required,
+        redact_in_logs=binding.redact_in_logs,
+        created_at=binding.created_at,
+        updated_at=binding.updated_at,
+    )
+
+
+def _tool_policy_response(policy: ProjectMcpToolPolicy) -> ProjectMcpToolPolicyResponse:
+    return ProjectMcpToolPolicyResponse(
+        id=str(policy.id),
+        installation_id=str(policy.installation_id),
+        tool_name=policy.tool_name,
+        enabled=policy.enabled,
+        risk_level=policy.risk_level,
+        approval_policy=policy.approval_policy,
+        created_at=policy.created_at,
+        updated_at=policy.updated_at,
+    )
+
+
+def _installation_response(
+    installation: ProjectMcpInstallation,
+    server: McpServer,
+    *,
+    bindings: list[ProjectMcpCredentialBinding] | None = None,
+    policies: list[ProjectMcpToolPolicy] | None = None,
+) -> ProjectMcpInstallationResponse:
+    return ProjectMcpInstallationResponse(
+        id=str(installation.id),
+        project_id=str(installation.project_id),
+        mcp_server_id=str(installation.mcp_server_id),
+        source_pack_id=str(installation.source_pack_id) if installation.source_pack_id else None,
+        installed_by_user_id=str(installation.installed_by_user_id),
+        server_alias=installation.server_alias,
+        tool_prefix=installation.tool_prefix,
+        version_pin=installation.version_pin,
+        enabled=installation.enabled,
+        command_override=installation.command_override,
+        args_override=installation.args_override_json,
+        cwd_template_override=installation.cwd_template_override,
+        url_override=installation.url_override,
+        env_template=installation.env_template_json,
+        headers_template=installation.headers_template_json,
+        auth_override=installation.auth_override_json,
+        timeout_ms=installation.timeout_ms,
+        startup_timeout_ms=installation.startup_timeout_ms,
+        restart_policy=installation.restart_policy,
+        archived_at=installation.archived_at,
+        created_at=installation.created_at,
+        updated_at=installation.updated_at,
+        server=_server_response(server),
+        bindings=[_binding_response(binding) for binding in bindings or []],
+        tool_policies=[_tool_policy_response(policy) for policy in policies or []],
+    )
+
+
+def _readable_server_stmt(auth: AuthContext):
+    return select(McpServer).where(
+        McpServer.archived_at.is_(None),
+        or_(McpServer.visibility == "catalog", McpServer.owner_user_id == auth.user_id),
+    )
+
+
+def _readable_pack_stmt(auth: AuthContext):
+    return select(McpPack).where(
+        McpPack.archived_at.is_(None),
+        or_(McpPack.visibility == "catalog", McpPack.owner_user_id == auth.user_id),
+    )
+
+
+async def _get_readable_server(
+    db: AsyncSession,
+    auth: AuthContext,
+    server_id: UUID,
+) -> McpServer:
+    server = (
+        await db.execute(_readable_server_stmt(auth).where(McpServer.id == server_id))
+    ).scalar_one_or_none()
+    if server is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "MCP server not found")
+    return server
+
+
+async def _get_readable_pack(db: AsyncSession, auth: AuthContext, pack_id: UUID) -> McpPack:
+    pack = (
+        await db.execute(_readable_pack_stmt(auth).where(McpPack.id == pack_id))
+    ).scalar_one_or_none()
+    if pack is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "MCP pack not found")
+    return pack
+
+
+async def _get_owned_server(db: AsyncSession, auth: AuthContext, server_id: UUID) -> McpServer:
+    server = (
+        await db.execute(
+            select(McpServer).where(
+                McpServer.id == server_id,
+                McpServer.owner_user_id == auth.user_id,
+                McpServer.archived_at.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    if server is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "MCP server not found")
+    return server
+
+
+async def _get_owned_pack(db: AsyncSession, auth: AuthContext, pack_id: UUID) -> McpPack:
+    pack = (
+        await db.execute(
+            select(McpPack).where(
+                McpPack.id == pack_id,
+                McpPack.owner_user_id == auth.user_id,
+                McpPack.archived_at.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    if pack is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "MCP pack not found")
+    return pack
+
+
+async def _load_pack_response(db: AsyncSession, pack: McpPack) -> McpPackResponse:
+    rows = (
+        await db.execute(
+            select(McpPackEntry, McpServer)
+            .join(McpServer, McpServer.id == McpPackEntry.mcp_server_id)
+            .where(
+                McpPackEntry.pack_id == pack.id,
+                McpServer.archived_at.is_(None),
+            )
+            .order_by(McpPackEntry.server_alias)
+        )
+    ).all()
+    return _pack_response(
+        pack,
+        entries=[_pack_entry_response(entry, server) for entry, server in rows],
+    )
+
+
+async def _replace_pack_entries(
+    db: AsyncSession,
+    auth: AuthContext,
+    pack: McpPack,
+    entries: list[McpPackEntryInput],
+) -> None:
+    validated = await _validate_pack_entries(db, auth, entries)
+    await db.execute(delete(McpPackEntry).where(McpPackEntry.pack_id == pack.id))
+    _add_pack_entries(db, pack, validated)
+
+
+async def _validate_pack_entries(
+    db: AsyncSession,
+    auth: AuthContext,
+    entries: list[McpPackEntryInput],
+) -> list[tuple[McpPackEntryInput, UUID]]:
+    validated: list[tuple[McpPackEntryInput, UUID]] = []
+    for item in entries:
+        server = await _get_readable_server(db, auth, _uuid(item.mcp_server_id, "mcp_server_id"))
+        validated.append((item, server.id))
+    return validated
+
+
+def _add_pack_entries(
+    db: AsyncSession,
+    pack: McpPack,
+    entries: list[tuple[McpPackEntryInput, UUID]],
+) -> None:
+    for item, server_id in entries:
+        db.add(
+            McpPackEntry(
+                pack_id=pack.id,
+                mcp_server_id=server_id,
+                server_alias=item.server_alias,
+                default_tool_prefix=item.default_tool_prefix,
+                default_enabled=item.default_enabled,
+                version_pin=item.version_pin,
+            )
+        )
+
+
+async def _validate_source_pack_for_server(
+    db: AsyncSession,
+    auth: AuthContext,
+    source_pack_id: str | None,
+    server_id: UUID,
+) -> UUID | None:
+    if source_pack_id is None:
+        return None
+    pack_id = _uuid(source_pack_id, "source_pack_id")
+    await _get_readable_pack(db, auth, pack_id)
+    entry = (
+        await db.execute(
+            select(McpPackEntry.id).where(
+                McpPackEntry.pack_id == pack_id,
+                McpPackEntry.mcp_server_id == server_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if entry is None:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "MCP server is not part of source pack")
+    return pack_id
+
+
+async def _get_project_installation(
+    db: AsyncSession,
+    project_id: UUID,
+    installation_id: UUID,
+) -> ProjectMcpInstallation:
+    installation = (
+        await db.execute(
+            select(ProjectMcpInstallation).where(
+                ProjectMcpInstallation.id == installation_id,
+                ProjectMcpInstallation.project_id == project_id,
+                ProjectMcpInstallation.archived_at.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    if installation is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Project MCP installation not found")
+    return installation
+
+
+async def _load_installation_response(
+    db: AsyncSession,
+    installation: ProjectMcpInstallation,
+) -> ProjectMcpInstallationResponse:
+    server = (
+        await db.execute(select(McpServer).where(McpServer.id == installation.mcp_server_id))
+    ).scalar_one()
+    bindings = (
+        await db.execute(
+            select(ProjectMcpCredentialBinding).where(
+                ProjectMcpCredentialBinding.installation_id == installation.id
+            )
+        )
+    ).scalars()
+    policies = (
+        await db.execute(
+            select(ProjectMcpToolPolicy).where(
+                ProjectMcpToolPolicy.installation_id == installation.id
+            )
+        )
+    ).scalars()
+    return _installation_response(
+        installation,
+        server,
+        bindings=list(bindings.all()),
+        policies=list(policies.all()),
+    )
+
+
+def _apply_server_update(server: McpServer, body: McpServerUpdate) -> None:
+    data = body.model_dump(exclude_unset=True)
+    field_map = {
+        "default_args": "default_args_json",
+        "required_inputs": "required_inputs_json",
+        "auth_config": "auth_config_json",
+        "runtime_config": "runtime_config_json",
+        "capabilities": "capabilities_json",
+        "discovery_cache": "discovery_cache_json",
+        "risk_metadata": "risk_metadata_json",
+    }
+    for key, value in data.items():
+        setattr(server, field_map.get(key, key), value)
+
+
+def _apply_installation_update(
+    installation: ProjectMcpInstallation,
+    body: ProjectMcpInstallationUpdate,
+) -> None:
+    data = body.model_dump(exclude_unset=True)
+    field_map = {
+        "args_override": "args_override_json",
+        "env_template": "env_template_json",
+        "headers_template": "headers_template_json",
+        "auth_override": "auth_override_json",
+    }
+    for key, value in data.items():
+        setattr(installation, field_map.get(key, key), value)
+
+
+@router.get("/servers", response_model=list[McpServerResponse])
+async def list_mcp_servers(
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> list[McpServerResponse]:
+    rows = (
+        await db.execute(_readable_server_stmt(auth).order_by(McpServer.visibility, McpServer.slug))
+    ).scalars()
+    return [_server_response(row) for row in rows.all()]
+
+
+@router.post("/servers", response_model=McpServerResponse, status_code=status.HTTP_201_CREATED)
+async def create_mcp_server(
+    body: McpServerCreate,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> McpServerResponse:
+    if body.visibility != "private":
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "catalog MCP servers are operator-managed")
+    server = McpServer(
+        owner_user_id=auth.user_id,
+        slug=body.slug,
+        name=body.name,
+        description=body.description,
+        visibility=body.visibility,
+        source_type=body.source_type,
+        source_ref=body.source_ref,
+        transport=body.transport,
+        runtime_mode=body.runtime_mode,
+        default_command=body.default_command,
+        default_args_json=body.default_args,
+        default_cwd_template=body.default_cwd_template,
+        default_url=body.default_url,
+        required_inputs_json=body.required_inputs,
+        auth_config_json=body.auth_config,
+        runtime_config_json=body.runtime_config,
+        capabilities_json=body.capabilities,
+        discovery_cache_json=body.discovery_cache,
+        risk_metadata_json=body.risk_metadata,
+    )
+    db.add(server)
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status.HTTP_409_CONFLICT, "MCP server slug already exists") from exc
+    await db.refresh(server)
+    return _server_response(server)
+
+
+@router.get("/servers/{server_id}", response_model=McpServerResponse)
+async def get_mcp_server(
+    server_id: UUID,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> McpServerResponse:
+    return _server_response(await _get_readable_server(db, auth, server_id))
+
+
+@router.patch("/servers/{server_id}", response_model=McpServerResponse)
+async def update_mcp_server(
+    server_id: UUID,
+    body: McpServerUpdate,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> McpServerResponse:
+    server = await _get_owned_server(db, auth, server_id)
+    _apply_server_update(server, body)
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status.HTTP_409_CONFLICT, "MCP server update conflict") from exc
+    await db.refresh(server)
+    return _server_response(server)
+
+
+@router.delete("/servers/{server_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_mcp_server(
+    server_id: UUID,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> None:
+    server = await _get_owned_server(db, auth, server_id)
+    server.archived_at = datetime.now(UTC)
+    await db.commit()
+
+
+@router.get("/packs", response_model=list[McpPackResponse])
+async def list_mcp_packs(
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> list[McpPackResponse]:
+    rows = (
+        await db.execute(_readable_pack_stmt(auth).order_by(McpPack.visibility, McpPack.slug))
+    ).scalars()
+    return [await _load_pack_response(db, row) for row in rows.all()]
+
+
+@router.post("/packs", response_model=McpPackResponse, status_code=status.HTTP_201_CREATED)
+async def create_mcp_pack(
+    body: McpPackCreate,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> McpPackResponse:
+    if body.visibility != "private":
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "catalog MCP packs are operator-managed")
+    pack = McpPack(
+        owner_user_id=auth.user_id,
+        slug=body.slug,
+        name=body.name,
+        description=body.description,
+        visibility=body.visibility,
+    )
+    try:
+        entries = await _validate_pack_entries(db, auth, body.entries)
+        db.add(pack)
+        await db.flush()
+        _add_pack_entries(db, pack, entries)
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status.HTTP_409_CONFLICT, "MCP pack conflict") from exc
+    await db.refresh(pack)
+    return await _load_pack_response(db, pack)
+
+
+@router.get("/packs/{pack_id}", response_model=McpPackResponse)
+async def get_mcp_pack(
+    pack_id: UUID,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> McpPackResponse:
+    return await _load_pack_response(db, await _get_readable_pack(db, auth, pack_id))
+
+
+@router.patch("/packs/{pack_id}", response_model=McpPackResponse)
+async def update_mcp_pack(
+    pack_id: UUID,
+    body: McpPackUpdate,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> McpPackResponse:
+    pack = await _get_owned_pack(db, auth, pack_id)
+    data = body.model_dump(exclude_unset=True)
+    for key, value in data.items():
+        setattr(pack, key, value)
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status.HTTP_409_CONFLICT, "MCP pack update conflict") from exc
+    await db.refresh(pack)
+    return await _load_pack_response(db, pack)
+
+
+@router.put("/packs/{pack_id}/entries", response_model=McpPackResponse)
+async def put_mcp_pack_entries(
+    pack_id: UUID,
+    body: McpPackEntriesPut,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> McpPackResponse:
+    pack = await _get_owned_pack(db, auth, pack_id)
+    try:
+        await _replace_pack_entries(db, auth, pack, body.entries)
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status.HTTP_409_CONFLICT, "duplicate MCP pack entry") from exc
+    await db.refresh(pack)
+    return await _load_pack_response(db, pack)
+
+
+@router.delete("/packs/{pack_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_mcp_pack(
+    pack_id: UUID,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> None:
+    pack = await _get_owned_pack(db, auth, pack_id)
+    pack.archived_at = datetime.now(UTC)
+    await db.commit()
+
+
+@project_router.get("", response_model=list[ProjectMcpInstallationResponse])
+async def list_project_mcp_installations(
+    project_id: UUID,
+    auth: AuthContext = Depends(require_user_auth),
+    db: AsyncSession = Depends(get_session),
+) -> list[ProjectMcpInstallationResponse]:
+    await validate_project_read_for_caller(db, auth, project_id)
+    rows = (
+        await db.execute(
+            select(ProjectMcpInstallation)
+            .where(
+                ProjectMcpInstallation.project_id == project_id,
+                ProjectMcpInstallation.archived_at.is_(None),
+            )
+            .order_by(ProjectMcpInstallation.server_alias)
+        )
+    ).scalars()
+    return [await _load_installation_response(db, row) for row in rows.all()]
+
+
+@project_router.post(
+    "/installations",
+    response_model=ProjectMcpInstallationResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_project_mcp_installation(
+    project_id: UUID,
+    body: ProjectMcpInstallationCreate,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> ProjectMcpInstallationResponse:
+    await validate_project_for_caller(db, auth, project_id)
+    server = await _get_readable_server(db, auth, _uuid(body.mcp_server_id, "mcp_server_id"))
+    source_pack_id = await _validate_source_pack_for_server(
+        db,
+        auth,
+        body.source_pack_id,
+        server.id,
+    )
+    installation = ProjectMcpInstallation(
+        project_id=project_id,
+        mcp_server_id=server.id,
+        source_pack_id=source_pack_id,
+        installed_by_user_id=auth.user_id,
+        server_alias=body.server_alias or server.slug,
+        tool_prefix=body.tool_prefix,
+        version_pin=body.version_pin,
+        enabled=body.enabled,
+        command_override=body.command_override,
+        args_override_json=body.args_override,
+        cwd_template_override=body.cwd_template_override,
+        url_override=body.url_override,
+        env_template_json=body.env_template,
+        headers_template_json=body.headers_template,
+        auth_override_json=body.auth_override,
+        timeout_ms=body.timeout_ms,
+        startup_timeout_ms=body.startup_timeout_ms,
+        restart_policy=body.restart_policy,
+    )
+    db.add(installation)
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status.HTTP_409_CONFLICT, "Project MCP alias already exists") from exc
+    await db.refresh(installation)
+    return _installation_response(installation, server)
+
+
+@project_router.post(
+    "/packs/{pack_id}/install",
+    response_model=list[ProjectMcpInstallationResponse],
+    status_code=status.HTTP_201_CREATED,
+)
+async def install_mcp_pack_in_project(
+    project_id: UUID,
+    pack_id: UUID,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> list[ProjectMcpInstallationResponse]:
+    await validate_project_for_caller(db, auth, project_id)
+    pack = await _get_readable_pack(db, auth, pack_id)
+    rows = (
+        await db.execute(
+            select(McpPackEntry, McpServer)
+            .join(McpServer, McpServer.id == McpPackEntry.mcp_server_id)
+            .where(
+                McpPackEntry.pack_id == pack.id,
+                McpServer.archived_at.is_(None),
+            )
+            .order_by(McpPackEntry.server_alias)
+        )
+    ).all()
+    installations: list[tuple[ProjectMcpInstallation, McpServer]] = []
+    for entry, server in rows:
+        installation = ProjectMcpInstallation(
+            project_id=project_id,
+            mcp_server_id=server.id,
+            source_pack_id=pack.id,
+            installed_by_user_id=auth.user_id,
+            server_alias=entry.server_alias,
+            tool_prefix=entry.default_tool_prefix,
+            version_pin=entry.version_pin,
+            enabled=entry.default_enabled,
+        )
+        db.add(installation)
+        installations.append((installation, server))
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status.HTTP_409_CONFLICT, "Project MCP alias already exists") from exc
+    for installation, _server in installations:
+        await db.refresh(installation)
+    return [_installation_response(installation, server) for installation, server in installations]
+
+
+@project_router.get(
+    "/installations/{installation_id}",
+    response_model=ProjectMcpInstallationResponse,
+)
+async def get_project_mcp_installation(
+    project_id: UUID,
+    installation_id: UUID,
+    auth: AuthContext = Depends(require_user_auth),
+    db: AsyncSession = Depends(get_session),
+) -> ProjectMcpInstallationResponse:
+    await validate_project_read_for_caller(db, auth, project_id)
+    installation = await _get_project_installation(db, project_id, installation_id)
+    return await _load_installation_response(db, installation)
+
+
+@project_router.patch(
+    "/installations/{installation_id}",
+    response_model=ProjectMcpInstallationResponse,
+)
+async def update_project_mcp_installation(
+    project_id: UUID,
+    installation_id: UUID,
+    body: ProjectMcpInstallationUpdate,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> ProjectMcpInstallationResponse:
+    await validate_project_for_caller(db, auth, project_id)
+    installation = await _get_project_installation(db, project_id, installation_id)
+    _apply_installation_update(installation, body)
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status.HTTP_409_CONFLICT, "Project MCP update conflict") from exc
+    await db.refresh(installation)
+    return await _load_installation_response(db, installation)
+
+
+@project_router.delete(
+    "/installations/{installation_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_project_mcp_installation(
+    project_id: UUID,
+    installation_id: UUID,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> None:
+    await validate_project_for_caller(db, auth, project_id)
+    installation = await _get_project_installation(db, project_id, installation_id)
+    installation.archived_at = datetime.now(UTC)
+    await db.commit()
+
+
+async def _validate_binding_project_scope(
+    db: AsyncSession,
+    project_id: UUID,
+    binding: ProjectMcpCredentialBindingInput,
+) -> tuple[UUID | None, UUID | None]:
+    vault_id = _uuid(binding.vault_id, "vault_id") if binding.vault_id else None
+    vault_item_id = _uuid(binding.vault_item_id, "vault_item_id") if binding.vault_item_id else None
+    if binding.value_source != "vault":
+        return vault_id, vault_item_id
+    if vault_id is None or vault_item_id is None:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            "vault bindings require vault_id and vault_item_id",
+        )
+    row = (
+        await db.execute(
+            select(VaultItem)
+            .join(Vault, Vault.id == VaultItem.vault_id)
+            .join(VaultProjectAttachment, VaultProjectAttachment.vault_id == Vault.id)
+            .where(
+                Vault.id == vault_id,
+                VaultProjectAttachment.project_id == project_id,
+                VaultItem.id == vault_item_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Vault item not found in this Project")
+    return vault_id, vault_item_id
+
+
+@project_router.put(
+    "/installations/{installation_id}/bindings",
+    response_model=ProjectMcpInstallationResponse,
+)
+async def put_project_mcp_credential_bindings(
+    project_id: UUID,
+    installation_id: UUID,
+    body: ProjectMcpCredentialBindingsPut,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> ProjectMcpInstallationResponse:
+    await validate_project_for_caller(db, auth, project_id)
+    installation = await _get_project_installation(db, project_id, installation_id)
+    validated_bindings = []
+    for item in body.bindings:
+        vault_id, vault_item_id = await _validate_binding_project_scope(db, project_id, item)
+        validated_bindings.append((item, vault_id, vault_item_id))
+    await db.execute(
+        delete(ProjectMcpCredentialBinding).where(
+            ProjectMcpCredentialBinding.installation_id == installation.id
+        )
+    )
+    for item, vault_id, vault_item_id in validated_bindings:
+        db.add(
+            ProjectMcpCredentialBinding(
+                installation_id=installation.id,
+                target_kind=item.target_kind,
+                target_name=item.target_name,
+                value_source=item.value_source,
+                vault_id=vault_id,
+                vault_item_id=vault_item_id,
+                display_vault_uri=item.display_vault_uri,
+                local_env_name=item.local_env_name,
+                input_id=item.input_id,
+                connector_ref=item.connector_ref,
+                required=item.required,
+                redact_in_logs=item.redact_in_logs,
+            )
+        )
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status.HTTP_409_CONFLICT, "duplicate MCP credential binding") from exc
+    await db.refresh(installation)
+    return await _load_installation_response(db, installation)
+
+
+@project_router.put(
+    "/installations/{installation_id}/tools",
+    response_model=ProjectMcpInstallationResponse,
+)
+async def put_project_mcp_tool_policies(
+    project_id: UUID,
+    installation_id: UUID,
+    body: ProjectMcpToolPoliciesPut,
+    auth: AuthContext = Depends(require_user_auth_unbound),
+    db: AsyncSession = Depends(get_session),
+) -> ProjectMcpInstallationResponse:
+    await validate_project_for_caller(db, auth, project_id)
+    installation = await _get_project_installation(db, project_id, installation_id)
+    await db.execute(
+        delete(ProjectMcpToolPolicy).where(ProjectMcpToolPolicy.installation_id == installation.id)
+    )
+    for item in body.tools:
+        db.add(
+            ProjectMcpToolPolicy(
+                installation_id=installation.id,
+                tool_name=item.tool_name,
+                enabled=item.enabled,
+                risk_level=item.risk_level,
+                approval_policy=item.approval_policy,
+            )
+        )
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status.HTTP_409_CONFLICT, "duplicate MCP tool policy") from exc
+    await db.refresh(installation)
+    return await _load_installation_response(db, installation)

--- a/backend/app/schemas/mcp.py
+++ b/backend/app/schemas/mcp.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+Slug = str
+JsonDict = dict[str, Any]
+
+McpVisibility = Literal["catalog", "private"]
+McpSourceType = Literal["catalog", "custom", "composio", "pipedream", "docker"]
+McpTransport = Literal["stdio", "http", "sse", "streamable_http"]
+McpRuntimeMode = Literal["local", "remote"]
+McpRestartPolicy = Literal["none", "on_failure"]
+McpBindingTargetKind = Literal["env", "header", "arg", "url", "oauth", "config_file"]
+McpBindingValueSource = Literal["vault", "local_env", "input", "connector"]
+McpToolRiskLevel = Literal["read", "write", "destructive", "unknown"]
+McpToolApprovalPolicy = Literal["default", "always_ask", "never_allow"]
+
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,119}$")
+ALIAS_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,119}$")
+
+
+def _normalize_slug(value: str) -> str:
+    normalized = value.strip().lower()
+    if not SLUG_RE.fullmatch(normalized):
+        raise ValueError("slug must use lowercase letters, numbers, and hyphens")
+    return normalized
+
+
+def _normalize_alias(value: str) -> str:
+    normalized = value.strip().lower()
+    if not ALIAS_RE.fullmatch(normalized):
+        raise ValueError("alias must use lowercase letters, numbers, hyphens, and underscores")
+    return normalized
+
+
+class McpServerCreate(BaseModel):
+    slug: Slug = Field(min_length=1, max_length=120)
+    name: str = Field(min_length=1, max_length=200)
+    description: str | None = None
+    visibility: McpVisibility = "private"
+    source_type: McpSourceType = "custom"
+    source_ref: str | None = None
+    transport: McpTransport
+    runtime_mode: McpRuntimeMode = "local"
+    default_command: str | None = None
+    default_args: list[Any] | None = None
+    default_cwd_template: str | None = None
+    default_url: str | None = None
+    required_inputs: JsonDict | None = None
+    auth_config: JsonDict | None = None
+    runtime_config: JsonDict | None = None
+    capabilities: JsonDict | None = None
+    discovery_cache: JsonDict | None = None
+    risk_metadata: JsonDict | None = None
+
+    @field_validator("slug")
+    @classmethod
+    def validate_slug(cls, value: str) -> str:
+        return _normalize_slug(value)
+
+    @field_validator("name")
+    @classmethod
+    def strip_name(cls, value: str) -> str:
+        normalized = " ".join(value.split())
+        if not normalized:
+            raise ValueError("name is required")
+        return normalized
+
+
+class McpServerUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = None
+    source_type: McpSourceType | None = None
+    source_ref: str | None = None
+    transport: McpTransport | None = None
+    runtime_mode: McpRuntimeMode | None = None
+    default_command: str | None = None
+    default_args: list[Any] | None = None
+    default_cwd_template: str | None = None
+    default_url: str | None = None
+    required_inputs: JsonDict | None = None
+    auth_config: JsonDict | None = None
+    runtime_config: JsonDict | None = None
+    capabilities: JsonDict | None = None
+    discovery_cache: JsonDict | None = None
+    risk_metadata: JsonDict | None = None
+
+    @field_validator("name")
+    @classmethod
+    def strip_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = " ".join(value.split())
+        if not normalized:
+            raise ValueError("name is required")
+        return normalized
+
+
+class McpServerResponse(BaseModel):
+    id: str
+    owner_user_id: str | None
+    slug: str
+    name: str
+    description: str | None
+    visibility: McpVisibility
+    source_type: McpSourceType
+    source_ref: str | None
+    transport: McpTransport
+    runtime_mode: McpRuntimeMode
+    default_command: str | None
+    default_args: list[Any] | None
+    default_cwd_template: str | None
+    default_url: str | None
+    required_inputs: JsonDict | None
+    auth_config: JsonDict | None
+    runtime_config: JsonDict | None
+    capabilities: JsonDict | None
+    discovery_cache: JsonDict | None
+    risk_metadata: JsonDict | None
+    archived_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProjectMcpInstallationCreate(BaseModel):
+    mcp_server_id: str
+    source_pack_id: str | None = None
+    server_alias: str | None = Field(default=None, min_length=1, max_length=120)
+    tool_prefix: str | None = Field(default=None, min_length=1, max_length=120)
+    version_pin: str | None = Field(default=None, max_length=200)
+    enabled: bool = True
+    command_override: str | None = None
+    args_override: list[Any] | None = None
+    cwd_template_override: str | None = None
+    url_override: str | None = None
+    env_template: JsonDict | None = None
+    headers_template: JsonDict | None = None
+    auth_override: JsonDict | None = None
+    timeout_ms: int | None = Field(default=None, ge=1)
+    startup_timeout_ms: int | None = Field(default=None, ge=1)
+    restart_policy: McpRestartPolicy = "none"
+
+    @field_validator("server_alias", "tool_prefix")
+    @classmethod
+    def validate_alias(cls, value: str | None) -> str | None:
+        return _normalize_alias(value) if value is not None else None
+
+
+class ProjectMcpInstallationUpdate(BaseModel):
+    server_alias: str | None = Field(default=None, min_length=1, max_length=120)
+    tool_prefix: str | None = Field(default=None, min_length=1, max_length=120)
+    version_pin: str | None = Field(default=None, max_length=200)
+    enabled: bool | None = None
+    command_override: str | None = None
+    args_override: list[Any] | None = None
+    cwd_template_override: str | None = None
+    url_override: str | None = None
+    env_template: JsonDict | None = None
+    headers_template: JsonDict | None = None
+    auth_override: JsonDict | None = None
+    timeout_ms: int | None = Field(default=None, ge=1)
+    startup_timeout_ms: int | None = Field(default=None, ge=1)
+    restart_policy: McpRestartPolicy | None = None
+
+    @field_validator("server_alias", "tool_prefix")
+    @classmethod
+    def validate_alias(cls, value: str | None) -> str | None:
+        return _normalize_alias(value) if value is not None else None
+
+
+class McpPackEntryInput(BaseModel):
+    mcp_server_id: str
+    server_alias: str = Field(min_length=1, max_length=120)
+    default_tool_prefix: str | None = Field(default=None, min_length=1, max_length=120)
+    default_enabled: bool = True
+    version_pin: str | None = Field(default=None, max_length=200)
+
+    @field_validator("server_alias", "default_tool_prefix")
+    @classmethod
+    def validate_alias(cls, value: str | None) -> str | None:
+        return _normalize_alias(value) if value is not None else None
+
+
+class McpPackEntryResponse(BaseModel):
+    id: str
+    pack_id: str
+    mcp_server_id: str
+    server_alias: str
+    default_tool_prefix: str | None
+    default_enabled: bool
+    version_pin: str | None
+    created_at: datetime
+    updated_at: datetime
+    server: McpServerResponse
+
+
+class McpPackCreate(BaseModel):
+    slug: Slug = Field(min_length=1, max_length=120)
+    name: str = Field(min_length=1, max_length=200)
+    description: str | None = None
+    visibility: McpVisibility = "private"
+    entries: list[McpPackEntryInput] = Field(default_factory=list)
+
+    @field_validator("slug")
+    @classmethod
+    def validate_slug(cls, value: str) -> str:
+        return _normalize_slug(value)
+
+    @field_validator("name")
+    @classmethod
+    def strip_name(cls, value: str) -> str:
+        normalized = " ".join(value.split())
+        if not normalized:
+            raise ValueError("name is required")
+        return normalized
+
+
+class McpPackUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = None
+
+    @field_validator("name")
+    @classmethod
+    def strip_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = " ".join(value.split())
+        if not normalized:
+            raise ValueError("name is required")
+        return normalized
+
+
+class McpPackEntriesPut(BaseModel):
+    entries: list[McpPackEntryInput]
+
+
+class McpPackResponse(BaseModel):
+    id: str
+    owner_user_id: str | None
+    slug: str
+    name: str
+    description: str | None
+    visibility: McpVisibility
+    archived_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+    entries: list[McpPackEntryResponse] = Field(default_factory=list)
+
+
+class ProjectMcpCredentialBindingInput(BaseModel):
+    target_kind: McpBindingTargetKind
+    target_name: str = Field(min_length=1, max_length=200)
+    value_source: McpBindingValueSource = "vault"
+    vault_id: str | None = None
+    vault_item_id: str | None = None
+    display_vault_uri: str | None = None
+    local_env_name: str | None = Field(default=None, max_length=200)
+    input_id: str | None = Field(default=None, max_length=200)
+    connector_ref: str | None = Field(default=None, max_length=300)
+    required: bool = True
+    redact_in_logs: bool = True
+
+
+class ProjectMcpCredentialBindingsPut(BaseModel):
+    bindings: list[ProjectMcpCredentialBindingInput]
+
+
+class ProjectMcpCredentialBindingResponse(ProjectMcpCredentialBindingInput):
+    id: str
+    installation_id: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProjectMcpToolPolicyInput(BaseModel):
+    tool_name: str = Field(min_length=1, max_length=300)
+    enabled: bool = True
+    risk_level: McpToolRiskLevel = "unknown"
+    approval_policy: McpToolApprovalPolicy = "default"
+
+
+class ProjectMcpToolPoliciesPut(BaseModel):
+    tools: list[ProjectMcpToolPolicyInput]
+
+
+class ProjectMcpToolPolicyResponse(ProjectMcpToolPolicyInput):
+    id: str
+    installation_id: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProjectMcpInstallationResponse(BaseModel):
+    id: str
+    project_id: str
+    mcp_server_id: str
+    source_pack_id: str | None
+    installed_by_user_id: str
+    server_alias: str
+    tool_prefix: str | None
+    version_pin: str | None
+    enabled: bool
+    command_override: str | None
+    args_override: list[Any] | None
+    cwd_template_override: str | None
+    url_override: str | None
+    env_template: JsonDict | None
+    headers_template: JsonDict | None
+    auth_override: JsonDict | None
+    timeout_ms: int | None
+    startup_timeout_ms: int | None
+    restart_policy: McpRestartPolicy
+    archived_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+    server: McpServerResponse
+    bindings: list[ProjectMcpCredentialBindingResponse] = Field(default_factory=list)
+    tool_policies: list[ProjectMcpToolPolicyResponse] = Field(default_factory=list)

--- a/backend/tests/test_project_mcp_routes.py
+++ b/backend/tests/test_project_mcp_routes.py
@@ -1,0 +1,341 @@
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+
+async def _create_server(client, nonce: str):
+    response = await client.post(
+        "/api/mcp/servers",
+        json={
+            "slug": f"github-{nonce}",
+            "name": f"GitHub {nonce}",
+            "description": "GitHub MCP server",
+            "transport": "stdio",
+            "runtime_mode": "local",
+            "default_command": "npx",
+            "default_args": ["-y", "@modelcontextprotocol/server-github"],
+            "required_inputs": {"env": ["GITHUB_TOKEN"]},
+            "capabilities": {"tools": ["github.create_issue"]},
+            "risk_metadata": {"default_risk": "write"},
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+@pytest.mark.asyncio
+async def test_mcp_server_crud_and_catalog_guard(client):
+    nonce = uuid.uuid4().hex[:8]
+
+    catalog = await client.post(
+        "/api/mcp/servers",
+        json={
+            "slug": f"catalog-{nonce}",
+            "name": "Catalog Server",
+            "visibility": "catalog",
+            "transport": "stdio",
+        },
+    )
+    assert catalog.status_code == 403, catalog.text
+
+    created = await _create_server(client, nonce)
+    server_id = created["id"]
+    assert created["visibility"] == "private"
+    assert created["default_args"] == ["-y", "@modelcontextprotocol/server-github"]
+
+    patched = await client.patch(
+        f"/api/mcp/servers/{server_id}",
+        json={"name": "GitHub MCP", "default_args": ["-y", "github-mcp"]},
+    )
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["name"] == "GitHub MCP"
+    assert patched.json()["default_args"] == ["-y", "github-mcp"]
+
+    listing = await client.get("/api/mcp/servers")
+    assert listing.status_code == 200, listing.text
+    assert any(row["id"] == server_id for row in listing.json())
+
+    deleted = await client.delete(f"/api/mcp/servers/{server_id}")
+    assert deleted.status_code == 204, deleted.text
+
+    after_delete = await client.get("/api/mcp/servers")
+    assert after_delete.status_code == 200, after_delete.text
+    assert all(row["id"] != server_id for row in after_delete.json())
+
+
+@pytest.mark.asyncio
+async def test_project_mcp_pack_installation_bindings_and_tool_policy(
+    client,
+    db_session,
+    seed_user,
+    seed_project,
+):
+    from app.models.project import PROJECT_KIND_WORKSPACE, Project
+    from app.models.vault import Vault, VaultItem, VaultProjectAttachment
+    from app.services.vault_crypto import encrypt
+
+    nonce = uuid.uuid4().hex[:8]
+    server = await _create_server(client, nonce)
+
+    pack_response = await client.post(
+        "/api/mcp/packs",
+        json={
+            "slug": f"dev-tools-{nonce}",
+            "name": f"Dev Tools {nonce}",
+            "entries": [
+                {
+                    "mcp_server_id": server["id"],
+                    "server_alias": f"github-{nonce}",
+                    "default_tool_prefix": "gh",
+                    "default_enabled": True,
+                    "version_pin": "latest",
+                }
+            ],
+        },
+    )
+    assert pack_response.status_code == 201, pack_response.text
+    pack = pack_response.json()
+    assert pack["entries"][0]["server"]["id"] == server["id"]
+
+    install_response = await client.post(
+        f"/api/projects/{seed_project.id}/mcp/packs/{pack['id']}/install"
+    )
+    assert install_response.status_code == 201, install_response.text
+    installed = install_response.json()
+    assert len(installed) == 1
+    installation = installed[0]
+    assert installation["source_pack_id"] == pack["id"]
+    assert installation["server_alias"] == f"github-{nonce}"
+    assert installation["tool_prefix"] == "gh"
+
+    other_project = Project(
+        user_id=seed_user.id,
+        name=f"Other {nonce}",
+        slug=f"other-{nonce}",
+        kind=PROJECT_KIND_WORKSPACE,
+    )
+    db_session.add(other_project)
+    await db_session.flush()
+
+    other_vault = Vault(
+        user_id=seed_user.id,
+        slug=f"other-{nonce}",
+        name="Other Vault",
+    )
+    db_session.add(other_vault)
+    await db_session.flush()
+    db_session.add(VaultProjectAttachment(vault_id=other_vault.id, project_id=other_project.id))
+    other_ciphertext, other_nonce = encrypt("wrong-project")
+    other_item = VaultItem(
+        vault_id=other_vault.id,
+        section="",
+        item_name="GITHUB_TOKEN",
+        encrypted_value=other_ciphertext,
+        nonce=other_nonce,
+    )
+    db_session.add(other_item)
+
+    vault = Vault(
+        user_id=seed_user.id,
+        slug=f"github-{nonce}",
+        name="GitHub",
+    )
+    db_session.add(vault)
+    await db_session.flush()
+    db_session.add(VaultProjectAttachment(vault_id=vault.id, project_id=seed_project.id))
+    ciphertext, nonce_bytes = encrypt("secret-token")
+    item = VaultItem(
+        vault_id=vault.id,
+        section="",
+        item_name="GITHUB_TOKEN",
+        encrypted_value=ciphertext,
+        nonce=nonce_bytes,
+    )
+    db_session.add(item)
+    await db_session.commit()
+
+    rejected_binding = await client.put(
+        f"/api/projects/{seed_project.id}/mcp/installations/{installation['id']}/bindings",
+        json={
+            "bindings": [
+                {
+                    "target_kind": "env",
+                    "target_name": "GITHUB_TOKEN",
+                    "value_source": "vault",
+                    "vault_id": str(other_vault.id),
+                    "vault_item_id": str(other_item.id),
+                }
+            ]
+        },
+    )
+    assert rejected_binding.status_code == 404, rejected_binding.text
+
+    binding_response = await client.put(
+        f"/api/projects/{seed_project.id}/mcp/installations/{installation['id']}/bindings",
+        json={
+            "bindings": [
+                {
+                    "target_kind": "env",
+                    "target_name": "GITHUB_TOKEN",
+                    "value_source": "vault",
+                    "vault_id": str(vault.id),
+                    "vault_item_id": str(item.id),
+                    "display_vault_uri": f"vault://{vault.slug}/GITHUB_TOKEN",
+                },
+            ]
+        },
+    )
+    assert binding_response.status_code == 200, binding_response.text
+    bindings = binding_response.json()["bindings"]
+    binding = next(item for item in bindings if item["target_name"] == "GITHUB_TOKEN")
+    assert binding["vault_id"] == str(vault.id)
+    assert binding["vault_item_id"] == str(item.id)
+
+    policy_response = await client.put(
+        f"/api/projects/{seed_project.id}/mcp/installations/{installation['id']}/tools",
+        json={
+            "tools": [
+                {
+                    "tool_name": "github.create_issue",
+                    "enabled": False,
+                    "risk_level": "write",
+                    "approval_policy": "always_ask",
+                }
+            ]
+        },
+    )
+    assert policy_response.status_code == 200, policy_response.text
+    body = policy_response.json()
+    assert body["bindings"][0]["target_name"] == "GITHUB_TOKEN"
+    assert body["tool_policies"][0]["approval_policy"] == "always_ask"
+
+    listing = await client.get(f"/api/projects/{seed_project.id}/mcp")
+    assert listing.status_code == 200, listing.text
+    assert any(row["id"] == installation["id"] for row in listing.json())
+
+
+@pytest.mark.asyncio
+async def test_project_mcp_member_can_read_but_not_write_shared_installation(
+    client,
+    db_session,
+    seed_user,
+):
+    from app.models.mcp import McpServer, ProjectMcpInstallation
+    from app.models.project import PROJECT_KIND_WORKSPACE, Project
+    from app.models.project_membership import ProjectMembership
+    from app.models.user import User
+
+    nonce = uuid.uuid4().hex[:8]
+    owner = User(
+        clerk_id=f"mcp_owner_{nonce}",
+        email=f"mcp_owner_{nonce}@test.dev",
+        name="MCP Owner",
+    )
+    db_session.add(owner)
+    await db_session.commit()
+
+    shared = Project(
+        user_id=owner.id,
+        name=f"Shared MCP {nonce}",
+        slug=f"shared-mcp-{nonce}",
+        kind=PROJECT_KIND_WORKSPACE,
+    )
+    db_session.add(shared)
+    await db_session.flush()
+    db_session.add(
+        ProjectMembership(
+            project_id=shared.id,
+            member_user_id=seed_user.id,
+            role="viewer",
+            joined_via="invite",
+            joined_at=datetime.now(UTC),
+            resolved_owner_handle=f"mcp-{nonce}",
+        )
+    )
+    server = McpServer(
+        owner_user_id=owner.id,
+        slug=f"owner-github-{nonce}",
+        name="Owner GitHub",
+        transport="stdio",
+        runtime_mode="local",
+        default_command="npx",
+    )
+    db_session.add(server)
+    await db_session.flush()
+    installation = ProjectMcpInstallation(
+        project_id=shared.id,
+        mcp_server_id=server.id,
+        installed_by_user_id=owner.id,
+        server_alias=f"owner-github-{nonce}",
+        tool_prefix="owner",
+    )
+    db_session.add(installation)
+    await db_session.commit()
+
+    try:
+        listing = await client.get(f"/api/projects/{shared.id}/mcp")
+        assert listing.status_code == 200, listing.text
+        rows = listing.json()
+        assert rows[0]["id"] == str(installation.id)
+        assert rows[0]["server"]["owner_user_id"] == str(owner.id)
+
+        detail = await client.get(f"/api/projects/{shared.id}/mcp/installations/{installation.id}")
+        assert detail.status_code == 200, detail.text
+        assert detail.json()["server_alias"] == f"owner-github-{nonce}"
+
+        write = await client.post(
+            f"/api/projects/{shared.id}/mcp/installations",
+            json={
+                "mcp_server_id": str(server.id),
+                "server_alias": f"recipient-{nonce}",
+            },
+        )
+        assert write.status_code == 404, write.text
+
+        delete = await client.delete(
+            f"/api/projects/{shared.id}/mcp/installations/{installation.id}"
+        )
+        assert delete.status_code == 404, delete.text
+    finally:
+        await db_session.delete(shared)
+        await db_session.delete(owner)
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_env_bound_agent_key_cannot_list_account_mcp_library(db_session, seed_user):
+    import httpx
+
+    from app.core.auth import AuthContext, get_auth
+    from app.core.database import get_session
+    from app.main import app
+    from app.models.api_key import ApiKey
+    from tests.conftest import create_env_with_project
+
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"mcp-bound-{uuid.uuid4().hex[:8]}",
+        machine_name="Bound Agent",
+    )
+
+    async def _override_get_session():
+        yield db_session
+
+    async def _override_get_auth() -> AuthContext:
+        return AuthContext(
+            user=seed_user,
+            api_key=ApiKey(user_id=seed_user.id, environment_id=env.id),
+        )
+
+    app.dependency_overrides[get_session] = _override_get_session
+    app.dependency_overrides[get_auth] = _override_get_auth
+    try:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+            response = await ac.get("/api/mcp/servers")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 403, response.text

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1426,6 +1426,201 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/mcp/servers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Mcp Servers */
+        get: operations["list_mcp_servers_api_mcp_servers_get"];
+        put?: never;
+        /** Create Mcp Server */
+        post: operations["create_mcp_server_api_mcp_servers_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/mcp/servers/{server_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Mcp Server */
+        get: operations["get_mcp_server_api_mcp_servers__server_id__get"];
+        put?: never;
+        post?: never;
+        /** Delete Mcp Server */
+        delete: operations["delete_mcp_server_api_mcp_servers__server_id__delete"];
+        options?: never;
+        head?: never;
+        /** Update Mcp Server */
+        patch: operations["update_mcp_server_api_mcp_servers__server_id__patch"];
+        trace?: never;
+    };
+    "/api/mcp/packs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Mcp Packs */
+        get: operations["list_mcp_packs_api_mcp_packs_get"];
+        put?: never;
+        /** Create Mcp Pack */
+        post: operations["create_mcp_pack_api_mcp_packs_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/mcp/packs/{pack_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Mcp Pack */
+        get: operations["get_mcp_pack_api_mcp_packs__pack_id__get"];
+        put?: never;
+        post?: never;
+        /** Delete Mcp Pack */
+        delete: operations["delete_mcp_pack_api_mcp_packs__pack_id__delete"];
+        options?: never;
+        head?: never;
+        /** Update Mcp Pack */
+        patch: operations["update_mcp_pack_api_mcp_packs__pack_id__patch"];
+        trace?: never;
+    };
+    "/api/mcp/packs/{pack_id}/entries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Put Mcp Pack Entries */
+        put: operations["put_mcp_pack_entries_api_mcp_packs__pack_id__entries_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/mcp": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Project Mcp Installations */
+        get: operations["list_project_mcp_installations_api_projects__project_id__mcp_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/mcp/installations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Project Mcp Installation */
+        post: operations["create_project_mcp_installation_api_projects__project_id__mcp_installations_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/mcp/packs/{pack_id}/install": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Install Mcp Pack In Project */
+        post: operations["install_mcp_pack_in_project_api_projects__project_id__mcp_packs__pack_id__install_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/mcp/installations/{installation_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Project Mcp Installation */
+        get: operations["get_project_mcp_installation_api_projects__project_id__mcp_installations__installation_id__get"];
+        put?: never;
+        post?: never;
+        /** Delete Project Mcp Installation */
+        delete: operations["delete_project_mcp_installation_api_projects__project_id__mcp_installations__installation_id__delete"];
+        options?: never;
+        head?: never;
+        /** Update Project Mcp Installation */
+        patch: operations["update_project_mcp_installation_api_projects__project_id__mcp_installations__installation_id__patch"];
+        trace?: never;
+    };
+    "/api/projects/{project_id}/mcp/installations/{installation_id}/bindings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Put Project Mcp Credential Bindings */
+        put: operations["put_project_mcp_credential_bindings_api_projects__project_id__mcp_installations__installation_id__bindings_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/projects/{project_id}/mcp/installations/{installation_id}/tools": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Put Project Mcp Tool Policies */
+        put: operations["put_project_mcp_tool_policies_api_projects__project_id__mcp_installations__installation_id__tools_put"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/search": {
         parameters: {
             query?: never;
@@ -2348,6 +2543,303 @@ export interface components {
              */
             created_at: string;
         };
+        /** McpPackCreate */
+        McpPackCreate: {
+            /** Slug */
+            slug: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description?: string | null;
+            /**
+             * Visibility
+             * @default private
+             * @enum {string}
+             */
+            visibility: "catalog" | "private";
+            /** Entries */
+            entries?: components["schemas"]["McpPackEntryInput"][];
+        };
+        /** McpPackEntriesPut */
+        McpPackEntriesPut: {
+            /** Entries */
+            entries: components["schemas"]["McpPackEntryInput"][];
+        };
+        /** McpPackEntryInput */
+        McpPackEntryInput: {
+            /** Mcp Server Id */
+            mcp_server_id: string;
+            /** Server Alias */
+            server_alias: string;
+            /** Default Tool Prefix */
+            default_tool_prefix?: string | null;
+            /**
+             * Default Enabled
+             * @default true
+             */
+            default_enabled: boolean;
+            /** Version Pin */
+            version_pin?: string | null;
+        };
+        /** McpPackEntryResponse */
+        McpPackEntryResponse: {
+            /** Id */
+            id: string;
+            /** Pack Id */
+            pack_id: string;
+            /** Mcp Server Id */
+            mcp_server_id: string;
+            /** Server Alias */
+            server_alias: string;
+            /** Default Tool Prefix */
+            default_tool_prefix: string | null;
+            /** Default Enabled */
+            default_enabled: boolean;
+            /** Version Pin */
+            version_pin: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            server: components["schemas"]["McpServerResponse"];
+        };
+        /** McpPackResponse */
+        McpPackResponse: {
+            /** Id */
+            id: string;
+            /** Owner User Id */
+            owner_user_id: string | null;
+            /** Slug */
+            slug: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string | null;
+            /**
+             * Visibility
+             * @enum {string}
+             */
+            visibility: "catalog" | "private";
+            /** Archived At */
+            archived_at: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /** Entries */
+            entries?: components["schemas"]["McpPackEntryResponse"][];
+        };
+        /** McpPackUpdate */
+        McpPackUpdate: {
+            /** Name */
+            name?: string | null;
+            /** Description */
+            description?: string | null;
+        };
+        /** McpServerCreate */
+        McpServerCreate: {
+            /** Slug */
+            slug: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description?: string | null;
+            /**
+             * Visibility
+             * @default private
+             * @enum {string}
+             */
+            visibility: "catalog" | "private";
+            /**
+             * Source Type
+             * @default custom
+             * @enum {string}
+             */
+            source_type: "catalog" | "custom" | "composio" | "pipedream" | "docker";
+            /** Source Ref */
+            source_ref?: string | null;
+            /**
+             * Transport
+             * @enum {string}
+             */
+            transport: "stdio" | "http" | "sse" | "streamable_http";
+            /**
+             * Runtime Mode
+             * @default local
+             * @enum {string}
+             */
+            runtime_mode: "local" | "remote";
+            /** Default Command */
+            default_command?: string | null;
+            /** Default Args */
+            default_args?: unknown[] | null;
+            /** Default Cwd Template */
+            default_cwd_template?: string | null;
+            /** Default Url */
+            default_url?: string | null;
+            /** Required Inputs */
+            required_inputs?: {
+                [key: string]: unknown;
+            } | null;
+            /** Auth Config */
+            auth_config?: {
+                [key: string]: unknown;
+            } | null;
+            /** Runtime Config */
+            runtime_config?: {
+                [key: string]: unknown;
+            } | null;
+            /** Capabilities */
+            capabilities?: {
+                [key: string]: unknown;
+            } | null;
+            /** Discovery Cache */
+            discovery_cache?: {
+                [key: string]: unknown;
+            } | null;
+            /** Risk Metadata */
+            risk_metadata?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /** McpServerResponse */
+        McpServerResponse: {
+            /** Id */
+            id: string;
+            /** Owner User Id */
+            owner_user_id: string | null;
+            /** Slug */
+            slug: string;
+            /** Name */
+            name: string;
+            /** Description */
+            description: string | null;
+            /**
+             * Visibility
+             * @enum {string}
+             */
+            visibility: "catalog" | "private";
+            /**
+             * Source Type
+             * @enum {string}
+             */
+            source_type: "catalog" | "custom" | "composio" | "pipedream" | "docker";
+            /** Source Ref */
+            source_ref: string | null;
+            /**
+             * Transport
+             * @enum {string}
+             */
+            transport: "stdio" | "http" | "sse" | "streamable_http";
+            /**
+             * Runtime Mode
+             * @enum {string}
+             */
+            runtime_mode: "local" | "remote";
+            /** Default Command */
+            default_command: string | null;
+            /** Default Args */
+            default_args: unknown[] | null;
+            /** Default Cwd Template */
+            default_cwd_template: string | null;
+            /** Default Url */
+            default_url: string | null;
+            /** Required Inputs */
+            required_inputs: {
+                [key: string]: unknown;
+            } | null;
+            /** Auth Config */
+            auth_config: {
+                [key: string]: unknown;
+            } | null;
+            /** Runtime Config */
+            runtime_config: {
+                [key: string]: unknown;
+            } | null;
+            /** Capabilities */
+            capabilities: {
+                [key: string]: unknown;
+            } | null;
+            /** Discovery Cache */
+            discovery_cache: {
+                [key: string]: unknown;
+            } | null;
+            /** Risk Metadata */
+            risk_metadata: {
+                [key: string]: unknown;
+            } | null;
+            /** Archived At */
+            archived_at: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
+        /** McpServerUpdate */
+        McpServerUpdate: {
+            /** Name */
+            name?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Source Type */
+            source_type?: ("catalog" | "custom" | "composio" | "pipedream" | "docker") | null;
+            /** Source Ref */
+            source_ref?: string | null;
+            /** Transport */
+            transport?: ("stdio" | "http" | "sse" | "streamable_http") | null;
+            /** Runtime Mode */
+            runtime_mode?: ("local" | "remote") | null;
+            /** Default Command */
+            default_command?: string | null;
+            /** Default Args */
+            default_args?: unknown[] | null;
+            /** Default Cwd Template */
+            default_cwd_template?: string | null;
+            /** Default Url */
+            default_url?: string | null;
+            /** Required Inputs */
+            required_inputs?: {
+                [key: string]: unknown;
+            } | null;
+            /** Auth Config */
+            auth_config?: {
+                [key: string]: unknown;
+            } | null;
+            /** Runtime Config */
+            runtime_config?: {
+                [key: string]: unknown;
+            } | null;
+            /** Capabilities */
+            capabilities?: {
+                [key: string]: unknown;
+            } | null;
+            /** Discovery Cache */
+            discovery_cache?: {
+                [key: string]: unknown;
+            } | null;
+            /** Risk Metadata */
+            risk_metadata?: {
+                [key: string]: unknown;
+            } | null;
+        };
         /**
          * MemberResponse
          * @description Returned by GET /api/projects/{project_id}/members.
@@ -2487,6 +2979,316 @@ export interface components {
             name: string;
             /** Slug */
             slug?: string | null;
+        };
+        /** ProjectMcpCredentialBindingInput */
+        ProjectMcpCredentialBindingInput: {
+            /**
+             * Target Kind
+             * @enum {string}
+             */
+            target_kind: "env" | "header" | "arg" | "url" | "oauth" | "config_file";
+            /** Target Name */
+            target_name: string;
+            /**
+             * Value Source
+             * @default vault
+             * @enum {string}
+             */
+            value_source: "vault" | "local_env" | "input" | "connector";
+            /** Vault Id */
+            vault_id?: string | null;
+            /** Vault Item Id */
+            vault_item_id?: string | null;
+            /** Display Vault Uri */
+            display_vault_uri?: string | null;
+            /** Local Env Name */
+            local_env_name?: string | null;
+            /** Input Id */
+            input_id?: string | null;
+            /** Connector Ref */
+            connector_ref?: string | null;
+            /**
+             * Required
+             * @default true
+             */
+            required: boolean;
+            /**
+             * Redact In Logs
+             * @default true
+             */
+            redact_in_logs: boolean;
+        };
+        /** ProjectMcpCredentialBindingResponse */
+        ProjectMcpCredentialBindingResponse: {
+            /**
+             * Target Kind
+             * @enum {string}
+             */
+            target_kind: "env" | "header" | "arg" | "url" | "oauth" | "config_file";
+            /** Target Name */
+            target_name: string;
+            /**
+             * Value Source
+             * @default vault
+             * @enum {string}
+             */
+            value_source: "vault" | "local_env" | "input" | "connector";
+            /** Vault Id */
+            vault_id?: string | null;
+            /** Vault Item Id */
+            vault_item_id?: string | null;
+            /** Display Vault Uri */
+            display_vault_uri?: string | null;
+            /** Local Env Name */
+            local_env_name?: string | null;
+            /** Input Id */
+            input_id?: string | null;
+            /** Connector Ref */
+            connector_ref?: string | null;
+            /**
+             * Required
+             * @default true
+             */
+            required: boolean;
+            /**
+             * Redact In Logs
+             * @default true
+             */
+            redact_in_logs: boolean;
+            /** Id */
+            id: string;
+            /** Installation Id */
+            installation_id: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
+        /** ProjectMcpCredentialBindingsPut */
+        ProjectMcpCredentialBindingsPut: {
+            /** Bindings */
+            bindings: components["schemas"]["ProjectMcpCredentialBindingInput"][];
+        };
+        /** ProjectMcpInstallationCreate */
+        ProjectMcpInstallationCreate: {
+            /** Mcp Server Id */
+            mcp_server_id: string;
+            /** Source Pack Id */
+            source_pack_id?: string | null;
+            /** Server Alias */
+            server_alias?: string | null;
+            /** Tool Prefix */
+            tool_prefix?: string | null;
+            /** Version Pin */
+            version_pin?: string | null;
+            /**
+             * Enabled
+             * @default true
+             */
+            enabled: boolean;
+            /** Command Override */
+            command_override?: string | null;
+            /** Args Override */
+            args_override?: unknown[] | null;
+            /** Cwd Template Override */
+            cwd_template_override?: string | null;
+            /** Url Override */
+            url_override?: string | null;
+            /** Env Template */
+            env_template?: {
+                [key: string]: unknown;
+            } | null;
+            /** Headers Template */
+            headers_template?: {
+                [key: string]: unknown;
+            } | null;
+            /** Auth Override */
+            auth_override?: {
+                [key: string]: unknown;
+            } | null;
+            /** Timeout Ms */
+            timeout_ms?: number | null;
+            /** Startup Timeout Ms */
+            startup_timeout_ms?: number | null;
+            /**
+             * Restart Policy
+             * @default none
+             * @enum {string}
+             */
+            restart_policy: "none" | "on_failure";
+        };
+        /** ProjectMcpInstallationResponse */
+        ProjectMcpInstallationResponse: {
+            /** Id */
+            id: string;
+            /** Project Id */
+            project_id: string;
+            /** Mcp Server Id */
+            mcp_server_id: string;
+            /** Source Pack Id */
+            source_pack_id: string | null;
+            /** Installed By User Id */
+            installed_by_user_id: string;
+            /** Server Alias */
+            server_alias: string;
+            /** Tool Prefix */
+            tool_prefix: string | null;
+            /** Version Pin */
+            version_pin: string | null;
+            /** Enabled */
+            enabled: boolean;
+            /** Command Override */
+            command_override: string | null;
+            /** Args Override */
+            args_override: unknown[] | null;
+            /** Cwd Template Override */
+            cwd_template_override: string | null;
+            /** Url Override */
+            url_override: string | null;
+            /** Env Template */
+            env_template: {
+                [key: string]: unknown;
+            } | null;
+            /** Headers Template */
+            headers_template: {
+                [key: string]: unknown;
+            } | null;
+            /** Auth Override */
+            auth_override: {
+                [key: string]: unknown;
+            } | null;
+            /** Timeout Ms */
+            timeout_ms: number | null;
+            /** Startup Timeout Ms */
+            startup_timeout_ms: number | null;
+            /**
+             * Restart Policy
+             * @enum {string}
+             */
+            restart_policy: "none" | "on_failure";
+            /** Archived At */
+            archived_at: string | null;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            server: components["schemas"]["McpServerResponse"];
+            /** Bindings */
+            bindings?: components["schemas"]["ProjectMcpCredentialBindingResponse"][];
+            /** Tool Policies */
+            tool_policies?: components["schemas"]["ProjectMcpToolPolicyResponse"][];
+        };
+        /** ProjectMcpInstallationUpdate */
+        ProjectMcpInstallationUpdate: {
+            /** Server Alias */
+            server_alias?: string | null;
+            /** Tool Prefix */
+            tool_prefix?: string | null;
+            /** Version Pin */
+            version_pin?: string | null;
+            /** Enabled */
+            enabled?: boolean | null;
+            /** Command Override */
+            command_override?: string | null;
+            /** Args Override */
+            args_override?: unknown[] | null;
+            /** Cwd Template Override */
+            cwd_template_override?: string | null;
+            /** Url Override */
+            url_override?: string | null;
+            /** Env Template */
+            env_template?: {
+                [key: string]: unknown;
+            } | null;
+            /** Headers Template */
+            headers_template?: {
+                [key: string]: unknown;
+            } | null;
+            /** Auth Override */
+            auth_override?: {
+                [key: string]: unknown;
+            } | null;
+            /** Timeout Ms */
+            timeout_ms?: number | null;
+            /** Startup Timeout Ms */
+            startup_timeout_ms?: number | null;
+            /** Restart Policy */
+            restart_policy?: ("none" | "on_failure") | null;
+        };
+        /** ProjectMcpToolPoliciesPut */
+        ProjectMcpToolPoliciesPut: {
+            /** Tools */
+            tools: components["schemas"]["ProjectMcpToolPolicyInput"][];
+        };
+        /** ProjectMcpToolPolicyInput */
+        ProjectMcpToolPolicyInput: {
+            /** Tool Name */
+            tool_name: string;
+            /**
+             * Enabled
+             * @default true
+             */
+            enabled: boolean;
+            /**
+             * Risk Level
+             * @default unknown
+             * @enum {string}
+             */
+            risk_level: "read" | "write" | "destructive" | "unknown";
+            /**
+             * Approval Policy
+             * @default default
+             * @enum {string}
+             */
+            approval_policy: "default" | "always_ask" | "never_allow";
+        };
+        /** ProjectMcpToolPolicyResponse */
+        ProjectMcpToolPolicyResponse: {
+            /** Tool Name */
+            tool_name: string;
+            /**
+             * Enabled
+             * @default true
+             */
+            enabled: boolean;
+            /**
+             * Risk Level
+             * @default unknown
+             * @enum {string}
+             */
+            risk_level: "read" | "write" | "destructive" | "unknown";
+            /**
+             * Approval Policy
+             * @default default
+             * @enum {string}
+             */
+            approval_policy: "default" | "always_ask" | "never_allow";
+            /** Id */
+            id: string;
+            /** Installation Id */
+            installation_id: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
         };
         /** ProjectResponse */
         ProjectResponse: {
@@ -5772,6 +6574,605 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ConnectorToolResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_mcp_servers_api_mcp_servers_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpServerResponse"][];
+                };
+            };
+        };
+    };
+    create_mcp_server_api_mcp_servers_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["McpServerCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpServerResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_mcp_server_api_mcp_servers__server_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                server_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpServerResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_mcp_server_api_mcp_servers__server_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                server_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_mcp_server_api_mcp_servers__server_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                server_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["McpServerUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpServerResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_mcp_packs_api_mcp_packs_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpPackResponse"][];
+                };
+            };
+        };
+    };
+    create_mcp_pack_api_mcp_packs_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["McpPackCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpPackResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_mcp_pack_api_mcp_packs__pack_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                pack_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpPackResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_mcp_pack_api_mcp_packs__pack_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                pack_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_mcp_pack_api_mcp_packs__pack_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                pack_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["McpPackUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpPackResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    put_mcp_pack_entries_api_mcp_packs__pack_id__entries_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                pack_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["McpPackEntriesPut"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpPackResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_project_mcp_installations_api_projects__project_id__mcp_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectMcpInstallationResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_project_mcp_installation_api_projects__project_id__mcp_installations_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProjectMcpInstallationCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectMcpInstallationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    install_mcp_pack_in_project_api_projects__project_id__mcp_packs__pack_id__install_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                pack_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectMcpInstallationResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_project_mcp_installation_api_projects__project_id__mcp_installations__installation_id__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                installation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectMcpInstallationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_project_mcp_installation_api_projects__project_id__mcp_installations__installation_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                installation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    update_project_mcp_installation_api_projects__project_id__mcp_installations__installation_id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                installation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProjectMcpInstallationUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectMcpInstallationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    put_project_mcp_credential_bindings_api_projects__project_id__mcp_installations__installation_id__bindings_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                installation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProjectMcpCredentialBindingsPut"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectMcpInstallationResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    put_project_mcp_tool_policies_api_projects__project_id__mcp_installations__installation_id__tools_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                project_id: string;
+                installation_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProjectMcpToolPoliciesPut"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProjectMcpInstallationResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Summary
- add Project MCP metadata tables for servers, packs, pack entries, Project installations, credential bindings, and tool policies
- add account-level MCP server/pack routes plus Project install/bind/tool policy routes
- keep Project member reads enabled while owner-only writes and env-bound Agent key restrictions remain enforced
- keep credential bindings Vault/local-env/input/connector based; no plaintext literal credential storage
- rebase on the Composio Tool Router MCP bridge and keep `/api/mcp/composio` as the connector bridge path
- regenerate shared OpenAPI types

Related planning doc: #103

## Verification
- `cd backend && uv run alembic heads`
- `cd backend && DATABASE_URL=postgresql+asyncpg://clawdi:clawdi_dev@127.0.0.1:5433/clawdi_rebase_composio_check uv run alembic upgrade head`
- `cd backend && uv run ruff check alembic/versions/e3a1c0f8b9d2_project_mcp_metadata.py app/models/mcp.py app/schemas/mcp.py app/routes/mcp.py app/main.py tests/test_project_mcp_routes.py`
- `cd backend && uv run python scripts/check_generated_api.py`
- `bun run typecheck`
- `cd backend && DATABASE_URL=postgresql+asyncpg://clawdi:clawdi_dev@127.0.0.1:5433/clawdi_rebase_composio_check uv run pytest tests/test_project_mcp_routes.py tests/test_settings_and_mcp.py -q`
- `bun test packages/cli/src/mcp/server.test.ts`
- `cd backend && DATABASE_URL=postgresql+asyncpg://clawdi:clawdi_dev@127.0.0.1:5433/clawdi_rebase_composio_check uv run pytest -q`