### PR TITLE
Normalize managed AI providers and Codex OAuth defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.12.1
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.1
+
+Package: `clawdi@0.12.1`
+
+### Fixed
+
+- Fixed Codex AI Provider apply so provider-bound Codex OAuth profiles write
+  the selected default model even when they use Codex's built-in OpenAI
+  provider configuration.
+
+## Clawdi 2026-06-05
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-2026-06-05
+
+### Fixed
+
+- Fixed Codex AI Provider OAuth setup in development environments whose web
+  dashboard runs on a configured HTTP origin other than loopback. Unconfigured
+  hosts and ports are still rejected.
+
 ## Clawdi CLI v0.12.0
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.0

--- a/backend/app/routes/ai_providers.py
+++ b/backend/app/routes/ai_providers.py
@@ -716,10 +716,27 @@ def _validate_redirect_uri(input: str) -> None:
         return
     if parsed.scheme == "http" and parsed.hostname in {"localhost", "127.0.0.1", "::1"}:
         return
+    if (
+        settings.environment == "development"
+        and parsed.scheme == "http"
+        and parsed.netloc
+        and parsed.hostname in _development_oauth_redirect_hosts()
+    ):
+        return
     raise HTTPException(
         status.HTTP_422_UNPROCESSABLE_ENTITY,
         "redirect_uri must be https or loopback http",
     )
