### PR TITLE
Fix Coolify runtime role env

### DIFF
--- a/backend/tests/test_coolify_runtime_deploy.py
+++ b/backend/tests/test_coolify_runtime_deploy.py
@@ -18,6 +18,16 @@ def _load_deploy_module():
     return module
 
 
+def _load_audit_module():
+    path = COOLIFY_DIR / "audit_stack.py"
+    spec = importlib.util.spec_from_file_location("coolify_audit_stack", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_application_patch_payload_reconciles_manifest_fields_without_placeholders():
     module = _load_deploy_module()
 
@@ -36,8 +46,7 @@ def test_application_patch_payload_reconciles_manifest_fields_without_placeholde
                 "health_check_retries": 12,
                 "health_check_start_period": 20,
                 "custom_docker_run_options": (
-                    "--init --env CLAWDI_PROCESS_ROLE=channels-worker "
-                    "--add-host=host.docker.internal:host-gateway"
+                    "--init --add-host=host.docker.internal:host-gateway"
                 ),
             }
         },
@@ -55,12 +64,58 @@ def test_application_patch_payload_reconciles_manifest_fields_without_placeholde
         "health_check_retries": 12,
         "health_check_start_period": 20,
         "custom_docker_run_options": (
-            "--init --env CLAWDI_PROCESS_ROLE=channels-worker "
-            "--add-host=host.docker.internal:host-gateway"
+            "--init --add-host=host.docker.internal:host-gateway"
         ),
         "docker_registry_image_name": "ghcr.io/clawdi-ai/clawdi-backend",
         "docker_registry_image_tag": "1370164c7b837280be9918ca3eb65b084cb32376",
     }
+
+
+def test_application_env_payload_uses_runtime_only_literal_value():
+    module = _load_deploy_module()
+
+    assert module.application_env_payload("CLAWDI_PROCESS_ROLE", "channels-worker") == {
+        "key": "CLAWDI_PROCESS_ROLE",
+        "value": "channels-worker",
+        "is_preview": False,
+        "is_literal": True,
+        "is_multiline": False,
+        "is_shown_once": False,
+        "is_runtime": True,
+        "is_buildtime": False,
+    }
+
+
+def test_plan_application_env_actions_creates_and_updates_only_declared_keys():
+    module = _load_deploy_module()
+
+    actions = module.plan_application_env_actions(
+        rows=[
+            {
+                "key": "CLAWDI_PROCESS_ROLE",
+                "value": "{{environment.CLAWDI_PROCESS_ROLE}}",
+                "is_preview": False,
+                "is_shared": True,
+                "is_literal": False,
+                "is_runtime": True,
+                "is_buildtime": False,
+            },
+            {
+                "key": "DATABASE_URL",
+                "value": "{{environment.DATABASE_URL}}",
+                "is_preview": False,
+            },
+        ],
+        expected_env={
+            "CLAWDI_PROCESS_ROLE": "channels-worker",
+            "OTHER_RUNTIME_FLAG": "enabled",
+        },
+    )
+
+    assert actions == [
+        module.ApplicationEnvAction("update", "CLAWDI_PROCESS_ROLE"),
+        module.ApplicationEnvAction("create", "OTHER_RUNTIME_FLAG"),
+    ]
 
 
 def test_production_stack_uses_init_without_nproc_ulimits():
@@ -70,6 +125,7 @@ def test_production_stack_uses_init_without_nproc_ulimits():
         options = app["fields"]["custom_docker_run_options"]
         assert options.startswith("--init "), app_name
         assert "--ulimit nproc=" not in options, app_name
+        assert "--env CLAWDI_PROCESS_ROLE=" not in options, app_name
         assert "start_command" not in app["fields"], app_name
 
 
@@ -77,9 +133,83 @@ def test_production_stack_assigns_runtime_roles():
     payload = json.loads((COOLIFY_DIR / "production-stack.json").read_text())
 
     expected_roles = {
-        "clawdi-backend": "CLAWDI_PROCESS_ROLE=api",
-        "clawdi-channels-worker": "CLAWDI_PROCESS_ROLE=channels-worker",
+        "clawdi-backend": "api",
+        "clawdi-channels-worker": "channels-worker",
     }
