### PR TITLE
Improve CLI daemon setup and auto-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ database migration, CI, and implementation details.
 - Clawdi app/backend/web releases use `clawdi-vYYYY.MM.DD.<run_number>`.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.8.0
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.8.0
+
+Package: `clawdi@0.8.0`
+
+### Added
+
+- Added `clawdi daemon` as the primary command for managing background sync.
+  The old `clawdi serve` command remains available as a legacy alias.
+- Added default daemon installation during `clawdi setup`, so every registered
+  local agent gets live sync unless setup is run with `--no-daemon`.
+- Added background auto-update for installed daemons. Daemons check for newer
+  CLI releases, install them silently, and let launchd/systemd restart onto the
+  new version.
+
+### Changed
+
+- CLI and daemon auto-update now install the latest available release, including
+  major versions.
+- `clawdi update` installs by default; use `--check` to report only.
+
+### Fixed
+
+- Reduced daemon idle and burst overhead by coalescing retry-queue persistence,
+  waking the queue only when work arrives, and debouncing skill watcher events.
+- Closed background auto-update log descriptors in the parent CLI process.
+
 ## Clawdi 2026.05.20.1
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-v2026.05.20.1

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ That gets you:
 - Agent auto-detection for Claude Code, Codex, Hermes, and OpenClaw
 - MCP registration so your agent can call Clawdi tools
 - The bundled `clawdi` skill installed into each detected agent
