### PR TITLE
Inject hosted provider secrets into runtime processes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.14",
+      "version": "0.12.10-beta.15",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.14",
+	"version": "0.12.10-beta.15",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -657,6 +657,24 @@ function hostedProviderRuntimeEnvName(providerId: string, input: Record<string, 
 	return `CLAWDI_PROVIDER_${providerId.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_API_KEY`;
 }
 
+function hostedProviderSecretEnv(manifest: RuntimeManifest): Record<string, string> {
+	const providers = recordValue(manifest.projection?.providers);
+	if (!providers) return {};
+	const env: Record<string, string> = {};
+	for (const [providerId, raw] of Object.entries(providers).sort(([a], [b]) =>
+		a.localeCompare(b),
+	)) {
+		const provider = recordValue(raw);
+		if (!provider) continue;
+		const apiKeySecretRef = stringValue(provider.apiKeySecretRef);
+		if (!apiKeySecretRef) continue;
+		const runtimeEnvName = hostedProviderRuntimeEnvName(providerId, provider);
+		if (!isEnvKey(runtimeEnvName)) continue;
+		env[runtimeEnvName] = normalizeSecretRef(apiKeySecretRef) ?? apiKeySecretRef;
+	}
+	return env;
+}
+
 function isEnvKey(value: string): boolean {
 	return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
 }
