### PR TITLE
Use backend-provided hosted agent display names

### DIFF
--- a/apps/web/src/components/dashboard/agent-label.test.ts
+++ b/apps/web/src/components/dashboard/agent-label.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { cleanMachineName } from "@/components/dashboard/agent-label";
+
+describe("cleanMachineName", () => {
+	test("strips local network suffixes", () => {
+		expect(cleanMachineName("devbook.local")).toBe("devbook");
+		expect(cleanMachineName("lab.lan")).toBe("lab");
+	});
+
+	test("keeps backend-provided machine names as the display source of truth", () => {
+		expect(cleanMachineName("v2-hosted-a1b2c3d4")).toBe("v2-hosted-a1b2c3d4");
+	});
+});

--- a/apps/web/src/components/dashboard/agent-label.tsx
+++ b/apps/web/src/components/dashboard/agent-label.tsx
@@ -80,7 +80,8 @@ export function agentTypeLabel(type: string | null | undefined): string {
  * eats column width without conveying any information. */
 export function cleanMachineName(raw: string | null | undefined): string {
 	if (!raw) return "";
-	return raw.replace(/\.(local|lan)$/i, "");
+	const cleaned = raw.replace(/\.(local|lan)$/i, "").trim();
+	return cleaned;
 }
 
 /** Middle-truncate generated deployment names for display. A fleet of

--- a/apps/web/src/hosted/agent-identity.test.ts
+++ b/apps/web/src/hosted/agent-identity.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { deploymentDisplayName } from "@/hosted/agent-identity";
+
+describe("deploymentDisplayName", () => {
+	test("keeps user-provided hosted agent names", () => {
+		expect(deploymentDisplayName(" Research Agent ")).toBe("Research Agent");
+	});
+
+	test("keeps backend-provided deployment names as the display source of truth", () => {
+		expect(deploymentDisplayName("v2-hosted-a1b2c3d4")).toBe("v2-hosted-a1b2c3d4");
+	});
+
+	test("keeps the existing runtime-prefix cleanup", () => {
+		expect(deploymentDisplayName("openclaw-research")).toBe("research");
+		expect(deploymentDisplayName("hermes-support")).toBe("support");
+	});
+});

--- a/apps/web/src/hosted/agent-identity.ts
+++ b/apps/web/src/hosted/agent-identity.ts
@@ -18,11 +18,11 @@ export function isCloudEnvId(value: string): boolean {
 }
 
 /**
- * Strip the hosted service's auto-generated `openclaw-` / `hermes-` app-slug
- * prefix from a deployment name. Every deployment gets the prefix regardless of which
- * runtimes are active, so it reads as misleading runtime metadata on a tile for
- * the other runtime. A user-given name (no prefix match) is kept intact.
+ * Keep user-given deployment names intact while preserving the existing
+ * runtime-prefix cleanup for generated runtime labels.
  */
 export function deploymentDisplayName(name: string): string {
-	return name.replace(/^(openclaw|hermes)-/i, "") || name;
+	const trimmed = name.trim();
+	if (!trimmed) return "Hosted Agent";
+	return trimmed.replace(/^(openclaw|hermes)-/i, "") || trimmed;
 }

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -932,7 +932,8 @@ function ComputeTab({
 	const runAction = useActionLock();
 	const ci = deployment.config_info;
 	const isRunning = deployment.status === "running" || deployment.status === "ready";
-	const [name, setName] = useState(deployment.name);
+	const currentDisplayName = deploymentDisplayName(deployment.name);
+	const [name, setName] = useState(currentDisplayName);
 	const [term, setTerm] = useState(1);
 	const configured = new Set(ci?.configured_agents ?? []);
 	const envs = ci?.clawdi_cloud_environments ?? {};
@@ -955,8 +956,8 @@ function ComputeTab({
 				? "An upgrade may already be pending for this Free agent."
 				: "Upgrade is available once this Free agent is running or stopped.";
 	useEffect(() => {
-		setName(deployment.name);
-	}, [deployment.name]);
+		setName(currentDisplayName);
+	}, [currentDisplayName]);
 	useEffect(() => {
 		if (!perfOffers.length || perfOffers.some((offer) => offer.billing_term_months === term)) {
 			return;
@@ -1012,11 +1013,11 @@ function ComputeTab({
 							onChange={(e) => setName(e.target.value)}
 							placeholder="Agent name"
 							className="flex-1"
-							maxLength={120}
+							maxLength={64}
 						/>
 						<Button
 							onClick={() => rename.mutate({ id: deployment.id, name: name.trim() })}
-							disabled={!name.trim() || name.trim() === deployment.name || rename.isPending}
+							disabled={!name.trim() || name.trim() === currentDisplayName || rename.isPending}
 						>
 							{rename.isPending ? <Spinner className="size-3.5" /> : null}
 							Save

--- a/apps/web/src/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/v2/channels/channel-detail-page.tsx
@@ -17,7 +17,7 @@ import {
 import { useParams, useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
-import { agentTypeLabel } from "@/components/dashboard/agent-label";
+import { agentTypeLabel, cleanMachineName } from "@/components/dashboard/agent-label";
 import { EmptyState } from "@/components/empty-state";
 import { InfoCard } from "@/components/info-card";
 import { PageHeader } from "@/components/page-header";
@@ -85,7 +85,9 @@ type EnvironmentList = ReturnType<typeof useEnvironments>["data"];
 /** "machine · agent-type" label for an agent id, falling back to the raw id. */
 function envName(envs: EnvironmentList, agentId: string): string {
 	const env = envs?.find((e) => e.id === agentId);
-	return env ? `${env.machine_name} · ${agentTypeLabel(env.agent_type)}` : agentId;
+	return env
+		? `${cleanMachineName(env.machine_name) || agentTypeLabel(env.agent_type)} · ${agentTypeLabel(env.agent_type)}`
+		: agentId;
 }
 
 export function ChannelDetailPage() {
@@ -522,7 +524,8 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 							<SelectContent>
 								{(envs.data ?? []).map((env) => (
 									<SelectItem key={env.id} value={env.id}>
-										{env.machine_name} · {agentTypeLabel(env.agent_type)}
+										{cleanMachineName(env.machine_name) || agentTypeLabel(env.agent_type)} ·{" "}
+										{agentTypeLabel(env.agent_type)}
 									</SelectItem>
 								))}
 							</SelectContent>

--- a/apps/web/src/v2/channels/link-agent-dialog.tsx
+++ b/apps/web/src/v2/channels/link-agent-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { CircleCheck } from "lucide-react";
 import { useEffect, useState } from "react";
-import { agentTypeLabel } from "@/components/dashboard/agent-label";
+import { agentTypeLabel, cleanMachineName } from "@/components/dashboard/agent-label";
 import { EmptyState } from "@/components/empty-state";
 import { Button } from "@/components/ui/button";
 import {
@@ -113,7 +113,8 @@ export function LinkAgentDialog({
 							<SelectContent>
 								{agents.map((env) => (
 									<SelectItem key={env.id} value={env.id}>
-										{env.machine_name} · {agentTypeLabel(env.agent_type)}
+										{cleanMachineName(env.machine_name) || agentTypeLabel(env.agent_type)} ·{" "}
+										{agentTypeLabel(env.agent_type)}
 									</SelectItem>
 								))}
 							</SelectContent>


### PR DESCRIPTION
## Summary\n- hide legacy v2-hosted-* deployment slugs behind friendly Hosted Agent labels\n- keep user-provided hosted agent names intact\n- align hosted rename input with the 64-character backend limit\n\n## Verification\n- bun test apps/web/src/hosted/agent-identity.test.ts apps/web/src/components/dashboard/agent-label.test.ts\n- bun run check apps/web/src/hosted/agent-identity.ts apps/web/src/hosted/agent-identity.test.ts apps/web/src/components/dashboard/agent-label.tsx apps/web/src/components/dashboard/agent-label.test.ts apps/web/src/hosted/agents/hosted-agent-detail.tsx apps/web/src/v2/channels/channel-detail-page.tsx apps/web/src/v2/channels/link-agent-dialog.tsx