### PR TITLE
Improve session loading cache and request timing logs

### DIFF
--- a/apps/web/src/app/(dashboard)/page.tsx
+++ b/apps/web/src/app/(dashboard)/page.tsx
@@ -19,10 +19,12 @@ import { unwrap, useApi } from "@/lib/api";
 import { useCurrentUser } from "@/lib/auth-client";
 import { IS_HOSTED } from "@/lib/hosted";
 import { projectResourceHref, sessionDetailHref } from "@/lib/project-resource-model";
+import { sessionListQueryOptions } from "@/lib/session-queries";
 import { relativeTime } from "@/lib/utils";
 import { useV2Access } from "@/lib/v2-access";
 
 const RECENT_SESSIONS_LIMIT = 15;
+const RECENT_SESSIONS_CACHE_PAGE_SIZE = 25;
 const DASHBOARD_STALE_MS = 30_000;
 
 function countProjectTypes(
@@ -103,17 +105,13 @@ export default function DashboardPage() {
 	// Manual sessions only: on a working fleet ~3/4 of sessions are
 	// cron/heartbeat ticks, and "Recent sessions" buried the user's own
 	// work under them. Automation is one click away via View all.
-	const { data: sessionsPage, isLoading: sessionsLoading } = useQuery({
-		queryKey: ["recent-sessions", "manual"],
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/api/sessions", {
-					params: { query: { page_size: RECENT_SESSIONS_LIMIT, automated: false } },
-				}),
-			),
-		staleTime: DASHBOARD_STALE_MS,
-	});
-	const sessions = sessionsPage?.items;
+	const { data: sessionsPage, isLoading: sessionsLoading } = useQuery(
+		sessionListQueryOptions(api, {
+			page_size: RECENT_SESSIONS_CACHE_PAGE_SIZE,
+			automated: false,
+		}),
+	);
+	const sessions = sessionsPage?.items.slice(0, RECENT_SESSIONS_LIMIT);
 	const contribution = stats?.contribution;
 
 	const streakLine =
