### PR TITLE
Add hosted channels dark launch UI

### DIFF
--- a/apps/web/src/app/(dashboard)/channels/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/channels/[id]/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { HostedRouteSkeleton } from "@/components/hosted-route-skeleton";
+import { IS_HOSTED } from "@/lib/hosted";
+
+const ChannelDetailPage = IS_HOSTED
+	? dynamic(
+			() =>
+				import("@/hosted/channels/channel-detail-page").then((m) => ({
+					default: m.ChannelDetailPage,
+				})),
+			{ loading: HostedRouteSkeleton },
+		)
+	: null;
+
+export default function Page() {
+	return ChannelDetailPage ? <ChannelDetailPage /> : null;
+}

--- a/apps/web/src/app/(dashboard)/channels/layout.tsx
+++ b/apps/web/src/app/(dashboard)/channels/layout.tsx
@@ -1,0 +1,10 @@
+import { pageMetadata } from "@/app/page-metadata";
+
+export const metadata = pageMetadata(
+	"Channels",
+	"Connect Telegram, Discord, WhatsApp, and iMessage to your agents.",
+);
+
+export default function ChannelsLayout({ children }: { children: React.ReactNode }) {
+	return children;
+}

--- a/apps/web/src/app/(dashboard)/channels/page.tsx
+++ b/apps/web/src/app/(dashboard)/channels/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { HostedRouteSkeleton } from "@/components/hosted-route-skeleton";
+import { IS_HOSTED } from "@/lib/hosted";
+
+// Hosted-only surface. The dynamic import is constructed only when
+// `IS_HOSTED` is true so OSS builds eliminate the chunk entirely.
+const ChannelsPage = IS_HOSTED
+	? dynamic(
+			() => import("@/hosted/channels/channels-page").then((m) => ({ default: m.ChannelsPage })),
+			{ loading: HostedRouteSkeleton },
+		)
+	: null;
+
+export default function Page() {
+	return ChannelsPage ? <ChannelsPage /> : null;
+}

