### PR TITLE
Add XTrace memory ingest and skill indexing

### DIFF
--- a/apps/web/src/app/(dashboard)/agents/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/agents/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
 	ArrowDown,
 	ArrowUp,
+	Brain,
 	Home,
 	Layers,
 	MessageSquare,
@@ -20,6 +21,7 @@ import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { AgentLabel, agentTypeLabel, cleanMachineName } from "@/components/dashboard/agent-label";
 import { DaemonStatusBadge } from "@/components/dashboard/daemon-status";
 import { DetailNotFound, DetailPanel } from "@/components/detail/layout";
+import { MemoryRelationshipList } from "@/components/memories/memory-relationship-list";
 import {
 	isCustomProject,
 	isProjectOwner,
@@ -41,7 +43,7 @@ import { projectResourceHref } from "@/lib/project-resource-model";
 import { errorMessage, relativeTime } from "@/lib/utils";
 
 type SkillSummary = components["schemas"]["SkillSummaryResponse"];
-type AgentTab = "sessions" | "skills" | "projects";
+type AgentTab = "sessions" | "memories" | "skills" | "projects";
 
 interface ProjectRow {
 	id: string;
@@ -137,6 +139,22 @@ export default function AgentDetailPage() {
 		enabled: !!agent,
 	});
 
+	const { data: memoriesPage, isLoading: memoriesLoading } = useQuery({
+		queryKey: ["agent-memories", id],
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/api/memories", {
+					params: {
+						query: {
+							environment_id: id,
+							page_size: 50,
+						},
+					},
+				}),
+			),
+		enabled: !!agent,
+	});
+
 	// Skills section: fetch ONLY this env's project. The earlier
 	// shape loaded the first 200 account-wide rows and filtered
 	// client-side, which on a multi-agent account with >200
@@ -218,11 +236,17 @@ export default function AgentDetailPage() {
 						description:
 							"The Agent Project is fixed. Added Custom or shared Projects add read-only context.",
 					}