-    for app_name, role_option in expected_roles.items():
-        options = payload["applications"][app_name]["fields"]["custom_docker_run_options"]
-        assert f"--env {role_option}" in options, app_name
+    for app_name, role in expected_roles.items():
+        app_env = payload["applications"][app_name]["application_env"]
+        assert app_env == {"CLAWDI_PROCESS_ROLE": role}, app_name
+
+
+def test_audit_env_accepts_shared_manifest_and_application_env(monkeypatch):
+    module = _load_audit_module()
+
+    def fake_request_json(**_kwargs):
+        return {
+            "data": [
+                {
+                    "key": "DATABASE_URL",
+                    "value": "{{environment.DATABASE_URL}}",
+                    "real_value": "postgresql+asyncpg://example",
+                    "is_preview": False,
+                    "is_shared": True,
+                    "is_runtime": True,
+                    "is_buildtime": False,
+                },
+                {
+                    "key": "CLAWDI_PROCESS_ROLE",
+                    "value": "channels-worker",
+                    "is_preview": False,
+                    "is_shared": False,
+                    "is_literal": True,
+                    "is_runtime": True,
+                    "is_buildtime": False,
+                },
+            ]
+        }
+
+    monkeypatch.setattr(module, "request_json", fake_request_json)
+
+    errors, digests = module.audit_env(
+        api_url="https://coolify.example.com",
+        token="token",
+        app_name="clawdi-channels-worker",
+        app_uuid="app-uuid",
+        expected_shared_keys={"DATABASE_URL"},
+        expected_application_env={"CLAWDI_PROCESS_ROLE": "channels-worker"},
+    )
+
+    assert errors == []
+    assert set(digests) == {"DATABASE_URL"}
+
+
+def test_audit_env_rejects_wrong_application_env_value(monkeypatch):
+    module = _load_audit_module()
+
+    def fake_request_json(**_kwargs):
+        return {
+            "data": [
+                {
+                    "key": "CLAWDI_PROCESS_ROLE",
+                    "value": "api",
+                    "is_preview": False,
+                    "is_shared": False,
+                    "is_literal": True,
+                    "is_runtime": True,
+                    "is_buildtime": False,
+                },
+            ]
+        }
+
+    monkeypatch.setattr(module, "request_json", fake_request_json)
+
+    errors, _digests = module.audit_env(
+        api_url="https://coolify.example.com",
+        token="token",
+        app_name="clawdi-channels-worker",
+        app_uuid="app-uuid",
+        expected_shared_keys=set(),
+        expected_application_env={"CLAWDI_PROCESS_ROLE": "channels-worker"},
+    )
+
+    assert errors == ["clawdi-channels-worker: CLAWDI_PROCESS_ROLE has an unexpected value"]

--- a/infra/deploy/coolify/README.md
+++ b/infra/deploy/coolify/README.md
@@ -27,8 +27,9 @@ deployment-specific backend image.
   environment shared variables and wire each Application env row as
   `KEY={{environment.KEY}}`.
 - `production-stack.json`: expected non-secret Application shape, image source,
-  runtime role, storage mounts, deployment tag, and operational constraints. It
-  is a public template, not a live production value dump.
+  Application-specific runtime env, storage mounts, deployment tag, and
+  operational constraints. It is a public template, not a live production value
+  dump.
 - `audit_stack.py`: read-only live configuration audit. It checks Application
   shape, storage, env wiring, and optional deployment commit parity without
   printing secret values.
@@ -52,12 +53,13 @@ Configure both Applications with the fields recorded in `production-stack.json`.
 Use placeholders in committed files and put environment-specific destination,
 route, and host storage values in an ignored local overlay.
 
-The API and worker intentionally receive the same env key set even when a key is
-mostly used by HTTP handlers. This keeps deploy drift obvious and avoids a
-second worker-specific env contract. The audit is exact about key parity:
-every key in `.env.example`, including optional empty keys, must exist on each
-Application as a runtime-only shared environment variable, and extra Application
-env rows are treated as drift.
+The API and worker intentionally receive the same shared env key set even when a
+key is mostly used by HTTP handlers. This keeps deploy drift obvious and avoids
+a second worker-specific shared env contract. The audit is exact about shared
+key parity: every key in `.env.example`, including optional empty keys, must
+exist on each Application as a runtime-only shared environment variable. Extra
+Application env rows are treated as drift unless they are declared in that
+Application's `application_env` block in `production-stack.json`.
 
 Coolify may return resolved values for shared env rows instead of the literal
 `{{environment.KEY}}` reference. The audit verifies shared/runtime flags, key
