### PR TITLE
Handle hidden Coolify shared env values

### DIFF
--- a/backend/tests/test_coolify_runtime_deploy.py
+++ b/backend/tests/test_coolify_runtime_deploy.py
@@ -346,6 +346,82 @@ def test_audit_env_rejects_permanently_pending_shared_file_store_resolution(monk
     ]
 
 
+def test_audit_env_accepts_hidden_shared_file_store_type_from_manifest(monkeypatch):
+    module = _load_audit_module()
+    calls = 0
+
+    def fake_load_env_rows(**_kwargs):
+        nonlocal calls
+        calls += 1
+        return [
+            {
+                "key": "FILE_STORE_TYPE",
+                "value": None,
+                "real_value": None,
+                "is_preview": False,
+                "is_shared": True,
+                "is_runtime": True,
+                "is_buildtime": False,
+            },
+            {
+                "key": "FILE_STORE_LOCAL_PATH",
+                "value": None,
+                "real_value": None,
+                "is_preview": False,
+                "is_shared": True,
+                "is_runtime": True,
+                "is_buildtime": False,
+            },
+        ]
+
+    monkeypatch.setattr(module, "load_env_rows", fake_load_env_rows)
+
+    errors, _digests = module.audit_env(
+        api_url="https://coolify.example.com",
+        token="token",
+        app_name="clawdi-backend",
+        app_uuid="app-uuid",
+        expected_shared_keys={"FILE_STORE_TYPE", "FILE_STORE_LOCAL_PATH"},
+        expected_application_env={},
+        expected_env_values={"FILE_STORE_TYPE": "local"},
+        env_resolution_attempts=2,
+    )
+
+    assert calls == 1
+    assert errors == []
+
+
+def test_audit_env_rejects_file_store_type_conflicting_with_manifest(monkeypatch):
+    module = _load_audit_module()
+
+    def fake_load_env_rows(**_kwargs):
+        return [
+            {
+                "key": "FILE_STORE_TYPE",
+                "value": "{{environment.FILE_STORE_TYPE}}",
+                "real_value": "s3",
+                "is_preview": False,
+                "is_shared": True,
+                "is_runtime": True,
+                "is_buildtime": False,
+            }
+        ]
+
+    monkeypatch.setattr(module, "load_env_rows", fake_load_env_rows)
+
+    errors, _digests = module.audit_env(
+        api_url="https://coolify.example.com",
+        token="token",
+        app_name="clawdi-backend",
+        app_uuid="app-uuid",
+        expected_shared_keys={"FILE_STORE_TYPE"},
+        expected_application_env={},
+        expected_env_values={"FILE_STORE_TYPE": "local"},
+    )
+
+    assert errors == ["clawdi-backend: FILE_STORE_TYPE expected 'local', got 's3'"]
+
+
 def test_audit_env_requires_s3_values_when_file_store_is_s3(monkeypatch):
     module = _load_audit_module()
     rows = [

--- a/infra/deploy/coolify/README.md
+++ b/infra/deploy/coolify/README.md
@@ -66,6 +66,13 @@ Coolify may return resolved values for shared env rows instead of the literal
 parity, and cross-Application value digests rather than relying on the stored
 value text for shared rows.
 
+Some Coolify API tokens intentionally receive `null` for hidden shared env
+values. The audit treats that as an unreadable value, not as an empty runtime
+value. For the non-secret file-store selector, `.env.example` is the expected
+contract: if `FILE_STORE_TYPE` is hidden, the audit uses the manifest value to
+select the local-vs-S3 validation branch; if Coolify exposes a different value,
+the audit fails.
+
 `production-stack.json` also records source/deploy Application settings such as
 auto deploy, preview deploys, and container label behavior. Coolify's public
 Application API may not expose every setting on every installed version. The

--- a/infra/deploy/coolify/audit_stack.py
+++ b/infra/deploy/coolify/audit_stack.py
@@ -59,15 +59,20 @@ ENV_RESOLUTION_RETRY_DELAY_SECONDS = 3.0
 
 
 def parse_env_manifest(path: Path) -> set[str]:
-    keys: set[str] = set()
+    return set(parse_env_manifest_values(path))
+
+
+def parse_env_manifest_values(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
     for raw_line in path.read_text(encoding="utf-8").splitlines():
         line = raw_line.strip()
         if not line or line.startswith("#") or "=" not in line:
             continue
-        key = line.split("=", 1)[0].strip()
+        key, value = line.split("=", 1)
+        key = key.strip()
         if key and (key[0].isalpha() or key[0] == "_"):
-            keys.add(key)
-    return keys
+            values[key] = value.strip()
+    return values
 
 
 def request_json(
@@ -126,6 +131,12 @@ def row_resolved_value(row: dict[str, Any]) -> object:
     return row.get("value")
 
 
+def shared_value_is_hidden(row: dict[str, Any]) -> bool:
+    return (
+        row.get("is_shared") is True and row.get("real_value") is None and row.get("value") is None
+    )
+
+
 def shared_value_is_pending(row: dict[str, Any]) -> bool:
     if row.get("is_shared") is not True:
         return False
@@ -133,7 +144,7 @@ def shared_value_is_pending(row: dict[str, Any]) -> bool:
     if real_value is not None:
         return isinstance(real_value, str) and looks_like_unresolved_shared_ref(real_value)
     value = row.get("value")
-    return value is None or (isinstance(value, str) and looks_like_unresolved_shared_ref(value))
+    return isinstance(value, str) and looks_like_unresolved_shared_ref(value)
 
 
 def env_resolution_pending(by_key: dict[str, dict[str, Any]]) -> bool:
@@ -182,20 +193,39 @@ def env_rows_by_key(rows: list[dict[str, Any]]) -> tuple[dict[str, dict[str, Any
 
 def file_store_required_non_empty_keys(
     by_key: dict[str, dict[str, Any]],
-) -> tuple[set[str], str | None]:
+    expected_file_store_type: str | None,
+) -> tuple[set[str], list[str]]:
     row = by_key.get("FILE_STORE_TYPE")
     if row is None:
-        return set(), None
-    kind_value = row_resolved_value(row) if row else None
+        return set(), []
+    kind_value = row_resolved_value(row)
+    expected_kind = normalize_literal_env_value(expected_file_store_type)
+    if isinstance(expected_kind, str):
+        expected_kind = expected_kind.strip().lower()
+
+    errors: list[str] = []
+    if shared_value_is_hidden(row) and expected_kind in {"local", "s3"}:
+        kind_value = expected_kind
+
     kind = str(kind_value or "").strip().lower()
     required = {"FILE_STORE_TYPE"}
+
+    if expected_kind and expected_kind not in {"local", "s3"}:
+        errors.append(
+            "env manifest FILE_STORE_TYPE must be 'local' or 's3', "
+            f"got {expected_file_store_type!r}"
+        )
+    if kind in {"local", "s3"} and expected_kind in {"local", "s3"} and kind != expected_kind:
+        errors.append(f"FILE_STORE_TYPE expected {expected_kind!r}, got {kind!r}")
+
     if kind == "local":
         required.add("FILE_STORE_LOCAL_PATH")
-        return required, None
+        return required, errors
     if kind == "s3":
         required.update(S3_REQUIRED_NON_EMPTY_KEYS)
-        return required, None
-    return required, f"FILE_STORE_TYPE must resolve to 'local' or 's3', got {kind_value!r}"
+        return required, errors
+    errors.append(f"FILE_STORE_TYPE must resolve to 'local' or 's3', got {kind_value!r}")
+    return required, errors
 
 
 def normalize_literal_env_value(value: object) -> str | None:
@@ -507,9 +537,11 @@ def audit_env(
     app_uuid: str,
     expected_shared_keys: set[str],
     expected_application_env: dict[str, str],
+    expected_env_values: dict[str, str] | None = None,
     env_resolution_attempts: int = 1,
     env_resolution_retry_delay_seconds: float = 0.0,
 ) -> tuple[list[str], dict[str, str]]:
+    expected_env_values = expected_env_values or {}
     attempts = max(env_resolution_attempts, 1)
     rows: list[dict[str, Any]] = []
     by_key: dict[str, dict[str, Any]] = {}
@@ -557,10 +589,13 @@ def audit_env(
                 errors.append(f"{app_name}: {key} does not resolve from shared variables")
 
     required_non_empty_keys = set(BASE_REQUIRED_NON_EMPTY_KEYS)
-    file_store_required, file_store_error = file_store_required_non_empty_keys(by_key)
+    file_store_required, file_store_errors = file_store_required_non_empty_keys(
+        by_key,
+        expected_file_store_type=expected_env_values.get("FILE_STORE_TYPE"),
+    )
     required_non_empty_keys.update(file_store_required)
-    if file_store_error:
-        errors.append(f"{app_name}: {file_store_error}")
+    for error in file_store_errors:
+        errors.append(f"{app_name}: {error}")
 
     for key in sorted(required_non_empty_keys & keys):
         value = row_resolved_value(by_key[key])
@@ -588,13 +623,14 @@ def audit_env(
         for key in sorted(expected_shared_keys & keys)
     }
     shared_refs = sum(1 for row in rows if row.get("is_shared") is True)
+    hidden_shared_refs = sum(1 for row in rows if shared_value_is_hidden(row))
     runtime_only = sum(
         1 for row in rows if row.get("is_runtime") is True and row.get("is_buildtime") is False
     )
     print(
         f"{app_name}: env_rows={len(rows)} keys={len(keys)} "
         f"shared_refs={shared_refs} app_env={len(expected_application_env)} "
-        f"runtime_only={runtime_only}"
+        f"runtime_only={runtime_only} hidden_shared_refs={hidden_shared_refs}"
     )
     return errors, digests
 
@@ -690,7 +726,8 @@ def main() -> int:
         raise SystemExit("--expect-commit must be a full 40-character git SHA.")
 
     stack = load_stack_manifest(args.stack_manifest)
-    expected_keys = parse_env_manifest(args.env_manifest)
+    expected_env_values = parse_env_manifest_values(args.env_manifest)
+    expected_keys = set(expected_env_values)
     missing_required_keys = REQUIRED_MANIFEST_KEYS - expected_keys
     if missing_required_keys:
         raise SystemExit(
@@ -754,6 +791,7 @@ def main() -> int:
             app_name=app_name,
             app_uuid=app_uuid,
             expected_shared_keys=expected_keys,
+            expected_env_values=expected_env_values,
             expected_application_env=application_env(expected),
             env_resolution_attempts=ENV_RESOLUTION_ATTEMPTS,
             env_resolution_retry_delay_seconds=ENV_RESOLUTION_RETRY_DELAY_SECONDS,


### PR DESCRIPTION
## Summary
- treat Coolify shared env rows with null value/real_value as hidden values instead of unresolved references
- use the public .env.example FILE_STORE_TYPE contract to select local vs S3 validation when Coolify hides that non-secret selector
- keep strict validation when Coolify exposes a conflicting FILE_STORE_TYPE or an unresolved shared reference
- document the hidden shared env behavior in the Coolify runbook

## Verification
- cd backend && uv run pytest tests/test_coolify_runtime_deploy.py
- cd backend && uv run ruff check tests/test_coolify_runtime_deploy.py ../infra/deploy/coolify/audit_stack.py
- cd backend && uv run ruff format --check tests/test_coolify_runtime_deploy.py ../infra/deploy/coolify/audit_stack.py