### PR TITLE
ci: update actions runtime and coverage

### DIFF
--- a/.github/actions/setup-bun-ci/action.yml
+++ b/.github/actions/setup-bun-ci/action.yml
@@ -1,5 +1,5 @@
 # Reusable composite action: set up Bun + install workspace dependencies
-# with a shared cache. Used by every client-ci job so caching is consistent.
+# with a shared cache. Used by JS-dependent CI jobs so caching is consistent.
 name: Setup Bun CI
 description: Install Bun and run `bun install --frozen-lockfile` with lockfile-scoped cache
 
@@ -18,14 +18,14 @@ runs:
         bun-version: ${{ inputs.bun-version }}
 
     - name: Cache bun install
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.bun/install/cache
           node_modules
-        key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+        key: bun-${{ runner.os }}-${{ runner.arch }}-${{ inputs.bun-version }}-${{ hashFiles('bun.lock') }}
         restore-keys: |
-          bun-${{ runner.os }}-
+          bun-${{ runner.os }}-${{ runner.arch }}-${{ inputs.bun-version }}-
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -48,12 +48,14 @@ jobs:
               - "package.json"
               - "bun.lock"
               - ".github/actions/setup-bun-ci/**"
+              - ".github/workflows/backend-ci.yml"
             test:
               - "backend/app/**"
               - "backend/tests/**"
               - "backend/alembic/**"
               - "backend/pyproject.toml"
               - "backend/uv.lock"
+              - ".github/workflows/backend-ci.yml"
 
   lint-and-typecheck:
     needs: changes

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -109,10 +109,24 @@ jobs:
       - name: Guard — run only if this target changed
         id: guard
         env:
-          CHANGED: ${{ matrix.target == 'web' && needs.changes.outputs.web || matrix.target == 'cli' && needs.changes.outputs.cli || matrix.target == 'shared' && needs.changes.outputs.shared }}
+          TARGET: ${{ matrix.target }}
+          WEB: ${{ needs.changes.outputs.web }}
+          CLI: ${{ needs.changes.outputs.cli }}
+          SHARED: ${{ needs.changes.outputs.shared }}
           INFRA: ${{ needs.changes.outputs.infra }}
         run: |
-          if [ "$CHANGED" = "true" ] || [ "$INFRA" = "true" ]; then
+          run=false
+          if [ "$INFRA" = "true" ]; then
+            run=true
+          elif [ "$TARGET" = "web" ] && { [ "$WEB" = "true" ] || [ "$SHARED" = "true" ]; }; then
+            run=true
+          elif [ "$TARGET" = "cli" ] && { [ "$CLI" = "true" ] || [ "$SHARED" = "true" ]; }; then
+            run=true
+          elif [ "$TARGET" = "shared" ] && [ "$SHARED" = "true" ]; then
+            run=true
+          fi
+
+          if [ "$run" = "true" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
@@ -131,9 +145,31 @@ jobs:
           NEXT_PUBLIC_API_URL: http://localhost:8000
         run: bunx turbo typecheck --filter=${{ matrix.filter }}
 
+  cli-test:
+    needs: changes
+    if: >-
+      needs.changes.outputs.cli == 'true' ||
+      needs.changes.outputs.shared == 'true' ||
+      needs.changes.outputs.infra == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-bun-ci
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      # Smoke tests exercise the compiled bin wrapper, so build before testing.
+      - name: Build CLI
+        run: bun run --cwd packages/cli build
+      - name: Test CLI
+        run: bun test packages/cli
+
   build:
     needs: [changes, typecheck]
-    if: needs.changes.outputs.web == 'true' || needs.changes.outputs.infra == 'true'
+    if: >-
+      needs.changes.outputs.web == 'true' ||
+      needs.changes.outputs.shared == 'true' ||
+      needs.changes.outputs.infra == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary
- Upgrade the shared Bun cache step to actions/cache@v5 so CI runs on the Node 24 action runtime.
- Include Bun version and runner arch in the cache key to avoid stale cache reuse across runtime changes.
- Run web/CLI consumer checks when shared code changes, and add a CLI build/test job to PR CI.
- Make backend workflow changes actually exercise backend lint/test jobs.

## Verification
- bun run check
- bun run typecheck
- bun run --cwd packages/cli build
- bun test packages/cli
- go run github.com/rhysd/actionlint/cmd/actionlint@latest