### PR TITLE
Fix Composio auth metadata contract

### DIFF
--- a/backend/app/routes/connectors.py
+++ b/backend/app/routes/connectors.py
@@ -18,6 +18,7 @@ from app.schemas.connector import (
     ConnectRequest,
 )
 from app.services.composio import (
+    ConnectorAuthMetadataError,
     connect_with_credentials,
     create_connect_link,
     create_mcp_bridge_token,
@@ -83,6 +84,11 @@ def _map_composio_error(exc: Exception, *, scrub: dict[str, str] | None = None) 
         }:
             return HTTPException(status.HTTP_400_BAD_REQUEST, message)
         return HTTPException(status.HTTP_404_NOT_FOUND, "Connector not found")
+    if isinstance(exc, ConnectorAuthMetadataError):
+        return HTTPException(
+            status.HTTP_502_BAD_GATEWAY,
+            "Connector auth metadata unavailable",
+        )
     if isinstance(exc, ComposioNotFoundError):
         return HTTPException(status.HTTP_404_NOT_FOUND, "Connector not found")
     if isinstance(exc, SDKTimeoutError):
@@ -145,7 +151,10 @@ async def get_available_app(
     Re-uses the cache that `/available` populates."""
     if not settings.composio_api_key:
         raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, "Composio not configured")
-    app = await get_app_by_name(app_name)
+    try:
+        app = await get_app_by_name(app_name)
+    except Exception as exc:
+        raise _map_composio_error(exc) from exc
     if app is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Connector not found")
     return ConnectorAvailableAppResponse.model_validate(app)
@@ -171,7 +180,9 @@ async def connect_app(
         app = await get_app_by_name(app_name)
         if app is None:
             raise HTTPException(status.HTTP_404_NOT_FOUND, "Connector not found")
-        auth_type = str(app.get("auth_type") or "oauth2").strip().lower()
+        auth_type = str(app.get("auth_type") or "").strip().lower()
+        if not auth_type or auth_type == "unknown":
+            raise ConnectorAuthMetadataError(f"Connector auth metadata unavailable for {app_name}")
         if auth_type not in _REDIRECT_AUTH_TYPES:
             raise HTTPException(status.HTTP_400_BAD_REQUEST, "Connector requires credentials")
         result = await create_connect_link(auth.user.clerk_id, app_name, redirect_url)

--- a/backend/app/schemas/connector.py
+++ b/backend/app/schemas/connector.py
@@ -86,10 +86,9 @@ class ConnectorAvailableAppResponse(BaseModel):
     logo: str
     description: str
     # Surfaces Composio's auth scheme so the UI can pick OAuth vs an
-    # API-key form on click. Lowercase strings — `oauth2`, `api_key`,
-    # `bearer_token`, `basic`, `none`. Falls back to "oauth2" when the
-    # SDK doesn't surface one.
-    auth_type: str = "oauth2"
+    # API-key form on click. Lowercase strings: `oauth2`, `api_key`,
+    # `bearer_token`, `basic`, `none`.
+    auth_type: str
 
 
 class ConnectorAuthFieldResponse(BaseModel):

--- a/backend/app/services/composio.py
+++ b/backend/app/services/composio.py
@@ -41,6 +41,10 @@ _ACTIVE_OR_PENDING_STATUSES = {"INITIALIZING", "INITIATED"}
 _TERMINAL_STATUSES = {"ACTIVE", "FAILED", "EXPIRED", "INACTIVE", "REVOKED"}
 
 
+class ConnectorAuthMetadataError(RuntimeError):
+    """Raised when Composio does not return enough metadata to choose an auth flow."""
+
+
 @dataclass(frozen=True)
 class ComposioMcpSession:
     url: str
@@ -595,10 +599,11 @@ def _primary_auth_type(toolkit: Any) -> str:
     for scheme in all_schemes:
         if scheme:
             return scheme
-    return "oauth2"
+    slug = _str_or_none(_value(toolkit, "slug", "key", "name")) or "unknown"
+    raise ConnectorAuthMetadataError(f"Connector auth metadata unavailable for {slug}")
 
 
-def _serialize_app(toolkit: Any) -> dict:
+def _serialize_app(toolkit: Any, *, allow_unknown_auth_type: bool = False) -> dict:
     meta = _value(toolkit, "meta", default={})
     key = _str_or_none(_value(toolkit, "slug", "key", "name")) or ""
     display = _str_or_none(_value(toolkit, "name", "display_name", "displayName"))
@@ -606,12 +611,18 @@ def _serialize_app(toolkit: Any) -> dict:
     logo = _str_or_none(_value(meta, "logo")) or _str_or_none(_value(toolkit, "logo")) or ""
     desc = _str_or_none(_value(meta, "description"))
     desc = desc or _str_or_none(_value(toolkit, "description")) or ""
+    try:
+        auth_type = _primary_auth_type(toolkit)
+    except ConnectorAuthMetadataError:
+        if not allow_unknown_auth_type:
+            raise
+        auth_type = "unknown"
     return {
         "name": key,
         "display_name": display,
         "logo": logo,
         "description": desc[:200],
-        "auth_type": _primary_auth_type(toolkit),
+        "auth_type": auth_type,
     }
 
 
@@ -652,7 +663,7 @@ async def _get_all_apps() -> list[dict]:
         if not cursor:
             break
 
-    fresh = [_serialize_app(toolkit) for toolkit in toolkits]
+    fresh = [_serialize_app(toolkit, allow_unknown_auth_type=True) for toolkit in toolkits]
     _apps_cache = fresh
     _apps_cache_at = now
     return fresh
@@ -663,19 +674,9 @@ async def get_app_by_name(name: str) -> dict | None:
     items = await _get_all_apps()
     for app in items:
         if app["name"] == name:
-            detail = await _get_app_detail_by_name(name)
-            if detail is None:
-                return app
-            return {**app, "auth_type": detail["auth_type"]}
+            toolkit = await _get_toolkit_detail(name)
+            return _serialize_app(toolkit)
     return None
-
-
-async def _get_app_detail_by_name(name: str) -> dict | None:
-    try:
-        toolkit = await _get_toolkit_detail(name)
-    except Exception:
-        return None
-    return _serialize_app(toolkit)
 
 
 async def _get_toolkit_detail(name: str) -> Any:

--- a/backend/tests/test_connectors.py
+++ b/backend/tests/test_connectors.py
@@ -4,11 +4,13 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 
 from app.core.auth import AuthContext
 from app.core.config import settings
 from app.models.user import User
 from app.routes import connectors
+from app.schemas.connector import ConnectorAvailableAppResponse
 from app.services import composio
 
 
@@ -194,7 +196,8 @@ class FakeClient:
         detail_toolkits: dict[str, Any] | None = None,
         auth_configs: FakeAuthConfigs | None = None,
     ):
-        detail_toolkits = detail_toolkits or {"posthog": _posthog_detail_toolkit()}
+        if detail_toolkits is None:
+            detail_toolkits = {"posthog": _posthog_detail_toolkit()}
         self.toolkits = FakeToolkits(
             list_toolkits=list_toolkits or [_posthog_list_toolkit()],
             detail_toolkits=detail_toolkits,
@@ -222,6 +225,55 @@ async def test_connector_detail_uses_toolkit_auth_config_details(monkeypatch: py
     assert app is not None
     assert app["name"] == "posthog"
     assert app["auth_type"] == "api_key"
+
+
+@pytest.mark.asyncio
+async def test_catalog_without_auth_metadata_is_unknown_not_oauth2(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake = FakeClient(list_toolkits=[_posthog_list_toolkit()])
+    monkeypatch.setattr(settings, "composio_api_key", "composio_test_key")
+    monkeypatch.setattr(composio, "get_composio_client", lambda: fake)
+
+    page = await composio.get_available_apps(search="posthog")
+
+    assert page["items"][0]["auth_type"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_connector_detail_requires_explicit_toolkit_auth_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake = FakeClient(detail_toolkits={"posthog": _posthog_list_toolkit()})
+    monkeypatch.setattr(settings, "composio_api_key", "composio_test_key")
+    monkeypatch.setattr(composio, "get_composio_client", lambda: fake)
+
+    with pytest.raises(composio.ConnectorAuthMetadataError):
+        await composio.get_app_by_name("posthog")
+
+
+@pytest.mark.asyncio
+async def test_connector_detail_does_not_fallback_to_catalog_when_retrieve_fails(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fake = FakeClient(list_toolkits=[_posthog_list_toolkit()], detail_toolkits={})
+    monkeypatch.setattr(settings, "composio_api_key", "composio_test_key")
+    monkeypatch.setattr(composio, "get_composio_client", lambda: fake)
+
+    with pytest.raises(KeyError):
+        await composio.get_app_by_name("posthog")
+
+
+def test_connector_available_app_response_requires_auth_type():
+    with pytest.raises(ValidationError):
+        ConnectorAvailableAppResponse.model_validate(
+            {
+                "name": "posthog",
+                "display_name": "PostHog",
+                "logo": "",
+                "description": "",
+            }
+        )
 
 
 @pytest.mark.asyncio
@@ -385,3 +437,29 @@ async def test_connect_route_rejects_credentials_connector_before_oauth_link(
 
     assert exc_info.value.status_code == 400
     assert exc_info.value.detail == "Connector requires credentials"
+
+
+@pytest.mark.asyncio
+async def test_connect_route_rejects_missing_auth_type_without_oauth_link(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def fake_get_app_by_name(app_name: str):
+        assert app_name == "posthog"
+        return {"name": "posthog"}
+
+    async def fail_create_connect_link(*args, **kwargs):
+        raise AssertionError("missing auth metadata must not start the OAuth link flow")
+
+    monkeypatch.setattr(settings, "composio_api_key", "composio_test_key")
+    monkeypatch.setattr(connectors, "get_app_by_name", fake_get_app_by_name)
+    monkeypatch.setattr(connectors, "create_connect_link", fail_create_connect_link)
+
+    with pytest.raises(connectors.HTTPException) as exc_info:
+        await connectors.connect_app(
+            "posthog",
+            None,
+            AuthContext(user=User(clerk_id="clerk_user_123")),
+        )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.detail == "Connector auth metadata unavailable"

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -2006,10 +2006,7 @@ export interface components {
             logo: string;
             /** Description */
             description: string;
-            /**
-             * Auth Type
-             * @default oauth2
-             */
+            /** Auth Type */
             auth_type: string;
         };
         /** ConnectorConnectResponse */


### PR DESCRIPTION
## Summary
- stop defaulting missing Composio auth metadata to OAuth2
- require single connector detail routes to use explicit toolkit auth metadata
- keep catalog-only entries honest with unknown auth_type instead of fake OAuth
- add regression coverage for PostHog-style API key connectors and missing metadata

## Verification
- cd backend && uv run pytest tests/test_connectors.py -q
- cd backend && uv run ruff check app tests/test_connectors.py && uv run deptry app
- bun test apps/web/src/components/connectors/credentials-dialog.logic.test.ts
- bun run check
- bun run typecheck
- bun run build
- cd backend && uv lock --check
- git diff --check

Note: full backend pytest currently fails in this local worktree because the test PostgreSQL port 127.0.0.1:33455 is not running; connector-focused tests pass.