### PR TITLE
chore(release): adopt clearer open-source release tags

### DIFF
--- a/.github/workflows/clawdi-release.yml
+++ b/.github/workflows/clawdi-release.yml
@@ -1,15 +1,17 @@
 name: Release Clawdi
 
-# Creates a GitHub Release for backend/web/shared changes that land on main.
+# Creates a GitHub Release for backend/web/shared/root-config changes that
+# land on main.
 # This repo is a monorepo: the npm package has its own `clawdi-cli-vX.Y.Z`
 # release, while the Clawdi app/backend/web line uses calendar-versioned
-# `clawdi-vYYYY.MM.DD.<run_number>` releases.
+# `clawdi-YYYY-MM-DD` releases, with `-2`, `-3`, ... appended only for
+# additional releases on the same UTC day.
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version without the clawdi-v prefix. Defaults to YYYY.MM.DD.<run_number>."
+        description: "Release version without the clawdi- prefix. Defaults to YYYY-MM-DD, or YYYY-MM-DD-N for additional releases on the same UTC day."
         required: false
       target:
         description: "Commit SHA to release. Defaults to the workflow SHA."
@@ -50,10 +52,63 @@ jobs:
           TARGET="${INPUT_TARGET:-$GITHUB_SHA}"
           if [ -n "$INPUT_VERSION" ]; then
             VERSION="${INPUT_VERSION#clawdi-v}"
+            VERSION="${VERSION#clawdi-}"
           else
-            VERSION="$(date -u +%Y.%m.%d).${GITHUB_RUN_NUMBER}"
+            BASE_VERSION="$(date -u +%Y-%m-%d)"
+            LEGACY_BASE_VERSION="$(date -u +%Y.%m.%d)"
+            MAX_SEQUENCE=0
+            while IFS= read -r existing_tag; do
+              case "$existing_tag" in
+                clawdi-v*) existing_version="${existing_tag#clawdi-v}" ;;
+                clawdi-*) existing_version="${existing_tag#clawdi-}" ;;
+                *) continue ;;
+              esac
+              if [ "$existing_version" = "$BASE_VERSION" ]; then
+                sequence=1
+              elif [[ "$existing_version" == "$BASE_VERSION"-* ]]; then
+                suffix="${existing_version#"$BASE_VERSION-"}"
+                if [[ "$suffix" =~ ^[0-9]+$ ]]; then
+                  sequence="$suffix"
+                else
+                  continue
+                fi
+              elif [ "$existing_version" = "$LEGACY_BASE_VERSION" ]; then
+                sequence=1
+              elif [[ "$existing_version" == "$LEGACY_BASE_VERSION".* ]]; then
+                suffix="${existing_version#"$LEGACY_BASE_VERSION."}"
+                if [[ "$suffix" =~ ^[0-9]+$ ]]; then
+                  sequence="$suffix"
+                else
+                  continue
+                fi
+              else
+                continue
+              fi
+
+              if (( sequence > MAX_SEQUENCE )); then
+                MAX_SEQUENCE="$sequence"
+              fi
+            done < <(
+              {
+                git tag --list "clawdi-${BASE_VERSION}*"
+                git tag --list "clawdi-v${BASE_VERSION}*"
+                git tag --list "clawdi-v${LEGACY_BASE_VERSION}*"
+              } | sort -u
+            )
+
+            if (( MAX_SEQUENCE == 0 )); then
+              VERSION="$BASE_VERSION"
+            else
+              VERSION="${BASE_VERSION}-$((MAX_SEQUENCE + 1))"
+            fi
           fi