@@ -77,11 +79,16 @@ explicit multi-replica lease or claim contract.
 
 The Docker Image Application build pack does not use `start_command`. The
 shared backend image starts `python -m app.runtime_entrypoint`, and each
-Application selects its role through `CLAWDI_PROCESS_ROLE` in
-`custom_docker_run_options`:
+Application selects its role through a runtime-only Application env row declared
+in `production-stack.json`:
 
 - `api`: runs `alembic upgrade head`, then Uvicorn on port `8000`.
 - `channels-worker`: runs `python -m app.workers.channels`.
+
+Do not pass `CLAWDI_PROCESS_ROLE` through `custom_docker_run_options`; Coolify
+Docker Image Applications do not reliably inject those `--env` values into the
+container. The deploy script applies declared `application_env` rows through the
+Coolify Application env API before queuing a deployment.
 
 Do not add a Dockerfile-level `HEALTHCHECK` to the shared backend image. The
 same image runs both the API and worker roles, so health checks belong on the

--- a/infra/deploy/coolify/audit_stack.py
+++ b/infra/deploy/coolify/audit_stack.py
@@ -152,6 +152,21 @@ def load_stack_manifest(path: Path) -> dict[str, Any]:
     return payload
 
 
+def application_env(expected: dict[str, Any]) -> dict[str, str]:
+    raw = expected.get("application_env", {})
+    if not isinstance(raw, dict):
+        raise SystemExit("Application application_env must be an object.")
+
+    normalized: dict[str, str] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str) or not key:
+            raise SystemExit("Application application_env keys must be non-empty strings.")
+        if not isinstance(value, str):
+            raise SystemExit(f"{key}: application_env values must be strings.")
+        normalized[key] = value
+    return normalized
+
+
 def explicit_uuid(expected: dict[str, Any]) -> str | None:
     value = expected.get("uuid")
     if isinstance(value, str) and value and not value.startswith("REPLACE_"):
