### PR TITLE
Fix hosted runtime UI token preservation

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.19",
+	"version": "0.12.10-beta.20",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1258,6 +1258,7 @@ function writeSupervisorConfig(
 	secretValues: Record<string, string> | undefined,
 ): string {
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
+	const uiAccessToken = process.env[UI_ACCESS_TOKEN_ENV]?.trim() ?? "";
 	const commonEnvironment = {
 		HOME: paths.userHome,
 		CLAWDI_RUNTIME_MODE: "hosted",
@@ -1272,6 +1273,7 @@ function writeSupervisorConfig(
 	const watcherEnvironment = supervisorEnvironment({
 		...commonEnvironment,
 		CLAWDI_AUTH_TOKEN: "",
+		[UI_ACCESS_TOKEN_ENV]: uiAccessToken,
 	});
 	const daemonEnvironment = supervisorEnvironment({
 		...commonEnvironment,
@@ -1367,7 +1369,7 @@ function writeSupervisorConfig(
 		const uiBridgeEnvironment = supervisorEnvironment({
 			...commonEnvironment,
 			CLAWDI_AUTH_TOKEN: "",
-			[UI_ACCESS_TOKEN_ENV]: process.env[UI_ACCESS_TOKEN_ENV]?.trim() ?? "",
+			[UI_ACCESS_TOKEN_ENV]: uiAccessToken,
 			CLAWDI_RUNTIME_REV: uiBridgeProgramRevision(manifest),
 		});
 		lines.push(

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -500,6 +500,117 @@ describe("runtime manifest datasource", () => {
 		}
 	});
 
+	it("preserves hosted UI access token for runtime-watch and ui bridge supervisor programs", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const sourcePath = join(root, "runtime-source.json");
+		const openclawInstaller = join(root, "install-openclaw.sh");
+		mkdirSync(home, { recursive: true });
+		writeFileSync(
+			openclawInstaller,
+			`#!/usr/bin/env bash
+set -euo pipefail
+install -d "$HOME/.openclaw/bin"
+cat > "$HOME/.openclaw/bin/openclaw" <<'SH'
+#!/usr/bin/env bash
+if [ "\${1:-} \${2:-} \${3:-}" = "config patch --stdin" ]; then
+  cat >/dev/null
+  exit 0
+fi
+if [ "\${1:-}" = "plugins" ] && [ "\${2:-}" = "install" ]; then
+  exit 0
+fi
+exit 0
+SH
+chmod +x "$HOME/.openclaw/bin/openclaw"
+`,
+		);
+		chmodSync(openclawInstaller, 0o700);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_AUTH_TOKEN = "auth-token";
+		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
+		process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER = openclawInstaller;
+		process.env[UI_ACCESS_TOKEN_ENV] = "ui-runtime-token";
+		writeFileSync(
+			sourcePath,
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeSource.v1",
+				type: "http",
+				url: "https://runtime.test/v1/manifest",
+				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
+			}),
+		);
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/manifest",
+				response: () =>
+					jsonResponse({
+						manifest: {
+							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							deploymentId: "dep_ui_bridge",
+							environmentId: "env_ui_bridge",
+							appId: "app_ui_bridge",
+							instanceId: "iid_ui_bridge",
+							generation: 4,
+							issuedAt: "2026-06-06T00:00:00Z",
+							system: { home, workspace: join(home, "managed-workspace") },
+							controlPlane: {
+								manifestUrl: "https://runtime-source.test/desired-state",
+								cloudApiUrl: "https://cloud-api.test",
+							},
+							runtimes: {
+								openclaw: {
+									enabled: true,
+									install: { source: "official", channel: "stable" },
+									paths: { home },
+								},
+								hermes: {
+									enabled: false,
+									install: { source: "official", channel: "stable" },
+									paths: { home },
+								},
+							},
+							providers: {
+								default: {
+									kind: "openai-compatible",
+									baseUrl: "https://ai-gateway.test/v1",
+									model: "gpt-5.5",
+									apiMode: "openai_chat",
+									runtimeEnvName: "CLAWDI_MANAGED_OPENAI_API_KEY",
+									apiKeySecretRef: "provider.default.apiKey",
+								},
+							},
+						},
+						secretValues: {
+							"provider.default.apiKey": "sk-runtime",
+						},
+					}),
+			},
+		]);
+
+		try {
+			const loaded = await loadRuntimeManifest(getRuntimePaths());
+			if (!("manifest" in loaded)) throw new Error("expected manifest load success");
+			convergeRuntimeManifest(loaded, getRuntimePaths());
+			const supervisorConfig = readFileSync(join(state, "supervisor", "supervisord.conf"), "utf-8");
+			const section = (name: string) =>
+				supervisorConfig.split(`[program:${name}]`)[1]?.split("\n[")[0] ?? "";
+
+			expect(section("clawdi-runtime-watch")).toContain('UI_ACCESS_TOKEN="ui-runtime-token"');
+			expect(section("clawdi-ui-bridge")).toContain('UI_ACCESS_TOKEN="ui-runtime-token"');
+			expect(section("clawdi-openclaw")).toContain('UI_ACCESS_TOKEN=""');
+			expect(supervisorConfig).not.toContain("sk-runtime");
+		} finally {
+			restore();
+		}
+	});
+
 	it("keeps explicit OpenAI chat providers on direct provider projection", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");


### PR DESCRIPTION
## Summary
- preserve the hosted UI access token for runtime-watch and ui-bridge supervisor programs
- keep the token out of user runtime programs such as OpenClaw
- bump CLI beta to 0.12.10-beta.20 so runtime-watch can upgrade in place

## Verification
- bun test packages/cli/tests/runtime.test.ts --timeout 30000
- bun test packages/cli/tests/runtime-ui-bridge.test.ts packages/cli/tests/commands/run.test.ts --timeout 30000
- bun run check
- bun run typecheck
- git diff --check