### PR TITLE
Fix vault write UX for empty stdin and prompt mode

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,11 +158,11 @@ Three-level layout: vault → section → field. A vault owns the key rows once;
 
 ```
 clawdi://project/<project-id>/vault/default/field/OPENAI_API_KEY
-clawdi://project/<project-id>/vault/prod/section/openai/field/api_key
+clawdi://project/<project-id>/vault/api-service/section/openai/field/api_key
 clawdi://default/OPENAI_API_KEY
-clawdi://prod/openai/api_key
-clawdi://prod/stripe/secret_key
-clawdi://prod/database/url
+clawdi://api-service/openai/api_key
+clawdi://payments/stripe/secret_key
+clawdi://api-service/database/url
 ```
 
 `.env` imports and `clawdi vault set OPENAI_API_KEY` store fields without a section by default, so that key resolves as `clawdi://default/OPENAI_API_KEY`. Use `clawdi vault import --section openai ...` or `clawdi vault set default/openai/api_key` for sectioned fields.

--- a/docs/plans/clawdi-vault-password-manager-research.md
+++ b/docs/plans/clawdi-vault-password-manager-research.md
@@ -618,7 +618,7 @@ Examples:
 
 ```text
 clawdi://project/00000000-0000-0000-0000-000000000123/vault/default/field/OPENAI_API_KEY
-clawdi://project/00000000-0000-0000-0000-000000000123/vault/prod/section/openai/field/api_key
+clawdi://project/00000000-0000-0000-0000-000000000123/vault/api-service/section/openai/field/api_key
 ```
 
 Keep project-relative syntax for portable templates and environment switching:
@@ -632,15 +632,15 @@ Examples:
 
 ```text
 clawdi://default/OPENAI_API_KEY
-clawdi://prod/openai/api_key
-clawdi://prod/database/url
-clawdi://prod/stripe/secret_key
+clawdi://api-service/openai/api_key
+clawdi://api-service/database/url
+clawdi://payments/stripe/secret_key
 ```
 
 Fields imported from `.env` files or stored with `clawdi vault set OPENAI_API_KEY`
 use no section by default, so they resolve as `clawdi://default/OPENAI_API_KEY`.
 Sectioned paths remain available for manually structured vault fields.
-In these examples `default`, `prod`, and any other first path component are
+In these examples `default`, `api-service`, and any other first path component are
 vault slugs, not Projects. Project selection is deliberately kept outside the
 portable reference.
 
@@ -686,7 +686,7 @@ model.
 Add 1Password-like general commands:
 
 ```bash
-clawdi read clawdi://project/<project-id>/vault/prod/section/stripe/field/secret_key
+clawdi read clawdi://project/<project-id>/vault/payments/section/stripe/field/secret_key
 
 clawdi run --env-file .env -- npm run dev
 
@@ -698,7 +698,7 @@ clawdi inject --in config.template.json
 Support `.env` files like:
 
 ```env
-STRIPE_SECRET_KEY=clawdi://prod/stripe/secret_key
+STRIPE_SECRET_KEY=clawdi://payments/stripe/secret_key
 OPENAI_API_KEY=clawdi://project/<project-id>/vault/default/field/OPENAI_API_KEY
 ```
 
@@ -718,7 +718,7 @@ Add quality-of-life flags:
 ```bash
 clawdi run --env-file .env --no-inherit-env -- npm run dev
 clawdi run --agent codex --env-file .env -- npm run test
-clawdi read clawdi://project/<project-id>/vault/prod/section/db/field/url --json
+clawdi read clawdi://project/<project-id>/vault/api-service/section/db/field/url --json
 clawdi inject --in .env.template --out -    # stdout
 ```
 

--- a/docs/scenarios/scenario-2-vault-claude-code.md
+++ b/docs/scenarios/scenario-2-vault-claude-code.md
@@ -41,21 +41,21 @@ Current pain points:
 
 ```bash
 # Add a single key interactively
-clawdi vault set OPENAI_API_KEY
+clawdi vault set OPENAI_API_KEY --prompt
 > Enter value: ****
 ✓ Stored OPENAI_API_KEY
 
 # Add non-interactively
