### PR TITLE
Consolidate daemon into singleton with control RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,8 @@ Package: `clawdi@0.11.0`
 
 ### Added
 
-- Added `clawdi daemon ping` plus advanced `clawdi daemon rpc` access for
-  local daemon control operations such as status, doctor, logs, lifecycle
-  actions, and control-token rotation.
+- Added `clawdi daemon ping` and `clawdi daemon rotate-token` for local daemon
+  control checks and token rotation.
 - Added headless daemon RPC methods for sync, vault, auth, update, and
   long-running operation status/log inspection.
 - Added HTTP JSON-RPC host/port binding for daemon control. It listens on
@@ -40,7 +39,7 @@ Package: `clawdi@0.11.0`
 
 - Daemon control RPC now requires bearer-token auth on every request. The
   generated token is stored owner-only, can be rotated with
-  `clawdi daemon rpc rotate_token`, and is checked with timing-safe comparison.
+  `clawdi daemon rotate-token`, and is checked with timing-safe comparison.
 - HTTP RPC listeners bind to loopback by default. Non-loopback binds require
   explicit `--rpc-allow-remote` opt-in and should only be used behind SSH
   tunneling, private networking, or TLS termination.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,14 +41,11 @@ Package: `clawdi@0.11.0`
 - Daemon control RPC now requires bearer-token auth on every request. The
   generated token is stored owner-only, can be rotated with
   `daemon.rotate_token`, and is checked with timing-safe comparison.
-- Added scoped daemon RPC tokens through `daemon.issue_token`. Non-loopback HTTP
-  listeners reject the local root control token and require scoped tokens.
 - HTTP RPC listeners bind to loopback by default. Non-loopback binds require
   explicit `--rpc-allow-remote` opt-in and should only be used behind SSH
   tunneling, private networking, or TLS termination.
-- Vault plaintext RPC calls require both explicit confirmation and the
-  `vault:secrets` capability; plaintext rendering cannot be sent to background
-  operation logs.
+- Vault plaintext RPC calls require explicit confirmation; plaintext rendering
+  cannot be sent to background operation logs.
 
 ## Clawdi CLI v0.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Package: `clawdi@0.11.0`
   generated token is stored owner-only, can be rotated with
   `clawdi daemon rotate-token`, and is checked with timing-safe comparison.
 - HTTP RPC listeners bind to loopback by default. Non-loopback binds require
-  explicit `--rpc-allow-remote` opt-in and should only be used behind SSH
+  explicit `--allow-remote` opt-in and should only be used behind SSH
   tunneling, private networking, or TLS termination.
 - Vault plaintext RPC calls require explicit confirmation; plaintext rendering
   cannot be sent to background operation logs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.11.0
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.11.0
+
+Package: `clawdi@0.11.0`
+
+### Changed
+
+- `clawdi daemon` now installs one singleton launchd/systemd unit that syncs
+  every registered local agent. User-facing per-agent daemon install, restart,
+  uninstall, logs, and `--all` controls were removed; use
+  `clawdi daemon status --agent <type>` when you need a focused status view.
+- Existing per-agent daemon units are migrated automatically. Re-running
+  `clawdi setup` or `clawdi daemon install` installs the singleton and removes
+  old per-agent supervisor units.
+
+### Added
+
+- Added `clawdi daemon rpc` for local daemon control operations such as
+  `daemon.ping`, `daemon.status`, `daemon.doctor`, `daemon.logs`, lifecycle
+  actions, and control-token rotation.
+- Added optional HTTP JSON-RPC host/port binding for daemon control. The
+  owner-only Unix socket remains enabled by default.
+
+### Security
+
+- Daemon control RPC now requires bearer-token auth on every request. The
+  generated token is stored owner-only, can be rotated with
+  `daemon.rotate_token`, and is checked with timing-safe comparison.
+- HTTP RPC listeners bind to loopback by default. Non-loopback binds require
+  explicit `--rpc-allow-remote` opt-in and should only be used behind SSH
+  tunneling, private networking, or TLS termination.
+
 ## Clawdi CLI v0.10.1
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.10.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,19 +28,19 @@ Package: `clawdi@0.11.0`
 
 ### Added
 
-- Added `clawdi daemon rpc` for local daemon control operations such as
-  `daemon.ping`, `daemon.status`, `daemon.doctor`, `daemon.logs`, lifecycle
+- Added `clawdi daemon ping` plus advanced `clawdi daemon rpc` access for
+  local daemon control operations such as status, doctor, logs, lifecycle
   actions, and control-token rotation.
 - Added headless daemon RPC methods for sync, vault, auth, update, and
   long-running operation status/log inspection.
-- Added optional HTTP JSON-RPC host/port binding for daemon control. The
-  owner-only Unix socket remains enabled by default.
+- Added HTTP JSON-RPC host/port binding for daemon control. It listens on
+  `127.0.0.1:17654` by default and supports custom host/port configuration.
 
 ### Security
 
 - Daemon control RPC now requires bearer-token auth on every request. The
   generated token is stored owner-only, can be rotated with
-  `daemon.rotate_token`, and is checked with timing-safe comparison.
+  `clawdi daemon rpc rotate_token`, and is checked with timing-safe comparison.
 - HTTP RPC listeners bind to loopback by default. Non-loopback binds require
   explicit `--rpc-allow-remote` opt-in and should only be used behind SSH
   tunneling, private networking, or TLS termination.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Package: `clawdi@0.11.0`
 - Added `clawdi daemon rpc` for local daemon control operations such as
   `daemon.ping`, `daemon.status`, `daemon.doctor`, `daemon.logs`, lifecycle
   actions, and control-token rotation.
+- Added headless daemon RPC methods for sync, vault, auth, update, and
+  long-running operation status/log inspection.
 - Added optional HTTP JSON-RPC host/port binding for daemon control. The
   owner-only Unix socket remains enabled by default.
 
@@ -39,9 +41,14 @@ Package: `clawdi@0.11.0`
 - Daemon control RPC now requires bearer-token auth on every request. The
   generated token is stored owner-only, can be rotated with
   `daemon.rotate_token`, and is checked with timing-safe comparison.
+- Added scoped daemon RPC tokens through `daemon.issue_token`. Non-loopback HTTP
+  listeners reject the local root control token and require scoped tokens.
 - HTTP RPC listeners bind to loopback by default. Non-loopback binds require
   explicit `--rpc-allow-remote` opt-in and should only be used behind SSH
   tunneling, private networking, or TLS termination.
+- Vault plaintext RPC calls require both explicit confirmation and the
+  `vault:secrets` capability; plaintext rendering cannot be sent to background
+  operation logs.
 
 ## Clawdi CLI v0.10.1
 

--- a/README.md
+++ b/README.md
@@ -298,9 +298,9 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](packages/cli
 | `clawdi auth login` / `logout` | Authenticate this machine |
 | `clawdi status [--json]` | Show auth and sync state |
 | `clawdi config list/get/set/unset` | Read or write CLI configuration |
-| `clawdi setup [--agent <type>] [--no-daemon]` | Register local agents, install MCP, install the bundled skill, and install/start daemons by default |
+| `clawdi setup [--agent <type>] [--no-daemon]` | Register local agents, install MCP, install the bundled skill, and install/start the singleton daemon by default |
 | `clawdi teardown [--agent <type>]` | Remove Clawdi's local agent wiring |
-| `clawdi daemon run/install/status/logs/doctor/restart/uninstall` | Run and manage the background sync daemon (`serve` remains a legacy alias) |
+| `clawdi daemon run/install/status/logs/doctor/restart/uninstall/ping/rpc` | Run, inspect, and control the singleton background sync daemon (`serve` remains a legacy alias) |
 | `clawdi push` | Upload sessions and skills |
 | `clawdi pull` | Download cloud skills into registered agents |
 | `clawdi session list/extract` | Inspect local agent sessions |
@@ -387,7 +387,7 @@ Common issues:
 - **No supported agent detected** - Install a supported agent or pass `--agent claude_code`, `--agent codex`, `--agent hermes`, or `--agent openclaw`.
 - **Memory search is empty** - Add a memory first with `clawdi memory add "..."`, then verify with `clawdi memory search "..."`.
 - **Local backend cannot start because `vector` is missing** - Install `pgvector` for your PostgreSQL 16 instance, or use the included Docker Compose database.
-- **Agent MCP tools look stale** - Run `clawdi setup --agent <type>` again, then `clawdi daemon restart --all`.
+- **Agent MCP tools look stale** - Run `clawdi setup --agent <type>` again, then `clawdi daemon restart`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](packages/cli
 | `clawdi config list/get/set/unset` | Read or write CLI configuration |
 | `clawdi setup [--agent <type>] [--no-daemon]` | Register local agents, install MCP, install the bundled skill, and install/start the singleton daemon by default |
 | `clawdi teardown [--agent <type>]` | Remove Clawdi's local agent wiring |
-| `clawdi daemon run/install/status/logs/doctor/restart/uninstall/ping/rpc` | Run, inspect, and control the singleton background sync daemon (`serve` remains a legacy alias) |
+| `clawdi daemon run/install/status/logs/doctor/restart/uninstall/ping/rotate-token` | Run, inspect, and control the singleton background sync daemon (`serve` remains a legacy alias) |
 | `clawdi push` | Upload sessions and skills |
 | `clawdi pull` | Download cloud skills into registered agents |
 | `clawdi session list/extract` | Inspect local agent sessions |

--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -134,13 +134,13 @@ clawdi daemon status
 If the user opted out during setup, install it now:
 
 ```bash
-clawdi daemon install --all
+clawdi daemon install
 ```
 
 The install command writes a launchd unit on macOS or a systemd `--user` service on Linux, then loads it. The daemon stays alive across reboots and respawns on crash. Ongoing logs:
 
-- macOS: `tail -f ~/.clawdi/serve/logs/<agent>.stderr.log`
-- Linux: `journalctl --user -u clawdi-serve-<agent> -f`
+- macOS: `tail -f ~/.clawdi/serve/logs/daemon.stderr.log`
+- Linux: `journalctl --user -u clawdi-serve.service -f`
 
 What the user gets:
 
@@ -154,7 +154,7 @@ Skip this step only if the user explicitly says they want manual sync. The CLI f
 If install fails (no launchd / systemd, e.g. inside a minimal container), fall back to running the daemon in the foreground and ask the user to wire their own supervisor:
 
 ```bash
-clawdi daemon run --agent claude_code
+clawdi daemon run
 ```
 
 ## Sync skills (optional one-time backup)

--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -149,7 +149,7 @@ clawdi daemon run
 clawdi daemon ping
 ```
 
-For non-loopback HTTP RPC, use a private network, SSH tunnel, or TLS proxy and pass the generated daemon token through `--rpc-token` or `CLAWDI_DAEMON_RPC_TOKEN`; treat it as an admin token.
+For non-loopback HTTP RPC, use a private network, SSH tunnel, or TLS proxy and pass the generated daemon token through `--token` on daemon commands or `CLAWDI_DAEMON_RPC_TOKEN`; treat it as an admin token.
 
 What the user gets:
 

--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -142,11 +142,11 @@ The install command writes a launchd unit on macOS or a systemd `--user` service
 - macOS: `tail -f ~/.clawdi/serve/logs/daemon.stderr.log`
 - Linux: `journalctl --user -u clawdi-serve.service -f`
 
-The control RPC uses an owner-only Unix socket by default. If the user needs local HTTP RPC, install with an explicit loopback host and port; every RPC request still requires the generated bearer token:
+The control RPC listens on loopback HTTP by default; every RPC request requires the generated bearer token:
 
 ```bash
-clawdi daemon install --rpc-host 127.0.0.1 --rpc-port 17654
-clawdi daemon rpc daemon.ping --rpc-host 127.0.0.1 --rpc-port 17654
+clawdi daemon run
+clawdi daemon ping
 ```
 
 For non-loopback HTTP RPC, use a private network, SSH tunnel, or TLS proxy and pass the generated daemon token through `--rpc-token` or `CLAWDI_DAEMON_RPC_TOKEN`; treat it as an admin token.

--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -149,7 +149,7 @@ clawdi daemon install --rpc-host 127.0.0.1 --rpc-port 17654
 clawdi daemon rpc daemon.ping --rpc-host 127.0.0.1 --rpc-port 17654
 ```
 
-For non-loopback HTTP RPC, issue a scoped token from the local socket with `clawdi daemon rpc daemon.issue_token` and pass the returned token through `--rpc-token` or `CLAWDI_DAEMON_RPC_TOKEN`; don't send the local root token to remote clients.
+For non-loopback HTTP RPC, use a private network, SSH tunnel, or TLS proxy and pass the generated daemon token through `--rpc-token` or `CLAWDI_DAEMON_RPC_TOKEN`; treat it as an admin token.
 
 What the user gets:
 

--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -149,6 +149,8 @@ clawdi daemon install --rpc-host 127.0.0.1 --rpc-port 17654
 clawdi daemon rpc daemon.ping --rpc-host 127.0.0.1 --rpc-port 17654
 ```
 
+For non-loopback HTTP RPC, issue a scoped token from the local socket with `clawdi daemon rpc daemon.issue_token` and pass the returned token through `--rpc-token` or `CLAWDI_DAEMON_RPC_TOKEN`; don't send the local root token to remote clients.
+
 What the user gets:
 
 - Edit a SKILL.md locally → uploaded to the cloud within ~1s

--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -142,7 +142,7 @@ The install command writes a launchd unit on macOS or a systemd `--user` service
 - macOS: `tail -f ~/.clawdi/serve/logs/daemon.stderr.log`
 - Linux: `journalctl --user -u clawdi-serve.service -f`
 
-The control RPC uses an owner-only Unix socket by default. If the user needs TCP, install with an explicit host and port; every RPC request still requires the generated bearer token:
+The control RPC uses an owner-only Unix socket by default. If the user needs local HTTP RPC, install with an explicit loopback host and port; every RPC request still requires the generated bearer token:
 
 ```bash
 clawdi daemon install --rpc-host 127.0.0.1 --rpc-port 17654

--- a/apps/web/public/skill.md
+++ b/apps/web/public/skill.md
@@ -142,6 +142,13 @@ The install command writes a launchd unit on macOS or a systemd `--user` service
 - macOS: `tail -f ~/.clawdi/serve/logs/daemon.stderr.log`
 - Linux: `journalctl --user -u clawdi-serve.service -f`
 
+The control RPC uses an owner-only Unix socket by default. If the user needs TCP, install with an explicit host and port; every RPC request still requires the generated bearer token:
+
+```bash
+clawdi daemon install --rpc-host 127.0.0.1 --rpc-port 17654
+clawdi daemon rpc daemon.ping --rpc-host 127.0.0.1 --rpc-port 17654
+```
+
 What the user gets:
 
 - Edit a SKILL.md locally → uploaded to the cloud within ~1s

--- a/apps/web/src/components/dashboard/add-agent-setup.tsx
+++ b/apps/web/src/components/dashboard/add-agent-setup.tsx
@@ -35,13 +35,13 @@ const CLI_STEPS = [
 		title: "Connect and enable sync",
 		code: "clawdi setup",
 		description:
-			"Detects Claude Code / Codex / Hermes / OpenClaw, registers each one with your account, and installs background daemons by default.",
+			"Detects Claude Code / Codex / Hermes / OpenClaw, registers each one with your account, and installs the background daemon by default.",
 	},
 	{
 		title: "Check live sync",
 		code: "clawdi daemon status",
 		description:
-			"Shows the daemon state for every registered agent. If you opted out during setup, run `clawdi daemon install --all`.",
+			"Shows the daemon state for every registered agent. If you opted out during setup, run `clawdi daemon install`.",
 	},
 	{
 		title: "One-time history backup (optional)",

--- a/apps/web/src/components/dashboard/daemon-status.tsx
+++ b/apps/web/src/components/dashboard/daemon-status.tsx
@@ -434,7 +434,7 @@ function SyncHelpDialog({
 										</p>
 										<CommandLine command="clawdi daemon status" />
 										<p className="text-sm text-muted-foreground">If it&apos;s down, restart:</p>
-										<CommandLine command={`clawdi daemon install --agent ${env.agent_type}`} />
+										<CommandLine command="clawdi daemon install" />
 									</div>
 								)
 							) : null}
@@ -503,14 +503,14 @@ function SyncSetupSnippet({ env }: { env: Env }) {
 }
 
 /** Hand-off prompt the user pastes into Claude / Codex / etc. The
- * agent reads the prompt, runs `clawdi daemon install --all`, and
+ * agent reads the prompt, runs `clawdi daemon install`, and
  * confirms with `clawdi daemon status`. Mirrors the prose tone and
  * structure of `useAgentPrompt` in add-agent-setup.tsx. */
 function useSyncAgentPrompt(env: Env): string {
 	const typeLabel = agentTypeLabel(env.agent_type);
 	return [
 		`Turn on Clawdi live sync on this machine for ${typeLabel}.`,
-		"Run `clawdi daemon install --all` to install the per-user daemon for every Clawdi-registered agent on this machine.",
+		"Run `clawdi daemon install` to install one per-user daemon that syncs every Clawdi-registered agent on this machine.",
 		"Then confirm with `clawdi daemon status` and report whether the daemon is live.",
 	].join(" ");
 }
@@ -527,15 +527,13 @@ function SyncSetupAgentTab({ env }: { env: Env }) {
 	);
 }
 
-function SyncSetupCliTab({ env }: { env: Env }) {
-	const perAgentCmd = `clawdi daemon install --agent ${env.agent_type}`;
-	const allCmd = "clawdi daemon install --all";
+function SyncSetupCliTab(_props: { env: Env }) {
+	const installCmd = "clawdi daemon install";
 	return (
 		<div className="space-y-3">
-			<p className="text-sm text-muted-foreground">In a terminal on this machine, run either:</p>
+			<p className="text-sm text-muted-foreground">In a terminal on this machine, run:</p>
 			<div className="space-y-1.5">
-				<CommandLine command={perAgentCmd} hint="this agent only" />
-				<CommandLine command={allCmd} hint="every agent on this machine" />
+				<CommandLine command={installCmd} hint="single daemon for every agent on this machine" />
 			</div>
 			<p className="text-xs text-muted-foreground">
 				Installs a launchd (macOS) or systemd (Linux) unit so the daemon survives reboots.

--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.10.1",
+      "version": "0.11.0",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/clawdi-serve-test-guide.md
+++ b/docs/clawdi-serve-test-guide.md
@@ -98,8 +98,11 @@ won't collide with anyone's real login. Tear it down later with
 
 ```sh
 export CLAWDI_AUTH_TOKEN="$RAW_KEY"
-export CLAWDI_ENVIRONMENT_ID="$ENV_ID"
 export CLAUDE_CONFIG_DIR=/tmp/manual-claude   # fake skills dir
+mkdir -p ~/.clawdi/environments
+cat > ~/.clawdi/environments/claude_code.json <<EOF
+{"id":"$ENV_ID","agentType":"claude_code"}
+EOF
 mkdir -p $CLAUDE_CONFIG_DIR/skills/test-skill
 cat > $CLAUDE_CONFIG_DIR/skills/test-skill/SKILL.md <<'EOF'
 ---
@@ -110,7 +113,7 @@ description: manual test
 EOF
 
 # CLAWDI_SERVE_DEBUG=1 prints debug-level events on stderr.
-CLAWDI_SERVE_DEBUG=1 bun run packages/cli/src/index.ts daemon run --agent claude_code
+CLAWDI_SERVE_DEBUG=1 bun run packages/cli/src/index.ts daemon run
 ```
 
 You should see (filtered to the interesting events):
@@ -178,23 +181,22 @@ rm -rf /tmp/manual-claude
 If you want the daemon supervised by launchd / systemd:
 
 ```sh
-clawdi daemon install --agent claude_code
+clawdi daemon install
 clawdi daemon status --agent claude_code
-clawdi daemon uninstall --agent claude_code  # when done
+clawdi daemon uninstall  # when done
 ```
 
-Logs land at `~/.clawdi/serve/logs/<agent>.{stdout,stderr}.log`
-on macOS and via `journalctl --user -u clawdi-serve-<agent>` on
-Linux.
+Logs land at `~/.clawdi/serve/logs/daemon.{stdout,stderr}.log`
+on macOS and via `journalctl --user -u clawdi-serve.service` on Linux.
 
 ## Troubleshooting
 
 **`serve.no_auth`** — `~/.clawdi/auth.json` missing AND no
 `CLAWDI_AUTH_TOKEN` env. Run `clawdi auth login` or set the env.
 
-**`serve.no_environment`** — no `~/.clawdi/environments/<agent>.json`,
-no `--environment-id` flag, no `CLAWDI_ENVIRONMENT_ID` env. Run
-`clawdi setup` or pass `--environment-id` explicitly.
+**`serve.no_environment`** — no `~/.clawdi/environments/<agent>.json`.
+Run `clawdi setup`; in a single-agent container, set both
+`CLAWDI_AGENT_TYPE` and `CLAWDI_ENVIRONMENT_ID`.
 
 **`watcher.fs_watch_failed` → falls back to poll** — expected
 inside containers / overlay-fs. The 30s poll picks up edits but
@@ -219,7 +221,8 @@ only conduit.
 | Var | Role |
 |---|---|
 | `CLAWDI_AUTH_TOKEN` | Deploy key. Bypasses `~/.clawdi/auth.json` so no interactive login is needed. |
-| `CLAWDI_ENVIRONMENT_ID` | The env this pod represents. Bypasses `~/.clawdi/environments/*.json`. |
+| `CLAWDI_AGENT_TYPE` | Agent adapter to load when the container has no `~/.clawdi/environments/*.json` registry. |
+| `CLAWDI_ENVIRONMENT_ID` | The env this single-agent pod represents. Bypasses `~/.clawdi/environments/*.json`. |
 | `CLAWDI_API_URL` | Cloud backend (e.g. `https://cloud-api.clawdi.ai`). |
 | `CLAWDI_SERVE_MODE=container` | Forces poll mode (overlay-fs doesn't fire fs.watch reliably). |
 
@@ -245,9 +248,8 @@ only conduit.
 ### Entrypoint shape
 
 ```sh
-exec clawdi daemon run --agent ${CLAWDI_AGENT_TYPE:-hermes}
+exec clawdi daemon run
 ```
 
-`--agent` is required when `CLAWDI_ENVIRONMENT_ID` is set (the
-env-pick logic uses agent_type to disambiguate the local
-adapter to load).
+Set `CLAWDI_AGENT_TYPE` when the image does not contain a
+`~/.clawdi/environments/<agent>.json` registry file.

--- a/docs/clawdi-serve-test-guide.md
+++ b/docs/clawdi-serve-test-guide.md
@@ -222,9 +222,10 @@ clawdi daemon rpc operation.status --params '{"id":"<operation-id>"}'
 clawdi daemon rpc operation.logs --params '{"id":"<operation-id>","limit":100}'
 ```
 
-Vault plaintext access is opt-in. `vault.resolve` and `vault.read`
-default to redacted dry-runs unless the request explicitly passes
-`confirm_secret_access: true`; plaintext access cannot be backgrounded
+Vault plaintext access is opt-in. `vault.resolve` defaults to a
+redacted dry-run unless the request explicitly asks for plaintext.
+`vault.read` and `vault.inject` require `confirm_secret_access: true`
+before rendering plaintext, and plaintext access cannot be backgrounded
 into an operation log. Mutating vault calls that would otherwise prompt
 must pass their non-interactive confirmation, such as `yes: true`.
 

--- a/docs/clawdi-serve-test-guide.md
+++ b/docs/clawdi-serve-test-guide.md
@@ -189,6 +189,18 @@ clawdi daemon uninstall  # when done
 Logs land at `~/.clawdi/serve/logs/daemon.{stdout,stderr}.log`
 on macOS and via `journalctl --user -u clawdi-serve.service` on Linux.
 
+The control RPC always exposes the owner-only Unix socket. To also
+listen on TCP, pass an explicit host and port at install time:
+
+```sh
+clawdi daemon install --rpc-host 127.0.0.1 --rpc-port 17654
+clawdi daemon rpc daemon.ping --rpc-host 127.0.0.1 --rpc-port 17654
+```
+
+TCP RPC requests require the generated bearer token by default. The
+CLI reads it from `~/.clawdi/daemon/control-token`; remote clients can
+pass it through `CLAWDI_DAEMON_RPC_TOKEN` or `--rpc-token`.
+
 ## Troubleshooting
 
 **`serve.no_auth`** — `~/.clawdi/auth.json` missing AND no
@@ -225,6 +237,9 @@ only conduit.
 | `CLAWDI_ENVIRONMENT_ID` | The env this single-agent pod represents. Bypasses `~/.clawdi/environments/*.json`. |
 | `CLAWDI_API_URL` | Cloud backend (e.g. `https://cloud-api.clawdi.ai`). |
 | `CLAWDI_SERVE_MODE=container` | Forces poll mode (overlay-fs doesn't fire fs.watch reliably). |
+| `CLAWDI_DAEMON_RPC_HOST` | Optional TCP host for the daemon control RPC. Requires `CLAWDI_DAEMON_RPC_PORT`. |
+| `CLAWDI_DAEMON_RPC_PORT` | Optional TCP port for the daemon control RPC. Requests still require bearer token auth. |
+| `CLAWDI_DAEMON_RPC_TOKEN` | Optional client-side bearer token for `clawdi daemon rpc` when the token file is not local. |
 
 ### Per-agent paths
 

--- a/docs/clawdi-serve-test-guide.md
+++ b/docs/clawdi-serve-test-guide.md
@@ -197,11 +197,20 @@ clawdi daemon install --rpc-host 127.0.0.1 --rpc-port 17654
 clawdi daemon rpc daemon.ping --rpc-host 127.0.0.1 --rpc-port 17654
 ```
 
-HTTP RPC requests require the generated bearer token by default. The
-CLI reads it from `~/.clawdi/daemon/control-token`; remote clients can
-pass it through `CLAWDI_DAEMON_RPC_TOKEN` or `--rpc-token`.
-Rotate the token with `clawdi daemon rpc daemon.rotate_token`; update
-remote clients with the returned token.
+HTTP RPC requests require bearer-token auth by default. The CLI reads
+the local root token from `~/.clawdi/daemon/control-token`; remote
+clients should use scoped tokens instead of the root token. Issue one
+from the owner-only Unix socket:
+
+```sh
+clawdi daemon rpc daemon.issue_token \
+  --params '{"label":"remote-dev","capabilities":["daemon:read","sync:run"],"expires_in_seconds":86400}'
+```
+
+Remote clients can pass the returned token through
+`CLAWDI_DAEMON_RPC_TOKEN` or `--rpc-token`. Rotate the root token with
+`clawdi daemon rpc daemon.rotate_token`; this invalidates all scoped
+tokens because they are signed by the root token.
 
 The RPC surface is discoverable:
 
@@ -228,10 +237,11 @@ must pass their non-interactive confirmation, such as `yes: true`.
 
 Non-loopback HTTP binds are rejected unless the daemon is started or
 installed with `--rpc-allow-remote` (or
-`CLAWDI_DAEMON_RPC_ALLOW_REMOTE=1`). Do not expose that listener directly
-on the public internet: the protocol is cleartext HTTP with bearer-token
-auth. Use an SSH tunnel, a private network, or a TLS-terminating reverse
-proxy.
+`CLAWDI_DAEMON_RPC_ALLOW_REMOTE=1`). Non-loopback HTTP listeners reject
+the local root token and require a scoped token. Do not expose that
+listener directly on the public internet: the protocol is cleartext HTTP
+with bearer-token auth. Use an SSH tunnel, a private network, or a
+TLS-terminating reverse proxy.
 
 ## Troubleshooting
 

--- a/docs/clawdi-serve-test-guide.md
+++ b/docs/clawdi-serve-test-guide.md
@@ -201,14 +201,21 @@ The default endpoint is `127.0.0.1:17654`. Pass `--rpc-host` and
 
 HTTP RPC requests require bearer-token auth by default. The CLI reads
 the daemon token from `~/.clawdi/daemon/control-token`. Remote clients
-can pass that token through `CLAWDI_DAEMON_RPC_TOKEN` or `--rpc-token`.
+can pass that token through `CLAWDI_DAEMON_RPC_TOKEN` or `--rpc-token`
+on daemon commands that call the control endpoint.
 Treat it as an admin token. Rotate it with
-`clawdi daemon rpc rotate_token`.
+`clawdi daemon rotate-token`.
 
-The RPC surface is discoverable:
+The CLI intentionally exposes specific daemon commands instead of a generic
+raw RPC command. For protocol-level tests or external control clients, call
+the HTTP JSON-RPC endpoint directly:
 
 ```sh
-clawdi daemon rpc methods --rpc-host 127.0.0.1 --rpc-port 17654
+TOKEN=$(cat ~/.clawdi/daemon/control-token)
+curl -s http://127.0.0.1:17654/rpc \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"methods","params":{}}'
 ```
 
 Daemon control methods use short names: `ping`, `methods`, `status`,
@@ -222,10 +229,15 @@ for `sync.push`, `sync.pull`, `vault.*`, `auth.*`, `update.*`, and
 `operation.*`. Long-running commands return an operation id:
 
 ```sh
-clawdi daemon rpc sync.push \
-  --params '{"cwd":"/path/to/project","agent":"codex"}'
-clawdi daemon rpc operation.status --params '{"id":"<operation-id>"}'
-clawdi daemon rpc operation.logs --params '{"id":"<operation-id>","limit":100}'
+curl -s http://127.0.0.1:17654/rpc \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"sync.push","params":{"cwd":"/path/to/project","agent":"codex"}}'
+
+curl -s http://127.0.0.1:17654/rpc \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"operation.status","params":{"id":"<operation-id>"}}'
 ```
 
 Vault plaintext access is opt-in. `vault.resolve` defaults to a
@@ -281,7 +293,7 @@ only conduit.
 | `CLAWDI_DAEMON_RPC_HOST` | HTTP host for the daemon control RPC. Defaults to `127.0.0.1`. |
 | `CLAWDI_DAEMON_RPC_PORT` | HTTP port for the daemon control RPC. Defaults to `17654`. Requests still require bearer token auth. |
 | `CLAWDI_DAEMON_RPC_ALLOW_REMOTE=1` | Allows the daemon to bind a non-loopback HTTP RPC host. Use only behind SSH tunneling, private networking, or TLS. |
-| `CLAWDI_DAEMON_RPC_TOKEN` | Optional client-side bearer token for `clawdi daemon rpc` when the token file is not local. |
+| `CLAWDI_DAEMON_RPC_TOKEN` | Optional client-side bearer token for daemon commands or external HTTP clients when the token file is not local. |
 
 ### Per-agent paths
 

--- a/docs/clawdi-serve-test-guide.md
+++ b/docs/clawdi-serve-test-guide.md
@@ -196,13 +196,15 @@ clawdi daemon run
 clawdi daemon ping
 ```
 
-The default endpoint is `127.0.0.1:17654`. Pass `--rpc-host` and
-`--rpc-port` to change it.
+The default endpoint is `127.0.0.1:17654`. Pass `--host` and
+`--port` on `clawdi daemon run`, `install`, `ping`, or `rotate-token`
+to change it.
 
 HTTP RPC requests require bearer-token auth by default. The CLI reads
 the daemon token from `~/.clawdi/daemon/control-token`. Remote clients
-can pass that token through `CLAWDI_DAEMON_RPC_TOKEN` or `--rpc-token`
-on daemon commands that call the control endpoint.
+can pass that token with an `Authorization: Bearer <token>` header, and
+daemon commands that call the control endpoint accept
+`CLAWDI_DAEMON_RPC_TOKEN` or `--token`.
 Treat it as an admin token. Rotate it with
 `clawdi daemon rotate-token`.
 
@@ -248,7 +250,7 @@ into an operation log. Mutating vault calls that would otherwise prompt
 must pass their non-interactive confirmation, such as `yes: true`.
 
 Non-loopback HTTP binds are rejected unless the daemon is started or
-installed with `--rpc-allow-remote` (or
+installed with `--allow-remote` (or
 `CLAWDI_DAEMON_RPC_ALLOW_REMOTE=1`). Do not expose that listener
 directly on the public internet: the protocol is cleartext HTTP with an
 admin bearer token. Use an SSH tunnel, a private network, or a

--- a/docs/clawdi-serve-test-guide.md
+++ b/docs/clawdi-serve-test-guide.md
@@ -211,9 +211,15 @@ The RPC surface is discoverable:
 clawdi daemon rpc methods --rpc-host 127.0.0.1 --rpc-port 17654
 ```
 
-Besides daemon control methods, the daemon exposes headless command
-methods for `sync.push`, `sync.pull`, `vault.*`, `auth.*`, and
-`update.*`. Long-running commands return an operation id:
+Daemon control methods use short names: `ping`, `methods`, `status`,
+`doctor`, `logs`, `install`, `uninstall`, `restart`, and `rotate_token`.
+The user-facing CLI wrappers stay as normal commands such as
+`clawdi daemon status`, `clawdi daemon doctor`, and
+`clawdi daemon logs`.
+
+Besides daemon control methods, the daemon exposes headless command methods
+for `sync.push`, `sync.pull`, `vault.*`, `auth.*`, `update.*`, and
+`operation.*`. Long-running commands return an operation id:
 
 ```sh
 clawdi daemon rpc sync.push \

--- a/docs/clawdi-serve-test-guide.md
+++ b/docs/clawdi-serve-test-guide.md
@@ -198,19 +198,10 @@ clawdi daemon rpc daemon.ping --rpc-host 127.0.0.1 --rpc-port 17654
 ```
 
 HTTP RPC requests require bearer-token auth by default. The CLI reads
-the local root token from `~/.clawdi/daemon/control-token`; remote
-clients should use scoped tokens instead of the root token. Issue one
-from the owner-only Unix socket:
-
-```sh
-clawdi daemon rpc daemon.issue_token \
-  --params '{"label":"remote-dev","capabilities":["daemon:read","sync:run"],"expires_in_seconds":86400}'
-```
-
-Remote clients can pass the returned token through
-`CLAWDI_DAEMON_RPC_TOKEN` or `--rpc-token`. Rotate the root token with
-`clawdi daemon rpc daemon.rotate_token`; this invalidates all scoped
-tokens because they are signed by the root token.
+the daemon token from `~/.clawdi/daemon/control-token`. Remote clients
+can pass that token through `CLAWDI_DAEMON_RPC_TOKEN` or `--rpc-token`.
+Treat it as an admin token. Rotate it with
+`clawdi daemon rpc daemon.rotate_token`.
 
 The RPC surface is discoverable:
 
@@ -237,10 +228,9 @@ must pass their non-interactive confirmation, such as `yes: true`.
 
 Non-loopback HTTP binds are rejected unless the daemon is started or
 installed with `--rpc-allow-remote` (or
-`CLAWDI_DAEMON_RPC_ALLOW_REMOTE=1`). Non-loopback HTTP listeners reject
-the local root token and require a scoped token. Do not expose that
-listener directly on the public internet: the protocol is cleartext HTTP
-with bearer-token auth. Use an SSH tunnel, a private network, or a
+`CLAWDI_DAEMON_RPC_ALLOW_REMOTE=1`). Do not expose that listener
+directly on the public internet: the protocol is cleartext HTTP with an
+admin bearer token. Use an SSH tunnel, a private network, or a
 TLS-terminating reverse proxy.
 
 ## Troubleshooting

--- a/docs/clawdi-serve-test-guide.md
+++ b/docs/clawdi-serve-test-guide.md
@@ -203,6 +203,29 @@ pass it through `CLAWDI_DAEMON_RPC_TOKEN` or `--rpc-token`.
 Rotate the token with `clawdi daemon rpc daemon.rotate_token`; update
 remote clients with the returned token.
 
+The RPC surface is discoverable:
+
+```sh
+clawdi daemon rpc daemon.methods --rpc-host 127.0.0.1 --rpc-port 17654
+```
+
+Besides daemon control methods, the daemon exposes headless command
+methods for `sync.push`, `sync.pull`, `vault.*`, `auth.*`, and
+`update.*`. Long-running commands return an operation id:
+
+```sh
+clawdi daemon rpc sync.push \
+  --params '{"cwd":"/path/to/project","agent":"codex"}'
+clawdi daemon rpc operation.status --params '{"id":"<operation-id>"}'
+clawdi daemon rpc operation.logs --params '{"id":"<operation-id>","limit":100}'
+```
+
+Vault plaintext access is opt-in. `vault.resolve` and `vault.read`
+default to redacted dry-runs unless the request explicitly passes
+`confirm_secret_access: true`; plaintext access cannot be backgrounded
+into an operation log. Mutating vault calls that would otherwise prompt
+must pass their non-interactive confirmation, such as `yes: true`.
+
 Non-loopback HTTP binds are rejected unless the daemon is started or
 installed with `--rpc-allow-remote` (or
 `CLAWDI_DAEMON_RPC_ALLOW_REMOTE=1`). Do not expose that listener directly

--- a/docs/clawdi-serve-test-guide.md
+++ b/docs/clawdi-serve-test-guide.md
@@ -190,16 +190,25 @@ Logs land at `~/.clawdi/serve/logs/daemon.{stdout,stderr}.log`
 on macOS and via `journalctl --user -u clawdi-serve.service` on Linux.
 
 The control RPC always exposes the owner-only Unix socket. To also
-listen on TCP, pass an explicit host and port at install time:
+listen on HTTP, pass an explicit host and port at install time:
 
 ```sh
 clawdi daemon install --rpc-host 127.0.0.1 --rpc-port 17654
 clawdi daemon rpc daemon.ping --rpc-host 127.0.0.1 --rpc-port 17654
 ```
 
-TCP RPC requests require the generated bearer token by default. The
+HTTP RPC requests require the generated bearer token by default. The
 CLI reads it from `~/.clawdi/daemon/control-token`; remote clients can
 pass it through `CLAWDI_DAEMON_RPC_TOKEN` or `--rpc-token`.
+Rotate the token with `clawdi daemon rpc daemon.rotate_token`; update
+remote clients with the returned token.
+
+Non-loopback HTTP binds are rejected unless the daemon is started or
+installed with `--rpc-allow-remote` (or
+`CLAWDI_DAEMON_RPC_ALLOW_REMOTE=1`). Do not expose that listener directly
+on the public internet: the protocol is cleartext HTTP with bearer-token
+auth. Use an SSH tunnel, a private network, or a TLS-terminating reverse
+proxy.
 
 ## Troubleshooting
 
@@ -237,8 +246,9 @@ only conduit.
 | `CLAWDI_ENVIRONMENT_ID` | The env this single-agent pod represents. Bypasses `~/.clawdi/environments/*.json`. |
 | `CLAWDI_API_URL` | Cloud backend (e.g. `https://cloud-api.clawdi.ai`). |
 | `CLAWDI_SERVE_MODE=container` | Forces poll mode (overlay-fs doesn't fire fs.watch reliably). |
-| `CLAWDI_DAEMON_RPC_HOST` | Optional TCP host for the daemon control RPC. Requires `CLAWDI_DAEMON_RPC_PORT`. |
-| `CLAWDI_DAEMON_RPC_PORT` | Optional TCP port for the daemon control RPC. Requests still require bearer token auth. |
+| `CLAWDI_DAEMON_RPC_HOST` | Optional HTTP host for the daemon control RPC. Requires `CLAWDI_DAEMON_RPC_PORT`. |
+| `CLAWDI_DAEMON_RPC_PORT` | Optional HTTP port for the daemon control RPC. Requests still require bearer token auth. |
+| `CLAWDI_DAEMON_RPC_ALLOW_REMOTE=1` | Allows the daemon to bind a non-loopback HTTP RPC host. Use only behind SSH tunneling, private networking, or TLS. |
 | `CLAWDI_DAEMON_RPC_TOKEN` | Optional client-side bearer token for `clawdi daemon rpc` when the token file is not local. |
 
 ### Per-agent paths

--- a/docs/clawdi-serve-test-guide.md
+++ b/docs/clawdi-serve-test-guide.md
@@ -189,24 +189,26 @@ clawdi daemon uninstall  # when done
 Logs land at `~/.clawdi/serve/logs/daemon.{stdout,stderr}.log`
 on macOS and via `journalctl --user -u clawdi-serve.service` on Linux.
 
-The control RPC always exposes the owner-only Unix socket. To also
-listen on HTTP, pass an explicit host and port at install time:
+The control RPC listens on loopback HTTP by default:
 
 ```sh
-clawdi daemon install --rpc-host 127.0.0.1 --rpc-port 17654
-clawdi daemon rpc daemon.ping --rpc-host 127.0.0.1 --rpc-port 17654
+clawdi daemon run
+clawdi daemon ping
 ```
+
+The default endpoint is `127.0.0.1:17654`. Pass `--rpc-host` and
+`--rpc-port` to change it.
 
 HTTP RPC requests require bearer-token auth by default. The CLI reads
 the daemon token from `~/.clawdi/daemon/control-token`. Remote clients
 can pass that token through `CLAWDI_DAEMON_RPC_TOKEN` or `--rpc-token`.
 Treat it as an admin token. Rotate it with
-`clawdi daemon rpc daemon.rotate_token`.
+`clawdi daemon rpc rotate_token`.
 
 The RPC surface is discoverable:
 
 ```sh
-clawdi daemon rpc daemon.methods --rpc-host 127.0.0.1 --rpc-port 17654
+clawdi daemon rpc methods --rpc-host 127.0.0.1 --rpc-port 17654
 ```
 
 Besides daemon control methods, the daemon exposes headless command
@@ -269,8 +271,8 @@ only conduit.
 | `CLAWDI_ENVIRONMENT_ID` | The env this single-agent pod represents. Bypasses `~/.clawdi/environments/*.json`. |
 | `CLAWDI_API_URL` | Cloud backend (e.g. `https://cloud-api.clawdi.ai`). |
 | `CLAWDI_SERVE_MODE=container` | Forces poll mode (overlay-fs doesn't fire fs.watch reliably). |
-| `CLAWDI_DAEMON_RPC_HOST` | Optional HTTP host for the daemon control RPC. Requires `CLAWDI_DAEMON_RPC_PORT`. |
-| `CLAWDI_DAEMON_RPC_PORT` | Optional HTTP port for the daemon control RPC. Requests still require bearer token auth. |
+| `CLAWDI_DAEMON_RPC_HOST` | HTTP host for the daemon control RPC. Defaults to `127.0.0.1`. |
+| `CLAWDI_DAEMON_RPC_PORT` | HTTP port for the daemon control RPC. Defaults to `17654`. Requests still require bearer token auth. |
 | `CLAWDI_DAEMON_RPC_ALLOW_REMOTE=1` | Allows the daemon to bind a non-loopback HTTP RPC host. Use only behind SSH tunneling, private networking, or TLS. |
 | `CLAWDI_DAEMON_RPC_TOKEN` | Optional client-side bearer token for `clawdi daemon rpc` when the token file is not local. |
 

--- a/docs/plans/ai-provider-catalog.md
+++ b/docs/plans/ai-provider-catalog.md
@@ -2963,12 +2963,14 @@ clawdi ai-provider apply --engine hermes --json
 clawdi ai-provider status --json
 ```
 
-That is sufficient for deployment-time materialization and avoids adding a new
-daemon security surface before the Module boundaries are ready.
+That remains sufficient for deployment-time AI Provider materialization and
+avoids adding provider-mutating RPC methods before the Module boundaries are
+ready.
 
-A daemon RPC surface is still the right direction for later local/hosted
-control-plane operations, but it should be a narrow **CLI Control RPC**, not
-"remote shell over CLI":
+Status update: the singleton `clawdi daemon` now owns the local control RPC.
+It is ordinary HTTP JSON-RPC on `POST /rpc`, binds to loopback by default,
+requires bearer-token auth, and exposes only allowlisted methods. It is not a
+remote shell over CLI.
 
 1. It must expose allowlisted methods, not arbitrary Commander command strings.
 2. It must return typed JSON results, warnings, diffs, and redacted diagnostics.
@@ -2978,9 +2980,9 @@ control-plane operations, but it should be a narrow **CLI Control RPC**, not
 4. It must distinguish secret resolution calls from model traffic. RPC may ask
    the CLI to resolve a `clawdi://` ref or managed provider payload, but model
    calls still go runtime to provider.
-5. It must be local-first: loopback HTTP RPC by default, with bearer-token auth
-   and a token stored under `$CLAWDI_HOME/daemon/control-token`. Non-loopback
-   binds must require an explicit opt-in.
+5. It must stay local-first: loopback HTTP RPC by default, with bearer-token
+   auth and a token stored under `$CLAWDI_HOME/daemon/control-token`.
+   Non-loopback binds must require explicit opt-in.
 6. It must never bind to public interfaces by default. If a hosted agent
    runtime exposes a control channel, Clawdi Cloud should reach it through the
    hosting control plane or a localhost-only control endpoint, not through an
@@ -2991,7 +2993,8 @@ control-plane operations, but it should be a narrow **CLI Control RPC**, not
    jobs with states such as `pending_user`, `completed`, `expired`, and
    `failed`; the RPC should not block an HTTP request for the full user flow.
 
-Suggested first RPC method set:
+Future AI Provider RPC methods should be added to the existing daemon RPC
+allowlist when the service layer is ready:
 
 ```text
 aiProvider.list
@@ -3023,14 +3026,11 @@ Implementation shape:
    resolution, profile import/materialization, and OAuth job state.
 4. Keep Commander as a thin adapter that parses flags, calls those modules,
    handles prompts, and formats terminal output.
-5. Add a separate `daemon control` adapter that speaks JSON-RPC over the local
-   control transport and calls the same modules. Do not route RPC through
-   Commander or shell command parsing.
-6. Keep the existing sync daemon loop focused on sync/SSE/heartbeats. The
-   control RPC can live in the same installed daemon process later, but it
-   should be implemented as a separate Module with its own auth token, endpoint,
-   logs, and tests. If that makes lifecycle coupling messy, ship it as
-   `clawdi control run` first and have `clawdi daemon install` opt into it.
+5. Add AI Provider methods to the existing daemon RPC handler registry and call
+   the same modules. Do not route RPC through Commander or shell command
+   parsing.
+6. Keep the sync engine loop and control RPC implementation separate inside the
+   singleton daemon process, with focused tests for each RPC method family.
 
 Security tests required before enabling RPC:
 

--- a/docs/plans/ai-provider-catalog.md
+++ b/docs/plans/ai-provider-catalog.md
@@ -2978,13 +2978,12 @@ control-plane operations, but it should be a narrow **CLI Control RPC**, not
 4. It must distinguish secret resolution calls from model traffic. RPC may ask
    the CLI to resolve a `clawdi://` ref or managed provider payload, but model
    calls still go runtime to provider.
-5. It must be local-first: Unix domain socket on macOS/Linux and named pipe on
-   Windows by default. Loopback HTTP RPC should require an explicit flag such as
-   `--listen 127.0.0.1:<port>` plus a bearer token stored under
-   `$CLAWDI_HOME/daemon/control-token`.
+5. It must be local-first: loopback HTTP RPC by default, with bearer-token auth
+   and a token stored under `$CLAWDI_HOME/daemon/control-token`. Non-loopback
+   binds must require an explicit opt-in.
 6. It must never bind to public interfaces by default. If a hosted agent
    runtime exposes a control channel, Clawdi Cloud should reach it through the
-   hosting control plane or a localhost-only control socket, not through an
+   hosting control plane or a localhost-only control endpoint, not through an
    internet-facing listener.
 7. Mutating methods need idempotency keys, dry-run support, and redacted
    before/after plans. Runtime activation remains an explicit apply step.
@@ -3029,14 +3028,14 @@ Implementation shape:
    Commander or shell command parsing.
 6. Keep the existing sync daemon loop focused on sync/SSE/heartbeats. The
    control RPC can live in the same installed daemon process later, but it
-   should be implemented as a separate Module with its own auth token, socket,
+   should be implemented as a separate Module with its own auth token, endpoint,
    logs, and tests. If that makes lifecycle coupling messy, ship it as
    `clawdi control run` first and have `clawdi daemon install` opt into it.
 
 Security tests required before enabling RPC:
 
-1. Socket/token permissions prevent another local user from invoking mutating
-   methods.
+1. Token-file permissions and loopback binding prevent another local or remote
+   user from invoking mutating methods.
 2. Loopback mode rejects missing/invalid bearer tokens and sends no CORS
    wildcard headers.
 3. RPC responses redact env values, Vault values, managed API keys, OAuth
@@ -3109,10 +3108,9 @@ Security tests required before enabling RPC:
     while `clawdi://` secret refs may resolve through Clawdi Vault.
 29. Extract AI Provider command behavior into deep service modules before
     adding remote invocation.
-30. Add a local CLI Control RPC adapter over Unix domain socket / named pipe
-    with an explicit loopback HTTP RPC opt-in, allowlisted methods, token auth,
-    dry-run support, and redacted JSON responses.
-30. Teach hosted deployment code to prefer one-shot CLI invocation for
+30. Add a local CLI Control RPC adapter over loopback HTTP, allowlisted methods,
+    token auth, dry-run support, and redacted JSON responses.
+31. Teach hosted deployment code to prefer one-shot CLI invocation for
     deployment-time materialization, then migrate to Control RPC only when
     runtime-local long-lived control is needed.
 

--- a/docs/plans/ai-provider-catalog.md
+++ b/docs/plans/ai-provider-catalog.md
@@ -2979,7 +2979,7 @@ control-plane operations, but it should be a narrow **CLI Control RPC**, not
    the CLI to resolve a `clawdi://` ref or managed provider payload, but model
    calls still go runtime to provider.
 5. It must be local-first: Unix domain socket on macOS/Linux and named pipe on
-   Windows by default. Loopback TCP should require an explicit flag such as
+   Windows by default. Loopback HTTP RPC should require an explicit flag such as
    `--listen 127.0.0.1:<port>` plus a bearer token stored under
    `$CLAWDI_HOME/daemon/control-token`.
 6. It must never bind to public interfaces by default. If a hosted agent
@@ -3110,7 +3110,7 @@ Security tests required before enabling RPC:
 29. Extract AI Provider command behavior into deep service modules before
     adding remote invocation.
 30. Add a local CLI Control RPC adapter over Unix domain socket / named pipe
-    with an explicit loopback TCP opt-in, allowlisted methods, token auth,
+    with an explicit loopback HTTP RPC opt-in, allowlisted methods, token auth,
     dry-run support, and redacted JSON responses.
 30. Teach hosted deployment code to prefer one-shot CLI invocation for
     deployment-time materialization, then migrate to Control RPC only when

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -291,9 +291,9 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](https://gith
 | `clawdi auth login` / `logout` | Authenticate this machine |
 | `clawdi status [--json]` | Show auth and sync state |
 | `clawdi config list/get/set/unset` | Read or write CLI configuration |
-| `clawdi setup [--agent <type>] [--no-daemon]` | Register local agents, install MCP, install the bundled skill, and install/start daemons by default |
+| `clawdi setup [--agent <type>] [--no-daemon]` | Register local agents, install MCP, install the bundled skill, and install/start the singleton daemon by default |
 | `clawdi teardown [--agent <type>]` | Remove Clawdi's local agent wiring |
-| `clawdi daemon run/install/status/logs/doctor/restart/uninstall` | Run and manage the background sync daemon (`serve` remains a legacy alias) |
+| `clawdi daemon run/install/status/logs/doctor/restart/uninstall/ping/rpc` | Run, inspect, and control the singleton background sync daemon (`serve` remains a legacy alias) |
 | `clawdi push` | Upload sessions and skills |
 | `clawdi pull` | Download cloud skills into registered agents |
 | `clawdi session list/extract` | Inspect local agent sessions |
@@ -380,7 +380,7 @@ Common issues:
 - **No supported agent detected** - Install a supported agent or pass `--agent claude_code`, `--agent codex`, `--agent hermes`, or `--agent openclaw`.
 - **Memory search is empty** - Add a memory first with `clawdi memory add "..."`, then verify with `clawdi memory search "..."`.
 - **Local backend cannot start because `vector` is missing** - Install `pgvector` for your PostgreSQL 16 instance, or use the included Docker Compose database.
-- **Agent MCP tools look stale** - Run `clawdi setup --agent <type>` again, then `clawdi daemon restart --all`.
+- **Agent MCP tools look stale** - Run `clawdi setup --agent <type>` again, then `clawdi daemon restart`.
 
 ## License
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -293,7 +293,7 @@ Each agent has a dedicated adapter in [`packages/cli/src/adapters`](https://gith
 | `clawdi config list/get/set/unset` | Read or write CLI configuration |
 | `clawdi setup [--agent <type>] [--no-daemon]` | Register local agents, install MCP, install the bundled skill, and install/start the singleton daemon by default |
 | `clawdi teardown [--agent <type>]` | Remove Clawdi's local agent wiring |
-| `clawdi daemon run/install/status/logs/doctor/restart/uninstall/ping/rpc` | Run, inspect, and control the singleton background sync daemon (`serve` remains a legacy alias) |
+| `clawdi daemon run/install/status/logs/doctor/restart/uninstall/ping/rotate-token` | Run, inspect, and control the singleton background sync daemon (`serve` remains a legacy alias) |
 | `clawdi push` | Upload sessions and skills |
 | `clawdi pull` | Download cloud skills into registered agents |
 | `clawdi session list/extract` | Inspect local agent sessions |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.10.1",
+	"version": "0.11.0",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -555,13 +555,13 @@ export async function authLogout() {
 	// env-file path would skip a daemon whose env file got deleted
 	// but whose plist was still installed (codex flagged this gap
 	// in PR-#74 review).
-	const { listInstalledAgents } = await import("../serve/installer");
-	const installedAgents = listInstalledAgents();
+	const { listInstalledDaemonTargets } = await import("../serve/installer");
+	const installedAgents = listInstalledDaemonTargets();
 	if (installedAgents.length > 0) {
 		p.log.warn(
 			`${installedAgents.length} daemon(s) still installed (${installedAgents.join(", ")}). ` +
 				`These keep running after logout and will fail with 401 against the cloud. ` +
-				`Run \`clawdi daemon uninstall --all\` first, or accept the noise.`,
+				`Run \`clawdi daemon uninstall\` first, or accept the noise.`,
 		);
 	}
 

--- a/packages/cli/src/commands/serve-cli-options.test.ts
+++ b/packages/cli/src/commands/serve-cli-options.test.ts
@@ -51,10 +51,41 @@ describe("registerServeCommand", () => {
 		expect(captured.last).toEqual({});
 	});
 
+	it("daemon run accepts RPC TCP host and port", async () => {
+		const { program, captured } = buildTree();
+		await program.parseAsync([
+			"node",
+			"clawdi",
+			"daemon",
+			"run",
+			"--rpc-host",
+			"127.0.0.1",
+			"--rpc-port",
+			"17654",
+		]);
+		expect(captured.last?.rpcHost).toBe("127.0.0.1");
+		expect(captured.last?.rpcPort).toBe("17654");
+	});
+
 	it("daemon with no subcommand still runs the foreground action", async () => {
 		const { program, captured } = buildTree();
 		await program.parseAsync(["node", "clawdi", "daemon"]);
 		expect(captured.last).toEqual({});
+	});
+
+	it("daemon with no subcommand accepts RPC TCP host and port", async () => {
+		const { program, captured } = buildTree();
+		await program.parseAsync([
+			"node",
+			"clawdi",
+			"daemon",
+			"--rpc-host",
+			"127.0.0.1",
+			"--rpc-port",
+			"17654",
+		]);
+		expect(captured.last?.rpcHost).toBe("127.0.0.1");
+		expect(captured.last?.rpcPort).toBe("17654");
 	});
 
 	it("legacy serve with no subcommand still runs the foreground action", async () => {
@@ -67,6 +98,22 @@ describe("registerServeCommand", () => {
 		const { program, captured } = buildTree();
 		await program.parseAsync(["node", "clawdi", "serve", "uninstall"]);
 		expect(captured.last).toEqual({});
+	});
+
+	it("install accepts RPC TCP host and port", async () => {
+		const { program, captured } = buildTree();
+		await program.parseAsync([
+			"node",
+			"clawdi",
+			"daemon",
+			"install",
+			"--rpc-host",
+			"127.0.0.1",
+			"--rpc-port",
+			"17654",
+		]);
+		expect(captured.last?.rpcHost).toBe("127.0.0.1");
+		expect(captured.last?.rpcPort).toBe("17654");
 	});
 
 	it("restart reaches the action", async () => {
@@ -124,8 +171,17 @@ describe("registerServeCommand", () => {
 			"daemon.ping",
 			"--params",
 			'{"verbose":true}',
+			"--rpc-host",
+			"127.0.0.1",
+			"--rpc-port",
+			"17654",
+			"--rpc-token",
+			"tok-test",
 		]);
 		expect(captured.lastMethod).toBe("daemon.ping");
 		expect(captured.last?.params).toBe('{"verbose":true}');
+		expect(captured.last?.rpcHost).toBe("127.0.0.1");
+		expect(captured.last?.rpcPort).toBe("17654");
+		expect(captured.last?.rpcToken).toBe("tok-test");
 	});
 });

--- a/packages/cli/src/commands/serve-cli-options.test.ts
+++ b/packages/cli/src/commands/serve-cli-options.test.ts
@@ -25,6 +25,9 @@ function makeHandlers(captured: { last: Record<string, unknown> | null }): Serve
 		serveStatus: recordOpts,
 		serveLogs: recordOpts,
 		serveDoctor: recordOpts,
+		serveRpc: async (_method: string, opts: Record<string, unknown>) => {
+			captured.last = opts;
+		},
 	};
 }
 
@@ -36,76 +39,40 @@ function buildTree(): { program: Command; captured: { last: Record<string, unkno
 }
 
 describe("registerServeCommand", () => {
-	it("daemon install --agent codex reaches the action", async () => {
+	it("daemon install reaches the action with no target selector", async () => {
 		const { program, captured } = buildTree();
-		await program.parseAsync(["node", "clawdi", "daemon", "install", "--agent", "codex"]);
-		expect(captured.last?.agent).toBe("codex");
+		await program.parseAsync(["node", "clawdi", "daemon", "install"]);
+		expect(captured.last).toEqual({});
 	});
 
-	it("daemon run --agent codex --environment-id <uuid> reaches the foreground action", async () => {
+	it("daemon run reaches the foreground action with no target selector", async () => {
 		const { program, captured } = buildTree();
-		await program.parseAsync([
-			"node",
-			"clawdi",
-			"daemon",
-			"run",
-			"--agent",
-			"codex",
-			"--environment-id",
-			"00000000-0000-0000-0000-000000000001",
-		]);
-		expect(captured.last?.agent).toBe("codex");
-		expect(captured.last?.environmentId).toBe("00000000-0000-0000-0000-000000000001");
+		await program.parseAsync(["node", "clawdi", "daemon", "run"]);
+		expect(captured.last).toEqual({});
 	});
 
 	it("daemon with no subcommand still runs the foreground action", async () => {
 		const { program, captured } = buildTree();
-		await program.parseAsync(["node", "clawdi", "daemon", "--agent", "codex"]);
-		expect(captured.last?.agent).toBe("codex");
+		await program.parseAsync(["node", "clawdi", "daemon"]);
+		expect(captured.last).toEqual({});
 	});
 
 	it("legacy serve with no subcommand still runs the foreground action", async () => {
 		const { program, captured } = buildTree();
-		await program.parseAsync(["node", "clawdi", "serve", "--agent", "codex"]);
-		expect(captured.last?.agent).toBe("codex");
+		await program.parseAsync(["node", "clawdi", "serve"]);
+		expect(captured.last).toEqual({});
 	});
 
-	it("install --agent codex (child-side) reaches the action", async () => {
+	it("uninstall reaches the action", async () => {
 		const { program, captured } = buildTree();
-		await program.parseAsync(["node", "clawdi", "serve", "install", "--agent", "codex"]);
-		expect(captured.last?.agent).toBe("codex");
+		await program.parseAsync(["node", "clawdi", "serve", "uninstall"]);
+		expect(captured.last).toEqual({});
 	});
 
-	it("install with --agent on parent side also reaches the action", async () => {
-		// `clawdi serve --agent codex install` — the user passed
-		// --agent before the subcommand. Without optsWithGlobals,
-		// the action received `agent: undefined`.
+	it("restart reaches the action", async () => {
 		const { program, captured } = buildTree();
-		await program.parseAsync(["node", "clawdi", "serve", "--agent", "codex", "install"]);
-		expect(captured.last?.agent).toBe("codex");
-	});
-
-	it("install --agent codex --environment-id <uuid> flows through", async () => {
-		const { program, captured } = buildTree();
-		await program.parseAsync([
-			"node",
-			"clawdi",
-			"serve",
-			"install",
-			"--agent",
-			"codex",
-			"--environment-id",
-			"00000000-0000-0000-0000-000000000001",
-		]);
-		expect(captured.last?.agent).toBe("codex");
-		expect(captured.last?.environmentId).toBe("00000000-0000-0000-0000-000000000001");
-	});
-
-	it("uninstall --all is visible to action", async () => {
-		const { program, captured } = buildTree();
-		await program.parseAsync(["node", "clawdi", "serve", "uninstall", "--all"]);
-		expect(captured.last?.all).toBe(true);
-		expect(captured.last?.agent).toBeUndefined();
+		await program.parseAsync(["node", "clawdi", "serve", "restart"]);
+		expect(captured.last).toEqual({});
 	});
 
 	it("status --agent claude_code (child-side) reaches the action", async () => {
@@ -124,17 +91,10 @@ describe("registerServeCommand", () => {
 		expect(captured.last?.agent).toBeUndefined();
 	});
 
-	it("restart --all reaches the action", async () => {
-		const { program, captured } = buildTree();
-		await program.parseAsync(["node", "clawdi", "serve", "restart", "--all"]);
-		expect(captured.last?.all).toBe(true);
-	});
-
 	it("logs --follow flows through", async () => {
 		const { program, captured } = buildTree();
-		await program.parseAsync(["node", "clawdi", "serve", "logs", "--follow", "--agent", "codex"]);
+		await program.parseAsync(["node", "clawdi", "serve", "logs", "--follow"]);
 		expect(captured.last?.follow).toBe(true);
-		expect(captured.last?.agent).toBe("codex");
 	});
 
 	it("doctor --json reaches the action", async () => {
@@ -143,16 +103,29 @@ describe("registerServeCommand", () => {
 		expect(captured.last?.json).toBe(true);
 	});
 
-	it("doctor passes through --agent (validated/rejected by handler, not parser)", async () => {
-		// Commander accepts `--agent X` on doctor because parent
-		// defines it, even though doctor itself doesn't. The handler
-		// is the one that says "doctor doesn't accept --agent" via
-		// `rejectUnsupportedOpts`. This test pins the parser-level
-		// invariant: agent IS visible to the action so the handler
-		// can produce the right error message.
-		const { program, captured } = buildTree();
-		await program.parseAsync(["node", "clawdi", "serve", "doctor", "--agent", "codex"]);
-		expect(captured.last?.agent).toBe("codex");
-		expect(captured.last?.json).toBeUndefined();
+	it("rpc passes method params through", async () => {
+		const captured = {
+			lastMethod: null as string | null,
+			last: null as Record<string, unknown> | null,
+		};
+		const program = new Command();
+		registerServeCommand(program, {
+			...makeHandlers(captured),
+			serveRpc: async (method: string, opts: Record<string, unknown>) => {
+				captured.lastMethod = method;
+				captured.last = opts;
+			},
+		});
+		await program.parseAsync([
+			"node",
+			"clawdi",
+			"serve",
+			"rpc",
+			"daemon.ping",
+			"--params",
+			'{"verbose":true}',
+		]);
+		expect(captured.lastMethod).toBe("daemon.ping");
+		expect(captured.last?.params).toBe('{"verbose":true}');
 	});
 });

--- a/packages/cli/src/commands/serve-cli-options.test.ts
+++ b/packages/cli/src/commands/serve-cli-options.test.ts
@@ -51,26 +51,26 @@ describe("registerServeCommand", () => {
 		expect(captured.last).toEqual({});
 	});
 
-	it("daemon run accepts RPC HTTP host and port", async () => {
+	it("daemon run accepts control HTTP RPC host and port", async () => {
 		const { program, captured } = buildTree();
 		await program.parseAsync([
 			"node",
 			"clawdi",
 			"daemon",
 			"run",
-			"--rpc-host",
+			"--host",
 			"127.0.0.1",
-			"--rpc-port",
+			"--port",
 			"17654",
 		]);
-		expect(captured.last?.rpcHost).toBe("127.0.0.1");
-		expect(captured.last?.rpcPort).toBe("17654");
+		expect(captured.last?.host).toBe("127.0.0.1");
+		expect(captured.last?.port).toBe("17654");
 	});
 
 	it("daemon run accepts the non-loopback HTTP RPC opt-in", async () => {
 		const { program, captured } = buildTree();
-		await program.parseAsync(["node", "clawdi", "daemon", "run", "--rpc-allow-remote"]);
-		expect(captured.last?.rpcAllowRemote).toBe(true);
+		await program.parseAsync(["node", "clawdi", "daemon", "run", "--allow-remote"]);
+		expect(captured.last?.allowRemote).toBe(true);
 	});
 
 	it("daemon run accepts hidden legacy selector args for supervisor migration", async () => {
@@ -95,25 +95,25 @@ describe("registerServeCommand", () => {
 		expect(captured.last).toEqual({});
 	});
 
-	it("daemon with no subcommand accepts RPC HTTP host and port", async () => {
+	it("daemon with no subcommand accepts control HTTP RPC host and port", async () => {
 		const { program, captured } = buildTree();
 		await program.parseAsync([
 			"node",
 			"clawdi",
 			"daemon",
-			"--rpc-host",
+			"--host",
 			"127.0.0.1",
-			"--rpc-port",
+			"--port",
 			"17654",
 		]);
-		expect(captured.last?.rpcHost).toBe("127.0.0.1");
-		expect(captured.last?.rpcPort).toBe("17654");
+		expect(captured.last?.host).toBe("127.0.0.1");
+		expect(captured.last?.port).toBe("17654");
 	});
 
 	it("daemon with no subcommand accepts the non-loopback HTTP RPC opt-in", async () => {
 		const { program, captured } = buildTree();
-		await program.parseAsync(["node", "clawdi", "daemon", "--rpc-allow-remote"]);
-		expect(captured.last?.rpcAllowRemote).toBe(true);
+		await program.parseAsync(["node", "clawdi", "daemon", "--allow-remote"]);
+		expect(captured.last?.allowRemote).toBe(true);
 	});
 
 	it("legacy serve with no subcommand still runs the foreground action", async () => {
@@ -128,26 +128,26 @@ describe("registerServeCommand", () => {
 		expect(captured.last).toEqual({});
 	});
 
-	it("install accepts RPC HTTP host and port", async () => {
+	it("install accepts control HTTP RPC host and port", async () => {
 		const { program, captured } = buildTree();
 		await program.parseAsync([
 			"node",
 			"clawdi",
 			"daemon",
 			"install",
-			"--rpc-host",
+			"--host",
 			"127.0.0.1",
-			"--rpc-port",
+			"--port",
 			"17654",
 		]);
-		expect(captured.last?.rpcHost).toBe("127.0.0.1");
-		expect(captured.last?.rpcPort).toBe("17654");
+		expect(captured.last?.host).toBe("127.0.0.1");
+		expect(captured.last?.port).toBe("17654");
 	});
 
 	it("install accepts the non-loopback HTTP RPC opt-in", async () => {
 		const { program, captured } = buildTree();
-		await program.parseAsync(["node", "clawdi", "daemon", "install", "--rpc-allow-remote"]);
-		expect(captured.last?.rpcAllowRemote).toBe(true);
+		await program.parseAsync(["node", "clawdi", "daemon", "install", "--allow-remote"]);
+		expect(captured.last?.allowRemote).toBe(true);
 	});
 
 	it("restart reaches the action", async () => {
@@ -195,18 +195,18 @@ describe("registerServeCommand", () => {
 			"clawdi",
 			"daemon",
 			"rotate-token",
-			"--rpc-host",
+			"--host",
 			"127.0.0.1",
-			"--rpc-port",
+			"--port",
 			"17654",
-			"--rpc-token",
+			"--token",
 			"tok-test",
 		]);
 
 		expect(captured.lastMethod).toBe("rotate_token");
-		expect(captured.last?.rpcHost).toBe("127.0.0.1");
-		expect(captured.last?.rpcPort).toBe("17654");
-		expect(captured.last?.rpcToken).toBe("tok-test");
+		expect(captured.last?.host).toBe("127.0.0.1");
+		expect(captured.last?.port).toBe("17654");
+		expect(captured.last?.token).toBe("tok-test");
 	});
 
 	it("status --agent claude_code (child-side) reaches the action", async () => {

--- a/packages/cli/src/commands/serve-cli-options.test.ts
+++ b/packages/cli/src/commands/serve-cli-options.test.ts
@@ -51,7 +51,7 @@ describe("registerServeCommand", () => {
 		expect(captured.last).toEqual({});
 	});
 
-	it("daemon run accepts RPC TCP host and port", async () => {
+	it("daemon run accepts RPC HTTP host and port", async () => {
 		const { program, captured } = buildTree();
 		await program.parseAsync([
 			"node",
@@ -67,13 +67,19 @@ describe("registerServeCommand", () => {
 		expect(captured.last?.rpcPort).toBe("17654");
 	});
 
+	it("daemon run accepts the non-loopback HTTP RPC opt-in", async () => {
+		const { program, captured } = buildTree();
+		await program.parseAsync(["node", "clawdi", "daemon", "run", "--rpc-allow-remote"]);
+		expect(captured.last?.rpcAllowRemote).toBe(true);
+	});
+
 	it("daemon with no subcommand still runs the foreground action", async () => {
 		const { program, captured } = buildTree();
 		await program.parseAsync(["node", "clawdi", "daemon"]);
 		expect(captured.last).toEqual({});
 	});
 
-	it("daemon with no subcommand accepts RPC TCP host and port", async () => {
+	it("daemon with no subcommand accepts RPC HTTP host and port", async () => {
 		const { program, captured } = buildTree();
 		await program.parseAsync([
 			"node",
@@ -86,6 +92,12 @@ describe("registerServeCommand", () => {
 		]);
 		expect(captured.last?.rpcHost).toBe("127.0.0.1");
 		expect(captured.last?.rpcPort).toBe("17654");
+	});
+
+	it("daemon with no subcommand accepts the non-loopback HTTP RPC opt-in", async () => {
+		const { program, captured } = buildTree();
+		await program.parseAsync(["node", "clawdi", "daemon", "--rpc-allow-remote"]);
+		expect(captured.last?.rpcAllowRemote).toBe(true);
 	});
 
 	it("legacy serve with no subcommand still runs the foreground action", async () => {
@@ -100,7 +112,7 @@ describe("registerServeCommand", () => {
 		expect(captured.last).toEqual({});
 	});
 
-	it("install accepts RPC TCP host and port", async () => {
+	it("install accepts RPC HTTP host and port", async () => {
 		const { program, captured } = buildTree();
 		await program.parseAsync([
 			"node",
@@ -114,6 +126,12 @@ describe("registerServeCommand", () => {
 		]);
 		expect(captured.last?.rpcHost).toBe("127.0.0.1");
 		expect(captured.last?.rpcPort).toBe("17654");
+	});
+
+	it("install accepts the non-loopback HTTP RPC opt-in", async () => {
+		const { program, captured } = buildTree();
+		await program.parseAsync(["node", "clawdi", "daemon", "install", "--rpc-allow-remote"]);
+		expect(captured.last?.rpcAllowRemote).toBe(true);
 	});
 
 	it("restart reaches the action", async () => {

--- a/packages/cli/src/commands/serve-cli-options.test.ts
+++ b/packages/cli/src/commands/serve-cli-options.test.ts
@@ -172,7 +172,7 @@ describe("registerServeCommand", () => {
 
 		await program.parseAsync(["node", "clawdi", "daemon", "ping"]);
 
-		expect(captured.lastMethod).toBe("daemon.ping");
+		expect(captured.lastMethod).toBe("ping");
 		expect(captured.last).toEqual({});
 	});
 

--- a/packages/cli/src/commands/serve-cli-options.test.ts
+++ b/packages/cli/src/commands/serve-cli-options.test.ts
@@ -73,6 +73,22 @@ describe("registerServeCommand", () => {
 		expect(captured.last?.rpcAllowRemote).toBe(true);
 	});
 
+	it("daemon run accepts hidden legacy selector args for supervisor migration", async () => {
+		const { program, captured } = buildTree();
+		await program.parseAsync([
+			"node",
+			"clawdi",
+			"daemon",
+			"run",
+			"--agent",
+			"codex",
+			"--environment-id",
+			"env-codex",
+		]);
+		expect(captured.last?.agent).toBe("codex");
+		expect(captured.last?.environmentId).toBe("env-codex");
+	});
+
 	it("daemon with no subcommand still runs the foreground action", async () => {
 		const { program, captured } = buildTree();
 		await program.parseAsync(["node", "clawdi", "daemon"]);

--- a/packages/cli/src/commands/serve-cli-options.test.ts
+++ b/packages/cli/src/commands/serve-cli-options.test.ts
@@ -156,6 +156,26 @@ describe("registerServeCommand", () => {
 		expect(captured.last).toEqual({});
 	});
 
+	it("ping reaches the daemon ping RPC", async () => {
+		const captured = {
+			lastMethod: null as string | null,
+			last: null as Record<string, unknown> | null,
+		};
+		const program = new Command();
+		registerServeCommand(program, {
+			...makeHandlers(captured),
+			serveRpc: async (method: string, opts: Record<string, unknown>) => {
+				captured.lastMethod = method;
+				captured.last = opts;
+			},
+		});
+
+		await program.parseAsync(["node", "clawdi", "daemon", "ping"]);
+
+		expect(captured.lastMethod).toBe("daemon.ping");
+		expect(captured.last).toEqual({});
+	});
+
 	it("status --agent claude_code (child-side) reaches the action", async () => {
 		const { program, captured } = buildTree();
 		await program.parseAsync(["node", "clawdi", "serve", "status", "--agent", "claude_code"]);
@@ -202,7 +222,7 @@ describe("registerServeCommand", () => {
 			"clawdi",
 			"serve",
 			"rpc",
-			"daemon.ping",
+			"sync.push",
 			"--params",
 			'{"verbose":true}',
 			"--rpc-host",
@@ -212,7 +232,7 @@ describe("registerServeCommand", () => {
 			"--rpc-token",
 			"tok-test",
 		]);
-		expect(captured.lastMethod).toBe("daemon.ping");
+		expect(captured.lastMethod).toBe("sync.push");
 		expect(captured.last?.params).toBe('{"verbose":true}');
 		expect(captured.last?.rpcHost).toBe("127.0.0.1");
 		expect(captured.last?.rpcPort).toBe("17654");

--- a/packages/cli/src/commands/serve-cli-options.test.ts
+++ b/packages/cli/src/commands/serve-cli-options.test.ts
@@ -176,6 +176,39 @@ describe("registerServeCommand", () => {
 		expect(captured.last).toEqual({});
 	});
 
+	it("rotate-token reaches the token rotation RPC", async () => {
+		const captured = {
+			lastMethod: null as string | null,
+			last: null as Record<string, unknown> | null,
+		};
+		const program = new Command();
+		registerServeCommand(program, {
+			...makeHandlers(captured),
+			serveRpc: async (method: string, opts: Record<string, unknown>) => {
+				captured.lastMethod = method;
+				captured.last = opts;
+			},
+		});
+
+		await program.parseAsync([
+			"node",
+			"clawdi",
+			"daemon",
+			"rotate-token",
+			"--rpc-host",
+			"127.0.0.1",
+			"--rpc-port",
+			"17654",
+			"--rpc-token",
+			"tok-test",
+		]);
+
+		expect(captured.lastMethod).toBe("rotate_token");
+		expect(captured.last?.rpcHost).toBe("127.0.0.1");
+		expect(captured.last?.rpcPort).toBe("17654");
+		expect(captured.last?.rpcToken).toBe("tok-test");
+	});
+
 	it("status --agent claude_code (child-side) reaches the action", async () => {
 		const { program, captured } = buildTree();
 		await program.parseAsync(["node", "clawdi", "serve", "status", "--agent", "claude_code"]);
@@ -202,40 +235,5 @@ describe("registerServeCommand", () => {
 		const { program, captured } = buildTree();
 		await program.parseAsync(["node", "clawdi", "serve", "doctor", "--json"]);
 		expect(captured.last?.json).toBe(true);
-	});
-
-	it("rpc passes method params through", async () => {
-		const captured = {
-			lastMethod: null as string | null,
-			last: null as Record<string, unknown> | null,
-		};
-		const program = new Command();
-		registerServeCommand(program, {
-			...makeHandlers(captured),
-			serveRpc: async (method: string, opts: Record<string, unknown>) => {
-				captured.lastMethod = method;
-				captured.last = opts;
-			},
-		});
-		await program.parseAsync([
-			"node",
-			"clawdi",
-			"serve",
-			"rpc",
-			"sync.push",
-			"--params",
-			'{"verbose":true}',
-			"--rpc-host",
-			"127.0.0.1",
-			"--rpc-port",
-			"17654",
-			"--rpc-token",
-			"tok-test",
-		]);
-		expect(captured.lastMethod).toBe("sync.push");
-		expect(captured.last?.params).toBe('{"verbose":true}');
-		expect(captured.last?.rpcHost).toBe("127.0.0.1");
-		expect(captured.last?.rpcPort).toBe("17654");
-		expect(captured.last?.rpcToken).toBe("tok-test");
 	});
 });

--- a/packages/cli/src/commands/serve-cli.ts
+++ b/packages/cli/src/commands/serve-cli.ts
@@ -30,7 +30,7 @@ export interface ServeHandlers {
 
 function addRpcEndpointOptions(cmd: Command): Command {
 	return cmd
-		.option("--rpc-host <host>", "Control RPC HTTP host (enables HTTP when paired with --rpc-port)")
+		.option("--rpc-host <host>", "Control RPC HTTP host")
 		.option("--rpc-port <port>", "Control RPC HTTP port")
 		.option("--rpc-allow-remote", "Allow the HTTP RPC listener to bind a non-loopback host");
 }
@@ -60,7 +60,7 @@ export function registerServeCommand(program: Command, handlers?: ServeHandlers)
 	const serveCmd = program
 		.command("daemon")
 		.alias("serve")
-		.option("--rpc-host <host>", "Control RPC HTTP host (enables HTTP when paired with --rpc-port)")
+		.option("--rpc-host <host>", "Control RPC HTTP host")
 		.option("--rpc-port <port>", "Control RPC HTTP port")
 		.option("--rpc-allow-remote", "Allow the HTTP RPC listener to bind a non-loopback host")
 		.description(
@@ -73,8 +73,8 @@ Environment:
   CLAWDI_AUTH_TOKEN       Bearer token (preferred over ~/.clawdi/auth.json)
   CLAWDI_SERVE_MODE       "container" forces polling watcher + graceful SIGTERM
   CLAWDI_STATE_DIR        Override location of queue.jsonl + health (default ~/.clawdi/serve)
-  CLAWDI_DAEMON_RPC_HOST         Optional HTTP host for daemon control RPC
-  CLAWDI_DAEMON_RPC_PORT         Optional HTTP port for daemon control RPC
+  CLAWDI_DAEMON_RPC_HOST         HTTP RPC host (default 127.0.0.1)
+  CLAWDI_DAEMON_RPC_PORT         HTTP RPC port (default 17654)
   CLAWDI_DAEMON_RPC_ALLOW_REMOTE Set to 1 to allow non-loopback HTTP bind
   CLAWDI_DAEMON_RPC_TOKEN        Bearer token for HTTP RPC clients (defaults to generated token file)
   CLAWDI_SERVE_DEBUG=1    Emit debug-level events to stderr
@@ -82,6 +82,7 @@ Environment:
 Examples:
   $ clawdi daemon run
   $ clawdi daemon run --rpc-host 127.0.0.1 --rpc-port 17654
+  $ clawdi daemon ping
   $ CLAWDI_SERVE_MODE=container clawdi daemon run
   $ clawdi daemon install                       # set up one launchd / systemd unit
   $ clawdi daemon status --agent claude_code    # health + supervisor state
@@ -102,14 +103,8 @@ Examples:
 			.command("run")
 			.description("Run the sync daemon in the foreground")
 			.configureHelp({ showGlobalOptions: true })
-			.addHelpText(
-				"after",
-				"\nControl RPC HTTP options are optional; Unix socket is always enabled.",
-			)
-			.option(
-				"--rpc-host <host>",
-				"Control RPC HTTP host (enables HTTP when paired with --rpc-port)",
-			)
+			.addHelpText("after", "\nControl RPC listens on loopback HTTP by default.")
+			.option("--rpc-host <host>", "Control RPC HTTP host")
 			.option("--rpc-port <port>", "Control RPC HTTP port")
 			.option("--rpc-allow-remote", "Allow the HTTP RPC listener to bind a non-loopback host"),
 	).action(async (_opts, cmd) => {
@@ -145,6 +140,17 @@ Examples:
 		});
 
 	serveCmd
+		.command("ping")
+		.description("Check whether the daemon control RPC is reachable")
+		.option("--rpc-host <host>", "Control RPC HTTP host to call")
+		.option("--rpc-port <port>", "Control RPC HTTP port to call")
+		.option("--rpc-token <token>", "Bearer token for RPC access (defaults to token file/env)")
+		.action(async (_opts, cmd) => {
+			const h = await get();
+			await h.serveRpc("daemon.ping", cmd.optsWithGlobals());
+		});
+
+	serveCmd
 		.command("status")
 		.description("Show daemon health (last heartbeat) and supervisor state")
 		.option("--agent <type>", "Agent to check (defaults to all registered agents)")
@@ -173,9 +179,9 @@ Examples:
 
 	serveCmd
 		.command("rpc <method>")
-		.description("Call the local daemon control RPC socket")
+		.description("Call an advanced daemon RPC method")
 		.option("--params <json>", "JSON object passed as RPC params", "{}")
-		.option("--rpc-host <host>", "Control RPC HTTP host to call (requires --rpc-port)")
+		.option("--rpc-host <host>", "Control RPC HTTP host to call")
 		.option("--rpc-port <port>", "Control RPC HTTP port to call")
 		.option("--rpc-token <token>", "Bearer token for RPC access (defaults to token file/env)")
 		.action(async (method: string, _opts, cmd) => {

--- a/packages/cli/src/commands/serve-cli.ts
+++ b/packages/cli/src/commands/serve-cli.ts
@@ -25,6 +25,7 @@ export interface ServeHandlers {
 	serveStatus: (opts: Record<string, unknown>) => Promise<void> | void;
 	serveLogs: (opts: Record<string, unknown>) => Promise<void> | void;
 	serveDoctor: (opts: Record<string, unknown>) => Promise<void> | void;
+	serveRpc: (method: string, opts: Record<string, unknown>) => Promise<void> | void;
 }
 
 async function defaultHandlers(): Promise<ServeHandlers> {
@@ -37,6 +38,7 @@ async function defaultHandlers(): Promise<ServeHandlers> {
 		serveStatus: m.serveStatus,
 		serveLogs: m.serveLogs,
 		serveDoctor: m.serveDoctor,
+		serveRpc: m.serveRpc,
 	};
 }
 
@@ -48,22 +50,19 @@ export function registerServeCommand(program: Command, handlers?: ServeHandlers)
 		.description(
 			"Manage the background sync daemon — pushes local skill edits to cloud, pulls dashboard installs via SSE",
 		)
-		.option("--agent <type>", "Agent to service (claude_code, codex, hermes, openclaw)")
-		.option("--environment-id <id>", "Environment id (overrides ~/.clawdi/environments/*.json)")
 		.addHelpText(
 			"after",
 			`
 Environment:
   CLAWDI_AUTH_TOKEN       Bearer token (preferred over ~/.clawdi/auth.json)
-  CLAWDI_ENVIRONMENT_ID   Same as --environment-id
   CLAWDI_SERVE_MODE       "container" forces polling watcher + graceful SIGTERM
   CLAWDI_STATE_DIR        Override location of queue.jsonl + health (default ~/.clawdi/serve)
   CLAWDI_SERVE_DEBUG=1    Emit debug-level events to stderr
 
 Examples:
-  $ clawdi daemon run --agent claude_code
-  $ CLAWDI_SERVE_MODE=container clawdi daemon run --agent claude_code
-  $ clawdi daemon install --agent claude_code   # set up launchd / systemd unit
+  $ clawdi daemon run
+  $ CLAWDI_SERVE_MODE=container clawdi daemon run
+  $ clawdi daemon install                       # set up one launchd / systemd unit
   $ clawdi daemon status --agent claude_code    # health + supervisor state
   $ clawdi serve status --agent claude_code     # legacy alias`,
 		)
@@ -79,8 +78,6 @@ Examples:
 	serveCmd
 		.command("run")
 		.description("Run the sync daemon in the foreground")
-		.option("--agent <type>", "Agent to service (claude_code, codex, hermes, openclaw)")
-		.option("--environment-id <id>", "Environment id (overrides ~/.clawdi/environments/*.json)")
 		.action(async (_opts, cmd) => {
 			const h = await get();
 			await h.serve(cmd.optsWithGlobals());
@@ -88,23 +85,7 @@ Examples:
 
 	serveCmd
 		.command("install")
-		.description("Install the daemon as a per-user OS service (launchd on macOS, systemd on Linux)")
-		.option(
-			"--agent <type>",
-			"Agent to service (auto-picked when only one is registered; required when multiple)",
-		)
-		.option("--all", "Install a daemon unit for every registered agent on this machine")
-		.option(
-			"--environment-id <id>",
-			"Pin a specific environment id into the unit (single-agent only; ignored with --all)",
-		)
-		// `optsWithGlobals` merges parent (`serveCmd`) options with this
-		// subcommand's. Without it, `--agent` defined on both the parent
-		// (`clawdi daemon --agent X`) and the child (`clawdi daemon install
-		// --agent X`) makes commander hand the child action ONLY the
-		// child-scoped opts, so `clawdi daemon install --agent codex` lost
-		// the agent and silently installed the default. Same fix applied
-		// to uninstall + status below.
+		.description("Install the singleton daemon as a per-user OS service")
 		.action(async (_opts, cmd) => {
 			const h = await get();
 			await h.serveInstall(cmd.optsWithGlobals());
@@ -112,12 +93,7 @@ Examples:
 
 	serveCmd
 		.command("uninstall")
-		.description("Remove the per-user OS service unit and stop the daemon")
-		.option(
-			"--agent <type>",
-			"Agent to uninstall (auto-picked when only one is registered; required when multiple)",
-		)
-		.option("--all", "Uninstall the daemon unit for every registered agent on this machine")
+		.description("Remove the singleton daemon service unit and stop the daemon")
 		.action(async (_opts, cmd) => {
 			const h = await get();
 			await h.serveUninstall(cmd.optsWithGlobals());
@@ -126,13 +102,8 @@ Examples:
 	serveCmd
 		.command("restart")
 		.description(
-			"Restart an installed daemon (launchctl kickstart -k on macOS, systemctl --user restart on Linux)",
+			"Restart the installed singleton daemon (launchctl kickstart -k on macOS, systemctl --user restart on Linux)",
 		)
-		.option(
-			"--agent <type>",
-			"Agent to restart (auto-picked when only one is registered; required when multiple)",
-		)
-		.option("--all", "Restart every installed daemon on this machine")
 		.action(async (_opts, cmd) => {
 			const h = await get();
 			await h.serveRestart(cmd.optsWithGlobals());
@@ -150,10 +121,6 @@ Examples:
 	serveCmd
 		.command("logs")
 		.description("Tail a daemon's stderr log (delegates to `tail -F`)")
-		.option(
-			"--agent <type>",
-			"Agent whose log to tail (auto-picked when only one is registered; required when multiple)",
-		)
 		.option("--follow", "Stream new lines as they arrive (default: print last 200 and exit)")
 		.action(async (_opts, cmd) => {
 			const h = await get();
@@ -167,6 +134,15 @@ Examples:
 		.action(async (_opts, cmd) => {
 			const h = await get();
 			await h.serveDoctor(cmd.optsWithGlobals());
+		});
+
+	serveCmd
+		.command("rpc <method>")
+		.description("Call the local daemon control RPC socket")
+		.option("--params <json>", "JSON object passed as RPC params", "{}")
+		.action(async (method: string, _opts, cmd) => {
+			const h = await get();
+			await h.serveRpc(method, cmd.optsWithGlobals());
 		});
 
 	return serveCmd;

--- a/packages/cli/src/commands/serve-cli.ts
+++ b/packages/cli/src/commands/serve-cli.ts
@@ -9,7 +9,7 @@
  * weakest link.
  */
 
-import type { Command } from "commander";
+import { type Command, Option } from "commander";
 
 /**
  * Handlers that the daemon command tree dispatches to. Production
@@ -33,6 +33,12 @@ function addRpcEndpointOptions(cmd: Command): Command {
 		.option("--rpc-host <host>", "Control RPC HTTP host (enables HTTP when paired with --rpc-port)")
 		.option("--rpc-port <port>", "Control RPC HTTP port")
 		.option("--rpc-allow-remote", "Allow the HTTP RPC listener to bind a non-loopback host");
+}
+
+function addLegacyRunOptions(cmd: Command): Command {
+	return cmd
+		.addOption(new Option("--agent <type>", "Legacy per-agent daemon selector").hideHelp())
+		.addOption(new Option("--environment-id <id>", "Legacy per-agent environment id").hideHelp());
 }
 
 async function defaultHandlers(): Promise<ServeHandlers> {
@@ -89,19 +95,27 @@ Examples:
 			const h = await get();
 			await h.serve(opts);
 		});
+	addLegacyRunOptions(serveCmd);
 
-	serveCmd
-		.command("run")
-		.description("Run the sync daemon in the foreground")
-		.configureHelp({ showGlobalOptions: true })
-		.addHelpText("after", "\nControl RPC HTTP options are optional; Unix socket is always enabled.")
-		.option("--rpc-host <host>", "Control RPC HTTP host (enables HTTP when paired with --rpc-port)")
-		.option("--rpc-port <port>", "Control RPC HTTP port")
-		.option("--rpc-allow-remote", "Allow the HTTP RPC listener to bind a non-loopback host")
-		.action(async (_opts, cmd) => {
-			const h = await get();
-			await h.serve(cmd.optsWithGlobals());
-		});
+	addLegacyRunOptions(
+		serveCmd
+			.command("run")
+			.description("Run the sync daemon in the foreground")
+			.configureHelp({ showGlobalOptions: true })
+			.addHelpText(
+				"after",
+				"\nControl RPC HTTP options are optional; Unix socket is always enabled.",
+			)
+			.option(
+				"--rpc-host <host>",
+				"Control RPC HTTP host (enables HTTP when paired with --rpc-port)",
+			)
+			.option("--rpc-port <port>", "Control RPC HTTP port")
+			.option("--rpc-allow-remote", "Allow the HTTP RPC listener to bind a non-loopback host"),
+	).action(async (_opts, cmd) => {
+		const h = await get();
+		await h.serve(cmd.optsWithGlobals());
+	});
 
 	addRpcEndpointOptions(
 		serveCmd

--- a/packages/cli/src/commands/serve-cli.ts
+++ b/packages/cli/src/commands/serve-cli.ts
@@ -147,7 +147,7 @@ Examples:
 		.option("--rpc-token <token>", "Bearer token for RPC access (defaults to token file/env)")
 		.action(async (_opts, cmd) => {
 			const h = await get();
-			await h.serveRpc("daemon.ping", cmd.optsWithGlobals());
+			await h.serveRpc("ping", cmd.optsWithGlobals());
 		});
 
 	serveCmd

--- a/packages/cli/src/commands/serve-cli.ts
+++ b/packages/cli/src/commands/serve-cli.ts
@@ -28,6 +28,12 @@ export interface ServeHandlers {
 	serveRpc: (method: string, opts: Record<string, unknown>) => Promise<void> | void;
 }
 
+function addRpcEndpointOptions(cmd: Command): Command {
+	return cmd
+		.option("--rpc-host <host>", "Control RPC TCP host (enables TCP when paired with --rpc-port)")
+		.option("--rpc-port <port>", "Control RPC TCP port");
+}
+
 async function defaultHandlers(): Promise<ServeHandlers> {
 	const m = await import("./serve.js");
 	return {
@@ -47,6 +53,8 @@ export function registerServeCommand(program: Command, handlers?: ServeHandlers)
 	const serveCmd = program
 		.command("daemon")
 		.alias("serve")
+		.option("--rpc-host <host>", "Control RPC TCP host (enables TCP when paired with --rpc-port)")
+		.option("--rpc-port <port>", "Control RPC TCP port")
 		.description(
 			"Manage the background sync daemon — pushes local skill edits to cloud, pulls dashboard installs via SSE",
 		)
@@ -57,10 +65,14 @@ Environment:
   CLAWDI_AUTH_TOKEN       Bearer token (preferred over ~/.clawdi/auth.json)
   CLAWDI_SERVE_MODE       "container" forces polling watcher + graceful SIGTERM
   CLAWDI_STATE_DIR        Override location of queue.jsonl + health (default ~/.clawdi/serve)
+  CLAWDI_DAEMON_RPC_HOST  Optional TCP host for daemon control RPC
+  CLAWDI_DAEMON_RPC_PORT  Optional TCP port for daemon control RPC
+  CLAWDI_DAEMON_RPC_TOKEN Bearer token for TCP RPC clients (defaults to generated token file)
   CLAWDI_SERVE_DEBUG=1    Emit debug-level events to stderr
 
 Examples:
   $ clawdi daemon run
+  $ clawdi daemon run --rpc-host 127.0.0.1 --rpc-port 17654
   $ CLAWDI_SERVE_MODE=container clawdi daemon run
   $ clawdi daemon install                       # set up one launchd / systemd unit
   $ clawdi daemon status --agent claude_code    # health + supervisor state
@@ -78,18 +90,23 @@ Examples:
 	serveCmd
 		.command("run")
 		.description("Run the sync daemon in the foreground")
+		.configureHelp({ showGlobalOptions: true })
+		.addHelpText("after", "\nControl RPC TCP options are optional; Unix socket is always enabled.")
+		.option("--rpc-host <host>", "Control RPC TCP host (enables TCP when paired with --rpc-port)")
+		.option("--rpc-port <port>", "Control RPC TCP port")
 		.action(async (_opts, cmd) => {
 			const h = await get();
 			await h.serve(cmd.optsWithGlobals());
 		});
 
-	serveCmd
-		.command("install")
-		.description("Install the singleton daemon as a per-user OS service")
-		.action(async (_opts, cmd) => {
-			const h = await get();
-			await h.serveInstall(cmd.optsWithGlobals());
-		});
+	addRpcEndpointOptions(
+		serveCmd
+			.command("install")
+			.description("Install the singleton daemon as a per-user OS service"),
+	).action(async (_opts, cmd) => {
+		const h = await get();
+		await h.serveInstall(cmd.optsWithGlobals());
+	});
 
 	serveCmd
 		.command("uninstall")
@@ -140,6 +157,9 @@ Examples:
 		.command("rpc <method>")
 		.description("Call the local daemon control RPC socket")
 		.option("--params <json>", "JSON object passed as RPC params", "{}")
+		.option("--rpc-host <host>", "Control RPC TCP host to call (requires --rpc-port)")
+		.option("--rpc-port <port>", "Control RPC TCP port to call")
+		.option("--rpc-token <token>", "Bearer token for RPC access (defaults to token file/env)")
 		.action(async (method: string, _opts, cmd) => {
 			const h = await get();
 			await h.serveRpc(method, cmd.optsWithGlobals());

--- a/packages/cli/src/commands/serve-cli.ts
+++ b/packages/cli/src/commands/serve-cli.ts
@@ -30,9 +30,9 @@ export interface ServeHandlers {
 
 function addRpcEndpointOptions(cmd: Command): Command {
 	return cmd
-		.option("--rpc-host <host>", "Control RPC HTTP host")
-		.option("--rpc-port <port>", "Control RPC HTTP port")
-		.option("--rpc-allow-remote", "Allow the HTTP RPC listener to bind a non-loopback host");
+		.option("--host <host>", "Control HTTP RPC host")
+		.option("--port <port>", "Control HTTP RPC port")
+		.option("--allow-remote", "Allow the control HTTP RPC listener to bind a non-loopback host");
 }
 
 function addLegacyRunOptions(cmd: Command): Command {
@@ -60,9 +60,9 @@ export function registerServeCommand(program: Command, handlers?: ServeHandlers)
 	const serveCmd = program
 		.command("daemon")
 		.alias("serve")
-		.option("--rpc-host <host>", "Control RPC HTTP host")
-		.option("--rpc-port <port>", "Control RPC HTTP port")
-		.option("--rpc-allow-remote", "Allow the HTTP RPC listener to bind a non-loopback host")
+		.option("--host <host>", "Control HTTP RPC host")
+		.option("--port <port>", "Control HTTP RPC port")
+		.option("--allow-remote", "Allow the control HTTP RPC listener to bind a non-loopback host")
 		.description(
 			"Manage the background sync daemon — pushes local skill edits to cloud, pulls dashboard installs via SSE",
 		)
@@ -81,7 +81,7 @@ Environment:
 
 Examples:
   $ clawdi daemon run
-  $ clawdi daemon run --rpc-host 127.0.0.1 --rpc-port 17654
+  $ clawdi daemon run --host 127.0.0.1 --port 17654
   $ clawdi daemon ping
   $ CLAWDI_SERVE_MODE=container clawdi daemon run
   $ clawdi daemon install                       # set up one launchd / systemd unit
@@ -105,9 +105,9 @@ Examples:
 			.description("Run the sync daemon in the foreground")
 			.configureHelp({ showGlobalOptions: true })
 			.addHelpText("after", "\nControl RPC listens on loopback HTTP by default.")
-			.option("--rpc-host <host>", "Control RPC HTTP host")
-			.option("--rpc-port <port>", "Control RPC HTTP port")
-			.option("--rpc-allow-remote", "Allow the HTTP RPC listener to bind a non-loopback host"),
+			.option("--host <host>", "Control HTTP RPC host")
+			.option("--port <port>", "Control HTTP RPC port")
+			.option("--allow-remote", "Allow the control HTTP RPC listener to bind a non-loopback host"),
 	).action(async (_opts, cmd) => {
 		const h = await get();
 		await h.serve(cmd.optsWithGlobals());
@@ -143,9 +143,9 @@ Examples:
 	serveCmd
 		.command("ping")
 		.description("Check whether the daemon control RPC is reachable")
-		.option("--rpc-host <host>", "Control RPC HTTP host to call")
-		.option("--rpc-port <port>", "Control RPC HTTP port to call")
-		.option("--rpc-token <token>", "Bearer token for RPC access (defaults to token file/env)")
+		.option("--host <host>", "Control HTTP RPC host to call")
+		.option("--port <port>", "Control HTTP RPC port to call")
+		.option("--token <token>", "Bearer token for control RPC access (defaults to token file/env)")
 		.action(async (_opts, cmd) => {
 			const h = await get();
 			await h.serveRpc("ping", cmd.optsWithGlobals());
@@ -154,9 +154,9 @@ Examples:
 	serveCmd
 		.command("rotate-token")
 		.description("Rotate the daemon control RPC bearer token")
-		.option("--rpc-host <host>", "Control RPC HTTP host to call")
-		.option("--rpc-port <port>", "Control RPC HTTP port to call")
-		.option("--rpc-token <token>", "Current bearer token for RPC access")
+		.option("--host <host>", "Control HTTP RPC host to call")
+		.option("--port <port>", "Control HTTP RPC port to call")
+		.option("--token <token>", "Current bearer token for control RPC access")
 		.action(async (_opts, cmd) => {
 			const h = await get();
 			await h.serveRpc("rotate_token", cmd.optsWithGlobals());

--- a/packages/cli/src/commands/serve-cli.ts
+++ b/packages/cli/src/commands/serve-cli.ts
@@ -85,6 +85,7 @@ Examples:
   $ clawdi daemon ping
   $ CLAWDI_SERVE_MODE=container clawdi daemon run
   $ clawdi daemon install                       # set up one launchd / systemd unit
+  $ clawdi daemon rotate-token                  # rotate the local control token
   $ clawdi daemon status --agent claude_code    # health + supervisor state
   $ clawdi serve status --agent claude_code     # legacy alias`,
 		)
@@ -151,6 +152,17 @@ Examples:
 		});
 
 	serveCmd
+		.command("rotate-token")
+		.description("Rotate the daemon control RPC bearer token")
+		.option("--rpc-host <host>", "Control RPC HTTP host to call")
+		.option("--rpc-port <port>", "Control RPC HTTP port to call")
+		.option("--rpc-token <token>", "Current bearer token for RPC access")
+		.action(async (_opts, cmd) => {
+			const h = await get();
+			await h.serveRpc("rotate_token", cmd.optsWithGlobals());
+		});
+
+	serveCmd
 		.command("status")
 		.description("Show daemon health (last heartbeat) and supervisor state")
 		.option("--agent <type>", "Agent to check (defaults to all registered agents)")
@@ -175,18 +187,6 @@ Examples:
 		.action(async (_opts, cmd) => {
 			const h = await get();
 			await h.serveDoctor(cmd.optsWithGlobals());
-		});
-
-	serveCmd
-		.command("rpc <method>")
-		.description("Call an advanced daemon RPC method")
-		.option("--params <json>", "JSON object passed as RPC params", "{}")
-		.option("--rpc-host <host>", "Control RPC HTTP host to call")
-		.option("--rpc-port <port>", "Control RPC HTTP port to call")
-		.option("--rpc-token <token>", "Bearer token for RPC access (defaults to token file/env)")
-		.action(async (method: string, _opts, cmd) => {
-			const h = await get();
-			await h.serveRpc(method, cmd.optsWithGlobals());
 		});
 
 	return serveCmd;

--- a/packages/cli/src/commands/serve-cli.ts
+++ b/packages/cli/src/commands/serve-cli.ts
@@ -30,8 +30,9 @@ export interface ServeHandlers {
 
 function addRpcEndpointOptions(cmd: Command): Command {
 	return cmd
-		.option("--rpc-host <host>", "Control RPC TCP host (enables TCP when paired with --rpc-port)")
-		.option("--rpc-port <port>", "Control RPC TCP port");
+		.option("--rpc-host <host>", "Control RPC HTTP host (enables HTTP when paired with --rpc-port)")
+		.option("--rpc-port <port>", "Control RPC HTTP port")
+		.option("--rpc-allow-remote", "Allow the HTTP RPC listener to bind a non-loopback host");
 }
 
 async function defaultHandlers(): Promise<ServeHandlers> {
@@ -53,8 +54,9 @@ export function registerServeCommand(program: Command, handlers?: ServeHandlers)
 	const serveCmd = program
 		.command("daemon")
 		.alias("serve")
-		.option("--rpc-host <host>", "Control RPC TCP host (enables TCP when paired with --rpc-port)")
-		.option("--rpc-port <port>", "Control RPC TCP port")
+		.option("--rpc-host <host>", "Control RPC HTTP host (enables HTTP when paired with --rpc-port)")
+		.option("--rpc-port <port>", "Control RPC HTTP port")
+		.option("--rpc-allow-remote", "Allow the HTTP RPC listener to bind a non-loopback host")
 		.description(
 			"Manage the background sync daemon — pushes local skill edits to cloud, pulls dashboard installs via SSE",
 		)
@@ -65,9 +67,10 @@ Environment:
   CLAWDI_AUTH_TOKEN       Bearer token (preferred over ~/.clawdi/auth.json)
   CLAWDI_SERVE_MODE       "container" forces polling watcher + graceful SIGTERM
   CLAWDI_STATE_DIR        Override location of queue.jsonl + health (default ~/.clawdi/serve)
-  CLAWDI_DAEMON_RPC_HOST  Optional TCP host for daemon control RPC
-  CLAWDI_DAEMON_RPC_PORT  Optional TCP port for daemon control RPC
-  CLAWDI_DAEMON_RPC_TOKEN Bearer token for TCP RPC clients (defaults to generated token file)
+  CLAWDI_DAEMON_RPC_HOST         Optional HTTP host for daemon control RPC
+  CLAWDI_DAEMON_RPC_PORT         Optional HTTP port for daemon control RPC
+  CLAWDI_DAEMON_RPC_ALLOW_REMOTE Set to 1 to allow non-loopback HTTP bind
+  CLAWDI_DAEMON_RPC_TOKEN        Bearer token for HTTP RPC clients (defaults to generated token file)
   CLAWDI_SERVE_DEBUG=1    Emit debug-level events to stderr
 
 Examples:
@@ -91,9 +94,10 @@ Examples:
 		.command("run")
 		.description("Run the sync daemon in the foreground")
 		.configureHelp({ showGlobalOptions: true })
-		.addHelpText("after", "\nControl RPC TCP options are optional; Unix socket is always enabled.")
-		.option("--rpc-host <host>", "Control RPC TCP host (enables TCP when paired with --rpc-port)")
-		.option("--rpc-port <port>", "Control RPC TCP port")
+		.addHelpText("after", "\nControl RPC HTTP options are optional; Unix socket is always enabled.")
+		.option("--rpc-host <host>", "Control RPC HTTP host (enables HTTP when paired with --rpc-port)")
+		.option("--rpc-port <port>", "Control RPC HTTP port")
+		.option("--rpc-allow-remote", "Allow the HTTP RPC listener to bind a non-loopback host")
 		.action(async (_opts, cmd) => {
 			const h = await get();
 			await h.serve(cmd.optsWithGlobals());
@@ -157,8 +161,8 @@ Examples:
 		.command("rpc <method>")
 		.description("Call the local daemon control RPC socket")
 		.option("--params <json>", "JSON object passed as RPC params", "{}")
-		.option("--rpc-host <host>", "Control RPC TCP host to call (requires --rpc-port)")
-		.option("--rpc-port <port>", "Control RPC TCP port to call")
+		.option("--rpc-host <host>", "Control RPC HTTP host to call (requires --rpc-port)")
+		.option("--rpc-port <port>", "Control RPC HTTP port to call")
 		.option("--rpc-token <token>", "Bearer token for RPC access (defaults to token file/env)")
 		.action(async (method: string, _opts, cmd) => {
 			const h = await get();

--- a/packages/cli/src/commands/serve-handlers.test.ts
+++ b/packages/cli/src/commands/serve-handlers.test.ts
@@ -149,6 +149,43 @@ describe("subcommand handler rejects parent-leaked options", () => {
 	});
 });
 
+describe("full control RPC handler surface", () => {
+	it("advertises sync, vault, auth, update, and operation RPC methods", async () => {
+		const { createControlRpcHandlers } = await import("./serve");
+		const handlers = createControlRpcHandlers();
+		const methodsResult = (await handlers["daemon.methods"]?.({})) as
+			| { methods?: string[] }
+			| undefined;
+
+		expect(methodsResult?.methods).toContain("sync.push");
+		expect(methodsResult?.methods).toContain("sync.pull");
+		expect(methodsResult?.methods).toContain("vault.resolve");
+		expect(methodsResult?.methods).toContain("auth.login");
+		expect(methodsResult?.methods).toContain("update.install");
+		expect(methodsResult?.methods).toContain("operation.status");
+	});
+
+	it("requires an explicit cwd, project, or all=true for sync.push", async () => {
+		const { createControlRpcHandlers } = await import("./serve");
+		const handler = createControlRpcHandlers()["sync.push"];
+		if (!handler) throw new Error("missing sync.push handler");
+
+		await expect((async () => handler({}))()).rejects.toThrow(
+			"sync.push RPC requires cwd or project unless all=true",
+		);
+	});
+
+	it("blocks vault plaintext reads unless explicitly confirmed", async () => {
+		const { createControlRpcHandlers } = await import("./serve");
+		const handler = createControlRpcHandlers()["vault.resolve"];
+		if (!handler) throw new Error("missing vault.resolve handler");
+
+		await expect(
+			(async () => handler({ key: "OPENAI_API_KEY", include_value: true }))(),
+		).rejects.toThrow("vault.resolve plaintext access requires confirm_secret_access=true");
+	});
+});
+
 describe("daemon HTTP RPC listener safety", () => {
 	it("rejects non-loopback listen hosts unless explicitly allowed", async () => {
 		const { serve } = await import("./serve");

--- a/packages/cli/src/commands/serve-handlers.test.ts
+++ b/packages/cli/src/commands/serve-handlers.test.ts
@@ -175,6 +175,16 @@ describe("full control RPC handler surface", () => {
 		);
 	});
 
+	it("rejects push-only sync params on pull", async () => {
+		const { createControlRpcHandlers } = await import("./serve");
+		const handler = createControlRpcHandlers()["sync.pull"];
+		if (!handler) throw new Error("missing sync.pull handler");
+
+		await expect(
+			(async () => handler({ exclude_project: "/tmp/private", wait: true }))(),
+		).rejects.toThrow("Unsupported RPC params: exclude_project");
+	});
+
 	it("blocks vault plaintext reads unless explicitly confirmed", async () => {
 		const { createControlRpcHandlers } = await import("./serve");
 		const handler = createControlRpcHandlers()["vault.resolve"];
@@ -230,6 +240,37 @@ describe("full control RPC handler surface", () => {
 			expect(getAuth()?.apiKey).toBe("old-key");
 		} finally {
 			globalThis.fetch = originalFetch;
+			if (originalClawdiHome === undefined) delete process.env.CLAWDI_HOME;
+			else process.env.CLAWDI_HOME = originalClawdiHome;
+			if (originalToken === undefined) delete process.env.CLAWDI_AUTH_TOKEN;
+			else process.env.CLAWDI_AUTH_TOKEN = originalToken;
+			rmSync(tmpHome, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects device-flow auth replacement while existing auth is present", async () => {
+		const originalClawdiHome = process.env.CLAWDI_HOME;
+		const originalToken = process.env.CLAWDI_AUTH_TOKEN;
+		const tmpHome = mkdtempSync(join(tmpdir(), "clawdi-rpc-auth-replace-"));
+		process.env.CLAWDI_HOME = join(tmpHome, ".clawdi");
+		delete process.env.CLAWDI_AUTH_TOKEN;
+		try {
+			const [{ createControlRpcHandlers }, { setAuth }] = await Promise.all([
+				import("./serve"),
+				import("../lib/config"),
+			]);
+			setAuth({ apiKey: "old-key", userId: "old-user", email: "old@example.com" });
+			const handler = createControlRpcHandlers()["auth.login"];
+			if (!handler) throw new Error("missing auth.login handler");
+
+			await expect(
+				(async () =>
+					handler({
+						replace: true,
+						confirm_secret_access: true,
+					}))(),
+			).rejects.toThrow("auth.login replace requires api_key");
+		} finally {
 			if (originalClawdiHome === undefined) delete process.env.CLAWDI_HOME;
 			else process.env.CLAWDI_HOME = originalClawdiHome;
 			if (originalToken === undefined) delete process.env.CLAWDI_AUTH_TOKEN;

--- a/packages/cli/src/commands/serve-handlers.test.ts
+++ b/packages/cli/src/commands/serve-handlers.test.ts
@@ -154,7 +154,7 @@ describe("full control RPC handler surface", () => {
 		const { createControlRpcHandlers } = await import("./serve");
 		const handlers = createControlRpcHandlers();
 		const methodsResult = (await handlers["daemon.methods"]?.({})) as
-			| { methods?: string[] }
+			| { capabilities?: string[]; methods?: string[] }
 			| undefined;
 
 		expect(methodsResult?.methods).toContain("sync.push");
@@ -163,6 +163,8 @@ describe("full control RPC handler surface", () => {
 		expect(methodsResult?.methods).toContain("auth.login");
 		expect(methodsResult?.methods).toContain("update.install");
 		expect(methodsResult?.methods).toContain("operation.status");
+		expect(methodsResult?.methods).toContain("daemon.issue_token");
+		expect(methodsResult?.capabilities).toContain("vault:secrets");
 	});
 
 	it("requires an explicit cwd, project, or all=true for sync.push", async () => {
@@ -183,6 +185,24 @@ describe("full control RPC handler surface", () => {
 		await expect(
 			(async () => handler({ key: "OPENAI_API_KEY", include_value: true }))(),
 		).rejects.toThrow("vault.resolve plaintext access requires confirm_secret_access=true");
+	});
+
+	it("does not allow vault.inject secret rendering in background operation logs", async () => {
+		const { createControlRpcHandlers } = await import("./serve");
+		const handler = createControlRpcHandlers()["vault.inject"];
+		if (!handler) throw new Error("missing vault.inject handler");
+
+		await expect(
+			(async () =>
+				handler(
+					{
+						input: "OPENAI_API_KEY=clawdi://prod/openai/key",
+						confirm_secret_access: true,
+						wait: false,
+					},
+					{ tokenKind: "root", capabilities: "*", transport: "socket" },
+				))(),
+		).rejects.toThrow("vault.inject secret rendering cannot run as a background operation");
 	});
 });
 

--- a/packages/cli/src/commands/serve-handlers.test.ts
+++ b/packages/cli/src/commands/serve-handlers.test.ts
@@ -4,7 +4,7 @@ import { rejectUnsupportedOpts } from "./serve";
 /**
  * Behavior tests for the post-codex-review fixes:
  *   - rejectUnsupportedOpts (helper used by status/uninstall/restart/logs/doctor)
- *   - --all + --agent mutex (install / uninstall / restart) via integration
+ *   - singleton daemon handlers rejecting legacy target selectors
  *
  * Strategy: swap `process.exit` to throw a tagged error so we can
  * `expect(...).toThrow()` and inspect the captured `console.error`
@@ -84,27 +84,31 @@ describe("rejectUnsupportedOpts", () => {
 	});
 });
 
-describe("--all + --agent mutex", () => {
-	it("uninstall errors with both flags", async () => {
-		const { serveUninstall } = await import("./serve");
-		await expect(serveUninstall({ all: true, agent: "codex" })).rejects.toThrow(ExitCalled);
-		expect(captured.exitCode).toBe(1);
-		expect(captured.stderr.join("\n")).toMatch(/--all and --agent are mutually exclusive/);
-	});
-
-	it("restart errors with both flags", async () => {
-		const { serveRestart } = await import("./serve");
-		await expect(serveRestart({ all: true, agent: "codex" })).rejects.toThrow(ExitCalled);
-		expect(captured.exitCode).toBe(1);
-		expect(captured.stderr.join("\n")).toMatch(/--all and --agent are mutually exclusive/);
-	});
-
-	// install's mutex is also tested via parser path (serve-cli-options.test.ts)
-	// — the handler-level test would need to stub `isLoggedIn` so we can reach
-	// the `if (opts.all)` branch. Skip in favor of the integration test.
-});
-
 describe("subcommand handler rejects parent-leaked options", () => {
+	it("install rejects legacy selectors", async () => {
+		const { serveInstall } = await import("./serve");
+		await expect(serveInstall({ agent: "codex" } as Record<string, unknown>)).rejects.toThrow(
+			ExitCalled,
+		);
+		expect(captured.stderr.join("\n")).toMatch(/daemon install.*--agent/);
+	});
+
+	it("uninstall rejects legacy selectors", async () => {
+		const { serveUninstall } = await import("./serve");
+		await expect(serveUninstall({ agent: "codex" } as Record<string, unknown>)).rejects.toThrow(
+			ExitCalled,
+		);
+		expect(captured.stderr.join("\n")).toMatch(/daemon uninstall.*--agent/);
+	});
+
+	it("restart rejects legacy selectors", async () => {
+		const { serveRestart } = await import("./serve");
+		await expect(serveRestart({ agent: "codex" } as Record<string, unknown>)).rejects.toThrow(
+			ExitCalled,
+		);
+		expect(captured.stderr.join("\n")).toMatch(/daemon restart.*--agent/);
+	});
+
 	it("uninstall rejects --environment-id", async () => {
 		const { serveUninstall } = await import("./serve");
 		await expect(

--- a/packages/cli/src/commands/serve-handlers.test.ts
+++ b/packages/cli/src/commands/serve-handlers.test.ts
@@ -153,10 +153,11 @@ describe("full control RPC handler surface", () => {
 	it("advertises sync, vault, auth, update, and operation RPC methods", async () => {
 		const { createControlRpcHandlers } = await import("./serve");
 		const handlers = createControlRpcHandlers();
-		const methodsResult = (await handlers["daemon.methods"]?.({})) as
-			| { methods?: string[] }
-			| undefined;
+		const methodsResult = (await handlers.methods?.({})) as { methods?: string[] } | undefined;
 
+		expect(methodsResult?.methods).toContain("ping");
+		expect(methodsResult?.methods).toContain("status");
+		expect(methodsResult?.methods?.some((method) => method.startsWith("daemon."))).toBe(false);
 		expect(methodsResult?.methods).toContain("sync.push");
 		expect(methodsResult?.methods).toContain("sync.pull");
 		expect(methodsResult?.methods).toContain("vault.resolve");

--- a/packages/cli/src/commands/serve-handlers.test.ts
+++ b/packages/cli/src/commands/serve-handlers.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { rejectUnsupportedOpts } from "./serve";
 
 /**
@@ -135,5 +138,47 @@ describe("subcommand handler rejects parent-leaked options", () => {
 			ExitCalled,
 		);
 		expect(captured.stderr.join("\n")).toMatch(/daemon doctor.*--agent/);
+	});
+});
+
+describe("daemon HTTP RPC listener safety", () => {
+	it("rejects non-loopback listen hosts unless explicitly allowed", async () => {
+		const { serve } = await import("./serve");
+
+		await expect(
+			serve({ rpcHost: "0.0.0.0", rpcPort: "17654" } as Record<string, unknown>),
+		).rejects.toThrow("Refusing to listen on non-loopback HTTP RPC host 0.0.0.0");
+	});
+
+	it("rejects a listen host without a port", async () => {
+		const { serve } = await import("./serve");
+
+		await expect(serve({ rpcHost: "127.0.0.1" } as Record<string, unknown>)).rejects.toThrow(
+			"--rpc-host requires --rpc-port",
+		);
+	});
+
+	it("allows explicit non-loopback opt-in before continuing to the auth gate", async () => {
+		const originalHome = process.env.CLAWDI_HOME;
+		const originalToken = process.env.CLAWDI_AUTH_TOKEN;
+		const tmpHome = mkdtempSync(join(tmpdir(), "clawdi-rpc-listen-"));
+		process.env.CLAWDI_HOME = join(tmpHome, ".clawdi");
+		delete process.env.CLAWDI_AUTH_TOKEN;
+		try {
+			const { serve } = await import("./serve");
+			await expect(
+				serve({
+					rpcHost: "0.0.0.0",
+					rpcPort: "17654",
+					rpcAllowRemote: true,
+				} as Record<string, unknown>),
+			).rejects.toThrow(ExitCalled);
+		} finally {
+			if (originalHome === undefined) delete process.env.CLAWDI_HOME;
+			else process.env.CLAWDI_HOME = originalHome;
+			if (originalToken === undefined) delete process.env.CLAWDI_AUTH_TOKEN;
+			else process.env.CLAWDI_AUTH_TOKEN = originalToken;
+			rmSync(tmpHome, { recursive: true, force: true });
+		}
 	});
 });

--- a/packages/cli/src/commands/serve-handlers.test.ts
+++ b/packages/cli/src/commands/serve-handlers.test.ts
@@ -13,7 +13,7 @@ import { dirname, join } from "node:path";
 import { rejectUnsupportedOpts } from "./serve";
 
 /**
- * Behavior tests for the post-codex-review fixes:
+ * Behavior tests for daemon singleton handler behavior:
  *   - rejectUnsupportedOpts (helper used by status/uninstall/restart/logs/doctor)
  *   - singleton daemon handlers rejecting legacy target selectors
  *
@@ -198,6 +198,44 @@ describe("full control RPC handler surface", () => {
 					wait: false,
 				}))(),
 		).rejects.toThrow("vault.inject secret rendering cannot run as a background operation");
+	});
+
+	it("does not overwrite existing auth with an unverified imported API key", async () => {
+		const originalClawdiHome = process.env.CLAWDI_HOME;
+		const originalToken = process.env.CLAWDI_AUTH_TOKEN;
+		const originalFetch = globalThis.fetch;
+		const tmpHome = mkdtempSync(join(tmpdir(), "clawdi-rpc-auth-"));
+		process.env.CLAWDI_HOME = join(tmpHome, ".clawdi");
+		delete process.env.CLAWDI_AUTH_TOKEN;
+		globalThis.fetch = Object.assign(async () => new Response("", { status: 401 }), {
+			preconnect: originalFetch.preconnect,
+		});
+		try {
+			const [{ createControlRpcHandlers }, { getAuth, setAuth }] = await Promise.all([
+				import("./serve"),
+				import("../lib/config"),
+			]);
+			setAuth({ apiKey: "old-key", userId: "old-user", email: "old@example.com" });
+			const handler = createControlRpcHandlers()["auth.login"];
+			if (!handler) throw new Error("missing auth.login handler");
+
+			await expect(
+				(async () =>
+					handler({
+						api_key: "bad-key",
+						replace: true,
+						confirm_secret_access: true,
+					}))(),
+			).rejects.toThrow("API key verification failed with HTTP 401");
+			expect(getAuth()?.apiKey).toBe("old-key");
+		} finally {
+			globalThis.fetch = originalFetch;
+			if (originalClawdiHome === undefined) delete process.env.CLAWDI_HOME;
+			else process.env.CLAWDI_HOME = originalClawdiHome;
+			if (originalToken === undefined) delete process.env.CLAWDI_AUTH_TOKEN;
+			else process.env.CLAWDI_AUTH_TOKEN = originalToken;
+			rmSync(tmpHome, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/packages/cli/src/commands/serve-handlers.test.ts
+++ b/packages/cli/src/commands/serve-handlers.test.ts
@@ -1,7 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { rejectUnsupportedOpts } from "./serve";
 
 /**
@@ -182,3 +190,63 @@ describe("daemon HTTP RPC listener safety", () => {
 		}
 	});
 });
+
+describe("legacy daemon run migration", () => {
+	it("installs the singleton unit, persists an explicit env id, and removes the old unit", async () => {
+		if (process.platform !== "linux") return;
+
+		const originalHome = process.env.HOME;
+		const originalClawdiHome = process.env.CLAWDI_HOME;
+		const originalPath = process.env.PATH;
+		const originalToken = process.env.CLAWDI_AUTH_TOKEN;
+		const originalArgv1 = process.argv[1];
+		const tmpHome = mkdtempSync(join(tmpdir(), "clawdi-legacy-daemon-"));
+		const stubBin = join(tmpHome, "bin");
+		const fakeEntry = join(tmpHome, "clawdi-bin");
+		const singletonUnit = join(tmpHome, ".config", "systemd", "user", "clawdi-serve.service");
+		const legacyUnit = join(tmpHome, ".config", "systemd", "user", "clawdi-serve-codex.service");
+		try {
+			process.env.HOME = tmpHome;
+			delete process.env.CLAWDI_HOME;
+			process.env.CLAWDI_AUTH_TOKEN = "clawdi_test_token";
+			mkdirSync(stubBin, { recursive: true });
+			writeExecutable(join(stubBin, "systemctl"), "#!/bin/sh\nexit 0\n");
+			process.env.PATH = `${stubBin}:${originalPath ?? ""}`;
+			writeExecutable(fakeEntry, "#!/bin/sh\nexit 0\n");
+			process.argv[1] = fakeEntry;
+			mkdirSync(dirname(legacyUnit), { recursive: true });
+			writeFileSync(legacyUnit, "legacy unit\n");
+
+			const { serve } = await import("./serve");
+			await expect(
+				serve({
+					agent: "codex",
+					environmentId: "env-codex",
+				} as Record<string, unknown>),
+			).rejects.toThrow(ExitCalled);
+
+			expect(captured.exitCode).toBe(0);
+			expect(existsSync(singletonUnit)).toBe(true);
+			expect(existsSync(legacyUnit)).toBe(false);
+			expect(
+				readFileSync(join(tmpHome, ".clawdi", "environments", "codex.json"), "utf-8"),
+			).toContain('"id": "env-codex"');
+		} finally {
+			if (originalHome === undefined) delete process.env.HOME;
+			else process.env.HOME = originalHome;
+			if (originalClawdiHome === undefined) delete process.env.CLAWDI_HOME;
+			else process.env.CLAWDI_HOME = originalClawdiHome;
+			if (originalPath === undefined) delete process.env.PATH;
+			else process.env.PATH = originalPath;
+			if (originalToken === undefined) delete process.env.CLAWDI_AUTH_TOKEN;
+			else process.env.CLAWDI_AUTH_TOKEN = originalToken;
+			process.argv[1] = originalArgv1 ?? "";
+			rmSync(tmpHome, { recursive: true, force: true });
+		}
+	});
+});
+
+function writeExecutable(path: string, content: string): void {
+	writeFileSync(path, content, { mode: 0o755 });
+	chmodSync(path, 0o755);
+}

--- a/packages/cli/src/commands/serve-handlers.test.ts
+++ b/packages/cli/src/commands/serve-handlers.test.ts
@@ -154,7 +154,7 @@ describe("full control RPC handler surface", () => {
 		const { createControlRpcHandlers } = await import("./serve");
 		const handlers = createControlRpcHandlers();
 		const methodsResult = (await handlers["daemon.methods"]?.({})) as
-			| { capabilities?: string[]; methods?: string[] }
+			| { methods?: string[] }
 			| undefined;
 
 		expect(methodsResult?.methods).toContain("sync.push");
@@ -163,8 +163,6 @@ describe("full control RPC handler surface", () => {
 		expect(methodsResult?.methods).toContain("auth.login");
 		expect(methodsResult?.methods).toContain("update.install");
 		expect(methodsResult?.methods).toContain("operation.status");
-		expect(methodsResult?.methods).toContain("daemon.issue_token");
-		expect(methodsResult?.capabilities).toContain("vault:secrets");
 	});
 
 	it("requires an explicit cwd, project, or all=true for sync.push", async () => {
@@ -194,14 +192,11 @@ describe("full control RPC handler surface", () => {
 
 		await expect(
 			(async () =>
-				handler(
-					{
-						input: "OPENAI_API_KEY=clawdi://prod/openai/key",
-						confirm_secret_access: true,
-						wait: false,
-					},
-					{ tokenKind: "root", capabilities: "*", transport: "socket" },
-				))(),
+				handler({
+					input: "OPENAI_API_KEY=clawdi://prod/openai/key",
+					confirm_secret_access: true,
+					wait: false,
+				}))(),
 		).rejects.toThrow("vault.inject secret rendering cannot run as a background operation");
 	});
 });

--- a/packages/cli/src/commands/serve-handlers.test.ts
+++ b/packages/cli/src/commands/serve-handlers.test.ts
@@ -210,11 +210,11 @@ describe("daemon HTTP RPC listener safety", () => {
 		).rejects.toThrow("Refusing to listen on non-loopback HTTP RPC host 0.0.0.0");
 	});
 
-	it("rejects a listen host without a port", async () => {
+	it("allows a loopback listen host without an explicit port before continuing to the auth gate", async () => {
 		const { serve } = await import("./serve");
 
 		await expect(serve({ rpcHost: "127.0.0.1" } as Record<string, unknown>)).rejects.toThrow(
-			"--rpc-host requires --rpc-port",
+			ExitCalled,
 		);
 	});
 

--- a/packages/cli/src/commands/serve-handlers.test.ts
+++ b/packages/cli/src/commands/serve-handlers.test.ts
@@ -286,14 +286,14 @@ describe("daemon HTTP RPC listener safety", () => {
 		const { serve } = await import("./serve");
 
 		await expect(
-			serve({ rpcHost: "0.0.0.0", rpcPort: "17654" } as Record<string, unknown>),
+			serve({ host: "0.0.0.0", port: "17654" } as Record<string, unknown>),
 		).rejects.toThrow("Refusing to listen on non-loopback HTTP RPC host 0.0.0.0");
 	});
 
 	it("allows a loopback listen host without an explicit port before continuing to the auth gate", async () => {
 		const { serve } = await import("./serve");
 
-		await expect(serve({ rpcHost: "127.0.0.1" } as Record<string, unknown>)).rejects.toThrow(
+		await expect(serve({ host: "127.0.0.1" } as Record<string, unknown>)).rejects.toThrow(
 			ExitCalled,
 		);
 	});
@@ -308,9 +308,9 @@ describe("daemon HTTP RPC listener safety", () => {
 			const { serve } = await import("./serve");
 			await expect(
 				serve({
-					rpcHost: "0.0.0.0",
-					rpcPort: "17654",
-					rpcAllowRemote: true,
+					host: "0.0.0.0",
+					port: "17654",
+					allowRemote: true,
 				} as Record<string, unknown>),
 			).rejects.toThrow(ExitCalled);
 		} finally {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -29,7 +29,9 @@ import { adapterForType, getEnvIdByAgent, listRegisteredAgentTypes } from "../li
 import { getCliVersion } from "../lib/version";
 import { startAutoRestart } from "../serve/auto-restart";
 import {
+	type ControlRpcClientConfig,
 	type ControlRpcHandlers,
+	type ControlRpcListenConfig,
 	callControlRpc,
 	startControlRpcServer,
 } from "../serve/control-rpc";
@@ -54,6 +56,13 @@ import { startDaemonAutoUpdate } from "./update";
 
 type ServeOpts = Record<string, unknown>;
 
+interface RpcListenOpts {
+	rpcHost?: unknown;
+	rpcPort?: unknown;
+}
+
+let activeControlRpcTcp: { host: string; port: number } | null = null;
+
 interface DaemonRunTarget {
 	agentType: AgentType;
 	adapter: NonNullable<ReturnType<typeof adapterForType>>;
@@ -77,6 +86,7 @@ interface DaemonDoctorReport {
 	control_rpc: {
 		socket_path: string;
 		token_path: string;
+		tcp: { host: string; port: number } | null;
 	};
 	api_url: string | null;
 	agents: Array<
@@ -122,6 +132,8 @@ function camelToFlag(name: string): string {
 }
 
 export async function serve(_opts: ServeOpts): Promise<void> {
+	const opts = _opts as RpcListenOpts;
+	const rpcListen = resolveRpcListenConfig(opts);
 	const mode = (process.env.CLAWDI_SERVE_MODE ?? "host").toLowerCase();
 	const isContainer = mode === "container";
 
@@ -177,10 +189,12 @@ export async function serve(_opts: ServeOpts): Promise<void> {
 		}
 	}
 
-	const rpc = await startControlRpcServer(createControlRpcHandlers(), abort.signal);
+	const rpc = await startControlRpcServer(createControlRpcHandlers(), abort.signal, rpcListen);
+	activeControlRpcTcp = rpc.tcp;
 	log.info("serve.rpc_listening", {
 		socket: rpc.socketPath,
 		token_path: rpc.tokenPath,
+		tcp: rpc.tcp,
 	});
 
 	try {
@@ -213,6 +227,7 @@ type ServeInstallOpts = Record<string, unknown>;
 
 export async function serveInstall(opts: ServeInstallOpts): Promise<void> {
 	rejectUnsupportedOpts("install", opts as Record<string, unknown>, INSTALL_ALLOWED);
+	const rpcListen = resolveRpcListenConfig(opts as RpcListenOpts);
 	if (!isLoggedIn()) {
 		console.error("Not logged in. Run `clawdi auth login` first — the daemon needs an api key.");
 		process.exit(1);
@@ -233,7 +248,10 @@ export async function serveInstall(opts: ServeInstallOpts): Promise<void> {
 		}
 	}
 	try {
-		const result = installService();
+		const result = installService({
+			rpcHost: rpcListen.host,
+			rpcPort: rpcListen.port,
+		});
 		const verb = result.replaced ? "Replaced existing" : "Installed";
 		console.log(`✓ ${verb} singleton daemon unit: ${result.unit}`);
 		console.log(result.instructions);
@@ -245,11 +263,11 @@ export async function serveInstall(opts: ServeInstallOpts): Promise<void> {
 	if (failed > 0) process.exit(1);
 }
 
-const INSTALL_ALLOWED = new Set<string>();
+const INSTALL_ALLOWED = new Set(["rpcHost", "rpcPort"]);
 const UNINSTALL_ALLOWED = new Set<string>();
 const STATUS_ALLOWED = new Set(["agent"]);
 const DOCTOR_ALLOWED = new Set(["json"]);
-const RPC_ALLOWED = new Set(["params"]);
+const RPC_ALLOWED = new Set(["params", "rpcHost", "rpcPort", "rpcToken"]);
 
 export async function serveUninstall(opts: ServeInstallOpts): Promise<void> {
 	rejectUnsupportedOpts("uninstall", opts as Record<string, unknown>, UNINSTALL_ALLOWED);
@@ -423,6 +441,9 @@ export async function serveDoctor(opts: ServeDoctorOpts): Promise<void> {
 		console.log(`legacy:      ${summary.legacy_daemon_units.join(", ")}`);
 	}
 	console.log(`rpc socket:  ${summary.control_rpc.socket_path}`);
+	if (summary.control_rpc.tcp) {
+		console.log(`rpc tcp:     ${summary.control_rpc.tcp.host}:${summary.control_rpc.tcp.port}`);
+	}
 	console.log("");
 	if (summary.registered_agents === 0) {
 		console.log("No agents registered yet — run `clawdi setup` first.");
@@ -490,6 +511,7 @@ function buildDoctorReport(): DaemonDoctorReport {
 		control_rpc: {
 			socket_path: getDaemonControlSocketPath(),
 			token_path: getDaemonControlTokenPath(),
+			tcp: activeControlRpcTcp ?? normalizeRpcTcpConfig(resolveRpcListenConfig({})),
 		},
 		api_url: process.env.CLAWDI_API_URL ?? null,
 		agents,
@@ -498,6 +520,9 @@ function buildDoctorReport(): DaemonDoctorReport {
 
 interface ServeRpcOpts {
 	params?: string;
+	rpcHost?: unknown;
+	rpcPort?: unknown;
+	rpcToken?: unknown;
 }
 
 export async function serveRpc(method: string, opts: ServeRpcOpts): Promise<void> {
@@ -510,7 +535,8 @@ export async function serveRpc(method: string, opts: ServeRpcOpts): Promise<void
 			throw new Error(`--params must be valid JSON: ${toErrorMessage(error)}`);
 		}
 	}
-	const result = await callControlRpc(method, params);
+	const rpcTarget = resolveRpcClientConfig(opts);
+	const result = await callControlRpc(method, params, rpcTarget);
 	console.log(JSON.stringify(result, null, 2));
 }
 
@@ -545,8 +571,15 @@ function createControlRpcHandlers(): ControlRpcHandlers {
 
 function daemonInstallRpc(params: unknown): unknown {
 	const record = rpcParamsRecord(params);
-	rejectRpcParams(record, new Set());
-	return installService();
+	rejectRpcParams(record, new Set(["rpc_host", "rpc_port"]));
+	const rpcListen = resolveRpcListenConfig({
+		rpcHost: record.rpc_host,
+		rpcPort: record.rpc_port,
+	});
+	return installService({
+		rpcHost: rpcListen.host,
+		rpcPort: rpcListen.port,
+	});
 }
 
 function daemonUninstallRpc(params: unknown): unknown {
@@ -631,6 +664,49 @@ function optionalAgentParam(value: unknown): AgentType | undefined {
 		throw new Error(`Unknown agent: ${agent}. Expected one of: ${AGENT_TYPES.join(", ")}`);
 	}
 	return agent;
+}
+
+function resolveRpcListenConfig(opts: RpcListenOpts): ControlRpcListenConfig {
+	const host =
+		optionalStringParam(opts.rpcHost, "--rpc-host") ?? process.env.CLAWDI_DAEMON_RPC_HOST;
+	const portValue = opts.rpcPort ?? process.env.CLAWDI_DAEMON_RPC_PORT;
+	const port = optionalPortParam(portValue, "--rpc-port");
+	if (host !== undefined && port === undefined) {
+		throw new Error("--rpc-host requires --rpc-port (or CLAWDI_DAEMON_RPC_PORT)");
+	}
+	if (host === undefined && port === undefined) return {};
+	return { host: host ?? "127.0.0.1", port };
+}
+
+function resolveRpcClientConfig(
+	opts: RpcListenOpts & { rpcToken?: unknown },
+): ControlRpcClientConfig {
+	const listen = resolveRpcListenConfig(opts);
+	const token = optionalStringParam(opts.rpcToken, "--rpc-token");
+	return { ...listen, token };
+}
+
+function normalizeRpcTcpConfig(
+	config: ControlRpcListenConfig,
+): { host: string; port: number } | null {
+	if (config.port === undefined) return null;
+	return { host: config.host ?? "127.0.0.1", port: config.port };
+}
+
+function optionalPortParam(value: unknown, label: string): number | undefined {
+	if (value === undefined || value === null) return undefined;
+	let port: number;
+	if (typeof value === "number") {
+		port = value;
+	} else if (typeof value === "string" && /^\d+$/.test(value.trim())) {
+		port = Number(value);
+	} else {
+		throw new Error(`${label} must be an integer from 1 to 65535`);
+	}
+	if (!Number.isInteger(port) || port < 1 || port > 65535) {
+		throw new Error(`${label} must be an integer from 1 to 65535`);
+	}
+	return port;
 }
 
 function cleanupLegacyDaemonUnits(): number {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -42,12 +42,19 @@ import { adapterForType, getEnvIdByAgent, listRegisteredAgentTypes } from "../li
 import { getCliVersion } from "../lib/version";
 import { startAutoRestart } from "../serve/auto-restart";
 import {
+	CONTROL_RPC_CAPABILITIES,
+	type ControlRpcAuthContext,
 	type ControlRpcClientConfig,
 	type ControlRpcHandlers,
 	type ControlRpcListenConfig,
 	callControlRpc,
+	issueScopedControlToken,
+	type RpcCapability,
+	requireRpcCapability,
+	rootOnlyRpcHandler,
 	rotateControlToken,
 	startControlRpcServer,
+	withRpcCapabilities,
 } from "../serve/control-rpc";
 import {
 	install as installService,
@@ -141,6 +148,7 @@ interface RpcCommandOptions {
 	parseJson?: boolean;
 	redactedArgs?: string[];
 	timeoutMs?: number;
+	exclusiveKey?: string;
 }
 
 interface RpcCommandResponse extends CommandResult {
@@ -242,7 +250,11 @@ export async function serve(_opts: ServeOpts): Promise<void> {
 		}
 	}
 
-	const rpc = await startControlRpcServer(createControlRpcHandlers(), abort.signal, rpcListen);
+	const rpc = await startControlRpcServer(
+		createControlRpcHandlers({ abortController: abort }),
+		abort.signal,
+		rpcListen,
+	);
 	activeControlRpcHttp = rpc.http
 		? { ...rpc.http, allow_remote: rpcListen.allowRemote === true }
 		: null;
@@ -596,17 +608,33 @@ export async function serveRpc(method: string, opts: ServeRpcOpts): Promise<void
 	console.log(JSON.stringify(result, null, 2));
 }
 
-export function createControlRpcHandlers(): ControlRpcHandlers {
+interface ControlRpcHandlerOptions {
+	abortController?: AbortController;
+}
+
+export function createControlRpcHandlers(opts: ControlRpcHandlerOptions = {}): ControlRpcHandlers {
 	const handlers: ControlRpcHandlers = {};
-	handlers["daemon.ping"] = () => ({
+	handlers["daemon.ping"] = rpcHandler(["daemon:read"], () => ({
 		pid: process.pid,
 		version: getCliVersion(),
 		uptime_seconds: Math.round(process.uptime()),
-	});
-	handlers["daemon.methods"] = () => ({
+	}));
+	handlers["daemon.methods"] = rpcHandler(["daemon:read"], () => ({
+		capabilities: CONTROL_RPC_CAPABILITIES,
 		methods: Object.keys(handlers).sort(),
-	});
-	handlers["daemon.status"] = (params) => {
+		requirements: Object.fromEntries(
+			Object.entries(handlers)
+				.sort(([left], [right]) => left.localeCompare(right))
+				.map(([method, handler]) => [
+					method,
+					{
+						capabilities: handler.requiredCapabilities ?? [],
+						root_only: handler.rootOnly === true,
+					},
+				]),
+		),
+	}));
+	handlers["daemon.status"] = rpcHandler(["daemon:read"], (params) => {
 		const record = rpcParamsRecord(params);
 		rejectRpcParams(record, new Set(["agent"]));
 		const agent = optionalAgentParam(record.agent);
@@ -616,37 +644,65 @@ export function createControlRpcHandlers(): ControlRpcHandlers {
 			legacy_daemon_units: listInstalledAgents(),
 			agents: targets.map(buildStatusReport),
 		};
-	};
-	handlers["daemon.doctor"] = () => buildDoctorReport();
-	handlers["daemon.install"] = (params) => daemonInstallRpc(params);
-	handlers["daemon.uninstall"] = (params) => daemonUninstallRpc(params);
-	handlers["daemon.restart"] = (params) => daemonRestartRpc(params);
-	handlers["daemon.logs"] = (params) => daemonLogsRpc(params);
-	handlers["daemon.rotate_token"] = (params) => daemonRotateTokenRpc(params);
-	handlers["operation.list"] = (params) => operationListRpc(params);
-	handlers["operation.status"] = (params) => operationStatusRpc(params);
-	handlers["operation.logs"] = (params) => operationLogsRpc(params);
-	handlers["operation.cancel"] = (params) => operationCancelRpc(params);
-	handlers["sync.push"] = (params) => syncPushRpc(params);
-	handlers["sync.pull"] = (params) => syncPullRpc(params);
-	handlers["sync.push_dry_run"] = (params) => syncPushDryRunRpc(params);
-	handlers["sync.pull_dry_run"] = (params) => syncPullDryRunRpc(params);
-	handlers["vault.set"] = (params) => vaultSetRpc(params);
-	handlers["vault.list"] = (params) => vaultListRpc(params);
-	handlers["vault.import"] = (params) => vaultImportRpc(params);
-	handlers["vault.attach"] = (params) => vaultAttachRpc(params);
-	handlers["vault.detach"] = (params) => vaultDetachRpc(params);
-	handlers["vault.rm"] = (params) => vaultRmRpc(params);
-	handlers["vault.resolve"] = (params) => vaultResolveRpc(params);
-	handlers["vault.read"] = (params) => vaultReadRpc(params);
-	handlers["vault.inject"] = (params) => vaultInjectRpc(params);
-	handlers["auth.status"] = (params) => authStatusRpc(params);
-	handlers["auth.login"] = (params) => authLoginRpc(params);
-	handlers["auth.complete"] = (params) => authCompleteRpc(params);
-	handlers["auth.logout"] = (params) => authLogoutRpc(params);
-	handlers["update.check"] = (params) => updateCheckRpc(params);
-	handlers["update.install"] = (params) => updateInstallRpc(params);
+	});
+	handlers["daemon.doctor"] = rpcHandler(["daemon:read"], () => buildDoctorReport());
+	handlers["daemon.install"] = rpcHandler(["daemon:control"], (params) => daemonInstallRpc(params));
+	handlers["daemon.uninstall"] = rpcHandler(["daemon:control"], (params) =>
+		daemonUninstallRpc(params),
+	);
+	handlers["daemon.restart"] = rpcHandler(["daemon:control"], (params) => daemonRestartRpc(params));
+	handlers["daemon.logs"] = rpcHandler(["daemon:read"], (params) => daemonLogsRpc(params));
+	handlers["daemon.issue_token"] = rootRpcHandler((params) => daemonIssueTokenRpc(params));
+	handlers["daemon.rotate_token"] = rootRpcHandler((params) => daemonRotateTokenRpc(params));
+	handlers["operation.list"] = rpcHandler(["operation:read"], (params) => operationListRpc(params));
+	handlers["operation.status"] = rpcHandler(["operation:read"], (params) =>
+		operationStatusRpc(params),
+	);
+	handlers["operation.logs"] = rpcHandler(["operation:read"], (params) => operationLogsRpc(params));
+	handlers["operation.cancel"] = rpcHandler(["operation:control"], (params) =>
+		operationCancelRpc(params),
+	);
+	handlers["sync.push"] = rpcHandler(["sync:run"], (params) => syncPushRpc(params));
+	handlers["sync.pull"] = rpcHandler(["sync:run"], (params) => syncPullRpc(params));
+	handlers["sync.push_dry_run"] = rpcHandler(["sync:run"], (params) => syncPushDryRunRpc(params));
+	handlers["sync.pull_dry_run"] = rpcHandler(["sync:run"], (params) => syncPullDryRunRpc(params));
+	handlers["vault.set"] = rpcHandler(["vault:write"], (params) => vaultSetRpc(params));
+	handlers["vault.list"] = rpcHandler(["vault:read"], (params) => vaultListRpc(params));
+	handlers["vault.import"] = rpcHandler(["vault:write"], (params) => vaultImportRpc(params));
+	handlers["vault.attach"] = rpcHandler(["vault:write"], (params) => vaultAttachRpc(params));
+	handlers["vault.detach"] = rpcHandler(["vault:write"], (params) => vaultDetachRpc(params));
+	handlers["vault.rm"] = rpcHandler(["vault:write"], (params) => vaultRmRpc(params));
+	handlers["vault.resolve"] = rpcHandler(["vault:read"], (params, context) =>
+		vaultResolveRpc(params, context),
+	);
+	handlers["vault.read"] = rpcHandler(["vault:read"], (params, context) =>
+		vaultReadRpc(params, context),
+	);
+	handlers["vault.inject"] = rpcHandler(["vault:read"], (params, context) =>
+		vaultInjectRpc(params, context),
+	);
+	handlers["auth.status"] = rpcHandler(["auth:read"], (params) => authStatusRpc(params));
+	handlers["auth.login"] = rpcHandler(["auth:write"], (params) => authLoginRpc(params));
+	handlers["auth.complete"] = rpcHandler(["auth:write"], (params) => authCompleteRpc(params));
+	handlers["auth.logout"] = rpcHandler(["auth:write"], (params) => authLogoutRpc(params));
+	handlers["update.check"] = rpcHandler(["update:read"], (params) => updateCheckRpc(params));
+	handlers["update.install"] = rpcHandler(["update:install"], (params) =>
+		updateInstallRpc(params, opts.abortController),
+	);
 	return handlers;
+}
+
+function rpcHandler(
+	capabilities: readonly RpcCapability[],
+	handler: (params: unknown, context?: ControlRpcAuthContext) => Promise<unknown> | unknown,
+) {
+	return withRpcCapabilities(handler, capabilities);
+}
+
+function rootRpcHandler(
+	handler: (params: unknown, context?: ControlRpcAuthContext) => Promise<unknown> | unknown,
+) {
+	return rootOnlyRpcHandler(handler);
 }
 
 function operationListRpc(params: unknown): unknown {
@@ -747,6 +803,7 @@ async function syncCommandRpc(
 		args,
 		cwd,
 		wait: optionalBooleanParam(record.wait, "wait") ?? opts.defaultWait,
+		exclusiveKey: dryRun ? undefined : "sync",
 	});
 }
 
@@ -842,7 +899,10 @@ function vaultRmRpc(params: unknown): Promise<unknown> {
 	});
 }
 
-function vaultResolveRpc(params: unknown): Promise<unknown> {
+function vaultResolveRpc(
+	params: unknown,
+	context: ControlRpcAuthContext | undefined,
+): Promise<unknown> {
 	const record = rpcParamsRecord(params);
 	rejectRpcParams(
 		record,
@@ -864,6 +924,7 @@ function vaultResolveRpc(params: unknown): Promise<unknown> {
 	const wait = optionalBooleanParam(record.wait, "wait") ?? true;
 	if (includeValue) {
 		requireBooleanConfirmation(record, "confirm_secret_access", "vault.resolve plaintext access");
+		requireRpcCapability(context, "vault:secrets", "vault.resolve plaintext access");
 		if (!wait)
 			throw new Error(
 				"vault.resolve with include_value=true cannot run as a background operation.",
@@ -882,7 +943,10 @@ function vaultResolveRpc(params: unknown): Promise<unknown> {
 	});
 }
 
-function vaultReadRpc(params: unknown): Promise<unknown> {
+function vaultReadRpc(
+	params: unknown,
+	context: ControlRpcAuthContext | undefined,
+): Promise<unknown> {
 	const record = rpcParamsRecord(params);
 	rejectRpcParams(
 		record,
@@ -903,6 +967,7 @@ function vaultReadRpc(params: unknown): Promise<unknown> {
 	const wait = optionalBooleanParam(record.wait, "wait") ?? true;
 	if (!dryRun) {
 		requireBooleanConfirmation(record, "confirm_secret_access", "vault.read plaintext access");
+		requireRpcCapability(context, "vault:secrets", "vault.read plaintext access");
 		if (!wait) throw new Error("vault.read plaintext access cannot run as a background operation.");
 	}
 	const args = ["read", requiredStringParam(record, "reference")];
@@ -918,7 +983,10 @@ function vaultReadRpc(params: unknown): Promise<unknown> {
 	});
 }
 
-function vaultInjectRpc(params: unknown): Promise<unknown> {
+function vaultInjectRpc(
+	params: unknown,
+	context: ControlRpcAuthContext | undefined,
+): Promise<unknown> {
 	const record = rpcParamsRecord(params);
 	rejectRpcParams(
 		record,
@@ -938,8 +1006,13 @@ function vaultInjectRpc(params: unknown): Promise<unknown> {
 		]),
 	);
 	const dryRun = optionalBooleanParam(record.dry_run, "dry_run") ?? false;
-	if (!dryRun)
+	const wait = optionalBooleanParam(record.wait, "wait") ?? true;
+	if (!dryRun) {
 		requireBooleanConfirmation(record, "confirm_secret_access", "vault.inject secret rendering");
+		requireRpcCapability(context, "vault:secrets", "vault.inject secret rendering");
+		if (!wait)
+			throw new Error("vault.inject secret rendering cannot run as a background operation.");
+	}
 	const args = ["inject"];
 	const stdin = optionalStringParam(record.input, "input");
 	const inPath = optionalStringParam(record.in, "in") ?? (stdin !== undefined ? "-" : undefined);
@@ -958,7 +1031,7 @@ function vaultInjectRpc(params: unknown): Promise<unknown> {
 		args,
 		cwd: optionalStringParam(record.cwd, "cwd"),
 		stdin,
-		wait: optionalBooleanParam(record.wait, "wait") ?? true,
+		wait,
 	});
 }
 
@@ -1042,7 +1115,10 @@ function updateCheckRpc(params: unknown): Promise<unknown> {
 	});
 }
 
-async function updateInstallRpc(params: unknown): Promise<unknown> {
+async function updateInstallRpc(
+	params: unknown,
+	abortController: AbortController | undefined,
+): Promise<unknown> {
 	const record = rpcParamsRecord(params);
 	rejectRpcParams(record, new Set(["confirm"]));
 	requireBooleanConfirmation(record, "confirm", "update.install");
@@ -1050,7 +1126,17 @@ async function updateInstallRpc(params: unknown): Promise<unknown> {
 		currentVersion: getCliVersion(),
 		ignoreDisabled: true,
 	});
-	return { result };
+	const restartScheduled = result === "installed" && abortController !== undefined;
+	if (restartScheduled) {
+		setTimeout(() => {
+			log.info("daemon.update_install_restart_scheduled", {});
+			abortController.abort();
+		}, CONTROL_ACTION_DELAY_MS);
+	}
+	return {
+		result,
+		restart_scheduled: restartScheduled,
+	};
 }
 
 async function runCommandRpc(options: RpcCommandOptions): Promise<unknown> {
@@ -1062,6 +1148,7 @@ async function runCommandRpc(options: RpcCommandOptions): Promise<unknown> {
 				cwd: options.cwd,
 				stdin: options.stdin,
 				redactedArgs: options.redactedArgs,
+				exclusiveKey: options.exclusiveKey,
 			}),
 		};
 	}
@@ -1319,6 +1406,30 @@ function daemonRotateTokenRpc(params: unknown): unknown {
 	};
 }
 
+function daemonIssueTokenRpc(params: unknown): unknown {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set(["capabilities", "label", "expires_in_seconds"]));
+	const capabilities = requiredCapabilityListParam(record, "capabilities");
+	const expiresInSeconds = optionalLimitParam(
+		record.expires_in_seconds,
+		"expires_in_seconds",
+		60,
+		30 * 24 * 60 * 60,
+		24 * 60 * 60,
+	);
+	const issued = issueScopedControlToken({
+		capabilities,
+		label: optionalStringParam(record.label, "label"),
+		expiresInSeconds,
+	});
+	return {
+		token: issued.token,
+		token_type: "scoped",
+		capabilities: issued.capabilities,
+		expires_at: issued.expires_at,
+	};
+}
+
 function scheduleDaemonControlAction(
 	action: string,
 	run: () => void,
@@ -1452,6 +1563,25 @@ function optionalStringListParam(value: unknown, label: string): string[] | unde
 		items.push(optionalStringParam(item, label) ?? "");
 	}
 	return items;
+}
+
+function requiredCapabilityListParam(
+	record: Record<string, unknown>,
+	key: string,
+): RpcCapability[] {
+	const items = optionalStringListParam(record[key], key);
+	if (!items || items.length === 0) throw new Error(`${key} is required`);
+	const capabilities: RpcCapability[] = [];
+	for (const item of items) {
+		if (!(CONTROL_RPC_CAPABILITIES as readonly string[]).includes(item)) {
+			throw new Error(
+				`Unknown RPC capability: ${item}. Expected one of: ${CONTROL_RPC_CAPABILITIES.join(", ")}`,
+			);
+		}
+		const capability = item as RpcCapability;
+		if (!capabilities.includes(capability)) capabilities.push(capability);
+	}
+	return capabilities;
 }
 
 function optionalAgentParam(value: unknown): AgentType | undefined {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -29,7 +29,13 @@ import { adapterForType, getEnvIdByAgent, listRegisteredAgentTypes } from "../li
 import { getCliVersion } from "../lib/version";
 import { startAutoRestart } from "../serve/auto-restart";
 import {
+	type ControlRpcHandlers,
+	callControlRpc,
+	startControlRpcServer,
+} from "../serve/control-rpc";
+import {
 	install as installService,
+	isSingletonDaemonInstalled,
 	listInstalledAgents,
 	readHealth,
 	restart as restartService,
@@ -37,23 +43,60 @@ import {
 	uninstall as uninstallService,
 } from "../serve/installer";
 import { log, toErrorMessage } from "../serve/log";
-import { getServeLogPath, getServeStateDir } from "../serve/paths";
+import {
+	getDaemonControlSocketPath,
+	getDaemonControlTokenPath,
+	getServeLogPath,
+	getServeStateDir,
+} from "../serve/paths";
 import { runSyncEngine } from "../serve/sync-engine";
 import { startDaemonAutoUpdate } from "./update";
 
-interface ServeOpts {
-	agent?: string;
-	environmentId?: string;
+type ServeOpts = Record<string, unknown>;
+
+interface DaemonRunTarget {
+	agentType: AgentType;
+	adapter: NonNullable<ReturnType<typeof adapterForType>>;
+	environmentId: string;
+}
+
+interface DaemonStatusReport {
+	agent: AgentType;
+	state_dir: string;
+	health: ReturnType<typeof readHealth> & { fresh: boolean };
+	supervisor: string[];
+}
+
+interface DaemonDoctorReport {
+	entrypoint: string | null;
+	node: string;
+	cli_version: string;
+	registered_agents: number;
+	singleton_unit_installed: boolean;
+	legacy_daemon_units: AgentType[];
+	control_rpc: {
+		socket_path: string;
+		token_path: string;
+	};
+	api_url: string | null;
+	agents: Array<
+		DaemonStatusReport & {
+			daemon_version: string | null;
+			version_drift: boolean;
+			heartbeat: {
+				age_seconds: number | null;
+				status: "live" | "stale" | "never_ran";
+			};
+		}
+	>;
 }
 
 /**
- * Reject parent (`daemonCmd`) global options that bled into a
- * subcommand which doesn't use them. Pre-fix `clawdi daemon doctor
- * --agent codex` and `clawdi daemon status --environment-id <id>`
- * silently accepted those flags (because parent defines them for the
- * foreground daemon's use) but ignored them — leaving users with no
- * signal that their command had no effect. Codex flagged this as
- * P2; we fail-loud now.
+ * Reject legacy selector options that a singleton-daemon subcommand
+ * does not support. Pre-fix `clawdi daemon doctor --agent codex`
+ * and `clawdi daemon status --environment-id <id>` silently accepted
+ * those flags but ignored them, leaving users with no signal that
+ * their command had no effect.
  */
 export function rejectUnsupportedOpts(
 	cmdName: string,
@@ -78,7 +121,7 @@ function camelToFlag(name: string): string {
 	return `--${name.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)}`;
 }
 
-export async function serve(opts: ServeOpts): Promise<void> {
+export async function serve(_opts: ServeOpts): Promise<void> {
 	const mode = (process.env.CLAWDI_SERVE_MODE ?? "host").toLowerCase();
 	const isContainer = mode === "container";
 
@@ -89,28 +132,14 @@ export async function serve(opts: ServeOpts): Promise<void> {
 		process.exit(1);
 	}
 
-	const { agentType, adapter } = pickAgent(opts.agent);
-	if (!adapter) {
-		log.error("serve.no_agent", {
-			hint: "Run `clawdi setup` to register an agent on this machine.",
-		});
-		process.exit(1);
-	}
-
-	const environmentId = resolveEnvironmentId(opts.environmentId, agentType);
-	if (!environmentId) {
-		log.error("serve.no_environment", {
-			agent: agentType,
-			hint: "Pass --environment-id, set CLAWDI_ENVIRONMENT_ID, or run `clawdi setup`.",
-		});
-		process.exit(1);
-	}
+	const targets = pickDaemonRunTargets();
 
 	log.info("serve.boot", {
 		mode,
-		agent_type: agentType,
-		environment_id: environmentId,
-		state_dir: getServeStateDir(agentType),
+		agents: targets.map((target) => target.agentType),
+		state_dirs: Object.fromEntries(
+			targets.map((target) => [target.agentType, getServeStateDir(target.agentType)]),
+		),
 		pid: process.pid,
 	});
 
@@ -148,14 +177,24 @@ export async function serve(opts: ServeOpts): Promise<void> {
 		}
 	}
 
+	const rpc = await startControlRpcServer(createControlRpcHandlers(), abort.signal);
+	log.info("serve.rpc_listening", {
+		socket: rpc.socketPath,
+		token_path: rpc.tokenPath,
+	});
+
 	try {
-		await runSyncEngine({
-			environmentId,
-			adapter,
-			abort: abort.signal,
-			abortController: abort,
-			forcePollWatcher: isContainer,
-		});
+		await Promise.all(
+			targets.map((target) =>
+				runSyncEngine({
+					environmentId: target.environmentId,
+					adapter: target.adapter,
+					abort: abort.signal,
+					abortController: abort,
+					forcePollWatcher: isContainer,
+				}),
+			),
+		);
 	} catch (e) {
 		log.error("serve.fatal", { error: toErrorMessage(e) });
 		process.exit(1);
@@ -170,231 +209,88 @@ export async function serve(opts: ServeOpts): Promise<void> {
 	process.exit(code);
 }
 
-interface ServeInstallOpts {
-	agent?: string;
-	all?: boolean;
-	environmentId?: string;
-}
+type ServeInstallOpts = Record<string, unknown>;
 
 export async function serveInstall(opts: ServeInstallOpts): Promise<void> {
+	rejectUnsupportedOpts("install", opts as Record<string, unknown>, INSTALL_ALLOWED);
 	if (!isLoggedIn()) {
 		console.error("Not logged in. Run `clawdi auth login` first — the daemon needs an api key.");
 		process.exit(1);
 	}
-	if (opts.all) {
-		// `--all` is the recommended path on multi-agent machines: one
-		// invocation, one daemon-per-agent, no shell loops in the docs.
-		// Failures on a single agent shouldn't abort the rest — surface
-		// per-agent results and exit non-zero only if every install
-		// failed.
-		if (opts.agent) {
-			// Mutex: --all targets every registered agent; --agent
-			// targets one. Both at once is contradictory and pre-fix
-			// --all silently won, e.g. `daemon uninstall --all --agent
-			// codex` looked like "uninstall codex with extras" but
-			// actually nuked everything.
+	const registered = listRegisteredAgentTypes();
+	if (registered.length === 0) {
+		console.error("No agents registered. Run `clawdi setup` first.");
+		process.exit(1);
+	}
+	for (const agentType of registered) {
+		if (getEnvIdByAgent(agentType) === null) {
 			console.error(
-				"--all and --agent are mutually exclusive. --all targets every registered agent; --agent targets one.",
+				`No environment configured for ${agentType} ` +
+					`(missing ~/.clawdi/environments/${agentType}.json). ` +
+					`Run \`clawdi setup --agent ${agentType}\` first.`,
 			);
 			process.exit(1);
 		}
-		const registered = listRegisteredAgentTypes();
-		if (registered.length === 0) {
-			console.error("No agents registered. Run `clawdi setup` first.");
-			process.exit(1);
-		}
-		// `--environment-id` deliberately rejected for `--all`. A
-		// single id pinned across every agent unit defeats the
-		// per-agent env model — every daemon would `resolveEnvironmentId`
-		// to the same value and trample each other's project. Each
-		// agent picks up its own id from `~/.clawdi/environments/<agent>.json`
-		// (written by `clawdi setup`), or fail loudly if missing.
-		if (opts.environmentId) {
-			console.error(
-				"--environment-id can't be combined with --all. Each agent's env is read from " +
-					"~/.clawdi/environments/<agent>.json (written by `clawdi setup`); pinning a " +
-					"single id across every unit would route every daemon to the same project.",
-			);
-			process.exit(1);
-		}
-		let installed = 0;
-		let failed = 0;
-		for (const agentType of registered) {
-			try {
-				if (getEnvIdByAgent(agentType) === null) {
-					throw new Error(`no environment configured (run \`clawdi setup --agent ${agentType}\`)`);
-				}
-				const result = installService({ agent: agentType });
-				const verb = result.replaced ? "(replaced)" : "(new)";
-				console.log(`✓ ${agentType} ${verb}: ${result.unit}`);
-				installed += 1;
-			} catch (e) {
-				console.error(`✗ ${agentType}: ${toErrorMessage(e)}`);
-				failed += 1;
-			}
-		}
-		console.log(`\n${installed} installed, ${failed} failed.`);
-		// Exit non-zero on any failure, not just total wipeout. CI /
-		// scripted callers need to know to retry the failed agents;
-		// silently exiting 0 with "2 of 4 installed" hides partial
-		// breakage in `set -e` pipelines.
-		if (failed > 0) process.exit(1);
-		return;
-	}
-	const { agentType, adapter } = pickAgent(opts.agent);
-	if (!adapter) {
-		console.error("No agent registered. Run `clawdi setup` first.");
-		process.exit(1);
-	}
-	// Pre-flight: when --environment-id isn't pinned at install time,
-	// the unit defers env-id resolution to daemon boot, which reads
-	// `~/.clawdi/environments/<agent>.json`. Without that file the
-	// unit boots into a no-op crash loop. Codex flagged: pre-fix the
-	// CLI happily wrote the unit, the user only saw the failure when
-	// they tailed the daemon's stderr 30 seconds later. Catch it here
-	// with an actionable error.
-	if (!opts.environmentId && getEnvIdByAgent(agentType) === null) {
-		console.error(
-			`No environment configured for ${agentType} ` +
-				`(missing ~/.clawdi/environments/${agentType}.json). ` +
-				`Run \`clawdi setup --agent ${agentType}\` first, or pass --environment-id <uuid>.`,
-		);
-		process.exit(1);
 	}
 	try {
-		const result = installService({
-			agent: agentType,
-			environmentId: opts.environmentId,
-		});
-		// Surface "replaced existing unit" so users running install
-		// after a CLI upgrade understand that the new plist /
-		// systemd unit just got written and the daemon was
-		// restarted. Pre-fix the message was identical for fresh
-		// vs reinstall, leaving "did anything actually change?"
-		// ambiguous.
+		const result = installService();
 		const verb = result.replaced ? "Replaced existing" : "Installed";
-		console.log(`✓ ${verb} daemon unit: ${result.unit}`);
+		console.log(`✓ ${verb} singleton daemon unit: ${result.unit}`);
 		console.log(result.instructions);
 	} catch (e) {
 		console.error(`Install failed: ${toErrorMessage(e)}`);
 		process.exit(1);
 	}
+	const failed = cleanupLegacyDaemonUnits();
+	if (failed > 0) process.exit(1);
 }
 
-const UNINSTALL_ALLOWED = new Set(["agent", "all"]);
+const INSTALL_ALLOWED = new Set<string>();
+const UNINSTALL_ALLOWED = new Set<string>();
 const STATUS_ALLOWED = new Set(["agent"]);
 const DOCTOR_ALLOWED = new Set(["json"]);
+const RPC_ALLOWED = new Set(["params"]);
 
 export async function serveUninstall(opts: ServeInstallOpts): Promise<void> {
 	rejectUnsupportedOpts("uninstall", opts as Record<string, unknown>, UNINSTALL_ALLOWED);
-	if (opts.all) {
-		// Symmetric with `install --all` — one invocation, every
-		// daemon gone. Pre-fix users had to loop in the shell
-		// (`for a in claude_code codex; do clawdi daemon uninstall --agent $a`),
-		// which is exactly the friction `install --all` exists to
-		// remove.
-		if (opts.agent) {
-			console.error(
-				"--all and --agent are mutually exclusive. --all uninstalls every daemon; --agent uninstalls one.",
-			);
-			process.exit(1);
-		}
-		const registered = listRegisteredAgentTypes();
-		if (registered.length === 0) {
-			console.log("No agents registered.");
-			return;
-		}
-		let removed = 0;
-		let failed = 0;
-		for (const agentType of registered) {
-			try {
-				const result = uninstallService({ agent: agentType });
-				if (result.removed) {
-					console.log(`✓ ${agentType}: removed`);
-					removed += 1;
-				} else {
-					console.log(`(${agentType}: no daemon unit installed)`);
-				}
-			} catch (e) {
-				console.error(`✗ ${agentType}: ${toErrorMessage(e)}`);
-				failed += 1;
-			}
-		}
-		console.log(`\n${removed} removed, ${failed} failed.`);
-		if (failed > 0) process.exit(1);
-		return;
-	}
-	const { agentType } = pickAgent(opts.agent);
+	let removed = 0;
+	let failed = 0;
 	try {
-		const result = uninstallService({ agent: agentType });
+		const result = uninstallService();
 		if (result.removed) {
-			console.log(`✓ Removed daemon unit for ${agentType}.`);
+			console.log("✓ Removed singleton daemon unit.");
+			removed += 1;
 		} else {
-			console.log(`(no daemon unit installed for ${agentType})`);
+			console.log("(no singleton daemon unit installed)");
 		}
 	} catch (e) {
-		console.error(`Uninstall failed: ${toErrorMessage(e)}`);
-		process.exit(1);
+		console.error(`✗ daemon: ${toErrorMessage(e)}`);
+		failed += 1;
 	}
+	failed += cleanupLegacyDaemonUnits();
+	if (removed === 0 && failed === 0) console.log("No daemon units installed.");
+	if (failed > 0) process.exit(1);
 }
 
-const RESTART_ALLOWED = new Set(["agent", "all"]);
+const RESTART_ALLOWED = new Set<string>();
 
 export async function serveRestart(opts: ServeInstallOpts): Promise<void> {
 	rejectUnsupportedOpts("restart", opts as Record<string, unknown>, RESTART_ALLOWED);
-	if (opts.all) {
-		if (opts.agent) {
-			console.error(
-				"--all and --agent are mutually exclusive. --all restarts every daemon; --agent restarts one.",
-			);
-			process.exit(1);
-		}
-		// Source from `listInstalledAgents` (scans the OS supervisor)
-		// rather than `listRegisteredAgentTypes` (reads the env-file
-		// registry). Pre-fix `restart --all` would silently skip a
-		// daemon whose env file got deleted but whose plist was
-		// still installed and the process still running — codex
-		// flagged this as the surface that mattered for actually
-		// touching every running daemon.
-		const installed = listInstalledAgents();
-		if (installed.length === 0) {
-			console.log("No daemon units installed.");
-			return;
-		}
-		let restarted = 0;
-		let failed = 0;
-		for (const agentType of installed) {
-			try {
-				restartService({ agent: agentType });
-				console.log(`✓ ${agentType}: restarted`);
-				restarted += 1;
-			} catch (e) {
-				console.error(`✗ ${agentType}: ${toErrorMessage(e)}`);
-				failed += 1;
-			}
-		}
-		console.log(`\n${restarted} restarted, ${failed} failed.`);
-		if (failed > 0) process.exit(1);
-		return;
-	}
-	const { agentType } = pickAgent(opts.agent);
 	try {
-		restartService({ agent: agentType });
-		console.log(`✓ Restarted daemon for ${agentType}.`);
+		restartService();
+		console.log("✓ Restarted singleton daemon.");
 	} catch (e) {
 		console.error(`Restart failed: ${toErrorMessage(e)}`);
 		process.exit(1);
 	}
 }
 
-export async function serveStatus(opts: ServeInstallOpts): Promise<void> {
+interface ServeStatusOpts {
+	agent?: string;
+}
+
+export async function serveStatus(opts: ServeStatusOpts): Promise<void> {
 	rejectUnsupportedOpts("status", opts as Record<string, unknown>, STATUS_ALLOWED);
-	// Without --agent, list every registered daemon — `daemon install
-	// --all` is the recommended path on multi-agent machines and
-	// status should mirror that. Falling through `pickAgent` here used
-	// to silently hide all-but-one daemon's state behind a warning,
-	// which made debugging multi-agent setups (the actual common case)
-	// confusing. With --agent, project to that one daemon.
 	const targets: AgentType[] = opts.agent
 		? [pickAgent(opts.agent).agentType]
 		: listRegisteredAgentTypes();
@@ -402,23 +298,35 @@ export async function serveStatus(opts: ServeInstallOpts): Promise<void> {
 		console.log("No agents registered yet — run `clawdi setup` first.");
 		return;
 	}
-	for (const [i, agentType] of targets.entries()) {
+	for (const [i, report] of targets.map(buildStatusReport).entries()) {
 		if (i > 0) console.log("");
-		printAgentStatus(agentType);
+		printAgentStatus(report);
 	}
 }
 
-function printAgentStatus(agentType: AgentType): void {
+function buildStatusReport(agentType: AgentType): DaemonStatusReport {
 	const stateDir = getServeStateDir(agentType);
 	const health = readHealth(stateDir);
-	console.log(`agent:   ${agentType}`);
-	console.log(`state:   ${stateDir}`);
+	const fresh = health.exists && health.ageSeconds !== null && health.ageSeconds < 90;
+	return {
+		agent: agentType,
+		state_dir: stateDir,
+		health: { ...health, fresh },
+		supervisor: serviceStatusLines(),
+	};
+}
+
+function printAgentStatus(report: DaemonStatusReport): void {
+	const health = report.health;
+	console.log(`agent:   ${report.agent}`);
+	console.log(`state:   ${report.state_dir}`);
 	if (health.exists) {
 		// The 90s cutoff matches the dashboard's "online/offline"
 		// freshness window. A daemon writing `health` more recently
 		// than that AND posting heartbeats is what we call "live".
-		const fresh = health.ageSeconds !== null && health.ageSeconds < 90;
-		console.log(`health:  ${fresh ? "✓ live" : "stale"} (last write ${health.ageSeconds}s ago)`);
+		console.log(
+			`health:  ${health.fresh ? "✓ live" : "stale"} (last write ${health.ageSeconds}s ago)`,
+		);
 	} else {
 		console.log("health:  (no health file — daemon never ran or wrote elsewhere)");
 	}
@@ -432,27 +340,25 @@ function printAgentStatus(agentType: AgentType): void {
 		if (health.version !== cliVersion) {
 			console.log(
 				`version: daemon=${health.version}, CLI=${cliVersion} ` +
-					"⚠ drift — run `clawdi daemon restart --all` to pick up the latest",
+					"⚠ drift — run `clawdi daemon restart` to pick up the latest",
 			);
 		} else {
 			console.log(`version: ${health.version}`);
 		}
 	}
-	for (const line of serviceStatusLines({ agent: agentType })) {
+	for (const line of report.supervisor) {
 		console.log(line);
 	}
 }
 
 interface ServeLogsOpts {
-	agent?: string;
 	follow?: boolean;
 }
 
-const LOGS_ALLOWED = new Set(["agent", "follow"]);
+const LOGS_ALLOWED = new Set(["follow"]);
 
 export async function serveLogs(opts: ServeLogsOpts): Promise<void> {
 	rejectUnsupportedOpts("logs", opts as Record<string, unknown>, LOGS_ALLOWED);
-	const { agentType } = pickAgent(opts.agent);
 	const { spawn } = await import("node:child_process");
 	// Per-platform log access. macOS launchd routes the unit's
 	// `StandardErrorPath` to a file we own (we wrote it in the
@@ -461,23 +367,22 @@ export async function serveLogs(opts: ServeLogsOpts): Promise<void> {
 	// tail, so we delegate to `journalctl --user -u <unit>`.
 	// Codex flagged the original implementation: it used `tail`
 	// unconditionally and silently failed (or worse, errored) on
-	// Linux because `~/.clawdi/serve/logs/<agent>.stderr.log`
+	// Linux because `~/.clawdi/serve/logs/daemon.stderr.log`
 	// never gets created.
 	const platform = process.platform;
 	let cmd: string;
 	let args: string[];
 	if (platform === "linux") {
-		const unit = `clawdi-serve-${agentType}.service`;
+		const unit = "clawdi-serve.service";
 		cmd = "journalctl";
 		args = opts.follow
 			? ["--user", "-u", unit, "-n", "200", "-f"]
 			: ["--user", "-u", unit, "-n", "200"];
 	} else if (platform === "darwin") {
-		const path = getServeLogPath(agentType, "stderr");
+		const path = getServeLogPath("daemon", "stderr");
 		if (!existsSync(path)) {
 			console.error(
-				`No log file at ${path} ` +
-					`(daemon for ${agentType} hasn't started yet — run \`clawdi daemon install --agent ${agentType}\`).`,
+				`No log file at ${path} (daemon hasn't started yet — run \`clawdi daemon install\`).`,
 			);
 			process.exit(1);
 		}
@@ -504,32 +409,7 @@ export async function serveDoctor(opts: ServeDoctorOpts): Promise<void> {
 	// state-dir path, last-heartbeat age, OS supervisor unit
 	// state, daemon entrypoint binary. JSON mode is for
 	// programmatic callers.
-	const cliVersion = getCliVersion();
-	const registered = listRegisteredAgentTypes();
-	const report = registered.map((agent) => {
-		const stateDir = getServeStateDir(agent);
-		const health = readHealth(stateDir);
-		const fresh = health.exists && health.ageSeconds !== null && health.ageSeconds < 90;
-		const status = fresh ? "live" : health.exists ? "stale" : "never_ran";
-		return {
-			agent,
-			state_dir: stateDir,
-			supervisor: serviceStatusLines({ agent }),
-			daemon_version: health.version,
-			version_drift: health.version !== null && health.version !== cliVersion,
-			heartbeat: health.exists
-				? { age_seconds: health.ageSeconds, status }
-				: { age_seconds: null, status },
-		};
-	});
-	const summary = {
-		entrypoint: process.argv[1] ?? null,
-		node: process.execPath,
-		cli_version: cliVersion,
-		registered_agents: registered.length,
-		api_url: process.env.CLAWDI_API_URL ?? null,
-		agents: report,
-	};
+	const summary = buildDoctorReport();
 	if (opts.json) {
 		console.log(JSON.stringify(summary, null, 2));
 		return;
@@ -538,13 +418,18 @@ export async function serveDoctor(opts: ServeDoctorOpts): Promise<void> {
 	console.log(`node:        ${summary.node}`);
 	console.log(`cli version: ${summary.cli_version}`);
 	console.log(`agents:      ${summary.registered_agents}`);
+	console.log(`unit:        ${summary.singleton_unit_installed ? "installed" : "not installed"}`);
+	if (summary.legacy_daemon_units.length > 0) {
+		console.log(`legacy:      ${summary.legacy_daemon_units.join(", ")}`);
+	}
+	console.log(`rpc socket:  ${summary.control_rpc.socket_path}`);
 	console.log("");
-	if (registered.length === 0) {
+	if (summary.registered_agents === 0) {
 		console.log("No agents registered yet — run `clawdi setup` first.");
 		return;
 	}
 	let anyDrift = false;
-	for (const r of report) {
+	for (const r of summary.agents) {
 		console.log(`── ${r.agent} ──`);
 		console.log(`state dir: ${r.state_dir}`);
 		const hb = r.heartbeat;
@@ -557,7 +442,7 @@ export async function serveDoctor(opts: ServeDoctorOpts): Promise<void> {
 		}
 		if (r.daemon_version) {
 			if (r.version_drift) {
-				console.log(`version:   ⚠ daemon=${r.daemon_version}, CLI=${cliVersion}`);
+				console.log(`version:   ⚠ daemon=${r.daemon_version}, CLI=${summary.cli_version}`);
 				anyDrift = true;
 			} else {
 				console.log(`version:   ${r.daemon_version}`);
@@ -571,13 +456,240 @@ export async function serveDoctor(opts: ServeDoctorOpts): Promise<void> {
 	if (anyDrift) {
 		console.log(
 			"⚠ One or more daemons are running an older CLI version. " +
-				"Run `clawdi daemon restart --all` to pick up the latest.",
+				"Run `clawdi daemon restart` to pick up the latest.",
 		);
 	}
 }
 
+function buildDoctorReport(): DaemonDoctorReport {
+	const cliVersion = getCliVersion();
+	const registered = listRegisteredAgentTypes();
+	const agents = registered.map((agent) => {
+		const report = buildStatusReport(agent);
+		const status: "live" | "stale" | "never_ran" = report.health.fresh
+			? "live"
+			: report.health.exists
+				? "stale"
+				: "never_ran";
+		return {
+			...report,
+			daemon_version: report.health.version,
+			version_drift: report.health.version !== null && report.health.version !== cliVersion,
+			heartbeat: report.health.exists
+				? { age_seconds: report.health.ageSeconds, status }
+				: { age_seconds: null, status },
+		};
+	});
+	return {
+		entrypoint: process.argv[1] ?? null,
+		node: process.execPath,
+		cli_version: cliVersion,
+		registered_agents: registered.length,
+		singleton_unit_installed: isSingletonDaemonInstalled(),
+		legacy_daemon_units: listInstalledAgents(),
+		control_rpc: {
+			socket_path: getDaemonControlSocketPath(),
+			token_path: getDaemonControlTokenPath(),
+		},
+		api_url: process.env.CLAWDI_API_URL ?? null,
+		agents,
+	};
+}
+
+interface ServeRpcOpts {
+	params?: string;
+}
+
+export async function serveRpc(method: string, opts: ServeRpcOpts): Promise<void> {
+	rejectUnsupportedOpts("rpc", opts as Record<string, unknown>, RPC_ALLOWED);
+	let params: unknown = {};
+	if (opts.params !== undefined) {
+		try {
+			params = JSON.parse(opts.params);
+		} catch (error) {
+			throw new Error(`--params must be valid JSON: ${toErrorMessage(error)}`);
+		}
+	}
+	const result = await callControlRpc(method, params);
+	console.log(JSON.stringify(result, null, 2));
+}
+
+function createControlRpcHandlers(): ControlRpcHandlers {
+	const handlers: ControlRpcHandlers = {};
+	handlers["daemon.ping"] = () => ({
+		pid: process.pid,
+		version: getCliVersion(),
+		uptime_seconds: Math.round(process.uptime()),
+	});
+	handlers["daemon.methods"] = () => ({
+		methods: Object.keys(handlers).sort(),
+	});
+	handlers["daemon.status"] = (params) => {
+		const record = rpcParamsRecord(params);
+		rejectRpcParams(record, new Set(["agent"]));
+		const agent = optionalAgentParam(record.agent);
+		const targets = agent ? [agent] : listRegisteredAgentTypes();
+		return {
+			singleton_unit_installed: isSingletonDaemonInstalled(),
+			legacy_daemon_units: listInstalledAgents(),
+			agents: targets.map(buildStatusReport),
+		};
+	};
+	handlers["daemon.doctor"] = () => buildDoctorReport();
+	handlers["daemon.install"] = (params) => daemonInstallRpc(params);
+	handlers["daemon.uninstall"] = (params) => daemonUninstallRpc(params);
+	handlers["daemon.restart"] = (params) => daemonRestartRpc(params);
+	handlers["daemon.logs"] = (params) => daemonLogsRpc(params);
+	return handlers;
+}
+
+function daemonInstallRpc(params: unknown): unknown {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set());
+	return installService();
+}
+
+function daemonUninstallRpc(params: unknown): unknown {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set());
+	return {
+		results: daemonUnitTargets().map((target) => {
+			try {
+				const opts = target === "daemon" ? undefined : { agent: target };
+				return { target, ...uninstallService(opts) };
+			} catch (error) {
+				return { target, removed: false, error: toErrorMessage(error) };
+			}
+		}),
+	};
+}
+
+function daemonRestartRpc(params: unknown): unknown {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set());
+	const targets = isSingletonDaemonInstalled() ? ["daemon"] : [];
+	return {
+		results: targets.map((target) => {
+			try {
+				restartService();
+				return { target, restarted: true };
+			} catch (error) {
+				return { target, restarted: false, error: toErrorMessage(error) };
+			}
+		}),
+	};
+}
+
+function daemonLogsRpc(params: unknown): unknown {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set());
+	const currentPlatform = process.platform;
+	return {
+		platform: currentPlatform,
+		command:
+			currentPlatform === "linux"
+				? ["journalctl", "--user", "-u", "clawdi-serve.service", "-n", "200"]
+				: undefined,
+		stdout: currentPlatform === "linux" ? undefined : getServeLogPath("daemon", "stdout"),
+		stderr: currentPlatform === "linux" ? undefined : getServeLogPath("daemon", "stderr"),
+	};
+}
+
+function daemonUnitTargets(): Array<"daemon" | AgentType> {
+	const targets: Array<"daemon" | AgentType> = [];
+	if (isSingletonDaemonInstalled()) targets.push("daemon");
+	targets.push(...listInstalledAgents());
+	return targets;
+}
+
+function rejectRpcParams(record: Record<string, unknown>, allowed: ReadonlySet<string>): void {
+	const offenders = Object.keys(record).filter((key) => !allowed.has(key));
+	if (offenders.length > 0) {
+		throw new Error(`Unsupported RPC params: ${offenders.join(", ")}`);
+	}
+}
+
+function rpcParamsRecord(params: unknown): Record<string, unknown> {
+	if (params === undefined || params === null) return {};
+	if (typeof params !== "object" || Array.isArray(params)) {
+		throw new Error("RPC params must be a JSON object");
+	}
+	return params as Record<string, unknown>;
+}
+
+function optionalStringParam(value: unknown, label: string): string | undefined {
+	if (value === undefined || value === null) return undefined;
+	if (typeof value !== "string") throw new Error(`${label} must be a string`);
+	if (!value.trim()) throw new Error(`${label} must not be empty`);
+	return value;
+}
+
+function optionalAgentParam(value: unknown): AgentType | undefined {
+	const agent = optionalStringParam(value, "agent");
+	if (agent === undefined) return undefined;
+	if (!isAgentType(agent)) {
+		throw new Error(`Unknown agent: ${agent}. Expected one of: ${AGENT_TYPES.join(", ")}`);
+	}
+	return agent;
+}
+
+function cleanupLegacyDaemonUnits(): number {
+	let failed = 0;
+	for (const agentType of listInstalledAgents()) {
+		try {
+			const result = uninstallService({ agent: agentType });
+			if (result.removed) {
+				console.log(`✓ Removed legacy per-agent daemon unit for ${agentType}`);
+			}
+		} catch (e) {
+			console.error(`✗ Failed to remove legacy daemon unit for ${agentType}: ${toErrorMessage(e)}`);
+			failed += 1;
+		}
+	}
+	return failed;
+}
+
 function isAgentType(s: string): s is AgentType {
 	return (AGENT_TYPES as readonly string[]).includes(s);
+}
+
+function pickDaemonRunTargets(): DaemonRunTarget[] {
+	const registered = listRegisteredAgentTypes();
+	const envAgent = process.env.CLAWDI_AGENT_TYPE;
+	const targets = registered.length > 0 ? registered : envAgent ? [envAgent] : [];
+	for (const target of targets) {
+		if (!isAgentType(target)) {
+			log.error("serve.unknown_agent", { agent: target, known: AGENT_TYPES });
+			console.error(`Unknown agent: ${target}. Expected one of: ${AGENT_TYPES.join(", ")}`);
+			process.exit(1);
+		}
+	}
+	if (registered.length === 0) {
+		if (!envAgent) {
+			log.error("serve.no_agent", {
+				hint: "Run `clawdi setup` to register an agent on this machine, or set CLAWDI_AGENT_TYPE in a container.",
+			});
+			process.exit(1);
+		}
+	}
+	const agentTypes = targets as AgentType[];
+	return agentTypes.map((agentType) => {
+		const adapter = adapterForType(agentType);
+		if (!adapter) {
+			log.error("serve.no_agent_adapter", { agent: agentType });
+			console.error(`No adapter available for ${agentType}.`);
+			process.exit(1);
+		}
+		const environmentId = resolveEnvironmentId(agentType, agentTypes.length);
+		if (!environmentId) {
+			log.error("serve.no_environment", {
+				agent: agentType,
+				hint: "Run `clawdi setup` to write ~/.clawdi/environments/<agent>.json.",
+			});
+			process.exit(1);
+		}
+		return { agentType, adapter, environmentId };
+	});
 }
 
 function pickAgent(explicit: string | undefined): {
@@ -607,18 +719,14 @@ function pickAgent(explicit: string | undefined): {
 	if (registered.length > 1) {
 		// Fail-fast on multi-agent without an explicit pick. Pre-fix
 		// we picked `registered[0]` and emitted a warn-level event,
-		// which let `daemon install --agent` (silently using default)
-		// and `daemon uninstall` (silently nuking the wrong daemon)
-		// hit production. Codex flagged: warn-and-pick is one of
-		// those things that "works on a single-agent laptop"
-		// (correct by accident) and bites multi-agent users in
-		// non-obvious ways. Single-agent setups are unaffected
+		// which used to let target-specific daemon operations pick
+		// an arbitrary agent. Single-agent setups are unaffected
 		// — registered.length === 1 takes the next line and
 		// auto-picks.
 		log.error("serve.ambiguous_agent", { agents: registered });
 		console.error(
 			`Multiple agents registered (${registered.join(", ")}). ` +
-				`Pass --agent <type> to target one, or --all where supported.`,
+				"Use `clawdi daemon status --agent <type>` to inspect one agent.",
 		);
 		process.exit(1);
 	}
@@ -626,19 +734,23 @@ function pickAgent(explicit: string | undefined): {
 	return { agentType: picked, adapter: adapterForType(picked) };
 }
 
-function resolveEnvironmentId(explicit: string | undefined, agentType: AgentType): string | null {
-	if (explicit) return explicit;
-	const fromEnv = process.env.CLAWDI_ENVIRONMENT_ID;
-	if (fromEnv) return fromEnv;
+function resolveEnvironmentId(agentType: AgentType, registeredCount: number): string | null {
 	// Fallback: read the per-agent env file written by `clawdi
 	// setup`. Hosted pods bypass this (provision flow injects
 	// CLAWDI_ENVIRONMENT_ID directly); laptops use it.
 	const fromFile = getEnvIdByAgent(agentType);
 	if (fromFile) return fromFile;
+	// Hosted/single-agent containers can still pass one env id via
+	// env var or mounted file. Multi-agent singleton runs must not
+	// apply one global env id to every engine.
+	if (registeredCount === 1) {
+		const fromEnv = process.env.CLAWDI_ENVIRONMENT_ID;
+		if (fromEnv) return fromEnv;
+	}
 	// Last resort: read /etc/clawdi/env-id (writable mount in
 	// the pod entrypoint). Skipped on host.
 	const podPath = "/etc/clawdi/env-id";
-	if (existsSync(podPath)) {
+	if (registeredCount === 1 && existsSync(podPath)) {
 		try {
 			return readFileSync(podPath, "utf-8").trim();
 		} catch {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -46,6 +46,8 @@ import {
 	type ControlRpcHandlers,
 	type ControlRpcListenConfig,
 	callControlRpc,
+	DEFAULT_CONTROL_RPC_HOST,
+	DEFAULT_CONTROL_RPC_PORT,
 	rotateControlToken,
 	startControlRpcServer,
 } from "../serve/control-rpc";
@@ -64,12 +66,7 @@ import {
 	operationManager,
 	runCliCommandImmediate,
 } from "../serve/operation-runner";
-import {
-	getDaemonControlSocketPath,
-	getDaemonControlTokenPath,
-	getServeLogPath,
-	getServeStateDir,
-} from "../serve/paths";
+import { getDaemonControlTokenPath, getServeLogPath, getServeStateDir } from "../serve/paths";
 import { runSyncEngine } from "../serve/sync-engine";
 import { daemonAutoUpdateOnce, startDaemonAutoUpdate } from "./update";
 
@@ -87,6 +84,8 @@ interface LegacyRunOpts {
 }
 
 interface ResolvedRpcListenConfig extends ControlRpcListenConfig {
+	host: string;
+	port: number;
 	allowRemote?: boolean;
 }
 
@@ -115,9 +114,8 @@ interface DaemonDoctorReport {
 	singleton_unit_installed: boolean;
 	legacy_daemon_units: AgentType[];
 	control_rpc: {
-		socket_path: string;
 		token_path: string;
-		http: { host: string; port: number; allow_remote: boolean } | null;
+		http: { host: string; port: number; allow_remote: boolean };
 	};
 	api_url: string | null;
 	agents: Array<
@@ -252,7 +250,6 @@ export async function serve(_opts: ServeOpts): Promise<void> {
 		? { ...rpc.http, allow_remote: rpcListen.allowRemote === true }
 		: null;
 	log.info("serve.rpc_listening", {
-		socket: rpc.socketPath,
 		token_path: rpc.tokenPath,
 		http: rpc.http,
 	});
@@ -501,10 +498,7 @@ export async function serveDoctor(opts: ServeDoctorOpts): Promise<void> {
 	if (summary.legacy_daemon_units.length > 0) {
 		console.log(`legacy:      ${summary.legacy_daemon_units.join(", ")}`);
 	}
-	console.log(`rpc socket:  ${summary.control_rpc.socket_path}`);
-	if (summary.control_rpc.http) {
-		console.log(`rpc http:    ${summary.control_rpc.http.host}:${summary.control_rpc.http.port}`);
-	}
+	console.log(`rpc http:    ${summary.control_rpc.http.host}:${summary.control_rpc.http.port}`);
 	console.log("");
 	if (summary.registered_agents === 0) {
 		console.log("No agents registered yet — run `clawdi setup` first.");
@@ -570,7 +564,6 @@ function buildDoctorReport(): DaemonDoctorReport {
 		singleton_unit_installed: isSingletonDaemonInstalled(),
 		legacy_daemon_units: listInstalledAgents(),
 		control_rpc: {
-			socket_path: getDaemonControlSocketPath(),
 			token_path: getDaemonControlTokenPath(),
 			http: activeControlRpcHttp ?? normalizeRpcHttpConfig(resolveRpcListenConfig({})),
 		},
@@ -597,8 +590,14 @@ export async function serveRpc(method: string, opts: ServeRpcOpts): Promise<void
 		}
 	}
 	const rpcTarget = resolveRpcClientConfig(opts);
-	const result = await callControlRpc(method, params, rpcTarget);
+	const result = await callControlRpc(normalizeDaemonRpcMethod(method), params, rpcTarget);
 	console.log(JSON.stringify(result, null, 2));
+}
+
+function normalizeDaemonRpcMethod(method: string): string {
+	const trimmed = method.trim();
+	if (!trimmed) throw new Error("RPC method is required");
+	return trimmed.includes(".") ? trimmed : `daemon.${trimmed}`;
 }
 
 interface ControlRpcHandlerOptions {
@@ -1493,9 +1492,11 @@ function optionalAgentParam(value: unknown): AgentType | undefined {
 
 function resolveRpcListenConfig(opts: RpcListenOpts): ResolvedRpcListenConfig {
 	const host =
-		optionalStringParam(opts.rpcHost, "--rpc-host") ?? process.env.CLAWDI_DAEMON_RPC_HOST;
+		optionalStringParam(opts.rpcHost, "--rpc-host") ??
+		process.env.CLAWDI_DAEMON_RPC_HOST ??
+		DEFAULT_CONTROL_RPC_HOST;
 	const portValue = opts.rpcPort ?? process.env.CLAWDI_DAEMON_RPC_PORT;
-	const port = optionalPortParam(portValue, "--rpc-port");
+	const port = optionalPortParam(portValue, "--rpc-port") ?? DEFAULT_CONTROL_RPC_PORT;
 	const allowRemote =
 		optionalBooleanParam(opts.rpcAllowRemote, "--rpc-allow-remote") ??
 		optionalBooleanParam(
@@ -1503,41 +1504,35 @@ function resolveRpcListenConfig(opts: RpcListenOpts): ResolvedRpcListenConfig {
 			"CLAWDI_DAEMON_RPC_ALLOW_REMOTE",
 		) ??
 		false;
-	if (host !== undefined && port === undefined) {
-		throw new Error("--rpc-host requires --rpc-port (or CLAWDI_DAEMON_RPC_PORT)");
-	}
-	if (host === undefined && port === undefined) return {};
-	const resolvedHost = host ?? "127.0.0.1";
-	if (!allowRemote && !isLoopbackRpcHost(resolvedHost)) {
+	if (!allowRemote && !isLoopbackRpcHost(host)) {
 		throw new Error(
-			`Refusing to listen on non-loopback HTTP RPC host ${resolvedHost}. ` +
+			`Refusing to listen on non-loopback HTTP RPC host ${host}. ` +
 				"Use --rpc-allow-remote only behind SSH tunneling or a TLS-terminating proxy.",
 		);
 	}
-	return { host: resolvedHost, port, allowRemote };
+	return { host, port, allowRemote };
 }
 
 function resolveRpcClientConfig(
 	opts: RpcListenOpts & { rpcToken?: unknown },
 ): ControlRpcClientConfig {
 	const host =
-		optionalStringParam(opts.rpcHost, "--rpc-host") ?? process.env.CLAWDI_DAEMON_RPC_HOST;
+		optionalStringParam(opts.rpcHost, "--rpc-host") ??
+		process.env.CLAWDI_DAEMON_RPC_HOST ??
+		DEFAULT_CONTROL_RPC_HOST;
 	const portValue = opts.rpcPort ?? process.env.CLAWDI_DAEMON_RPC_PORT;
-	const port = optionalPortParam(portValue, "--rpc-port");
-	if (host !== undefined && port === undefined) {
-		throw new Error("--rpc-host requires --rpc-port (or CLAWDI_DAEMON_RPC_PORT)");
-	}
+	const port = optionalPortParam(portValue, "--rpc-port") ?? DEFAULT_CONTROL_RPC_PORT;
 	const token = optionalStringParam(opts.rpcToken, "--rpc-token");
-	if (host === undefined && port === undefined) return { token };
-	return { host: host ?? "127.0.0.1", port, token };
+	return { host, port, token };
 }
 
-function normalizeRpcHttpConfig(
-	config: ResolvedRpcListenConfig,
-): { host: string; port: number; allow_remote: boolean } | null {
-	if (config.port === undefined) return null;
+function normalizeRpcHttpConfig(config: ResolvedRpcListenConfig): {
+	host: string;
+	port: number;
+	allow_remote: boolean;
+} {
 	return {
-		host: config.host ?? "127.0.0.1",
+		host: config.host,
 		port: config.port,
 		allow_remote: config.allowRemote === true,
 	};

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -1150,7 +1150,7 @@ async function startDeviceAuthRpc(apiUrl: string): Promise<unknown> {
 	const response = await fetch(`${apiUrl}/api/cli/auth/device`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ client_label: `clawdi daemon rpc · ${hostname()}` }),
+		body: JSON.stringify({ client_label: `clawdi daemon control · ${hostname()}` }),
 	});
 	if (!response.ok) {
 		throw new Error(`Failed to start device authorization: HTTP ${response.status}`);

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -22,6 +22,7 @@
  * Logs are JSON-per-line on stderr; stdout is reserved.
  */
 
+import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { AGENT_TYPES, type AgentType } from "../adapters/registry";
 import { isLoggedIn } from "../lib/config";
@@ -33,6 +34,7 @@ import {
 	type ControlRpcHandlers,
 	type ControlRpcListenConfig,
 	callControlRpc,
+	rotateControlToken,
 	startControlRpcServer,
 } from "../serve/control-rpc";
 import {
@@ -59,9 +61,16 @@ type ServeOpts = Record<string, unknown>;
 interface RpcListenOpts {
 	rpcHost?: unknown;
 	rpcPort?: unknown;
+	rpcAllowRemote?: unknown;
 }
 
-let activeControlRpcTcp: { host: string; port: number } | null = null;
+interface ResolvedRpcListenConfig extends ControlRpcListenConfig {
+	allowRemote?: boolean;
+}
+
+let activeControlRpcHttp: { host: string; port: number; allow_remote: boolean } | null = null;
+
+const CONTROL_ACTION_DELAY_MS = 100;
 
 interface DaemonRunTarget {
 	agentType: AgentType;
@@ -86,7 +95,7 @@ interface DaemonDoctorReport {
 	control_rpc: {
 		socket_path: string;
 		token_path: string;
-		tcp: { host: string; port: number } | null;
+		http: { host: string; port: number; allow_remote: boolean } | null;
 	};
 	api_url: string | null;
 	agents: Array<
@@ -190,11 +199,13 @@ export async function serve(_opts: ServeOpts): Promise<void> {
 	}
 
 	const rpc = await startControlRpcServer(createControlRpcHandlers(), abort.signal, rpcListen);
-	activeControlRpcTcp = rpc.tcp;
+	activeControlRpcHttp = rpc.http
+		? { ...rpc.http, allow_remote: rpcListen.allowRemote === true }
+		: null;
 	log.info("serve.rpc_listening", {
 		socket: rpc.socketPath,
 		token_path: rpc.tokenPath,
-		tcp: rpc.tcp,
+		http: rpc.http,
 	});
 
 	try {
@@ -251,6 +262,7 @@ export async function serveInstall(opts: ServeInstallOpts): Promise<void> {
 		const result = installService({
 			rpcHost: rpcListen.host,
 			rpcPort: rpcListen.port,
+			rpcAllowRemote: rpcListen.allowRemote === true ? true : undefined,
 		});
 		const verb = result.replaced ? "Replaced existing" : "Installed";
 		console.log(`✓ ${verb} singleton daemon unit: ${result.unit}`);
@@ -263,7 +275,7 @@ export async function serveInstall(opts: ServeInstallOpts): Promise<void> {
 	if (failed > 0) process.exit(1);
 }
 
-const INSTALL_ALLOWED = new Set(["rpcHost", "rpcPort"]);
+const INSTALL_ALLOWED = new Set(["rpcHost", "rpcPort", "rpcAllowRemote"]);
 const UNINSTALL_ALLOWED = new Set<string>();
 const STATUS_ALLOWED = new Set(["agent"]);
 const DOCTOR_ALLOWED = new Set(["json"]);
@@ -441,8 +453,8 @@ export async function serveDoctor(opts: ServeDoctorOpts): Promise<void> {
 		console.log(`legacy:      ${summary.legacy_daemon_units.join(", ")}`);
 	}
 	console.log(`rpc socket:  ${summary.control_rpc.socket_path}`);
-	if (summary.control_rpc.tcp) {
-		console.log(`rpc tcp:     ${summary.control_rpc.tcp.host}:${summary.control_rpc.tcp.port}`);
+	if (summary.control_rpc.http) {
+		console.log(`rpc http:    ${summary.control_rpc.http.host}:${summary.control_rpc.http.port}`);
 	}
 	console.log("");
 	if (summary.registered_agents === 0) {
@@ -511,7 +523,7 @@ function buildDoctorReport(): DaemonDoctorReport {
 		control_rpc: {
 			socket_path: getDaemonControlSocketPath(),
 			token_path: getDaemonControlTokenPath(),
-			tcp: activeControlRpcTcp ?? normalizeRpcTcpConfig(resolveRpcListenConfig({})),
+			http: activeControlRpcHttp ?? normalizeRpcHttpConfig(resolveRpcListenConfig({})),
 		},
 		api_url: process.env.CLAWDI_API_URL ?? null,
 		agents,
@@ -566,66 +578,179 @@ function createControlRpcHandlers(): ControlRpcHandlers {
 	handlers["daemon.uninstall"] = (params) => daemonUninstallRpc(params);
 	handlers["daemon.restart"] = (params) => daemonRestartRpc(params);
 	handlers["daemon.logs"] = (params) => daemonLogsRpc(params);
+	handlers["daemon.rotate_token"] = (params) => daemonRotateTokenRpc(params);
 	return handlers;
 }
 
 function daemonInstallRpc(params: unknown): unknown {
 	const record = rpcParamsRecord(params);
-	rejectRpcParams(record, new Set(["rpc_host", "rpc_port"]));
-	const rpcListen = resolveRpcListenConfig({
-		rpcHost: record.rpc_host,
-		rpcPort: record.rpc_port,
-	});
-	return installService({
-		rpcHost: rpcListen.host,
-		rpcPort: rpcListen.port,
-	});
+	rejectRpcParams(record, new Set(["rpc_host", "rpc_port", "rpc_allow_remote"]));
+	const hasExplicitRpcConfig =
+		record.rpc_host !== undefined ||
+		record.rpc_port !== undefined ||
+		record.rpc_allow_remote !== undefined;
+	const rpcListen = hasExplicitRpcConfig
+		? resolveRpcListenConfig({
+				rpcHost: record.rpc_host,
+				rpcPort: record.rpc_port,
+				rpcAllowRemote: record.rpc_allow_remote,
+			})
+		: resolveRpcListenConfig({
+				rpcHost: activeControlRpcHttp?.host,
+				rpcPort: activeControlRpcHttp?.port,
+				rpcAllowRemote: activeControlRpcHttp?.allow_remote,
+			});
+	return scheduleDaemonControlAction(
+		"install",
+		() => {
+			installService({
+				rpcHost: rpcListen.host,
+				rpcPort: rpcListen.port,
+				rpcAllowRemote: rpcListen.allowRemote === true ? true : undefined,
+			});
+		},
+		{
+			rpc_http: normalizeRpcHttpConfig(rpcListen),
+		},
+	);
 }
 
 function daemonUninstallRpc(params: unknown): unknown {
 	const record = rpcParamsRecord(params);
 	rejectRpcParams(record, new Set());
-	return {
-		results: daemonUnitTargets().map((target) => {
-			try {
-				const opts = target === "daemon" ? undefined : { agent: target };
-				return { target, ...uninstallService(opts) };
-			} catch (error) {
-				return { target, removed: false, error: toErrorMessage(error) };
+	const targets = daemonUnitTargets();
+	if (targets.length === 0) {
+		return { accepted: false, reason: "no daemon units installed" };
+	}
+	return scheduleDaemonControlAction(
+		"uninstall",
+		() => {
+			for (const target of targets) {
+				try {
+					const opts = target === "daemon" ? undefined : { agent: target };
+					uninstallService(opts);
+				} catch (error) {
+					log.error("daemon.control_action_target_failed", {
+						action: "uninstall",
+						target,
+						error: toErrorMessage(error),
+					});
+				}
 			}
-		}),
-	};
+		},
+		{ targets },
+	);
 }
 
 function daemonRestartRpc(params: unknown): unknown {
 	const record = rpcParamsRecord(params);
 	rejectRpcParams(record, new Set());
-	const targets = isSingletonDaemonInstalled() ? ["daemon"] : [];
+	if (!isSingletonDaemonInstalled()) {
+		return { accepted: false, reason: "no singleton daemon unit installed" };
+	}
+	return scheduleDaemonControlAction(
+		"restart",
+		() => {
+			restartService();
+		},
+		{ target: "daemon" },
+	);
+}
+
+function daemonRotateTokenRpc(params: unknown): unknown {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set());
+	const token = rotateControlToken();
 	return {
-		results: targets.map((target) => {
-			try {
-				restartService();
-				return { target, restarted: true };
-			} catch (error) {
-				return { target, restarted: false, error: toErrorMessage(error) };
-			}
-		}),
+		rotated: true,
+		token_path: getDaemonControlTokenPath(),
+		token,
+	};
+}
+
+function scheduleDaemonControlAction(
+	action: string,
+	run: () => void,
+	extra: Record<string, unknown> = {},
+): unknown {
+	setTimeout(() => {
+		try {
+			run();
+			log.info("daemon.control_action_completed", { action });
+		} catch (error) {
+			log.error("daemon.control_action_failed", { action, error: toErrorMessage(error) });
+		}
+	}, CONTROL_ACTION_DELAY_MS);
+	return {
+		accepted: true,
+		action,
+		delay_ms: CONTROL_ACTION_DELAY_MS,
+		...extra,
 	};
 }
 
 function daemonLogsRpc(params: unknown): unknown {
 	const record = rpcParamsRecord(params);
-	rejectRpcParams(record, new Set());
+	rejectRpcParams(record, new Set(["limit"]));
+	const limit = optionalLogLimitParam(record.limit);
 	const currentPlatform = process.platform;
+	if (currentPlatform === "linux") {
+		const command = [
+			"journalctl",
+			"--user",
+			"-u",
+			"clawdi-serve.service",
+			"-n",
+			String(limit),
+			"--no-pager",
+		];
+		try {
+			const output = execFileSync(command[0], command.slice(1), {
+				encoding: "utf-8",
+				maxBuffer: 1024 * 1024,
+				stdio: ["ignore", "pipe", "pipe"],
+				timeout: 5000,
+			});
+			return {
+				platform: currentPlatform,
+				source: "journalctl",
+				command,
+				lines: splitLogLines(output),
+			};
+		} catch (error) {
+			return {
+				platform: currentPlatform,
+				source: "journalctl",
+				command,
+				lines: [],
+				error: toErrorMessage(error),
+			};
+		}
+	}
+	if (currentPlatform === "darwin") {
+		const stderr = getServeLogPath("daemon", "stderr");
+		const output = existsSync(stderr) ? readFileSync(stderr, "utf-8") : "";
+		return {
+			platform: currentPlatform,
+			source: "file",
+			stdout: getServeLogPath("daemon", "stdout"),
+			stderr,
+			lines: tailLogLines(splitLogLines(output), limit),
+		};
+	}
 	return {
 		platform: currentPlatform,
-		command:
-			currentPlatform === "linux"
-				? ["journalctl", "--user", "-u", "clawdi-serve.service", "-n", "200"]
-				: undefined,
-		stdout: currentPlatform === "linux" ? undefined : getServeLogPath("daemon", "stdout"),
-		stderr: currentPlatform === "linux" ? undefined : getServeLogPath("daemon", "stderr"),
+		lines: [],
+		error: `unsupported platform for daemon logs: ${currentPlatform}`,
 	};
+}
+
+function splitLogLines(output: string): string[] {
+	return output.split(/\r?\n/).filter((line) => line.length > 0);
+}
+
+function tailLogLines(lines: string[], limit: number): string[] {
+	return lines.slice(Math.max(0, lines.length - limit));
 }
 
 function daemonUnitTargets(): Array<"daemon" | AgentType> {
@@ -666,7 +791,35 @@ function optionalAgentParam(value: unknown): AgentType | undefined {
 	return agent;
 }
 
-function resolveRpcListenConfig(opts: RpcListenOpts): ControlRpcListenConfig {
+function resolveRpcListenConfig(opts: RpcListenOpts): ResolvedRpcListenConfig {
+	const host =
+		optionalStringParam(opts.rpcHost, "--rpc-host") ?? process.env.CLAWDI_DAEMON_RPC_HOST;
+	const portValue = opts.rpcPort ?? process.env.CLAWDI_DAEMON_RPC_PORT;
+	const port = optionalPortParam(portValue, "--rpc-port");
+	const allowRemote =
+		optionalBooleanParam(opts.rpcAllowRemote, "--rpc-allow-remote") ??
+		optionalBooleanParam(
+			process.env.CLAWDI_DAEMON_RPC_ALLOW_REMOTE,
+			"CLAWDI_DAEMON_RPC_ALLOW_REMOTE",
+		) ??
+		false;
+	if (host !== undefined && port === undefined) {
+		throw new Error("--rpc-host requires --rpc-port (or CLAWDI_DAEMON_RPC_PORT)");
+	}
+	if (host === undefined && port === undefined) return {};
+	const resolvedHost = host ?? "127.0.0.1";
+	if (!allowRemote && !isLoopbackRpcHost(resolvedHost)) {
+		throw new Error(
+			`Refusing to listen on non-loopback HTTP RPC host ${resolvedHost}. ` +
+				"Use --rpc-allow-remote only behind SSH tunneling or a TLS-terminating proxy.",
+		);
+	}
+	return { host: resolvedHost, port, allowRemote };
+}
+
+function resolveRpcClientConfig(
+	opts: RpcListenOpts & { rpcToken?: unknown },
+): ControlRpcClientConfig {
 	const host =
 		optionalStringParam(opts.rpcHost, "--rpc-host") ?? process.env.CLAWDI_DAEMON_RPC_HOST;
 	const portValue = opts.rpcPort ?? process.env.CLAWDI_DAEMON_RPC_PORT;
@@ -674,23 +827,60 @@ function resolveRpcListenConfig(opts: RpcListenOpts): ControlRpcListenConfig {
 	if (host !== undefined && port === undefined) {
 		throw new Error("--rpc-host requires --rpc-port (or CLAWDI_DAEMON_RPC_PORT)");
 	}
-	if (host === undefined && port === undefined) return {};
-	return { host: host ?? "127.0.0.1", port };
-}
-
-function resolveRpcClientConfig(
-	opts: RpcListenOpts & { rpcToken?: unknown },
-): ControlRpcClientConfig {
-	const listen = resolveRpcListenConfig(opts);
 	const token = optionalStringParam(opts.rpcToken, "--rpc-token");
-	return { ...listen, token };
+	if (host === undefined && port === undefined) return { token };
+	return { host: host ?? "127.0.0.1", port, token };
 }
 
-function normalizeRpcTcpConfig(
-	config: ControlRpcListenConfig,
-): { host: string; port: number } | null {
+function normalizeRpcHttpConfig(
+	config: ResolvedRpcListenConfig,
+): { host: string; port: number; allow_remote: boolean } | null {
 	if (config.port === undefined) return null;
-	return { host: config.host ?? "127.0.0.1", port: config.port };
+	return {
+		host: config.host ?? "127.0.0.1",
+		port: config.port,
+		allow_remote: config.allowRemote === true,
+	};
+}
+
+function optionalBooleanParam(value: unknown, label: string): boolean | undefined {
+	if (value === undefined || value === null) return undefined;
+	if (typeof value === "boolean") return value;
+	if (typeof value === "string") {
+		const normalized = value.trim().toLowerCase();
+		if (!normalized) return undefined;
+		if (["1", "true", "yes", "on"].includes(normalized)) return true;
+		if (["0", "false", "no", "off"].includes(normalized)) return false;
+	}
+	throw new Error(`${label} must be a boolean`);
+}
+
+function optionalLogLimitParam(value: unknown): number {
+	if (value === undefined || value === null) return 200;
+	let limit: number;
+	if (typeof value === "number") {
+		limit = value;
+	} else if (typeof value === "string" && /^\d+$/.test(value.trim())) {
+		limit = Number(value);
+	} else {
+		throw new Error("limit must be an integer from 1 to 1000");
+	}
+	if (!Number.isInteger(limit) || limit < 1 || limit > 1000) {
+		throw new Error("limit must be an integer from 1 to 1000");
+	}
+	return limit;
+}
+
+function isLoopbackRpcHost(host: string): boolean {
+	const normalized = host.trim().toLowerCase();
+	return (
+		normalized === "localhost" ||
+		normalized === "::1" ||
+		normalized === "[::1]" ||
+		normalized === "0:0:0:0:0:0:0:1" ||
+		normalized === "127.0.0.1" ||
+		normalized.startsWith("127.")
+	);
 }
 
 function optionalPortParam(value: unknown, label: string): number | undefined {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -74,9 +74,9 @@ import { daemonAutoUpdateOnce, startDaemonAutoUpdate } from "./update";
 type ServeOpts = Record<string, unknown>;
 
 interface RpcListenOpts {
-	rpcHost?: unknown;
-	rpcPort?: unknown;
-	rpcAllowRemote?: unknown;
+	host?: unknown;
+	port?: unknown;
+	allowRemote?: unknown;
 }
 
 interface LegacyRunOpts {
@@ -320,11 +320,11 @@ export async function serveInstall(opts: ServeInstallOpts): Promise<void> {
 	if (failed > 0) process.exit(1);
 }
 
-const INSTALL_ALLOWED = new Set(["rpcHost", "rpcPort", "rpcAllowRemote"]);
+const INSTALL_ALLOWED = new Set(["host", "port", "allowRemote"]);
 const UNINSTALL_ALLOWED = new Set<string>();
 const STATUS_ALLOWED = new Set(["agent"]);
 const DOCTOR_ALLOWED = new Set(["json"]);
-const RPC_ALLOWED = new Set(["params", "rpcHost", "rpcPort", "rpcToken"]);
+const RPC_ALLOWED = new Set(["host", "port", "token"]);
 
 export async function serveUninstall(opts: ServeInstallOpts): Promise<void> {
 	rejectUnsupportedOpts("uninstall", opts as Record<string, unknown>, UNINSTALL_ALLOWED);
@@ -565,24 +565,20 @@ function buildDoctorReport(): DaemonDoctorReport {
 }
 
 interface ServeRpcOpts {
-	params?: string;
-	rpcHost?: unknown;
-	rpcPort?: unknown;
-	rpcToken?: unknown;
+	host?: unknown;
+	port?: unknown;
+	token?: unknown;
 }
 
 export async function serveRpc(method: string, opts: ServeRpcOpts): Promise<void> {
-	rejectUnsupportedOpts("rpc", opts as Record<string, unknown>, RPC_ALLOWED);
-	let params: unknown = {};
-	if (opts.params !== undefined) {
-		try {
-			params = JSON.parse(opts.params);
-		} catch (error) {
-			throw new Error(`--params must be valid JSON: ${toErrorMessage(error)}`);
-		}
-	}
+	const normalizedMethod = normalizeRpcMethod(method);
+	rejectUnsupportedOpts(
+		rpcMethodCommandName(normalizedMethod),
+		opts as Record<string, unknown>,
+		RPC_ALLOWED,
+	);
 	const rpcTarget = resolveRpcClientConfig(opts);
-	const result = await callControlRpc(normalizeRpcMethod(method), params, rpcTarget);
+	const result = await callControlRpc(normalizedMethod, {}, rpcTarget);
 	console.log(JSON.stringify(result, null, 2));
 }
 
@@ -590,6 +586,11 @@ function normalizeRpcMethod(method: string): string {
 	const trimmed = method.trim();
 	if (!trimmed) throw new Error("RPC method is required");
 	return trimmed;
+}
+
+function rpcMethodCommandName(method: string): string {
+	if (method === "rotate_token") return "rotate-token";
+	return method;
 }
 
 interface ControlRpcHandlerOptions {
@@ -1255,21 +1256,19 @@ function isAuthPollResponse(value: unknown): value is AuthPollResponse {
 
 function daemonInstallRpc(params: unknown): unknown {
 	const record = rpcParamsRecord(params);
-	rejectRpcParams(record, new Set(["rpc_host", "rpc_port", "rpc_allow_remote"]));
+	rejectRpcParams(record, new Set(["host", "port", "allow_remote"]));
 	const hasExplicitRpcConfig =
-		record.rpc_host !== undefined ||
-		record.rpc_port !== undefined ||
-		record.rpc_allow_remote !== undefined;
+		record.host !== undefined || record.port !== undefined || record.allow_remote !== undefined;
 	const rpcListen = hasExplicitRpcConfig
 		? resolveRpcListenConfig({
-				rpcHost: record.rpc_host,
-				rpcPort: record.rpc_port,
-				rpcAllowRemote: record.rpc_allow_remote,
+				host: record.host,
+				port: record.port,
+				allowRemote: record.allow_remote,
 			})
 		: resolveRpcListenConfig({
-				rpcHost: activeControlRpcHttp?.host,
-				rpcPort: activeControlRpcHttp?.port,
-				rpcAllowRemote: activeControlRpcHttp?.allow_remote,
+				host: activeControlRpcHttp?.host,
+				port: activeControlRpcHttp?.port,
+				allowRemote: activeControlRpcHttp?.allow_remote,
 			});
 	return scheduleDaemonControlAction(
 		"install",
@@ -1485,13 +1484,13 @@ function optionalAgentParam(value: unknown): AgentType | undefined {
 
 function resolveRpcListenConfig(opts: RpcListenOpts): ResolvedRpcListenConfig {
 	const host =
-		optionalStringParam(opts.rpcHost, "--rpc-host") ??
+		optionalStringParam(opts.host, "--host") ??
 		process.env.CLAWDI_DAEMON_RPC_HOST ??
 		DEFAULT_CONTROL_RPC_HOST;
-	const portValue = opts.rpcPort ?? process.env.CLAWDI_DAEMON_RPC_PORT;
-	const port = optionalPortParam(portValue, "--rpc-port") ?? DEFAULT_CONTROL_RPC_PORT;
+	const portValue = opts.port ?? process.env.CLAWDI_DAEMON_RPC_PORT;
+	const port = optionalPortParam(portValue, "--port") ?? DEFAULT_CONTROL_RPC_PORT;
 	const allowRemote =
-		optionalBooleanParam(opts.rpcAllowRemote, "--rpc-allow-remote") ??
+		optionalBooleanParam(opts.allowRemote, "--allow-remote") ??
 		optionalBooleanParam(
 			process.env.CLAWDI_DAEMON_RPC_ALLOW_REMOTE,
 			"CLAWDI_DAEMON_RPC_ALLOW_REMOTE",
@@ -1500,22 +1499,20 @@ function resolveRpcListenConfig(opts: RpcListenOpts): ResolvedRpcListenConfig {
 	if (!allowRemote && !isLoopbackRpcHost(host)) {
 		throw new Error(
 			`Refusing to listen on non-loopback HTTP RPC host ${host}. ` +
-				"Use --rpc-allow-remote only behind SSH tunneling or a TLS-terminating proxy.",
+				"Use --allow-remote only behind SSH tunneling or a TLS-terminating proxy.",
 		);
 	}
 	return { host, port, allowRemote };
 }
 
-function resolveRpcClientConfig(
-	opts: RpcListenOpts & { rpcToken?: unknown },
-): ControlRpcClientConfig {
+function resolveRpcClientConfig(opts: RpcListenOpts & { token?: unknown }): ControlRpcClientConfig {
 	const host =
-		optionalStringParam(opts.rpcHost, "--rpc-host") ??
+		optionalStringParam(opts.host, "--host") ??
 		process.env.CLAWDI_DAEMON_RPC_HOST ??
 		DEFAULT_CONTROL_RPC_HOST;
-	const portValue = opts.rpcPort ?? process.env.CLAWDI_DAEMON_RPC_PORT;
-	const port = optionalPortParam(portValue, "--rpc-port") ?? DEFAULT_CONTROL_RPC_PORT;
-	const token = optionalStringParam(opts.rpcToken, "--rpc-token");
+	const portValue = opts.port ?? process.env.CLAWDI_DAEMON_RPC_PORT;
+	const port = optionalPortParam(portValue, "--port") ?? DEFAULT_CONTROL_RPC_PORT;
+	const token = optionalStringParam(opts.token, "--token");
 	return { host, port, token };
 }
 

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -42,19 +42,12 @@ import { adapterForType, getEnvIdByAgent, listRegisteredAgentTypes } from "../li
 import { getCliVersion } from "../lib/version";
 import { startAutoRestart } from "../serve/auto-restart";
 import {
-	CONTROL_RPC_CAPABILITIES,
-	type ControlRpcAuthContext,
 	type ControlRpcClientConfig,
 	type ControlRpcHandlers,
 	type ControlRpcListenConfig,
 	callControlRpc,
-	issueScopedControlToken,
-	type RpcCapability,
-	requireRpcCapability,
-	rootOnlyRpcHandler,
 	rotateControlToken,
 	startControlRpcServer,
-	withRpcCapabilities,
 } from "../serve/control-rpc";
 import {
 	install as installService,
@@ -614,27 +607,15 @@ interface ControlRpcHandlerOptions {
 
 export function createControlRpcHandlers(opts: ControlRpcHandlerOptions = {}): ControlRpcHandlers {
 	const handlers: ControlRpcHandlers = {};
-	handlers["daemon.ping"] = rpcHandler(["daemon:read"], () => ({
+	handlers["daemon.ping"] = () => ({
 		pid: process.pid,
 		version: getCliVersion(),
 		uptime_seconds: Math.round(process.uptime()),
-	}));
-	handlers["daemon.methods"] = rpcHandler(["daemon:read"], () => ({
-		capabilities: CONTROL_RPC_CAPABILITIES,
+	});
+	handlers["daemon.methods"] = () => ({
 		methods: Object.keys(handlers).sort(),
-		requirements: Object.fromEntries(
-			Object.entries(handlers)
-				.sort(([left], [right]) => left.localeCompare(right))
-				.map(([method, handler]) => [
-					method,
-					{
-						capabilities: handler.requiredCapabilities ?? [],
-						root_only: handler.rootOnly === true,
-					},
-				]),
-		),
-	}));
-	handlers["daemon.status"] = rpcHandler(["daemon:read"], (params) => {
+	});
+	handlers["daemon.status"] = (params) => {
 		const record = rpcParamsRecord(params);
 		rejectRpcParams(record, new Set(["agent"]));
 		const agent = optionalAgentParam(record.agent);
@@ -644,65 +625,37 @@ export function createControlRpcHandlers(opts: ControlRpcHandlerOptions = {}): C
 			legacy_daemon_units: listInstalledAgents(),
 			agents: targets.map(buildStatusReport),
 		};
-	});
-	handlers["daemon.doctor"] = rpcHandler(["daemon:read"], () => buildDoctorReport());
-	handlers["daemon.install"] = rpcHandler(["daemon:control"], (params) => daemonInstallRpc(params));
-	handlers["daemon.uninstall"] = rpcHandler(["daemon:control"], (params) =>
-		daemonUninstallRpc(params),
-	);
-	handlers["daemon.restart"] = rpcHandler(["daemon:control"], (params) => daemonRestartRpc(params));
-	handlers["daemon.logs"] = rpcHandler(["daemon:read"], (params) => daemonLogsRpc(params));
-	handlers["daemon.issue_token"] = rootRpcHandler((params) => daemonIssueTokenRpc(params));
-	handlers["daemon.rotate_token"] = rootRpcHandler((params) => daemonRotateTokenRpc(params));
-	handlers["operation.list"] = rpcHandler(["operation:read"], (params) => operationListRpc(params));
-	handlers["operation.status"] = rpcHandler(["operation:read"], (params) =>
-		operationStatusRpc(params),
-	);
-	handlers["operation.logs"] = rpcHandler(["operation:read"], (params) => operationLogsRpc(params));
-	handlers["operation.cancel"] = rpcHandler(["operation:control"], (params) =>
-		operationCancelRpc(params),
-	);
-	handlers["sync.push"] = rpcHandler(["sync:run"], (params) => syncPushRpc(params));
-	handlers["sync.pull"] = rpcHandler(["sync:run"], (params) => syncPullRpc(params));
-	handlers["sync.push_dry_run"] = rpcHandler(["sync:run"], (params) => syncPushDryRunRpc(params));
-	handlers["sync.pull_dry_run"] = rpcHandler(["sync:run"], (params) => syncPullDryRunRpc(params));
-	handlers["vault.set"] = rpcHandler(["vault:write"], (params) => vaultSetRpc(params));
-	handlers["vault.list"] = rpcHandler(["vault:read"], (params) => vaultListRpc(params));
-	handlers["vault.import"] = rpcHandler(["vault:write"], (params) => vaultImportRpc(params));
-	handlers["vault.attach"] = rpcHandler(["vault:write"], (params) => vaultAttachRpc(params));
-	handlers["vault.detach"] = rpcHandler(["vault:write"], (params) => vaultDetachRpc(params));
-	handlers["vault.rm"] = rpcHandler(["vault:write"], (params) => vaultRmRpc(params));
-	handlers["vault.resolve"] = rpcHandler(["vault:read"], (params, context) =>
-		vaultResolveRpc(params, context),
-	);
-	handlers["vault.read"] = rpcHandler(["vault:read"], (params, context) =>
-		vaultReadRpc(params, context),
-	);
-	handlers["vault.inject"] = rpcHandler(["vault:read"], (params, context) =>
-		vaultInjectRpc(params, context),
-	);
-	handlers["auth.status"] = rpcHandler(["auth:read"], (params) => authStatusRpc(params));
-	handlers["auth.login"] = rpcHandler(["auth:write"], (params) => authLoginRpc(params));
-	handlers["auth.complete"] = rpcHandler(["auth:write"], (params) => authCompleteRpc(params));
-	handlers["auth.logout"] = rpcHandler(["auth:write"], (params) => authLogoutRpc(params));
-	handlers["update.check"] = rpcHandler(["update:read"], (params) => updateCheckRpc(params));
-	handlers["update.install"] = rpcHandler(["update:install"], (params) =>
-		updateInstallRpc(params, opts.abortController),
-	);
+	};
+	handlers["daemon.doctor"] = () => buildDoctorReport();
+	handlers["daemon.install"] = (params) => daemonInstallRpc(params);
+	handlers["daemon.uninstall"] = (params) => daemonUninstallRpc(params);
+	handlers["daemon.restart"] = (params) => daemonRestartRpc(params);
+	handlers["daemon.logs"] = (params) => daemonLogsRpc(params);
+	handlers["daemon.rotate_token"] = (params) => daemonRotateTokenRpc(params);
+	handlers["operation.list"] = (params) => operationListRpc(params);
+	handlers["operation.status"] = (params) => operationStatusRpc(params);
+	handlers["operation.logs"] = (params) => operationLogsRpc(params);
+	handlers["operation.cancel"] = (params) => operationCancelRpc(params);
+	handlers["sync.push"] = (params) => syncPushRpc(params);
+	handlers["sync.pull"] = (params) => syncPullRpc(params);
+	handlers["sync.push_dry_run"] = (params) => syncPushDryRunRpc(params);
+	handlers["sync.pull_dry_run"] = (params) => syncPullDryRunRpc(params);
+	handlers["vault.set"] = (params) => vaultSetRpc(params);
+	handlers["vault.list"] = (params) => vaultListRpc(params);
+	handlers["vault.import"] = (params) => vaultImportRpc(params);
+	handlers["vault.attach"] = (params) => vaultAttachRpc(params);
+	handlers["vault.detach"] = (params) => vaultDetachRpc(params);
+	handlers["vault.rm"] = (params) => vaultRmRpc(params);
+	handlers["vault.resolve"] = (params) => vaultResolveRpc(params);
+	handlers["vault.read"] = (params) => vaultReadRpc(params);
+	handlers["vault.inject"] = (params) => vaultInjectRpc(params);
+	handlers["auth.status"] = (params) => authStatusRpc(params);
+	handlers["auth.login"] = (params) => authLoginRpc(params);
+	handlers["auth.complete"] = (params) => authCompleteRpc(params);
+	handlers["auth.logout"] = (params) => authLogoutRpc(params);
+	handlers["update.check"] = (params) => updateCheckRpc(params);
+	handlers["update.install"] = (params) => updateInstallRpc(params, opts.abortController);
 	return handlers;
-}
-
-function rpcHandler(
-	capabilities: readonly RpcCapability[],
-	handler: (params: unknown, context?: ControlRpcAuthContext) => Promise<unknown> | unknown,
-) {
-	return withRpcCapabilities(handler, capabilities);
-}
-
-function rootRpcHandler(
-	handler: (params: unknown, context?: ControlRpcAuthContext) => Promise<unknown> | unknown,
-) {
-	return rootOnlyRpcHandler(handler);
 }
 
 function operationListRpc(params: unknown): unknown {
@@ -899,10 +852,7 @@ function vaultRmRpc(params: unknown): Promise<unknown> {
 	});
 }
 
-function vaultResolveRpc(
-	params: unknown,
-	context: ControlRpcAuthContext | undefined,
-): Promise<unknown> {
+function vaultResolveRpc(params: unknown): Promise<unknown> {
 	const record = rpcParamsRecord(params);
 	rejectRpcParams(
 		record,
@@ -924,7 +874,6 @@ function vaultResolveRpc(
 	const wait = optionalBooleanParam(record.wait, "wait") ?? true;
 	if (includeValue) {
 		requireBooleanConfirmation(record, "confirm_secret_access", "vault.resolve plaintext access");
-		requireRpcCapability(context, "vault:secrets", "vault.resolve plaintext access");
 		if (!wait)
 			throw new Error(
 				"vault.resolve with include_value=true cannot run as a background operation.",
@@ -943,10 +892,7 @@ function vaultResolveRpc(
 	});
 }
 
-function vaultReadRpc(
-	params: unknown,
-	context: ControlRpcAuthContext | undefined,
-): Promise<unknown> {
+function vaultReadRpc(params: unknown): Promise<unknown> {
 	const record = rpcParamsRecord(params);
 	rejectRpcParams(
 		record,
@@ -967,7 +913,6 @@ function vaultReadRpc(
 	const wait = optionalBooleanParam(record.wait, "wait") ?? true;
 	if (!dryRun) {
 		requireBooleanConfirmation(record, "confirm_secret_access", "vault.read plaintext access");
-		requireRpcCapability(context, "vault:secrets", "vault.read plaintext access");
 		if (!wait) throw new Error("vault.read plaintext access cannot run as a background operation.");
 	}
 	const args = ["read", requiredStringParam(record, "reference")];
@@ -983,10 +928,7 @@ function vaultReadRpc(
 	});
 }
 
-function vaultInjectRpc(
-	params: unknown,
-	context: ControlRpcAuthContext | undefined,
-): Promise<unknown> {
+function vaultInjectRpc(params: unknown): Promise<unknown> {
 	const record = rpcParamsRecord(params);
 	rejectRpcParams(
 		record,
@@ -1009,7 +951,6 @@ function vaultInjectRpc(
 	const wait = optionalBooleanParam(record.wait, "wait") ?? true;
 	if (!dryRun) {
 		requireBooleanConfirmation(record, "confirm_secret_access", "vault.inject secret rendering");
-		requireRpcCapability(context, "vault:secrets", "vault.inject secret rendering");
 		if (!wait)
 			throw new Error("vault.inject secret rendering cannot run as a background operation.");
 	}
@@ -1406,30 +1347,6 @@ function daemonRotateTokenRpc(params: unknown): unknown {
 	};
 }
 
-function daemonIssueTokenRpc(params: unknown): unknown {
-	const record = rpcParamsRecord(params);
-	rejectRpcParams(record, new Set(["capabilities", "label", "expires_in_seconds"]));
-	const capabilities = requiredCapabilityListParam(record, "capabilities");
-	const expiresInSeconds = optionalLimitParam(
-		record.expires_in_seconds,
-		"expires_in_seconds",
-		60,
-		30 * 24 * 60 * 60,
-		24 * 60 * 60,
-	);
-	const issued = issueScopedControlToken({
-		capabilities,
-		label: optionalStringParam(record.label, "label"),
-		expiresInSeconds,
-	});
-	return {
-		token: issued.token,
-		token_type: "scoped",
-		capabilities: issued.capabilities,
-		expires_at: issued.expires_at,
-	};
-}
-
 function scheduleDaemonControlAction(
 	action: string,
 	run: () => void,
@@ -1563,25 +1480,6 @@ function optionalStringListParam(value: unknown, label: string): string[] | unde
 		items.push(optionalStringParam(item, label) ?? "");
 	}
 	return items;
-}
-
-function requiredCapabilityListParam(
-	record: Record<string, unknown>,
-	key: string,
-): RpcCapability[] {
-	const items = optionalStringListParam(record[key], key);
-	if (!items || items.length === 0) throw new Error(`${key} is required`);
-	const capabilities: RpcCapability[] = [];
-	for (const item of items) {
-		if (!(CONTROL_RPC_CAPABILITIES as readonly string[]).includes(item)) {
-			throw new Error(
-				`Unknown RPC capability: ${item}. Expected one of: ${CONTROL_RPC_CAPABILITIES.join(", ")}`,
-			);
-		}
-		const capability = item as RpcCapability;
-		if (!capabilities.includes(capability)) capabilities.push(capability);
-	}
-	return capabilities;
 }
 
 function optionalAgentParam(value: unknown): AgentType | undefined {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -435,13 +435,8 @@ const LOGS_ALLOWED = new Set(["follow"]);
 export async function serveLogs(opts: ServeLogsOpts): Promise<void> {
 	rejectUnsupportedOpts("logs", opts as Record<string, unknown>, LOGS_ALLOWED);
 	const { spawn } = await import("node:child_process");
-	// Per-platform log access. macOS launchd routes the unit's
-	// `StandardErrorPath` to a file we own (we wrote it in the
-	// plist), so `tail` works. Linux systemd routes
-	// `StandardError=journal` to journald — there's no file to
-	// tail, so we delegate to `journalctl --user -u <unit>`.
-	// Linux daemon logs live in journald, while macOS launchd writes
-	// to the file path configured by the plist.
+	// Per-platform log access. macOS launchd writes to the plist's
+	// StandardErrorPath; Linux systemd writes to journald.
 	const platform = process.platform;
 	let cmd: string;
 	let args: string[];
@@ -710,20 +705,18 @@ async function syncCommandRpc(
 	opts: { forceDryRun: boolean; defaultWait: boolean },
 ): Promise<unknown> {
 	const record = rpcParamsRecord(params);
-	rejectRpcParams(
-		record,
-		new Set([
-			"modules",
-			"project",
-			"exclude_project",
-			"all",
-			"all_agents",
-			"agent",
-			"dry_run",
-			"cwd",
-			"wait",
-		]),
-	);
+	const allowedParams = new Set([
+		"modules",
+		"project",
+		"all",
+		"all_agents",
+		"agent",
+		"dry_run",
+		"cwd",
+		"wait",
+	]);
+	if (command === "push") allowedParams.add("exclude_project");
+	rejectRpcParams(record, allowedParams);
 	const args: string[] = [command];
 	const modules = optionalStringParam(record.modules, "modules");
 	const project = optionalStringParam(record.project, "project");
@@ -1006,6 +999,11 @@ async function authLoginRpc(params: unknown): Promise<unknown> {
 	}
 	const apiUrl = optionalStringParam(record.api_url, "api_url") ?? getConfig().apiUrl;
 	const apiKey = optionalStringParam(record.api_key, "api_key");
+	if (existing && replace && !apiKey) {
+		throw new Error(
+			"auth.login replace requires api_key, or call auth.logout before device login.",
+		);
+	}
 	if (apiKey) {
 		requireBooleanConfirmation(record, "confirm_secret_access", "auth.login API key import");
 		const me = await verifyAndSaveRpcAuth(apiUrl, apiKey);

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -23,9 +23,10 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { AGENT_TYPES, type AgentType } from "../adapters/registry";
-import { isLoggedIn } from "../lib/config";
+import { getClawdiDir, isLoggedIn } from "../lib/config";
 import { adapterForType, getEnvIdByAgent, listRegisteredAgentTypes } from "../lib/select-adapter";
 import { getCliVersion } from "../lib/version";
 import { startAutoRestart } from "../serve/auto-restart";
@@ -62,6 +63,11 @@ interface RpcListenOpts {
 	rpcHost?: unknown;
 	rpcPort?: unknown;
 	rpcAllowRemote?: unknown;
+}
+
+interface LegacyRunOpts {
+	agent?: unknown;
+	environmentId?: unknown;
 }
 
 interface ResolvedRpcListenConfig extends ControlRpcListenConfig {
@@ -141,10 +147,17 @@ function camelToFlag(name: string): string {
 }
 
 export async function serve(_opts: ServeOpts): Promise<void> {
-	const opts = _opts as RpcListenOpts;
-	const rpcListen = resolveRpcListenConfig(opts);
+	const opts = _opts as RpcListenOpts & LegacyRunOpts;
 	const mode = (process.env.CLAWDI_SERVE_MODE ?? "host").toLowerCase();
 	const isContainer = mode === "container";
+	const legacyRun = resolveLegacyRunOpts(opts);
+
+	if (legacyRun && !isContainer) {
+		migrateLegacyDaemonRun(legacyRun);
+		return;
+	}
+
+	const rpcListen = resolveRpcListenConfig(opts);
 
 	if (!isLoggedIn()) {
 		log.error("serve.no_auth", {
@@ -153,7 +166,7 @@ export async function serve(_opts: ServeOpts): Promise<void> {
 		process.exit(1);
 	}
 
-	const targets = pickDaemonRunTargets();
+	const targets = legacyRun ? [pickLegacyDaemonRunTarget(legacyRun)] : pickDaemonRunTargets();
 
 	log.info("serve.boot", {
 		mode,
@@ -900,8 +913,19 @@ function optionalPortParam(value: unknown, label: string): number | undefined {
 }
 
 function cleanupLegacyDaemonUnits(): number {
+	return cleanupLegacyDaemonUnitsExceptLast();
+}
+
+function cleanupLegacyDaemonUnitsExceptLast(lastAgent?: AgentType): number {
 	let failed = 0;
-	for (const agentType of listInstalledAgents()) {
+	const installedAgents = listInstalledAgents();
+	const orderedAgents = lastAgent
+		? [
+				...installedAgents.filter((agentType) => agentType !== lastAgent),
+				...installedAgents.filter((agentType) => agentType === lastAgent),
+			]
+		: installedAgents;
+	for (const agentType of orderedAgents) {
 		try {
 			const result = uninstallService({ agent: agentType });
 			if (result.removed) {
@@ -913,6 +937,98 @@ function cleanupLegacyDaemonUnits(): number {
 		}
 	}
 	return failed;
+}
+
+interface LegacyDaemonRun {
+	agentType: AgentType;
+	environmentId?: string;
+}
+
+function resolveLegacyRunOpts(opts: LegacyRunOpts): LegacyDaemonRun | null {
+	const agentType = optionalAgentParam(opts.agent);
+	const environmentId = optionalStringParam(opts.environmentId, "--environment-id");
+	if (!agentType) {
+		if (environmentId) {
+			throw new Error("--environment-id requires --agent for legacy daemon run compatibility");
+		}
+		return null;
+	}
+	return { agentType, environmentId };
+}
+
+function migrateLegacyDaemonRun(legacy: LegacyDaemonRun): void {
+	if (!isLoggedIn()) {
+		log.error("serve.legacy_daemon_migration_no_auth", {
+			agent: legacy.agentType,
+			hint: "Set CLAWDI_AUTH_TOKEN env or run `clawdi auth login`, then run `clawdi daemon install`.",
+		});
+		process.exit(1);
+	}
+	if (legacy.environmentId) {
+		persistLegacyEnvironmentId(legacy);
+	}
+	log.info("serve.legacy_daemon_migration_started", {
+		agent: legacy.agentType,
+		has_environment_id: legacy.environmentId !== undefined,
+	});
+	try {
+		const result = installService();
+		log.info("serve.legacy_daemon_migration_singleton_installed", {
+			unit: result.unit,
+			replaced: result.replaced,
+		});
+	} catch (error) {
+		log.error("serve.legacy_daemon_migration_install_failed", {
+			agent: legacy.agentType,
+			error: toErrorMessage(error),
+		});
+		process.exit(1);
+	}
+	const failed = cleanupLegacyDaemonUnitsExceptLast(legacy.agentType);
+	log.info("serve.legacy_daemon_migration_finished", {
+		agent: legacy.agentType,
+		failed,
+	});
+	process.exit(failed > 0 ? 1 : 0);
+}
+
+function persistLegacyEnvironmentId(legacy: LegacyDaemonRun): void {
+	if (!legacy.environmentId) return;
+	const envDir = join(getClawdiDir(), "environments");
+	mkdirSync(envDir, { recursive: true });
+	const envPath = join(envDir, `${legacy.agentType}.json`);
+	writeFileSync(
+		envPath,
+		`${JSON.stringify({ id: legacy.environmentId, agentType: legacy.agentType }, null, 2)}\n`,
+		{ mode: 0o600 },
+	);
+	try {
+		chmodSync(envPath, 0o600);
+	} catch {
+		/* best effort */
+	}
+}
+
+function pickLegacyDaemonRunTarget(legacy: LegacyDaemonRun): DaemonRunTarget {
+	const adapter = adapterForType(legacy.agentType);
+	if (!adapter) {
+		log.error("serve.no_agent_adapter", { agent: legacy.agentType });
+		console.error(`No adapter available for ${legacy.agentType}.`);
+		process.exit(1);
+	}
+	const environmentId = legacy.environmentId ?? resolveEnvironmentId(legacy.agentType, 1);
+	if (!environmentId) {
+		log.error("serve.no_environment", {
+			agent: legacy.agentType,
+			hint: "Pass --environment-id, set CLAWDI_ENVIRONMENT_ID, or run `clawdi setup`.",
+		});
+		process.exit(1);
+	}
+	return {
+		agentType: legacy.agentType,
+		adapter,
+		environmentId,
+	};
 }
 
 function isAgentType(s: string): s is AgentType {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -582,14 +582,14 @@ export async function serveRpc(method: string, opts: ServeRpcOpts): Promise<void
 		}
 	}
 	const rpcTarget = resolveRpcClientConfig(opts);
-	const result = await callControlRpc(normalizeDaemonRpcMethod(method), params, rpcTarget);
+	const result = await callControlRpc(normalizeRpcMethod(method), params, rpcTarget);
 	console.log(JSON.stringify(result, null, 2));
 }
 
-function normalizeDaemonRpcMethod(method: string): string {
+function normalizeRpcMethod(method: string): string {
 	const trimmed = method.trim();
 	if (!trimmed) throw new Error("RPC method is required");
-	return trimmed.includes(".") ? trimmed : `daemon.${trimmed}`;
+	return trimmed;
 }
 
 interface ControlRpcHandlerOptions {
@@ -598,15 +598,15 @@ interface ControlRpcHandlerOptions {
 
 export function createControlRpcHandlers(opts: ControlRpcHandlerOptions = {}): ControlRpcHandlers {
 	const handlers: ControlRpcHandlers = {};
-	handlers["daemon.ping"] = () => ({
+	handlers.ping = () => ({
 		pid: process.pid,
 		version: getCliVersion(),
 		uptime_seconds: Math.round(process.uptime()),
 	});
-	handlers["daemon.methods"] = () => ({
+	handlers.methods = () => ({
 		methods: Object.keys(handlers).sort(),
 	});
-	handlers["daemon.status"] = (params) => {
+	handlers.status = (params) => {
 		const record = rpcParamsRecord(params);
 		rejectRpcParams(record, new Set(["agent"]));
 		const agent = optionalAgentParam(record.agent);
@@ -617,12 +617,12 @@ export function createControlRpcHandlers(opts: ControlRpcHandlerOptions = {}): C
 			agents: targets.map(buildStatusReport),
 		};
 	};
-	handlers["daemon.doctor"] = () => buildDoctorReport();
-	handlers["daemon.install"] = (params) => daemonInstallRpc(params);
-	handlers["daemon.uninstall"] = (params) => daemonUninstallRpc(params);
-	handlers["daemon.restart"] = (params) => daemonRestartRpc(params);
-	handlers["daemon.logs"] = (params) => daemonLogsRpc(params);
-	handlers["daemon.rotate_token"] = (params) => daemonRotateTokenRpc(params);
+	handlers.doctor = () => buildDoctorReport();
+	handlers.install = (params) => daemonInstallRpc(params);
+	handlers.uninstall = (params) => daemonUninstallRpc(params);
+	handlers.restart = (params) => daemonRestartRpc(params);
+	handlers.logs = (params) => daemonLogsRpc(params);
+	handlers.rotate_token = (params) => daemonRotateTokenRpc(params);
 	handlers["operation.list"] = (params) => operationListRpc(params);
 	handlers["operation.status"] = (params) => operationStatusRpc(params);
 	handlers["operation.logs"] = (params) => operationLogsRpc(params);

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -48,6 +48,7 @@ import {
 	callControlRpc,
 	DEFAULT_CONTROL_RPC_HOST,
 	DEFAULT_CONTROL_RPC_PORT,
+	isLoopbackRpcHost,
 	rotateControlToken,
 	startControlRpcServer,
 } from "../serve/control-rpc";
@@ -246,9 +247,7 @@ export async function serve(_opts: ServeOpts): Promise<void> {
 		abort.signal,
 		rpcListen,
 	);
-	activeControlRpcHttp = rpc.http
-		? { ...rpc.http, allow_remote: rpcListen.allowRemote === true }
-		: null;
+	activeControlRpcHttp = { ...rpc.http, allow_remote: rpcListen.allowRemote === true };
 	log.info("serve.rpc_listening", {
 		token_path: rpc.tokenPath,
 		http: rpc.http,
@@ -441,10 +440,8 @@ export async function serveLogs(opts: ServeLogsOpts): Promise<void> {
 	// plist), so `tail` works. Linux systemd routes
 	// `StandardError=journal` to journald — there's no file to
 	// tail, so we delegate to `journalctl --user -u <unit>`.
-	// Codex flagged the original implementation: it used `tail`
-	// unconditionally and silently failed (or worse, errored) on
-	// Linux because `~/.clawdi/serve/logs/daemon.stderr.log`
-	// never gets created.
+	// Linux daemon logs live in journald, while macOS launchd writes
+	// to the file path configured by the plist.
 	const platform = process.platform;
 	let cmd: string;
 	let args: string[];
@@ -1140,12 +1137,10 @@ interface AuthPollResponse {
 }
 
 async function verifyAndSaveRpcAuth(apiUrl: string, apiKey: string): Promise<AuthMeResponse> {
-	setAuth({ apiKey });
 	const response = await fetch(`${apiUrl}/api/auth/me`, {
 		headers: { Authorization: `Bearer ${apiKey}` },
 	});
 	if (!response.ok) {
-		clearAuth();
 		throw new Error(`API key verification failed with HTTP ${response.status}`);
 	}
 	const me = await readJsonObject<AuthMeResponse>(response, isAuthMeResponse, "/api/auth/me");
@@ -1596,18 +1591,6 @@ function requireBooleanConfirmation(
 	if (optionalBooleanParam(record[key], key) !== true) {
 		throw new Error(`${action} requires ${key}=true.`);
 	}
-}
-
-function isLoopbackRpcHost(host: string): boolean {
-	const normalized = host.trim().toLowerCase();
-	return (
-		normalized === "localhost" ||
-		normalized === "::1" ||
-		normalized === "[::1]" ||
-		normalized === "0:0:0:0:0:0:0:1" ||
-		normalized === "127.0.0.1" ||
-		normalized.startsWith("127.")
-	);
 }
 
 function optionalPortParam(value: unknown, label: string): number | undefined {

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -24,9 +24,20 @@
 
 import { execFileSync } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { hostname } from "node:os";
 import { join } from "node:path";
 import { AGENT_TYPES, type AgentType } from "../adapters/registry";
-import { getClawdiDir, isLoggedIn } from "../lib/config";
+import {
+	clearAuth,
+	clearPendingAuth,
+	getAuth,
+	getClawdiDir,
+	getConfig,
+	getPendingAuth,
+	isLoggedIn,
+	setAuth,
+	setPendingAuth,
+} from "../lib/config";
 import { adapterForType, getEnvIdByAgent, listRegisteredAgentTypes } from "../lib/select-adapter";
 import { getCliVersion } from "../lib/version";
 import { startAutoRestart } from "../serve/auto-restart";
@@ -49,13 +60,18 @@ import {
 } from "../serve/installer";
 import { log, toErrorMessage } from "../serve/log";
 import {
+	type CommandResult,
+	operationManager,
+	runCliCommandImmediate,
+} from "../serve/operation-runner";
+import {
 	getDaemonControlSocketPath,
 	getDaemonControlTokenPath,
 	getServeLogPath,
 	getServeStateDir,
 } from "../serve/paths";
 import { runSyncEngine } from "../serve/sync-engine";
-import { startDaemonAutoUpdate } from "./update";
+import { daemonAutoUpdateOnce, startDaemonAutoUpdate } from "./update";
 
 type ServeOpts = Record<string, unknown>;
 
@@ -114,6 +130,21 @@ interface DaemonDoctorReport {
 			};
 		}
 	>;
+}
+
+interface RpcCommandOptions {
+	name: string;
+	args: string[];
+	cwd?: string;
+	stdin?: string;
+	wait: boolean;
+	parseJson?: boolean;
+	redactedArgs?: string[];
+	timeoutMs?: number;
+}
+
+interface RpcCommandResponse extends CommandResult {
+	json?: unknown;
 }
 
 /**
@@ -565,7 +596,7 @@ export async function serveRpc(method: string, opts: ServeRpcOpts): Promise<void
 	console.log(JSON.stringify(result, null, 2));
 }
 
-function createControlRpcHandlers(): ControlRpcHandlers {
+export function createControlRpcHandlers(): ControlRpcHandlers {
 	const handlers: ControlRpcHandlers = {};
 	handlers["daemon.ping"] = () => ({
 		pid: process.pid,
@@ -592,7 +623,614 @@ function createControlRpcHandlers(): ControlRpcHandlers {
 	handlers["daemon.restart"] = (params) => daemonRestartRpc(params);
 	handlers["daemon.logs"] = (params) => daemonLogsRpc(params);
 	handlers["daemon.rotate_token"] = (params) => daemonRotateTokenRpc(params);
+	handlers["operation.list"] = (params) => operationListRpc(params);
+	handlers["operation.status"] = (params) => operationStatusRpc(params);
+	handlers["operation.logs"] = (params) => operationLogsRpc(params);
+	handlers["operation.cancel"] = (params) => operationCancelRpc(params);
+	handlers["sync.push"] = (params) => syncPushRpc(params);
+	handlers["sync.pull"] = (params) => syncPullRpc(params);
+	handlers["sync.push_dry_run"] = (params) => syncPushDryRunRpc(params);
+	handlers["sync.pull_dry_run"] = (params) => syncPullDryRunRpc(params);
+	handlers["vault.set"] = (params) => vaultSetRpc(params);
+	handlers["vault.list"] = (params) => vaultListRpc(params);
+	handlers["vault.import"] = (params) => vaultImportRpc(params);
+	handlers["vault.attach"] = (params) => vaultAttachRpc(params);
+	handlers["vault.detach"] = (params) => vaultDetachRpc(params);
+	handlers["vault.rm"] = (params) => vaultRmRpc(params);
+	handlers["vault.resolve"] = (params) => vaultResolveRpc(params);
+	handlers["vault.read"] = (params) => vaultReadRpc(params);
+	handlers["vault.inject"] = (params) => vaultInjectRpc(params);
+	handlers["auth.status"] = (params) => authStatusRpc(params);
+	handlers["auth.login"] = (params) => authLoginRpc(params);
+	handlers["auth.complete"] = (params) => authCompleteRpc(params);
+	handlers["auth.logout"] = (params) => authLogoutRpc(params);
+	handlers["update.check"] = (params) => updateCheckRpc(params);
+	handlers["update.install"] = (params) => updateInstallRpc(params);
 	return handlers;
+}
+
+function operationListRpc(params: unknown): unknown {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set(["limit"]));
+	const limit = optionalLimitParam(record.limit, "limit", 1, 1000, 50);
+	return { operations: operationManager.list(limit) };
+}
+
+function operationStatusRpc(params: unknown): unknown {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set(["id"]));
+	const operation = operationManager.get(requiredStringParam(record, "id"));
+	if (!operation) throw new Error("Unknown operation id");
+	return operation;
+}
+
+function operationLogsRpc(params: unknown): unknown {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set(["id", "limit"]));
+	const logs = operationManager.logs(
+		requiredStringParam(record, "id"),
+		optionalLimitParam(record.limit, "limit", 1, 1000, 200),
+	);
+	if (!logs) throw new Error("Unknown operation id");
+	return logs;
+}
+
+function operationCancelRpc(params: unknown): unknown {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set(["id"]));
+	const operation = operationManager.cancel(requiredStringParam(record, "id"));
+	if (!operation) throw new Error("Unknown operation id");
+	return operation;
+}
+
+function syncPushRpc(params: unknown): Promise<unknown> {
+	return syncCommandRpc("push", params, { forceDryRun: false, defaultWait: false });
+}
+
+function syncPullRpc(params: unknown): Promise<unknown> {
+	return syncCommandRpc("pull", params, { forceDryRun: false, defaultWait: false });
+}
+
+function syncPushDryRunRpc(params: unknown): Promise<unknown> {
+	return syncCommandRpc("push", params, { forceDryRun: true, defaultWait: true });
+}
+
+function syncPullDryRunRpc(params: unknown): Promise<unknown> {
+	return syncCommandRpc("pull", params, { forceDryRun: true, defaultWait: true });
+}
+
+async function syncCommandRpc(
+	command: "push" | "pull",
+	params: unknown,
+	opts: { forceDryRun: boolean; defaultWait: boolean },
+): Promise<unknown> {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(
+		record,
+		new Set([
+			"modules",
+			"project",
+			"exclude_project",
+			"all",
+			"all_agents",
+			"agent",
+			"dry_run",
+			"cwd",
+			"wait",
+		]),
+	);
+	const args: string[] = [command];
+	const modules = optionalStringParam(record.modules, "modules");
+	const project = optionalStringParam(record.project, "project");
+	const agent = optionalStringParam(record.agent, "agent");
+	const cwd = optionalStringParam(record.cwd, "cwd");
+	const all = optionalBooleanParam(record.all, "all") ?? false;
+	const allAgents = optionalBooleanParam(record.all_agents, "all_agents") ?? false;
+	const dryRun = opts.forceDryRun || (optionalBooleanParam(record.dry_run, "dry_run") ?? false);
+	if (modules) args.push("--modules", modules);
+	if (project) args.push("--project", project);
+	if (agent) args.push("--agent", agent);
+	if (all) args.push("--all");
+	if (allAgents) args.push("--all-agents");
+	if (dryRun) args.push("--dry-run");
+	if (command === "push") {
+		for (const excluded of optionalStringListParam(record.exclude_project, "exclude_project") ??
+			[]) {
+			args.push("--exclude-project", excluded);
+		}
+		if (!all && !project && !cwd) {
+			throw new Error("sync.push RPC requires cwd or project unless all=true.");
+		}
+	}
+	return runCommandRpc({
+		name: `sync.${command}`,
+		args,
+		cwd,
+		wait: optionalBooleanParam(record.wait, "wait") ?? opts.defaultWait,
+	});
+}
+
+function vaultSetRpc(params: unknown): Promise<unknown> {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set(["key", "value", "project", "allow_empty", "cwd", "wait"]));
+	const key = requiredStringParam(record, "key");
+	const value = requiredStringParam(record, "value");
+	const args = ["vault", "set", key, "--stdin"];
+	appendOptionalStringFlag(args, "--project", record.project);
+	if (optionalBooleanParam(record.allow_empty, "allow_empty")) args.push("--allow-empty");
+	return runCommandRpc({
+		name: "vault.set",
+		args,
+		cwd: optionalStringParam(record.cwd, "cwd"),
+		stdin: value,
+		wait: optionalBooleanParam(record.wait, "wait") ?? true,
+	});
+}
+
+function vaultListRpc(params: unknown): Promise<unknown> {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set(["project", "cwd", "wait"]));
+	const args = ["vault", "list", "--json"];
+	appendOptionalStringFlag(args, "--project", record.project);
+	return runCommandRpc({
+		name: "vault.list",
+		args,
+		cwd: optionalStringParam(record.cwd, "cwd"),
+		wait: optionalBooleanParam(record.wait, "wait") ?? true,
+		parseJson: true,
+	});
+}
+
+function vaultImportRpc(params: unknown): Promise<unknown> {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set(["file", "project", "vault", "section", "yes", "cwd", "wait"]));
+	if (!optionalBooleanParam(record.yes, "yes")) {
+		throw new Error("vault.import RPC requires yes=true to avoid an interactive confirmation.");
+	}
+	const args = ["vault", "import", requiredStringParam(record, "file"), "--yes"];
+	appendOptionalStringFlag(args, "--project", record.project);
+	appendOptionalStringFlag(args, "--vault", record.vault);
+	appendOptionalStringFlag(args, "--section", record.section);
+	return runCommandRpc({
+		name: "vault.import",
+		args,
+		cwd: optionalStringParam(record.cwd, "cwd"),
+		wait: optionalBooleanParam(record.wait, "wait") ?? true,
+	});
+}
+
+function vaultAttachRpc(params: unknown): Promise<unknown> {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set(["vault", "project", "cwd", "wait"]));
+	const args = ["vault", "attach", requiredStringParam(record, "vault")];
+	args.push("--project", requiredStringParam(record, "project"));
+	return runCommandRpc({
+		name: "vault.attach",
+		args,
+		cwd: optionalStringParam(record.cwd, "cwd"),
+		wait: optionalBooleanParam(record.wait, "wait") ?? true,
+	});
+}
+
+function vaultDetachRpc(params: unknown): Promise<unknown> {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set(["vault", "project", "cwd", "wait"]));
+	const args = ["vault", "detach", requiredStringParam(record, "vault")];
+	args.push("--project", requiredStringParam(record, "project"));
+	return runCommandRpc({
+		name: "vault.detach",
+		args,
+		cwd: optionalStringParam(record.cwd, "cwd"),
+		wait: optionalBooleanParam(record.wait, "wait") ?? true,
+	});
+}
+
+function vaultRmRpc(params: unknown): Promise<unknown> {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set(["key", "project", "yes", "global", "cwd", "wait"]));
+	if (!optionalBooleanParam(record.yes, "yes")) {
+		throw new Error("vault.rm RPC requires yes=true to avoid an interactive confirmation.");
+	}
+	const args = ["vault", "rm", requiredStringParam(record, "key"), "--yes"];
+	appendOptionalStringFlag(args, "--project", record.project);
+	if (optionalBooleanParam(record.global, "global")) args.push("--global");
+	return runCommandRpc({
+		name: "vault.rm",
+		args,
+		cwd: optionalStringParam(record.cwd, "cwd"),
+		wait: optionalBooleanParam(record.wait, "wait") ?? true,
+	});
+}
+
+function vaultResolveRpc(params: unknown): Promise<unknown> {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(
+		record,
+		new Set([
+			"key",
+			"project",
+			"agent",
+			"allow_conflicts",
+			"debug",
+			"dry_run",
+			"include_value",
+			"confirm_secret_access",
+			"json",
+			"cwd",
+			"wait",
+		]),
+	);
+	const includeValue = optionalBooleanParam(record.include_value, "include_value") ?? false;
+	const wait = optionalBooleanParam(record.wait, "wait") ?? true;
+	if (includeValue) {
+		requireBooleanConfirmation(record, "confirm_secret_access", "vault.resolve plaintext access");
+		if (!wait)
+			throw new Error(
+				"vault.resolve with include_value=true cannot run as a background operation.",
+			);
+	}
+	const args = ["vault", "resolve", requiredStringParam(record, "key")];
+	appendVaultResolveFlags(args, record);
+	if (!includeValue || optionalBooleanParam(record.dry_run, "dry_run")) args.push("--dry-run");
+	if (optionalBooleanParam(record.json, "json")) args.push("--json");
+	return runCommandRpc({
+		name: "vault.resolve",
+		args,
+		cwd: optionalStringParam(record.cwd, "cwd"),
+		wait,
+		parseJson: optionalBooleanParam(record.json, "json") ?? false,
+	});
+}
+
+function vaultReadRpc(params: unknown): Promise<unknown> {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(
+		record,
+		new Set([
+			"reference",
+			"project",
+			"agent",
+			"allow_conflicts",
+			"debug",
+			"dry_run",
+			"confirm_secret_access",
+			"json",
+			"cwd",
+			"wait",
+		]),
+	);
+	const dryRun = optionalBooleanParam(record.dry_run, "dry_run") ?? false;
+	const wait = optionalBooleanParam(record.wait, "wait") ?? true;
+	if (!dryRun) {
+		requireBooleanConfirmation(record, "confirm_secret_access", "vault.read plaintext access");
+		if (!wait) throw new Error("vault.read plaintext access cannot run as a background operation.");
+	}
+	const args = ["read", requiredStringParam(record, "reference")];
+	appendVaultResolveFlags(args, record);
+	if (dryRun) args.push("--dry-run");
+	if (optionalBooleanParam(record.json, "json")) args.push("--json");
+	return runCommandRpc({
+		name: "vault.read",
+		args,
+		cwd: optionalStringParam(record.cwd, "cwd"),
+		wait,
+		parseJson: optionalBooleanParam(record.json, "json") ?? false,
+	});
+}
+
+function vaultInjectRpc(params: unknown): Promise<unknown> {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(
+		record,
+		new Set([
+			"in",
+			"out",
+			"input",
+			"project",
+			"agent",
+			"allow_conflicts",
+			"no_project_folder",
+			"force",
+			"dry_run",
+			"confirm_secret_access",
+			"cwd",
+			"wait",
+		]),
+	);
+	const dryRun = optionalBooleanParam(record.dry_run, "dry_run") ?? false;
+	if (!dryRun)
+		requireBooleanConfirmation(record, "confirm_secret_access", "vault.inject secret rendering");
+	const args = ["inject"];
+	const stdin = optionalStringParam(record.input, "input");
+	const inPath = optionalStringParam(record.in, "in") ?? (stdin !== undefined ? "-" : undefined);
+	appendOptionalStringFlag(args, "--in", inPath);
+	appendOptionalStringFlag(args, "--out", record.out);
+	appendOptionalStringFlag(args, "--project", record.project);
+	appendOptionalStringFlag(args, "--agent", record.agent);
+	if (optionalBooleanParam(record.allow_conflicts, "allow_conflicts"))
+		args.push("--allow-conflicts");
+	if (optionalBooleanParam(record.no_project_folder, "no_project_folder"))
+		args.push("--no-project-folder");
+	if (optionalBooleanParam(record.force, "force")) args.push("--force");
+	if (dryRun) args.push("--dry-run");
+	return runCommandRpc({
+		name: "vault.inject",
+		args,
+		cwd: optionalStringParam(record.cwd, "cwd"),
+		stdin,
+		wait: optionalBooleanParam(record.wait, "wait") ?? true,
+	});
+}
+
+function authStatusRpc(params: unknown): unknown {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set());
+	const auth = getAuth();
+	const pending = getPendingAuth();
+	return {
+		logged_in: auth !== null,
+		user: auth ? { email: auth.email, id: auth.userId } : null,
+		api_url: getConfig().apiUrl,
+		pending_auth: pending
+			? {
+					user_code: pending.userCode,
+					verification_uri: pending.verificationUri,
+					expires_at: pending.expiresAt,
+					interval_ms: pending.intervalMs,
+					api_url: pending.apiUrl,
+				}
+			: null,
+	};
+}
+
+async function authLoginRpc(params: unknown): Promise<unknown> {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set(["api_key", "api_url", "replace", "confirm_secret_access"]));
+	const existing = getAuth();
+	const replace = optionalBooleanParam(record.replace, "replace") ?? false;
+	if (existing && !replace) {
+		return { status: "already_logged_in", user: { email: existing.email, id: existing.userId } };
+	}
+	if (existing && replace) {
+		requireBooleanConfirmation(record, "confirm_secret_access", "auth.login replace existing auth");
+	}
+	const apiUrl = optionalStringParam(record.api_url, "api_url") ?? getConfig().apiUrl;
+	const apiKey = optionalStringParam(record.api_key, "api_key");
+	if (apiKey) {
+		requireBooleanConfirmation(record, "confirm_secret_access", "auth.login API key import");
+		const me = await verifyAndSaveRpcAuth(apiUrl, apiKey);
+		return { status: "logged_in", user: me, api_url: apiUrl };
+	}
+	return startDeviceAuthRpc(apiUrl);
+}
+
+async function authCompleteRpc(params: unknown): Promise<unknown> {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set(["wait_ms"]));
+	if (getAuth()) return { status: "already_logged_in" };
+	const pending = getPendingAuth();
+	if (!pending) return { status: "no_pending_auth" };
+	if (Date.now() / 1000 >= pending.expiresAt) {
+		clearPendingAuth();
+		return { status: "expired" };
+	}
+	return pollPendingAuthRpc(
+		pending,
+		optionalLimitParam(record.wait_ms, "wait_ms", 0, 600_000, 30_000),
+	);
+}
+
+function authLogoutRpc(params: unknown): unknown {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set(["confirm"]));
+	requireBooleanConfirmation(record, "confirm", "auth.logout");
+	const wasLoggedIn = isLoggedIn();
+	clearAuth();
+	clearPendingAuth();
+	return { logged_out: wasLoggedIn };
+}
+
+function updateCheckRpc(params: unknown): Promise<unknown> {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set(["cwd"]));
+	return runCommandRpc({
+		name: "update.check",
+		args: ["update", "--json"],
+		cwd: optionalStringParam(record.cwd, "cwd"),
+		wait: true,
+		parseJson: true,
+	});
+}
+
+async function updateInstallRpc(params: unknown): Promise<unknown> {
+	const record = rpcParamsRecord(params);
+	rejectRpcParams(record, new Set(["confirm"]));
+	requireBooleanConfirmation(record, "confirm", "update.install");
+	const result = await daemonAutoUpdateOnce({
+		currentVersion: getCliVersion(),
+		ignoreDisabled: true,
+	});
+	return { result };
+}
+
+async function runCommandRpc(options: RpcCommandOptions): Promise<unknown> {
+	if (!options.wait) {
+		return {
+			operation: operationManager.start({
+				name: options.name,
+				args: options.args,
+				cwd: options.cwd,
+				stdin: options.stdin,
+				redactedArgs: options.redactedArgs,
+			}),
+		};
+	}
+	const result = await runCliCommandImmediate({
+		name: options.name,
+		args: options.args,
+		cwd: options.cwd,
+		stdin: options.stdin,
+		redactedArgs: options.redactedArgs,
+		timeoutMs: options.timeoutMs,
+	});
+	const response: RpcCommandResponse = { ...result };
+	if (options.parseJson && result.stdout.trim()) {
+		response.json = JSON.parse(result.stdout);
+	}
+	return response;
+}
+
+function appendVaultResolveFlags(args: string[], record: Record<string, unknown>): void {
+	appendOptionalStringFlag(args, "--project", record.project);
+	appendOptionalStringFlag(args, "--agent", record.agent);
+	if (optionalBooleanParam(record.allow_conflicts, "allow_conflicts"))
+		args.push("--allow-conflicts");
+	if (optionalBooleanParam(record.debug, "debug")) args.push("--debug");
+}
+
+function appendOptionalStringFlag(args: string[], flag: string, value: unknown): void {
+	const parsed = optionalStringParam(value, flag);
+	if (parsed !== undefined) args.push(flag, parsed);
+}
+
+interface AuthMeResponse {
+	id: string;
+	email?: string;
+	name?: string;
+}
+
+interface DeviceStartResponse {
+	device_code: string;
+	user_code: string;
+	verification_uri: string;
+	expires_in: number;
+	interval: number;
+}
+
+interface AuthPollResponse {
+	status: string;
+	api_key?: string | null;
+}
+
+async function verifyAndSaveRpcAuth(apiUrl: string, apiKey: string): Promise<AuthMeResponse> {
+	setAuth({ apiKey });
+	const response = await fetch(`${apiUrl}/api/auth/me`, {
+		headers: { Authorization: `Bearer ${apiKey}` },
+	});
+	if (!response.ok) {
+		clearAuth();
+		throw new Error(`API key verification failed with HTTP ${response.status}`);
+	}
+	const me = await readJsonObject<AuthMeResponse>(response, isAuthMeResponse, "/api/auth/me");
+	setAuth({ apiKey, userId: me.id, email: me.email });
+	return me;
+}
+
+async function startDeviceAuthRpc(apiUrl: string): Promise<unknown> {
+	const response = await fetch(`${apiUrl}/api/cli/auth/device`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ client_label: `clawdi daemon rpc · ${hostname()}` }),
+	});
+	if (!response.ok) {
+		throw new Error(`Failed to start device authorization: HTTP ${response.status}`);
+	}
+	const start = await readJsonObject<DeviceStartResponse>(
+		response,
+		isDeviceStartResponse,
+		"/api/cli/auth/device",
+	);
+	const pending = {
+		deviceCode: start.device_code,
+		userCode: start.user_code,
+		verificationUri: start.verification_uri,
+		expiresAt: Math.floor(Date.now() / 1000) + start.expires_in,
+		intervalMs: Math.max(1, start.interval) * 1000,
+		apiUrl,
+	};
+	setPendingAuth(pending);
+	return {
+		status: "pending",
+		user_code: pending.userCode,
+		verification_uri: pending.verificationUri,
+		expires_at: pending.expiresAt,
+		interval_ms: pending.intervalMs,
+		api_url: pending.apiUrl,
+	};
+}
+
+async function pollPendingAuthRpc(
+	pending: NonNullable<ReturnType<typeof getPendingAuth>>,
+	waitMs: number,
+): Promise<unknown> {
+	const deadline = Date.now() + waitMs;
+	while (true) {
+		const poll = await pollAuthOnce(pending.apiUrl, pending.deviceCode);
+		if (poll.status === "approved" && poll.api_key) {
+			setAuth({ apiKey: poll.api_key });
+			const me = await verifyAndSaveRpcAuth(pending.apiUrl, poll.api_key);
+			clearPendingAuth();
+			return { status: "logged_in", user: me };
+		}
+		if (poll.status === "denied" || poll.status === "expired") {
+			clearPendingAuth();
+			return { status: poll.status };
+		}
+		if (Date.now() >= deadline || waitMs === 0) {
+			return {
+				status: "pending",
+				user_code: pending.userCode,
+				expires_at: pending.expiresAt,
+			};
+		}
+		await new Promise((resolve) =>
+			setTimeout(resolve, Math.min(pending.intervalMs, Math.max(0, deadline - Date.now()))),
+		);
+	}
+}
+
+async function pollAuthOnce(apiUrl: string, deviceCode: string): Promise<AuthPollResponse> {
+	const response = await fetch(`${apiUrl}/api/cli/auth/poll`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ device_code: deviceCode }),
+	});
+	if (!response.ok) throw new Error(`Auth polling failed with HTTP ${response.status}`);
+	return readJsonObject<AuthPollResponse>(response, isAuthPollResponse, "/api/cli/auth/poll");
+}
+
+async function readJsonObject<T>(
+	response: Response,
+	guard: (value: unknown) => value is T,
+	label: string,
+): Promise<T> {
+	const value: unknown = await response.json();
+	if (!guard(value)) throw new Error(`Unexpected response body from ${label}`);
+	return value;
+}
+
+function isAuthMeResponse(value: unknown): value is AuthMeResponse {
+	if (!isRecord(value)) return false;
+	return typeof value.id === "string";
+}
+
+function isDeviceStartResponse(value: unknown): value is DeviceStartResponse {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.device_code === "string" &&
+		typeof value.user_code === "string" &&
+		typeof value.verification_uri === "string" &&
+		typeof value.expires_in === "number" &&
+		typeof value.interval === "number"
+	);
+}
+
+function isAuthPollResponse(value: unknown): value is AuthPollResponse {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.status === "string" &&
+		(value.api_key === undefined || value.api_key === null || typeof value.api_key === "string")
+	);
 }
 
 function daemonInstallRpc(params: unknown): unknown {
@@ -788,11 +1426,32 @@ function rpcParamsRecord(params: unknown): Record<string, unknown> {
 	return params as Record<string, unknown>;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requiredStringParam(record: Record<string, unknown>, key: string): string {
+	const value = optionalStringParam(record[key], key);
+	if (value === undefined) throw new Error(`${key} is required`);
+	return value;
+}
+
 function optionalStringParam(value: unknown, label: string): string | undefined {
 	if (value === undefined || value === null) return undefined;
 	if (typeof value !== "string") throw new Error(`${label} must be a string`);
 	if (!value.trim()) throw new Error(`${label} must not be empty`);
 	return value;
+}
+
+function optionalStringListParam(value: unknown, label: string): string[] | undefined {
+	if (value === undefined || value === null) return undefined;
+	if (typeof value === "string") return [optionalStringParam(value, label) ?? ""];
+	if (!Array.isArray(value)) throw new Error(`${label} must be a string or string array`);
+	const items: string[] = [];
+	for (const item of value) {
+		items.push(optionalStringParam(item, label) ?? "");
+	}
+	return items;
 }
 
 function optionalAgentParam(value: unknown): AgentType | undefined {
@@ -882,6 +1541,38 @@ function optionalLogLimitParam(value: unknown): number {
 		throw new Error("limit must be an integer from 1 to 1000");
 	}
 	return limit;
+}
+
+function optionalLimitParam(
+	value: unknown,
+	label: string,
+	min: number,
+	max: number,
+	defaultValue: number,
+): number {
+	if (value === undefined || value === null) return defaultValue;
+	let parsed: number;
+	if (typeof value === "number") {
+		parsed = value;
+	} else if (typeof value === "string" && /^\d+$/.test(value.trim())) {
+		parsed = Number(value);
+	} else {
+		throw new Error(`${label} must be an integer from ${min} to ${max}`);
+	}
+	if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+		throw new Error(`${label} must be an integer from ${min} to ${max}`);
+	}
+	return parsed;
+}
+
+function requireBooleanConfirmation(
+	record: Record<string, unknown>,
+	key: string,
+	action: string,
+): void {
+	if (optionalBooleanParam(record[key], key) !== true) {
+		throw new Error(`${action} requires ${key}=true.`);
+	}
 }
 
 function isLoopbackRpcHost(host: string): boolean {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -170,19 +170,15 @@ async function registerEnv(
 	}
 }
 
-function installDaemon(agentType: AgentType) {
+function installDaemonForAllRegisteredAgents() {
 	try {
-		const result = installDaemonService({ agent: agentType });
+		const result = installDaemonService();
 		const verb = result.replaced ? "updated" : "installed";
-		console.log(chalk.green(`✓ Daemon ${verb} for ${adapterRegistry[agentType].displayName}`));
+		console.log(chalk.green(`✓ Singleton daemon ${verb}`));
 		console.log(chalk.gray(`  ${result.instructions}`));
 	} catch (e) {
-		console.log(
-			chalk.yellow(
-				`⚠ Could not install daemon for ${adapterRegistry[agentType].displayName}: ${errMessage(e)}`,
-			),
-		);
-		console.log(chalk.gray(`  Run manually: clawdi daemon install --agent ${agentType}`));
+		console.log(chalk.yellow(`⚠ Could not install daemon: ${errMessage(e)}`));
+		console.log(chalk.gray("  Run manually: clawdi daemon install"));
 	}
 }
 
@@ -211,10 +207,8 @@ function installDaemonsForRegisteredAgents() {
 		return;
 	}
 	console.log();
-	console.log(chalk.cyan("Installing background sync daemons..."));
-	for (const agentType of registered) {
-		installDaemon(agentType);
-	}
+	console.log(chalk.cyan("Installing background sync daemon..."));
+	installDaemonForAllRegisteredAgents();
 }
 
 async function installBuiltinSkill(agentType: AgentType) {

--- a/packages/cli/src/commands/setup.ts
+++ b/packages/cli/src/commands/setup.ts
@@ -19,7 +19,11 @@ import { getClawdiDir, isLoggedIn } from "../lib/config";
 import { errMessage } from "../lib/errors";
 import { listRegisteredAgentTypes } from "../lib/select-adapter";
 import { isInteractive } from "../lib/tty";
-import { install as installDaemonService } from "../serve/installer";
+import {
+	install as installDaemonService,
+	listInstalledAgents,
+	uninstall as uninstallDaemonService,
+} from "../serve/installer";
 
 interface SetupOpts {
 	agent?: string;
@@ -176,10 +180,32 @@ function installDaemonForAllRegisteredAgents() {
 		const verb = result.replaced ? "updated" : "installed";
 		console.log(chalk.green(`✓ Singleton daemon ${verb}`));
 		console.log(chalk.gray(`  ${result.instructions}`));
+		const failed = cleanupLegacyDaemonUnits();
+		if (failed > 0) process.exitCode = 1;
 	} catch (e) {
 		console.log(chalk.yellow(`⚠ Could not install daemon: ${errMessage(e)}`));
 		console.log(chalk.gray("  Run manually: clawdi daemon install"));
 	}
+}
+
+function cleanupLegacyDaemonUnits(): number {
+	let failed = 0;
+	for (const agentType of listInstalledAgents()) {
+		try {
+			const result = uninstallDaemonService({ agent: agentType });
+			if (result.removed) {
+				console.log(chalk.green(`✓ Removed legacy per-agent daemon unit for ${agentType}`));
+			}
+		} catch (e) {
+			console.log(
+				chalk.yellow(
+					`⚠ Could not remove legacy per-agent daemon unit for ${agentType}: ${errMessage(e)}`,
+				),
+			);
+			failed += 1;
+		}
+	}
+	return failed;
 }
 
 async function shouldInstallDaemons(opts: SetupOpts): Promise<boolean> {

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -13,8 +13,9 @@ import {
 import { dirname, join, normalize, resolve, sep } from "node:path";
 import chalk from "chalk";
 import { getClawdiDir, getStoredConfig } from "../lib/config";
+import { listRegisteredAgentTypes } from "../lib/select-adapter";
 import { getCliVersion } from "../lib/version";
-import { listInstalledAgents, readHealth } from "../serve/installer";
+import { isSingletonDaemonInstalled, listInstalledAgents, readHealth } from "../serve/installer";
 import { log } from "../serve/log";
 import { getServeStateDir } from "../serve/paths";
 
@@ -396,7 +397,10 @@ function isInformationalInvocation(args = process.argv.slice(2)): boolean {
 
 function outdatedDaemonAgents(current: string): string[] {
 	try {
-		return listInstalledAgents().filter((agent) => {
+		const targets = isSingletonDaemonInstalled()
+			? listRegisteredAgentTypes()
+			: listInstalledAgents();
+		return targets.filter((agent) => {
 			const health = readHealth(getServeStateDir(agent));
 			if (!health.exists) return false;
 			if (!health.version) return true;
@@ -618,11 +622,7 @@ export async function maybeAutoUpdate(runtime: AutoUpdateRuntime = {}): Promise<
 				);
 				const outdatedDaemons = outdatedDaemonAgents(current);
 				if (outdatedDaemons.length > 0) {
-					console.log(
-						chalk.gray(
-							`  Restart ${outdatedDaemons.length === 1 ? "the daemon" : "daemons"} to pick it up: clawdi daemon restart --all`,
-						),
-					);
+					console.log(chalk.gray("  Restart the daemon to pick it up: clawdi daemon restart"));
 				}
 			}
 		}

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -517,10 +517,11 @@ export async function daemonAutoUpdateOnce(
 		currentVersion?: string;
 		installer?: Installer | null;
 		installRunner?: InstallRunner;
+		ignoreDisabled?: boolean;
 		signal?: AbortSignal;
 	} = {},
 ): Promise<DaemonAutoUpdateResult> {
-	if (autoUpdateDisabled()) return "disabled";
+	if (!opts.ignoreDisabled && autoUpdateDisabled()) return "disabled";
 	if (opts.signal?.aborted) return "disabled";
 
 	const current = opts.currentVersion ?? getCliVersion();

--- a/packages/cli/src/lib/sessions-lock.ts
+++ b/packages/cli/src/lib/sessions-lock.ts
@@ -73,13 +73,13 @@ export function writeSessionsLock(lock: SessionsLock): void {
 		if (entry) sortedSessions[key] = entry;
 	}
 	const sorted: SessionsLock = { version: lock.version, sessions: sortedSessions };
-	// Atomic write: temp file + rename. `--all` mode runs N daemons
-	// (one per agent) on the same machine, all sharing this single
-	// lock file. Without atomic rename the read-modify-write would
-	// truncate-and-overwrite, allowing two daemons writing within
-	// the same OS-scheduled tick to lose each other's keys (or
-	// produce a half-written file the next reader rejects). The
-	// rename is atomic on POSIX so the worst case is "one daemon's
+	// Atomic write: temp file + rename. The singleton daemon runs
+	// multiple agent engines on the same machine, all sharing this
+	// single lock file. Without atomic rename the read-modify-write
+	// would truncate-and-overwrite, allowing two engines writing
+	// within the same OS-scheduled tick to lose each other's keys
+	// (or produce a half-written file the next reader rejects). The
+	// rename is atomic on POSIX so the worst case is "one engine's
 	// hash didn't land, next push catches it" — never corruption.
 	const tmp = `${path}.tmp.${process.pid}`;
 	writeFileSync(tmp, `${JSON.stringify(sorted, null, 2)}\n`, { mode: 0o600 });

--- a/packages/cli/src/serve/control-rpc.test.ts
+++ b/packages/cli/src/serve/control-rpc.test.ts
@@ -40,25 +40,26 @@ if (process.platform !== "win32") {
 			rmSync(tmpHome, { recursive: true, force: true });
 		});
 
-		it("serves JSON-RPC methods over the daemon control socket", async () => {
+		it("serves JSON-RPC methods over HTTP", async () => {
 			const server = await startControlRpcServer(
 				{
 					"daemon.echo": (params) => ({ params }),
 				},
 				abort.signal,
+				{ port: 0 },
 			);
 			closeServer = server.close;
 
-			const result = await callControlRpc("daemon.echo", { ok: true });
+			const result = await callControlRpc("daemon.echo", { ok: true }, server.http);
 
 			expect(result).toEqual({ params: { ok: true } });
 		});
 
 		it("returns JSON-RPC errors for unknown methods", async () => {
-			const server = await startControlRpcServer({}, abort.signal);
+			const server = await startControlRpcServer({}, abort.signal, { port: 0 });
 			closeServer = server.close;
 
-			await expect(callControlRpc("daemon.missing")).rejects.toThrow(
+			await expect(callControlRpc("daemon.missing", {}, server.http)).rejects.toThrow(
 				"Unknown RPC method: daemon.missing",
 			);
 		});
@@ -73,7 +74,7 @@ if (process.platform !== "win32") {
 			);
 			closeServer = server.close;
 
-			const result = await callControlRpc("daemon.echo", { via: "http" }, server.http ?? undefined);
+			const result = await callControlRpc("daemon.echo", { via: "http" }, server.http);
 
 			expect(result).toEqual({ params: { via: "http" } });
 		});
@@ -93,7 +94,6 @@ if (process.platform !== "win32") {
 				{ host: "127.0.0.1", port: 0 },
 			);
 			closeServer = server.close;
-			if (!server.http) throw new Error("expected HTTP listener");
 
 			const response = await postWithoutToken(server.http.host, server.http.port);
 
@@ -110,7 +110,6 @@ if (process.platform !== "win32") {
 				{ host: "127.0.0.1", port: 0 },
 			);
 			closeServer = server.close;
-			if (!server.http) throw new Error("expected HTTP listener");
 			const token = readFileSync(getDaemonControlTokenPath(), "utf-8").trim();
 
 			const result = await callControlRpc(
@@ -131,7 +130,7 @@ if (process.platform !== "win32") {
 			writeFileSync(tokenPath, "fixed-token\n", { mode: 0o644 });
 			chmodSync(tokenPath, 0o644);
 
-			const server = await startControlRpcServer({}, abort.signal);
+			const server = await startControlRpcServer({}, abort.signal, { port: 0 });
 			closeServer = server.close;
 
 			expect(statSync(tokenPath).mode & 0o777).toBe(0o600);
@@ -147,7 +146,6 @@ if (process.platform !== "win32") {
 				{ host: "127.0.0.1", port: 0 },
 			);
 			closeServer = server.close;
-			if (!server.http) throw new Error("expected HTTP listener");
 			const oldToken = readFileSync(getDaemonControlTokenPath(), "utf-8").trim();
 
 			const rotated = (await callControlRpc("daemon.rotate_token", {}, server.http)) as {
@@ -187,7 +185,6 @@ if (process.platform !== "win32") {
 				{ host: "0.0.0.0", port: 0, allowRemote: true },
 			);
 			closeServer = server.close;
-			if (!server.http) throw new Error("expected HTTP listener");
 			const token = readFileSync(getDaemonControlTokenPath(), "utf-8").trim();
 
 			const result = await callControlRpc(

--- a/packages/cli/src/serve/control-rpc.test.ts
+++ b/packages/cli/src/serve/control-rpc.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
+import { request } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { callControlRpc, startControlRpcServer } from "./control-rpc";
+import { getDaemonControlTokenPath } from "./paths";
 
 if (process.platform !== "win32") {
 	describe("control RPC", () => {
@@ -52,5 +54,95 @@ if (process.platform !== "win32") {
 				"Unknown RPC method: daemon.missing",
 			);
 		});
+
+		it("serves TCP RPC when a host and port are configured", async () => {
+			const server = await startControlRpcServer(
+				{
+					"daemon.echo": (params) => ({ params }),
+				},
+				abort.signal,
+				{ host: "127.0.0.1", port: 0 },
+			);
+			closeServer = server.close;
+
+			const result = await callControlRpc("daemon.echo", { via: "tcp" }, server.tcp ?? undefined);
+
+			expect(result).toEqual({ params: { via: "tcp" } });
+		});
+
+		it("requires a bearer token for TCP RPC access", async () => {
+			const server = await startControlRpcServer(
+				{
+					"daemon.echo": (params) => ({ params }),
+				},
+				abort.signal,
+				{ host: "127.0.0.1", port: 0 },
+			);
+			closeServer = server.close;
+			if (!server.tcp) throw new Error("expected tcp listener");
+
+			const response = await postWithoutToken(server.tcp.host, server.tcp.port);
+
+			expect(response.statusCode).toBe(401);
+			expect(response.body).toContain("unauthorized");
+		});
+
+		it("allows explicit RPC tokens for TCP clients", async () => {
+			const server = await startControlRpcServer(
+				{
+					"daemon.echo": (params) => ({ params }),
+				},
+				abort.signal,
+				{ host: "127.0.0.1", port: 0 },
+			);
+			closeServer = server.close;
+			if (!server.tcp) throw new Error("expected tcp listener");
+			const token = await Bun.file(getDaemonControlTokenPath()).text();
+
+			const result = await callControlRpc(
+				"daemon.echo",
+				{ token: "explicit" },
+				{
+					...server.tcp,
+					token: token.trim(),
+				},
+			);
+
+			expect(result).toEqual({ params: { token: "explicit" } });
+		});
+	});
+}
+
+function postWithoutToken(
+	host: string,
+	port: number,
+): Promise<{ statusCode: number; body: string }> {
+	const body = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "daemon.echo", params: {} });
+	return new Promise((resolve, reject) => {
+		const req = request(
+			{
+				hostname: host,
+				port,
+				path: "/rpc",
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					"Content-Length": Buffer.byteLength(body),
+				},
+			},
+			(res) => {
+				let chunks = "";
+				res.setEncoding("utf-8");
+				res.on("data", (chunk) => {
+					chunks += chunk;
+				});
+				res.on("end", () => {
+					resolve({ statusCode: res.statusCode ?? 0, body: chunks });
+				});
+			},
+		);
+		req.on("error", reject);
+		req.write(body);
+		req.end();
 	});
 }

--- a/packages/cli/src/serve/control-rpc.test.ts
+++ b/packages/cli/src/serve/control-rpc.test.ts
@@ -1,9 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import {
+	chmodSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { request } from "node:http";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { callControlRpc, startControlRpcServer } from "./control-rpc";
+import { dirname, join } from "node:path";
+import { callControlRpc, rotateControlToken, startControlRpcServer } from "./control-rpc";
 import { getDaemonControlTokenPath } from "./paths";
 
 if (process.platform !== "win32") {
@@ -55,7 +63,7 @@ if (process.platform !== "win32") {
 			);
 		});
 
-		it("serves TCP RPC when a host and port are configured", async () => {
+		it("serves HTTP RPC when a host and port are configured", async () => {
 			const server = await startControlRpcServer(
 				{
 					"daemon.echo": (params) => ({ params }),
@@ -65,12 +73,18 @@ if (process.platform !== "win32") {
 			);
 			closeServer = server.close;
 
-			const result = await callControlRpc("daemon.echo", { via: "tcp" }, server.tcp ?? undefined);
+			const result = await callControlRpc("daemon.echo", { via: "http" }, server.http ?? undefined);
 
-			expect(result).toEqual({ params: { via: "tcp" } });
+			expect(result).toEqual({ params: { via: "http" } });
 		});
 
-		it("requires a bearer token for TCP RPC access", async () => {
+		it("rejects non-loopback HTTP listeners unless explicitly allowed", async () => {
+			await expect(
+				startControlRpcServer({}, abort.signal, { host: "0.0.0.0", port: 0 }),
+			).rejects.toThrow("Refusing to listen on non-loopback HTTP RPC host 0.0.0.0");
+		});
+
+		it("requires a bearer token for HTTP RPC access", async () => {
 			const server = await startControlRpcServer(
 				{
 					"daemon.echo": (params) => ({ params }),
@@ -79,15 +93,15 @@ if (process.platform !== "win32") {
 				{ host: "127.0.0.1", port: 0 },
 			);
 			closeServer = server.close;
-			if (!server.tcp) throw new Error("expected tcp listener");
+			if (!server.http) throw new Error("expected HTTP listener");
 
-			const response = await postWithoutToken(server.tcp.host, server.tcp.port);
+			const response = await postWithoutToken(server.http.host, server.http.port);
 
 			expect(response.statusCode).toBe(401);
 			expect(response.body).toContain("unauthorized");
 		});
 
-		it("allows explicit RPC tokens for TCP clients", async () => {
+		it("allows explicit RPC tokens for HTTP clients", async () => {
 			const server = await startControlRpcServer(
 				{
 					"daemon.echo": (params) => ({ params }),
@@ -96,19 +110,72 @@ if (process.platform !== "win32") {
 				{ host: "127.0.0.1", port: 0 },
 			);
 			closeServer = server.close;
-			if (!server.tcp) throw new Error("expected tcp listener");
-			const token = await Bun.file(getDaemonControlTokenPath()).text();
+			if (!server.http) throw new Error("expected HTTP listener");
+			const token = readFileSync(getDaemonControlTokenPath(), "utf-8").trim();
 
 			const result = await callControlRpc(
 				"daemon.echo",
 				{ token: "explicit" },
 				{
-					...server.tcp,
-					token: token.trim(),
+					...server.http,
+					token,
 				},
 			);
 
 			expect(result).toEqual({ params: { token: "explicit" } });
+		});
+
+		it("repairs existing token file permissions on startup", async () => {
+			const tokenPath = getDaemonControlTokenPath();
+			mkdirSync(dirname(tokenPath), { recursive: true });
+			writeFileSync(tokenPath, "fixed-token\n", { mode: 0o644 });
+			chmodSync(tokenPath, 0o644);
+
+			const server = await startControlRpcServer({}, abort.signal);
+			closeServer = server.close;
+
+			expect(statSync(tokenPath).mode & 0o777).toBe(0o600);
+		});
+
+		it("rotates the bearer token without restarting the server", async () => {
+			const server = await startControlRpcServer(
+				{
+					"daemon.echo": (params) => ({ params }),
+					"daemon.rotate_token": () => ({ token: rotateControlToken() }),
+				},
+				abort.signal,
+				{ host: "127.0.0.1", port: 0 },
+			);
+			closeServer = server.close;
+			if (!server.http) throw new Error("expected HTTP listener");
+			const oldToken = readFileSync(getDaemonControlTokenPath(), "utf-8").trim();
+
+			const rotated = (await callControlRpc("daemon.rotate_token", {}, server.http)) as {
+				token: string;
+			};
+
+			expect(rotated.token).not.toBe(oldToken);
+			await expect(
+				callControlRpc(
+					"daemon.echo",
+					{ rejected: true },
+					{
+						...server.http,
+						token: oldToken,
+					},
+				),
+			).rejects.toThrow("unauthorized");
+
+			const result = await callControlRpc(
+				"daemon.echo",
+				{ accepted: true },
+				{
+					...server.http,
+					token: rotated.token,
+				},
+			);
+
+			expect(result).toEqual({ params: { accepted: true } });
 		});
 	});
 }

--- a/packages/cli/src/serve/control-rpc.test.ts
+++ b/packages/cli/src/serve/control-rpc.test.ts
@@ -11,14 +11,7 @@ import {
 import { request } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import {
-	callControlRpc,
-	issueScopedControlToken,
-	rootOnlyRpcHandler,
-	rotateControlToken,
-	startControlRpcServer,
-	withRpcCapabilities,
-} from "./control-rpc";
+import { callControlRpc, rotateControlToken, startControlRpcServer } from "./control-rpc";
 import { getDaemonControlTokenPath } from "./paths";
 
 if (process.platform !== "win32") {
@@ -185,77 +178,25 @@ if (process.platform !== "win32") {
 			expect(result).toEqual({ params: { accepted: true } });
 		});
 
-		it("requires scoped tokens on non-loopback HTTP listeners", async () => {
+		it("allows explicit non-loopback HTTP listeners with the bearer token", async () => {
 			const server = await startControlRpcServer(
 				{
-					"daemon.echo": withRpcCapabilities((params) => ({ params }), ["daemon:read"]),
+					"daemon.echo": (params) => ({ params }),
 				},
 				abort.signal,
 				{ host: "0.0.0.0", port: 0, allowRemote: true },
 			);
 			closeServer = server.close;
 			if (!server.http) throw new Error("expected HTTP listener");
-			const rootToken = readFileSync(getDaemonControlTokenPath(), "utf-8").trim();
+			const token = readFileSync(getDaemonControlTokenPath(), "utf-8").trim();
 
-			await expect(
-				callControlRpc(
-					"daemon.echo",
-					{ rejected: true },
-					{ host: "127.0.0.1", port: server.http.port, token: rootToken },
-				),
-			).rejects.toThrow("root_token_not_allowed_on_remote_http");
-
-			const scoped = issueScopedControlToken({
-				capabilities: ["daemon:read"],
-				expiresInSeconds: 60,
-			});
 			const result = await callControlRpc(
 				"daemon.echo",
 				{ accepted: true },
-				{ host: "127.0.0.1", port: server.http.port, token: scoped.token },
+				{ host: "127.0.0.1", port: server.http.port, token },
 			);
 
 			expect(result).toEqual({ params: { accepted: true } });
-		});
-
-		it("enforces scoped token capabilities per method", async () => {
-			const server = await startControlRpcServer(
-				{
-					"vault.secret": withRpcCapabilities(() => ({ ok: true }), ["vault:secrets"]),
-				},
-				abort.signal,
-				{ host: "127.0.0.1", port: 0 },
-			);
-			closeServer = server.close;
-			if (!server.http) throw new Error("expected HTTP listener");
-			const scoped = issueScopedControlToken({
-				capabilities: ["daemon:read"],
-				expiresInSeconds: 60,
-			});
-
-			await expect(
-				callControlRpc("vault.secret", {}, { ...server.http, token: scoped.token }),
-			).rejects.toThrow("requires RPC capability vault:secrets");
-		});
-
-		it("keeps root-only methods unavailable to scoped tokens", async () => {
-			const server = await startControlRpcServer(
-				{
-					"daemon.rotate_token": rootOnlyRpcHandler(() => ({ rotated: true })),
-				},
-				abort.signal,
-				{ host: "127.0.0.1", port: 0 },
-			);
-			closeServer = server.close;
-			if (!server.http) throw new Error("expected HTTP listener");
-			const scoped = issueScopedControlToken({
-				capabilities: ["daemon:control"],
-				expiresInSeconds: 60,
-			});
-
-			await expect(
-				callControlRpc("daemon.rotate_token", {}, { ...server.http, token: scoped.token }),
-			).rejects.toThrow("requires the daemon root control token");
 		});
 	});
 }

--- a/packages/cli/src/serve/control-rpc.test.ts
+++ b/packages/cli/src/serve/control-rpc.test.ts
@@ -11,7 +11,12 @@ import {
 import { request } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { callControlRpc, rotateControlToken, startControlRpcServer } from "./control-rpc";
+import {
+	callControlRpc,
+	isLoopbackRpcHost,
+	rotateControlToken,
+	startControlRpcServer,
+} from "./control-rpc";
 import { getDaemonControlTokenPath } from "./paths";
 
 if (process.platform !== "win32") {
@@ -83,6 +88,15 @@ if (process.platform !== "win32") {
 			await expect(
 				startControlRpcServer({}, abort.signal, { host: "0.0.0.0", port: 0 }),
 			).rejects.toThrow("Refusing to listen on non-loopback HTTP RPC host 0.0.0.0");
+		});
+
+		it("only treats numeric 127/8 hosts and localhost as loopback", () => {
+			expect(isLoopbackRpcHost("localhost")).toBe(true);
+			expect(isLoopbackRpcHost("127.0.0.1")).toBe(true);
+			expect(isLoopbackRpcHost("127.42.0.1")).toBe(true);
+			expect(isLoopbackRpcHost("[::1]")).toBe(true);
+			expect(isLoopbackRpcHost("127.evil.com")).toBe(false);
+			expect(isLoopbackRpcHost("0.0.0.0")).toBe(false);
 		});
 
 		it("requires a bearer token for HTTP RPC access", async () => {

--- a/packages/cli/src/serve/control-rpc.test.ts
+++ b/packages/cli/src/serve/control-rpc.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { callControlRpc, startControlRpcServer } from "./control-rpc";
+
+if (process.platform !== "win32") {
+	describe("control RPC", () => {
+		const originalClawdiHome = process.env.CLAWDI_HOME;
+		const originalStateDir = process.env.CLAWDI_STATE_DIR;
+		let tmpHome: string;
+		let abort: AbortController;
+		let closeServer: (() => Promise<void>) | undefined;
+
+		beforeEach(() => {
+			tmpHome = mkdtempSync(join(tmpdir(), "clawdi-control-rpc-"));
+			process.env.CLAWDI_HOME = join(tmpHome, ".clawdi");
+			delete process.env.CLAWDI_STATE_DIR;
+			abort = new AbortController();
+			closeServer = undefined;
+		});
+
+		afterEach(async () => {
+			abort.abort();
+			await closeServer?.();
+			if (originalClawdiHome === undefined) delete process.env.CLAWDI_HOME;
+			else process.env.CLAWDI_HOME = originalClawdiHome;
+			if (originalStateDir === undefined) delete process.env.CLAWDI_STATE_DIR;
+			else process.env.CLAWDI_STATE_DIR = originalStateDir;
+			rmSync(tmpHome, { recursive: true, force: true });
+		});
+
+		it("serves JSON-RPC methods over the daemon control socket", async () => {
+			const server = await startControlRpcServer(
+				{
+					"daemon.echo": (params) => ({ params }),
+				},
+				abort.signal,
+			);
+			closeServer = server.close;
+
+			const result = await callControlRpc("daemon.echo", { ok: true });
+
+			expect(result).toEqual({ params: { ok: true } });
+		});
+
+		it("returns JSON-RPC errors for unknown methods", async () => {
+			const server = await startControlRpcServer({}, abort.signal);
+			closeServer = server.close;
+
+			await expect(callControlRpc("daemon.missing")).rejects.toThrow(
+				"Unknown RPC method: daemon.missing",
+			);
+		});
+	});
+}

--- a/packages/cli/src/serve/control-rpc.test.ts
+++ b/packages/cli/src/serve/control-rpc.test.ts
@@ -11,7 +11,14 @@ import {
 import { request } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { callControlRpc, rotateControlToken, startControlRpcServer } from "./control-rpc";
+import {
+	callControlRpc,
+	issueScopedControlToken,
+	rootOnlyRpcHandler,
+	rotateControlToken,
+	startControlRpcServer,
+	withRpcCapabilities,
+} from "./control-rpc";
 import { getDaemonControlTokenPath } from "./paths";
 
 if (process.platform !== "win32") {
@@ -176,6 +183,79 @@ if (process.platform !== "win32") {
 			);
 
 			expect(result).toEqual({ params: { accepted: true } });
+		});
+
+		it("requires scoped tokens on non-loopback HTTP listeners", async () => {
+			const server = await startControlRpcServer(
+				{
+					"daemon.echo": withRpcCapabilities((params) => ({ params }), ["daemon:read"]),
+				},
+				abort.signal,
+				{ host: "0.0.0.0", port: 0, allowRemote: true },
+			);
+			closeServer = server.close;
+			if (!server.http) throw new Error("expected HTTP listener");
+			const rootToken = readFileSync(getDaemonControlTokenPath(), "utf-8").trim();
+
+			await expect(
+				callControlRpc(
+					"daemon.echo",
+					{ rejected: true },
+					{ host: "127.0.0.1", port: server.http.port, token: rootToken },
+				),
+			).rejects.toThrow("root_token_not_allowed_on_remote_http");
+
+			const scoped = issueScopedControlToken({
+				capabilities: ["daemon:read"],
+				expiresInSeconds: 60,
+			});
+			const result = await callControlRpc(
+				"daemon.echo",
+				{ accepted: true },
+				{ host: "127.0.0.1", port: server.http.port, token: scoped.token },
+			);
+
+			expect(result).toEqual({ params: { accepted: true } });
+		});
+
+		it("enforces scoped token capabilities per method", async () => {
+			const server = await startControlRpcServer(
+				{
+					"vault.secret": withRpcCapabilities(() => ({ ok: true }), ["vault:secrets"]),
+				},
+				abort.signal,
+				{ host: "127.0.0.1", port: 0 },
+			);
+			closeServer = server.close;
+			if (!server.http) throw new Error("expected HTTP listener");
+			const scoped = issueScopedControlToken({
+				capabilities: ["daemon:read"],
+				expiresInSeconds: 60,
+			});
+
+			await expect(
+				callControlRpc("vault.secret", {}, { ...server.http, token: scoped.token }),
+			).rejects.toThrow("requires RPC capability vault:secrets");
+		});
+
+		it("keeps root-only methods unavailable to scoped tokens", async () => {
+			const server = await startControlRpcServer(
+				{
+					"daemon.rotate_token": rootOnlyRpcHandler(() => ({ rotated: true })),
+				},
+				abort.signal,
+				{ host: "127.0.0.1", port: 0 },
+			);
+			closeServer = server.close;
+			if (!server.http) throw new Error("expected HTTP listener");
+			const scoped = issueScopedControlToken({
+				capabilities: ["daemon:control"],
+				expiresInSeconds: 60,
+			});
+
+			await expect(
+				callControlRpc("daemon.rotate_token", {}, { ...server.http, token: scoped.token }),
+			).rejects.toThrow("requires the daemon root control token");
 		});
 	});
 }

--- a/packages/cli/src/serve/control-rpc.test.ts
+++ b/packages/cli/src/serve/control-rpc.test.ts
@@ -48,14 +48,14 @@ if (process.platform !== "win32") {
 		it("serves JSON-RPC methods over HTTP", async () => {
 			const server = await startControlRpcServer(
 				{
-					"daemon.echo": (params) => ({ params }),
+					echo: (params) => ({ params }),
 				},
 				abort.signal,
 				{ port: 0 },
 			);
 			closeServer = server.close;
 
-			const result = await callControlRpc("daemon.echo", { ok: true }, server.http);
+			const result = await callControlRpc("echo", { ok: true }, server.http);
 
 			expect(result).toEqual({ params: { ok: true } });
 		});
@@ -64,22 +64,22 @@ if (process.platform !== "win32") {
 			const server = await startControlRpcServer({}, abort.signal, { port: 0 });
 			closeServer = server.close;
 
-			await expect(callControlRpc("daemon.missing", {}, server.http)).rejects.toThrow(
-				"Unknown RPC method: daemon.missing",
+			await expect(callControlRpc("missing", {}, server.http)).rejects.toThrow(
+				"Unknown RPC method: missing",
 			);
 		});
 
 		it("serves HTTP RPC when a host and port are configured", async () => {
 			const server = await startControlRpcServer(
 				{
-					"daemon.echo": (params) => ({ params }),
+					echo: (params) => ({ params }),
 				},
 				abort.signal,
 				{ host: "127.0.0.1", port: 0 },
 			);
 			closeServer = server.close;
 
-			const result = await callControlRpc("daemon.echo", { via: "http" }, server.http);
+			const result = await callControlRpc("echo", { via: "http" }, server.http);
 
 			expect(result).toEqual({ params: { via: "http" } });
 		});
@@ -102,7 +102,7 @@ if (process.platform !== "win32") {
 		it("requires a bearer token for HTTP RPC access", async () => {
 			const server = await startControlRpcServer(
 				{
-					"daemon.echo": (params) => ({ params }),
+					echo: (params) => ({ params }),
 				},
 				abort.signal,
 				{ host: "127.0.0.1", port: 0 },
@@ -118,7 +118,7 @@ if (process.platform !== "win32") {
 		it("allows explicit RPC tokens for HTTP clients", async () => {
 			const server = await startControlRpcServer(
 				{
-					"daemon.echo": (params) => ({ params }),
+					echo: (params) => ({ params }),
 				},
 				abort.signal,
 				{ host: "127.0.0.1", port: 0 },
@@ -127,7 +127,7 @@ if (process.platform !== "win32") {
 			const token = readFileSync(getDaemonControlTokenPath(), "utf-8").trim();
 
 			const result = await callControlRpc(
-				"daemon.echo",
+				"echo",
 				{ token: "explicit" },
 				{
 					...server.http,
@@ -153,8 +153,8 @@ if (process.platform !== "win32") {
 		it("rotates the bearer token without restarting the server", async () => {
 			const server = await startControlRpcServer(
 				{
-					"daemon.echo": (params) => ({ params }),
-					"daemon.rotate_token": () => ({ token: rotateControlToken() }),
+					echo: (params) => ({ params }),
+					rotate_token: () => ({ token: rotateControlToken() }),
 				},
 				abort.signal,
 				{ host: "127.0.0.1", port: 0 },
@@ -162,14 +162,14 @@ if (process.platform !== "win32") {
 			closeServer = server.close;
 			const oldToken = readFileSync(getDaemonControlTokenPath(), "utf-8").trim();
 
-			const rotated = (await callControlRpc("daemon.rotate_token", {}, server.http)) as {
+			const rotated = (await callControlRpc("rotate_token", {}, server.http)) as {
 				token: string;
 			};
 
 			expect(rotated.token).not.toBe(oldToken);
 			await expect(
 				callControlRpc(
-					"daemon.echo",
+					"echo",
 					{ rejected: true },
 					{
 						...server.http,
@@ -179,7 +179,7 @@ if (process.platform !== "win32") {
 			).rejects.toThrow("unauthorized");
 
 			const result = await callControlRpc(
-				"daemon.echo",
+				"echo",
 				{ accepted: true },
 				{
 					...server.http,
@@ -193,7 +193,7 @@ if (process.platform !== "win32") {
 		it("allows explicit non-loopback HTTP listeners with the bearer token", async () => {
 			const server = await startControlRpcServer(
 				{
-					"daemon.echo": (params) => ({ params }),
+					echo: (params) => ({ params }),
 				},
 				abort.signal,
 				{ host: "0.0.0.0", port: 0, allowRemote: true },
@@ -202,7 +202,7 @@ if (process.platform !== "win32") {
 			const token = readFileSync(getDaemonControlTokenPath(), "utf-8").trim();
 
 			const result = await callControlRpc(
-				"daemon.echo",
+				"echo",
 				{ accepted: true },
 				{ host: "127.0.0.1", port: server.http.port, token },
 			);
@@ -216,7 +216,7 @@ function postWithoutToken(
 	host: string,
 	port: number,
 ): Promise<{ statusCode: number; body: string }> {
-	const body = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "daemon.echo", params: {} });
+	const body = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "echo", params: {} });
 	return new Promise((resolve, reject) => {
 		const req = request(
 			{

--- a/packages/cli/src/serve/control-rpc.ts
+++ b/packages/cli/src/serve/control-rpc.ts
@@ -1,21 +1,17 @@
 import { randomBytes, timingSafeEqual } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import {
 	createServer,
 	type IncomingMessage,
-	type RequestOptions,
 	request,
 	type Server,
 	type ServerResponse,
 } from "node:http";
-import { type AddressInfo, createConnection } from "node:net";
-import {
-	getDaemonControlDir,
-	getDaemonControlSocketPath,
-	getDaemonControlTokenPath,
-} from "./paths";
+import { getDaemonControlDir, getDaemonControlTokenPath } from "./paths";
 
 const MAX_RPC_BODY_BYTES = 1024 * 1024;
+export const DEFAULT_CONTROL_RPC_HOST = "127.0.0.1";
+export const DEFAULT_CONTROL_RPC_PORT = 17654;
 
 export type ControlRpcHandler = (params: unknown) => Promise<unknown> | unknown;
 export type ControlRpcHandlers = Record<string, ControlRpcHandler>;
@@ -40,9 +36,8 @@ interface JsonRpcRequest {
 }
 
 interface ControlRpcServer {
-	socketPath: string;
 	tokenPath: string;
-	http: { host: string; port: number } | null;
+	http: { host: string; port: number };
 	close: () => Promise<void>;
 }
 
@@ -51,17 +46,13 @@ export async function startControlRpcServer(
 	abort: AbortSignal,
 	config: ControlRpcListenConfig = {},
 ): Promise<ControlRpcServer> {
-	if (process.platform === "win32") {
-		throw new Error("daemon control RPC is not supported on Windows yet");
-	}
-	if (config.port !== undefined) {
-		const host = config.host ?? "127.0.0.1";
-		if (config.allowRemote !== true && !isLoopbackRpcHost(host)) {
-			throw new Error(
-				`Refusing to listen on non-loopback HTTP RPC host ${host}. ` +
-					"Use --rpc-allow-remote only behind SSH tunneling or a TLS-terminating proxy.",
-			);
-		}
+	const host = config.host ?? DEFAULT_CONTROL_RPC_HOST;
+	const port = config.port ?? DEFAULT_CONTROL_RPC_PORT;
+	if (config.allowRemote !== true && !isLoopbackRpcHost(host)) {
+		throw new Error(
+			`Refusing to listen on non-loopback HTTP RPC host ${host}. ` +
+				"Use --rpc-allow-remote only behind SSH tunneling or a TLS-terminating proxy.",
+		);
 	}
 	const controlDir = getDaemonControlDir();
 	mkdirSync(controlDir, { recursive: true, mode: 0o700 });
@@ -71,43 +62,21 @@ export async function startControlRpcServer(
 		/* best effort */
 	}
 	ensureControlToken();
-	const socketPath = getDaemonControlSocketPath();
-	if (existsSync(socketPath)) {
-		if (await socketAcceptsConnections(socketPath)) {
-			throw new Error(`daemon control socket already in use at ${socketPath}`);
-		}
-		unlinkSync(socketPath);
-	}
-
-	const socketServer = createServer(async (req, res) => {
+	const httpServer = createServer(async (req, res) => {
 		await handleHttpRequest(req, res, handlers);
 	});
-	await listenOnSocket(socketServer, socketPath);
 	try {
-		chmodSync(socketPath, 0o600);
-	} catch {
-		/* best effort */
+		await listenOnHttpEndpoint(httpServer, host, port);
+	} catch (error) {
+		await closeServer(httpServer);
+		throw error;
 	}
-	let httpServer: Server | null = null;
-	let http: { host: string; port: number } | null = null;
-	if (config.port !== undefined) {
-		const host = config.host ?? "127.0.0.1";
-		httpServer = createServer(async (req, res) => {
-			await handleHttpRequest(req, res, handlers);
-		});
-		try {
-			await listenOnHttpEndpoint(httpServer, host, config.port);
-		} catch (error) {
-			await closeServers(socketServer, socketPath, httpServer);
-			throw error;
-		}
-		const address = httpServer.address();
-		http = {
-			host,
-			port: typeof address === "object" && address ? address.port : config.port,
-		};
-	}
-	const close = () => closeServers(socketServer, socketPath, httpServer);
+	const address = httpServer.address();
+	const http = {
+		host,
+		port: typeof address === "object" && address ? address.port : port,
+	};
+	const close = () => closeServer(httpServer);
 	abort.addEventListener(
 		"abort",
 		() => {
@@ -115,7 +84,7 @@ export async function startControlRpcServer(
 		},
 		{ once: true },
 	);
-	return { socketPath, tokenPath: getDaemonControlTokenPath(), http, close };
+	return { tokenPath: getDaemonControlTokenPath(), http, close };
 }
 
 export async function callControlRpc(
@@ -124,7 +93,7 @@ export async function callControlRpc(
 	config: ControlRpcClientConfig = {},
 ): Promise<unknown> {
 	if (config.host !== undefined && config.port === undefined) {
-		throw new Error("RPC host requires an RPC port");
+		config = { ...config, port: DEFAULT_CONTROL_RPC_PORT };
 	}
 	const token = config.token ?? process.env.CLAWDI_DAEMON_RPC_TOKEN ?? readControlToken();
 	const body = JSON.stringify({
@@ -155,18 +124,10 @@ function createServerlessRequest(
 	resolve: (value: string) => void,
 	reject: (reason?: unknown) => void,
 ) {
-	const requestOptions: RequestOptions =
-		config.host !== undefined || config.port !== undefined
-			? {
-					hostname: config.host ?? "127.0.0.1",
-					port: config.port,
-				}
-			: {
-					socketPath: getDaemonControlSocketPath(),
-				};
 	const req = request(
 		{
-			...requestOptions,
+			hostname: config.host ?? DEFAULT_CONTROL_RPC_HOST,
+			port: config.port ?? DEFAULT_CONTROL_RPC_PORT,
 			path: "/rpc",
 			method: "POST",
 			headers: {
@@ -378,22 +339,6 @@ function sendHttp(res: ServerResponse, status: number, body: unknown): void {
 	res.end(text);
 }
 
-function listenOnSocket(server: Server, socketPath: string): Promise<void> {
-	return new Promise((resolve, reject) => {
-		const onError = (error: Error) => {
-			server.off("listening", onListening);
-			reject(error);
-		};
-		const onListening = () => {
-			server.off("error", onError);
-			resolve();
-		};
-		server.once("error", onError);
-		server.once("listening", onListening);
-		server.listen(socketPath);
-	});
-}
-
 function listenOnHttpEndpoint(server: Server, host: string, port: number): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const onError = (error: Error) => {
@@ -410,44 +355,10 @@ function listenOnHttpEndpoint(server: Server, host: string, port: number): Promi
 	});
 }
 
-async function closeServers(
-	socketServer: Server,
-	socketPath: string,
-	httpServer: Server | null,
-): Promise<void> {
-	await Promise.all([closeServer(socketServer), httpServer ? closeServer(httpServer) : undefined]);
-	try {
-		if (existsSync(socketPath)) unlinkSync(socketPath);
-	} catch {
-		/* best effort */
-	}
-}
-
 function closeServer(server: Server): Promise<void> {
 	return new Promise((resolve) => {
 		server.close(() => {
-			try {
-				const address = server.address() as AddressInfo | string | null;
-				if (typeof address === "string" && existsSync(address)) unlinkSync(address);
-			} catch {
-				/* best effort */
-			}
 			resolve();
 		});
-	});
-}
-
-function socketAcceptsConnections(socketPath: string): Promise<boolean> {
-	return new Promise((resolve) => {
-		const socket = createConnection({ path: socketPath });
-		const done = (value: boolean) => {
-			socket.removeAllListeners();
-			socket.destroy();
-			resolve(value);
-		};
-		socket.setTimeout(200);
-		socket.once("connect", () => done(true));
-		socket.once("timeout", () => done(false));
-		socket.once("error", () => done(false));
 	});
 }

--- a/packages/cli/src/serve/control-rpc.ts
+++ b/packages/cli/src/serve/control-rpc.ts
@@ -3,11 +3,12 @@ import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSy
 import {
 	createServer,
 	type IncomingMessage,
+	type RequestOptions,
 	request,
 	type Server,
 	type ServerResponse,
 } from "node:http";
-import { createConnection } from "node:net";
+import { type AddressInfo, createConnection } from "node:net";
 import {
 	getDaemonControlDir,
 	getDaemonControlSocketPath,
@@ -19,6 +20,17 @@ const MAX_RPC_BODY_BYTES = 1024 * 1024;
 export type ControlRpcHandler = (params: unknown) => Promise<unknown> | unknown;
 export type ControlRpcHandlers = Record<string, ControlRpcHandler>;
 
+export interface ControlRpcListenConfig {
+	host?: string;
+	port?: number;
+}
+
+export interface ControlRpcClientConfig {
+	host?: string;
+	port?: number;
+	token?: string;
+}
+
 interface JsonRpcRequest {
 	jsonrpc: "2.0";
 	id?: string | number | null;
@@ -29,12 +41,14 @@ interface JsonRpcRequest {
 interface ControlRpcServer {
 	socketPath: string;
 	tokenPath: string;
+	tcp: { host: string; port: number } | null;
 	close: () => Promise<void>;
 }
 
 export async function startControlRpcServer(
 	handlers: ControlRpcHandlers,
 	abort: AbortSignal,
+	config: ControlRpcListenConfig = {},
 ): Promise<ControlRpcServer> {
 	if (process.platform === "win32") {
 		throw new Error("daemon control RPC is not supported on Windows yet");
@@ -55,16 +69,35 @@ export async function startControlRpcServer(
 		unlinkSync(socketPath);
 	}
 
-	const server = createServer(async (req, res) => {
+	const socketServer = createServer(async (req, res) => {
 		await handleHttpRequest(req, res, handlers, token);
 	});
-	await listenOnSocket(server, socketPath);
+	await listenOnSocket(socketServer, socketPath);
 	try {
 		chmodSync(socketPath, 0o600);
 	} catch {
 		/* best effort */
 	}
-	const close = () => closeServer(server, socketPath);
+	let tcpServer: Server | null = null;
+	let tcp: { host: string; port: number } | null = null;
+	if (config.port !== undefined) {
+		const host = config.host ?? "127.0.0.1";
+		tcpServer = createServer(async (req, res) => {
+			await handleHttpRequest(req, res, handlers, token);
+		});
+		try {
+			await listenOnTcp(tcpServer, host, config.port);
+		} catch (error) {
+			await closeServers(socketServer, socketPath, tcpServer);
+			throw error;
+		}
+		const address = tcpServer.address();
+		tcp = {
+			host,
+			port: typeof address === "object" && address ? address.port : config.port,
+		};
+	}
+	const close = () => closeServers(socketServer, socketPath, tcpServer);
 	abort.addEventListener(
 		"abort",
 		() => {
@@ -72,11 +105,15 @@ export async function startControlRpcServer(
 		},
 		{ once: true },
 	);
-	return { socketPath, tokenPath: getDaemonControlTokenPath(), close };
+	return { socketPath, tokenPath: getDaemonControlTokenPath(), tcp, close };
 }
 
-export async function callControlRpc(method: string, params?: unknown): Promise<unknown> {
-	const token = readControlToken();
+export async function callControlRpc(
+	method: string,
+	params?: unknown,
+	config: ControlRpcClientConfig = {},
+): Promise<unknown> {
+	const token = config.token ?? process.env.CLAWDI_DAEMON_RPC_TOKEN ?? readControlToken();
 	const body = JSON.stringify({
 		jsonrpc: "2.0",
 		id: 1,
@@ -84,7 +121,7 @@ export async function callControlRpc(method: string, params?: unknown): Promise<
 		params: params ?? {},
 	});
 	const response = await new Promise<string>((resolve, reject) => {
-		const req = createServerlessRequest(body, token, resolve, reject);
+		const req = createServerlessRequest(body, token, config, resolve, reject);
 		req.write(body);
 		req.end();
 	});
@@ -101,12 +138,22 @@ export async function callControlRpc(method: string, params?: unknown): Promise<
 function createServerlessRequest(
 	body: string,
 	token: string,
+	config: ControlRpcClientConfig,
 	resolve: (value: string) => void,
 	reject: (reason?: unknown) => void,
 ) {
+	const requestOptions: RequestOptions =
+		config.host !== undefined || config.port !== undefined
+			? {
+					hostname: config.host ?? "127.0.0.1",
+					port: config.port,
+				}
+			: {
+					socketPath: getDaemonControlSocketPath(),
+				};
 	const req = request(
 		{
-			socketPath: getDaemonControlSocketPath(),
+			...requestOptions,
 			path: "/rpc",
 			method: "POST",
 			headers: {
@@ -289,11 +336,41 @@ function listenOnSocket(server: Server, socketPath: string): Promise<void> {
 	});
 }
 
-function closeServer(server: Server, socketPath: string): Promise<void> {
+function listenOnTcp(server: Server, host: string, port: number): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const onError = (error: Error) => {
+			server.off("listening", onListening);
+			reject(error);
+		};
+		const onListening = () => {
+			server.off("error", onError);
+			resolve();
+		};
+		server.once("error", onError);
+		server.once("listening", onListening);
+		server.listen(port, host);
+	});
+}
+
+async function closeServers(
+	socketServer: Server,
+	socketPath: string,
+	tcpServer: Server | null,
+): Promise<void> {
+	await Promise.all([closeServer(socketServer), tcpServer ? closeServer(tcpServer) : undefined]);
+	try {
+		if (existsSync(socketPath)) unlinkSync(socketPath);
+	} catch {
+		/* best effort */
+	}
+}
+
+function closeServer(server: Server): Promise<void> {
 	return new Promise((resolve) => {
 		server.close(() => {
 			try {
-				if (existsSync(socketPath)) unlinkSync(socketPath);
+				const address = server.address() as AddressInfo | string | null;
+				if (typeof address === "string" && existsSync(address)) unlinkSync(address);
 			} catch {
 				/* best effort */
 			}

--- a/packages/cli/src/serve/control-rpc.ts
+++ b/packages/cli/src/serve/control-rpc.ts
@@ -7,6 +7,7 @@ import {
 	type Server,
 	type ServerResponse,
 } from "node:http";
+import { isIP } from "node:net";
 import { getDaemonControlDir, getDaemonControlTokenPath } from "./paths";
 
 const MAX_RPC_BODY_BYTES = 1024 * 1024;
@@ -92,9 +93,6 @@ export async function callControlRpc(
 	params?: unknown,
 	config: ControlRpcClientConfig = {},
 ): Promise<unknown> {
-	if (config.host !== undefined && config.port === undefined) {
-		config = { ...config, port: DEFAULT_CONTROL_RPC_PORT };
-	}
 	const token = config.token ?? process.env.CLAWDI_DAEMON_RPC_TOKEN ?? readControlToken();
 	const body = JSON.stringify({
 		jsonrpc: "2.0",
@@ -264,15 +262,15 @@ function bearerTokenMatches(auth: string | undefined, token: string): boolean {
 	);
 }
 
-function isLoopbackRpcHost(host: string): boolean {
+export function isLoopbackRpcHost(host: string): boolean {
 	const normalized = host.trim().toLowerCase();
+	const unbracketed =
+		normalized.startsWith("[") && normalized.endsWith("]") ? normalized.slice(1, -1) : normalized;
 	return (
-		normalized === "localhost" ||
-		normalized === "::1" ||
-		normalized === "[::1]" ||
-		normalized === "0:0:0:0:0:0:0:1" ||
-		normalized === "127.0.0.1" ||
-		normalized.startsWith("127.")
+		unbracketed === "localhost" ||
+		unbracketed === "::1" ||
+		unbracketed === "0:0:0:0:0:0:0:1" ||
+		(isIP(unbracketed) === 4 && unbracketed.split(".")[0] === "127")
 	);
 }
 

--- a/packages/cli/src/serve/control-rpc.ts
+++ b/packages/cli/src/serve/control-rpc.ts
@@ -52,7 +52,7 @@ export async function startControlRpcServer(
 	if (config.allowRemote !== true && !isLoopbackRpcHost(host)) {
 		throw new Error(
 			`Refusing to listen on non-loopback HTTP RPC host ${host}. ` +
-				"Use --rpc-allow-remote only behind SSH tunneling or a TLS-terminating proxy.",
+				"Use --allow-remote only behind SSH tunneling or a TLS-terminating proxy.",
 		);
 	}
 	const controlDir = getDaemonControlDir();

--- a/packages/cli/src/serve/control-rpc.ts
+++ b/packages/cli/src/serve/control-rpc.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { randomBytes, timingSafeEqual } from "node:crypto";
 import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import {
 	createServer,
@@ -23,6 +23,7 @@ export type ControlRpcHandlers = Record<string, ControlRpcHandler>;
 export interface ControlRpcListenConfig {
 	host?: string;
 	port?: number;
+	allowRemote?: boolean;
 }
 
 export interface ControlRpcClientConfig {
@@ -41,7 +42,7 @@ interface JsonRpcRequest {
 interface ControlRpcServer {
 	socketPath: string;
 	tokenPath: string;
-	tcp: { host: string; port: number } | null;
+	http: { host: string; port: number } | null;
 	close: () => Promise<void>;
 }
 
@@ -53,6 +54,15 @@ export async function startControlRpcServer(
 	if (process.platform === "win32") {
 		throw new Error("daemon control RPC is not supported on Windows yet");
 	}
+	if (config.port !== undefined) {
+		const host = config.host ?? "127.0.0.1";
+		if (config.allowRemote !== true && !isLoopbackRpcHost(host)) {
+			throw new Error(
+				`Refusing to listen on non-loopback HTTP RPC host ${host}. ` +
+					"Use --rpc-allow-remote only behind SSH tunneling or a TLS-terminating proxy.",
+			);
+		}
+	}
 	const controlDir = getDaemonControlDir();
 	mkdirSync(controlDir, { recursive: true, mode: 0o700 });
 	try {
@@ -60,7 +70,7 @@ export async function startControlRpcServer(
 	} catch {
 		/* best effort */
 	}
-	const token = ensureControlToken();
+	ensureControlToken();
 	const socketPath = getDaemonControlSocketPath();
 	if (existsSync(socketPath)) {
 		if (await socketAcceptsConnections(socketPath)) {
@@ -70,7 +80,7 @@ export async function startControlRpcServer(
 	}
 
 	const socketServer = createServer(async (req, res) => {
-		await handleHttpRequest(req, res, handlers, token);
+		await handleHttpRequest(req, res, handlers);
 	});
 	await listenOnSocket(socketServer, socketPath);
 	try {
@@ -78,26 +88,26 @@ export async function startControlRpcServer(
 	} catch {
 		/* best effort */
 	}
-	let tcpServer: Server | null = null;
-	let tcp: { host: string; port: number } | null = null;
+	let httpServer: Server | null = null;
+	let http: { host: string; port: number } | null = null;
 	if (config.port !== undefined) {
 		const host = config.host ?? "127.0.0.1";
-		tcpServer = createServer(async (req, res) => {
-			await handleHttpRequest(req, res, handlers, token);
+		httpServer = createServer(async (req, res) => {
+			await handleHttpRequest(req, res, handlers);
 		});
 		try {
-			await listenOnTcp(tcpServer, host, config.port);
+			await listenOnHttpEndpoint(httpServer, host, config.port);
 		} catch (error) {
-			await closeServers(socketServer, socketPath, tcpServer);
+			await closeServers(socketServer, socketPath, httpServer);
 			throw error;
 		}
-		const address = tcpServer.address();
-		tcp = {
+		const address = httpServer.address();
+		http = {
 			host,
 			port: typeof address === "object" && address ? address.port : config.port,
 		};
 	}
-	const close = () => closeServers(socketServer, socketPath, tcpServer);
+	const close = () => closeServers(socketServer, socketPath, httpServer);
 	abort.addEventListener(
 		"abort",
 		() => {
@@ -105,7 +115,7 @@ export async function startControlRpcServer(
 		},
 		{ once: true },
 	);
-	return { socketPath, tokenPath: getDaemonControlTokenPath(), tcp, close };
+	return { socketPath, tokenPath: getDaemonControlTokenPath(), http, close };
 }
 
 export async function callControlRpc(
@@ -113,6 +123,9 @@ export async function callControlRpc(
 	params?: unknown,
 	config: ControlRpcClientConfig = {},
 ): Promise<unknown> {
+	if (config.host !== undefined && config.port === undefined) {
+		throw new Error("RPC host requires an RPC port");
+	}
 	const token = config.token ?? process.env.CLAWDI_DAEMON_RPC_TOKEN ?? readControlToken();
 	const body = JSON.stringify({
 		jsonrpc: "2.0",
@@ -186,6 +199,18 @@ function ensureControlToken(): string {
 	if (existsSync(tokenPath)) {
 		return readControlToken();
 	}
+	return rotateControlToken();
+}
+
+export function rotateControlToken(): string {
+	const controlDir = getDaemonControlDir();
+	mkdirSync(controlDir, { recursive: true, mode: 0o700 });
+	try {
+		chmodSync(controlDir, 0o700);
+	} catch {
+		/* best effort */
+	}
+	const tokenPath = getDaemonControlTokenPath();
 	const token = randomBytes(32).toString("hex");
 	writeFileSync(tokenPath, `${token}\n`, { mode: 0o600 });
 	try {
@@ -203,6 +228,11 @@ function readControlToken(): string {
 			`daemon control token not found at ${tokenPath}. Start \`clawdi daemon run\` first.`,
 		);
 	}
+	try {
+		chmodSync(tokenPath, 0o600);
+	} catch {
+		/* best effort */
+	}
 	const token = readFileSync(tokenPath, "utf-8").trim();
 	if (!token) throw new Error(`daemon control token at ${tokenPath} is empty`);
 	return token;
@@ -212,14 +242,20 @@ async function handleHttpRequest(
 	req: IncomingMessage,
 	res: ServerResponse,
 	handlers: ControlRpcHandlers,
-	token: string,
 ): Promise<void> {
 	if (req.method !== "POST" || req.url !== "/rpc") {
 		sendHttp(res, 404, { error: "not_found" });
 		return;
 	}
+	let token: string;
+	try {
+		token = readControlToken();
+	} catch (error) {
+		sendHttp(res, 500, { error: error instanceof Error ? error.message : "token_unavailable" });
+		return;
+	}
 	const auth = req.headers.authorization;
-	if (auth !== `Bearer ${token}`) {
+	if (!bearerTokenMatches(auth, token)) {
 		sendHttp(res, 401, { error: "unauthorized" });
 		return;
 	}
@@ -255,6 +291,28 @@ async function handleHttpRequest(
 		const message = error instanceof Error ? error.message : String(error);
 		sendRpcError(res, request.id ?? null, -32000, message);
 	}
+}
+
+function bearerTokenMatches(auth: string | undefined, token: string): boolean {
+	if (!auth?.startsWith("Bearer ")) return false;
+	const provided = auth.slice("Bearer ".length);
+	const providedBuffer = Buffer.from(provided);
+	const tokenBuffer = Buffer.from(token);
+	return (
+		providedBuffer.length === tokenBuffer.length && timingSafeEqual(providedBuffer, tokenBuffer)
+	);
+}
+
+function isLoopbackRpcHost(host: string): boolean {
+	const normalized = host.trim().toLowerCase();
+	return (
+		normalized === "localhost" ||
+		normalized === "::1" ||
+		normalized === "[::1]" ||
+		normalized === "0:0:0:0:0:0:0:1" ||
+		normalized === "127.0.0.1" ||
+		normalized.startsWith("127.")
+	);
 }
 
 function parseJsonRpcRequest(raw: string): JsonRpcRequest {
@@ -336,7 +394,7 @@ function listenOnSocket(server: Server, socketPath: string): Promise<void> {
 	});
 }
 
-function listenOnTcp(server: Server, host: string, port: number): Promise<void> {
+function listenOnHttpEndpoint(server: Server, host: string, port: number): Promise<void> {
 	return new Promise((resolve, reject) => {
 		const onError = (error: Error) => {
 			server.off("listening", onListening);
@@ -355,9 +413,9 @@ function listenOnTcp(server: Server, host: string, port: number): Promise<void> 
 async function closeServers(
 	socketServer: Server,
 	socketPath: string,
-	tcpServer: Server | null,
+	httpServer: Server | null,
 ): Promise<void> {
-	await Promise.all([closeServer(socketServer), tcpServer ? closeServer(tcpServer) : undefined]);
+	await Promise.all([closeServer(socketServer), httpServer ? closeServer(httpServer) : undefined]);
 	try {
 		if (existsSync(socketPath)) unlinkSync(socketPath);
 	} catch {

--- a/packages/cli/src/serve/control-rpc.ts
+++ b/packages/cli/src/serve/control-rpc.ts
@@ -1,4 +1,4 @@
-import { randomBytes, timingSafeEqual } from "node:crypto";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import {
 	createServer,
@@ -16,8 +16,36 @@ import {
 } from "./paths";
 
 const MAX_RPC_BODY_BYTES = 1024 * 1024;
+const SCOPED_TOKEN_PREFIX = "clawdi_rpc_v1_";
 
-export type ControlRpcHandler = (params: unknown) => Promise<unknown> | unknown;
+export const CONTROL_RPC_CAPABILITIES = [
+	"daemon:read",
+	"daemon:control",
+	"operation:read",
+	"operation:control",
+	"sync:run",
+	"vault:read",
+	"vault:write",
+	"vault:secrets",
+	"auth:read",
+	"auth:write",
+	"update:read",
+	"update:install",
+] as const;
+
+export type RpcCapability = (typeof CONTROL_RPC_CAPABILITIES)[number];
+
+export interface ControlRpcAuthContext {
+	tokenKind: "root" | "scoped";
+	capabilities: readonly RpcCapability[] | "*";
+	transport: "socket" | "http";
+}
+
+export type ControlRpcHandler = {
+	(params: unknown, context?: ControlRpcAuthContext): Promise<unknown> | unknown;
+	requiredCapabilities?: readonly RpcCapability[];
+	rootOnly?: boolean;
+};
 export type ControlRpcHandlers = Record<string, ControlRpcHandler>;
 
 export interface ControlRpcListenConfig {
@@ -44,6 +72,20 @@ interface ControlRpcServer {
 	tokenPath: string;
 	http: { host: string; port: number } | null;
 	close: () => Promise<void>;
+}
+
+interface ControlRpcEndpoint {
+	transport: "socket" | "http";
+	requireScopedToken?: boolean;
+}
+
+interface ScopedTokenPayload {
+	v: 1;
+	jti: string;
+	iat: number;
+	exp?: number;
+	cap: RpcCapability[];
+	label?: string;
 }
 
 export async function startControlRpcServer(
@@ -80,7 +122,7 @@ export async function startControlRpcServer(
 	}
 
 	const socketServer = createServer(async (req, res) => {
-		await handleHttpRequest(req, res, handlers);
+		await handleHttpRequest(req, res, handlers, { transport: "socket" });
 	});
 	await listenOnSocket(socketServer, socketPath);
 	try {
@@ -92,8 +134,12 @@ export async function startControlRpcServer(
 	let http: { host: string; port: number } | null = null;
 	if (config.port !== undefined) {
 		const host = config.host ?? "127.0.0.1";
+		const requireScopedToken = !isLoopbackRpcHost(host);
 		httpServer = createServer(async (req, res) => {
-			await handleHttpRequest(req, res, handlers);
+			await handleHttpRequest(req, res, handlers, {
+				transport: "http",
+				requireScopedToken,
+			});
 		});
 		try {
 			await listenOnHttpEndpoint(httpServer, host, config.port);
@@ -221,6 +267,70 @@ export function rotateControlToken(): string {
 	return token;
 }
 
+export function issueScopedControlToken(opts: {
+	capabilities: readonly RpcCapability[];
+	label?: string;
+	expiresInSeconds?: number;
+	nowSeconds?: number;
+}): { token: string; expires_at: number | null; capabilities: RpcCapability[] } {
+	const rootToken = readControlToken();
+	const now = opts.nowSeconds ?? Math.floor(Date.now() / 1000);
+	const capabilities = normalizeCapabilities(opts.capabilities);
+	const expiresAt =
+		opts.expiresInSeconds === undefined ? null : now + Math.max(1, opts.expiresInSeconds);
+	const payload: ScopedTokenPayload = {
+		v: 1,
+		jti: randomBytes(16).toString("hex"),
+		iat: now,
+		cap: capabilities,
+	};
+	if (expiresAt !== null) payload.exp = expiresAt;
+	if (opts.label) payload.label = opts.label;
+	const payloadPart = base64UrlEncode(JSON.stringify(payload));
+	const signature = signScopedTokenPayload(payloadPart, rootToken);
+	return {
+		token: `${SCOPED_TOKEN_PREFIX}${payloadPart}.${signature}`,
+		expires_at: expiresAt,
+		capabilities,
+	};
+}
+
+export function withRpcCapabilities(
+	handler: ControlRpcHandler,
+	capabilities: readonly RpcCapability[],
+): ControlRpcHandler {
+	handler.requiredCapabilities = capabilities;
+	return handler;
+}
+
+export function rootOnlyRpcHandler(handler: ControlRpcHandler): ControlRpcHandler {
+	handler.rootOnly = true;
+	return handler;
+}
+
+export function requireRpcCapability(
+	context: ControlRpcAuthContext | undefined,
+	capability: RpcCapability,
+	action: string,
+): void {
+	if (!hasRpcCapability(context, capability)) {
+		throw new Error(`${action} requires RPC capability ${capability}.`);
+	}
+}
+
+export function hasRpcCapability(
+	context: ControlRpcAuthContext | undefined,
+	capability: RpcCapability,
+): boolean {
+	if (!context) return false;
+	if (context.capabilities === "*") return true;
+	if (context.capabilities.includes(capability)) return true;
+	for (const held of context.capabilities) {
+		if (capabilityImplications(held).includes(capability)) return true;
+	}
+	return false;
+}
+
 function readControlToken(): string {
 	const tokenPath = getDaemonControlTokenPath();
 	if (!existsSync(tokenPath)) {
@@ -242,6 +352,7 @@ async function handleHttpRequest(
 	req: IncomingMessage,
 	res: ServerResponse,
 	handlers: ControlRpcHandlers,
+	endpoint: ControlRpcEndpoint,
 ): Promise<void> {
 	if (req.method !== "POST" || req.url !== "/rpc") {
 		sendHttp(res, 404, { error: "not_found" });
@@ -255,8 +366,9 @@ async function handleHttpRequest(
 		return;
 	}
 	const auth = req.headers.authorization;
-	if (!bearerTokenMatches(auth, token)) {
-		sendHttp(res, 401, { error: "unauthorized" });
+	const authResult = authenticateBearerToken(auth, token, endpoint);
+	if (!authResult.ok) {
+		sendHttp(res, authResult.status, { error: authResult.error });
 		return;
 	}
 	let raw: string;
@@ -281,7 +393,8 @@ async function handleHttpRequest(
 		return;
 	}
 	try {
-		const result = await handler(request.params ?? {});
+		assertHandlerAuthorized(handler, authResult.context, request.method);
+		const result = await handler(request.params ?? {}, authResult.context);
 		sendHttp(res, 200, {
 			jsonrpc: "2.0",
 			id: request.id ?? null,
@@ -293,14 +406,58 @@ async function handleHttpRequest(
 	}
 }
 
-function bearerTokenMatches(auth: string | undefined, token: string): boolean {
-	if (!auth?.startsWith("Bearer ")) return false;
+function authenticateBearerToken(
+	auth: string | undefined,
+	rootToken: string,
+	endpoint: ControlRpcEndpoint,
+): { ok: true; context: ControlRpcAuthContext } | { ok: false; status: number; error: string } {
+	if (!auth?.startsWith("Bearer ")) return { ok: false, status: 401, error: "unauthorized" };
 	const provided = auth.slice("Bearer ".length);
+	if (tokenMatches(provided, rootToken)) {
+		if (endpoint.requireScopedToken) {
+			return { ok: false, status: 403, error: "root_token_not_allowed_on_remote_http" };
+		}
+		return {
+			ok: true,
+			context: {
+				tokenKind: "root",
+				capabilities: "*",
+				transport: endpoint.transport,
+			},
+		};
+	}
+	const scoped = verifyScopedControlToken(provided, rootToken);
+	if (!scoped.ok) return { ok: false, status: 401, error: scoped.error };
+	return {
+		ok: true,
+		context: {
+			tokenKind: "scoped",
+			capabilities: scoped.payload.cap,
+			transport: endpoint.transport,
+		},
+	};
+}
+
+function tokenMatches(provided: string, expected: string): boolean {
 	const providedBuffer = Buffer.from(provided);
-	const tokenBuffer = Buffer.from(token);
+	const expectedBuffer = Buffer.from(expected);
 	return (
-		providedBuffer.length === tokenBuffer.length && timingSafeEqual(providedBuffer, tokenBuffer)
+		providedBuffer.length === expectedBuffer.length &&
+		timingSafeEqual(providedBuffer, expectedBuffer)
 	);
+}
+
+function assertHandlerAuthorized(
+	handler: ControlRpcHandler,
+	context: ControlRpcAuthContext,
+	method: string,
+): void {
+	if (handler.rootOnly && context.tokenKind !== "root") {
+		throw new Error(`${method} requires the daemon root control token.`);
+	}
+	for (const capability of handler.requiredCapabilities ?? []) {
+		requireRpcCapability(context, capability, method);
+	}
 }
 
 function isLoopbackRpcHost(host: string): boolean {
@@ -450,4 +607,94 @@ function socketAcceptsConnections(socketPath: string): Promise<boolean> {
 		socket.once("timeout", () => done(false));
 		socket.once("error", () => done(false));
 	});
+}
+
+function verifyScopedControlToken(
+	token: string,
+	rootToken: string,
+):
+	| { ok: true; payload: ScopedTokenPayload }
+	| { ok: false; error: "unauthorized" | "scoped_rpc_token_expired" } {
+	if (!token.startsWith(SCOPED_TOKEN_PREFIX)) return { ok: false, error: "unauthorized" };
+	const body = token.slice(SCOPED_TOKEN_PREFIX.length);
+	const parts = body.split(".");
+	if (parts.length !== 2) return { ok: false, error: "unauthorized" };
+	const [payloadPart, signature] = parts;
+	if (!payloadPart || !signature) return { ok: false, error: "unauthorized" };
+	const expected = signScopedTokenPayload(payloadPart, rootToken);
+	if (!tokenMatches(signature, expected)) return { ok: false, error: "unauthorized" };
+	let payload: unknown;
+	try {
+		payload = JSON.parse(Buffer.from(payloadPart, "base64url").toString("utf8"));
+	} catch {
+		return { ok: false, error: "unauthorized" };
+	}
+	if (!isScopedTokenPayload(payload)) return { ok: false, error: "unauthorized" };
+	if (payload.exp !== undefined && payload.exp <= Math.floor(Date.now() / 1000)) {
+		return { ok: false, error: "scoped_rpc_token_expired" };
+	}
+	return { ok: true, payload };
+}
+
+function signScopedTokenPayload(payloadPart: string, rootToken: string): string {
+	return createHmac("sha256", rootToken).update(payloadPart).digest("base64url");
+}
+
+function base64UrlEncode(value: string): string {
+	return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function isScopedTokenPayload(value: unknown): value is ScopedTokenPayload {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+	const record = value as Record<string, unknown>;
+	if (record.v !== 1) return false;
+	if (typeof record.jti !== "string" || record.jti.length === 0) return false;
+	if (typeof record.iat !== "number" || !Number.isInteger(record.iat)) return false;
+	if (
+		record.exp !== undefined &&
+		(typeof record.exp !== "number" || !Number.isInteger(record.exp))
+	) {
+		return false;
+	}
+	if (record.label !== undefined && typeof record.label !== "string") return false;
+	if (!Array.isArray(record.cap)) return false;
+	for (const capability of record.cap) {
+		if (!isRpcCapability(capability)) return false;
+	}
+	return true;
+}
+
+function normalizeCapabilities(capabilities: readonly RpcCapability[]): RpcCapability[] {
+	const out: RpcCapability[] = [];
+	for (const capability of capabilities) {
+		if (!isRpcCapability(capability)) {
+			throw new Error(`Unknown RPC capability: ${String(capability)}`);
+		}
+		if (!out.includes(capability)) out.push(capability);
+	}
+	if (out.length === 0) throw new Error("At least one RPC capability is required.");
+	return out;
+}
+
+function isRpcCapability(value: unknown): value is RpcCapability {
+	return (
+		typeof value === "string" && (CONTROL_RPC_CAPABILITIES as readonly string[]).includes(value)
+	);
+}
+
+function capabilityImplications(capability: RpcCapability): readonly RpcCapability[] {
+	switch (capability) {
+		case "daemon:control":
+			return ["daemon:read"];
+		case "operation:control":
+			return ["operation:read"];
+		case "vault:secrets":
+			return ["vault:read"];
+		case "auth:write":
+			return ["auth:read"];
+		case "update:install":
+			return ["update:read"];
+		default:
+			return [];
+	}
 }

--- a/packages/cli/src/serve/control-rpc.ts
+++ b/packages/cli/src/serve/control-rpc.ts
@@ -1,4 +1,4 @@
-import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { randomBytes, timingSafeEqual } from "node:crypto";
 import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import {
 	createServer,
@@ -16,36 +16,8 @@ import {
 } from "./paths";
 
 const MAX_RPC_BODY_BYTES = 1024 * 1024;
-const SCOPED_TOKEN_PREFIX = "clawdi_rpc_v1_";
 
-export const CONTROL_RPC_CAPABILITIES = [
-	"daemon:read",
-	"daemon:control",
-	"operation:read",
-	"operation:control",
-	"sync:run",
-	"vault:read",
-	"vault:write",
-	"vault:secrets",
-	"auth:read",
-	"auth:write",
-	"update:read",
-	"update:install",
-] as const;
-
-export type RpcCapability = (typeof CONTROL_RPC_CAPABILITIES)[number];
-
-export interface ControlRpcAuthContext {
-	tokenKind: "root" | "scoped";
-	capabilities: readonly RpcCapability[] | "*";
-	transport: "socket" | "http";
-}
-
-export type ControlRpcHandler = {
-	(params: unknown, context?: ControlRpcAuthContext): Promise<unknown> | unknown;
-	requiredCapabilities?: readonly RpcCapability[];
-	rootOnly?: boolean;
-};
+export type ControlRpcHandler = (params: unknown) => Promise<unknown> | unknown;
 export type ControlRpcHandlers = Record<string, ControlRpcHandler>;
 
 export interface ControlRpcListenConfig {
@@ -72,20 +44,6 @@ interface ControlRpcServer {
 	tokenPath: string;
 	http: { host: string; port: number } | null;
 	close: () => Promise<void>;
-}
-
-interface ControlRpcEndpoint {
-	transport: "socket" | "http";
-	requireScopedToken?: boolean;
-}
-
-interface ScopedTokenPayload {
-	v: 1;
-	jti: string;
-	iat: number;
-	exp?: number;
-	cap: RpcCapability[];
-	label?: string;
 }
 
 export async function startControlRpcServer(
@@ -122,7 +80,7 @@ export async function startControlRpcServer(
 	}
 
 	const socketServer = createServer(async (req, res) => {
-		await handleHttpRequest(req, res, handlers, { transport: "socket" });
+		await handleHttpRequest(req, res, handlers);
 	});
 	await listenOnSocket(socketServer, socketPath);
 	try {
@@ -134,12 +92,8 @@ export async function startControlRpcServer(
 	let http: { host: string; port: number } | null = null;
 	if (config.port !== undefined) {
 		const host = config.host ?? "127.0.0.1";
-		const requireScopedToken = !isLoopbackRpcHost(host);
 		httpServer = createServer(async (req, res) => {
-			await handleHttpRequest(req, res, handlers, {
-				transport: "http",
-				requireScopedToken,
-			});
+			await handleHttpRequest(req, res, handlers);
 		});
 		try {
 			await listenOnHttpEndpoint(httpServer, host, config.port);
@@ -267,70 +221,6 @@ export function rotateControlToken(): string {
 	return token;
 }
 
-export function issueScopedControlToken(opts: {
-	capabilities: readonly RpcCapability[];
-	label?: string;
-	expiresInSeconds?: number;
-	nowSeconds?: number;
-}): { token: string; expires_at: number | null; capabilities: RpcCapability[] } {
-	const rootToken = readControlToken();
-	const now = opts.nowSeconds ?? Math.floor(Date.now() / 1000);
-	const capabilities = normalizeCapabilities(opts.capabilities);
-	const expiresAt =
-		opts.expiresInSeconds === undefined ? null : now + Math.max(1, opts.expiresInSeconds);
-	const payload: ScopedTokenPayload = {
-		v: 1,
-		jti: randomBytes(16).toString("hex"),
-		iat: now,
-		cap: capabilities,
-	};
-	if (expiresAt !== null) payload.exp = expiresAt;
-	if (opts.label) payload.label = opts.label;
-	const payloadPart = base64UrlEncode(JSON.stringify(payload));
-	const signature = signScopedTokenPayload(payloadPart, rootToken);
-	return {
-		token: `${SCOPED_TOKEN_PREFIX}${payloadPart}.${signature}`,
-		expires_at: expiresAt,
-		capabilities,
-	};
-}
-
-export function withRpcCapabilities(
-	handler: ControlRpcHandler,
-	capabilities: readonly RpcCapability[],
-): ControlRpcHandler {
-	handler.requiredCapabilities = capabilities;
-	return handler;
-}
-
-export function rootOnlyRpcHandler(handler: ControlRpcHandler): ControlRpcHandler {
-	handler.rootOnly = true;
-	return handler;
-}
-
-export function requireRpcCapability(
-	context: ControlRpcAuthContext | undefined,
-	capability: RpcCapability,
-	action: string,
-): void {
-	if (!hasRpcCapability(context, capability)) {
-		throw new Error(`${action} requires RPC capability ${capability}.`);
-	}
-}
-
-export function hasRpcCapability(
-	context: ControlRpcAuthContext | undefined,
-	capability: RpcCapability,
-): boolean {
-	if (!context) return false;
-	if (context.capabilities === "*") return true;
-	if (context.capabilities.includes(capability)) return true;
-	for (const held of context.capabilities) {
-		if (capabilityImplications(held).includes(capability)) return true;
-	}
-	return false;
-}
-
 function readControlToken(): string {
 	const tokenPath = getDaemonControlTokenPath();
 	if (!existsSync(tokenPath)) {
@@ -352,7 +242,6 @@ async function handleHttpRequest(
 	req: IncomingMessage,
 	res: ServerResponse,
 	handlers: ControlRpcHandlers,
-	endpoint: ControlRpcEndpoint,
 ): Promise<void> {
 	if (req.method !== "POST" || req.url !== "/rpc") {
 		sendHttp(res, 404, { error: "not_found" });
@@ -366,9 +255,8 @@ async function handleHttpRequest(
 		return;
 	}
 	const auth = req.headers.authorization;
-	const authResult = authenticateBearerToken(auth, token, endpoint);
-	if (!authResult.ok) {
-		sendHttp(res, authResult.status, { error: authResult.error });
+	if (!bearerTokenMatches(auth, token)) {
+		sendHttp(res, 401, { error: "unauthorized" });
 		return;
 	}
 	let raw: string;
@@ -393,8 +281,7 @@ async function handleHttpRequest(
 		return;
 	}
 	try {
-		assertHandlerAuthorized(handler, authResult.context, request.method);
-		const result = await handler(request.params ?? {}, authResult.context);
+		const result = await handler(request.params ?? {});
 		sendHttp(res, 200, {
 			jsonrpc: "2.0",
 			id: request.id ?? null,
@@ -406,58 +293,14 @@ async function handleHttpRequest(
 	}
 }
 
-function authenticateBearerToken(
-	auth: string | undefined,
-	rootToken: string,
-	endpoint: ControlRpcEndpoint,
-): { ok: true; context: ControlRpcAuthContext } | { ok: false; status: number; error: string } {
-	if (!auth?.startsWith("Bearer ")) return { ok: false, status: 401, error: "unauthorized" };
+function bearerTokenMatches(auth: string | undefined, token: string): boolean {
+	if (!auth?.startsWith("Bearer ")) return false;
 	const provided = auth.slice("Bearer ".length);
-	if (tokenMatches(provided, rootToken)) {
-		if (endpoint.requireScopedToken) {
-			return { ok: false, status: 403, error: "root_token_not_allowed_on_remote_http" };
-		}
-		return {
-			ok: true,
-			context: {
-				tokenKind: "root",
-				capabilities: "*",
-				transport: endpoint.transport,
-			},
-		};
-	}
-	const scoped = verifyScopedControlToken(provided, rootToken);
-	if (!scoped.ok) return { ok: false, status: 401, error: scoped.error };
-	return {
-		ok: true,
-		context: {
-			tokenKind: "scoped",
-			capabilities: scoped.payload.cap,
-			transport: endpoint.transport,
-		},
-	};
-}
-
-function tokenMatches(provided: string, expected: string): boolean {
 	const providedBuffer = Buffer.from(provided);
-	const expectedBuffer = Buffer.from(expected);
+	const tokenBuffer = Buffer.from(token);
 	return (
-		providedBuffer.length === expectedBuffer.length &&
-		timingSafeEqual(providedBuffer, expectedBuffer)
+		providedBuffer.length === tokenBuffer.length && timingSafeEqual(providedBuffer, tokenBuffer)
 	);
-}
-
-function assertHandlerAuthorized(
-	handler: ControlRpcHandler,
-	context: ControlRpcAuthContext,
-	method: string,
-): void {
-	if (handler.rootOnly && context.tokenKind !== "root") {
-		throw new Error(`${method} requires the daemon root control token.`);
-	}
-	for (const capability of handler.requiredCapabilities ?? []) {
-		requireRpcCapability(context, capability, method);
-	}
 }
 
 function isLoopbackRpcHost(host: string): boolean {
@@ -607,94 +450,4 @@ function socketAcceptsConnections(socketPath: string): Promise<boolean> {
 		socket.once("timeout", () => done(false));
 		socket.once("error", () => done(false));
 	});
-}
-
-function verifyScopedControlToken(
-	token: string,
-	rootToken: string,
-):
-	| { ok: true; payload: ScopedTokenPayload }
-	| { ok: false; error: "unauthorized" | "scoped_rpc_token_expired" } {
-	if (!token.startsWith(SCOPED_TOKEN_PREFIX)) return { ok: false, error: "unauthorized" };
-	const body = token.slice(SCOPED_TOKEN_PREFIX.length);
-	const parts = body.split(".");
-	if (parts.length !== 2) return { ok: false, error: "unauthorized" };
-	const [payloadPart, signature] = parts;
-	if (!payloadPart || !signature) return { ok: false, error: "unauthorized" };
-	const expected = signScopedTokenPayload(payloadPart, rootToken);
-	if (!tokenMatches(signature, expected)) return { ok: false, error: "unauthorized" };
-	let payload: unknown;
-	try {
-		payload = JSON.parse(Buffer.from(payloadPart, "base64url").toString("utf8"));
-	} catch {
-		return { ok: false, error: "unauthorized" };
-	}
-	if (!isScopedTokenPayload(payload)) return { ok: false, error: "unauthorized" };
-	if (payload.exp !== undefined && payload.exp <= Math.floor(Date.now() / 1000)) {
-		return { ok: false, error: "scoped_rpc_token_expired" };
-	}
-	return { ok: true, payload };
-}
-
-function signScopedTokenPayload(payloadPart: string, rootToken: string): string {
-	return createHmac("sha256", rootToken).update(payloadPart).digest("base64url");
-}
-
-function base64UrlEncode(value: string): string {
-	return Buffer.from(value, "utf8").toString("base64url");
-}
-
-function isScopedTokenPayload(value: unknown): value is ScopedTokenPayload {
-	if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-	const record = value as Record<string, unknown>;
-	if (record.v !== 1) return false;
-	if (typeof record.jti !== "string" || record.jti.length === 0) return false;
-	if (typeof record.iat !== "number" || !Number.isInteger(record.iat)) return false;
-	if (
-		record.exp !== undefined &&
-		(typeof record.exp !== "number" || !Number.isInteger(record.exp))
-	) {
-		return false;
-	}
-	if (record.label !== undefined && typeof record.label !== "string") return false;
-	if (!Array.isArray(record.cap)) return false;
-	for (const capability of record.cap) {
-		if (!isRpcCapability(capability)) return false;
-	}
-	return true;
-}
-
-function normalizeCapabilities(capabilities: readonly RpcCapability[]): RpcCapability[] {
-	const out: RpcCapability[] = [];
-	for (const capability of capabilities) {
-		if (!isRpcCapability(capability)) {
-			throw new Error(`Unknown RPC capability: ${String(capability)}`);
-		}
-		if (!out.includes(capability)) out.push(capability);
-	}
-	if (out.length === 0) throw new Error("At least one RPC capability is required.");
-	return out;
-}
-
-function isRpcCapability(value: unknown): value is RpcCapability {
-	return (
-		typeof value === "string" && (CONTROL_RPC_CAPABILITIES as readonly string[]).includes(value)
-	);
-}
-
-function capabilityImplications(capability: RpcCapability): readonly RpcCapability[] {
-	switch (capability) {
-		case "daemon:control":
-			return ["daemon:read"];
-		case "operation:control":
-			return ["operation:read"];
-		case "vault:secrets":
-			return ["vault:read"];
-		case "auth:write":
-			return ["auth:read"];
-		case "update:install":
-			return ["update:read"];
-		default:
-			return [];
-	}
 }

--- a/packages/cli/src/serve/control-rpc.ts
+++ b/packages/cli/src/serve/control-rpc.ts
@@ -1,0 +1,318 @@
+import { randomBytes } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+	createServer,
+	type IncomingMessage,
+	request,
+	type Server,
+	type ServerResponse,
+} from "node:http";
+import { createConnection } from "node:net";
+import {
+	getDaemonControlDir,
+	getDaemonControlSocketPath,
+	getDaemonControlTokenPath,
+} from "./paths";
+
+const MAX_RPC_BODY_BYTES = 1024 * 1024;
+
+export type ControlRpcHandler = (params: unknown) => Promise<unknown> | unknown;
+export type ControlRpcHandlers = Record<string, ControlRpcHandler>;
+
+interface JsonRpcRequest {
+	jsonrpc: "2.0";
+	id?: string | number | null;
+	method: string;
+	params?: unknown;
+}
+
+interface ControlRpcServer {
+	socketPath: string;
+	tokenPath: string;
+	close: () => Promise<void>;
+}
+
+export async function startControlRpcServer(
+	handlers: ControlRpcHandlers,
+	abort: AbortSignal,
+): Promise<ControlRpcServer> {
+	if (process.platform === "win32") {
+		throw new Error("daemon control RPC is not supported on Windows yet");
+	}
+	const controlDir = getDaemonControlDir();
+	mkdirSync(controlDir, { recursive: true, mode: 0o700 });
+	try {
+		chmodSync(controlDir, 0o700);
+	} catch {
+		/* best effort */
+	}
+	const token = ensureControlToken();
+	const socketPath = getDaemonControlSocketPath();
+	if (existsSync(socketPath)) {
+		if (await socketAcceptsConnections(socketPath)) {
+			throw new Error(`daemon control socket already in use at ${socketPath}`);
+		}
+		unlinkSync(socketPath);
+	}
+
+	const server = createServer(async (req, res) => {
+		await handleHttpRequest(req, res, handlers, token);
+	});
+	await listenOnSocket(server, socketPath);
+	try {
+		chmodSync(socketPath, 0o600);
+	} catch {
+		/* best effort */
+	}
+	const close = () => closeServer(server, socketPath);
+	abort.addEventListener(
+		"abort",
+		() => {
+			void close();
+		},
+		{ once: true },
+	);
+	return { socketPath, tokenPath: getDaemonControlTokenPath(), close };
+}
+
+export async function callControlRpc(method: string, params?: unknown): Promise<unknown> {
+	const token = readControlToken();
+	const body = JSON.stringify({
+		jsonrpc: "2.0",
+		id: 1,
+		method,
+		params: params ?? {},
+	});
+	const response = await new Promise<string>((resolve, reject) => {
+		const req = createServerlessRequest(body, token, resolve, reject);
+		req.write(body);
+		req.end();
+	});
+	const parsed = JSON.parse(response) as {
+		error?: { code?: number; message?: string };
+		result?: unknown;
+	};
+	if (parsed.error) {
+		throw new Error(parsed.error.message ?? "RPC call failed");
+	}
+	return parsed.result;
+}
+
+function createServerlessRequest(
+	body: string,
+	token: string,
+	resolve: (value: string) => void,
+	reject: (reason?: unknown) => void,
+) {
+	const req = request(
+		{
+			socketPath: getDaemonControlSocketPath(),
+			path: "/rpc",
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+				"Content-Length": Buffer.byteLength(body),
+			},
+		},
+		(res) => {
+			let chunks = "";
+			res.setEncoding("utf-8");
+			res.on("data", (chunk) => {
+				chunks += chunk;
+			});
+			res.on("end", () => {
+				if ((res.statusCode ?? 500) >= 400) {
+					reject(new Error(chunks || `RPC HTTP ${res.statusCode}`));
+					return;
+				}
+				resolve(chunks);
+			});
+		},
+	);
+	req.on("error", reject);
+	return req;
+}
+
+function ensureControlToken(): string {
+	const tokenPath = getDaemonControlTokenPath();
+	if (existsSync(tokenPath)) {
+		return readControlToken();
+	}
+	const token = randomBytes(32).toString("hex");
+	writeFileSync(tokenPath, `${token}\n`, { mode: 0o600 });
+	try {
+		chmodSync(tokenPath, 0o600);
+	} catch {
+		/* best effort */
+	}
+	return token;
+}
+
+function readControlToken(): string {
+	const tokenPath = getDaemonControlTokenPath();
+	if (!existsSync(tokenPath)) {
+		throw new Error(
+			`daemon control token not found at ${tokenPath}. Start \`clawdi daemon run\` first.`,
+		);
+	}
+	const token = readFileSync(tokenPath, "utf-8").trim();
+	if (!token) throw new Error(`daemon control token at ${tokenPath} is empty`);
+	return token;
+}
+
+async function handleHttpRequest(
+	req: IncomingMessage,
+	res: ServerResponse,
+	handlers: ControlRpcHandlers,
+	token: string,
+): Promise<void> {
+	if (req.method !== "POST" || req.url !== "/rpc") {
+		sendHttp(res, 404, { error: "not_found" });
+		return;
+	}
+	const auth = req.headers.authorization;
+	if (auth !== `Bearer ${token}`) {
+		sendHttp(res, 401, { error: "unauthorized" });
+		return;
+	}
+	let raw: string;
+	try {
+		raw = await readBody(req);
+	} catch (error) {
+		if (!res.destroyed && !res.writableEnded) {
+			sendRpcError(res, null, -32600, error instanceof Error ? error.message : "Invalid request");
+		}
+		return;
+	}
+	let request: JsonRpcRequest;
+	try {
+		request = parseJsonRpcRequest(raw);
+	} catch (error) {
+		sendRpcError(res, null, -32600, error instanceof Error ? error.message : "Invalid request");
+		return;
+	}
+	const handler = handlers[request.method];
+	if (!handler) {
+		sendRpcError(res, request.id ?? null, -32601, `Unknown RPC method: ${request.method}`);
+		return;
+	}
+	try {
+		const result = await handler(request.params ?? {});
+		sendHttp(res, 200, {
+			jsonrpc: "2.0",
+			id: request.id ?? null,
+			result,
+		});
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		sendRpcError(res, request.id ?? null, -32000, message);
+	}
+}
+
+function parseJsonRpcRequest(raw: string): JsonRpcRequest {
+	const parsed = JSON.parse(raw) as Partial<JsonRpcRequest>;
+	if (parsed.jsonrpc !== "2.0") throw new Error("jsonrpc must be 2.0");
+	if (typeof parsed.method !== "string" || parsed.method.length === 0) {
+		throw new Error("method must be a non-empty string");
+	}
+	if (
+		parsed.id !== undefined &&
+		parsed.id !== null &&
+		typeof parsed.id !== "string" &&
+		typeof parsed.id !== "number"
+	) {
+		throw new Error("id must be a string, number, or null");
+	}
+	return {
+		jsonrpc: "2.0",
+		id: parsed.id,
+		method: parsed.method,
+		params: parsed.params,
+	};
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+	return new Promise((resolve, reject) => {
+		let size = 0;
+		let body = "";
+		req.setEncoding("utf-8");
+		req.on("data", (chunk) => {
+			size += Buffer.byteLength(chunk);
+			if (size > MAX_RPC_BODY_BYTES) {
+				reject(new Error("RPC request body too large"));
+				req.destroy();
+				return;
+			}
+			body += chunk;
+		});
+		req.on("end", () => resolve(body));
+		req.on("error", reject);
+	});
+}
+
+function sendRpcError(
+	res: ServerResponse,
+	id: string | number | null,
+	code: number,
+	message: string,
+): void {
+	sendHttp(res, 200, {
+		jsonrpc: "2.0",
+		id,
+		error: { code, message },
+	});
+}
+
+function sendHttp(res: ServerResponse, status: number, body: unknown): void {
+	const text = `${JSON.stringify(body)}\n`;
+	res.writeHead(status, {
+		"Content-Type": "application/json",
+		"Content-Length": Buffer.byteLength(text),
+	});
+	res.end(text);
+}
+
+function listenOnSocket(server: Server, socketPath: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const onError = (error: Error) => {
+			server.off("listening", onListening);
+			reject(error);
+		};
+		const onListening = () => {
+			server.off("error", onError);
+			resolve();
+		};
+		server.once("error", onError);
+		server.once("listening", onListening);
+		server.listen(socketPath);
+	});
+}
+
+function closeServer(server: Server, socketPath: string): Promise<void> {
+	return new Promise((resolve) => {
+		server.close(() => {
+			try {
+				if (existsSync(socketPath)) unlinkSync(socketPath);
+			} catch {
+				/* best effort */
+			}
+			resolve();
+		});
+	});
+}
+
+function socketAcceptsConnections(socketPath: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		const socket = createConnection({ path: socketPath });
+		const done = (value: boolean) => {
+			socket.removeAllListeners();
+			socket.destroy();
+			resolve(value);
+		};
+		socket.setTimeout(200);
+		socket.once("connect", () => done(true));
+		socket.once("timeout", () => done(false));
+		socket.once("error", () => done(false));
+	});
+}

--- a/packages/cli/src/serve/installer.test.ts
+++ b/packages/cli/src/serve/installer.test.ts
@@ -253,7 +253,7 @@ describe("installer.install (macOS plist)", () => {
 });
 
 describe("installer.install (Linux systemd)", () => {
-	it("captures RPC host and port into the unit Environment", async () => {
+	it("captures RPC host, port, and remote opt-in into the unit Environment", async () => {
 		const os = await import("node:os");
 		if (os.platform() !== "linux") return;
 
@@ -268,10 +268,15 @@ describe("installer.install (Linux systemd)", () => {
 
 		try {
 			const { install } = await import("./installer");
-			const result = install({ rpcHost: "127.0.0.1", rpcPort: 17654 });
+			const result = install({
+				rpcHost: "0.0.0.0",
+				rpcPort: 17654,
+				rpcAllowRemote: true,
+			});
 			const content = readFileSync(result.unit, "utf-8");
-			expect(content).toContain('Environment="CLAWDI_DAEMON_RPC_HOST=127.0.0.1"');
+			expect(content).toContain('Environment="CLAWDI_DAEMON_RPC_HOST=0.0.0.0"');
 			expect(content).toContain('Environment="CLAWDI_DAEMON_RPC_PORT=17654"');
+			expect(content).toContain('Environment="CLAWDI_DAEMON_RPC_ALLOW_REMOTE=1"');
 		} finally {
 			process.env.PATH = oldPath;
 		}

--- a/packages/cli/src/serve/installer.test.ts
+++ b/packages/cli/src/serve/installer.test.ts
@@ -77,12 +77,15 @@ describe("installer.install (macOS plist)", () => {
 			if (os.platform() !== "darwin") return;
 
 			const { install } = await import("./installer");
-			const result = install({ agent: "claude_code" });
+			const result = install();
 			expect(existsSync(result.unit)).toBe(true);
 			const content = readFileSync(result.unit, "utf-8");
 			expect(content).toContain("<key>Label</key>");
-			expect(content).toContain("<string>ai.clawdi.serve.claude_code</string>");
+			expect(content).toContain("<string>ai.clawdi.serve</string>");
 			expect(content).toContain(process.argv[1] ?? "");
+			expect(content).toContain("<string>daemon</string>");
+			expect(content).toContain("<string>run</string>");
+			expect(content).not.toContain("<string>--agent</string>");
 			expect(content).toContain("<key>RunAtLoad</key>");
 			expect(content).toContain("<key>KeepAlive</key>");
 		} finally {
@@ -106,7 +109,7 @@ describe("installer.install (macOS plist)", () => {
 
 		try {
 			const { install } = await import("./installer");
-			const result = install({ agent: "claude_code" });
+			const result = install();
 			const content = readFileSync(result.unit, "utf-8");
 			expect(content).toContain("<key>HOME</key>");
 			expect(content).toContain(process.env.HOME ?? "");
@@ -136,7 +139,7 @@ describe("installer.install (macOS plist)", () => {
 
 		try {
 			const { install } = await import("./installer");
-			const result = install({ agent: "claude_code" });
+			const result = install();
 			const content = readFileSync(result.unit, "utf-8");
 			// Both keys baked into the plist so the daemon spawned by
 			// launchd after reboot still sees them. Without this, env-
@@ -161,7 +164,7 @@ describe("installer.install (macOS plist)", () => {
 		// daemon's `resolveEnvironmentId` prefers env vars over the
 		// per-agent file, so a captured CLAWDI_ENVIRONMENT_ID would
 		// pin every installed agent to that one env id during
-		// `clawdi daemon install --all` — all daemons trampling the
+		// singleton daemon — every engine could be routed to the
 		// same project.
 		const os = await import("node:os");
 		if (os.platform() !== "darwin") return;
@@ -178,7 +181,7 @@ describe("installer.install (macOS plist)", () => {
 		process.env.CLAWDI_ENVIRONMENT_ID = "00000000-0000-0000-0000-deadbeef0001";
 		try {
 			const { install } = await import("./installer");
-			const result = install({ agent: "claude_code" });
+			const result = install();
 			const content = readFileSync(result.unit, "utf-8");
 			// CLAWDI_ENVIRONMENT_ID must NOT appear under
 			// EnvironmentVariables — neither key nor value.
@@ -191,62 +194,6 @@ describe("installer.install (macOS plist)", () => {
 			process.env.PATH = oldPath;
 			if (oldEnv === undefined) delete process.env.CLAWDI_ENVIRONMENT_ID;
 			else process.env.CLAWDI_ENVIRONMENT_ID = oldEnv;
-		}
-	});
-
-	it("bakes explicit environmentId into ProgramArguments (not EnvironmentVariables)", async () => {
-		const os = await import("node:os");
-		if (os.platform() !== "darwin") return;
-
-		const stubBin = join(process.env.HOME ?? tmp, "stub-bin");
-		const { mkdirSync, chmodSync } = await import("node:fs");
-		mkdirSync(stubBin, { recursive: true });
-		const stubLaunchctl = join(stubBin, "launchctl");
-		writeFileSync(stubLaunchctl, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
-		chmodSync(stubLaunchctl, 0o755);
-		const oldPath = process.env.PATH;
-		process.env.PATH = `${stubBin}:${oldPath}`;
-		try {
-			const { install } = await import("./installer");
-			const result = install({
-				agent: "claude_code",
-				environmentId: "11111111-2222-3333-4444-555555555555",
-			});
-			const content = readFileSync(result.unit, "utf-8");
-			// Pinned id appears as a CLI argument (scoped to this
-			// unit), not as an env var (would leak across multi-agent
-			// installs if every unit picked up the shell var).
-			expect(content).toContain("<string>--environment-id</string>");
-			expect(content).toContain("<string>11111111-2222-3333-4444-555555555555</string>");
-			expect(content).not.toContain("<key>CLAWDI_ENVIRONMENT_ID</key>");
-		} finally {
-			process.env.PATH = oldPath;
-		}
-	});
-
-	it("rejects non-UUID environmentId at install time (defense-in-depth)", async () => {
-		const os = await import("node:os");
-		if (os.platform() !== "darwin") return;
-
-		const stubBin = join(process.env.HOME ?? tmp, "stub-bin");
-		const { mkdirSync, chmodSync } = await import("node:fs");
-		mkdirSync(stubBin, { recursive: true });
-		const stubLaunchctl = join(stubBin, "launchctl");
-		writeFileSync(stubLaunchctl, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
-		chmodSync(stubLaunchctl, 0o755);
-		const oldPath = process.env.PATH;
-		process.env.PATH = `${stubBin}:${oldPath}`;
-		try {
-			const { install } = await import("./installer");
-			expect(() =>
-				install({
-					agent: "claude_code",
-					// Shell metachar that could append `--flag` if not validated.
-					environmentId: "abc -- --flag injected",
-				}),
-			).toThrow(/non-UUID/);
-		} finally {
-			process.env.PATH = oldPath;
 		}
 	});
 
@@ -270,7 +217,7 @@ describe("installer.install (macOS plist)", () => {
 		process.env.PATH = `${stubBin}:${oldPath}`;
 		try {
 			const { install } = await import("./installer");
-			const result = install({ agent: "claude_code" });
+			const result = install();
 			const mode = statSync(result.unit).mode & 0o777;
 			expect(mode).toBe(0o600);
 		} finally {
@@ -293,11 +240,11 @@ describe("installer.install (macOS plist)", () => {
 
 		try {
 			const { install, uninstall } = await import("./installer");
-			install({ agent: "claude_code" });
-			const result = uninstall({ agent: "claude_code" });
+			install();
+			const result = uninstall();
 			expect(result.removed).toBe(true);
 			// Second uninstall is a no-op — no file, no error.
-			const result2 = uninstall({ agent: "claude_code" });
+			const result2 = uninstall();
 			expect(result2.removed).toBe(false);
 		} finally {
 			process.env.PATH = oldPath;

--- a/packages/cli/src/serve/installer.test.ts
+++ b/packages/cli/src/serve/installer.test.ts
@@ -252,6 +252,32 @@ describe("installer.install (macOS plist)", () => {
 	});
 });
 
+describe("installer.install (Linux systemd)", () => {
+	it("captures RPC host and port into the unit Environment", async () => {
+		const os = await import("node:os");
+		if (os.platform() !== "linux") return;
+
+		const stubBin = join(process.env.HOME ?? tmp, "stub-bin");
+		const { mkdirSync, chmodSync } = await import("node:fs");
+		mkdirSync(stubBin, { recursive: true });
+		const stubSystemctl = join(stubBin, "systemctl");
+		writeFileSync(stubSystemctl, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+		chmodSync(stubSystemctl, 0o755);
+		const oldPath = process.env.PATH;
+		process.env.PATH = `${stubBin}:${oldPath}`;
+
+		try {
+			const { install } = await import("./installer");
+			const result = install({ rpcHost: "127.0.0.1", rpcPort: 17654 });
+			const content = readFileSync(result.unit, "utf-8");
+			expect(content).toContain('Environment="CLAWDI_DAEMON_RPC_HOST=127.0.0.1"');
+			expect(content).toContain('Environment="CLAWDI_DAEMON_RPC_PORT=17654"');
+		} finally {
+			process.env.PATH = oldPath;
+		}
+	});
+});
+
 describe("installer.readHealth", () => {
 	it("returns exists=false when the file is missing", async () => {
 		const { readHealth } = await import("./installer");

--- a/packages/cli/src/serve/installer.ts
+++ b/packages/cli/src/serve/installer.ts
@@ -14,10 +14,10 @@
  *     the user logs out (laptops where each session ssh's into
  *     a fresh shell)
  *
- * Per-agent unit name (e.g. `ai.clawdi.serve.claude_code`) so a
- * laptop running Claude Code AND Codex can have one daemon per
- * agent without arguing about which one owns the supervisor
- * slot. v1 daemon services exactly one agent per process.
+ * `clawdi daemon install` writes one singleton unit
+ * (`ai.clawdi.serve` / `clawdi-serve.service`) whose process runs
+ * every registered agent's sync engine. Older per-agent units are
+ * still detected so setup/install can remove them during migration.
  *
  * Windows is not part of v1 — explicitly told by the user.
  */
@@ -37,15 +37,8 @@ import { homedir, platform } from "node:os";
 import { isAbsolute, join } from "node:path";
 
 interface InstallOpts {
-	agent: string;
-	/** Pinned environment id baked into the unit's
-	 * `--environment-id <id>` flag. Use ONLY when the caller
-	 * explicitly opts a single agent into a non-default env (e.g.
-	 * `clawdi daemon install --agent codex --environment-id <id>`).
-	 * Must not be derived from `process.env.CLAWDI_ENVIRONMENT_ID`
-	 * during multi-agent install (`--all`); a shell-set env var
-	 * would otherwise pin every agent unit to the same env. */
-	environmentId?: string;
+	/** Internal migration hook for removing pre-singleton per-agent units. */
+	agent?: string;
 }
 
 function home(): string {
@@ -67,11 +60,13 @@ function clawdiRoot(): string {
 	return join(home(), ".clawdi");
 }
 
-function unitName(agent: string): string {
-	// launchd labels follow reverse-DNS; systemd unit names are
-	// freeform but conventionally use a slug. We use the same
-	// agent slug both ways for predictability.
-	return `ai.clawdi.serve.${agent}`;
+function unitName(): string {
+	return "ai.clawdi.serve";
+}
+
+function daemonProgramArgs(opts: InstallOpts): string[] {
+	if (opts.agent) return ["daemon", "run", "--agent", opts.agent];
+	return ["daemon", "run"];
 }
 
 /** CLAWDI_* env vars that need to be baked into the supervisor
@@ -86,6 +81,7 @@ function unitName(agent: string): string {
  * Whitelist deliberately narrow:
  *   - CLAWDI_AUTH_TOKEN / CLAWDI_API_URL: auth + endpoint
  *   - CLAWDI_STATE_DIR: state dir override
+ *   - CLAWDI_AGENT_TYPE: container fallback when no env registry exists
  *   - CLAWDI_SERVE_MODE: container/laptop mode
  *   - CLAWDI_SERVE_DEBUG: verbose log level
  *   - CLAUDE_CONFIG_DIR / CODEX_HOME / HERMES_HOME /
@@ -96,13 +92,8 @@ function unitName(agent: string): string {
  * NOTE: `CLAWDI_ENVIRONMENT_ID` is deliberately NOT captured here.
  * It's per-agent state and lives in `~/.clawdi/environments/<agent>.json`
  * (written by `clawdi setup`). Capturing the shell env var would let a
- * single env id leak into every agent's unit during
- * `clawdi daemon install --all` — at runtime `resolveEnvironmentId`
- * prefers the env var over the per-agent file, so all daemons would
- * pin to the same env. Single-agent installs that need an explicit
- * pin pass `--environment-id` via `InstallOpts.environmentId`, which
- * gets baked into the unit's ProgramArguments (NOT
- * EnvironmentVariables) and so doesn't bleed across agents.
+ * single env id leak into the singleton daemon and be misapplied across
+ * multiple engines.
  */
 const PERSISTED_ENV_KEYS = [
 	"CLAWDI_AUTH_TOKEN",
@@ -118,6 +109,7 @@ const PERSISTED_ENV_KEYS = [
 	// `~/.clawdi/` after the user logs out — splitting state
 	// across two directories and breaking the isolation guarantee.
 	"CLAWDI_HOME",
+	"CLAWDI_AGENT_TYPE",
 	"CLAWDI_SERVE_MODE",
 	"CLAWDI_SERVE_DEBUG",
 	"CLAUDE_CONFIG_DIR",
@@ -193,7 +185,7 @@ function currentClawdiCommand(): string[] {
 	return [node, entry];
 }
 
-export function install(opts: InstallOpts): {
+export function install(opts: InstallOpts = {}): {
 	unit: string;
 	instructions: string;
 	replaced: boolean;
@@ -204,14 +196,14 @@ export function install(opts: InstallOpts): {
 	throw new Error(`unsupported platform for service install: ${p}`);
 }
 
-export function uninstall(opts: InstallOpts): { removed: boolean } {
+export function uninstall(opts: InstallOpts = {}): { removed: boolean } {
 	const p = platform();
 	if (p === "darwin") return uninstallLaunchd(opts);
 	if (p === "linux") return uninstallSystemd(opts);
 	throw new Error(`unsupported platform for service uninstall: ${p}`);
 }
 
-export function statusLines(opts: InstallOpts): string[] {
+export function statusLines(opts: InstallOpts = {}): string[] {
 	const p = platform();
 	if (p === "darwin") return statusLaunchd(opts);
 	if (p === "linux") return statusSystemd(opts);
@@ -221,7 +213,7 @@ export function statusLines(opts: InstallOpts): string[] {
 /** Restart an already-installed daemon unit. Throws if no unit is
  * installed (caller should install first) or if the supervisor
  * refuses to restart (corrupt unit, permissions, etc). */
-export function restart(opts: InstallOpts): void {
+export function restart(opts: InstallOpts = {}): void {
 	const p = platform();
 	if (p === "darwin") {
 		restartLaunchd(opts);
@@ -233,14 +225,11 @@ export function restart(opts: InstallOpts): void {
 }
 
 function restartLaunchd(opts: InstallOpts): void {
-	const path = plistPath(opts.agent);
+	const path = opts.agent ? plistPath(opts.agent) : singletonPlistPath();
 	if (!existsSync(path)) {
-		throw new Error(
-			`no daemon unit installed for ${opts.agent} ` +
-				`(run \`clawdi daemon install --agent ${opts.agent}\` first)`,
-		);
+		throw new Error("no daemon unit installed (run `clawdi daemon install` first)");
 	}
-	const label = unitName(opts.agent);
+	const label = opts.agent ? legacyUnitName(opts.agent) : unitName();
 	const target = `gui/${process.getuid?.() ?? 501}/${label}`;
 	// Two restart shapes depending on launchd's view of the unit:
 	//   - Loaded: hot restart via `kickstart -k` (kills the running
@@ -263,7 +252,7 @@ function restartLaunchd(opts: InstallOpts): void {
 }
 
 function restartSystemd(opts: InstallOpts): void {
-	const unit = `clawdi-serve-${opts.agent}.service`;
+	const unit = unitFileName(opts.agent);
 	const ok = tryRun(["systemctl", "--user", "restart", unit]);
 	if (!ok) {
 		throw new Error(
@@ -284,7 +273,15 @@ function launchAgentsDir(): string {
 }
 
 function plistPath(agent: string): string {
-	return join(launchAgentsDir(), `${unitName(agent)}.plist`);
+	return join(launchAgentsDir(), `${legacyUnitName(agent)}.plist`);
+}
+
+function singletonPlistPath(): string {
+	return join(launchAgentsDir(), `${unitName()}.plist`);
+}
+
+function legacyUnitName(agent: string): string {
+	return `ai.clawdi.serve.${agent}`;
 }
 
 function installLaunchd(opts: InstallOpts): {
@@ -292,8 +289,7 @@ function installLaunchd(opts: InstallOpts): {
 	instructions: string;
 	replaced: boolean;
 } {
-	validateEnvironmentId(opts.environmentId);
-	const label = unitName(opts.agent);
+	const label = opts.agent ? legacyUnitName(opts.agent) : unitName();
 	const [node, entry] = currentClawdiCommand();
 	const logDir = join(clawdiRoot(), "serve", "logs");
 	if (!existsSync(logDir)) mkdirSync(logDir, { recursive: true });
@@ -304,15 +300,10 @@ function installLaunchd(opts: InstallOpts): {
 	// stderr (where we emit JSON logs) lands in a rotating
 	// file the user can `tail`.
 	//
-	// `--environment-id <id>` is appended to ProgramArguments
-	// (NOT EnvironmentVariables) when the caller pinned an env_id
-	// for this specific agent. Putting it in argv keeps it scoped
-	// to this unit; an EnvironmentVariables entry could leak
-	// across multi-agent installs if every unit picked up the same
-	// shell env var.
-	const envIdArgs = opts.environmentId
-		? `\n    <string>--environment-id</string>\n    <string>${escapeXml(opts.environmentId)}</string>`
-		: "";
+	const args = daemonProgramArgs(opts);
+	const programArgs = [node, entry, ...args]
+		.map((arg) => `    <string>${escapeXml(arg)}</string>`)
+		.join("\n");
 	const plist = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -321,12 +312,7 @@ function installLaunchd(opts: InstallOpts): {
   <string>${escapeXml(label)}</string>
   <key>ProgramArguments</key>
   <array>
-    <string>${escapeXml(node)}</string>
-    <string>${escapeXml(entry)}</string>
-    <string>daemon</string>
-    <string>run</string>
-    <string>--agent</string>
-    <string>${escapeXml(opts.agent)}</string>${envIdArgs}
+${programArgs}
   </array>
   <key>RunAtLoad</key>
   <true/>
@@ -335,9 +321,9 @@ function installLaunchd(opts: InstallOpts): {
   <key>ThrottleInterval</key>
   <integer>10</integer>
   <key>StandardErrorPath</key>
-  <string>${escapeXml(join(logDir, `${opts.agent}.stderr.log`))}</string>
+  <string>${escapeXml(join(logDir, `${opts.agent ?? "daemon"}.stderr.log`))}</string>
   <key>StandardOutPath</key>
-  <string>${escapeXml(join(logDir, `${opts.agent}.stdout.log`))}</string>
+  <string>${escapeXml(join(logDir, `${opts.agent ?? "daemon"}.stdout.log`))}</string>
   <key>EnvironmentVariables</key>
   <dict>
     <key>HOME</key>
@@ -352,7 +338,7 @@ function installLaunchd(opts: InstallOpts): {
 </plist>
 `;
 
-	const path = plistPath(opts.agent);
+	const path = opts.agent ? plistPath(opts.agent) : singletonPlistPath();
 	// Sample BEFORE we writeFileSync — caller wants to know
 	// whether this install was a fresh write or replacing an
 	// existing unit.
@@ -381,15 +367,15 @@ function installLaunchd(opts: InstallOpts): {
 	const loaded = tryRun(["launchctl", "load", "-w", path]);
 
 	const instructions = loaded
-		? `Loaded ${label}. Tail logs with: tail -f ${join(logDir, `${opts.agent}.stderr.log`)}`
+		? `Loaded ${label}. Tail logs with: tail -f ${join(logDir, `${opts.agent ?? "daemon"}.stderr.log`)}`
 		: `Wrote plist to ${path}, but launchctl load failed (try: launchctl load -w "${path}").`;
 	return { unit: path, instructions, replaced };
 }
 
 function uninstallLaunchd(opts: InstallOpts): { removed: boolean } {
-	const path = plistPath(opts.agent);
+	const path = opts.agent ? plistPath(opts.agent) : singletonPlistPath();
 	if (!existsSync(path)) return { removed: false };
-	const label = unitName(opts.agent);
+	const label = opts.agent ? legacyUnitName(opts.agent) : unitName();
 	// Stop the daemon BEFORE removing the plist. Pre-fix this used a
 	// bare `tryRun(["launchctl", "unload", path])` and ignored the
 	// return code, then `unlinkSync(path)` regardless — so a
@@ -422,9 +408,9 @@ function uninstallLaunchd(opts: InstallOpts): { removed: boolean } {
 }
 
 function statusLaunchd(opts: InstallOpts): string[] {
-	const label = unitName(opts.agent);
+	const label = opts.agent ? legacyUnitName(opts.agent) : unitName();
 	const lines: string[] = [];
-	const path = plistPath(opts.agent);
+	const path = opts.agent ? plistPath(opts.agent) : singletonPlistPath();
 	lines.push(`unit:    ${existsSync(path) ? path : "(not installed)"}`);
 	const out = tryRunCapture(["launchctl", "list", label]);
 	if (out !== null) {
@@ -452,8 +438,12 @@ function systemdUserDir(): string {
 	return dir;
 }
 
-function unitPath(agent: string): string {
-	return join(systemdUserDir(), `clawdi-serve-${agent}.service`);
+function unitFileName(agent?: string): string {
+	return agent ? `clawdi-serve-${agent}.service` : "clawdi-serve.service";
+}
+
+function unitPath(agent?: string): string {
+	return join(systemdUserDir(), unitFileName(agent));
 }
 
 function installSystemd(opts: InstallOpts): {
@@ -461,10 +451,10 @@ function installSystemd(opts: InstallOpts): {
 	instructions: string;
 	replaced: boolean;
 } {
-	validateEnvironmentId(opts.environmentId);
 	const [node, entry] = currentClawdiCommand();
 	const path = unitPath(opts.agent);
 	const replaced = existsSync(path);
+	const args = daemonProgramArgs(opts);
 
 	// systemd `Environment="KEY=VALUE"` parses backslash + double-
 	// quote inside the value. A $HOME containing `"` could close
@@ -515,15 +505,13 @@ function installSystemd(opts: InstallOpts): {
 	// of "start at user login"; requires `loginctl enable-linger
 	// <user>` to fire on boot rather than first login session.
 	const unit = `[Unit]
-Description=clawdi daemon (${opts.agent})
+Description=clawdi daemon
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=${shellEscape(node)} ${shellEscape(entry)} daemon run --agent ${shellEscape(opts.agent)}${
-		opts.environmentId ? ` --environment-id ${shellEscape(opts.environmentId)}` : ""
-	}
+ExecStart=${[node, entry, ...args].map(shellEscape).join(" ")}
 Restart=always
 RestartSec=10
 RestartPreventExitStatus=2
@@ -547,24 +535,18 @@ WantedBy=default.target
 		/* best effort */
 	}
 	tryRun(["systemctl", "--user", "daemon-reload"]);
-	const enabled = tryRun([
-		"systemctl",
-		"--user",
-		"enable",
-		"--now",
-		`clawdi-serve-${opts.agent}.service`,
-	]);
+	const enabled = tryRun(["systemctl", "--user", "enable", "--now", unitFileName(opts.agent)]);
 
 	const instructions = enabled
-		? `Enabled and started clawdi-serve-${opts.agent}.service. Tail logs with: journalctl --user -u clawdi-serve-${opts.agent} -f`
-		: `Wrote ${path} but systemctl enable failed. Try: systemctl --user enable --now clawdi-serve-${opts.agent}.service`;
+		? `Enabled and started ${unitFileName(opts.agent)}. Tail logs with: journalctl --user -u ${unitFileName(opts.agent)} -f`
+		: `Wrote ${path} but systemctl enable failed. Try: systemctl --user enable --now ${unitFileName(opts.agent)}`;
 	return { unit: path, instructions, replaced };
 }
 
 function uninstallSystemd(opts: InstallOpts): { removed: boolean } {
 	const path = unitPath(opts.agent);
 	if (!existsSync(path)) return { removed: false };
-	tryRun(["systemctl", "--user", "disable", "--now", `clawdi-serve-${opts.agent}.service`]);
+	tryRun(["systemctl", "--user", "disable", "--now", unitFileName(opts.agent)]);
 	unlinkSync(path);
 	tryRun(["systemctl", "--user", "daemon-reload"]);
 	return { removed: true };
@@ -574,18 +556,13 @@ function statusSystemd(opts: InstallOpts): string[] {
 	const lines: string[] = [];
 	const path = unitPath(opts.agent);
 	lines.push(`unit:    ${existsSync(path) ? path : "(not installed)"}`);
-	const out = tryRunCapture([
-		"systemctl",
-		"--user",
-		"is-active",
-		`clawdi-serve-${opts.agent}.service`,
-	]);
+	const out = tryRunCapture(["systemctl", "--user", "is-active", unitFileName(opts.agent)]);
 	lines.push(`active:  ${out?.trim() ?? "unknown"}`);
 	const sub = tryRunCapture([
 		"systemctl",
 		"--user",
 		"status",
-		`clawdi-serve-${opts.agent}.service`,
+		unitFileName(opts.agent),
 		"--no-pager",
 	]);
 	if (sub !== null) {
@@ -634,23 +611,6 @@ function escapeXml(s: string): string {
 		.replace(/'/g, "&apos;");
 }
 
-/** Validate `environmentId` is safe to bake into a unit's argv.
- * Defense-in-depth — the install command should already pass a
- * UUID, but injecting a control char or shell metachar via a
- * compromised env file would otherwise let an attacker append
- * arbitrary `--flag` arguments. Allow only the canonical UUID
- * shape. */
-function validateEnvironmentId(envId: string | undefined): void {
-	if (envId === undefined) return;
-	const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-	if (!UUID_RE.test(envId)) {
-		throw new Error(
-			`refusing to install with non-UUID --environment-id (${envId}). ` +
-				"Pass a valid environment id from `clawdi setup` output.",
-		);
-	}
-}
-
 function shellEscape(s: string): string {
 	// systemd unit ExecStart accepts a quoted form for paths
 	// containing spaces. Wrap in double-quotes and escape any
@@ -661,13 +621,10 @@ function shellEscape(s: string): string {
 }
 
 /** Scan the OS supervisor for every clawdi daemon unit installed
- * by `clawdi daemon install`, regardless of whether its agent is
- * still registered in `~/.clawdi/environments/`. Used by callers
- * that need to act on the actual installed surface (e.g. `serve
- * restart --all`, `auth logout`'s warn-about-residual-daemons
- * check) — `listRegisteredAgentTypes()` would miss daemons whose
- * env file was deleted out from under them, leaving the unit
- * orphaned but still running.
+ * by older `clawdi daemon install --agent <agent>` builds,
+ * regardless of whether its agent is still registered in
+ * `~/.clawdi/environments/`. Used only for migration cleanup and
+ * logout warnings.
  *
  * Cheap implementation: enumerate `~/Library/LaunchAgents/` (macOS)
  * or `~/.config/systemd/user/` (Linux) and pattern-match against
@@ -684,6 +641,21 @@ export function listInstalledAgents(): KnownAgent[] {
 		if (path && existsSync(path)) installed.push(agent);
 	}
 	return installed;
+}
+
+export type InstalledDaemonTarget = KnownAgent | "daemon";
+
+export function isSingletonDaemonInstalled(): boolean {
+	const p = platform();
+	const path = p === "darwin" ? singletonPlistPath() : p === "linux" ? unitPath() : null;
+	return path ? existsSync(path) : false;
+}
+
+export function listInstalledDaemonTargets(): InstalledDaemonTarget[] {
+	const targets: InstalledDaemonTarget[] = [];
+	if (isSingletonDaemonInstalled()) targets.push("daemon");
+	targets.push(...listInstalledAgents());
+	return targets;
 }
 
 /** Health-file age check, used by `clawdi daemon status` even

--- a/packages/cli/src/serve/installer.ts
+++ b/packages/cli/src/serve/installer.ts
@@ -56,7 +56,7 @@ function home(): string {
  * `$HOME/.clawdi/serve/logs/...` into the plist while `daemon logs`
  * (which DID honor CLAWDI_HOME via `getServeLogPath`) looked at
  * `/foo/serve/logs/...` — `daemon logs` couldn't find the file.
- * Codex flagged this as P2 in PR-#74 review. */
+ * The installer and log command must resolve the same state root. */
 function clawdiRoot(): string {
 	const homeOverride = process.env.CLAWDI_HOME;
 	if (homeOverride) return homeOverride;

--- a/packages/cli/src/serve/installer.ts
+++ b/packages/cli/src/serve/installer.ts
@@ -39,6 +39,8 @@ import { isAbsolute, join } from "node:path";
 interface InstallOpts {
 	/** Internal migration hook for removing pre-singleton per-agent units. */
 	agent?: string;
+	rpcHost?: string;
+	rpcPort?: number;
 }
 
 function home(): string {
@@ -81,6 +83,8 @@ function daemonProgramArgs(opts: InstallOpts): string[] {
  * Whitelist deliberately narrow:
  *   - CLAWDI_AUTH_TOKEN / CLAWDI_API_URL: auth + endpoint
  *   - CLAWDI_STATE_DIR: state dir override
+ *   - CLAWDI_DAEMON_RPC_HOST / CLAWDI_DAEMON_RPC_PORT: optional
+ *     TCP listener for the owner-token-protected control RPC
  *   - CLAWDI_AGENT_TYPE: container fallback when no env registry exists
  *   - CLAWDI_SERVE_MODE: container/laptop mode
  *   - CLAWDI_SERVE_DEBUG: verbose log level
@@ -99,6 +103,8 @@ const PERSISTED_ENV_KEYS = [
 	"CLAWDI_AUTH_TOKEN",
 	"CLAWDI_API_URL",
 	"CLAWDI_STATE_DIR",
+	"CLAWDI_DAEMON_RPC_HOST",
+	"CLAWDI_DAEMON_RPC_PORT",
 	// CLAWDI_HOME redirects the entire CLI state tree (auth.json,
 	// environments, locks, serve queue/health) to a sibling
 	// directory; honored by `lib/config.ts:clawdiDir()` and
@@ -119,7 +125,7 @@ const PERSISTED_ENV_KEYS = [
 	"OPENCLAW_AGENT_ID",
 ] as const;
 
-function capturedEnv(): { key: string; value: string }[] {
+function capturedEnv(opts: InstallOpts = {}): { key: string; value: string }[] {
 	const out: { key: string; value: string }[] = [];
 	for (const key of PERSISTED_ENV_KEYS) {
 		const value = process.env[key];
@@ -127,7 +133,27 @@ function capturedEnv(): { key: string; value: string }[] {
 			out.push({ key, value });
 		}
 	}
+	upsertCapturedEnv(out, "CLAWDI_DAEMON_RPC_HOST", opts.rpcHost);
+	upsertCapturedEnv(
+		out,
+		"CLAWDI_DAEMON_RPC_PORT",
+		opts.rpcPort === undefined ? undefined : String(opts.rpcPort),
+	);
 	return out;
+}
+
+function upsertCapturedEnv(
+	out: { key: string; value: string }[],
+	key: string,
+	value?: string,
+): void {
+	if (value === undefined || value === "") return;
+	const existing = out.find((item) => item.key === key);
+	if (existing) {
+		existing.value = value;
+		return;
+	}
+	out.push({ key, value });
 }
 
 /** Path to the currently-running clawdi entry point. Both paths
@@ -327,7 +353,7 @@ ${programArgs}
   <key>EnvironmentVariables</key>
   <dict>
     <key>HOME</key>
-    <string>${escapeXml(home())}</string>${capturedEnv()
+    <string>${escapeXml(home())}</string>${capturedEnv(opts)
 			.map(
 				({ key, value }) =>
 					`\n    <key>${escapeXml(key)}</key>\n    <string>${escapeXml(value)}</string>`,
@@ -478,7 +504,7 @@ function installSystemd(opts: InstallOpts): {
 	// inject newlines + extra Environment= directives); escape
 	// `\` and `"` for the rest.
 	const envLines: string[] = [`Environment="HOME=${escapedHome}"`];
-	for (const { key, value } of capturedEnv()) {
+	for (const { key, value } of capturedEnv(opts)) {
 		// biome-ignore lint/suspicious/noControlCharactersInRegex: targeting control chars on purpose
 		if (/[\x00-\x1F\x7F]/.test(value)) {
 			throw new Error(

--- a/packages/cli/src/serve/installer.ts
+++ b/packages/cli/src/serve/installer.ts
@@ -41,6 +41,7 @@ interface InstallOpts {
 	agent?: string;
 	rpcHost?: string;
 	rpcPort?: number;
+	rpcAllowRemote?: boolean;
 }
 
 function home(): string {
@@ -83,8 +84,9 @@ function daemonProgramArgs(opts: InstallOpts): string[] {
  * Whitelist deliberately narrow:
  *   - CLAWDI_AUTH_TOKEN / CLAWDI_API_URL: auth + endpoint
  *   - CLAWDI_STATE_DIR: state dir override
- *   - CLAWDI_DAEMON_RPC_HOST / CLAWDI_DAEMON_RPC_PORT: optional
- *     TCP listener for the owner-token-protected control RPC
+ *   - CLAWDI_DAEMON_RPC_HOST / CLAWDI_DAEMON_RPC_PORT /
+ *     CLAWDI_DAEMON_RPC_ALLOW_REMOTE: optional HTTP listener for
+ *     the owner-token-protected control RPC
  *   - CLAWDI_AGENT_TYPE: container fallback when no env registry exists
  *   - CLAWDI_SERVE_MODE: container/laptop mode
  *   - CLAWDI_SERVE_DEBUG: verbose log level
@@ -105,6 +107,7 @@ const PERSISTED_ENV_KEYS = [
 	"CLAWDI_STATE_DIR",
 	"CLAWDI_DAEMON_RPC_HOST",
 	"CLAWDI_DAEMON_RPC_PORT",
+	"CLAWDI_DAEMON_RPC_ALLOW_REMOTE",
 	// CLAWDI_HOME redirects the entire CLI state tree (auth.json,
 	// environments, locks, serve queue/health) to a sibling
 	// directory; honored by `lib/config.ts:clawdiDir()` and
@@ -138,6 +141,11 @@ function capturedEnv(opts: InstallOpts = {}): { key: string; value: string }[] {
 		out,
 		"CLAWDI_DAEMON_RPC_PORT",
 		opts.rpcPort === undefined ? undefined : String(opts.rpcPort),
+	);
+	upsertCapturedEnv(
+		out,
+		"CLAWDI_DAEMON_RPC_ALLOW_REMOTE",
+		opts.rpcAllowRemote === true ? "1" : undefined,
 	);
 	return out;
 }

--- a/packages/cli/src/serve/installer.ts
+++ b/packages/cli/src/serve/installer.ts
@@ -85,7 +85,7 @@ function daemonProgramArgs(opts: InstallOpts): string[] {
  *   - CLAWDI_AUTH_TOKEN / CLAWDI_API_URL: auth + endpoint
  *   - CLAWDI_STATE_DIR: state dir override
  *   - CLAWDI_DAEMON_RPC_HOST / CLAWDI_DAEMON_RPC_PORT /
- *     CLAWDI_DAEMON_RPC_ALLOW_REMOTE: optional HTTP listener for
+ *     CLAWDI_DAEMON_RPC_ALLOW_REMOTE: HTTP listener settings for
  *     the owner-token-protected control RPC
  *   - CLAWDI_AGENT_TYPE: container fallback when no env registry exists
  *   - CLAWDI_SERVE_MODE: container/laptop mode

--- a/packages/cli/src/serve/operation-runner.ts
+++ b/packages/cli/src/serve/operation-runner.ts
@@ -5,6 +5,7 @@ import { stripTerminalEscapes } from "../lib/sanitize";
 
 const MAX_OUTPUT_LINES = 1000;
 const MAX_OPERATIONS = 100;
+const MAX_RUNNING_OPERATIONS = 4;
 const DEFAULT_IMMEDIATE_TIMEOUT_MS = 60_000;
 
 export type OperationStatus = "running" | "succeeded" | "failed" | "cancelled";
@@ -20,6 +21,7 @@ export interface OperationSnapshot {
 	id: string;
 	name: string;
 	status: OperationStatus;
+	exclusive_key?: string;
 	command: string[];
 	cwd: string;
 	started_at: string;
@@ -40,6 +42,7 @@ export interface CommandOperationOptions {
 	cwd?: string;
 	stdin?: string;
 	redactedArgs?: string[];
+	exclusiveKey?: string;
 }
 
 export interface ImmediateCommandOptions extends CommandOperationOptions {
@@ -50,17 +53,20 @@ class OperationManager {
 	private operations = new Map<string, OperationRecord>();
 
 	start(options: CommandOperationOptions): OperationSnapshot {
+		this.assertCanStart(options);
 		const invocation = buildCliInvocation(options.args);
 		const cwd = resolveOperationCwd(options.cwd);
 		const child = spawn(invocation.command, invocation.args, {
 			cwd,
 			env: nestedCliEnv(),
+			detached: process.platform !== "win32",
 			stdio: ["pipe", "pipe", "pipe"],
 		});
 		const operation: OperationRecord = {
 			id: randomUUID(),
 			name: options.name,
 			status: "running",
+			exclusive_key: options.exclusiveKey,
 			command: [invocation.command, ...(options.redactedArgs ?? invocation.args)],
 			cwd,
 			started_at: new Date().toISOString(),
@@ -120,9 +126,24 @@ class OperationManager {
 		if (operation.status === "running") {
 			operation.status = "cancelled";
 			operation.finished_at = new Date().toISOString();
-			operation.child.kill("SIGTERM");
+			terminateChild(operation.child);
 		}
 		return snapshotOperation(operation);
+	}
+
+	private assertCanStart(options: CommandOperationOptions): void {
+		const running = [...this.operations.values()].filter(
+			(operation) => operation.status === "running",
+		);
+		if (running.length >= MAX_RUNNING_OPERATIONS) {
+			throw new Error(`Too many running daemon operations (max ${MAX_RUNNING_OPERATIONS}).`);
+		}
+		if (
+			options.exclusiveKey &&
+			running.some((operation) => operation.exclusive_key === options.exclusiveKey)
+		) {
+			throw new Error(`Another ${options.exclusiveKey} operation is already running.`);
+		}
 	}
 
 	private prune(): void {
@@ -152,6 +173,7 @@ export async function runCliCommandImmediate(
 		const child = spawn(invocation.command, invocation.args, {
 			cwd,
 			env: nestedCliEnv(),
+			detached: process.platform !== "win32",
 			stdio: ["pipe", "pipe", "pipe"],
 		});
 		const finish = (result: CommandResult) => {
@@ -165,7 +187,7 @@ export async function runCliCommandImmediate(
 			});
 		};
 		const timer = setTimeout(() => {
-			child.kill("SIGTERM");
+			terminateChild(child);
 			finish({
 				exit_code: null,
 				signal: "SIGTERM",
@@ -200,6 +222,7 @@ function snapshotOperation(operation: OperationRecord): OperationSnapshot {
 		id: operation.id,
 		name: operation.name,
 		status: operation.status,
+		exclusive_key: operation.exclusive_key,
 		command: operation.command,
 		cwd: operation.cwd,
 		started_at: operation.started_at,
@@ -240,10 +263,63 @@ function resolveOperationCwd(cwd: string | undefined): string {
 	return resolve(cwd ?? process.cwd());
 }
 
+const NESTED_CLI_ENV_KEYS = [
+	"PATH",
+	"HOME",
+	"USER",
+	"LOGNAME",
+	"SHELL",
+	"LANG",
+	"LC_ALL",
+	"TMPDIR",
+	"TEMP",
+	"TMP",
+	"CI",
+	"GITHUB_ACTIONS",
+	"CLAWDI_AUTH_TOKEN",
+	"CLAWDI_API_URL",
+	"CLAWDI_HOME",
+	"CLAWDI_STATE_DIR",
+	"CLAWDI_AGENT_TYPE",
+	"CLAWDI_SERVE_MODE",
+	"CLAWDI_SERVE_DEBUG",
+	"CLAUDE_CONFIG_DIR",
+	"CODEX_HOME",
+	"HERMES_HOME",
+	"OPENCLAW_STATE_DIR",
+	"OPENCLAW_AGENT_ID",
+	"HTTP_PROXY",
+	"HTTPS_PROXY",
+	"NO_PROXY",
+	"http_proxy",
+	"https_proxy",
+	"no_proxy",
+	"SSL_CERT_FILE",
+	"SSL_CERT_DIR",
+	"NODE_EXTRA_CA_CERTS",
+	"BUN_INSTALL",
+] as const;
+
 function nestedCliEnv(): NodeJS.ProcessEnv {
-	return {
-		...process.env,
+	const env: NodeJS.ProcessEnv = {
 		CLAWDI_NO_UPDATE_CHECK: "1",
 		CLAWDI_NO_AUTO_UPDATE: "1",
 	};
+	for (const key of NESTED_CLI_ENV_KEYS) {
+		const value = process.env[key];
+		if (value !== undefined) env[key] = value;
+	}
+	return env;
+}
+
+function terminateChild(child: ChildProcess): void {
+	if (process.platform !== "win32" && child.pid) {
+		try {
+			process.kill(-child.pid, "SIGTERM");
+			return;
+		} catch {
+			// Fall back to signalling the direct child.
+		}
+	}
+	child.kill("SIGTERM");
 }

--- a/packages/cli/src/serve/operation-runner.ts
+++ b/packages/cli/src/serve/operation-runner.ts
@@ -1,0 +1,249 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+import { stripTerminalEscapes } from "../lib/sanitize";
+
+const MAX_OUTPUT_LINES = 1000;
+const MAX_OPERATIONS = 100;
+const DEFAULT_IMMEDIATE_TIMEOUT_MS = 60_000;
+
+export type OperationStatus = "running" | "succeeded" | "failed" | "cancelled";
+
+export interface CommandResult {
+	exit_code: number | null;
+	signal: NodeJS.Signals | null;
+	stdout: string;
+	stderr: string;
+}
+
+export interface OperationSnapshot {
+	id: string;
+	name: string;
+	status: OperationStatus;
+	command: string[];
+	cwd: string;
+	started_at: string;
+	finished_at: string | null;
+	exit_code: number | null;
+	signal: NodeJS.Signals | null;
+	stdout: string[];
+	stderr: string[];
+}
+
+interface OperationRecord extends OperationSnapshot {
+	child: ChildProcess;
+}
+
+export interface CommandOperationOptions {
+	name: string;
+	args: string[];
+	cwd?: string;
+	stdin?: string;
+	redactedArgs?: string[];
+}
+
+export interface ImmediateCommandOptions extends CommandOperationOptions {
+	timeoutMs?: number;
+}
+
+class OperationManager {
+	private operations = new Map<string, OperationRecord>();
+
+	start(options: CommandOperationOptions): OperationSnapshot {
+		const invocation = buildCliInvocation(options.args);
+		const cwd = resolveOperationCwd(options.cwd);
+		const child = spawn(invocation.command, invocation.args, {
+			cwd,
+			env: nestedCliEnv(),
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		const operation: OperationRecord = {
+			id: randomUUID(),
+			name: options.name,
+			status: "running",
+			command: [invocation.command, ...(options.redactedArgs ?? invocation.args)],
+			cwd,
+			started_at: new Date().toISOString(),
+			finished_at: null,
+			exit_code: null,
+			signal: null,
+			stdout: [],
+			stderr: [],
+			child,
+		};
+		this.operations.set(operation.id, operation);
+		this.prune();
+		child.stdout?.setEncoding("utf8");
+		child.stderr?.setEncoding("utf8");
+		child.stdout?.on("data", (chunk: string) => appendLines(operation.stdout, chunk));
+		child.stderr?.on("data", (chunk: string) => appendLines(operation.stderr, chunk));
+		child.on("error", (error) => {
+			appendLines(operation.stderr, error.message);
+		});
+		child.on("close", (code, signal) => {
+			operation.exit_code = code;
+			operation.signal = signal;
+			operation.finished_at = new Date().toISOString();
+			if (operation.status !== "cancelled") {
+				operation.status = code === 0 ? "succeeded" : "failed";
+			}
+		});
+		if (options.stdin !== undefined) {
+			child.stdin?.end(options.stdin);
+		} else {
+			child.stdin?.end();
+		}
+		return snapshotOperation(operation);
+	}
+
+	list(limit = 50): OperationSnapshot[] {
+		return [...this.operations.values()].slice(-limit).reverse().map(snapshotOperation);
+	}
+
+	get(id: string): OperationSnapshot | null {
+		const operation = this.operations.get(id);
+		return operation ? snapshotOperation(operation) : null;
+	}
+
+	logs(id: string, limit = 200): { stdout: string[]; stderr: string[] } | null {
+		const operation = this.operations.get(id);
+		if (!operation) return null;
+		return {
+			stdout: tail(operation.stdout, limit),
+			stderr: tail(operation.stderr, limit),
+		};
+	}
+
+	cancel(id: string): OperationSnapshot | null {
+		const operation = this.operations.get(id);
+		if (!operation) return null;
+		if (operation.status === "running") {
+			operation.status = "cancelled";
+			operation.finished_at = new Date().toISOString();
+			operation.child.kill("SIGTERM");
+		}
+		return snapshotOperation(operation);
+	}
+
+	private prune(): void {
+		let overflow = this.operations.size - MAX_OPERATIONS;
+		if (overflow <= 0) return;
+		for (const operation of this.operations.values()) {
+			if (overflow <= 0) break;
+			if (operation.status === "running") continue;
+			this.operations.delete(operation.id);
+			overflow -= 1;
+		}
+	}
+}
+
+export const operationManager = new OperationManager();
+
+export async function runCliCommandImmediate(
+	options: ImmediateCommandOptions,
+): Promise<CommandResult> {
+	const invocation = buildCliInvocation(options.args);
+	const cwd = resolveOperationCwd(options.cwd);
+	const timeoutMs = options.timeoutMs ?? DEFAULT_IMMEDIATE_TIMEOUT_MS;
+	return await new Promise<CommandResult>((resolveResult) => {
+		let stdout = "";
+		let stderr = "";
+		let settled = false;
+		const child = spawn(invocation.command, invocation.args, {
+			cwd,
+			env: nestedCliEnv(),
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		const finish = (result: CommandResult) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			resolveResult({
+				...result,
+				stdout: stripTerminalEscapes(result.stdout),
+				stderr: stripTerminalEscapes(result.stderr),
+			});
+		};
+		const timer = setTimeout(() => {
+			child.kill("SIGTERM");
+			finish({
+				exit_code: null,
+				signal: "SIGTERM",
+				stdout,
+				stderr: `${stderr}${stderr ? "\n" : ""}Command timed out after ${timeoutMs}ms.`,
+			});
+		}, timeoutMs);
+		child.stdout?.setEncoding("utf8");
+		child.stderr?.setEncoding("utf8");
+		child.stdout?.on("data", (chunk: string) => {
+			stdout += chunk;
+		});
+		child.stderr?.on("data", (chunk: string) => {
+			stderr += chunk;
+		});
+		child.on("error", (error) => {
+			stderr += `${stderr ? "\n" : ""}${error.message}`;
+		});
+		child.on("close", (code, signal) => {
+			finish({ exit_code: code, signal, stdout, stderr });
+		});
+		if (options.stdin !== undefined) {
+			child.stdin?.end(options.stdin);
+		} else {
+			child.stdin?.end();
+		}
+	});
+}
+
+function snapshotOperation(operation: OperationRecord): OperationSnapshot {
+	return {
+		id: operation.id,
+		name: operation.name,
+		status: operation.status,
+		command: operation.command,
+		cwd: operation.cwd,
+		started_at: operation.started_at,
+		finished_at: operation.finished_at,
+		exit_code: operation.exit_code,
+		signal: operation.signal,
+		stdout: tail(operation.stdout, 200),
+		stderr: tail(operation.stderr, 200),
+	};
+}
+
+function appendLines(target: string[], chunk: string): void {
+	for (const line of stripTerminalEscapes(chunk).split(/\r?\n/)) {
+		if (!line) continue;
+		target.push(line);
+	}
+	if (target.length > MAX_OUTPUT_LINES) {
+		target.splice(0, target.length - MAX_OUTPUT_LINES);
+	}
+}
+
+function tail(lines: string[], limit: number): string[] {
+	return lines.slice(Math.max(0, lines.length - limit));
+}
+
+function buildCliInvocation(args: string[]): { command: string; args: string[] } {
+	const entrypoint = process.argv[1];
+	if (!entrypoint) {
+		throw new Error("Cannot resolve the current clawdi CLI entrypoint for RPC operation.");
+	}
+	return {
+		command: process.execPath,
+		args: [entrypoint, ...args],
+	};
+}
+
+function resolveOperationCwd(cwd: string | undefined): string {
+	return resolve(cwd ?? process.cwd());
+}
+
+function nestedCliEnv(): NodeJS.ProcessEnv {
+	return {
+		...process.env,
+		CLAWDI_NO_UPDATE_CHECK: "1",
+		CLAWDI_NO_AUTO_UPDATE: "1",
+	};
+}

--- a/packages/cli/src/serve/paths.ts
+++ b/packages/cli/src/serve/paths.ts
@@ -56,10 +56,6 @@ export function getDaemonControlDir(): string {
 	return join(clawdiRoot(), "daemon");
 }
 
-export function getDaemonControlSocketPath(): string {
-	return join(getDaemonControlDir(), "control.sock");
-}
-
 export function getDaemonControlTokenPath(): string {
 	return join(getDaemonControlDir(), "control-token");
 }

--- a/packages/cli/src/serve/paths.ts
+++ b/packages/cli/src/serve/paths.ts
@@ -17,24 +17,28 @@
  *      isolation guarantee. Mirrors `getClawdiDir()` in
  *      `lib/config.ts`.
  *
- *   3. Default `$HOME/.clawdi/serve/<agent>/` so the queue file
- *      sits alongside auth.json. Per-agent suffix matters: a
- *      laptop running both Claude Code and Codex daemons can't
- *      share `queue.jsonl` — atomic-rename would race and one
- *      daemon's view of the queue would silently overwrite the
- *      other's.
+ *   3. Default `$HOME/.clawdi/serve/<agent>/` so each sync engine's
+ *      queue file sits alongside auth.json. Per-agent suffix still
+ *      matters inside the singleton daemon: Claude Code and Codex
+ *      engines can't share `queue.jsonl` — atomic-rename would race
+ *      and one engine's view of the queue would silently overwrite
+ *      the other's.
  */
 
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+function clawdiRoot(): string {
+	const homeOverride = process.env.CLAWDI_HOME;
+	if (homeOverride) return homeOverride;
+	const home = process.env.HOME || homedir();
+	return join(home, ".clawdi");
+}
+
 export function getServeStateDir(agentType: string): string {
 	const stateOverride = process.env.CLAWDI_STATE_DIR;
 	if (stateOverride) return join(stateOverride, agentType);
-	const homeOverride = process.env.CLAWDI_HOME;
-	if (homeOverride) return join(homeOverride, "serve", agentType);
-	const home = process.env.HOME || homedir();
-	return join(home, ".clawdi", "serve", agentType);
+	return join(clawdiRoot(), "serve", agentType);
 }
 
 /** Path to a daemon's stderr/stdout log file. The daemon writes
@@ -43,7 +47,19 @@ export function getServeStateDir(agentType: string): string {
  * launchd/systemd at unit-load time per the path baked into the
  * unit definition (see `installer.ts`). */
 export function getServeLogPath(agentType: string, stream: "stderr" | "stdout"): string {
-	const homeOverride = process.env.CLAWDI_HOME;
-	const root = homeOverride ?? join(process.env.HOME || homedir(), ".clawdi");
-	return join(root, "serve", "logs", `${agentType}.${stream}.log`);
+	return join(clawdiRoot(), "serve", "logs", `${agentType}.${stream}.log`);
+}
+
+export function getDaemonControlDir(): string {
+	const stateOverride = process.env.CLAWDI_STATE_DIR;
+	if (stateOverride) return join(stateOverride, "control");
+	return join(clawdiRoot(), "daemon");
+}
+
+export function getDaemonControlSocketPath(): string {
+	return join(getDaemonControlDir(), "control.sock");
+}
+
+export function getDaemonControlTokenPath(): string {
+	return join(getDaemonControlDir(), "control-token");
 }

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -78,6 +78,24 @@ const HEARTBEAT_INTERVAL_MS = 30_000;
 // (dashboard install / delete) propagate to the machine; 60s is
 // the worst-case lag a user sees after acting on the dashboard.
 const RECONCILE_INTERVAL_MS = 60_000;
+const LAUNCHD_DAEMON_LABEL = "ai.clawdi.serve";
+
+function removeLaunchdDaemonSupervision(agentType: string): void {
+	if (process.platform !== "darwin") return;
+	void (async () => {
+		try {
+			const { execFile } = await import("node:child_process");
+			for (const label of [LAUNCHD_DAEMON_LABEL, `${LAUNCHD_DAEMON_LABEL}.${agentType}`]) {
+				execFile("launchctl", ["remove", label], () => {
+					// fire-and-forget; the daemon is exiting anyway
+				});
+			}
+		} catch {
+			/* launchctl missing, ignore — the manual `launchctl unload`
+			 * from the user is the fallback. */
+		}
+	})();
+}
 // Backoff between retry attempts when the queue has items but the
 // last drain attempt failed. Keeps the daemon from hammering a
 // dead network. Per-item attempts counter caps the work too.
@@ -326,14 +344,7 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 			// handler below — boot-time auth failure also needs
 			// supervision removal on macOS or launchd respawns
 			// the daemon every 10s.
-			if (process.platform === "darwin" && opts.adapter.agentType) {
-				try {
-					const { execFile } = await import("node:child_process");
-					execFile("launchctl", ["remove", `ai.clawdi.serve.${opts.adapter.agentType}`], () => {});
-				} catch {
-					/* launchctl missing, fall through */
-				}
-			}
+			removeLaunchdDaemonSupervision(opts.adapter.agentType);
 			opts.abortController.abort();
 			return;
 		}
@@ -400,20 +411,7 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 		// the same revoked key isn't retried every 10s. Best-effort:
 		// failures (non-installed daemon, no launchctl in PATH) just
 		// fall through to the abort + exit 2 path below.
-		if (process.platform === "darwin" && opts.adapter.agentType) {
-			void (async () => {
-				try {
-					const { execFile } = await import("node:child_process");
-					execFile("launchctl", ["remove", `ai.clawdi.serve.${opts.adapter.agentType}`], () => {
-						// fire-and-forget; the daemon is exiting anyway
-					});
-				} catch {
-					/* launchctl missing, ignore — the manual
-					 * `launchctl unload` from the user is the
-					 * fallback. */
-				}
-			})();
-		}
+		removeLaunchdDaemonSupervision(opts.adapter.agentType);
 		opts.abortController.abort();
 	};
 

--- a/packages/cli/tests/commands/setup.test.ts
+++ b/packages/cli/tests/commands/setup.test.ts
@@ -9,7 +9,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { setup } from "../../src/commands/setup";
 import {
 	type AgentHomeOverrideSnapshot,
@@ -105,6 +105,7 @@ afterEach(() => {
 describe("setup daemon install", () => {
 	it("defaults to installing one daemon unit for all registered agents", async () => {
 		seedRegisteredAgent("claude_code", "env-claude");
+		seedDaemonUnit("claude_code");
 		const { captured } = installEnvironmentMock("env-codex");
 
 		await setup({ agent: "codex", yes: true });
@@ -324,6 +325,12 @@ function daemonUnitPath(agent: string): string {
 
 function daemonUnitExists(agent: string): boolean {
 	return existsSync(daemonUnitPath(agent));
+}
+
+function seedDaemonUnit(agent: string): void {
+	const path = daemonUnitPath(agent);
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, "legacy daemon unit\n");
 }
 
 function readDaemonUnit(agent: string): string {

--- a/packages/cli/tests/commands/setup.test.ts
+++ b/packages/cli/tests/commands/setup.test.ts
@@ -103,7 +103,7 @@ afterEach(() => {
 });
 
 describe("setup daemon install", () => {
-	it("defaults to installing daemon units for every registered agent", async () => {
+	it("defaults to installing one daemon unit for all registered agents", async () => {
 		seedRegisteredAgent("claude_code", "env-claude");
 		const { captured } = installEnvironmentMock("env-codex");
 
@@ -117,8 +117,9 @@ describe("setup daemon install", () => {
 					(req.body as { agent_type?: string } | undefined)?.agent_type === "codex",
 			),
 		).toBe(true);
-		expectDaemonRun("claude_code");
-		expectDaemonRun("codex");
+		expectDaemonRunSingleton();
+		expect(daemonUnitExists("claude_code")).toBe(false);
+		expect(daemonUnitExists("codex")).toBe(false);
 	});
 
 	it("honors --no-daemon while still registering the requested agent", async () => {
@@ -127,6 +128,7 @@ describe("setup daemon install", () => {
 		await setup({ agent: "codex", yes: true, daemon: false });
 
 		expect(existsSync(join(home, ".clawdi", "environments", "codex.json"))).toBe(true);
+		expect(daemonUnitExists("daemon")).toBe(false);
 		expect(daemonUnitExists("codex")).toBe(false);
 	});
 
@@ -138,6 +140,7 @@ describe("setup daemon install", () => {
 		expect(process.exitCode).toBe(1);
 		process.exitCode = 0;
 		expect(existsSync(join(home, ".clawdi", "environments", "codex.json"))).toBe(false);
+		expect(daemonUnitExists("daemon")).toBe(false);
 		expect(daemonUnitExists("codex")).toBe(false);
 	});
 });
@@ -307,6 +310,12 @@ function seedRegisteredAgent(agent: string, envId: string): void {
 }
 
 function daemonUnitPath(agent: string): string {
+	if (agent === "daemon") {
+		if (process.platform === "darwin") {
+			return join(home, "Library", "LaunchAgents", "ai.clawdi.serve.plist");
+		}
+		return join(home, ".config", "systemd", "user", "clawdi-serve.service");
+	}
 	if (process.platform === "darwin") {
 		return join(home, "Library", "LaunchAgents", `ai.clawdi.serve.${agent}.plist`);
 	}
@@ -321,15 +330,18 @@ function readDaemonUnit(agent: string): string {
 	return readFileSync(daemonUnitPath(agent), "utf-8");
 }
 
-function expectDaemonRun(agent: string): void {
-	const content = readDaemonUnit(agent);
+function expectDaemonRunSingleton(): void {
+	const content = readDaemonUnit("daemon");
 	if (process.platform === "darwin") {
 		expect(content).toContain("<string>daemon</string>");
 		expect(content).toContain("<string>run</string>");
-		expect(content).toContain(`<string>${agent}</string>`);
+		expect(content).not.toContain("<string>--all</string>");
+		expect(content).not.toContain("<string>--agent</string>");
 		return;
 	}
-	expect(content).toContain(`daemon run --agent ${agent}`);
+	expect(content).toContain("daemon run");
+	expect(content).not.toContain("--all");
+	expect(content).not.toContain("--agent");
 }
 
 function writeExecutable(path: string, content: string): void {

--- a/packages/cli/tests/commands/update.test.ts
+++ b/packages/cli/tests/commands/update.test.ts
@@ -336,7 +336,7 @@ describe("maybeAutoUpdate", () => {
 			restore();
 		}
 		expect(captured).toContain("Updated clawdi to");
-		expect(captured).toContain("Restart the daemon to pick it up: clawdi daemon restart --all");
+		expect(captured).toContain("Restart the daemon to pick it up: clawdi daemon restart");
 	});
 
 	it("keeps post-update notice out of non-TTY stdout", async () => {

--- a/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
+++ b/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
@@ -110,12 +110,7 @@ if (process.platform !== "win32") {
 				const noToken = await postRpcWithoutToken(rpcPort);
 				expect(noToken.status).toBe(401);
 
-				const defaultPing = await runCli(fixture, [
-					"daemon",
-					"ping",
-					"--rpc-port",
-					String(rpcPort),
-				]);
+				const defaultPing = await runCli(fixture, ["daemon", "ping", "--port", String(rpcPort)]);
 				expect(defaultPing.code).toBe(0);
 				expect(defaultPing.stderr).toBe("");
 				const defaultResult = JSON.parse(defaultPing.stdout) as { pid?: number; version?: string };
@@ -125,9 +120,9 @@ if (process.platform !== "win32") {
 				const httpPing = await runCli(fixture, [
 					"daemon",
 					"ping",
-					"--rpc-host",
+					"--host",
 					"127.0.0.1",
-					"--rpc-port",
+					"--port",
 					String(rpcPort),
 				]);
 				expect(httpPing.code).toBe(0);
@@ -138,12 +133,7 @@ if (process.platform !== "win32") {
 
 				const tokenPath = join(fixture.stateDir, "control", "control-token");
 				const oldToken = readFileSync(tokenPath, "utf-8").trim();
-				const rotate = await runCli(fixture, [
-					"daemon",
-					"rotate-token",
-					"--rpc-port",
-					String(rpcPort),
-				]);
+				const rotate = await runCli(fixture, ["daemon", "rotate-token", "--port", String(rpcPort)]);
 				expect(rotate.code).toBe(0);
 				expect(rotate.stderr).toBe("");
 				const rotateResult = JSON.parse(rotate.stdout) as { token?: string; rotated?: boolean };
@@ -187,16 +177,7 @@ function createFixture(): Fixture {
 
 function startDaemon(fixture: Fixture, rpcPort: number): ReturnType<typeof Bun.spawn> {
 	return Bun.spawn(
-		[
-			process.execPath,
-			srcEntry,
-			"daemon",
-			"run",
-			"--rpc-host",
-			"127.0.0.1",
-			"--rpc-port",
-			String(rpcPort),
-		],
+		[process.execPath, srcEntry, "daemon", "run", "--host", "127.0.0.1", "--port", String(rpcPort)],
 		{
 			cwd: fixture.root,
 			stdout: "pipe",

--- a/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
+++ b/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
@@ -1,0 +1,324 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { type AddressInfo, createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const cliRoot = join(here, "..", "..");
+const srcEntry = join(cliRoot, "src", "index.ts");
+const ENV_ID = "env-daemon-rpc-e2e";
+const PROJECT_ID = "project-daemon-rpc-e2e";
+const API_KEY = "daemon-rpc-e2e-key";
+
+interface ApiCall {
+	method: string;
+	path: string;
+	auth: string | null;
+	body?: unknown;
+}
+
+interface Fixture {
+	root: string;
+	home: string;
+	clawdiHome: string;
+	stateDir: string;
+	codexHome: string;
+}
+
+let server: ReturnType<typeof Bun.serve>;
+let apiCalls: ApiCall[] = [];
+let sseControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+
+beforeAll(() => {
+	server = Bun.serve({
+		hostname: "127.0.0.1",
+		port: 0,
+		async fetch(req) {
+			const url = new URL(req.url);
+			const body = req.method === "POST" ? await readJsonBody(req) : undefined;
+			apiCalls.push({
+				method: req.method,
+				path: `${url.pathname}${url.search}`,
+				auth: req.headers.get("authorization"),
+				body,
+			});
+
+			if (req.method === "GET" && url.pathname === `/api/environments/${ENV_ID}`) {
+				return json({
+					id: ENV_ID,
+					default_project_id: PROJECT_ID,
+				});
+			}
+
+			if (req.method === "GET" && url.pathname === "/api/skills") {
+				return json(
+					{
+						items: [],
+						total: 0,
+						page: 1,
+						page_size: 200,
+					},
+					200,
+					{ ETag: `"1:${PROJECT_ID}"` },
+				);
+			}
+
+			if (req.method === "GET" && url.pathname === "/api/sync/events") {
+				return sse();
+			}
+
+			if (req.method === "POST" && url.pathname === `/api/agents/${ENV_ID}/sync-heartbeat`) {
+				return json({ ok: true });
+			}
+
+			return json({ detail: "not found" }, 404);
+		},
+	});
+});
+
+afterAll(() => {
+	for (const controller of sseControllers) {
+		try {
+			controller.close();
+		} catch {
+			/* already closed */
+		}
+	}
+	server.stop(true);
+});
+
+beforeEach(() => {
+	apiCalls = [];
+	sseControllers = [];
+});
+
+if (process.platform !== "win32") {
+	describe("daemon RPC process e2e", () => {
+		it("serves daemon RPC over the control socket and configured HTTP port", async () => {
+			const fixture = createFixture();
+			const rpcPort = await getFreePort();
+			const daemon = startDaemon(fixture, rpcPort);
+			const daemonStdout = new Response(daemon.stdout).text();
+			const daemonStderr = new Response(daemon.stderr).text();
+
+			try {
+				await waitFor(() => existsSync(join(fixture.stateDir, "control", "control-token")));
+				await waitForHttpUnauthorized(rpcPort);
+
+				const noToken = await postRpcWithoutToken(rpcPort);
+				expect(noToken.status).toBe(401);
+
+				const socketPing = await runCli(fixture, ["daemon", "rpc", "daemon.ping"]);
+				expect(socketPing.code).toBe(0);
+				expect(socketPing.stderr).toBe("");
+				const socketResult = JSON.parse(socketPing.stdout) as { pid?: number; version?: string };
+				expect(socketResult.pid).toBe(daemon.pid);
+				expect(socketResult.version).toBeString();
+
+				const httpPing = await runCli(fixture, [
+					"daemon",
+					"rpc",
+					"daemon.ping",
+					"--rpc-host",
+					"127.0.0.1",
+					"--rpc-port",
+					String(rpcPort),
+				]);
+				expect(httpPing.code).toBe(0);
+				expect(httpPing.stderr).toBe("");
+				const httpResult = JSON.parse(httpPing.stdout) as { pid?: number; version?: string };
+				expect(httpResult.pid).toBe(daemon.pid);
+				expect(httpResult.version).toBe(socketResult.version);
+
+				expect(apiCalls.some((call) => call.path === `/api/environments/${ENV_ID}`)).toBe(true);
+				expect(apiCalls.some((call) => call.path.startsWith("/api/skills?"))).toBe(true);
+				expect(apiCalls.some((call) => call.path === `/api/agents/${ENV_ID}/sync-heartbeat`)).toBe(
+					true,
+				);
+				expect(apiCalls.every((call) => call.auth === `Bearer ${API_KEY}`)).toBe(true);
+			} finally {
+				await stopDaemon(daemon);
+				await Promise.all([daemonStdout, daemonStderr]);
+				rmSync(fixture.root, { recursive: true, force: true });
+			}
+		});
+	});
+}
+
+function createFixture(): Fixture {
+	const root = mkdtempSync(join(tmpdir(), "clawdi-daemon-rpc-e2e-"));
+	const home = join(root, "home");
+	const clawdiHome = join(root, "clawdi-state");
+	const stateDir = join(root, "serve-state");
+	const codexHome = join(home, ".codex");
+	mkdirSync(join(clawdiHome, "environments"), { recursive: true });
+	mkdirSync(join(codexHome, "skills"), { recursive: true });
+	mkdirSync(join(codexHome, "sessions"), { recursive: true });
+	writeFileSync(
+		join(clawdiHome, "environments", "codex.json"),
+		`${JSON.stringify({ id: ENV_ID })}\n`,
+	);
+	return { root, home, clawdiHome, stateDir, codexHome };
+}
+
+function startDaemon(fixture: Fixture, rpcPort: number): ReturnType<typeof Bun.spawn> {
+	return Bun.spawn(
+		[
+			process.execPath,
+			srcEntry,
+			"daemon",
+			"run",
+			"--rpc-host",
+			"127.0.0.1",
+			"--rpc-port",
+			String(rpcPort),
+		],
+		{
+			cwd: fixture.root,
+			stdout: "pipe",
+			stderr: "pipe",
+			env: cliEnv(fixture),
+		},
+	);
+}
+
+async function runCli(
+	fixture: Fixture,
+	args: string[],
+): Promise<{ stdout: string; stderr: string; code: number }> {
+	const proc = Bun.spawn([process.execPath, srcEntry, ...args], {
+		cwd: fixture.root,
+		stdout: "pipe",
+		stderr: "pipe",
+		env: cliEnv(fixture),
+	});
+	const [stdout, stderr, code] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	return { stdout, stderr, code };
+}
+
+function cliEnv(fixture: Fixture): Record<string, string> {
+	return {
+		CLAWDI_API_URL: server.url.origin,
+		CLAWDI_AUTH_TOKEN: API_KEY,
+		CLAWDI_HOME: fixture.clawdiHome,
+		CLAWDI_NO_AUTO_UPDATE: "1",
+		CLAWDI_NO_UPDATE_CHECK: "1",
+		CLAWDI_SERVE_MODE: "container",
+		CLAWDI_STATE_DIR: fixture.stateDir,
+		CODEX_HOME: fixture.codexHome,
+		CI: "true",
+		HOME: fixture.home,
+		NO_COLOR: "1",
+		PATH: process.env.PATH ?? "",
+		TMPDIR: tmpdir(),
+	};
+}
+
+async function stopDaemon(proc: ReturnType<typeof Bun.spawn>): Promise<void> {
+	proc.kill("SIGTERM");
+	await withTimeout(proc.exited, 3_000).catch(async () => {
+		proc.kill("SIGKILL");
+		await proc.exited;
+	});
+}
+
+async function waitFor(
+	predicate: () => boolean | Promise<boolean>,
+	timeoutMs = 5_000,
+): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (await predicate()) return;
+		await sleep(25);
+	}
+	throw new Error("Timed out waiting for daemon RPC readiness");
+}
+
+async function waitForHttpUnauthorized(port: number): Promise<void> {
+	await waitFor(async () => {
+		try {
+			const response = await postRpcWithoutToken(port);
+			return response.status === 401;
+		} catch {
+			return false;
+		}
+	});
+}
+
+async function postRpcWithoutToken(port: number): Promise<Response> {
+	return await fetch(`http://127.0.0.1:${port}/rpc`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "daemon.ping", params: {} }),
+	});
+}
+
+async function getFreePort(): Promise<number> {
+	return await new Promise((resolve, reject) => {
+		const server = createServer();
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address() as AddressInfo;
+			server.close(() => {
+				resolve(address.port);
+			});
+		});
+	});
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(() => reject(new Error("timeout")), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
+function sse(): Response {
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			sseControllers.push(controller);
+			controller.enqueue(new TextEncoder().encode(": connected\n\n"));
+		},
+	});
+	return new Response(stream, {
+		headers: {
+			"content-type": "text/event-stream",
+			"cache-control": "no-cache",
+		},
+	});
+}
+
+function json(data: unknown, status = 200, headers: Record<string, string> = {}): Response {
+	return new Response(JSON.stringify(data), {
+		status,
+		headers: {
+			"content-type": "application/json",
+			...headers,
+		},
+	});
+}
+
+async function readJsonBody(req: Request): Promise<unknown> {
+	try {
+		return await req.json();
+	} catch {
+		return undefined;
+	}
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
+++ b/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { type AddressInfo, createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -124,7 +124,6 @@ if (process.platform !== "win32") {
 
 				const httpPing = await runCli(fixture, [
 					"daemon",
-					"rpc",
 					"ping",
 					"--rpc-host",
 					"127.0.0.1",
@@ -136,6 +135,24 @@ if (process.platform !== "win32") {
 				const httpResult = JSON.parse(httpPing.stdout) as { pid?: number; version?: string };
 				expect(httpResult.pid).toBe(daemon.pid);
 				expect(httpResult.version).toBe(defaultResult.version);
+
+				const tokenPath = join(fixture.stateDir, "control", "control-token");
+				const oldToken = readFileSync(tokenPath, "utf-8").trim();
+				const rotate = await runCli(fixture, [
+					"daemon",
+					"rotate-token",
+					"--rpc-port",
+					String(rpcPort),
+				]);
+				expect(rotate.code).toBe(0);
+				expect(rotate.stderr).toBe("");
+				const rotateResult = JSON.parse(rotate.stdout) as { token?: string; rotated?: boolean };
+				expect(rotateResult.rotated).toBe(true);
+				expect(rotateResult.token).toBeString();
+				expect(rotateResult.token).not.toBe(oldToken);
+				expect(readFileSync(tokenPath, "utf-8").trim()).toBe(rotateResult.token);
+				const staleToken = await postRpcWithToken(rpcPort, oldToken);
+				expect(staleToken.status).toBe(401);
 
 				expect(apiCalls.some((call) => call.path === `/api/environments/${ENV_ID}`)).toBe(true);
 				expect(apiCalls.some((call) => call.path.startsWith("/api/skills?"))).toBe(true);
@@ -260,6 +277,17 @@ async function postRpcWithoutToken(port: number): Promise<Response> {
 	return await fetch(`http://127.0.0.1:${port}/rpc`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }),
+	});
+}
+
+async function postRpcWithToken(port: number, token: string): Promise<Response> {
+	return await fetch(`http://127.0.0.1:${port}/rpc`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${token}`,
+			"Content-Type": "application/json",
+		},
 		body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }),
 	});
 }

--- a/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
+++ b/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
@@ -96,7 +96,7 @@ beforeEach(() => {
 
 if (process.platform !== "win32") {
 	describe("daemon RPC process e2e", () => {
-		it("serves daemon RPC over the control socket and configured HTTP port", async () => {
+		it("serves daemon RPC over the configured HTTP port", async () => {
 			const fixture = createFixture();
 			const rpcPort = await getFreePort();
 			const daemon = startDaemon(fixture, rpcPort);
@@ -110,17 +110,22 @@ if (process.platform !== "win32") {
 				const noToken = await postRpcWithoutToken(rpcPort);
 				expect(noToken.status).toBe(401);
 
-				const socketPing = await runCli(fixture, ["daemon", "rpc", "daemon.ping"]);
-				expect(socketPing.code).toBe(0);
-				expect(socketPing.stderr).toBe("");
-				const socketResult = JSON.parse(socketPing.stdout) as { pid?: number; version?: string };
-				expect(socketResult.pid).toBe(daemon.pid);
-				expect(socketResult.version).toBeString();
+				const defaultPing = await runCli(fixture, [
+					"daemon",
+					"ping",
+					"--rpc-port",
+					String(rpcPort),
+				]);
+				expect(defaultPing.code).toBe(0);
+				expect(defaultPing.stderr).toBe("");
+				const defaultResult = JSON.parse(defaultPing.stdout) as { pid?: number; version?: string };
+				expect(defaultResult.pid).toBe(daemon.pid);
+				expect(defaultResult.version).toBeString();
 
 				const httpPing = await runCli(fixture, [
 					"daemon",
 					"rpc",
-					"daemon.ping",
+					"ping",
 					"--rpc-host",
 					"127.0.0.1",
 					"--rpc-port",
@@ -130,7 +135,7 @@ if (process.platform !== "win32") {
 				expect(httpPing.stderr).toBe("");
 				const httpResult = JSON.parse(httpPing.stdout) as { pid?: number; version?: string };
 				expect(httpResult.pid).toBe(daemon.pid);
-				expect(httpResult.version).toBe(socketResult.version);
+				expect(httpResult.version).toBe(defaultResult.version);
 
 				expect(apiCalls.some((call) => call.path === `/api/environments/${ENV_ID}`)).toBe(true);
 				expect(apiCalls.some((call) => call.path.startsWith("/api/skills?"))).toBe(true);

--- a/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
+++ b/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
@@ -260,7 +260,7 @@ async function postRpcWithoutToken(port: number): Promise<Response> {
 	return await fetch(`http://127.0.0.1:${port}/rpc`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "daemon.ping", params: {} }),
+		body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping", params: {} }),
 	});
 }
 


### PR DESCRIPTION
## Summary
- consolidate `clawdi daemon` into one singleton launchd/systemd unit that runs sync engines for every registered agent
- remove user-facing daemon `--all` and per-agent install/restart/uninstall/log selectors while keeping `clawdi daemon status --agent <type>` for focused inspection
- add loopback HTTP JSON-RPC daemon control on `127.0.0.1:17654` by default, with public daemon flags `--host` / `--port` and matching `CLAWDI_DAEMON_RPC_*` env overrides
- require bearer-token auth on every daemon RPC request; store the generated control token owner-only, repair permissions, rotate it with `clawdi daemon rotate-token`, and compare tokens with timing-safe equality
- reject non-loopback HTTP binds by default; `--allow-remote` / `CLAWDI_DAEMON_RPC_ALLOW_REMOTE=1` is explicit opt-in for SSH tunneling, private networking, or TLS termination
- expose normal user commands for daemon control: `run`, `install`, `uninstall`, `restart`, `status`, `logs`, `doctor`, `ping`, and `rotate-token`
- keep the daemon HTTP JSON-RPC method registry for headless/control clients, but do not expose a generic `clawdi daemon rpc <method>` CLI command
- expose allowlisted headless RPC methods for `sync.*`, `vault.*`, `auth.*`, `update.*`, and `operation.*` without allowing arbitrary Commander command execution
- require explicit confirmations for destructive or plaintext-producing RPC calls and block plaintext vault rendering from background operation logs
- schedule RPC-triggered daemon install/uninstall/restart after the HTTP response is accepted so the daemon does not kill itself mid-response
- migrate setup/update/auth/dashboard/docs copy to the singleton daemon model and clean up legacy per-agent units
- bump CLI package version to `0.11.0` and add user-facing changelog notes

## Legacy daemon migration
- `clawdi daemon install` installs/replaces the singleton unit, then removes old per-agent units such as `ai.clawdi.serve.codex` / `clawdi-serve-codex.service`
- `clawdi setup` now performs the same legacy cleanup after its default singleton daemon install
- hidden legacy supervisor args like `clawdi daemon run --agent codex --environment-id ...` are accepted only for migration; in host mode they install the singleton, persist an explicit env id into `~/.clawdi/environments/<agent>.json`, remove legacy units, and exit
- in container mode, hidden legacy run args keep the old single-agent foreground behavior for compatibility without installing host services

## RPC Binding Note
The control RPC is ordinary HTTP JSON-RPC. There is no Unix socket transport and no framework layer such as Hono. The daemon uses Node built-in HTTP because the surface is a single local `POST /rpc` endpoint with an allowlisted method registry. Remote HTTP is cleartext and must not be exposed directly on the public internet; use an SSH tunnel, private network, or TLS-terminating reverse proxy.

## User Commands vs RPC Methods
- user commands remain normal CLI commands: `clawdi daemon status`, `clawdi daemon doctor`, `clawdi daemon logs`, `clawdi daemon ping`, `clawdi daemon rotate-token`, etc.
- protocol-level clients call HTTP JSON-RPC directly with method names such as `methods`, `status`, `sync.push`, and `operation.status`; the CLI no longer exposes a generic raw RPC subcommand.

## Release Impact
- CLI/npm release intended: `clawdi@0.11.0`, `clawdi-cli-v0.11.0`
- App/backend/web calendar release may also be created because dashboard/docs copy changed

## Verification
- `bun test packages/cli/src/commands/serve-cli-options.test.ts packages/cli/src/commands/serve-handlers.test.ts packages/cli/src/serve/control-rpc.test.ts packages/cli/tests/e2e/daemon-rpc.e2e.test.ts`
- `bun run --cwd packages/cli test:e2e`
- `bun run test`
- `bun run check`
- `bun run typecheck`
- `bun run --cwd packages/cli build`
- `bun run --cwd packages/cli check:publish-manifest`
- `git diff --check`
