### PR TITLE
Add upload validation diagnostics

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,8 +4,11 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Literal
 
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -46,6 +49,20 @@ logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("httpcore").setLevel(logging.WARNING)
 log = logging.getLogger(__name__)
 init_sentry()
+
+
+def _validation_errors_for_log(exc: RequestValidationError) -> list[dict[str, object]]:
+    errors: list[dict[str, object]] = []
+    for err in exc.errors():
+        item: dict[str, object] = {
+            "type": err.get("type"),
+            "loc": err.get("loc"),
+            "msg": err.get("msg"),
+        }
+        if "ctx" in err:
+            item["ctx"] = err["ctx"]
+        errors.append(item)
+    return errors
 
 
 class HealthResponse(BaseModel):
@@ -166,6 +183,32 @@ app.add_middleware(
 )
 app.add_middleware(RequestIDMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
+
+
+@app.exception_handler(RequestValidationError)
+async def request_validation_exception_handler(
+    request: Request,
+    exc: RequestValidationError,
+) -> JSONResponse:
+    path = request.url.path
+    if path.endswith("/skills/upload") or path == "/api/sessions/batch":
+        log.warning(
+            (
+                "request_validation_failed method=%s path=%s user_agent=%r "
+                "content_type=%r content_length=%r errors=%s"
+            ),
+            request.method,
+            path,
+            request.headers.get("user-agent", ""),
+            request.headers.get("content-type", ""),
+            request.headers.get("content-length", ""),
+            _validation_errors_for_log(exc),
+        )
+    return JSONResponse(
+        status_code=422,
+        content={"detail": jsonable_encoder(exc.errors())},
+    )
+
 
 app.include_router(auth_router)
 app.include_router(admin_router)

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -8,6 +8,7 @@ archive is later extracted on the server or CLI.
 from __future__ import annotations
 
 import io
+import logging
 import tarfile
 
 import httpx
@@ -513,6 +514,32 @@ async def test_nested_skill_round_trips_through_project_routes(
     assert r_delete.status_code == 200, r_delete.text
     r_get_after = await client.get(f"/api/projects/{project_id}/skills/{nested_key}")
     assert r_get_after.status_code == 404, r_get_after.text
+
+
+@pytest.mark.asyncio
+async def test_malformed_skill_upload_logs_validation_reason(
+    client: httpx.AsyncClient,
+    project_id: str,
+    caplog: pytest.LogCaptureFixture,
+):
+    caplog.set_level(logging.WARNING, logger="app.main")
+
+    response = await client.post(
+        f"/api/projects/{project_id}/skills/upload",
+        data={"skill_key": "missing-file"},
+        headers={"User-Agent": "clawdi-cli/test"},
+    )
+
+    assert response.status_code == 422
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "request_validation_failed" in message
+        and "/skills/upload" in message
+        and "clawdi-cli/test" in message
+        and "content_type=" in message
+        and "file" in message
+        for message in messages
+    )
 
 
 @pytest.mark.asyncio

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { type components, extractApiDetail, type paths } from "@clawdi/shared/api";
 import createClient, { type Client } from "openapi-fetch";
 import { getAuth, getConfig } from "./config";
+import { getCliVersion } from "./version";
 
 type SkillUploadResponse = components["schemas"]["SkillUploadResponse"];
 type SessionUploadResponse = components["schemas"]["SessionUploadResponse"];
@@ -9,6 +10,7 @@ type SessionUploadResponse = components["schemas"]["SessionUploadResponse"];
 const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_RETRIES = 3;
 const RETRY_DELAYS_MS = [100, 400, 1600] as const;
+const USER_AGENT = `clawdi-cli/${getCliVersion()}`;
 
 /** Error thrown by ApiClient. Carries HTTP status and a human-facing hint. */
 export class ApiError extends Error {
@@ -200,6 +202,7 @@ export class ApiClient {
 				if (this.apiKey) {
 					request.headers.set("Authorization", `Bearer ${this.apiKey}`);
 				}
+				request.headers.set("User-Agent", USER_AGENT);
 				// Generate a per-request correlation ID. Backend's
 				// RequestIDMiddleware accepts the header and echoes
 				// it on the response + every log line, so an oncall
@@ -306,6 +309,7 @@ export class ApiClient {
 		try {
 			const headers: Record<string, string> = {
 				Authorization: `Bearer ${this.apiKey}`,
+				"User-Agent": USER_AGENT,
 				...(extraHeaders ?? {}),
 			};
 			const res = await fetch(`${this.baseUrl}${path}`, {


### PR DESCRIPTION
## Summary
- log selected FastAPI request validation failures for skill upload and session batch endpoints
- include method, path, user-agent, content-type, content-length, and validation error fields without logging auth headers or request bodies
- send a versioned `User-Agent: clawdi-cli/<version>` from the CLI API client, including multipart uploads, so cloud logs can separate new CLI traffic from old or non-CLI Node callers

## Verification
- `bun run check`
- `cd backend && uv run ruff check app scripts tests/test_skills.py && uv run ruff format --check app scripts tests/test_skills.py`
- `bun run --cwd packages/cli typecheck`
- `cd backend && DATABASE_URL=postgresql+asyncpg://clawdi:clawdi_dev@127.0.0.1:39043/clawdi uv run pytest tests/test_skills.py -q` -> 21 passed
- `bun test packages/cli/tests/commands/push.test.ts packages/cli/src/serve/sync-engine.test.ts packages/cli/src/serve/queue.test.ts`

## Operational Note
This intentionally does not add `/api/scopes/...` backward compatibility. The current cloud upload 422s need better request-shape diagnostics first; after deploy, inspect `request_validation_failed` log entries for the exact missing/invalid fields and caller user-agent.