-printf '%s\n' "$STRIPE_SECRET_KEY" | clawdi vault set prod/stripe/STRIPE_SECRET_KEY --stdin
-✓ Stored prod/stripe/STRIPE_SECRET_KEY
+printf '%s\n' "$STRIPE_SECRET_KEY" | clawdi vault set payments/env/STRIPE_SECRET_KEY --stdin
+✓ Stored payments/env/STRIPE_SECRET_KEY
 
 # Import from existing .env file
 clawdi vault import .env --yes
 ✓ Imported 6 keys to vault "default" in default-write project "personal" (...)
 
 # Import into a vault section
-clawdi vault import --vault prod --section stripe --project personal --yes .env.stripe
-✓ Imported 6 keys to vault "prod" section "stripe" in explicit project "personal" (...)
+clawdi vault import --vault payments --section stripe --project personal --yes .env.stripe
+✓ Imported 6 keys to vault "payments" section "stripe" in explicit project "personal" (...)
 
 # List stored keys (values never shown)
 clawdi vault list
@@ -63,13 +63,13 @@ Project personal (...)
   Vault default
     OPENAI_API_KEY
       clawdi://project/.../vault/default/field/OPENAI_API_KEY
-  Vault prod
+  Vault payments
     stripe/STRIPE_SECRET_KEY
-      clawdi://project/.../vault/prod/section/stripe/field/STRIPE_SECRET_KEY
+      clawdi://project/.../vault/payments/section/stripe/field/STRIPE_SECRET_KEY
 
 # Remove a key
-clawdi vault rm prod/database/DATABASE_URL --yes
-✓ Deleted prod/database/DATABASE_URL from vault "prod" section "database" in default-write project "personal" (...)
+clawdi vault rm api-service/database/DATABASE_URL --yes
+✓ Deleted api-service/database/DATABASE_URL from vault "api-service" section "database" in default-write project "personal" (...)
 ```
 
 **Via Dashboard (for visual management):**
@@ -164,7 +164,7 @@ jobs:
   deploy:
     steps:
       - run: |
-          clawdi run --keys prod/* -- ./deploy.sh
+          clawdi run --keys api-service/* -- ./deploy.sh
         env:
           CLAWDI_AUTH_TOKEN: ${{ secrets.CLAWDI_AUTH_TOKEN }}
 ```

--- a/docs/using-clawdi-with-claude-code.md
+++ b/docs/using-clawdi-with-claude-code.md
@@ -145,15 +145,15 @@ Works the same under Codex / Hermes / OpenClaw when their MCP connection to Claw
 Store a secret once:
 
 ```bash
-$ clawdi vault set OPENAI_API_KEY
+$ clawdi vault set OPENAI_API_KEY --prompt
 Value for OPENAI_API_KEY: ••••••••••
 ✓ Stored OPENAI_API_KEY
 
-$ printf '%s\n' "$STRIPE_SECRET_KEY" | clawdi vault set prod/stripe/STRIPE_SECRET_KEY --stdin
-✓ Stored prod/stripe/STRIPE_SECRET_KEY
+$ printf '%s\n' "$STRIPE_SECRET_KEY" | clawdi vault set payments/env/STRIPE_SECRET_KEY --stdin
+✓ Stored payments/env/STRIPE_SECRET_KEY
 
-$ clawdi vault import --vault prod --section stripe --project personal --yes .env.stripe
-✓ Imported 3 keys to vault "prod" section "stripe"
+$ clawdi vault import --vault payments --section stripe --project personal --yes .env.stripe
+✓ Imported 3 keys to vault "payments" section "stripe"
 ```
 
 List what's stored (values never leave the CLI unmasked):

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -90,8 +90,9 @@ Later, in a different agent or a fresh session, ask "what package manager should
 Run a fullstack dev command with vault references without putting plaintext secrets on disk:
 
 ```bash
-printf '%s\n' "$OPENAI_API_KEY" | clawdi vault set OPENAI_API_KEY --stdin
-clawdi vault import --vault prod --section stripe --project personal --yes .env.stripe
+clawdi vault set OPENAI_API_KEY --prompt
+printf '%s\n' "$OPENAI_API_KEY" | clawdi vault set api-service/env/OPENAI_API_KEY --stdin
+clawdi vault import --vault api-service --section stripe --project personal --yes .env.stripe
 echo "OPENAI_API_KEY=clawdi://project/<project-id>/vault/default/field/OPENAI_API_KEY" > .env.clawdi
 clawdi run --dry-run --env-file .env.clawdi -- npm run dev
 clawdi run --env-file .env.clawdi -- npm run dev
@@ -100,7 +101,7 @@ clawdi inject --dry-run --in .env.clawdi --out .env.local
 clawdi inject --force --in .env.clawdi --out .env.local
 ```
 
