### PR TITLE
feat!: harden vault project deletion semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.9.0
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.9.0
+
+Package: `clawdi@0.9.0`
+
+### Added
+
+- Added `clawdi vault attach` and `clawdi vault detach` / `unlink` so users can
+  add or remove one Project's access to an existing Vault without copying or
+  deleting the underlying keys.
+
+### Changed
+
+- Deleting a key from a Vault attached to multiple Projects now requires
+  explicit global confirmation. The CLI refuses `clawdi vault rm` unless
+  `--global` is passed, and the API requires `global_delete=true`. Scripts
+  that intentionally delete keys from shared Vaults must add the new explicit
+  confirmation.
+- `clawdi vault rm` now fails clearly in non-interactive shells when `--yes` is
+  missing instead of waiting on a prompt that cannot be answered.
+
+### Security
+
+- Memory creation now rejects likely plaintext API keys, bearer tokens, and
+  similar secrets in the CLI, MCP server, dashboard, and backend, and points
+  users to Vault references instead. Automations that stored plaintext secrets
+  in memory should store the secret in Vault and save only a `clawdi://`
+  reference in memory.
+
 ## Clawdi CLI v0.8.6
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.8.6

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ clawdi inject --dry-run --in .env.clawdi --out .env.local
 clawdi inject --force --in .env.clawdi --out .env.local
 ```
 
-`clawdi vault set`, `clawdi vault import`, `clawdi vault rm`, and `clawdi vault list` print the concrete Project target or exact references that include the Project ID. `vault set` supports `--value` and `--stdin` for scripts; `vault import` supports `--vault`, `--section`, `--project`, and warns about skipped invalid dotenv identifiers. Project-relative references such as `clawdi://default/OPENAI_API_KEY` still work for portable templates, but exact references are the default copy/read UX.
+Vaults are account-level key bundles. Projects attach to a Vault to use the same shared key set. `clawdi vault set`, `clawdi vault import`, `clawdi vault rm`, and `clawdi vault list` print the concrete Project target or exact references that include the Project ID. `vault set` supports `--value` and `--stdin` for scripts; `vault import` supports `--vault`, `--section`, `--project`, and warns about skipped invalid dotenv identifiers. Use `clawdi vault attach <vault> --project <project>` to make an existing Vault available in another Project, and `clawdi vault detach <vault> --project <project>` to remove one Project's access without deleting keys. `vault rm` deletes a key from the shared Vault; when a Vault is attached to multiple Projects, it requires `--global`. Project-relative references such as `clawdi://default/OPENAI_API_KEY` still work for portable templates, but exact references are the default copy/read UX.
 
 Agents should prefer `clawdi run --env-file .env.clawdi -- <command>` when they can launch the tool themselves. Use `clawdi inject` only for tools that must read a physical `.env.local`; generated files are written owner-only and should stay gitignored.
 
