### PR TITLE
Release CLI 0.10.1 and session sync fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,45 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.10.1
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.10.1
+
+Package: `clawdi@0.10.1`
+
+### Fixed
+
+- Fixed `clawdi update` choosing Bun just because `bun` was on `PATH`. The
+  updater now prefers the package manager that owns the currently running
+  `clawdi` binary, so npm-installed CLIs update with npm and Bun-installed CLIs
+  update with Bun.
+- Reduced live-sync daemon noise during transient Cloud SSE reconnects and
+  heartbeat timeouts. Short reconnect bursts are now classified as transient;
+  only sustained failures are written to `last_sync_error` or logged as warning
+  signals.
+- Fixed AI Provider OpenClaw import round-trips, stale runtime env display after
+  auth edits, and local no-auth endpoint validation parity between CLI and
+  backend.
+- Clarified that Codex provider auth should use `clawdi ai-provider
+  import-auth/connect/materialize-auth`; lower-level `agent credentials` commands
+  remain a compatibility backup/restore surface.
+
+## Clawdi 2026-06-03-2
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-2026-06-03-2
+
+### Fixed
+
+- Fixed session sync failures when an agent runtime reported structured provider
+  configuration or very long strings in the `model` field. Clawdi now extracts a
+  usable model id when possible and caps stored model labels to the database
+  limit instead of returning a 500.
+
+### Security
+
+- Hardened backend database error logging so SQL bound parameter values are not
+  written to logs when an unexpected database exception occurs.
+
 ## Clawdi CLI v0.10.0
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.10.0

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Clawdi is the shared layer underneath:
 - **Project sharing** — Share read-only Project access from the dashboard or CLI, accept it from a share page or CLI inbox, and explicitly attach accepted Projects to Agents when they should be used at runtime.
 - **Session sync** — Push local session history to the dashboard for review and recall.
 - **Vault secrets** — Store secrets server-side, commit only `clawdi://` references, and resolve them at runtime.
-- **AI Providers** — Define model providers once, keep keys in env/Vault/auth profiles, and apply verified Codex or Hermes agent config without proxying BYOK model traffic.
+- **AI Providers** — Define model providers once, keep keys in env/Vault/auth profiles, and apply verified Codex, Hermes, or OpenClaw agent config without proxying BYOK model traffic.
 - **App connections** — Hook agents into Notion, Gmail, Drive, Calendar, Linear, GitHub, and more from the dashboard. Tools show up inside every connected agent automatically over MCP.
 - **MCP tools** — Memory, vault, and connector tools served through the Model Context Protocol so any MCP-aware agent can use them.
 
@@ -114,18 +114,61 @@ Agents should prefer `clawdi run --env-file .env.clawdi -- <command>` when they 
 
 Use `--dry-run` on `clawdi read`, `clawdi inject`, `clawdi run`, and `clawdi vault resolve` to verify provenance without requesting plaintext values. `clawdi doctor` checks vault metadata only; it does not resolve stored secrets.
 
-Sync a local agent CLI credential profile to another machine:
+Sync a local CLI credential profile to another machine. For Codex model-provider
+auth, prefer the AI Provider commands in the next section; the lower-level
+`agent credentials` commands remain available for compatibility and for
+non-provider CLI credentials such as Claude Code and GitHub CLI.
 
 ```bash
-clawdi agent credentials import codex
 clawdi agent credentials import claude-code
 clawdi agent credentials import gh
-clawdi agent credentials materialize codex
 clawdi agent credentials materialize claude-code
 clawdi agent credentials materialize gh
 ```
 
 Credential profile sync is separate from `clawdi run`: it stores and restores a supported tool's local auth file, while `run` injects explicit `clawdi://` references into one child process. Profiles default to your stable Personal Project so `import` on one machine and `materialize` on another resolve the same namespace. They are personal backup/restore artifacts: shared Project viewers and env-bound Agent keys cannot materialize them. macOS Keychain imports are guarded behind `--source keychain` and require explicit `--keychain-service` plus `--keychain-account`; Clawdi does not guess or silently scrape credential-store items, and Keychain reads cannot use `--yes`.
+
+Manage model providers without turning Clawdi into a model proxy:
+
+```bash
+clawdi ai-provider add openai-main \
+  --type openai \
+  --default-model gpt-5.2 \
+  --auth env:OPENAI_API_KEY \
+  --capability chat \
+  --capability responses \
+  --capability tools
+
+clawdi ai-provider validate openai-main
+clawdi ai-provider test openai-main        # config + auth availability
+clawdi ai-provider test openai-main --live # optional direct provider probe
+```
+
+AI Provider metadata lives in `~/.clawdi/ai-providers/catalog.json`; API keys do not. Use `env:...` refs, `clawdi://...` Vault refs, `none` for local unauthenticated endpoints, or a verified auth profile such as `agent:codex/default`. BYOK model requests still go directly from the agent runtime to OpenAI, Anthropic, OpenRouter, Gemini, Mistral, or your compatible endpoint.
+
+Apply provider config explicitly, with a dry run first:
+
+```bash
+clawdi ai-provider apply --engine codex --dry-run
+clawdi ai-provider apply --engine codex
+codex --profile clawdi-ai-provider
+
+clawdi ai-provider apply --engine hermes --dry-run
+clawdi ai-provider apply --engine openclaw --dry-run
+```
+
+Codex OAuth is managed through the AI Provider surface:
+
+```bash
+clawdi ai-provider add openai-codex \
+  --type openai \
+  --default-model gpt-5-codex \
+  --auth agent:codex/default
+clawdi ai-provider connect openai-codex --tool codex
+clawdi ai-provider materialize-auth openai-codex
+```
+
+Use `clawdi ai-provider connect ... --callback manual` in headless environments. Export/import is metadata-only by default; `--include-secrets` requires passphrase-encrypted secret export.
 
 Current vault storage is server-managed encryption. Clawdi avoids plaintext secrets in repo files and local templates, but the backend can decrypt stored vault values and credential profiles today. Do not treat this release as zero-knowledge.
 