-`clawdi vault set`, `clawdi vault import`, `clawdi vault rm`, and `clawdi vault list` print the concrete Project target or exact references that include the Project ID. `vault set` supports `--value` and `--stdin` for scripts; `vault import` supports `--vault`, `--section`, `--project`, and warns about skipped invalid dotenv identifiers. Project-relative references such as `clawdi://default/OPENAI_API_KEY` still work for portable templates, but exact references are the default copy/read UX.
+`clawdi vault set`, `clawdi vault import`, `clawdi vault rm`, and `clawdi vault list` print the concrete Project target or exact references that include the Project ID. `vault set` supports `--prompt` for secure one-off entry, `--stdin` for scripts, and `--value` when shell history exposure is acceptable; empty stdin is rejected unless `--allow-empty` is passed intentionally. `vault import` supports `--vault`, `--section`, `--project`, and warns about skipped invalid dotenv identifiers. Prefer service-specific vault slugs such as `api-service` over broad environment slugs such as `prod`. Project-relative references such as `clawdi://default/OPENAI_API_KEY` still work for portable templates, but exact references are the default copy/read UX.
 
 Agents should prefer `clawdi run --env-file .env.clawdi -- <command>` when they can launch the tool themselves. Use `clawdi inject` only for tools that must read a physical `.env.local`; generated files are written owner-only and should stay gitignored.
 

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -88,8 +88,11 @@ Connected service tools (Gmail, GitHub, Notion, etc.) are dynamically registered
 
 When the user asks to migrate secrets into Clawdi Vault or script secret writes, prefer the CLI over raw HTTP calls:
 
-- Use `clawdi vault set KEY --stdin` for piped values, or `clawdi vault set KEY --value <value>` only when shell history exposure is acceptable.
-- Use `clawdi vault import --vault <slug> --section <name> --project <project> --yes <file>` for non-interactive `.env` migrations into a section.
+- Use `clawdi vault set KEY --prompt` for one-off manual secret entry; it prompts without echoing input.
+- Use `clawdi vault set KEY --stdin` for piped values. Empty stdin is rejected unless `--allow-empty` is passed intentionally.
+- Use `clawdi vault set KEY --value <value>` only when shell history exposure is acceptable.
+- Use service-specific vault slugs such as `api-service/env/KEY`; avoid broad slugs such as `prod/KEY`.
+- Use `clawdi vault import --vault <service-slug> --section <name> --project <project> --yes <file>` for non-interactive `.env` migrations into a section.
 - Keep `.env` import keys as POSIX environment identifiers such as `OPENAI_API_KEY`; section names belong in `--section`, not inside the key name.
 - Use `clawdi vault rm <vault>/<section>/<field> --yes` or `clawdi vault delete ...` to clean up misplaced keys.
 - Prefer exact `clawdi://project/...` references printed by the CLI. Do not print plaintext secret values unless the user explicitly asks for them.

--- a/packages/cli/src/commands/vault.ts
+++ b/packages/cli/src/commands/vault.ts
@@ -7,9 +7,20 @@ import { parseDotenvDetailed } from "../lib/dotenv";
 import { listProjects, resolveProjectId } from "../lib/project-resolver";
 import { sanitizeMetadata } from "../lib/sanitize";
 import { buildExactClawdiReference } from "../lib/secret-references";
+import { isInteractive } from "../lib/tty";
 
 const VAULT_SLUG_RE = /^[a-z0-9](?:[a-z0-9-]{0,198}[a-z0-9])?$/;
 const VAULT_ITEM_SEGMENT_RE = /^[A-Za-z0-9_.-]+$/;
