### PR TITLE
Narrow OpenAI-compatible runtime health scope

### DIFF
--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -231,9 +231,7 @@ function providerHealthReasons(
 }
 
 function isOpenAiCompatibleMode(apiMode: string | null): boolean {
-	return (
-		apiMode === "openai_chat" || apiMode === "openai_responses" || apiMode === "codex_responses"
-	);
+	return apiMode === "openai_chat" || apiMode === "openai_responses";
 }
 
 function recordValue(value: unknown): Record<string, unknown> | null {

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -226,9 +226,7 @@ function providerReasons(provider: JsonRecord, secretAvailable: boolean | null):
 }
 
 function isOpenAiCompatibleMode(apiMode: string | null): boolean {
-	return (
-		apiMode === "openai_chat" || apiMode === "openai_responses" || apiMode === "codex_responses"
-	);
+	return apiMode === "openai_chat" || apiMode === "openai_responses";
 }
 
 function readSupervisorObserved(paths: RuntimePaths): JsonRecord | null {


### PR DESCRIPTION
## Summary
- Limit the new provider base URL path health check to direct OpenAI-compatible modes: openai_chat and openai_responses
- Avoid expanding this runtime-health change to Codex/PI transport paths

## Verification
- bun test packages/cli/tests/runtime.test.ts packages/cli/tests/commands/ai-provider.test.ts
