### PR TITLE
Enforce connector auth flow metadata

### DIFF
--- a/apps/web/src/app/(dashboard)/connectors/[name]/page.tsx
+++ b/apps/web/src/app/(dashboard)/connectors/[name]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import { parseAsString, useQueryStates } from "nuqs";
 import { Suspense, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { getConnectorAuthFlow } from "@/components/connectors/auth-flow.logic";
 import { ConnectorIcon } from "@/components/connectors/connector-icon";
 import { ConnectorCredentialsDialog } from "@/components/connectors/credentials-dialog";
 import { DashboardSection, DashboardSectionHeader } from "@/components/dashboard/section";
@@ -26,12 +27,6 @@ import {
 	useDisconnect,
 } from "@/lib/connectors-data";
 import { cn, errorMessage } from "@/lib/utils";
-
-// Auth schemes whose connect flow is a redirect (OAuth family) or
-// Composio-hosted link; everything else needs the in-page credentials form
-// unless the toolkit is explicitly no-auth.
-const REDIRECT_AUTH_TYPES = new Set(["oauth", "oauth1", "oauth2", "dcr_oauth", "composio_link"]);
-const NO_AUTH_TYPES = new Set(["none", "no_auth"]);
 
 /** Strip leading underscores/dashes and title-case for fallback display. */
 function formatName(raw: string): string {
@@ -149,28 +144,16 @@ function ConnectorDetail() {
 
 	const displayName = app?.display_name || formatName(name);
 
-	// Connectors split into redirect flows (OAuth family) and credentials
-	// flows (form-based: API_KEY, BEARER_TOKEN, BASIC, …). Composio
-	// surfaces several scheme strings that all belong to the redirect
-	// path — `oauth`, `oauth1`, `oauth2`, `composio_link` — plus
-	// `none` for instant-connect apps. Anything outside that set goes
-	// to the dialog so newer credential-style schemes default safely
-	// without code changes here.
-	//
-	// `app.auth_type` may be missing during a frontend-deployed-before-
-	// backend window (older backend without the new field). Treat
-	// undefined as "oauth2" — the safe redirect path — so the OAuth
-	// popup is the worst-case experience instead of a credentials
-	// dialog hitting an endpoint that doesn't exist yet.
+	// Connectors split only on explicit Composio auth schemes:
+	// OAuth-family schemes open a Connect Link, credential schemes open
+	// the credentials form, and no-auth toolkits are ready immediately.
+	// Missing or unknown metadata is a backend contract error; do not
+	// guess a connection flow.
 	const [credsOpen, setCredsOpen] = useState(false);
-	// `||` (not `??`): Composio occasionally returns empty string for
-	// `auth_type` and an older backend may omit the field entirely; both
-	// cases must fall through to the OAuth path. `??` would let `""`
-	// pass and route the user into a credentials dialog calling
-	// `/auth-fields` on a backend that lacks the endpoint.
-	const authType = app?.auth_type || "oauth2";
-	const usesNoAuth = !!app && NO_AUTH_TYPES.has(authType);
-	const usesCredentialsForm = !!app && !usesNoAuth && !REDIRECT_AUTH_TYPES.has(authType);
+	const authFlow = app ? getConnectorAuthFlow(app.auth_type) : null;
+	const hasUnsupportedAuthType = !!app && authFlow === null;
+	const usesNoAuth = authFlow === "no_auth";
+	const usesCredentialsForm = authFlow === "credentials";
 	// Synchronous single-flight guard for the connect flow. Mirrors the
 	// disconnect ref above: `connectMutation.isPending` only flips after
 	// TanStack Query notifies subscribers (next microtask + render), so a
@@ -180,6 +163,12 @@ function ConnectorDetail() {
 	const inflightConnectRef = useRef(false);
 	const startConnect = () => {
 		if (inflightConnectRef.current) return;
+		if (hasUnsupportedAuthType) {
+			toast.error("Connector Metadata Error", {
+				description: `${displayName} did not return a supported auth type.`,
+			});
+			return;
+		}
 		if (usesNoAuth) {
 			toast.info(`${displayName} does not require setup`);
 			return;
@@ -238,6 +227,7 @@ function ConnectorDetail() {
 		);
 	};
 	const isStarting = connectMutation.isPending;
+	const isConnectDisabled = isStarting || hasUnsupportedAuthType;
 	const isReady = isConnected || usesNoAuth;
 
 	if (isLoading) {
@@ -297,7 +287,12 @@ function ConnectorDetail() {
 					}
 					toolbar={
 						!usesNoAuth && activeConnections.length > 0 ? (
-							<Button variant="outline" size="sm" onClick={startConnect} disabled={isStarting}>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={startConnect}
+								disabled={isConnectDisabled}
+							>
 								{isStarting ? <Spinner className="size-3.5" /> : <Plug className="size-3.5" />}
 								Connect Account
 							</Button>
@@ -321,13 +316,21 @@ function ConnectorDetail() {
 							bordered
 							description="No account connection is required."
 						/>
+					) : hasUnsupportedAuthType ? (
+						<Alert variant="destructive">
+							<AlertCircle />
+							<AlertTitle>Connector Metadata Error</AlertTitle>
+							<AlertDescription>
+								This connector did not return a supported auth type. Refresh the page and try again.
+							</AlertDescription>
+						</Alert>
 					) : activeConnections.length === 0 ? (
 						<EmptyState
 							fillHeight={false}
 							bordered
 							description="No connected accounts yet."
 							action={
-								<Button onClick={startConnect} disabled={isStarting}>
+								<Button onClick={startConnect} disabled={isConnectDisabled}>
 									{isStarting ? <Spinner className="size-3.5" /> : <Plug className="size-3.5" />}
 									{isStarting ? "Connecting…" : "Connect Account"}
 								</Button>

--- a/apps/web/src/components/connectors/auth-flow.logic.test.ts
+++ b/apps/web/src/components/connectors/auth-flow.logic.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { getConnectorAuthFlow } from "./auth-flow.logic";
+
+describe("connector auth flow classification", () => {
+	test.each([
+		"oauth",
+		"oauth1",
+		"oauth2",
+		"OAUTH2",
+		"dcr_oauth",
+		"composio_link",
+	])("routes %s through the redirect flow", (authType) => {
+		expect(getConnectorAuthFlow(authType)).toBe("redirect");
+	});
+
+	test.each([
+		"api_key",
+		"API_KEY",
+		"bearer_token",
+		"BEARER_TOKEN",
+		"basic",
+		"BASIC",
+	])("routes %s through the credentials flow", (authType) => {
+		expect(getConnectorAuthFlow(authType)).toBe("credentials");
+	});
+
+	test.each(["none", "no_auth", "NO_AUTH"])("routes %s through the no-auth flow", (authType) => {
+		expect(getConnectorAuthFlow(authType)).toBe("no_auth");
+	});
+
+	test.each([
+		undefined,
+		null,
+		"",
+		"   ",
+		"unknown",
+		"session_token",
+	])("rejects unsupported auth_type value %p instead of guessing", (authType) => {
+		expect(getConnectorAuthFlow(authType)).toBeNull();
+	});
+});

--- a/apps/web/src/components/connectors/auth-flow.logic.ts
+++ b/apps/web/src/components/connectors/auth-flow.logic.ts
@@ -1,0 +1,15 @@
+const REDIRECT_AUTH_TYPES = new Set(["oauth", "oauth1", "oauth2", "dcr_oauth", "composio_link"]);
+const CREDENTIAL_AUTH_TYPES = new Set(["api_key", "bearer_token", "basic"]);
+const NO_AUTH_TYPES = new Set(["none", "no_auth"]);
+
+export type ConnectorAuthFlow = "credentials" | "no_auth" | "redirect";
+
+export function getConnectorAuthFlow(
+	authType: string | null | undefined,
+): ConnectorAuthFlow | null {
+	const normalized = (authType ?? "").trim().toLowerCase();
+	if (NO_AUTH_TYPES.has(normalized)) return "no_auth";
+	if (REDIRECT_AUTH_TYPES.has(normalized)) return "redirect";
+	if (CREDENTIAL_AUTH_TYPES.has(normalized)) return "credentials";
+	return null;
+}

--- a/backend/tests/test_connectors.py
+++ b/backend/tests/test_connectors.py
@@ -404,10 +404,10 @@ async def test_credentials_connect_uses_custom_auth_config_and_connected_account
         "auth_config": {"id": "ac_1"},
         "connection": {
             "user_id": "clerk_user_123",
-                "state": {
-                    "auth_scheme": "API_KEY",
-                    "val": {"generic_api_key": "phx_123"},
-                },
+            "state": {
+                "auth_scheme": "API_KEY",
+                "val": {"generic_api_key": "phx_123"},
+            },
         },
         "validate_credentials": True,
     }
@@ -449,6 +449,32 @@ async def test_connect_route_rejects_missing_auth_type_without_oauth_link(
 
     async def fail_create_connect_link(*args, **kwargs):
         raise AssertionError("missing auth metadata must not start the OAuth link flow")
+
+    monkeypatch.setattr(settings, "composio_api_key", "composio_test_key")
+    monkeypatch.setattr(connectors, "get_app_by_name", fake_get_app_by_name)
+    monkeypatch.setattr(connectors, "create_connect_link", fail_create_connect_link)
+
+    with pytest.raises(connectors.HTTPException) as exc_info:
+        await connectors.connect_app(
+            "posthog",
+            None,
+            AuthContext(user=User(clerk_id="clerk_user_123")),
+        )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.detail == "Connector auth metadata unavailable"
+
+
+@pytest.mark.asyncio
+async def test_connect_route_rejects_unknown_auth_type_without_oauth_link(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def fake_get_app_by_name(app_name: str):
+        assert app_name == "posthog"
+        return {"name": "posthog", "auth_type": "unknown"}
+
+    async def fail_create_connect_link(*args, **kwargs):
+        raise AssertionError("unknown auth metadata must not start the OAuth link flow")
 
     monkeypatch.setattr(settings, "composio_api_key", "composio_test_key")
     monkeypatch.setattr(connectors, "get_app_by_name", fake_get_app_by_name)

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -126,6 +126,54 @@ run these checks before traffic is considered healthy:
 4. Check logs for migration errors, 5xx spikes, auth failures, and frontend
    build/runtime errors.
 
+### Hosted Cloud API Deployment
+
+`cloud-api.clawdi.ai` is served from `/opt/clawdi-cloud` through the
+`clawdi-cloud-backend` Supervisor group on port `8070`. Do not use the
+`clawdi-backend` group for this service; that group serves the separate
+`api.clawdi.ai` deployment on ports `8060/8061`.
+
+Deploy the hosted cloud API backend with:
+
+```bash
+ssh clawdi 'cd /opt/clawdi-cloud \
+  && git pull --ff-only origin main \
+  && cd backend \
+  && uv sync --frozen \
+  && sudo -n supervisorctl restart "clawdi-cloud-backend:*" \
+  && sudo -n supervisorctl status "clawdi-cloud-backend:*"'
+```
+
+After a connector change, run a real public API smoke against
+`https://cloud-api.clawdi.ai` with a user-level Clawdi API key injected from
+your password manager or current shell. Do not commit or print the key.
+
+```bash
+curl -sS -H "Authorization: Bearer $CLAWDI_API_KEY" \
+  https://cloud-api.clawdi.ai/api/connectors/available/posthog | jq '{name, auth_type}'
+# expect: {"name":"posthog","auth_type":"api_key"}
+
+curl -sS -H "Authorization: Bearer $CLAWDI_API_KEY" \
+  https://cloud-api.clawdi.ai/api/connectors/posthog/auth-fields \
+  | jq '{auth_scheme, fields:[.expected_input_fields[].name]}'
+# expect: {"auth_scheme":"API_KEY","fields":["generic_api_key"]}
+
+curl -sS -o /tmp/posthog-connect.json -w '%{http_code}\n' \
+  -H "Authorization: Bearer $CLAWDI_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{}' \
+  https://cloud-api.clawdi.ai/api/connectors/posthog/connect
+# expect: 400 and {"detail":"Connector requires credentials"}
+
+curl -sS -H "Authorization: Bearer $CLAWDI_API_KEY" \
+  https://cloud-api.clawdi.ai/api/connectors/available/gmail | jq '{name, auth_type}'
+# expect: {"name":"gmail","auth_type":"oauth2"}
+
+curl -sS -H "Authorization: Bearer $CLAWDI_API_KEY" \
+  https://cloud-api.clawdi.ai/api/connectors/available/hackernews | jq '{name, auth_type}'
+# expect: {"name":"hackernews","auth_type":"no_auth"}
+```
+
 ## Rollback
 
 1. Prefer rolling back app/backend/web code to the previous deployment before


### PR DESCRIPTION
## Summary
- stop the connector detail page from guessing OAuth when `auth_type` is missing or unsupported
- route only explicit Composio auth schemes: OAuth-family -> Connect Link, API key/bearer/basic -> credentials dialog, no-auth -> ready state
- add backend regression coverage for `unknown` auth metadata not starting OAuth

## Root Cause
The connector flow had a contract gap: missing or unsupported Composio auth metadata could be treated as OAuth instead of failing closed. That allowed an API-key connector to start the redirect flow when the backend/UI did not agree on auth metadata.

## Verification
- `cd backend && uv run pytest tests/test_connectors.py -q`
- `cd backend && uv run ruff format --check app tests/test_connectors.py && uv run ruff check app tests/test_connectors.py`
- `bun test apps/web/src/components/connectors/auth-flow.logic.test.ts apps/web/src/components/connectors/credentials-dialog.logic.test.ts`
- `bun run check`
- `bun run typecheck`
- `bun run build`

## Notes
- No DB migration.
- The separate clawdi monorepo has an independent Composio implementation and should be handled in a separate PR if we decide to harden it too.