### PR TITLE
Smooth skills reconcile polling

### DIFF
--- a/backend/app/routes/skills.py
+++ b/backend/app/routes/skills.py
@@ -21,7 +21,7 @@ from sqlalchemy import func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import AuthContext, require_scope_short_session
-from app.core.database import get_session
+from app.core.database import async_session_factory, get_session
 from app.core.project import (
     project_ids_visible_to,
     resolve_default_write_project,
@@ -230,7 +230,6 @@ def _compute_file_tree_hash(tar_bytes: bytes, skill_key: str | None = None) -> s
 @router.get("")
 async def list_skills(
     auth: AuthContext = Depends(require_scope_short_session("skills:read")),
-    db: AsyncSession = Depends(get_session),
     q: str | None = Query(default=None, description="Search name / description / skill_key"),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=25, ge=1, le=200),
@@ -247,6 +246,38 @@ async def list_skills(
         ),
     ),
     if_none_match: str | None = Header(default=None, alias="If-None-Match"),
+) -> Paginated[SkillSummaryResponse]:
+    fast_response = _bound_api_key_skills_304_response(
+        auth=auth,
+        selected_project_id=project_id,
+        if_none_match=if_none_match,
+    )
+    if fast_response is not None:
+        return fast_response
+
+    async with async_session_factory() as db:
+        return await _list_skills_with_db(
+            auth=auth,
+            db=db,
+            q=q,
+            page=page,
+            page_size=page_size,
+            include_content=include_content,
+            project_id=project_id,
+            if_none_match=if_none_match,
+        )
+
+
+async def _list_skills_with_db(
+    *,
+    auth: AuthContext,
+    db: AsyncSession,
+    q: str | None,
+    page: int,
+    page_size: int,
+    include_content: bool,
+    project_id: UUID | None,
+    if_none_match: str | None,
 ) -> Paginated[SkillSummaryResponse]:
     # Collection-level ETag short-circuit: when the daemon's
     # last-seen revision matches current, return 304 with no body
@@ -285,20 +316,17 @@ async def list_skills(
     else:
         # Unscoped read: full inventory across owned + shared projects.
         visible_project_ids = await project_ids_visible_to(db, auth)
-    project_tag = str(selected_project_id) if selected_project_id is not None else "all"
-    # Short fingerprint of the visible-project set (sorted for
-    # determinism). 16 hex chars = 64 bits of collision space —
-    # one in ~10^19, well past the realistic distinct-set count
-    # for any account.
-    visible_fingerprint = hashlib.sha256(
-        ":".join(sorted(str(s) for s in visible_project_ids)).encode()
-    ).hexdigest()[:16]
     visible_revision_fingerprint = await _visible_skills_revision_fingerprint(
         db,
         auth,
         visible_project_ids,
     )
-    etag = f'"{revision}:{project_tag}:{visible_fingerprint}:{visible_revision_fingerprint}"'
+    etag = _skills_collection_etag(
+        revision=revision,
+        selected_project_id=selected_project_id,
+        visible_project_ids=visible_project_ids,
+        visible_revision_fingerprint=visible_revision_fingerprint,
+    )
     if if_none_match is not None and if_none_match.strip() == etag:
         await db.commit()
         return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers={"ETag": etag})
@@ -438,6 +466,72 @@ async def list_skills(
     )
 
 
