### PR TITLE
Preserve disabled Hermes hosted runtime manifests

### DIFF
--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -116,7 +116,7 @@ function isKnownRuntime(s: string): s is Runtime {
 
 /**
  * One deployment fans out to one tile per running runtime. OpenClaw
- * (:18789) and Hermes (:18793) are completely separate dashboard
+ * (:18789) and Hermes (:9119) are completely separate dashboard
  * surfaces in clawdi.ai — different web servers, capability sets,
  * management URLs — so the unified grid renders them as distinct
  * agents.

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -533,12 +533,14 @@ function hostedRuntimeEntries(
 ): HostedRuntimeManifest["runtimes"] {
 	const token = process.env[UI_ACCESS_TOKEN_ENV]?.trim();
 	if (!token) return runtimes;
+	const hermes = runtimes.hermes;
+	if (hermes?.enabled === false) return runtimes;
 	return {
 		...runtimes,
 		hermes: {
-			...runtimes.hermes,
+			...hermes,
 			enabled: true,
-			install: runtimes.hermes?.install ?? { source: "official" },
+			install: hermes?.install ?? { source: "official" },
 		},
 	};
 }

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -49,6 +49,7 @@ import {
 	type SupportedRuntimeName,
 	writeRuntimeRunConfig,
 } from "./run-config";
+import { UI_BRIDGE_LISTEN_HOST_ENV } from "./ui-bridge";
 
 export interface RuntimeConvergenceResult {
 	manifest: RuntimeManifest;
@@ -1195,6 +1196,7 @@ function writeSupervisorConfig(
 		CLAWDI_SERVICE_STATE_DIR: paths.serviceStateRoot,
 		CLAWDI_RUN_DIR: paths.runRoot,
 		CLAWDI_HOST_POLICY_PATH: paths.hostPolicy,
+		[UI_BRIDGE_LISTEN_HOST_ENV]: process.env[UI_BRIDGE_LISTEN_HOST_ENV]?.trim() ?? "",
 		PATH: supervisorPath(paths),
 	};
 	const watcherEnvironment = supervisorEnvironment({

--- a/packages/cli/src/runtime/run-config.ts
+++ b/packages/cli/src/runtime/run-config.ts
@@ -45,7 +45,7 @@ const runtimeRunConfigSchema = z
 export type RuntimeRunConfig = z.infer<typeof runtimeRunConfigSchema>;
 
 const DEFAULT_RUNTIME_ARGS: Record<SupportedRuntimeName, string[]> = {
-	hermes: ["dashboard", "--host", "127.0.0.1", "--port", "18793", "--no-open"],
+	hermes: ["dashboard", "--host", "127.0.0.1", "--no-open"],
 	openclaw: [
 		"gateway",
 		"run",

--- a/packages/cli/src/runtime/ui-bridge.ts
+++ b/packages/cli/src/runtime/ui-bridge.ts
@@ -4,6 +4,8 @@ import { createConnection, createServer, isIP, type Server, type Socket } from "
 export const UI_ACCESS_TOKEN_ENV = "UI_ACCESS_TOKEN";
 export const UI_ACCESS_COOKIE = "clawdi_ui";
 export const UI_FRAME_ANCESTORS_ENV = "CLAWDI_UI_FRAME_ANCESTORS";
+export const UI_BRIDGE_LISTEN_HOST_ENV = "CLAWDI_UI_BRIDGE_LISTEN_HOST";
+export const KUBERNETES_POD_IP_ENV = "POD_IP";
 export const DEFAULT_UI_FRAME_ANCESTORS = "'self' https://*.clawdi.ai";
 
 export interface RuntimeUiBridgeTarget {
@@ -52,16 +54,16 @@ export const DEFAULT_UI_BRIDGE_TARGETS: RuntimeUiBridgeTarget[] = [
 	{
 		name: "openclaw",
 		listenHost: "0.0.0.0",
-		listenPort: 28789,
+		listenPort: 18789,
 		targetHost: "127.0.0.1",
 		targetPort: 18789,
 	},
 	{
 		name: "hermes",
 		listenHost: "0.0.0.0",
-		listenPort: 28793,
+		listenPort: 9119,
 		targetHost: "127.0.0.1",
-		targetPort: 18793,
+		targetPort: 9119,
 	},
 ];
 
@@ -94,7 +96,7 @@ export async function startRuntimeUiBridge(
 	options: RuntimeUiBridgeOptions = {},
 ): Promise<RuntimeUiBridgeServer> {
 	const token = options.token ?? process.env[UI_ACCESS_TOKEN_ENV]?.trim() ?? "";
-	const targets = options.targets ?? DEFAULT_UI_BRIDGE_TARGETS;
+	const targets = options.targets ?? defaultRuntimeUiBridgeTargets();
 	const frameAncestors =
 		options.frameAncestors?.trim() ||
 		process.env[UI_FRAME_ANCESTORS_ENV]?.trim() ||
@@ -120,6 +122,14 @@ export async function startRuntimeUiBridge(
 			await Promise.allSettled(servers.map((server) => closeServer(server)));
 		},
 	};
+}
+
+export function defaultRuntimeUiBridgeTargets(): RuntimeUiBridgeTarget[] {
+	const listenHost =
+		process.env[UI_BRIDGE_LISTEN_HOST_ENV]?.trim() ||
+		process.env[KUBERNETES_POD_IP_ENV]?.trim() ||
+		"0.0.0.0";
+	return DEFAULT_UI_BRIDGE_TARGETS.map((target) => ({ ...target, listenHost }));
 }
 
 function createBridgeServer(

--- a/packages/cli/src/runtime/ui-bridge.ts
+++ b/packages/cli/src/runtime/ui-bridge.ts
@@ -5,7 +5,6 @@ export const UI_ACCESS_TOKEN_ENV = "UI_ACCESS_TOKEN";
 export const UI_ACCESS_COOKIE = "clawdi_ui";
 export const UI_FRAME_ANCESTORS_ENV = "CLAWDI_UI_FRAME_ANCESTORS";
 export const UI_BRIDGE_LISTEN_HOST_ENV = "CLAWDI_UI_BRIDGE_LISTEN_HOST";
-export const KUBERNETES_POD_IP_ENV = "POD_IP";
 export const DEFAULT_UI_FRAME_ANCESTORS = "'self' https://*.clawdi.ai";
 
 export interface RuntimeUiBridgeTarget {
@@ -125,10 +124,7 @@ export async function startRuntimeUiBridge(
 }
 
 export function defaultRuntimeUiBridgeTargets(): RuntimeUiBridgeTarget[] {
-	const listenHost =
-		process.env[UI_BRIDGE_LISTEN_HOST_ENV]?.trim() ||
-		process.env[KUBERNETES_POD_IP_ENV]?.trim() ||
-		"0.0.0.0";
+	const listenHost = process.env[UI_BRIDGE_LISTEN_HOST_ENV]?.trim() || "0.0.0.0";
 	return DEFAULT_UI_BRIDGE_TARGETS.map((target) => ({ ...target, listenHost }));
 }
 

--- a/packages/cli/tests/runtime-ui-bridge.test.ts
+++ b/packages/cli/tests/runtime-ui-bridge.test.ts
@@ -3,9 +3,53 @@ import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
 import { connect, createServer as createNetServer, type Server as NetServer } from "node:net";
 import {
 	DEFAULT_UI_BRIDGE_TARGETS,
+	defaultRuntimeUiBridgeTargets,
+	KUBERNETES_POD_IP_ENV,
 	startRuntimeUiBridge,
 	UI_ACCESS_COOKIE,
+	UI_BRIDGE_LISTEN_HOST_ENV,
 } from "../src/runtime/ui-bridge";
+
+describe("runtime UI bridge defaults", () => {
+	it("uses the official runtime UI ports by default", () => {
+		withBridgeListenEnv({}, () => {
+			expect(defaultRuntimeUiBridgeTargets()).toEqual([
+				{
+					name: "openclaw",
+					listenHost: "0.0.0.0",
+					listenPort: 18789,
+					targetHost: "127.0.0.1",
+					targetPort: 18789,
+				},
+				{
+					name: "hermes",
+					listenHost: "0.0.0.0",
+					listenPort: 9119,
+					targetHost: "127.0.0.1",
+					targetPort: 9119,
+				},
+			]);
+		});
+	});
+
+	it("honors the explicit bridge listen host", () => {
+		withBridgeListenEnv({ [UI_BRIDGE_LISTEN_HOST_ENV]: "10.42.0.20" }, () => {
+			expect(defaultRuntimeUiBridgeTargets().map((target) => target.listenHost)).toEqual([
+				"10.42.0.20",
+				"10.42.0.20",
+			]);
+		});
+	});
+
+	it("falls back to the Kubernetes Pod IP for the bridge listen host", () => {
+		withBridgeListenEnv({ [KUBERNETES_POD_IP_ENV]: "10.42.0.21" }, () => {
+			expect(defaultRuntimeUiBridgeTargets().map((target) => target.listenHost)).toEqual([
+				"10.42.0.21",
+				"10.42.0.21",
+			]);
+		});
+	});
+});
 
 describe("runtime UI bridge", () => {
 	it("authenticates with query token, sets a cookie, and proxies cookie-authorized HTTP", async () => {
@@ -444,9 +488,9 @@ describe("runtime UI bridge", () => {
 				port: bridgePort,
 				path: "/api/ws?token=hermes-session&channel=chat-1",
 				cookie: `${UI_ACCESS_COOKIE}=hermes-bridge-token`,
-				host: "agent-18793.phala-prod2.clawdi.ai",
-				origin: "https://agent-18793.phala-prod2.clawdi.ai",
-				referer: "https://agent-18793.phala-prod2.clawdi.ai/chat",
+				host: "agent-9119.phala-prod2.clawdi.ai",
+				origin: "https://agent-9119.phala-prod2.clawdi.ai",
+				referer: "https://agent-9119.phala-prod2.clawdi.ai/chat",
 				headers: forwardingHeaderLines(),
 			});
 
@@ -457,7 +501,7 @@ describe("runtime UI bridge", () => {
 			expect(upstreamRequest).toContain(`Referer: http://127.0.0.1:${upstreamPort}/chat`);
 			expect(upstreamRequest).toContain("X-App-Header: keep-me");
 			expectForwardingHeadersStripped(upstreamRequest);
-			expect(upstreamRequest).not.toContain("agent-18793.phala-prod2.clawdi.ai");
+			expect(upstreamRequest).not.toContain("agent-9119.phala-prod2.clawdi.ai");
 			expect(upstreamRequest).not.toContain(UI_ACCESS_COOKIE);
 		} finally {
 			await bridge.close();
@@ -537,6 +581,25 @@ function forwardingHeaderLines(): string[] {
 		'CF-Visitor: {"scheme":"https"}',
 		"CF-Worker: worker-name",
 	];
+}
+
+function withBridgeListenEnv(values: Record<string, string>, fn: () => void): void {
+	const keys = [UI_BRIDGE_LISTEN_HOST_ENV, KUBERNETES_POD_IP_ENV];
+	const previous = new Map(keys.map((key) => [key, process.env[key]]));
+	try {
+		for (const key of keys) delete process.env[key];
+		for (const [key, value] of Object.entries(values)) process.env[key] = value;
+		fn();
+	} finally {
+		for (const key of keys) {
+			const value = previous.get(key);
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	}
 }
 
 function expectForwardingHeadersStripped(rawRequest: string): void {

--- a/packages/cli/tests/runtime-ui-bridge.test.ts
+++ b/packages/cli/tests/runtime-ui-bridge.test.ts
@@ -4,7 +4,6 @@ import { connect, createServer as createNetServer, type Server as NetServer } fr
 import {
 	DEFAULT_UI_BRIDGE_TARGETS,
 	defaultRuntimeUiBridgeTargets,
-	KUBERNETES_POD_IP_ENV,
 	startRuntimeUiBridge,
 	UI_ACCESS_COOKIE,
 	UI_BRIDGE_LISTEN_HOST_ENV,
@@ -37,15 +36,6 @@ describe("runtime UI bridge defaults", () => {
 			expect(defaultRuntimeUiBridgeTargets().map((target) => target.listenHost)).toEqual([
 				"10.42.0.20",
 				"10.42.0.20",
-			]);
-		});
-	});
-
-	it("falls back to the Kubernetes Pod IP for the bridge listen host", () => {
-		withBridgeListenEnv({ [KUBERNETES_POD_IP_ENV]: "10.42.0.21" }, () => {
-			expect(defaultRuntimeUiBridgeTargets().map((target) => target.listenHost)).toEqual([
-				"10.42.0.21",
-				"10.42.0.21",
 			]);
 		});
 	});
@@ -280,13 +270,13 @@ describe("runtime UI bridge", () => {
 					"X-App-Header": "keep-me",
 					"X-Forwarded": "legacy",
 					"X-Forwarded-For": "10.42.0.1",
-					"X-Forwarded-Host": "agent-18789.phala-prod2.clawdi.ai",
+					"X-Forwarded-Host": "agent-18789.gateway.example.test",
 					"X-Forwarded-Port": "443",
 					"X-Forwarded-Prefix": "/control",
 					"X-Forwarded-Proto": "https",
 					"X-Forwarded-Server": "ingress",
 					"X-Real-IP": "198.51.100.8",
-					Forwarded: "for=10.42.0.1;proto=https;host=agent-18789.phala-prod2.clawdi.ai",
+					Forwarded: "for=10.42.0.1;proto=https;host=agent-18789.gateway.example.test",
 					"CF-Connecting-IP": "198.51.100.9",
 					"CF-IPCountry": "US",
 					"CF-Ray": "ray-id",
@@ -419,9 +409,9 @@ describe("runtime UI bridge", () => {
 				port: bridgePort,
 				path: "/control/?session=abc",
 				cookie: `${UI_ACCESS_COOKIE}=openclaw-token; app_cookie=keep`,
-				host: "agent-18789.phala-prod2.clawdi.ai",
-				origin: "https://agent-18789.phala-prod2.clawdi.ai",
-				referer: "https://agent-18789.phala-prod2.clawdi.ai/control/?session=abc",
+				host: "agent-18789.gateway.example.test",
+				origin: "https://agent-18789.gateway.example.test",
+				referer: "https://agent-18789.gateway.example.test/control/?session=abc",
 				headers: forwardingHeaderLines(),
 			});
 
@@ -435,7 +425,7 @@ describe("runtime UI bridge", () => {
 			expect(upstreamRequest).toContain("Cookie: app_cookie=keep");
 			expect(upstreamRequest).toContain("X-App-Header: keep-me");
 			expectForwardingHeadersStripped(upstreamRequest);
-			expect(upstreamRequest).not.toContain("agent-18789.phala-prod2.clawdi.ai");
+			expect(upstreamRequest).not.toContain("agent-18789.gateway.example.test");
 			expect(upstreamRequest).not.toContain(UI_ACCESS_COOKIE);
 		} finally {
 			await bridge.close();
@@ -488,9 +478,9 @@ describe("runtime UI bridge", () => {
 				port: bridgePort,
 				path: "/api/ws?token=hermes-session&channel=chat-1",
 				cookie: `${UI_ACCESS_COOKIE}=hermes-bridge-token`,
-				host: "agent-9119.phala-prod2.clawdi.ai",
-				origin: "https://agent-9119.phala-prod2.clawdi.ai",
-				referer: "https://agent-9119.phala-prod2.clawdi.ai/chat",
+				host: "agent-9119.gateway.example.test",
+				origin: "https://agent-9119.gateway.example.test",
+				referer: "https://agent-9119.gateway.example.test/chat",
 				headers: forwardingHeaderLines(),
 			});
 
@@ -501,7 +491,7 @@ describe("runtime UI bridge", () => {
 			expect(upstreamRequest).toContain(`Referer: http://127.0.0.1:${upstreamPort}/chat`);
 			expect(upstreamRequest).toContain("X-App-Header: keep-me");
 			expectForwardingHeadersStripped(upstreamRequest);
-			expect(upstreamRequest).not.toContain("agent-9119.phala-prod2.clawdi.ai");
+			expect(upstreamRequest).not.toContain("agent-9119.gateway.example.test");
 			expect(upstreamRequest).not.toContain(UI_ACCESS_COOKIE);
 		} finally {
 			await bridge.close();
@@ -568,13 +558,13 @@ function forwardingHeaderLines(): string[] {
 		"X-App-Header: keep-me",
 		"X-Forwarded: legacy",
 		"X-Forwarded-For: 10.42.0.1",
-		"X-Forwarded-Host: agent-18789.phala-prod2.clawdi.ai",
+		"X-Forwarded-Host: agent-18789.gateway.example.test",
 		"X-Forwarded-Port: 443",
 		"X-Forwarded-Prefix: /control",
 		"X-Forwarded-Proto: https",
 		"X-Forwarded-Server: ingress",
 		"X-Real-IP: 198.51.100.8",
-		"Forwarded: for=10.42.0.1;proto=https;host=agent-18789.phala-prod2.clawdi.ai",
+		"Forwarded: for=10.42.0.1;proto=https;host=agent-18789.gateway.example.test",
 		"CF-Connecting-IP: 198.51.100.9",
 		"CF-IPCountry: US",
 		"CF-Ray: ray-id",
@@ -584,7 +574,7 @@ function forwardingHeaderLines(): string[] {
 }
 
 function withBridgeListenEnv(values: Record<string, string>, fn: () => void): void {
-	const keys = [UI_BRIDGE_LISTEN_HOST_ENV, KUBERNETES_POD_IP_ENV];
+	const keys = [UI_BRIDGE_LISTEN_HOST_ENV];
 	const previous = new Map(keys.map((key) => [key, process.env[key]]));
 	try {
 		for (const key of keys) delete process.env[key];

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -564,7 +564,7 @@ describe("runtime manifest datasource", () => {
 		}
 	});
 
-	it("enables Hermes in hosted-runtime manifests when the UI bridge token is present", async () => {
+	it("adds Hermes to legacy hosted-runtime manifests when the UI bridge token is present", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -589,7 +589,6 @@ describe("runtime manifest datasource", () => {
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					runtimes: {
 						openclaw: { enabled: true, install: { source: "official" }, paths: { home } },
-						hermes: { enabled: false, install: { source: "official" }, paths: { home } },
 					},
 				},
 				secretValues: {},
@@ -609,6 +608,46 @@ describe("runtime manifest datasource", () => {
 			"--skip-browser",
 			"--non-interactive",
 		]);
+	});
+
+	it("keeps Hermes disabled when a hosted-runtime manifest explicitly disables it", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const manifestPath = join(root, "hosted-ui-token-hermes-disabled.json");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env[UI_ACCESS_TOKEN_ENV] = "ui-token";
+		writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				manifest: {
+					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					deploymentId: "dep_ui_token_explicit",
+					environmentId: "env_ui_token_explicit",
+					instanceId: "iid_ui_token_explicit",
+					generation: 1,
+					issuedAt: "2026-06-15T00:00:00Z",
+					system: { home },
+					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+					runtimes: {
+						openclaw: { enabled: true, install: { source: "official" }, paths: { home } },
+						hermes: { enabled: false, install: { source: "official" }, paths: { home } },
+					},
+				},
+				secretValues: {},
+			}),
+		);
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths(), { manifestPath });
+
+		expect("manifest" in loaded).toBe(true);
+		if (!("manifest" in loaded)) throw new Error("expected manifest load success");
+		expect(loaded.manifest.runtimes.hermes.enabled).toBe(false);
+		expect(loaded.manifest.runtimes.hermes.install).toBeUndefined();
 	});
 
 	it("honors the auth env declared by the runtime source", async () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -41,7 +41,7 @@ import {
 	writeRuntimeBootStatus,
 	writeRuntimeWatchStatus,
 } from "../src/runtime/state";
-import { UI_ACCESS_TOKEN_ENV } from "../src/runtime/ui-bridge";
+import { UI_ACCESS_TOKEN_ENV, UI_BRIDGE_LISTEN_HOST_ENV } from "../src/runtime/ui-bridge";
 import { jsonResponse, mockFetch } from "./commands/helpers";
 
 const ENV_KEYS = [
@@ -67,6 +67,7 @@ const ENV_KEYS = [
 	"CLAWDI_SUPERVISORCTL_PATH",
 	"CLAWDI_RUNTIME_USER",
 	UI_ACCESS_TOKEN_ENV,
+	UI_BRIDGE_LISTEN_HOST_ENV,
 ] as const;
 
 type EnvKey = (typeof ENV_KEYS)[number];
@@ -239,7 +240,7 @@ describe("runtime paths", () => {
 });
 
 describe("runtime run config", () => {
-	it("starts Hermes dashboard on loopback port 18793 by default", () => {
+	it("starts Hermes dashboard on its default loopback port", () => {
 		const config = buildRuntimeRunConfig({
 			runtime: "hermes",
 			enabled: true,
@@ -251,14 +252,7 @@ describe("runtime run config", () => {
 			workspaceRoot: "/home/clawdi/clawdi",
 		});
 
-		expect(config.defaultArgs).toEqual([
-			"dashboard",
-			"--host",
-			"127.0.0.1",
-			"--port",
-			"18793",
-			"--no-open",
-		]);
+		expect(config.defaultArgs).toEqual(["dashboard", "--host", "127.0.0.1", "--no-open"]);
 	});
 });
 
@@ -3165,6 +3159,7 @@ exit 64
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env[UI_ACCESS_TOKEN_ENV] = "ui-secret";
+		process.env[UI_BRIDGE_LISTEN_HOST_ENV] = "10.42.0.20";
 
 		const convergence = convergeRuntimeManifest(
 			{
@@ -3193,6 +3188,7 @@ exit 64
 		const supervisorConfig = readFileSync(convergence.outputs.supervisorConfig, "utf-8");
 		expect(supervisorConfig).toContain("[program:clawdi-ui-bridge]");
 		expect(supervisorConfig).toContain("command=/usr/bin/env clawdi runtime ui-bridge");
+		expect(supervisorConfig).toContain('CLAWDI_UI_BRIDGE_LISTEN_HOST="10.42.0.20"');
 		expect(supervisorConfig).toContain('CLAWDI_RUNTIME_REV="');
 		expect(supervisorConfig).not.toContain("ui-secret");
 	});


### PR DESCRIPTION
## Summary
- keep explicit `runtimes.hermes.enabled=false` when a hosted-runtime manifest includes a UI bridge token
- continue backfilling Hermes only for legacy hosted manifests that omit the Hermes entry
- add regression coverage for the explicit-disabled case

## Why
Prod2 OpenClaw-only smoke validated that disabled runtime UI ports must stay disabled. This CLI-side fix prevents a UI bridge token from re-enabling Hermes after the backend sends an explicit disabled runtime entry.

## Verification
- `bun test packages/cli/tests/runtime.test.ts`
- `bun run typecheck`
- `bun run check`
- `git diff --check`