### PR TITLE
Allow Coolify file store type audit override

### DIFF
--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -274,6 +274,7 @@ jobs:
           COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
           CLAWDI_BACKEND_RUNTIME_TAG: ${{ needs.build.outputs.image_tag }}
           CLAWDI_DEPLOY_SCOPE: ${{ needs.build.outputs.deploy_scope }}
+          CLAWDI_EXPECT_FILE_STORE_TYPE: ${{ vars.CLAWDI_COOLIFY_FILE_STORE_TYPE }}
         run: |
           if [ "$CLAWDI_DEPLOY_SCOPE" = "api-only" ]; then
             phase=api-only
@@ -299,6 +300,7 @@ jobs:
         env:
           COOLIFY_API_URL: ${{ secrets.COOLIFY_API_URL }}
           COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
+          CLAWDI_EXPECT_FILE_STORE_TYPE: ${{ vars.CLAWDI_COOLIFY_FILE_STORE_TYPE }}
         run: |
           if [ -z "$COOLIFY_API_URL" ] || [ -z "$COOLIFY_TOKEN" ]; then
             echo "COOLIFY_API_URL and COOLIFY_TOKEN secrets are required for automated Coolify audit." >&2

--- a/backend/tests/test_coolify_runtime_deploy.py
+++ b/backend/tests/test_coolify_runtime_deploy.py
@@ -422,6 +422,88 @@ def test_audit_env_rejects_file_store_type_conflicting_with_manifest(monkeypatch
     assert errors == ["clawdi-backend: FILE_STORE_TYPE expected 'local', got 's3'"]
 
 
+def test_audit_env_uses_expected_file_store_type_override_for_hidden_shared_value(
+    monkeypatch,
+):
+    module = _load_audit_module()
+    rows = [
+        {
+            "key": "FILE_STORE_TYPE",
+            "value": None,
+            "real_value": None,
+            "is_preview": False,
+            "is_shared": True,
+            "is_runtime": True,
+            "is_buildtime": False,
+        },
+        {
+            "key": "FILE_STORE_S3_BUCKET",
+            "value": None,
+            "real_value": None,
+            "is_preview": False,
+            "is_shared": True,
+            "is_runtime": True,
+            "is_buildtime": False,
+        },
+    ]
+
+    def fake_load_env_rows(**_kwargs):
+        return rows
+
+    monkeypatch.setattr(module, "load_env_rows", fake_load_env_rows)
+
+    errors, _digests = module.audit_env(
+        api_url="https://coolify.example.com",
+        token="token",
+        app_name="clawdi-backend",
+        app_uuid="app-uuid",
+        expected_shared_keys={str(row["key"]) for row in rows} | module.S3_REQUIRED_NON_EMPTY_KEYS,
+        expected_application_env={},
+        expected_env_values={"FILE_STORE_TYPE": "s3"},
+    )
+
+    assert errors == [
+        "clawdi-backend: missing env key FILE_STORE_S3_ACCESS_KEY_ID",
+        "clawdi-backend: missing env key FILE_STORE_S3_ENDPOINT_URL",
+        "clawdi-backend: missing env key FILE_STORE_S3_REGION",
+        "clawdi-backend: missing env key FILE_STORE_S3_SECRET_ACCESS_KEY",
+    ]
+
+
+def test_audit_env_rejects_invalid_expected_file_store_type(monkeypatch):
+    module = _load_audit_module()
+
+    def fake_load_env_rows(**_kwargs):
+        return [
+            {
+                "key": "FILE_STORE_TYPE",
+                "value": None,
+                "real_value": None,
+                "is_preview": False,
+                "is_shared": True,
+                "is_runtime": True,
+                "is_buildtime": False,
+            }
+        ]
+
+    monkeypatch.setattr(module, "load_env_rows", fake_load_env_rows)
+
+    errors, _digests = module.audit_env(
+        api_url="https://coolify.example.com",
+        token="token",
+        app_name="clawdi-backend",
+        app_uuid="app-uuid",
+        expected_shared_keys={"FILE_STORE_TYPE"},
+        expected_application_env={},
+        expected_env_values={"FILE_STORE_TYPE": "blob"},
+    )
+
+    assert errors == [
+        "clawdi-backend: expected FILE_STORE_TYPE must be 'local' or 's3', got 'blob'",
+        "clawdi-backend: FILE_STORE_TYPE must resolve to 'local' or 's3', got None",
+    ]
+
+
 def test_audit_env_requires_s3_values_when_file_store_is_s3(monkeypatch):
     module = _load_audit_module()
     rows = [

--- a/infra/deploy/coolify/audit_stack.py
+++ b/infra/deploy/coolify/audit_stack.py
@@ -212,8 +212,7 @@ def file_store_required_non_empty_keys(
 
     if expected_kind and expected_kind not in {"local", "s3"}:
         errors.append(
-            "env manifest FILE_STORE_TYPE must be 'local' or 's3', "
-            f"got {expected_file_store_type!r}"
+            f"expected FILE_STORE_TYPE must be 'local' or 's3', got {expected_file_store_type!r}"
         )
     if kind in {"local", "s3"} and expected_kind in {"local", "s3"} and kind != expected_kind:
         errors.append(f"FILE_STORE_TYPE expected {expected_kind!r}, got {kind!r}")
@@ -715,6 +714,12 @@ def main() -> int:
     parser.add_argument("--token", default=os.environ.get("COOLIFY_TOKEN"))
     parser.add_argument("--phase", choices=("api-only", "live", "none"), default="none")
     parser.add_argument("--expect-commit")
+    parser.add_argument(
+        "--expect-file-store-type",
+        choices=("local", "s3"),
+        default=os.environ.get("CLAWDI_EXPECT_FILE_STORE_TYPE"),
+        help=("Expected live FILE_STORE_TYPE. Defaults to FILE_STORE_TYPE in the env manifest."),
+    )
     parser.add_argument("--skip-deployment-commit-audit", action="store_true")
     args = parser.parse_args()
 
@@ -727,6 +732,8 @@ def main() -> int:
 
     stack = load_stack_manifest(args.stack_manifest)
     expected_env_values = parse_env_manifest_values(args.env_manifest)
+    if args.expect_file_store_type:
+        expected_env_values["FILE_STORE_TYPE"] = args.expect_file_store_type
     expected_keys = set(expected_env_values)
     missing_required_keys = REQUIRED_MANIFEST_KEYS - expected_keys
     if missing_required_keys:


### PR DESCRIPTION
## Summary
- add --expect-file-store-type to Coolify stack audit
- let the image release workflow pass CLAWDI_COOLIFY_FILE_STORE_TYPE as a non-secret expected value
- keep .env.example as the default when no production override is configured
- add tests for hidden shared FILE_STORE_TYPE under s3 override and invalid override values

## Verification
- cd backend && uv run pytest tests/test_coolify_runtime_deploy.py
- cd backend && uv run ruff check tests/test_coolify_runtime_deploy.py ../infra/deploy/coolify/audit_stack.py
- cd backend && uv run ruff format --check tests/test_coolify_runtime_deploy.py ../infra/deploy/coolify/audit_stack.py