### PR TITLE
Unify CLI skill key generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.12.8
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.8
+
+Package: `clawdi@0.12.8`
+
+### Fixed
+
+- Fixed skill uploads from local directories with names that need cleanup, such
+  as long names or names containing punctuation. `clawdi skill add`,
+  `clawdi skill init`, and daemon sync now use the same skill key rules as
+  Clawdi Cloud, so generated skill keys are accepted without manual renaming.
+
 ## Clawdi CLI v0.12.7
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.7

--- a/backend/app/core/skill_key.py
+++ b/backend/app/core/skill_key.py
@@ -1,0 +1,51 @@
+import re
+
+# `skill_key` is concatenated into a file-store path, so any '..'
+# segment or empty / hidden component would let a caller escape the
+# user's prefix. The pattern allows up to 4 nested path components
+# joined by '/' (Hermes layouts like `category/foo/SKILL.md` need
+# this). Each component:
+#   - starts with [A-Za-z0-9] (rejects '.' / '..' as a component,
+#     and leading-dot hidden segments)
+#   - then [A-Za-z0-9._-]{0,199}
+#
+# Total length is capped separately at MAX_SKILL_KEY_LEN, matching
+# the Skill.skill_key String(200) column width.
+SKILL_KEY_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._\-]{0,199}(/[A-Za-z0-9][A-Za-z0-9._\-]{0,199}){0,3}$"
+MAX_SKILL_KEY_LEN = 200
+RESERVED_SKILL_KEY_SUFFIXES = frozenset({"download", "content", "install"})
+
+_SKILL_KEY_RE = re.compile(SKILL_KEY_PATTERN)
+
+
+class SkillKeyValidationError(ValueError):
+    pass
+
+
+def has_reserved_skill_key_suffix(skill_key: str) -> bool:
+    """True iff the last component conflicts with a route-owned suffix.
+
+    Flat keys like `download` are allowed; only nested keys like
+    `team/download` collide with `/{skill_key:path}/download`.
+    """
+    parts = skill_key.split("/")
+    return len(parts) > 1 and parts[-1] in RESERVED_SKILL_KEY_SUFFIXES
+
+
+def is_valid_skill_key(skill_key: str) -> bool:
+    return (
+        len(skill_key) <= MAX_SKILL_KEY_LEN
+        and _SKILL_KEY_RE.match(skill_key) is not None
+        and not has_reserved_skill_key_suffix(skill_key)
+    )
+
+
+def validate_derived_skill_key(skill_key: str) -> str:
+    """Validate a server-derived skill_key before storage.
+
+    Marketplace installs derive keys from SKILL.md frontmatter, so they
+    must pass the same storage and route-safety contract as client input.
+    """
+    if not is_valid_skill_key(skill_key):
+        raise SkillKeyValidationError(f"derived skill_key {skill_key!r} is not safe for storage")
+    return skill_key

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -1,7 +1,6 @@
 import hashlib
 import io
 import logging
-import re
 import tarfile
 from uuid import UUID
 
@@ -30,6 +29,14 @@ from app.core.project import (
     validate_project_read_for_caller,
 )
 from app.core.query_utils import like_needle
