### PR TITLE
Add hosted management dark launch UI

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -15,7 +15,11 @@ const nextConfig: NextConfig = {
 	// Redirecting these breaks payload delivery.
 	skipTrailingSlashRedirect: isHostedBuild,
 	images: {
-		remotePatterns: [{ hostname: "img.clerk.com" }],
+		remotePatterns: [
+			{ hostname: "img.clerk.com" },
+			{ hostname: "assets.clawdi.ai" },
+			{ hostname: "cdn.simpleicons.org" },
+		],
 	},
 	// Share URLs use a file-extension UX (`/s/{id}.md`, `/s/{id}.json`)
 	// rather than `/s/{id}?format=md`. The extension is what makes

--- a/apps/web/src/app/(dashboard)/ai-providers/layout.tsx
+++ b/apps/web/src/app/(dashboard)/ai-providers/layout.tsx
@@ -1,0 +1,10 @@
+import { pageMetadata } from "@/app/page-metadata";
+
+export const metadata = pageMetadata(
+	"AI Providers",
+	"Managed AI by default, plus your own OpenAI, Anthropic, OpenRouter, Gemini, Mistral, or custom providers.",
+);
+
+export default function AiProvidersLayout({ children }: { children: React.ReactNode }) {
+	return children;
+}

--- a/apps/web/src/app/(dashboard)/ai-providers/page.tsx
+++ b/apps/web/src/app/(dashboard)/ai-providers/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { HostedRouteSkeleton } from "@/components/hosted-route-skeleton";
+import { IS_HOSTED } from "@/lib/hosted";
+
+// Hosted-only surface. The dynamic import is constructed only when
+// `IS_HOSTED` is true so OSS builds eliminate the chunk entirely.
+const AiProvidersPage = IS_HOSTED
+	? dynamic(
+			() =>
+				import("@/hosted/ai-providers/ai-providers-page").then((m) => ({
+					default: m.AiProvidersPage,
+				})),
+			{ loading: HostedRouteSkeleton },
+		)
+	: null;
+
+export default function Page() {
+	return AiProvidersPage ? <AiProvidersPage /> : null;
+}

--- a/apps/web/src/app/(dashboard)/channels/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/channels/[id]/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { HostedRouteSkeleton } from "@/components/hosted-route-skeleton";
+import { IS_HOSTED } from "@/lib/hosted";
+
+const ChannelDetailPage = IS_HOSTED
+	? dynamic(
+			() =>
+				import("@/hosted/channels/channel-detail-page").then((m) => ({
+					default: m.ChannelDetailPage,
+				})),
+			{ loading: HostedRouteSkeleton },
+		)
+	: null;
+
+export default function Page() {
+	return ChannelDetailPage ? <ChannelDetailPage /> : null;
+}

--- a/apps/web/src/app/(dashboard)/channels/layout.tsx
+++ b/apps/web/src/app/(dashboard)/channels/layout.tsx
@@ -1,0 +1,10 @@
+import { pageMetadata } from "@/app/page-metadata";
+
+export const metadata = pageMetadata(
+	"Channels",
+	"Connect Telegram, Discord, WhatsApp, and iMessage to your agents.",
+);
+
+export default function ChannelsLayout({ children }: { children: React.ReactNode }) {
+	return children;
+}

--- a/apps/web/src/app/(dashboard)/channels/page.tsx
+++ b/apps/web/src/app/(dashboard)/channels/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { HostedRouteSkeleton } from "@/components/hosted-route-skeleton";
+import { IS_HOSTED } from "@/lib/hosted";
+
+// Hosted-only surface. The dynamic import is constructed only when
+// `IS_HOSTED` is true so OSS builds eliminate the chunk entirely.
+const ChannelsPage = IS_HOSTED
+	? dynamic(
+			() => import("@/hosted/channels/channels-page").then((m) => ({ default: m.ChannelsPage })),
+			{ loading: HostedRouteSkeleton },
+		)
+	: null;
+
+export default function Page() {
+	return ChannelsPage ? <ChannelsPage /> : null;
+}

--- a/apps/web/src/app/oauth/codex/callback/page.tsx
+++ b/apps/web/src/app/oauth/codex/callback/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { HostedRouteSkeleton } from "@/components/hosted-route-skeleton";
+import { IS_HOSTED } from "@/lib/hosted";
+
+// Codex "Sign in with ChatGPT" OAuth callback. Hosted-only; the OSS bundle
+// tree-shakes it via the IS_HOSTED-gated dynamic import.
+const CodexOAuthCallback = IS_HOSTED
+	? dynamic(
+			() => import("@/hosted/ai-providers/codex-oauth-callback").then((m) => m.CodexOAuthCallback),
+			{ loading: HostedRouteSkeleton },
+		)
+	: null;
+
+export default function CodexOAuthCallbackPage() {
+	if (!CodexOAuthCallback) return null;
+	return <CodexOAuthCallback />;
+}

--- a/apps/web/src/components/entity-card.tsx
+++ b/apps/web/src/components/entity-card.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { Check, ChevronRight } from "lucide-react";
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The entity-card FAMILY. Consistency comes from SHARED PRIMITIVES, not one
+ * rigid shape:
+ *
+ *   - `EntityIcon` (separate module)  — the real brand/app-icon tile
+ *   - `EntityHeader` / `EntityMeta`   — the `[icon] [title + meta]` lockup
+ *   - `StatusBadge`, the p-4/gap-3/rounded-lg/border + hover/focus tokens
+ *
+ * Card TYPES compose those primitives but differ by the entity's role:
+ *   - `EntityRow`        — compact list rows (channels, connectors)
+ *   - `EntityChoiceCard` — selectable options (deploy wizard)
+ *   - agent tiles, resource cards, pool items compose `EntityHeader` directly
+ *     where they need a richer, bespoke body.
+ */
+
+export const ENTITY_CARD_BASE = "rounded-lg border p-4";
+
+/** Meta line — array items render middot-separated; truncates per item. */
+export function EntityMeta({
+	items,
+	className,
+}: {
+	items: ReactNode | ReactNode[];
+	className?: string;
+}) {
+	const arr = (Array.isArray(items) ? items : [items]).filter(
+		(x) => x !== null && x !== undefined && x !== false && x !== "",
+	);
+	if (arr.length === 0) return null;
+	// Stable, content-derived keys (string items key on their text; nodes on
+	// position) so we never key on the raw map index.
+	const keyFor = (item: ReactNode, i: number) =>
+		typeof item === "string" || typeof item === "number" ? `t:${item}` : `n:${i}`;
+	return (
+		<div
+			className={cn(
+				"mt-0.5 flex min-w-0 flex-wrap items-center gap-y-0.5 text-sm text-muted-foreground",
+				className,
+			)}
+		>
+			{arr.map((item, i) => (
+				<span key={keyFor(item, i)} className="inline-flex min-w-0 items-center">
+					{i > 0 ? <span className="mx-1.5 text-muted-foreground/40">·</span> : null}
+					<span className="truncate">{item}</span>
+				</span>
+			))}
+		</div>
+	);
+}
+
+/**
+ * The shared lockup every card type reuses: `[EntityIcon] [title (+adornment) /
+ * meta]`. This is where the cross-surface consistency lives.
+ */
+export function EntityHeader({
+	icon,
+	title,
+	titleAdornment,
+	meta,
+	align = "center",
+	className,
+}: {
+	icon: ReactNode;
+	title: ReactNode;
+	titleAdornment?: ReactNode;
+	meta?: ReactNode | ReactNode[];
+	/** `start` aligns the icon to the top for multi-line bodies. */
+	align?: "center" | "start";
+	className?: string;
+}) {
+	return (
+		<div
+			className={cn(
+				"flex min-w-0 gap-3",
+				align === "start" ? "items-start" : "items-center",
+				className,
+			)}
+		>
+			{icon}
+			<div className="min-w-0 flex-1">
+				<div className="flex items-center gap-2">
+					<span className="truncate text-sm font-medium">{title}</span>
+					{titleAdornment}
+				</div>
+				{meta !== undefined ? <EntityMeta items={meta} /> : null}
+			</div>
+		</div>
+	);
+}
+
+interface EntityRowProps {
+	icon: ReactNode;
+	title: ReactNode;
+	titleAdornment?: ReactNode;
+	meta?: ReactNode | ReactNode[];
+	/** Right-aligned status chip (StatusBadge). Non-interactive. */
+	status?: ReactNode;
+	/** Right-aligned interactive controls; suppresses the chevron. */
+	actions?: ReactNode;
+	/** Extra right-aligned interactive content (e.g. a manage link). */
+	trailing?: ReactNode;
+	/** Whole-row navigation (stretched link). */
+	href?: string;
+	external?: boolean;
+	ariaLabel?: string;
+	/** Whole-row button. Ignored when `href` is set. */
+	onClick?: () => void;
+	disabled?: boolean;
+	className?: string;
+}
+
+/**
+ * Compact list row — `[icon][title + meta][status][chevron | actions]`. The
+ * dense, single-line member of the family (channels, connectors). When `href`
+ * is set the whole row navigates via a stretched link while `actions`/`trailing`
+ * stay independently clickable.
+ */
+export function EntityRow({
+	icon,
+	title,
+	titleAdornment,
+	meta,
+	status,
+	actions,
+	trailing,
+	href,
+	external,
+	ariaLabel,
+	onClick,
+	disabled,
+	className,
+}: EntityRowProps) {
+	const label = ariaLabel ?? (typeof title === "string" ? title : "Open");
+	const body = (
+		<>
+			<EntityHeader icon={icon} title={title} titleAdornment={titleAdornment} meta={meta} />
+			{status ? <div className="shrink-0">{status}</div> : null}
+			{trailing ? <div className="relative z-10 shrink-0">{trailing}</div> : null}
+			{actions ? (
+				<div className="relative z-10 flex shrink-0 items-center gap-2">{actions}</div>
+			) : null}
+		</>
+	);
+
+	if (onClick && !href) {
+		return (
+			<button
+				type="button"
+				onClick={onClick}
+				disabled={disabled}
+				className={cn(
+					ENTITY_CARD_BASE,
+					"flex w-full items-center gap-3 text-left transition-colors hover:bg-muted/50",
+					disabled && "pointer-events-none opacity-60",
+					className,
+				)}
+			>
+				{body}
+			</button>
+		);
+	}
+
+	if (href) {
+		const linkClass =
+			"absolute inset-0 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+		return (
+			<div className="group relative z-0">
+				<div
+					className={cn(
+						ENTITY_CARD_BASE,
+						"flex items-center gap-3 transition-colors group-hover:bg-muted/50",
+						className,
+					)}
+				>
+					{body}
+					{!actions && !trailing ? (
+						<ChevronRight className="size-4 shrink-0 text-muted-foreground/60" aria-hidden />
+					) : null}
+				</div>
+				{external ? (
+					<a href={href} target="_blank" rel="noopener noreferrer" className={linkClass}>
+						<span className="sr-only">{label}</span>
+					</a>
+				) : (
+					<Link href={href} className={linkClass}>
+						<span className="sr-only">{label}</span>
+					</Link>
+				)}
+			</div>
+		);
+	}
+
+	return <div className={cn(ENTITY_CARD_BASE, "flex items-center gap-3", className)}>{body}</div>;
+}
+
+/**
+ * Selectable option — icon + title + description + a selected check/ring. The
+ * picker member of the family (deploy-wizard framework / provider / channel
+ * choices).
+ */
+export function EntityChoiceCard({
+	icon,
+	title,
+	description,
+	badge,
+	selected,
+	onClick,
+	disabled,
+	className,
+}: {
+	icon: ReactNode;
+	title: ReactNode;
+	description?: ReactNode;
+	/** Trailing badge in the title row (e.g. "Default", an auth chip). */
+	badge?: ReactNode;
+	selected?: boolean;
+	onClick?: () => void;
+	disabled?: boolean;
+	className?: string;
+}) {
+	const content = (
+		<>
+			{icon}
+			<div className="min-w-0 flex-1">
+				<div className="flex items-center gap-2">
+					<span className="truncate text-sm font-medium">{title}</span>
+					{badge}
+				</div>
+				{description ? <p className="mt-0.5 text-sm text-muted-foreground">{description}</p> : null}
+			</div>
+			{selected ? <Check className="mt-0.5 size-4 shrink-0 text-primary" aria-hidden /> : null}
+		</>
+	);
+	const cardClass = cn(
+		ENTITY_CARD_BASE,
+		"flex w-full items-start gap-3 text-left transition-colors",
+		selected
+			? "border-primary bg-primary/5 ring-1 ring-primary/30"
+			: onClick && "hover:bg-muted/50",
+		disabled && "pointer-events-none opacity-60",
+		className,
+	);
+	if (!onClick) {
+		return <div className={cardClass}>{content}</div>;
+	}
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			disabled={disabled}
+			aria-pressed={selected}
+			className={cardClass}
+		>
+			{content}
+		</button>
+	);
+}

--- a/apps/web/src/components/entity-icon.tsx
+++ b/apps/web/src/components/entity-icon.tsx
@@ -1,0 +1,146 @@
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+
+/**
+ * One icon for every entity — channels, AI providers, and agent frameworks —
+ * so they share identical geometry (rounded tile + subtle shadow) across
+ * cards, pickers, lists, and the sidebar.
+ *
+ * Sources, in resolution order:
+ *   - channel   → full-color app-icon PNG on Clawdi's CDN
+ *   - framework → local app-icon PNG in /public/agents
+ *   - provider  → colored brand logo from simpleicons (the CDN has no
+ *                 provider PNGs) on a white tile so the brand color reads in
+ *                 both themes; OpenAI / custom have no brand mark → monogram
+ *   - anything unresolved → neutral monogram tile
+ *
+ * Uses next/image `unoptimized` (per the monorepo ChannelIcon) — these are
+ * tiny/vector brand assets that don't benefit from the optimizer.
+ */
+
+const ICON_BASE = "https://assets.clawdi.ai/icons";
+const SIMPLEICON_BASE = "https://cdn.simpleicons.org";
+
+/** Channels: full-color app-icon PNGs on Clawdi's CDN. */
+const CHANNEL_PNG: Record<string, string> = {
+	telegram: `${ICON_BASE}/telegram.png`,
+	discord: `${ICON_BASE}/discord.png`,
+	whatsapp: `${ICON_BASE}/whatsapp.png`,
+	imessage: `${ICON_BASE}/imessage.png`,
+	bluebubbles: `${ICON_BASE}/bluebubbles.png`,
+	slack: `${ICON_BASE}/slack.png`,
+};
+
+/** Agent frameworks: local app-icon PNGs in /public/agents. */
+const FRAMEWORK_PNG: Record<string, string> = {
+	openclaw: "/agents/openclaw.png",
+	hermes: "/agents/hermes.png",
+	"claude-code": "/agents/claude-code.png",
+	claude_code: "/agents/claude-code.png",
+	codex: "/agents/codex.png",
+};
+
+/**
+ * AI providers: no CDN PNG (those 404) → colored simpleicons brand logo. The
+ * hex is pinned to a vivid, mid-tone brand color so it reads on a white tile
+ * in both themes. `null` → neutral monogram (OpenAI isn't in simpleicons;
+ * custom endpoints have no brand).
+ */
+const PROVIDER_SIMPLEICON: Record<string, { slug: string; hex: string } | null> = {
+	openai: null,
+	anthropic: { slug: "anthropic", hex: "D97757" },
+	gemini: { slug: "googlegemini", hex: "1C69FF" },
+	google: { slug: "googlegemini", hex: "1C69FF" },
+	mistral: { slug: "mistralai", hex: "FA520F" },
+	openrouter: { slug: "openrouter", hex: "6566F1" },
+	custom_openai_compatible: null,
+};
+
+const SIZE = {
+	sm: { px: 24, box: "size-6 rounded-md", mono: "text-[10px]" },
+	md: { px: 40, box: "size-10 rounded-lg", mono: "text-sm" },
+	lg: { px: 48, box: "size-12 rounded-xl", mono: "text-base" },
+} as const;
+
+export type EntityIconSize = keyof typeof SIZE;
+export type EntityKind = "channel" | "provider" | "framework";
+
+const SHADOW = "shadow-[0_2px_6px_rgba(0,0,0,0.1)] dark:shadow-none";
+
+export function EntityIcon({
+	kind,
+	id,
+	label,
+	size = "md",
+	className,
+}: {
+	kind: EntityKind;
+	/** Provider type / channel provider / framework agent_type. */
+	id: string;
+	/** Human label — used for alt text and the fallback monogram. */
+	label?: string;
+	size?: EntityIconSize;
+	className?: string;
+}) {
+	const s = SIZE[size];
+	const key = id?.toLowerCase?.() ?? "";
+	const alt = label ?? id ?? "";
+
+	// Full-color PNG app icon (channels, frameworks) — fills the rounded tile.
+	const png =
+		kind === "channel" ? CHANNEL_PNG[key] : kind === "framework" ? FRAMEWORK_PNG[key] : undefined;
+	if (png) {
+		return (
+			<Image
+				src={png}
+				alt={alt}
+				width={s.px}
+				height={s.px}
+				unoptimized
+				className={cn(s.box, "shrink-0 object-cover", SHADOW, className)}
+			/>
+		);
+	}
+
+	// Provider brand logo (colored simpleicon) on a white tile.
+	if (kind === "provider") {
+		const brand = PROVIDER_SIMPLEICON[key];
+		if (brand) {
+			return (
+				<span
+					className={cn(
+						s.box,
+						"flex shrink-0 items-center justify-center border border-border bg-white",
+						SHADOW,
+						className,
+					)}
+				>
+					<Image
+						src={`${SIMPLEICON_BASE}/${brand.slug}/${brand.hex}`}
+						alt={alt}
+						width={s.px}
+						height={s.px}
+						unoptimized
+						className="size-[60%] object-contain"
+					/>
+				</span>
+			);
+		}
+	}
+
+	// Neutral fallback: a monogram tile (OpenAI, custom endpoints, unknown ids).
+	const mono = alt.trim().charAt(0).toUpperCase() || "?";
+	return (
+		<span
+			aria-hidden
+			className={cn(
+				s.box,
+				"flex shrink-0 items-center justify-center bg-muted font-semibold text-muted-foreground",
+				s.mono,
+				className,
+			)}
+		>
+			{mono}
+		</span>
+	);
+}

--- a/apps/web/src/components/hosted-route-skeleton.tsx
+++ b/apps/web/src/components/hosted-route-skeleton.tsx
@@ -1,0 +1,19 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Loading fallback for the IS_HOSTED-gated `dynamic()` route imports (billing,
+ * ai-providers, deploy). Without it the chunk load shows a blank frame before
+ * the page's own skeleton mounts. Header + body skeleton matching the canonical
+ * `px-4 lg:px-6` page chrome.
+ */
+export function HostedRouteSkeleton() {
+	return (
+		<div className="space-y-6 px-4 lg:px-6">
+			<div className="space-y-2">
+				<Skeleton className="h-8 w-48" />
+				<Skeleton className="h-4 w-72" />
+			</div>
+			<Skeleton className="h-48 w-full rounded-lg" />
+		</div>
+	);
+}

