### PR TITLE
Fix CLI 0.8.6 npm package install

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -87,6 +87,24 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         run: bun test
 
+      - name: Validate npm tarball install
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          node scripts/check-publish-manifest.mjs
+          TMP=$(mktemp -d)
+          PACK_DIR=$(mktemp -d)
+          cleanup() {
+            rm -rf "$TMP"
+            rm -rf "$PACK_DIR"
+          }
+          trap cleanup EXIT
+          PACK_JSON=$(npm pack --json --ignore-scripts --pack-destination "$PACK_DIR")
+          TARBALL=$(node -e "const fs=require('node:fs'); const data=JSON.parse(fs.readFileSync(0,'utf8')); console.log(data[0].filename)" <<< "$PACK_JSON")
+          TARBALL_PATH="$PACK_DIR/$TARBALL"
+          cd "$TMP"
+          npm init -y >/dev/null
+          npm install "$TARBALL_PATH" --ignore-scripts --no-audit --no-fund
+
       # `prepublishOnly` would re-run the build. We pass `--ignore-scripts`
       # because the step above already built everything; rerunning wastes
       # ~10s of CI time and risks a silent re-bundle with stale env.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.8.6
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.8.6
+
+Package: `clawdi@0.8.6`
+
+### Fixed
+
+- Fixed the npm package metadata for `clawdi@0.8.5`, which accidentally used
+  Bun workspace catalog syntax for the `zod` runtime dependency and caused
+  plain `npm install clawdi@0.8.5` installs to fail.
+
 ## Clawdi CLI v0.8.5
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.8.5

--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.8.5",
+      "version": "0.8.6",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },
@@ -65,7 +65,7 @@
         "commander": "^13.0.0",
         "openapi-fetch": "^0.17.0",
         "tar": "^7.5.13",
-        "zod": "catalog:",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@clawdi/shared": "workspace:*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.8.5",
+	"version": "0.8.6",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",
@@ -24,6 +24,7 @@
 		"dev": "bun run src/index.ts",
 		"build": "rm -rf dist && bun build src/index.ts --outdir dist --target node --minify --define 'process.env.CLAWDI_DEFAULT_API_URL=\"https://cloud-api.clawdi.ai\"' && cp -r skills dist/skills",
 		"build:dev": "rm -rf dist && bun build src/index.ts --outdir dist --target node && cp -r skills dist/skills",
+		"check:publish-manifest": "node scripts/check-publish-manifest.mjs",
 		"typecheck": "tsc --noEmit",
 		"test": "bun test",
 		"test:e2e": "bun test tests/e2e",
@@ -58,7 +59,7 @@
 		"commander": "^13.0.0",
 		"openapi-fetch": "^0.17.0",
 		"tar": "^7.5.13",
-		"zod": "catalog:"
+		"zod": "^4.3.6"
 	},
 	"devDependencies": {
 		"@clawdi/shared": "workspace:*",

--- a/packages/cli/scripts/check-publish-manifest.mjs
+++ b/packages/cli/scripts/check-publish-manifest.mjs
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+
+const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+const forbiddenProtocols = /^(catalog|workspace):/;
+const dependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"];
+
+const problems = [];
+for (const field of dependencyFields) {
+	const dependencies = packageJson[field];
+	if (!dependencies || typeof dependencies !== "object") continue;
+	for (const [name, specifier] of Object.entries(dependencies)) {
+		if (typeof specifier === "string" && forbiddenProtocols.test(specifier)) {
+			problems.push(`${field}.${name} uses ${specifier}`);
+		}
+	}
+}
+
+if (problems.length > 0) {
+	console.error("The published CLI package cannot contain monorepo-only dependency protocols:");
+	for (const problem of problems) {
+		console.error(`- ${problem}`);
+	}
+	console.error("Use a real npm semver/range in packages/cli/package.json before publishing.");
+	process.exit(1);
+}


### PR DESCRIPTION
## Summary
- bump the CLI package to `0.8.6` and restore the published runtime `zod` dependency to a real npm semver range
- add a publish-manifest guard so runtime dependency fields cannot contain `catalog:` or `workspace:` protocols
- make the CLI publish workflow install the packed tarball before `npm publish`, catching plain npm install failures before release

## Root cause
`clawdi@0.8.5` was published with `dependencies.zod = "catalog:"`. Bun can resolve that inside the monorepo, but plain npm users and agent images cannot.

## Verification
- `npm install clawdi@0.8.5` reproduces `EUNSUPPORTEDPROTOCOL Unsupported URL Type "catalog:"`
- `bun run check`
- `bun run --cwd packages/cli typecheck`
- `bun run --cwd packages/cli test`
- `bun run --cwd packages/cli build`
- `bun run --cwd packages/cli check:publish-manifest`
- packed `clawdi-0.8.6.tgz`, installed it with plain `npm install`, and confirmed `npx clawdi --version` prints `0.8.6`

## Release impact
CLI/npm release required: `clawdi@0.8.6` / `clawdi-cli-v0.8.6`. No backend production deploy is required for this packaging-only hotfix.