+const BROAD_VAULT_SLUGS = new Set([
+	"dev",
+	"development",
+	"prod",
+	"production",
+	"stage",
+	"staging",
+	"test",
+	"testing",
+]);
 
 function requireAuth() {
 	if (!isLoggedIn()) {
@@ -83,6 +94,8 @@ interface VaultSetOptions {
 	project?: string;
 	value?: string;
 	stdin?: boolean;
+	prompt?: boolean;
+	allowEmpty?: boolean;
 }
 
 export async function vaultSet(key: string, opts: VaultSetOptions = {}) {
@@ -90,6 +103,7 @@ export async function vaultSet(key: string, opts: VaultSetOptions = {}) {
 
 	const { vaultSlug, section, field } = parseVaultKey(key);
 	const normalizedKey = formatVaultKey(vaultSlug, section, field);
+	warnIfBroadVaultSlug(vaultSlug);
 
 	const value = await readVaultSetValue(key, opts);
 	if (value === null) {
@@ -165,6 +179,7 @@ export async function vaultList(opts: { json?: boolean; project?: string } = {})
 			const projectIds = vaultProjectIds(v);
 			const attachedProjectId = projectId ?? projectIds[0];
 			const items = await fetchItems(v.slug, attachedProjectId);
+			if (!hasVaultItems(items)) continue;
 			out.push({
 				slug: v.slug,
 				project_id: attachedProjectId ?? null,
@@ -185,12 +200,6 @@ export async function vaultList(opts: { json?: boolean; project?: string } = {})
 		return;
 	}
 
-	const projects = await listProjects(api.baseUrl, api.apiKey).catch(() => []);
-	const projectLabel = (projectId: string | undefined) => {
-		if (!projectId) return "unattached";
-		const project = projects.find((item) => item.id === projectId);
-		return project ? `${formatProjectLabel(project)} (${projectId})` : projectId;
-	};
 	const groups = new Map<
 		string,
 		{
@@ -201,11 +210,23 @@ export async function vaultList(opts: { json?: boolean; project?: string } = {})
 	for (const v of vaults) {
 		const attachedProjectId = projectId ?? vaultProjectIds(v)[0];
 		const items = await fetchItems(v.slug, attachedProjectId);
+		if (!hasVaultItems(items)) continue;
 		const key = attachedProjectId ?? "(unattached)";
 		const group = groups.get(key) ?? { projectId: attachedProjectId, rows: [] };
 		group.rows.push({ vault: v, items });
 		groups.set(key, group);
 	}
+	if (groups.size === 0) {
+		console.log(chalk.gray("No vaults."));
+		return;
+	}
+
+	const projects = await listProjects(api.baseUrl, api.apiKey).catch(() => []);
+	const projectLabel = (projectId: string | undefined) => {
+		if (!projectId) return "unattached";
+		const project = projects.find((item) => item.id === projectId);
+		return project ? `${formatProjectLabel(project)} (${projectId})` : projectId;
+	};
 
 	for (const group of groups.values()) {
 		console.log(chalk.white(`Project ${projectLabel(group.projectId)}`));
@@ -258,6 +279,7 @@ export async function vaultImport(file: string, opts: VaultImportOptions = {}) {
 
 	const vaultSlug = cleanVaultSlug(opts.vault ?? "default");
 	const section = cleanVaultSection(opts.section ?? "");
+	warnIfBroadVaultSlug(vaultSlug);
 	const content = readFileSync(file, "utf-8");
 	const fields: Record<string, string> = {};
 	const parsed = parseDotenvDetailed(content);
@@ -364,22 +386,52 @@ export async function vaultRm(key: string, opts: VaultRmOptions = {}) {
 }
 
 async function readVaultSetValue(key: string, opts: VaultSetOptions): Promise<string | null> {
-	if (opts.value !== undefined && opts.stdin) {
-		throw new Error("Pass either --value or --stdin, not both.");
+	const selectedSources = [
+		opts.value !== undefined,
+		Boolean(opts.stdin),
+		Boolean(opts.prompt),
+	].filter(Boolean).length;
+	if (selectedSources > 1) {
+		throw new Error("Pass only one of --value, --stdin, or --prompt.");
 	}
-	if (opts.value !== undefined) return opts.value;
+	if (opts.value !== undefined) {
+		assertNonEmptyVaultValue(opts.value, "--value", opts);
+		return opts.value;
+	}
 	if (opts.stdin) {
 		if (process.stdin.isTTY) {
 			throw new Error("Refusing to read --stdin from an interactive TTY.");
 		}
-		return stripFinalNewline(await readStdin());
+		const value = stripFinalNewline(await readStdin());
+		assertNonEmptyVaultValue(value, "--stdin", opts);
+		return value;
+	}
+	if ((opts.prompt || selectedSources === 0) && !isInteractive()) {
+		throw new Error(
+			"Cannot prompt for a vault value in a non-interactive shell. Use --stdin with piped input.",
+		);
 	}
 	const value = await p.password({ message: `Value for ${key}:` });
-	if (p.isCancel(value) || !value) {
+	if (p.isCancel(value)) {
+		p.cancel("Cancelled.");
+		return null;
+	}
+	if (!value && !opts.allowEmpty) {
 		p.cancel("Cancelled.");
 		return null;
 	}
 	return value;
+}
+
+function assertNonEmptyVaultValue(
+	value: string,
+	source: "--value" | "--stdin",
+	opts: VaultSetOptions,
+) {
+	if (value.length > 0 || opts.allowEmpty) return;
+	throw new Error(
+		`Refusing to store an empty secret from ${source}. Pass --allow-empty to store an empty value intentionally.`,
+	);
 }
 
 async function readStdin(): Promise<string> {
@@ -410,6 +462,19 @@ async function readStdin(): Promise<string> {
 
 function stripFinalNewline(value: string): string {
 	return value.replace(/\r?\n$/, "");
+}
+
+function hasVaultItems(items: Record<string, string[]>): boolean {
+	return Object.values(items).some((fields) => fields.length > 0);
+}
+
+function warnIfBroadVaultSlug(vaultSlug: string) {
+	if (!BROAD_VAULT_SLUGS.has(vaultSlug)) return;
+	console.log(
+		chalk.yellow(
+			`Hint: consider using a service-specific vault slug instead of "${sanitizeMetadata(vaultSlug)}" for shared project secrets.`,
+		),
+	);
 }
 
 function cleanVaultSlug(value: string): string {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -286,11 +286,13 @@ vaultCmd
 		"-p, --project <id-or-slug>",
 		"Target a specific project (default: your default-write project)",
 	)
-	.option("--value <value>", "Secret value; use --stdin to avoid shell history")
+	.option("--value <value>", "Secret value; use --prompt or --stdin to avoid shell history")
 	.option("--stdin", "Read the secret value from stdin")
+	.option("--prompt", "Prompt for the secret value without echoing input")
+	.option("--allow-empty", "Allow storing an empty secret value intentionally")
 	.addHelpText(
 		"after",
-		"\nExamples:\n  $ clawdi vault set OPENAI_API_KEY\n  $ clawdi vault set DEPLOY_KEY --project engineering\n  $ printf 'secret' | clawdi vault set prod/api/DEPLOY_KEY --stdin",
+		"\nExamples:\n  $ clawdi vault set OPENAI_API_KEY --prompt\n  $ clawdi vault set DEPLOY_KEY --project engineering --prompt\n  $ printf 'secret' | clawdi vault set api-service/env/DEPLOY_KEY --stdin",
 	)
 	.action(async (key, opts) => {
 		const { vaultSet } = await import("./commands/vault.js");
@@ -299,6 +301,8 @@ vaultCmd
 			project: opts.project,
 			value: opts.value,
 			stdin: opts.stdin,
+			prompt: opts.prompt,
+			allowEmpty: opts.allowEmpty,
 		});
 	});
 

--- a/packages/cli/tests/commands/vault.test.ts
+++ b/packages/cli/tests/commands/vault.test.ts
@@ -70,6 +70,48 @@ describe("vaultList", () => {
 		]);
 	});
 
+	it("hides empty vaults in JSON output", async () => {
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/api/vault/default/items",
+				response: () => jsonResponse({ "(default)": ["OPENAI_API_KEY"] }),
+			},
+			{
+				method: "GET",
+				path: "/api/vault/prod/items",
+				response: () => jsonResponse({}),
+			},
+			{
+				method: "GET",
+				path: "/api/vault",
+				response: () =>
+					jsonResponse({
+						items: [
+							{ id: "vault-1", slug: "default", name: "Default", project_id: PROJECT_ID },
+							{ id: "vault-2", slug: "prod", name: "prod", project_id: PROJECT_ID },
+						],
+						total: 2,
+					}),
+			},
+		]);
+		const origLog = console.log;
+		let out = "";
+		console.log = (...args: unknown[]) => {
+			out = args.map(String).join(" ");
+		};
+
+		try {
+			await vaultList({ json: true });
+		} finally {
+			console.log = origLog;
+			restore();
+		}
+
+		const rows = JSON.parse(out) as Array<{ slug: string }>;
+		expect(rows.map((row) => row.slug)).toEqual(["default"]);
+	});
+
 	it("prints copyable exact references in human output", async () => {
 		const { restore } = mockVaultListFetch();
 		const ttyDesc = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
@@ -143,6 +185,44 @@ describe("vaultList", () => {
 		expect(out.match(/Project personal/g)?.length).toBe(1);
 		expect(out).toContain("Vault default");
 		expect(out).toContain("Vault prod");
+	});
+
+	it("hides empty vaults in human output", async () => {
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/api/vault/prod/items",
+				response: () => jsonResponse({}),
+			},
+			{
+				method: "GET",
+				path: "/api/vault",
+				response: () =>
+					jsonResponse({
+						items: [{ id: "vault-1", slug: "prod", name: "prod", project_id: PROJECT_ID }],
+						total: 1,
+					}),
+			},
+		]);
+		const ttyDesc = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+		const origLog = console.log;
+		let out = "";
+		console.log = (...args: unknown[]) => {
+			out += `${args.map(String).join(" ")}\n`;
+		};
+
+		try {
+			await vaultList({});
+		} finally {
+			console.log = origLog;
+			if (ttyDesc) Object.defineProperty(process.stdout, "isTTY", ttyDesc);
+			else Object.defineProperty(process.stdout, "isTTY", { value: undefined, configurable: true });
+			restore();
+		}
+
+		expect(out).toContain("No vaults.");
+		expect(out).not.toContain("Vault prod");
 	});
 });
 
@@ -438,6 +518,76 @@ describe("vaultSet", () => {
 		});
 	});
 
+	it("rejects empty --stdin before writing", async () => {
+		const { captured, restore } = mockFetch([]);
+		const stdinTtyDesc = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+		Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+
+		try {
+			const run = vaultSet("SECRET_KEY", { stdin: true });
+			queueMicrotask(() => {
+				process.stdin.emit("end");
+			});
+			await expect(run).rejects.toThrow(
+				"Refusing to store an empty secret from --stdin. Pass --allow-empty to store an empty value intentionally.",
+			);
+		} finally {
+			if (stdinTtyDesc) Object.defineProperty(process.stdin, "isTTY", stdinTtyDesc);
+			else Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+			restore();
+		}
+
+		expect(captured).toHaveLength(0);
+	});
+
+	it("allows empty --stdin only when explicitly requested", async () => {
+		const { captured, restore } = mockFetch([
+			...mockDefaultProjectResolution(),
+			{
+				method: "POST",
+				path: "/api/vault",
+				response: () => jsonResponse({ detail: "already exists" }, 409),
+			},
+			{
+				method: "GET",
+				path: "/api/vault",
+				response: () =>
+					jsonResponse({
+						items: [{ id: "vault-1", slug: "default", name: "Default", project_id: PROJECT_ID }],
+						total: 1,
+					}),
+			},
+			{
+				method: "PUT",
+				path: "/api/vault/default/items",
+				response: () => jsonResponse({ status: "ok", fields: 1 }),
+			},
+		]);
+		const stdinTtyDesc = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+		Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+		const origLog = console.log;
+		console.log = () => {};
+
+		try {
+			const run = vaultSet("SECRET_KEY", { stdin: true, allowEmpty: true });
+			queueMicrotask(() => {
+				process.stdin.emit("end");
+			});
+			await run;
+		} finally {
+			console.log = origLog;
+			if (stdinTtyDesc) Object.defineProperty(process.stdin, "isTTY", stdinTtyDesc);
+			else Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+			restore();
+		}
+
+		const put = captured.find((request) => request.method === "PUT");
+		expect(put?.body).toEqual({
+			section: "",
+			fields: { SECRET_KEY: "" },
+		});
+	});
+
 	it("rejects --stdin from an interactive TTY before writing", async () => {
 		const { captured, restore } = mockFetch([]);
 		const stdinTtyDesc = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
@@ -450,6 +600,28 @@ describe("vaultSet", () => {
 		} finally {
 			if (stdinTtyDesc) Object.defineProperty(process.stdin, "isTTY", stdinTtyDesc);
 			else Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+			restore();
+		}
+
+		expect(captured).toHaveLength(0);
+	});
+
+	it("rejects --prompt outside an interactive TTY before writing", async () => {
+		const { captured, restore } = mockFetch([]);
+		const stdinTtyDesc = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+		const stdoutTtyDesc = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+		Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+		Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+
+		try {
+			await expect(vaultSet("SECRET_KEY", { prompt: true })).rejects.toThrow(
+				"Cannot prompt for a vault value in a non-interactive shell. Use --stdin with piped input.",
+			);
+		} finally {
+			if (stdinTtyDesc) Object.defineProperty(process.stdin, "isTTY", stdinTtyDesc);
+			else Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+			if (stdoutTtyDesc) Object.defineProperty(process.stdout, "isTTY", stdoutTtyDesc);
+			else Object.defineProperty(process.stdout, "isTTY", { value: undefined, configurable: true });
 			restore();
 		}
 
@@ -508,13 +680,58 @@ describe("vaultSet", () => {
 
 		try {
 			await expect(vaultSet("SECRET_KEY", { value: "sk-live", stdin: true })).rejects.toThrow(
-				"Pass either --value or --stdin, not both.",
+				"Pass only one of --value, --stdin, or --prompt.",
+			);
+			await expect(vaultSet("SECRET_KEY", { value: "sk-live", prompt: true })).rejects.toThrow(
+				"Pass only one of --value, --stdin, or --prompt.",
 			);
 		} finally {
 			restore();
 		}
 
 		expect(captured).toHaveLength(0);
+	});
+
+	it("prints a non-blocking hint for broad vault slugs", async () => {
+		const { restore } = mockFetch([
+			...mockDefaultProjectResolution(),
+			{
+				method: "POST",
+				path: "/api/vault",
+				response: () => jsonResponse({ detail: "already exists" }, 409),
+			},
+			{
+				method: "GET",
+				path: "/api/vault",
+				response: () =>
+					jsonResponse({
+						items: [{ id: "vault-1", slug: "prod", name: "prod", project_id: PROJECT_ID }],
+						total: 1,
+					}),
+			},
+			{
+				method: "PUT",
+				path: "/api/vault/prod/items",
+				response: () => jsonResponse({ status: "ok", fields: 1 }),
+			},
+		]);
+		const origLog = console.log;
+		let out = "";
+		console.log = (...args: unknown[]) => {
+			out += `${args.map(String).join(" ")}\n`;
+		};
+
+		try {
+			await vaultSet("prod/stripe/SECRET_KEY", { value: "sk-live" });
+		} finally {
+			console.log = origLog;
+			restore();
+		}
+
+		expect(out).toContain(
+			'Hint: consider using a service-specific vault slug instead of "prod" for shared project secrets.',
+		);
+		expect(out).toContain("Stored prod/stripe/SECRET_KEY");
 	});
 });
 


### PR DESCRIPTION
## Summary
- reject empty vault set --stdin/--value unless --allow-empty is explicit
- add vault set --prompt for no-echo manual secret entry
- hide empty vaults from vault list output
- add broad vault slug hints and update agent/docs examples

Fixes #116

## Verification
- bun test packages/cli/tests/commands/vault.test.ts
- bun run typecheck (packages/cli)
- bun run check
- git diff --check