### PR TITLE
Use chat completions for managed provider

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -250,7 +250,7 @@ async def admin_upsert_clawdi_managed_ai_provider(
 
     This intentionally does not expose a generic admin AI-provider write API.
     Hosted deploy orchestration only needs to install the fixed
-    Clawdi-managed OpenAI-compatible Responses provider and rotate its key.
+    Clawdi-managed OpenAI-compatible chat provider and rotate its key.
     """
     target = await _resolve_or_create_user(db, body.target_clerk_id)
     try:

--- a/backend/app/services/managed_ai_provider.py
+++ b/backend/app/services/managed_ai_provider.py
@@ -11,7 +11,7 @@ from app.models.user import User
 from app.services.vault_crypto import encrypt
 
 MANAGED_AI_PROVIDER_ID = "clawdi-managed"
-MANAGED_AI_PROVIDER_API_MODE = "openai_responses"
+MANAGED_AI_PROVIDER_API_MODE = "openai_chat"
 MANAGED_AI_PROVIDER_RUNTIME_ENV = "CLAWDI_MANAGED_OPENAI_API_KEY"
 MANAGED_AI_PROVIDER_TYPE = "custom_openai_compatible"
 MANAGED_AI_PROVIDER_LABEL = "Clawdi managed"

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -117,7 +117,7 @@ async def test_ai_provider_rejects_invalid_auth_and_api_mode(client: httpx.Async
         },
     )
     assert managed_wrong_mode.status_code == 422, managed_wrong_mode.text
-    assert "must use api_mode openai_responses" in managed_wrong_mode.text
+    assert "must use api_mode openai_chat" in managed_wrong_mode.text
 
     managed = await client.post(
         "/api/ai-providers",
@@ -125,15 +125,15 @@ async def test_ai_provider_rejects_invalid_auth_and_api_mode(client: httpx.Async
             "provider_id": "clawdi-managed",
             "type": "custom_openai_compatible",
             "base_url": "https://managed.example/v1",
-            "default_model": "openai-codex/gpt-5.5",
-            "api_mode": "openai_responses",
+            "default_model": "gpt-5.5",
+            "api_mode": "openai_chat",
             "auth": {"type": "api_key", "source": "managed"},
             "managed_by": "clawdi",
             "runtime_env_name": "CLAWDI_MANAGED_OPENAI_API_KEY",
         },
     )
     assert managed.status_code == 200, managed.text
-    assert managed.json()["api_mode"] == "openai_responses"
+    assert managed.json()["api_mode"] == "openai_chat"
 
     plaintext_extra = await client.post(
         "/api/ai-providers",

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -794,7 +794,8 @@ async def test_runtime_manifest_projects_provider_secret_values(
             type="custom_openai_compatible",
             base_url="https://sub2api.test/v1",
             default_model="gpt-5.5",
-            api_mode="codex_responses",
+            # Simulate a stale managed provider row from before the chat-completions contract.
+            api_mode="openai_responses",
             auth_type="api_key",
             auth_metadata={"source": "managed"},
             managed_by="clawdi",
@@ -826,7 +827,7 @@ async def test_runtime_manifest_projects_provider_secret_values(
         "kind": "openai-compatible",
         "baseUrl": "https://sub2api.test/v1",
         "model": "gpt-5.5",
-        "apiMode": "openai_responses",
+        "apiMode": "openai_chat",
         "runtimeEnvName": "CLAWDI_MANAGED_OPENAI_API_KEY",
         "apiKeySecretRef": "provider.default.apiKey",
     }

--- a/packages/cli/tests/commands/ai-provider.test.ts
+++ b/packages/cli/tests/commands/ai-provider.test.ts
@@ -744,8 +744,8 @@ describe("ai-provider commands", () => {
 						id: "clawdi-managed",
 						type: "custom_openai_compatible",
 						base_url: "https://sub2api.example.test/v1",
-						default_model: "openai-codex/gpt-5.5",
-						api_mode: "openai_responses",
+						default_model: "gpt-5.5",
+						api_mode: "openai_chat",
 						auth: {
 							type: "api_key",
 							source: "managed",
@@ -1721,7 +1721,7 @@ describe("ai-provider commands", () => {
 		});
 	});
 
-	it("projects Clawdi-managed OpenAI Responses providers directly to OpenClaw", async () => {
+	it("projects Clawdi-managed OpenAI chat providers directly to OpenClaw", async () => {
 		const catalog = {
 			schema_version: 1,
 			providers: [
@@ -1730,8 +1730,8 @@ describe("ai-provider commands", () => {
 					type: "custom_openai_compatible",
 					label: "Clawdi AI",
 					base_url: "https://sub2api.example.test/v1",
-					default_model: "openai-codex/gpt-5.5",
-					api_mode: "openai_responses",
+					default_model: "gpt-5.5",
+					api_mode: "openai_chat",
 					auth: { type: "api_key", source: "managed" },
 					managed_by: "clawdi",
 					runtime_env_name: "CLAWDI_MANAGED_OPENAI_API_KEY",
@@ -1743,16 +1743,16 @@ describe("ai-provider commands", () => {
 		const projection = buildAgentTargetProjection("openclaw", catalog);
 		const patch = JSON.parse(projection.files[0]!.content);
 
-		expect(patch.agents.defaults.model.primary).toBe("clawdi-managed/openai-codex/gpt-5.5");
+		expect(patch.agents.defaults.model.primary).toBe("clawdi-managed/gpt-5.5");
 		expect(patch.models.providers["clawdi-managed"].baseUrl).toBe(
 			"https://sub2api.example.test/v1",
 		);
-		expect(patch.models.providers["clawdi-managed"].api).toBe("openai-responses");
+		expect(patch.models.providers["clawdi-managed"].api).toBe("openai-completions");
 		expect(patch.models.providers["clawdi-managed"].agentRuntime).toBeUndefined();
 		expect(patch.models.providers["clawdi-managed"].models[0]).toMatchObject({
-			id: "openai-codex/gpt-5.5",
-			name: "openai-codex/gpt-5.5",
-			api: "openai-responses",
+			id: "gpt-5.5",
+			name: "gpt-5.5",
+			api: "openai-completions",
 		});
 		expect(patch.models.providers["clawdi-managed"].apiKey).toEqual({
 			source: "env",
@@ -1761,7 +1761,7 @@ describe("ai-provider commands", () => {
 		});
 	});
 
-	it("projects Clawdi-managed OpenAI Responses providers directly to Hermes", () => {
+	it("projects Clawdi-managed OpenAI chat providers directly to Hermes", () => {
 		const projection = buildAgentTargetProjection("hermes", {
 			schema_version: 1,
 			providers: [
@@ -1770,8 +1770,8 @@ describe("ai-provider commands", () => {
 					type: "custom_openai_compatible",
 					label: "Clawdi AI",
 					base_url: "https://sub2api.example.test/v1",
-					default_model: "openai-codex/gpt-5.5",
-					api_mode: "openai_responses",
+					default_model: "gpt-5.5",
+					api_mode: "openai_chat",
 					auth: { type: "api_key", source: "managed" },
 					managed_by: "clawdi",
 					runtime_env_name: "CLAWDI_MANAGED_OPENAI_API_KEY",
@@ -1783,8 +1783,8 @@ describe("ai-provider commands", () => {
 		const patch = projection.files[0]?.content ?? "";
 		expect(patch).toContain('provider: "custom:clawdi-managed"');
 		expect(patch).toContain('api: "https://sub2api.example.test/v1"');
-		expect(patch).toContain('transport: "codex_responses"');
-		expect(patch).toContain('default_model: "openai-codex/gpt-5.5"');
+		expect(patch).toContain('transport: "chat_completions"');
+		expect(patch).toContain('default_model: "gpt-5.5"');
 		expect(patch).toContain('key_env: "CLAWDI_MANAGED_OPENAI_API_KEY"');
 		expect(patch).not.toContain("chatgpt.com");
 		expect(patch).not.toContain("CLAWDI_PROVIDER_PLACEHOLDER_TOKEN");

--- a/packages/shared/src/ai-provider.test.ts
+++ b/packages/shared/src/ai-provider.test.ts
@@ -135,7 +135,7 @@ describe("validateAiProviderCatalog", () => {
 		expect(result.errors).toEqual([]);
 	});
 
-	test("requires Clawdi-managed providers to use OpenAI Responses mode", () => {
+	test("accepts Clawdi-managed providers in OpenAI chat mode", () => {
 		const result = validateAiProviderCatalog({
 			schema_version: 1,
 			providers: [
@@ -143,8 +143,30 @@ describe("validateAiProviderCatalog", () => {
 					id: "clawdi-managed",
 					type: "custom_openai_compatible",
 					base_url: "https://managed.example/v1",
-					default_model: "openai-codex/gpt-5.5",
+					default_model: "gpt-5.5",
 					api_mode: "openai_chat",
+					auth: { type: "api_key", source: "managed" },
+					managed_by: "clawdi",
+					runtime_env_name: "CLAWDI_MANAGED_OPENAI_API_KEY",
+				},
+			],
+			defaults: { chat_provider_id: "clawdi-managed" },
+		});
+
+		expect(result.valid).toBe(true);
+		expect(result.errors).toEqual([]);
+	});
+
+	test("requires Clawdi-managed providers to use OpenAI chat mode", () => {
+		const result = validateAiProviderCatalog({
+			schema_version: 1,
+			providers: [
+				{
+					id: "clawdi-managed",
+					type: "custom_openai_compatible",
+					base_url: "https://managed.example/v1",
+					default_model: "gpt-5.5",
+					api_mode: "openai_responses",
 					auth: { type: "api_key", source: "managed" },
 					managed_by: "clawdi",
 					runtime_env_name: "CLAWDI_MANAGED_OPENAI_API_KEY",
@@ -155,7 +177,7 @@ describe("validateAiProviderCatalog", () => {
 
 		expect(result.valid).toBe(false);
 		expect(result.errors).toContain(
-			"Provider clawdi-managed managed_by clawdi must use api_mode openai_responses.",
+			"Provider clawdi-managed managed_by clawdi must use api_mode openai_chat.",
 		);
 	});
 });

--- a/packages/shared/src/ai-provider.ts
+++ b/packages/shared/src/ai-provider.ts
@@ -122,7 +122,7 @@ const DEFAULT_BASE_URL: Partial<Record<AiProviderType, string>> = {
 };
 
 const CLAWDI_MANAGED_PROVIDER_ID = "clawdi-managed";
-const CLAWDI_MANAGED_API_MODE = "openai_responses";
+const CLAWDI_MANAGED_API_MODE = "openai_chat";
 const CLAWDI_MANAGED_RUNTIME_ENV = "CLAWDI_MANAGED_OPENAI_API_KEY";
 
 export function isAiProviderId(input: string): boolean {


### PR DESCRIPTION
## Summary
- change the first-party Clawdi-managed provider contract to `openai_chat`
- keep managed OpenClaw/Hermes projection on the OpenAI-compatible chat/completions transport
- update backend validation, runtime manifest, shared catalog, CLI command projection, and managed-provider tests

## Design
The managed provider is a custom OpenAI-compatible gateway at `/v1`. Kingsley smoke showed the same base URL/key/model succeeds through `/v1/chat/completions` and fails through `/v1/responses` with HTTP 400. The correct contract for this provider is therefore `openai_chat`, which the existing CLI projection maps to OpenClaw `openai-completions` and Hermes `chat_completions`.

## Non-goals
- no v1 hosted deployment changes
- no OpenClaw fork/runtime patch
- no `codex_responses` or PI runtime path
- no MITM or payload rewrite hack

## Verification
- `bun test packages/cli/tests/commands/ai-provider.test.ts packages/shared/src/ai-provider.test.ts --timeout 60000`
- `bun test packages/shared/src/ai-provider.test.ts packages/cli/tests/runtime.test.ts --timeout 30000`
- `cd backend && uv run pytest tests/test_ai_providers.py::test_ai_provider_rejects_invalid_auth_and_api_mode tests/test_runtime_manifest.py::test_runtime_manifest_projects_provider_secret_values tests/test_admin_endpoints.py::test_admin_upsert_managed_ai_provider_writes_fixed_contract -q`
- `bunx biome check packages/cli/tests/commands/ai-provider.test.ts packages/shared/src/ai-provider.test.ts packages/shared/src/ai-provider.ts`
- `bunx biome check packages/shared/src/ai-provider.ts packages/shared/src/ai-provider.test.ts packages/cli/src/lib/ai-provider-projection.ts backend/app/services/managed_ai_provider.py backend/app/routes/admin.py backend/tests/test_ai_providers.py backend/tests/test_runtime_manifest.py`
- `cd backend && uv run ruff check app/services/managed_ai_provider.py app/routes/admin.py tests/test_ai_providers.py tests/test_runtime_manifest.py`
- GitHub CI: green

## Deploy notes
Deploy Clawdi Cloud before reconciling Kingsley so runtime manifest generation forces managed providers to `openai_chat`. Existing stored provider rows do not need a DB migration because runtime manifest projection overrides recognized Clawdi-managed rows with this constant.