### PR TITLE
Enable managed Codex MITM profiles for hosted runtime

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.9",
+      "version": "0.12.10-beta.10",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.9",
+	"version": "0.12.10-beta.10",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/hosted-mitm-profiles.ts
+++ b/packages/cli/src/runtime/hosted-mitm-profiles.ts
@@ -17,13 +17,15 @@ interface HostedProviderProjection {
 	apiKeySecretRef?: string | null;
 }
 
+const MANAGED_MITM_PLACEHOLDER_VALUE = "clawdi-mitm-placeholder";
+
 export function hostedManifestMitmProfiles(
 	hosted: HostedRuntimeManifestProjection,
 ): MitmProfileInputBundle {
 	if (hosted.mitmProfiles !== undefined) {
 		return mitmProfileInputBundleSchema.parse(hosted.mitmProfiles);
 	}
-	return { profiles: [] };
+	return { profiles: managedProviderMitmProfiles(hosted) };
 }
 
 function providerUsesDirectProjection(apiMode: string | null): boolean {
@@ -53,6 +55,54 @@ export function directProviderPassthroughProfile(
 		priority: 240,
 		owner: "provider-projection",
 	};
+}
+
+function managedProviderMitmProfiles(hosted: HostedRuntimeManifestProjection): HostedMitmProfile[] {
+	const provider = defaultProviderProjection(hosted.providers);
+	const providerBaseUrl = cleanBaseUrl(provider?.baseUrl);
+	const providerApiMode = cleanString(provider?.apiMode);
+	const secretRef = normalizeSecretRef(provider?.apiKeySecretRef);
+	if (!providerBaseUrl || !providerUsesCodexBackendProjection(providerApiMode) || !secretRef) {
+		return [];
+	}
+	return [
+		{
+			id: "codex-chatgpt-backend-responses",
+			enabled: true,
+			kind: "provider",
+			match: {
+				scheme: "https",
+				host: "chatgpt.com",
+				path: { type: "equals", value: "/backend-api/codex/responses" },
+				headers: {
+					authorization: {
+						type: "equals",
+						value: MANAGED_MITM_PLACEHOLDER_VALUE,
+						prefix: "Bearer ",
+					},
+				},
+				query: {},
+			},
+			rewrite: {
+				upstreamBaseUrl: codexBackendResponsesUrl(providerBaseUrl),
+				preservePath: false,
+				setHeaders: {
+					authorization: {
+						type: "secretRef",
+						secretRef,
+						prefix: "Bearer ",
+					},
+				},
+			},
+			logging: { redactHeaders: ["authorization"], redactUrlPatterns: [] },
+			priority: 125,
+			owner: "provider-projection",
+		},
+	];
+}
+
+function providerUsesCodexBackendProjection(apiMode: string | null): boolean {
+	return apiMode === "codex_responses" || apiMode === "openai_responses";
 }
 
 export function normalizeSecretRef(value: string | null | undefined): string | null {
@@ -88,4 +138,21 @@ function providerPathPrefix(pathname: string): string {
 	const cleaned = pathname.replace(/\/+$/, "");
 	if (!cleaned) return "/";
 	return `${cleaned}/`;
+}
+
+function codexBackendResponsesUrl(baseUrl: string): string {
+	const parsed = new URL(baseUrl);
+	const path = parsed.pathname.replace(/\/+$/, "");
+	if (path.endsWith("/backend-api/codex/responses")) {
+		parsed.pathname = path;
+	} else if (path.endsWith("/backend-api/codex")) {
+		parsed.pathname = `${path}/responses`;
+	} else if (path.endsWith("/v1")) {
+		parsed.pathname = `${path.slice(0, -"/v1".length)}/backend-api/codex/responses`;
+	} else {
+		parsed.pathname = `${path}/backend-api/codex/responses`;
+	}
+	parsed.search = "";
+	parsed.hash = "";
+	return parsed.toString().replace(/\/$/, "");
 }

--- a/packages/cli/tests/runtime-mitm-profiles.test.ts
+++ b/packages/cli/tests/runtime-mitm-profiles.test.ts
@@ -123,6 +123,54 @@ describe("runtime MITM profile schema", () => {
 		expect(bundle.profiles).toEqual([]);
 	});
 
+	it("enables the hosted broker for managed Codex provider projection", () => {
+		const bundle = hostedManifestMitmProfiles({
+			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+			providers: {
+				default: {
+					baseUrl: "https://ai-gateway.example.test/v1",
+					apiMode: "codex_responses",
+					apiKeySecretRef: "provider.default.apiKey",
+				},
+			},
+		});
+
+		expect(bundle.profiles).toEqual([
+			{
+				id: "codex-chatgpt-backend-responses",
+				enabled: true,
+				kind: "provider",
+				match: {
+					scheme: "https",
+					host: "chatgpt.com",
+					path: { type: "equals", value: "/backend-api/codex/responses" },
+					headers: {
+						authorization: {
+							type: "equals",
+							value: "clawdi-mitm-placeholder",
+							prefix: "Bearer ",
+						},
+					},
+					query: {},
+				},
+				rewrite: {
+					upstreamBaseUrl: "https://ai-gateway.example.test/backend-api/codex/responses",
+					preservePath: false,
+					setHeaders: {
+						authorization: {
+							type: "secretRef",
+							secretRef: "secret://provider.default.apiKey",
+							prefix: "Bearer ",
+						},
+					},
+				},
+				logging: { redactHeaders: ["authorization"], redactUrlPatterns: [] },
+				priority: 125,
+				owner: "provider-projection",
+			},
+		]);
+	});
+
 	it("builds a direct provider allowlist only when another manifest feature enables the broker", () => {
 		const direct = directProviderPassthroughProfile({
 			providers: {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -568,6 +568,84 @@ describe("runtime manifest datasource", () => {
 		}
 	});
 
+	it("generates managed Codex MITM profiles from hosted-runtime manifests", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime-source.test/desired-state";
+		process.env.CLAWDI_AUTH_TOKEN = "runtime-auth-token";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/desired-state",
+				response: () =>
+					jsonResponse({
+						manifest: {
+							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							deploymentId: "dep_codex_provider",
+							environmentId: "env_codex_provider",
+							appId: "app_codex_provider",
+							instanceId: "iid_codex_provider",
+							generation: 1,
+							issuedAt: "2026-06-22T00:00:00Z",
+							system: { home, workspace: join(home, "clawdi") },
+							controlPlane: {
+								manifestUrl: "https://runtime-source.test/desired-state",
+								cloudApiUrl: "https://cloud-api.test",
+							},
+							runtimes: {
+								openclaw: { enabled: false },
+								hermes: { enabled: false },
+							},
+							providers: {
+								default: {
+									kind: "openai-compatible",
+									baseUrl: "https://ai-gateway.example.test/v1",
+									model: "openai-codex/gpt-5.4-mini",
+									apiMode: "codex_responses",
+									runtimeEnvName: "CLAWDI_MANAGED_OPENAI_API_KEY",
+									apiKeySecretRef: "provider.default.apiKey",
+								},
+							},
+						},
+						secretValues: {
+							"provider.default.apiKey": "sk-runtime",
+						},
+					}),
+			},
+		]);
+
+		try {
+			const loaded = await loadRuntimeManifest(getRuntimePaths());
+			expect("manifest" in loaded).toBe(true);
+			if (!("manifest" in loaded)) throw new Error("expected manifest load success");
+			expect(loaded.manifest.mitmProfiles?.profiles).toEqual([
+				expect.objectContaining({
+					id: "codex-chatgpt-backend-responses",
+					kind: "provider",
+					match: expect.objectContaining({
+						scheme: "https",
+						host: "chatgpt.com",
+						path: { type: "equals", value: "/backend-api/codex/responses" },
+					}),
+					rewrite: expect.objectContaining({
+						upstreamBaseUrl: "https://ai-gateway.example.test/backend-api/codex/responses",
+						preservePath: false,
+					}),
+					owner: "provider-projection",
+				}),
+			]);
+			expect(JSON.stringify(loaded.manifest.mitmProfiles)).not.toContain("sk-runtime");
+		} finally {
+			restore();
+		}
+	});
+
 	it("projects hosted OpenAI chat providers directly into OpenClaw config", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");


### PR DESCRIPTION
## Summary
- generate a managed ChatGPT backend MITM profile when hosted runtime provider projection uses managed Codex/Responses auth
- keep direct OpenAI chat providers on direct projection without enabling the broker
- bump CLI beta to 0.12.10-beta.10

## Verification
- bun run check
- bun run typecheck
- bun test packages/cli/tests/runtime-mitm-profiles.test.ts packages/cli/tests/runtime.test.ts packages/cli/tests/runtime-mitm-env.test.ts packages/cli/tests/commands/run.test.ts