### PR TITLE
Skip invalid local skill keys before upload

### DIFF
--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -22,6 +22,7 @@ import {
 	type SessionsLock,
 	writeSessionsLock,
 } from "../lib/sessions-lock";
+import { isValidSkillKey } from "../lib/skill-key";
 import {
 	computeSkillFolderHash,
 	readSkillsLock,
@@ -356,11 +357,21 @@ async function scanOneAgent(
 		// Hash each skill's file tree and diff against the skills-lock here,
 		// in the scan — the same per-entity cache check sessions get below —
 		// so the summary's skill count reflects what will actually upload.
+		let invalidSkillCount = 0;
 		for (const skill of await adapter.collectSkills()) {
+			if (!isValidSkillKey(skill.skillKey)) {
+				invalidSkillCount++;
+				continue;
+			}
 			skill.contentHash = await computeSkillFolderHash(skill.directoryPath);
 			const cached = skillsLock.skills[skillCacheKey(agentType, skill.skillKey)]?.hash;
 			if (cached === skill.contentHash) skillsCacheSkipped++;
 			else skills.push(skill);
+		}
+		if (invalidSkillCount > 0) {
+			notes.push(
+				`Skipped ${invalidSkillCount} skill ${invalidSkillCount === 1 ? "directory" : "directories"} with invalid names. Rename local skill directories to letters, numbers, dot, underscore, hyphen, or up to 4 slash-separated components.`,
+			);
 		}
 	}
 

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -56,6 +56,7 @@ import { ApiClient, ApiError, unwrap } from "../lib/api-client";
 import { listRegisteredAgentTypes } from "../lib/select-adapter";
 import { computeLastActivityIso } from "../lib/session-activity";
 import { cacheKey, readSessionsLock, writeSessionsLock } from "../lib/sessions-lock";
+import { isValidSkillKey } from "../lib/skill-key";
 import {
 	computeSkillFolderHash,
 	readSkillsLock,
@@ -844,6 +845,11 @@ async function enqueueIfChanged(
 	skillKey: string,
 	getProjectId: () => string,
 ): Promise<void> {
+	if (!isValidSkillKey(skillKey)) {
+		lastPushedHash.delete(skillKey);
+		log.warn("engine.invalid_skill_key_skipped", { skill_key: skillKey });
+		return;
+	}
 	const dir = join(opts.adapter.getSkillsRootDir(), skillKey);
 	let hash: string;
 	try {

--- a/packages/cli/src/serve/watcher.ts
+++ b/packages/cli/src/serve/watcher.ts
@@ -152,6 +152,10 @@ async function watchEvents(opts: Opts): Promise<void> {
 	});
 
 	const on = (skillKey: string) => {
+		if (!isValidSkillKey(skillKey)) {
+			log.warn("watcher.invalid_skill_key_skipped", { skill_key: skillKey });
+			return;
+		}
 		changeEmitter.emit(skillKey);
 	};
 
@@ -351,6 +355,10 @@ async function snapshot(
 	const out = new Map<string, string>();
 	const skills = listSkillKeys ? await listSkillKeys() : await listSkillDirs(rootDir);
 	for (const key of skills) {
+		if (!isValidSkillKey(key)) {
+			log.warn("watcher.invalid_skill_key_skipped", { skill_key: key });
+			continue;
+		}
 		const sig = await dirSignature(join(rootDir, key));
 		out.set(key, sig);
 	}

--- a/packages/cli/tests/commands/push.test.ts
+++ b/packages/cli/tests/commands/push.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { push } from "../../src/commands/push";
 import { cleanupTmp, copyFixtureToTmp } from "../adapters/helpers";
@@ -146,6 +146,34 @@ describe("push — Hermes fixture", () => {
 		const uploads = captured.filter((c) => c.path === `/api/projects/${projectId}/skills/upload`);
 		expect(uploads.length).toBeGreaterThan(0);
 		for (const upload of uploads) expect(upload.isMultipart).toBe(true);
+	});
+
+	it("skips local skills with invalid skill_keys before upload", async () => {
+		setup("hermes");
+		const invalidDir = join(tmpHome, ".hermes", "skills", "core", "bad skill");
+		mkdirSync(invalidDir, { recursive: true });
+		writeFileSync(
+			join(invalidDir, "SKILL.md"),
+			"---\nname: Bad Skill\ndescription: invalid local directory name\n---\n# Bad\n",
+		);
+
+		const projectId = "00000000-0000-0000-0000-000000000099";
+		const { captured, restore } = mockFetch([
+			okEnvironmentProbe(),
+			{
+				method: "POST",
+				path: `/api/projects/${projectId}/skills/upload`,
+				response: () => jsonResponse({ skill_key: "core/demo", version: 1, file_count: 1 }),
+			},
+		]);
+		try {
+			await push({ agent: "hermes", modules: "skills", all: true });
+		} finally {
+			restore();
+		}
+
+		const uploads = captured.filter((c) => c.path === `/api/projects/${projectId}/skills/upload`);
+		expect(uploads).toHaveLength(1);
 	});
 
 	it("a skill already in the skills-lock is skipped on the next push", async () => {


### PR DESCRIPTION
## Summary
- skip invalid local skill keys during `clawdi push` scan before multipart upload
- add daemon enqueue and watcher validation so invalid local skill paths do not enter the retry queue
- add a regression test for a local Hermes skill directory whose key fails the backend `skill_key` pattern

## Root Cause
Cloud logs after PR #146 show the upload 422s are FastAPI validation failures on `body.skill_key`: `string_pattern_mismatch` against the backend `SKILL_KEY_PATTERN`. The requests are valid multipart uploads, but the client is sending local directory-derived skill keys that the backend correctly rejects.

## Verification
- `bun run check`
- `bun run --cwd packages/cli typecheck`
- `bun test packages/cli/src/serve/watcher.test.ts packages/cli/src/serve/sync-engine.test.ts packages/cli/tests/commands/push.test.ts` -> 58 passed