@@ -266,7 +266,7 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](packages/cli
 | `clawdi agent projects list/attach/detach/move` | View the fixed Agent Project and manage attached Projects |
 | `clawdi agent credentials import/materialize` | Sync local CLI credential profiles for Codex, Claude Code, and GitHub CLI; explicit Keychain import requires service/account options |
 | `clawdi project folder link/status/unlink` | Link a local folder to a Project for vault reference selection |
-| `clawdi vault set/list/import/rm` | Manage encrypted secrets and copy exact references |
+| `clawdi vault set/list/import/attach/detach/rm` | Manage encrypted secrets, Project access, and copy exact references |
 | `clawdi read <clawdi://...>` | Explicitly print one vault reference value |
 | `clawdi inject --in <file> --out <file>` | Render `clawdi://` references into templates |
 | `clawdi run --env-file <file> -- <cmd>` | Run a command with explicit vault references resolved |

--- a/apps/web/src/app/(dashboard)/memories/page.tsx
+++ b/apps/web/src/app/(dashboard)/memories/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { findLikelySecret, formatSecretMemoryWarning } from "@clawdi/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertCircle, Brain, Database, Key, Laptop, Plus, Trash2 } from "lucide-react";
 import Link from "next/link";
@@ -394,6 +395,7 @@ function AddMemoryForm() {
 	const [open, setOpen] = useState(false);
 	const [content, setContent] = useState("");
 	const [addCategory, setAddCategory] = useState("fact");
+	const secretFinding = findLikelySecret(content);
 
 	const createMemory = useMutation({
 		mutationFn: async () =>
@@ -440,6 +442,13 @@ function AddMemoryForm() {
 						className="resize-none"
 					/>
 				</div>
+				{secretFinding ? (
+					<Alert variant="destructive">
+						<AlertCircle />
+						<AlertTitle>Use Vault for Secrets</AlertTitle>
+						<AlertDescription>{formatSecretMemoryWarning(secretFinding)}</AlertDescription>
+					</Alert>
+				) : null}
 				<div className="flex items-center justify-between gap-2">
 					<div className="flex items-center gap-2">
 						<Label htmlFor="memory-category" className="text-sm text-muted-foreground">
@@ -470,7 +479,7 @@ function AddMemoryForm() {
 						</Button>
 						<Button
 							onClick={() => content.trim() && createMemory.mutate()}
-							disabled={!content.trim() || createMemory.isPending}
+							disabled={!content.trim() || !!secretFinding || createMemory.isPending}
 						>
 							{createMemory.isPending ? <Spinner /> : <Plus />}
 							Add Memory

--- a/apps/web/src/app/(dashboard)/vault/page.tsx
+++ b/apps/web/src/app/(dashboard)/vault/page.tsx
@@ -1084,7 +1084,13 @@ function VaultKeysPanel({
 		mutationFn: async ({ section, name }: { section: string; name: string }) =>
 			unwrap(
 				await api.DELETE("/api/vault/{slug}/items", {
-					params: { path: { slug: vault.slug }, query: queryParams },
+					params: {
+						path: { slug: vault.slug },
+						query: {
+							...queryParams,
+							global_delete: vault.project_ids.length > 1,
+						},
+					},
 					body: { section, fields: [name] },
 				}),
 			),
@@ -1140,8 +1146,9 @@ function VaultKeysPanel({
 										title={`Delete ${row.original.key}?`}
 										description={
 											<p>
-												This cannot be undone. Apps, workflows, or agent runs using this key will
-												fail until you add it again.
+												This cannot be undone. This key will be removed from the Vault for every
+												Project using it. Apps, workflows, or agent runs using this key will fail
+												until you add it again.
 											</p>
 										}
 										confirmLabel="Delete Key"

--- a/backend/app/routes/memories.py
+++ b/backend/app/routes/memories.py
@@ -23,6 +23,7 @@ from app.schemas.memory import (
 )
 from app.services.embedding import resolve_embedder
 from app.services.memory_provider import BuiltinProvider, get_memory_provider, memory_to_dict
+from app.services.secret_detection import find_likely_secret, secret_memory_warning
 
 
 async def _attach_source_machines(
@@ -324,6 +325,16 @@ async def create_memory(
             status.HTTP_403_FORBIDDEN,
             "Agent API keys cannot create manual memories. "
             "Memories without a source session aren't visible to scoped reads.",
+        )
+    finding = find_likely_secret(body.content)
+    if finding is not None:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "memory_secret_rejected",
+                "message": secret_memory_warning(finding),
+                "secret_type": finding.label,
+            },
         )
     provider = await get_memory_provider(str(auth.user_id), db)
     return MemoryCreatedResponse.model_validate(

--- a/backend/app/routes/vault.py
+++ b/backend/app/routes/vault.py
@@ -268,16 +268,40 @@ async def delete_vault_items(
     slug: str,
     body: VaultItemDelete,
     project_id: UUID | None = Query(default=None),
+    global_delete: bool = Query(
+        default=False,
+        description=(
+            "Allow deleting the account-level item when this Vault is attached to "
+            "multiple Projects."
+        ),
+    ),
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
 ) -> VaultItemsDeleteResponse:
     vault = await _get_vault_write(auth, slug, db, project_id=project_id)
     existing_by_name = await _load_items_by_name(db, vault.id, body.section)
+    items_to_delete = [
+        existing_by_name[field_name] for field_name in body.fields if field_name in existing_by_name
+    ]
 
-    for field_name in body.fields:
-        item = existing_by_name.get(field_name)
-        if item:
-            await db.delete(item)
+    if items_to_delete and not global_delete:
+        project_count = await _vault_project_count(db, vault.id)
+        if project_count > 1:
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                detail={
+                    "code": "vault_item_global_delete_requires_confirmation",
+                    "message": (
+                        "This Vault is attached to multiple Projects. Deleting a key removes the "
+                        "account-level secret for every Project that uses this Vault. Pass "
+                        "global_delete=true after explicit confirmation."
+                    ),
+                    "project_count": project_count,
+                },
+            )
+
+    for item in items_to_delete:
+        await db.delete(item)
 
     await db.commit()
     return VaultItemsDeleteResponse(status="deleted")
@@ -475,6 +499,16 @@ async def _ensure_vault_attached(
     ).scalar_one_or_none()
     if existing is None:
         db.add(VaultProjectAttachment(vault_id=vault_id, project_id=project_id))
+
+
+async def _vault_project_count(db: AsyncSession, vault_id: UUID) -> int:
+    return (
+        await db.execute(
+            select(func.count())
+            .select_from(VaultProjectAttachment)
+            .where(VaultProjectAttachment.vault_id == vault_id)
+        )
+    ).scalar_one()
 
 
 async def _project_precedence(

--- a/backend/app/services/secret_detection.py
+++ b/backend/app/services/secret_detection.py
@@ -1,0 +1,30 @@
+import re
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SecretFinding:
+    label: str
+
+
+SECRET_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("OpenAI-style API key", re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b")),
+    ("GitHub token", re.compile(r"\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b")),
+    ("GitHub fine-grained token", re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b")),
+    ("Slack token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b")),
+    ("Bearer token", re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{20,}\b", re.IGNORECASE)),
+)
+
+
+def find_likely_secret(value: str) -> SecretFinding | None:
+    for label, pattern in SECRET_PATTERNS:
+        if pattern.search(value):
+            return SecretFinding(label=label)
+    return None
+
+
+def secret_memory_warning(finding: SecretFinding) -> str:
+    return (
+        f"Detected a likely {finding.label}. Store secrets with "
+        "`clawdi vault set <KEY> --stdin` and save a clawdi:// reference in memory instead."
+    )

--- a/backend/tests/test_smoke.py
+++ b/backend/tests/test_smoke.py
@@ -64,3 +64,18 @@ async def test_create_and_list_memory(client: httpx.AsyncClient):
     assert any("smoke test memory" in (m.get("content") or m.get("text") or "") for m in items), (
         items
     )
+
+
+@pytest.mark.asyncio
+async def test_create_memory_rejects_likely_secret(client: httpx.AsyncClient):
+    r = await client.post(
+        "/api/memories",
+        json={
+            "content": "OpenAI key is sk-abcdefghijklmnopqrstuvwxyz123456",
+            "category": "fact",
+        },
+    )
+    assert r.status_code == 400, r.text
+    body = r.json()
+    assert body["detail"]["code"] == "memory_secret_rejected"
+    assert "vault set" in body["detail"]["message"]

--- a/backend/tests/test_vault.py
+++ b/backend/tests/test_vault.py
@@ -689,6 +689,58 @@ async def test_vault_attaches_one_vault_to_multiple_projects(client, db_session,
 
 
 @pytest.mark.asyncio
+async def test_vault_item_delete_requires_global_confirmation_for_shared_vault(
+    client, seed_project, workspace_project
+):
+    first = await client.post(
+        f"/api/vault?project_id={seed_project.id}",
+        json={"slug": "github", "name": "GitHub"},
+    )
+    assert first.status_code == 200, first.text
+    second = await client.post(
+        f"/api/vault?project_id={workspace_project.id}",
+        json={"slug": "github", "name": "GitHub"},
+    )
+    assert second.status_code == 200, second.text
+    upsert = await client.put(
+        f"/api/vault/github/items?project_id={workspace_project.id}",
+        json={"section": "", "fields": {"TOKEN": "secret"}},
+    )
+    assert upsert.status_code == 200, upsert.text
+
+    blocked = await client.request(
+        "DELETE",
+        f"/api/vault/github/items?project_id={seed_project.id}",
+        json={"section": "", "fields": ["TOKEN"]},
+    )
+    assert blocked.status_code == 409, blocked.text
+    assert blocked.json()["detail"]["code"] == "vault_item_global_delete_requires_confirmation"
+
+    still_there = await client.get(f"/api/vault/github/items?project_id={workspace_project.id}")
+    assert still_there.json() == {"(default)": ["TOKEN"]}
+
+    blocked_without_project = await client.request(
+        "DELETE",
+        "/api/vault/github/items",
+        json={"section": "", "fields": ["TOKEN"]},
+    )
+    assert blocked_without_project.status_code == 409, blocked_without_project.text
+    assert (
+        blocked_without_project.json()["detail"]["code"]
+        == "vault_item_global_delete_requires_confirmation"
+    )
+
+    confirmed = await client.request(
+        "DELETE",
+        f"/api/vault/github/items?project_id={seed_project.id}&global_delete=true",
+        json={"section": "", "fields": ["TOKEN"]},
+    )
+    assert confirmed.status_code == 200, confirmed.text
+    gone = await client.get(f"/api/vault/github/items?project_id={workspace_project.id}")
+    assert gone.json() == {}
+
+
+@pytest.mark.asyncio
 async def test_vault_duplicate_slug_does_not_duplicate_keys(client):
     r = await client.post("/api/vault", json={"slug": "dup", "name": "First"})
     assert r.status_code == 200, r.text

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -168,6 +168,8 @@ clawdi://api-service/database/url
 `.env` imports and `clawdi vault set OPENAI_API_KEY` store fields without a section by default, so that key resolves as `clawdi://default/OPENAI_API_KEY`. Use `clawdi vault import --section openai ...` or `clawdi vault set default/openai/api_key` for sectioned fields.
 Exact references include the Project ID and are the default Web/CLI copy UX. In project-relative references, `default` is the vault slug, not the Project; Project selection happens outside the URI through `--project`, `--agent`, local folder links, or the caller's default Project.
 
+Project access and key mutation are separate operations. `clawdi vault attach` and `clawdi vault detach` add or remove a Project's access to the whole Vault without changing stored values. `clawdi vault rm` deletes a key from the shared Vault itself; for Vaults attached to multiple Projects, the CLI and API require explicit global confirmation.
+
 Values encrypted with AES-256-GCM (`vault_encryption_key` env var is the master key). The backend has two vault surfaces:
 
 - `/api/vault/*` — CRUD, accessible from the web dashboard, but **never returns plain values**

--- a/docs/using-clawdi-with-claude-code.md
+++ b/docs/using-clawdi-with-claude-code.md
@@ -323,7 +323,7 @@ $ clawdi push --agent codex
 | `clawdi push` | Push sessions + skills to the cloud |
 | `clawdi pull` | Pull skills from the cloud into Claude Code's skills dir |
 | `clawdi memory list / search / add / rm` | Inspect or edit cross-agent memory (alias: `mem`) |
-| `clawdi vault set / list / import / rm` | Manage runtime secrets |
+| `clawdi vault set / list / import / attach / detach / rm` | Manage runtime secrets and Project access |
 | `clawdi run -- <cmd>` | Run a command with vault secrets injected |
 | `clawdi skill list / add / install / rm` | Manage skills |
 | `clawdi mcp` | Start MCP stdio server (invoked by Claude Code automatically) |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -101,7 +101,7 @@ clawdi inject --dry-run --in .env.clawdi --out .env.local
 clawdi inject --force --in .env.clawdi --out .env.local
 ```
 
-`clawdi vault set`, `clawdi vault import`, `clawdi vault rm`, and `clawdi vault list` print the concrete Project target or exact references that include the Project ID. `vault set` supports `--prompt` for secure one-off entry, `--stdin` for scripts, and `--value` when shell history exposure is acceptable; empty stdin is rejected unless `--allow-empty` is passed intentionally. `vault import` supports `--vault`, `--section`, `--project`, and warns about skipped invalid dotenv identifiers. Prefer service-specific vault slugs such as `api-service` over broad environment slugs such as `prod`. Project-relative references such as `clawdi://default/OPENAI_API_KEY` still work for portable templates, but exact references are the default copy/read UX.
+Vaults are account-level key bundles. Projects attach to a Vault to use the same shared key set. `clawdi vault set`, `clawdi vault import`, `clawdi vault rm`, and `clawdi vault list` print the concrete Project target or exact references that include the Project ID. `vault set` supports `--prompt` for secure one-off entry, `--stdin` for scripts, and `--value` when shell history exposure is acceptable; empty stdin is rejected unless `--allow-empty` is passed intentionally. `vault import` supports `--vault`, `--section`, `--project`, and warns about skipped invalid dotenv identifiers. Use `clawdi vault attach <vault> --project <project>` to make an existing Vault available in another Project, and `clawdi vault detach <vault> --project <project>` to remove one Project's access without deleting keys. `vault rm` deletes a key from the shared Vault; when a Vault is attached to multiple Projects, it requires `--global`. Prefer service-specific vault slugs such as `api-service` over broad environment slugs such as `prod`. Project-relative references such as `clawdi://default/OPENAI_API_KEY` still work for portable templates, but exact references are the default copy/read UX.
 
 Agents should prefer `clawdi run --env-file .env.clawdi -- <command>` when they can launch the tool themselves. Use `clawdi inject` only for tools that must read a physical `.env.local`; generated files are written owner-only and should stay gitignored.
 
@@ -260,7 +260,7 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](https://gith
 | `clawdi agent projects list/attach/detach/move` | View the fixed Agent Project and manage attached Projects |
 | `clawdi agent credentials import/materialize` | Sync local CLI credential profiles for Codex, Claude Code, and GitHub CLI; explicit Keychain import requires service/account options |
 | `clawdi project folder link/status/unlink` | Link a local folder to a Project for vault reference selection |
-| `clawdi vault set/list/import/rm` | Manage encrypted secrets and copy exact references |
+| `clawdi vault set/list/import/attach/detach/rm` | Manage encrypted secrets, Project access, and copy exact references |
 | `clawdi read <clawdi://...>` | Explicitly print one vault reference value |
 | `clawdi inject --in <file> --out <file>` | Render `clawdi://` references into templates |
 | `clawdi run --env-file <file> -- <cmd>` | Run a command with explicit vault references resolved |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.8.6",
+	"version": "0.9.0",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -12,7 +12,7 @@ You have access to Clawdi Cloud tools via the `clawdi` MCP server. Use them aggr
 Three tools for cross-agent memory:
 
 - `memory_search` — Search long-term memory by natural-language query (any language).
-- `memory_add` — Save a durable memory for cross-agent recall. Categories: `fact` (technical facts, API details, config values), `preference` (user preferences, coding style, workflow choices), `pattern` (recurring patterns, pitfalls, team conventions), `decision` (architecture decisions and their reasoning), `context` (project context, deadlines, ongoing work).
+- `memory_add` — Save a durable memory for cross-agent recall. Do not store plaintext tokens, API keys, or bearer credentials; store those in Vault and save only the `clawdi://` reference. Categories: `fact` (technical facts, API details, config values), `preference` (user preferences, coding style, workflow choices), `pattern` (recurring patterns, pitfalls, team conventions), `decision` (architecture decisions and their reasoning), `context` (project context, deadlines, ongoing work).
 - `memory_extract` — Batch-extract durable memories from the CURRENT conversation. Call this when the user says "extract memories", "save what we discussed", "remember this conversation", or equivalent. The tool returns instructions that walk you through a list-then-confirm flow using `memory_search` and `memory_add` — follow them exactly, including **waiting for the user's approval before writing anything**. Never skip the confirmation step, never save more than 5 memories in one invocation, and do not narrate your internal workflow to the user.
 
 ### When to search — bias toward calling
@@ -45,6 +45,8 @@ Do NOT search for:
 Write memories as standalone sentences with full context — include names, not pronouns. A future session will read this without knowing today's conversation.
 
 Do NOT save trivial facts that are obvious from the code itself, or generic programming knowledge.
+
+Do NOT save plaintext tokens, API keys, bearer credentials, or private keys in memory. Use Vault for secret values and save only a `clawdi://` reference when future agents need to know where a secret lives.
 
 ## Sessions
 
@@ -94,5 +96,7 @@ When the user asks to migrate secrets into Clawdi Vault or script secret writes,
 - Use service-specific vault slugs such as `api-service/env/KEY`; avoid broad slugs such as `prod/KEY`.
 - Use `clawdi vault import --vault <service-slug> --section <name> --project <project> --yes <file>` for non-interactive `.env` migrations into a section.
 - Keep `.env` import keys as POSIX environment identifiers such as `OPENAI_API_KEY`; section names belong in `--section`, not inside the key name.
-- Use `clawdi vault rm <vault>/<section>/<field> --yes` or `clawdi vault delete ...` to clean up misplaced keys.
+- Use `clawdi vault attach <vault> --project <project>` to make an existing Vault available in another Project.
+- Use `clawdi vault detach <vault> --project <project>` to remove one Project's access without deleting keys.
+- Use `clawdi vault rm <vault>/<section>/<field> --global --yes` only when the key should be deleted from the shared Vault for every attached Project.
 - Prefer exact `clawdi://project/...` references printed by the CLI. Do not print plaintext secret values unless the user explicitly asks for them.

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -1,3 +1,4 @@
+import { findLikelySecret, formatSecretMemoryWarning } from "@clawdi/shared";
 import chalk from "chalk";
 import { ApiClient, unwrap } from "../lib/api-client";
 import type { Memory } from "../lib/api-schemas";
@@ -103,6 +104,11 @@ export async function memoryAdd(content: string, opts: { category?: string } = {
 				`⚠ Unknown category "${opts.category}". Valid: ${VALID_CATEGORIES.join(", ")}. Defaulting to "fact".`,
 			),
 		);
+	}
+
+	const finding = findLikelySecret(content);
+	if (finding) {
+		throw new Error(formatSecretMemoryWarning(finding));
 	}
 
 	const api = new ApiClient();

--- a/packages/cli/src/commands/vault.ts
+++ b/packages/cli/src/commands/vault.ts
@@ -116,6 +116,7 @@ export async function vaultSet(key: string, opts: VaultSetOptions = {}) {
 	console.log(chalk.gray(`  Target: ${formatVaultTarget(vaultSlug, section, targetProject)}`));
 
 	await ensureVault(api, vaultSlug, vaultSlug, targetProject.projectId);
+	await warnIfSharedVaultWrite(api, vaultSlug);
 
 	unwrap(
 		await api.PUT("/api/vault/{slug}/items", {
@@ -231,7 +232,9 @@ export async function vaultList(opts: { json?: boolean; project?: string } = {})
 	for (const group of groups.values()) {
 		console.log(chalk.white(`Project ${projectLabel(group.projectId)}`));
 		for (const { vault, items } of group.rows) {
-			console.log(chalk.gray(`  Vault ${sanitizeMetadata(vault.slug)}`));
+			const projectCount = vaultProjectIds(vault).length;
+			const attachedSummary = projectCount > 1 ? ` (${projectCount} attached Projects)` : "";
+			console.log(chalk.gray(`  Vault ${sanitizeMetadata(vault.slug)}${attachedSummary}`));
 			for (const row of group.projectId
 				? buildVaultReferenceRows(group.projectId, vault.slug, items)
 				: []) {
@@ -240,6 +243,90 @@ export async function vaultList(opts: { json?: boolean; project?: string } = {})
 			}
 		}
 	}
+}
+
+interface VaultProjectOptions {
+	project?: string;
+}
+
+export async function vaultAttach(vaultSlugArg: string, opts: VaultProjectOptions = {}) {
+	requireAuth();
+	if (!opts.project) {
+		throw new Error("Pass --project to choose which Project should use this Vault.");
+	}
+
+	const vaultSlug = cleanVaultSlug(vaultSlugArg);
+	const api = new ApiClient();
+	const targetProject = await resolveVaultWriteProject(api, opts.project);
+	const vault = await loadVault(api, vaultSlug);
+	if (!vault) {
+		throw new Error(
+			`No Vault named "${vaultSlug}" was found. Store a key first with \`clawdi vault set ${vaultSlug}/KEY --prompt\`.`,
+		);
+	}
+	const projectIdsBefore = vaultProjectIds(vault);
+	if (projectIdsBefore.includes(targetProject.projectId)) {
+		console.log(
+			chalk.gray(
+				`Vault "${sanitizeMetadata(vaultSlug)}" is already available in ${formatProjectTarget(targetProject)}.`,
+			),
+		);
+		return;
+	}
+
+	await ensureVault(api, vaultSlug, vaultSlug, targetProject.projectId);
+	const attachedCount = projectIdsBefore.length + 1;
+	console.log(
+		chalk.green(
+			`✓ Attached vault "${sanitizeMetadata(vaultSlug)}" to ${formatProjectTarget(targetProject)}`,
+		),
+	);
+	console.log(
+		chalk.gray(
+			`  Keys in this Vault are now available from ${attachedCount} Project${attachedCount === 1 ? "" : "s"} and remain one shared key set.`,
+		),
+	);
+}
+
+export async function vaultDetach(vaultSlugArg: string, opts: VaultProjectOptions = {}) {
+	requireAuth();
+	if (!opts.project) {
+		throw new Error("Pass --project to choose which Project should stop using this Vault.");
+	}
+
+	const vaultSlug = cleanVaultSlug(vaultSlugArg);
+	const api = new ApiClient();
+	const targetProject = await resolveVaultWriteProject(api, opts.project);
+	const vault = await loadVault(api, vaultSlug);
+	if (!vault) {
+		throw new Error(`No Vault named "${vaultSlug}" was found.`);
+	}
+	const projectIdsBefore = vaultProjectIds(vault);
+	if (!projectIdsBefore.includes(targetProject.projectId)) {
+		console.log(
+			chalk.gray(
+				`Vault "${sanitizeMetadata(vaultSlug)}" is not attached to ${formatProjectTarget(targetProject)}.`,
+			),
+		);
+		return;
+	}
+
+	unwrap(
+		await api.DELETE("/api/vault/{slug}", {
+			params: { path: { slug: vaultSlug }, query: { project_id: targetProject.projectId } },
+		}),
+	);
+	const remainingCount = Math.max(projectIdsBefore.length - 1, 0);
+	console.log(
+		chalk.green(
+			`✓ Detached vault "${sanitizeMetadata(vaultSlug)}" from ${formatProjectTarget(targetProject)}`,
+		),
+	);
+	console.log(
+		chalk.gray(
+			`  No keys were deleted. This Vault remains attached to ${remainingCount} Project${remainingCount === 1 ? "" : "s"}.`,
+		),
+	);
 }
 
 interface VaultReferenceRow {
@@ -328,6 +415,7 @@ export async function vaultImport(file: string, opts: VaultImportOptions = {}) {
 		vaultSlug === "default" ? "Default" : vaultSlug,
 		targetProject.projectId,
 	);
+	await warnIfSharedVaultWrite(api, vaultSlug);
 
 	unwrap(
 		await api.PUT("/api/vault/{slug}/items", {
@@ -353,6 +441,7 @@ export async function vaultImport(file: string, opts: VaultImportOptions = {}) {
 interface VaultRmOptions {
 	project?: string;
 	yes?: boolean;
+	global?: boolean;
 }
 
 export async function vaultRm(key: string, opts: VaultRmOptions = {}) {
@@ -360,12 +449,29 @@ export async function vaultRm(key: string, opts: VaultRmOptions = {}) {
 
 	const { vaultSlug, section, field } = parseVaultKey(key);
 	const normalizedKey = formatVaultKey(vaultSlug, section, field);
+	if (!opts.yes && !isInteractive()) {
+		throw new Error(
+			"Cannot prompt for vault deletion in a non-interactive shell. Pass --yes to confirm explicitly.",
+		);
+	}
+
 	const api = new ApiClient();
 	const targetProject = await resolveVaultWriteProject(api, opts.project);
 	const target = formatVaultTarget(vaultSlug, section, targetProject);
+	const attachedProjectIds = await loadVaultProjectIds(api, vaultSlug);
+	if (attachedProjectIds.length > 1 && !opts.global) {
+		throw new Error(
+			`Refusing to delete ${normalizedKey} from shared vault "${vaultSlug}". This Vault is attached to ${attachedProjectIds.length} Projects, so deleting the key would remove it for every Project. Re-run with --global after you have confirmed that is intended.`,
+		);
+	}
 
 	if (!opts.yes) {
-		const ok = await p.confirm({ message: `Delete ${normalizedKey} from ${target}?` });
+		const ok = await p.confirm({
+			message:
+				attachedProjectIds.length > 1
+					? `Delete ${normalizedKey} globally from ${attachedProjectIds.length} Projects using ${target}?`
+					: `Delete ${normalizedKey} from ${target}?`,
+		});
 		if (p.isCancel(ok) || !ok) {
 			p.cancel("Cancelled.");
 			return;
@@ -376,13 +482,17 @@ export async function vaultRm(key: string, opts: VaultRmOptions = {}) {
 		await api.DELETE("/api/vault/{slug}/items", {
 			params: {
 				path: { slug: vaultSlug },
-				query: { project_id: targetProject.projectId },
+				query: { project_id: targetProject.projectId, global_delete: Boolean(opts.global) },
 			},
 			body: { section, fields: [field] },
 		}),
 	);
 
-	console.log(chalk.green(`✓ Deleted ${normalizedKey} from ${target}`));
+	const suffix =
+		attachedProjectIds.length > 1
+			? ` globally from shared ${target} (${attachedProjectIds.length} Projects attached)`
+			: ` from ${target}`;
+	console.log(chalk.green(`✓ Deleted ${normalizedKey}${suffix}`));
 }
 
 async function readVaultSetValue(key: string, opts: VaultSetOptions): Promise<string | null> {
@@ -477,6 +587,27 @@ function warnIfBroadVaultSlug(vaultSlug: string) {
 	);
 }
 
+async function loadVaultProjectIds(api: ApiClient, vaultSlug: string): Promise<string[]> {
+	const vault = await loadVault(api, vaultSlug);
+	return vault ? vaultProjectIds(vault) : [];
+}
+
+async function loadVault(api: ApiClient, vaultSlug: string): Promise<VaultListRow | null> {
+	const page = await fetchAllVaults(api);
+	const vault = page.items.find((item) => item.slug === vaultSlug);
+	return vault ?? null;
+}
+
+async function warnIfSharedVaultWrite(api: ApiClient, vaultSlug: string) {
+	const projectIds = await loadVaultProjectIds(api, vaultSlug).catch(() => []);
+	if (projectIds.length <= 1) return;
+	console.log(
+		chalk.yellow(
+			`  Shared Vault: "${sanitizeMetadata(vaultSlug)}" is attached to ${projectIds.length} Projects. This write updates the same key set for every attached Project.`,
+		),
+	);
+}
+
 function cleanVaultSlug(value: string): string {
 	const slug = value.trim();
 	if (!VAULT_SLUG_RE.test(slug)) {
@@ -536,6 +667,11 @@ function formatVaultTarget(vaultSlug: string, section: string, project: VaultWri
 	const target = section ? `vault "${vaultSlug}" section "${section}"` : `vault "${vaultSlug}"`;
 	const source = project.source === "explicit" ? "explicit project" : "default-write project";
 	return `${target} in ${source} "${sanitizeMetadata(project.label)}" (${project.projectId})`;
+}
+
+function formatProjectTarget(project: VaultWriteProject): string {
+	const source = project.source === "explicit" ? "explicit project" : "default-write project";
+	return `${source} "${sanitizeMetadata(project.label)}" (${project.projectId})`;
 }
 
 function formatProjectLabel(project: {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -274,8 +274,9 @@ const vaultCmd = program
 		"after",
 		`
 Scope:
-  Write commands (set/import/rm) use --project first; otherwise they write to
-  your default-write project. The selected project is printed before writing.
+  Vaults are account-level key bundles. Projects attach to a Vault to use the
+  same shared key set. set/import update the Vault for every attached Project.
+  rm deletes a key from the Vault; detach only removes one Project's access.
   Key paths are KEY, vault/KEY, or vault/section/KEY.`,
 	);
 
@@ -344,21 +345,52 @@ vaultCmd
 	});
 
 vaultCmd
-	.command("rm <key>")
-	.alias("delete")
-	.description("Delete a secret")
-	.option(
-		"-p, --project <id-or-slug>",
-		"Target a specific project (default: your default-write project)",
-	)
-	.option("-y, --yes", "Skip the confirmation prompt")
+	.command("attach <vault>")
+	.description("Make an existing Vault available in a Project")
+	.requiredOption("-p, --project <id-or-slug>", "Project that should use this Vault")
 	.addHelpText(
 		"after",
-		"\nExamples:\n  $ clawdi vault rm OPENAI_API_KEY\n  $ clawdi vault delete prod/stripe/SECRET_KEY --project engineering --yes",
+		"\nExamples:\n  $ clawdi vault attach providers --project redpill-providers",
+	)
+	.action(async (vault, opts) => {
+		const { vaultAttach } = await import("./commands/vault.js");
+		await vaultAttach(vault, { project: opts.project });
+	});
+
+vaultCmd
+	.command("detach <vault>")
+	.alias("unlink")
+	.description("Remove a Project's access to a Vault without deleting keys")
+	.requiredOption("-p, --project <id-or-slug>", "Project that should stop using this Vault")
+	.addHelpText(
+		"after",
+		"\nExamples:\n  $ clawdi vault detach providers --project env-abc123\n  $ clawdi vault unlink providers --project old-agent",
+	)
+	.action(async (vault, opts) => {
+		const { vaultDetach } = await import("./commands/vault.js");
+		await vaultDetach(vault, { project: opts.project });
+	});
+
+vaultCmd
+	.command("rm <key>")
+	.alias("delete")
+	.description("Delete a key from a Vault")
+	.option(
+		"-p, --project <id-or-slug>",
+		"Select the Project used to locate the Vault (default: your default-write project)",
+	)
+	.option("-y, --yes", "Skip the confirmation prompt")
+	.option(
+		"--global",
+		"Allow deleting a key from a Vault attached to multiple Projects (affects every Project using it)",
+	)
+	.addHelpText(
+		"after",
+		"\nExamples:\n  $ clawdi vault rm OPENAI_API_KEY\n  $ clawdi vault delete prod/stripe/SECRET_KEY --project engineering --yes\n  $ clawdi vault rm OPENAI_API_KEY --project engineering --global --yes",
 	)
 	.action(async (key, opts) => {
 		const { vaultRm } = await import("./commands/vault.js");
-		await vaultRm(key, { ...opts, project: opts.project, yes: opts.yes });
+		await vaultRm(key, { ...opts, project: opts.project, yes: opts.yes, global: opts.global });
 	});
 
 vaultCmd

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -1,3 +1,4 @@
+import { findLikelySecret, formatSecretMemoryWarning } from "@clawdi/shared";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
@@ -316,7 +317,7 @@ export async function startMcpServer() {
 
 	server.tool(
 		"memory_add",
-		'Store a durable memory so future agent sessions (same agent, or a different one) can retrieve this context. Call this when you learn something non-obvious about the user or their project that a future session would benefit from knowing.\n\nMUST call when:\n- The user explicitly asks you to remember something ("remember this", "save this", or equivalent in any language) — always honor the request\n- You just fixed a non-trivial bug — save ROOT CAUSE + fix, not just "bug fixed"\n- You and the user made an architecture decision together — save the decision AND the reasoning (why this option over alternatives)\n- The user expressed a coding / workflow preference you had to ask about — save it so you or another agent never asks again (e.g. "user prefers pnpm over npm")\n- The user shared personal info (their name, their project name, their team, who they work with) that future context would need\n\nDo NOT save:\n- Trivia that any agent can discover by reading the current code\n- Generic programming knowledge (how APIs work, language features)\n- Ephemeral conversation details ("the user asked about X today")\n\nWrite the content as a standalone sentence with full context — include proper nouns, not pronouns. A future session will read it without today\'s conversation. Content language should match the user\'s primary language for that context.',
+		'Store a durable memory so future agent sessions (same agent, or a different one) can retrieve this context. Call this when you learn something non-obvious about the user or their project that a future session would benefit from knowing.\n\nMUST call when:\n- The user explicitly asks you to remember something ("remember this", "save this", or equivalent in any language) — always honor the request\n- You just fixed a non-trivial bug — save ROOT CAUSE + fix, not just "bug fixed"\n- You and the user made an architecture decision together — save the decision AND the reasoning (why this option over alternatives)\n- The user expressed a coding / workflow preference you had to ask about — save it so you or another agent never asks again (e.g. "user prefers pnpm over npm")\n- The user shared personal info (their name, their project name, their team, who they work with) that future context would need\n\nDo NOT save:\n- Trivia that any agent can discover by reading the current code\n- Generic programming knowledge (how APIs work, language features)\n- Ephemeral conversation details ("the user asked about X today")\n- Plaintext tokens, API keys, bearer credentials, or private keys; use Vault and save a clawdi:// reference instead\n\nWrite the content as a standalone sentence with full context — include proper nouns, not pronouns. A future session will read it without today\'s conversation. Content language should match the user\'s primary language for that context.',
 		{
 			content: z
 				.string()
@@ -332,6 +333,14 @@ export async function startMcpServer() {
 		},
 		async ({ content, category }) => {
 			try {
+				const finding = findLikelySecret(content);
+				if (finding) {
+					return {
+						content: [
+							{ type: "text" as const, text: `Error: ${formatSecretMemoryWarning(finding)}` },
+						],
+					};
+				}
 				const result = unwrap(
 					await api.POST("/api/memories", {
 						body: { content, category: category ?? "fact", source: "mcp" },

--- a/packages/cli/tests/commands/memory.test.ts
+++ b/packages/cli/tests/commands/memory.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { memoryAdd } from "../../src/commands/memory";
+import { jsonResponse, mockFetch } from "./helpers";
+
+let tmpHome: string;
+let origHome: string | undefined;
+let origApiUrl: string | undefined;
+
+beforeEach(() => {
+	origHome = process.env.HOME;
+	origApiUrl = process.env.CLAWDI_API_URL;
+	tmpHome = join(tmpdir(), `clawdi-memory-${Date.now()}-${Math.random().toString(36)}`);
+	mkdirSync(join(tmpHome, ".clawdi"), { recursive: true });
+	writeFileSync(join(tmpHome, ".clawdi", "auth.json"), JSON.stringify({ apiKey: "test-key" }));
+	process.env.HOME = tmpHome;
+	process.env.CLAWDI_API_URL = "http://api.test";
+});
+
+afterEach(() => {
+	if (origHome) process.env.HOME = origHome;
+	else delete process.env.HOME;
+	if (origApiUrl) process.env.CLAWDI_API_URL = origApiUrl;
+	else delete process.env.CLAWDI_API_URL;
+	rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("memoryAdd", () => {
+	it("rejects likely secrets before posting", async () => {
+		const { captured, restore } = mockFetch([]);
+
+		try {
+			await expect(memoryAdd("OpenAI key is sk-abcdefghijklmnopqrstuvwxyz123456")).rejects.toThrow(
+				"Store secrets with `clawdi vault set <KEY> --stdin`",
+			);
+		} finally {
+			restore();
+		}
+
+		expect(captured).toHaveLength(0);
+	});
+
+	it("posts ordinary memories", async () => {
+		const { captured, restore } = mockFetch([
+			{
+				method: "POST",
+				path: "/api/memories",
+				response: () => jsonResponse({ id: "00000000-0000-0000-0000-000000000abc" }),
+			},
+		]);
+		const origLog = console.log;
+		console.log = () => {};
+
+		try {
+			await memoryAdd("The user prefers concise PR summaries.", {
+				category: "preference",
+			});
+		} finally {
+			console.log = origLog;
+			restore();
+		}
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0].body).toEqual({
+			content: "The user prefers concise PR summaries.",
+			category: "preference",
+			source: "manual",
+		});
+	});
+});

--- a/packages/cli/tests/commands/vault.test.ts
+++ b/packages/cli/tests/commands/vault.test.ts
@@ -2,7 +2,14 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { vaultImport, vaultList, vaultRm, vaultSet } from "../../src/commands/vault";
+import {
+	vaultAttach,
+	vaultDetach,
+	vaultImport,
+	vaultList,
+	vaultRm,
+	vaultSet,
+} from "../../src/commands/vault";
 import { jsonResponse, mockFetch } from "./helpers";
 
 let tmpHome: string;
@@ -10,6 +17,7 @@ let origHome: string | undefined;
 let origApiUrl: string | undefined;
 
 const PROJECT_ID = "00000000-0000-0000-0000-000000000123";
+const OTHER_PROJECT_ID = "00000000-0000-0000-0000-000000000456";
 
 beforeEach(() => {
 	origHome = process.env.HOME;
@@ -185,6 +193,51 @@ describe("vaultList", () => {
 		expect(out.match(/Project personal/g)?.length).toBe(1);
 		expect(out).toContain("Vault default");
 		expect(out).toContain("Vault prod");
+	});
+
+	it("marks vaults attached to multiple projects in human output", async () => {
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/api/vault/shared/items",
+				response: () => jsonResponse({ "(default)": ["TOKEN"] }),
+			},
+			{
+				method: "GET",
+				path: "/api/vault",
+				response: () =>
+					jsonResponse({
+						items: [
+							{
+								id: "vault-1",
+								slug: "shared",
+								name: "shared",
+								project_ids: [PROJECT_ID, OTHER_PROJECT_ID],
+							},
+						],
+						total: 1,
+					}),
+			},
+			...mockProjectList(),
+		]);
+		const ttyDesc = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+		const origLog = console.log;
+		let out = "";
+		console.log = (...args: unknown[]) => {
+			out += `${args.map(String).join(" ")}\n`;
+		};
+
+		try {
+			await vaultList({});
+		} finally {
+			console.log = origLog;
+			if (ttyDesc) Object.defineProperty(process.stdout, "isTTY", ttyDesc);
+			else Object.defineProperty(process.stdout, "isTTY", { value: undefined, configurable: true });
+			restore();
+		}
+
+		expect(out).toContain("Vault shared (2 attached Projects)");
 	});
 
 	it("hides empty vaults in human output", async () => {
@@ -426,6 +479,160 @@ describe("vaultImport", () => {
 	});
 });
 
+describe("vault attach/detach", () => {
+	it("attaches an existing vault to another project without touching keys", async () => {
+		const { captured, restore } = mockFetch([
+			...mockProjectList(),
+			{
+				method: "GET",
+				path: "/api/vault",
+				response: () =>
+					jsonResponse({
+						items: [
+							{ id: "vault-1", slug: "providers", name: "providers", project_ids: [PROJECT_ID] },
+						],
+						total: 1,
+					}),
+			},
+			{
+				method: "POST",
+				path: "/api/vault",
+				response: () => jsonResponse({ id: "vault-1", slug: "providers" }),
+			},
+		]);
+		const origLog = console.log;
+		let out = "";
+		console.log = (...args: unknown[]) => {
+			out += `${args.map(String).join(" ")}\n`;
+		};
+
+		try {
+			await vaultAttach("providers", { project: OTHER_PROJECT_ID });
+		} finally {
+			console.log = origLog;
+			restore();
+		}
+
+		const post = captured.find((request) => request.method === "POST");
+		expect(post?.path).toContain(`/api/vault?project_id=${OTHER_PROJECT_ID}`);
+		expect(post?.body).toEqual({ slug: "providers", name: "providers" });
+		expect(captured.some((request) => request.method === "PUT")).toBe(false);
+		expect(out).toContain("Attached vault");
+		expect(out).toContain("one shared key set");
+	});
+
+	it("attaches an existing but currently unattached vault", async () => {
+		const { captured, restore } = mockFetch([
+			...mockProjectList(),
+			{
+				method: "GET",
+				path: "/api/vault",
+				response: () =>
+					jsonResponse({
+						items: [
+							{
+								id: "vault-1",
+								slug: "providers",
+								name: "providers",
+								project_ids: [],
+							},
+						],
+						total: 1,
+					}),
+			},
+			{
+				method: "POST",
+				path: "/api/vault",
+				response: () => jsonResponse({ id: "vault-1", slug: "providers" }),
+			},
+		]);
+		const origLog = console.log;
+		let out = "";
+		console.log = (...args: unknown[]) => {
+			out += `${args.map(String).join(" ")}\n`;
+		};
+
+		try {
+			await vaultAttach("providers", { project: OTHER_PROJECT_ID });
+		} finally {
+			console.log = origLog;
+			restore();
+		}
+
+		const post = captured.find((request) => request.method === "POST");
+		expect(post?.path).toContain(`/api/vault?project_id=${OTHER_PROJECT_ID}`);
+		expect(out).toContain("Attached vault");
+		expect(out).toContain("1 Project");
+		expect(out).not.toContain("1 Projects");
+	});
+
+	it("detaches a vault from one project without deleting keys", async () => {
+		const { captured, restore } = mockFetch([
+			...mockProjectList(),
+			{
+				method: "GET",
+				path: "/api/vault",
+				response: () =>
+					jsonResponse({
+						items: [
+							{
+								id: "vault-1",
+								slug: "providers",
+								name: "providers",
+								project_ids: [PROJECT_ID, OTHER_PROJECT_ID],
+							},
+						],
+						total: 1,
+					}),
+			},
+			{
+				method: "DELETE",
+				path: "/api/vault/providers",
+				response: () => jsonResponse({ status: "deleted" }),
+			},
+		]);
+		const origLog = console.log;
+		let out = "";
+		console.log = (...args: unknown[]) => {
+			out += `${args.map(String).join(" ")}\n`;
+		};
+
+		try {
+			await vaultDetach("providers", { project: OTHER_PROJECT_ID });
+		} finally {
+			console.log = origLog;
+			restore();
+		}
+
+		const del = captured.find((request) => request.method === "DELETE");
+		expect(del?.path).toContain(`/api/vault/providers?project_id=${OTHER_PROJECT_ID}`);
+		expect(captured.some((request) => request.path.includes("/items"))).toBe(false);
+		expect(out).toContain("Detached vault");
+		expect(out).toContain("No keys were deleted");
+	});
+
+	it("refuses to attach a missing vault because attach should not create key bundles", async () => {
+		const { captured, restore } = mockFetch([
+			...mockProjectList(),
+			{
+				method: "GET",
+				path: "/api/vault",
+				response: () => jsonResponse({ items: [], total: 0 }),
+			},
+		]);
+
+		try {
+			await expect(vaultAttach("missing", { project: PROJECT_ID })).rejects.toThrow(
+				'No Vault named "missing" was found',
+			);
+		} finally {
+			restore();
+		}
+
+		expect(captured.some((request) => request.method === "POST")).toBe(false);
+	});
+});
+
 describe("vaultSet", () => {
 	it("stores a non-interactive --value without prompting", async () => {
 		const { captured, restore } = mockFetch([
@@ -632,6 +839,15 @@ describe("vaultSet", () => {
 		const { captured, restore } = mockFetch([
 			...mockDefaultProjectResolution(),
 			{
+				method: "GET",
+				path: "/api/vault",
+				response: () =>
+					jsonResponse({
+						items: [{ id: "vault-1", slug: "prod", name: "prod", project_ids: [PROJECT_ID] }],
+						total: 1,
+					}),
+			},
+			{
 				method: "DELETE",
 				path: "/api/vault/prod/items",
 				response: () => jsonResponse({ status: "deleted" }),
@@ -652,6 +868,7 @@ describe("vaultSet", () => {
 
 		const del = captured.find((request) => request.method === "DELETE");
 		expect(del?.path).toContain(`/api/vault/prod/items?project_id=${PROJECT_ID}`);
+		expect(del?.path).toContain("global_delete=false");
 		expect(del?.body).toEqual({
 			section: "stripe",
 			fields: ["SECRET_KEY"],
@@ -659,6 +876,104 @@ describe("vaultSet", () => {
 		expect(out).toContain(
 			`Deleted prod/stripe/SECRET_KEY from vault "prod" section "stripe" in default-write project "personal" (${PROJECT_ID})`,
 		);
+	});
+
+	it("refuses to delete a shared vault key without --global", async () => {
+		const { captured, restore } = mockFetch([
+			...mockDefaultProjectResolution(),
+			{
+				method: "GET",
+				path: "/api/vault",
+				response: () =>
+					jsonResponse({
+						items: [
+							{
+								id: "vault-1",
+								slug: "prod",
+								name: "prod",
+								project_ids: [PROJECT_ID, OTHER_PROJECT_ID],
+							},
+						],
+						total: 1,
+					}),
+			},
+		]);
+
+		try {
+			await expect(vaultRm("prod/stripe/SECRET_KEY", { yes: true })).rejects.toThrow(
+				"Refusing to delete prod/stripe/SECRET_KEY from shared vault",
+			);
+		} finally {
+			restore();
+		}
+
+		expect(captured.some((request) => request.method === "DELETE")).toBe(false);
+	});
+
+	it("passes explicit global confirmation for shared vault key deletion", async () => {
+		const { captured, restore } = mockFetch([
+			...mockDefaultProjectResolution(),
+			{
+				method: "GET",
+				path: "/api/vault",
+				response: () =>
+					jsonResponse({
+						items: [
+							{
+								id: "vault-1",
+								slug: "prod",
+								name: "prod",
+								project_ids: [PROJECT_ID, OTHER_PROJECT_ID],
+							},
+						],
+						total: 1,
+					}),
+			},
+			{
+				method: "DELETE",
+				path: "/api/vault/prod/items",
+				response: () => jsonResponse({ status: "deleted" }),
+			},
+		]);
+		const origLog = console.log;
+		let out = "";
+		console.log = (...args: unknown[]) => {
+			out += `${args.map(String).join(" ")}\n`;
+		};
+
+		try {
+			await vaultRm("prod/stripe/SECRET_KEY", { yes: true, global: true });
+		} finally {
+			console.log = origLog;
+			restore();
+		}
+
+		const del = captured.find((request) => request.method === "DELETE");
+		expect(del?.path).toContain("global_delete=true");
+		expect(out).toContain("globally from shared vault");
+		expect(out).toContain("2 Projects attached");
+	});
+
+	it("rejects interactive deletion prompts outside a TTY", async () => {
+		const { captured, restore } = mockFetch([]);
+		const stdinTtyDesc = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+		const stdoutTtyDesc = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+		Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+		Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+
+		try {
+			await expect(vaultRm("SECRET_KEY")).rejects.toThrow(
+				"Cannot prompt for vault deletion in a non-interactive shell. Pass --yes",
+			);
+		} finally {
+			if (stdinTtyDesc) Object.defineProperty(process.stdin, "isTTY", stdinTtyDesc);
+			else Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+			if (stdoutTtyDesc) Object.defineProperty(process.stdout, "isTTY", stdoutTtyDesc);
+			else Object.defineProperty(process.stdout, "isTTY", { value: undefined, configurable: true });
+			restore();
+		}
+
+		expect(captured).toHaveLength(0);
 	});
 
 	it("rejects ambiguous vault keys before writing", async () => {
@@ -804,6 +1119,13 @@ function mockProjects() {
 			slug: "personal",
 			name: "Personal",
 			kind: "personal",
+			is_owner: true,
+		},
+		{
+			id: OTHER_PROJECT_ID,
+			slug: "redpill-providers",
+			name: "Redpill Providers",
+			kind: "workspace",
 			is_owner: true,
 		},
 	];

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -5343,6 +5343,8 @@ export interface operations {
         parameters: {
             query?: {
                 project_id?: string | null;
+                /** @description Allow deleting the account-level item when this Vault is attached to multiple Projects. */
+                global_delete?: boolean;
             };
             header?: never;
             path: {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./api";
 export * from "./consts";
+export * from "./secret-detection";
 export * from "./sharing/agent-handoff";

--- a/packages/shared/src/secret-detection.ts
+++ b/packages/shared/src/secret-detection.ts
@@ -1,0 +1,22 @@
+export interface SecretFinding {
+	label: string;
+}
+
+const SECRET_PATTERNS: Array<{ label: string; pattern: RegExp }> = [
+	{ label: "OpenAI-style API key", pattern: /\bsk-[A-Za-z0-9_-]{20,}\b/ },
+	{ label: "GitHub token", pattern: /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b/ },
+	{ label: "GitHub fine-grained token", pattern: /\bgithub_pat_[A-Za-z0-9_]{20,}\b/ },
+	{ label: "Slack token", pattern: /\bxox[baprs]-[A-Za-z0-9-]{20,}\b/ },
+	{ label: "Bearer token", pattern: /\bBearer\s+[A-Za-z0-9._~+/=-]{20,}\b/i },
+];
+
+export function findLikelySecret(value: string): SecretFinding | null {
+	for (const { label, pattern } of SECRET_PATTERNS) {
+		if (pattern.test(value)) return { label };
+	}
+	return null;
+}
+
+export function formatSecretMemoryWarning(finding: SecretFinding): string {
+	return `Detected a likely ${finding.label}. Store secrets with \`clawdi vault set <KEY> --stdin\` and save a clawdi:// reference in memory instead.`;
+}


### PR DESCRIPTION
## Summary
- Add `clawdi vault attach` and `clawdi vault detach` / `unlink` so Project access can be changed without copying or deleting Vault keys.
- Require explicit global confirmation before deleting keys from Vaults attached to multiple Projects.
- Reject likely plaintext secrets from memory creation in CLI, MCP, dashboard, and backend paths.
- Update docs, bundled skill guidance, generated OpenAPI types, and changelog for `clawdi@0.9.0`.

## Breaking / Behavior Changes
- `clawdi vault rm KEY --yes` now refuses to delete from a Vault attached to multiple Projects unless `--global` is also passed.
- `DELETE /api/vault/{slug}/items` now requires `global_delete=true` for shared Vault item deletion.
- Memory creation rejects likely plaintext API keys, bearer tokens, GitHub/Slack/OpenAI-style tokens, and similar secrets. Users should store secret values in Vault and save only `clawdi://` references in memory.

## Release Impact
- Latest head SHA: `b7b61157`
- CLI publish: yes. `packages/cli/package.json` is bumped from `0.8.6` to `0.9.0`, so `.github/workflows/cli-publish.yml` should publish `clawdi@0.9.0` and create `clawdi-cli-v0.9.0` after merge.
- App/backend/web release: yes. This PR touches backend, web, shared API types, docs, and root changelog, so `.github/workflows/clawdi-release.yml` should create the next `clawdi-YYYY-MM-DD` release after merge.
- Database migration: none. No Alembic migration is added.

## Verification
- `bun run check`
- `bun run typecheck`
- `bun run test` — web `129 passed`, CLI `443 passed`
- `bun run check:publish-manifest` from `packages/cli`
- `uv run python scripts/check_generated_api.py`
- `uv run ruff check app/services/secret_detection.py app/routes/memories.py app/routes/vault.py tests/test_vault.py tests/test_smoke.py`
- `uv run pytest` — backend `343 passed`, 1 fastembed warning
- `git diff --check`

## Post-Merge Checks
- Watch `cli-publish.yml`; verify `npm view clawdi version` reports `0.9.0`.
- Watch `clawdi-release.yml`; verify the generated GitHub release notes call out the breaking Vault delete confirmation and Memory secret rejection.