### PR TITLE
Shadow hosted runtime agent commands

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.12",
+	"version": "0.12.10-beta.13",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1466,7 +1466,7 @@ export function convergeRuntimeManifest(
 	const installInventory: string[] = [];
 	const projections: string[] = [];
 	const runConfigs: string[] = [];
-	const commandShims: RuntimeCommandShimName[] = [];
+	const commandShims: RuntimeCommandShimName[] = ["codex", ...SUPPORTED_RUNTIME_NAMES];
 	const installErrors: string[] = [];
 
 	mkdirSync(workspaceRoot, { recursive: true });
@@ -1536,7 +1536,6 @@ export function convergeRuntimeManifest(
 	const mitmProfileBundlePath = hasEnabledMitmProfiles(mitmProfileBundle)
 		? writeMitmProfileBundle(mitmProfileBundle, paths)
 		: clearMitmProfileBundle(paths);
-	if (mitmProfileBundlePath) commandShims.push("codex");
 	const mitmSecretFile = writeSecretValues(load.secretValues, paths);
 	writeProviderHealthStatus(manifest, load.secretValues, paths);
 	const liveSyncEnvironments = writeLiveSyncEnvironmentFiles(manifest, paths);
@@ -1632,7 +1631,6 @@ export function convergeRuntimeManifest(
 			);
 			runConfigs.push(runConfigPath);
 			writtenRunConfigRuntimes.add(name);
-			commandShims.push(name);
 		}
 
 		const semaphorePath = join(semRoot, `${name}.enabled`);

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -712,10 +712,12 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 			expect(existsSync(join(home, ".local", "bin", "hermes"))).toBe(false);
 			expect(existsSync(join(serviceStateRoot, "bin", "openclaw"))).toBe(true);
 			expect(existsSync(join(serviceStateRoot, "bin", "hermes"))).toBe(true);
-			expect(existsSync(join(serviceStateRoot, "bin", "codex"))).toBe(false);
-			expect(readFileSync(join(serviceStateRoot, "bin", "hermes"), "utf-8")).toContain(
-				`exec '${join(serviceStateRoot, "bin", "clawdi")}' run -- hermes "$@"`,
-			);
+			expect(existsSync(join(serviceStateRoot, "bin", "codex"))).toBe(true);
+			for (const command of ["hermes", "codex"]) {
+				expect(readFileSync(join(serviceStateRoot, "bin", command), "utf-8")).toContain(
+					`exec '${join(serviceStateRoot, "bin", "clawdi")}' run -- ${command} "$@"`,
+				);
+			}
 
 			const openclawInventory = JSON.parse(
 				readFileSync(join(serviceStateRoot, "install-inventory", "openclaw.json"), "utf-8"),


### PR DESCRIPTION
## Summary
- Always shadow managed runtime agent commands: `openclaw`, `hermes`, and `codex`
- Unconfigured/disabled agents now fail through `clawdi run -- <agent>` instead of falling through to native binaries on PATH
- Bump CLI to `0.12.10-beta.13`

## Verification
- `bun test packages/cli/tests/smoke.test.ts packages/cli/tests/commands/run.test.ts packages/cli/tests/runtime-mitm-profiles.test.ts`
- `bun run check`
- `bun run typecheck`
