### PR TITLE
Fix Coolify runtime role entrypoint

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -34,4 +34,4 @@ USER app
 
 EXPOSE 8000
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python", "-m", "app.runtime_entrypoint"]

--- a/backend/app/runtime_entrypoint.py
+++ b/backend/app/runtime_entrypoint.py
@@ -1,0 +1,35 @@
+import os
+import sys
+
+API_ROLE = "api"
+CHANNELS_WORKER_ROLE = "channels-worker"
+
+
+def _exec(args: list[str]) -> None:
+    os.execvp(args[0], args)
+
+
+def main() -> None:
+    role = os.environ.get("CLAWDI_PROCESS_ROLE", API_ROLE).strip() or API_ROLE
+
+    if role == API_ROLE:
+        _exec(
+            [
+                "sh",
+                "-c",
+                "alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000",
+            ]
+        )
+    if role == CHANNELS_WORKER_ROLE:
+        _exec(["python", "-m", "app.workers.channels"])
+
+    print(
+        f"Unsupported CLAWDI_PROCESS_ROLE={role!r}; expected "
+        f"{API_ROLE!r} or {CHANNELS_WORKER_ROLE!r}.",
+        file=sys.stderr,
+    )
+    raise SystemExit(64)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_coolify_runtime_deploy.py
+++ b/backend/tests/test_coolify_runtime_deploy.py
@@ -35,9 +35,9 @@ def test_application_patch_payload_reconciles_manifest_fields_without_placeholde
                 "health_check_interval": 5,
                 "health_check_retries": 12,
                 "health_check_start_period": 20,
-                "start_command": "cd /app/backend && exec python -m app.workers.channels",
                 "custom_docker_run_options": (
-                    "--init --add-host=host.docker.internal:host-gateway"
+                    "--init --env CLAWDI_PROCESS_ROLE=channels-worker "
+                    "--add-host=host.docker.internal:host-gateway"
                 ),
             }
         },
@@ -54,8 +54,10 @@ def test_application_patch_payload_reconciles_manifest_fields_without_placeholde
         "health_check_interval": 5,
         "health_check_retries": 12,
         "health_check_start_period": 20,
-        "start_command": "cd /app/backend && exec python -m app.workers.channels",
-        "custom_docker_run_options": "--init --add-host=host.docker.internal:host-gateway",
+        "custom_docker_run_options": (
+            "--init --env CLAWDI_PROCESS_ROLE=channels-worker "
+            "--add-host=host.docker.internal:host-gateway"
+        ),
         "docker_registry_image_name": "ghcr.io/clawdi-ai/clawdi-backend",
         "docker_registry_image_tag": "1370164c7b837280be9918ca3eb65b084cb32376",
     }
@@ -68,3 +70,16 @@ def test_production_stack_uses_init_without_nproc_ulimits():
         options = app["fields"]["custom_docker_run_options"]
         assert options.startswith("--init "), app_name
         assert "--ulimit nproc=" not in options, app_name
+        assert "start_command" not in app["fields"], app_name
+
+
+def test_production_stack_assigns_runtime_roles():
+    payload = json.loads((COOLIFY_DIR / "production-stack.json").read_text())
+
+    expected_roles = {
+        "clawdi-backend": "CLAWDI_PROCESS_ROLE=api",
+        "clawdi-channels-worker": "CLAWDI_PROCESS_ROLE=channels-worker",
+    }
+    for app_name, role_option in expected_roles.items():
+        options = payload["applications"][app_name]["fields"]["custom_docker_run_options"]
+        assert f"--env {role_option}" in options, app_name

