### PR TITLE
Harden Coolify runtime process handling

### DIFF
--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -129,7 +129,7 @@ jobs:
           readarray -t files <<< "$changed_files"
           for file in "${files[@]}"; do
             case "$file" in
-              backend/*|.dockerignore)
+              backend/*|.dockerignore|infra/deploy/coolify/production-stack.json|infra/deploy/coolify/deploy_ghcr_runtime.py|.github/workflows/clawdi-image-release.yml)
                 build=true
                 ;;
             esac

--- a/backend/tests/test_coolify_runtime_deploy.py
+++ b/backend/tests/test_coolify_runtime_deploy.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+COOLIFY_DIR = Path(__file__).resolve().parents[2] / "infra" / "deploy" / "coolify"
+
+
+def _load_deploy_module():
+    path = COOLIFY_DIR / "deploy_ghcr_runtime.py"
+    spec = importlib.util.spec_from_file_location("coolify_deploy_ghcr_runtime", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_runtime_update_payload_syncs_custom_docker_run_options():
+    module = _load_deploy_module()
+
+    payload = module.runtime_update_payload(
+        expected={
+            "fields": {
+                "custom_docker_run_options": (
+                    "--init --add-host=host.docker.internal:host-gateway"
+                ),
+                "limits_memory": "2g",
+            }
+        },
+        image="ghcr.io/clawdi-ai/clawdi-backend",
+        tag="a" * 40,
+    )
+
+    assert payload == {
+        "docker_registry_image_name": "ghcr.io/clawdi-ai/clawdi-backend",
+        "docker_registry_image_tag": "a" * 40,
+        "git_commit_sha": "a" * 40,
+        "custom_docker_run_options": "--init --add-host=host.docker.internal:host-gateway",
+    }
+
+
+def test_production_stack_uses_init_without_nproc_ulimits():
+    payload = json.loads((COOLIFY_DIR / "production-stack.json").read_text())
+
+    for app_name, app in payload["applications"].items():
+        options = app["fields"]["custom_docker_run_options"]
+        assert options.startswith("--init "), app_name
+        assert "--ulimit nproc=" not in options, app_name

--- a/infra/deploy/coolify/README.md
+++ b/infra/deploy/coolify/README.md
@@ -105,6 +105,12 @@ Application keeps the `--add-host=host.docker.internal:host-gateway` run option
 from the stack manifest. If your database is a Coolify resource or an external
 managed database, set `DATABASE_URL` to that hostname instead.
 
+Runtime Applications should keep Docker `--init` in
+`custom_docker_run_options`. Docker health checks and short-lived child
+processes can otherwise accumulate as zombies under Python PID 1 processes.
+Keep the high `nofile` ulimit for descriptor-heavy channel/runtime traffic, but
+do not add low per-user `nproc` limits.
+
 ## Audit
 
 Validate the template locally:
@@ -170,11 +176,12 @@ dispatches audit with `--phase live --expect-commit <full-git-sha>`.
 
 Automatic releases can be enabled after the Coolify stack is the live runtime.
 When `Backend CI` succeeds on `main`, `.github/workflows/clawdi-image-release.yml`
-checks whether backend image inputs changed. If they did, and the repository
-variable `CLAWDI_COOLIFY_AUTO_DEPLOY` is set to `true`, the workflow builds the
-backend image, deploys the `all` scope through Coolify, waits for completion,
-and runs the live audit. If backend image inputs did not change, the automatic
-path runs a live audit without publishing or deploying a new image.
+checks whether backend image inputs or the checked-in Coolify runtime contract
+changed. If they did, and the repository variable `CLAWDI_COOLIFY_AUTO_DEPLOY`
+is set to `true`, the workflow builds the backend image, deploys the `all`
+scope through Coolify, waits for completion, and runs the live audit. If
+backend image/runtime deploy inputs did not change, the automatic path runs a
+live audit without publishing or deploying a new image.
 
 The workflow uses the public `production-stack.json` template by default, which
 is safe because deploy only needs the app names, roles, and deployment tag to

--- a/infra/deploy/coolify/deploy_ghcr_runtime.py
+++ b/infra/deploy/coolify/deploy_ghcr_runtime.py
@@ -24,6 +24,7 @@ TERMINAL_FAILURE = {
     "failed:healthcheck",
     "failed:rollback",
 }
+SYNCED_APPLICATION_FIELDS = ("custom_docker_run_options",)
 
 
 def log(message: str) -> None:
@@ -229,6 +230,25 @@ def deploy_application(
     return deployment_uuid
 
 
+def runtime_update_payload(
+    *,
+    expected: dict[str, Any],
+    image: str,
+    tag: str,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "docker_registry_image_name": image,
+        "docker_registry_image_tag": tag,
+        "git_commit_sha": tag,
+    }
+    fields = expected.get("fields", {})
+    if isinstance(fields, dict):
+        for field in SYNCED_APPLICATION_FIELDS:
+            if field in fields:
+                payload[field] = fields[field]
+    return payload
+
+
 def deploy_applications(
     *,
     api_url: str,
@@ -369,11 +389,11 @@ def main() -> int:
             token=args.token,
             method="PATCH",
             path=f"/api/v1/applications/{app_uuid}",
-            payload={
-                "docker_registry_image_name": args.image,
-                "docker_registry_image_tag": args.tag,
-                "git_commit_sha": args.tag,
-            },
+            payload=runtime_update_payload(
+                expected=expected,
+                image=args.image,
+                tag=args.tag,
+            ),
         )
         log(f"{app_name}: image_tag=updated uuid={app_uuid}")
 

--- a/infra/deploy/coolify/production-stack.json
+++ b/infra/deploy/coolify/production-stack.json
@@ -58,7 +58,7 @@
 				"limits_memory": "2g",
 				"limits_cpus": "2",
 				"start_command": "cd /app/backend && alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000",
-				"custom_docker_run_options": "--add-host=host.docker.internal:host-gateway --ulimit nofile=65535:65535"
+				"custom_docker_run_options": "--init --add-host=host.docker.internal:host-gateway --ulimit nofile=65535:65535"
 			},
 			"storages": [
 				{
@@ -91,7 +91,7 @@
 				"limits_memory": "1g",
 				"limits_cpus": "1",
 				"start_command": "cd /app/backend && exec python -m app.workers.channels",
-				"custom_docker_run_options": "--add-host=host.docker.internal:host-gateway --ulimit nofile=65535:65535"
+				"custom_docker_run_options": "--init --add-host=host.docker.internal:host-gateway --ulimit nofile=65535:65535"
 			},
 			"storages": [
 				{


### PR DESCRIPTION
## Summary

Harden the Coolify production runtime contract for the legacy Clawdi backend stack:

- add Docker `--init` to both `clawdi-backend` and `clawdi-channels-worker`
- keep the existing high `nofile` ulimit, but avoid low `nproc` limits
- sync `custom_docker_run_options` through the Coolify deploy script alongside the image tag
- include Coolify runtime contract/deploy workflow changes in the image release trigger
- document the runtime process handling contract

This is the same root-cause class fixed in `clawdi-hosted`: avoid unreaped child processes under Python PID 1 and avoid host UID process-limit collisions from low `nproc` ulimits.

## Verification

- `uv run pytest tests/test_coolify_runtime_deploy.py -q`
- `uv run ruff check tests/test_coolify_runtime_deploy.py`
- `python3 -m py_compile infra/deploy/coolify/deploy_ghcr_runtime.py infra/deploy/coolify/audit_stack.py`
- `python3 -m json.tool infra/deploy/coolify/production-stack.json >/dev/null`
- `git diff --check`
