### PR TITLE
Skip null Coolify application fields

### DIFF
--- a/backend/tests/test_coolify_runtime_deploy.py
+++ b/backend/tests/test_coolify_runtime_deploy.py
@@ -28,6 +28,7 @@ def test_application_patch_payload_reconciles_manifest_fields_without_placeholde
                 "git_commit_sha": "EXPECT_COMMIT",
                 "build_pack": "dockerimage",
                 "fqdn": "CONFIGURE_IN_COOLIFY",
+                "ports_exposes": None,
                 "start_command": "cd /app/backend && exec python -m app.workers.channels",
                 "custom_docker_run_options": (
                     "--init --add-host=host.docker.internal:host-gateway"

--- a/infra/deploy/coolify/deploy_ghcr_runtime.py
+++ b/infra/deploy/coolify/deploy_ghcr_runtime.py
@@ -287,6 +287,8 @@ def application_patch_payload(
     for field, value in expected.get("fields", {}).items():
         if field == "build_pack":
             continue
+        if value is None:
+            continue
         if value == CONFIGURE_IN_COOLIFY_PLACEHOLDER:
             continue
         if value == EXPECT_COMMIT_PLACEHOLDER:


### PR DESCRIPTION
## Summary
- omit null fields from Coolify Application PATCH payloads
- cover worker ports_exposes=null so worker deployments do not send an invalid Coolify field value

## Verification
- cd backend && uv run pytest -q tests/test_coolify_runtime_deploy.py
- cd backend && uv run ruff check tests/test_coolify_runtime_deploy.py ../infra/deploy/coolify/deploy_ghcr_runtime.py
- git diff --check