### PR TITLE
Replace hosted OpenClaw provider projection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.14",
+      "version": "0.12.10-beta.15",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.14",
+	"version": "0.12.10-beta.15",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -593,7 +593,7 @@ function projectionPayload(name: string, manifest: RuntimeManifest): unknown {
 		managedBy: "clawdi runtime init",
 		target:
 			name === "openclaw"
-				? "openclaw config patch --stdin"
+				? "openclaw config patch --stdin --replace-path models.providers"
 				: name === "hermes"
 					? "official Hermes user config"
 					: "clawdi mcp",
@@ -688,7 +688,7 @@ function applyHostedAiProviderProjection(
 		if (!file) throw new Error("OpenClaw projection did not include a config patch JSON file.");
 		runRuntimeUserCommand(
 			observation.commandPath,
-			["config", "patch", "--stdin"],
+			["config", "patch", "--stdin", "--replace-path", "models.providers"],
 			file.content,
 			home,
 			workspaceRoot,

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -637,6 +637,7 @@ describe("runtime manifest datasource", () => {
 		const run = join(root, "run", "clawdi");
 		const openclawBin = join(home, ".openclaw", "bin", "openclaw");
 		const openclawPatch = join(root, "openclaw-provider-patch.json");
+		const openclawCommand = join(root, "openclaw-provider-command.txt");
 		mkdirSync(dirname(openclawBin), { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
@@ -646,7 +647,8 @@ describe("runtime manifest datasource", () => {
 			openclawBin,
 			[
 				"#!/bin/sh",
-				'if [ "$1 $2 $3" = "config patch --stdin" ]; then',
+				`printf '%s\\n' "$*" > '${openclawCommand}'`,
+				'if [ "$1 $2 $3 $4 $5" = "config patch --stdin --replace-path models.providers" ]; then',
 				`  cat > '${openclawPatch}'`,
 				"  exit 0",
 				"fi",
@@ -709,6 +711,9 @@ describe("runtime manifest datasource", () => {
 		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
 
 		expect(convergence.installErrors).toEqual([]);
+		expect(readFileSync(openclawCommand, "utf-8").trim()).toBe(
+			"config patch --stdin --replace-path models.providers",
+		);
 		const patch = JSON.parse(readFileSync(openclawPatch, "utf-8"));
 		expect(patch.agents.defaults.model.primary).toBe("default/openai-codex/gpt-5.4-mini");
 		expect(patch.models.providers.default).toMatchObject({


### PR DESCRIPTION
## Summary
- replace hosted runtime OpenClaw provider projection at models.providers instead of recursively merging it
- prevent stale built-in providers with missing placeholder secrets from blocking OpenClaw gateway startup
- bump CLI beta package to 0.12.10-beta.15

## Verification
- bun run --filter clawdi typecheck
- bun test packages/cli/tests/runtime.test.ts packages/cli/tests/commands/ai-provider.test.ts packages/cli/tests/runtime-mitm-profiles.test.ts --timeout 30000
- git diff --check