### PR TITLE
Polish sidebar agent summary and hosted console

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -736,18 +736,27 @@ function agentHeaderMeta(
 	agent: SidebarEnvironment,
 	hosted: boolean,
 ): {
-	identity: string[];
-	activity: string[];
+	visibleLabel: string;
+	detailLabel: string;
+	activityLabel: string;
 } {
-	const identity = [
-		hosted ? `${agentTypeLabel(agent.agent_type)} runtime` : agentTypeLabel(agent.agent_type),
-		agentVersionLabel(agent.agent_version),
+	const source = hosted ? "Hosted" : "Connected";
+	const typeLabel = agentTypeLabel(agent.agent_type);
+	const version = agentVersionLabel(agent.agent_version);
+	const relativeSeen = agent.last_seen_at ? relativeTime(agent.last_seen_at) : null;
+	const activityLabel = relativeSeen ? `last seen ${relativeSeen}` : "never seen";
+	const visible = [
+		source,
+		hosted ? `${typeLabel} runtime` : typeLabel,
 		agent.os?.trim() || null,
 	].filter((item): item is string => Boolean(item));
-	const activity = [
-		agent.last_seen_at ? `last seen ${relativeTime(agent.last_seen_at)}` : "never seen",
+	const detail = [
+		source,
+		hosted ? `${typeLabel} runtime` : typeLabel,
+		version,
+		agent.os?.trim() || null,
 	].filter((item): item is string => Boolean(item));
-	return { identity, activity };
+	return { visibleLabel: visible.join(" · "), detailLabel: detail.join(" · "), activityLabel };
 }
 
 function FocusHeader({
@@ -786,43 +795,32 @@ function FocusHeader({
 	const name = agentDisplayName(activeAgent);
 	const displayName = displayMachineName(name);
 	const hosted = showV2Features && isHostedAgentEnvironment(activeAgent);
-	const source = hosted ? "Hosted" : "Connected";
 	const meta = agentHeaderMeta(activeAgent, hosted);
-	const identityLabel = meta.identity.join(" · ");
-	const activityLabel = meta.activity.join(" · ");
+	const title = [name, meta.detailLabel, meta.activityLabel].filter(Boolean).join(" · ");
 	return (
 		<div className="min-w-0 text-left">
-			<div className="flex min-w-0 items-center gap-2">
-				<div
-					className="min-w-0 flex-1 truncate text-sm font-semibold leading-5"
-					title={displayName}
-				>
-					{displayName}
-				</div>
-				<span className="shrink-0 text-[10px] font-medium leading-4 text-muted-foreground uppercase tracking-wide">
-					{source}
-				</span>
+			<div className="truncate text-sm font-semibold leading-5" title={title}>
+				{displayName}
 			</div>
-			{identityLabel ? (
+			{meta.visibleLabel ? (
 				<div
-					className="mt-0.5 truncate text-xs leading-4 text-muted-foreground"
-					title={identityLabel}
+					className="mt-1 truncate text-xs leading-4 text-muted-foreground"
+					title={meta.detailLabel}
 				>
-					{identityLabel}
+					{meta.visibleLabel}
 				</div>
 			) : null}
-			<div className="mt-0.5 flex min-w-0 items-center gap-1.5 text-xs leading-4">
-				<span className="min-w-0 truncate text-muted-foreground" title={activityLabel}>
-					{activityLabel}
-				</span>
-				<span aria-hidden="true" className="shrink-0 text-muted-foreground/50">
-					·
-				</span>
+			<div className="mt-2 flex min-w-0 items-center justify-between gap-2 rounded-md border border-sidebar-border bg-sidebar-accent/45 px-2 py-1 text-xs leading-4">
 				<DaemonStatusBadge
 					env={activeAgent}
 					source={hosted ? "on-clawdi" : "self-managed"}
 					manageHref={hosted ? agentSectionHref(activeAgent.id, "compute") : undefined}
+					compact
+					tooltipDetail={meta.detailLabel}
 				/>
+				<span className="min-w-0 truncate text-muted-foreground" title={meta.activityLabel}>
+					{meta.activityLabel}
+				</span>
 			</div>
 		</div>
 	);

--- a/apps/web/src/components/dashboard/daemon-status.tsx
+++ b/apps/web/src/components/dashboard/daemon-status.tsx
@@ -139,10 +139,19 @@ const SHORT_LABEL: Record<Status, string> = {
 	paused: "Sync paused",
 };
 
+const COMPACT_LABEL: Record<Status, string> = {
+	live: "Live",
+	"set-up": "Setup",
+	errored: "Error",
+	paused: "Paused",
+};
+
 export function DaemonStatusBadge({
 	env,
 	source = "self-managed",
 	manageHref,
+	compact = false,
+	tooltipDetail,
 }: {
 	env: Env;
 	/** "on-clawdi" tiles change the dialog copy across every non-
@@ -161,27 +170,33 @@ export function DaemonStatusBadge({
 	 * omit it; hosted callers without a deployment link get a plain
 	 * "contact support / check agent settings" message. */
 	manageHref?: string;
+	/** Use a one-word label in constrained layouts such as the sidebar header. */
+	compact?: boolean;
+	/** Extra context shown only in the tooltip for crowded layouts. */
+	tooltipDetail?: string;
 }) {
 	const status = classify(env);
 	const isHosted = source === "on-clawdi";
 	const [open, setOpen] = useState(false);
+	const label =
+		isHosted && status === "set-up"
+			? compact
+				? "Pending"
+				: "Sync pending"
+			: compact
+				? COMPACT_LABEL[status]
+				: SHORT_LABEL[status];
 	const inner = (
 		<span
 			className={cn(
-				"inline-flex items-center gap-1.5",
+				"inline-flex items-center gap-1.5 whitespace-nowrap",
+				compact && "gap-1",
 				status === "live" ? "text-muted-foreground" : TEXT_TONE[status],
 				"cursor-pointer hover:text-foreground",
 			)}
 		>
 			<span aria-hidden className={cn("inline-block size-1.5 rounded-full", DOT_TONE[status])} />
-			<span>
-				{/* Hosted "set-up" reads as "Sync pending" — the rollout
-				    is in flight, not waiting on the user. Other states
-				    use the same label as self-managed because they have
-				    the same product meaning regardless of who provisioned
-				    the hosted runtime. */}
-				{isHosted && status === "set-up" ? "Sync pending" : SHORT_LABEL[status]}
-			</span>
+			<span className="whitespace-nowrap">{label}</span>
 		</span>
 	);
 	// Hosted users see a tooltip that doesn't promise a CLI fix.
@@ -213,13 +228,21 @@ export function DaemonStatusBadge({
 						// for visual fit in the meta line; pair it with an
 						// explicit focus-visible ring so keyboard users
 						// still see where they are.
-						className="appearance-none rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+						className={cn(
+							"appearance-none rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+							compact && "shrink-0 whitespace-nowrap",
+						)}
 					>
 						{inner}
 					</button>
 				</TooltipTrigger>
 				<TooltipContent side="bottom" className="text-xs">
-					{tooltip}
+					<div className="flex flex-col gap-0.5">
+						<span>{tooltip}</span>
+						{tooltipDetail ? (
+							<span className="font-normal text-muted-foreground">{tooltipDetail}</span>
+						) : null}
+					</div>
 				</TooltipContent>
 			</Tooltip>
 			{/* Dialog content portals into document.body, but React events

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -233,26 +233,36 @@ export function HostedAgentDetail({
 
 	const activeNavItem = HOSTED_AGENT_NAV_META[activeTab];
 	const activeTabLabel = agentSectionLabel(activeTab);
+	const isConsoleTab = activeTab === "console";
 
 	return (
-		<div data-hosted="true" className="space-y-6 px-4 lg:px-6">
-			<section className="space-y-4">
-				<div className="flex flex-wrap items-start justify-between gap-3">
-					<div>
-						<h1 className="text-xl font-semibold tracking-tight">{activeTabLabel}</h1>
-						{activeNavItem.description ? (
-							<p className="mt-1 text-sm text-muted-foreground">{activeNavItem.description}</p>
+		<div
+			data-hosted="true"
+			className={
+				isConsoleTab
+					? "-my-4 flex min-h-[calc(100svh-var(--header-height))] flex-col md:-my-5 md:min-h-[calc(100svh-var(--header-height)-1rem)]"
+					: "space-y-6 px-4 lg:px-6"
+			}
+		>
+			<section className={isConsoleTab ? "flex min-h-0 flex-1 flex-col" : "space-y-4"}>
+				{isConsoleTab ? null : (
+					<div className="flex flex-wrap items-start justify-between gap-3">
+						<div>
+							<h1 className="text-xl font-semibold tracking-tight">{activeTabLabel}</h1>
+							{activeNavItem.description ? (
+								<p className="mt-1 text-sm text-muted-foreground">{activeNavItem.description}</p>
+							) : null}
+						</div>
+						{consoleUrl ? (
+							<Button asChild variant="outline" size="sm">
+								<a href={consoleUrl} target="_blank" rel="noopener noreferrer">
+									Open {runtimeLabel}
+									<ExternalLink className="size-3.5" />
+								</a>
+							</Button>
 						) : null}
 					</div>
-					{consoleUrl ? (
-						<Button asChild variant="outline" size="sm">
-							<a href={consoleUrl} target="_blank" rel="noopener noreferrer">
-								Open {runtimeLabel}
-								<ExternalLink className="size-3.5" />
-							</a>
-						</Button>
-					) : null}
-				</div>
+				)}
 				{activeTab === "overview" ? (
 					<OverviewTab
 						deployment={deployment}
@@ -265,7 +275,7 @@ export function HostedAgentDetail({
 						sessionHref={(session) => scopedSessionHref(session.id)}
 					/>
 				) : null}
-				{activeTab === "console" ? <ConsoleTab deployment={deployment} runtime={runtime} /> : null}
+				{isConsoleTab ? <ConsoleTab deployment={deployment} runtime={runtime} /> : null}
 				{activeTab === "sessions" ? (
 					<div className="max-w-4xl">
 						{sessions.error ? (
@@ -417,12 +427,14 @@ function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; run
 	}
 
 	return (
-		<div className="space-y-3">
-			<LiveNote>This is the live {label} UI, embedded from the running agent.</LiveNote>
-
-			<div className="flex flex-wrap items-center justify-between gap-2">
-				<span className="text-sm font-medium">{label}</span>
-				<Button asChild variant="outline" size="sm">
+		<div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-none border-y bg-background md:rounded-b-xl">
+			<div className="flex h-11 shrink-0 items-center justify-between gap-3 border-b px-4 lg:px-6">
+				<div className="flex min-w-0 items-center gap-2 text-sm">
+					<MonitorPlay className="size-4 shrink-0 text-muted-foreground" />
+					<span className="shrink-0 font-medium">{label}</span>
+					<span className="min-w-0 truncate text-muted-foreground">Live runtime UI</span>
+				</div>
+				<Button asChild variant="outline" size="sm" className="hidden sm:inline-flex">
 					<a href={url} target="_blank" rel="noopener noreferrer">
 						Open full screen
 						<Maximize2 className="size-3.5" />
@@ -436,10 +448,10 @@ function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; run
 				key={runtime}
 				src={url}
 				title={`${label} console`}
-				className="hidden h-[70vh] min-h-[520px] w-full rounded-lg border bg-background sm:block"
+				className="hidden min-h-0 flex-1 border-0 bg-background sm:block"
 				allow="clipboard-read; clipboard-write"
 			/>
-			<div className="rounded-lg border border-dashed p-6 text-center sm:hidden">
+			<div className="flex min-h-[420px] flex-1 items-center justify-center border border-dashed p-6 text-center sm:hidden">
 				<p className="text-sm text-muted-foreground">
 					The console is best viewed full screen on a small screen.
 				</p>


### PR DESCRIPTION
## Summary
- polish the agent focus header so identity, runtime metadata, and sync health each have their own readable row
- keep full agent/version/last-seen detail available through titles and sync tooltip/dialog
- let hosted Runtime Console iframe fill the right-side body with a compact toolbar

## Verification
- bun run check
- bun run typecheck
- bun run build