### PR TITLE
docs: add product-facing changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,6 +2,10 @@ changelog:
   exclude:
     labels:
       - skip-changelog
+      - dependencies
+      - chore
+      - ci
+      - maintenance
     authors:
       - dependabot
   categories:
@@ -17,9 +21,10 @@ changelog:
       labels:
         - bug
         - fix
+    - title: Security
+      labels:
+        - security
     - title: Documentation
       labels:
         - documentation
-    - title: Maintenance
-      labels:
-        - "*"
+        - docs

--- a/.github/workflows/clawdi-release.yml
+++ b/.github/workflows/clawdi-release.yml
@@ -1,15 +1,15 @@
-name: Release Cloud
+name: Release Clawdi
 
 # Creates a GitHub Release for backend/web/shared changes that land on main.
 # This repo is a monorepo: the npm package has its own `clawdi-cli-vX.Y.Z`
-# release, while the hosted backend + web app use calendar-versioned
-# `cloud-vYYYY.MM.DD.<run_number>` releases.
+# release, while the Clawdi app/backend/web line uses calendar-versioned
+# `clawdi-vYYYY.MM.DD.<run_number>` releases.
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version without the cloud-v prefix. Defaults to YYYY.MM.DD.<run_number>."
+        description: "Release version without the clawdi-v prefix. Defaults to YYYY.MM.DD.<run_number>."
         required: false
       target:
         description: "Commit SHA to release. Defaults to the workflow SHA."
@@ -30,7 +30,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: cloud-release
+  group: clawdi-release
   cancel-in-progress: false
 
 jobs:
@@ -41,7 +41,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create cloud release
+      - name: Create Clawdi release
         env:
           GH_TOKEN: ${{ github.token }}
           INPUT_VERSION: ${{ inputs.version }}
@@ -49,11 +49,11 @@ jobs:
         run: |
           TARGET="${INPUT_TARGET:-$GITHUB_SHA}"
           if [ -n "$INPUT_VERSION" ]; then
-            VERSION="${INPUT_VERSION#cloud-v}"
+            VERSION="${INPUT_VERSION#clawdi-v}"
           else
             VERSION="$(date -u +%Y.%m.%d).${GITHUB_RUN_NUMBER}"
           fi
