### PR TITLE
Relax Coolify literal env audit comparison

### DIFF
--- a/backend/tests/test_coolify_runtime_deploy.py
+++ b/backend/tests/test_coolify_runtime_deploy.py
@@ -214,3 +214,20 @@ def test_audit_env_rejects_wrong_application_env_value(monkeypatch):
     )
 
     assert errors == ["clawdi-channels-worker: CLAWDI_PROCESS_ROLE has an unexpected value"]
+
+
+def test_literal_env_value_matches_value_or_quoted_real_value():
+    module = _load_audit_module()
+
+    assert module.literal_env_value_matches(
+        {"value": "api", "real_value": "'api'"},
+        "api",
+    )
+    assert module.literal_env_value_matches(
+        {"value": "masked", "real_value": '"channels-worker"'},
+        "channels-worker",
+    )
+    assert not module.literal_env_value_matches(
+        {"value": "api", "real_value": "'api'"},
+        "channels-worker",
+    )

--- a/infra/deploy/coolify/audit_stack.py
+++ b/infra/deploy/coolify/audit_stack.py
@@ -104,10 +104,21 @@ def value_digest(value: object) -> str:
 def normalize_literal_env_value(value: object) -> str | None:
     if value is None:
         return None
-    normalized = str(value)
+    normalized = str(value).strip()
     if len(normalized) >= 2 and normalized[0] == "'" and normalized[-1] == "'":
         return normalized[1:-1]
+    if len(normalized) >= 2 and normalized[0] == '"' and normalized[-1] == '"':
+        return normalized[1:-1]
     return normalized
+
+
+def literal_env_value_matches(row: dict[str, Any], expected: str) -> bool:
+    candidates = {
+        normalized
+        for value in (row.get("value"), row.get("real_value"))
+        if (normalized := normalize_literal_env_value(value)) is not None
+    }
+    return expected in candidates
 
 
 def looks_like_placeholder(value: str) -> bool:
@@ -450,10 +461,7 @@ def audit_env(
         if row.get("is_buildtime") is not False:
             errors.append(f"{app_name}: {key} must not be exposed at build time")
 
-        actual_value = normalize_literal_env_value(row.get("real_value"))
-        if actual_value is None:
-            actual_value = normalize_literal_env_value(row.get("value"))
-        if actual_value != expected_value:
+        if not literal_env_value_matches(row, expected_value):
             errors.append(f"{app_name}: {key} has an unexpected value")
 
     digests = {


### PR DESCRIPTION
## Summary
- compare app-specific literal env against both Coolify `value` and `real_value` representations
- normalize quoted literal values before comparison
- add direct tests for the candidate comparison helper

## Verification
- `uv run pytest tests/test_coolify_runtime_deploy.py -q`
- `uv run ruff check ../infra/deploy/coolify/audit_stack.py tests/test_coolify_runtime_deploy.py`
- `python3 -m py_compile infra/deploy/coolify/audit_stack.py`
- `git diff --check`