-          TAG="clawdi-v${VERSION}"
+
+          if [[ ! "$VERSION" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}(-[0-9]+)?$ ]]; then
+            echo "Invalid release version: $VERSION"
+            echo "Expected YYYY-MM-DD or YYYY-MM-DD-N, optionally prefixed with clawdi-."
+            exit 1
+          fi
+          TAG="clawdi-${VERSION}"
 
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "GitHub release $TAG already exists; skipping."
@@ -61,7 +116,8 @@ jobs:
           fi
 
           PREVIOUS=$(
-            git tag --list 'clawdi-v*' --sort=-creatordate \
+            git tag --list 'clawdi-*' --sort=-creatordate \
+              | grep -v '^clawdi-cli-v' \
               | grep -v "^${TAG}$" \
               | head -n 1 || true
           )

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -130,7 +130,7 @@ jobs:
           ## Scope
           This is the release for the published \`packages/cli\` package.
           Clawdi app/backend/web changes are versioned separately as
-          \`clawdi-v...\` releases.
+          \`clawdi-YYYY-MM-DD[-N]\` releases.
           EOF
           )
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,12 +59,14 @@ lives in `CHANGELOG.md`.
 
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`; bump `packages/cli/package.json`
   and let `.github/workflows/cli-publish.yml` publish.
-- Clawdi app/backend/web releases use `clawdi-vYYYY.MM.DD.<run_number>` and
-  are created by `.github/workflows/clawdi-release.yml`.
-- Release notes should be user-facing only. Include notable features, behavior
-  changes, fixes, deprecations, removals, security notes, and user actions.
-  Omit migrations, CI, deployment steps, refactors, generated files, and other
-  implementation-only details.
+- Clawdi app/backend/web releases use `clawdi-YYYY-MM-DD` for the first UTC
+  release of a day, then `clawdi-YYYY-MM-DD-2`, `-3`, and so on for
+  additional releases that same day. They are created by
+  `.github/workflows/clawdi-release.yml`.
+- Release notes and `CHANGELOG.md` entries should be user-facing only. Include
+  notable features, behavior changes, fixes, deprecations, removals, security
+  notes, and user actions. Omit migrations, CI, deployment steps, refactors,
+  generated files, and other implementation-only details.
 
 ## Tech Stack
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,56 @@ This changelog tracks notable user-facing Clawdi releases. It is written for
 people using or upgrading Clawdi, so it intentionally omits internal deployment,
 database migration, CI, and implementation details.
 
-- Clawdi app/backend/web releases use `clawdi-vYYYY.MM.DD.<run_number>`.
+- Clawdi app/backend/web releases use `clawdi-YYYY-MM-DD` for the first UTC
+  release of a day, then `clawdi-YYYY-MM-DD-2`, `-3`, and so on for
+  additional releases that same day. Older releases may use the previous dotted
+  `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
+
+## Clawdi CLI v0.8.1
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.8.1
+
+Package: `clawdi@0.8.1`
+
+### Changed
+
+- Updated CLI vault commands for account-owned Vaults that can be attached to
+  multiple Projects. JSON output now includes `project_ids`, while exact
+  references continue to include the Project ID used for resolution.
+- `clawdi project show`, `clawdi skill list`, `clawdi pull`, and
+  `clawdi vault list` now page through cloud results instead of showing only
+  the first page.
+- Share-link preview copy now says Vault names unlock after sign-in, avoiding
+  the implication that shared secret values are exposed to human viewers.
+
+## Clawdi 2026.05.21.2
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-v2026.05.21.2
+
+### Added
+
+- Added dashboard Projects and Project detail surfaces for viewing resources,
+  metadata, sharing state, and Agent attachments.
+- Added dashboard Project sharing flows, including share links, direct invites,
+  member management, public share acceptance, and notifications.
+- Added Vault import and Project attachment controls in the dashboard, including
+  read-only Vault views for shared Project viewers.
+
+### Changed
+
+- Clarified the Project model across the dashboard: user-created Projects can be
+  shared, the Global Project is the account default, and Agent Projects are
+  managed per connected agent.
+- Vaults are now account-owned resources that can be attached to multiple
+  Projects. Existing `project_id` API consumers and legacy exact
+  `clawdi://project/.../vault/...` references remain compatible.
+
+### Security
+
+- Shared Project recipients remain read-only Viewers. Vault plaintext stays
+  hidden in web and human shared-access flows; bound Agent keys can use shared
+  Vault values only through explicit Agent Project attachments.
 
 ## Clawdi CLI v0.8.0
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Clawdi is the shared layer underneath:
 
 - **Cross-agent memory** — Store durable preferences, decisions, facts, and project context once. Search them from any connected agent.
 - **Portable skills** — Upload or install agent instructions once, then sync them into every registered agent.
