### PR TITLE
Keep hosted runtime managed secrets internal

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.8",
+      "version": "0.12.10-beta.9",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.8",
+	"version": "0.12.10-beta.9",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -187,7 +187,8 @@ export async function run(
 		process.exit(1);
 	}
 
-	const managedAiProviderEnv = await resolveManagedAiProviderEnv(spawnEnv);
+	const managedAiProviderEnv =
+		detectRuntimeMode() === "hosted" ? {} : await resolveManagedAiProviderEnv(spawnEnv);
 	const childEnv = { ...spawnEnv, ...managedAiProviderEnv };
 	if (hostedRuntimeRun.status === "ok") {
 		await spawnRuntimeInvocation(
@@ -282,6 +283,7 @@ function hostedGenericRunInvocation(
 		env: buildMitmBrokerEnv({
 			env: baseEnv,
 			profileBundlePath: paths.mitmProfileBundle,
+			secretFile: paths.managedSecretFile,
 		}),
 		configPath: paths.mitmProfileBundle,
 	};

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1160,7 +1160,7 @@ function hasRuntimeCredential(input: {
 	const paths = input.paths ?? getRuntimePaths();
 	if (existsSync(paths.manifestLastGood)) return true;
 	try {
-		if (readFileSync(join(paths.runRoot, "sync", "auth-token"), "utf-8").trim()) return true;
+		if (readFileSync(paths.daemonAuthToken, "utf-8").trim()) return true;
 	} catch {
 		// Fall through to the configured auth environment variable.
 	}
@@ -2066,9 +2066,9 @@ export async function runtimeDoctor(opts: { json?: boolean } = {}) {
 		},
 		{
 			name: "Ephemeral runtime state",
-			ok: existsSync(paths.runRoot) && writable(paths.runRoot),
+			ok: existsSync(paths.runRoot),
 			detail: paths.runRoot,
-			hint: "The runtime tmpfs path should be recreated on each boot.",
+			hint: "The runtime tmpfs path should be recreated on each boot and owned by the system boundary.",
 		},
 		{
 			name: "Sensitive instance data",

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -207,7 +207,7 @@ function runtimeCredential(source: RuntimeSource, paths: RuntimePaths): string |
 	const token = process.env[source.auth.env]?.trim();
 	if (token) return token;
 	try {
-		const fileToken = readFileSync(join(paths.runRoot, "sync", "auth-token"), "utf-8").trim();
+		const fileToken = readFileSync(paths.daemonAuthToken, "utf-8").trim();
 		return fileToken || null;
 	} catch {
 		return null;

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -49,7 +49,7 @@ import {
 	type SupportedRuntimeName,
 	writeRuntimeRunConfig,
 } from "./run-config";
-import { UI_BRIDGE_LISTEN_HOST_ENV } from "./ui-bridge";
+import { UI_ACCESS_TOKEN_ENV, UI_BRIDGE_LISTEN_HOST_ENV } from "./ui-bridge";
 
 export interface RuntimeConvergenceResult {
 	manifest: RuntimeManifest;
@@ -115,17 +115,20 @@ function writeSecretValues(
 	secretValues: Record<string, string> | undefined,
 	paths: RuntimePaths,
 ): string | null {
-	const path = join(paths.runRoot, "mitm", "secrets.json");
+	const path = paths.managedSecretFile;
+	const legacyPath = join(paths.runRoot, "mitm", "secrets.json");
 	if (!secretValues || Object.keys(secretValues).length === 0) {
 		rmSync(path, { force: true });
+		rmSync(legacyPath, { force: true });
 		return null;
 	}
+	rmSync(legacyPath, { force: true });
 	writePrivateFileAtomic(path, `${JSON.stringify(secretValues, null, 2)}\n`, {
 		mode: 0o600,
 		dirMode: 0o700,
 	});
-	makeRuntimeUserPrivateDir(dirname(path));
-	makeRuntimeUserOwned(path);
+	makeRootOwned(dirname(path));
+	makeRootOwned(path);
 	try {
 		chmodSync(path, 0o600);
 	} catch {
@@ -237,6 +240,15 @@ function makeRuntimeUserOwned(path: string): void {
 	} catch {
 		// Best effort: hosted demos without a system user still exercise the
 		// manifest path, but production images provide CLAWDI_RUNTIME_USER.
+	}
+}
+
+function makeRootOwned(path: string): void {
+	if (!runningAsRoot()) return;
+	try {
+		chownSync(path, 0, 0);
+	} catch {
+		// Best effort for local tests and non-root development environments.
 	}
 }
 
@@ -643,21 +655,6 @@ function hostedProviderRuntimeEnvName(providerId: string, input: Record<string, 
 	return `CLAWDI_PROVIDER_${providerId.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_API_KEY`;
 }
 
-function hostedProviderSecretEnv(manifest: RuntimeManifest): Record<string, string> {
-	const providers = manifest.projection?.providers;
-	if (!providers || Object.keys(providers).length === 0) return {};
-	const secretEnv: Record<string, string> = {};
-	for (const [providerId, raw] of Object.entries(providers)) {
-		if (typeof raw !== "object" || raw === null || Array.isArray(raw)) continue;
-		const input = raw as Record<string, unknown>;
-		const apiKeySecretRef =
-			typeof input.apiKeySecretRef === "string" ? input.apiKeySecretRef : undefined;
-		if (!apiKeySecretRef) continue;
-		secretEnv[hostedProviderRuntimeEnvName(providerId, input)] = apiKeySecretRef;
-	}
-	return secretEnv;
-}
-
 function isEnvKey(value: string): boolean {
 	return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
 }
@@ -1020,16 +1017,19 @@ function writeLiveSyncEnvironmentFiles(manifest: RuntimeManifest, paths: Runtime
 }
 
 function writeDaemonAuthToken(paths: RuntimePaths): string | null {
-	const path = join(paths.runRoot, "sync", "auth-token");
+	const path = paths.daemonAuthToken;
+	const legacyPath = join(paths.runRoot, "sync", "auth-token");
 	const token = process.env.CLAWDI_AUTH_TOKEN?.trim();
 	if (!token) {
 		if (existsSync(path)) return path;
 		rmSync(path, { force: true });
+		rmSync(legacyPath, { force: true });
 		return null;
 	}
+	rmSync(legacyPath, { force: true });
 	writePrivateFileAtomic(path, `${token}\n`, { mode: 0o600, dirMode: 0o700 });
-	makeRuntimeUserOwned(dirname(path));
-	makeRuntimeUserOwned(path);
+	makeRootOwned(dirname(path));
+	makeRootOwned(path);
 	return path;
 }
 
@@ -1234,6 +1234,7 @@ function writeSupervisorConfig(
 		CLAWDI_SERVICE_STATE_DIR: paths.serviceStateRoot,
 		CLAWDI_RUN_DIR: paths.runRoot,
 		CLAWDI_HOST_POLICY_PATH: paths.hostPolicy,
+		[UI_ACCESS_TOKEN_ENV]: "",
 		[UI_BRIDGE_LISTEN_HOST_ENV]: process.env[UI_BRIDGE_LISTEN_HOST_ENV]?.trim() ?? "",
 		PATH: supervisorPath(paths),
 	};
@@ -1273,8 +1274,8 @@ function writeSupervisorConfig(
 		"",
 		"[unix_http_server]",
 		`file=${paths.runRoot}/supervisor.sock`,
-		"chmod=0770",
-		`chown=${runtimeUser}:${runtimeUser}`,
+		"chmod=0700",
+		"chown=root:root",
 		"",
 		"[supervisorctl]",
 		`serverurl=unix://${paths.runRoot}/supervisor.sock`,
@@ -1316,7 +1317,6 @@ function writeSupervisorConfig(
 			"[program:clawdi-daemon]",
 			`command=/bin/sh -lc ${shellQuote(script)}`,
 			`directory=${workspaceRoot}`,
-			`user=${runtimeUser}`,
 			"autostart=true",
 			"autorestart=true",
 			"startsecs=2",
@@ -1336,6 +1336,7 @@ function writeSupervisorConfig(
 		const uiBridgeEnvironment = supervisorEnvironment({
 			...commonEnvironment,
 			CLAWDI_AUTH_TOKEN: "",
+			[UI_ACCESS_TOKEN_ENV]: process.env[UI_ACCESS_TOKEN_ENV]?.trim() ?? "",
 			CLAWDI_RUNTIME_REV: uiBridgeProgramRevision(manifest),
 		});
 		lines.push(
@@ -1434,7 +1435,6 @@ export function convergeRuntimeManifest(
 	makeRuntimeUserOwned(paths.userHome);
 	makeRuntimeUserPrivateDir(paths.clawdiHome);
 	makeRuntimeUserOwned(workspaceRoot);
-	makeRuntimeUserOwned(paths.runRoot);
 	mkdirSync(paths.installInventory, { recursive: true });
 	mkdirSync(paths.projectionRoot, { recursive: true });
 	mkdirSync(semRoot, { recursive: true });
@@ -1499,7 +1499,6 @@ export function convergeRuntimeManifest(
 		? writeMitmProfileBundle(mitmProfileBundle, paths)
 		: clearMitmProfileBundle(paths);
 	const mitmSecretFile = writeSecretValues(load.secretValues, paths);
-	const providerSecretEnv = hostedProviderSecretEnv(manifest);
 	writeProviderHealthStatus(manifest, load.secretValues, paths);
 	const liveSyncEnvironments = writeLiveSyncEnvironmentFiles(manifest, paths);
 	const daemonAuthTokenFile = writeDaemonAuthToken(paths);
@@ -1588,7 +1587,6 @@ export function convergeRuntimeManifest(
 					workspaceRoot,
 					mitmProfileBundlePath,
 					settings: runtime.run,
-					secretEnv: providerSecretEnv,
 					secretFilePath: mitmSecretFile,
 				}),
 				paths,

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -45,6 +45,9 @@ export interface RuntimePaths {
 	installInventory: string;
 	projectionRoot: string;
 	runRoot: string;
+	managedSecretRoot: string;
+	managedSecretFile: string;
+	daemonAuthToken: string;
 	instanceData: string;
 	sensitiveInstanceData: string;
 	workspaceRoot: string;
@@ -132,6 +135,9 @@ export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths
 		installInventory: join(serviceStateRoot, "install-inventory"),
 		projectionRoot: join(serviceStateRoot, "config", "projections"),
 		runRoot,
+		managedSecretRoot: join(runRoot, "secrets"),
+		managedSecretFile: join(runRoot, "secrets", "runtime-secrets.json"),
+		daemonAuthToken: join(runRoot, "secrets", "auth-token"),
 		instanceData: join(runRoot, "instance-data.json"),
 		sensitiveInstanceData: join(runRoot, "instance-data-sensitive.json"),
 		workspaceRoot: join(userHome, "clawdi"),

--- a/packages/cli/src/runtime/run-config.ts
+++ b/packages/cli/src/runtime/run-config.ts
@@ -2,7 +2,6 @@ import { existsSync, readFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { z } from "zod";
 import { writePrivateFileAtomic } from "../lib/private-file";
-import { normalizeSecretRef } from "./hosted-mitm-profiles";
 import { buildMitmBrokerEnv } from "./mitm-env";
 import type { RuntimePaths } from "./paths";
 import { getRuntimePaths } from "./paths";
@@ -35,7 +34,6 @@ const runtimeRunConfigSchema = z
 		command: z.string().min(1),
 		defaultArgs: z.array(z.string()).default([]),
 		env: z.record(envKeySchema, z.string()).default({}),
-		secretEnv: z.record(envKeySchema, z.string().min(1)).default({}),
 		secretFilePath: z.string().min(1).nullable().default(null),
 		prependPath: z.array(z.string().min(1)).default([]),
 		cwd: z.string().min(1).optional(),
@@ -101,7 +99,6 @@ export function buildRuntimeRunConfig(input: {
 	workspaceRoot: string;
 	mitmProfileBundlePath?: string | null;
 	settings?: RuntimeRunSettings;
-	secretEnv?: Record<string, string>;
 	secretFilePath?: string | null;
 }): RuntimeRunConfig {
 	const defaultPath = input.commandPath ? [dirname(input.commandPath)] : [];
@@ -118,7 +115,6 @@ export function buildRuntimeRunConfig(input: {
 		command: input.settings?.command ?? input.commandPath ?? input.runtime,
 		defaultArgs: input.settings?.args ?? DEFAULT_RUNTIME_ARGS[input.runtime],
 		env: input.settings?.env ?? {},
-		secretEnv: input.secretEnv ?? {},
 		secretFilePath: input.secretFilePath ?? null,
 		prependPath,
 		cwd: input.settings?.cwd ?? input.workspaceRoot,
@@ -168,11 +164,10 @@ export function buildRuntimeRunInvocation(
 ): RuntimeRunInvocation {
 	const pathPrefix = read.config.prependPath.join(":");
 	const currentPath = baseEnv.PATH ?? "";
-	const secretEnv = runtimeSecretEnv(read.config);
 	const env = {
 		...baseEnv,
 		...read.config.env,
-		...secretEnv,
+		...(read.config.secretFilePath ? { CLAWDI_MITM_SECRET_FILE: read.config.secretFilePath } : {}),
 		PATH: pathPrefix ? [pathPrefix, currentPath].filter(Boolean).join(":") : currentPath,
 	};
 	const brokerEnv = buildMitmBrokerEnv({
@@ -191,35 +186,4 @@ export function buildRuntimeRunInvocation(
 		env: brokerEnv,
 		configPath: read.path,
 	};
-}
-
-function runtimeSecretEnv(config: RuntimeRunConfig): Record<string, string> {
-	const entries = Object.entries(config.secretEnv);
-	if (entries.length === 0) return {};
-	if (!config.secretFilePath) {
-		throw new Error(`runtime ${config.runtime} declares secret env but has no secret file`);
-	}
-	const secrets = readSecretValues(config.secretFilePath);
-	const env: Record<string, string> = {};
-	for (const [envName, ref] of entries) {
-		const normalized = normalizeSecretRef(ref);
-		const value = secrets[ref] ?? (normalized ? secrets[normalized] : undefined);
-		if (!value) {
-			throw new Error(`runtime ${config.runtime} secret ${ref} is unavailable`);
-		}
-		env[envName] = value;
-	}
-	return env;
-}
-
-function readSecretValues(path: string): Record<string, string> {
-	const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
-	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-		throw new Error(`runtime secret file is invalid: ${path}`);
-	}
-	const secrets: Record<string, string> = {};
-	for (const [key, value] of Object.entries(parsed)) {
-		if (typeof value === "string") secrets[key] = value;
-	}
-	return secrets;
 }

--- a/packages/cli/src/runtime/state.ts
+++ b/packages/cli/src/runtime/state.ts
@@ -74,6 +74,9 @@ export interface RuntimeBootStatus {
 		cloudStatus: string;
 		cloudResult: string;
 		runRoot: string;
+		managedSecretRoot: string;
+		managedSecretFile: string;
+		daemonAuthToken: string;
 		instanceData: string;
 		sensitiveInstanceData: string;
 		projectionRoot: string;
@@ -112,6 +115,9 @@ function pathSummary(paths: RuntimePaths): RuntimeBootStatus["paths"] {
 		cloudStatus: paths.cloudStatus,
 		cloudResult: paths.cloudResult,
 		runRoot: paths.runRoot,
+		managedSecretRoot: paths.managedSecretRoot,
+		managedSecretFile: paths.managedSecretFile,
+		daemonAuthToken: paths.daemonAuthToken,
 		instanceData: paths.instanceData,
 		sensitiveInstanceData: paths.sensitiveInstanceData,
 		projectionRoot: paths.projectionRoot,

--- a/packages/cli/tests/commands/run.test.ts
+++ b/packages/cli/tests/commands/run.test.ts
@@ -25,6 +25,7 @@ interface BrokerCall {
 	profileBundlePath: string;
 	proxyUrl?: string;
 	caFile?: string;
+	secretFile?: string;
 	authToken?: string;
 }
 
@@ -108,6 +109,7 @@ function recordBroker(output?: { proxyUrl?: string; caFile?: string }): {
 			profileBundlePath: input.profileBundlePath,
 			proxyUrl: input.env.CLAWDI_MITM_PROXY_URL,
 			caFile: input.env.CLAWDI_MITM_CA_FILE,
+			secretFile: input.env.CLAWDI_MITM_SECRET_FILE,
 			authToken: input.env.CLAWDI_AUTH_TOKEN,
 		});
 		return {
@@ -144,7 +146,7 @@ describe("run command project folder selection", () => {
 					HOME: "/home/clawdi",
 					CLAWDI_RUNTIME_USER: "clawdi",
 					CLAWDI_AUTH_TOKEN: "runtime-auth-token",
-					CLAWDI_MITM_SECRET_FILE: "/run/clawdi/mitm/secrets.json",
+					CLAWDI_MITM_SECRET_FILE: "/run/clawdi/secrets/runtime-secrets.json",
 					HTTPS_PROXY: "http://127.0.0.1:19090",
 					CLAWDI_PROVIDER_PLACEHOLDER_TOKEN: "clawdi-mitm-placeholder",
 				},
@@ -176,7 +178,7 @@ describe("run command project folder selection", () => {
 					PATH: "/home/clawdi/.local/bin:/usr/bin",
 					CLAWDI_RUNTIME_USER: "clawdi",
 					CLAWDI_AUTH_TOKEN: "runtime-auth-token",
-					CLAWDI_MITM_SECRET_FILE: "/run/clawdi/mitm/secrets.json",
+					CLAWDI_MITM_SECRET_FILE: "/run/clawdi/secrets/runtime-secrets.json",
 					HTTPS_PROXY: "http://127.0.0.1:19090",
 					SSL_CERT_FILE: "/run/clawdi/mitm/brokers/test/ca.pem",
 				},
@@ -266,16 +268,19 @@ describe("run command project folder selection", () => {
 		);
 	});
 
-	it("injects hosted runtime provider secrets from the private runtime secret file", async () => {
+	it("passes hosted runtime provider secrets only to the managed MITM broker", async () => {
 		unlinkSync(join(fakeClawdiHome, "auth.json"));
 		const serviceStateRoot = join(tmpRoot, "var", "lib", "clawdi");
 		const runRoot = join(tmpRoot, "run", "clawdi");
 		const openclawPath = join(tmpRoot, "home", "clawdi", ".openclaw", "bin", "openclaw");
 		const runConfigRoot = join(serviceStateRoot, "config", "run");
-		const secretFile = join(runRoot, "mitm", "secrets.json");
+		const secretFile = join(runRoot, "secrets", "runtime-secrets.json");
+		const mitmBundle = join(serviceStateRoot, "config", "mitm", "profiles.json");
 		mkdirSync(runConfigRoot, { recursive: true });
-		mkdirSync(join(runRoot, "mitm"), { recursive: true });
+		mkdirSync(join(runRoot, "secrets"), { recursive: true });
+		mkdirSync(join(serviceStateRoot, "config", "mitm"), { recursive: true });
 		mkdirSync(join(tmpRoot, "home", "clawdi", ".openclaw", "bin"), { recursive: true });
+		writeFileSync(mitmBundle, JSON.stringify({ profiles: [] }));
 		writeFileSync(
 			secretFile,
 			JSON.stringify({
@@ -294,27 +299,28 @@ describe("run command project folder selection", () => {
 				command: "openclaw",
 				defaultArgs: ["gateway", "run"],
 				env: {},
-				secretEnv: {
-					CLAWDI_MANAGED_OPENAI_API_KEY: "provider.default.apiKey",
-				},
 				secretFilePath: secretFile,
 				prependPath: [join(tmpRoot, "home", "clawdi", ".openclaw", "bin")],
 				cwd: projectRoot,
 				commandPath: openclawPath,
 				appRoot: join(tmpRoot, "home", "clawdi", ".openclaw"),
+				mitmProfileBundlePath: mitmBundle,
 			}),
 		);
 		writeFileSync(openclawPath, "#!/usr/bin/env sh\n");
 		const { calls, spawnImpl } = recordSpawn();
+		const broker = recordBroker();
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = serviceStateRoot;
 		process.env.CLAWDI_RUN_DIR = runRoot;
 		process.env.CLAWDI_AUTH_TOKEN = "hosted-runtime-token";
 
-		await run(["openclaw"], {}, spawnImpl);
+		await run(["openclaw"], {}, spawnImpl, broker.brokerFactory);
 
 		expect(calls).toHaveLength(1);
-		expect(calls[0].env.CLAWDI_MANAGED_OPENAI_API_KEY).toBe("sk-runtime-provider");
+		expect(broker.calls).toHaveLength(1);
+		expect(broker.calls[0].secretFile).toBe(secretFile);
+		expect(calls[0].env.CLAWDI_MANAGED_OPENAI_API_KEY).toBeUndefined();
 		expect(calls[0].env.CLAWDI_AUTH_TOKEN).toBeUndefined();
 		expect(calls[0].env.CLAWDI_MITM_SECRET_FILE).toBeUndefined();
 	});
@@ -645,6 +651,7 @@ describe("run command project folder selection", () => {
 			runtime: "generic",
 			profileBundlePath: mitmProfileBundle,
 			proxyUrl: "http://127.0.0.1:0",
+			secretFile: join(runRoot, "secrets", "runtime-secrets.json"),
 		});
 		expect(broker.calls[0].caFile?.startsWith(join(runRoot, "mitm", "brokers"))).toBe(true);
 		expect(broker.calls[0].caFile?.endsWith(join("", "ca.pem"))).toBe(true);
@@ -662,6 +669,78 @@ describe("run command project folder selection", () => {
 		expect(calls[0].env.CODEX_CA_CERTIFICATE).toBe(
 			join(runRoot, "mitm", "brokers", "actual", "ca.pem"),
 		);
+	});
+
+	it("does not inject cloud-managed AI provider keys into hosted runtime commands", async () => {
+		const serviceStateRoot = join(tmpRoot, "var", "lib", "clawdi");
+		const runRoot = join(tmpRoot, "run", "clawdi");
+		const mitmProfileBundle = join(serviceStateRoot, "config", "mitm", "profiles.json");
+		const catalogDir = join(fakeClawdiHome, "ai-providers");
+		mkdirSync(join(serviceStateRoot, "config", "mitm"), { recursive: true });
+		mkdirSync(catalogDir, { recursive: true });
+		writeFileSync(
+			mitmProfileBundle,
+			JSON.stringify({
+				schemaVersion: "clawdi.mitmProfiles.v1",
+				generatedAt: "2026-06-05T00:00:00Z",
+				generation: 1,
+				instanceId: "iid_test",
+				profiles: [],
+			}),
+		);
+		writeFileSync(
+			join(catalogDir, "catalog.json"),
+			JSON.stringify({
+				schema_version: 1,
+				providers: [
+					{
+						id: "managed-openai",
+						type: "openai",
+						label: "Managed OpenAI",
+						base_url: "https://provider.test/v1",
+						default_model: "gpt-5.5",
+						api_mode: "openai_responses",
+						auth: { type: "api_key", source: "managed" },
+						managed_by: "user",
+						runtime_env_name: "CLAWDI_OPENAI_API_KEY",
+					},
+				],
+				defaults: { chat_provider_id: "managed-openai" },
+			}),
+		);
+		const { calls, spawnImpl } = recordSpawn();
+		const broker = recordBroker({
+			proxyUrl: "http://127.0.0.1:19191",
+			caFile: join(runRoot, "mitm", "brokers", "actual", "ca.pem"),
+		});
+		const { captured, restore } = mockFetch([
+			{
+				method: "POST",
+				path: "/api/vault/resolve",
+				response: () => jsonResponse({ RUNTIME_VALUE: "from-vault" }),
+			},
+		]);
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = serviceStateRoot;
+		process.env.CLAWDI_RUN_DIR = runRoot;
+		try {
+			await run(
+				["codex", "exec", "hello"],
+				{ allVaultEnv: true, projectFolder: false },
+				spawnImpl,
+				broker.brokerFactory,
+			);
+		} finally {
+			restore();
+		}
+
+		expect(captured.map((request) => request.path)).toEqual(["/api/vault/resolve"]);
+		expect(broker.calls).toHaveLength(1);
+		expect(broker.calls[0].secretFile).toBe(join(runRoot, "secrets", "runtime-secrets.json"));
+		expect(calls).toHaveLength(1);
+		expect(calls[0].env.RUNTIME_VALUE).toBe("from-vault");
+		expect(calls[0].env.CLAWDI_OPENAI_API_KEY).toBeUndefined();
+		expect(calls[0].env.CLAWDI_MITM_SECRET_FILE).toBeUndefined();
 	});
 
 	it("uses the linked Project folder when resolving vault env", async () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -661,10 +661,8 @@ describe("runtime manifest datasource", () => {
 		const runConfig = JSON.parse(
 			readFileSync(join(state, "config", "run", "openclaw.json"), "utf-8"),
 		);
-		expect(runConfig.secretEnv).toEqual({
-			CLAWDI_MANAGED_OPENAI_API_KEY: "provider.default.apiKey",
-		});
-		expect(runConfig.secretFilePath).toBe(join(run, "mitm", "secrets.json"));
+		expect(runConfig).not.toHaveProperty("secretEnv");
+		expect(runConfig.secretFilePath).toBe(join(run, "secrets", "runtime-secrets.json"));
 		expect(JSON.stringify(runConfig)).not.toContain("sk-runtime-provider");
 	});
 
@@ -810,14 +808,14 @@ describe("runtime manifest datasource", () => {
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const sourcePath = join(root, "runtime-source.json");
-		mkdirSync(join(run, "sync"), { recursive: true });
+		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(home, { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
-		writeFileSync(join(run, "sync", "auth-token"), "file-runtime-token\n");
+		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({
@@ -860,14 +858,14 @@ describe("runtime manifest datasource", () => {
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const sourcePath = join(root, "runtime-source.json");
-		mkdirSync(join(run, "sync"), { recursive: true });
+		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(home, { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
-		writeFileSync(join(run, "sync", "auth-token"), "file-runtime-token\n");
+		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({
@@ -1130,7 +1128,7 @@ describe("runtime manifest datasource", () => {
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const logs: string[] = [];
-		mkdirSync(join(run, "sync"), { recursive: true });
+		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
 		mkdirSync(home, { recursive: true });
 		writeFileSync(
@@ -1158,7 +1156,7 @@ fi
 			logs.push(String(value));
 		};
 		seedCurrentCliInstall(state);
-		writeFileSync(join(run, "sync", "auth-token"), "file-runtime-token\n");
+		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({
@@ -1354,7 +1352,7 @@ fi
 			return match?.[1] ?? "";
 		};
 
-		mkdirSync(join(run, "sync"), { recursive: true });
+		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
 		mkdirSync(dirname(openclawBin), { recursive: true });
 		writeFileSync(
@@ -1394,7 +1392,7 @@ exit 64
 			logs.push(String(value));
 		};
 		seedCurrentCliInstall(state);
-		writeFileSync(join(run, "sync", "auth-token"), "file-runtime-token\n");
+		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({
@@ -1433,7 +1431,9 @@ exit 64
 		}
 		const baselineConfig = readFileSync(paths.supervisorConfig, "utf-8");
 		const baselineRevision = openclawRevision(baselineConfig);
-		const baselineSecrets = JSON.parse(readFileSync(join(run, "mitm", "secrets.json"), "utf-8"));
+		const baselineSecrets = JSON.parse(
+			readFileSync(join(run, "secrets", "runtime-secrets.json"), "utf-8"),
+		);
 		expect(baselineSecrets["secret://provider.default.apiKey"]).toBe("sk-provider-watch");
 		expect(baselineSecrets[channelSecretRef]).toBe("agent-token-watch");
 
@@ -1470,7 +1470,9 @@ exit 64
 			expect(event.status).toBe("applied");
 			expect(event.generation).toBe(22);
 			expect(event.supervisorConfigChanged).toBe(false);
-			const secrets = JSON.parse(readFileSync(join(run, "mitm", "secrets.json"), "utf-8"));
+			const secrets = JSON.parse(
+				readFileSync(join(run, "secrets", "runtime-secrets.json"), "utf-8"),
+			);
 			expect(secrets["secret://provider.default.apiKey"]).toBe("sk-provider-watch");
 			expect(secrets[channelSecretRef]).toBe("agent-token-watch");
 			const supervisorConfig = readFileSync(paths.supervisorConfig, "utf-8");
@@ -1493,7 +1495,7 @@ exit 64
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const logs: string[] = [];
-		mkdirSync(join(run, "sync"), { recursive: true });
+		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
 		mkdirSync(home, { recursive: true });
 		writeFileSync(
@@ -1515,7 +1517,7 @@ fi
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
 		process.env.CLAWDI_SUPERVISORCTL_PATH = join(bin, "supervisorctl");
-		writeFileSync(join(run, "sync", "auth-token"), "file-runtime-token\n");
+		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({
@@ -1601,14 +1603,14 @@ fi
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const logs: string[] = [];
-		mkdirSync(join(run, "sync"), { recursive: true });
+		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(home, { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
-		writeFileSync(join(run, "sync", "auth-token"), "revoked-runtime-token\n");
+		writeFileSync(join(run, "secrets", "auth-token"), "revoked-runtime-token\n");
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({
@@ -1975,7 +1977,7 @@ fi
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
 		const logs: string[] = [];
-		mkdirSync(join(run, "sync"), { recursive: true });
+		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
 		mkdirSync(home, { recursive: true });
 		writeFileSync(
@@ -2034,7 +2036,7 @@ fi
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		writeFileSync(join(run, "sync", "auth-token"), "file-runtime-token\n");
+		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({
@@ -2154,7 +2156,7 @@ fi
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
 		const logs: string[] = [];
-		mkdirSync(join(run, "sync"), { recursive: true });
+		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
 		mkdirSync(home, { recursive: true });
 		writeFileSync(
@@ -2216,7 +2218,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		writeFileSync(join(run, "sync", "auth-token"), "file-runtime-token\n");
+		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({
@@ -2312,7 +2314,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 		const previousLog = console.log;
 		const previousPath = process.env.PATH;
 		const logs: string[] = [];
-		mkdirSync(join(run, "sync"), { recursive: true });
+		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
 		mkdirSync(home, { recursive: true });
 		writeFileSync(join(bin, "npm"), "#!/usr/bin/env bash\necho npm down >&2\nexit 42\n");
@@ -2341,7 +2343,7 @@ fi
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		writeFileSync(join(run, "sync", "auth-token"), "file-runtime-token\n");
+		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({
@@ -2699,7 +2701,7 @@ chmod +x "$prefix/bin/clawdi"
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const logs: string[] = [];
-		mkdirSync(join(run, "sync"), { recursive: true });
+		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(join(home, ".openclaw", "bin"), { recursive: true });
 		mkdirSync(join(root, "etc", "clawdi"), { recursive: true });
 		writeFileSync(
@@ -2729,7 +2731,7 @@ exit 64
 				deniedCommands: ["setup", "teardown", "update"],
 			}),
 		);
-		writeFileSync(join(run, "sync", "auth-token"), "file-runtime-token\n");
+		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({
@@ -2855,7 +2857,7 @@ exit 64
 			expect(patchText).toContain('"token": "discord-agent-token-init"');
 			expect(patchText).toContain('"plugins"');
 			expect(readFileSync(openclawPluginInstalls, "utf-8")).toBe("@openclaw/discord\n");
-			const secretsText = readFileSync(join(run, "mitm", "secrets.json"), "utf-8");
+			const secretsText = readFileSync(join(run, "secrets", "runtime-secrets.json"), "utf-8");
 			expect(secretsText).toContain("secret://channels/telegram/");
 			expect(secretsText).toContain("agent-token-init");
 			expect(secretsText).toContain("secret://channels/discord/");
@@ -3345,7 +3347,7 @@ exit 64
 		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
 
 		expect(convergence.installErrors).toEqual([]);
-		const authTokenFile = join(run, "sync", "auth-token");
+		const authTokenFile = join(run, "secrets", "auth-token");
 		const openclawConfig = JSON.parse(readFileSync(openclawMcp, "utf-8"));
 		expect(openclawConfig.command).toBe("/bin/sh");
 		expect(openclawConfig.args[0]).toBe("-lc");
@@ -3458,7 +3460,11 @@ exit 64
 		expect(supervisorConfig).toContain("command=/usr/bin/env clawdi runtime ui-bridge");
 		expect(supervisorConfig).toContain('CLAWDI_UI_BRIDGE_LISTEN_HOST="10.42.0.20"');
 		expect(supervisorConfig).toContain('CLAWDI_RUNTIME_REV="');
-		expect(supervisorConfig).not.toContain("ui-secret");
+		const uiBridgeSection = supervisorConfig.split("[program:clawdi-openclaw]")[0];
+		const openclawSection = supervisorConfig.split("[program:clawdi-openclaw]")[1] ?? "";
+		expect(uiBridgeSection).toContain('UI_ACCESS_TOKEN="ui-secret"');
+		expect(openclawSection).toContain('UI_ACCESS_TOKEN=""');
+		expect(openclawSection).not.toContain("ui-secret");
 	});
 
 	it("does not advance last-good manifest cache when convergence has install errors", async () => {
@@ -3764,7 +3770,7 @@ exit 64
 
 			expect(convergence.mode).toBe("normal");
 			expect(convergence.outputs.mitmProfileBundle).toBe(null);
-			expect(convergence.outputs.mitmSecretFile).toBe(join(run, "mitm", "secrets.json"));
+			expect(convergence.outputs.mitmSecretFile).toBe(join(run, "secrets", "runtime-secrets.json"));
 			expect(convergence.outputs.supervisorConfig).toBe(
 				join(state, "supervisor", "supervisord.conf"),
 			);
@@ -3780,7 +3786,9 @@ exit 64
 			expect(readFileSync(join(state, "cache", "manifest.last-good.json"), "utf-8")).not.toContain(
 				"sk-runtime",
 			);
-			expect(readFileSync(join(run, "mitm", "secrets.json"), "utf-8")).toContain("sk-runtime");
+			expect(readFileSync(join(run, "secrets", "runtime-secrets.json"), "utf-8")).toContain(
+				"sk-runtime",
+			);
 			const providerHealth = JSON.parse(
 				readFileSync(join(state, "status", "provider-health.json"), "utf-8"),
 			);
@@ -4026,14 +4034,16 @@ exit 64
 				join(home, ".clawdi", "environments", "codex.json"),
 				join(home, ".clawdi", "environments", "openclaw.json"),
 			]);
-			expect(convergence.outputs.daemonAuthTokenFile).toBe(join(run, "sync", "auth-token"));
-			expect(readFileSync(join(run, "sync", "auth-token"), "utf-8")).toBe("runtime-auth-token\n");
+			expect(convergence.outputs.daemonAuthTokenFile).toBe(join(run, "secrets", "auth-token"));
+			expect(readFileSync(join(run, "secrets", "auth-token"), "utf-8")).toBe(
+				"runtime-auth-token\n",
+			);
 			expect(openclawEnv.id).toBe("env-openclaw");
 			expect(codexEnv.id).toBe("env-codex");
 			expect(supervisorConfig).toContain("[program:clawdi-runtime-watch]");
 			expect(supervisorConfig).toContain("command=/usr/bin/env clawdi runtime watch");
-			expect(supervisorConfig).toContain("chmod=0770");
-			expect(supervisorConfig).toContain("chown=clawdi:clawdi");
+			expect(supervisorConfig).toContain("chmod=0700");
+			expect(supervisorConfig).toContain("chown=root:root");
 			expect(supervisorConfig).toContain("[program:clawdi-daemon]");
 			expect(supervisorConfig).toContain("clawdi daemon run");
 			expect(supervisorConfig).toContain('CLAWDI_SERVE_MODE="container"');


### PR DESCRIPTION
## Summary
- keep hosted runtime provider secrets in root-owned managed secret files and pass them only to the MITM broker
- prevent hosted runtime commands from resolving cloud-managed provider keys into child env
- add tests for generic hosted run secret-file handling and hosted no-provider-key injection

## Verification
- bun test packages/cli/tests/commands/run.test.ts packages/cli/tests/runtime.test.ts packages/cli/tests/runtime-mitm-profiles.test.ts
- bun run typecheck --filter=clawdi
- git diff --check