### PR TITLE
Tune API key auth cache TTL

### DIFF
--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -39,7 +39,11 @@ API_KEY_PREFIX = "clawdi_"
 # long ago. Every authenticated CLI request used to write+commit the row,
 # which becomes write-lock contention on a hot key at scale.
 LAST_USED_THROTTLE = timedelta(minutes=1)
-API_KEY_AUTH_CACHE_TTL_SECONDS = 5.0
+# Daemons reconcile skills on a 60s cadence. The cache needs to span that
+# interval to avoid turning every conditional GET into three auth DB reads.
+# Dashboard revocation calls `invalidate_api_key_auth_cache`, so user-initiated
+# revokes still take effect immediately in the single-process deployment model.
+API_KEY_AUTH_CACHE_TTL_SECONDS = 75.0
 API_KEY_AUTH_CACHE_MAX_SIZE = 4096
 
 


### PR DESCRIPTION
## Summary
- Increase the API key auth snapshot TTL from 5s to 75s so it covers the daemon 60s skills reconcile cadence.
- Document why this is still bounded and how dashboard revoke invalidates the cache immediately.

## Why
Production after #211 showed fewer and shorter `/api/skills` 304 slow requests, but 5s TTL does not help the normal 60s daemon poll cadence. A 75s TTL lets consecutive polls reuse auth snapshots while explicit dashboard revocation still clears the cache immediately.

## Verification
- `cd backend && uv run ruff check app/core/auth.py app/routes/auth.py`
- `cd backend && uv run python -m py_compile app/core/auth.py app/routes/auth.py`
- `git diff --check`