### PR TITLE
Fix Coolify literal env audit

### DIFF
--- a/backend/tests/test_coolify_runtime_deploy.py
+++ b/backend/tests/test_coolify_runtime_deploy.py
@@ -159,6 +159,7 @@ def test_audit_env_accepts_shared_manifest_and_application_env(monkeypatch):
                 {
                     "key": "CLAWDI_PROCESS_ROLE",
                     "value": "channels-worker",
+                    "real_value": "'channels-worker'",
                     "is_preview": False,
                     "is_shared": False,
                     "is_literal": True,

--- a/infra/deploy/coolify/audit_stack.py
+++ b/infra/deploy/coolify/audit_stack.py
@@ -101,6 +101,15 @@ def value_digest(value: object) -> str:
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
 
 
+def normalize_literal_env_value(value: object) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value)
+    if len(normalized) >= 2 and normalized[0] == "'" and normalized[-1] == "'":
+        return normalized[1:-1]
+    return normalized
+
+
 def looks_like_placeholder(value: str) -> bool:
     normalized = value.strip()
     lower = normalized.lower()
@@ -441,9 +450,9 @@ def audit_env(
         if row.get("is_buildtime") is not False:
             errors.append(f"{app_name}: {key} must not be exposed at build time")
 
-        actual_value = row.get("real_value")
+        actual_value = normalize_literal_env_value(row.get("real_value"))
         if actual_value is None:
-            actual_value = row.get("value")
+            actual_value = normalize_literal_env_value(row.get("value"))
         if actual_value != expected_value:
             errors.append(f"{app_name}: {key} has an unexpected value")
 


### PR DESCRIPTION
## Summary
- normalize Coolify literal env `real_value` before comparing app-specific runtime env values
- cover quoted `CLAWDI_PROCESS_ROLE` real_value in the Coolify deploy/audit test

## Verification
- `uv run pytest tests/test_coolify_runtime_deploy.py -q`
- `uv run ruff check ../infra/deploy/coolify/audit_stack.py tests/test_coolify_runtime_deploy.py`
- `python3 -m py_compile infra/deploy/coolify/audit_stack.py`
- `git diff --check`