--- a/apps/web/src/components/info-card.tsx
+++ b/apps/web/src/components/info-card.tsx
@@ -1,0 +1,32 @@
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+/**
+ * Informational banner — a tinted icon tile beside a title + description. The
+ * static "here's how this works" card shared across hosted surfaces (channel
+ * detail tabs, agent detail). `children` is the description body, so it may
+ * carry inline links or interpolated copy.
+ */
+export function InfoCard({
+	icon: Icon,
+	title,
+	children,
+}: {
+	icon: LucideIcon;
+	title: ReactNode;
+	children: ReactNode;
+}) {
+	return (
+		<div className="rounded-lg border bg-card p-4">
+			<div className="flex items-start gap-3">
+				<span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+					<Icon className="size-5" />
+				</span>
+				<div className="min-w-0 flex-1 space-y-1">
+					<div className="text-sm font-medium">{title}</div>
+					<p className="text-sm text-muted-foreground">{children}</p>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/ui/confirm-action.tsx
+++ b/apps/web/src/components/ui/confirm-action.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { type ReactNode, useRef, useState } from "react";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -13,6 +13,7 @@ import {
 	AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { buttonVariants } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 
 export function ConfirmAction({
@@ -30,10 +31,34 @@ export function ConfirmAction({
 	confirmLabel?: string;
 	cancelLabel?: string;
 	destructive?: boolean;
-	onConfirm: () => void;
+	/**
+	 * May be sync or async (any return). When it returns a promise the dialog
+	 * stays open with a spinner until it settles, then closes.
+	 */
+	onConfirm: () => unknown;
 }) {
+	const [open, setOpen] = useState(false);
+	const [pending, setPending] = useState(false);
+	// Synchronous lock: `disabled` only takes effect on the next render, leaving
+	// a sub-frame window where a fast double-click (or Enter repeat) could fire
+	// the destructive action twice before React repaints.
+	const locked = useRef(false);
+
+	async function runConfirm() {
+		if (locked.current) return;
+		locked.current = true;
+		setPending(true);
+		try {
+			await onConfirm();
+			setOpen(false);
+		} finally {
+			setPending(false);
+			locked.current = false;
+		}
+	}
+
 	return (
-		<AlertDialog>
+		<AlertDialog open={open} onOpenChange={(next) => !pending && setOpen(next)}>
 			<AlertDialogTrigger asChild>{children}</AlertDialogTrigger>
 			<AlertDialogContent>
 				<AlertDialogHeader>
@@ -43,11 +68,22 @@ export function ConfirmAction({
 					</AlertDialogDescription>
 				</AlertDialogHeader>
 				<AlertDialogFooter>
-					<AlertDialogCancel>{cancelLabel}</AlertDialogCancel>
+					<AlertDialogCancel disabled={pending}>{cancelLabel}</AlertDialogCancel>
 					<AlertDialogAction
-						onClick={onConfirm}
+						// Keep the dialog open until the action settles — Radix's Dialog.Close
+						// composes its close with `checkForDefaultPrevented`, so preventDefault
+						// suppresses the auto-close while we run.
+						onClick={(event) => {
+							event.preventDefault();
+							// runConfirm rejects when onConfirm does; the dialog already stays open
+							// on reject and callers own their onError, so just swallow the
+							// unhandled-rejection console noise without changing behavior.
+							void runConfirm().catch(() => {});
+						}}
+						disabled={pending}
 						className={cn(destructive && buttonVariants({ variant: "destructive" }))}
 					>
+						{pending ? <Spinner /> : null}
 						{confirmLabel}
 					</AlertDialogAction>
 				</AlertDialogFooter>

--- a/apps/web/src/hosted/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/ai-providers/add-provider-dialog.tsx
@@ -1,0 +1,748 @@
+"use client";
+
+import { CircleAlert, ExternalLink } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import {
+	useAiProviders,
+	useDeleteProviderQuiet,
+	useOAuthComplete,
+	useOAuthStart,
+	useSaveApiKeyToVault,
+	useSetApiKey,
+	useUpsertProvider,
+	useUpsertProviderQuiet,
+	useValidateProvider,
+} from "@/hosted/ai-providers/ai-providers-hooks";
+import { ProviderTypeChip } from "@/hosted/ai-providers/ai-providers-ui";
+import {
+	CLAWDI_CODEX_OAUTH_PROVIDER_ID,
+	CODEX_OAUTH_CHANNEL,
+	CODEX_OAUTH_STORAGE_KEY,
+	type CodexOAuthResult,
+	codexProviderBody,
+	codexRedirectUri,
+	parseCodexCallback,
+} from "@/hosted/ai-providers/codex-oauth";
+import {
+	API_MODE_LABEL,
+	type ApiMode,
+	PROVIDER_TYPES,
+	type ProviderTypeId,
+	providerTypeMeta,
+	toProviderId,
+} from "@/hosted/ai-providers/provider-types";
+import type { AiProvider, AiProviderAuth } from "@/hosted/ai-providers/types";
+
+type AuthMethod = "api_key" | "vault" | "oauth" | "none";
+
+function authFor(method: AuthMethod): AiProviderAuth {
+	if (method === "api_key") return { type: "api_key", source: "managed" };
+	if (method === "oauth") return { type: "agent_profile", tool: "codex", profile: "default" };
+	// `vault` builds its `secret_ref` after the key is stored (see submit()).
+	return { type: "none" };
+}
+
+// Backend rule (_validate_base_url): `none` auth is only allowed for a loopback
+// or RFC-1918 private base_url. Mirror it so the form blocks early with a hint
+// instead of a generic 422.
+function isLoopbackOrPrivateUrl(raw: string): boolean {
+	let host: string;
+	try {
+		host = new URL(raw).hostname;
+	} catch {
+		return false;
+	}
+	if (host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "0.0.0.0")
+		return true;
+	if (/^10\./.test(host) || /^192\.168\./.test(host)) return true;
+	if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
+	return false;
+}
+
+export function AddProviderDialog({
+	open,
+	onOpenChange,
+	editing,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	editing?: AiProvider | null;
+}) {
+	const providers = useAiProviders();
+	const upsert = useUpsertProvider();
+	const upsertQuiet = useUpsertProviderQuiet();
+	const cleanupCodex = useDeleteProviderQuiet();
+	const setKey = useSetApiKey();
+	const saveToVault = useSaveApiKeyToVault();
+	const validate = useValidateProvider();
+	const oauthStart = useOAuthStart();
+	const oauthComplete = useOAuthComplete();
+
+	const isEdit = Boolean(editing);
+	const [type, setType] = useState<ProviderTypeId>("openai");
+	const [label, setLabel] = useState("");
+	const [baseUrl, setBaseUrl] = useState("");
+	const [defaultModel, setDefaultModel] = useState("");
+	const [apiMode, setApiMode] = useState<ApiMode>("openai_chat");
+	const [runtimeEnv, setRuntimeEnv] = useState("");
+	const [authMethod, setAuthMethod] = useState<AuthMethod>("api_key");
+	const [apiKey, setApiKey] = useState("");
+
+	// OAuth sub-flow
+	const [oauth, setOauth] = useState<{
+		providerId: string;
+		state: string;
+		authUrl: string;
+		redirectUri: string;
+		expiresAt: string;
+	} | null>(null);
+	const [oauthCode, setOauthCode] = useState("");
+	// "closed" = the popup was closed before completing; "expired" = the start
+	// session timed out; "blocked" = the browser blocked the pop-up. All three
+	// stop the spinner and surface a recover-from-here CTA — recovery always
+	// re-runs `oauth/start` for a FRESH link (a stale/expired/consumed start
+	// can't be reopened), never reuses `oauth.authUrl`.
+	const [oauthIssue, setOauthIssue] = useState<"closed" | "expired" | "blocked" | null>(null);
+	// Guards a single completion across the three callback channels; finishRef
+	// holds the latest completion closure for the listener effect.
+	const completedRef = useRef(false);
+	const finishRef = useRef<(r: CodexOAuthResult) => void>(() => {});
+	// The sign-in popup handle (to poll `closed`) and whether THIS flow created
+	// the canonical openai-codex provider (so an abandon cleans up only our own
+	// orphan, never a pre-existing connected provider).
+	const popupRef = useRef<Window | null>(null);
+	const createdFreshRef = useRef(false);
+
+	const meta = providerTypeMeta(type);
+
+	// Initialize when (re)opened.
+	useEffect(() => {
+		if (!open) return;
+		setOauth(null);
+		setOauthCode("");
+		setOauthIssue(null);
+		setApiKey("");
+		completedRef.current = false;
+		createdFreshRef.current = false;
+		popupRef.current = null;
+		if (editing) {
+			const m = providerTypeMeta(editing.type);
+			setType(editing.type as ProviderTypeId);
+			setLabel(editing.label ?? "");
+			setBaseUrl(editing.base_url);
+			setDefaultModel(editing.default_model ?? "");
+			setApiMode((editing.api_mode as ApiMode) ?? m.defaultApiMode);
+			setRuntimeEnv(editing.runtime_env_name ?? m.defaultRuntimeEnv);
+			setAuthMethod(
+				editing.auth.type === "none"
+					? "none"
+					: editing.auth.type === "api_key"
+						? "api_key"
+						: editing.auth.type === "secret_ref"
+							? "vault"
+							: "oauth",
+			);
+		} else {
+			const m = providerTypeMeta("openai");
+			setType("openai");
+			setLabel("");
+			setBaseUrl(m.defaultBaseUrl);
+			setDefaultModel("");
+			setApiMode(m.defaultApiMode);
+			setRuntimeEnv(m.defaultRuntimeEnv);
+			setAuthMethod("api_key");
+		}
+	}, [open, editing]);
+
+	// Prefill when the type changes (add mode only).
+	function changeType(next: ProviderTypeId) {
+		setType(next);
+		const m = providerTypeMeta(next);
+		setBaseUrl(m.defaultBaseUrl);
+		setDefaultModel("");
+		setApiMode(m.defaultApiMode);
+		setRuntimeEnv(m.defaultRuntimeEnv);
+		setApiKey("");
+		if (!m.oauth && authMethod === "oauth") setAuthMethod("api_key");
+		if (!m.custom && authMethod === "none") setAuthMethod("api_key");
+	}
+
+	const providerId = isEdit ? (editing?.provider_id ?? "") : toProviderId(label || meta.label);
+	// `none` auth only works with a loopback/private base_url (backend rule).
+	const noneAuthOk = authMethod !== "none" || isLoopbackOrPrivateUrl(baseUrl.trim());
+	const canKeepManagedApiKey =
+		authMethod === "api_key" && isEdit && editing?.auth.type === "api_key";
+	// A key is required for api_key unless this provider is already using a
+	// managed API key, and always for vault (the secret_ref is built from the
+	// entered key — there's nothing to "keep").
+	const keyRequired = (authMethod === "api_key" && !canKeepManagedApiKey) || authMethod === "vault";
+	const canSubmit =
+		Boolean(providerId) &&
+		Boolean(baseUrl.trim()) &&
+		noneAuthOk &&
+		(!keyRequired || apiKey.trim().length > 0);
+
+	async function submit() {
+		if (!canSubmit) return;
+
+		// Codex "Sign in with ChatGPT": create the canonical openai-codex provider
+		// with the app callback redirect, then open ChatGPT. The callback route
+		// hands code+state back and we complete automatically (paste fallback in
+		// the sub-screen). redirect_uri stays identical across start/complete.
+		if (authMethod === "oauth") {
+			const redirectUri = codexRedirectUri();
+			// The canonical openai-codex provider must exist before `start`, but it
+			// isn't connected until `complete`. Only create it (quietly, without
+			// invalidating the list) if it doesn't already exist — so we never
+			// clobber a previously-connected provider, and an abandon cleans up
+			// only the record we ourselves created.
+			const existingCodex = providers.data?.providers?.some(
+				(p) => p.provider_id === CLAWDI_CODEX_OAUTH_PROVIDER_ID,
+			);
+			if (!existingCodex) {
+				const codexCreated = await upsertQuiet
+					.mutateAsync(codexProviderBody(defaultModel))
+					.catch(() => null);
+				if (!codexCreated) return; // upsertQuiet.onError already toasts
+				createdFreshRef.current = true;
+			} else {
+				createdFreshRef.current = false;
+			}
+			const started = await oauthStart
+				.mutateAsync({
+					providerId: CLAWDI_CODEX_OAUTH_PROVIDER_ID,
+					provider: "codex",
+					redirect_uri: redirectUri,
+				})
+				.catch(() => null);
+			if (!started) {
+				// Couldn't start — don't leave our just-created placeholder behind.
+				if (createdFreshRef.current) {
+					cleanupCodex.mutate(CLAWDI_CODEX_OAUTH_PROVIDER_ID);
+					createdFreshRef.current = false;
+				}
+				return; // oauthStart.onError already toasts
+			}
+			completedRef.current = false;
+			setOauthIssue(null);
+			try {
+				localStorage.removeItem(CODEX_OAUTH_STORAGE_KEY);
+			} catch {}
+			setOauth({
+				providerId: CLAWDI_CODEX_OAUTH_PROVIDER_ID,
+				state: started.state,
+				authUrl: started.auth_url,
+				redirectUri,
+				expiresAt: started.expires_at,
+			});
+			openSignIn(started.auth_url);
+			return;
+		}
+
+		// `vault`: store the key in the project vault first → secret_ref.
+		let auth = authFor(authMethod);
+		if (authMethod === "vault") {
+			const ref = await saveToVault
+				.mutateAsync({ providerId, apiKey: apiKey.trim() })
+				.catch(() => null);
+			if (!ref) return; // saveToVault.onError already toasts
+			auth = { type: "secret_ref", ref };
+		}
+
+		const keyBacked = authMethod === "api_key" || authMethod === "vault";
+		const body = {
+			provider_id: providerId,
+			type,
+			label: label.trim() || null,
+			base_url: baseUrl.trim(),
+			default_model: defaultModel.trim() || null,
+			api_mode: apiMode,
+			auth,
+			managed_by: "user" as const,
+			runtime_env_name: keyBacked ? runtimeEnv.trim() || null : null,
+		};
+		const created = await upsert.mutateAsync(body).catch(() => null);
+		if (!created) return;
+
+		if (authMethod === "api_key" && apiKey.trim()) {
+			// Don't claim success on a key that didn't store — `/validate` only
+			// re-checks config shape, not that the key landed. setKey's onError
+			// already toasts; keep the dialog open so the user can retry.
+			const keyStored = await setKey
+				.mutateAsync({
+					providerId,
+					value: apiKey.trim(),
+					runtime_env_name: runtimeEnv.trim() || undefined,
+				})
+				.catch(() => null);
+			if (!keyStored) return;
+		}
+
+		// The provider IS saved at this point. `validate` is a post-save config
+		// check — distinguish its three outcomes honestly: invalid config,
+		// couldn't-run (network/throw → null), or clean.
+		const saved = isEdit ? "Provider updated" : "Provider added";
+		const result = await validate.mutateAsync(providerId).catch(() => null);
+		if (result && !result.valid) {
+			toast.warning("Provider saved with issues", { description: result.errors.join(" · ") });
+		} else if (!result) {
+			toast.success(saved, { description: "Couldn't run validation — check it from the list." });
+		} else {
+			toast.success(saved);
+		}
+		onOpenChange(false);
+	}
+
+	function openSignIn(url: string) {
+		setOauthIssue(null);
+		// window.open returns null (no throw) when the popup is blocked.
+		const win = window.open(url, "codex-oauth", "width=520,height=720");
+		popupRef.current = win;
+		if (!win) {
+			// Persist a recoverable state (not just a toast) so the dialog swaps the
+			// "waiting…" spinner for a click-to-retry affordance.
+			setOauthIssue("blocked");
+			toast.error("Pop-up blocked", {
+				description: "Allow pop-ups for this site, then use “Restart ChatGPT sign-in” below.",
+			});
+		}
+	}
+
+	/**
+	 * Re-run `oauth/start` to mint a FRESH auth_url (+state +expires_at), then
+	 * open it. An expired, consumed, or otherwise stale start session can't be
+	 * reopened — reusing `oauth.authUrl` just dead-ends — so every in-dialog
+	 * recovery (expired / closed / pop-up blocked) restarts rather than reopening.
+	 */
+	async function restartSignIn() {
+		if (!oauth || oauthStart.isPending) return;
+		const started = await oauthStart
+			.mutateAsync({
+				providerId: oauth.providerId,
+				provider: "codex",
+				redirect_uri: oauth.redirectUri,
+			})
+			.catch(() => null);
+		if (!started) return; // oauthStart.onError already toasts
+		completedRef.current = false;
+		try {
+			localStorage.removeItem(CODEX_OAUTH_STORAGE_KEY);
+		} catch {}
+		// Fresh session resets the expiry/poll effect (keyed on `oauth`).
+		setOauth({
+			providerId: oauth.providerId,
+			state: started.state,
+			authUrl: started.auth_url,
+			redirectUri: oauth.redirectUri,
+			expiresAt: started.expires_at,
+		});
+		openSignIn(started.auth_url);
+	}
+
+	/**
+	 * Remove the placeholder provider we created if sign-in is left unfinished.
+	 *
+	 * This covers closing the DIALOG only. If the user closes the browser tab
+	 * mid-OAuth this never runs, and we deliberately don't reconcile the orphan on
+	 * next mount: AiProviderResponse exposes no verified/status field, and a
+	 * never-completed placeholder is byte-for-byte identical to a connected Codex
+	 * provider (both `auth: {agent_profile, codex, default}`). Any client-side
+	 * "looks incomplete" heuristic would risk deleting a legitimately connected
+	 * provider, so honest reconciliation needs backend completion state the
+	 * dashboard doesn't have.
+	 */
+	function abandonCodexIfIncomplete() {
+		if (oauth && !completedRef.current && createdFreshRef.current) {
+			cleanupCodex.mutate(oauth.providerId);
+			createdFreshRef.current = false;
+		}
+	}
+
+	function requestClose(next: boolean) {
+		if (!next) abandonCodexIfIncomplete();
+		onOpenChange(next);
+	}
+
+	function submitPastedCallback() {
+		const parsed = parseCodexCallback(oauthCode);
+		if (!parsed) {
+			toast.error("Couldn't read that", {
+				description: "Paste the full address from the OpenAI page after signing in.",
+			});
+			return;
+		}
+		finishRef.current(parsed);
+	}
+
+	// Keep the latest completion handler in a ref so the cross-window listener
+	// (set up once per oauth session) always calls the current closure.
+	finishRef.current = async (result: CodexOAuthResult) => {
+		if (!oauth || completedRef.current) return;
+		if (result.error || !result.code) {
+			if (result.error) toast.error("ChatGPT sign-in failed", { description: result.error });
+			return;
+		}
+		completedRef.current = true;
+		const done = await oauthComplete
+			.mutateAsync({
+				providerId: oauth.providerId,
+				state: result.state || oauth.state,
+				code: result.code,
+				redirect_uri: oauth.redirectUri,
+			})
+			.catch(() => null);
+		if (done) {
+			toast.success("Signed in with ChatGPT");
+			onOpenChange(false);
+		} else {
+			completedRef.current = false; // allow retry
+		}
+	};
+
+	// While a Codex sign-in is in flight, listen for the callback route handing
+	// back code+state over any of three channels (postMessage, BroadcastChannel,
+	// localStorage) and complete automatically.
+	useEffect(() => {
+		if (!oauth) return;
+		const handle = (r: CodexOAuthResult | null) => {
+			if (r) finishRef.current(r);
+		};
+		let ch: BroadcastChannel | null = null;
+		try {
+			ch = new BroadcastChannel(CODEX_OAUTH_CHANNEL);
+			ch.onmessage = (e) => handle(e.data as CodexOAuthResult);
+		} catch {}
+		const onMessage = (e: MessageEvent) => {
+			if (e.origin === window.location.origin && e.data?.source === CODEX_OAUTH_CHANNEL) {
+				handle(e.data as CodexOAuthResult);
+			}
+		};
+		const onStorage = (e: StorageEvent) => {
+			if (e.key === CODEX_OAUTH_STORAGE_KEY && e.newValue) {
+				try {
+					handle(JSON.parse(e.newValue) as CodexOAuthResult);
+				} catch {}
+			}
+		};
+		window.addEventListener("message", onMessage);
+		window.addEventListener("storage", onStorage);
+		return () => {
+			ch?.close();
+			window.removeEventListener("message", onMessage);
+			window.removeEventListener("storage", onStorage);
+		};
+	}, [oauth]);
+
+	// Don't spin forever: surface when the sign-in popup is closed before it
+	// completes, and when the start session expires (`expires_at`).
+	useEffect(() => {
+		if (!oauth) return;
+		const poll = setInterval(() => {
+			if (completedRef.current) return;
+			if (popupRef.current?.closed) setOauthIssue((cur) => cur ?? "closed");
+		}, 800);
+		const remaining = new Date(oauth.expiresAt).getTime() - Date.now();
+		const expiry = Number.isFinite(remaining)
+			? setTimeout(
+					() => {
+						if (!completedRef.current) setOauthIssue("expired");
+					},
+					Math.max(remaining, 0),
+				)
+			: undefined;
+		return () => {
+			clearInterval(poll);
+			if (expiry) clearTimeout(expiry);
+		};
+	}, [oauth]);
+
+	const busy =
+		upsert.isPending ||
+		upsertQuiet.isPending ||
+		setKey.isPending ||
+		saveToVault.isPending ||
+		validate.isPending ||
+		oauthStart.isPending;
+
+	return (
+		<Dialog open={open} onOpenChange={requestClose}>
+			<DialogContent data-hosted="true" className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+				{oauth ? (
+					<>
+						<DialogHeader>
+							<DialogTitle>Sign in with ChatGPT</DialogTitle>
+							<DialogDescription>
+								Finish signing in in the ChatGPT window — we’ll connect Codex automatically when it
+								returns.
+							</DialogDescription>
+						</DialogHeader>
+						<div className="space-y-3">
+							<Button
+								variant="outline"
+								className="w-full"
+								onClick={() => {
+									// An issue means the prior link is stale — mint a fresh one. With no
+									// issue the popup just opened on a still-valid link; reopening is fine.
+									if (oauthIssue) void restartSignIn();
+									else openSignIn(oauth.authUrl);
+								}}
+								disabled={oauthStart.isPending}
+							>
+								{oauthIssue ? "Restart ChatGPT sign-in" : "Open ChatGPT sign-in"}
+								{oauthStart.isPending ? (
+									<Spinner className="size-3.5" />
+								) : (
+									<ExternalLink className="size-3.5" />
+								)}
+							</Button>
+							{oauthIssue === "expired" ? (
+								<p className="flex items-center gap-2 text-xs text-destructive">
+									<CircleAlert className="size-3.5" /> This sign-in link expired. Restart to get a
+									fresh one.
+								</p>
+							) : oauthIssue === "blocked" ? (
+								<p className="flex items-center gap-2 text-xs text-destructive">
+									<CircleAlert className="size-3.5" /> Pop-up blocked. Allow pop-ups, then restart
+									sign-in — or paste the address below.
+								</p>
+							) : oauthIssue === "closed" ? (
+								<p className="flex items-center gap-2 text-xs text-muted-foreground">
+									<CircleAlert className="size-3.5" /> The sign-in window closed before finishing.
+									Restart it, or paste the address below.
+								</p>
+							) : oauthComplete.isPending ? (
+								<p className="flex items-center gap-2 text-xs text-muted-foreground">
+									<Spinner className="size-3.5" /> Connecting Codex…
+								</p>
+							) : (
+								<p className="flex items-center gap-2 text-xs text-muted-foreground">
+									<Spinner className="size-3.5" /> Waiting for sign-in to finish…
+								</p>
+							)}
+							<details className="rounded-md border bg-muted/30 p-3 text-xs text-muted-foreground">
+								<summary className="cursor-pointer font-medium text-foreground">
+									Didn’t return automatically?
+								</summary>
+								<div className="mt-2 space-y-2">
+									<p>Paste the full address from the OpenAI page after signing in.</p>
+									<Input
+										value={oauthCode}
+										onChange={(e) => setOauthCode(e.target.value)}
+										placeholder="https://…/callback?code=…&state=…"
+										autoComplete="off"
+										spellCheck={false}
+									/>
+									<Button
+										size="sm"
+										onClick={submitPastedCallback}
+										disabled={!oauthCode.trim() || oauthComplete.isPending}
+									>
+										{oauthComplete.isPending ? "Finishing…" : "Finish sign-in"}
+									</Button>
+									<p>
+										If it never returns, an admin may need to register this app’s callback URL in
+										the Codex OAuth config.
+									</p>
+								</div>
+							</details>
+						</div>
+						<DialogFooter>
+							<Button variant="outline" onClick={() => requestClose(false)}>
+								Cancel
+							</Button>
+						</DialogFooter>
+					</>
+				) : (
+					<>
+						<DialogHeader>
+							<DialogTitle>{isEdit ? "Edit provider" : "Add a provider"}</DialogTitle>
+							<DialogDescription>
+								Route inference through your own account by API key, sign-in, or a custom endpoint.
+							</DialogDescription>
+						</DialogHeader>
+
+						<div className="space-y-4">
+							<div className="space-y-1.5">
+								<Label htmlFor="provider-type">Provider</Label>
+								<Select
+									value={type}
+									onValueChange={(v) => changeType(v as ProviderTypeId)}
+									disabled={isEdit}
+								>
+									<SelectTrigger id="provider-type">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										{PROVIDER_TYPES.map((t) => (
+											<SelectItem key={t} value={t}>
+												{providerTypeMeta(t).label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+
+							<div className="flex items-center gap-3 rounded-lg border bg-muted/30 p-3">
+								<ProviderTypeChip type={type} />
+								<div className="min-w-0 text-xs text-muted-foreground">
+									Saved as <code className="font-mono">{providerId || "—"}</code>
+								</div>
+							</div>
+
+							<div className="space-y-1.5">
+								<Label htmlFor="provider-label">Name</Label>
+								<Input
+									id="provider-label"
+									value={label}
+									onChange={(e) => setLabel(e.target.value)}
+									placeholder={`${meta.label} (my key)`}
+									autoComplete="off"
+								/>
+							</div>
+
+							{/* Auth method */}
+							<div className="space-y-1.5">
+								<Label htmlFor="provider-auth">Authentication</Label>
+								<Select value={authMethod} onValueChange={(v) => setAuthMethod(v as AuthMethod)}>
+									<SelectTrigger id="provider-auth">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="api_key">API key (managed runtime env)</SelectItem>
+										<SelectItem value="vault">Store key in project vault</SelectItem>
+										{meta.oauth ? (
+											<SelectItem value="oauth">Sign in with ChatGPT (Codex)</SelectItem>
+										) : null}
+										{meta.custom ? <SelectItem value="none">No auth (local)</SelectItem> : null}
+									</SelectContent>
+								</Select>
+							</div>
+
+							{authMethod === "api_key" || authMethod === "vault" ? (
+								<>
+									<div className="space-y-1.5">
+										<Label htmlFor="provider-key">
+											API key{canKeepManagedApiKey ? " (leave blank to keep)" : ""}
+										</Label>
+										<Input
+											id="provider-key"
+											type="password"
+											value={apiKey}
+											onChange={(e) => setApiKey(e.target.value)}
+											placeholder="sk-…"
+											autoComplete="off"
+											spellCheck={false}
+										/>
+										<p className="text-xs text-muted-foreground">
+											{authMethod === "vault"
+												? "Stored in your project vault; the runtime resolves it by secret reference — never shown to the dashboard again."
+												: "Stored encrypted in your vault — never shown to the dashboard again."}
+										</p>
+										{authMethod === "api_key" && keyRequired && isEdit && !apiKey.trim() ? (
+											<p className="text-xs text-destructive">
+												Enter a key to switch this provider to managed API-key auth.
+											</p>
+										) : null}
+									</div>
+									<div className="space-y-1.5">
+										<Label htmlFor="provider-env">Runtime env var</Label>
+										<Input
+											id="provider-env"
+											value={runtimeEnv}
+											onChange={(e) => setRuntimeEnv(e.target.value.toUpperCase())}
+											placeholder="OPENAI_API_KEY"
+											autoComplete="off"
+											spellCheck={false}
+										/>
+									</div>
+								</>
+							) : null}
+
+							<div className="space-y-1.5">
+								<Label htmlFor="provider-base">Base URL</Label>
+								<Input
+									id="provider-base"
+									value={baseUrl}
+									onChange={(e) => setBaseUrl(e.target.value)}
+									placeholder="https://api.example.com/v1"
+									autoComplete="off"
+									spellCheck={false}
+								/>
+								{authMethod === "none" && baseUrl.trim() && !noneAuthOk ? (
+									<p className="text-xs text-destructive">
+										No-auth providers must use a loopback or private-network URL (e.g.
+										http://127.0.0.1:11434/v1).
+									</p>
+								) : null}
+							</div>
+
+							<div className="grid gap-3 sm:grid-cols-2">
+								<div className="space-y-1.5">
+									<Label htmlFor="provider-model">Default model</Label>
+									<Input
+										id="provider-model"
+										value={defaultModel}
+										onChange={(e) => setDefaultModel(e.target.value)}
+										placeholder={meta.modelPlaceholder}
+										autoComplete="off"
+										spellCheck={false}
+									/>
+								</div>
+								<div className="space-y-1.5">
+									<Label htmlFor="provider-mode">API mode</Label>
+									<Select value={apiMode} onValueChange={(v) => setApiMode(v as ApiMode)}>
+										<SelectTrigger id="provider-mode">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{meta.apiModes.map((m) => (
+												<SelectItem key={m} value={m}>
+													{API_MODE_LABEL[m]}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+							</div>
+						</div>
+
+						<DialogFooter>
+							<Button variant="outline" onClick={() => requestClose(false)}>
+								Cancel
+							</Button>
+							<Button onClick={submit} disabled={!canSubmit || busy}>
+								{busy
+									? "Saving…"
+									: authMethod === "oauth"
+										? "Continue to sign-in"
+										: isEdit
+											? "Save changes"
+											: "Add provider"}
+							</Button>
+						</DialogFooter>
+					</>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/hosted/ai-providers/ai-providers-hooks.ts
+++ b/apps/web/src/hosted/ai-providers/ai-providers-hooks.ts
@@ -1,0 +1,190 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import type { AiProviderUpsert } from "@/hosted/ai-providers/types";
+import { toastApiError, unwrap, useApi } from "@/lib/api";
+
+/** Typed data hooks for the AI Providers surface (cloud-api `/api/ai-providers`). */
+
+const KEY = ["ai-providers"] as const;
+
+export function useAiProviders() {
+	const api = useApi();
+	return useQuery({
+		queryKey: KEY,
+		queryFn: async () => unwrap(await api.GET("/api/ai-providers")),
+	});
+}
+
+export function useUpsertProvider() {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (body: AiProviderUpsert) =>
+			unwrap(await api.POST("/api/ai-providers", { body, params: { query: { replace: true } } })),
+		onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
+		onError: toastApiError("Couldn't save provider"),
+	});
+}
+
+export function useDeleteProvider() {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (providerId: string) =>
+			unwrap(
+				await api.DELETE("/api/ai-providers/{provider_id}", {
+					params: { path: { provider_id: providerId } },
+				}),
+			),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: KEY });
+			toast.success("Provider removed");
+		},
+		onError: toastApiError("Couldn't remove provider"),
+	});
+}
+
+/**
+ * Codex pre-create that does NOT touch the cached provider list. The OAuth
+ * `start` route needs the provider record to exist, but until `complete`
+ * succeeds it isn't really connected — invalidating the list here would surface
+ * a provider that looks connected even if the user abandons sign-in. The list
+ * refreshes on a successful `complete` (`useOAuthComplete`) instead.
+ */
+export function useUpsertProviderQuiet() {
+	const api = useApi();
+	return useMutation({
+		mutationFn: async (body: AiProviderUpsert) =>
+			unwrap(await api.POST("/api/ai-providers", { body, params: { query: { replace: true } } })),
+		onError: toastApiError("Couldn't start sign-in"),
+	});
+}
+
+/** Silent provider delete (no toast) — cleans up an abandoned Codex pre-create. */
+export function useDeleteProviderQuiet() {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (providerId: string) =>
+			unwrap(
+				await api.DELETE("/api/ai-providers/{provider_id}", {
+					params: { path: { provider_id: providerId } },
+				}),
+			),
+		onSettled: () => qc.invalidateQueries({ queryKey: KEY }),
+	});
+}
+
+/** vault field name from a provider id (mirrors v1 safeVaultField). */
+function safeVaultField(providerId: string): string {
+	const n = providerId
+		.toLowerCase()
+		.replace(/[^a-z0-9_]+/g, "_")
+		.replace(/^_+|_+$/g, "");
+	return `${n || "provider"}_api_key`;
+}
+
+function exactVaultRef(projectId: string, slug: string, section: string, field: string): string {
+	const parts = ["project", projectId, "vault", slug, "section", section, "field", field];
+	return `clawdi://${parts.map((p) => encodeURIComponent(p)).join("/")}`;
+}
+
+/**
+ * Store a BYOK key in the user's project vault and return the `clawdi://…`
+ * secret_ref — the create path for `{type:"secret_ref"}` providers (v1
+ * `saveApiKeyToVault`). The provider's auth is then set to that ref so the
+ * runtime resolves the key from the vault, never the dashboard.
+ */
+export function useSaveApiKeyToVault() {
+	const api = useApi();
+	return useMutation({
+		mutationFn: async (vars: { providerId: string; apiKey: string }): Promise<string> => {
+			const proj = unwrap(await api.GET("/api/projects/default"));
+			const projectId = proj.project_id;
+			const slug = "ai-providers";
+			const section = "onboarding";
+			const field = safeVaultField(vars.providerId);
+			// Create-or-attach the vault (no create_only → attaches if it exists).
+			unwrap(
+				await api.POST("/api/vault", {
+					params: { query: { project_id: projectId } },
+					body: { slug, name: "AI Providers" },
+				}),
+			);
+			unwrap(
+				await api.PUT("/api/vault/{slug}/items", {
+					params: { path: { slug }, query: { project_id: projectId } },
+					body: { section, fields: { [field]: vars.apiKey } },
+				}),
+			);
+			return exactVaultRef(projectId, slug, section, field);
+		},
+		onError: toastApiError("Couldn't save to vault"),
+	});
+}
+
+export function useSetApiKey() {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (vars: { providerId: string; value: string; runtime_env_name?: string }) =>
+			unwrap(
+				await api.POST("/api/ai-providers/{provider_id}/auth/api-key", {
+					params: { path: { provider_id: vars.providerId } },
+					body: { value: vars.value, runtime_env_name: vars.runtime_env_name },
+				}),
+			),
+		onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
+		onError: toastApiError("Couldn't save API key"),
+	});
+}
+
+export function useValidateProvider() {
+	const api = useApi();
+	return useMutation({
+		mutationFn: async (providerId: string) =>
+			unwrap(
+				await api.POST("/api/ai-providers/{provider_id}/validate", {
+					params: { path: { provider_id: providerId } },
+				}),
+			),
+		onError: toastApiError("Couldn't validate"),
+	});
+}
+
+export function useOAuthStart() {
+	const api = useApi();
+	return useMutation({
+		mutationFn: async (vars: { providerId: string; provider: string; redirect_uri?: string }) =>
+			unwrap(
+				await api.POST("/api/ai-providers/{provider_id}/auth/oauth/start", {
+					params: { path: { provider_id: vars.providerId } },
+					body: { provider: vars.provider, redirect_uri: vars.redirect_uri },
+				}),
+			),
+		onError: toastApiError("Couldn't start sign-in"),
+	});
+}
+
+export function useOAuthComplete() {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (vars: {
+			providerId: string;
+			state: string;
+			code: string;
+			redirect_uri?: string;
+		}) =>
+			unwrap(
+				await api.POST("/api/ai-providers/{provider_id}/auth/oauth/complete", {
+					params: { path: { provider_id: vars.providerId } },
+					body: { state: vars.state, code: vars.code, redirect_uri: vars.redirect_uri },
+				}),
+			),
+		onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
+		onError: toastApiError("Couldn't finish sign-in"),
+	});
+}

--- a/apps/web/src/hosted/ai-providers/ai-providers-page.tsx
+++ b/apps/web/src/hosted/ai-providers/ai-providers-page.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { BadgeCheck, CircleAlert, Pencil, Plus, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { EmptyState } from "@/components/empty-state";
+import { ENTITY_CARD_BASE, EntityHeader } from "@/components/entity-card";
+import { EntityIcon } from "@/components/entity-icon";
+import { PageHeader } from "@/components/page-header";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { ConfirmAction } from "@/components/ui/confirm-action";
+import { Skeleton } from "@/components/ui/skeleton";
+import { AddProviderDialog } from "@/hosted/ai-providers/add-provider-dialog";
+import {
+	useAiProviders,
+	useDeleteProvider,
+	useValidateProvider,
+} from "@/hosted/ai-providers/ai-providers-hooks";
+import { AuthBadge, ManagedProviderCard } from "@/hosted/ai-providers/ai-providers-ui";
+import {
+	API_MODE_LABEL,
+	type ApiMode,
+	providerTypeMeta,
+} from "@/hosted/ai-providers/provider-types";
+import type { AiProvider } from "@/hosted/ai-providers/types";
+import { normalizeApiError } from "@/lib/api-errors";
+import { formatModelLabel } from "@/lib/format";
+import { cn } from "@/lib/utils";
+
+const DESCRIPTION = "Choose how your hosted agents reach a model.";
+
+export function AiProvidersPage() {
+	const providers = useAiProviders();
+	const [addOpen, setAddOpen] = useState(false);
+	const [editing, setEditing] = useState<AiProvider | null>(null);
+
+	const list = providers.data?.providers ?? [];
+
+	return (
+		<div data-hosted="true" className="space-y-6 px-4 lg:px-6">
+			<PageHeader
+				title="AI Providers"
+				description={DESCRIPTION}
+				actions={
+					<Button
+						onClick={() => {
+							setEditing(null);
+							setAddOpen(true);
+						}}
+					>
+						<Plus />
+						Add provider
+					</Button>
+				}
+			/>
+
+			<ManagedProviderCard />
+
+			<div className="space-y-2">
+				<div className="px-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+					Your providers
+				</div>
+				{providers.error ? (
+					<AiProviderError
+						error={providers.error}
+						onRetry={() => providers.refetch()}
+						title="Couldn’t load providers"
+					/>
+				) : providers.isLoading ? (
+					<div className="space-y-2">
+						{[0, 1].map((i) => (
+							<Skeleton key={i} className="h-24 w-full rounded-lg" />
+						))}
+					</div>
+				) : list.length === 0 ? (
+					<EmptyState
+						title="No custom providers"
+						description="Add your own OpenAI, Anthropic, OpenRouter, Gemini, Mistral, or a custom OpenAI-compatible endpoint."
+						fillHeight={false}
+					/>
+				) : (
+					<div className="space-y-2">
+						{list.map((provider) => (
+							<ProviderCard
+								key={provider.provider_id}
+								provider={provider}
+								onEdit={() => {
+									setEditing(provider);
+									setAddOpen(true);
+								}}
+							/>
+						))}
+					</div>
+				)}
+			</div>
+
+			<AddProviderDialog open={addOpen} onOpenChange={setAddOpen} editing={editing} />
+		</div>
+	);
+}
+
+function ProviderCard({ provider, onEdit }: { provider: AiProvider; onEdit: () => void }) {
+	const meta = providerTypeMeta(provider.type);
+	const del = useDeleteProvider();
+	const validate = useValidateProvider();
+
+	function runValidate() {
+		validate.mutate(provider.provider_id, {
+			onSuccess: (result) => {
+				if (result.valid) toast.success("Configuration looks good");
+				else toast.warning("Validation issues", { description: result.errors.join(" · ") });
+			},
+		});
+	}
+
+	return (
+		<div className={cn(ENTITY_CARD_BASE, "bg-card")}>
+			<EntityHeader
+				align="start"
+				icon={
+					<EntityIcon
+						kind="provider"
+						id={provider.type}
+						label={provider.label ?? provider.provider_id}
+					/>
+				}
+				title={provider.label ?? provider.provider_id}
+				titleAdornment={<AuthBadge auth={provider.auth} />}
+				meta={[
+					`${meta.label}${provider.default_model ? ` · ${formatModelLabel(provider.default_model)}` : ""}${
+						provider.api_mode
+							? ` · ${API_MODE_LABEL[provider.api_mode as ApiMode] ?? provider.api_mode}`
+							: ""
+					}`,
+					<span key="base" className="font-mono">
+						{provider.base_url}
+						{provider.runtime_env_name ? ` · ${provider.runtime_env_name}` : ""}
+					</span>,
+				]}
+			/>
+			<div className="mt-3 flex flex-wrap justify-end gap-2">
+				<Button variant="ghost" size="sm" onClick={runValidate} disabled={validate.isPending}>
+					<BadgeCheck className="size-3.5" />
+					Validate
+				</Button>
+				<Button variant="outline" size="sm" onClick={onEdit}>
+					<Pencil className="size-3.5" />
+					Edit
+				</Button>
+				<ConfirmAction
+					title={`Remove ${provider.label ?? provider.provider_id}?`}
+					description={
+						<p>
+							Agents using this provider fall back to the managed default. This can't be undone.
+						</p>
+					}
+					confirmLabel="Remove provider"
+					destructive
+					onConfirm={() => del.mutate(provider.provider_id)}
+				>
+					<Button
+						variant="ghost"
+						size="sm"
+						className="text-muted-foreground hover:text-destructive"
+						disabled={del.isPending}
+					>
+						<Trash2 className="size-3.5" />
+						Remove
+					</Button>
+				</ConfirmAction>
+			</div>
+		</div>
+	);
+}
+
+function AiProviderError({
+	error,
+	title,
+	onRetry,
+}: {
+	error: unknown;
+	title: string;
+	onRetry: () => void;
+}) {
+	return (
+		<Alert variant="destructive">
+			<CircleAlert className="size-4" />
+			<AlertTitle>{title}</AlertTitle>
+			<AlertDescription className="flex flex-col gap-3">
+				<span>{normalizeApiError(error)}</span>
+				<Button variant="outline" size="sm" className="w-fit" onClick={onRetry}>
+					Try again
+				</Button>
+			</AlertDescription>
+		</Alert>
+	);
+}

--- a/apps/web/src/hosted/ai-providers/ai-providers-ui.tsx
+++ b/apps/web/src/hosted/ai-providers/ai-providers-ui.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { ShieldCheck, Sparkles } from "lucide-react";
+import { EntityIcon, type EntityIconSize } from "@/components/entity-icon";
+import { providerTypeMeta } from "@/hosted/ai-providers/provider-types";
+import type { AiProviderAuth } from "@/hosted/ai-providers/types";
+
+/** Real brand-logo icon for a provider type (delegates to the unified EntityIcon). */
+export function ProviderTypeChip({
+	type,
+	size = "md",
+	className,
+}: {
+	type: string;
+	size?: EntityIconSize;
+	className?: string;
+}) {
+	const meta = providerTypeMeta(type);
+	return (
+		<EntityIcon kind="provider" id={type} label={meta.label} size={size} className={className} />
+	);
+}
+
+const AUTH_LABEL: Record<string, string> = {
+	api_key: "API key",
+	// Matches the "Sign in with ChatGPT (Codex)" auth option label.
+	agent_profile: "ChatGPT",
+	oauth_profile: "ChatGPT",
+	secret_ref: "Vault key",
+	none: "No auth",
+};
+
+/** Auth-method pill for a provider. */
+export function AuthBadge({ auth }: { auth: AiProviderAuth }) {
+	const label = AUTH_LABEL[auth.type] ?? auth.type;
+	return (
+		<span
+			data-hosted="true"
+			className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
+		>
+			{label}
+		</span>
+	);
+}
+
+/** The always-on managed default — Clawdi-hosted Claude, no setup. */
+export function ManagedProviderCard() {
+	return (
+		<div data-hosted="true" className="rounded-lg border bg-card p-4">
+			<div className="flex items-start gap-3">
+				<span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+					<Sparkles className="size-5" />
+				</span>
+				<div className="min-w-0 flex-1 space-y-1">
+					<div className="flex flex-wrap items-center gap-2">
+						<span className="text-sm font-medium">Managed by Clawdi</span>
+						<span className="inline-flex items-center gap-1 rounded-full bg-success-muted px-2 py-0.5 text-xs font-medium text-success-muted-foreground">
+							<ShieldCheck className="size-3" />
+							Default
+						</span>
+					</div>
+					<p className="text-sm text-muted-foreground">
+						Hosted agents use Clawdi-managed Claude models out of the box — no API key, no setup.
+						Usage draws from your wallet balance.
+					</p>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/hosted/ai-providers/codex-oauth-callback.tsx
+++ b/apps/web/src/hosted/ai-providers/codex-oauth-callback.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { CircleAlert, CircleCheck } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+	CODEX_OAUTH_CHANNEL,
+	CODEX_OAUTH_STORAGE_KEY,
+	type CodexOAuthResult,
+	parseCodexCallback,
+} from "@/hosted/ai-providers/codex-oauth";
+
+/**
+ * The Codex OAuth landing page. ChatGPT redirects here with `?code&state`;
+ * this hands them back to the add-provider dialog (the opener) over three
+ * channels for resilience — postMessage to the opener, a BroadcastChannel,
+ * and localStorage — then closes itself when it was opened as a popup.
+ */
+export function CodexOAuthCallback() {
+	const [state, setState] = useState<"ok" | "error">("ok");
+
+	useEffect(() => {
+		const parsed = parseCodexCallback(window.location.href);
+		const result: CodexOAuthResult = parsed ?? {
+			code: "",
+			state: "",
+			error: "missing_code",
+		};
+		setState(result.error || !result.code ? "error" : "ok");
+
+		try {
+			const ch = new BroadcastChannel(CODEX_OAUTH_CHANNEL);
+			ch.postMessage(result);
+			ch.close();
+		} catch {
+			// BroadcastChannel unsupported — the other channels still cover it.
+		}
+		try {
+			window.opener?.postMessage(
+				{ source: CODEX_OAUTH_CHANNEL, ...result },
+				window.location.origin,
+			);
+		} catch {
+			// Cross-origin opener — ignore; storage/broadcast still deliver.
+		}
+		try {
+			localStorage.setItem(CODEX_OAUTH_STORAGE_KEY, JSON.stringify(result));
+		} catch {
+			// Storage blocked — best-effort only.
+		}
+
+		// Opened as a popup with a usable result → auto-close shortly.
+		if (window.opener && !result.error && result.code) {
+			const t = setTimeout(() => window.close(), 1000);
+			return () => clearTimeout(t);
+		}
+	}, []);
+
+	return (
+		<div
+			data-hosted="true"
+			className="flex min-h-dvh items-center justify-center bg-background p-6"
+		>
+			<div className="w-full max-w-sm rounded-lg border bg-card p-6 text-center">
+				<span
+					className={`mx-auto flex size-10 items-center justify-center rounded-full ${
+						state === "ok" ? "bg-success-muted text-success" : "bg-destructive/10 text-destructive"
+					}`}
+				>
+					{state === "ok" ? <CircleCheck className="size-5" /> : <CircleAlert className="size-5" />}
+				</span>
+				<h1 className="mt-3 text-sm font-semibold">
+					{state === "ok" ? "Signed in to ChatGPT" : "Sign-in didn’t complete"}
+				</h1>
+				<p className="mt-1 text-sm text-muted-foreground">
+					{state === "ok"
+						? "You can close this window and return to Clawdi — your provider is connecting."
+						: "Return to Clawdi and try again, or paste this page’s URL into the dialog."}
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/hosted/ai-providers/codex-oauth.ts
+++ b/apps/web/src/hosted/ai-providers/codex-oauth.ts
@@ -1,0 +1,80 @@
+"use client";
+
+import type { AiProviderUpsert } from "@/hosted/ai-providers/types";
+
+/**
+ * Codex "Sign in with ChatGPT" OAuth — v2 parity with the monorepo v1 flow
+ * (lib/cloud-ai-providers.ts). The canonical provider id is `openai-codex`;
+ * a successful sign-in lands `auth: {type:"agent_profile", tool:"codex",
+ * profile}` (NOT oauth_profile).
+ *
+ * Flow: create the openai-codex provider → POST .../auth/oauth/start
+ * {provider:"codex", redirect_uri} → open auth_url (ChatGPT) → the v2 callback
+ * route captures code+state → POST .../auth/oauth/complete {code, state,
+ * redirect_uri}. The redirect_uri is the SAME app callback route across
+ * start + complete + the callback page.
+ */
+
+export const CLAWDI_CODEX_OAUTH_PROVIDER_ID = "openai-codex";
+
+/** Cross-window channel + storage key the callback uses to hand back code+state. */
+export const CODEX_OAUTH_CHANNEL = "clawdi-codex-oauth";
+export const CODEX_OAUTH_STORAGE_KEY = "clawdi:codex-oauth-result";
+
+export interface CodexOAuthResult {
+	code: string;
+	state: string;
+	error?: string;
+}
+
+/** The v2 app's own OAuth callback route — the redirect_uri the flow uses. */
+export function codexRedirectUri(): string {
+	if (typeof window === "undefined") return "";
+	return `${window.location.origin}/oauth/codex/callback`;
+}
+
+/** Default model shown for a fresh Codex provider (OpenAI Responses / GPT-5). */
+export const CODEX_DEFAULT_MODEL = "gpt-5";
+
+/** Upsert body for the canonical Codex provider (pre-sign-in placeholder auth). */
+export function codexProviderBody(defaultModel?: string): AiProviderUpsert {
+	return {
+		provider_id: CLAWDI_CODEX_OAUTH_PROVIDER_ID,
+		type: "openai",
+		label: "Codex (ChatGPT)",
+		base_url: "https://api.openai.com/v1",
+		default_model: defaultModel?.trim() || CODEX_DEFAULT_MODEL,
+		api_mode: "openai_responses",
+		auth: { type: "agent_profile", tool: "codex", profile: "default" },
+		managed_by: "user",
+		runtime_env_name: null,
+	};
+}
+
+/**
+ * Parse a pasted OAuth callback URL (or raw `?code=…&state=…` query) — the
+ * manual fallback for when the redirect can't reach the app automatically
+ * (e.g. the backend hasn't whitelisted the app redirect_uri yet).
+ */
+export function parseCodexCallback(input: string): CodexOAuthResult | null {
+	const trimmed = input.trim();
+	if (!trimmed) return null;
+	let search = "";
+	let hash = "";
+	try {
+		const url = new URL(trimmed);
+		search = url.search;
+		hash = url.hash.replace(/^#/, "");
+	} catch {
+		// Not a full URL — treat the whole string as a query fragment.
+		search = trimmed.replace(/^[?#]/, "");
+	}
+	const q = new URLSearchParams(search);
+	const h = new URLSearchParams(hash);
+	const code = q.get("code") || h.get("code") || "";
+	const state = q.get("state") || h.get("state") || "";
+	const error = q.get("error") || h.get("error") || undefined;
+	if (error) return { code: "", state: "", error };
+	if (!code || !state) return null;
+	return { code, state };
+}

--- a/apps/web/src/hosted/ai-providers/provider-types.ts
+++ b/apps/web/src/hosted/ai-providers/provider-types.ts
@@ -1,0 +1,125 @@
+/**
+ * The six AI provider types (backend `ProviderType`) with the defaults the
+ * add flow prefills: base URL, allowed API modes, runtime env var, and a
+ * model placeholder. Tints reuse the app identity palette.
+ */
+export const PROVIDER_TYPES = [
+	"openai",
+	"anthropic",
+	"openrouter",
+	"gemini",
+	"mistral",
+	"custom_openai_compatible",
+] as const;
+export type ProviderTypeId = (typeof PROVIDER_TYPES)[number];
+
+export type ApiMode =
+	| "openai_chat"
+	| "openai_responses"
+	| "codex_responses"
+	| "anthropic_messages"
+	| "google_generate_content";
+
+export interface ProviderTypeMeta {
+	id: ProviderTypeId;
+	label: string;
+	tint: string;
+	defaultBaseUrl: string;
+	apiModes: ApiMode[];
+	defaultApiMode: ApiMode;
+	defaultRuntimeEnv: string;
+	modelPlaceholder: string;
+	/** base_url + api_mode are user-supplied / required. */
+	custom?: boolean;
+	/** Offers "Sign in with ChatGPT" (Codex OAuth). */
+	oauth?: boolean;
+}
+
+export const PROVIDER_TYPE_META: Record<ProviderTypeId, ProviderTypeMeta> = {
+	openai: {
+		id: "openai",
+		label: "OpenAI",
+		tint: "bg-identity-2-bg text-identity-2-fg",
+		defaultBaseUrl: "https://api.openai.com/v1",
+		apiModes: ["openai_chat", "openai_responses"],
+		defaultApiMode: "openai_chat",
+		defaultRuntimeEnv: "OPENAI_API_KEY",
+		modelPlaceholder: "gpt-4o",
+		oauth: true,
+	},
+	anthropic: {
+		id: "anthropic",
+		label: "Anthropic",
+		tint: "bg-identity-1-bg text-identity-1-fg",
+		defaultBaseUrl: "https://api.anthropic.com",
+		apiModes: ["anthropic_messages"],
+		defaultApiMode: "anthropic_messages",
+		defaultRuntimeEnv: "ANTHROPIC_API_KEY",
+		modelPlaceholder: "claude-sonnet-4-5",
+	},
+	openrouter: {
+		id: "openrouter",
+		label: "OpenRouter",
+		tint: "bg-identity-7-bg text-identity-7-fg",
+		defaultBaseUrl: "https://openrouter.ai/api/v1",
+		apiModes: ["openai_chat"],
+		defaultApiMode: "openai_chat",
+		defaultRuntimeEnv: "OPENROUTER_API_KEY",
+		modelPlaceholder: "anthropic/claude-3.7-sonnet",
+	},
+	gemini: {
+		id: "gemini",
+		label: "Gemini",
+		tint: "bg-identity-3-bg text-identity-3-fg",
+		defaultBaseUrl: "https://generativelanguage.googleapis.com/v1beta",
+		apiModes: ["google_generate_content"],
+		defaultApiMode: "google_generate_content",
+		defaultRuntimeEnv: "GEMINI_API_KEY",
+		modelPlaceholder: "gemini-2.0-flash",
+	},
+	mistral: {
+		id: "mistral",
+		label: "Mistral",
+		tint: "bg-identity-4-bg text-identity-4-fg",
+		defaultBaseUrl: "https://api.mistral.ai/v1",
+		apiModes: ["openai_chat"],
+		defaultApiMode: "openai_chat",
+		defaultRuntimeEnv: "MISTRAL_API_KEY",
+		modelPlaceholder: "mistral-large-latest",
+	},
+	custom_openai_compatible: {
+		id: "custom_openai_compatible",
+		label: "Custom (OpenAI-compatible)",
+		tint: "bg-identity-6-bg text-identity-6-fg",
+		defaultBaseUrl: "",
+		apiModes: ["openai_chat", "openai_responses", "codex_responses"],
+		defaultApiMode: "openai_chat",
+		defaultRuntimeEnv: "CUSTOM_API_KEY",
+		modelPlaceholder: "model name",
+		custom: true,
+	},
+};
+
+export const API_MODE_LABEL: Record<ApiMode, string> = {
+	openai_chat: "OpenAI Chat",
+	openai_responses: "OpenAI Responses",
+	codex_responses: "Codex Responses",
+	anthropic_messages: "Anthropic Messages",
+	google_generate_content: "Google GenerateContent",
+};
+
+export function providerTypeMeta(id: string): ProviderTypeMeta {
+	return PROVIDER_TYPE_META[id as ProviderTypeId] ?? PROVIDER_TYPE_META.custom_openai_compatible;
+}
+
+/** Slugify a label into a valid provider_id (`^[a-z][a-z0-9._-]{1,62}$`). */
+export function toProviderId(input: string): string {
+	const slug = input
+		.toLowerCase()
+		.replace(/[^a-z0-9._-]+/g, "-")
+		.replace(/^[^a-z]+/, "")
+		.replace(/-+/g, "-")
+		.replace(/^-|-$/g, "")
+		.slice(0, 63);
+	return slug.length >= 2 ? slug : "";
+}

--- a/apps/web/src/hosted/ai-providers/runtime-bootstrap.test.ts
+++ b/apps/web/src/hosted/ai-providers/runtime-bootstrap.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import {
+	aiProviderRuntimeId,
+	buildAiProviderBootstrap,
+	toRuntimeAiProvider,
+} from "@/hosted/ai-providers/runtime-bootstrap";
+import type { AiProvider } from "@/hosted/ai-providers/types";
+
+const provider: AiProvider = {
+	id: "db-record-uuid",
+	provider_id: "openai-codex",
+	scope: "user",
+	type: "openai",
+	label: "ChatGPT",
+	base_url: "https://api.openai.com/v1",
+	default_model: "gpt-5.1",
+	api_mode: "openai_responses",
+	auth: { type: "agent_profile", tool: "codex", profile: "default" },
+	managed_by: "user",
+	runtime_env_name: null,
+	capabilities: { chat: true, responses: true, ignored: "yes" },
+	created_at: "2026-01-01T00:00:00Z",
+	updated_at: "2026-01-01T00:00:00Z",
+};
+
+describe("AI provider runtime bootstrap", () => {
+	test("uses stable provider_id instead of the response row id", () => {
+		const bootstrap = buildAiProviderBootstrap(provider, "codex_oauth");
+
+		expect(aiProviderRuntimeId(provider)).toBe("openai-codex");
+		expect(bootstrap.selected_provider_id).toBe("openai-codex");
+		expect(bootstrap.catalog.defaults?.chat_provider_id).toBe("openai-codex");
+		expect(bootstrap.catalog.providers[0]?.id).toBe("openai-codex");
+		expect(bootstrap.catalog.providers[0]?.id).not.toBe("db-record-uuid");
+	});
+
+	test("normalizes generated nullable fields into the runtime catalog shape", () => {
+		const runtimeProvider = toRuntimeAiProvider({
+			...provider,
+			label: null,
+			default_model: null,
+			api_mode: null,
+			runtime_env_name: null,
+		});
+
+		expect(runtimeProvider).toEqual({
+			id: "openai-codex",
+			type: "openai",
+			base_url: "https://api.openai.com/v1",
+			auth: { type: "agent_profile", tool: "codex", profile: "default" },
+			managed_by: "user",
+			capabilities: { chat: true, responses: true },
+		});
+	});
+
+	test("rejects malformed auth before building a bootstrap payload", () => {
+		expect(() =>
+			buildAiProviderBootstrap(
+				{
+					...provider,
+					auth: { type: "api_key" },
+				},
+				"api_key",
+			),
+		).toThrow("Invalid AI provider auth source.");
+	});
+
+	test("rejects public no-auth provider endpoints", () => {
+		expect(() =>
+			buildAiProviderBootstrap(
+				{
+					...provider,
+					provider_id: "public-no-auth",
+					type: "custom_openai_compatible",
+					base_url: "https://example.com/v1",
+					api_mode: "openai_chat",
+					auth: { type: "none" },
+				},
+				"api_key",
+			),
+		).toThrow("uses no auth on a public URL");
+	});
+
+	test("allows local no-auth provider endpoints", () => {
+		const bootstrap = buildAiProviderBootstrap(
+			{
+				...provider,
+				provider_id: "local-no-auth",
+				type: "custom_openai_compatible",
+				base_url: "http://127.0.0.1:11434/v1",
+				api_mode: "openai_chat",
+				auth: { type: "none" },
+			},
+			"api_key",
+		);
+
+		expect(bootstrap.selected_provider_id).toBe("local-no-auth");
+	});
+});

--- a/apps/web/src/hosted/ai-providers/runtime-bootstrap.ts
+++ b/apps/web/src/hosted/ai-providers/runtime-bootstrap.ts
@@ -1,0 +1,118 @@
+import type {
+	AiProviderCatalog,
+	AiProvider as RuntimeAiProvider,
+	AiProviderAuth as RuntimeAiProviderAuth,
+} from "@clawdi/shared";
+import { validateAiProviderCatalog } from "@clawdi/shared";
+import type { AiProvider } from "@/hosted/ai-providers/types";
+
+export type RuntimeAiProviderAuthKind = "api_key" | "codex_oauth";
+
+export interface RuntimeAiProviderBootstrap extends Record<string, unknown> {
+	schema_version: 1;
+	selected_provider_id: string;
+	auth_kind: RuntimeAiProviderAuthKind;
+	catalog: AiProviderCatalog;
+}
+
+const CAPABILITY_KEYS = [
+	"chat",
+	"responses",
+	"tools",
+	"vision",
+	"embeddings",
+	"image_generation",
+] as const;
+
+export function aiProviderRuntimeId(provider: AiProvider): string {
+	return provider.provider_id;
+}
+
+export function buildAiProviderBootstrap(
+	provider: AiProvider,
+	authKind: RuntimeAiProviderAuthKind,
+): RuntimeAiProviderBootstrap {
+	const runtimeProvider = toRuntimeAiProvider(provider);
+	const catalog: AiProviderCatalog = {
+		schema_version: 1,
+		providers: [runtimeProvider],
+		defaults: { chat_provider_id: runtimeProvider.id },
+	};
+	const validation = validateAiProviderCatalog(catalog);
+	if (!validation.valid) {
+		throw new Error(`Invalid AI provider catalog: ${validation.errors.join("; ")}`);
+	}
+	return {
+		schema_version: 1,
+		selected_provider_id: runtimeProvider.id,
+		auth_kind: authKind,
+		catalog,
+	};
+}
+
+export function toRuntimeAiProvider(provider: AiProvider): RuntimeAiProvider {
+	const runtimeProvider: RuntimeAiProvider = {
+		id: provider.provider_id,
+		type: provider.type,
+		base_url: provider.base_url,
+		auth: toRuntimeAuth(provider.auth),
+		managed_by: provider.managed_by,
+	};
+	if (provider.label) runtimeProvider.label = provider.label;
+	if (provider.default_model) runtimeProvider.default_model = provider.default_model;
+	if (provider.api_mode) runtimeProvider.api_mode = provider.api_mode;
+	if (provider.runtime_env_name) runtimeProvider.runtime_env_name = provider.runtime_env_name;
+	const capabilities = toRuntimeCapabilities(provider.capabilities);
+	if (capabilities) runtimeProvider.capabilities = capabilities;
+	return runtimeProvider;
+}
+
+function toRuntimeAuth(auth: AiProvider["auth"]): RuntimeAiProviderAuth {
+	if (auth.type === "secret_ref") {
+		return { type: "secret_ref", ref: requireAuthString(auth.ref, "secret_ref.ref") };
+	}
+	if (auth.type === "api_key") {
+		if (auth.source !== "env" && auth.source !== "vault" && auth.source !== "managed") {
+			throw new Error("Invalid AI provider auth source.");
+		}
+		if (auth.source === "managed") return { type: "api_key", source: "managed" };
+		return {
+			type: "api_key",
+			source: auth.source,
+			ref: requireAuthString(auth.ref, `api_key.${auth.source}.ref`),
+		};
+	}
+	if (auth.type === "oauth_profile") {
+		return {
+			type: "oauth_profile",
+			provider: requireAuthString(auth.provider, "oauth_profile.provider"),
+			profile: requireAuthString(auth.profile, "oauth_profile.profile"),
+		};
+	}
+	if (auth.type === "agent_profile") {
+		return {
+			type: "agent_profile",
+			tool: requireAuthString(auth.tool, "agent_profile.tool"),
+			profile: requireAuthString(auth.profile, "agent_profile.profile"),
+		};
+	}
+	if (auth.type === "none") return { type: "none" };
+	throw new Error("Unsupported AI provider auth type.");
+}
+
+function requireAuthString(value: string | null | undefined, field: string): string {
+	if (!value) throw new Error(`Invalid AI provider auth metadata: missing ${field}.`);
+	return value;
+}
+
+function toRuntimeCapabilities(
+	capabilities: Record<string, unknown> | null | undefined,
+): RuntimeAiProvider["capabilities"] | undefined {
+	if (!capabilities) return undefined;
+	const output: RuntimeAiProvider["capabilities"] = {};
+	for (const key of CAPABILITY_KEYS) {
+		const value = capabilities[key];
+		if (typeof value === "boolean") output[key] = value;
+	}
+	return Object.keys(output).length > 0 ? output : undefined;
+}

--- a/apps/web/src/hosted/ai-providers/types.ts
+++ b/apps/web/src/hosted/ai-providers/types.ts
@@ -1,0 +1,17 @@
+import type { components } from "@/lib/api-schemas";
+
+/**
+ * AI Provider API-response types, derived from the generated cloud-api schema.
+ * Kept local to the hosted feature rather than aliased in `@clawdi/shared`,
+ * whose root barrel already exports `AiProvider`/`AiProviderAuth` from the
+ * hand-written provider-catalog module (those names would clash).
+ */
+type Schemas = components["schemas"];
+
+export type AiProvider = Schemas["AiProviderResponse"];
+export type AiProviderAuth = Schemas["AiProviderAuth"];
+export type AiProviderUpsert = Schemas["AiProviderUpsert"];
+export type AiProviderPatch = Schemas["AiProviderPatch"];
+export type AiProviderValidation = Schemas["AiProviderValidationResponse"];
+export type AiProviderOAuthStart = Schemas["AiProviderOAuthStartResponse"];
+export type AiProviderDeleted = Schemas["AiProviderDeleteResponse"];

--- a/apps/web/src/hosted/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/channels/channel-detail-page.tsx
@@ -1,0 +1,817 @@
+"use client";
+
+import {
+	ArrowDownLeft,
+	ArrowUpRight,
+	KeyRound,
+	Link2,
+	Link2Off,
+	MessageSquareDashed,
+	QrCode,
+	RefreshCw,
+	Smartphone,
+	TerminalSquare,
+	Trash2,
+	TriangleAlert,
+} from "lucide-react";
+import { useParams, useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
+import { agentTypeLabel } from "@/components/dashboard/agent-label";
+import { EmptyState } from "@/components/empty-state";
+import { InfoCard } from "@/components/info-card";
+import { PageHeader } from "@/components/page-header";
+import { Button } from "@/components/ui/button";
+import { ConfirmAction } from "@/components/ui/confirm-action";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { providerMeta } from "@/hosted/channels/channel-providers";
+import type {
+	ChannelActivityItem,
+	ChannelAgentLink,
+	ChannelBinding,
+} from "@/hosted/channels/channel-types";
+import {
+	ChannelError,
+	CopyInline,
+	DeliveryBadge,
+	HealthBadge,
+	ProviderChip,
+	TokenReveal,
+} from "@/hosted/channels/channel-ui";
+import {
+	useChannel,
+	useChannelActivity,
+	useChannelAgentLinks,
+	useChannelBindings,
+	useChannelHealth,
+	useCreatePairCode,
+	useCreateWhatsappTenantCred,
+	useDeleteChannel,
+	useEnvironments,
+	useRevokeWhatsappTenantCred,
+	useRotateAgentToken,
+	useSyncCommands,
+	useUnlinkChannelAgent,
+	useWhatsappTenantCreds,
+} from "@/hosted/channels/channels-hooks";
+import { LinkAgentDialog } from "@/hosted/channels/link-agent-dialog";
+
+function formatWhen(iso: string | null | undefined): string {
+	if (!iso) return "—";
+	const delta = new Date(iso).getTime() - Date.now(); // positive = future
+	const future = delta > 0;
+	const phrase = (value: number, unit: string) =>
+		future ? `in ${value}${unit}` : `${value}${unit} ago`;
+	const min = Math.round(Math.abs(delta) / 60000);
+	if (min < 1) return "just now";
+	if (min < 60) return phrase(min, "m");
+	const hr = Math.round(min / 60);
+	if (hr < 24) return phrase(hr, "h");
+	return new Date(iso).toLocaleDateString();
+}
+
+type EnvironmentList = ReturnType<typeof useEnvironments>["data"];
+
+/** "machine · agent-type" label for an agent id, falling back to the raw id. */
+function envName(envs: EnvironmentList, agentId: string): string {
+	const env = envs?.find((e) => e.id === agentId);
+	return env ? `${env.machine_name} · ${agentTypeLabel(env.agent_type)}` : agentId;
+}
+
+export function ChannelDetailPage() {
+	const params = useParams<{ id: string }>();
+	const id = params.id;
+	const channel = useChannel(id);
+	const health = useChannelHealth();
+	const router = useRouter();
+	const del = useDeleteChannel();
+
+	useSetBreadcrumbTitle(channel.data?.name);
+
+	const healthItem = useMemo(
+		() => health.data?.items.find((h) => h.account_id === id),
+		[health.data, id],
+	);
+
+	if (channel.isLoading) {
+		return (
+			<div data-hosted="true" className="space-y-6 px-4 lg:px-6">
+				<Skeleton className="h-12 w-64" />
+				<Skeleton className="h-64 w-full rounded-lg" />
+			</div>
+		);
+	}
+
+	if (channel.error) {
+		return (
+			<div data-hosted="true" className="px-4 lg:px-6">
+				<ChannelError
+					error={channel.error}
+					onRetry={() => channel.refetch()}
+					title="Couldn't load channel"
+				/>
+			</div>
+		);
+	}
+
+	if (!channel.data) {
+		return (
+			<div data-hosted="true" className="px-4 lg:px-6">
+				<EmptyState
+					icon={MessageSquareDashed}
+					title="Channel not found"
+					description="This channel may have been removed."
+					action={
+						<Button variant="outline" onClick={() => router.push("/channels")}>
+							Back to Channels
+						</Button>
+					}
+				/>
+			</div>
+		);
+	}
+
+	const ch = channel.data;
+	const meta = providerMeta(ch.provider);
+
+	return (
+		<div data-hosted="true" className="space-y-6 px-4 lg:px-6">
+			<PageHeader
+				title={ch.name}
+				description={`${meta.label} · ${ch.visibility === "public" ? "Shared bot" : "Private bot"}`}
+				actions={
+					<ConfirmAction
+						title={`Remove ${ch.name}?`}
+						description={
+							<p>
+								Agents linked to this channel will stop sending and receiving. This can't be undone.
+							</p>
+						}
+						confirmLabel="Remove channel"
+						destructive
+						onConfirm={() => del.mutate(id, { onSuccess: () => router.push("/channels") })}
+					>
+						<Button variant="outline" className="text-muted-foreground hover:text-destructive">
+							<Trash2 className="size-4" />
+							Remove
+						</Button>
+					</ConfirmAction>
+				}
+			/>
+
+			<div className="flex items-center gap-3">
+				<ProviderChip provider={ch.provider} />
+				<div className="flex items-center gap-2 text-sm text-muted-foreground">
+					<span className="capitalize">{ch.status}</span>
+					{healthItem ? <HealthBadge status={healthItem.health_status} /> : null}
+				</div>
+			</div>
+
+			<Tabs defaultValue="agents">
+				<TabsList className="flex-wrap">
+					<TabsTrigger value="agents">Agents</TabsTrigger>
+					{ch.provider === "whatsapp" ? (
+						<TabsTrigger value="devices">Linked devices</TabsTrigger>
+					) : null}
+					<TabsTrigger value="pair">Pair code</TabsTrigger>
+					<TabsTrigger value="bindings">Chats</TabsTrigger>
+					<TabsTrigger value="activity">Activity</TabsTrigger>
+					<TabsTrigger value="health">Health</TabsTrigger>
+					<TabsTrigger value="commands">Commands</TabsTrigger>
+				</TabsList>
+
+				<TabsContent value="agents" className="mt-4">
+					<AgentsTab accountId={id} accountName={ch.name} />
+				</TabsContent>
+				{ch.provider === "whatsapp" ? (
+					<TabsContent value="devices" className="mt-4">
+						<WhatsAppDevicesTab accountId={id} />
+					</TabsContent>
+				) : null}
+				<TabsContent value="pair" className="mt-4">
+					<PairCodeTab accountId={id} provider={ch.provider} />
+				</TabsContent>
+				<TabsContent value="bindings" className="mt-4">
+					<BindingsTab accountId={id} />
+				</TabsContent>
+				<TabsContent value="activity" className="mt-4">
+					<ActivityTab accountId={id} />
+				</TabsContent>
+				<TabsContent value="health" className="mt-4">
+					<HealthTab accountId={id} />
+				</TabsContent>
+				<TabsContent value="commands" className="mt-4">
+					<CommandsTab accountId={id} provider={ch.provider} />
+				</TabsContent>
+			</Tabs>
+		</div>
+	);
+}
+
+// ── Agents ───────────────────────────────────────────────────────────────────
+
+function AgentsTab({ accountId, accountName }: { accountId: string; accountName: string }) {
+	const links = useChannelAgentLinks(accountId);
+	const envs = useEnvironments();
+	const rotate = useRotateAgentToken(accountId);
+	const unlink = useUnlinkChannelAgent(accountId);
+	const [linkOpen, setLinkOpen] = useState(false);
+	const [rotated, setRotated] = useState<Record<string, string>>({});
+
+	if (links.isLoading) return <Skeleton className="h-24 w-full rounded-lg" />;
+	if (links.error) {
+		return (
+			<ChannelError
+				error={links.error}
+				onRetry={() => links.refetch()}
+				title="Couldn't load linked agents"
+			/>
+		);
+	}
+	const items = links.data ?? [];
+
+	return (
+		<div className="space-y-3">
+			{envs.error ? (
+				<ChannelError
+					error={envs.error}
+					onRetry={() => envs.refetch()}
+					title="Couldn't load agent names"
+				/>
+			) : null}
+			<div className="flex justify-end">
+				<Button size="sm" onClick={() => setLinkOpen(true)}>
+					<Link2 className="size-3.5" />
+					Link an agent
+				</Button>
+			</div>
+
+			{items.length === 0 ? (
+				<EmptyState
+					icon={Link2}
+					title="No agents linked"
+					description="Link an agent so it can send and receive on this channel."
+					fillHeight={false}
+				/>
+			) : (
+				<div className="space-y-2">
+					{items.map((link: ChannelAgentLink) => (
+						<div key={link.id} className="rounded-lg border p-3">
+							<div className="flex items-center justify-between gap-3">
+								<div className="min-w-0">
+									<div className="truncate text-sm font-medium">
+										{envName(envs.data, link.agent_id)}
+									</div>
+									<div className="text-xs capitalize text-muted-foreground">
+										{link.status} · linked {formatWhen(link.created_at)}
+									</div>
+								</div>
+								<div className="flex shrink-0 items-center gap-1.5">
+									<Button
+										variant="outline"
+										size="sm"
+										// Per-row: only the acting row's button shows pending, not all.
+										disabled={rotate.isPending && rotate.variables === link.id}
+										onClick={() =>
+											rotate.mutate(link.id, {
+												onSuccess: (data) => {
+													const token = data.agent_token;
+													if (!token) return;
+													setRotated((prev) => ({
+														...prev,
+														[link.id]: token,
+													}));
+												},
+											})
+										}
+									>
+										{rotate.isPending && rotate.variables === link.id ? (
+											<Spinner className="size-3.5" />
+										) : (
+											<RefreshCw className="size-3.5" />
+										)}
+										Rotate token
+									</Button>
+									<ConfirmAction
+										title="Unlink this agent?"
+										description={<p>It stops sending and receiving on {accountName}.</p>}
+										confirmLabel="Unlink"
+										destructive
+										onConfirm={() => unlink.mutate(link.id)}
+									>
+										<Button
+											variant="ghost"
+											size="icon-sm"
+											className="text-muted-foreground hover:text-destructive"
+											disabled={unlink.isPending && unlink.variables === link.id}
+											aria-label="Unlink agent"
+										>
+											<Link2Off className="size-4" />
+										</Button>
+									</ConfirmAction>
+								</div>
+							</div>
+							{rotated[link.id] ? (
+								<div className="mt-3">
+									<TokenReveal
+										label="New agent token"
+										value={rotated[link.id]}
+										note="The previous token is now invalid. Update the agent with this value."
+									/>
+								</div>
+							) : null}
+						</div>
+					))}
+				</div>
+			)}
+
+			<LinkAgentDialog
+				open={linkOpen}
+				onOpenChange={setLinkOpen}
+				accountId={accountId}
+				accountName={accountName}
+			/>
+		</div>
+	);
+}
+
+// ── WhatsApp linked devices (Baileys tenant credentials) ─────────────────────
+
+function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
+	const links = useChannelAgentLinks(accountId);
+	const envs = useEnvironments();
+	const creds = useWhatsappTenantCreds(accountId);
+	const create = useCreateWhatsappTenantCred(accountId);
+	const revoke = useRevokeWhatsappTenantCred(accountId);
+	const [linkId, setLinkId] = useState("");
+
+	const linkItems = links.data ?? [];
+	const devices = creds.data ?? [];
+	// Default to the only link when there's exactly one.
+	const effectiveLink = linkId || (linkItems.length === 1 ? linkItems[0].id : "");
+
+	return (
+		<div className="max-w-xl space-y-4">
+			<InfoCard icon={Smartphone} title="Link a WhatsApp number">
+				WhatsApp uses no bot token. Mint a device credential for an agent, then finish the link by
+				scanning it in WhatsApp → Linked devices. The live in-dashboard QR is coming soon — for now
+				the credential is handed to the agent runtime to complete pairing.
+			</InfoCard>
+
+			{links.isLoading ? (
+				<Skeleton className="h-16 w-full rounded-lg" />
+			) : links.error ? (
+				<ChannelError
+					error={links.error}
+					onRetry={() => links.refetch()}
+					title="Couldn't load linked agents"
+				/>
+			) : linkItems.length === 0 ? (
+				<EmptyState
+					bordered
+					fillHeight={false}
+					title="Link an agent first"
+					description="A WhatsApp device is minted per agent. Link an agent on the Agents tab, then come back."
+				/>
+			) : (
+				<div className="space-y-2">
+					{envs.error ? (
+						<ChannelError
+							error={envs.error}
+							onRetry={() => envs.refetch()}
+							title="Couldn't load agent names"
+						/>
+					) : null}
+					{linkItems.length > 1 ? (
+						<div className="space-y-1.5">
+							<Label htmlFor="wa-agent">Agent</Label>
+							<Select value={effectiveLink} onValueChange={setLinkId}>
+								<SelectTrigger id="wa-agent">
+									<SelectValue placeholder="Choose an agent" />
+								</SelectTrigger>
+								<SelectContent>
+									{linkItems.map((l) => (
+										<SelectItem key={l.id} value={l.id}>
+											{envName(envs.data, l.agent_id)}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+					) : null}
+					<Button
+						onClick={() => effectiveLink && create.mutate({ agent_link_id: effectiveLink })}
+						disabled={!effectiveLink || create.isPending}
+					>
+						<Smartphone className="size-4" />
+						{create.isPending ? "Minting…" : "Link a device"}
+					</Button>
+				</div>
+			)}
+
+			<div className="space-y-2">
+				<div className="text-sm font-medium">Linked devices</div>
+				{creds.isLoading ? (
+					<Skeleton className="h-16 w-full rounded-lg" />
+				) : creds.error ? (
+					<ChannelError
+						error={creds.error}
+						onRetry={() => creds.refetch()}
+						title="Couldn't load linked devices"
+					/>
+				) : devices.length === 0 ? (
+					<div className="rounded-lg border border-dashed px-3 py-6 text-center text-sm text-muted-foreground">
+						No devices linked yet.
+					</div>
+				) : (
+					devices.map((d) => (
+						<div
+							key={d.credential_id}
+							className="flex items-center justify-between gap-3 rounded-lg border p-3"
+						>
+							<div className="min-w-0">
+								{d.jid ? (
+									<div className="truncate font-mono text-xs">{d.jid}</div>
+								) : (
+									<div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+										<Spinner className="size-3" />
+										Pending pairing
+									</div>
+								)}
+								<div className="text-xs text-muted-foreground">
+									{envName(envs.data, d.agent_id)} · added {formatWhen(d.created_at)}
+								</div>
+							</div>
+							<ConfirmAction
+								title="Unlink this device?"
+								description={<p>The WhatsApp credential is revoked. This can't be undone.</p>}
+								confirmLabel="Unlink"
+								destructive
+								onConfirm={() => revoke.mutate(d.credential_id)}
+							>
+								<Button
+									variant="ghost"
+									size="icon-sm"
+									className="text-muted-foreground hover:text-destructive"
+									disabled={revoke.isPending}
+									aria-label="Unlink device"
+								>
+									<Trash2 className="size-4" />
+								</Button>
+							</ConfirmAction>
+						</div>
+					))
+				)}
+			</div>
+		</div>
+	);
+}
+
+// ── Pair code ────────────────────────────────────────────────────────────────
+
+const TTL_OPTIONS = [
+	{ value: "900", label: "15 minutes" },
+	{ value: "3600", label: "1 hour" },
+	{ value: "86400", label: "24 hours" },
+];
+
+function PairCodeTab({ accountId, provider }: { accountId: string; provider: string }) {
+	const envs = useEnvironments();
+	const create = useCreatePairCode(accountId);
+	// "" = no agent chosen (use the channel's linked agent). Sentinel keeps the
+	// Select controlled; mapped back to undefined in the request below.
+	const [agentId, setAgentId] = useState("");
+	const [ttl, setTtl] = useState("900");
+	const [result, setResult] = useState<{ code: string; expires_at: string } | null>(null);
+	const meta = providerMeta(provider);
+
+	function generate() {
+		create.mutate(
+			{ agent_id: agentId || undefined, ttl_seconds: Number(ttl) },
+			{ onSuccess: (data) => setResult({ code: data.code, expires_at: data.expires_at }) },
+		);
+	}
+
+	return (
+		<div className="max-w-xl space-y-4">
+			<InfoCard icon={QrCode} title="Pair a chat">
+				Generate a one-time code, then send it from the {meta.label} chat you want to pair — the
+				agent links that conversation when it sees the code.
+			</InfoCard>
+
+			<div className="grid gap-3 sm:grid-cols-2">
+				<div className="space-y-1.5">
+					<Label htmlFor="pair-agent">Agent</Label>
+					{envs.isLoading ? (
+						<Skeleton className="h-10 w-full rounded-md" />
+					) : (
+						<Select value={agentId} onValueChange={setAgentId} disabled={!!envs.error}>
+							<SelectTrigger id="pair-agent">
+								<SelectValue placeholder="Use linked agent" />
+							</SelectTrigger>
+							<SelectContent>
+								{(envs.data ?? []).map((env) => (
+									<SelectItem key={env.id} value={env.id}>
+										{env.machine_name} · {agentTypeLabel(env.agent_type)}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					)}
+				</div>
+				<div className="space-y-1.5">
+					<Label htmlFor="pair-ttl">Expires in</Label>
+					<Select value={ttl} onValueChange={setTtl}>
+						<SelectTrigger id="pair-ttl">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{TTL_OPTIONS.map((o) => (
+								<SelectItem key={o.value} value={o.value}>
+									{o.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+			</div>
+
+			{envs.error ? (
+				<ChannelError
+					error={envs.error}
+					onRetry={() => envs.refetch()}
+					title="Couldn't load agents"
+				/>
+			) : null}
+
+			<Button onClick={generate} disabled={create.isPending}>
+				<QrCode className="size-4" />
+				{create.isPending ? "Generating…" : "Generate pairing code"}
+			</Button>
+
+			{result ? (
+				<div className="space-y-3 rounded-lg border border-primary/30 bg-primary/5 p-4">
+					<div className="text-xs font-medium text-primary">Pairing code</div>
+					<div className="font-mono text-3xl font-semibold tracking-[0.2em]">{result.code}</div>
+					<p className="text-sm text-muted-foreground">
+						Send <span className="font-mono font-medium">{result.code}</span> from the chat you want
+						to pair. Expires {formatWhen(result.expires_at)}.
+					</p>
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+// ── Bindings (paired chats) ──────────────────────────────────────────────────
+
+function BindingsTab({ accountId }: { accountId: string }) {
+	const bindings = useChannelBindings(accountId);
+	if (bindings.isLoading) return <Skeleton className="h-24 w-full rounded-lg" />;
+	if (bindings.error) {
+		return (
+			<ChannelError
+				error={bindings.error}
+				onRetry={() => bindings.refetch()}
+				title="Couldn't load paired chats"
+			/>
+		);
+	}
+	const items = bindings.data ?? [];
+
+	if (items.length === 0) {
+		return (
+			<EmptyState
+				icon={MessageSquareDashed}
+				title="No paired chats"
+				description="Generate a pairing code, then send it from a chat to link it here."
+			/>
+		);
+	}
+
+	return (
+		<div className="space-y-2">
+			{items.map((b: ChannelBinding) => (
+				<div key={b.id} className="flex items-center justify-between gap-3 rounded-lg border p-3">
+					<div className="min-w-0">
+						<div className="truncate text-sm font-medium">{b.external_chat_name ?? "Chat"}</div>
+						<div className="flex items-center gap-2 text-xs text-muted-foreground">
+							<span className="capitalize">{b.external_chat_type ?? "chat"}</span>
+							<span>·</span>
+							<CopyInline value={b.external_chat_id} />
+						</div>
+					</div>
+					<span className="text-xs capitalize text-muted-foreground">{b.status}</span>
+				</div>
+			))}
+		</div>
+	);
+}
+
+// ── Activity ─────────────────────────────────────────────────────────────────
+
+function ActivityTab({ accountId }: { accountId: string }) {
+	const activity = useChannelActivity(accountId);
+	if (activity.isLoading) return <Skeleton className="h-32 w-full rounded-lg" />;
+	if (activity.error) {
+		return (
+			<ChannelError
+				error={activity.error}
+				onRetry={() => activity.refetch()}
+				title="Couldn't load activity"
+			/>
+		);
+	}
+	const items = activity.data?.items ?? [];
+
+	if (items.length === 0) {
+		return (
+			<EmptyState
+				icon={MessageSquareDashed}
+				title="No activity yet"
+				description="Messages and delivery events will show up here."
+			/>
+		);
+	}
+
+	return (
+		<div className="space-y-2">
+			{items.map((item: ChannelActivityItem) => (
+				<ActivityRow key={item.id} item={item} />
+			))}
+		</div>
+	);
+}
+
+function ActivityRow({ item }: { item: ChannelActivityItem }) {
+	const inbound = item.direction === "inbound";
+	const isEvent = item.kind === "debug_event";
+	const error = item.delivery_last_error ?? item.error;
+
+	return (
+		<div className="flex items-start gap-3 rounded-lg border p-3">
+			<span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+				{isEvent ? (
+					<TerminalSquare className="size-3.5" />
+				) : inbound ? (
+					<ArrowDownLeft className="size-3.5" />
+				) : (
+					<ArrowUpRight className="size-3.5" />
+				)}
+			</span>
+			<div className="min-w-0 flex-1">
+				<div className="flex items-center gap-2">
+					<span className="text-xs font-medium capitalize">
+						{isEvent ? (item.stage ?? "event") : inbound ? "Inbound" : "Outbound"}
+					</span>
+					{item.delivery_status ? <DeliveryBadge status={item.delivery_status} /> : null}
+					<span className="ml-auto shrink-0 text-xs text-muted-foreground">
+						{formatWhen(item.created_at)}
+					</span>
+				</div>
+				{item.text ? <p className="mt-1 text-sm">{item.text}</p> : null}
+				{error ? (
+					<p className="mt-1 flex items-start gap-1 text-xs text-destructive">
+						<TriangleAlert className="mt-0.5 size-3 shrink-0" />
+						{error}
+					</p>
+				) : null}
+				{item.external_chat_id ? (
+					<div className="mt-1">
+						<CopyInline value={item.external_chat_id} />
+					</div>
+				) : null}
+			</div>
+		</div>
+	);
+}
+
+// ── Health ───────────────────────────────────────────────────────────────────
+
+function HealthTab({ accountId }: { accountId: string }) {
+	const health = useChannelHealth();
+	if (health.isLoading) return <Skeleton className="h-32 w-full rounded-lg" />;
+	if (health.error) {
+		return (
+			<ChannelError
+				error={health.error}
+				onRetry={() => health.refetch()}
+				title="Couldn't load health"
+			/>
+		);
+	}
+	const h = health.data?.items.find((x) => x.account_id === accountId);
+	if (!h)
+		return <EmptyState title="No health data" description="Health metrics aren't available yet." />;
+
+	const stats = [
+		{ label: "Pending inbox", value: h.pending_inbox },
+		{ label: "Pending deliveries", value: h.pending_deliveries },
+		{ label: "In progress", value: h.in_progress_deliveries },
+		{ label: "Failed deliveries", value: h.failed_deliveries },
+	];
+
+	return (
+		<div className="space-y-4">
+			<div className="flex items-center gap-2">
+				<HealthBadge status={h.health_status} />
+				{(h.reasons ?? []).length > 0 ? (
+					<span className="text-xs text-muted-foreground">
+						{(h.reasons ?? []).join(" · ").replace(/_/g, " ")}
+					</span>
+				) : (
+					<span className="text-xs text-muted-foreground">No issues detected</span>
+				)}
+			</div>
+
+			<div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+				{stats.map((s) => (
+					<div key={s.label} className="rounded-lg border p-3">
+						<div className="text-2xl font-semibold tabular-nums">{s.value}</div>
+						<div className="text-xs text-muted-foreground">{s.label}</div>
+					</div>
+				))}
+			</div>
+
+			{h.last_error ? (
+				<div className="space-y-1 rounded-lg border border-destructive/30 bg-destructive/5 p-3">
+					<div className="flex items-center gap-1.5 text-sm font-medium text-destructive">
+						<TriangleAlert className="size-4" />
+						Last error
+					</div>
+					<p className="text-sm text-destructive/90">{h.last_error}</p>
+					<p className="text-xs text-muted-foreground">
+						{[h.last_error_stage, h.last_error_outcome].filter(Boolean).join(" · ")} ·{" "}
+						{formatWhen(h.last_error_at)}
+					</p>
+				</div>
+			) : null}
+
+			{h.native_transport ? (
+				<div className="rounded-lg border p-3">
+					<div className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+						Native transport
+					</div>
+					<pre className="overflow-x-auto text-xs text-muted-foreground">
+						{JSON.stringify(h.native_transport, null, 2)}
+					</pre>
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+// ── Commands ─────────────────────────────────────────────────────────────────
+
+function CommandsTab({ accountId, provider }: { accountId: string; provider: string }) {
+	const sync = useSyncCommands(accountId);
+	const meta = providerMeta(provider);
+	const supportsCommands = provider === "telegram" || provider === "discord";
+	const commands = sync.data?.commands ?? [];
+
+	return (
+		<div className="max-w-xl space-y-4">
+			<InfoCard icon={KeyRound} title="Slash commands">
+				{supportsCommands
+					? `Publish this agent's slash commands to ${meta.label}.`
+					: `${meta.label} doesn't support slash commands.`}
+			</InfoCard>
+
+			{supportsCommands ? (
+				<>
+					<Button onClick={() => sync.mutate()} disabled={sync.isPending}>
+						<RefreshCw className="size-4" />
+						{sync.isPending ? "Syncing…" : "Sync commands"}
+					</Button>
+					{commands.length > 0 ? (
+						<div className="space-y-2 rounded-lg border p-3">
+							<div className="text-xs font-medium text-success-muted-foreground">
+								Synced {commands.length} command{commands.length === 1 ? "" : "s"}
+							</div>
+							{commands.map((c) => (
+								<div key={String(c.name)} className="flex items-baseline gap-2 text-sm">
+									<code className="font-mono text-xs">/{String(c.name)}</code>
+									<span className="text-muted-foreground">{String(c.description)}</span>
+								</div>
+							))}
+						</div>
+					) : sync.data ? (
+						<div className="rounded-lg border border-dashed px-3 py-3 text-sm text-muted-foreground">
+							Command sync completed. The runtime returned no commands to publish.
+						</div>
+					) : null}
+				</>
+			) : null}
+		</div>
+	);
+}

--- a/apps/web/src/hosted/channels/channel-edit-client.ts
+++ b/apps/web/src/hosted/channels/channel-edit-client.ts
@@ -1,0 +1,109 @@
+"use client";
+
+import { extractApiDetail } from "@clawdi/shared/api";
+import { useMemo } from "react";
+import { ApiError, ApiNetworkError } from "@/lib/api-errors";
+import { useAuthToken } from "@/lib/auth-client";
+import { env } from "@/lib/env";
+
+const API_URL = env.NEXT_PUBLIC_API_URL;
+
+/** Client-side request ceiling so a stalled call can't freeze the page (matches lib/api.ts). */
+const REQUEST_TIMEOUT_MS = 20_000;
+
+/**
+ * Account summary embedded in an agent's channel link. Handwritten to mirror
+ * the cloud-api `/api/channels/agent-links` response.
+ */
+export interface AgentChannelLinkAccount {
+	id: string;
+	provider: string;
+	name: string;
+	status: string;
+	visibility: "private" | "public";
+}
+
+/** An agent's channel link with its embedded account summary. */
+export interface AgentChannelLink {
+	id: string;
+	account_id: string;
+	agent_id: string;
+	status: string;
+	created_at: string;
+	agent_token?: string | null;
+	/**
+	 * Embedded account summary. OPTIONAL on purpose: the cloud-api list-by-agent
+	 * response (#155) is not guaranteed to nest the account — the matching
+	 * backend link schema (`ChannelAgentLinkResponse`) carries only
+	 * `account_id`. Consumers MUST null-guard and fall back to `account_id` /
+	 * the loaded channels list (apps/web has no ErrorBoundary).
+	 */
+	account?: AgentChannelLinkAccount | null;
+}
+
+/**
+ * Handwritten, Clerk-authenticated client for the two agent-link edit routes.
+ *
+ * These endpoints ship in the cloud-api PR and are intentionally NOT part of
+ * main's generated OpenAPI client, so we call them directly with the Clerk
+ * bearer instead of `useApi`. Non-2xx responses throw `ApiError` so the
+ * channel hooks route failures through their existing error handling.
+ */
+export function useChannelEditApi() {
+	const { getToken } = useAuthToken();
+	return useMemo(() => {
+		async function request<T>(
+			path: string,
+			init: { method: "GET" | "DELETE"; query?: Record<string, string> },
+		): Promise<T> {
+			const token = await getToken();
+			const url = new URL(`${API_URL}${path}`);
+			if (init.query) {
+				for (const [key, value] of Object.entries(init.query)) url.searchParams.set(key, value);
+			}
+			// Bound the request so a stalled connection can't freeze the surface.
+			const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+			let response: Response;
+			try {
+				response = await fetch(url.toString(), {
+					method: init.method,
+					headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+					signal: timeout,
+				});
+			} catch (cause) {
+				// fetch only rejects on transport failure (offline, DNS, CORS, abort) —
+				// never on a non-2xx. Map our timeout abort and bare network failures
+				// to a recoverable, normalizable error.
+				if (timeout.aborted) throw new ApiNetworkError("timeout", { cause });
+				throw new ApiNetworkError("offline", { cause });
+			}
+			if (!response.ok) {
+				let detail = response.statusText;
+				try {
+					detail = extractApiDetail(await response.json());
+				} catch {
+					// Non-JSON error body — fall back to the status text.
+				}
+				throw new ApiError(response.status, detail);
+			}
+			if (response.status === 204) return undefined as T;
+			const text = await response.text();
+			return (text ? JSON.parse(text) : undefined) as T;
+		}
+
+		return {
+			/** GET /api/channels/agent-links?agent_id={id} — links for one agent. */
+			listAgentLinks: (agentId: string) =>
+				request<AgentChannelLink[]>("/api/channels/agent-links", {
+					method: "GET",
+					query: { agent_id: agentId },
+				}),
+			/** DELETE /api/channels/{accountId}/agent-links/{linkId} — unlink. */
+			unlinkAgent: (accountId: string, linkId: string) =>
+				request<void>(
+					`/api/channels/${encodeURIComponent(accountId)}/agent-links/${encodeURIComponent(linkId)}`,
+					{ method: "DELETE" },
+				),
+		};
+	}, [getToken]);
+}

--- a/apps/web/src/hosted/channels/channel-edit-client.ts
+++ b/apps/web/src/hosted/channels/channel-edit-client.ts
@@ -11,6 +11,23 @@ const API_URL = env.NEXT_PUBLIC_API_URL;
 /** Client-side request ceiling so a stalled call can't freeze the page (matches lib/api.ts). */
 const REQUEST_TIMEOUT_MS = 20_000;
 
+async function fetchWithTimeout(input: string, init: RequestInit): Promise<Response> {
+	const controller = new AbortController();
+	let timedOut = false;
+	const timeoutId = setTimeout(() => {
+		timedOut = true;
+		controller.abort();
+	}, REQUEST_TIMEOUT_MS);
+	try {
+		return await fetch(input, { ...init, signal: controller.signal });
+	} catch (cause) {
+		if (timedOut) throw new ApiNetworkError("timeout", { cause });
+		throw new ApiNetworkError("offline", { cause });
+	} finally {
+		clearTimeout(timeoutId);
+	}
+}
+
 /**
  * Account summary embedded in an agent's channel link. Handwritten to mirror
  * the cloud-api `/api/channels/agent-links` response.
@@ -61,22 +78,11 @@ export function useChannelEditApi() {
 			if (init.query) {
 				for (const [key, value] of Object.entries(init.query)) url.searchParams.set(key, value);
 			}
-			// Bound the request so a stalled connection can't freeze the surface.
-			const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
 			let response: Response;
-			try {
-				response = await fetch(url.toString(), {
-					method: init.method,
-					headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-					signal: timeout,
-				});
-			} catch (cause) {
-				// fetch only rejects on transport failure (offline, DNS, CORS, abort) —
-				// never on a non-2xx. Map our timeout abort and bare network failures
-				// to a recoverable, normalizable error.
-				if (timeout.aborted) throw new ApiNetworkError("timeout", { cause });
-				throw new ApiNetworkError("offline", { cause });
-			}
+			response = await fetchWithTimeout(url.toString(), {
+				method: init.method,
+				headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+			});
 			if (!response.ok) {
 				let detail = response.statusText;
 				try {

--- a/apps/web/src/hosted/channels/channel-providers.ts
+++ b/apps/web/src/hosted/channels/channel-providers.ts
@@ -1,0 +1,87 @@
+/**
+ * The four native channel providers (backend `CHANNEL_PROVIDERS`). Each takes
+ * DIFFERENT real connect inputs — grounded in cloud-api:
+ *   - telegram:  bot token (BotFather)                → provider_token
+ *   - discord:   bot token + application_id + public_key (+ optional guild_id)
+ *                                                       → provider_token + config
+ *   - whatsapp:  NO token — Baileys device link via the tenant-creds flow
+ *   - imessage:  BlueBubbles server_url + password (+ auth_mode)
+ *                                                       → provider_token + config
+ * Tints reuse the app identity palette so channel chips match the chrome.
+ */
+export const CHANNEL_PROVIDERS = ["telegram", "discord", "whatsapp", "imessage"] as const;
+export type ChannelProviderId = (typeof CHANNEL_PROVIDERS)[number];
+
+/** How the connect form behaves for this provider. */
+export type ChannelConnectMode = "token" | "discord" | "whatsapp" | "imessage";
+
+export interface ChannelProviderMeta {
+	id: ChannelProviderId;
+	label: string;
+	tint: string;
+	connect: ChannelConnectMode;
+	/** Label/placeholder for the single credential field (token / password). */
+	tokenLabel?: string;
+	tokenPlaceholder?: string;
+	hint: string;
+}
+
+export const PROVIDER_META: Record<ChannelProviderId, ChannelProviderMeta> = {
+	telegram: {
+		id: "telegram",
+		label: "Telegram",
+		tint: "bg-identity-3-bg text-identity-3-fg",
+		connect: "token",
+		tokenLabel: "Bot token",
+		tokenPlaceholder: "123456:ABC-DEF…",
+		hint: "Create a bot with @BotFather and paste its token.",
+	},
+	discord: {
+		id: "discord",
+		label: "Discord",
+		tint: "bg-identity-5-bg text-identity-5-fg",
+		connect: "discord",
+		tokenLabel: "Bot token",
+		tokenPlaceholder: "Bot token",
+		hint: "From the Discord developer portal: the bot token, plus the application ID and public key for slash commands and interactions.",
+	},
+	whatsapp: {
+		id: "whatsapp",
+		label: "WhatsApp",
+		tint: "bg-identity-2-bg text-identity-2-fg",
+		connect: "whatsapp",
+		hint: "No bot token — connect, then link your WhatsApp number by scanning a code (Linked devices).",
+	},
+	imessage: {
+		id: "imessage",
+		label: "iMessage",
+		tint: "bg-identity-6-bg text-identity-6-fg",
+		connect: "imessage",
+		tokenLabel: "BlueBubbles password",
+		tokenPlaceholder: "Server password",
+		hint: "Connect your BlueBubbles server — its URL and password.",
+	},
+};
+
+/** BlueBubbles auth modes the backend understands (channels.py `_send_imessage`). */
+export const IMESSAGE_AUTH_MODES = [
+	{ value: "password_query", label: "Password (query)" },
+	{ value: "x_api_key", label: "API key header" },
+	{ value: "bearer", label: "Bearer token" },
+] as const;
+
+const FALLBACK: ChannelProviderMeta = {
+	id: "telegram",
+	label: "Channel",
+	tint: "bg-muted text-muted-foreground",
+	connect: "token",
+	hint: "",
+};
+
+export function providerMeta(id: string): ChannelProviderMeta {
+	return PROVIDER_META[id as ChannelProviderId] ?? { ...FALLBACK, label: id };
+}
+
+export function isChannelProvider(id: string): id is ChannelProviderId {
+	return (CHANNEL_PROVIDERS as readonly string[]).includes(id);
+}

--- a/apps/web/src/hosted/channels/channel-types.ts
+++ b/apps/web/src/hosted/channels/channel-types.ts
@@ -1,0 +1,19 @@
+import type { components } from "@/lib/api-schemas";
+
+/**
+ * Local aliases for the native-channel response shapes.
+ *
+ * Each maps to a schema already present in main's generated cloud-api client,
+ * so these are purely a convenience layer. We keep them in apps/web (rather
+ * than re-exporting from the shared package) so this surface stays apps/web-only
+ * — the shared `schemas.ts` convenience aliases ship with the cloud-api PR.
+ */
+type Schemas = components["schemas"];
+
+export type ChannelAccount = Schemas["ChannelAccountResponse"];
+export type ChannelCreate = Schemas["ChannelAccountCreate"];
+export type ChannelCreated = Schemas["ChannelAccountCreatedResponse"];
+export type ChannelBotPoolItem = Schemas["ChannelBotPoolItem"];
+export type ChannelAgentLink = Schemas["ChannelAgentLinkResponse"];
+export type ChannelBinding = Schemas["ChannelBindingResponse"];
+export type ChannelActivityItem = Schemas["ChannelActivityItemResponse"];

--- a/apps/web/src/hosted/channels/channel-ui.tsx
+++ b/apps/web/src/hosted/channels/channel-ui.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import {
+	Check,
+	CircleAlert,
+	CircleCheck,
+	Copy,
+	LogIn,
+	RefreshCw,
+	TriangleAlert,
+} from "lucide-react";
+import { EntityIcon, type EntityIconSize } from "@/components/entity-icon";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { StatusBadge } from "@/components/ui/status-badge";
+import { providerMeta } from "@/hosted/channels/channel-providers";
+import { useCopyToClipboard } from "@/hosted/use-copy-to-clipboard";
+import { isApiAuthError, normalizeApiError } from "@/lib/api-errors";
+import { cn } from "@/lib/utils";
+
+type StatusTone = "success" | "warning" | "destructive" | "info" | "neutral";
+
+/** Send the user back through Clerk, returning to wherever they are now. */
+function reauthenticate() {
+	if (typeof window === "undefined") return;
+	const redirect = encodeURIComponent(window.location.pathname + window.location.search);
+	window.location.href = `/sign-in?redirect_url=${redirect}`;
+}
+
+/**
+ * Cloud-api error panel for the hosted channel / provider surfaces. Normalizes
+ * the failure to internal-free copy and, on a session-expiry 401, leads with a
+ * "Sign in again" action (a retry can't fix a dead token) while keeping Retry
+ * as a secondary affordance for the race where Clerk already refreshed it.
+ */
+export function ChannelError({
+	error,
+	onRetry,
+	title = "Couldn't load this",
+}: {
+	error: unknown;
+	onRetry?: () => void;
+	title?: string;
+}) {
+	const expired = isApiAuthError(error);
+	return (
+		<Alert data-hosted="true" variant="destructive">
+			<CircleAlert />
+			<AlertTitle>{expired ? "Your session expired" : title}</AlertTitle>
+			<AlertDescription className="flex flex-col items-start gap-3">
+				<span>{normalizeApiError(error)}</span>
+				<div className="flex flex-wrap gap-2">
+					{expired ? (
+						<Button size="sm" onClick={reauthenticate}>
+							<LogIn /> Sign in again
+						</Button>
+					) : null}
+					{onRetry ? (
+						<Button size="sm" variant="outline" onClick={onRetry}>
+							<RefreshCw /> Retry
+						</Button>
+					) : null}
+				</div>
+			</AlertDescription>
+		</Alert>
+	);
+}
+
+/** Real app-icon for a channel provider (delegates to the unified EntityIcon). */
+export function ProviderChip({
+	provider,
+	size = "md",
+	className,
+}: {
+	provider: string;
+	size?: EntityIconSize;
+	className?: string;
+}) {
+	const meta = providerMeta(provider);
+	return (
+		<EntityIcon kind="channel" id={provider} label={meta.label} size={size} className={className} />
+	);
+}
+
+const HEALTH_META: Record<string, { label: string; tone: StatusTone; icon: typeof CircleCheck }> = {
+	ok: { label: "Healthy", tone: "success", icon: CircleCheck },
+	warning: { label: "Warning", tone: "warning", icon: TriangleAlert },
+	error: { label: "Error", tone: "destructive", icon: CircleAlert },
+};
+
+/** Health chip (ok / warning / error) from `GET /api/channels/health`. */
+export function HealthBadge({ status, className }: { status: string; className?: string }) {
+	const m = HEALTH_META[status] ?? HEALTH_META.warning;
+	const Icon = m.icon;
+	return (
+		<StatusBadge status={m.tone} className={className}>
+			<Icon />
+			{m.label}
+		</StatusBadge>
+	);
+}
+
+/** Owner / shared access label for pool items. */
+export function AccessBadge({ access }: { access: string }) {
+	const owner = access === "owner";
+	return (
+		<StatusBadge status={owner ? "info" : "neutral"}>{owner ? "Your bot" : "Shared"}</StatusBadge>
+	);
+}
+
+const DELIVERY_TONE: Record<string, StatusTone> = {
+	sent: "success",
+	delivered: "success",
+	pending: "warning",
+	in_progress: "warning",
+	failed: "destructive",
+};
+
+/** Delivery state chip for activity rows. */
+export function DeliveryBadge({ status }: { status: string }) {
+	return (
+		<StatusBadge status={DELIVERY_TONE[status] ?? "neutral"}>
+			{status.replace("_", " ")}
+		</StatusBadge>
+	);
+}
+
+function useCopy() {
+	return useCopyToClipboard({ error: "Copy failed" });
+}
+
+/** Copyable secret box — used for revealed agent tokens, webhook secrets. */
+export function TokenReveal({
+	label,
+	value,
+	note,
+}: {
+	label: string;
+	value: string;
+	note?: string;
+}) {
+	const { copied, copy } = useCopy();
+	return (
+		<div
+			data-hosted="true"
+			className="space-y-2 rounded-lg border border-primary/30 bg-primary/5 p-3"
+		>
+			<div className="text-xs font-medium text-primary">{label}</div>
+			<div className="flex items-center gap-2">
+				<code className="flex-1 break-all rounded bg-muted px-3 py-2 font-mono text-xs">
+					{value}
+				</code>
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon"
+					onClick={() => copy(value)}
+					aria-label={`Copy ${label}`}
+				>
+					{copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+				</Button>
+			</div>
+			{note ? <p className="text-xs text-muted-foreground">{note}</p> : null}
+		</div>
+	);
+}
+
+/** Inline copyable monospace value (chat ids, webhook urls). */
+export function CopyInline({ value, className }: { value: string; className?: string }) {
+	const { copied, copy } = useCopy();
+	return (
+		<button
+			type="button"
+			data-hosted="true"
+			onClick={() => copy(value)}
+			className={cn(
+				"inline-flex items-center gap-1 font-mono text-xs text-muted-foreground transition-colors hover:text-foreground",
+				className,
+			)}
+			aria-label="Copy"
+		>
+			<span className="truncate">{value}</span>
+			{copied ? <Check className="size-3 shrink-0" /> : <Copy className="size-3 shrink-0" />}
+		</button>
+	);
+}

--- a/apps/web/src/hosted/channels/channels-hooks.ts
+++ b/apps/web/src/hosted/channels/channels-hooks.ts
@@ -1,0 +1,325 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useChannelEditApi } from "@/hosted/channels/channel-edit-client";
+import type { ChannelCreate } from "@/hosted/channels/channel-types";
+import { toastApiError, unwrap, useApi } from "@/lib/api";
+
+/**
+ * Typed data hooks for the native channels surface. All reads/writes go
+ * through the generated cloud-api client (`useApi`) against
+ * `/api/channels/*`; mutations invalidate the affected queries and surface
+ * recoverable errors as toasts.
+ */
+
+const keys = {
+	list: ["channels"] as const,
+	pool: ["channel-bot-pool"] as const,
+	health: ["channel-health"] as const,
+	channel: (id: string) => ["channel", id] as const,
+	agentLinks: (id: string) => ["channel-agent-links", id] as const,
+	bindings: (id: string) => ["channel-bindings", id] as const,
+	activity: (id: string) => ["channel-activity", id] as const,
+	whatsappCreds: (id: string) => ["whatsapp-tenant-creds", id] as const,
+};
+
+export function useChannels() {
+	const api = useApi();
+	return useQuery({
+		queryKey: keys.list,
+		queryFn: async () => unwrap(await api.GET("/api/channels")),
+	});
+}
+
+export function useBotPool() {
+	const api = useApi();
+	return useQuery({
+		queryKey: keys.pool,
+		queryFn: async () => unwrap(await api.GET("/api/channels/bot-pool")),
+	});
+}
+
+export function useChannelHealth() {
+	const api = useApi();
+	return useQuery({
+		queryKey: keys.health,
+		queryFn: async () => unwrap(await api.GET("/api/channels/health")),
+	});
+}
+
+export function useChannel(id: string) {
+	const api = useApi();
+	return useQuery({
+		queryKey: keys.channel(id),
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/api/channels/{account_id}", {
+					params: { path: { account_id: id } },
+				}),
+			),
+		enabled: Boolean(id),
+	});
+}
+
+export function useChannelAgentLinks(id: string) {
+	const api = useApi();
+	return useQuery({
+		queryKey: keys.agentLinks(id),
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/api/channels/{account_id}/agent-links", {
+					params: { path: { account_id: id } },
+				}),
+			),
+		enabled: Boolean(id),
+	});
+}
+
+export function useChannelBindings(id: string) {
+	const api = useApi();
+	return useQuery({
+		queryKey: keys.bindings(id),
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/api/channels/{account_id}/bindings", {
+					params: { path: { account_id: id } },
+				}),
+			),
+		enabled: Boolean(id),
+	});
+}
+
+export function useChannelActivity(id: string) {
+	const api = useApi();
+	return useQuery({
+		queryKey: keys.activity(id),
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/api/channels/{account_id}/activity", {
+					params: { path: { account_id: id }, query: { limit: 50 } },
+				}),
+			),
+		enabled: Boolean(id),
+	});
+}
+
+/** Connected agents available to link / pair. Shares the `environments` key. */
+export function useEnvironments() {
+	const api = useApi();
+	return useQuery({
+		queryKey: ["environments"],
+		queryFn: async () => unwrap(await api.GET("/api/environments")),
+	});
+}
+
+export function useCreateChannel() {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (body: ChannelCreate) => unwrap(await api.POST("/api/channels", { body })),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: keys.list });
+			qc.invalidateQueries({ queryKey: keys.pool });
+			qc.invalidateQueries({ queryKey: keys.health });
+		},
+		onError: toastApiError("Couldn't connect channel"),
+	});
+}
+
+export function useDeleteChannel() {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (id: string) =>
+			unwrap(
+				await api.DELETE("/api/channels/{account_id}", {
+					params: { path: { account_id: id } },
+				}),
+			),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: keys.list });
+			qc.invalidateQueries({ queryKey: keys.pool });
+			qc.invalidateQueries({ queryKey: keys.health });
+			toast.success("Channel removed");
+		},
+		onError: toastApiError("Couldn't remove channel"),
+	});
+}
+
+export function useLinkAgent(accountId: string) {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (agentId: string) =>
+			unwrap(
+				await api.POST("/api/channels/{account_id}/agent-links", {
+					params: { path: { account_id: accountId } },
+					body: { agent_id: agentId },
+				}),
+			),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: keys.agentLinks(accountId) });
+			qc.invalidateQueries({ queryKey: ["agent-channel-links"] });
+			qc.invalidateQueries({ queryKey: keys.pool });
+		},
+		onError: toastApiError("Couldn't link agent"),
+	});
+}
+
+export function useRotateAgentToken(accountId: string) {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (linkId: string) =>
+			unwrap(
+				await api.POST("/api/channels/{account_id}/agent-links/{link_id}/token", {
+					params: { path: { account_id: accountId, link_id: linkId } },
+				}),
+			),
+		onSuccess: (data) => {
+			qc.invalidateQueries({ queryKey: keys.agentLinks(accountId) });
+			qc.invalidateQueries({ queryKey: ["agent-channel-links"] });
+			// Always confirm — the new token is also revealed inline when present,
+			// but the rotation must never be a silent no-op even without a token.
+			toast.success("Token rotated", {
+				description: data.agent_token
+					? "Copy the new token below — the previous one is now invalid."
+					: "The previous token is now invalid.",
+			});
+		},
+		onError: toastApiError("Couldn't rotate token"),
+	});
+}
+
+export function useCreatePairCode(accountId: string) {
+	const api = useApi();
+	return useMutation({
+		mutationFn: async (vars: { agent_id?: string; agent_link_id?: string; ttl_seconds?: number }) =>
+			unwrap(
+				await api.POST("/api/channels/{account_id}/pair-codes", {
+					params: { path: { account_id: accountId } },
+					body: { ttl_seconds: vars.ttl_seconds ?? 900, ...vars },
+				}),
+			),
+		onError: toastApiError("Couldn't create pairing code"),
+	});
+}
+
+/** An agent's linked channels (+account summary) — fixes the per-channel N+1. */
+export function useAgentChannelLinks(agentId: string, enabled = true) {
+	const editApi = useChannelEditApi();
+	return useQuery({
+		queryKey: ["agent-channel-links", agentId],
+		queryFn: () => editApi.listAgentLinks(agentId),
+		enabled: enabled && Boolean(agentId),
+	});
+}
+
+export function useUnlinkAgentChannel(agentId: string) {
+	const editApi = useChannelEditApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: (vars: { accountId: string; linkId: string }) =>
+			editApi.unlinkAgent(vars.accountId, vars.linkId),
+		onSuccess: (_data, vars) => {
+			qc.invalidateQueries({ queryKey: ["agent-channel-links", agentId] });
+			qc.invalidateQueries({ queryKey: keys.agentLinks(vars.accountId) });
+			qc.invalidateQueries({ queryKey: keys.list });
+			qc.invalidateQueries({ queryKey: keys.pool });
+			toast.success("Channel unlinked");
+		},
+		onError: toastApiError("Couldn't unlink channel"),
+	});
+}
+
+/** Unlink keyed by channel account (for the channel-detail Agents tab). */
+export function useUnlinkChannelAgent(accountId: string) {
+	const editApi = useChannelEditApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: (linkId: string) => editApi.unlinkAgent(accountId, linkId),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: keys.agentLinks(accountId) });
+			qc.invalidateQueries({ queryKey: ["agent-channel-links"] });
+			qc.invalidateQueries({ queryKey: keys.list });
+			qc.invalidateQueries({ queryKey: keys.pool });
+			toast.success("Agent unlinked");
+		},
+		onError: toastApiError("Couldn't unlink agent"),
+	});
+}
+
+export function useSyncCommands(accountId: string) {
+	const api = useApi();
+	return useMutation({
+		mutationFn: async () =>
+			unwrap(
+				await api.POST("/api/channels/{account_id}/commands/sync", {
+					params: { path: { account_id: accountId } },
+					body: {},
+				}),
+			),
+		onError: toastApiError("Couldn't sync commands"),
+	});
+}
+
+// ── WhatsApp device linking (Baileys tenant credentials) ─────────────────────
+// WhatsApp connects with NO token; a device is linked by minting a per-agent
+// tenant credential (the Baileys auth material). The live QR/pairing handshake
+// runs in the agent runtime over the credential's websocket_url.
+
+export function useWhatsappTenantCreds(accountId: string, enabled = true) {
+	const api = useApi();
+	return useQuery({
+		queryKey: keys.whatsappCreds(accountId),
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/api/channels/whatsapp/{account_id}/tenant-creds", {
+					params: { path: { account_id: accountId } },
+				}),
+			),
+		enabled,
+	});
+}
+
+export function useCreateWhatsappTenantCred(accountId: string) {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (vars: { agent_id?: string; agent_link_id?: string }) =>
+			unwrap(
+				await api.POST("/api/channels/whatsapp/{account_id}/tenant-creds", {
+					params: { path: { account_id: accountId } },
+					// `device` defaults to 1 server-side but the generated client types
+					// it required — send the primary device.
+					body: { device: 1, ...vars },
+				}),
+			),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: keys.whatsappCreds(accountId) });
+			toast.success("Device credential minted", {
+				description: "Finish pairing from the agent runtime to link the number.",
+			});
+		},
+		onError: toastApiError("Couldn't link WhatsApp device"),
+	});
+}
+
+export function useRevokeWhatsappTenantCred(accountId: string) {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (credentialId: string) =>
+			unwrap(
+				await api.DELETE("/api/channels/whatsapp/{account_id}/tenant-creds/{credential_id}", {
+					params: { path: { account_id: accountId, credential_id: credentialId } },
+				}),
+			),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: keys.whatsappCreds(accountId) });
+			toast.success("WhatsApp device unlinked");
+		},
+		onError: toastApiError("Couldn't unlink device"),
+	});
+}