--- a/apps/web/src/components/info-card.tsx
+++ b/apps/web/src/components/info-card.tsx
@@ -1,0 +1,32 @@
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+/**
+ * Informational banner — a tinted icon tile beside a title + description. The
+ * static "here's how this works" card shared across hosted surfaces (channel
+ * detail tabs, agent detail). `children` is the description body, so it may
+ * carry inline links or interpolated copy.
+ */
+export function InfoCard({
+	icon: Icon,
+	title,
+	children,
+}: {
+	icon: LucideIcon;
+	title: ReactNode;
+	children: ReactNode;
+}) {
+	return (
+		<div className="rounded-lg border bg-card p-4">
+			<div className="flex items-start gap-3">
+				<span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+					<Icon className="size-5" />
+				</span>
+				<div className="min-w-0 flex-1 space-y-1">
+					<div className="text-sm font-medium">{title}</div>
+					<p className="text-sm text-muted-foreground">{children}</p>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/hosted/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/channels/channel-detail-page.tsx
@@ -1,0 +1,817 @@
+"use client";
+
+import {
+	ArrowDownLeft,
+	ArrowUpRight,
+	KeyRound,
+	Link2,
+	Link2Off,
+	MessageSquareDashed,
+	QrCode,
+	RefreshCw,
+	Smartphone,
+	TerminalSquare,
+	Trash2,
+	TriangleAlert,
+} from "lucide-react";
+import { useParams, useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
+import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
+import { agentTypeLabel } from "@/components/dashboard/agent-label";
+import { EmptyState } from "@/components/empty-state";
+import { InfoCard } from "@/components/info-card";
+import { PageHeader } from "@/components/page-header";
+import { Button } from "@/components/ui/button";
+import { ConfirmAction } from "@/components/ui/confirm-action";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { providerMeta } from "@/hosted/channels/channel-providers";
+import type {
+	ChannelActivityItem,
+	ChannelAgentLink,
+	ChannelBinding,
+} from "@/hosted/channels/channel-types";
+import {
+	ChannelError,
+	CopyInline,
+	DeliveryBadge,
+	HealthBadge,
+	ProviderChip,
+	TokenReveal,
+} from "@/hosted/channels/channel-ui";
+import {
+	useChannel,
+	useChannelActivity,
+	useChannelAgentLinks,
+	useChannelBindings,
+	useChannelHealth,
+	useCreatePairCode,
+	useCreateWhatsappTenantCred,
+	useDeleteChannel,
+	useEnvironments,
+	useRevokeWhatsappTenantCred,
+	useRotateAgentToken,
+	useSyncCommands,
+	useUnlinkChannelAgent,
+	useWhatsappTenantCreds,
+} from "@/hosted/channels/channels-hooks";
+import { LinkAgentDialog } from "@/hosted/channels/link-agent-dialog";
+
+function formatWhen(iso: string | null | undefined): string {
+	if (!iso) return "—";
+	const delta = new Date(iso).getTime() - Date.now(); // positive = future
+	const future = delta > 0;
+	const phrase = (value: number, unit: string) =>
+		future ? `in ${value}${unit}` : `${value}${unit} ago`;
+	const min = Math.round(Math.abs(delta) / 60000);
+	if (min < 1) return "just now";
+	if (min < 60) return phrase(min, "m");
+	const hr = Math.round(min / 60);
+	if (hr < 24) return phrase(hr, "h");
+	return new Date(iso).toLocaleDateString();
+}
+
+type EnvironmentList = ReturnType<typeof useEnvironments>["data"];
+
+/** "machine · agent-type" label for an agent id, falling back to the raw id. */
+function envName(envs: EnvironmentList, agentId: string): string {
+	const env = envs?.find((e) => e.id === agentId);
+	return env ? `${env.machine_name} · ${agentTypeLabel(env.agent_type)}` : agentId;
+}
+
+export function ChannelDetailPage() {
+	const params = useParams<{ id: string }>();
+	const id = params.id;
+	const channel = useChannel(id);
+	const health = useChannelHealth();
+	const router = useRouter();
+	const del = useDeleteChannel();
+
+	useSetBreadcrumbTitle(channel.data?.name);
+
+	const healthItem = useMemo(
+		() => health.data?.items.find((h) => h.account_id === id),
+		[health.data, id],
+	);
+
+	if (channel.isLoading) {
+		return (
+			<div data-hosted="true" className="space-y-6 px-4 lg:px-6">
+				<Skeleton className="h-12 w-64" />
+				<Skeleton className="h-64 w-full rounded-lg" />
+			</div>
+		);
+	}
+
+	if (channel.error) {
+		return (
+			<div data-hosted="true" className="px-4 lg:px-6">
+				<ChannelError
+					error={channel.error}
+					onRetry={() => channel.refetch()}
+					title="Couldn't load channel"
+				/>
+			</div>
+		);
+	}
+
+	if (!channel.data) {
+		return (
+			<div data-hosted="true" className="px-4 lg:px-6">
+				<EmptyState
+					icon={MessageSquareDashed}
+					title="Channel not found"
+					description="This channel may have been removed."
+					action={
+						<Button variant="outline" onClick={() => router.push("/channels")}>
+							Back to Channels
+						</Button>
+					}
+				/>
+			</div>
+		);
+	}
+
+	const ch = channel.data;
+	const meta = providerMeta(ch.provider);
+
+	return (
+		<div data-hosted="true" className="space-y-6 px-4 lg:px-6">
+			<PageHeader
+				title={ch.name}
+				description={`${meta.label} · ${ch.visibility === "public" ? "Shared bot" : "Private bot"}`}
+				actions={
+					<ConfirmAction
+						title={`Remove ${ch.name}?`}
+						description={
+							<p>
+								Agents linked to this channel will stop sending and receiving. This can't be undone.
+							</p>
+						}
+						confirmLabel="Remove channel"
+						destructive
+						onConfirm={() => del.mutate(id, { onSuccess: () => router.push("/channels") })}
+					>
+						<Button variant="outline" className="text-muted-foreground hover:text-destructive">
+							<Trash2 className="size-4" />
+							Remove
+						</Button>
+					</ConfirmAction>
+				}
+			/>
+
+			<div className="flex items-center gap-3">
+				<ProviderChip provider={ch.provider} />
+				<div className="flex items-center gap-2 text-sm text-muted-foreground">
+					<span className="capitalize">{ch.status}</span>
+					{healthItem ? <HealthBadge status={healthItem.health_status} /> : null}
+				</div>
+			</div>
+
+			<Tabs defaultValue="agents">
+				<TabsList className="flex-wrap">
+					<TabsTrigger value="agents">Agents</TabsTrigger>
+					{ch.provider === "whatsapp" ? (
+						<TabsTrigger value="devices">Linked devices</TabsTrigger>
+					) : null}
+					<TabsTrigger value="pair">Pair code</TabsTrigger>
+					<TabsTrigger value="bindings">Chats</TabsTrigger>
+					<TabsTrigger value="activity">Activity</TabsTrigger>
+					<TabsTrigger value="health">Health</TabsTrigger>
+					<TabsTrigger value="commands">Commands</TabsTrigger>
+				</TabsList>
+
+				<TabsContent value="agents" className="mt-4">
+					<AgentsTab accountId={id} accountName={ch.name} />
+				</TabsContent>
+				{ch.provider === "whatsapp" ? (
+					<TabsContent value="devices" className="mt-4">
+						<WhatsAppDevicesTab accountId={id} />
+					</TabsContent>
+				) : null}
+				<TabsContent value="pair" className="mt-4">
+					<PairCodeTab accountId={id} provider={ch.provider} />
+				</TabsContent>
+				<TabsContent value="bindings" className="mt-4">
+					<BindingsTab accountId={id} />
+				</TabsContent>
+				<TabsContent value="activity" className="mt-4">
+					<ActivityTab accountId={id} />
+				</TabsContent>
+				<TabsContent value="health" className="mt-4">
+					<HealthTab accountId={id} />
+				</TabsContent>
+				<TabsContent value="commands" className="mt-4">
+					<CommandsTab accountId={id} provider={ch.provider} />
+				</TabsContent>
+			</Tabs>
+		</div>
+	);
+}
+
+// ── Agents ───────────────────────────────────────────────────────────────────
+
+function AgentsTab({ accountId, accountName }: { accountId: string; accountName: string }) {
+	const links = useChannelAgentLinks(accountId);
+	const envs = useEnvironments();
+	const rotate = useRotateAgentToken(accountId);
+	const unlink = useUnlinkChannelAgent(accountId);
+	const [linkOpen, setLinkOpen] = useState(false);
+	const [rotated, setRotated] = useState<Record<string, string>>({});
+
+	if (links.isLoading) return <Skeleton className="h-24 w-full rounded-lg" />;
+	if (links.error) {
+		return (
+			<ChannelError
+				error={links.error}
+				onRetry={() => links.refetch()}
+				title="Couldn't load linked agents"
+			/>
+		);
+	}
+	const items = links.data ?? [];
+
+	return (
+		<div className="space-y-3">
+			{envs.error ? (
+				<ChannelError
+					error={envs.error}
+					onRetry={() => envs.refetch()}
+					title="Couldn't load agent names"
+				/>
+			) : null}
+			<div className="flex justify-end">
+				<Button size="sm" onClick={() => setLinkOpen(true)}>
+					<Link2 className="size-3.5" />
+					Link an agent
+				</Button>
+			</div>
+
+			{items.length === 0 ? (
+				<EmptyState
+					icon={Link2}
+					title="No agents linked"
+					description="Link an agent so it can send and receive on this channel."
+					fillHeight={false}
+				/>
+			) : (
+				<div className="space-y-2">
+					{items.map((link: ChannelAgentLink) => (
+						<div key={link.id} className="rounded-lg border p-3">
+							<div className="flex items-center justify-between gap-3">
+								<div className="min-w-0">
+									<div className="truncate text-sm font-medium">
+										{envName(envs.data, link.agent_id)}
+									</div>
+									<div className="text-xs capitalize text-muted-foreground">
+										{link.status} · linked {formatWhen(link.created_at)}
+									</div>
+								</div>
+								<div className="flex shrink-0 items-center gap-1.5">
+									<Button
+										variant="outline"
+										size="sm"
+										// Per-row: only the acting row's button shows pending, not all.
+										disabled={rotate.isPending && rotate.variables === link.id}
+										onClick={() =>
+											rotate.mutate(link.id, {
+												onSuccess: (data) => {
+													const token = data.agent_token;
+													if (!token) return;
+													setRotated((prev) => ({
+														...prev,
+														[link.id]: token,
+													}));
+												},
+											})
+										}
+									>
+										{rotate.isPending && rotate.variables === link.id ? (
+											<Spinner className="size-3.5" />
+										) : (
+											<RefreshCw className="size-3.5" />
+										)}
+										Rotate token
+									</Button>
+									<ConfirmAction
+										title="Unlink this agent?"
+										description={<p>It stops sending and receiving on {accountName}.</p>}
+										confirmLabel="Unlink"
+										destructive
+										onConfirm={() => unlink.mutate(link.id)}
+									>
+										<Button
+											variant="ghost"
+											size="icon-sm"
+											className="text-muted-foreground hover:text-destructive"
+											disabled={unlink.isPending && unlink.variables === link.id}
+											aria-label="Unlink agent"
+										>
+											<Link2Off className="size-4" />
+										</Button>
+									</ConfirmAction>
+								</div>
+							</div>
+							{rotated[link.id] ? (
+								<div className="mt-3">
+									<TokenReveal
+										label="New agent token"
+										value={rotated[link.id]}
+										note="The previous token is now invalid. Update the agent with this value."
+									/>
+								</div>
+							) : null}
+						</div>
+					))}
+				</div>
+			)}
+
+			<LinkAgentDialog
+				open={linkOpen}
+				onOpenChange={setLinkOpen}
+				accountId={accountId}
+				accountName={accountName}
+			/>
+		</div>
+	);
+}
+
+// ── WhatsApp linked devices (Baileys tenant credentials) ─────────────────────
+
+function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
+	const links = useChannelAgentLinks(accountId);
+	const envs = useEnvironments();
+	const creds = useWhatsappTenantCreds(accountId);
+	const create = useCreateWhatsappTenantCred(accountId);
+	const revoke = useRevokeWhatsappTenantCred(accountId);
+	const [linkId, setLinkId] = useState("");
+
+	const linkItems = links.data ?? [];
+	const devices = creds.data ?? [];
+	// Default to the only link when there's exactly one.
+	const effectiveLink = linkId || (linkItems.length === 1 ? linkItems[0].id : "");
+
+	return (
+		<div className="max-w-xl space-y-4">
+			<InfoCard icon={Smartphone} title="Link a WhatsApp number">
+				WhatsApp uses no bot token. Mint a device credential for an agent, then finish the link by
+				scanning it in WhatsApp → Linked devices. The live in-dashboard QR is coming soon — for now
+				the credential is handed to the agent runtime to complete pairing.
+			</InfoCard>
+
+			{links.isLoading ? (
+				<Skeleton className="h-16 w-full rounded-lg" />
+			) : links.error ? (
+				<ChannelError
+					error={links.error}
+					onRetry={() => links.refetch()}
+					title="Couldn't load linked agents"
+				/>
+			) : linkItems.length === 0 ? (
+				<EmptyState
+					bordered
+					fillHeight={false}
+					title="Link an agent first"
+					description="A WhatsApp device is minted per agent. Link an agent on the Agents tab, then come back."
+				/>
+			) : (
+				<div className="space-y-2">
+					{envs.error ? (
+						<ChannelError
+							error={envs.error}
+							onRetry={() => envs.refetch()}
+							title="Couldn't load agent names"
+						/>
+					) : null}
+					{linkItems.length > 1 ? (
+						<div className="space-y-1.5">
+							<Label htmlFor="wa-agent">Agent</Label>
+							<Select value={effectiveLink} onValueChange={setLinkId}>
+								<SelectTrigger id="wa-agent">
+									<SelectValue placeholder="Choose an agent" />
+								</SelectTrigger>
+								<SelectContent>
+									{linkItems.map((l) => (
+										<SelectItem key={l.id} value={l.id}>
+											{envName(envs.data, l.agent_id)}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+					) : null}
+					<Button
+						onClick={() => effectiveLink && create.mutate({ agent_link_id: effectiveLink })}
+						disabled={!effectiveLink || create.isPending}
+					>
+						<Smartphone className="size-4" />
+						{create.isPending ? "Minting…" : "Link a device"}
+					</Button>
+				</div>
+			)}
+
+			<div className="space-y-2">
+				<div className="text-sm font-medium">Linked devices</div>
+				{creds.isLoading ? (
+					<Skeleton className="h-16 w-full rounded-lg" />
+				) : creds.error ? (
+					<ChannelError
+						error={creds.error}
+						onRetry={() => creds.refetch()}
+						title="Couldn't load linked devices"
+					/>
+				) : devices.length === 0 ? (
+					<div className="rounded-lg border border-dashed px-3 py-6 text-center text-sm text-muted-foreground">
+						No devices linked yet.
+					</div>
+				) : (
+					devices.map((d) => (
+						<div
+							key={d.credential_id}
+							className="flex items-center justify-between gap-3 rounded-lg border p-3"
+						>
+							<div className="min-w-0">
+								{d.jid ? (
+									<div className="truncate font-mono text-xs">{d.jid}</div>
+								) : (
+									<div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+										<Spinner className="size-3" />
+										Pending pairing
+									</div>
+								)}
+								<div className="text-xs text-muted-foreground">
+									{envName(envs.data, d.agent_id)} · added {formatWhen(d.created_at)}
+								</div>
+							</div>
+							<ConfirmAction
+								title="Unlink this device?"
+								description={<p>The WhatsApp credential is revoked. This can't be undone.</p>}
+								confirmLabel="Unlink"
+								destructive
+								onConfirm={() => revoke.mutate(d.credential_id)}
+							>
+								<Button
+									variant="ghost"
+									size="icon-sm"
+									className="text-muted-foreground hover:text-destructive"
+									disabled={revoke.isPending}
+									aria-label="Unlink device"
+								>
+									<Trash2 className="size-4" />
+								</Button>
+							</ConfirmAction>
+						</div>
+					))
+				)}
+			</div>
+		</div>
+	);
+}
+
+// ── Pair code ────────────────────────────────────────────────────────────────
+
+const TTL_OPTIONS = [
+	{ value: "900", label: "15 minutes" },
+	{ value: "3600", label: "1 hour" },
+	{ value: "86400", label: "24 hours" },
+];
+
+function PairCodeTab({ accountId, provider }: { accountId: string; provider: string }) {
+	const envs = useEnvironments();
+	const create = useCreatePairCode(accountId);
+	// "" = no agent chosen (use the channel's linked agent). Sentinel keeps the
+	// Select controlled; mapped back to undefined in the request below.
+	const [agentId, setAgentId] = useState("");
+	const [ttl, setTtl] = useState("900");
+	const [result, setResult] = useState<{ code: string; expires_at: string } | null>(null);
+	const meta = providerMeta(provider);
+
+	function generate() {
+		create.mutate(
+			{ agent_id: agentId || undefined, ttl_seconds: Number(ttl) },
+			{ onSuccess: (data) => setResult({ code: data.code, expires_at: data.expires_at }) },
+		);
+	}
+
+	return (
+		<div className="max-w-xl space-y-4">
+			<InfoCard icon={QrCode} title="Pair a chat">
+				Generate a one-time code, then send it from the {meta.label} chat you want to pair — the
+				agent links that conversation when it sees the code.
+			</InfoCard>
+
+			<div className="grid gap-3 sm:grid-cols-2">
+				<div className="space-y-1.5">
+					<Label htmlFor="pair-agent">Agent</Label>
+					{envs.isLoading ? (
+						<Skeleton className="h-10 w-full rounded-md" />
+					) : (
+						<Select value={agentId} onValueChange={setAgentId} disabled={!!envs.error}>
+							<SelectTrigger id="pair-agent">
+								<SelectValue placeholder="Use linked agent" />
+							</SelectTrigger>
+							<SelectContent>
+								{(envs.data ?? []).map((env) => (
+									<SelectItem key={env.id} value={env.id}>
+										{env.machine_name} · {agentTypeLabel(env.agent_type)}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					)}
+				</div>
+				<div className="space-y-1.5">
+					<Label htmlFor="pair-ttl">Expires in</Label>
+					<Select value={ttl} onValueChange={setTtl}>
+						<SelectTrigger id="pair-ttl">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{TTL_OPTIONS.map((o) => (
+								<SelectItem key={o.value} value={o.value}>
+									{o.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+			</div>
+
+			{envs.error ? (
+				<ChannelError
+					error={envs.error}
+					onRetry={() => envs.refetch()}
+					title="Couldn't load agents"
+				/>
+			) : null}
+
+			<Button onClick={generate} disabled={create.isPending}>
+				<QrCode className="size-4" />
+				{create.isPending ? "Generating…" : "Generate pairing code"}
+			</Button>
+
+			{result ? (
+				<div className="space-y-3 rounded-lg border border-primary/30 bg-primary/5 p-4">
+					<div className="text-xs font-medium text-primary">Pairing code</div>
+					<div className="font-mono text-3xl font-semibold tracking-[0.2em]">{result.code}</div>
+					<p className="text-sm text-muted-foreground">
+						Send <span className="font-mono font-medium">{result.code}</span> from the chat you want
+						to pair. Expires {formatWhen(result.expires_at)}.
+					</p>
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+// ── Bindings (paired chats) ──────────────────────────────────────────────────
+
+function BindingsTab({ accountId }: { accountId: string }) {
+	const bindings = useChannelBindings(accountId);
+	if (bindings.isLoading) return <Skeleton className="h-24 w-full rounded-lg" />;
+	if (bindings.error) {
+		return (
+			<ChannelError
+				error={bindings.error}
+				onRetry={() => bindings.refetch()}
+				title="Couldn't load paired chats"
+			/>
+		);
+	}
+	const items = bindings.data ?? [];
+
+	if (items.length === 0) {
+		return (
+			<EmptyState
+				icon={MessageSquareDashed}
+				title="No paired chats"
+				description="Generate a pairing code, then send it from a chat to link it here."
+			/>
+		);
+	}
+
+	return (
+		<div className="space-y-2">
+			{items.map((b: ChannelBinding) => (
+				<div key={b.id} className="flex items-center justify-between gap-3 rounded-lg border p-3">
+					<div className="min-w-0">
+						<div className="truncate text-sm font-medium">{b.external_chat_name ?? "Chat"}</div>
+						<div className="flex items-center gap-2 text-xs text-muted-foreground">
+							<span className="capitalize">{b.external_chat_type ?? "chat"}</span>
+							<span>·</span>
+							<CopyInline value={b.external_chat_id} />
+						</div>
+					</div>
+					<span className="text-xs capitalize text-muted-foreground">{b.status}</span>
+				</div>
+			))}
+		</div>
+	);
+}
+
+// ── Activity ─────────────────────────────────────────────────────────────────
+
+function ActivityTab({ accountId }: { accountId: string }) {
+	const activity = useChannelActivity(accountId);
+	if (activity.isLoading) return <Skeleton className="h-32 w-full rounded-lg" />;
+	if (activity.error) {
+		return (
+			<ChannelError
+				error={activity.error}
+				onRetry={() => activity.refetch()}
+				title="Couldn't load activity"
+			/>
+		);
+	}
+	const items = activity.data?.items ?? [];
+
+	if (items.length === 0) {
+		return (
+			<EmptyState
+				icon={MessageSquareDashed}
+				title="No activity yet"
+				description="Messages and delivery events will show up here."
+			/>
+		);
+	}
+
+	return (
+		<div className="space-y-2">
+			{items.map((item: ChannelActivityItem) => (
+				<ActivityRow key={item.id} item={item} />
+			))}
+		</div>
+	);
+}
+
+function ActivityRow({ item }: { item: ChannelActivityItem }) {
+	const inbound = item.direction === "inbound";
+	const isEvent = item.kind === "debug_event";
+	const error = item.delivery_last_error ?? item.error;
+
+	return (
+		<div className="flex items-start gap-3 rounded-lg border p-3">
+			<span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+				{isEvent ? (
+					<TerminalSquare className="size-3.5" />
+				) : inbound ? (
+					<ArrowDownLeft className="size-3.5" />
+				) : (
+					<ArrowUpRight className="size-3.5" />
+				)}
+			</span>
+			<div className="min-w-0 flex-1">
+				<div className="flex items-center gap-2">
+					<span className="text-xs font-medium capitalize">
+						{isEvent ? (item.stage ?? "event") : inbound ? "Inbound" : "Outbound"}
+					</span>
+					{item.delivery_status ? <DeliveryBadge status={item.delivery_status} /> : null}
+					<span className="ml-auto shrink-0 text-xs text-muted-foreground">
+						{formatWhen(item.created_at)}
+					</span>
+				</div>
+				{item.text ? <p className="mt-1 text-sm">{item.text}</p> : null}
+				{error ? (
+					<p className="mt-1 flex items-start gap-1 text-xs text-destructive">
+						<TriangleAlert className="mt-0.5 size-3 shrink-0" />
+						{error}
+					</p>
+				) : null}
+				{item.external_chat_id ? (
+					<div className="mt-1">
+						<CopyInline value={item.external_chat_id} />
+					</div>
+				) : null}
+			</div>
+		</div>
+	);
+}
+
+// ── Health ───────────────────────────────────────────────────────────────────
+
+function HealthTab({ accountId }: { accountId: string }) {
+	const health = useChannelHealth();
+	if (health.isLoading) return <Skeleton className="h-32 w-full rounded-lg" />;
+	if (health.error) {
+		return (
+			<ChannelError
+				error={health.error}
+				onRetry={() => health.refetch()}
+				title="Couldn't load health"
+			/>
+		);
+	}
+	const h = health.data?.items.find((x) => x.account_id === accountId);
+	if (!h)
+		return <EmptyState title="No health data" description="Health metrics aren't available yet." />;
+
+	const stats = [
+		{ label: "Pending inbox", value: h.pending_inbox },
+		{ label: "Pending deliveries", value: h.pending_deliveries },
+		{ label: "In progress", value: h.in_progress_deliveries },
+		{ label: "Failed deliveries", value: h.failed_deliveries },
+	];
+
+	return (
+		<div className="space-y-4">
+			<div className="flex items-center gap-2">
+				<HealthBadge status={h.health_status} />
+				{(h.reasons ?? []).length > 0 ? (
+					<span className="text-xs text-muted-foreground">
+						{(h.reasons ?? []).join(" · ").replace(/_/g, " ")}
+					</span>
+				) : (
+					<span className="text-xs text-muted-foreground">No issues detected</span>
+				)}
+			</div>
+
+			<div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+				{stats.map((s) => (
+					<div key={s.label} className="rounded-lg border p-3">
+						<div className="text-2xl font-semibold tabular-nums">{s.value}</div>
+						<div className="text-xs text-muted-foreground">{s.label}</div>
+					</div>
+				))}
+			</div>
+
+			{h.last_error ? (
+				<div className="space-y-1 rounded-lg border border-destructive/30 bg-destructive/5 p-3">
+					<div className="flex items-center gap-1.5 text-sm font-medium text-destructive">
+						<TriangleAlert className="size-4" />
+						Last error
+					</div>
+					<p className="text-sm text-destructive/90">{h.last_error}</p>
+					<p className="text-xs text-muted-foreground">
+						{[h.last_error_stage, h.last_error_outcome].filter(Boolean).join(" · ")} ·{" "}
+						{formatWhen(h.last_error_at)}
+					</p>
+				</div>
+			) : null}
+
+			{h.native_transport ? (
+				<div className="rounded-lg border p-3">
+					<div className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+						Native transport
+					</div>
+					<pre className="overflow-x-auto text-xs text-muted-foreground">
+						{JSON.stringify(h.native_transport, null, 2)}
+					</pre>
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+// ── Commands ─────────────────────────────────────────────────────────────────
+
+function CommandsTab({ accountId, provider }: { accountId: string; provider: string }) {
+	const sync = useSyncCommands(accountId);
+	const meta = providerMeta(provider);
+	const supportsCommands = provider === "telegram" || provider === "discord";
+	const commands = sync.data?.commands ?? [];
+
+	return (
+		<div className="max-w-xl space-y-4">
+			<InfoCard icon={KeyRound} title="Slash commands">
+				{supportsCommands
+					? `Publish this agent's slash commands to ${meta.label}.`
+					: `${meta.label} doesn't support slash commands.`}
+			</InfoCard>
+
+			{supportsCommands ? (
+				<>
+					<Button onClick={() => sync.mutate()} disabled={sync.isPending}>
+						<RefreshCw className="size-4" />
+						{sync.isPending ? "Syncing…" : "Sync commands"}
+					</Button>
+					{commands.length > 0 ? (
+						<div className="space-y-2 rounded-lg border p-3">
+							<div className="text-xs font-medium text-success-muted-foreground">
+								Synced {commands.length} command{commands.length === 1 ? "" : "s"}
+							</div>
+							{commands.map((c) => (
+								<div key={String(c.name)} className="flex items-baseline gap-2 text-sm">
+									<code className="font-mono text-xs">/{String(c.name)}</code>
+									<span className="text-muted-foreground">{String(c.description)}</span>
+								</div>
+							))}
+						</div>
+					) : sync.data ? (
+						<div className="rounded-lg border border-dashed px-3 py-3 text-sm text-muted-foreground">
+							Command sync completed. The runtime returned no commands to publish.
+						</div>
+					) : null}
+				</>
+			) : null}
+		</div>
+	);
+}

--- a/apps/web/src/hosted/channels/channel-edit-client.ts
+++ b/apps/web/src/hosted/channels/channel-edit-client.ts
@@ -1,0 +1,109 @@
+"use client";
+
+import { extractApiDetail } from "@clawdi/shared/api";
+import { useMemo } from "react";
+import { ApiError, ApiNetworkError } from "@/lib/api-errors";
+import { useAuthToken } from "@/lib/auth-client";
+import { env } from "@/lib/env";
+
+const API_URL = env.NEXT_PUBLIC_API_URL;
+
+/** Client-side request ceiling so a stalled call can't freeze the page (matches lib/api.ts). */
+const REQUEST_TIMEOUT_MS = 20_000;
+
+/**
+ * Account summary embedded in an agent's channel link. Handwritten to mirror
+ * the cloud-api `/api/channels/agent-links` response.
+ */
+export interface AgentChannelLinkAccount {
+	id: string;
+	provider: string;
+	name: string;
+	status: string;
+	visibility: "private" | "public";
+}
+
+/** An agent's channel link with its embedded account summary. */
+export interface AgentChannelLink {
+	id: string;
+	account_id: string;
+	agent_id: string;
+	status: string;
+	created_at: string;
+	agent_token?: string | null;
+	/**
+	 * Embedded account summary. OPTIONAL on purpose: the cloud-api list-by-agent
+	 * response (#155) is not guaranteed to nest the account — the matching
+	 * backend link schema (`ChannelAgentLinkResponse`) carries only
+	 * `account_id`. Consumers MUST null-guard and fall back to `account_id` /
+	 * the loaded channels list (apps/web has no ErrorBoundary).
+	 */
+	account?: AgentChannelLinkAccount | null;
+}
+
+/**
+ * Handwritten, Clerk-authenticated client for the two agent-link edit routes.
+ *
+ * These endpoints ship in the cloud-api PR and are intentionally NOT part of
+ * main's generated OpenAPI client, so we call them directly with the Clerk
+ * bearer instead of `useApi`. Non-2xx responses throw `ApiError` so the
+ * channel hooks route failures through their existing error handling.
+ */
+export function useChannelEditApi() {
+	const { getToken } = useAuthToken();
+	return useMemo(() => {
+		async function request<T>(
+			path: string,
+			init: { method: "GET" | "DELETE"; query?: Record<string, string> },
+		): Promise<T> {
+			const token = await getToken();
+			const url = new URL(`${API_URL}${path}`);
+			if (init.query) {
+				for (const [key, value] of Object.entries(init.query)) url.searchParams.set(key, value);
+			}
+			// Bound the request so a stalled connection can't freeze the surface.
+			const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+			let response: Response;
+			try {
+				response = await fetch(url.toString(), {
+					method: init.method,
+					headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+					signal: timeout,
+				});
+			} catch (cause) {
+				// fetch only rejects on transport failure (offline, DNS, CORS, abort) —
+				// never on a non-2xx. Map our timeout abort and bare network failures
+				// to a recoverable, normalizable error.
+				if (timeout.aborted) throw new ApiNetworkError("timeout", { cause });
+				throw new ApiNetworkError("offline", { cause });
+			}
+			if (!response.ok) {
+				let detail = response.statusText;
+				try {
+					detail = extractApiDetail(await response.json());
+				} catch {
+					// Non-JSON error body — fall back to the status text.
+				}
+				throw new ApiError(response.status, detail);
+			}
+			if (response.status === 204) return undefined as T;
+			const text = await response.text();
+			return (text ? JSON.parse(text) : undefined) as T;
+		}
+
+		return {
+			/** GET /api/channels/agent-links?agent_id={id} — links for one agent. */
+			listAgentLinks: (agentId: string) =>
+				request<AgentChannelLink[]>("/api/channels/agent-links", {
+					method: "GET",
+					query: { agent_id: agentId },
+				}),
+			/** DELETE /api/channels/{accountId}/agent-links/{linkId} — unlink. */
+			unlinkAgent: (accountId: string, linkId: string) =>
+				request<void>(
+					`/api/channels/${encodeURIComponent(accountId)}/agent-links/${encodeURIComponent(linkId)}`,
+					{ method: "DELETE" },
+				),
+		};
+	}, [getToken]);
+}

--- a/apps/web/src/hosted/channels/channel-providers.ts
+++ b/apps/web/src/hosted/channels/channel-providers.ts
@@ -1,0 +1,87 @@
+/**
+ * The four native channel providers (backend `CHANNEL_PROVIDERS`). Each takes
+ * DIFFERENT real connect inputs — grounded in cloud-api:
+ *   - telegram:  bot token (BotFather)                → provider_token
+ *   - discord:   bot token + application_id + public_key (+ optional guild_id)
+ *                                                       → provider_token + config
+ *   - whatsapp:  NO token — Baileys device link via the tenant-creds flow
+ *   - imessage:  BlueBubbles server_url + password (+ auth_mode)
+ *                                                       → provider_token + config
+ * Tints reuse the app identity palette so channel chips match the chrome.
+ */
+export const CHANNEL_PROVIDERS = ["telegram", "discord", "whatsapp", "imessage"] as const;
+export type ChannelProviderId = (typeof CHANNEL_PROVIDERS)[number];
+
+/** How the connect form behaves for this provider. */
+export type ChannelConnectMode = "token" | "discord" | "whatsapp" | "imessage";
+
+export interface ChannelProviderMeta {
+	id: ChannelProviderId;
+	label: string;
+	tint: string;
+	connect: ChannelConnectMode;
+	/** Label/placeholder for the single credential field (token / password). */
+	tokenLabel?: string;
+	tokenPlaceholder?: string;
+	hint: string;
+}
+
+export const PROVIDER_META: Record<ChannelProviderId, ChannelProviderMeta> = {
+	telegram: {
+		id: "telegram",
+		label: "Telegram",
+		tint: "bg-identity-3-bg text-identity-3-fg",
+		connect: "token",
+		tokenLabel: "Bot token",
+		tokenPlaceholder: "123456:ABC-DEF…",
+		hint: "Create a bot with @BotFather and paste its token.",
+	},
+	discord: {
+		id: "discord",
+		label: "Discord",
+		tint: "bg-identity-5-bg text-identity-5-fg",
+		connect: "discord",
+		tokenLabel: "Bot token",
+		tokenPlaceholder: "Bot token",
+		hint: "From the Discord developer portal: the bot token, plus the application ID and public key for slash commands and interactions.",
+	},
+	whatsapp: {
+		id: "whatsapp",
+		label: "WhatsApp",
+		tint: "bg-identity-2-bg text-identity-2-fg",
+		connect: "whatsapp",
+		hint: "No bot token — connect, then link your WhatsApp number by scanning a code (Linked devices).",
+	},
+	imessage: {
+		id: "imessage",
+		label: "iMessage",
+		tint: "bg-identity-6-bg text-identity-6-fg",
+		connect: "imessage",
+		tokenLabel: "BlueBubbles password",
+		tokenPlaceholder: "Server password",
+		hint: "Connect your BlueBubbles server — its URL and password.",
+	},
+};
+
+/** BlueBubbles auth modes the backend understands (channels.py `_send_imessage`). */
+export const IMESSAGE_AUTH_MODES = [
+	{ value: "password_query", label: "Password (query)" },
+	{ value: "x_api_key", label: "API key header" },
+	{ value: "bearer", label: "Bearer token" },
+] as const;
+
+const FALLBACK: ChannelProviderMeta = {
+	id: "telegram",
+	label: "Channel",
+	tint: "bg-muted text-muted-foreground",
+	connect: "token",
+	hint: "",
+};
+
+export function providerMeta(id: string): ChannelProviderMeta {
+	return PROVIDER_META[id as ChannelProviderId] ?? { ...FALLBACK, label: id };
+}
+
+export function isChannelProvider(id: string): id is ChannelProviderId {
+	return (CHANNEL_PROVIDERS as readonly string[]).includes(id);
+}

--- a/apps/web/src/hosted/channels/channel-types.ts
+++ b/apps/web/src/hosted/channels/channel-types.ts
@@ -1,0 +1,19 @@
+import type { components } from "@/lib/api-schemas";
+
+/**
+ * Local aliases for the native-channel response shapes.
+ *
+ * Each maps to a schema already present in main's generated cloud-api client,
+ * so these are purely a convenience layer. We keep them in apps/web (rather
+ * than re-exporting from the shared package) so this surface stays apps/web-only
+ * — the shared `schemas.ts` convenience aliases ship with the cloud-api PR.
+ */
+type Schemas = components["schemas"];
+
+export type ChannelAccount = Schemas["ChannelAccountResponse"];
+export type ChannelCreate = Schemas["ChannelAccountCreate"];
+export type ChannelCreated = Schemas["ChannelAccountCreatedResponse"];
+export type ChannelBotPoolItem = Schemas["ChannelBotPoolItem"];
+export type ChannelAgentLink = Schemas["ChannelAgentLinkResponse"];
+export type ChannelBinding = Schemas["ChannelBindingResponse"];
+export type ChannelActivityItem = Schemas["ChannelActivityItemResponse"];

--- a/apps/web/src/hosted/channels/channel-ui.tsx
+++ b/apps/web/src/hosted/channels/channel-ui.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import {
+	Check,
+	CircleAlert,
+	CircleCheck,
+	Copy,
+	LogIn,
+	RefreshCw,
+	TriangleAlert,
+} from "lucide-react";
+import { EntityIcon, type EntityIconSize } from "@/components/entity-icon";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { StatusBadge } from "@/components/ui/status-badge";
+import { providerMeta } from "@/hosted/channels/channel-providers";
+import { useCopyToClipboard } from "@/hosted/use-copy-to-clipboard";
+import { isApiAuthError, normalizeApiError } from "@/lib/api-errors";
+import { cn } from "@/lib/utils";
+
+type StatusTone = "success" | "warning" | "destructive" | "info" | "neutral";
+
+/** Send the user back through Clerk, returning to wherever they are now. */
+function reauthenticate() {
+	if (typeof window === "undefined") return;
+	const redirect = encodeURIComponent(window.location.pathname + window.location.search);
+	window.location.href = `/sign-in?redirect_url=${redirect}`;
+}
+
+/**
+ * Cloud-api error panel for the hosted channel / provider surfaces. Normalizes
+ * the failure to internal-free copy and, on a session-expiry 401, leads with a
+ * "Sign in again" action (a retry can't fix a dead token) while keeping Retry
+ * as a secondary affordance for the race where Clerk already refreshed it.
+ */
+export function ChannelError({
+	error,
+	onRetry,
+	title = "Couldn't load this",
+}: {
+	error: unknown;
+	onRetry?: () => void;
+	title?: string;
+}) {
+	const expired = isApiAuthError(error);
+	return (
+		<Alert data-hosted="true" variant="destructive">
+			<CircleAlert />
+			<AlertTitle>{expired ? "Your session expired" : title}</AlertTitle>
+			<AlertDescription className="flex flex-col items-start gap-3">
+				<span>{normalizeApiError(error)}</span>
+				<div className="flex flex-wrap gap-2">
+					{expired ? (
+						<Button size="sm" onClick={reauthenticate}>
+							<LogIn /> Sign in again
+						</Button>
+					) : null}
+					{onRetry ? (
+						<Button size="sm" variant="outline" onClick={onRetry}>
+							<RefreshCw /> Retry
+						</Button>
+					) : null}
+				</div>
+			</AlertDescription>
+		</Alert>
+	);
+}
+
+/** Real app-icon for a channel provider (delegates to the unified EntityIcon). */
+export function ProviderChip({
+	provider,
+	size = "md",
+	className,
+}: {
+	provider: string;
+	size?: EntityIconSize;
+	className?: string;
+}) {
+	const meta = providerMeta(provider);
+	return (
+		<EntityIcon kind="channel" id={provider} label={meta.label} size={size} className={className} />
+	);
+}
+
+const HEALTH_META: Record<string, { label: string; tone: StatusTone; icon: typeof CircleCheck }> = {
+	ok: { label: "Healthy", tone: "success", icon: CircleCheck },
+	warning: { label: "Warning", tone: "warning", icon: TriangleAlert },
+	error: { label: "Error", tone: "destructive", icon: CircleAlert },
+};
+
+/** Health chip (ok / warning / error) from `GET /api/channels/health`. */
+export function HealthBadge({ status, className }: { status: string; className?: string }) {
+	const m = HEALTH_META[status] ?? HEALTH_META.warning;
+	const Icon = m.icon;
+	return (
+		<StatusBadge status={m.tone} className={className}>
+			<Icon />
+			{m.label}
+		</StatusBadge>
+	);
+}
+
+/** Owner / shared access label for pool items. */
+export function AccessBadge({ access }: { access: string }) {
+	const owner = access === "owner";
+	return (
+		<StatusBadge status={owner ? "info" : "neutral"}>{owner ? "Your bot" : "Shared"}</StatusBadge>
+	);
+}
+
+const DELIVERY_TONE: Record<string, StatusTone> = {
+	sent: "success",
+	delivered: "success",
+	pending: "warning",
+	in_progress: "warning",
+	failed: "destructive",
+};
+
+/** Delivery state chip for activity rows. */
+export function DeliveryBadge({ status }: { status: string }) {
+	return (
+		<StatusBadge status={DELIVERY_TONE[status] ?? "neutral"}>
+			{status.replace("_", " ")}
+		</StatusBadge>
+	);
+}
+
+function useCopy() {
+	return useCopyToClipboard({ error: "Copy failed" });
+}
+
+/** Copyable secret box — used for revealed agent tokens, webhook secrets. */
+export function TokenReveal({
+	label,
+	value,
+	note,
+}: {
+	label: string;
+	value: string;
+	note?: string;
+}) {
+	const { copied, copy } = useCopy();
+	return (
+		<div
+			data-hosted="true"
+			className="space-y-2 rounded-lg border border-primary/30 bg-primary/5 p-3"
+		>
+			<div className="text-xs font-medium text-primary">{label}</div>
+			<div className="flex items-center gap-2">
+				<code className="flex-1 break-all rounded bg-muted px-3 py-2 font-mono text-xs">
+					{value}
+				</code>
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon"
+					onClick={() => copy(value)}
+					aria-label={`Copy ${label}`}
+				>
+					{copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+				</Button>
+			</div>
+			{note ? <p className="text-xs text-muted-foreground">{note}</p> : null}
+		</div>
+	);
+}
+
+/** Inline copyable monospace value (chat ids, webhook urls). */
+export function CopyInline({ value, className }: { value: string; className?: string }) {
+	const { copied, copy } = useCopy();
+	return (
+		<button
+			type="button"
+			data-hosted="true"
+			onClick={() => copy(value)}
+			className={cn(
+				"inline-flex items-center gap-1 font-mono text-xs text-muted-foreground transition-colors hover:text-foreground",
+				className,
+			)}
+			aria-label="Copy"
+		>
+			<span className="truncate">{value}</span>
+			{copied ? <Check className="size-3 shrink-0" /> : <Copy className="size-3 shrink-0" />}
+		</button>
+	);
+}

--- a/apps/web/src/hosted/channels/channels-hooks.ts
+++ b/apps/web/src/hosted/channels/channels-hooks.ts
@@ -1,0 +1,325 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useChannelEditApi } from "@/hosted/channels/channel-edit-client";
+import type { ChannelCreate } from "@/hosted/channels/channel-types";
+import { toastApiError, unwrap, useApi } from "@/lib/api";
+
+/**
+ * Typed data hooks for the native channels surface. All reads/writes go
+ * through the generated cloud-api client (`useApi`) against
+ * `/api/channels/*`; mutations invalidate the affected queries and surface
+ * recoverable errors as toasts.
+ */
+
+const keys = {
+	list: ["channels"] as const,
+	pool: ["channel-bot-pool"] as const,
+	health: ["channel-health"] as const,
+	channel: (id: string) => ["channel", id] as const,
+	agentLinks: (id: string) => ["channel-agent-links", id] as const,
+	bindings: (id: string) => ["channel-bindings", id] as const,
+	activity: (id: string) => ["channel-activity", id] as const,
+	whatsappCreds: (id: string) => ["whatsapp-tenant-creds", id] as const,
+};
+
+export function useChannels() {
+	const api = useApi();
+	return useQuery({
+		queryKey: keys.list,
+		queryFn: async () => unwrap(await api.GET("/api/channels")),
+	});
+}
+
+export function useBotPool() {
+	const api = useApi();
+	return useQuery({
+		queryKey: keys.pool,
+		queryFn: async () => unwrap(await api.GET("/api/channels/bot-pool")),
+	});
+}
+
+export function useChannelHealth() {
+	const api = useApi();
+	return useQuery({
+		queryKey: keys.health,
+		queryFn: async () => unwrap(await api.GET("/api/channels/health")),
+	});
+}
+
+export function useChannel(id: string) {
+	const api = useApi();
+	return useQuery({
+		queryKey: keys.channel(id),
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/api/channels/{account_id}", {
+					params: { path: { account_id: id } },
+				}),
+			),
+		enabled: Boolean(id),
+	});
+}
+
+export function useChannelAgentLinks(id: string) {
+	const api = useApi();
+	return useQuery({
+		queryKey: keys.agentLinks(id),
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/api/channels/{account_id}/agent-links", {
+					params: { path: { account_id: id } },
+				}),
+			),
+		enabled: Boolean(id),
+	});
+}
+
+export function useChannelBindings(id: string) {
+	const api = useApi();
+	return useQuery({
+		queryKey: keys.bindings(id),
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/api/channels/{account_id}/bindings", {
+					params: { path: { account_id: id } },
+				}),
+			),
+		enabled: Boolean(id),
+	});
+}
+
+export function useChannelActivity(id: string) {
+	const api = useApi();
+	return useQuery({
+		queryKey: keys.activity(id),
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/api/channels/{account_id}/activity", {
+					params: { path: { account_id: id }, query: { limit: 50 } },
+				}),
+			),
+		enabled: Boolean(id),
+	});
+}
+
+/** Connected agents available to link / pair. Shares the `environments` key. */
+export function useEnvironments() {
+	const api = useApi();
+	return useQuery({
+		queryKey: ["environments"],
+		queryFn: async () => unwrap(await api.GET("/api/environments")),
+	});
+}
+
+export function useCreateChannel() {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (body: ChannelCreate) => unwrap(await api.POST("/api/channels", { body })),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: keys.list });
+			qc.invalidateQueries({ queryKey: keys.pool });
+			qc.invalidateQueries({ queryKey: keys.health });
+		},
+		onError: toastApiError("Couldn't connect channel"),
+	});
+}
+
+export function useDeleteChannel() {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (id: string) =>
+			unwrap(
+				await api.DELETE("/api/channels/{account_id}", {
+					params: { path: { account_id: id } },
+				}),
+			),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: keys.list });
+			qc.invalidateQueries({ queryKey: keys.pool });
+			qc.invalidateQueries({ queryKey: keys.health });
+			toast.success("Channel removed");
+		},
+		onError: toastApiError("Couldn't remove channel"),
+	});
+}
+
+export function useLinkAgent(accountId: string) {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (agentId: string) =>
+			unwrap(
+				await api.POST("/api/channels/{account_id}/agent-links", {
+					params: { path: { account_id: accountId } },
+					body: { agent_id: agentId },
+				}),
+			),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: keys.agentLinks(accountId) });
+			qc.invalidateQueries({ queryKey: ["agent-channel-links"] });
+			qc.invalidateQueries({ queryKey: keys.pool });
+		},
+		onError: toastApiError("Couldn't link agent"),
+	});
+}
+
+export function useRotateAgentToken(accountId: string) {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (linkId: string) =>
+			unwrap(
+				await api.POST("/api/channels/{account_id}/agent-links/{link_id}/token", {
+					params: { path: { account_id: accountId, link_id: linkId } },
+				}),
+			),
+		onSuccess: (data) => {
+			qc.invalidateQueries({ queryKey: keys.agentLinks(accountId) });
+			qc.invalidateQueries({ queryKey: ["agent-channel-links"] });
+			// Always confirm — the new token is also revealed inline when present,
+			// but the rotation must never be a silent no-op even without a token.
+			toast.success("Token rotated", {
+				description: data.agent_token
+					? "Copy the new token below — the previous one is now invalid."
+					: "The previous token is now invalid.",
+			});
+		},
+		onError: toastApiError("Couldn't rotate token"),
+	});
+}
+
+export function useCreatePairCode(accountId: string) {
+	const api = useApi();
+	return useMutation({
+		mutationFn: async (vars: { agent_id?: string; agent_link_id?: string; ttl_seconds?: number }) =>
+			unwrap(
+				await api.POST("/api/channels/{account_id}/pair-codes", {
+					params: { path: { account_id: accountId } },
+					body: { ttl_seconds: vars.ttl_seconds ?? 900, ...vars },
+				}),
+			),
+		onError: toastApiError("Couldn't create pairing code"),
+	});
+}
+
+/** An agent's linked channels (+account summary) — fixes the per-channel N+1. */
+export function useAgentChannelLinks(agentId: string, enabled = true) {
+	const editApi = useChannelEditApi();
+	return useQuery({
+		queryKey: ["agent-channel-links", agentId],
+		queryFn: () => editApi.listAgentLinks(agentId),
+		enabled: enabled && Boolean(agentId),
+	});
+}
+
+export function useUnlinkAgentChannel(agentId: string) {
+	const editApi = useChannelEditApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: (vars: { accountId: string; linkId: string }) =>
+			editApi.unlinkAgent(vars.accountId, vars.linkId),
+		onSuccess: (_data, vars) => {
+			qc.invalidateQueries({ queryKey: ["agent-channel-links", agentId] });
+			qc.invalidateQueries({ queryKey: keys.agentLinks(vars.accountId) });
+			qc.invalidateQueries({ queryKey: keys.list });
+			qc.invalidateQueries({ queryKey: keys.pool });
+			toast.success("Channel unlinked");
+		},
+		onError: toastApiError("Couldn't unlink channel"),
+	});
+}
+
+/** Unlink keyed by channel account (for the channel-detail Agents tab). */
+export function useUnlinkChannelAgent(accountId: string) {
+	const editApi = useChannelEditApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: (linkId: string) => editApi.unlinkAgent(accountId, linkId),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: keys.agentLinks(accountId) });
+			qc.invalidateQueries({ queryKey: ["agent-channel-links"] });
+			qc.invalidateQueries({ queryKey: keys.list });
+			qc.invalidateQueries({ queryKey: keys.pool });
+			toast.success("Agent unlinked");
+		},
+		onError: toastApiError("Couldn't unlink agent"),
+	});
+}
+
+export function useSyncCommands(accountId: string) {
+	const api = useApi();
+	return useMutation({
+		mutationFn: async () =>
+			unwrap(
+				await api.POST("/api/channels/{account_id}/commands/sync", {
+					params: { path: { account_id: accountId } },
+					body: {},
+				}),
+			),
+		onError: toastApiError("Couldn't sync commands"),
+	});
+}
+
+// ── WhatsApp device linking (Baileys tenant credentials) ─────────────────────
+// WhatsApp connects with NO token; a device is linked by minting a per-agent
+// tenant credential (the Baileys auth material). The live QR/pairing handshake
+// runs in the agent runtime over the credential's websocket_url.
+
+export function useWhatsappTenantCreds(accountId: string, enabled = true) {
+	const api = useApi();
+	return useQuery({
+		queryKey: keys.whatsappCreds(accountId),
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/api/channels/whatsapp/{account_id}/tenant-creds", {
+					params: { path: { account_id: accountId } },
+				}),
+			),
+		enabled,
+	});
+}
+
+export function useCreateWhatsappTenantCred(accountId: string) {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (vars: { agent_id?: string; agent_link_id?: string }) =>
+			unwrap(
+				await api.POST("/api/channels/whatsapp/{account_id}/tenant-creds", {
+					params: { path: { account_id: accountId } },
+					// `device` defaults to 1 server-side but the generated client types
+					// it required — send the primary device.
+					body: { device: 1, ...vars },
+				}),
+			),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: keys.whatsappCreds(accountId) });
+			toast.success("Device credential minted", {
+				description: "Finish pairing from the agent runtime to link the number.",
+			});
+		},
+		onError: toastApiError("Couldn't link WhatsApp device"),
+	});
+}
+
+export function useRevokeWhatsappTenantCred(accountId: string) {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (credentialId: string) =>
+			unwrap(
+				await api.DELETE("/api/channels/whatsapp/{account_id}/tenant-creds/{credential_id}", {
+					params: { path: { account_id: accountId, credential_id: credentialId } },
+				}),
+			),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: keys.whatsappCreds(accountId) });
+			toast.success("WhatsApp device unlinked");
+		},
+		onError: toastApiError("Couldn't unlink device"),
+	});
+}