-				: {
-						icon: MessageSquare,
-						title: "Session history",
-						description: "Review sessions synced by this agent.",
-					};
+				: activeTab === "memories"
+					? {
+							icon: Brain,
+							title: "Learned memories",
+							description: "Account-level memories generated from this agent's sessions.",
+						}
+					: {
+							icon: MessageSquare,
+							title: "Session history",
+							description: "Review sessions synced by this agent.",
+						};
 
 	useEffect(() => {
 		setActiveTab(requestedTab);
@@ -339,12 +363,20 @@ export default function AgentDetailPage() {
 					<Tabs value={activeTab} onValueChange={(v) => setTab(parseAgentTab(v) ?? "sessions")}>
 						{/* Flat tab chrome — no boxed section wrappers (taste audit #1). */}
 						<div className="flex flex-wrap items-end justify-between gap-2">
-							<TabsList className="grid w-full grid-cols-3 sm:w-fit">
+							<TabsList className="grid w-full grid-cols-4 sm:w-fit">
 								<TabsTrigger value="sessions" className="min-w-0 px-2">
 									Sessions
 									<span className="ml-1.5 text-xs text-muted-foreground tabular-nums">
 										{sessionTotal}
 									</span>
+								</TabsTrigger>
+								<TabsTrigger value="memories" className="min-w-0 px-2">
+									Memories
+									{memoriesPage ? (
+										<span className="ml-1.5 text-xs text-muted-foreground tabular-nums">
+											{memoriesPage.total}
+										</span>
+									) : null}
 								</TabsTrigger>
 								<TabsTrigger value="skills" className="min-w-0 px-2">
 									Skills
@@ -388,6 +420,16 @@ export default function AgentDetailPage() {
 								</div>
 							</TabsContent>
 
+							<TabsContent value="memories" className="m-0">
+								<div className="max-w-4xl">
+									<MemoryRelationshipList
+										memories={memoriesPage?.items ?? []}
+										isLoading={memoriesLoading}
+										emptyMessage="No memories have been linked to this agent yet."
+									/>
+								</div>
+							</TabsContent>
+
 							<TabsContent value="skills" className="m-0">
 								<SkillCardGrid
 									skills={skillsForThisEnv ?? []}
@@ -427,7 +469,9 @@ export default function AgentDetailPage() {
 }
 
 function parseAgentTab(value: string | null): AgentTab | null {
-	if (value === "sessions" || value === "skills" || value === "projects") return value;
+	if (value === "sessions" || value === "memories" || value === "skills" || value === "projects") {
+		return value;
+	}
 	return null;
 }
 

--- a/apps/web/src/app/(dashboard)/memories/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/memories/[id]/page.tsx
@@ -1,13 +1,30 @@
 "use client";
 
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { Brain, GitBranch, Laptop, Trash2 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import {
+	Brain,
+	CalendarClock,
+	GitBranch,
+	History,
+	Laptop,
+	Link2,
+	Tags,
+	Trash2,
+} from "lucide-react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
-import { DetailMeta, DetailNotFound, DetailPanel, DetailTitle } from "@/components/detail/layout";
+import {
+	DetailMeta,
+	DetailNotFound,
+	DetailPanel,
+	DetailStats,
+	DetailTitle,
+} from "@/components/detail/layout";
 import { MemoryRelationshipList } from "@/components/memories/memory-relationship-list";
+import { Stat } from "@/components/meta/stat";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -50,10 +67,10 @@ export default function MemoryDetailPage() {
 		enabled: !!memory?.source_session_id,
 	});
 
-	// First sentence (or 80 chars) — keeps the breadcrumb readable.
 	const memoryTitle = memory?.content
 		? memory.content.split(/[.\n]/)[0]?.slice(0, 80)?.trim() || null
 		: null;
+	const detailTitle = memoryTitle || "Memory";
 	const siblingMemories = (relatedMemories?.items ?? []).filter((item) => item.id !== memory?.id);
 	useSetBreadcrumbTitle(memoryTitle);
 
@@ -89,11 +106,11 @@ export default function MemoryDetailPage() {
 				<>
 					<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
 						<div className="min-w-0 flex-1 space-y-2">
-							<div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+							<div className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
 								<Brain className="size-3.5" />
 								<span>Memory</span>
 							</div>
-							<DetailTitle>Memory</DetailTitle>
+							<DetailTitle className="break-words">{detailTitle}</DetailTitle>
 							<DetailMeta>
 								<Badge
 									variant="secondary"
@@ -110,8 +127,6 @@ export default function MemoryDetailPage() {
 										</span>
 									</>
 								) : null}
-								{/* Whether agents actually USE a memory is the
-								    fact that decides keep-vs-delete — surface it. */}
 								<span>·</span>
 								<span className="tabular-nums">
 									{(memory.access_count ?? 0) > 0
@@ -119,6 +134,23 @@ export default function MemoryDetailPage() {
 										: "Never recalled yet"}
 								</span>
 							</DetailMeta>
+							{memory.source_machine_name || memory.source_session_id || memory.xtrace?.status ? (
+								<DetailStats>
+									{memory.source_machine_name ? (
+										<Stat icon={Laptop} label={memory.source_machine_name} />
+									) : null}
+									{memory.source_session_id ? (
+										<Stat
+											icon={Link2}
+											label={`Session ${shortId(memory.source_session_id)}`}
+											title={memory.source_session_id}
+										/>
+									) : null}
+									{memory.xtrace?.status ? (
+										<Stat icon={GitBranch} label={`XTrace ${memory.xtrace.status}`} />
+									) : null}
+								</DetailStats>
+							) : null}
 						</div>
 						<ConfirmAction
 							title="Delete this memory?"
@@ -144,84 +176,80 @@ export default function MemoryDetailPage() {
 						</ConfirmAction>
 					</div>
 
-					<DetailPanel>
-						<p className="whitespace-pre-wrap break-words text-base leading-relaxed">
+					<DetailPanel className="space-y-3">
+						<SectionHeader icon={Brain} title="Content" />
+						<p className="whitespace-pre-wrap break-words text-sm leading-relaxed">
 							{memory.content}
 						</p>
 					</DetailPanel>
 
 					<DetailPanel className="space-y-4">
-						<div className="space-y-1">
-							<h2 className="text-sm font-semibold">Source relationship</h2>
-							<p className="text-xs text-muted-foreground">
-								This memory is account-level context. Its source tells you which agent/session
-								taught it to Clawdi.
-							</p>
+						<SectionHeader icon={Link2} title="Source" />
+						<div className="grid gap-x-6 gap-y-3 sm:grid-cols-2">
+							<MetadataItem label="Source" value={memory.source} />
+							<MetadataItem label="Agent" value={memory.source_machine_name} />
+							<MetadataItem
+								label="Session"
+								value={memory.source_session_id}
+								href={
+									memory.source_session_id ? sessionDetailHref(memory.source_session_id) : undefined
+								}
+								valueTitle={memory.source_session_id}
+								compact
+								mono
+							/>
+							<MetadataItem
+								label="Environment"
+								value={memory.source_environment_id}
+								valueTitle={memory.source_environment_id}
+								compact
+								mono
+							/>
 						</div>
-						<div className="grid gap-2 text-sm sm:grid-cols-2">
-							<DetailField label="source" value={memory.source} />
-							<DetailField label="agent" value={memory.source_machine_name} />
-							<DetailField label="session" value={memory.source_session_id} />
-							<DetailField label="environment" value={memory.source_environment_id} />
-						</div>
-						{memory.tags?.length ? (
-							<div className="flex flex-wrap items-center gap-1.5">
-								<span className="text-xs text-muted-foreground">Tags:</span>
-								{memory.tags.map((t) => (
-									<Badge key={t} variant="outline" className="font-normal">
-										#{t}
-									</Badge>
-								))}
-							</div>
-						) : (
-							<p className="text-xs text-muted-foreground">No tags saved for this memory.</p>
-						)}
 
-						{/* Provenance renders whenever ANY of it is known — machine
-						    name alone is still useful without a session link. */}
-						{memory.source_session_id || memory.source_machine_name ? (
-							<div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
-								<Laptop className="size-3" />
-								<span>
-									{memory.source_machine_name
-										? `Learned on ${memory.source_machine_name}`
-										: "Learned from a session"}
-								</span>
-								{memory.source_session_id ? (
-									<>
-										<span>·</span>
-										<Link
-											href={sessionDetailHref(memory.source_session_id)}
-											className="underline hover:text-foreground"
-										>
-											View session
-										</Link>
-									</>
-								) : null}
-							</div>
-						) : null}
+						<div className="flex flex-wrap items-center gap-1.5">
+							<Tags className="size-3.5 text-muted-foreground" />
+							{memory.tags?.length ? (
+								memory.tags.map((tag) => (
+									<Badge key={tag} variant="outline" className="h-5 font-normal">
+										#{tag}
+									</Badge>
+								))
+							) : (
+								<span className="text-xs text-muted-foreground">No tags</span>
+							)}
+						</div>
 
 						{memory.source_session_id ? (
-							<div className="space-y-3 border-t pt-4">
-								<div className="flex items-center justify-between gap-3">
-									<h2 className="text-sm font-semibold">Learned in the same session</h2>
-									{siblingMemories.length ? (
-										<span className="text-xs tabular-nums text-muted-foreground">
-											{siblingMemories.length}
-										</span>
-									) : null}
-								</div>
-								<MemoryRelationshipList
-									memories={siblingMemories}
-									isLoading={relatedMemoriesLoading}
-									emptyMessage="No other memories are linked to this source session."
-									limit={5}
-								/>
-							</div>
+							<Button variant="outline" size="sm" className="w-fit" asChild>
+								<Link href={sessionDetailHref(memory.source_session_id)}>
+									<Link2 />
+									View session
+								</Link>
+							</Button>
 						) : null}
-
-						{memory.xtrace ? <XTraceMemoryDetails xtrace={memory.xtrace} /> : null}
 					</DetailPanel>
+
+					{memory.xtrace ? <XTraceMemoryDetails xtrace={memory.xtrace} /> : null}
+
+					{memory.source_session_id ? (
+						<section className="space-y-3">
+							<div className="flex items-center justify-between gap-3">
+								<SectionHeader icon={History} title="Same Session" />
+								{siblingMemories.length ? (
+									<span className="text-xs tabular-nums text-muted-foreground">
+										{siblingMemories.length}
+									</span>
+								) : null}
+							</div>
+							<MemoryRelationshipList
+								memories={siblingMemories}
+								isLoading={relatedMemoriesLoading}
+								emptyMessage="No other memories are linked to this source session."
+								limit={5}
+							/>
+						</section>
+					) : null}
 				</>
 			) : (
 				<Alert>
@@ -234,12 +262,50 @@ export default function MemoryDetailPage() {
 	);
 }
 
-function DetailField({ label, value }: { label: string; value?: string | null }) {
-	if (!value) return null;
+function SectionHeader({ icon: Icon, title }: { icon: LucideIcon; title: string }) {
 	return (
-		<div className="min-w-0">
-			<span className="text-muted-foreground">{label}: </span>
-			<span className="break-words font-mono text-xs">{value}</span>
+		<div className="flex items-center gap-2 text-sm font-semibold">
+			<Icon className="size-4 text-muted-foreground" />
+			<h2>{title}</h2>
+		</div>
+	);
+}
+
+function MetadataItem({
+	label,
+	value,
+	href,
+	valueTitle,
+	compact = false,
+	mono = false,
+}: {
+	label: string;
+	value?: string | null;
+	href?: string;
+	valueTitle?: string | null;
+	compact?: boolean;
+	mono?: boolean;
+}) {
+	if (!value) return null;
+	const displayValue = compact && shouldShorten(value) ? shortId(value) : value;
+	const valueClassName = cn("break-words text-foreground", mono ? "font-mono text-xs" : "text-sm");
+
+	return (
+		<div className="min-w-0 space-y-1">
+			<div className="text-xs font-medium text-muted-foreground">{label}</div>
+			{href ? (
+				<Link
+					href={href}
+					title={valueTitle ?? value}
+					className={cn(valueClassName, "underline-offset-4 hover:underline")}
+				>
+					{displayValue}
+				</Link>
+			) : (
+				<div title={valueTitle ?? value} className={valueClassName}>
+					{displayValue}
+				</div>
+			)}
 		</div>
 	);
 }
@@ -247,38 +313,58 @@ function DetailField({ label, value }: { label: string; value?: string | null })
 function XTraceMemoryDetails({ xtrace }: { xtrace: NonNullable<Memory["xtrace"]> }) {
 	const timeline = xtrace.timeline ?? [];
 	return (
-		<div className="space-y-3 border-t pt-4">
-			<div className="flex items-center gap-2">
-				<GitBranch className="size-4 text-muted-foreground" />
-				<h2 className="text-sm font-semibold">XTrace details</h2>
-			</div>
-			<div className="grid gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
-				<XTraceField label="type" value={xtrace.type} />
-				<XTraceField label="status" value={xtrace.status} />
-				<XTraceField label="operation" value={xtrace.operation} />
-				<XTraceField label="source" value={xtrace.source_type} />
-				<XTraceField label="supersedes" value={xtrace.supersedes?.join(", ")} />
-				<XTraceField label="superseded by" value={xtrace.superseded_by} />
+		<DetailPanel className="space-y-4">
+			<SectionHeader icon={GitBranch} title="XTrace" />
+			<div className="grid gap-x-6 gap-y-3 sm:grid-cols-2">
+				<MetadataItem label="Type" value={xtrace.type} />
+				<MetadataItem label="Status" value={xtrace.status} />
+				<MetadataItem label="Operation" value={xtrace.operation} />
+				<MetadataItem label="Source" value={xtrace.source_type} />
+				<MetadataItem
+					label="Supersedes"
+					value={xtrace.supersedes?.map((id) => shortId(id)).join(", ")}
+					valueTitle={xtrace.supersedes?.join(", ")}
+					mono
+				/>
+				<MetadataItem
+					label="Superseded by"
+					value={xtrace.superseded_by}
+					valueTitle={xtrace.superseded_by}
+					compact
+					mono
+				/>
 			</div>
 			{xtrace.memory_id ? (
-				<div className="break-all rounded-md bg-muted px-2.5 py-2 font-mono text-xs text-muted-foreground">
-					{xtrace.memory_id}
-				</div>
+				<MetadataItem
+					label="XTrace ID"
+					value={xtrace.memory_id}
+					valueTitle={xtrace.memory_id}
+					compact
+					mono
+				/>
 			) : null}
 			{timeline.length ? (
 				<div className="space-y-2">
-					<h3 className="text-xs font-medium text-muted-foreground">Versioning timeline</h3>
-					<div className="space-y-2">
+					<div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+						<CalendarClock className="size-3.5" />
+						<span>Timeline</span>
+					</div>
+					<div className="divide-y border-y">
 						{timeline.map((item, index) => (
-							<div key={`${item.memory_id ?? index}-${index}`} className="flex gap-3 text-sm">
-								<Badge variant="outline" className="h-fit shrink-0 uppercase">
-									{item.operation}
+							<div key={`${item.memory_id ?? index}-${index}`} className="flex gap-3 py-3">
+								<Badge variant="outline" className="h-5 shrink-0 uppercase">
+									{item.operation ?? "event"}
 								</Badge>
 								<div className="min-w-0 space-y-1">
-									<p className="break-words leading-relaxed">{item.content}</p>
+									<p className="line-clamp-3 break-words text-sm leading-relaxed">{item.content}</p>
 									<div className="flex flex-wrap gap-1.5 text-xs text-muted-foreground">
 										{item.status ? <span>{item.status}</span> : null}
-										{item.at ? <span>{new Date(item.at).toLocaleString()}</span> : null}
+										{item.status && item.at ? <span>·</span> : null}
+										{item.at ? (
+											<span title={new Date(item.at).toLocaleString()}>
+												{relativeTime(item.at)}
+											</span>
+										) : null}
 									</div>
 								</div>
 							</div>
@@ -286,16 +372,15 @@ function XTraceMemoryDetails({ xtrace }: { xtrace: NonNullable<Memory["xtrace"]>
 					</div>
 				</div>
 			) : null}
-		</div>
+		</DetailPanel>
 	);
 }
 
-function XTraceField({ label, value }: { label: string; value?: string | null }) {
-	if (!value) return null;
-	return (
-		<div className="min-w-0">
-			<span className="text-muted-foreground">{label}: </span>
-			<span className="break-words font-mono text-xs">{value}</span>
-		</div>
-	);
+function shouldShorten(value: string) {
+	return value.length > 28 && /^[a-zA-Z0-9_-]+$/.test(value);
+}
+
+function shortId(value: string) {
+	if (value.length <= 16) return value;
+	return `${value.slice(0, 8)}...${value.slice(-6)}`;
 }

--- a/apps/web/src/app/(dashboard)/memories/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/memories/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { Brain, Laptop, Trash2 } from "lucide-react";
+import { Brain, GitBranch, Laptop, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { toast } from "sonner";
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Skeleton } from "@/components/ui/skeleton";
 import { unwrap, useApi } from "@/lib/api";
+import type { Memory } from "@/lib/api-schemas";
 import { MEMORY_CATEGORY_COLORS } from "@/lib/memory-utils";
 import { projectResourceHref, sessionDetailHref } from "@/lib/project-resource-model";
 import { cn, errorMessage, relativeTime } from "@/lib/utils";
@@ -171,6 +172,8 @@ export default function MemoryDetailPage() {
 								) : null}
 							</div>
 						) : null}
+
+						{memory.xtrace ? <XTraceMemoryDetails xtrace={memory.xtrace} /> : null}
 					</DetailPanel>
 				</>
 			) : (
@@ -180,6 +183,62 @@ export default function MemoryDetailPage() {
 					<AlertDescription>This memory doesn't exist.</AlertDescription>
 				</Alert>
 			)}
+		</div>
+	);
+}
+
+function XTraceMemoryDetails({ xtrace }: { xtrace: NonNullable<Memory["xtrace"]> }) {
+	const timeline = xtrace.timeline ?? [];
+	return (
+		<div className="space-y-3 border-t pt-4">
+			<div className="flex items-center gap-2">
+				<GitBranch className="size-4 text-muted-foreground" />
+				<h2 className="text-sm font-semibold">XTrace details</h2>
+			</div>
+			<div className="grid gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
+				<XTraceField label="type" value={xtrace.type} />
+				<XTraceField label="status" value={xtrace.status} />
+				<XTraceField label="operation" value={xtrace.operation} />
+				<XTraceField label="source" value={xtrace.source_type} />
+				<XTraceField label="supersedes" value={xtrace.supersedes?.join(", ")} />
+				<XTraceField label="superseded by" value={xtrace.superseded_by} />
+			</div>
+			{xtrace.memory_id ? (
+				<div className="break-all rounded-md bg-muted px-2.5 py-2 font-mono text-xs text-muted-foreground">
+					{xtrace.memory_id}
+				</div>
+			) : null}
+			{timeline.length ? (
+				<div className="space-y-2">
+					<h3 className="text-xs font-medium text-muted-foreground">Versioning timeline</h3>
+					<div className="space-y-2">
+						{timeline.map((item, index) => (
+							<div key={`${item.memory_id ?? index}-${index}`} className="flex gap-3 text-sm">
+								<Badge variant="outline" className="h-fit shrink-0 uppercase">
+									{item.operation}
+								</Badge>
+								<div className="min-w-0 space-y-1">
+									<p className="break-words leading-relaxed">{item.content}</p>
+									<div className="flex flex-wrap gap-1.5 text-xs text-muted-foreground">
+										{item.status ? <span>{item.status}</span> : null}
+										{item.at ? <span>{new Date(item.at).toLocaleString()}</span> : null}
+									</div>
+								</div>
+							</div>
+						))}
+					</div>
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+function XTraceField({ label, value }: { label: string; value?: string | null }) {
+	if (!value) return null;
+	return (
+		<div className="min-w-0">
+			<span className="text-muted-foreground">{label}: </span>
+			<span className="break-words font-mono text-xs">{value}</span>
 		</div>
 	);
 }

--- a/apps/web/src/app/(dashboard)/memories/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/memories/[id]/page.tsx
@@ -32,7 +32,12 @@ import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Skeleton } from "@/components/ui/skeleton";
 import { unwrap, useApi } from "@/lib/api";
 import type { Memory } from "@/lib/api-schemas";
-import { MEMORY_CATEGORY_COLORS } from "@/lib/memory-utils";
+import {
+	MEMORY_CATEGORY_COLORS,
+	MEMORY_CATEGORY_EMOJI,
+	MEMORY_CATEGORY_TILE_CLASSES,
+	MEMORY_FALLBACK_EMOJI,
+} from "@/lib/memory-utils";
 import { projectResourceHref, sessionDetailHref } from "@/lib/project-resource-model";
 import { cn, errorMessage, relativeTime } from "@/lib/utils";
 
@@ -105,52 +110,65 @@ export default function MemoryDetailPage() {
 			) : memory ? (
 				<>
 					<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-						<div className="min-w-0 flex-1 space-y-2">
-							<div className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-								<Brain className="size-3.5" />
-								<span>Memory</span>
-							</div>
-							<DetailTitle className="break-words">{detailTitle}</DetailTitle>
-							<DetailMeta>
-								<Badge
-									variant="secondary"
-									className={cn("h-5", MEMORY_CATEGORY_COLORS[memory.category])}
-								>
-									{memory.category}
-								</Badge>
-								<span>{memory.source}</span>
-								{memory.created_at ? (
-									<>
-										<span>·</span>
-										<span title={new Date(memory.created_at).toLocaleString()}>
-											Saved {relativeTime(memory.created_at)}
-										</span>
-									</>
+						{/* Category emoji tile — the same identity treatment every
+						    other object card/detail header gets (vivid art direction). */}
+						<div className="flex min-w-0 flex-1 items-start gap-3">
+							<span
+								aria-hidden
+								className={cn(
+									"flex size-11 shrink-0 select-none items-center justify-center rounded-xl text-2xl leading-none",
+									MEMORY_CATEGORY_TILE_CLASSES[memory.category] ?? "bg-muted",
+								)}
+							>
+								{MEMORY_CATEGORY_EMOJI[memory.category] ?? MEMORY_FALLBACK_EMOJI}
+							</span>
+							<div className="min-w-0 flex-1 space-y-2">
+								<div className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+									<Brain className="size-3.5" />
+									<span>Memory</span>
+								</div>
+								<DetailTitle className="break-words">{detailTitle}</DetailTitle>
+								<DetailMeta>
+									<Badge
+										variant="secondary"
+										className={cn("h-5", MEMORY_CATEGORY_COLORS[memory.category])}
+									>
+										{memory.category}
+									</Badge>
+									<span>{memory.source}</span>
+									{memory.created_at ? (
+										<>
+											<span>·</span>
+											<span title={new Date(memory.created_at).toLocaleString()}>
+												Saved {relativeTime(memory.created_at)}
+											</span>
+										</>
+									) : null}
+									<span>·</span>
+									<span className="tabular-nums">
+										{(memory.access_count ?? 0) > 0
+											? `Recalled ${memory.access_count} ${memory.access_count === 1 ? "time" : "times"}`
+											: "Never recalled yet"}
+									</span>
+								</DetailMeta>
+								{memory.source_machine_name || memory.source_session_id || memory.xtrace?.status ? (
+									<DetailStats>
+										{memory.source_machine_name ? (
+											<Stat icon={Laptop} label={memory.source_machine_name} />
+										) : null}
+										{memory.source_session_id ? (
+											<Stat
+												icon={Link2}
+												label={`Session ${shortId(memory.source_session_id)}`}
+												title={memory.source_session_id}
+											/>
+										) : null}
+										{memory.xtrace?.status ? (
+											<Stat icon={GitBranch} label={`XTrace ${memory.xtrace.status}`} />
+										) : null}
+									</DetailStats>
 								) : null}
-								<span>·</span>
-								<span className="tabular-nums">
-									{(memory.access_count ?? 0) > 0
-										? `Recalled ${memory.access_count} ${memory.access_count === 1 ? "time" : "times"}`
-										: "Never recalled yet"}
-								</span>
-							</DetailMeta>
-							{memory.source_machine_name || memory.source_session_id || memory.xtrace?.status ? (
-								<DetailStats>
-									{memory.source_machine_name ? (
-										<Stat icon={Laptop} label={memory.source_machine_name} />
-									) : null}
-									{memory.source_session_id ? (
-										<Stat
-											icon={Link2}
-											label={`Session ${shortId(memory.source_session_id)}`}
-											title={memory.source_session_id}
-										/>
-									) : null}
-									{memory.xtrace?.status ? (
-										<Stat icon={GitBranch} label={`XTrace ${memory.xtrace.status}`} />
-									) : null}
-								</DetailStats>
-							) : null}
+							</div>
 						</div>
 						<ConfirmAction
 							title="Delete this memory?"

--- a/apps/web/src/app/(dashboard)/memories/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/memories/[id]/page.tsx
@@ -7,6 +7,7 @@ import { useParams, useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { DetailMeta, DetailNotFound, DetailPanel, DetailTitle } from "@/components/detail/layout";
+import { MemoryRelationshipList } from "@/components/memories/memory-relationship-list";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -33,10 +34,27 @@ export default function MemoryDetailPage() {
 			unwrap(await api.GET("/api/memories/{memory_id}", { params: { path: { memory_id: id } } })),
 	});
 
+	const { data: relatedMemories, isLoading: relatedMemoriesLoading } = useQuery({
+		queryKey: ["memories", "session", memory?.source_session_id],
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/api/memories", {
+					params: {
+						query: {
+							source_session_id: memory?.source_session_id ?? "",
+							page_size: 10,
+						},
+					},
+				}),
+			),
+		enabled: !!memory?.source_session_id,
+	});
+
 	// First sentence (or 80 chars) — keeps the breadcrumb readable.
 	const memoryTitle = memory?.content
 		? memory.content.split(/[.\n]/)[0]?.slice(0, 80)?.trim() || null
 		: null;
+	const siblingMemories = (relatedMemories?.items ?? []).filter((item) => item.id !== memory?.id);
 	useSetBreadcrumbTitle(memoryTitle);
 
 	const deleteMemory = useMutation({
@@ -75,9 +93,7 @@ export default function MemoryDetailPage() {
 								<Brain className="size-3.5" />
 								<span>Memory</span>
 							</div>
-							<DetailTitle className="whitespace-pre-wrap leading-snug">
-								{memory.content}
-							</DetailTitle>
+							<DetailTitle>Memory</DetailTitle>
 							<DetailMeta>
 								<Badge
 									variant="secondary"
@@ -128,13 +144,25 @@ export default function MemoryDetailPage() {
 						</ConfirmAction>
 					</div>
 
+					<DetailPanel>
+						<p className="whitespace-pre-wrap break-words text-base leading-relaxed">
+							{memory.content}
+						</p>
+					</DetailPanel>
+
 					<DetailPanel className="space-y-4">
 						<div className="space-y-1">
-							<h2 className="text-sm font-semibold">Recall Scope</h2>
+							<h2 className="text-sm font-semibold">Source relationship</h2>
 							<p className="text-xs text-muted-foreground">
-								This is account-level context. Agents can recall it across runs; it is not shared
-								through Projects.
+								This memory is account-level context. Its source tells you which agent/session
+								taught it to Clawdi.
 							</p>
+						</div>
+						<div className="grid gap-2 text-sm sm:grid-cols-2">
+							<DetailField label="source" value={memory.source} />
+							<DetailField label="agent" value={memory.source_machine_name} />
+							<DetailField label="session" value={memory.source_session_id} />
+							<DetailField label="environment" value={memory.source_environment_id} />
 						</div>
 						{memory.tags?.length ? (
 							<div className="flex flex-wrap items-center gap-1.5">
@@ -173,6 +201,25 @@ export default function MemoryDetailPage() {
 							</div>
 						) : null}
 
+						{memory.source_session_id ? (
+							<div className="space-y-3 border-t pt-4">
+								<div className="flex items-center justify-between gap-3">
+									<h2 className="text-sm font-semibold">Learned in the same session</h2>
+									{siblingMemories.length ? (
+										<span className="text-xs tabular-nums text-muted-foreground">
+											{siblingMemories.length}
+										</span>
+									) : null}
+								</div>
+								<MemoryRelationshipList
+									memories={siblingMemories}
+									isLoading={relatedMemoriesLoading}
+									emptyMessage="No other memories are linked to this source session."
+									limit={5}
+								/>
+							</div>
+						) : null}
+
 						{memory.xtrace ? <XTraceMemoryDetails xtrace={memory.xtrace} /> : null}
 					</DetailPanel>
 				</>
@@ -183,6 +230,16 @@ export default function MemoryDetailPage() {
 					<AlertDescription>This memory doesn't exist.</AlertDescription>
 				</Alert>
 			)}
+		</div>
+	);
+}
+
+function DetailField({ label, value }: { label: string; value?: string | null }) {
+	if (!value) return null;
+	return (
+		<div className="min-w-0">
+			<span className="text-muted-foreground">{label}: </span>
+			<span className="break-words font-mono text-xs">{value}</span>
 		</div>
 	);
 }

--- a/apps/web/src/app/(dashboard)/memories/page.tsx
+++ b/apps/web/src/app/(dashboard)/memories/page.tsx
@@ -37,7 +37,12 @@ import { Textarea } from "@/components/ui/textarea";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { unwrap, useApi } from "@/lib/api";
 import type { Memory } from "@/lib/api-schemas";
-import { MEMORY_CATEGORY_COLORS } from "@/lib/memory-utils";
+import {
+	MEMORY_CATEGORY_COLORS,
+	MEMORY_CATEGORY_EMOJI,
+	MEMORY_CATEGORY_TILE_CLASSES,
+	MEMORY_FALLBACK_EMOJI,
+} from "@/lib/memory-utils";
 import { getProjectResourceDefinition, memoryDetailHref } from "@/lib/project-resource-model";
 import { useDebouncedValue } from "@/lib/use-debounced";
 import { cn, errorMessage, relativeTime } from "@/lib/utils";
@@ -278,7 +283,20 @@ function MemoryNotesGrid({
 						aria-label={`Open memory ${memory.id.slice(0, 8)}`}
 						className="absolute inset-0 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 					/>
-					<p className="line-clamp-[8] break-words text-sm leading-relaxed">{memory.content}</p>
+					<div className="flex items-start gap-2.5">
+						<span
+							aria-hidden
+							className={cn(
+								"flex size-7 shrink-0 select-none items-center justify-center rounded-lg text-sm leading-none",
+								MEMORY_CATEGORY_TILE_CLASSES[memory.category] ?? "bg-muted",
+							)}
+						>
+							{MEMORY_CATEGORY_EMOJI[memory.category] ?? MEMORY_FALLBACK_EMOJI}
+						</span>
+						<p className="line-clamp-[8] min-w-0 break-words text-sm leading-relaxed">
+							{memory.content}
+						</p>
+					</div>
 					<div className="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1.5">
 						<Badge variant="secondary" className={cn(MEMORY_CATEGORY_COLORS[memory.category])}>
 							{memory.category}

--- a/apps/web/src/app/(dashboard)/memories/page.tsx
+++ b/apps/web/src/app/(dashboard)/memories/page.tsx
@@ -57,6 +57,11 @@ const CATEGORIES = [
 // for the All chip (Radix does not treat "" as a selected value).
 const ALL = "all";
 const MEMORIES_RESOURCE = getProjectResourceDefinition("memories");
+const PROVIDER_OPTIONS = {
+	builtin: { label: "Built-in", icon: Database },
+	mem0: { label: "Mem0", icon: Brain },
+	xtrace: { label: "XTrace", icon: GitBranch },
+} as const;
 
 export default function MemoriesPage() {
 	const api = useApi();
@@ -71,9 +76,17 @@ export default function MemoriesPage() {
 		queryKey: ["settings"],
 		queryFn: async () => unwrap(await api.GET("/api/settings")),
 	});
+	const { data: capabilities } = useQuery({
+		queryKey: ["capabilities"],
+		queryFn: async () => unwrap(await api.GET("/api/capabilities")),
+	});
 
 	const provider =
 		typeof settings?.memory_provider === "string" ? settings.memory_provider : "builtin";
+	const availableProviders = new Set(capabilities?.memory_providers ?? ["builtin"]);
+	const providerOptions = (Object.keys(PROVIDER_OPTIONS) as Array<keyof typeof PROVIDER_OPTIONS>)
+		.filter((value) => value === provider || availableProviders.has(value))
+		.map((value) => ({ value, ...PROVIDER_OPTIONS[value] }));
 	const mem0Key = typeof settings?.mem0_api_key === "string" ? settings.mem0_api_key : "";
 	const hasMem0Key = mem0Key !== "";
 
@@ -148,14 +161,12 @@ export default function MemoriesPage() {
 							variant="outline"
 							size="sm"
 						>
-							<ToggleGroupItem value="builtin">
-								<Database />
-								Built-in
-							</ToggleGroupItem>
-							<ToggleGroupItem value="mem0">
-								<Brain />
-								Mem0
-							</ToggleGroupItem>
+							{providerOptions.map(({ value, label, icon: Icon }) => (
+								<ToggleGroupItem key={value} value={value}>
+									<Icon />
+									{label}
+								</ToggleGroupItem>
+							))}
 						</ToggleGroup>
 						<AddMemoryForm />
 					</>

--- a/apps/web/src/app/(dashboard)/memories/page.tsx
+++ b/apps/web/src/app/(dashboard)/memories/page.tsx
@@ -2,7 +2,7 @@
 
 import { findLikelySecret, formatSecretMemoryWarning } from "@clawdi/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertCircle, Brain, Database, Key, Laptop, Plus, Trash2 } from "lucide-react";
+import { AlertCircle, Brain, Database, GitBranch, Key, Laptop, Plus, Trash2 } from "lucide-react";
 import Link from "next/link";
 import { type ReactNode, useCallback, useState } from "react";
 import { toast } from "sonner";
@@ -277,6 +277,15 @@ function MemoryNotesGrid({
 								#{tag}
 							</span>
 						))}
+						{memory.xtrace?.status ? (
+							<span
+								className="inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-xs text-muted-foreground"
+								title="XTrace memory status"
+							>
+								<GitBranch className="size-3" />
+								{memory.xtrace.status}
+							</span>
+						) : null}
 						<span className="ml-auto inline-flex items-center gap-2 text-xs text-muted-foreground">
 							{memory.created_at ? <span>{relativeTime(memory.created_at)}</span> : null}
 							{memory.source_machine_name ? (

--- a/apps/web/src/app/(dashboard)/memories/page.tsx
+++ b/apps/web/src/app/(dashboard)/memories/page.tsx
@@ -48,6 +48,7 @@ const CATEGORIES = [
 	{ value: "preference", label: "Preference" },
 	{ value: "pattern", label: "Pattern" },
 	{ value: "decision", label: "Decision" },
+	{ value: "artifact", label: "Artifact" },
 	{ value: "context", label: "Context" },
 ] as const;
 

--- a/apps/web/src/app/(dashboard)/sessions/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/sessions/[id]/page.tsx
@@ -5,6 +5,7 @@ import {
 	ArrowDown,
 	ArrowDownNarrowWide,
 	ArrowUpNarrowWide,
+	Brain,
 	Clock,
 	Hash,
 	MessageSquare,
@@ -16,6 +17,7 @@ import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { AgentInline } from "@/components/dashboard/agent-label";
 import { DetailMeta, DetailPanel, DetailStats, DetailTitle } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
+import { MemoryRelationshipList } from "@/components/memories/memory-relationship-list";
 import { ModelBadge } from "@/components/meta/model-badge";
 import { Stat } from "@/components/meta/stat";
 import { MessageList } from "@/components/sessions/message-list";
@@ -53,6 +55,22 @@ export default function SessionDetailPage() {
 			if (status >= 400 && status < 500) return false;
 			return failureCount < 2;
 		},
+	});
+
+	const { data: sessionMemories, isLoading: isSessionMemoriesLoading } = useQuery({
+		queryKey: ["memories", "session", id],
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/api/memories", {
+					params: {
+						query: {
+							source_session_id: id,
+							page_size: 12,
+						},
+					},
+				}),
+			),
+		enabled: !!session,
 	});
 
 	// Direction toggle: "desc" (newest-first, default) is the most
@@ -268,6 +286,30 @@ export default function SessionDetailPage() {
 					title={session.local_session_id}
 				/>
 			</DetailStats>
+
+			<DetailPanel className="space-y-3">
+				<div className="flex items-center justify-between gap-3">
+					<div className="space-y-1">
+						<div className="flex items-center gap-2">
+							<Brain className="size-4 text-muted-foreground" />
+							<h2 className="text-sm font-semibold">Memories learned from this session</h2>
+						</div>
+						<p className="text-xs text-muted-foreground">
+							These are account-level memories generated from this session and available to agents
+							later.
+						</p>
+					</div>
+					<span className="text-xs tabular-nums text-muted-foreground">
+						{sessionMemories?.total ?? 0}
+					</span>
+				</div>
+				<MemoryRelationshipList
+					memories={sessionMemories?.items ?? []}
+					isLoading={isSessionMemoriesLoading}
+					emptyMessage="No memories have been linked to this session yet."
+					limit={6}
+				/>
+			</DetailPanel>
 
 			{/* Direction toggle. Gated on `has_content` (not on
 			    `messages.length`) so it stays visible while pages

--- a/apps/web/src/components/memories/memory-relationship-list.tsx
+++ b/apps/web/src/components/memories/memory-relationship-list.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Brain, GitBranch, Laptop } from "lucide-react";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { Memory } from "@/lib/api-schemas";
+import { MEMORY_CATEGORY_COLORS } from "@/lib/memory-utils";
+import { memoryDetailHref } from "@/lib/project-resource-model";
+import { cn, relativeTime } from "@/lib/utils";
+
+export function MemoryRelationshipList({
+	memories,
+	isLoading,
+	emptyMessage,
+	limit,
+}: {
+	memories: Memory[];
+	isLoading: boolean;
+	emptyMessage: string;
+	limit?: number;
+}) {
+	if (isLoading) {
+		return (
+			<div className="space-y-2">
+				{Array.from({ length: 3 }).map((_, index) => (
+					<Skeleton key={index} className="h-16 w-full" />
+				))}
+			</div>
+		);
+	}
+
+	const visible = typeof limit === "number" ? memories.slice(0, limit) : memories;
+	if (!visible.length) {
+		return (
+			<div className="rounded-lg border border-dashed px-3 py-4 text-sm text-muted-foreground">
+				{emptyMessage}
+			</div>
+		);
+	}
+
+	return (
+		<div className="divide-y rounded-lg border bg-background/50">
+			{visible.map((memory) => (
+				<Link
+					key={memory.id}
+					href={memoryDetailHref(memory.id)}
+					className="block px-3 py-3 transition-colors hover:bg-accent/50"
+				>
+					<div className="flex flex-wrap items-center gap-1.5">
+						<Badge variant="secondary" className={cn(MEMORY_CATEGORY_COLORS[memory.category])}>
+							{memory.category}
+						</Badge>
+						{memory.xtrace?.status ? (
+							<span className="inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-xs text-muted-foreground">
+								<GitBranch className="size-3" />
+								{memory.xtrace.status}
+							</span>
+						) : null}
+						{memory.created_at ? (
+							<span className="text-xs text-muted-foreground">
+								{relativeTime(memory.created_at)}
+							</span>
+						) : null}
+					</div>
+					<p className="mt-2 line-clamp-3 break-words text-sm leading-relaxed">{memory.content}</p>
+					<div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+						<span className="inline-flex items-center gap-1">
+							<Brain className="size-3" />
+							{memory.source}
+						</span>
+						{memory.source_machine_name ? (
+							<span className="inline-flex items-center gap-1">
+								<Laptop className="size-3" />
+								{memory.source_machine_name}
+							</span>
+						) : null}
+						{memory.source_session_id ? <span>source session</span> : null}
+					</div>
+				</Link>
+			))}
+			{typeof limit === "number" && memories.length > limit ? (
+				<div className="px-3 py-2 text-xs text-muted-foreground">
+					+{memories.length - limit} more
+				</div>
+			) : null}
+		</div>
+	);
+}

--- a/apps/web/src/lib/memory-utils.ts
+++ b/apps/web/src/lib/memory-utils.ts
@@ -14,3 +14,27 @@ export const MEMORY_CATEGORY_COLORS: Record<string, string> = {
 	artifact: "border-transparent bg-accent text-accent-foreground",
 	context: "border-transparent bg-primary/10 text-primary",
 };
+
+/** Object-identity emoji per category (emoji are object avatars, not UI
+ * icons — DESIGN.md). One glyph per kind so a wall of memories scans by
+ * category at a glance, matching the skill/vault/project card language. */
+export const MEMORY_CATEGORY_EMOJI: Record<string, string> = {
+	fact: "\u{1F4CC}",
+	preference: "\u{1F3AF}",
+	pattern: "\u{1F9E9}",
+	decision: "\u{2696}\u{FE0F}",
+	artifact: "\u{1F4E6}",
+	context: "\u{1F9ED}",
+};
+export const MEMORY_FALLBACK_EMOJI = "\u{1F4DD}";
+
+/** Tinted tile behind the category emoji — same pastel family as
+ * MEMORY_CATEGORY_COLORS, minus text color (the emoji carries its own). */
+export const MEMORY_CATEGORY_TILE_CLASSES: Record<string, string> = {
+	fact: "bg-muted",
+	preference: "bg-info-muted",
+	pattern: "bg-success-muted",
+	decision: "bg-warning-muted",
+	artifact: "bg-accent",
+	context: "bg-primary/10",
+};

--- a/apps/web/src/lib/memory-utils.ts
+++ b/apps/web/src/lib/memory-utils.ts
@@ -11,5 +11,6 @@ export const MEMORY_CATEGORY_COLORS: Record<string, string> = {
 	preference: "border-transparent bg-info-muted text-info-muted-foreground",
 	pattern: "border-transparent bg-success-muted text-success-muted-foreground",
 	decision: "border-transparent bg-warning-muted text-warning-muted-foreground",
+	artifact: "border-transparent bg-accent text-accent-foreground",
 	context: "border-transparent bg-primary/10 text-primary",
 };

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -58,3 +58,12 @@ MEMORY_EMBEDDING_API_KEY=
 MEMORY_EMBEDDING_BASE_URL=
 
 MEMORY_EMBEDDING_MODEL=text-embedding-3-small
+
+# --- Optional XTrace Memory integration ---
+# When enabled, uploaded cloud sessions are sent to XTrace Memory and returned
+# memory refs are mirrored into Clawdi memories.
+XTRACE_MEMORY_ENABLED=false
+XTRACE_API_KEY=
+XTRACE_ORG_ID=
+XTRACE_MEMORY_BASE_URL=https://api.production.xtrace.ai
+XTRACE_MEMORY_APP_ID=clawdi-cloud

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -20,6 +20,7 @@ from app.models import (  # noqa: F401 - register models
     skill_chunk,
     user,
     vault,
+    xtrace_backfill_job,
     xtrace_ingest,
 )
 from app.models.base import Base

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -17,8 +17,10 @@ from app.models import (  # noqa: F401 - register models
     session,
     session_permission,
     skill,
+    skill_chunk,
     user,
     vault,
+    xtrace_ingest,
 )
 from app.models.base import Base
 

--- a/backend/alembic/versions/2d4b0e9a1c7f_add_xtrace_ingest_queue_metadata.py
+++ b/backend/alembic/versions/2d4b0e9a1c7f_add_xtrace_ingest_queue_metadata.py
@@ -1,0 +1,55 @@
+"""add xtrace ingest queue metadata
+
+Revision ID: 2d4b0e9a1c7f
+Revises: f49d6a8e2c31
+Create Date: 2026-06-05 14:20:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2d4b0e9a1c7f"
+down_revision: str | Sequence[str] | None = "f49d6a8e2c31"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "xtrace_memory_ingests",
+        sa.Column("attempt_count", sa.Integer(), server_default="0", nullable=False),
+    )
+    op.add_column(
+        "xtrace_memory_ingests",
+        sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "xtrace_memory_ingests",
+        sa.Column("claimed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "xtrace_memory_ingests",
+        sa.Column("claimed_by", sa.String(length=200), nullable=True),
+    )
+    op.add_column("xtrace_memory_ingests", sa.Column("error", sa.Text(), nullable=True))
+    op.create_index("ix_xtrace_memory_ingests_claimed_by", "xtrace_memory_ingests", ["claimed_by"])
+    op.create_index(
+        "ix_xtrace_memory_ingests_next_attempt_at",
+        "xtrace_memory_ingests",
+        ["next_attempt_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_xtrace_memory_ingests_next_attempt_at", table_name="xtrace_memory_ingests")
+    op.drop_index("ix_xtrace_memory_ingests_claimed_by", table_name="xtrace_memory_ingests")
+    op.drop_column("xtrace_memory_ingests", "error")
+    op.drop_column("xtrace_memory_ingests", "claimed_by")
+    op.drop_column("xtrace_memory_ingests", "claimed_at")
+    op.drop_column("xtrace_memory_ingests", "next_attempt_at")
+    op.drop_column("xtrace_memory_ingests", "attempt_count")

--- a/backend/alembic/versions/3d0b4d7f9a2e_add_skill_chunks.py
+++ b/backend/alembic/versions/3d0b4d7f9a2e_add_skill_chunks.py
@@ -1,0 +1,107 @@
+"""add skill chunks search index
+
+Revision ID: 3d0b4d7f9a2e
+Revises: 0b7c2a4e9d10
+Create Date: 2026-06-04 16:15:00.000000
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from pgvector.sqlalchemy import Vector
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "3d0b4d7f9a2e"
+down_revision: str | Sequence[str] | None = "0b7c2a4e9d10"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm;")
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector;")
+
+    op.create_table(
+        "skill_chunks",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "skill_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("skill_key", sa.String(length=200), nullable=False),
+        sa.Column("content_hash", sa.String(length=64), nullable=False),
+        sa.Column("file_path", sa.Text(), nullable=False),
+        sa.Column("chunk_index", sa.Integer(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("embedding", Vector(768), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["skill_id"], ["skills.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.execute("ALTER TABLE skill_chunks ALTER COLUMN id SET DEFAULT gen_random_uuid();")
+    op.create_index("ix_skill_chunks_project_id", "skill_chunks", ["project_id"])
+    op.create_index(
+        "ix_skill_chunks_skill_file_chunk",
+        "skill_chunks",
+        ["skill_id", "file_path", "chunk_index"],
+        unique=True,
+    )
+    op.create_index("ix_skill_chunks_skill_id", "skill_chunks", ["skill_id"])
+    op.create_index("ix_skill_chunks_user_id", "skill_chunks", ["user_id"])
+    op.create_index(
+        "ix_skill_chunks_user_project_key",
+        "skill_chunks",
+        ["user_id", "project_id", "skill_key"],
+    )
+    op.execute(
+        "ALTER TABLE skill_chunks "
+        "ADD COLUMN content_tsv tsvector "
+        "GENERATED ALWAYS AS (to_tsvector('simple', content)) STORED;"
+    )
+    op.execute(
+        "CREATE INDEX ix_skill_chunks_content_tsv "
+        "ON skill_chunks USING GIN (content_tsv);"
+    )
+    op.execute(
+        "CREATE INDEX ix_skill_chunks_content_trgm "
+        "ON skill_chunks USING GIN (content gin_trgm_ops);"
+    )
+    op.execute(
+        "CREATE INDEX ix_skill_chunks_embedding "
+        "ON skill_chunks USING hnsw (embedding vector_cosine_ops);"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_skill_chunks_embedding;")
+    op.execute("DROP INDEX IF EXISTS ix_skill_chunks_content_trgm;")
+    op.execute("DROP INDEX IF EXISTS ix_skill_chunks_content_tsv;")
+    op.drop_index("ix_skill_chunks_user_project_key", table_name="skill_chunks")
+    op.drop_index("ix_skill_chunks_user_id", table_name="skill_chunks")
+    op.drop_index("ix_skill_chunks_skill_id", table_name="skill_chunks")
+    op.drop_index("ix_skill_chunks_skill_file_chunk", table_name="skill_chunks")
+    op.drop_index("ix_skill_chunks_project_id", table_name="skill_chunks")
+    op.drop_table("skill_chunks")
+    # Keep pg_trgm/vector extensions; other tables may use them.

--- a/backend/alembic/versions/84a75f7f0e2d_add_xtrace_memory_ingests.py
+++ b/backend/alembic/versions/84a75f7f0e2d_add_xtrace_memory_ingests.py
@@ -1,0 +1,79 @@
+"""add xtrace memory ingest audits
+
+Revision ID: 84a75f7f0e2d
+Revises: 3d0b4d7f9a2e
+Create Date: 2026-06-04 16:45:00.000000
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "84a75f7f0e2d"
+down_revision: str | Sequence[str] | None = "3d0b4d7f9a2e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "xtrace_memory_ingests",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("session_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("local_session_id", sa.String(length=200), nullable=False),
+        sa.Column("job_id", sa.String(length=200), nullable=True),
+        sa.Column("status", sa.String(length=50), nullable=True),
+        sa.Column("created_ref_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("updated_ref_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("mirrored_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("response", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["session_id"], ["sessions.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_xtrace_memory_ingests_job_id", "xtrace_memory_ingests", ["job_id"])
+    op.create_index(
+        "ix_xtrace_memory_ingests_local_session_id",
+        "xtrace_memory_ingests",
+        ["local_session_id"],
+    )
+    op.create_index(
+        "ix_xtrace_memory_ingests_session_id",
+        "xtrace_memory_ingests",
+        ["session_id"],
+    )
+    op.create_index("ix_xtrace_memory_ingests_status", "xtrace_memory_ingests", ["status"])
+    op.create_index("ix_xtrace_memory_ingests_user_id", "xtrace_memory_ingests", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_xtrace_memory_ingests_user_id", table_name="xtrace_memory_ingests")
+    op.drop_index("ix_xtrace_memory_ingests_status", table_name="xtrace_memory_ingests")
+    op.drop_index("ix_xtrace_memory_ingests_session_id", table_name="xtrace_memory_ingests")
+    op.drop_index(
+        "ix_xtrace_memory_ingests_local_session_id",
+        table_name="xtrace_memory_ingests",
+    )
+    op.drop_index("ix_xtrace_memory_ingests_job_id", table_name="xtrace_memory_ingests")
+    op.drop_table("xtrace_memory_ingests")

--- a/backend/alembic/versions/c7486d1f5b60_extend_xtrace_ingests_for_skills.py
+++ b/backend/alembic/versions/c7486d1f5b60_extend_xtrace_ingests_for_skills.py
@@ -1,0 +1,67 @@
+"""extend xtrace ingests for skill sources
+
+Revision ID: c7486d1f5b60
+Revises: 84a75f7f0e2d
+Create Date: 2026-06-04 17:10:00.000000
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c7486d1f5b60"
+down_revision: str | Sequence[str] | None = "84a75f7f0e2d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "xtrace_memory_ingests",
+        sa.Column("source_type", sa.String(length=50), server_default="session", nullable=False),
+    )
+    op.add_column(
+        "xtrace_memory_ingests",
+        sa.Column("skill_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.add_column(
+        "xtrace_memory_ingests",
+        sa.Column("source_key", sa.String(length=300), nullable=True),
+    )
+    op.alter_column("xtrace_memory_ingests", "session_id", nullable=True)
+    op.alter_column("xtrace_memory_ingests", "local_session_id", nullable=True)
+    op.create_foreign_key(
+        "fk_xtrace_memory_ingests_skill_id_skills",
+        "xtrace_memory_ingests",
+        "skills",
+        ["skill_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_index(
+        "ix_xtrace_memory_ingests_source_type",
+        "xtrace_memory_ingests",
+        ["source_type"],
+    )
+    op.create_index("ix_xtrace_memory_ingests_skill_id", "xtrace_memory_ingests", ["skill_id"])
+    op.create_index("ix_xtrace_memory_ingests_source_key", "xtrace_memory_ingests", ["source_key"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_xtrace_memory_ingests_source_key", table_name="xtrace_memory_ingests")
+    op.drop_index("ix_xtrace_memory_ingests_skill_id", table_name="xtrace_memory_ingests")
+    op.drop_index("ix_xtrace_memory_ingests_source_type", table_name="xtrace_memory_ingests")
+    op.drop_constraint(
+        "fk_xtrace_memory_ingests_skill_id_skills",
+        "xtrace_memory_ingests",
+        type_="foreignkey",
+    )
+    op.alter_column("xtrace_memory_ingests", "local_session_id", nullable=False)
+    op.alter_column("xtrace_memory_ingests", "session_id", nullable=False)
+    op.drop_column("xtrace_memory_ingests", "source_key")
+    op.drop_column("xtrace_memory_ingests", "skill_id")
+    op.drop_column("xtrace_memory_ingests", "source_type")

--- a/backend/alembic/versions/f49d6a8e2c31_add_xtrace_backfill_jobs.py
+++ b/backend/alembic/versions/f49d6a8e2c31_add_xtrace_backfill_jobs.py
@@ -1,0 +1,90 @@
+"""add xtrace backfill jobs
+
+Revision ID: f49d6a8e2c31
+Revises: c7486d1f5b60
+Create Date: 2026-06-04 17:45:00.000000
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f49d6a8e2c31"
+down_revision: str | Sequence[str] | None = "c7486d1f5b60"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "xtrace_backfill_jobs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("requested_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("scope_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("include_sessions", sa.Boolean(), server_default="true", nullable=False),
+        sa.Column("include_skills", sa.Boolean(), server_default="true", nullable=False),
+        sa.Column("force", sa.Boolean(), server_default="false", nullable=False),
+        sa.Column("dry_run", sa.Boolean(), server_default="false", nullable=False),
+        sa.Column("limit", sa.Integer(), nullable=True),
+        sa.Column("status", sa.String(length=50), server_default="queued", nullable=False),
+        sa.Column("current_source_type", sa.String(length=50), nullable=True),
+        sa.Column("current_source_key", sa.String(length=300), nullable=True),
+        sa.Column("considered_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("sent_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("skipped_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("failed_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("mirrored_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("sessions_considered", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("sessions_sent", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("sessions_skipped", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("sessions_failed", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("sessions_mirrored", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("skills_considered", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("skills_sent", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("skills_skipped", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("skills_failed", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("skills_mirrored", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(
+            ["requested_by_user_id"],
+            ["users.id"],
+            name="fk_xtrace_backfill_jobs_requested_by_user_id_users",
+            ondelete="SET NULL",
+        ),
+        sa.ForeignKeyConstraint(
+            ["scope_user_id"],
+            ["users.id"],
+            name="fk_xtrace_backfill_jobs_scope_user_id_users",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_xtrace_backfill_jobs_requested_by_user_id",
+        "xtrace_backfill_jobs",
+        ["requested_by_user_id"],
+    )
+    op.create_index(
+        "ix_xtrace_backfill_jobs_scope_user_id",
+        "xtrace_backfill_jobs",
+        ["scope_user_id"],
+    )
+    op.create_index("ix_xtrace_backfill_jobs_status", "xtrace_backfill_jobs", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_xtrace_backfill_jobs_status", table_name="xtrace_backfill_jobs")
+    op.drop_index("ix_xtrace_backfill_jobs_scope_user_id", table_name="xtrace_backfill_jobs")
+    op.drop_index(
+        "ix_xtrace_backfill_jobs_requested_by_user_id",
+        table_name="xtrace_backfill_jobs",
+    )
+    op.drop_table("xtrace_backfill_jobs")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -153,15 +153,16 @@ class Settings(BaseSettings):
     llm_model: str = "gpt-4o-mini"
 
     # Optional XTrace Memory API integration. When enabled and configured,
-    # uploaded cloud sessions are forwarded to XTrace for memory extraction,
-    # and returned memory refs are mirrored into Clawdi's builtin memory table.
+    # uploaded cloud sessions and skill bundles are forwarded to XTrace for
+    # belief, episode, and artifact extraction, and returned memory refs are
+    # mirrored into Clawdi's builtin memory table.
     xtrace_memory_enabled: bool = False
     xtrace_api_key: str = ""
     xtrace_org_id: str = ""
     xtrace_memory_base_url: str = "https://api.production.xtrace.ai"
     xtrace_memory_app_id: str = "clawdi-cloud"
     xtrace_memory_timeout_seconds: float = 35.0
-    xtrace_memory_max_messages: int = 200
+    xtrace_memory_max_messages: int = 1000
 
     # JSON object keyed by provider/tool id. Each value can include:
     # authorization_url, token_url, client_id, client_secret, scope, audience,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -164,9 +164,9 @@ class Settings(BaseSettings):
     xtrace_memory_timeout_seconds: float = 35.0
     xtrace_memory_max_messages: int = 80
     xtrace_memory_backfill_max_messages: int = 20
-    xtrace_memory_worker_enabled: bool = True
-    xtrace_memory_worker_batch_size: int = 5
-    xtrace_memory_worker_poll_seconds: float = 15.0
+    xtrace_memory_worker_enabled: bool = False
+    xtrace_memory_worker_batch_size: int = 1
+    xtrace_memory_worker_poll_seconds: float = 60.0
 
     # JSON object keyed by provider/tool id. Each value can include:
     # authorization_url, token_url, client_id, client_secret, scope, audience,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -164,6 +164,9 @@ class Settings(BaseSettings):
     xtrace_memory_timeout_seconds: float = 35.0
     xtrace_memory_max_messages: int = 80
     xtrace_memory_backfill_max_messages: int = 20
+    xtrace_memory_worker_enabled: bool = True
+    xtrace_memory_worker_batch_size: int = 5
+    xtrace_memory_worker_poll_seconds: float = 15.0
 
     # JSON object keyed by provider/tool id. Each value can include:
     # authorization_url, token_url, client_id, client_secret, scope, audience,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -162,7 +162,8 @@ class Settings(BaseSettings):
     xtrace_memory_base_url: str = "https://api.production.xtrace.ai"
     xtrace_memory_app_id: str = "clawdi-cloud"
     xtrace_memory_timeout_seconds: float = 35.0
-    xtrace_memory_max_messages: int = 1000
+    xtrace_memory_max_messages: int = 80
+    xtrace_memory_backfill_max_messages: int = 20
 
     # JSON object keyed by provider/tool id. Each value can include:
     # authorization_url, token_url, client_id, client_secret, scope, audience,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -169,6 +169,7 @@ class Settings(BaseSettings):
     xtrace_memory_worker_poll_seconds: float = 60.0
     xtrace_memory_max_attempts: int = 3
     xtrace_memory_retry_base_seconds: float = 60.0
+    xtrace_memory_daily_message_budget_per_user: int = 0
     xtrace_memory_skip_automated_sessions: bool = True
     xtrace_memory_skip_tiny_sessions: bool = False
     xtrace_memory_low_quality_max_messages: int = 3

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -169,6 +169,10 @@ class Settings(BaseSettings):
     xtrace_memory_worker_poll_seconds: float = 60.0
     xtrace_memory_max_attempts: int = 3
     xtrace_memory_retry_base_seconds: float = 60.0
+    xtrace_memory_skip_automated_sessions: bool = True
+    xtrace_memory_skip_tiny_sessions: bool = False
+    xtrace_memory_low_quality_max_messages: int = 3
+    xtrace_memory_low_quality_max_duration_seconds: int = 120
 
     # JSON object keyed by provider/tool id. Each value can include:
     # authorization_url, token_url, client_id, client_secret, scope, audience,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -152,6 +152,17 @@ class Settings(BaseSettings):
     llm_api_key: str = ""
     llm_model: str = "gpt-4o-mini"
 
+    # Optional XTrace Memory API integration. When enabled and configured,
+    # uploaded cloud sessions are forwarded to XTrace for memory extraction,
+    # and returned memory refs are mirrored into Clawdi's builtin memory table.
+    xtrace_memory_enabled: bool = False
+    xtrace_api_key: str = ""
+    xtrace_org_id: str = ""
+    xtrace_memory_base_url: str = "https://api.production.xtrace.ai"
+    xtrace_memory_app_id: str = "clawdi-cloud"
+    xtrace_memory_timeout_seconds: float = 35.0
+    xtrace_memory_max_messages: int = 200
+
     # JSON object keyed by provider/tool id. Each value can include:
     # authorization_url, token_url, client_id, client_secret, scope, audience,
     # and extra_authorize_params. Codex has an official built-in default; this

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -167,6 +167,8 @@ class Settings(BaseSettings):
     xtrace_memory_worker_enabled: bool = False
     xtrace_memory_worker_batch_size: int = 1
     xtrace_memory_worker_poll_seconds: float = 60.0
+    xtrace_memory_max_attempts: int = 3
+    xtrace_memory_retry_base_seconds: float = 60.0
 
     # JSON object keyed by provider/tool id. Each value can include:
     # authorization_url, token_url, client_id, client_secret, scope, audience,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -36,6 +36,7 @@ from app.routes.skills import project_router as skills_project_router
 from app.routes.skills import router as skills_router
 from app.routes.sync import router as sync_router
 from app.routes.vault import router as vault_router
+from app.routes.xtrace import router as xtrace_router
 from app.services.composio import close_composio_client
 from app.services.embedding import LocalEmbedder
 
@@ -187,6 +188,7 @@ app.include_router(share_redeem_router)
 app.include_router(sharing_router)
 app.include_router(me_router)
 app.include_router(agent_project_bindings_router)
+app.include_router(xtrace_router)
 
 
 @app.get("/health")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -39,6 +39,8 @@ from app.routes.vault import router as vault_router
 from app.routes.xtrace import router as xtrace_router
 from app.services.composio import close_composio_client
 from app.services.embedding import LocalEmbedder
+from app.services.xtrace_ingest_queue import run_xtrace_ingest_worker
+from app.services.xtrace_memory import xtrace_memory_configured
 
 logging.basicConfig(level=logging.INFO)
 logging.getLogger("httpx").setLevel(logging.WARNING)
@@ -71,6 +73,11 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         # Task and the GC can reap it mid-flight otherwise. Python docs
         # explicitly warn about this pattern.
         task = asyncio.create_task(_warm(), name="embedder-warm")
+        background.add(task)
+        task.add_done_callback(background.discard)
+
+    if settings.xtrace_memory_worker_enabled and xtrace_memory_configured():
+        task = asyncio.create_task(run_xtrace_ingest_worker(), name="xtrace-ingest-worker")
         background.add(task)
         task.add_done_callback(background.discard)
 

--- a/backend/app/models/skill_chunk.py
+++ b/backend/app/models/skill_chunk.py
@@ -1,0 +1,46 @@
+import uuid
+
+from pgvector.sqlalchemy import Vector
+from sqlalchemy import ForeignKey, Index, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+from app.models.project import Project  # noqa: F401 - register `projects` table for FK resolution
+from app.models.skill import Skill  # noqa: F401 - register `skills` table for FK resolution
+
+
+class SkillChunk(Base, TimestampMixin):
+    __tablename__ = "skill_chunks"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    skill_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("skills.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    skill_key: Mapped[str] = mapped_column(String(200), nullable=False)
+    content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    file_path: Mapped[str] = mapped_column(Text, nullable=False)
+    chunk_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    embedding: Mapped[list[float] | None] = mapped_column(Vector(768), nullable=True)
+
+    __table_args__ = (
+        Index(
+            "ix_skill_chunks_skill_file_chunk",
+            "skill_id",
+            "file_path",
+            "chunk_index",
+            unique=True,
+        ),
+        Index("ix_skill_chunks_user_project_key", "user_id", "project_id", "skill_key"),
+    )

--- a/backend/app/models/xtrace_backfill_job.py
+++ b/backend/app/models/xtrace_backfill_job.py
@@ -1,0 +1,58 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+from app.models.user import User  # noqa: F401 - register `users` table for FK resolution
+
+
+class XTraceBackfillJob(Base, TimestampMixin):
+    __tablename__ = "xtrace_backfill_jobs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    requested_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    scope_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+    include_sessions: Mapped[bool] = mapped_column(Boolean, server_default="true", nullable=False)
+    include_skills: Mapped[bool] = mapped_column(Boolean, server_default="true", nullable=False)
+    force: Mapped[bool] = mapped_column(Boolean, server_default="false", nullable=False)
+    dry_run: Mapped[bool] = mapped_column(Boolean, server_default="false", nullable=False)
+    limit: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    status: Mapped[str] = mapped_column(
+        String(50),
+        server_default="queued",
+        nullable=False,
+        index=True,
+    )
+    current_source_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    current_source_key: Mapped[str | None] = mapped_column(String(300), nullable=True)
+    considered_count: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    sent_count: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    skipped_count: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    failed_count: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    mirrored_count: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    sessions_considered: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    sessions_sent: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    sessions_skipped: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    sessions_failed: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    sessions_mirrored: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    skills_considered: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    skills_sent: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    skills_skipped: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    skills_failed: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    skills_mirrored: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/models/xtrace_ingest.py
+++ b/backend/app/models/xtrace_ingest.py
@@ -1,0 +1,28 @@
+import uuid
+
+from sqlalchemy import ForeignKey, Integer, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+from app.models.session import Session  # noqa: F401 - register `sessions` table for FK resolution
+
+
+class XTraceMemoryIngest(Base, TimestampMixin):
+    __tablename__ = "xtrace_memory_ingests"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    session_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("sessions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    local_session_id: Mapped[str] = mapped_column(String(200), nullable=False, index=True)
+    job_id: Mapped[str | None] = mapped_column(String(200), nullable=True, index=True)
+    status: Mapped[str | None] = mapped_column(String(50), nullable=True, index=True)
+    created_ref_count: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    updated_ref_count: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    mirrored_count: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    response: Mapped[dict | None] = mapped_column(JSONB)

--- a/backend/app/models/xtrace_ingest.py
+++ b/backend/app/models/xtrace_ingest.py
@@ -1,6 +1,7 @@
 import uuid
+from datetime import datetime
 
-from sqlalchemy import ForeignKey, Integer, String
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -34,4 +35,9 @@ class XTraceMemoryIngest(Base, TimestampMixin):
     created_ref_count: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
     updated_ref_count: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
     mirrored_count: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    attempt_count: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)
+    next_attempt_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    claimed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    claimed_by: Mapped[str | None] = mapped_column(String(200), nullable=True, index=True)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
     response: Mapped[dict | None] = mapped_column(JSONB)

--- a/backend/app/models/xtrace_ingest.py
+++ b/backend/app/models/xtrace_ingest.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base, TimestampMixin
 from app.models.session import Session  # noqa: F401 - register `sessions` table for FK resolution
+from app.models.skill import Skill  # noqa: F401 - register `skills` table for FK resolution
 
 
 class XTraceMemoryIngest(Base, TimestampMixin):
@@ -13,13 +14,21 @@ class XTraceMemoryIngest(Base, TimestampMixin):
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
-    session_id: Mapped[uuid.UUID] = mapped_column(
+    source_type: Mapped[str] = mapped_column(String(50), server_default="session", nullable=False)
+    session_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("sessions.id", ondelete="CASCADE"),
-        nullable=False,
+        nullable=True,
         index=True,
     )
-    local_session_id: Mapped[str] = mapped_column(String(200), nullable=False, index=True)
+    skill_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("skills.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+    local_session_id: Mapped[str | None] = mapped_column(String(200), nullable=True, index=True)
+    source_key: Mapped[str | None] = mapped_column(String(300), nullable=True, index=True)
     job_id: Mapped[str | None] = mapped_column(String(200), nullable=True, index=True)
     status: Mapped[str | None] = mapped_column(String(50), nullable=True, index=True)
     created_ref_count: Mapped[int] = mapped_column(Integer, server_default="0", nullable=False)

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -28,10 +28,10 @@ can land in this file under the same auth dep.
 
 import logging
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -40,7 +40,7 @@ from app.core.auth import require_admin_api_key
 from app.core.database import get_session
 from app.models.api_key import ApiKey
 from app.models.project import PROJECT_KIND_ENVIRONMENT, Project
-from app.models.session import AgentEnvironment
+from app.models.session import AgentEnvironment, Session
 from app.models.user import User
 from app.schemas.admin import AdminApiKeyCreate, AdminEnvironmentCreate
 from app.schemas.api_key import ApiKeyCreated, ApiKeyRevokeResponse
@@ -57,6 +57,19 @@ logger = logging.getLogger(__name__)
 # tell admin endpoints exist let alone what header they expect. The
 # routes themselves stay live — gating is `require_admin_api_key`.
 router = APIRouter(prefix="/api/admin", tags=["admin"], include_in_schema=False)
+
+
+def _is_automated_session(summary: str | None) -> bool:
+    summary_text = summary or ""
+    return summary_text.startswith("Cron:") or summary_text.startswith("[")
+
+
+def _percentile(values: list[int], percentile: float) -> int:
+    if not values:
+        return 0
+    sorted_values = sorted(values)
+    index = max(0, min(len(sorted_values) - 1, int((len(sorted_values) - 1) * percentile)))
+    return sorted_values[index]
 
 
 async def _resolve_or_create_user(db: AsyncSession, clerk_id: str) -> User:
@@ -94,6 +107,129 @@ async def _resolve_or_create_user(db: AsyncSession, clerk_id: str) -> User:
     )
     logger.info("admin_lazy_create_user clerk_id=%s user_id=%s", clerk_id, user.id)
     return user
+
+
+@router.get("/stats/sessions")
+async def admin_session_stats(
+    _: None = Depends(require_admin_api_key),
+    db: AsyncSession = Depends(get_session),
+    since: datetime | None = Query(
+        default=None,
+        description="Window start; defaults to the current UTC day.",
+    ),
+    until: datetime | None = Query(
+        default=None,
+        description="Window end; defaults to the next UTC day after since.",
+    ),
+) -> dict:
+    """Fleet-wide session volume for capacity planning.
+
+    This route intentionally returns aggregate counters only. It is used for
+    quota/cost planning and cron-noise analysis; it does not expose session
+    summaries, project paths, or message content.
+    """
+
+    now = datetime.now(UTC)
+    window_start = since or datetime(now.year, now.month, now.day, tzinfo=UTC)
+    window_end = until or (window_start + timedelta(days=1))
+    if window_end <= window_start:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, "until must be after since")
+
+    rows = (
+        await db.execute(
+            select(
+                Session.user_id,
+                AgentEnvironment.agent_type,
+                Session.summary,
+                Session.message_count,
+                Session.duration_seconds,
+                Session.input_tokens,
+                Session.output_tokens,
+                Session.cache_read_tokens,
+                Session.file_key,
+            )
+            .outerjoin(AgentEnvironment, Session.environment_id == AgentEnvironment.id)
+            .where(Session.last_activity_at >= window_start, Session.last_activity_at < window_end)
+        )
+    ).all()
+
+    by_user: dict[str, int] = {}
+    automated_users: set[str] = set()
+    manual_users: set[str] = set()
+    agent_counts: dict[str, int] = {}
+    totals = {
+        "sessions": 0,
+        "messages": 0,
+        "tokens": 0,
+        "sessions_with_content": 0,
+        "automated_sessions": 0,
+        "automated_messages": 0,
+        "manual_sessions": 0,
+        "manual_messages": 0,
+        "tiny_sessions": 0,
+    }
+
+    for row in rows:
+        user_id = str(row.user_id)
+        message_count = int(row.message_count or 0)
+        duration_seconds = int(row.duration_seconds or 0)
+        token_count = int(row.input_tokens or 0) + int(row.output_tokens or 0)
+        if row.cache_read_tokens:
+            token_count += int(row.cache_read_tokens)
+        automated = _is_automated_session(row.summary)
+        agent_type = row.agent_type or "unknown"
+
+        totals["sessions"] += 1
+        totals["messages"] += message_count
+        totals["tokens"] += token_count
+        if row.file_key:
+            totals["sessions_with_content"] += 1
+        if message_count <= 3 or duration_seconds <= 120:
+            totals["tiny_sessions"] += 1
+        by_user[user_id] = by_user.get(user_id, 0) + 1
+        agent_counts[agent_type] = agent_counts.get(agent_type, 0) + 1
+        if automated:
+            totals["automated_sessions"] += 1
+            totals["automated_messages"] += message_count
+            automated_users.add(user_id)
+        else:
+            totals["manual_sessions"] += 1
+            totals["manual_messages"] += message_count
+            manual_users.add(user_id)
+
+    session_counts = list(by_user.values())
+    user_count = len(by_user)
+    automated_session_share = (
+        totals["automated_sessions"] / totals["sessions"] if totals["sessions"] else 0
+    )
+
+    return {
+        "window": {
+            "since": window_start.isoformat(),
+            "until": window_end.isoformat(),
+        },
+        "totals": {
+            **totals,
+            "active_users": user_count,
+            "automated_users": len(automated_users),
+            "manual_users": len(manual_users),
+            "automated_session_share": automated_session_share,
+        },
+        "per_user": {
+            "p50_sessions": _percentile(session_counts, 0.50),
+            "p90_sessions": _percentile(session_counts, 0.90),
+            "p95_sessions": _percentile(session_counts, 0.95),
+            "max_sessions": max(session_counts) if session_counts else 0,
+        },
+        "agents": sorted(
+            [
+                {"agent_type": agent_type, "sessions": count}
+                for agent_type, count in agent_counts.items()
+            ],
+            key=lambda item: item["sessions"],
+            reverse=True,
+        ),
+    }
 
 
 @router.post("/auth/keys", response_model=ApiKeyCreated)

--- a/backend/app/routes/capabilities.py
+++ b/backend/app/routes/capabilities.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel
 
 from app.core.auth import AuthContext, require_user_auth
 from app.services.memory_provider import mem0_available
+from app.services.xtrace_memory import xtrace_memory_configured
 
 router = APIRouter(prefix="/api", tags=["capabilities"])
 
@@ -47,4 +48,6 @@ async def get_capabilities(
     providers = ["builtin"]
     if mem0_available():
         providers.append("mem0")
+    if xtrace_memory_configured():
+        providers.append("xtrace")
     return CapabilitiesResponse(memory_providers=providers)

--- a/backend/app/routes/memories.py
+++ b/backend/app/routes/memories.py
@@ -157,8 +157,24 @@ async def list_memories(
     category: str | None = Query(default=None),
     q: str | None = Query(default=None),
     order: str = Query(default="desc", pattern=r"^(asc|desc)$"),
+    source_session_id: UUID | None = Query(default=None),
+    environment_id: UUID | None = Query(default=None),
 ) -> Paginated[MemoryResponse]:
     provider = await get_memory_provider(str(auth.user_id), db)
+    if (source_session_id is not None or environment_id is not None) and isinstance(
+        provider, BuiltinProvider
+    ):
+        return await _list_builtin_relationship_memories(
+            db,
+            auth,
+            page=page,
+            page_size=page_size,
+            category=category,
+            q=q,
+            order=order,
+            source_session_id=source_session_id,
+            environment_id=environment_id,
+        )
 
     if q:
         # Search is top-N ranked (FTS + trgm + vector hybrid). Paging through
@@ -269,6 +285,53 @@ async def list_memories(
             page=page,
             page_size=page_size,
         )
+    return Paginated[MemoryResponse](
+        items=[MemoryResponse.model_validate(m) for m in rows],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+async def _list_builtin_relationship_memories(
+    db: AsyncSession,
+    auth: AuthContext,
+    *,
+    page: int,
+    page_size: int,
+    category: str | None,
+    q: str | None,
+    order: str,
+    source_session_id: UUID | None,
+    environment_id: UUID | None,
+) -> Paginated[MemoryResponse]:
+    from sqlalchemy import desc, func
+
+    base = (
+        select(Memory)
+        .join(Session, Memory.source_session_id == Session.id)
+        .where(Memory.user_id == auth.user_id, Session.user_id == auth.user_id)
+    )
+    if source_session_id is not None:
+        base = base.where(Session.id == source_session_id)
+    if environment_id is not None:
+        base = base.where(Session.environment_id == environment_id)
+    if _is_env_bound_api_key(auth):
+        if auth.api_key is None or auth.api_key.environment_id is None:
+            return Paginated[MemoryResponse](items=[], total=0, page=page, page_size=page_size)
+        base = base.where(Session.environment_id == auth.api_key.environment_id)
+    if category:
+        base = base.where(Memory.category == category)
+    if q:
+        base = base.where(Memory.content.ilike(f"%{q}%"))
+
+    total = (await db.execute(select(func.count()).select_from(base.subquery()))).scalar_one()
+    order_col = desc(Memory.created_at) if order == "desc" else Memory.created_at
+    result = await db.execute(
+        base.order_by(order_col).limit(page_size).offset((page - 1) * page_size)
+    )
+    rows = [memory_to_dict(m) for m in result.scalars().all()]
+    await _attach_source_machines(db, auth, rows)
     return Paginated[MemoryResponse](
         items=[MemoryResponse.model_validate(m) for m in rows],
         total=total,

--- a/backend/app/routes/search.py
+++ b/backend/app/routes/search.py
@@ -13,7 +13,7 @@ from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
-from sqlalchemy import or_, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import AuthContext, _is_env_bound_api_key, _is_scoped_api_key, get_auth
@@ -22,6 +22,7 @@ from app.core.project import project_ids_visible_to
 from app.core.query_utils import like_needle
 from app.models.session import AgentEnvironment, Session
 from app.models.skill import Skill
+from app.models.skill_chunk import SkillChunk
 from app.models.vault import Vault, VaultProjectAttachment
 from app.services.memory_provider import get_memory_provider
 
@@ -59,6 +60,20 @@ class SearchResponse(BaseModel):
 
 
 TYPE_LIMIT = 5
+
+
+def _query_excerpt(content: str, query: str, max_len: int = 120) -> str:
+    haystack = content.replace("\n", " ").strip()
+    if len(haystack) <= max_len:
+        return haystack
+    pos = haystack.lower().find(query.lower())
+    if pos < 0:
+        return haystack[: max_len - 3].rstrip() + "..."
+    start = max(0, pos - 40)
+    end = min(len(haystack), start + max_len)
+    prefix = "..." if start > 0 else ""
+    suffix = "..." if end < len(haystack) else ""
+    return prefix + haystack[start:end].strip() + suffix
 
 
 async def _search_sessions(db: AsyncSession, auth: AuthContext, query: str) -> list[SearchHit]:
@@ -151,7 +166,7 @@ async def _search_skills(db: AsyncSession, auth: AuthContext, query: str) -> lis
         .limit(TYPE_LIMIT)
     )
     rows = (await db.execute(stmt)).scalars().all()
-    return [
+    hits = [
         SearchHit(
             type="skill",
             id=str(s.id),
@@ -173,6 +188,45 @@ async def _search_skills(db: AsyncSession, auth: AuthContext, query: str) -> lis
         )
         for s in rows
     ]
+    seen_skill_ids = {s.id for s in rows}
+    remaining = TYPE_LIMIT - len(hits)
+    if remaining <= 0:
+        return hits
+
+    content_score = func.similarity(SkillChunk.content, query)
+    chunk_stmt = (
+        select(Skill, SkillChunk)
+        .join(SkillChunk, SkillChunk.skill_id == Skill.id)
+        .where(
+            Skill.is_active,
+            Skill.project_id.in_(visible_project_ids),
+            SkillChunk.content_hash == Skill.content_hash,
+            or_(
+                SkillChunk.content.ilike(needle, escape="\\"),
+                SkillChunk.file_path.ilike(needle, escape="\\"),
+                content_score > 0.1,
+            ),
+        )
+        .order_by(content_score.desc(), Skill.updated_at.desc(), SkillChunk.file_path)
+        .limit(TYPE_LIMIT * 3)
+    )
+    chunk_rows = (await db.execute(chunk_stmt)).all()
+    for skill, chunk in chunk_rows:
+        if skill.id in seen_skill_ids:
+            continue
+        hits.append(
+            SearchHit(
+                type="skill",
+                id=str(skill.id),
+                title=skill.name or skill.skill_key,
+                subtitle=f"{chunk.file_path} · {_query_excerpt(chunk.content, query)}",
+                href=f"/skills/{quote(skill.skill_key, safe='')}?project={skill.project_id}",
+            )
+        )
+        seen_skill_ids.add(skill.id)
+        if len(hits) >= TYPE_LIMIT:
+            break
+    return hits
 
 
 async def _search_vaults(db: AsyncSession, auth: AuthContext, query: str) -> list[SearchHit]:

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -58,6 +58,7 @@ from app.services.session_content import (
 )
 from app.services.session_export import session_to_markdown
 from app.services.session_refs import extract_related_refs
+from app.services.xtrace_memory import ingest_xtrace_session_memories, xtrace_memory_configured
 
 router = APIRouter(tags=["sessions"])
 log = logging.getLogger(__name__)
@@ -1232,9 +1233,11 @@ async def upload_session_content(
     # the file store and the row's content_hash is the source of truth;
     # we'd rather have a session with NULL related_refs than a
     # half-committed upload).
+    parsed_messages: list[dict[str, object]] | None = None
     try:
         parsed = json.loads(data)
         if isinstance(parsed, list):
+            parsed_messages = [m for m in parsed if isinstance(m, dict)]
             session.related_refs = extract_related_refs(parsed) or None
     except (json.JSONDecodeError, ValueError, TypeError):
         # log.exception (not warning) so the traceback lands in logs —
@@ -1246,6 +1249,31 @@ async def upload_session_content(
         )
 
     await db.commit()
+
+    if parsed_messages is not None and xtrace_memory_configured():
+        try:
+            xtrace_result = await ingest_xtrace_session_memories(
+                db,
+                session=session,
+                messages=parsed_messages,
+            )
+            if xtrace_result is not None:
+                log.info(
+                    "xtrace_memory_ingested local_session_id=%s job_id=%s status=%s "
+                    "created_refs=%s updated_refs=%s mirrored=%s",
+                    local_session_id,
+                    xtrace_result.job_id,
+                    xtrace_result.status,
+                    xtrace_result.created_ref_count,
+                    xtrace_result.updated_ref_count,
+                    xtrace_result.mirrored_count,
+                )
+        except Exception:
+            await db.rollback()
+            log.exception(
+                "xtrace_memory_ingest_failed local_session_id=%s",
+                local_session_id,
+            )
 
     return SessionUploadResponse(status="uploaded", file_key=fk, content_hash=content_hash)
 

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -58,7 +58,8 @@ from app.services.session_content import (
 )
 from app.services.session_export import session_to_markdown
 from app.services.session_refs import extract_related_refs
-from app.services.xtrace_memory import ingest_xtrace_session_memories, xtrace_memory_configured
+from app.services.xtrace_ingest_queue import enqueue_xtrace_session_ingest
+from app.services.xtrace_memory import xtrace_memory_configured
 
 router = APIRouter(tags=["sessions"])
 log = logging.getLogger(__name__)
@@ -1252,21 +1253,13 @@ async def upload_session_content(
 
     if parsed_messages is not None and xtrace_memory_configured():
         try:
-            xtrace_result = await ingest_xtrace_session_memories(
-                db,
-                session=session,
-                messages=parsed_messages,
-            )
-            if xtrace_result is not None:
+            xtrace_job = await enqueue_xtrace_session_ingest(db, session=session)
+            if xtrace_job is not None:
                 log.info(
-                    "xtrace_memory_ingested local_session_id=%s job_id=%s status=%s "
-                    "created_refs=%s updated_refs=%s mirrored=%s",
+                    "xtrace_memory_ingest_queued local_session_id=%s ingest_id=%s status=%s",
                     local_session_id,
-                    xtrace_result.job_id,
-                    xtrace_result.status,
-                    xtrace_result.created_ref_count,
-                    xtrace_result.updated_ref_count,
-                    xtrace_result.mirrored_count,
+                    xtrace_job.id,
+                    xtrace_job.status,
                 )
         except Exception:
             await db.rollback()

--- a/backend/app/routes/settings.py
+++ b/backend/app/routes/settings.py
@@ -13,6 +13,7 @@ from app.schemas.settings import (
 )
 from app.services.memory_provider import mem0_available
 from app.services.vault_crypto import encrypt_field, is_encrypted_field
+from app.services.xtrace_memory import xtrace_memory_configured
 
 router = APIRouter(prefix="/api/settings", tags=["settings"])
 
@@ -100,6 +101,14 @@ async def update_settings(
                     "Mem0 memory provider isn't available on this deployment. "
                     "The operator must install the [mem0] extra on the backend."
                 ),
+            },
+        )
+    if raw_patch.get("memory_provider") == "xtrace" and not xtrace_memory_configured():
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "memory_provider_unavailable",
+                "message": "XTrace memory provider isn't configured on this deployment.",
             },
         )
 

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -51,7 +51,8 @@ from app.services.tar_utils import (
     tar_from_content,
     validate_tar,
 )
-from app.services.xtrace_memory import ingest_xtrace_skill_memories, xtrace_memory_configured
+from app.services.xtrace_ingest_queue import enqueue_xtrace_skill_ingest
+from app.services.xtrace_memory import xtrace_memory_configured
 
 router = APIRouter(prefix="/api/skills", tags=["skills"])
 
@@ -1342,17 +1343,13 @@ async def _ingest_skill_to_xtrace(db: AsyncSession, skill: Skill, data: bytes) -
     if not xtrace_memory_configured():
         return
     try:
-        result = await ingest_xtrace_skill_memories(db, skill=skill, data=data)
-        if result is not None:
+        job = await enqueue_xtrace_skill_ingest(db, skill=skill)
+        if job is not None:
             log.info(
-                "xtrace_skill_memory_ingested skill_key=%s job_id=%s status=%s "
-                "created_refs=%s updated_refs=%s mirrored=%s",
+                "xtrace_skill_memory_ingest_queued skill_key=%s ingest_id=%s status=%s",
                 skill.skill_key,
-                result.job_id,
-                result.status,
-                result.created_ref_count,
-                result.updated_ref_count,
-                result.mirrored_count,
+                job.id,
+                job.status,
             )
     except Exception:
         await db.rollback()

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -51,6 +51,7 @@ from app.services.tar_utils import (
     tar_from_content,
     validate_tar,
 )
+from app.services.xtrace_memory import ingest_xtrace_skill_memories, xtrace_memory_configured
 
 router = APIRouter(prefix="/api/skills", tags=["skills"])
 
@@ -984,6 +985,7 @@ async def _do_upload_skill(
     # holds across the upsert + revision bump and is released
     # only when this commit lands.
     await db.commit()
+    await _ingest_skill_to_xtrace(db, skill, data)
 
     return SkillUploadResponse(
         skill_key=skill.skill_key,
@@ -1319,6 +1321,7 @@ async def _do_install_skill(
     await index_skill_archive(db, skill, fetched.tar_bytes)
     # Single commit at the route boundary — see upload_skill.
     await db.commit()
+    await _ingest_skill_to_xtrace(db, skill, fetched.tar_bytes)
 
     return SkillInstallResponse(
         skill_key=skill_key,
@@ -1333,6 +1336,27 @@ async def _do_install_skill(
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+async def _ingest_skill_to_xtrace(db: AsyncSession, skill: Skill, data: bytes) -> None:
+    if not xtrace_memory_configured():
+        return
+    try:
+        result = await ingest_xtrace_skill_memories(db, skill=skill, data=data)
+        if result is not None:
+            log.info(
+                "xtrace_skill_memory_ingested skill_key=%s job_id=%s status=%s "
+                "created_refs=%s updated_refs=%s mirrored=%s",
+                skill.skill_key,
+                result.job_id,
+                result.status,
+                result.created_ref_count,
+                result.updated_ref_count,
+                result.mirrored_count,
+            )
+    except Exception:
+        await db.rollback()
+        log.exception("xtrace_skill_memory_ingest_failed skill_key=%s", skill.skill_key)
 
 
 async def _upsert_skill(

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -42,6 +42,7 @@ from app.schemas.skill import (
     SkillUploadResponse,
 )
 from app.services.file_store import get_file_store
+from app.services.skill_index import index_skill_archive
 from app.services.sync_events import bump_skills_revision, get_skills_revision
 from app.services.tar_utils import (
     TarValidationError,
@@ -977,6 +978,7 @@ async def _do_upload_skill(
         source="local",
         source_repo=None,
     )
+    await index_skill_archive(db, skill, data)
     # Single commit at the route boundary — _upsert_skill now
     # only flushes, so the advisory lock acquired at line 317
     # holds across the upsert + revision bump and is released
@@ -1314,6 +1316,7 @@ async def _do_install_skill(
         source="marketplace",
         source_repo=body.repo,
     )
+    await index_skill_archive(db, skill, fetched.tar_bytes)
     # Single commit at the route boundary — see upload_skill.
     await db.commit()
 

--- a/backend/app/routes/xtrace.py
+++ b/backend/app/routes/xtrace.py
@@ -73,9 +73,7 @@ async def list_backfills(
         )
         .order_by(desc(XTraceBackfillJob.created_at))
     )
-    rows = (
-        await db.execute(stmt.offset((page - 1) * page_size).limit(page_size))
-    ).scalars().all()
+    rows = (await db.execute(stmt.offset((page - 1) * page_size).limit(page_size))).scalars().all()
     total = len(
         (
             await db.execute(

--- a/backend/app/routes/xtrace.py
+++ b/backend/app/routes/xtrace.py
@@ -1,0 +1,163 @@
+import asyncio
+import hmac
+import logging
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import AuthContext, require_scope
+from app.core.config import settings
+from app.core.database import get_session
+from app.models.xtrace_backfill_job import XTraceBackfillJob
+from app.schemas.common import Paginated
+from app.schemas.xtrace import XTraceBackfillCreate, XTraceBackfillJobResponse
+from app.services.xtrace_backfill import create_xtrace_backfill_job, run_xtrace_backfill_job
+
+router = APIRouter(prefix="/api/xtrace", tags=["xtrace"])
+log = logging.getLogger(__name__)
+
+_BACKGROUND_TASKS: set[asyncio.Task[None]] = set()
+
+
+@router.post("/backfills", status_code=status.HTTP_202_ACCEPTED)
+async def create_backfill(
+    body: XTraceBackfillCreate,
+    auth: AuthContext = Depends(require_scope("memories:write")),
+    db: AsyncSession = Depends(get_session),
+    x_admin_key: str | None = Header(default=None, alias="X-Admin-Key"),
+) -> XTraceBackfillJobResponse:
+    scope_user_id = None if body.all_users else auth.user_id
+    if body.all_users:
+        _require_admin_key(x_admin_key)
+
+    try:
+        job = await create_xtrace_backfill_job(
+            db,
+            requested_by_user_id=auth.user_id,
+            scope_user_id=scope_user_id,
+            include_sessions=body.include_sessions,
+            include_skills=body.include_skills,
+            force=body.force,
+            dry_run=body.dry_run,
+            limit=body.limit,
+        )
+    except ValueError as exc:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(exc)) from exc
+    except RuntimeError as exc:
+        message = str(exc)
+        status_code = (
+            status.HTTP_503_SERVICE_UNAVAILABLE
+            if "not configured" in message
+            else status.HTTP_409_CONFLICT
+        )
+        raise HTTPException(status_code, message) from exc
+
+    _start_job(job.id)
+    return _job_response(job)
+
+
+@router.get("/backfills")
+async def list_backfills(
+    auth: AuthContext = Depends(require_scope("memories:read")),
+    db: AsyncSession = Depends(get_session),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(25, ge=1, le=100),
+) -> Paginated[XTraceBackfillJobResponse]:
+    stmt = (
+        select(XTraceBackfillJob)
+        .where(
+            (XTraceBackfillJob.scope_user_id == auth.user_id)
+            | (XTraceBackfillJob.requested_by_user_id == auth.user_id)
+        )
+        .order_by(desc(XTraceBackfillJob.created_at))
+    )
+    rows = (
+        await db.execute(stmt.offset((page - 1) * page_size).limit(page_size))
+    ).scalars().all()
+    total = len(
+        (
+            await db.execute(
+                select(XTraceBackfillJob.id).where(
+                    (XTraceBackfillJob.scope_user_id == auth.user_id)
+                    | (XTraceBackfillJob.requested_by_user_id == auth.user_id)
+                )
+            )
+        ).all()
+    )
+    return Paginated(
+        items=[_job_response(job) for job in rows],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get("/backfills/{job_id}")
+async def get_backfill(
+    job_id: UUID,
+    auth: AuthContext = Depends(require_scope("memories:read")),
+    db: AsyncSession = Depends(get_session),
+    x_admin_key: str | None = Header(default=None, alias="X-Admin-Key"),
+) -> XTraceBackfillJobResponse:
+    job = await db.get(XTraceBackfillJob, job_id)
+    if job is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "backfill job not found")
+    if job.scope_user_id == auth.user_id or job.requested_by_user_id == auth.user_id:
+        return _job_response(job)
+    _require_admin_key(x_admin_key)
+    return _job_response(job)
+
+
+def _start_job(job_id: UUID) -> None:
+    task = asyncio.create_task(run_xtrace_backfill_job(job_id), name=f"xtrace-backfill-{job_id}")
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
+
+
+def _require_admin_key(x_admin_key: str | None) -> None:
+    expected = settings.admin_api_key
+    if not expected:
+        raise HTTPException(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "admin endpoints are disabled (admin_api_key not configured)",
+        )
+    if not x_admin_key or not hmac.compare_digest(x_admin_key, expected):
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "invalid admin auth")
+
+
+def _job_response(job: XTraceBackfillJob) -> XTraceBackfillJobResponse:
+    return XTraceBackfillJobResponse(
+        id=str(job.id),
+        status=job.status,
+        requested_by_user_id=str(job.requested_by_user_id) if job.requested_by_user_id else None,
+        scope_user_id=str(job.scope_user_id) if job.scope_user_id else None,
+        include_sessions=job.include_sessions,
+        include_skills=job.include_skills,
+        force=job.force,
+        dry_run=job.dry_run,
+        limit=job.limit,
+        current_source_type=job.current_source_type,
+        current_source_key=job.current_source_key,
+        considered_count=job.considered_count,
+        sent_count=job.sent_count,
+        skipped_count=job.skipped_count,
+        failed_count=job.failed_count,
+        mirrored_count=job.mirrored_count,
+        sessions_considered=job.sessions_considered,
+        sessions_sent=job.sessions_sent,
+        sessions_skipped=job.sessions_skipped,
+        sessions_failed=job.sessions_failed,
+        sessions_mirrored=job.sessions_mirrored,
+        skills_considered=job.skills_considered,
+        skills_sent=job.skills_sent,
+        skills_skipped=job.skills_skipped,
+        skills_failed=job.skills_failed,
+        skills_mirrored=job.skills_mirrored,
+        error=job.error,
+        created_at=job.created_at,
+        updated_at=job.updated_at,
+        started_at=job.started_at,
+        finished_at=job.finished_at,
+    )

--- a/backend/app/routes/xtrace.py
+++ b/backend/app/routes/xtrace.py
@@ -102,6 +102,7 @@ async def get_backfill(
     job = await db.get(XTraceBackfillJob, job_id)
     if job is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "backfill job not found")
+    await db.refresh(job)
     if job.scope_user_id == auth.user_id or job.requested_by_user_id == auth.user_id:
         return _job_response(job)
     _require_admin_key(x_admin_key)

--- a/backend/app/schemas/memory.py
+++ b/backend/app/schemas/memory.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class MemoryCreate(BaseModel):
@@ -8,6 +8,28 @@ class MemoryCreate(BaseModel):
     category: str = "fact"
     source: str = "manual"
     tags: list[str] | None = None
+
+
+class XTraceMemoryTimelineItem(BaseModel):
+    operation: str
+    content: str
+    memory_id: str | None = None
+    status: str | None = None
+    at: str | None = None
+
+
+class XTraceMemoryDetails(BaseModel):
+    memory_id: str | None = None
+    type: str | None = None
+    status: str | None = None
+    operation: str | None = None
+    source_type: str | None = None
+    source_key: str | None = None
+    local_session_id: str | None = None
+    skill_key: str | None = None
+    supersedes: list[str] = Field(default_factory=list)
+    superseded_by: str | None = None
+    timeline: list[XTraceMemoryTimelineItem] = Field(default_factory=list)
 
 
 class MemoryResponse(BaseModel):
@@ -26,6 +48,7 @@ class MemoryResponse(BaseModel):
     source_session_id: str | None = None
     source_environment_id: str | None = None
     source_machine_name: str | None = None
+    xtrace: XTraceMemoryDetails | None = None
 
 
 class MemoryCreatedResponse(BaseModel):

--- a/backend/app/schemas/xtrace.py
+++ b/backend/app/schemas/xtrace.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class XTraceBackfillCreate(BaseModel):
+    include_sessions: bool = True
+    include_skills: bool = True
+    force: bool = False
+    dry_run: bool = False
+    limit: int | None = Field(default=None, ge=1, le=5000)
+    all_users: bool = False
+
+
+class XTraceBackfillJobResponse(BaseModel):
+    id: str
+    status: Literal["queued", "running", "succeeded", "failed"]
+    requested_by_user_id: str | None
+    scope_user_id: str | None
+    include_sessions: bool
+    include_skills: bool
+    force: bool
+    dry_run: bool
+    limit: int | None
+    current_source_type: str | None
+    current_source_key: str | None
+    considered_count: int
+    sent_count: int
+    skipped_count: int
+    failed_count: int
+    mirrored_count: int
+    sessions_considered: int
+    sessions_sent: int
+    sessions_skipped: int
+    sessions_failed: int
+    sessions_mirrored: int
+    skills_considered: int
+    skills_sent: int
+    skills_skipped: int
+    skills_failed: int
+    skills_mirrored: int
+    error: str | None
+    created_at: datetime | None
+    updated_at: datetime | None
+    started_at: datetime | None
+    finished_at: datetime | None

--- a/backend/app/services/memory_provider.py
+++ b/backend/app/services/memory_provider.py
@@ -8,9 +8,11 @@ import uuid
 from datetime import UTC, datetime
 from typing import Protocol
 
+import httpx
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.models.memory import Memory
 from app.services.embedding import Embedder, resolve_embedder
 from app.services.vault_crypto import decrypt_field
@@ -268,6 +270,41 @@ class XTraceProvider(BuiltinProvider):
     XTrace recall/search endpoints are added on top.
     """
 
+    async def search(
+        self, user_id: str, query: str, limit: int = 50, category: str | None = None
+    ) -> list[dict]:
+        try:
+            rows = await self._search_remote(user_id, query, limit=limit)
+        except Exception as exc:
+            log.warning("xtrace remote memory search failed, falling back to builtin: %s", exc)
+            return await super().search(user_id, query, limit=limit, category=category)
+
+        if category:
+            rows = [row for row in rows if row.get("category") == category]
+        return rows[:limit]
+
+    async def _search_remote(self, user_id: str, query: str, *, limit: int) -> list[dict]:
+        url = f"{settings.xtrace_memory_base_url.rstrip('/')}/v1/memories/search"
+        headers = {
+            "Authorization": f"Bearer {settings.xtrace_api_key}",
+            "X-Org-Id": settings.xtrace_org_id,
+            "Accept": "application/json",
+        }
+        body = {
+            "query": query,
+            "user_id": user_id,
+            "app_id": settings.xtrace_memory_app_id,
+            "limit": limit,
+        }
+        async with httpx.AsyncClient(timeout=settings.xtrace_memory_timeout_seconds) as client:
+            response = await client.post(url, headers=headers, json=body)
+            response.raise_for_status()
+            payload = response.json()
+        data = payload.get("data") if isinstance(payload, dict) else None
+        if not isinstance(data, list):
+            return []
+        return [_xtrace_remote_memory_to_dict(item) for item in data if isinstance(item, dict)]
+
 
 class Mem0Provider:
     """Memory provider backed by Mem0 API."""
@@ -380,6 +417,60 @@ def memory_to_dict(m: Memory) -> dict:
         "source_session_id": str(m.source_session_id) if m.source_session_id else None,
         "xtrace": _xtrace_details(m.metadata_, m.content),
     }
+
+
+def _xtrace_remote_memory_to_dict(raw: dict) -> dict:
+    text = str(raw.get("text") or "")
+    memory_type = str(raw.get("type") or "fact")
+    metadata = raw.get("metadata") if isinstance(raw.get("metadata"), dict) else {}
+    details = raw.get("details") if isinstance(raw.get("details"), dict) else {}
+    categories = raw.get("categories")
+    category = (
+        str(categories[0])
+        if isinstance(categories, list) and categories and categories[0]
+        else _category_for_xtrace_type(memory_type)
+    )
+    created_at = _string_or_none(raw.get("created_at")) or datetime.now(UTC).isoformat()
+    status = _string_or_none(details.get("status")) or "active"
+    return {
+        "id": str(raw.get("id") or ""),
+        "content": text,
+        "category": category,
+        "source": "xtrace",
+        "tags": ["xtrace", f"xtrace:{memory_type}"],
+        "access_count": 0,
+        "created_at": created_at,
+        "source_session_id": _string_or_none(metadata.get("source_session_id")),
+        "xtrace": {
+            "memory_id": str(raw.get("id") or ""),
+            "type": memory_type,
+            "status": status,
+            "operation": _string_or_none(metadata.get("xtrace_operation")),
+            "source_type": _string_or_none(metadata.get("source_type")),
+            "source_key": _string_or_none(metadata.get("source_key")),
+            "local_session_id": _string_or_none(metadata.get("local_session_id")),
+            "skill_key": _string_or_none(metadata.get("skill_key")),
+            "supersedes": _string_list(details.get("supersedes")),
+            "superseded_by": _string_or_none(details.get("superseded_by")),
+            "timeline": [
+                {
+                    "operation": _string_or_none(metadata.get("xtrace_operation")) or "add",
+                    "content": text,
+                    "memory_id": str(raw.get("id") or ""),
+                    "status": status,
+                    "at": created_at,
+                }
+            ],
+        },
+    }
+
+
+def _category_for_xtrace_type(memory_type: str) -> str:
+    if memory_type == "artifact":
+        return "artifact"
+    if memory_type == "episode":
+        return "context"
+    return "fact"
 
 
 def _row_to_dict(r) -> dict:

--- a/backend/app/services/memory_provider.py
+++ b/backend/app/services/memory_provider.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.memory import Memory
 from app.services.embedding import Embedder, resolve_embedder
 from app.services.vault_crypto import decrypt_field
+from app.services.xtrace_memory import xtrace_memory_configured
 
 log = logging.getLogger(__name__)
 
@@ -256,6 +257,16 @@ class BuiltinProvider:
         if memory:
             await self.db.delete(memory)
             await self.db.commit()
+
+
+class XTraceProvider(BuiltinProvider):
+    """Provider facade for XTrace-backed memory.
+
+    XTrace owns extraction, belief revision, and lineage on the write side.
+    Clawdi mirrors returned refs into the local memory table, so dashboard
+    browse/search/delete can keep using the builtin provider contract while
+    XTrace recall/search endpoints are added on top.
+    """
 
 
 class Mem0Provider:
@@ -640,6 +651,12 @@ async def get_memory_provider(user_id: str, db: AsyncSession) -> MemoryProvider:
     result = await db.execute(select(UserSetting).where(UserSetting.user_id == uuid.UUID(user_id)))
     setting = result.scalar_one_or_none()
     s = (setting.settings if setting else {}) or {}
+
+    if s.get("memory_provider") == "xtrace":
+        if xtrace_memory_configured():
+            return XTraceProvider(db, embedder=resolve_embedder())
+        log.warning("memory_provider=xtrace but XTrace is not configured; falling back to builtin.")
+        return BuiltinProvider(db, embedder=resolve_embedder())
 
     if s.get("memory_provider") == "mem0":
         raw_key = s.get("mem0_api_key", "")

--- a/backend/app/services/memory_provider.py
+++ b/backend/app/services/memory_provider.py
@@ -367,6 +367,7 @@ def memory_to_dict(m: Memory) -> dict:
         # source machine in one bulk query. None when the memory was
         # added manually.
         "source_session_id": str(m.source_session_id) if m.source_session_id else None,
+        "xtrace": _xtrace_details(m.metadata_, m.content),
     }
 
 
@@ -374,6 +375,7 @@ def _row_to_dict(r) -> dict:
     """Serialize a raw SQL row (SQLAlchemy RowMapping) to the API shape."""
     created_at = r["created_at"]
     sid = r.get("source_session_id") if hasattr(r, "get") else None
+    metadata = r.get("metadata") if hasattr(r, "get") else None
     return {
         "id": str(r["id"]),
         "content": r["content"],
@@ -383,7 +385,86 @@ def _row_to_dict(r) -> dict:
         "access_count": r["access_count"],
         "created_at": created_at.isoformat() if hasattr(created_at, "isoformat") else created_at,
         "source_session_id": str(sid) if sid else None,
+        "xtrace": _xtrace_details(metadata, r["content"]),
     }
+
+
+def _xtrace_details(metadata: object, content: str) -> dict | None:
+    if not isinstance(metadata, dict):
+        return None
+    memory_id = _string_or_none(metadata.get("xtrace_memory_id"))
+    memory_type = _string_or_none(metadata.get("xtrace_type"))
+    if memory_id is None and memory_type is None:
+        return None
+
+    operation = _string_or_none(metadata.get("xtrace_operation"))
+    status = _string_or_none(metadata.get("xtrace_status")) or "active"
+    timeline = metadata.get("xtrace_timeline")
+    return {
+        "memory_id": memory_id,
+        "type": memory_type,
+        "status": status,
+        "operation": operation,
+        "source_type": _string_or_none(metadata.get("source_type")),
+        "source_key": _string_or_none(metadata.get("source_key")),
+        "local_session_id": _string_or_none(metadata.get("local_session_id")),
+        "skill_key": _string_or_none(metadata.get("skill_key")),
+        "supersedes": _string_list(metadata.get("xtrace_supersedes")),
+        "superseded_by": _string_or_none(metadata.get("xtrace_superseded_by")),
+        "timeline": _timeline_items(timeline, content, memory_id, status, operation),
+    }
+
+
+def _timeline_items(
+    raw: object,
+    content: str,
+    memory_id: str | None,
+    status: str,
+    operation: str | None,
+) -> list[dict]:
+    if isinstance(raw, list):
+        out: list[dict] = []
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            item_content = _string_or_none(item.get("content"))
+            if item_content is None:
+                continue
+            out.append(
+                {
+                    "operation": _string_or_none(item.get("operation")) or "add",
+                    "content": item_content,
+                    "memory_id": _string_or_none(item.get("memory_id")),
+                    "status": _string_or_none(item.get("status")),
+                    "at": _string_or_none(item.get("at")),
+                }
+            )
+        if out:
+            return out
+
+    return [
+        {
+            "operation": operation or "add",
+            "content": content,
+            "memory_id": memory_id,
+            "status": status,
+            "at": None,
+        }
+    ]
+
+
+def _string_or_none(value: object) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _string_list(value: object) -> list[str]:
+    if isinstance(value, str) and value:
+        return [value]
+    if isinstance(value, list):
+        return [str(v) for v in value if isinstance(v, str) and v]
+    return []
 
 
 def _row_to_search_dict(r, score_key: str) -> dict:

--- a/backend/app/services/skill_index.py
+++ b/backend/app/services/skill_index.py
@@ -1,0 +1,127 @@
+"""Index searchable text chunks from skill archives."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.skill import Skill
+from app.models.skill_chunk import SkillChunk
+
+_TEXT_EXTENSIONS = {
+    ".cfg",
+    ".conf",
+    ".css",
+    ".csv",
+    ".html",
+    ".ini",
+    ".js",
+    ".json",
+    ".jsx",
+    ".md",
+    ".mdx",
+    ".py",
+    ".rst",
+    ".sh",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".txt",
+    ".xml",
+    ".yaml",
+    ".yml",
+}
+_TEXT_FILE_NAMES = {"Dockerfile", "Makefile", "SKILL.md"}
+_MAX_FILE_BYTES = 512 * 1024
+_MAX_CHUNK_CHARS = 6000
+_CHUNK_OVERLAP_CHARS = 500
+
+
+@dataclass(frozen=True)
+class SkillTextFile:
+    path: str
+    content: str
+
+
+def extract_skill_text_files(data: bytes, skill_key: str) -> list[SkillTextFile]:
+    """Extract UTF-8 text files from a validated skill tarball."""
+    files: list[SkillTextFile] = []
+    strip_count = len(skill_key.split("/"))
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tf:
+        for member in tf.getmembers():
+            if not member.isfile() or member.size > _MAX_FILE_BYTES:
+                continue
+            relative_path = _relative_skill_path(member.name, strip_count)
+            if not relative_path or not _is_indexable_text_path(relative_path):
+                continue
+            extracted = tf.extractfile(member)
+            if extracted is None:
+                continue
+            try:
+                content = extracted.read().decode("utf-8")
+            except UnicodeDecodeError:
+                continue
+            content = content.strip()
+            if content:
+                files.append(SkillTextFile(path=relative_path, content=content))
+    files.sort(key=lambda item: item.path)
+    return files
+
+
+async def index_skill_archive(db: AsyncSession, skill: Skill, data: bytes) -> int:
+    """Replace indexed chunks for a skill archive. Caller commits."""
+    await db.execute(delete(SkillChunk).where(SkillChunk.skill_id == skill.id))
+
+    inserted = 0
+    for text_file in extract_skill_text_files(data, skill.skill_key):
+        for chunk_index, chunk in enumerate(_chunk_text(text_file.content)):
+            db.add(
+                SkillChunk(
+                    skill_id=skill.id,
+                    user_id=skill.user_id,
+                    project_id=skill.project_id,
+                    skill_key=skill.skill_key,
+                    content_hash=skill.content_hash,
+                    file_path=text_file.path,
+                    chunk_index=chunk_index,
+                    content=chunk,
+                    embedding=None,
+                )
+            )
+            inserted += 1
+    await db.flush()
+    return inserted
+
+
+def _relative_skill_path(member_name: str, strip_count: int) -> str:
+    parts = PurePosixPath(member_name).parts
+    if len(parts) <= strip_count:
+        return ""
+    return "/".join(parts[strip_count:])
+
+
+def _is_indexable_text_path(path: str) -> bool:
+    posix = PurePosixPath(path)
+    if posix.name in _TEXT_FILE_NAMES:
+        return True
+    return posix.suffix.lower() in _TEXT_EXTENSIONS
+
+
+def _chunk_text(content: str) -> list[str]:
+    if len(content) <= _MAX_CHUNK_CHARS:
+        return [content]
+
+    chunks: list[str] = []
+    start = 0
+    step = _MAX_CHUNK_CHARS - _CHUNK_OVERLAP_CHARS
+    while start < len(content):
+        chunk = content[start : start + _MAX_CHUNK_CHARS].strip()
+        if chunk:
+            chunks.append(chunk)
+        start += step
+    return chunks

--- a/backend/app/services/xtrace_backfill.py
+++ b/backend/app/services/xtrace_backfill.py
@@ -12,6 +12,7 @@ from uuid import UUID
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from app.core.config import settings
 from app.core.database import async_session_factory
 from app.models.session import Session
 from app.models.skill import Skill
@@ -197,7 +198,12 @@ async def _backfill_sessions(db: AsyncSession, job: XTraceBackfillJob) -> None:
             if not isinstance(parsed, list):
                 raise ValueError("session content is not a JSON message list")
             messages: list[dict[str, Any]] = [m for m in parsed if isinstance(m, dict)]
-            result = await ingest_xtrace_session_memories(db, session=session, messages=messages)
+            result = await ingest_xtrace_session_memories(
+                db,
+                session=session,
+                messages=messages,
+                max_messages=settings.xtrace_memory_backfill_max_messages,
+            )
         except Exception as exc:
             await db.rollback()
             await db.refresh(job)

--- a/backend/app/services/xtrace_backfill.py
+++ b/backend/app/services/xtrace_backfill.py
@@ -1,0 +1,271 @@
+"""Persistent XTrace backfill jobs for stored sessions and skills."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.database import async_session_factory
+from app.models.session import Session
+from app.models.skill import Skill
+from app.models.xtrace_backfill_job import XTraceBackfillJob
+from app.models.xtrace_ingest import XTraceMemoryIngest
+from app.services.file_store import get_file_store
+from app.services.xtrace_memory import (
+    ingest_xtrace_session_memories,
+    ingest_xtrace_skill_memories,
+    xtrace_memory_configured,
+    xtrace_session_source_key,
+    xtrace_skill_source_key,
+)
+
+log = logging.getLogger(__name__)
+
+_ACTIVE_STATUSES = {"queued", "running"}
+_COMMIT_EVERY = 10
+
+
+async def create_xtrace_backfill_job(
+    db: AsyncSession,
+    *,
+    requested_by_user_id: UUID | None,
+    scope_user_id: UUID | None,
+    include_sessions: bool,
+    include_skills: bool,
+    force: bool,
+    dry_run: bool,
+    limit: int | None,
+) -> XTraceBackfillJob:
+    if not xtrace_memory_configured():
+        raise RuntimeError("XTrace memory is not configured")
+
+    if not include_sessions and not include_skills:
+        raise ValueError("at least one source type must be selected")
+
+    scope_filter = (
+        XTraceBackfillJob.scope_user_id.is_(None)
+        if scope_user_id is None
+        else or_(
+            XTraceBackfillJob.scope_user_id.is_(None),
+            XTraceBackfillJob.scope_user_id == scope_user_id,
+        )
+    )
+    active = (
+        await db.execute(
+            select(XTraceBackfillJob.id)
+            .where(
+                scope_filter,
+                XTraceBackfillJob.status.in_(_ACTIVE_STATUSES),
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if active is not None:
+        raise RuntimeError(f"backfill job already active: {active}")
+
+    job = XTraceBackfillJob(
+        requested_by_user_id=requested_by_user_id,
+        scope_user_id=scope_user_id,
+        include_sessions=include_sessions,
+        include_skills=include_skills,
+        force=force,
+        dry_run=dry_run,
+        limit=limit,
+        status="queued",
+    )
+    db.add(job)
+    await db.commit()
+    await db.refresh(job)
+    return job
+
+
+async def run_xtrace_backfill_job(
+    job_id: UUID,
+    *,
+    session_factory: async_sessionmaker[AsyncSession] = async_session_factory,
+) -> None:
+    async with session_factory() as db:
+        job = await db.get(XTraceBackfillJob, job_id)
+        if job is None:
+            log.error("xtrace_backfill_job_missing job_id=%s", job_id)
+            return
+        if job.status not in _ACTIVE_STATUSES:
+            log.info("xtrace_backfill_job_not_active job_id=%s status=%s", job_id, job.status)
+            return
+
+        job.status = "running"
+        job.started_at = datetime.now(UTC)
+        await db.commit()
+
+        try:
+            if job.include_sessions:
+                await _backfill_sessions(db, job)
+            if job.include_skills:
+                await _backfill_skills(db, job)
+            job.status = "succeeded" if job.failed_count == 0 else "failed"
+            job.finished_at = datetime.now(UTC)
+            job.current_source_type = None
+            job.current_source_key = None
+            await db.commit()
+            log.info(
+                "xtrace_backfill_job_finished job_id=%s status=%s considered=%s "
+                "sent=%s skipped=%s failed=%s mirrored=%s",
+                job.id,
+                job.status,
+                job.considered_count,
+                job.sent_count,
+                job.skipped_count,
+                job.failed_count,
+                job.mirrored_count,
+            )
+        except Exception as exc:
+            await db.rollback()
+            job = await db.get(XTraceBackfillJob, job_id)
+            if job is not None:
+                job.status = "failed"
+                job.error = str(exc)[:4000]
+                job.finished_at = datetime.now(UTC)
+                await db.commit()
+            log.exception("xtrace_backfill_job_failed job_id=%s", job_id)
+
+
+async def _backfill_sessions(db: AsyncSession, job: XTraceBackfillJob) -> None:
+    stmt = select(Session).where(Session.file_key.is_not(None))
+    if job.scope_user_id is not None:
+        stmt = stmt.where(Session.user_id == job.scope_user_id)
+    stmt = stmt.order_by(Session.last_activity_at.desc())
+    if job.limit is not None:
+        stmt = stmt.limit(job.limit)
+
+    sessions = (await db.execute(stmt)).scalars().all()
+    file_store = get_file_store()
+    for session in sessions:
+        source_key = xtrace_session_source_key(session)
+        job.current_source_type = "session"
+        job.current_source_key = source_key
+        job.considered_count += 1
+        job.sessions_considered += 1
+        if not job.force and await _already_ingested(db, "session", source_key):
+            _increment_skipped(job, "session")
+            await _commit_periodically(db, job)
+            continue
+        if job.dry_run:
+            _increment_skipped(job, "session")
+            await _commit_periodically(db, job)
+            continue
+
+        try:
+            data = await file_store.get(session.file_key)
+            parsed = json.loads(data)
+            if not isinstance(parsed, list):
+                raise ValueError("session content is not a JSON message list")
+            messages: list[dict[str, Any]] = [m for m in parsed if isinstance(m, dict)]
+            result = await ingest_xtrace_session_memories(db, session=session, messages=messages)
+        except Exception:
+            await db.rollback()
+            await db.refresh(job)
+            _increment_failed(job, "session")
+            await db.commit()
+            log.exception("xtrace_backfill_session_failed source_key=%s", source_key)
+            continue
+        if result is None:
+            _increment_skipped(job, "session")
+        else:
+            _increment_sent(job, "session", result.mirrored_count)
+        await _commit_periodically(db, job)
+    await db.commit()
+
+
+async def _backfill_skills(db: AsyncSession, job: XTraceBackfillJob) -> None:
+    stmt = select(Skill).where(Skill.is_active.is_(True), Skill.file_key.is_not(None))
+    if job.scope_user_id is not None:
+        stmt = stmt.where(Skill.user_id == job.scope_user_id)
+    stmt = stmt.order_by(Skill.updated_at.desc())
+    if job.limit is not None:
+        stmt = stmt.limit(job.limit)
+
+    skills = (await db.execute(stmt)).scalars().all()
+    file_store = get_file_store()
+    for skill in skills:
+        source_key = xtrace_skill_source_key(skill)
+        job.current_source_type = "skill"
+        job.current_source_key = source_key
+        job.considered_count += 1
+        job.skills_considered += 1
+        if not job.force and await _already_ingested(db, "skill", source_key):
+            _increment_skipped(job, "skill")
+            await _commit_periodically(db, job)
+            continue
+        if job.dry_run:
+            _increment_skipped(job, "skill")
+            await _commit_periodically(db, job)
+            continue
+
+        try:
+            data = await file_store.get(skill.file_key)
+            result = await ingest_xtrace_skill_memories(db, skill=skill, data=data)
+        except Exception:
+            await db.rollback()
+            await db.refresh(job)
+            _increment_failed(job, "skill")
+            await db.commit()
+            log.exception("xtrace_backfill_skill_failed source_key=%s", source_key)
+            continue
+        if result is None:
+            _increment_skipped(job, "skill")
+        else:
+            _increment_sent(job, "skill", result.mirrored_count)
+        await _commit_periodically(db, job)
+    await db.commit()
+
+
+async def _already_ingested(db: AsyncSession, source_type: str, source_key: str) -> bool:
+    row = (
+        await db.execute(
+            select(XTraceMemoryIngest.id)
+            .where(
+                XTraceMemoryIngest.source_type == source_type,
+                XTraceMemoryIngest.source_key == source_key,
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    return row is not None
+
+
+def _increment_skipped(job: XTraceBackfillJob, source_type: str) -> None:
+    job.skipped_count += 1
+    if source_type == "session":
+        job.sessions_skipped += 1
+    else:
+        job.skills_skipped += 1
+
+
+def _increment_failed(job: XTraceBackfillJob, source_type: str) -> None:
+    job.failed_count += 1
+    if source_type == "session":
+        job.sessions_failed += 1
+    else:
+        job.skills_failed += 1
+
+
+def _increment_sent(job: XTraceBackfillJob, source_type: str, mirrored_count: int) -> None:
+    job.sent_count += 1
+    job.mirrored_count += mirrored_count
+    if source_type == "session":
+        job.sessions_sent += 1
+        job.sessions_mirrored += mirrored_count
+    else:
+        job.skills_sent += 1
+        job.skills_mirrored += mirrored_count
+
+
+async def _commit_periodically(db: AsyncSession, job: XTraceBackfillJob) -> None:
+    if job.considered_count % _COMMIT_EVERY == 0:
+        await db.commit()

--- a/backend/app/services/xtrace_backfill.py
+++ b/backend/app/services/xtrace_backfill.py
@@ -198,11 +198,12 @@ async def _backfill_sessions(db: AsyncSession, job: XTraceBackfillJob) -> None:
                 raise ValueError("session content is not a JSON message list")
             messages: list[dict[str, Any]] = [m for m in parsed if isinstance(m, dict)]
             result = await ingest_xtrace_session_memories(db, session=session, messages=messages)
-        except Exception:
+        except Exception as exc:
             await db.rollback()
             await db.refresh(job)
             job.current_source_type = "session"
             job.current_source_key = source_key
+            job.error = _source_error("session", source_key, exc)
             job.considered_count += 1
             job.sessions_considered += 1
             _increment_failed(job, "session")
@@ -245,11 +246,12 @@ async def _backfill_skills(db: AsyncSession, job: XTraceBackfillJob) -> None:
         try:
             data = await file_store.get(skill.file_key)
             result = await ingest_xtrace_skill_memories(db, skill=skill, data=data)
-        except Exception:
+        except Exception as exc:
             await db.rollback()
             await db.refresh(job)
             job.current_source_type = "skill"
             job.current_source_key = source_key
+            job.error = _source_error("skill", source_key, exc)
             job.considered_count += 1
             job.skills_considered += 1
             _increment_failed(job, "skill")
@@ -315,6 +317,10 @@ def _skill_source(skill: Skill) -> SimpleNamespace:
         agent_types=skill.agent_types,
         file_key=skill.file_key,
     )
+
+
+def _source_error(source_type: str, source_key: str, exc: Exception) -> str:
+    return f"{source_type} {source_key} failed: {exc}"[:4000]
 
 
 def _increment_skipped(job: XTraceBackfillJob, source_type: str) -> None:

--- a/backend/app/services/xtrace_backfill.py
+++ b/backend/app/services/xtrace_backfill.py
@@ -19,6 +19,10 @@ from app.models.skill import Skill
 from app.models.xtrace_backfill_job import XTraceBackfillJob
 from app.models.xtrace_ingest import XTraceMemoryIngest
 from app.services.file_store import get_file_store
+from app.services.xtrace_ingest_policy import (
+    decide_xtrace_session_ingest,
+    xtrace_skip_response,
+)
 from app.services.xtrace_memory import (
     ingest_xtrace_session_memories,
     ingest_xtrace_skill_memories,
@@ -187,6 +191,15 @@ async def _backfill_sessions(db: AsyncSession, job: XTraceBackfillJob) -> None:
             _increment_skipped(job, "session")
             await _commit_periodically(db, job)
             continue
+        decision = decide_xtrace_session_ingest(
+            session,
+            max_messages=settings.xtrace_memory_backfill_max_messages,
+        )
+        if not job.force and not decision.should_ingest:
+            await _record_skipped_session_ingest(db, session, source_key, decision)
+            _increment_skipped(job, "session")
+            await _commit_periodically(db, job)
+            continue
         if job.dry_run:
             _increment_skipped(job, "session")
             await _commit_periodically(db, job)
@@ -284,6 +297,43 @@ async def _already_ingested(db: AsyncSession, source_type: str, source_key: str)
         )
     ).scalar_one_or_none()
     return row is not None
+
+
+async def _record_skipped_session_ingest(
+    db: AsyncSession,
+    session: SimpleNamespace,
+    source_key: str,
+    decision,
+) -> None:
+    existing = (
+        await db.execute(
+            select(XTraceMemoryIngest)
+            .where(
+                XTraceMemoryIngest.source_type == "session",
+                XTraceMemoryIngest.source_key == source_key,
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return
+
+    db.add(
+        XTraceMemoryIngest(
+            user_id=session.user_id,
+            source_type="session",
+            session_id=session.id,
+            local_session_id=session.local_session_id,
+            source_key=source_key,
+            status="skipped",
+            attempt_count=0,
+            created_ref_count=0,
+            updated_ref_count=0,
+            mirrored_count=0,
+            response=xtrace_skip_response(decision),
+        )
+    )
+    await db.flush()
 
 
 def _session_source(session: Session) -> SimpleNamespace:

--- a/backend/app/services/xtrace_backfill.py
+++ b/backend/app/services/xtrace_backfill.py
@@ -19,6 +19,7 @@ from app.models.skill import Skill
 from app.models.xtrace_backfill_job import XTraceBackfillJob
 from app.models.xtrace_ingest import XTraceMemoryIngest
 from app.services.file_store import get_file_store
+from app.services.xtrace_ingest_budget import decide_xtrace_user_budget
 from app.services.xtrace_ingest_policy import (
     decide_xtrace_session_ingest,
     xtrace_skip_response,
@@ -200,6 +201,23 @@ async def _backfill_sessions(db: AsyncSession, job: XTraceBackfillJob) -> None:
             _increment_skipped(job, "session")
             await _commit_periodically(db, job)
             continue
+        budget = await decide_xtrace_user_budget(
+            db,
+            user_id=session.user_id,
+            requested_messages=decision.estimated_xtrace_messages,
+        )
+        if budget is not None and not budget.allowed:
+            await _record_skipped_session_ingest(
+                db,
+                session,
+                source_key,
+                decision,
+                reason="budget_exceeded",
+                budget=budget.as_response(),
+            )
+            _increment_skipped(job, "session")
+            await _commit_periodically(db, job)
+            continue
         if job.dry_run:
             _increment_skipped(job, "session")
             await _commit_periodically(db, job)
@@ -304,6 +322,9 @@ async def _record_skipped_session_ingest(
     session: SimpleNamespace,
     source_key: str,
     decision,
+    *,
+    reason: str | None = None,
+    budget: dict[str, Any] | None = None,
 ) -> None:
     existing = (
         await db.execute(
@@ -330,7 +351,7 @@ async def _record_skipped_session_ingest(
             created_ref_count=0,
             updated_ref_count=0,
             mirrored_count=0,
-            response=xtrace_skip_response(decision),
+            response=xtrace_skip_response(decision, reason=reason, budget=budget),
         )
     )
     await db.flush()

--- a/backend/app/services/xtrace_backfill.py
+++ b/backend/app/services/xtrace_backfill.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from typing import Any
 from uuid import UUID
 
@@ -173,7 +174,7 @@ async def _backfill_sessions(db: AsyncSession, job: XTraceBackfillJob) -> None:
     if job.limit is not None:
         stmt = stmt.limit(job.limit)
 
-    sessions = (await db.execute(stmt)).scalars().all()
+    sessions = [_session_source(session) for session in (await db.execute(stmt)).scalars().all()]
     file_store = get_file_store()
     for session in sessions:
         source_key = xtrace_session_source_key(session)
@@ -200,6 +201,10 @@ async def _backfill_sessions(db: AsyncSession, job: XTraceBackfillJob) -> None:
         except Exception:
             await db.rollback()
             await db.refresh(job)
+            job.current_source_type = "session"
+            job.current_source_key = source_key
+            job.considered_count += 1
+            job.sessions_considered += 1
             _increment_failed(job, "session")
             await db.commit()
             log.exception("xtrace_backfill_session_failed source_key=%s", source_key)
@@ -220,7 +225,7 @@ async def _backfill_skills(db: AsyncSession, job: XTraceBackfillJob) -> None:
     if job.limit is not None:
         stmt = stmt.limit(job.limit)
 
-    skills = (await db.execute(stmt)).scalars().all()
+    skills = [_skill_source(skill) for skill in (await db.execute(stmt)).scalars().all()]
     file_store = get_file_store()
     for skill in skills:
         source_key = xtrace_skill_source_key(skill)
@@ -243,6 +248,10 @@ async def _backfill_skills(db: AsyncSession, job: XTraceBackfillJob) -> None:
         except Exception:
             await db.rollback()
             await db.refresh(job)
+            job.current_source_type = "skill"
+            job.current_source_key = source_key
+            job.considered_count += 1
+            job.skills_considered += 1
             _increment_failed(job, "skill")
             await db.commit()
             log.exception("xtrace_backfill_skill_failed source_key=%s", source_key)
@@ -267,6 +276,45 @@ async def _already_ingested(db: AsyncSession, source_type: str, source_key: str)
         )
     ).scalar_one_or_none()
     return row is not None
+
+
+def _session_source(session: Session) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=session.id,
+        user_id=session.user_id,
+        environment_id=session.environment_id,
+        local_session_id=session.local_session_id,
+        project_path=session.project_path,
+        content_hash=session.content_hash,
+        summary=session.summary,
+        message_count=session.message_count,
+        started_at=session.started_at,
+        ended_at=session.ended_at,
+        last_activity_at=session.last_activity_at,
+        model=session.model,
+        models_used=session.models_used,
+        tags=session.tags,
+        related_refs=session.related_refs,
+        file_key=session.file_key,
+    )
+
+
+def _skill_source(skill: Skill) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=skill.id,
+        user_id=skill.user_id,
+        project_id=skill.project_id,
+        skill_key=skill.skill_key,
+        name=skill.name,
+        description=skill.description,
+        content_hash=skill.content_hash,
+        version=skill.version,
+        source=skill.source,
+        source_repo=skill.source_repo,
+        file_count=skill.file_count,
+        agent_types=skill.agent_types,
+        file_key=skill.file_key,
+    )
 
 
 def _increment_skipped(job: XTraceBackfillJob, source_type: str) -> None:

--- a/backend/app/services/xtrace_backfill.py
+++ b/backend/app/services/xtrace_backfill.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID
 
@@ -29,6 +29,7 @@ log = logging.getLogger(__name__)
 
 _ACTIVE_STATUSES = {"queued", "running"}
 _COMMIT_EVERY = 10
+_STALE_ACTIVE_AFTER = timedelta(minutes=10)
 
 
 async def create_xtrace_backfill_job(
@@ -56,6 +57,7 @@ async def create_xtrace_backfill_job(
             XTraceBackfillJob.scope_user_id == scope_user_id,
         )
     )
+    await _fail_stale_active_jobs(db, scope_filter=scope_filter)
     active = (
         await db.execute(
             select(XTraceBackfillJob.id)
@@ -83,6 +85,34 @@ async def create_xtrace_backfill_job(
     await db.commit()
     await db.refresh(job)
     return job
+
+
+async def _fail_stale_active_jobs(db: AsyncSession, *, scope_filter: Any) -> None:
+    stale_before = datetime.now(UTC) - _STALE_ACTIVE_AFTER
+    rows = (
+        (
+            await db.execute(
+                select(XTraceBackfillJob).where(
+                    scope_filter,
+                    XTraceBackfillJob.status.in_(_ACTIVE_STATUSES),
+                    XTraceBackfillJob.updated_at < stale_before,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not rows:
+        return
+
+    now = datetime.now(UTC)
+    for job in rows:
+        job.status = "failed"
+        job.error = "Backfill worker was interrupted before completion; start a new job to resume."
+        job.finished_at = now
+        job.current_source_type = None
+        job.current_source_key = None
+    await db.commit()
 
 
 async def run_xtrace_backfill_job(

--- a/backend/app/services/xtrace_ingest_budget.py
+++ b/backend/app/services/xtrace_ingest_budget.py
@@ -1,0 +1,116 @@
+"""Budget accounting for XTrace memory ingestion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, time
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.xtrace_ingest import XTraceMemoryIngest
+
+
+@dataclass(frozen=True)
+class XTraceBudgetDecision:
+    allowed: bool
+    limit: int
+    used: int
+    requested: int
+    remaining: int
+
+    def as_response(self) -> dict[str, int | bool]:
+        return {
+            "allowed": self.allowed,
+            "limit": self.limit,
+            "used": self.used,
+            "requested": self.requested,
+            "remaining": self.remaining,
+        }
+
+
+async def decide_xtrace_user_budget(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    requested_messages: int,
+) -> XTraceBudgetDecision | None:
+    limit = max(0, settings.xtrace_memory_daily_message_budget_per_user)
+    if limit == 0:
+        return None
+
+    used = await xtrace_user_daily_message_usage(db, user_id=user_id)
+    requested = max(0, requested_messages)
+    remaining = max(0, limit - used)
+    return XTraceBudgetDecision(
+        allowed=used + requested <= limit,
+        limit=limit,
+        used=used,
+        requested=requested,
+        remaining=remaining,
+    )
+
+
+async def xtrace_user_daily_message_usage(db: AsyncSession, *, user_id: UUID) -> int:
+    start = datetime.combine(datetime.now(UTC).date(), time.min, tzinfo=UTC)
+    rows = (
+        (
+            await db.execute(
+                select(XTraceMemoryIngest.response).where(
+                    XTraceMemoryIngest.user_id == user_id,
+                    XTraceMemoryIngest.created_at >= start,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return sum(_accounted_messages(response) for response in rows)
+
+
+def xtrace_cost_metadata(
+    *,
+    estimated_source_messages: int,
+    estimated_xtrace_messages: int,
+    payload_message_count: int | None = None,
+    accounted_xtrace_messages: int | None = None,
+    message_hashes: list[str] | None = None,
+) -> dict[str, Any]:
+    cost: dict[str, Any] = {
+        "estimated_source_messages": estimated_source_messages,
+        "estimated_xtrace_messages": estimated_xtrace_messages,
+        "accounted_xtrace_messages": max(
+            0,
+            accounted_xtrace_messages
+            if accounted_xtrace_messages is not None
+            else estimated_xtrace_messages,
+        ),
+    }
+    if payload_message_count is not None:
+        cost["payload_message_count"] = max(0, payload_message_count)
+
+    metadata: dict[str, Any] = {"cost": cost}
+    if message_hashes is not None:
+        metadata["message_hashes"] = message_hashes
+    return metadata
+
+
+def _accounted_messages(response: Any) -> int:
+    if not isinstance(response, dict):
+        return 0
+    clawdi = response.get("_clawdi")
+    if not isinstance(clawdi, dict):
+        return 0
+    cost = clawdi.get("cost")
+    if not isinstance(cost, dict):
+        return 0
+    for key in ("accounted_xtrace_messages", "payload_message_count", "estimated_xtrace_messages"):
+        value = cost.get(key)
+        if isinstance(value, int):
+            return max(0, value)
+        if isinstance(value, float):
+            return max(0, int(value))
+    return 0

--- a/backend/app/services/xtrace_ingest_policy.py
+++ b/backend/app/services/xtrace_ingest_policy.py
@@ -63,18 +63,38 @@ def decide_xtrace_session_ingest(
     )
 
 
-def xtrace_skip_response(decision: XTraceSessionIngestDecision) -> dict[str, Any]:
-    return {
+def xtrace_skip_response(
+    decision: XTraceSessionIngestDecision,
+    *,
+    reason: str | None = None,
+    budget: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    skip_reason = reason or decision.reason
+    response: dict[str, Any] = {
         "skipped_at": datetime.now(UTC).isoformat(),
-        "skip_reason": decision.reason,
-        "policy": {
-            "quality": decision.quality,
-            "automated": decision.automated,
-            "tiny": decision.tiny,
-            "estimated_source_messages": decision.estimated_source_messages,
-            "estimated_xtrace_messages": decision.estimated_xtrace_messages,
-            "max_messages": decision.max_messages,
+        "skip_reason": skip_reason,
+        "policy": xtrace_policy_response(decision),
+        "_clawdi": {
+            "cost": {
+                "estimated_source_messages": decision.estimated_source_messages,
+                "estimated_xtrace_messages": decision.estimated_xtrace_messages,
+                "accounted_xtrace_messages": 0,
+            }
         },
+    }
+    if budget is not None:
+        response["budget"] = budget
+    return response
+
+
+def xtrace_policy_response(decision: XTraceSessionIngestDecision) -> dict[str, Any]:
+    return {
+        "quality": decision.quality,
+        "automated": decision.automated,
+        "tiny": decision.tiny,
+        "estimated_source_messages": decision.estimated_source_messages,
+        "estimated_xtrace_messages": decision.estimated_xtrace_messages,
+        "max_messages": decision.max_messages,
     }
 
 

--- a/backend/app/services/xtrace_ingest_policy.py
+++ b/backend/app/services/xtrace_ingest_policy.py
@@ -1,0 +1,82 @@
+"""Cost and quality policy for XTrace memory ingestion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from app.core.config import settings
+
+
+@dataclass(frozen=True)
+class XTraceSessionIngestDecision:
+    should_ingest: bool
+    reason: str | None
+    quality: str
+    automated: bool
+    tiny: bool
+    estimated_source_messages: int
+    estimated_xtrace_messages: int
+    max_messages: int
+
+
+def decide_xtrace_session_ingest(
+    session: Any,
+    *,
+    max_messages: int | None = None,
+) -> XTraceSessionIngestDecision:
+    message_count = max(0, int(getattr(session, "message_count", 0) or 0))
+    duration_seconds = getattr(session, "duration_seconds", None)
+    duration = int(duration_seconds or 0)
+    summary = str(getattr(session, "summary", "") or "")
+    cap = max(1, max_messages or settings.xtrace_memory_max_messages)
+    automated = _is_automated_summary(summary)
+    tiny = message_count <= settings.xtrace_memory_low_quality_max_messages or (
+        duration > 0 and duration <= settings.xtrace_memory_low_quality_max_duration_seconds
+    )
+    reason = None
+    should_ingest = True
+    quality = "normal"
+
+    if automated:
+        quality = "automated"
+        if settings.xtrace_memory_skip_automated_sessions:
+            reason = "automated_session"
+            should_ingest = False
+    elif tiny:
+        quality = "tiny"
+        if settings.xtrace_memory_skip_tiny_sessions:
+            reason = "tiny_session"
+            should_ingest = False
+
+    estimated_payload_messages = min(message_count, cap)
+    return XTraceSessionIngestDecision(
+        should_ingest=should_ingest,
+        reason=reason,
+        quality=quality,
+        automated=automated,
+        tiny=tiny,
+        estimated_source_messages=message_count,
+        estimated_xtrace_messages=estimated_payload_messages + 1,
+        max_messages=cap,
+    )
+
+
+def xtrace_skip_response(decision: XTraceSessionIngestDecision) -> dict[str, Any]:
+    return {
+        "skipped_at": datetime.now(UTC).isoformat(),
+        "skip_reason": decision.reason,
+        "policy": {
+            "quality": decision.quality,
+            "automated": decision.automated,
+            "tiny": decision.tiny,
+            "estimated_source_messages": decision.estimated_source_messages,
+            "estimated_xtrace_messages": decision.estimated_xtrace_messages,
+            "max_messages": decision.max_messages,
+        },
+    }
+
+
+def _is_automated_summary(summary: str) -> bool:
+    return summary.startswith("Cron:") or summary.startswith("[")

--- a/backend/app/services/xtrace_ingest_queue.py
+++ b/backend/app/services/xtrace_ingest_queue.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from datetime import UTC, datetime
-from uuid import UUID
+import socket
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.config import settings
@@ -27,7 +28,7 @@ from app.services.xtrace_memory import (
 
 log = logging.getLogger(__name__)
 
-_RUNNABLE_STATUSES = {"queued"}
+_DEFAULT_WORKER_ID = f"{socket.gethostname()}:{uuid4()}"
 
 
 async def enqueue_xtrace_session_ingest(
@@ -59,6 +60,7 @@ async def enqueue_xtrace_session_ingest(
         local_session_id=session.local_session_id,
         source_key=source_key,
         status="queued",
+        attempt_count=0,
         created_ref_count=0,
         updated_ref_count=0,
         mirrored_count=0,
@@ -98,6 +100,7 @@ async def enqueue_xtrace_skill_ingest(
         skill_id=skill.id,
         source_key=source_key,
         status="queued",
+        attempt_count=0,
         created_ref_count=0,
         updated_ref_count=0,
         mirrored_count=0,
@@ -128,12 +131,11 @@ async def _run_xtrace_ingest_job_in_session(db: AsyncSession, job_id: UUID) -> N
     if job is None:
         log.error("xtrace_ingest_job_missing job_id=%s", job_id)
         return
-    if job.status not in _RUNNABLE_STATUSES:
+    if job.status == "queued":
+        await _mark_job_claimed(db, job, worker_id=_DEFAULT_WORKER_ID)
+    elif job.status not in {"running"}:
         log.info("xtrace_ingest_job_not_active job_id=%s status=%s", job_id, job.status)
         return
-
-    job.status = "running"
-    await db.commit()
 
     try:
         if job.source_type == "session":
@@ -145,13 +147,15 @@ async def _run_xtrace_ingest_job_in_session(db: AsyncSession, job_id: UUID) -> N
         if result is None:
             job.status = "skipped"
             job.response = {"skipped_at": datetime.now(UTC).isoformat()}
-            await db.commit()
+        job.claimed_at = None
+        job.claimed_by = None
+        job.error = None
+        await db.commit()
     except Exception as exc:
         await db.rollback()
         job = await db.get(XTraceMemoryIngest, job_id)
         if job is not None:
-            job.status = "failed"
-            job.response = {"error": str(exc)[:4000]}
+            _schedule_failed_job(job, exc)
             await db.commit()
         log.exception("xtrace_ingest_job_failed job_id=%s", job_id)
 
@@ -163,30 +167,98 @@ async def run_queued_xtrace_ingest_jobs(
     db: AsyncSession | None = None,
 ) -> int:
     if db is not None:
-        job_ids = await _queued_job_ids(db, limit)
-        for job_id in job_ids:
-            await run_xtrace_ingest_job(job_id, session_factory=session_factory, db=db)
-        return len(job_ids)
+        jobs = await claim_queued_xtrace_ingest_jobs(db, limit=limit, worker_id=_DEFAULT_WORKER_ID)
+        for job in jobs:
+            await run_xtrace_ingest_job(job.id, session_factory=session_factory, db=db)
+        return len(jobs)
 
     async with session_factory() as session:
-        job_ids = await _queued_job_ids(session, limit)
+        jobs = await claim_queued_xtrace_ingest_jobs(
+            session, limit=limit, worker_id=_DEFAULT_WORKER_ID
+        )
+        job_ids = [job.id for job in jobs]
     for job_id in job_ids:
         await run_xtrace_ingest_job(job_id, session_factory=session_factory)
     return len(job_ids)
 
 
-async def _queued_job_ids(db: AsyncSession, limit: int) -> list[UUID]:
-    return [
-        row[0]
-        for row in (
+async def claim_queued_xtrace_ingest_jobs(
+    db: AsyncSession,
+    *,
+    limit: int,
+    worker_id: str,
+) -> list[XTraceMemoryIngest]:
+    now = datetime.now(UTC)
+    rows = (
+        (
             await db.execute(
-                select(XTraceMemoryIngest.id)
-                .where(XTraceMemoryIngest.status == "queued")
+                select(XTraceMemoryIngest)
+                .where(
+                    XTraceMemoryIngest.status == "queued",
+                    or_(
+                        XTraceMemoryIngest.next_attempt_at.is_(None),
+                        XTraceMemoryIngest.next_attempt_at <= now,
+                    ),
+                )
                 .order_by(XTraceMemoryIngest.created_at.asc())
                 .limit(limit)
+                .with_for_update(skip_locked=True)
             )
-        ).all()
-    ]
+        )
+        .scalars()
+        .all()
+    )
+    for job in rows:
+        _mark_job_claimed_in_memory(job, worker_id=worker_id, now=now)
+    if rows:
+        await db.commit()
+    return rows
+
+
+async def _mark_job_claimed(
+    db: AsyncSession,
+    job: XTraceMemoryIngest,
+    *,
+    worker_id: str,
+) -> None:
+    _mark_job_claimed_in_memory(job, worker_id=worker_id, now=datetime.now(UTC))
+    await db.commit()
+
+
+def _mark_job_claimed_in_memory(
+    job: XTraceMemoryIngest,
+    *,
+    worker_id: str,
+    now: datetime,
+) -> None:
+    job.status = "running"
+    job.claimed_at = now
+    job.claimed_by = worker_id
+    job.next_attempt_at = None
+    job.error = None
+    job.attempt_count = (job.attempt_count or 0) + 1
+
+
+def _schedule_failed_job(job: XTraceMemoryIngest, exc: Exception) -> None:
+    attempts = job.attempt_count or 0
+    error = str(exc)[:4000]
+    job.error = error
+    job.response = {
+        **(job.response or {}),
+        "error": error,
+        "attempt_count": attempts,
+        "failed_at": datetime.now(UTC).isoformat(),
+    }
+    job.claimed_at = None
+    job.claimed_by = None
+    if attempts >= max(1, settings.xtrace_memory_max_attempts):
+        job.status = "failed"
+        job.next_attempt_at = None
+        return
+
+    delay = settings.xtrace_memory_retry_base_seconds * (2 ** max(0, attempts - 1))
+    job.status = "queued"
+    job.next_attempt_at = datetime.now(UTC) + timedelta(seconds=max(1.0, delay))
 
 
 async def run_xtrace_ingest_worker(

--- a/backend/app/services/xtrace_ingest_queue.py
+++ b/backend/app/services/xtrace_ingest_queue.py
@@ -18,6 +18,10 @@ from app.models.session import Session
 from app.models.skill import Skill
 from app.models.xtrace_ingest import XTraceMemoryIngest
 from app.services.file_store import get_file_store
+from app.services.xtrace_ingest_policy import (
+    decide_xtrace_session_ingest,
+    xtrace_skip_response,
+)
 from app.services.xtrace_memory import (
     ingest_xtrace_session_memories,
     ingest_xtrace_skill_memories,
@@ -52,6 +56,26 @@ async def enqueue_xtrace_session_ingest(
     ).scalar_one_or_none()
     if existing is not None:
         return existing
+
+    decision = decide_xtrace_session_ingest(session)
+    if not decision.should_ingest:
+        job = XTraceMemoryIngest(
+            user_id=session.user_id,
+            source_type="session",
+            session_id=session.id,
+            local_session_id=session.local_session_id,
+            source_key=source_key,
+            status="skipped",
+            attempt_count=0,
+            created_ref_count=0,
+            updated_ref_count=0,
+            mirrored_count=0,
+            response=xtrace_skip_response(decision),
+        )
+        db.add(job)
+        await db.commit()
+        await db.refresh(job)
+        return job
 
     job = XTraceMemoryIngest(
         user_id=session.user_id,
@@ -146,7 +170,7 @@ async def _run_xtrace_ingest_job_in_session(db: AsyncSession, job_id: UUID) -> N
             raise ValueError(f"unsupported XTrace ingest source type: {job.source_type}")
         if result is None:
             job.status = "skipped"
-            job.response = {"skipped_at": datetime.now(UTC).isoformat()}
+            job.response = job.response or {"skipped_at": datetime.now(UTC).isoformat()}
         job.claimed_at = None
         job.claimed_by = None
         job.error = None
@@ -289,6 +313,12 @@ async def _run_session_job(db: AsyncSession, job: XTraceMemoryIngest):
         raise ValueError(f"session not found: {job.session_id}")
     if not session.file_key:
         raise ValueError(f"session content not uploaded: {job.session_id}")
+
+    decision = decide_xtrace_session_ingest(session)
+    if not decision.should_ingest:
+        job.status = "skipped"
+        job.response = xtrace_skip_response(decision)
+        return None
 
     data = await get_file_store().get(session.file_key)
     parsed = json.loads(data)

--- a/backend/app/services/xtrace_ingest_queue.py
+++ b/backend/app/services/xtrace_ingest_queue.py
@@ -18,8 +18,10 @@ from app.models.session import Session
 from app.models.skill import Skill
 from app.models.xtrace_ingest import XTraceMemoryIngest
 from app.services.file_store import get_file_store
+from app.services.xtrace_ingest_budget import decide_xtrace_user_budget, xtrace_cost_metadata
 from app.services.xtrace_ingest_policy import (
     decide_xtrace_session_ingest,
+    xtrace_policy_response,
     xtrace_skip_response,
 )
 from app.services.xtrace_memory import (
@@ -77,6 +79,34 @@ async def enqueue_xtrace_session_ingest(
         await db.refresh(job)
         return job
 
+    budget = await decide_xtrace_user_budget(
+        db,
+        user_id=session.user_id,
+        requested_messages=decision.estimated_xtrace_messages,
+    )
+    if budget is not None and not budget.allowed:
+        job = XTraceMemoryIngest(
+            user_id=session.user_id,
+            source_type="session",
+            session_id=session.id,
+            local_session_id=session.local_session_id,
+            source_key=source_key,
+            status="skipped",
+            attempt_count=0,
+            created_ref_count=0,
+            updated_ref_count=0,
+            mirrored_count=0,
+            response=xtrace_skip_response(
+                decision,
+                reason="budget_exceeded",
+                budget=budget.as_response(),
+            ),
+        )
+        db.add(job)
+        await db.commit()
+        await db.refresh(job)
+        return job
+
     job = XTraceMemoryIngest(
         user_id=session.user_id,
         source_type="session",
@@ -88,7 +118,14 @@ async def enqueue_xtrace_session_ingest(
         created_ref_count=0,
         updated_ref_count=0,
         mirrored_count=0,
-        response=None,
+        response={
+            "queued_at": datetime.now(UTC).isoformat(),
+            "policy": xtrace_policy_response(decision),
+            "_clawdi": xtrace_cost_metadata(
+                estimated_source_messages=decision.estimated_source_messages,
+                estimated_xtrace_messages=decision.estimated_xtrace_messages,
+            ),
+        },
     )
     db.add(job)
     await db.commit()

--- a/backend/app/services/xtrace_ingest_queue.py
+++ b/backend/app/services/xtrace_ingest_queue.py
@@ -1,0 +1,249 @@
+"""Durable queue for XTrace memory ingest work."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.config import settings
+from app.core.database import async_session_factory
+from app.models.session import Session
+from app.models.skill import Skill
+from app.models.xtrace_ingest import XTraceMemoryIngest
+from app.services.file_store import get_file_store
+from app.services.xtrace_memory import (
+    ingest_xtrace_session_memories,
+    ingest_xtrace_skill_memories,
+    xtrace_memory_configured,
+    xtrace_session_source_key,
+    xtrace_skill_source_key,
+)
+
+log = logging.getLogger(__name__)
+
+_RUNNABLE_STATUSES = {"queued"}
+
+
+async def enqueue_xtrace_session_ingest(
+    db: AsyncSession,
+    *,
+    session: Session,
+) -> XTraceMemoryIngest | None:
+    if not xtrace_memory_configured():
+        return None
+
+    source_key = xtrace_session_source_key(session)
+    existing = (
+        await db.execute(
+            select(XTraceMemoryIngest)
+            .where(
+                XTraceMemoryIngest.source_type == "session",
+                XTraceMemoryIngest.source_key == source_key,
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return existing
+
+    job = XTraceMemoryIngest(
+        user_id=session.user_id,
+        source_type="session",
+        session_id=session.id,
+        local_session_id=session.local_session_id,
+        source_key=source_key,
+        status="queued",
+        created_ref_count=0,
+        updated_ref_count=0,
+        mirrored_count=0,
+        response=None,
+    )
+    db.add(job)
+    await db.commit()
+    await db.refresh(job)
+    return job
+
+
+async def enqueue_xtrace_skill_ingest(
+    db: AsyncSession,
+    *,
+    skill: Skill,
+) -> XTraceMemoryIngest | None:
+    if not xtrace_memory_configured():
+        return None
+
+    source_key = xtrace_skill_source_key(skill)
+    existing = (
+        await db.execute(
+            select(XTraceMemoryIngest)
+            .where(
+                XTraceMemoryIngest.source_type == "skill",
+                XTraceMemoryIngest.source_key == source_key,
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return existing
+
+    job = XTraceMemoryIngest(
+        user_id=skill.user_id,
+        source_type="skill",
+        skill_id=skill.id,
+        source_key=source_key,
+        status="queued",
+        created_ref_count=0,
+        updated_ref_count=0,
+        mirrored_count=0,
+        response=None,
+    )
+    db.add(job)
+    await db.commit()
+    await db.refresh(job)
+    return job
+
+
+async def run_xtrace_ingest_job(
+    job_id: UUID,
+    *,
+    session_factory: async_sessionmaker[AsyncSession] = async_session_factory,
+    db: AsyncSession | None = None,
+) -> None:
+    if db is not None:
+        await _run_xtrace_ingest_job_in_session(db, job_id)
+        return
+
+    async with session_factory() as session:
+        await _run_xtrace_ingest_job_in_session(session, job_id)
+
+
+async def _run_xtrace_ingest_job_in_session(db: AsyncSession, job_id: UUID) -> None:
+    job = await db.get(XTraceMemoryIngest, job_id)
+    if job is None:
+        log.error("xtrace_ingest_job_missing job_id=%s", job_id)
+        return
+    if job.status not in _RUNNABLE_STATUSES:
+        log.info("xtrace_ingest_job_not_active job_id=%s status=%s", job_id, job.status)
+        return
+
+    job.status = "running"
+    await db.commit()
+
+    try:
+        if job.source_type == "session":
+            result = await _run_session_job(db, job)
+        elif job.source_type == "skill":
+            result = await _run_skill_job(db, job)
+        else:
+            raise ValueError(f"unsupported XTrace ingest source type: {job.source_type}")
+        if result is None:
+            job.status = "skipped"
+            job.response = {"skipped_at": datetime.now(UTC).isoformat()}
+            await db.commit()
+    except Exception as exc:
+        await db.rollback()
+        job = await db.get(XTraceMemoryIngest, job_id)
+        if job is not None:
+            job.status = "failed"
+            job.response = {"error": str(exc)[:4000]}
+            await db.commit()
+        log.exception("xtrace_ingest_job_failed job_id=%s", job_id)
+
+
+async def run_queued_xtrace_ingest_jobs(
+    *,
+    limit: int = 10,
+    session_factory: async_sessionmaker[AsyncSession] = async_session_factory,
+    db: AsyncSession | None = None,
+) -> int:
+    if db is not None:
+        job_ids = await _queued_job_ids(db, limit)
+        for job_id in job_ids:
+            await run_xtrace_ingest_job(job_id, session_factory=session_factory, db=db)
+        return len(job_ids)
+
+    async with session_factory() as session:
+        job_ids = await _queued_job_ids(session, limit)
+    for job_id in job_ids:
+        await run_xtrace_ingest_job(job_id, session_factory=session_factory)
+    return len(job_ids)
+
+
+async def _queued_job_ids(db: AsyncSession, limit: int) -> list[UUID]:
+    return [
+        row[0]
+        for row in (
+            await db.execute(
+                select(XTraceMemoryIngest.id)
+                .where(XTraceMemoryIngest.status == "queued")
+                .order_by(XTraceMemoryIngest.created_at.asc())
+                .limit(limit)
+            )
+        ).all()
+    ]
+
+
+async def run_xtrace_ingest_worker(
+    *,
+    session_factory: async_sessionmaker[AsyncSession] = async_session_factory,
+) -> None:
+    while True:
+        try:
+            if xtrace_memory_configured():
+                processed = await run_queued_xtrace_ingest_jobs(
+                    limit=max(1, settings.xtrace_memory_worker_batch_size),
+                    session_factory=session_factory,
+                )
+                if processed:
+                    log.info("xtrace_ingest_worker_drained count=%s", processed)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("xtrace_ingest_worker_tick_failed")
+        await asyncio.sleep(max(1.0, settings.xtrace_memory_worker_poll_seconds))
+
+
+async def _run_session_job(db: AsyncSession, job: XTraceMemoryIngest):
+    if job.session_id is None:
+        raise ValueError("session ingest job is missing session_id")
+    session = await db.get(Session, job.session_id)
+    if session is None:
+        raise ValueError(f"session not found: {job.session_id}")
+    if not session.file_key:
+        raise ValueError(f"session content not uploaded: {job.session_id}")
+
+    data = await get_file_store().get(session.file_key)
+    parsed = json.loads(data)
+    if not isinstance(parsed, list):
+        raise ValueError("session content is not a JSON message list")
+    messages = [m for m in parsed if isinstance(m, dict)]
+    return await ingest_xtrace_session_memories(
+        db,
+        session=session,
+        messages=messages,
+        ingest_record=job,
+    )
+
+
+async def _run_skill_job(db: AsyncSession, job: XTraceMemoryIngest):
+    if job.skill_id is None:
+        raise ValueError("skill ingest job is missing skill_id")
+    skill = await db.get(Skill, job.skill_id)
+    if skill is None:
+        raise ValueError(f"skill not found: {job.skill_id}")
+    if not skill.file_key:
+        raise ValueError(f"skill content not uploaded: {job.skill_id}")
+
+    data = await get_file_store().get(skill.file_key)
+    return await ingest_xtrace_skill_memories(
+        db,
+        skill=skill,
+        data=data,
+        ingest_record=job,
+    )

--- a/backend/app/services/xtrace_memory.py
+++ b/backend/app/services/xtrace_memory.py
@@ -1,0 +1,282 @@
+"""XTrace Memory API integration for cloud session uploads."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.memory import Memory
+from app.models.session import Session
+from app.models.xtrace_ingest import XTraceMemoryIngest
+
+log = logging.getLogger(__name__)
+
+_XTRACE_ROLES = {"user", "assistant", "system"}
+_SOURCE = "xtrace_session"
+
+
+@dataclass(frozen=True)
+class XTraceMemoryRef:
+    id: str
+    type: str
+    text: str
+
+
+@dataclass(frozen=True)
+class XTraceRemoteIngest:
+    payload: dict[str, Any]
+    created_refs: list[XTraceMemoryRef]
+    updated_refs: list[XTraceMemoryRef]
+
+
+@dataclass(frozen=True)
+class XTraceMemoryIngestResult:
+    job_id: str | None
+    status: str | None
+    created_ref_count: int
+    updated_ref_count: int
+    mirrored_count: int
+    response: dict[str, Any]
+
+
+def xtrace_memory_configured() -> bool:
+    return bool(
+        settings.xtrace_memory_enabled
+        and settings.xtrace_api_key.strip()
+        and settings.xtrace_org_id.strip()
+    )
+
+
+async def ingest_xtrace_session_memories(
+    db: AsyncSession,
+    *,
+    session: Session,
+    messages: list[dict[str, Any]],
+) -> XTraceMemoryIngestResult | None:
+    """Send session messages to XTrace and mirror returned memory refs.
+
+    XTrace may return a pending job even with ``wait=true``. In that case
+    there are no memory refs to mirror yet, so this returns 0 and leaves
+    XTrace's async job to finish remotely.
+    """
+    if not xtrace_memory_configured():
+        return None
+
+    normalized = _normalize_messages(messages)
+    if not normalized:
+        return None
+
+    remote = await _ingest(normalized, session=session)
+    refs = [*remote.created_refs, *remote.updated_refs]
+    mirrored_count = await _store_refs(db, session=session, refs=refs) if refs else 0
+    result = XTraceMemoryIngestResult(
+        job_id=_string_or_none(remote.payload.get("id")),
+        status=_string_or_none(remote.payload.get("status")),
+        created_ref_count=len(remote.created_refs),
+        updated_ref_count=len(remote.updated_refs),
+        mirrored_count=mirrored_count,
+        response=remote.payload,
+    )
+    db.add(
+        XTraceMemoryIngest(
+            user_id=session.user_id,
+            session_id=session.id,
+            local_session_id=session.local_session_id,
+            job_id=result.job_id,
+            status=result.status,
+            created_ref_count=result.created_ref_count,
+            updated_ref_count=result.updated_ref_count,
+            mirrored_count=result.mirrored_count,
+            response=result.response,
+        )
+    )
+    await db.commit()
+    return result
+
+
+async def _ingest(messages: list[dict[str, str]], *, session: Session) -> XTraceRemoteIngest:
+    url = f"{settings.xtrace_memory_base_url.rstrip('/')}/v1/memories"
+    headers = {
+        "Authorization": f"Bearer {settings.xtrace_api_key}",
+        "X-Org-Id": settings.xtrace_org_id,
+        "Accept": "application/json",
+    }
+    body: dict[str, Any] = {
+        "messages": messages,
+        "user_id": str(session.user_id),
+        "conv_id": str(session.id),
+        "app_id": settings.xtrace_memory_app_id,
+        "extract_artifacts": False,
+        "metadata": {
+            "source": "clawdi_cloud_session",
+            "local_session_id": session.local_session_id,
+            "project_path": session.project_path,
+            "content_hash": session.content_hash,
+        },
+    }
+    if session.environment_id is not None:
+        body["agent_id"] = str(session.environment_id)
+
+    async with httpx.AsyncClient(timeout=settings.xtrace_memory_timeout_seconds) as client:
+        response = await client.post(
+            url,
+            headers=headers,
+            params={"wait": "true"},
+            json=body,
+        )
+        response.raise_for_status()
+        payload = response.json()
+
+    return _extract_remote_ingest(payload)
+
+
+def _normalize_messages(messages: list[dict[str, Any]]) -> list[dict[str, str]]:
+    max_messages = max(1, settings.xtrace_memory_max_messages)
+    selected = messages[-max_messages:] if len(messages) > max_messages else messages
+    normalized: list[dict[str, str]] = []
+    for message in selected:
+        if not isinstance(message, dict):
+            continue
+        raw_content = message.get("content")
+        if raw_content is None:
+            continue
+        if isinstance(raw_content, str):
+            content = raw_content.strip()
+        else:
+            try:
+                content = json.dumps(raw_content, ensure_ascii=False)
+            except (TypeError, ValueError):
+                content = str(raw_content)
+        if not content:
+            continue
+
+        role = str(message.get("role") or "assistant")
+        if role not in _XTRACE_ROLES:
+            role = "assistant"
+        item = {"role": role, "content": content}
+        date = message.get("date") or message.get("timestamp") or message.get("created_at")
+        if isinstance(date, str) and date:
+            item["date"] = date
+        normalized.append(item)
+    return normalized
+
+
+def _extract_remote_ingest(payload: dict[str, Any]) -> XTraceRemoteIngest:
+    created_refs: list[XTraceMemoryRef] = []
+    updated_refs: list[XTraceMemoryRef] = []
+
+    result = payload.get("result")
+    if isinstance(result, dict):
+        created_refs.extend(_parse_ref_list(result.get("memories_created")))
+        updated_refs.extend(_parse_ref_list(result.get("memories_updated")))
+
+    # Older quickstart-style response: {"results": [{data: {memory: "..."}}]}.
+    raw_results = payload.get("results")
+    if isinstance(raw_results, list):
+        for raw in raw_results:
+            if not isinstance(raw, dict):
+                continue
+            data = raw.get("data")
+            text = data.get("memory") if isinstance(data, dict) else None
+            if isinstance(text, str) and text.strip():
+                created_refs.append(
+                    XTraceMemoryRef(
+                        id=str(raw.get("id") or ""),
+                        type="fact",
+                        text=text.strip(),
+                    )
+                )
+
+    return XTraceRemoteIngest(
+        payload=payload,
+        created_refs=created_refs,
+        updated_refs=updated_refs,
+    )
+
+
+def _parse_ref_list(raw_refs: Any) -> list[XTraceMemoryRef]:
+    if not isinstance(raw_refs, list):
+        return []
+    refs: list[XTraceMemoryRef] = []
+    for raw in raw_refs:
+        ref = _parse_ref(raw)
+        if ref is not None:
+            refs.append(ref)
+    return refs
+
+
+def _parse_ref(raw: Any) -> XTraceMemoryRef | None:
+    if not isinstance(raw, dict):
+        return None
+    text = raw.get("text")
+    if not isinstance(text, str) or not text.strip():
+        return None
+    return XTraceMemoryRef(
+        id=str(raw.get("id") or ""),
+        type=str(raw.get("type") or "fact"),
+        text=text.strip(),
+    )
+
+
+async def _store_refs(
+    db: AsyncSession,
+    *,
+    session: Session,
+    refs: list[XTraceMemoryRef],
+) -> int:
+    if not refs:
+        return 0
+
+    texts = [r.text for r in refs]
+    existing = (
+        await db.execute(
+            select(Memory.content).where(
+                Memory.user_id == session.user_id,
+                Memory.source_session_id == session.id,
+                Memory.source == _SOURCE,
+                Memory.content.in_(texts),
+            )
+        )
+    ).scalars()
+    existing_texts = set(existing.all())
+
+    created = 0
+    for ref in refs:
+        if ref.text in existing_texts:
+            continue
+        db.add(
+            Memory(
+                user_id=session.user_id,
+                content=ref.text,
+                category=_category_for_xtrace_type(ref.type),
+                source=_SOURCE,
+                source_session_id=session.id,
+                tags=["xtrace", f"xtrace:{ref.type}"],
+                metadata_={"xtrace_memory_id": ref.id, "xtrace_type": ref.type},
+            )
+        )
+        existing_texts.add(ref.text)
+        created += 1
+
+    if created:
+        await db.flush()
+    return created
+
+
+def _category_for_xtrace_type(memory_type: str) -> str:
+    if memory_type == "fact":
+        return "fact"
+    return "context"
+
+
+def _string_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)

--- a/backend/app/services/xtrace_memory.py
+++ b/backend/app/services/xtrace_memory.py
@@ -87,6 +87,7 @@ async def ingest_xtrace_session_memories(
     session: Session,
     messages: list[dict[str, Any]],
     max_messages: int | None = None,
+    ingest_record: XTraceMemoryIngest | None = None,
 ) -> XTraceMemoryIngestResult | None:
     """Send session messages to XTrace and mirror returned memory refs.
 
@@ -121,21 +122,21 @@ async def ingest_xtrace_session_memories(
         else 0
     )
     result = _result_from_remote(remote, mirrored_count)
-    db.add(
-        XTraceMemoryIngest(
-            user_id=session.user_id,
-            source_type="session",
-            session_id=session.id,
-            local_session_id=session.local_session_id,
-            source_key=source_key,
-            job_id=result.job_id,
-            status=result.status,
-            created_ref_count=result.created_ref_count,
-            updated_ref_count=result.updated_ref_count,
-            mirrored_count=result.mirrored_count,
-            response=result.response,
-        )
+    record = ingest_record or XTraceMemoryIngest(
+        user_id=session.user_id,
+        source_type="session",
+        session_id=session.id,
+        local_session_id=session.local_session_id,
+        source_key=source_key,
     )
+    record.job_id = result.job_id
+    record.status = result.status
+    record.created_ref_count = result.created_ref_count
+    record.updated_ref_count = result.updated_ref_count
+    record.mirrored_count = result.mirrored_count
+    record.response = result.response
+    if ingest_record is None:
+        db.add(record)
     await db.commit()
     return result
 
@@ -145,6 +146,7 @@ async def ingest_xtrace_skill_memories(
     *,
     skill: Skill,
     data: bytes,
+    ingest_record: XTraceMemoryIngest | None = None,
 ) -> XTraceMemoryIngestResult | None:
     """Send a skill archive to XTrace as an artifact-shaped memory source."""
     if not xtrace_memory_configured():
@@ -176,20 +178,20 @@ async def ingest_xtrace_skill_memories(
         else 0
     )
     result = _result_from_remote(remote, mirrored_count)
-    db.add(
-        XTraceMemoryIngest(
-            user_id=skill.user_id,
-            source_type="skill",
-            skill_id=skill.id,
-            source_key=source_key,
-            job_id=result.job_id,
-            status=result.status,
-            created_ref_count=result.created_ref_count,
-            updated_ref_count=result.updated_ref_count,
-            mirrored_count=result.mirrored_count,
-            response=result.response,
-        )
+    record = ingest_record or XTraceMemoryIngest(
+        user_id=skill.user_id,
+        source_type="skill",
+        skill_id=skill.id,
+        source_key=source_key,
     )
+    record.job_id = result.job_id
+    record.status = result.status
+    record.created_ref_count = result.created_ref_count
+    record.updated_ref_count = result.updated_ref_count
+    record.mirrored_count = result.mirrored_count
+    record.response = result.response
+    if ingest_record is None:
+        db.add(record)
     await db.commit()
     return result
 

--- a/backend/app/services/xtrace_memory.py
+++ b/backend/app/services/xtrace_memory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from dataclasses import dataclass
@@ -28,6 +29,8 @@ _SESSION_SOURCE = "xtrace_session"
 _SKILL_SOURCE = "xtrace_skill"
 _MAX_SKILL_FILE_CHARS = 24_000
 _MAX_SKILL_INGEST_CHARS = 160_000
+_INGEST_RETRY_STATUSES = {429, 500, 502, 503, 504}
+_INGEST_MAX_ATTEMPTS = 5
 
 
 @dataclass(frozen=True)
@@ -322,16 +325,43 @@ async def _ingest(body: dict[str, Any]) -> XTraceRemoteIngest:
     }
 
     async with httpx.AsyncClient(timeout=settings.xtrace_memory_timeout_seconds) as client:
-        response = await client.post(
-            url,
-            headers=headers,
-            params={"wait": "true"},
-            json=body,
-        )
+        response: httpx.Response | None = None
+        for attempt in range(1, _INGEST_MAX_ATTEMPTS + 1):
+            response = await client.post(
+                url,
+                headers=headers,
+                params={"wait": "true"},
+                json=body,
+            )
+            if response.status_code not in _INGEST_RETRY_STATUSES:
+                break
+            if attempt == _INGEST_MAX_ATTEMPTS:
+                break
+            delay = _retry_delay_seconds(response, attempt)
+            log.warning(
+                "xtrace_memory_ingest_retry status=%s attempt=%s delay_seconds=%s",
+                response.status_code,
+                attempt,
+                delay,
+            )
+            await asyncio.sleep(delay)
+
+        if response is None:
+            raise RuntimeError("XTrace ingest did not return a response")
         response.raise_for_status()
         payload = response.json()
 
     return _extract_remote_ingest(payload)
+
+
+def _retry_delay_seconds(response: httpx.Response, attempt: int) -> float:
+    retry_after = response.headers.get("Retry-After")
+    if retry_after:
+        try:
+            return min(max(float(retry_after), 1.0), 60.0)
+        except ValueError:
+            pass
+    return min(2.0 * (2 ** (attempt - 1)), 30.0)
 
 
 def _normalize_messages(messages: list[dict[str, Any]]) -> list[dict[str, str]]:

--- a/backend/app/services/xtrace_memory.py
+++ b/backend/app/services/xtrace_memory.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
@@ -21,6 +22,7 @@ from app.models.session import Session
 from app.models.skill import Skill
 from app.models.xtrace_ingest import XTraceMemoryIngest
 from app.services.skill_index import SkillTextFile, extract_skill_text_files
+from app.services.xtrace_ingest_budget import xtrace_cost_metadata
 
 log = logging.getLogger(__name__)
 
@@ -103,7 +105,55 @@ async def ingest_xtrace_session_memories(
         return None
 
     source_key = xtrace_session_source_key(session)
-    remote = await _ingest(_build_session_payload(session, normalized))
+    previous_hashes = await _previous_xtrace_session_message_hashes(
+        db,
+        session_id=session.id,
+        exclude_ingest_id=ingest_record.id if ingest_record is not None else None,
+    )
+    message_pairs = [(message, _message_hash(message)) for message in normalized]
+    new_pairs = [
+        (message, digest) for message, digest in message_pairs if digest not in previous_hashes
+    ]
+    new_messages = [message for message, _digest in new_pairs]
+    new_hashes = [digest for _message, digest in new_pairs]
+    payload_message_count = len(new_messages) + 1
+    cost = xtrace_cost_metadata(
+        estimated_source_messages=len(normalized),
+        estimated_xtrace_messages=len(normalized) + 1,
+        payload_message_count=payload_message_count,
+        accounted_xtrace_messages=payload_message_count,
+        message_hashes=new_hashes,
+    )
+    if not new_messages:
+        skip_cost = xtrace_cost_metadata(
+            estimated_source_messages=len(normalized),
+            estimated_xtrace_messages=len(normalized) + 1,
+            payload_message_count=0,
+            accounted_xtrace_messages=0,
+            message_hashes=[],
+        )
+        record = ingest_record or XTraceMemoryIngest(
+            user_id=session.user_id,
+            source_type="session",
+            session_id=session.id,
+            local_session_id=session.local_session_id,
+            source_key=source_key,
+        )
+        record.status = "skipped"
+        record.created_ref_count = 0
+        record.updated_ref_count = 0
+        record.mirrored_count = 0
+        record.response = {
+            "skipped_at": datetime.now(UTC).isoformat(),
+            "skip_reason": "no_new_messages",
+            "_clawdi": skip_cost,
+        }
+        if ingest_record is None:
+            db.add(record)
+        await db.commit()
+        return None
+
+    remote = await _ingest(_build_session_payload(session, new_messages))
     refs = [*remote.created_refs, *remote.updated_refs]
     mirrored_count = (
         await _store_refs(
@@ -121,7 +171,7 @@ async def ingest_xtrace_session_memories(
         if refs
         else 0
     )
-    result = _result_from_remote(remote, mirrored_count)
+    result = _result_from_remote(remote, mirrored_count, clawdi_metadata=cost)
     record = ingest_record or XTraceMemoryIngest(
         user_id=session.user_id,
         source_type="session",
@@ -406,6 +456,38 @@ def _normalize_messages(
     return normalized
 
 
+async def _previous_xtrace_session_message_hashes(
+    db: AsyncSession,
+    *,
+    session_id: UUID,
+    exclude_ingest_id: UUID | None,
+) -> set[str]:
+    stmt = select(XTraceMemoryIngest.response).where(
+        XTraceMemoryIngest.source_type == "session",
+        XTraceMemoryIngest.session_id == session_id,
+    )
+    if exclude_ingest_id is not None:
+        stmt = stmt.where(XTraceMemoryIngest.id != exclude_ingest_id)
+
+    rows = (await db.execute(stmt)).scalars().all()
+    hashes: set[str] = set()
+    for response in rows:
+        if not isinstance(response, dict):
+            continue
+        clawdi = response.get("_clawdi")
+        if not isinstance(clawdi, dict):
+            continue
+        raw_hashes = clawdi.get("message_hashes")
+        if isinstance(raw_hashes, list):
+            hashes.update(str(item) for item in raw_hashes if item)
+    return hashes
+
+
+def _message_hash(message: dict[str, str]) -> str:
+    encoded = json.dumps(message, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
 def _extract_remote_ingest(payload: dict[str, Any]) -> XTraceRemoteIngest:
     created_refs: list[XTraceMemoryRef] = []
     updated_refs: list[XTraceMemoryRef] = []
@@ -657,14 +739,23 @@ def _existing_timeline(memory: Memory) -> list[dict[str, Any]]:
 def _result_from_remote(
     remote: XTraceRemoteIngest,
     mirrored_count: int,
+    *,
+    clawdi_metadata: dict[str, Any] | None = None,
 ) -> XTraceMemoryIngestResult:
+    response = dict(remote.payload)
+    if clawdi_metadata is not None:
+        existing = response.get("_clawdi")
+        response["_clawdi"] = {
+            **(existing if isinstance(existing, dict) else {}),
+            **clawdi_metadata,
+        }
     return XTraceMemoryIngestResult(
         job_id=_string_or_none(remote.payload.get("id")),
         status=_string_or_none(remote.payload.get("status")),
         created_ref_count=len(remote.created_refs),
         updated_ref_count=len(remote.updated_refs),
         mirrored_count=mirrored_count,
-        response=remote.payload,
+        response=response,
     )
 
 

--- a/backend/app/services/xtrace_memory.py
+++ b/backend/app/services/xtrace_memory.py
@@ -1,11 +1,13 @@
-"""XTrace Memory API integration for cloud session uploads."""
+"""XTrace Memory API integration for Clawdi sessions and skills."""
 
 from __future__ import annotations
 
 import json
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
+from uuid import UUID
 
 import httpx
 from sqlalchemy import select
@@ -14,12 +16,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.models.memory import Memory
 from app.models.session import Session
+from app.models.skill import Skill
 from app.models.xtrace_ingest import XTraceMemoryIngest
+from app.services.skill_index import SkillTextFile, extract_skill_text_files
 
 log = logging.getLogger(__name__)
 
 _XTRACE_ROLES = {"user", "assistant", "system"}
-_SOURCE = "xtrace_session"
+_SESSION_SOURCE = "xtrace_session"
+_SKILL_SOURCE = "xtrace_skill"
+_MAX_SKILL_FILE_CHARS = 24_000
+_MAX_SKILL_INGEST_CHARS = 160_000
 
 
 @dataclass(frozen=True)
@@ -54,6 +61,15 @@ def xtrace_memory_configured() -> bool:
     )
 
 
+def xtrace_session_source_key(session: Session) -> str:
+    version = session.content_hash or session.local_session_id
+    return f"session:{session.id}:{version}"
+
+
+def xtrace_skill_source_key(skill: Skill) -> str:
+    return f"skill:{skill.id}:{skill.content_hash}"
+
+
 async def ingest_xtrace_session_memories(
     db: AsyncSession,
     *,
@@ -73,22 +89,33 @@ async def ingest_xtrace_session_memories(
     if not normalized:
         return None
 
-    remote = await _ingest(normalized, session=session)
+    source_key = xtrace_session_source_key(session)
+    remote = await _ingest(_build_session_payload(session, normalized))
     refs = [*remote.created_refs, *remote.updated_refs]
-    mirrored_count = await _store_refs(db, session=session, refs=refs) if refs else 0
-    result = XTraceMemoryIngestResult(
-        job_id=_string_or_none(remote.payload.get("id")),
-        status=_string_or_none(remote.payload.get("status")),
-        created_ref_count=len(remote.created_refs),
-        updated_ref_count=len(remote.updated_refs),
-        mirrored_count=mirrored_count,
-        response=remote.payload,
+    mirrored_count = (
+        await _store_refs(
+            db,
+            user_id=session.user_id,
+            source=_SESSION_SOURCE,
+            source_session_id=session.id,
+            refs=refs,
+            metadata={
+                "source_type": "session",
+                "source_key": source_key,
+                "local_session_id": session.local_session_id,
+            },
+        )
+        if refs
+        else 0
     )
+    result = _result_from_remote(remote, mirrored_count)
     db.add(
         XTraceMemoryIngest(
             user_id=session.user_id,
+            source_type="session",
             session_id=session.id,
             local_session_id=session.local_session_id,
+            source_key=source_key,
             job_id=result.job_id,
             status=result.status,
             created_ref_count=result.created_ref_count,
@@ -101,28 +128,191 @@ async def ingest_xtrace_session_memories(
     return result
 
 
-async def _ingest(messages: list[dict[str, str]], *, session: Session) -> XTraceRemoteIngest:
+async def ingest_xtrace_skill_memories(
+    db: AsyncSession,
+    *,
+    skill: Skill,
+    data: bytes,
+) -> XTraceMemoryIngestResult | None:
+    """Send a skill archive to XTrace as an artifact-shaped memory source."""
+    if not xtrace_memory_configured():
+        return None
+
+    text_files = extract_skill_text_files(data, skill.skill_key)
+    if not text_files:
+        return None
+
+    source_key = xtrace_skill_source_key(skill)
+    remote = await _ingest(_build_skill_payload(skill, text_files))
+    refs = [*remote.created_refs, *remote.updated_refs]
+    mirrored_count = (
+        await _store_refs(
+            db,
+            user_id=skill.user_id,
+            source=_SKILL_SOURCE,
+            source_session_id=None,
+            refs=refs,
+            metadata={
+                "source_type": "skill",
+                "source_key": source_key,
+                "skill_id": str(skill.id),
+                "skill_key": skill.skill_key,
+                "content_hash": skill.content_hash,
+            },
+        )
+        if refs
+        else 0
+    )
+    result = _result_from_remote(remote, mirrored_count)
+    db.add(
+        XTraceMemoryIngest(
+            user_id=skill.user_id,
+            source_type="skill",
+            skill_id=skill.id,
+            source_key=source_key,
+            job_id=result.job_id,
+            status=result.status,
+            created_ref_count=result.created_ref_count,
+            updated_ref_count=result.updated_ref_count,
+            mirrored_count=result.mirrored_count,
+            response=result.response,
+        )
+    )
+    await db.commit()
+    return result
+
+
+def _build_session_payload(
+    session: Session,
+    messages: list[dict[str, str]],
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "messages": [_session_context_message(session), *messages],
+        "user_id": str(session.user_id),
+        "conv_id": str(session.id),
+        "app_id": settings.xtrace_memory_app_id,
+        "extract_artifacts": True,
+        "metadata": {
+            "source": "clawdi_cloud_session",
+            "source_type": "session",
+            "source_key": xtrace_session_source_key(session),
+            "local_session_id": session.local_session_id,
+            "project_path": session.project_path,
+            "content_hash": session.content_hash,
+            "summary": session.summary,
+            "message_count": session.message_count,
+            "started_at": _iso_or_none(session.started_at),
+            "ended_at": _iso_or_none(session.ended_at),
+            "last_activity_at": _iso_or_none(session.last_activity_at),
+            "model": session.model,
+            "models_used": session.models_used,
+            "tags": session.tags,
+            "related_refs": session.related_refs,
+        },
+    }
+    if session.environment_id is not None:
+        body["agent_id"] = str(session.environment_id)
+        body["metadata"]["agent_environment_id"] = str(session.environment_id)
+    return body
+
+
+def _session_context_message(session: Session) -> dict[str, str]:
+    parts = [
+        "Clawdi Cloud session context.",
+        "The following messages are from an AI coding or operations agent "
+        "session synced to Clawdi.",
+        "Extract durable beliefs, decisions, preferences, project facts, episodes, and artifacts.",
+        "Ignore transient shell output unless it establishes a reusable "
+        "decision, result, or failure mode.",
+    ]
+    if session.project_path:
+        parts.append(f"Project path: {session.project_path}")
+    if session.summary:
+        parts.append(f"Session summary: {session.summary}")
+    return {"role": "system", "content": "\n".join(parts)}
+
+
+def _build_skill_payload(skill: Skill, text_files: list[SkillTextFile]) -> dict[str, Any]:
+    messages = _skill_messages(skill, text_files)
+    return {
+        "messages": messages,
+        "user_id": str(skill.user_id),
+        "conv_id": f"skill:{skill.id}:{skill.content_hash[:12]}",
+        "app_id": settings.xtrace_memory_app_id,
+        "extract_artifacts": True,
+        "metadata": {
+            "source": "clawdi_cloud_skill",
+            "source_type": "skill",
+            "source_key": xtrace_skill_source_key(skill),
+            "skill_id": str(skill.id),
+            "skill_key": skill.skill_key,
+            "name": skill.name,
+            "description": skill.description,
+            "version": skill.version,
+            "project_id": str(skill.project_id),
+            "source_repo": skill.source_repo,
+            "content_hash": skill.content_hash,
+            "file_count": skill.file_count,
+            "agent_types": skill.agent_types,
+        },
+    }
+
+
+def _skill_messages(skill: Skill, text_files: list[SkillTextFile]) -> list[dict[str, str]]:
+    messages = [
+        {
+            "role": "system",
+            "content": "\n".join(
+                [
+                    "Clawdi Cloud skill bundle context.",
+                    "The following files define an agent skill available in Clawdi.",
+                    "Extract the reusable workflow, operating constraints, "
+                    "artifact content, and when the skill should be used.",
+                    "Treat SKILL.md and reference files as durable artifacts, not casual chat.",
+                ]
+            ),
+        },
+        {
+            "role": "user",
+            "content": "\n".join(
+                [
+                    "Skill metadata:",
+                    f"key: {skill.skill_key}",
+                    f"name: {skill.name}",
+                    f"description: {skill.description or ''}",
+                    f"version: {skill.version}",
+                    f"source: {skill.source}",
+                    f"project_id: {skill.project_id}",
+                    f"content_hash: {skill.content_hash}",
+                ]
+            ),
+        },
+    ]
+
+    used_chars = sum(len(m["content"]) for m in messages)
+    for text_file in text_files:
+        if used_chars >= _MAX_SKILL_INGEST_CHARS:
+            break
+        remaining = _MAX_SKILL_INGEST_CHARS - used_chars
+        content = text_file.content[: min(_MAX_SKILL_FILE_CHARS, remaining)]
+        if len(text_file.content) > len(content):
+            content = f"{content}\n\n[truncated]"
+        message = {
+            "role": "user",
+            "content": f"Skill file: {text_file.path}\n\n{content}",
+        }
+        messages.append(message)
+        used_chars += len(message["content"])
+    return messages
+
+
+async def _ingest(body: dict[str, Any]) -> XTraceRemoteIngest:
     url = f"{settings.xtrace_memory_base_url.rstrip('/')}/v1/memories"
     headers = {
         "Authorization": f"Bearer {settings.xtrace_api_key}",
         "X-Org-Id": settings.xtrace_org_id,
         "Accept": "application/json",
     }
-    body: dict[str, Any] = {
-        "messages": messages,
-        "user_id": str(session.user_id),
-        "conv_id": str(session.id),
-        "app_id": settings.xtrace_memory_app_id,
-        "extract_artifacts": False,
-        "metadata": {
-            "source": "clawdi_cloud_session",
-            "local_session_id": session.local_session_id,
-            "project_path": session.project_path,
-            "content_hash": session.content_hash,
-        },
-    }
-    if session.environment_id is not None:
-        body["agent_id"] = str(session.environment_id)
 
     async with httpx.AsyncClient(timeout=settings.xtrace_memory_timeout_seconds) as client:
         response = await client.post(
@@ -164,6 +354,9 @@ def _normalize_messages(messages: list[dict[str, Any]]) -> list[dict[str, str]]:
         date = message.get("date") or message.get("timestamp") or message.get("created_at")
         if isinstance(date, str) and date:
             item["date"] = date
+        dia_id = message.get("dia_id") or message.get("id")
+        if isinstance(dia_id, str) and dia_id:
+            item["dia_id"] = dia_id
         normalized.append(item)
     return normalized
 
@@ -228,23 +421,26 @@ def _parse_ref(raw: Any) -> XTraceMemoryRef | None:
 async def _store_refs(
     db: AsyncSession,
     *,
-    session: Session,
+    user_id: UUID,
+    source: str,
+    source_session_id: UUID | None,
     refs: list[XTraceMemoryRef],
+    metadata: dict[str, Any],
 ) -> int:
     if not refs:
         return 0
 
     texts = [r.text for r in refs]
-    existing = (
-        await db.execute(
-            select(Memory.content).where(
-                Memory.user_id == session.user_id,
-                Memory.source_session_id == session.id,
-                Memory.source == _SOURCE,
-                Memory.content.in_(texts),
-            )
-        )
-    ).scalars()
+    stmt = select(Memory.content).where(
+        Memory.user_id == user_id,
+        Memory.source == source,
+        Memory.content.in_(texts),
+    )
+    if source_session_id is None:
+        stmt = stmt.where(Memory.source_session_id.is_(None))
+    else:
+        stmt = stmt.where(Memory.source_session_id == source_session_id)
+    existing = (await db.execute(stmt)).scalars()
     existing_texts = set(existing.all())
 
     created = 0
@@ -253,13 +449,17 @@ async def _store_refs(
             continue
         db.add(
             Memory(
-                user_id=session.user_id,
+                user_id=user_id,
                 content=ref.text,
                 category=_category_for_xtrace_type(ref.type),
-                source=_SOURCE,
-                source_session_id=session.id,
-                tags=["xtrace", f"xtrace:{ref.type}"],
-                metadata_={"xtrace_memory_id": ref.id, "xtrace_type": ref.type},
+                source=source,
+                source_session_id=source_session_id,
+                tags=["xtrace", f"xtrace:{ref.type}", source],
+                metadata_={
+                    **metadata,
+                    "xtrace_memory_id": ref.id,
+                    "xtrace_type": ref.type,
+                },
             )
         )
         existing_texts.add(ref.text)
@@ -270,10 +470,32 @@ async def _store_refs(
     return created
 
 
+def _result_from_remote(
+    remote: XTraceRemoteIngest,
+    mirrored_count: int,
+) -> XTraceMemoryIngestResult:
+    return XTraceMemoryIngestResult(
+        job_id=_string_or_none(remote.payload.get("id")),
+        status=_string_or_none(remote.payload.get("status")),
+        created_ref_count=len(remote.created_refs),
+        updated_ref_count=len(remote.updated_refs),
+        mirrored_count=mirrored_count,
+        response=remote.payload,
+    )
+
+
 def _category_for_xtrace_type(memory_type: str) -> str:
     if memory_type == "fact":
         return "fact"
+    if memory_type == "artifact":
+        return "artifact"
     return "context"
+
+
+def _iso_or_none(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.isoformat()
 
 
 def _string_or_none(value: Any) -> str | None:

--- a/backend/app/services/xtrace_memory.py
+++ b/backend/app/services/xtrace_memory.py
@@ -12,6 +12,7 @@ from uuid import UUID
 import httpx
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import flag_modified
 
 from app.core.config import settings
 from app.models.memory import Memory
@@ -34,6 +35,11 @@ class XTraceMemoryRef:
     id: str
     type: str
     text: str
+    status: str | None = None
+    operation: str | None = None
+    supersedes: list[str] | None = None
+    superseded_by: str | None = None
+    created_at: str | None = None
 
 
 @dataclass(frozen=True)
@@ -41,6 +47,7 @@ class XTraceRemoteIngest:
     payload: dict[str, Any]
     created_refs: list[XTraceMemoryRef]
     updated_refs: list[XTraceMemoryRef]
+    memories_superseded_by: dict[str, str]
 
 
 @dataclass(frozen=True)
@@ -364,11 +371,13 @@ def _normalize_messages(messages: list[dict[str, Any]]) -> list[dict[str, str]]:
 def _extract_remote_ingest(payload: dict[str, Any]) -> XTraceRemoteIngest:
     created_refs: list[XTraceMemoryRef] = []
     updated_refs: list[XTraceMemoryRef] = []
+    memories_superseded_by: dict[str, str] = {}
 
     result = payload.get("result")
     if isinstance(result, dict):
         created_refs.extend(_parse_ref_list(result.get("memories_created")))
         updated_refs.extend(_parse_ref_list(result.get("memories_updated")))
+        memories_superseded_by = _parse_superseded_by(result.get("memories_superseded_by"))
 
     # Older quickstart-style response: {"results": [{data: {memory: "..."}}]}.
     raw_results = payload.get("results")
@@ -389,8 +398,9 @@ def _extract_remote_ingest(payload: dict[str, Any]) -> XTraceRemoteIngest:
 
     return XTraceRemoteIngest(
         payload=payload,
-        created_refs=created_refs,
-        updated_refs=updated_refs,
+        created_refs=_with_lineage(created_refs, "add", memories_superseded_by),
+        updated_refs=_with_lineage(updated_refs, "update", memories_superseded_by),
+        memories_superseded_by=memories_superseded_by,
     )
 
 
@@ -415,7 +425,51 @@ def _parse_ref(raw: Any) -> XTraceMemoryRef | None:
         id=str(raw.get("id") or ""),
         type=str(raw.get("type") or "fact"),
         text=text.strip(),
+        status=_string_or_none(raw.get("status")) or "active",
+        operation=_string_or_none(raw.get("operation")),
+        supersedes=_string_list(raw.get("supersedes")),
+        superseded_by=_string_or_none(raw.get("superseded_by")),
+        created_at=_string_or_none(raw.get("created_at")),
     )
+
+
+def _parse_superseded_by(raw: Any) -> dict[str, str]:
+    if not isinstance(raw, dict):
+        return {}
+    out: dict[str, str] = {}
+    for old_id, new_id in raw.items():
+        if old_id and new_id:
+            out[str(old_id)] = str(new_id)
+    return out
+
+
+def _with_lineage(
+    refs: list[XTraceMemoryRef],
+    operation: str,
+    superseded_by: dict[str, str],
+) -> list[XTraceMemoryRef]:
+    if not refs:
+        return []
+    supersedes_by_new_id: dict[str, list[str]] = {}
+    for old_id, new_id in superseded_by.items():
+        supersedes_by_new_id.setdefault(new_id, []).append(old_id)
+
+    out: list[XTraceMemoryRef] = []
+    for ref in refs:
+        supersedes = [*(ref.supersedes or []), *supersedes_by_new_id.get(ref.id, [])]
+        out.append(
+            XTraceMemoryRef(
+                id=ref.id,
+                type=ref.type,
+                text=ref.text,
+                status=ref.status or "active",
+                operation=ref.operation or operation,
+                supersedes=supersedes,
+                superseded_by=ref.superseded_by,
+                created_at=ref.created_at,
+            )
+        )
+    return out
 
 
 async def _store_refs(
@@ -431,7 +485,9 @@ async def _store_refs(
         return 0
 
     texts = [r.text for r in refs]
-    stmt = select(Memory.content).where(
+    await _mark_superseded_refs(db, user_id=user_id, source=source, refs=refs)
+
+    stmt = select(Memory).where(
         Memory.user_id == user_id,
         Memory.source == source,
         Memory.content.in_(texts),
@@ -440,11 +496,23 @@ async def _store_refs(
         stmt = stmt.where(Memory.source_session_id.is_(None))
     else:
         stmt = stmt.where(Memory.source_session_id == source_session_id)
-    existing = (await db.execute(stmt)).scalars()
-    existing_texts = set(existing.all())
+    existing = (await db.execute(stmt)).scalars().all()
+    existing_by_text = {m.content: m for m in existing}
+    existing_texts = set(existing_by_text)
 
     created = 0
     for ref in refs:
+        metadata_ = _memory_metadata(metadata, ref)
+        existing_memory = existing_by_text.get(ref.text)
+        if existing_memory is not None:
+            existing_memory.category = _category_for_xtrace_type(ref.type)
+            existing_memory.tags = ["xtrace", f"xtrace:{ref.type}", source]
+            existing_memory.metadata_ = {
+                **(existing_memory.metadata_ or {}),
+                **metadata_,
+            }
+            flag_modified(existing_memory, "metadata_")
+            continue
         if ref.text in existing_texts:
             continue
         db.add(
@@ -455,11 +523,7 @@ async def _store_refs(
                 source=source,
                 source_session_id=source_session_id,
                 tags=["xtrace", f"xtrace:{ref.type}", source],
-                metadata_={
-                    **metadata,
-                    "xtrace_memory_id": ref.id,
-                    "xtrace_type": ref.type,
-                },
+                metadata_=metadata_,
             )
         )
         existing_texts.add(ref.text)
@@ -468,6 +532,88 @@ async def _store_refs(
     if created:
         await db.flush()
     return created
+
+
+async def _mark_superseded_refs(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    source: str,
+    refs: list[XTraceMemoryRef],
+) -> None:
+    superseded_pairs: list[tuple[str, str]] = []
+    for ref in refs:
+        if not ref.id:
+            continue
+        for old_id in ref.supersedes or []:
+            superseded_pairs.append((old_id, ref.id))
+    if not superseded_pairs:
+        return
+
+    superseded_by = dict(superseded_pairs)
+    old_ids = list(superseded_by)
+    rows = (
+        (
+            await db.execute(
+                select(Memory).where(
+                    Memory.user_id == user_id,
+                    Memory.source == source,
+                    Memory.metadata_["xtrace_memory_id"].astext.in_(old_ids),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for memory in rows:
+        metadata = dict(memory.metadata_ or {})
+        remote_id = _string_or_none(metadata.get("xtrace_memory_id"))
+        if remote_id is None:
+            continue
+        metadata["xtrace_status"] = "superseded"
+        metadata["xtrace_superseded_by"] = superseded_by.get(remote_id)
+        metadata["xtrace_timeline"] = [
+            *_existing_timeline(memory),
+            {
+                "operation": "superseded",
+                "content": memory.content,
+                "memory_id": remote_id,
+                "status": "superseded",
+                "at": None,
+            },
+        ]
+        memory.metadata_ = metadata
+        flag_modified(memory, "metadata_")
+
+
+def _memory_metadata(metadata: dict[str, Any], ref: XTraceMemoryRef) -> dict[str, Any]:
+    return {
+        **metadata,
+        "xtrace_memory_id": ref.id,
+        "xtrace_type": ref.type,
+        "xtrace_status": ref.status or "active",
+        "xtrace_operation": ref.operation or "add",
+        "xtrace_supersedes": ref.supersedes or [],
+        "xtrace_superseded_by": ref.superseded_by,
+        "xtrace_created_at": ref.created_at,
+        "xtrace_timeline": [
+            {
+                "operation": ref.operation or "add",
+                "content": ref.text,
+                "memory_id": ref.id,
+                "status": ref.status or "active",
+                "at": ref.created_at,
+            }
+        ],
+    }
+
+
+def _existing_timeline(memory: Memory) -> list[dict[str, Any]]:
+    metadata = memory.metadata_ if isinstance(memory.metadata_, dict) else {}
+    raw = metadata.get("xtrace_timeline")
+    if isinstance(raw, list):
+        return [item for item in raw if isinstance(item, dict)]
+    return []
 
 
 def _result_from_remote(
@@ -501,4 +647,13 @@ def _iso_or_none(value: datetime | None) -> str | None:
 def _string_or_none(value: Any) -> str | None:
     if value is None:
         return None
-    return str(value)
+    text = str(value)
+    return text if text else None
+
+
+def _string_list(value: Any) -> list[str]:
+    if isinstance(value, str) and value:
+        return [value]
+    if isinstance(value, list):
+        return [str(v) for v in value if v]
+    return []

--- a/backend/app/services/xtrace_memory.py
+++ b/backend/app/services/xtrace_memory.py
@@ -29,6 +29,7 @@ _SESSION_SOURCE = "xtrace_session"
 _SKILL_SOURCE = "xtrace_skill"
 _MAX_SKILL_FILE_CHARS = 24_000
 _MAX_SKILL_INGEST_CHARS = 160_000
+_MAX_SKILL_FILES = 20
 _INGEST_RETRY_STATUSES = {429, 500, 502, 503, 504}
 _INGEST_MAX_ATTEMPTS = 5
 
@@ -85,6 +86,7 @@ async def ingest_xtrace_session_memories(
     *,
     session: Session,
     messages: list[dict[str, Any]],
+    max_messages: int | None = None,
 ) -> XTraceMemoryIngestResult | None:
     """Send session messages to XTrace and mirror returned memory refs.
 
@@ -95,7 +97,7 @@ async def ingest_xtrace_session_memories(
     if not xtrace_memory_configured():
         return None
 
-    normalized = _normalize_messages(messages)
+    normalized = _normalize_messages(messages, max_messages=max_messages)
     if not normalized:
         return None
 
@@ -300,7 +302,7 @@ def _skill_messages(skill: Skill, text_files: list[SkillTextFile]) -> list[dict[
     ]
 
     used_chars = sum(len(m["content"]) for m in messages)
-    for text_file in text_files:
+    for text_file in text_files[:_MAX_SKILL_FILES]:
         if used_chars >= _MAX_SKILL_INGEST_CHARS:
             break
         remaining = _MAX_SKILL_INGEST_CHARS - used_chars
@@ -364,9 +366,13 @@ def _retry_delay_seconds(response: httpx.Response, attempt: int) -> float:
     return min(2.0 * (2 ** (attempt - 1)), 30.0)
 
 
-def _normalize_messages(messages: list[dict[str, Any]]) -> list[dict[str, str]]:
-    max_messages = max(1, settings.xtrace_memory_max_messages)
-    selected = messages[-max_messages:] if len(messages) > max_messages else messages
+def _normalize_messages(
+    messages: list[dict[str, Any]],
+    *,
+    max_messages: int | None = None,
+) -> list[dict[str, str]]:
+    message_limit = max(1, max_messages or settings.xtrace_memory_max_messages)
+    selected = messages[-message_limit:] if len(messages) > message_limit else messages
     normalized: list[dict[str, str]] = []
     for message in selected:
         if not isinstance(message, dict):

--- a/backend/scripts/backfill_xtrace_memory.py
+++ b/backend/scripts/backfill_xtrace_memory.py
@@ -1,0 +1,279 @@
+"""Backfill stored Clawdi sessions and skills into XTrace Memory.
+
+Usage:
+    pdm run python -m scripts.backfill_xtrace_memory --all
+    pdm run python -m scripts.backfill_xtrace_memory --sessions --limit 100
+    pdm run python -m scripts.backfill_xtrace_memory --skills --force
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.core.database import engine
+from app.models.session import Session
+from app.models.skill import Skill
+from app.models.xtrace_ingest import XTraceMemoryIngest
+from app.services.file_store import get_file_store
+from app.services.xtrace_memory import (
+    ingest_xtrace_session_memories,
+    ingest_xtrace_skill_memories,
+    xtrace_memory_configured,
+    xtrace_session_source_key,
+    xtrace_skill_source_key,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("backfill-xtrace-memory")
+
+
+@dataclass
+class Totals:
+    considered: int = 0
+    sent: int = 0
+    skipped: int = 0
+    failed: int = 0
+    mirrored: int = 0
+
+
+async def run(
+    *,
+    include_sessions: bool,
+    include_skills: bool,
+    user_id: uuid.UUID | None,
+    limit: int | None,
+    force: bool,
+    dry_run: bool,
+) -> int:
+    if not xtrace_memory_configured():
+        log.error(
+            "XTrace memory is not configured. Set XTRACE_MEMORY_ENABLED=true, "
+            "XTRACE_API_KEY, and XTRACE_ORG_ID."
+        )
+        return 2
+
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+    async with SessionLocal() as db:
+        totals = Totals()
+        if include_sessions:
+            session_totals = await _backfill_sessions(
+                db,
+                user_id=user_id,
+                limit=limit,
+                force=force,
+                dry_run=dry_run,
+            )
+            _merge_totals(totals, session_totals)
+        if include_skills:
+            skill_totals = await _backfill_skills(
+                db,
+                user_id=user_id,
+                limit=limit,
+                force=force,
+                dry_run=dry_run,
+            )
+            _merge_totals(totals, skill_totals)
+
+    log.info(
+        "done considered=%s sent=%s skipped=%s failed=%s mirrored=%s dry_run=%s",
+        totals.considered,
+        totals.sent,
+        totals.skipped,
+        totals.failed,
+        totals.mirrored,
+        dry_run,
+    )
+    return 1 if totals.failed else 0
+
+
+async def _backfill_sessions(
+    db,
+    *,
+    user_id: uuid.UUID | None,
+    limit: int | None,
+    force: bool,
+    dry_run: bool,
+) -> Totals:
+    totals = Totals()
+    stmt = select(Session).where(Session.file_key.is_not(None))
+    if user_id is not None:
+        stmt = stmt.where(Session.user_id == user_id)
+    stmt = stmt.order_by(Session.last_activity_at.desc())
+    if limit is not None:
+        stmt = stmt.limit(limit)
+
+    sessions = (await db.execute(stmt)).scalars().all()
+    file_store = get_file_store()
+    for session in sessions:
+        totals.considered += 1
+        source_key = xtrace_session_source_key(session)
+        if not force and await _already_ingested(db, "session", source_key):
+            totals.skipped += 1
+            continue
+        if dry_run:
+            totals.skipped += 1
+            log.info(
+                "dry_run session local_session_id=%s source_key=%s",
+                session.local_session_id,
+                source_key,
+            )
+            continue
+
+        try:
+            data = await file_store.get(session.file_key)
+            parsed = json.loads(data)
+            if not isinstance(parsed, list):
+                raise ValueError("session content is not a JSON message list")
+            messages: list[dict[str, Any]] = [m for m in parsed if isinstance(m, dict)]
+            result = await ingest_xtrace_session_memories(db, session=session, messages=messages)
+        except Exception:
+            await db.rollback()
+            totals.failed += 1
+            log.exception("session_backfill_failed local_session_id=%s", session.local_session_id)
+            continue
+        if result is None:
+            totals.skipped += 1
+            continue
+        totals.sent += 1
+        totals.mirrored += result.mirrored_count
+        log.info(
+            "session_backfilled local_session_id=%s job_id=%s status=%s "
+            "created=%s updated=%s mirrored=%s",
+            session.local_session_id,
+            result.job_id,
+            result.status,
+            result.created_ref_count,
+            result.updated_ref_count,
+            result.mirrored_count,
+        )
+    return totals
+
+
+async def _backfill_skills(
+    db,
+    *,
+    user_id: uuid.UUID | None,
+    limit: int | None,
+    force: bool,
+    dry_run: bool,
+) -> Totals:
+    totals = Totals()
+    stmt = select(Skill).where(Skill.is_active.is_(True), Skill.file_key.is_not(None))
+    if user_id is not None:
+        stmt = stmt.where(Skill.user_id == user_id)
+    stmt = stmt.order_by(Skill.updated_at.desc())
+    if limit is not None:
+        stmt = stmt.limit(limit)
+
+    skills = (await db.execute(stmt)).scalars().all()
+    file_store = get_file_store()
+    for skill in skills:
+        totals.considered += 1
+        source_key = xtrace_skill_source_key(skill)
+        if not force and await _already_ingested(db, "skill", source_key):
+            totals.skipped += 1
+            continue
+        if dry_run:
+            totals.skipped += 1
+            log.info("dry_run skill skill_key=%s source_key=%s", skill.skill_key, source_key)
+            continue
+
+        try:
+            data = await file_store.get(skill.file_key)
+            result = await ingest_xtrace_skill_memories(db, skill=skill, data=data)
+        except Exception:
+            await db.rollback()
+            totals.failed += 1
+            log.exception("skill_backfill_failed skill_key=%s", skill.skill_key)
+            continue
+        if result is None:
+            totals.skipped += 1
+            continue
+        totals.sent += 1
+        totals.mirrored += result.mirrored_count
+        log.info(
+            "skill_backfilled skill_key=%s job_id=%s status=%s created=%s updated=%s mirrored=%s",
+            skill.skill_key,
+            result.job_id,
+            result.status,
+            result.created_ref_count,
+            result.updated_ref_count,
+            result.mirrored_count,
+        )
+    return totals
+
+
+async def _already_ingested(db, source_type: str, source_key: str) -> bool:
+    row = (
+        await db.execute(
+            select(XTraceMemoryIngest.id)
+            .where(
+                XTraceMemoryIngest.source_type == source_type,
+                XTraceMemoryIngest.source_key == source_key,
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    return row is not None
+
+
+def _merge_totals(target: Totals, source: Totals) -> None:
+    target.considered += source.considered
+    target.sent += source.sent
+    target.skipped += source.skipped
+    target.failed += source.failed
+    target.mirrored += source.mirrored
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    mode = ap.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--all", action="store_true", help="Backfill sessions and skills.")
+    mode.add_argument("--sessions", action="store_true", help="Backfill sessions only.")
+    mode.add_argument("--skills", action="store_true", help="Backfill skills only.")
+    ap.add_argument("--user-id", type=str, help="Limit backfill to one Clawdi user UUID.")
+    ap.add_argument("--limit", type=int, help="Maximum rows per selected source type.")
+    ap.add_argument("--force", action="store_true", help="Re-send rows already audited.")
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print candidates without calling XTrace.",
+    )
+    args = ap.parse_args()
+
+    user_id: uuid.UUID | None = None
+    try:
+        if args.user_id:
+            user_id = uuid.UUID(args.user_id)
+    except ValueError:
+        log.error("invalid --user-id UUID")
+        sys.exit(2)
+
+    include_sessions = args.all or args.sessions
+    include_skills = args.all or args.skills
+    sys.exit(
+        asyncio.run(
+            run(
+                include_sessions=include_sessions,
+                include_skills=include_skills,
+                user_id=user_id,
+                limit=args.limit,
+                force=args.force,
+                dry_run=args.dry_run,
+            )
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/debug_xtrace_session_ingest.py
+++ b/backend/scripts/debug_xtrace_session_ingest.py
@@ -1,0 +1,134 @@
+"""Ingest one stored session into XTrace Memory and print the result.
+
+Use this in local or Coolify preview to answer: did the backend call XTrace,
+what job id/status came back, and how many memories were mirrored locally?
+
+Usage:
+    pdm run python -m scripts.debug_xtrace_session_ingest --session-id <uuid>
+    pdm run python -m scripts.debug_xtrace_session_ingest --local-session-id <id> --user-id <uuid>
+    pdm run python -m scripts.debug_xtrace_session_ingest --session-id <uuid> --print-response
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.core.database import engine
+from app.models.session import Session
+from app.services.file_store import get_file_store
+from app.services.xtrace_memory import ingest_xtrace_session_memories, xtrace_memory_configured
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("debug-xtrace-session-ingest")
+
+
+async def run(
+    *,
+    session_id: uuid.UUID | None,
+    local_session_id: str | None,
+    user_id: uuid.UUID | None,
+    print_response: bool,
+) -> int:
+    if not xtrace_memory_configured():
+        log.error(
+            "XTrace memory is not configured. Set XTRACE_MEMORY_ENABLED=true, "
+            "XTRACE_API_KEY, and XTRACE_ORG_ID."
+        )
+        return 2
+
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+    async with SessionLocal() as db:
+        stmt = select(Session)
+        if session_id is not None:
+            stmt = stmt.where(Session.id == session_id)
+        else:
+            stmt = stmt.where(Session.local_session_id == local_session_id)
+            if user_id is not None:
+                stmt = stmt.where(Session.user_id == user_id)
+        rows = (await db.execute(stmt.limit(2))).scalars().all()
+        if not rows:
+            log.error("session not found")
+            return 1
+        if len(rows) > 1:
+            log.error("local_session_id is ambiguous; pass --user-id or use --session-id")
+            return 1
+
+        session = rows[0]
+        if not session.file_key:
+            log.error("session %s has no uploaded content file", session.id)
+            return 1
+
+        data = await get_file_store().get(session.file_key)
+        try:
+            parsed = json.loads(data)
+        except json.JSONDecodeError:
+            log.error("session %s content is not valid JSON", session.id)
+            return 1
+        if not isinstance(parsed, list):
+            log.error("session %s content is not a JSON message list", session.id)
+            return 1
+
+        messages: list[dict[str, Any]] = [m for m in parsed if isinstance(m, dict)]
+        result = await ingest_xtrace_session_memories(db, session=session, messages=messages)
+        if result is None:
+            log.error("XTrace ingest skipped; no normalized messages or configuration missing")
+            return 1
+
+    output: dict[str, Any] = {
+        "session_id": str(session.id),
+        "local_session_id": session.local_session_id,
+        "job_id": result.job_id,
+        "status": result.status,
+        "created_ref_count": result.created_ref_count,
+        "updated_ref_count": result.updated_ref_count,
+        "mirrored_count": result.mirrored_count,
+    }
+    if print_response:
+        output["response"] = result.response
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--session-id", type=str, help="Cloud Session.id UUID.")
+    g.add_argument("--local-session-id", type=str, help="Client local_session_id.")
+    ap.add_argument("--user-id", type=str, help="Required if local_session_id is ambiguous.")
+    ap.add_argument("--print-response", action="store_true", help="Include XTrace response JSON.")
+    args = ap.parse_args()
+
+    session_id: uuid.UUID | None = None
+    user_id: uuid.UUID | None = None
+    try:
+        if args.session_id:
+            session_id = uuid.UUID(args.session_id)
+        if args.user_id:
+            user_id = uuid.UUID(args.user_id)
+    except ValueError:
+        log.error("invalid UUID argument")
+        sys.exit(2)
+
+    sys.exit(
+        asyncio.run(
+            run(
+                session_id=session_id,
+                local_session_id=args.local_session_id,
+                user_id=user_id,
+                print_response=args.print_response,
+            )
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/reindex_skill_chunks.py
+++ b/backend/scripts/reindex_skill_chunks.py
@@ -1,0 +1,132 @@
+"""Rebuild searchable skill chunks from stored skill archives.
+
+Runs after deploying the skill_chunks migration so existing cloud skill files
+become searchable by file content. New uploads and installs index themselves.
+
+Usage:
+    pdm run python -m scripts.reindex_skill_chunks --all
+    pdm run python -m scripts.reindex_skill_chunks --user-id <uuid>
+    pdm run python -m scripts.reindex_skill_chunks --all --force
+    pdm run python -m scripts.reindex_skill_chunks --all --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.core.database import engine
+from app.models.skill import Skill
+from app.models.skill_chunk import SkillChunk
+from app.services.file_store import get_file_store
+from app.services.skill_index import index_skill_archive
+from app.services.tar_utils import tar_from_content
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("reindex-skill-chunks")
+
+
+async def reindex(user_id: uuid.UUID | None, force: bool, dry_run: bool) -> None:
+    file_store = get_file_store()
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    current_chunk_exists = (
+        select(SkillChunk.id)
+        .where(
+            SkillChunk.skill_id == Skill.id,
+            SkillChunk.content_hash == Skill.content_hash,
+        )
+        .exists()
+    )
+    id_query = select(Skill.id).where(
+        Skill.is_active,
+        Skill.file_key.is_not(None),
+    )
+    if user_id is not None:
+        id_query = id_query.where(Skill.user_id == user_id)
+    if not force:
+        id_query = id_query.where(~current_chunk_exists)
+    id_query = id_query.order_by(Skill.created_at.asc())
+
+    async with SessionLocal() as db:
+        target_ids = (await db.execute(id_query)).scalars().all()
+
+    log.info("found %d skill(s) needing chunk indexing", len(target_ids))
+    if dry_run or not target_ids:
+        if dry_run:
+            log.info("dry-run: would reindex %d skill(s); no writes performed", len(target_ids))
+        return
+
+    processed = 0
+    failed = 0
+    for skill_id in target_ids:
+        async with SessionLocal() as db:
+            skill = (
+                await db.execute(
+                    select(Skill).where(
+                        Skill.id == skill_id,
+                        Skill.is_active,
+                        Skill.file_key.is_not(None),
+                    )
+                )
+            ).scalar_one_or_none()
+            if skill is None or skill.file_key is None:
+                continue
+
+            try:
+                data = await file_store.get(skill.file_key)
+                if skill.file_key.endswith(".md"):
+                    data, _ = tar_from_content(skill.skill_key, data.decode("utf-8"))
+                chunks = await index_skill_archive(db, skill, data)
+                await db.commit()
+                processed += 1
+                log.info("indexed skill=%s chunks=%d", skill.id, chunks)
+            except Exception as exc:
+                await db.rollback()
+                failed += 1
+                log.warning(
+                    "failed to index skill=%s file_key=%s: %s",
+                    skill.id,
+                    skill.file_key,
+                    exc,
+                )
+
+    log.info("done: processed=%d failed=%d", processed, failed)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--user-id", type=str, help="Reindex a single user's skills by UUID.")
+    g.add_argument("--all", action="store_true", help="Reindex all active skills.")
+    ap.add_argument(
+        "--force",
+        action="store_true",
+        help="Rebuild chunks even when the current content hash is already indexed.",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be reindexed without writing.",
+    )
+    args = ap.parse_args()
+
+    user_id: uuid.UUID | None = None
+    if args.user_id:
+        try:
+            user_id = uuid.UUID(args.user_id)
+        except ValueError:
+            log.error("invalid --user-id; expected a UUID")
+            sys.exit(2)
+
+    asyncio.run(reindex(user_id=user_id, force=args.force, dry_run=args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -101,6 +101,112 @@ async def test_admin_endpoints_disabled_when_unset(db_session, seed_user):
 
 
 @pytest.mark.asyncio
+async def test_admin_session_stats_splits_automated_and_manual(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    import uuid
+    from datetime import UTC, datetime, timedelta
+
+    from app.models.session import Session
+    from app.models.user import User
+
+    other_user = User(clerk_id=f"stats_user_{uuid.uuid4().hex[:12]}", email="stats@example.com")
+    db_session.add(other_user)
+    await db_session.flush()
+
+    base = datetime(2100, 1, 1, tzinfo=UTC) + timedelta(minutes=uuid.uuid4().int % 500_000)
+    db_session.add_all(
+        [
+            Session(
+                user_id=seed_user.id,
+                local_session_id=f"stats-manual-{uuid.uuid4().hex[:8]}",
+                started_at=base,
+                last_activity_at=base,
+                duration_seconds=900,
+                message_count=12,
+                input_tokens=100,
+                output_tokens=50,
+                cache_read_tokens=25,
+                summary="Manual debugging session",
+                file_key="sessions/manual.json",
+            ),
+            Session(
+                user_id=seed_user.id,
+                local_session_id=f"stats-cron-{uuid.uuid4().hex[:8]}",
+                started_at=base + timedelta(minutes=1),
+                last_activity_at=base + timedelta(minutes=1),
+                duration_seconds=20,
+                message_count=2,
+                input_tokens=10,
+                output_tokens=5,
+                cache_read_tokens=0,
+                summary="Cron: portfolio-watch",
+                file_key="sessions/cron.json",
+            ),
+            Session(
+                user_id=other_user.id,
+                local_session_id=f"stats-heartbeat-{uuid.uuid4().hex[:8]}",
+                started_at=base + timedelta(minutes=2),
+                last_activity_at=base + timedelta(minutes=2),
+                duration_seconds=5,
+                message_count=1,
+                input_tokens=7,
+                output_tokens=3,
+                cache_read_tokens=0,
+                summary="[OpenClaw heartbeat poll]",
+            ),
+            Session(
+                user_id=other_user.id,
+                local_session_id=f"stats-outside-{uuid.uuid4().hex[:8]}",
+                started_at=base - timedelta(days=1),
+                last_activity_at=base - timedelta(days=1),
+                duration_seconds=900,
+                message_count=100,
+                input_tokens=1000,
+                output_tokens=1000,
+                cache_read_tokens=0,
+                summary="Outside window",
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    r = await admin_client.get(
+        "/api/admin/stats/sessions",
+        headers=_AUTH,
+        params={
+            "since": (base - timedelta(seconds=1)).isoformat(),
+            "until": (base + timedelta(minutes=3)).isoformat(),
+        },
+    )
+
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    totals = payload["totals"]
+    assert totals["active_users"] == 2
+    assert totals["sessions"] == 3
+    assert totals["messages"] == 15
+    assert totals["tokens"] == 200
+    assert totals["sessions_with_content"] == 2
+    assert totals["manual_sessions"] == 1
+    assert totals["manual_messages"] == 12
+    assert totals["automated_sessions"] == 2
+    assert totals["automated_messages"] == 3
+    assert totals["automated_users"] == 2
+    assert totals["manual_users"] == 1
+    assert totals["tiny_sessions"] == 2
+    assert payload["per_user"]["max_sessions"] == 2
+
+
+@pytest.mark.asyncio
+async def test_admin_session_stats_requires_admin_key(admin_client):
+    r = await admin_client.get("/api/admin/stats/sessions")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
 async def test_admin_mint_default_grants_full_account_access(admin_client, db_session, seed_user):
     """Mint via admin endpoint with no `scopes` field defaults to
     full account access — same as user-self-mint via Clerk JWT."""

--- a/backend/tests/test_capabilities.py
+++ b/backend/tests/test_capabilities.py
@@ -104,3 +104,11 @@ async def test_settings_accepts_xtrace_when_configured(client: httpx.AsyncClient
     _patch_xtrace_configured(monkeypatch, configured=True)
     r = await client.patch("/api/settings", json={"settings": {"memory_provider": "xtrace"}})
     assert r.status_code == 200, r.text
+
+
+def test_xtrace_worker_is_opt_in_by_default():
+    from app.core.config import Settings
+
+    settings = Settings()
+    assert settings.xtrace_memory_worker_enabled is False
+    assert settings.xtrace_memory_worker_batch_size == 1

--- a/backend/tests/test_capabilities.py
+++ b/backend/tests/test_capabilities.py
@@ -31,6 +31,14 @@ def _patch_mem0_available(monkeypatch, *, available: bool) -> None:
         monkeypatch.setattr(mod, "mem0_available", lambda: available)
 
 
+def _patch_xtrace_configured(monkeypatch, *, configured: bool) -> None:
+    import app.routes.capabilities as cap
+    import app.routes.settings as st
+
+    for mod in (cap, st):
+        monkeypatch.setattr(mod, "xtrace_memory_configured", lambda: configured)
+
+
 @pytest.mark.asyncio
 async def test_capabilities_excludes_mem0_when_unavailable(client: httpx.AsyncClient, monkeypatch):
     _patch_mem0_available(monkeypatch, available=False)
@@ -45,6 +53,14 @@ async def test_capabilities_includes_mem0_when_available(client: httpx.AsyncClie
     r = await client.get("/api/capabilities")
     assert r.status_code == 200, r.text
     assert "mem0" in r.json()["memory_providers"]
+
+
+@pytest.mark.asyncio
+async def test_capabilities_includes_xtrace_when_configured(client: httpx.AsyncClient, monkeypatch):
+    _patch_xtrace_configured(monkeypatch, configured=True)
+    r = await client.get("/api/capabilities")
+    assert r.status_code == 200, r.text
+    assert "xtrace" in r.json()["memory_providers"]
 
 
 @pytest.mark.asyncio
@@ -72,4 +88,19 @@ async def test_settings_refuses_mem0_when_unavailable(client: httpx.AsyncClient,
 async def test_settings_accepts_mem0_when_available(client: httpx.AsyncClient, monkeypatch):
     _patch_mem0_available(monkeypatch, available=True)
     r = await client.patch("/api/settings", json={"settings": {"memory_provider": "mem0"}})
+    assert r.status_code == 200, r.text
+
+
+@pytest.mark.asyncio
+async def test_settings_refuses_xtrace_when_unconfigured(client: httpx.AsyncClient, monkeypatch):
+    _patch_xtrace_configured(monkeypatch, configured=False)
+    r = await client.patch("/api/settings", json={"settings": {"memory_provider": "xtrace"}})
+    assert r.status_code == 400, r.text
+    assert r.json().get("detail", {}).get("code") == "memory_provider_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_settings_accepts_xtrace_when_configured(client: httpx.AsyncClient, monkeypatch):
+    _patch_xtrace_configured(monkeypatch, configured=True)
+    r = await client.patch("/api/settings", json={"settings": {"memory_provider": "xtrace"}})
     assert r.status_code == 200, r.text

--- a/backend/tests/test_memory_provider_fallback.py
+++ b/backend/tests/test_memory_provider_fallback.py
@@ -12,6 +12,7 @@ from app.models.user import User, UserSetting
 from app.services.memory_provider import (
     BuiltinProvider,
     Mem0Provider,
+    XTraceProvider,
     get_memory_provider,
 )
 from app.services.vault_crypto import encrypt_field
@@ -85,6 +86,25 @@ async def test_get_memory_provider_uses_builtin_when_no_setting(
 ):
     provider = await get_memory_provider(str(seed_user.id), db_session)
     assert isinstance(provider, BuiltinProvider)
+
+
+@pytest.mark.asyncio
+async def test_get_memory_provider_uses_xtrace_when_configured(
+    db_session: AsyncSession, seed_user: User, monkeypatch
+):
+    setting = UserSetting(
+        user_id=seed_user.id,
+        settings={"memory_provider": "xtrace"},
+    )
+    db_session.add(setting)
+    await db_session.commit()
+
+    import app.services.memory_provider as mp
+
+    monkeypatch.setattr(mp, "xtrace_memory_configured", lambda: True)
+
+    provider = await get_memory_provider(str(seed_user.id), db_session)
+    assert isinstance(provider, XTraceProvider)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_memory_provider_fallback.py
+++ b/backend/tests/test_memory_provider_fallback.py
@@ -108,6 +108,156 @@ async def test_get_memory_provider_uses_xtrace_when_configured(
 
 
 @pytest.mark.asyncio
+async def test_xtrace_provider_search_uses_remote_memory_search(
+    db_session: AsyncSession, seed_user: User, monkeypatch
+):
+    import app.services.memory_provider as mp
+
+    calls: list[dict] = []
+
+    class FakeXTraceClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, **kwargs):
+            calls.append({"url": str(url), **kwargs})
+            import httpx
+
+            request = httpx.Request("POST", str(url))
+            return httpx.Response(
+                200,
+                request=request,
+                json={
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "mem_remote",
+                            "object": "memory",
+                            "type": "fact",
+                            "text": "User prefers XTrace remote recall for memory search.",
+                            "user_id": str(seed_user.id),
+                            "agent_id": None,
+                            "conv_id": None,
+                            "app_id": "clawdi-cloud",
+                            "metadata": {"source_type": "session"},
+                            "categories": ["preference"],
+                            "score": 0.91,
+                            "created_at": "2026-06-05T22:41:44Z",
+                            "updated_at": "2026-06-05T22:41:44Z",
+                            "details": {
+                                "fact_type": "preference",
+                                "status": "active",
+                                "supersedes": None,
+                                "source_role": "user",
+                                "episode_id": None,
+                                "artifact_id": None,
+                                "artifact_ids": [],
+                                "source_event_ids": [],
+                            },
+                        }
+                    ],
+                    "has_more": False,
+                    "next_cursor": None,
+                },
+            )
+
+    monkeypatch.setattr(mp.settings, "xtrace_api_key", "xtk_test")
+    monkeypatch.setattr(mp.settings, "xtrace_org_id", "org_test")
+    monkeypatch.setattr(mp.settings, "xtrace_memory_base_url", "https://xtrace.test")
+    monkeypatch.setattr(mp.settings, "xtrace_memory_app_id", "clawdi-cloud")
+    monkeypatch.setattr(mp.httpx, "AsyncClient", FakeXTraceClient)
+
+    provider = XTraceProvider(db_session)
+    results = await provider.search(str(seed_user.id), "remote recall", limit=3)
+
+    assert calls[0]["url"] == "https://xtrace.test/v1/memories/search"
+    assert calls[0]["headers"]["Authorization"] == "Bearer xtk_test"
+    assert calls[0]["headers"]["X-Org-Id"] == "org_test"
+    assert calls[0]["json"] == {
+        "query": "remote recall",
+        "user_id": str(seed_user.id),
+        "app_id": "clawdi-cloud",
+        "limit": 3,
+    }
+    assert results == [
+        {
+            "id": "mem_remote",
+            "content": "User prefers XTrace remote recall for memory search.",
+            "category": "preference",
+            "source": "xtrace",
+            "tags": ["xtrace", "xtrace:fact"],
+            "access_count": 0,
+            "created_at": "2026-06-05T22:41:44Z",
+            "source_session_id": None,
+            "xtrace": {
+                "memory_id": "mem_remote",
+                "type": "fact",
+                "status": "active",
+                "operation": None,
+                "source_type": "session",
+                "source_key": None,
+                "local_session_id": None,
+                "skill_key": None,
+                "supersedes": [],
+                "superseded_by": None,
+                "timeline": [
+                    {
+                        "operation": "add",
+                        "content": "User prefers XTrace remote recall for memory search.",
+                        "memory_id": "mem_remote",
+                        "status": "active",
+                        "at": "2026-06-05T22:41:44Z",
+                    }
+                ],
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_xtrace_provider_search_falls_back_to_builtin_on_remote_failure(
+    db_session: AsyncSession, seed_user: User, monkeypatch
+):
+    import app.services.memory_provider as mp
+
+    class BrokenXTraceClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, **kwargs):
+            raise RuntimeError("xtrace unavailable")
+
+    monkeypatch.setattr(mp.settings, "xtrace_api_key", "xtk_test")
+    monkeypatch.setattr(mp.settings, "xtrace_org_id", "org_test")
+    monkeypatch.setattr(mp.httpx, "AsyncClient", BrokenXTraceClient)
+
+    provider = XTraceProvider(db_session)
+    await provider.add(
+        str(seed_user.id),
+        "User prefers local fallback when XTrace search is unavailable.",
+        category="preference",
+    )
+
+    results = await provider.search(str(seed_user.id), "local fallback", limit=5)
+
+    assert len(results) == 1
+    assert results[0]["content"] == "User prefers local fallback when XTrace search is unavailable."
+    assert results[0]["source"] == "manual"
+
+
+@pytest.mark.asyncio
 async def test_get_memory_provider_handles_unknown_user_id(db_session: AsyncSession):
     fake_id = str(uuid.uuid4())
     provider = await get_memory_provider(fake_id, db_session)

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -658,6 +658,153 @@ async def test_session_upload_skips_automated_xtrace_ingest(
 
 
 @pytest.mark.asyncio
+async def test_session_upload_skips_xtrace_when_user_budget_exceeded(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from sqlalchemy import select
+
+    from app.core.config import settings as app_settings
+    from app.models.session import Session
+    from app.models.xtrace_ingest import XTraceMemoryIngest
+
+    monkeypatch.setattr(app_settings, "xtrace_memory_enabled", True)
+    monkeypatch.setattr(app_settings, "xtrace_api_key", "xtk_test")
+    monkeypatch.setattr(app_settings, "xtrace_org_id", "org_test")
+    monkeypatch.setattr(app_settings, "xtrace_memory_daily_message_budget_per_user", 1)
+
+    local_id = f"sess-xtrace-budget-skip-{uuid.uuid4().hex[:8]}"
+    await _seed_session_with_content(
+        client,
+        local_id,
+        content=b'[{"role":"user","content":"manual but over budget"}]',
+    )
+    session = (
+        await db_session.execute(
+            select(Session).where(
+                Session.user_id == seed_user.id,
+                Session.local_session_id == local_id,
+            )
+        )
+    ).scalar_one()
+    audit = (
+        await db_session.execute(
+            select(XTraceMemoryIngest).where(XTraceMemoryIngest.session_id == session.id)
+        )
+    ).scalar_one()
+
+    assert audit.status == "skipped"
+    assert audit.response["skip_reason"] == "budget_exceeded"
+    assert audit.response["budget"]["limit"] == 1
+    assert audit.response["policy"]["estimated_xtrace_messages"] == 3
+
+
+@pytest.mark.asyncio
+async def test_xtrace_session_ingest_sends_only_new_messages_on_append(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from sqlalchemy import select
+
+    from app.core.config import settings as app_settings
+    from app.models.session import Session
+    from app.models.xtrace_ingest import XTraceMemoryIngest
+    from app.services.xtrace_ingest_queue import run_xtrace_ingest_job
+
+    calls: list[list[dict]] = []
+
+    class FakeXTraceClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, **kwargs):
+            calls.append(kwargs["json"]["messages"])
+            request = httpx.Request("POST", str(url))
+            return httpx.Response(
+                200,
+                request=request,
+                json={
+                    "object": "ingest_job",
+                    "id": f"job_delta_{len(calls)}",
+                    "status": "succeeded",
+                    "result": {"memories_created": [], "memories_updated": []},
+                },
+            )
+
+    monkeypatch.setattr(app_settings, "xtrace_memory_enabled", True)
+    monkeypatch.setattr(app_settings, "xtrace_api_key", "xtk_test")
+    monkeypatch.setattr(app_settings, "xtrace_org_id", "org_test")
+    monkeypatch.setattr(app_settings, "xtrace_memory_base_url", "https://xtrace.test")
+    monkeypatch.setattr("app.services.xtrace_memory.httpx.AsyncClient", FakeXTraceClient)
+
+    local_id = f"sess-xtrace-delta-{uuid.uuid4().hex[:8]}"
+    await _seed_session_with_content(
+        client,
+        local_id,
+        content=b'[{"role":"user","content":"first"},{"role":"assistant","content":"second"}]',
+    )
+    session = (
+        await db_session.execute(
+            select(Session).where(
+                Session.user_id == seed_user.id,
+                Session.local_session_id == local_id,
+            )
+        )
+    ).scalar_one()
+    first_job = (
+        await db_session.execute(
+            select(XTraceMemoryIngest).where(XTraceMemoryIngest.session_id == session.id)
+        )
+    ).scalar_one()
+    await run_xtrace_ingest_job(first_job.id, db=db_session)
+
+    upload = await client.post(
+        f"/api/sessions/{local_id}/upload",
+        files={
+            "file": (
+                f"{local_id}.json",
+                (
+                    b'[{"role":"user","content":"first"},'
+                    b'{"role":"assistant","content":"second"},'
+                    b'{"role":"user","content":"third"}]'
+                ),
+                "application/json",
+            )
+        },
+    )
+    assert upload.status_code == 200, upload.text
+    jobs = (
+        (
+            await db_session.execute(
+                select(XTraceMemoryIngest)
+                .where(XTraceMemoryIngest.session_id == session.id)
+                .order_by(XTraceMemoryIngest.created_at.asc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(jobs) == 2
+    await run_xtrace_ingest_job(jobs[-1].id, db=db_session)
+
+    assert len(calls) == 2
+    assert [m["content"] for m in calls[0][1:]] == ["first", "second"]
+    assert [m["content"] for m in calls[1][1:]] == ["third"]
+    await db_session.refresh(jobs[-1])
+    assert jobs[-1].response["_clawdi"]["cost"]["payload_message_count"] == 2
+
+
+@pytest.mark.asyncio
 async def test_xtrace_session_ingest_worker_processes_queued_upload(
     client: httpx.AsyncClient,
     db_session: AsyncSession,

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -652,6 +652,84 @@ async def test_session_upload_xtrace_error_does_not_fail_upload(
 
 
 @pytest.mark.asyncio
+async def test_session_upload_retries_xtrace_rate_limit(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from sqlalchemy import select
+
+    from app.core.config import settings as app_settings
+    from app.models.memory import Memory
+
+    calls = 0
+
+    class RateLimitedXTraceClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, **kwargs):
+            nonlocal calls
+            calls += 1
+            request = httpx.Request("POST", str(url))
+            if calls == 1:
+                return httpx.Response(
+                    429,
+                    request=request,
+                    headers={"Retry-After": "0.01"},
+                    json={"detail": "rate limited"},
+                )
+            return httpx.Response(
+                200,
+                request=request,
+                json={
+                    "id": "job_retry",
+                    "status": "succeeded",
+                    "result": {
+                        "memories_created": [
+                            {
+                                "id": "mem_retry",
+                                "type": "fact",
+                                "text": "User retries XTrace rate limits.",
+                            }
+                        ],
+                        "memories_updated": [],
+                    },
+                },
+            )
+
+    monkeypatch.setattr(app_settings, "xtrace_memory_enabled", True)
+    monkeypatch.setattr(app_settings, "xtrace_api_key", "xtk_test")
+    monkeypatch.setattr(app_settings, "xtrace_org_id", "org_test")
+    monkeypatch.setattr(app_settings, "xtrace_memory_base_url", "https://xtrace.test")
+    monkeypatch.setattr("app.services.xtrace_memory.httpx.AsyncClient", RateLimitedXTraceClient)
+
+    await _seed_session_with_content(
+        client,
+        "sess-xtrace-rate-limit",
+        content=b'[{"role":"user","content":"Retry XTrace rate limits."}]',
+    )
+
+    assert calls == 2
+    memory = (
+        await db_session.execute(
+            select(Memory).where(
+                Memory.user_id == seed_user.id,
+                Memory.content == "User retries XTrace rate limits.",
+            )
+        )
+    ).scalar_one()
+    assert memory.metadata_["xtrace_memory_id"] == "mem_retry"
+
+
+@pytest.mark.asyncio
 async def test_session_upload_records_xtrace_ingest_when_no_memories_returned(
     client: httpx.AsyncClient,
     db_session: AsyncSession,

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -586,6 +586,16 @@ async def test_session_upload_auto_ingests_xtrace_memories_when_configured(
     assert api_memory["xtrace"]["supersedes"] == ["mem_old"]
     assert api_memory["xtrace"]["timeline"][0]["operation"] == "add"
 
+    by_session = await client.get(f"/api/memories?source_session_id={session.id}")
+    assert by_session.status_code == 200, by_session.text
+    assert by_session.json()["total"] == 1
+    assert by_session.json()["items"][0]["id"] == api_memory["id"]
+
+    by_agent = await client.get(f"/api/memories?environment_id={session.environment_id}")
+    assert by_agent.status_code == 200, by_agent.text
+    assert by_agent.json()["total"] == 1
+    assert by_agent.json()["items"][0]["id"] == api_memory["id"]
+
     audit = (
         await db_session.execute(
             select(XTraceMemoryIngest).where(XTraceMemoryIngest.session_id == session.id)

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -576,6 +576,88 @@ async def test_session_upload_enqueues_xtrace_ingest_when_configured(
 
 
 @pytest.mark.asyncio
+async def test_session_upload_skips_automated_xtrace_ingest(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from sqlalchemy import select
+
+    from app.core.config import settings as app_settings
+    from app.models.session import Session
+    from app.models.xtrace_ingest import XTraceMemoryIngest
+
+    class UnexpectedXTraceClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, **kwargs):
+            raise AssertionError("automated sessions should not be sent to XTrace")
+
+    monkeypatch.setattr(app_settings, "xtrace_memory_enabled", True)
+    monkeypatch.setattr(app_settings, "xtrace_api_key", "xtk_test")
+    monkeypatch.setattr(app_settings, "xtrace_org_id", "org_test")
+    monkeypatch.setattr("app.services.xtrace_memory.httpx.AsyncClient", UnexpectedXTraceClient)
+
+    env_id = await _register_env(client)
+    local_id = f"sess-xtrace-cron-skip-{uuid.uuid4().hex[:8]}"
+    started = datetime.now(UTC).isoformat()
+    r = await client.post(
+        "/api/sessions/batch",
+        json={
+            "sessions": [
+                {
+                    "environment_id": env_id,
+                    "local_session_id": local_id,
+                    "started_at": started,
+                    "message_count": 12,
+                    "content_hash": "d" * 64,
+                    "summary": "Cron: portfolio-watch",
+                }
+            ]
+        },
+    )
+    assert r.status_code == 200, r.text
+    upload = await client.post(
+        f"/api/sessions/{local_id}/upload",
+        files={
+            "file": (
+                f"{local_id}.json",
+                b'[{"role":"user","content":"automated price scan"}]',
+                "application/json",
+            )
+        },
+    )
+    assert upload.status_code == 200, upload.text
+
+    session = (
+        await db_session.execute(
+            select(Session).where(
+                Session.user_id == seed_user.id,
+                Session.local_session_id == local_id,
+            )
+        )
+    ).scalar_one()
+    audit = (
+        await db_session.execute(
+            select(XTraceMemoryIngest).where(XTraceMemoryIngest.session_id == session.id)
+        )
+    ).scalar_one()
+    assert audit.status == "skipped"
+    assert audit.attempt_count == 0
+    assert audit.response["skip_reason"] == "automated_session"
+    assert audit.response["policy"]["quality"] == "automated"
+    assert audit.response["policy"]["estimated_source_messages"] == 12
+
+
+@pytest.mark.asyncio
 async def test_xtrace_session_ingest_worker_processes_queued_upload(
     client: httpx.AsyncClient,
     db_session: AsyncSession,

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -480,6 +480,7 @@ async def test_session_upload_auto_ingests_xtrace_memories_when_configured(
     from app.core.config import settings as app_settings
     from app.models.memory import Memory
     from app.models.session import Session
+    from app.models.xtrace_ingest import XTraceMemoryIngest
 
     calls: list[dict] = []
 
@@ -552,7 +553,12 @@ async def test_session_upload_auto_ingests_xtrace_memories_when_configured(
     assert call["json"]["conv_id"] == str(session.id)
     assert call["json"]["agent_id"] == str(session.environment_id)
     assert call["json"]["app_id"] == "clawdi-cloud"
-    assert call["json"]["messages"] == [{"role": "user", "content": "I prefer Bun over npm."}]
+    assert call["json"]["extract_artifacts"] is True
+    assert call["json"]["metadata"]["source_type"] == "session"
+    assert call["json"]["metadata"]["source_key"].startswith(f"session:{session.id}:")
+    assert call["json"]["messages"][0]["role"] == "system"
+    assert "Clawdi Cloud session context" in call["json"]["messages"][0]["content"]
+    assert call["json"]["messages"][1] == {"role": "user", "content": "I prefer Bun over npm."}
 
     memories = (
         (await db_session.execute(select(Memory).where(Memory.user_id == seed_user.id)))
@@ -564,7 +570,15 @@ async def test_session_upload_auto_ingests_xtrace_memories_when_configured(
     assert memories[0].category == "fact"
     assert memories[0].source == "xtrace_session"
     assert memories[0].source_session_id == session.id
-    assert memories[0].tags == ["xtrace", "xtrace:fact"]
+    assert memories[0].tags == ["xtrace", "xtrace:fact", "xtrace_session"]
+
+    audit = (
+        await db_session.execute(
+            select(XTraceMemoryIngest).where(XTraceMemoryIngest.session_id == session.id)
+        )
+    ).scalar_one()
+    assert audit.source_type == "session"
+    assert audit.source_key == call["json"]["metadata"]["source_key"]
 
 
 @pytest.mark.asyncio
@@ -688,6 +702,8 @@ async def test_session_upload_records_xtrace_ingest_when_no_memories_returned(
         )
     ).scalar_one()
     assert audit.job_id == "job_pending"
+    assert audit.source_type == "session"
+    assert audit.source_key.startswith(f"session:{session.id}:")
     assert audit.status == "pending"
     assert audit.created_ref_count == 0
     assert audit.updated_ref_count == 0

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -733,6 +733,127 @@ async def test_xtrace_ingest_queue_drain_dispatches_queued_jobs(
 
 
 @pytest.mark.asyncio
+async def test_xtrace_ingest_queue_claims_due_jobs_once(
+    db_session: AsyncSession,
+    seed_user,
+):
+    from datetime import UTC, datetime, timedelta
+
+    from app.models.xtrace_ingest import XTraceMemoryIngest
+    from app.services.xtrace_ingest_queue import claim_queued_xtrace_ingest_jobs
+
+    old_enough_to_claim_first = datetime(2000, 1, 1, tzinfo=UTC)
+    due = XTraceMemoryIngest(
+        user_id=seed_user.id,
+        source_type="session",
+        source_key="session:claim-due",
+        status="queued",
+        created_at=old_enough_to_claim_first,
+    )
+    future = XTraceMemoryIngest(
+        user_id=seed_user.id,
+        source_type="session",
+        source_key="session:claim-future",
+        status="queued",
+        created_at=old_enough_to_claim_first,
+        next_attempt_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+    db_session.add_all([due, future])
+    await db_session.commit()
+
+    claimed = await claim_queued_xtrace_ingest_jobs(db_session, limit=10, worker_id="worker-a")
+
+    assert due.id in [job.id for job in claimed]
+    await db_session.refresh(due)
+    await db_session.refresh(future)
+    assert due.status == "running"
+    assert due.claimed_by == "worker-a"
+    assert due.claimed_at is not None
+    assert due.attempt_count == 1
+    assert future.status == "queued"
+    assert future.attempt_count == 0
+
+    claimed_again = await claim_queued_xtrace_ingest_jobs(
+        db_session, limit=10, worker_id="worker-b"
+    )
+    claimed_again_ids = [job.id for job in claimed_again]
+    assert due.id not in claimed_again_ids
+    assert future.id not in claimed_again_ids
+
+
+@pytest.mark.asyncio
+async def test_xtrace_ingest_worker_requeues_failed_jobs_with_backoff(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from datetime import UTC, datetime
+
+    from sqlalchemy import select
+
+    from app.core.config import settings as app_settings
+    from app.models.session import Session
+    from app.models.xtrace_ingest import XTraceMemoryIngest
+    from app.services.xtrace_ingest_queue import (
+        claim_queued_xtrace_ingest_jobs,
+        run_xtrace_ingest_job,
+    )
+
+    class BrokenXTraceClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, **kwargs):
+            raise httpx.ConnectError("xtrace unavailable")
+
+    monkeypatch.setattr(app_settings, "xtrace_memory_enabled", True)
+    monkeypatch.setattr(app_settings, "xtrace_api_key", "xtk_test")
+    monkeypatch.setattr(app_settings, "xtrace_org_id", "org_test")
+    monkeypatch.setattr(app_settings, "xtrace_memory_max_attempts", 3)
+    monkeypatch.setattr("app.services.xtrace_memory.httpx.AsyncClient", BrokenXTraceClient)
+
+    await _seed_session_with_content(
+        client,
+        "sess-xtrace-retry-queue",
+        content=b'[{"role":"user","content":"retry later"}]',
+    )
+    session = (
+        await db_session.execute(
+            select(Session).where(
+                Session.user_id == seed_user.id,
+                Session.local_session_id == "sess-xtrace-retry-queue",
+            )
+        )
+    ).scalar_one()
+    queued = (
+        await db_session.execute(
+            select(XTraceMemoryIngest).where(XTraceMemoryIngest.session_id == session.id)
+        )
+    ).scalar_one()
+    queued.created_at = datetime(2000, 1, 1, tzinfo=UTC)
+    await db_session.commit()
+    claimed = await claim_queued_xtrace_ingest_jobs(db_session, limit=10, worker_id="worker-retry")
+    assert queued.id in [job.id for job in claimed]
+
+    await run_xtrace_ingest_job(queued.id, db=db_session)
+    await db_session.refresh(queued)
+
+    assert queued.status == "queued"
+    assert queued.attempt_count == 1
+    assert queued.next_attempt_at is not None
+    assert queued.claimed_by is None
+    assert queued.claimed_at is None
+    assert "xtrace unavailable" in (queued.error or "")
+
+
+@pytest.mark.asyncio
 async def test_session_upload_xtrace_error_does_not_fail_upload(
     client: httpx.AsyncClient,
     db_session: AsyncSession,

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -469,6 +469,233 @@ async def test_session_upload_records_content_hash_and_uploaded_at(
 
 
 @pytest.mark.asyncio
+async def test_session_upload_auto_ingests_xtrace_memories_when_configured(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from sqlalchemy import select
+
+    from app.core.config import settings as app_settings
+    from app.models.memory import Memory
+    from app.models.session import Session
+
+    calls: list[dict] = []
+
+    class FakeXTraceClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, **kwargs):
+            calls.append({"url": str(url), **kwargs})
+            request = httpx.Request("POST", str(url))
+            return httpx.Response(
+                200,
+                request=request,
+                json={
+                    "object": "ingest_job",
+                    "id": "job_test",
+                    "status": "succeeded",
+                    "created_at": "2026-06-04T12:00:00Z",
+                    "result": {
+                        "object": "ingest_result",
+                        "memories_created": [
+                            {
+                                "id": "mem_test",
+                                "type": "fact",
+                                "text": "User prefers Bun over npm.",
+                            }
+                        ],
+                        "memories_updated": [],
+                        "memories_superseded_by": {},
+                        "stage_timings": {},
+                    },
+                },
+            )
+
+    monkeypatch.setattr(app_settings, "xtrace_memory_enabled", True)
+    monkeypatch.setattr(app_settings, "xtrace_api_key", "xtk_test")
+    monkeypatch.setattr(app_settings, "xtrace_org_id", "org_test")
+    monkeypatch.setattr(app_settings, "xtrace_memory_base_url", "https://xtrace.test")
+    monkeypatch.setattr("app.services.xtrace_memory.httpx.AsyncClient", FakeXTraceClient)
+
+    local_id = "sess-xtrace-auto"
+    await _seed_session_with_content(
+        client,
+        local_id,
+        content=b'[{"role":"user","content":"I prefer Bun over npm."}]',
+    )
+
+    session = (
+        await db_session.execute(
+            select(Session).where(
+                Session.user_id == seed_user.id,
+                Session.local_session_id == local_id,
+            )
+        )
+    ).scalar_one()
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["url"] == "https://xtrace.test/v1/memories"
+    assert call["params"] == {"wait": "true"}
+    assert call["headers"]["Authorization"] == "Bearer xtk_test"
+    assert call["headers"]["X-Org-Id"] == "org_test"
+    assert call["json"]["user_id"] == str(seed_user.id)
+    assert call["json"]["conv_id"] == str(session.id)
+    assert call["json"]["agent_id"] == str(session.environment_id)
+    assert call["json"]["app_id"] == "clawdi-cloud"
+    assert call["json"]["messages"] == [{"role": "user", "content": "I prefer Bun over npm."}]
+
+    memories = (
+        (await db_session.execute(select(Memory).where(Memory.user_id == seed_user.id)))
+        .scalars()
+        .all()
+    )
+    assert len(memories) == 1
+    assert memories[0].content == "User prefers Bun over npm."
+    assert memories[0].category == "fact"
+    assert memories[0].source == "xtrace_session"
+    assert memories[0].source_session_id == session.id
+    assert memories[0].tags == ["xtrace", "xtrace:fact"]
+
+
+@pytest.mark.asyncio
+async def test_session_upload_xtrace_error_does_not_fail_upload(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from sqlalchemy import select
+
+    from app.core.config import settings as app_settings
+    from app.models.memory import Memory
+
+    class BrokenXTraceClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, **kwargs):
+            raise httpx.ConnectError("xtrace unavailable")
+
+    monkeypatch.setattr(app_settings, "xtrace_memory_enabled", True)
+    monkeypatch.setattr(app_settings, "xtrace_api_key", "xtk_test")
+    monkeypatch.setattr(app_settings, "xtrace_org_id", "org_test")
+    monkeypatch.setattr(app_settings, "xtrace_memory_base_url", "https://xtrace.test")
+    monkeypatch.setattr("app.services.xtrace_memory.httpx.AsyncClient", BrokenXTraceClient)
+
+    local_id = "sess-xtrace-failure"
+    await _seed_session_with_content(
+        client,
+        local_id,
+        content=b'[{"role":"user","content":"I prefer Bun over npm."}]',
+    )
+
+    rows = (
+        (await db_session.execute(select(Memory).where(Memory.user_id == seed_user.id)))
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_session_upload_records_xtrace_ingest_when_no_memories_returned(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from sqlalchemy import select
+
+    from app.core.config import settings as app_settings
+    from app.models.memory import Memory
+    from app.models.session import Session
+    from app.models.xtrace_ingest import XTraceMemoryIngest
+
+    class PendingXTraceClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, **kwargs):
+            request = httpx.Request("POST", str(url))
+            return httpx.Response(
+                200,
+                request=request,
+                json={
+                    "object": "ingest_job",
+                    "id": "job_pending",
+                    "status": "pending",
+                    "result": {
+                        "object": "ingest_result",
+                        "memories_created": [],
+                        "memories_updated": [],
+                    },
+                },
+            )
+
+    monkeypatch.setattr(app_settings, "xtrace_memory_enabled", True)
+    monkeypatch.setattr(app_settings, "xtrace_api_key", "xtk_test")
+    monkeypatch.setattr(app_settings, "xtrace_org_id", "org_test")
+    monkeypatch.setattr(app_settings, "xtrace_memory_base_url", "https://xtrace.test")
+    monkeypatch.setattr("app.services.xtrace_memory.httpx.AsyncClient", PendingXTraceClient)
+
+    local_id = "sess-xtrace-pending"
+    await _seed_session_with_content(
+        client,
+        local_id,
+        content=b'[{"role":"user","content":"Remember that preview smoke tests are required."}]',
+    )
+
+    session = (
+        await db_session.execute(
+            select(Session).where(
+                Session.user_id == seed_user.id,
+                Session.local_session_id == local_id,
+            )
+        )
+    ).scalar_one()
+    rows = (
+        (await db_session.execute(select(Memory).where(Memory.user_id == seed_user.id)))
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+    audit = (
+        await db_session.execute(
+            select(XTraceMemoryIngest).where(XTraceMemoryIngest.session_id == session.id)
+        )
+    ).scalar_one()
+    assert audit.job_id == "job_pending"
+    assert audit.status == "pending"
+    assert audit.created_ref_count == 0
+    assert audit.updated_ref_count == 0
+    assert audit.mirrored_count == 0
+    assert audit.response["id"] == "job_pending"
+
+
+@pytest.mark.asyncio
 async def test_session_messages_endpoint_paginates_long_conversations(
     client: httpx.AsyncClient,
 ):

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -511,11 +511,13 @@ async def test_session_upload_auto_ingests_xtrace_memories_when_configured(
                             {
                                 "id": "mem_test",
                                 "type": "fact",
+                                "status": "active",
+                                "created_at": "2026-06-04T12:01:00Z",
                                 "text": "User prefers Bun over npm.",
                             }
                         ],
                         "memories_updated": [],
-                        "memories_superseded_by": {},
+                        "memories_superseded_by": {"mem_old": "mem_test"},
                         "stage_timings": {},
                     },
                 },
@@ -571,6 +573,18 @@ async def test_session_upload_auto_ingests_xtrace_memories_when_configured(
     assert memories[0].source == "xtrace_session"
     assert memories[0].source_session_id == session.id
     assert memories[0].tags == ["xtrace", "xtrace:fact", "xtrace_session"]
+    assert memories[0].metadata_["xtrace_memory_id"] == "mem_test"
+    assert memories[0].metadata_["xtrace_status"] == "active"
+    assert memories[0].metadata_["xtrace_operation"] == "add"
+    assert memories[0].metadata_["xtrace_supersedes"] == ["mem_old"]
+
+    list_response = await client.get("/api/memories")
+    assert list_response.status_code == 200, list_response.text
+    api_memory = list_response.json()["items"][0]
+    assert api_memory["xtrace"]["memory_id"] == "mem_test"
+    assert api_memory["xtrace"]["status"] == "active"
+    assert api_memory["xtrace"]["supersedes"] == ["mem_old"]
+    assert api_memory["xtrace"]["timeline"][0]["operation"] == "add"
 
     audit = (
         await db_session.execute(

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -469,7 +469,7 @@ async def test_session_upload_records_content_hash_and_uploaded_at(
 
 
 @pytest.mark.asyncio
-async def test_session_upload_auto_ingests_xtrace_memories_when_configured(
+async def test_session_upload_enqueues_xtrace_ingest_when_configured(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user,
@@ -478,7 +478,6 @@ async def test_session_upload_auto_ingests_xtrace_memories_when_configured(
     from sqlalchemy import select
 
     from app.core.config import settings as app_settings
-    from app.models.memory import Memory
     from app.models.session import Session
     from app.models.xtrace_ingest import XTraceMemoryIngest
 
@@ -545,21 +544,132 @@ async def test_session_upload_auto_ingests_xtrace_memories_when_configured(
         )
     ).scalar_one()
 
+    assert calls == []
+
+    audit = (
+        await db_session.execute(
+            select(XTraceMemoryIngest).where(XTraceMemoryIngest.session_id == session.id)
+        )
+    ).scalar_one()
+    assert audit.source_type == "session"
+    assert audit.source_key == f"session:{session.id}:{session.content_hash}"
+    assert audit.status == "queued"
+    assert audit.created_ref_count == 0
+    assert audit.updated_ref_count == 0
+    assert audit.mirrored_count == 0
+
+    await _seed_session_with_content(
+        client,
+        local_id,
+        content=b'[{"role":"user","content":"I prefer Bun over npm."}]',
+    )
+    audits = (
+        (
+            await db_session.execute(
+                select(XTraceMemoryIngest).where(XTraceMemoryIngest.session_id == session.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audits) == 1
+
+
+@pytest.mark.asyncio
+async def test_xtrace_session_ingest_worker_processes_queued_upload(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from sqlalchemy import select
+
+    from app.core.config import settings as app_settings
+    from app.models.memory import Memory
+    from app.models.session import Session
+    from app.models.xtrace_ingest import XTraceMemoryIngest
+    from app.services.xtrace_ingest_queue import run_xtrace_ingest_job
+
+    calls: list[dict] = []
+
+    class FakeXTraceClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, **kwargs):
+            calls.append({"url": str(url), **kwargs})
+            request = httpx.Request("POST", str(url))
+            return httpx.Response(
+                200,
+                request=request,
+                json={
+                    "object": "ingest_job",
+                    "id": "job_worker",
+                    "status": "succeeded",
+                    "result": {
+                        "memories_created": [
+                            {
+                                "id": "mem_worker",
+                                "type": "fact",
+                                "status": "active",
+                                "created_at": "2026-06-04T12:01:00Z",
+                                "text": "User prefers Bun over npm.",
+                            }
+                        ],
+                        "memories_updated": [],
+                        "memories_superseded_by": {},
+                    },
+                },
+            )
+
+    monkeypatch.setattr(app_settings, "xtrace_memory_enabled", True)
+    monkeypatch.setattr(app_settings, "xtrace_api_key", "xtk_test")
+    monkeypatch.setattr(app_settings, "xtrace_org_id", "org_test")
+    monkeypatch.setattr(app_settings, "xtrace_memory_base_url", "https://xtrace.test")
+    monkeypatch.setattr("app.services.xtrace_memory.httpx.AsyncClient", FakeXTraceClient)
+
+    local_id = "sess-xtrace-worker"
+    await _seed_session_with_content(
+        client,
+        local_id,
+        content=b'[{"role":"user","content":"I prefer Bun over npm."}]',
+    )
+    session = (
+        await db_session.execute(
+            select(Session).where(
+                Session.user_id == seed_user.id,
+                Session.local_session_id == local_id,
+            )
+        )
+    ).scalar_one()
+    queued = (
+        await db_session.execute(
+            select(XTraceMemoryIngest).where(XTraceMemoryIngest.session_id == session.id)
+        )
+    ).scalar_one()
+
+    await run_xtrace_ingest_job(queued.id, db=db_session)
+
+    processed = await db_session.get(XTraceMemoryIngest, queued.id)
+    assert processed is not None
+    await db_session.refresh(processed)
+    assert processed.status == "succeeded"
+    assert processed.job_id == "job_worker"
+    assert processed.created_ref_count == 1
+    assert processed.mirrored_count == 1
+
     assert len(calls) == 1
     call = calls[0]
     assert call["url"] == "https://xtrace.test/v1/memories"
-    assert call["params"] == {"wait": "true"}
-    assert call["headers"]["Authorization"] == "Bearer xtk_test"
-    assert call["headers"]["X-Org-Id"] == "org_test"
     assert call["json"]["user_id"] == str(seed_user.id)
     assert call["json"]["conv_id"] == str(session.id)
     assert call["json"]["agent_id"] == str(session.environment_id)
-    assert call["json"]["app_id"] == "clawdi-cloud"
-    assert call["json"]["extract_artifacts"] is True
-    assert call["json"]["metadata"]["source_type"] == "session"
-    assert call["json"]["metadata"]["source_key"].startswith(f"session:{session.id}:")
-    assert call["json"]["messages"][0]["role"] == "system"
-    assert "Clawdi Cloud session context" in call["json"]["messages"][0]["content"]
     assert call["json"]["messages"][1] == {"role": "user", "content": "I prefer Bun over npm."}
 
     memories = (
@@ -569,40 +679,57 @@ async def test_session_upload_auto_ingests_xtrace_memories_when_configured(
     )
     assert len(memories) == 1
     assert memories[0].content == "User prefers Bun over npm."
-    assert memories[0].category == "fact"
     assert memories[0].source == "xtrace_session"
-    assert memories[0].source_session_id == session.id
-    assert memories[0].tags == ["xtrace", "xtrace:fact", "xtrace_session"]
-    assert memories[0].metadata_["xtrace_memory_id"] == "mem_test"
-    assert memories[0].metadata_["xtrace_status"] == "active"
-    assert memories[0].metadata_["xtrace_operation"] == "add"
-    assert memories[0].metadata_["xtrace_supersedes"] == ["mem_old"]
+    assert memories[0].metadata_["xtrace_memory_id"] == "mem_worker"
 
-    list_response = await client.get("/api/memories")
-    assert list_response.status_code == 200, list_response.text
-    api_memory = list_response.json()["items"][0]
-    assert api_memory["xtrace"]["memory_id"] == "mem_test"
-    assert api_memory["xtrace"]["status"] == "active"
-    assert api_memory["xtrace"]["supersedes"] == ["mem_old"]
-    assert api_memory["xtrace"]["timeline"][0]["operation"] == "add"
 
-    by_session = await client.get(f"/api/memories?source_session_id={session.id}")
-    assert by_session.status_code == 200, by_session.text
-    assert by_session.json()["total"] == 1
-    assert by_session.json()["items"][0]["id"] == api_memory["id"]
+@pytest.mark.asyncio
+async def test_xtrace_ingest_queue_drain_dispatches_queued_jobs(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from sqlalchemy import select
 
-    by_agent = await client.get(f"/api/memories?environment_id={session.environment_id}")
-    assert by_agent.status_code == 200, by_agent.text
-    assert by_agent.json()["total"] == 1
-    assert by_agent.json()["items"][0]["id"] == api_memory["id"]
+    from app.core.config import settings as app_settings
+    from app.models.session import Session
+    from app.models.xtrace_ingest import XTraceMemoryIngest
+    from app.services.xtrace_ingest_queue import run_queued_xtrace_ingest_jobs
 
-    audit = (
+    monkeypatch.setattr(app_settings, "xtrace_memory_enabled", True)
+    monkeypatch.setattr(app_settings, "xtrace_api_key", "xtk_test")
+    monkeypatch.setattr(app_settings, "xtrace_org_id", "org_test")
+
+    await _seed_session_with_content(
+        client,
+        "sess-xtrace-drain",
+        content=b'[{"role":"user","content":"drain me"}]',
+    )
+    session = (
+        await db_session.execute(
+            select(Session).where(
+                Session.user_id == seed_user.id,
+                Session.local_session_id == "sess-xtrace-drain",
+            )
+        )
+    ).scalar_one()
+    queued = (
         await db_session.execute(
             select(XTraceMemoryIngest).where(XTraceMemoryIngest.session_id == session.id)
         )
     ).scalar_one()
-    assert audit.source_type == "session"
-    assert audit.source_key == call["json"]["metadata"]["source_key"]
+    dispatched: list[str] = []
+
+    async def fake_run(job_id, **_kwargs):
+        dispatched.append(str(job_id))
+
+    monkeypatch.setattr("app.services.xtrace_ingest_queue.run_xtrace_ingest_job", fake_run)
+
+    count = await run_queued_xtrace_ingest_jobs(limit=1000, db=db_session)
+
+    assert count >= 1
+    assert str(queued.id) in dispatched
 
 
 @pytest.mark.asyncio
@@ -662,6 +789,9 @@ async def test_session_upload_retries_xtrace_rate_limit(
 
     from app.core.config import settings as app_settings
     from app.models.memory import Memory
+    from app.models.session import Session
+    from app.models.xtrace_ingest import XTraceMemoryIngest
+    from app.services.xtrace_ingest_queue import run_xtrace_ingest_job
 
     calls = 0
 
@@ -717,6 +847,21 @@ async def test_session_upload_retries_xtrace_rate_limit(
         content=b'[{"role":"user","content":"Retry XTrace rate limits."}]',
     )
 
+    session = (
+        await db_session.execute(
+            select(Session).where(
+                Session.user_id == seed_user.id,
+                Session.local_session_id == "sess-xtrace-rate-limit",
+            )
+        )
+    ).scalar_one()
+    queued = (
+        await db_session.execute(
+            select(XTraceMemoryIngest).where(XTraceMemoryIngest.session_id == session.id)
+        )
+    ).scalar_one()
+    await run_xtrace_ingest_job(queued.id, db=db_session)
+
     assert calls == 2
     memory = (
         await db_session.execute(
@@ -742,6 +887,7 @@ async def test_session_upload_records_xtrace_ingest_when_no_memories_returned(
     from app.models.memory import Memory
     from app.models.session import Session
     from app.models.xtrace_ingest import XTraceMemoryIngest
+    from app.services.xtrace_ingest_queue import run_xtrace_ingest_job
 
     class PendingXTraceClient:
         def __init__(self, **kwargs):
@@ -803,6 +949,9 @@ async def test_session_upload_records_xtrace_ingest_when_no_memories_returned(
             select(XTraceMemoryIngest).where(XTraceMemoryIngest.session_id == session.id)
         )
     ).scalar_one()
+    await run_xtrace_ingest_job(audit.id, db=db_session)
+    await db_session.refresh(audit)
+
     assert audit.job_id == "job_pending"
     assert audit.source_type == "session"
     assert audit.source_key.startswith(f"session:{session.id}:")

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -118,6 +118,7 @@ async def test_skill_upload_auto_ingests_xtrace_artifacts_when_configured(
                             {
                                 "id": "artifact_skill",
                                 "type": "artifact",
+                                "status": "active",
                                 "text": (
                                     "Deploy helper skill captures the preview rollout checklist."
                                 ),
@@ -181,6 +182,9 @@ async def test_skill_upload_auto_ingests_xtrace_artifacts_when_configured(
     assert memory.source_session_id is None
     assert memory.tags == ["xtrace", "xtrace:artifact", "xtrace_skill"]
     assert memory.metadata_["skill_key"] == "deploy-helper"
+    assert memory.metadata_["xtrace_memory_id"] == "artifact_skill"
+    assert memory.metadata_["xtrace_type"] == "artifact"
+    assert memory.metadata_["xtrace_status"] == "active"
 
     audit = (
         await db_session.execute(

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -76,7 +76,7 @@ async def test_skill_upload_indexes_file_content_for_search(
 
 
 @pytest.mark.asyncio
-async def test_skill_upload_auto_ingests_xtrace_artifacts_when_configured(
+async def test_skill_upload_enqueues_xtrace_ingest_when_configured(
     client: httpx.AsyncClient,
     db_session,
     project_id: str,
@@ -86,7 +86,6 @@ async def test_skill_upload_auto_ingests_xtrace_artifacts_when_configured(
     from sqlalchemy import select
 
     from app.core.config import settings as app_settings
-    from app.models.memory import Memory
     from app.models.skill import Skill
     from app.models.xtrace_ingest import XTraceMemoryIngest
 
@@ -157,20 +156,143 @@ async def test_skill_upload_auto_ingests_xtrace_artifacts_when_configured(
             select(Skill).where(Skill.user_id == seed_user.id, Skill.skill_key == "deploy-helper")
         )
     ).scalar_one()
+    assert calls == []
+
+    audit = (
+        await db_session.execute(
+            select(XTraceMemoryIngest).where(XTraceMemoryIngest.skill_id == skill.id)
+        )
+    ).scalar_one()
+    assert audit.source_type == "skill"
+    assert audit.source_key == f"skill:{skill.id}:{skill.content_hash}"
+    assert audit.status == "queued"
+    assert audit.mirrored_count == 0
+
+    upload_again = await client.post(
+        f"/api/projects/{project_id}/skills/upload",
+        data={"skill_key": "deploy-helper"},
+        files={"file": ("deploy-helper.tar.gz", tar_bytes, "application/gzip")},
+    )
+    assert upload_again.status_code == 200, upload_again.text
+    audits = (
+        (
+            await db_session.execute(
+                select(XTraceMemoryIngest).where(XTraceMemoryIngest.skill_id == skill.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audits) == 1
+
+
+@pytest.mark.asyncio
+async def test_xtrace_skill_ingest_worker_processes_queued_upload(
+    client: httpx.AsyncClient,
+    db_session,
+    project_id: str,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from sqlalchemy import select
+
+    from app.core.config import settings as app_settings
+    from app.models.memory import Memory
+    from app.models.skill import Skill
+    from app.models.xtrace_ingest import XTraceMemoryIngest
+    from app.services.xtrace_ingest_queue import run_xtrace_ingest_job
+
+    calls: list[dict] = []
+
+    class FakeXTraceClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, **kwargs):
+            calls.append({"url": str(url), **kwargs})
+            request = httpx.Request("POST", str(url))
+            return httpx.Response(
+                200,
+                request=request,
+                json={
+                    "object": "ingest_job",
+                    "id": "job_skill_worker",
+                    "status": "succeeded",
+                    "result": {
+                        "memories_created": [
+                            {
+                                "id": "artifact_skill_worker",
+                                "type": "artifact",
+                                "status": "active",
+                                "text": (
+                                    "Deploy helper skill captures the preview rollout checklist."
+                                ),
+                            }
+                        ],
+                        "memories_updated": [],
+                    },
+                },
+            )
+
+    monkeypatch.setattr(app_settings, "xtrace_memory_enabled", True)
+    monkeypatch.setattr(app_settings, "xtrace_api_key", "xtk_test")
+    monkeypatch.setattr(app_settings, "xtrace_org_id", "org_test")
+    monkeypatch.setattr(app_settings, "xtrace_memory_base_url", "https://xtrace.test")
+    monkeypatch.setattr("app.services.xtrace_memory.httpx.AsyncClient", FakeXTraceClient)
+
+    content = (
+        "---\n"
+        "name: deploy helper\n"
+        "description: preview deployment workflow\n"
+        "---\n"
+        "# Deploy\n"
+        "Use Coolify preview and verify health checks before sharing the URL.\n"
+    )
+    tar_bytes, _ = tar_from_content("deploy-helper-worker", content)
+    upload = await client.post(
+        f"/api/projects/{project_id}/skills/upload",
+        data={"skill_key": "deploy-helper-worker"},
+        files={"file": ("deploy-helper-worker.tar.gz", tar_bytes, "application/gzip")},
+    )
+    assert upload.status_code == 200, upload.text
+
+    skill = (
+        await db_session.execute(
+            select(Skill).where(
+                Skill.user_id == seed_user.id,
+                Skill.skill_key == "deploy-helper-worker",
+            )
+        )
+    ).scalar_one()
+    queued = (
+        await db_session.execute(
+            select(XTraceMemoryIngest).where(XTraceMemoryIngest.skill_id == skill.id)
+        )
+    ).scalar_one()
+
+    await run_xtrace_ingest_job(queued.id, db=db_session)
+
+    processed = await db_session.get(XTraceMemoryIngest, queued.id)
+    assert processed is not None
+    await db_session.refresh(processed)
+    assert processed.status == "succeeded"
+    assert processed.job_id == "job_skill_worker"
+    assert processed.created_ref_count == 1
+    assert processed.mirrored_count == 1
+
     assert len(calls) == 1
     call = calls[0]
     assert call["url"] == "https://xtrace.test/v1/memories"
-    assert call["params"] == {"wait": "true"}
     assert call["json"]["user_id"] == str(seed_user.id)
     assert call["json"]["conv_id"].startswith(f"skill:{skill.id}:")
-    assert call["json"]["extract_artifacts"] is True
-    assert call["json"]["metadata"]["source_type"] == "skill"
-    assert call["json"]["metadata"]["skill_key"] == "deploy-helper"
-    assert call["json"]["messages"][0]["role"] == "system"
-    assert "Clawdi Cloud skill bundle context" in call["json"]["messages"][0]["content"]
-    assert any(
-        "Skill file: SKILL.md" in message["content"] for message in call["json"]["messages"]
-    )
+    assert call["json"]["metadata"]["skill_key"] == "deploy-helper-worker"
+    assert any("Skill file: SKILL.md" in message["content"] for message in call["json"]["messages"])
 
     memory = (
         await db_session.execute(
@@ -179,21 +301,8 @@ async def test_skill_upload_auto_ingests_xtrace_artifacts_when_configured(
     ).scalar_one()
     assert memory.content == "Deploy helper skill captures the preview rollout checklist."
     assert memory.category == "artifact"
-    assert memory.source_session_id is None
-    assert memory.tags == ["xtrace", "xtrace:artifact", "xtrace_skill"]
-    assert memory.metadata_["skill_key"] == "deploy-helper"
-    assert memory.metadata_["xtrace_memory_id"] == "artifact_skill"
-    assert memory.metadata_["xtrace_type"] == "artifact"
-    assert memory.metadata_["xtrace_status"] == "active"
-
-    audit = (
-        await db_session.execute(
-            select(XTraceMemoryIngest).where(XTraceMemoryIngest.skill_id == skill.id)
-        )
-    ).scalar_one()
-    assert audit.source_type == "skill"
-    assert audit.source_key == call["json"]["metadata"]["source_key"]
-    assert audit.mirrored_count == 1
+    assert memory.metadata_["skill_key"] == "deploy-helper-worker"
+    assert memory.metadata_["xtrace_memory_id"] == "artifact_skill_worker"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -76,6 +76,123 @@ async def test_skill_upload_indexes_file_content_for_search(
 
 
 @pytest.mark.asyncio
+async def test_skill_upload_auto_ingests_xtrace_artifacts_when_configured(
+    client: httpx.AsyncClient,
+    db_session,
+    project_id: str,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from sqlalchemy import select
+
+    from app.core.config import settings as app_settings
+    from app.models.memory import Memory
+    from app.models.skill import Skill
+    from app.models.xtrace_ingest import XTraceMemoryIngest
+
+    calls: list[dict] = []
+
+    class FakeXTraceClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, **kwargs):
+            calls.append({"url": str(url), **kwargs})
+            request = httpx.Request("POST", str(url))
+            return httpx.Response(
+                200,
+                request=request,
+                json={
+                    "object": "ingest_job",
+                    "id": "job_skill",
+                    "status": "succeeded",
+                    "result": {
+                        "object": "ingest_result",
+                        "memories_created": [
+                            {
+                                "id": "artifact_skill",
+                                "type": "artifact",
+                                "text": (
+                                    "Deploy helper skill captures the preview rollout checklist."
+                                ),
+                            }
+                        ],
+                        "memories_updated": [],
+                    },
+                },
+            )
+
+    monkeypatch.setattr(app_settings, "xtrace_memory_enabled", True)
+    monkeypatch.setattr(app_settings, "xtrace_api_key", "xtk_test")
+    monkeypatch.setattr(app_settings, "xtrace_org_id", "org_test")
+    monkeypatch.setattr(app_settings, "xtrace_memory_base_url", "https://xtrace.test")
+    monkeypatch.setattr("app.services.xtrace_memory.httpx.AsyncClient", FakeXTraceClient)
+
+    content = (
+        "---\n"
+        "name: deploy helper\n"
+        "description: preview deployment workflow\n"
+        "---\n"
+        "# Deploy\n"
+        "Use Coolify preview and verify health checks before sharing the URL.\n"
+    )
+    tar_bytes, _ = tar_from_content("deploy-helper", content)
+
+    upload = await client.post(
+        f"/api/projects/{project_id}/skills/upload",
+        data={"skill_key": "deploy-helper"},
+        files={"file": ("deploy-helper.tar.gz", tar_bytes, "application/gzip")},
+    )
+    assert upload.status_code == 200, upload.text
+
+    skill = (
+        await db_session.execute(
+            select(Skill).where(Skill.user_id == seed_user.id, Skill.skill_key == "deploy-helper")
+        )
+    ).scalar_one()
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["url"] == "https://xtrace.test/v1/memories"
+    assert call["params"] == {"wait": "true"}
+    assert call["json"]["user_id"] == str(seed_user.id)
+    assert call["json"]["conv_id"].startswith(f"skill:{skill.id}:")
+    assert call["json"]["extract_artifacts"] is True
+    assert call["json"]["metadata"]["source_type"] == "skill"
+    assert call["json"]["metadata"]["skill_key"] == "deploy-helper"
+    assert call["json"]["messages"][0]["role"] == "system"
+    assert "Clawdi Cloud skill bundle context" in call["json"]["messages"][0]["content"]
+    assert any(
+        "Skill file: SKILL.md" in message["content"] for message in call["json"]["messages"]
+    )
+
+    memory = (
+        await db_session.execute(
+            select(Memory).where(Memory.user_id == seed_user.id, Memory.source == "xtrace_skill")
+        )
+    ).scalar_one()
+    assert memory.content == "Deploy helper skill captures the preview rollout checklist."
+    assert memory.category == "artifact"
+    assert memory.source_session_id is None
+    assert memory.tags == ["xtrace", "xtrace:artifact", "xtrace_skill"]
+    assert memory.metadata_["skill_key"] == "deploy-helper"
+
+    audit = (
+        await db_session.execute(
+            select(XTraceMemoryIngest).where(XTraceMemoryIngest.skill_id == skill.id)
+        )
+    ).scalar_one()
+    assert audit.source_type == "skill"
+    assert audit.source_key == call["json"]["metadata"]["source_key"]
+    assert audit.mirrored_count == 1
+
+
+@pytest.mark.asyncio
 async def test_skill_upload_indexes_reference_file_content_for_search(
     client: httpx.AsyncClient, project_id: str
 ):

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -47,6 +47,69 @@ async def test_skill_upload_happy_path(client: httpx.AsyncClient, project_id: st
 
 
 @pytest.mark.asyncio
+async def test_skill_upload_indexes_file_content_for_search(
+    client: httpx.AsyncClient, project_id: str
+):
+    content = (
+        "---\n"
+        "name: deploy helper\n"
+        "description: ordinary deployment instructions\n"
+        "---\n"
+        "# Deploy\n"
+        "Use the zephyr-coolify-handshake checklist before preview rollout.\n"
+    )
+    tar_bytes, _ = tar_from_content("deploy-helper", content)
+
+    upload = await client.post(
+        f"/api/projects/{project_id}/skills/upload",
+        data={"skill_key": "deploy-helper"},
+        files={"file": ("deploy-helper.tar.gz", tar_bytes, "application/gzip")},
+    )
+    assert upload.status_code == 200, upload.text
+
+    search = await client.get("/api/search?q=zephyr-coolify-handshake")
+    assert search.status_code == 200, search.text
+    skill_hits = [h for h in search.json()["results"] if h["type"] == "skill"]
+    assert skill_hits, search.json()
+    assert skill_hits[0]["title"] == "deploy helper"
+    assert "SKILL.md" in (skill_hits[0]["subtitle"] or "")
+
+
+@pytest.mark.asyncio
+async def test_skill_upload_indexes_reference_file_content_for_search(
+    client: httpx.AsyncClient, project_id: str
+):
+    buf = io.BytesIO()
+    files = {
+        "multi-file/SKILL.md": "---\nname: multi file\ndescription: docs bundle\n---\n# Multi\n",
+        "multi-file/references/deploy.md": (
+            "# Preview\nUse the nebula-reference-marker before promoting a preview.\n"
+        ),
+    }
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, content in files.items():
+            encoded = content.encode("utf-8")
+            info = tarfile.TarInfo(name=name)
+            info.size = len(encoded)
+            tf.addfile(info, io.BytesIO(encoded))
+    tar_bytes = buf.getvalue()
+
+    upload = await client.post(
+        f"/api/projects/{project_id}/skills/upload",
+        data={"skill_key": "multi-file"},
+        files={"file": ("multi-file.tar.gz", tar_bytes, "application/gzip")},
+    )
+    assert upload.status_code == 200, upload.text
+
+    search = await client.get("/api/search?q=nebula-reference-marker")
+    assert search.status_code == 200, search.text
+    skill_hits = [h for h in search.json()["results"] if h["type"] == "skill"]
+    assert skill_hits, search.json()
+    assert skill_hits[0]["title"] == "multi file"
+    assert "references/deploy.md" in (skill_hits[0]["subtitle"] or "")
+
+
+@pytest.mark.asyncio
 async def test_dashboard_edit_with_stale_content_hash_returns_412(
     client: httpx.AsyncClient, project_id: str
 ):

--- a/backend/tests/test_xtrace_backfill.py
+++ b/backend/tests/test_xtrace_backfill.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import json
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from uuid import UUID, uuid4
 
 import httpx
@@ -149,3 +150,63 @@ async def test_xtrace_backfill_replaces_stale_active_job(
     assert stale["status"] == "failed"
     assert stale["current_source_key"] is None
     assert "interrupted" in stale["error"]
+
+
+@pytest.mark.asyncio
+async def test_xtrace_backfill_continues_after_session_rollback(
+    db_session,
+    engine,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from app.models.session import Session
+    from app.models.xtrace_backfill_job import XTraceBackfillJob
+
+    for local_id in ("rollback-first", "rollback-second"):
+        payload = json.dumps([{"role": "user", "content": local_id}]).encode()
+        file_key = f"sessions/{seed_user.id}/{local_id}.json"
+        await get_file_store().put(file_key, payload)
+        db_session.add(
+            Session(
+                user_id=seed_user.id,
+                local_session_id=local_id,
+                started_at=datetime.now(UTC),
+                last_activity_at=datetime.now(UTC),
+                message_count=1,
+                file_key=file_key,
+                content_hash=hashlib.sha256(payload).hexdigest(),
+            )
+        )
+    job = XTraceBackfillJob(
+        requested_by_user_id=seed_user.id,
+        scope_user_id=seed_user.id,
+        include_sessions=True,
+        include_skills=False,
+        force=True,
+        status="queued",
+    )
+    db_session.add(job)
+    await db_session.commit()
+
+    calls = 0
+
+    async def fake_ingest(db, *, session, messages):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("simulated ingest failure")
+        return SimpleNamespace(mirrored_count=2)
+
+    monkeypatch.setattr("app.services.xtrace_backfill.ingest_xtrace_session_memories", fake_ingest)
+
+    test_session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    await run_xtrace_backfill_job(job.id, session_factory=test_session_factory)
+
+    refreshed = await db_session.get(XTraceBackfillJob, job.id)
+    assert refreshed is not None
+    await db_session.refresh(refreshed)
+    assert refreshed.status == "failed"
+    assert refreshed.considered_count == 2
+    assert refreshed.failed_count == 1
+    assert refreshed.sent_count == 1
+    assert refreshed.mirrored_count == 2

--- a/backend/tests/test_xtrace_backfill.py
+++ b/backend/tests/test_xtrace_backfill.py
@@ -211,3 +211,74 @@ async def test_xtrace_backfill_continues_after_session_rollback(
     assert refreshed.sent_count == 1
     assert refreshed.mirrored_count == 2
     assert "simulated ingest failure" in (refreshed.error or "")
+
+
+@pytest.mark.asyncio
+async def test_xtrace_backfill_records_automated_session_skip(
+    db_session,
+    engine,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from sqlalchemy import select
+
+    from app.models.session import Session
+    from app.models.xtrace_backfill_job import XTraceBackfillJob
+    from app.models.xtrace_ingest import XTraceMemoryIngest
+
+    local_id = f"xtrace-cron-skip-{uuid4().hex[:8]}"
+    payload = json.dumps([{"role": "user", "content": "automated cron output"}]).encode()
+    file_key = f"sessions/{seed_user.id}/{local_id}.json"
+    await get_file_store().put(file_key, payload)
+    db_session.add(
+        Session(
+            user_id=seed_user.id,
+            local_session_id=local_id,
+            started_at=datetime.now(UTC),
+            last_activity_at=datetime.now(UTC),
+            duration_seconds=600,
+            message_count=20,
+            file_key=file_key,
+            content_hash=hashlib.sha256(payload).hexdigest(),
+            summary="Cron: portfolio-watch",
+        )
+    )
+    job = XTraceBackfillJob(
+        requested_by_user_id=seed_user.id,
+        scope_user_id=seed_user.id,
+        include_sessions=True,
+        include_skills=False,
+        status="queued",
+    )
+    db_session.add(job)
+    await db_session.commit()
+
+    async def unexpected_ingest(*args, **kwargs):
+        raise AssertionError("automated sessions should not be sent to XTrace")
+
+    monkeypatch.setattr(
+        "app.services.xtrace_backfill.ingest_xtrace_session_memories",
+        unexpected_ingest,
+    )
+
+    test_session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    await run_xtrace_backfill_job(job.id, session_factory=test_session_factory)
+
+    refreshed = await db_session.get(XTraceBackfillJob, job.id)
+    assert refreshed is not None
+    await db_session.refresh(refreshed)
+    assert refreshed.status == "succeeded"
+    assert refreshed.considered_count == 1
+    assert refreshed.sent_count == 0
+    assert refreshed.skipped_count == 1
+    audit = (
+        await db_session.execute(
+            select(XTraceMemoryIngest).where(
+                XTraceMemoryIngest.user_id == seed_user.id,
+                XTraceMemoryIngest.local_session_id == local_id,
+            )
+        )
+    ).scalar_one()
+    assert audit.status == "skipped"
+    assert audit.response["skip_reason"] == "automated_session"
+    assert audit.response["policy"]["estimated_xtrace_messages"] == 21

--- a/backend/tests/test_xtrace_backfill.py
+++ b/backend/tests/test_xtrace_backfill.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from datetime import UTC, datetime
+from uuid import UUID
+
+import httpx
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.services.file_store import get_file_store
+from app.services.tar_utils import tar_from_content
+from app.services.xtrace_backfill import run_xtrace_backfill_job
+
+
+@pytest.mark.asyncio
+async def test_xtrace_backfill_job_dry_run_tracks_session_and_skill_progress(
+    client: httpx.AsyncClient,
+    db_session,
+    engine,
+    seed_user,
+    project_id: str,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from app.core.config import settings as app_settings
+    from app.models.session import Session
+    from app.models.skill import Skill
+
+    session_bytes = json.dumps(
+        [{"role": "user", "content": "Remember that preview backfills are tracked."}]
+    ).encode()
+    session_file_key = f"sessions/{seed_user.id}/xtrace-job-session.json"
+    await get_file_store().put(session_file_key, session_bytes)
+    db_session.add(
+        Session(
+            user_id=seed_user.id,
+            local_session_id="xtrace-job-session",
+            started_at=datetime.now(UTC),
+            last_activity_at=datetime.now(UTC),
+            message_count=1,
+            file_key=session_file_key,
+            content_hash=hashlib.sha256(session_bytes).hexdigest(),
+        )
+    )
+
+    skill_bytes, skill_file_count = tar_from_content(
+        "xtrace-job-skill",
+        "---\nname: xtrace job skill\ndescription: tracked skill\n---\n# Skill\n",
+    )
+    skill_hash = hashlib.sha256(skill_bytes).hexdigest()
+    skill_file_key = f"skills/{seed_user.id}/{project_id}/xtrace-job-skill.tar.gz"
+    await get_file_store().put(skill_file_key, skill_bytes)
+    db_session.add(
+        Skill(
+            user_id=seed_user.id,
+            project_id=project_id,
+            skill_key="xtrace-job-skill",
+            name="xtrace job skill",
+            description="tracked skill",
+            content_hash=skill_hash,
+            file_key=skill_file_key,
+            file_count=skill_file_count,
+            source="local",
+        )
+    )
+    await db_session.commit()
+
+    monkeypatch.setattr(app_settings, "xtrace_memory_enabled", True)
+    monkeypatch.setattr(app_settings, "xtrace_api_key", "xtk_test")
+    monkeypatch.setattr(app_settings, "xtrace_org_id", "org_test")
+    monkeypatch.setattr("app.routes.xtrace._start_job", lambda job_id: None)
+
+    created = await client.post("/api/xtrace/backfills", json={"dry_run": True})
+    assert created.status_code == 202, created.text
+    job_id = created.json()["id"]
+    test_session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    await run_xtrace_backfill_job(UUID(job_id), session_factory=test_session_factory)
+
+    job = None
+    for _ in range(40):
+        status = await client.get(f"/api/xtrace/backfills/{job_id}")
+        assert status.status_code == 200, status.text
+        job = status.json()
+        if job["status"] == "succeeded":
+            break
+        await asyncio.sleep(0.05)
+
+    assert job is not None
+    assert job["status"] == "succeeded"
+    assert job["considered_count"] == 2
+    assert job["skipped_count"] == 2
+    assert job["sent_count"] == 0
+    assert job["sessions_considered"] == 1
+    assert job["skills_considered"] == 1
+    assert job["scope_user_id"] == str(seed_user.id)
+
+
+@pytest.mark.asyncio
+async def test_xtrace_backfill_requires_xtrace_configuration(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from app.core.config import settings as app_settings
+
+    monkeypatch.setattr(app_settings, "xtrace_memory_enabled", False)
+
+    response = await client.post("/api/xtrace/backfills", json={"dry_run": True})
+    assert response.status_code == 503
+    assert "not configured" in response.text

--- a/backend/tests/test_xtrace_backfill.py
+++ b/backend/tests/test_xtrace_backfill.py
@@ -190,7 +190,7 @@ async def test_xtrace_backfill_continues_after_session_rollback(
 
     calls = 0
 
-    async def fake_ingest(db, *, session, messages):
+    async def fake_ingest(db, *, session, messages, max_messages=None):
         nonlocal calls
         calls += 1
         if calls == 1:

--- a/backend/tests/test_xtrace_backfill.py
+++ b/backend/tests/test_xtrace_backfill.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
-from datetime import UTC, datetime
-from uuid import UUID
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
@@ -109,3 +109,43 @@ async def test_xtrace_backfill_requires_xtrace_configuration(
     response = await client.post("/api/xtrace/backfills", json={"dry_run": True})
     assert response.status_code == 503
     assert "not configured" in response.text
+
+
+@pytest.mark.asyncio
+async def test_xtrace_backfill_replaces_stale_active_job(
+    client: httpx.AsyncClient,
+    db_session,
+    seed_user,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from app.core.config import settings as app_settings
+    from app.models.xtrace_backfill_job import XTraceBackfillJob
+
+    stale_job_id = uuid4()
+    stale_job = XTraceBackfillJob(
+        id=stale_job_id,
+        requested_by_user_id=seed_user.id,
+        scope_user_id=seed_user.id,
+        status="running",
+        updated_at=datetime.now(UTC) - timedelta(minutes=30),
+        current_source_type="session",
+        current_source_key="session:stale",
+    )
+    db_session.add(stale_job)
+    await db_session.commit()
+
+    monkeypatch.setattr(app_settings, "xtrace_memory_enabled", True)
+    monkeypatch.setattr(app_settings, "xtrace_api_key", "xtk_test")
+    monkeypatch.setattr(app_settings, "xtrace_org_id", "org_test")
+    monkeypatch.setattr("app.routes.xtrace._start_job", lambda job_id: None)
+
+    created = await client.post("/api/xtrace/backfills", json={"dry_run": True})
+    assert created.status_code == 202, created.text
+    assert created.json()["id"] != str(stale_job_id)
+
+    status = await client.get(f"/api/xtrace/backfills/{stale_job_id}")
+    assert status.status_code == 200, status.text
+    stale = status.json()
+    assert stale["status"] == "failed"
+    assert stale["current_source_key"] is None
+    assert "interrupted" in stale["error"]

--- a/backend/tests/test_xtrace_backfill.py
+++ b/backend/tests/test_xtrace_backfill.py
@@ -210,3 +210,4 @@ async def test_xtrace_backfill_continues_after_session_rollback(
     assert refreshed.failed_count == 1
     assert refreshed.sent_count == 1
     assert refreshed.mirrored_count == 2
+    assert "simulated ingest failure" in (refreshed.error or "")

--- a/deploy/preview/README.md
+++ b/deploy/preview/README.md
@@ -130,6 +130,8 @@ for each service.
     XTRACE_API_KEY=
     XTRACE_ORG_ID=
     XTRACE_MEMORY_BASE_URL=https://api.production.xtrace.ai
+    XTRACE_MEMORY_MAX_MESSAGES=80
+    XTRACE_MEMORY_BACKFILL_MAX_MESSAGES=20
     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=...
     CLERK_SECRET_KEY=...
     NEXT_PUBLIC_DEPLOY_API_URL=https://<your-public-prod-api>
@@ -203,6 +205,12 @@ The output prints `job_id`, `status`, `created_ref_count`,
 or `source_type=skill`, including cases where XTrace returns a pending job or
 zero memory refs. API logs include `xtrace_memory_ingested ... job_id=...` and
 `xtrace_skill_memory_ingested ... job_id=...`.
+
+Preview defaults intentionally cap XTrace payload size. Live session uploads
+send at most `XTRACE_MEMORY_MAX_MESSAGES` messages, and historical backfills
+send at most `XTRACE_MEMORY_BACKFILL_MAX_MESSAGES` messages per session. Keep
+the backfill cap low so a bulk run does not exhaust the XTrace message quota by
+replaying full transcripts.
 
 Existing skill archives from the restored snapshot need one backfill after the
 migration so skill-file content search works:

--- a/deploy/preview/README.md
+++ b/deploy/preview/README.md
@@ -144,7 +144,7 @@ for each service.
     command from the auto-injected `SERVICE_FQDN_*` — no need to set them
     in the Coolify UI.
 
-    To enable XTrace session memory in a preview, set
+    To enable XTrace session and skill memory in a preview, set
     `XTRACE_MEMORY_ENABLED=true` plus the preview XTrace key/org values,
     then redeploy the preview so the API container starts with those env vars.
 
@@ -157,8 +157,22 @@ After all eleven, opening a PR on the repo deploys a preview automatically.
 
 ## XTrace memory preview checks
 
-After deploying a preview with XTrace enabled, upload or re-upload one session,
-then run this inside the preview API container:
+After deploying a preview with XTrace enabled, run the backfill from inside the
+preview API container so existing stored sessions and skills are sent to XTrace:
+
+```bash
+cd /app/backend
+pdm run python -m scripts.backfill_xtrace_memory --all
+```
+
+For a smaller validation run:
+
+```bash
+cd /app/backend
+pdm run python -m scripts.backfill_xtrace_memory --all --limit 10
+```
+
+To inspect one session directly:
 
 ```bash
 cd /app/backend
@@ -170,8 +184,10 @@ pdm run python -m scripts.debug_xtrace_session_ingest \
 
 The output prints `job_id`, `status`, `created_ref_count`,
 `updated_ref_count`, and `mirrored_count`. The same data is also stored in
-`xtrace_memory_ingests`, including cases where XTrace returns a pending job or
-zero memory refs. API logs include `xtrace_memory_ingested ... job_id=...`.
+`xtrace_memory_ingests` with `source_type=session` or `source_type=skill`,
+including cases where XTrace returns a pending job or zero memory refs. API logs
+include `xtrace_memory_ingested ... job_id=...` and
+`xtrace_skill_memory_ingested ... job_id=...`.
 
 Existing skill archives from the restored snapshot need one backfill after the
 migration so skill-file content search works:

--- a/deploy/preview/README.md
+++ b/deploy/preview/README.md
@@ -126,6 +126,10 @@ for each service.
     COMPOSIO_API_KEY=...
     MEMORY_EMBEDDING_MODE=...
     MEMORY_EMBEDDING_MODEL=...
+    XTRACE_MEMORY_ENABLED=false
+    XTRACE_API_KEY=
+    XTRACE_ORG_ID=
+    XTRACE_MEMORY_BASE_URL=https://api.production.xtrace.ai
     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=...
     CLERK_SECRET_KEY=...
     NEXT_PUBLIC_DEPLOY_API_URL=https://<your-public-prod-api>
@@ -140,12 +144,42 @@ for each service.
     command from the auto-injected `SERVICE_FQDN_*` — no need to set them
     in the Coolify UI.
 
+    To enable XTrace session memory in a preview, set
+    `XTRACE_MEMORY_ENABLED=true` plus the preview XTrace key/org values,
+    then redeploy the preview so the API container starts with those env vars.
+
 11. **Clerk dashboard:** add `https://*.<your-domain>` to **Allowed Origins**
     and `https://*.<your-domain>/sign-in/sso-callback` to **Authorized Redirect
     URLs** for the production Clerk app. (Wildcard at the apex covers all
     one-label preview hostnames.)
 
 After all eleven, opening a PR on the repo deploys a preview automatically.
+
+## XTrace memory preview checks
+
+After deploying a preview with XTrace enabled, upload or re-upload one session,
+then run this inside the preview API container:
+
+```bash
+cd /app/backend
+pdm run python -m scripts.debug_xtrace_session_ingest \
+  --local-session-id <local-session-id> \
+  --user-id <user-uuid> \
+  --print-response
+```
+
+The output prints `job_id`, `status`, `created_ref_count`,
+`updated_ref_count`, and `mirrored_count`. The same data is also stored in
+`xtrace_memory_ingests`, including cases where XTrace returns a pending job or
+zero memory refs. API logs include `xtrace_memory_ingested ... job_id=...`.
+
+Existing skill archives from the restored snapshot need one backfill after the
+migration so skill-file content search works:
+
+```bash
+cd /app/backend
+pdm run python -m scripts.reindex_skill_chunks --all
+```
 
 ## Refreshing the snapshot
 

--- a/deploy/preview/README.md
+++ b/deploy/preview/README.md
@@ -157,19 +157,33 @@ After all eleven, opening a PR on the repo deploys a preview automatically.
 
 ## XTrace memory preview checks
 
-After deploying a preview with XTrace enabled, run the backfill from inside the
-preview API container so existing stored sessions and skills are sent to XTrace:
+After deploying a preview with XTrace enabled, trigger a backend-managed
+backfill job so existing stored sessions and skills are sent to XTrace:
 
 ```bash
-cd /app/backend
-pdm run python -m scripts.backfill_xtrace_memory --all
+API_KEY=<preview-api-key>
+curl -s -X POST \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  https://preview-api.faraday.cloud/api/xtrace/backfills \
+  -d '{"include_sessions":true,"include_skills":true}'
 ```
 
 For a smaller validation run:
 
 ```bash
-cd /app/backend
-pdm run python -m scripts.backfill_xtrace_memory --all --limit 10
+curl -s -X POST \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  https://preview-api.faraday.cloud/api/xtrace/backfills \
+  -d '{"include_sessions":true,"include_skills":true,"limit":10}'
+```
+
+Poll the job until `status` leaves `queued`/`running`:
+
+```bash
+curl -s -H "Authorization: Bearer $API_KEY" \
+  https://preview-api.faraday.cloud/api/xtrace/backfills/<job-id>
 ```
 
 To inspect one session directly:
@@ -184,9 +198,10 @@ pdm run python -m scripts.debug_xtrace_session_ingest \
 
 The output prints `job_id`, `status`, `created_ref_count`,
 `updated_ref_count`, and `mirrored_count`. The same data is also stored in
-`xtrace_memory_ingests` with `source_type=session` or `source_type=skill`,
-including cases where XTrace returns a pending job or zero memory refs. API logs
-include `xtrace_memory_ingested ... job_id=...` and
+`xtrace_backfill_jobs` tracks job progress and per-source counters.
+`xtrace_memory_ingests` stores each XTrace request with `source_type=session`
+or `source_type=skill`, including cases where XTrace returns a pending job or
+zero memory refs. API logs include `xtrace_memory_ingested ... job_id=...` and
 `xtrace_skill_memory_ingested ... job_id=...`.
 
 Existing skill archives from the restored snapshot need one backfill after the

--- a/deploy/preview/docker-compose.yml
+++ b/deploy/preview/docker-compose.yml
@@ -151,6 +151,8 @@ services:
       XTRACE_ORG_ID: ${XTRACE_ORG_ID:-}
       XTRACE_MEMORY_BASE_URL: ${XTRACE_MEMORY_BASE_URL:-https://api.production.xtrace.ai}
       XTRACE_MEMORY_APP_ID: ${XTRACE_MEMORY_APP_ID:-clawdi-cloud-preview}
+      XTRACE_MEMORY_MAX_MESSAGES: ${XTRACE_MEMORY_MAX_MESSAGES:-80}
+      XTRACE_MEMORY_BACKFILL_MAX_MESSAGES: ${XTRACE_MEMORY_BACKFILL_MAX_MESSAGES:-20}
     ports:
       - "8000"
     command: >

--- a/deploy/preview/docker-compose.yml
+++ b/deploy/preview/docker-compose.yml
@@ -146,6 +146,11 @@ services:
       MEMORY_EMBEDDING_API_KEY: ${MEMORY_EMBEDDING_API_KEY:-}
       MEMORY_EMBEDDING_BASE_URL: ${MEMORY_EMBEDDING_BASE_URL:-}
       MEMORY_EMBEDDING_MODEL: ${MEMORY_EMBEDDING_MODEL:-text-embedding-3-small}
+      XTRACE_MEMORY_ENABLED: ${XTRACE_MEMORY_ENABLED:-false}
+      XTRACE_API_KEY: ${XTRACE_API_KEY:-}
+      XTRACE_ORG_ID: ${XTRACE_ORG_ID:-}
+      XTRACE_MEMORY_BASE_URL: ${XTRACE_MEMORY_BASE_URL:-https://api.production.xtrace.ai}
+      XTRACE_MEMORY_APP_ID: ${XTRACE_MEMORY_APP_ID:-clawdi-cloud-preview}
     ports:
       - "8000"
     command: >

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1934,6 +1934,41 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/xtrace/backfills": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Backfills */
+        get: operations["list_backfills_api_xtrace_backfills_get"];
+        put?: never;
+        /** Create Backfill */
+        post: operations["create_backfill_api_xtrace_backfills_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/xtrace/backfills/{job_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Backfill */
+        get: operations["get_backfill_api_xtrace_backfills__job_id__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/health": {
         parameters: {
             query?: never;
@@ -2839,6 +2874,7 @@ export interface components {
             source_environment_id?: string | null;
             /** Source Machine Name */
             source_machine_name?: string | null;
+            xtrace?: components["schemas"]["XTraceMemoryDetails"] | null;
         };
         /** Paginated[ConnectorAvailableAppResponse] */
         Paginated_ConnectorAvailableAppResponse_: {
@@ -2888,6 +2924,17 @@ export interface components {
         Paginated_VaultResponse_: {
             /** Items */
             items: components["schemas"]["VaultResponse"][];
+            /** Total */
+            total: number;
+            /** Page */
+            page: number;
+            /** Page Size */
+            page_size: number;
+        };
+        /** Paginated[XTraceBackfillJobResponse] */
+        Paginated_XTraceBackfillJobResponse_: {
+            /** Items */
+            items: components["schemas"]["XTraceBackfillJobResponse"][];
             /** Total */
             total: number;
             /** Page */
@@ -3847,6 +3894,142 @@ export interface components {
         /** VaultSectionsResponse */
         VaultSectionsResponse: {
             [key: string]: string[];
+        };
+        /** XTraceBackfillCreate */
+        XTraceBackfillCreate: {
+            /**
+             * Include Sessions
+             * @default true
+             */
+            include_sessions: boolean;
+            /**
+             * Include Skills
+             * @default true
+             */
+            include_skills: boolean;
+            /**
+             * Force
+             * @default false
+             */
+            force: boolean;
+            /**
+             * Dry Run
+             * @default false
+             */
+            dry_run: boolean;
+            /** Limit */
+            limit?: number | null;
+            /**
+             * All Users
+             * @default false
+             */
+            all_users: boolean;
+        };
+        /** XTraceBackfillJobResponse */
+        XTraceBackfillJobResponse: {
+            /** Id */
+            id: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "queued" | "running" | "succeeded" | "failed";
+            /** Requested By User Id */
+            requested_by_user_id: string | null;
+            /** Scope User Id */
+            scope_user_id: string | null;
+            /** Include Sessions */
+            include_sessions: boolean;
+            /** Include Skills */
+            include_skills: boolean;
+            /** Force */
+            force: boolean;
+            /** Dry Run */
+            dry_run: boolean;
+            /** Limit */
+            limit: number | null;
+            /** Current Source Type */
+            current_source_type: string | null;
+            /** Current Source Key */
+            current_source_key: string | null;
+            /** Considered Count */
+            considered_count: number;
+            /** Sent Count */
+            sent_count: number;
+            /** Skipped Count */
+            skipped_count: number;
+            /** Failed Count */
+            failed_count: number;
+            /** Mirrored Count */
+            mirrored_count: number;
+            /** Sessions Considered */
+            sessions_considered: number;
+            /** Sessions Sent */
+            sessions_sent: number;
+            /** Sessions Skipped */
+            sessions_skipped: number;
+            /** Sessions Failed */
+            sessions_failed: number;
+            /** Sessions Mirrored */
+            sessions_mirrored: number;
+            /** Skills Considered */
+            skills_considered: number;
+            /** Skills Sent */
+            skills_sent: number;
+            /** Skills Skipped */
+            skills_skipped: number;
+            /** Skills Failed */
+            skills_failed: number;
+            /** Skills Mirrored */
+            skills_mirrored: number;
+            /** Error */
+            error: string | null;
+            /** Created At */
+            created_at: string | null;
+            /** Updated At */
+            updated_at: string | null;
+            /** Started At */
+            started_at: string | null;
+            /** Finished At */
+            finished_at: string | null;
+        };
+        /** XTraceMemoryDetails */
+        XTraceMemoryDetails: {
+            /** Memory Id */
+            memory_id?: string | null;
+            /** Type */
+            type?: string | null;
+            /** Status */
+            status?: string | null;
+            /** Operation */
+            operation?: string | null;
+            /** Source Type */
+            source_type?: string | null;
+            /** Source Key */
+            source_key?: string | null;
+            /** Local Session Id */
+            local_session_id?: string | null;
+            /** Skill Key */
+            skill_key?: string | null;
+            /** Supersedes */
+            supersedes?: string[];
+            /** Superseded By */
+            superseded_by?: string | null;
+            /** Timeline */
+            timeline?: components["schemas"]["XTraceMemoryTimelineItem"][];
+        };
+        /** XTraceMemoryTimelineItem */
+        XTraceMemoryTimelineItem: {
+            /** Operation */
+            operation: string;
+            /** Content */
+            content: string;
+            /** Memory Id */
+            memory_id?: string | null;
+            /** Status */
+            status?: string | null;
+            /** At */
+            at?: string | null;
         };
     };
     responses: never;
@@ -7297,6 +7480,106 @@ export interface operations {
                     "application/json": {
                         [key: string]: string;
                     };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_backfills_api_xtrace_backfills_get: {
+        parameters: {
+            query?: {
+                page?: number;
+                page_size?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Paginated_XTraceBackfillJobResponse_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_backfill_api_xtrace_backfills_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-Admin-Key"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["XTraceBackfillCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["XTraceBackfillJobResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_backfill_api_xtrace_backfills__job_id__get: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-Admin-Key"?: string | null;
+            };
+            path: {
+                job_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["XTraceBackfillJobResponse"];
                 };
             };
             /** @description Validation Error */

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -5917,6 +5917,8 @@ export interface operations {
                 category?: string | null;
                 q?: string | null;
                 order?: string;
+                source_session_id?: string | null;
+                environment_id?: string | null;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## Summary
- Add optional XTrace Memory ingestion for uploaded cloud sessions, including local mirrored memories and audit rows for job/status/ref counts.
- Add searchable skill file chunks for uploaded/installed skills, plus a backfill script for existing skill archives.
- Add Coolify preview docs and debug scripts for XTrace ingestion verification.

## Verification
- cd backend && uv run ruff check app tests/test_sessions.py tests/test_skills.py scripts/debug_xtrace_session_ingest.py scripts/reindex_skill_chunks.py alembic/versions/84a75f7f0e2d_add_xtrace_memory_ingests.py alembic/versions/3d0b4d7f9a2e_add_skill_chunks.py
- cd backend && uv run pytest -q

Full suite: 363 passed, 13 warnings.