### PR TITLE
Optimize skills 304 fast path

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -2,6 +2,7 @@ import hashlib
 import hmac
 import logging
 from datetime import UTC, datetime, timedelta
+from uuid import UUID
 
 import httpx
 import jwt
@@ -37,14 +38,22 @@ LAST_USED_THROTTLE = timedelta(minutes=1)
 
 
 class AuthContext:
-    def __init__(self, user: User, api_key: ApiKey | None = None):
+    def __init__(
+        self,
+        user: User,
+        api_key: ApiKey | None = None,
+        api_key_project_id: UUID | None = None,
+    ):
         self.user = user
         self.api_key = api_key
         self.is_cli = api_key is not None
+        self.api_key_project_id = api_key_project_id
+        self._user_id = user.id
+        self.skills_revision = int(user.skills_revision or 0)
 
     @property
     def user_id(self):
-        return self.user.id
+        return self._user_id
 
 
 async def _auth_via_api_key(token: str, db: AsyncSession) -> AuthContext | None:
@@ -74,7 +83,20 @@ async def _auth_via_api_key(token: str, db: AsyncSession) -> AuthContext | None:
     if not user:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, "User not found")
 
-    return AuthContext(user=user, api_key=api_key)
+    api_key_project_id = None
+    if api_key.environment_id is not None:
+        from app.models.session import AgentEnvironment
+
+        api_key_project_id = (
+            await db.execute(
+                select(AgentEnvironment.default_project_id).where(
+                    AgentEnvironment.id == api_key.environment_id,
+                    AgentEnvironment.user_id == api_key.user_id,
+                )
+            )
+        ).scalar_one_or_none()
+
+    return AuthContext(user=user, api_key=api_key, api_key_project_id=api_key_project_id)
 
 
 async def _auth_via_dev_bypass(token: str, db: AsyncSession) -> AuthContext | None:

--- a/backend/app/core/project.py
+++ b/backend/app/core/project.py
@@ -96,6 +96,9 @@ async def resolve_default_write_project(
     (never None) — callers can treat the column as required.
     """
     if auth.is_cli and auth.api_key is not None and auth.api_key.environment_id is not None:
+        if auth.api_key_project_id is not None:
+            return auth.api_key_project_id
+
         bound_env_id = auth.api_key.environment_id
         result = await db.execute(
             select(AgentEnvironment.default_project_id).where(

--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -49,7 +49,7 @@ from app.schemas.skill import (
     SkillUploadResponse,
 )
 from app.services.file_store import get_file_store
-from app.services.sync_events import bump_skills_revision, get_skills_revision
+from app.services.sync_events import bump_skills_revision
 from app.services.tar_utils import (
     TarValidationError,
     extract_skill_md,
@@ -271,12 +271,17 @@ async def list_skills(
     # it can't write to). When the caller pins `project_id`,
     # intersect with what they're allowed to see — an ID
     # outside that set yields a deliberately-empty listing.
-    revision = await get_skills_revision(db, auth.user_id)
+    revision = auth.skills_revision
     selected_project_id = project_id
     if selected_project_id is not None:
-        from app.core.project import resolve_for_parent
+        if auth.api_key_project_id is not None:
+            visible_project_ids = (
+                [selected_project_id] if selected_project_id == auth.api_key_project_id else []
+            )
+        else:
+            from app.core.project import resolve_for_parent
 
-        visible_project_ids = list(await resolve_for_parent(db, auth, selected_project_id))
+            visible_project_ids = list(await resolve_for_parent(db, auth, selected_project_id))
     else:
         # Unscoped read: full inventory across owned + shared projects.
         visible_project_ids = await project_ids_visible_to(db, auth)
@@ -290,6 +295,7 @@ async def list_skills(
     ).hexdigest()[:16]
     visible_revision_fingerprint = await _visible_skills_revision_fingerprint(
         db,
+        auth,
         visible_project_ids,
     )
     etag = f'"{revision}:{project_tag}:{visible_fingerprint}:{visible_revision_fingerprint}"'
@@ -460,6 +466,7 @@ async def _resolve_legacy_skill(
 
 async def _visible_skills_revision_fingerprint(
     db: AsyncSession,
+    auth: AuthContext,
     visible_project_ids: list,
 ) -> str:
     """Fingerprint skill revisions for every owner represented in
@@ -474,6 +481,11 @@ async def _visible_skills_revision_fingerprint(
     """
     if not visible_project_ids:
         return "none"
+
+    if auth.api_key_project_id is not None and set(visible_project_ids) == {
+        auth.api_key_project_id
+    }:
+        return hashlib.sha256(f"{auth.user_id}:{auth.skills_revision}".encode()).hexdigest()[:16]
 
     from app.models.project import Project
     from app.models.user import User


### PR DESCRIPTION
## Summary
- Snapshot `AuthContext.user_id`, `skills_revision`, and env-bound API key project ids during auth.
- Let env-bound daemon skill listings reuse the auth snapshot instead of re-querying `agent_environments` and owner revision state on every conditional GET.
- Keep dashboard/shared-project paths on the existing DB-backed fingerprint path for correctness.

## Why
After #209 deployed, `QueuePool` timeouts stopped, but production still showed many slow `/api/skills` 304 responses. Those requests do not read S3/R2 or return a body; the remaining cost is repeated auth/project/revision DB work under high daemon fan-out. This PR makes the common env-bound daemon 304 path avoid route-level DB reads when the cached ETag is still valid.

## Verification
- `cd backend && uv run ruff check app/core/auth.py app/core/project.py app/routes/skills.py tests/conftest.py tests/test_project_isolation.py tests/test_skills.py`
- `cd backend && uv run python -m py_compile app/core/auth.py app/core/project.py app/routes/skills.py tests/conftest.py tests/test_project_isolation.py tests/test_skills.py`
- `git diff --check`