### PR TITLE
Avoid redundant runtime watch restarts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.7",
+      "version": "0.12.10-beta.8",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.7",
+	"version": "0.12.10-beta.8",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1269,6 +1269,11 @@ function supervisorctl(
 	);
 }
 
+function readFileIfExists(path: string): string | null {
+	if (!existsSync(path)) return null;
+	return readFileSync(path, "utf-8");
+}
+
 function applySupervisorRuntimeUpdate(paths: ReturnType<typeof getRuntimePaths>): void {
 	const targets = supervisorRuntimeUpdateTargets(paths);
 	supervisorctl(paths, ["reread"]);
@@ -1694,6 +1699,7 @@ async function runtimeWatchTick(
 	}
 
 	try {
+		const previousSupervisorConfig = readFileIfExists(paths.supervisorConfig);
 		const loaded = await runtimeWatchLoadForApply(paths, manifestLoad, channelsLoad);
 		const { convergence, cliUpdate } = withRuntimeConvergeLock(paths, () =>
 			applyRuntimeDesiredState(loaded, paths, {
@@ -1706,7 +1712,9 @@ async function runtimeWatchTick(
 			cliUpdate.status === "error" ? (cliUpdate.error ?? "CLI update failed") : null;
 		const errors = [...(cliUpdateError ? [cliUpdateError] : []), ...convergence.installErrors];
 		const selfReexec = shouldSelfReexecForCliUpdate(cliUpdate);
-		if (convergence.installErrors.length === 0) {
+		const supervisorConfigChanged =
+			readFileIfExists(paths.supervisorConfig) !== previousSupervisorConfig;
+		if (convergence.installErrors.length === 0 && supervisorConfigChanged) {
 			applySupervisorRuntimeUpdate(paths);
 		}
 		if (errors.length > 0) {
@@ -1725,6 +1733,7 @@ async function runtimeWatchTick(
 				activeGeneration: convergence.manifest.generation,
 				cliUpdate,
 				selfReexec,
+				supervisorConfigChanged,
 				convergence: convergence.outputs,
 			};
 		}
@@ -1752,6 +1761,7 @@ async function runtimeWatchTick(
 			enabledRuntimes: convergence.enabledRuntimes,
 			cliUpdate,
 			selfReexec,
+			supervisorConfigChanged,
 			convergence: convergence.outputs,
 		};
 	} catch (error) {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1469,11 +1469,13 @@ exit 64
 			const event = JSON.parse(logs[0]);
 			expect(event.status).toBe("applied");
 			expect(event.generation).toBe(22);
+			expect(event.supervisorConfigChanged).toBe(false);
 			const secrets = JSON.parse(readFileSync(join(run, "mitm", "secrets.json"), "utf-8"));
 			expect(secrets["secret://provider.default.apiKey"]).toBe("sk-provider-watch");
 			expect(secrets[channelSecretRef]).toBe("agent-token-watch");
 			const supervisorConfig = readFileSync(paths.supervisorConfig, "utf-8");
 			expect(openclawRevision(supervisorConfig)).toBe(baselineRevision);
+			expect(existsSync(supervisorCalls)).toBe(false);
 		} finally {
 			watchFetch.restore();
 			console.log = previousLog;


### PR DESCRIPTION
## Summary
- skip supervisor reread/update when runtime watch convergence leaves supervisord.conf unchanged
- keep saving ETags, secrets, and projections without interrupting running UI/runtime processes

## Verification
- bun test packages/cli/tests/runtime.test.ts -t "runtime watch applies remote changes"
- bun test packages/cli/tests/runtime.test.ts -t "runtime watch keeps provider secrets"
- bun test packages/cli/tests/runtime.test.ts packages/cli/tests/runtime-ui-bridge.test.ts packages/cli/tests/runtime-mitm-profiles.test.ts
- cd packages/cli && bun run typecheck