### PR TITLE
Add credential profile metadata listing

### DIFF
--- a/backend/app/routes/vault.py
+++ b/backend/app/routes/vault.py
@@ -368,6 +368,53 @@ async def upsert_credential_profile(
     )
 
 
+@router.get("/credential-profiles", response_model=list[VaultCredentialProfileResponse])
+async def list_credential_profiles(
+    tool: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=80,
+        pattern=r"^[A-Za-z0-9_.-]+$",
+    ),
+    project_id: UUID | None = Query(default=None),
+    auth: AuthContext = Depends(require_user_auth),
+    db: AsyncSession = Depends(get_session),
+) -> list[VaultCredentialProfileResponse]:
+    """List credential profile metadata without returning encrypted payloads.
+
+    The web dashboard needs this to offer profiles imported by the local CLI.
+    Materialization still goes through the CLI-only resolve endpoint below.
+    """
+    _require_user_level_credential_profile_auth(auth)
+    if project_id is not None:
+        await validate_project_for_caller(db, auth, project_id)
+        selected_project_id = project_id
+    else:
+        selected_project_id = await resolve_personal_project(db, auth)
+
+    query = select(VaultCredentialProfile).where(
+        VaultCredentialProfile.user_id == auth.user_id,
+        VaultCredentialProfile.project_id == selected_project_id,
+    )
+    if tool is not None:
+        query = query.where(VaultCredentialProfile.tool == tool)
+    query = query.order_by(
+        VaultCredentialProfile.tool.asc(),
+        VaultCredentialProfile.profile.asc(),
+    )
+    rows = (await db.execute(query)).scalars().all()
+    return [
+        VaultCredentialProfileResponse(
+            id=str(profile.id),
+            project_id=str(profile.project_id),
+            tool=profile.tool,
+            profile=profile.profile,
+            updated_at=profile.updated_at,
+        )
+        for profile in rows
+    ]
+
+
 @router.post("/credential-profiles/resolve")
 async def resolve_credential_profile(
     body: VaultCredentialProfileResolveRequest,

--- a/backend/tests/test_vault.py
+++ b/backend/tests/test_vault.py
@@ -357,6 +357,45 @@ async def test_vault_credential_profile_defaults_to_personal_project(
 
 
 @pytest.mark.asyncio
+async def test_vault_credential_profile_list_metadata_for_web(
+    client: httpx.AsyncClient,
+    db_session,
+    seed_user,
+    seed_project,
+):
+    from app.services.vault_crypto import encrypt
+
+    payload = '{"kind":"local_agent_profile","secret":"codex-token"}'
+    ciphertext, nonce = encrypt(payload)
+    db_session.add(
+        VaultCredentialProfile(
+            user_id=seed_user.id,
+            project_id=seed_project.id,
+            tool="codex",
+            profile="work",
+            encrypted_payload=ciphertext,
+            nonce=nonce,
+        )
+    )
+    await db_session.commit()
+
+    listed = await client.get("/api/vault/credential-profiles?tool=codex")
+    assert listed.status_code == 200, listed.text
+    body = listed.json()
+    assert body == [
+        {
+            "id": body[0]["id"],
+            "project_id": str(seed_project.id),
+            "tool": "codex",
+            "profile": "work",
+            "updated_at": body[0]["updated_at"],
+        }
+    ]
+    assert "payload" not in body[0]
+    assert "codex-token" not in listed.text
+
+
+@pytest.mark.asyncio
 async def test_vault_credential_profile_shared_project_viewer_cannot_resolve(
     cli_client: httpx.AsyncClient,
     db_session,
@@ -546,6 +585,9 @@ async def test_vault_credential_profile_rejects_env_bound_agent_key(db_session, 
                 json={"tool": "codex", "profile": "default"},
             )
             assert resolved.status_code == 403, resolved.text
+
+            listed = await ac.get("/api/vault/credential-profiles?tool=codex")
+            assert listed.status_code == 403, listed.text
     finally:
         app.dependency_overrides.clear()
 

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1275,7 +1275,14 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /**
+         * List Credential Profiles
+         * @description List credential profile metadata without returning encrypted payloads.
+         *
+         *     The web dashboard needs this to offer profiles imported by the local CLI.
+         *     Materialization still goes through the CLI-only resolve endpoint below.
+         */
+        get: operations["list_credential_profiles_api_vault_credential_profiles_get"];
         put?: never;
         /**
          * Upsert Credential Profile
@@ -6104,6 +6111,38 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["VaultItemsDeleteResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_credential_profiles_api_vault_credential_profiles_get: {
+        parameters: {
+            query?: {
+                tool?: string | null;
+                project_id?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["VaultCredentialProfileResponse"][];
                 };
             };
             /** @description Validation Error */

--- a/scripts/vault-e2e.sh
+++ b/scripts/vault-e2e.sh
@@ -8,6 +8,7 @@
 #   4. seed a synthetic user + env-bound API key
 #   5. use the CLI to import vault values, read/inject/run clawdi:// refs
 #   6. use the CLI to import/materialize Codex, Claude Code, and gh credentials
+#   7. verify credential profile metadata listing with user-level auth only
 #
 # No real credentials are read. Every HOME / tool config path is under mktemp.
 #
@@ -328,6 +329,32 @@ credential_case() {
 }
 
 credential_case "codex" ".codex/auth.json" '{"token":"codex-real-e2e-secret"}'$'\n' "codex-real-e2e-secret"
+curl -sf \
+  -H "Authorization: Bearer $USER_RAW_KEY" \
+  "$API_URL/api/vault/credential-profiles?tool=codex" \
+  >"$LOG_DIR/credential-codex-list.json" \
+  || fail "credential profile metadata list failed"
+"$(command -v bun)" -e '
+const fs = require("fs");
+const rows = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+if (!rows.some((row) => row.tool === "codex" && row.profile === "e2e")) {
+  console.error("codex profile e2e was not listed");
+  process.exit(1);
+}
+if (JSON.stringify(rows).includes("codex-real-e2e-secret")) {
+  console.error("credential metadata leaked a secret");
+  process.exit(2);
+}
+' "$LOG_DIR/credential-codex-list.json" || fail "credential profile metadata response was invalid"
+ENV_BOUND_LIST_STATUS="$(
+  curl -s \
+    -o "$LOG_DIR/credential-codex-list-env-bound.out" \
+    -w "%{http_code}" \
+    -H "Authorization: Bearer $RAW_KEY" \
+    "$API_URL/api/vault/credential-profiles?tool=codex"
+)"
+[ "$ENV_BOUND_LIST_STATUS" = "403" ] || fail "env-bound agent key listed credential profile metadata"
+ok "credential profile metadata listing passed"
 credential_case "claude-code" ".claude/.credentials.json" '{"accessToken":"claude-real-e2e-secret"}'$'\n' "claude-real-e2e-secret"
 credential_case "gh" ".config/gh/hosts.yml" 'github.com:
   oauth_token: gh-real-e2e-secret


### PR DESCRIPTION
## Summary
- Add `GET /api/vault/credential-profiles` for credential profile metadata without decrypted payloads.
- Keep credential profile listing restricted to user-level auth; env-bound agent keys still receive 403.
- Regenerate the shared OpenAPI TypeScript client and extend vault E2E coverage.

## Tests
- `uv run pytest -q tests/test_vault.py -k "credential_profile"`
- `uv run python scripts/check_generated_api.py`
- `uv run ruff check app/routes/vault.py tests/test_vault.py`
- `git diff --check`
- `bunx biome check packages/shared/src/api/api.generated.ts`