### PR TITLE
Release CLI beta 19 for hosted runtime wrapper

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.18",
+	"version": "0.12.10-beta.19",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/run-config.ts
+++ b/packages/cli/src/runtime/run-config.ts
@@ -188,7 +188,7 @@ export function buildRuntimeRunInvocation(
 	return {
 		runtime: read.runtime,
 		command,
-		args: [...read.config.defaultArgs, ...args.slice(1)],
+		args: args.length > 1 ? args.slice(1) : read.config.defaultArgs,
 		cwd: read.config.cwd,
 		env: brokerEnv,
 		configPath: read.path,

--- a/packages/cli/tests/commands/run.test.ts
+++ b/packages/cli/tests/commands/run.test.ts
@@ -260,7 +260,7 @@ describe("run command project folder selection", () => {
 
 		expect(calls).toHaveLength(1);
 		expect(calls[0].command).toBe(hermesPath);
-		expect(calls[0].args).toEqual(["--no-browser", "--version"]);
+		expect(calls[0].args).toEqual(["--version"]);
 		expect(calls[0].cwd).toBe(projectRoot);
 		expect(calls[0].env.DISCORD_API_BASE_URL).toBe("http://127.0.0.1:4500/discord");
 		expect(calls[0].env.PATH?.startsWith(join(tmpRoot, "home", "clawdi", ".local", "bin"))).toBe(
@@ -371,9 +371,52 @@ describe("run command project folder selection", () => {
 
 		expect(calls).toHaveLength(1);
 		expect(broker.calls).toHaveLength(0);
+		expect(calls[0].args).toEqual(["gateway", "run"]);
 		expect(calls[0].env.CLAWDI_MANAGED_OPENAI_API_KEY).toBe("sk-runtime-provider");
 		expect(calls[0].env.CLAWDI_AUTH_TOKEN).toBeUndefined();
 		expect(calls[0].env.CLAWDI_MITM_SECRET_FILE).toBeUndefined();
+	});
+
+	it("does not prepend supervisor default args to hosted runtime subcommands", async () => {
+		unlinkSync(join(fakeClawdiHome, "auth.json"));
+		const serviceStateRoot = join(tmpRoot, "var", "lib", "clawdi");
+		const runRoot = join(tmpRoot, "run", "clawdi");
+		const openclawPath = join(tmpRoot, "home", "clawdi", ".openclaw", "bin", "openclaw");
+		const runConfigRoot = join(serviceStateRoot, "config", "run");
+		mkdirSync(runConfigRoot, { recursive: true });
+		mkdirSync(join(tmpRoot, "home", "clawdi", ".openclaw", "bin"), { recursive: true });
+		writeFileSync(
+			join(runConfigRoot, "openclaw.json"),
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeRunConfig.v1",
+				runtime: "openclaw",
+				enabled: true,
+				generatedAt: "2026-06-25T00:00:00Z",
+				generation: 2,
+				instanceId: "iid_test",
+				command: "openclaw",
+				defaultArgs: ["gateway", "run", "--auth", "none"],
+				env: {},
+				secretEnv: {},
+				secretFilePath: null,
+				prependPath: [join(tmpRoot, "home", "clawdi", ".openclaw", "bin")],
+				cwd: projectRoot,
+				commandPath: openclawPath,
+				appRoot: join(tmpRoot, "home", "clawdi", ".openclaw"),
+				mitmProfileBundlePath: null,
+			}),
+		);
+		writeFileSync(openclawPath, "#!/usr/bin/env sh\n");
+		const { calls, spawnImpl } = recordSpawn();
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = serviceStateRoot;
+		process.env.CLAWDI_RUN_DIR = runRoot;
+
+		await run(["openclaw", "agent", "--local"], {}, spawnImpl);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].command).toBe(openclawPath);
+		expect(calls[0].args).toEqual(["agent", "--local"]);
 	});
 
 	it("keeps hosted runtime wrapper alive until the child exits", async () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -770,7 +770,7 @@ describe("runtime manifest datasource", () => {
 						default: {
 							kind: "openai-compatible",
 							baseUrl: "https://ai-gateway.example.test/v1",
-							model: "openai-codex/gpt-5.5",
+							model: "gpt-5.5",
 							apiMode: "openai_responses",
 							runtimeEnvName: "CLAWDI_MANAGED_OPENAI_API_KEY",
 							apiKeySecretRef: "provider.default.apiKey",


### PR DESCRIPTION
## Summary
- bump `clawdi` CLI to `0.12.10-beta.19`
- keep hosted runtime supervisor default args only for bare runtime startup
- let hosted runtime user subcommands such as `openclaw agent` and `hermes --version` run through the wrapper without being rewritten to gateway/dashboard startup
- update the hosted runtime provider fixture to the v2 managed Responses model id shape

## Verification
- `bun test packages/cli/tests/commands/run.test.ts packages/cli/tests/runtime.test.ts`
- `bun run check`
- `bun run typecheck`
- `git diff --check`