### PR TITLE
Use sidebar navigation on agent details

### DIFF
--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -25,7 +25,13 @@ import {
 	isHostedAgentEnvironment,
 } from "@/components/dashboard/agent-label";
 import { DaemonStatusBadge } from "@/components/dashboard/daemon-status";
-import { DetailNotFound, DetailPanel } from "@/components/detail/layout";
+import {
+	type DetailNavItem,
+	DetailNavLayout,
+	DetailNotFound,
+	DetailPanel,
+	DetailSectionNav,
+} from "@/components/detail/layout";
 import {
 	isCustomProject,
 	isProjectOwner,
@@ -39,7 +45,6 @@ import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { unwrap, useApi } from "@/lib/api";
 import { fetchAllPages } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
@@ -51,6 +56,24 @@ type AgentTab = "sessions" | "skills" | "projects";
 
 type ProjectRow = components["schemas"]["ProjectResponse"];
 type ProjectBindingRow = components["schemas"]["AgentProjectBindingResponse"];
+
+const AGENT_DETAIL_NAV_META: Record<AgentTab, Omit<DetailNavItem<AgentTab>, "id" | "count">> = {
+	sessions: {
+		icon: MessageSquare,
+		label: "Sessions",
+		description: "History synced by this agent.",
+	},
+	skills: {
+		icon: Sparkles,
+		label: "Skills",
+		description: "Installed in this agent's Agent Project.",
+	},
+	projects: {
+		icon: Layers,
+		label: "Projects",
+		description: "Project access and read order.",
+	},
+};
 
 export function ConnectedAgentDetail({ environmentId }: { environmentId: string }) {
 	const id = environmentId;
@@ -190,32 +213,41 @@ export function ConnectedAgentDetail({ environmentId }: { environmentId: string 
 			: badgeSource === "on-clawdi"
 				? "hosted"
 				: "connected";
+	const tabHref = (tab: AgentTab) => {
+		const next = new URLSearchParams(searchParams.toString());
+		if (tab === "sessions") next.delete("tab");
+		else next.set("tab", tab);
+		const query = next.toString();
+		return query ? `/agents/${id}?${query}` : `/agents/${id}`;
+	};
+	const navItems: DetailNavItem<AgentTab>[] = [
+		{
+			id: "sessions",
+			...AGENT_DETAIL_NAV_META.sessions,
+			count: sessionTotal,
+			href: tabHref("sessions"),
+		},
+		{
+			id: "skills",
+			...AGENT_DETAIL_NAV_META.skills,
+			count: skillsForThisEnv?.length,
+			href: tabHref("skills"),
+		},
+		{
+			id: "projects",
+			...AGENT_DETAIL_NAV_META.projects,
+			count: projectBindings?.length,
+			href: tabHref("projects"),
+		},
+	];
 
 	// Controlled tab state so the row-level "Install skills" button can
 	// render only on the Skills tab — keeping the action contextual to
 	// what the user is looking at, instead of floating an Install CTA
 	// over a Sessions list it has nothing to do with.
 	const [activeTab, setActiveTab] = useState<AgentTab>(requestedTab);
-	const activeTabMeta =
-		activeTab === "skills"
-			? {
-					icon: Sparkles,
-					title: "Installed skills",
-					description:
-						"Skills installed in this agent's Agent Project. They apply whenever this agent runs.",
-				}
-			: activeTab === "projects"
-				? {
-						icon: Layers,
-						title: "Project access",
-						description:
-							"The Agent Project is fixed. Added Custom or shared Projects add read-only context.",
-					}
-				: {
-						icon: MessageSquare,
-						title: "Session history",
-						description: "Review sessions synced by this agent.",
-					};
+	const activeTabMeta = AGENT_DETAIL_NAV_META[activeTab];
+	const ActiveTabIcon = activeTabMeta.icon;
 
 	useEffect(() => {
 		setActiveTab(requestedTab);
@@ -332,48 +364,44 @@ export function ConnectedAgentDetail({ environmentId }: { environmentId: string 
 						</ConfirmAction>
 					</div>
 
-					<Tabs value={activeTab} onValueChange={(v) => setTab(parseAgentTab(v) ?? "sessions")}>
-						{/* Flat tab chrome — no boxed section wrappers (taste audit #1). */}
-						<div className="flex flex-wrap items-end justify-between gap-2">
-							<TabsList className="grid w-full grid-cols-3 sm:w-fit">
-								<TabsTrigger value="sessions" className="min-w-0 px-2">
-									Sessions
-									<span className="ml-1.5 text-xs text-muted-foreground tabular-nums">
-										{sessionTotal}
-									</span>
-								</TabsTrigger>
-								<TabsTrigger value="skills" className="min-w-0 px-2">
-									Skills
-									{skillsForThisEnv ? (
-										<span className="ml-1.5 text-xs text-muted-foreground tabular-nums">
-											{skillsForThisEnv.length}
-										</span>
+					<DetailNavLayout
+						nav={
+							<DetailSectionNav
+								items={navItems}
+								activeId={activeTab}
+								onSelect={setTab}
+								label="Agent detail sections"
+							/>
+						}
+					>
+						<section className="space-y-4">
+							<div className="flex flex-wrap items-start justify-between gap-3">
+								<div>
+									<div className="flex items-center gap-2">
+										{ActiveTabIcon ? (
+											<ActiveTabIcon className="size-4 text-muted-foreground" />
+										) : null}
+										<h2 className="text-sm font-semibold">{activeTabMeta.label}</h2>
+									</div>
+									{activeTabMeta.description ? (
+										<p className="mt-1 text-xs text-muted-foreground">
+											{activeTabMeta.description}
+										</p>
 									) : null}
-								</TabsTrigger>
-								<TabsTrigger value="projects" className="min-w-0 px-2">
-									Projects
-									{projectBindings ? (
-										<span className="ml-1.5 text-xs text-muted-foreground tabular-nums">
-											{projectBindings.length}
-										</span>
-									) : null}
-								</TabsTrigger>
-							</TabsList>
-							{activeTab === "skills" ? (
-								<Button asChild variant="outline" size="sm">
-									<Link href={`${projectResourceHref("skills")}?target=${encodeURIComponent(id)}`}>
-										<Plus />
-										Install skills
-									</Link>
-								</Button>
-							) : null}
-						</div>
-						<p className="mt-2 text-xs text-muted-foreground">{activeTabMeta.description}</p>
+								</div>
+								{activeTab === "skills" ? (
+									<Button asChild variant="outline" size="sm">
+										<Link
+											href={`${projectResourceHref("skills")}?target=${encodeURIComponent(id)}`}
+										>
+											<Plus />
+											Install skills
+										</Link>
+									</Button>
+								) : null}
+							</div>
 
-						<div className="mt-4">
-							<TabsContent value="sessions" className="m-0">
-								{/* This page IS the agent — the feed drops the redundant
-								    per-row agent column the old table repeated 25 times. */}
+							{activeTab === "sessions" ? (
 								<div className="max-w-4xl">
 									<SessionFeed
 										sessions={sessionsPage?.items ?? []}
@@ -382,9 +410,9 @@ export function ConnectedAgentDetail({ environmentId }: { environmentId: string 
 										showAgent={false}
 									/>
 								</div>
-							</TabsContent>
+							) : null}
 
-							<TabsContent value="skills" className="m-0">
+							{activeTab === "skills" ? (
 								<SkillCardGrid
 									skills={skillsForThisEnv ?? []}
 									isLoading={skillsLoading}
@@ -397,9 +425,9 @@ export function ConnectedAgentDetail({ environmentId }: { environmentId: string 
 									}
 									uninstallPending={uninstallSkill.isPending}
 								/>
-							</TabsContent>
+							) : null}
 
-							<TabsContent value="projects" className="m-0">
+							{activeTab === "projects" ? (
 								<AgentProjectsPanel
 									agentId={id}
 									bindings={projectBindings ?? []}
@@ -412,9 +440,9 @@ export function ConnectedAgentDetail({ environmentId }: { environmentId: string 
 										queryClient.invalidateQueries({ queryKey: ["projects"] });
 									}}
 								/>
-							</TabsContent>
-						</div>
-					</Tabs>
+							) : null}
+						</section>
+					</DetailNavLayout>
 				</>
 			) : null}
 		</div>

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -13,7 +13,7 @@ import {
 	Unplug,
 } from "lucide-react";
 import Link from "next/link";
-import { useRouter, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
@@ -77,6 +77,7 @@ const AGENT_DETAIL_NAV_META: Record<AgentTab, Omit<DetailNavItem<AgentTab>, "id"
 
 export function ConnectedAgentDetail({ environmentId }: { environmentId: string }) {
 	const id = environmentId;
+	const pathname = usePathname();
 	const router = useRouter();
 	const api = useApi();
 	const queryClient = useQueryClient();
@@ -218,7 +219,7 @@ export function ConnectedAgentDetail({ environmentId }: { environmentId: string 
 		if (tab === "sessions") next.delete("tab");
 		else next.set("tab", tab);
 		const query = next.toString();
-		return query ? `/agents/${id}?${query}` : `/agents/${id}`;
+		return query ? `${pathname}?${query}` : pathname;
 	};
 	const navItems: DetailNavItem<AgentTab>[] = [
 		{
@@ -259,7 +260,7 @@ export function ConnectedAgentDetail({ environmentId }: { environmentId: string 
 		if (tab === "sessions") next.delete("tab");
 		else next.set("tab", tab);
 		const query = next.toString();
-		router.replace(query ? `/agents/${id}?${query}` : `/agents/${id}`, { scroll: false });
+		router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
 	};
 
 	// Wait until `agent` is loaded — otherwise `agentTypeLabel(undefined)`

--- a/apps/web/src/components/detail/layout.tsx
+++ b/apps/web/src/components/detail/layout.tsx
@@ -15,7 +15,7 @@
  */
 
 import { AlertCircle } from "lucide-react";
-import type { ReactNode } from "react";
+import type { ComponentType, ReactNode } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { cn } from "@/lib/utils";
 
@@ -46,6 +46,111 @@ export function DetailStats({ children }: { children: ReactNode }) {
 export function DetailPanel({ children, className }: { children: ReactNode; className?: string }) {
 	return (
 		<section className={cn("rounded-lg border bg-card/60 p-4", className)}>{children}</section>
+	);
+}
+
+export type DetailNavItem<T extends string> = {
+	id: T;
+	label: string;
+	description?: string;
+	href?: string;
+	icon?: ComponentType<{ className?: string }>;
+	count?: ReactNode;
+};
+
+export function DetailNavLayout({ nav, children }: { nav: ReactNode; children: ReactNode }) {
+	return (
+		<div className="grid gap-6 lg:grid-cols-[220px_minmax(0,1fr)] lg:items-start">
+			<aside className="min-w-0 lg:sticky lg:top-[calc(var(--header-height)+1rem)]">{nav}</aside>
+			<div className="min-w-0">{children}</div>
+		</div>
+	);
+}
+
+export function DetailSectionNav<T extends string>({
+	items,
+	activeId,
+	onSelect,
+	label,
+}: {
+	items: DetailNavItem<T>[];
+	activeId: T;
+	onSelect: (id: T) => void;
+	label: string;
+}) {
+	return (
+		<nav
+			aria-label={label}
+			className="-mx-1 flex gap-1 overflow-x-auto border-b px-1 pb-2 lg:mx-0 lg:block lg:space-y-1 lg:overflow-visible lg:border-b-0 lg:px-0 lg:pb-0"
+		>
+			{items.map((item) => {
+				const Icon = item.icon;
+				const active = item.id === activeId;
+				const className = cn(
+					"flex min-w-40 shrink-0 items-start gap-2 rounded-md px-2.5 py-2 text-left text-sm outline-hidden transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 lg:w-full lg:min-w-0",
+					active
+						? "bg-accent text-accent-foreground"
+						: "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+				);
+				const content = (
+					<>
+						{Icon ? <Icon className="mt-0.5 size-4 shrink-0" /> : null}
+						<span className="min-w-0 flex-1">
+							<span className="flex min-w-0 items-center gap-2">
+								<span className="truncate font-medium">{item.label}</span>
+								{item.count !== undefined && item.count !== null ? (
+									<span className="ml-auto shrink-0 text-xs tabular-nums opacity-70">
+										{item.count}
+									</span>
+								) : null}
+							</span>
+							{item.description ? (
+								<span className="mt-0.5 hidden text-xs leading-snug opacity-80 lg:block">
+									{item.description}
+								</span>
+							) : null}
+						</span>
+					</>
+				);
+				if (item.href) {
+					return (
+						<a
+							key={item.id}
+							href={item.href}
+							aria-current={active ? "page" : undefined}
+							onClick={(event) => {
+								if (
+									event.defaultPrevented ||
+									event.button !== 0 ||
+									event.metaKey ||
+									event.altKey ||
+									event.ctrlKey ||
+									event.shiftKey
+								) {
+									return;
+								}
+								event.preventDefault();
+								onSelect(item.id);
+							}}
+							className={className}
+						>
+							{content}
+						</a>
+					);
+				}
+				return (
+					<button
+						key={item.id}
+						type="button"
+						aria-current={active ? "page" : undefined}
+						onClick={() => onSelect(item.id)}
+						className={className}
+					>
+						{content}
+					</button>
+				);
+			})}
+		</nav>
 	);
 }
 

--- a/apps/web/src/components/detail/layout.tsx
+++ b/apps/web/src/components/detail/layout.tsx
@@ -87,7 +87,7 @@ export function DetailSectionNav<T extends string>({
 				const Icon = item.icon;
 				const active = item.id === activeId;
 				const className = cn(
-					"flex min-w-40 shrink-0 items-start gap-2 rounded-md px-2.5 py-2 text-left text-sm outline-hidden transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 lg:w-full lg:min-w-0",
+					"flex min-w-fit shrink-0 items-start gap-2 rounded-md px-2.5 py-2 text-left text-sm outline-hidden transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 lg:w-full lg:min-w-0",
 					active
 						? "bg-accent text-accent-foreground"
 						: "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
@@ -104,11 +104,6 @@ export function DetailSectionNav<T extends string>({
 									</span>
 								) : null}
 							</span>
-							{item.description ? (
-								<span className="mt-0.5 hidden text-xs leading-snug opacity-80 lg:block">
-									{item.description}
-								</span>
-							) : null}
 						</span>
 					</>
 				);

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -22,6 +22,7 @@ import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
+import { type DetailNavItem, DetailNavLayout, DetailSectionNav } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
 import { PageHeader } from "@/components/page-header";
 import { SessionFeed } from "@/components/sessions/session-feed";
@@ -43,7 +44,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { StatusBadge } from "@/components/ui/status-badge";
 import { Switch } from "@/components/ui/switch";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { deploymentDisplayName, isCloudEnvId } from "@/hosted/agent-identity";
 import {
 	useDeleteDeployment,
@@ -95,6 +95,38 @@ const HOSTED_AGENT_TABS = new Set<HostedAgentTab>([
 	"channels",
 	"compute",
 ]);
+const HOSTED_AGENT_NAV: DetailNavItem<HostedAgentTab>[] = [
+	{
+		id: "overview",
+		label: "Overview",
+		description: "Status, model, resources, and recent sessions.",
+		icon: Info,
+	},
+	{
+		id: "console",
+		label: "Console",
+		description: "Open the live runtime UI.",
+		icon: MonitorPlay,
+	},
+	{
+		id: "ai",
+		label: "AI Provider",
+		description: "Runtime-scoped provider and model binding.",
+		icon: Zap,
+	},
+	{
+		id: "channels",
+		label: "Channels",
+		description: "Messaging links for this hosted agent.",
+		icon: Link2,
+	},
+	{
+		id: "compute",
+		label: "Compute",
+		description: "Plan, lifecycle, and runtime availability.",
+		icon: Cpu,
+	},
+];
 const STARTABLE_STATUSES = new Set(["stopped", "failed"]);
 const STOPPABLE_STATUSES = new Set(["running", "ready", "starting"]);
 const RESTARTABLE_STATUSES = new Set(["running", "ready", "starting", "failed"]);
@@ -198,6 +230,16 @@ export function HostedAgentDetail({
 		const query = next.toString();
 		router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
 	};
+	const tabHref = (tab: HostedAgentTab) => {
+		const next = new URLSearchParams(searchParams.toString());
+		if (tab === "overview") next.delete("tab");
+		else next.set("tab", tab);
+		const query = next.toString();
+		return query ? `${pathname}?${query}` : pathname;
+	};
+	const navItems = HOSTED_AGENT_NAV.map((item) => ({ ...item, href: tabHref(item.id) }));
+	const activeNavItem =
+		HOSTED_AGENT_NAV.find((item) => item.id === activeTab) ?? HOSTED_AGENT_NAV[0];
 
 	return (
 		<div data-hosted="true" className="space-y-6 px-4 lg:px-6">
@@ -232,46 +274,44 @@ export function HostedAgentDetail({
 				}
 			/>
 
-			<Tabs
-				value={activeTab}
-				onValueChange={(value) => {
-					const tab = parseHostedAgentTab(value);
-					if (tab) setTab(tab);
-				}}
-			>
-				{/* Per-runtime facets first, then the shared Compute tab. */}
-				<TabsList className="flex-wrap">
-					<TabsTrigger value="overview">Overview</TabsTrigger>
-					<TabsTrigger value="console">Console</TabsTrigger>
-					<TabsTrigger value="ai">AI Provider</TabsTrigger>
-					<TabsTrigger value="channels">Channels</TabsTrigger>
-					<TabsTrigger value="compute">Compute</TabsTrigger>
-				</TabsList>
-
-				<TabsContent value="overview" className="mt-4">
-					<OverviewTab
-						deployment={deployment}
-						runtime={runtime}
-						isPerformance={isPerformance}
-						sessions={sessions.data?.items ?? []}
-						sessionsLoading={sessions.isLoading}
-						sessionsError={sessions.error}
-						onRetrySessions={() => sessions.refetch()}
+			<DetailNavLayout
+				nav={
+					<DetailSectionNav
+						items={navItems}
+						activeId={activeTab}
+						onSelect={setTab}
+						label="Hosted agent sections"
 					/>
-				</TabsContent>
-				<TabsContent value="console" className="mt-4">
-					<ConsoleTab deployment={deployment} runtime={runtime} />
-				</TabsContent>
-				<TabsContent value="ai" className="mt-4">
-					<AiProviderTab deployment={deployment} runtime={runtime} />
-				</TabsContent>
-				<TabsContent value="channels" className="mt-4">
-					<ChannelsTab environmentId={environmentId} />
-				</TabsContent>
-				<TabsContent value="compute" className="mt-4">
-					<ComputeTab deployment={deployment} isPerformance={isPerformance} runtime={runtime} />
-				</TabsContent>
-			</Tabs>
+				}
+			>
+				<section className="space-y-4">
+					<div>
+						<h2 className="text-sm font-semibold">{activeNavItem.label}</h2>
+						{activeNavItem.description ? (
+							<p className="mt-1 text-xs text-muted-foreground">{activeNavItem.description}</p>
+						) : null}
+					</div>
+					{activeTab === "overview" ? (
+						<OverviewTab
+							deployment={deployment}
+							runtime={runtime}
+							isPerformance={isPerformance}
+							sessions={sessions.data?.items ?? []}
+							sessionsLoading={sessions.isLoading}
+							sessionsError={sessions.error}
+							onRetrySessions={() => sessions.refetch()}
+						/>
+					) : null}
+					{activeTab === "console" ? (
+						<ConsoleTab deployment={deployment} runtime={runtime} />
+					) : null}
+					{activeTab === "ai" ? <AiProviderTab deployment={deployment} runtime={runtime} /> : null}
+					{activeTab === "channels" ? <ChannelsTab environmentId={environmentId} /> : null}
+					{activeTab === "compute" ? (
+						<ComputeTab deployment={deployment} isPerformance={isPerformance} runtime={runtime} />
+					) : null}
+				</section>
+			</DetailNavLayout>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- Replace tab chrome on connected and hosted agent detail pages with a shared sidebar section navigation
- Preserve URL-backed section state with ?tab= deep links while supporting normal link behavior for sidebar items
- Keep hosted v2 sections scoped to runtime-specific overview, console, AI provider, channels, and compute views

## Verification
- bun run check
- bun run typecheck
- Gate review: no blocker/high/medium; low focus/link semantics addressed