### PR TITLE
Optimize dashboard backend performance

### DIFF
--- a/apps/web/src/app/(dashboard)/page.tsx
+++ b/apps/web/src/app/(dashboard)/page.tsx
@@ -23,6 +23,7 @@ import { relativeTime } from "@/lib/utils";
 import { useV2Access } from "@/lib/v2-access";
 
 const RECENT_SESSIONS_LIMIT = 15;
+const DASHBOARD_STALE_MS = 30_000;
 
 function countProjectTypes(
 	projects: Array<{ kind?: string | null }> | undefined,
@@ -77,14 +78,16 @@ export default function DashboardPage() {
 	const api = useApi();
 	const v2Access = useV2Access();
 
-	const { data: stats } = useQuery({
+	const { data: stats, isLoading: statsLoading } = useQuery({
 		queryKey: ["dashboard-stats"],
 		queryFn: async () => unwrap(await api.GET("/api/dashboard/stats")),
+		staleTime: DASHBOARD_STALE_MS,
 	});
 
 	const { data: projects, isLoading: projectsLoading } = useQuery({
 		queryKey: ["projects"],
 		queryFn: async () => unwrap(await api.GET("/api/projects")),
+		staleTime: DASHBOARD_STALE_MS,
 	});
 
 	const { data: environments, isLoading: envsLoading } = useQuery({
@@ -95,11 +98,6 @@ export default function DashboardPage() {
 		// stay green indefinitely. Match the agent detail page's
 		// 10s cadence so the live indicator is actually live.
 		refetchInterval: 10_000,
-	});
-
-	const { data: contribution, isLoading: contribLoading } = useQuery({
-		queryKey: ["dashboard-contribution"],
-		queryFn: async () => unwrap(await api.GET("/api/dashboard/contribution")),
 	});
 
 	// Manual sessions only: on a working fleet ~3/4 of sessions are
@@ -113,8 +111,10 @@ export default function DashboardPage() {
 					params: { query: { page_size: RECENT_SESSIONS_LIMIT, automated: false } },
 				}),
 			),
+		staleTime: DASHBOARD_STALE_MS,
 	});
 	const sessions = sessionsPage?.items;
+	const contribution = stats?.contribution;
 
 	const streakLine =
 		stats && stats.current_streak > 0
@@ -181,7 +181,7 @@ export default function DashboardPage() {
 							</CardDescription>
 						</CardHeader>
 						<CardContent>
-							{contribLoading ? (
+							{statsLoading ? (
 								<Skeleton className="h-28 w-full rounded-md" />
 							) : contribution ? (
 								<ContributionGraph data={contribution} />

--- a/apps/web/src/app/(dashboard)/skills/page.tsx
+++ b/apps/web/src/app/(dashboard)/skills/page.tsx
@@ -46,7 +46,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
-import { ensureBlob, unwrap, useApi } from "@/lib/api";
+import { ensureBlob, unwrap, useApi, useSkillArchiveUploader } from "@/lib/api";
 import { fetchAllPages } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
@@ -77,6 +77,7 @@ export default function SkillsPage() {
 
 function SkillsPageInner() {
 	const api = useApi();
+	const uploadSkillArchive = useSkillArchiveUploader();
 	const queryClient = useQueryClient();
 	// `?project=<project_id>` is the canonical scope. `?target=<env_id>`
 	// remains supported for older deep links from agent detail pages.
@@ -366,17 +367,7 @@ function SkillsPageInner() {
 					continue;
 				}
 				try {
-					const fileName = `${newest.skill_key.replace(/\//g, "-")}.tar.gz`;
-					const form = new FormData();
-					form.append("skill_key", newest.skill_key);
-					form.append("file", blob, fileName);
-					await unwrap(
-						await api.POST("/api/projects/{project_id}/skills/upload", {
-							params: { path: { project_id: copy.project_id } },
-							body: { skill_key: newest.skill_key, file: fileName },
-							bodySerializer: () => form,
-						}),
-					);
+					await uploadSkillArchive(copy.project_id, newest.skill_key, blob);
 					updated += 1;
 				} catch {
 					failed.push(copy.project_name ?? "unknown project");

--- a/apps/web/src/components/dashboard/this-week-card.tsx
+++ b/apps/web/src/components/dashboard/this-week-card.tsx
@@ -1,9 +1,7 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { unwrap, useApi } from "@/lib/api";
 import type { ContributionDay, DashboardStats } from "@/lib/api-schemas";
 import { formatModelLabel } from "@/lib/format";
 import { formatNumber } from "@/lib/utils";
@@ -20,28 +18,11 @@ export function ThisWeekCard({
 	stats: DashboardStats | undefined;
 	contribution: ContributionDay[] | undefined;
 }) {
-	const api = useApi();
 	const ready = !!stats;
 	const weekSessions = sessionsInLastDays(contribution, 7);
 	const todaySessions = sessionsInLastDays(contribution, 1);
 	const topModel = formatModelLabel(stats?.favorite_model) || null;
-
-	// "388 sessions this week" is a fleet vanity number when ~3/4 of it
-	// is cron/heartbeat ticks. Split out the user's own (manual) count —
-	// that's the number that means anything. One cheap count query:
-	// page_size=1, we only read `total`.
-	const { data: manualWeek } = useQuery({
-		queryKey: ["this-week-manual"],
-		queryFn: async () => {
-			const since = new Date(Date.now() - 7 * 86_400_000).toISOString();
-			const page = unwrap(
-				await api.GET("/api/sessions", {
-					params: { query: { page_size: 1, automated: false, since } },
-				}),
-			);
-			return page.total;
-		},
-	});
+	const manualWeek = stats?.manual_sessions_last_7_days;
 	const automatedWeek = manualWeek === undefined ? null : Math.max(0, weekSessions - manualWeek);
 
 	return (

--- a/apps/web/src/components/skills/send-skill-dialog.tsx
+++ b/apps/web/src/components/skills/send-skill-dialog.tsx
@@ -27,7 +27,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
-import { ensureBlob, unwrap, useApi } from "@/lib/api";
+import { ensureBlob, unwrap, useApi, useSkillArchiveUploader } from "@/lib/api";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
 import { errorMessage } from "@/lib/utils";
@@ -52,6 +52,7 @@ export function SendSkillDialog({
 	onDone?: () => void;
 }) {
 	const api = useApi();
+	const uploadSkillArchive = useSkillArchiveUploader();
 	const qc = useQueryClient();
 	const [open, setOpen] = useState(false);
 	const [target, setTarget] = useState("");
@@ -129,17 +130,7 @@ export function SendSkillDialog({
 							}),
 						),
 					);
-					const fileName = `${skill.skill_key.replace(/\//g, "-")}.tar.gz`;
-					const form = new FormData();
-					form.append("skill_key", skill.skill_key);
-					form.append("file", blob, fileName);
-					await unwrap(
-						await api.POST("/api/projects/{project_id}/skills/upload", {
-							params: { path: { project_id: target } },
-							body: { skill_key: skill.skill_key, file: fileName },
-							bodySerializer: () => form,
-						}),
-					);
+					await uploadSkillArchive(target, skill.skill_key, blob);
 					copied += 1;
 					if (removeFromSource) {
 						try {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,8 +1,8 @@
 "use client";
 
-import { extractApiDetail, type paths } from "@clawdi/shared/api";
+import { type components, extractApiDetail, type paths } from "@clawdi/shared/api";
 import createClient from "openapi-fetch";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { ApiError, ApiNetworkError } from "@/lib/api-errors";
 import { useAuthToken } from "@/lib/auth-client";
 import { env } from "@/lib/env";
@@ -13,6 +13,12 @@ import { env } from "@/lib/env";
 export { ApiError, toastApiError } from "@/lib/api-errors";
 
 const API_URL = env.NEXT_PUBLIC_API_URL;
+type SkillUploadResponse = components["schemas"]["SkillUploadResponse"];
+
+function apiUrl(path: string): string {
+	const base = API_URL.endsWith("/") ? API_URL : `${API_URL}/`;
+	return new URL(path.replace(/^\/+/, ""), base).toString();
+}
 
 /**
  * Client-side request ceiling. A hung backend or a black-holed connection must
@@ -96,4 +102,50 @@ export function unwrap<T>(result: { data?: T; error?: unknown; response: Respons
 export function ensureBlob(value: unknown): Blob {
 	if (value instanceof Blob) return value;
 	throw new Error("Expected a binary API response");
+}
+
+async function apiErrorDetail(response: Response): Promise<string> {
+	try {
+		if ((response.headers.get("content-type") ?? "").includes("application/json")) {
+			const body: unknown = await response.json();
+			return extractApiDetail(body);
+		}
+		return (await response.text()) || response.statusText;
+	} catch {
+		return response.statusText;
+	}
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+	const body: unknown = await response.json();
+	return body as T;
+}
+
+export function useSkillArchiveUploader() {
+	const { getToken } = useAuthToken();
+	return useCallback(
+		async (projectId: string, skillKey: string, archive: Blob): Promise<SkillUploadResponse> => {
+			const fileName = `${skillKey.replace(/\//g, "-")}.tar.gz`;
+			const form = new FormData();
+			form.append("skill_key", skillKey);
+			form.append("file", archive, fileName);
+
+			const headers = new Headers();
+			const token = await getToken();
+			if (token) headers.set("Authorization", `Bearer ${token}`);
+
+			const response = await fetchWithTimeout(
+				new Request(apiUrl(`/api/projects/${encodeURIComponent(projectId)}/skills/upload`), {
+					method: "POST",
+					headers,
+					body: form,
+				}),
+			);
+			if (!response.ok) {
+				throw new ApiError(response.status, await apiErrorDetail(response));
+			}
+			return readJson<SkillUploadResponse>(response);
+		},
+		[getToken],
+	);
 }

--- a/backend/alembic/versions/f6a1b2c3d4e5_add_manual_sessions_recent_index.py
+++ b/backend/alembic/versions/f6a1b2c3d4e5_add_manual_sessions_recent_index.py
@@ -1,0 +1,38 @@
+"""add partial index for recent manual sessions
+
+Revision ID: f6a1b2c3d4e5
+Revises: e3b8a7c9d2f1
+Create Date: 2026-06-27 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "f6a1b2c3d4e5"
+down_revision: str | Sequence[str] | None = "e3b8a7c9d2f1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Dashboard home requests recent manual sessions with
+    # `automated=false`, ordered by last_activity_at DESC and limited to
+    # a tiny page. Production fleets can be dominated by cron/heartbeat
+    # rows, so this partial index lets Postgres skip those rows entirely
+    # instead of scanning backward through automated sessions first.
+    op.create_index(
+        "ix_sessions_user_manual_last_activity",
+        "sessions",
+        ["user_id", sa.text("last_activity_at DESC")],
+        postgresql_where=sa.text(
+            "summary IS NULL OR (summary NOT LIKE 'Cron:%' AND summary NOT LIKE '[%')"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sessions_user_manual_last_activity", table_name="sessions")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -46,6 +46,7 @@ from app.routes.share_redeem import router as share_redeem_router
 from app.routes.sharing import router as sharing_router
 from app.routes.skills import project_router as skills_project_router
 from app.routes.skills import router as skills_router
+from app.routes.skills import scope_router as skills_scope_router
 from app.routes.sync import router as sync_router
 from app.routes.vault import router as vault_router
 from app.services.composio import close_composio_client
@@ -240,6 +241,7 @@ app.include_router(projects_router)
 app.include_router(runtime_router)
 app.include_router(skills_router)
 app.include_router(skills_project_router)
+app.include_router(skills_scope_router)
 app.include_router(sync_router)
 app.include_router(memories_router)
 app.include_router(settings_router)

--- a/backend/app/routes/dashboard.py
+++ b/backend/app/routes/dashboard.py
@@ -1,18 +1,25 @@
-from datetime import UTC, datetime, timedelta
+import asyncio
+import logging
+from datetime import UTC, date, datetime, timedelta
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Response
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import AuthContext, require_web_auth
+from app.core.config import settings
 from app.core.database import get_session
-from app.models.memory import Memory
 from app.models.session import Session
-from app.models.skill import Skill
-from app.models.vault import Vault, VaultItem
 from app.schemas.dashboard import ContributionDayResponse, DashboardStatsResponse
 
 router = APIRouter(prefix="/api/dashboard", tags=["dashboard"])
+log = logging.getLogger(__name__)
+
+_DASHBOARD_DAYS_MAX = 3660
+_CONNECTORS_COUNT_CACHE_TTL = timedelta(minutes=2)
+_CONNECTORS_COUNT_TIMEOUT_SECONDS = 2.0
+_CONNECTORS_COUNT_CACHE_MAX = 1024
+_connectors_count_cache: dict[str, tuple[datetime, int]] = {}
 
 # These endpoints aggregate by `user_id` across every project/env
 # the user owns. An Agent API key (full-permission api_key
@@ -31,125 +38,223 @@ router = APIRouter(prefix="/api/dashboard", tags=["dashboard"])
 
 @router.get("/stats")
 async def get_stats(
+    response: Response,
     auth: AuthContext = Depends(require_web_auth),
     db: AsyncSession = Depends(get_session),
-    days: int = Query(default=365),
+    days: int = Query(default=365, ge=1, le=_DASHBOARD_DAYS_MAX),
 ) -> DashboardStatsResponse:
-    since = datetime.now(UTC) - timedelta(days=days)
+    response.headers["Cache-Control"] = "private, max-age=30, stale-while-revalidate=30"
+    now = datetime.now(UTC)
+    since = now - timedelta(days=days)
+    current_floor = now.date() - timedelta(days=1)
+    manual_since = now - timedelta(days=7)
 
     result = await db.execute(
-        select(
-            func.count(Session.id),
-            func.coalesce(func.sum(Session.message_count), 0),
-            func.coalesce(func.sum(Session.input_tokens + Session.output_tokens), 0),
-        ).where(Session.user_id == auth.user_id, Session.started_at >= since)
-    )
-    row = result.one()
-    total_sessions, total_messages, total_tokens = int(row[0]), int(row[1]), int(row[2])
-
-    # Active days
-    result = await db.execute(
-        select(func.count(func.distinct(func.date(Session.started_at)))).where(
-            Session.user_id == auth.user_id, Session.started_at >= since
-        )
-    )
-    active_days = result.scalar() or 0
-
-    # Favorite model
-    result = await db.execute(
-        select(Session.model, func.count(Session.id).label("cnt"))
-        .where(Session.user_id == auth.user_id, Session.model.isnot(None))
-        .group_by(Session.model)
-        .order_by(text("cnt DESC"))
-        .limit(1)
-    )
-    fav_row = result.first()
-    favorite_model = fav_row[0] if fav_row else None
-
-    # Peak hour
-    result = await db.execute(
-        select(
-            func.extract("hour", Session.started_at).label("hr"),
-            func.count(Session.id).label("cnt"),
-        )
-        .where(Session.user_id == auth.user_id)
-        .group_by(text("hr"))
-        .order_by(text("cnt DESC"))
-        .limit(1)
-    )
-    peak_row = result.first()
-    peak_hour = int(peak_row[0]) if peak_row else 0
-
-    # Streaks
-    current_streak, longest_streak = await _calc_streaks(db, auth.user_id)
-
-    # Module counts
-    skills_count = (
-        await db.execute(
-            select(func.count(Skill.id)).where(Skill.user_id == auth.user_id, Skill.is_active)
-        )
-    ).scalar() or 0
-
-    memories_count = (
-        await db.execute(select(func.count(Memory.id)).where(Memory.user_id == auth.user_id))
-    ).scalar() or 0
-
-    vault_count = (
-        await db.execute(select(func.count(Vault.id)).where(Vault.user_id == auth.user_id))
-    ).scalar() or 0
-
-    vault_keys_count = 0
-    vault_ids = (
-        (await db.execute(select(Vault.id).where(Vault.user_id == auth.user_id))).scalars().all()
-    )
-    if vault_ids:
-        vault_keys_count = (
-            await db.execute(
-                select(func.count(VaultItem.id)).where(VaultItem.vault_id.in_(vault_ids))
+        text(
+            """
+            WITH session_window AS (
+                SELECT
+                    count(*)::integer AS total_sessions,
+                    COALESCE(sum(message_count), 0)::bigint AS total_messages,
+                    COALESCE(sum(input_tokens + output_tokens), 0)::bigint AS total_tokens
+                FROM sessions
+                WHERE user_id = :user_id
+                  AND started_at >= :since
+            ),
+            day_counts AS (
+                SELECT
+                    CAST(started_at AS date) AS day,
+                    count(*)::integer AS count
+                FROM sessions
+                WHERE user_id = :user_id
+                  AND started_at >= :since
+                GROUP BY CAST(started_at AS date)
+            ),
+            favorite_model AS (
+                SELECT model
+                FROM sessions
+                WHERE user_id = :user_id
+                  AND model IS NOT NULL
+                GROUP BY model
+                ORDER BY count(*) DESC
+                LIMIT 1
+            ),
+            peak_hour AS (
+                SELECT CAST(EXTRACT(hour FROM started_at) AS integer) AS peak_hour
+                FROM sessions
+                WHERE user_id = :user_id
+                GROUP BY EXTRACT(hour FROM started_at)
+                ORDER BY count(*) DESC
+                LIMIT 1
+            ),
+            days AS (
+                SELECT DISTINCT CAST(started_at AS date) AS day
+                FROM sessions
+                WHERE user_id = :user_id
+            ),
+            numbered AS (
+                SELECT
+                    day,
+                    day - CAST(row_number() OVER (ORDER BY day) AS integer) AS streak_group
+                FROM days
+            ),
+            runs AS (
+                SELECT
+                    min(day) AS start_day,
+                    max(day) AS end_day,
+                    count(*)::integer AS streak_len
+                FROM numbered
+                GROUP BY streak_group
+            ),
+            streaks AS (
+                SELECT
+                    COALESCE(
+                        max(streak_len) FILTER (WHERE end_day >= :current_floor),
+                        0
+                    )::integer AS current_streak,
+                    COALESCE(max(streak_len), 0)::integer AS longest_streak
+                FROM runs
+            ),
+            resource_counts AS (
+                SELECT
+                    (SELECT count(*)::integer
+                     FROM skills
+                     WHERE user_id = :user_id AND is_active) AS skills_count,
+                    (SELECT count(*)::integer
+                     FROM memories
+                     WHERE user_id = :user_id) AS memories_count,
+                    (SELECT count(*)::integer
+                     FROM vaults
+                     WHERE user_id = :user_id) AS vault_count,
+                    (SELECT count(*)::integer
+                     FROM vault_items
+                     JOIN vaults ON vaults.id = vault_items.vault_id
+                     WHERE vaults.user_id = :user_id) AS vault_keys_count
+            ),
+            manual_recent AS (
+                SELECT count(*)::integer AS manual_sessions_last_7_days
+                FROM sessions
+                WHERE user_id = :user_id
+                  AND last_activity_at >= :manual_since
+                  AND (
+                      summary IS NULL
+                      OR (summary NOT LIKE 'Cron:%' AND summary NOT LIKE '[%')
+                  )
             )
-        ).scalar() or 0
+            SELECT
+                session_window.total_sessions,
+                session_window.total_messages,
+                session_window.total_tokens,
+                (SELECT count(*)::integer FROM day_counts) AS active_days,
+                (SELECT model FROM favorite_model) AS favorite_model,
+                COALESCE((SELECT peak_hour FROM peak_hour), 0)::integer AS peak_hour,
+                streaks.current_streak,
+                streaks.longest_streak,
+                resource_counts.skills_count,
+                resource_counts.memories_count,
+                resource_counts.vault_count,
+                resource_counts.vault_keys_count,
+                manual_recent.manual_sessions_last_7_days,
+                day_counts.day AS contribution_day,
+                day_counts.count AS contribution_count
+            FROM session_window
+            CROSS JOIN streaks
+            CROSS JOIN resource_counts
+            CROSS JOIN manual_recent
+            LEFT JOIN day_counts ON true
+            ORDER BY day_counts.day
+            """
+        ),
+        {
+            "user_id": auth.user_id,
+            "since": since,
+            "current_floor": current_floor,
+            "manual_since": manual_since,
+        },
+    )
+    rows = result.mappings().all()
+    row = rows[0]
+    day_map = {
+        str(item["contribution_day"]): int(item["contribution_count"] or 0)
+        for item in rows
+        if item["contribution_day"] is not None
+    }
 
-    # Connectors (Composio) — best-effort, don't fail if unavailable
-    connectors_count = 0
-    try:
-        from app.core.config import settings
-        from app.services.composio import get_connected_accounts
-
-        if settings.composio_api_key:
-            # Composio entity_id is the Clerk user id, not the local PG
-            # UUID — must match what /api/connectors uses or this stat
-            # silently reads zero for users who actually have connections.
-            accounts = await get_connected_accounts(auth.user.clerk_id)
-            connectors_count = sum(
-                1 for a in accounts if (a.get("status") or "").upper() == "ACTIVE"
-            )
-    except Exception:
-        pass
+    connectors_count = await _cached_connectors_count(auth.user.clerk_id)
 
     return DashboardStatsResponse(
-        total_sessions=total_sessions,
-        total_messages=total_messages,
-        total_tokens=total_tokens,
-        active_days=active_days,
-        current_streak=current_streak,
-        longest_streak=longest_streak,
-        peak_hour=peak_hour,
-        favorite_model=favorite_model,
-        skills_count=skills_count,
-        memories_count=memories_count,
-        vault_count=vault_count,
-        vault_keys_count=vault_keys_count,
+        total_sessions=int(row["total_sessions"] or 0),
+        total_messages=int(row["total_messages"] or 0),
+        total_tokens=int(row["total_tokens"] or 0),
+        active_days=int(row["active_days"] or 0),
+        current_streak=int(row["current_streak"] or 0),
+        longest_streak=int(row["longest_streak"] or 0),
+        peak_hour=int(row["peak_hour"] or 0),
+        favorite_model=row["favorite_model"],
+        skills_count=int(row["skills_count"] or 0),
+        memories_count=int(row["memories_count"] or 0),
+        vault_count=int(row["vault_count"] or 0),
+        vault_keys_count=int(row["vault_keys_count"] or 0),
         connectors_count=connectors_count,
+        manual_sessions_last_7_days=int(row["manual_sessions_last_7_days"] or 0),
+        contribution=_build_contribution_graph(
+            day_map,
+            since_date=since.date(),
+            end_date=now.date(),
+        ),
     )
+
+
+async def _cached_connectors_count(clerk_id: str) -> int:
+    if not settings.composio_api_key:
+        return 0
+
+    now = datetime.now(UTC)
+    cached = _connectors_count_cache.get(clerk_id)
+    if cached and cached[0] > now:
+        return cached[1]
+
+    try:
+        from app.services.composio import get_connected_accounts
+
+        # Composio entity_id is the Clerk user id, not the local PG UUID.
+        accounts = await asyncio.wait_for(
+            get_connected_accounts(clerk_id),
+            timeout=_CONNECTORS_COUNT_TIMEOUT_SECONDS,
+        )
+    except Exception as exc:
+        log.warning("dashboard connectors count unavailable: %s", exc)
+        return cached[1] if cached else 0
+
+    connectors_count = sum(1 for a in accounts if (a.get("status") or "").upper() == "ACTIVE")
+    _remember_connectors_count(clerk_id, connectors_count, now=now)
+    return connectors_count
+
+
+def _remember_connectors_count(clerk_id: str, count: int, *, now: datetime) -> None:
+    expired_keys = [
+        key for key, (expires_at, _) in _connectors_count_cache.items() if expires_at <= now
+    ]
+    for key in expired_keys:
+        _connectors_count_cache.pop(key, None)
+
+    if len(_connectors_count_cache) >= _CONNECTORS_COUNT_CACHE_MAX:
+        oldest_key = min(_connectors_count_cache, key=lambda key: _connectors_count_cache[key][0])
+        _connectors_count_cache.pop(oldest_key, None)
+
+    _connectors_count_cache[clerk_id] = (now + _CONNECTORS_COUNT_CACHE_TTL, count)
 
 
 @router.get("/contribution")
 async def get_contribution_graph(
+    response: Response,
     auth: AuthContext = Depends(require_web_auth),
     db: AsyncSession = Depends(get_session),
-    days: int = Query(default=365),
+    days: int = Query(default=365, ge=1, le=_DASHBOARD_DAYS_MAX),
 ) -> list[ContributionDayResponse]:
-    since = datetime.now(UTC) - timedelta(days=days)
+    response.headers["Cache-Control"] = "private, max-age=30, stale-while-revalidate=30"
+    now = datetime.now(UTC)
+    since = now - timedelta(days=days)
 
     result = await db.execute(
         select(
@@ -162,14 +267,25 @@ async def get_contribution_graph(
     )
     rows = result.all()
 
-    # Build full date range with zeros
     day_map = {str(r[0]): int(r[1]) for r in rows}
+    return _build_contribution_graph(
+        day_map,
+        since_date=since.date(),
+        end_date=now.date(),
+    )
+
+
+def _build_contribution_graph(
+    day_map: dict[str, int],
+    *,
+    since_date: date,
+    end_date: date,
+) -> list[ContributionDayResponse]:
     max_count = max(day_map.values()) if day_map else 1
 
     contributions: list[ContributionDayResponse] = []
-    current = since.date()
-    end = datetime.now(UTC).date()
-    while current <= end:
+    current = since_date
+    while current <= end_date:
         count = day_map.get(str(current), 0)
         level = 0
         if count > 0:
@@ -186,36 +302,3 @@ async def get_contribution_graph(
         current += timedelta(days=1)
 
     return contributions
-
-
-async def _calc_streaks(db: AsyncSession, user_id) -> tuple[int, int]:
-    result = await db.execute(
-        select(func.distinct(func.date(Session.started_at)))
-        .where(Session.user_id == user_id)
-        .order_by(func.date(Session.started_at).desc())
-    )
-    dates = [r[0] for r in result.all()]
-
-    if not dates:
-        return 0, 0
-
-    today = datetime.now(UTC).date()
-    current_streak = 0
-    if dates[0] >= today - timedelta(days=1):
-        current_streak = 1
-        for i in range(1, len(dates)):
-            if dates[i] == dates[i - 1] - timedelta(days=1):
-                current_streak += 1
-            else:
-                break
-
-    longest_streak = 1 if dates else 0
-    streak = 1
-    for i in range(1, len(dates)):
-        if dates[i] == dates[i - 1] - timedelta(days=1):
-            streak += 1
-            longest_streak = max(longest_streak, streak)
-        else:
-            streak = 1
-
-    return current_streak, longest_streak

--- a/backend/app/routes/projects.py
+++ b/backend/app/routes/projects.py
@@ -10,7 +10,7 @@ from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field, field_validator
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -194,43 +194,37 @@ async def list_projects(
     """List every project the caller can read. JWT auth -> all of
     the user's visible projects. Agent API key -> that Agent Project only.
     """
-    visible_project_ids = await project_ids_visible_to(db, auth)
-    if not visible_project_ids:
-        return []
-    result = await db.execute(
-        select(Project)
-        .where(Project.id.in_(visible_project_ids))
+    caller_user_id = auth.user_id
+    membership_join = and_(
+        ProjectMembership.project_id == Project.id,
+        ProjectMembership.member_user_id == caller_user_id,
+    )
+    stmt = (
+        select(Project, User, ProjectMembership)
+        .outerjoin(User, User.id == Project.user_id)
+        .outerjoin(ProjectMembership, membership_join)
         .order_by(Project.created_at.desc())
     )
-    rows = result.scalars().all()
-    caller_user_id = auth.user_id
-    owner_ids = {project.user_id for project in rows}
-    owners = {}
-    if owner_ids:
-        owner_rows = (await db.execute(select(User).where(User.id.in_(owner_ids)))).scalars().all()
-        owners = {owner.id: owner for owner in owner_rows}
-
-    membership_rows = (
-        (
-            await db.execute(
-                select(ProjectMembership).where(
-                    ProjectMembership.member_user_id == caller_user_id,
-                    ProjectMembership.project_id.in_(visible_project_ids),
-                )
+    if auth.is_cli and auth.api_key is not None and auth.api_key.environment_id is not None:
+        bound_project_id = await resolve_default_write_project(db, auth)
+        stmt = stmt.where(Project.id == bound_project_id)
+    else:
+        stmt = stmt.where(
+            or_(
+                Project.user_id == caller_user_id,
+                ProjectMembership.member_user_id == caller_user_id,
             )
         )
-        .scalars()
-        .all()
-    )
-    memberships = {membership.project_id: membership for membership in membership_rows}
+
+    result = await db.execute(stmt)
     return [
         _project_response(
-            p,
+            project,
             caller_user_id,
-            owner=owners.get(p.user_id),
-            membership=memberships.get(p.id),
+            owner=owner,
+            membership=membership,
         )
-        for p in rows
+        for project, owner, membership in result.all()
     ]
 
 

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -13,12 +13,13 @@ from fastapi import (
     HTTPException,
     Path,
     Query,
+    Request,
     Response,
     UploadFile,
     status,
 )
 from pydantic import BaseModel, Field
-from sqlalchemy import case, func, or_, select
+from sqlalchemy import case, func, or_, select, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -59,6 +60,7 @@ from app.schemas.session import (
     SessionUploadResponse,
 )
 from app.services.file_store import get_file_store
+from app.services.http_cache import if_none_match_contains, strong_json_etag
 from app.services.memory_extraction import extract_memories_from_session
 from app.services.memory_provider import get_memory_provider
 from app.services.session_content import (
@@ -77,6 +79,10 @@ _MAX_RUNTIME_OBSERVED_BYTES = 64 * 1024
 _RUNTIME_OBSERVED_STALE_AFTER = timedelta(seconds=90)
 _HOSTED_MANAGED_AGENT_TYPES = {"codex", "hermes", "openclaw"}
 _LEGACY_HOSTED_MACHINE_NAME_RE = re.compile(r"^v2-hosted-[a-f0-9]{6,16}$")
+_MANUAL_SESSION_SUMMARY_FILTER = text(
+    "(sessions.summary IS NULL OR "
+    "(sessions.summary NOT LIKE 'Cron:%' AND sessions.summary NOT LIKE '[%'))"
+)
 
 
 def _bound_env_id(auth: AuthContext) -> UUID | None:
@@ -306,8 +312,14 @@ async def register_environment(
         return EnvironmentCreatedResponse(id=str(winner.id))
 
 
-@router.get("/api/environments")
+@router.get(
+    "/api/environments",
+    response_model=list[EnvironmentResponse],
+    responses={status.HTTP_304_NOT_MODIFIED: {"description": "Not Modified"}},
+)
 async def list_environments(
+    request: Request,
+    response: Response,
     # Bare get_auth is intentional. Even narrowly-scoped api_keys
     # (e.g. the legacy `sessions:write`-only deploy key) need to
     # discover their own env at boot to find its default_project.
@@ -317,7 +329,7 @@ async def list_environments(
     # themselves.
     auth: AuthContext = Depends(get_auth),
     db: AsyncSession = Depends(get_session),
-) -> list[EnvironmentResponse]:
+) -> list[EnvironmentResponse] | Response:
     # Bound api_keys (deploy keys) only see their own env.
     # Returning every env of the user would let a leaked deploy
     # key enumerate sibling machines and their default_project_ids
@@ -348,7 +360,7 @@ async def list_environments(
         )
         states_by_env = {state.environment_id: state for state in states}
     hosted_deployments_by_machine = _hosted_deployments_by_machine(envs, states_by_env)
-    return [
+    payload = [
         _env_to_response(
             e,
             states_by_env.get(e.id),
@@ -356,6 +368,12 @@ async def list_environments(
         )
         for e in envs
     ]
+    etag = strong_json_etag([item.model_dump(mode="json") for item in payload])
+    headers = {"ETag": etag, "Cache-Control": "private, max-age=10, must-revalidate"}
+    if if_none_match_contains(request.headers.get("if-none-match"), etag):
+        return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)
+    response.headers.update(headers)
+    return payload
 
 
 @router.get("/api/environments/runtime-observed")
@@ -1424,53 +1442,51 @@ async def list_sessions(
     else:
         relevance_expr = None  # type: ignore[assignment]
 
-    base = (
-        select(
-            Session,
-            AgentEnvironment.agent_type,
-            AgentEnvironment.machine_name,
-            is_shared_subq,
-        )
-        .outerjoin(AgentEnvironment, Session.environment_id == AgentEnvironment.id)
-        .where(Session.user_id == auth.user_id)
-    )
+    base = select(
+        Session,
+        AgentEnvironment.agent_type,
+        AgentEnvironment.machine_name,
+        is_shared_subq,
+    ).outerjoin(AgentEnvironment, Session.environment_id == AgentEnvironment.id)
+    session_filters = [Session.user_id == auth.user_id]
+    agent_filter = AgentEnvironment.agent_type == agent if agent else None
     if bound_env is not None:
-        base = base.where(Session.environment_id == bound_env)
+        session_filters.append(Session.environment_id == bound_env)
     # Filter on `last_activity_at` (not `started_at`) so a long-
     # running session that began before the window but was active
     # inside it still surfaces under "Today" / "Last 7 days".
     if since:
-        base = base.where(Session.last_activity_at >= since)
+        session_filters.append(Session.last_activity_at >= since)
     if until:
-        base = base.where(Session.last_activity_at < until)
-    if agent:
-        base = base.where(AgentEnvironment.agent_type == agent)
+        session_filters.append(Session.last_activity_at < until)
     if environment_id:
-        base = base.where(Session.environment_id == environment_id)
+        session_filters.append(Session.environment_id == environment_id)
 
     if model:
-        base = base.where(Session.model.in_(model))
+        session_filters.append(Session.model.in_(model))
     if tag:
         # AND semantics for tags: every requested tag must be present.
         # `tags @> ARRAY[...]` is the indexable form vs N separate
         # `tags && ARRAY[t]` clauses.
-        base = base.where(Session.tags.op("@>")(tag))
+        session_filters.append(Session.tags.op("@>")(tag))
     if min_messages is not None:
-        base = base.where(Session.message_count >= min_messages)
+        session_filters.append(Session.message_count >= min_messages)
     if min_duration is not None:
-        base = base.where(Session.duration_seconds >= min_duration)
+        session_filters.append(Session.duration_seconds >= min_duration)
     if has_pr is True:
         # `related_refs ? 'prs'` would also match `{"prs": null}` — we
         # want a non-empty array. The JSONB length check is explicit
         # and matches what `_session_to_response` carries.
-        base = base.where(
-            Session.related_refs.is_not(None),
-            func.jsonb_array_length(Session.related_refs.op("->")("prs")) > 0,
+        session_filters.extend(
+            (
+                Session.related_refs.is_not(None),
+                func.jsonb_array_length(Session.related_refs.op("->")("prs")) > 0,
+            )
         )
     elif has_pr is False:
         # Explicit "no PRs" — NULL `related_refs` (never extracted)
         # counts as "no PR".
-        base = base.where(
+        session_filters.append(
             or_(
                 Session.related_refs.is_(None),
                 func.coalesce(
@@ -1485,10 +1501,11 @@ async def list_sessions(
         # Heuristic, mirrored from the dashboard feed's muting regex
         # (^(Cron:|\[)). Most fleets are dominated by cron/heartbeat
         # sessions; "Manual only" is how users find their own work.
-        # COALESCE so NULL summaries count as manual, not as neither.
-        summary_text = func.coalesce(Session.summary, "")
-        is_automated = or_(summary_text.like("Cron:%"), summary_text.like("[%"))
-        base = base.where(is_automated if automated else ~is_automated)
+        if automated:
+            summary_text = func.coalesce(Session.summary, "")
+            session_filters.append(or_(summary_text.like("Cron:%"), summary_text.like("[%")))
+        else:
+            session_filters.append(_MANUAL_SESSION_SUMMARY_FILTER)
 
     if q:
         # pg_trgm `similarity()` for typo / partial-word tolerance.
@@ -1498,13 +1515,23 @@ async def list_sessions(
         # for the typical few-thousand-rows-per-user. If a power user
         # ever hits real latency here, swap to `WHERE summary % :q`
         # plus a GIN index. Threshold tuned for "type to filter" UX.
-        base = base.where(relevance_expr >= _TRGM_THRESHOLD)
+        session_filters.append(relevance_expr >= _TRGM_THRESHOLD)
+
+    base = base.where(*session_filters)
+    if agent_filter is not None:
+        base = base.where(agent_filter)
 
     # Run the count BEFORE attaching ORDER BY: PG would otherwise
     # plan a sort over the full filtered set just to discard it for
     # COUNT(*). For 50k+ session users this saves a measurable
     # fraction of list-page latency.
-    total = (await db.execute(select(func.count()).select_from(base.subquery()))).scalar_one()
+    count_base = select(Session.id).where(*session_filters)
+    if agent_filter is not None:
+        count_base = count_base.outerjoin(
+            AgentEnvironment,
+            Session.environment_id == AgentEnvironment.id,
+        ).where(agent_filter)
+    total = (await db.execute(select(func.count()).select_from(count_base.subquery()))).scalar_one()
 
     # Resolve sort column. `relevance` is special — only valid when
     # `q` is present (else fall back to the date default so the empty-

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -68,6 +68,15 @@ router = APIRouter(prefix="/api/skills", tags=["skills"])
 # of phase 2).
 project_router = APIRouter(prefix="/api/projects/{project_id}/skills", tags=["skills"])
 
+# Back-compat for binaries built during the Scope -> Project migration.
+# The table row id was preserved, so old `/api/scopes/{id}/skills/...`
+# read URLs can be served by the project-explicit handlers.
+scope_router = APIRouter(
+    prefix="/api/scopes/{scope_id}/skills",
+    tags=["skills"],
+    include_in_schema=False,
+)
+
 log = logging.getLogger(__name__)
 
 file_store = get_file_store()
@@ -964,18 +973,27 @@ async def download_skill_project(
     delete) still gate on `validate_project_for_caller`, which stays
     owner-only.
     """
-    await validate_project_read_for_caller(db, auth, project_id)
-    result = await db.execute(
-        select(Skill).where(
-            Skill.project_id == project_id,
-            Skill.skill_key == skill_key,
-            Skill.is_active,
-        )
+    return await _get_project_skill_download(
+        db=db,
+        auth=auth,
+        project_id=project_id,
+        skill_key=skill_key,
     )
-    skill = result.scalar_one_or_none()
-    if not skill:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "Skill not found")
-    return await _build_skill_download(skill, skill_key)
+
+
+@scope_router.get("/{skill_key:path}/download")
+async def download_skill_scope_compat(
+    scope_id: UUID = Path(...),
+    skill_key: str = Path(..., pattern=SKILL_KEY_PATTERN, max_length=MAX_SKILL_KEY_LEN),
+    auth: AuthContext = Depends(require_scope("skills:read")),
+    db: AsyncSession = Depends(get_session),
+):
+    return await _get_project_skill_download(
+        db=db,
+        auth=auth,
+        project_id=scope_id,
+        skill_key=skill_key,
+    )
 
 
 # NOTE: bare-key GETs declared AFTER `/{skill_key:path}/download` so
@@ -1015,6 +1033,68 @@ async def get_skill_project(
     shared-project skill metadata/content, while write paths stay
     owner-only via `validate_project_for_caller`.
     """
+    return await _get_project_skill_detail(
+        db=db,
+        auth=auth,
+        project_id=project_id,
+        skill_key=skill_key,
+    )
+
+
+@scope_router.get("/{skill_key:path}")
+async def get_skill_scope_compat(
+    scope_id: UUID = Path(...),
+    skill_key: str = Path(..., pattern=SKILL_KEY_PATTERN, max_length=MAX_SKILL_KEY_LEN),
+    auth: AuthContext = Depends(require_scope("skills:read")),
+    db: AsyncSession = Depends(get_session),
+) -> SkillDetailResponse:
+    return await _get_project_skill_detail(
+        db=db,
+        auth=auth,
+        project_id=scope_id,
+        skill_key=skill_key,
+    )
+
+
+async def _get_project_skill_download(
+    *,
+    db: AsyncSession,
+    auth: AuthContext,
+    project_id: UUID,
+    skill_key: str,
+) -> Response:
+    skill = await _get_project_skill(
+        db=db,
+        auth=auth,
+        project_id=project_id,
+        skill_key=skill_key,
+    )
+    return await _build_skill_download(skill, skill_key)
+
+
+async def _get_project_skill_detail(
+    *,
+    db: AsyncSession,
+    auth: AuthContext,
+    project_id: UUID,
+    skill_key: str,
+) -> SkillDetailResponse:
+    skill = await _get_project_skill(
+        db=db,
+        auth=auth,
+        project_id=project_id,
+        skill_key=skill_key,
+    )
+    return await _build_skill_detail(skill, db)
+
+
+async def _get_project_skill(
+    *,
+    db: AsyncSession,
+    auth: AuthContext,
+    project_id: UUID,
+    skill_key: str,
+) -> Skill:
     await validate_project_read_for_caller(db, auth, project_id)
     result = await db.execute(
         select(Skill).where(
@@ -1026,7 +1106,7 @@ async def get_skill_project(
     skill = result.scalar_one_or_none()
     if not skill:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Skill not found")
-    return await _build_skill_detail(skill, db)
+    return skill
 
 
 async def _build_skill_download(skill: Skill, skill_key: str) -> Response:

--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -3,6 +3,12 @@ from datetime import date
 from pydantic import BaseModel
 
 
+class ContributionDayResponse(BaseModel):
+    date: date
+    count: int
+    level: int
+
+
 class DashboardStatsResponse(BaseModel):
     total_sessions: int
     total_messages: int
@@ -17,9 +23,5 @@ class DashboardStatsResponse(BaseModel):
     vault_count: int
     vault_keys_count: int
     connectors_count: int
-
-
-class ContributionDayResponse(BaseModel):
-    date: date
-    count: int
-    level: int
+    manual_sessions_last_7_days: int
+    contribution: list[ContributionDayResponse]

--- a/backend/tests/test_dashboard_performance.py
+++ b/backend/tests/test_dashboard_performance.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from app.core.config import settings
+from app.models.memory import Memory
+from app.models.project import PROJECT_KIND_WORKSPACE, Project
+from app.models.project_membership import ProjectMembership
+from app.models.session import Session
+from app.models.skill import Skill
+from app.models.user import User
+from app.models.vault import Vault, VaultItem
+
+
+async def _seed_dashboard_sessions(db_session: AsyncSession, user_id) -> None:
+    now = datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0)
+    day_offsets = [0, 1, 2, 5, 6, 7, 8]
+    sessions = [
+        Session(
+            user_id=user_id,
+            local_session_id=f"dashboard-perf-{offset}",
+            started_at=now - timedelta(days=offset),
+            last_activity_at=now - timedelta(days=offset),
+            message_count=offset + 1,
+            input_tokens=10,
+            output_tokens=5,
+            model="claude-sonnet" if offset < 5 else "gpt-4o-mini",
+        )
+        for offset in day_offsets
+    ]
+    db_session.add_all(sessions)
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_dashboard_stats_uses_bounded_database_round_trips(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+    seed_user,
+    seed_project,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(settings, "composio_api_key", "")
+    await _seed_dashboard_sessions(db_session, seed_user.id)
+    skill = Skill(
+        user_id=seed_user.id,
+        project_id=seed_project.id,
+        skill_key="dashboard-perf",
+        name="Dashboard Perf",
+        content_hash="abc123",
+        is_active=True,
+    )
+    memory = Memory(user_id=seed_user.id, content="Dashboard memory")
+    vault = Vault(user_id=seed_user.id, slug="dashboard-perf", name="Dashboard Perf")
+    db_session.add_all([skill, memory, vault])
+    await db_session.flush()
+    db_session.add(
+        VaultItem(
+            vault_id=vault.id,
+            section="api",
+            item_name="TOKEN",
+            encrypted_value=b"x",
+            nonce=b"y",
+        )
+    )
+    await db_session.commit()
+
+    statements: list[str] = []
+
+    def before_cursor_execute(
+        _conn,
+        _cursor,
+        statement,
+        _parameters,
+        _context,
+        _executemany,
+    ) -> None:
+        statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", before_cursor_execute)
+    try:
+        response = await client.get("/api/dashboard/stats")
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", before_cursor_execute)
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["total_sessions"] == 7
+    assert data["active_days"] == 7
+    assert data["favorite_model"] == "gpt-4o-mini"
+    assert data["peak_hour"] == 12
+    assert data["current_streak"] == 3
+    assert data["longest_streak"] == 4
+    assert data["skills_count"] == 1
+    assert data["memories_count"] == 1
+    assert data["vault_count"] == 1
+    assert data["vault_keys_count"] == 1
+    assert data["manual_sessions_last_7_days"] >= 1
+    contribution_by_date = {entry["date"]: entry["count"] for entry in data["contribution"]}
+    assert contribution_by_date[str(datetime.now(UTC).date())] == 1
+    assert len(data["contribution"]) >= 365
+    assert len(statements) <= 1
+
+
+@pytest.mark.asyncio
+async def test_dashboard_stats_caches_connector_count(
+    client: httpx.AsyncClient,
+    monkeypatch,
+) -> None:
+    from app.services import composio
+
+    monkeypatch.setattr(settings, "composio_api_key", "test-composio-key")
+
+    calls = 0
+
+    async def fake_get_connected_accounts(_clerk_id: str) -> list[dict]:
+        nonlocal calls
+        calls += 1
+        return [{"status": "ACTIVE"}]
+
+    monkeypatch.setattr(composio, "get_connected_accounts", fake_get_connected_accounts)
+
+    first = await client.get("/api/dashboard/stats")
+    second = await client.get("/api/dashboard/stats")
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.json()["connectors_count"] == 1
+    assert second.json()["connectors_count"] == 1
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_projects_list_uses_single_query_for_dashboard_user(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+    seed_user,
+) -> None:
+    owner = User(
+        clerk_id=f"project-owner-{seed_user.id}",
+        email=f"project-owner-{seed_user.id}@clawdi.local",
+        name="Project Owner",
+    )
+    db_session.add(owner)
+    await db_session.flush()
+    shared = Project(
+        user_id=owner.id,
+        name="Shared Project",
+        slug="shared-project",
+        kind=PROJECT_KIND_WORKSPACE,
+    )
+    db_session.add(shared)
+    await db_session.flush()
+    db_session.add(
+        ProjectMembership(
+            project_id=shared.id,
+            member_user_id=seed_user.id,
+            role="viewer",
+            joined_via="link",
+            joined_at=datetime.now(UTC),
+            resolved_owner_handle="project-owner",
+        )
+    )
+    await db_session.commit()
+
+    statements: list[str] = []
+
+    def before_cursor_execute(
+        _conn,
+        _cursor,
+        statement,
+        _parameters,
+        _context,
+        _executemany,
+    ) -> None:
+        statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", before_cursor_execute)
+    try:
+        response = await client.get("/api/projects")
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", before_cursor_execute)
+        await db_session.delete(owner)
+        await db_session.commit()
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert any(project["is_owner"] is False for project in body)
+    assert len(statements) <= 1
+
+
+@pytest.mark.asyncio
+async def test_sessions_count_query_does_not_compute_share_state(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    engine: AsyncEngine,
+    seed_user,
+) -> None:
+    await _seed_dashboard_sessions(db_session, seed_user.id)
+
+    statements: list[str] = []
+
+    def before_cursor_execute(
+        _conn,
+        _cursor,
+        statement,
+        _parameters,
+        _context,
+        _executemany,
+    ) -> None:
+        statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", before_cursor_execute)
+    try:
+        response = await client.get(
+            "/api/sessions",
+            params={"page_size": 6, "automated": False},
+        )
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", before_cursor_execute)
+
+    assert response.status_code == 200, response.text
+    count_statements = [
+        statement
+        for statement in statements
+        if "count(" in statement.lower() or "count(*)" in statement.lower()
+    ]
+    assert count_statements
+    assert all("session_permissions" not in statement.lower() for statement in count_statements)
+    assert all("agent_environments" not in statement.lower() for statement in count_statements)

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -11,11 +11,11 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
-async def _register_env(client: httpx.AsyncClient) -> str:
+async def _register_env(client: httpx.AsyncClient, machine_id: str = "test-machine-1") -> str:
     r = await client.post(
         "/api/environments",
         json={
-            "machine_id": "test-machine-1",
+            "machine_id": machine_id,
             "machine_name": "Test Mac",
             "agent_type": "claude-code",
             "agent_version": "0.1.0",
@@ -33,6 +33,30 @@ async def test_environment_register_is_idempotent(client: httpx.AsyncClient):
     # Same (user, machine_id, agent_type) must return the same environment row,
     # not create a duplicate.
     assert first == second
+
+
+@pytest.mark.asyncio
+async def test_environments_support_conditional_get(client: httpx.AsyncClient):
+    env_id = await _register_env(client, machine_id=f"etag-{uuid.uuid4().hex}")
+
+    first = await client.get("/api/environments")
+    assert first.status_code == 200, first.text
+    etag = first.headers.get("ETag")
+    assert etag
+    assert first.headers.get("Cache-Control") == "private, max-age=10, must-revalidate"
+
+    not_modified = await client.get("/api/environments", headers={"If-None-Match": etag})
+    assert not_modified.status_code == 304, not_modified.text
+    assert not_modified.headers.get("ETag") == etag
+
+    heartbeat = await client.post(f"/api/agents/{env_id}/sync-heartbeat", json={"queue_depth": 1})
+    assert heartbeat.status_code == 204, heartbeat.text
+
+    changed = await client.get("/api/environments", headers={"If-None-Match": etag})
+    assert changed.status_code == 200, changed.text
+    assert changed.headers.get("ETag") != etag
+    updated = next(item for item in changed.json() if item["id"] == env_id)
+    assert updated["queue_depth_high_water"] == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -517,6 +517,35 @@ async def test_nested_skill_round_trips_through_project_routes(
 
 
 @pytest.mark.asyncio
+async def test_scope_skill_read_routes_remain_compat_aliases(
+    client: httpx.AsyncClient, project_id: str
+):
+    """Prod compatibility: binaries built during the Scope -> Project
+    migration still call `/api/scopes/{id}/skills/...` for reads.
+    Project ids preserve the old scope id, so these should behave like
+    the project-explicit read routes instead of 404ing at the router.
+    """
+    content = "---\nname: compat\ndescription: old scope URL\n---\n# Compat\n"
+    skill_key = "compat/nested"
+    tar_bytes, _ = tar_from_content(skill_key, content)
+    upload = await client.post(
+        f"/api/projects/{project_id}/skills/upload",
+        data={"skill_key": skill_key},
+        files={"file": ("compat-nested.tar.gz", tar_bytes, "application/gzip")},
+    )
+    assert upload.status_code == 200, upload.text
+
+    detail = await client.get(f"/api/scopes/{project_id}/skills/{skill_key}")
+    assert detail.status_code == 200, detail.text
+    assert detail.json()["skill_key"] == skill_key
+    assert detail.json()["project_id"] == project_id
+
+    download = await client.get(f"/api/scopes/{project_id}/skills/{skill_key}/download")
+    assert download.status_code == 200, download.text
+    assert download.headers["content-type"].startswith("application/gzip")
+
+
+@pytest.mark.asyncio
 async def test_malformed_skill_upload_logs_validation_reason(
     client: httpx.AsyncClient,
     project_id: str,

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -3536,6 +3536,10 @@ export interface components {
             vault_keys_count: number;
             /** Connectors Count */
             connectors_count: number;
+            /** Manual Sessions Last 7 Days */
+            manual_sessions_last_7_days: number;
+            /** Contribution */
+            contribution: components["schemas"]["ContributionDayResponse"][];
         };
         /** DefaultProjectResponse */
         DefaultProjectResponse: {
@@ -6580,6 +6584,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["EnvironmentResponse"][];
                 };
+            };
+            /** @description Not Modified */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };


### PR DESCRIPTION
## Summary
- Collapse dashboard stats/contribution/manual-week data into fewer backend and frontend requests
- Add bounded Composio connector-count cache/timeout and dashboard/environments cache headers
- Optimize projects and sessions list/count query paths, including a partial manual-session index
- Add legacy scope skill read aliases for old clients and clean multipart skill uploads

## Verification
- uv run pytest -q
- bun run check
- bun run typecheck
- uv run ruff check app scripts
- uv run ruff format --check app scripts
- uv run python scripts/check_generated_api.py
- uv run alembic heads
- git diff --check