### PR TITLE
Fix v2 OpenClaw provider model projection

### DIFF
--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -188,6 +188,7 @@ async def _provider_projection(
     state: HostedRuntimeState,
 ) -> tuple[dict[str, Any], dict[str, str], list[Any]]:
     provider_id = _runtime_provider_id(state)
+    runtime_model = _runtime_provider_model(state)
     provider = await _select_provider(db, auth=auth, provider_id=provider_id)
     if provider is None:
         return {}, {}, []
@@ -197,8 +198,9 @@ async def _provider_projection(
         "kind": "openai-compatible",
         "baseUrl": provider.base_url,
     }
-    if provider.default_model:
-        projection["model"] = provider.default_model
+    model = runtime_model or provider.default_model
+    if model:
+        projection["model"] = model
     api_mode = provider.api_mode
     runtime_env_name = provider.runtime_env_name
     if _is_clawdi_managed_provider(provider):
@@ -254,6 +256,30 @@ def _runtime_provider_id(state: HostedRuntimeState) -> str | None:
             "runtime state provider id does not match enabled runtime provider id",
         )
     return state.provider_id or declared_provider_id
+
+
+def _runtime_provider_model(state: HostedRuntimeState) -> str | None:
+    declared_models: set[str] = set()
+    for runtime in (state.runtimes or {}).values():
+        if not isinstance(runtime, dict) or runtime.get("enabled") is not True:
+            continue
+        model = runtime.get("model", runtime.get("primary_model"))
+        if model is None:
+            continue
+        if not isinstance(model, str) or not model.strip():
+            raise HTTPException(
+                status.HTTP_409_CONFLICT,
+                "enabled runtime provider model must be a non-empty string",
+            )
+        declared_models.add(model.strip())
+
+    if len(declared_models) > 1:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "enabled runtimes must use a single provider model",
+        )
+
+    return next(iter(declared_models), None)
 
 
 async def _select_provider(

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -926,3 +926,73 @@ async def test_runtime_manifest_preserves_user_provider_api_mode(
         "runtimeEnvName": "CUSTOM_OPENAI_API_KEY",
         "apiKeySecretRef": "provider.default.apiKey",
     }
+
+
+@pytest.mark.asyncio
+async def test_runtime_manifest_uses_runtime_model_when_provider_default_is_missing(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"runtime-model-{uuid4().hex[:8]}",
+        machine_name="Runtime Model Provider",
+        agent_type="openclaw",
+    )
+    ciphertext, nonce = encrypt("sk-user-provider")
+    db_session.add(
+        AiProvider(
+            owner_user_id=seed_user.id,
+            provider_id="custom-openai",
+            type="custom_openai_compatible",
+            base_url="https://provider.test/v1",
+            default_model=None,
+            api_mode="openai_responses",
+            auth_type="api_key",
+            auth_metadata={"source": "managed"},
+            managed_by="user",
+            runtime_env_name="CUSTOM_OPENAI_API_KEY",
+        )
+    )
+    db_session.add(
+        AiProviderAuthPayload(
+            owner_user_id=seed_user.id,
+            provider_id="custom-openai",
+            auth_profile="default",
+            kind="api_key",
+            source="managed",
+            encrypted_payload=ciphertext,
+            nonce=nonce,
+        )
+    )
+    await db_session.commit()
+    await _write_runtime_state(
+        admin_client,
+        str(env.id),
+        provider_id="custom-openai",
+        runtimes={
+            "openclaw": {
+                "enabled": True,
+                "provider_id": "custom-openai",
+                "model": "gpt-5.5",
+            },
+            "hermes": {"enabled": False},
+        },
+    )
+
+    api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        response = await client.get("/api/runtime/manifest")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200, response.text
+    assert response.json()["manifest"]["providers"]["default"] == {
+        "kind": "openai-compatible",
+        "baseUrl": "https://provider.test/v1",
+        "model": "gpt-5.5",
+        "apiMode": "openai_responses",
+        "runtimeEnvName": "CUSTOM_OPENAI_API_KEY",
+        "apiKeySecretRef": "provider.default.apiKey",
+    }

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -210,10 +210,30 @@ function providerHealthReasons(
 			reasons.push("base_url_invalid");
 		}
 	}