@@ -1626,6 +1644,7 @@ export function convergeRuntimeManifest(
 					mitmProfileBundlePath,
 					settings: runtime.run,
 					secretFilePath: mitmSecretFile,
+					secretEnv: hostedProviderSecretEnv(manifest),
 				}),
 				paths,
 			);

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -593,7 +593,7 @@ function projectionPayload(name: string, manifest: RuntimeManifest): unknown {
 		managedBy: "clawdi runtime init",
 		target:
 			name === "openclaw"
-				? "openclaw config patch --stdin"
+				? "openclaw config patch --stdin --replace-path models.providers"
 				: name === "hermes"
 					? "official Hermes user config"
 					: "clawdi mcp",
@@ -688,7 +688,7 @@ function applyHostedAiProviderProjection(
 		if (!file) throw new Error("OpenClaw projection did not include a config patch JSON file.");
 		runRuntimeUserCommand(
 			observation.commandPath,
-			["config", "patch", "--stdin"],
+			["config", "patch", "--stdin", "--replace-path", "models.providers"],
 			file.content,
 			home,
 			workspaceRoot,

--- a/packages/cli/src/runtime/run-config.ts
+++ b/packages/cli/src/runtime/run-config.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { z } from "zod";
 import { writePrivateFileAtomic } from "../lib/private-file";
+import { normalizeSecretRef } from "./hosted-mitm-profiles";
 import { buildMitmBrokerEnv } from "./mitm-env";
 import type { RuntimePaths } from "./paths";
 import { getRuntimePaths } from "./paths";
@@ -34,6 +35,7 @@ const runtimeRunConfigSchema = z
 		command: z.string().min(1),
 		defaultArgs: z.array(z.string()).default([]),
 		env: z.record(envKeySchema, z.string()).default({}),
+		secretEnv: z.record(envKeySchema, z.string().min(1)).default({}),
 		secretFilePath: z.string().min(1).nullable().default(null),
 		prependPath: z.array(z.string().min(1)).default([]),
 		cwd: z.string().min(1).optional(),
@@ -100,6 +102,7 @@ export function buildRuntimeRunConfig(input: {
 	mitmProfileBundlePath?: string | null;
 	settings?: RuntimeRunSettings;
 	secretFilePath?: string | null;
+	secretEnv?: Record<string, string>;
 }): RuntimeRunConfig {
 	const defaultPath = input.commandPath ? [dirname(input.commandPath)] : [];
 	const prependPath = [...defaultPath, ...(input.settings?.prependPath ?? [])].filter(
@@ -115,6 +118,7 @@ export function buildRuntimeRunConfig(input: {
 		command: input.settings?.command ?? input.commandPath ?? input.runtime,
 		defaultArgs: input.settings?.args ?? DEFAULT_RUNTIME_ARGS[input.runtime],
 		env: input.settings?.env ?? {},
+		secretEnv: input.secretEnv ?? {},
 		secretFilePath: input.secretFilePath ?? null,
 		prependPath,
 		cwd: input.settings?.cwd ?? input.workspaceRoot,
@@ -167,7 +171,10 @@ export function buildRuntimeRunInvocation(
 	const env = {
 		...baseEnv,
 		...read.config.env,
-		...(read.config.secretFilePath ? { CLAWDI_MITM_SECRET_FILE: read.config.secretFilePath } : {}),
+		...runtimeSecretEnv(read.config.secretFilePath, read.config.secretEnv),
+		...(read.config.secretFilePath && read.config.mitmProfileBundlePath
+			? { CLAWDI_MITM_SECRET_FILE: read.config.secretFilePath }
+			: {}),
 		PATH: pathPrefix ? [pathPrefix, currentPath].filter(Boolean).join(":") : currentPath,
 	};
 	const brokerEnv = buildMitmBrokerEnv({
@@ -186,4 +193,46 @@ export function buildRuntimeRunInvocation(
 		env: brokerEnv,
 		configPath: read.path,
 	};
+}
+
+function runtimeSecretEnv(
+	secretFilePath: string | null,
+	secretEnv: Record<string, string>,
+): Record<string, string> {
+	const entries = Object.entries(secretEnv);
+	if (entries.length === 0) return {};
+	if (!secretFilePath) {
+		throw new Error("Runtime run config references secrets but has no secret file.");
+	}
+	let rawSecrets: unknown;
+	try {
+		rawSecrets = JSON.parse(readFileSync(secretFilePath, "utf-8"));
+	} catch (error) {
+		throw new Error(
+			`Runtime secret file is unavailable: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	if (!rawSecrets || typeof rawSecrets !== "object" || Array.isArray(rawSecrets)) {
+		throw new Error("Runtime secret file must contain a JSON object.");
+	}
+	const secrets = rawSecrets as Record<string, unknown>;
+	const env: Record<string, string> = {};
+	for (const [envName, ref] of entries) {
+		const value = runtimeSecretValue(secrets, ref);
+		if (!value) {
+			throw new Error(`Runtime secret ${ref} for ${envName} is unavailable.`);
+		}
+		env[envName] = value;
+	}
+	return env;
+}
+
+function runtimeSecretValue(secrets: Record<string, unknown>, ref: string): string | null {
+	const normalized = normalizeSecretRef(ref);
+	const candidates = normalized && normalized !== ref ? [ref, normalized] : [ref];
+	for (const candidate of candidates) {
+		const value = secrets[candidate];
+		if (typeof value === "string" && value.length > 0) return value;
+	}
+	return null;
 }

--- a/packages/cli/tests/commands/run.test.ts
+++ b/packages/cli/tests/commands/run.test.ts
@@ -320,19 +320,16 @@ describe("run command project folder selection", () => {
 		expect(logs.join("\n")).toContain("Runtime hermes is disabled");
 	});
 
-	it("passes hosted runtime provider secrets only to the managed MITM broker", async () => {
+	it("injects hosted runtime provider secrets into the managed runtime process", async () => {
 		unlinkSync(join(fakeClawdiHome, "auth.json"));
 		const serviceStateRoot = join(tmpRoot, "var", "lib", "clawdi");
 		const runRoot = join(tmpRoot, "run", "clawdi");
 		const openclawPath = join(tmpRoot, "home", "clawdi", ".openclaw", "bin", "openclaw");
 		const runConfigRoot = join(serviceStateRoot, "config", "run");
 		const secretFile = join(runRoot, "secrets", "runtime-secrets.json");
-		const mitmBundle = join(serviceStateRoot, "config", "mitm", "profiles.json");
 		mkdirSync(runConfigRoot, { recursive: true });
 		mkdirSync(join(runRoot, "secrets"), { recursive: true });
-		mkdirSync(join(serviceStateRoot, "config", "mitm"), { recursive: true });
 		mkdirSync(join(tmpRoot, "home", "clawdi", ".openclaw", "bin"), { recursive: true });
-		writeFileSync(mitmBundle, JSON.stringify({ profiles: [] }));
 		writeFileSync(
 			secretFile,
 			JSON.stringify({
@@ -351,12 +348,15 @@ describe("run command project folder selection", () => {
 				command: "openclaw",
 				defaultArgs: ["gateway", "run"],
 				env: {},
+				secretEnv: {
+					CLAWDI_MANAGED_OPENAI_API_KEY: "provider.default.apiKey",
+				},
 				secretFilePath: secretFile,
 				prependPath: [join(tmpRoot, "home", "clawdi", ".openclaw", "bin")],
 				cwd: projectRoot,
 				commandPath: openclawPath,
 				appRoot: join(tmpRoot, "home", "clawdi", ".openclaw"),
-				mitmProfileBundlePath: mitmBundle,
+				mitmProfileBundlePath: null,
 			}),
 		);
 		writeFileSync(openclawPath, "#!/usr/bin/env sh\n");
@@ -370,9 +370,8 @@ describe("run command project folder selection", () => {
 		await run(["openclaw"], {}, spawnImpl, broker.brokerFactory);
 
 		expect(calls).toHaveLength(1);
-		expect(broker.calls).toHaveLength(1);
-		expect(broker.calls[0].secretFile).toBe(secretFile);
-		expect(calls[0].env.CLAWDI_MANAGED_OPENAI_API_KEY).toBeUndefined();
+		expect(broker.calls).toHaveLength(0);
+		expect(calls[0].env.CLAWDI_MANAGED_OPENAI_API_KEY).toBe("sk-runtime-provider");
 		expect(calls[0].env.CLAWDI_AUTH_TOKEN).toBeUndefined();
 		expect(calls[0].env.CLAWDI_MITM_SECRET_FILE).toBeUndefined();
 	});

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -637,6 +637,7 @@ describe("runtime manifest datasource", () => {
 		const run = join(root, "run", "clawdi");
 		const openclawBin = join(home, ".openclaw", "bin", "openclaw");
 		const openclawPatch = join(root, "openclaw-provider-patch.json");
+		const openclawCommand = join(root, "openclaw-provider-command.txt");
 		mkdirSync(dirname(openclawBin), { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
@@ -646,7 +647,8 @@ describe("runtime manifest datasource", () => {
 			openclawBin,
 			[
 				"#!/bin/sh",
-				'if [ "$1 $2 $3" = "config patch --stdin" ]; then',
+				`printf '%s\\n' "$*" > '${openclawCommand}'`,
+				'if [ "$1 $2 $3 $4 $5" = "config patch --stdin --replace-path models.providers" ]; then',
 				`  cat > '${openclawPatch}'`,
 				"  exit 0",
 				"fi",
@@ -709,6 +711,9 @@ describe("runtime manifest datasource", () => {
 		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
 
 		expect(convergence.installErrors).toEqual([]);
+		expect(readFileSync(openclawCommand, "utf-8").trim()).toBe(
+			"config patch --stdin --replace-path models.providers",
+		);
 		const patch = JSON.parse(readFileSync(openclawPatch, "utf-8"));
 		expect(patch.agents.defaults.model.primary).toBe("default/openai-codex/gpt-5.4-mini");
 		expect(patch.models.providers.default).toMatchObject({

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -729,7 +729,9 @@ describe("runtime manifest datasource", () => {
 		const runConfig = JSON.parse(
 			readFileSync(join(state, "config", "run", "openclaw.json"), "utf-8"),
 		);
-		expect(runConfig).not.toHaveProperty("secretEnv");
+		expect(runConfig.secretEnv).toEqual({
+			CLAWDI_MANAGED_OPENAI_API_KEY: "secret://provider.default.apiKey",
+		});
 		expect(runConfig.secretFilePath).toBe(join(run, "secrets", "runtime-secrets.json"));
 		expect(JSON.stringify(runConfig)).not.toContain("sk-runtime-provider");
 	});


### PR DESCRIPTION
## Summary\n- add a non-secret run-config mapping from managed provider env vars to runtime secret refs\n- inject managed provider secrets into hosted runtime child processes through `clawdi run -- <agent>`\n- keep MITM secret-file env internal unless a MITM profile bundle is active\n\n## Verification\n- `bun test packages/cli/tests/commands/run.test.ts packages/cli/tests/runtime.test.ts`\n- `bun run check`\n- `bun run typecheck`