### PR TITLE
Add channel agent-link edit APIs

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -646,6 +646,63 @@ async def admin_upsert_runtime_state(
     )
 
 
+@router.delete(
+    "/environments/{environment_id}/runtime-state",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def admin_delete_runtime_state(
+    environment_id: UUID,
+    _: None = Depends(require_admin_api_key),
+    db: AsyncSession = Depends(get_session),
+) -> None:
+    env = (
+        await db.execute(select(AgentEnvironment).where(AgentEnvironment.id == environment_id))
+    ).scalar_one_or_none()
+    if env is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent environment not found")
+
+    state = (
+        await db.execute(
+            select(HostedRuntimeState)
+            .where(HostedRuntimeState.environment_id == environment_id)
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    details: dict[str, object] = {"existed": state is not None}
+    if state is not None:
+        details.update(
+            {
+                "deployment_id": state.deployment_id,
+                "app_id": state.app_id,
+                "instance_id": state.instance_id,
+                "generation": state.generation,
+                "provider_id": state.provider_id,
+                "enabled_runtimes": _enabled_runtime_names(state.runtimes),
+                "has_mcp": state.mcp is not None,
+                "has_tools": state.tools is not None,
+            }
+        )
+        await db.delete(state)
+
+    record_control_plane_audit(
+        db,
+        actor_type="admin",
+        action="hosted_runtime_state.delete",
+        resource_type="hosted_runtime_state",
+        resource_id=str(environment_id),
+        environment_id=environment_id,
+        target_user_id=env.user_id,
+        source="api.admin",
+        details=details,
+    )
+    await db.commit()
+    logger.info(
+        "admin_runtime_state_deleted environment_id=%s existed=%s",
+        environment_id,
+        state is not None,
+    )
+
+
 async def _admin_get_channel_row(
     db: AsyncSession,
     *,

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -74,6 +74,7 @@ from app.services.agent_bindings import get_owned_agent_or_404
 from app.services.audit import record_control_plane_audit
 from app.services.channel_config import validate_channel_account_config_urls
 from app.services.channels import (
+    archive_bot_agent_link,
     archive_channel_account,
     channel_bot_link_limit,
     create_pair_code,
@@ -666,6 +667,34 @@ async def rotate_channel_agent_link_token(
     await db.commit()
     await db.refresh(link)
     return _agent_link_response(link, agent_token=agent_token)
+
+
+@router.delete("/{account_id}/agent-links/{link_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_channel_agent_link(
+    account_id: UUID,
+    link_id: UUID,
+    auth: AuthContext = Depends(require_user_auth),
+    db: AsyncSession = Depends(get_session),
+) -> None:
+    account = await get_usable_channel_account(db, account_id=account_id, user_id=auth.user_id)
+    link = await get_owned_bot_agent_link(
+        db, account=account, link_id=link_id, user_id=auth.user_id
+    )
+    await archive_bot_agent_link(db, link=link)
+    record_control_plane_audit(
+        db,
+        actor_type="user",
+        actor_user_id=auth.user_id,
+        target_user_id=auth.user_id,
+        action="channel.agent_link.archive",
+        resource_type="channel_agent_link",
+        resource_id=str(link.id),
+        channel_account_id=account.id,
+        channel_agent_link_id=link.id,
+        source="api.channels",
+        details={"provider": account.provider, "agent_id": str(link.agent_id)},
+    )
+    await db.commit()
 
 
 @router.get("/{account_id}/bindings")

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -54,6 +54,7 @@ from app.schemas.channel import (
     ChannelActivityListResponse,
     ChannelAgentLinkCreate,
     ChannelAgentLinkResponse,
+    ChannelAgentLinkWithAccountResponse,
     ChannelBindingResponse,
     ChannelBotPoolAccess,
     ChannelBotPoolCapabilities,
@@ -90,6 +91,7 @@ from app.services.channels import (
     get_usable_channel_account,
     hash_token,
     list_owned_active_bot_agent_links,
+    list_owned_active_bot_agent_links_for_agent,
     rotate_bot_agent_link_token,
     store_channel_secrets,
     sync_channel_commands,
@@ -153,6 +155,16 @@ def _runtime_account_response(
     return ChannelRuntimeAccountResponse(
         **_account_response(account).model_dump(),
         runtime_links=[runtime_link],
+    )
+
+
+def _agent_link_with_account_response(
+    link: ChannelBotAgentLink,
+    account: ChannelAccount,
+) -> ChannelAgentLinkWithAccountResponse:
+    return ChannelAgentLinkWithAccountResponse(
+        **_agent_link_response(link).model_dump(),
+        account=_account_response(account),
     )
 
 
@@ -449,6 +461,21 @@ async def create_channel(
         agent_id=link.agent_id if link else None,
         agent_token=link_agent_token,
     )
+
+
+@router.get("/agent-links")
+async def list_agent_channel_links(
+    agent_id: UUID,
+    auth: AuthContext = Depends(require_user_auth),
+    db: AsyncSession = Depends(get_session),
+) -> list[ChannelAgentLinkWithAccountResponse]:
+    await get_owned_agent_or_404(db, user_id=auth.user_id, agent_id=agent_id)
+    rows = await list_owned_active_bot_agent_links_for_agent(
+        db,
+        user_id=auth.user_id,
+        agent_id=agent_id,
+    )
+    return [_agent_link_with_account_response(link, account) for link, account in rows]
 
 
 @router.get("/{account_id}/activity")

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -704,9 +704,17 @@ async def delete_channel_agent_link(
     db: AsyncSession = Depends(get_session),
 ) -> None:
     account = await get_usable_channel_account(db, account_id=account_id, user_id=auth.user_id)
-    link = await get_owned_bot_agent_link(
-        db, account=account, link_id=link_id, user_id=auth.user_id
+    link_result = await db.execute(
+        select(ChannelBotAgentLink).where(
+            ChannelBotAgentLink.id == link_id,
+            ChannelBotAgentLink.account_id == account.id,
+            ChannelBotAgentLink.user_id == auth.user_id,
+        )
     )
+    link = link_result.scalar_one_or_none()
+    if link is None or link.status != BOT_AGENT_LINK_STATUS_ACTIVE or link.archived_at is not None:
+        return
+
     await archive_bot_agent_link(db, link=link)
     record_control_plane_audit(
         db,

--- a/backend/app/schemas/channel.py
+++ b/backend/app/schemas/channel.py
@@ -108,6 +108,10 @@ class ChannelAgentLinkResponse(BaseModel):
     agent_token: str | None = None
 
 
+class ChannelAgentLinkWithAccountResponse(ChannelAgentLinkResponse):
+    account: ChannelAccountResponse
+
+
 class ChannelPairCodeCreate(BaseModel):
     agent_id: UUID | None = None
     agent_link_id: UUID | None = None

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -444,6 +444,34 @@ async def list_owned_active_bot_agent_links(
     return list(result.scalars().all())
 
 
+async def list_owned_active_bot_agent_links_for_agent(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    agent_id: UUID,
+) -> list[tuple[ChannelBotAgentLink, ChannelAccount]]:
+    result = await db.execute(
+        select(ChannelBotAgentLink, ChannelAccount)
+        .join(ChannelAccount, ChannelAccount.id == ChannelBotAgentLink.account_id)
+        .where(
+            ChannelBotAgentLink.user_id == user_id,
+            ChannelBotAgentLink.agent_id == agent_id,
+            ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+            ChannelBotAgentLink.archived_at.is_(None),
+            ChannelAccount.archived_at.is_(None),
+            ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+        )
+        .order_by(
+            ChannelAccount.provider,
+            ChannelAccount.visibility,
+            ChannelAccount.name,
+            ChannelAccount.id,
+            ChannelBotAgentLink.created_at,
+        )
+    )
+    return list(result.all())
+
+
 async def rotate_bot_agent_link_token(
     db: AsyncSession,
     *,

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -456,6 +456,17 @@ async def rotate_bot_agent_link_token(
     return raw_token
 
 
+async def archive_bot_agent_link(
+    db: AsyncSession,
+    *,
+    link: ChannelBotAgentLink,
+) -> None:
+    link.status = BOT_AGENT_LINK_STATUS_ARCHIVED
+    link.agent_token_hash = None
+    link.archived_at = datetime.now(UTC)
+    await db.flush()
+
+
 async def get_owned_private_channel_account(
     db: AsyncSession,
     *,

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -94,6 +94,8 @@ DEFAULT_CHANNEL_COMMANDS: tuple[dict[str, Any], ...] = (
         "options": [],
     },
 )
+DELIVERY_LINK_LOCK_CONTENTION_ERROR = "channel agent link is being updated"
+DELIVERY_LINK_LOCK_CONTENTION_MAX_DELAY_SECONDS = 30
 
 TELEGRAM_REF_CALLBACK_QUERY_ID = "telegram_callback_query_id"
 TELEGRAM_REF_FILE_ID = "telegram_file_id"
@@ -2042,10 +2044,13 @@ async def deliver_channel_delivery(
             provider_payload=_channel_message_provider_payload(message),
         )
     except HTTPException as exc:
-        if exc.status_code < status.HTTP_500_INTERNAL_SERVER_ERROR:
-            _fail_delivery(delivery, _http_exception_detail(exc))
+        error = _http_exception_detail(exc)
+        if _is_delivery_link_lock_contention(exc, error=error):
+            _schedule_delivery_link_contention_retry(delivery, error)
+        elif exc.status_code < status.HTTP_500_INTERNAL_SERVER_ERROR:
+            _fail_delivery(delivery, error)
         else:
-            _schedule_delivery_retry(delivery, _http_exception_detail(exc))
+            _schedule_delivery_retry(delivery, error)
         await db.flush()
         return delivery
 
@@ -3420,7 +3425,7 @@ async def _lock_active_delivery_link(
     ):
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="channel agent link is being updated",
+            detail=DELIVERY_LINK_LOCK_CONTENTION_ERROR,
         )
     raise HTTPException(
         status_code=status.HTTP_400_BAD_REQUEST,
@@ -3440,11 +3445,32 @@ def _schedule_delivery_retry(delivery: ChannelDelivery, error: str) -> None:
     delivery.next_attempt_at = datetime.now(UTC) + timedelta(seconds=delay_seconds)
 
 
+def _schedule_delivery_link_contention_retry(delivery: ChannelDelivery, error: str) -> None:
+    refunded_attempts = max(delivery.attempts - 1, 0)
+    delay_seconds = min(
+        2 ** max(refunded_attempts, 0),
+        DELIVERY_LINK_LOCK_CONTENTION_MAX_DELAY_SECONDS,
+    )
+    delivery.attempts = refunded_attempts
+    delivery.locked_at = None
+    delivery.locked_by = None
+    delivery.last_error = error[:1000]
+    delivery.status = DELIVERY_STATUS_PENDING
+    delivery.next_attempt_at = datetime.now(UTC) + timedelta(seconds=delay_seconds)
+
+
 def _fail_delivery(delivery: ChannelDelivery, error: str) -> None:
     delivery.locked_at = None
     delivery.locked_by = None
     delivery.last_error = error[:1000]
     delivery.status = DELIVERY_STATUS_FAILED
+
+
+def _is_delivery_link_lock_contention(exc: HTTPException, *, error: str) -> bool:
+    return (
+        exc.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        and error == DELIVERY_LINK_LOCK_CONTENTION_ERROR
+    )
 
 
 def _http_exception_detail(exc: HTTPException) -> str:

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -489,9 +489,52 @@ async def archive_bot_agent_link(
     *,
     link: ChannelBotAgentLink,
 ) -> None:
+    now = datetime.now(UTC)
     link.status = BOT_AGENT_LINK_STATUS_ARCHIVED
     link.agent_token_hash = None
-    link.archived_at = datetime.now(UTC)
+    link.archived_at = now
+
+    bindings_result = await db.execute(
+        select(ChannelBinding).where(
+            ChannelBinding.bot_agent_link_id == link.id,
+            ChannelBinding.status == BINDING_STATUS_ACTIVE,
+        )
+    )
+    for binding in bindings_result.scalars().all():
+        binding.status = BINDING_STATUS_ARCHIVED
+
+    pair_codes_result = await db.execute(
+        select(ChannelPairCode).where(
+            ChannelPairCode.bot_agent_link_id == link.id,
+            ChannelPairCode.status == PAIR_CODE_STATUS_PENDING,
+        )
+    )
+    for pair_code in pair_codes_result.scalars().all():
+        pair_code.status = PAIR_CODE_STATUS_REVOKED
+
+    credentials_result = await db.execute(
+        select(ChannelAgentCredential).where(
+            ChannelAgentCredential.bot_agent_link_id == link.id,
+            ChannelAgentCredential.revoked_at.is_(None),
+        )
+    )
+    for credential in credentials_result.scalars().all():
+        credential.revoked_at = now
+
+    deliveries_result = await db.execute(
+        select(ChannelDelivery).where(
+            ChannelDelivery.bot_agent_link_id == link.id,
+            ChannelDelivery.status.in_(
+                (
+                    DELIVERY_STATUS_PENDING,
+                    DELIVERY_STATUS_IN_PROGRESS,
+                )
+            ),
+        )
+    )
+    for delivery in deliveries_result.scalars().all():
+        _fail_delivery(delivery, "channel agent link archived")
+
     await db.flush()
 
 

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -212,6 +212,12 @@ def store_agent_link_token(link: ChannelBotAgentLink, raw_token: str) -> None:
     link.agent_token_nonce = nonce
 
 
+def scrub_agent_link_token(link: ChannelBotAgentLink) -> None:
+    link.agent_token_hash = None
+    link.encrypted_agent_token = None
+    link.agent_token_nonce = None
+
+
 def decrypt_agent_link_token(link: ChannelBotAgentLink) -> str | None:
     if not link.encrypted_agent_token or not link.agent_token_nonce:
         return None
@@ -491,7 +497,7 @@ async def archive_bot_agent_link(
 ) -> None:
     now = datetime.now(UTC)
     link.status = BOT_AGENT_LINK_STATUS_ARCHIVED
-    link.agent_token_hash = None
+    scrub_agent_link_token(link)
     link.archived_at = now
 
     bindings_result = await db.execute(
@@ -646,7 +652,7 @@ async def archive_channel_account(db: AsyncSession, *, account: ChannelAccount) 
     )
     for link in links_result.scalars().all():
         link.status = BOT_AGENT_LINK_STATUS_ARCHIVED
-        link.agent_token_hash = None
+        scrub_agent_link_token(link)
         link.archived_at = now
 
     bindings_result = await db.execute(
@@ -1988,11 +1994,22 @@ async def claim_next_channel_delivery(
     result = await db.execute(
         select(ChannelDelivery)
         .join(ChannelAccount, ChannelAccount.id == ChannelDelivery.account_id)
+        .outerjoin(
+            ChannelBotAgentLink,
+            ChannelBotAgentLink.id == ChannelDelivery.bot_agent_link_id,
+        )
         .where(
             ChannelDelivery.status == DELIVERY_STATUS_PENDING,
             ChannelDelivery.next_attempt_at <= now,
             ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
             ChannelAccount.archived_at.is_(None),
+            or_(
+                ChannelDelivery.bot_agent_link_id.is_(None),
+                and_(
+                    ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+                    ChannelBotAgentLink.archived_at.is_(None),
+                ),
+            ),
         )
         .order_by(ChannelDelivery.next_attempt_at, ChannelDelivery.created_at)
         .limit(1)
@@ -2016,6 +2033,7 @@ async def deliver_channel_delivery(
 ) -> ChannelDelivery:
     try:
         account = await _delivery_account(db, delivery)
+        await _lock_active_delivery_link(db, delivery)
         message = await _delivery_message(db, delivery)
         provider_message_id, provider_response = await send_provider_outbound_payload(
             account=account,
@@ -3367,6 +3385,47 @@ async def _delivery_message(db: AsyncSession, delivery: ChannelDelivery) -> Chan
             detail="channel message not found",
         )
     return message
+
+
+async def _lock_active_delivery_link(
+    db: AsyncSession,
+    delivery: ChannelDelivery,
+) -> ChannelBotAgentLink | None:
+    if delivery.bot_agent_link_id is None:
+        return None
+
+    result = await db.execute(
+        select(ChannelBotAgentLink)
+        .where(
+            ChannelBotAgentLink.id == delivery.bot_agent_link_id,
+            ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+            ChannelBotAgentLink.archived_at.is_(None),
+        )
+        .with_for_update(of=ChannelBotAgentLink, skip_locked=True)
+    )
+    link = result.scalar_one_or_none()
+    if link is not None:
+        return link
+
+    state_result = await db.execute(
+        select(ChannelBotAgentLink.status, ChannelBotAgentLink.archived_at).where(
+            ChannelBotAgentLink.id == delivery.bot_agent_link_id
+        )
+    )
+    state_row = state_result.one_or_none()
+    if (
+        state_row is not None
+        and state_row.status == BOT_AGENT_LINK_STATUS_ACTIVE
+        and state_row.archived_at is None
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="channel agent link is being updated",
+        )
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="channel agent link archived",
+    )
 
 
 def _schedule_delivery_retry(delivery: ChannelDelivery, error: str) -> None:

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -29,6 +29,7 @@ from app.core.database import get_session
 from app.main import app
 from app.models.api_key import ApiKey
 from app.models.channel import (
+    BOT_AGENT_LINK_STATUS_ARCHIVED,
     CHANNEL_PROVIDER_TELEGRAM,
     CHANNEL_STATUS_DISABLED,
     CHANNEL_VISIBILITY_PUBLIC,
@@ -1409,6 +1410,92 @@ async def test_public_bot_pool_capacity_rejects_new_agent_links(
     assert second_link.json()["detail"] == "channel bot link capacity reached"
     assert second_pair.status_code == 409
     assert second_pair.json()["detail"] == "channel bot link capacity reached"
+
+
+@pytest.mark.asyncio
+async def test_delete_channel_agent_link_archives_link_and_releases_capacity(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+):
+    created = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider="telegram",
+        name=f"public-unlink-{uuid4().hex}",
+        config={"max_links": 1},
+    )
+    assert created.status_code == 201, created.text
+    account_id = created.json()["id"]
+    user_a, agent_a = await _create_user_with_channel_agent(db_session, label="pool-unlink-a")
+    user_b, agent_b = await _create_user_with_channel_agent(db_session, label="pool-unlink-b")
+
+    async with _client_for_user(db_session, user_a) as client_a:
+        first_link = await client_a.post(
+            f"/api/channels/{account_id}/agent-links",
+            json={"agent_id": str(agent_a.id)},
+        )
+        assert first_link.status_code == 201, first_link.text
+        first_link_id = first_link.json()["id"]
+        full_pool = await client_a.get("/api/channels/bot-pool")
+        api_key = ApiKey(user_id=user_a.id, environment_id=agent_a.id, label="hosted")
+        async with _client_for_api_key(db_session, user_a, api_key) as runtime_client:
+            desired_before = await runtime_client.get("/api/channels")
+
+        deleted = await client_a.delete(f"/api/channels/{account_id}/agent-links/{first_link_id}")
+
+        links_after = await client_a.get(f"/api/channels/{account_id}/agent-links")
+        pool_after_delete = await client_a.get("/api/channels/bot-pool")
+        async with _client_for_api_key(db_session, user_a, api_key) as runtime_client:
+            desired_after = await runtime_client.get("/api/channels")
+        audit_response = await client_a.get(
+            "/api/audit/events",
+            params={"channel_account_id": account_id, "limit": 20},
+        )
+    async with _client_for_user(db_session, user_b) as client_b:
+        second_link = await client_b.post(
+            f"/api/channels/{account_id}/agent-links",
+            json={"agent_id": str(agent_b.id)},
+        )
+
+    assert desired_before.status_code == 200, desired_before.text
+    assert [item["id"] for item in desired_before.json()] == [account_id]
+    before_item = next(
+        item for item in full_pool.json()["providers"]["telegram"] if item["id"] == account_id
+    )
+    assert before_item["link_count"] == 1
+    assert before_item["available"] is False
+
+    assert deleted.status_code == 204, deleted.text
+    assert links_after.status_code == 200, links_after.text
+    assert links_after.json() == []
+    assert desired_after.status_code == 200, desired_after.text
+    assert desired_after.json() == []
+    after_item = next(
+        item
+        for item in pool_after_delete.json()["providers"]["telegram"]
+        if item["id"] == account_id
+    )
+    assert after_item["link_count"] == 0
+    assert after_item["available"] is True
+    assert second_link.status_code == 201, second_link.text
+
+    audit_response_body = audit_response.json()
+    archive_event = next(
+        event
+        for event in audit_response_body["items"]
+        if event["action"] == "channel.agent_link.archive"
+    )
+    assert archive_event["resource_type"] == "channel_agent_link"
+    assert archive_event["resource_id"] == first_link_id
+    assert archive_event["channel_agent_link_id"] == first_link_id
+    assert archive_event["details"]["agent_id"] == str(agent_a.id)
+
+    archived_link = await db_session.get(ChannelBotAgentLink, UUID(first_link_id))
+    assert archived_link is not None
+    assert archived_link.status == BOT_AGENT_LINK_STATUS_ARCHIVED
+    assert archived_link.archived_at is not None
+    assert archived_link.agent_token_hash is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -29,14 +29,19 @@ from app.core.database import get_session
 from app.main import app
 from app.models.api_key import ApiKey
 from app.models.channel import (
+    BINDING_STATUS_ACTIVE,
+    BINDING_STATUS_ARCHIVED,
     BOT_AGENT_LINK_STATUS_ARCHIVED,
     CHANNEL_PROVIDER_TELEGRAM,
     CHANNEL_STATUS_DISABLED,
     CHANNEL_VISIBILITY_PUBLIC,
     DELIVERY_STATUS_FAILED,
+    DELIVERY_STATUS_IN_PROGRESS,
     DELIVERY_STATUS_PENDING,
     MESSAGE_DIRECTION_INBOUND,
     MESSAGE_DIRECTION_OUTBOUND,
+    PAIR_CODE_STATUS_PENDING,
+    PAIR_CODE_STATUS_REVOKED,
     ChannelAccount,
     ChannelBinding,
     ChannelBindingAlias,
@@ -1443,6 +1448,10 @@ async def test_delete_channel_agent_link_archives_link_and_releases_capacity(
             desired_before = await runtime_client.get("/api/channels")
 
         deleted = await client_a.delete(f"/api/channels/{account_id}/agent-links/{first_link_id}")
+        second_delete = await client_a.delete(
+            f"/api/channels/{account_id}/agent-links/{first_link_id}"
+        )
+        missing_delete = await client_a.delete(f"/api/channels/{account_id}/agent-links/{uuid4()}")
 
         links_after = await client_a.get(f"/api/channels/{account_id}/agent-links")
         pool_after_delete = await client_a.get("/api/channels/bot-pool")
@@ -1467,6 +1476,8 @@ async def test_delete_channel_agent_link_archives_link_and_releases_capacity(
     assert before_item["available"] is False
 
     assert deleted.status_code == 204, deleted.text
+    assert second_delete.status_code == 204, second_delete.text
+    assert missing_delete.status_code == 204, missing_delete.text
     assert links_after.status_code == 200, links_after.text
     assert links_after.json() == []
     assert desired_after.status_code == 200, desired_after.text
@@ -1481,11 +1492,13 @@ async def test_delete_channel_agent_link_archives_link_and_releases_capacity(
     assert second_link.status_code == 201, second_link.text
 
     audit_response_body = audit_response.json()
-    archive_event = next(
+    archive_events = [
         event
         for event in audit_response_body["items"]
-        if event["action"] == "channel.agent_link.archive"
-    )
+        if event["action"] == "channel.agent_link.archive" and event["resource_id"] == first_link_id
+    ]
+    assert len(archive_events) == 1
+    archive_event = archive_events[0]
     assert archive_event["resource_type"] == "channel_agent_link"
     assert archive_event["resource_id"] == first_link_id
     assert archive_event["channel_agent_link_id"] == first_link_id
@@ -1496,6 +1509,166 @@ async def test_delete_channel_agent_link_archives_link_and_releases_capacity(
     assert archived_link.status == BOT_AGENT_LINK_STATUS_ARCHIVED
     assert archived_link.archived_at is not None
     assert archived_link.agent_token_hash is None
+
+
+@pytest.mark.asyncio
+async def test_delete_channel_agent_link_cleans_only_link_scoped_runtime_state(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    channel_agent,
+    second_channel_agent,
+):
+    created = (
+        await client.post(
+            "/api/channels",
+            json={
+                "provider": "telegram",
+                "name": f"agent-link-state-delete-{uuid4().hex}",
+                "agent_id": str(channel_agent.id),
+            },
+        )
+    ).json()
+    account_id = UUID(created["id"])
+    target_link_id = UUID(created["agent_link_id"])
+    sibling_link_response = await client.post(
+        f"/api/channels/{account_id}/agent-links",
+        json={"agent_id": str(second_channel_agent.id)},
+    )
+    assert sibling_link_response.status_code == 201, sibling_link_response.text
+    sibling_link_id = UUID(sibling_link_response.json()["id"])
+
+    now = datetime.now(UTC)
+    target_pair_code = ChannelPairCode(
+        account_id=account_id,
+        bot_agent_link_id=target_link_id,
+        user_id=seed_user.id,
+        code_hash=hash_token(f"target-{uuid4()}"),
+        expires_at=now + timedelta(minutes=15),
+    )
+    sibling_pair_code = ChannelPairCode(
+        account_id=account_id,
+        bot_agent_link_id=sibling_link_id,
+        user_id=seed_user.id,
+        code_hash=hash_token(f"sibling-{uuid4()}"),
+        expires_at=now + timedelta(minutes=15),
+    )
+    target_binding = ChannelBinding(
+        account_id=account_id,
+        bot_agent_link_id=target_link_id,
+        user_id=seed_user.id,
+        external_chat_id=f"target-chat-{uuid4().hex}",
+        external_chat_type="private",
+        external_chat_name="Target",
+        status=BINDING_STATUS_ACTIVE,
+    )
+    sibling_binding = ChannelBinding(
+        account_id=account_id,
+        bot_agent_link_id=sibling_link_id,
+        user_id=seed_user.id,
+        external_chat_id=f"sibling-chat-{uuid4().hex}",
+        external_chat_type="private",
+        external_chat_name="Sibling",
+        status=BINDING_STATUS_ACTIVE,
+    )
+    db_session.add_all(
+        [
+            target_pair_code,
+            sibling_pair_code,
+            target_binding,
+            sibling_binding,
+        ]
+    )
+    await db_session.flush()
+
+    target_pending_message = ChannelMessage(
+        account_id=account_id,
+        bot_agent_link_id=target_link_id,
+        binding_id=target_binding.id,
+        user_id=seed_user.id,
+        direction=MESSAGE_DIRECTION_OUTBOUND,
+        external_chat_id=target_binding.external_chat_id,
+        text="queued target",
+        payload={"delivery": DELIVERY_STATUS_PENDING},
+    )
+    target_in_progress_message = ChannelMessage(
+        account_id=account_id,
+        bot_agent_link_id=target_link_id,
+        binding_id=target_binding.id,
+        user_id=seed_user.id,
+        direction=MESSAGE_DIRECTION_OUTBOUND,
+        external_chat_id=target_binding.external_chat_id,
+        text="locked target",
+        payload={"delivery": DELIVERY_STATUS_IN_PROGRESS},
+    )
+    sibling_message = ChannelMessage(
+        account_id=account_id,
+        bot_agent_link_id=sibling_link_id,
+        binding_id=sibling_binding.id,
+        user_id=seed_user.id,
+        direction=MESSAGE_DIRECTION_OUTBOUND,
+        external_chat_id=sibling_binding.external_chat_id,
+        text="queued sibling",
+        payload={"delivery": DELIVERY_STATUS_PENDING},
+    )
+    db_session.add_all([target_pending_message, target_in_progress_message, sibling_message])
+    await db_session.flush()
+
+    target_pending_delivery = ChannelDelivery(
+        account_id=account_id,
+        bot_agent_link_id=target_link_id,
+        message_id=target_pending_message.id,
+        user_id=seed_user.id,
+        status=DELIVERY_STATUS_PENDING,
+        next_attempt_at=now,
+    )
+    target_in_progress_delivery = ChannelDelivery(
+        account_id=account_id,
+        bot_agent_link_id=target_link_id,
+        message_id=target_in_progress_message.id,
+        user_id=seed_user.id,
+        status=DELIVERY_STATUS_IN_PROGRESS,
+        next_attempt_at=now,
+        locked_at=now,
+        locked_by="test-worker",
+    )
+    sibling_delivery = ChannelDelivery(
+        account_id=account_id,
+        bot_agent_link_id=sibling_link_id,
+        message_id=sibling_message.id,
+        user_id=seed_user.id,
+        status=DELIVERY_STATUS_PENDING,
+        next_attempt_at=now,
+    )
+    db_session.add_all([target_pending_delivery, target_in_progress_delivery, sibling_delivery])
+    await db_session.commit()
+
+    deleted = await client.delete(f"/api/channels/{account_id}/agent-links/{target_link_id}")
+
+    assert deleted.status_code == 204, deleted.text
+    for row in (
+        target_pair_code,
+        sibling_pair_code,
+        target_binding,
+        sibling_binding,
+        target_pending_delivery,
+        target_in_progress_delivery,
+        sibling_delivery,
+    ):
+        await db_session.refresh(row)
+
+    assert target_pair_code.status == PAIR_CODE_STATUS_REVOKED
+    assert sibling_pair_code.status == PAIR_CODE_STATUS_PENDING
+    assert target_binding.status == BINDING_STATUS_ARCHIVED
+    assert sibling_binding.status == BINDING_STATUS_ACTIVE
+    assert target_pending_delivery.status == DELIVERY_STATUS_FAILED
+    assert target_pending_delivery.last_error == "channel agent link archived"
+    assert target_in_progress_delivery.status == DELIVERY_STATUS_FAILED
+    assert target_in_progress_delivery.locked_at is None
+    assert target_in_progress_delivery.locked_by is None
+    assert target_in_progress_delivery.last_error == "channel agent link archived"
+    assert sibling_delivery.status == DELIVERY_STATUS_PENDING
+    assert sibling_delivery.last_error is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -1442,6 +1442,10 @@ async def test_delete_channel_agent_link_archives_link_and_releases_capacity(
         )
         assert first_link.status_code == 201, first_link.text
         first_link_id = first_link.json()["id"]
+        active_link = await db_session.get(ChannelBotAgentLink, UUID(first_link_id))
+        assert active_link is not None
+        assert active_link.encrypted_agent_token is not None
+        assert active_link.agent_token_nonce is not None
         full_pool = await client_a.get("/api/channels/bot-pool")
         api_key = ApiKey(user_id=user_a.id, environment_id=agent_a.id, label="hosted")
         async with _client_for_api_key(db_session, user_a, api_key) as runtime_client:
@@ -1509,6 +1513,8 @@ async def test_delete_channel_agent_link_archives_link_and_releases_capacity(
     assert archived_link.status == BOT_AGENT_LINK_STATUS_ARCHIVED
     assert archived_link.archived_at is not None
     assert archived_link.agent_token_hash is None
+    assert archived_link.encrypted_agent_token is None
+    assert archived_link.agent_token_nonce is None
 
 
 @pytest.mark.asyncio
@@ -8081,6 +8087,75 @@ async def test_channel_delivery_worker_retries_provider_failures(
     assert delivery.status == "pending"
     assert delivery.attempts == 1
     assert delivery.last_error == "telegram api unreachable"
+
+
+@pytest.mark.asyncio
+async def test_channel_delivery_does_not_send_after_claimed_link_is_archived(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch,
+):
+    _FakeProviderClient.calls = []
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    created = (
+        await client.post(
+            "/api/channels",
+            json={
+                "provider": "telegram",
+                "name": "telegram-claimed-link-archive",
+                "provider_token": "123456:telegram-secret",
+            },
+        )
+    ).json()
+    binding = ChannelBinding(
+        account_id=UUID(created["id"]),
+        bot_agent_link_id=UUID(created["agent_link_id"]),
+        user_id=seed_user.id,
+        external_chat_id="111",
+        external_chat_type="private",
+        external_chat_name="Test Chat",
+        status=BINDING_STATUS_ACTIVE,
+    )
+    db_session.add(binding)
+    await db_session.commit()
+
+    sent = await client.post(
+        f"/api/channels/{created['id']}/messages",
+        json={"binding_id": str(binding.id), "text": "do not leak"},
+    )
+    assert sent.status_code == 201, sent.text
+
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+    async with sessionmaker() as worker_db:
+        delivery = await channel_service.claim_next_channel_delivery(
+            worker_db,
+            worker_id="claimed-link-archive-test",
+        )
+        assert delivery is not None
+        assert delivery.id == UUID(sent.json()["delivery_id"])
+        await worker_db.commit()
+
+        deleted = await client.delete(
+            f"/api/channels/{created['id']}/agent-links/{created['agent_link_id']}"
+        )
+        assert deleted.status_code == 204, deleted.text
+
+        await channel_service.deliver_channel_delivery(worker_db, delivery=delivery)
+        await worker_db.commit()
+
+    assert _FakeProviderClient.calls == []
+    delivery = (
+        await db_session.execute(
+            select(ChannelDelivery)
+            .where(ChannelDelivery.id == UUID(sent.json()["delivery_id"]))
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one()
+    assert delivery.status == DELIVERY_STATUS_FAILED
+    assert delivery.locked_at is None
+    assert delivery.locked_by is None
+    assert delivery.last_error == "channel agent link archived"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -8125,15 +8125,20 @@ async def test_channel_delivery_does_not_send_after_claimed_link_is_archived(
         json={"binding_id": str(binding.id), "text": "do not leak"},
     )
     assert sent.status_code == 201, sent.text
+    delivery_id = UUID(sent.json()["delivery_id"])
 
     sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
     async with sessionmaker() as worker_db:
-        delivery = await channel_service.claim_next_channel_delivery(
-            worker_db,
-            worker_id="claimed-link-archive-test",
-        )
-        assert delivery is not None
-        assert delivery.id == UUID(sent.json()["delivery_id"])
+        delivery = (
+            await worker_db.execute(
+                select(ChannelDelivery).where(ChannelDelivery.id == delivery_id).with_for_update()
+            )
+        ).scalar_one()
+        delivery.status = DELIVERY_STATUS_IN_PROGRESS
+        delivery.locked_at = datetime.now(UTC)
+        delivery.locked_by = "claimed-link-archive-test"
+        delivery.attempts += 1
+        await worker_db.flush()
         await worker_db.commit()
 
         deleted = await client.delete(
@@ -8148,7 +8153,7 @@ async def test_channel_delivery_does_not_send_after_claimed_link_is_archived(
     delivery = (
         await db_session.execute(
             select(ChannelDelivery)
-            .where(ChannelDelivery.id == UUID(sent.json()["delivery_id"]))
+            .where(ChannelDelivery.id == delivery_id)
             .execution_options(populate_existing=True)
         )
     ).scalar_one()
@@ -8156,6 +8161,171 @@ async def test_channel_delivery_does_not_send_after_claimed_link_is_archived(
     assert delivery.locked_at is None
     assert delivery.locked_by is None
     assert delivery.last_error == "channel agent link archived"
+
+
+@pytest.mark.asyncio
+async def test_channel_delivery_link_lock_contention_does_not_exhaust_attempts(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch,
+):
+    _FakeProviderClient.calls = []
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    created = (
+        await client.post(
+            "/api/channels",
+            json={
+                "provider": "telegram",
+                "name": "telegram-link-lock-contention",
+                "provider_token": "123456:telegram-secret",
+            },
+        )
+    ).json()
+    contention_seen = asyncio.Event()
+    original_lock_active_delivery_link = channel_service._lock_active_delivery_link
+
+    async def lock_active_delivery_link_with_signal(
+        db: AsyncSession,
+        delivery: ChannelDelivery,
+    ):
+        try:
+            return await original_lock_active_delivery_link(db, delivery)
+        except HTTPException as exc:
+            if (
+                exc.status_code == 503
+                and exc.detail == channel_service.DELIVERY_LINK_LOCK_CONTENTION_ERROR
+            ):
+                contention_seen.set()
+            raise
+
+    monkeypatch.setattr(
+        channel_service,
+        "_lock_active_delivery_link",
+        lock_active_delivery_link_with_signal,
+    )
+    binding = ChannelBinding(
+        account_id=UUID(created["id"]),
+        bot_agent_link_id=UUID(created["agent_link_id"]),
+        user_id=seed_user.id,
+        external_chat_id="111",
+        external_chat_type="private",
+        external_chat_name="Test Chat",
+        status=BINDING_STATUS_ACTIVE,
+    )
+    db_session.add(binding)
+    await db_session.commit()
+
+    sent = await client.post(
+        f"/api/channels/{created['id']}/messages",
+        json={"binding_id": str(binding.id), "text": "send after contention"},
+    )
+    assert sent.status_code == 201, sent.text
+    delivery_id = UUID(sent.json()["delivery_id"])
+    delivery = (
+        await db_session.execute(select(ChannelDelivery).where(ChannelDelivery.id == delivery_id))
+    ).scalar_one()
+    assert delivery.bot_agent_link_id == UUID(created["agent_link_id"])
+    delivery.attempts = 1
+    delivery.max_attempts = 2
+    delivery.next_attempt_at = datetime(2000, 1, 1, tzinfo=UTC)
+    await db_session.commit()
+
+    async def claim_delivery(worker_db: AsyncSession, *, worker_id: str) -> ChannelDelivery:
+        claimed = (
+            await worker_db.execute(
+                select(ChannelDelivery).where(ChannelDelivery.id == delivery_id).with_for_update()
+            )
+        ).scalar_one()
+        assert claimed.status == DELIVERY_STATUS_PENDING
+        claimed.status = DELIVERY_STATUS_IN_PROGRESS
+        claimed.locked_at = datetime.now(UTC)
+        claimed.locked_by = worker_id
+        claimed.attempts += 1
+        await worker_db.flush()
+        return claimed
+
+    sessionmaker = async_sessionmaker(db_session.bind, expire_on_commit=False)
+
+    async def run_claimed_delivery(*, worker_id: str) -> None:
+        async with sessionmaker() as worker_db:
+            claimed = await claim_delivery(worker_db, worker_id=worker_id)
+            await channel_service.deliver_channel_delivery(worker_db, delivery=claimed)
+            await worker_db.commit()
+
+    async with sessionmaker() as link_lock_db:
+        contended_task: asyncio.Task[None] | None = None
+        try:
+            async with link_lock_db.begin():
+                locked_link = (
+                    await link_lock_db.execute(
+                        select(ChannelBotAgentLink)
+                        .where(ChannelBotAgentLink.id == UUID(created["agent_link_id"]))
+                        .with_for_update()
+                    )
+                ).scalar_one()
+                assert locked_link.status == "active"
+
+                async with sessionmaker() as probe_db:
+                    skipped_link = (
+                        await probe_db.execute(
+                            select(ChannelBotAgentLink.id)
+                            .where(ChannelBotAgentLink.id == UUID(created["agent_link_id"]))
+                            .with_for_update(skip_locked=True)
+                        )
+                    ).scalar_one_or_none()
+                    assert skipped_link is None
+                    await probe_db.rollback()
+
+                contended_task = asyncio.create_task(
+                    run_claimed_delivery(worker_id="link-contention-test")
+                )
+                await asyncio.wait_for(contention_seen.wait(), timeout=5.0)
+        except Exception:
+            if contended_task is not None and not contended_task.done():
+                contended_task.cancel()
+                try:
+                    await contended_task
+                except asyncio.CancelledError:
+                    pass
+            raise
+
+        assert contended_task is not None
+        await contended_task
+
+    contended_delivery = (
+        await db_session.execute(
+            select(ChannelDelivery)
+            .where(ChannelDelivery.id == delivery_id)
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one()
+    assert contended_delivery.status == DELIVERY_STATUS_PENDING
+    assert contended_delivery.attempts == 1
+    assert contended_delivery.locked_at is None
+    assert contended_delivery.locked_by is None
+    assert contended_delivery.last_error == channel_service.DELIVERY_LINK_LOCK_CONTENTION_ERROR
+    assert _FakeProviderClient.calls == []
+
+    contended_delivery.next_attempt_at = datetime(2000, 1, 1, tzinfo=UTC)
+    await db_session.commit()
+
+    async with sessionmaker() as worker_db:
+        claimed = await claim_delivery(worker_db, worker_id="link-contention-send-test")
+        await channel_service.deliver_channel_delivery(worker_db, delivery=claimed)
+        await worker_db.commit()
+
+    assert len(_FakeProviderClient.calls) == 1
+    delivered = (
+        await db_session.execute(
+            select(ChannelDelivery)
+            .where(ChannelDelivery.id == delivery_id)
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one()
+    assert delivered.status == "succeeded"
+    assert delivered.attempts == 2
+    assert delivered.last_error is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -1499,6 +1499,88 @@ async def test_delete_channel_agent_link_archives_link_and_releases_capacity(
 
 
 @pytest.mark.asyncio
+async def test_list_channel_agent_links_by_agent_returns_linked_channel_summaries(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    channel_agent,
+    second_channel_agent,
+):
+    private = (
+        await client.post(
+            "/api/channels",
+            json={
+                "provider": "telegram",
+                "name": f"agent-links-private-{uuid4().hex}",
+                "agent_id": str(channel_agent.id),
+            },
+        )
+    ).json()
+    other_private = (
+        await client.post(
+            "/api/channels",
+            json={
+                "provider": "discord",
+                "name": f"agent-links-other-{uuid4().hex}",
+                "agent_id": str(second_channel_agent.id),
+            },
+        )
+    ).json()
+    public = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider="telegram",
+        name=f"agent-links-public-{uuid4().hex}",
+    )
+    assert public.status_code == 201, public.text
+    public_body = public.json()
+    public_link = await client.post(
+        f"/api/channels/{public_body['id']}/agent-links",
+        json={"agent_id": str(channel_agent.id)},
+    )
+    assert public_link.status_code == 201, public_link.text
+
+    other_user, other_agent = await _create_user_with_channel_agent(
+        db_session,
+        label="agent-links-other-user",
+    )
+    async with _client_for_user(db_session, other_user) as other_client:
+        other_user_link = await other_client.post(
+            f"/api/channels/{public_body['id']}/agent-links",
+            json={"agent_id": str(other_agent.id)},
+        )
+        other_user_listing = await other_client.get(
+            "/api/channels/agent-links",
+            params={"agent_id": str(channel_agent.id)},
+        )
+    assert other_user_link.status_code == 201, other_user_link.text
+
+    listed = await client.get(
+        "/api/channels/agent-links",
+        params={"agent_id": str(channel_agent.id)},
+    )
+
+    assert listed.status_code == 200, listed.text
+    body = listed.json()
+    by_account_id = {item["account_id"]: item for item in body}
+    assert set(by_account_id) == {private["id"], public_body["id"]}
+    private_item = by_account_id[private["id"]]
+    public_item = by_account_id[public_body["id"]]
+    assert private_item["id"] == private["agent_link_id"]
+    assert private_item["agent_id"] == str(channel_agent.id)
+    assert private_item["status"] == "active"
+    assert private_item["agent_token"] is None
+    assert private_item["account"]["id"] == private["id"]
+    assert private_item["account"]["name"] == private["name"]
+    assert private_item["account"]["visibility"] == "private"
+    assert public_item["id"] == public_link.json()["id"]
+    assert public_item["account"]["id"] == public_body["id"]
+    assert public_item["account"]["visibility"] == "public"
+    assert other_private["id"] not in by_account_id
+    assert other_user_listing.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_public_bot_account_is_admin_managed_even_for_seed_owner(
     client: httpx.AsyncClient,
     db_session: AsyncSession,

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -222,6 +222,129 @@ async def test_admin_runtime_state_upsert_writes_redacted_audit_event(
 
 
 @pytest.mark.asyncio
+async def test_admin_delete_runtime_state_clears_existing_state_and_writes_audit_event(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"delete-runtime-{uuid4().hex[:8]}",
+        machine_name="Runtime Delete",
+        agent_type="openclaw",
+    )
+    expected = await _write_runtime_state(admin_client, str(env.id))
+
+    api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        response = await client.get("/api/runtime/manifest")
+    assert response.status_code == 200, response.text
+    etag = response.headers["etag"]
+
+    deleted = await admin_client.delete(
+        f"/api/admin/environments/{env.id}/runtime-state",
+        headers=_AUTH,
+    )
+
+    assert deleted.status_code == 204, deleted.text
+    assert deleted.content == b""
+    assert await db_session.get(HostedRuntimeState, env.id) is None
+
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        missing = await client.get(
+            "/api/runtime/manifest",
+            headers={"If-None-Match": etag},
+        )
+        audit = await client.get(
+            "/api/audit/events",
+            params={
+                "resource_type": "hosted_runtime_state",
+                "environment_id": str(env.id),
+            },
+        )
+    app.dependency_overrides.clear()
+
+    assert missing.status_code == 404, missing.text
+    assert missing.json() == {"detail": "Hosted runtime state not found"}
+    assert audit.status_code == 200, audit.text
+    payload = audit.json()
+    assert len(payload["items"]) == 2
+    latest = payload["items"][0]
+    assert latest["action"] == "hosted_runtime_state.delete"
+    assert latest["resource_type"] == "hosted_runtime_state"
+    assert latest["environment_id"] == str(env.id)
+    assert latest["target_user_id"] == str(seed_user.id)
+    assert latest["details"]["deployment_id"] == expected["deployment_id"]
+    assert latest["details"]["generation"] == expected["generation"]
+    assert latest["details"]["enabled_runtimes"] == ["openclaw"]
+    assert "secret" not in json.dumps(payload).lower()
+    assert "token" not in json.dumps(payload).lower()
+
+
+@pytest.mark.asyncio
+async def test_admin_delete_runtime_state_missing_row_is_idempotent(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"delete-missing-{uuid4().hex[:8]}",
+        machine_name="Runtime Delete Missing",
+        agent_type="openclaw",
+    )
+
+    deleted = await admin_client.delete(
+        f"/api/admin/environments/{env.id}/runtime-state",
+        headers=_AUTH,
+    )
+
+    assert deleted.status_code == 204, deleted.text
+    assert deleted.content == b""
+    assert await db_session.get(HostedRuntimeState, env.id) is None
+
+    async with await _runtime_client(db_session, seed_user, None) as client:
+        audit = await client.get(
+            "/api/audit/events",
+            params={
+                "resource_type": "hosted_runtime_state",
+                "environment_id": str(env.id),
+            },
+        )
+    app.dependency_overrides.clear()
+
+    assert audit.status_code == 200, audit.text
+    payload = audit.json()
+    assert len(payload["items"]) == 1
+    latest = payload["items"][0]
+    assert latest["action"] == "hosted_runtime_state.delete"
+    assert latest["details"] == {"existed": False}
+
+
+@pytest.mark.asyncio
+async def test_admin_delete_runtime_state_requires_admin_key(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"delete-auth-{uuid4().hex[:8]}",
+        machine_name="Runtime Delete Auth",
+        agent_type="openclaw",
+    )
+    await _write_runtime_state(admin_client, str(env.id))
+
+    rejected = await admin_client.delete(f"/api/admin/environments/{env.id}/runtime-state")
+
+    assert rejected.status_code == 401, rejected.text
+    assert await db_session.get(HostedRuntimeState, env.id) is not None
+
+
+@pytest.mark.asyncio
 async def test_runtime_manifest_generation_reset_keeps_etag_but_returns_generation(
     admin_client,
     db_session,

--- a/backend/tests/test_whatsapp_baileys.py
+++ b/backend/tests/test_whatsapp_baileys.py
@@ -1638,6 +1638,41 @@ async def test_channel_delete_revokes_whatsapp_tenant_credentials(
 
 
 @pytest.mark.asyncio
+async def test_channel_agent_link_delete_revokes_whatsapp_tenant_credentials(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+):
+    created = (
+        await client.post(
+            "/api/channels",
+            json={"provider": "whatsapp", "name": "wa-creds-link-delete"},
+        )
+    ).json()
+    minted = (
+        await client.post(
+            f"/api/channels/whatsapp/{created['id']}/tenant-creds",
+            json={},
+        )
+    ).json()
+
+    deleted = await client.delete(
+        f"/api/channels/{created['id']}/agent-links/{minted['agent_link_id']}"
+    )
+
+    credential = await db_session.get(ChannelAgentCredential, UUID(minted["credential_id"]))
+    assert deleted.status_code == 204
+    assert credential is not None
+    assert credential.revoked_at is not None
+    assert (
+        await resolve_whatsapp_credential_by_identity(
+            db_session,
+            identity_public_key=bytes.fromhex(minted["identity_pub_key_hex"]),
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
 async def test_whatsapp_websocket_inbox_is_scoped_to_agent_link(
     client: httpx.AsyncClient,
     db_session: AsyncSession,

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -298,6 +298,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/channels/agent-links": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List Agent Channel Links */
+        get: operations["list_agent_channel_links_api_channels_agent_links_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/channels/{account_id}/activity": {
         parameters: {
             query?: never;
@@ -2905,6 +2922,34 @@ export interface components {
             created_at: string;
             /** Agent Token */
             agent_token?: string | null;
+        };
+        /** ChannelAgentLinkWithAccountResponse */
+        ChannelAgentLinkWithAccountResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Account Id
+             * Format: uuid
+             */
+            account_id: string;
+            /**
+             * Agent Id
+             * Format: uuid
+             */
+            agent_id: string;
+            /** Status */
+            status: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Agent Token */
+            agent_token?: string | null;
+            account: components["schemas"]["ChannelAccountResponse"];
         };
         /** ChannelBindingResponse */
         ChannelBindingResponse: {
@@ -5826,6 +5871,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ChannelHealthListResponse"];
+                };
+            };
+        };
+    };
+    list_agent_channel_links_api_channels_agent_links_get: {
+        parameters: {
+            query: {
+                agent_id: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChannelAgentLinkWithAccountResponse"][];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -385,6 +385,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/channels/{account_id}/agent-links/{link_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Channel Agent Link */
+        delete: operations["delete_channel_agent_link_api_channels__account_id__agent_links__link_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/channels/{account_id}/bindings": {
         parameters: {
             query?: never;
@@ -6028,6 +6045,36 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["ChannelAgentLinkResponse"];
                 };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_channel_agent_link_api_channels__account_id__agent_links__link_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                account_id: string;
+                link_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Validation Error */
             422: {


### PR DESCRIPTION
## Summary
- Add `DELETE /api/channels/{account_id}/agent-links/{link_id}` to archive an active channel bot-agent link with owner-scoped auth and a `channel.agent_link.archive` control-plane audit event.
- Add `GET /api/channels/agent-links?agent_id={agent_id}` to list one agent's active channel links in a single join query, including each channel account summary for UI rendering.
- Regenerate `packages/shared/src/api/api.generated.ts` for both new public channel API surfaces.

## Endpoint behavior
- `DELETE /api/channels/{account_id}/agent-links/{link_id}` returns `204 No Content`. It resolves the usable account, then uses `get_owned_bot_agent_link` so only the link owner can archive it. Archiving sets `status=archived`, sets `archived_at`, and clears `agent_token_hash`.
- `GET /api/channels/agent-links?agent_id={agent_id}` returns `ChannelAgentLinkWithAccountResponse[]`: the existing agent-link response fields plus an `account` shaped like `ChannelAccountResponse`. It first verifies the requested agent belongs to the authenticated user, then returns active, unarchived links on active, unarchived channel accounts.

## Reconcile and capacity
- Runtime desired-state reads still use `GET /api/channels` for environment-bound API keys. Because that query only includes active, unarchived links, an archived link disappears from the pod's desired-state response and the runtime reconciles the removal on its next fetch.
- Bot-pool `link_count` and shared-pool capacity are unchanged semantically: existing counts only include active, unarchived links. After unlink, capacity is released and another user/agent can link when `max_links` allows it.

## Tests
- Added coverage that unlink removes a link from account link listing and runtime desired state, records audit, archives the DB row, clears token hash, and releases public bot-pool capacity.
- Added coverage that per-agent listing returns private + public linked channel summaries for the owning user, excludes other agents/users, and rejects another user listing an agent they do not own.

## Verification
- `uv run pytest -q tests/test_channels.py` -> 147 passed, 2 existing SQLAlchemy connection cleanup warnings.
- `uv run ruff check app/routes/channel_routers/public.py app/services/channels.py app/schemas/channel.py tests/test_channels.py` -> passed.
- `uv run python scripts/check_generated_api.py` -> passed.
- `bun run check` -> passed.

Note: full `uv run ruff check .` is currently blocked by pre-existing Alembic migration lint issues unrelated to this change.
