### PR TITLE
Clarify hosted agent UI boundaries

### DIFF
--- a/apps/web/src/app/(dashboard)/agents/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/agents/[id]/page.tsx
@@ -7,9 +7,9 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { IS_HOSTED } from "@/lib/hosted";
 import { useV2Access } from "@/lib/v2-access";
 
-// Hosted builds route through `AgentHome`, which renders the manifest editor
+// Hosted builds route through `AgentHome`, which renders hosted agent detail
 // for agents backed by a hosted deployment and falls back to the connected
-// (CLI) detail otherwise. OSS builds render the connected detail directly —
+// detail otherwise. OSS builds render the connected detail directly —
 // the hosted chunk (and the deploy-API client it carries) never ships.
 const AgentHome = IS_HOSTED
 	? dynamic(() => import("@/hosted/agents/agent-home").then((m) => ({ default: m.AgentHome })))

--- a/apps/web/src/components/dashboard/agent-label.tsx
+++ b/apps/web/src/components/dashboard/agent-label.tsx
@@ -74,6 +74,30 @@ export function agentTypeLabel(type: string | null | undefined): string {
 	return TYPE_LABEL[type] ?? type;
 }
 
+export type AgentSourceKind = "hosted" | "connected";
+
+export function isHostedAgentEnvironment(env: {
+	hosted_managed?: boolean | null;
+	hosted_deployment_id?: string | null;
+}): boolean {
+	return env.hosted_managed === true || Boolean(env.hosted_deployment_id);
+}
+
+export function agentSourceFromEnvironment(env: {
+	hosted_managed?: boolean | null;
+	hosted_deployment_id?: string | null;
+}): AgentSourceKind {
+	return isHostedAgentEnvironment(env) ? "hosted" : "connected";
+}
+
+export function agentSourceLabel(source: AgentSourceKind): string {
+	return source === "hosted" ? "Hosted" : "Connected";
+}
+
+export function agentSourceKindLabel(source: AgentSourceKind): string {
+	return source === "hosted" ? "Hosted agent" : "Connected agent";
+}
+
 /** Strip mDNS-style suffixes (`.local`, `.lan`) from a hostname.
  * Bonjour appends `.local` automatically on macOS — the user
  * never typed it, never thinks about it, and showing it just
@@ -139,7 +163,7 @@ export function AgentLabel({
 	meta?: ReactNode[];
 	/** Tag rendered immediately to the right of the title — for
 	 * identity-level adornments that aren't meta-data (e.g. a
-	 * "hosted-on-Clawdi" pill). Goes here, not in meta, so it stays
+	 * source badge). Goes here, not in meta, so it stays
 	 * with the name as a single visual unit no matter how the
 	 * subtitle wraps. */
 	titleAdornment?: ReactNode;