--- a/apps/web/src/hosted/channels/channels-page.tsx
+++ b/apps/web/src/hosted/channels/channels-page.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { MessagesSquare, Plus } from "lucide-react";
+import { useState } from "react";
+import { EmptyState } from "@/components/empty-state";
+import { EntityRow } from "@/components/entity-card";
+import { EntityIcon } from "@/components/entity-icon";
+import { PageHeader } from "@/components/page-header";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+	CHANNEL_PROVIDERS,
+	type ChannelProviderId,
+	providerMeta,
+} from "@/hosted/channels/channel-providers";
+import type { ChannelAccount } from "@/hosted/channels/channel-types";
+import { ChannelError, HealthBadge } from "@/hosted/channels/channel-ui";
+import { useChannelHealth, useChannels } from "@/hosted/channels/channels-hooks";
+import { ConnectBotDialog } from "@/hosted/channels/connect-bot-dialog";
+import { SharedBotsPool } from "@/hosted/channels/shared-bots-pool";
+import { cn } from "@/lib/utils";
+
+const DESCRIPTION = "Connect Telegram, Discord, WhatsApp, and iMessage to your agents.";
+
+export function ChannelsPage() {
+	const [connectOpen, setConnectOpen] = useState(false);
+
+	return (
+		<div data-hosted="true" className="space-y-6 px-4 lg:px-6">
+			<PageHeader
+				title="Channels"
+				description={DESCRIPTION}
+				actions={
+					<Button onClick={() => setConnectOpen(true)}>
+						<Plus />
+						Connect a bot
+					</Button>
+				}
+			/>
+
+			<Tabs defaultValue="mine">
+				<TabsList>
+					<TabsTrigger value="mine">Your channels</TabsTrigger>
+					<TabsTrigger value="shared">Shared bots</TabsTrigger>
+				</TabsList>
+				<TabsContent value="mine" className="mt-4">
+					<YourChannels onConnect={() => setConnectOpen(true)} />
+				</TabsContent>
+				<TabsContent value="shared" className="mt-4">
+					<SharedBotsPool />
+				</TabsContent>
+			</Tabs>
+
+			<ConnectBotDialog open={connectOpen} onOpenChange={setConnectOpen} />
+		</div>
+	);
+}
+
+function YourChannels({ onConnect }: { onConnect: () => void }) {
+	const channels = useChannels();
+	const health = useChannelHealth();
+	const [filter, setFilter] = useState<ChannelProviderId | "all">("all");
+
+	if (channels.isLoading) {
+		return (
+			<div className="space-y-2">
+				{[0, 1, 2].map((i) => (
+					<Skeleton key={i} className="h-16 w-full rounded-lg" />
+				))}
+			</div>
+		);
+	}
+
+	if (channels.error) {
+		return (
+			<ChannelError
+				error={channels.error}
+				onRetry={() => channels.refetch()}
+				title="Couldn't load channels"
+			/>
+		);
+	}
+
+	const all = channels.data ?? [];
+	if (all.length === 0) {
+		return (
+			<EmptyState
+				icon={MessagesSquare}
+				title="No channels yet"
+				description="Connect a bot, or link a shared bot to an agent from the Shared bots tab."
+				action={
+					<Button onClick={onConnect}>
+						<Plus />
+						Connect a bot
+					</Button>
+				}
+			/>
+		);
+	}
+
+	const healthByAccount = new Map(
+		(health.data?.items ?? []).map((h) => [h.account_id, h.health_status]),
+	);
+	const counts = new Map<string, number>();
+	for (const c of all) counts.set(c.provider, (counts.get(c.provider) ?? 0) + 1);
+
+	const visible = filter === "all" ? all : all.filter((c) => c.provider === filter);
+	const groups = CHANNEL_PROVIDERS.map((p) => ({
+		provider: p,
+		items: visible.filter((c) => c.provider === p),
+	})).filter((g) => g.items.length > 0);
+
+	return (
+		<div className="space-y-4">
+			{health.error ? (
+				<ChannelError
+					error={health.error}
+					onRetry={() => health.refetch()}
+					title="Couldn't load channel health"
+				/>
+			) : null}
+			{/* Provider filter */}
+			<div className="flex flex-wrap gap-1.5">
+				<FilterChip active={filter === "all"} onClick={() => setFilter("all")}>
+					All
+					<span className="ml-1 text-muted-foreground">{all.length}</span>
+				</FilterChip>
+				{CHANNEL_PROVIDERS.filter((p) => counts.has(p)).map((p) => (
+					<FilterChip key={p} active={filter === p} onClick={() => setFilter(p)}>
+						{providerMeta(p).label}
+						<span className="ml-1 text-muted-foreground">{counts.get(p)}</span>
+					</FilterChip>
+				))}
+			</div>
+
+			<div className="space-y-5">
+				{groups.map((group) => (
+					<div key={group.provider} className="space-y-2">
+						{filter === "all" ? (
+							<div className="px-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+								{providerMeta(group.provider).label}
+							</div>
+						) : null}
+						<div className="space-y-2">
+							{group.items.map((channel) => (
+								<ChannelRow
+									key={channel.id}
+									channel={channel}
+									health={healthByAccount.get(channel.id)}
+								/>
+							))}
+						</div>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
+
+function FilterChip({
+	active,
+	onClick,
+	children,
+}: {
+	active: boolean;
+	onClick: () => void;
+	children: React.ReactNode;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			aria-pressed={active}
+			className={cn(
+				"rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+				active
+					? "border-primary bg-primary/10 text-primary"
+					: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+			)}
+		>
+			{children}
+		</button>
+	);
+}
+
+function ChannelRow({ channel, health }: { channel: ChannelAccount; health?: string }) {
+	const meta = providerMeta(channel.provider);
+	return (
+		<EntityRow
+			href={`/channels/${channel.id}`}
+			icon={<EntityIcon kind="channel" id={channel.provider} label={meta.label} />}
+			title={channel.name}
+			meta={[
+				meta.label,
+				<span key="status" className="capitalize">
+					{channel.status}
+				</span>,
+			]}
+			status={health ? <HealthBadge status={health} /> : undefined}
+		/>
+	);
+}

--- a/apps/web/src/hosted/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/channels/connect-bot-dialog.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { EntityChoiceCard } from "@/components/entity-card";
+import { EntityIcon } from "@/components/entity-icon";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	CHANNEL_PROVIDERS,
+	type ChannelProviderId,
+	IMESSAGE_AUTH_MODES,
+	PROVIDER_META,
+	providerMeta,
+} from "@/hosted/channels/channel-providers";
+import type { ChannelCreate, ChannelCreated } from "@/hosted/channels/channel-types";
+import { ProviderChip, TokenReveal } from "@/hosted/channels/channel-ui";
+import { useCreateChannel } from "@/hosted/channels/channels-hooks";
+
+/**
+ * Connect a channel. Each provider takes its OWN real inputs (grounded in
+ * cloud-api): Telegram = bot token; Discord = bot token + application_id +
+ * public_key (+ guild_id); iMessage = BlueBubbles server_url + password
+ * (+ auth_mode); WhatsApp = no token (device is linked afterwards via the
+ * Baileys tenant-creds flow on the channel page). On success the webhook
+ * secret is revealed once.
+ */
+export function ConnectBotDialog({
+	open,
+	onOpenChange,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}) {
+	const create = useCreateChannel();
+	const [provider, setProvider] = useState<ChannelProviderId>("telegram");
+	const [name, setName] = useState("");
+	const [token, setToken] = useState(""); // bot token / BlueBubbles password
+	// Discord
+	const [applicationId, setApplicationId] = useState("");
+	const [publicKey, setPublicKey] = useState("");
+	const [guildId, setGuildId] = useState("");
+	// iMessage
+	const [serverUrl, setServerUrl] = useState("");
+	const [authMode, setAuthMode] = useState<string>("password_query");
+	const [created, setCreated] = useState<ChannelCreated | null>(null);
+
+	useEffect(() => {
+		if (!open) {
+			setProvider("telegram");
+			setName("");
+			setToken("");
+			setApplicationId("");
+			setPublicKey("");
+			setGuildId("");
+			setServerUrl("");
+			setAuthMode("password_query");
+			setCreated(null);
+		}
+	}, [open]);
+
+	const meta = providerMeta(provider);
+
+	function changeProvider(next: ChannelProviderId) {
+		setProvider(next);
+		setToken("");
+		setApplicationId("");
+		setPublicKey("");
+		setGuildId("");
+		setServerUrl("");
+		setAuthMode("password_query");
+	}
+
+	const canSubmit =
+		name.trim().length > 0 &&
+		(meta.connect === "whatsapp"
+			? true
+			: meta.connect === "token"
+				? token.trim().length > 0
+				: meta.connect === "discord"
+					? token.trim().length > 0 && applicationId.trim().length > 0
+					: meta.connect === "imessage"
+						? token.trim().length > 0 && serverUrl.trim().length > 0
+						: false);
+
+	function buildBody(): ChannelCreate {
+		const trimmedName = name.trim();
+		if (meta.connect === "discord") {
+			const config: Record<string, unknown> = { application_id: applicationId.trim() };
+			if (publicKey.trim()) config.public_key = publicKey.trim();
+			if (guildId.trim()) config.guild_id = guildId.trim();
+			return { provider, name: trimmedName, provider_token: token.trim(), config };
+		}
+		if (meta.connect === "imessage") {
+			return {
+				provider,
+				name: trimmedName,
+				provider_token: token.trim(),
+				config: { server_url: serverUrl.trim(), auth_mode: authMode },
+			};
+		}
+		if (meta.connect === "token") {
+			return { provider, name: trimmedName, provider_token: token.trim() };
+		}
+		// whatsapp — no token; the device is linked afterwards (tenant-creds)
+		return { provider, name: trimmedName };
+	}
+
+	function submit() {
+		if (!canSubmit) return;
+		create.mutate(buildBody(), { onSuccess: (data) => setCreated(data) });
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent data-hosted="true" className="sm:max-w-md">
+				{created ? (
+					<>
+						<DialogHeader>
+							<DialogTitle>Channel connected</DialogTitle>
+							<DialogDescription>
+								<span className="font-medium">{created.name}</span> is ready. Keep the webhook
+								secret safe — it signs incoming updates.
+							</DialogDescription>
+						</DialogHeader>
+						<TokenReveal
+							label="Webhook secret"
+							value={created.webhook_secret}
+							note="Shown once. Configure this as the secret token on your bot's webhook."
+						/>
+						{created.agent_token ? (
+							<TokenReveal
+								label="Agent token"
+								value={created.agent_token}
+								note="An agent was auto-linked. This token lets it send and receive on the channel."
+							/>
+						) : null}
+						{provider === "whatsapp" ? (
+							<p className="text-sm text-muted-foreground">
+								Next: open the channel and link your WhatsApp number under{" "}
+								<span className="font-medium">Linked devices</span>.
+							</p>
+						) : null}
+						<DialogFooter>
+							<Button variant="outline" onClick={() => onOpenChange(false)}>
+								Close
+							</Button>
+							<Button asChild>
+								<Link href={`/channels/${created.id}`}>Open channel</Link>
+							</Button>
+						</DialogFooter>
+					</>
+				) : (
+					<>
+						<DialogHeader>
+							<DialogTitle>Connect a channel</DialogTitle>
+							<DialogDescription>
+								Each provider needs its own setup — pick one to see what it requires.
+							</DialogDescription>
+						</DialogHeader>
+
+						<div className="space-y-4">
+							<div className="space-y-1.5">
+								<Label>Provider</Label>
+								<div className="grid grid-cols-2 gap-2">
+									{CHANNEL_PROVIDERS.map((p) => (
+										<EntityChoiceCard
+											key={p}
+											selected={provider === p}
+											onClick={() => changeProvider(p)}
+											icon={<EntityIcon kind="channel" id={p} label={PROVIDER_META[p].label} />}
+											title={PROVIDER_META[p].label}
+										/>
+									))}
+								</div>
+							</div>
+
+							<div className="flex items-start gap-3 rounded-lg border bg-muted/30 p-3">
+								<ProviderChip provider={provider} />
+								<p className="text-xs text-muted-foreground">{meta.hint}</p>
+							</div>
+
+							<div className="space-y-1.5">
+								<Label htmlFor="connect-name">Name</Label>
+								<Input
+									id="connect-name"
+									value={name}
+									onChange={(e) => setName(e.target.value)}
+									placeholder="Support Bot"
+									autoComplete="off"
+								/>
+							</div>
+
+							{/* Telegram / Discord bot token, or iMessage BlueBubbles password. */}
+							{meta.connect !== "whatsapp" ? (
+								<div className="space-y-1.5">
+									<Label htmlFor="connect-token">{meta.tokenLabel}</Label>
+									<Input
+										id="connect-token"
+										type="password"
+										value={token}
+										onChange={(e) => setToken(e.target.value)}
+										placeholder={meta.tokenPlaceholder}
+										autoComplete="off"
+										spellCheck={false}
+									/>
+								</div>
+							) : null}
+
+							{/* Discord: application_id (+ public_key, guild_id). */}
+							{meta.connect === "discord" ? (
+								<>
+									<div className="space-y-1.5">
+										<Label htmlFor="connect-app-id">Application ID</Label>
+										<Input
+											id="connect-app-id"
+											value={applicationId}
+											onChange={(e) => setApplicationId(e.target.value)}
+											placeholder="Application (client) ID"
+											autoComplete="off"
+											spellCheck={false}
+										/>
+										<p className="text-xs text-muted-foreground">
+											Required to publish slash commands.
+										</p>
+									</div>
+									<div className="space-y-1.5">
+										<Label htmlFor="connect-public-key">
+											Public key <span className="text-muted-foreground">· recommended</span>
+										</Label>
+										<Input
+											id="connect-public-key"
+											value={publicKey}
+											onChange={(e) => setPublicKey(e.target.value)}
+											placeholder="Ed25519 public key (hex)"
+											autoComplete="off"
+											spellCheck={false}
+										/>
+										<p className="text-xs text-muted-foreground">
+											Verifies incoming interaction signatures.
+										</p>
+									</div>
+									<div className="space-y-1.5">
+										<Label htmlFor="connect-guild-id">
+											Guild ID <span className="text-muted-foreground">· optional</span>
+										</Label>
+										<Input
+											id="connect-guild-id"
+											value={guildId}
+											onChange={(e) => setGuildId(e.target.value)}
+											placeholder="Default command scope"
+											autoComplete="off"
+											spellCheck={false}
+										/>
+									</div>
+								</>
+							) : null}
+
+							{/* iMessage: BlueBubbles server URL + auth mode. */}
+							{meta.connect === "imessage" ? (
+								<>
+									<div className="space-y-1.5">
+										<Label htmlFor="connect-server-url">BlueBubbles server URL</Label>
+										<Input
+											id="connect-server-url"
+											value={serverUrl}
+											onChange={(e) => setServerUrl(e.target.value)}
+											placeholder="https://your-bluebubbles.example.com"
+											autoComplete="off"
+											spellCheck={false}
+										/>
+									</div>
+									<div className="space-y-1.5">
+										<Label htmlFor="connect-auth-mode">Auth mode</Label>
+										<Select value={authMode} onValueChange={setAuthMode}>
+											<SelectTrigger id="connect-auth-mode">
+												<SelectValue />
+											</SelectTrigger>
+											<SelectContent>
+												{IMESSAGE_AUTH_MODES.map((m) => (
+													<SelectItem key={m.value} value={m.value}>
+														{m.label}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+									</div>
+								</>
+							) : null}
+						</div>
+
+						<DialogFooter>
+							<Button variant="outline" onClick={() => onOpenChange(false)}>
+								Cancel
+							</Button>
+							<Button onClick={submit} disabled={!canSubmit || create.isPending}>
+								{create.isPending ? "Connecting…" : "Connect"}
+							</Button>
+						</DialogFooter>
+					</>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/hosted/channels/link-agent-dialog.tsx
+++ b/apps/web/src/hosted/channels/link-agent-dialog.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { CircleCheck } from "lucide-react";
+import { useEffect, useState } from "react";
+import { agentTypeLabel } from "@/components/dashboard/agent-label";
+import { EmptyState } from "@/components/empty-state";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ChannelError, TokenReveal } from "@/hosted/channels/channel-ui";
+import { useEnvironments, useLinkAgent } from "@/hosted/channels/channels-hooks";
+
+/**
+ * Link a connected agent to a channel — instant, no token paste. On success
+ * the scoped agent token is revealed once (the handle the agent runtime uses
+ * to send/receive on this channel).
+ */
+export function LinkAgentDialog({
+	open,
+	onOpenChange,
+	accountId,
+	accountName,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	accountId: string;
+	accountName: string;
+}) {
+	const envs = useEnvironments();
+	const link = useLinkAgent(accountId);
+	// Empty string is the "no selection" sentinel: keeps the Select controlled
+	// (never flips undefined↔string, which warns), and reads as falsy so submit
+	// stays gated. Radix renders the placeholder for value="".
+	const [agentId, setAgentId] = useState("");
+	const [token, setToken] = useState<string | null>(null);
+	const [linkedNoToken, setLinkedNoToken] = useState(false);
+
+	useEffect(() => {
+		if (!open) {
+			setAgentId("");
+			setToken(null);
+			setLinkedNoToken(false);
+		}
+	}, [open]);
+
+	function submit() {
+		if (!agentId) return;
+		link.mutate(agentId, {
+			onSuccess: (data) => {
+				if (data.agent_token) setToken(data.agent_token);
+				else setLinkedNoToken(true);
+			},
+		});
+	}
+
+	const agents = envs.data ?? [];
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent data-hosted="true" className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>Link an agent</DialogTitle>
+					<DialogDescription>
+						Connect one of your agents to <span className="font-medium">{accountName}</span>.
+					</DialogDescription>
+				</DialogHeader>
+
+				{token ? (
+					<TokenReveal
+						label="Agent token"
+						value={token}
+						note="Copy it now — it won't be shown again. The agent runtime uses this to send and receive on this channel."
+					/>
+				) : linkedNoToken ? (
+					<div className="flex items-center gap-2 rounded-lg border border-success/30 bg-success-muted p-3 text-sm text-success-muted-foreground">
+						<CircleCheck className="size-4 shrink-0" />
+						This agent is already linked to the channel.
+					</div>
+				) : envs.isLoading ? (
+					<Skeleton className="h-10 w-full rounded-md" />
+				) : envs.error ? (
+					<ChannelError
+						error={envs.error}
+						onRetry={() => envs.refetch()}
+						title="Couldn't load agents"
+					/>
+				) : agents.length === 0 ? (
+					<EmptyState
+						title="No agents yet"
+						description="Connect an agent first, then link it to this channel."
+						fillHeight={false}
+					/>
+				) : (
+					<div className="space-y-2">
+						<Select value={agentId} onValueChange={setAgentId}>
+							<SelectTrigger>
+								<SelectValue placeholder="Choose an agent" />
+							</SelectTrigger>
+							<SelectContent>
+								{agents.map((env) => (
+									<SelectItem key={env.id} value={env.id}>
+										{env.machine_name} · {agentTypeLabel(env.agent_type)}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				)}
+
+				<DialogFooter>
+					{token || linkedNoToken ? (
+						<Button onClick={() => onOpenChange(false)}>Done</Button>
+					) : (
+						<>
+							<Button variant="outline" onClick={() => onOpenChange(false)}>
+								Cancel
+							</Button>
+							<Button onClick={submit} disabled={!agentId || link.isPending}>
+								{link.isPending ? "Linking…" : "Link agent"}
+							</Button>
+						</>
+					)}
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/hosted/channels/shared-bots-pool.tsx
+++ b/apps/web/src/hosted/channels/shared-bots-pool.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { ArrowUpRight, Link2, Users } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import { EmptyState } from "@/components/empty-state";
+import { ENTITY_CARD_BASE, EntityHeader } from "@/components/entity-card";
+import { EntityIcon } from "@/components/entity-icon";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { CHANNEL_PROVIDERS, providerMeta } from "@/hosted/channels/channel-providers";
+import type { ChannelBotPoolItem } from "@/hosted/channels/channel-types";
+import { AccessBadge, ChannelError } from "@/hosted/channels/channel-ui";
+import { useBotPool } from "@/hosted/channels/channels-hooks";
+import { LinkAgentDialog } from "@/hosted/channels/link-agent-dialog";
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared bot pool — public bots the user can link an agent to instantly (no
+ * token), plus their own bots. Grouped by provider; at-capacity bots are
+ * shown but disabled.
+ */
+export function SharedBotsPool() {
+	const pool = useBotPool();
+	const [linkTarget, setLinkTarget] = useState<{ id: string; name: string } | null>(null);
+
+	if (pool.isLoading) {
+		return (
+			<div data-hosted="true" className="space-y-3">
+				{[0, 1, 2].map((i) => (
+					<Skeleton key={i} className="h-20 w-full rounded-lg" />
+				))}
+			</div>
+		);
+	}
+
+	if (pool.error) {
+		return (
+			<div data-hosted="true">
+				<ChannelError
+					error={pool.error}
+					onRetry={() => pool.refetch()}
+					title="Couldn't load shared bots"
+				/>
+			</div>
+		);
+	}
+
+	const providers = pool.data?.providers ?? {};
+	const sections = CHANNEL_PROVIDERS.map((p) => ({
+		provider: p,
+		items: providers[p] ?? [],
+	})).filter((s) => s.items.length > 0);
+
+	if (sections.length === 0) {
+		return (
+			<div data-hosted="true">
+				<EmptyState
+					icon={Users}
+					title="No shared bots available"
+					description="Shared bots you can link to instantly will appear here."
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<div data-hosted="true" className="space-y-6">
+			{sections.map((section) => {
+				const meta = providerMeta(section.provider);
+				return (
+					<div key={section.provider} className="space-y-2">
+						<div className="flex items-center gap-2 px-0.5">
+							<span className="text-sm font-medium">{meta.label}</span>
+							<span className="text-xs text-muted-foreground">{section.items.length}</span>
+						</div>
+						<div className="grid gap-2 sm:grid-cols-2">
+							{section.items.map((item) => (
+								<PoolCard
+									key={item.id}
+									item={item}
+									onLink={() => setLinkTarget({ id: item.id, name: item.name })}
+								/>
+							))}
+						</div>
+					</div>
+				);
+			})}
+
+			{linkTarget ? (
+				<LinkAgentDialog
+					open={Boolean(linkTarget)}
+					onOpenChange={(o) => !o && setLinkTarget(null)}
+					accountId={linkTarget.id}
+					accountName={linkTarget.name}
+				/>
+			) : null}
+		</div>
+	);
+}
+
+function PoolCard({ item, onLink }: { item: ChannelBotPoolItem; onLink: () => void }) {
+	const owner = item.access === "owner";
+	const capacity =
+		item.max_links == null
+			? `${item.link_count} linked · unlimited`
+			: `${item.link_count} of ${item.max_links} linked`;
+
+	const meta = providerMeta(item.provider);
+	const linkable = item.available && item.capabilities.link_agent;
+
+	return (
+		<div className={cn(ENTITY_CARD_BASE, "flex flex-col gap-3 bg-card")}>
+			<EntityHeader
+				align="start"
+				icon={<EntityIcon kind="channel" id={item.provider} label={meta.label} />}
+				title={item.name}
+				titleAdornment={<AccessBadge access={item.access} />}
+				meta={
+					<span className="inline-flex items-center gap-1.5">
+						<Users className="size-3" />
+						{capacity}
+					</span>
+				}
+			/>
+
+			{owner ? (
+				<Button asChild variant="outline" size="sm" className="w-full">
+					<Link href={`/channels/${item.id}`}>
+						Manage
+						<ArrowUpRight className="size-3.5" />
+					</Link>
+				</Button>
+			) : linkable ? (
+				<Button size="sm" className="w-full" onClick={onLink}>
+					<Link2 className="size-3.5" />
+					Link to an agent
+				</Button>
+			) : (
+				<Button size="sm" variant="outline" className="w-full" disabled>
+					{/* `available` false = genuinely full; otherwise the bot just
+					    isn't linkable (capability-gated) — don't mislabel as capacity. */}
+					{item.available ? "Not linkable" : "At capacity"}
+				</Button>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/hosted/use-copy-to-clipboard.ts
+++ b/apps/web/src/hosted/use-copy-to-clipboard.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+
+interface CopyToastCopy {
+	/** Success toast title. Defaults to "Copied to clipboard". */
+	success?: string;
+	/** Failure toast title (clipboard blocked / insecure context). */
+	error?: string;
+}
+
+/**
+ * Shared copy-to-clipboard affordance: writes to the clipboard, flips a
+ * `copied` flag true for ~1.5s, and toasts. Each surface passes its own toast
+ * copy so wording stays put; only the clipboard write, the reset, and the
+ * success/failure split are shared. Used by the billing `CopyButton` and the
+ * channels token/inline copy controls.
+ */
+export function useCopyToClipboard(toasts: CopyToastCopy = {}) {
+	const [copied, setCopied] = useState(false);
+	async function copy(value: string) {
+		try {
+			await navigator.clipboard.writeText(value);
+			setCopied(true);
+			toast.success(toasts.success ?? "Copied to clipboard");
+			setTimeout(() => setCopied(false), 1500);
+		} catch {
+			toast.error(toasts.error ?? "Couldn’t copy — select and copy manually.");
+		}
+	}
+	return { copied, copy };
+}

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -5,6 +5,12 @@ import { env } from "@/lib/env";
 
 const DEV_AUTH_BEARER = env.NEXT_PUBLIC_DEV_AUTH_TOKEN;
 
+// Stable identity for the dev-bypass branch: returning a fresh object (and
+// fresh `getToken`) each render would churn every `useMemo`/`useQuery` that
+// depends on `getToken` (e.g. the channel-edit client), re-creating clients
+// and re-issuing in-flight requests. Keep one constant reference.
+const DEV_AUTH_TOKEN_RESULT = { getToken: async () => DEV_AUTH_BEARER };
+
 const DEV_USER = {
 	id: "dev_browser",
 	fullName: env.NEXT_PUBLIC_DEV_AUTH_NAME,
@@ -18,7 +24,7 @@ const DEV_USER = {
 
 export function useAuthToken() {
 	if (env.NEXT_PUBLIC_DEV_AUTH_BYPASS) {
-		return { getToken: async () => DEV_AUTH_BEARER };
+		return DEV_AUTH_TOKEN_RESULT;
 	}
 	const { getToken } = useAuth();
 	return { getToken };


### PR DESCRIPTION
## Summary
- add hosted-only Channels list/detail routes behind `IS_HOSTED` dynamic imports
- add channel management UI for private/shared bots, linking agents, pair codes, bindings, activity, health, commands, and WhatsApp tenant credentials
- add the small shared helpers used by the channel surface (`InfoCard`, copy-to-clipboard, stable dev auth token reference)

## Launch posture
- stacked on #156 (`feat-hosted-ai-providers-dark-launch`) to reuse shared entity/API error primitives
- dark launch only: no sidebar or command palette entry is added
- hosted backend/runtime implementation stays outside this repo

## Verification
- `bun test apps/web/src/hosted/oss-clean.test.ts apps/web/src/lib/api-errors.test.ts`
- `bun run typecheck`
- `bun run check`
- `git diff --check`