### PR TITLE
Clean native channel bot pool access

### DIFF
--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -39,6 +39,7 @@ from app.routes.channel_routers.shared import (
     _discord_gateway_dispatch,
     _discord_interaction_content,
     _discord_message_result,
+    _fan_out_discord_global_commands,
     _handle_discord_application_commands,
     _json_object_from_bytes,
     _optional_int_param,
@@ -67,6 +68,7 @@ from app.services.channels import (
     resolve_channel_agent_by_token,
     resolve_inbound_binding,
     send_channel_outbound_message,
+    send_pairing_command_reply,
     upsert_binding_alias,
     verify_discord_signature,
     verify_webhook_secret,
@@ -471,12 +473,58 @@ async def discord_webhook(
                 "flags": 64,
             },
         }
+    await _replay_discord_commands_on_pair(
+        db,
+        account=account,
+        application_id=_discord_application_id(account),
+        guild_id=guild_id,
+        paired=binding_result.paired,
+    )
+    reply = await send_pairing_command_reply(
+        db,
+        account=account,
+        external_chat_id=external_chat_id,
+        send_external_chat_id=channel_id,
+        command=command,
+        binding_result=binding_result,
+    )
+    if reply is not None:
+        await db.commit()
     return {
         "ok": True,
         "paired": binding_result.paired,
         "unpaired": binding_result.unpaired,
         "binding_id": str(message.binding_id) if message.binding_id else None,
     }
+
+
+async def _replay_discord_commands_on_pair(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    application_id: str,
+    guild_id: str | None,
+    paired: bool,
+) -> None:
+    if not paired or guild_id is None:
+        return
+    config = account.config if isinstance(account.config, dict) else {}
+    shadow = config.get("discord_agent_commands")
+    if not isinstance(shadow, dict):
+        return
+    commands = shadow.get("global")
+    if not isinstance(commands, list):
+        return
+    try:
+        await _fan_out_discord_global_commands(
+            db,
+            account=account,
+            application_id=application_id,
+            commands=[command for command in commands if isinstance(command, dict)],
+            guild_ids={guild_id},
+        )
+    except HTTPException:
+        return
 
 
 async def _handle_discord_interaction_callback(

--- a/backend/app/routes/channel_routers/imessage_realtime.py
+++ b/backend/app/routes/channel_routers/imessage_realtime.py
@@ -38,9 +38,11 @@ from app.services.channels import (
     imessage_external_user_id_from_payload,
     imessage_message_id_from_payload,
     imessage_text_from_payload,
+    parse_pair_command,
     record_inbound_messages_for_bindings,
     resolve_channel_agent_by_token,
     resolve_inbound_binding,
+    send_pairing_command_reply,
     verify_webhook_secret,
 )
 
@@ -133,6 +135,7 @@ async def imessage_webhook(
         return TelegramWebhookResponse(ok=True)
     external_chat_id, external_chat_type, external_chat_name = chat
     text = imessage_text_from_payload(payload)
+    command = parse_pair_command(text)
     binding_result = await resolve_inbound_binding(
         db,
         account=account,
@@ -141,6 +144,7 @@ async def imessage_webhook(
         external_chat_name=external_chat_name,
         external_user_id=imessage_external_user_id_from_payload(payload),
         text=text,
+        command=command,
     )
 
     messages = await record_inbound_messages_for_bindings(
@@ -153,6 +157,15 @@ async def imessage_webhook(
         payload=payload,
     )
     await db.commit()
+    reply = await send_pairing_command_reply(
+        db,
+        account=account,
+        external_chat_id=external_chat_id,
+        command=command,
+        binding_result=binding_result,
+    )
+    if reply is not None:
+        await db.commit()
     message = messages[0][0]
     if not binding_result.command_handled:
         for routed_message, _binding in messages:

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -8,7 +8,7 @@ from fastapi import (
     HTTPException,
     status,
 )
-from sqlalchemy import and_, or_, select
+from sqlalchemy import or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -21,6 +21,7 @@ from app.models.channel import (
     BINDING_STATUS_ACTIVE,
     CHANNEL_PROVIDERS,
     CHANNEL_STATUS_ACTIVE,
+    CHANNEL_VISIBILITY_PRIVATE,
     CHANNEL_VISIBILITY_PUBLIC,
     ChannelAccount,
     ChannelBinding,
@@ -39,6 +40,10 @@ from app.schemas.channel import (
     ChannelAgentLinkCreate,
     ChannelAgentLinkResponse,
     ChannelBindingResponse,
+    ChannelBotPoolAccess,
+    ChannelBotPoolCapabilities,
+    ChannelBotPoolItem,
+    ChannelBotPoolResponse,
     ChannelCommandSyncRequest,
     ChannelCommandSyncResponse,
     ChannelMessageResponse,
@@ -58,7 +63,8 @@ from app.services.channels import (
     get_accessible_channel_account,
     get_or_create_bot_agent_link,
     get_owned_bot_agent_link,
-    get_owned_channel_account,
+    get_owned_private_channel_account,
+    get_usable_channel_account,
     hash_token,
     list_owned_active_bot_agent_links,
     rotate_bot_agent_link_token,
@@ -84,6 +90,36 @@ def _agent_link_response(
     )
 
 
+def _bot_pool_item(
+    account: ChannelAccount,
+    *,
+    user_id: UUID,
+) -> ChannelBotPoolItem:
+    access = _bot_pool_access(account, user_id=user_id)
+    return ChannelBotPoolItem(
+        **_account_response(account).model_dump(),
+        access=access,
+        capabilities=_bot_pool_capabilities(access),
+    )
+
+
+def _bot_pool_access(account: ChannelAccount, *, user_id: UUID) -> ChannelBotPoolAccess:
+    if account.user_id == user_id and account.visibility == CHANNEL_VISIBILITY_PRIVATE:
+        return "owner"
+    return "public"
+
+
+def _bot_pool_capabilities(access: ChannelBotPoolAccess) -> ChannelBotPoolCapabilities:
+    can_manage_account = access == "owner"
+    return ChannelBotPoolCapabilities(
+        link_agent=True,
+        pair_chat=True,
+        send_message=True,
+        manage_account=can_manage_account,
+        sync_commands=can_manage_account,
+    )
+
+
 @router.get("")
 async def list_channels(
     auth: AuthContext = Depends(require_user_auth),
@@ -93,17 +129,39 @@ async def list_channels(
         select(ChannelAccount)
         .where(
             ChannelAccount.archived_at.is_(None),
-            or_(
-                ChannelAccount.user_id == auth.user_id,
-                and_(
-                    ChannelAccount.visibility == CHANNEL_VISIBILITY_PUBLIC,
-                    ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
-                ),
-            ),
+            ChannelAccount.user_id == auth.user_id,
+            ChannelAccount.visibility == CHANNEL_VISIBILITY_PRIVATE,
         )
         .order_by(ChannelAccount.provider, ChannelAccount.visibility, ChannelAccount.name)
     )
     return [_account_response(account) for account in result.scalars().all()]
+
+
+@router.get("/bot-pool")
+async def list_channel_bot_pool(
+    auth: AuthContext = Depends(require_user_auth),
+    db: AsyncSession = Depends(get_session),
+) -> ChannelBotPoolResponse:
+    result = await db.execute(
+        select(ChannelAccount)
+        .where(
+            ChannelAccount.archived_at.is_(None),
+            ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+            or_(
+                ChannelAccount.user_id == auth.user_id,
+                ChannelAccount.visibility == CHANNEL_VISIBILITY_PUBLIC,
+            ),
+        )
+        .order_by(ChannelAccount.provider, ChannelAccount.visibility.desc(), ChannelAccount.name)
+    )
+    providers: dict[str, list[ChannelBotPoolItem]] = {
+        provider: [] for provider in CHANNEL_PROVIDERS
+    }
+    for account in result.scalars().all():
+        providers.setdefault(account.provider, []).append(
+            _bot_pool_item(account, user_id=auth.user_id)
+        )
+    return ChannelBotPoolResponse(providers=providers)
 
 
 @router.post("", status_code=status.HTTP_201_CREATED)
@@ -181,7 +239,11 @@ async def delete_channel(
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
 ) -> None:
-    account = await get_owned_channel_account(db, account_id=account_id, user_id=auth.user_id)
+    account = await get_owned_private_channel_account(
+        db,
+        account_id=account_id,
+        user_id=auth.user_id,
+    )
     await archive_channel_account(db, account=account)
     await db.commit()
 
@@ -193,7 +255,7 @@ async def create_channel_pair_code(
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
 ) -> ChannelPairCodeResponse:
-    account = await get_accessible_channel_account(db, account_id=account_id, user_id=auth.user_id)
+    account = await get_usable_channel_account(db, account_id=account_id, user_id=auth.user_id)
     link, agent_token = await _resolve_pair_code_link(db, auth=auth, account=account, body=body)
     created = await create_pair_code(
         db,
@@ -240,7 +302,7 @@ async def create_channel_agent_link(
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
 ) -> ChannelAgentLinkResponse:
-    account = await get_accessible_channel_account(db, account_id=account_id, user_id=auth.user_id)
+    account = await get_usable_channel_account(db, account_id=account_id, user_id=auth.user_id)
     agent_id = await _resolve_agent_id_for_link(db, auth=auth, requested_agent_id=body.agent_id)
     link, agent_token = await get_or_create_bot_agent_link(
         db,
@@ -260,7 +322,7 @@ async def rotate_channel_agent_link_token(
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
 ) -> ChannelAgentLinkResponse:
-    account = await get_accessible_channel_account(db, account_id=account_id, user_id=auth.user_id)
+    account = await get_usable_channel_account(db, account_id=account_id, user_id=auth.user_id)
     link = await get_owned_bot_agent_link(
         db, account=account, link_id=link_id, user_id=auth.user_id
     )
@@ -296,7 +358,11 @@ async def sync_channel_commands_route(
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
 ) -> ChannelCommandSyncResponse:
-    account = await get_owned_channel_account(db, account_id=account_id, user_id=auth.user_id)
+    account = await get_owned_private_channel_account(
+        db,
+        account_id=account_id,
+        user_id=auth.user_id,
+    )
     commands = (
         [command.model_dump(exclude_none=True) for command in body.commands]
         if body.commands is not None
@@ -317,7 +383,7 @@ async def send_channel_message(
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
 ) -> ChannelMessageResponse:
-    account = await get_accessible_channel_account(db, account_id=account_id, user_id=auth.user_id)
+    account = await get_usable_channel_account(db, account_id=account_id, user_id=auth.user_id)
     external_chat_id = body.external_chat_id
     bot_agent_link_id: UUID | None = None
     if body.binding_id is not None:

--- a/backend/app/routes/channel_routers/shared.py
+++ b/backend/app/routes/channel_routers/shared.py
@@ -866,9 +866,7 @@ async def _fan_out_discord_global_commands(
     token = decrypt_provider_token(account)
     uncontested_guild_ids = await _discord_uncontested_guilds_for_account(db, account=account)
     target_guild_ids = [
-        guild_id
-        for guild_id in uncontested_guild_ids
-        if guild_ids is None or guild_id in guild_ids
+        guild_id for guild_id in uncontested_guild_ids if guild_ids is None or guild_id in guild_ids
     ]
     if not target_guild_ids:
         return

--- a/backend/app/routes/channel_routers/shared.py
+++ b/backend/app/routes/channel_routers/shared.py
@@ -859,12 +859,18 @@ async def _fan_out_discord_global_commands(
     account: ChannelAccount,
     application_id: str,
     commands: list[dict[str, Any]],
+    guild_ids: set[str] | None = None,
 ) -> None:
     if not account.encrypted_provider_token or not account.provider_token_nonce:
         return
     token = decrypt_provider_token(account)
-    guild_ids = await _discord_uncontested_guilds_for_account(db, account=account)
-    if not guild_ids:
+    uncontested_guild_ids = await _discord_uncontested_guilds_for_account(db, account=account)
+    target_guild_ids = [
+        guild_id
+        for guild_id in uncontested_guild_ids
+        if guild_ids is None or guild_id in guild_ids
+    ]
+    if not target_guild_ids:
         return
     base_url = settings.channel_discord_api_base_url.strip()
     await _validate_discord_provider_base_url(base_url)
@@ -875,7 +881,7 @@ async def _fan_out_discord_global_commands(
     }
     try:
         async with httpx.AsyncClient(timeout=20.0) as client:
-            for guild_id in guild_ids:
+            for guild_id in target_guild_ids:
                 await client.put(
                     f"{base_url}/applications/{application_id}/guilds/{guild_id}/commands",
                     json=commands,

--- a/backend/app/routes/channel_routers/telegram.py
+++ b/backend/app/routes/channel_routers/telegram.py
@@ -26,6 +26,7 @@ from app.models.channel import (
     BINDING_STATUS_ACTIVE,
     BOT_AGENT_LINK_STATUS_ACTIVE,
     CHANNEL_PROVIDER_TELEGRAM,
+    ChannelAccount,
     ChannelBinding,
     ChannelBotAgentLink,
 )
@@ -52,12 +53,14 @@ from app.services.channels import (
     drop_pending_telegram_updates,
     find_binding,
     get_active_channel_account,
+    parse_pair_command,
     pending_channel_inbox_count,
     record_channel_agent_reference,
     record_inbound_messages_for_bindings,
     record_telegram_update_references,
     resolve_channel_agent_by_token,
     resolve_inbound_binding,
+    send_pairing_command_reply,
     telegram_chat_from_update,
     telegram_external_user_id_from_update,
     telegram_message_id_from_update,
@@ -371,6 +374,7 @@ async def telegram_webhook(
 
     external_chat_id, external_chat_type, external_chat_name = chat
     text = telegram_text_from_update(payload)
+    command = parse_pair_command(text)
     binding_result = await resolve_inbound_binding(
         db,
         account=account,
@@ -379,6 +383,7 @@ async def telegram_webhook(
         external_chat_name=external_chat_name,
         external_user_id=telegram_external_user_id_from_update(payload),
         text=text,
+        command=command,
     )
 
     messages = await record_inbound_messages_for_bindings(
@@ -400,6 +405,20 @@ async def telegram_webhook(
             payload=payload,
         )
     await db.commit()
+    reply = await send_pairing_command_reply(
+        db,
+        account=account,
+        external_chat_id=external_chat_id,
+        command=command,
+        binding_result=binding_result,
+    )
+    if reply is not None:
+        await db.commit()
+    await _replay_telegram_commands_on_pair(
+        db,
+        account=account,
+        binding=binding_result.binding if binding_result.paired else None,
+    )
     if messages and message.binding_id and not binding_result.command_handled:
         delivered_at = datetime.now(UTC)
         delivered_any = False
@@ -648,6 +667,58 @@ async def _fan_out_telegram_commands(
                 content=_telegram_response_json(response),
             )
     return None
+
+
+async def _replay_telegram_commands_on_pair(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    binding: ChannelBinding | None,
+) -> None:
+    if binding is None or not account.encrypted_provider_token or not account.provider_token_nonce:
+        return
+    link = await db.get(ChannelBotAgentLink, binding.bot_agent_link_id)
+    if link is None or link.status != BOT_AGENT_LINK_STATUS_ACTIVE:
+        return
+    config = link.config if isinstance(link.config, dict) else {}
+    shadow = config.get("telegram_agent_commands")
+    if not isinstance(shadow, dict):
+        return
+    for key, commands in shadow.items():
+        if not isinstance(key, str) or not isinstance(commands, list):
+            continue
+        scope_key, language_code = _telegram_command_shadow_parts(key)
+        if scope_key not in {
+            "default",
+            "all_private_chats",
+            "all_group_chats",
+            "all_chat_administrators",
+        }:
+            continue
+        scope = _telegram_command_fanout_scope(binding, scope_key=scope_key)
+        if scope is None:
+            continue
+        payload: dict[str, Any] = {
+            "commands": [command for command in commands if isinstance(command, dict)],
+            "scope": scope,
+        }
+        if language_code:
+            payload["language_code"] = language_code
+        try:
+            await _post_telegram_command_payload(
+                account=account,
+                method="setMyCommands",
+                payload=payload,
+            )
+        except HTTPException:
+            return
+
+
+def _telegram_command_shadow_parts(key: str) -> tuple[str, str]:
+    scope_key, separator, language_code = key.rpartition(":")
+    if not separator:
+        return key, ""
+    return scope_key, language_code
 
 
 def _telegram_command_fanout_scope(

--- a/backend/app/routes/channel_routers/whatsapp.py
+++ b/backend/app/routes/channel_routers/whatsapp.py
@@ -53,17 +53,18 @@ from app.schemas.channel import (
 from app.services.agent_bindings import get_owned_agent_or_404
 from app.services.channel_debug_events import record_channel_debug_event
 from app.services.channels import (
-    get_accessible_channel_account,
     get_active_channel_account,
     get_channel_secret,
     get_or_create_bot_agent_link,
     get_owned_bot_agent_link,
-    get_owned_channel_account,
+    get_usable_channel_account,
     list_owned_active_bot_agent_links,
+    parse_pair_command,
     record_inbound_messages_for_bindings,
     resolve_channel_agent_by_token,
     resolve_inbound_binding,
     send_channel_outbound_message,
+    send_pairing_command_reply,
     verify_hub_signature,
     verify_webhook_secret,
     whatsapp_chat_from_payload,
@@ -121,7 +122,7 @@ async def create_whatsapp_tenant_credential(
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
 ) -> WhatsAppTenantCredentialResponse:
-    account = await get_accessible_channel_account(db, account_id=account_id, user_id=auth.user_id)
+    account = await get_usable_channel_account(db, account_id=account_id, user_id=auth.user_id)
     if account.provider != CHANNEL_PROVIDER_WHATSAPP:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="channel not found")
     self_identity = (
@@ -160,7 +161,7 @@ async def list_whatsapp_tenant_credentials(
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
 ) -> list[WhatsAppTenantCredentialMetadata]:
-    account = await get_accessible_channel_account(db, account_id=account_id, user_id=auth.user_id)
+    account = await get_usable_channel_account(db, account_id=account_id, user_id=auth.user_id)
     if account.provider != CHANNEL_PROVIDER_WHATSAPP:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="channel not found")
     result = await db.execute(
@@ -232,7 +233,7 @@ async def delete_whatsapp_tenant_credential(
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
 ) -> None:
-    account = await get_accessible_channel_account(db, account_id=account_id, user_id=auth.user_id)
+    account = await get_usable_channel_account(db, account_id=account_id, user_id=auth.user_id)
     if account.provider != CHANNEL_PROVIDER_WHATSAPP:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="channel not found")
     revoked = await revoke_whatsapp_agent_credential(
@@ -252,7 +253,7 @@ async def get_whatsapp_auth_cert(
     auth: AuthContext = Depends(require_user_auth),
     db: AsyncSession = Depends(get_session),
 ) -> dict[str, Any]:
-    account = await get_owned_channel_account(db, account_id=account_id, user_id=auth.user_id)
+    account = await get_usable_channel_account(db, account_id=account_id, user_id=auth.user_id)
     if account.provider != CHANNEL_PROVIDER_WHATSAPP:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="channel not found")
     auth_cert = await load_or_create_whatsapp_auth_cert(db, account=account)
@@ -762,6 +763,7 @@ async def whatsapp_webhook(
             external_chat_type = existing_binding.external_chat_type
             external_chat_name = existing_binding.external_chat_name
     text = whatsapp_text_from_payload(payload)
+    command = parse_pair_command(text)
     binding_result = await resolve_inbound_binding(
         db,
         account=account,
@@ -770,6 +772,7 @@ async def whatsapp_webhook(
         external_chat_name=external_chat_name,
         external_user_id=whatsapp_external_user_id_from_payload(payload),
         text=text,
+        command=command,
     )
 
     messages = await record_inbound_messages_for_bindings(
@@ -791,6 +794,15 @@ async def whatsapp_webhook(
                     alt_jid=alt_jid,
                 )
     await db.commit()
+    reply = await send_pairing_command_reply(
+        db,
+        account=account,
+        external_chat_id=external_chat_id,
+        command=command,
+        binding_result=binding_result,
+    )
+    if reply is not None:
+        await db.commit()
     message = messages[0][0]
     return TelegramWebhookResponse(
         ok=True,

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -60,9 +60,11 @@ class AdminApiKeyCreate(BaseModel):
 class AdminChannelCreate(BaseModel):
     """Create a provider bot account through the admin control plane.
 
-    `target_clerk_id` owns provider credentials and destructive bot-level
-    operations. Public visibility only lets other authenticated users create
-    their own bot-agent links and pair codes.
+    `target_clerk_id` supplies the backing user row for bookkeeping and
+    private managed bots. Public bots remain admin-managed shared
+    infrastructure: authenticated users can create their own links and pair
+    codes, but cannot mutate provider credentials or destructive bot-level
+    state through user APIs.
     """
 
     target_clerk_id: str

--- a/backend/app/schemas/channel.py
+++ b/backend/app/schemas/channel.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field, field_validator
 
 ChannelProvider = Literal["telegram", "discord", "whatsapp", "imessage"]
 ChannelVisibility = Literal["private", "public"]
+ChannelBotPoolAccess = Literal["owner", "public"]
 
 
 class ChannelAccountCreate(BaseModel):
@@ -51,6 +52,23 @@ class ChannelAccountResponse(BaseModel):
     has_provider_token: bool
     webhook_url: str
     created_at: datetime
+
+
+class ChannelBotPoolCapabilities(BaseModel):
+    link_agent: bool
+    pair_chat: bool
+    send_message: bool
+    manage_account: bool
+    sync_commands: bool
+
+
+class ChannelBotPoolItem(ChannelAccountResponse):
+    access: ChannelBotPoolAccess
+    capabilities: ChannelBotPoolCapabilities
+
+
+class ChannelBotPoolResponse(BaseModel):
+    providers: dict[str, list[ChannelBotPoolItem]]
 
 
 class ChannelAccountCreatedResponse(ChannelAccountResponse):

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import hmac
+import logging
 import re
 import secrets
 from dataclasses import dataclass
@@ -31,6 +32,7 @@ from app.models.channel import (
     CHANNEL_PROVIDER_WHATSAPP,
     CHANNEL_STATUS_ACTIVE,
     CHANNEL_STATUS_DISABLED,
+    CHANNEL_VISIBILITY_PRIVATE,
     CHANNEL_VISIBILITY_PUBLIC,
     DELIVERY_STATUS_FAILED,
     DELIVERY_STATUS_IN_PROGRESS,
@@ -66,6 +68,8 @@ from app.services.metrics import (
 )
 from app.services.url_security import UnsafeOutboundUrlError, validate_channel_http_url
 from app.services.vault_crypto import decrypt, encrypt
+
+log = logging.getLogger(__name__)
 
 PAIR_COMMAND = "/bot_pair"
 UNPAIR_COMMAND = "/bot_unpair"
@@ -387,16 +391,23 @@ async def rotate_bot_agent_link_token(
     return raw_token
 
 
-async def get_owned_channel_account(
+async def get_owned_private_channel_account(
     db: AsyncSession,
     *,
     account_id: UUID,
     user_id: UUID,
 ) -> ChannelAccount:
+    """Resolve a user-owned mutable channel account.
+
+    Public channel accounts are Clawdi-managed infrastructure even when their
+    database owner is a target user row. User-facing mutable operations must
+    only apply to private accounts created by that user.
+    """
     result = await db.execute(
         select(ChannelAccount).where(
             ChannelAccount.id == account_id,
             ChannelAccount.user_id == user_id,
+            ChannelAccount.visibility == CHANNEL_VISIBILITY_PRIVATE,
             ChannelAccount.archived_at.is_(None),
         )
     )
@@ -404,10 +415,6 @@ async def get_owned_channel_account(
     if account is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="channel not found")
     return account
-
-
-def is_public_channel_account(account: ChannelAccount) -> bool:
-    return account.visibility == CHANNEL_VISIBILITY_PUBLIC
 
 
 async def get_accessible_channel_account(
@@ -435,11 +442,34 @@ async def get_accessible_channel_account(
     return account
 
 
+async def get_usable_channel_account(
+    db: AsyncSession,
+    *,
+    account_id: UUID,
+    user_id: UUID,
+) -> ChannelAccount:
+    result = await db.execute(
+        select(ChannelAccount).where(
+            ChannelAccount.id == account_id,
+            ChannelAccount.archived_at.is_(None),
+            ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+            or_(
+                ChannelAccount.user_id == user_id,
+                ChannelAccount.visibility == CHANNEL_VISIBILITY_PUBLIC,
+            ),
+        )
+    )
+    account = result.scalar_one_or_none()
+    if account is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="channel not found")
+    return account
+
+
 async def get_active_channel_account(db: AsyncSession, *, account_id: UUID) -> ChannelAccount:
     """Resolve an account for provider ingress or agent-facing SDK routes.
 
-    This is intentionally visibility-neutral: private user bots and public
-    Clawdi-managed bots both receive provider webhooks under account-scoped URLs.
+    This is intentionally visibility-neutral: private user bots and public bots
+    both receive provider webhooks under account-scoped URLs.
     User-facing access checks belong in get_accessible_channel_account.
     """
     result = await db.execute(
@@ -916,6 +946,53 @@ def pairing_reply_for_command(
 def extract_pair_code(text: str | None) -> str | None:
     command = parse_pair_command(text)
     return command.code if command is not None and command.kind == "pair" else None
+
+
+async def send_pairing_command_reply(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    external_chat_id: str,
+    send_external_chat_id: str | None = None,
+    command: ChannelPairCommand | None,
+    binding_result: InboundBindingResult,
+) -> ChannelMessage | None:
+    if not binding_result.command_handled:
+        return None
+    reply = pairing_reply_for_command(command, binding_result)
+    reply_link_id = (
+        binding_result.binding.bot_agent_link_id
+        if binding_result.binding is not None
+        and (binding_result.paired or binding_result.unpaired)
+        else None
+    )
+    bind_reply_to_existing = reply_link_id is not None
+    try:
+        return await send_channel_outbound_message(
+            db,
+            account=account,
+            external_chat_id=send_external_chat_id or external_chat_id,
+            text=reply,
+            bot_agent_link_id=reply_link_id,
+            bind_to_existing=bind_reply_to_existing,
+        )
+    except HTTPException as exc:
+        log.warning(
+            "channel_pairing_reply_failed provider=%s account_id=%s chat_id=%s status=%s detail=%s",
+            account.provider,
+            account.id,
+            external_chat_id,
+            exc.status_code,
+            exc.detail,
+        )
+    except Exception:
+        log.exception(
+            "channel_pairing_reply_failed provider=%s account_id=%s chat_id=%s",
+            account.provider,
+            account.id,
+            external_chat_id,
+        )
+    return None
 
 
 def telegram_chat_from_update(payload: dict[str, Any]) -> tuple[str, str | None, str | None] | None:
@@ -1731,6 +1808,7 @@ async def send_channel_outbound_message(
     external_chat_id: str,
     text: str,
     bot_agent_link_id: UUID | None = None,
+    bind_to_existing: bool = True,
 ) -> ChannelMessage:
     if account.provider == CHANNEL_PROVIDER_TELEGRAM:
         return await send_telegram_message(
@@ -1739,6 +1817,7 @@ async def send_channel_outbound_message(
             external_chat_id=external_chat_id,
             text=text,
             bot_agent_link_id=bot_agent_link_id,
+            bind_to_existing=bind_to_existing,
         )
     if account.provider == CHANNEL_PROVIDER_DISCORD:
         return await send_discord_message(
@@ -1747,6 +1826,7 @@ async def send_channel_outbound_message(
             external_chat_id=external_chat_id,
             text=text,
             bot_agent_link_id=bot_agent_link_id,
+            bind_to_existing=bind_to_existing,
         )
     if account.provider == CHANNEL_PROVIDER_WHATSAPP:
         return await send_whatsapp_message(
@@ -1755,6 +1835,7 @@ async def send_channel_outbound_message(
             external_chat_id=external_chat_id,
             text=text,
             bot_agent_link_id=bot_agent_link_id,
+            bind_to_existing=bind_to_existing,
         )
     if account.provider == CHANNEL_PROVIDER_IMESSAGE:
         return await send_imessage_message(
@@ -1763,6 +1844,7 @@ async def send_channel_outbound_message(
             external_chat_id=external_chat_id,
             text=text,
             bot_agent_link_id=bot_agent_link_id,
+            bind_to_existing=bind_to_existing,
         )
     raise HTTPException(
         status_code=status.HTTP_501_NOT_IMPLEMENTED,
@@ -1798,6 +1880,7 @@ async def send_telegram_message(
     external_chat_id: str,
     text: str,
     bot_agent_link_id: UUID | None = None,
+    bind_to_existing: bool = True,
 ) -> ChannelMessage:
     _require_channel_provider(account, CHANNEL_PROVIDER_TELEGRAM)
     provider_message_id, payload = await _send_telegram_provider_payload(
@@ -1805,11 +1888,15 @@ async def send_telegram_message(
         external_chat_id=external_chat_id,
         text=text,
     )
-    binding = await find_binding(
-        db,
-        account=account,
-        external_chat_id=external_chat_id,
-        bot_agent_link_id=bot_agent_link_id,
+    binding = (
+        await find_binding(
+            db,
+            account=account,
+            external_chat_id=external_chat_id,
+            bot_agent_link_id=bot_agent_link_id,
+        )
+        if bind_to_existing
+        else None
     )
     return await _record_outbound_channel_message(
         db,
@@ -1895,6 +1982,7 @@ async def send_discord_message(
     external_chat_id: str,
     text: str,
     bot_agent_link_id: UUID | None = None,
+    bind_to_existing: bool = True,
 ) -> ChannelMessage:
     _require_channel_provider(account, CHANNEL_PROVIDER_DISCORD)
     provider_message_id, response_payload = await _send_discord_provider_payload(
@@ -1902,11 +1990,15 @@ async def send_discord_message(
         external_chat_id=external_chat_id,
         text=text,
     )
-    binding = await find_binding(
-        db,
-        account=account,
-        external_chat_id=external_chat_id,
-        bot_agent_link_id=bot_agent_link_id,
+    binding = (
+        await find_binding(
+            db,
+            account=account,
+            external_chat_id=external_chat_id,
+            bot_agent_link_id=bot_agent_link_id,
+        )
+        if bind_to_existing
+        else None
     )
     return await _record_outbound_channel_message(
         db,
@@ -2050,6 +2142,7 @@ async def send_whatsapp_message(
     external_chat_id: str,
     text: str,
     bot_agent_link_id: UUID | None = None,
+    bind_to_existing: bool = True,
 ) -> ChannelMessage:
     _require_channel_provider(account, CHANNEL_PROVIDER_WHATSAPP)
     provider_message_id, response_payload = await _send_whatsapp_provider_payload(
@@ -2057,11 +2150,15 @@ async def send_whatsapp_message(
         external_chat_id=external_chat_id,
         text=text,
     )
-    binding = await find_binding(
-        db,
-        account=account,
-        external_chat_id=external_chat_id,
-        bot_agent_link_id=bot_agent_link_id,
+    binding = (
+        await find_binding(
+            db,
+            account=account,
+            external_chat_id=external_chat_id,
+            bot_agent_link_id=bot_agent_link_id,
+        )
+        if bind_to_existing
+        else None
     )
     return await _record_outbound_channel_message(
         db,
@@ -2244,13 +2341,18 @@ async def send_imessage_message(
     external_chat_id: str,
     text: str,
     bot_agent_link_id: UUID | None = None,
+    bind_to_existing: bool = True,
 ) -> ChannelMessage:
     _require_channel_provider(account, CHANNEL_PROVIDER_IMESSAGE)
-    binding = await find_imessage_binding_for_send(
-        db,
-        account=account,
-        requested_chat_guid=external_chat_id,
-        bot_agent_link_id=bot_agent_link_id,
+    binding = (
+        await find_imessage_binding_for_send(
+            db,
+            account=account,
+            requested_chat_guid=external_chat_id,
+            bot_agent_link_id=bot_agent_link_id,
+        )
+        if bind_to_existing
+        else None
     )
     bound_chat_guid = binding.external_chat_id if binding is not None else external_chat_id
     provider_chat_guid = resolve_imessage_send_chat_guid(

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -962,8 +962,7 @@ async def send_pairing_command_reply(
     reply = pairing_reply_for_command(command, binding_result)
     reply_link_id = (
         binding_result.binding.bot_agent_link_id
-        if binding_result.binding is not None
-        and (binding_result.paired or binding_result.unpaired)
+        if binding_result.binding is not None and (binding_result.paired or binding_result.unpaired)
         else None
     )
     bind_reply_to_existing = reply_link_id is not None

--- a/backend/app/services/whatsapp_wabinary_tokens.py
+++ b/backend/app/services/whatsapp_wabinary_tokens.py
@@ -956,7 +956,7 @@ DOUBLE_BYTE_TOKENS: list[list[str]] = [
         "59",
         "Asia/Riyadh",
         "1177",
-        "test_recommended",
+        "test_sample",
         "057",
         "1612",
         "43",

--- a/backend/tests/e2e/test_channels_blackbox.py
+++ b/backend/tests/e2e/test_channels_blackbox.py
@@ -302,6 +302,7 @@ async def _pair_discord(
                 "channel_id": channel_id,
                 "guild_id": guild_id,
                 "content": f"/bot_pair {pair['code']}",
+                "author": {"id": f"discord-user-{run_id}"},
             },
         },
     )

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -27,6 +27,7 @@ from app.core.config import settings
 from app.core.database import get_session
 from app.main import app
 from app.models.channel import (
+    CHANNEL_STATUS_DISABLED,
     DELIVERY_STATUS_FAILED,
     MESSAGE_DIRECTION_INBOUND,
     MESSAGE_DIRECTION_OUTBOUND,
@@ -149,6 +150,39 @@ async def _create_user_with_channel_agent(
     return user, agent
 
 
+async def _create_admin_channel(
+    client: httpx.AsyncClient,
+    *,
+    target_clerk_id: str,
+    provider: str,
+    name: str,
+    visibility: str = "public",
+    provider_token: str | None = None,
+    config: dict[str, Any] | None = None,
+) -> httpx.Response:
+    admin_key = f"admin-{uuid4().hex}"
+    original_admin_key = settings.admin_api_key
+    settings.admin_api_key = admin_key
+    try:
+        payload: dict[str, Any] = {
+            "target_clerk_id": target_clerk_id,
+            "provider": provider,
+            "name": name,
+            "visibility": visibility,
+        }
+        if provider_token is not None:
+            payload["provider_token"] = provider_token
+        if config is not None:
+            payload["config"] = config
+        return await client.post(
+            "/api/admin/channels",
+            headers={"X-Admin-Key": admin_key},
+            json=payload,
+        )
+    finally:
+        settings.admin_api_key = original_admin_key
+
+
 class _FakeProviderResponse:
     def __init__(
         self,
@@ -255,6 +289,12 @@ def _reset_sequenced_provider_client(status_codes: list[int]) -> None:
     _SequencedProviderClient.status_codes = list(status_codes)
 
 
+def _clear_fake_provider_calls() -> None:
+    _FakeProviderClient.calls = []
+    _FailingProviderClient.calls = []
+    _SequencedProviderClient.calls = []
+
+
 class _MemoryFileStore:
     def __init__(self):
         self.data: dict[str, bytes] = {}
@@ -287,6 +327,7 @@ async def _create_paired_imessage_channel(
     chat_guid: str,
     webhook_message_guid: str = "imsg-test-message",
 ) -> dict[str, Any]:
+    sequenced_status_codes = list(_SequencedProviderClient.status_codes)
     created = (
         await client.post(
             "/api/channels",
@@ -326,6 +367,8 @@ async def _create_paired_imessage_channel(
             }
         },
     )
+    _SequencedProviderClient.status_codes = sequenced_status_codes
+    _clear_fake_provider_calls()
     return created
 
 
@@ -386,6 +429,7 @@ async def _pair_telegram_chat(
             },
         },
     )
+    _clear_fake_provider_calls()
 
 
 async def _create_paired_discord_channel(
@@ -562,27 +606,180 @@ async def test_user_created_channel_is_private_to_owner(
 
 
 @pytest.mark.asyncio
+async def test_channel_bot_pool_lists_public_bots_and_owned_private_bots(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+):
+    private = (
+        await client.post(
+            "/api/channels",
+            json={"provider": "telegram", "name": f"pool-private-{uuid4().hex}"},
+        )
+    ).json()
+    public = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider="telegram",
+        name=f"pool-public-{uuid4().hex}",
+    )
+    assert public.status_code == 201, public.text
+    public_body = public.json()
+    disabled_private = (
+        await client.post(
+            "/api/channels",
+            json={"provider": "telegram", "name": f"pool-disabled-{uuid4().hex}"},
+        )
+    ).json()
+    disabled_account = (
+        await db_session.execute(
+            select(ChannelAccount).where(ChannelAccount.id == UUID(disabled_private["id"]))
+        )
+    ).scalar_one()
+    disabled_account.status = CHANNEL_STATUS_DISABLED
+    await db_session.flush()
+    disabled_whatsapp = (
+        await client.post(
+            "/api/channels",
+            json={"provider": "whatsapp", "name": f"pool-disabled-wa-{uuid4().hex}"},
+        )
+    ).json()
+    disabled_whatsapp_account = (
+        await db_session.execute(
+            select(ChannelAccount).where(ChannelAccount.id == UUID(disabled_whatsapp["id"]))
+        )
+    ).scalar_one()
+    disabled_whatsapp_account.status = CHANNEL_STATUS_DISABLED
+    await db_session.flush()
+
+    pool = await client.get("/api/channels/bot-pool")
+    assert pool.status_code == 200
+    telegram = pool.json()["providers"]["telegram"]
+    pool_by_id = {item["id"]: item for item in telegram}
+    assert pool_by_id[private["id"]]["visibility"] == "private"
+    assert pool_by_id[private["id"]]["access"] == "owner"
+    assert pool_by_id[private["id"]]["capabilities"] == {
+        "link_agent": True,
+        "pair_chat": True,
+        "send_message": True,
+        "manage_account": True,
+        "sync_commands": True,
+    }
+    assert pool_by_id[public_body["id"]]["visibility"] == "public"
+    assert pool_by_id[public_body["id"]]["access"] == "public"
+    assert pool_by_id[public_body["id"]]["capabilities"] == {
+        "link_agent": True,
+        "pair_chat": True,
+        "send_message": True,
+        "manage_account": False,
+        "sync_commands": False,
+    }
+
+    other_user, _other_agent = await _create_user_with_channel_agent(
+        db_session,
+        label="pool-other",
+    )
+    async with _client_for_user(db_session, other_user) as other_client:
+        other_pool = await other_client.get("/api/channels/bot-pool")
+    assert other_pool.status_code == 200
+    other_telegram = other_pool.json()["providers"]["telegram"]
+    other_ids = {item["id"] for item in other_telegram}
+    assert public_body["id"] in other_ids
+    assert private["id"] not in other_ids
+    assert disabled_private["id"] not in pool_by_id
+    other_public = next(item for item in other_telegram if item["id"] == public_body["id"])
+    assert other_public["access"] == "public"
+
+    disabled_detail = await client.get(f"/api/channels/{disabled_private['id']}")
+    disabled_links = await client.get(f"/api/channels/{disabled_private['id']}/agent-links")
+    disabled_link_create = await client.post(
+        f"/api/channels/{disabled_private['id']}/agent-links",
+        json={},
+    )
+    disabled_pair = await client.post(
+        f"/api/channels/{disabled_private['id']}/pair-codes",
+        json={"ttl_seconds": 900},
+    )
+    disabled_send = await client.post(
+        f"/api/channels/{disabled_private['id']}/messages",
+        json={"external_chat_id": "12345", "text": "hello"},
+    )
+    disabled_whatsapp_credential = await client.post(
+        f"/api/channels/whatsapp/{disabled_whatsapp['id']}/tenant-creds",
+        json={},
+    )
+    disabled_whatsapp_auth_cert = await client.get(
+        f"/api/channels/whatsapp/{disabled_whatsapp['id']}/auth-cert"
+    )
+    assert disabled_detail.status_code == 200
+    assert disabled_links.status_code == 200
+    assert disabled_link_create.status_code == 404
+    assert disabled_pair.status_code == 404
+    assert disabled_send.status_code == 404
+    assert disabled_whatsapp_credential.status_code == 404
+    assert disabled_whatsapp_auth_cert.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_public_bot_account_is_admin_managed_even_for_seed_owner(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    channel_agent,
+    monkeypatch,
+):
+    created = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider="telegram",
+        name=f"public-owned-boundary-{uuid4().hex}",
+        provider_token="123456:telegram-secret",
+    )
+    assert created.status_code == 201, created.text
+    account_id = created.json()["id"]
+
+    _FakeProviderClient.calls = []
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+
+    sync = await client.post(f"/api/channels/{account_id}/commands/sync", json={})
+    delete = await client.delete(f"/api/channels/{account_id}")
+    link = await client.post(
+        f"/api/channels/{account_id}/agent-links",
+        json={"agent_id": str(channel_agent.id)},
+    )
+    pair = await client.post(
+        f"/api/channels/{account_id}/pair-codes",
+        json={"agent_id": str(channel_agent.id), "ttl_seconds": 900},
+    )
+
+    assert sync.status_code == 404
+    assert delete.status_code == 404
+    assert link.status_code == 201
+    assert link.json()["agent_id"] == str(channel_agent.id)
+    assert pair.status_code == 201
+    assert pair.json()["agent_id"] == str(channel_agent.id)
+    assert _FakeProviderClient.calls == []
+    account = (
+        await db_session.execute(
+            select(ChannelAccount).where(ChannelAccount.id == UUID(account_id))
+        )
+    ).scalar_one()
+    assert account.archived_at is None
+    assert account.visibility == "public"
+
+
+@pytest.mark.asyncio
 async def test_public_preset_channel_links_and_bindings_are_user_scoped(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user,
 ):
-    admin_key = f"admin-{uuid4().hex}"
-    original_admin_key = settings.admin_api_key
-    settings.admin_api_key = admin_key
-    try:
-        created = await client.post(
-            "/api/admin/channels",
-            headers={"X-Admin-Key": admin_key},
-            json={
-                "target_clerk_id": seed_user.clerk_id,
-                "provider": "telegram",
-                "name": f"public-telegram-{uuid4().hex}",
-                "visibility": "public",
-            },
-        )
-    finally:
-        settings.admin_api_key = original_admin_key
+    created = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider="telegram",
+        name=f"public-telegram-{uuid4().hex}",
+    )
     assert created.status_code == 201, created.text
     admin_body = created.json()
     account_id = UUID(admin_body["id"])
@@ -594,8 +791,17 @@ async def test_public_preset_channel_links_and_bindings_are_user_scoped(
     async with _client_for_user(db_session, user_a) as client_a:
         listed = await client_a.get("/api/channels")
         assert listed.status_code == 200
-        public_item = next(item for item in listed.json() if item["id"] == str(account_id))
+        assert all(item["id"] != str(account_id) for item in listed.json())
+
+        pool = await client_a.get("/api/channels/bot-pool")
+        assert pool.status_code == 200
+        public_item = next(
+            item
+            for item in pool.json()["providers"]["telegram"]
+            if item["id"] == str(account_id)
+        )
         assert public_item["visibility"] == "public"
+        assert public_item["access"] == "public"
 
         pair = await client_a.post(
             f"/api/channels/{account_id}/pair-codes",
@@ -689,27 +895,64 @@ async def test_public_preset_channel_links_and_bindings_are_user_scoped(
 
 
 @pytest.mark.asyncio
-async def test_group_pairing_can_only_be_changed_by_pairing_actor(
+async def test_public_whatsapp_bot_runtime_credentials_are_user_scoped(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user,
 ):
-    admin_key = f"admin-{uuid4().hex}"
-    original_admin_key = settings.admin_api_key
-    settings.admin_api_key = admin_key
-    try:
-        created = await client.post(
-            "/api/admin/channels",
-            headers={"X-Admin-Key": admin_key},
-            json={
-                "target_clerk_id": seed_user.clerk_id,
-                "provider": "telegram",
-                "name": f"public-group-telegram-{uuid4().hex}",
-                "visibility": "public",
-            },
+    created = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider="whatsapp",
+        name=f"public-whatsapp-{uuid4().hex}",
+        provider_token="wa-access-token",
+        config={"phone_number_id": "phone-public"},
+    )
+    assert created.status_code == 201, created.text
+    account_id = created.json()["id"]
+
+    user_a, agent_a = await _create_user_with_channel_agent(db_session, label="public-wa-a")
+    user_b, _agent_b = await _create_user_with_channel_agent(db_session, label="public-wa-b")
+
+    async with _client_for_user(db_session, user_a) as client_a:
+        auth_cert = await client_a.get(f"/api/channels/whatsapp/{account_id}/auth-cert")
+        credential = await client_a.post(
+            f"/api/channels/whatsapp/{account_id}/tenant-creds",
+            json={"agent_id": str(agent_a.id), "phone_user": "15551234567"},
         )
-    finally:
-        settings.admin_api_key = original_admin_key
+        listed_a = await client_a.get(f"/api/channels/whatsapp/{account_id}/tenant-creds")
+
+    assert auth_cert.status_code == 200
+    assert auth_cert.json()["ISSUER"] == "clawdi"
+    assert credential.status_code == 201, credential.text
+    assert credential.json()["agent_id"] == str(agent_a.id)
+    assert credential.json()["auth_cert"]["ISSUER"] == "clawdi"
+    assert len(listed_a.json()) == 1
+
+    async with _client_for_user(db_session, user_b) as client_b:
+        listed_b = await client_b.get(f"/api/channels/whatsapp/{account_id}/tenant-creds")
+        auth_cert_b = await client_b.get(f"/api/channels/whatsapp/{account_id}/auth-cert")
+
+    assert listed_b.status_code == 200
+    assert listed_b.json() == []
+    assert auth_cert_b.status_code == 200
+    assert auth_cert_b.json()["PUBLIC_KEY"] == auth_cert.json()["PUBLIC_KEY"]
+
+
+@pytest.mark.asyncio
+async def test_group_pairing_can_only_be_changed_by_pairing_actor(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch,
+):
+    created = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider="telegram",
+        name=f"public-group-telegram-{uuid4().hex}",
+        provider_token="123456:telegram-secret",
+    )
     assert created.status_code == 201, created.text
     channel = created.json()
     account_id = UUID(channel["id"])
@@ -729,8 +972,11 @@ async def test_group_pairing_can_only_be_changed_by_pairing_actor(
         pair_b = await client_b.post(
             f"/api/channels/{account_id}/pair-codes",
             json={"agent_id": str(agent_b.id), "ttl_seconds": 900},
-        )
+    )
     assert pair_b.status_code == 201
+
+    _reset_fake_provider_client({"ok": True, "result": {"message_id": 8100}})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
 
     def group_command(message_id: int, text: str, actor_id: int) -> dict[str, Any]:
         return {
@@ -773,6 +1019,21 @@ async def test_group_pairing_can_only_be_changed_by_pairing_actor(
     await db_session.refresh(binding)
     assert binding.status == "active"
     assert binding.user_id == user_a.id
+    bob_unpair_reply = (
+        await db_session.execute(
+            select(ChannelMessage)
+                .where(
+                    ChannelMessage.account_id == account_id,
+                    ChannelMessage.direction == MESSAGE_DIRECTION_OUTBOUND,
+                    ChannelMessage.text
+                    == "Only the user who paired this chat can change its pairing.",
+            )
+            .order_by(ChannelMessage.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one()
+    assert bob_unpair_reply.binding_id is None
+    assert bob_unpair_reply.bot_agent_link_id is None
 
     bob_takeover = await client.post(
         f"/api/channels/telegram/{account_id}/webhook",
@@ -784,6 +1045,21 @@ async def test_group_pairing_can_only_be_changed_by_pairing_actor(
     await db_session.refresh(binding)
     assert binding.status == "active"
     assert binding.user_id == user_a.id
+    bob_takeover_reply = (
+        await db_session.execute(
+            select(ChannelMessage)
+                .where(
+                    ChannelMessage.account_id == account_id,
+                    ChannelMessage.direction == MESSAGE_DIRECTION_OUTBOUND,
+                    ChannelMessage.text
+                    == "Only the user who paired this chat can change its pairing.",
+            )
+            .order_by(ChannelMessage.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one()
+    assert bob_takeover_reply.binding_id is None
+    assert bob_takeover_reply.bot_agent_link_id is None
 
     pair_code_b = (
         await db_session.execute(
@@ -996,7 +1272,7 @@ async def test_telegram_repair_moves_chat_to_new_agent_link(
             "/api/channels",
             json={
                 "provider": "telegram",
-                "name": "telegram-shared-bot",
+                "name": "telegram-public-bot",
                 "agent_id": str(channel_agent.id),
             },
         )
@@ -1994,6 +2270,67 @@ async def test_telegram_set_my_commands_fans_out_to_bound_chats(
 
 
 @pytest.mark.asyncio
+async def test_telegram_pairing_replays_stored_broad_scope_commands(
+    client: httpx.AsyncClient,
+    monkeypatch,
+):
+    _reset_fake_provider_client({"ok": True, "result": True})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    monkeypatch.setattr(
+        "app.routes.channel_routers.telegram.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+    created = (
+        await client.post(
+            "/api/channels",
+            json={
+                "provider": "telegram",
+                "name": "telegram-command-replay-on-pair",
+                "provider_token": "123456:telegram-secret",
+            },
+        )
+    ).json()
+    commands = [{"command": "welcome", "description": "Say hi"}]
+    stored = await client.post(
+        f"/api/channels/telegram/bot/{created['agent_token']}/setMyCommands",
+        json={"commands": commands},
+    )
+    assert stored.status_code == 200
+    _reset_fake_provider_client({"ok": True, "result": True})
+
+    pair = (
+        await client.post(
+            f"/api/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+    paired = await client.post(
+        f"/api/channels/telegram/{created['id']}/webhook",
+        headers={"x-telegram-bot-api-secret-token": created["webhook_secret"]},
+        json={
+            "update_id": 51,
+            "message": {
+                "message_id": 51,
+                "text": f"/bot_pair {pair['code']}",
+                "chat": {"id": 777, "type": "private"},
+                "from": {"id": 777, "is_bot": False},
+            },
+        },
+    )
+
+    assert paired.status_code == 200
+    assert paired.json()["paired"] is True
+    command_calls = [
+        call for call in _FakeProviderClient.calls if call["url"].endswith("/setMyCommands")
+    ]
+    assert len(command_calls) == 1
+    assert command_calls[0]["json"] == {
+        "commands": commands,
+        "scope": {"type": "chat", "chat_id": "777"},
+    }
+
+
+@pytest.mark.asyncio
 async def test_telegram_generic_bot_api_proxies_only_bound_chats(
     client: httpx.AsyncClient,
     monkeypatch,
@@ -2945,6 +3282,70 @@ async def test_discord_global_commands_fan_out_only_to_uncontested_guilds(
 
 
 @pytest.mark.asyncio
+async def test_discord_pairing_replays_stored_global_commands_to_new_guild(
+    client: httpx.AsyncClient,
+    monkeypatch,
+):
+    _reset_fake_provider_client({"id": "provider-ok"})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    monkeypatch.setattr(
+        "app.routes.channel_routers.shared.httpx.AsyncClient",
+        _FakeProviderClient,
+    )
+    created = (
+        await client.post(
+            "/api/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-command-replay-on-pair",
+                "provider_token": "discord-provider-token",
+                "config": {"application_id": "app-replay"},
+            },
+        )
+    ).json()
+    commands = [{"name": "deploy", "description": "Deploy"}]
+    stored = await client.put(
+        "/api/channels/discord/v10/applications/app-replay/commands",
+        headers={"Authorization": f"Bot {created['agent_token']}"},
+        json=commands,
+    )
+    assert stored.status_code == 200
+    _reset_fake_provider_client({"id": "provider-ok"})
+
+    pair = (
+        await client.post(
+            f"/api/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+    paired = await client.post(
+        f"/api/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "msg-pair-replay",
+                "channel_id": "chan-replay",
+                "guild_id": "guild-replay",
+                "content": f"/bot_pair {pair['code']}",
+                "author": {"id": "discord-replay-user"},
+            },
+        },
+    )
+
+    assert paired.status_code == 200
+    assert paired.json()["paired"] is True
+    command_calls = [
+        call
+        for call in _FakeProviderClient.calls
+        if call.get("method") == "PUT"
+        and call["url"].endswith("/applications/app-replay/guilds/guild-replay/commands")
+    ]
+    assert len(command_calls) == 1
+    assert command_calls[0]["json"][0]["name"] == "deploy"
+
+
+@pytest.mark.asyncio
 async def test_discord_interaction_callback_and_followup_require_recorded_token(
     client: httpx.AsyncClient,
     monkeypatch,
@@ -3212,7 +3613,7 @@ async def test_whatsapp_graph_agent_send_uses_agent_token_and_binding(
     monkeypatch,
 ):
     _FakeProviderClient.calls = []
-    _FakeProviderClient.response_payload = {"messages": [{"id": "wamid.agent.sent"}]}
+    _FakeProviderClient.response_payload = {"messages": [{"id": "wamid.agent.pair-reply"}]}
     monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
     created = (
         await client.post(
@@ -3254,6 +3655,7 @@ async def test_whatsapp_graph_agent_send_uses_agent_token_and_binding(
             ]
         },
     )
+    _reset_fake_provider_client({"messages": [{"id": "wamid.agent.sent"}]})
 
     sent = await client.post(
         "/api/channels/whatsapp/graph/v20.0/phone-agent/messages",
@@ -3283,7 +3685,7 @@ async def test_bluebubbles_agent_send_uses_agent_token_and_binding(
     monkeypatch,
 ):
     _FakeProviderClient.calls = []
-    _FakeProviderClient.response_payload = {"data": {"guid": "imsg-agent-sent"}}
+    _FakeProviderClient.response_payload = {"data": {"guid": "imsg-pair-reply"}}
     monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
     created = (
         await client.post(
@@ -3313,6 +3715,7 @@ async def test_bluebubbles_agent_send_uses_agent_token_and_binding(
             }
         },
     )
+    _reset_fake_provider_client({"data": {"guid": "imsg-agent-sent"}})
 
     sent = await client.post(
         "/api/channels/imessage/bluebubbles/v1/message/text",
@@ -3338,7 +3741,7 @@ async def test_bluebubbles_agent_send_resolves_any_service_binding(
     monkeypatch,
 ):
     _FakeProviderClient.calls = []
-    _FakeProviderClient.response_payload = {"data": {"guid": "imsg-any-service-sent"}}
+    _FakeProviderClient.response_payload = {"data": {"guid": "imsg-any-pair-reply"}}
     monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
     created = (
         await client.post(
@@ -3368,6 +3771,7 @@ async def test_bluebubbles_agent_send_resolves_any_service_binding(
             }
         },
     )
+    _reset_fake_provider_client({"data": {"guid": "imsg-any-service-sent"}})
 
     sent = await client.post(
         "/api/channels/imessage/bluebubbles/v1/message/text",
@@ -4348,6 +4752,213 @@ async def test_telegram_webhook_pair_code_creates_binding(client: httpx.AsyncCli
 
 
 @pytest.mark.asyncio
+async def test_telegram_webhook_pair_code_sends_user_reply(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_fake_provider_client({"ok": True, "result": {"message_id": 100}})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    created = (
+        await client.post(
+            "/api/channels",
+            json={
+                "provider": "telegram",
+                "name": "telegram-pair-reply",
+                "provider_token": "123456:telegram-secret",
+            },
+        )
+    ).json()
+    pair = (
+        await client.post(
+            f"/api/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+
+    webhook = await client.post(
+        f"/api/channels/telegram/{created['id']}/webhook",
+        headers={"x-telegram-bot-api-secret-token": created["webhook_secret"]},
+        json={
+            "update_id": 1,
+            "message": {
+                "message_id": 42,
+                "text": f"/bot_pair {pair['code']}",
+                "chat": {"id": 987654321, "type": "private", "username": "paco"},
+                "from": {"id": 987654321, "is_bot": False, "username": "paco"},
+            },
+        },
+    )
+
+    assert webhook.status_code == 200
+    assert webhook.json()["paired"] is True
+    assert _FakeProviderClient.calls[0]["url"].endswith(
+        "/bot123456:telegram-secret/sendMessage"
+    )
+    assert _FakeProviderClient.calls[0]["json"] == {
+        "chat_id": "987654321",
+        "text": "Paired! This chat is now connected to your agent.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_telegram_webhook_pair_command_sends_failure_replies(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_fake_provider_client({"ok": True, "result": {"message_id": 101}})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    created = (
+        await client.post(
+            "/api/channels",
+            json={
+                "provider": "telegram",
+                "name": "telegram-pair-failure-replies",
+                "provider_token": "123456:telegram-secret",
+            },
+        )
+    ).json()
+
+    missing = await client.post(
+        f"/api/channels/telegram/{created['id']}/webhook",
+        headers={"x-telegram-bot-api-secret-token": created["webhook_secret"]},
+        json={
+            "update_id": 1,
+            "message": {
+                "message_id": 43,
+                "text": "/bot_pair",
+                "chat": {"id": 987654322, "type": "private"},
+                "from": {"id": 987654322, "is_bot": False},
+            },
+        },
+    )
+    invalid = await client.post(
+        f"/api/channels/telegram/{created['id']}/webhook",
+        headers={"x-telegram-bot-api-secret-token": created["webhook_secret"]},
+        json={
+            "update_id": 2,
+            "message": {
+                "message_id": 44,
+                "text": "/bot_pair PAIRDOESNOTEXIST",
+                "chat": {"id": 987654322, "type": "private"},
+                "from": {"id": 987654322, "is_bot": False},
+            },
+        },
+    )
+
+    assert missing.status_code == 200
+    assert invalid.status_code == 200
+    assert [call["json"]["text"] for call in _FakeProviderClient.calls] == [
+        "Usage: /bot_pair <code>",
+        "Pairing failed: invalid.",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_telegram_webhook_unpair_sends_user_reply(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_fake_provider_client({"ok": True, "result": {"message_id": 102}})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    created = (
+        await client.post(
+            "/api/channels",
+            json={
+                "provider": "telegram",
+                "name": "telegram-unpair-reply",
+                "provider_token": "123456:telegram-secret",
+            },
+        )
+    ).json()
+    pair = (
+        await client.post(
+            f"/api/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+
+    await client.post(
+        f"/api/channels/telegram/{created['id']}/webhook",
+        headers={"x-telegram-bot-api-secret-token": created["webhook_secret"]},
+        json={
+            "update_id": 1,
+            "message": {
+                "message_id": 45,
+                "text": f"/bot_pair {pair['code']}",
+                "chat": {"id": 987654323, "type": "private"},
+                "from": {"id": 987654323, "is_bot": False},
+            },
+        },
+    )
+    unpaired = await client.post(
+        f"/api/channels/telegram/{created['id']}/webhook",
+        headers={"x-telegram-bot-api-secret-token": created["webhook_secret"]},
+        json={
+            "update_id": 2,
+            "message": {
+                "message_id": 46,
+                "text": "/bot_unpair",
+                "chat": {"id": 987654323, "type": "private"},
+                "from": {"id": 987654323, "is_bot": False},
+            },
+        },
+    )
+
+    assert unpaired.status_code == 200
+    assert unpaired.json()["unpaired"] is True
+    assert [call["json"]["text"] for call in _FakeProviderClient.calls] == [
+        "Paired! This chat is now connected to your agent.",
+        "Unpaired. This chat is no longer connected to an agent.",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_telegram_webhook_pair_reply_failure_does_not_roll_back_binding(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _FailingProviderClient.calls = []
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FailingProviderClient)
+    created = (
+        await client.post(
+            "/api/channels",
+            json={
+                "provider": "telegram",
+                "name": "telegram-pair-reply-fails",
+                "provider_token": "123456:telegram-secret",
+            },
+        )
+    ).json()
+    pair = (
+        await client.post(
+            f"/api/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+
+    webhook = await client.post(
+        f"/api/channels/telegram/{created['id']}/webhook",
+        headers={"x-telegram-bot-api-secret-token": created["webhook_secret"]},
+        json={
+            "update_id": 1,
+            "message": {
+                "message_id": 47,
+                "text": f"/bot_pair {pair['code']}",
+                "chat": {"id": 987654324, "type": "private"},
+                "from": {"id": 987654324, "is_bot": False},
+            },
+        },
+    )
+
+    assert webhook.status_code == 200
+    assert webhook.json()["paired"] is True
+    bindings = await client.get(f"/api/channels/{created['id']}/bindings")
+    assert bindings.status_code == 200
+    assert bindings.json()[0]["external_chat_id"] == "987654324"
+    assert len(_FailingProviderClient.calls) == 1
+
+
+@pytest.mark.asyncio
 async def test_telegram_webhook_start_deep_link_pair_code_creates_binding(
     client: httpx.AsyncClient,
 ):
@@ -4958,6 +5569,62 @@ async def test_discord_webhook_pair_code_creates_binding(client: httpx.AsyncClie
 
 
 @pytest.mark.asyncio
+async def test_discord_message_pair_code_sends_user_reply(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_fake_provider_client({"id": "discord-pair-reply"})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    created = (
+        await client.post(
+            "/api/channels",
+            json={
+                "provider": "discord",
+                "name": "discord-message-pair-reply",
+                "provider_token": "discord-provider-token",
+            },
+        )
+    ).json()
+    pair = (
+        await client.post(
+            f"/api/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+
+    webhook = await client.post(
+        f"/api/channels/discord/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "t": "MESSAGE_CREATE",
+            "d": {
+                "id": "msg-1",
+                "channel_id": "chan-1",
+                "guild_id": "guild-1",
+                "content": f"/bot_pair {pair['code']}",
+                "author": {"id": "discord-msg-pair-user"},
+                "channel": {"id": "chan-1", "name": "ops"},
+            },
+        },
+    )
+
+    assert webhook.status_code == 200
+    assert webhook.json()["paired"] is True
+    reply_call = next(
+        call
+        for call in _FakeProviderClient.calls
+        if call["url"].endswith("/channels/chan-1/messages")
+    )
+    assert reply_call["headers"]["Authorization"] == (
+        "Bot discord-provider-token"
+    )
+    assert reply_call["json"] == {
+        "content": "Paired! This chat is now connected to your agent.",
+        "allowed_mentions": {"parse": []},
+    }
+
+
+@pytest.mark.asyncio
 async def test_discord_interaction_unpair_archives_binding(client: httpx.AsyncClient):
     created = (
         await client.post(
@@ -5213,6 +5880,58 @@ async def test_imessage_webhook_pair_code_creates_binding(client: httpx.AsyncCli
 
 
 @pytest.mark.asyncio
+async def test_imessage_webhook_pair_code_sends_user_reply(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_fake_provider_client({"data": {"guid": "imsg-pair-reply"}})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    created = (
+        await client.post(
+            "/api/channels",
+            json={
+                "provider": "imessage",
+                "name": "imessage-pair-reply",
+                "provider_token": "bb-password",
+                "config": {"server_url": "https://bluebubbles.example"},
+            },
+        )
+    ).json()
+    pair = (
+        await client.post(
+            f"/api/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+
+    webhook = await client.post(
+        f"/api/channels/imessage/{created['id']}/webhook",
+        params={"secret": created["webhook_secret"]},
+        json={
+            "type": "new-message",
+            "data": {
+                "guid": "imsg-1",
+                "text": f"/bot_pair {pair['code']}",
+                "chats": [{"guid": "iMessage;-;+15551234567", "displayName": "Ops"}],
+            },
+        },
+    )
+
+    assert webhook.status_code == 200
+    assert webhook.json()["paired"] is True
+    assert _FakeProviderClient.calls[0]["url"] == (
+        "https://bluebubbles.example/api/v1/message/text"
+    )
+    assert _FakeProviderClient.calls[0]["params"] == {"password": "bb-password"}
+    assert _FakeProviderClient.calls[0]["json"] == {
+        "chatGuid": "iMessage;-;+15551234567",
+        "message": "Paired! This chat is now connected to your agent.",
+        "text": "Paired! This chat is now connected to your agent.",
+        "method": "private-api",
+    }
+
+
+@pytest.mark.asyncio
 async def test_whatsapp_webhook_pair_code_creates_binding(client: httpx.AsyncClient):
     created = (
         await client.post(
@@ -5273,6 +5992,66 @@ async def test_whatsapp_webhook_pair_code_creates_binding(client: httpx.AsyncCli
     bindings = await client.get(f"/api/channels/{created['id']}/bindings")
     assert bindings.json()[0]["external_chat_id"] == "15551234567"
     assert bindings.json()[0]["external_chat_name"] == "Ops Phone"
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_webhook_pair_code_sends_user_reply(
+    client: httpx.AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _reset_fake_provider_client({"messages": [{"id": "wamid.pair-reply"}]})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    created = (
+        await client.post(
+            "/api/channels",
+            json={
+                "provider": "whatsapp",
+                "name": "wa-pair-reply",
+                "provider_token": "wa-access-token",
+                "config": {"phone_number_id": "phone-1"},
+            },
+        )
+    ).json()
+    pair = (
+        await client.post(
+            f"/api/channels/{created['id']}/pair-codes",
+            json={"ttl_seconds": 900},
+        )
+    ).json()
+
+    webhook = await client.post(
+        f"/api/channels/whatsapp/{created['id']}/webhook",
+        headers={"x-clawdi-channel-secret": created["webhook_secret"]},
+        json={
+            "entry": [
+                {
+                    "changes": [
+                        {
+                            "value": {
+                                "messages": [
+                                    {
+                                        "id": "wamid.1",
+                                        "from": "15551234567",
+                                        "text": {"body": f"/bot_pair {pair['code']}"},
+                                    }
+                                ],
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+    )
+
+    assert webhook.status_code == 200
+    assert webhook.json()["paired"] is True
+    assert _FakeProviderClient.calls[0]["url"].endswith("/phone-1/messages")
+    assert _FakeProviderClient.calls[0]["headers"]["Authorization"] == "Bearer wa-access-token"
+    assert _FakeProviderClient.calls[0]["json"]["to"] == "15551234567"
+    assert (
+        _FakeProviderClient.calls[0]["json"]["text"]["body"]
+        == "Paired! This chat is now connected to your agent."
+    )
 
 
 @pytest.mark.asyncio

--- a/docs/designs/channel-runtime-manifest.md
+++ b/docs/designs/channel-runtime-manifest.md
@@ -32,6 +32,12 @@ Add a `clawdi.runtime.yaml` manifest with a `channels` section. The manifest is
 the user CLI surface for channel runtime configuration. It composes existing
 user APIs; it does not add admin behavior to the CLI.
 
+The runtime manifest is not a second channel control plane. It does not own
+provider webhooks, pair-code claiming, bindings, command replies, provider
+protocol state, or worker queues. Those remain in Clawdi-native Channels. The
+manifest only reconciles user intent into channel accounts, bot-agent links,
+pair codes, and local runtime outputs.
+
 The old `msg-router` process and env shape are compatibility inputs only. The
 source of truth is Clawdi-native channel state:
 
@@ -50,6 +56,10 @@ source of truth is Clawdi-native channel state:
 - Private bots are created by the user through `/api/channels`.
 - One external chat session still routes to exactly one active bot-agent link.
 - A bot can link to many agents, and one agent can link to many bots.
+- Local runtime outputs must be written under explicit manifest output paths
+  with private permissions. E2E tests should run with isolated `HOME` and
+  `CLAWDI_HOME`; hosted-runtime tests should prefer an isolated Docker
+  container home instead of the developer's host `~/.clawdi`.
 - Each bot-agent link owns its own agent SDK token.
 - Provider secrets are read from env or a future secret reference, never stored
   inline in the manifest.
@@ -126,17 +136,22 @@ outputs:
 
 1. Parse and validate the manifest.
 2. Resolve all provider token and secret env refs.
-3. List accessible channels through `GET /api/channels`.
-4. For `account.id`, fetch and validate the channel account.
-5. For `account.private`, reuse an existing private channel by
+3. List caller-owned private channels through `GET /api/channels` when the
+   manifest needs to create or reuse a private bot.
+4. For provider selection UX, optionally read `GET /api/channels/bot-pool` so
+   the user or hosted runtime can choose among owned private and public bots
+   without hardcoding ids. Selection should use `capabilities` instead of
+   inferring permissions from `visibility`.
+5. For `account.id`, fetch and validate the channel account.
+6. For `account.private`, reuse an existing private channel by
    `(provider, name)` or create it through `POST /api/channels`.
-6. List the caller's links for the account.
-7. Reuse an existing link by `(account, agent_id)` or create one through
+7. List the caller's links for the account.
+8. Reuse an existing link by `(account, agent_id)` or create one through
    `POST /api/channels/{account_id}/agent-links`.
-8. Rotate only when requested by the manifest or CLI flag.
-9. Create pair codes when requested.
-10. Sync provider commands when requested.
-11. Materialize runtime outputs.
+9. Rotate only when requested by the manifest or CLI flag.
+10. Create pair codes when requested.
+11. Sync provider commands when requested.
+12. Materialize runtime outputs.
 
 Apply is idempotent except for explicitly requested one-time values:
 
@@ -309,7 +324,7 @@ Apply should call:
 - `POST /api/channels/whatsapp/{account_id}/tenant-creds` to mint or reuse a
   link-scoped credential.
 - `GET /api/channels/whatsapp/{account_id}/auth-cert` when the runtime needs
-  server auth material.
+  shared account public auth material.
 
 It should write the Baileys auth state into the requested credential directory
 with private permissions and emit:
@@ -331,7 +346,7 @@ clawdi runtime apply -f clawdi.runtime.yaml --dry-run --json
 clawdi runtime status -f clawdi.runtime.yaml --json
 ```
 
-Recommended command boundaries:
+Command boundaries:
 
 | Command | Side effects |
 | --- | --- |
@@ -347,6 +362,7 @@ Do not add admin subcommands under `runtime`.
 The CLI should use only existing user APIs:
 
 - `GET /api/channels`
+- `GET /api/channels/bot-pool`
 - `POST /api/channels`
 - `GET /api/channels/{account_id}`
 - `GET /api/channels/{account_id}/agent-links`
@@ -359,6 +375,11 @@ The CLI should use only existing user APIs:
 - `GET /api/channels/whatsapp/{account_id}/auth-cert`
 
 No admin endpoint is needed for user runtime setup.
+
+Hosted deployment code should follow the same boundary. It may invoke the CLI
+inside the runtime or call these user APIs directly before launch, but it should
+not store its own pair-code state, implement provider webhooks, or recreate the
+old `msg-router` tenant router.
 
 ## Compatibility Mapping
 

--- a/docs/designs/channel-runtime-manifest.md
+++ b/docs/designs/channel-runtime-manifest.md
@@ -5,8 +5,9 @@ Date: 2026-06-08
 
 ## Current State
 
-The CLI does not currently have first-class runtime manifest support for the
-old `msg-router` configuration shape.
+The CLI now has baseline runtime manifest support for Clawdi-native channels.
+It reconciles user-facing channel state through ordinary authenticated APIs and
+materializes agent-facing SDK config into explicit local runtime outputs.
 
 What exists today:
 
@@ -16,15 +17,20 @@ What exists today:
   process.
 - `clawdi ai-provider apply ...` materializes AI Provider config into selected
   agent runtimes.
+- `clawdi runtime plan/status/apply` reads `clawdi.runtime.yaml`, creates or
+  reuses private channel accounts, links accessible bots to agents, emits pair
+  codes, and writes dotenv/WhatsApp Baileys runtime outputs with private file
+  permissions.
 
-What is missing:
+Still intentionally out of scope for this baseline:
 
-- A declarative file that creates or reuses channel accounts, links them to
-  agents, emits pair codes, and materializes the agent-facing SDK config that
-  replaces old `msg-router` env.
-- A safe strategy for one-time agent SDK tokens.
-- Runtime output adapters beyond the implemented dotenv and WhatsApp Baileys
-  credential baseline.
+- Admin/public bot publishing from the CLI.
+- Provider webhook ownership, pair-code claiming, bindings, command replies,
+  provider protocol state, and worker queues. Those remain backend-owned.
+- Runtime output adapters beyond dotenv and the implemented WhatsApp Baileys
+  credential output.
+- OpenClaw/Hermes target-native adapters. They should be added as explicit
+  future projections instead of overloading the dotenv baseline.
 
 ## Decision
 

--- a/docs/designs/native-channels-product-model.md
+++ b/docs/designs/native-channels-product-model.md
@@ -31,6 +31,9 @@ provider protocol requires them, such as the WhatsApp Web Baileys sidecar.
 | Provider | The external network family: Telegram, Discord, WhatsApp, or iMessage/BlueBubbles. | `ChannelAccount.provider` |
 | External bot | A concrete external bot identity or provider endpoint, such as one Telegram bot token, one Discord application, one WhatsApp phone identity, or one BlueBubbles server. | `channel_accounts` |
 | Visibility | Whether an external bot is private to its owner or available as a Clawdi-managed public bot. | `ChannelAccount.visibility` |
+| Bot access | The caller's effective relationship to a selectable bot account: `owner` for caller-owned private bots, `public` for Clawdi-managed public bots. | `/api/channels/bot-pool` response |
+| Bot capabilities | The caller's allowed actions for a selectable bot account, such as link, pair, send, manage account, or sync commands. | `/api/channels/bot-pool` response |
+| Bot pool | The authenticated user's selectable bot candidates: owned private bots and active Clawdi-managed public bots. This is a read-only view, not a separate state table. | `/api/channels/bot-pool` |
 | Bot-agent link | A user's authorization edge from one external bot to one Clawdi agent. This is the unit that owns the mock provider SDK token. | `channel_bot_agent_links` |
 | Agent SDK token | The token an agent process uses when it calls a Telegram Bot API, Discord REST/Gateway, WhatsApp Graph/Baileys, or BlueBubbles-compatible endpoint hosted by Clawdi. Tokens are scoped to one bot-agent link. | `ChannelBotAgentLink.agent_token_hash` |
 | External chat | The provider conversation id: Telegram chat id, Discord guild/channel route id, WhatsApp JID, or iMessage chat GUID. | `ChannelBinding.external_chat_id` |
@@ -126,7 +129,8 @@ Public bots:
 - Stored as `visibility = public`.
 - Visible to authenticated users for linking and pairing.
 - Provider credentials, webhook secret rotation, archive, and provider-wide
-  command sync remain admin/owner operations.
+  command sync remain admin operations. The backing `user_id` is not product
+  ownership and does not grant mutable user API access.
 - User-created child state is still owned by the requesting user:
   `channel_bot_agent_links`, `channel_pair_codes`, `channel_bindings`,
   `channel_messages`, `channel_deliveries`, attachments, scheduled messages,
@@ -134,6 +138,37 @@ Public bots:
 
 This means a public bot is shared infrastructure, but each user's route and
 agent token state is private to that user.
+
+Public and private bots have the same user-facing usage surface once the caller
+can access the account. The difference is account management, not runtime use:
+
+| Capability | Private user bot | Public Clawdi-managed bot |
+| --- | --- | --- |
+| List/read account | Owner only | Every authenticated user when active |
+| Create bot-agent link | Owner only | Any authenticated user, scoped to that user |
+| Rotate link token | Caller-owned links only | Caller-owned links only |
+| Create pair code | Caller-owned link only | Caller-owned link only |
+| Pair/unpair external chat | Actor-scoped shared state machine | Actor-scoped shared state machine |
+| List bindings/messages/send | Caller-owned child state only | Caller-owned child state only |
+| WhatsApp tenant credentials/auth cert | Caller-owned child state plus shared account cert | Caller-owned child state plus shared account cert |
+| Delete account | Owner through user API | Admin API only |
+| Provider token/config/webhook secret | Owner/admin for private managed accounts | Admin API only |
+| Provider-wide command sync | Owner through user API | Admin API only |
+
+Bot pool:
+
+- `GET /api/channels/bot-pool` returns the user's selectable bot candidates
+  grouped by provider.
+- Owned private bots appear only for their owner.
+- Only active bots appear in the selectable pool. Disabled private bots remain
+  readable/manageable by their owner, but they are not runtime candidates and
+  cannot create new links, pair codes, tokens, sends, or runtime credentials.
+- Active public bots appear for every authenticated user.
+- Each item includes `access` and `capabilities`. The current access values are
+  `owner` and `public`. UI and hosted runtime code should prefer capabilities
+  over inferring behavior from `visibility`.
+- The pool does not grant ownership. Public bot provider credentials, webhook
+  secrets, account config, archive, and command sync remain admin-managed.
 
 ## Session And Pairing Model
 
@@ -158,6 +193,19 @@ Pair flow:
 6. The backend claims the pair code and creates or updates the active binding.
 7. The binding stores the target link, Clawdi user owner, external chat id, and
    external actor id.
+8. The provider adapter sends a best-effort visible reply to the same external
+   chat, such as `Paired! This chat is now connected to your agent.`.
+9. If the provider has persistent bot command menus, the adapter replays the
+   link's stored broad-scope command state onto the newly paired chat. Telegram
+   replays broad `setMyCommands` scopes to a per-chat scope. Discord replays
+   stored global application commands to the newly paired guild when the guild
+   is uncontested.
+
+The visible reply is not part of the database transaction that claims the pair
+code. If the provider send fails, the claimed binding remains valid and the
+webhook still succeeds. This prevents a transient provider outage from rolling
+back a pairing operation that was already accepted by Clawdi. Command replay is
+also best-effort and must not roll back the binding.
 
 Unpair flow:
 
@@ -166,6 +214,7 @@ Unpair flow:
 3. The backend verifies the command actor matches
    `ChannelBinding.paired_external_user_id`.
 4. The active binding is archived.
+5. The provider adapter sends a best-effort visible unpair or failure reply.
 
 Pair codes are not consumed when actor authorization fails.
 
@@ -175,7 +224,7 @@ Pairing control is actor-scoped, not just chat-scoped.
 
 The backend must prevent this attack:
 
-1. Alice pairs a shared public bot in a group chat to Alice's agent.
+1. Alice pairs a public bot in a group chat to Alice's agent.
 2. Bob is another group participant.
 3. Bob sends `/bot_unpair`.
 4. Bob sends `/bot_pair <bob-code>`.
@@ -293,25 +342,46 @@ Outbound sends:
 
 ## API Boundary
 
+Repository and service ownership:
+
+| Owner | Responsibility |
+| --- | --- |
+| `clawdi` repo | Native channel tables, user/admin channel APIs, provider webhooks, pair/unpair state machine, visible command replies, provider protocol adapters, workers, agent SDK emulation, and CLI/runtime channel materialization. |
+| Hosted service / monorepo | Deployment profile selection, feature flags, hosted runtime orchestration, and calls into `clawdi` native channel APIs to create or reuse accounts, links, pair codes, and runtime manifests. |
+
+The hosted service must not duplicate channel bindings, pair-code claiming,
+provider webhook handlers, provider protocol state, or `/bot_pair` behavior.
+Those are product-state concerns owned by `clawdi` native Channels. Hosted
+deployment code may pass a Clawdi auth token and selected channel intent into a
+runtime, or call user-facing channel APIs before launch, but the canonical
+channel state remains in the native channel backend.
+
 User-facing control plane:
 
 | API | Scope |
 | --- | --- |
-| `GET /api/channels` | Lists owned private bots and accessible public bots. |
+| `GET /api/channels` | Lists caller-owned private bots only. Use bot-pool for selectable public bots. |
+| `GET /api/channels/bot-pool` | Lists selectable bot candidates grouped by provider, including caller access and capabilities. |
 | `POST /api/channels` | Creates private bots only. |
 | `GET /api/channels/{id}` | Reads an owned private bot or accessible public bot. |
-| `POST /api/channels/{id}/agent-links` | Creates a user-owned link from an accessible bot to one of the user's agents. |
+| `POST /api/channels/{id}/agent-links` | Creates a user-owned link from an active accessible bot to one of the user's agents. |
 | `GET /api/channels/{id}/agent-links` | Lists only the caller's links. |
 | `POST /api/channels/{id}/agent-links/{link_id}/token` | Rotates only the caller's link token. |
-| `POST /api/channels/{id}/pair-codes` | Creates a one-time code for one caller-owned link. |
+| `POST /api/channels/{id}/pair-codes` | Creates a one-time code for one caller-owned link on an active accessible bot. |
 | `GET /api/channels/{id}/bindings` | Lists only the caller's active bindings. |
-| `POST /api/channels/{id}/messages` | Sends only through the caller's active binding. |
+| `POST /api/channels/{id}/messages` | Sends only through the caller's active binding on an active accessible bot. |
+| `DELETE /api/channels/{id}` | Archives only caller-owned private bots. Public bots must use admin API. |
+| `POST /api/channels/{id}/commands/sync` | Syncs commands only for caller-owned private bots. Public bots must use admin API. |
+| `POST /api/channels/whatsapp/{id}/tenant-creds` | Creates or reuses caller-owned WhatsApp runtime credentials for an accessible WhatsApp bot. |
+| `GET /api/channels/whatsapp/{id}/tenant-creds` | Lists only caller-owned WhatsApp runtime credentials. |
+| `GET /api/channels/whatsapp/{id}/auth-cert` | Returns WhatsApp account public auth material for an active accessible WhatsApp bot. |
 
 CLI control plane:
 
 | CLI | Scope |
 | --- | --- |
-| `clawdi channel list` | Lists owned private bots and accessible public bots. |
+| `clawdi channel list` | Lists caller-owned private bots only. |
+| `clawdi channel available` | Lists selectable owned private and public bots from `/api/channels/bot-pool`. |
 | `clawdi channel create <provider> <name>` | Creates a private bot, optionally with an initial `--agent` link. |
 | `clawdi channel links <channel-id>` | Lists only the caller's bot-agent links for that bot. |
 | `clawdi channel link <channel-id> --agent <agent-id>` | Creates a caller-owned link from an accessible bot to one of the caller's agents. |
@@ -375,7 +445,9 @@ Every channel adapter must implement the same product contract:
 9. Persist inbound messages through the shared message recorder.
 10. Persist provider references and aliases after the binding is known.
 11. Mark handled system commands as delivered so they do not reach agents.
-12. Deliver only non-system, bound messages to link-scoped agent surfaces.
+12. Send a best-effort visible reply for handled pair/unpair/unknown command
+    outcomes.
+13. Deliver only non-system, bound messages to link-scoped agent surfaces.
 
 Adapters should not implement their own ownership rules. Ownership,
 actor-scoped control, pair code claim semantics, and command handling belong in

--- a/docs/plans/channels-native-backend.md
+++ b/docs/plans/channels-native-backend.md
@@ -71,7 +71,7 @@ does not run or proxy the old TypeScript `msg-router` service.
   Baileys sidecar HTTP client contract, preserving Baileys additional attrs for
   native-only relay paths without reintroducing the old TypeScript `msg-router`
   process.
-- `whatsapp_sidecar_registry.py` wires configured sidecars into the shared-bot
+- `whatsapp_sidecar_registry.py` wires configured sidecars into the public-bot
   transport registry at FastAPI lifespan startup and closes/unregisters them on
   shutdown, while keeping unavailable configured sidecars observable in debug
   health.
@@ -128,15 +128,16 @@ cannot be handled by multiple agents at the same time.
 Channel accounts have `visibility = private | public`. User-created channel
 accounts are always `private`: only the account owner can see them, link them,
 delete them, or pair them, and they can only be linked to that user's agents.
-Clawdi-preconfigured shared bots are stored as `public`: any authenticated user
+Clawdi-preconfigured public bots are stored as `public`: any authenticated user
 can list the account and create their own bot-agent links and pair codes for
 their own agents, but provider-token management, deletion, and provider-wide
-command sync remain owner/admin operations. Public bot links, pair codes,
-bindings, messages, deliveries, attachments, scheduled messages, and
-WhatsApp tenant credentials are owned by the requesting/link user, not by the
-bot account owner. Operationally, create and manage public bots through the
-server-to-server `/api/admin/channels` endpoints; do not expose visibility or
-provider credential management on the ordinary user create-channel API.
+command sync remain admin operations. The backing account `user_id` is not
+product ownership and must not grant mutable user API access. Public bot links,
+pair codes, bindings, messages, deliveries, attachments, scheduled messages,
+and WhatsApp tenant credentials are owned by the requesting/link user, not by
+the bot account row owner. Operationally, create and manage public bots through
+the server-to-server `/api/admin/channels` endpoints; do not expose visibility
+or provider credential management on the ordinary user create-channel API.
 
 Agent-facing SDK credentials are link-scoped, not agent-scoped. If two external
 bots are both linked to the same Clawdi agent, each `(bot, agent)` link still
@@ -168,7 +169,7 @@ current agent as ordinary messages.
 Provider-wide state, such as real upstream bot credentials, remains on
 `channel_accounts`. Agent-facing SDK state that can differ per agent token must
 live on `channel_bot_agent_links`; otherwise one agent can accidentally block or
-change another agent on the same shared bot. Telegram `setWebhook`,
+change another agent on the same public bot. Telegram `setWebhook`,
 `deleteWebhook`, `getWebhookInfo`, `getUpdates`, and command shadows follow
 this rule, while provider-side command synchronization is restricted to chats
 owned by the current link.
@@ -200,7 +201,7 @@ contract and ownership split.
 | Batch | Status | Port | Acceptance |
 | --- | --- | --- | --- |
 | W4 | Done | WhatsApp encrypted media reupload through Cloud API | Private-chat Baileys image/audio media with `mediaKey`/`directPath` is decrypted/verified in memory, uploaded to Graph media, and sent by media id through the delivery outbox; invalid media records a safe debug failure. |
-| W5 | Done | Baileys sidecar live upstream shared-bot transport | Backend adapter/health semantics are implemented for outbound-message, raw-node, and IQ relay; `WhatsAppBaileysSidecarClient` defines the internal HTTP contract; `ConfiguredWhatsAppSidecarRegistry` registers configured sidecars per account during FastAPI lifespan; `packages/whatsapp-baileys-sidecar` implements the minimal Baileys runtime package; opt-in smoke proves the sidecar reaches `connected` against the FastAPI Baileys runtime. Real linked-account smoke is a deployment acceptance gate. |
+| W5 | Done | Baileys sidecar live upstream public-bot transport | Backend adapter/health semantics are implemented for outbound-message, raw-node, and IQ relay; `WhatsAppBaileysSidecarClient` defines the internal HTTP contract; `ConfiguredWhatsAppSidecarRegistry` registers configured sidecars per account during FastAPI lifespan; `packages/whatsapp-baileys-sidecar` implements the minimal Baileys runtime package; opt-in smoke proves the sidecar reaches `connected` against the FastAPI Baileys runtime. Real linked-account smoke is a deployment acceptance gate. |
 | W6 | Done | Final product/ops closure | Route audit, stale marker search, matrix counters, full backend tests, opt-in Baileys smoke, and docs all agree. Backend APIs cover provider tokens, webhooks, pair codes, bindings, debug health, and metrics. |
 
 The Python backend already owns creds, auth certs, Noise handshake/frame

--- a/docs/plans/msg-router-parity-matrix.md
+++ b/docs/plans/msg-router-parity-matrix.md
@@ -36,16 +36,24 @@ extraction, and minimal WhatsApp text proto encoding, tenant-scoped DM Signal
 sender snapshot restore, plus outbound message ack/error-close handling and
 group sender-key snapshot restore,
 and decoded WhatsApp text/reply/Cloud-link image/audio outbound enqueue through a
-Python-native transparent shared-bot runtime seam into the Clawdi delivery
+Python-native transparent public-bot runtime seam into the Clawdi delivery
 outbox, private-chat encrypted image/audio media reupload through Graph media IDs,
 Cloud-native raw relay for WhatsApp read receipts and typing indicators,
 and a route-wired native-transport registry/status surface plus a Baileys
 sidecar client contract and workspace sidecar package for Baileys-only proto,
 Baileys 7 packed WABinary token/JID decode with a generated full token table,
 plus cross-provider chat isolation coverage.
+Pairing commands now also include user-visible provider replies for Telegram,
+Discord message commands, WhatsApp, and iMessage/BlueBubbles: successful pair,
+invalid or missing pair code, forbidden actor, and unpair outcomes are handled
+by the shared channel state machine and sent best-effort by each provider
+adapter. Provider reply failure does not roll back a successful binding claim.
+Bot command parity now includes Telegram broad-scope command replay on new
+pairing and Discord global command replay to the newly paired uncontested
+guild, matching the old msg-router post-bind behavior.
 As of this audit, the matrix has 128 Implemented, 0 Partial, 0 Pending, and
 24 Superseded rows. Backend tests pass at
-`671 passed, 7 skipped, 13 warnings in 46.66s` by default. The opt-in
+`708 passed, 7 skipped, 13 warnings in 47.59s` by default. The opt-in
 blackbox channel E2E starts a real `uvicorn app.main:app` process and exercises
 the provider-prefixed FastAPI HTTP and Discord WebSocket surfaces with
 `CLAWDI_RUN_CHANNELS_BLACKBOX_E2E=1 uv run pytest -q tests/e2e/test_channels_blackbox.py --maxfail=1`
@@ -242,7 +250,7 @@ Field-level configuration mapping:
 | `src/channels/whatsapp/tenant-creds.ts` | Implemented | Tenant creds minting is covered. |
 | `src/channels/whatsapp/tenant-registry.ts` | Implemented | Minted credential lookup by Noise static identity gates websocket sessions, carries credential id through tenant resolution, persists uploaded prekey bundles, DM Signal sender snapshots, and group sender-key snapshots into `ChannelAgentCredential.config`, restores the stored bundle, preKey count, sender snapshots, and group sender keys on reconnect, and supports real Baileys open/inbox lifecycle. |
 | `src/channels/whatsapp/ws-server.ts` | Implemented | The old file only re-exported `egress-ws.ts`; Python uses the provider-prefixed FastAPI websocket route instead of a standalone Node server. Real Baileys reaches `connection: open` and receives DB inbox messages, malformed Noise/client frames close with 1011 and sanitized debug events, disconnects cancel the inbox pump, route delivery now uses the shared `WhatsAppInboxPump` retry/ack/backoff module, and focused tests cover continuous idle polling plus IQ inflight backpressure. |
-| `src/core/admin.ts` | Superseded | Clawdi admin/user model supersedes tenant admin CRUD; debug event surfaces are Clawdi-native under `/api/channels/*`; old manual shared-bot/admin utilities are not recreated. |
+| `src/core/admin.ts` | Superseded | Clawdi admin/user model supersedes tenant admin CRUD; debug event surfaces are Clawdi-native under `/api/channels/*`; old manual shared-bot admin utilities are not recreated. |
 | `src/core/api.ts` | Superseded | Tenant `/v1` control plane is replaced by `/api/channels` with Clawdi auth, channel accounts, and agent links. |
 | `src/core/auth.ts` | Superseded | API-key tenant auth is replaced by Clawdi auth and hashed channel agent tokens. |
 | `src/core/bindings.ts` | Implemented | `channel_bindings` and aliases exist with tests. |
@@ -318,7 +326,7 @@ Field-level configuration mapping:
 | `tests/channels/whatsapp/shared-bot-runtime.test.ts` | Implemented | `test_whatsapp_baileys.py` ports pure `forwardIqOver`, `relayOutboundExtraAttrs`, WAProto-to-Cloud-payload helper contracts including image/audio fixture shapes, and encrypted image/audio reupload candidate parsing. `test_whatsapp_noise.py` now directly covers the `WhatsAppClawdiOutboxSharedBotRuntime` text/quoted reply queueing, encrypted media Graph reupload into delivery-worker media-id sends, encrypted media native-transport routing when a transport exists, Cloud-native read receipt and typing indicator relay, route-level registered native transport use for Baileys relay attrs, raw relay transport policy, IQ forwarding, and websocket-level outbound queueing. `test_whatsapp_native_transport.py` covers the native transport adapter, sidecar HTTP contract, outbound message attrs, raw nodes, IQ queries, disconnected health, and sidecar health mode. `test_whatsapp_sidecar_registry.py` covers sidecar config parsing, FastAPI registry wiring, unhealthy sidecar visibility, unregister, and client close. `test_whatsapp_baileys_smoke.py` now covers real Baileys open/inbox/fixture-shape smoke plus sidecar `connected` smoke against the FastAPI runtime. `test_channel_debug_events.py` covers native transport health visibility. `test_channels.py` covers delivery-worker use of structured WhatsApp `providerPayload` for text and audio plus invalid-payload failure handling. `packages/whatsapp-baileys-sidecar` has Bun tests for its bearer-authenticated HTTP contract, byte encoding, config parsing, disconnected mapping, proto relay, raw nodes, and IQ response encoding. Live deployment-supervised real linked-account sidecar smoke is a deployment acceptance gate. |
 | `tests/channels/whatsapp/signal-sender.test.ts` | Implemented | `SignalSender` session/snapshot/prekey/envelope parity is covered in `test_whatsapp_baileys.py`. |
 | `tests/channels/whatsapp/tenant-creds.test.ts` | Implemented | Tenant creds JSON and auth cert route tests exist. |
-| `tests/core/admin.test.ts` | Superseded | Clawdi admin supersedes tenant CRUD; msg-router import and debug surfaces have Python route/service tests, while old manual shared-bot/admin utilities are not recreated. |
+| `tests/core/admin.test.ts` | Superseded | Clawdi admin supersedes tenant CRUD; msg-router import and debug surfaces have Python route/service tests, while old manual shared-bot admin utilities are not recreated. |
 | `tests/core/api.test.ts` | Superseded | Old tenant `/v1` API replaced by `/api/channels`; control-plane tests exist in `test_channels.py`. |
 | `tests/core/auth.test.ts` | Superseded | Old tenant API-key auth replaced by Clawdi auth and hashed channel tokens. |
 | `tests/core/bindings.test.ts` | Implemented | Binding behavior covered through SQLAlchemy model/service tests. |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.0",
+	"version": "0.12.10-beta.1",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/channel.ts
+++ b/packages/cli/src/commands/channel.ts
@@ -11,6 +11,7 @@ type ChannelCommandSpec = components["schemas"]["ChannelCommandSpec"];
 type ChannelCommandSync = components["schemas"]["ChannelCommandSyncResponse"];
 type ChannelMessage = components["schemas"]["ChannelMessageResponse"];
 type ChannelPairCode = components["schemas"]["ChannelPairCodeResponse"];
+type ChannelBotPoolResponse = components["schemas"]["ChannelBotPoolResponse"];
 type ChannelProvider = components["schemas"]["ChannelAccountCreate"]["provider"];
 
 interface JsonOption {
@@ -65,6 +66,7 @@ export async function channelListCommand(opts: JsonOption = {}): Promise<void> {
 	if (channels.length === 0) {
 		console.log("No channels configured.");
 		console.log(chalk.gray("Create a private bot: clawdi channel create telegram my-bot"));
+		console.log(chalk.gray("List available channel bots: clawdi channel available"));
 		return;
 	}
 	printTable(
@@ -77,6 +79,16 @@ export async function channelListCommand(opts: JsonOption = {}): Promise<void> {
 			channel.name,
 		]),
 	);
+}
+
+export async function channelAvailableCommand(opts: JsonOption = {}): Promise<void> {
+	const api = new ApiClient();
+	const pool = unwrap(await api.GET("/api/channels/bot-pool"));
+	if (opts.json) {
+		console.log(JSON.stringify({ bot_pool: pool }, null, 2));
+		return;
+	}
+	printBotPool(pool);
 }
 
 export async function channelGetCommand(accountId: string, opts: JsonOption = {}): Promise<void> {
@@ -401,6 +413,37 @@ function printSyncedCommands(sync: ChannelCommandSync): void {
 			formatUnknown(command.description ?? "-"),
 		]),
 	);
+}
+
+function printBotPool(pool: ChannelBotPoolResponse): void {
+	const rows = Object.entries(pool.providers).flatMap(([provider, items]) =>
+		items.map((item) => [
+			shortId(item.id),
+			provider,
+			item.access,
+			item.visibility,
+			item.status,
+			capabilitySummary(item.capabilities),
+			item.name,
+		]),
+	);
+	if (rows.length === 0) {
+		console.log("No available channel bots.");
+		return;
+	}
+	printTable(["ID", "PROVIDER", "ACCESS", "VISIBILITY", "STATUS", "CAPABILITIES", "NAME"], rows);
+}
+
+function capabilitySummary(
+	capabilities: components["schemas"]["ChannelBotPoolCapabilities"],
+): string {
+	const labels: string[] = [];
+	if (capabilities.link_agent) labels.push("link");
+	if (capabilities.pair_chat) labels.push("pair");
+	if (capabilities.send_message) labels.push("send");
+	if (capabilities.manage_account) labels.push("manage");
+	if (capabilities.sync_commands) labels.push("sync");
+	return labels.join(",");
 }
 
 function parseProvider(value: string): ChannelProvider {

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -321,30 +321,35 @@ export async function runtimeApplyCommand(opts: RuntimeApplyOptions = {}): Promi
 }
 
 async function buildPlan(api: ApiClient, manifest: RuntimeManifest, manifestDir: string) {
-	const channels = unwrap(await api.GET("/api/channels"));
+	let channels: ChannelAccount[] | null = null;
 	const accountPlans = [];
 	const linkPlans = [];
 	const warnings: string[] = [];
 	for (const channel of manifest.channels) {
-		const existingAccount = findManifestAccount(channels, channel);
 		const existingAccountId = isExistingAccountSpec(channel.account) ? channel.account.id : null;
-		const missingExistingAccount = !existingAccount && existingAccountId !== null;
+		let existingAccount: ChannelAccount | null;
+		if (existingAccountId !== null) {
+			existingAccount = unwrap(
+				await api.GET("/api/channels/{account_id}", {
+					params: { path: { account_id: existingAccountId } },
+				}),
+			);
+		} else {
+			if (channels === null) {
+				channels = unwrap(await api.GET("/api/channels"));
+			}
+			existingAccount = findManifestAccount(channels, channel) ?? null;
+		}
+		if (existingAccount) {
+			assertManifestAccountCompatible(channel, existingAccount);
+		}
 		accountPlans.push({
 			ref: channel.ref,
 			provider: channel.provider,
 			account_id: existingAccount?.id ?? null,
-			action: existingAccount
-				? "reuse_account"
-				: missingExistingAccount
-					? "resolve_account"
-					: "create_private_account",
+			action: existingAccount ? "reuse_account" : "create_private_account",
 		});
 		if (!existingAccount) {
-			if (missingExistingAccount) {
-				warnings.push(
-					`${channel.ref}: account ${existingAccountId} is not visible from GET /api/channels; apply will validate it with GET /api/channels/${existingAccountId}.`,
-				);
-			}
 			for (const link of channel.links) {
 				linkPlans.push({
 					ref: link.ref,
@@ -425,16 +430,7 @@ async function ensureAccount(
 				params: { path: { account_id: accountSpec.id } },
 			}),
 		);
-		if (account.provider !== channel.provider) {
-			throw new Error(
-				`${channel.ref}: account ${account.id} is provider ${account.provider}, expected ${channel.provider}.`,
-			);
-		}
-		if (accountSpec.visibility && account.visibility !== accountSpec.visibility) {
-			throw new Error(
-				`${channel.ref}: account ${account.id} visibility is ${account.visibility}, expected ${accountSpec.visibility}.`,
-			);
-		}
+		assertManifestAccountCompatible(channel, account);
 		ctx.actions.push({ action: "reuse_account", channel_ref: channel.ref, account_id: account.id });
 		return account;
 	}
@@ -848,6 +844,23 @@ function runtimeAccountKey(channel: RuntimeChannel): string {
 	if (isExistingAccountSpec(channel.account)) return `account:${channel.account.id}`;
 	const account = createPrivateAccountSpec(channel.account);
 	return `private:${channel.provider}:${account.name}`;
+}
+
+function assertManifestAccountCompatible(channel: RuntimeChannel, account: ChannelAccount): void {
+	if (account.provider !== channel.provider) {
+		throw new Error(
+			`${channel.ref}: account ${account.id} is provider ${account.provider}, expected ${channel.provider}.`,
+		);
+	}
+	if (
+		isExistingAccountSpec(channel.account) &&
+		channel.account.visibility &&
+		account.visibility !== channel.account.visibility
+	) {
+		throw new Error(
+			`${channel.ref}: account ${account.id} visibility is ${account.visibility}, expected ${channel.account.visibility}.`,
+		);
+	}
 }
 
 function findManifestAccount(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -544,11 +544,20 @@ const channelCmd = program
 
 channelCmd
 	.command("list")
-	.description("List private bots and accessible public bots")
+	.description("List your private channel bots")
 	.option("--json", "Emit machine-readable JSON")
 	.action(async (opts: { json?: boolean }) => {
 		const { channelListCommand } = await import("./commands/channel.js");
 		await channelListCommand(opts);
+	});
+
+channelCmd
+	.command("available")
+	.description("List available channel bots")
+	.option("--json", "Emit machine-readable JSON")
+	.action(async (opts: { json?: boolean }) => {
+		const { channelAvailableCommand } = await import("./commands/channel.js");
+		await channelAvailableCommand(opts);
 	});
 
 channelCmd

--- a/packages/cli/tests/commands/channel.test.ts
+++ b/packages/cli/tests/commands/channel.test.ts
@@ -4,10 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+	channelAvailableCommand,
 	channelCreateCommand,
 	channelDeleteCommand,
 	channelGetCommand,
 	channelLinkCommand,
+	channelListCommand,
 	channelPairCodeCommand,
 	channelRotateTokenCommand,
 	channelSendCommand,
@@ -40,6 +42,80 @@ afterEach(() => {
 });
 
 describe("channel commands", () => {
+	it("lists only user-owned channel bots", async () => {
+		const { captured, restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/api/channels",
+				response: () =>
+					jsonResponse([
+						{
+							id: "channel-private",
+							provider: "telegram",
+							name: "ops-bot",
+							status: "active",
+							visibility: "private",
+							has_provider_token: true,
+							webhook_url: "https://api.test/api/channels/telegram/channel-private/webhook",
+							created_at: new Date().toISOString(),
+						},
+					]),
+			},
+		]);
+		const out = await captureStdout(() => channelListCommand({ json: true }));
+		restore();
+
+		expect(captured[0]).toMatchObject({ method: "GET", path: "/api/channels" });
+		expect(JSON.parse(out)).toMatchObject({
+			channels: [{ id: "channel-private", visibility: "private" }],
+		});
+	});
+
+	it("lists available channel bots from the bot pool", async () => {
+		const { captured, restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/api/channels/bot-pool",
+				response: () =>
+					jsonResponse({
+						providers: {
+							telegram: [
+								{
+									id: "channel-public",
+									provider: "telegram",
+									name: "Clawdi Telegram",
+									status: "active",
+									visibility: "public",
+									has_provider_token: true,
+									webhook_url: "https://api.test/api/channels/telegram/channel-public/webhook",
+									created_at: new Date().toISOString(),
+									access: "public",
+									capabilities: {
+										link_agent: true,
+										pair_chat: true,
+										send_message: true,
+										manage_account: false,
+										sync_commands: false,
+									},
+								},
+							],
+						},
+					}),
+			},
+		]);
+		const out = await captureStdout(() => channelAvailableCommand({ json: true }));
+		restore();
+
+		expect(captured[0]).toMatchObject({ method: "GET", path: "/api/channels/bot-pool" });
+		expect(JSON.parse(out)).toMatchObject({
+			bot_pool: {
+				providers: {
+					telegram: [{ id: "channel-public", access: "public" }],
+				},
+			},
+		});
+	});
+
 	it("creates a private channel bot with optional initial agent link", async () => {
 		const { captured, restore } = mockFetch([
 			{

--- a/packages/cli/tests/commands/runtime.test.ts
+++ b/packages/cli/tests/commands/runtime.test.ts
@@ -510,7 +510,7 @@ outputs:
 		expect(JSON.parse(status).status.accounts[0].action).toBe("reuse_account");
 	});
 
-	it("plans existing account ids as account resolution when list does not include them", async () => {
+	it("plans existing account ids by resolving the account directly", async () => {
 		const manifestPath = writeManifest(`
 version: 1
 channels:
@@ -529,7 +529,22 @@ outputs:
 		const { captured, restore } = mockFetch([
 			{
 				method: "GET",
-				path: /^\/api\/channels$/,
+				path: /^\/api\/channels\/channel-public$/,
+				response: () =>
+					jsonResponse({
+						id: "channel-public",
+						provider: "discord",
+						name: "clawdi-discord",
+						status: "active",
+						visibility: "public",
+						has_provider_token: true,
+						webhook_url: "https://api.test/api/channels/discord/channel-public/webhook",
+						created_at: "2026-06-08T00:00:00Z",
+					}),
+			},
+			{
+				method: "GET",
+				path: /^\/api\/channels\/channel-public\/agent-links$/,
 				response: () => jsonResponse([]),
 			},
 		]);
@@ -537,9 +552,52 @@ outputs:
 		const plan = await captureStdout(() => runtimePlanCommand({ file: manifestPath, json: true }));
 		restore();
 
-		expect(captured).toHaveLength(1);
-		expect(JSON.parse(plan).plan.accounts[0].action).toBe("resolve_account");
-		expect(JSON.parse(plan).plan.warnings[0]).toContain("not visible");
+		expect(captured.map((request) => `${request.method} ${request.path}`)).toEqual([
+			"GET /api/channels/channel-public",
+			"GET /api/channels/channel-public/agent-links",
+		]);
+		expect(JSON.parse(plan).plan.accounts[0].action).toBe("reuse_account");
+		expect(JSON.parse(plan).plan.warnings).toEqual([]);
+	});
+
+	it("rejects existing account ids with the wrong provider during planning", async () => {
+		const manifestPath = writeManifest(`
+version: 1
+channels:
+  - ref: public-discord
+    provider: discord
+    account:
+      id: channel-telegram
+    links:
+      - ref: discord-main
+        agent_id: agent-1
+        runtime:
+          token_env: DISCORD_AGENT_TOKEN
+outputs:
+  dotenv: .env.channels
+`);
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: /^\/api\/channels\/channel-telegram$/,
+				response: () =>
+					jsonResponse({
+						id: "channel-telegram",
+						provider: "telegram",
+						name: "clawdi-telegram",
+						status: "active",
+						visibility: "public",
+						has_provider_token: true,
+						webhook_url: "https://api.test/api/channels/telegram/channel-telegram/webhook",
+						created_at: "2026-06-08T00:00:00Z",
+					}),
+			},
+		]);
+
+		await expect(runtimePlanCommand({ file: manifestPath, json: true })).rejects.toThrow(
+			"public-discord: account channel-telegram is provider telegram, expected discord.",
+		);
+		restore();
 	});
 
 	it("rejects malformed manifests before API calls", async () => {

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -247,6 +247,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/channels/bot-pool": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Channel Bot Pool */
+        get: operations["list_channel_bot_pool_api_channels_bot_pool_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/channels/{account_id}": {
         parameters: {
             query?: never;
@@ -2729,6 +2746,61 @@ export interface components {
              */
             created_at: string;
         };
+        /** ChannelBotPoolCapabilities */
+        ChannelBotPoolCapabilities: {
+            /** Link Agent */
+            link_agent: boolean;
+            /** Pair Chat */
+            pair_chat: boolean;
+            /** Send Message */
+            send_message: boolean;
+            /** Manage Account */
+            manage_account: boolean;
+            /** Sync Commands */
+            sync_commands: boolean;
+        };
+        /** ChannelBotPoolItem */
+        ChannelBotPoolItem: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Provider */
+            provider: string;
+            /** Name */
+            name: string;
+            /** Status */
+            status: string;
+            /**
+             * Visibility
+             * @default private
+             * @enum {string}
+             */
+            visibility: "private" | "public";
+            /** Has Provider Token */
+            has_provider_token: boolean;
+            /** Webhook Url */
+            webhook_url: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Access
+             * @enum {string}
+             */
+            access: "owner" | "public";
+            capabilities: components["schemas"]["ChannelBotPoolCapabilities"];
+        };
+        /** ChannelBotPoolResponse */
+        ChannelBotPoolResponse: {
+            /** Providers */
+            providers: {
+                [key: string]: components["schemas"]["ChannelBotPoolItem"][];
+            };
+        };
         /** ChannelCommandSpec */
         ChannelCommandSpec: {
             /** Name */
@@ -5186,6 +5258,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_channel_bot_pool_api_channels_bot_pool_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChannelBotPoolResponse"];
                 };
             };
         };


### PR DESCRIPTION
## Why

The native channel runtime needs a clean selectable-bot contract before v2 hosted runtime testing. The previous shape leaked transitional product concepts into the API (`recommended`, `owned_by_user`, and a reserved `shared` access value), which made UI/runtime selection ambiguous and encouraged hidden default-bot logic.

This PR keeps the v2/native channel surface explicit: users can select owned private bots or active public bots, and callers should rely on action capabilities rather than inferred ownership flags.

## What Changed

- Tightens `/api/channels/bot-pool` to return only `access` and `capabilities` for caller-relative use.
- Limits `ChannelBotPoolAccess` to the currently implemented values: `owner | public`.
- Keeps `GET /api/channels` scoped to caller-owned private bots; public bots are selected through bot-pool.
- Ensures public bot account-level mutation stays admin-managed while user-created child state remains user-scoped.
- Blocks disabled channels from runtime actions, including WhatsApp tenant credential minting and auth-cert reads.
- Makes `clawdi runtime plan` validate explicit account provider/visibility the same way `apply` does.
- Adds `clawdi channel available` for selectable bot discovery.
- Bumps CLI to `0.12.10-beta.1`; after merge, the CLI publish workflow should publish this under the `beta` dist-tag.

## Verification

- `uv run ruff check app tests`
- `uv run pytest -q tests/test_channels.py`
- `uv run pytest -q --durations=25 --durations-min=0.05`
- `CLAWDI_RUN_CHANNELS_BLACKBOX_E2E=1 uv run pytest -q tests/e2e/test_channels_blackbox.py --maxfail=1`
- `bun run --cwd packages/cli typecheck`
- `bun test --cwd packages/cli --isolate --max-concurrency=1 tests/commands/channel.test.ts tests/commands/runtime.test.ts`
- `bun run check`
- `bun run --cwd packages/cli build`
- `bun run --cwd packages/cli check:publish-manifest`
- `CLAWDI_MITM_BROKER_BUNDLE_OUTDIR=clawdi-mitm-broker bun run --cwd packages/cli build:mitm-broker`
- `go test ./...` from `packages/cli/native/mitm-broker`
- npm tarball install smoke: packed local CLI installed and reported `0.12.10-beta.1`

## Release Impact

Merging this PR should publish `clawdi@0.12.10-beta.1` with npm dist-tag `beta`. It should not move `latest`.

After merge:

1. Verify backend deploy on the test/prod2 environment.
2. Verify `npm view clawdi dist-tags` shows `beta: 0.12.10-beta.1`.
3. Build/run the v2 image with `clawdi@beta` or exact `clawdi@0.12.10-beta.1`.
4. Run v2 internal Telegram/Discord/WhatsApp channel tests before any wider rollout.