@@ -266,9 +309,8 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](packages/cli
 | `clawdi project create/list/show/share/share-links/invite/invites/members/leave/unshare` | Manage Projects and read-only sharing |
 | `clawdi inbox [accept/decline/forget]` | Accept invitations and share links |
 | `clawdi agent projects list/attach/detach/move` | View the fixed Agent Project and manage attached Projects |
-| `clawdi agent credentials import/materialize` | Sync local CLI credential profiles for Codex, Claude Code, and GitHub CLI; explicit Keychain import requires service/account options |
-| `clawdi ai-provider ...` | Manage portable model providers, auth refs, Codex OAuth/profile auth, tests, and provider-only export/import |
-| `clawdi ai-provider apply/status` | Preview AI Provider agent config changes, apply verified Codex/Hermes config, and inspect apply state |
+| `clawdi agent credentials import/materialize` | Compatibility backup/restore for local CLI credential profiles; use `ai-provider import-auth/connect/materialize-auth` for Codex provider auth |
+| `clawdi ai-provider list/add/edit/remove/validate/test/connect/import-auth/materialize-auth/apply/status/export/import` | Manage portable model providers, auth refs, Codex OAuth/profile auth, tests, verified Codex/Hermes/OpenClaw agent config apply, and provider-only export/import |
 | `clawdi project folder link/status/unlink` | Link a local folder to a Project for vault reference selection |
 | `clawdi vault set/list/import/attach/detach/rm` | Manage encrypted secrets, Project access, and copy exact references |
 | `clawdi read <clawdi://...>` | Explicitly print one vault reference value |

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -13,6 +13,7 @@ from app.core.config import settings
 engine = create_async_engine(
     settings.database_url,
     echo=settings.debug,
+    hide_parameters=True,
     pool_size=settings.db_pool_size,
     max_overflow=settings.db_max_overflow,
     pool_timeout=settings.db_pool_timeout,

--- a/backend/app/routes/ai_providers.py
+++ b/backend/app/routes/ai_providers.py
@@ -930,7 +930,7 @@ def _validate_base_url(base_url: str, auth: AiProviderAuth) -> list[str]:
 
 
 def _is_loopback_host(hostname: str) -> bool:
-    return hostname in {"localhost", "127.0.0.1", "::1"}
+    return hostname in {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
 
 
 def _is_private_host(hostname: str) -> bool:

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -15,6 +15,8 @@ from pydantic import BaseModel, Field, StringConstraints, field_validator
 # the fix — strip on ingest so one bad record can't take the
 # batch down again.
 _LONE_SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
+_MODEL_FIELD_RE = re.compile(r"""["'](?:default|model)["']\s*:\s*["']([^"']+)["']""")
+_MAX_MODEL_LENGTH = 100
 
 
 # local_session_id flows straight into a file-store key
@@ -77,6 +79,23 @@ class SessionCreate(BaseModel):
             return None
         return _LONE_SURROGATE_RE.sub("", v)
 
+    @field_validator("model", mode="after")
+    @classmethod
+    def _clean_model(cls, v: str | None) -> str | None:
+        return _clean_model_value(v)
+
+    @field_validator("models_used", mode="after")
+    @classmethod
+    def _clean_models_used(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return None
+        models: list[str] = []
+        for raw in v:
+            model = _clean_model_value(raw)
+            if model and model not in models:
+                models.append(model)
+        return models or None
+
     @field_validator("started_at", "ended_at", "last_activity_at", mode="after")
     @classmethod
     def _coerce_to_utc(cls, v: datetime | None) -> datetime | None:
@@ -94,6 +113,23 @@ class SessionCreate(BaseModel):
         if v.tzinfo is None:
             return v.replace(tzinfo=UTC)
         return v
+
+
+def _clean_model_value(v: str | None) -> str | None:
+    if v is None:
+        return None
+    value = _LONE_SURROGATE_RE.sub("", v).strip()
+    if not value:
+        return None
+    if value.startswith("{"):
+        match = _MODEL_FIELD_RE.search(value)
+        if match:
+            value = match.group(1).strip()
+        else:
+            return None
+    if not value:
+        return None
+    return value[:_MAX_MODEL_LENGTH]
 
 
 class SessionBatchRequest(BaseModel):

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -206,6 +206,29 @@ async def test_ai_provider_rejects_invalid_auth_and_api_mode(client: httpx.Async
 
 
 @pytest.mark.asyncio
+async def test_ai_provider_allows_no_auth_local_endpoints(client: httpx.AsyncClient):
+    for index, base_url in enumerate(
+        [
+            "http://localhost:1234/v1",
+            "http://127.0.0.1:1234/v1",
+            "http://[::1]:1234/v1",
+            "http://0.0.0.0:1234/v1",
+        ],
+    ):
+        created = await client.post(
+            "/api/ai-providers",
+            json={
+                "provider_id": f"local-model-{index}",
+                "type": "custom_openai_compatible",
+                "base_url": base_url,
+                "api_mode": "openai_chat",
+                "auth": {"type": "none"},
+            },
+        )
+        assert created.status_code == 200, created.text
+
+
+@pytest.mark.asyncio
 async def test_ai_provider_managed_api_key_is_redacted(client: httpx.AsyncClient):
     created = await client.post(
         "/api/ai-providers",

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -76,6 +76,43 @@ async def test_session_batch_upserts_and_returns_needs_content(client: httpx.Asy
 
 
 @pytest.mark.asyncio
+async def test_session_batch_cleans_structured_and_long_model_values(client: httpx.AsyncClient):
+    env_id = await _register_env(client)
+    started = datetime.now(UTC).isoformat()
+    structured_model = (
+        "{'default': 'gpt-5.3-codex', 'provider': 'openai-codex', "
+        "'base_url': 'https://example.invalid/v1', "
+        "'headers': {'x-api-key': 'sk-redacted'}}"
+    )
+    long_model = "custom-" + ("x" * 160)
+
+    r = await client.post(
+        "/api/sessions/batch",
+        json={
+            "sessions": [
+                {
+                    "environment_id": env_id,
+                    "local_session_id": "sess-structured-model",
+                    "started_at": started,
+                    "model": structured_model,
+                    "models_used": [structured_model, long_model],
+                    "content_hash": "c" * 64,
+                }
+            ]
+        },
+    )
+    assert r.status_code == 200, r.text
+
+    listing = (await client.get("/api/sessions")).json()
+    session = next(
+        item for item in listing["items"] if item["local_session_id"] == "sess-structured-model"
+    )
+    assert session["model"] == "gpt-5.3-codex"
+    assert session["models_used"][0] == "gpt-5.3-codex"
+    assert len(session["models_used"][1]) == 100
+
+
+@pytest.mark.asyncio
 async def test_session_batch_unchanged_when_hash_matches_and_content_uploaded(
     client: httpx.AsyncClient,
 ):

--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/ai-provider-isolated-e2e.md
+++ b/docs/ai-provider-isolated-e2e.md
@@ -19,6 +19,7 @@ or Python packages on the host machine.
 
 - Date: 2026-06-03
 - Branch: `feat/ai-provider-abstraction`
+- Latest rerun: 2026-06-03 on `review/cli-release-readiness`
 - Container image: `node:24-bookworm-slim`
 - Container-only installs:
   - `bun@1.3.14`

--- a/docs/scenarios/project-sharing-agent-bindings-demo.md
+++ b/docs/scenarios/project-sharing-agent-bindings-demo.md
@@ -275,15 +275,15 @@ Project-aware skill commands target a project explicitly when needed.
 ```bash
 clawdi skill list --project @alice/engineering --json
 clawdi skill add ./deploy-helper --project engineering --yes
-clawdi skill install owner/repo/path --project engineering --yes
+clawdi skill install owner/repo/path --project engineering
 clawdi skill rm deploy-helper --project engineering
-clawdi pull --modules skills --project @alice/engineering --agent codex --yes
+clawdi pull --modules skills --project @alice/engineering --agent codex
 ```
 
 Session push `--project` remains a local path filter:
 
 ```bash
-clawdi push --modules sessions --project ~/work/client-a --agent codex --yes
+clawdi push --modules sessions --project ~/work/client-a --agent codex
 ```
 
 Expected:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -76,6 +76,7 @@ Clawdi is the shared layer underneath:
 - **Project sharing** — Share read-only Project access from the dashboard or CLI, accept it from a share page or CLI inbox, and explicitly attach accepted Projects to Agents when they should be used at runtime.
 - **Session sync** — Push local session history to the dashboard for review and recall.
 - **Vault secrets** — Store secrets server-side, commit only `clawdi://` references, and resolve them at runtime.
+- **AI Providers** — Define model providers once, keep keys in env/Vault/auth profiles, and apply verified Codex, Hermes, or OpenClaw agent config without proxying BYOK model traffic.
 - **App connections** — Hook agents into Notion, Gmail, Drive, Calendar, Linear, GitHub, and more from the dashboard. Tools show up inside every connected agent automatically over MCP.
 - **MCP tools** — Memory, vault, and connector tools served through the Model Context Protocol so any MCP-aware agent can use them.
 
@@ -107,18 +108,61 @@ Agents should prefer `clawdi run --env-file .env.clawdi -- <command>` when they 
 
 Use `--dry-run` on `clawdi read`, `clawdi inject`, `clawdi run`, and `clawdi vault resolve` to verify provenance without requesting plaintext values. `clawdi doctor` checks vault metadata only; it does not resolve stored secrets.
 
-Sync a local agent CLI credential profile to another machine:
+Sync a local CLI credential profile to another machine. For Codex model-provider
+auth, prefer the AI Provider commands in the next section; the lower-level
+`agent credentials` commands remain available for compatibility and for
+non-provider CLI credentials such as Claude Code and GitHub CLI.
 
 ```bash
-clawdi agent credentials import codex
 clawdi agent credentials import claude-code
 clawdi agent credentials import gh
-clawdi agent credentials materialize codex
 clawdi agent credentials materialize claude-code
 clawdi agent credentials materialize gh
 ```
 
 Credential profile sync is separate from `clawdi run`: it stores and restores a supported tool's local auth file, while `run` injects explicit `clawdi://` references into one child process. Profiles default to your stable Personal Project so `import` on one machine and `materialize` on another resolve the same namespace. They are personal backup/restore artifacts: shared Project viewers and env-bound Agent keys cannot materialize them. macOS Keychain imports are guarded behind `--source keychain` and require explicit `--keychain-service` plus `--keychain-account`; Clawdi does not guess or silently scrape credential-store items, and Keychain reads cannot use `--yes`.
+
+Manage model providers without turning Clawdi into a model proxy:
+
+```bash
+clawdi ai-provider add openai-main \
+  --type openai \
+  --default-model gpt-5.2 \
+  --auth env:OPENAI_API_KEY \
+  --capability chat \
+  --capability responses \
+  --capability tools
+
+clawdi ai-provider validate openai-main
+clawdi ai-provider test openai-main        # config + auth availability
+clawdi ai-provider test openai-main --live # optional direct provider probe
+```
+
+AI Provider metadata lives in `~/.clawdi/ai-providers/catalog.json`; API keys do not. Use `env:...` refs, `clawdi://...` Vault refs, `none` for local unauthenticated endpoints, or a verified auth profile such as `agent:codex/default`. BYOK model requests still go directly from the agent runtime to OpenAI, Anthropic, OpenRouter, Gemini, Mistral, or your compatible endpoint.
+
+Apply provider config explicitly, with a dry run first:
+
+```bash
+clawdi ai-provider apply --engine codex --dry-run
+clawdi ai-provider apply --engine codex
+codex --profile clawdi-ai-provider
+
+clawdi ai-provider apply --engine hermes --dry-run
+clawdi ai-provider apply --engine openclaw --dry-run
+```
+
+Codex OAuth is managed through the AI Provider surface:
+
+```bash
+clawdi ai-provider add openai-codex \
+  --type openai \
+  --default-model gpt-5-codex \
+  --auth agent:codex/default
+clawdi ai-provider connect openai-codex --tool codex
+clawdi ai-provider materialize-auth openai-codex
+```
+
+Use `clawdi ai-provider connect ... --callback manual` in headless environments. Export/import is metadata-only by default; `--include-secrets` requires passphrase-encrypted secret export.
 
 Current vault storage is server-managed encryption. Clawdi avoids plaintext secrets in repo files and local templates, but the backend can decrypt stored vault values and credential profiles today. Do not treat this release as zero-knowledge.
 
@@ -258,7 +302,8 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](https://gith
 | `clawdi project create/list/show/share/share-links/invite/invites/members/leave/unshare` | Manage Projects and read-only sharing |
 | `clawdi inbox [accept/decline/forget]` | Accept invitations and share links |
 | `clawdi agent projects list/attach/detach/move` | View the fixed Agent Project and manage attached Projects |
-| `clawdi agent credentials import/materialize` | Sync local CLI credential profiles for Codex, Claude Code, and GitHub CLI; explicit Keychain import requires service/account options |
+| `clawdi agent credentials import/materialize` | Compatibility backup/restore for local CLI credential profiles; use `ai-provider import-auth/connect/materialize-auth` for Codex provider auth |
+| `clawdi ai-provider list/add/edit/remove/validate/test/connect/import-auth/materialize-auth/apply/status/export/import` | Manage reusable AI Providers, provider auth, and verified agent config application |
 | `clawdi project folder link/status/unlink` | Link a local folder to a Project for vault reference selection |
 | `clawdi vault set/list/import/attach/detach/rm` | Manage encrypted secrets, Project access, and copy exact references |
 | `clawdi read <clawdi://...>` | Explicitly print one vault reference value |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/skills/clawdi/SKILL.md
+++ b/packages/cli/skills/clawdi/SKILL.md
@@ -100,3 +100,16 @@ When the user asks to migrate secrets into Clawdi Vault or script secret writes,
 - Use `clawdi vault detach <vault> --project <project>` to remove one Project's access without deleting keys.
 - Use `clawdi vault rm <vault>/<section>/<field> --global --yes` only when the key should be deleted from the shared Vault for every attached Project.
 - Prefer exact `clawdi://project/...` references printed by the CLI. Do not print plaintext secret values unless the user explicitly asks for them.
+
+## AI Provider CLI
+
+When the user asks to configure model providers, API keys, or Codex OAuth for agents, use `clawdi ai-provider`:
+
+- Add reusable providers with `clawdi ai-provider add <id> --type <openai|anthropic|openrouter|gemini|mistral|custom_openai_compatible> --default-model <model> --auth <env:KEY|clawdi://...|agent:codex/profile|none>`.
+- Validate metadata with `clawdi ai-provider validate [provider-id]`.
+- Check local auth availability with `clawdi ai-provider test <provider-id>`; add `--live` only when the user explicitly wants a real provider API probe.
+- Apply agent config with `clawdi ai-provider apply --engine codex|hermes|openclaw --dry-run` first, then run without `--dry-run` if the diff is acceptable.
+- Connect Codex OAuth with `clawdi ai-provider connect <provider-id> --tool codex`; use `--callback manual` when loopback localhost cannot be reached.
+- Materialize a stored provider auth profile with `clawdi ai-provider materialize-auth <provider-id>`.
+- Default export/import is metadata-only; `--include-secrets` requires passphrase-encrypted secret export.
+- BYOK model requests go directly from the agent runtime to the configured provider. Clawdi stores metadata and secret references but is not a model proxy.

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -68,7 +68,7 @@ function parseModelField(raw: string | null): string | null {
 			const obj = JSON.parse(raw);
 			return obj.default || obj.model || null;
 		} catch {
-			return raw;
+			return /['"](?:default|model)['"]\s*:\s*['"]([^'"]+)['"]/.exec(raw)?.[1] ?? null;
 		}
 	}
 	return raw;

--- a/packages/cli/src/commands/ai-provider-apply.ts
+++ b/packages/cli/src/commands/ai-provider-apply.ts
@@ -95,7 +95,7 @@ export async function aiProviderStatusCommand(opts: AiProviderStatusOptions = {}
 		type: provider.type,
 		default_model: provider.default_model ?? null,
 		auth: describeAuth(provider),
-		agent_env_name: provider.runtime_env_name ?? inferredAgentEnvName(provider) ?? null,
+		agent_env_name: inferredAgentEnvName(provider) ?? provider.runtime_env_name ?? null,
 	}));
 	const agents = (["openclaw", "hermes", "codex"] as const).map((engine) =>
 		inspectAiProviderAgentApply(engine),

--- a/packages/cli/src/commands/ai-provider.ts
+++ b/packages/cli/src/commands/ai-provider.ts
@@ -139,7 +139,6 @@ interface AiProviderConnectOptions {
 	redirectUri?: string;
 	timeout?: string;
 	open?: boolean;
-	yes?: boolean;
 	dryRun?: boolean;
 	json?: boolean;
 }
@@ -925,7 +924,8 @@ function buildProvider(
 		provider.default_model = opts.defaultModel ?? existing?.default_model;
 	}
 	if (apiMode) provider.api_mode = apiMode;
-	const agentEnv = opts.agentEnv ?? existing?.runtime_env_name;
+	const agentEnv =
+		opts.agentEnv ?? (authNeedsSeparateRuntimeEnv(auth) ? existing?.runtime_env_name : undefined);
 	if (agentEnv) {
 		if (!isRuntimeEnvName(agentEnv)) throw new Error(`Invalid agent env name: ${agentEnv}`);
 		provider.runtime_env_name = agentEnv;
@@ -970,6 +970,12 @@ function parseAuth(input: string): AiProviderAuth {
 	throw new Error(
 		"Unsupported --auth. Use env:<NAME>, clawdi://..., agent:codex/<profile>, or none.",
 	);
+}
+
+function authNeedsSeparateRuntimeEnv(auth: AiProviderAuth): boolean {
+	if (auth.type === "secret_ref") return !auth.ref.startsWith("env:");
+	if (auth.type === "api_key") return auth.source !== "env";
+	return false;
 }
 
 function parseProfileRef(input: string): { provider: string; profile: string } {
@@ -1254,13 +1260,23 @@ function catalogFromOpenClawConfig(input: unknown): AiProviderCatalog {
 	for (const [id, value] of Object.entries(providerMap)) {
 		if (!isAiProviderId(id)) continue;
 		const entry = asRecord(value, `OpenClaw provider ${id}`);
-		const type = parseProviderType(
-			String(entry.type ?? entry.provider ?? "custom_openai_compatible"),
-		);
 		const baseUrl = stringField(entry, "baseUrl") ?? stringField(entry, "base_url");
 		if (!baseUrl) continue;
-		const apiModeInput = stringField(entry, "apiMode") ?? stringField(entry, "api_mode");
-		const keyEnv = stringField(entry, "keyEnv") ?? stringField(entry, "key_env");
+		const apiMode =
+			openClawApiModeFromLabel(stringField(entry, "api")) ??
+			parseApiMode(stringField(entry, "apiMode") ?? stringField(entry, "api_mode"));
+		const type = parseProviderType(
+			stringField(entry, "type") ??
+				stringField(entry, "provider") ??
+				inferProviderTypeFromEndpoint(id, baseUrl, {
+					api_mode: apiMode ?? stringField(entry, "api"),
+				}),
+		);
+		const keyEnv =
+			stringField(entry, "keyEnv") ??
+			stringField(entry, "key_env") ??
+			openClawApiKeyEnv(entry.apiKey) ??
+			openClawApiKeyEnv(entry.api_key);
 		const modelId = firstModelId(entry.models);
 		const provider: AiProvider = {
 			id,
@@ -1269,8 +1285,7 @@ function catalogFromOpenClawConfig(input: unknown): AiProviderCatalog {
 			auth: keyEnv ? { type: "secret_ref", ref: `env:${keyEnv}` } : { type: "none" },
 		};
 		if (modelId) provider.default_model = modelId;
-		const apiMode = parseApiMode(apiModeInput ?? defaultAiProviderApiMode(type));
-		if (apiMode) provider.api_mode = apiMode;
+		provider.api_mode = apiMode ?? defaultAiProviderApiMode(type);
 		if (keyEnv) provider.runtime_env_name = keyEnv;
 		providers.push(provider);
 	}
@@ -1397,6 +1412,14 @@ function aiApiModeFromHermesTransport(input: string | undefined): AiProviderApiM
 	return undefined;
 }
 
+function openClawApiModeFromLabel(input: string | undefined): AiProviderApiMode | undefined {
+	if (input === "openai-completions") return "openai_chat";
+	if (input === "openai-responses") return "openai_responses";
+	if (input === "anthropic-messages") return "anthropic_messages";
+	if (input === "google-generative-ai") return "google_generate_content";
+	return undefined;
+}
+
 function normalizeHermesProviderSelector(input: string | undefined): string | undefined {
 	if (!input) return undefined;
 	const providerId = input.startsWith("custom:") ? input.slice("custom:".length) : input;
@@ -1466,9 +1489,22 @@ function defaultProviderFromOpenClaw(root: Record<string, unknown>): AiProviderC
 	if (typeof defaults !== "object" || defaults === null || Array.isArray(defaults))
 		return undefined;
 	const model = (defaults as Record<string, unknown>).model;
-	if (typeof model !== "string") return undefined;
-	const providerId = model.split("/")[0];
+	const modelRef =
+		typeof model === "string"
+			? model
+			: typeof model === "object" && model !== null && !Array.isArray(model)
+				? (model as Record<string, unknown>).primary
+				: undefined;
+	if (typeof modelRef !== "string") return undefined;
+	const providerId = modelRef.split("/")[0];
 	return isAiProviderId(providerId) ? { chat_provider_id: providerId } : undefined;
+}
+
+function openClawApiKeyEnv(input: unknown): string | undefined {
+	if (typeof input !== "object" || input === null || Array.isArray(input)) return undefined;
+	const record = input as Record<string, unknown>;
+	if (record.source !== "env") return undefined;
+	return typeof record.id === "string" ? record.id : undefined;
 }
 
 function describeAuth(auth: AiProviderAuth): string {

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -33,12 +33,19 @@ interface MeResponse {
  * copies the URL out of the terminal. We don't want to crash the login flow
  * over a missing `xdg-open`.
  */
+export function browserOpenCommand(
+	url: string,
+	platform: NodeJS.Platform = process.platform,
+): { command: string; args: string[] } {
+	if (platform === "darwin") return { command: "open", args: [url] };
+	if (platform === "win32") return { command: "cmd", args: ["/c", "start", "", url] };
+	return { command: "xdg-open", args: [url] };
+}
+
 function openInBrowser(url: string): void {
-	const cmd =
-		process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
+	const { command, args } = browserOpenCommand(url);
 	try {
-		const args = process.platform === "win32" ? ["", url] : [url];
-		const child = spawn(cmd, args, { stdio: "ignore", detached: true });
+		const child = spawn(command, args, { stdio: "ignore", detached: true });
 		child.on("error", () => {
 			/* opener missing — user copies URL manually */
 		});

--- a/packages/cli/src/commands/pull.ts
+++ b/packages/cli/src/commands/pull.ts
@@ -32,14 +32,13 @@ interface PullOpts {
 	agent?: string;
 	allAgents?: boolean;
 	all?: boolean;
-	yes?: boolean;
 }
 
 /**
  * What `scanOneAgent` found for a single agent: the skills and sessions
  * staged for download. Splitting scan from download lets `pull` show a
- * combined, per-agent summary across every target agent and ask for ONE
- * confirmation — the same shape as `clawdi push`.
+ * combined, per-agent summary across every target agent before downloading,
+ * the same shape as `clawdi push`.
  */
 interface AgentPullScan {
 	agentType: AgentType;
@@ -130,7 +129,7 @@ export async function pull(opts: PullOpts) {
 	}
 	scanSpinner.stop("Scan complete.");
 
-	// Combined per-agent summary, visible in full before the confirmation.
+	// Combined per-agent summary, visible in full before downloads begin.
 	for (const scan of scans) {
 		const name = adapterRegistry[scan.agentType].displayName;
 		const bits: string[] = [];
@@ -403,16 +402,16 @@ async function fetchCloudSessions(
 ): Promise<SessionListItem[]> {
 	const all: SessionListItem[] = [];
 	const pageSize = 200;
-	for (let page = 1; ; page++) {
+	for (let page = 1; page <= 50; page++) {
 		const result = unwrap(
 			await api.GET("/api/sessions", {
 				params: { query: { agent: agentType, page, page_size: pageSize } },
 			}),
 		);
 		all.push(...result.items);
-		if (result.items.length < pageSize) break;
+		if (all.length >= (result.total ?? all.length) || result.items.length < pageSize) return all;
 	}
-	return all;
+	throw new Error("Too many session pages to pull safely.");
 }
 
 interface SessionMirrorMeta {

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -59,10 +59,9 @@ interface AgentUploadResult {
 /**
  * What `scanOneAgent` found for a single agent: the sessions and skills
  * staged for upload. Splitting scan from upload lets `push` show a
- * combined, per-agent summary across every target agent and ask for ONE
- * confirmation — instead of confirming each agent before the next is even
- * scanned (which made a multi-agent `clawdi push` look like it had only
- * picked the first agent).
+ * combined, per-agent summary across every target agent before uploading,
+ * instead of interleaving scan and upload per agent (which made a multi-agent
+ * `clawdi push` look like it had only picked the first agent).
  */
 interface AgentScanResult {
 	agentType: AgentType;
@@ -179,7 +178,7 @@ export async function push(opts: PushOpts) {
 	}
 
 	// Combined per-agent summary: every target agent, its counts, and
-	// any advisories — visible in full before the confirmation.
+	// any advisories — visible in full before uploads begin.
 	for (const scan of scans) {
 		const name = adapterRegistry[scan.agentType].displayName;
 		const bits: string[] = [];

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -301,7 +301,7 @@ export async function skillAdd(
 
 export async function skillInstall(
 	repoInput: string,
-	opts: { agent?: string; project?: string; list?: boolean; yes?: boolean } = {},
+	opts: { agent?: string; project?: string } = {},
 ) {
 	requireAuth();
 

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -5,11 +5,12 @@ import {
 	mkdirSync,
 	openSync,
 	readFileSync,
+	realpathSync,
 	rmSync,
 	statSync,
 	writeFileSync,
 } from "node:fs";
-import { join } from "node:path";
+import { dirname, join, normalize, resolve, sep } from "node:path";
 import chalk from "chalk";
 import { getClawdiDir, getStoredConfig } from "../lib/config";
 import { getCliVersion } from "../lib/version";
@@ -26,7 +27,7 @@ const REGISTRY_URL = "https://registry.npmjs.org/clawdi";
 const CACHE_TTL_MS = 60 * 60 * 1000;
 const DAEMON_UPDATE_INTERVAL_MS = 60 * 60 * 1000;
 const DAEMON_UPDATE_LOCK_STALE_MS = 15 * 60 * 1000;
-type Installer = "bun" | "npm";
+export type Installer = "bun" | "npm";
 
 interface UpdateCache {
 	checkedAt: string;
@@ -157,11 +158,12 @@ export async function update(opts: { json?: boolean; check?: boolean } = {}) {
 	// `--check` keeps the old display-only behavior for users who scripted
 	// against it (CI guards, custom dashboards). Default is now to install.
 	if (opts.check) {
+		const installer = detectInstaller();
 		console.log();
 		console.log(
 			chalk.cyan(`A newer version is available. Install with:`) +
 				"\n  " +
-				chalk.white("npm i -g clawdi"),
+				chalk.white(installCommand(installer)),
 		);
 		return;
 	}
@@ -172,7 +174,7 @@ export async function update(opts: { json?: boolean; check?: boolean } = {}) {
 		console.log(
 			chalk.yellow("Neither bun nor npm is on PATH; install manually:") +
 				"\n  " +
-				chalk.white("npm i -g clawdi"),
+				chalk.white(installCommand(null)),
 		);
 		return;
 	}
@@ -186,7 +188,7 @@ export async function update(opts: { json?: boolean; check?: boolean } = {}) {
 		console.log(
 			chalk.red(`Install failed (${installer} exited ${result.status}). Try manually:`) +
 				"\n  " +
-				chalk.white("npm i -g clawdi"),
+				chalk.white(installCommand(installer)),
 		);
 		process.exitCode = result.status ?? 1;
 		return;
@@ -212,16 +214,130 @@ function writeLastVersion(version: string): void {
 	}
 }
 
-function detectInstaller(): Installer | null {
-	for (const name of ["bun", "npm"] as const) {
-		try {
-			const r = spawnSync(name, ["--version"], { stdio: "ignore" });
-			if (r.status === 0) return name;
-		} catch {
-			// fall through
-		}
+export function detectInstaller(): Installer | null {
+	const available = {
+		bun: commandExists("bun"),
+		npm: commandExists("npm"),
+	};
+	if (!available.bun && !available.npm) return null;
+
+	const current = installerForCurrentInvocation(available);
+	if (current) return current;
+
+	// npm is the documented install path and is the safer default when the
+	// current executable cannot be mapped to a global install. If the current
+	// executable is Bun-managed, installerForCurrentInvocation catches it first.
+	if (available.npm) return "npm";
+	return available.bun ? "bun" : null;
+}
+
+function commandExists(command: string): boolean {
+	try {
+		const r = spawnSync(command, ["--version"], { stdio: "ignore" });
+		return r.status === 0;
+	} catch {
+		return false;
+	}
+}
+
+function installerForCurrentInvocation(available: Record<Installer, boolean>): Installer | null {
+	return detectInstallerFromPaths(process.argv[1], {
+		npmBin: available.npm ? npmGlobalBinDir() : null,
+		npmRoot: available.npm ? npmGlobalRootDir() : null,
+		bunBin: available.bun ? bunGlobalBinDir() : null,
+	});
+}
+
+export function detectInstallerFromPaths(
+	invokedPath: string | undefined,
+	paths: { bunBin?: string | null; npmBin?: string | null; npmRoot?: string | null },
+): Installer | null {
+	if (!invokedPath) return null;
+
+	const candidates = normalizedPathCandidates(invokedPath);
+	const npmBin = paths.npmBin ? normalizePath(paths.npmBin) : null;
+	const npmRoot = paths.npmRoot ? normalizePath(paths.npmRoot) : null;
+	const bunBin = paths.bunBin ? normalizePath(paths.bunBin) : null;
+
+	if (npmBin && candidates.some((candidate) => samePath(dirname(candidate), npmBin))) {
+		return "npm";
+	}
+	if (bunBin && candidates.some((candidate) => samePath(dirname(candidate), bunBin))) {
+		return "bun";
+	}
+	if (
+		npmRoot &&
+		candidates.some((candidate) => pathStartsWith(candidate, join(npmRoot, "clawdi")))
+	) {
+		return "npm";
+	}
+	if (
+		candidates.some((candidate) =>
+			candidate.includes(`${sep}.bun${sep}install${sep}global${sep}node_modules${sep}clawdi${sep}`),
+		)
+	) {
+		return "bun";
 	}
 	return null;
+}
+
+function npmGlobalBinDir(): string | null {
+	const prefix = commandOutput("npm", ["prefix", "-g"]);
+	if (!prefix) return null;
+	return process.platform === "win32" ? normalizePath(prefix) : normalizePath(join(prefix, "bin"));
+}
+
+function npmGlobalRootDir(): string | null {
+	const root = commandOutput("npm", ["root", "-g"]);
+	return root ? normalizePath(root) : null;
+}
+
+function bunGlobalBinDir(): string | null {
+	const bin = commandOutput("bun", ["pm", "bin", "-g"]);
+	return bin ? normalizePath(bin) : null;
+}
+
+function commandOutput(command: string, args: string[]): string | null {
+	try {
+		const result = spawnSync(command, args, { encoding: "utf-8" });
+		if (result.status !== 0) return null;
+		const stdout = typeof result.stdout === "string" ? result.stdout.trim() : "";
+		return stdout || null;
+	} catch {
+		return null;
+	}
+}
+
+function normalizedPathCandidates(path: string): string[] {
+	const paths = [normalizePath(path)];
+	try {
+		paths.push(normalizePath(realpathSync(path)));
+	} catch {
+		// The executable path does not need to exist in tests or unusual launchers.
+	}
+	return [...new Set(paths)];
+}
+
+function normalizePath(path: string): string {
+	return normalize(resolve(path));
+}
+
+function samePath(left: string, right: string): boolean {
+	if (process.platform === "win32") {
+		return normalizePath(left).toLowerCase() === normalizePath(right).toLowerCase();
+	}
+	return normalizePath(left) === normalizePath(right);
+}
+
+function pathStartsWith(path: string, parent: string): boolean {
+	const normalizedPath = normalizePath(path);
+	const normalizedParent = normalizePath(parent);
+	if (samePath(normalizedPath, normalizedParent)) return true;
+	const prefix = normalizedParent.endsWith(sep) ? normalizedParent : `${normalizedParent}${sep}`;
+	if (process.platform === "win32") {
+		return normalizedPath.toLowerCase().startsWith(prefix.toLowerCase());
+	}
+	return normalizedPath.startsWith(prefix);
 }
 
 function detectAutoUpdateInstaller(runtime: AutoUpdateRuntime): Installer | null {
@@ -230,6 +346,10 @@ function detectAutoUpdateInstaller(runtime: AutoUpdateRuntime): Installer | null
 
 function installArgs(installer: Installer): string[] {
 	return installer === "bun" ? ["add", "-g", "clawdi@latest"] : ["i", "-g", "clawdi@latest"];
+}
+
+export function installCommand(installer: Installer | null): string {
+	return installer === "bun" ? "bun add -g clawdi" : "npm i -g clawdi";
 }
 
 // `npx clawdi …` and `bunx clawdi …` install the package into a per-call

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -240,7 +240,6 @@ program
 		"--dry-run",
 		"Preview without downloading. Use to check which skills will be overwritten locally.",
 	)
-	.option("-y, --yes", "Skip confirmation prompts")
 	.addHelpText(
 		"after",
 		`
@@ -376,7 +375,6 @@ aiProviderCmd
 	.option("--redirect-uri <uri>", "Override OAuth redirect URI for manual callback mode")
 	.option("--timeout <seconds>", "Seconds to wait for loopback callback", "600")
 	.option("--no-open", "Do not open the browser automatically")
-	.option("-y, --yes", "Skip the post-login import confirmation prompt")
 	.option("--dry-run", "Show the OAuth start request without running it")
 	.option("--json", "Emit machine-readable JSON")
 	.action(async (providerId: string, opts) => {
@@ -725,8 +723,6 @@ skillCmd
 		"-p, --project <id-or-slug>",
 		"Install into an explicit owned project (UUID, slug, or name). Mutex with --agent.",
 	)
-	.option("-l, --list", "List skills in the repo without installing (planned)")
-	.option("-y, --yes", "Skip confirmation prompts")
 	.addHelpText(
 		"after",
 		`
@@ -1161,11 +1157,13 @@ agentCredentialsCmd
 		"after",
 		`
 Examples:
-  $ clawdi agent credentials import codex
   $ clawdi agent credentials import claude-code
   $ clawdi agent credentials import claude-code --source keychain --keychain-service <service> --keychain-account <account>
   $ clawdi agent credentials import gh
-  $ clawdi agent credentials import aws --from ~/.aws/credentials --to ~/.aws/credentials`,
+  $ clawdi agent credentials import aws --from ~/.aws/credentials --to ~/.aws/credentials
+
+Codex model-provider auth:
+  $ clawdi ai-provider import-auth openai-codex --tool codex`,
 	)
 	.action(async (tool: string, opts) => {
 		const { agentCredentialsImportCommand } = await import("./commands/agent-credentials.js");
@@ -1186,10 +1184,12 @@ agentCredentialsCmd
 		"after",
 		`
 Examples:
-  $ clawdi agent credentials materialize codex
   $ clawdi agent credentials materialize claude-code
   $ clawdi agent credentials materialize gh
-  $ clawdi agent credentials materialize aws --profile work --to ~/.aws/credentials`,
+  $ clawdi agent credentials materialize aws --profile work --to ~/.aws/credentials
+
+Codex model-provider auth:
+  $ clawdi ai-provider materialize-auth openai-codex`,
 	)
 	.action(async (tool: string, opts) => {
 		const { agentCredentialsMaterializeCommand } = await import("./commands/agent-credentials.js");

--- a/packages/cli/src/serve/sse-client.test.ts
+++ b/packages/cli/src/serve/sse-client.test.ts
@@ -6,13 +6,115 @@
  * that's easy to get wrong. These tests pin the behavior so a
  * future refactor can't silently start dropping events.
  *
- * End-to-end stream behavior (reconnect backoff, stale-silence
- * timer, 401 handling) is exercised by the daemon against a real
- * backend and not unit-tested here — too much asyncio plumbing.
+ * Full daemon stream behavior (long reconnect storms, stale-silence
+ * timer, 401 shutdown) is exercised against a real backend. The small
+ * reconnect-metadata unit tests below pin the CLI-side classification
+ * contract without needing a long-running daemon fixture.
  */
 
-import { describe, expect, it } from "bun:test";
-import { parseRecord } from "./sse-client";
+import { afterEach, describe, expect, it } from "bun:test";
+import { classifySseReconnect, consumeSse, parseRecord } from "./sse-client";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+describe("classifySseReconnect", () => {
+	it("treats the first few reconnects as transient churn", () => {
+		expect(classifySseReconnect(1)).toBe("transient");
+		expect(classifySseReconnect(2)).toBe("transient");
+		expect(classifySseReconnect(3)).toBe("transient");
+	});
+
+	it("promotes repeated reconnects to a sustained failure", () => {
+		expect(classifySseReconnect(4)).toBe("sustained");
+	});
+});
+
+describe("consumeSse reconnect metadata", () => {
+	it("reports request ids and transient classification for HTTP reconnects", async () => {
+		const fakeFetch: typeof fetch = Object.assign(
+			async () =>
+				new Response("bad gateway", {
+					status: 502,
+					headers: { "x-request-id": "req-sse-502" },
+				}),
+			{
+				preconnect: originalFetch.preconnect,
+			},
+		);
+		globalThis.fetch = fakeFetch;
+		const abort = new AbortController();
+		const disconnects: unknown[] = [];
+
+		await consumeSse({
+			apiUrl: "https://cloud.example",
+			apiKey: "test-key",
+			abort: abort.signal,
+			onEvent: () => {},
+			onDisconnect: (info) => {
+				disconnects.push(info);
+				abort.abort();
+			},
+		});
+
+		expect(disconnects).toEqual([
+			{
+				reason: "http_502",
+				attempt: 0,
+				wait_ms: expect.any(Number),
+				consecutive_failures: 1,
+				classification: "transient",
+				http_status: 502,
+				request_id: "req-sse-502",
+			},
+		]);
+	});
+
+	it("starts unstable close failure counts at one", async () => {
+		const fakeFetch: typeof fetch = Object.assign(
+			async () =>
+				new Response(
+					new ReadableStream<Uint8Array>({
+						start(controller) {
+							controller.close();
+						},
+					}),
+					{ status: 200 },
+				),
+			{
+				preconnect: originalFetch.preconnect,
+			},
+		);
+		globalThis.fetch = fakeFetch;
+		const abort = new AbortController();
+		const disconnects: unknown[] = [];
+
+		await consumeSse({
+			apiUrl: "https://cloud.example",
+			apiKey: "test-key",
+			abort: abort.signal,
+			onEvent: () => {},
+			onDisconnect: (info) => {
+				disconnects.push(info);
+				abort.abort();
+			},
+		});
+
+		expect(disconnects).toEqual([
+			{
+				reason: "unstable_close",
+				attempt: 0,
+				wait_ms: expect.any(Number),
+				consecutive_failures: 1,
+				classification: "transient",
+				first_byte_received: false,
+			},
+		]);
+	});
+});
 
 describe("parseRecord", () => {
 	it("parses a well-formed skill_changed record", () => {

--- a/packages/cli/src/serve/sse-client.ts
+++ b/packages/cli/src/serve/sse-client.ts
@@ -74,10 +74,39 @@ interface Opts {
 	onConnect?: () => void;
 	/** Called when the stream drops (network error, server close,
 	 * stale read). Daemon flips status to "reconnecting". */
-	onDisconnect?: (reason: string) => void;
+	onDisconnect?: (info: SseReconnectInfo) => void;
 	/** Called once on a 401, just before the consumer loop exits.
 	 * Daemon shuts down — the deploy-key won't come back. */
 	onAuthFailure?: () => void;
+}
+
+export type SseReconnectClassification = "transient" | "sustained";
+
+export interface SseReconnectInfo {
+	reason: string;
+	attempt: number;
+	wait_ms: number;
+	consecutive_failures: number;
+	classification: SseReconnectClassification;
+	first_byte_received?: boolean;
+	http_status?: number;
+	request_id?: string;
+}
+
+const TRANSIENT_RECONNECT_FAILURES = 3;
+
+class SseConnectionError extends Error {
+	readonly reason: string;
+	readonly httpStatus?: number;
+	readonly requestId?: string;
+
+	constructor(reason: string, fields?: { httpStatus?: number; requestId?: string | null }) {
+		super(reason);
+		this.name = "SseConnectionError";
+		this.reason = reason;
+		this.httpStatus = fields?.httpStatus;
+		this.requestId = fields?.requestId ?? undefined;
+	}
 }
 
 // Only reset the backoff counter if the connection survived this
@@ -108,33 +137,80 @@ export async function consumeSse(opts: Opts): Promise<void> {
 			if (firstByteAt !== null && Date.now() - firstByteAt >= STABLE_CONNECTION_MS) {
 				attempt = 0;
 			} else {
-				attempt += 1;
 				const wait = backoffMs(attempt);
-				log.warn("sse.reconnect_unstable_close", {
+				const info = buildReconnectInfo({
+					reason: "unstable_close",
 					attempt,
 					wait_ms: wait,
 					first_byte_received: firstByteAt !== null,
 				});
+				logReconnect("sse.reconnect_unstable_close", info);
+				opts.onDisconnect?.(info);
+				attempt += 1;
 				await sleep(wait, opts.abort);
 			}
 		} catch (err) {
 			if (opts.abort.aborted) return;
-			const reason = errorReason(err);
-			opts.onDisconnect?.(reason);
-			if (reason === "auth_failed") {
+			const error = errorInfo(err);
+			if (error.reason === "auth_failed") {
 				opts.onAuthFailure?.();
 				return;
 			}
 			// Honor Retry-After on 429 rate-limit. The error message
 			// carries the value as `rate_limited:<seconds>`; parse
 			// it and use as the floor for this reconnect's wait.
-			const rateLimitMs = parseRateLimit(reason);
+			const rateLimitMs = parseRateLimit(error.reason);
 			const wait = rateLimitMs ?? backoffMs(attempt);
-			log.warn("sse.reconnect", { reason, attempt, wait_ms: wait });
+			const info = buildReconnectInfo({
+				reason: error.reason,
+				attempt,
+				wait_ms: wait,
+				http_status: error.http_status,
+				request_id: error.request_id,
+			});
+			logReconnect("sse.reconnect", info);
+			opts.onDisconnect?.(info);
 			attempt += 1;
 			await sleep(wait, opts.abort);
 		}
 	}
+}
+
+export function classifySseReconnect(consecutiveFailures: number): SseReconnectClassification {
+	return consecutiveFailures <= TRANSIENT_RECONNECT_FAILURES ? "transient" : "sustained";
+}
+
+function buildReconnectInfo(
+	fields: Omit<SseReconnectInfo, "classification" | "consecutive_failures">,
+): SseReconnectInfo {
+	const consecutiveFailures = fields.attempt + 1;
+	return {
+		...fields,
+		consecutive_failures: consecutiveFailures,
+		classification: classifySseReconnect(consecutiveFailures),
+	};
+}
+
+function logReconnect(event: string, info: SseReconnectInfo): void {
+	const fields = pruneUndefined({
+		reason: info.reason,
+		attempt: info.attempt,
+		consecutive_failures: info.consecutive_failures,
+		wait_ms: info.wait_ms,
+		classification: info.classification,
+		first_byte_received: info.first_byte_received,
+		http_status: info.http_status,
+		request_id: info.request_id,
+	});
+	if (info.classification === "sustained") {
+		log.warn(event, fields);
+	} else {
+		log.info(event, fields);
+	}
+}
+
+function pruneUndefined(fields: Record<string, unknown>): Record<string, unknown> {
+	return Object.fromEntries(Object.entries(fields).filter(([, value]) => value !== undefined));
 }
 
 function parseRateLimit(reason: string): number | null {
@@ -179,16 +255,25 @@ async function dialAndStream(opts: Opts & { onFirstByte?: () => void }): Promise
 	});
 
 	if (res.status === 401 || res.status === 403) {
-		throw new Error("auth_failed");
+		throw new SseConnectionError("auth_failed", {
+			httpStatus: res.status,
+			requestId: res.headers.get("x-request-id"),
+		});
 	}
 	if (res.status === 429) {
-		throw new Error(`rate_limited:${res.headers.get("retry-after") ?? ""}`);
+		throw new SseConnectionError(`rate_limited:${res.headers.get("retry-after") ?? ""}`, {
+			httpStatus: res.status,
+			requestId: res.headers.get("x-request-id"),
+		});
 	}
 	if (!res.ok) {
-		throw new Error(`http_${res.status}`);
+		throw new SseConnectionError(`http_${res.status}`, {
+			httpStatus: res.status,
+			requestId: res.headers.get("x-request-id"),
+		});
 	}
 	if (!res.body) {
-		throw new Error("no_body");
+		throw new SseConnectionError("no_body", { requestId: res.headers.get("x-request-id") });
 	}
 
 	opts.onConnect?.();
@@ -283,15 +368,18 @@ export function parseRecord(record: string): ServerEvent | null {
 	}
 }
 
-function errorReason(err: unknown): string {
-	if (!(err instanceof Error)) return "unknown";
-	if (err.message === "auth_failed") return "auth_failed";
-	if (err.message === "no_body") return "no_body";
-	if (err.message === "stale") return "stale";
-	if (err.message.startsWith("http_")) return err.message;
-	if (err.message.startsWith("rate_limited")) return err.message;
-	if (err.name === "AbortError") return "aborted";
-	return err.message;
+function errorInfo(err: unknown): { reason: string; http_status?: number; request_id?: string } {
+	if (err instanceof SseConnectionError) {
+		return {
+			reason: err.reason,
+			http_status: err.httpStatus,
+			request_id: err.requestId,
+		};
+	}
+	if (!(err instanceof Error)) return { reason: "unknown" };
+	if (err.message === "stale") return { reason: "stale" };
+	if (err.name === "AbortError") return { reason: "aborted" };
+	return { reason: err.message };
 }
 
 function backoffMs(attempt: number): number {
@@ -302,6 +390,10 @@ function backoffMs(attempt: number): number {
 
 function sleep(ms: number, abort: AbortSignal): Promise<void> {
 	return new Promise((resolve) => {
+		if (abort.aborted) {
+			resolve();
+			return;
+		}
 		// Listener must be removed when timeout wins, otherwise a
 		// long reconnect storm leaks listeners on the same shared
 		// AbortSignal and eventually trips MaxListenersExceededWarning.

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -6,9 +6,11 @@ import { ApiError } from "../lib/api-client";
 import type { PendingSkillUploadEcho } from "./sync-engine";
 import {
 	addInFlight,
+	classifyHeartbeatFailure,
 	consumePendingSkillUploadEcho,
 	isAuthFailure,
 	isOversizedUploadError,
+	lastSyncErrorForSseReconnect,
 	releaseInFlight,
 	rememberPendingSkillUploadEcho,
 	resolveOwningSkillKey,
@@ -49,6 +51,32 @@ describe("isAuthFailure", () => {
 		expect(isAuthFailure(undefined)).toBe(false);
 		expect(isAuthFailure("401")).toBe(false);
 		expect(isAuthFailure({ status: 401 })).toBe(false);
+	});
+});
+
+describe("live-sync transient failure classification", () => {
+	it("does not surface transient SSE reconnects as last_sync_error", () => {
+		expect(
+			lastSyncErrorForSseReconnect({
+				reason: "http_502",
+				classification: "transient",
+			}),
+		).toBeNull();
+	});
+
+	it("surfaces sustained SSE reconnects as last_sync_error", () => {
+		expect(
+			lastSyncErrorForSseReconnect({
+				reason: "http_502",
+				classification: "sustained",
+			}),
+		).toBe("sse_disconnect:http_502");
+	});
+
+	it("classifies early heartbeat failures as transient and repeated failures as sustained", () => {
+		expect(classifyHeartbeatFailure(1)).toBe("transient");
+		expect(classifyHeartbeatFailure(3)).toBe("transient");
+		expect(classifyHeartbeatFailure(4)).toBe("sustained");
 	});
 });
 

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -68,7 +68,7 @@ import { log, toErrorMessage } from "./log";
 import { getServeStateDir } from "./paths";
 import { type QueueItem, RetryQueue } from "./queue";
 import { watchSessions } from "./sessions-watcher";
-import { consumeSse, type ServerEvent } from "./sse-client";
+import { consumeSse, type ServerEvent, type SseReconnectInfo } from "./sse-client";
 import { watchSkills } from "./watcher";
 
 type SkillSummary = components["schemas"]["SkillSummaryResponse"];
@@ -88,6 +88,9 @@ const QUEUE_RETRY_INTERVAL_MS = 15_000;
 const QUEUE_IDLE_WAKEUP_MS = 30_000;
 const MAX_QUEUE_ATTEMPTS = 30;
 const SKILL_UPLOAD_ECHO_TTL_MS = 2 * 60_000;
+const TRANSIENT_HEARTBEAT_FAILURES = 3;
+
+type FailureClassification = "transient" | "sustained";
 
 export type PendingSkillUploadEcho = {
 	contentHash: string;
@@ -750,8 +753,11 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 			onConnect: () => {
 				lastSyncError = null;
 			},
-			onDisconnect: (reason) => {
-				lastSyncError = `sse_disconnect:${reason}`;
+			onDisconnect: (info) => {
+				const nextError = lastSyncErrorForSseReconnect(info);
+				if (nextError !== null || lastSyncError?.startsWith("sse_disconnect:")) {
+					lastSyncError = nextError;
+				}
 			},
 			onAuthFailure: () => triggerAuthFailureAbort("sse_channel"),
 		}),
@@ -889,6 +895,16 @@ async function enqueueIfChanged(
 export function isAuthFailure(e: unknown): boolean {
 	if (e instanceof ApiError && (e.status === 401 || e.status === 403)) return true;
 	return false;
+}
+
+export function lastSyncErrorForSseReconnect(
+	info: Pick<SseReconnectInfo, "reason" | "classification">,
+): string | null {
+	return info.classification === "sustained" ? `sse_disconnect:${info.reason}` : null;
+}
+
+export function classifyHeartbeatFailure(consecutiveFailures: number): FailureClassification {
+	return consecutiveFailures <= TRANSIENT_HEARTBEAT_FAILURES ? "transient" : "sustained";
 }
 
 /**
@@ -2161,6 +2177,7 @@ async function heartbeatLoop(
 	abort: AbortSignal,
 	snapshot: () => { last_revision_seen: number | null; last_sync_error: string | null },
 ): Promise<void> {
+	let heartbeatFailureStreak = 0;
 	const send = async () => {
 		const fields = snapshot();
 		const dropped = queue.drainDroppedDelta();
@@ -2181,6 +2198,7 @@ async function heartbeatLoop(
 					last_sync_error: fields.last_sync_error,
 				},
 			});
+			heartbeatFailureStreak = 0;
 			await touchHealthFile(opts.adapter.agentType);
 		} catch (e) {
 			// POST failed — restore the unsent dropped delta so the
@@ -2188,7 +2206,18 @@ async function heartbeatLoop(
 			// count is permanently lost on every flaky-network
 			// cycle, which is precisely when drops are most likely.
 			queue.restoreDroppedDelta(dropped);
-			log.warn("engine.heartbeat_failed", { error: toErrorMessage(e) });
+			heartbeatFailureStreak += 1;
+			const classification = classifyHeartbeatFailure(heartbeatFailureStreak);
+			const fields = {
+				error: toErrorMessage(e),
+				consecutive_failures: heartbeatFailureStreak,
+				classification,
+			};
+			if (classification === "sustained") {
+				log.warn("engine.heartbeat_failed", fields);
+			} else {
+				log.info("engine.heartbeat_failed", fields);
+			}
 		}
 	};
 

--- a/packages/cli/tests/adapters/hermes.test.ts
+++ b/packages/cli/tests/adapters/hermes.test.ts
@@ -1,3 +1,4 @@
+import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -69,6 +70,22 @@ describe("HermesAdapter.collectSessions", () => {
 		const { sessions } = await a.collectSessions();
 		const json = sessions.find((s) => s.localSessionId === "s-json");
 		expect(json).toBeDefined();
+		expect(json?.model).toBe("gpt-5.3-codex");
+		expect(json?.modelsUsed).toEqual(["gpt-5.3-codex"]);
+	});
+
+	it("parses Python-repr model config without uploading provider secrets as the model", async () => {
+		const db = new Database(join(tmpHome, ".hermes", "state.db"));
+		db.run(
+			"UPDATE sessions SET model = ? WHERE id = ?",
+			"{'default': 'gpt-5.3-codex', 'provider': 'openai-codex', 'headers': {'x-api-key': 'sk-redacted'}}",
+			"s-json",
+		);
+		db.close();
+
+		const a = new HermesAdapter();
+		const { sessions } = await a.collectSessions();
+		const json = sessions.find((s) => s.localSessionId === "s-json");
 		expect(json?.model).toBe("gpt-5.3-codex");
 		expect(json?.modelsUsed).toEqual(["gpt-5.3-codex"]);
 	});

--- a/packages/cli/tests/commands/ai-provider.test.ts
+++ b/packages/cli/tests/commands/ai-provider.test.ts
@@ -16,6 +16,7 @@ import {
 	aiProviderAddCommand,
 	aiProviderCompleteOAuthCommand,
 	aiProviderConnectCommand,
+	aiProviderEditCommand,
 	aiProviderExportCommand,
 	aiProviderImportAuthCommand,
 	aiProviderImportCommand,
@@ -960,6 +961,37 @@ describe("ai-provider commands", () => {
 		expect(after.output()).toContain('"applied": true');
 	});
 
+	it("clears stale runtime env names when auth changes to an env ref", async () => {
+		const { restore } = captureConsole();
+		try {
+			await aiProviderAddCommand("openai-main", {
+				type: "openai",
+				defaultModel: "gpt-5.2",
+				auth: "clawdi://default/openai/api_key",
+				agentEnv: "OLD_OPENAI_API_KEY",
+				json: true,
+			});
+			await aiProviderEditCommand("openai-main", {
+				auth: "env:NEW_OPENAI_API_KEY",
+				json: true,
+			});
+		} finally {
+			restore();
+		}
+
+		const catalog = JSON.parse(readFileSync(aiProviderCatalogPath(), "utf-8"));
+		expect(catalog.providers[0].runtime_env_name).toBeUndefined();
+
+		const status = captureConsole();
+		try {
+			await aiProviderStatusCommand({ json: true });
+		} finally {
+			status.restore();
+		}
+		expect(status.output()).toContain('"agent_env_name": "NEW_OPENAI_API_KEY"');
+		expect(status.output()).not.toContain("OLD_OPENAI_API_KEY");
+	});
+
 	it("uses Codex native auth for Codex agent profiles", async () => {
 		const { output, restore } = captureConsole();
 		try {
@@ -1513,6 +1545,61 @@ describe("ai-provider commands", () => {
 		expect(openrouter.auth).toEqual({
 			type: "secret_ref",
 			ref: "env:OPENROUTER_API_KEY",
+		});
+	});
+
+	it("imports provider metadata from the current OpenClaw patch shape", async () => {
+		const openclawConfig = join(tmpHome, "openclaw-config.json");
+		const projection = buildAgentEngineProjection("openclaw", {
+			schema_version: 1,
+			defaults: { chat_provider_id: "anthropic-main" },
+			providers: [
+				{
+					id: "openai-main",
+					type: "openai",
+					base_url: "https://api.openai.com/v1",
+					default_model: "gpt-5.2",
+					api_mode: "openai_responses",
+					auth: { type: "secret_ref", ref: "env:OPENAI_API_KEY" },
+				},
+				{
+					id: "anthropic-main",
+					type: "anthropic",
+					base_url: "https://api.anthropic.com",
+					default_model: "claude-opus-4-6",
+					api_mode: "anthropic_messages",
+					auth: { type: "secret_ref", ref: "env:ANTHROPIC_API_KEY" },
+				},
+			],
+		});
+		writeFileSync(openclawConfig, projection.files[0]?.content ?? "{}");
+		const { restore } = captureConsole();
+		try {
+			await aiProviderImportCommand(undefined, { fromOpenclaw: openclawConfig, json: true });
+		} finally {
+			restore();
+		}
+
+		const catalog = JSON.parse(readFileSync(aiProviderCatalogPath(), "utf-8"));
+		expect(catalog.defaults.chat_provider_id).toBe("anthropic-main");
+		expect(catalog.providers).toHaveLength(2);
+		expect(catalog.providers[0]).toMatchObject({
+			id: "openai-main",
+			type: "openai",
+			base_url: "https://api.openai.com/v1",
+			default_model: "gpt-5.2",
+			api_mode: "openai_responses",
+			auth: { type: "secret_ref", ref: "env:OPENAI_API_KEY" },
+			runtime_env_name: "OPENAI_API_KEY",
+		});
+		expect(catalog.providers[1]).toMatchObject({
+			id: "anthropic-main",
+			type: "anthropic",
+			base_url: "https://api.anthropic.com",
+			default_model: "claude-opus-4-6",
+			api_mode: "anthropic_messages",
+			auth: { type: "secret_ref", ref: "env:ANTHROPIC_API_KEY" },
+			runtime_env_name: "ANTHROPIC_API_KEY",
 		});
 	});
 

--- a/packages/cli/tests/commands/auth.test.ts
+++ b/packages/cli/tests/commands/auth.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { authLogin } from "../../src/commands/auth";
+import { authLogin, browserOpenCommand } from "../../src/commands/auth";
 import { addToken, listTokens } from "../../src/share/tokens";
 import { jsonResponse, mockFetch } from "./helpers";
 
@@ -51,6 +51,21 @@ afterEach(() => {
 });
 
 describe("authLogin pending share upgrade", () => {
+	it("uses a real executable for browser opening on every supported platform", () => {
+		expect(browserOpenCommand("https://example.test", "darwin")).toEqual({
+			command: "open",
+			args: ["https://example.test"],
+		});
+		expect(browserOpenCommand("https://example.test", "linux")).toEqual({
+			command: "xdg-open",
+			args: ["https://example.test"],
+		});
+		expect(browserOpenCommand("https://example.test", "win32")).toEqual({
+			command: "cmd",
+			args: ["/c", "start", "", "https://example.test"],
+		});
+	});
+
 	it("upgrades anonymous share tokens and eager-pulls shared skills", async () => {
 		addToken({
 			project_id: "project-shared",

--- a/packages/cli/tests/commands/pull.test.ts
+++ b/packages/cli/tests/commands/pull.test.ts
@@ -57,6 +57,38 @@ async function buildSkillTar(skillKey: string, skillMdContent: string): Promise<
 }
 
 describe("pull — Hermes fixture", () => {
+	it("bounds cloud session pagination if the backend keeps returning full pages", async () => {
+		setup("hermes");
+		const page = Array.from({ length: 200 }, (_, index) => ({
+			id: `session-${index}`,
+			local_session_id: `local-${index}`,
+			agent_type: "hermes",
+			machine_name: "Test Mac",
+			project_path: "/tmp/project",
+			started_at: "2026-06-01T00:00:00.000Z",
+			ended_at: null,
+			message_count: 1,
+			model: null,
+			summary: null,
+			content_hash: `hash-${index}`,
+		}));
+		const { captured, restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/api/sessions",
+				response: () => jsonResponse({ items: page, total: 100_000 }),
+			},
+		]);
+		try {
+			await expect(pull({ agent: "hermes", modules: "sessions" })).rejects.toThrow(
+				"Too many session pages to pull safely.",
+			);
+		} finally {
+			restore();
+		}
+		expect(captured.filter((request) => request.path.startsWith("/api/sessions"))).toHaveLength(50);
+	});
+
 	it("downloads the cloud skill into $HOME/.hermes/skills/<key>/", async () => {
 		setup("hermes");
 

--- a/packages/cli/tests/commands/update.test.ts
+++ b/packages/cli/tests/commands/update.test.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { daemonAutoUpdateOnce, maybeAutoUpdate, update } from "../../src/commands/update";
+import {
+	daemonAutoUpdateOnce,
+	detectInstallerFromPaths,
+	installCommand,
+	maybeAutoUpdate,
+	update,
+} from "../../src/commands/update";
 import { jsonResponse, mockFetch } from "./helpers";
 
 let tmpHome: string;
@@ -43,6 +49,58 @@ afterEach(() => {
 	if (origNoAuto) process.env.CLAWDI_NO_AUTO_UPDATE = origNoAuto;
 	else delete process.env.CLAWDI_NO_AUTO_UPDATE;
 	rmSync(tmpHome, { recursive: true, force: true });
+});
+
+describe("detectInstaller", () => {
+	it("uses npm when the running clawdi binary is in npm's global bin even if bun is available", () => {
+		expect(
+			detectInstallerFromPaths("/home/user/.local/bin/clawdi", {
+				npmBin: "/home/user/.local/bin",
+				npmRoot: "/home/user/.local/lib/node_modules",
+				bunBin: "/home/user/.bun/bin",
+			}),
+		).toBe("npm");
+	});
+
+	it("uses bun when the running clawdi binary is in bun's global bin", () => {
+		expect(
+			detectInstallerFromPaths("/home/user/.bun/bin/clawdi", {
+				npmBin: "/home/user/.local/bin",
+				npmRoot: "/home/user/.local/lib/node_modules",
+				bunBin: "/home/user/.bun/bin",
+			}),
+		).toBe("bun");
+	});
+
+	it("uses npm when the resolved clawdi package path is inside npm's global root", () => {
+		expect(
+			detectInstallerFromPaths("/home/user/.local/lib/node_modules/clawdi/bin/clawdi.mjs", {
+				npmBin: "/home/user/.local/bin",
+				npmRoot: "/home/user/.local/lib/node_modules",
+				bunBin: "/home/user/.bun/bin",
+			}),
+		).toBe("npm");
+	});
+
+	it("uses bun when the resolved clawdi package path is inside Bun's global install", () => {
+		expect(
+			detectInstallerFromPaths(
+				"/home/user/.bun/install/global/node_modules/clawdi/bin/clawdi.mjs",
+				{
+					npmBin: "/home/user/.local/bin",
+					npmRoot: "/home/user/.local/lib/node_modules",
+				},
+			),
+		).toBe("bun");
+	});
+});
+
+describe("installCommand", () => {
+	it("prints the installer-specific manual command", () => {
+		expect(installCommand("npm")).toBe("npm i -g clawdi");
+		expect(installCommand("bun")).toBe("bun add -g clawdi");
+		expect(installCommand(null)).toBe("npm i -g clawdi");
+	});
 });
 
 describe("update --json", () => {

--- a/packages/shared/src/ai-provider.test.ts
+++ b/packages/shared/src/ai-provider.test.ts
@@ -71,4 +71,45 @@ describe("validateAiProviderCatalog", () => {
 			"Provider openai-agent has invalid agent_profile auth metadata.",
 		);
 	});
+
+	test("allows no-auth local endpoints but rejects public no-auth URLs", () => {
+		for (const base_url of [
+			"http://localhost:1234/v1",
+			"http://127.0.0.1:1234/v1",
+			"http://[::1]:1234/v1",
+			"http://0.0.0.0:1234/v1",
+		]) {
+			const result = validateAiProviderCatalog({
+				schema_version: 1,
+				providers: [
+					{
+						id: "local-main",
+						type: "custom_openai_compatible",
+						base_url,
+						api_mode: "openai_chat",
+						auth: { type: "none" },
+					},
+				],
+			});
+
+			expect(result.errors).toEqual([]);
+			expect(result.valid).toBe(true);
+		}
+
+		const result = validateAiProviderCatalog({
+			schema_version: 1,
+			providers: [
+				{
+					id: "public-main",
+					type: "custom_openai_compatible",
+					base_url: "https://example.com/v1",
+					api_mode: "openai_chat",
+					auth: { type: "none" },
+				},
+			],
+		});
+
+		expect(result.valid).toBe(false);
+		expect(result.errors).toContain("Provider public-main uses no auth on a public URL.");
+	});
 });

--- a/packages/shared/src/ai-provider.ts
+++ b/packages/shared/src/ai-provider.ts
@@ -366,7 +366,13 @@ function isHttpUrl(input: string): boolean {
 }
 
 function isLoopbackHost(hostname: string): boolean {
-	return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+	return (
+		hostname === "localhost" ||
+		hostname === "127.0.0.1" ||
+		hostname === "::1" ||
+		hostname === "[::1]" ||
+		hostname === "0.0.0.0"
+	);
 }
 
 function isPrivateHost(hostname: string): boolean {


### PR DESCRIPTION
## Summary
- Release clawdi CLI v0.10.1 with updater, live-sync, AI Provider, and command-surface fixes.
- Harden backend session ingest for structured or overlong model values observed in production /api/sessions/batch failures.
- Hide SQL bound parameters from backend database exception logs.

## Production log review
- Found repeated /api/sessions/batch 500s caused by StringDataRightTruncationError on sessions.model varchar(100).
- AI Provider/OAuth log grep did not show independent errors.
- /api/sync/events log samples were 200.

## Verification
- bun run check
- bun run typecheck
- bun run test
- bun run --cwd packages/cli typecheck
- bun run --cwd packages/cli test (508 pass)
- bun run --cwd packages/cli build
- bun run --cwd packages/cli check:publish-manifest
- cd backend && uv run ruff check app tests
- cd backend && uv run pytest -q (358 pass)

## Release impact
- CLI/npm release: clawdi@0.10.1 / clawdi-cli-v0.10.1
- App/backend release: clawdi-2026-06-03-2
- Backend deploy should follow merge so the production session-ingest and log-parameter fixes take effect.