--- a/apps/web/src/hosted/channels/channels-page.tsx
+++ b/apps/web/src/hosted/channels/channels-page.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { MessagesSquare, Plus } from "lucide-react";
+import { useState } from "react";
+import { EmptyState } from "@/components/empty-state";
+import { EntityRow } from "@/components/entity-card";
+import { EntityIcon } from "@/components/entity-icon";
+import { PageHeader } from "@/components/page-header";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+	CHANNEL_PROVIDERS,
+	type ChannelProviderId,
+	providerMeta,
+} from "@/hosted/channels/channel-providers";
+import type { ChannelAccount } from "@/hosted/channels/channel-types";
+import { ChannelError, HealthBadge } from "@/hosted/channels/channel-ui";
+import { useChannelHealth, useChannels } from "@/hosted/channels/channels-hooks";
+import { ConnectBotDialog } from "@/hosted/channels/connect-bot-dialog";
+import { SharedBotsPool } from "@/hosted/channels/shared-bots-pool";
+import { cn } from "@/lib/utils";
+
+const DESCRIPTION = "Connect Telegram, Discord, WhatsApp, and iMessage to your agents.";
+
+export function ChannelsPage() {
+	const [connectOpen, setConnectOpen] = useState(false);
+
+	return (
+		<div data-hosted="true" className="space-y-6 px-4 lg:px-6">
+			<PageHeader
+				title="Channels"
+				description={DESCRIPTION}
+				actions={
+					<Button onClick={() => setConnectOpen(true)}>
+						<Plus />
+						Connect a bot
+					</Button>
+				}
+			/>
+
+			<Tabs defaultValue="mine">
+				<TabsList>
+					<TabsTrigger value="mine">Your channels</TabsTrigger>
+					<TabsTrigger value="shared">Shared bots</TabsTrigger>
+				</TabsList>
+				<TabsContent value="mine" className="mt-4">
+					<YourChannels onConnect={() => setConnectOpen(true)} />
+				</TabsContent>
+				<TabsContent value="shared" className="mt-4">
+					<SharedBotsPool />
+				</TabsContent>
+			</Tabs>
+
+			<ConnectBotDialog open={connectOpen} onOpenChange={setConnectOpen} />
+		</div>
+	);
+}
+
+function YourChannels({ onConnect }: { onConnect: () => void }) {
+	const channels = useChannels();
+	const health = useChannelHealth();
+	const [filter, setFilter] = useState<ChannelProviderId | "all">("all");
+
+	if (channels.isLoading) {
+		return (
+			<div className="space-y-2">
+				{[0, 1, 2].map((i) => (
+					<Skeleton key={i} className="h-16 w-full rounded-lg" />
+				))}
+			</div>
+		);
+	}
+
+	if (channels.error) {
+		return (
+			<ChannelError
+				error={channels.error}
+				onRetry={() => channels.refetch()}
+				title="Couldn't load channels"
+			/>
+		);
+	}
+
+	const all = channels.data ?? [];
+	if (all.length === 0) {
+		return (
+			<EmptyState
+				icon={MessagesSquare}
+				title="No channels yet"
+				description="Connect a bot, or link a shared bot to an agent from the Shared bots tab."
+				action={
+					<Button onClick={onConnect}>
+						<Plus />
+						Connect a bot
+					</Button>
+				}
+			/>
+		);
+	}
+
+	const healthByAccount = new Map(
+		(health.data?.items ?? []).map((h) => [h.account_id, h.health_status]),
+	);
+	const counts = new Map<string, number>();
+	for (const c of all) counts.set(c.provider, (counts.get(c.provider) ?? 0) + 1);
+
+	const visible = filter === "all" ? all : all.filter((c) => c.provider === filter);
+	const groups = CHANNEL_PROVIDERS.map((p) => ({
+		provider: p,
+		items: visible.filter((c) => c.provider === p),
+	})).filter((g) => g.items.length > 0);
+
+	return (
+		<div className="space-y-4">
+			{health.error ? (
+				<ChannelError
+					error={health.error}
+					onRetry={() => health.refetch()}
+					title="Couldn't load channel health"
+				/>
+			) : null}
+			{/* Provider filter */}
+			<div className="flex flex-wrap gap-1.5">
+				<FilterChip active={filter === "all"} onClick={() => setFilter("all")}>
+					All
+					<span className="ml-1 text-muted-foreground">{all.length}</span>
+				</FilterChip>
+				{CHANNEL_PROVIDERS.filter((p) => counts.has(p)).map((p) => (
+					<FilterChip key={p} active={filter === p} onClick={() => setFilter(p)}>
+						{providerMeta(p).label}
+						<span className="ml-1 text-muted-foreground">{counts.get(p)}</span>
+					</FilterChip>
+				))}
+			</div>
+
+			<div className="space-y-5">
+				{groups.map((group) => (
+					<div key={group.provider} className="space-y-2">
+						{filter === "all" ? (
+							<div className="px-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+								{providerMeta(group.provider).label}
+							</div>
+						) : null}
+						<div className="space-y-2">
+							{group.items.map((channel) => (
+								<ChannelRow
+									key={channel.id}
+									channel={channel}
+									health={healthByAccount.get(channel.id)}
+								/>
+							))}
+						</div>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
+
+function FilterChip({
+	active,
+	onClick,
+	children,
+}: {
+	active: boolean;
+	onClick: () => void;
+	children: React.ReactNode;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			aria-pressed={active}
+			className={cn(
+				"rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+				active
+					? "border-primary bg-primary/10 text-primary"
+					: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+			)}
+		>
+			{children}
+		</button>
+	);
+}
+
+function ChannelRow({ channel, health }: { channel: ChannelAccount; health?: string }) {
+	const meta = providerMeta(channel.provider);
+	return (
+		<EntityRow
+			href={`/channels/${channel.id}`}
+			icon={<EntityIcon kind="channel" id={channel.provider} label={meta.label} />}
+			title={channel.name}
+			meta={[
+				meta.label,
+				<span key="status" className="capitalize">
+					{channel.status}
+				</span>,
+			]}
+			status={health ? <HealthBadge status={health} /> : undefined}
+		/>
+	);
+}

--- a/apps/web/src/hosted/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/channels/connect-bot-dialog.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { EntityChoiceCard } from "@/components/entity-card";
+import { EntityIcon } from "@/components/entity-icon";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	CHANNEL_PROVIDERS,
+	type ChannelProviderId,
+	IMESSAGE_AUTH_MODES,
+	PROVIDER_META,
+	providerMeta,
+} from "@/hosted/channels/channel-providers";
+import type { ChannelCreate, ChannelCreated } from "@/hosted/channels/channel-types";
+import { ProviderChip, TokenReveal } from "@/hosted/channels/channel-ui";
+import { useCreateChannel } from "@/hosted/channels/channels-hooks";
+
+/**
+ * Connect a channel. Each provider takes its OWN real inputs (grounded in
+ * cloud-api): Telegram = bot token; Discord = bot token + application_id +
+ * public_key (+ guild_id); iMessage = BlueBubbles server_url + password
+ * (+ auth_mode); WhatsApp = no token (device is linked afterwards via the
+ * Baileys tenant-creds flow on the channel page). On success the webhook
+ * secret is revealed once.
+ */
+export function ConnectBotDialog({
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const create = useCreateChannel();
+	const [provider, setProvider] = useState<ChannelProviderId>("telegram");
+	const [name, setName] = useState("");
+	const [token, setToken] = useState(""); // bot token / BlueBubbles password
+	// Discord
+	const [applicationId, setApplicationId] = useState("");
+	const [publicKey, setPublicKey] = useState("");
+	const [guildId, setGuildId] = useState("");
+	// iMessage
+	const [serverUrl, setServerUrl] = useState("");
+	const [authMode, setAuthMode] = useState<string>("password_query");
+	const [created, setCreated] = useState<ChannelCreated | null>(null);
+
+	useEffect(() => {
+		if (!open) {
+			setProvider("telegram");
+			setName("");
+			setToken("");
+			setApplicationId("");
+			setPublicKey("");
+			setGuildId("");
+			setServerUrl("");
+			setAuthMode("password_query");
+			setCreated(null);
+		}
+	}, [open]);
+
+	const meta = providerMeta(provider);
+
+	function changeProvider(next: ChannelProviderId) {
+		setProvider(next);
+		setToken("");
+		setApplicationId("");
+		setPublicKey("");
+		setGuildId("");
+		setServerUrl("");
+		setAuthMode("password_query");
+	}
+
+	const canSubmit =
+		name.trim().length > 0 &&
+		(meta.connect === "whatsapp"
+			? true
+			: meta.connect === "token"
+				? token.trim().length > 0
+				: meta.connect === "discord"
+					? token.trim().length > 0 && applicationId.trim().length > 0
+					: meta.connect === "imessage"
+						? token.trim().length > 0 && serverUrl.trim().length > 0
+						: false);
+
+	function buildBody(): ChannelCreate {
+		const trimmedName = name.trim();
+		if (meta.connect === "discord") {
+			const config: Record<string, unknown> = { application_id: applicationId.trim() };
+			if (publicKey.trim()) config.public_key = publicKey.trim();
+			if (guildId.trim()) config.guild_id = guildId.trim();
+			return { provider, name: trimmedName, provider_token: token.trim(), config };
+		}
+		if (meta.connect === "imessage") {
+			return {
+				provider,
+				name: trimmedName,
+				provider_token: token.trim(),
+				config: { server_url: serverUrl.trim(), auth_mode: authMode },
+			};
+		}
+		if (meta.connect === "token") {
+			return { provider, name: trimmedName, provider_token: token.trim() };
+		}
+		// whatsapp — no token; the device is linked afterwards (tenant-creds)
+		return { provider, name: trimmedName };
+	}
+
+	function submit() {
+		if (!canSubmit) return;
+		create.mutate(buildBody(), { onSuccess: (data) => setCreated(data) });
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent data-hosted="true" className="sm:max-w-md">
+				{created ? (
+					<>
+						<DialogHeader>
+							<DialogTitle>Channel connected</DialogTitle>
+							<DialogDescription>
+								<span className="font-medium">{created.name}</span> is ready. Keep the webhook
+								secret safe — it signs incoming updates.
+							</DialogDescription>
+						</DialogHeader>
+						<TokenReveal
+							label="Webhook secret"
+							value={created.webhook_secret}
+							note="Shown once. Configure this as the secret token on your bot's webhook."
+						/>
+						{created.agent_token ? (
+							<TokenReveal
+								label="Agent token"
+								value={created.agent_token}
+								note="An agent was auto-linked. This token lets it send and receive on the channel."
+							/>
+						) : null}
+						{provider === "whatsapp" ? (
+							<p className="text-sm text-muted-foreground">
+								Next: open the channel and link your WhatsApp number under{" "}
+								<span className="font-medium">Linked devices</span>.
+							</p>
+						) : null}
+						<DialogFooter>
+							<Button variant="outline" onClick={() => onOpenChange(false)}>
+								Close
+							</Button>
+							<Button asChild>
+								<Link href={`/channels/${created.id}`}>Open channel</Link>
+							</Button>
+						</DialogFooter>
+					</>
+				) : (
+					<>
+						<DialogHeader>
+							<DialogTitle>Connect a channel</DialogTitle>
+							<DialogDescription>
+								Each provider needs its own setup — pick one to see what it requires.
+							</DialogDescription>
+						</DialogHeader>
+
+						<div className="space-y-4">
+							<div className="space-y-1.5">
+								<Label>Provider</Label>
+								<div className="grid grid-cols-2 gap-2">
+									{CHANNEL_PROVIDERS.map((p) => (
+										<EntityChoiceCard
+											key={p}
+											selected={provider === p}
+											onClick={() => changeProvider(p)}
+											icon={<EntityIcon kind="channel" id={p} label={PROVIDER_META[p].label} />}
+											title={PROVIDER_META[p].label}
+										/>
+									))}
+								</div>
+							</div>
+
+							<div className="flex items-start gap-3 rounded-lg border bg-muted/30 p-3">
+								<ProviderChip provider={provider} />
+								<p className="text-xs text-muted-foreground">{meta.hint}</p>
+							</div>
+
+							<div className="space-y-1.5">
+								<Label htmlFor="connect-name">Name</Label>
+								<Input
+									id="connect-name"
+									value={name}
+									onChange={(e) => setName(e.target.value)}
+									placeholder="Support Bot"
+									autoComplete="off"
+								/>
+							</div>
+
+							{/* Telegram / Discord bot token, or iMessage BlueBubbles password. */}
+							{meta.connect !== "whatsapp" ? (
+								<div className="space-y-1.5">
+									<Label htmlFor="connect-token">{meta.tokenLabel}</Label>
+									<Input
+										id="connect-token"
+										type="password"
+										value={token}
+										onChange={(e) => setToken(e.target.value)}
+										placeholder={meta.tokenPlaceholder}
+										autoComplete="off"
+										spellCheck={false}
+									/>
+								</div>
+							) : null}
+
+							{/* Discord: application_id (+ public_key, guild_id). */}
+							{meta.connect === "discord" ? (
+								<>
+									<div className="space-y-1.5">
+										<Label htmlFor="connect-app-id">Application ID</Label>
+										<Input
+											id="connect-app-id"
+											value={applicationId}
+											onChange={(e) => setApplicationId(e.target.value)}
+											placeholder="Application (client) ID"
+											autoComplete="off"
+											spellCheck={false}
+										/>
+										<p className="text-xs text-muted-foreground">
+											Required to publish slash commands.
+										</p>
+									</div>
+									<div className="space-y-1.5">
+										<Label htmlFor="connect-public-key">
+											Public key <span className="text-muted-foreground">· recommended</span>
+										</Label>
+										<Input
+											id="connect-public-key"
+											value={publicKey}
+											onChange={(e) => setPublicKey(e.target.value)}
+											placeholder="Ed25519 public key (hex)"
+											autoComplete="off"
+											spellCheck={false}
+										/>
+										<p className="text-xs text-muted-foreground">
+											Verifies incoming interaction signatures.
+										</p>
+									</div>
+									<div className="space-y-1.5">
+										<Label htmlFor="connect-guild-id">
+											Guild ID <span className="text-muted-foreground">· optional</span>
+										</Label>
+										<Input
+											id="connect-guild-id"
+											value={guildId}
+											onChange={(e) => setGuildId(e.target.value)}
+											placeholder="Default command scope"
+											autoComplete="off"
+											spellCheck={false}
+										/>
+									</div>
+								</>
+							) : null}
+
+							{/* iMessage: BlueBubbles server URL + auth mode. */}
+							{meta.connect === "imessage" ? (
+								<>
+									<div className="space-y-1.5">
+										<Label htmlFor="connect-server-url">BlueBubbles server URL</Label>
+										<Input
+											id="connect-server-url"
+											value={serverUrl}
+											onChange={(e) => setServerUrl(e.target.value)}
+											placeholder="https://your-bluebubbles.example.com"
+											autoComplete="off"
+											spellCheck={false}
+										/>
+									</div>
+									<div className="space-y-1.5">
+										<Label htmlFor="connect-auth-mode">Auth mode</Label>
+										<Select value={authMode} onValueChange={setAuthMode}>
+											<SelectTrigger id="connect-auth-mode">
+												<SelectValue />
+											</SelectTrigger>
+											<SelectContent>
+												{IMESSAGE_AUTH_MODES.map((m) => (
+													<SelectItem key={m.value} value={m.value}>
+														{m.label}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+									</div>
+								</>
+							) : null}
+						</div>
+
+						<DialogFooter>
+							<Button variant="outline" onClick={() => onOpenChange(false)}>
+								Cancel
+							</Button>
+							<Button onClick={submit} disabled={!canSubmit || create.isPending}>
+								{create.isPending ? "Connecting…" : "Connect"}
+							</Button>
+						</DialogFooter>
+					</>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/hosted/channels/link-agent-dialog.tsx
+++ b/apps/web/src/hosted/channels/link-agent-dialog.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { CircleCheck } from "lucide-react";
+import { useEffect, useState } from "react";
+import { agentTypeLabel } from "@/components/dashboard/agent-label";
+import { EmptyState } from "@/components/empty-state";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ChannelError, TokenReveal } from "@/hosted/channels/channel-ui";
+import { useEnvironments, useLinkAgent } from "@/hosted/channels/channels-hooks";
+
+/**
+ * Link a connected agent to a channel — instant, no token paste. On success
+ * the scoped agent token is revealed once (the handle the agent runtime uses
+ * to send/receive on this channel).
+ */
+export function LinkAgentDialog({
+	open,
+	onOpenChange,
+	accountId,
+	accountName,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	accountId: string;
+	accountName: string;
+}) {
+	const envs = useEnvironments();
+	const link = useLinkAgent(accountId);
+	// Empty string is the "no selection" sentinel: keeps the Select controlled
+	// (never flips undefined↔string, which warns), and reads as falsy so submit
+	// stays gated. Radix renders the placeholder for value="".
+	const [agentId, setAgentId] = useState("");
+	const [token, setToken] = useState<string | null>(null);
+	const [linkedNoToken, setLinkedNoToken] = useState(false);
+
+	useEffect(() => {
+		if (!open) {
+			setAgentId("");
+			setToken(null);
+			setLinkedNoToken(false);
+		}
+	}, [open]);
+
+	function submit() {
+		if (!agentId) return;
+		link.mutate(agentId, {
+			onSuccess: (data) => {
+				if (data.agent_token) setToken(data.agent_token);
+				else setLinkedNoToken(true);
+			},
+		});
+	}
+
+	const agents = envs.data ?? [];
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent data-hosted="true" className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>Link an agent</DialogTitle>
+					<DialogDescription>
+						Connect one of your agents to <span className="font-medium">{accountName}</span>.
+					</DialogDescription>
+				</DialogHeader>
+
+				{token ? (
+					<TokenReveal
+						label="Agent token"
+						value={token}
+						note="Copy it now — it won't be shown again. The agent runtime uses this to send and receive on this channel."
+					/>
+				) : linkedNoToken ? (
+					<div className="flex items-center gap-2 rounded-lg border border-success/30 bg-success-muted p-3 text-sm text-success-muted-foreground">
+						<CircleCheck className="size-4 shrink-0" />
+						This agent is already linked to the channel.
+					</div>
+				) : envs.isLoading ? (
+					<Skeleton className="h-10 w-full rounded-md" />
+				) : envs.error ? (
+					<ChannelError
+						error={envs.error}
+						onRetry={() => envs.refetch()}
+						title="Couldn't load agents"
+					/>
+				) : agents.length === 0 ? (
+					<EmptyState
+						title="No agents yet"
+						description="Connect an agent first, then link it to this channel."
+						fillHeight={false}
+					/>
+				) : (
+					<div className="space-y-2">
+						<Select value={agentId} onValueChange={setAgentId}>
+							<SelectTrigger>
+								<SelectValue placeholder="Choose an agent" />
+							</SelectTrigger>
+							<SelectContent>
+								{agents.map((env) => (
+									<SelectItem key={env.id} value={env.id}>
+										{env.machine_name} · {agentTypeLabel(env.agent_type)}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				)}
+
+				<DialogFooter>
+					{token || linkedNoToken ? (
+						<Button onClick={() => onOpenChange(false)}>Done</Button>
+					) : (
+						<>
+							<Button variant="outline" onClick={() => onOpenChange(false)}>
+								Cancel
+							</Button>
+							<Button onClick={submit} disabled={!agentId || link.isPending}>
+								{link.isPending ? "Linking…" : "Link agent"}
+							</Button>
+						</>
+					)}
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/hosted/channels/shared-bots-pool.tsx
+++ b/apps/web/src/hosted/channels/shared-bots-pool.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { ArrowUpRight, Link2, Users } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import { EmptyState } from "@/components/empty-state";
+import { ENTITY_CARD_BASE, EntityHeader } from "@/components/entity-card";
+import { EntityIcon } from "@/components/entity-icon";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { CHANNEL_PROVIDERS, providerMeta } from "@/hosted/channels/channel-providers";
+import type { ChannelBotPoolItem } from "@/hosted/channels/channel-types";
+import { AccessBadge, ChannelError } from "@/hosted/channels/channel-ui";
+import { useBotPool } from "@/hosted/channels/channels-hooks";
+import { LinkAgentDialog } from "@/hosted/channels/link-agent-dialog";
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared bot pool — public bots the user can link an agent to instantly (no
+ * token), plus their own bots. Grouped by provider; at-capacity bots are
+ * shown but disabled.
+ */
+export function SharedBotsPool() {
+	const pool = useBotPool();
+	const [linkTarget, setLinkTarget] = useState<{ id: string; name: string } | null>(null);
+
+	if (pool.isLoading) {
+		return (
+			<div data-hosted="true" className="space-y-3">
+				{[0, 1, 2].map((i) => (
+					<Skeleton key={i} className="h-20 w-full rounded-lg" />
+				))}
+			</div>
+		);
+	}
+
+	if (pool.error) {
+		return (
+			<div data-hosted="true">
+				<ChannelError
+					error={pool.error}
+					onRetry={() => pool.refetch()}
+					title="Couldn't load shared bots"
+				/>
+			</div>
+		);
+	}
+
+	const providers = pool.data?.providers ?? {};
+	const sections = CHANNEL_PROVIDERS.map((p) => ({
+		provider: p,
+		items: providers[p] ?? [],
+	})).filter((s) => s.items.length > 0);
+
+	if (sections.length === 0) {
+		return (
+			<div data-hosted="true">
+				<EmptyState
+					icon={Users}
+					title="No shared bots available"
+					description="Shared bots you can link to instantly will appear here."
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<div data-hosted="true" className="space-y-6">
+			{sections.map((section) => {
+				const meta = providerMeta(section.provider);
+				return (
+					<div key={section.provider} className="space-y-2">
+						<div className="flex items-center gap-2 px-0.5">
+							<span className="text-sm font-medium">{meta.label}</span>
+							<span className="text-xs text-muted-foreground">{section.items.length}</span>
+						</div>
+						<div className="grid gap-2 sm:grid-cols-2">
+							{section.items.map((item) => (
+								<PoolCard
+									key={item.id}
+									item={item}
+									onLink={() => setLinkTarget({ id: item.id, name: item.name })}
+								/>
+							))}
+						</div>
+					</div>
+				);
+			})}
+
+			{linkTarget ? (
+				<LinkAgentDialog
+					open={Boolean(linkTarget)}
+					onOpenChange={(o) => !o && setLinkTarget(null)}
+					accountId={linkTarget.id}
+					accountName={linkTarget.name}
+				/>
+			) : null}
+		</div>
+	);
+}
+
+function PoolCard({ item, onLink }: { item: ChannelBotPoolItem; onLink: () => void }) {
+	const owner = item.access === "owner";
+	const capacity =
+		item.max_links == null
+			? `${item.link_count} linked · unlimited`
+			: `${item.link_count} of ${item.max_links} linked`;
+
+	const meta = providerMeta(item.provider);
+	const linkable = item.available && item.capabilities.link_agent;
+
+	return (
+		<div className={cn(ENTITY_CARD_BASE, "flex flex-col gap-3 bg-card")}>
+			<EntityHeader
+				align="start"
+				icon={<EntityIcon kind="channel" id={item.provider} label={meta.label} />}
+				title={item.name}
+				titleAdornment={<AccessBadge access={item.access} />}
+				meta={
+					<span className="inline-flex items-center gap-1.5">
+						<Users className="size-3" />
+						{capacity}
+					</span>
+				}
+			/>
+
+			{owner ? (
+				<Button asChild variant="outline" size="sm" className="w-full">
+					<Link href={`/channels/${item.id}`}>
+						Manage
+						<ArrowUpRight className="size-3.5" />
+					</Link>
+				</Button>
+			) : linkable ? (
+				<Button size="sm" className="w-full" onClick={onLink}>
+					<Link2 className="size-3.5" />
+					Link to an agent
+				</Button>
+			) : (
+				<Button size="sm" variant="outline" className="w-full" disabled>
+					{/* `available` false = genuinely full; otherwise the bot just
+					    isn't linkable (capability-gated) — don't mislabel as capacity. */}
+					{item.available ? "Not linkable" : "At capacity"}
+				</Button>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/hosted/use-copy-to-clipboard.ts
+++ b/apps/web/src/hosted/use-copy-to-clipboard.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+
+interface CopyToastCopy {
+	/** Success toast title. Defaults to "Copied to clipboard". */
+	success?: string;
+	/** Failure toast title (clipboard blocked / insecure context). */
+	error?: string;
+}
+
+/**
+ * Shared copy-to-clipboard affordance: writes to the clipboard, flips a
+ * `copied` flag true for ~1.5s, and toasts. Each surface passes its own toast
+ * copy so wording stays put; only the clipboard write, the reset, and the
+ * success/failure split are shared. Used by the billing `CopyButton` and the
+ * channels token/inline copy controls.
+ */
+export function useCopyToClipboard(toasts: CopyToastCopy = {}) {
+	const [copied, setCopied] = useState(false);
+	async function copy(value: string) {
+		try {
+			await navigator.clipboard.writeText(value);
+			setCopied(true);
+			toast.success(toasts.success ?? "Copied to clipboard");
+			setTimeout(() => setCopied(false), 1500);
+		} catch {
+			toast.error(toasts.error ?? "Couldn’t copy — select and copy manually.");
+		}
+	}
+	return { copied, copy };
+}

--- a/apps/web/src/lib/api-errors.test.ts
+++ b/apps/web/src/lib/api-errors.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { formatApiError, parseApiDetail } from "./api-errors";
+import {
+	ApiError,
+	ApiNetworkError,
+	formatApiError,
+	isApiAuthError,
+	isApiNetworkError,
+	isApiServerError,
+	normalizeApiError,
+	parseApiDetail,
+} from "./api-errors";
 
 describe("API error details", () => {
 	test("parses nested FastAPI details", () => {
@@ -35,5 +44,76 @@ describe("API error details", () => {
 
 	test("keeps plain text API errors readable", () => {
 		expect(formatApiError("project not found")).toBe("project not found");
+	});
+});
+
+describe("cloud-api error classification", () => {
+	test("401 is an auth error, not server", () => {
+		const e = new ApiError(401, "token expired");
+		expect(isApiAuthError(e)).toBe(true);
+		expect(isApiServerError(e)).toBe(false);
+		expect(isApiNetworkError(e)).toBe(false);
+	});
+
+	test("5xx and 429 are server errors", () => {
+		for (const status of [500, 502, 503, 429]) {
+			expect(isApiServerError(new ApiError(status, "boom"))).toBe(true);
+		}
+	});
+
+	test("network errors classify as transport failures", () => {
+		for (const kind of ["timeout", "offline"] as const) {
+			const e = new ApiNetworkError(kind);
+			expect(isApiNetworkError(e)).toBe(true);
+			expect(isApiAuthError(e)).toBe(false);
+			expect(isApiServerError(e)).toBe(false);
+		}
+	});
+
+	test("non-api errors classify as nothing", () => {
+		const e = new Error("random");
+		expect(isApiAuthError(e)).toBe(false);
+		expect(isApiServerError(e)).toBe(false);
+		expect(isApiNetworkError(e)).toBe(false);
+	});
+});
+
+describe("normalizeApiError", () => {
+	test("timeout → try-again guidance", () => {
+		expect(normalizeApiError(new ApiNetworkError("timeout"))).toMatch(/taking longer than usual/i);
+	});
+
+	test("offline → connection guidance", () => {
+		expect(normalizeApiError(new ApiNetworkError("offline"))).toMatch(
+			/couldn't reach the service/i,
+		);
+	});
+
+	test("401 → session expired prompt", () => {
+		expect(normalizeApiError(new ApiError(401, "jwt expired"))).toMatch(/session has expired/i);
+	});
+
+	test("5xx → transient message, not the raw detail", () => {
+		const msg = normalizeApiError(new ApiError(503, "upstream connect error"));
+		expect(msg).toMatch(/having trouble/i);
+		expect(msg).not.toMatch(/upstream connect error/);
+	});
+
+	test("snake_case codes become readable, real sentences pass through", () => {
+		expect(normalizeApiError(new ApiError(400, "provider_not_found"))).toBe("Provider Not Found");
+		expect(normalizeApiError(new ApiError(409, "That name is already in use."))).toBe(
+			"That name is already in use.",
+		);
+	});
+
+	test("nested FastAPI detail is unwrapped to its message", () => {
+		const detail = JSON.stringify({
+			detail: { error: "already_member", message: "Already a member." },
+		});
+		expect(normalizeApiError(new ApiError(403, detail))).toBe("Already a member.");
+	});
+
+	test("unknown shapes get a safe fallback", () => {
+		expect(normalizeApiError(null)).toMatch(/something went wrong/i);
 	});
 });

--- a/apps/web/src/lib/api-errors.ts
+++ b/apps/web/src/lib/api-errors.ts
@@ -1,3 +1,44 @@
+import { toast } from "sonner";
+
+/**
+ * Cloud-api (`useApi` / openapi-fetch) error model + normalization.
+ *
+ * The cloud-api backend raises FastAPI `HTTPException`s whose body is
+ * `{ "detail": "<message-or-code>" }`. `ApiError` captures the status + parsed
+ * detail; `ApiNetworkError` covers transport failures (offline / our own
+ * client-side timeout abort). `normalizeApiError` turns either into a single,
+ * user-facing sentence — hiding raw 5xx/gateway internals and reading a 401 as
+ * "sign in again" — mirroring the hosted billing surfaces' error handling.
+ */
+
+export class ApiError extends Error {
+	constructor(
+		public status: number,
+		public detail: string,
+	) {
+		super(`API ${status}: ${detail}`);
+		this.name = "ApiError";
+	}
+}
+
+/**
+ * Transport-level failure: the request never produced an HTTP response (the
+ * network is down, DNS failed, the host is unreachable, or our client-side
+ * timeout aborted it). Distinct from `ApiError` (which always carries a real
+ * status) so the UI can offer a "check your connection / try again" path
+ * instead of a raw status message.
+ */
+export class ApiNetworkError extends Error {
+	constructor(
+		public readonly kind: "timeout" | "offline",
+		options?: { cause?: unknown },
+	) {
+		super(kind === "timeout" ? "API request timed out" : "API request failed");
+		this.name = "ApiNetworkError";
+		if (options?.cause !== undefined) this.cause = options.cause;
+	}
+}
+
 export function parseApiDetail(detail: string): unknown {
 	try {
 		const body = JSON.parse(detail) as { detail?: unknown };
@@ -15,4 +56,56 @@ export function formatApiError(detail: string): string {
 		if (typeof message === "string") return message;
 	}
 	return detail;
+}
+
+/** Auth expired / invalid token mid-session (401). Needs re-auth, not a retry. */
+export function isApiAuthError(error: unknown): boolean {
+	return error instanceof ApiError && error.status === 401;
+}
+
+/** Backend fault (5xx) or rate-limit (429) — transient; safe to retry. */
+export function isApiServerError(error: unknown): boolean {
+	return error instanceof ApiError && (error.status >= 500 || error.status === 429);
+}
+
+/** True when the request never reached the server (offline / DNS / timeout). */
+export function isApiNetworkError(error: unknown): boolean {
+	return error instanceof ApiNetworkError;
+}
+
+/**
+ * Turn a cloud-api error into a single user-facing sentence. Hides backend
+ * internals (raw 5xx/gateway bodies), reads a 401 as a re-auth prompt, and
+ * makes snake_case error codes readable while passing real sentences through.
+ */
+export function normalizeApiError(error: unknown): string {
+	if (error instanceof ApiNetworkError) {
+		return error.kind === "timeout"
+			? "This is taking longer than usual. Check your connection and try again."
+			: "We couldn't reach the service. Check your connection and try again.";
+	}
+	if (error instanceof ApiError) {
+		if (error.status === 401) {
+			return "Your session has expired. Please sign in again to continue.";
+		}
+		if (error.status >= 500 || error.status === 429) {
+			return "The service is having trouble right now. Please try again in a moment.";
+		}
+		const message = formatApiError(error.detail);
+		// Snake_case codes → readable text; pass through real sentences.
+		if (/^[a-z0-9_]+$/.test(message)) {
+			return message.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+		}
+		return message;
+	}
+	if (error instanceof Error) return error.message;
+	return "Something went wrong. Please try again.";
+}
+
+/**
+ * Mutation `onError` handler for cloud-api (`useApi`) hooks: toast `title` with
+ * the normalized, internal-free error copy as the description.
+ */
+export function toastApiError(title: string) {
+	return (error: unknown) => toast.error(title, { description: normalizeApiError(error) });
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -24,19 +24,34 @@ const REQUEST_TIMEOUT_MS = 20_000;
 
 /**
  * `fetch` wrapper that bounds every request with a timeout and maps transport
- * failures to a normalizable `ApiNetworkError`. A caller-supplied abort (none
- * today, but openapi-fetch may attach one) is preserved and re-thrown as-is so
- * an intentional cancel isn't mislabeled as a network failure.
+ * failures to a normalizable `ApiNetworkError`. A caller-supplied abort is
+ * preserved and re-thrown as-is so an intentional cancel isn't mislabeled as a
+ * network failure.
  */
 function fetchWithTimeout(request: Request, init?: RequestInit): Promise<Response> {
-	const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
 	const caller = init?.signal ?? request.signal;
-	const signal = caller ? AbortSignal.any([caller, timeout]) : timeout;
-	return fetch(request, { ...init, signal }).catch((cause: unknown) => {
-		if (timeout.aborted) throw new ApiNetworkError("timeout", { cause });
-		if (caller?.aborted) throw cause;
-		throw new ApiNetworkError("offline", { cause });
-	});
+	const controller = new AbortController();
+	let timedOut = false;
+	const onAbort = () => controller.abort();
+	if (caller?.aborted) {
+		controller.abort();
+	} else {
+		caller?.addEventListener("abort", onAbort, { once: true });
+	}
+	const timeoutId = setTimeout(() => {
+		timedOut = true;
+		controller.abort();
+	}, REQUEST_TIMEOUT_MS);
+	return fetch(request, { ...init, signal: controller.signal })
+		.catch((cause: unknown) => {
+			if (timedOut) throw new ApiNetworkError("timeout", { cause });
+			if (caller?.aborted) throw cause;
+			throw new ApiNetworkError("offline", { cause });
+		})
+		.finally(() => {
+			clearTimeout(timeoutId);
+			caller?.removeEventListener("abort", onAbort);
+		});
 }
 
 /**

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -3,19 +3,40 @@
 import { extractApiDetail, type paths } from "@clawdi/shared/api";
 import createClient from "openapi-fetch";
 import { useMemo } from "react";
+import { ApiError, ApiNetworkError } from "@/lib/api-errors";
 import { useAuthToken } from "@/lib/auth-client";
 import { env } from "@/lib/env";
 
+// `ApiError` and the cloud-api error-toast helper live in `api-errors` (a
+// dependency-free module so they're unit-testable); re-export so the many
+// existing `@/lib/api` import sites keep working.
+export { ApiError, toastApiError } from "@/lib/api-errors";
+
 const API_URL = env.NEXT_PUBLIC_API_URL;
 
-export class ApiError extends Error {
-	constructor(
-		public status: number,
-		public detail: string,
-	) {
-		super(`API ${status}: ${detail}`);
-		this.name = "ApiError";
-	}
+/**
+ * Client-side request ceiling. A hung backend or a black-holed connection must
+ * not leave a surface spinning forever — abort after this and surface a
+ * recoverable `ApiNetworkError("timeout")` instead. Matches the hosted billing
+ * client's 20s bound.
+ */
+const REQUEST_TIMEOUT_MS = 20_000;
+
+/**
+ * `fetch` wrapper that bounds every request with a timeout and maps transport
+ * failures to a normalizable `ApiNetworkError`. A caller-supplied abort (none
+ * today, but openapi-fetch may attach one) is preserved and re-thrown as-is so
+ * an intentional cancel isn't mislabeled as a network failure.
+ */
+function fetchWithTimeout(request: Request, init?: RequestInit): Promise<Response> {
+	const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+	const caller = init?.signal ?? request.signal;
+	const signal = caller ? AbortSignal.any([caller, timeout]) : timeout;
+	return fetch(request, { ...init, signal }).catch((cause: unknown) => {
+		if (timeout.aborted) throw new ApiNetworkError("timeout", { cause });
+		if (caller?.aborted) throw cause;
+		throw new ApiNetworkError("offline", { cause });
+	});
 }
 
 /**
@@ -28,7 +49,7 @@ export class ApiError extends Error {
 export function useApi() {
 	const { getToken } = useAuthToken();
 	return useMemo(() => {
-		const client = createClient<paths>({ baseUrl: API_URL });
+		const client = createClient<paths>({ baseUrl: API_URL, fetch: fetchWithTimeout });
 		client.use({
 			async onRequest({ request }) {
 				const token = await getToken();

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -5,6 +5,12 @@ import { env } from "@/lib/env";
 
 const DEV_AUTH_BEARER = env.NEXT_PUBLIC_DEV_AUTH_TOKEN;
 
+// Stable identity for the dev-bypass branch: returning a fresh object (and
+// fresh `getToken`) each render would churn every `useMemo`/`useQuery` that
+// depends on `getToken` (e.g. the channel-edit client), re-creating clients
+// and re-issuing in-flight requests. Keep one constant reference.
+const DEV_AUTH_TOKEN_RESULT = { getToken: async () => DEV_AUTH_BEARER };
+
 const DEV_USER = {
 	id: "dev_browser",
 	fullName: env.NEXT_PUBLIC_DEV_AUTH_NAME,
@@ -18,7 +24,7 @@ const DEV_USER = {
 
 export function useAuthToken() {
 	if (env.NEXT_PUBLIC_DEV_AUTH_BYPASS) {
-		return { getToken: async () => DEV_AUTH_BEARER };
+		return DEV_AUTH_TOKEN_RESULT;
 	}
 	const { getToken } = useAuth();
 	return { getToken };


### PR DESCRIPTION
## Summary
- add hosted-only AI Providers and Channels management routes behind `IS_HOSTED` dynamic imports
- add AI provider CRUD/OAuth UI, Codex OAuth callback, and runtime bootstrap mapper/test
- add channel management UI for private/shared bots, agent links, pair codes, bindings, activity, health, commands, and WhatsApp tenant credentials
- add shared entity-card/icon, route skeleton, `InfoCard`, copy-to-clipboard, async confirm action, stable dev auth token reference, and normalized API error handling used by these surfaces

## Launch posture
- dark launch only: no sidebar or command palette entries are added
- OSS build stays clean: hosted code is only reached through `IS_HOSTED`-gated dynamic imports
- hosted backend/runtime implementation stays outside this repo

## Verification
- `bun test apps/web/src/hosted/ai-providers/runtime-bootstrap.test.ts apps/web/src/lib/api-errors.test.ts apps/web/src/hosted/oss-clean.test.ts`
- `bun run typecheck`
- `bun run check`
- `git diff --check`