### PR TITLE
Shadow disabled hosted runtime commands

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.11",
+	"version": "0.12.10-beta.12",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1632,9 +1632,7 @@ export function convergeRuntimeManifest(
 			);
 			runConfigs.push(runConfigPath);
 			writtenRunConfigRuntimes.add(name);
-			if (runtime.enabled && observation.commandPath && observation.status !== "install_failed") {
-				commandShims.push(name);
-			}
+			commandShims.push(name);
 		}
 
 		const semaphorePath = join(semRoot, `${name}.enabled`);

--- a/packages/cli/tests/commands/run.test.ts
+++ b/packages/cli/tests/commands/run.test.ts
@@ -268,6 +268,58 @@ describe("run command project folder selection", () => {
 		);
 	});
 
+	it("rejects disabled hosted runtime commands before native binaries can run", async () => {
+		unlinkSync(join(fakeClawdiHome, "auth.json"));
+		const serviceStateRoot = join(tmpRoot, "var", "lib", "clawdi");
+		const runRoot = join(tmpRoot, "run", "clawdi");
+		const hermesPath = join(tmpRoot, "home", "clawdi", ".local", "bin", "hermes");
+		const runConfigRoot = join(serviceStateRoot, "config", "run");
+		mkdirSync(runConfigRoot, { recursive: true });
+		mkdirSync(join(tmpRoot, "home", "clawdi", ".local", "bin"), { recursive: true });
+		writeFileSync(
+			join(runConfigRoot, "hermes.json"),
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeRunConfig.v1",
+				runtime: "hermes",
+				enabled: false,
+				generatedAt: "2026-06-25T00:00:00Z",
+				generation: 2,
+				instanceId: "iid_test",
+				command: "hermes",
+				defaultArgs: [],
+				env: {},
+				prependPath: [join(tmpRoot, "home", "clawdi", ".local", "bin")],
+				cwd: projectRoot,
+				commandPath: hermesPath,
+				appRoot: join(tmpRoot, "home", "clawdi", ".hermes", "hermes-agent"),
+			}),
+		);
+		writeFileSync(hermesPath, "#!/usr/bin/env sh\n");
+		const { calls, spawnImpl } = recordSpawn();
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = serviceStateRoot;
+		process.env.CLAWDI_RUN_DIR = runRoot;
+
+		const originalExit = process.exit;
+		const originalLog = console.log;
+		const logs: string[] = [];
+		process.exit = ((code?: string | number | null) => {
+			throw new Error(`process.exit:${code ?? 0}`);
+		}) as typeof process.exit;
+		console.log = (message?: unknown) => {
+			logs.push(String(message ?? ""));
+		};
+		try {
+			await expect(run(["hermes"], {}, spawnImpl)).rejects.toThrow("process.exit:1");
+		} finally {
+			console.log = originalLog;
+			process.exit = originalExit;
+		}
+
+		expect(calls).toHaveLength(0);
+		expect(logs.join("\n")).toContain("Runtime hermes is disabled");
+	});
+
 	it("passes hosted runtime provider secrets only to the managed MITM broker", async () => {
 		unlinkSync(join(fakeClawdiHome, "auth.json"));
 		const serviceStateRoot = join(tmpRoot, "var", "lib", "clawdi");

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -711,8 +711,11 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 			expect(existsSync(join(home, ".openclaw", "bin", "openclaw"))).toBe(true);
 			expect(existsSync(join(home, ".local", "bin", "hermes"))).toBe(false);
 			expect(existsSync(join(serviceStateRoot, "bin", "openclaw"))).toBe(true);
-			expect(existsSync(join(serviceStateRoot, "bin", "hermes"))).toBe(false);
+			expect(existsSync(join(serviceStateRoot, "bin", "hermes"))).toBe(true);
 			expect(existsSync(join(serviceStateRoot, "bin", "codex"))).toBe(false);
+			expect(readFileSync(join(serviceStateRoot, "bin", "hermes"), "utf-8")).toContain(
+				`exec '${join(serviceStateRoot, "bin", "clawdi")}' run -- hermes "$@"`,
+			);
 
 			const openclawInventory = JSON.parse(
 				readFileSync(join(serviceStateRoot, "install-inventory", "openclaw.json"), "utf-8"),


### PR DESCRIPTION
## Summary
- Always write hosted runtime command shims for declared OpenClaw/Hermes run configs
- Disabled runtimes now fail through `clawdi run -- <agent>` instead of falling through to native binaries on PATH
- Bump CLI to `0.12.10-beta.12`

## Verification
- `bun test packages/cli/tests/smoke.test.ts packages/cli/tests/commands/run.test.ts packages/cli/tests/runtime-mitm-profiles.test.ts`
- `bun run check`
- `bun run typecheck`