-- **Project sharing** — Share read-only Project access, accept it from the CLI inbox, and explicitly attach accepted Projects to Agents when they should be used at runtime.
+- **Project sharing** — Share read-only Project access from the dashboard or CLI, accept it from a share page or CLI inbox, and explicitly attach accepted Projects to Agents when they should be used at runtime.
 - **Session sync** — Push local session history to the dashboard for review and recall.
 - **Vault secrets** — Store secrets server-side, commit only `clawdi://` references, and resolve them at runtime.
 - **App connections** — Hook agents into Notion, Gmail, Drive, Calendar, Linear, GitHub, and more from the dashboard. Tools show up inside every connected agent automatically over MCP.
@@ -134,7 +134,7 @@ clawdi skill install anthropics/skills/artifacts-builder
 
 ## Roadmap
 
-Today Clawdi gives one person a shared layer across their agents. Two bigger bets come next.
+Today Clawdi gives individuals and read-only Project collaborators a shared layer across their agents. Two bigger bets come next.
 
 The first is autonomy. Agents should work without you at the keyboard.
 
@@ -142,9 +142,10 @@ The first is autonomy. Agents should work without you at the keyboard.
 - Remote control for agents on any of your machines.
 - Automatic memory built from session history.
 
-The second is making Clawdi multi-player. Project sharing now covers read-only Project access in the CLI/backend; dashboard surfaces and richer team roles come next.
+The second is deepening multi-player workflows beyond read-only Project sharing.
 
-- Shared memory, skills, and connections, with broader access controls.
+- Richer team roles and broader access controls.
+- Shared memory, skills, and connections.
 - An agent-to-agent channel for handoff and ask-for-help.
 - Task tracking that every connected agent can use.
 
