### PR TITLE
Fix Hermes archived skill sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.12.10-beta.25
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.25
+
+Package: `clawdi@0.12.10-beta.25`
+
+### Fixed
+
+- Fixed Hermes skill sync so archived dot-directories such as `.archive` are
+  ignored instead of being uploaded as invalid skill keys.
+
 ## Clawdi CLI v0.12.10-beta.0
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.0

--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.15",
+      "version": "0.12.10-beta.25",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.24",
+	"version": "0.12.10-beta.25",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { join, relative } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
+import { isValidSkillKey } from "../lib/skill-key";
 import { extractSharedSkillTarGz, extractTarGz } from "../lib/tar";
 import type {
 	AgentAdapter,
@@ -54,6 +55,15 @@ function stateDbPath() {
 }
 function skillsDir() {
 	return join(hermesDir(), "skills");
+}
+
+function shouldSkipHermesSkillDir(entryName: string): boolean {
+	return entryName.startsWith(".") || SKIP_DIRS.has(entryName);
+}
+
+function hermesSkillKeyFromPath(fullPath: string): string | null {
+	const skillKey = relative(skillsDir(), fullPath).replaceAll("\\", "/");
+	return isValidSkillKey(skillKey) ? skillKey : null;
 }
 
 /**
@@ -210,7 +220,7 @@ export class HermesAdapter implements AgentAdapter {
 	private _scanSkillsDir(dir: string, results: RawSkill[]): void {
 		for (const entry of readdirSync(dir, { withFileTypes: true })) {
 			if (!entry.isDirectory()) continue;
-			if (SKIP_DIRS.has(entry.name)) continue;
+			if (shouldSkipHermesSkillDir(entry.name)) continue;
 			// Bundled by `clawdi setup`, not user-authored. See claude-code.ts
 			// for the full reasoning. Hermes only filters at the top level
 			// — nested skills with the literal name "clawdi" deeper in the
@@ -221,7 +231,8 @@ export class HermesAdapter implements AgentAdapter {
 
 			if (existsSync(skillMd)) {
 				const content = readFileSync(skillMd, "utf-8");
-				const skillKey = relative(skillsDir(), fullPath);
+				const skillKey = hermesSkillKeyFromPath(fullPath);
+				if (!skillKey) continue;
 				const fileCount = readdirSync(fullPath, { recursive: true }).length;
 
 				results.push({
@@ -269,11 +280,12 @@ export class HermesAdapter implements AgentAdapter {
 		const walk = (dir: string): void => {
 			for (const entry of readdirSync(dir, { withFileTypes: true })) {
 				if (!entry.isDirectory()) continue;
-				if (SKIP_DIRS.has(entry.name)) continue;
+				if (shouldSkipHermesSkillDir(entry.name)) continue;
 				if (dir === skillsDir() && entry.name === "clawdi") continue;
 				const fullPath = join(dir, entry.name);
 				if (existsSync(join(fullPath, "SKILL.md"))) {
-					out.push(relative(skillsDir(), fullPath));
+					const skillKey = hermesSkillKeyFromPath(fullPath);
+					if (skillKey) out.push(skillKey);
 				} else {
 					walk(fullPath);
 				}

--- a/packages/cli/tests/adapters/hermes.test.ts
+++ b/packages/cli/tests/adapters/hermes.test.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { HermesAdapter } from "../../src/adapters/hermes";
 import { tarSkillDir } from "../../src/lib/tar";
@@ -129,6 +129,28 @@ describe("HermesAdapter.collectSkills", () => {
 			name: "demo",
 		});
 		expect(skills[0]?.content).toContain("description: A nested demo skill");
+	});
+
+	it("skips archived dot-directories and invalid skill keys at every depth", async () => {
+		const skillsRoot = join(tmpHome, ".hermes", "skills");
+		mkdirSync(join(skillsRoot, ".archive", "old-skill"), { recursive: true });
+		writeFileSync(join(skillsRoot, ".archive", "old-skill", "SKILL.md"), "---\nname: old\n---\n");
+		mkdirSync(join(skillsRoot, "apple", ".archive", "old-reminders"), { recursive: true });
+		writeFileSync(
+			join(skillsRoot, "apple", ".archive", "old-reminders", "SKILL.md"),
+			"---\nname: old reminders\n---\n",
+		);
+		mkdirSync(join(skillsRoot, "bad key"), { recursive: true });
+		writeFileSync(join(skillsRoot, "bad key", "SKILL.md"), "---\nname: bad key\n---\n");
+		mkdirSync(join(skillsRoot, "apple", "_private"), { recursive: true });
+		writeFileSync(join(skillsRoot, "apple", "_private", "SKILL.md"), "---\nname: private\n---\n");
+
+		const a = new HermesAdapter();
+		const skills = await a.collectSkills();
+		const keys = skills.map((s) => s.skillKey).sort();
+
+		expect(keys).toEqual(["core/demo"]);
+		expect(await a.listSkillKeys()).toEqual(["core/demo"]);
 	});
 
 	it("returns empty when skills dir is missing", async () => {


### PR DESCRIPTION
## Summary
- skip Hermes dot-directories such as `.archive` during recursive skill enumeration
- validate normalized Hermes nested skill keys before upload/listing
- bump the CLI beta package to `0.12.10-beta.25` so the fix publishes after merge

## Prod evidence
- prod logs showed a large `/api/projects/{id}/skills/upload` 422 storm from Hermes sync
- failing `skill_key` values came from archived paths such as `.archive/...` and nested `apple/.archive/...`

## Verification
- `bun test packages/cli/tests/adapters/hermes.test.ts`
- `bun test packages/cli/src/serve/sync-engine.test.ts`
- `bun run typecheck`
- `bun run check`
- `bun install --frozen-lockfile`

## Rollout note
Merging this PR publishes a new CLI beta. Existing Hermes daemons still need to update/restart to stop sending the old invalid uploads.