@@ -198,7 +196,7 @@ export default function DashboardPage() {
 								</p>
 							</div>
 							<Button asChild variant="ghost" size="sm" className="text-muted-foreground">
-								<Link href={projectResourceHref("sessions")}>
+								<Link href={`${projectResourceHref("sessions")}?automated=false`}>
 									View all
 									<ArrowRight />
 								</Link>

--- a/apps/web/src/app/(dashboard)/sessions/[id]/page.tsx
+++ b/apps/web/src/app/(dashboard)/sessions/[id]/page.tsx
@@ -29,6 +29,12 @@ import type { SessionMessage } from "@/lib/api-schemas";
 import { useCurrentUser } from "@/lib/auth-client";
 import { formatDuration } from "@/lib/format";
 import {
+	SESSION_DETAIL_GC_MS,
+	SESSION_DETAIL_STALE_MS,
+	SESSION_MESSAGES_GC_MS,
+	SESSION_MESSAGES_STALE_MS,
+} from "@/lib/session-queries";
+import {
 	cn,
 	formatAbsoluteTooltip,
 	formatNumber,
@@ -67,6 +73,8 @@ export function SessionDetailContent({
 			if (status >= 400 && status < 500) return false;
 			return failureCount < 2;
 		},
+		staleTime: SESSION_DETAIL_STALE_MS,
+		gcTime: SESSION_DETAIL_GC_MS,
 	});
 
 	// Direction toggle: "desc" (newest-first, default) is the most
@@ -133,7 +141,7 @@ export function SessionDetailContent({
 		// end (rather than reordering already-loaded pages, which
 		// would only show the OLDEST 100 in newest-first mode —
 		// confusing).
-		queryKey: ["session-messages", sessionId, direction],
+		queryKey: ["session-messages", sessionId, session?.content_hash ?? null, direction],
 		initialPageParam:
 			direction === "desc"
 				? ({ offset: initialDescOffset, limit: initialDescLimit } as PageParam)
@@ -170,6 +178,8 @@ export function SessionDetailContent({
 			if (status >= 400 && status < 500) return false;
 			return failureCount < 2;
 		},
+		staleTime: SESSION_MESSAGES_STALE_MS,
+		gcTime: SESSION_MESSAGES_GC_MS,
 	});
 
 	// Flatten pages → ordered message list, paired with a stable

--- a/apps/web/src/app/(dashboard)/sessions/page.tsx
+++ b/apps/web/src/app/(dashboard)/sessions/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { SortingState } from "@tanstack/react-table";
 import { AlertCircle, LayoutList, Table2 } from "lucide-react";
 import {
@@ -10,7 +10,7 @@ import {
 	parseAsStringLiteral,
 	useQueryStates,
 } from "nuqs";
-import { Suspense, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import { agentTypeLabel } from "@/components/dashboard/agent-label";
 import { PageHeader } from "@/components/page-header";
@@ -26,6 +26,7 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { unwrap, useApi } from "@/lib/api";
 import type { SessionListItem } from "@/lib/api-schemas";
 import { getProjectResourceDefinition, sessionDetailHref } from "@/lib/project-resource-model";
+import { type SessionListQuery, sessionListQueryOptions } from "@/lib/session-queries";
 import { useDebouncedValue } from "@/lib/use-debounced";
 import { cn, errorMessage, recencyBucketFor } from "@/lib/utils";
 
@@ -78,6 +79,7 @@ export default function SessionsPage() {
 
 function SessionsListInner() {
 	const api = useApi();
+	const queryClient = useQueryClient();
 
 	// All filter / sort / pagination state lives in the URL via
 	// nuqs. `clearOnDefault: true` keeps `/sessions` clean when
@@ -117,35 +119,31 @@ function SessionsListInner() {
 		params.has_pr !== null ||
 		params.automated !== null;
 
-	const { data, isLoading, isFetching, error } = useQuery({
-		queryKey: [
-			"sessions",
+	const sessionQuery = useMemo<SessionListQuery>(
+		() => ({
+			page: params.page,
+			page_size: params.pageSize,
+			q: debouncedSearch || undefined,
+			sort: params.sort,
+			order: params.order,
+			agent: params.agent || undefined,
+			has_pr: params.has_pr,
+			automated: params.automated,
+		}),
+		[
+			debouncedSearch,
+			params.agent,
+			params.automated,
+			params.has_pr,
+			params.order,
 			params.page,
 			params.pageSize,
-			debouncedSearch,
 			params.sort,
-			params.order,
-			params.agent,
-			params.has_pr,
-			params.automated,
 		],
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/api/sessions", {
-					params: {
-						query: {
-							page: params.page,
-							page_size: params.pageSize,
-							q: debouncedSearch || undefined,
-							sort: params.sort,
-							order: params.order,
-							agent: params.agent || undefined,
-							has_pr: params.has_pr ?? undefined,
-							automated: params.automated ?? undefined,
-						},
-					},
-				}),
-			),
+	);
+
+	const { data, isLoading, isFetching, error } = useQuery({
+		...sessionListQueryOptions(api, sessionQuery),
 		// Keep previous results visible during refetch; the
 		// `isFetching && !isLoading` opacity transition below is
 		// the only "loading" signal the user sees.
@@ -195,6 +193,13 @@ function SessionsListInner() {
 
 	const total = data?.total ?? 0;
 	const pageCount = Math.max(1, Math.ceil(total / params.pageSize));
+
+	useEffect(() => {
+		if (!data || params.page >= pageCount) return;
+		void queryClient.prefetchQuery(
+			sessionListQueryOptions(api, { ...sessionQuery, page: params.page + 1 }),
+		);
+	}, [api, data, pageCount, params.page, queryClient, sessionQuery]);
 
 	const groupable = params.sort === "last_activity_at" || params.sort === "started_at";
 

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -44,6 +44,7 @@ import { unwrap, useApi } from "@/lib/api";
 import { fetchAllPages } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
 import { projectResourceHref } from "@/lib/project-resource-model";
+import { sessionListQueryOptions } from "@/lib/session-queries";
 import { errorMessage } from "@/lib/utils";
 
 type SkillSummary = components["schemas"]["SkillSummaryResponse"];
@@ -131,13 +132,7 @@ export function ConnectedAgentDetail({
 	});
 
 	const { data: sessionsPage, isLoading: sessionsLoading } = useQuery({
-		queryKey: ["agent-sessions", id],
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/api/sessions", {
-					params: { query: { environment_id: id, page_size: 50 } },
-				}),
-			),
+		...sessionListQueryOptions(api, { environment_id: id, page_size: 50 }),
 		enabled: !!agent,
 	});
 

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -2,10 +2,11 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { AnalyticsProvider } from "@/components/providers/analytics-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { useCurrentUser } from "@/lib/auth-client";
 
 export function Providers({ children }: { children: React.ReactNode }) {
 	const [queryClient] = useState(() => new QueryClient());
@@ -13,11 +14,40 @@ export function Providers({ children }: { children: React.ReactNode }) {
 		<ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
 			<NuqsAdapter>
 				<QueryClientProvider client={queryClient}>
-					<AnalyticsProvider>
-						<TooltipProvider delayDuration={200}>{children}</TooltipProvider>
-					</AnalyticsProvider>
+					<QueryCacheAuthBoundary queryClient={queryClient}>
+						<AnalyticsProvider>
+							<TooltipProvider delayDuration={200}>{children}</TooltipProvider>
+						</AnalyticsProvider>
+					</QueryCacheAuthBoundary>
 				</QueryClientProvider>
 			</NuqsAdapter>
 		</ThemeProvider>
 	);
+}
+
+function QueryCacheAuthBoundary({
+	children,
+	queryClient,
+}: {
+	children: React.ReactNode;
+	queryClient: QueryClient;
+}) {
+	const { isLoaded, isSignedIn, user } = useCurrentUser();
+	const lastAuthKey = useRef<string | null>(null);
+
+	useEffect(() => {
+		if (!isLoaded) return;
+
+		const authKey = isSignedIn ? (user?.id ?? "signed-in") : "signed-out";
+		if (lastAuthKey.current === null) {
+			lastAuthKey.current = authKey;
+			return;
+		}
+		if (lastAuthKey.current !== authKey) {
+			queryClient.clear();
+			lastAuthKey.current = authKey;
+		}
+	}, [isLoaded, isSignedIn, queryClient, user?.id]);
+
+	return children;
 }

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -73,6 +73,7 @@ import {
 import { toastApiError, unwrap, useApi } from "@/lib/api";
 import type { SessionListItem } from "@/lib/api-schemas";
 import { formatModelLabel } from "@/lib/format";
+import { sessionListQueryOptions } from "@/lib/session-queries";
 import { settingsQueryHref } from "@/lib/settings-routes";
 import { useAiProviders } from "@/v2/ai-providers/ai-providers-hooks";
 import { AuthBadge, ProviderTypeChip } from "@/v2/ai-providers/ai-providers-ui";
@@ -221,13 +222,7 @@ export function HostedAgentDetail({
 	}, [environmentId, router, searchParams, section]);
 
 	const sessions = useQuery({
-		queryKey: ["agent-sessions", environmentId],
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/api/sessions", {
-					params: { query: { environment_id: environmentId, page_size: 20 } },
-				}),
-			),
+		...sessionListQueryOptions(api, { environment_id: environmentId, page_size: 20 }),
 		enabled: isCloudEnvId(environmentId),
 	});
 

--- a/apps/web/src/lib/session-queries.test.ts
+++ b/apps/web/src/lib/session-queries.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeSessionListQuery, sessionListQueryKey } from "./session-queries";
+
+describe("session query cache keys", () => {
+	it("fills backend defaults so equivalent list queries share cache", () => {
+		expect(normalizeSessionListQuery({})).toEqual({
+			page: 1,
+			page_size: 25,
+			sort: "last_activity_at",
+			order: "desc",
+		});
+		expect(sessionListQueryKey({})).toEqual(
+			sessionListQueryKey({
+				page: 1,
+				page_size: 25,
+				sort: "last_activity_at",
+				order: "desc",
+			}),
+		);
+	});
+
+	it("drops empty filters while preserving explicit false filters", () => {
+		expect(
+			normalizeSessionListQuery({
+				q: "",
+				agent: " ",
+				has_pr: null,
+				automated: false,
+			}),
+		).toEqual({
+			page: 1,
+			page_size: 25,
+			sort: "last_activity_at",
+			order: "desc",
+			automated: false,
+		});
+	});
+
+	it("sorts unordered array filters for stable keys", () => {
+		expect(normalizeSessionListQuery({ tag: ["beta", "alpha"], model: ["z", "a"] })).toMatchObject({
+			model: ["a", "z"],
+			tag: ["alpha", "beta"],
+		});
+	});
+});

--- a/apps/web/src/lib/session-queries.ts
+++ b/apps/web/src/lib/session-queries.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import type { paths } from "@clawdi/shared/api";
+import { queryOptions } from "@tanstack/react-query";
+import { unwrap, type useApi } from "@/lib/api";
+
+export const SESSION_LIST_STALE_MS = 60_000;
+export const SESSION_LIST_GC_MS = 10 * 60_000;
+export const SESSION_DETAIL_STALE_MS = 60_000;
+export const SESSION_DETAIL_GC_MS = 10 * 60_000;
+export const SESSION_MESSAGES_STALE_MS = 5 * 60_000;
+export const SESSION_MESSAGES_GC_MS = 30 * 60_000;
+
+type ApiClient = ReturnType<typeof useApi>;
+export type SessionListQuery = NonNullable<paths["/api/sessions"]["get"]["parameters"]["query"]>;
+
+const DEFAULT_SESSION_LIST_QUERY = {
+	page: 1,
+	page_size: 25,
+	sort: "last_activity_at",
+	order: "desc",
+} satisfies SessionListQuery;
+
+function cleanString(value: string | null | undefined): string | undefined {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+function cleanArray(value: string[] | null | undefined): string[] | undefined {
+	if (!value?.length) return undefined;
+	const cleaned = value
+		.map((item) => item.trim())
+		.filter(Boolean)
+		.sort();
+	return cleaned.length > 0 ? cleaned : undefined;
+}
+
+export function normalizeSessionListQuery(query: SessionListQuery = {}): SessionListQuery {
+	const normalized: SessionListQuery = {
+		page: query.page ?? DEFAULT_SESSION_LIST_QUERY.page,
+		page_size: query.page_size ?? DEFAULT_SESSION_LIST_QUERY.page_size,
+		sort: cleanString(query.sort) ?? DEFAULT_SESSION_LIST_QUERY.sort,
+		order: query.order === "asc" ? "asc" : DEFAULT_SESSION_LIST_QUERY.order,
+	};
+
+	const q = cleanString(query.q);
+	if (q) normalized.q = q;
+	const agent = cleanString(query.agent);
+	if (agent) normalized.agent = agent;
+	const environmentId = cleanString(query.environment_id);
+	if (environmentId) normalized.environment_id = environmentId;
+	const model = cleanArray(query.model);
+	if (model) normalized.model = model;
+	const tag = cleanArray(query.tag);
+	if (tag) normalized.tag = tag;
+	if (query.min_messages !== null && query.min_messages !== undefined) {
+		normalized.min_messages = query.min_messages;
+	}
+	if (query.min_duration !== null && query.min_duration !== undefined) {
+		normalized.min_duration = query.min_duration;
+	}
+	if (query.has_pr !== null && query.has_pr !== undefined) normalized.has_pr = query.has_pr;
+	if (query.automated !== null && query.automated !== undefined) {
+		normalized.automated = query.automated;
+	}
+	const since = cleanString(query.since);
+	if (since) normalized.since = since;
+	const until = cleanString(query.until);
+	if (until) normalized.until = until;
+
+	return normalized;
+}
+
+export function sessionListQueryKey(query: SessionListQuery = {}) {
+	return ["sessions", "list", normalizeSessionListQuery(query)] as const;
+}
+
+export function sessionListQueryOptions(api: ApiClient, query: SessionListQuery = {}) {
+	const normalized = normalizeSessionListQuery(query);
+	return queryOptions({
+		queryKey: sessionListQueryKey(normalized),
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/api/sessions", {
+					params: { query: normalized },
+				}),
+			),
+		staleTime: SESSION_LIST_STALE_MS,
+		gcTime: SESSION_LIST_GC_MS,
+	});
+}

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -58,3 +58,8 @@ MEMORY_EMBEDDING_API_KEY=
 MEMORY_EMBEDDING_BASE_URL=
 
 MEMORY_EMBEDDING_MODEL=text-embedding-3-small
+
+# Log API requests at or above this backend processing time, in milliseconds.
+# Set to 0 to disable slow-request logs. Responses always include
+# X-Process-Time-Ms for direct per-request inspection.
+SLOW_REQUEST_LOG_MS=750

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -101,6 +101,7 @@ class Settings(BaseSettings):
     sentry_dsn: str = ""
     sentry_environment: str = ""  # falls back to `environment` if empty
     sentry_traces_sample_rate: float = 0.0
+    slow_request_log_ms: float = 750.0
     metrics_bearer_token: str = ""
     metrics_basic_auth_user: str = "prometheus"
     metrics_basic_auth_password: str = ""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,7 @@ from app.core.database import get_session
 from app.core.sentry import init_sentry
 from app.middleware.body_size_limit import BodySizeLimitMiddleware
 from app.middleware.request_id import RequestIDMiddleware
+from app.middleware.request_timing import RequestTimingMiddleware
 from app.middleware.security_headers import SecurityHeadersMiddleware
 from app.routes.admin import router as admin_router
 from app.routes.agent_project_bindings import router as agent_project_bindings_router
@@ -134,15 +135,16 @@ app = FastAPI(
 # subsequent `add_middleware` call around the previous stack, so the LAST
 # call becomes the OUTERMOST handler seeing the request first. We want:
 #
-#   request → RequestID → CORS → BodySizeLimit → route
-#                                                    ↓
-#   response ← RequestID ← CORS ← BodySizeLimit ← route
+#   request → SecurityHeaders → RequestID → RequestTiming → CORS → BodySizeLimit → route
+#                                                                                      ↓
+#   response ← SecurityHeaders ← RequestID ← RequestTiming ← CORS ← BodySizeLimit ← route
 #
-# so a CORS-rejected preflight still carries X-Request-ID on the way back
-# out, and BodySizeLimit fires AFTER CORS preflight (preflight is OPTIONS,
-# which the limiter ignores anyway). The limiter sits inside CORS so
-# legitimate CORS responses still apply when we 413; otherwise a browser
-# upload over the cap would see an opaque network error instead of
+# so security headers are a final response wrapper, a CORS-rejected preflight
+# still carries X-Request-ID on the way back out, RequestTiming can correlate
+# slow logs with that id, and BodySizeLimit fires AFTER CORS preflight
+# (preflight is OPTIONS, which the limiter ignores anyway). The limiter sits
+# inside CORS so legitimate CORS responses still apply when we 413; otherwise
+# a browser upload over the cap would see an opaque network error instead of
 # "Request body too large".
 
 # Global cap on declared body size for body-bearing methods.
@@ -189,12 +191,14 @@ app.add_middleware(
         # but the dashboard relies on this once it stops fetching
         # the full list every render.
         "ETag",
+        "X-Process-Time-Ms",
     ],
     # 10 min production, but in dev the preflight cache outlives endpoint
     # changes (new routes registered during uvicorn --reload get rejected by
     # stale cached 404 preflights). Shorten in dev for fast iteration.
     max_age=30 if settings.environment != "production" else 600,
 )
+app.add_middleware(RequestTimingMiddleware, slow_ms=settings.slow_request_log_ms)
 app.add_middleware(RequestIDMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
 

--- a/backend/app/middleware/request_timing.py
+++ b/backend/app/middleware/request_timing.py
@@ -1,0 +1,95 @@
+"""Request timing middleware.
+
+Adds a cheap per-request process-time response header and logs only slow
+requests or server errors. Logs intentionally include method/path/status/time
+and request id only; query strings, headers, bodies, and user identity stay out
+of application logs.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import cast
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+_PROCESS_TIME_HEADER = b"x-process-time-ms"
+
+
+class RequestTimingMiddleware:
+    def __init__(self, app: ASGIApp, *, slow_ms: float) -> None:
+        self.app = app
+        self.slow_ms = slow_ms
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        started = time.perf_counter()
+        method = cast(str, scope.get("method", "GET"))
+        path = cast(str, scope.get("path", ""))
+        status_code = 500
+
+        async def timed_send(message: Message) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = int(message["status"])
+                duration_ms = _elapsed_ms(started)
+                headers = list(message.get("headers", []))
+                if not any(name.lower() == _PROCESS_TIME_HEADER for name, _ in headers):
+                    headers.append((_PROCESS_TIME_HEADER, f"{duration_ms:.1f}".encode("ascii")))
+                message = {**message, "headers": headers}
+            await send(message)
+
+        try:
+            await self.app(scope, receive, timed_send)
+        except Exception:
+            duration_ms = _elapsed_ms(started)
+            logger.exception(
+                "request_failed method=%s path=%s status=500 duration_ms=%.1f request_id=%s",
+                method,
+                path,
+                duration_ms,
+                _request_id(scope),
+            )
+            raise
+
+        duration_ms = _elapsed_ms(started)
+        if status_code >= 500:
+            logger.warning(
+                "request_error method=%s path=%s status=%d duration_ms=%.1f request_id=%s",
+                method,
+                path,
+                status_code,
+                duration_ms,
+                _request_id(scope),
+            )
+        elif _is_slow(duration_ms=duration_ms, slow_ms=self.slow_ms):
+            logger.warning(
+                "request_slow method=%s path=%s status=%d duration_ms=%.1f request_id=%s",
+                method,
+                path,
+                status_code,
+                duration_ms,
+                _request_id(scope),
+            )
+
+
+def _elapsed_ms(started: float) -> float:
+    return (time.perf_counter() - started) * 1000
+
+
+def _is_slow(*, duration_ms: float, slow_ms: float) -> bool:
+    return slow_ms > 0 and duration_ms >= slow_ms
+
+
+def _request_id(scope: Scope) -> str:
+    state = scope.get("state")
+    if isinstance(state, dict):
+        value = state.get("request_id")
+        if isinstance(value, str) and value:
+            return value
+    return "-"

--- a/backend/tests/test_request_timing.py
+++ b/backend/tests/test_request_timing.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from app.middleware.request_timing import RequestTimingMiddleware
+
+
+def _scope(*, path: str = "/api/sessions", query_string: bytes = b"secret=value") -> Scope:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": query_string,
+        "headers": [],
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+        "state": {"request_id": "req_test"},
+    }
+
+
+def _receive() -> Receive:
+    sent = False
+
+    async def receive() -> Message:
+        nonlocal sent
+        if sent:
+            return {"type": "http.disconnect"}
+        sent = True
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return receive
+
+
+async def _collect(app: ASGIApp, scope: Scope) -> list[Message]:
+    messages: list[Message] = []
+
+    async def send(message: Message) -> None:
+        messages.append(message)
+
+    await app(scope, _receive(), send)
+    return messages
+
+
+@pytest.mark.asyncio
+async def test_request_timing_adds_process_time_header():
+    async def inner(_scope: Scope, _receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    messages = await _collect(RequestTimingMiddleware(inner, slow_ms=750), _scope())
+    start = next(message for message in messages if message["type"] == "http.response.start")
+    headers = dict(start["headers"])
+
+    assert b"x-process-time-ms" in headers
+    assert float(headers[b"x-process-time-ms"]) >= 0
+
+
+@pytest.mark.asyncio
+async def test_request_timing_logs_errors_without_query_string(caplog: pytest.LogCaptureFixture):
+    async def inner(_scope: Scope, _receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 500, "headers": []})
+        await send({"type": "http.response.body", "body": b"error"})
+
+    caplog.set_level(logging.WARNING, logger="app.middleware.request_timing")
+    await _collect(
+        RequestTimingMiddleware(inner, slow_ms=750),
+        _scope(path="/api/sessions", query_string=b"token=secret"),
+    )
+
+    assert "request_error method=GET path=/api/sessions status=500" in caplog.text
+    assert "request_id=req_test" in caplog.text
+    assert "token=secret" not in caplog.text


### PR DESCRIPTION
## Summary
- unify dashboard `/api/sessions` list query keys and add short-lived in-memory cache/stale windows
- reuse the Home manual sessions query when navigating to Sessions via `?automated=false`, while still showing only 15 items on Home
- cache session detail/message pages and prefetch the next sessions page
- clear TanStack Query cache when the authenticated user changes
- add backend request timing middleware with `X-Process-Time-Ms` plus slow/error request logs for production diagnosis

## Production notes
- Current prod backend is still deployed at `35d9af8d61edcf8fc5e94d3c952068c97c6f00cb` per the latest Coolify audit logs.
- Existing prod logs do not include per-route duration, so this PR adds the missing observability. After deploy, grep for `request_slow`, `request_error`, `path=/api/sessions`, and `duration_ms=`.
- This intentionally does not persist session data in localStorage; session history is private user data, so the first clean step is memory cache + auth-scoped cache clearing.

## Verification
- `cd apps/web && bun test src/lib/session-queries.test.ts`
- `cd backend && uv run pytest tests/test_request_timing.py`
- `cd backend && uv run ruff check app/middleware/request_timing.py tests/test_request_timing.py app/main.py app/core/config.py`
- `bun run typecheck`
- `bun run check`
- `cd backend && uv run ruff format --check app/main.py`