@@ -268,9 +269,9 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](packages/cli
 | `clawdi run --env-file <file> -- <cmd>` | Run a command with explicit vault references resolved |
 | `clawdi doctor` | Diagnose auth, agent paths, vault, and MCP config |
 | `clawdi update` | Install the latest CLI version (`--check` only reports) |
+| `clawdi mcp` | Start the MCP stdio server used by agents |
 
 Auto-update is enabled by default for all newer releases, including majors. Human CLI invocations update the global CLI in the background; installed daemons check on their own cadence, install silently, then let launchd/systemd restart them onto the new code. Disable both with `CLAWDI_NO_AUTO_UPDATE=1` or `clawdi config set autoUpdate false`.
-| `clawdi mcp` | Start the MCP stdio server used by agents |
 
 Every command supports `--help`.
 

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -239,19 +239,24 @@ The monorepo has two GitHub Release lines:
 - `clawdi-cli-vX.Y.Z` for the published npm package. The CLI publish
   workflow creates this release after npm publish succeeds and prepends
   package/install notes to the generated changelog.
-- `clawdi-vYYYY.MM.DD.<run_number>` for Clawdi app/backend/web changes.
+- `clawdi-YYYY-MM-DD` for Clawdi app/backend/web changes. Additional releases
+  on the same UTC day append `-2`, `-3`, and so on. The suffix is a same-day
+  release sequence, not a semver patch number.
   `.github/workflows/clawdi-release.yml` creates this release
   when relevant files land on `main`; it can also be run manually with a
   specific version/commit after an out-of-band production deploy.
 
-Use the release body as the changelog. GitHub's generated notes are
-categorized by `.github/release.yml`; only PRs with release-note labels such as
-`feature`, `fix`, `security`, or `documentation` are included. Add
-`skip-changelog` to explicitly suppress a PR that would otherwise appear. Keep
-release notes user-facing: include notable features, behavior changes, fixes,
-deprecations, removals, security notes, and user actions; omit migrations, CI,
-deployment steps, refactors, generated files, and other implementation-only
-details.
+Use the GitHub release body as the published release notes and keep notable
+entries mirrored in `CHANGELOG.md`. GitHub's generated notes are categorized by
+`.github/release.yml`; only PRs with release-note labels such as `feature`,
+`fix`, `security`, or `documentation` are included. Add `skip-changelog` to
+explicitly suppress a PR that would otherwise appear. Generated notes are a
+draft, not a final product surface: review and edit them when a PR touched both
+release lines, a title is implementation-focused, or user impact needs clearer
+wording. Keep release notes user-facing: include notable features, behavior
+changes, fixes, deprecations, removals, security notes, and user actions; omit
+migrations, CI, deployment steps, refactors, generated files, and other
+implementation-only details.
 
 Old preview releases can be deleted when their binaries and install links
 are no longer needed. Prefer leaving them as prereleases while they are

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -5,12 +5,30 @@ create a Clawdi release from an already-deployed commit.
 
 ## Release Lines
 
-- App/backend/web/shared changes use calendar GitHub releases:
-  `clawdi-vYYYY.MM.DD.<run_number>`.
+- App/backend/web/shared/root-config changes use calendar GitHub releases:
+  `clawdi-YYYY-MM-DD` for the first UTC release of a day, then
+  `clawdi-YYYY-MM-DD-2`, `-3`, and so on for additional releases that same
+  day.
 - CLI/npm changes use semver GitHub releases and npm package versions:
   `clawdi-cli-vX.Y.Z` and `clawdi@X.Y.Z`.
-- User-facing release notes come from GitHub generated notes. Keep PR labels
-  accurate; use `skip-changelog` for implementation-only PRs.
+- GitHub generated notes seed the release body. Keep PR labels accurate; use
+  `skip-changelog` for implementation-only PRs, then review and edit the body
+  before treating it as final release copy.
+
+For app/backend/web releases, the date is UTC. A numeric suffix is a same-day
+release sequence, not a semantic-version patch number. The automatic workflow
+computes the next sequence by looking at existing `clawdi-YYYY-MM-DD*` tags:
+first release is unsuffixed, second is `-2`, third is `-3`. Older dotted
+`clawdi-v...` CalVer tags are considered only during the transition so the
+same UTC day does not restart at `-1`.
+
+Reserve `vX.Y.Z` tag shapes for semver release lines. The dated app release
+line intentionally avoids both the `v` prefix and dotted date suffixes so users
+do not read it as a package version.
+
+GitHub release bodies are the published release notes. `CHANGELOG.md` is the
+curated user-facing history in the repository. Keep them aligned for notable
+releases.
 
 ## Pre-Merge Checklist
 
@@ -49,17 +67,21 @@ create a Clawdi release from an already-deployed commit.
 6. If the PR touches the CLI package and should publish, bump
    `packages/cli/package.json` using semver. If no npm publish is intended,
    leave the version unchanged.
-7. Update the PR body with the latest head SHA, verification, release impact,
+7. Decide whether `CHANGELOG.md` needs a curated entry. Add one for notable
+   user-facing releases, especially when GitHub generated notes would be too
+   noisy or too terse.
+8. Update the PR body with the latest head SHA, verification, release impact,
    migration notes, and whether the CLI publish workflow will run.
 
 ## Merge And Release
 
 1. Merge the PR into `main` after required checks are green.
 2. Watch Actions for these workflows:
-   - `.github/workflows/clawdi-release.yml` runs for app/backend/web/shared
-     paths and creates `clawdi-v...`.
-   - `.github/workflows/cli-publish.yml` runs for `packages/cli/**` paths and
-     publishes only when the local CLI version differs from npm.
+   - `.github/workflows/clawdi-release.yml` runs for backend, web, shared
+     package, and root build/tooling config paths, then creates `clawdi-...`.
+   - `.github/workflows/cli-publish.yml` runs for `packages/cli/**` and the
+     CLI publish workflow file, then publishes only when the local CLI version
+     differs from npm.
 3. For CLI releases, verify npm after the workflow succeeds:
 
    ```bash
@@ -69,7 +91,15 @@ create a Clawdi release from an already-deployed commit.
 
 4. For app/backend/web releases, verify the GitHub release exists and has
    user-facing notes. If production deploy happened out of band, run
-   `Release Clawdi` manually with the deployed commit SHA.
+   `Release Clawdi` manually with the deployed commit SHA. Manual versions must
+   use `YYYY-MM-DD` or `YYYY-MM-DD-N`; the workflow adds the `clawdi-` prefix.
+   If a manually provided tag already exists, the workflow skips release
+   creation. Automatic runs choose the next same-day sequence when a tag for
+   the current UTC date already exists.
+5. Review generated GitHub release notes for both release lines. Edit the
+   release body when PR titles are too implementation-focused, a PR touched
+   both release lines, generated notes include unrelated entries, or the notes
+   omit user impact.
 
 ## Production Deployment Checks
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -73,7 +73,7 @@ Clawdi is the shared layer underneath:
 
 - **Cross-agent memory** — Store durable preferences, decisions, facts, and project context once. Search them from any connected agent.
 - **Portable skills** — Upload or install agent instructions once, then sync them into every registered agent.
-- **Project sharing** — Share read-only Project access, accept it from the CLI inbox, and explicitly attach accepted Projects to Agents when they should be used at runtime.
+- **Project sharing** — Share read-only Project access from the dashboard or CLI, accept it from a share page or CLI inbox, and explicitly attach accepted Projects to Agents when they should be used at runtime.
 - **Session sync** — Push local session history to the dashboard for review and recall.
 - **Vault secrets** — Store secrets server-side, commit only `clawdi://` references, and resolve them at runtime.
 - **App connections** — Hook agents into Notion, Gmail, Drive, Calendar, Linear, GitHub, and more from the dashboard. Tools show up inside every connected agent automatically over MCP.
@@ -128,7 +128,7 @@ clawdi skill install anthropics/skills/artifacts-builder
 
 ## Roadmap
 
-Today Clawdi gives one person a shared layer across their agents. Two bigger bets come next.
+Today Clawdi gives individuals and read-only Project collaborators a shared layer across their agents. Two bigger bets come next.
 
 The first is autonomy. Agents should work without you at the keyboard.
 
@@ -136,9 +136,10 @@ The first is autonomy. Agents should work without you at the keyboard.
 - Remote control for agents on any of your machines.
 - Automatic memory built from session history.
 
-The second is making Clawdi multi-player. Project sharing now covers read-only Project access in the CLI/backend; dashboard surfaces and richer team roles come next.
+The second is deepening multi-player workflows beyond read-only Project sharing.
 
-- Shared memory, skills, and connections, with broader access controls.
+- Richer team roles and broader access controls.
+- Shared memory, skills, and connections.
 - An agent-to-agent channel for handoff and ask-for-help.
 - Task tracking that every connected agent can use.
 
@@ -261,9 +262,9 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](https://gith
 | `clawdi run --env-file <file> -- <cmd>` | Run a command with explicit vault references resolved |
 | `clawdi doctor` | Diagnose auth, agent paths, vault, and MCP config |
 | `clawdi update` | Install the latest CLI version (`--check` only reports) |
+| `clawdi mcp` | Start the MCP stdio server used by agents |
 
 Auto-update is enabled by default for all newer releases, including majors. Human CLI invocations update the global CLI in the background; installed daemons check on their own cadence, install silently, then let launchd/systemd restart them onto the new code. Disable both with `CLAWDI_NO_AUTO_UPDATE=1` or `clawdi config set autoUpdate false`.
-| `clawdi mcp` | Start the MCP stdio server used by agents |
 
 Every command supports `--help`.
 


### PR DESCRIPTION
## Summary
- Switch app/backend/web release tags from workflow-run dotted CalVer to clearer dated tags: `clawdi-YYYY-MM-DD[-N]`.
- Keep CLI/npm releases on SemVer: `clawdi-cli-vX.Y.Z` / `clawdi@X.Y.Z`.
- Update release runbook, CLI release docs, changelog, and README copy to match the new release model and user-facing notes guidance.

## Verification
- `bun run lint`
- `bun run check`
- `git diff --check`
- `bash -n` on the edited release workflow shell blocks
- Local tag-sequence simulation with existing legacy `clawdi-v2026.05.21.2` produced `2026-05-21-3`

## Release Impact
- App/backend/web release workflow behavior changes for future tags only. Existing historical tags are left untouched.
- No CLI/npm package version bump; CLI publish should not publish a new npm version.