### PR TITLE
Fix daemon invalid skill upload retries

### DIFF
--- a/packages/cli/src/lib/api-client.test.ts
+++ b/packages/cli/src/lib/api-client.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "bun:test";
+import { ApiClient } from "./api-client";
+
+describe("ApiClient.uploadSkill", () => {
+	it("rejects invalid skill_key before building a multipart request", async () => {
+		const api = new ApiClient({ requireAuth: false });
+
+		await expect(
+			api.uploadSkill(
+				"00000000-0000-0000-0000-000000000000",
+				".system",
+				Buffer.from("not a tar"),
+				".system.tar.gz",
+			),
+		).rejects.toThrow('Invalid skill_key: ".system"');
+	});
+});

--- a/packages/cli/src/lib/api-client.ts
+++ b/packages/cli/src/lib/api-client.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { type components, extractApiDetail, type paths } from "@clawdi/shared/api";
 import createClient, { type Client } from "openapi-fetch";
 import { getAuth, getConfig } from "./config";
+import { assertValidSkillKey } from "./skill-key";
 import { getCliVersion } from "./version";
 
 type SkillUploadResponse = components["schemas"]["SkillUploadResponse"];
@@ -249,6 +250,7 @@ export class ApiClient {
 		filename: string,
 		contentHash?: string,
 	): Promise<SkillUploadResponse> {
+		assertValidSkillKey(skillKey);
 		// `content_hash` is optional server-side (added 0.3.4). Omit the
 		// field entirely when the caller doesn't have one — server falls
 		// back to computing it from the uploaded tar.

--- a/packages/cli/src/lib/skill-key.ts
+++ b/packages/cli/src/lib/skill-key.ts
@@ -7,6 +7,13 @@ import {
 const SKILL_KEY_RE = new RegExp(SKILL_KEY_PATTERN);
 const RESERVED_SUFFIXES = new Set<string>(RESERVED_SKILL_KEY_SUFFIXES);
 
+export class SkillKeyValidationError extends Error {
+	constructor(skillKey: string) {
+		super(`Invalid skill_key: ${JSON.stringify(skillKey)}`);
+		this.name = "SkillKeyValidationError";
+	}
+}
+
 function hasReservedSkillKeySuffix(skillKey: string): boolean {
 	const parts = skillKey.split("/");
 	return parts.length > 1 && RESERVED_SUFFIXES.has(parts[parts.length - 1] ?? "");
@@ -22,7 +29,7 @@ export function isValidSkillKey(skillKey: string): boolean {
 
 export function assertValidSkillKey(skillKey: string): void {
 	if (!isValidSkillKey(skillKey)) {
-		throw new Error(`Invalid skill_key: ${JSON.stringify(skillKey)}`);
+		throw new SkillKeyValidationError(skillKey);
 	}
 }
 

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -8,6 +8,7 @@ import {
 	addInFlight,
 	classifyHeartbeatFailure,
 	consumePendingSkillUploadEcho,
+	filterValidSkillKeysForSync,
 	isAuthFailure,
 	isOversizedUploadError,
 	lastSyncErrorForSseReconnect,
@@ -222,6 +223,17 @@ describe("resolveOwningSkillKey — dotfile component rejection", () => {
 	it("returns null for a path with no SKILL.md ancestor", () => {
 		expect(resolveOwningSkillKey(tmp, "no-skill-here")).toBeNull();
 		expect(resolveOwningSkillKey(tmp, "deep/nested/no-skill")).toBeNull();
+	});
+});
+
+describe("filterValidSkillKeysForSync", () => {
+	it("drops adapter-listed keys the backend would reject", () => {
+		expect(
+			filterValidSkillKeysForSync(
+				["valid-skill", ".system", "category/nested", "category/.cache/sub", "team/download"],
+				{ logSkipped: false },
+			),
+		).toEqual(["valid-skill", "category/nested"]);
 	});
 });
 

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -56,7 +56,7 @@ import { ApiClient, ApiError, unwrap } from "../lib/api-client";
 import { listRegisteredAgentTypes } from "../lib/select-adapter";
 import { computeLastActivityIso } from "../lib/session-activity";
 import { cacheKey, readSessionsLock, writeSessionsLock } from "../lib/sessions-lock";
-import { isValidSkillKey } from "../lib/skill-key";
+import { isValidSkillKey, SkillKeyValidationError } from "../lib/skill-key";
 import {
 	computeSkillFolderHash,
 	readSkillsLock,
@@ -930,6 +930,7 @@ export function classifyHeartbeatFailure(consecutiveFailures: number): FailureCl
  * retry queue's whole reason to exist.
  */
 function isPermanentUploadError(e: unknown): boolean {
+	if (e instanceof SkillKeyValidationError) return true;
 	if (e instanceof ApiError) {
 		if (e.status >= 400 && e.status < 500) {
 			// 408 = server-side request timeout; the daemon should
@@ -1607,8 +1608,9 @@ async function initialSync(
 	// real skill, no SKILL.md) and miss the actual nested skills.
 	// `listSkillKeys` returns the same shape the adapter's
 	// `collectSkills` would emit `skillKey` (relative paths,
-	// dotfile + bundled-`clawdi` filtering already applied).
-	const localKeys = await opts.adapter.listSkillKeys();
+	// flat or nested). The sync engine still validates the result
+	// against the backend `skill_key` contract before queueing.
+	const localKeys = filterValidSkillKeysForSync(await opts.adapter.listSkillKeys());
 	const localHashes = new Map<string, string>();
 	for (const key of localKeys) {
 		try {
@@ -1838,6 +1840,22 @@ async function initialSync(
 	}
 }
 
+export function filterValidSkillKeysForSync(
+	keys: Iterable<string>,
+	opts: { logSkipped?: boolean } = {},
+): string[] {
+	const logSkipped = opts.logSkipped ?? true;
+	const validKeys: string[] = [];
+	for (const key of keys) {
+		if (isValidSkillKey(key)) {
+			validKeys.push(key);
+		} else if (logSkipped) {
+			log.warn("engine.invalid_skill_key_skipped", { skill_key: key, origin: "adapter_list" });
+		}
+	}
+	return validKeys;
+}
+
 /** Periodic full reconciliation. Different from initialSync —
  * this runs after the daemon has already established what's in
  * the cloud, so it CAN sweep local skills the cloud has since
@@ -2060,7 +2078,7 @@ async function rescanLocalSkillsForChanges(
 	pullsInFlight: Map<string, number>,
 	getProjectId: () => string,
 ): Promise<void> {
-	const localKeys = await opts.adapter.listSkillKeys();
+	const localKeys = filterValidSkillKeysForSync(await opts.adapter.listSkillKeys());
 	for (const key of localKeys) {
 		if (pullsInFlight.has(key)) {
 			log.debug("engine.rescan_skipped_in_flight", { skill_key: key });


### PR DESCRIPTION
## Summary
- Filter adapter-listed skill keys during daemon boot and rescan before queueing uploads
- Add an explicit SkillKeyValidationError and treat invalid skill keys as permanent queue drops
- Assert skill_key validity in ApiClient.uploadSkill before constructing multipart requests
- Add regression coverage for invalid adapter-listed keys and preflight upload rejection

## Production context
Prod still had high /api/projects/*/skills/upload validation pressure after the DB pool fixes: request failures and pool timeouts stopped, but logs showed thousands of multipart 422s from node clients. The remaining root cause is the daemon boot path: initialSync trusted adapter.listSkillKeys() and directly enqueued skill_push items, bypassing the watcher/enqueueIfChanged validation path. Invalid local directories could then retry against the backend and force multipart parsing before the 422.

## Verification
- bun test packages/cli/src/serve/sync-engine.test.ts packages/cli/src/lib/api-client.test.ts
- bun run check
- bun run typecheck
- git diff --check