### PR TITLE
Preflight invalid skill upload keys

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,6 +23,7 @@ from app.middleware.body_size_limit import BodySizeLimitMiddleware
 from app.middleware.request_id import RequestIDMiddleware
 from app.middleware.request_timing import RequestTimingMiddleware
 from app.middleware.security_headers import SecurityHeadersMiddleware
+from app.middleware.skill_upload_preflight import SkillUploadPreflightMiddleware
 from app.routes.admin import router as admin_router
 from app.routes.agent_project_bindings import router as agent_project_bindings_router
 from app.routes.ai_providers import router as ai_providers_router
@@ -135,9 +136,11 @@ app = FastAPI(
 # subsequent `add_middleware` call around the previous stack, so the LAST
 # call becomes the OUTERMOST handler seeing the request first. We want:
 #
-#   request → SecurityHeaders → RequestID → RequestTiming → CORS → BodySizeLimit → route
-#                                                                                      ↓
-#   response ← SecurityHeaders ← RequestID ← RequestTiming ← CORS ← BodySizeLimit ← route
+#   request → SecurityHeaders → RequestID → RequestTiming → CORS
+#           → SkillUploadPreflight → BodySizeLimit → route
+#                                                        ↓
+#   response ← SecurityHeaders ← RequestID ← RequestTiming ← CORS
+#            ← SkillUploadPreflight ← BodySizeLimit ← route
 #
 # so security headers are a final response wrapper, a CORS-rejected preflight
 # still carries X-Request-ID on the way back out, RequestTiming can correlate
@@ -145,7 +148,9 @@ app = FastAPI(
 # (preflight is OPTIONS, which the limiter ignores anyway). The limiter sits
 # inside CORS so legitimate CORS responses still apply when we 413; otherwise
 # a browser upload over the cap would see an opaque network error instead of
-# "Request body too large".
+# "Request body too large". SkillUploadPreflight sits in front of the limiter
+# so invalid daemon upload metadata can be rejected before FastAPI's multipart
+# parser spools a doomed file part.
 
 # Global cap on declared body size for body-bearing methods.
 # Sized ABOVE the largest legitimate route-level cap so multipart
@@ -163,6 +168,7 @@ _MAX_SESSION_CONTENT_BYTES = 50 * 1024 * 1024  # mirror of sessions.py
 _MULTIPART_OVERHEAD_HEADROOM = 1 * 1024 * 1024  # 1 MB
 _MAX_REQUEST_BODY_BYTES = _MAX_SESSION_CONTENT_BYTES + _MULTIPART_OVERHEAD_HEADROOM
 app.add_middleware(BodySizeLimitMiddleware, max_bytes=_MAX_REQUEST_BODY_BYTES)
+app.add_middleware(SkillUploadPreflightMiddleware)
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/app/middleware/skill_upload_preflight.py
+++ b/backend/app/middleware/skill_upload_preflight.py
@@ -1,0 +1,144 @@
+"""Early `skill_key` validation for skill multipart uploads.
+
+FastAPI validates `Form(..., pattern=...)` only after Starlette has parsed the
+multipart body. A daemon with an invalid local skill directory can therefore
+make the server parse and log a doomed archive before returning 422. This
+middleware peeks at the small metadata prefix our clients send before the file
+part and rejects invalid `skill_key` values before the upload reaches the
+multipart parser.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Awaitable
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from app.core.skill_key import (
+    RESERVED_SKILL_KEY_SUFFIXES,
+    has_reserved_skill_key_suffix,
+    is_valid_skill_key,
+)
+
+_PROJECT_SKILL_UPLOAD_RE = re.compile(
+    r"^/api/projects/[0-9a-fA-F-]{36}/skills/upload$",
+)
+_MAX_PREFLIGHT_BYTES = 64 * 1024
+
+
+class SkillUploadPreflightMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if not _should_preflight(scope):
+            await self.app(scope, receive, send)
+            return
+
+        buffered: list[Message] = []
+        body_prefix = bytearray()
+
+        while len(body_prefix) < _MAX_PREFLIGHT_BYTES:
+            message = await receive()
+            buffered.append(message)
+            if message.get("type") != "http.request":
+                break
+
+            body = message.get("body", b"")
+            if body:
+                body_prefix.extend(body)
+                skill_key = _extract_skill_key(bytes(body_prefix))
+                if skill_key is not None:
+                    if has_reserved_skill_key_suffix(skill_key):
+                        await _send_reserved_skill_key(send)
+                        return
+                    if not is_valid_skill_key(skill_key):
+                        await _send_invalid_skill_key(send)
+                        return
+                    break
+
+            if not message.get("more_body", False):
+                break
+
+        replay = _ReplayReceive(buffered, receive)
+        await self.app(scope, replay, send)
+
+
+def _should_preflight(scope: Scope) -> bool:
+    if scope.get("type") != "http":
+        return False
+    if scope.get("method", "").upper() != "POST":
+        return False
+
+    path = str(scope.get("path", ""))
+    if path != "/api/skills/upload" and not _PROJECT_SKILL_UPLOAD_RE.match(path):
+        return False
+
+    content_type = _header(scope, b"content-type")
+    return content_type.startswith("multipart/form-data;")
+
+
+def _extract_skill_key(body_prefix: bytes) -> str | None:
+    marker = b'name="skill_key"'
+    marker_pos = body_prefix.find(marker)
+    if marker_pos < 0:
+        return None
+
+    header_end = body_prefix.find(b"\r\n\r\n", marker_pos)
+    if header_end < 0:
+        return None
+
+    value_start = header_end + 4
+    value_end = body_prefix.find(b"\r\n--", value_start)
+    if value_end < 0:
+        return None
+
+    return body_prefix[value_start:value_end].decode("utf-8", errors="replace")
+
+
+def _header(scope: Scope, name: bytes) -> str:
+    for header_name, header_value in scope.get("headers", []):
+        if header_name == name:
+            return header_value.decode("latin-1", errors="replace")
+    return ""
+
+
+class _ReplayReceive:
+    def __init__(self, buffered: list[Message], receive: Receive) -> None:
+        self._buffered = buffered
+        self._receive = receive
+
+    def __call__(self) -> Awaitable[Message]:
+        if self._buffered:
+            message = self._buffered.pop(0)
+
+            async def _return_buffered() -> Message:
+                return message
+
+            return _return_buffered()
+        return self._receive()
+
+
+async def _send_invalid_skill_key(send: Send) -> None:
+    body = json.dumps({"detail": "Invalid skill_key"}).encode("utf-8")
+    await _send_json(send, status=422, body=body)
+
+
+async def _send_reserved_skill_key(send: Send) -> None:
+    detail = (
+        "skill_key cannot end with reserved suffix "
+        f"({', '.join(sorted(RESERVED_SKILL_KEY_SUFFIXES))})"
+    )
+    body = json.dumps({"detail": detail}).encode("utf-8")
+    await _send_json(send, status=400, body=body)
+
+
+async def _send_json(send: Send, *, status: int, body: bytes) -> None:
+    headers = [
+        (b"content-type", b"application/json"),
+        (b"content-length", str(len(body)).encode("ascii")),
+    ]
+    await send({"type": "http.response.start", "status": status, "headers": headers})
+    await send({"type": "http.response.body", "body": body, "more_body": False})

--- a/backend/tests/test_skill_upload_preflight.py
+++ b/backend/tests/test_skill_upload_preflight.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+from starlette.types import Message, Receive, Scope, Send
+
+from app.middleware.skill_upload_preflight import SkillUploadPreflightMiddleware
+
+
+def _multipart_body(*, skill_key: str | None) -> tuple[bytes, str]:
+    boundary = "----clawdi-test-boundary"
+    parts: list[bytes] = []
+    if skill_key is not None:
+        parts.append(
+            (
+                f"--{boundary}\r\n"
+                'Content-Disposition: form-data; name="skill_key"\r\n'
+                "\r\n"
+                f"{skill_key}\r\n"
+            ).encode()
+        )
+    parts.append(
+        (
+            f"--{boundary}\r\n"
+            'Content-Disposition: form-data; name="file"; filename="skill.tar.gz"\r\n'
+            "Content-Type: application/gzip\r\n"
+            "\r\n"
+            "not-a-real-archive\r\n"
+            f"--{boundary}--\r\n"
+        ).encode()
+    )
+    return b"".join(parts), f"multipart/form-data; boundary={boundary}"
+
+
+@pytest.mark.asyncio
+async def test_skill_upload_preflight_rejects_invalid_key_before_inner_app():
+    called = False
+
+    async def inner_app(_scope: Scope, _receive: Receive, _send: Send) -> None:
+        nonlocal called
+        called = True
+        raise AssertionError("inner app should not receive invalid skill uploads")
+
+    app = SkillUploadPreflightMiddleware(inner_app)
+    body, content_type = _multipart_body(skill_key=".system")
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/api/projects/00000000-0000-0000-0000-000000000000/skills/upload",
+            content=body,
+            headers={"Content-Type": content_type},
+        )
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": "Invalid skill_key"}
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_skill_upload_preflight_replays_valid_upload_to_inner_app():
+    seen_body = bytearray()
+
+    async def inner_app(_scope: Scope, receive: Receive, send: Send) -> None:
+        while True:
+            message: Message = await receive()
+            if message["type"] != "http.request":
+                break
+            seen_body.extend(message.get("body", b""))
+            if not message.get("more_body", False):
+                break
+        await send({"type": "http.response.start", "status": 204, "headers": []})
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+    app = SkillUploadPreflightMiddleware(inner_app)
+    body, content_type = _multipart_body(skill_key="valid-skill")
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/api/projects/00000000-0000-0000-0000-000000000000/skills/upload",
+            content=body,
+            headers={"Content-Type": content_type},
+        )
+
+    assert response.status_code == 204
+    assert bytes(seen_body) == body
+
+
+@pytest.mark.asyncio
+async def test_skill_upload_preflight_replays_when_skill_key_is_not_in_prefix():
+    called = False
+
+    async def inner_app(_scope: Scope, receive: Receive, send: Send) -> None:
+        nonlocal called
+        called = True
+        while True:
+            message: Message = await receive()
+            if message["type"] != "http.request" or not message.get("more_body", False):
+                break
+        await send({"type": "http.response.start", "status": 204, "headers": []})
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
+
+    app = SkillUploadPreflightMiddleware(inner_app)
+    body, content_type = _multipart_body(skill_key=None)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/api/projects/00000000-0000-0000-0000-000000000000/skills/upload",
+            content=body,
+            headers={"Content-Type": content_type},
+        )
+
+    assert response.status_code == 204
+    assert called is True


### PR DESCRIPTION
## Summary
- Add ASGI preflight middleware for skill upload multipart requests
- Reject invalid skill_key metadata before FastAPI parses/spools the file part
- Keep valid and unknown multipart shapes compatible by replaying buffered request bytes to the existing app
- Wire middleware into the existing stack inside CORS and before BodySizeLimit
- Add focused middleware tests for invalid rejection and valid replay

## Production context
After #209-#213, prod has no request_failed, no DB pool timeouts, and no S3/R2 errors, but old node daemons are still sending thousands of invalid /api/projects/*/skills/upload requests. FastAPI Form(pattern=...) rejects them only after multipart parsing, which keeps CPU high and floods request_validation_failed logs. #213 fixes new CLI/daemon behavior; this PR protects the backend while older clients are still running.

## Verification
- uv run ruff format app/middleware/skill_upload_preflight.py app/main.py tests/test_skill_upload_preflight.py
- uv run ruff check app/middleware/skill_upload_preflight.py app/main.py tests/test_skill_upload_preflight.py
- uv run pytest -q tests/test_skill_upload_preflight.py
- uv run python -m py_compile app/middleware/skill_upload_preflight.py app/main.py

Note: local run of tests/test_skills.py::test_malformed_skill_upload_logs_validation_reason could not connect to the local test Postgres (ConnectionRefused on 127.0.0.1); CI has the database-backed suite.