### PR TITLE
Recover hosted UI token during runtime self-upgrade

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.20",
+	"version": "0.12.10-beta.21",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1258,7 +1258,7 @@ function writeSupervisorConfig(
 	secretValues: Record<string, string> | undefined,
 ): string {
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
-	const uiAccessToken = process.env[UI_ACCESS_TOKEN_ENV]?.trim() ?? "";
+	const uiAccessToken = hostedUiAccessToken();
 	const commonEnvironment = {
 		HOME: paths.userHome,
 		CLAWDI_RUNTIME_MODE: "hosted",
@@ -1455,6 +1455,28 @@ function runtimeCommandShimScript(command: RuntimeCommandShimName, paths: Runtim
 		`exec ${shellQuote(paths.cliManagedBin)} run -- ${command} "$@"`,
 		"",
 	].join("\n");
+}
+
+function hostedUiAccessToken(): string {
+	const direct = process.env[UI_ACCESS_TOKEN_ENV]?.trim();
+	if (direct) return direct;
+	return readProcEnvironmentValue(
+		process.env.CLAWDI_RUNTIME_PID1_ENVIRON_PATH?.trim() || "/proc/1/environ",
+		UI_ACCESS_TOKEN_ENV,
+	);
+}
+
+function readProcEnvironmentValue(path: string, key: string): string {
+	try {
+		const raw = readFileSync(path);
+		const prefix = `${key}=`;
+		for (const part of raw.toString("utf8").split("\0")) {
+			if (part.startsWith(prefix)) return part.slice(prefix.length).trim();
+		}
+	} catch {
+		// Best effort: runtime managers can still run without hosted UI access.
+	}
+	return "";
 }
 
 function supervisorPath(paths: RuntimePaths): string {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -61,6 +61,7 @@ const ENV_KEYS = [
 	"CLAWDI_RUNTIME_INSTALL_TIMEOUT",
 	"CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER",
 	"CLAWDI_RUNTIME_TEST_HERMES_INSTALLER",
+	"CLAWDI_RUNTIME_PID1_ENVIRON_PATH",
 	"CUSTOM_RUNTIME_TOKEN",
 	"CLAWDI_RUNTIME_MANIFEST_TIMEOUT_MS",
 	"CLAWDI_API_URL",
@@ -500,13 +501,15 @@ describe("runtime manifest datasource", () => {
 		}
 	});
 
-	it("preserves hosted UI access token for runtime-watch and ui bridge supervisor programs", async () => {
+	it("recovers hosted UI access token from pid1 env for runtime-watch and ui bridge supervisor programs", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const sourcePath = join(root, "runtime-source.json");
+		const pid1EnvPath = join(root, "pid1-environ");
 		const openclawInstaller = join(root, "install-openclaw.sh");
 		mkdirSync(home, { recursive: true });
+		writeFileSync(pid1EnvPath, `PATH=/usr/bin\0${UI_ACCESS_TOKEN_ENV}=ui-runtime-token\0`);
 		writeFileSync(
 			openclawInstaller,
 			`#!/usr/bin/env bash
@@ -535,7 +538,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
 		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
 		process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER = openclawInstaller;
-		process.env[UI_ACCESS_TOKEN_ENV] = "ui-runtime-token";
+		process.env.CLAWDI_RUNTIME_PID1_ENVIRON_PATH = pid1EnvPath;
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({


### PR DESCRIPTION
## Summary
- recover the hosted UI access token from the supervisor/PID1 environment when runtime-watch was started with an empty token
- keep user runtime programs without UI_ACCESS_TOKEN
- bump CLI beta to 0.12.10-beta.21 for in-place runtime convergence

## Verification
- bun test packages/cli/tests/runtime.test.ts --timeout 30000
- bun test packages/cli/tests/runtime-ui-bridge.test.ts packages/cli/tests/commands/run.test.ts --timeout 30000
- bun run check
- bun run typecheck
- git diff --check