### PR TITLE
Clean hosted managed provider runtime projection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.10",
+      "version": "0.12.10-beta.14",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.13",
+	"version": "0.12.10-beta.14",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/lib/ai-provider-projection.ts
+++ b/packages/cli/src/lib/ai-provider-projection.ts
@@ -84,9 +84,7 @@ const HERMES_TRANSPORT_LABELS: Partial<Record<AiProviderApiMode, string>> = {
 };
 
 const HERMES_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex";
-const OPENCLAW_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const OPENCLAW_CODEX_PROVIDER_ID = "openai";
-const MANAGED_MITM_PLACEHOLDER_ENV = "CLAWDI_PROVIDER_PLACEHOLDER_TOKEN";
 
 export function buildAgentTargetProjection(
 	target: AgentTarget,
@@ -301,23 +299,12 @@ function openClawApiLabel(apiMode: AiProviderApiMode): string | undefined {
 	return OPENCLAW_API_LABELS[apiMode];
 }
 
-function isClawdiManagedProvider(provider: ProjectionProvider): boolean {
-	return provider.managed_by === "clawdi" || provider.id === "clawdi-managed";
-}
-
 function isCodexResponsesApiMode(apiMode: AiProviderApiMode): boolean {
-	return apiMode === "codex_responses" || apiMode === "openai_responses";
-}
-
-function usesManagedCodexMitm(provider: ProjectionProvider): boolean {
-	return isClawdiManagedProvider(provider) && isCodexResponsesApiMode(provider.api_mode);
+	return apiMode === "codex_responses";
 }
 
 function usesOpenClawCodexResponsesRuntime(provider: ProjectionProvider): boolean {
-	return (
-		provider.api_mode === "codex_responses" ||
-		(provider.api_mode === "openai_responses" && isClawdiManagedProvider(provider))
-	);
+	return provider.api_mode === "codex_responses";
 }
 
 function openClawProjectionSkipReason(provider: ProjectionProvider): string | undefined {
@@ -347,13 +334,12 @@ function openClawModelId(provider: ProjectionProvider, modelId: string): string 
 }
 
 function openClawBaseUrlForProvider(provider: ProjectionProvider): string {
-	if (usesManagedCodexMitm(provider)) return OPENCLAW_CODEX_BASE_URL;
 	if (!usesOpenClawCodexResponsesRuntime(provider)) return provider.base_url;
 	return openClawCodexBaseUrl(provider.base_url);
 }
 
 function openClawApiKeyEnvForProvider(provider: ProjectionProvider): string | undefined {
-	return usesManagedCodexMitm(provider) ? MANAGED_MITM_PLACEHOLDER_ENV : provider.env_name;
+	return provider.env_name;
 }
 
 function openClawCodexBaseUrl(input: string): string {
@@ -399,9 +385,6 @@ function buildHermesProjection(
 		lines.push('  provider: "openai-codex"');
 		lines.push(`  default: ${quoteYaml(codexNativeModelId(defaultProvider.default_model))}`);
 		lines.push(`  base_url: ${quoteYaml(HERMES_CODEX_BASE_URL)}`);
-	} else if (usesManagedCodexMitm(defaultProvider)) {
-		lines.push(`  provider: ${quoteYaml(hermesProviderSelector(defaultProvider.id))}`);
-		lines.push(`  default: ${quoteYaml(codexNativeModelId(defaultProvider.default_model))}`);
 	} else {
 		lines.push(`  provider: ${quoteYaml(hermesProviderSelector(defaultProvider.id))}`);
 		lines.push(`  default: ${quoteYaml(defaultProvider.default_model)}`);
@@ -418,7 +401,7 @@ function buildHermesProjection(
 		if (provider.label) lines.push(`    name: ${quoteYaml(provider.label)}`);
 		lines.push(`    api: ${quoteYaml(hermesBaseUrlForProvider(provider))}`);
 		lines.push(`    transport: ${quoteYaml(transport)}`);
-		lines.push(`    default_model: ${quoteYaml(hermesModelId(provider, provider.default_model))}`);
+		lines.push(`    default_model: ${quoteYaml(provider.default_model)}`);
 		const envName = hermesKeyEnvForProvider(provider);
 		if (envName) lines.push(`    key_env: ${quoteYaml(envName)}`);
 	}
@@ -426,15 +409,11 @@ function buildHermesProjection(
 }
 
 function hermesBaseUrlForProvider(provider: ProjectionProvider): string {
-	return usesManagedCodexMitm(provider) ? HERMES_CODEX_BASE_URL : provider.base_url;
-}
-
-function hermesModelId(provider: ProjectionProvider, modelId: string): string {
-	return usesManagedCodexMitm(provider) ? codexNativeModelId(modelId) : modelId;
+	return provider.base_url;
 }
 
 function hermesKeyEnvForProvider(provider: ProjectionProvider): string | undefined {
-	return usesManagedCodexMitm(provider) ? MANAGED_MITM_PLACEHOLDER_ENV : provider.env_name;
+	return provider.env_name;
 }
 
 function hermesProjectionSkipReason(provider: ProjectionProvider): string | undefined {

--- a/packages/cli/src/runtime/hosted-mitm-profiles.ts
+++ b/packages/cli/src/runtime/hosted-mitm-profiles.ts
@@ -14,10 +14,7 @@ interface HostedRuntimeManifestProjection {
 interface HostedProviderProjection {
 	baseUrl?: string | null;
 	apiMode?: string | null;
-	apiKeySecretRef?: string | null;
 }
-
-const MANAGED_MITM_PLACEHOLDER_VALUE = "clawdi-mitm-placeholder";
 
 export function hostedManifestMitmProfiles(
 	hosted: HostedRuntimeManifestProjection,
@@ -25,7 +22,7 @@ export function hostedManifestMitmProfiles(
 	if (hosted.mitmProfiles !== undefined) {
 		return mitmProfileInputBundleSchema.parse(hosted.mitmProfiles);
 	}
-	return { profiles: managedProviderMitmProfiles(hosted) };
+	return { profiles: [] };
 }
 
 function providerUsesDirectProjection(apiMode: string | null): boolean {
@@ -55,54 +52,6 @@ export function directProviderPassthroughProfile(
 		priority: 240,
 		owner: "provider-projection",
 	};
-}
-
-function managedProviderMitmProfiles(hosted: HostedRuntimeManifestProjection): HostedMitmProfile[] {
-	const provider = defaultProviderProjection(hosted.providers);
-	const providerBaseUrl = cleanBaseUrl(provider?.baseUrl);
-	const providerApiMode = cleanString(provider?.apiMode);
-	const secretRef = normalizeSecretRef(provider?.apiKeySecretRef);
-	if (!providerBaseUrl || !providerUsesCodexBackendProjection(providerApiMode) || !secretRef) {
-		return [];
-	}
-	return [
-		{
-			id: "codex-chatgpt-backend-responses",
-			enabled: true,
-			kind: "provider",
-			match: {
-				scheme: "https",
-				host: "chatgpt.com",
-				path: { type: "equals", value: "/backend-api/codex/responses" },
-				headers: {
-					authorization: {
-						type: "equals",
-						value: MANAGED_MITM_PLACEHOLDER_VALUE,
-						prefix: "Bearer ",
-					},
-				},
-				query: {},
-			},
-			rewrite: {
-				upstreamBaseUrl: codexBackendResponsesUrl(providerBaseUrl),
-				preservePath: false,
-				setHeaders: {
-					authorization: {
-						type: "secretRef",
-						secretRef,
-						prefix: "Bearer ",
-					},
-				},
-			},
-			logging: { redactHeaders: ["authorization"], redactUrlPatterns: [] },
-			priority: 125,
-			owner: "provider-projection",
-		},
-	];
-}
-
-function providerUsesCodexBackendProjection(apiMode: string | null): boolean {
-	return apiMode === "codex_responses" || apiMode === "openai_responses";
 }
 
 export function normalizeSecretRef(value: string | null | undefined): string | null {
@@ -138,21 +87,4 @@ function providerPathPrefix(pathname: string): string {
 	const cleaned = pathname.replace(/\/+$/, "");
 	if (!cleaned) return "/";
 	return `${cleaned}/`;
-}
-
-function codexBackendResponsesUrl(baseUrl: string): string {
-	const parsed = new URL(baseUrl);
-	const path = parsed.pathname.replace(/\/+$/, "");
-	if (path.endsWith("/backend-api/codex/responses")) {
-		parsed.pathname = path;
-	} else if (path.endsWith("/backend-api/codex")) {
-		parsed.pathname = `${path}/responses`;
-	} else if (path.endsWith("/v1")) {
-		parsed.pathname = `${path.slice(0, -"/v1".length)}/backend-api/codex/responses`;
-	} else {
-		parsed.pathname = `${path}/backend-api/codex/responses`;
-	}
-	parsed.search = "";
-	parsed.hash = "";
-	return parsed.toString().replace(/\/$/, "");
 }

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -643,7 +643,7 @@ function hostedProviderApiMode(input: Record<string, unknown>): AiProviderApiMod
 	if (raw === "openai_chat" || raw === "openai_responses" || raw === "codex_responses") {
 		return raw;
 	}
-	return "codex_responses";
+	return "openai_chat";
 }
 
 function hostedProviderRuntimeEnvName(providerId: string, input: Record<string, unknown>): string {

--- a/packages/cli/tests/commands/ai-provider.test.ts
+++ b/packages/cli/tests/commands/ai-provider.test.ts
@@ -1721,7 +1721,7 @@ describe("ai-provider commands", () => {
 		});
 	});
 
-	it("projects Clawdi-managed Codex Responses providers to OpenClaw Codex transport", async () => {
+	it("projects Clawdi-managed OpenAI chat providers directly to OpenClaw", async () => {
 		const catalog = {
 			schema_version: 1,
 			providers: [
@@ -1731,7 +1731,7 @@ describe("ai-provider commands", () => {
 					label: "Clawdi AI",
 					base_url: "https://sub2api.example.test/v1",
 					default_model: "openai-codex/gpt-5.5",
-					api_mode: "codex_responses",
+					api_mode: "openai_chat",
 					auth: { type: "api_key", source: "managed" },
 					managed_by: "clawdi",
 					runtime_env_name: "CLAWDI_OPENAI_API_KEY",
@@ -1743,24 +1743,25 @@ describe("ai-provider commands", () => {
 		const projection = buildAgentTargetProjection("openclaw", catalog);
 		const patch = JSON.parse(projection.files[0]!.content);
 
-		expect(patch.agents.defaults.model.primary).toBe("openai/gpt-5.5");
-		expect(patch.models.providers.openai.baseUrl).toBe("https://chatgpt.com/backend-api");
-		expect(patch.models.providers.openai.api).toBe("openai-chatgpt-responses");
-		expect(patch.models.providers.openai.agentRuntime).toBeUndefined();
-		expect(patch.models.providers.openai.models[0]).toMatchObject({
-			id: "gpt-5.5",
-			name: "gpt-5.5",
-			api: "openai-chatgpt-responses",
-			agentRuntime: { id: "pi" },
+		expect(patch.agents.defaults.model.primary).toBe("clawdi-managed/openai-codex/gpt-5.5");
+		expect(patch.models.providers["clawdi-managed"].baseUrl).toBe(
+			"https://sub2api.example.test/v1",
+		);
+		expect(patch.models.providers["clawdi-managed"].api).toBe("openai-completions");
+		expect(patch.models.providers["clawdi-managed"].agentRuntime).toBeUndefined();
+		expect(patch.models.providers["clawdi-managed"].models[0]).toMatchObject({
+			id: "openai-codex/gpt-5.5",
+			name: "openai-codex/gpt-5.5",
+			api: "openai-completions",
 		});
-		expect(patch.models.providers.openai.apiKey).toEqual({
+		expect(patch.models.providers["clawdi-managed"].apiKey).toEqual({
 			source: "env",
 			provider: "default",
-			id: "CLAWDI_PROVIDER_PLACEHOLDER_TOKEN",
+			id: "CLAWDI_OPENAI_API_KEY",
 		});
 	});
 
-	it("projects Clawdi-managed Codex Responses providers to Hermes through MITM official endpoints", () => {
+	it("projects Clawdi-managed OpenAI chat providers directly to Hermes", () => {
 		const projection = buildAgentTargetProjection("hermes", {
 			schema_version: 1,
 			providers: [
@@ -1770,7 +1771,7 @@ describe("ai-provider commands", () => {
 					label: "Clawdi AI",
 					base_url: "https://sub2api.example.test/v1",
 					default_model: "openai-codex/gpt-5.5",
-					api_mode: "codex_responses",
+					api_mode: "openai_chat",
 					auth: { type: "api_key", source: "managed" },
 					managed_by: "clawdi",
 					runtime_env_name: "CLAWDI_OPENAI_API_KEY",
@@ -1781,11 +1782,12 @@ describe("ai-provider commands", () => {
 
 		const patch = projection.files[0]?.content ?? "";
 		expect(patch).toContain('provider: "custom:clawdi-managed"');
-		expect(patch).toContain('api: "https://chatgpt.com/backend-api/codex"');
-		expect(patch).toContain('default_model: "gpt-5.5"');
-		expect(patch).toContain('key_env: "CLAWDI_PROVIDER_PLACEHOLDER_TOKEN"');
-		expect(patch).not.toContain("https://sub2api.example.test");
-		expect(patch).not.toContain("CLAWDI_OPENAI_API_KEY");
+		expect(patch).toContain('api: "https://sub2api.example.test/v1"');
+		expect(patch).toContain('transport: "chat_completions"');
+		expect(patch).toContain('default_model: "openai-codex/gpt-5.5"');
+		expect(patch).toContain('key_env: "CLAWDI_OPENAI_API_KEY"');
+		expect(patch).not.toContain("chatgpt.com");
+		expect(patch).not.toContain("CLAWDI_PROVIDER_PLACEHOLDER_TOKEN");
 	});
 
 	it("projects user BYOK Codex Responses providers to the OpenClaw PI route", async () => {

--- a/packages/cli/tests/runtime-mitm-profiles.test.ts
+++ b/packages/cli/tests/runtime-mitm-profiles.test.ts
@@ -123,7 +123,7 @@ describe("runtime MITM profile schema", () => {
 		expect(bundle.profiles).toEqual([]);
 	});
 
-	it("enables the hosted broker for managed Codex provider projection", () => {
+	it("does not derive provider MITM profiles from hosted provider projection", () => {
 		const bundle = hostedManifestMitmProfiles({
 			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 			providers: {
@@ -135,40 +135,7 @@ describe("runtime MITM profile schema", () => {
 			},
 		});
 
-		expect(bundle.profiles).toEqual([
-			{
-				id: "codex-chatgpt-backend-responses",
-				enabled: true,
-				kind: "provider",
-				match: {
-					scheme: "https",
-					host: "chatgpt.com",
-					path: { type: "equals", value: "/backend-api/codex/responses" },
-					headers: {
-						authorization: {
-							type: "equals",
-							value: "clawdi-mitm-placeholder",
-							prefix: "Bearer ",
-						},
-					},
-					query: {},
-				},
-				rewrite: {
-					upstreamBaseUrl: "https://ai-gateway.example.test/backend-api/codex/responses",
-					preservePath: false,
-					setHeaders: {
-						authorization: {
-							type: "secretRef",
-							secretRef: "secret://provider.default.apiKey",
-							prefix: "Bearer ",
-						},
-					},
-				},
-				logging: { redactHeaders: ["authorization"], redactUrlPatterns: [] },
-				priority: 125,
-				owner: "provider-projection",
-			},
-		]);
+		expect(bundle.profiles).toEqual([]);
 	});
 
 	it("builds a direct provider allowlist only when another manifest feature enables the broker", () => {
@@ -198,7 +165,7 @@ describe("runtime MITM profile schema", () => {
 		});
 	});
 
-	it("does not derive provider MITM profiles without a managed Codex projection", () => {
+	it("does not derive provider MITM profiles without explicit manifest profiles", () => {
 		const bundle = hostedManifestMitmProfiles({
 			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 			providers: {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -568,7 +568,7 @@ describe("runtime manifest datasource", () => {
 		}
 	});
 
-	it("generates managed Codex MITM profiles from hosted-runtime manifests", async () => {
+	it("does not derive provider MITM profiles from hosted-runtime manifests", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -624,22 +624,7 @@ describe("runtime manifest datasource", () => {
 			const loaded = await loadRuntimeManifest(getRuntimePaths());
 			expect("manifest" in loaded).toBe(true);
 			if (!("manifest" in loaded)) throw new Error("expected manifest load success");
-			expect(loaded.manifest.mitmProfiles?.profiles).toEqual([
-				expect.objectContaining({
-					id: "codex-chatgpt-backend-responses",
-					kind: "provider",
-					match: expect.objectContaining({
-						scheme: "https",
-						host: "chatgpt.com",
-						path: { type: "equals", value: "/backend-api/codex/responses" },
-					}),
-					rewrite: expect.objectContaining({
-						upstreamBaseUrl: "https://ai-gateway.example.test/backend-api/codex/responses",
-						preservePath: false,
-					}),
-					owner: "provider-projection",
-				}),
-			]);
+			expect(loaded.manifest.mitmProfiles?.profiles).toEqual([]);
 			expect(JSON.stringify(loaded.manifest.mitmProfiles)).not.toContain("sk-runtime");
 		} finally {
 			restore();


### PR DESCRIPTION
## Summary\n- remove automatic hosted provider MITM derivation; MITM now comes from explicit manifest profiles or channel projection\n- project Clawdi-managed OpenAI chat providers directly into OpenClaw/Hermes configs\n- default hosted provider apiMode to openai_chat and bump CLI to 0.12.10-beta.14\n\n## Verification\n- bun run check\n- bun run typecheck\n- bun test packages/cli/tests/runtime-mitm-profiles.test.ts packages/cli/tests/runtime.test.ts packages/cli/tests/commands/ai-provider.test.ts packages/cli/tests/commands/run.test.ts