### PR TITLE
fix(web): prevent share modal overflow

### DIFF
--- a/apps/web/src/components/sharing/share-project-dialog.tsx
+++ b/apps/web/src/components/sharing/share-project-dialog.tsx
@@ -132,7 +132,7 @@ export function ShareProjectDialog({
 					</Button>
 				)}
 			</DialogTrigger>
-			<DialogContent className="max-h-[calc(100vh-2rem)] max-w-2xl overflow-y-auto">
+			<DialogContent className="max-h-[calc(100vh-2rem)] max-w-2xl min-w-0 overflow-x-hidden overflow-y-auto">
 				<DialogHeader>
 					<DialogTitle>
 						{isShareableProject ? `Share ${projectName}` : "Only Projects You Create Can Be Shared"}
@@ -147,7 +147,7 @@ export function ShareProjectDialog({
 					<>
 						<PermissionSummary />
 						<ShareMethodGuide />
-						<Tabs defaultValue="members" className="w-full">
+						<Tabs defaultValue="members" className="min-w-0 w-full">
 							<TabsList className="grid w-full grid-cols-3">
 								<TabsTrigger value="members" className="min-w-0 px-2">
 									<Users className="mr-2 size-3.5" />
@@ -162,13 +162,13 @@ export function ShareProjectDialog({
 									<span className="truncate">Links</span>
 								</TabsTrigger>
 							</TabsList>
-							<TabsContent value="members" className="mt-4">
+							<TabsContent value="members" className="mt-4 min-w-0">
 								<MembersPanel projectId={projectId} />
 							</TabsContent>
-							<TabsContent value="invitations" className="mt-4">
+							<TabsContent value="invitations" className="mt-4 min-w-0">
 								<InvitationsPanel projectId={projectId} />
 							</TabsContent>
-							<TabsContent value="links" className="mt-4">
+							<TabsContent value="links" className="mt-4 min-w-0">
 								<ShareLinksPanel projectId={projectId} />
 							</TabsContent>
 						</Tabs>
@@ -307,7 +307,7 @@ function ShareLinksPanel({ projectId }: { projectId: string }) {
 	const visibleLinks = links.data ?? [];
 
 	return (
-		<div className="space-y-3">
+		<div className="min-w-0 space-y-3">
 			<div className="space-y-1">
 				<h3 className="text-sm font-semibold">Share Links</h3>
 				<p className="text-xs text-muted-foreground">
@@ -316,7 +316,7 @@ function ShareLinksPanel({ projectId }: { projectId: string }) {
 				</p>
 			</div>
 			<form
-				className="space-y-2 rounded-lg border p-3"
+				className="min-w-0 space-y-2 rounded-lg border p-3"
 				onSubmit={(e) => {
 					e.preventDefault();
 					create.mutate(label);
@@ -403,10 +403,10 @@ function FreshLinkBanner({ link, onDismiss }: { link: ShareLinkCreated; onDismis
 	};
 	const agentPrompt = buildShareAgentHandoffPrompt(link);
 	return (
-		<Alert>
+		<Alert className="overflow-hidden">
 			<CheckCircle2 />
 			<AlertTitle>Copy This Link Now</AlertTitle>
-			<AlertDescription>
+			<AlertDescription className="max-w-full">
 				<p className="text-xs text-muted-foreground">
 					Send this URL to the person you want to invite. They sign in or create an account, accept
 					as a read-only Viewer, then open the Project from their dashboard.
@@ -420,7 +420,7 @@ function FreshLinkBanner({ link, onDismiss }: { link: ShareLinkCreated; onDismis
 						Label: <span className="font-medium text-foreground">{link.label}</span>
 					</p>
 				) : null}
-				<div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
+				<div className="mt-2 flex w-full min-w-0 flex-col gap-2 sm:flex-row sm:items-center">
 					<Input
 						readOnly
 						value={link.url}
@@ -428,7 +428,7 @@ function FreshLinkBanner({ link, onDismiss }: { link: ShareLinkCreated; onDismis
 						aria-label="New share link URL"
 						autoComplete="off"
 						spellCheck={false}
-						className="min-w-0 font-mono text-xs"
+						className="min-w-0 flex-1 font-mono text-xs"
 					/>
 					<Button
 						variant="outline"
@@ -444,7 +444,7 @@ function FreshLinkBanner({ link, onDismiss }: { link: ShareLinkCreated; onDismis
 						Done
 					</Button>
 				</div>
-				<div className="mt-2 rounded-md border bg-background/60 p-2">
+				<div className="mt-2 w-full min-w-0 rounded-md border bg-background/60 p-2">
 					<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
 						<div className="min-w-0">
 							<div className="text-xs font-medium">Agent Handoff Prompt</div>

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -4,7 +4,7 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const alertVariants = cva(
-	"relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+	"relative grid w-full min-w-0 grid-cols-[0_minmax(0,1fr)] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_minmax(0,1fr)] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
 	{
 		variants: {
 			variant: {
@@ -38,7 +38,10 @@ function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
 	return (
 		<div
 			data-slot="alert-title"
-			className={cn("col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight", className)}
+			className={cn(
+				"col-start-2 line-clamp-1 min-h-4 min-w-0 font-medium tracking-tight",
+				className,
+			)}
 			{...props}
 		/>
 	);
@@ -49,7 +52,7 @@ function AlertDescription({ className, ...props }: React.ComponentProps<"div">) 
 		<div
 			data-slot="alert-description"
 			className={cn(
-				"col-start-2 grid justify-items-start gap-1 text-sm text-muted-foreground [&_p]:leading-relaxed",
+				"col-start-2 grid min-w-0 justify-items-start gap-1 text-sm text-muted-foreground [&_p]:leading-relaxed",
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
## Summary
- Prevent the project share dialog from expanding horizontally after a share link is created
- Make the shared Alert grid shrink-safe for long unbroken content
- Constrain the fresh share-link banner URL row inside the modal

## Test Plan
- bun run --cwd apps/web lint
- bun run --cwd apps/web typecheck
- git diff --check