-          TAG="cloud-v${VERSION}"
+          TAG="clawdi-v${VERSION}"
 
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "GitHub release $TAG already exists; skipping."
@@ -61,28 +61,23 @@ jobs:
           fi
 
           PREVIOUS=$(
-            git tag --list 'cloud-v*' --sort=-creatordate \
+            git tag --list 'clawdi-v*' --sort=-creatordate \
               | grep -v "^${TAG}$" \
               | head -n 1 || true
           )
 
           NOTES=$(cat <<EOF
           ## Scope
-          This is the release for Clawdi Cloud: backend API, web dashboard, and
-          shared generated clients.
+          This is the release for Clawdi app/backend/web changes.
 
-          ## Deployment
-          - Commit: \`${TARGET}\`
-          - Production backend deploy still runs through \`/opt/clawdi-cloud\`
-            with Alembic migrations and supervisor restart.
-          - CLI/npm releases are versioned separately as \`clawdi-cli-v...\`.
+          CLI/npm releases are versioned separately as \`clawdi-cli-v...\`.
           EOF
           )
 
           args=(
             release create "$TAG"
             --target "$TARGET"
-            --title "Clawdi Cloud ${VERSION}"
+            --title "Clawdi ${VERSION}"
             --notes "$NOTES"
             --generate-notes
             --latest

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -128,8 +128,9 @@ jobs:
           - Install: \`npm i -g clawdi@${VERSION}\`
 
           ## Scope
-          This is the release for the published \`packages/cli\` package. Backend
-          and web changes are versioned separately as \`cloud-v...\` releases.
+          This is the release for the published \`packages/cli\` package.
+          Clawdi app/backend/web changes are versioned separately as
+          \`clawdi-v...\` releases.
           EOF
           )
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,30 @@
 # Changelog
 
-This changelog tracks user-facing Clawdi releases. GitHub Releases remain the
-canonical release artifacts:
+This changelog tracks notable user-facing Clawdi releases. It is written for
+people using or upgrading Clawdi, so it intentionally omits internal deployment,
+database migration, CI, and implementation details.
 
-- Cloud/backend/web releases use `cloud-vYYYY.MM.DD.<run_number>`.
+- Clawdi app/backend/web releases use `clawdi-vYYYY.MM.DD.<run_number>`.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
-## Clawdi Cloud 2026.05.20.1
+## Clawdi 2026.05.20.1
 
-Release: https://github.com/Clawdi-AI/clawdi/releases/tag/cloud-v2026.05.20.1
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-v2026.05.20.1
 
 ### Added
 
-- Added backend support for bulk exact `clawdi://` reference resolution.
-- Added `vault_credential_profiles` storage for personal local CLI credential sync.
-- Added plaintext-free preview resolution for vault references.
-- Added generated OpenAPI client updates for the new vault APIs.
+- Added first-class `clawdi://` secret references for project-scoped vault
+  secrets.
+- Added dry-run secret previews that show where a secret resolves from without
+  printing plaintext.
+- Added support for syncing local CLI credential profiles for Codex, Claude
+  Code, and GitHub CLI.
 
 ### Changed
 
-- Hardened shared Project and env-bound Agent credential boundaries.
-- Separated runtime vault secrets from local CLI credential profile backup/restore.
-
-### Migration
-
-- Applied Alembic migration `e4f8a91c2d3b`.
-- The migration creates `vault_credential_profiles` and indexes only; it does not
-  rewrite existing vault data.
+- Improved vault conflict and provenance handling for multi-project and agent
+  workflows.
+- Kept local CLI credential profiles separate from runtime vault secrets.
 
 ### Security
 
@@ -56,8 +54,8 @@ Package: `clawdi@0.7.0`
 - `clawdi run --env-file` can resolve explicit references without broad
   all-vault env injection.
 
-### Operational Notes
+### Security
 
-- `clawdi@0.7.0` expects hosted backend support for vault bulk resolve and
-  credential profile endpoints.
-- Vault storage remains server-managed encryption, not zero-knowledge.
+- Secret reference previews do not print secret values.
+- Local CLI credential profiles are restored only for the authenticated user
+  who stored them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+This changelog tracks user-facing Clawdi releases. GitHub Releases remain the
+canonical release artifacts:
+
+- Cloud/backend/web releases use `cloud-vYYYY.MM.DD.<run_number>`.
+- CLI/npm releases use `clawdi-cli-vX.Y.Z`.
+
+## Clawdi Cloud 2026.05.20.1
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/cloud-v2026.05.20.1
+
+### Added
+
+- Added backend support for bulk exact `clawdi://` reference resolution.
+- Added `vault_credential_profiles` storage for personal local CLI credential sync.
+- Added plaintext-free preview resolution for vault references.
+- Added generated OpenAPI client updates for the new vault APIs.
+
+### Changed
+
+- Hardened shared Project and env-bound Agent credential boundaries.
+- Separated runtime vault secrets from local CLI credential profile backup/restore.
+
+### Migration
+
+- Applied Alembic migration `e4f8a91c2d3b`.
+- The migration creates `vault_credential_profiles` and indexes only; it does not
+  rewrite existing vault data.
+
+### Security
+
+- Shared Project viewers can use shared runtime vault values, but cannot store or
+  materialize another user's local CLI credential profiles.
+- Vault storage remains server-managed encryption, not zero-knowledge.
+
+## Clawdi CLI v0.7.0
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.7.0
+
+Package: `clawdi@0.7.0`
+
+### Added
+
+- Added `clawdi://` secret reference workflows across `read`, `inject`, and
+  `run --env-file`.
+- Added exact Project-scoped references such as
+  `clawdi://project/<project>/vault/<vault>/field/<field>`.
+- Added bulk reference resolution for templates and env files.
+- Added local credential profile sync for Codex, Claude Code, and GitHub CLI.
+- Added dry-run previews that show provenance without requesting plaintext.
+
+### Changed
+
+- `clawdi inject` writes generated secret files owner-only.
+- `clawdi run --env-file` can resolve explicit references without broad
+  all-vault env injection.
+
+### Operational Notes
+
+- `clawdi@0.7.0` expects hosted backend support for vault bulk resolve and
+  credential profile endpoints.
+- Vault storage remains server-managed encryption, not zero-knowledge.

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -139,7 +139,7 @@ validate installation and adapter `detect()` but not session parsing.
 
 ## Running the backend
 
-Full-pipe commands need the Clawdi Cloud backend on `:8000`. PostgreSQL
+Full-pipe commands need the Clawdi backend on `:8000`. PostgreSQL
 (with `pgvector` + `pg_trgm`) must be running first — see the root
 README for setup details.
 
@@ -236,14 +236,17 @@ The monorepo has two GitHub Release lines:
 - `clawdi-cli-vX.Y.Z` for the published npm package. The CLI publish
   workflow creates this release after npm publish succeeds and prepends
   package/install notes to the generated changelog.
-- `cloud-vYYYY.MM.DD.<run_number>` for backend, web, and shared-client
-  changes. `.github/workflows/cloud-release.yml` creates this release
+- `clawdi-vYYYY.MM.DD.<run_number>` for Clawdi app/backend/web changes.
+  `.github/workflows/clawdi-release.yml` creates this release
   when relevant files land on `main`; it can also be run manually with a
   specific version/commit after an out-of-band production deploy.
 
 Use the release body as the changelog. GitHub's generated notes are
 categorized by `.github/release.yml`; add `skip-changelog` to PRs that
-should not show up.
+should not show up. Keep release notes user-facing: include notable features,
+behavior changes, fixes, deprecations, removals, security notes, and user
+actions; omit migrations, CI, deployment steps, refactors, generated files, and
+other implementation-only details.
 
 Old preview releases can be deleted when their binaries and install links
 are no longer needed. Prefer leaving them as prereleases while they are

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -242,11 +242,13 @@ The monorepo has two GitHub Release lines:
   specific version/commit after an out-of-band production deploy.
 
 Use the release body as the changelog. GitHub's generated notes are
-categorized by `.github/release.yml`; add `skip-changelog` to PRs that
-should not show up. Keep release notes user-facing: include notable features,
-behavior changes, fixes, deprecations, removals, security notes, and user
-actions; omit migrations, CI, deployment steps, refactors, generated files, and
-other implementation-only details.
+categorized by `.github/release.yml`; only PRs with release-note labels such as
+`feature`, `fix`, `security`, or `documentation` are included. Add
+`skip-changelog` to explicitly suppress a PR that would otherwise appear. Keep
+release notes user-facing: include notable features, behavior changes, fixes,
+deprecations, removals, security notes, and user actions; omit migrations, CI,
+deployment steps, refactors, generated files, and other implementation-only
+details.
 
 Old preview releases can be deleted when their binaries and install links
 are no longer needed. Prefer leaving them as prereleases while they are


### PR DESCRIPTION
## Summary
- add a root CHANGELOG.md for Clawdi releases using product-facing Added/Changed/Security sections
- standardize release tags as `clawdi-vYYYY.MM.DD.<run_number>` for app/backend/web and `clawdi-cli-vX.Y.Z` for the npm CLI
- rename the app release workflow from `cloud-release` to `clawdi-release`
- tune GitHub generated release notes so internal maintenance PRs are not included by default

## Verification
- git diff --check
- verified `preview-0.1.0` release/tag was removed
- renamed the existing app release to `Clawdi 2026.05.20.1` / `clawdi-v2026.05.20.1`
- deleted the old orphan `cloud-v2026.05.20.1` tag