@@ -150,7 +174,7 @@ export function AgentLabel({
 	const titleText = primary === "type" ? typeLabel : cleanedMachine || typeLabel;
 	// The disambiguator is the OTHER field — when title is the type
 	// we surface the machine name (and vice versa). Suppressed if
-	// it'd duplicate the title (e.g. hosted-on-Clawdi tiles whose
+	// it'd duplicate the title (e.g. hosted tiles whose
 	// `machineName` is just the runtime label "Hermes" — disambig
 	// would print "Hermes" again under the title).
 	const rawDisambig =

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -4,7 +4,13 @@ import type { components } from "@clawdi/shared/api";
 import { AlertCircle, ArrowUpRight, Cloud } from "lucide-react";
 import Link from "next/link";
 import { type ReactNode, useState } from "react";
-import { cleanMachineName, displayMachineName } from "@/components/dashboard/agent-label";
+import {
+	agentSourceKindLabel,
+	agentSourceLabel,
+	cleanMachineName,
+	displayMachineName,
+	isHostedAgentEnvironment,
+} from "@/components/dashboard/agent-label";
 import { DaemonStatusBadge } from "@/components/dashboard/daemon-status";
 import { EmptyState } from "@/components/empty-state";
 import { ENTITY_CARD_BASE, EntityMeta } from "@/components/entity-card";
@@ -24,7 +30,7 @@ export function isAgentActive(lastSeenAt: string | null | undefined): boolean {
 }
 
 export function isHostedManagedEnv(env: Env): boolean {
-	return env.hosted_managed === true || Boolean(env.hosted_deployment_id);
+	return isHostedAgentEnvironment(env);
 }
 
 /** Agent-type → friendly runtime label (OpenClaw, Claude Code, …). */
@@ -137,6 +143,8 @@ export function AgentsCard({
 	});
 	const visible = showAll ? ordered : ordered.slice(0, 6);
 	const hiddenCount = ordered.length - visible.length;
+	const hasHosted = agents.some((agent) => agent.source === "on-clawdi");
+	const hasSelfManaged = agents.some((agent) => agent.source === "self-managed");
 
 	// No section header: the greeting directly above already carries the
 	// fleet summary ("N agents connected · last active …"), and a bare
@@ -156,7 +164,12 @@ export function AgentsCard({
 					<>
 						<div className="grid gap-2 sm:grid-cols-2">
 							{visible.map((tile) => (
-								<AgentTileView key={`${tile.source}:${tile.id}`} tile={tile} />
+								<AgentTileView
+									key={`${tile.source}:${tile.id}`}
+									tile={tile}
+									showSourceBadge
+									showConnectedBadge={hasHosted && hasSelfManaged}
+								/>
 							))}
 							{hostedStatus?.isLoading ? <TileSkeleton /> : null}
 						</div>
@@ -213,23 +226,38 @@ export function AgentTileGrid({ tiles }: { tiles: AgentTile[] }) {
 	);
 }
 
-function AgentTileView({ tile }: { tile: AgentTile }) {
+function AgentTileView({
+	tile,
+	showSourceBadge = false,
+	showConnectedBadge = false,
+}: {
+	tile: AgentTile;
+	showSourceBadge?: boolean;
+	showConnectedBadge?: boolean;
+}) {
 	const onClawdi = tile.source === "on-clawdi";
-	// "Clawdi" pill is an identity adornment, not metadata — it sits
+	// Source pill is an identity adornment, not metadata — it sits
 	// next to the title so it stays glued to the agent name no matter
 	// how the meta wraps. Hosted agents get the same live-sync badge
 	// as self-managed ones; the platform will wire up sync automatically
 	// in a future release, so the surface stays consistent today and
 	// the data reflects reality once that lands.
-	const clawdiPill = onClawdi ? (
-		<span
-			title="Hosted on Clawdi"
-			className="inline-flex items-center gap-1 rounded-md border border-primary/30 bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-primary"
-		>
-			<Cloud className="size-2.5" />
-			Clawdi
-		</span>
-	) : null;
+	const source = onClawdi ? "hosted" : "connected";
+	const sourcePill =
+		showSourceBadge && (onClawdi || showConnectedBadge) ? (
+			<span
+				title={agentSourceKindLabel(source)}
+				className={cn(
+					"inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[10px] font-semibold",
+					onClawdi
+						? "border-primary/30 bg-primary/10 text-primary"
+						: "border-border bg-secondary text-secondary-foreground",
+				)}
+			>
+				{onClawdi ? <Cloud className="size-2.5" /> : null}
+				{agentSourceLabel(source)}
+			</span>
+		) : null;
 	// `tile.env` adds a sync badge that renders a `<button>`
 	// (clicks open a status dialog). It MUST live in the meta
 	// line under the agent name — same row as `statusLabel` so
@@ -317,7 +345,7 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 					<span className="truncate text-sm font-medium" title={cleanedName}>
 						{displayMachineName(cleanedName)}
 					</span>
-					{clawdiPill}
+					{sourcePill}
 				</div>
 				<EntityMeta items={meta} />
 			</div>

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -17,7 +17,13 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
-import { AgentLabel, agentTypeLabel, cleanMachineName } from "@/components/dashboard/agent-label";
+import {
+	AgentLabel,
+	agentSourceKindLabel,
+	agentTypeLabel,
+	cleanMachineName,
+	isHostedAgentEnvironment,
+} from "@/components/dashboard/agent-label";
 import { DaemonStatusBadge } from "@/components/dashboard/daemon-status";
 import { DetailNotFound, DetailPanel } from "@/components/detail/layout";
 import {
@@ -178,6 +184,12 @@ export function ConnectedAgentDetail({ environmentId }: { environmentId: string 
 	});
 
 	const sessionTotal = sessionsPage?.total ?? 0;
+	const detailSource =
+		agent && isHostedAgentEnvironment(agent)
+			? "hosted"
+			: badgeSource === "on-clawdi"
+				? "hosted"
+				: "connected";
 
 	// Controlled tab state so the row-level "Install skills" button can
 	// render only on the Skills tab — keeping the action contextual to
@@ -283,6 +295,9 @@ export function ConnectedAgentDetail({ environmentId }: { environmentId: string 
 							type={agent.agent_type}
 							size="xl"
 							primary="machine"
+							titleAdornment={
+								<Badge variant="secondary">{agentSourceKindLabel(detailSource)}</Badge>
+							}
 							meta={[
 								agent.agent_version ? `v${agent.agent_version}` : null,
 								agent.os,

--- a/apps/web/src/hosted/README.md
+++ b/apps/web/src/hosted/README.md
@@ -53,11 +53,11 @@ OSS users running their own Clawdi instance see none of this UI.
 - `use-hosted-agent-tiles.ts` — Lists the user's deployed agents on
   the v2 hosted runtime API, polled while any tile is in a transient
   state.
-- `agents/` — Hosted agent detail, runtime controls, and manifest editing.
+- `agents/` — Hosted agent detail, runtime controls, and AI-provider configuration.
 - `billing/` — Wallet, subscription, usage, and managed agent deployment.
 - `posthog.ts` — Hosted-only PostHog init helpers (called from
   `apps/web/instrumentation-client.ts` through a compile-time hosted
   gate (`NEXT_PUBLIC_CLAWDI_HOSTED === "true"`) plus dynamic import).
 
-Connector UI does not live here. Hosted and self-managed sessions both
+Connector UI does not live here. Hosted and connected sessions both
 read connectors from the shared `/api/connectors` route.

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -10,8 +10,8 @@ import { BillingEmpty, BillingError } from "@/hosted/billing/components/state-vi
 
 /**
  * Agent home for hosted builds. An agent backed by a hosted deployment renders
- * the manifest editor (`HostedAgentDetail`); a self-managed (CLI) agent — or
- * one we can't resolve to a deployment — falls back to the connected detail.
+ * the hosted agent detail (`HostedAgentDetail`); a connected agent — or one
+ * we can't resolve to a deployment — falls back to the connected detail.
  * The deployment lookup is hosted-only data, so the whole branch lives here
  * behind the IS_HOSTED dynamic import.
  */

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -8,14 +8,12 @@ import {
 	Info,
 	Link2,
 	Link2Off,
-	Lock,
 	Maximize2,
 	MonitorPlay,
 	Plus,
 	QrCode,
 	RefreshCw,
 	Trash2,
-	Wrench,
 	Zap,
 } from "lucide-react";
 import Link from "next/link";
@@ -25,7 +23,6 @@ import { toast } from "sonner";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import { EmptyState } from "@/components/empty-state";
-import { InfoCard } from "@/components/info-card";
 import { PageHeader } from "@/components/page-header";
 import { SessionFeed } from "@/components/sessions/session-feed";
 import { Badge } from "@/components/ui/badge";
@@ -86,7 +83,7 @@ import {
 } from "@/v2/channels/channels-hooks";
 
 type Runtime = "openclaw" | "hermes";
-type HostedAgentTab = "overview" | "console" | "ai" | "channels" | "tools" | "compute";
+type HostedAgentTab = "overview" | "console" | "ai" | "channels" | "compute";
 const RUNTIMES: { id: Runtime; label: string; blurb: string }[] = [
 	{ id: "openclaw", label: "OpenClaw", blurb: "General-purpose agent runtime." },
 	{ id: "hermes", label: "Hermes", blurb: "Messaging-first agent runtime." },
@@ -96,7 +93,6 @@ const HOSTED_AGENT_TABS = new Set<HostedAgentTab>([
 	"console",
 	"ai",
 	"channels",
-	"tools",
 	"compute",
 ]);
 const STARTABLE_STATUSES = new Set(["stopped", "failed"]);
@@ -129,16 +125,6 @@ function statusLabel(status: string): string {
 
 function parseHostedAgentTab(value: string | null): HostedAgentTab | null {
 	return value && HOSTED_AGENT_TABS.has(value as HostedAgentTab) ? (value as HostedAgentTab) : null;
-}
-
-/** A flag banner for facets the backend doesn't yet expose for live edit. */
-function NotExposedNote({ children }: { children: React.ReactNode }) {
-	return (
-		<div className="flex items-start gap-2 rounded-md border border-dashed bg-muted/30 p-3 text-xs text-muted-foreground">
-			<Lock className="mt-0.5 size-3.5 shrink-0" />
-			<span>{children}</span>
-		</div>
-	);
 }
 
 function LiveNote({ children }: { children: React.ReactNode }) {
@@ -224,6 +210,8 @@ export function HostedAgentDetail({
 						<StatusBadge status={statusTone(deployment.status)} withDot>
 							{statusLabel(deployment.status)}
 						</StatusBadge>
+						<span>Hosted agent</span>
+						<span>·</span>
 						<span>{runtimeLabel} runtime</span>
 						<span>·</span>
 						<span className="inline-flex items-center gap-1">
@@ -257,12 +245,6 @@ export function HostedAgentDetail({
 					<TabsTrigger value="console">Console</TabsTrigger>
 					<TabsTrigger value="ai">AI Provider</TabsTrigger>
 					<TabsTrigger value="channels">Channels</TabsTrigger>
-					<TabsTrigger value="tools">
-						Tools &amp; MCP
-						<Badge variant="secondary" className="ml-1.5">
-							Managed
-						</Badge>
-					</TabsTrigger>
 					<TabsTrigger value="compute">Compute</TabsTrigger>
 				</TabsList>
 
@@ -285,9 +267,6 @@ export function HostedAgentDetail({
 				</TabsContent>
 				<TabsContent value="channels" className="mt-4">
 					<ChannelsTab environmentId={environmentId} />
-				</TabsContent>
-				<TabsContent value="tools" className="mt-4">
-					<ToolsTab />
 				</TabsContent>
 				<TabsContent value="compute" className="mt-4">
 					<ComputeTab deployment={deployment} isPerformance={isPerformance} runtime={runtime} />
@@ -492,7 +471,7 @@ function AiProviderTab({
 	const [primaryModel, setPrimaryModel] = useState<string>(currentModel);
 
 	// Re-seed the form only when the server-side binding genuinely changes (the
-	// user's own apply reconciling, or an out-of-band change) — never on a plain
+	// user's own apply completing, or an out-of-band change) — never on a plain
 	// background poll. Keyed on the binding identity: identical server truth →
 	// same identity → in-progress edits stay untouched; a real change → reset to
 	// the new truth. This is React's "adjust state during render" idiom, which
@@ -543,14 +522,14 @@ function AiProviderTab({
 			{ id: deployment.id, agentTypes: [runtime], body },
 			{
 				onSuccess: () =>
-					toast.success("Provider updated", { description: "Reconciling to the runtime…" }),
+					toast.success("Provider updated", { description: "Updating the runtime…" }),
 			},
 		);
 	}
 
 	return (
 		<div className="space-y-4">
-			<LiveNote>Provider changes reconcile to the running runtime — no restart.</LiveNote>
+			<LiveNote>Provider changes apply to the running runtime — no restart.</LiveNote>
 
 			<div className="space-y-2">
 				<button
@@ -641,7 +620,7 @@ function AiProviderTab({
 					{setProvider.isPending ? "Applying live…" : "Apply changes"}
 				</Button>
 				{setProvider.isPending ? (
-					<span className="text-xs text-muted-foreground">Reconciling to the runtime…</span>
+					<span className="text-xs text-muted-foreground">Updating the runtime…</span>
 				) : null}
 			</div>
 
@@ -889,26 +868,6 @@ function LinkedChannelRow({
 					chat to pair it.
 				</div>
 			) : null}
-		</div>
-	);
-}
-
-// ── Tools & MCP ──────────────────────────────────────────────────────────────
-
-function ToolsTab() {
-	return (
-		<div className="space-y-4">
-			<InfoCard icon={Wrench} title="Managed tools & MCP">
-				This agent runs Clawdi-managed MCP and tool configuration. Connectors you approve in{" "}
-				<Link href="/connectors" className="underline">
-					Connectors
-				</Link>{" "}
-				are available to the agent.
-			</InfoCard>
-			<NotExposedNote>
-				Per-agent MCP/tool editing isn’t exposed by the runtime API yet. The manifest reconciles
-				tool changes live once the backend surfaces them.
-			</NotExposedNote>
 		</div>
 	);
 }

--- a/apps/web/src/hosted/billing/agents/hosted-agent-controls.tsx
+++ b/apps/web/src/hosted/billing/agents/hosted-agent-controls.tsx
@@ -33,18 +33,14 @@ function deploymentLabel(d: HostedDeployment): string {
 	return d.name.replace(/^(openclaw|hermes)-/i, "") || d.name;
 }
 
-/** "Telegram · OpenClaw + Hermes" — channel + engine summary for a deployment. */
+/** "OpenClaw + Hermes" — enabled runtime summary for a deployment. */
 function metaLine(d: HostedDeployment): string | null {
 	const info = d.config_info;
 	if (!info) return null;
 	const engines = [info.enable_openclaw && "OpenClaw", info.enable_hermes && "Hermes"]
 		.filter(Boolean)
 		.join(" + ");
-	const channel = info.channel
-		? info.channel.charAt(0).toUpperCase() + info.channel.slice(1)
-		: null;
-	const parts = [channel, engines].filter(Boolean);
-	return parts.length ? parts.join(" · ") : null;
+	return engines || null;
 }
 
 /**
@@ -54,7 +50,7 @@ function metaLine(d: HostedDeployment): string | null {
  * missing (e.g. while the agent is still provisioning).
  *
  * Renders null when the user has no hosted deployments, so it can sit on the
- * overview without adding noise for self-managed-only users.
+ * overview without adding noise for connected-agent-only users.
  */
 export function HostedAgentControls() {
 	const deployments = useHostedDeployments();

--- a/apps/web/src/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/v2/channels/channel-detail-page.tsx
@@ -17,7 +17,12 @@ import {
 import { useParams, useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
-import { agentTypeLabel, cleanMachineName } from "@/components/dashboard/agent-label";
+import {
+	agentSourceFromEnvironment,
+	agentSourceLabel,
+	agentTypeLabel,
+	cleanMachineName,
+} from "@/components/dashboard/agent-label";
 import { EmptyState } from "@/components/empty-state";
 import { InfoCard } from "@/components/info-card";
 import { PageHeader } from "@/components/page-header";
@@ -82,12 +87,19 @@ function formatWhen(iso: string | null | undefined): string {
 
 type EnvironmentList = ReturnType<typeof useEnvironments>["data"];
 
+function hasMixedAgentSources(envs: EnvironmentList): boolean {
+	const sources = new Set((envs ?? []).map((env) => agentSourceFromEnvironment(env)));
+	return sources.size > 1;
+}
+
 /** "machine · agent-type" label for an agent id, falling back to the raw id. */
-function envName(envs: EnvironmentList, agentId: string): string {
+function envName(envs: EnvironmentList, agentId: string, includeSource = false): string {
 	const env = envs?.find((e) => e.id === agentId);
-	return env
+	const source = env ? agentSourceLabel(agentSourceFromEnvironment(env)) : null;
+	const label = env
 		? `${cleanMachineName(env.machine_name) || agentTypeLabel(env.agent_type)} · ${agentTypeLabel(env.agent_type)}`
 		: agentId;
+	return env ? [includeSource ? source : null, label].filter(Boolean).join(" · ") : agentId;
 }
 
 export function ChannelDetailPage() {
@@ -229,6 +241,7 @@ function AgentsTab({ accountId, accountName }: { accountId: string; accountName:
 	const unlink = useUnlinkChannelAgent(accountId);
 	const [linkOpen, setLinkOpen] = useState(false);
 	const [rotated, setRotated] = useState<Record<string, string>>({});
+	const showAgentSource = hasMixedAgentSources(envs.data);
 
 	if (links.isLoading) return <Skeleton className="h-24 w-full rounded-lg" />;
 	if (links.error) {
@@ -272,7 +285,7 @@ function AgentsTab({ accountId, accountName }: { accountId: string; accountName:
 							<div className="flex items-center justify-between gap-3">
 								<div className="min-w-0">
 									<div className="truncate text-sm font-medium">
-										{envName(envs.data, link.agent_id)}
+										{envName(envs.data, link.agent_id, showAgentSource)}
 									</div>
 									<div className="text-xs capitalize text-muted-foreground">
 										{link.status} · linked {formatWhen(link.created_at)}
@@ -356,6 +369,7 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 	const create = useCreateWhatsappTenantCred(accountId);
 	const revoke = useRevokeWhatsappTenantCred(accountId);
 	const [linkId, setLinkId] = useState("");
+	const showAgentSource = hasMixedAgentSources(envs.data);
 
 	const linkItems = links.data ?? [];
 	const devices = creds.data ?? [];
@@ -404,7 +418,7 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 								<SelectContent>
 									{linkItems.map((l) => (
 										<SelectItem key={l.id} value={l.id}>
-											{envName(envs.data, l.agent_id)}
+											{envName(envs.data, l.agent_id, showAgentSource)}
 										</SelectItem>
 									))}
 								</SelectContent>
@@ -451,7 +465,8 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 									</div>
 								)}
 								<div className="text-xs text-muted-foreground">
-									{envName(envs.data, d.agent_id)} · added {formatWhen(d.created_at)}
+									{envName(envs.data, d.agent_id, showAgentSource)} · added{" "}
+									{formatWhen(d.created_at)}
 								</div>
 							</div>
 							<ConfirmAction
@@ -496,6 +511,7 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 	const [ttl, setTtl] = useState("900");
 	const [result, setResult] = useState<{ code: string; expires_at: string } | null>(null);
 	const meta = providerMeta(provider);
+	const showAgentSource = hasMixedAgentSources(envs.data);
 
 	function generate() {
 		create.mutate(
@@ -524,8 +540,7 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 							<SelectContent>
 								{(envs.data ?? []).map((env) => (
 									<SelectItem key={env.id} value={env.id}>
-										{cleanMachineName(env.machine_name) || agentTypeLabel(env.agent_type)} ·{" "}
-										{agentTypeLabel(env.agent_type)}
+										{envName(envs.data, env.id, showAgentSource)}
 									</SelectItem>
 								))}
 							</SelectContent>

--- a/apps/web/src/v2/channels/link-agent-dialog.tsx
+++ b/apps/web/src/v2/channels/link-agent-dialog.tsx
@@ -2,7 +2,12 @@
 
 import { CircleCheck } from "lucide-react";
 import { useEffect, useState } from "react";
-import { agentTypeLabel, cleanMachineName } from "@/components/dashboard/agent-label";
+import {
+	agentSourceFromEnvironment,
+	agentSourceLabel,
+	agentTypeLabel,
+	cleanMachineName,
+} from "@/components/dashboard/agent-label";
 import { EmptyState } from "@/components/empty-state";
 import { Button } from "@/components/ui/button";
 import {
@@ -68,6 +73,9 @@ export function LinkAgentDialog({
 	}
 
 	const agents = envs.data ?? [];
+	const hasHosted = agents.some((env) => agentSourceFromEnvironment(env) === "hosted");
+	const hasConnected = agents.some((env) => agentSourceFromEnvironment(env) === "connected");
+	const showSource = hasHosted && hasConnected;
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -113,8 +121,7 @@ export function LinkAgentDialog({
 							<SelectContent>
 								{agents.map((env) => (
 									<SelectItem key={env.id} value={env.id}>
-										{cleanMachineName(env.machine_name) || agentTypeLabel(env.agent_type)} ·{" "}
-										{agentTypeLabel(env.agent_type)}
+										{agentOptionLabel(env, showSource)}
 									</SelectItem>
 								))}
 							</SelectContent>
@@ -139,4 +146,19 @@ export function LinkAgentDialog({
 			</DialogContent>
 		</Dialog>
 	);
+}
+
+function agentOptionLabel(
+	env: {
+		machine_name?: string | null;
+		agent_type?: string | null;
+		hosted_managed?: boolean | null;
+		hosted_deployment_id?: string | null;
+	},
+	includeSource: boolean,
+): string {
+	const identity = cleanMachineName(env.machine_name) || agentTypeLabel(env.agent_type);
+	const runtime = agentTypeLabel(env.agent_type);
+	const source = agentSourceLabel(agentSourceFromEnvironment(env));
+	return includeSource ? `${source} · ${identity} · ${runtime}` : `${identity} · ${runtime}`;
 }


### PR DESCRIPTION
## Summary
- label hosted and connected agents consistently across dashboard, details, and channel selectors
- remove the empty v2 hosted Tools & MCP tab and legacy manifest wording
- stop surfacing legacy deployment-level channel metadata in v2 hosted controls

## Verification
- bun run check
- bun run typecheck
- bun test apps/web/src/components/dashboard/agent-label.test.ts apps/web/src/components/dashboard/agents-card.test.ts
- bun --cwd apps/web test src/hosted/oss-clean.test.ts
- git diff --check
- rg -n "ToolsTab|Tools & MCP|NotExposedNote" apps/web/src packages/shared (no matches)
- rg -n "manifest" apps/web/src/hosted apps/web/src/app (only site.webmanifest and webpack/turbopack test comment)

## Notes
Browser route smoke was blocked locally by Clerk dev-browser auth and missing browser tooling; static/type/boundary checks are green.