### PR TITLE
Disable backend access logs

### DIFF
--- a/backend/app/runtime_entrypoint.py
+++ b/backend/app/runtime_entrypoint.py
@@ -17,7 +17,8 @@ def main() -> None:
             [
                 "sh",
                 "-c",
-                "alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000",
+                "alembic upgrade head && exec uvicorn app.main:app "
+                "--host 0.0.0.0 --port 8000 --no-access-log",
             ]
         )
     if role == CHANNELS_WORKER_ROLE:

--- a/backend/tests/test_runtime_entrypoint.py
+++ b/backend/tests/test_runtime_entrypoint.py
@@ -24,7 +24,8 @@ def test_runtime_entrypoint_defaults_to_api_role(monkeypatch):
     assert exc.value.args_list == [
         "sh",
         "-c",
-        "alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000",
+        "alembic upgrade head && exec uvicorn app.main:app "
+        "--host 0.0.0.0 --port 8000 --no-access-log",
     ]
 
 


### PR DESCRIPTION
## Summary
- start production uvicorn with `--no-access-log`
- keep structured slow/error request logs from `RequestTimingMiddleware`
- update runtime entrypoint coverage

## Verification
- `cd backend && uv run pytest tests/test_runtime_entrypoint.py`
- `cd backend && uv run ruff check app/runtime_entrypoint.py tests/test_runtime_entrypoint.py && uv run ruff format --check app/runtime_entrypoint.py tests/test_runtime_entrypoint.py`
