### PR TITLE
Remove v2 invoice billing fallbacks from UI

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -951,7 +951,7 @@ function ComputeTab({
 				ui_mode: "hosted",
 				upgrade_deployment_id: deployment.id,
 			});
-			if (redirectToCheckout(result.action_url || result.checkout_url || result.invoice_url)) {
+			if (redirectToCheckout(result.action_url || result.checkout_url)) {
 				return;
 			}
 			toast.error("Couldn’t start upgrade", {

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -305,7 +305,7 @@ export function DeployWizard() {
 					ui_mode: "hosted",
 					deploy_config: deployConfig,
 				});
-				if (redirectTo(result.action_url || result.checkout_url || result.invoice_url)) return;
+				if (redirectTo(result.action_url || result.checkout_url)) return;
 				toast.error("Couldn't start checkout", {
 					description: "No checkout URL was returned. Please try again.",
 				});

--- a/apps/web/src/hosted/billing/wallet/ledger-table.tsx
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.tsx
@@ -28,7 +28,7 @@ import { cn, relativeTime } from "@/lib/utils";
 
 const OPERATION_LABELS: Record<string, string> = {
 	topup: "Top-up",
-	invoice: "Invoice top-up",
+	invoice: "Top-up",
 	x402: "On-chain top-up",
 	grant_signup: "Signup grant",
 	grant_subscription: "Monthly grant",

--- a/apps/web/src/hosted/billing/wallet/stripe-payment-form.tsx
+++ b/apps/web/src/hosted/billing/wallet/stripe-payment-form.tsx
@@ -104,7 +104,7 @@ function InnerForm({
  * Elements against the `client_secret` from `POST /wallet/topup`.
  *
  * Three degrade paths so the dialog never silently breaks:
- *  - no publishable key (OSS / preview) → invoice-billing guidance.
+ *  - no publishable key (OSS / preview) → explicit configuration error.
  *  - Stripe.js fails to load (network / blocked script) → explicit error +
  *    Retry that re-injects the script (rather than mounting `Elements` against
  *    a rejected promise, which renders nothing).
@@ -147,8 +147,8 @@ export function StripePaymentForm({
 			<Alert data-hosted="true">
 				<AlertCircle />
 				<AlertDescription>
-					Card payments aren’t configured in this environment. Switch your wallet to invoice billing
-					to top up, or set a Stripe publishable key.
+					Card payments aren’t configured in this environment. Set a Stripe publishable key to top
+					up.
 				</AlertDescription>
 			</Alert>
 		);

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
@@ -92,12 +92,6 @@ export function TopUpDialog({
 				setStep("pay");
 				return;
 			}
-			// Invoice mode → hand off to the hosted invoice page.
-			const url = "url" in result ? result.url || result.invoice_url : null;
-			if (url) {
-				window.location.href = url;
-				return;
-			}
 			toast.error("Couldn’t start top-up", {
 				description: "No payment was returned. Please try again.",
 			});

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -447,10 +447,6 @@ export interface components {
             checkout_url: string;
             /** Client Secret */
             client_secret?: string | null;
-            /** Invoice Url */
-            invoice_url?: string | null;
-            /** Invoice Id */
-            invoice_id?: string | null;
         };
         /** V2ComputeCheckoutRequest */
         V2ComputeCheckoutRequest: {
@@ -461,8 +457,6 @@ export interface components {
              * @default 1
              */
             billing_term_months: number;
-            /** Invoice Days Until Due */
-            invoice_days_until_due?: number | null;
             deploy_config?: components["schemas"]["V2HostedDeployRequest"] | null;
             /** Upgrade Deployment Id */
             upgrade_deployment_id?: string | null;
@@ -954,10 +948,6 @@ export interface components {
             pending_collection_method_effective_at?: string | null;
             /** Entitled Until */
             entitled_until?: string | null;
-            /** Invoice Days Until Due */
-            invoice_days_until_due?: number | null;
-            /** Invoice Due At */
-            invoice_due_at?: string | null;
             /** Contract Source */
             contract_source?: string | null;
             /** Prepaid Ends At */
@@ -990,7 +980,7 @@ export interface components {
         /** V2WalletAutoReloadRequest */
         V2WalletAutoReloadRequest: {
             /** Payment Mode */
-            payment_mode?: ("card" | "invoice") | null;
+            payment_mode?: "card" | null;
             /** Auto Reload Enabled */
             auto_reload_enabled?: boolean | null;
             /** Auto Reload Threshold Credits */
@@ -1032,9 +1022,9 @@ export interface components {
             balance_snapshot_at?: string | null;
             /**
              * Payment Mode
-             * @enum {string}
+             * @constant
              */
-            payment_mode: "card" | "invoice";
+            payment_mode: "card";
             /** Auto Reload Enabled */
             auto_reload_enabled: boolean;
             /** Auto Reload Threshold Credits */
@@ -1064,12 +1054,6 @@ export interface components {
             payment_intent_id?: string | null;
             /** Client Secret */
             client_secret?: string | null;
-            /** Url */
-            url?: string | null;
-            /** Invoice Url */
-            invoice_url?: string | null;
-            /** Invoice Id */
-            invoice_id?: string | null;
             /** Credits Added */
             credits_added?: number | null;
         };


### PR DESCRIPTION
## Summary
- update generated deploy API types for standard v2 checkout/card top-up responses
- remove hosted UI redirects to invoice URLs for compute checkout, upgrade, and wallet top-up flows
- keep historical invoice wallet ledger rows displayed as generic top-ups

## Verification
- bun run check
- bun run typecheck
- git diff --check
- bun test apps/web/src/hosted/oss-clean.test.ts apps/web/src/components/dashboard/agent-label.test.ts apps/web/src/components/dashboard/agents-card.test.ts