+
+
+def _development_oauth_redirect_hosts() -> set[str]:
+    origins = [settings.web_origin, *settings.cors_origins]
+    hosts: set[str] = set()
+    for origin in origins:
+        parsed = urlparse(origin)
+        if parsed.scheme == "http" and parsed.hostname:
+            hosts.add(parsed.hostname)
+    return hosts
 
 
 async def _find_provider(

--- a/backend/app/routes/ai_providers.py
+++ b/backend/app/routes/ai_providers.py
@@ -719,8 +719,7 @@ def _validate_redirect_uri(input: str) -> None:
     if (
         settings.environment == "development"
         and parsed.scheme == "http"
-        and parsed.netloc
-        and parsed.hostname in _development_oauth_redirect_hosts()
+        and _url_origin(parsed) in _development_oauth_redirect_origins()
     ):
         return
     raise HTTPException(
@@ -729,14 +728,22 @@ def _validate_redirect_uri(input: str) -> None:
     )
 
 
-def _development_oauth_redirect_hosts() -> set[str]:
+def _url_origin(parsed) -> str | None:
+    if not parsed.scheme or not parsed.netloc or parsed.username or parsed.password:
+        return None
+    return f"{parsed.scheme.lower()}://{parsed.netloc.lower()}"
+
+
+def _development_oauth_redirect_origins() -> set[str]:
     origins = [settings.web_origin, *settings.cors_origins]
-    hosts: set[str] = set()
+    allowed_origins: set[str] = set()
     for origin in origins:
         parsed = urlparse(origin)
-        if parsed.scheme == "http" and parsed.hostname:
-            hosts.add(parsed.hostname)
-    return hosts
+        if parsed.scheme == "http":
+            parsed_origin = _url_origin(parsed)
+            if parsed_origin:
+                allowed_origins.add(parsed_origin)
+    return allowed_origins
 
 
 async def _find_provider(

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -575,12 +575,20 @@ async def test_ai_provider_oauth_start_allows_dev_web_origin_http_redirect(
                 "redirect_uri": "http://phala-dev:33221/onboarding?step=provider&provider_oauth=codex",
             },
         )
+        wrong_port = await client.post(
+            "/api/ai-providers/openai-codex/auth/oauth/start",
+            json={
+                "provider": "codex",
+                "redirect_uri": "http://phala-dev:33222/onboarding?step=provider&provider_oauth=codex",
+            },
+        )
     finally:
         settings.environment = previous_environment
         settings.web_origin = previous_web_origin
         settings.cors_origins = previous_cors_origins
 
     assert started.status_code == 200, started.text
+    assert wrong_port.status_code == 422, wrong_port.text
     params = parse_qs(urlparse(started.json()["auth_url"]).query)
     assert params["redirect_uri"] == [
         "http://phala-dev:33221/onboarding?step=provider&provider_oauth=codex"

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -548,6 +548,46 @@ async def test_ai_provider_oauth_start_uses_builtin_codex_config(client: httpx.A
 
 
 @pytest.mark.asyncio
+async def test_ai_provider_oauth_start_allows_dev_web_origin_http_redirect(
+    client: httpx.AsyncClient,
+):
+    created = await client.post(
+        "/api/ai-providers",
+        json={
+            "provider_id": "openai-codex",
+            "type": "openai",
+            "base_url": "https://api.openai.com/v1",
+            "auth": {"type": "agent_profile", "tool": "codex", "profile": "default"},
+        },
+    )
+    assert created.status_code == 200, created.text
+    previous_environment = settings.environment
+    previous_web_origin = settings.web_origin
+    previous_cors_origins = settings.cors_origins
+    settings.environment = "development"
+    settings.web_origin = "http://phala-dev:33221"
+    settings.cors_origins = ["http://localhost:33221"]
+    try:
+        started = await client.post(
+            "/api/ai-providers/openai-codex/auth/oauth/start",
+            json={
+                "provider": "codex",
+                "redirect_uri": "http://phala-dev:33221/onboarding?step=provider&provider_oauth=codex",
+            },
+        )
+    finally:
+        settings.environment = previous_environment
+        settings.web_origin = previous_web_origin
+        settings.cors_origins = previous_cors_origins
+
+    assert started.status_code == 200, started.text
+    params = parse_qs(urlparse(started.json()["auth_url"]).query)
+    assert params["redirect_uri"] == [
+        "http://phala-dev:33221/onboarding?step=provider&provider_oauth=codex"
+    ]
+
+
+@pytest.mark.asyncio
 async def test_ai_provider_oauth_start_requires_clean_redirect_and_params(
     client: httpx.AsyncClient,
 ):

--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.0",
+	"version": "0.12.1",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/lib/ai-provider-projection.ts
+++ b/packages/cli/src/lib/ai-provider-projection.ts
@@ -408,7 +408,7 @@ function codexModelProviderId(provider: ProjectionProvider): string {
 }
 
 function shouldWriteCodexModel(provider: ProjectionProvider): boolean {
-	return !usesBuiltInCodexOpenAiProvider(provider);
+	return Boolean(provider.default_model);
 }
 
 function usesBuiltInCodexOpenAiProvider(provider: ProjectionProvider): boolean {

--- a/packages/cli/tests/commands/ai-provider.test.ts
+++ b/packages/cli/tests/commands/ai-provider.test.ts
@@ -1153,7 +1153,7 @@ describe("ai-provider commands", () => {
 		}
 
 		expect(output()).toContain('model_provider = \\"openai\\"');
-		expect(output()).not.toContain('model = \\"gpt-5.2\\"');
+		expect(output()).toContain('model = \\"gpt-5.2\\"');
 		expect(output()).not.toContain("env_key");
 		expect(output()).not.toContain("[model_providers");
 	});
@@ -1228,6 +1228,7 @@ describe("ai-provider commands", () => {
 
 		expect(output()).toContain("Provider anthropic-main skipped for codex");
 		expect(output()).toContain("Default provider anthropic-main cannot be applied to codex");
+		expect(output()).toContain('model = \\"gpt-5.2\\"');
 		expect(output()).toContain('model_provider = \\"openai\\"');
 	});
 


### PR DESCRIPTION
## Summary
- allow development OAuth redirects from configured web/CORS HTTP origins
- apply Codex OAuth default models even when using the built-in OpenAI provider
- prepare the CLI patch release as `clawdi@0.12.1`

## Latest head
- `2526b2b40770f67b018b08e6e361365c6c2dbd17`

## Verification
- `backend`: `uv run python scripts/check_generated_api.py`
- `backend`: `uv run ruff check app tests`
- `backend`: `uv run pytest -q`
- repo root: `bun run check`
- repo root: `bun run typecheck`
- repo root: `bun run test`
- repo root: `bun run build`

## Release impact
- App/backend/web release expected: `clawdi-2026-06-05`
- CLI publish expected: `clawdi-cli-v0.12.1` / `clawdi@0.12.1`

## Migration notes
- No database migrations.
