### PR TITLE
Add hosted runtime channels and MITM broker

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -40,6 +40,11 @@ jobs:
         with:
           bun-version: "1.3.13"
 
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: packages/cli/native/mitm-broker/go.mod
+          cache-dependency-path: packages/cli/native/mitm-broker/go.mod
+
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
@@ -48,21 +53,30 @@ jobs:
       - name: Skip if no publish needed
         id: check
         # Three skip cases:
-        #   1. Local version matches what's already on npm (no bump → no publish).
+        #   1. Local exact version already exists on npm (no bump → no publish).
         #   2. Package has never been published (`npm view` fails, fallback "0.0.0").
         #      The first publish must be manual — `npm publish --access public`
         #      from a maintainer's machine — because npm trusted-publisher OIDC
         #      requires the package to already exist on the registry to accept
         #      a workflow as the publisher. Until that bootstrap happens, the
         #      workflow stays inert.
+        #   3. Pre-release versions publish under the `beta` dist-tag so they
+        #      cannot accidentally replace `latest`.
         run: |
           LOCAL=$(node -p "require('./package.json').version")
-          REMOTE=$(npm view clawdi version 2>/dev/null || echo "0.0.0")
-          echo "local=$LOCAL remote=$REMOTE"
-          if [ "$REMOTE" = "0.0.0" ]; then
+          REMOTE_LATEST=$(npm view clawdi version 2>/dev/null || echo "0.0.0")
+          if [[ "$LOCAL" == *-* ]]; then
+            NPM_TAG=beta
+          else
+            NPM_TAG=latest
+          fi
+          echo "local=$LOCAL remote_latest=$REMOTE_LATEST npm_tag=$NPM_TAG"
+          echo "npm_tag=$NPM_TAG" >> "$GITHUB_OUTPUT"
+          if [ "$REMOTE_LATEST" = "0.0.0" ]; then
             echo "Package not on npm yet — bootstrap with manual publish first."
             echo "skip=true" >> "$GITHUB_OUTPUT"
-          elif [ "$LOCAL" = "$REMOTE" ]; then
+          elif npm view "clawdi@$LOCAL" version >/dev/null 2>&1; then
+            echo "Package version clawdi@$LOCAL already exists on npm."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -83,9 +97,26 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         run: bun run build
 
+      - name: Test native MITM broker
+        if: steps.check.outputs.skip != 'true'
+        working-directory: packages/cli/native/mitm-broker
+        run: go test ./...
+
+      - name: Build standalone CLI binary
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          bun run build:binary
+          ./dist-bin/clawdi --version
+          test -x dist-bin/clawdi-mitm-broker/bin/clawdi-mitm-broker
+          bun run package:binary-release
+          test -f dist-release/clawdi-cli-linux-x64.tar.gz
+          test -f dist-release/clawdi-cli-linux-x64.tar.gz.sha256
+          CLAWDI_MITM_BROKER_BUNDLE_OUTDIR=clawdi-mitm-broker bun run build:mitm-broker
+          test -x clawdi-mitm-broker/bin/clawdi-mitm-broker
+
       - name: Test
         if: steps.check.outputs.skip != 'true'
-        run: bun test
+        run: bun test --isolate --max-concurrency=1
 
       - name: Validate npm tarball install
         if: steps.check.outputs.skip != 'true'
@@ -119,7 +150,7 @@ jobs:
       # badge linking back to this exact workflow run.
       - name: Publish to npm
         if: steps.check.outputs.skip != 'true'
-        run: npm publish --access public --provenance --ignore-scripts
+        run: npm publish --access public --provenance --ignore-scripts --tag "${{ steps.check.outputs.npm_tag }}"
 
       - name: Create GitHub release
         if: steps.check.outputs.skip != 'true'
@@ -127,10 +158,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
+          NPM_TAG="${{ steps.check.outputs.npm_tag }}"
           TAG="clawdi-cli-v${VERSION}"
 
           if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "GitHub release $TAG already exists; skipping."
+            echo "GitHub release $TAG already exists; uploading standalone CLI assets."
+            gh release upload "$TAG" \
+              dist-release/clawdi-cli-linux-x64.tar.gz \
+              dist-release/clawdi-cli-linux-x64.tar.gz.sha256 \
+              --clobber
             exit 0
           fi
 
@@ -143,7 +179,9 @@ jobs:
           NOTES=$(cat <<EOF
           ## npm
           - Package: \`clawdi@${VERSION}\`
+          - Dist tag: \`${NPM_TAG}\`
           - Install: \`npm i -g clawdi@${VERSION}\`
+          - Dist-tag install: \`npm i -g clawdi@${NPM_TAG}\`
 
           ## Scope
           This is the release for the published \`packages/cli\` package.
@@ -154,12 +192,17 @@ jobs:
 
           args=(
             release create "$TAG"
+            dist-release/clawdi-cli-linux-x64.tar.gz
+            dist-release/clawdi-cli-linux-x64.tar.gz.sha256
             --target "$GITHUB_SHA"
             --title "Clawdi CLI v${VERSION}"
             --notes "$NOTES"
             --generate-notes
             --latest=false
           )
+          if [ "$NPM_TAG" != "latest" ]; then
+            args+=(--prerelease)
+          fi
           if [ -n "$PREVIOUS" ]; then
             args+=(--notes-start-tag "$PREVIOUS")
           fi

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -158,11 +158,29 @@ jobs:
       - uses: ./.github/actions/setup-bun-ci
         with:
           bun-version: ${{ env.BUN_VERSION }}
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: packages/cli/native/mitm-broker/go.mod
+          cache-dependency-path: packages/cli/native/mitm-broker/go.mod
       # Smoke tests exercise the compiled bin wrapper, so build before testing.
       - name: Build CLI
         run: bun run --cwd packages/cli build
+      - name: Test native MITM broker
+        working-directory: packages/cli/native/mitm-broker
+        run: go test ./...
+      - name: Build standalone CLI binary
+        run: bun run --cwd packages/cli build:binary
+      - name: Smoke standalone CLI binary
+        run: |
+          packages/cli/dist-bin/clawdi --version
+          test -x packages/cli/dist-bin/clawdi-mitm-broker/bin/clawdi-mitm-broker
+      - name: Validate CLI publish payload
+        run: |
+          CLAWDI_MITM_BROKER_BUNDLE_OUTDIR=clawdi-mitm-broker bun run --cwd packages/cli build:mitm-broker
+          bun run --cwd packages/cli check:publish-manifest
+          test -x packages/cli/clawdi-mitm-broker/bin/clawdi-mitm-broker
       - name: Test CLI
-        run: bun test packages/cli
+        run: bun test --isolate --max-concurrency=1 packages/cli
 
   build:
     needs: [changes, typecheck]

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 node_modules/
 .next/
 dist/
+dist-bin/
+packages/cli/dist-release/
+packages/cli/clawdi-mitm-broker/
 .turbo/
 *.tsbuildinfo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.12.10-beta.0
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.0
+
+Package: `clawdi@0.12.10-beta.0`
+
+### Changed
+
+- Added a hosted runtime CLI prerelease for controlled validation. This release
+  keeps the hosted runtime flow behind explicit runtime commands and hosted
+  controller manifests, so existing `clawdi` CLI users and the Clawdi
+  app/backend/web release line are not changed by default.
+- Cleaned up the runtime manifest contract so the CLI accepts one controller
+  response shape and one local desired-state shape, with stricter validation for
+  runtime paths, secrets, MITM profiles, and manifest expiry.
+
 ## Clawdi CLI v0.12.9
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.9

--- a/README.md
+++ b/README.md
@@ -302,8 +302,9 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](packages/cli
 | Command | What it does |
 | --- | --- |
 | `clawdi auth login` / `logout` | Authenticate this machine |
+| `clawdi auth status [--json]` | Show credential source without printing secrets |
 | `clawdi status [--json]` | Show auth and sync state |
-| `clawdi config list/get/set/unset` | Read or write CLI configuration |
+| `clawdi config list/get/set/unset/paths` | Read/write CLI configuration and inspect local/runtime paths |
 | `clawdi setup [--agent <type>] [--no-daemon]` | Register local agents, install MCP, install the bundled skill, and install/start the singleton daemon by default |
 | `clawdi teardown [--agent <type>]` | Remove Clawdi's local agent wiring |
 | `clawdi daemon run/install/status/logs/doctor/restart/uninstall/ping/rotate-token` | Run, inspect, and control the singleton background sync daemon (`serve` remains a legacy alias) |
@@ -329,6 +330,28 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](packages/cli
 Auto-update is enabled by default for all newer releases, including majors. Human CLI invocations update the global CLI in the background; installed daemons check on their own cadence, install silently, then let launchd/systemd restart them onto the new code. Disable both with `CLAWDI_NO_AUTO_UPDATE=1` or `clawdi config set autoUpdate false`.
 
 Every command supports `--help`.
+
+### Advanced Runtime Operators
+
+These commands are for controlled hosted or self-hosted runtime envelopes. They
+are not part of normal laptop onboarding.
+
+| Command | What it does |
+| --- | --- |
+| `clawdi capabilities [--json]` | Show CLI feature surface, runtime mode, and hosted policy restrictions |
+| `clawdi runtime init --non-interactive [--json]` | Run one cloud-init-style hosted runtime convergence pass |
+| `clawdi runtime status [--json]` | Read the last runtime boot result from service-state files |
+| `clawdi runtime doctor [--json]` | Diagnose hosted policy, service state, HOME, tmpfs runtime state, and last boot status |
+
+Hosted runtime mode is detected from host policy or runtime credentials. In
+hosted mode, `/etc/clawdi/host-policy.json` can deny local-user commands such
+as `setup`, `teardown`, `update`, `config set`, and `auth login`, while keeping
+agent-facing commands such as `mcp`, `daemon run`, `read`, `inject`, and `run`
+available. Local self-update is skipped in hosted mode; hosted CLI updates are
+expected to be system-managed through the standard npm package installation.
+
+For the hosted runtime design, profile matrix, and runtime image contract, see
+[`docs/hosted-runtime.md`](docs/hosted-runtime.md).
 
 App connections are configured in the [Clawdi Cloud dashboard](https://clawdi.ai) and surface inside agents automatically over MCP — there is no CLI command to manage them.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@ High-level map of what's actually in Clawdi Cloud today — updated as the code 
 
 ## One-paragraph overview
 
-Clawdi Cloud is a cross-agent sync + recall layer. A local CLI (`clawdi`) reads per-agent data (Claude Code, Codex, Hermes, OpenClaw) from well-known directories, pushes sessions and skills to a FastAPI backend, pulls shared skills back down, and exposes a long-term memory store to each agent via the Model Context Protocol. Projects are the collaboration and data ownership boundary; each Agent has one fixed Agent Project plus optional attached Projects for read-time composition. The web app is a read-mostly dashboard on the same backend. The memory store is the differentiator: it gives every connected agent the same cross-session, cross-machine context without the agents having to know about each other.
+Clawdi Cloud is a cross-agent sync + recall layer. A local CLI (`clawdi`) reads per-agent data (Claude Code, Codex, Hermes, OpenClaw) from well-known directories, pushes sessions and skills to a FastAPI backend, pulls shared skills back down, and exposes a long-term memory store to each agent via the Model Context Protocol. Projects are the collaboration and data ownership boundary; each Agent has one fixed Agent Project plus optional attached Projects for read-time composition. The web app is a read-mostly dashboard on the same backend. The same CLI also owns the hosted runtime convergence path for controlled agent containers. The memory store is the differentiator: it gives every connected agent the same cross-session, cross-machine context without the agents having to know about each other.
 
 ---
 
@@ -138,6 +138,94 @@ The MCP server registration path also differs per agent — see `commands/setup.
 
 ---
 
+## Hosted runtime
+
+Hosted runtime mode is a controlled container/runtime envelope that reuses the
+same open-source `clawdi` CLI. It is not a separate private init binary and it
+does not add a private runtime-control RPC surface for ordinary agent actions.
+
+Canonical detailed design: [`hosted-runtime.md`](hosted-runtime.md).
+
+### Runtime Flow
+
+```
+┌────────────────────────────┐
+│ Hosted image / supervisor  │
+│  calls: clawdi runtime init│
+└──────────────┬─────────────┘
+               │ configured runtime source
+               ▼
+┌────────────────────────────┐
+│ Runtime source response     │
+│ { manifest, secretValues } │
+└──────────────┬─────────────┘
+               │ normalize
+               ▼
+┌────────────────────────────┐
+│ clawdi.runtimeDesiredState │
+│ non-secret desired state   │
+└──────────────┬─────────────┘
+               │ converge
+               ▼
+┌────────────────────────────┐
+│ /var/lib/clawdi + /run     │
+│ config, cache, run files   │
+└──────────────┬─────────────┘
+               │ launch
+               ▼
+┌────────────────────────────┐
+│ clawdi run -- <runtime>    │
+│ starts broker when needed  │
+└────────────────────────────┘
+```
+
+### Contracts
+
+| Contract | Schema / path | Owner |
+|---|---|---|
+| Runtime source response | `{ manifest, secretValues }` | External runtime source |
+| Runtime source manifest | `clawdi.hosted-runtime.manifest.v1` | External runtime source |
+| Normalized desired state | `clawdi.runtimeDesiredState.v1` | CLI normalization layer |
+| Last-good cache | `/var/lib/clawdi/cache/manifest.last-good.json` | CLI, non-secret only |
+| Short-lived secrets | `/run/clawdi/mitm/secrets.json` | CLI, recreated per boot |
+| Runtime run config | `/var/lib/clawdi/config/run/{runtime}.json` | CLI convergence |
+| MITM profile bundle | `/var/lib/clawdi/config/mitm/profiles.json` | CLI convergence |
+| Supervisor config | `/var/lib/clawdi/supervisor/supervisord.conf` | CLI convergence |
+
+The runtime source response is the only hosted wire input. The CLI may also
+read a local `clawdi.runtimeDesiredState.v1` fixture for simulation, but it no
+longer accepts earlier development manifest shapes.
+
+### Module Map
+
+| Area | Files |
+|---|---|
+| Contract schemas | `packages/cli/src/runtime/manifest-contract.ts` |
+| Datasource fetch, normalization, validation | `packages/cli/src/runtime/manifest-source.ts` |
+| Local convergence, install inventory, supervisor output | `packages/cli/src/runtime/manifest.ts` |
+| Hosted path contract | `packages/cli/src/runtime/paths.ts` |
+| Runtime boot status | `packages/cli/src/runtime/state.ts` |
+| Run config and invocation | `packages/cli/src/runtime/run-config.ts`, `packages/cli/src/commands/run.ts` |
+| MITM profile schema and hosted profile generation | `packages/cli/src/runtime/mitm-profiles.ts`, `packages/cli/src/runtime/hosted-mitm-profiles.ts` |
+| Native broker launcher and env projection | `packages/cli/src/runtime/mitm-broker.ts`, `packages/cli/src/runtime/mitm-env.ts` |
+| Native broker implementation | `packages/cli/native/mitm-broker/` |
+
+### Ownership Boundaries
+
+- The external runtime source owns identity, manifest generation, and secret
+  resolution. Deployment selection, rollout, and UI policy stay outside this
+  CLI repository.
+- The CLI owns manifest validation, non-secret convergence, official
+  OpenClaw/Hermes install orchestration, run config, supervisor config,
+  short-lived secret files, and broker lifecycle.
+- OpenClaw and Hermes keep their official installer/updater authority.
+- Clawdi native Channels own shared channel protocol state. Hosted runtime
+  profiles only route official-looking egress to managed channel/provider
+  surfaces.
+- User BYOK provider traffic must not be silently proxied.
+
+---
+
 ## Sync engine
 
 `clawdi push` and `clawdi pull` share a selector that picks the target agent:
@@ -202,7 +290,7 @@ Several items were considered but not built. Named for discoverability if someon
 - **Celery / background tasks** — no async task queue. Memory is embedded synchronously on `memory_add`.
 - **Session → Memory LLM pipeline** — sessions are just stored; nothing auto-extracts memories from transcripts. Users / agents add memories explicitly.
 - **CronJobs** — no `cron_job` table, no scheduler. `scripts/embed_memories.py` exists as a manual operator-level tool.
-- **Channels provider coverage** — the Clawdi-native control plane plus Python-native Telegram Bot API, Discord REST/Gateway/rate-limit handling, WhatsApp Cloud API/Graph plus Baileys credential/Noise/IQ/relay/media boundary handling, and iMessage/BlueBubbles HTTP/query/webhook/attachment/Socket.IO slices exist. Outbound delivery, agent webhook redelivery, and Discord Gateway inbound dispatch run through the DB-backed `pdm run channels-worker` stack; WhatsApp Baileys outbound relay reaches that outbox through a transparent shared-bot runtime adapter that converts sendable WAProto into validated Cloud API `providerPayload` for text/reply/public-link image/audio, relays Cloud-native raw status nodes for read receipts and typing indicators, and routes remaining Baileys-only media, voice-note/audio, group proto, and relay-attr messages to a registered native transport instead of route-local persistence. The FastAPI websocket reaches real Baileys `connection: open` plus DB-inbox `messages.upsert` delivery in the opt-in smoke, including quoted reply, image envelope, and group participant/sender-key fixture shapes. Discord Gateway capture uses per-account Postgres advisory locks inside that worker stack. WhatsApp debug health reports whether the native transport is unavailable, disconnected, `in_process`, or `sidecar` and which native relay capabilities it exposes. A minimal Clawdi-owned Baileys sidecar runtime package and FastAPI registration path exist for the remaining WhatsApp Web live protocol adapter; the old TypeScript `msg-router` remains excluded. Opt-in smoke starts the sidecar against the FastAPI Baileys runtime; remaining work is deployment-level sidecar supervision and real linked-account upstream smoke.
+- **Channels provider coverage** — the Clawdi-native control plane plus Python-native Telegram Bot API, Discord REST/Gateway/rate-limit handling, WhatsApp Cloud API/Graph plus Baileys credential/Noise/IQ/relay/media boundary handling, and iMessage/BlueBubbles HTTP/query/webhook/attachment/Socket.IO slices exist. Outbound delivery, agent webhook redelivery, and Discord Gateway inbound dispatch run through the DB-backed `pdm run channels-worker` stack; WhatsApp Baileys outbound relay reaches that outbox through a transparent channel runtime adapter that converts sendable WAProto into validated Cloud API `providerPayload` for text/reply/public-link image/audio, relays Cloud-native raw status nodes for read receipts and typing indicators, and routes remaining Baileys-only media, voice-note/audio, group proto, and relay-attr messages to a registered native transport instead of route-local persistence. The FastAPI websocket reaches real Baileys `connection: open` plus DB-inbox `messages.upsert` delivery in the opt-in smoke, including quoted reply, image envelope, and group participant/sender-key fixture shapes. Discord Gateway capture uses per-account Postgres advisory locks inside that worker stack. WhatsApp debug health reports whether the native transport is unavailable, disconnected, `in_process`, or `sidecar` and which native relay capabilities it exposes. A minimal Clawdi-owned Baileys sidecar runtime package and FastAPI registration path exist for the remaining WhatsApp Web live protocol adapter; the legacy TypeScript router remains excluded. Opt-in smoke starts the sidecar against the FastAPI Baileys runtime; remaining work is deployment-level sidecar supervision and real linked-account upstream smoke.
 - **Cognee memory provider** — only `Builtin` and `Mem0`.
 - **Browser-based `clawdi auth login`** — the implemented flow is "paste your API key", same UX but no OAuth dance.
 - **`bun build --compile` single-binary distribution** — currently `bun link` over the workspace.

--- a/docs/clawdi-serve-test-guide.md
+++ b/docs/clawdi-serve-test-guide.md
@@ -301,8 +301,8 @@ only conduit.
 
 | Agent | What you need to set |
 |---|---|
-| Hermes | `HERMES_HOME=/data/hermes` (or wherever the pod stores `state.db`). The adapter reads SQLite via `node:sqlite` (Node 22.5+) or `bun:sqlite` — both are built-in, no native bindings to ship. |
-| OpenClaw | `OPENCLAW_STATE_DIR=/data/openclaw` (state lives outside `$HOME` in production). `OPENCLAW_AGENT_ID=<id>` if the pod runs a single agent personality; omit to sync every agent under `agents/`. |
+| Hermes | `HERMES_HOME=<hermes-state-dir>` when the pod does not use Hermes' default HOME path. The adapter reads SQLite via `node:sqlite` (Node 22.5+) or `bun:sqlite` — both are built-in, no native bindings to ship. |
+| OpenClaw | `OPENCLAW_STATE_DIR=<openclaw-state-dir>` when the pod does not use OpenClaw's default HOME path. `OPENCLAW_AGENT_ID=<id>` if the pod runs a single agent personality; omit to sync every agent under `agents/`. |
 
 ### What NOT to do
 

--- a/docs/hosted-runtime.md
+++ b/docs/hosted-runtime.md
@@ -1,0 +1,481 @@
+# Hosted Runtime Design
+
+| Field | Value |
+| --- | --- |
+| Status | CLI/runtime contract implemented locally; deployment rollout is out of scope |
+| Last updated | 2026-06-09 |
+| Owner | CLI runtime layer |
+
+This is the canonical Markdown design document for the hosted runtime work.
+All hosted runtime design material should live in Markdown.
+
+Related deep dives:
+
+- System architecture overview: [`architecture.md`](architecture.md)
+- CLI contract: [`plans/hosted-runtime-cli.md`](plans/hosted-runtime-cli.md)
+- OpenClaw/Hermes patch replacement inventory:
+  [`plans/openclaw-hermes-mitm-inventory.md`](plans/openclaw-hermes-mitm-inventory.md)
+- Implementation roadmap:
+  [`plans/hosted-runtime-roadmap.md`](plans/hosted-runtime-roadmap.md)
+
+## Product Goal
+
+Hosted runtime should feel like a normal Linux system inside a Docker envelope:
+
+1. The host only needs to run Docker and inject `CLAWDI_AUTH_TOKEN`.
+2. The base image stays stable and does not bake OpenClaw, Hermes, channel
+   plugins, tenant config, or endpoint patches.
+3. `clawdi runtime init --non-interactive` performs one cloud-init-style
+   convergence pass.
+4. Selected OpenClaw/Hermes runtimes install with official installers under the
+   persistent runtime user's HOME.
+5. Runtime startup uses `clawdi run -- <runtime>` or
+   `clawdi run -- <command>`, not Docker startup flags.
+6. Channel and provider routing is expressed as named MITM profiles.
+7. Shared channel protocol state is owned by Clawdi native Channels; hosted-managed
+   provider traffic can route to sub2api when explicitly configured.
+
+The target is zero source patching for OpenClaw and Hermes.
+
+## Design Decisions
+
+| Decision | Rationale |
+| --- | --- |
+| Keep the base image plain Linux | The image should be stable, cacheable, and easy to reason about. App/runtime changes belong in Clawdi CLI and upstream installers. |
+| Use `clawdi` as the convergence engine | One open-source CLI owns hosted runtime init, status, diagnostics, run config, and broker lifecycle. No private `clawdi-init` binary. |
+| Keep service APIs out of CLI defaults | The CLI reads a runtime source contract and does not hardcode backend paths. |
+| Install runtimes as the `clawdi` user | OpenClaw/Hermes files stay in the normal runtime user's HOME and preserve official updater expectations. |
+| Persist Clawdi-managed state under `/var/lib/clawdi` | This follows Linux service-state conventions and separates managed config from user HOME. |
+| Keep short-lived secrets under `/run/clawdi` | Secret projections and broker CA files should be recreated each boot/run and not cached in last-good manifests. |
+| Use `clawdi run` as the activation boundary | The child process keeps official behavior while Clawdi projects proxy, CA, PATH, cwd, and env from persisted config. |
+| Keep MITM out of the JS CLI process | The CLI starts a managed native broker child. The broker owns CONNECT, TLS, WebSocket, profile matching, and forwarding. |
+| Prefer native runtime/provider config first | MITM is only for hosted-managed policy gaps and official-behavior simulation. User BYOK provider traffic must not be silently proxied. |
+
+## Image Anatomy
+
+The image has five operational layers. Each layer has one owner and one
+persistence rule.
+
+### 1. Read-Only System Layer
+
+- Owner: image build / platform
+- Persistence: baked into the image, treated as read-only at runtime
+
+| Path | Purpose |
+| --- | --- |
+| `/usr/local/bin/clawdi` | Stable launcher or entrypoint for the managed CLI. |
+| `/etc/clawdi/host-policy.json` | Host policy, denied local mutations, and hosted-mode constraints. |
+| `/etc/clawdi/runtime-source.json` | Read-only datasource contract for runtime desired state. |
+| `/usr/bin/supervisord` | Standard process manager for enabled long-running runtimes. |
+| `/usr/bin/node` and npm tooling | Required for the npm-managed Clawdi CLI package and normal user workflows. |
+
+The image should not contain:
+
+- OpenClaw or Hermes app packages;
+- channel plugins;
+- channel runtime state;
+- tenant credentials;
+- endpoint patches;
+- a legacy runtime tree;
+- paths named after `agent-image-v2`.
+
+`agent-image-v2` is a repository directory name only.
+
+### 2. Persistent Runtime HOME
+
+- Owner: ordinary runtime user, normally `clawdi`
+- Persistence: persistent volume across container restarts
+
+| Path | Purpose |
+| --- | --- |
+| `/home/clawdi` | Runtime user's HOME. Official runtime installers write here. |
+| `/home/clawdi/clawdi` | Default workspace visible to agents and user workflows. |
+| `/home/clawdi/.openclaw` | OpenClaw official app root. |
+| `/home/clawdi/.openclaw/bin/openclaw` | OpenClaw executable expected by generated run config. |
+| `/home/clawdi/.hermes` | Hermes app state/root when created by its official installer. |
+| `/home/clawdi/.local/bin/hermes` | Hermes executable expected by generated run config. |
+
+Requirement: if `runtime init` starts as root/system, official OpenClaw/Hermes
+installers must drop to `CLAWDI_RUNTIME_USER` before writing HOME-local files.
+
+### 3. Persistent Clawdi Service State
+
+- Owner: Clawdi init/maintenance context
+- Persistence: persistent volume across container restarts
+
+| Path | Purpose |
+| --- | --- |
+| `/var/lib/clawdi/bin/clawdi` | Active managed CLI entrypoint. |
+| `/var/lib/clawdi/npm` | Managed npm prefix for the CLI package. |
+| `/var/lib/clawdi/npm-cache` | Managed npm cache. |
+| `/var/lib/clawdi/config/clawdi.json` | Managed non-secret Clawdi config. |
+| `/var/lib/clawdi/config/run/{hermes,openclaw}.json` | Persisted runtime launch contracts consumed by `clawdi run`. |
+| `/var/lib/clawdi/config/mitm/profiles.json` | Non-secret MITM profile bundle. |
+| `/var/lib/clawdi/cache/manifest.last-good.json` | Non-secret last-good manifest for degraded offline boot. |
+| `/var/lib/clawdi/install-inventory/*.json` | Per-runtime install/present/disabled/failed status. |
+| `/var/lib/clawdi/supervisor/supervisord.conf` | Generated standard supervisor config. |
+| `/var/lib/clawdi/status/cli-bootstrap.json` | CLI bootstrap/update status. |
+
+Normal user flows can execute the CLI, but should not hand-edit Clawdi-managed
+state or mutate the managed npm prefix.
+
+### 4. Ephemeral Runtime State
+
+- Owner: Clawdi runtime / current boot
+- Persistence: tmpfs or recreated on container restart
+
+| Path | Purpose |
+| --- | --- |
+| `/run/clawdi/instance-data.json` | Non-secret per-boot instance metadata. |
+| `/run/clawdi/instance-data-sensitive.json` | Redacted sensitive status marker. |
+| `/run/clawdi/mitm/secrets.json` | Short-lived secret values for broker `secretRef` gates. |
+| `/run/clawdi/mitm/ca.pem` | Per-run broker CA projected into child env. |
+| `/run/clawdi/supervisor.sock` | Supervisor control socket. |
+| `/tmp` | Normal temporary scratch for installers and tools. |
+
+Secrets must not be written into:
+
+- last-good manifests;
+- npm state;
+- shell startup files;
+- OpenClaw/Hermes source patches;
+- Docker args beyond the single runtime auth token injection.
+
+### 5. External Services
+
+- Owner: corresponding backend/service teams
+- Persistence: outside the runtime container
+
+| Service | Purpose |
+| --- | --- |
+| Runtime source | Endpoint configured by `/etc/clawdi/runtime-source.json`; returns a manifest and `secretValues`. |
+| npm registry | Standard `clawdi` package update channel. |
+| OpenClaw official installer | OpenClaw install/update authority. |
+| Hermes official installer | Hermes install/update authority. |
+| Clawdi native Channels | Shared Telegram, Discord, WhatsApp, iMessage, and Kobb-compatible channel control plane. |
+| sub2api | Hosted-managed OpenAI/Codex-compatible provider gateway. |
+
+## Boot Sequence
+
+`clawdi runtime init --non-interactive` is the hosted runtime convergence
+command. It is not a monorepo API client. The CLI reads a datasource contract
+from `/etc/clawdi/runtime-source.json` by default, or from
+`CLAWDI_RUNTIME_SOURCE_PATH` when explicitly overridden. `CLAWDI_RUNTIME_MANIFEST_PATH`
+is only a local fixture/simulation escape hatch.
+
+Example runtime source:
+
+```json
+{
+  "schemaVersion": "clawdi.runtimeSource.v1",
+  "type": "http",
+  "url": "https://runtime-source.example.test/manifest",
+  "auth": {
+    "type": "bearer-env",
+    "env": "CLAWDI_AUTH_TOKEN"
+  },
+  "timeoutMs": 15000
+}
+```
+
+Boundary:
+
+- `clawdi` CLI owns local convergence, validation, official installer
+  execution, local state projection, supervisor config, `clawdi run`, and MITM
+  broker lifecycle.
+- The external runtime source owns manifest generation and secret resolution.
+  Platform policy and UI remain outside this CLI contract.
+- The runtime source contract is the only wire boundary between them.
+
+| Step | Action | Expected result |
+| --- | --- | --- |
+| 1 | Detect hosted mode through host policy or explicit runtime mode. | Missing or invalid policy fails closed for mutation commands while recovery commands remain available. |
+| 2 | Check runtime credential. | `CLAWDI_AUTH_TOKEN` is present, or a last-good manifest exists for allowed offline boot. |
+| 3 | Fetch desired state from the configured runtime source. | Manifest generation, selected runtimes, channels, providers, and recovery policy are validated. |
+| 4 | Cache non-secret desired state. | `/var/lib/clawdi/cache/manifest.last-good.json` is written without secret values. |
+| 5 | Project short-lived secrets. | `/run/clawdi/mitm/secrets.json` is written only when secret values are returned. |
+| 6 | Install selected runtimes. | Enabled OpenClaw/Hermes entries use official installers under `/home/clawdi`; disabled entries are skipped. |
+| 7 | Write run contracts. | `/var/lib/clawdi/config/run/*.json`, MITM profiles, supervisor config, install inventory, status, and result files are written. |
+| 8 | Start managed runtime processes. | Standard `supervisord` launches enabled long-running runtimes through `clawdi run -- <runtime>`. |
+
+## Runtime Launch Sequence
+
+Hosted runtime startup is not configured through runtime-specific Docker args.
+`clawdi run` reads persisted local state.
+
+For runtime commands:
+
+```bash
+clawdi run -- hermes
+clawdi run -- openclaw
+```
+
+For generic hosted commands:
+
+```bash
+clawdi run -- codex exec ...
+clawdi run -- node script.js
+```
+
+Launch behavior:
+
+1. Read runtime run config from
+   `/var/lib/clawdi/config/run/{runtime}.json` when the command is a managed
+   runtime.
+2. For generic commands, use the managed profile bundle directly when hosted
+   mode has `/var/lib/clawdi/config/mitm/profiles.json`.
+3. If no enabled MITM profiles exist, exec the child with normal env/PATH/cwd.
+4. If profiles exist, start the native `clawdi-mitm-broker` bundle as a managed
+   child process.
+5. Wait for broker readiness and receive its actual proxy URL and generated CA
+   path.
+6. Project child-visible env:
+
+   ```text
+   HTTPS_PROXY
+   HTTP_PROXY
+   https_proxy
+   http_proxy
+   NO_PROXY
+   NODE_USE_ENV_PROXY
+   OPENCLAW_PROXY_URL
+   SSL_CERT_FILE
+   NODE_EXTRA_CA_CERTS
+   REQUESTS_CA_BUNDLE
+   CURL_CA_BUNDLE
+   GIT_SSL_CAINFO
+   DENO_CERT
+   CODEX_CA_CERTIFICATE
+   ```
+
+7. Strip hosted control env before launching the child:
+
+   ```text
+   CLAWDI_AUTH_TOKEN
+   CLAWDI_MITM_ENABLED
+   CLAWDI_MITM_PROFILE_BUNDLE
+   CLAWDI_MITM_PROXY_URL
+   CLAWDI_MITM_PROXY_HOST
+   CLAWDI_MITM_PROXY_PORT
+   CLAWDI_MITM_CA_FILE
+   CLAWDI_MITM_CA_PATH
+   CLAWDI_MITM_SECRET_FILE
+   CLAWDI_MITM_BROKER_PATH
+   CLAWDI_MITM_BROKER_BUNDLE
+   CLAWDI_MITM_ALLOW_REMOTE_PROXY
+   ```
+
+8. Exec the upstream child process and stop the broker when the child exits.
+
+## MITM Profile Model
+
+Profiles are non-secret JSON generated by `runtime init`. They describe
+matching, rewrite, and logging policy. Secret values live in `secretRef` entries
+and short-lived runtime files.
+
+Profile bundle path:
+
+```text
+/var/lib/clawdi/config/mitm/profiles.json
+```
+
+Secret value path:
+
+```text
+/run/clawdi/mitm/secrets.json
+```
+
+Current productized profile IDs. Hosted runtime manifests use top-level
+`channels` entries only. Profiles use secretRef gates when the runtime source
+manifest provides channel/provider credential references; without those refs,
+the generated staging fallback is host/path-scoped only and must not be treated
+as the production security boundary.
+
+| Profile ID | Kind | Match | Route target |
+| --- | --- | --- | --- |
+| `telegram-bot-api-channel` | HTTP | `api.telegram.org` + `/bot...` path token when `botTokenSecretRef` is present | `channels.telegram.baseUrl`, for example Kobb Bot API-compatible surface |
+| `discord-rest-channel` | HTTP | `discord.com/api/` + Bot authorization when `botTokenSecretRef` is present | `channels.discord.baseUrl` |
+| `discord-gateway-channel` | WebSocket | `gateway.discord.gg` WebSocket upgrade | `channels.discord.gatewayBaseUrl` or `channels.discord.websocketBaseUrl` |
+| `bluebubbles-imessage-channel` | HTTP | `bluebubbles.invalid/api/` + password query when `passwordSecretRef` is present | `channels.imessage.baseUrl` |
+| `whatsapp-web-channel` | WebSocket | `web.whatsapp.com/ws/` bridge path | `channels.whatsapp.websocketBaseUrl` |
+| `codex-openai-responses` | Provider | `api.openai.com/v1/responses` + Bearer authorization when `apiKeySecretRef` is present | Clawdi-managed sub2api Responses gateway |
+
+Profile constraints:
+
+- `rewrite.upstreamBaseUrl` must use `http`, `https`, `ws`, or `wss`.
+- `rewrite.upstreamBaseUrl` must not include credentials.
+- Profile bundle JSON must not contain secret values.
+- Broker defaults to loopback-only listening unless explicitly allowed for
+  tests.
+- Broker strips hop-by-hop headers, proxy-scoped auth headers, and upstream
+  `Set-Cookie` responses.
+- User BYOK provider traffic must not be silently proxied.
+
+## Agent Vault Alignment
+
+The MITM boundary intentionally follows Agent Vault's mature shape where it
+fits the hosted runtime product:
+
+- `clawdi run -- <command>` is the same wrapper boundary as
+  `agent-vault run -- <command>`.
+- The child receives standard `HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`,
+  Node/OpenClaw proxy hints, and CA trust env vars.
+- The broker is a native Go HTTP forward proxy that owns CONNECT, TLS leaf
+  minting, HTTP/1.1 forwarding, WebSocket upgrades, and header hygiene.
+- Profiles are explicit service rules; secret values stay outside the profile
+  JSON and are resolved through `secretRef` gates.
+
+Intentional differences:
+
+- Clawdi strips `CLAWDI_AUTH_TOKEN` from the child. Agent Vault can expose its
+  scoped token because that token is a broker credential; Clawdi's auth token is
+  a full runtime/control credential.
+- Clawdi defaults unmatched requests to deny. Agent Vault defaults unmatched
+  hosts to passthrough unless a vault is put into strict deny mode. Hosted
+  runtime should be stricter because Channels/sub2api routes are managed
+  desired state, not local developer convenience. Clawdi v1 intentionally does
+  not expose a passthrough profile kind.
+- Clawdi's local broker has no `Proxy-Authorization` challenge in the normal
+  loopback path. Remote proxy listening is for tests only unless a separate
+  authenticated proxy boundary is added.
+- Clawdi v1 profiles match and rewrite request metadata, but do not do
+  placeholder substitution inside request bodies or WebSocket text frames. Use
+  native provider projection or Clawdi Channels bridge surfaces for those cases.
+- Clawdi v1 channel profiles are endpoint-routing gates, not a complete
+  credential vault. If a runtime must keep a real Bot/API token in its own
+  config or env to produce an official-looking request, that token remains
+  visible to the same Unix user. Full Agent Vault-style credential isolation
+  requires dummy-token substitution or a broker/control boundary outside the
+  agent user's readable state.
+- Clawdi hosted runtime is not a network sandbox by itself. Strong bypass
+  prevention requires Docker/network policy such as an egress-locked container
+  mode; env-based proxying alone is cooperative.
+
+## Channel Boundary
+
+Hosted v2 channels are Clawdi-native channel resources. The external runtime
+source provisions or selects channel accounts and emits their runtime-facing
+surface through top-level `channels` entries.
+
+| Channel | Boundary |
+| --- | --- |
+| Telegram/Kobb | Runtime source emits `channels.telegram`; CLI routes Bot API-shaped traffic to the configured Bot API-compatible surface. |
+| Discord | Runtime source emits `channels.discord`; CLI routes REST and Gateway-shaped traffic to the configured Channels surface. |
+| WhatsApp | Runtime source emits `channels.whatsapp`; CLI routes a runtime-facing bridge. Protocol state stays in the Channels control plane, not in OpenClaw/Hermes patches. |
+| iMessage | Runtime source emits `channels.imessage`; CLI routes BlueBubbles-compatible traffic. BlueBubbles state and cert handling stay in the Channels control plane. |
+
+The CLI must not add a private RPC route for channel control.
+
+## Codex / Provider Boundary
+
+Codex source check: `@openai/codex@0.136.0` maps to upstream tag
+`rust-v0.136.0` (`7ca611348db9446711ed16ed81c84095e3721cee`). In that source,
+Codex builds Requests API calls from provider `base_url` plus `responses`,
+defaults OpenAI API-key mode to `https://api.openai.com/v1`, supports native
+`model_providers.*.base_url`, `wire_api = "responses"`, and `env_key`, and
+honors custom CA through `CODEX_CA_CERTIFICATE` / `SSL_CERT_FILE`.
+
+Product decision:
+
+- Hosted-managed Codex can use MITM so the child still sees official
+  `https://api.openai.com/v1/responses` behavior.
+- Ordinary OpenAI-compatible providers that do not need official OpenAI/Codex
+  endpoint simulation should use native provider projection/direct provider
+  URLs.
+- Managed provider routing must not project provider pool/group selection into
+  the agent environment. Provider selection stays in the runtime source and
+  profile policy.
+
+## Clawdi CLI Update Model
+
+Hosted runtime CLI updates belong to the standalone `clawdi` repo and the
+standard npm package channel.
+
+| Component | Update authority |
+| --- | --- |
+| Base image | Runtime platform image pipeline. |
+| Clawdi CLI | npm-managed `clawdi` package. |
+| Native broker | `clawdi-mitm-broker/` bundle shipped with the CLI package. |
+| OpenClaw | OpenClaw official installer/updater behavior. |
+| Hermes | Hermes official installer/updater behavior. |
+
+The target hosted shape is:
+
+- read-only `/usr/local/bin/clawdi` launcher;
+- active managed CLI entrypoint at `/var/lib/clawdi/bin/clawdi`;
+- root/system-owned npm prefix at `/var/lib/clawdi/npm`;
+- normal user execution allowed;
+- normal user mutation of the managed install/config denied by host policy.
+
+## Current Verification
+
+The current branch has local and CI coverage for the non-secret path.
+
+Focused local checks used during the implementation:
+
+```bash
+bun run --filter clawdi typecheck
+go test ./...
+bun test --isolate --max-concurrency=1 \
+  packages/cli/tests/runtime.test.ts \
+  packages/cli/tests/runtime-mitm-env.test.ts \
+  packages/cli/tests/runtime-mitm-profiles.test.ts \
+  packages/cli/tests/runtime-mitm-broker.test.ts \
+  packages/cli/tests/commands/run.test.ts \
+  packages/cli/tests/smoke.test.ts
+CLAWDI_MITM_BROKER_BUNDLE_OUTDIR=clawdi-mitm-broker \
+  bun run --cwd packages/cli build:mitm-broker
+bun run --cwd packages/cli check:publish-manifest
+```
+
+External runtime smoke should cover official runtime installers, real
+Channels credentials, provider gateway credentials, restart behavior, and
+inbound bot canaries. That smoke belongs to the runtime platform, not this CLI
+package.
+
+## Release Readiness
+
+This slice is ready for npm-package integration and external runtime-platform
+staging.
+
+Ready:
+
+- runtime init/status/doctor commands;
+- hosted path resolver and host policy parser;
+- runtime source fetch/cache path;
+- selected official install for OpenClaw/Hermes;
+- persisted run configs;
+- generated standard supervisor config;
+- self-contained native broker bundle;
+- profile validation and broker tests;
+- CLI CI and publish payload checks.
+
+Production blockers:
+
+- external channel activation must ensure per-channel credentials before
+  publishing a new manifest generation;
+- runtime source manifests must expose per-channel secret refs for precise
+  generated profiles;
+- real npm publish/update channel must be promoted;
+- runtime-platform staging and real external bot-message canary have not run
+  yet;
+- Channels/provider-gateway runtime smoke remains external to this CLI PR;
+- daemon/control RPC full-suite flake remains an unrelated residual risk even
+  though the failing shard passes when rerun directly.
+
+## Source Map
+
+| Area | File |
+| --- | --- |
+| System architecture overview | `docs/architecture.md` |
+| Runtime manifest contract and datasource normalization | `packages/cli/src/runtime/manifest-contract.ts`, `packages/cli/src/runtime/manifest-source.ts` |
+| Runtime convergence, official install, profiles, supervisor config | `packages/cli/src/runtime/manifest.ts` |
+| Path contract | `packages/cli/src/runtime/paths.ts` |
+| Run wrapper | `packages/cli/src/commands/run.ts` |
+| MITM env projection | `packages/cli/src/runtime/mitm-env.ts` |
+| Profile schema | `packages/cli/src/runtime/mitm-profiles.ts` |
+| Native broker | `packages/cli/native/mitm-broker/main.go` |
+| Broker tests | `packages/cli/tests/runtime-mitm-broker.test.ts` |
+| Runtime tests | `packages/cli/tests/runtime.test.ts` |
+| CLI contract | `docs/plans/hosted-runtime-cli.md` |
+| OpenClaw/Hermes patch replacement inventory | `docs/plans/openclaw-hermes-mitm-inventory.md` |

--- a/docs/plans/hosted-runtime-cli.md
+++ b/docs/plans/hosted-runtime-cli.md
@@ -1,0 +1,479 @@
+# Hosted Runtime CLI Contract
+
+**Status:** managed npm bootstrap and local runtime contract implemented
+**Last updated:** 2026-06-09
+**Owner:** CLI runtime layer
+
+## Document Map
+
+- Canonical hosted runtime design: `../hosted-runtime.md`.
+- Current CLI contract: this file.
+- Current implementation roadmap: `hosted-runtime-roadmap.md`.
+- OpenClaw/Hermes patch replacement and MITM boundary:
+  `openclaw-hermes-mitm-inventory.md`.
+## Runtime Image Assumption
+
+A managed runtime image owns only the Linux envelope, baked environment
+defaults, host policy, and an entrypoint that calls:
+
+```bash
+clawdi runtime init --non-interactive
+```
+
+The image does not bake OpenClaw, Hermes, legacy runtime trees, source patches,
+endpoint flags, or private runtime-control RPC behavior. All cloud-init-style
+convergence and runtime command wrapping belongs to the standalone `clawdi`
+CLI.
+
+## Product Decision
+
+The hosted runtime uses the normal open-source `clawdi` CLI as the
+cloud-init-like convergence engine. There is no private `clawdi-init` binary,
+no reduced hosted-only CLI, and no runtime-control RPC surface for ordinary agent
+CLI actions.
+
+Command namespace:
+
+```bash
+clawdi runtime init
+clawdi runtime status
+clawdi runtime doctor
+```
+
+Supporting inspect commands:
+
+```bash
+clawdi auth status
+clawdi config paths
+clawdi capabilities
+```
+
+`clawdi runtime init` is an operator/runtime command. Normal local onboarding
+continues to use `clawdi setup`.
+
+Hosted `runtime init` may run in a system context so it can write Clawdi-owned
+service state. That does not make the whole `clawdi` CLI privileged: normal
+agent/user CLI calls run as the ordinary runtime user. OpenClaw/Hermes official
+installer processes are also launched as the runtime user when `runtime init`
+itself starts as root.
+
+## CLI Package And Broker Packaging
+
+The user-facing command is still `clawdi`, but the hosted release unit is the
+standard npm package. The package is prepared with:
+
+```bash
+bun run --cwd packages/cli build
+bun run --cwd packages/cli build:mitm-broker
+npm pack
+```
+
+That builds the JS CLI, builds a managed MITM broker bundle at
+`packages/cli/clawdi-mitm-broker/`, and produces a tarball/installable package
+with the same layout as the public npm release.
+
+Packaging decision:
+
+- `clawdi` remains the single user-facing command.
+- The `clawdi` npm package owns manifest convergence, runtime command wrapping,
+  policy evaluation, broker bundle selection, diagnostics, and update
+  orchestration.
+- The MITM broker remains a separate managed child process inside the package.
+  TLS MITM
+  and proxy protocol handling must not run inside the JS CLI process.
+- The current broker bundle is a relocatable `clawdi-mitm-broker/` directory
+  inside the package. It contains a Go native
+  `bin/clawdi-mitm-broker` executable and a manifest.
+- `clawdi run -- <runtime>` first looks for that bundle beside the active CLI
+  package entrypoint. It can still use an explicit `CLAWDI_MITM_BROKER_PATH` or
+  `CLAWDI_MITM_BROKER_BUNDLE` for local verification and emergency override.
+- The native broker implements HTTPS CONNECT, TLS interception, HTTP
+  forwarding, WebSocket upgrade tunneling, profile matching, secretRef gates,
+  rewrites, denial, and original-host annotations.
+- Runtime images should bake only the stable Linux envelope plus a way to invoke
+  the managed npm-installed `clawdi`. CLI and broker updates are owned by the
+  standalone `clawdi` npm release channel, not an image build.
+
+This gives a one-command UX without running TLS MITM inside the Bun/JS CLI
+process. The broker still keeps a process and version boundary so it can be
+updated, replaced, or disabled independently.
+
+## Managed CLI Npm Install
+
+Managed runtime CLI install uses the same package channel as public `clawdi`:
+the npm package. It is not a backend artifact URL/SHA channel.
+
+- `/usr/local/bin/clawdi`: image-baked, read-only, root-owned launcher shim;
+- `/var/lib/clawdi/bin/clawdi`: active managed CLI entrypoint;
+- `/var/lib/clawdi/npm`: root-owned npm prefix;
+- `/var/lib/clawdi/npm-cache`: root-owned npm cache;
+- `/var/lib/clawdi/status/cli-bootstrap.json`: first-install status;
+- `/usr/local/share/clawdi/cli-bootstrap.json`: read-only npm package spec for
+  first boot when no active package exists.
+
+The shim is intentionally small. It may locate an active npm-managed entrypoint,
+run `npm install -g <packageSpec> --prefix /var/lib/clawdi/npm` for first boot,
+and `exec` the real CLI. It must not parse runtime manifests, write
+OpenClaw/Hermes config, own MITM profiles, resolve tenant policy, or persist
+auth.
+
+Rules:
+
+- `CLAWDI_AUTH_TOKEN` is used only to fetch control-plane state and must not be
+  persisted in npm state, status files, shell startup files, or manifests.
+- Ordinary agent/user invocations execute the active CLI but cannot modify the
+  managed npm prefix or Clawdi-managed config.
+- Hosted policy may deny ordinary-user `clawdi update`; system init/maintenance
+  can still update the managed npm package.
+- CLI npm updates are separate from OpenClaw/Hermes native updater behavior.
+
+Manifest shape:
+
+```json
+{
+  "clawdiCli": {
+    "source": "npm:clawdi",
+    "packageSpec": "clawdi@latest",
+    "managedConfig": true,
+    "userEditableConfig": false
+  }
+}
+```
+
+Manifest contract:
+
+- the runtime source returns `{ manifest, secretValues }`, where `manifest` is
+  `clawdi.hosted-runtime.manifest.v1`;
+- the CLI normalizes runtime source input into `clawdi.runtimeDesiredState.v1`
+  before validation and convergence;
+- runtime desired state does not include embedded secret values; runtime
+  secrets are delivered through the response side channel and written only to
+  `/run`;
+- `system.workspace` controls the shared workspace root, while a runtime-level
+  `paths.workspace` controls that runtime's run config `cwd`.
+
+Current implementation:
+
+- `runtime init` treats hosted manifest `clawdiCli` as non-secret metadata;
+- the image-side shim bootstraps the first npm package from immutable metadata
+  when `/var/lib/clawdi/bin/clawdi` is missing;
+- local runnable image tests use a packed npm tarball to exercise the same npm
+  install path without publishing a package.
+
+## Ownership Boundary
+
+The CLI owns:
+
+- hosted/runtime path resolution;
+- host policy parsing and enforcement;
+- runtime manifest validation;
+- boot state machine and local status files;
+- official first-install orchestration for selected OpenClaw/Hermes runtimes;
+- persisted per-runtime run configs consumed by `clawdi run -- hermes` and
+  `clawdi run -- openclaw`;
+- runtime source datasource, projection writers, diagnostics, and local
+  maintenance commands.
+
+External runtime platform responsibilities:
+
+- container injection of `CLAWDI_AUTH_TOKEN`;
+- runtime manifest generation;
+- secret resolution service;
+- CLI npm install policy;
+- image build and Docker launch envelope.
+
+The CLI consumes runtime policy. It must not contain private tenant policy or
+platform UI policy.
+
+## Implemented Surface
+
+Implemented commands:
+
+- `clawdi auth status [--json]`;
+- `clawdi config paths [--json]`;
+- `clawdi capabilities [--json]`;
+- `clawdi runtime init --non-interactive --json`;
+- `clawdi runtime init --manifest-file <path>`;
+- `clawdi runtime status --json`;
+- `clawdi runtime doctor --json`.
+- `clawdi run -- hermes` and `clawdi run -- openclaw` in hosted mode when a
+  managed runtime run config exists.
+
+Implemented behavior:
+
+- hosted/local path resolver;
+- host policy parser;
+- hosted policy enforcement for denied local mutation commands;
+- hosted-mode local user self-update skip;
+- cloud-init-style `status.json` and `result.json`;
+- fixture manifest simulation;
+- authenticated desired-state fetch/cache from the configured runtime source
+  contract;
+- normalizer from `clawdi.hosted-runtime.manifest.v1` into
+  `clawdi.runtimeDesiredState.v1`;
+- runtime `secretValues` projection into `/run/clawdi/mitm/secrets.json`
+  without writing secrets into the last-good manifest cache;
+- last-good manifest cache and degraded offline restart;
+- stale generation rejection;
+- managed projection files and boot semaphores;
+- manifest-selected official first install for OpenClaw/Hermes.
+- managed run config generation under
+  `/var/lib/clawdi/config/run/{hermes,openclaw}.json`.
+- hosted `clawdi run -- <runtime>` command wrapping from those persisted
+  configs without requiring docker startup flags.
+- MITM profile bundle schema `clawdi.mitmProfiles.v1`.
+- `runtime init` writes enabled non-secret MITM profiles to
+  `/var/lib/clawdi/config/mitm/profiles.json`.
+- managed run configs reference `mitmProfileBundlePath` when enabled profiles
+  exist.
+- generated `supervisord` config at
+  `/var/lib/clawdi/supervisor/supervisord.conf` for enabled long-running
+  runtimes. Supervised programs still execute through
+  `clawdi run -- <runtime>`.
+- hosted `clawdi run -- <runtime>` now injects broker/proxy/CA env when a
+  managed MITM profile bundle is present.
+- hosted `clawdi run -- <runtime>` now starts the managed broker bundle,
+  rewrites child env to the broker's actual proxy/CA paths, and stops the
+  broker when the runtime process exits.
+- hosted `clawdi run -- <command>` also applies the managed MITM profile bundle
+  to generic commands such as `codex` or `node` when no runtime-specific run
+  config exists. This keeps Codex official endpoint MITM on the same user-facing
+  command without adding a private RPC surface.
+- `clawdi-mitm-broker/` is a self-contained native broker bundle. It supports
+  profile-driven routing, secretRef header/path/query matching via short-lived
+  secret files, HTTP rewrites, denial, original-host annotations, CONNECT/TLS
+  interception, WebSocket upgrade tunneling, loopback-only default listening,
+  strict upstream URL validation, proxy-scoped header stripping, upstream
+  `Set-Cookie` stripping, and per-run CA generation.
+- npm package build via `bun run --filter clawdi build` plus
+  `build:mitm-broker`, including the packaged broker bundle.
+- managed CLI npm bootstrap from immutable image metadata, with active symlink
+  switch and bootstrap status under `/var/lib/clawdi/status/cli-bootstrap.json`.
+- local broker/runtime tests covering profile validation, proxy/CA env
+  projection, official-looking provider routes, HTTP rewrite, and WebSocket
+  upgrade handling.
+
+Not yet implemented in this branch:
+
+- platform-level status handling for
+  `/var/lib/clawdi/status/cli-bootstrap.json`.
+
+## Official First Install
+
+Runtime selection is manifest-driven:
+
+```json
+{
+  "schemaVersion": "clawdi.runtimeDesiredState.v1",
+  "runtimes": {
+    "openclaw": { "enabled": true },
+    "hermes": { "enabled": false }
+  }
+}
+```
+
+OpenClaw installer:
+
+```text
+https://openclaw.ai/install-cli.sh
+```
+
+Hermes installer:
+
+```text
+https://hermes-agent.nousresearch.com/install.sh
+```
+
+Installers run with `HOME` set to the runtime user's persistent HOME. The CLI
+does not pass hosted-only install roots such as Hermes `--dir` or OpenClaw
+`--prefix` in the normal path.
+
+If the expected command already exists, install is skipped and inventory records
+`present`. Disabled runtimes are not installed and inventory records
+`disabled`. Enabled runtimes that cannot be installed make boot status fail.
+
+## Filesystem Contract
+
+Local mode:
+
+- state root: user config/cache/state locations already used by the CLI;
+- runtime homes: native defaults such as `~/.hermes` and `~/.openclaw`;
+- user can run normal setup/update/teardown commands.
+
+Hosted mode:
+
+- user: `clawdi`;
+- HOME: `/home/clawdi`;
+- workspace: `/home/clawdi/clawdi`;
+- service state: `/var/lib/clawdi`;
+- runtime scratch and short-lived secrets: `/run/clawdi` and `/tmp`;
+- host policy: `/etc/clawdi/host-policy.json`;
+- no legacy target model.
+
+`/var/lib/clawdi` must be exec-capable in hosted runtime deployments because
+the active managed CLI entrypoint is `/var/lib/clawdi/bin/clawdi`.
+
+Managed runtime command config:
+
+- path: `/var/lib/clawdi/config/run/{runtime}.json`;
+- owner: `clawdi runtime init` in the system convergence context;
+- consumer: `clawdi run -- hermes` / `clawdi run -- openclaw`;
+- contents: command path, default args, environment, PATH prefix, cwd,
+  generation, and instance id;
+- sensitive values should be delivered as secret references or short-lived
+  runtime files, not plain persisted tokens.
+
+Managed MITM profile bundle:
+
+- path: `/var/lib/clawdi/config/mitm/profiles.json`;
+- schema: `clawdi.mitmProfiles.v1`;
+- owner: `clawdi runtime init`;
+- consumer: hosted `clawdi run -- <runtime>` and `clawdi run -- <command>`
+  broker startup;
+- contents: enabled profile ids, match rules, rewrite targets, redaction
+  policy, and secret references;
+- sensitive values must not be inlined.
+
+## `clawdi run` Broker Direction
+
+The current implementation makes `clawdi run -- hermes` and
+`clawdi run -- openclaw` consume a persisted run config and, when profiles are
+present, start a managed broker child process. In hosted mode, generic
+`clawdi run -- <command>` also starts the broker when the managed profile bundle
+exists. This is the activation boundary for runtime MITM/broker policy across
+Hermes, OpenClaw, Codex, and small diagnostic tools.
+
+Target behavior:
+
+- read the persisted run config;
+- read a persisted non-secret MITM profile bundle generated by `runtime init`;
+- start or attach to a local broker/proxy process;
+- project a CA PEM when TLS interception is enabled;
+- strip stale proxy/trust env from the parent process;
+- inject `HTTPS_PROXY`, `HTTP_PROXY`, `https_proxy`, `http_proxy`, `NO_PROXY`,
+  `no_proxy`, `NODE_USE_ENV_PROXY`, `OPENCLAW_PROXY_URL`, and CA trust env into
+  the child;
+- strip `CLAWDI_AUTH_TOKEN` and all `CLAWDI_MITM_*` control variables before
+  `exec` so the child sees standard proxy/CA behavior, not Clawdi internals;
+- do not globally inject `--use-env-proxy` through `NODE_OPTIONS`; Node-based
+  diagnostics/runtimes need a hosted base Node version that supports
+  `NODE_USE_ENV_PROXY` for their HTTP client path, or an explicit runtime
+  command/config decision;
+- inject service/provider credentials only through secret references or
+  short-lived runtime files;
+- exec the upstream runtime command;
+- never require normal startup flags such as Discord endpoint, channel URL,
+  provider token, or certificate path.
+
+Focused implementation checks:
+
+```bash
+bun test packages/cli/tests/commands/run.test.ts \
+  packages/cli/tests/runtime-mitm-broker.test.ts
+bun test packages/cli/tests/runtime.test.ts \
+  packages/cli/tests/smoke.test.ts \
+  packages/cli/tests/runtime-mitm-broker.test.ts \
+  packages/cli/tests/commands/run.test.ts
+bun run --filter clawdi typecheck
+bun run --filter clawdi build
+CLAWDI_MITM_BROKER_BUNDLE_OUTDIR=packages/cli/clawdi-mitm-broker \
+  bun run --filter clawdi build:mitm-broker
+```
+
+The focused tests prove proxy+CA routing, profile validation, secretRef gates,
+HTTP rewrite, WebSocket tunneling, and official-looking provider routes without
+requiring deployed runtime services. Real runtime image boot, deployed native
+channel credentials, and inbound bot canaries belong to an external runtime
+platform smoke lane.
+
+Agent Vault is the implementation reference for the mechanics: one local plain
+HTTP proxy listener handles both `CONNECT` for HTTPS upstreams and absolute-form
+HTTP forwarding; WebSocket upgrade/tunnel traffic is supported explicitly; proxy
+auth is stripped before upstream forwarding; request logging redacts tokens.
+
+Clawdi now follows the Agent Vault-style split more closely: `clawdi` remains
+the user-facing orchestrator, while a native broker child process owns the
+local proxy transport. The profile model stays above the transport
+implementation so a future broker can be replaced without changing run config
+or runtime UX.
+
+Clawdi-specific boundaries:
+
+- Telegram and Discord route to Clawdi native channel HTTP/WebSocket surfaces
+  when native runtime config is missing.
+- WhatsApp channel protocol state belongs to the hosted channel service. The
+  broker may route a runtime-facing bridge, but it must not own real WhatsApp
+  protocol state.
+- iMessage channel service paths and managed trust config belong to the hosted
+  channel service, not the CLI.
+- Hosted-managed Codex uses MITM to simulate the official OpenAI Responses
+  path from the child process view. The child still sees
+  `https://api.openai.com/v1/responses`; the broker owns the managed-provider
+  credential and rewrite boundary.
+- Ordinary OpenAI-compatible provider APIs use native provider projection or a
+  direct provider URL when official Codex/OpenAI behavior does not need to be
+  simulated.
+- User BYOK provider traffic must not be silently proxied.
+
+External runtime smoke is not part of default CLI CI because it depends on a
+runtime image, external channel credentials, and provider gateway credentials.
+
+The current productized profile IDs are:
+
+- `discord-rest-channel`;
+- `discord-gateway-channel`;
+- `telegram-bot-api-channel`;
+- `bluebubbles-imessage-channel`;
+- `whatsapp-web-channel`;
+- `codex-openai-responses`.
+
+An egress-deny profile remains a follow-up policy profile, not part of the
+current generated default bundle.
+
+Hosted mode should support a read-only rootfs shape where:
+
+- `/home/clawdi` is writable by the ordinary `clawdi` runtime user;
+- `/var/lib/clawdi` is writable only by the system init/maintenance context and
+  exec-capable for the managed CLI entrypoint;
+- `/run/clawdi` is system-writable scratch;
+- `/tmp` is normal temporary scratch;
+- system assets are read-only.
+
+If `runtime init` starts as root/system, official OpenClaw/Hermes installers
+must still execute as `CLAWDI_RUNTIME_USER` so files created under HOME remain
+owned by the runtime user.
+
+## Current Non-Goals
+
+- No deployment rollout policy in this repo; the CLI fetch path is implemented
+  and deployment gating belongs to the runtime platform.
+- No OpenClaw/Hermes native updater or rollback behavior in the current slice.
+- No default-CI native channel E2E in the current slice.
+- No endpoint/token flags on normal runtime startup.
+- No OpenClaw/Hermes source patching.
+
+## Next Implementation Gates
+
+1. Publish the production `clawdi` npm package with the broker bundle and keep
+   runtime image bootstrap on the approved package spec or dist-tag.
+2. Tighten generated native channel MITM routes once runtime source manifests expose
+   per-channel secret refs.
+3. Generate full OpenClaw/Hermes managed projection files from the manifest.
+4. Keep the self-contained broker bundle part of the managed CLI npm package and
+   report CLI/broker versions in runtime inventory.
+5. Add an external opt-in smoke lane for runtime images and native channel
+   credentials outside the default CLI PR checks.
+6. Promote native channel smoke into a repeatable external test lane.
+7. Expand broker tests for WebSocket, provider projection, and egress-deny
+   policy.
+
+## Verification
+
+Focused checks for this branch:
+
+```bash
+bun test packages/cli/tests/smoke.test.ts packages/cli/tests/runtime.test.ts
+bun run --filter clawdi typecheck
+bun run --filter clawdi build
+bunx biome check packages/cli/src/runtime docs/plans/hosted-runtime-cli.md docs/plans/openclaw-hermes-mitm-inventory.md docs/plans/hosted-runtime-roadmap.md
+```

--- a/docs/plans/hosted-runtime-roadmap.md
+++ b/docs/plans/hosted-runtime-roadmap.md
@@ -1,0 +1,82 @@
+# Hosted Runtime Roadmap
+
+**Status:** current CLI roadmap after managed npm bootstrap and local runtime contract tests
+**Last updated:** 2026-06-09
+
+## Canonical Inputs
+
+- Current CLI contract: `hosted-runtime-cli.md`.
+- Canonical hosted runtime design: `../hosted-runtime.md`.
+- OpenClaw/Hermes patch replacement and MITM boundary:
+  `openclaw-hermes-mitm-inventory.md`.
+
+## Current Slice
+
+The active slice is hosted runtime command wrapping on top of selected
+official first install:
+
+- `clawdi runtime init` validates `clawdi.runtimeDesiredState.v1` after
+  normalizing the runtime source `{ manifest, secretValues }` response;
+- secret material is not part of the current desired-state schema; runtime
+  source `secretValues` are projected only into ephemeral runtime files;
+- hosted `system.workspace` and runtime-level `paths.workspace` are honored when
+  writing managed config, supervisor config, and run configs;
+- runtime selection is driven by `runtimes.openclaw.enabled` and
+  `runtimes.hermes.enabled`;
+- selected OpenClaw/Hermes runtimes use official installer metadata;
+- installers run with the runtime user's persistent HOME;
+- when `runtime init` runs in a system context, installers drop to
+  `CLAWDI_RUNTIME_USER` before writing HOME-local app files;
+- disabled runtimes are skipped;
+- installed/present/disabled/failed states are recorded in local inventory;
+- boot status fails if an enabled runtime cannot install.
+- `runtime init` writes managed run configs under
+  `/var/lib/clawdi/config/run/{runtime}.json`;
+- `clawdi run -- hermes` and `clawdi run -- openclaw` consume those configs in
+  hosted mode without docker startup flags.
+- hosted `clawdi run -- <command>` also applies the managed MITM bundle to
+  generic commands such as Codex when no runtime-specific config exists.
+- `runtime init` writes `/var/lib/clawdi/supervisor/supervisord.conf`; the
+  hosted image uses standard `supervisord` to manage enabled long-running
+  runtimes through `clawdi run -- <runtime>`.
+
+## Phase Status
+
+| Phase | Status | Notes |
+| --- | --- | --- |
+| P0 naming and docs | Done | Use `clawdi runtime ...`; no private `clawdi-init`. |
+| P1 inspect commands and path resolver | Done | `auth status`, `config paths`, `capabilities`, hosted/local paths. |
+| P2 runtime namespace skeleton | Done | `runtime init/status/doctor` and status/result files. |
+| P3 fixture manifest simulation | Done | Local manifest file override, cache, stale generation rejection. |
+| P4 selected official first install | Done | OpenClaw/Hermes installed only when enabled. |
+| P5 authenticated datasource | Done locally | `runtime init` reads a configured runtime source contract, fetches desired state with `CLAWDI_AUTH_TOKEN`, normalizes `clawdi.hosted-runtime.manifest.v1`, caches the non-secret manifest, and projects `secretValues` into `/run/clawdi/mitm/secrets.json`. |
+| P6 managed projections | Partial locally | `runtime init` generates runtime run configs, supervisor config, MITM profiles, and `/run/clawdi/mitm/secrets.json` from the hosted manifest. Native OpenClaw/Hermes config fragment writers and on-demand OpenClaw plugin install remain follow-up. |
+| P6.5 runtime process management | Done locally | `runtime init` generates `/var/lib/clawdi/supervisor/supervisord.conf`; the image default command runs `supervisord` after convergence. No private `clawdi runtime supervise` daemon. |
+| P7 CLI npm bootstrap | Done locally | The standalone `clawdi` npm package includes the self-contained `clawdi-mitm-broker/` bundle. Runtime image bootstrap can use npm to install the package into `/var/lib/clawdi/npm` and switch `/var/lib/clawdi/bin/clawdi` to that package entrypoint. `runtime init` does not consume backend artifact URLs. |
+| P8 native channel profiles | Done locally | Profile generation and broker tests cover Telegram, Discord, WhatsApp, BlueBubbles/iMessage, and OpenAI Responses-compatible routes with fake/local upstreams. Real channel credentials belong to an external smoke lane, not the default CLI PR. |
+| P9 `clawdi run` broker | Self-contained native broker bundle implemented | Persisted run config exists; runtime init writes `clawdi.mitmProfiles.v1` bundles and run configs reference them. Hosted `clawdi run` starts the managed broker bundle for runtime commands and generic commands, rewrites child proxy/CA env to the actual broker values, hides the secret-file path from the child, and stops the broker with the child process. The bundle contains a Go native `clawdi-mitm-broker` binary; the broker owns CONNECT/TLS/WebSocket mechanics, header/path/query secretRef gates, rewrites, denial, and loopback-only default listening. |
+| P10 native updater and rollback | Deferred | Keep authority with OpenClaw/Hermes native behavior. |
+
+## Next Gates
+
+1. Publish the standalone `clawdi` npm package with the broker bundle.
+2. Keep runtime image bootstrap on `clawdi@latest` or an approved npm dist-tag
+   outside this CLI repo.
+3. Add native OpenClaw/Hermes projection writers and on-demand OpenClaw channel
+   plugin installation for enabled Clawdi native Channels.
+4. Report CLI/broker versions in runtime inventory.
+5. Define an external opt-in smoke lane for runtime images and secret-gated
+   native channel credentials.
+6. Add native channel inbound E2E outside default CLI PR checks when the test
+   control plane exposes safe admin ingress fixtures.
+
+## Explicit Non-Goals For Current PR
+
+- No channel credential activation transaction in the CLI; the runtime source
+  and hosted service remain the authority for channel credentials.
+- No native OpenClaw/Hermes update or rollback.
+- No egress-deny network policy enforcement beyond broker profile gates.
+- No default-CI native channel E2E implementation in this CLI PR.
+- No rollout policy for the managed npm bootstrap in this repo.
+- No private RPC surface for agent CLI actions.
+- No OpenClaw/Hermes source patching.

--- a/docs/plans/openclaw-hermes-mitm-inventory.md
+++ b/docs/plans/openclaw-hermes-mitm-inventory.md
@@ -1,0 +1,198 @@
+# OpenClaw/Hermes MITM And Patch Replacement Inventory
+
+**Status:** current implementation plan
+**Last updated:** 2026-06-09
+
+Canonical hosted runtime design:
+[`../hosted-runtime.md`](../hosted-runtime.md).
+
+## Decision
+
+The hosted runtime keeps OpenClaw and Hermes as upstream runtimes with zero
+Clawdi source patches.
+
+Use native runtime configuration wherever OpenClaw or Hermes exposes a stable
+surface. Use Clawdi native Channels for channel-owned protocol behavior. Use the
+broker/MITM layer only as an egress, trust, and credential projection layer when
+native runtime configuration cannot express the required endpoint or credential
+source.
+
+The target activation command is:
+
+```bash
+clawdi run -- hermes
+clawdi run -- openclaw
+```
+
+In hosted mode this command reads the persisted runtime run config, starts a
+local broker when a managed profile bundle exists, injects standard proxy and
+trust environment into the child process, and then execs the upstream runtime
+command. Normal startup must not require endpoint, token, or certificate flags.
+
+MITM is not a replacement for:
+
+- runtime-native provider/model semantics;
+- local runtime state;
+- OpenClaw/Hermes updater source of truth;
+- channel ownership policy;
+- Clawdi hosted service channel activation.
+
+## Channel Boundary
+
+All hosted channel credentials and product semantics are owned by Clawdi hosted
+service native Channels. The CLI consumes the runtime manifest and secret
+values; it does not activate channels, pair accounts, or expose a private RPC
+surface for channel control.
+
+| Channel | Owner | Runtime-facing contract |
+| --- | --- | --- |
+| Telegram | Clawdi native Channels | Bot API-compatible HTTP surface. |
+| Discord | Clawdi native Channels | Discord REST and Gateway-compatible surfaces. |
+| WhatsApp | Clawdi native Channels | Runtime-facing bridge surface; hosted service owns real protocol state. |
+| iMessage | Clawdi native Channels | BlueBubbles/Photon-compatible service path and trust config. |
+
+Current hosted manifests use top-level `channels`; the schema is strict so
+undeclared top-level fields are rejected.
+
+## Agent Vault Reference Patterns
+
+Agent Vault is the concrete implementation reference for the transport layer,
+not for Clawdi product ownership.
+
+Patterns to copy:
+
+- `run -- <command>` is the activation boundary for the child process.
+- The child receives `HTTPS_PROXY`, `HTTP_PROXY`, `https_proxy`, and
+  `http_proxy` pointing at one plain HTTP local proxy listener.
+- The proxy listener handles `CONNECT` for HTTPS upstreams and absolute-form
+  forward-proxy requests for plain HTTP upstreams.
+- Proxy-scoped auth headers are stripped before upstream forwarding.
+- The run wrapper writes/projects a CA PEM and injects common trust env:
+  `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`,
+  `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, and `DENO_CERT`.
+- `NODE_USE_ENV_PROXY=1` is injected for Node runtimes that honor env proxy
+  natively.
+- `OPENCLAW_PROXY_URL` is injected for OpenClaw proxy-aware paths.
+- WebSocket upgrade/tunnel traffic is implemented and tested explicitly.
+- Request logs redact tokens and sensitive payload values.
+- Network egress policy must block metadata/private ranges unless explicitly
+  allowed.
+
+Patterns not to copy:
+
+- Do not require a separate broker server product boundary for Clawdi hosted
+  runtime.
+- Do not expose a Clawdi RPC route for channel control in the CLI.
+- Do not store proxy tokens in Docker args or user-mutated dotfiles.
+
+## Framework Decision
+
+The implementation path is a Clawdi-managed native broker child process,
+modeled after Agent Vault's split between CLI orchestration and local proxy
+transport:
+
+1. Keep `clawdi` as the single user-facing command and update surface.
+2. Generate persisted non-secret MITM profiles from `clawdi runtime init`.
+3. Resolve managed secrets at run time into short-lived broker state.
+4. Let hosted `clawdi run -- <runtime>` and `clawdi run -- <command>` start
+   `clawdi-mitm-broker` as a managed child process, wait for readiness, project
+   CA/proxy env, then exec the upstream runtime or tool.
+5. Package the broker as a relocatable `clawdi-mitm-broker/` bundle next to the
+   standalone `clawdi` package entrypoint.
+
+Why native broker:
+
+- one small broker artifact instead of bundling Python plus mitmproxy;
+- no dependency on system Python, uv, or host-installed proxy tooling;
+- the request profile model, secretRef gate, rewrites, and lifecycle are all
+  Clawdi-owned and testable in one repo;
+- profile and run config contracts do not depend on broker implementation
+  internals, so the transport engine can be replaced later.
+
+## Replacement Matrix
+
+| Legacy patch class | Preferred replacement | Notes |
+| --- | --- | --- |
+| Telegram custom endpoint | Native runtime config if available; otherwise broker egress rewrite to a Clawdi native Bot API-compatible channel surface. | Token matching belongs in broker secret resolution, not logs or Docker args. |
+| Discord REST base URL | Native config if available; otherwise broker egress rewrite to a Clawdi native Discord REST-compatible channel surface. | Requires host/path allowlist and network egress enforcement. |
+| Discord Gateway/WebSocket endpoint | Native gateway config if available; otherwise broker WebSocket tunnel/rewrite to a Clawdi native Gateway-compatible channel surface. | Requires explicit WebSocket support and cannot rely only on cooperative env vars. |
+| WhatsApp endpoint/state patch | Runtime-facing channel bridge. | Hosted service owns real WhatsApp protocol state; CLI/image do not own protocol state. |
+| iMessage endpoint patch | BlueBubbles/Photon-compatible native channel service. | Hosted service owns iMessage service state and cert handling; CLI only projects endpoint/trust config. |
+| Certificate trust patch | Project broker CA only when TLS interception is enabled. | Prefer explicit proxy roots; avoid broad system trust mutation when possible. |
+| Hosted-managed Codex official behavior | Broker MITM to managed provider. | Cover both `api.openai.com/v1/responses` and `chatgpt.com/backend-api/codex/responses`; managed provider credentials are injected by secretRef, not forwarded from user tokens. |
+| Ordinary OpenAI-compatible provider base URL changes | Native AI provider projection/direct provider URL. | Use this where official OpenAI behavior does not need to be simulated. Do not silently proxy user BYOK traffic. |
+| Runtime update endpoint/channel patch | Do not replace with MITM. | Native OpenClaw/Hermes updater authority stays with the runtime. |
+
+## MITM Scenario Matrix
+
+| Scenario | Upstream-looking request from runtime | Match condition | Broker action | Target owner | Priority |
+| --- | --- | --- | --- | --- | --- |
+| Discord REST channel | `https://discord.com/api/v10/...` | `Authorization: Bot <configured-token>` matches channel secretRef | Rewrite to native channel REST surface; strip broker-only headers; redact token. | Clawdi native Channels | P0 |
+| Discord Gateway channel | `wss://gateway.discord.gg/?v=10...` | Gateway host allowlist and enabled channel profile | WebSocket tunnel/rewrite to native channel Gateway surface. | Clawdi native Channels | P0 |
+| Telegram Bot API channel | `https://api.telegram.org/bot<TOKEN>/<method>` | `<TOKEN>` matches channel secretRef | Rewrite to native Bot API-compatible channel surface; do not log token-bearing URL. | Clawdi native Channels | P0 |
+| WhatsApp channel | Runtime-facing WhatsApp bridge URL or upstream-compatible shim | Manifest enables WhatsApp channel profile | Route only to the hosted channel bridge; do not own real WhatsApp protocol state. | Clawdi native Channels | P0 |
+| iMessage channel | BlueBubbles/Photon-compatible HTTP(S) service path | Manifest enables iMessage channel profile | Project endpoint/trust config or broker route to hosted iMessage-compatible service. | Clawdi native Channels | P0 |
+| Codex hosted-managed official OpenAI behavior | `https://api.openai.com/v1/responses` from Codex | Provider policy explicitly marks Clawdi-managed Codex brokerage | MITM and rewrite to managed Responses-compatible provider while preserving official-looking Codex request shape. Never use for user BYOK. | Clawdi provider layer | P1 |
+| Codex ChatGPT backend behavior | `https://chatgpt.com/backend-api/codex/responses` | Official path plus managed provider policy | Rewrite to managed Responses-compatible provider and replace upstream authorization from provider secretRef. | Clawdi provider layer | P1 |
+| Ordinary OpenAI-compatible provider projection | Runtime/provider-specific configured base URL | Provider can be expressed natively and does not need official `api.openai.com` simulation | Project native provider config/direct URL; no MITM. | User/runtime or Clawdi provider projection | P1 |
+| Generic service credential brokerage | Any allowlisted HTTP(S) host/path | Broker policy has service rule and secret refs | Inject headers/query/path substitutions from secret refs; redact request logs. | Broker policy | P2 |
+| CA trust projection | Any TLS-intercepted host | Broker policy enables TLS MITM | Project per-run CA file and trust env; avoid broad system trust mutation. | `clawdi run` | P0 |
+| Egress deny/bypass prevention | Any non-allowlisted egress | Runtime network policy enabled | Deny or force proxy; block metadata/private ranges unless explicitly allowed. | Runtime platform + broker | P0 |
+| Native OpenClaw/Hermes updater endpoints | Runtime updater traffic | Runtime update flow | Do not hide with MITM. Native updater repo/channel must stay explicit and auditable. | OpenClaw/Hermes | Rejected |
+| User BYOK provider traffic | User-configured provider direct URL | User-owned credentials, no hosted-managed policy | Prefer native projection/direct provider URL. Do not silently proxy or record model traffic. | User/runtime | Rejected |
+
+## Broker Requirements
+
+A production broker/MITM path needs:
+
+- persisted broker config loaded by hosted `clawdi run`;
+- no normal startup endpoint/token flags;
+- a container or network boundary that prevents bypass in hosted mode;
+- HTTP CONNECT, absolute-form HTTP forwarding, and WebSocket support;
+- per-service host/path/method allowlists;
+- credential lookup by secret reference or short-lived runtime file;
+- endpoint rewrite to Clawdi native channel surfaces where native runtime config
+  is missing;
+- standard proxy/trust env injection for the child process;
+- request logging that redacts tokens and payload-sensitive fields;
+- clear CA projection rules when TLS interception is enabled;
+- tests with local fake upstreams for channel and provider routes.
+
+## Verification Scope
+
+This CLI repository verifies the reusable broker and runtime-convergence
+contract. Deployment-specific hosted service tenants, provider gateway
+credentials, runtime image boot timing, and real inbound channel canaries belong
+to an external runtime platform smoke lane.
+
+Current in-repo coverage:
+
+- profile schema validation for HTTP, WebSocket, provider, and deny profiles;
+- secretRef matching without persisting secret values in desired state;
+- broker HTTP CONNECT, TLS interception, request rewrite, and WebSocket
+  upgrade/tunnel behavior;
+- proxy/CA env projection through `clawdi run`;
+- official-looking route profiles for Telegram Bot API, Discord REST/Gateway,
+  BlueBubbles/iMessage, WhatsApp bridge, and Codex/OpenAI Responses-compatible
+  requests using local or fake upstreams;
+- strict schema rejection for undeclared hosted manifest fields.
+
+Route kinds expected from the runtime source:
+
+| Route kind | Scope | Notes |
+| --- | --- | --- |
+| `telegram-bot-api` | Hermes/OpenClaw-compatible traffic | Official `api.telegram.org` traffic can be rewritten to a native Bot API-compatible channel surface. |
+| `discord-rest` | Hermes/OpenClaw-compatible traffic | Official `discord.com/api/...` REST traffic can be rewritten to a native REST-compatible channel surface. |
+| `discord-gateway-ws` | Hermes/OpenClaw-compatible traffic | Gateway traffic requires explicit WebSocket support, not only HTTP forwarding. |
+| `bluebubbles-rest` | iMessage-compatible traffic | BlueBubbles-compatible iMessage REST can be routed to a compatible hosted service surface. |
+| `whatsapp-ws-upgrade` | Runtime-facing WhatsApp bridge | The broker may route a bridge WebSocket, but real WhatsApp protocol state remains outside the CLI. |
+| `codex-openai-responses` | Codex/OpenAI-compatible provider traffic | Official OpenAI Responses endpoint shape can be preserved while routing to a managed provider. |
+| `codex-chatgpt-backend-responses` | Codex official backend shape | Requests to `chatgpt.com/backend-api/codex/responses` are matched by official path and forwarded with a managed provider bearer token. |
+
+Priority meaning:
+
+- P0: required for zero-patch hosted native channel runtime.
+- P1: required for hosted-managed Codex official-behavior simulation and
+  ordinary provider projection boundaries.
+- P2: generalization after the channel and provider cases are pinned.
+- Rejected: intentionally not implemented through MITM.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -295,8 +295,9 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](https://gith
 | Command | What it does |
 | --- | --- |
 | `clawdi auth login` / `logout` | Authenticate this machine |
+| `clawdi auth status [--json]` | Show credential source without printing secrets |
 | `clawdi status [--json]` | Show auth and sync state |
-| `clawdi config list/get/set/unset` | Read or write CLI configuration |
+| `clawdi config list/get/set/unset/paths` | Read/write CLI configuration and inspect local/runtime paths |
 | `clawdi setup [--agent <type>] [--no-daemon]` | Register local agents, install MCP, install the bundled skill, and install/start the singleton daemon by default |
 | `clawdi teardown [--agent <type>]` | Remove Clawdi's local agent wiring |
 | `clawdi daemon run/install/status/logs/doctor/restart/uninstall/ping/rotate-token` | Run, inspect, and control the singleton background sync daemon (`serve` remains a legacy alias) |
@@ -322,6 +323,32 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](https://gith
 Auto-update is enabled by default for all newer releases, including majors. Human CLI invocations update the global CLI in the background; installed daemons check on their own cadence, install silently, then let launchd/systemd restart them onto the new code. Disable both with `CLAWDI_NO_AUTO_UPDATE=1` or `clawdi config set autoUpdate false`.
 
 Every command supports `--help`.
+
+### Advanced Runtime Operators
+
+These commands are for controlled hosted or self-hosted runtime envelopes. They
+are not part of normal laptop onboarding.
+
+| Command | What it does |
+| --- | --- |
+| `clawdi capabilities [--json]` | Show CLI feature surface, runtime mode, and hosted policy restrictions |
+| `clawdi runtime init --non-interactive [--json]` | Run one cloud-init-style hosted runtime convergence pass |
+| `clawdi runtime status [--json]` | Read the last runtime boot result from service-state files |
+| `clawdi runtime doctor [--json]` | Diagnose hosted policy, service state, HOME, tmpfs runtime state, and last boot status |
+
+Hosted runtime mode is detected from host policy or runtime credentials. In
+hosted mode, `/etc/clawdi/host-policy.json` can deny local-user commands such
+as `setup`, `teardown`, `update`, `config set`, and `auth login`, while keeping
+agent-facing commands such as `mcp`, `daemon run`, `read`, `inject`, and `run`
+available. Local self-update is skipped in hosted mode; hosted CLI updates are
+expected to be system-managed through the standard npm package installation.
+The target hosted shape is a read-only `/usr/local/bin/clawdi` launcher shim
+that installs/execs the npm-managed entrypoint at `/var/lib/clawdi/bin/clawdi`
+from the root-owned prefix `/var/lib/clawdi/npm`. The ordinary runtime user can
+execute the CLI but cannot modify the managed install or config.
+
+For the hosted runtime design, profile matrix, and runtime image contract, see
+[`docs/hosted-runtime.md`](https://github.com/Clawdi-AI/clawdi/blob/main/docs/hosted-runtime.md).
 
 App connections are configured in the [Clawdi Cloud dashboard](https://clawdi.ai) and surface inside agents automatically over MCP — there is no CLI command to manage them.
 

--- a/packages/cli/native/mitm-broker/go.mod
+++ b/packages/cli/native/mitm-broker/go.mod
@@ -1,0 +1,3 @@
+module github.com/clawdi-ai/clawdi/packages/cli/native/mitm-broker
+
+go 1.26

--- a/packages/cli/native/mitm-broker/main.go
+++ b/packages/cli/native/mitm-broker/main.go
@@ -1,0 +1,1321 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type profileBundle struct {
+	SchemaVersion string    `json:"schemaVersion"`
+	GeneratedAt   string    `json:"generatedAt"`
+	Generation    int       `json:"generation"`
+	InstanceID    string    `json:"instanceId"`
+	Profiles      []profile `json:"profiles"`
+}
+
+type profile struct {
+	ID          string       `json:"id"`
+	Enabled     *bool        `json:"enabled"`
+	Kind        string       `json:"kind"`
+	Match       profileMatch `json:"match"`
+	Rewrite     rewriteRule  `json:"rewrite"`
+	Logging     loggingRule  `json:"logging"`
+	Priority    int          `json:"priority"`
+	Owner       string       `json:"owner"`
+	Description string       `json:"description"`
+}
+
+type profileMatch struct {
+	Scheme     string                   `json:"scheme"`
+	Host       string                   `json:"host"`
+	PathPrefix string                   `json:"pathPrefix"`
+	Path       pathMatcher              `json:"path"`
+	Headers    map[string]headerMatcher `json:"headers"`
+	Query      map[string]headerMatcher `json:"query"`
+}
+
+type pathMatcher struct {
+	Type      string `json:"type"`
+	Value     string `json:"value"`
+	SecretRef string `json:"secretRef"`
+	Prefix    string `json:"prefix"`
+	Suffix    string `json:"suffix"`
+}
+
+type headerMatcher struct {
+	Type      string `json:"type"`
+	Value     string `json:"value"`
+	SecretRef string `json:"secretRef"`
+	Prefix    string `json:"prefix"`
+}
+
+type rewriteRule struct {
+	UpstreamBaseURL string                  `json:"upstreamBaseUrl"`
+	PreservePath    *bool                   `json:"preservePath"`
+	SetHeaders      map[string]headerSetter `json:"setHeaders"`
+}
+
+type headerSetter struct {
+	Type      string `json:"type"`
+	Value     string `json:"value"`
+	SecretRef string `json:"secretRef"`
+	Prefix    string `json:"prefix"`
+}
+
+type loggingRule struct {
+	RedactHeaders     []string `json:"redactHeaders"`
+	RedactURLPatterns []string `json:"redactUrlPatterns"`
+}
+
+type secretFile struct {
+	Secrets map[string]string `json:"secrets"`
+}
+
+type route struct {
+	profile      profile
+	originalHost string
+}
+
+type proxyServer struct {
+	profiles  []profile
+	secrets   map[string]string
+	ca        *certificateAuthority
+	transport *http.Transport
+}
+
+func main() {
+	var profileBundlePath string
+	var proxyURL string
+	var caFile string
+	var secretPath string
+	var allowRemoteProxy bool
+
+	flag.StringVar(&profileBundlePath, "profile-bundle", "", "Path to the Clawdi MITM profile bundle JSON.")
+	flag.StringVar(&proxyURL, "proxy-url", "http://127.0.0.1:0", "HTTP proxy listen URL.")
+	flag.StringVar(&caFile, "ca-file", "", "Path where the generated CA PEM should be written.")
+	flag.StringVar(&secretPath, "secret-file", "", "Path to the short-lived Clawdi MITM secret map JSON.")
+	flag.BoolVar(&allowRemoteProxy, "allow-remote-proxy", false, "Allow the proxy to listen on a non-loopback interface.")
+	flag.Parse()
+
+	if profileBundlePath == "" {
+		exitf("--profile-bundle is required")
+	}
+	if caFile == "" {
+		exitf("--ca-file is required")
+	}
+
+	profiles, err := loadProfiles(profileBundlePath)
+	if err != nil {
+		exitf("load profile bundle: %v", err)
+	}
+	if len(profiles) == 0 {
+		ready(false, "", "", "no-enabled-profiles")
+		return
+	}
+	secrets, err := loadSecrets(secretPath)
+	if err != nil {
+		exitf("load secrets: %v", err)
+	}
+	ca, err := newCertificateAuthority()
+	if err != nil {
+		exitf("create CA: %v", err)
+	}
+	if err := writePrivateFile(caFile, ca.rootPEM, 0o644); err != nil {
+		exitf("write CA: %v", err)
+	}
+
+	listener, actualProxyURL, err := listenProxy(proxyURL, allowRemoteProxy)
+	if err != nil {
+		exitf("listen proxy: %v", err)
+	}
+
+	proxy := &proxyServer{
+		profiles: profiles,
+		secrets:  secrets,
+		ca:       ca,
+		transport: &http.Transport{
+			Proxy:                 nil,
+			ForceAttemptHTTP2:     false,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 5 * time.Minute,
+			IdleConnTimeout:       90 * time.Second,
+			MaxIdleConns:          100,
+			TLSClientConfig:       &tls.Config{MinVersion: tls.VersionTLS12},
+		},
+	}
+
+	server := &http.Server{
+		Handler:           http.HandlerFunc(proxy.dispatch),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	errs := make(chan error, 1)
+	go func() {
+		errs <- server.Serve(listener)
+	}()
+
+	ready(true, actualProxyURL, caFile, "")
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGTERM, syscall.SIGINT)
+
+	select {
+	case sig := <-signals:
+		_ = sig
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_ = server.Shutdown(ctx)
+	case err := <-errs:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			exitf("proxy server: %v", err)
+		}
+	}
+}
+
+func loadProfiles(path string) ([]profile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var bundle profileBundle
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&bundle); err != nil {
+		return nil, err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, fmt.Errorf("profile bundle has trailing data")
+	}
+	if bundle.SchemaVersion != "clawdi.mitmProfiles.v1" {
+		return nil, fmt.Errorf("unsupported profile bundle schemaVersion %q", bundle.SchemaVersion)
+	}
+	if strings.TrimSpace(bundle.GeneratedAt) == "" {
+		return nil, fmt.Errorf("profile bundle generatedAt is required")
+	}
+	if bundle.Generation < 0 {
+		return nil, fmt.Errorf("profile bundle generation must be non-negative")
+	}
+	if strings.TrimSpace(bundle.InstanceID) == "" {
+		return nil, fmt.Errorf("profile bundle instanceId is required")
+	}
+	profiles := make([]profile, 0, len(bundle.Profiles))
+	for _, p := range bundle.Profiles {
+		if p.Enabled != nil && !*p.Enabled {
+			continue
+		}
+		if err := validateProfile(p); err != nil {
+			return nil, err
+		}
+		if p.Priority == 0 {
+			p.Priority = 100
+		}
+		profiles = append(profiles, p)
+	}
+	sort.SliceStable(profiles, func(i, j int) bool {
+		return profiles[i].Priority < profiles[j].Priority
+	})
+	return profiles, nil
+}
+
+func validateProfile(p profile) error {
+	if !isProfileID(p.ID) {
+		return fmt.Errorf("profile id %q must match ^[a-z0-9][a-z0-9-_.]*$", p.ID)
+	}
+	switch p.Kind {
+	case "http", "websocket", "provider", "deny":
+	default:
+		return fmt.Errorf("profile %s has unsupported kind %q", p.ID, p.Kind)
+	}
+	if !isSafeHost(normalizeHost(p.Match.Host)) {
+		return fmt.Errorf("profile %s has invalid match.host", p.ID)
+	}
+	if p.Match.Scheme != "" {
+		switch p.Match.Scheme {
+		case "http", "https", "ws", "wss":
+		default:
+			return fmt.Errorf("profile %s has unsupported match.scheme %q", p.ID, p.Match.Scheme)
+		}
+	}
+	if p.Match.PathPrefix != "" && !strings.HasPrefix(p.Match.PathPrefix, "/") {
+		return fmt.Errorf("profile %s match.pathPrefix must start with /", p.ID)
+	}
+	if err := validatePathMatcher(p.ID, p.Match.Path); err != nil {
+		return err
+	}
+	for name, matcher := range p.Match.Headers {
+		if !isHeaderName(name) {
+			return fmt.Errorf("profile %s has invalid header matcher name %q", p.ID, name)
+		}
+		if err := validateMatcher(p.ID, "header", name, matcher); err != nil {
+			return err
+		}
+	}
+	for name, matcher := range p.Match.Query {
+		if strings.TrimSpace(name) == "" {
+			return fmt.Errorf("profile %s has an empty query matcher name", p.ID)
+		}
+		if err := validateMatcher(p.ID, "query", name, matcher); err != nil {
+			return err
+		}
+	}
+	if p.Kind == "deny" {
+		if p.Rewrite.UpstreamBaseURL != "" {
+			return fmt.Errorf("profile %s deny profiles must not set rewrite.upstreamBaseUrl", p.ID)
+		}
+		if p.Rewrite.PreservePath != nil || len(p.Rewrite.SetHeaders) > 0 {
+			return fmt.Errorf("profile %s deny profiles must not set rewrite rules", p.ID)
+		}
+		return nil
+	}
+	if p.Rewrite.UpstreamBaseURL == "" {
+		return fmt.Errorf("profile %s requires rewrite.upstreamBaseUrl", p.ID)
+	}
+	if err := validateUpstreamURL(p.ID, p.Rewrite.UpstreamBaseURL); err != nil {
+		return err
+	}
+	for name := range p.Rewrite.SetHeaders {
+		if !isHeaderName(name) {
+			return fmt.Errorf("profile %s has invalid rewrite.setHeaders name %q", p.ID, name)
+		}
+		if err := validateHeaderSetter(p.ID, name, p.Rewrite.SetHeaders[name]); err != nil {
+			return err
+		}
+	}
+	for _, name := range p.Logging.RedactHeaders {
+		if !isHeaderName(name) {
+			return fmt.Errorf("profile %s has invalid logging.redactHeaders name %q", p.ID, name)
+		}
+	}
+	for _, pattern := range p.Logging.RedactURLPatterns {
+		if strings.TrimSpace(pattern) == "" {
+			return fmt.Errorf("profile %s logging.redactUrlPatterns entries must be non-empty", p.ID)
+		}
+	}
+	return nil
+}
+
+func (s *headerSetter) UnmarshalJSON(data []byte) error {
+	var literal string
+	if err := json.Unmarshal(data, &literal); err == nil {
+		s.Type = "literal"
+		s.Value = literal
+		return nil
+	}
+
+	type headerSetterObject headerSetter
+	var object headerSetterObject
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&object); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return fmt.Errorf("header setter has trailing data")
+	}
+	*s = headerSetter(object)
+	return nil
+}
+
+func validateHeaderSetter(profileID, name string, setter headerSetter) error {
+	switch setter.Type {
+	case "literal":
+		if setter.SecretRef != "" || setter.Prefix != "" {
+			return fmt.Errorf("profile %s rewrite.setHeaders %s literal must not set secretRef or prefix", profileID, name)
+		}
+	case "secretRef":
+		if !strings.HasPrefix(setter.SecretRef, "secret://") {
+			return fmt.Errorf("profile %s rewrite.setHeaders %s must use a secret:// ref", profileID, name)
+		}
+		if setter.Value != "" {
+			return fmt.Errorf("profile %s rewrite.setHeaders %s secretRef must not set value", profileID, name)
+		}
+	default:
+		return fmt.Errorf("profile %s rewrite.setHeaders %s has unsupported type %q", profileID, name, setter.Type)
+	}
+	return nil
+}
+
+func (s headerSetter) resolve(secrets map[string]string) (string, bool) {
+	switch s.Type {
+	case "literal":
+		return s.Value, true
+	case "secretRef":
+		secret, ok := secrets[s.SecretRef]
+		if !ok {
+			return "", false
+		}
+		return s.Prefix + secret, true
+	default:
+		return "", false
+	}
+}
+
+func validateMatcher(profileID, scope, name string, matcher headerMatcher) error {
+	switch matcher.Type {
+	case "exists":
+		if matcher.Value != "" || matcher.SecretRef != "" || matcher.Prefix != "" {
+			return fmt.Errorf("profile %s %s matcher %s exists must not set value, secretRef, or prefix", profileID, scope, name)
+		}
+	case "equals":
+		if matcher.SecretRef != "" {
+			return fmt.Errorf("profile %s %s matcher %s equals must not set secretRef", profileID, scope, name)
+		}
+	case "secretRefEquals":
+		if !strings.HasPrefix(matcher.SecretRef, "secret://") {
+			return fmt.Errorf("profile %s %s matcher %s must use a secret:// ref", profileID, scope, name)
+		}
+		if matcher.Value != "" {
+			return fmt.Errorf("profile %s %s matcher %s secretRefEquals must not set value", profileID, scope, name)
+		}
+	default:
+		return fmt.Errorf("profile %s %s matcher %s has unsupported type %q", profileID, scope, name, matcher.Type)
+	}
+	return nil
+}
+
+func validateUpstreamURL(profileID, rawURL string) error {
+	upstream, err := url.Parse(rawURL)
+	if err != nil || upstream.Scheme == "" || upstream.Host == "" {
+		return fmt.Errorf("profile %s has invalid rewrite.upstreamBaseUrl", profileID)
+	}
+	switch upstream.Scheme {
+	case "http", "https", "ws", "wss":
+	default:
+		return fmt.Errorf("profile %s rewrite.upstreamBaseUrl must use http, https, ws, or wss", profileID)
+	}
+	if upstream.User != nil {
+		return fmt.Errorf("profile %s rewrite.upstreamBaseUrl must not include credentials", profileID)
+	}
+	if !isSafeHost(normalizeHost(upstream.Hostname())) {
+		return fmt.Errorf("profile %s rewrite.upstreamBaseUrl has invalid host", profileID)
+	}
+	return nil
+}
+
+func validatePathMatcher(profileID string, matcher pathMatcher) error {
+	if matcher.Type == "" {
+		return nil
+	}
+	switch matcher.Type {
+	case "equals", "prefix":
+		if matcher.Value == "" {
+			return fmt.Errorf("profile %s path matcher requires value", profileID)
+		}
+		if matcher.SecretRef != "" || matcher.Prefix != "" || matcher.Suffix != "" {
+			return fmt.Errorf("profile %s path matcher %s must not set secretRef, prefix, or suffix", profileID, matcher.Type)
+		}
+	case "secretRefEquals", "secretRefPrefix":
+		if !strings.HasPrefix(matcher.SecretRef, "secret://") {
+			return fmt.Errorf("profile %s path matcher must use a secret:// ref", profileID)
+		}
+		if matcher.Value != "" {
+			return fmt.Errorf("profile %s path matcher %s must not set value", profileID, matcher.Type)
+		}
+	default:
+		return fmt.Errorf("profile %s path matcher has unsupported type %q", profileID, matcher.Type)
+	}
+	return nil
+}
+
+func isProfileID(value string) bool {
+	if value == "" {
+		return false
+	}
+	for i, r := range value {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' {
+			continue
+		}
+		if i > 0 && (r == '-' || r == '_' || r == '.') {
+			continue
+		}
+		return false
+	}
+	first := value[0]
+	return first >= 'a' && first <= 'z' || first >= '0' && first <= '9'
+}
+
+func isHeaderName(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		switch {
+		case r >= 'A' && r <= 'Z':
+		case r >= 'a' && r <= 'z':
+		case r >= '0' && r <= '9':
+		case strings.ContainsRune("!#$%&'*+.^_`|~-", r):
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func loadSecrets(path string) (map[string]string, error) {
+	if path == "" {
+		return map[string]string{}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]string{}, nil
+		}
+		return nil, err
+	}
+	var wrapped secretFile
+	if err := json.Unmarshal(data, &wrapped); err == nil && wrapped.Secrets != nil {
+		return wrapped.Secrets, nil
+	}
+	var direct map[string]string
+	if err := json.Unmarshal(data, &direct); err != nil {
+		return nil, err
+	}
+	return direct, nil
+}
+
+func listenProxy(rawURL string, allowRemote bool) (net.Listener, string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, "", err
+	}
+	if parsed.Scheme != "http" {
+		return nil, "", fmt.Errorf("unsupported proxy URL scheme %q", parsed.Scheme)
+	}
+	host := parsed.Hostname()
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	if !allowRemote && !isLoopbackHost(host) {
+		return nil, "", fmt.Errorf("refusing to listen on non-loopback MITM proxy host %s", host)
+	}
+	port := parsed.Port()
+	if port == "" {
+		port = "0"
+	}
+	listener, err := net.Listen("tcp", net.JoinHostPort(host, port))
+	if err != nil {
+		return nil, "", err
+	}
+	actualHost, actualPort, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		_ = listener.Close()
+		return nil, "", err
+	}
+	if actualHost == "" || actualHost == "::" {
+		actualHost = host
+	}
+	return listener, (&url.URL{Scheme: "http", Host: net.JoinHostPort(actualHost, actualPort)}).String(), nil
+}
+
+func isLoopbackHost(host string) bool {
+	host = strings.Trim(host, "[]")
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func (p *proxyServer) dispatch(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodConnect {
+		p.handleConnect(w, r)
+		return
+	}
+	if r.URL != nil && r.URL.IsAbs() && r.URL.Scheme == "http" && r.URL.Host != "" {
+		target, matchHost, err := targetFromURL(r.URL)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		p.forwardRequest(w, r, target, matchHost, "http", r.URL.Path, r.URL.RawQuery)
+		return
+	}
+	http.Error(w, "this endpoint is an HTTP forward proxy", http.StatusBadRequest)
+}
+
+func (p *proxyServer) handleConnect(w http.ResponseWriter, r *http.Request) {
+	target, matchHost, tlsHost, err := targetFromConnect(r.Host)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+	clientConn, _, err := hijacker.Hijack()
+	if err != nil {
+		http.Error(w, "hijack failed", http.StatusInternalServerError)
+		return
+	}
+	if _, err := io.WriteString(clientConn, "HTTP/1.1 200 Connection Established\r\n\r\n"); err != nil {
+		_ = clientConn.Close()
+		return
+	}
+
+	tlsConn := tls.Server(clientConn, &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		NextProtos: []string{"http/1.1"},
+		GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+			sni := hello.ServerName
+			if sni == "" {
+				sni = tlsHost
+			}
+			return p.ca.mintLeaf(sni)
+		},
+	})
+	_ = tlsConn.SetDeadline(time.Now().Add(10 * time.Second))
+	if err := tlsConn.Handshake(); err != nil {
+		_ = tlsConn.Close()
+		return
+	}
+	_ = tlsConn.SetDeadline(time.Time{})
+
+	listener := newOneShotListener(tlsConn)
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			p.forwardRequest(w, r, target, matchHost, "https", r.URL.Path, r.URL.RawQuery)
+		}),
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       60 * time.Second,
+		WriteTimeout:      30 * time.Minute,
+		IdleTimeout:       2 * time.Minute,
+		ConnState: func(_ net.Conn, state http.ConnState) {
+			if state == http.StateHijacked || state == http.StateClosed {
+				_ = listener.Close()
+			}
+		},
+	}
+	_ = server.Serve(listener)
+}
+
+func targetFromConnect(rawTarget string) (target, matchHost, tlsHost string, err error) {
+	host, port, err := net.SplitHostPort(rawTarget)
+	if err != nil || host == "" || port == "" {
+		return "", "", "", fmt.Errorf("CONNECT target must be host:port")
+	}
+	if !isSafeHost(host) {
+		return "", "", "", fmt.Errorf("invalid host")
+	}
+	if !isValidPort(port) {
+		return "", "", "", fmt.Errorf("invalid port")
+	}
+	target = urlHost(host, port)
+	return target, normalizeHost(target), host, nil
+}
+
+func targetFromURL(u *url.URL) (target, matchHost string, err error) {
+	host := u.Hostname()
+	if host == "" {
+		return "", "", fmt.Errorf("absolute-form proxy request requires a host")
+	}
+	if !isSafeHost(host) {
+		return "", "", fmt.Errorf("invalid host")
+	}
+	port := u.Port()
+	if port != "" && !isValidPort(port) {
+		return "", "", fmt.Errorf("invalid port")
+	}
+	target = urlHost(host, port)
+	return target, normalizeHost(target), nil
+}
+
+func urlHost(host, port string) string {
+	if port != "" {
+		return net.JoinHostPort(host, port)
+	}
+	if strings.Contains(host, ":") && !strings.HasPrefix(host, "[") {
+		return "[" + host + "]"
+	}
+	return host
+}
+
+func isValidPort(port string) bool {
+	n, err := strconv.Atoi(port)
+	return err == nil && n > 0 && n <= 65535
+}
+
+func (p *proxyServer) forwardRequest(w http.ResponseWriter, r *http.Request, originalTarget, matchHost, scheme, path, rawQuery string) {
+	if path == "" {
+		path = "/"
+	}
+	requestPath := path
+	if rawQuery != "" {
+		requestPath += "?" + rawQuery
+	}
+	matchScheme := scheme
+	if isWebSocketUpgrade(r) {
+		if scheme == "https" {
+			matchScheme = "wss"
+		} else {
+			matchScheme = "ws"
+		}
+	}
+	route := p.matchRoute(matchHost, matchScheme, path, rawQuery, r.Header)
+	if route == nil {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "request did not match an enabled Clawdi MITM profile"})
+		return
+	}
+	if route.profile.Kind == "deny" {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "blocked by Clawdi MITM profile"})
+		return
+	}
+	upstream, err := routeUpstream(route.profile)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "Clawdi MITM profile has invalid upstream"})
+		return
+	}
+
+	outURL := *upstream
+	outURL.Scheme = normalizeUpstreamScheme(outURL.Scheme)
+	outURL.Path, outURL.RawQuery = rewritePath(upstream, requestPath, route.profile.Rewrite.preservePath())
+	outReq, err := http.NewRequestWithContext(r.Context(), r.Method, outURL.String(), r.Body)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "bad gateway"})
+		return
+	}
+	outReq.ContentLength = r.ContentLength
+	copyForwardHeaders(r.Header, outReq.Header)
+	outReq.Host = upstream.Host
+	outReq.Header.Set("Host", upstream.Host)
+	outReq.Header.Set("X-Clawdi-Original-Host", route.originalHost)
+	for key, value := range route.profile.Rewrite.SetHeaders {
+		resolved, ok := value.resolve(p.secrets)
+		if !ok {
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "Clawdi MITM profile has unresolved rewrite secret"})
+			return
+		}
+		outReq.Header.Set(key, resolved)
+	}
+
+	if isWebSocketUpgrade(r) {
+		outReq.Body = nil
+		outReq.ContentLength = 0
+		outReq.Header.Set("Connection", "Upgrade")
+		outReq.Header.Set("Upgrade", r.Header.Get("Upgrade"))
+		p.forwardWebSocket(w, r, outReq)
+		return
+	}
+
+	resp, err := p.transport.RoundTrip(outReq)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "upstream request failed"})
+		return
+	}
+	defer resp.Body.Close()
+
+	for key, values := range resp.Header {
+		if shouldStripResponseHeader(key) {
+			continue
+		}
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+func routeUpstream(p profile) (*url.URL, error) {
+	return url.Parse(p.Rewrite.UpstreamBaseURL)
+}
+
+func (p *proxyServer) matchRoute(originalHost, scheme, path, rawQuery string, headers http.Header) *route {
+	for _, profile := range p.profiles {
+		if normalizeHost(profile.Match.Host) != originalHost {
+			continue
+		}
+		if profile.Match.Scheme != "" && profile.Match.Scheme != scheme {
+			continue
+		}
+		if profile.Match.PathPrefix != "" && !strings.HasPrefix(path, profile.Match.PathPrefix) {
+			continue
+		}
+		if !p.pathMatch(profile.Match.Path, path) {
+			continue
+		}
+		if !p.headersMatch(profile.Match.Headers, headers) {
+			continue
+		}
+		if !p.queryMatch(profile.Match.Query, rawQuery) {
+			continue
+		}
+		return &route{profile: profile, originalHost: originalHost}
+	}
+	return nil
+}
+
+func (p *proxyServer) pathMatch(matcher pathMatcher, path string) bool {
+	if matcher.Type == "" {
+		return true
+	}
+	switch matcher.Type {
+	case "equals":
+		return path == matcher.Value
+	case "prefix":
+		return strings.HasPrefix(path, matcher.Value)
+	case "secretRefEquals":
+		secret, ok := p.secrets[matcher.SecretRef]
+		return ok && path == matcher.Prefix+secret+matcher.Suffix
+	case "secretRefPrefix":
+		secret, ok := p.secrets[matcher.SecretRef]
+		return ok && strings.HasPrefix(path, matcher.Prefix+secret+matcher.Suffix)
+	default:
+		return false
+	}
+}
+
+func (p *proxyServer) queryMatch(matchers map[string]headerMatcher, rawQuery string) bool {
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return false
+	}
+	for name, matcher := range matchers {
+		actualValues := values[name]
+		switch matcher.Type {
+		case "exists":
+			if len(actualValues) == 0 {
+				return false
+			}
+		case "equals":
+			if !containsValue(actualValues, matcher.Prefix+matcher.Value) {
+				return false
+			}
+		case "secretRefEquals":
+			secret, ok := p.secrets[matcher.SecretRef]
+			if !ok {
+				return false
+			}
+			if !containsValue(actualValues, matcher.Prefix+secret) {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func containsValue(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *proxyServer) headersMatch(matchers map[string]headerMatcher, headers http.Header) bool {
+	for name, matcher := range matchers {
+		actual := headers.Get(name)
+		switch matcher.Type {
+		case "exists":
+			if actual == "" {
+				return false
+			}
+		case "equals":
+			if actual != matcher.Prefix+matcher.Value {
+				return false
+			}
+		case "secretRefEquals":
+			secret, ok := p.secrets[matcher.SecretRef]
+			if !ok {
+				return false
+			}
+			if actual != matcher.Prefix+secret {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func (p *profile) enabled() bool {
+	return p.Enabled == nil || *p.Enabled
+}
+
+func (r rewriteRule) preservePath() bool {
+	return r.PreservePath == nil || *r.PreservePath
+}
+
+func rewritePath(upstream *url.URL, requestPath string, preserve bool) (string, string) {
+	if !preserve {
+		path := upstream.Path
+		if path == "" {
+			path = "/"
+		}
+		return path, upstream.RawQuery
+	}
+	requestOnlyPath := requestPath
+	requestRawQuery := ""
+	if idx := strings.IndexByte(requestPath, '?'); idx >= 0 {
+		requestOnlyPath = requestPath[:idx]
+		requestRawQuery = requestPath[idx+1:]
+	}
+	base := strings.TrimRight(upstream.Path, "/")
+	if upstream.Path == "/" {
+		base = ""
+	}
+	if !strings.HasPrefix(requestOnlyPath, "/") {
+		requestOnlyPath = "/" + requestOnlyPath
+	}
+	rawQuery := requestRawQuery
+	if upstream.RawQuery != "" {
+		if rawQuery != "" {
+			rawQuery = upstream.RawQuery + "&" + rawQuery
+		} else {
+			rawQuery = upstream.RawQuery
+		}
+	}
+	return base + requestOnlyPath, rawQuery
+}
+
+func normalizeUpstreamScheme(scheme string) string {
+	switch scheme {
+	case "ws":
+		return "http"
+	case "wss":
+		return "https"
+	default:
+		return scheme
+	}
+}
+
+func copyForwardHeaders(src, dst http.Header) {
+	strip := map[string]bool{}
+	for _, value := range src.Values("Connection") {
+		for _, field := range strings.Split(value, ",") {
+			field = strings.TrimSpace(field)
+			if field != "" {
+				strip[http.CanonicalHeaderKey(field)] = true
+			}
+		}
+	}
+	for key, values := range src {
+		canonical := http.CanonicalHeaderKey(key)
+		if isHopByHop(canonical) || strip[canonical] || strings.EqualFold(canonical, "Proxy-Authorization") {
+			continue
+		}
+		for _, value := range values {
+			dst.Add(canonical, value)
+		}
+	}
+}
+
+func isHopByHop(header string) bool {
+	switch http.CanonicalHeaderKey(header) {
+	case "Connection", "Keep-Alive", "Proxy-Authenticate", "Proxy-Authorization", "Proxy-Connection", "Te", "Trailer", "Transfer-Encoding", "Upgrade":
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldStripResponseHeader(header string) bool {
+	return isHopByHop(header) || strings.EqualFold(header, "Set-Cookie")
+}
+
+func writeJSON(w http.ResponseWriter, status int, body map[string]string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Clawdi-Mitm-Error", "true")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func ready(ok bool, proxyURL, caFile, reason string) {
+	payload := map[string]any{"ready": ok}
+	if ok {
+		payload["proxyUrl"] = proxyURL
+		payload["caFile"] = caFile
+	} else if reason != "" {
+		payload["reason"] = reason
+	}
+	_ = json.NewEncoder(os.Stdout).Encode(payload)
+}
+
+func exitf(format string, args ...any) {
+	_, _ = fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}
+
+func writePrivateFile(path string, data []byte, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	file, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Chmod(tmp, mode); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func isSafeHost(host string) bool {
+	if host == "" || len(host) > 253 {
+		return false
+	}
+	for _, c := range host {
+		if c == '@' || c == '?' || c == '#' || c == '/' || c == '\\' || c == ' ' || c == '%' || c < 0x20 || c == 0x7f {
+			return false
+		}
+	}
+	return !strings.HasPrefix(host, ".") && !strings.HasSuffix(host, ".")
+}
+
+func normalizeHost(host string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if h, port, err := net.SplitHostPort(host); err == nil {
+		if port == "443" || port == "80" {
+			return strings.Trim(h, "[]")
+		}
+		return urlHost(strings.Trim(h, "[]"), port)
+	}
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		return strings.Trim(host, "[]")
+	}
+	return host
+}
+
+func isWebSocketUpgrade(r *http.Request) bool {
+	if !strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+		return false
+	}
+	for _, value := range r.Header.Values("Connection") {
+		for _, part := range strings.Split(value, ",") {
+			if strings.EqualFold(strings.TrimSpace(part), "upgrade") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (p *proxyServer) forwardWebSocket(w http.ResponseWriter, r *http.Request, outReq *http.Request) {
+	upstreamConn, upstreamReader, resp, err := dialWebSocket(r.Context(), outReq)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "upstream websocket failed"})
+		return
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		defer upstreamConn.Close()
+		defer resp.Body.Close()
+		for key, values := range resp.Header {
+			if shouldStripResponseHeader(key) {
+				continue
+			}
+			for _, value := range values {
+				w.Header().Add(key, value)
+			}
+		}
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
+		return
+	}
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		_ = upstreamConn.Close()
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "hijacking not supported"})
+		return
+	}
+	clientConn, clientBuf, err := hijacker.Hijack()
+	if err != nil {
+		_ = upstreamConn.Close()
+		return
+	}
+	if err := resp.Write(clientConn); err != nil {
+		_ = clientConn.Close()
+		_ = upstreamConn.Close()
+		return
+	}
+	pipeBidirectional(clientConn, clientBuf.Reader, upstreamConn, upstreamReader)
+}
+
+func dialWebSocket(ctx context.Context, outReq *http.Request) (net.Conn, *bufio.Reader, *http.Response, error) {
+	dialer := net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}
+	conn, err := dialer.DialContext(ctx, "tcp", dialAddress(outReq.URL))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if outReq.URL.Scheme == "https" {
+		host := outReq.URL.Hostname()
+		tlsConn := tls.Client(conn, &tls.Config{MinVersion: tls.VersionTLS12, ServerName: host, NextProtos: []string{"http/1.1"}})
+		_ = tlsConn.SetDeadline(time.Now().Add(10 * time.Second))
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			_ = conn.Close()
+			return nil, nil, nil, err
+		}
+		_ = tlsConn.SetDeadline(time.Time{})
+		conn = tlsConn
+	}
+	if err := writeWebSocketRequest(conn, outReq); err != nil {
+		_ = conn.Close()
+		return nil, nil, nil, err
+	}
+	reader := bufio.NewReader(conn)
+	resp, err := readWebSocketResponse(reader)
+	if err != nil {
+		_ = conn.Close()
+		return nil, nil, nil, err
+	}
+	return conn, reader, resp, nil
+}
+
+func dialAddress(u *url.URL) string {
+	if u.Port() != "" {
+		return u.Host
+	}
+	port := "80"
+	if u.Scheme == "https" {
+		port = "443"
+	}
+	return net.JoinHostPort(u.Hostname(), port)
+}
+
+func writeWebSocketRequest(conn net.Conn, req *http.Request) error {
+	path := req.URL.RequestURI()
+	if path == "" {
+		path = "/"
+	}
+	host := req.Host
+	if host == "" {
+		host = req.URL.Host
+	}
+	if _, err := fmt.Fprintf(conn, "%s %s HTTP/1.1\r\nHost: %s\r\n", req.Method, path, host); err != nil {
+		return err
+	}
+	header := req.Header.Clone()
+	header.Del("Host")
+	header.Del("Content-Length")
+	header.Del("Transfer-Encoding")
+	if err := header.WriteSubset(conn, nil); err != nil {
+		return err
+	}
+	_, err := io.WriteString(conn, "\r\n")
+	return err
+}
+
+func readWebSocketResponse(reader *bufio.Reader) (*http.Response, error) {
+	tp := textproto.NewReader(reader)
+	statusLine, err := tp.ReadLine()
+	if err != nil {
+		return nil, err
+	}
+	parts := strings.SplitN(statusLine, " ", 3)
+	if len(parts) < 2 || !strings.HasPrefix(parts[0], "HTTP/") {
+		return nil, fmt.Errorf("bad websocket response status line %q", statusLine)
+	}
+	statusCode, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("bad websocket response status code %q", parts[1])
+	}
+	header, err := tp.ReadMIMEHeader()
+	if err != nil {
+		return nil, err
+	}
+	statusText := parts[1]
+	if len(parts) == 3 {
+		statusText += " " + parts[2]
+	}
+	return &http.Response{
+		Status:        statusText,
+		StatusCode:    statusCode,
+		Proto:         parts[0],
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        http.Header(header),
+		Body:          io.NopCloser(reader),
+		ContentLength: -1,
+	}, nil
+}
+
+func pipeBidirectional(clientConn net.Conn, clientReader *bufio.Reader, upstreamConn net.Conn, upstreamReader *bufio.Reader) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(upstreamConn, clientReader)
+		_ = upstreamConn.SetDeadline(time.Now())
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(clientConn, upstreamReader)
+		_ = clientConn.SetDeadline(time.Now())
+	}()
+	wg.Wait()
+	_ = clientConn.Close()
+	_ = upstreamConn.Close()
+}
+
+type oneShotListener struct {
+	conn   net.Conn
+	yield  chan net.Conn
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newOneShotListener(conn net.Conn) *oneShotListener {
+	listener := &oneShotListener{
+		conn:   conn,
+		yield:  make(chan net.Conn, 1),
+		closed: make(chan struct{}),
+	}
+	listener.yield <- conn
+	return listener
+}
+
+func (l *oneShotListener) Accept() (net.Conn, error) {
+	select {
+	case conn := <-l.yield:
+		return conn, nil
+	case <-l.closed:
+		return nil, net.ErrClosed
+	}
+}
+
+func (l *oneShotListener) Close() error {
+	l.once.Do(func() {
+		close(l.closed)
+	})
+	return nil
+}
+
+func (l *oneShotListener) Addr() net.Addr {
+	return l.conn.LocalAddr()
+}
+
+type certificateAuthority struct {
+	rootCert *x509.Certificate
+	rootKey  *rsa.PrivateKey
+	rootPEM  []byte
+	cache    map[string]*tls.Certificate
+	mu       sync.Mutex
+}
+
+func newCertificateAuthority() (*certificateAuthority, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	cert := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "Clawdi MITM Root CA", Organization: []string{"Clawdi"}},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, cert, cert, &key.PublicKey, key)
+	if err != nil {
+		return nil, err
+	}
+	rootPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	parsed, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, err
+	}
+	return &certificateAuthority{rootCert: parsed, rootKey: key, rootPEM: rootPEM, cache: map[string]*tls.Certificate{}}, nil
+}
+
+func (c *certificateAuthority) mintLeaf(host string) (*tls.Certificate, error) {
+	host = normalizeHost(host)
+	if !isSafeHost(host) {
+		return nil, fmt.Errorf("invalid SNI %q", host)
+	}
+	c.mu.Lock()
+	if cert := c.cache[host]; cert != nil {
+		c.mu.Unlock()
+		return cert, nil
+	}
+	c.mu.Unlock()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	leaf := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: host},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(12 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		leaf.IPAddresses = []net.IP{ip}
+	} else {
+		leaf.DNSNames = []string{host}
+	}
+	der, err := x509.CreateCertificate(rand.Reader, leaf, c.rootCert, &key.PublicKey, c.rootKey)
+	if err != nil {
+		return nil, err
+	}
+	tlsCert := &tls.Certificate{
+		Certificate: [][]byte{der, c.rootCert.Raw},
+		PrivateKey:  key,
+		Leaf:        leaf,
+	}
+	c.mu.Lock()
+	c.cache[host] = tlsCert
+	c.mu.Unlock()
+	return tlsCert, nil
+}
+
+func randomSerial() (*big.Int, error) {
+	limit := new(big.Int).Lsh(big.NewInt(1), 128)
+	return rand.Int(rand.Reader, limit)
+}

--- a/packages/cli/native/mitm-broker/main_test.go
+++ b/packages/cli/native/mitm-broker/main_test.go
@@ -1,0 +1,500 @@
+package main
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadProfilesValidatesAndSorts(t *testing.T) {
+	path := writeTestJSON(t, `{
+		"schemaVersion": "clawdi.mitmProfiles.v1",
+		"generatedAt": "2026-06-05T00:00:00Z",
+		"generation": 7,
+		"instanceId": "iid_test",
+		"profiles": [
+			{
+				"id": "disabled",
+				"enabled": false,
+				"kind": "http",
+				"match": { "scheme": "https", "host": "discord.com", "pathPrefix": "/api/" },
+				"rewrite": { "upstreamBaseUrl": "https://router.test/discord" },
+				"priority": 1
+			},
+			{
+				"id": "later",
+				"enabled": true,
+				"kind": "http",
+				"match": { "scheme": "https", "host": "api.telegram.org", "pathPrefix": "/" },
+				"rewrite": { "upstreamBaseUrl": "https://router.test/telegram" },
+				"priority": 50
+			},
+			{
+				"id": "default-priority",
+				"enabled": true,
+				"kind": "http",
+				"match": { "scheme": "https", "host": "discord.com", "pathPrefix": "/api/" },
+				"rewrite": { "upstreamBaseUrl": "https://router.test/discord" }
+			}
+		]
+	}`)
+
+	profiles, err := loadProfiles(path)
+	if err != nil {
+		t.Fatalf("loadProfiles failed: %v", err)
+	}
+	if len(profiles) != 2 {
+		t.Fatalf("expected 2 enabled profiles, got %d", len(profiles))
+	}
+	if profiles[0].ID != "later" || profiles[1].ID != "default-priority" {
+		t.Fatalf("profiles not sorted by priority: %#v", []string{profiles[0].ID, profiles[1].ID})
+	}
+	if profiles[1].Priority != 100 {
+		t.Fatalf("expected default priority 100, got %d", profiles[1].Priority)
+	}
+}
+
+func TestLoadProfilesRejectsTrailingDataAndUnknownFields(t *testing.T) {
+	valid := `{
+		"schemaVersion": "clawdi.mitmProfiles.v1",
+		"generatedAt": "2026-06-05T00:00:00Z",
+		"generation": 1,
+		"instanceId": "iid_test",
+		"profiles": []
+	}`
+	if _, err := loadProfiles(writeTestJSON(t, valid+`{}`)); err == nil {
+		t.Fatal("expected trailing data rejection")
+	}
+	if _, err := loadProfiles(writeTestJSON(t, `{
+		"schemaVersion": "clawdi.mitmProfiles.v1",
+		"generatedAt": "2026-06-05T00:00:00Z",
+		"generation": 1,
+		"instanceId": "iid_test",
+		"profiles": [],
+		"extra": true
+	}`)); err == nil {
+		t.Fatal("expected unknown field rejection")
+	}
+}
+
+func TestValidateProfileRejectsUnsafeRewrite(t *testing.T) {
+	err := validateProfile(profile{
+		ID:   "bad-upstream",
+		Kind: "http",
+		Match: profileMatch{
+			Scheme:     "https",
+			Host:       "discord.com",
+			PathPrefix: "/api/",
+		},
+		Rewrite: rewriteRule{UpstreamBaseURL: "secret://router/url"},
+	})
+	if err == nil {
+		t.Fatal("expected non-http upstream rejection")
+	}
+
+	err = validateProfile(profile{
+		ID:   "credentialed-upstream",
+		Kind: "http",
+		Match: profileMatch{
+			Scheme:     "https",
+			Host:       "discord.com",
+			PathPrefix: "/api/",
+		},
+		Rewrite: rewriteRule{UpstreamBaseURL: "https://user:pass@router.test/discord"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "must not include credentials") {
+		t.Fatalf("expected credentialed upstream rejection, got %v", err)
+	}
+
+	err = validateProfile(profile{
+		ID:   "unsafe-upstream-host",
+		Kind: "http",
+		Match: profileMatch{
+			Scheme:     "https",
+			Host:       "discord.com",
+			PathPrefix: "/api/",
+		},
+		Rewrite: rewriteRule{UpstreamBaseURL: "https://.router.test/discord"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "invalid host") {
+		t.Fatalf("expected unsafe upstream host rejection, got %v", err)
+	}
+
+	err = validateProfile(profile{
+		ID:   "deny-with-upstream",
+		Kind: "deny",
+		Match: profileMatch{
+			Scheme: "https",
+			Host:   "169.254.169.254",
+		},
+		Rewrite: rewriteRule{UpstreamBaseURL: "https://router.test/"},
+	})
+	if err == nil {
+		t.Fatal("expected deny rewrite rejection")
+	}
+
+	preserve := true
+	err = validateProfile(profile{
+		ID:   "deny-with-rewrite-rules",
+		Kind: "deny",
+		Match: profileMatch{
+			Scheme: "https",
+			Host:   "169.254.169.254",
+		},
+		Rewrite: rewriteRule{PreservePath: &preserve},
+	})
+	if err == nil {
+		t.Fatal("expected deny rewrite rule rejection")
+	}
+}
+
+func TestResponseHeaderStrippingMatchesCredentialBrokerPolicy(t *testing.T) {
+	if !shouldStripResponseHeader("Connection") {
+		t.Fatalf("expected Connection to be stripped through hop-by-hop check")
+	}
+	if !shouldStripResponseHeader("Transfer-Encoding") {
+		t.Fatalf("expected Transfer-Encoding to be stripped")
+	}
+	if !shouldStripResponseHeader("Set-Cookie") {
+		t.Fatalf("expected Set-Cookie to be stripped")
+	}
+	if shouldStripResponseHeader("X-Request-Id") {
+		t.Fatalf("expected end-to-end response headers to be preserved")
+	}
+}
+
+func TestCopyForwardHeadersStripsProxyScopedAndHopByHopHeaders(t *testing.T) {
+	src := http.Header{}
+	src.Set("Authorization", "Bot managed-token")
+	src.Set("Cookie", "session=abc")
+	src.Set("Connection", "X-Custom-Hop, close")
+	src.Set("X-Custom-Hop", "must-not-forward")
+	src.Set("Proxy-Authorization", "Basic scoped-token")
+	src.Set("Proxy-Connection", "keep-alive")
+	src.Set("Transfer-Encoding", "chunked")
+	src.Set("X-Trace-Id", "trace-1")
+
+	dst := http.Header{}
+	copyForwardHeaders(src, dst)
+
+	if dst.Get("Authorization") != "Bot managed-token" {
+		t.Fatalf("Authorization should pass through for profile matching, got %q", dst.Get("Authorization"))
+	}
+	if dst.Get("Cookie") != "session=abc" {
+		t.Fatalf("Cookie should pass through to the upstream request, got %q", dst.Get("Cookie"))
+	}
+	for _, header := range []string{
+		"Connection",
+		"X-Custom-Hop",
+		"Proxy-Authorization",
+		"Proxy-Connection",
+		"Transfer-Encoding",
+	} {
+		if got := dst.Get(header); got != "" {
+			t.Fatalf("%s should be stripped, got %q", header, got)
+		}
+	}
+	if dst.Get("X-Trace-Id") != "trace-1" {
+		t.Fatalf("X-Trace-Id should pass through, got %q", dst.Get("X-Trace-Id"))
+	}
+}
+
+func TestValidateProfileRejectsSchemaMismatches(t *testing.T) {
+	base := profile{
+		ID:   "discord-rest",
+		Kind: "http",
+		Match: profileMatch{
+			Scheme:     "https",
+			Host:       "discord.com",
+			PathPrefix: "/api/",
+		},
+		Rewrite: rewriteRule{UpstreamBaseURL: "https://router.test/discord"},
+	}
+	tests := []struct {
+		name    string
+		mutate  func(*profile)
+		wantErr string
+	}{
+		{
+			name: "invalid profile id",
+			mutate: func(p *profile) {
+				p.ID = "Discord REST"
+			},
+			wantErr: "must match",
+		},
+		{
+			name: "invalid header matcher name",
+			mutate: func(p *profile) {
+				p.Match.Headers = map[string]headerMatcher{
+					"bad header": {Type: "exists"},
+				}
+			},
+			wantErr: "invalid header matcher name",
+		},
+		{
+			name: "invalid rewrite header name",
+			mutate: func(p *profile) {
+				p.Rewrite.SetHeaders = map[string]headerSetter{
+					"bad header": {Type: "literal", Value: "value"},
+				}
+			},
+			wantErr: "invalid rewrite.setHeaders name",
+		},
+		{
+			name: "invalid rewrite header secret ref",
+			mutate: func(p *profile) {
+				p.Rewrite.SetHeaders = map[string]headerSetter{
+					"authorization": {Type: "secretRef", SecretRef: "provider.default.apiKey"},
+				}
+			},
+			wantErr: "must use a secret:// ref",
+		},
+		{
+			name: "exists matcher with extra fields",
+			mutate: func(p *profile) {
+				p.Match.Headers = map[string]headerMatcher{
+					"authorization": {Type: "exists", Value: "unexpected"},
+				}
+			},
+			wantErr: "exists must not set",
+		},
+		{
+			name: "equals matcher with secret ref",
+			mutate: func(p *profile) {
+				p.Match.Headers = map[string]headerMatcher{
+					"authorization": {
+						Type:      "equals",
+						Value:     "public",
+						SecretRef: "secret://discord/token",
+					},
+				}
+			},
+			wantErr: "equals must not set secretRef",
+		},
+		{
+			name: "secret matcher with public value",
+			mutate: func(p *profile) {
+				p.Match.Headers = map[string]headerMatcher{
+					"authorization": {
+						Type:      "secretRefEquals",
+						SecretRef: "secret://discord/token",
+						Value:     "public",
+					},
+				}
+			},
+			wantErr: "secretRefEquals must not set value",
+		},
+		{
+			name: "path prefix matcher with secret ref",
+			mutate: func(p *profile) {
+				p.Match.Path = pathMatcher{
+					Type:      "prefix",
+					Value:     "/api/",
+					SecretRef: "secret://path/token",
+				}
+			},
+			wantErr: "must not set secretRef",
+		},
+		{
+			name: "secret path matcher with public value",
+			mutate: func(p *profile) {
+				p.Match.Path = pathMatcher{
+					Type:      "secretRefPrefix",
+					SecretRef: "secret://path/token",
+					Value:     "/api/",
+				}
+			},
+			wantErr: "must not set value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := base
+			tt.mutate(&p)
+			err := validateProfile(p)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestMatchRouteUsesSecretRefGates(t *testing.T) {
+	proxy := proxyServer{
+		secrets: map[string]string{
+			"secret://discord/token":  "discord-token",
+			"secret://telegram/token": "telegram-token",
+			"secret://imessage/token": "imessage-token",
+		},
+		profiles: []profile{
+			{
+				ID:   "discord-rest",
+				Kind: "http",
+				Match: profileMatch{
+					Scheme: "https",
+					Host:   "discord.com",
+					Headers: map[string]headerMatcher{
+						"authorization": {
+							Type:      "secretRefEquals",
+							SecretRef: "secret://discord/token",
+							Prefix:    "Bot ",
+						},
+					},
+				},
+				Rewrite: rewriteRule{UpstreamBaseURL: "https://router.test/discord"},
+			},
+			{
+				ID:   "telegram-bot-api",
+				Kind: "http",
+				Match: profileMatch{
+					Scheme: "https",
+					Host:   "api.telegram.org",
+					Path: pathMatcher{
+						Type:      "secretRefPrefix",
+						SecretRef: "secret://telegram/token",
+						Prefix:    "/bot",
+						Suffix:    "/",
+					},
+				},
+				Rewrite: rewriteRule{UpstreamBaseURL: "https://router.test/telegram"},
+			},
+			{
+				ID:   "bluebubbles-rest",
+				Kind: "http",
+				Match: profileMatch{
+					Scheme: "https",
+					Host:   "bluebubbles.invalid",
+					Query: map[string]headerMatcher{
+						"password": {
+							Type:      "secretRefEquals",
+							SecretRef: "secret://imessage/token",
+						},
+					},
+				},
+				Rewrite: rewriteRule{UpstreamBaseURL: "https://router.test/imessage"},
+			},
+		},
+	}
+
+	headers := http.Header{}
+	headers.Set("Authorization", "Bot discord-token")
+	if route := proxy.matchRoute("discord.com", "https", "/api/v10/users/@me", "", headers); route == nil || route.profile.ID != "discord-rest" {
+		t.Fatalf("expected discord route, got %#v", route)
+	}
+	headers.Set("Authorization", "Bot wrong")
+	if route := proxy.matchRoute("discord.com", "https", "/api/v10/users/@me", "", headers); route != nil {
+		t.Fatalf("expected discord route denial, got %#v", route.profile.ID)
+	}
+	if route := proxy.matchRoute("api.telegram.org", "https", "/bottelegram-token/getMe", "", http.Header{}); route == nil || route.profile.ID != "telegram-bot-api" {
+		t.Fatalf("expected telegram route, got %#v", route)
+	}
+	if route := proxy.matchRoute("api.telegram.org", "https", "/botwrong/getMe", "", http.Header{}); route != nil {
+		t.Fatalf("expected telegram route denial, got %#v", route.profile.ID)
+	}
+	if route := proxy.matchRoute("bluebubbles.invalid", "https", "/api/v1/ping", "password=imessage-token", http.Header{}); route == nil || route.profile.ID != "bluebubbles-rest" {
+		t.Fatalf("expected bluebubbles route, got %#v", route)
+	}
+	if route := proxy.matchRoute("bluebubbles.invalid", "https", "/api/v1/ping", "password=wrong", http.Header{}); route != nil {
+		t.Fatalf("expected bluebubbles route denial, got %#v", route.profile.ID)
+	}
+}
+
+func TestRewritePathPreservesBaseAndQueries(t *testing.T) {
+	upstream := mustParseURL(t, "https://router.test/base?tenant=abc")
+	path, query := rewritePath(upstream, "/api/v1/ping?password=secret", true)
+	if path != "/base/api/v1/ping" {
+		t.Fatalf("unexpected path %q", path)
+	}
+	if query != "tenant=abc&password=secret" {
+		t.Fatalf("unexpected query %q", query)
+	}
+
+	path, query = rewritePath(mustParseURL(t, "https://router.test/fixed?tenant=abc"), "/ignored?x=1", false)
+	if path != "/fixed" || query != "tenant=abc" {
+		t.Fatalf("unexpected non-preserve rewrite path=%q query=%q", path, query)
+	}
+}
+
+func TestValidateProfileRejectsPassthrough(t *testing.T) {
+	err := validateProfile(profile{
+		ID:   "local-passthrough",
+		Kind: "passthrough",
+		Match: profileMatch{
+			Scheme:     "http",
+			Host:       "example.com",
+			PathPrefix: "/",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected passthrough profile to be rejected")
+	}
+	if !strings.Contains(err.Error(), `unsupported kind "passthrough"`) {
+		t.Fatalf("unexpected passthrough rejection: %v", err)
+	}
+}
+
+func TestTargetNormalizationPreservesNonDefaultPorts(t *testing.T) {
+	target, matchHost, tlsHost, err := targetFromConnect("example.com:8443")
+	if err != nil {
+		t.Fatalf("targetFromConnect failed: %v", err)
+	}
+	if target != "example.com:8443" || matchHost != "example.com:8443" || tlsHost != "example.com" {
+		t.Fatalf("unexpected non-default target=%q matchHost=%q tlsHost=%q", target, matchHost, tlsHost)
+	}
+
+	target, matchHost, tlsHost, err = targetFromConnect("example.com:443")
+	if err != nil {
+		t.Fatalf("targetFromConnect default port failed: %v", err)
+	}
+	if target != "example.com:443" || matchHost != "example.com" || tlsHost != "example.com" {
+		t.Fatalf("unexpected default target=%q matchHost=%q tlsHost=%q", target, matchHost, tlsHost)
+	}
+
+	absolute := mustParseURL(t, "http://127.0.0.1:18080/path")
+	target, matchHost, err = targetFromURL(absolute)
+	if err != nil {
+		t.Fatalf("targetFromURL failed: %v", err)
+	}
+	if target != "127.0.0.1:18080" || matchHost != "127.0.0.1:18080" {
+		t.Fatalf("unexpected absolute target=%q matchHost=%q", target, matchHost)
+	}
+}
+
+func TestListenProxyLoopbackPolicy(t *testing.T) {
+	if _, _, err := listenProxy("http://0.0.0.0:0", false); err == nil {
+		t.Fatal("expected non-loopback listener rejection")
+	}
+	listener, actual, err := listenProxy("http://127.0.0.1:0", false)
+	if err != nil {
+		t.Fatalf("loopback listener failed: %v", err)
+	}
+	defer listener.Close()
+	if actual == "" {
+		t.Fatal("expected actual proxy URL")
+	}
+}
+
+func writeTestJSON(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "profiles.json")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write test JSON: %v", err)
+	}
+	return path
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse URL %q: %v", raw, err)
+	}
+	return u
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.9",
+	"version": "0.12.10-beta.0",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",
@@ -10,6 +10,7 @@
 	},
 	"files": [
 		"bin",
+		"clawdi-mitm-broker",
 		"dist",
 		"LICENSE",
 		"README.md"
@@ -23,13 +24,16 @@
 	"scripts": {
 		"dev": "bun run src/index.ts",
 		"build": "rm -rf dist && bun build src/index.ts --outdir dist --target node --minify --define 'process.env.CLAWDI_DEFAULT_API_URL=\"https://cloud-api.clawdi.ai\"' && cp -r skills dist/skills",
+		"build:binary": "bun run scripts/build-binary.mjs",
+		"build:mitm-broker": "bun run scripts/build-mitm-broker-bundle.mjs",
+		"package:binary-release": "bun run scripts/package-binary-release.mjs",
 		"build:dev": "rm -rf dist && bun build src/index.ts --outdir dist --target node && cp -r skills dist/skills",
 		"check:publish-manifest": "node scripts/check-publish-manifest.mjs",
 		"typecheck": "tsc --noEmit",
-		"test": "bun test",
-		"test:e2e": "bun test tests/e2e",
+		"test": "bun test --isolate --max-concurrency=1",
+		"test:e2e": "bun test --isolate --max-concurrency=1 tests/e2e",
 		"test:watch": "bun test --watch",
-		"prepublishOnly": "bun run build"
+		"prepublishOnly": "bun run build && CLAWDI_MITM_BROKER_BUNDLE_OUTDIR=clawdi-mitm-broker bun run build:mitm-broker"
 	},
 	"repository": {
 		"type": "git",
@@ -52,20 +56,18 @@
 		"vault",
 		"mcp"
 	],
-	"dependencies": {
+	"devDependencies": {
+		"@clawdi/shared": "workspace:*",
 		"@clack/prompts": "^1.2.0",
 		"@modelcontextprotocol/sdk": "^1.29.0",
+		"@types/bun": "^1.3.12",
+		"@types/node": "^22.0.0",
 		"chalk": "^5.4.0",
 		"commander": "^13.0.0",
 		"openapi-fetch": "^0.17.0",
 		"tar": "^7.5.13",
+		"typescript": "^5.9.0",
 		"yaml": "^2.9.0",
 		"zod": "^4.3.6"
-	},
-	"devDependencies": {
-		"@clawdi/shared": "workspace:*",
-		"@types/bun": "^1.3.12",
-		"@types/node": "^22.0.0",
-		"typescript": "^5.9.0"
 	}
 }

--- a/packages/cli/scripts/build-binary.mjs
+++ b/packages/cli/scripts/build-binary.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env bun
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const cliRoot = resolve(scriptDir, "..");
+const packageJson = JSON.parse(readFileSync(resolve(cliRoot, "package.json"), "utf-8"));
+
+const target = process.env.CLAWDI_BINARY_TARGET || "bun-linux-x64-baseline";
+const outfile = resolve(cliRoot, process.env.CLAWDI_BINARY_OUTFILE || "dist-bin/clawdi");
+const defaultApiUrl = process.env.CLAWDI_DEFAULT_API_URL || "https://cloud-api.clawdi.ai";
+
+rmSync(dirname(outfile), { recursive: true, force: true });
+mkdirSync(dirname(outfile), { recursive: true });
+
+const result = await Bun.build({
+	entrypoints: [resolve(cliRoot, "src/index.ts")],
+	compile: {
+		target,
+		outfile,
+	},
+	define: {
+		CLAWDI_CLI_VERSION: JSON.stringify(packageJson.version),
+		"process.env.CLAWDI_DEFAULT_API_URL": JSON.stringify(defaultApiUrl),
+	},
+	minify: true,
+});
+
+if (!result.success) {
+	for (const log of result.logs) console.error(log.message);
+	process.exit(1);
+}
+
+console.log(`built ${outfile} (${target})`);
+
+if (process.env.CLAWDI_SKIP_MITM_BROKER_BUNDLE !== "1") {
+	const bundleOutdir = resolve(dirname(outfile), "clawdi-mitm-broker");
+	const result = spawnSync(
+		"bun",
+		["run", resolve(cliRoot, "scripts", "build-mitm-broker-bundle.mjs")],
+		{
+			encoding: "utf8",
+			env: {
+				...process.env,
+				CLAWDI_MITM_BROKER_BUNDLE_OUTDIR: bundleOutdir,
+			},
+			stdio: "pipe",
+		},
+	);
+	if (result.status !== 0) {
+		throw new Error(`MITM broker bundle build failed\n${result.stdout}${result.stderr}`);
+	}
+	if (result.stdout.trim()) process.stdout.write(result.stdout);
+	if (result.stderr.trim()) process.stderr.write(result.stderr);
+} else {
+	console.log("skipped MITM broker bundle (CLAWDI_SKIP_MITM_BROKER_BUNDLE=1)");
+}

--- a/packages/cli/scripts/build-mitm-broker-bundle.mjs
+++ b/packages/cli/scripts/build-mitm-broker-bundle.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env bun
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const cliRoot = resolve(scriptDir, "..");
+const sourceDir = resolve(cliRoot, "native", "mitm-broker");
+const outdir = resolve(
+	cliRoot,
+	process.env.CLAWDI_MITM_BROKER_BUNDLE_OUTDIR || "dist-bin/clawdi-mitm-broker",
+);
+const binDir = join(outdir, "bin");
+const outfile = join(binDir, "clawdi-mitm-broker");
+
+rmSync(outdir, { recursive: true, force: true });
+mkdirSync(binDir, { recursive: true });
+
+const buildEnv = {
+	...process.env,
+	CGO_ENABLED: process.env.CLAWDI_MITM_BROKER_CGO_ENABLED || "0",
+};
+if (process.env.CLAWDI_MITM_BROKER_GOOS) {
+	buildEnv.GOOS = process.env.CLAWDI_MITM_BROKER_GOOS;
+}
+if (process.env.CLAWDI_MITM_BROKER_GOARCH) {
+	buildEnv.GOARCH = process.env.CLAWDI_MITM_BROKER_GOARCH;
+}
+
+run("go", ["build", "-trimpath", "-ldflags", "-s -w", "-o", outfile, "."], {
+	cwd: sourceDir,
+	env: buildEnv,
+});
+chmodSync(outfile, 0o755);
+
+const goVersion = spawnSync("go", ["version"], { encoding: "utf8", stdio: "pipe" });
+writeFileSync(
+	join(outdir, "manifest.json"),
+	`${JSON.stringify(
+		{
+			schemaVersion: "clawdi.mitmBrokerBundle.v1",
+			kind: "native-go",
+			entrypoint: "bin/clawdi-mitm-broker",
+			source: "native/mitm-broker",
+			go: goVersion.status === 0 ? goVersion.stdout.trim() : null,
+			cgoEnabled: buildEnv.CGO_ENABLED,
+			goos: buildEnv.GOOS ?? null,
+			goarch: buildEnv.GOARCH ?? null,
+		},
+		null,
+		2,
+	)}\n`,
+);
+
+console.log(`built native MITM broker bundle ${outdir}`);
+
+function run(command, args, options = {}) {
+	const result = spawnSync(command, args, { encoding: "utf8", stdio: "pipe", ...options });
+	if (result.status !== 0) {
+		throw new Error(
+			`${command} ${args.join(" ")} failed\n${result.stdout ?? ""}${result.stderr ?? ""}`,
+		);
+	}
+	if (result.stdout.trim()) process.stdout.write(result.stdout);
+	if (result.stderr.trim()) process.stderr.write(result.stderr);
+}

--- a/packages/cli/scripts/check-publish-manifest.mjs
+++ b/packages/cli/scripts/check-publish-manifest.mjs
@@ -1,10 +1,16 @@
-import { readFileSync } from "node:fs";
+import { accessSync, constants, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
 const forbiddenProtocols = /^(catalog|workspace):/;
 const dependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"];
+const cliRoot = fileURLToPath(new URL("..", import.meta.url));
 
 const problems = [];
+if (packageJson.dependencies && Object.keys(packageJson.dependencies).length > 0) {
+	problems.push("published bundled CLI package must not declare runtime dependencies");
+}
 for (const field of dependencyFields) {
 	const dependencies = packageJson[field];
 	if (!dependencies || typeof dependencies !== "object") continue;
@@ -15,11 +21,23 @@ for (const field of dependencyFields) {
 	}
 }
 
+const packageFiles = Array.isArray(packageJson.files) ? packageJson.files : [];
+if (!packageFiles.includes("clawdi-mitm-broker")) {
+	problems.push('package.json files must include "clawdi-mitm-broker"');
+}
+
+try {
+	accessSync(join(cliRoot, "clawdi-mitm-broker", "bin", "clawdi-mitm-broker"), constants.X_OK);
+} catch {
+	problems.push(
+		"clawdi-mitm-broker/bin/clawdi-mitm-broker is missing or not executable; run `CLAWDI_MITM_BROKER_BUNDLE_OUTDIR=clawdi-mitm-broker bun run build:mitm-broker` before publishing",
+	);
+}
+
 if (problems.length > 0) {
-	console.error("The published CLI package cannot contain monorepo-only dependency protocols:");
+	console.error("The published CLI package manifest is not ready:");
 	for (const problem of problems) {
 		console.error(`- ${problem}`);
 	}
-	console.error("Use a real npm semver/range in packages/cli/package.json before publishing.");
 	process.exit(1);
 }

--- a/packages/cli/scripts/package-binary-release.mjs
+++ b/packages/cli/scripts/package-binary-release.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env bun
+import { spawnSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const cliRoot = resolve(scriptDir, "..");
+const distBin = resolve(cliRoot, "dist-bin");
+const outdir = resolve(cliRoot, "dist-release");
+const assetName = process.env.CLAWDI_BINARY_RELEASE_ASSET || "clawdi-cli-linux-x64.tar.gz";
+const assetPath = resolve(outdir, assetName);
+const checksumPath = `${assetPath}.sha256`;
+
+rmSync(outdir, { recursive: true, force: true });
+mkdirSync(outdir, { recursive: true });
+
+run("test", ["-x", resolve(distBin, "clawdi")]);
+run("test", ["-x", resolve(distBin, "clawdi-mitm-broker", "bin", "clawdi-mitm-broker")]);
+run("tar", [
+	"-C",
+	distBin,
+	"--owner=0",
+	"--group=0",
+	"--numeric-owner",
+	"-czf",
+	assetPath,
+	"clawdi",
+	"clawdi-mitm-broker",
+]);
+
+const checksum = run("sha256sum", [assetPath]).trim().split(/\s+/)[0];
+writeFileSync(checksumPath, `${checksum}  ${basename(assetPath)}\n`);
+
+console.log(`packaged ${assetPath}`);
+console.log(`sha256 ${checksum}`);
+
+function run(command, args) {
+	const result = spawnSync(command, args, { encoding: "utf8", stdio: "pipe" });
+	if (result.status !== 0) {
+		throw new Error(
+			`${command} ${args.join(" ")} failed\n${result.stdout ?? ""}${result.stderr ?? ""}`,
+		);
+	}
+	if (result.stderr.trim()) process.stderr.write(result.stderr);
+	return result.stdout;
+}

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
 import { hostname } from "node:os";
 import * as p from "@clack/prompts";
 import chalk from "chalk";
@@ -15,6 +16,7 @@ import {
 	setAuth,
 	setPendingAuth,
 } from "../lib/config";
+import { detectRuntimeMode, getRuntimePaths } from "../runtime/paths";
 import type { ShareToken } from "../share/tokens";
 
 function upgradeIdempotencyKey(token: string): string {
@@ -567,4 +569,52 @@ export async function authLogout() {
 
 	clearAuth();
 	p.log.success("Logged out. Credentials and cached environments removed.");
+}
+
+type AuthStatusSource = "auth.json" | "CLAWDI_AUTH_TOKEN" | "runtime-instance-data" | "none";
+
+function detectAuthSource(): AuthStatusSource {
+	const paths = getRuntimePaths();
+	if (process.env.CLAWDI_AUTH_TOKEN) return "CLAWDI_AUTH_TOKEN";
+	if (existsSync(paths.localAuth)) return "auth.json";
+	if (existsSync(paths.sensitiveInstanceData)) return "runtime-instance-data";
+	return "none";
+}
+
+export async function authStatus(opts: { json?: boolean } = {}) {
+	const auth = getAuth();
+	const config = getConfig();
+	const mode = detectRuntimeMode();
+	const paths = getRuntimePaths({ mode });
+	const source = detectAuthSource();
+	const authenticated = Boolean(auth) || source === "runtime-instance-data";
+	const payload = {
+		schemaVersion: "clawdi.authStatus.v1",
+		authenticated,
+		source,
+		apiUrl: config.apiUrl,
+		runtimeMode: mode,
+		user: auth ? { email: auth.email, id: auth.userId } : undefined,
+		paths: {
+			clawdiHome: paths.clawdiHome,
+			auth: source === "auth.json" ? paths.localAuth : undefined,
+			managedConfig: mode === "hosted" ? paths.managedConfig : undefined,
+			sensitiveInstanceDataPresent: existsSync(paths.sensitiveInstanceData),
+			sensitiveInstanceData: "<redacted>",
+		},
+	};
+
+	if (opts.json || !process.stdout.isTTY) {
+		console.log(JSON.stringify(payload, null, 2));
+		return;
+	}
+
+	console.log(chalk.bold("clawdi auth status"));
+	console.log();
+	console.log(`  Authenticated: ${authenticated ? chalk.green("yes") : chalk.red("no")}`);
+	console.log(`  Source: ${source}`);
+	console.log(chalk.gray(`  API: ${config.apiUrl}`));
+	if (auth?.email || auth?.userId) {
+		console.log(chalk.gray(`  User: ${auth.email || auth.userId}`));
+	}
 }

--- a/packages/cli/src/commands/capabilities.ts
+++ b/packages/cli/src/commands/capabilities.ts
@@ -1,0 +1,103 @@
+import chalk from "chalk";
+import { getCliVersion } from "../lib/version";
+import { normalizeDeniedCommands, readHostPolicy } from "../runtime/host-policy";
+import { detectRuntimeMode } from "../runtime/paths";
+
+interface Capabilities {
+	schemaVersion: "clawdi.capabilities.v1";
+	cliVersion: string;
+	fullCliSurface: true;
+	runtimeMode: "local" | "hosted";
+	updateMode: "local-self-update" | "system-managed-npm";
+	commands: string[];
+	restrictedByHostedPolicy: Array<{ command: string; reason?: string }>;
+	hostPolicy: {
+		path: string;
+		exists: boolean;
+		valid: boolean;
+		error?: string;
+	};
+	mcp: { available: true; command: "clawdi mcp" };
+	daemon: { available: true; command: "clawdi daemon run" };
+	providerApply: { available: true; command: "clawdi ai-provider apply" };
+}
+
+const COMMANDS = [
+	"auth",
+	"status",
+	"config",
+	"setup",
+	"teardown",
+	"push",
+	"pull",
+	"daemon",
+	"serve",
+	"ai-provider",
+	"vault",
+	"read",
+	"inject",
+	"skill",
+	"session",
+	"memory",
+	"doctor",
+	"update",
+	"mcp",
+	"run",
+	"project",
+	"agent",
+	"inbox",
+	"runtime",
+	"capabilities",
+];
+
+function buildCapabilities(): Capabilities {
+	const runtimeMode = detectRuntimeMode();
+	const hostPolicy = readHostPolicy();
+	const cliUpdateMode = hostPolicy.policy?.cliUpdateMode;
+	const updateMode =
+		runtimeMode === "hosted" || cliUpdateMode === "system-managed-npm"
+			? "system-managed-npm"
+			: "local-self-update";
+
+	return {
+		schemaVersion: "clawdi.capabilities.v1",
+		cliVersion: getCliVersion(),
+		fullCliSurface: true,
+		runtimeMode,
+		updateMode,
+		commands: COMMANDS,
+		restrictedByHostedPolicy: normalizeDeniedCommands(hostPolicy.policy),
+		hostPolicy: {
+			path: hostPolicy.path,
+			exists: hostPolicy.exists,
+			valid: hostPolicy.valid,
+			error: hostPolicy.error,
+		},
+		mcp: { available: true, command: "clawdi mcp" },
+		daemon: { available: true, command: "clawdi daemon run" },
+		providerApply: { available: true, command: "clawdi ai-provider apply" },
+	};
+}
+
+export async function capabilitiesCommand(opts: { json?: boolean } = {}) {
+	const capabilities = buildCapabilities();
+	if (opts.json || !process.stdout.isTTY) {
+		console.log(JSON.stringify(capabilities, null, 2));
+		return;
+	}
+
+	console.log(chalk.bold("clawdi capabilities"));
+	console.log();
+	console.log(`  CLI version: ${capabilities.cliVersion}`);
+	console.log(`  Runtime mode: ${capabilities.runtimeMode}`);
+	console.log(`  Update mode: ${capabilities.updateMode}`);
+	console.log(`  Full CLI surface: yes`);
+	if (capabilities.restrictedByHostedPolicy.length > 0) {
+		console.log();
+		console.log(chalk.bold("  Hosted policy restrictions:"));
+		for (const entry of capabilities.restrictedByHostedPolicy) {
+			const reason = entry.reason ? chalk.gray(` — ${entry.reason}`) : "";
+			console.log(`    ${entry.command}${reason}`);
+		}
+	}
+}

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -2,10 +2,13 @@ import chalk from "chalk";
 import {
 	CONFIG_KEYS,
 	type ConfigKey,
+	getClawdiDir,
+	getConfig,
 	getStoredConfig,
 	setConfigKey,
 	unsetConfigKey,
 } from "../lib/config";
+import { detectRuntimeMode, getRuntimePaths } from "../runtime/paths";
 
 function isKnownKey(k: string): k is ConfigKey {
 	return (CONFIG_KEYS as readonly string[]).includes(k);
@@ -65,4 +68,65 @@ export function configUnset(key: string) {
 	}
 	unsetConfigKey(key);
 	console.log(chalk.green(`✓ Unset ${key}`));
+}
+
+function apiUrlSource(): "CLAWDI_API_URL" | "config.json" | "default" {
+	if (process.env.CLAWDI_API_URL) return "CLAWDI_API_URL";
+	if (getStoredConfig().apiUrl) return "config.json";
+	return "default";
+}
+
+export function configPaths(opts: { json?: boolean } = {}) {
+	const mode = detectRuntimeMode();
+	const paths = getRuntimePaths({ mode });
+	const payload = {
+		schemaVersion: "clawdi.configPaths.v1",
+		runtimeMode: mode,
+		apiUrl: getConfig().apiUrl,
+		apiUrlSource: apiUrlSource(),
+		local: {
+			clawdiHome: getClawdiDir(),
+			config: paths.localConfig,
+			auth: paths.localAuth,
+			pendingAuth: paths.localPendingAuth,
+			environments: paths.localEnvironments,
+			serveState: paths.serveState,
+		},
+		hosted: {
+			imageShim: paths.imageShim,
+			hostPolicy: paths.hostPolicy,
+			shareRoot: paths.shareRoot,
+			serviceStateRoot: paths.serviceStateRoot,
+			managedConfig: paths.managedConfig,
+			syncState: paths.syncState,
+			managedCliBin: paths.cliManagedBin,
+			cliNpmPrefix: paths.cliNpmPrefix,
+			cliBootstrapStatus: paths.cliBootstrapStatus,
+			runRoot: paths.runRoot,
+			persistentHome: paths.userHome,
+			workspaceRoot: paths.workspaceRoot,
+		},
+	};
+
+	if (opts.json || !process.stdout.isTTY) {
+		console.log(JSON.stringify(payload, null, 2));
+		return;
+	}
+
+	console.log(chalk.bold("clawdi config paths"));
+	console.log();
+	console.log(chalk.bold("  Local"));
+	console.log(chalk.gray(`    clawdiHome: ${payload.local.clawdiHome}`));
+	console.log(chalk.gray(`    config:     ${payload.local.config}`));
+	console.log(chalk.gray(`    auth:       ${payload.local.auth}`));
+	console.log(chalk.gray(`    envs:       ${payload.local.environments}`));
+	console.log();
+	console.log(chalk.bold("  Hosted"));
+	console.log(chalk.gray(`    policy:     ${payload.hosted.hostPolicy}`));
+	console.log(chalk.gray(`    state:      ${payload.hosted.serviceStateRoot}`));
+	console.log(chalk.gray(`    config:     ${payload.hosted.managedConfig}`));
+	console.log(chalk.gray(`    run:        ${payload.hosted.runRoot}`));
+	console.log(chalk.gray(`    home:       ${payload.hosted.persistentHome}`));
+	console.log();
+	console.log(chalk.gray(`  API URL: ${payload.apiUrl} (${payload.apiUrlSource})`));
 }

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import chalk from "chalk";
 import { readAiProviderCatalog } from "../lib/ai-provider-catalog";
 import { inspectAiProviderAuth } from "../lib/ai-provider-test";
@@ -25,6 +25,24 @@ import {
 	VAULT_PROJECT_ACCESS_ERROR,
 	VAULT_PROJECT_ACCESS_HINT,
 } from "../lib/vault-errors";
+import {
+	type RuntimeMitmBroker,
+	type RuntimeMitmBrokerFactory,
+	shouldStartRuntimeMitmBroker,
+	startRuntimeMitmBroker,
+} from "../runtime/mitm-broker";
+import {
+	applyMitmBrokerRuntimeEnv,
+	buildMitmBrokerEnv,
+	stripMitmBrokerControlEnv,
+} from "../runtime/mitm-env";
+import { detectRuntimeMode, getRuntimePaths } from "../runtime/paths";
+import {
+	buildRuntimeRunInvocation,
+	type RuntimeRunConfigRead,
+	type RuntimeRunInvocation,
+	readRuntimeRunConfigForCommand,
+} from "../runtime/run-config";
 
 interface RunOpts {
 	project?: string;
@@ -44,14 +62,46 @@ interface SelectedProject {
 
 type SpawnFn = typeof spawn;
 
-export async function run(args: string[], opts: RunOpts = {}, spawnImpl: SpawnFn = spawn) {
-	if (!isLoggedIn()) {
-		console.log(chalk.red("Not logged in. Run `clawdi auth login` first."));
+export async function run(
+	args: string[],
+	opts: RunOpts = {},
+	spawnImpl: SpawnFn = spawn,
+	brokerFactory: RuntimeMitmBrokerFactory = startRuntimeMitmBroker,
+) {
+	if (args.length === 0) {
+		console.log(chalk.red("No command specified. Usage: clawdi run -- <command>"));
 		process.exit(1);
 	}
 
-	if (args.length === 0) {
-		console.log(chalk.red("No command specified. Usage: clawdi run -- <command>"));
+	const hostedRuntimeRun = hostedRuntimeRunConfig(args[0]);
+	const baseProcessEnv = { ...process.env };
+	const hostedGenericRun = hostedGenericRunInvocation(args, baseProcessEnv);
+	if (hostedRuntimeRun.status === "ok" && !requiresCloudResolution(opts)) {
+		await spawnRuntimeInvocation(
+			buildRuntimeRunInvocation(hostedRuntimeRun, args, baseProcessEnv),
+			spawnImpl,
+			brokerFactory,
+		);
+		return;
+	}
+	if (
+		hostedRuntimeRun.status !== "not-runtime" &&
+		hostedRuntimeRun.status !== "ok" &&
+		!requiresCloudResolution(opts)
+	) {
+		console.log(chalk.red(hostedRuntimeRunError(hostedRuntimeRun)));
+		process.exit(1);
+	}
+	if (hostedGenericRun && !requiresCloudResolution(opts)) {
+		await spawnRuntimeInvocation(hostedGenericRun, spawnImpl, brokerFactory);
+		return;
+	}
+	if (!isLoggedIn()) {
+		if (hostedRuntimeRun.status !== "not-runtime" && hostedRuntimeRun.status !== "ok") {
+			console.log(chalk.red(hostedRuntimeRunError(hostedRuntimeRun)));
+			process.exit(1);
+		}
+		console.log(chalk.red("Not logged in. Run `clawdi auth login` first."));
 		process.exit(1);
 	}
 
@@ -119,23 +169,36 @@ export async function run(args: string[], opts: RunOpts = {}, spawnImpl: SpawnFn
 		process.exit(1);
 	}
 	const spawnEnv = { ...envWithReferences, ...vaultEnv, ...referenceEnv };
-	const managedAiProviderEnv = await resolveManagedAiProviderEnv(spawnEnv);
+	if (hostedRuntimeRun.status !== "not-runtime" && hostedRuntimeRun.status !== "ok") {
+		console.log(chalk.red(hostedRuntimeRunError(hostedRuntimeRun)));
+		process.exit(1);
+	}
 
-	// Spawn child process with injected env
+	const managedAiProviderEnv = await resolveManagedAiProviderEnv(spawnEnv);
+	const childEnv = { ...spawnEnv, ...managedAiProviderEnv };
+	if (hostedRuntimeRun.status === "ok") {
+		await spawnRuntimeInvocation(
+			buildRuntimeRunInvocation(hostedRuntimeRun, args, childEnv),
+			spawnImpl,
+			brokerFactory,
+		);
+		return;
+	}
+
+	const hostedGenericLoggedInRun = hostedGenericRunInvocation(args, childEnv);
+	if (hostedGenericLoggedInRun) {
+		await spawnRuntimeInvocation(hostedGenericLoggedInRun, spawnImpl, brokerFactory);
+		return;
+	}
+
 	const [cmd, ...cmdArgs] = args;
 	const child = spawnImpl(cmd, cmdArgs, {
-		env: { ...spawnEnv, ...managedAiProviderEnv },
+		env: childEnv,
 		stdio: "inherit",
 	});
 
-	child.on("error", (err) => {
-		console.log(chalk.red(`Failed to start: ${err.message}`));
-		process.exit(1);
-	});
-
-	child.on("exit", (code) => {
-		process.exit(code ?? 0);
-	});
+	const code = await waitForChildExit(child, "command");
+	process.exitCode = code;
 }
 
 async function resolveManagedAiProviderEnv(
@@ -172,6 +235,136 @@ async function resolveManagedAiProviderEnv(
 		console.log(chalk.green(`✓ Resolved ${count} AI provider key${count === 1 ? "" : "s"}`));
 	}
 	return injected;
+}
+
+function requiresCloudResolution(opts: RunOpts): boolean {
+	return Boolean(
+		opts.project ||
+			opts.agent ||
+			opts.allVaultEnv ||
+			opts.dryRun ||
+			(opts.envFile && opts.envFile.length > 0),
+	);
+}
+
+function hostedRuntimeRunConfig(command: string): RuntimeRunConfigRead {
+	if (detectRuntimeMode() !== "hosted") return { status: "not-runtime", runtime: null };
+	return readRuntimeRunConfigForCommand(command, getRuntimePaths({ mode: "hosted" }));
+}
+
+function hostedGenericRunInvocation(
+	args: string[],
+	baseEnv: NodeJS.ProcessEnv,
+): RuntimeRunInvocation | null {
+	if (detectRuntimeMode() !== "hosted") return null;
+	const [command, ...commandArgs] = args;
+	if (!command) return null;
+	const paths = getRuntimePaths({ mode: "hosted" });
+	if (!existsSync(paths.mitmProfileBundle)) return null;
+	return {
+		runtime: "generic",
+		command,
+		args: commandArgs,
+		cwd: process.cwd(),
+		env: buildMitmBrokerEnv({
+			env: baseEnv,
+			profileBundlePath: paths.mitmProfileBundle,
+		}),
+		configPath: paths.mitmProfileBundle,
+	};
+}
+
+function hostedRuntimeRunError(
+	read: Exclude<RuntimeRunConfigRead, { status: "ok" | "not-runtime" }>,
+): string {
+	if (read.status === "missing") {
+		return `No hosted run config for ${read.runtime}. Run \`clawdi runtime init --non-interactive\` first.`;
+	}
+	if (read.status === "disabled") {
+		return `Runtime ${read.runtime} is disabled by the current hosted runtime manifest.`;
+	}
+	return `Invalid hosted run config for ${read.runtime} at ${read.path}: ${read.error}`;
+}
+
+async function spawnRuntimeInvocation(
+	invocation: RuntimeRunInvocation,
+	spawnImpl: SpawnFn,
+	brokerFactory: RuntimeMitmBrokerFactory,
+): Promise<void> {
+	delete invocation.env.CLAWDI_AUTH_TOKEN;
+	let broker: RuntimeMitmBroker | null = null;
+	if (shouldStartRuntimeMitmBroker(invocation.env)) {
+		try {
+			broker = await brokerFactory({
+				runtime: invocation.runtime,
+				env: invocation.env,
+				profileBundlePath: invocation.env.CLAWDI_MITM_PROFILE_BUNDLE ?? invocation.configPath,
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			console.log(chalk.red(`Failed to start MITM broker for ${invocation.runtime}: ${message}`));
+			process.exit(1);
+		}
+	}
+	if (broker) {
+		applyMitmBrokerRuntimeEnv(invocation.env, broker);
+		stripMitmBrokerControlEnv(invocation.env);
+	}
+	const child = spawnImpl(invocation.command, invocation.args, {
+		cwd: invocation.cwd,
+		env: invocation.env,
+		stdio: "inherit",
+	});
+
+	const code = await waitForChildExit(child, invocation.runtime);
+	try {
+		await broker?.stop();
+	} finally {
+		process.exitCode = code;
+	}
+}
+
+const SIGNAL_EXIT_CODES: Record<string, number> = {
+	SIGHUP: 129,
+	SIGINT: 130,
+	SIGQUIT: 131,
+	SIGILL: 132,
+	SIGTRAP: 133,
+	SIGABRT: 134,
+	SIGBUS: 135,
+	SIGFPE: 136,
+	SIGKILL: 137,
+	SIGUSR1: 138,
+	SIGSEGV: 139,
+	SIGUSR2: 140,
+	SIGPIPE: 141,
+	SIGALRM: 142,
+	SIGTERM: 143,
+};
+
+function exitCodeForSignal(signal: NodeJS.Signals | null): number {
+	if (!signal) return 1;
+	return SIGNAL_EXIT_CODES[signal] ?? 1;
+}
+
+function waitForChildExit(child: ReturnType<SpawnFn>, label: string): Promise<number> {
+	return new Promise((resolve) => {
+		let settled = false;
+		const settle = (code: number) => {
+			if (settled) return;
+			settled = true;
+			resolve(code);
+		};
+
+		child.once("error", (err) => {
+			console.log(chalk.red(`Failed to start ${label}: ${err.message}`));
+			settle(1);
+		});
+
+		child.once("exit", (code, signal) => {
+			settle(code ?? exitCodeForSignal(signal));
+		});
+	});
 }
 
 async function previewRun(

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { accessSync, constants, existsSync, readFileSync } from "node:fs";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import type { components } from "@clawdi/shared/api";
 import chalk from "chalk";
@@ -7,6 +8,18 @@ import { z } from "zod";
 import { ApiClient, unwrap } from "../lib/api-client";
 import { getConfig } from "../lib/config";
 import { PRIVATE_DIR_MODE, writePrivateFileAtomic } from "../lib/private-file";
+import { readHostPolicy } from "../runtime/host-policy";
+import { convergeRuntimeManifest, loadRuntimeManifest } from "../runtime/manifest";
+import { runtimeSourceAuthEnv } from "../runtime/manifest-source";
+import { detectRuntimeMode, getRuntimePaths } from "../runtime/paths";
+import {
+	buildRuntimeBootStatus,
+	ensureRuntimeStateDirs,
+	hostPolicySummary,
+	type RuntimeBootStage,
+	readRuntimeBootStatus,
+	writeRuntimeBootStatus,
+} from "../runtime/state";
 
 type ChannelAccount = components["schemas"]["ChannelAccountResponse"];
 type ChannelAccountCreate = components["schemas"]["ChannelAccountCreate"];
@@ -1075,4 +1088,379 @@ function collectWarnings(value: unknown): string[] {
 		applied?: { warnings?: string[] };
 	};
 	return root.plan?.warnings ?? root.status?.warnings ?? root.applied?.warnings ?? [];
+}
+
+interface RuntimeInitOptions {
+	nonInteractive?: boolean;
+	json?: boolean;
+	manifestFile?: string;
+}
+
+interface RuntimeDoctorCheck {
+	name: string;
+	ok: boolean;
+	detail?: string;
+	hint?: string;
+}
+
+function hasRuntimeCredential(input: {
+	manifestPath?: string;
+	paths?: ReturnType<typeof getRuntimePaths>;
+}): boolean {
+	if (input.manifestPath) return true;
+	const paths = input.paths ?? getRuntimePaths();
+	if (existsSync(paths.manifestLastGood)) return true;
+	try {
+		return Boolean(process.env[runtimeSourceAuthEnv(paths)]?.trim());
+	} catch {
+		return Boolean(process.env.CLAWDI_AUTH_TOKEN?.trim());
+	}
+}
+
+function runtimeCredentialName(paths: ReturnType<typeof getRuntimePaths>): string {
+	try {
+		return runtimeSourceAuthEnv(paths);
+	} catch {
+		return "CLAWDI_AUTH_TOKEN";
+	}
+}
+
+function writable(path: string): boolean {
+	try {
+		accessSync(path, constants.W_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function readable(path: string): boolean {
+	try {
+		accessSync(path, constants.R_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function repairStatus(
+	input: {
+		bootId: string;
+		stage: RuntimeBootStage;
+		runtimeMode: "local" | "hosted";
+		errors: string[];
+		exitCode: number;
+	},
+	paths = getRuntimePaths(),
+) {
+	const policy = readHostPolicy(paths.hostPolicy);
+	return buildRuntimeBootStatus(
+		{
+			mode: "repair",
+			status: "error",
+			stage: input.stage,
+			bootId: input.bootId,
+			runtimeMode: input.runtimeMode,
+			activeGeneration: null,
+			enabledRuntimes: [],
+			error: input.errors[0],
+			errors: input.errors,
+			exitCode: input.exitCode,
+			datasource: "RuntimeSource",
+			hostPolicy: hostPolicySummary(policy),
+		},
+		paths,
+	);
+}
+
+export async function runtimeInit(opts: RuntimeInitOptions = {}) {
+	const paths = getRuntimePaths();
+	const mode = detectRuntimeMode();
+	const bootId = randomUUID();
+
+	if (mode !== "hosted") {
+		const status = repairStatus(
+			{
+				bootId,
+				runtimeMode: mode,
+				stage: "detect",
+				exitCode: 2,
+				errors: [
+					"runtime init requires hosted runtime mode (host policy or CLAWDI_RUNTIME_MODE=hosted)",
+				],
+			},
+			paths,
+		);
+		if (opts.json || !process.stdout.isTTY) {
+			console.log(JSON.stringify(status, null, 2));
+		} else {
+			console.log(chalk.red("runtime init is only available in hosted runtime mode."));
+		}
+		process.exitCode = 2;
+		return;
+	}
+
+	const hostPolicy = readHostPolicy(paths.hostPolicy);
+	try {
+		ensureRuntimeStateDirs(paths);
+	} catch (e) {
+		const status = repairStatus(
+			{
+				bootId,
+				runtimeMode: mode,
+				stage: "detect",
+				exitCode: 20,
+				errors: [
+					`could not create runtime state directories: ${
+						e instanceof Error ? e.message : String(e)
+					}`,
+				],
+			},
+			paths,
+		);
+		if (opts.json || !process.stdout.isTTY) console.log(JSON.stringify(status, null, 2));
+		else console.log(chalk.red(status.error));
+		process.exitCode = 20;
+		return;
+	}
+
+	const credentialAvailable = hasRuntimeCredential({ manifestPath: opts.manifestFile, paths });
+	const nonInteractiveOk = opts.nonInteractive === true;
+	const errors: string[] = [];
+	let stage: RuntimeBootStage = "detect";
+	let exitCode = 20;
+	if (!nonInteractiveOk) {
+		errors.push("runtime init requires --non-interactive in hosted mode");
+	}
+	if (!hostPolicy.exists) {
+		errors.push(`missing hosted runtime policy at ${hostPolicy.path}`);
+	} else if (!hostPolicy.valid) {
+		errors.push(
+			`invalid hosted runtime policy at ${hostPolicy.path}: ${hostPolicy.error ?? "parse failed"}`,
+		);
+	}
+	if (!credentialAvailable) {
+		errors.push(`missing ${runtimeCredentialName(paths)} and no last-good runtime manifest cache`);
+	}
+	if (errors.length === 0) {
+		stage = "local";
+		const loaded = await loadRuntimeManifest(paths, { manifestPath: opts.manifestFile });
+		if ("errors" in loaded) {
+			stage = loaded.stage;
+			exitCode = loaded.mode === "manifest-rejected" ? 22 : 21;
+			errors.push(...loaded.errors);
+			const status = buildRuntimeBootStatus(
+				{
+					mode: loaded.mode,
+					status: "error",
+					stage,
+					bootId,
+					runtimeMode: mode,
+					activeGeneration: loaded.activeGeneration ?? null,
+					rejectedGeneration: loaded.rejectedGeneration ?? null,
+					enabledRuntimes: [],
+					error: errors[0],
+					errors,
+					exitCode,
+					datasource: "RuntimeSource",
+					hostPolicy: hostPolicySummary(hostPolicy),
+				},
+				paths,
+			);
+			writeRuntimeBootStatus(status, paths);
+
+			if (opts.json || !process.stdout.isTTY) {
+				console.log(JSON.stringify(status, null, 2));
+			} else {
+				console.log(chalk.bold("clawdi runtime init"));
+				console.log(chalk.yellow(`  ${loaded.mode}: ${errors[0]}`));
+				console.log(chalk.gray(`  status: ${paths.bootStatus}`));
+			}
+			process.exitCode = exitCode;
+			return;
+		}
+
+		const convergence = convergeRuntimeManifest(loaded, paths);
+		const installOk = convergence.installErrors.length === 0;
+		const status = buildRuntimeBootStatus(
+			{
+				mode: convergence.mode,
+				status: installOk ? "ok" : "error",
+				stage: "final",
+				bootId,
+				runtimeMode: mode,
+				activeGeneration: convergence.manifest.generation,
+				instanceId: convergence.manifest.instanceId,
+				enabledRuntimes: convergence.enabledRuntimes,
+				error: convergence.installErrors[0],
+				errors: convergence.installErrors,
+				exitCode: installOk ? 0 : 23,
+				datasource: "RuntimeSource",
+				hostPolicy: hostPolicySummary(hostPolicy),
+				manifestSource: {
+					type: convergence.source,
+					path: convergence.sourcePath,
+					offline: convergence.offline,
+				},
+				convergence: convergence.outputs,
+			},
+			paths,
+		);
+		writeRuntimeBootStatus(status, paths);
+
+		if (opts.json || !process.stdout.isTTY) {
+			console.log(JSON.stringify(status, null, 2));
+		} else {
+			console.log(chalk.bold("clawdi runtime init"));
+			console.log(
+				chalk.green(`  ${convergence.mode}: generation ${convergence.manifest.generation}`),
+			);
+			console.log(chalk.gray(`  status: ${paths.bootStatus}`));
+		}
+		process.exitCode = installOk ? 0 : 23;
+		return;
+	}
+
+	const status = buildRuntimeBootStatus(
+		{
+			mode: "repair",
+			status: "error",
+			stage,
+			bootId,
+			runtimeMode: mode,
+			activeGeneration: null,
+			enabledRuntimes: [],
+			error: errors[0],
+			errors,
+			exitCode,
+			datasource: "RuntimeSource",
+			hostPolicy: hostPolicySummary(hostPolicy),
+		},
+		paths,
+	);
+	writeRuntimeBootStatus(status, paths);
+
+	if (opts.json || !process.stdout.isTTY) {
+		console.log(JSON.stringify(status, null, 2));
+	} else {
+		console.log(chalk.bold("clawdi runtime init"));
+		console.log(chalk.yellow(`  repair: ${errors[0]}`));
+		console.log(chalk.gray(`  status: ${paths.bootStatus}`));
+	}
+	process.exitCode = exitCode;
+}
+
+export async function runtimeStatus(opts: { json?: boolean } = {}) {
+	const paths = getRuntimePaths();
+	const read = readRuntimeBootStatus(paths);
+	const payload = {
+		schemaVersion: "clawdi.runtimeStatus.v1",
+		runtimeMode: paths.mode,
+		paths: {
+			bootStatus: paths.bootStatus,
+			cloudStatus: paths.cloudStatus,
+			cloudResult: paths.cloudResult,
+			installInventory: paths.installInventory,
+			syncState: paths.syncState,
+			instanceData: paths.instanceData,
+		},
+		...read,
+	};
+
+	if (opts.json || !process.stdout.isTTY) {
+		console.log(JSON.stringify(payload, null, 2));
+		return;
+	}
+
+	console.log(chalk.bold("clawdi runtime status"));
+	console.log();
+	if (!read.exists) {
+		console.log(chalk.gray("  No runtime boot status has been written yet."));
+		return;
+	}
+	if (read.error) {
+		console.log(chalk.red(`  Could not read ${read.source}: ${read.error}`));
+		process.exitCode = 1;
+		return;
+	}
+	if (!read.status) {
+		console.log(chalk.yellow("  Runtime status files exist, but boot-status.json is missing."));
+		return;
+	}
+	console.log(`  Mode: ${read.status?.mode ?? "unknown"}`);
+	console.log(`  Status: ${read.status?.status ?? "unknown"}`);
+	console.log(`  Stage: ${read.status?.stage ?? "unknown"}`);
+	console.log(chalk.gray(`  Source: ${read.source}`));
+	if (read.status?.error) console.log(chalk.yellow(`  Error: ${read.status.error}`));
+}
+
+export async function runtimeDoctor(opts: { json?: boolean } = {}) {
+	const paths = getRuntimePaths();
+	const policy = readHostPolicy(paths.hostPolicy);
+	const lastStatus = readRuntimeBootStatus(paths);
+	const checks: RuntimeDoctorCheck[] = [
+		{
+			name: "Runtime mode",
+			ok: paths.mode === "hosted",
+			detail: paths.mode,
+			hint: "Hosted mode requires a host policy or CLAWDI_RUNTIME_MODE=hosted.",
+		},
+		{
+			name: "Host policy",
+			ok: policy.exists && policy.valid,
+			detail: policy.exists ? (policy.valid ? policy.path : policy.error) : "missing",
+			hint: "Expected a readable JSON policy at the configured host policy path.",
+		},
+		{
+			name: "Service state",
+			ok: existsSync(paths.serviceStateRoot) && writable(paths.serviceStateRoot),
+			detail: paths.serviceStateRoot,
+			hint: "The hosted service-state volume must be writable by the runtime user.",
+		},
+		{
+			name: "Runtime HOME",
+			ok: existsSync(paths.userHome) && writable(paths.userHome),
+			detail: paths.userHome,
+			hint: "HOME should be the persistent runtime/user volume.",
+		},
+		{
+			name: "Ephemeral runtime state",
+			ok: existsSync(paths.runRoot) && writable(paths.runRoot),
+			detail: paths.runRoot,
+			hint: "The runtime tmpfs path should be recreated on each boot.",
+		},
+		{
+			name: "Sensitive instance data",
+			ok: !existsSync(paths.sensitiveInstanceData) || readable(paths.sensitiveInstanceData),
+			detail: existsSync(paths.sensitiveInstanceData) ? "present" : "absent",
+		},
+		{
+			name: "Last boot status",
+			ok:
+				!lastStatus.exists ||
+				(lastStatus.status?.status === "ok" && lastStatus.status.errors.length === 0),
+			detail: !lastStatus.exists
+				? "none"
+				: (lastStatus.error ??
+					`${lastStatus.status?.status ?? "unknown"} / ${lastStatus.status?.mode ?? "unknown"}`),
+			hint: "Run `clawdi runtime status` for the last boot result.",
+		},
+	];
+	const failed = checks.filter((check) => !check.ok).length;
+
+	if (opts.json || !process.stdout.isTTY) {
+		console.log(JSON.stringify(checks, null, 2));
+		if (failed > 0) process.exitCode = 1;
+		return;
+	}
+
+	console.log(chalk.bold("clawdi runtime doctor"));
+	console.log();
+	for (const check of checks) {
+		const icon = check.ok ? chalk.green("✓") : chalk.red("✗");
+		const detail = check.detail ? chalk.gray(` — ${check.detail}`) : "";
+		console.log(`  ${icon} ${check.name}${detail}`);
+		if (!check.ok && check.hint) console.log(chalk.gray(`     ${check.hint}`));
+	}
+	if (failed > 0) process.exitCode = 1;
 }

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1488,7 +1488,8 @@ function resolveRpcListenConfig(opts: RpcListenOpts): ResolvedRpcListenConfig {
 		process.env.CLAWDI_DAEMON_RPC_HOST ??
 		DEFAULT_CONTROL_RPC_HOST;
 	const portValue = opts.port ?? process.env.CLAWDI_DAEMON_RPC_PORT;
-	const port = optionalPortParam(portValue, "--port") ?? DEFAULT_CONTROL_RPC_PORT;
+	const port =
+		optionalPortParam(portValue, "--port", { allowZero: true }) ?? DEFAULT_CONTROL_RPC_PORT;
 	const allowRemote =
 		optionalBooleanParam(opts.allowRemote, "--allow-remote") ??
 		optionalBooleanParam(
@@ -1588,18 +1589,24 @@ function requireBooleanConfirmation(
 	}
 }
 
-function optionalPortParam(value: unknown, label: string): number | undefined {
+function optionalPortParam(
+	value: unknown,
+	label: string,
+	opts: { allowZero?: boolean } = {},
+): number | undefined {
 	if (value === undefined || value === null) return undefined;
 	let port: number;
+	const min = opts.allowZero === true ? 0 : 1;
+	const message = `${label} must be an integer from ${min} to 65535`;
 	if (typeof value === "number") {
 		port = value;
 	} else if (typeof value === "string" && /^\d+$/.test(value.trim())) {
 		port = Number(value);
 	} else {
-		throw new Error(`${label} must be an integer from 1 to 65535`);
+		throw new Error(message);
 	}
-	if (!Number.isInteger(port) || port < 1 || port > 65535) {
-		throw new Error(`${label} must be an integer from 1 to 65535`);
+	if (!Number.isInteger(port) || port < min || port > 65535) {
+		throw new Error(message);
 	}
 	return port;
 }

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -15,6 +15,7 @@ import chalk from "chalk";
 import { getClawdiDir, getStoredConfig } from "../lib/config";
 import { listRegisteredAgentTypes } from "../lib/select-adapter";
 import { getCliVersion } from "../lib/version";
+import { detectRuntimeMode } from "../runtime/paths";
 import { isSingletonDaemonInstalled, listInstalledAgents, readHealth } from "../serve/installer";
 import { log } from "../serve/log";
 import { getServeStateDir } from "../serve/paths";
@@ -594,6 +595,7 @@ export function startDaemonAutoUpdate(opts: {
  * false`, non-TTY (CI), or running via npx/bunx.
  */
 export async function maybeAutoUpdate(runtime: AutoUpdateRuntime = {}): Promise<void> {
+	if (detectRuntimeMode() === "hosted") return;
 	if (
 		isLongLivedDaemonInvocation() ||
 		isAutoUpdateControlInvocation() ||

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,8 +3,20 @@ import { Command } from "commander";
 import { registerServeCommand } from "./commands/serve-cli.js";
 import { handleError } from "./lib/errors.js";
 import { getCliVersion } from "./lib/version.js";
+import { evaluateHostPolicyForCommand } from "./runtime/host-policy.js";
 
 const program = new Command();
+
+function commandPath(command: Command): string {
+	const names: string[] = [];
+	let current: Command | null = command;
+	while (current) {
+		const name = current.name();
+		if (name && name !== "clawdi") names.push(name);
+		current = current.parent ?? null;
+	}
+	return names.reverse().join(" ");
+}
 
 function collectCsvValues(value: string, prev: string[] = []): string[] {
 	const values = value
@@ -27,6 +39,7 @@ program
 		`
 Examples:
   $ clawdi auth login               Authenticate with Clawdi Cloud
+  $ clawdi auth status --json       Inspect credential source without printing secrets
   $ clawdi setup                    Detect agents and register the current machine
   $ clawdi session list             Preview local sessions before pushing
   $ clawdi push --all               Upload everything (every agent, project, module)
@@ -36,12 +49,15 @@ Examples:
   $ clawdi vault set OPENAI_API_KEY Store a secret
   $ clawdi project folder link --project engineering  Use this folder with a Project
   $ clawdi run --env-file .env.clawdi -- npm run dev  Resolve clawdi:// refs at runtime
+  $ clawdi runtime status --json    Inspect hosted runtime boot state
 
 Environment:
   CLAWDI_API_URL           Override the Clawdi Cloud API endpoint
   CLAWDI_DEBUG             Print stack traces on error
   CLAWDI_NO_UPDATE_CHECK   Suppress the non-blocking update check
   CLAWDI_NO_AUTO_UPDATE    Skip CLI/daemon background auto-update (also disables via \`config set autoUpdate false\`)
+  CLAWDI_RUNTIME_MODE      Explicit runtime mode override for hosted tests/operators
+  CLAWDI_AUTH_TOKEN        Clawdi Cloud auth token; the only hosted container credential
   CLAUDE_CONFIG_DIR        Custom Claude Code home (else ~/.claude)
   CODEX_HOME               Custom Codex home (else ~/.codex)
   HERMES_HOME              Custom Hermes home (else ~/.hermes)
@@ -51,6 +67,14 @@ Environment:
 
 Docs: https://github.com/Clawdi-AI/clawdi`,
 	);
+
+program.hook("preAction", (_thisCommand, actionCommand) => {
+	const command = commandPath(actionCommand);
+	const decision = evaluateHostPolicyForCommand(command);
+	if (decision.allowed) return;
+	const reason = decision.reason ?? "disabled by hosted runtime policy";
+	throw new Error(`Command \`clawdi ${command}\` is disabled in hosted runtime mode: ${reason}`);
+});
 
 // ─────────────────────────────────────────────────────────────
 // auth
@@ -83,6 +107,15 @@ authCmd
 		await authLogout();
 	});
 
+authCmd
+	.command("status")
+	.description("Show credential source without printing secrets")
+	.option("--json", "Output as JSON")
+	.action(async (opts: { json?: boolean }) => {
+		const { authStatus } = await import("./commands/auth.js");
+		await authStatus(opts);
+	});
+
 // ─────────────────────────────────────────────────────────────
 // status
 // ─────────────────────────────────────────────────────────────
@@ -109,6 +142,15 @@ configCmd
 	.action(async () => {
 		const { configList } = await import("./commands/config.js");
 		configList();
+	});
+
+configCmd
+	.command("paths")
+	.description("Show local and hosted runtime paths used by the CLI")
+	.option("--json", "Output as JSON")
+	.action(async (opts: { json?: boolean }) => {
+		const { configPaths } = await import("./commands/config.js");
+		configPaths(opts);
 	});
 
 configCmd
@@ -644,7 +686,18 @@ channelCmd
 // ─────────────────────────────────────────────────────────────
 const runtimeCmd = program
 	.command("runtime")
-	.description("Apply channel runtime manifest projections for agents");
+	.description("Hosted runtime boot and channel runtime projections");
+
+runtimeCmd
+	.command("init")
+	.description("Converge a hosted runtime from controller desired state")
+	.option("--non-interactive", "Required for hosted boot; never prompt")
+	.option("--json", "Output as JSON")
+	.option("--manifest-file <path>", "Use a local runtime manifest fixture for simulation")
+	.action(async (opts: { nonInteractive?: boolean; json?: boolean; manifestFile?: string }) => {
+		const { runtimeInit } = await import("./commands/runtime.js");
+		await runtimeInit(opts);
+	});
 
 runtimeCmd
 	.command("plan")
@@ -684,12 +737,25 @@ runtimeCmd
 
 runtimeCmd
 	.command("status")
-	.description("Show current backend status for a runtime manifest")
-	.option("-f, --file <path>", "Runtime manifest path", "clawdi.runtime.yaml")
+	.description("Show hosted runtime boot status, or channel manifest status with --file")
+	.option("-f, --file <path>", "Channel runtime manifest path")
 	.option("--json", "Emit machine-readable JSON")
 	.action(async (opts: { file?: string; json?: boolean }) => {
-		const { runtimeStatusCommand } = await import("./commands/runtime.js");
-		await runtimeStatusCommand(opts);
+		const { runtimeStatus, runtimeStatusCommand } = await import("./commands/runtime.js");
+		if (opts.file) {
+			await runtimeStatusCommand(opts);
+			return;
+		}
+		await runtimeStatus(opts);
+	});
+
+runtimeCmd
+	.command("doctor")
+	.description("Diagnose hosted runtime policy, paths, and last boot state")
+	.option("--json", "Output as JSON")
+	.action(async (opts: { json?: boolean }) => {
+		const { runtimeDoctor } = await import("./commands/runtime.js");
+		await runtimeDoctor(opts);
 	});
 
 // ─────────────────────────────────────────────────────────────
@@ -1095,6 +1161,15 @@ program
 		}
 		const { doctor } = await import("./commands/doctor.js");
 		await doctor(opts);
+	});
+
+program
+	.command("capabilities")
+	.description("Show CLI feature surface and hosted policy restrictions")
+	.option("--json", "Output as JSON")
+	.action(async (opts: { json?: boolean }) => {
+		const { capabilitiesCommand } = await import("./commands/capabilities.js");
+		await capabilitiesCommand(opts);
 	});
 
 program

--- a/packages/cli/src/lib/version.ts
+++ b/packages/cli/src/lib/version.ts
@@ -2,8 +2,18 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-/** Read CLI version from package.json at runtime. Falls back to "0.0.0" if the file can't be read. */
+declare const CLAWDI_CLI_VERSION: string | undefined;
+
+/**
+ * Resolve the CLI version.
+ *
+ * Packaged Node/Bun installs can read package.json from disk. Single-file
+ * binaries cannot, so release builds inject CLAWDI_CLI_VERSION at build time.
+ */
 export function getCliVersion(): string {
+	const compiledVersion = typeof CLAWDI_CLI_VERSION === "string" ? CLAWDI_CLI_VERSION.trim() : "";
+	if (compiledVersion) return compiledVersion;
+
 	try {
 		// import.meta.url → .../src/lib/version.ts at dev time, .../dist/index.js at build time
 		const here = dirname(fileURLToPath(import.meta.url));

--- a/packages/cli/src/runtime/host-policy.ts
+++ b/packages/cli/src/runtime/host-policy.ts
@@ -1,0 +1,191 @@
+import { existsSync, readFileSync } from "node:fs";
+import { detectRuntimeMode, getRuntimePaths, type RuntimeMode } from "./paths";
+
+export interface DeniedCommand {
+	command: string;
+	reason?: string;
+}
+
+export interface HostPolicy {
+	schemaVersion?: string;
+	mode?: string;
+	cliUpdateMode?: string;
+	immutableShim?: boolean;
+	deniedCommands?: Array<string | DeniedCommand>;
+	managedState?: string[];
+	writableState?: string[];
+	systemWritableState?: string[];
+	userWritableState?: string[];
+	ordinaryUserDeniedState?: string[];
+}
+
+export interface HostPolicyReadResult {
+	path: string;
+	exists: boolean;
+	valid: boolean;
+	policy?: HostPolicy;
+	error?: string;
+}
+
+export interface HostPolicyCommandDecision {
+	allowed: boolean;
+	command: string;
+	runtimeMode: RuntimeMode;
+	policyPath?: string;
+	reason?: string;
+}
+
+const POLICY_RECOVERY_COMMANDS = [
+	"runtime",
+	"capabilities",
+	"auth status",
+	"config paths",
+	"status",
+	"doctor",
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function parseDeniedCommands(value: unknown): Array<string | DeniedCommand> | undefined {
+	if (value === undefined) return undefined;
+	if (!Array.isArray(value)) throw new Error("deniedCommands must be an array");
+	return value.map((item) => {
+		if (typeof item === "string") return item;
+		if (!isRecord(item) || typeof item.command !== "string") {
+			throw new Error("deniedCommands entries must be strings or { command, reason } objects");
+		}
+		const reason = typeof item.reason === "string" ? item.reason : undefined;
+		return reason ? { command: item.command, reason } : { command: item.command };
+	});
+}
+
+export function readHostPolicy(path = getRuntimePaths().hostPolicy): HostPolicyReadResult {
+	if (!existsSync(path)) return { path, exists: false, valid: false };
+
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+		if (!isRecord(parsed)) throw new Error("policy root must be an object");
+
+		const policy: HostPolicy = {};
+		if (typeof parsed.schemaVersion === "string") policy.schemaVersion = parsed.schemaVersion;
+		if (typeof parsed.mode === "string") policy.mode = parsed.mode;
+		if (typeof parsed.cliUpdateMode === "string") policy.cliUpdateMode = parsed.cliUpdateMode;
+		if (typeof parsed.immutableShim === "boolean") policy.immutableShim = parsed.immutableShim;
+		policy.deniedCommands = parseDeniedCommands(parsed.deniedCommands);
+		if (parsed.managedState !== undefined) {
+			if (!isStringArray(parsed.managedState))
+				throw new Error("managedState must be a string array");
+			policy.managedState = parsed.managedState;
+		}
+		if (parsed.writableState !== undefined) {
+			if (!isStringArray(parsed.writableState))
+				throw new Error("writableState must be a string array");
+			policy.writableState = parsed.writableState;
+		}
+		if (parsed.systemWritableState !== undefined) {
+			if (!isStringArray(parsed.systemWritableState))
+				throw new Error("systemWritableState must be a string array");
+			policy.systemWritableState = parsed.systemWritableState;
+		}
+		if (parsed.userWritableState !== undefined) {
+			if (!isStringArray(parsed.userWritableState))
+				throw new Error("userWritableState must be a string array");
+			policy.userWritableState = parsed.userWritableState;
+		}
+		if (parsed.ordinaryUserDeniedState !== undefined) {
+			if (!isStringArray(parsed.ordinaryUserDeniedState))
+				throw new Error("ordinaryUserDeniedState must be a string array");
+			policy.ordinaryUserDeniedState = parsed.ordinaryUserDeniedState;
+		}
+
+		return { path, exists: true, valid: true, policy };
+	} catch (e) {
+		return {
+			path,
+			exists: true,
+			valid: false,
+			error: e instanceof Error ? e.message : String(e),
+		};
+	}
+}
+
+export function normalizeDeniedCommands(policy?: HostPolicy): DeniedCommand[] {
+	return (policy?.deniedCommands ?? []).map((entry) => {
+		if (typeof entry === "string") return { command: entry };
+		return entry;
+	});
+}
+
+export function deniedCommandReason(
+	policy: HostPolicy | undefined,
+	command: string,
+): string | null {
+	const normalized = command.trim().replace(/\s+/g, " ");
+	for (const entry of normalizeDeniedCommands(policy)) {
+		const denied = entry.command.trim().replace(/\s+/g, " ");
+		if (normalized === denied || normalized.startsWith(`${denied} `)) {
+			return entry.reason ?? "disabled by hosted runtime policy";
+		}
+	}
+	return null;
+}
+
+function commandMatches(command: string, prefix: string): boolean {
+	return command === prefix || command.startsWith(`${prefix} `);
+}
+
+function isPolicyRecoveryCommand(command: string): boolean {
+	return POLICY_RECOVERY_COMMANDS.some((allowed) => commandMatches(command, allowed));
+}
+
+export function evaluateHostPolicyForCommand(command: string): HostPolicyCommandDecision {
+	const normalized = command.trim().replace(/\s+/g, " ");
+	const runtimeMode = detectRuntimeMode();
+	if (runtimeMode !== "hosted") return { allowed: true, command: normalized, runtimeMode };
+
+	const policy = readHostPolicy();
+	if (!policy.exists) {
+		if (isPolicyRecoveryCommand(normalized)) {
+			return { allowed: true, command: normalized, runtimeMode, policyPath: policy.path };
+		}
+		return {
+			allowed: false,
+			command: normalized,
+			runtimeMode,
+			policyPath: policy.path,
+			reason: `missing hosted runtime policy at ${policy.path}`,
+		};
+	}
+
+	if (!policy.valid) {
+		if (isPolicyRecoveryCommand(normalized)) {
+			return { allowed: true, command: normalized, runtimeMode, policyPath: policy.path };
+		}
+		return {
+			allowed: false,
+			command: normalized,
+			runtimeMode,
+			policyPath: policy.path,
+			reason: `invalid hosted runtime policy at ${policy.path}: ${policy.error ?? "parse failed"}`,
+		};
+	}
+
+	const reason = deniedCommandReason(policy.policy, normalized);
+	if (reason) {
+		return {
+			allowed: false,
+			command: normalized,
+			runtimeMode,
+			policyPath: policy.path,
+			reason,
+		};
+	}
+
+	return { allowed: true, command: normalized, runtimeMode, policyPath: policy.path };
+}

--- a/packages/cli/src/runtime/hosted-mitm-profiles.ts
+++ b/packages/cli/src/runtime/hosted-mitm-profiles.ts
@@ -1,0 +1,351 @@
+import { type MitmProfileInputBundle, mitmProfileInputBundleSchema } from "./mitm-profiles";
+
+type HostedMitmProfile = MitmProfileInputBundle["profiles"][number];
+type HostedChannelName = "discord" | "telegram" | "imessage" | "whatsapp";
+
+interface HostedRuntimeChannel {
+	enabled: boolean;
+	owner?: string | null;
+	provider?: string | null;
+	baseUrl?: string | null;
+	apiBaseUrl?: string | null;
+	restBaseUrl?: string | null;
+	gatewayBaseUrl?: string | null;
+	websocketBaseUrl?: string | null;
+	upstreamBaseUrl?: string | null;
+	secretRef?: string | null;
+	tokenSecretRef?: string | null;
+	botTokenSecretRef?: string | null;
+	passwordSecretRef?: string | null;
+	apiKeySecretRef?: string | null;
+}
+
+interface HostedRuntimeManifestProjection {
+	mitmProfiles?: unknown;
+	providers?: {
+		default?: {
+			baseUrl?: string | null;
+			apiKeySecretRef?: string | null;
+		} | null;
+	} | null;
+	channels?: Partial<Record<HostedChannelName, HostedRuntimeChannel>> | null;
+}
+
+type ChannelProfileBuilder = {
+	channel: HostedChannelName;
+	build: (
+		baseUrl: string | null,
+		channel: HostedRuntimeChannel | undefined,
+		owner: string,
+	) => HostedMitmProfile[];
+};
+
+const CHANNEL_PROFILE_BUILDERS: readonly ChannelProfileBuilder[] = [
+	{
+		channel: "discord",
+		build: (baseUrl, channel, owner) => {
+			if (!baseUrl) return [];
+			const botTokenRef = channelTokenSecretRef(channel);
+			return [
+				channelProfile({
+					id: "discord-rest-channel",
+					kind: "http",
+					scheme: "https",
+					host: "discord.com",
+					pathPrefix: "/api/",
+					headers: botTokenRef
+						? {
+								authorization: {
+									type: "secretRefEquals",
+									secretRef: botTokenRef,
+									prefix: "Bot ",
+								},
+							}
+						: undefined,
+					upstreamBaseUrl: baseUrl,
+					redactHeaders: ["authorization"],
+					priority: 100,
+					owner,
+				}),
+				channelProfile({
+					id: "discord-gateway-channel",
+					kind: "websocket",
+					scheme: "wss",
+					host: "gateway.discord.gg",
+					pathPrefix: "/",
+					upstreamBaseUrl: channelWebSocketBaseUrl(channel) ?? baseUrl,
+					priority: 130,
+					owner,
+				}),
+			];
+		},
+	},
+	{
+		channel: "telegram",
+		build: (baseUrl, channel, owner) => {
+			if (!baseUrl) return [];
+			const botTokenRef = channelTokenSecretRef(channel);
+			return [
+				channelProfile({
+					id: "telegram-bot-api-channel",
+					kind: "http",
+					scheme: "https",
+					host: "api.telegram.org",
+					pathPrefix: "/bot",
+					path: botTokenRef
+						? {
+								type: "secretRefPrefix",
+								secretRef: botTokenRef,
+								prefix: "/bot",
+								suffix: "/",
+							}
+						: undefined,
+					upstreamBaseUrl: baseUrl,
+					redactUrlPatterns: ["/bot[^/]+/"],
+					priority: 110,
+					owner,
+				}),
+			];
+		},
+	},
+	{
+		channel: "imessage",
+		build: (baseUrl, channel, owner) => {
+			if (!baseUrl) return [];
+			const passwordRef = normalizeSecretRef(
+				channel?.passwordSecretRef ?? channel?.tokenSecretRef ?? channel?.secretRef,
+			);
+			return [
+				channelProfile({
+					id: "bluebubbles-imessage-channel",
+					kind: "http",
+					scheme: "https",
+					host: "bluebubbles.invalid",
+					pathPrefix: "/api/",
+					query: passwordRef
+						? {
+								password: {
+									type: "secretRefEquals",
+									secretRef: passwordRef,
+								},
+							}
+						: undefined,
+					upstreamBaseUrl: baseUrl,
+					redactUrlPatterns: ["password=[^&]+"],
+					priority: 120,
+					owner,
+				}),
+			];
+		},
+	},
+	{
+		channel: "whatsapp",
+		build: (baseUrl, channel, owner) =>
+			baseUrl
+				? [
+						channelProfile({
+							id: "whatsapp-web-channel",
+							kind: "websocket",
+							scheme: "wss",
+							host: "web.whatsapp.com",
+							pathPrefix: "/ws/",
+							upstreamBaseUrl: channelWebSocketBaseUrl(channel) ?? baseUrl,
+							preservePath: false,
+							priority: 140,
+							owner,
+						}),
+					]
+				: [],
+	},
+];
+
+export function hostedManifestMitmProfiles(
+	hosted: HostedRuntimeManifestProjection,
+): MitmProfileInputBundle {
+	if (hosted.mitmProfiles !== undefined) {
+		return mitmProfileInputBundleSchema.parse(hosted.mitmProfiles);
+	}
+
+	const profiles: HostedMitmProfile[] = [];
+	const channels = hosted.channels ?? {};
+	for (const entry of CHANNEL_PROFILE_BUILDERS) {
+		const channel = channels[entry.channel];
+		if (channel?.enabled !== true) continue;
+		profiles.push(
+			...entry.build(channelProfileBaseUrl(entry.channel, channel), channel, channelOwner(channel)),
+		);
+	}
+
+	const provider = hosted.providers?.default;
+	const providerBaseUrl = cleanBaseUrl(provider?.baseUrl);
+	const providerApiKeySecretRef = normalizeSecretRef(provider?.apiKeySecretRef);
+	if (providerBaseUrl && providerApiKeySecretRef) {
+		profiles.push(...providerMitmProfiles(providerBaseUrl, providerApiKeySecretRef));
+	}
+
+	return { profiles };
+}
+
+function channelProfile(input: {
+	id: string;
+	kind: "http" | "websocket";
+	scheme: "https" | "wss";
+	host: string;
+	pathPrefix: string;
+	path?: HostedMitmProfile["match"]["path"];
+	headers?: HostedMitmProfile["match"]["headers"];
+	query?: HostedMitmProfile["match"]["query"];
+	upstreamBaseUrl: string;
+	preservePath?: boolean;
+	redactHeaders?: string[];
+	redactUrlPatterns?: string[];
+	priority: number;
+	owner: string;
+}): HostedMitmProfile {
+	return {
+		id: input.id,
+		enabled: true,
+		kind: input.kind,
+		match: {
+			scheme: input.scheme,
+			host: input.host,
+			pathPrefix: input.pathPrefix,
+			...(input.path ? { path: input.path } : {}),
+			headers: input.headers ?? {},
+			query: input.query ?? {},
+		},
+		rewrite: {
+			upstreamBaseUrl: input.upstreamBaseUrl,
+			preservePath: input.preservePath ?? true,
+			setHeaders: {},
+		},
+		logging: {
+			redactHeaders: input.redactHeaders ?? [],
+			redactUrlPatterns: input.redactUrlPatterns ?? [],
+		},
+		priority: input.priority,
+		owner: input.owner,
+	};
+}
+
+function channelBaseUrl(channel: HostedRuntimeChannel | undefined): string | null {
+	return cleanBaseUrl(channel?.apiBaseUrl ?? channel?.baseUrl ?? channel?.upstreamBaseUrl);
+}
+
+function channelProfileBaseUrl(
+	channelName: HostedChannelName,
+	channel: HostedRuntimeChannel | undefined,
+): string | null {
+	if (channelName === "whatsapp")
+		return channelWebSocketBaseUrl(channel) ?? channelBaseUrl(channel);
+	return channelBaseUrl(channel);
+}
+
+function channelWebSocketBaseUrl(channel: HostedRuntimeChannel | undefined): string | null {
+	return cleanBaseUrl(
+		channel?.gatewayBaseUrl ??
+			channel?.websocketBaseUrl ??
+			channel?.upstreamBaseUrl ??
+			channel?.baseUrl,
+	);
+}
+
+function channelOwner(channel: HostedRuntimeChannel | undefined): string {
+	return channel?.owner?.trim() || channel?.provider?.trim() || "channel";
+}
+
+function providerMitmProfiles(
+	providerBaseUrl: string,
+	apiKeySecretRef: string,
+): HostedMitmProfile[] {
+	const apiKeyHeader: HostedMitmProfile["match"]["headers"] = {
+		authorization: {
+			type: "secretRefEquals" as const,
+			secretRef: apiKeySecretRef,
+			prefix: "Bearer ",
+		},
+	};
+	return [
+		{
+			id: "codex-openai-responses",
+			enabled: true,
+			kind: "provider",
+			match: {
+				scheme: "https",
+				host: "api.openai.com",
+				pathPrefix: "/v1/",
+				headers: apiKeyHeader,
+				query: {},
+			},
+			rewrite: {
+				upstreamBaseUrl: providerBaseUrl,
+				preservePath: true,
+				setHeaders: {},
+			},
+			logging: { redactHeaders: ["authorization"], redactUrlPatterns: [] },
+			priority: 150,
+			owner: "provider-projection",
+		},
+		{
+			id: "codex-chatgpt-backend-responses",
+			enabled: true,
+			kind: "provider",
+			match: {
+				scheme: "https",
+				host: "chatgpt.com",
+				path: { type: "equals", value: "/backend-api/codex/responses" },
+				headers: {
+					authorization: { type: "exists" },
+				},
+				query: {},
+			},
+			rewrite: {
+				upstreamBaseUrl: appendCleanPath(providerBaseUrl, "/responses"),
+				preservePath: false,
+				setHeaders: {
+					authorization: {
+						type: "secretRef",
+						secretRef: apiKeySecretRef,
+						prefix: "Bearer ",
+					},
+				},
+			},
+			logging: { redactHeaders: ["authorization"], redactUrlPatterns: [] },
+			priority: 151,
+			owner: "provider-projection",
+		},
+	];
+}
+
+function channelTokenSecretRef(channel: HostedRuntimeChannel | undefined): string | null {
+	return normalizeSecretRef(
+		channel?.botTokenSecretRef ?? channel?.tokenSecretRef ?? channel?.secretRef,
+	);
+}
+
+export function normalizeSecretRef(value: string | null | undefined): string | null {
+	const trimmed = value?.trim();
+	if (!trimmed) return null;
+	return trimmed.startsWith("secret://") ? trimmed : `secret://${trimmed}`;
+}
+
+function cleanBaseUrl(value: string | null | undefined): string | null {
+	if (!value) return null;
+	try {
+		const parsed = new URL(value);
+		if (!["http:", "https:", "ws:", "wss:"].includes(parsed.protocol)) return null;
+		return parsed.toString().replace(/\/+$/, "");
+	} catch {
+		return null;
+	}
+}
+
+function appendCleanPath(baseUrl: string, path: string): string {
+	const parsed = new URL(baseUrl);
+	const basePath = parsed.pathname.replace(/\/+$/, "");
+	const childPath = path.replace(/^\/+/, "");
+	parsed.pathname = `${basePath}/${childPath}`;
+	parsed.search = "";
+	parsed.hash = "";
+	return parsed.toString().replace(/\/+$/, "");
+}

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -1,0 +1,215 @@
+import { z } from "zod";
+import { mitmProfileInputBundleSchema } from "./mitm-profiles";
+import { runtimeRunSettingsSchema } from "./run-config";
+
+export const RUNTIME_DESIRED_STATE_SCHEMA_VERSION = "clawdi.runtimeDesiredState.v1";
+
+export const OFFICIAL_INSTALL_URLS: Record<string, string> = {
+	openclaw: "https://openclaw.ai/install-cli.sh",
+	hermes: "https://hermes-agent.nousresearch.com/install.sh",
+};
+
+export const OFFICIAL_INSTALL_ARGS: Record<string, string[]> = {
+	openclaw: ["--json", "--no-onboard"],
+	hermes: ["--skip-setup", "--skip-browser", "--non-interactive"],
+};
+
+const installSchema = z
+	.object({
+		authority: z.literal("official"),
+		method: z.literal("official-installer"),
+		url: z.string().url(),
+		home: z.string().min(1),
+		args: z.array(z.string()).default([]),
+	})
+	.strict();
+
+const runtimeSchema = z
+	.object({
+		enabled: z.boolean(),
+		updateChannel: z.string().min(1).optional(),
+		install: installSchema.optional(),
+		run: runtimeRunSettingsSchema.optional(),
+	})
+	.strict();
+
+const cliPayloadPolicySchema = z
+	.object({
+		version: z.string().min(1).optional(),
+		channel: z.string().min(1).optional(),
+		source: z.string().min(1).optional(),
+		packageSpec: z.string().min(1).optional(),
+	})
+	.passthrough();
+
+export const DEFAULT_CLAWDI_CLI_POLICY = {
+	source: "npm:clawdi",
+	packageSpec: "clawdi@latest",
+} satisfies z.infer<typeof cliPayloadPolicySchema>;
+
+const liveSyncAgentSchema = z
+	.object({
+		agentType: z.enum(["openclaw", "hermes", "codex"]),
+		environmentId: z.string().min(1),
+	})
+	.strict();
+
+const liveSyncSchema = z
+	.object({
+		enabled: z.boolean().optional(),
+		agents: z.array(liveSyncAgentSchema).default([]),
+	})
+	.strict();
+
+const runtimeProjectionSchema = z
+	.object({
+		sourceSchemaVersion: z.string().min(1).optional(),
+		system: z.unknown().nullable().optional(),
+		providers: z.record(z.string().min(1), z.unknown()).optional(),
+		channels: z.record(z.string().min(1), z.unknown()).optional(),
+		aiProviders: z.record(z.string().min(1), z.unknown()).optional(),
+		mcp: z.unknown().optional(),
+	})
+	.strict();
+
+const runtimeDesiredStateShape = {
+	deploymentId: z.string().min(1),
+	environmentId: z.string().min(1),
+	instanceId: z.string().min(1),
+	generation: z.number().int().nonnegative(),
+	issuedAt: z.string().min(1),
+	expiresAt: z.string().min(1).optional(),
+	workspaceRoot: z.string().min(1).optional(),
+	controlPlane: z
+		.object({
+			apiUrl: z.string().url(),
+		})
+		.strict(),
+	clawdiCli: cliPayloadPolicySchema.optional(),
+	runtimes: z.record(z.string().min(1), runtimeSchema),
+	projection: runtimeProjectionSchema.optional(),
+	mitmProfiles: mitmProfileInputBundleSchema.optional(),
+	liveSync: liveSyncSchema.optional(),
+	recovery: z
+		.object({
+			cacheManifest: z.boolean().optional(),
+			allowOfflineBoot: z.boolean().optional(),
+		})
+		.strict()
+		.default({}),
+};
+
+export const manifestSchema = z
+	.object({
+		schemaVersion: z.literal(RUNTIME_DESIRED_STATE_SCHEMA_VERSION),
+		...runtimeDesiredStateShape,
+	})
+	.strict();
+
+const hostedRuntimeInstallSchema = z
+	.object({
+		source: z.literal("official"),
+		channel: z.string().min(1).optional(),
+		args: z.array(z.string()).optional(),
+	})
+	.passthrough();
+
+const hostedRuntimeEntrySchema = z
+	.object({
+		enabled: z.boolean(),
+		install: hostedRuntimeInstallSchema.optional(),
+		run: runtimeRunSettingsSchema.optional(),
+		paths: z
+			.object({
+				home: z.string().min(1).optional(),
+				workspace: z.string().min(1).optional(),
+			})
+			.passthrough()
+			.optional(),
+	})
+	.passthrough();
+
+const hostedRuntimeChannelSchema = z
+	.object({
+		enabled: z.boolean(),
+		owner: z.string().min(1).optional(),
+		provider: z.string().min(1).optional(),
+		routeKind: z.string().min(1).optional(),
+		baseUrl: z.string().url().optional(),
+		apiBaseUrl: z.string().url().optional(),
+		restBaseUrl: z.string().url().optional(),
+		gatewayBaseUrl: z.string().url().optional(),
+		websocketBaseUrl: z.string().url().optional(),
+		upstreamBaseUrl: z.string().url().optional(),
+		secretRef: z.string().min(1).optional(),
+		tokenSecretRef: z.string().min(1).optional(),
+		botTokenSecretRef: z.string().min(1).optional(),
+		passwordSecretRef: z.string().min(1).optional(),
+		apiKeySecretRef: z.string().min(1).optional(),
+	})
+	.passthrough();
+
+export const hostedRuntimeManifestSchema = z
+	.object({
+		schemaVersion: z.literal("clawdi.hosted-runtime.manifest.v1"),
+		deploymentId: z.string().min(1),
+		appId: z.string().min(1).optional(),
+		instanceId: z.string().min(1),
+		generation: z.number().int().nonnegative(),
+		issuedAt: z.string().min(1),
+		expiresAt: z.string().min(1).optional(),
+		system: z
+			.object({
+				user: z.string().min(1).optional(),
+				home: z.string().min(1).optional(),
+				workspace: z.string().min(1).optional(),
+				persistentPaths: z.array(z.string().min(1)).optional(),
+			})
+			.passthrough()
+			.optional(),
+		controlPlane: z
+			.object({
+				manifestUrl: z.string().url().optional(),
+				apiUrl: z.string().url().optional(),
+				cloudApiUrl: z.string().url().optional(),
+			})
+			.passthrough(),
+		clawdiCli: cliPayloadPolicySchema.optional(),
+		runtimes: z.record(z.string().min(1), hostedRuntimeEntrySchema),
+		providers: z
+			.record(
+				z.string().min(1),
+				z
+					.object({
+						kind: z.string().min(1).optional(),
+						baseUrl: z.string().url().optional(),
+						model: z.string().min(1).optional(),
+						apiKeySecretRef: z.string().min(1).nullable().optional(),
+					})
+					.passthrough(),
+			)
+			.optional(),
+		channels: z.record(z.string().min(1), hostedRuntimeChannelSchema).optional(),
+		liveSync: liveSyncSchema.optional(),
+		mitmProfiles: z.unknown().optional(),
+		recovery: z
+			.object({
+				cacheManifest: z.boolean().optional(),
+				allowOfflineBoot: z.boolean().optional(),
+			})
+			.passthrough()
+			.optional(),
+	})
+	.strict();
+
+export const hostedRuntimeManifestResponseSchema = z
+	.object({
+		manifest: hostedRuntimeManifestSchema,
+		secretValues: z.record(z.string().min(1), z.string()).default({}),
+	})
+	.strict();
+
+export type RuntimeManifest = z.output<typeof manifestSchema>;
+export type RuntimeInstall = z.infer<typeof installSchema>;
+export type HostedRuntimeManifest = z.infer<typeof hostedRuntimeManifestSchema>;
+export type LiveSyncAgent = z.infer<typeof liveSyncAgentSchema>;

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -1,0 +1,534 @@
+import { existsSync, readFileSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+import { z } from "zod";
+import { hostedManifestMitmProfiles, normalizeSecretRef } from "./hosted-mitm-profiles";
+import {
+	DEFAULT_CLAWDI_CLI_POLICY,
+	type HostedRuntimeManifest,
+	hostedRuntimeManifestResponseSchema,
+	manifestSchema,
+	OFFICIAL_INSTALL_ARGS,
+	OFFICIAL_INSTALL_URLS,
+	RUNTIME_DESIRED_STATE_SCHEMA_VERSION,
+	type RuntimeManifest,
+} from "./manifest-contract";
+import type { RuntimePaths } from "./paths";
+import type { RuntimeRunSettings } from "./run-config";
+
+export interface RuntimeManifestLoad {
+	manifest: RuntimeManifest;
+	source: "fixture-file" | "remote-datasource" | "last-good-cache";
+	sourcePath: string;
+	offline: boolean;
+	secretValues?: Record<string, string>;
+}
+
+export interface RuntimeManifestFailure {
+	mode: "repair" | "manifest-rejected";
+	stage: "detect" | "local" | "network";
+	errors: string[];
+	rejectedGeneration?: number | null;
+	activeGeneration?: number | null;
+}
+
+interface ExistingManifestState {
+	instanceId?: string;
+	generation?: number;
+}
+
+const runtimeSourceAuthSchema = z
+	.object({
+		type: z.literal("bearer-env"),
+		env: z.string().min(1).default("CLAWDI_AUTH_TOKEN"),
+	})
+	.strict();
+
+const runtimeSourceSchema = z
+	.object({
+		schemaVersion: z.literal("clawdi.runtimeSource.v1"),
+		type: z.literal("http"),
+		url: z.string().url(),
+		auth: runtimeSourceAuthSchema.default({ type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" }),
+		timeoutMs: z.number().int().positive().optional(),
+	})
+	.strict();
+
+type RuntimeSource = z.infer<typeof runtimeSourceSchema>;
+
+function readJsonFile(path: string): unknown {
+	return JSON.parse(readFileSync(path, "utf-8")) as unknown;
+}
+
+function zodErrors(error: z.ZodError): string[] {
+	return error.issues.map((issue) => {
+		const path = issue.path.length > 0 ? `${issue.path.join(".")}: ` : "";
+		return `${path}${issue.message}`;
+	});
+}
+
+function parseManifest(value: unknown): RuntimeManifest {
+	return manifestSchema.parse(value);
+}
+
+function parseManifestSafe(value: unknown): RuntimeManifest | null {
+	const result = manifestSchema.safeParse(value);
+	return result.success ? result.data : null;
+}
+
+function normalizeManifestPayload(value: unknown): {
+	manifest: RuntimeManifest;
+	secretValues?: Record<string, string>;
+} {
+	const internal = manifestSchema.safeParse(value);
+	if (internal.success) return { manifest: internal.data };
+
+	const hostedResponse = hostedRuntimeManifestResponseSchema.safeParse(value);
+	if (hostedResponse.success) {
+		return {
+			manifest: hostedManifestToRuntimeManifest(hostedResponse.data.manifest),
+			secretValues: normalizeSecretValues(hostedResponse.data.secretValues),
+		};
+	}
+	if (looksLikeHostedManifestResponse(value)) {
+		throw hostedResponse.error;
+	}
+
+	throw internal.error;
+}
+
+function looksLikeHostedManifestResponse(value: unknown): boolean {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+	const manifest = (value as Record<string, unknown>).manifest;
+	if (typeof manifest !== "object" || manifest === null || Array.isArray(manifest)) return false;
+	return (
+		(manifest as Record<string, unknown>).schemaVersion === "clawdi.hosted-runtime.manifest.v1"
+	);
+}
+
+function rawGeneration(value: unknown): number | null {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+	const record = value as Record<string, unknown>;
+	const manifestValue = record.manifest;
+	const generation =
+		typeof manifestValue === "object" && manifestValue !== null && !Array.isArray(manifestValue)
+			? (manifestValue as Record<string, unknown>).generation
+			: record.generation;
+	return typeof generation === "number" && Number.isInteger(generation) ? generation : null;
+}
+
+function runtimeCredential(source: RuntimeSource): string | null {
+	const token = process.env[source.auth.env]?.trim();
+	return token || null;
+}
+
+function resolveRuntimeSource(paths: RuntimePaths): RuntimeSource {
+	const explicit = process.env.CLAWDI_RUNTIME_MANIFEST_URL?.trim();
+	if (explicit) {
+		return {
+			schemaVersion: "clawdi.runtimeSource.v1",
+			type: "http",
+			url: explicit,
+			auth: {
+				type: "bearer-env",
+				env: process.env.CLAWDI_RUNTIME_AUTH_ENV?.trim() || "CLAWDI_AUTH_TOKEN",
+			},
+		};
+	}
+	return readRuntimeSource(paths);
+}
+
+function readRuntimeSource(paths: RuntimePaths): RuntimeSource {
+	if (!existsSync(paths.runtimeSource)) {
+		throw new Error(`runtime source config does not exist: ${paths.runtimeSource}`);
+	}
+	const parsed = runtimeSourceSchema.safeParse(readJsonFile(paths.runtimeSource));
+	if (!parsed.success) {
+		throw new Error(
+			`invalid runtime source config at ${paths.runtimeSource}: ${zodErrors(parsed.error).join("; ")}`,
+		);
+	}
+	return parsed.data;
+}
+
+export function runtimeSourceAuthEnv(paths: RuntimePaths): string {
+	return resolveRuntimeSource(paths).auth.env;
+}
+
+async function fetchRuntimeManifestPayload(paths: RuntimePaths): Promise<{
+	url: string;
+	raw: unknown;
+}> {
+	const source = resolveRuntimeSource(paths);
+	const token = runtimeCredential(source);
+	if (!token) {
+		throw new Error(`missing ${source.auth.env}`);
+	}
+	const url = source.url;
+	const timeoutMs =
+		Number.parseInt(process.env.CLAWDI_RUNTIME_MANIFEST_TIMEOUT_MS ?? "", 10) ||
+		source.timeoutMs ||
+		15000;
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+	try {
+		const response = await fetch(url, {
+			method: "GET",
+			headers: {
+				accept: "application/json",
+				authorization: `Bearer ${token}`,
+			},
+			signal: controller.signal,
+		});
+		if (!response.ok) {
+			const detail = await response.text().catch(() => "");
+			throw new Error(
+				`runtime manifest request failed: HTTP ${response.status}${
+					detail ? ` ${detail.slice(0, 200)}` : ""
+				}`,
+			);
+		}
+		return { url, raw: await response.json() };
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): RuntimeManifest {
+	const home = hosted.system?.home || "/home/clawdi";
+	const workspaceRoot = hosted.system?.workspace || join(home, "clawdi");
+	return {
+		schemaVersion: RUNTIME_DESIRED_STATE_SCHEMA_VERSION,
+		deploymentId: hosted.deploymentId,
+		environmentId: hosted.appId || hosted.deploymentId,
+		instanceId: hosted.instanceId,
+		generation: hosted.generation,
+		issuedAt: hosted.issuedAt,
+		expiresAt: hosted.expiresAt,
+		workspaceRoot,
+		controlPlane: {
+			apiUrl: hostedControlPlaneApiUrl(hosted),
+		},
+		clawdiCli: hosted.clawdiCli
+			? {
+					...DEFAULT_CLAWDI_CLI_POLICY,
+					...hosted.clawdiCli,
+					source: hosted.clawdiCli.source ?? DEFAULT_CLAWDI_CLI_POLICY.source,
+				}
+			: { ...DEFAULT_CLAWDI_CLI_POLICY },
+		runtimes: Object.fromEntries(
+			Object.entries(hosted.runtimes).map(([name, runtime]) => [
+				name,
+				{
+					enabled: runtime.enabled,
+					updateChannel: runtime.install?.channel,
+					install: runtime.enabled
+						? {
+								authority: "official" as const,
+								method: "official-installer" as const,
+								url: OFFICIAL_INSTALL_URLS[name] ?? "",
+								home: runtime.paths?.home || home,
+								args: runtime.install?.args ?? OFFICIAL_INSTALL_ARGS[name] ?? [],
+							}
+						: undefined,
+					run: hostedRuntimeRunSettings(runtime.run, runtime.paths?.workspace, workspaceRoot),
+				},
+			]),
+		),
+		projection: {
+			sourceSchemaVersion: hosted.schemaVersion,
+			system: hosted.system ?? null,
+			providers: hosted.providers ?? {},
+			channels: hosted.channels ?? {},
+		},
+		liveSync: hosted.liveSync,
+		mitmProfiles: hostedManifestMitmProfiles(hosted),
+		recovery: {
+			cacheManifest: hosted.recovery?.cacheManifest ?? true,
+			allowOfflineBoot: hosted.recovery?.allowOfflineBoot ?? true,
+		},
+	};
+}
+
+function hostedRuntimeRunSettings(
+	run: RuntimeRunSettings | undefined,
+	runtimeWorkspace: string | undefined,
+	workspaceRoot: string,
+): RuntimeRunSettings | undefined {
+	if (!run && !runtimeWorkspace) return undefined;
+	const cwd = run?.cwd ?? runtimeWorkspace ?? workspaceRoot;
+	return {
+		command: run?.command,
+		args: run?.args ?? [],
+		env: run?.env ?? {},
+		cwd,
+		prependPath: run?.prependPath ?? [],
+	};
+}
+
+function hostedControlPlaneApiUrl(hosted: HostedRuntimeManifest): string {
+	const explicit = hosted.controlPlane.cloudApiUrl || hosted.controlPlane.apiUrl;
+	if (explicit) return explicit;
+	const manifestUrl = hosted.controlPlane.manifestUrl;
+	if (!manifestUrl) return new URL(runtimeManifestUrlFromEnvOrSource()).origin;
+	try {
+		return new URL(manifestUrl).origin;
+	} catch {
+		return new URL(runtimeManifestUrlFromEnvOrSource()).origin;
+	}
+}
+
+function runtimeManifestUrlFromEnvOrSource(): string {
+	const explicit = process.env.CLAWDI_RUNTIME_MANIFEST_URL?.trim();
+	if (explicit) return explicit;
+	const sourcePath =
+		process.env.CLAWDI_RUNTIME_SOURCE_PATH?.trim() || "/etc/clawdi/runtime-source.json";
+	if (existsSync(sourcePath)) {
+		const parsed = runtimeSourceSchema.safeParse(readJsonFile(sourcePath));
+		if (parsed.success) return parsed.data.url;
+	}
+	return "https://runtime.invalid/manifest";
+}
+
+function normalizeSecretValues(secretValues: Record<string, string>): Record<string, string> {
+	const normalized: Record<string, string> = {};
+	for (const [ref, value] of Object.entries(secretValues)) {
+		normalized[ref] = value;
+		const secretRef = normalizeSecretRef(ref);
+		if (secretRef && normalized[secretRef] === undefined) {
+			normalized[secretRef] = value;
+		}
+	}
+	return normalized;
+}
+
+function loadExistingState(paths: RuntimePaths): ExistingManifestState {
+	if (!existsSync(paths.manifestLastGood)) return {};
+	const parsed = parseManifestSafe(readJsonFile(paths.manifestLastGood));
+	if (!parsed) return {};
+	return {
+		instanceId: parsed.instanceId,
+		generation: parsed.generation,
+	};
+}
+
+function manifestExpiryError(manifest: RuntimeManifest): string | null {
+	if (!manifest.expiresAt) return null;
+	const expiresAtMs = Date.parse(manifest.expiresAt);
+	if (!Number.isFinite(expiresAtMs)) {
+		return `manifest expiresAt is not a valid timestamp: ${manifest.expiresAt}`;
+	}
+	if (expiresAtMs <= Date.now()) {
+		return `manifest expired at ${manifest.expiresAt}`;
+	}
+	return null;
+}
+
+function validateManifestSemantics(manifest: RuntimeManifest, paths: RuntimePaths): string[] {
+	const errors: string[] = [];
+	const expiryError = manifestExpiryError(manifest);
+	if (expiryError) errors.push(expiryError);
+	if (!isAbsolute(paths.userHome)) errors.push(`runtime HOME must be absolute: ${paths.userHome}`);
+	if (manifest.workspaceRoot && !isAbsolute(manifest.workspaceRoot)) {
+		errors.push(`runtime workspaceRoot must be absolute: ${manifest.workspaceRoot}`);
+	}
+	for (const [name, runtime] of Object.entries(manifest.runtimes)) {
+		if (!runtime.enabled) continue;
+		if (name !== "openclaw" && name !== "hermes") {
+			errors.push(`runtime ${name} is not supported by the hosted runtime simulator`);
+			continue;
+		}
+		if (!runtime.install) {
+			errors.push(`runtime ${name} is enabled but missing install metadata`);
+			continue;
+		}
+		const expectedUrl = OFFICIAL_INSTALL_URLS[name];
+		if (runtime.install.url !== expectedUrl) {
+			errors.push(`runtime ${name} must use official installer ${expectedUrl}`);
+		}
+		if (runtime.install.home !== paths.userHome) {
+			errors.push(`runtime ${name} install.home must match runtime HOME ${paths.userHome}`);
+		}
+		if (!isAbsolute(runtime.install.home)) {
+			errors.push(`runtime ${name} install.home must be absolute`);
+		}
+		if (runtime.install.args.includes("--dir")) {
+			errors.push(`runtime ${name} install args must not include --dir`);
+		}
+		if (runtime.install.args.includes("--prefix")) {
+			errors.push(`runtime ${name} install args must not include --prefix`);
+		}
+	}
+	return errors;
+}
+
+export function runtimeManifestFixturePath(): string | undefined {
+	const value = process.env.CLAWDI_RUNTIME_MANIFEST_PATH?.trim();
+	return value ? value : undefined;
+}
+
+export async function loadRuntimeManifest(
+	paths: RuntimePaths,
+	opts: { manifestPath?: string } = {},
+): Promise<RuntimeManifestLoad | RuntimeManifestFailure> {
+	const manifestPath = opts.manifestPath ?? runtimeManifestFixturePath();
+	if (!manifestPath) {
+		let fetched: { url: string; raw: unknown };
+		try {
+			fetched = await fetchRuntimeManifestPayload(paths);
+		} catch (error) {
+			const cached = loadLastGoodManifest(paths);
+			if ("manifest" in cached) return cached;
+			return {
+				mode: "repair",
+				stage: "network",
+				errors: [
+					`could not fetch runtime manifest: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+					...cached.errors,
+				],
+			};
+		}
+
+		let normalized: { manifest: RuntimeManifest; secretValues?: Record<string, string> };
+		try {
+			normalized = normalizeManifestPayload(fetched.raw);
+		} catch (error) {
+			return {
+				mode: "manifest-rejected",
+				stage: "network",
+				errors: error instanceof z.ZodError ? zodErrors(error) : [String(error)],
+				rejectedGeneration: rawGeneration(fetched.raw),
+				activeGeneration: loadExistingState(paths).generation ?? null,
+			};
+		}
+		return validateLoadedManifest(normalized, paths, "remote-datasource", fetched.url);
+	}
+
+	if (!isAbsolute(manifestPath)) {
+		return {
+			mode: "repair",
+			stage: "local",
+			errors: [`CLAWDI_RUNTIME_MANIFEST_PATH must be absolute: ${manifestPath}`],
+		};
+	}
+	if (!existsSync(manifestPath)) {
+		return {
+			mode: "repair",
+			stage: "local",
+			errors: [`runtime manifest fixture does not exist: ${manifestPath}`],
+		};
+	}
+
+	let raw: unknown;
+	try {
+		raw = readJsonFile(manifestPath);
+	} catch (error) {
+		return {
+			mode: "manifest-rejected",
+			stage: "local",
+			errors: [
+				`could not read runtime manifest fixture at ${manifestPath}: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			],
+			activeGeneration: loadExistingState(paths).generation ?? null,
+		};
+	}
+	let normalized: { manifest: RuntimeManifest; secretValues?: Record<string, string> };
+	try {
+		normalized = normalizeManifestPayload(raw);
+	} catch (error) {
+		return {
+			mode: "manifest-rejected",
+			stage: "local",
+			errors: error instanceof z.ZodError ? zodErrors(error) : [String(error)],
+			rejectedGeneration: rawGeneration(raw),
+			activeGeneration: loadExistingState(paths).generation ?? null,
+		};
+	}
+
+	return validateLoadedManifest(normalized, paths, "fixture-file", manifestPath);
+}
+
+function loadLastGoodManifest(paths: RuntimePaths): RuntimeManifestLoad | RuntimeManifestFailure {
+	if (!existsSync(paths.manifestLastGood)) {
+		return {
+			mode: "repair",
+			stage: "local",
+			errors: ["last-good runtime manifest does not exist"],
+		};
+	}
+	try {
+		const manifest = parseManifest(readJsonFile(paths.manifestLastGood));
+		if (manifest.recovery.allowOfflineBoot !== true) {
+			return {
+				mode: "repair",
+				stage: "local",
+				errors: ["cached manifest does not allow offline boot"],
+			};
+		}
+		const expiryError = manifestExpiryError(manifest);
+		if (expiryError) {
+			return {
+				mode: "repair",
+				stage: "local",
+				errors: [`cached ${expiryError}`],
+			};
+		}
+		return {
+			manifest,
+			source: "last-good-cache",
+			sourcePath: paths.manifestLastGood,
+			offline: true,
+		};
+	} catch (error) {
+		return {
+			mode: "repair",
+			stage: "local",
+			errors: [
+				`could not read last-good runtime manifest at ${paths.manifestLastGood}: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			],
+		};
+	}
+}
+
+function validateLoadedManifest(
+	normalized: { manifest: RuntimeManifest; secretValues?: Record<string, string> },
+	paths: RuntimePaths,
+	source: RuntimeManifestLoad["source"],
+	sourcePath: string,
+): RuntimeManifestLoad | RuntimeManifestFailure {
+	const existing = loadExistingState(paths);
+	const manifest = normalized.manifest;
+	const semanticErrors = validateManifestSemantics(manifest, paths);
+	if (existing.instanceId && existing.instanceId !== manifest.instanceId) {
+		semanticErrors.push(
+			`manifest instanceId ${manifest.instanceId} does not match last-good instanceId ${existing.instanceId}`,
+		);
+	}
+	if (existing.generation !== undefined && manifest.generation < existing.generation) {
+		semanticErrors.push(
+			`manifest generation ${manifest.generation} is older than last-good generation ${existing.generation}`,
+		);
+	}
+	if (semanticErrors.length > 0) {
+		return {
+			mode: "manifest-rejected",
+			stage: source === "remote-datasource" ? "network" : "local",
+			errors: semanticErrors,
+			rejectedGeneration: manifest.generation,
+			activeGeneration: existing.generation ?? null,
+		};
+	}
+
+	return {
+		manifest,
+		source,
+		sourcePath,
+		offline: false,
+		secretValues: normalized.secretValues,
+	};
+}

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1,0 +1,898 @@
+import { spawnSync } from "node:child_process";
+import {
+	accessSync,
+	chmodSync,
+	chownSync,
+	constants,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { writePrivateFileAtomic } from "../lib/private-file";
+import type { LiveSyncAgent, RuntimeInstall, RuntimeManifest } from "./manifest-contract";
+
+export type { RuntimeInstall, RuntimeManifest } from "./manifest-contract";
+export {
+	loadRuntimeManifest,
+	type RuntimeManifestFailure,
+	type RuntimeManifestLoad,
+	runtimeManifestFixturePath,
+} from "./manifest-source";
+
+import type { RuntimeManifestLoad } from "./manifest-source";
+import {
+	buildMitmProfileBundle,
+	hasEnabledMitmProfiles,
+	writeMitmProfileBundle,
+} from "./mitm-profiles";
+import type { RuntimePaths } from "./paths";
+import {
+	buildRuntimeRunConfig,
+	runtimeRunConfigPath,
+	type SupportedRuntimeName,
+	writeRuntimeRunConfig,
+} from "./run-config";
+
+export interface RuntimeConvergenceResult {
+	manifest: RuntimeManifest;
+	source: RuntimeManifestLoad["source"];
+	sourcePath: string;
+	offline: boolean;
+	mode: "normal" | "degraded-offline";
+	enabledRuntimes: string[];
+	installErrors: string[];
+	outputs: {
+		workspaceRoot: string;
+		managedConfig: string;
+		syncState: string;
+		instanceData: string;
+		sensitiveInstanceData: string;
+		manifestLastGood: string | null;
+		installInventory: string[];
+		projections: string[];
+		runConfigs: string[];
+		supervisorConfig: string;
+		mitmProfileBundle: string | null;
+		mitmSecretFile: string | null;
+		liveSyncEnvironments: string[];
+		daemonAuthTokenFile: string | null;
+		instanceSemaphores: string[];
+		bootFinished: string;
+	};
+}
+
+interface RuntimeInstallObservation {
+	runtime: string;
+	enabled: boolean;
+	status: "disabled" | "present" | "installed" | "install_failed";
+	executionUser: string | null;
+	commandPath: string | null;
+	appRoot: string | null;
+	install: RuntimeInstall | null;
+	installerUrl: string | null;
+	executedInstallerUrl: string | null;
+	exitCode: number | null;
+	installStartedAt?: string;
+	installFinishedAt?: string;
+	installDurationMs?: number;
+	stdoutTail: string | null;
+	stderrTail: string | null;
+	error: string | null;
+}
+
+function writeJsonFile(path: string, payload: unknown): void {
+	writePrivateFileAtomic(path, `${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function writeLastGoodManifest(manifest: RuntimeManifest, paths: RuntimePaths): string | null {
+	if (manifest.recovery.cacheManifest === false) {
+		rmSync(paths.manifestLastGood, { force: true });
+		return null;
+	}
+	writeJsonFile(paths.manifestLastGood, manifest);
+	return paths.manifestLastGood;
+}
+
+function writeSecretValues(
+	secretValues: Record<string, string> | undefined,
+	paths: RuntimePaths,
+): string | null {
+	const path = join(paths.runRoot, "mitm", "secrets.json");
+	if (!secretValues || Object.keys(secretValues).length === 0) {
+		rmSync(path, { force: true });
+		return null;
+	}
+	writePrivateFileAtomic(path, `${JSON.stringify(secretValues, null, 2)}\n`, {
+		mode: 0o600,
+		dirMode: 0o700,
+	});
+	makeRuntimeUserOwned(dirname(path));
+	makeRuntimeUserOwned(path);
+	return path;
+}
+
+function makeRuntimeUserOwned(path: string): void {
+	if (!runningAsRoot()) return;
+	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
+	if (!runtimeUser || runtimeUser === "root") return;
+	const result = spawnSync("id", ["-u", runtimeUser], { encoding: "utf8" });
+	const group = spawnSync("id", ["-g", runtimeUser], { encoding: "utf8" });
+	if (result.status !== 0 || group.status !== 0) return;
+	const uid = Number.parseInt(result.stdout.trim(), 10);
+	const gid = Number.parseInt(group.stdout.trim(), 10);
+	if (!Number.isFinite(uid) || !Number.isFinite(gid)) return;
+	try {
+		chownSync(path, uid, gid);
+	} catch {
+		// Best effort: hosted demos without a system user still exercise the
+		// manifest path, but production images provide CLAWDI_RUNTIME_USER.
+	}
+}
+
+function runtimeInstallerCommand(name: string, install: RuntimeInstall | undefined): string[] {
+	if (!install) return [];
+	if (name === "openclaw") {
+		return ["bash", "<downloaded-official-openclaw-installer>", ...install.args];
+	}
+	if (name === "hermes") {
+		return ["bash", "<downloaded-official-hermes-installer>", ...install.args];
+	}
+	return [];
+}
+
+function runtimeCommandPath(name: string, home: string): string | null {
+	if (name === "openclaw") return join(home, ".openclaw", "bin", "openclaw");
+	if (name === "hermes") return join(home, ".local", "bin", "hermes");
+	return null;
+}
+
+function runtimeAppRoot(name: string, home: string): string | null {
+	if (name === "openclaw") return join(home, ".openclaw");
+	if (name === "hermes") return join(home, ".hermes", "hermes-agent");
+	return null;
+}
+
+const SUPPORTED_RUNTIME_NAMES = [
+	"hermes",
+	"openclaw",
+] as const satisfies readonly SupportedRuntimeName[];
+
+function isSupportedRuntimeName(name: string): name is SupportedRuntimeName {
+	return (SUPPORTED_RUNTIME_NAMES as readonly string[]).includes(name);
+}
+
+function executableExists(path: string): boolean {
+	try {
+		accessSync(path, constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function commandExists(name: string): boolean {
+	const path = process.env.PATH ?? "";
+	for (const dir of path.split(":")) {
+		if (!dir) continue;
+		if (executableExists(join(dir, name))) return true;
+	}
+	return false;
+}
+
+function runningAsRoot(): boolean {
+	return typeof process.getuid === "function" && process.getuid() === 0;
+}
+
+function runtimeInstallerExecution(
+	install: RuntimeInstall,
+	installerPath: string,
+): {
+	command: string;
+	args: string[];
+	env: NodeJS.ProcessEnv;
+	executionUser: string | null;
+} {
+	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
+	const env = runtimeInstallerEnv(install);
+	if (!runningAsRoot() || !runtimeUser || runtimeUser === "root") {
+		return {
+			command: "bash",
+			args: [installerPath, ...install.args],
+			env,
+			executionUser: null,
+		};
+	}
+
+	const userEnv = {
+		...env,
+		USER: runtimeUser,
+		LOGNAME: runtimeUser,
+	};
+	if (commandExists("gosu")) {
+		return {
+			command: "gosu",
+			args: [runtimeUser, "bash", installerPath, ...install.args],
+			env: userEnv,
+			executionUser: runtimeUser,
+		};
+	}
+	if (commandExists("runuser")) {
+		return {
+			command: "runuser",
+			args: [
+				"-u",
+				runtimeUser,
+				"--",
+				"env",
+				`HOME=${install.home}`,
+				`USER=${runtimeUser}`,
+				`LOGNAME=${runtimeUser}`,
+				"bash",
+				installerPath,
+				...install.args,
+			],
+			env,
+			executionUser: runtimeUser,
+		};
+	}
+
+	throw new Error(
+		`runtime init is running as root but cannot drop to CLAWDI_RUNTIME_USER=${runtimeUser}; install gosu or runuser`,
+	);
+}
+
+function runtimeInstallerEnv(install: RuntimeInstall): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = { ...process.env, HOME: install.home };
+	delete env.NPM_CONFIG_PREFIX;
+	delete env.npm_config_prefix;
+	delete env.NPM_CONFIG_CACHE;
+	delete env.npm_config_cache;
+	return env;
+}
+
+function tail(value: string | null | undefined): string | null {
+	if (!value) return null;
+	return value.slice(-4000);
+}
+
+function testInstallerEnvName(name: string): string | null {
+	if (name === "openclaw") return "CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER";
+	if (name === "hermes") return "CLAWDI_RUNTIME_TEST_HERMES_INSTALLER";
+	return null;
+}
+
+function executionInstallerUrl(name: string, officialUrl: string): string {
+	const envName = testInstallerEnvName(name);
+	const override = envName ? process.env[envName]?.trim() : undefined;
+	if (override) {
+		if (process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS !== "1") {
+			throw new Error(`${envName} requires CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS=1`);
+		}
+		return override;
+	}
+	return officialUrl;
+}
+
+function materializeInstaller(
+	name: string,
+	installerUrl: string,
+): { path: string; cleanup?: string } {
+	if (installerUrl.startsWith("file://")) {
+		return { path: fileURLToPath(installerUrl) };
+	}
+	if (installerUrl.startsWith("/")) {
+		return { path: installerUrl };
+	}
+	if (!installerUrl.startsWith("https://")) {
+		throw new Error(`runtime ${name} installer must use https:// or a test file URL`);
+	}
+	const dir = mkdtempSync(join(tmpdir(), `clawdi-${name}-installer-`));
+	chmodSync(dir, 0o755);
+	const path = join(dir, "install.sh");
+	const curl = spawnSync(
+		"curl",
+		["-fsSL", "--proto", "=https", "--tlsv1.2", "--retry", "3", "-o", path, installerUrl],
+		{ encoding: "utf8" },
+	);
+	if (curl.status !== 0) {
+		rmSync(dir, { recursive: true, force: true });
+		throw new Error(
+			`could not download ${name} official installer: ${tail(curl.stderr) ?? "curl failed"}`,
+		);
+	}
+	chmodSync(path, 0o755);
+	return { path, cleanup: dir };
+}
+
+function runOfficialInstaller(name: string, install: RuntimeInstall): RuntimeInstallObservation {
+	const installStartedAt = new Date().toISOString();
+	const installStartedMs = Date.now();
+	const finish = (
+		observation: Omit<
+			RuntimeInstallObservation,
+			"installStartedAt" | "installFinishedAt" | "installDurationMs"
+		>,
+	): RuntimeInstallObservation => ({
+		...observation,
+		installStartedAt,
+		installFinishedAt: new Date().toISOString(),
+		installDurationMs: Math.max(0, Date.now() - installStartedMs),
+	});
+	const commandPath = runtimeCommandPath(name, install.home);
+	const appRoot = runtimeAppRoot(name, install.home);
+	if (!commandPath || !appRoot) {
+		return finish({
+			runtime: name,
+			enabled: true,
+			status: "install_failed",
+			executionUser: null,
+			commandPath,
+			appRoot,
+			install,
+			installerUrl: install.url,
+			executedInstallerUrl: null,
+			exitCode: null,
+			stdoutTail: null,
+			stderrTail: null,
+			error: `unsupported runtime ${name}`,
+		});
+	}
+	if (executableExists(commandPath)) {
+		return finish({
+			runtime: name,
+			enabled: true,
+			status: "present",
+			executionUser: null,
+			commandPath,
+			appRoot,
+			install,
+			installerUrl: install.url,
+			executedInstallerUrl: null,
+			exitCode: null,
+			stdoutTail: null,
+			stderrTail: null,
+			error: null,
+		});
+	}
+
+	mkdirSync(install.home, { recursive: true });
+	makeRuntimeUserOwned(install.home);
+	const url = executionInstallerUrl(name, install.url);
+	const materialized = materializeInstaller(name, url);
+	try {
+		const execution = runtimeInstallerExecution(install, materialized.path);
+		const result = spawnSync(execution.command, execution.args, {
+			cwd: install.home,
+			env: execution.env,
+			encoding: "utf8",
+			timeout: Number.parseInt(process.env.CLAWDI_RUNTIME_INSTALL_TIMEOUT ?? "1800000", 10),
+		});
+		const exitCode = result.status ?? 1;
+		const installed = exitCode === 0 && executableExists(commandPath);
+		return finish({
+			runtime: name,
+			enabled: true,
+			status: installed ? "installed" : "install_failed",
+			executionUser: execution.executionUser,
+			commandPath,
+			appRoot,
+			install,
+			installerUrl: install.url,
+			executedInstallerUrl: url === install.url ? install.url : url,
+			exitCode,
+			stdoutTail: tail(result.stdout),
+			stderrTail: tail(result.stderr),
+			error: installed
+				? null
+				: `runtime ${name} installer exited ${exitCode} or did not create ${commandPath}`,
+		});
+	} catch (error) {
+		return finish({
+			runtime: name,
+			enabled: true,
+			status: "install_failed",
+			executionUser: null,
+			commandPath,
+			appRoot,
+			install,
+			installerUrl: install.url,
+			executedInstallerUrl: url,
+			exitCode: null,
+			stdoutTail: null,
+			stderrTail: null,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	} finally {
+		if (materialized.cleanup) rmSync(materialized.cleanup, { recursive: true, force: true });
+	}
+}
+
+function observeRuntimeInstall(name: string, runtime: RuntimeManifest["runtimes"][string]) {
+	if (!runtime.enabled) {
+		return {
+			runtime: name,
+			enabled: false,
+			status: "disabled",
+			executionUser: null,
+			commandPath: null,
+			appRoot: null,
+			install: runtime.install ?? null,
+			installerUrl: runtime.install?.url ?? null,
+			executedInstallerUrl: null,
+			exitCode: null,
+			stdoutTail: null,
+			stderrTail: null,
+			error: null,
+		} satisfies RuntimeInstallObservation;
+	}
+	if (!runtime.install) {
+		return {
+			runtime: name,
+			enabled: true,
+			status: "install_failed",
+			executionUser: null,
+			commandPath: null,
+			appRoot: null,
+			install: null,
+			installerUrl: null,
+			executedInstallerUrl: null,
+			exitCode: null,
+			stdoutTail: null,
+			stderrTail: null,
+			error: `runtime ${name} is enabled but missing install metadata`,
+		} satisfies RuntimeInstallObservation;
+	}
+	return runOfficialInstaller(name, runtime.install);
+}
+
+function projectionPayload(name: string, manifest: RuntimeManifest): unknown {
+	const projection =
+		typeof manifest.projection === "object" && manifest.projection !== null
+			? manifest.projection
+			: undefined;
+	return {
+		schemaVersion: "clawdi.runtimeProjection.v1",
+		runtime: name,
+		generation: manifest.generation,
+		instanceId: manifest.instanceId,
+		managedBy: "clawdi runtime init",
+		target:
+			name === "openclaw"
+				? "openclaw config patch --stdin"
+				: name === "hermes"
+					? "official Hermes user config"
+					: "clawdi mcp",
+		projection: projection ?? null,
+	};
+}
+
+function runtimeSettingsWithSecretFile(
+	settings: RuntimeManifest["runtimes"][string]["run"],
+	secretFile: string | null,
+	enabled: boolean,
+): RuntimeManifest["runtimes"][string]["run"] {
+	if (!secretFile || !enabled) return settings;
+	return {
+		command: settings?.command,
+		args: settings?.args ?? [],
+		env: {
+			...(settings?.env ?? {}),
+			CLAWDI_MITM_SECRET_FILE: secretFile,
+		},
+		cwd: settings?.cwd,
+		prependPath: settings?.prependPath ?? [],
+	};
+}
+
+function clearMitmProfileBundle(paths: RuntimePaths): null {
+	rmSync(paths.mitmProfileBundle, { force: true });
+	return null;
+}
+
+function removeStaleRuntimeRunConfigs(
+	writtenRuntimes: Set<SupportedRuntimeName>,
+	paths: RuntimePaths,
+): void {
+	for (const runtime of SUPPORTED_RUNTIME_NAMES) {
+		if (!writtenRuntimes.has(runtime)) {
+			rmSync(runtimeRunConfigPath(runtime, paths), { force: true });
+		}
+	}
+}
+
+const MANAGED_LIVE_SYNC_AGENTS = ["openclaw", "hermes", "codex"] as const;
+
+function desiredLiveSyncAgents(manifest: RuntimeManifest): LiveSyncAgent[] {
+	if (manifest.liveSync?.enabled === false) return [];
+	const agents = manifest.liveSync?.agents ?? [];
+	const byAgent = new Map<LiveSyncAgent["agentType"], LiveSyncAgent>();
+	for (const agent of agents) byAgent.set(agent.agentType, agent);
+	return [...byAgent.values()].sort((a, b) => a.agentType.localeCompare(b.agentType));
+}
+
+function writeLiveSyncEnvironmentFiles(manifest: RuntimeManifest, paths: RuntimePaths): string[] {
+	const envDir = paths.localEnvironments;
+	mkdirSync(envDir, { recursive: true });
+	makeRuntimeUserOwned(envDir);
+	const agents = desiredLiveSyncAgents(manifest);
+	const desiredTypes = new Set(agents.map((agent) => agent.agentType));
+	for (const agentType of MANAGED_LIVE_SYNC_AGENTS) {
+		if (!desiredTypes.has(agentType)) {
+			rmSync(join(envDir, `${agentType}.json`), { force: true });
+		}
+	}
+	const written: string[] = [];
+	for (const agent of agents) {
+		const path = join(envDir, `${agent.agentType}.json`);
+		writePrivateFileAtomic(
+			path,
+			`${JSON.stringify(
+				{
+					id: agent.environmentId,
+					agentType: agent.agentType,
+					managedBy: "clawdi runtime init",
+					deploymentId: manifest.deploymentId,
+					instanceId: manifest.instanceId,
+				},
+				null,
+				2,
+			)}\n`,
+			{ mode: 0o600, dirMode: 0o700 },
+		);
+		makeRuntimeUserOwned(path);
+		written.push(path);
+	}
+	return written;
+}
+
+function writeDaemonAuthToken(manifest: RuntimeManifest, paths: RuntimePaths): string | null {
+	const path = join(paths.runRoot, "sync", "auth-token");
+	const hasLiveSyncAgents = desiredLiveSyncAgents(manifest).length > 0;
+	const token = process.env.CLAWDI_AUTH_TOKEN?.trim();
+	if (!hasLiveSyncAgents || !token) {
+		rmSync(path, { force: true });
+		return null;
+	}
+	writePrivateFileAtomic(path, `${token}\n`, { mode: 0o600, dirMode: 0o700 });
+	makeRuntimeUserOwned(dirname(path));
+	makeRuntimeUserOwned(path);
+	return path;
+}
+
+function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function writeSupervisorConfig(
+	enabledRuntimes: string[],
+	manifest: RuntimeManifest,
+	paths: RuntimePaths,
+	workspaceRoot: string,
+	daemonAuthTokenFile: string | null,
+): string {
+	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
+	const commonEnvironment = {
+		HOME: paths.userHome,
+		CLAWDI_RUNTIME_MODE: "hosted",
+		CLAWDI_RUNTIME_USER: runtimeUser,
+		CLAWDI_SERVICE_STATE_DIR: paths.serviceStateRoot,
+		CLAWDI_RUN_DIR: paths.runRoot,
+		CLAWDI_HOST_POLICY_PATH: paths.hostPolicy,
+		PATH: supervisorPath(paths),
+	};
+	const runtimeEnvironment = supervisorEnvironment({
+		...commonEnvironment,
+		CLAWDI_AUTH_TOKEN: "",
+	});
+	const daemonEnvironment = supervisorEnvironment({
+		...commonEnvironment,
+		CLAWDI_SERVE_MODE: "container",
+		CLAWDI_API_URL: manifest.controlPlane.apiUrl,
+		CLAWDI_NO_AUTO_UPDATE: "1",
+		CLAWDI_NO_UPDATE_CHECK: "1",
+	});
+	const supportedEnabled = enabledRuntimes.filter(isSupportedRuntimeName);
+	const shouldRunDaemon =
+		daemonAuthTokenFile !== null && desiredLiveSyncAgents(manifest).length > 0;
+	const lines = [
+		"; Generated by clawdi runtime init. Do not edit inside hosted runtime.",
+		`; Desired-state generation: ${manifest.generation}`,
+		"[supervisord]",
+		"nodaemon=true",
+		"logfile=/dev/null",
+		"logfile_maxbytes=0",
+		`pidfile=${paths.runRoot}/supervisord.pid`,
+		"childlogdir=/tmp",
+		"",
+		"[unix_http_server]",
+		`file=${paths.runRoot}/supervisor.sock`,
+		"chmod=0700",
+		"",
+		"[supervisorctl]",
+		`serverurl=unix://${paths.runRoot}/supervisor.sock`,
+		"",
+		"[rpcinterface:supervisor]",
+		"supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface",
+		"",
+	];
+
+	if (supportedEnabled.length === 0 && !shouldRunDaemon) {
+		lines.push("; No enabled agent runtimes in the current manifest.", "");
+	}
+
+	if (shouldRunDaemon && daemonAuthTokenFile) {
+		const script = `export CLAWDI_AUTH_TOKEN="$(cat ${shellQuote(
+			daemonAuthTokenFile,
+		)})"; exec /usr/bin/env clawdi daemon run`;
+		lines.push(
+			"[program:clawdi-daemon]",
+			`command=/bin/sh -lc ${shellQuote(script)}`,
+			`directory=${workspaceRoot}`,
+			`user=${runtimeUser}`,
+			"autostart=true",
+			"autorestart=true",
+			"startsecs=2",
+			"startretries=5",
+			"stopasgroup=true",
+			"killasgroup=true",
+			"stdout_logfile=/dev/fd/1",
+			"stdout_logfile_maxbytes=0",
+			"stderr_logfile=/dev/fd/2",
+			"stderr_logfile_maxbytes=0",
+			`environment=${daemonEnvironment}`,
+			"",
+		);
+	}
+
+	for (const runtime of supportedEnabled) {
+		lines.push(
+			`[program:clawdi-${runtime}]`,
+			`command=/usr/bin/env clawdi run -- ${runtime}`,
+			`directory=${workspaceRoot}`,
+			`user=${runtimeUser}`,
+			"autostart=true",
+			"autorestart=true",
+			"startsecs=2",
+			"startretries=5",
+			"stopasgroup=true",
+			"killasgroup=true",
+			"stdout_logfile=/dev/fd/1",
+			"stdout_logfile_maxbytes=0",
+			"stderr_logfile=/dev/fd/2",
+			"stderr_logfile_maxbytes=0",
+			`environment=${runtimeEnvironment}`,
+			"",
+		);
+	}
+
+	writePrivateFileAtomic(paths.supervisorConfig, `${lines.join("\n")}\n`, { mode: 0o644 });
+	return paths.supervisorConfig;
+}
+
+function supervisorPath(paths: RuntimePaths): string {
+	return [
+		join(paths.serviceStateRoot, "bin"),
+		join(paths.userHome, ".local", "bin"),
+		join(paths.userHome, ".openclaw", "bin"),
+		process.env.PATH || "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+	].join(":");
+}
+
+function supervisorEnvironment(values: Record<string, string>): string {
+	return Object.entries(values)
+		.map(([key, value]) => `${key}="${supervisorEscape(value)}"`)
+		.join(",");
+}
+
+function supervisorEscape(value: string): string {
+	return value.replace(/%/g, "%%").replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function runtimeWorkspaceRoot(manifest: RuntimeManifest, paths: RuntimePaths): string {
+	return manifest.workspaceRoot ?? paths.workspaceRoot;
+}
+
+export function convergeRuntimeManifest(
+	load: RuntimeManifestLoad,
+	paths: RuntimePaths,
+): RuntimeConvergenceResult {
+	const { manifest } = load;
+	const workspaceRoot = runtimeWorkspaceRoot(manifest, paths);
+	const enabledRuntimes = Object.entries(manifest.runtimes)
+		.filter(([, runtime]) => runtime.enabled)
+		.map(([name]) => name)
+		.sort();
+	const generatedAt = new Date().toISOString();
+	const instanceRoot = join(paths.instanceRoot, manifest.instanceId);
+	const semRoot = join(instanceRoot, "sem");
+	const instanceSemaphores: string[] = [];
+	const installInventory: string[] = [];
+	const projections: string[] = [];
+	const runConfigs: string[] = [];
+	const installErrors: string[] = [];
+
+	mkdirSync(workspaceRoot, { recursive: true });
+	makeRuntimeUserOwned(paths.userHome);
+	makeRuntimeUserOwned(workspaceRoot);
+	makeRuntimeUserOwned(paths.runRoot);
+	mkdirSync(paths.installInventory, { recursive: true });
+	mkdirSync(paths.projectionRoot, { recursive: true });
+	mkdirSync(semRoot, { recursive: true });
+
+	const manifestLastGood = writeLastGoodManifest(manifest, paths);
+	writeJsonFile(paths.managedConfig, {
+		schemaVersion: "clawdi.hostedManagedConfig.v1",
+		generatedAt,
+		deploymentId: manifest.deploymentId,
+		environmentId: manifest.environmentId,
+		instanceId: manifest.instanceId,
+		generation: manifest.generation,
+		controlPlane: manifest.controlPlane,
+		auth: {
+			source: "runtime-instance-data",
+			token: "<redacted>",
+		},
+		workspaceRoot,
+	});
+	writeJsonFile(paths.syncState, {
+		schemaVersion: "clawdi.runtimeSyncState.v1",
+		generatedAt,
+		deploymentId: manifest.deploymentId,
+		environmentId: manifest.environmentId,
+		instanceId: manifest.instanceId,
+		generation: manifest.generation,
+		runtimes: Object.fromEntries(
+			Object.entries(manifest.runtimes).map(([name, runtime]) => [
+				name,
+				{
+					enabled: runtime.enabled,
+					updateChannel: runtime.updateChannel ?? null,
+					workspaceRoot,
+				},
+			]),
+		),
+	});
+	writeJsonFile(paths.instanceData, {
+		schemaVersion: "clawdi.runtimeInstanceData.v1",
+		generatedAt,
+		deploymentId: manifest.deploymentId,
+		environmentId: manifest.environmentId,
+		instanceId: manifest.instanceId,
+		generation: manifest.generation,
+		controlPlane: manifest.controlPlane,
+		workspaceRoot,
+	});
+	writeJsonFile(paths.sensitiveInstanceData, {
+		schemaVersion: "clawdi.runtimeSensitiveInstanceData.v1",
+		generatedAt,
+		tokenSource: process.env.CLAWDI_AUTH_TOKEN ? "CLAWDI_AUTH_TOKEN" : load.source,
+		token: "<redacted>",
+	});
+
+	const mitmProfileBundle = buildMitmProfileBundle({
+		generatedAt,
+		generation: manifest.generation,
+		instanceId: manifest.instanceId,
+		profiles: manifest.mitmProfiles,
+	});
+	const mitmProfileBundlePath = hasEnabledMitmProfiles(mitmProfileBundle)
+		? writeMitmProfileBundle(mitmProfileBundle, paths)
+		: clearMitmProfileBundle(paths);
+	const mitmSecretFile = writeSecretValues(load.secretValues, paths);
+	const liveSyncEnvironments = writeLiveSyncEnvironmentFiles(manifest, paths);
+	const daemonAuthTokenFile = writeDaemonAuthToken(manifest, paths);
+	const supervisorConfig = writeSupervisorConfig(
+		enabledRuntimes,
+		manifest,
+		paths,
+		workspaceRoot,
+		daemonAuthTokenFile,
+	);
+	const writtenRunConfigRuntimes = new Set<SupportedRuntimeName>();
+
+	for (const [name, runtime] of Object.entries(manifest.runtimes).sort(([a], [b]) =>
+		a.localeCompare(b),
+	)) {
+		const observation = observeRuntimeInstall(name, runtime);
+		if (observation.error) installErrors.push(observation.error);
+
+		const inventoryPath = join(paths.installInventory, `${name}.json`);
+		writeJsonFile(inventoryPath, {
+			schemaVersion: "clawdi.runtimeInstallInventory.v1",
+			generatedAt,
+			runtime: name,
+			enabled: runtime.enabled,
+			updateChannel: runtime.updateChannel ?? null,
+			simulation: false,
+			status: observation.status,
+			executionUser: observation.executionUser,
+			install: observation.install,
+			command: runtimeInstallerCommand(name, runtime.install),
+			commandPath: observation.commandPath,
+			appRoot: observation.appRoot,
+			installerUrl: observation.installerUrl,
+			executedInstallerUrl: observation.executedInstallerUrl,
+			installStartedAt: observation.installStartedAt ?? null,
+			installFinishedAt: observation.installFinishedAt ?? null,
+			installDurationMs: observation.installDurationMs ?? null,
+			resultExitCode: observation.exitCode,
+			stdoutTail: observation.stdoutTail,
+			stderrTail: observation.stderrTail,
+			error: observation.error,
+		});
+		installInventory.push(inventoryPath);
+
+		const projectionPath = join(paths.projectionRoot, `${name}.json`);
+		writeJsonFile(projectionPath, projectionPayload(name, manifest));
+		projections.push(projectionPath);
+
+		if (isSupportedRuntimeName(name)) {
+			const runConfigPath = writeRuntimeRunConfig(
+				buildRuntimeRunConfig({
+					runtime: name,
+					enabled: runtime.enabled,
+					generatedAt,
+					generation: manifest.generation,
+					instanceId: manifest.instanceId,
+					commandPath: observation.commandPath,
+					appRoot: observation.appRoot,
+					workspaceRoot,
+					mitmProfileBundlePath,
+					settings: runtimeSettingsWithSecretFile(
+						runtime.run,
+						mitmProfileBundlePath ? mitmSecretFile : null,
+						runtime.enabled,
+					),
+				}),
+				paths,
+			);
+			runConfigs.push(runConfigPath);
+			writtenRunConfigRuntimes.add(name);
+		}
+
+		const semaphorePath = join(semRoot, `${name}.enabled`);
+		if (runtime.enabled) {
+			writePrivateFileAtomic(semaphorePath, `${generatedAt}\n`);
+			instanceSemaphores.push(semaphorePath);
+		}
+	}
+
+	const mcpProjection = join(paths.projectionRoot, "clawdi-mcp.json");
+	writeJsonFile(mcpProjection, projectionPayload("clawdi-mcp", manifest));
+	projections.push(mcpProjection);
+
+	const bootFinished = join(instanceRoot, "boot-finished");
+	writePrivateFileAtomic(bootFinished, `${generatedAt}\n`);
+	removeStaleRuntimeRunConfigs(writtenRunConfigRuntimes, paths);
+
+	return {
+		manifest,
+		source: load.source,
+		sourcePath: load.sourcePath,
+		offline: load.offline,
+		mode: load.offline ? "degraded-offline" : "normal",
+		enabledRuntimes,
+		installErrors,
+		outputs: {
+			workspaceRoot,
+			managedConfig: paths.managedConfig,
+			syncState: paths.syncState,
+			instanceData: paths.instanceData,
+			sensitiveInstanceData: paths.sensitiveInstanceData,
+			manifestLastGood,
+			installInventory,
+			projections,
+			runConfigs,
+			supervisorConfig,
+			mitmProfileBundle: mitmProfileBundlePath,
+			mitmSecretFile,
+			liveSyncEnvironments,
+			daemonAuthTokenFile,
+			instanceSemaphores,
+			bootFinished,
+		},
+	};
+}

--- a/packages/cli/src/runtime/mitm-broker.ts
+++ b/packages/cli/src/runtime/mitm-broker.ts
@@ -1,0 +1,196 @@
+import { type ChildProcessByStdio, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { Readable } from "node:stream";
+import { fileURLToPath } from "node:url";
+import { stripMitmBrokerControlEnv } from "./mitm-env";
+
+export interface RuntimeMitmBrokerInput {
+	runtime: string;
+	env: NodeJS.ProcessEnv;
+	profileBundlePath: string;
+}
+
+export interface RuntimeMitmBroker {
+	proxyUrl: string;
+	caFile: string;
+	stop: () => Promise<void>;
+}
+
+export type RuntimeMitmBrokerFactory = (
+	input: RuntimeMitmBrokerInput,
+) => Promise<RuntimeMitmBroker>;
+
+export function shouldStartRuntimeMitmBroker(env: NodeJS.ProcessEnv): boolean {
+	return env.CLAWDI_MITM_ENABLED === "1" && Boolean(env.CLAWDI_MITM_PROFILE_BUNDLE?.trim());
+}
+
+export async function startRuntimeMitmBroker(
+	input: RuntimeMitmBrokerInput,
+): Promise<RuntimeMitmBroker> {
+	const invocation = resolveBrokerInvocation(input.env);
+	if (!invocation) {
+		throw new Error(
+			"Native MITM broker bundle not found. Expected clawdi-mitm-broker/bin/clawdi-mitm-broker beside the clawdi package entrypoint, or set CLAWDI_MITM_BROKER_BUNDLE or CLAWDI_MITM_BROKER_PATH.",
+		);
+	}
+	const caFile = input.env.CLAWDI_MITM_CA_FILE?.trim();
+	if (!caFile) {
+		throw new Error("CLAWDI_MITM_CA_FILE is required when starting the native MITM broker.");
+	}
+
+	const args = [
+		"--profile-bundle",
+		input.profileBundlePath,
+		"--proxy-url",
+		input.env.CLAWDI_MITM_PROXY_URL ?? "http://127.0.0.1:0",
+		"--ca-file",
+		caFile,
+	];
+	if (input.env.CLAWDI_MITM_SECRET_FILE) {
+		args.push("--secret-file", input.env.CLAWDI_MITM_SECRET_FILE);
+	}
+	if (input.env.CLAWDI_MITM_ALLOW_REMOTE_PROXY === "1") {
+		args.push("--allow-remote-proxy");
+	}
+
+	const child = spawn(invocation.command, args, {
+		env: brokerProcessEnv(input.env),
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	child.stderr.on("data", (chunk) => {
+		if (input.env.CLAWDI_DEBUG === "1") process.stderr.write(chunk);
+	});
+
+	const ready = await waitForBrokerReady(child);
+	return {
+		proxyUrl: ready.proxyUrl,
+		caFile: ready.caFile,
+		stop: async () => {
+			await stopChild(child);
+		},
+	};
+}
+
+function brokerProcessEnv(inputEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+	const env = { ...process.env, ...inputEnv };
+	delete env.CLAWDI_AUTH_TOKEN;
+	stripMitmBrokerControlEnv(env);
+	return env;
+}
+
+function resolveBrokerInvocation(env: NodeJS.ProcessEnv): { command: string } | null {
+	const explicit = env.CLAWDI_MITM_BROKER_PATH?.trim();
+	if (explicit) return { command: explicit };
+
+	const explicitBundle = env.CLAWDI_MITM_BROKER_BUNDLE?.trim();
+	if (explicitBundle) {
+		const executable = join(explicitBundle, "bin", "clawdi-mitm-broker");
+		if (existsSync(executable)) return { command: executable };
+	}
+
+	const here = dirname(fileURLToPath(import.meta.url));
+	const baseDirs = unique([
+		dirname(process.execPath),
+		process.argv[1] ? dirname(process.argv[1]) : "",
+		here,
+		join(here, ".."),
+		join(here, "..", ".."),
+	]);
+	for (const baseDir of baseDirs) {
+		const executable = join(baseDir, "clawdi-mitm-broker", "bin", "clawdi-mitm-broker");
+		if (existsSync(executable)) return { command: executable };
+	}
+
+	return null;
+}
+
+function unique(values: string[]): string[] {
+	return Array.from(new Set(values.filter(Boolean)));
+}
+
+function waitForBrokerReady(
+	child: ChildProcessByStdio<null, Readable, Readable>,
+): Promise<{ proxyUrl: string; caFile: string }> {
+	return new Promise((resolve, reject) => {
+		let stdout = "";
+		let stderr = "";
+		let settled = false;
+		const settle = (fn: () => void) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			fn();
+		};
+		const timer = setTimeout(() => {
+			child.kill("SIGKILL");
+			settle(() => reject(new Error(`MITM broker did not become ready\n${stderr.trim()}`)));
+		}, 15_000);
+
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => {
+			stdout += chunk;
+			const line = stdout.split(/\r?\n/).find((item) => item.trim().startsWith("{"));
+			if (!line) return;
+			try {
+				const parsed: unknown = JSON.parse(line);
+				if (isRecord(parsed) && parsed.ready === false) {
+					const reason = typeof parsed.reason === "string" ? `: ${parsed.reason}` : "";
+					settle(() => reject(new Error(`MITM broker did not become ready${reason}`)));
+					return;
+				}
+				if (
+					isRecord(parsed) &&
+					parsed.ready === true &&
+					typeof parsed.proxyUrl === "string" &&
+					typeof parsed.caFile === "string"
+				) {
+					const proxyUrl = parsed.proxyUrl;
+					const caFile = parsed.caFile;
+					settle(() => resolve({ proxyUrl, caFile }));
+					return;
+				}
+				settle(() => reject(new Error(`MITM broker emitted invalid ready payload: ${line}`)));
+			} catch (error) {
+				settle(() => reject(error));
+			}
+		});
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk;
+		});
+		child.once("error", (error) => {
+			settle(() => reject(error));
+		});
+		child.once("close", (code, signal) => {
+			const detail = [stderr.trim(), stdout.trim()].filter(Boolean).join("\n");
+			settle(() =>
+				reject(
+					new Error(`MITM broker exited before ready: code=${code} signal=${signal}\n${detail}`),
+				),
+			);
+		});
+	});
+}
+
+function stopChild(child: ChildProcessByStdio<null, Readable, Readable>): Promise<void> {
+	return new Promise((resolve) => {
+		if (child.exitCode !== null) {
+			resolve();
+			return;
+		}
+		const timer = setTimeout(() => {
+			child.kill("SIGKILL");
+			resolve();
+		}, 2_000);
+		child.once("exit", () => {
+			clearTimeout(timer);
+			resolve();
+		});
+		child.kill("SIGTERM");
+	});
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/cli/src/runtime/mitm-env.ts
+++ b/packages/cli/src/runtime/mitm-env.ts
@@ -1,0 +1,145 @@
+import { join } from "node:path";
+
+export const mitmBrokerEnvKeys = [
+	"CLAWDI_MITM_ENABLED",
+	"CLAWDI_MITM_PROFILE_BUNDLE",
+	"CLAWDI_MITM_PROXY_URL",
+	"CLAWDI_MITM_PROXY_HOST",
+	"CLAWDI_MITM_PROXY_PORT",
+	"CLAWDI_MITM_CA_FILE",
+	"CLAWDI_MITM_CA_PATH",
+	"CLAWDI_MITM_SECRET_FILE",
+	"CLAWDI_MITM_BROKER_PATH",
+	"CLAWDI_MITM_BROKER_BUNDLE",
+	"CLAWDI_MITM_ALLOW_REMOTE_PROXY",
+	"HTTPS_PROXY",
+	"HTTP_PROXY",
+	"NO_PROXY",
+	"NODE_USE_ENV_PROXY",
+	"OPENCLAW_PROXY_URL",
+	"SSL_CERT_FILE",
+	"SSL_CERT_DIR",
+	"NODE_EXTRA_CA_CERTS",
+	"REQUESTS_CA_BUNDLE",
+	"CURL_CA_BUNDLE",
+	"GIT_SSL_CAINFO",
+	"DENO_CERT",
+	"CODEX_CA_CERTIFICATE",
+	"http_proxy",
+	"https_proxy",
+	"no_proxy",
+] as const;
+
+export interface MitmBrokerEnvInput {
+	env: NodeJS.ProcessEnv;
+	profileBundlePath: string | null;
+	proxyUrl?: string;
+	caPath?: string;
+	secretFile?: string;
+}
+
+export function buildMitmBrokerEnv(input: MitmBrokerEnvInput): NodeJS.ProcessEnv {
+	if (!input.profileBundlePath) return { ...input.env };
+
+	const env = stripMitmBrokerEnv(input.env);
+	const proxyUrl = input.proxyUrl ?? resolveProxyUrl(input.env);
+	const caPath = input.caPath ?? resolveCaPath(input.env);
+	const secretFile = input.secretFile ?? resolveSecretFile(input.env);
+
+	env.CLAWDI_MITM_ENABLED = "1";
+	env.CLAWDI_MITM_PROFILE_BUNDLE = input.profileBundlePath;
+	env.CLAWDI_MITM_PROXY_URL = proxyUrl;
+	env.CLAWDI_MITM_CA_FILE = caPath;
+	env.CLAWDI_MITM_SECRET_FILE = secretFile;
+	env.HTTPS_PROXY = proxyUrl;
+	env.HTTP_PROXY = proxyUrl;
+	env.https_proxy = proxyUrl;
+	env.http_proxy = proxyUrl;
+	env.NO_PROXY = buildNoProxy(proxyUrl);
+	env.no_proxy = env.NO_PROXY;
+	env.NODE_USE_ENV_PROXY = "1";
+	env.OPENCLAW_PROXY_URL = proxyUrl;
+	env.SSL_CERT_FILE = caPath;
+	env.NODE_EXTRA_CA_CERTS = caPath;
+	env.REQUESTS_CA_BUNDLE = caPath;
+	env.CURL_CA_BUNDLE = caPath;
+	env.GIT_SSL_CAINFO = caPath;
+	env.DENO_CERT = caPath;
+	env.CODEX_CA_CERTIFICATE = caPath;
+
+	return env;
+}
+
+export function stripMitmBrokerEnv(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = { ...source };
+	for (const key of mitmBrokerEnvKeys) {
+		delete env[key];
+	}
+	return env;
+}
+
+export function stripMitmBrokerControlEnv(env: NodeJS.ProcessEnv): void {
+	for (const key of Object.keys(env)) {
+		if (key.startsWith("CLAWDI_MITM_")) delete env[key];
+	}
+}
+
+export function applyMitmBrokerRuntimeEnv(
+	env: NodeJS.ProcessEnv,
+	output: { proxyUrl: string; caFile: string },
+): void {
+	env.CLAWDI_MITM_PROXY_URL = output.proxyUrl;
+	env.HTTPS_PROXY = output.proxyUrl;
+	env.HTTP_PROXY = output.proxyUrl;
+	env.https_proxy = output.proxyUrl;
+	env.http_proxy = output.proxyUrl;
+	env.NO_PROXY = buildNoProxy(output.proxyUrl);
+	env.no_proxy = env.NO_PROXY;
+	env.OPENCLAW_PROXY_URL = output.proxyUrl;
+	env.CLAWDI_MITM_CA_FILE = output.caFile;
+	env.SSL_CERT_FILE = output.caFile;
+	env.NODE_EXTRA_CA_CERTS = output.caFile;
+	env.REQUESTS_CA_BUNDLE = output.caFile;
+	env.CURL_CA_BUNDLE = output.caFile;
+	env.GIT_SSL_CAINFO = output.caFile;
+	env.DENO_CERT = output.caFile;
+	env.CODEX_CA_CERTIFICATE = output.caFile;
+}
+
+function resolveProxyUrl(env: NodeJS.ProcessEnv): string {
+	const explicit = env.CLAWDI_MITM_PROXY_URL?.trim();
+	if (explicit) return explicit;
+	const port = env.CLAWDI_MITM_PROXY_PORT?.trim() || "0";
+	const host = env.CLAWDI_MITM_PROXY_HOST?.trim() || "127.0.0.1";
+	return `http://${host}:${port}`;
+}
+
+function resolveCaPath(env: NodeJS.ProcessEnv): string {
+	return (
+		env.CLAWDI_MITM_CA_FILE?.trim() ||
+		env.CLAWDI_MITM_CA_PATH?.trim() ||
+		(env.CLAWDI_RUN_DIR?.trim() ? join(env.CLAWDI_RUN_DIR.trim(), "mitm", "ca.pem") : undefined) ||
+		join("/run/clawdi", "mitm", "ca.pem")
+	);
+}
+
+function resolveSecretFile(env: NodeJS.ProcessEnv): string {
+	return (
+		env.CLAWDI_MITM_SECRET_FILE?.trim() ||
+		(env.CLAWDI_RUN_DIR?.trim()
+			? join(env.CLAWDI_RUN_DIR.trim(), "mitm", "secrets.json")
+			: undefined) ||
+		join("/run/clawdi", "mitm", "secrets.json")
+	);
+}
+
+function buildNoProxy(proxyUrl: string): string {
+	const base = ["localhost", "127.0.0.1", "::1"];
+	try {
+		const host = new URL(proxyUrl).hostname;
+		if (host && !base.includes(host)) base.push(host);
+	} catch {
+		// Leave the default localhost bypass list.
+	}
+	return base.join(",");
+}

--- a/packages/cli/src/runtime/mitm-profiles.ts
+++ b/packages/cli/src/runtime/mitm-profiles.ts
@@ -1,0 +1,246 @@
+import { z } from "zod";
+import { writePrivateFileAtomic } from "../lib/private-file";
+import type { RuntimePaths } from "./paths";
+
+const secretRefSchema = z
+	.string()
+	.min(1)
+	.regex(/^secret:\/\//);
+const profileIdSchema = z
+	.string()
+	.min(1)
+	.regex(/^[a-z0-9][a-z0-9-_.]*$/);
+const headerNameSchema = z
+	.string()
+	.min(1)
+	.regex(/^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/);
+const queryNameSchema = z.string().min(1);
+
+function isSafeMitmHost(host: string): boolean {
+	if (!host || host.length > 253) return false;
+	for (const char of host) {
+		const code = char.charCodeAt(0);
+		if (
+			char === "@" ||
+			char === "?" ||
+			char === "#" ||
+			char === "/" ||
+			char === "\\" ||
+			char === " " ||
+			char === "%" ||
+			code < 0x20 ||
+			code === 0x7f
+		) {
+			return false;
+		}
+	}
+	return !host.startsWith(".") && !host.endsWith(".");
+}
+
+function isSafeUpstreamBaseUrl(value: string): boolean {
+	try {
+		const parsed = new URL(value);
+		return (
+			["http:", "https:", "ws:", "wss:"].includes(parsed.protocol) &&
+			parsed.username === "" &&
+			parsed.password === "" &&
+			isSafeMitmHost(parsed.hostname.toLowerCase())
+		);
+	} catch {
+		return false;
+	}
+}
+
+const headerMatcherSchema = z
+	.discriminatedUnion("type", [
+		z
+			.object({
+				type: z.literal("exists"),
+			})
+			.strict(),
+		z
+			.object({
+				type: z.literal("equals"),
+				value: z.string(),
+				prefix: z.string().optional(),
+			})
+			.strict(),
+		z
+			.object({
+				type: z.literal("secretRefEquals"),
+				secretRef: secretRefSchema,
+				prefix: z.string().optional(),
+			})
+			.strict(),
+	])
+	.describe(
+		"Header matchers must never inline secret values unless type=equals is intentionally public.",
+	);
+
+const pathMatcherSchema = z
+	.discriminatedUnion("type", [
+		z
+			.object({
+				type: z.literal("equals"),
+				value: z.string().min(1),
+			})
+			.strict(),
+		z
+			.object({
+				type: z.literal("prefix"),
+				value: z.string().min(1),
+			})
+			.strict(),
+		z
+			.object({
+				type: z.literal("secretRefEquals"),
+				secretRef: secretRefSchema,
+				prefix: z.string().default(""),
+				suffix: z.string().default(""),
+			})
+			.strict(),
+		z
+			.object({
+				type: z.literal("secretRefPrefix"),
+				secretRef: secretRefSchema,
+				prefix: z.string().default(""),
+				suffix: z.string().default(""),
+			})
+			.strict(),
+	])
+	.describe("Path matchers allow URL-embedded tokens such as Telegram Bot API tokens.");
+
+const headerSetterSchema = z
+	.union([
+		z.string(),
+		z
+			.object({
+				type: z.literal("secretRef"),
+				secretRef: secretRefSchema,
+				prefix: z.string().default(""),
+			})
+			.strict(),
+	])
+	.describe(
+		"Rewrite headers can be literal public values or secretRef-backed values resolved only by the broker.",
+	);
+
+const mitmProfileMatchSchema = z
+	.object({
+		scheme: z.enum(["http", "https", "ws", "wss"]).optional(),
+		host: z.string().min(1),
+		pathPrefix: z
+			.string()
+			.min(1)
+			.refine((value) => value.startsWith("/"), "pathPrefix must start with /")
+			.optional(),
+		path: pathMatcherSchema.optional(),
+		headers: z.record(headerNameSchema, headerMatcherSchema).default({}),
+		query: z.record(queryNameSchema, headerMatcherSchema).default({}),
+	})
+	.strict();
+
+const mitmProfileRewriteSchema = z
+	.object({
+		upstreamBaseUrl: z
+			.string()
+			.url()
+			.refine(
+				(value) => ["http:", "https:", "ws:", "wss:"].includes(new URL(value).protocol),
+				"upstreamBaseUrl must use http, https, ws, or wss",
+			)
+			.refine(
+				isSafeUpstreamBaseUrl,
+				"upstreamBaseUrl must not include credentials or an unsafe host",
+			)
+			.optional(),
+		preservePath: z.boolean().default(true),
+		setHeaders: z.record(headerNameSchema, headerSetterSchema).default({}),
+	})
+	.strict();
+
+const mitmProfileLoggingSchema = z
+	.object({
+		redactHeaders: z.array(headerNameSchema).default([]),
+		redactUrlPatterns: z.array(z.string().min(1)).default([]),
+	})
+	.strict();
+
+export const mitmProfileSchema = z
+	.object({
+		id: profileIdSchema,
+		enabled: z.boolean().default(true),
+		kind: z.enum(["http", "websocket", "provider", "deny"]),
+		match: mitmProfileMatchSchema,
+		rewrite: mitmProfileRewriteSchema.optional(),
+		logging: mitmProfileLoggingSchema.default({ redactHeaders: [], redactUrlPatterns: [] }),
+		priority: z.number().int().default(100),
+		owner: z.string().min(1).optional(),
+		description: z.string().min(1).optional(),
+	})
+	.strict()
+	.superRefine((profile, ctx) => {
+		if (
+			(profile.kind === "http" || profile.kind === "websocket" || profile.kind === "provider") &&
+			!profile.rewrite?.upstreamBaseUrl
+		) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["rewrite", "upstreamBaseUrl"],
+				message: `${profile.kind} profiles require rewrite.upstreamBaseUrl`,
+			});
+		}
+		if (profile.kind === "deny" && profile.rewrite) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["rewrite"],
+				message: "deny profiles must not include rewrite rules",
+			});
+		}
+	});
+
+export const mitmProfileInputBundleSchema = z
+	.object({
+		profiles: z.array(mitmProfileSchema).default([]),
+	})
+	.strict();
+
+export const mitmProfileBundleSchema = z
+	.object({
+		schemaVersion: z.literal("clawdi.mitmProfiles.v1"),
+		generatedAt: z.string().min(1),
+		generation: z.number().int().nonnegative(),
+		instanceId: z.string().min(1),
+		profiles: z.array(mitmProfileSchema),
+	})
+	.strict();
+
+export type MitmProfileInputBundle = z.infer<typeof mitmProfileInputBundleSchema>;
+export type MitmProfileBundle = z.infer<typeof mitmProfileBundleSchema>;
+
+export function buildMitmProfileBundle(input: {
+	generatedAt: string;
+	generation: number;
+	instanceId: string;
+	profiles?: MitmProfileInputBundle;
+}): MitmProfileBundle {
+	return {
+		schemaVersion: "clawdi.mitmProfiles.v1",
+		generatedAt: input.generatedAt,
+		generation: input.generation,
+		instanceId: input.instanceId,
+		profiles: input.profiles?.profiles ?? [],
+	};
+}
+
+export function hasEnabledMitmProfiles(bundle: MitmProfileBundle): boolean {
+	return bundle.profiles.some((profile) => profile.enabled);
+}
+
+export function writeMitmProfileBundle(bundle: MitmProfileBundle, paths: RuntimePaths): string {
+	writePrivateFileAtomic(paths.mitmProfileBundle, `${JSON.stringify(bundle, null, 2)}\n`, {
+		mode: 0o644,
+		dirMode: 0o755,
+	});
+	return paths.mitmProfileBundle;
+}

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -1,0 +1,131 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { getClawdiDir } from "../lib/config";
+
+export type RuntimeMode = "local" | "hosted";
+
+export interface RuntimePaths {
+	mode: RuntimeMode;
+	userHome: string;
+	clawdiHome: string;
+	localConfig: string;
+	localAuth: string;
+	localPendingAuth: string;
+	localEnvironments: string;
+	serveState: string;
+	imageShim: string;
+	hostPolicy: string;
+	runtimeSource: string;
+	shareRoot: string;
+	serviceStateRoot: string;
+	managedConfig: string;
+	syncState: string;
+	cliShim: string;
+	cliManagedBin: string;
+	cliNpmPrefix: string;
+	cliNpmCache: string;
+	cliBootstrapStatus: string;
+	cacheRoot: string;
+	manifestLastGood: string;
+	runConfigRoot: string;
+	mitmProfileRoot: string;
+	mitmProfileBundle: string;
+	supervisorRoot: string;
+	supervisorConfig: string;
+	bootRoot: string;
+	bootStatus: string;
+	cloudStatus: string;
+	cloudResult: string;
+	instanceRoot: string;
+	installInventory: string;
+	projectionRoot: string;
+	runRoot: string;
+	instanceData: string;
+	sensitiveInstanceData: string;
+	workspaceRoot: string;
+}
+
+function envPath(name: string): string | undefined {
+	const value = process.env[name]?.trim();
+	return value ? value : undefined;
+}
+
+function defaultHome(mode: RuntimeMode): string {
+	if (mode === "hosted") {
+		return envPath("CLAWDI_RUNTIME_HOME") ?? process.env.HOME ?? "/home/clawdi";
+	}
+	return process.env.HOME || homedir();
+}
+
+export function getHostPolicyPath(): string {
+	return envPath("CLAWDI_HOST_POLICY_PATH") ?? "/etc/clawdi/host-policy.json";
+}
+
+export function getRuntimeSourcePath(): string {
+	return envPath("CLAWDI_RUNTIME_SOURCE_PATH") ?? "/etc/clawdi/runtime-source.json";
+}
+
+export function detectRuntimeMode(): RuntimeMode {
+	const explicit = process.env.CLAWDI_RUNTIME_MODE?.trim().toLowerCase();
+	if (explicit === "hosted" || explicit === "hosted-runtime") return "hosted";
+	if (explicit === "local") return "local";
+	if (existsSync(getHostPolicyPath())) return "hosted";
+	return "local";
+}
+
+export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths {
+	const mode = opts.mode ?? detectRuntimeMode();
+	const userHome = defaultHome(mode);
+	const clawdiHome = getClawdiDir();
+	const serviceStateRoot = envPath("CLAWDI_SERVICE_STATE_DIR") ?? "/var/lib/clawdi";
+	const runRoot = envPath("CLAWDI_RUN_DIR") ?? "/run/clawdi";
+	const imageShim = envPath("CLAWDI_IMAGE_SHIM_PATH") ?? "/usr/local/bin/clawdi";
+	const shareRoot = envPath("CLAWDI_SHARE_DIR") ?? "/usr/share/clawdi";
+	const binRoot = join(serviceStateRoot, "bin");
+	const npmRoot = join(serviceStateRoot, "npm");
+	const cacheRoot = join(serviceStateRoot, "cache");
+	const bootRoot = join(serviceStateRoot, "boot");
+	const instanceRoot = join(serviceStateRoot, "instances");
+
+	return {
+		mode,
+		userHome,
+		clawdiHome,
+		localConfig: join(clawdiHome, "config.json"),
+		localAuth: join(clawdiHome, "auth.json"),
+		localPendingAuth: join(clawdiHome, "pending-auth.json"),
+		localEnvironments: join(clawdiHome, "environments"),
+		serveState: join(clawdiHome, "serve"),
+		imageShim,
+		hostPolicy: getHostPolicyPath(),
+		runtimeSource: getRuntimeSourcePath(),
+		shareRoot,
+		serviceStateRoot,
+		managedConfig: join(serviceStateRoot, "config", "clawdi.json"),
+		syncState: join(serviceStateRoot, "sync", "runtimes.json"),
+		cliShim: imageShim,
+		cliManagedBin: join(binRoot, "clawdi"),
+		cliNpmPrefix: npmRoot,
+		cliNpmCache: join(serviceStateRoot, "npm-cache"),
+		cliBootstrapStatus: join(serviceStateRoot, "status", "cli-bootstrap.json"),
+		cacheRoot,
+		manifestLastGood: join(cacheRoot, "manifest.last-good.json"),
+		runConfigRoot: join(serviceStateRoot, "config", "run"),
+		mitmProfileRoot: join(serviceStateRoot, "config", "mitm"),
+		mitmProfileBundle: join(serviceStateRoot, "config", "mitm", "profiles.json"),
+		supervisorRoot: join(serviceStateRoot, "supervisor"),
+		supervisorConfig: join(serviceStateRoot, "supervisor", "supervisord.conf"),
+		bootRoot,
+		bootStatus: join(cacheRoot, "boot-status.json"),
+		cloudStatus: join(bootRoot, "status.json"),
+		cloudResult: join(bootRoot, "result.json"),
+		instanceRoot,
+		installInventory: join(serviceStateRoot, "install-inventory"),
+		projectionRoot: join(serviceStateRoot, "config", "projections"),
+		runRoot,
+		instanceData: join(runRoot, "instance-data.json"),
+		sensitiveInstanceData: join(runRoot, "instance-data-sensitive.json"),
+		workspaceRoot: join(userHome, "clawdi"),
+	};
+}

--- a/packages/cli/src/runtime/run-config.ts
+++ b/packages/cli/src/runtime/run-config.ts
@@ -1,0 +1,185 @@
+import { existsSync, readFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { z } from "zod";
+import { writePrivateFileAtomic } from "../lib/private-file";
+import { buildMitmBrokerEnv } from "./mitm-env";
+import type { RuntimePaths } from "./paths";
+import { getRuntimePaths } from "./paths";
+
+const supportedRuntimeSchema = z.enum(["hermes", "openclaw"]);
+export type SupportedRuntimeName = z.infer<typeof supportedRuntimeSchema>;
+
+const envKeySchema = z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/);
+
+export const runtimeRunSettingsSchema = z
+	.object({
+		command: z.string().min(1).optional(),
+		args: z.array(z.string()).default([]),
+		env: z.record(envKeySchema, z.string()).default({}),
+		cwd: z.string().min(1).optional(),
+		prependPath: z.array(z.string().min(1)).default([]),
+	})
+	.strict();
+
+export type RuntimeRunSettings = z.infer<typeof runtimeRunSettingsSchema>;
+
+const runtimeRunConfigSchema = z
+	.object({
+		schemaVersion: z.literal("clawdi.runtimeRunConfig.v1"),
+		runtime: supportedRuntimeSchema,
+		enabled: z.boolean(),
+		generatedAt: z.string().min(1),
+		generation: z.number().int().nonnegative(),
+		instanceId: z.string().min(1),
+		command: z.string().min(1),
+		defaultArgs: z.array(z.string()).default([]),
+		env: z.record(envKeySchema, z.string()).default({}),
+		prependPath: z.array(z.string().min(1)).default([]),
+		cwd: z.string().min(1).optional(),
+		commandPath: z.string().min(1).nullable(),
+		appRoot: z.string().min(1).nullable(),
+		mitmProfileBundlePath: z.string().min(1).nullable().default(null),
+	})
+	.strict();
+
+export type RuntimeRunConfig = z.infer<typeof runtimeRunConfigSchema>;
+
+const DEFAULT_RUNTIME_ARGS: Record<SupportedRuntimeName, string[]> = {
+	hermes: ["gateway", "run"],
+	openclaw: [
+		"gateway",
+		"run",
+		"--allow-unconfigured",
+		"--auth",
+		"none",
+		"--bind",
+		"loopback",
+		"--force",
+	],
+};
+
+export type RuntimeRunConfigRead =
+	| { status: "not-runtime"; runtime: null }
+	| { status: "missing"; runtime: SupportedRuntimeName; path: string }
+	| { status: "invalid"; runtime: SupportedRuntimeName; path: string; error: string }
+	| { status: "disabled"; runtime: SupportedRuntimeName; path: string; config: RuntimeRunConfig }
+	| { status: "ok"; runtime: SupportedRuntimeName; path: string; config: RuntimeRunConfig };
+
+export interface RuntimeRunInvocation {
+	runtime: string;
+	command: string;
+	args: string[];
+	cwd?: string;
+	env: NodeJS.ProcessEnv;
+	configPath: string;
+}
+
+export function runtimeNameForCommand(command: string): SupportedRuntimeName | null {
+	const name = basename(command);
+	const parsed = supportedRuntimeSchema.safeParse(name);
+	return parsed.success ? parsed.data : null;
+}
+
+export function runtimeRunConfigPath(
+	runtime: SupportedRuntimeName,
+	paths = getRuntimePaths(),
+): string {
+	return join(paths.runConfigRoot, `${runtime}.json`);
+}
+
+export function buildRuntimeRunConfig(input: {
+	runtime: SupportedRuntimeName;
+	enabled: boolean;
+	generatedAt: string;
+	generation: number;
+	instanceId: string;
+	commandPath: string | null;
+	appRoot: string | null;
+	workspaceRoot: string;
+	mitmProfileBundlePath?: string | null;
+	settings?: RuntimeRunSettings;
+}): RuntimeRunConfig {
+	const defaultPath = input.commandPath ? [dirname(input.commandPath)] : [];
+	const prependPath = [...defaultPath, ...(input.settings?.prependPath ?? [])].filter(
+		(value, index, values) => values.indexOf(value) === index,
+	);
+	return {
+		schemaVersion: "clawdi.runtimeRunConfig.v1",
+		runtime: input.runtime,
+		enabled: input.enabled,
+		generatedAt: input.generatedAt,
+		generation: input.generation,
+		instanceId: input.instanceId,
+		command: input.settings?.command ?? input.commandPath ?? input.runtime,
+		defaultArgs: input.settings?.args ?? DEFAULT_RUNTIME_ARGS[input.runtime],
+		env: input.settings?.env ?? {},
+		prependPath,
+		cwd: input.settings?.cwd ?? input.workspaceRoot,
+		commandPath: input.commandPath,
+		appRoot: input.appRoot,
+		mitmProfileBundlePath: input.mitmProfileBundlePath ?? null,
+	};
+}
+
+export function writeRuntimeRunConfig(config: RuntimeRunConfig, paths: RuntimePaths): string {
+	const path = runtimeRunConfigPath(config.runtime, paths);
+	writePrivateFileAtomic(path, `${JSON.stringify(config, null, 2)}\n`, {
+		mode: 0o644,
+		dirMode: 0o755,
+	});
+	return path;
+}
+
+export function readRuntimeRunConfigForCommand(
+	command: string,
+	paths = getRuntimePaths(),
+): RuntimeRunConfigRead {
+	const runtime = runtimeNameForCommand(command);
+	if (!runtime) return { status: "not-runtime", runtime: null };
+
+	const path = runtimeRunConfigPath(runtime, paths);
+	if (!existsSync(path)) return { status: "missing", runtime, path };
+
+	try {
+		const parsed = runtimeRunConfigSchema.parse(JSON.parse(readFileSync(path, "utf8")));
+		if (!parsed.enabled) return { status: "disabled", runtime, path, config: parsed };
+		return { status: "ok", runtime, path, config: parsed };
+	} catch (error) {
+		return {
+			status: "invalid",
+			runtime,
+			path,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+export function buildRuntimeRunInvocation(
+	read: Extract<RuntimeRunConfigRead, { status: "ok" }>,
+	args: string[],
+	baseEnv: NodeJS.ProcessEnv,
+): RuntimeRunInvocation {
+	const pathPrefix = read.config.prependPath.join(":");
+	const currentPath = baseEnv.PATH ?? "";
+	const env = {
+		...baseEnv,
+		...read.config.env,
+		PATH: pathPrefix ? [pathPrefix, currentPath].filter(Boolean).join(":") : currentPath,
+	};
+	const brokerEnv = buildMitmBrokerEnv({
+		env,
+		profileBundlePath: read.config.mitmProfileBundlePath,
+	});
+	const command =
+		read.config.commandPath && existsSync(read.config.commandPath)
+			? read.config.commandPath
+			: read.config.command;
+	return {
+		runtime: read.runtime,
+		command,
+		args: [...read.config.defaultArgs, ...args.slice(1)],
+		cwd: read.config.cwd,
+		env: brokerEnv,
+		configPath: read.path,
+	};
+}

--- a/packages/cli/src/runtime/state.ts
+++ b/packages/cli/src/runtime/state.ts
@@ -1,0 +1,254 @@
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import type { HostPolicyReadResult } from "./host-policy";
+import type { RuntimePaths } from "./paths";
+import { getRuntimePaths } from "./paths";
+
+export type RuntimeBootMode = "normal" | "degraded-offline" | "manifest-rejected" | "repair";
+export type RuntimeBootStage = "detect" | "local" | "network" | "config" | "final";
+
+export interface RuntimeBootStatus {
+	schemaVersion: "clawdi.runtimeBootStatus.v1";
+	mode: RuntimeBootMode;
+	status: "ok" | "error";
+	stage: RuntimeBootStage;
+	timestamp: string;
+	bootId: string;
+	runtimeMode: "local" | "hosted";
+	activeGeneration: number | null;
+	rejectedGeneration?: number | null;
+	instanceId?: string | null;
+	enabledRuntimes: string[];
+	manifestSource?: {
+		type: "fixture-file" | "remote-datasource" | "last-good-cache";
+		path: string;
+		offline: boolean;
+	};
+	convergence?: {
+		workspaceRoot: string;
+		managedConfig: string;
+		syncState: string;
+		instanceData: string;
+		sensitiveInstanceData: string;
+		manifestLastGood: string | null;
+		installInventory: string[];
+		projections: string[];
+		runConfigs: string[];
+		supervisorConfig: string;
+		mitmProfileBundle: string | null;
+		mitmSecretFile: string | null;
+		liveSyncEnvironments: string[];
+		daemonAuthTokenFile: string | null;
+		instanceSemaphores: string[];
+		bootFinished: string;
+	};
+	error?: string;
+	errors: string[];
+	exitCode: number;
+	datasource: "RuntimeSource";
+	hostPolicy: {
+		path: string;
+		exists: boolean;
+		valid: boolean;
+		mode?: string;
+		cliUpdateMode?: string;
+		error?: string;
+	};
+	paths: {
+		hostPolicy: string;
+		runtimeSource: string;
+		serviceStateRoot: string;
+		managedConfig: string;
+		syncState: string;
+		manifestLastGood: string;
+		runConfigRoot: string;
+		mitmProfileRoot: string;
+		mitmProfileBundle: string;
+		supervisorRoot: string;
+		supervisorConfig: string;
+		cliManagedBin: string;
+		cliNpmPrefix: string;
+		cliBootstrapStatus: string;
+		bootStatus: string;
+		cloudStatus: string;
+		cloudResult: string;
+		runRoot: string;
+		instanceData: string;
+		sensitiveInstanceData: string;
+		projectionRoot: string;
+		userHome: string;
+		workspaceRoot: string;
+	};
+}
+
+export interface RuntimeStatusRead {
+	exists: boolean;
+	source?: string;
+	status?: RuntimeBootStatus;
+	cloudStatus?: unknown;
+	cloudResult?: unknown;
+	error?: string;
+}
+
+function pathSummary(paths: RuntimePaths): RuntimeBootStatus["paths"] {
+	return {
+		hostPolicy: paths.hostPolicy,
+		runtimeSource: paths.runtimeSource,
+		serviceStateRoot: paths.serviceStateRoot,
+		managedConfig: paths.managedConfig,
+		syncState: paths.syncState,
+		manifestLastGood: paths.manifestLastGood,
+		runConfigRoot: paths.runConfigRoot,
+		mitmProfileRoot: paths.mitmProfileRoot,
+		mitmProfileBundle: paths.mitmProfileBundle,
+		supervisorRoot: paths.supervisorRoot,
+		supervisorConfig: paths.supervisorConfig,
+		cliManagedBin: paths.cliManagedBin,
+		cliNpmPrefix: paths.cliNpmPrefix,
+		cliBootstrapStatus: paths.cliBootstrapStatus,
+		bootStatus: paths.bootStatus,
+		cloudStatus: paths.cloudStatus,
+		cloudResult: paths.cloudResult,
+		runRoot: paths.runRoot,
+		instanceData: paths.instanceData,
+		sensitiveInstanceData: paths.sensitiveInstanceData,
+		projectionRoot: paths.projectionRoot,
+		userHome: paths.userHome,
+		workspaceRoot: paths.workspaceRoot,
+	};
+}
+
+export function buildRuntimeBootStatus(
+	partial: Omit<RuntimeBootStatus, "schemaVersion" | "timestamp" | "paths"> & {
+		timestamp?: string;
+		paths?: RuntimeBootStatus["paths"];
+	},
+	paths = getRuntimePaths(),
+): RuntimeBootStatus {
+	return {
+		schemaVersion: "clawdi.runtimeBootStatus.v1",
+		timestamp: partial.timestamp ?? new Date().toISOString(),
+		paths: partial.paths ?? pathSummary(paths),
+		...partial,
+	};
+}
+
+export function hostPolicySummary(policy: HostPolicyReadResult): RuntimeBootStatus["hostPolicy"] {
+	return {
+		path: policy.path,
+		exists: policy.exists,
+		valid: policy.valid,
+		mode: policy.policy?.mode,
+		cliUpdateMode: policy.policy?.cliUpdateMode,
+		error: policy.error,
+	};
+}
+
+function writeJson(path: string, data: unknown, mode = 0o600): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, { mode });
+	try {
+		chmodSync(path, mode);
+	} catch {
+		// Best effort on filesystems without POSIX mode support.
+	}
+}
+
+export function ensureRuntimeStateDirs(paths = getRuntimePaths()): void {
+	for (const dir of [
+		paths.cacheRoot,
+		paths.bootRoot,
+		paths.instanceRoot,
+		paths.installInventory,
+		paths.projectionRoot,
+		paths.runConfigRoot,
+		paths.mitmProfileRoot,
+		paths.supervisorRoot,
+		dirname(paths.managedConfig),
+		dirname(paths.syncState),
+		paths.runRoot,
+	]) {
+		mkdirSync(dir, { recursive: true });
+	}
+}
+
+export function writeRuntimeBootStatus(status: RuntimeBootStatus, paths = getRuntimePaths()): void {
+	writeJson(paths.bootStatus, status, 0o644);
+	writeJson(
+		paths.cloudStatus,
+		{
+			v1: {
+				datasource: status.datasource,
+				status: status.status,
+				extended_status: status.mode,
+				stage: status.stage,
+				boot_id: status.bootId,
+				timestamp: status.timestamp,
+				errors: status.errors,
+			},
+		},
+		0o644,
+	);
+	writeJson(
+		paths.cloudResult,
+		{
+			v1: {
+				datasource: status.datasource,
+				status: status.status,
+				mode: status.mode,
+				stage: status.stage,
+				exit_code: status.exitCode,
+				boot_id: status.bootId,
+				active_generation: status.activeGeneration,
+				rejected_generation: status.rejectedGeneration ?? null,
+				instance_id: status.instanceId ?? null,
+				errors: status.errors,
+			},
+		},
+		0o644,
+	);
+}
+
+function readJson<T>(path: string): T {
+	return JSON.parse(readFileSync(path, "utf-8")) as T;
+}
+
+export function readRuntimeBootStatus(paths = getRuntimePaths()): RuntimeStatusRead {
+	const read: RuntimeStatusRead = { exists: false };
+
+	if (existsSync(paths.bootStatus)) {
+		try {
+			read.exists = true;
+			read.source = paths.bootStatus;
+			read.status = readJson<RuntimeBootStatus>(paths.bootStatus);
+		} catch (e) {
+			return {
+				exists: true,
+				source: paths.bootStatus,
+				error: e instanceof Error ? e.message : String(e),
+			};
+		}
+	}
+
+	if (existsSync(paths.cloudStatus)) {
+		try {
+			read.exists = true;
+			read.cloudStatus = readJson<unknown>(paths.cloudStatus);
+		} catch (e) {
+			read.error = e instanceof Error ? e.message : String(e);
+			read.source = paths.cloudStatus;
+		}
+	}
+
+	if (existsSync(paths.cloudResult)) {
+		try {
+			read.exists = true;
+			read.cloudResult = readJson<unknown>(paths.cloudResult);
+		} catch (e) {
+			read.error = e instanceof Error ? e.message : String(e);
+			read.source = paths.cloudResult;
+		}
+	}
+
+	return read;
+}

--- a/packages/cli/src/serve/control-rpc.test.ts
+++ b/packages/cli/src/serve/control-rpc.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import {
 	chmodSync,
 	mkdirSync,
@@ -12,82 +12,58 @@ import { request } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import {
+	type ControlRpcHandlers,
+	type ControlRpcListenConfig,
 	callControlRpc,
 	isLoopbackRpcHost,
-	rotateControlToken,
 	startControlRpcServer,
 } from "./control-rpc";
-import { getDaemonControlTokenPath } from "./paths";
 
 if (process.platform !== "win32") {
 	describe("control RPC", () => {
-		const originalClawdiHome = process.env.CLAWDI_HOME;
-		const originalStateDir = process.env.CLAWDI_STATE_DIR;
-		let tmpHome: string;
-		let abort: AbortController;
-		let closeServer: (() => Promise<void>) | undefined;
-
-		beforeEach(() => {
-			tmpHome = mkdtempSync(join(tmpdir(), "clawdi-control-rpc-"));
-			process.env.CLAWDI_HOME = join(tmpHome, ".clawdi");
-			delete process.env.CLAWDI_STATE_DIR;
-			abort = new AbortController();
-			closeServer = undefined;
-		});
-
-		afterEach(async () => {
-			abort.abort();
-			await closeServer?.();
-			if (originalClawdiHome === undefined) delete process.env.CLAWDI_HOME;
-			else process.env.CLAWDI_HOME = originalClawdiHome;
-			if (originalStateDir === undefined) delete process.env.CLAWDI_STATE_DIR;
-			else process.env.CLAWDI_STATE_DIR = originalStateDir;
-			rmSync(tmpHome, { recursive: true, force: true });
-		});
-
 		it("serves JSON-RPC methods over HTTP", async () => {
-			const server = await startControlRpcServer(
-				{
+			await withRpcFixture(async ({ start }) => {
+				const server = await start({
 					echo: (params) => ({ params }),
-				},
-				abort.signal,
-				{ port: 0 },
-			);
-			closeServer = server.close;
+				});
 
-			const result = await callControlRpc("echo", { ok: true }, server.http);
+				const result = await callControlRpc("echo", { ok: true }, rpcClient(server));
 
-			expect(result).toEqual({ params: { ok: true } });
+				expect(result).toEqual({ params: { ok: true } });
+			});
 		});
 
 		it("returns JSON-RPC errors for unknown methods", async () => {
-			const server = await startControlRpcServer({}, abort.signal, { port: 0 });
-			closeServer = server.close;
+			await withRpcFixture(async ({ start }) => {
+				const server = await start({});
 
-			await expect(callControlRpc("missing", {}, server.http)).rejects.toThrow(
-				"Unknown RPC method: missing",
-			);
+				await expect(callControlRpc("missing", {}, rpcClient(server))).rejects.toThrow(
+					"Unknown RPC method: missing",
+				);
+			});
 		});
 
 		it("serves HTTP RPC when a host and port are configured", async () => {
-			const server = await startControlRpcServer(
-				{
-					echo: (params) => ({ params }),
-				},
-				abort.signal,
-				{ host: "127.0.0.1", port: 0 },
-			);
-			closeServer = server.close;
+			await withRpcFixture(async ({ start }) => {
+				const server = await start(
+					{
+						echo: (params) => ({ params }),
+					},
+					{ host: "127.0.0.1", port: 0 },
+				);
 
-			const result = await callControlRpc("echo", { via: "http" }, server.http);
+				const result = await callControlRpc("echo", { via: "http" }, rpcClient(server));
 
-			expect(result).toEqual({ params: { via: "http" } });
+				expect(result).toEqual({ params: { via: "http" } });
+			});
 		});
 
 		it("rejects non-loopback HTTP listeners unless explicitly allowed", async () => {
-			await expect(
-				startControlRpcServer({}, abort.signal, { host: "0.0.0.0", port: 0 }),
-			).rejects.toThrow("Refusing to listen on non-loopback HTTP RPC host 0.0.0.0");
+			await withRpcFixture(async ({ start }) => {
+				await expect(start({}, { host: "0.0.0.0", port: 0 })).rejects.toThrow(
+					"Refusing to listen on non-loopback HTTP RPC host 0.0.0.0",
+				);
+			});
 		});
 
 		it("only treats numeric 127/8 hosts and localhost as loopback", () => {
@@ -100,116 +76,156 @@ if (process.platform !== "win32") {
 		});
 
 		it("requires a bearer token for HTTP RPC access", async () => {
-			const server = await startControlRpcServer(
-				{
-					echo: (params) => ({ params }),
-				},
-				abort.signal,
-				{ host: "127.0.0.1", port: 0 },
-			);
-			closeServer = server.close;
+			await withRpcFixture(async ({ start }) => {
+				const server = await start(
+					{
+						echo: (params) => ({ params }),
+					},
+					{ host: "127.0.0.1", port: 0 },
+				);
 
-			const response = await postWithoutToken(server.http.host, server.http.port);
+				const response = await postWithoutToken(server.http.host, server.http.port);
 
-			expect(response.statusCode).toBe(401);
-			expect(response.body).toContain("unauthorized");
+				expect(response.statusCode).toBe(401);
+				expect(response.body).toContain("unauthorized");
+			});
 		});
 
 		it("allows explicit RPC tokens for HTTP clients", async () => {
-			const server = await startControlRpcServer(
-				{
-					echo: (params) => ({ params }),
-				},
-				abort.signal,
-				{ host: "127.0.0.1", port: 0 },
-			);
-			closeServer = server.close;
-			const token = readFileSync(getDaemonControlTokenPath(), "utf-8").trim();
+			await withRpcFixture(async ({ start }) => {
+				const server = await start(
+					{
+						echo: (params) => ({ params }),
+					},
+					{ host: "127.0.0.1", port: 0 },
+				);
 
-			const result = await callControlRpc(
-				"echo",
-				{ token: "explicit" },
-				{
-					...server.http,
-					token,
-				},
-			);
+				const result = await callControlRpc("echo", { token: "explicit" }, rpcClient(server));
 
-			expect(result).toEqual({ params: { token: "explicit" } });
+				expect(result).toEqual({ params: { token: "explicit" } });
+			});
 		});
 
 		it("repairs existing token file permissions on startup", async () => {
-			const tokenPath = getDaemonControlTokenPath();
-			mkdirSync(dirname(tokenPath), { recursive: true });
-			writeFileSync(tokenPath, "fixed-token\n", { mode: 0o644 });
-			chmodSync(tokenPath, 0o644);
+			await withRpcFixture(async ({ controlDir, start }) => {
+				const tokenPath = join(controlDir, "control-token");
+				mkdirSync(dirname(tokenPath), { recursive: true });
+				writeFileSync(tokenPath, "fixed-token\n", { mode: 0o644 });
+				chmodSync(tokenPath, 0o644);
 
-			const server = await startControlRpcServer({}, abort.signal, { port: 0 });
-			closeServer = server.close;
+				await start({});
 
-			expect(statSync(tokenPath).mode & 0o777).toBe(0o600);
+				expect(statSync(tokenPath).mode & 0o777).toBe(0o600);
+			});
 		});
 
 		it("rotates the bearer token without restarting the server", async () => {
-			const server = await startControlRpcServer(
-				{
-					echo: (params) => ({ params }),
-					rotate_token: () => ({ token: rotateControlToken() }),
-				},
-				abort.signal,
-				{ host: "127.0.0.1", port: 0 },
-			);
-			closeServer = server.close;
-			const oldToken = readFileSync(getDaemonControlTokenPath(), "utf-8").trim();
+			await withRpcFixture(async ({ start }) => {
+				let server: Awaited<ReturnType<typeof startControlRpcServer>>;
+				server = await start(
+					{
+						echo: (params) => ({ params }),
+						rotate_token: () => ({ token: server.rotateToken() }),
+					},
+					{ host: "127.0.0.1", port: 0 },
+				);
+				const oldToken = readServerToken(server);
 
-			const rotated = (await callControlRpc("rotate_token", {}, server.http)) as {
-				token: string;
-			};
+				const rotated = (await callControlRpc("rotate_token", {}, rpcClient(server))) as {
+					token: string;
+				};
 
-			expect(rotated.token).not.toBe(oldToken);
-			await expect(
-				callControlRpc(
+				expect(rotated.token).not.toBe(oldToken);
+				await expect(
+					callControlRpc(
+						"echo",
+						{ rejected: true },
+						{
+							...server.http,
+							token: oldToken,
+						},
+					),
+				).rejects.toThrow("unauthorized");
+
+				const result = await callControlRpc(
 					"echo",
-					{ rejected: true },
+					{ accepted: true },
 					{
 						...server.http,
-						token: oldToken,
+						token: rotated.token,
 					},
-				),
-			).rejects.toThrow("unauthorized");
+				);
 
-			const result = await callControlRpc(
-				"echo",
-				{ accepted: true },
-				{
-					...server.http,
-					token: rotated.token,
-				},
-			);
-
-			expect(result).toEqual({ params: { accepted: true } });
+				expect(result).toEqual({ params: { accepted: true } });
+			});
 		});
 
 		it("allows explicit non-loopback HTTP listeners with the bearer token", async () => {
-			const server = await startControlRpcServer(
-				{
-					echo: (params) => ({ params }),
-				},
-				abort.signal,
-				{ host: "0.0.0.0", port: 0, allowRemote: true },
-			);
-			closeServer = server.close;
-			const token = readFileSync(getDaemonControlTokenPath(), "utf-8").trim();
+			await withRpcFixture(async ({ start }) => {
+				const server = await start(
+					{
+						echo: (params) => ({ params }),
+					},
+					{ host: "0.0.0.0", port: 0, allowRemote: true },
+				);
 
-			const result = await callControlRpc(
-				"echo",
-				{ accepted: true },
-				{ host: "127.0.0.1", port: server.http.port, token },
-			);
+				const result = await callControlRpc(
+					"echo",
+					{ accepted: true },
+					{
+						host: "127.0.0.1",
+						port: server.http.port,
+						token: readServerToken(server),
+					},
+				);
 
-			expect(result).toEqual({ params: { accepted: true } });
+				expect(result).toEqual({ params: { accepted: true } });
+			});
 		});
 	});
+}
+
+type RpcServer = Awaited<ReturnType<typeof startControlRpcServer>>;
+
+interface RpcFixture {
+	controlDir: string;
+	start: (handlers: ControlRpcHandlers, config?: ControlRpcListenConfig) => Promise<RpcServer>;
+}
+
+async function withRpcFixture<T>(run: (fixture: RpcFixture) => Promise<T>): Promise<T> {
+	const root = mkdtempSync(join(tmpdir(), "clawdi-control-rpc-"));
+	const controlDir = join(root, "control");
+	const abort = new AbortController();
+	const servers: RpcServer[] = [];
+	try {
+		return await run({
+			controlDir,
+			start: async (handlers, config = {}) => {
+				const server = await startControlRpcServer(handlers, abort.signal, {
+					port: 0,
+					controlDir,
+					...config,
+				});
+				servers.push(server);
+				return server;
+			},
+		});
+	} finally {
+		abort.abort();
+		await Promise.allSettled(servers.map((server) => server.close()));
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+function rpcClient(server: RpcServer): { host: string; port: number; token: string } {
+	return {
+		...server.http,
+		token: readServerToken(server),
+	};
+}
+
+function readServerToken(server: RpcServer): string {
+	return readFileSync(server.tokenPath, "utf-8").trim();
 }
 
 function postWithoutToken(

--- a/packages/cli/src/serve/control-rpc.ts
+++ b/packages/cli/src/serve/control-rpc.ts
@@ -8,6 +8,7 @@ import {
 	type ServerResponse,
 } from "node:http";
 import { isIP } from "node:net";
+import { dirname, join } from "node:path";
 import { getDaemonControlDir, getDaemonControlTokenPath } from "./paths";
 
 const MAX_RPC_BODY_BYTES = 1024 * 1024;
@@ -21,6 +22,8 @@ export interface ControlRpcListenConfig {
 	host?: string;
 	port?: number;
 	allowRemote?: boolean;
+	controlDir?: string;
+	tokenPath?: string;
 }
 
 export interface ControlRpcClientConfig {
@@ -39,7 +42,13 @@ interface JsonRpcRequest {
 interface ControlRpcServer {
 	tokenPath: string;
 	http: { host: string; port: number };
+	rotateToken: () => string;
 	close: () => Promise<void>;
+}
+
+interface ControlRpcTokenPaths {
+	controlDir: string;
+	tokenPath: string;
 }
 
 export async function startControlRpcServer(
@@ -55,16 +64,10 @@ export async function startControlRpcServer(
 				"Use --allow-remote only behind SSH tunneling or a TLS-terminating proxy.",
 		);
 	}
-	const controlDir = getDaemonControlDir();
-	mkdirSync(controlDir, { recursive: true, mode: 0o700 });
-	try {
-		chmodSync(controlDir, 0o700);
-	} catch {
-		/* best effort */
-	}
-	ensureControlToken();
+	const tokenPaths = resolveControlTokenPaths(config);
+	ensureControlToken(tokenPaths);
 	const httpServer = createServer(async (req, res) => {
-		await handleHttpRequest(req, res, handlers);
+		await handleHttpRequest(req, res, handlers, tokenPaths);
 	});
 	try {
 		await listenOnHttpEndpoint(httpServer, host, port);
@@ -77,7 +80,12 @@ export async function startControlRpcServer(
 		host,
 		port: typeof address === "object" && address ? address.port : port,
 	};
-	const close = () => closeServer(httpServer);
+	let closed = false;
+	const close = () => {
+		if (closed) return Promise.resolve();
+		closed = true;
+		return closeServer(httpServer);
+	};
 	abort.addEventListener(
 		"abort",
 		() => {
@@ -85,7 +93,12 @@ export async function startControlRpcServer(
 		},
 		{ once: true },
 	);
-	return { tokenPath: getDaemonControlTokenPath(), http, close };
+	return {
+		tokenPath: tokenPaths.tokenPath,
+		http,
+		rotateToken: () => rotateControlToken(tokenPaths),
+		close,
+	};
 }
 
 export async function callControlRpc(
@@ -153,47 +166,67 @@ function createServerlessRequest(
 	return req;
 }
 
-function ensureControlToken(): string {
-	const tokenPath = getDaemonControlTokenPath();
-	if (existsSync(tokenPath)) {
-		return readControlToken();
+function resolveControlTokenPaths(config: ControlRpcListenConfig): ControlRpcTokenPaths {
+	if (config.tokenPath) {
+		return {
+			controlDir: config.controlDir ?? dirname(config.tokenPath),
+			tokenPath: config.tokenPath,
+		};
 	}
-	return rotateControlToken();
+	if (config.controlDir) {
+		return {
+			controlDir: config.controlDir,
+			tokenPath: join(config.controlDir, "control-token"),
+		};
+	}
+	return {
+		controlDir: getDaemonControlDir(),
+		tokenPath: getDaemonControlTokenPath(),
+	};
 }
 
-export function rotateControlToken(): string {
-	const controlDir = getDaemonControlDir();
+function ensureControlDir(controlDir: string): void {
 	mkdirSync(controlDir, { recursive: true, mode: 0o700 });
 	try {
 		chmodSync(controlDir, 0o700);
 	} catch {
 		/* best effort */
 	}
-	const tokenPath = getDaemonControlTokenPath();
+}
+
+function ensureControlToken(paths = resolveControlTokenPaths({})): string {
+	ensureControlDir(paths.controlDir);
+	if (existsSync(paths.tokenPath)) {
+		return readControlToken(paths);
+	}
+	return rotateControlToken(paths);
+}
+
+export function rotateControlToken(paths = resolveControlTokenPaths({})): string {
+	ensureControlDir(paths.controlDir);
 	const token = randomBytes(32).toString("hex");
-	writeFileSync(tokenPath, `${token}\n`, { mode: 0o600 });
+	writeFileSync(paths.tokenPath, `${token}\n`, { mode: 0o600 });
 	try {
-		chmodSync(tokenPath, 0o600);
+		chmodSync(paths.tokenPath, 0o600);
 	} catch {
 		/* best effort */
 	}
 	return token;
 }
 
-function readControlToken(): string {
-	const tokenPath = getDaemonControlTokenPath();
-	if (!existsSync(tokenPath)) {
+function readControlToken(paths = resolveControlTokenPaths({})): string {
+	if (!existsSync(paths.tokenPath)) {
 		throw new Error(
-			`daemon control token not found at ${tokenPath}. Start \`clawdi daemon run\` first.`,
+			`daemon control token not found at ${paths.tokenPath}. Start \`clawdi daemon run\` first.`,
 		);
 	}
 	try {
-		chmodSync(tokenPath, 0o600);
+		chmodSync(paths.tokenPath, 0o600);
 	} catch {
 		/* best effort */
 	}
-	const token = readFileSync(tokenPath, "utf-8").trim();
-	if (!token) throw new Error(`daemon control token at ${tokenPath} is empty`);
+	const token = readFileSync(paths.tokenPath, "utf-8").trim();
+	if (!token) throw new Error(`daemon control token at ${paths.tokenPath} is empty`);
 	return token;
 }
 
@@ -201,6 +234,7 @@ async function handleHttpRequest(
 	req: IncomingMessage,
 	res: ServerResponse,
 	handlers: ControlRpcHandlers,
+	tokenPaths: ControlRpcTokenPaths,
 ): Promise<void> {
 	if (req.method !== "POST" || req.url !== "/rpc") {
 		sendHttp(res, 404, { error: "not_found" });
@@ -208,7 +242,7 @@ async function handleHttpRequest(
 	}
 	let token: string;
 	try {
-		token = readControlToken();
+		token = readControlToken(tokenPaths);
 	} catch (error) {
 		sendHttp(res, 500, { error: error instanceof Error ? error.message : "token_unavailable" });
 		return;

--- a/packages/cli/tests/commands/run.test.ts
+++ b/packages/cli/tests/commands/run.test.ts
@@ -1,35 +1,42 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { run } from "../../src/commands/run";
 import { setProjectFolderLink } from "../../src/lib/project-folders";
+import type {
+	RuntimeMitmBrokerFactory,
+	RuntimeMitmBrokerInput,
+} from "../../src/runtime/mitm-broker";
 import { jsonResponse, mockFetch } from "./helpers";
 
 interface SpawnCall {
 	command: string;
 	args: string[];
 	env: NodeJS.ProcessEnv;
+	cwd?: string;
+}
+
+interface BrokerCall {
+	runtime: string;
+	profileBundlePath: string;
+	proxyUrl?: string;
+	caFile?: string;
+	authToken?: string;
 }
 
 let tmpRoot: string;
 let fakeClawdiHome: string;
 let projectRoot: string;
 let projectChild: string;
-let origHome: string | undefined;
-let origClawdiHome: string | undefined;
-let origAuthToken: string | undefined;
-let origApiUrl: string | undefined;
+let origEnv: Record<string, string | undefined>;
 let origCwd: string;
 
 beforeEach(() => {
-	origHome = process.env.HOME;
-	origClawdiHome = process.env.CLAWDI_HOME;
-	origAuthToken = process.env.CLAWDI_AUTH_TOKEN;
-	origApiUrl = process.env.CLAWDI_API_URL;
+	origEnv = { ...process.env };
 	origCwd = process.cwd();
 
 	tmpRoot = join(tmpdir(), `clawdi-run-${Date.now()}-${Math.random().toString(36)}`);
@@ -49,32 +56,69 @@ beforeEach(() => {
 
 afterEach(() => {
 	process.chdir(origCwd);
-	if (origHome) process.env.HOME = origHome;
-	else delete process.env.HOME;
-	if (origClawdiHome) process.env.CLAWDI_HOME = origClawdiHome;
-	else delete process.env.CLAWDI_HOME;
-	if (origAuthToken) process.env.CLAWDI_AUTH_TOKEN = origAuthToken;
-	else delete process.env.CLAWDI_AUTH_TOKEN;
-	if (origApiUrl) process.env.CLAWDI_API_URL = origApiUrl;
-	else delete process.env.CLAWDI_API_URL;
+	restoreEnv(origEnv);
 	rmSync(tmpRoot, { recursive: true, force: true });
 	process.exitCode = undefined;
 });
 
-function recordSpawn(): {
+function restoreEnv(snapshot: Record<string, string | undefined>): void {
+	for (const key of Object.keys(process.env)) {
+		if (!(key in snapshot)) delete process.env[key];
+	}
+	for (const [key, value] of Object.entries(snapshot)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+}
+
+function recordSpawn(opts: { autoExit?: boolean } = {}): {
 	calls: SpawnCall[];
+	children: ChildProcess[];
 	spawnImpl: NonNullable<Parameters<typeof run>[2]>;
 } {
 	const calls: SpawnCall[] = [];
+	const children: ChildProcess[] = [];
 	const spawnImpl = ((command: string, args: string[], options: SpawnOptions) => {
 		calls.push({
 			command,
 			args,
 			env: (options.env ?? {}) as NodeJS.ProcessEnv,
+			cwd: typeof options.cwd === "string" ? options.cwd : undefined,
 		});
-		return new EventEmitter() as ChildProcess;
+		const child = new EventEmitter() as ChildProcess;
+		children.push(child);
+		if (opts.autoExit !== false) {
+			queueMicrotask(() => child.emit("exit", 0));
+		}
+		return child;
 	}) as NonNullable<Parameters<typeof run>[2]>;
-	return { calls, spawnImpl };
+	return { calls, children, spawnImpl };
+}
+
+function recordBroker(output?: { proxyUrl?: string; caFile?: string }): {
+	calls: BrokerCall[];
+	brokerFactory: RuntimeMitmBrokerFactory;
+	stopCount: () => number;
+} {
+	const calls: BrokerCall[] = [];
+	let stops = 0;
+	const brokerFactory: RuntimeMitmBrokerFactory = async (input: RuntimeMitmBrokerInput) => {
+		calls.push({
+			runtime: input.runtime,
+			profileBundlePath: input.profileBundlePath,
+			proxyUrl: input.env.CLAWDI_MITM_PROXY_URL,
+			caFile: input.env.CLAWDI_MITM_CA_FILE,
+			authToken: input.env.CLAWDI_AUTH_TOKEN,
+		});
+		return {
+			proxyUrl: output?.proxyUrl ?? input.env.CLAWDI_MITM_PROXY_URL ?? "http://127.0.0.1:18080",
+			caFile: output?.caFile ?? input.env.CLAWDI_MITM_CA_FILE ?? "/run/clawdi/mitm/ca.pem",
+			stop: async () => {
+				stops += 1;
+			},
+		};
+	};
+	return { calls, brokerFactory, stopCount: () => stops };
 }
 
 function linkCurrentProjectFolder(): void {
@@ -89,6 +133,390 @@ function linkCurrentProjectFolder(): void {
 }
 
 describe("run command project folder selection", () => {
+	it("runs hosted runtime commands from managed run config without login", async () => {
+		unlinkSync(join(fakeClawdiHome, "auth.json"));
+		const serviceStateRoot = join(tmpRoot, "var", "lib", "clawdi");
+		const runRoot = join(tmpRoot, "run", "clawdi");
+		const hermesPath = join(tmpRoot, "home", "clawdi", ".local", "bin", "hermes");
+		const runConfigRoot = join(serviceStateRoot, "config", "run");
+		mkdirSync(runConfigRoot, { recursive: true });
+		mkdirSync(join(tmpRoot, "home", "clawdi", ".local", "bin"), { recursive: true });
+		writeFileSync(
+			join(runConfigRoot, "hermes.json"),
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeRunConfig.v1",
+				runtime: "hermes",
+				enabled: true,
+				generatedAt: "2026-06-04T00:00:00Z",
+				generation: 1,
+				instanceId: "iid_test",
+				command: "hermes",
+				defaultArgs: ["--no-browser"],
+				env: {
+					DISCORD_API_BASE_URL: "http://127.0.0.1:4500/discord",
+				},
+				prependPath: [join(tmpRoot, "home", "clawdi", ".local", "bin")],
+				cwd: projectRoot,
+				commandPath: hermesPath,
+				appRoot: join(tmpRoot, "home", "clawdi", ".hermes", "hermes-agent"),
+			}),
+		);
+		writeFileSync(hermesPath, "#!/usr/bin/env sh\n");
+		const { calls, spawnImpl } = recordSpawn();
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = serviceStateRoot;
+		process.env.CLAWDI_RUN_DIR = runRoot;
+		delete process.env.CLAWDI_AUTH_TOKEN;
+
+		await run(["hermes", "--version"], {}, spawnImpl);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].command).toBe(hermesPath);
+		expect(calls[0].args).toEqual(["--no-browser", "--version"]);
+		expect(calls[0].cwd).toBe(projectRoot);
+		expect(calls[0].env.DISCORD_API_BASE_URL).toBe("http://127.0.0.1:4500/discord");
+		expect(calls[0].env.PATH?.startsWith(join(tmpRoot, "home", "clawdi", ".local", "bin"))).toBe(
+			true,
+		);
+	});
+
+	it("keeps hosted runtime wrapper alive until the child exits", async () => {
+		unlinkSync(join(fakeClawdiHome, "auth.json"));
+		const serviceStateRoot = join(tmpRoot, "var", "lib", "clawdi");
+		const runRoot = join(tmpRoot, "run", "clawdi");
+		const hermesPath = join(tmpRoot, "home", "clawdi", ".local", "bin", "hermes");
+		const runConfigRoot = join(serviceStateRoot, "config", "run");
+		mkdirSync(runConfigRoot, { recursive: true });
+		mkdirSync(join(tmpRoot, "home", "clawdi", ".local", "bin"), { recursive: true });
+		writeFileSync(
+			join(runConfigRoot, "hermes.json"),
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeRunConfig.v1",
+				runtime: "hermes",
+				enabled: true,
+				generatedAt: "2026-06-08T00:00:00Z",
+				generation: 1,
+				instanceId: "iid_test",
+				command: "hermes",
+				defaultArgs: [],
+				env: {},
+				prependPath: [join(tmpRoot, "home", "clawdi", ".local", "bin")],
+				cwd: projectRoot,
+				commandPath: hermesPath,
+				appRoot: join(tmpRoot, "home", "clawdi", ".hermes", "hermes-agent"),
+			}),
+		);
+		writeFileSync(hermesPath, "#!/usr/bin/env sh\n");
+		const { calls, children, spawnImpl } = recordSpawn({ autoExit: false });
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = serviceStateRoot;
+		process.env.CLAWDI_RUN_DIR = runRoot;
+		delete process.env.CLAWDI_AUTH_TOKEN;
+
+		let resolved = false;
+		const running = run(["hermes"], {}, spawnImpl).then(() => {
+			resolved = true;
+		});
+		await new Promise((resolve) => setTimeout(resolve, 20));
+
+		expect(calls).toHaveLength(1);
+		expect(resolved).toBe(false);
+
+		children[0].emit("exit", 0);
+		await running;
+		expect(resolved).toBe(true);
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("reports signal-terminated hosted runtime children as failures", async () => {
+		unlinkSync(join(fakeClawdiHome, "auth.json"));
+		const serviceStateRoot = join(tmpRoot, "var", "lib", "clawdi");
+		const runRoot = join(tmpRoot, "run", "clawdi");
+		const hermesPath = join(tmpRoot, "home", "clawdi", ".local", "bin", "hermes");
+		const runConfigRoot = join(serviceStateRoot, "config", "run");
+		mkdirSync(runConfigRoot, { recursive: true });
+		mkdirSync(join(tmpRoot, "home", "clawdi", ".local", "bin"), { recursive: true });
+		writeFileSync(
+			join(runConfigRoot, "hermes.json"),
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeRunConfig.v1",
+				runtime: "hermes",
+				enabled: true,
+				generatedAt: "2026-06-08T00:00:00Z",
+				generation: 1,
+				instanceId: "iid_test",
+				command: "hermes",
+				defaultArgs: [],
+				env: {},
+				prependPath: [join(tmpRoot, "home", "clawdi", ".local", "bin")],
+				cwd: projectRoot,
+				commandPath: hermesPath,
+				appRoot: join(tmpRoot, "home", "clawdi", ".hermes", "hermes-agent"),
+			}),
+		);
+		writeFileSync(hermesPath, "#!/usr/bin/env sh\n");
+		const { children, spawnImpl } = recordSpawn({ autoExit: false });
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = serviceStateRoot;
+		process.env.CLAWDI_RUN_DIR = runRoot;
+		delete process.env.CLAWDI_AUTH_TOKEN;
+
+		const running = run(["hermes"], {}, spawnImpl);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		children[0].emit("exit", null, "SIGTERM");
+		await running;
+
+		expect(process.exitCode).toBe(143);
+	});
+
+	it("injects MITM broker env for hosted runtime commands with profile bundles", async () => {
+		unlinkSync(join(fakeClawdiHome, "auth.json"));
+		const serviceStateRoot = join(tmpRoot, "var", "lib", "clawdi");
+		const runRoot = join(tmpRoot, "run", "clawdi");
+		const hermesPath = join(tmpRoot, "home", "clawdi", ".local", "bin", "hermes");
+		const runConfigRoot = join(serviceStateRoot, "config", "run");
+		const mitmProfileBundle = join(serviceStateRoot, "config", "mitm", "profiles.json");
+		mkdirSync(runConfigRoot, { recursive: true });
+		mkdirSync(join(serviceStateRoot, "config", "mitm"), { recursive: true });
+		mkdirSync(join(tmpRoot, "home", "clawdi", ".local", "bin"), { recursive: true });
+		writeFileSync(mitmProfileBundle, "{}\n");
+		writeFileSync(
+			join(runConfigRoot, "hermes.json"),
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeRunConfig.v1",
+				runtime: "hermes",
+				enabled: true,
+				generatedAt: "2026-06-04T00:00:00Z",
+				generation: 1,
+				instanceId: "iid_test",
+				command: "hermes",
+				defaultArgs: ["--no-browser"],
+				env: {},
+				prependPath: [join(tmpRoot, "home", "clawdi", ".local", "bin")],
+				cwd: projectRoot,
+				commandPath: hermesPath,
+				appRoot: join(tmpRoot, "home", "clawdi", ".hermes", "hermes-agent"),
+				mitmProfileBundlePath: mitmProfileBundle,
+			}),
+		);
+		writeFileSync(hermesPath, "#!/usr/bin/env sh\n");
+		const { calls, spawnImpl } = recordSpawn();
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = serviceStateRoot;
+		process.env.CLAWDI_RUN_DIR = runRoot;
+		process.env.CLAWDI_AUTH_TOKEN = "hosted-runtime-token";
+		const broker = recordBroker();
+
+		await run(["hermes", "serve"], {}, spawnImpl, broker.brokerFactory);
+
+		expect(broker.calls).toHaveLength(1);
+		expect(broker.calls[0]).toMatchObject({
+			runtime: "hermes",
+			profileBundlePath: mitmProfileBundle,
+			proxyUrl: "http://127.0.0.1:0",
+			caFile: join(runRoot, "mitm", "ca.pem"),
+		});
+		expect(broker.calls[0].authToken).toBeUndefined();
+		expect(calls).toHaveLength(1);
+		expect(calls[0].env.CLAWDI_MITM_ENABLED).toBeUndefined();
+		expect(calls[0].env.CLAWDI_MITM_PROFILE_BUNDLE).toBeUndefined();
+		expect(calls[0].env.CLAWDI_MITM_SECRET_FILE).toBeUndefined();
+		expect(calls[0].env.CLAWDI_MITM_PROXY_URL).toBeUndefined();
+		expect(calls[0].env.HTTPS_PROXY).toBe("http://127.0.0.1:0");
+		expect(calls[0].env.HTTP_PROXY).toBe("http://127.0.0.1:0");
+		expect(calls[0].env.https_proxy).toBe("http://127.0.0.1:0");
+		expect(calls[0].env.http_proxy).toBe("http://127.0.0.1:0");
+		expect(calls[0].env.NO_PROXY).toContain("127.0.0.1");
+		expect(calls[0].env.no_proxy).toBe(calls[0].env.NO_PROXY);
+		expect(calls[0].env.NODE_USE_ENV_PROXY).toBe("1");
+		expect(calls[0].env.OPENCLAW_PROXY_URL).toBe("http://127.0.0.1:0");
+		expect(calls[0].env.SSL_CERT_FILE).toBe(join(runRoot, "mitm", "ca.pem"));
+		expect(calls[0].env.NODE_EXTRA_CA_CERTS).toBe(join(runRoot, "mitm", "ca.pem"));
+		expect(calls[0].env.REQUESTS_CA_BUNDLE).toBe(join(runRoot, "mitm", "ca.pem"));
+		expect(calls[0].env.CURL_CA_BUNDLE).toBe(join(runRoot, "mitm", "ca.pem"));
+		expect(calls[0].env.GIT_SSL_CAINFO).toBe(join(runRoot, "mitm", "ca.pem"));
+		expect(calls[0].env.DENO_CERT).toBe(join(runRoot, "mitm", "ca.pem"));
+		expect(calls[0].env.CODEX_CA_CERTIFICATE).toBe(join(runRoot, "mitm", "ca.pem"));
+		expect(calls[0].env.CLAWDI_MITM_BROKER_PATH).toBeUndefined();
+		expect(calls[0].env.CLAWDI_MITM_BROKER_BUNDLE).toBeUndefined();
+		expect(calls[0].env.CLAWDI_MITM_ALLOW_REMOTE_PROXY).toBeUndefined();
+		expect(calls[0].env.CLAWDI_AUTH_TOKEN).toBeUndefined();
+	});
+
+	it("fails closed when a hosted runtime MITM broker fails to start", async () => {
+		unlinkSync(join(fakeClawdiHome, "auth.json"));
+		const serviceStateRoot = join(tmpRoot, "var", "lib", "clawdi");
+		const runRoot = join(tmpRoot, "run", "clawdi");
+		const hermesPath = join(tmpRoot, "home", "clawdi", ".local", "bin", "hermes");
+		const runConfigRoot = join(serviceStateRoot, "config", "run");
+		const mitmProfileBundle = join(serviceStateRoot, "config", "mitm", "profiles.json");
+		mkdirSync(runConfigRoot, { recursive: true });
+		mkdirSync(join(serviceStateRoot, "config", "mitm"), { recursive: true });
+		mkdirSync(join(tmpRoot, "home", "clawdi", ".local", "bin"), { recursive: true });
+		writeFileSync(mitmProfileBundle, "{}\n");
+		writeFileSync(
+			join(runConfigRoot, "hermes.json"),
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeRunConfig.v1",
+				runtime: "hermes",
+				enabled: true,
+				generatedAt: "2026-06-04T00:00:00Z",
+				generation: 1,
+				instanceId: "iid_test",
+				command: "hermes",
+				defaultArgs: [],
+				env: {},
+				prependPath: [join(tmpRoot, "home", "clawdi", ".local", "bin")],
+				cwd: projectRoot,
+				commandPath: hermesPath,
+				appRoot: join(tmpRoot, "home", "clawdi", ".hermes", "hermes-agent"),
+				mitmProfileBundlePath: mitmProfileBundle,
+			}),
+		);
+		writeFileSync(hermesPath, "#!/usr/bin/env sh\n");
+		const { calls, spawnImpl } = recordSpawn();
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = serviceStateRoot;
+		process.env.CLAWDI_RUN_DIR = runRoot;
+
+		const originalExit = process.exit;
+		const originalLog = console.log;
+		process.exit = ((code?: string | number | null) => {
+			throw new Error(`process.exit:${code ?? 0}`);
+		}) as typeof process.exit;
+		console.log = () => {};
+		try {
+			await expect(
+				run(["hermes", "serve"], {}, spawnImpl, async () => {
+					throw new Error("MITM broker did not become ready");
+				}),
+			).rejects.toThrow("process.exit:1");
+		} finally {
+			console.log = originalLog;
+			process.exit = originalExit;
+		}
+
+		expect(calls).toHaveLength(0);
+	});
+
+	it("uses the broker's actual proxy and CA paths for hosted runtime commands", async () => {
+		unlinkSync(join(fakeClawdiHome, "auth.json"));
+		const serviceStateRoot = join(tmpRoot, "var", "lib", "clawdi");
+		const runRoot = join(tmpRoot, "run", "clawdi");
+		const hermesPath = join(tmpRoot, "home", "clawdi", ".local", "bin", "hermes");
+		const runConfigRoot = join(serviceStateRoot, "config", "run");
+		const mitmProfileBundle = join(serviceStateRoot, "config", "mitm", "profiles.json");
+		mkdirSync(runConfigRoot, { recursive: true });
+		mkdirSync(join(serviceStateRoot, "config", "mitm"), { recursive: true });
+		mkdirSync(join(tmpRoot, "home", "clawdi", ".local", "bin"), { recursive: true });
+		writeFileSync(
+			mitmProfileBundle,
+			JSON.stringify({
+				schemaVersion: "clawdi.mitmProfiles.v1",
+				generatedAt: "2026-06-04T00:00:00Z",
+				generation: 1,
+				instanceId: "iid_test",
+				profiles: [],
+			}),
+		);
+		writeFileSync(
+			join(runConfigRoot, "hermes.json"),
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeRunConfig.v1",
+				runtime: "hermes",
+				enabled: true,
+				generatedAt: "2026-06-04T00:00:00Z",
+				generation: 1,
+				instanceId: "iid_test",
+				command: "hermes",
+				defaultArgs: [],
+				env: {},
+				prependPath: [join(tmpRoot, "home", "clawdi", ".local", "bin")],
+				cwd: projectRoot,
+				commandPath: hermesPath,
+				appRoot: join(tmpRoot, "home", "clawdi", ".hermes", "hermes-agent"),
+				mitmProfileBundlePath: mitmProfileBundle,
+			}),
+		);
+		writeFileSync(hermesPath, "#!/usr/bin/env sh\n");
+		const { calls, spawnImpl } = recordSpawn();
+		const broker = recordBroker({
+			proxyUrl: "http://127.0.0.1:19090",
+			caFile: join(runRoot, "actual-ca.pem"),
+		});
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = serviceStateRoot;
+		process.env.CLAWDI_RUN_DIR = runRoot;
+		process.env.CLAWDI_MITM_PROXY_PORT = "0";
+		delete process.env.CLAWDI_AUTH_TOKEN;
+
+		try {
+			await run(["hermes", "serve"], {}, spawnImpl, broker.brokerFactory);
+		} finally {
+			delete process.env.CLAWDI_MITM_PROXY_PORT;
+		}
+
+		expect(broker.calls).toHaveLength(1);
+		expect(calls).toHaveLength(1);
+		expect(calls[0].env.CLAWDI_MITM_PROXY_URL).toBeUndefined();
+		expect(calls[0].env.HTTPS_PROXY).toBe("http://127.0.0.1:19090");
+		expect(calls[0].env.HTTP_PROXY).toBe("http://127.0.0.1:19090");
+		expect(calls[0].env.https_proxy).toBe("http://127.0.0.1:19090");
+		expect(calls[0].env.http_proxy).toBe("http://127.0.0.1:19090");
+		expect(calls[0].env.OPENCLAW_PROXY_URL).toBe("http://127.0.0.1:19090");
+		expect(calls[0].env.CLAWDI_MITM_CA_FILE).toBeUndefined();
+		expect(calls[0].env.SSL_CERT_FILE).toBe(join(runRoot, "actual-ca.pem"));
+		expect(calls[0].env.NODE_EXTRA_CA_CERTS).toBe(join(runRoot, "actual-ca.pem"));
+		expect(calls[0].env.CODEX_CA_CERTIFICATE).toBe(join(runRoot, "actual-ca.pem"));
+	});
+
+	it("runs generic hosted commands with the managed MITM profile bundle without login", async () => {
+		unlinkSync(join(fakeClawdiHome, "auth.json"));
+		const serviceStateRoot = join(tmpRoot, "var", "lib", "clawdi");
+		const runRoot = join(tmpRoot, "run", "clawdi");
+		const mitmProfileBundle = join(serviceStateRoot, "config", "mitm", "profiles.json");
+		mkdirSync(join(serviceStateRoot, "config", "mitm"), { recursive: true });
+		writeFileSync(
+			mitmProfileBundle,
+			JSON.stringify({
+				schemaVersion: "clawdi.mitmProfiles.v1",
+				generatedAt: "2026-06-05T00:00:00Z",
+				generation: 1,
+				instanceId: "iid_test",
+				profiles: [],
+			}),
+		);
+		const { calls, spawnImpl } = recordSpawn();
+		const broker = recordBroker({
+			proxyUrl: "http://127.0.0.1:19191",
+			caFile: join(runRoot, "mitm", "ca.pem"),
+		});
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = serviceStateRoot;
+		process.env.CLAWDI_RUN_DIR = runRoot;
+		delete process.env.CLAWDI_AUTH_TOKEN;
+
+		await run(["codex", "exec", "hello"], {}, spawnImpl, broker.brokerFactory);
+
+		expect(broker.calls).toHaveLength(1);
+		expect(broker.calls[0]).toMatchObject({
+			runtime: "generic",
+			profileBundlePath: mitmProfileBundle,
+			proxyUrl: "http://127.0.0.1:0",
+			caFile: join(runRoot, "mitm", "ca.pem"),
+		});
+		expect(calls).toHaveLength(1);
+		expect(calls[0].command).toBe("codex");
+		expect(calls[0].args).toEqual(["exec", "hello"]);
+		expect(calls[0].cwd).toBe(projectChild);
+		expect(calls[0].env.CLAWDI_MITM_PROFILE_BUNDLE).toBeUndefined();
+		expect(calls[0].env.CLAWDI_MITM_SECRET_FILE).toBeUndefined();
+		expect(calls[0].env.HTTPS_PROXY).toBe("http://127.0.0.1:19191");
+		expect(calls[0].env.https_proxy).toBe("http://127.0.0.1:19191");
+		expect(calls[0].env.NODE_EXTRA_CA_CERTS).toBe(join(runRoot, "mitm", "ca.pem"));
+		expect(calls[0].env.CODEX_CA_CERTIFICATE).toBe(join(runRoot, "mitm", "ca.pem"));
+	});
+
 	it("uses the linked Project folder when resolving vault env", async () => {
 		linkCurrentProjectFolder();
 		const { calls, spawnImpl } = recordSpawn();

--- a/packages/cli/tests/commands/update.test.ts
+++ b/packages/cli/tests/commands/update.test.ts
@@ -15,6 +15,8 @@ let tmpHome: string;
 let origHome: string | undefined;
 let origNoCheck: string | undefined;
 let origNoAuto: string | undefined;
+let origRuntimeMode: string | undefined;
+let origHostPolicyPath: string | undefined;
 let origArgv: string[];
 
 async function withStdoutTty<T>(fn: () => Promise<T>): Promise<T> {
@@ -32,9 +34,13 @@ beforeEach(() => {
 	origHome = process.env.HOME;
 	origNoCheck = process.env.CLAWDI_NO_UPDATE_CHECK;
 	origNoAuto = process.env.CLAWDI_NO_AUTO_UPDATE;
+	origRuntimeMode = process.env.CLAWDI_RUNTIME_MODE;
+	origHostPolicyPath = process.env.CLAWDI_HOST_POLICY_PATH;
 	origArgv = [...process.argv];
 	delete process.env.CLAWDI_NO_UPDATE_CHECK;
 	delete process.env.CLAWDI_NO_AUTO_UPDATE;
+	delete process.env.CLAWDI_RUNTIME_MODE;
+	delete process.env.CLAWDI_HOST_POLICY_PATH;
 	tmpHome = join(tmpdir(), `clawdi-update-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	mkdirSync(join(tmpHome, ".clawdi"), { recursive: true });
 	process.env.HOME = tmpHome;
@@ -48,6 +54,10 @@ afterEach(() => {
 	else delete process.env.CLAWDI_NO_UPDATE_CHECK;
 	if (origNoAuto) process.env.CLAWDI_NO_AUTO_UPDATE = origNoAuto;
 	else delete process.env.CLAWDI_NO_AUTO_UPDATE;
+	if (origRuntimeMode) process.env.CLAWDI_RUNTIME_MODE = origRuntimeMode;
+	else delete process.env.CLAWDI_RUNTIME_MODE;
+	if (origHostPolicyPath) process.env.CLAWDI_HOST_POLICY_PATH = origHostPolicyPath;
+	else delete process.env.CLAWDI_HOST_POLICY_PATH;
 	rmSync(tmpHome, { recursive: true, force: true });
 });
 
@@ -279,6 +289,24 @@ describe("daemonAutoUpdateOnce", () => {
 });
 
 describe("maybeAutoUpdate", () => {
+	it("skips local self-update path in hosted runtime mode", async () => {
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		const { captured, restore } = mockFetch([]);
+		try {
+			await withStdoutTty(() =>
+				maybeAutoUpdate({
+					detectInstaller: () => "npm",
+					spawnBackgroundInstall: () => {
+						throw new Error("should not spawn hosted local self-update");
+					},
+				}),
+			);
+		} finally {
+			restore();
+		}
+		expect(captured).toHaveLength(0);
+	});
+
 	it("writes last-version on first run; no notice", async () => {
 		const orig = console.log;
 		let captured = "";

--- a/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
+++ b/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { type AddressInfo, createServer } from "node:net";
+import { request } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -98,12 +98,16 @@ if (process.platform !== "win32") {
 	describe("daemon RPC process e2e", () => {
 		it("serves daemon RPC over the configured HTTP port", async () => {
 			const fixture = createFixture();
-			const rpcPort = await getFreePort();
-			const daemon = startDaemon(fixture, rpcPort);
+			const daemon = startDaemon(fixture);
 			const daemonStdout = new Response(daemon.stdout).text();
-			const daemonStderr = new Response(daemon.stderr).text();
+			const [stderrReady, stderrText] = daemon.stderr.tee();
+			const daemonStderr = new Response(stderrText).text();
+			let failure: unknown;
+			let daemonStdoutText = "";
+			let daemonStderrText = "";
 
 			try {
+				const rpcPort = await waitForRpcListening(stderrReady);
 				await waitFor(() => existsSync(join(fixture.stateDir, "control", "control-token")));
 				await waitForHttpUnauthorized(rpcPort);
 
@@ -150,12 +154,27 @@ if (process.platform !== "win32") {
 					true,
 				);
 				expect(apiCalls.every((call) => call.auth === `Bearer ${API_KEY}`)).toBe(true);
+			} catch (error) {
+				failure = error;
 			} finally {
 				await stopDaemon(daemon);
-				await Promise.all([daemonStdout, daemonStderr]);
+				const [stdout, stderr] = await Promise.all([daemonStdout, daemonStderr]);
+				daemonStdoutText = stdout;
+				daemonStderrText = stderr;
 				rmSync(fixture.root, { recursive: true, force: true });
 			}
-		});
+			if (failure) {
+				throw new Error(
+					[
+						failure instanceof Error ? failure.message : String(failure),
+						"daemon stdout:",
+						daemonStdoutText.trim() || "(empty)",
+						"daemon stderr:",
+						daemonStderrText.trim() || "(empty)",
+					].join("\n"),
+				);
+			}
+		}, 20_000);
 	});
 }
 
@@ -175,9 +194,9 @@ function createFixture(): Fixture {
 	return { root, home, clawdiHome, stateDir, codexHome };
 }
 
-function startDaemon(fixture: Fixture, rpcPort: number): ReturnType<typeof Bun.spawn> {
+function startDaemon(fixture: Fixture): ReturnType<typeof Bun.spawn> {
 	return Bun.spawn(
-		[process.execPath, srcEntry, "daemon", "run", "--host", "127.0.0.1", "--port", String(rpcPort)],
+		[process.execPath, srcEntry, "daemon", "run", "--host", "127.0.0.1", "--port", "0"],
 		{
 			cwd: fixture.root,
 			stdout: "pipe",
@@ -233,7 +252,7 @@ async function stopDaemon(proc: ReturnType<typeof Bun.spawn>): Promise<void> {
 
 async function waitFor(
 	predicate: () => boolean | Promise<boolean>,
-	timeoutMs = 5_000,
+	timeoutMs = 10_000,
 ): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
@@ -254,35 +273,98 @@ async function waitForHttpUnauthorized(port: number): Promise<void> {
 	});
 }
 
-async function postRpcWithoutToken(port: number): Promise<Response> {
-	return await fetch(`http://127.0.0.1:${port}/rpc`, {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }),
-	});
+async function waitForRpcListening(
+	stream: ReadableStream<Uint8Array>,
+	timeoutMs = 10_000,
+): Promise<number> {
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		const deadline = Date.now() + timeoutMs;
+		while (Date.now() < deadline) {
+			const remainingMs = Math.max(1, deadline - Date.now());
+			const read = await Promise.race([
+				reader.read(),
+				new Promise<never>((_, reject) => {
+					timer = setTimeout(() => reject(new Error("timeout")), remainingMs);
+				}),
+			]);
+			if (timer) {
+				clearTimeout(timer);
+				timer = undefined;
+			}
+			if (read.done) break;
+			buffer += decoder.decode(read.value, { stream: true });
+			const lines = buffer.split(/\r?\n/);
+			buffer = lines.pop() ?? "";
+			for (const line of lines) {
+				const port = rpcListeningPort(line);
+				if (port !== null) return port;
+			}
+		}
+		throw new Error("Timed out waiting for daemon RPC listening log");
+	} finally {
+		if (timer) clearTimeout(timer);
+		reader.releaseLock();
+	}
 }
 
-async function postRpcWithToken(port: number, token: string): Promise<Response> {
-	return await fetch(`http://127.0.0.1:${port}/rpc`, {
-		method: "POST",
-		headers: {
-			Authorization: `Bearer ${token}`,
-			"Content-Type": "application/json",
-		},
-		body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }),
-	});
+function rpcListeningPort(line: string): number | null {
+	if (!line.trim()) return null;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(line);
+	} catch {
+		return null;
+	}
+	if (!isRecord(parsed) || parsed.event !== "serve.rpc_listening") return null;
+	const http = parsed.http;
+	if (!isRecord(http) || typeof http.port !== "number") return null;
+	return http.port;
 }
 
-async function getFreePort(): Promise<number> {
-	return await new Promise((resolve, reject) => {
-		const server = createServer();
-		server.once("error", reject);
-		server.listen(0, "127.0.0.1", () => {
-			const address = server.address() as AddressInfo;
-			server.close(() => {
-				resolve(address.port);
-			});
-		});
+async function postRpcWithoutToken(port: number): Promise<{ status: number; body: string }> {
+	return await postRpc(port);
+}
+
+async function postRpcWithToken(
+	port: number,
+	token: string,
+): Promise<{ status: number; body: string }> {
+	return await postRpc(port, token);
+}
+
+function postRpc(port: number, token?: string): Promise<{ status: number; body: string }> {
+	const body = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping", params: {} });
+	return new Promise((resolve, reject) => {
+		const req = request(
+			{
+				hostname: "127.0.0.1",
+				port,
+				path: "/rpc",
+				method: "POST",
+				headers: {
+					...(token ? { Authorization: `Bearer ${token}` } : {}),
+					"Content-Type": "application/json",
+					"Content-Length": Buffer.byteLength(body),
+				},
+			},
+			(res) => {
+				let responseBody = "";
+				res.setEncoding("utf-8");
+				res.on("data", (chunk) => {
+					responseBody += chunk;
+				});
+				res.on("end", () => {
+					resolve({ status: res.statusCode ?? 0, body: responseBody });
+				});
+			},
+		);
+		req.on("error", reject);
+		req.write(body);
+		req.end();
 	});
 }
 
@@ -323,6 +405,10 @@ function json(data: unknown, status = 200, headers: Record<string, string> = {})
 			...headers,
 		},
 	});
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 async function readJsonBody(req: Request): Promise<unknown> {

--- a/packages/cli/tests/runtime-mitm-broker.test.ts
+++ b/packages/cli/tests/runtime-mitm-broker.test.ts
@@ -1,0 +1,771 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import http from "node:http";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { startRuntimeMitmBroker } from "../src/runtime/mitm-broker";
+
+const cliRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+let tmpRoot = "";
+
+afterEach(() => {
+	if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
+	tmpRoot = "";
+});
+
+describe("runtime MITM broker launcher", () => {
+	it("starts a native broker executable and stops it", async () => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "clawdi-runtime-mitm-broker-launcher-"));
+		const fakeBroker = join(tmpRoot, "fake-broker");
+		const stopped = join(tmpRoot, "stopped.txt");
+		const envOut = join(tmpRoot, "broker-env.txt");
+		writeFileSync(
+			fakeBroker,
+			[
+				"#!/usr/bin/env sh",
+				"trap 'printf stopped > \"$STOPPED\"; exit 0' TERM INT",
+				[
+					'printf "auth=%s\\nprofile=%s\\nsecret=%s\\n"',
+					'"$' + '{CLAWDI_AUTH_TOKEN-}"',
+					'"$' + '{CLAWDI_MITM_PROFILE_BUNDLE-}"',
+					'"$' + '{CLAWDI_MITM_SECRET_FILE-}"',
+					'> "$ENV_OUT"',
+				].join(" "),
+				'printf \'{"ready":true,"proxyUrl":"http://127.0.0.1:19090","caFile":"/tmp/fake-ca.pem"}\\n\'',
+				"while :; do sleep 1; done",
+				"",
+			].join("\n"),
+		);
+		chmodSync(fakeBroker, 0o755);
+		const profileBundlePath = join(tmpRoot, "profiles.json");
+		writeFileSync(
+			profileBundlePath,
+			JSON.stringify({
+				schemaVersion: "clawdi.mitmProfiles.v1",
+				generatedAt: "2026-06-05T00:00:00Z",
+				generation: 1,
+				instanceId: "iid_test",
+				profiles: [{ id: "test", enabled: true }],
+			}),
+		);
+
+		const broker = await startRuntimeMitmBroker({
+			runtime: "hermes",
+			profileBundlePath,
+			env: {
+				CLAWDI_AUTH_TOKEN: "must-not-reach-broker-env",
+				CLAWDI_MITM_BROKER_PATH: fakeBroker,
+				STOPPED: stopped,
+				ENV_OUT: envOut,
+				CLAWDI_MITM_PROXY_URL: "http://127.0.0.1:0",
+				CLAWDI_MITM_CA_FILE: join(tmpRoot, "ca.pem"),
+				CLAWDI_MITM_SECRET_FILE: join(tmpRoot, "secrets.json"),
+			},
+		});
+
+		expect(broker.proxyUrl).toBe("http://127.0.0.1:19090");
+		expect(broker.caFile).toBe("/tmp/fake-ca.pem");
+		await broker.stop();
+		expect(readFileSync(stopped, "utf8")).toBe("stopped");
+		expect(readFileSync(envOut, "utf8")).toBe("auth=\nprofile=\nsecret=\n");
+	});
+
+	it("starts a bundled native broker launcher", async () => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "clawdi-runtime-mitm-broker-bundle-"));
+		const bundle = join(tmpRoot, "bundle");
+		const bin = join(bundle, "bin");
+		mkdirSync(bin, { recursive: true });
+		const launcher = join(bin, "clawdi-mitm-broker");
+		const stopped = join(tmpRoot, "bundle-stopped.txt");
+		writeFileSync(
+			launcher,
+			[
+				"#!/usr/bin/env sh",
+				"trap 'printf stopped > \"$STOPPED\"; exit 0' TERM INT",
+				'printf \'{"ready":true,"proxyUrl":"http://127.0.0.1:19191","caFile":"/tmp/bundle-ca.pem"}\\n\'',
+				"while :; do sleep 1; done",
+				"",
+			].join("\n"),
+		);
+		chmodSync(launcher, 0o755);
+		const profileBundlePath = join(tmpRoot, "profiles.json");
+		writeFileSync(
+			profileBundlePath,
+			JSON.stringify({
+				schemaVersion: "clawdi.mitmProfiles.v1",
+				generatedAt: "2026-06-05T00:00:00Z",
+				generation: 1,
+				instanceId: "iid_test",
+				profiles: [{ id: "test", enabled: true }],
+			}),
+		);
+
+		const broker = await startRuntimeMitmBroker({
+			runtime: "hermes",
+			profileBundlePath,
+			env: {
+				CLAWDI_MITM_BROKER_BUNDLE: bundle,
+				STOPPED: stopped,
+				CLAWDI_MITM_PROXY_URL: "http://127.0.0.1:0",
+				CLAWDI_MITM_CA_FILE: join(tmpRoot, "ca.pem"),
+			},
+		});
+
+		expect(broker.proxyUrl).toBe("http://127.0.0.1:19191");
+		expect(broker.caFile).toBe("/tmp/bundle-ca.pem");
+		await broker.stop();
+		expect(readFileSync(stopped, "utf8")).toBe("stopped");
+	});
+
+	it("rejects brokers that report not ready", async () => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "clawdi-runtime-mitm-broker-not-ready-"));
+		const fakeBroker = join(tmpRoot, "fake-broker");
+		writeFileSync(
+			fakeBroker,
+			[
+				"#!/usr/bin/env sh",
+				'printf \'{"ready":false,"reason":"no-enabled-profiles"}\\n\'',
+				"",
+			].join("\n"),
+		);
+		chmodSync(fakeBroker, 0o755);
+		const profileBundlePath = join(tmpRoot, "profiles.json");
+		writeFileSync(profileBundlePath, "{}\n");
+
+		await expect(
+			startRuntimeMitmBroker({
+				runtime: "hermes",
+				profileBundlePath,
+				env: {
+					CLAWDI_MITM_BROKER_PATH: fakeBroker,
+					CLAWDI_MITM_PROXY_URL: "http://127.0.0.1:0",
+					CLAWDI_MITM_CA_FILE: join(tmpRoot, "ca.pem"),
+				},
+			}),
+		).rejects.toThrow("MITM broker did not become ready: no-enabled-profiles");
+	});
+
+	it("rejects non-loopback proxy listeners by default", async () => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "clawdi-runtime-mitm-broker-loopback-"));
+		const brokerEnv = resolveNativeBrokerEnv();
+		if (!brokerEnv) {
+			console.warn("Skipping native broker loopback test: Go is not available.");
+			return;
+		}
+		const profileBundlePath = join(tmpRoot, "profiles.json");
+		writeFileSync(
+			profileBundlePath,
+			JSON.stringify({
+				schemaVersion: "clawdi.mitmProfiles.v1",
+				generatedAt: "2026-06-05T00:00:00Z",
+				generation: 1,
+				instanceId: "iid_test",
+				profiles: [
+					{
+						id: "deny-metadata",
+						enabled: true,
+						kind: "deny",
+						match: { scheme: "https", host: "169.254.169.254", pathPrefix: "/" },
+						priority: 1,
+					},
+				],
+			}),
+		);
+
+		await expect(
+			startRuntimeMitmBroker({
+				runtime: "hermes",
+				profileBundlePath,
+				env: {
+					...brokerEnv,
+					CLAWDI_MITM_PROXY_URL: "http://0.0.0.0:0",
+					CLAWDI_MITM_CA_FILE: join(tmpRoot, "ca.pem"),
+				},
+			}),
+		).rejects.toThrow("refusing to listen on non-loopback MITM proxy host 0.0.0.0");
+	});
+
+	it("rejects broker profiles with non-HTTP upstream URLs", async () => {
+		tmpRoot = mkdtempSync(join(tmpdir(), "clawdi-runtime-mitm-broker-invalid-profile-"));
+		const brokerEnv = resolveNativeBrokerEnv();
+		if (!brokerEnv) {
+			console.warn("Skipping native broker profile validation test: Go is not available.");
+			return;
+		}
+		const profileBundlePath = join(tmpRoot, "profiles.json");
+		writeFileSync(
+			profileBundlePath,
+			JSON.stringify({
+				schemaVersion: "clawdi.mitmProfiles.v1",
+				generatedAt: "2026-06-05T00:00:00Z",
+				generation: 1,
+				instanceId: "iid_test",
+				profiles: [
+					{
+						id: "bad-upstream",
+						enabled: true,
+						kind: "http",
+						match: { scheme: "https", host: "discord.com", pathPrefix: "/api/" },
+						rewrite: { upstreamBaseUrl: "secret://runtime/channels/url" },
+					},
+				],
+			}),
+		);
+
+		await expect(
+			startRuntimeMitmBroker({
+				runtime: "hermes",
+				profileBundlePath,
+				env: {
+					...brokerEnv,
+					CLAWDI_MITM_PROXY_URL: "http://127.0.0.1:0",
+					CLAWDI_MITM_CA_FILE: join(tmpRoot, "ca.pem"),
+				},
+			}),
+		).rejects.toThrow("rewrite.upstreamBaseUrl must use http, https, ws, or wss");
+	});
+
+	it("routes HTTPS CONNECT requests through the native broker", async () => {
+		if (!commandExists("curl")) {
+			console.warn("Skipping native broker routing test: curl is not available.");
+			return;
+		}
+		tmpRoot = mkdtempSync(join(tmpdir(), "clawdi-runtime-mitm-broker-"));
+		const brokerEnv = resolveNativeBrokerEnv();
+		if (!brokerEnv) {
+			console.warn("Skipping native broker routing test: Go is not available.");
+			return;
+		}
+
+		const upstreamHits: Array<{ path: string; originalHost: string | undefined }> = [];
+		const providerHits: Array<{
+			path: string;
+			originalHost: string | undefined;
+			authorization: string | undefined;
+		}> = [];
+		const websocketHits: Array<{ path: string; originalHost: string | undefined }> = [];
+		const upstream = http.createServer((req, res) => {
+			const hit = {
+				path: req.url ?? "",
+				originalHost: req.headers["x-clawdi-original-host"]?.toString(),
+			};
+			if (hit.originalHost === "chatgpt.com") {
+				providerHits.push({
+					...hit,
+					authorization: req.headers.authorization,
+				});
+			} else {
+				upstreamHits.push(hit);
+			}
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(JSON.stringify({ ok: true, via: "test-upstream" }));
+		});
+		const websocketUpstream = net.createServer((socket) => {
+			let buffer = "";
+			socket.setEncoding("utf8");
+			socket.on("data", (chunk) => {
+				buffer += chunk;
+				if (!buffer.includes("\r\n\r\n")) return;
+				socket.removeAllListeners("data");
+				const head = parseHttpHead(buffer);
+				const key = head.headers["sec-websocket-key"] ?? "";
+				const accept = createHash("sha1")
+					.update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+					.digest("base64");
+				websocketHits.push({
+					path: head.path,
+					originalHost: head.headers["x-clawdi-original-host"],
+				});
+				socket.write(
+					[
+						"HTTP/1.1 101 Switching Protocols",
+						"Upgrade: websocket",
+						"Connection: Upgrade",
+						`Sec-WebSocket-Accept: ${accept}`,
+						"",
+						"",
+					].join("\r\n"),
+					() => setTimeout(() => socket.end(), 500),
+				);
+			});
+		});
+		await listen(upstream, 0, "127.0.0.1");
+		await listen(websocketUpstream, 0, "127.0.0.1");
+		const upstreamAddress = upstream.address();
+		const websocketAddress = websocketUpstream.address();
+		if (
+			typeof upstreamAddress !== "object" ||
+			!upstreamAddress ||
+			typeof websocketAddress !== "object" ||
+			!websocketAddress
+		) {
+			throw new Error("expected upstream TCP address");
+		}
+
+		const profileBundlePath = join(tmpRoot, "profiles.json");
+		const secretFile = join(tmpRoot, "secrets.json");
+		const caFile = join(tmpRoot, "ca.pem");
+		writeFileSync(
+			profileBundlePath,
+			JSON.stringify({
+				schemaVersion: "clawdi.mitmProfiles.v1",
+				generatedAt: "2026-06-05T00:00:00Z",
+				generation: 1,
+				instanceId: "iid_test",
+				profiles: [
+					{
+						id: "discord-rest-channel",
+						enabled: true,
+						kind: "http",
+						match: {
+							scheme: "https",
+							host: "discord.com",
+							pathPrefix: "/api/",
+							headers: {
+								authorization: {
+									type: "secretRefEquals",
+									secretRef: "secret://channels/discord/bot-token",
+									prefix: "Bot ",
+								},
+							},
+						},
+						rewrite: {
+							upstreamBaseUrl: `http://127.0.0.1:${upstreamAddress.port}/discord`,
+							preservePath: true,
+							setHeaders: {},
+						},
+						logging: { redactHeaders: ["authorization"], redactUrlPatterns: [] },
+						priority: 100,
+					},
+					{
+						id: "discord-gateway-channel",
+						enabled: true,
+						kind: "websocket",
+						match: {
+							scheme: "wss",
+							host: "gateway.discord.gg",
+							pathPrefix: "/",
+							headers: {},
+						},
+						rewrite: {
+							upstreamBaseUrl: `http://127.0.0.1:${websocketAddress.port}/discord/gateway`,
+							preservePath: true,
+							setHeaders: {},
+						},
+						priority: 110,
+					},
+					{
+						id: "telegram-bot-api-channel",
+						enabled: true,
+						kind: "http",
+						match: {
+							scheme: "https",
+							host: "api.telegram.org",
+							path: {
+								type: "secretRefPrefix",
+								secretRef: "secret://channels/telegram/bot-token",
+								prefix: "/bot",
+								suffix: "/",
+							},
+						},
+						rewrite: {
+							upstreamBaseUrl: `http://127.0.0.1:${upstreamAddress.port}/telegram`,
+							preservePath: true,
+							setHeaders: {},
+						},
+						priority: 115,
+					},
+					{
+						id: "bluebubbles-imessage-channel",
+						enabled: true,
+						kind: "http",
+						match: {
+							scheme: "https",
+							host: "bluebubbles.invalid",
+							pathPrefix: "/api/",
+							query: {
+								password: {
+									type: "secretRefEquals",
+									secretRef: "secret://channels/imessage/agent-token",
+								},
+							},
+						},
+						rewrite: {
+							upstreamBaseUrl: `http://127.0.0.1:${upstreamAddress.port}/bluebubbles`,
+							preservePath: true,
+							setHeaders: {},
+						},
+						logging: { redactHeaders: [], redactUrlPatterns: ["password=[^&]+"] },
+						priority: 120,
+					},
+					{
+						id: "codex-chatgpt-backend-responses",
+						enabled: true,
+						kind: "provider",
+						match: {
+							scheme: "https",
+							host: "chatgpt.com",
+							path: { type: "equals", value: "/backend-api/codex/responses" },
+							headers: { authorization: { type: "exists" } },
+						},
+						rewrite: {
+							upstreamBaseUrl: `http://127.0.0.1:${upstreamAddress.port}/sub2api/v1/responses`,
+							preservePath: false,
+							setHeaders: {
+								authorization: {
+									type: "secretRef",
+									secretRef: "secret://providers/openai/api-key",
+									prefix: "Bearer ",
+								},
+							},
+						},
+						logging: { redactHeaders: ["authorization"], redactUrlPatterns: [] },
+						priority: 125,
+					},
+				],
+			}),
+		);
+		writeFileSync(
+			secretFile,
+			JSON.stringify({
+				secrets: {
+					"secret://channels/discord/bot-token": "managed-token",
+					"secret://channels/telegram/bot-token": "managed-telegram-token",
+					"secret://channels/imessage/agent-token": "managed-imessage-token",
+					"secret://providers/openai/api-key": "sk-managed-provider",
+				},
+			}),
+		);
+
+		const broker = await startRuntimeMitmBroker({
+			runtime: "hermes",
+			profileBundlePath,
+			env: {
+				...brokerEnv,
+				CLAWDI_MITM_PROXY_URL: "http://127.0.0.1:0",
+				CLAWDI_MITM_CA_FILE: caFile,
+				CLAWDI_MITM_SECRET_FILE: secretFile,
+			},
+		});
+		try {
+			const routed = await requestThroughProxy({
+				proxyUrl: broker.proxyUrl,
+				caFile: broker.caFile,
+				host: "discord.com",
+				path: "/api/v10/users/@me",
+				headers: { authorization: "Bot managed-token" },
+			});
+			expect(routed.status).toBe(200);
+			expect(routed.body).toContain("test-upstream");
+			expect(upstreamHits).toEqual([
+				{ path: "/discord/api/v10/users/@me", originalHost: "discord.com" },
+			]);
+
+			const telegram = await requestThroughProxy({
+				proxyUrl: broker.proxyUrl,
+				caFile: broker.caFile,
+				host: "api.telegram.org",
+				path: "/botmanaged-telegram-token/getMe",
+				headers: {},
+			});
+			expect(telegram.status).toBe(200);
+			expect(upstreamHits).toEqual([
+				{ path: "/discord/api/v10/users/@me", originalHost: "discord.com" },
+				{ path: "/telegram/botmanaged-telegram-token/getMe", originalHost: "api.telegram.org" },
+			]);
+
+			const bluebubbles = await requestThroughProxy({
+				proxyUrl: broker.proxyUrl,
+				caFile: broker.caFile,
+				host: "bluebubbles.invalid",
+				path: "/api/v1/ping?password=managed-imessage-token",
+				headers: {},
+			});
+			expect(bluebubbles.status).toBe(200);
+			expect(upstreamHits).toEqual([
+				{ path: "/discord/api/v10/users/@me", originalHost: "discord.com" },
+				{ path: "/telegram/botmanaged-telegram-token/getMe", originalHost: "api.telegram.org" },
+				{
+					path: "/bluebubbles/api/v1/ping?password=managed-imessage-token",
+					originalHost: "bluebubbles.invalid",
+				},
+			]);
+
+			const deniedBluebubbles = await requestThroughProxy({
+				proxyUrl: broker.proxyUrl,
+				caFile: broker.caFile,
+				host: "bluebubbles.invalid",
+				path: "/api/v1/ping?password=wrong-token",
+				headers: {},
+			});
+			expect(deniedBluebubbles.status).toBe(403);
+			expect(upstreamHits).toHaveLength(3);
+
+			const deniedTelegram = await requestThroughProxy({
+				proxyUrl: broker.proxyUrl,
+				caFile: broker.caFile,
+				host: "api.telegram.org",
+				path: "/botwrong-token/getMe",
+				headers: {},
+			});
+			expect(deniedTelegram.status).toBe(403);
+			expect(upstreamHits).toHaveLength(3);
+
+			const chatgptCodex = await requestThroughProxy({
+				proxyUrl: broker.proxyUrl,
+				caFile: broker.caFile,
+				host: "chatgpt.com",
+				path: "/backend-api/codex/responses",
+				headers: { authorization: "Bearer user-chatgpt-token" },
+			});
+			expect(chatgptCodex.status).toBe(200);
+			expect(providerHits).toEqual([
+				{
+					path: "/sub2api/v1/responses",
+					originalHost: "chatgpt.com",
+					authorization: "Bearer sk-managed-provider",
+				},
+			]);
+			expect(JSON.stringify(providerHits)).not.toContain("user-chatgpt-token");
+			expect(upstreamHits).toHaveLength(3);
+
+			const denied = await requestThroughProxy({
+				proxyUrl: broker.proxyUrl,
+				caFile: broker.caFile,
+				host: "discord.com",
+				path: "/api/v10/users/@me",
+				headers: { authorization: "Bot wrong-token" },
+			});
+			expect(denied.status).toBe(403);
+			expect(upstreamHits).toHaveLength(3);
+
+			const gateway = await requestWebSocketThroughNodeProxy({
+				proxyUrl: broker.proxyUrl,
+				caFile: broker.caFile,
+				host: "gateway.discord.gg",
+				path: "/?v=10&encoding=json",
+			});
+			if (gateway.status !== 101) {
+				throw new Error(JSON.stringify({ gateway, upstreamHits, websocketHits }, null, 2));
+			}
+			expect(gateway.status).toBe(101);
+			expect(websocketHits).toEqual([
+				{ path: "/discord/gateway/?v=10&encoding=json", originalHost: "gateway.discord.gg" },
+			]);
+		} finally {
+			await broker.stop();
+			await close(upstream);
+			await close(websocketUpstream);
+		}
+	}, 60_000);
+});
+
+function commandExists(command: string): boolean {
+	return spawnSync("sh", ["-lc", `command -v ${command}`], { stdio: "ignore" }).status === 0;
+}
+
+function resolveNativeBrokerEnv(): Record<string, string> | null {
+	const bundle = process.env.CLAWDI_MITM_BROKER_BUNDLE?.trim();
+	if (bundle) return { CLAWDI_MITM_BROKER_BUNDLE: bundle };
+
+	const explicit = process.env.CLAWDI_MITM_BROKER_PATH?.trim();
+	if (explicit) return { CLAWDI_MITM_BROKER_PATH: explicit };
+
+	if (!commandExists("go")) return null;
+	const brokerPath = join(tmpRoot, "clawdi-mitm-broker");
+	const result = spawnSync("go", ["build", "-trimpath", "-o", brokerPath, "."], {
+		cwd: join(cliRoot, "native", "mitm-broker"),
+		encoding: "utf8",
+		stdio: "pipe",
+	});
+	if (result.status !== 0) {
+		throw new Error(`native broker build failed\n${result.stdout}${result.stderr}`);
+	}
+	return { CLAWDI_MITM_BROKER_PATH: brokerPath };
+}
+
+function listen(server: http.Server | net.Server, port: number, host: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(port, host, () => {
+			server.off("error", reject);
+			resolve();
+		});
+	});
+}
+
+function close(server: http.Server | net.Server): Promise<void> {
+	return new Promise((resolve) => {
+		server.close(() => resolve());
+	});
+}
+
+function parseHttpHead(raw: string): { path: string; headers: Record<string, string> } {
+	const [requestLine = "", ...lines] = raw.split("\r\n");
+	const [, path = "/"] = requestLine.split(" ");
+	const headers: Record<string, string> = {};
+	for (const line of lines) {
+		const idx = line.indexOf(":");
+		if (idx === -1) continue;
+		headers[line.slice(0, idx).toLowerCase()] = line.slice(idx + 1).trim();
+	}
+	return { path, headers };
+}
+
+async function requestThroughProxy(input: {
+	proxyUrl: string;
+	caFile: string;
+	host: string;
+	path: string;
+	headers: Record<string, string>;
+}): Promise<{ status: number; body: string }> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(
+			"curl",
+			[
+				"--silent",
+				"--show-error",
+				"--max-time",
+				"10",
+				"--http1.1",
+				"--proxy",
+				input.proxyUrl,
+				"--cacert",
+				input.caFile,
+				...Object.entries(input.headers).flatMap(([key, value]) => ["-H", `${key}: ${value}`]),
+				"-w",
+				"\n%{http_code}",
+				`https://${input.host}${input.path}`,
+			],
+			{ stdio: "pipe" },
+		);
+		let stdout = "";
+		let stderr = "";
+		const timer = setTimeout(() => {
+			child.kill("SIGKILL");
+			reject(new Error(`curl timed out\nstdout=${stdout}\nstderr=${stderr}`));
+		}, 8_000);
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => {
+			stdout += chunk;
+		});
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk;
+		});
+		child.once("error", (error) => {
+			clearTimeout(timer);
+			reject(error);
+		});
+		child.once("exit", (code) => {
+			clearTimeout(timer);
+			const lines = stdout.split("\n");
+			const statusText = lines.pop() ?? "0";
+			const status = Number.parseInt(statusText, 10);
+			const body = lines.join("\n");
+			if (code !== 0) {
+				reject(new Error(`curl failed code=${code}\nstdout=${stdout}\nstderr=${stderr}`));
+				return;
+			}
+			resolve({ status, body });
+		});
+		child.stdin.end();
+	});
+}
+
+async function requestWebSocketThroughNodeProxy(input: {
+	proxyUrl: string;
+	caFile: string;
+	host: string;
+	path: string;
+}): Promise<{ status: number; body: string }> {
+	return new Promise((resolve, reject) => {
+		const script = `
+import https from "node:https";
+import { randomBytes } from "node:crypto";
+
+const key = randomBytes(16).toString("base64");
+const req = https.request("https://${input.host}${input.path}", {
+  headers: {
+    connection: "Upgrade",
+    upgrade: "websocket",
+    "sec-websocket-key": key,
+    "sec-websocket-version": "13",
+  },
+});
+req.on("upgrade", (res, socket) => {
+  console.log(JSON.stringify({ status: res.statusCode }));
+  socket.destroy();
+});
+req.on("response", (res) => {
+  let body = "";
+  res.setEncoding("utf8");
+  res.on("data", (chunk) => {
+    body += chunk;
+  });
+  res.on("end", () => {
+    console.log(JSON.stringify({ status: res.statusCode, unexpectedResponse: true, body }));
+  });
+});
+req.on("error", (err) => {
+  console.error(err.message);
+  process.exit(1);
+});
+req.end();
+`;
+		const child = spawn(process.execPath, ["--input-type=module", "-e", script], {
+			env: {
+				PATH: process.env.PATH ?? "",
+				HOME: process.env.HOME ?? tmpdir(),
+				HTTPS_PROXY: input.proxyUrl,
+				HTTP_PROXY: input.proxyUrl,
+				NO_PROXY: "",
+				NODE_OPTIONS: [process.env.NODE_OPTIONS, "--use-env-proxy"].filter(Boolean).join(" "),
+				NODE_USE_ENV_PROXY: "1",
+				NODE_EXTRA_CA_CERTS: input.caFile,
+				SSL_CERT_FILE: input.caFile,
+			},
+			stdio: "pipe",
+		});
+		let stdout = "";
+		let stderr = "";
+		const timer = setTimeout(() => {
+			child.kill("SIGKILL");
+			reject(new Error(`node websocket request timed out\nstdout=${stdout}\nstderr=${stderr}`));
+		}, 8_000);
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => {
+			stdout += chunk;
+		});
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk;
+		});
+		child.once("error", (error) => {
+			clearTimeout(timer);
+			reject(error);
+		});
+		child.once("exit", (code) => {
+			clearTimeout(timer);
+			if (code !== 0) {
+				reject(
+					new Error(
+						`node websocket request failed code=${code}\nstdout=${stdout}\nstderr=${stderr}`,
+					),
+				);
+				return;
+			}
+			const parsed = JSON.parse(stdout.trim()) as { status?: unknown; body?: unknown };
+			resolve({
+				status: typeof parsed.status === "number" ? parsed.status : 0,
+				body: typeof parsed.body === "string" ? parsed.body : "",
+			});
+		});
+	});
+}

--- a/packages/cli/tests/runtime-mitm-env.test.ts
+++ b/packages/cli/tests/runtime-mitm-env.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+import {
+	applyMitmBrokerRuntimeEnv,
+	buildMitmBrokerEnv,
+	stripMitmBrokerControlEnv,
+	stripMitmBrokerEnv,
+} from "../src/runtime/mitm-env";
+
+describe("runtime MITM env projection", () => {
+	it("builds a child proxy/CA env from a profile bundle", () => {
+		const profileBundlePath = "/var/lib/clawdi/config/mitm/profiles.json";
+		const env = buildMitmBrokerEnv({
+			profileBundlePath,
+			env: {
+				PATH: "/usr/bin",
+				HTTPS_PROXY: "http://stale-proxy.invalid:8080",
+				https_proxy: "http://stale-lowercase-proxy.invalid:8080",
+				NODE_OPTIONS: "--trace-warnings",
+				CLAWDI_RUN_DIR: "/run/clawdi",
+				CLAWDI_MITM_PROXY_PORT: "19090",
+				CLAWDI_MITM_BROKER_BUNDLE: "/usr/local/bin/clawdi-mitm-broker",
+			},
+		});
+
+		expect(env.PATH).toBe("/usr/bin");
+		expect(env.HTTPS_PROXY).toBe("http://127.0.0.1:19090");
+		expect(env.HTTP_PROXY).toBe("http://127.0.0.1:19090");
+		expect(env.https_proxy).toBe("http://127.0.0.1:19090");
+		expect(env.http_proxy).toBe("http://127.0.0.1:19090");
+		expect(env.CLAWDI_MITM_ENABLED).toBe("1");
+		expect(env.CLAWDI_MITM_PROFILE_BUNDLE).toBe(profileBundlePath);
+		expect(env.CLAWDI_MITM_CA_FILE).toBe(join("/run/clawdi", "mitm", "ca.pem"));
+		expect(env.CLAWDI_MITM_SECRET_FILE).toBe(join("/run/clawdi", "mitm", "secrets.json"));
+		expect(env.NODE_USE_ENV_PROXY).toBe("1");
+		expect(env.NODE_OPTIONS).toBe("--trace-warnings");
+		expect(env.SSL_CERT_FILE).toBe(join("/run/clawdi", "mitm", "ca.pem"));
+		expect(env.NODE_EXTRA_CA_CERTS).toBe(join("/run/clawdi", "mitm", "ca.pem"));
+		expect(env.CODEX_CA_CERTIFICATE).toBe(join("/run/clawdi", "mitm", "ca.pem"));
+		expect(env.NO_PROXY).toContain("127.0.0.1");
+		expect(env.no_proxy).toBe(env.NO_PROXY);
+	});
+
+	it("applies broker runtime output without exposing Clawdi MITM internals", () => {
+		const env = buildMitmBrokerEnv({
+			profileBundlePath: "/var/lib/clawdi/config/mitm/profiles.json",
+			env: {
+				CLAWDI_RUN_DIR: "/run/clawdi",
+				CLAWDI_MITM_BROKER_PATH: "/tmp/test-broker",
+				CLAWDI_MITM_ALLOW_REMOTE_PROXY: "1",
+			},
+		});
+
+		applyMitmBrokerRuntimeEnv(env, {
+			proxyUrl: "http://127.0.0.1:27183",
+			caFile: "/run/clawdi/mitm/live-ca.pem",
+		});
+		stripMitmBrokerControlEnv(env);
+
+		expect(env.HTTPS_PROXY).toBe("http://127.0.0.1:27183");
+		expect(env.https_proxy).toBe("http://127.0.0.1:27183");
+		expect(env.CODEX_CA_CERTIFICATE).toBe("/run/clawdi/mitm/live-ca.pem");
+		expect(env.CLAWDI_MITM_ENABLED).toBeUndefined();
+		expect(env.CLAWDI_MITM_PROFILE_BUNDLE).toBeUndefined();
+		expect(env.CLAWDI_MITM_PROXY_URL).toBeUndefined();
+		expect(env.CLAWDI_MITM_CA_FILE).toBeUndefined();
+		expect(env.CLAWDI_MITM_SECRET_FILE).toBeUndefined();
+		expect(env.CLAWDI_MITM_BROKER_PATH).toBeUndefined();
+		expect(env.CLAWDI_MITM_BROKER_BUNDLE).toBeUndefined();
+		expect(env.CLAWDI_MITM_ALLOW_REMOTE_PROXY).toBeUndefined();
+	});
+
+	it("strips stale proxy and broker env from inherited environments", () => {
+		const stripped = stripMitmBrokerEnv({
+			PATH: "/usr/bin",
+			CLAWDI_MITM_ENABLED: "1",
+			CLAWDI_MITM_PROFILE_BUNDLE: "/tmp/profiles.json",
+			CLAWDI_MITM_PROXY_URL: "http://127.0.0.1:8080",
+			CLAWDI_MITM_BROKER_BUNDLE: "/tmp/bundle",
+			NODE_OPTIONS: "--trace-warnings",
+			HTTPS_PROXY: "http://proxy.invalid:8080",
+			CODEX_CA_CERTIFICATE: "/tmp/ca.pem",
+		});
+
+		expect(stripped.PATH).toBe("/usr/bin");
+		expect(stripped.CLAWDI_MITM_ENABLED).toBeUndefined();
+		expect(stripped.CLAWDI_MITM_PROFILE_BUNDLE).toBeUndefined();
+		expect(stripped.CLAWDI_MITM_PROXY_URL).toBeUndefined();
+		expect(stripped.CLAWDI_MITM_BROKER_BUNDLE).toBeUndefined();
+		expect(stripped.NODE_OPTIONS).toBe("--trace-warnings");
+		expect(stripped.HTTPS_PROXY).toBeUndefined();
+		expect(stripped.CODEX_CA_CERTIFICATE).toBeUndefined();
+	});
+});

--- a/packages/cli/tests/runtime-mitm-profiles.test.ts
+++ b/packages/cli/tests/runtime-mitm-profiles.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "bun:test";
+import { mitmProfileSchema } from "../src/runtime/mitm-profiles";
+
+describe("runtime MITM profile schema", () => {
+	it("accepts HTTP and websocket upstream base URLs", () => {
+		const base = {
+			id: "discord-rest",
+			enabled: true,
+			kind: "http",
+			match: { scheme: "https", host: "discord.com", pathPrefix: "/api/" },
+			rewrite: { upstreamBaseUrl: "https://router.test/discord" },
+		};
+
+		expect(mitmProfileSchema.safeParse(base).success).toBe(true);
+		expect(
+			mitmProfileSchema.safeParse({
+				...base,
+				id: "discord-gateway",
+				kind: "websocket",
+				match: { scheme: "wss", host: "gateway.discord.gg", pathPrefix: "/" },
+				rewrite: { upstreamBaseUrl: "wss://router.test/discord/gateway" },
+			}).success,
+		).toBe(true);
+	});
+
+	it("accepts secretRef-backed rewrite headers", () => {
+		expect(
+			mitmProfileSchema.safeParse({
+				id: "codex-chatgpt-backend-responses",
+				enabled: true,
+				kind: "provider",
+				match: {
+					scheme: "https",
+					host: "chatgpt.com",
+					path: { type: "equals", value: "/backend-api/codex/responses" },
+					headers: { authorization: { type: "exists" } },
+				},
+				rewrite: {
+					upstreamBaseUrl: "https://sub2api.test/v1/responses",
+					preservePath: false,
+					setHeaders: {
+						authorization: {
+							type: "secretRef",
+							secretRef: "secret://provider.default.apiKey",
+							prefix: "Bearer ",
+						},
+					},
+				},
+			}).success,
+		).toBe(true);
+	});
+
+	it("rejects upstream base URLs with unsupported schemes, credentials, or unsafe hosts", () => {
+		const base = {
+			id: "bad-upstream",
+			enabled: true,
+			kind: "http",
+			match: { scheme: "https", host: "discord.com", pathPrefix: "/api/" },
+		};
+
+		for (const upstreamBaseUrl of [
+			"secret://runtime/channels/url",
+			"https://user:pass@router.test/discord",
+			"https://.router.test/discord",
+		]) {
+			expect(
+				mitmProfileSchema.safeParse({
+					...base,
+					rewrite: { upstreamBaseUrl },
+				}).success,
+			).toBe(false);
+		}
+	});
+
+	it("rejects passthrough profiles", () => {
+		expect(
+			mitmProfileSchema.safeParse({
+				id: "direct-egress",
+				enabled: true,
+				kind: "passthrough",
+				match: { scheme: "https", host: "example.com", pathPrefix: "/" },
+			}).success,
+		).toBe(false);
+	});
+
+	it("rejects path prefixes that the native broker would reject", () => {
+		expect(
+			mitmProfileSchema.safeParse({
+				id: "bad-prefix",
+				enabled: true,
+				kind: "http",
+				match: { scheme: "https", host: "example.com", pathPrefix: "api/" },
+				rewrite: { upstreamBaseUrl: "https://router.test" },
+			}).success,
+		).toBe(false);
+	});
+});

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1,0 +1,1175 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	deniedCommandReason,
+	evaluateHostPolicyForCommand,
+	readHostPolicy,
+} from "../src/runtime/host-policy";
+import { convergeRuntimeManifest, loadRuntimeManifest } from "../src/runtime/manifest";
+import { detectRuntimeMode, getRuntimePaths } from "../src/runtime/paths";
+import { jsonResponse, mockFetch } from "./commands/helpers";
+
+const ENV_KEYS = [
+	"HOME",
+	"CLAWDI_HOME",
+	"CLAWDI_RUNTIME_MODE",
+	"CLAWDI_HOST_POLICY_PATH",
+	"CLAWDI_SERVICE_STATE_DIR",
+	"CLAWDI_RUN_DIR",
+	"CLAWDI_RUNTIME_HOME",
+	"CLAWDI_AUTH_TOKEN",
+	"CLAWDI_RUNTIME_MANIFEST_PATH",
+	"CLAWDI_RUNTIME_MANIFEST_URL",
+	"CLAWDI_RUNTIME_SOURCE_PATH",
+	"CLAWDI_RUNTIME_AUTH_ENV",
+	"CUSTOM_RUNTIME_TOKEN",
+	"CLAWDI_RUNTIME_MANIFEST_TIMEOUT_MS",
+	"CLAWDI_API_URL",
+] as const;
+
+type EnvKey = (typeof ENV_KEYS)[number];
+
+let originalEnv: Partial<Record<EnvKey, string>>;
+let root: string;
+
+beforeEach(() => {
+	originalEnv = {};
+	for (const key of ENV_KEYS) {
+		const value = process.env[key];
+		if (value !== undefined) originalEnv[key] = value;
+		delete process.env[key];
+	}
+	root = join(tmpdir(), `clawdi-runtime-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	mkdirSync(root, { recursive: true });
+});
+
+afterEach(() => {
+	for (const key of ENV_KEYS) delete process.env[key];
+	for (const [key, value] of Object.entries(originalEnv)) {
+		process.env[key as EnvKey] = value;
+	}
+	rmSync(root, { recursive: true, force: true });
+});
+
+describe("runtime paths", () => {
+	it("uses ~/.clawdi in local mode", () => {
+		const home = join(root, "home", "alice");
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "local";
+
+		expect(detectRuntimeMode()).toBe("local");
+		const paths = getRuntimePaths();
+		expect(paths.mode).toBe("local");
+		expect(paths.localConfig).toBe(join(home, ".clawdi", "config.json"));
+		expect(paths.localAuth).toBe(join(home, ".clawdi", "auth.json"));
+		expect(paths.serviceStateRoot).toBe("/var/lib/clawdi");
+		expect(paths.runRoot).toBe("/run/clawdi");
+	});
+
+	it("uses hosted runtime state and run path overrides", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+
+		expect(detectRuntimeMode()).toBe("hosted");
+		const paths = getRuntimePaths();
+		expect(paths.mode).toBe("hosted");
+		expect(paths.userHome).toBe(home);
+		expect(paths.workspaceRoot).toBe(join(home, "clawdi"));
+		expect(paths.managedConfig).toBe(join(state, "config", "clawdi.json"));
+		expect(paths.syncState).toBe(join(state, "sync", "runtimes.json"));
+		expect(paths.runtimeSource).toBe("/etc/clawdi/runtime-source.json");
+		expect(paths.mitmProfileRoot).toBe(join(state, "config", "mitm"));
+		expect(paths.mitmProfileBundle).toBe(join(state, "config", "mitm", "profiles.json"));
+		expect(paths.instanceData).toBe(join(run, "instance-data.json"));
+	});
+});
+
+describe("host policy", () => {
+	it("parses denied commands from strings and objects", () => {
+		const path = join(root, "host-policy.json");
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_HOST_POLICY_PATH = path;
+		writeFileSync(
+			path,
+			JSON.stringify({
+				schemaVersion: "clawdi.hostPolicy.v1",
+				mode: "hosted-runtime",
+				deniedCommands: ["setup", { command: "config set", reason: "managed config" }],
+				managedState: ["/var/lib/clawdi/config"],
+				systemWritableState: ["/var/lib/clawdi", "/run/clawdi"],
+				userWritableState: ["/home/clawdi", "/tmp"],
+				ordinaryUserDeniedState: ["/var/lib/clawdi"],
+			}),
+		);
+
+		const result = readHostPolicy(path);
+		expect(result.valid).toBe(true);
+		expect(result.policy?.systemWritableState).toEqual(["/var/lib/clawdi", "/run/clawdi"]);
+		expect(result.policy?.userWritableState).toEqual(["/home/clawdi", "/tmp"]);
+		expect(result.policy?.ordinaryUserDeniedState).toEqual(["/var/lib/clawdi"]);
+		expect(deniedCommandReason(result.policy, "setup")).toBe("disabled by hosted runtime policy");
+		expect(deniedCommandReason(result.policy, "config set apiUrl http://x")).toBe("managed config");
+		expect(deniedCommandReason(result.policy, "mcp")).toBe(null);
+		expect(evaluateHostPolicyForCommand("config set apiUrl http://x")).toEqual({
+			allowed: false,
+			command: "config set apiUrl http://x",
+			runtimeMode: "hosted",
+			policyPath: path,
+			reason: "managed config",
+		});
+		expect(evaluateHostPolicyForCommand("mcp")).toEqual({
+			allowed: true,
+			command: "mcp",
+			runtimeMode: "hosted",
+			policyPath: path,
+		});
+	});
+
+	it("fails closed for malformed policy JSON", () => {
+		const path = join(root, "host-policy.json");
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_HOST_POLICY_PATH = path;
+		writeFileSync(path, "{not-json");
+
+		const result = readHostPolicy(path);
+		expect(result.exists).toBe(true);
+		expect(result.valid).toBe(false);
+		expect(result.error).toBeTruthy();
+		expect(evaluateHostPolicyForCommand("config set apiUrl http://x").allowed).toBe(false);
+		expect(evaluateHostPolicyForCommand("runtime doctor").allowed).toBe(true);
+	});
+
+	it("fails closed for missing policy except recovery commands", () => {
+		const path = join(root, "missing-host-policy.json");
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_HOST_POLICY_PATH = path;
+
+		const denied = evaluateHostPolicyForCommand("auth login");
+		expect(denied.allowed).toBe(false);
+		expect(denied.reason).toContain("missing hosted runtime policy");
+		expect(evaluateHostPolicyForCommand("config paths").allowed).toBe(true);
+		expect(evaluateHostPolicyForCommand("runtime status").allowed).toBe(true);
+	});
+});
+
+describe("runtime manifest datasource", () => {
+	it("reports missing runtime source when no fixture or cache exists", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths());
+		expect("errors" in loaded).toBe(true);
+		if (!("errors" in loaded)) throw new Error("expected manifest load failure");
+		expect(loaded.mode).toBe("repair");
+		expect(loaded.stage).toBe("network");
+		expect(loaded.errors[0]).toContain("could not fetch runtime manifest");
+		expect(loaded.errors[0]).toContain("runtime source config does not exist");
+	});
+
+	it("fetches hosted-runtime manifests from a configured runtime source", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const sourcePath = join(root, "runtime-source.json");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_AUTH_TOKEN = "auth-token";
+		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		writeFileSync(
+			sourcePath,
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeSource.v1",
+				type: "http",
+				url: "https://runtime.test/v1/manifest",
+				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
+			}),
+		);
+		const { captured, restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/manifest",
+				response: () =>
+					jsonResponse({
+						manifest: {
+							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							deploymentId: "dep_test",
+							appId: "app_test",
+							instanceId: "iid_remote",
+							generation: 3,
+							issuedAt: "2026-06-06T00:00:00Z",
+							system: {
+								user: "clawdi",
+								home,
+								workspace: join(home, "managed-workspace"),
+								persistentPaths: [home],
+							},
+							controlPlane: {
+								manifestUrl: "https://runtime-source.test/desired-state",
+								apiUrl: "https://api.test",
+								cloudApiUrl: "https://cloud-api.test",
+							},
+							clawdiCli: {
+								source: "npm:clawdi",
+								managedConfig: true,
+								userEditableConfig: false,
+							},
+							runtimes: {
+								openclaw: {
+									enabled: true,
+									install: { source: "official", channel: "stable" },
+									paths: { home },
+								},
+								hermes: {
+									enabled: false,
+									install: { source: "official", channel: "stable" },
+									paths: { home },
+								},
+							},
+							providers: {
+								default: {
+									kind: "openai-compatible",
+									baseUrl: "https://sub2api.test/v1",
+									model: "gpt-5.5",
+									apiKeySecretRef: "provider.default.apiKey",
+								},
+							},
+							channels: {
+								telegram: {
+									enabled: true,
+									provider: "clawdi-channels",
+									routeKind: "telegram-bot-api",
+									baseUrl: "https://channels.test/telegram",
+									botTokenSecretRef: "channels.telegram.bot-token",
+								},
+								discord: {
+									enabled: true,
+									provider: "clawdi-channels",
+									routeKind: "discord-rest-gateway",
+									baseUrl: "https://channels.test/discord",
+									gatewayBaseUrl: "wss://channels.test/discord/gateway",
+									botTokenSecretRef: "channels.discord.bot-token",
+								},
+								whatsapp: {
+									enabled: true,
+									provider: "clawdi-channels",
+									routeKind: "whatsapp-web-bridge",
+									websocketBaseUrl: "wss://channels.test/whatsapp",
+								},
+								imessage: {
+									enabled: true,
+									provider: "clawdi-channels",
+									routeKind: "bluebubbles-imessage",
+									baseUrl: "https://channels.test/imessage",
+									passwordSecretRef: "channels.imessage.password",
+								},
+							},
+						},
+						secretValues: {
+							"provider.default.apiKey": "sk-runtime",
+							"channels.telegram.bot-token": "telegram-token",
+							"channels.discord.bot-token": "discord-token",
+							"channels.imessage.password": "imessage-password",
+						},
+					}),
+			},
+		]);
+
+		try {
+			const loaded = await loadRuntimeManifest(getRuntimePaths());
+			expect("manifest" in loaded).toBe(true);
+			if (!("manifest" in loaded)) throw new Error("expected manifest load success");
+			expect(captured).toHaveLength(1);
+			expect(captured[0].headers.authorization).toBe("Bearer auth-token");
+			expect(loaded.source).toBe("remote-datasource");
+			expect(loaded.sourcePath).toBe("https://runtime.test/v1/manifest");
+			expect(loaded.manifest.schemaVersion).toBe("clawdi.runtimeDesiredState.v1");
+			expect(loaded.manifest.workspaceRoot).toBe(join(home, "managed-workspace"));
+			expect(loaded.manifest.environmentId).toBe("app_test");
+			expect(loaded.manifest.controlPlane.apiUrl).toBe("https://cloud-api.test");
+			expect(loaded.manifest.clawdiCli?.source).toBe("npm:clawdi");
+			expect(loaded.manifest.clawdiCli?.packageSpec).toBe("clawdi@latest");
+			expect(loaded.manifest.runtimes.openclaw.install?.url).toBe(
+				"https://openclaw.ai/install-cli.sh",
+			);
+			expect(loaded.manifest.runtimes.openclaw.install?.home).toBe(home);
+			expect(loaded.manifest.runtimes.openclaw.install?.args).toEqual(["--json", "--no-onboard"]);
+			expect(loaded.manifest.mitmProfiles?.profiles.map((profile) => profile.id)).toEqual([
+				"discord-rest-channel",
+				"discord-gateway-channel",
+				"telegram-bot-api-channel",
+				"bluebubbles-imessage-channel",
+				"whatsapp-web-channel",
+				"codex-openai-responses",
+				"codex-chatgpt-backend-responses",
+			]);
+			const profiles = Object.fromEntries(
+				loaded.manifest.mitmProfiles?.profiles.map((profile) => [profile.id, profile]) ?? [],
+			);
+			expect(profiles["discord-rest-channel"]?.match.headers.authorization).toEqual({
+				type: "secretRefEquals",
+				secretRef: "secret://channels.discord.bot-token",
+				prefix: "Bot ",
+			});
+			expect(profiles["telegram-bot-api-channel"]?.match.path).toEqual({
+				type: "secretRefPrefix",
+				secretRef: "secret://channels.telegram.bot-token",
+				prefix: "/bot",
+				suffix: "/",
+			});
+			expect(profiles["bluebubbles-imessage-channel"]?.match.query.password).toEqual({
+				type: "secretRefEquals",
+				secretRef: "secret://channels.imessage.password",
+			});
+			expect(profiles["codex-openai-responses"]?.match.headers.authorization).toEqual({
+				type: "secretRefEquals",
+				secretRef: "secret://provider.default.apiKey",
+				prefix: "Bearer ",
+			});
+			expect(profiles["codex-chatgpt-backend-responses"]?.match).toEqual({
+				scheme: "https",
+				host: "chatgpt.com",
+				path: { type: "equals", value: "/backend-api/codex/responses" },
+				headers: { authorization: { type: "exists" } },
+				query: {},
+			});
+			expect(profiles["codex-chatgpt-backend-responses"]?.rewrite).toEqual({
+				upstreamBaseUrl: "https://sub2api.test/v1/responses",
+				preservePath: false,
+				setHeaders: {
+					authorization: {
+						type: "secretRef",
+						secretRef: "secret://provider.default.apiKey",
+						prefix: "Bearer ",
+					},
+				},
+			});
+			expect(loaded.secretValues).toEqual({
+				"provider.default.apiKey": "sk-runtime",
+				"secret://provider.default.apiKey": "sk-runtime",
+				"channels.telegram.bot-token": "telegram-token",
+				"secret://channels.telegram.bot-token": "telegram-token",
+				"channels.discord.bot-token": "discord-token",
+				"secret://channels.discord.bot-token": "discord-token",
+				"channels.imessage.password": "imessage-password",
+				"secret://channels.imessage.password": "imessage-password",
+			});
+		} finally {
+			restore();
+		}
+	});
+
+	it("projects hosted channels without requiring a legacy router", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const manifestPath = join(root, "kobb-channel-manifest.json");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				manifest: {
+					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					deploymentId: "dep_kobb",
+					appId: "app_kobb",
+					instanceId: "iid_kobb",
+					generation: 4,
+					issuedAt: "2026-06-06T00:00:00Z",
+					system: { home },
+					controlPlane: { apiUrl: "https://cloud-api.test" },
+					runtimes: {
+						openclaw: { enabled: true, install: { source: "official" }, paths: { home } },
+					},
+					channels: {
+						telegram: {
+							enabled: true,
+							provider: "kobb",
+							routeKind: "telegram-bot-api",
+							baseUrl: "https://kobb.test",
+							botTokenSecretRef: "channels.telegram.bot-token",
+						},
+					},
+				},
+				secretValues: {
+					"channels.telegram.bot-token": "2733207171:test-token",
+				},
+			}),
+		);
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths(), { manifestPath });
+
+		expect("manifest" in loaded).toBe(true);
+		if (!("manifest" in loaded)) throw new Error("expected manifest load success");
+		expect(loaded.manifest.projection?.channels).toEqual({
+			telegram: {
+				enabled: true,
+				provider: "kobb",
+				routeKind: "telegram-bot-api",
+				baseUrl: "https://kobb.test",
+				botTokenSecretRef: "channels.telegram.bot-token",
+			},
+		});
+		const profiles = Object.fromEntries(
+			loaded.manifest.mitmProfiles?.profiles.map((profile) => [profile.id, profile]) ?? [],
+		);
+		expect(Object.keys(profiles)).toEqual(["telegram-bot-api-channel"]);
+		expect(profiles["telegram-bot-api-channel"]).toEqual({
+			id: "telegram-bot-api-channel",
+			enabled: true,
+			kind: "http",
+			match: {
+				scheme: "https",
+				host: "api.telegram.org",
+				pathPrefix: "/bot",
+				path: {
+					type: "secretRefPrefix",
+					secretRef: "secret://channels.telegram.bot-token",
+					prefix: "/bot",
+					suffix: "/",
+				},
+				headers: {},
+				query: {},
+			},
+			rewrite: {
+				upstreamBaseUrl: "https://kobb.test",
+				preservePath: true,
+				setHeaders: {},
+			},
+			logging: {
+				redactHeaders: [],
+				redactUrlPatterns: ["/bot[^/]+/"],
+			},
+			priority: 110,
+			owner: "kobb",
+		});
+		expect(loaded.secretValues).toEqual({
+			"channels.telegram.bot-token": "2733207171:test-token",
+			"secret://channels.telegram.bot-token": "2733207171:test-token",
+		});
+	});
+
+	it("honors the auth env declared by the runtime source", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const sourcePath = join(root, "runtime-source.json");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CUSTOM_RUNTIME_TOKEN = "custom-token";
+		writeFileSync(
+			sourcePath,
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeSource.v1",
+				type: "http",
+				url: "https://runtime.test/manifest",
+				auth: { type: "bearer-env", env: "CUSTOM_RUNTIME_TOKEN" },
+			}),
+		);
+		const { captured, restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/manifest",
+				response: () =>
+					jsonResponse({
+						manifest: {
+							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							deploymentId: "dep_custom_auth",
+							instanceId: "iid_custom_auth",
+							generation: 1,
+							issuedAt: "2026-06-06T00:00:00Z",
+							system: { home },
+							controlPlane: { apiUrl: "https://cloud-api.test" },
+							runtimes: { hermes: { enabled: false } },
+						},
+						secretValues: {},
+					}),
+			},
+		]);
+
+		try {
+			const loaded = await loadRuntimeManifest(getRuntimePaths());
+			expect("manifest" in loaded).toBe(true);
+			expect(captured[0].headers.authorization).toBe("Bearer custom-token");
+		} finally {
+			restore();
+		}
+	});
+
+	it("uses hosted system workspace when converging run and supervisor config", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const workspace = join(home, "custom-workspace");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_AUTH_TOKEN = "auth-token";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime-source.test/desired-state";
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/desired-state",
+				response: () =>
+					jsonResponse({
+						manifest: {
+							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							deploymentId: "dep_workspace",
+							instanceId: "iid_workspace",
+							generation: 1,
+							issuedAt: "2026-06-06T00:00:00Z",
+							system: { home, workspace },
+							controlPlane: { apiUrl: "https://cloud-api.test" },
+							runtimes: {
+								hermes: { enabled: false },
+							},
+						},
+						secretValues: {},
+					}),
+			},
+		]);
+
+		try {
+			const loaded = await loadRuntimeManifest(getRuntimePaths());
+			expect("manifest" in loaded).toBe(true);
+			if (!("manifest" in loaded)) throw new Error("expected manifest load success");
+			const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
+			const hermesRunConfig = JSON.parse(
+				readFileSync(join(state, "config", "run", "hermes.json"), "utf-8"),
+			);
+
+			expect(convergence.outputs.workspaceRoot).toBe(workspace);
+			expect(existsSync(workspace)).toBe(true);
+			expect(hermesRunConfig.cwd).toBe(workspace);
+			expect(readFileSync(convergence.outputs.supervisorConfig, "utf-8")).toContain(
+				`; Desired-state generation: 1`,
+			);
+		} finally {
+			restore();
+		}
+	});
+
+	it("uses hosted runtime workspace paths even without explicit run settings", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const runtimeWorkspace = join(home, "hermes-workspace");
+		const manifestPath = join(root, "runtime-workspace.json");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				manifest: {
+					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					deploymentId: "dep_runtime_workspace",
+					instanceId: "iid_runtime_workspace",
+					generation: 1,
+					issuedAt: "2026-06-06T00:00:00Z",
+					system: { home, workspace: join(home, "system-workspace") },
+					controlPlane: { apiUrl: "https://cloud-api.test" },
+					runtimes: {
+						hermes: {
+							enabled: false,
+							paths: { workspace: runtimeWorkspace },
+						},
+					},
+				},
+				secretValues: {},
+			}),
+		);
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths(), { manifestPath });
+		expect("manifest" in loaded).toBe(true);
+		if (!("manifest" in loaded)) throw new Error("expected manifest load success");
+		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
+		const hermesRunConfig = JSON.parse(
+			readFileSync(join(state, "config", "run", "hermes.json"), "utf-8"),
+		);
+
+		expect(convergence.outputs.workspaceRoot).toBe(join(home, "system-workspace"));
+		expect(hermesRunConfig.cwd).toBe(runtimeWorkspace);
+	});
+
+	it("derives a safe API origin when manifests only include a source URL", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_AUTH_TOKEN = "auth-token";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime-source.test/desired-state";
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/desired-state",
+				response: () =>
+					jsonResponse({
+						manifest: {
+							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							deploymentId: "dep_manifest_only",
+							instanceId: "iid_manifest_only",
+							generation: 1,
+							issuedAt: "2026-06-06T00:00:00Z",
+							system: { home, workspace: join(home, "clawdi") },
+							controlPlane: {
+								manifestUrl: "https://runtime-source.test/v1/desired-state/",
+							},
+							runtimes: {
+								openclaw: { enabled: false },
+								hermes: { enabled: false },
+							},
+						},
+						secretValues: {},
+					}),
+			},
+		]);
+
+		try {
+			const loaded = await loadRuntimeManifest(getRuntimePaths());
+			expect("manifest" in loaded).toBe(true);
+			if (!("manifest" in loaded)) throw new Error("expected manifest load success");
+			expect(loaded.manifest.controlPlane.apiUrl).toBe("https://runtime-source.test");
+		} finally {
+			restore();
+		}
+	});
+
+	it("converges remote manifests without caching secret values", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_AUTH_TOKEN = "auth-token";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime-source.test/desired-state";
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/desired-state",
+				response: () =>
+					jsonResponse({
+						manifest: {
+							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							deploymentId: "dep_test",
+							appId: "app_test",
+							instanceId: "iid_remote",
+							generation: 4,
+							issuedAt: "2026-06-06T00:00:00Z",
+							system: { home, workspace: join(home, "clawdi") },
+							controlPlane: {
+								manifestUrl: "https://runtime-source.test/desired-state",
+								apiUrl: "https://api.test",
+							},
+							runtimes: {
+								openclaw: { enabled: false, install: { source: "official" }, paths: { home } },
+								hermes: { enabled: false, install: { source: "official" }, paths: { home } },
+							},
+							providers: {
+								default: { kind: "openai-compatible", baseUrl: "https://sub2api.test/v1" },
+							},
+							channels: {
+								telegram: {
+									enabled: true,
+									provider: "clawdi-channels",
+									routeKind: "telegram-bot-api",
+									baseUrl: "https://channels.test/telegram",
+								},
+							},
+						},
+						secretValues: {
+							"provider.default.apiKey": "sk-runtime",
+						},
+					}),
+			},
+		]);
+
+		try {
+			const loaded = await loadRuntimeManifest(getRuntimePaths());
+			if (!("manifest" in loaded)) throw new Error("expected manifest load success");
+			const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
+
+			expect(convergence.mode).toBe("normal");
+			expect(convergence.outputs.mitmProfileBundle).toBe(
+				join(state, "config", "mitm", "profiles.json"),
+			);
+			expect(convergence.outputs.mitmSecretFile).toBe(join(run, "mitm", "secrets.json"));
+			expect(convergence.outputs.supervisorConfig).toBe(
+				join(state, "supervisor", "supervisord.conf"),
+			);
+			expect(existsSync(convergence.outputs.mitmSecretFile ?? "")).toBe(true);
+			expect(existsSync(convergence.outputs.supervisorConfig)).toBe(true);
+			expect(readFileSync(convergence.outputs.supervisorConfig, "utf-8")).not.toContain(
+				"[program:",
+			);
+			expect(readFileSync(join(state, "cache", "manifest.last-good.json"), "utf-8")).not.toContain(
+				"sk-runtime",
+			);
+			expect(readFileSync(join(run, "mitm", "secrets.json"), "utf-8")).toContain("sk-runtime");
+		} finally {
+			restore();
+		}
+	});
+
+	it("removes stale MITM and run config state when the next manifest stops declaring it", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const manifestPath = join(root, "manifest-no-mitm.json");
+		mkdirSync(home, { recursive: true });
+		mkdirSync(join(state, "config", "mitm"), { recursive: true });
+		mkdirSync(join(state, "config", "run"), { recursive: true });
+		mkdirSync(join(run, "mitm"), { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		writeFileSync(join(state, "config", "mitm", "profiles.json"), "{}\n");
+		writeFileSync(join(run, "mitm", "secrets.json"), '{"secret://old":"old"}\n');
+		writeFileSync(join(state, "config", "run", "openclaw.json"), '{"enabled":true}\n');
+		writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				deploymentId: "dep_no_mitm",
+				environmentId: "env_no_mitm",
+				instanceId: "iid_no_mitm",
+				generation: 2,
+				issuedAt: "2026-06-06T00:00:00Z",
+				controlPlane: { apiUrl: "https://cloud-api.example.test" },
+				runtimes: {
+					hermes: { enabled: false },
+				},
+				mitmProfiles: { profiles: [] },
+				recovery: { cacheManifest: true, allowOfflineBoot: true },
+			}),
+		);
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths(), { manifestPath });
+		expect("manifest" in loaded).toBe(true);
+		if (!("manifest" in loaded)) throw new Error("expected manifest load success");
+		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
+
+		expect(convergence.outputs.mitmProfileBundle).toBeNull();
+		expect(convergence.outputs.mitmSecretFile).toBeNull();
+		expect(existsSync(join(state, "config", "mitm", "profiles.json"))).toBe(false);
+		expect(existsSync(join(run, "mitm", "secrets.json"))).toBe(false);
+		expect(existsSync(join(state, "config", "run", "openclaw.json"))).toBe(false);
+		expect(existsSync(join(state, "config", "run", "hermes.json"))).toBe(true);
+	});
+
+	it("removes the last-good cache when manifest recovery disables caching", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const cachePath = join(state, "cache", "manifest.last-good.json");
+		const manifestPath = join(root, "manifest-no-cache.json");
+		mkdirSync(home, { recursive: true });
+		mkdirSync(join(state, "cache"), { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		const previousManifest = {
+			schemaVersion: "clawdi.runtimeDesiredState.v1",
+			deploymentId: "dep_no_cache",
+			environmentId: "env_no_cache",
+			instanceId: "iid_no_cache",
+			generation: 1,
+			issuedAt: "2026-06-06T00:00:00Z",
+			controlPlane: { apiUrl: "https://cloud-api.example.test" },
+			runtimes: {
+				hermes: { enabled: false },
+			},
+			recovery: { cacheManifest: true, allowOfflineBoot: true },
+		};
+		writeFileSync(cachePath, JSON.stringify(previousManifest));
+		writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				...previousManifest,
+				generation: 2,
+				recovery: { cacheManifest: false, allowOfflineBoot: false },
+			}),
+		);
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths(), { manifestPath });
+		expect("manifest" in loaded).toBe(true);
+		if (!("manifest" in loaded)) throw new Error("expected manifest load success");
+		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
+
+		expect(convergence.outputs.manifestLastGood).toBeNull();
+		expect(existsSync(cachePath)).toBe(false);
+	});
+
+	it("rejects expired runtime desired state manifests", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const manifestPath = join(root, "expired-manifest.json");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				deploymentId: "dep_expired",
+				environmentId: "env_expired",
+				instanceId: "iid_expired",
+				generation: 1,
+				issuedAt: "2026-06-06T00:00:00Z",
+				expiresAt: "2000-01-01T00:00:00Z",
+				controlPlane: { apiUrl: "https://cloud-api.example.test" },
+				runtimes: {
+					hermes: { enabled: false },
+				},
+				recovery: { cacheManifest: true, allowOfflineBoot: true },
+			}),
+		);
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths(), { manifestPath });
+
+		expect("errors" in loaded).toBe(true);
+		if (!("errors" in loaded)) throw new Error("expected manifest load failure");
+		expect(loaded.mode).toBe("manifest-rejected");
+		expect(loaded.errors[0]).toContain("manifest expired");
+	});
+
+	it("rejects secret values embedded in runtime desired state", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const manifestPath = join(root, "current-schema-with-secrets.json");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				deploymentId: "dep_current_schema",
+				environmentId: "env_current_schema",
+				instanceId: "iid_current_schema",
+				generation: 1,
+				issuedAt: "2026-06-06T00:00:00Z",
+				controlPlane: { apiUrl: "https://cloud-api.example.test" },
+				runtimes: {
+					hermes: { enabled: false },
+				},
+				secrets: [{ ref: "secret://old", exposeAs: "OLD_SECRET" }],
+				recovery: { cacheManifest: true, allowOfflineBoot: true },
+			}),
+		);
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths(), { manifestPath });
+
+		expect("errors" in loaded).toBe(true);
+		if (!("errors" in loaded)) throw new Error("expected manifest load failure");
+		expect(loaded.mode).toBe("manifest-rejected");
+		expect(loaded.errors.join("\n")).toContain("Unrecognized key");
+		expect(loaded.errors.join("\n")).toContain("secrets");
+	});
+
+	it("registers live-sync environments and starts one hosted daemon", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_AUTH_TOKEN = "runtime-auth-token";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime-source.test/desired-state";
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/desired-state",
+				response: () =>
+					jsonResponse({
+						manifest: {
+							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							deploymentId: "dep_sync",
+							appId: "app_sync",
+							instanceId: "iid_sync",
+							generation: 9,
+							issuedAt: "2026-06-06T00:00:00Z",
+							system: { home, workspace: join(home, "clawdi") },
+							controlPlane: {
+								manifestUrl: "https://runtime-source.test/desired-state",
+								apiUrl: "https://api.test",
+								cloudApiUrl: "https://cloud-api.test",
+							},
+							runtimes: {
+								openclaw: { enabled: false, install: { source: "official" }, paths: { home } },
+								hermes: { enabled: false, install: { source: "official" }, paths: { home } },
+							},
+							liveSync: {
+								enabled: true,
+								agents: [
+									{ agentType: "openclaw", environmentId: "env-openclaw" },
+									{ agentType: "codex", environmentId: "env-codex" },
+								],
+							},
+						},
+						secretValues: {},
+					}),
+			},
+		]);
+
+		try {
+			const loaded = await loadRuntimeManifest(getRuntimePaths());
+			if (!("manifest" in loaded)) throw new Error("expected manifest load success");
+			const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
+			const supervisorConfig = readFileSync(convergence.outputs.supervisorConfig, "utf-8");
+			const openclawEnv = JSON.parse(
+				readFileSync(join(home, ".clawdi", "environments", "openclaw.json"), "utf-8"),
+			);
+			const codexEnv = JSON.parse(
+				readFileSync(join(home, ".clawdi", "environments", "codex.json"), "utf-8"),
+			);
+
+			expect(convergence.outputs.liveSyncEnvironments.sort()).toEqual([
+				join(home, ".clawdi", "environments", "codex.json"),
+				join(home, ".clawdi", "environments", "openclaw.json"),
+			]);
+			expect(convergence.outputs.daemonAuthTokenFile).toBe(join(run, "sync", "auth-token"));
+			expect(readFileSync(join(run, "sync", "auth-token"), "utf-8")).toBe("runtime-auth-token\n");
+			expect(openclawEnv.id).toBe("env-openclaw");
+			expect(codexEnv.id).toBe("env-codex");
+			expect(supervisorConfig).toContain("[program:clawdi-daemon]");
+			expect(supervisorConfig).toContain("clawdi daemon run");
+			expect(supervisorConfig).toContain('CLAWDI_SERVE_MODE="container"');
+			expect(supervisorConfig).toContain("https://cloud-api.test");
+			expect(supervisorConfig).not.toContain("runtime-auth-token");
+		} finally {
+			restore();
+		}
+	});
+
+	it("does not generate Codex MITM profiles without a managed provider secret ref", async () => {
+		const home = join(root, "home", "clawdi");
+		const manifestPath = join(root, "hosted-no-provider-secret.json");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				manifest: {
+					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					deploymentId: "dep_no_secret_ref",
+					appId: "app_no_secret_ref",
+					instanceId: "iid_no_secret_ref",
+					generation: 1,
+					issuedAt: "2026-06-06T00:00:00Z",
+					system: { home, workspace: join(home, "clawdi") },
+					controlPlane: { apiUrl: "https://api.test" },
+					runtimes: {
+						openclaw: { enabled: false, install: { source: "official" }, paths: { home } },
+						hermes: { enabled: false, install: { source: "official" }, paths: { home } },
+					},
+					providers: {
+						default: { kind: "openai-compatible", baseUrl: "https://sub2api.test/v1" },
+					},
+				},
+				secretValues: {},
+			}),
+		);
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths(), { manifestPath });
+
+		expect("manifest" in loaded).toBe(true);
+		if (!("manifest" in loaded)) throw new Error("expected manifest load success");
+		expect(loaded.manifest.mitmProfiles?.profiles.map((profile) => profile.id)).toEqual([]);
+	});
+
+	it("rejects invalid explicit hosted MITM profiles instead of falling back", async () => {
+		const home = join(root, "home", "clawdi");
+		const manifestPath = join(root, "hosted-bad-mitm.json");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				manifest: {
+					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					deploymentId: "dep_bad_mitm",
+					appId: "app_bad_mitm",
+					instanceId: "iid_bad_mitm",
+					generation: 1,
+					issuedAt: "2026-06-06T00:00:00Z",
+					system: { home, workspace: join(home, "clawdi") },
+					controlPlane: { apiUrl: "https://api.test" },
+					runtimes: {
+						hermes: { enabled: false },
+					},
+					mitmProfiles: {
+						profiles: [
+							{
+								id: "bad-prefix",
+								enabled: true,
+								kind: "http",
+								match: { scheme: "https", host: "example.com", pathPrefix: "api/" },
+								rewrite: { upstreamBaseUrl: "https://router.test" },
+							},
+						],
+					},
+				},
+				secretValues: {},
+			}),
+		);
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths(), { manifestPath });
+
+		expect("errors" in loaded).toBe(true);
+		if (!("errors" in loaded)) throw new Error("expected manifest load failure");
+		expect(loaded.mode).toBe("manifest-rejected");
+		expect(loaded.errors.join("\n")).toContain("pathPrefix must start with /");
+	});
+
+	it("treats hosted CLI policy as npm-managed metadata only", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const manifestPath = join(root, "manifest.json");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_AUTH_TOKEN = "auth-token";
+		writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				deploymentId: "dep_cli_payload",
+				environmentId: "env_cli_payload",
+				instanceId: "iid_cli_payload",
+				generation: 1,
+				issuedAt: "2026-06-06T00:00:00Z",
+				controlPlane: { apiUrl: "https://cloud-api.example.test" },
+				clawdiCli: {
+					version: "0.13.0-test",
+					channel: "stable",
+					source: "npm:clawdi",
+					packageSpec: "clawdi@0.13.0-test",
+				},
+				runtimes: {
+					openclaw: { enabled: false },
+					hermes: { enabled: false },
+				},
+				recovery: { cacheManifest: true, allowOfflineBoot: true },
+			}),
+		);
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths(), { manifestPath });
+		if (!("manifest" in loaded)) throw new Error("expected manifest load success");
+		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
+
+		expect(convergence.installErrors).toEqual([]);
+		expect(loaded.manifest.clawdiCli?.source).toBe("npm:clawdi");
+		expect(loaded.manifest.clawdiCli?.packageSpec).toBe("clawdi@0.13.0-test");
+		expect(existsSync(join(state, "payloads"))).toBe(false);
+		expect(existsSync(join(state, "status", "cli-bootstrap.json"))).toBe(false);
+	});
+
+	it("accepts non-secret MITM profile bundles in runtime manifests", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const manifestPath = join(root, "manifest.json");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				deploymentId: "dep_test",
+				environmentId: "env_test",
+				instanceId: "iid_test",
+				generation: 1,
+				issuedAt: "2026-06-04T00:00:00Z",
+				controlPlane: { apiUrl: "https://cloud-api.example.test" },
+				runtimes: {
+					hermes: { enabled: false },
+				},
+				mitmProfiles: {
+					profiles: [
+						{
+							id: "discord-rest-channel",
+							kind: "http",
+							match: {
+								scheme: "https",
+								host: "discord.com",
+								pathPrefix: "/api/",
+								headers: {
+									authorization: {
+										type: "secretRefEquals",
+										secretRef: "secret://channels/discord/bot-token",
+										prefix: "Bot ",
+									},
+								},
+							},
+							rewrite: {
+								upstreamBaseUrl: "http://127.0.0.1:18890/discord",
+								preservePath: true,
+								setHeaders: { "x-clawdi-original-host": "discord.com" },
+							},
+							logging: { redactHeaders: ["authorization"] },
+							owner: "clawdi-channels",
+						},
+					],
+				},
+			}),
+		);
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths(), { manifestPath });
+
+		expect("manifest" in loaded).toBe(true);
+		if (!("manifest" in loaded)) throw new Error("expected manifest load success");
+		expect(loaded.manifest.mitmProfiles?.profiles[0]?.id).toBe("discord-rest-channel");
+	});
+});

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -12,10 +12,23 @@ const srcEntry = join(cliRoot, "src", "index.ts");
  * Uses the src entry (fast; no build step needed). The bin wrapper smoke
  * tests verify the dist path separately (run post-build).
  */
-async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+async function runCli(
+	args: string[],
+	envOverrides: Record<string, string | undefined> = {},
+): Promise<{ stdout: string; stderr: string; code: number }> {
+	const env: Record<string, string> = {
+		...process.env,
+		CLAWDI_NO_AUTO_UPDATE: "1",
+		CLAWDI_NO_UPDATE_CHECK: "1",
+	};
+	for (const [key, value] of Object.entries(envOverrides)) {
+		if (value === undefined) delete env[key];
+		else env[key] = value;
+	}
 	const proc = Bun.spawn(["bun", srcEntry, ...args], {
 		stdout: "pipe",
 		stderr: "pipe",
+		env,
 	});
 	const [stdout, stderr, code] = await Promise.all([
 		new Response(proc.stdout).text(),
@@ -47,19 +60,631 @@ describe("CLI smoke — src entry", () => {
 			"skill",
 			"memory",
 			"doctor",
+			"capabilities",
 			"update",
 			"mcp",
 			"read",
 			"inject",
 			"run",
+			"runtime",
 		]) {
 			expect(stdout).toContain(cmd);
 		}
 	});
 
-	it("runtime namespace is not a top-level command", async () => {
-		const { code } = await runCli(["runtime", "apply", "--target", "hermes"]);
-		expect(code).not.toBe(0);
+	it("capabilities prints JSON without requiring auth", async () => {
+		const { tmpdir } = await import("node:os");
+		const { mkdirSync, rmSync } = await import("node:fs");
+		const fakeHome = join(tmpdir(), `clawdi-smoke-cap-${Date.now()}`);
+		mkdirSync(fakeHome, { recursive: true });
+
+		try {
+			const { stdout, code } = await runCli(["capabilities", "--json"], { HOME: fakeHome });
+			expect(code).toBe(0);
+			const parsed = JSON.parse(stdout);
+			expect(parsed.schemaVersion).toBe("clawdi.capabilities.v1");
+			expect(parsed.commands).toContain("runtime");
+			expect(parsed.updateMode).toBe("local-self-update");
+		} finally {
+			rmSync(fakeHome, { recursive: true, force: true });
+		}
+	});
+
+	it("auth status reports no auth in an isolated HOME", async () => {
+		const { tmpdir } = await import("node:os");
+		const { mkdirSync, rmSync } = await import("node:fs");
+		const fakeHome = join(tmpdir(), `clawdi-smoke-auth-${Date.now()}`);
+		mkdirSync(fakeHome, { recursive: true });
+
+		try {
+			const { stdout, code } = await runCli(["auth", "status", "--json"], {
+				HOME: fakeHome,
+				CLAWDI_AUTH_TOKEN: undefined,
+			});
+			expect(code).toBe(0);
+			const parsed = JSON.parse(stdout);
+			expect(parsed.authenticated).toBe(false);
+			expect(parsed.source).toBe("none");
+			expect(stdout).not.toContain("secret");
+		} finally {
+			rmSync(fakeHome, { recursive: true, force: true });
+		}
+	});
+
+	it("config paths reports local ~/.clawdi paths", async () => {
+		const { tmpdir } = await import("node:os");
+		const { mkdirSync, rmSync } = await import("node:fs");
+		const fakeHome = join(tmpdir(), `clawdi-smoke-paths-${Date.now()}`);
+		mkdirSync(fakeHome, { recursive: true });
+
+		try {
+			const { stdout, code } = await runCli(["config", "paths", "--json"], { HOME: fakeHome });
+			expect(code).toBe(0);
+			const parsed = JSON.parse(stdout);
+			expect(parsed.runtimeMode).toBe("local");
+			expect(parsed.local.config).toBe(join(fakeHome, ".clawdi", "config.json"));
+			expect(parsed.hosted.serviceStateRoot).toBe("/var/lib/clawdi");
+			expect(parsed.hosted.workspaceRoot).toBe(join(fakeHome, "clawdi"));
+			expect(stdout).not.toContain("CLAWDI_AUTH_TOKEN");
+		} finally {
+			rmSync(fakeHome, { recursive: true, force: true });
+		}
+	});
+
+	it("runtime status exits cleanly before runtime init", async () => {
+		const { tmpdir } = await import("node:os");
+		const { mkdirSync, rmSync } = await import("node:fs");
+		const fakeHome = join(tmpdir(), `clawdi-smoke-runtime-status-${Date.now()}`);
+		mkdirSync(fakeHome, { recursive: true });
+
+		try {
+			const { stdout, code } = await runCli(["runtime", "status", "--json"], {
+				HOME: fakeHome,
+				CLAWDI_SERVICE_STATE_DIR: join(fakeHome, "var", "lib", "clawdi"),
+				CLAWDI_RUN_DIR: join(fakeHome, "run", "clawdi"),
+			});
+			expect(code).toBe(0);
+			const parsed = JSON.parse(stdout);
+			expect(parsed.schemaVersion).toBe("clawdi.runtimeStatus.v1");
+			expect(parsed.exists).toBe(false);
+		} finally {
+			rmSync(fakeHome, { recursive: true, force: true });
+		}
+	});
+
+	it("runtime init enters repair and writes boot status without datasource", async () => {
+		const { tmpdir } = await import("node:os");
+		const { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } = await import("node:fs");
+		const root = join(tmpdir(), `clawdi-smoke-runtime-init-${Date.now()}`);
+		const home = join(root, "home", "clawdi");
+		const policyPath = join(root, "etc", "clawdi", "host-policy.json");
+		const serviceStateRoot = join(root, "var", "lib", "clawdi");
+		const runRoot = join(root, "run", "clawdi");
+		mkdirSync(dirname(policyPath), { recursive: true });
+		mkdirSync(home, { recursive: true });
+		writeFileSync(
+			policyPath,
+			JSON.stringify({
+				schemaVersion: "clawdi.hostPolicy.v1",
+				mode: "hosted-runtime",
+				cliUpdateMode: "system-managed-npm",
+				deniedCommands: ["setup", "teardown", "update"],
+			}),
+		);
+
+		const env = {
+			HOME: home,
+			CLAWDI_RUNTIME_MODE: "hosted",
+			CLAWDI_HOST_POLICY_PATH: policyPath,
+			CLAWDI_SERVICE_STATE_DIR: serviceStateRoot,
+			CLAWDI_RUN_DIR: runRoot,
+			CLAWDI_AUTH_TOKEN: undefined,
+		};
+
+		try {
+			const { stdout, code } = await runCli(
+				["runtime", "init", "--non-interactive", "--json"],
+				env,
+			);
+			expect(code).toBe(20);
+			const parsed = JSON.parse(stdout);
+			expect(parsed.mode).toBe("repair");
+			expect(parsed.status).toBe("error");
+			expect(parsed.stage).toBe("detect");
+			expect(parsed.errors).toContain(
+				"missing CLAWDI_AUTH_TOKEN and no last-good runtime manifest cache",
+			);
+			expect(parsed.datasource).toBe("RuntimeSource");
+			expect(parsed.hostPolicy.valid).toBe(true);
+			expect(parsed.paths.serviceStateRoot).toBe(serviceStateRoot);
+			expect(existsSync(join(serviceStateRoot, "cache", "boot-status.json"))).toBe(true);
+			const cloudResult = JSON.parse(
+				readFileSync(join(serviceStateRoot, "boot", "result.json"), "utf-8"),
+			);
+			expect(cloudResult.v1.stage).toBe("detect");
+			expect(cloudResult.v1.errors).toEqual(parsed.errors);
+
+			const status = await runCli(["runtime", "status", "--json"], env);
+			expect(status.code).toBe(0);
+			const statusParsed = JSON.parse(status.stdout);
+			expect(statusParsed.exists).toBe(true);
+			expect(statusParsed.status.mode).toBe("repair");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("runtime init performs first-install convergence from a fixture manifest", async () => {
+		const { tmpdir } = await import("node:os");
+		const { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } =
+			await import("node:fs");
+		const root = join(tmpdir(), `clawdi-smoke-runtime-full-${Date.now()}`);
+		const home = join(root, "home", "clawdi");
+		const policyPath = join(root, "etc", "clawdi", "host-policy.json");
+		const manifestPath = join(root, "runtime-manifest.json");
+		const staleManifestPath = join(root, "runtime-manifest-stale.json");
+		const serviceStateRoot = join(root, "var", "lib", "clawdi");
+		const runRoot = join(root, "run", "clawdi");
+		const openclawInstaller = join(root, "fixtures", "openclaw-install.sh");
+		const hermesInstaller = join(root, "fixtures", "hermes-install.sh");
+		mkdirSync(dirname(policyPath), { recursive: true });
+		mkdirSync(dirname(openclawInstaller), { recursive: true });
+		mkdirSync(home, { recursive: true });
+		writeFileSync(
+			policyPath,
+			JSON.stringify({
+				schemaVersion: "clawdi.hostPolicy.v1",
+				mode: "hosted-runtime",
+				cliUpdateMode: "system-managed-npm",
+				deniedCommands: ["setup", "teardown", "update"],
+			}),
+		);
+		writeFileSync(
+			openclawInstaller,
+			`#!/usr/bin/env bash
+set -euo pipefail
+install -d "$HOME/.openclaw/bin" "$HOME/.openclaw/install-proof"
+printf '%s\\n' "\${NPM_CONFIG_PREFIX:-}" > "$HOME/.openclaw/install-proof/npm-config-prefix"
+printf '%s\\n' "\${NPM_CONFIG_CACHE:-}" > "$HOME/.openclaw/install-proof/npm-config-cache"
+cat > "$HOME/.openclaw/bin/openclaw" <<'SH'
+#!/usr/bin/env bash
+echo "openclaw fixture"
+SH
+chmod +x "$HOME/.openclaw/bin/openclaw"
+`,
+		);
+		chmodSync(openclawInstaller, 0o700);
+		writeFileSync(
+			hermesInstaller,
+			`#!/usr/bin/env bash
+set -euo pipefail
+install -d "$HOME/.local/bin" "$HOME/.hermes/hermes-agent" "$HOME/.hermes/install-proof"
+printf '%s\\n' "\${NPM_CONFIG_PREFIX:-}" > "$HOME/.hermes/install-proof/npm-config-prefix"
+printf '%s\\n' "\${NPM_CONFIG_CACHE:-}" > "$HOME/.hermes/install-proof/npm-config-cache"
+cat > "$HOME/.local/bin/hermes" <<'SH'
+#!/usr/bin/env bash
+echo "hermes fixture"
+SH
+chmod +x "$HOME/.local/bin/hermes"
+`,
+		);
+		chmodSync(hermesInstaller, 0o700);
+
+		const manifest = {
+			schemaVersion: "clawdi.runtimeDesiredState.v1",
+			deploymentId: "dep_test",
+			environmentId: "env_test",
+			instanceId: "iid_test",
+			generation: 7,
+			issuedAt: "2026-06-03T00:00:00Z",
+			controlPlane: { apiUrl: "https://cloud-api.example.test" },
+			clawdiCli: { version: "0.10.1", channel: "stable", source: "npm:clawdi@stable" },
+			runtimes: {
+				openclaw: {
+					enabled: true,
+					updateChannel: "stable",
+					install: {
+						authority: "official",
+						method: "official-installer",
+						url: "https://openclaw.ai/install-cli.sh",
+						home,
+						args: ["--json", "--version", "stable", "--no-onboard"],
+					},
+				},
+				hermes: {
+					enabled: true,
+					updateChannel: "main",
+					install: {
+						authority: "official",
+						method: "official-installer",
+						url: "https://hermes-agent.nousresearch.com/install.sh",
+						home,
+						args: ["--branch", "main", "--skip-setup", "--non-interactive"],
+					},
+					run: {
+						env: {
+							DISCORD_API_BASE_URL: "http://127.0.0.1:4500/discord",
+						},
+						args: ["gateway", "run"],
+					},
+				},
+			},
+			mitmProfiles: {
+				profiles: [
+					{
+						id: "discord-rest-channel",
+						kind: "http",
+						match: {
+							scheme: "https",
+							host: "discord.com",
+							pathPrefix: "/api/",
+							headers: {
+								authorization: {
+									type: "secretRefEquals",
+									secretRef: "secret://channels/discord/bot-token",
+									prefix: "Bot ",
+								},
+							},
+						},
+						rewrite: {
+							upstreamBaseUrl: "http://127.0.0.1:18890/discord",
+							preservePath: true,
+							setHeaders: { "x-clawdi-original-host": "discord.com" },
+						},
+						logging: { redactHeaders: ["authorization"] },
+						owner: "clawdi-channels",
+					},
+				],
+			},
+			projection: {
+				aiProviders: {
+					default: "openai-main/gpt-5.2",
+				},
+				mcp: { command: "clawdi mcp" },
+			},
+			recovery: { cacheManifest: true, allowOfflineBoot: true },
+		};
+		writeFileSync(manifestPath, JSON.stringify(manifest));
+
+		const env = {
+			HOME: home,
+			CLAWDI_RUNTIME_MODE: "hosted",
+			CLAWDI_HOST_POLICY_PATH: policyPath,
+			CLAWDI_SERVICE_STATE_DIR: serviceStateRoot,
+			CLAWDI_RUN_DIR: runRoot,
+			CLAWDI_AUTH_TOKEN: undefined,
+			CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS: "1",
+			CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER: openclawInstaller,
+			CLAWDI_RUNTIME_TEST_HERMES_INSTALLER: hermesInstaller,
+			CLAWDI_RUNTIME_MANIFEST_PATH: undefined,
+			NPM_CONFIG_PREFIX: "/var/lib/clawdi/npm",
+			NPM_CONFIG_CACHE: "/var/lib/clawdi/npm-cache",
+			HERMES_HOME: undefined,
+			OPENCLAW_STATE_DIR: undefined,
+		};
+
+		try {
+			const first = await runCli(
+				["runtime", "init", "--non-interactive", "--json", "--manifest-file", manifestPath],
+				env,
+			);
+			expect(first.code).toBe(0);
+			const parsed = JSON.parse(first.stdout);
+			expect(parsed.mode).toBe("normal");
+			expect(parsed.status).toBe("ok");
+			expect(parsed.stage).toBe("final");
+			expect(parsed.activeGeneration).toBe(7);
+			expect(parsed.enabledRuntimes).toEqual(["hermes", "openclaw"]);
+			expect(parsed.manifestSource.type).toBe("fixture-file");
+			expect(parsed.paths.workspaceRoot).toBe(join(home, "clawdi"));
+			expect(parsed.convergence.mitmProfileBundle).toBe(
+				join(serviceStateRoot, "config", "mitm", "profiles.json"),
+			);
+
+			for (const outputPath of [
+				join(serviceStateRoot, "config", "clawdi.json"),
+				join(serviceStateRoot, "sync", "runtimes.json"),
+				join(serviceStateRoot, "cache", "manifest.last-good.json"),
+				join(runRoot, "instance-data.json"),
+				join(runRoot, "instance-data-sensitive.json"),
+				join(serviceStateRoot, "install-inventory", "openclaw.json"),
+				join(serviceStateRoot, "install-inventory", "hermes.json"),
+				join(serviceStateRoot, "config", "projections", "openclaw.json"),
+				join(serviceStateRoot, "config", "projections", "hermes.json"),
+				join(serviceStateRoot, "config", "run", "openclaw.json"),
+				join(serviceStateRoot, "config", "run", "hermes.json"),
+				join(serviceStateRoot, "supervisor", "supervisord.conf"),
+				join(serviceStateRoot, "config", "mitm", "profiles.json"),
+				join(serviceStateRoot, "instances", "iid_test", "boot-finished"),
+				join(home, "clawdi"),
+				join(home, ".openclaw", "bin", "openclaw"),
+				join(home, ".local", "bin", "hermes"),
+			]) {
+				expect(existsSync(outputPath)).toBe(true);
+			}
+			expect(statSync(join(serviceStateRoot, "cache", "boot-status.json")).mode & 0o777).toBe(
+				0o644,
+			);
+			expect(statSync(join(serviceStateRoot, "boot", "status.json")).mode & 0o777).toBe(0o644);
+			expect(statSync(join(serviceStateRoot, "boot", "result.json")).mode & 0o777).toBe(0o644);
+			expect(statSync(join(runRoot, "instance-data-sensitive.json")).mode & 0o777).toBe(0o600);
+			expect(
+				JSON.parse(readFileSync(join(runRoot, "instance-data-sensitive.json"), "utf-8"))
+					.tokenSource,
+			).toBe("fixture-file");
+			expect(
+				readFileSync(join(home, ".openclaw", "install-proof", "npm-config-prefix"), "utf-8"),
+			).toBe("\n");
+			expect(
+				readFileSync(join(home, ".openclaw", "install-proof", "npm-config-cache"), "utf-8"),
+			).toBe("\n");
+			expect(
+				readFileSync(join(home, ".hermes", "install-proof", "npm-config-prefix"), "utf-8"),
+			).toBe("\n");
+			expect(
+				readFileSync(join(home, ".hermes", "install-proof", "npm-config-cache"), "utf-8"),
+			).toBe("\n");
+
+			const managed = JSON.parse(
+				readFileSync(join(serviceStateRoot, "config", "clawdi.json"), "utf-8"),
+			);
+			expect(managed.generation).toBe(7);
+			expect(JSON.stringify(managed)).not.toContain("auth-test-token");
+			const supervisorConfig = readFileSync(
+				join(serviceStateRoot, "supervisor", "supervisord.conf"),
+				"utf-8",
+			);
+			expect(supervisorConfig).toContain("[program:clawdi-hermes]");
+			expect(supervisorConfig).toContain("[program:clawdi-openclaw]");
+			expect(supervisorConfig).toContain("command=/usr/bin/env clawdi run -- hermes");
+			expect(supervisorConfig).toContain("command=/usr/bin/env clawdi run -- openclaw");
+			expect(supervisorConfig).toContain("user=clawdi");
+			expect(supervisorConfig).not.toContain("auth-test-token");
+			const inventory = JSON.parse(
+				readFileSync(join(serviceStateRoot, "install-inventory", "openclaw.json"), "utf-8"),
+			);
+			expect(inventory.install.url).toBe("https://openclaw.ai/install-cli.sh");
+			expect(inventory.install.args).not.toContain("--dir");
+			expect(inventory.install.args).not.toContain("--prefix");
+			expect(inventory.status).toBe("installed");
+			expect(inventory.commandPath).toBe(join(home, ".openclaw", "bin", "openclaw"));
+			expect(typeof inventory.installStartedAt).toBe("string");
+			expect(typeof inventory.installFinishedAt).toBe("string");
+			expect(typeof inventory.installDurationMs).toBe("number");
+			expect(inventory.installDurationMs).toBeGreaterThanOrEqual(0);
+			const openclawRunConfig = JSON.parse(
+				readFileSync(join(serviceStateRoot, "config", "run", "openclaw.json"), "utf-8"),
+			);
+			expect(openclawRunConfig.schemaVersion).toBe("clawdi.runtimeRunConfig.v1");
+			expect(openclawRunConfig.commandPath).toBe(join(home, ".openclaw", "bin", "openclaw"));
+			expect(openclawRunConfig.defaultArgs).toEqual([
+				"gateway",
+				"run",
+				"--allow-unconfigured",
+				"--auth",
+				"none",
+				"--bind",
+				"loopback",
+				"--force",
+			]);
+			const hermesRunConfig = JSON.parse(
+				readFileSync(join(serviceStateRoot, "config", "run", "hermes.json"), "utf-8"),
+			);
+			expect(hermesRunConfig.schemaVersion).toBe("clawdi.runtimeRunConfig.v1");
+			expect(hermesRunConfig.commandPath).toBe(join(home, ".local", "bin", "hermes"));
+			expect(hermesRunConfig.defaultArgs).toEqual(["gateway", "run"]);
+			expect(hermesRunConfig.env.DISCORD_API_BASE_URL).toBe("http://127.0.0.1:4500/discord");
+			expect(hermesRunConfig.mitmProfileBundlePath).toBe(
+				join(serviceStateRoot, "config", "mitm", "profiles.json"),
+			);
+			const mitmProfiles = JSON.parse(
+				readFileSync(join(serviceStateRoot, "config", "mitm", "profiles.json"), "utf-8"),
+			);
+			expect(mitmProfiles.schemaVersion).toBe("clawdi.mitmProfiles.v1");
+			expect(mitmProfiles.profiles[0].id).toBe("discord-rest-channel");
+			expect(JSON.stringify(mitmProfiles)).toContain("secret://channels/discord/bot-token");
+			expect(JSON.stringify(mitmProfiles)).not.toContain("auth-test-token");
+
+			const offline = await runCli(["runtime", "init", "--non-interactive", "--json"], env);
+			expect(offline.code).toBe(0);
+			const offlineParsed = JSON.parse(offline.stdout);
+			expect(offlineParsed.mode).toBe("degraded-offline");
+			expect(offlineParsed.manifestSource.type).toBe("last-good-cache");
+			expect(offlineParsed.activeGeneration).toBe(7);
+			const offlineInventory = JSON.parse(
+				readFileSync(join(serviceStateRoot, "install-inventory", "openclaw.json"), "utf-8"),
+			);
+			expect(offlineInventory.status).toBe("present");
+
+			writeFileSync(staleManifestPath, JSON.stringify({ ...manifest, generation: 6 }));
+			const stale = await runCli(
+				["runtime", "init", "--non-interactive", "--json", "--manifest-file", staleManifestPath],
+				env,
+			);
+			expect(stale.code).toBe(22);
+			const staleParsed = JSON.parse(stale.stdout);
+			expect(staleParsed.mode).toBe("manifest-rejected");
+			expect(staleParsed.activeGeneration).toBe(7);
+			expect(staleParsed.rejectedGeneration).toBe(6);
+			const lastGood = JSON.parse(
+				readFileSync(join(serviceStateRoot, "cache", "manifest.last-good.json"), "utf-8"),
+			);
+			expect(lastGood.generation).toBe(7);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("runtime init installs only selected runtimes", async () => {
+		const { tmpdir } = await import("node:os");
+		const { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } = await import(
+			"node:fs"
+		);
+		const root = join(tmpdir(), `clawdi-smoke-runtime-selection-${Date.now()}`);
+		const home = join(root, "home", "clawdi");
+		const policyPath = join(root, "etc", "clawdi", "host-policy.json");
+		const manifestPath = join(root, "runtime-manifest.json");
+		const serviceStateRoot = join(root, "var", "lib", "clawdi");
+		const runRoot = join(root, "run", "clawdi");
+		const openclawInstaller = join(root, "fixtures", "openclaw-install.sh");
+		mkdirSync(dirname(policyPath), { recursive: true });
+		mkdirSync(dirname(openclawInstaller), { recursive: true });
+		mkdirSync(home, { recursive: true });
+		writeFileSync(
+			policyPath,
+			JSON.stringify({
+				schemaVersion: "clawdi.hostPolicy.v1",
+				mode: "hosted-runtime",
+				cliUpdateMode: "system-managed-npm",
+				deniedCommands: ["setup", "teardown", "update"],
+			}),
+		);
+		writeFileSync(
+			openclawInstaller,
+			`#!/usr/bin/env bash
+set -euo pipefail
+install -d "$HOME/.openclaw/bin"
+cat > "$HOME/.openclaw/bin/openclaw" <<'SH'
+#!/usr/bin/env bash
+echo "openclaw fixture"
+SH
+chmod +x "$HOME/.openclaw/bin/openclaw"
+`,
+		);
+		chmodSync(openclawInstaller, 0o700);
+
+		writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				deploymentId: "dep_selection",
+				environmentId: "env_selection",
+				instanceId: "iid_selection",
+				generation: 1,
+				issuedAt: "2026-06-04T00:00:00Z",
+				controlPlane: { apiUrl: "https://cloud-api.example.test" },
+				runtimes: {
+					openclaw: {
+						enabled: true,
+						updateChannel: "stable",
+						install: {
+							authority: "official",
+							method: "official-installer",
+							url: "https://openclaw.ai/install-cli.sh",
+							home,
+							args: ["--json", "--no-onboard"],
+						},
+					},
+					hermes: {
+						enabled: false,
+					},
+				},
+				recovery: { cacheManifest: true, allowOfflineBoot: true },
+			}),
+		);
+
+		try {
+			const result = await runCli(
+				["runtime", "init", "--non-interactive", "--json", "--manifest-file", manifestPath],
+				{
+					HOME: home,
+					CLAWDI_RUNTIME_MODE: "hosted",
+					CLAWDI_HOST_POLICY_PATH: policyPath,
+					CLAWDI_SERVICE_STATE_DIR: serviceStateRoot,
+					CLAWDI_RUN_DIR: runRoot,
+					CLAWDI_AUTH_TOKEN: "auth-selection-token",
+					CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS: "1",
+					CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER: openclawInstaller,
+					CLAWDI_RUNTIME_TEST_HERMES_INSTALLER: undefined,
+					CLAWDI_RUNTIME_MANIFEST_PATH: undefined,
+					HERMES_HOME: undefined,
+					OPENCLAW_STATE_DIR: undefined,
+				},
+			);
+			expect(result.code).toBe(0);
+			const parsed = JSON.parse(result.stdout);
+			expect(parsed.enabledRuntimes).toEqual(["openclaw"]);
+			expect(existsSync(join(home, ".openclaw", "bin", "openclaw"))).toBe(true);
+			expect(existsSync(join(home, ".local", "bin", "hermes"))).toBe(false);
+
+			const openclawInventory = JSON.parse(
+				readFileSync(join(serviceStateRoot, "install-inventory", "openclaw.json"), "utf-8"),
+			);
+			const hermesInventory = JSON.parse(
+				readFileSync(join(serviceStateRoot, "install-inventory", "hermes.json"), "utf-8"),
+			);
+			expect(openclawInventory.status).toBe("installed");
+			expect(hermesInventory.status).toBe("disabled");
+			const hermesRunConfig = JSON.parse(
+				readFileSync(join(serviceStateRoot, "config", "run", "hermes.json"), "utf-8"),
+			);
+			expect(hermesRunConfig.enabled).toBe(false);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("runtime init writes repair status when host policy is missing", async () => {
+		const { tmpdir } = await import("node:os");
+		const { existsSync, mkdirSync, rmSync } = await import("node:fs");
+		const root = join(tmpdir(), `clawdi-smoke-runtime-no-policy-${Date.now()}`);
+		const home = join(root, "home", "clawdi");
+		const policyPath = join(root, "etc", "clawdi", "missing-host-policy.json");
+		const serviceStateRoot = join(root, "var", "lib", "clawdi");
+		mkdirSync(home, { recursive: true });
+
+		try {
+			const { stdout, code } = await runCli(["runtime", "init", "--non-interactive", "--json"], {
+				HOME: home,
+				CLAWDI_RUNTIME_MODE: "hosted",
+				CLAWDI_HOST_POLICY_PATH: policyPath,
+				CLAWDI_SERVICE_STATE_DIR: serviceStateRoot,
+				CLAWDI_RUN_DIR: join(root, "run", "clawdi"),
+				CLAWDI_AUTH_TOKEN: "auth-test-token",
+			});
+			expect(code).toBe(20);
+			const parsed = JSON.parse(stdout);
+			expect(parsed.mode).toBe("repair");
+			expect(parsed.stage).toBe("detect");
+			expect(parsed.hostPolicy.exists).toBe(false);
+			expect(parsed.errors[0]).toContain("missing hosted runtime policy");
+			expect(existsSync(join(serviceStateRoot, "cache", "boot-status.json"))).toBe(true);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("hosted policy denies local-user mutation commands", async () => {
+		const { tmpdir } = await import("node:os");
+		const { mkdirSync, rmSync, writeFileSync } = await import("node:fs");
+		const root = join(tmpdir(), `clawdi-smoke-policy-${Date.now()}`);
+		const home = join(root, "home", "clawdi");
+		const policyPath = join(root, "etc", "clawdi", "host-policy.json");
+		mkdirSync(dirname(policyPath), { recursive: true });
+		mkdirSync(home, { recursive: true });
+		writeFileSync(
+			policyPath,
+			JSON.stringify({
+				schemaVersion: "clawdi.hostPolicy.v1",
+				mode: "hosted-runtime",
+				deniedCommands: [{ command: "config set", reason: "managed config is runtime-owned" }],
+			}),
+		);
+
+		try {
+			const result = await runCli(["config", "set", "apiUrl", "http://example.test"], {
+				HOME: home,
+				CLAWDI_RUNTIME_MODE: "hosted",
+				CLAWDI_HOST_POLICY_PATH: policyPath,
+				CLAWDI_SERVICE_STATE_DIR: join(root, "var", "lib", "clawdi"),
+				CLAWDI_RUN_DIR: join(root, "run", "clawdi"),
+			});
+			expect(result.code).not.toBe(0);
+			expect(result.stderr).toContain("disabled in hosted runtime mode");
+			expect(result.stderr).toContain("managed config is runtime-owned");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
 	});
 
 	it("status exits cleanly when not logged in (via isolated HOME)", async () => {


### PR DESCRIPTION
## Why

Hosted runtime v2 needs to run unmodified OpenClaw/Hermes while Clawdi still manages provider routing and external channels. The runtime image should not bake msg-router-specific state or upstream endpoint patches. This PR moves the local runtime boundary into the open-source `clawdi` CLI: `clawdi runtime init` consumes a controller manifest, and `clawdi run -- <runtime>` launches children with managed run config, short-lived secrets, and a native MITM broker.

## What Changed

- Adds hosted runtime manifest loading, validation, last-good caching, run-config projection, host policy checks, and boot status files.
- Adds top-level hosted manifest `channels` support. New v2 manifests can emit `channels.telegram` for Kobb/Telegram Bot API routing without using `sharedBots` or msg-router. Legacy `sharedBots` manifests remain accepted only as a compatibility input.
- Adds a self-contained native Go MITM broker bundle and `clawdi run` integration for HTTP, CONNECT/TLS, WebSocket, profile matching, and secretRef-gated routing.
- Adds managed provider profiles for Codex/OpenAI-compatible traffic and channel profiles for Telegram, Discord, WhatsApp, and iMessage-compatible surfaces.
- Keeps deployment selection, rollout policy, channel credential lifecycle, UI policy, and runtime image concerns outside this CLI repo.
- Documents the clean hosted-runtime flow, Channels boundary, Agent Vault alignment, and OpenClaw/Hermes endpoint inventory.

## Verification

- `bun run --filter clawdi typecheck`
- `bun test --isolate --max-concurrency=1 packages/cli/tests/runtime.test.ts packages/cli/tests/runtime-mitm-profiles.test.ts packages/cli/tests/runtime-mitm-broker.test.ts packages/cli/tests/commands/run.test.ts packages/cli/tests/smoke.test.ts`
- `go test ./...` in `packages/cli/native/mitm-broker`
- `CLAWDI_MITM_BROKER_BUNDLE_OUTDIR=clawdi-mitm-broker bun run --cwd packages/cli build:mitm-broker`
- `bun run --cwd packages/cli check:publish-manifest`

## Release Notes

Publishing should use the normal npm package channel for `clawdi`. This PR does not introduce backend artifact URLs, image-baked CLI update channels, or hosted-service-specific API routes in the CLI.