+from app.core.skill_key import (
+    MAX_SKILL_KEY_LEN,
+    RESERVED_SKILL_KEY_SUFFIXES,
+    SKILL_KEY_PATTERN,
+    SkillKeyValidationError,
+    has_reserved_skill_key_suffix,
+    validate_derived_skill_key,
+)
 from app.models.skill import Skill
 from app.schemas.common import Paginated
 from app.schemas.skill import (
@@ -64,78 +71,6 @@ project_router = APIRouter(prefix="/api/projects/{project_id}/skills", tags=["sk
 log = logging.getLogger(__name__)
 
 file_store = get_file_store()
-
-
-# `skill_key` is concatenated into a file-store path, so any '..'
-# segment or empty / hidden component would let a caller escape the
-# user's prefix. The pattern allows up to 4 nested path components
-# joined by '/' (Hermes layouts like `category/foo/SKILL.md` need
-# this — pre-fix the flat-key validator rejected nested keys with
-# 422 and silently dropped them from sync). Each component:
-#   - starts with [A-Za-z0-9] (rejects '.' / '..' as a component,
-#     and leading-dot hidden segments)
-#   - then [A-Za-z0-9._-]{0,199} (so per-component max is 200
-#     chars, preserving the pre-Hermes flat-key length cap so an
-#     existing skill_key longer than 100 chars doesn't suddenly
-#     422)
-# The leading-alphanum requirement on every component is the
-# path-traversal guard — '..' as a component, or `.foo` hidden
-# segments, are both rejected at the first character.
-#
-# TOTAL LENGTH is capped separately at `MAX_SKILL_KEY_LEN` (200,
-# matching the `Skill.skill_key` column's `String(200)` width).
-# Without that cap, a 4-component key could reach ~803 chars and
-# pass FastAPI's `pattern` check, then fail at INSERT with a
-# truncation error — accepted at validation, dead at persistence.
-# Every Path/Form/Query param that captures a skill_key combines
-# both `pattern=SKILL_KEY_PATTERN` AND `max_length=MAX_SKILL_KEY_LEN`
-# so the 422 fires at request time, not at the DB.
-SKILL_KEY_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._\-]{0,199}(/[A-Za-z0-9][A-Za-z0-9._\-]{0,199}){0,3}$"
-_SKILL_KEY_RE = re.compile(SKILL_KEY_PATTERN)
-MAX_SKILL_KEY_LEN = 200
-
-# Terminal path components that conflict with route suffixes on
-# `/api/skills/{skill_key:path}/*` and
-# `/api/projects/{project_id}/skills/{skill_key:path}/*`. Starlette
-# matches routes in declaration order, so `/skills/team/download`
-# (a key literally named `team/download`) would resolve to the
-# `/{skill_key:path}/download` GET with `skill_key="team"` — the
-# bare-detail route never gets a chance to see the real key.
-# Reserving these suffixes keeps the routing tree unambiguous.
-# Reupping is a no-op for legitimate users; a skill named
-# `notes/download` is unusual and the 400 explains how to rename.
-_RESERVED_SKILL_KEY_SUFFIXES = frozenset({"download", "content", "install"})
-
-
-def _has_reserved_suffix(skill_key: str) -> bool:
-    """True iff the skill_key's last `/`-separated component is a
-    URL suffix the routing tree owns. Always false for flat keys
-    that happen to BE a reserved word (e.g. `download`) — the
-    one-segment route shape can't collide with a deeper suffix.
-    """
-    parts = skill_key.split("/")
-    return len(parts) > 1 and parts[-1] in _RESERVED_SKILL_KEY_SUFFIXES
-
-
-def _validate_derived_skill_key(skill_key: str) -> str:
-    """Validate a skill_key that was derived server-side (e.g. from
-    a marketplace SKILL.md frontmatter). Path-component constraints
-    apply to derived keys too — a malicious SKILL.md `name: "../x"`
-    would otherwise reach `_file_key` and traverse the file store.
-    Total-length cap mirrors `Skill.skill_key` column width
-    (`String(200)`); without it a derived key could pass the regex
-    check but blow up at INSERT.
-    """
-    if (
-        len(skill_key) > MAX_SKILL_KEY_LEN
-        or not _SKILL_KEY_RE.match(skill_key)
-        or _has_reserved_suffix(skill_key)
-    ):
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST,
-            f"derived skill_key {skill_key!r} is not safe for storage",
-        )
-    return skill_key
 
 
 def _file_key(user_id, project_id, skill_key: str) -> str:
@@ -824,11 +759,11 @@ async def _do_upload_skill(
     # with `skill_key="team"` and the bare detail handler
     # never saw the real key. Path/Form validators don't
     # express this constraint cleanly so we re-check here.
-    if _has_reserved_suffix(skill_key):
+    if has_reserved_skill_key_suffix(skill_key):
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,
             f"skill_key cannot end with reserved suffix "
-            f"({', '.join(sorted(_RESERVED_SKILL_KEY_SUFFIXES))})",
+            f"({', '.join(sorted(RESERVED_SKILL_KEY_SUFFIXES))})",
         )
     try:
         file_count = validate_tar(data)
@@ -1289,7 +1224,10 @@ async def _do_install_skill(
     # which the user controls. A malicious `name: "../etc/passwd"`
     # would otherwise traverse the file store. Validate the derived
     # key against the same pattern the upload route enforces.
-    skill_key = _validate_derived_skill_key(fetched.name.lower().replace(" ", "-"))
+    try:
+        skill_key = validate_derived_skill_key(fetched.name.lower().replace(" ", "-"))
+    except SkillKeyValidationError as e:
+        raise HTTPException(status.HTTP_400_BAD_REQUEST, str(e)) from None
     fk = _file_key(auth.user_id, project_id, skill_key)
 
     # Same advisory lock pattern as upload_skill. Lock identity

--- a/backend/tests/test_skill_key.py
+++ b/backend/tests/test_skill_key.py
@@ -1,0 +1,30 @@
+import pytest
+
+from app.core.skill_key import (
+    MAX_SKILL_KEY_LEN,
+    SkillKeyValidationError,
+    has_reserved_skill_key_suffix,
+    is_valid_skill_key,
+    validate_derived_skill_key,
+)
+
+
+def test_skill_key_validation_accepts_flat_and_nested_keys():
+    assert is_valid_skill_key("demo")
+    assert is_valid_skill_key("category/demo")
+    assert is_valid_skill_key("team.tools/demo_v1")
+    assert is_valid_skill_key("a" * MAX_SKILL_KEY_LEN)
+
+
+def test_skill_key_validation_rejects_storage_unsafe_keys():
+    for key in ["", ".system", "../etc", "team/.hidden", "team//demo", "a" * 201]:
+        assert not is_valid_skill_key(key)
+        with pytest.raises(SkillKeyValidationError):
+            validate_derived_skill_key(key)
+
+
+def test_reserved_suffixes_only_apply_to_nested_keys():
+    assert is_valid_skill_key("download")
+    assert not is_valid_skill_key("team/download")
+    assert has_reserved_skill_key_suffix("team/content")
+    assert not has_reserved_skill_key_suffix("content")

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.7",
+	"version": "0.12.8",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -20,12 +20,13 @@ import type { SkillSummary } from "../lib/api-schemas";
 import { getClawdiDir, isLoggedIn } from "../lib/config";
 import { errMessage } from "../lib/errors";
 import { parseFrontmatter } from "../lib/frontmatter";
-import { sanitizeMetadata, sanitizeName } from "../lib/sanitize";
+import { sanitizeMetadata } from "../lib/sanitize";
 import {
 	fetchDefaultProjectId,
 	fetchProjectIdForEnv,
 	getEnvIdByAgent,
 } from "../lib/select-adapter";
+import { sanitizeSkillKey } from "../lib/skill-key";
 import { computeSkillFolderHash } from "../lib/skills-lock";
 import { type ParsedSource, parseSource } from "../lib/source-parser";
 import { tarSingleFile, tarSkillDir } from "../lib/tar";
@@ -147,7 +148,7 @@ export async function skillAdd(
 			process.exit(1);
 		}
 		skillMdSource = readFileSync(skillMdPath, "utf-8");
-		skillKey = sanitizeName(basename(resolved));
+		skillKey = sanitizeSkillKey(basename(resolved));
 		fileCount = countFiles(resolved);
 		// Tar the skill under the SANITIZED key so the archive's
 		// directory entries match what the upload route expects.
@@ -193,7 +194,7 @@ export async function skillAdd(
 		}
 	} else {
 		skillMdSource = readFileSync(resolved, "utf-8");
-		skillKey = sanitizeName(basename(resolved, ".md"));
+		skillKey = sanitizeSkillKey(basename(resolved, ".md"));
 		fileCount = 1;
 		tarBytes = await tarSingleFile(skillKey, skillMdSource);
 	}
@@ -584,7 +585,7 @@ export async function skillRm(key: string, opts: { agent?: string; project?: str
 export function skillInit(nameArg?: string) {
 	const cwd = process.cwd();
 	const hasName = Boolean(nameArg);
-	const name = sanitizeName(nameArg ?? basename(cwd));
+	const name = sanitizeSkillKey(nameArg ?? basename(cwd));
 	const targetDir = hasName ? join(cwd, name) : cwd;
 	const skillMd = join(targetDir, "SKILL.md");
 	const displayPath = hasName ? `${name}/SKILL.md` : "SKILL.md";

--- a/packages/cli/src/lib/sanitize.ts
+++ b/packages/cli/src/lib/sanitize.ts
@@ -85,17 +85,3 @@ export function isSubpathSafe(basePath: string, subpath: string): boolean {
 	const normalizedTarget = normalize(resolve(basePath, subpath));
 	return normalizedTarget === normalizedBase || normalizedTarget.startsWith(normalizedBase + sep);
 }
-
-/**
- * Turn an arbitrary user-supplied name into a kebab-case identifier safe for use
- * as a directory name / skill_key. Lowercase, non-alphanumeric collapses to `-`,
- * leading/trailing `.`/`-` stripped, capped at 255 chars.
- * Ported from vercel/skills `installer.ts:sanitizeName`.
- */
-export function sanitizeName(name: string): string {
-	const sanitized = name
-		.toLowerCase()
-		.replace(/[^a-z0-9._]+/g, "-")
-		.replace(/^[.-]+|[.-]+$/g, "");
-	return sanitized.substring(0, 255) || "unnamed-skill";
-}

--- a/packages/cli/src/lib/skill-key.ts
+++ b/packages/cli/src/lib/skill-key.ts
@@ -1,8 +1,11 @@
-const MAX_SKILL_KEY_LEN = 200;
+import {
+	MAX_SKILL_KEY_LEN,
+	RESERVED_SKILL_KEY_SUFFIXES,
+	SKILL_KEY_PATTERN,
+} from "@clawdi/shared/consts";
 
-const SKILL_KEY_PATTERN =
-	/^[A-Za-z0-9][A-Za-z0-9._-]{0,199}(\/[A-Za-z0-9][A-Za-z0-9._-]{0,199}){0,3}$/;
-const RESERVED_SUFFIXES = new Set(["download", "content", "install"]);
+const SKILL_KEY_RE = new RegExp(SKILL_KEY_PATTERN);
+const RESERVED_SUFFIXES = new Set<string>(RESERVED_SKILL_KEY_SUFFIXES);
 
 function hasReservedSkillKeySuffix(skillKey: string): boolean {
 	const parts = skillKey.split("/");
@@ -12,13 +15,30 @@ function hasReservedSkillKeySuffix(skillKey: string): boolean {
 export function isValidSkillKey(skillKey: string): boolean {
 	return (
 		skillKey.length <= MAX_SKILL_KEY_LEN &&
-		SKILL_KEY_PATTERN.test(skillKey) &&
+		SKILL_KEY_RE.test(skillKey) &&
 		!hasReservedSkillKeySuffix(skillKey)
 	);
 }
 
 export function assertValidSkillKey(skillKey: string): void {
 	if (!isValidSkillKey(skillKey)) {
-		throw new Error(`Invalid skill_key from server: ${JSON.stringify(skillKey)}`);
+		throw new Error(`Invalid skill_key: ${JSON.stringify(skillKey)}`);
 	}
+}
+
+/**
+ * Turn an arbitrary local file/directory name into a backend-valid skill_key.
+ *
+ * This is intentionally colocated with `isValidSkillKey` so generated keys and
+ * accepted keys do not drift from the backend contract.
+ */
+export function sanitizeSkillKey(name: string): string {
+	const sanitized = name
+		.toLowerCase()
+		.replace(/[^a-z0-9._]+/g, "-")
+		.replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, "")
+		.substring(0, MAX_SKILL_KEY_LEN);
+	const skillKey = sanitized || "unnamed-skill";
+	assertValidSkillKey(skillKey);
+	return skillKey;
 }

--- a/packages/cli/tests/commands/helpers.ts
+++ b/packages/cli/tests/commands/helpers.ts
@@ -41,6 +41,7 @@ export interface CapturedRequest {
 	method: string;
 	headers: Record<string, string>;
 	isMultipart: boolean;
+	multipartFields?: Record<string, string>;
 	body?: unknown;
 }
 
@@ -55,7 +56,7 @@ export function mockFetch(
 	handlers: Array<{
 		method?: string;
 		path: string | RegExp;
-		response: () => Response | Promise<Response>;
+		response: (request: CapturedRequest) => Response | Promise<Response>;
 	}>,
 ): { captured: CapturedRequest[]; restore: () => void } {
 	const orig = globalThis.fetch;
@@ -77,6 +78,13 @@ export function mockFetch(
 		const isMultipart = rawBody instanceof FormData;
 
 		let body: unknown;
+		let multipartFields: Record<string, string> | undefined;
+		if (isMultipart) {
+			multipartFields = {};
+			for (const [key, value] of rawBody.entries()) {
+				if (typeof value === "string") multipartFields[key] = value;
+			}
+		}
 		if (!isMultipart && contentType.includes("json")) {
 			try {
 				const text = isRequest ? await input.clone().text() : String(rawBody ?? "");
@@ -86,12 +94,21 @@ export function mockFetch(
 			}
 		}
 
-		captured.push({ url, path, method, headers: capturedHeaders, isMultipart, body });
+		const request = {
+			url,
+			path,
+			method,
+			headers: capturedHeaders,
+			isMultipart,
+			multipartFields,
+			body,
+		};
+		captured.push(request);
 
 		for (const h of handlers) {
 			if (h.method && h.method.toUpperCase() !== method) continue;
 			const m = typeof h.path === "string" ? path.startsWith(h.path) : h.path.test(path);
-			if (m) return await h.response();
+			if (m) return await h.response(request);
 		}
 		return new Response(`unhandled ${method} ${path}`, { status: 404 });
 	}) as typeof fetch;

--- a/packages/cli/tests/commands/skill.test.ts
+++ b/packages/cli/tests/commands/skill.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { skillInit } from "../../src/commands/skill";
+import { skillAdd, skillInit } from "../../src/commands/skill";
+import { jsonResponse, mockFetch, okEnvironmentProbe, seedAuthAndEnv } from "./helpers";
 
 let tmpHome: string;
 let origCwd: string;
@@ -53,5 +54,48 @@ describe("skillInit", () => {
 	it("sanitizes the name to kebab-case", () => {
 		skillInit("My Cool Skill!");
 		expect(existsSync(join(tmpHome, "my-cool-skill", "SKILL.md"))).toBe(true);
+	});
+
+	it("caps generated skill directory names at the backend skill_key limit", () => {
+		skillInit("a".repeat(300));
+		const generated = "a".repeat(200);
+		expect(existsSync(join(tmpHome, generated, "SKILL.md"))).toBe(true);
+	});
+});
+
+describe("skillAdd", () => {
+	it("uploads a backend-valid skill_key generated from a long local directory name", async () => {
+		seedAuthAndEnv(tmpHome, "claude_code");
+		const longName = "a".repeat(240);
+		const skillDir = join(tmpHome, longName);
+		mkdirSync(skillDir, { recursive: true });
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			"---\nname: Long Skill\ndescription: long directory name\n---\n# Long\n",
+		);
+
+		const projectId = "00000000-0000-0000-0000-000000000099";
+		const { captured, restore } = mockFetch([
+			okEnvironmentProbe(),
+			{
+				method: "POST",
+				path: `/api/projects/${projectId}/skills/upload`,
+				response: (request) =>
+					jsonResponse({
+						skill_key: request.multipartFields?.skill_key,
+						version: 1,
+						file_count: 1,
+					}),
+			},
+		]);
+		try {
+			await skillAdd(skillDir, { agent: "claude_code", yes: true });
+		} finally {
+			restore();
+		}
+
+		const upload = captured.find((c) => c.path === `/api/projects/${projectId}/skills/upload`);
+		expect(upload?.multipartFields?.skill_key).toHaveLength(200);
+		expect(upload?.multipartFields?.skill_key).toBe("a".repeat(200));
 	});
 });

--- a/packages/cli/tests/sanitize.test.ts
+++ b/packages/cli/tests/sanitize.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "bun:test";
 import {
 	isSubpathSafe,
 	sanitizeMetadata,
-	sanitizeName,
 	sanitizeSubpath,
 	stripTerminalEscapes,
 } from "../src/lib/sanitize";
@@ -89,41 +88,5 @@ describe("isSubpathSafe", () => {
 	it("returns false when subpath escapes base", () => {
 		expect(isSubpathSafe("/tmp/base", "../etc")).toBe(false);
 		expect(isSubpathSafe("/tmp/base", "../../../etc/passwd")).toBe(false);
-	});
-});
-
-describe("sanitizeName", () => {
-	it("kebab-cases user-supplied names", () => {
-		expect(sanitizeName("My Cool Skill")).toBe("my-cool-skill");
-		expect(sanitizeName("Hello, World!")).toBe("hello-world");
-	});
-
-	it("lowercases", () => {
-		expect(sanitizeName("UPPER")).toBe("upper");
-	});
-
-	it("strips leading/trailing dots and hyphens", () => {
-		expect(sanitizeName("-foo-")).toBe("foo");
-		expect(sanitizeName(".hidden.")).toBe("hidden");
-	});
-
-	it("preserves dots and underscores in the middle", () => {
-		expect(sanitizeName("my_skill.v1")).toBe("my_skill.v1");
-	});
-
-	it("falls back to unnamed-skill on empty", () => {
-		expect(sanitizeName("")).toBe("unnamed-skill");
-		expect(sanitizeName("---")).toBe("unnamed-skill");
-		expect(sanitizeName("!@#$")).toBe("unnamed-skill");
-	});
-
-	it("caps at 255 chars", () => {
-		const long = "a".repeat(300);
-		expect(sanitizeName(long)).toHaveLength(255);
-	});
-
-	it("prevents path traversal attempts", () => {
-		expect(sanitizeName("../etc/passwd")).toBe("etc-passwd");
-		expect(sanitizeName("..")).toBe("unnamed-skill");
 	});
 });

--- a/packages/cli/tests/skill-key.test.ts
+++ b/packages/cli/tests/skill-key.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { isValidSkillKey, sanitizeSkillKey } from "../src/lib/skill-key";
+
+describe("sanitizeSkillKey", () => {
+	it("kebab-cases user-supplied names into valid skill_keys", () => {
+		expect(sanitizeSkillKey("My Cool Skill")).toBe("my-cool-skill");
+		expect(sanitizeSkillKey("Hello, World!")).toBe("hello-world");
+		expect(isValidSkillKey(sanitizeSkillKey("Hello, World!"))).toBe(true);
+	});
+
+	it("lowercases", () => {
+		expect(sanitizeSkillKey("UPPER")).toBe("upper");
+	});
+
+	it("strips leading characters that cannot start a skill_key", () => {
+		expect(sanitizeSkillKey("-foo-")).toBe("foo");
+		expect(sanitizeSkillKey(".hidden.")).toBe("hidden");
+		expect(sanitizeSkillKey("_internal")).toBe("internal");
+	});
+
+	it("preserves dots and underscores in the middle", () => {
+		expect(sanitizeSkillKey("my_skill.v1")).toBe("my_skill.v1");
+	});
+
+	it("falls back to unnamed-skill on empty", () => {
+		expect(sanitizeSkillKey("")).toBe("unnamed-skill");
+		expect(sanitizeSkillKey("---")).toBe("unnamed-skill");
+		expect(sanitizeSkillKey("!@#$")).toBe("unnamed-skill");
+	});
+
+	it("caps at the backend skill_key column length", () => {
+		const key = sanitizeSkillKey("a".repeat(300));
+		expect(key).toHaveLength(200);
+		expect(isValidSkillKey(key)).toBe(true);
+	});
+
+	it("prevents path traversal attempts", () => {
+		expect(sanitizeSkillKey("../etc/passwd")).toBe("etc-passwd");
+		expect(sanitizeSkillKey("..")).toBe("unnamed-skill");
+	});
+});

--- a/packages/shared/src/consts/index.ts
+++ b/packages/shared/src/consts/index.ts
@@ -1,1 +1,2 @@
 export * from "./featured-skills";
+export * from "./skill-key";

--- a/packages/shared/src/consts/skill-key.ts
+++ b/packages/shared/src/consts/skill-key.ts
@@ -1,0 +1,6 @@
+export const MAX_SKILL_KEY_LEN = 200;
+
+export const SKILL_KEY_PATTERN =
+	"^[A-Za-z0-9][A-Za-z0-9._-]{0,199}(/[A-Za-z0-9][A-Za-z0-9._-]{0,199}){0,3}$";
+
+export const RESERVED_SKILL_KEY_SUFFIXES = ["download", "content", "install"] as const;


### PR DESCRIPTION
## Summary
- move generated skill key sanitization into `lib/skill-key.ts` next to validation
- update `skill add` and `skill init` to use the same backend-aligned 200-char skill key contract
- remove skill-key-specific sanitization from generic terminal/path sanitization utilities
- let command tests inspect multipart string fields and cover long manual skill uploads

## Verification
- `bun run check`
- `bun run --cwd packages/cli typecheck`
- `bun test packages/cli/tests/sanitize.test.ts packages/cli/tests/skill-key.test.ts packages/cli/tests/commands/skill.test.ts packages/cli/tests/commands/push.test.ts packages/cli/src/serve/watcher.test.ts packages/cli/src/serve/sync-engine.test.ts` -> 88 passed

## Note
This PR is intentionally not merged automatically. It closes the gap found in review of #147: manual `clawdi skill add` now generates a backend-valid `skill_key` through the same module that validates daemon/push keys.