### PR TITLE
Handle redacted Coolify literal env values

### DIFF
--- a/backend/tests/test_coolify_runtime_deploy.py
+++ b/backend/tests/test_coolify_runtime_deploy.py
@@ -219,6 +219,7 @@ def test_audit_env_rejects_wrong_application_env_value(monkeypatch):
 def test_literal_env_value_matches_value_or_quoted_real_value():
     module = _load_audit_module()
 
+    assert module.literal_env_value_matches({}, "api")
     assert module.literal_env_value_matches(
         {"value": "api", "real_value": "'api'"},
         "api",

--- a/infra/deploy/coolify/audit_stack.py
+++ b/infra/deploy/coolify/audit_stack.py
@@ -118,6 +118,8 @@ def literal_env_value_matches(row: dict[str, Any], expected: str) -> bool:
         for value in (row.get("value"), row.get("real_value"))
         if (normalized := normalize_literal_env_value(value)) is not None
     }
+    if not candidates:
+        return True
     return expected in candidates
 
 


### PR DESCRIPTION
## Summary
- allow app-specific literal env audit to pass when Coolify API redacts both `value` and `real_value`
- keep strict comparison when either field is visible
- cover redacted payloads in the Coolify deploy/audit test

## Verification
- `uv run pytest tests/test_coolify_runtime_deploy.py -q`
- `uv run ruff check ../infra/deploy/coolify/audit_stack.py tests/test_coolify_runtime_deploy.py`
- `python3 -m py_compile infra/deploy/coolify/audit_stack.py`
- `git diff --check`