### PR TITLE
Release CLI beta 18 for runtime secret file access

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.17",
+	"version": "0.12.10-beta.18",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -128,7 +128,7 @@ function writeSecretValues(
 		dirMode: 0o700,
 	});
 	makeRootOwned(dirname(path));
-	makeRootOwned(path);
+	makeRuntimeSecretReadable(path);
 	try {
 		chmodSync(path, 0o600);
 	} catch {
@@ -250,6 +250,17 @@ function makeRootOwned(path: string): void {
 	} catch {
 		// Best effort for local tests and non-root development environments.
 	}
+}
+
+function makeRuntimeSecretReadable(path: string): void {
+	const dir = dirname(path);
+	makeRootOwned(dir);
+	try {
+		chmodSync(dir, 0o711);
+	} catch {
+		// Best effort for non-POSIX local development environments.
+	}
+	makeRuntimeUserOwned(path);
 }
 
 function makeRuntimeUserPrivateDir(path: string): void {
@@ -1554,10 +1565,10 @@ export function convergeRuntimeManifest(
 	const mitmProfileBundlePath = hasEnabledMitmProfiles(mitmProfileBundle)
 		? writeMitmProfileBundle(mitmProfileBundle, paths)
 		: clearMitmProfileBundle(paths);
+	const daemonAuthTokenFile = writeDaemonAuthToken(paths);
 	const mitmSecretFile = writeSecretValues(load.secretValues, paths);
 	writeProviderHealthStatus(manifest, load.secretValues, paths);
 	const liveSyncEnvironments = writeLiveSyncEnvironmentFiles(manifest, paths);
-	const daemonAuthTokenFile = writeDaemonAuthToken(paths);
 	const supervisorConfig = writeSupervisorConfig(
 		enabledRuntimes,
 		manifest,


### PR DESCRIPTION
## Summary
- bump clawdi CLI to 0.12.10-beta.18
- make hosted runtime managed secret file readable by the runtime user while keeping secrets out of supervisor config
- preserve root-owned secrets directory without write/list access for the runtime user

## Verification
- bun test packages/cli/tests/runtime.test.ts -t "provider secrets|projects hosted OpenAI chat providers"
- bun run check packages/cli/src/runtime/manifest.ts packages/cli/tests/runtime.test.ts
- bun x tsc -p packages/cli/tsconfig.json --noEmit --pretty false