### PR TITLE
chore: automate GitHub releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+    authors:
+      - dependabot
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+        - semver-major
+    - title: Features
+      labels:
+        - enhancement
+        - feature
+    - title: Fixes
+      labels:
+        - bug
+        - fix
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Maintenance
+      labels:
+        - "*"

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -26,13 +26,15 @@ jobs:
     # trusted-publisher OIDC so no NPM_TOKEN secret is needed.
     environment: npm
     permissions:
-      contents: read
+      contents: write
       id-token: write
     defaults:
       run:
         working-directory: packages/cli
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -100,3 +102,46 @@ jobs:
       - name: Publish to npm
         if: steps.check.outputs.skip != 'true'
         run: npm publish --access public --provenance --ignore-scripts
+
+      - name: Create GitHub release
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="clawdi-cli-v${VERSION}"
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub release $TAG already exists; skipping."
+            exit 0
+          fi
+
+          PREVIOUS=$(
+            git tag --list 'clawdi-cli-v*' --sort=-v:refname \
+              | grep -v "^${TAG}$" \
+              | head -n 1 || true
+          )
+
+          NOTES=$(cat <<EOF
+          ## npm
+          - Package: \`clawdi@${VERSION}\`
+          - Install: \`npm i -g clawdi@${VERSION}\`
+
+          ## Scope
+          This is the release for the published \`packages/cli\` package. Backend
+          and web changes are versioned separately as \`cloud-v...\` releases.
+          EOF
+          )
+
+          args=(
+            release create "$TAG"
+            --target "$GITHUB_SHA"
+            --title "Clawdi CLI v${VERSION}"
+            --notes "$NOTES"
+            --generate-notes
+            --latest=false
+          )
+          if [ -n "$PREVIOUS" ]; then
+            args+=(--notes-start-tag "$PREVIOUS")
+          fi
+          gh "${args[@]}"

--- a/.github/workflows/cloud-release.yml
+++ b/.github/workflows/cloud-release.yml
@@ -1,0 +1,93 @@
+name: Release Cloud
+
+# Creates a GitHub Release for backend/web/shared changes that land on main.
+# This repo is a monorepo: the npm package has its own `clawdi-cli-vX.Y.Z`
+# release, while the hosted backend + web app use calendar-versioned
+# `cloud-vYYYY.MM.DD.<run_number>` releases.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version without the cloud-v prefix. Defaults to YYYY.MM.DD.<run_number>."
+        required: false
+      target:
+        description: "Commit SHA to release. Defaults to the workflow SHA."
+        required: false
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - "apps/web/**"
+      - "packages/shared/**"
+      - "package.json"
+      - "bun.lock"
+      - "turbo.json"
+      - "tsconfig.base.json"
+      - "biome.json"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: cloud-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Create cloud release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_TARGET: ${{ inputs.target }}
+        run: |
+          TARGET="${INPUT_TARGET:-$GITHUB_SHA}"
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="${INPUT_VERSION#cloud-v}"
+          else
+            VERSION="$(date -u +%Y.%m.%d).${GITHUB_RUN_NUMBER}"
+          fi
+          TAG="cloud-v${VERSION}"
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "GitHub release $TAG already exists; skipping."
+            exit 0
+          fi
+
+          PREVIOUS=$(
+            git tag --list 'cloud-v*' --sort=-creatordate \
+              | grep -v "^${TAG}$" \
+              | head -n 1 || true
+          )
+
+          NOTES=$(cat <<EOF
+          ## Scope
+          This is the release for Clawdi Cloud: backend API, web dashboard, and
+          shared generated clients.
+
+          ## Deployment
+          - Commit: \`${TARGET}\`
+          - Production backend deploy still runs through \`/opt/clawdi-cloud\`
+            with Alembic migrations and supervisor restart.
+          - CLI/npm releases are versioned separately as \`clawdi-cli-v...\`.
+          EOF
+          )
+
+          args=(
+            release create "$TAG"
+            --target "$TARGET"
+            --title "Clawdi Cloud ${VERSION}"
+            --notes "$NOTES"
+            --generate-notes
+            --latest
+          )
+          if [ -n "$PREVIOUS" ]; then
+            args+=(--notes-start-tag "$PREVIOUS")
+          fi
+          gh "${args[@]}"

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -231,6 +231,24 @@ version bump. A merge with no version change is a no-op — the workflow
 diffs `packages/cli/package.json` against `npm view clawdi version` and
 exits early on a match.
 
+The monorepo has two GitHub Release lines:
+
+- `clawdi-cli-vX.Y.Z` for the published npm package. The CLI publish
+  workflow creates this release after npm publish succeeds and prepends
+  package/install notes to the generated changelog.
+- `cloud-vYYYY.MM.DD.<run_number>` for backend, web, and shared-client
+  changes. `.github/workflows/cloud-release.yml` creates this release
+  when relevant files land on `main`; it can also be run manually with a
+  specific version/commit after an out-of-band production deploy.
+
+Use the release body as the changelog. GitHub's generated notes are
+categorized by `.github/release.yml`; add `skip-changelog` to PRs that
+should not show up.
+
+Old preview releases can be deleted when their binaries and install links
+are no longer needed. Prefer leaving them as prereleases while they are
+still useful for reproducing old preview environments.
+
 ### Bootstrap (one-time, before the workflow can do anything)
 
 npm's trusted-publisher OIDC requires the package to already exist on the
@@ -256,7 +274,8 @@ onward releases are automatic.
 3. The workflow runs typecheck → `bun run build` → `bun test` →
    `npm publish --access public --provenance`. Each step is a separate
    job so a failing test doesn't pollute the publish log.
-4. Watch the Actions tab; on green, `npm view clawdi version` will
+4. The workflow creates `clawdi-cli-v<version>` with changelog notes.
+5. Watch the Actions tab; on green, `npm view clawdi version` will
    reflect the new number within ~60s.
 
 A manual run is available under `workflow_dispatch` if the auto-run


### PR DESCRIPTION
## Summary
- create CLI GitHub releases after npm publish succeeds
- add cloud/backend/web release workflow with calendar-version tags
- add generated release-note categories and release docs

## Verification
- parsed workflow YAML with PyYAML
- ran git diff --check
- created current releases: clawdi-cli-v0.7.0 and cloud-v2026.05.20.1

## Notes
- preview-0.1.0 was left in place because deleting old preview binaries breaks existing install links; it is no longer Latest.