+	if (!stringValue(provider.model)) {
+		reasons.push("model_missing");
+	}
+	const apiMode = stringValue(provider.apiMode) ?? stringValue(provider.api_mode);
+	if (baseUrl && isOpenAiCompatibleMode(apiMode)) {
+		try {
+			const parsed = new URL(baseUrl);
+			if (!parsed.pathname || parsed.pathname === "/") {
+				reasons.push("base_url_path_missing");
+			}
+		} catch {
+			// Already reported as base_url_invalid above.
+		}
+	}
 	if (stringValue(provider.apiKeySecretRef) && secretAvailable === false) {
 		reasons.push("secret_missing");
 	}
 	return reasons;
+}
+
+function isOpenAiCompatibleMode(apiMode: string | null): boolean {
+	return (
+		apiMode === "openai_chat" || apiMode === "openai_responses" || apiMode === "codex_responses"
+	);
 }
 
 function recordValue(value: unknown): Record<string, unknown> | null {

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -207,15 +207,28 @@ function providerReasons(provider: JsonRecord, secretAvailable: boolean | null):
 		reasons.push("base_url_missing");
 	} else {
 		try {
-			new URL(baseUrl);
+			const parsed = new URL(baseUrl);
+			const apiMode = stringValue(provider.apiMode) ?? stringValue(provider.api_mode);
+			if (isOpenAiCompatibleMode(apiMode) && (!parsed.pathname || parsed.pathname === "/")) {
+				reasons.push("base_url_path_missing");
+			}
 		} catch {
 			reasons.push("base_url_invalid");
 		}
+	}
+	if (!stringValue(provider.model)) {
+		reasons.push("model_missing");
 	}
 	if (stringValue(provider.apiKeySecretRef) && secretAvailable === false) {
 		reasons.push("secret_missing");
 	}
 	return reasons;
+}
+
+function isOpenAiCompatibleMode(apiMode: string | null): boolean {
+	return (
+		apiMode === "openai_chat" || apiMode === "openai_responses" || apiMode === "codex_responses"
+	);
 }
 
 function readSupervisorObserved(paths: RuntimePaths): JsonRecord | null {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -2211,7 +2211,7 @@ fi
 				model: null,
 				apiKeySecretRef: "provider.default.apiKey",
 				secretAvailable: false,
-				reasons: ["secret_missing"],
+				reasons: ["model_missing", "secret_missing"],
 			},
 		});
 	});
@@ -4125,14 +4125,14 @@ exit 64
 				readFileSync(join(state, "status", "provider-health.json"), "utf-8"),
 			);
 			expect(providerHealth.providers.default).toEqual({
-				status: "ok",
+				status: "error",
 				configured: true,
 				kind: "openai-compatible",
 				baseUrl: "https://sub2api.test/v1",
 				model: null,
 				apiKeySecretRef: "provider.default.apiKey",
 				secretAvailable: true,
-				reasons: [],
+				reasons: ["model_missing"],
 			});
 			expect(JSON.stringify(providerHealth)).not.toContain("sk-runtime");
 		} finally {


### PR DESCRIPTION
## Summary
- use the enabled runtime model as a fallback when runtime manifest provider.default_model is missing
- surface model_missing and base_url_path_missing in hosted runtime provider health/status
- keep v2 OpenClaw on OpenAI-compatible Responses; this does not switch to Codex/PI transport

Depends on Clawdi-AI/clawdi-hosted#609 for v2 hosted runtime state to include the runtime model.

## Tests
- uv run pytest tests/test_runtime_manifest.py -q
- uv run ruff check app/routes/runtime.py tests/test_runtime_manifest.py
- bun test packages/cli/tests/runtime.test.ts packages/cli/tests/commands/ai-provider.test.ts