### PR TITLE
CLI vault scripting and section imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,37 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.8.2
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.8.2
+
+Package: `clawdi@0.8.2`
+
+### Added
+
+- Added non-interactive vault writes with `clawdi vault set --value <value>`
+  and `clawdi vault set --stdin`.
+- Added `--vault`, `--section`, and `--project` targeting to
+  `clawdi vault import`, so `.env` imports can populate sectioned vault paths.
+- Added `clawdi vault rm` / `clawdi vault delete` for scripted cleanup.
+- Added `clawdi project list --include-envs` to show auto-created machine
+  Projects when needed.
+
+### Changed
+
+- Vault write commands now print the concrete target vault, section, and Project
+  before writing, then print exact `clawdi://project/...` references after
+  writes.
+- `clawdi project list` now hides auto-created machine Projects by default and
+  reports how many were hidden.
+- The bundled `clawdi` skill now points agents at the new vault CLI workflow
+  for scripted secret migration and cleanup.
+
+### Fixed
+
+- `clawdi vault import` now warns about skipped invalid dotenv identifiers
+  instead of reporting only that no keys were found.
+
 ## Clawdi CLI v0.8.1
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.8.1

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ Later, in a different agent or a fresh session, ask "what package manager should
 Run a fullstack dev command with vault references without putting plaintext secrets on disk:
 
 ```bash
-clawdi vault set OPENAI_API_KEY
+printf '%s\n' "$OPENAI_API_KEY" | clawdi vault set OPENAI_API_KEY --stdin
+clawdi vault import --vault prod --section stripe --project personal --yes .env.stripe
 echo "OPENAI_API_KEY=clawdi://project/<project-id>/vault/default/field/OPENAI_API_KEY" > .env.clawdi
 clawdi run --dry-run --env-file .env.clawdi -- npm run dev
 clawdi run --env-file .env.clawdi -- npm run dev
@@ -105,7 +106,7 @@ clawdi inject --dry-run --in .env.clawdi --out .env.local
 clawdi inject --force --in .env.clawdi --out .env.local
 ```
 
-`clawdi vault set`, `clawdi vault import`, and `clawdi vault list` print exact references that include the Project ID. Project-relative references such as `clawdi://default/OPENAI_API_KEY` still work for portable templates, but exact references are the default copy/read UX.
+`clawdi vault set`, `clawdi vault import`, `clawdi vault rm`, and `clawdi vault list` print the concrete Project target or exact references that include the Project ID. `vault set` supports `--value` and `--stdin` for scripts; `vault import` supports `--vault`, `--section`, `--project`, and warns about skipped invalid dotenv identifiers. Project-relative references such as `clawdi://default/OPENAI_API_KEY` still work for portable templates, but exact references are the default copy/read UX.
 
 Agents should prefer `clawdi run --env-file .env.clawdi -- <command>` when they can launch the tool themselves. Use `clawdi inject` only for tools that must read a physical `.env.local`; generated files are written owner-only and should stay gitignored.
 
