### PR TITLE
Fix vault and skill UI regressions

### DIFF
--- a/apps/web/src/app/(dashboard)/agents/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/agents/[id]/page.tsx
@@ -34,7 +34,7 @@ import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { unwrap, useApi, useAuthedFetch } from "@/lib/api";
+import { unwrap, useApi } from "@/lib/api";
 import { fetchAllPages } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
 import { projectResourceHref } from "@/lib/project-resource-model";
@@ -43,31 +43,13 @@ import { errorMessage, relativeTime } from "@/lib/utils";
 type SkillSummary = components["schemas"]["SkillSummaryResponse"];
 type AgentTab = "sessions" | "skills" | "projects";
 
-interface ProjectRow {
-	id: string;
-	name: string;
-	slug: string;
-	kind: string;
-	is_owner?: boolean;
-	owner_display?: string | null;
-	owner_handle?: string | null;
-}
-
-interface ProjectBindingRow {
-	id: string;
-	agent_id: string;
-	project_id: string;
-	binding_type: "primary" | "context";
-	priority: number;
-	default_write_enabled: boolean;
-	created_at: string;
-}
+type ProjectRow = components["schemas"]["ProjectResponse"];
+type ProjectBindingRow = components["schemas"]["AgentProjectBindingResponse"];
 
 export default function AgentDetailPage() {
 	const { id } = useParams<{ id: string }>();
 	const router = useRouter();
 	const api = useApi();
-	const authedFetch = useAuthedFetch();
 	const queryClient = useQueryClient();
 	// Hosted tiles navigate here with `?source=on-clawdi` so the sync
 	// badge can render hosted-aware remediation copy (no CLI snippets,
@@ -101,10 +83,7 @@ export default function AgentDetailPage() {
 
 	const { data: projects } = useQuery({
 		queryKey: ["projects"],
-		queryFn: async (): Promise<ProjectRow[]> => {
-			const r = await authedFetch("/api/projects");
-			return r.json();
-		},
+		queryFn: async (): Promise<ProjectRow[]> => unwrap(await api.GET("/api/projects")),
 		enabled: !!agent,
 	});
 	const writableProjectIds = useMemo(
@@ -119,10 +98,12 @@ export default function AgentDetailPage() {
 
 	const { data: projectBindings, isLoading: projectBindingsLoading } = useQuery({
 		queryKey: ["agent-project-bindings", id],
-		queryFn: async (): Promise<ProjectBindingRow[]> => {
-			const r = await authedFetch(`/api/agents/${id}/project-bindings`);
-			return r.json();
-		},
+		queryFn: async (): Promise<ProjectBindingRow[]> =>
+			unwrap(
+				await api.GET("/api/agents/{agent_id}/project-bindings", {
+					params: { path: { agent_id: id } },
+				}),
+			),
 		enabled: !!agent,
 	});
 
@@ -409,7 +390,6 @@ export default function AgentDetailPage() {
 									bindings={projectBindings ?? []}
 									projects={projects ?? []}
 									isLoading={projectBindingsLoading}
-									authedFetch={authedFetch}
 									onChanged={() => {
 										queryClient.invalidateQueries({
 											queryKey: ["agent-project-bindings", id],
@@ -436,16 +416,15 @@ function AgentProjectsPanel({
 	bindings,
 	projects,
 	isLoading,
-	authedFetch,
 	onChanged,
 }: {
 	agentId: string;
 	bindings: ProjectBindingRow[];
 	projects: ProjectRow[];
 	isLoading: boolean;
-	authedFetch: (path: string, init?: RequestInit) => Promise<Response>;
 	onChanged: () => void;
 }) {
+	const api = useApi();
 	const [contextProjectId, setContextProjectId] = useState("");
 	const primary = bindings.find((binding) => binding.binding_type === "primary") ?? null;
 	const contexts = bindings
@@ -462,11 +441,12 @@ function AgentProjectsPanel({
 
 	const addContext = useMutation({
 		mutationFn: async () => {
-			await authedFetch(`/api/agents/${agentId}/project-bindings/context`, {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ project_id: contextProjectId }),
-			});
+			await unwrap(
+				await api.POST("/api/agents/{agent_id}/project-bindings/context", {
+					params: { path: { agent_id: agentId } },
+					body: { project_id: contextProjectId },
+				}),
+			);
 		},
 		onSuccess: () => {
 			setContextProjectId("");
@@ -478,9 +458,11 @@ function AgentProjectsPanel({
 
 	const removeBinding = useMutation({
 		mutationFn: async (bindingId: string) => {
-			await authedFetch(`/api/agents/${agentId}/project-bindings/${bindingId}`, {
-				method: "DELETE",
-			});
+			await unwrap(
+				await api.DELETE("/api/agents/{agent_id}/project-bindings/{binding_id}", {
+					params: { path: { agent_id: agentId, binding_id: bindingId } },
+				}),
+			);
 		},
 		onSuccess: () => {
 			onChanged();
@@ -491,11 +473,12 @@ function AgentProjectsPanel({
 
 	const reorder = useMutation({
 		mutationFn: async (items: Array<{ binding_id: string; priority: number }>) => {
-			await authedFetch(`/api/agents/${agentId}/project-bindings/context/reorder`, {
-				method: "PATCH",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ items }),
-			});
+			await unwrap(
+				await api.PATCH("/api/agents/{agent_id}/project-bindings/context/reorder", {
+					params: { path: { agent_id: agentId } },
+					body: { items },
+				}),
+			);
 		},
 		onSuccess: () => {
 			onChanged();

--- a/apps/web/src/app/(dashboard)/projects/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/projects/[id]/page.tsx
@@ -64,7 +64,7 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
-import { ApiError, unwrap, useApi, useAuthedFetch } from "@/lib/api";
+import { ApiError, unwrap, useApi } from "@/lib/api";
 import { formatApiError } from "@/lib/api-errors";
 import { fetchAllPages } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
@@ -77,24 +77,13 @@ type VaultSummary = components["schemas"]["VaultResponse"];
 type Env = components["schemas"]["EnvironmentResponse"];
 type AgentProjectBinding = components["schemas"]["AgentProjectBindingResponse"];
 
-interface ProjectRow {
-	id: string;
-	name: string;
-	slug: string;
-	kind: string;
-	origin_environment_id: string | null;
-	archived_at: string | null;
-	created_at: string;
-	is_owner?: boolean;
-	owner_display?: string | null;
-	owner_handle?: string | null;
-}
+type ProjectRow = components["schemas"]["ProjectResponse"];
+type Member = components["schemas"]["MemberResponse"];
 
 export default function ProjectDetailPage() {
 	const params = useParams<{ id: string }>();
 	const projectId = params.id;
 	const api = useApi();
-	const authedFetch = useAuthedFetch();
 	const qc = useQueryClient();
 	const router = useRouter();
 	const searchParams = useSearchParams();
@@ -109,10 +98,7 @@ export default function ProjectDetailPage() {
 
 	const projects = useQuery({
 		queryKey: ["projects"],
-		queryFn: async (): Promise<ProjectRow[]> => {
-			const r = await authedFetch("/api/projects");
-			return r.json();
-		},
+		queryFn: async (): Promise<ProjectRow[]> => unwrap(await api.GET("/api/projects")),
 	});
 
 	const rows = projects.data ?? [];
@@ -178,12 +164,12 @@ export default function ProjectDetailPage() {
 	// simply don't get the section.
 	const members = useQuery({
 		queryKey: ["project-members", projectId],
-		queryFn: async (): Promise<
-			Array<{ member_user_id: string; email?: string | null; role: string }>
-		> => {
-			const r = await authedFetch(`/api/projects/${projectId}/members`);
-			return r.json();
-		},
+		queryFn: async (): Promise<Member[]> =>
+			unwrap(
+				await api.GET("/api/projects/{project_id}/members", {
+					params: { path: { project_id: projectId } },
+				}),
+			),
 		enabled: !!project && isOwner && isShareableProject,
 	});
 
@@ -223,10 +209,12 @@ export default function ProjectDetailPage() {
 	};
 
 	const leaveSharedProject = useMutation({
-		mutationFn: async (): Promise<{ status: string }> => {
-			const r = await authedFetch(`/api/projects/${projectId}/leave`, { method: "POST" });
-			return r.json();
-		},
+		mutationFn: async () =>
+			unwrap(
+				await api.POST("/api/projects/{project_id}/leave", {
+					params: { path: { project_id: projectId } },
+				}),
+			),
 		onSuccess: () => {
 			refresh();
 			qc.invalidateQueries({ queryKey: ["agent-project-bindings"] });
@@ -492,10 +480,12 @@ export default function ProjectDetailPage() {
 						<div className="divide-y overflow-hidden rounded-lg border bg-card">
 							{(members.data ?? []).map((member) => (
 								<div
-									key={member.member_user_id}
+									key={member.user_id}
 									className="flex items-center justify-between gap-3 px-4 py-3"
 								>
-									<span className="truncate text-sm">{member.email ?? member.member_user_id}</span>
+									<span className="truncate text-sm">
+										{member.user_email ?? member.user_display ?? member.user_id}
+									</span>
 									<Badge variant="secondary">{member.role}</Badge>
 								</div>
 							))}
@@ -1060,7 +1050,7 @@ function CreateVaultInProjectForm({
 		mutationFn: async (nextSlug: string) =>
 			unwrap(
 				await api.POST("/api/vault", {
-					params: { query: { project_id: projectId } },
+					params: { query: { project_id: projectId, create_only: true } },
 					body: { slug: nextSlug, name: nextSlug },
 				}),
 			),

--- a/apps/web/src/app/(dashboard)/projects/page.tsx
+++ b/apps/web/src/app/(dashboard)/projects/page.tsx
@@ -30,7 +30,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SearchInput } from "@/components/ui/search-input";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ApiError, unwrap, useApi, useAuthedFetch } from "@/lib/api";
+import { ApiError, unwrap, useApi } from "@/lib/api";
 import { formatApiError } from "@/lib/api-errors";
 import { fetchAllPages } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
@@ -41,31 +41,12 @@ import { cn, errorMessage } from "@/lib/utils";
 type Env = components["schemas"]["EnvironmentResponse"];
 type SkillSummary = components["schemas"]["SkillSummaryResponse"];
 
-interface ProjectRow {
-	id: string;
-	name: string;
-	slug: string;
-	kind: string;
-	origin_environment_id: string | null;
-	archived_at: string | null;
-	created_at: string;
-	is_owner?: boolean;
-	owner_display?: string | null;
-	owner_handle?: string | null;
-}
-
-interface VaultRow {
-	id: string;
-	slug: string;
-	name: string;
-	project_ids?: string[] | null;
-}
+type ProjectRow = components["schemas"]["ProjectResponse"];
 
 const PROJECTS_RESOURCE = getProjectResourceDefinition("projects");
 
 export default function ProjectsPage() {
 	const api = useApi();
-	const authedFetch = useAuthedFetch();
 	const qc = useQueryClient();
 	const router = useRouter();
 	const [newProjectName, setNewProjectName] = useState("");
@@ -76,10 +57,7 @@ export default function ProjectsPage() {
 
 	const projects = useQuery({
 		queryKey: ["projects"],
-		queryFn: async (): Promise<ProjectRow[]> => {
-			const r = await authedFetch("/api/projects");
-			return r.json();
-		},
+		queryFn: async (): Promise<ProjectRow[]> => unwrap(await api.GET("/api/projects")),
 	});
 
 	const rows = projects.data ?? [];
@@ -108,10 +86,8 @@ export default function ProjectsPage() {
 	});
 	const vaults = useQuery({
 		queryKey: ["vaults", "all"],
-		queryFn: async (): Promise<{ items: VaultRow[] }> => {
-			const r = await authedFetch("/api/vault?page_size=200");
-			return r.json();
-		},
+		queryFn: async () =>
+			unwrap(await api.GET("/api/vault", { params: { query: { page_size: 200 } } })),
 	});
 	const skillCounts = useMemo(() => {
 		const m = new Map<string, number>();
@@ -169,12 +145,7 @@ export default function ProjectsPage() {
 			const payload: { name: string; slug?: string } = { name: newProjectName.trim() };
 			const slug = normalizeSlugInput(newProjectSlug);
 			if (slug) payload.slug = slug;
-			const r = await authedFetch("/api/projects", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify(payload),
-			});
-			return r.json();
+			return unwrap(await api.POST("/api/projects", { body: payload }));
 		},
 		onSuccess: (project) => {
 			setNewProjectName("");

--- a/apps/web/src/app/(dashboard)/skills/page.tsx
+++ b/apps/web/src/app/(dashboard)/skills/page.tsx
@@ -46,7 +46,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
-import { unwrap, useApi, useAuthedFetch } from "@/lib/api";
+import { ensureBlob, unwrap, useApi } from "@/lib/api";
 import { fetchAllPages } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
@@ -77,7 +77,6 @@ export default function SkillsPage() {
 
 function SkillsPageInner() {
 	const api = useApi();
-	const authedFetch = useAuthedFetch();
 	const queryClient = useQueryClient();
 	// `?project=<project_id>` is the canonical scope. `?target=<env_id>`
 	// remains supported for older deep links from agent detail pages.
@@ -346,21 +345,38 @@ function SkillsPageInner() {
 					c.content_hash !== newest.content_hash,
 			);
 			if (stale.length === 0) return { name: newest.name, updated: 0, failed: [] as string[] };
-			const dl = await authedFetch(
-				`/api/projects/${newest.project_id}/skills/${encodeURIComponent(newest.skill_key)}/download`,
+			if (!newest.project_id) {
+				return { name: newest.name, updated: 0, failed: ["source project"] };
+			}
+			const blob = ensureBlob(
+				unwrap(
+					await api.GET("/api/projects/{project_id}/skills/{skill_key}/download", {
+						params: {
+							path: { project_id: newest.project_id, skill_key: newest.skill_key },
+						},
+						parseAs: "blob",
+					}),
+				),
 			);
-			const blob = await dl.blob();
 			let updated = 0;
 			const failed: string[] = [];
 			for (const copy of stale) {
+				if (!copy.project_id) {
+					failed.push(copy.project_name ?? "unknown project");
+					continue;
+				}
 				try {
+					const fileName = `${newest.skill_key.replace(/\//g, "-")}.tar.gz`;
 					const form = new FormData();
 					form.append("skill_key", newest.skill_key);
-					form.append("file", blob, `${newest.skill_key.replace(/\//g, "-")}.tar.gz`);
-					await authedFetch(`/api/projects/${copy.project_id}/skills/upload`, {
-						method: "POST",
-						body: form,
-					});
+					form.append("file", blob, fileName);
+					await unwrap(
+						await api.POST("/api/projects/{project_id}/skills/upload", {
+							params: { path: { project_id: copy.project_id } },
+							body: { skill_key: newest.skill_key, file: fileName },
+							bodySerializer: () => form,
+						}),
+					);
 					updated += 1;
 				} catch {
 					failed.push(copy.project_name ?? "unknown project");
@@ -372,6 +388,12 @@ function SkillsPageInner() {
 			queryClient.invalidateQueries({ queryKey: ["skills"] });
 			if (updated === 0 && failed.length === 0) {
 				toast.success(`${name} copies already match`);
+				return;
+			}
+			if (updated === 0) {
+				toast.error(`Couldn't sync ${name}`, {
+					description: `Failed: ${failed.join(", ")}.`,
+				});
 				return;
 			}
 			toast.success(`${name} synced`, {

--- a/apps/web/src/app/(dashboard)/vault/[slug]/page.tsx
+++ b/apps/web/src/app/(dashboard)/vault/[slug]/page.tsx
@@ -225,6 +225,24 @@ export default function VaultDetailPage() {
 			toast.error("Couldn't remove vault from Project", { description: errorMessage(e) }),
 	});
 
+	const deleteVault = useMutation({
+		mutationFn: async () =>
+			unwrap(
+				await api.DELETE("/api/vault/{slug}", {
+					params: { path: { slug }, query: {} },
+				}),
+			),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: ["vaults"] });
+			qc.removeQueries({ queryKey: ["vault-items", slug] });
+			toast.success("Vault deleted", {
+				description: `${vault?.name ?? slug} and its keys were removed.`,
+			});
+			router.push("/vault");
+		},
+		onError: (e) => toast.error("Couldn't delete vault", { description: errorMessage(e) }),
+	});
+
 	useSetBreadcrumbTitle(vault?.name ?? null);
 
 	if (vaults.isLoading) {
@@ -305,14 +323,14 @@ export default function VaultDetailPage() {
 							}
 							confirmLabel="Delete vault"
 							destructive
-							onConfirm={async () => {
-								for (const pid of vault.project_ids ?? []) {
-									await detachProject.mutateAsync(pid);
-								}
-								router.push("/vault");
-							}}
+							onConfirm={() => deleteVault.mutateAsync()}
 						>
-							<Button variant="outline" size="sm" className="text-destructive">
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={deleteVault.isPending}
+								className="text-destructive"
+							>
 								<Trash2 className="mr-1.5 size-3.5" />
 								Delete
 							</Button>

--- a/apps/web/src/app/(dashboard)/vault/page.tsx
+++ b/apps/web/src/app/(dashboard)/vault/page.tsx
@@ -24,6 +24,7 @@ import { SearchInput } from "@/components/ui/search-input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { AddKeysDialog } from "@/components/vault/add-keys-dialog";
+import { slugFromVaultName } from "@/components/vault/vault-slug";
 import { unwrap, useApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
@@ -294,6 +295,12 @@ function NewVaultDialog({ trigger }: { trigger?: React.ReactNode }) {
 		queryFn: async (): Promise<ProjectRow[]> => unwrap(await api.GET("/api/projects")),
 		enabled: open,
 	});
+	const vaultsQuery = useQuery({
+		queryKey: ["vaults", "all"],
+		queryFn: async () =>
+			unwrap(await api.GET("/api/vault", { params: { query: { page_size: 200 } } })),
+		enabled: open,
+	});
 	// A vault is created through a project the user can write to; the
 	// personal (Global) project always exists and is the least surprising
 	// default — attachments can be changed afterwards on the vault page.
@@ -302,18 +309,28 @@ function NewVaultDialog({ trigger }: { trigger?: React.ReactNode }) {
 		return rows.find((p) => p.kind === "personal") ?? rows.find((p) => p.is_owner !== false);
 	}, [projects.data]);
 
-	const slug = name
-		.toLowerCase()
-		.replace(/[^a-z0-9-]+/g, "-")
-		.replace(/-{2,}/g, "-")
-		.replace(/^-+|-+$/g, "");
+	const slug = slugFromVaultName(name);
+	const slugTaken =
+		slug.length > 0 &&
+		(vaultsQuery.data?.items ?? []).some((v) => v.is_owner !== false && v.slug === slug);
+	const canCreate =
+		name.trim().length > 0 &&
+		slug.length > 0 &&
+		!slugTaken &&
+		!projects.isLoading &&
+		!vaultsQuery.isLoading &&
+		defaultProject !== undefined;
 
 	const create = useMutation({
 		mutationFn: async () => {
 			if (!defaultProject) throw new Error("No writable Project available yet");
+			if (!slug) throw new Error("Use letters or numbers in the vault name");
+			if ((vaultsQuery.data?.items ?? []).some((v) => v.is_owner !== false && v.slug === slug)) {
+				throw new Error("A vault with that name already exists");
+			}
 			return unwrap(
 				await api.POST("/api/vault", {
-					params: { query: { project_id: defaultProject.id } },
+					params: { query: { project_id: defaultProject.id, create_only: true } },
 					body: { slug, name: name.trim() },
 				}),
 			);
@@ -355,7 +372,7 @@ function NewVaultDialog({ trigger }: { trigger?: React.ReactNode }) {
 					className="space-y-4"
 					onSubmit={(e) => {
 						e.preventDefault();
-						if (name.trim() && slug && !create.isPending) create.mutate();
+						if (canCreate && !create.isPending) create.mutate();
 					}}
 				>
 					<div className="space-y-1.5">
@@ -372,9 +389,14 @@ function NewVaultDialog({ trigger }: { trigger?: React.ReactNode }) {
 						{slug ? (
 							<p className="font-mono text-xs text-muted-foreground">vault://{slug}</p>
 						) : null}
+						{slugTaken ? (
+							<p className="text-xs text-destructive">
+								That vault already exists. Open it from the vault list or use a different name.
+							</p>
+						) : null}
 					</div>
 					<div className="flex justify-end">
-						<Button type="submit" disabled={!name.trim() || !slug || create.isPending}>
+						<Button type="submit" disabled={!canCreate || create.isPending}>
 							{create.isPending ? <Spinner /> : <Plus className="size-3.5" />}
 							Create vault
 						</Button>

--- a/apps/web/src/app/s/[id]/[format]/route.ts
+++ b/apps/web/src/app/s/[id]/[format]/route.ts
@@ -1,3 +1,5 @@
+import type { paths } from "@clawdi/shared/api";
+import createClient from "openapi-fetch";
 import { env } from "@/lib/env";
 
 /**
@@ -44,21 +46,29 @@ export async function GET(
 		return new Response("Not found", { status: 404 });
 	}
 
-	const upstreamPath = format === "md" ? "export.md" : "export.json";
-	const upstream = `${env.NEXT_PUBLIC_API_URL}/api/public/sessions/${id}/${upstreamPath}`;
+	const api = createClient<paths>({ baseUrl: env.NEXT_PUBLIC_API_URL });
+	const result =
+		format === "md"
+			? await api.GET("/api/public/sessions/{session_id}/export.md", {
+					params: { path: { session_id: id } },
+					parseAs: "text",
+					cache: "no-store",
+				})
+			: await api.GET("/api/public/sessions/{session_id}/export.json", {
+					params: { path: { session_id: id } },
+					parseAs: "text",
+					cache: "no-store",
+				});
 
-	const res = await fetch(upstream, { cache: "no-store" });
-
-	if (!res.ok) {
-		return new Response(await res.text(), {
-			status: res.status,
+	if (result.error !== undefined) {
+		return new Response(String(result.error), {
+			status: result.response.status,
 			headers: { "content-type": "text/plain; charset=utf-8" },
 		});
 	}
 
-	// NO cache-control — revocation / permission-toggle must take effect
-	// immediately. Stream the upstream body unchanged.
-	return new Response(res.body, {
+	// NO cache-control — revocation / permission-toggle must take effect immediately.
+	return new Response(result.data, {
 		status: 200,
 		headers: {
 			"content-type": FORMAT_MEDIA_TYPE[format],

--- a/apps/web/src/app/s/[id]/page.tsx
+++ b/apps/web/src/app/s/[id]/page.tsx
@@ -1,9 +1,11 @@
+import type { components, paths } from "@clawdi/shared/api";
 import { auth } from "@clerk/nextjs/server";
 import { Clock, Hash, MessageSquare, Zap } from "lucide-react";
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import createClient from "openapi-fetch";
 import { cache } from "react";
 import { AgentInline } from "@/components/dashboard/agent-label";
 import { DetailMeta, DetailStats, DetailTitle } from "@/components/detail/layout";
@@ -15,7 +17,6 @@ import { ShareHeaderUser } from "@/components/share/header-user";
 import { NoAccess } from "@/components/share/no-access";
 import { PublicShareControls } from "@/components/share/public-share-controls";
 import { SignInToView } from "@/components/share/sign-in-to-view";
-import type { SessionMessage } from "@/lib/api-schemas";
 import { env } from "@/lib/env";
 import { formatDuration } from "@/lib/format";
 import {
@@ -57,41 +58,8 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 type Params = { id: string };
 
-type PublicShare = {
-	id: string;
-	summary: string | null;
-	project_path: string | null;
-	agent_type: string | null;
-	model: string | null;
-	models_used: string[] | null;
-	started_at: string;
-	ended_at: string | null;
-	last_activity_at: string;
-	duration_seconds: number | null;
-	message_count: number;
-	input_tokens: number;
-	output_tokens: number;
-	cache_read_tokens: number;
-	tags: string[] | null;
-	status: string;
-	related_refs: {
-		prs?: string[] | null;
-		repos?: string[] | null;
-		branches?: string[] | null;
-	} | null;
-	// Public identity of the session owner. Optional — pre-Clerk-login
-	// users may have no `name`, and avatar is only populated after the
-	// owner has signed in at least once post the avatar_url migration.
-	owner_name: string | null;
-	owner_avatar_url: string | null;
-};
-
-type PublicMessagesPage = {
-	items: SessionMessage[];
-	total: number;
-	offset: number;
-	limit: number;
-};
+type PublicShare = components["schemas"]["PublicSessionResponse"];
+type PublicMessagesPage = components["schemas"]["SessionMessagesPage"];
 
 type FetchResult =
 	| { kind: "ok"; share: PublicShare }
@@ -106,20 +74,24 @@ type FetchResult =
  * this boundary.
  */
 const fetchShare = cache(async (sessionId: string, token: string | null): Promise<FetchResult> => {
-	const headers: Record<string, string> = {};
-	if (token) headers.Authorization = `Bearer ${token}`;
-
-	const res = await fetch(`${env.NEXT_PUBLIC_API_URL}/api/public/sessions/${sessionId}`, {
+	const api = createPublicApi(token);
+	const result = await api.GET("/api/public/sessions/{session_id}", {
+		params: { path: { session_id: sessionId } },
 		cache: "no-store",
-		headers,
 	});
-	if (res.status === 404) return { kind: "not-found" };
-	if (res.status === 401) return { kind: "unauthorized" };
-	if (res.status === 403) return { kind: "forbidden" };
-	if (!res.ok) throw new Error(`backend returned ${res.status}`);
-	const share = (await res.json()) as PublicShare;
-	return { kind: "ok", share };
+	if (result.response.status === 404) return { kind: "not-found" };
+	if (result.response.status === 401) return { kind: "unauthorized" };
+	if (result.response.status === 403) return { kind: "forbidden" };
+	if (result.error !== undefined) throw new Error(`backend returned ${result.response.status}`);
+	return { kind: "ok", share: result.data };
 });
+
+function createPublicApi(token: string | null) {
+	return createClient<paths>({
+		baseUrl: env.NEXT_PUBLIC_API_URL,
+		headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+	});
+}
 
 async function getOptionalToken(): Promise<string | null> {
 	if (env.NEXT_PUBLIC_DEV_AUTH_BYPASS) return env.NEXT_PUBLIC_DEV_AUTH_TOKEN;
@@ -131,18 +103,16 @@ async function fetchFirstMessages(
 	sessionId: string,
 	token: string | null,
 ): Promise<PublicMessagesPage> {
-	const headers: Record<string, string> = {};
-	if (token) headers.Authorization = `Bearer ${token}`;
-
-	const res = await fetch(
-		`${env.NEXT_PUBLIC_API_URL}/api/public/sessions/${sessionId}/messages?offset=0&limit=${PAGE_SIZE}`,
-		{ cache: "no-store", headers },
-	);
-	if (!res.ok) {
+	const api = createPublicApi(token);
+	const result = await api.GET("/api/public/sessions/{session_id}/messages", {
+		params: { path: { session_id: sessionId }, query: { offset: 0, limit: PAGE_SIZE } },
+		cache: "no-store",
+	});
+	if (result.error !== undefined) {
 		// Soft-failure: render the header even if messages errored.
 		return { items: [], total: 0, offset: 0, limit: PAGE_SIZE };
 	}
-	return res.json() as Promise<PublicMessagesPage>;
+	return result.data;
 }
 
 export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
@@ -197,6 +167,10 @@ export default async function PublicSharePage({ params }: { params: Promise<Para
 	const mdUrl = `/s/${share.id}.md`;
 	const jsonUrl = `/s/${share.id}.json`;
 	const truncated = messagesPage.total > messagesPage.items.length;
+	const showLastActivity =
+		share.last_activity_at !== null &&
+		Math.abs(new Date(share.last_activity_at).getTime() - new Date(share.started_at).getTime()) >
+			5 * 60_000;
 
 	return (
 		<>
@@ -241,10 +215,7 @@ export default async function PublicSharePage({ params }: { params: Promise<Para
 							<span title={formatAbsoluteTooltip(share.started_at)}>
 								Started {relativeTime(share.started_at)}
 							</span>
-							{Math.abs(
-								new Date(share.last_activity_at).getTime() - new Date(share.started_at).getTime(),
-							) >
-							5 * 60_000 ? (
+							{showLastActivity ? (
 								<>
 									<span>·</span>
 									<span title={formatAbsoluteTooltip(share.last_activity_at)}>

--- a/apps/web/src/app/share/[token]/page.tsx
+++ b/apps/web/src/app/share/[token]/page.tsx
@@ -20,8 +20,9 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
+import { unwrap, useApi } from "@/lib/api";
+import type { components } from "@/lib/api-schemas";
 import { useCurrentUser, useDashboardAuth } from "@/lib/auth-client";
-import { env } from "@/lib/env";
 import { projectDetailHref } from "@/lib/project-resource-model";
 
 /**
@@ -34,58 +35,11 @@ import { projectDetailHref } from "@/lib/project-resource-model";
  *   3. Agent use is explicit and handled separately after accept.
  */
 
-interface SharePreview {
-	project_id: string;
-	project_name: string;
-	owner_display: string;
-	owner_handle: string;
-	skill_count: number;
-	vault_count: number;
-	vault_locked: boolean;
-}
-
-interface ShareUpgradeResponse {
-	membership_id: string;
-	project_id: string;
-	role: string;
-	joined_via: string;
-	joined_at: string;
-	resolved_owner_handle: string;
-	bound_agent_ids?: string[];
-}
-
-const API_URL = env.NEXT_PUBLIC_API_URL;
+type SharePreview = components["schemas"]["ShareRedeemResponse"];
 
 function buildLandingUrl(token: string): string {
 	if (typeof window === "undefined") return `/share/${token}`;
 	return `${window.location.origin}/share/${token}`;
-}
-
-async function fetchPreview(token: string): Promise<SharePreview> {
-	const r = await fetch(`${API_URL}/api/share/${token}/preview`, {
-		method: "GET",
-	});
-	if (r.status === 404) throw new ShareError("not_found");
-	if (r.status === 410) throw new ShareError("revoked");
-	if (!r.ok) throw new ShareError("unknown", r.status);
-	return r.json();
-}
-
-async function upgradeShare(token: string, bearer: string): Promise<ShareUpgradeResponse> {
-	const r = await fetch(`${API_URL}/api/share/${token}/upgrade`, {
-		method: "POST",
-		headers: { Authorization: `Bearer ${bearer}`, "Content-Type": "application/json" },
-		body: JSON.stringify({}),
-	});
-	if (r.status === 404) throw new ShareError("not_found");
-	if (r.status === 410) throw new ShareError("revoked");
-	if (r.status === 409) {
-		const body = (await r.json().catch(() => ({}))) as { detail?: { error?: string } };
-		if (body?.detail?.error === "already_owner") throw new ShareError("already_owner");
-		throw new ShareError("already_member");
-	}
-	if (!r.ok) throw new ShareError("unknown", r.status);
-	return r.json();
 }
 
 type ShareErrorCode = "not_found" | "revoked" | "already_member" | "already_owner" | "unknown";
@@ -99,16 +53,42 @@ class ShareError extends Error {
 	}
 }
 
+function shareErrorFromApi(status: number, error: unknown): ShareError {
+	if (status === 404) return new ShareError("not_found");
+	if (status === 410) return new ShareError("revoked");
+	if (status === 409) {
+		return hasStructuredDetailError(error, "already_owner")
+			? new ShareError("already_owner")
+			: new ShareError("already_member");
+	}
+	return new ShareError("unknown", status);
+}
+
+function hasStructuredDetailError(error: unknown, code: string): boolean {
+	if (typeof error !== "object" || error === null || !("detail" in error)) return false;
+	const detail = error.detail;
+	return (
+		typeof detail === "object" && detail !== null && "error" in detail && detail.error === code
+	);
+}
+
 export default function SharePage() {
 	const params = useParams<{ token: string }>();
 	const token = params.token;
+	const api = useApi();
 	const router = useRouter();
 	const { isSignedIn, getToken } = useDashboardAuth();
 	const { user } = useCurrentUser();
 
 	const preview = useQuery({
 		queryKey: ["share-preview", token],
-		queryFn: () => fetchPreview(token),
+		queryFn: async (): Promise<SharePreview> => {
+			const result = await api.GET("/api/share/{token}/preview", {
+				params: { path: { token } },
+			});
+			if (result.error !== undefined) throw shareErrorFromApi(result.response.status, result.error);
+			return unwrap(result);
+		},
 		retry: false,
 	});
 
@@ -116,7 +96,12 @@ export default function SharePage() {
 		mutationFn: async () => {
 			const bearer = await getToken();
 			if (!bearer) throw new ShareError("unknown");
-			return upgradeShare(token, bearer);
+			const result = await api.POST("/api/share/{token}/upgrade", {
+				params: { path: { token } },
+				body: { use_as: "attached" },
+			});
+			if (result.error !== undefined) throw shareErrorFromApi(result.response.status, result.error);
+			return unwrap(result);
 		},
 		onSuccess: (result) => {
 			router.push(`${projectDetailHref(result.project_id)}?joined=share`);

--- a/apps/web/src/components/notification-center.tsx
+++ b/apps/web/src/components/notification-center.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
 import { Spinner } from "@/components/ui/spinner";
-import { ApiError, useAuthedFetch } from "@/lib/api";
+import { ApiError, unwrap, useApi } from "@/lib/api";
 import { formatApiError } from "@/lib/api-errors";
 import { projectDetailHref } from "@/lib/project-resource-model";
 import { cn, errorMessage } from "@/lib/utils";
@@ -38,7 +38,7 @@ import {
 export function NotificationCenter() {
 	const router = useRouter();
 	const queryClient = useQueryClient();
-	const authedFetch = useAuthedFetch();
+	const api = useApi();
 	const [open, setOpen] = useState(false);
 
 	function refetchMembershipDerived() {
@@ -49,10 +49,8 @@ export function NotificationCenter() {
 
 	const invitations = useQuery({
 		queryKey: NOTIFICATION_CENTER_QUERY_KEY,
-		queryFn: async (): Promise<ProjectInvitationNotification[]> => {
-			const response = await authedFetch("/api/me/invitations");
-			return response.json();
-		},
+		queryFn: async (): Promise<ProjectInvitationNotification[]> =>
+			unwrap(await api.GET("/api/me/invitations")),
 		refetchOnWindowFocus: true,
 	});
 
@@ -62,14 +60,13 @@ export function NotificationCenter() {
 		}: {
 			id: string;
 			projectName: string;
-		}): Promise<AcceptInvitationResponse> => {
-			const response = await authedFetch(`/api/me/invitations/${id}/accept`, {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({}),
-			});
-			return response.json();
-		},
+		}): Promise<AcceptInvitationResponse> =>
+			unwrap(
+				await api.POST("/api/me/invitations/{invitation_id}/accept", {
+					params: { path: { invitation_id: id } },
+					body: { use_as: "attached" },
+				}),
+			),
 		onSuccess: (result, variables) => {
 			refetchMembershipDerived();
 			const copy = getAcceptedProjectInvitationToastCopy(variables.projectName);
@@ -94,7 +91,11 @@ export function NotificationCenter() {
 
 	const decline = useMutation({
 		mutationFn: async (id: string) => {
-			await authedFetch(`/api/me/invitations/${id}/decline`, { method: "POST" });
+			await unwrap(
+				await api.POST("/api/me/invitations/{invitation_id}/decline", {
+					params: { path: { invitation_id: id } },
+				}),
+			);
 		},
 		onSuccess: () => {
 			refetchMembershipDerived();

--- a/apps/web/src/components/sharing/share-project-dialog.tsx
+++ b/apps/web/src/components/sharing/share-project-dialog.tsx
@@ -42,8 +42,9 @@ import {
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ApiError, useAuthedFetch } from "@/lib/api";
+import { ApiError, unwrap, useApi } from "@/lib/api";
 import { formatApiError } from "@/lib/api-errors";
+import type { components } from "@/lib/api-schemas";
 import { errorMessage } from "@/lib/utils";
 
 /**
@@ -61,48 +62,12 @@ import { errorMessage } from "@/lib/utils";
  *   POST   /api/projects/{project_id}/invitations
  *   DELETE /api/projects/{project_id}/invitations/{invitation_id}
  *
- * Schemas swap to typed openapi-fetch once codex regenerates them.
  */
 
-// List shape: prefix-only, raw_token is unrecoverable once create returned.
-interface ShareLinkRow {
-	id: string;
-	prefix: string;
-	label: string | null;
-	created_at: string;
-	expires_at: string | null;
-	revoked_at: string | null;
-	redeem_count: number;
-	last_redeemed_at: string | null;
-}
-
-// Create-time shape: raw_token + url shown ONCE.
-interface ShareLinkCreated {
-	id: string;
-	raw_token: string;
-	url: string;
-	prefix: string;
-	owner_handle: string;
-	label: string | null;
-	created_at: string;
-	expires_at: string | null;
-}
-
-interface Invitation {
-	id: string;
-	invitee_email: string;
-	created_at: string;
-}
-
-interface Member {
-	id: string;
-	user_id: string;
-	user_email: string | null;
-	user_display: string | null;
-	role: string;
-	joined_via: string;
-	joined_at: string;
-}
+type ShareLinkRow = components["schemas"]["ShareLinkResponse"];
+type ShareLinkCreated = components["schemas"]["ShareLinkCreated"];
+type Invitation = components["schemas"]["InvitationResponse"];
+type Member = components["schemas"]["MemberResponse"];
 
 interface ShareProjectDialogProps {
 	projectId: string;
@@ -189,31 +154,32 @@ export function ShareProjectDialog({
 }
 
 function ShareLinksPanel({ projectId }: { projectId: string }) {
+	const api = useApi();
 	const qc = useQueryClient();
 	const [label, setLabel] = useState("");
 	// The just-created link's full URL is shown once because the server
 	// stores only the prefix going forward.
 	const [freshLink, setFreshLink] = useState<ShareLinkCreated | null>(null);
 
-	const authedFetch = useAuthedFetch();
-
 	const links = useQuery({
 		queryKey: ["share-links", projectId],
-		queryFn: async (): Promise<ShareLinkRow[]> => {
-			const r = await authedFetch(`/api/projects/${projectId}/share-links`);
-			return r.json();
-		},
+		queryFn: async (): Promise<ShareLinkRow[]> =>
+			unwrap(
+				await api.GET("/api/projects/{project_id}/share-links", {
+					params: { path: { project_id: projectId } },
+				}),
+			),
 	});
 
 	const create = useMutation({
 		mutationFn: async (nextLabel: string): Promise<ShareLinkCreated> => {
 			const trimmedLabel = nextLabel.trim();
-			const r = await authedFetch(`/api/projects/${projectId}/share-links`, {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ label: trimmedLabel.length > 0 ? trimmedLabel : null }),
-			});
-			return r.json();
+			return unwrap(
+				await api.POST("/api/projects/{project_id}/share-links", {
+					params: { path: { project_id: projectId } },
+					body: { label: trimmedLabel.length > 0 ? trimmedLabel : null },
+				}),
+			);
 		},
 		onSuccess: (body) => {
 			setLabel("");
@@ -242,9 +208,11 @@ function ShareLinksPanel({ projectId }: { projectId: string }) {
 
 	const revoke = useMutation({
 		mutationFn: async (linkId: string) => {
-			await authedFetch(`/api/projects/${projectId}/share-links/${linkId}`, {
-				method: "DELETE",
-			});
+			await unwrap(
+				await api.DELETE("/api/projects/{project_id}/share-links/{link_id}", {
+					params: { path: { project_id: projectId, link_id: linkId } },
+				}),
+			);
 		},
 		onSuccess: () => {
 			qc.invalidateQueries({ queryKey: ["share-links", projectId] });
@@ -514,29 +482,28 @@ function LinkRow({
 }
 
 function InvitationsPanel({ projectId }: { projectId: string }) {
+	const api = useApi();
 	const qc = useQueryClient();
 	const [email, setEmail] = useState("");
 
-	const authedFetch = useAuthedFetch();
-
 	const invites = useQuery({
 		queryKey: ["invitations", projectId],
-		queryFn: async (): Promise<Invitation[]> => {
-			const r = await authedFetch(`/api/projects/${projectId}/invitations`);
-			const body = (await r.json()) as { items?: Invitation[] } | Invitation[];
-			return Array.isArray(body) ? body : (body.items ?? []);
-		},
+		queryFn: async (): Promise<Invitation[]> =>
+			unwrap(
+				await api.GET("/api/projects/{project_id}/invitations", {
+					params: { path: { project_id: projectId } },
+				}),
+			),
 	});
 
 	const invite = useMutation({
-		mutationFn: async (inviteEmail: string) => {
-			const r = await authedFetch(`/api/projects/${projectId}/invitations`, {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ email: inviteEmail }),
-			});
-			return r.json();
-		},
+		mutationFn: async (inviteEmail: string) =>
+			unwrap(
+				await api.POST("/api/projects/{project_id}/invitations", {
+					params: { path: { project_id: projectId } },
+					body: { email: inviteEmail },
+				}),
+			),
 		onSuccess: () => {
 			qc.invalidateQueries({ queryKey: ["invitations", projectId] });
 			setEmail("");
@@ -554,9 +521,11 @@ function InvitationsPanel({ projectId }: { projectId: string }) {
 
 	const cancel = useMutation({
 		mutationFn: async (invitationId: string) => {
-			await authedFetch(`/api/projects/${projectId}/invitations/${invitationId}`, {
-				method: "DELETE",
-			});
+			await unwrap(
+				await api.DELETE("/api/projects/{project_id}/invitations/{invitation_id}", {
+					params: { path: { project_id: projectId, invitation_id: invitationId } },
+				}),
+			);
 		},
 		onSuccess: () => {
 			qc.invalidateQueries({ queryKey: ["invitations", projectId] });
@@ -686,15 +655,17 @@ function InvitationsPanel({ projectId }: { projectId: string }) {
 }
 
 function MembersPanel({ projectId }: { projectId: string }) {
+	const api = useApi();
 	const qc = useQueryClient();
-	const authedFetch = useAuthedFetch();
 
 	const members = useQuery({
 		queryKey: ["project-members", projectId],
-		queryFn: async (): Promise<Member[]> => {
-			const r = await authedFetch(`/api/projects/${projectId}/members`);
-			return r.json();
-		},
+		queryFn: async (): Promise<Member[]> =>
+			unwrap(
+				await api.GET("/api/projects/{project_id}/members", {
+					params: { path: { project_id: projectId } },
+				}),
+			),
 	});
 
 	const refreshSharingState = () => {
@@ -707,10 +678,11 @@ function MembersPanel({ projectId }: { projectId: string }) {
 
 	const remove = useMutation({
 		mutationFn: async (userId: string) => {
-			const r = await authedFetch(`/api/projects/${projectId}/members/${userId}`, {
-				method: "DELETE",
-			});
-			return r.json() as Promise<{ status: string }>;
+			return unwrap(
+				await api.DELETE("/api/projects/{project_id}/members/{member_user_id}", {
+					params: { path: { project_id: projectId, member_user_id: userId } },
+				}),
+			);
 		},
 		onSuccess: () => {
 			refreshSharingState();
@@ -723,14 +695,12 @@ function MembersPanel({ projectId }: { projectId: string }) {
 	});
 
 	const unshare = useMutation({
-		mutationFn: async () => {
-			const r = await authedFetch(`/api/projects/${projectId}/unshare`, { method: "POST" });
-			return r.json() as Promise<{
-				links_revoked: number;
-				members_removed: number;
-				invitations_cancelled: number;
-			}>;
-		},
+		mutationFn: async () =>
+			unwrap(
+				await api.POST("/api/projects/{project_id}/unshare", {
+					params: { path: { project_id: projectId } },
+				}),
+			),
 		onSuccess: (body) => {
 			refreshSharingState();
 			toast.success("Sharing Stopped", {

--- a/apps/web/src/components/skills/send-skill-dialog.tsx
+++ b/apps/web/src/components/skills/send-skill-dialog.tsx
@@ -27,7 +27,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
-import { unwrap, useApi, useAuthedFetch } from "@/lib/api";
+import { ensureBlob, unwrap, useApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
 import { errorMessage } from "@/lib/utils";
@@ -52,7 +52,6 @@ export function SendSkillDialog({
 	onDone?: () => void;
 }) {
 	const api = useApi();
-	const authedFetch = useAuthedFetch();
 	const qc = useQueryClient();
 	const [open, setOpen] = useState(false);
 	const [target, setTarget] = useState("");
@@ -113,55 +112,75 @@ export function SendSkillDialog({
 			if (!target) throw new Error("Choose a destination first");
 			// Per-skill try/catch: in a batch, one unreadable skill must
 			// not abort the rest — report partial success instead.
-			let sent = 0;
+			let copied = 0;
 			const failed: string[] = [];
+			const sourceRemoveFailed: string[] = [];
 			for (const skill of skills) {
 				if (!skill.project_id || skill.project_id === target) continue;
+				const label = skill.name || skill.skill_key;
 				try {
-					const dl = await authedFetch(
-						`/api/projects/${skill.project_id}/skills/${encodeURIComponent(skill.skill_key)}/download`,
+					const blob = ensureBlob(
+						unwrap(
+							await api.GET("/api/projects/{project_id}/skills/{skill_key}/download", {
+								params: {
+									path: { project_id: skill.project_id, skill_key: skill.skill_key },
+								},
+								parseAs: "blob",
+							}),
+						),
 					);
-					const blob = await dl.blob();
+					const fileName = `${skill.skill_key.replace(/\//g, "-")}.tar.gz`;
 					const form = new FormData();
 					form.append("skill_key", skill.skill_key);
-					form.append("file", blob, `${skill.skill_key.replace(/\//g, "-")}.tar.gz`);
-					await authedFetch(`/api/projects/${target}/skills/upload`, {
-						method: "POST",
-						body: form,
-					});
+					form.append("file", blob, fileName);
+					await unwrap(
+						await api.POST("/api/projects/{project_id}/skills/upload", {
+							params: { path: { project_id: target } },
+							body: { skill_key: skill.skill_key, file: fileName },
+							bodySerializer: () => form,
+						}),
+					);
+					copied += 1;
 					if (removeFromSource) {
-						await api.DELETE("/api/projects/{project_id}/skills/{skill_key}", {
-							params: { path: { project_id: skill.project_id, skill_key: skill.skill_key } },
-						});
+						try {
+							unwrap(
+								await api.DELETE("/api/projects/{project_id}/skills/{skill_key}", {
+									params: { path: { project_id: skill.project_id, skill_key: skill.skill_key } },
+								}),
+							);
+						} catch {
+							sourceRemoveFailed.push(label);
+						}
 					}
-					sent += 1;
 				} catch {
-					failed.push(skill.name || skill.skill_key);
+					failed.push(label);
 				}
 			}
-			if (sent === 0) {
+			if (copied === 0) {
 				throw new Error(
 					failed.length > 0
-						? `Couldn't read ${failed.join(", ")} from the source`
+						? `Couldn't send ${failed.join(", ")}`
 						: "Everything selected is already in that destination",
 				);
 			}
-			return { sent, failed };
+			return { copied, failed, sourceRemoveFailed };
 		},
-		onSuccess: ({ sent, failed }) => {
+		onSuccess: ({ copied, failed, sourceRemoveFailed }) => {
 			qc.invalidateQueries({ queryKey: ["skills"] });
 			const targetLabel =
 				[...agentTargets, ...projectTargets].find((t) => t.value === target)?.label ??
 				"the destination";
-			const what = sent === 1 && single ? single.name : `${sent} skills`;
+			const what = copied === 1 ? (single?.name ?? "1 skill") : `${copied} skills`;
+			const sourceCleanupFailed = sourceRemoveFailed.length > 0;
 			toast.success(
-				removeFromSource
-					? `${sent === 1 ? "Skill" : "Skills"} moved`
-					: `${sent === 1 ? "Skill" : "Skills"} copied`,
+				removeFromSource && !sourceCleanupFailed
+					? `${copied === 1 ? "Skill" : "Skills"} moved`
+					: `${copied === 1 ? "Skill" : "Skills"} copied`,
 				{
 					description:
 						`${what} now available in ${targetLabel}.` +
-						(failed.length > 0 ? ` Skipped (couldn't read): ${failed.join(", ")}.` : ""),
+						(sourceCleanupFailed ? ` Source not removed: ${sourceRemoveFailed.join(", ")}.` : "") +
+						(failed.length > 0 ? ` Failed: ${failed.join(", ")}.` : ""),
 				},
 			);
 			setOpen(false);

--- a/apps/web/src/components/vault/add-keys-dialog.tsx
+++ b/apps/web/src/components/vault/add-keys-dialog.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, Plus } from "lucide-react";
+import { AlertCircle, Check, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
 	Dialog,
 	DialogContent,
@@ -24,6 +27,8 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
+import { buildKeyImportPreview } from "@/components/vault/key-import-logic";
+import { slugFromVaultName } from "@/components/vault/vault-slug";
 import { unwrap, useApi } from "@/lib/api";
 import { identityFor } from "@/lib/identity";
 import { errorMessage } from "@/lib/utils";
@@ -33,32 +38,6 @@ import { errorMessage } from "@/lib/utils";
  * inline create), from anywhere. No navigation required. */
 
 const NEW_VAULT = "__new__";
-
-/** dotenv-style parser: `export` prefixes, quotes, comments handled. */
-export function parseKeyLines(text: string): Record<string, string> {
-	const out: Record<string, string> = {};
-	for (const rawLine of text.split("\n")) {
-		const line = rawLine.trim();
-		if (!line || line.startsWith("#")) continue;
-		const eq = line.indexOf("=");
-		if (eq <= 0) continue;
-		const key = line
-			.slice(0, eq)
-			.trim()
-			.replace(/^export\s+/, "")
-			.toUpperCase()
-			.replace(/[^A-Z0-9_]/g, "_");
-		let value = line.slice(eq + 1).trim();
-		if (
-			(value.startsWith('"') && value.endsWith('"')) ||
-			(value.startsWith("'") && value.endsWith("'"))
-		) {
-			value = value.slice(1, -1);
-		}
-		if (key && value) out[key] = value;
-	}
-	return out;
-}
 
 export function AddKeysDialog({
 	/** Pin the destination vault (vault detail page); omit for the picker. */
@@ -74,28 +53,85 @@ export function AddKeysDialog({
 	const [text, setText] = useState("");
 	const [vaultChoice, setVaultChoice] = useState<string>(vaultSlug ?? "");
 	const [newVaultName, setNewVaultName] = useState("");
+	const [updateExisting, setUpdateExisting] = useState(false);
 
-	const { data: vaults } = useQuery({
+	const vaultsQuery = useQuery({
 		queryKey: ["vaults", "all"],
 		queryFn: async () =>
 			unwrap(await api.GET("/api/vault", { params: { query: { page_size: 200 } } })),
 		enabled: open,
 	});
-	const { data: projects } = useQuery({
+	const projectsQuery = useQuery({
 		queryKey: ["projects"],
 		queryFn: async () => unwrap(await api.GET("/api/projects")),
 		enabled: open,
 	});
 
 	const ownVaults = useMemo(
-		() => (vaults?.items ?? []).filter((v) => v.is_owner !== false),
-		[vaults],
+		() => (vaultsQuery.data?.items ?? []).filter((v) => v.is_owner !== false),
+		[vaultsQuery.data],
 	);
-	const fields = useMemo(() => parseKeyLines(text), [text]);
-	const count = Object.keys(fields).length;
-
 	// Default destination: pinned slug, else the first vault, else create-new.
 	const effectiveChoice = vaultChoice || (ownVaults.length > 0 ? ownVaults[0].slug : NEW_VAULT);
+	const selectedVault = ownVaults.find((v) => v.slug === effectiveChoice);
+	const selectedVaultProjectId = selectedVault?.project_ids?.[0] ?? undefined;
+	const newVaultSlug = useMemo(() => slugFromVaultName(newVaultName), [newVaultName]);
+	const newVaultSlugTaken =
+		effectiveChoice === NEW_VAULT &&
+		newVaultSlug.length > 0 &&
+		ownVaults.some((v) => v.slug === newVaultSlug);
+	const writableProject = useMemo(
+		() =>
+			(projectsQuery.data ?? []).find((p) => p.kind === "personal") ??
+			(projectsQuery.data ?? []).find((p) => p.is_owner !== false),
+		[projectsQuery.data],
+	);
+	const newVaultPending =
+		effectiveChoice === NEW_VAULT &&
+		!vaultSlug &&
+		(vaultsQuery.isLoading || projectsQuery.isLoading);
+	const newVaultUnavailable =
+		effectiveChoice === NEW_VAULT &&
+		!vaultSlug &&
+		!vaultsQuery.isLoading &&
+		!projectsQuery.isLoading &&
+		writableProject === undefined;
+	const existingItems = useQuery({
+		queryKey: ["vault-items", effectiveChoice, selectedVaultProjectId],
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/api/vault/{slug}/items", {
+					params: {
+						path: { slug: effectiveChoice },
+						query: { project_id: selectedVaultProjectId },
+					},
+				}),
+			),
+		enabled: open && effectiveChoice !== NEW_VAULT && selectedVault !== undefined,
+	});
+	const existingDefaultKeys = useMemo(
+		() => new Set(existingItems.data?.["(default)"] ?? []),
+		[existingItems.data],
+	);
+	const importPlan = useMemo(
+		() => buildKeyImportPreview(text, existingDefaultKeys, updateExisting),
+		[text, existingDefaultKeys, updateExisting],
+	);
+	const count = importPlan.parsed.entries.length;
+	const importableCount = importPlan.importableRows.length;
+	const destinationPending =
+		open &&
+		effectiveChoice !== NEW_VAULT &&
+		(vaultsQuery.isLoading || selectedVault === undefined || existingItems.isLoading);
+	const canSave =
+		importPlan.parsed.errors.length === 0 &&
+		importableCount > 0 &&
+		!saveDisabledForNewVault(effectiveChoice, vaultSlug, newVaultName, newVaultSlug) &&
+		!newVaultSlugTaken &&
+		!newVaultPending &&
+		!newVaultUnavailable &&
+		!destinationPending &&
+		!existingItems.error;
 
 	const save = useMutation({
 		mutationFn: async () => {
@@ -104,27 +140,25 @@ export function AddKeysDialog({
 			if (slug === NEW_VAULT) {
 				const name = newVaultName.trim();
 				if (!name) throw new Error("Name the new vault first");
-				slug = name
-					.toLowerCase()
-					.replace(/[^a-z0-9-]+/g, "-")
-					.replace(/-{2,}/g, "-")
-					.replace(/^-+|-+$/g, "");
-				const personal =
-					(projects ?? []).find((p) => p.kind === "personal") ??
-					(projects ?? []).find((p) => p.is_owner !== false);
-				if (!personal) throw new Error("No writable Project available yet");
-				projectId = personal.id;
+				slug = newVaultSlug;
+				if (!slug) throw new Error("Use letters or numbers in the vault name");
+				if (ownVaults.some((v) => v.slug === slug)) {
+					throw new Error("A vault with that name already exists");
+				}
+				if (!writableProject) throw new Error("No writable Project available yet");
+				projectId = writableProject.id;
 				await unwrap(
 					await api.POST("/api/vault", {
-						params: { query: { project_id: projectId } },
+						params: { query: { project_id: projectId, create_only: true } },
 						body: { slug, name },
 					}),
 				);
 			} else {
-				projectId = ownVaults.find((v) => v.slug === slug)?.project_ids?.[0] ?? undefined;
+				projectId = selectedVaultProjectId;
 			}
 			// API caps 200 fields per write; chunk for big pastes.
-			const entries = Object.entries(fields);
+			const entries = Object.entries(importPlan.fields);
+			if (entries.length === 0) throw new Error("No keys to save");
 			for (let i = 0; i < entries.length; i += 150) {
 				await unwrap(
 					await api.PUT("/api/vault/{slug}/items", {
@@ -133,17 +167,22 @@ export function AddKeysDialog({
 					}),
 				);
 			}
-			return slug;
+			return { slug, summary: importPlan.summary };
 		},
-		onSuccess: (slug) => {
+		onSuccess: ({ slug, summary }) => {
 			qc.invalidateQueries({ queryKey: ["vaults"] });
 			qc.invalidateQueries({ queryKey: ["vault-items", slug] });
-			toast.success(`${count} ${count === 1 ? "key" : "keys"} saved`, {
-				description: `In vault://${slug}. Agents read them through the CLI at runtime.`,
+			const changed = summary.created + summary.updated;
+			toast.success(`${changed} ${changed === 1 ? "key" : "keys"} saved`, {
+				description:
+					summary.updated > 0 || summary.skipped > 0
+						? `${summary.created} new, ${summary.updated} updated, ${summary.skipped} skipped in vault://${slug}.`
+						: `In vault://${slug}. Agents read them through the CLI at runtime.`,
 			});
 			setOpen(false);
 			setText("");
 			setNewVaultName("");
+			setUpdateExisting(false);
 		},
 		onError: (e) => toast.error("Couldn't save keys", { description: errorMessage(e) }),
 	});
@@ -157,6 +196,7 @@ export function AddKeysDialog({
 					setText("");
 					setNewVaultName("");
 					setVaultChoice(vaultSlug ?? "");
+					setUpdateExisting(false);
 				}
 			}}
 		>
@@ -172,7 +212,7 @@ export function AddKeysDialog({
 				<DialogHeader>
 					<DialogTitle>Add keys</DialogTitle>
 					<DialogDescription>
-						Paste <span className="font-mono">KEY=value</span> lines — one key or a whole .env file.
+						Paste <span className="font-mono">KEY=value</span> lines or a flat JSON object.
 					</DialogDescription>
 				</DialogHeader>
 				<div className="space-y-3">
@@ -210,34 +250,133 @@ export function AddKeysDialog({
 								</Select>
 							</div>
 							{effectiveChoice === NEW_VAULT ? (
-								<Input
-									value={newVaultName}
-									onChange={(e) => setNewVaultName(e.target.value)}
-									placeholder="Vault name…"
-									aria-label="New vault name"
-									className="sm:w-44"
-								/>
+								<div className="space-y-1">
+									<Input
+										value={newVaultName}
+										onChange={(e) => setNewVaultName(e.target.value)}
+										placeholder="Vault name…"
+										aria-label="New vault name"
+										className="sm:w-44"
+									/>
+									{newVaultSlugTaken ? (
+										<p className="max-w-44 text-xs text-destructive">
+											That vault already exists. Choose it from the list or use a different name.
+										</p>
+									) : null}
+									{newVaultUnavailable ? (
+										<p className="max-w-44 text-xs text-destructive">
+											No writable Project is available yet.
+										</p>
+									) : null}
+								</div>
 							) : null}
+						</div>
+					) : null}
+					{importPlan.parsed.errors.length > 0 ? (
+						<Alert variant="destructive">
+							<AlertCircle className="size-4" />
+							<AlertTitle>Fix import text</AlertTitle>
+							<AlertDescription>
+								<ul className="max-h-32 list-disc space-y-1 overflow-auto pl-4">
+									{importPlan.parsed.errors.map((error, index) => (
+										<li key={`${index}-${error}`}>{error}</li>
+									))}
+								</ul>
+							</AlertDescription>
+						</Alert>
+					) : null}
+					{existingItems.error ? (
+						<Alert variant="destructive">
+							<AlertCircle className="size-4" />
+							<AlertTitle>Couldn't check existing keys</AlertTitle>
+							<AlertDescription>{errorMessage(existingItems.error)}</AlertDescription>
+						</Alert>
+					) : null}
+					{importPlan.conflicts.length > 0 && importPlan.parsed.errors.length === 0 ? (
+						<div className="flex items-start gap-3 rounded-md border bg-muted/20 p-3">
+							<Checkbox
+								id="add-keys-update-existing"
+								checked={updateExisting}
+								onCheckedChange={(checked) => setUpdateExisting(checked === true)}
+								className="mt-0.5"
+							/>
+							<div className="space-y-1">
+								<Label htmlFor="add-keys-update-existing" className="text-sm font-medium">
+									Overwrite existing keys
+								</Label>
+								<p className="text-xs text-muted-foreground">
+									{importPlan.conflicts.length} key
+									{importPlan.conflicts.length === 1 ? "" : "s"} already exist. By default, they are
+									skipped.
+								</p>
+							</div>
+						</div>
+					) : null}
+					{importPlan.preview.length > 0 && importPlan.parsed.errors.length === 0 ? (
+						<div className="rounded-md border">
+							<div className="flex items-center justify-between gap-2 border-b px-3 py-2">
+								<p className="text-xs font-medium">Preview</p>
+								<div className="flex flex-wrap gap-1.5">
+									<Badge variant="secondary">{importPlan.summary.created} new</Badge>
+									{importPlan.conflicts.length > 0 ? (
+										<Badge variant="outline">
+											{updateExisting
+												? `${importPlan.summary.updated} update`
+												: `${importPlan.summary.skipped} skip`}
+										</Badge>
+									) : null}
+								</div>
+							</div>
+							<div className="max-h-44 divide-y overflow-auto">
+								{importPlan.preview.slice(0, 10).map((entry) => (
+									<div
+										key={`${entry.line ?? "json"}-${entry.key}`}
+										className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-3 py-2 text-sm"
+									>
+										<span className="truncate font-mono text-xs" translate="no">
+											{entry.key}
+										</span>
+										<KeyImportActionBadge action={entry.action} />
+									</div>
+								))}
+								{importPlan.preview.length > 10 ? (
+									<p className="px-3 py-2 text-xs text-muted-foreground">
+										{importPlan.preview.length - 10} more key
+										{importPlan.preview.length - 10 === 1 ? "" : "s"} ready.
+									</p>
+								) : null}
+							</div>
 						</div>
 					) : null}
 					<div className="flex items-center justify-between gap-2">
 						<span className="text-xs text-muted-foreground tabular-nums">
 							{count} {count === 1 ? "key" : "keys"} detected
+							{importPlan.summary.skipped > 0 ? ` · ${importPlan.summary.skipped} skipped` : ""}
 						</span>
-						<Button
-							onClick={() => save.mutate()}
-							disabled={
-								count === 0 ||
-								save.isPending ||
-								(effectiveChoice === NEW_VAULT && !newVaultName.trim() && !vaultSlug)
-							}
-						>
+						<Button onClick={() => save.mutate()} disabled={!canSave || save.isPending}>
 							{save.isPending ? <Spinner /> : <Check className="size-3.5" />}
-							Save {count > 0 ? count : ""}
+							Save {importableCount > 0 ? importableCount : ""}
 						</Button>
 					</div>
 				</div>
 			</DialogContent>
 		</Dialog>
+	);
+}
+
+function saveDisabledForNewVault(
+	effectiveChoice: string,
+	vaultSlug: string | undefined,
+	newVaultName: string,
+	newVaultSlug: string,
+): boolean {
+	return effectiveChoice === NEW_VAULT && !vaultSlug && (!newVaultName.trim() || !newVaultSlug);
+}
+
+function KeyImportActionBadge({ action }: { action: "create" | "update" | "skip" }) {
+	return (
+		<Badge variant={action === "create" ? "secondary" : "outline"}>
+			{action === "create" ? "New" : action === "update" ? "Update" : "Skip"}
+		</Badge>
 	);
 }

--- a/apps/web/src/components/vault/copy-keys-dialog.tsx
+++ b/apps/web/src/components/vault/copy-keys-dialog.tsx
@@ -23,6 +23,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
+import { slugFromVaultName } from "@/components/vault/vault-slug";
 import { unwrap, useApi } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
@@ -61,23 +62,53 @@ export function CopyKeysDialog({
 	const attachedCount = vault.project_ids?.length ?? 0;
 	const verb = mode === "move" ? "Move" : "Copy";
 
-	const { data: vaults } = useQuery({
+	const vaultsQuery = useQuery({
 		queryKey: ["vaults", "all"],
 		queryFn: async () =>
 			unwrap(await api.GET("/api/vault", { params: { query: { page_size: 200 } } })),
 		enabled: open,
 	});
-	const { data: projects } = useQuery({
+	const projectsQuery = useQuery({
 		queryKey: ["projects"],
 		queryFn: async () => unwrap(await api.GET("/api/projects")),
 		enabled: open,
 	});
+	const ownVaults = useMemo(
+		() => (vaultsQuery.data?.items ?? []).filter((v) => v.is_owner !== false),
+		[vaultsQuery.data],
+	);
 	const targetVaults = useMemo(
-		() => (vaults?.items ?? []).filter((v) => v.is_owner !== false && v.slug !== vault.slug),
-		[vaults, vault.slug],
+		() => ownVaults.filter((v) => v.slug !== vault.slug),
+		[ownVaults, vault.slug],
 	);
 	const effectiveChoice =
 		targetChoice || (targetVaults.length > 0 ? targetVaults[0].slug : NEW_VAULT);
+	const creatingNewVault = effectiveChoice === NEW_VAULT;
+	const newVaultSlug = useMemo(() => slugFromVaultName(newVaultName), [newVaultName]);
+	const newVaultSlugTaken =
+		creatingNewVault && newVaultSlug.length > 0 && ownVaults.some((v) => v.slug === newVaultSlug);
+	const writableProject = useMemo(
+		() =>
+			(projectsQuery.data ?? []).find((p) => p.kind === "personal") ??
+			(projectsQuery.data ?? []).find((p) => p.is_owner !== false),
+		[projectsQuery.data],
+	);
+	const newVaultPending = creatingNewVault && (vaultsQuery.isLoading || projectsQuery.isLoading);
+	const newVaultUnavailable =
+		creatingNewVault &&
+		!projectsQuery.isLoading &&
+		!vaultsQuery.isLoading &&
+		writableProject === undefined;
+	const canRun =
+		keys.length > 0 &&
+		!runIsBlockedForNewVault(
+			creatingNewVault,
+			newVaultName,
+			newVaultSlug,
+			newVaultSlugTaken,
+			newVaultPending,
+			newVaultUnavailable,
+		);
 
 	const run = useMutation({
 		mutationFn: async () => {
@@ -85,18 +116,15 @@ export function CopyKeysDialog({
 			if (targetSlug === NEW_VAULT) {
 				const name = newVaultName.trim();
 				if (!name) throw new Error("Name the new vault first");
-				targetSlug = name
-					.toLowerCase()
-					.replace(/[^a-z0-9-]+/g, "-")
-					.replace(/-{2,}/g, "-")
-					.replace(/^-+|-+$/g, "");
-				const personal =
-					(projects ?? []).find((p) => p.kind === "personal") ??
-					(projects ?? []).find((p) => p.is_owner !== false);
-				if (!personal) throw new Error("No writable Project available yet");
+				targetSlug = newVaultSlug;
+				if (!targetSlug) throw new Error("Use letters or numbers in the vault name");
+				if (ownVaults.some((v) => v.slug === targetSlug)) {
+					throw new Error("A vault with that name already exists");
+				}
+				if (!writableProject) throw new Error("No writable Project available yet");
 				await unwrap(
 					await api.POST("/api/vault", {
-						params: { query: { project_id: personal.id } },
+						params: { query: { project_id: writableProject.id, create_only: true } },
 						body: { slug: targetSlug, name },
 					}),
 				);
@@ -109,40 +137,68 @@ export function CopyKeysDialog({
 				if (bucket) bucket.push(k.name);
 				else bySection.set(section, [k.name]);
 			}
+			let copied = 0;
+			const failed: string[] = [];
+			const sourceRemoveFailed: string[] = [];
 			for (const [section, names] of bySection) {
 				for (let i = 0; i < names.length; i += CHUNK) {
 					const fields = names.slice(i, i + CHUNK);
-					await unwrap(
-						await api.POST("/api/vault/{slug}/items/copy", {
-							params: {
-								path: { slug: vault.slug },
-								query: { project_id: anyProjectId ?? undefined },
-							},
-							body: { target_slug: targetSlug, section, fields },
-						}),
-					);
-					if (mode === "move") {
-						await unwrap(
-							await api.DELETE("/api/vault/{slug}/items", {
+					let copiedInChunk = 0;
+					try {
+						const result = unwrap(
+							await api.POST("/api/vault/{slug}/items/copy", {
 								params: {
 									path: { slug: vault.slug },
-									query: { project_id: anyProjectId ?? undefined, global_delete: true },
+									query: { project_id: anyProjectId ?? undefined },
 								},
-								body: { section, fields },
+								body: { target_slug: targetSlug, section, fields },
 							}),
 						);
+						copiedInChunk = result.copied;
+						copied += result.copied;
+					} catch {
+						failed.push(...fields);
+						continue;
+					}
+					if (mode === "move") {
+						try {
+							if (copiedInChunk > 0) {
+								await unwrap(
+									await api.DELETE("/api/vault/{slug}/items", {
+										params: {
+											path: { slug: vault.slug },
+											query: { project_id: anyProjectId ?? undefined, global_delete: true },
+										},
+										body: { section, fields },
+									}),
+								);
+							}
+						} catch {
+							sourceRemoveFailed.push(...fields);
+						}
 					}
 				}
 			}
-			return targetSlug;
+			if (copied === 0) {
+				throw new Error(
+					failed.length > 0 ? `Couldn't copy ${failed.join(", ")}` : "No keys copied",
+				);
+			}
+			return { targetSlug, copied, failed, sourceRemoveFailed };
 		},
-		onSuccess: (targetSlug) => {
+		onSuccess: ({ targetSlug, copied, failed, sourceRemoveFailed }) => {
 			qc.invalidateQueries({ queryKey: ["vaults"] });
 			qc.invalidateQueries({ queryKey: ["vault-items"] });
+			const sourceCleanupFailed = sourceRemoveFailed.length > 0;
 			toast.success(
-				`${keys.length} ${keys.length === 1 ? "key" : "keys"} ${mode === "move" ? "moved" : "copied"}`,
+				`${copied} ${copied === 1 ? "key" : "keys"} ${
+					mode === "move" && !sourceCleanupFailed ? "moved" : "copied"
+				}`,
 				{
-					description: `Now in vault://${targetSlug}.`,
+					description:
+						`Now in vault://${targetSlug}.` +
+						(sourceCleanupFailed ? ` Source not removed: ${sourceRemoveFailed.join(", ")}.` : "") +
+						(failed.length > 0 ? ` Failed: ${failed.join(", ")}.` : ""),
 				},
 			);
 			setOpen(false);
@@ -207,13 +263,25 @@ export function CopyKeysDialog({
 							</Select>
 						</div>
 						{effectiveChoice === NEW_VAULT ? (
-							<Input
-								value={newVaultName}
-								onChange={(e) => setNewVaultName(e.target.value)}
-								placeholder="Vault name…"
-								aria-label="New vault name"
-								className="sm:w-44"
-							/>
+							<div className="space-y-1">
+								<Input
+									value={newVaultName}
+									onChange={(e) => setNewVaultName(e.target.value)}
+									placeholder="Vault name…"
+									aria-label="New vault name"
+									className="sm:w-44"
+								/>
+								{newVaultSlugTaken ? (
+									<p className="max-w-44 text-xs text-destructive">
+										That vault already exists. Choose it from the list or use a different name.
+									</p>
+								) : null}
+								{newVaultUnavailable ? (
+									<p className="max-w-44 text-xs text-destructive">
+										No writable Project is available yet.
+									</p>
+								) : null}
+							</div>
 						) : null}
 					</div>
 					{mode === "move" && attachedCount > 1 ? (
@@ -231,7 +299,7 @@ export function CopyKeysDialog({
 					) : null}
 					<Button
 						className="w-full"
-						disabled={run.isPending || (effectiveChoice === NEW_VAULT && !newVaultName.trim())}
+						disabled={run.isPending || !canRun}
 						onClick={() => run.mutate()}
 					>
 						{run.isPending ? <Spinner /> : <ArrowRight className="size-3.5" />}
@@ -240,5 +308,23 @@ export function CopyKeysDialog({
 				</div>
 			</DialogContent>
 		</Dialog>
+	);
+}
+
+function runIsBlockedForNewVault(
+	creatingNewVault: boolean,
+	newVaultName: string,
+	newVaultSlug: string,
+	newVaultSlugTaken: boolean,
+	newVaultPending: boolean,
+	newVaultUnavailable: boolean,
+): boolean {
+	return (
+		creatingNewVault &&
+		(!newVaultName.trim() ||
+			!newVaultSlug ||
+			newVaultSlugTaken ||
+			newVaultPending ||
+			newVaultUnavailable)
 	);
 }

--- a/apps/web/src/components/vault/key-import-logic.test.ts
+++ b/apps/web/src/components/vault/key-import-logic.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { buildKeyImportPreview } from "./key-import-logic";
+
+describe("buildKeyImportPreview", () => {
+	test("uses the robust vault parser for env lines", () => {
+		const plan = buildKeyImportPreview(
+			`
+				API_KEY=one
+				EMPTY_VALUE=
+				WITH_COMMENT=value # comment
+			`,
+			new Set(),
+			false,
+		);
+
+		expect(plan.parsed.errors).toEqual([]);
+		expect(plan.fields).toEqual({
+			API_KEY: "one",
+			EMPTY_VALUE: "",
+			WITH_COMMENT: "value",
+		});
+		expect(plan.summary).toEqual({ created: 3, updated: 0, skipped: 0 });
+	});
+
+	test("supports flat JSON imports", () => {
+		const plan = buildKeyImportPreview('{"api_key":"secret","ENABLED":true}', new Set(), false);
+
+		expect(plan.fields).toEqual({ API_KEY: "secret", ENABLED: "true" });
+		expect(plan.preview.map((entry) => entry.action)).toEqual(["create", "create"]);
+	});
+
+	test("skips existing keys by default and can mark them for update", () => {
+		const existing = new Set(["API_KEY"]);
+		const skipPlan = buildKeyImportPreview("API_KEY=new\nOTHER=ok", existing, false);
+		const updatePlan = buildKeyImportPreview("API_KEY=new\nOTHER=ok", existing, true);
+
+		expect(skipPlan.fields).toEqual({ OTHER: "ok" });
+		expect(skipPlan.summary).toEqual({ created: 1, updated: 0, skipped: 1 });
+		expect(skipPlan.preview.map((entry) => entry.action)).toEqual(["skip", "create"]);
+		expect(updatePlan.fields).toEqual({ API_KEY: "new", OTHER: "ok" });
+		expect(updatePlan.summary).toEqual({ created: 1, updated: 1, skipped: 0 });
+		expect(updatePlan.preview.map((entry) => entry.action)).toEqual(["update", "create"]);
+	});
+
+	test("surfaces parser errors without importable fields", () => {
+		const plan = buildKeyImportPreview("API_KEY=one\napi_key=two", new Set(), false);
+
+		expect(plan.parsed.errors).toEqual([
+			'Line 2: duplicate key "api_key" (same as "API_KEY" after normalization to "API_KEY").',
+		]);
+		expect(plan.preview).toEqual([]);
+		expect(plan.fields).toEqual({});
+	});
+});

--- a/apps/web/src/components/vault/key-import-logic.ts
+++ b/apps/web/src/components/vault/key-import-logic.ts
@@ -1,0 +1,41 @@
+import {
+	type KeyImportSummary,
+	type ParsedKey,
+	parseVaultKeyImport,
+} from "@/components/vault/key-import-parse";
+
+export interface KeyImportPreviewRow extends ParsedKey {
+	exists: boolean;
+	action: "create" | "update" | "skip";
+}
+
+export function buildKeyImportPreview(
+	text: string,
+	existingKeys: ReadonlySet<string>,
+	updateExisting: boolean,
+) {
+	const parsed = parseVaultKeyImport(text);
+	const preview: KeyImportPreviewRow[] = parsed.entries.map((entry) => {
+		const exists = existingKeys.has(entry.key);
+		return {
+			...entry,
+			exists,
+			action: exists ? (updateExisting ? "update" : "skip") : "create",
+		};
+	});
+	const importableRows = preview.filter((entry) => entry.action !== "skip");
+	const summary: KeyImportSummary = {
+		created: importableRows.filter((entry) => entry.action === "create").length,
+		updated: importableRows.filter((entry) => entry.action === "update").length,
+		skipped: preview.filter((entry) => entry.action === "skip").length,
+	};
+	const fields = Object.fromEntries(importableRows.map((entry) => [entry.key, entry.value]));
+	return {
+		parsed,
+		preview,
+		conflicts: preview.filter((entry) => entry.exists),
+		importableRows,
+		fields,
+		summary,
+	};
+}

--- a/apps/web/src/components/vault/split-vault-dialog.tsx
+++ b/apps/web/src/components/vault/split-vault-dialog.tsx
@@ -93,18 +93,20 @@ export function SplitVaultDialog({
 				(projects ?? []).find((p) => p.is_owner !== false);
 			if (!personal) throw new Error("No writable Project available yet");
 			let done = 0;
+			let affectedKeys = 0;
 			const failed: string[] = [];
 			for (const group of selected) {
 				setProgress(`${group.slug} (${done + 1}/${selected.length})…`);
 				try {
 					await unwrap(
 						await api.POST("/api/vault", {
-							params: { query: { project_id: personal.id } },
+							params: { query: { project_id: personal.id, create_only: true } },
 							body: { slug: group.slug, name: group.prefix.slice(0, -1) },
 						}),
 					);
 					// Group by section, then chunked copy with rename + delete.
 					const bySection = new Map<string, string[]>();
+					let copiedInGroup = 0;
 					for (const k of group.keys) {
 						const section = k.section === "(default)" ? "" : k.section;
 						const bucket = bySection.get(section);
@@ -114,7 +116,7 @@ export function SplitVaultDialog({
 					for (const [section, names] of bySection) {
 						for (let i = 0; i < names.length; i += CHUNK) {
 							const fields = names.slice(i, i + CHUNK);
-							await unwrap(
+							const result = unwrap(
 								await api.POST("/api/vault/{slug}/items/copy", {
 									params: {
 										path: { slug: vault.slug },
@@ -128,33 +130,43 @@ export function SplitVaultDialog({
 									},
 								}),
 							);
+							copiedInGroup += result.copied;
 							if (removeOriginals) {
-								await unwrap(
-									await api.DELETE("/api/vault/{slug}/items", {
-										params: {
-											path: { slug: vault.slug },
-											query: { project_id: anyProjectId ?? undefined, global_delete: true },
-										},
-										body: { section, fields },
-									}),
-								);
+								if (result.copied > 0) {
+									await unwrap(
+										await api.DELETE("/api/vault/{slug}/items", {
+											params: {
+												path: { slug: vault.slug },
+												query: { project_id: anyProjectId ?? undefined, global_delete: true },
+											},
+											body: { section, fields },
+										}),
+									);
+								}
 							}
 						}
 					}
+					if (copiedInGroup === 0) throw new Error("No keys copied");
 					done += 1;
+					affectedKeys += copiedInGroup;
 				} catch {
 					failed.push(group.slug);
 				}
 			}
-			return { done, failed };
+			if (done === 0) {
+				throw new Error(
+					failed.length > 0 ? `Couldn't split ${failed.join(", ")}` : "No vaults selected",
+				);
+			}
+			return { done, failed, affectedKeys };
 		},
-		onSuccess: ({ done, failed }) => {
+		onSuccess: ({ done, failed, affectedKeys }) => {
 			qc.invalidateQueries({ queryKey: ["vaults"] });
 			qc.invalidateQueries({ queryKey: ["vault-items"] });
 			setProgress(null);
 			toast.success(`Split into ${done} ${done === 1 ? "vault" : "vaults"}`, {
 				description:
-					`${selectedKeyCount} keys ${removeOriginals ? "moved" : "copied"} with clean names.` +
+					`${affectedKeys} keys ${removeOriginals ? "moved" : "copied"} with clean names.` +
 					(failed.length > 0 ? ` Failed: ${failed.join(", ")}.` : ""),
 			});
 			setOpen(false);

--- a/apps/web/src/components/vault/vault-slug.test.ts
+++ b/apps/web/src/components/vault/vault-slug.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+import { slugFromVaultName } from "./vault-slug";
+
+describe("slugFromVaultName", () => {
+	test("normalizes vault display names to backend slugs", () => {
+		expect(slugFromVaultName("OpenAI Production")).toBe("openai-production");
+		expect(slugFromVaultName("  GitHub___Tokens  ")).toBe("github-tokens");
+		expect(slugFromVaultName("!!!")).toBe("");
+	});
+});

--- a/apps/web/src/components/vault/vault-slug.ts
+++ b/apps/web/src/components/vault/vault-slug.ts
@@ -1,0 +1,7 @@
+export function slugFromVaultName(name: string): string {
+	return name
+		.toLowerCase()
+		.replace(/[^a-z0-9-]+/g, "-")
+		.replace(/-{2,}/g, "-")
+		.replace(/^-+|-+$/g, "");
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -57,25 +57,7 @@ export function unwrap<T>(result: { data?: T; error?: unknown; response: Respons
 	return result.data as T;
 }
 
-/**
- * Raw-fetch helper bound to the current Clerk session. Use when the
- * typed openapi-fetch client doesn't yet cover the endpoint (e.g.
- * generated paths are temporarily stale) — the typed `useApi()` client is still the default
- * for everything in the OpenAPI surface.
- *
- * Throws ApiError on non-2xx, mirroring `unwrap()`'s shape so a
- * useQuery / useMutation error path routes through the same channel.
- */
-export function useAuthedFetch(): (path: string, init?: RequestInit) => Promise<Response> {
-	const { getToken } = useAuthToken();
-	return useMemo(() => {
-		return async (path: string, init?: RequestInit) => {
-			const headers = new Headers(init?.headers);
-			const token = await getToken();
-			if (token) headers.set("Authorization", `Bearer ${token}`);
-			const r = await fetch(`${API_URL}${path}`, { ...init, headers });
-			if (!r.ok) throw new ApiError(r.status, await r.text());
-			return r;
-		};
-	}, [getToken]);
+export function ensureBlob(value: unknown): Blob {
+	if (value instanceof Blob) return value;
+	throw new Error("Expected a binary API response");
 }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,9 +2,11 @@ import asyncio
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import Literal
 
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -44,6 +46,10 @@ logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("httpcore").setLevel(logging.WARNING)
 log = logging.getLogger(__name__)
 init_sentry()
+
+
+class HealthResponse(BaseModel):
+    status: Literal["ok"]
 
 
 @asynccontextmanager
@@ -189,8 +195,8 @@ app.include_router(me_router)
 app.include_router(agent_project_bindings_router)
 
 
-@app.get("/health")
-async def health(db: AsyncSession = Depends(get_session)) -> dict[str, str]:
+@app.get("/health", response_model=HealthResponse)
+async def health(db: AsyncSession = Depends(get_session)) -> HealthResponse:
     """Liveness + DB connectivity probe.
 
     Returns 200 + ``{"status": "ok"}`` on success. If the DB is unreachable
@@ -198,4 +204,4 @@ async def health(db: AsyncSession = Depends(get_session)) -> dict[str, str]:
     load balancer to yank this pod out of rotation.
     """
     await db.execute(text("SELECT 1"))
-    return {"status": "ok"}
+    return HealthResponse(status="ok")

--- a/backend/app/routes/agent_project_bindings.py
+++ b/backend/app/routes/agent_project_bindings.py
@@ -16,7 +16,9 @@ from app.models.project import PROJECT_KIND_WORKSPACE
 from app.schemas.sharing import (
     AgentProjectBindingResponse,
     BindingCreate,
+    BindingDeleteResponse,
     BindingReorderBody,
+    BindingReorderResponse,
 )
 from app.services.agent_bindings import (
     assert_project_visible_to_user,
@@ -159,13 +161,16 @@ async def add_context_project_binding(
     return _to_response(binding)
 
 
-@router.patch("/{agent_id}/project-bindings/context/reorder")
+@router.patch(
+    "/{agent_id}/project-bindings/context/reorder",
+    response_model=BindingReorderResponse,
+)
 async def reorder_context_project_bindings(
     agent_id: UUID,
     body: BindingReorderBody,
     auth: AuthContext = Depends(require_user_auth_unbound),
     db: AsyncSession = Depends(get_session),
-) -> dict[str, str]:
+) -> BindingReorderResponse:
     agent = await get_owned_agent_or_404(db, user_id=auth.user_id, agent_id=agent_id)
     await ensure_agent_primary_binding(
         db,
@@ -224,16 +229,19 @@ async def reorder_context_project_bindings(
             binding.priority = priority
 
     await db.commit()
-    return {"status": "reordered"}
+    return BindingReorderResponse(status="reordered")
 
 
-@router.delete("/{agent_id}/project-bindings/{binding_id}")
+@router.delete(
+    "/{agent_id}/project-bindings/{binding_id}",
+    response_model=BindingDeleteResponse,
+)
 async def delete_project_binding(
     agent_id: UUID,
     binding_id: UUID,
     auth: AuthContext = Depends(require_user_auth_unbound),
     db: AsyncSession = Depends(get_session),
-) -> dict[str, str]:
+) -> BindingDeleteResponse:
     agent = await get_owned_agent_or_404(db, user_id=auth.user_id, agent_id=agent_id)
     await ensure_agent_primary_binding(
         db,
@@ -258,4 +266,4 @@ async def delete_project_binding(
 
     await db.delete(binding)
     await db.commit()
-    return {"status": "deleted"}
+    return BindingDeleteResponse(status="deleted")

--- a/backend/app/routes/me.py
+++ b/backend/app/routes/me.py
@@ -16,7 +16,12 @@ from app.core.database import get_session
 from app.models.project import PROJECT_KIND_WORKSPACE, Project
 from app.models.project_invitation import ProjectInvitation
 from app.models.user import User
-from app.schemas.sharing import InvitationAcceptResponse, InvitationResponse, UpgradeBody
+from app.schemas.sharing import (
+    InvitationAcceptResponse,
+    InvitationDeclineResponse,
+    InvitationResponse,
+    UpgradeBody,
+)
 from app.services.agent_bindings import attach_project_to_owned_agents
 from app.services.sharing import ensure_viewer_membership, safe_owner_display
 
@@ -73,7 +78,7 @@ async def accept_invitation(
     body: UpgradeBody | None = None,
     auth: AuthContext = Depends(require_user_auth_unbound),
     db: AsyncSession = Depends(get_session),
-) -> dict:
+) -> InvitationAcceptResponse:
     return await accept_invitation_for_user(
         invitation_id=invitation_id,
         body=body,
@@ -88,7 +93,7 @@ async def accept_invitation_for_user(
     body: UpgradeBody | None,
     auth: AuthContext,
     db: AsyncSession,
-) -> dict:
+) -> InvitationAcceptResponse:
     body = body or UpgradeBody()
     inv_pre = (
         await db.execute(select(ProjectInvitation).where(ProjectInvitation.id == invitation_id))
@@ -144,23 +149,26 @@ async def accept_invitation_for_user(
         inv.project_id,
         bound_agent_ids,
     )
-    return {
-        "id": str(membership.id),
-        "project_id": str(membership.project_id),
-        "role": membership.role,
-        "joined_via": membership.joined_via,
-        "joined_at": membership.joined_at.isoformat(),
-        "resolved_owner_handle": membership.resolved_owner_handle,
-        "bound_agent_ids": bound_agent_ids,
-    }
+    return InvitationAcceptResponse(
+        id=str(membership.id),
+        project_id=str(membership.project_id),
+        role=membership.role,
+        joined_via=membership.joined_via,
+        joined_at=membership.joined_at,
+        resolved_owner_handle=membership.resolved_owner_handle,
+        bound_agent_ids=bound_agent_ids,
+    )
 
 
-@router.post("/invitations/{invitation_id}/decline")
+@router.post(
+    "/invitations/{invitation_id}/decline",
+    response_model=InvitationDeclineResponse,
+)
 async def decline_invitation(
     invitation_id: UUID,
     auth: AuthContext = Depends(require_user_auth_unbound),
     db: AsyncSession = Depends(get_session),
-) -> dict[str, str]:
+) -> InvitationDeclineResponse:
     inv = (
         await db.execute(select(ProjectInvitation).where(ProjectInvitation.id == invitation_id))
     ).scalar_one_or_none()
@@ -168,4 +176,4 @@ async def decline_invitation(
         raise HTTPException(status.HTTP_410_GONE, "invitation not available")
     await db.delete(inv)
     await db.commit()
-    return {"status": "declined"}
+    return InvitationDeclineResponse(status="declined")

--- a/backend/app/routes/public_sessions.py
+++ b/backend/app/routes/public_sessions.py
@@ -17,7 +17,6 @@ Access policy:
 from __future__ import annotations
 
 import logging
-from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response, status
@@ -33,7 +32,12 @@ from app.models.session_permission import (
     SessionPermission,
 )
 from app.models.user import User
-from app.schemas.session import SessionMessageResponse, SessionMessagesPage
+from app.schemas.session import (
+    PublicSessionExportResponse,
+    PublicSessionResponse,
+    SessionMessageResponse,
+    SessionMessagesPage,
+)
 from app.services.file_store import get_file_store
 from app.services.session_content import (
     SessionContentInvalid,
@@ -112,12 +116,12 @@ async def _resolve_session_for_view(
     raise HTTPException(status.HTTP_403_FORBIDDEN, "You don't have access to this session")
 
 
-@router.get("/api/public/sessions/{session_id}")
+@router.get("/api/public/sessions/{session_id}", response_model=PublicSessionResponse)
 async def get_shared_session_detail(
     session_id: UUID = Path(...),
     db: AsyncSession = Depends(get_session),
     visitor: AuthContext | None = Depends(optional_web_auth),
-) -> dict[str, Any]:
+) -> PublicSessionResponse:
     """Detail payload for the public HTML share page.
 
     Server-side rendered by `/s/[id]/page.tsx` so the page works
@@ -127,7 +131,9 @@ async def get_shared_session_detail(
     updating that helper can't silently leak.
     """
     session, agent_type, owner = await _resolve_session_for_view(db, session_id, visitor)
-    return public_session_base_fields(session, agent_type, owner)
+    return PublicSessionResponse.model_validate(
+        public_session_base_fields(session, agent_type, owner)
+    )
 
 
 @router.get("/api/public/sessions/{session_id}/messages")
@@ -211,12 +217,16 @@ async def export_shared_session_markdown(
     )
 
 
-@router.get("/api/public/sessions/{session_id}/export.json")
+@router.get(
+    "/api/public/sessions/{session_id}/export.json",
+    response_model=PublicSessionExportResponse,
+    response_model_exclude_none=True,
+)
 async def export_shared_session_json(
     session_id: UUID = Path(...),
     db: AsyncSession = Depends(get_session),
     visitor: AuthContext | None = Depends(optional_web_auth),
-) -> dict[str, Any]:
+) -> PublicSessionExportResponse:
     """Structured JSON export — public-stripped variant.
 
     `include_owner_metadata=False`: drops local_session_id,
@@ -237,10 +247,12 @@ async def export_shared_session_json(
             status.HTTP_500_INTERNAL_SERVER_ERROR, "Internal server error"
         ) from None
 
-    return session_to_json(
-        session,
-        messages,
-        agent_type=agent_type,
-        public=True,
-        include_owner_metadata=False,
+    return PublicSessionExportResponse.model_validate(
+        session_to_json(
+            session,
+            messages,
+            agent_type=agent_type,
+            public=True,
+            include_owner_metadata=False,
+        )
     )

--- a/backend/app/routes/sharing.py
+++ b/backend/app/routes/sharing.py
@@ -21,12 +21,16 @@ from app.models.project_membership import ProjectMembership
 from app.models.project_share_link import ProjectShareLink
 from app.models.user import User
 from app.schemas.sharing import (
+    InvitationCancelResponse,
     InvitationCreate,
     InvitationResponse,
     MemberResponse,
+    ProjectLeaveResponse,
+    ProjectMemberRemoveResponse,
     ShareLinkCreate,
     ShareLinkCreated,
     ShareLinkResponse,
+    ShareLinkRevokeResponse,
     UnshareResponse,
 )
 from app.services.agent_bindings import delete_project_bindings_for_users
@@ -172,13 +176,16 @@ async def list_share_links(
     ]
 
 
-@router.delete("/{project_id}/share-links/{link_id}")
+@router.delete(
+    "/{project_id}/share-links/{link_id}",
+    response_model=ShareLinkRevokeResponse,
+)
 async def revoke_share_link(
     project_id: UUID,
     link_id: UUID,
     auth: AuthContext = Depends(require_user_auth_unbound),
     db: AsyncSession = Depends(get_session),
-) -> dict[str, str]:
+) -> ShareLinkRevokeResponse:
     await _assert_shareable_project_owner(db, auth, project_id, for_update=True)
     result = await db.execute(
         select(ProjectShareLink).where(
@@ -193,7 +200,7 @@ async def revoke_share_link(
         link.revoked_at = datetime.now(UTC)
         await db.commit()
         logger.info("project_share_link_revoked link_id=%s by=%s", link_id, auth.user_id)
-    return {"status": "revoked"}
+    return ShareLinkRevokeResponse(status="revoked")
 
 
 def _owner_view(auth: AuthContext) -> tuple[str, str]:
@@ -335,13 +342,16 @@ async def list_invitations(
     ]
 
 
-@router.delete("/{project_id}/invitations/{invitation_id}")
+@router.delete(
+    "/{project_id}/invitations/{invitation_id}",
+    response_model=InvitationCancelResponse,
+)
 async def cancel_invitation(
     project_id: UUID,
     invitation_id: UUID,
     auth: AuthContext = Depends(require_user_auth_unbound),
     db: AsyncSession = Depends(get_session),
-) -> dict[str, str]:
+) -> InvitationCancelResponse:
     await _assert_shareable_project_owner(db, auth, project_id, for_update=True)
     row = (
         await db.execute(
@@ -355,7 +365,7 @@ async def cancel_invitation(
         raise HTTPException(status.HTTP_404_NOT_FOUND, "invitation not found")
     await db.delete(row)
     await db.commit()
-    return {"status": "cancelled"}
+    return InvitationCancelResponse(status="cancelled")
 
 
 @router.get("/{project_id}/members", response_model=list[MemberResponse])
@@ -388,13 +398,16 @@ async def list_members(
     ]
 
 
-@router.delete("/{project_id}/members/{member_user_id}")
+@router.delete(
+    "/{project_id}/members/{member_user_id}",
+    response_model=ProjectMemberRemoveResponse,
+)
 async def remove_member(
     project_id: UUID,
     member_user_id: UUID,
     auth: AuthContext = Depends(require_user_auth_unbound),
     db: AsyncSession = Depends(get_session),
-) -> dict[str, str | int]:
+) -> ProjectMemberRemoveResponse:
     project = await _assert_shareable_project_owner(db, auth, project_id)
     if member_user_id == project.user_id:
         raise HTTPException(
@@ -419,15 +432,18 @@ async def remove_member(
         user_ids=[member_user_id],
     )
     await db.commit()
-    return {"status": "removed", "agent_bindings_removed": bindings_removed}
+    return ProjectMemberRemoveResponse(
+        status="removed",
+        agent_bindings_removed=bindings_removed,
+    )
 
 
-@router.post("/{project_id}/leave")
+@router.post("/{project_id}/leave", response_model=ProjectLeaveResponse)
 async def leave_project(
     project_id: UUID,
     auth: AuthContext = Depends(require_user_auth_unbound),
     db: AsyncSession = Depends(get_session),
-) -> dict[str, str | int]:
+) -> ProjectLeaveResponse:
     project = (
         await db.execute(select(Project).where(Project.id == project_id))
     ).scalar_one_or_none()
@@ -456,7 +472,10 @@ async def leave_project(
         user_ids=[auth.user_id],
     )
     await db.commit()
-    return {"status": "left", "agent_bindings_removed": bindings_removed}
+    return ProjectLeaveResponse(
+        status="left",
+        agent_bindings_removed=bindings_removed,
+    )
 
 
 @router.post("/{project_id}/unshare", response_model=UnshareResponse)

--- a/backend/app/routes/vault.py
+++ b/backend/app/routes/vault.py
@@ -160,6 +160,10 @@ async def list_vaults(
 async def create_vault(
     body: VaultCreate,
     project_id: UUID | None = Query(default=None),
+    create_only: bool = Query(
+        default=False,
+        description="Return 409 if this slug already exists instead of attaching it.",
+    ),
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
 ) -> VaultCreatedResponse:
@@ -180,6 +184,8 @@ async def create_vault(
         )
     )
     vault = existing_result.scalar_one_or_none()
+    if vault is not None and create_only:
+        raise HTTPException(status.HTTP_409_CONFLICT, "Vault slug already exists")
     if vault is None:
         vault = Vault(user_id=auth.user_id, slug=body.slug, name=body.name)
         db.add(vault)

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -258,6 +258,30 @@ class SessionListItemResponse(BaseModel):
     related_refs: dict[str, list[str]] | None = None
 
 
+class PublicSessionResponse(BaseModel):
+    """Public-safe session detail payload for `/api/public/sessions/{id}`."""
+
+    id: str
+    summary: str | None
+    project_path: str | None
+    agent_type: str | None
+    model: str | None
+    models_used: list[str] | None
+    started_at: datetime
+    ended_at: datetime | None
+    last_activity_at: datetime | None
+    duration_seconds: int | None
+    message_count: int
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    tags: list[str] | None
+    status: str
+    related_refs: dict[str, list[str] | None] | None = None
+    owner_name: str | None
+    owner_avatar_url: str | None
+
+
 class SessionDetailResponse(SessionListItemResponse):
     has_content: bool
 
@@ -336,6 +360,13 @@ class SessionMessageResponse(BaseModel):
     content: str
     model: str | None = None
     timestamp: datetime | None = None
+
+
+class PublicSessionExportResponse(PublicSessionResponse):
+    """Public-safe structured session export payload."""
+
+    messages: list[SessionMessageResponse]
+    share_url: str
 
 
 class SessionMessagesPage(BaseModel):

--- a/backend/app/schemas/sharing.py
+++ b/backend/app/schemas/sharing.py
@@ -41,6 +41,12 @@ class ShareLinkResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class ShareLinkRevokeResponse(BaseModel):
+    """Returned after an owner revokes a project share link."""
+
+    status: Literal["revoked"]
+
+
 class InvitationCreate(BaseModel):
     """Body for POST /api/projects/{project_id}/invitations."""
 
@@ -75,6 +81,18 @@ class InvitationResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class InvitationCancelResponse(BaseModel):
+    """Returned after an owner cancels a pending project invitation."""
+
+    status: Literal["cancelled"]
+
+
+class InvitationDeclineResponse(BaseModel):
+    """Returned after a recipient declines a project invitation."""
+
+    status: Literal["declined"]
+
+
 class MemberResponse(BaseModel):
     """Returned by GET /api/projects/{project_id}/members."""
 
@@ -88,6 +106,20 @@ class MemberResponse(BaseModel):
     resolved_owner_handle: str
 
     model_config = {"from_attributes": True}
+
+
+class ProjectMemberRemoveResponse(BaseModel):
+    """Returned after an owner removes a project member."""
+
+    status: Literal["removed"]
+    agent_bindings_removed: int
+
+
+class ProjectLeaveResponse(BaseModel):
+    """Returned after a member leaves a shared project."""
+
+    status: Literal["left"]
+    agent_bindings_removed: int
 
 
 class UnshareResponse(BaseModel):
@@ -173,6 +205,14 @@ class BindingReorderItem(BaseModel):
 
 class BindingReorderBody(BaseModel):
     items: list[BindingReorderItem]
+
+
+class BindingReorderResponse(BaseModel):
+    status: Literal["reordered"]
+
+
+class BindingDeleteResponse(BaseModel):
+    status: Literal["deleted"]
 
 
 class AgentProjectBindingResponse(BaseModel):

--- a/backend/tests/test_vault.py
+++ b/backend/tests/test_vault.py
@@ -834,6 +834,49 @@ async def test_vault_attaches_one_vault_to_multiple_projects(client, db_session,
 
 
 @pytest.mark.asyncio
+async def test_vault_create_only_rejects_existing_slug(client, db_session, seed_user):
+    """Dashboard "New vault" flows must not hit the create-or-attach path.
+
+    Plain POST stays idempotent attach for CLI/back-compat, while
+    `create_only=true` gives UI callers a real create semantics.
+    """
+    from app.models.project import PROJECT_KIND_ENVIRONMENT, Project
+
+    project_a = Project(
+        user_id=seed_user.id, name="A", slug="create-only-a", kind=PROJECT_KIND_ENVIRONMENT
+    )
+    project_b = Project(
+        user_id=seed_user.id, name="B", slug="create-only-b", kind=PROJECT_KIND_ENVIRONMENT
+    )
+    db_session.add_all([project_a, project_b])
+    await db_session.commit()
+
+    first = await client.post(
+        f"/api/vault?project_id={project_a.id}",
+        json={"slug": "github", "name": "GitHub"},
+    )
+    assert first.status_code == 200, first.text
+
+    duplicate = await client.post(
+        f"/api/vault?project_id={project_b.id}&create_only=true",
+        json={"slug": "github", "name": "GitHub"},
+    )
+    assert duplicate.status_code == 409, duplicate.text
+
+    listing_b = (await client.get(f"/api/vault?project_id={project_b.id}")).json()
+    assert [v["slug"] for v in listing_b["items"]] == []
+
+    attach = await client.post(
+        f"/api/vault?project_id={project_b.id}",
+        json={"slug": "github", "name": "GitHub"},
+    )
+    assert attach.status_code == 200, attach.text
+    assert attach.json()["id"] == first.json()["id"]
+    b_resp = await client.get(f"/api/vault/github/items?project_id={project_b.id}")
+    assert b_resp.status_code == 200, b_resp.text
+
+
+@pytest.mark.asyncio
 async def test_vault_item_delete_requires_global_confirmation_for_shared_vault(
     client, seed_project, workspace_project
 ):

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -2293,6 +2293,14 @@ export interface components {
             /** Priority */
             priority?: number | null;
         };
+        /** BindingDeleteResponse */
+        BindingDeleteResponse: {
+            /**
+             * Status
+             * @constant
+             */
+            status: "deleted";
+        };
         /** BindingReorderBody */
         BindingReorderBody: {
             /** Items */
@@ -2304,6 +2312,14 @@ export interface components {
             binding_id: string;
             /** Priority */
             priority: number;
+        };
+        /** BindingReorderResponse */
+        BindingReorderResponse: {
+            /**
+             * Status
+             * @constant
+             */
+            status: "reordered";
         };
         /** Body_upload_session_content_api_sessions__local_session_id__upload_post */
         Body_upload_session_content_api_sessions__local_session_id__upload_post: {
@@ -2702,6 +2718,14 @@ export interface components {
             /** Detail */
             detail?: components["schemas"]["ValidationError"][];
         };
+        /** HealthResponse */
+        HealthResponse: {
+            /**
+             * Status
+             * @constant
+             */
+            status: "ok";
+        };
         /**
          * InvitationAcceptResponse
          * @description Returned after a directed project invitation is accepted.
@@ -2726,12 +2750,34 @@ export interface components {
             bound_agent_ids: string[];
         };
         /**
+         * InvitationCancelResponse
+         * @description Returned after an owner cancels a pending project invitation.
+         */
+        InvitationCancelResponse: {
+            /**
+             * Status
+             * @constant
+             */
+            status: "cancelled";
+        };
+        /**
          * InvitationCreate
          * @description Body for POST /api/projects/{project_id}/invitations.
          */
         InvitationCreate: {
             /** Email */
             email: string;
+        };
+        /**
+         * InvitationDeclineResponse
+         * @description Returned after a recipient declines a project invitation.
+         */
+        InvitationDeclineResponse: {
+            /**
+             * Status
+             * @constant
+             */
+            status: "declined";
         };
         /**
          * InvitationResponse
@@ -2902,6 +2948,32 @@ export interface components {
             /** Slug */
             slug?: string | null;
         };
+        /**
+         * ProjectLeaveResponse
+         * @description Returned after a member leaves a shared project.
+         */
+        ProjectLeaveResponse: {
+            /**
+             * Status
+             * @constant
+             */
+            status: "left";
+            /** Agent Bindings Removed */
+            agent_bindings_removed: number;
+        };
+        /**
+         * ProjectMemberRemoveResponse
+         * @description Returned after an owner removes a project member.
+         */
+        ProjectMemberRemoveResponse: {
+            /**
+             * Status
+             * @constant
+             */
+            status: "removed";
+            /** Agent Bindings Removed */
+            agent_bindings_removed: number;
+        };
         /** ProjectResponse */
         ProjectResponse: {
             /** Id */
@@ -2930,6 +3002,108 @@ export interface components {
             owner_display?: string | null;
             /** Owner Handle */
             owner_handle?: string | null;
+        };
+        /**
+         * PublicSessionExportResponse
+         * @description Public-safe structured session export payload.
+         */
+        PublicSessionExportResponse: {
+            /** Id */
+            id: string;
+            /** Summary */
+            summary: string | null;
+            /** Project Path */
+            project_path: string | null;
+            /** Agent Type */
+            agent_type: string | null;
+            /** Model */
+            model: string | null;
+            /** Models Used */
+            models_used: string[] | null;
+            /**
+             * Started At
+             * Format: date-time
+             */
+            started_at: string;
+            /** Ended At */
+            ended_at: string | null;
+            /** Last Activity At */
+            last_activity_at: string | null;
+            /** Duration Seconds */
+            duration_seconds: number | null;
+            /** Message Count */
+            message_count: number;
+            /** Input Tokens */
+            input_tokens: number;
+            /** Output Tokens */
+            output_tokens: number;
+            /** Cache Read Tokens */
+            cache_read_tokens: number;
+            /** Tags */
+            tags: string[] | null;
+            /** Status */
+            status: string;
+            /** Related Refs */
+            related_refs?: {
+                [key: string]: string[] | null;
+            } | null;
+            /** Owner Name */
+            owner_name: string | null;
+            /** Owner Avatar Url */
+            owner_avatar_url: string | null;
+            /** Messages */
+            messages: components["schemas"]["SessionMessageResponse"][];
+            /** Share Url */
+            share_url: string;
+        };
+        /**
+         * PublicSessionResponse
+         * @description Public-safe session detail payload for `/api/public/sessions/{id}`.
+         */
+        PublicSessionResponse: {
+            /** Id */
+            id: string;
+            /** Summary */
+            summary: string | null;
+            /** Project Path */
+            project_path: string | null;
+            /** Agent Type */
+            agent_type: string | null;
+            /** Model */
+            model: string | null;
+            /** Models Used */
+            models_used: string[] | null;
+            /**
+             * Started At
+             * Format: date-time
+             */
+            started_at: string;
+            /** Ended At */
+            ended_at: string | null;
+            /** Last Activity At */
+            last_activity_at: string | null;
+            /** Duration Seconds */
+            duration_seconds: number | null;
+            /** Message Count */
+            message_count: number;
+            /** Input Tokens */
+            input_tokens: number;
+            /** Output Tokens */
+            output_tokens: number;
+            /** Cache Read Tokens */
+            cache_read_tokens: number;
+            /** Tags */
+            tags: string[] | null;
+            /** Status */
+            status: string;
+            /** Related Refs */
+            related_refs?: {
+                [key: string]: string[] | null;
+            } | null;
+            /** Owner Name */
+            owner_name: string | null;
+            /** Owner Avatar Url */
+            owner_avatar_url: string | null;
         };
         /** SearchHit */
         SearchHit: {
@@ -3368,6 +3542,17 @@ export interface components {
             redeem_count: number;
             /** Last Redeemed At */
             last_redeemed_at: string | null;
+        };
+        /**
+         * ShareLinkRevokeResponse
+         * @description Returned after an owner revokes a project share link.
+         */
+        ShareLinkRevokeResponse: {
+            /**
+             * Status
+             * @constant
+             */
+            status: "revoked";
         };
         /**
          * ShareRedeemResponse
@@ -5033,9 +5218,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["PublicSessionResponse"];
                 };
             };
             /** @description Validation Error */
@@ -5131,9 +5314,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["PublicSessionExportResponse"];
                 };
             };
             /** @description Validation Error */
@@ -6009,6 +6190,8 @@ export interface operations {
         parameters: {
             query?: {
                 project_id?: string | null;
+                /** @description Return 409 if this slug already exists instead of attaching it. */
+                create_only?: boolean;
             };
             header?: never;
             path?: never;
@@ -6847,9 +7030,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: string;
-                    };
+                    "application/json": components["schemas"]["ShareLinkRevokeResponse"];
                 };
             };
             /** @description Validation Error */
@@ -6947,9 +7128,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: string;
-                    };
+                    "application/json": components["schemas"]["InvitationCancelResponse"];
                 };
             };
             /** @description Validation Error */
@@ -7012,9 +7191,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: string | number;
-                    };
+                    "application/json": components["schemas"]["ProjectMemberRemoveResponse"];
                 };
             };
             /** @description Validation Error */
@@ -7045,9 +7222,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: string | number;
-                    };
+                    "application/json": components["schemas"]["ProjectLeaveResponse"];
                 };
             };
             /** @description Validation Error */
@@ -7164,9 +7339,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: string;
-                    };
+                    "application/json": components["schemas"]["InvitationDeclineResponse"];
                 };
             };
             /** @description Validation Error */
@@ -7267,9 +7440,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: string;
-                    };
+                    "application/json": components["schemas"]["BindingReorderResponse"];
                 };
             };
             /** @description Validation Error */
@@ -7301,9 +7472,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: string;
-                    };
+                    "application/json": components["schemas"]["BindingDeleteResponse"];
                 };
             };
             /** @description Validation Error */
@@ -7332,9 +7501,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: string;
-                    };
+                    "application/json": components["schemas"]["HealthResponse"];
                 };
             };
         };


### PR DESCRIPTION
## Summary
- Delete vault now calls the full vault delete endpoint instead of detaching every Project attachment.
- Skill move now unwraps source-delete failures and reports copy-vs-remove partial failures accurately.
- Add Keys now reuses the robust vault import parser, previews conflicts, skips existing keys unless overwrite is selected, and blocks accidental new-vault slug collisions.
- Backend `POST /api/vault` now supports `create_only=true`, so dashboard "New vault" flows get real create semantics while CLI/backcompat and Add to Project keep create-or-attach behavior.
- New/Copy/Split vault flows use strict create semantics for new vaults, regenerated shared API types, and report actual copied key counts from the backend.
- Split Vault and duplicate-skill sync now report all-failed operations as failures instead of success toasts.
- Removed dashboard/public-page untyped API calls: `useAuthedFetch` is gone, app code now uses generated `openapi-fetch` clients instead of raw `/api` URL construction.
- Added typed backend response models for public session detail/export, sharing status responses, agent binding status responses, and `/health`; regenerated shared OpenAPI types.
- Fixed a front/back semantic mismatch in Project People: the UI now reads generated `MemberResponse.user_id/user_email/user_display` instead of stale `member_user_id/email` fields.
- Skill copy/send binary flows now use typed download/upload paths with a runtime Blob guard and multipart `bodySerializer`.

## Tests
- `bun run check`
- `bun run typecheck --force`
- `bun run test`
- `bun run build`
- `uv run ruff check app/main.py app/routes/agent_project_bindings.py app/routes/sharing.py app/routes/me.py app/routes/public_sessions.py app/schemas/sharing.py app/schemas/session.py`
- `uv run ruff check app/routes/vault.py tests/test_vault.py`
- `uv run python scripts/check_generated_api.py`
- `git diff --check`

## Not Run / Blocked
- `uv run pytest -q tests/test_public_sessions.py tests/test_sharing_schemas.py tests/test_sharing_list_revoke.py tests/test_sharing_create_link.py tests/test_sharing_invitations.py tests/test_agent_project_bindings_routes.py tests/test_projects_routes.py tests/test_project_visibility_shared.py`: local PostgreSQL test DB connection refused at `127.0.0.1:45329` before DB-backed assertions ran; 7 non-DB/schema tests passed before the DB fixture failures.
- `uv run pytest -q tests/test_vault.py`: same local PostgreSQL test DB connection refusal at `127.0.0.1:45329`.
