### PR TITLE
fix(vault): tolerate web/api deploy skew on vault key counts

### DIFF
--- a/apps/web/src/app/(dashboard)/vault/page.tsx
+++ b/apps/web/src/app/(dashboard)/vault/page.tsx
@@ -198,8 +198,27 @@ function VaultCard({
 	shared?: boolean;
 }) {
 	// Key count ships on the list response (names only, never values) —
-	// no per-card items fetch.
-	const keyCount = vault.item_count ?? 0;
+	// no per-card items fetch. EXCEPT under deploy skew: a web build that
+	// knows item_count can face an API that doesn't send it yet (web and
+	// api don't deploy atomically), and treating missing as 0 told prod
+	// users every vault was empty. Fall back to the per-card fetch then.
+	const listCount: number | undefined = vault.item_count;
+	const keys = useQuery({
+		queryKey: ["vault-items", vault.slug, vault.project_ids?.[0]],
+		enabled: listCount === undefined,
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/api/vault/{slug}/items", {
+					params: {
+						path: { slug: vault.slug },
+						query: { project_id: vault.project_ids?.[0] ?? undefined },
+					},
+				}),
+			),
+	});
+	const keyCount =
+		listCount ??
+		(keys.data ? Object.values(keys.data).reduce((n, arr) => n + arr.length, 0) : null);
 	const usedBy = (vault.project_ids ?? [])
 		.map((id) => projectNameById.get(id))
 		.filter((n): n is string => !!n);
@@ -224,7 +243,7 @@ function VaultCard({
 				<p className="truncate font-mono text-xs text-muted-foreground">{vault.slug}</p>
 			</div>
 			<div className="mt-auto flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground tabular-nums">
-				<span>{`${keyCount} ${keyCount === 1 ? "key" : "keys"}`}</span>
+				<span>{keyCount === null ? "…" : `${keyCount} ${keyCount === 1 ? "key" : "keys"}`}</span>
 				{usedBy.length > 0 ? (
 					<span className="truncate" title={usedBy.join(", ")}>
 						used by {usedBy.slice(0, 2).join(", ")}

--- a/apps/web/src/app/(dashboard)/vault/page.tsx
+++ b/apps/web/src/app/(dashboard)/vault/page.tsx
@@ -197,6 +197,7 @@ function VaultCard({
 	projectNameById: ReadonlyMap<string, string>;
 	shared?: boolean;
 }) {
+	const api = useApi();
 	// Key count ships on the list response (names only, never values) —
 	// no per-card items fetch. EXCEPT under deploy skew: a web build that
 	// knows item_count can face an API that doesn't send it yet (web and


### PR DESCRIPTION
Prod regression after #139's web rollout: the prod API hasn't redeployed yet, so `item_count` is missing from the vault list and every card showed **0 keys** (e.g. default actually has 695).

Fix: missing field = unknown, not zero — show `…` and fall back to the old per-card items fetch until the API catches up. Zero behavior change once the API ships `item_count`.

Real fix in parallel: redeploy cloud-api from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)