+def _bound_api_key_skills_304_response(
+    *,
+    auth: AuthContext,
+    selected_project_id: UUID | None,
+    if_none_match: str | None,
+) -> Response | None:
+    """Serve the hot daemon conditional-GET path without opening a DB session.
+
+    Env-bound API keys are already narrowed by the auth snapshot to exactly one
+    Agent Project (`auth.api_key_project_id`) and never see shared projects.
+    Their visible-owner revision is therefore the authenticated user's cached
+    `skills_revision`. That makes the 304 ETag fully derivable from the auth
+    context and query parameters.
+
+    Dashboard JWTs and unbound CLI keys still go through the DB-backed path so
+    shared-project owner revisions stay part of the ETag.
+    """
+    if if_none_match is None or auth.api_key_project_id is None:
+        return None
+
+    if selected_project_id is not None:
+        visible_project_ids = (
+            [selected_project_id] if selected_project_id == auth.api_key_project_id else []
+        )
+    else:
+        visible_project_ids = [auth.api_key_project_id]
+
+    visible_revision_fingerprint = (
+        _auth_user_skills_revision_fingerprint(auth) if visible_project_ids else "none"
+    )
+    etag = _skills_collection_etag(
+        revision=auth.skills_revision,
+        selected_project_id=selected_project_id,
+        visible_project_ids=visible_project_ids,
+        visible_revision_fingerprint=visible_revision_fingerprint,
+    )
+    if if_none_match.strip() != etag:
+        return None
+    return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers={"ETag": etag})
+
+
+def _skills_collection_etag(
+    *,
+    revision: int,
+    selected_project_id: UUID | None,
+    visible_project_ids: list[UUID],
+    visible_revision_fingerprint: str,
+) -> str:
+    project_tag = str(selected_project_id) if selected_project_id is not None else "all"
+    visible_fingerprint = _visible_project_fingerprint(visible_project_ids)
+    return f'"{revision}:{project_tag}:{visible_fingerprint}:{visible_revision_fingerprint}"'
+
+
+def _visible_project_fingerprint(visible_project_ids: list[UUID]) -> str:
+    # Short fingerprint of the visible-project set (sorted for determinism).
+    # 16 hex chars = 64 bits of collision space, well past the realistic
+    # distinct-set count for any account.
+    return hashlib.sha256(
+        ":".join(sorted(str(s) for s in visible_project_ids)).encode()
+    ).hexdigest()[:16]
+
+
+def _auth_user_skills_revision_fingerprint(auth: AuthContext) -> str:
+    return hashlib.sha256(f"{auth.user_id}:{auth.skills_revision}".encode()).hexdigest()[:16]
+
+
 async def _resolve_legacy_skill(
     db: AsyncSession,
     auth: AuthContext,
@@ -485,7 +579,7 @@ async def _visible_skills_revision_fingerprint(
     if auth.api_key_project_id is not None and set(visible_project_ids) == {
         auth.api_key_project_id
     }:
-        return hashlib.sha256(f"{auth.user_id}:{auth.skills_revision}".encode()).hexdigest()[:16]
+        return _auth_user_skills_revision_fingerprint(auth)
 
     from app.models.project import Project
     from app.models.user import User

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import io
 import logging
 import tarfile
+import uuid
 
 import httpx
 import pytest
@@ -674,6 +675,55 @@ async def test_list_skills_etag_binds_revision_and_project(
         f"/api/skills?project_id={project_b}", headers={"If-None-Match": forged}
     )
     assert r_forged.status_code == 200, r_forged.text
+
+
+@pytest.mark.asyncio
+async def test_bound_api_key_matching_skills_etag_304_skips_list_db_session(
+    client: httpx.AsyncClient,
+    seed_user,
+    project_id: str,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Hot daemon reconcile path: a matching bound-key ETag should not open
+    the list handler's DB session.
+
+    Auth has already resolved the env-bound API key to exactly one Agent
+    Project. For that caller shape the collection ETag is derivable from the
+    auth snapshot, so the 304 path should avoid the DB-backed project
+    visibility and listing work entirely.
+    """
+    from app.core.auth import AuthContext, get_auth_short_session
+    from app.main import app
+    from app.models.api_key import ApiKey
+    from app.routes import skills as skills_route
+
+    project_uuid = uuid.UUID(project_id)
+
+    async def _override_get_auth() -> AuthContext:
+        return AuthContext(
+            user=seed_user,
+            api_key=ApiKey(user_id=seed_user.id, environment_id=uuid.uuid4()),
+            api_key_project_id=project_uuid,
+        )
+
+    app.dependency_overrides[get_auth_short_session] = _override_get_auth
+
+    first = await client.get(f"/api/skills?project_id={project_id}")
+    assert first.status_code == 200, first.text
+    etag = first.headers.get("ETag")
+    assert etag
+
+    def _fail_session_factory():
+        raise AssertionError("matching bound-key skills ETag opened a DB session")
+
+    monkeypatch.setattr(skills_route, "async_session_factory", _fail_session_factory)
+
+    cached = await client.get(
+        f"/api/skills?project_id={project_id}",
+        headers={"If-None-Match": etag},
+    )
+    assert cached.status_code == 304, cached.text
+    assert cached.headers.get("ETag") == etag
 
 
 @pytest.mark.asyncio

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -12,6 +12,7 @@ import {
 	isAuthFailure,
 	isOversizedUploadError,
 	lastSyncErrorForSseReconnect,
+	reconcileDelayMs,
 	releaseInFlight,
 	rememberPendingSkillUploadEcho,
 	resolveOwningSkillKey,
@@ -78,6 +79,14 @@ describe("live-sync transient failure classification", () => {
 		expect(classifyHeartbeatFailure(1)).toBe("transient");
 		expect(classifyHeartbeatFailure(3)).toBe("transient");
 		expect(classifyHeartbeatFailure(4)).toBe("sustained");
+	});
+});
+
+describe("reconcileDelayMs", () => {
+	it("spreads 60s reconcile polls across a bounded jitter window", () => {
+		expect(reconcileDelayMs(() => 0)).toBe(45_000);
+		expect(reconcileDelayMs(() => 0.5)).toBe(60_000);
+		expect(reconcileDelayMs(() => 1)).toBe(75_000);
 	});
 });
 

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -80,6 +80,7 @@ const HEARTBEAT_INTERVAL_MS = 30_000;
 // (dashboard install / delete) propagate to the machine; 60s is
 // the worst-case lag a user sees after acting on the dashboard.
 const RECONCILE_INTERVAL_MS = 60_000;
+const RECONCILE_JITTER_MS = 15_000;
 const LAUNCHD_DAEMON_LABEL = "ai.clawdi.serve";
 
 function removeLaunchdDaemonSupervision(agentType: string): void {
@@ -1876,7 +1877,7 @@ async function reconcileLoop(
 	onAuthFailure: (origin: string) => void,
 ): Promise<void> {
 	while (!abort.aborted) {
-		await sleep(RECONCILE_INTERVAL_MS, abort);
+		await sleep(reconcileDelayMs(), abort);
 		if (abort.aborted) return;
 		try {
 			await reconcileFromCloud(
@@ -1903,6 +1904,11 @@ async function reconcileLoop(
 			log.warn("engine.reconcile_failed", { error: toErrorMessage(e) });
 		}
 	}
+}
+
+export function reconcileDelayMs(random: () => number = Math.random): number {
+	const offset = (random() - 0.5) * 2 * RECONCILE_JITTER_MS;
+	return Math.round(RECONCILE_INTERVAL_MS + offset);
 }
 
 async function reconcileFromCloud(


### PR DESCRIPTION
## Summary
- add bounded jitter to CLI skills reconcile polling so daemons do not herd on the same 60s boundary
- serve env-bound API key `/api/skills` matching-ETag 304 responses before opening the list route DB session
- add regression coverage for reconcile jitter and the bound-key 304 DB-session skip

## Verification
- `bun test packages/cli/src/serve/sync-engine.test.ts`
- `bun run check`
- `bun run typecheck`
- `cd backend && uv run ruff check app/routes/skills.py tests/test_skills.py && uv run ruff format --check app/routes/skills.py tests/test_skills.py`

Backend DB integration test note: `cd backend && uv run pytest tests/test_skills.py -k 'etag or transaction'` could not run locally because the local Postgres test port refused connection (`127.0.0.1:34703`); CI should run it against the provisioned Postgres service.
