### PR TITLE
Add hosted runtime agent command shims

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.10",
+	"version": "0.12.10-beta.11",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -290,6 +290,8 @@ const SUPPORTED_RUNTIME_NAMES = [
 	"openclaw",
 ] as const satisfies readonly SupportedRuntimeName[];
 
+type RuntimeCommandShimName = SupportedRuntimeName | "codex";
+
 function isSupportedRuntimeName(name: string): name is SupportedRuntimeName {
 	return (SUPPORTED_RUNTIME_NAMES as readonly string[]).includes(name);
 }
@@ -1389,6 +1391,41 @@ function writeSupervisorConfig(
 	return paths.supervisorConfig;
 }
 
+function writeRuntimeCommandShims(commands: RuntimeCommandShimName[], paths: RuntimePaths): void {
+	const active = new Set(commands);
+	for (const command of ["codex", ...SUPPORTED_RUNTIME_NAMES] satisfies RuntimeCommandShimName[]) {
+		const shimPath = join(paths.serviceStateRoot, "bin", command);
+		if (!active.has(command)) {
+			rmSync(shimPath, { force: true });
+			continue;
+		}
+		writePrivateFileAtomic(shimPath, runtimeCommandShimScript(command, paths), {
+			mode: 0o755,
+			dirMode: 0o755,
+		});
+		makeRuntimeUserOwned(shimPath);
+	}
+}
+
+function runtimeCommandShimScript(command: RuntimeCommandShimName, paths: RuntimePaths): string {
+	return [
+		"#!/usr/bin/env sh",
+		"set -eu",
+		'shim_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)',
+		"old_ifs=$" + "{IFS-}",
+		"IFS=:",
+		"clean_path=",
+		"for dir in $" + "{PATH-}; do",
+		'  [ "$dir" = "$shim_dir" ] && continue',
+		'  if [ -z "$clean_path" ]; then clean_path=$dir; else clean_path=$clean_path:$dir; fi',
+		"done",
+		"IFS=$old_ifs",
+		"export PATH=$clean_path",
+		`exec ${shellQuote(paths.cliManagedBin)} run -- ${command} "$@"`,
+		"",
+	].join("\n");
+}
+
 function supervisorPath(paths: RuntimePaths): string {
 	return [
 		join(paths.serviceStateRoot, "bin"),
@@ -1429,6 +1466,7 @@ export function convergeRuntimeManifest(
 	const installInventory: string[] = [];
 	const projections: string[] = [];
 	const runConfigs: string[] = [];
+	const commandShims: RuntimeCommandShimName[] = [];
 	const installErrors: string[] = [];
 
 	mkdirSync(workspaceRoot, { recursive: true });
@@ -1498,6 +1536,7 @@ export function convergeRuntimeManifest(
 	const mitmProfileBundlePath = hasEnabledMitmProfiles(mitmProfileBundle)
 		? writeMitmProfileBundle(mitmProfileBundle, paths)
 		: clearMitmProfileBundle(paths);
+	if (mitmProfileBundlePath) commandShims.push("codex");
 	const mitmSecretFile = writeSecretValues(load.secretValues, paths);
 	writeProviderHealthStatus(manifest, load.secretValues, paths);
 	const liveSyncEnvironments = writeLiveSyncEnvironmentFiles(manifest, paths);
@@ -1593,6 +1632,9 @@ export function convergeRuntimeManifest(
 			);
 			runConfigs.push(runConfigPath);
 			writtenRunConfigRuntimes.add(name);
+			if (runtime.enabled && observation.commandPath && observation.status !== "install_failed") {
+				commandShims.push(name);
+			}
 		}
 
 		const semaphorePath = join(semRoot, `${name}.enabled`);
@@ -1605,6 +1647,7 @@ export function convergeRuntimeManifest(
 	const mcpProjection = join(paths.projectionRoot, "clawdi-mcp.json");
 	writeJsonFile(mcpProjection, projectionPayload("clawdi-mcp", manifest));
 	projections.push(mcpProjection);
+	writeRuntimeCommandShims(commandShims, paths);
 
 	const bootFinished = join(instanceRoot, "boot-finished");
 	writePrivateFileAtomic(bootFinished, `${generatedAt}\n`);

--- a/packages/cli/tests/runtime-mitm-profiles.test.ts
+++ b/packages/cli/tests/runtime-mitm-profiles.test.ts
@@ -198,7 +198,7 @@ describe("runtime MITM profile schema", () => {
 		});
 	});
 
-	it("does not derive provider MITM profiles from provider projection", () => {
+	it("does not derive provider MITM profiles without a managed Codex projection", () => {
 		const bundle = hostedManifestMitmProfiles({
 			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 			providers: {

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -398,11 +398,21 @@ chmod +x "$HOME/.local/bin/hermes"
 				join(serviceStateRoot, "supervisor", "supervisord.conf"),
 				join(serviceStateRoot, "config", "mitm", "profiles.json"),
 				join(serviceStateRoot, "instances", "iid_test", "boot-finished"),
+				join(serviceStateRoot, "bin", "openclaw"),
+				join(serviceStateRoot, "bin", "hermes"),
+				join(serviceStateRoot, "bin", "codex"),
 				join(home, "clawdi"),
 				join(home, ".openclaw", "bin", "openclaw"),
 				join(home, ".local", "bin", "hermes"),
 			]) {
 				expect(existsSync(outputPath)).toBe(true);
+			}
+			for (const command of ["openclaw", "hermes", "codex"]) {
+				const shim = readFileSync(join(serviceStateRoot, "bin", command), "utf-8");
+				expect(shim).toContain("clean_path=");
+				expect(shim).toContain(
+					`exec '${join(serviceStateRoot, "bin", "clawdi")}' run -- ${command} "$@"`,
+				);
 			}
 			expect(statSync(join(serviceStateRoot, "cache", "boot-status.json")).mode & 0o777).toBe(
 				0o644,
@@ -700,6 +710,9 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 			expect(parsed.enabledRuntimes).toEqual(["openclaw"]);
 			expect(existsSync(join(home, ".openclaw", "bin", "openclaw"))).toBe(true);
 			expect(existsSync(join(home, ".local", "bin", "hermes"))).toBe(false);
+			expect(existsSync(join(serviceStateRoot, "bin", "openclaw"))).toBe(true);
+			expect(existsSync(join(serviceStateRoot, "bin", "hermes"))).toBe(false);
+			expect(existsSync(join(serviceStateRoot, "bin", "codex"))).toBe(false);
 
 			const openclawInventory = JSON.parse(
 				readFileSync(join(serviceStateRoot, "install-inventory", "openclaw.json"), "utf-8"),


### PR DESCRIPTION
## Summary\n- add hosted runtime command shims for openclaw and hermes so interactive shell usage goes through `clawdi run`\n- add a codex shim when a hosted MITM profile bundle is active so managed AI calls use the broker path\n- keep native agent binaries and configs intact; shims remove their own bin dir from PATH before launching Clawdi to avoid recursion\n\n## Verification\n- bun run check\n- bun run typecheck\n- bun test packages/cli/tests/smoke.test.ts packages/cli/tests/commands/run.test.ts packages/cli/tests/runtime-mitm-profiles.test.ts