@@ -365,7 +380,8 @@ def audit_env(
     token: str,
     app_name: str,
     app_uuid: str,
-    expected_keys: set[str],
+    expected_shared_keys: set[str],
+    expected_application_env: dict[str, str],
 ) -> tuple[list[str], dict[str, str]]:
     payload = request_json(
         api_url=api_url,
@@ -384,12 +400,14 @@ def audit_env(
         by_key[key] = row
 
     keys = set(by_key)
+    expected_application_keys = set(expected_application_env)
+    expected_keys = expected_shared_keys | expected_application_keys
     for key in sorted(expected_keys - keys):
         errors.append(f"{app_name}: missing env key {key}")
     for key in sorted(keys - expected_keys):
         errors.append(f"{app_name}: extra env key {key}")
 
-    for key in sorted(expected_keys & keys):
+    for key in sorted(expected_shared_keys & keys):
         row = by_key[key]
         expected_ref = f"{{{{environment.{key}}}}}"
         if row.get("is_shared") is not True:
@@ -410,13 +428,32 @@ def audit_env(
             if isinstance(real_value, str) and looks_like_placeholder(real_value):
                 errors.append(f"{app_name}: {key} still looks like a placeholder")
 
+    for key, expected_value in sorted(expected_application_env.items()):
+        row = by_key.get(key)
+        if not row:
+            continue
+        if row.get("is_shared") is True:
+            errors.append(f"{app_name}: {key} must be Application-specific, not shared")
+        if row.get("is_literal") is not True:
+            errors.append(f"{app_name}: {key} must be stored as a literal value")
+        if row.get("is_runtime") is not True:
+            errors.append(f"{app_name}: {key} is not marked as runtime")
+        if row.get("is_buildtime") is not False:
+            errors.append(f"{app_name}: {key} must not be exposed at build time")
+
+        actual_value = row.get("real_value")
+        if actual_value is None:
+            actual_value = row.get("value")
+        if actual_value != expected_value:
+            errors.append(f"{app_name}: {key} has an unexpected value")
+
     digests = {
         key: value_digest(
             by_key[key].get("real_value")
             if by_key[key].get("real_value") is not None
             else by_key[key].get("value")
         )
-        for key in sorted(expected_keys & keys)
+        for key in sorted(expected_shared_keys & keys)
     }
     shared_refs = sum(1 for row in rows if row.get("is_shared") is True)
     runtime_only = sum(
@@ -424,7 +461,8 @@ def audit_env(
     )
     print(
         f"{app_name}: env_rows={len(rows)} keys={len(keys)} "
-        f"shared_refs={shared_refs} runtime_only={runtime_only}"
+        f"shared_refs={shared_refs} app_env={len(expected_application_env)} "
+        f"runtime_only={runtime_only}"
     )
     return errors, digests
 
@@ -583,7 +621,8 @@ def main() -> int:
             token=args.token,
             app_name=app_name,
             app_uuid=app_uuid,
-            expected_keys=expected_keys,
+            expected_shared_keys=expected_keys,
+            expected_application_env=application_env(expected),
         )
         all_errors.extend(env_errors)
         app_digests[app_name] = digests

--- a/infra/deploy/coolify/deploy_ghcr_runtime.py
+++ b/infra/deploy/coolify/deploy_ghcr_runtime.py
@@ -12,6 +12,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +27,12 @@ TERMINAL_FAILURE = {
     "failed:healthcheck",
     "failed:rollback",
 }
+
+
+@dataclass(frozen=True)
+class ApplicationEnvAction:
+    action: str
+    key: str
 
 
 def log(message: str) -> None:
@@ -277,6 +284,131 @@ def applications_by_role(
     return api_app, worker_apps
 
 
+def application_env(expected: dict[str, Any]) -> dict[str, str]:
+    raw = expected.get("application_env", {})
+    if not isinstance(raw, dict):
+        raise SystemExit("Application application_env must be an object.")
+
+    normalized: dict[str, str] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str) or not key:
+            raise SystemExit("Application application_env keys must be non-empty strings.")
+        if not isinstance(value, str):
+            raise SystemExit(f"{key}: application_env values must be strings.")
+        normalized[key] = value
+    return normalized
+
+
+def application_env_payload(key: str, value: str) -> dict[str, Any]:
+    return {
+        "key": key,
+        "value": value,
+        "is_preview": False,
+        "is_literal": True,
+        "is_multiline": False,
+        "is_shown_once": False,
+        "is_runtime": True,
+        "is_buildtime": False,
+    }
+
+
+def application_env_row_matches(row: dict[str, Any], key: str, value: str) -> bool:
+    desired = application_env_payload(key, value)
+    for field, expected_value in desired.items():
+        if row.get(field) != expected_value:
+            return False
+    return row.get("is_shared") is not True
+
+
+def plan_application_env_actions(
+    *,
+    rows: list[dict[str, Any]],
+    expected_env: dict[str, str],
+) -> list[ApplicationEnvAction]:
+    production_rows = [row for row in rows if row.get("is_preview") is not True]
+    by_key: dict[str, list[dict[str, Any]]] = {}
+    for row in production_rows:
+        key = str(row.get("key", ""))
+        if key in expected_env:
+            by_key.setdefault(key, []).append(row)
+
+    actions: list[ApplicationEnvAction] = []
+    for key, value in sorted(expected_env.items()):
+        candidates = by_key.get(key, [])
+        if not candidates:
+            actions.append(ApplicationEnvAction("create", key))
+            continue
+        if len(candidates) > 1:
+            raise SystemExit(f"{key}: duplicate application env rows require manual cleanup.")
+        if not application_env_row_matches(candidates[0], key, value):
+            actions.append(ApplicationEnvAction("update", key))
+    return actions
+
+
+def apply_application_env_action(
+    *,
+    api_url: str,
+    token: str,
+    app_uuid: str,
+    action: ApplicationEnvAction,
+    expected_env: dict[str, str],
+) -> None:
+    payload = application_env_payload(action.key, expected_env[action.key])
+    if action.action == "create":
+        request_json(
+            api_url=api_url,
+            token=token,
+            method="POST",
+            path=f"/api/v1/applications/{app_uuid}/envs",
+            payload=payload,
+        )
+        return
+    if action.action == "update":
+        request_json(
+            api_url=api_url,
+            token=token,
+            method="PATCH",
+            path=f"/api/v1/applications/{app_uuid}/envs",
+            payload=payload,
+        )
+        return
+    raise SystemExit(f"Unknown application env action {action.action!r}")
+
+
+def sync_application_env(
+    *,
+    api_url: str,
+    token: str,
+    app_name: str,
+    app_uuid: str,
+    expected_env: dict[str, str],
+) -> None:
+    if not expected_env:
+        return
+
+    payload = request_json(
+        api_url=api_url,
+        token=token,
+        method="GET",
+        path=f"/api/v1/applications/{app_uuid}/envs",
+    )
+    rows = get_payload_list(payload, "data")
+    actions = plan_application_env_actions(rows=rows, expected_env=expected_env)
+    if not actions:
+        log(f"{app_name}: application_env=ok keys={len(expected_env)}")
+        return
+
+    for action in actions:
+        apply_application_env_action(
+            api_url=api_url,
+            token=token,
+            app_uuid=app_uuid,
+            action=action,
+            expected_env=expected_env,
+        )
+        log(f"{app_name}: application_env={action.action} key={action.key}")
+
+
 def application_patch_payload(
     *,
     expected: dict[str, Any],
@@ -388,6 +520,13 @@ def main() -> int:
                 f"{app_name}: expected Coolify Docker Image Application "
                 f"(build_pack=dockerimage), found {current_build_pack!r}."
             )
+        sync_application_env(
+            api_url=args.api_url,
+            token=args.token,
+            app_name=app_name,
+            app_uuid=app_uuid,
+            expected_env=application_env(expected),
+        )
         if app_name not in apps_to_update_names:
             log(f"{app_name}: image_tag=unchanged uuid={app_uuid}")
             continue

--- a/infra/deploy/coolify/production-stack.json
+++ b/infra/deploy/coolify/production-stack.json
@@ -57,7 +57,10 @@
 				"health_check_start_period": 60,
 				"limits_memory": "2g",
 				"limits_cpus": "2",
-				"custom_docker_run_options": "--init --env CLAWDI_PROCESS_ROLE=api --add-host=host.docker.internal:host-gateway --ulimit nofile=65535:65535"
+				"custom_docker_run_options": "--init --add-host=host.docker.internal:host-gateway --ulimit nofile=65535:65535"
+			},
+			"application_env": {
+				"CLAWDI_PROCESS_ROLE": "api"
 			},
 			"storages": [
 				{
@@ -94,7 +97,10 @@
 				"health_check_start_period": 20,
 				"limits_memory": "1g",
 				"limits_cpus": "1",
-				"custom_docker_run_options": "--init --env CLAWDI_PROCESS_ROLE=channels-worker --add-host=host.docker.internal:host-gateway --ulimit nofile=65535:65535"
+				"custom_docker_run_options": "--init --add-host=host.docker.internal:host-gateway --ulimit nofile=65535:65535"
+			},
+			"application_env": {
+				"CLAWDI_PROCESS_ROLE": "channels-worker"
 			},
 			"storages": [
 				{


### PR DESCRIPTION
## Summary
- move `CLAWDI_PROCESS_ROLE` out of `custom_docker_run_options` and into explicit per-Application `application_env` contract
- make the Coolify deploy script create/update those declared non-secret app env rows via the Coolify Application env API before deployment
- teach the audit script to validate shared env rows separately from app-specific runtime env rows

## Verification
- `uv run pytest tests/test_coolify_runtime_deploy.py tests/test_runtime_entrypoint.py tests/test_channel_workers.py -q`
- `uv run ruff check app tests/test_coolify_runtime_deploy.py tests/test_runtime_entrypoint.py tests/test_channel_workers.py`
- `uv run ruff check ../infra/deploy/coolify/deploy_ghcr_runtime.py ../infra/deploy/coolify/audit_stack.py tests/test_coolify_runtime_deploy.py`
- `uv run python -m compileall -q app`
- `python3 -m json.tool infra/deploy/coolify/production-stack.json >/dev/null`
- `python3 -m py_compile infra/deploy/coolify/deploy_ghcr_runtime.py infra/deploy/coolify/audit_stack.py`
- `git diff --check`