+- Background sync daemons installed and started for every registered agent
 - A health check that verifies auth, agent paths, vault access, and MCP config
 
 By default the CLI talks to hosted Clawdi Cloud. Want to run your own backend? See [Own the Stack](#own-the-stack).
@@ -207,7 +208,7 @@ Local self-hosting currently expects:
 - PostgreSQL 16 with `pg_trgm` and `pgvector`
 - Clerk keys for dashboard auth
 - Two generated encryption keys for vault data and MCP proxy JWTs
-- **One backend process** until v1.5. The `clawdi serve` realtime SSE fan-out lives in process memory (`backend/app/services/sync_events.py`), so a broadcast on worker A doesn't reach a daemon attached to worker B. Run a single uvicorn worker (or one gunicorn worker with `--workers 1`) behind your reverse proxy. Multi-process fan-out via Postgres LISTEN/NOTIFY ships in v1.5.
+- **One backend process** until v1.5. The `clawdi daemon` realtime SSE fan-out lives in process memory (`backend/app/services/sync_events.py`), so a broadcast on worker A doesn't reach a daemon attached to worker B. Run a single uvicorn worker (or one gunicorn worker with `--workers 1`) behind your reverse proxy. Multi-process fan-out via Postgres LISTEN/NOTIFY ships in v1.5.
 
 See [`backend/.env.example`](backend/.env.example) and [`apps/web/.env.example`](apps/web/.env.example) for the exact environment variables.
 
@@ -249,8 +250,9 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](packages/cli
 | --- | --- |
 | `clawdi auth login` / `logout` | Authenticate this machine |
 | `clawdi status [--json]` | Show auth and sync state |
-| `clawdi setup [--agent <type>]` | Register local agents, install MCP, install the bundled skill |
+| `clawdi setup [--agent <type>] [--no-daemon]` | Register local agents, install MCP, install the bundled skill, and install/start daemons by default |
 | `clawdi teardown [--agent <type>]` | Remove Clawdi's local agent wiring |
+| `clawdi daemon run/install/status/logs/doctor/restart/uninstall` | Run and manage the background sync daemon (`serve` remains a legacy alias) |
 | `clawdi push` | Upload sessions and skills |
 | `clawdi pull` | Download cloud skills into registered agents |
 | `clawdi memory list/search/add/rm` | Manage cross-agent long-term memory |
@@ -265,7 +267,9 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](packages/cli
 | `clawdi inject --in <file> --out <file>` | Render `clawdi://` references into templates |
 | `clawdi run --env-file <file> -- <cmd>` | Run a command with explicit vault references resolved |
 | `clawdi doctor` | Diagnose auth, agent paths, vault, and MCP config |
-| `clawdi update` | Check for a newer CLI version |
+| `clawdi update` | Install the latest CLI version (`--check` only reports) |
+
+Auto-update is enabled by default for all newer releases, including majors. Human CLI invocations update the global CLI in the background; installed daemons check on their own cadence, install silently, then let launchd/systemd restart them onto the new code. Disable both with `CLAWDI_NO_AUTO_UPDATE=1` or `clawdi config set autoUpdate false`.
 | `clawdi mcp` | Start the MCP stdio server used by agents |
 
 Every command supports `--help`.
@@ -333,7 +337,7 @@ Common issues:
 - **No supported agent detected** - Install a supported agent or pass `--agent claude_code`, `--agent codex`, `--agent hermes`, or `--agent openclaw`.
 - **Memory search is empty** - Add a memory first with `clawdi memory add "..."`, then verify with `clawdi memory search "..."`.
 - **Local backend cannot start because `vector` is missing** - Install `pgvector` for your PostgreSQL 16 instance, or use the included Docker Compose database.
-- **Agent MCP tools look stale** - Run `clawdi setup --agent <type>` again and restart the agent.
+- **Agent MCP tools look stale** - Run `clawdi setup --agent <type>` again, then `clawdi daemon restart --all`.
 
 ## License
 

--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -56,7 +56,7 @@ If it prints "Still waiting for approval" (exit code 2), the user hasn't clicked
 clawdi setup
 ```
 
-Auto-detects every installed AI agent (Claude Code, Codex, Hermes, OpenClaw), registers each with the cloud, and installs the Clawdi MCP server in each agent's home. Without an `--agent` flag it picks up everything detected — which is what you want, so the next step can sync from all of them.
+Auto-detects every installed AI agent (Claude Code, Codex, Hermes, OpenClaw), registers each with the cloud, installs the Clawdi MCP server in each agent's home, and installs background sync daemons by default. Without an `--agent` flag it picks up everything detected — which is what you want, so later sync steps can cover all of them.
 
 ## Sync the user's sessions
 
@@ -123,17 +123,21 @@ Resolve `~` to an absolute path before passing to the CLI.
 
 Note the "X new, Y updated, Z unchanged" total from the push output — you'll cite it next.
 
-## Turn on live sync (recommended)
+## Verify live sync (recommended)
 
-Without this step, the user has to remember to run `clawdi push` and `clawdi pull` by hand whenever they edit a skill. Most won't. Install the sync daemon so changes flow automatically in both directions — local edits show up on the dashboard within a second, dashboard installs land on the laptop within two.
+`clawdi setup` installs the sync daemon by default so changes flow automatically in both directions — local edits show up on the dashboard within a second, dashboard installs land on the laptop within two. Verify it is running:
 
 ```bash
-clawdi serve install --agent claude_code
+clawdi daemon status
 ```
 
-Replace `claude_code` with whichever agent the user has installed (you saw the list during `clawdi setup`). If they have multiple, run install once per agent — each gets its own supervised daemon.
+If the user opted out during setup, install it now:
 
-The command writes a launchd unit on macOS or a systemd `--user` service on Linux, then loads it. The daemon stays alive across reboots and respawns on crash. Ongoing logs:
+```bash
+clawdi daemon install --all
+```
+
+The install command writes a launchd unit on macOS or a systemd `--user` service on Linux, then loads it. The daemon stays alive across reboots and respawns on crash. Ongoing logs:
 
 - macOS: `tail -f ~/.clawdi/serve/logs/<agent>.stderr.log`
 - Linux: `journalctl --user -u clawdi-serve-<agent> -f`
@@ -150,7 +154,7 @@ Skip this step only if the user explicitly says they want manual sync. The CLI f
 If install fails (no launchd / systemd, e.g. inside a minimal container), fall back to running the daemon in the foreground and ask the user to wire their own supervisor:
 
 ```bash
-clawdi serve --agent claude_code
+clawdi daemon run --agent claude_code
 ```
 
 ## Sync skills (optional one-time backup)

--- a/apps/web/src/components/dashboard/add-agent-setup.tsx
+++ b/apps/web/src/components/dashboard/add-agent-setup.tsx
@@ -32,16 +32,16 @@ const CLI_STEPS = [
 		description: "Opens your browser to authorize this machine.",
 	},
 	{
-		title: "Connect this agent",
+		title: "Connect and enable sync",
 		code: "clawdi setup",
 		description:
-			"Detects Claude Code / Codex / Hermes / OpenClaw, registers each one with your account.",
+			"Detects Claude Code / Codex / Hermes / OpenClaw, registers each one with your account, and installs background daemons by default.",
 	},
 	{
-		title: "Turn on live sync",
-		code: "clawdi serve install --all",
+		title: "Check live sync",
+		code: "clawdi daemon status",
 		description:
-			"Installs a tiny background service per registered agent — Claude Code, Codex, OpenClaw, Hermes — so anything you change here lands on the machine in seconds, and vice versa. To install for one agent, replace `--all` with `--agent <name>`.",
+			"Shows the daemon state for every registered agent. If you opted out during setup, run `clawdi daemon install --all`.",
 	},
 	{
 		title: "One-time history backup (optional)",

--- a/apps/web/src/components/dashboard/daemon-status.tsx
+++ b/apps/web/src/components/dashboard/daemon-status.tsx
@@ -147,7 +147,7 @@ export function DaemonStatusBadge({
 	env: Env;
 	/** "on-clawdi" tiles change the dialog copy across every non-
 	 * live state: hosted users don't have a CLI to run
-	 * `clawdi serve install` / `clawdi serve status` / `clawdi auth login`
+	 * `clawdi daemon install` / `clawdi daemon status` / `clawdi auth login`
 	 * against — the supervised daemon ships in the pod image. All
 	 * remediation copy points back at the Clawdi dashboard
 	 * (`manageHref`) instead. Self-managed installs see the
@@ -364,14 +364,14 @@ function SyncHelpDialog({
 												<p className="text-xs text-muted-foreground">
 													Daemon stopped after this error. Inspect:
 												</p>
-												<CommandLine command="clawdi serve status" />
+												<CommandLine command="clawdi daemon status" />
 												<AuthLoginHint />
 											</>
 										)
 									) : isPermanentError(env.last_sync_error) ? (
 										// Same product story on both sides: permanent drop means the
 										// daemon is still healthy and will pick up the next edit.
-										// Self-managed offers `clawdi serve status` as a sanity check;
+										// Self-managed offers `clawdi daemon status` as a sanity check;
 										// hosted users have no CLI, so we just explain the daemon
 										// state and let the next file save do the rest.
 										<>
@@ -386,7 +386,7 @@ function SyncHelpDialog({
 												build output). Fix the source and re-save to retry — the daemon is still
 												healthy and will pick up the next edit.
 											</p>
-											{isHosted ? null : <CommandLine command="clawdi serve status" />}
+											{isHosted ? null : <CommandLine command="clawdi daemon status" />}
 										</>
 									) : isRetryExhaustedError(env.last_sync_error) ? (
 										<>
@@ -396,7 +396,7 @@ function SyncHelpDialog({
 												automatically once connectivity is back; no source edit needed.
 												{isHosted ? null : " If your network looks fine, inspect:"}
 											</p>
-											{isHosted ? null : <CommandLine command="clawdi serve status" />}
+											{isHosted ? null : <CommandLine command="clawdi daemon status" />}
 										</>
 									) : isHosted ? (
 										<>
@@ -411,7 +411,7 @@ function SyncHelpDialog({
 											<p className="text-xs text-muted-foreground">
 												It will keep retrying. If this persists:
 											</p>
-											<CommandLine command="clawdi serve status" />
+											<CommandLine command="clawdi daemon status" />
 											<AuthLoginHint />
 										</>
 									)}
@@ -432,9 +432,9 @@ function SyncHelpDialog({
 										<p className="text-sm text-muted-foreground">
 											Daemon isn&apos;t checking in. From the same terminal you set it up on:
 										</p>
-										<CommandLine command="clawdi serve status" />
+										<CommandLine command="clawdi daemon status" />
 										<p className="text-sm text-muted-foreground">If it&apos;s down, restart:</p>
-										<CommandLine command={`clawdi serve install --agent ${env.agent_type}`} />
+										<CommandLine command={`clawdi daemon install --agent ${env.agent_type}`} />
 									</div>
 								)
 							) : null}
@@ -503,15 +503,15 @@ function SyncSetupSnippet({ env }: { env: Env }) {
 }
 
 /** Hand-off prompt the user pastes into Claude / Codex / etc. The
- * agent reads the prompt, runs `clawdi serve install --all`, and
- * confirms with `clawdi serve status`. Mirrors the prose tone and
+ * agent reads the prompt, runs `clawdi daemon install --all`, and
+ * confirms with `clawdi daemon status`. Mirrors the prose tone and
  * structure of `useAgentPrompt` in add-agent-setup.tsx. */
 function useSyncAgentPrompt(env: Env): string {
 	const typeLabel = agentTypeLabel(env.agent_type);
 	return [
 		`Turn on Clawdi live sync on this machine for ${typeLabel}.`,
-		"Run `clawdi serve install --all` to install the per-user daemon for every Clawdi-registered agent on this machine.",
-		"Then confirm with `clawdi serve status` and report whether the daemon is live.",
+		"Run `clawdi daemon install --all` to install the per-user daemon for every Clawdi-registered agent on this machine.",
+		"Then confirm with `clawdi daemon status` and report whether the daemon is live.",
 	].join(" ");
 }
 
@@ -528,8 +528,8 @@ function SyncSetupAgentTab({ env }: { env: Env }) {
 }
 
 function SyncSetupCliTab({ env }: { env: Env }) {
-	const perAgentCmd = `clawdi serve install --agent ${env.agent_type}`;
-	const allCmd = "clawdi serve install --all";
+	const perAgentCmd = `clawdi daemon install --agent ${env.agent_type}`;
+	const allCmd = "clawdi daemon install --all";
 	return (
 		<div className="space-y-3">
 			<p className="text-sm text-muted-foreground">In a terminal on this machine, run either:</p>

--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -307,7 +307,7 @@ function ApiKeysPanel() {
 							CLAWDI_AUTH_TOKEN
 						</code>{" "}
 						(this is the env var the CLI and{" "}
-						<code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">clawdi serve</code>{" "}
+						<code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">clawdi daemon</code>{" "}
 						actually read).
 					</>
 				}

--- a/backend/app/core/project.py
+++ b/backend/app/core/project.py
@@ -304,10 +304,10 @@ async def project_ids_visible_to(
       * api_key WITHOUT env binding (the device-flow CLI key from
         `clawdi auth login`) → ALL the user's projects, same as
         Clerk JWT. The user authenticated as themselves; multi-
-        agent setups need `clawdi serve --agent <other>` and
+        agent setups need `clawdi daemon run --agent <other>` and
         `clawdi push --all` to operate on any of the user's envs,
         not just whichever was touched last. An earlier "single
-        most-recently-active project" policy broke `serve --agent`
+        most-recently-active project" policy broke `daemon run --agent`
         when its project wasn't the default, since the daemon's
         explicit `?project_id=...` listing intersected to empty.
     """

--- a/backend/app/models/api_key.py
+++ b/backend/app/models/api_key.py
@@ -27,7 +27,7 @@ class ApiKey(Base, TimestampMixin):
 
     # API permission set this key is allowed to act under. Examples:
     # `["sessions:write", "skills:read", "skills:write"]` (deploy-key
-    # for `clawdi serve` daemon). NULL means full account access —
+    # for `clawdi daemon`). NULL means full account access —
     # interactive `clawdi auth login` keys keep this null for backwards
     # compatibility with existing CLI flows.
     scopes: Mapped[list[str] | None] = mapped_column(ARRAY(String(64)))

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -50,7 +50,7 @@ class AgentEnvironment(Base, TimestampMixin):
     os: Mapped[str] = mapped_column(String(50), nullable=False)
     last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
-    # `clawdi serve` daemon observability. last_seen_at is the
+    # `clawdi daemon` observability. last_seen_at is the
     # legacy "anything happened on this env" timestamp; sync_*
     # fields are specifically about the daemon's push/pull cycle.
     # Dashboard renders "Last synced: X ago" + "Daemon offline" red
@@ -61,7 +61,7 @@ class AgentEnvironment(Base, TimestampMixin):
     # lets server detect "missed events" if SSE drops mid-flight.
     last_revision_seen: Mapped[int | None] = mapped_column(Integer)
     # Peak retry-queue depth since the daemon last booted. Resets
-    # on `clawdi serve` start. NOT a 24h rolling window — that
+    # on `clawdi daemon` start. NOT a 24h rolling window — that
     # needs real time-series storage and is not part of v1.
     queue_depth_high_water_since_start: Mapped[int] = mapped_column(
         Integer, server_default="0", nullable=False

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -396,7 +396,7 @@ async def delete_environment(
 
 
 class SyncHeartbeatRequest(BaseModel):
-    """Daemon-emitted observability snapshot for `clawdi serve`.
+    """Daemon-emitted observability snapshot for `clawdi daemon`.
 
     Sent every ~30s even on quiet cycles so the dashboard's
     "Last synced: X ago" indicator stays fresh and the operator
@@ -499,7 +499,7 @@ async def sync_heartbeat(
         env.dropped_count_since_start = (
             env.dropped_count_since_start or 0
         ) + body.dropped_count_delta
-    # A heartbeat IS the user opting in: they ran `clawdi serve` (or
+    # A heartbeat IS the user opting in: they ran `clawdi daemon` (or
     # installed the launchd / systemd unit) and the daemon is
     # successfully posting liveness. The `sync_enabled` flag was a
     # canary toggle so existing envs wouldn't auto-pick-up sync at

--- a/backend/app/routes/sync.py
+++ b/backend/app/routes/sync.py
@@ -1,4 +1,4 @@
-"""SSE event channel for `clawdi serve` daemons.
+"""SSE event channel for `clawdi daemon` processes.
 
 Daemon opens a long-lived `GET /api/sync/events` connection authed
 with the same Bearer token it uses for any other API call; server
@@ -151,7 +151,7 @@ async def events(
         api_key_id=auth.api_key.id if auth.api_key is not None else None,
         # Per-key cap only applies to Agent API keys. Unbound
         # CLI keys are user-level (one key shared across N daemons
-        # via `clawdi serve install --all`), so the per-key cap of 2
+        # via `clawdi daemon install --all`), so the per-key cap of 2
         # would silently 429 the third local agent on a multi-agent
         # machine.
         is_env_bound=(auth.api_key is not None and auth.api_key.environment_id is not None),

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -129,7 +129,7 @@ class EnvironmentResponse(BaseModel):
     agent_version: str | None
     os: str
     last_seen_at: datetime | None
-    # `clawdi serve` daemon liveness / observability — populated by
+    # `clawdi daemon` liveness / observability — populated by
     # the heartbeat endpoint. NULL on environments whose daemon
     # has never checked in (legacy laptops, freshly created
     # envs). Dashboard renders "offline" red when last_sync_at is

--- a/backend/app/schemas/skill.py
+++ b/backend/app/schemas/skill.py
@@ -88,7 +88,7 @@ class SkillUploadResponse(BaseModel):
     name: str
     version: int
     file_count: int
-    # Echo the resulting content_hash so `clawdi serve` daemons
+    # Echo the resulting content_hash so `clawdi daemon` processes
     # can chain the next push with `If-Match: <this hash>` without
     # an extra round-trip. Empty (legacy) is fine for old callers
     # that don't read it.

--- a/backend/app/services/sync_events.py
+++ b/backend/app/services/sync_events.py
@@ -1,4 +1,4 @@
-"""Skill revision counter + SSE fan-out for `clawdi serve` daemons.
+"""Skill revision counter + SSE fan-out for `clawdi daemon`.
 
 Single owner of two intertwined concerns:
 
@@ -11,7 +11,7 @@ Single owner of two intertwined concerns:
    short-circuit and as the safety-net catchup mechanism when
    SSE events are missed.
 
-2. Each running `clawdi serve` daemon has an open SSE connection
+2. Each running `clawdi daemon` process has an open SSE connection
    to `GET /api/sync/events` and is parked in a per-user queue.
    When `bump_skills_revision()` runs, it pushes a
    `{type:"skill_changed"|"skill_deleted", skill_key, project_id,
@@ -130,7 +130,7 @@ async def try_subscribe(
     (one daemon + one debug session). Bypasses:
       - Clerk JWT (api_key_id=None)
       - Unbound personal CLI keys (`is_env_bound=False`) — multi-
-        agent setups run `clawdi serve install --all` which spawns
+        agent setups run `clawdi daemon install --all` which spawns
         N daemons, all sharing the user's device-flow auth key
         from `~/.clawdi/auth.json`. Capping that at 2 silently
         broke realtime sync for users with 3+ registered agents

--- a/backend/scripts/seed_serve_test.py
+++ b/backend/scripts/seed_serve_test.py
@@ -1,5 +1,5 @@
 """Seed a synthetic user + agent environment + deploy api_key for
-the `clawdi serve` e2e test.
+the daemon e2e test.
 
 Companion to `scripts/serve-e2e.sh` at the repo root. Creates one
 test user, one agent_environment row, AND one api_key bound to

--- a/backend/tests/test_project_isolation.py
+++ b/backend/tests/test_project_isolation.py
@@ -352,7 +352,7 @@ async def test_unbound_cli_key_can_pin_any_project(
     `?project_id=...`. Pre-fix `project_ids_visible_to` returned only
     the most-recently-active project for ALL is_cli auth, which
     intersected to empty when the daemon pinned a different project
-    (e.g. `clawdi serve --agent codex` with claude_code as the
+    (e.g. `clawdi daemon run --agent codex` with claude_code as the
     default) — daemon got zero skills.
 
     Bound deploy keys are still pinned to their env's project; this

--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/clawdi-serve-test-guide.md
+++ b/docs/clawdi-serve-test-guide.md
@@ -1,4 +1,4 @@
-# Testing `clawdi serve`
+# Testing `clawdi daemon`
 
 How to verify the daemon works on your machine, end to end. Two
 paths: the **automated script** (one command, ~10 seconds) and
@@ -29,7 +29,7 @@ What it checks:
 | 1 | Backend boots and `/health` responds |
 | 2 | User + agent_environment + deploy api_key seeded |
 | 3 | CLI scratch dirs (`~/.clawdi/`, fake skills dir) exist |
-| 4 | `clawdi serve` reaches `engine.start` log line |
+| 4 | `clawdi daemon run` reaches `engine.start` log line |
 | 5 | Local SKILL.md edit → cloud row updates within 15s |
 | 6 | Cloud-side upload → local SKILL.md picks up the change |
 | 7 | Server-side DELETE → daemon removes local dir within 15s |
@@ -110,7 +110,7 @@ description: manual test
 EOF
 
 # CLAWDI_SERVE_DEBUG=1 prints debug-level events on stderr.
-CLAWDI_SERVE_DEBUG=1 bun run packages/cli/src/index.ts serve --agent claude_code
+CLAWDI_SERVE_DEBUG=1 bun run packages/cli/src/index.ts daemon run --agent claude_code
 ```
 
 You should see (filtered to the interesting events):
@@ -178,9 +178,9 @@ rm -rf /tmp/manual-claude
 If you want the daemon supervised by launchd / systemd:
 
 ```sh
-clawdi serve install --agent claude_code
-clawdi serve status --agent claude_code
-clawdi serve uninstall --agent claude_code  # when done
+clawdi daemon install --agent claude_code
+clawdi daemon status --agent claude_code
+clawdi daemon uninstall --agent claude_code  # when done
 ```
 
 Logs land at `~/.clawdi/serve/logs/<agent>.{stdout,stderr}.log`
@@ -204,7 +204,7 @@ with a delay. Forced by `CLAWDI_SERVE_MODE=container`.
 unknown. Check `CLAWDI_API_URL` and that the env still exists
 server-side.
 
-## Running `clawdi serve` inside an agent image (clawdi-monorepo)
+## Running `clawdi daemon` inside an agent image (clawdi-monorepo)
 
 The daemon was designed for laptops but works inside the clawdi
 agent container with three caveats. The clawdi.ai monorepo's
@@ -232,7 +232,7 @@ only conduit.
 
 ### What NOT to do
 
-- **Don't run `clawdi serve install`** inside the container. Install
+- **Don't run `clawdi daemon install`** inside the container. Install
   is for laptop / VPS users where launchd or systemd will respawn
   the daemon. The agent image's entrypoint (Docker / k8s) is
   already supervising; install would write a unit file inside
@@ -245,7 +245,7 @@ only conduit.
 ### Entrypoint shape
 
 ```sh
-exec clawdi serve --agent ${CLAWDI_AGENT_TYPE:-hermes}
+exec clawdi daemon run --agent ${CLAWDI_AGENT_TYPE:-hermes}
 ```
 
 `--agent` is required when `CLAWDI_ENVIRONMENT_ID` is set (the

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -46,6 +46,7 @@ That gets you:
 - Agent auto-detection for Claude Code, Codex, Hermes, and OpenClaw
 - MCP registration so your agent can call Clawdi tools
 - The bundled `clawdi` skill installed into each detected agent
+- Background sync daemons installed and started for every registered agent
 - A health check that verifies auth, agent paths, vault access, and MCP config
 
 By default the CLI talks to hosted Clawdi Cloud. Want to run your own backend? See [Own the Stack](#own-the-stack).
@@ -242,8 +243,9 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](https://gith
 | --- | --- |
 | `clawdi auth login` / `logout` | Authenticate this machine |
 | `clawdi status [--json]` | Show auth and sync state |
-| `clawdi setup [--agent <type>]` | Register local agents, install MCP, install the bundled skill |
+| `clawdi setup [--agent <type>] [--no-daemon]` | Register local agents, install MCP, install the bundled skill, and install/start daemons by default |
 | `clawdi teardown [--agent <type>]` | Remove Clawdi's local agent wiring |
+| `clawdi daemon run/install/status/logs/doctor/restart/uninstall` | Run and manage the background sync daemon (`serve` remains a legacy alias) |
 | `clawdi push` | Upload sessions and skills |
 | `clawdi pull` | Download cloud skills into registered agents |
 | `clawdi memory list/search/add/rm` | Manage cross-agent long-term memory |
@@ -258,7 +260,9 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](https://gith
 | `clawdi inject --in <file> --out <file>` | Render `clawdi://` references into templates |
 | `clawdi run --env-file <file> -- <cmd>` | Run a command with explicit vault references resolved |
 | `clawdi doctor` | Diagnose auth, agent paths, vault, and MCP config |
-| `clawdi update` | Check for a newer CLI version |
+| `clawdi update` | Install the latest CLI version (`--check` only reports) |
+
+Auto-update is enabled by default for all newer releases, including majors. Human CLI invocations update the global CLI in the background; installed daemons check on their own cadence, install silently, then let launchd/systemd restart them onto the new code. Disable both with `CLAWDI_NO_AUTO_UPDATE=1` or `clawdi config set autoUpdate false`.
 | `clawdi mcp` | Start the MCP stdio server used by agents |
 
 Every command supports `--help`.
@@ -326,7 +330,7 @@ Common issues:
 - **No supported agent detected** - Install a supported agent or pass `--agent claude_code`, `--agent codex`, `--agent hermes`, or `--agent openclaw`.
 - **Memory search is empty** - Add a memory first with `clawdi memory add "..."`, then verify with `clawdi memory search "..."`.
 - **Local backend cannot start because `vector` is missing** - Install `pgvector` for your PostgreSQL 16 instance, or use the included Docker Compose database.
-- **Agent MCP tools look stale** - Run `clawdi setup --agent <type>` again and restart the agent.
+- **Agent MCP tools look stale** - Run `clawdi setup --agent <type>` again, then `clawdi daemon restart --all`.
 
 ## License
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.7.0",
+	"version": "0.8.0",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/adapters/base.ts
+++ b/packages/cli/src/adapters/base.ts
@@ -92,7 +92,7 @@ export interface AgentAdapter {
 
 	getSkillPath(key: string): string;
 	/** Directory containing one subdirectory per skill_key.
-	 * `clawdi serve` watches this for change events. Distinct from
+	 * `clawdi daemon` watches this for change events. Distinct from
 	 * `getSkillPath(key)` which points at the SKILL.md inside one
 	 * skill — empty-key callers were getting `<root>/skills//SKILL.md`
 	 * before this method existed. */
@@ -110,7 +110,7 @@ export interface AgentAdapter {
 	 * Personal project skills keep using `getSkillsRootDir() + key`
 	 * with no suffix. */
 	getSharedSkillPath(skillKey: string, ownerHandle: string): string;
-	/** Path(s) `clawdi serve` should watch for session changes. May
+	/** Path(s) `clawdi daemon` should watch for session changes. May
 	 * be directories (Claude Code, Codex, OpenClaw all dump JSONL
 	 * files there) or a single file (Hermes uses a SQLite DB). The
 	 * daemon walks each path on a change event, then runs

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -537,11 +537,11 @@ export async function authLogout() {
 
 	// Warn about running daemons before clearing creds. `clearAuth`
 	// deletes auth.json + ~/.clawdi/environments/*, but launchd /
-	// systemd units installed by `clawdi serve install` keep
+	// systemd units installed by `clawdi daemon install` keep
 	// running with the API key cached in their unit env. They'll
 	// keep posting heartbeats to the cloud (with a now-revoked
 	// token, getting 401s in a tight loop) until the user
-	// `serve uninstall`s.
+	// `daemon uninstall`s.
 	//
 	// Source from `listInstalledAgents` (scans the OS supervisor)
 	// not `listRegisteredAgentTypes` (env-file registry) — the
@@ -554,7 +554,7 @@ export async function authLogout() {
 		p.log.warn(
 			`${installedAgents.length} daemon(s) still installed (${installedAgents.join(", ")}). ` +
 				`These keep running after logout and will fail with 401 against the cloud. ` +
-				`Run \`clawdi serve uninstall --all\` first, or accept the noise.`,
+				`Run \`clawdi daemon uninstall --all\` first, or accept the noise.`,
 		);
 	}
 

--- a/packages/cli/src/commands/serve-cli-options.test.ts
+++ b/packages/cli/src/commands/serve-cli-options.test.ts
@@ -3,7 +3,7 @@ import { Command } from "commander";
 import { registerServeCommand, type ServeHandlers } from "./serve-cli";
 
 /**
- * Regression tests for the `clawdi serve` command tree wiring.
+ * Regression tests for the `clawdi daemon` command tree wiring.
  *
  * `index.ts` and this test both call `registerServeCommand` —
  * earlier rounds maintained a parallel mock tree, which silently
@@ -36,6 +36,40 @@ function buildTree(): { program: Command; captured: { last: Record<string, unkno
 }
 
 describe("registerServeCommand", () => {
+	it("daemon install --agent codex reaches the action", async () => {
+		const { program, captured } = buildTree();
+		await program.parseAsync(["node", "clawdi", "daemon", "install", "--agent", "codex"]);
+		expect(captured.last?.agent).toBe("codex");
+	});
+
+	it("daemon run --agent codex --environment-id <uuid> reaches the foreground action", async () => {
+		const { program, captured } = buildTree();
+		await program.parseAsync([
+			"node",
+			"clawdi",
+			"daemon",
+			"run",
+			"--agent",
+			"codex",
+			"--environment-id",
+			"00000000-0000-0000-0000-000000000001",
+		]);
+		expect(captured.last?.agent).toBe("codex");
+		expect(captured.last?.environmentId).toBe("00000000-0000-0000-0000-000000000001");
+	});
+
+	it("daemon with no subcommand still runs the foreground action", async () => {
+		const { program, captured } = buildTree();
+		await program.parseAsync(["node", "clawdi", "daemon", "--agent", "codex"]);
+		expect(captured.last?.agent).toBe("codex");
+	});
+
+	it("legacy serve with no subcommand still runs the foreground action", async () => {
+		const { program, captured } = buildTree();
+		await program.parseAsync(["node", "clawdi", "serve", "--agent", "codex"]);
+		expect(captured.last?.agent).toBe("codex");
+	});
+
 	it("install --agent codex (child-side) reaches the action", async () => {
 		const { program, captured } = buildTree();
 		await program.parseAsync(["node", "clawdi", "serve", "install", "--agent", "codex"]);

--- a/packages/cli/src/commands/serve-cli.ts
+++ b/packages/cli/src/commands/serve-cli.ts
@@ -1,8 +1,8 @@
 /**
- * `clawdi serve` command tree registration.
+ * `clawdi daemon` command tree registration.
  *
  * Extracted from `index.ts` so tests can import the real wiring
- * (parent `serveCmd` + 6 subcommands) onto a test-local Commander
+ * (parent daemon command + subcommands) onto a test-local Commander
  * tree and exercise option scoping end-to-end. Pre-fix, the test
  * file built a parallel mock tree which silently drifted from the
  * real one — codex's review of PR #73 flagged this as the test's
@@ -12,7 +12,7 @@
 import type { Command } from "commander";
 
 /**
- * Handlers that the serve command tree dispatches to. Production
+ * Handlers that the daemon command tree dispatches to. Production
  * callers leave this undefined; tests pass stub handlers to
  * intercept dispatch without having to `mock.module` the whole
  * `./serve.js` module (which bleeds across test files in bun:test).
@@ -43,9 +43,10 @@ async function defaultHandlers(): Promise<ServeHandlers> {
 export function registerServeCommand(program: Command, handlers?: ServeHandlers): Command {
 	const get = handlers ? () => Promise.resolve(handlers) : defaultHandlers;
 	const serveCmd = program
-		.command("serve")
+		.command("daemon")
+		.alias("serve")
 		.description(
-			"Run the long-lived sync daemon — pushes local skill edits to cloud, pulls dashboard installs via SSE within seconds",
+			"Manage the background sync daemon — pushes local skill edits to cloud, pulls dashboard installs via SSE",
 		)
 		.option("--agent <type>", "Agent to service (claude_code, codex, hermes, openclaw)")
 		.option("--environment-id <id>", "Environment id (overrides ~/.clawdi/environments/*.json)")
@@ -60,25 +61,34 @@ Environment:
   CLAWDI_SERVE_DEBUG=1    Emit debug-level events to stderr
 
 Examples:
-  $ clawdi serve --agent claude_code
-  $ CLAWDI_SERVE_MODE=container clawdi serve --agent claude_code
-  $ clawdi serve install --agent claude_code   # set up launchd / systemd unit
-  $ clawdi serve status --agent claude_code    # health + supervisor state`,
+  $ clawdi daemon run --agent claude_code
+  $ CLAWDI_SERVE_MODE=container clawdi daemon run --agent claude_code
+  $ clawdi daemon install --agent claude_code   # set up launchd / systemd unit
+  $ clawdi daemon status --agent claude_code    # health + supervisor state
+  $ clawdi serve status --agent claude_code     # legacy alias`,
 		)
 		.action(async (opts) => {
-			// `clawdi serve` with no subcommand runs the daemon in
-			// the foreground. Subcommands (install/uninstall/status)
-			// are handled below — Commander dispatches them before
-			// this action fires.
+			// `clawdi daemon` (or legacy `clawdi serve`) with no
+			// subcommand still runs the daemon in the foreground for
+			// backward compatibility. `daemon run` is the clearer
+			// spelling for new users.
 			const h = await get();
 			await h.serve(opts);
 		});
 
 	serveCmd
+		.command("run")
+		.description("Run the sync daemon in the foreground")
+		.option("--agent <type>", "Agent to service (claude_code, codex, hermes, openclaw)")
+		.option("--environment-id <id>", "Environment id (overrides ~/.clawdi/environments/*.json)")
+		.action(async (_opts, cmd) => {
+			const h = await get();
+			await h.serve(cmd.optsWithGlobals());
+		});
+
+	serveCmd
 		.command("install")
-		.description(
-			"Install clawdi serve as a per-user OS service (launchd on macOS, systemd on Linux)",
-		)
+		.description("Install the daemon as a per-user OS service (launchd on macOS, systemd on Linux)")
 		.option(
 			"--agent <type>",
 			"Agent to service (auto-picked when only one is registered; required when multiple)",
@@ -90,9 +100,9 @@ Examples:
 		)
 		// `optsWithGlobals` merges parent (`serveCmd`) options with this
 		// subcommand's. Without it, `--agent` defined on both the parent
-		// (`clawdi serve --agent X`) and the child (`clawdi serve install
+		// (`clawdi daemon --agent X`) and the child (`clawdi daemon install
 		// --agent X`) makes commander hand the child action ONLY the
-		// child-scoped opts, so `clawdi serve install --agent codex` lost
+		// child-scoped opts, so `clawdi daemon install --agent codex` lost
 		// the agent and silently installed the default. Same fix applied
 		// to uninstall + status below.
 		.action(async (_opts, cmd) => {

--- a/packages/cli/src/commands/serve-handlers.test.ts
+++ b/packages/cli/src/commands/serve-handlers.test.ts
@@ -70,7 +70,7 @@ describe("rejectUnsupportedOpts", () => {
 		expect(captured.exitCode).toBe(1);
 		// Both offenders surfaced, kebab-cased, in the error.
 		const msg = captured.stderr.join("\n");
-		expect(msg).toMatch(/serve doctor/);
+		expect(msg).toMatch(/daemon doctor/);
 		expect(msg).toMatch(/--agent/);
 		expect(msg).toMatch(/--environment-id/);
 	});
@@ -112,7 +112,7 @@ describe("subcommand handler rejects parent-leaked options", () => {
 				environmentId: "00000000-0000-0000-0000-000000000001",
 			} as Record<string, unknown>),
 		).rejects.toThrow(ExitCalled);
-		expect(captured.stderr.join("\n")).toMatch(/serve uninstall.*--environment-id/);
+		expect(captured.stderr.join("\n")).toMatch(/daemon uninstall.*--environment-id/);
 	});
 
 	it("status rejects --environment-id", async () => {
@@ -122,7 +122,7 @@ describe("subcommand handler rejects parent-leaked options", () => {
 				environmentId: "00000000-0000-0000-0000-000000000001",
 			} as Record<string, unknown>),
 		).rejects.toThrow(ExitCalled);
-		expect(captured.stderr.join("\n")).toMatch(/serve status.*--environment-id/);
+		expect(captured.stderr.join("\n")).toMatch(/daemon status.*--environment-id/);
 	});
 
 	it("doctor rejects --agent", async () => {
@@ -130,6 +130,6 @@ describe("subcommand handler rejects parent-leaked options", () => {
 		await expect(serveDoctor({ agent: "codex" } as Record<string, unknown>)).rejects.toThrow(
 			ExitCalled,
 		);
-		expect(captured.stderr.join("\n")).toMatch(/serve doctor.*--agent/);
+		expect(captured.stderr.join("\n")).toMatch(/daemon doctor.*--agent/);
 	});
 });

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1,13 +1,13 @@
 /**
- * `clawdi serve` daemon entry.
+ * `clawdi daemon` entry.
  *
  * Long-lived process. Watches local skill directories, mirrors
  * cloud changes back to the local agent, posts heartbeats, and
  * keeps a bounded retry queue to survive transient outages.
  *
  * Three deploy contexts share this same code:
- *   - laptop: started by the user via `clawdi serve install`
- *     (launchd / systemd unit) or `clawdi serve` in a tmux pane
+ *   - laptop: started by the user via `clawdi daemon install`
+ *     (launchd / systemd unit) or `clawdi daemon run` in a tmux pane
  *   - VPS: same as laptop (systemd unit)
  *   - hosted pod: pid-1 in a sidecar container; auth via
  *     CLAWDI_AUTH_TOKEN env, env id passed via flag or env var
@@ -39,6 +39,7 @@ import {
 import { log, toErrorMessage } from "../serve/log";
 import { getServeLogPath, getServeStateDir } from "../serve/paths";
 import { runSyncEngine } from "../serve/sync-engine";
+import { startDaemonAutoUpdate } from "./update";
 
 interface ServeOpts {
 	agent?: string;
@@ -46,9 +47,9 @@ interface ServeOpts {
 }
 
 /**
- * Reject parent (`serveCmd`) global options that bled into a
- * subcommand which doesn't use them. Pre-fix `clawdi serve doctor
- * --agent codex` and `clawdi serve status --environment-id <id>`
+ * Reject parent (`daemonCmd`) global options that bled into a
+ * subcommand which doesn't use them. Pre-fix `clawdi daemon doctor
+ * --agent codex` and `clawdi daemon status --environment-id <id>`
  * silently accepted those flags (because parent defines them for the
  * foreground daemon's use) but ignored them — leaving users with no
  * signal that their command had no effect. Codex flagged this as
@@ -66,7 +67,8 @@ export function rejectUnsupportedOpts(
 	if (offenders.length > 0) {
 		const flags = offenders.map(camelToFlag).join(", ");
 		console.error(
-			`\`serve ${cmdName}\` does not accept ${flags}. ` + `See \`clawdi serve ${cmdName} --help\`.`,
+			`\`daemon ${cmdName}\` does not accept ${flags}. ` +
+				`See \`clawdi daemon ${cmdName} --help\`.`,
 		);
 		process.exit(1);
 	}
@@ -141,6 +143,9 @@ export async function serve(opts: ServeOpts): Promise<void> {
 		if (watching) {
 			log.info("serve.auto_restart_armed", { entry: watching });
 		}
+		if (startDaemonAutoUpdate({ abort })) {
+			log.info("serve.auto_update_armed", {});
+		}
 	}
 
 	try {
@@ -185,7 +190,7 @@ export async function serveInstall(opts: ServeInstallOpts): Promise<void> {
 		if (opts.agent) {
 			// Mutex: --all targets every registered agent; --agent
 			// targets one. Both at once is contradictory and pre-fix
-			// --all silently won, e.g. `serve uninstall --all --agent
+			// --all silently won, e.g. `daemon uninstall --all --agent
 			// codex` looked like "uninstall codex with extras" but
 			// actually nuked everything.
 			console.error(
@@ -285,7 +290,7 @@ export async function serveUninstall(opts: ServeInstallOpts): Promise<void> {
 	if (opts.all) {
 		// Symmetric with `install --all` — one invocation, every
 		// daemon gone. Pre-fix users had to loop in the shell
-		// (`for a in claude_code codex; do clawdi serve uninstall --agent $a`),
+		// (`for a in claude_code codex; do clawdi daemon uninstall --agent $a`),
 		// which is exactly the friction `install --all` exists to
 		// remove.
 		if (opts.agent) {
@@ -384,7 +389,7 @@ export async function serveRestart(opts: ServeInstallOpts): Promise<void> {
 
 export async function serveStatus(opts: ServeInstallOpts): Promise<void> {
 	rejectUnsupportedOpts("status", opts as Record<string, unknown>, STATUS_ALLOWED);
-	// Without --agent, list every registered daemon — `serve install
+	// Without --agent, list every registered daemon — `daemon install
 	// --all` is the recommended path on multi-agent machines and
 	// status should mirror that. Falling through `pickAgent` here used
 	// to silently hide all-but-one daemon's state behind a warning,
@@ -427,7 +432,7 @@ function printAgentStatus(agentType: AgentType): void {
 		if (health.version !== cliVersion) {
 			console.log(
 				`version: daemon=${health.version}, CLI=${cliVersion} ` +
-					"⚠ drift — run `clawdi serve restart --all` to pick up the latest",
+					"⚠ drift — run `clawdi daemon restart --all` to pick up the latest",
 			);
 		} else {
 			console.log(`version: ${health.version}`);
@@ -472,14 +477,14 @@ export async function serveLogs(opts: ServeLogsOpts): Promise<void> {
 		if (!existsSync(path)) {
 			console.error(
 				`No log file at ${path} ` +
-					`(daemon for ${agentType} hasn't started yet — run \`clawdi serve install --agent ${agentType}\`).`,
+					`(daemon for ${agentType} hasn't started yet — run \`clawdi daemon install --agent ${agentType}\`).`,
 			);
 			process.exit(1);
 		}
 		cmd = "tail";
 		args = opts.follow ? ["-n", "200", "-F", path] : ["-n", "200", path];
 	} else {
-		console.error(`unsupported platform for serve logs: ${platform}`);
+		console.error(`unsupported platform for daemon logs: ${platform}`);
 		process.exit(1);
 	}
 	const proc = spawn(cmd, args, { stdio: "inherit" });
@@ -492,7 +497,7 @@ interface ServeDoctorOpts {
 
 export async function serveDoctor(opts: ServeDoctorOpts): Promise<void> {
 	rejectUnsupportedOpts("doctor", opts as Record<string, unknown>, DOCTOR_ALLOWED);
-	// `clawdi serve doctor` — single-call snapshot of every
+	// `clawdi daemon doctor` — single-call snapshot of every
 	// daemon's runtime state, designed for support handoff and
 	// for the dashboard's "What's wrong with my sync?" panel
 	// (round-5 must-have #3). Shows per-agent: registration,
@@ -566,7 +571,7 @@ export async function serveDoctor(opts: ServeDoctorOpts): Promise<void> {
 	if (anyDrift) {
 		console.log(
 			"⚠ One or more daemons are running an older CLI version. " +
-				"Run `clawdi serve restart --all` to pick up the latest.",
+				"Run `clawdi daemon restart --all` to pick up the latest.",
 		);
 	}
 }
@@ -602,8 +607,8 @@ function pickAgent(explicit: string | undefined): {
 	if (registered.length > 1) {
 		// Fail-fast on multi-agent without an explicit pick. Pre-fix
 		// we picked `registered[0]` and emitted a warn-level event,
-		// which let `serve install --agent` (silently using default)
-		// and `serve uninstall` (silently nuking the wrong daemon)
+		// which let `daemon install --agent` (silently using default)
+		// and `daemon uninstall` (silently nuking the wrong daemon)
 		// hit production. Codex flagged: warn-and-pick is one of
 		// those things that "works on a single-agent laptop"
 		// (correct by accident) and bites multi-agent users in

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -17,9 +17,18 @@ import {
 import { ApiClient, unwrap } from "../lib/api-client";
 import { getClawdiDir, isLoggedIn } from "../lib/config";
 import { errMessage } from "../lib/errors";
+import { listRegisteredAgentTypes } from "../lib/select-adapter";
 import { isInteractive } from "../lib/tty";
+import { install as installDaemonService } from "../serve/installer";
 
-export async function setup(opts: { agent?: string; yes?: boolean }) {
+interface SetupOpts {
+	agent?: string;
+	yes?: boolean;
+	/** Commander sets this to false for --no-daemon. Undefined means default-on. */
+	daemon?: boolean;
+}
+
+export async function setup(opts: SetupOpts) {
 	if (!isLoggedIn()) {
 		console.log(chalk.red("Not logged in. Run `clawdi auth login` first."));
 		process.exitCode = 1;
@@ -41,9 +50,13 @@ export async function setup(opts: { agent?: string; yes?: boolean }) {
 			return;
 		}
 		const type = opts.agent as AgentType;
-		await registerEnv(api, type, null, machineId, machineName);
+		if (!(await registerEnv(api, type, null, machineId, machineName))) {
+			process.exitCode = 1;
+			return;
+		}
 		await registerMcpServer(type);
 		await installBuiltinSkill(type);
+		if (await shouldInstallDaemons(opts)) installDaemonsForRegisteredAgents();
 		return;
 	}
 
@@ -102,11 +115,21 @@ export async function setup(opts: { agent?: string; yes?: boolean }) {
 	}
 
 	console.log();
+	let registeredCount = 0;
+	let failedCount = 0;
 	for (const { adapter, version } of toRegister) {
-		await registerEnv(api, adapter.agentType, version, machineId, machineName);
+		if (!(await registerEnv(api, adapter.agentType, version, machineId, machineName))) {
+			failedCount += 1;
+			continue;
+		}
+		registeredCount += 1;
 		await registerMcpServer(adapter.agentType);
 		await installBuiltinSkill(adapter.agentType);
 	}
+	if (registeredCount > 0 && (await shouldInstallDaemons(opts))) {
+		installDaemonsForRegisteredAgents();
+	}
+	if (failedCount > 0) process.exitCode = 1;
 }
 
 async function registerEnv(
@@ -115,7 +138,7 @@ async function registerEnv(
 	agentVersion: string | null,
 	machineId: string,
 	machineName: string,
-) {
+): Promise<boolean> {
 	try {
 		const env = unwrap(
 			await api.POST("/api/environments", {
@@ -138,10 +161,59 @@ async function registerEnv(
 		);
 
 		console.log(chalk.green(`✓ ${adapterRegistry[agentType].displayName} registered`));
+		return true;
 	} catch (e) {
 		console.log(
 			chalk.red(`  Failed to register ${adapterRegistry[agentType].displayName}: ${errMessage(e)}`),
 		);
+		return false;
+	}
+}
+
+function installDaemon(agentType: AgentType) {
+	try {
+		const result = installDaemonService({ agent: agentType });
+		const verb = result.replaced ? "updated" : "installed";
+		console.log(chalk.green(`✓ Daemon ${verb} for ${adapterRegistry[agentType].displayName}`));
+		console.log(chalk.gray(`  ${result.instructions}`));
+	} catch (e) {
+		console.log(
+			chalk.yellow(
+				`⚠ Could not install daemon for ${adapterRegistry[agentType].displayName}: ${errMessage(e)}`,
+			),
+		);
+		console.log(chalk.gray(`  Run manually: clawdi daemon install --agent ${agentType}`));
+	}
+}
+
+async function shouldInstallDaemons(opts: SetupOpts): Promise<boolean> {
+	if (opts.daemon === false) {
+		console.log(chalk.gray("Daemon install skipped (--no-daemon)."));
+		return false;
+	}
+	if (opts.yes || !isInteractive()) return true;
+
+	const result = await p.confirm({
+		message: "Install and start background sync daemons for all registered agents?",
+		initialValue: true,
+	});
+	if (p.isCancel(result)) {
+		console.log(chalk.gray("Daemon install skipped."));
+		return false;
+	}
+	return result === true;
+}
+
+function installDaemonsForRegisteredAgents() {
+	const registered = listRegisteredAgentTypes();
+	if (registered.length === 0) {
+		console.log(chalk.gray("No registered agents available for daemon install."));
+		return;
+	}
+	console.log();
+	console.log(chalk.cyan("Installing background sync daemons..."));
+	for (const agentType of registered) {
+		installDaemon(agentType);
 	}
 }
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,9 +1,21 @@
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, openSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	closeSync,
+	existsSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import chalk from "chalk";
 import { getClawdiDir, getStoredConfig } from "../lib/config";
 import { getCliVersion } from "../lib/version";
+import { listInstalledAgents, readHealth } from "../serve/installer";
+import { log } from "../serve/log";
+import { getServeStateDir } from "../serve/paths";
 
 const REGISTRY_URL = "https://registry.npmjs.org/clawdi";
 // 1 hour: short enough that a fresh release reaches users within an hour of
@@ -12,11 +24,29 @@ const REGISTRY_URL = "https://registry.npmjs.org/clawdi";
 // invisible to active users for a full day, which made `--auto-update`
 // feel broken whenever a fix shipped.
 const CACHE_TTL_MS = 60 * 60 * 1000;
+const DAEMON_UPDATE_INTERVAL_MS = 60 * 60 * 1000;
+const DAEMON_UPDATE_LOCK_STALE_MS = 15 * 60 * 1000;
+type Installer = "bun" | "npm";
 
 interface UpdateCache {
 	checkedAt: string;
 	latest: string;
 }
+
+type BackgroundInstallContext = {
+	current: string;
+	latest: string;
+	logFd: number;
+};
+
+type AutoUpdateRuntime = {
+	detectInstaller?: () => Installer | null;
+	spawnBackgroundInstall?: (
+		installer: Installer,
+		args: string[],
+		context: BackgroundInstallContext,
+	) => void;
+};
 
 function cachePath(): string {
 	return join(getClawdiDir(), "update.json");
@@ -175,11 +205,7 @@ function lastVersionPath(): string {
 	return join(getClawdiDir(), LAST_VERSION_FILE);
 }
 
-function isMajorBump(current: string, latest: string): boolean {
-	return parseVersion(latest).triple[0] > parseVersion(current).triple[0];
-}
-
-function detectInstaller(): "bun" | "npm" | null {
+function detectInstaller(): Installer | null {
 	for (const name of ["bun", "npm"] as const) {
 		try {
 			const r = spawnSync(name, ["--version"], { stdio: "ignore" });
@@ -189,6 +215,14 @@ function detectInstaller(): "bun" | "npm" | null {
 		}
 	}
 	return null;
+}
+
+function detectAutoUpdateInstaller(runtime: AutoUpdateRuntime): Installer | null {
+	return runtime.detectInstaller?.() ?? detectInstaller();
+}
+
+function installArgs(installer: Installer): string[] {
+	return installer === "bun" ? ["add", "-g", "clawdi@latest"] : ["i", "-g", "clawdi@latest"];
 }
 
 // `npx clawdi …` and `bunx clawdi …` install the package into a per-call
@@ -206,18 +240,240 @@ function isTransientInvocation(): boolean {
 	return /\/_npx\/|\/\.bunx-|\/bun\/install\/cache\//.test(argv1);
 }
 
+function isLongLivedDaemonInvocation(args = process.argv.slice(2)): boolean {
+	const commandIndex = args.findIndex((arg) => arg === "daemon" || arg === "serve");
+	if (commandIndex < 0) return false;
+	const rest = args.slice(commandIndex + 1);
+	for (let i = 0; i < rest.length; i++) {
+		const arg = rest[i];
+		if (arg === "--agent" || arg === "--environment-id") {
+			i += 1;
+			continue;
+		}
+		if (arg.startsWith("-")) continue;
+		return arg === "run";
+	}
+	return true;
+}
+
+function isAutoUpdateControlInvocation(args = process.argv.slice(2)): boolean {
+	const first = args.find((arg) => !arg.startsWith("-"));
+	return first === "update" || first === "config";
+}
+
+function isInformationalInvocation(args = process.argv.slice(2)): boolean {
+	return args.some(
+		(arg) => arg === "--version" || arg === "-V" || arg === "--help" || arg === "-h",
+	);
+}
+
+function outdatedDaemonAgents(current: string): string[] {
+	try {
+		return listInstalledAgents().filter((agent) => {
+			const health = readHealth(getServeStateDir(agent));
+			if (!health.exists) return false;
+			if (!health.version) return true;
+			return isNewer(current, health.version);
+		});
+	} catch {
+		return [];
+	}
+}
+
+function autoUpdateDisabled(): boolean {
+	if (process.env.CLAWDI_NO_AUTO_UPDATE) return true;
+	if (process.env.CLAWDI_NO_UPDATE_CHECK) return true;
+	if (isTransientInvocation()) return true;
+	const stored = getStoredConfig() as { autoUpdate?: unknown };
+	return stored.autoUpdate === false || stored.autoUpdate === "false";
+}
+
+async function latestFromCacheOrRegistry(): Promise<string | null> {
+	const cached = readCache();
+	const now = Date.now();
+	if (cached && now - new Date(cached.checkedAt).getTime() <= CACHE_TTL_MS) {
+		return cached.latest;
+	}
+	const latest = await fetchLatest();
+	if (latest) {
+		writeCache(latest);
+		return latest;
+	}
+	return cached?.latest ?? null;
+}
+
+function acquireDaemonUpdateLock(): (() => void) | null {
+	const root = getClawdiDir();
+	const lockDir = join(root, "daemon-auto-update.lock");
+	const acquire = () => {
+		mkdirSync(root, { recursive: true });
+		mkdirSync(lockDir, { mode: 0o700 });
+		writeFileSync(join(lockDir, "pid"), `${process.pid}\n`, { mode: 0o600 });
+		return () => {
+			rmSync(lockDir, { recursive: true, force: true });
+		};
+	};
+	try {
+		return acquire();
+	} catch {
+		try {
+			const age = Date.now() - statSync(lockDir).mtimeMs;
+			if (age > DAEMON_UPDATE_LOCK_STALE_MS) {
+				rmSync(lockDir, { recursive: true, force: true });
+				return acquire();
+			}
+		} catch {
+			// If stat/remove failed, treat as locked; another daemon
+			// will retry on the next cadence.
+		}
+		return null;
+	}
+}
+
+type InstallRunner = (
+	installer: Installer,
+	args: string[],
+	signal?: AbortSignal,
+) => Promise<number | null>;
+
+async function runInstall(installer: Installer, args: string[], signal?: AbortSignal) {
+	if (signal?.aborted) return null;
+	const logPath = join(getClawdiDir(), "auto-update.log");
+	let logFd: number;
+	try {
+		mkdirSync(getClawdiDir(), { recursive: true });
+		logFd = openSync(logPath, "a");
+	} catch {
+		logFd = -1;
+	}
+	try {
+		return await new Promise<number | null>((resolve) => {
+			const child = spawn(installer, args, {
+				stdio: logFd >= 0 ? ["ignore", logFd, logFd] : "ignore",
+				env: process.env,
+			});
+			const onAbort = () => {
+				child.kill();
+			};
+			signal?.addEventListener("abort", onAbort, { once: true });
+			child.on("error", () => resolve(null));
+			child.on("close", (code) => {
+				signal?.removeEventListener("abort", onAbort);
+				resolve(code);
+			});
+		});
+	} finally {
+		if (logFd >= 0) {
+			try {
+				closeSync(logFd);
+			} catch {
+				// best-effort
+			}
+		}
+	}
+}
+
+export type DaemonAutoUpdateResult =
+	| "disabled"
+	| "no_update"
+	| "no_installer"
+	| "locked"
+	| "installed"
+	| "failed";
+
+export async function daemonAutoUpdateOnce(
+	opts: {
+		currentVersion?: string;
+		installer?: Installer | null;
+		installRunner?: InstallRunner;
+		signal?: AbortSignal;
+	} = {},
+): Promise<DaemonAutoUpdateResult> {
+	if (autoUpdateDisabled()) return "disabled";
+	if (opts.signal?.aborted) return "disabled";
+
+	const current = opts.currentVersion ?? getCliVersion();
+	const latest = await latestFromCacheOrRegistry();
+	if (!latest || !isNewer(latest, current)) return "no_update";
+
+	const installer = opts.installer === undefined ? detectInstaller() : opts.installer;
+	if (!installer) {
+		log.warn("daemon.auto_update_no_installer", { current, latest });
+		return "no_installer";
+	}
+
+	const release = acquireDaemonUpdateLock();
+	if (!release) return "locked";
+	try {
+		log.info("daemon.auto_update_installing", { current, latest, installer });
+		const status = await (opts.installRunner ?? runInstall)(
+			installer,
+			installArgs(installer),
+			opts.signal,
+		);
+		if (status !== 0) {
+			log.warn("daemon.auto_update_failed", { current, latest, installer, status });
+			return "failed";
+		}
+		try {
+			writeFileSync(lastVersionPath(), current, { mode: 0o644 });
+		} catch {
+			// best-effort; the installed binary still wins.
+		}
+		log.info("daemon.auto_update_installed", { from: current, to: latest, installer });
+		return "installed";
+	} finally {
+		release();
+	}
+}
+
+export function startDaemonAutoUpdate(opts: {
+	abort: AbortController;
+	intervalMs?: number;
+	initialDelayMs?: number;
+}): boolean {
+	if (autoUpdateDisabled()) return false;
+	const intervalMs = opts.intervalMs ?? DAEMON_UPDATE_INTERVAL_MS;
+	const initialDelayMs =
+		opts.initialDelayMs ?? Math.min(5 * 60_000, intervalMs) + Math.floor(Math.random() * 60_000);
+
+	void (async () => {
+		await sleep(initialDelayMs, opts.abort.signal);
+		while (!opts.abort.signal.aborted) {
+			const result = await daemonAutoUpdateOnce({ signal: opts.abort.signal });
+			if (result === "installed") {
+				opts.abort.abort();
+				return;
+			}
+			await sleep(intervalMs, opts.abort.signal);
+		}
+	})().catch((e) => {
+		log.warn("daemon.auto_update_loop_failed", {
+			error: e instanceof Error ? e.message : String(e),
+		});
+	});
+	return true;
+}
+
 /**
  * Default-on auto-updater. On startup:
  *   1. If the binary version differs from `last-version` on disk, print a
  *      one-line "updated to v…" notice (the previous run's spawn finished).
  *   2. If a newer release exists in the cache, kick off a detached
- *      `npm/bun add -g clawdi@latest` so the next invocation gets it. Only
- *      patch + minor — major bumps print a hint and require explicit opt-in.
+ *      `npm/bun add -g clawdi@latest` so the next invocation gets it.
  *
  * Opt-out: `CLAWDI_NO_AUTO_UPDATE=1` env, `clawdi config set autoUpdate
  * false`, non-TTY (CI), or running via npx/bunx.
  */
-export async function maybeAutoUpdate(): Promise<void> {
+export async function maybeAutoUpdate(runtime: AutoUpdateRuntime = {}): Promise<void> {
+	if (
+		isLongLivedDaemonInvocation() ||
+		isAutoUpdateControlInvocation() ||
+		isInformationalInvocation()
+	) {
+		return;
+	}
+
 	const current = getCliVersion();
 	const isHumanTerminal = !!process.stdout.isTTY;
 
@@ -237,6 +493,14 @@ export async function maybeAutoUpdate(): Promise<void> {
 				console.log(
 					`${chalk.green("✓")} ${chalk.gray(`Updated clawdi to v${current} (was v${last})`)}`,
 				);
+				const outdatedDaemons = outdatedDaemonAgents(current);
+				if (outdatedDaemons.length > 0) {
+					console.log(
+						chalk.gray(
+							`  Restart ${outdatedDaemons.length === 1 ? "the daemon" : "daemons"} to pick it up: clawdi daemon restart --all`,
+						),
+					);
+				}
 			}
 		}
 		writeFileSync(lastFile, current, { mode: 0o644 });
@@ -278,15 +542,7 @@ export async function maybeAutoUpdate(): Promise<void> {
 	if (!latest) return;
 	if (!isNewer(latest, current)) return;
 
-	if (isMajorBump(current, latest)) {
-		console.log();
-		console.log(
-			chalk.cyan(`Major release v${latest} available — run \`clawdi update\` to install.`),
-		);
-		return;
-	}
-
-	const installer = detectInstaller();
+	const installer = detectAutoUpdateInstaller(runtime);
 	if (!installer) return;
 
 	// No single-flight lock. Two concurrent CLIs both spawning `npm i -g
@@ -297,10 +553,10 @@ export async function maybeAutoUpdate(): Promise<void> {
 	// "Updating…" line); not worth it.
 	//
 	// `clawdi@latest` (not the pinned cache version) keeps installs
-	// idempotent — a newer patch landing between cache write and now is
+	// idempotent — a newer release landing between cache write and now is
 	// picked up automatically, and `last-version` on next invocation
 	// detects the change.
-	const args = installer === "bun" ? ["add", "-g", "clawdi@latest"] : ["i", "-g", "clawdi@latest"];
+	const args = installArgs(installer);
 
 	// Redirect installer output to a logfile so silent failures (network
 	// flake, perms error, npm 4xx) leave a trail. `stdio: "ignore"` would
@@ -318,8 +574,27 @@ export async function maybeAutoUpdate(): Promise<void> {
 	}
 
 	console.log(chalk.gray(`Updating clawdi v${current} → v${latest} in background…`));
+	try {
+		const spawner = runtime.spawnBackgroundInstall ?? spawnBackgroundInstall;
+		spawner(installer, args, { current, latest, logFd });
+	} finally {
+		if (logFd >= 0) {
+			try {
+				closeSync(logFd);
+			} catch {
+				// best-effort
+			}
+		}
+	}
+}
+
+function spawnBackgroundInstall(
+	installer: Installer,
+	args: string[],
+	context: BackgroundInstallContext,
+): void {
 	const child = spawn(installer, args, {
-		stdio: logFd >= 0 ? ["ignore", logFd, logFd] : "ignore",
+		stdio: context.logFd >= 0 ? ["ignore", context.logFd, context.logFd] : "ignore",
 		detached: true,
 		// Pass env explicitly so a future change to spawn defaults can't
 		// strip NPM_CONFIG_PREFIX / BUN_INSTALL and silently install into
@@ -331,4 +606,18 @@ export async function maybeAutoUpdate(): Promise<void> {
 		// `auto-update.log` if they care, and the next invocation retries.
 	});
 	child.unref();
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+	return new Promise((resolve) => {
+		const onAbort = () => {
+			clearTimeout(t);
+			resolve();
+		};
+		const t = setTimeout(() => {
+			signal.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		signal.addEventListener("abort", onAbort, { once: true });
+	});
 }

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -64,6 +64,7 @@ function readCache(): UpdateCache | null {
 
 function writeCache(latest: string): void {
 	try {
+		mkdirSync(getClawdiDir(), { recursive: true });
 		writeFileSync(
 			cachePath(),
 			`${JSON.stringify({ checkedAt: new Date().toISOString(), latest }, null, 2)}\n`,
@@ -75,16 +76,17 @@ function writeCache(latest: string): void {
 }
 
 async function fetchLatest(timeoutMs = 3000): Promise<string | null> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
 	try {
-		const controller = new AbortController();
-		const timer = setTimeout(() => controller.abort(), timeoutMs);
 		const res = await fetch(REGISTRY_URL, { signal: controller.signal });
-		clearTimeout(timer);
 		if (!res.ok) return null;
 		const data = (await res.json()) as { "dist-tags"?: { latest?: string } };
 		return data["dist-tags"]?.latest ?? null;
 	} catch {
 		return null;
+	} finally {
+		clearTimeout(timer);
 	}
 }
 
@@ -190,11 +192,7 @@ export async function update(opts: { json?: boolean; check?: boolean } = {}) {
 		return;
 	}
 	// Update last-version so the post-install run prints "Updated to v…".
-	try {
-		writeFileSync(lastVersionPath(), current, { mode: 0o644 });
-	} catch {
-		// best-effort
-	}
+	writeLastVersion(current);
 	console.log();
 	console.log(chalk.green(`✓ clawdi v${latest} installed.`));
 }
@@ -203,6 +201,15 @@ const LAST_VERSION_FILE = "last-version";
 
 function lastVersionPath(): string {
 	return join(getClawdiDir(), LAST_VERSION_FILE);
+}
+
+function writeLastVersion(version: string): void {
+	try {
+		mkdirSync(getClawdiDir(), { recursive: true });
+		writeFileSync(lastVersionPath(), version, { mode: 0o644 });
+	} catch {
+		// best-effort
+	}
 }
 
 function detectInstaller(): Installer | null {
@@ -415,11 +422,7 @@ export async function daemonAutoUpdateOnce(
 			log.warn("daemon.auto_update_failed", { current, latest, installer, status });
 			return "failed";
 		}
-		try {
-			writeFileSync(lastVersionPath(), current, { mode: 0o644 });
-		} catch {
-			// best-effort; the installed binary still wins.
-		}
+		writeLastVersion(current);
 		log.info("daemon.auto_update_installed", { from: current, to: latest, installer });
 		return "installed";
 	} finally {
@@ -503,10 +506,10 @@ export async function maybeAutoUpdate(runtime: AutoUpdateRuntime = {}): Promise<
 				}
 			}
 		}
-		writeFileSync(lastFile, current, { mode: 0o644 });
 	} catch {
 		// best-effort
 	}
+	writeLastVersion(current);
 
 	if (process.env.CLAWDI_NO_AUTO_UPDATE) return;
 	if (process.env.CLAWDI_NO_UPDATE_CHECK) return;
@@ -567,6 +570,7 @@ export async function maybeAutoUpdate(runtime: AutoUpdateRuntime = {}): Promise<
 	const logPath = join(getClawdiDir(), "auto-update.log");
 	let logFd: number;
 	try {
+		mkdirSync(getClawdiDir(), { recursive: true });
 		logFd = openSync(logPath, "a");
 	} catch {
 		// Fall back to ignore — best-effort. The install can still succeed.
@@ -609,6 +613,7 @@ function spawnBackgroundInstall(
 }
 
 function sleep(ms: number, signal: AbortSignal): Promise<void> {
+	if (signal.aborted) return Promise.resolve();
 	return new Promise((resolve) => {
 		const onAbort = () => {
 			clearTimeout(t);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -41,7 +41,7 @@ Environment:
   CLAWDI_API_URL           Override the Clawdi Cloud API endpoint
   CLAWDI_DEBUG             Print stack traces on error
   CLAWDI_NO_UPDATE_CHECK   Suppress the non-blocking update check
-  CLAWDI_NO_AUTO_UPDATE    Skip background auto-update (also disables via \`config set autoUpdate false\`)
+  CLAWDI_NO_AUTO_UPDATE    Skip CLI/daemon background auto-update (also disables via \`config set autoUpdate false\`)
   CLAUDE_CONFIG_DIR        Custom Claude Code home (else ~/.claude)
   CODEX_HOME               Custom Codex home (else ~/.codex)
   HERMES_HOME              Custom Hermes home (else ~/.hermes)
@@ -140,12 +140,13 @@ configCmd
 // ─────────────────────────────────────────────────────────────
 program
 	.command("setup")
-	.description("Detect installed agents and register this machine")
+	.description("Detect installed agents, register this machine, and install daemons")
 	.option("--agent <type>", "Agent type (claude_code, codex, openclaw, hermes)")
 	.option("-y, --yes", "Register every detected agent without prompting")
+	.option("--no-daemon", "Skip installing/starting background sync daemons")
 	.addHelpText(
 		"after",
-		"\nExamples:\n  $ clawdi setup\n  $ clawdi setup --yes\n  $ clawdi setup --agent claude_code",
+		"\nExamples:\n  $ clawdi setup\n  $ clawdi setup --yes\n  $ clawdi setup --agent claude_code\n  $ clawdi setup --no-daemon",
 	)
 	.action(async (opts) => {
 		const { setup } = await import("./commands/setup.js");

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -296,7 +296,7 @@ export class ApiClient {
 		const controller = new AbortController();
 		const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
 		// Mirror engine-wide abort onto this upload's controller so
-		// `clawdi serve` shutdown doesn't wait the full 30s timeout
+		// `clawdi daemon` shutdown doesn't wait the full 30s timeout
 		// for an in-flight upload to give up. Pre-fix the runtime
 		// would hang on the active multipart fetch even after the
 		// engine signalled abort, delaying SIGTERM cleanup and

--- a/packages/cli/src/serve/installer.test.ts
+++ b/packages/cli/src/serve/installer.test.ts
@@ -5,7 +5,7 @@
  * We intentionally do NOT exercise launchctl / systemctl here.
  * Those side effects depend on the host's user session, log
  * out / log in state, etc. — flaky in CI. The integration test
- * (running `clawdi serve install` against a real shell) lives
+ * (running `clawdi daemon install` against a real shell) lives
  * in /tmp manual smoke tests, not in `bun test`.
  */
 
@@ -140,7 +140,7 @@ describe("installer.install (macOS plist)", () => {
 			const content = readFileSync(result.unit, "utf-8");
 			// Both keys baked into the plist so the daemon spawned by
 			// launchd after reboot still sees them. Without this, env-
-			// only auth (`CLAWDI_AUTH_TOKEN=… clawdi serve install`)
+			// only auth (`CLAWDI_AUTH_TOKEN=… clawdi daemon install`)
 			// silently lost the token after the next login.
 			expect(content).toContain("<key>CLAWDI_AUTH_TOKEN</key>");
 			expect(content).toContain("clawdi_test_capture_token_value");
@@ -161,7 +161,7 @@ describe("installer.install (macOS plist)", () => {
 		// daemon's `resolveEnvironmentId` prefers env vars over the
 		// per-agent file, so a captured CLAWDI_ENVIRONMENT_ID would
 		// pin every installed agent to that one env id during
-		// `clawdi serve install --all` — all daemons trampling the
+		// `clawdi daemon install --all` — all daemons trampling the
 		// same project.
 		const os = await import("node:os");
 		if (os.platform() !== "darwin") return;

--- a/packages/cli/src/serve/installer.ts
+++ b/packages/cli/src/serve/installer.ts
@@ -1,5 +1,5 @@
 /**
- * Generate / load / unload `clawdi serve` as a per-user OS
+ * Generate / load / unload `clawdi daemon` as a per-user OS
  * service.
  *
  * Two backends, one shape:
@@ -41,7 +41,7 @@ interface InstallOpts {
 	/** Pinned environment id baked into the unit's
 	 * `--environment-id <id>` flag. Use ONLY when the caller
 	 * explicitly opts a single agent into a non-default env (e.g.
-	 * `clawdi serve install --agent codex --environment-id <id>`).
+	 * `clawdi daemon install --agent codex --environment-id <id>`).
 	 * Must not be derived from `process.env.CLAWDI_ENVIRONMENT_ID`
 	 * during multi-agent install (`--all`); a shell-set env var
 	 * would otherwise pin every agent unit to the same env. */
@@ -53,13 +53,13 @@ function home(): string {
 }
 
 /** Root of the clawdi state tree (auth, environments, locks,
- * serve queue, serve logs). Honors `CLAWDI_HOME` so test harnesses
+ * daemon queue, daemon logs). Honors `CLAWDI_HOME` so test harnesses
  * + the `clawdi-dev` wrapper get isolated state. Pre-fix
  * `installLaunchd`'s logDir hardcoded `$HOME/.clawdi`, so a
- * `CLAWDI_HOME=/foo clawdi serve install` would bake
- * `$HOME/.clawdi/serve/logs/...` into the plist while `serve logs`
+ * `CLAWDI_HOME=/foo clawdi daemon install` would bake
+ * `$HOME/.clawdi/serve/logs/...` into the plist while `daemon logs`
  * (which DID honor CLAWDI_HOME via `getServeLogPath`) looked at
- * `/foo/serve/logs/...` — `serve logs` couldn't find the file.
+ * `/foo/serve/logs/...` — `daemon logs` couldn't find the file.
  * Codex flagged this as P2 in PR-#74 review. */
 function clawdiRoot(): string {
 	const homeOverride = process.env.CLAWDI_HOME;
@@ -79,7 +79,7 @@ function unitName(agent: string): string {
  * reboot. Capturing these at install time matches "the daemon
  * runs the same way it ran when I installed it" — the user's
  * mental model. Without this, an env-only auth setup
- * (`CLAWDI_AUTH_TOKEN=… clawdi serve install`) silently breaks
+ * (`CLAWDI_AUTH_TOKEN=… clawdi daemon install`) silently breaks
  * after the first reboot because the supervisor strips the
  * shell env and `~/.clawdi/auth.json` was never written.
  *
@@ -97,7 +97,7 @@ function unitName(agent: string): string {
  * It's per-agent state and lives in `~/.clawdi/environments/<agent>.json`
  * (written by `clawdi setup`). Capturing the shell env var would let a
  * single env id leak into every agent's unit during
- * `clawdi serve install --all` — at runtime `resolveEnvironmentId`
+ * `clawdi daemon install --all` — at runtime `resolveEnvironmentId`
  * prefers the env var over the per-agent file, so all daemons would
  * pin to the same env. Single-agent installs that need an explicit
  * pin pass `--environment-id` via `InstallOpts.environmentId`, which
@@ -113,7 +113,7 @@ const PERSISTED_ENV_KEYS = [
 	// directory; honored by `lib/config.ts:clawdiDir()` and
 	// `serve/paths.ts:getServeStateDir()`. Without persisting it
 	// in the supervisor unit, an install run via
-	// `CLAWDI_HOME=… clawdi serve install` would foreground-work
+	// `CLAWDI_HOME=… clawdi daemon install` would foreground-work
 	// but the supervised daemon would fall back to the real
 	// `~/.clawdi/` after the user logs out — splitting state
 	// across two directories and breaking the isolation guarantee.
@@ -175,7 +175,7 @@ function currentClawdiCommand(): string[] {
 		);
 	}
 	// Reject TypeScript source paths. A common dev-mode footgun:
-	// running `bun run packages/cli/src/index.ts serve install`
+	// running `bun run packages/cli/src/index.ts daemon install`
 	// from a clone bakes the .ts source path into the launchd /
 	// systemd unit. After reboot, the supervisor launches that
 	// unit via the system `node` binary which can't execute raw
@@ -237,7 +237,7 @@ function restartLaunchd(opts: InstallOpts): void {
 	if (!existsSync(path)) {
 		throw new Error(
 			`no daemon unit installed for ${opts.agent} ` +
-				`(run \`clawdi serve install --agent ${opts.agent}\` first)`,
+				`(run \`clawdi daemon install --agent ${opts.agent}\` first)`,
 		);
 	}
 	const label = unitName(opts.agent);
@@ -323,7 +323,8 @@ function installLaunchd(opts: InstallOpts): {
   <array>
     <string>${escapeXml(node)}</string>
     <string>${escapeXml(entry)}</string>
-    <string>serve</string>
+    <string>daemon</string>
+    <string>run</string>
     <string>--agent</string>
     <string>${escapeXml(opts.agent)}</string>${envIdArgs}
   </array>
@@ -514,13 +515,13 @@ function installSystemd(opts: InstallOpts): {
 	// of "start at user login"; requires `loginctl enable-linger
 	// <user>` to fire on boot rather than first login session.
 	const unit = `[Unit]
-Description=clawdi serve daemon (${opts.agent})
+Description=clawdi daemon (${opts.agent})
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=${shellEscape(node)} ${shellEscape(entry)} serve --agent ${shellEscape(opts.agent)}${
+ExecStart=${shellEscape(node)} ${shellEscape(entry)} daemon run --agent ${shellEscape(opts.agent)}${
 		opts.environmentId ? ` --environment-id ${shellEscape(opts.environmentId)}` : ""
 	}
 Restart=always
@@ -614,7 +615,7 @@ function tryRunCapture(argv: string[]): string | null {
 		// Pipe stdout (we want it), discard stdin/stderr — pre-fix
 		// stderr leaked through, e.g. `launchctl list <label>`
 		// failing with "Could not find service ..." printed during
-		// `serve restart`'s liveness probe.
+		// `daemon restart`'s liveness probe.
 		return execFileSync(argv[0], argv.slice(1), {
 			encoding: "utf-8",
 			stdio: ["ignore", "pipe", "ignore"],
@@ -660,7 +661,7 @@ function shellEscape(s: string): string {
 }
 
 /** Scan the OS supervisor for every clawdi daemon unit installed
- * by `clawdi serve install`, regardless of whether its agent is
+ * by `clawdi daemon install`, regardless of whether its agent is
  * still registered in `~/.clawdi/environments/`. Used by callers
  * that need to act on the actual installed surface (e.g. `serve
  * restart --all`, `auth logout`'s warn-about-residual-daemons
@@ -685,12 +686,12 @@ export function listInstalledAgents(): KnownAgent[] {
 	return installed;
 }
 
-/** Health-file age check, used by `clawdi serve status` even
+/** Health-file age check, used by `clawdi daemon status` even
  * before the unit framework reports anything. The daemon writes
  * `<state-dir>/health` after every successful heartbeat as a JSON
  * payload (`{"timestamp", "version"}`); file mtime within ~90s
  * means the daemon is alive and reaching the cloud. The `version`
- * field lets `serve status` flag drift after a CLI upgrade
+ * field lets `daemon status` flag drift after a CLI upgrade
  * (daemon needs a restart to pick up the new bundle). Older
  * daemons wrote a bare ISO timestamp; the parser falls back to
  * that shape and reports `version: null`.

--- a/packages/cli/src/serve/log.ts
+++ b/packages/cli/src/serve/log.ts
@@ -1,5 +1,5 @@
 /**
- * Structured JSON logger for `clawdi serve`.
+ * Structured JSON logger for `clawdi daemon`.
  *
  * Daemon logs are NEVER for humans reading a TTY — they get
  * redirected by launchd / systemd / the pod's stdout collector

--- a/packages/cli/src/serve/paths.ts
+++ b/packages/cli/src/serve/paths.ts
@@ -1,5 +1,5 @@
 /**
- * Resolves on-disk locations for `clawdi serve`.
+ * Resolves on-disk locations for `clawdi daemon`.
  *
  * Two override knobs, in precedence order:
  *

--- a/packages/cli/src/serve/queue.test.ts
+++ b/packages/cli/src/serve/queue.test.ts
@@ -78,6 +78,67 @@ describe("RetryQueue", () => {
 		await q.flushPersist();
 	});
 
+	it("coalesces a burst of persists into one active flush", async () => {
+		const q = new RetryQueue({ agentType: "claude_code" });
+		const originalFlushPending = Reflect.get(q, "flushPending");
+		let flushCalls = 0;
+		Reflect.set(q, "flushPending", async function (this: RetryQueue) {
+			flushCalls += 1;
+			return originalFlushPending.call(this);
+		});
+
+		for (let i = 0; i < 10_000; i++) {
+			q.enqueue({
+				kind: "skill_push",
+				project_id: "test-project",
+				skill_key: "alpha",
+				new_hash: `h${i}`,
+				enqueued_at: "2026-01-01T00:00:00Z",
+				attempts: 0,
+			});
+		}
+
+		await q.flushPersist();
+		expect(q.depth).toBe(1);
+		expect(flushCalls).toBe(1);
+	});
+
+	it("wakes waitForItem immediately when an item is enqueued", async () => {
+		const q = new RetryQueue({ agentType: "claude_code" });
+		const abort = new AbortController();
+		let resolved = false;
+		const wait = q.waitForItem(abort.signal, 10_000).then(() => {
+			resolved = true;
+		});
+
+		q.enqueue({
+			kind: "skill_push",
+			project_id: "test-project",
+			skill_key: "alpha",
+			new_hash: "h1",
+			enqueued_at: "2026-01-01T00:00:00Z",
+			attempts: 0,
+		});
+
+		await wait;
+		expect(resolved).toBe(true);
+	});
+
+	it("waitForItem returns immediately when the queue already has work", async () => {
+		const q = new RetryQueue({ agentType: "claude_code" });
+		q.enqueue({
+			kind: "skill_push",
+			project_id: "test-project",
+			skill_key: "alpha",
+			new_hash: "h1",
+			enqueued_at: "2026-01-01T00:00:00Z",
+			attempts: 0,
+		});
+
+		await q.waitForItem(new AbortController().signal, 10_000);
+		expect(q.depth).toBe(1);
+	});
+
 	it("evicts oldest when over maxItems and counts the drop", async () => {
 		const q = new RetryQueue({ agentType: "claude_code", maxItems: 2 });
 		for (const k of ["a", "b", "c"]) {

--- a/packages/cli/src/serve/queue.ts
+++ b/packages/cli/src/serve/queue.ts
@@ -1,5 +1,5 @@
 /**
- * Bounded persistent retry queue for `clawdi serve`.
+ * Bounded persistent retry queue for `clawdi daemon`.
  *
  * Daemons need a queue because the network goes away. A skill
  * change happens at T0; the cloud is unreachable for the next 90
@@ -161,12 +161,13 @@ export class RetryQueue {
 	private readonly maxItems: number;
 	private readonly agentType: string;
 	private readonly onEvict?: (item: QueueItem) => void;
-	// Serialize on-disk writes through this chain so concurrent
-	// `persist()` calls don't race the rename. The chain is what
-	// tests await via `flushPersist()` — production callers are
+	// One active on-disk flush at a time. Production callers are
 	// fire-and-forget so the watcher's hot path doesn't block on
-	// disk I/O during a burst.
+	// disk I/O during a burst; tests await the current flush via
+	// `flushPersist()`.
 	private writeChain: Promise<void> = Promise.resolve();
+	private flushActive = false;
+	private readonly itemWaiters = new Set<() => void>();
 	// Latest snapshot waiting to be written. Multiple `persist()`
 	// calls within one tick coalesce into a single write because
 	// the flush loop reads this until it's null. Last-write-wins,
@@ -277,32 +278,44 @@ export class RetryQueue {
 		const blob = `${this.items.map((i) => JSON.stringify(i)).join("\n")}${this.items.length > 0 ? "\n" : ""}`;
 		this.pendingBlob = blob;
 		// If a flush is already running, it'll pick up the new
-		// `pendingBlob` on its next loop iteration. Only kick off
-		// a fresh flush when no chain exists yet (the chain is
-		// only ever resolved when the flush loop fully drained
-		// pendingBlob to null).
-		this.writeChain = this.writeChain.then(() => this.flushPending());
+		// `pendingBlob` on its next loop iteration. Pre-fix this
+		// appended one `.then(flushPending)` per enqueue; a watcher
+		// burst could hold thousands of no-op promise callbacks even
+		// though the queue itself is bounded.
+		if (this.flushActive) return;
+		this.flushActive = true;
+		this.writeChain = this.flushPending();
 	}
 
 	/** Drain `pendingBlob` to disk. Loops until it's null so that
 	 * a write that lands after this flush started picks up the
 	 * latest snapshot in the same flush. */
 	private async flushPending(): Promise<void> {
-		while (this.pendingBlob !== null) {
-			const blob = this.pendingBlob;
-			this.pendingBlob = null;
-			try {
-				ensureDir(this.persistPath);
-				const tmp = `${this.persistPath}.tmp`;
-				await writeFile(tmp, blob, { mode: 0o600 });
-				await rename(tmp, this.persistPath);
-			} catch (e) {
-				// Persist failures shouldn't crash the daemon — the
-				// in-memory queue is still authoritative for the
-				// running process. Log and continue; next persist
-				// retries.
-				log.error("queue.persist_failed", { error: toErrorMessage(e) });
+		while (true) {
+			while (this.pendingBlob !== null) {
+				const blob = this.pendingBlob;
+				this.pendingBlob = null;
+				try {
+					ensureDir(this.persistPath);
+					const tmp = `${this.persistPath}.tmp`;
+					await writeFile(tmp, blob, { mode: 0o600 });
+					await rename(tmp, this.persistPath);
+				} catch (e) {
+					// Persist failures shouldn't crash the daemon —
+					// the in-memory queue is still authoritative for
+					// the running process. Log and continue; next
+					// persist retries.
+					log.error("queue.persist_failed", { error: toErrorMessage(e) });
+				}
 			}
+			// Close the active window before returning. If another
+			// persist() lands after this point, it sees `flushActive`
+			// false and starts a new flush. If it landed earlier while
+			// this loop was active, `pendingBlob` is non-null and we
+			// keep draining in this same promise.
+			this.flushActive = false;
+			if (this.pendingBlob === null) return;
+			this.flushActive = true;
 		}
 	}
 
@@ -331,7 +344,38 @@ export class RetryQueue {
 		this.evictIfFull();
 		this.highWater = Math.max(this.highWater, this.items.length);
 		this.persist();
+		this.notifyItemWaiters();
 		return stamped.version;
+	}
+
+	/** Wait until an item is available, the timeout expires, or abort fires.
+	 * Used by the daemon drain loop so an idle queue can sleep until
+	 * enqueue() provides real work. */
+	waitForItem(abort: AbortSignal, timeoutMs: number): Promise<void> {
+		if (this.items.length > 0 || abort.aborted || timeoutMs <= 0) return Promise.resolve();
+		return new Promise((resolve) => {
+			let settled = false;
+			let timer: ReturnType<typeof setTimeout> | null = null;
+			const finish = () => {
+				if (settled) return;
+				settled = true;
+				if (timer) clearTimeout(timer);
+				this.itemWaiters.delete(finish);
+				abort.removeEventListener("abort", finish);
+				resolve();
+			};
+			timer = setTimeout(finish, timeoutMs);
+			this.itemWaiters.add(finish);
+			abort.addEventListener("abort", finish, { once: true });
+			if (this.items.length > 0) finish();
+		});
+	}
+
+	private notifyItemWaiters(): void {
+		if (this.itemWaiters.size === 0) return;
+		const waiters = [...this.itemWaiters];
+		this.itemWaiters.clear();
+		for (const finish of waiters) finish();
 	}
 
 	private evictIfFull(): void {
@@ -363,7 +407,7 @@ export class RetryQueue {
 			// queue at cap silently shed N items before this commit
 			// — the heartbeat aggregator surfaces the count remotely
 			// but no local log fired. warn level + the per-item
-			// fields below let `clawdi serve doctor` and journalctl
+			// fields below let `clawdi daemon doctor` and journalctl
 			// piece together what was lost.
 			log.warn("queue.evicted", {
 				kind: evicted.kind,

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -1,5 +1,5 @@
 /**
- * `clawdi serve` orchestrator.
+ * `clawdi daemon` orchestrator.
  *
  * Wires the background tasks that make up a sync daemon:
  *
@@ -82,10 +82,10 @@ const RECONCILE_INTERVAL_MS = 60_000;
 // last drain attempt failed. Keeps the daemon from hammering a
 // dead network. Per-item attempts counter caps the work too.
 const QUEUE_RETRY_INTERVAL_MS = 15_000;
-// Idle poll when the queue is empty. Short — we don't want a
-// fresh enqueue from the watcher to sit unnoticed for 15s. Tight
-// loop is fine; the queue.peek() is cheap (in-memory check).
-const QUEUE_EMPTY_POLL_MS = 500;
+// Safety wakeup for an idle queue. enqueue() wakes the drain loop
+// immediately; this timeout is only a backstop in case a wake signal
+// is missed.
+const QUEUE_IDLE_WAKEUP_MS = 30_000;
 const MAX_QUEUE_ATTEMPTS = 30;
 const SKILL_UPLOAD_ECHO_TTL_MS = 2 * 60_000;
 
@@ -991,7 +991,7 @@ async function drainQueueLoop(
 	while (!opts.abort.aborted) {
 		const item = queue.peek();
 		if (!item) {
-			await sleep(QUEUE_EMPTY_POLL_MS, opts.abort);
+			await queue.waitForItem(opts.abort, QUEUE_IDLE_WAKEUP_MS);
 			continue;
 		}
 		try {
@@ -2212,7 +2212,7 @@ async function heartbeatLoop(
 async function touchHealthFile(agentType: string): Promise<void> {
 	const p = join(getServeStateDir(agentType), "health");
 	try {
-		// JSON shape lets `serve status` / `serve doctor` surface
+		// JSON shape lets `daemon status` / `daemon doctor` surface
 		// "your daemon is running an older CLI version, restart to
 		// pick up the latest" without having to re-derive it from
 		// the launchd plist or process tree. Pre-fix this was a
@@ -2281,8 +2281,7 @@ export function releaseInFlight(m: Map<string, number>, key: string): void {
 function sleep(ms: number, abort: AbortSignal): Promise<void> {
 	return new Promise((resolve) => {
 		// Listener must be removed when the timer fires, otherwise
-		// long-running daemon code paths (the 500ms queue empty
-		// poll in particular) accumulate listeners on the shared
+		// long-running daemon code paths accumulate listeners on the shared
 		// AbortSignal and eventually trip
 		// MaxListenersExceededWarning. Same cleanup shape as
 		// sse-client.ts:sleep.

--- a/packages/cli/src/serve/watcher.test.ts
+++ b/packages/cli/src/serve/watcher.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createDebouncedSkillChangeEmitter } from "./watcher";
 
 const SKILL_KEY_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$/;
 
@@ -80,3 +81,40 @@ describe("listLocalSkillKeys filters dotfile dirs", () => {
 		}
 	});
 });
+
+describe("createDebouncedSkillChangeEmitter", () => {
+	it("coalesces a burst of events by skill_key", async () => {
+		const seen: string[] = [];
+		const emitter = createDebouncedSkillChangeEmitter((key) => seen.push(key), {
+			debounceMs: 5,
+		});
+
+		for (let i = 0; i < 100; i++) {
+			emitter.emit("frontend-design");
+			emitter.emit("webapp-testing");
+		}
+
+		await sleep(20);
+		expect(seen).toEqual(["frontend-design", "webapp-testing"]);
+		emitter.dispose();
+	});
+
+	it("drops pending events on abort", async () => {
+		const abort = new AbortController();
+		const seen: string[] = [];
+		const emitter = createDebouncedSkillChangeEmitter((key) => seen.push(key), {
+			abort: abort.signal,
+			debounceMs: 20,
+		});
+
+		emitter.emit("frontend-design");
+		abort.abort();
+		await sleep(30);
+
+		expect(seen).toEqual([]);
+	});
+});
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/cli/src/serve/watcher.ts
+++ b/packages/cli/src/serve/watcher.ts
@@ -30,6 +30,7 @@ import { isValidSkillKey } from "../lib/skill-key";
 import { log, toErrorMessage } from "./log";
 
 const POLL_INTERVAL_MS = 30_000;
+const CHANGE_DEBOUNCE_MS = 500;
 
 /** Sentinel: thrown out of `watchEvents` when recursive fs.watch
  * isn't supported. The outer `watchSkills` catches it and falls
@@ -91,6 +92,42 @@ export async function watchSkills(opts: Opts): Promise<void> {
 	}
 }
 
+export function createDebouncedSkillChangeEmitter(
+	onSkillChanged: (skillKey: string) => void,
+	opts: { abort?: AbortSignal; debounceMs?: number } = {},
+): { emit: (skillKey: string) => void; flush: () => void; dispose: () => void } {
+	const debounceMs = opts.debounceMs ?? CHANGE_DEBOUNCE_MS;
+	const pending = new Set<string>();
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let disposed = false;
+
+	const flush = () => {
+		if (disposed) return;
+		if (timer) {
+			clearTimeout(timer);
+			timer = null;
+		}
+		const keys = [...pending];
+		pending.clear();
+		for (const key of keys) onSkillChanged(key);
+	};
+	const dispose = () => {
+		disposed = true;
+		if (timer) clearTimeout(timer);
+		timer = null;
+		pending.clear();
+		opts.abort?.removeEventListener("abort", dispose);
+	};
+	const emit = (skillKey: string) => {
+		if (disposed || opts.abort?.aborted) return;
+		pending.add(skillKey);
+		if (timer) return;
+		timer = setTimeout(flush, debounceMs);
+	};
+	opts.abort?.addEventListener("abort", dispose, { once: true });
+	return { emit, flush, dispose };
+}
+
 /** fs.watch-based mode. The Node API requires us to fan out a
  * single recursive watch ourselves on platforms where recursive
  * watch isn't supported (Linux). We handle both cases in one
@@ -110,9 +147,12 @@ async function watchEvents(opts: Opts): Promise<void> {
 
 	const skillWatchers = new Map<string, { close(): void }>();
 	let rootWatcher: { close(): void } | null = null;
+	const changeEmitter = createDebouncedSkillChangeEmitter(opts.onSkillChanged, {
+		abort: opts.abort,
+	});
 
 	const on = (skillKey: string) => {
-		opts.onSkillChanged(skillKey);
+		changeEmitter.emit(skillKey);
 	};
 
 	const attachSubWatcher = (key: string) => {
@@ -243,6 +283,7 @@ async function watchEvents(opts: Opts): Promise<void> {
 		}
 		skillWatchers.clear();
 		rootWatcher = null;
+		changeEmitter.dispose();
 		throw e;
 	}
 
@@ -264,6 +305,7 @@ async function watchEvents(opts: Opts): Promise<void> {
 						/* already closed */
 					}
 				}
+				changeEmitter.dispose();
 				resolve();
 			},
 			{ once: true },

--- a/packages/cli/tests/commands/setup.test.ts
+++ b/packages/cli/tests/commands/setup.test.ts
@@ -1,0 +1,214 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setup } from "../../src/commands/setup";
+import {
+	type AgentHomeOverrideSnapshot,
+	jsonResponse,
+	mockFetch,
+	restoreAgentHomeOverrides,
+	snapshotAndClearAgentHomeOverrides,
+} from "./helpers";
+
+const tmpRoot = mkdtempSync(join(tmpdir(), "clawdi-setup-test-"));
+const ENV_KEYS = [
+	"CI",
+	"HOME",
+	"PATH",
+	"CLAWDI_HOME",
+	"CLAWDI_API_URL",
+	"CLAWDI_AUTH_TOKEN",
+	"CLAWDI_ENVIRONMENT_ID",
+	"CLAWDI_STATE_DIR",
+	"CLAWDI_SERVE_MODE",
+	"CLAWDI_SERVE_DEBUG",
+] as const;
+
+let envSnapshot: Partial<Record<(typeof ENV_KEYS)[number], string>> = {};
+let agentHomeSnapshot: AgentHomeOverrideSnapshot = {};
+let restoreFetch: (() => void) | null = null;
+let restoreConsole: (() => void) | null = null;
+let originalArgv1: string | undefined;
+let home = "";
+
+afterAll(() => {
+	rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+	home = mkdtempSync(join(tmpRoot, "case-"));
+	envSnapshot = {};
+	for (const key of ENV_KEYS) {
+		const value = process.env[key];
+		if (value !== undefined) envSnapshot[key] = value;
+		delete process.env[key];
+	}
+	agentHomeSnapshot = snapshotAndClearAgentHomeOverrides();
+
+	process.env.CI = "1";
+	process.env.HOME = home;
+	process.env.CLAWDI_API_URL = "http://api.test";
+
+	originalArgv1 = process.argv[1];
+	const fakeEntry = join(home, "clawdi-bin");
+	writeExecutable(fakeEntry, "#!/bin/sh\nexit 0\n");
+	process.argv[1] = fakeEntry;
+
+	const stubDir = join(home, "bin");
+	mkdirSync(stubDir, { recursive: true });
+	writeExecutable(join(stubDir, "codex"), "#!/bin/sh\nexit 0\n");
+	writeExecutable(join(stubDir, "systemctl"), "#!/bin/sh\nexit 0\n");
+	writeExecutable(join(stubDir, "launchctl"), "#!/bin/sh\nexit 0\n");
+	process.env.PATH = `${stubDir}:${envSnapshot.PATH ?? ""}`;
+
+	seedAuth();
+	const originalLog = console.log;
+	const originalError = console.error;
+	console.log = () => {};
+	console.error = () => {};
+	restoreConsole = () => {
+		console.log = originalLog;
+		console.error = originalError;
+	};
+	process.exitCode = undefined;
+});
+
+afterEach(() => {
+	restoreFetch?.();
+	restoreFetch = null;
+	restoreConsole?.();
+	restoreConsole = null;
+	process.argv[1] = originalArgv1 ?? "";
+	process.exitCode = undefined;
+
+	for (const key of ENV_KEYS) delete process.env[key];
+	for (const [key, value] of Object.entries(envSnapshot)) {
+		if (value !== undefined) process.env[key as (typeof ENV_KEYS)[number]] = value;
+	}
+	restoreAgentHomeOverrides(agentHomeSnapshot);
+	rmSync(home, { recursive: true, force: true });
+});
+
+describe("setup daemon install", () => {
+	it("defaults to installing daemon units for every registered agent", async () => {
+		seedRegisteredAgent("claude_code", "env-claude");
+		const { captured } = installEnvironmentMock("env-codex");
+
+		await setup({ agent: "codex", yes: true });
+
+		expect(
+			captured.some(
+				(req) =>
+					req.method === "POST" &&
+					req.path === "/api/environments" &&
+					(req.body as { agent_type?: string } | undefined)?.agent_type === "codex",
+			),
+		).toBe(true);
+		expectDaemonRun("claude_code");
+		expectDaemonRun("codex");
+	});
+
+	it("honors --no-daemon while still registering the requested agent", async () => {
+		installEnvironmentMock("env-codex");
+
+		await setup({ agent: "codex", yes: true, daemon: false });
+
+		expect(existsSync(join(home, ".clawdi", "environments", "codex.json"))).toBe(true);
+		expect(daemonUnitExists("codex")).toBe(false);
+	});
+
+	it("does not install a daemon when environment registration fails", async () => {
+		installFailingEnvironmentMock();
+
+		await setup({ agent: "codex", yes: true });
+
+		expect(process.exitCode).toBe(1);
+		process.exitCode = 0;
+		expect(existsSync(join(home, ".clawdi", "environments", "codex.json"))).toBe(false);
+		expect(daemonUnitExists("codex")).toBe(false);
+	});
+});
+
+function installEnvironmentMock(envId: string) {
+	const mock = mockFetch([
+		{
+			method: "POST",
+			path: "/api/environments",
+			response: () => jsonResponse({ id: envId }),
+		},
+	]);
+	restoreFetch = mock.restore;
+	return mock;
+}
+
+function installFailingEnvironmentMock() {
+	const mock = mockFetch([
+		{
+			method: "POST",
+			path: "/api/environments",
+			response: () => jsonResponse({ error: "boom" }, 500),
+		},
+	]);
+	restoreFetch = mock.restore;
+	return mock;
+}
+
+function seedAuth(): void {
+	const clawdiDir = join(home, ".clawdi");
+	mkdirSync(clawdiDir, { recursive: true });
+	writeFileSync(
+		join(clawdiDir, "auth.json"),
+		`${JSON.stringify({ apiKey: "test-key", userId: "u1", email: "u@example.test" })}\n`,
+		{ mode: 0o600 },
+	);
+}
+
+function seedRegisteredAgent(agent: string, envId: string): void {
+	const envDir = join(home, ".clawdi", "environments");
+	mkdirSync(envDir, { recursive: true });
+	writeFileSync(
+		join(envDir, `${agent}.json`),
+		`${JSON.stringify({ id: envId, agentType: agent })}\n`,
+		{ mode: 0o600 },
+	);
+}
+
+function daemonUnitPath(agent: string): string {
+	if (process.platform === "darwin") {
+		return join(home, "Library", "LaunchAgents", `ai.clawdi.serve.${agent}.plist`);
+	}
+	return join(home, ".config", "systemd", "user", `clawdi-serve-${agent}.service`);
+}
+
+function daemonUnitExists(agent: string): boolean {
+	return existsSync(daemonUnitPath(agent));
+}
+
+function readDaemonUnit(agent: string): string {
+	return readFileSync(daemonUnitPath(agent), "utf-8");
+}
+
+function expectDaemonRun(agent: string): void {
+	const content = readDaemonUnit(agent);
+	if (process.platform === "darwin") {
+		expect(content).toContain("<string>daemon</string>");
+		expect(content).toContain("<string>run</string>");
+		expect(content).toContain(`<string>${agent}</string>`);
+		return;
+	}
+	expect(content).toContain(`daemon run --agent ${agent}`);
+}
+
+function writeExecutable(path: string, content: string): void {
+	writeFileSync(path, content, { mode: 0o755 });
+	chmodSync(path, 0o755);
+}

--- a/packages/cli/tests/commands/update.test.ts
+++ b/packages/cli/tests/commands/update.test.ts
@@ -1,13 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { maybeAutoUpdate, update } from "../../src/commands/update";
+import { dirname, join } from "node:path";
+import { daemonAutoUpdateOnce, maybeAutoUpdate, update } from "../../src/commands/update";
 import { jsonResponse, mockFetch } from "./helpers";
 
 let tmpHome: string;
 let origHome: string | undefined;
 let origNoCheck: string | undefined;
+let origNoAuto: string | undefined;
+let origArgv: string[];
 
 async function withStdoutTty<T>(fn: () => Promise<T>): Promise<T> {
 	const ttyDesc = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
@@ -23,17 +25,23 @@ async function withStdoutTty<T>(fn: () => Promise<T>): Promise<T> {
 beforeEach(() => {
 	origHome = process.env.HOME;
 	origNoCheck = process.env.CLAWDI_NO_UPDATE_CHECK;
+	origNoAuto = process.env.CLAWDI_NO_AUTO_UPDATE;
+	origArgv = [...process.argv];
 	delete process.env.CLAWDI_NO_UPDATE_CHECK;
+	delete process.env.CLAWDI_NO_AUTO_UPDATE;
 	tmpHome = join(tmpdir(), `clawdi-update-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	mkdirSync(join(tmpHome, ".clawdi"), { recursive: true });
 	process.env.HOME = tmpHome;
 });
 
 afterEach(() => {
+	process.argv.splice(0, process.argv.length, ...origArgv);
 	if (origHome) process.env.HOME = origHome;
 	else delete process.env.HOME;
 	if (origNoCheck) process.env.CLAWDI_NO_UPDATE_CHECK = origNoCheck;
 	else delete process.env.CLAWDI_NO_UPDATE_CHECK;
+	if (origNoAuto) process.env.CLAWDI_NO_AUTO_UPDATE = origNoAuto;
+	else delete process.env.CLAWDI_NO_AUTO_UPDATE;
 	rmSync(tmpHome, { recursive: true, force: true });
 });
 
@@ -120,6 +128,98 @@ describe("update --json", () => {
 	});
 });
 
+describe("daemonAutoUpdateOnce", () => {
+	it("installs updates and leaves last-version for the next human CLI notice", async () => {
+		const calls: { installer: string; args: string[] }[] = [];
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/clawdi",
+				response: () => jsonResponse({ "dist-tags": { latest: "1.2.4" } }),
+			},
+		]);
+		try {
+			const result = await daemonAutoUpdateOnce({
+				currentVersion: "1.2.3",
+				installer: "npm",
+				installRunner: async (installer, args) => {
+					calls.push({ installer, args });
+					return 0;
+				},
+			});
+
+			expect(result).toBe("installed");
+			expect(calls).toEqual([{ installer: "npm", args: ["i", "-g", "clawdi@latest"] }]);
+			expect(readFileSync(join(tmpHome, ".clawdi", "last-version"), "utf-8").trim()).toBe("1.2.3");
+		} finally {
+			restore();
+		}
+	});
+
+	it("auto-installs major updates from daemon context", async () => {
+		const calls: { installer: string; args: string[] }[] = [];
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/clawdi",
+				response: () => jsonResponse({ "dist-tags": { latest: "2.0.0" } }),
+			},
+		]);
+		try {
+			const result = await daemonAutoUpdateOnce({
+				currentVersion: "1.9.9",
+				installer: "npm",
+				installRunner: async (installer, args) => {
+					calls.push({ installer, args });
+					return 0;
+				},
+			});
+			expect(result).toBe("installed");
+			expect(calls).toEqual([{ installer: "npm", args: ["i", "-g", "clawdi@latest"] }]);
+		} finally {
+			restore();
+		}
+	});
+
+	it("respects autoUpdate=false for daemon auto-update", async () => {
+		writeFileSync(join(tmpHome, ".clawdi", "config.json"), JSON.stringify({ autoUpdate: "false" }));
+		const { captured: fetches, restore } = mockFetch([]);
+		try {
+			const result = await daemonAutoUpdateOnce({
+				currentVersion: "1.2.3",
+				installer: "npm",
+			});
+			expect(result).toBe("disabled");
+			expect(fetches).toHaveLength(0);
+		} finally {
+			restore();
+		}
+	});
+
+	it("uses a cross-daemon lock so only one daemon installs at a time", async () => {
+		mkdirSync(join(tmpHome, ".clawdi", "daemon-auto-update.lock"), { recursive: true });
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/clawdi",
+				response: () => jsonResponse({ "dist-tags": { latest: "1.2.4" } }),
+			},
+		]);
+		try {
+			const result = await daemonAutoUpdateOnce({
+				currentVersion: "1.2.3",
+				installer: "npm",
+				installRunner: async () => {
+					throw new Error("should not install while locked");
+				},
+			});
+			expect(result).toBe("locked");
+		} finally {
+			restore();
+		}
+	});
+});
+
 describe("maybeAutoUpdate", () => {
 	it("writes last-version on first run; no notice", async () => {
 		const orig = console.log;
@@ -158,6 +258,27 @@ describe("maybeAutoUpdate", () => {
 		}
 		expect(captured).toContain("Updated clawdi to");
 		expect(captured).toContain("(was v0.0.1)");
+	});
+
+	it("nudges daemon restart after CLI update when an installed daemon reports an older version", async () => {
+		writeFileSync(join(tmpHome, ".clawdi", "last-version"), "0.0.1");
+		writeInstalledDaemon("codex");
+		writeDaemonHealth("codex", "0.0.1");
+
+		const orig = console.log;
+		let captured = "";
+		console.log = (...args: unknown[]) => {
+			captured += `${args.map(String).join(" ")}\n`;
+		};
+		const { restore } = mockFetch([]);
+		try {
+			await withStdoutTty(() => maybeAutoUpdate());
+		} finally {
+			console.log = orig;
+			restore();
+		}
+		expect(captured).toContain("Updated clawdi to");
+		expect(captured).toContain("Restart the daemon to pick it up: clawdi daemon restart --all");
 	});
 
 	it("keeps post-update notice out of non-TTY stdout", async () => {
@@ -205,15 +326,20 @@ describe("maybeAutoUpdate", () => {
 		expect(fetches).toHaveLength(0);
 	});
 
-	it("major bump prints hint, does not spawn install", async () => {
+	it("auto-installs major updates from human CLI startup", async () => {
 		writeFileSync(join(tmpHome, ".clawdi", "last-version"), "0.0.1");
-		// Plant cache showing a major bump available (1.x → 2.x style).
-		// Our binary version is whatever the package.json says; pick something
-		// way higher to guarantee a major-bump diff.
+		// Plant cache with a version way higher than package.json so this
+		// remains a major-bump test regardless of the fixture version.
 		writeFileSync(
 			join(tmpHome, ".clawdi", "update.json"),
 			JSON.stringify({ checkedAt: new Date().toISOString(), latest: "999.0.0" }),
 		);
+		const installs: {
+			installer: string;
+			args: string[];
+			latest: string;
+			logFd: number;
+		}[] = [];
 		const orig = console.log;
 		let captured = "";
 		console.log = (...args: unknown[]) => {
@@ -221,14 +347,26 @@ describe("maybeAutoUpdate", () => {
 		};
 		const { restore } = mockFetch([]);
 		try {
-			await withStdoutTty(() => maybeAutoUpdate());
+			await withStdoutTty(() =>
+				maybeAutoUpdate({
+					detectInstaller: () => "npm",
+					spawnBackgroundInstall: (installer, args, context) => {
+						installs.push({ installer, args, latest: context.latest, logFd: context.logFd });
+					},
+				}),
+			);
 		} finally {
 			console.log = orig;
 			restore();
 		}
-		// Hint about manual upgrade, NOT the in-background spawn line.
-		expect(captured).toContain("Major release v999.0.0");
-		expect(captured).not.toContain("in background");
+		expect(captured).toContain("Updating clawdi v");
+		expect(captured).toContain("→ v999.0.0 in background");
+		expect(captured).not.toContain("Major release");
+		expect(installs).toHaveLength(1);
+		expect(installs[0]?.installer).toBe("npm");
+		expect(installs[0]?.args).toEqual(["i", "-g", "clawdi@latest"]);
+		expect(installs[0]?.latest).toBe("999.0.0");
+		expect(installs[0]?.logFd ?? -1).toBeGreaterThanOrEqual(0);
 	});
 
 	it("respects autoUpdate=false config — skips install path", async () => {
@@ -253,4 +391,59 @@ describe("maybeAutoUpdate", () => {
 		// No "Updating in background…" line — the install path is skipped.
 		expect(captured).not.toContain("in background");
 	});
+
+	it("skips long-lived daemon invocations so daemons do not consume update notices", async () => {
+		writeFileSync(join(tmpHome, ".clawdi", "last-version"), "0.0.1");
+		process.argv.splice(2, process.argv.length - 2, "daemon", "run", "--agent", "codex");
+		const orig = console.log;
+		let captured = "";
+		console.log = (...args: unknown[]) => {
+			captured += `${args.map(String).join(" ")}\n`;
+		};
+		const { captured: fetches, restore } = mockFetch([]);
+		try {
+			await withStdoutTty(() => maybeAutoUpdate());
+		} finally {
+			console.log = orig;
+			restore();
+		}
+		expect(captured).not.toContain("Updated clawdi to");
+		expect(fetches).toHaveLength(0);
+		expect(readFileSync(join(tmpHome, ".clawdi", "last-version"), "utf-8").trim()).toBe("0.0.1");
+	});
+
+	it("skips update/config/help startup invocations", async () => {
+		writeFileSync(join(tmpHome, ".clawdi", "last-version"), "0.0.1");
+		const cases = [["update", "--check"], ["config", "set", "autoUpdate", "false"], ["--version"]];
+
+		for (const argv of cases) {
+			process.argv.splice(2, process.argv.length - 2, ...argv);
+			const { captured: fetches, restore } = mockFetch([]);
+			try {
+				await withStdoutTty(() => maybeAutoUpdate());
+			} finally {
+				restore();
+			}
+			expect(fetches).toHaveLength(0);
+			expect(readFileSync(join(tmpHome, ".clawdi", "last-version"), "utf-8").trim()).toBe("0.0.1");
+		}
+	});
 });
+
+function writeInstalledDaemon(agent: string): void {
+	const path =
+		process.platform === "darwin"
+			? join(tmpHome, "Library", "LaunchAgents", `ai.clawdi.serve.${agent}.plist`)
+			: join(tmpHome, ".config", "systemd", "user", `clawdi-serve-${agent}.service`);
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, "test daemon unit\n");
+}
+
+function writeDaemonHealth(agent: string, version: string): void {
+	const dir = join(tmpHome, ".clawdi", "serve", agent);
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(
+		join(dir, "health"),
+		`${JSON.stringify({ timestamp: new Date().toISOString(), version })}\n`,
+	);
+}

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -3160,7 +3160,7 @@ export interface components {
         };
         /**
          * SyncHeartbeatRequest
-         * @description Daemon-emitted observability snapshot for `clawdi serve`.
+         * @description Daemon-emitted observability snapshot for `clawdi daemon`.
          *
          *     Sent every ~30s even on quiet cycles so the dashboard's
          *     "Last synced: X ago" indicator stays fresh and the operator

--- a/scripts/local-e2e-bootstrap.sh
+++ b/scripts/local-e2e-bootstrap.sh
@@ -11,7 +11,7 @@
 #      mean full account access
 #      (read + write across sessions / skills / memories / vault), same
 #      as a user-self-minted key. Hosted pods need this parity.
-#   3. Prints env vars for running `clawdi serve` against the local
+#   3. Prints env vars for running `clawdi daemon run` against the local
 #      cloud-api so you can push real Claude Code sessions through the
 #      live-sync path locally and watch them land in `cloud.clawdi.ai`'s
 #      Postgres.
@@ -95,18 +95,18 @@ PGPASSWORD=clawdi_dev psql -h localhost -p 5433 -U clawdi -d clawdi_cloud -t -c 
 echo
 
 echo "============================================================"
-echo "Now run \`clawdi serve\` in a SEPARATE terminal with:"
+echo "Now run \`clawdi daemon run\` in a SEPARATE terminal with:"
 echo "============================================================"
 cat <<EOF
 
   export CLAWDI_AUTH_TOKEN="$RAW_KEY"
   export CLAWDI_API_URL="$API"
   export CLAWDI_ENVIRONMENT_ID="$ENV_ID"
-  clawdi serve --agent claude_code
+  clawdi daemon run --agent claude_code
 
 EOF
 echo "============================================================"
-echo "After \`serve\` is running:"
+echo "After \`daemon run\` is running:"
 echo "  - Backfill is automatic; daemon scans ~/.claude/projects/ on startup"
 echo "  - Open or continue any Claude Code conversation → new session JSONL appears"
 echo "  - Daemon picks it up via fs watcher, pushes to cloud-api"
@@ -132,4 +132,4 @@ export CLAWDI_LOCAL_E2E_CLERK_ID="$NOVEL_CLERK_ID"
 EOF
 echo
 echo "Or skip the copy-paste — env vars saved to $ENV_FILE:"
-echo "  source $ENV_FILE && clawdi serve --agent claude_code"
+echo "  source $ENV_FILE && clawdi daemon run --agent claude_code"

--- a/scripts/serve-e2e.sh
+++ b/scripts/serve-e2e.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# End-to-end smoke test for `clawdi serve`.
+# End-to-end smoke test for `clawdi daemon`.
 #
 # Drives the whole sync pipeline against a real backend + DB
 # without involving Clerk auth. Roughly:
@@ -9,7 +9,7 @@
 #      (the seed script mints the key directly via the service
 #      layer — no HTTP roundtrip, no shared internal secret)
 #   3. point the CLI at a fresh ~/.clawdi/ + ~/.claude-test/ tree
-#   4. run `clawdi serve` for ~12s in the background
+#   4. run `clawdi daemon run` for ~12s in the background
 #   5. assert: a freshly-written local skill landed on the server
 #   6. assert: a server-side skill change lands back on disk
 #   7. tear down (kill daemon, delete seeded rows, stop backend)
@@ -108,10 +108,10 @@ description: e2e seed skill
 EOF
 ok "plant skill at $SKILL_DIR"
 
-bold "4) starting clawdi serve in background"
+bold "4) starting clawdi daemon in background"
 cd "$REPO_ROOT"
 CLAWDI_SERVE_DEBUG=1 \
-  bun run packages/cli/src/index.ts serve --agent claude_code \
+  bun run packages/cli/src/index.ts daemon run --agent claude_code \
   > "$LOG_DIR/serve.stderr.log" 2>&1 &
 DAEMON_PID=$!
 


### PR DESCRIPTION
## Summary
- Rename the CLI surface from `serve` to `daemon` while keeping `serve` as a legacy alias, and update docs/dashboard/setup snippets.
- Make `clawdi setup` install/start daemon units for all registered agents by default, with `--no-daemon` as the opt-out and safer failure handling.
- Reduce daemon idle/burst overhead: coalesced retry-queue persistence, wait-based queue drain, debounced skill watcher events, and cleanup of background update log file descriptors.
- Add CLI and daemon auto-update to latest for every newer release, including majors; daemon updates install silently and rely on supervisor restart.

## Tests
- `bun test packages/cli`
- `bun run typecheck`
- `bun run check`
- `bun run build`
- `pdm run ruff check app/routes/sync.py app/routes/sessions.py app/services/sync_events.py app/schemas/session.py app/schemas/skill.py app/core/project.py app/models/api_key.py app/models/session.py scripts/seed_serve_test.py tests/test_project_isolation.py`

## Note
- `pdm lint` still fails on pre-existing Alembic migration lint violations unrelated to this PR.