@@ -265,7 +266,7 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](packages/cli
 | `clawdi agent projects list/attach/detach/move` | View the fixed Agent Project and manage attached Projects |
 | `clawdi agent credentials import/materialize` | Sync local CLI credential profiles for Codex, Claude Code, and GitHub CLI; explicit Keychain import requires service/account options |
 | `clawdi project folder link/status/unlink` | Link a local folder to a Project for vault reference selection |
-| `clawdi vault set/list/import` | Manage encrypted secrets and copy exact references |
+| `clawdi vault set/list/import/rm` | Manage encrypted secrets and copy exact references |
 | `clawdi read <clawdi://...>` | Explicitly print one vault reference value |
 | `clawdi inject --in <file> --out <file>` | Render `clawdi://` references into templates |
 | `clawdi run --env-file <file> -- <cmd>` | Run a command with explicit vault references resolved |

--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.8.0",
+      "version": "0.8.2",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,7 +165,7 @@ clawdi://prod/stripe/secret_key
 clawdi://prod/database/url
 ```
 
-`.env` imports and `clawdi vault set OPENAI_API_KEY` store fields without a section by default, so that key resolves as `clawdi://default/OPENAI_API_KEY`. Sectioned references are for manually structured fields.
+`.env` imports and `clawdi vault set OPENAI_API_KEY` store fields without a section by default, so that key resolves as `clawdi://default/OPENAI_API_KEY`. Use `clawdi vault import --section openai ...` or `clawdi vault set default/openai/api_key` for sectioned fields.
 Exact references include the Project ID and are the default Web/CLI copy UX. In project-relative references, `default` is the vault slug, not the Project; Project selection happens outside the URI through `--project`, `--agent`, local folder links, or the caller's default Project.
 
 Values encrypted with AES-256-GCM (`vault_encryption_key` env var is the master key). The backend has two vault surfaces:

--- a/docs/scenarios/scenario-2-vault-claude-code.md
+++ b/docs/scenarios/scenario-2-vault-claude-code.md
@@ -40,36 +40,36 @@ Current pain points:
 **Via CLI (primary for developers):**
 
 ```bash
-# Add a single key
+# Add a single key interactively
 clawdi vault set OPENAI_API_KEY
 > Enter value: ****
 ✓ Stored OPENAI_API_KEY
 
-# Add with namespace
-clawdi vault set prod/STRIPE_SECRET_KEY
-> Enter value: ****
-✓ Stored prod/STRIPE_SECRET_KEY
+# Add non-interactively
+printf '%s\n' "$STRIPE_SECRET_KEY" | clawdi vault set prod/stripe/STRIPE_SECRET_KEY --stdin
+✓ Stored prod/stripe/STRIPE_SECRET_KEY
 
 # Import from existing .env file
-clawdi vault import .env
-✓ Imported 6 keys from .env
+clawdi vault import .env --yes
+✓ Imported 6 keys to vault "default" in default-write project "personal" (...)
 
-# Import with namespace prefix
-clawdi vault import .env --namespace prod/
-✓ Imported 6 keys under prod/
+# Import into a vault section
+clawdi vault import --vault prod --section stripe --project personal --yes .env.stripe
+✓ Imported 6 keys to vault "prod" section "stripe" in explicit project "personal" (...)
 
 # List stored keys (values never shown)
 clawdi vault list
-  ai/OPENAI_API_KEY        last used: 2h ago
-  ai/ANTHROPIC_API_KEY     last used: 2h ago
-  prod/STRIPE_SECRET_KEY   last used: 1d ago
-  prod/AWS_ACCESS_KEY_ID   last used: 3d ago
-  prod/DATABASE_URL        last used: 1d ago
-  dev/DATABASE_URL         last used: 5m ago
+Project personal (...)
+  Vault default
+    OPENAI_API_KEY
+      clawdi://project/.../vault/default/field/OPENAI_API_KEY
+  Vault prod
+    stripe/STRIPE_SECRET_KEY
+      clawdi://project/.../vault/prod/section/stripe/field/STRIPE_SECRET_KEY
 
 # Remove a key
-clawdi vault rm dev/DATABASE_URL
-✓ Removed dev/DATABASE_URL
+clawdi vault rm prod/database/DATABASE_URL --yes
+✓ Deleted prod/database/DATABASE_URL from vault "prod" section "database" in default-write project "personal" (...)
 ```
 
 **Via Dashboard (for visual management):**

--- a/docs/using-clawdi-with-claude-code.md
+++ b/docs/using-clawdi-with-claude-code.md
@@ -148,6 +148,12 @@ Store a secret once:
 $ clawdi vault set OPENAI_API_KEY
 Value for OPENAI_API_KEY: ••••••••••
 ✓ Stored OPENAI_API_KEY
+
+$ printf '%s\n' "$STRIPE_SECRET_KEY" | clawdi vault set prod/stripe/STRIPE_SECRET_KEY --stdin
+✓ Stored prod/stripe/STRIPE_SECRET_KEY
+
+$ clawdi vault import --vault prod --section stripe --project personal --yes .env.stripe
+✓ Imported 3 keys to vault "prod" section "stripe"
 ```
 
 List what's stored (values never leave the CLI unmasked):
@@ -317,7 +323,7 @@ $ clawdi push --agent codex
 | `clawdi push` | Push sessions + skills to the cloud |
 | `clawdi pull` | Pull skills from the cloud into Claude Code's skills dir |
 | `clawdi memory list / search / add / rm` | Inspect or edit cross-agent memory (alias: `mem`) |
-| `clawdi vault set / list / import` | Manage runtime secrets |
+| `clawdi vault set / list / import / rm` | Manage runtime secrets |
 | `clawdi run -- <cmd>` | Run a command with vault secrets injected |
 | `clawdi skill list / add / install / rm` | Manage skills |
 | `clawdi mcp` | Start MCP stdio server (invoked by Claude Code automatically) |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -90,7 +90,8 @@ Later, in a different agent or a fresh session, ask "what package manager should
 Run a fullstack dev command with vault references without putting plaintext secrets on disk:
 
 ```bash
-clawdi vault set OPENAI_API_KEY
+printf '%s\n' "$OPENAI_API_KEY" | clawdi vault set OPENAI_API_KEY --stdin
+clawdi vault import --vault prod --section stripe --project personal --yes .env.stripe
 echo "OPENAI_API_KEY=clawdi://project/<project-id>/vault/default/field/OPENAI_API_KEY" > .env.clawdi
 clawdi run --dry-run --env-file .env.clawdi -- npm run dev
 clawdi run --env-file .env.clawdi -- npm run dev
@@ -99,7 +100,7 @@ clawdi inject --dry-run --in .env.clawdi --out .env.local
 clawdi inject --force --in .env.clawdi --out .env.local
 ```
 
-`clawdi vault set`, `clawdi vault import`, and `clawdi vault list` print exact references that include the Project ID. Project-relative references such as `clawdi://default/OPENAI_API_KEY` still work for portable templates, but exact references are the default copy/read UX.
+`clawdi vault set`, `clawdi vault import`, `clawdi vault rm`, and `clawdi vault list` print the concrete Project target or exact references that include the Project ID. `vault set` supports `--value` and `--stdin` for scripts; `vault import` supports `--vault`, `--section`, `--project`, and warns about skipped invalid dotenv identifiers. Project-relative references such as `clawdi://default/OPENAI_API_KEY` still work for portable templates, but exact references are the default copy/read UX.
 
 Agents should prefer `clawdi run --env-file .env.clawdi -- <command>` when they can launch the tool themselves. Use `clawdi inject` only for tools that must read a physical `.env.local`; generated files are written owner-only and should stay gitignored.
 
@@ -258,7 +259,7 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](https://gith
 | `clawdi agent projects list/attach/detach/move` | View the fixed Agent Project and manage attached Projects |
 | `clawdi agent credentials import/materialize` | Sync local CLI credential profiles for Codex, Claude Code, and GitHub CLI; explicit Keychain import requires service/account options |
 | `clawdi project folder link/status/unlink` | Link a local folder to a Project for vault reference selection |
-| `clawdi vault set/list/import` | Manage encrypted secrets and copy exact references |
+| `clawdi vault set/list/import/rm` | Manage encrypted secrets and copy exact references |
 | `clawdi read <clawdi://...>` | Explicitly print one vault reference value |
 | `clawdi inject --in <file> --out <file>` | Render `clawdi://` references into templates |
 | `clawdi run --env-file <file> -- <cmd>` | Run a command with explicit vault references resolved |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.8.1",
+	"version": "0.8.2",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -83,3 +83,13 @@ Connected service tools (Gmail, GitHub, Notion, etc.) are dynamically registered
 - If a tool call fails with "No connected account", tell the user to connect the service in the Clawdi Cloud dashboard
 - File downloads from connectors return signed URLs — download them with `curl` or `fetch` before processing
 - Confirm with the user before side-effecting operations (sending email, creating issues, etc.)
+
+## Vault CLI
+
+When the user asks to migrate secrets into Clawdi Vault or script secret writes, prefer the CLI over raw HTTP calls:
+
+- Use `clawdi vault set KEY --stdin` for piped values, or `clawdi vault set KEY --value <value>` only when shell history exposure is acceptable.
+- Use `clawdi vault import --vault <slug> --section <name> --project <project> --yes <file>` for non-interactive `.env` migrations into a section.
+- Keep `.env` import keys as POSIX environment identifiers such as `OPENAI_API_KEY`; section names belong in `--section`, not inside the key name.
+- Use `clawdi vault rm <vault>/<section>/<field> --yes` or `clawdi vault delete ...` to clean up misplaced keys.
+- Prefer exact `clawdi://project/...` references printed by the CLI. Do not print plaintext secret values unless the user explicitly asks for them.

--- a/packages/cli/src/commands/project-list.ts
+++ b/packages/cli/src/commands/project-list.ts
@@ -12,6 +12,7 @@ export async function projectListCommand(opts: {
 	json?: boolean;
 	sharedWithMe?: boolean;
 	owned?: boolean;
+	includeEnvs?: boolean;
 }): Promise<void> {
 	const ctx = projectAuthOrExit();
 	if (!ctx) return;
@@ -23,9 +24,19 @@ export async function projectListCommand(opts: {
 	}
 
 	const projects = await listProjects(apiUrl, apiKey);
-	const owned = projects.filter((s) => s.is_owner !== false);
-	const shared = projects.filter((s) => s.is_owner === false);
+	const environmentProjects = projects.filter((s) => s.kind === "environment");
+	const defaultProjects = opts.includeEnvs
+		? projects
+		: projects.filter((s) => s.kind !== "environment");
+	const owned = defaultProjects.filter((s) => s.is_owner !== false && s.kind !== "environment");
+	const shared = defaultProjects.filter((s) => s.is_owner === false);
+	const machines = opts.includeEnvs
+		? projects.filter((s) => s.kind === "environment" && s.is_owner !== false)
+		: [];
 	const visibleProjects = opts.sharedWithMe ? shared : opts.owned ? owned : projects;
+	const filteredVisibleProjects = opts.includeEnvs
+		? visibleProjects
+		: visibleProjects.filter((s) => s.kind !== "environment");
 
 	if (opts.json) {
 		const ownedProjects = owned.map((s) => ({
@@ -49,7 +60,7 @@ export async function projectListCommand(opts: {
 		console.log(
 			JSON.stringify(
 				{
-					projects: visibleProjects.map((s) => ({
+					projects: filteredVisibleProjects.map((s) => ({
 						id: s.id,
 						slug: s.slug,
 						name: s.name,
@@ -60,6 +71,18 @@ export async function projectListCommand(opts: {
 					})),
 					owned_projects: ownedProjects,
 					shared_projects: sharedProjects,
+					environment_projects: opts.includeEnvs
+						? environmentProjects.map((s) => ({
+								id: s.id,
+								slug: s.slug,
+								name: s.name,
+								kind: s.kind,
+								is_owner: s.is_owner !== false,
+								owner_display: s.owner_display ?? null,
+								owner_handle: s.owner_handle ?? null,
+							}))
+						: [],
+					hidden_environment_project_count: opts.includeEnvs ? 0 : environmentProjects.length,
 				},
 				null,
 				2,
@@ -68,7 +91,7 @@ export async function projectListCommand(opts: {
 		return;
 	}
 
-	if (visibleProjects.length === 0) {
+	if (filteredVisibleProjects.length === 0) {
 		if (opts.sharedWithMe) {
 			console.log("No shared projects yet.");
 			console.log(chalk.gray("Accept an invite with `clawdi inbox`, or accept a link with:"));
@@ -79,6 +102,13 @@ export async function projectListCommand(opts: {
 		} else {
 			console.log("No projects yet.");
 			console.log(`Create one: ${chalk.cyan('clawdi project create "Engineering"')}`);
+		}
+		if (!opts.includeEnvs && environmentProjects.length > 0 && !opts.sharedWithMe) {
+			console.log(
+				chalk.gray(
+					`Hidden machine projects: ${environmentProjects.length}. Show them with \`clawdi project list --include-envs\`.`,
+				),
+			);
 		}
 		return;
 	}
@@ -99,6 +129,22 @@ export async function projectListCommand(opts: {
 		}
 	}
 
+	if (!opts.sharedWithMe && machines.length > 0) {
+		if (owned.length > 0) console.log();
+		console.log(chalk.bold(`Machines (${machines.length}):`));
+		console.log(chalk.gray("  Auto-created environment projects for registered local agents."));
+		for (const s of machines) {
+			const alias = projectAlias(s);
+			console.log(
+				`  ${chalk.cyan(alias.padEnd(24))} ${chalk.gray("machine")}  ${chalk.gray(s.id.slice(0, 8))}`,
+			);
+			if (s.name && s.name !== s.slug) {
+				console.log(`    ${chalk.dim(s.name)}`);
+			}
+			console.log(`    ${chalk.gray(`Open: clawdi project show ${alias}`)}`);
+		}
+	}
+
 	if (!opts.owned && shared.length > 0) {
 		if (!opts.sharedWithMe) console.log();
 		console.log(chalk.bold(`Shared with me (${shared.length}):`));
@@ -116,5 +162,14 @@ export async function projectListCommand(opts: {
 				`    ${chalk.gray(`Attach to Agent: clawdi agent projects attach <agent-id> --project ${alias}`)}`,
 			);
 		}
+	}
+
+	if (!opts.includeEnvs && environmentProjects.length > 0 && !opts.sharedWithMe) {
+		if (owned.length > 0 || shared.length > 0) console.log();
+		console.log(
+			chalk.gray(
+				`Hidden machine projects: ${environmentProjects.length}. Show them with \`clawdi project list --include-envs\`.`,
+			),
+		);
 	}
 }

--- a/packages/cli/src/commands/vault.ts
+++ b/packages/cli/src/commands/vault.ts
@@ -3,9 +3,13 @@ import * as p from "@clack/prompts";
 import chalk from "chalk";
 import { ApiClient, unwrap } from "../lib/api-client";
 import { isLoggedIn } from "../lib/config";
-import { parseDotenv } from "../lib/dotenv";
+import { parseDotenvDetailed } from "../lib/dotenv";
+import { listProjects, resolveProjectId } from "../lib/project-resolver";
 import { sanitizeMetadata } from "../lib/sanitize";
 import { buildExactClawdiReference } from "../lib/secret-references";
+
+const VAULT_SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,198}[a-z0-9])?$/;
+const VAULT_ITEM_SEGMENT_RE = /^[A-Za-z0-9_.-]+$/;
 
 function requireAuth() {
 	if (!isLoggedIn()) {
@@ -75,66 +79,46 @@ async function fetchAllVaults(api: ApiClient, projectId?: string): Promise<Vault
 	throw new Error("Too many vault pages to load safely. Use --project to narrow the listing.");
 }
 
-async function resolveVaultProjectId(api: ApiClient, slug: string): Promise<string | null> {
-	const list = await fetchAllVaults(api);
-	const candidate = list.items.find((v) => v.slug === slug);
-	if (!candidate) return null;
-	const defaultProject = await api.GET("/api/projects/default");
-	const def = defaultProject.error === undefined ? (unwrap(defaultProject).project_id ?? "") : "";
-	const projectIds = vaultProjectIds(candidate);
-	if (def && projectIds.includes(def)) return def;
-	return projectIds[0] ?? null;
+interface VaultSetOptions {
+	project?: string;
+	value?: string;
+	stdin?: boolean;
 }
 
-export async function vaultSet(key: string, opts: { project?: string } = {}) {
+export async function vaultSet(key: string, opts: VaultSetOptions = {}) {
 	requireAuth();
 
 	const { vaultSlug, section, field } = parseVaultKey(key);
+	const normalizedKey = formatVaultKey(vaultSlug, section, field);
 
-	const value = await p.password({ message: `Value for ${key}:` });
-	if (p.isCancel(value) || !value) {
-		p.cancel("Cancelled.");
+	const value = await readVaultSetValue(key, opts);
+	if (value === null) {
 		return;
 	}
 
 	const api = new ApiClient();
 
-	// Resolve --project to a concrete UUID up front so both
-	// ensureVault (create) AND the items PUT land in the same project.
-	let pinnedProjectId: string | undefined;
-	if (opts.project) {
-		const { resolveProjectId } = await import("../lib/project-resolver.js");
-		const { getAuth, getConfig } = await import("../lib/config.js");
-		const cfg = getConfig();
-		const auth = getAuth();
-		if (!auth?.apiKey) {
-			console.log(chalk.red("Not signed in. Run `clawdi auth login` first."));
-			process.exit(1);
-		}
-		pinnedProjectId = await resolveProjectId(cfg.apiUrl, auth.apiKey, opts.project);
-	}
+	const targetProject = await resolveVaultWriteProject(api, opts.project);
+	console.log(chalk.gray(`  Target: ${formatVaultTarget(vaultSlug, section, targetProject)}`));
 
-	await ensureVault(api, vaultSlug, vaultSlug, pinnedProjectId);
+	await ensureVault(api, vaultSlug, vaultSlug, targetProject.projectId);
 
-	const project_id = pinnedProjectId ?? (await resolveVaultProjectId(api, vaultSlug));
 	unwrap(
 		await api.PUT("/api/vault/{slug}/items", {
 			params: {
 				path: { slug: vaultSlug },
-				query: project_id ? { project_id } : {},
+				query: { project_id: targetProject.projectId },
 			},
 			body: { section, fields: { [field]: value } },
 		}),
 	);
 
-	console.log(chalk.green(`✓ Stored ${key}`));
-	if (project_id) {
-		console.log(
-			chalk.gray(
-				`  Reference: ${buildExactClawdiReference(project_id, vaultSlug, section, field)}`,
-			),
-		);
-	}
+	console.log(chalk.green(`✓ Stored ${normalizedKey}`));
+	console.log(
+		chalk.gray(
+			`  Reference: ${buildExactClawdiReference(targetProject.projectId, vaultSlug, section, field)}`,
+		),
+	);
 }
 
 export async function vaultList(opts: { json?: boolean; project?: string } = {}) {
@@ -201,16 +185,38 @@ export async function vaultList(opts: { json?: boolean; project?: string } = {})
 		return;
 	}
 
+	const projects = await listProjects(api.baseUrl, api.apiKey).catch(() => []);
+	const projectLabel = (projectId: string | undefined) => {
+		if (!projectId) return "unattached";
+		const project = projects.find((item) => item.id === projectId);
+		return project ? `${formatProjectLabel(project)} (${projectId})` : projectId;
+	};
+	const groups = new Map<
+		string,
+		{
+			projectId: string | undefined;
+			rows: Array<{ vault: VaultListRow; items: Record<string, string[]> }>;
+		}
+	>();
 	for (const v of vaults) {
 		const attachedProjectId = projectId ?? vaultProjectIds(v)[0];
 		const items = await fetchItems(v.slug, attachedProjectId);
-		const projectLabel = attachedProjectId ? `project=${attachedProjectId}` : "project=unattached";
-		console.log(chalk.white(`  ${sanitizeMetadata(v.slug)} ${chalk.gray(projectLabel)}`));
-		for (const row of attachedProjectId
-			? buildVaultReferenceRows(attachedProjectId, v.slug, items)
-			: []) {
-			console.log(chalk.gray(`    ${sanitizeMetadata(row.key)}`));
-			console.log(chalk.gray(`      ${row.reference}`));
+		const key = attachedProjectId ?? "(unattached)";
+		const group = groups.get(key) ?? { projectId: attachedProjectId, rows: [] };
+		group.rows.push({ vault: v, items });
+		groups.set(key, group);
+	}
+
+	for (const group of groups.values()) {
+		console.log(chalk.white(`Project ${projectLabel(group.projectId)}`));
+		for (const { vault, items } of group.rows) {
+			console.log(chalk.gray(`  Vault ${sanitizeMetadata(vault.slug)}`));
+			for (const row of group.projectId
+				? buildVaultReferenceRows(group.projectId, vault.slug, items)
+				: []) {
+				console.log(chalk.gray(`    ${sanitizeMetadata(row.key)}`));
+				console.log(chalk.gray(`      ${row.reference}`));
+			}
 		}
 	}
 }
@@ -240,77 +246,283 @@ function buildVaultReferenceRows(
 	);
 }
 
-export async function vaultImport(file: string, opts: { yes?: boolean; project?: string } = {}) {
+interface VaultImportOptions {
+	yes?: boolean;
+	project?: string;
+	section?: string;
+	vault?: string;
+}
+
+export async function vaultImport(file: string, opts: VaultImportOptions = {}) {
 	requireAuth();
 
+	const vaultSlug = cleanVaultSlug(opts.vault ?? "default");
+	const section = cleanVaultSection(opts.section ?? "");
 	const content = readFileSync(file, "utf-8");
 	const fields: Record<string, string> = {};
-	for (const [key, value] of parseDotenv(content)) {
+	const parsed = parseDotenvDetailed(content);
+	for (const [key, value] of parsed.entries) {
 		fields[key] = value;
 	}
 
+	if (parsed.skippedInvalidIdentifiers.length > 0) {
+		console.log(chalk.yellow(formatSkippedInvalidIdentifiers(parsed.skippedInvalidIdentifiers)));
+	}
+
 	if (Object.keys(fields).length === 0) {
-		console.log(chalk.gray("No keys found in file."));
+		console.log(
+			chalk.gray(
+				parsed.skippedInvalidIdentifiers.length > 0
+					? "No valid keys found in file."
+					: "No keys found in file.",
+			),
+		);
 		return;
 	}
+
+	const api = new ApiClient();
+	const targetProject = await resolveVaultWriteProject(api, opts.project);
+	const target = formatVaultTarget(vaultSlug, section, targetProject);
 
 	// Skip the confirmation prompt under `--yes` so CI / scripted
 	// imports (demos, .env bootstrap) don't hang on stdin. The
 	// preview banner still renders so the operator can see what
 	// just landed.
-	p.note(Object.keys(fields).join("\n"), `${Object.keys(fields).length} keys from ${file}`);
+	p.note(
+		Object.keys(fields).join("\n"),
+		`${Object.keys(fields).length} keys from ${file} -> ${target}`,
+	);
 	if (!opts.yes) {
-		const ok = await p.confirm({ message: "Import these keys?" });
+		const ok = await p.confirm({ message: `Import these keys to ${target}?` });
 		if (p.isCancel(ok) || !ok) {
 			p.cancel("Cancelled.");
 			return;
 		}
 	}
 
-	const api = new ApiClient();
-	let pinnedProjectId: string | undefined;
-	if (opts.project) {
-		const { resolveProjectId } = await import("../lib/project-resolver.js");
-		const { getAuth, getConfig } = await import("../lib/config.js");
-		const cfg = getConfig();
-		const auth = getAuth();
-		if (!auth?.apiKey) {
-			console.log(chalk.red("Not signed in. Run `clawdi auth login` first."));
-			process.exit(1);
-		}
-		pinnedProjectId = await resolveProjectId(cfg.apiUrl, auth.apiKey, opts.project);
-	}
+	await ensureVault(
+		api,
+		vaultSlug,
+		vaultSlug === "default" ? "Default" : vaultSlug,
+		targetProject.projectId,
+	);
 
-	await ensureVault(api, "default", "Default", pinnedProjectId);
-
-	const project_id = pinnedProjectId ?? (await resolveVaultProjectId(api, "default"));
 	unwrap(
 		await api.PUT("/api/vault/{slug}/items", {
 			params: {
-				path: { slug: "default" },
-				query: project_id ? { project_id } : {},
+				path: { slug: vaultSlug },
+				query: { project_id: targetProject.projectId },
 			},
-			body: { section: "", fields },
+			body: { section, fields },
 		}),
 	);
 
-	console.log(chalk.green(`✓ Imported ${Object.keys(fields).length} keys to vault "default"`));
-	if (project_id) {
-		console.log(chalk.gray("  References:"));
-		for (const field of Object.keys(fields).sort()) {
-			console.log(
-				chalk.gray(
-					`    ${sanitizeMetadata(field)}=${buildExactClawdiReference(project_id, "default", "", field)}`,
-				),
-			);
-		}
+	console.log(chalk.green(`✓ Imported ${Object.keys(fields).length} keys to ${target}`));
+	console.log(chalk.gray("  References:"));
+	for (const field of Object.keys(fields).sort()) {
+		console.log(
+			chalk.gray(
+				`    ${sanitizeMetadata(field)}=${buildExactClawdiReference(targetProject.projectId, vaultSlug, section, field)}`,
+			),
+		);
 	}
 }
 
+interface VaultRmOptions {
+	project?: string;
+	yes?: boolean;
+}
+
+export async function vaultRm(key: string, opts: VaultRmOptions = {}) {
+	requireAuth();
+
+	const { vaultSlug, section, field } = parseVaultKey(key);
+	const normalizedKey = formatVaultKey(vaultSlug, section, field);
+	const api = new ApiClient();
+	const targetProject = await resolveVaultWriteProject(api, opts.project);
+	const target = formatVaultTarget(vaultSlug, section, targetProject);
+
+	if (!opts.yes) {
+		const ok = await p.confirm({ message: `Delete ${normalizedKey} from ${target}?` });
+		if (p.isCancel(ok) || !ok) {
+			p.cancel("Cancelled.");
+			return;
+		}
+	}
+
+	unwrap(
+		await api.DELETE("/api/vault/{slug}/items", {
+			params: {
+				path: { slug: vaultSlug },
+				query: { project_id: targetProject.projectId },
+			},
+			body: { section, fields: [field] },
+		}),
+	);
+
+	console.log(chalk.green(`✓ Deleted ${normalizedKey} from ${target}`));
+}
+
+async function readVaultSetValue(key: string, opts: VaultSetOptions): Promise<string | null> {
+	if (opts.value !== undefined && opts.stdin) {
+		throw new Error("Pass either --value or --stdin, not both.");
+	}
+	if (opts.value !== undefined) return opts.value;
+	if (opts.stdin) {
+		if (process.stdin.isTTY) {
+			throw new Error("Refusing to read --stdin from an interactive TTY.");
+		}
+		return stripFinalNewline(await readStdin());
+	}
+	const value = await p.password({ message: `Value for ${key}:` });
+	if (p.isCancel(value) || !value) {
+		p.cancel("Cancelled.");
+		return null;
+	}
+	return value;
+}
+
+async function readStdin(): Promise<string> {
+	return await new Promise((resolve, reject) => {
+		let input = "";
+		const cleanup = () => {
+			process.stdin.off("data", onData);
+			process.stdin.off("end", onEnd);
+			process.stdin.off("error", onError);
+		};
+		const onData = (chunk: string) => {
+			input += chunk;
+		};
+		const onEnd = () => {
+			cleanup();
+			resolve(input);
+		};
+		const onError = (error: Error) => {
+			cleanup();
+			reject(error);
+		};
+		process.stdin.setEncoding("utf8");
+		process.stdin.on("data", onData);
+		process.stdin.once("end", onEnd);
+		process.stdin.once("error", onError);
+	});
+}
+
+function stripFinalNewline(value: string): string {
+	return value.replace(/\r?\n$/, "");
+}
+
+function cleanVaultSlug(value: string): string {
+	const slug = value.trim();
+	if (!VAULT_SLUG_RE.test(slug)) {
+		throw new Error(
+			"Vault slug must use lowercase letters, numbers, and hyphens, without leading or trailing hyphens.",
+		);
+	}
+	return slug;
+}
+
+function cleanVaultSection(value: string): string {
+	const section = value.trim();
+	if (!section) return "";
+	if (section.length > 200) throw new Error("Vault section must be at most 200 characters.");
+	if (!VAULT_ITEM_SEGMENT_RE.test(section)) {
+		throw new Error(
+			"Vault section may contain only letters, numbers, dots, underscores, and hyphens.",
+		);
+	}
+	return section;
+}
+
+function cleanVaultField(value: string): string {
+	const field = value.trim();
+	if (!field) throw new Error("Vault field cannot be empty.");
+	if (field.length > 200) throw new Error("Vault field must be at most 200 characters.");
+	if (!VAULT_ITEM_SEGMENT_RE.test(field)) {
+		throw new Error(
+			"Vault field may contain only letters, numbers, dots, underscores, and hyphens.",
+		);
+	}
+	return field;
+}
+
+interface VaultWriteProject {
+	projectId: string;
+	label: string;
+	source: "explicit" | "default";
+}
+
+async function resolveVaultWriteProject(
+	api: ApiClient,
+	projectArg: string | undefined,
+): Promise<VaultWriteProject> {
+	const projectId = await resolveProjectId(api.baseUrl, api.apiKey, projectArg);
+	const project = (await listProjects(api.baseUrl, api.apiKey).catch(() => [])).find(
+		(item) => item.id === projectId,
+	);
+	return {
+		projectId,
+		label: project ? formatProjectLabel(project) : projectArg || projectId,
+		source: projectArg ? "explicit" : "default",
+	};
+}
+
+function formatVaultTarget(vaultSlug: string, section: string, project: VaultWriteProject): string {
+	const target = section ? `vault "${vaultSlug}" section "${section}"` : `vault "${vaultSlug}"`;
+	const source = project.source === "explicit" ? "explicit project" : "default-write project";
+	return `${target} in ${source} "${sanitizeMetadata(project.label)}" (${project.projectId})`;
+}
+
+function formatProjectLabel(project: {
+	slug: string;
+	is_owner?: boolean;
+	owner_handle?: string | null;
+}) {
+	if (project.is_owner === false && project.owner_handle) {
+		return `@${project.owner_handle}/${project.slug}`;
+	}
+	return project.slug;
+}
+
+function formatVaultKey(vaultSlug: string, section: string, field: string): string {
+	if (vaultSlug === "default" && !section) return field;
+	return [vaultSlug, section, field].filter(Boolean).join("/");
+}
+
+function formatSkippedInvalidIdentifiers(identifiers: string[]): string {
+	const maxShown = 10;
+	const shown = identifiers.slice(0, maxShown).map(sanitizeMetadata).join(", ");
+	const more = identifiers.length > maxShown ? `, +${identifiers.length - maxShown} more` : "";
+	return `Skipped ${identifiers.length} ${pluralize(
+		"key",
+		identifiers.length,
+	)} with invalid identifiers: ${shown}${more}`;
+}
+
+function pluralize(word: string, count: number): string {
+	return count === 1 ? word : `${word}s`;
+}
+
 function parseVaultKey(key: string): { vaultSlug: string; section: string; field: string } {
-	const cleaned = key.replace(/^clawdi:\/\//, "");
-	const [a = "", b = "", c = ""] = cleaned.split("/");
-	if (c) return { vaultSlug: a, section: b, field: c };
-	if (b) return { vaultSlug: a, section: "", field: b };
-	return { vaultSlug: "default", section: "", field: a };
+	const cleaned = key.replace(/^clawdi:\/\//, "").trim();
+	const parts = cleaned.split("/");
+	if (parts.length === 1) {
+		return { vaultSlug: "default", section: "", field: cleanVaultField(parts[0] ?? "") };
+	}
+	if (parts.length === 2) {
+		return {
+			vaultSlug: cleanVaultSlug(parts[0] ?? ""),
+			section: "",
+			field: cleanVaultField(parts[1] ?? ""),
+		};
+	}
+	if (parts.length === 3) {
+		if (!(parts[1] ?? "").trim()) throw new Error("Vault section cannot be empty.");
+		return {
+			vaultSlug: cleanVaultSlug(parts[0] ?? ""),
+			section: cleanVaultSection(parts[1] ?? ""),
+			field: cleanVaultField(parts[2] ?? ""),
+		};
+	}
+	throw new Error("Vault key must be KEY, vault/KEY, or vault/section/KEY.");
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -267,22 +267,39 @@ registerServeCommand(program);
 // ─────────────────────────────────────────────────────────────
 // vault
 // ─────────────────────────────────────────────────────────────
-const vaultCmd = program.command("vault").description("Manage secrets");
+const vaultCmd = program
+	.command("vault")
+	.description("Manage secrets")
+	.addHelpText(
+		"after",
+		`
+Scope:
+  Write commands (set/import/rm) use --project first; otherwise they write to
+  your default-write project. The selected project is printed before writing.
+  Key paths are KEY, vault/KEY, or vault/section/KEY.`,
+	);
 
 vaultCmd
 	.command("set <key>")
-	.description("Store a secret (prompted for value)")
+	.description("Store a secret")
 	.option(
 		"-p, --project <id-or-slug>",
 		"Target a specific project (default: your default-write project)",
 	)
+	.option("--value <value>", "Secret value; use --stdin to avoid shell history")
+	.option("--stdin", "Read the secret value from stdin")
 	.addHelpText(
 		"after",
-		"\nExamples:\n  $ clawdi vault set OPENAI_API_KEY\n  $ clawdi vault set DEPLOY_KEY --project engineering",
+		"\nExamples:\n  $ clawdi vault set OPENAI_API_KEY\n  $ clawdi vault set DEPLOY_KEY --project engineering\n  $ printf 'secret' | clawdi vault set prod/api/DEPLOY_KEY --stdin",
 	)
 	.action(async (key, opts) => {
 		const { vaultSet } = await import("./commands/vault.js");
-		await vaultSet(key, { ...opts, project: opts.project });
+		await vaultSet(key, {
+			...opts,
+			project: opts.project,
+			value: opts.value,
+			stdin: opts.stdin,
+		});
 	});
 
 vaultCmd
@@ -302,17 +319,42 @@ vaultCmd
 	.command("import <file>")
 	.description("Import from .env file")
 	.option("-y, --yes", "Skip the confirmation prompt (for CI / scripted imports)")
+	.option("--vault <slug>", "Target vault slug", "default")
+	.option("--section <name>", "Target vault section")
 	.option(
 		"-p, --project <id-or-slug>",
 		"Target a specific project (default: your default-write project)",
 	)
 	.addHelpText(
 		"after",
-		"\nExamples:\n  $ clawdi vault import .env.production\n  $ clawdi vault import .env.staging --project engineering --yes",
+		"\nExamples:\n  $ clawdi vault import .env.production\n  $ clawdi vault import .env.staging --project engineering --yes\n  $ clawdi vault import --vault prod --section stripe --project engineering --yes .env.stripe",
 	)
 	.action(async (file, opts) => {
 		const { vaultImport } = await import("./commands/vault.js");
-		await vaultImport(file, { ...opts, project: opts.project });
+		await vaultImport(file, {
+			...opts,
+			project: opts.project,
+			section: opts.section,
+			vault: opts.vault,
+		});
+	});
+
+vaultCmd
+	.command("rm <key>")
+	.alias("delete")
+	.description("Delete a secret")
+	.option(
+		"-p, --project <id-or-slug>",
+		"Target a specific project (default: your default-write project)",
+	)
+	.option("-y, --yes", "Skip the confirmation prompt")
+	.addHelpText(
+		"after",
+		"\nExamples:\n  $ clawdi vault rm OPENAI_API_KEY\n  $ clawdi vault delete prod/stripe/SECRET_KEY --project engineering --yes",
+	)
+	.action(async (key, opts) => {
+		const { vaultRm } = await import("./commands/vault.js");
+		await vaultRm(key, { ...opts, project: opts.project, yes: opts.yes });
 	});
 
 vaultCmd
@@ -630,7 +672,11 @@ Examples:
 
   $ clawdi run --project @alice/engineering --env-file .env.clawdi -- npm run dev
   $ clawdi run --all-vault-env -- npm run dev
-  $ clawdi run --no-project-folder -- python main.py`,
+  $ clawdi run --no-project-folder -- python main.py
+
+Scope resolution:
+  Exact clawdi://project/... references carry their own project.
+  Otherwise --project wins, then --agent, then linked folder, then default-write project.`,
 	)
 	.action(async (args, opts) => {
 		const { run } = await import("./commands/run.js");
@@ -646,7 +692,11 @@ const projectCmd = program
 Folder-link workflow:
   $ clawdi project folder link --project engineering
   $ clawdi project folder status
-  $ clawdi run -- npm run deploy`,
+  $ clawdi run -- npm run deploy
+
+Notes:
+  project list hides auto-created machine/environment projects by default.
+  Use project list --include-envs to inspect those scopes.`,
 	);
 
 projectCmd
@@ -671,14 +721,22 @@ projectCmd
 	.option("--json", "Emit machine-readable JSON (agent contract)")
 	.option("--shared-with-me", "Show only projects shared with you")
 	.option("--owned", "Show only projects you own")
+	.option("--include-envs", "Include auto-created machine/environment projects")
 	.addHelpText(
 		"after",
-		"\nExamples:\n  $ clawdi project list\n  $ clawdi project list --shared-with-me --json",
+		"\nExamples:\n  $ clawdi project list\n  $ clawdi project list --include-envs\n  $ clawdi project list --shared-with-me --json",
 	)
-	.action(async (opts: { json?: boolean; sharedWithMe?: boolean; owned?: boolean }) => {
-		const { projectListCommand } = await import("./commands/project-list.js");
-		await projectListCommand(opts);
-	});
+	.action(
+		async (opts: {
+			json?: boolean;
+			sharedWithMe?: boolean;
+			owned?: boolean;
+			includeEnvs?: boolean;
+		}) => {
+			const { projectListCommand } = await import("./commands/project-list.js");
+			await projectListCommand(opts);
+		},
+	);
 
 projectCmd
 	.command("show <project>")

--- a/packages/cli/src/lib/dotenv.ts
+++ b/packages/cli/src/lib/dotenv.ts
@@ -1,13 +1,29 @@
+const DOTENV_IDENTIFIER_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export interface ParsedDotenv {
+	entries: Array<[string, string]>;
+	skippedInvalidIdentifiers: string[];
+}
+
 export function parseDotenv(content: string): Array<[string, string]> {
+	return parseDotenvDetailed(content).entries;
+}
+
+export function parseDotenvDetailed(content: string): ParsedDotenv {
 	const entries: Array<[string, string]> = [];
+	const skippedInvalidIdentifiers: string[] = [];
 	for (const line of content.split(/\r?\n/)) {
 		const trimmed = line.trim();
 		if (!trimmed || trimmed.startsWith("#")) continue;
-		const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/.exec(trimmed);
+		const match = /^(?:export\s+)?([^=\s]+)\s*=\s*(.*)$/.exec(trimmed);
 		if (!match) continue;
+		if (!DOTENV_IDENTIFIER_RE.test(match[1])) {
+			skippedInvalidIdentifiers.push(match[1]);
+			continue;
+		}
 		entries.push([match[1], parseDotenvValue(match[2].trim())]);
 	}
-	return entries;
+	return { entries, skippedInvalidIdentifiers };
 }
 
 function parseDotenvValue(value: string): string {

--- a/packages/cli/tests/commands/project-list.test.ts
+++ b/packages/cli/tests/commands/project-list.test.ts
@@ -119,5 +119,88 @@ describe("projectListCommand", () => {
 		expect(parsed.shared_projects.map((p: { slug: string }) => p.slug)).toEqual(["shared-toolkit"]);
 		expect(parsed.shared_projects[0].owner_handle).toBe("alice-a3b4");
 		expect(parsed.projects).toHaveLength(3);
+		expect(parsed.environment_projects).toEqual([]);
+		expect(parsed.hidden_environment_project_count).toBe(0);
+	});
+
+	it("hides machine environment projects by default and can include them", async () => {
+		const projects = [
+			{ id: "project-a", slug: "personal", name: "Personal", kind: "personal", is_owner: true },
+			{
+				id: "project-env",
+				slug: "env-abc123",
+				name: "Workstation (codex)",
+				kind: "environment",
+				is_owner: true,
+			},
+		];
+		const { restore } = mockFetch([
+			{ method: "GET", path: "/api/projects", response: () => jsonResponse(projects) },
+		]);
+		const orig = console.log;
+		const lines: string[] = [];
+		console.log = (...args: unknown[]) => {
+			lines.push(args.map(String).join(" "));
+		};
+
+		try {
+			await projectListCommand({});
+			const hiddenOut = lines.join("\n");
+			expect(hiddenOut).toContain("My projects (1)");
+			expect(hiddenOut).not.toContain("env-abc123");
+			expect(hiddenOut).toContain("Hidden machine projects: 1");
+
+			lines.length = 0;
+			await projectListCommand({ includeEnvs: true });
+			const includedOut = lines.join("\n");
+			expect(includedOut).toContain("Machines (1)");
+			expect(includedOut).toContain("env-abc123");
+		} finally {
+			console.log = orig;
+			restore();
+		}
+	});
+
+	it("omits machine environment projects from JSON unless requested", async () => {
+		const projects = [
+			{ id: "project-a", slug: "personal", name: "Personal", kind: "personal", is_owner: true },
+			{
+				id: "project-env",
+				slug: "env-abc123",
+				name: "Workstation (codex)",
+				kind: "environment",
+				is_owner: true,
+			},
+		];
+		const { restore } = mockFetch([
+			{ method: "GET", path: "/api/projects", response: () => jsonResponse(projects) },
+		]);
+		const orig = console.log;
+		let out = "";
+		console.log = (...args: unknown[]) => {
+			out = args.map(String).join(" ");
+		};
+
+		try {
+			await projectListCommand({ json: true });
+			const hidden = JSON.parse(out);
+			expect(hidden.projects.map((p: { slug: string }) => p.slug)).toEqual(["personal"]);
+			expect(hidden.environment_projects).toEqual([]);
+			expect(hidden.hidden_environment_project_count).toBe(1);
+
+			await projectListCommand({ json: true, includeEnvs: true });
+			const included = JSON.parse(out);
+			expect(included.projects.map((p: { slug: string }) => p.slug)).toEqual([
+				"personal",
+				"env-abc123",
+			]);
+			expect(included.environment_projects.map((p: { slug: string }) => p.slug)).toEqual([
+				"env-abc123",
+			]);
+			expect(included.hidden_environment_project_count).toBe(0);
+		} finally {
+			console.log = orig;
+			restore();
+		}
 	});
 });

--- a/packages/cli/tests/commands/vault.test.ts
+++ b/packages/cli/tests/commands/vault.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { vaultImport, vaultList } from "../../src/commands/vault";
+import { vaultImport, vaultList, vaultRm, vaultSet } from "../../src/commands/vault";
 import { jsonResponse, mockFetch } from "./helpers";
 
 let tmpHome: string;
@@ -89,11 +89,60 @@ describe("vaultList", () => {
 			restore();
 		}
 
-		expect(out).toContain(`default project=${PROJECT_ID}`);
+		expect(out).toContain(`Project personal (${PROJECT_ID})`);
+		expect(out).toContain("Vault default");
 		expect(out).toContain(`clawdi://project/${PROJECT_ID}/vault/default/field/OPENAI_API_KEY`);
 		expect(out).toContain(
 			`clawdi://project/${PROJECT_ID}/vault/default/section/openai/field/api%20key`,
 		);
+	});
+
+	it("groups multiple vaults under one project in human output", async () => {
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/api/vault/default/items",
+				response: () => jsonResponse({ "(default)": ["OPENAI_API_KEY"] }),
+			},
+			{
+				method: "GET",
+				path: "/api/vault/prod/items",
+				response: () => jsonResponse({ stripe: ["SECRET_KEY"] }),
+			},
+			{
+				method: "GET",
+				path: "/api/vault",
+				response: () =>
+					jsonResponse({
+						items: [
+							{ id: "vault-1", slug: "default", name: "Default", project_id: PROJECT_ID },
+							{ id: "vault-2", slug: "prod", name: "prod", project_id: PROJECT_ID },
+						],
+						total: 2,
+					}),
+			},
+			...mockProjectList(),
+		]);
+		const ttyDesc = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+		const origLog = console.log;
+		let out = "";
+		console.log = (...args: unknown[]) => {
+			out += `${args.map(String).join(" ")}\n`;
+		};
+
+		try {
+			await vaultList({});
+		} finally {
+			console.log = origLog;
+			if (ttyDesc) Object.defineProperty(process.stdout, "isTTY", ttyDesc);
+			else Object.defineProperty(process.stdout, "isTTY", { value: undefined, configurable: true });
+			restore();
+		}
+
+		expect(out.match(/Project personal/g)?.length).toBe(1);
+		expect(out).toContain("Vault default");
+		expect(out).toContain("Vault prod");
 	});
 });
 
@@ -112,6 +161,7 @@ describe("vaultImport", () => {
 			].join("\n"),
 		);
 		const { captured, restore } = mockFetch([
+			...mockDefaultProjectResolution(),
 			{
 				method: "POST",
 				path: "/api/vault",
@@ -173,6 +223,299 @@ describe("vaultImport", () => {
 		expect(captured).toHaveLength(0);
 		expect(out).toContain("No keys found in file.");
 	});
+
+	it("warns about invalid dotenv identifiers without writing when none are valid", async () => {
+		const envFile = join(tmpHome, ".env.invalid");
+		writeFileSync(envFile, ["my-section/OPENAI_API_KEY=secret", "api.key=value", ""].join("\n"));
+		const { captured, restore } = mockFetch([]);
+		const origLog = console.log;
+		let out = "";
+		console.log = (...args: unknown[]) => {
+			out += `${args.map(String).join(" ")}\n`;
+		};
+
+		try {
+			await vaultImport(envFile, { yes: true });
+		} finally {
+			console.log = origLog;
+			restore();
+		}
+
+		expect(captured).toHaveLength(0);
+		expect(out).toContain(
+			"Skipped 2 keys with invalid identifiers: my-section/OPENAI_API_KEY, api.key",
+		);
+		expect(out).toContain("No valid keys found in file.");
+	});
+
+	it("caps long invalid identifier warnings", async () => {
+		const envFile = join(tmpHome, ".env.many-invalid");
+		writeFileSync(
+			envFile,
+			Array.from({ length: 12 }, (_, index) => `bad-key-${index}=secret`).join("\n"),
+		);
+		const { captured, restore } = mockFetch([]);
+		const origLog = console.log;
+		let out = "";
+		console.log = (...args: unknown[]) => {
+			out += `${args.map(String).join(" ")}\n`;
+		};
+
+		try {
+			await vaultImport(envFile, { yes: true });
+		} finally {
+			console.log = origLog;
+			restore();
+		}
+
+		expect(captured).toHaveLength(0);
+		expect(out).toContain(
+			"Skipped 12 keys with invalid identifiers: bad-key-0, bad-key-1, bad-key-2, bad-key-3, bad-key-4, bad-key-5, bad-key-6, bad-key-7, bad-key-8, bad-key-9, +2 more",
+		);
+	});
+
+	it("imports dotenv files into the requested vault section", async () => {
+		const envFile = join(tmpHome, ".env.prod");
+		writeFileSync(envFile, ["STRIPE_SECRET_KEY=sk_live", "bad-key=skipped"].join("\n"));
+		const { captured, restore } = mockFetch([
+			...mockDefaultProjectResolution(),
+			{
+				method: "POST",
+				path: "/api/vault",
+				response: () => jsonResponse({ detail: "already exists" }, 409),
+			},
+			{
+				method: "GET",
+				path: "/api/vault",
+				response: () =>
+					jsonResponse({
+						items: [{ id: "vault-1", slug: "prod", name: "prod", project_id: PROJECT_ID }],
+						total: 1,
+					}),
+			},
+			{
+				method: "PUT",
+				path: "/api/vault/prod/items",
+				response: () => jsonResponse({ status: "ok", fields: 1 }),
+			},
+		]);
+		const origLog = console.log;
+		let out = "";
+		console.log = (...args: unknown[]) => {
+			out += `${args.map(String).join(" ")}\n`;
+		};
+
+		try {
+			await vaultImport(envFile, { yes: true, vault: "prod", section: "stripe" });
+		} finally {
+			console.log = origLog;
+			restore();
+		}
+
+		const create = captured.find((request) => request.method === "POST");
+		expect(create?.body).toEqual({ slug: "prod", name: "prod" });
+		const put = captured.find((request) => request.method === "PUT");
+		expect(put?.path).toContain("/api/vault/prod/items");
+		expect(put?.body).toEqual({
+			section: "stripe",
+			fields: { STRIPE_SECRET_KEY: "sk_live" },
+		});
+		expect(out).toContain("Skipped 1 key with invalid identifiers: bad-key");
+		expect(out).toContain(
+			`Imported 1 keys to vault "prod" section "stripe" in default-write project "personal" (${PROJECT_ID})`,
+		);
+		expect(out).toContain(
+			`clawdi://project/${PROJECT_ID}/vault/prod/section/stripe/field/STRIPE_SECRET_KEY`,
+		);
+	});
+
+	it("rejects invalid import targets before writing", async () => {
+		const envFile = join(tmpHome, ".env.bad-target");
+		writeFileSync(envFile, "TOKEN=secret\n");
+		const { captured, restore } = mockFetch([]);
+
+		try {
+			await expect(vaultImport(envFile, { yes: true, section: "api/keys" })).rejects.toThrow(
+				"Vault section may contain only letters",
+			);
+		} finally {
+			restore();
+		}
+
+		expect(captured).toHaveLength(0);
+	});
+});
+
+describe("vaultSet", () => {
+	it("stores a non-interactive --value without prompting", async () => {
+		const { captured, restore } = mockFetch([
+			...mockDefaultProjectResolution(),
+			{
+				method: "POST",
+				path: "/api/vault",
+				response: () => jsonResponse({ detail: "already exists" }, 409),
+			},
+			{
+				method: "GET",
+				path: "/api/vault",
+				response: () =>
+					jsonResponse({
+						items: [{ id: "vault-1", slug: "prod", name: "prod", project_id: PROJECT_ID }],
+						total: 1,
+					}),
+			},
+			{
+				method: "PUT",
+				path: "/api/vault/prod/items",
+				response: () => jsonResponse({ status: "ok", fields: 1 }),
+			},
+		]);
+		const origLog = console.log;
+		console.log = () => {};
+
+		try {
+			await vaultSet("prod/stripe/SECRET_KEY", { value: "sk-live" });
+		} finally {
+			console.log = origLog;
+			restore();
+		}
+
+		const put = captured.find((request) => request.method === "PUT");
+		expect(put?.path).toContain("/api/vault/prod/items");
+		expect(put?.body).toEqual({
+			section: "stripe",
+			fields: { SECRET_KEY: "sk-live" },
+		});
+	});
+
+	it("stores a non-interactive --stdin value and strips one final newline", async () => {
+		const { captured, restore } = mockFetch([
+			...mockDefaultProjectResolution(),
+			{
+				method: "POST",
+				path: "/api/vault",
+				response: () => jsonResponse({ detail: "already exists" }, 409),
+			},
+			{
+				method: "GET",
+				path: "/api/vault",
+				response: () =>
+					jsonResponse({
+						items: [{ id: "vault-1", slug: "prod", name: "prod", project_id: PROJECT_ID }],
+						total: 1,
+					}),
+			},
+			{
+				method: "PUT",
+				path: "/api/vault/prod/items",
+				response: () => jsonResponse({ status: "ok", fields: 1 }),
+			},
+		]);
+		const stdinTtyDesc = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+		Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+		const origLog = console.log;
+		console.log = () => {};
+
+		try {
+			const run = vaultSet("prod/stripe/SECRET_KEY", { stdin: true });
+			queueMicrotask(() => {
+				process.stdin.emit("data", "sk-live\n");
+				process.stdin.emit("end");
+			});
+			await run;
+		} finally {
+			console.log = origLog;
+			if (stdinTtyDesc) Object.defineProperty(process.stdin, "isTTY", stdinTtyDesc);
+			else Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+			restore();
+		}
+
+		const put = captured.find((request) => request.method === "PUT");
+		expect(put?.path).toContain("/api/vault/prod/items");
+		expect(put?.body).toEqual({
+			section: "stripe",
+			fields: { SECRET_KEY: "sk-live" },
+		});
+	});
+
+	it("rejects --stdin from an interactive TTY before writing", async () => {
+		const { captured, restore } = mockFetch([]);
+		const stdinTtyDesc = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+		Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+
+		try {
+			await expect(vaultSet("SECRET_KEY", { stdin: true })).rejects.toThrow(
+				"Refusing to read --stdin from an interactive TTY.",
+			);
+		} finally {
+			if (stdinTtyDesc) Object.defineProperty(process.stdin, "isTTY", stdinTtyDesc);
+			else Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+			restore();
+		}
+
+		expect(captured).toHaveLength(0);
+	});
+
+	it("deletes a key from the resolved vault project", async () => {
+		const { captured, restore } = mockFetch([
+			...mockDefaultProjectResolution(),
+			{
+				method: "DELETE",
+				path: "/api/vault/prod/items",
+				response: () => jsonResponse({ status: "deleted" }),
+			},
+		]);
+		const origLog = console.log;
+		let out = "";
+		console.log = (...args: unknown[]) => {
+			out += `${args.map(String).join(" ")}\n`;
+		};
+
+		try {
+			await vaultRm("prod/stripe/SECRET_KEY", { yes: true });
+		} finally {
+			console.log = origLog;
+			restore();
+		}
+
+		const del = captured.find((request) => request.method === "DELETE");
+		expect(del?.path).toContain(`/api/vault/prod/items?project_id=${PROJECT_ID}`);
+		expect(del?.body).toEqual({
+			section: "stripe",
+			fields: ["SECRET_KEY"],
+		});
+		expect(out).toContain(
+			`Deleted prod/stripe/SECRET_KEY from vault "prod" section "stripe" in default-write project "personal" (${PROJECT_ID})`,
+		);
+	});
+
+	it("rejects ambiguous vault keys before writing", async () => {
+		const { captured, restore } = mockFetch([]);
+
+		try {
+			await expect(vaultSet("prod/stripe/SECRET_KEY/extra", { value: "sk-live" })).rejects.toThrow(
+				"Vault key must be KEY, vault/KEY, or vault/section/KEY.",
+			);
+		} finally {
+			restore();
+		}
+
+		expect(captured).toHaveLength(0);
+	});
+
+	it("rejects conflicting non-interactive value sources before writing", async () => {
+		const { captured, restore } = mockFetch([]);
+
+		try {
+			await expect(vaultSet("SECRET_KEY", { value: "sk-live", stdin: true })).rejects.toThrow(
+				"Pass either --value or --stdin, not both.",
+			);
+		} finally {
+			restore();
+		}
+
+		expect(captured).toHaveLength(0);
+	});
 });
 
 function mockVaultListFetch() {
@@ -195,5 +538,56 @@ function mockVaultListFetch() {
 					total: 1,
 				}),
 		},
+		{
+			method: "GET",
+			path: "/api/projects",
+			response: () =>
+				jsonResponse([
+					{
+						id: PROJECT_ID,
+						slug: "personal",
+						name: "Personal",
+						kind: "personal",
+						is_owner: true,
+					},
+				]),
+		},
 	]);
+}
+
+function mockDefaultProjectResolution() {
+	return [
+		{
+			method: "GET",
+			path: "/api/projects/default",
+			response: () => jsonResponse({ project_id: PROJECT_ID }),
+		},
+		{
+			method: "GET",
+			path: "/api/projects",
+			response: () => jsonResponse(mockProjects()),
+		},
+	];
+}
+
+function mockProjectList() {
+	return [
+		{
+			method: "GET",
+			path: "/api/projects",
+			response: () => jsonResponse(mockProjects()),
+		},
+	];
+}
+
+function mockProjects() {
+	return [
+		{
+			id: PROJECT_ID,
+			slug: "personal",
+			name: "Personal",
+			kind: "personal",
+			is_owner: true,
+		},
+	];
 }


### PR DESCRIPTION
## Summary
- add non-interactive vault writes via --value and --stdin
- add vault import targeting for --vault, --section, and --project, with invalid dotenv identifier warnings
- add vault rm/delete and clearer vault/project list UX
- bump CLI package to 0.8.2 and update README, changelog, scenario docs, and bundled clawdi skill

## Verification
- bun install --frozen-lockfile
- bun run check
- bun run typecheck
- bun run test
- bun run --cwd packages/cli build
- bun pm pack
- node packages/cli/bin/clawdi.mjs --version