--- a/backend/tests/test_runtime_entrypoint.py
+++ b/backend/tests/test_runtime_entrypoint.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+
+from app import runtime_entrypoint
+
+
+class ExecCalled(Exception):
+    def __init__(self, args: list[str]) -> None:
+        self.args_list = args
+
+
+def _capture_exec(args: list[str]) -> None:
+    raise ExecCalled(args)
+
+
+def test_runtime_entrypoint_defaults_to_api_role(monkeypatch):
+    monkeypatch.delenv("CLAWDI_PROCESS_ROLE", raising=False)
+    monkeypatch.setattr(runtime_entrypoint, "_exec", _capture_exec)
+
+    with pytest.raises(ExecCalled) as exc:
+        runtime_entrypoint.main()
+
+    assert exc.value.args_list == [
+        "sh",
+        "-c",
+        "alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000",
+    ]
+
+
+def test_runtime_entrypoint_starts_channels_worker_role(monkeypatch):
+    monkeypatch.setenv("CLAWDI_PROCESS_ROLE", "channels-worker")
+    monkeypatch.setattr(runtime_entrypoint, "_exec", _capture_exec)
+
+    with pytest.raises(ExecCalled) as exc:
+        runtime_entrypoint.main()
+
+    assert exc.value.args_list == ["python", "-m", "app.workers.channels"]
+
+
+def test_runtime_entrypoint_rejects_unknown_role(monkeypatch):
+    monkeypatch.setenv("CLAWDI_PROCESS_ROLE", "scheduler")
+    monkeypatch.setattr(
+        runtime_entrypoint,
+        "_exec",
+        lambda _args: pytest.fail("unexpected exec"),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        runtime_entrypoint.main()
+
+    assert exc.value.code == 64

--- a/infra/deploy/coolify/README.md
+++ b/infra/deploy/coolify/README.md
@@ -27,8 +27,8 @@ deployment-specific backend image.
   environment shared variables and wire each Application env row as
   `KEY={{environment.KEY}}`.
 - `production-stack.json`: expected non-secret Application shape, image source,
-  command, storage mounts, deployment tag, and operational constraints. It is a
-  public template, not a live production value dump.
+  runtime role, storage mounts, deployment tag, and operational constraints. It
+  is a public template, not a live production value dump.
 - `audit_stack.py`: read-only live configuration audit. It checks Application
   shape, storage, env wiring, and optional deployment commit parity without
   printing secret values.
@@ -75,11 +75,19 @@ Keep `clawdi-channels-worker` at one replica. The combined worker should be
 operated as a singleton until every loop in `app.workers.channels` has an
 explicit multi-replica lease or claim contract.
 
+The Docker Image Application build pack does not use `start_command`. The
+shared backend image starts `python -m app.runtime_entrypoint`, and each
+Application selects its role through `CLAWDI_PROCESS_ROLE` in
+`custom_docker_run_options`:
+
+- `api`: runs `alembic upgrade head`, then Uvicorn on port `8000`.
+- `channels-worker`: runs `python -m app.workers.channels`.
+
 Do not add a Dockerfile-level `HEALTHCHECK` to the shared backend image. The
-same image runs both the API and worker entrypoints, so health checks belong on
-the Coolify Application. The worker process itself listens on container port
-`8000` for `/health`; keep `fqdn` and host port mappings empty so that endpoint
-remains an internal liveness probe rather than a public route.
+same image runs both the API and worker roles, so health checks belong on the
+Coolify Application. The worker process itself listens on container port `8000`
+for `/health`; keep `fqdn` and host port mappings empty so that endpoint remains
+an internal liveness probe rather than a public route.
 
 ## Runtime State
 
@@ -195,6 +203,6 @@ is safe because deploy only needs the app names, roles, and deployment tag to
 resolve live Coolify resources. Environment-specific audits should use an
 ignored local overlay with the real destination and storage values.
 
-The API start command runs `alembic upgrade head` before Uvicorn starts. Keep
-migrations backward-compatible and short enough for the API health-check startup
-budget, or run long data migrations manually before deploying the image.
+The API role runs `alembic upgrade head` before Uvicorn starts. Keep migrations
+backward-compatible and short enough for the API health-check startup budget, or
+run long data migrations manually before deploying the image.

--- a/infra/deploy/coolify/production-stack.json
+++ b/infra/deploy/coolify/production-stack.json
@@ -57,8 +57,7 @@
 				"health_check_start_period": 60,
 				"limits_memory": "2g",
 				"limits_cpus": "2",
-				"start_command": "cd /app/backend && alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000",
-				"custom_docker_run_options": "--init --add-host=host.docker.internal:host-gateway --ulimit nofile=65535:65535"
+				"custom_docker_run_options": "--init --env CLAWDI_PROCESS_ROLE=api --add-host=host.docker.internal:host-gateway --ulimit nofile=65535:65535"
 			},
 			"storages": [
 				{
@@ -95,8 +94,7 @@
 				"health_check_start_period": 20,
 				"limits_memory": "1g",
 				"limits_cpus": "1",
-				"start_command": "cd /app/backend && exec python -m app.workers.channels",
-				"custom_docker_run_options": "--init --add-host=host.docker.internal:host-gateway --ulimit nofile=65535:65535"
+				"custom_docker_run_options": "--init --env CLAWDI_PROCESS_ROLE=channels-worker --add-host=host.docker.internal:host-gateway --ulimit nofile=65535:65535"
 			},
 			"storages": [
 				{


### PR DESCRIPTION
## Summary
- route the shared backend image through a runtime role entrypoint
- set Coolify API/worker roles via docker run env options instead of ignored Docker Image start_command
- document the Docker Image build-pack behavior and add focused tests

## Verification
- uv run pytest tests/test_coolify_runtime_deploy.py tests/test_channel_workers.py tests/test_runtime_entrypoint.py -q
- uv run ruff check app tests/test_coolify_runtime_deploy.py tests/test_channel_workers.py tests/test_runtime_entrypoint.py
- uv run python -m compileall -q app
- python3 -m json.tool infra/deploy/coolify/production-stack.json >/dev/null
- git diff --check
- docker build -f backend/Dockerfile -t clawdi-backend:role-entrypoint-smoke .