### PR TITLE
Optimize daemon control-plane cadence

### DIFF
--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -83,6 +83,7 @@ _MAX_AGENT_AVATAR_BYTES = 2 * 1024 * 1024
 _AGENT_AVATAR_PREFIX = "agent-avatars/"
 _AGENT_AVATAR_KEY_RE = re.compile(r"^agent-avatars/[0-9a-f]{32}\.(png|jpg|webp)$")
 _RUNTIME_OBSERVED_STALE_AFTER = timedelta(seconds=90)
+_HEARTBEAT_FRESHNESS_WRITE_INTERVAL = timedelta(seconds=40)
 _HOSTED_MANAGED_AGENT_TYPES = {"codex", "hermes", "openclaw"}
 _LEGACY_HOSTED_MACHINE_NAME_RE = re.compile(r"^v2-hosted-[a-f0-9]{6,16}$")
 _MANUAL_SESSION_SUMMARY_FILTER = text(
@@ -511,12 +512,18 @@ async def reorder_environments(
     ]
 
 
-@router.get("/api/environments/{environment_id}", response_model=EnvironmentResponse)
+@router.get(
+    "/api/environments/{environment_id}",
+    response_model=EnvironmentResponse,
+    responses={status.HTTP_304_NOT_MODIFIED: {"description": "Not Modified"}},
+)
 async def get_environment(
     environment_id: UUID,
+    request: Request,
+    response: Response,
     auth: AuthContext = Depends(get_auth),
     db: AsyncSession = Depends(get_session),
-) -> EnvironmentResponse:
+) -> EnvironmentResponse | Response:
     # Bound api_keys may only fetch their own env. Without this an
     # env-A deploy key could probe sibling envs by id and read their
     # `default_project_id` — the same boundary that list_environments
@@ -524,24 +531,32 @@ async def get_environment(
     bound_env = _bound_env_id(auth)
     if bound_env is not None and environment_id != bound_env:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
-    result = await db.execute(
-        select(AgentEnvironment).where(
-            AgentEnvironment.id == environment_id,
-            AgentEnvironment.user_id == auth.user_id,
-        )
-    )
-    env = result.scalar_one_or_none()
-    if not env:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
-    state = (
+    row = (
         await db.execute(
-            select(HostedRuntimeState).where(HostedRuntimeState.environment_id == environment_id)
+            select(AgentEnvironment, HostedRuntimeState)
+            .outerjoin(
+                HostedRuntimeState,
+                HostedRuntimeState.environment_id == AgentEnvironment.id,
+            )
+            .where(
+                AgentEnvironment.id == environment_id,
+                AgentEnvironment.user_id == auth.user_id,
+            )
         )
-    ).scalar_one_or_none()
+    ).first()
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
+    env, state = row
     sibling_deployment_id = (
         None if bound_env is not None else await _hosted_deployment_id_for_machine(db, env, state)
     )
-    return _env_to_response(env, state, hosted_deployment_id=sibling_deployment_id)
+    payload = _env_to_response(env, state, hosted_deployment_id=sibling_deployment_id)
+    etag = strong_json_etag(payload.model_dump(mode="json"))
+    headers = {"ETag": etag, "Cache-Control": "private, no-cache"}
+    if if_none_match_contains(request.headers.get("if-none-match"), etag):
+        return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)
+    response.headers.update(headers)
+    return payload
 
 
 @router.patch("/api/environments/{environment_id}", response_model=EnvironmentResponse)
@@ -1156,12 +1171,14 @@ async def sync_heartbeat(
         or not env.sync_enabled
         or observed_changed
     )
-    # Even with no state change, refresh last_sync_at if the
-    # previous value is older than 30s — the dashboard freshness
-    # cutoff is 90s, so a 30s refresh keeps the badge "live"
-    # without writing on every single heartbeat.
+    # Even with no state change, refresh last_sync_at on a bounded
+    # cadence. The dashboard freshness cutoff is 90s; 40s keeps new
+    # 60s clients live while preventing old 30s clients from writing
+    # on every heartbeat.
     last = env.last_sync_at
-    needs_freshness_refresh = last is None or (now - last).total_seconds() > 30
+    needs_freshness_refresh = (
+        last is None or now - _as_utc(last) > _HEARTBEAT_FRESHNESS_WRITE_INTERVAL
+    )
     if not has_state_change and not needs_freshness_refresh:
         return
     env.last_sync_at = now

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -60,6 +60,32 @@ async def test_environments_support_conditional_get(client: httpx.AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_environment_detail_supports_conditional_get(client: httpx.AsyncClient):
+    env_id = await _register_env(client, machine_id=f"detail-etag-{uuid.uuid4().hex}")
+
+    first = await client.get(f"/api/environments/{env_id}")
+    assert first.status_code == 200, first.text
+    etag = first.headers.get("ETag")
+    assert etag
+    assert first.headers.get("Cache-Control") == "private, no-cache"
+
+    not_modified = await client.get(
+        f"/api/environments/{env_id}",
+        headers={"If-None-Match": etag},
+    )
+    assert not_modified.status_code == 304, not_modified.text
+    assert not_modified.headers.get("ETag") == etag
+
+    heartbeat = await client.post(f"/api/agents/{env_id}/sync-heartbeat", json={"queue_depth": 1})
+    assert heartbeat.status_code == 204, heartbeat.text
+
+    changed = await client.get(f"/api/environments/{env_id}", headers={"If-None-Match": etag})
+    assert changed.status_code == 200, changed.text
+    assert changed.headers.get("ETag") != etag
+    assert changed.json()["queue_depth_high_water"] == 1
+
+
+@pytest.mark.asyncio
 async def test_environments_mark_hosted_runtime_siblings(
     client: httpx.AsyncClient, db_session: AsyncSession, seed_user
 ):

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -9,9 +9,11 @@ import {
 	classifyHeartbeatFailure,
 	consumePendingSkillUploadEcho,
 	filterValidSkillKeysForSync,
+	heartbeatDelayMs,
 	isAuthFailure,
 	isOversizedUploadError,
 	lastSyncErrorForSseReconnect,
+	projectRefreshDelayMs,
 	reconcileDelayMs,
 	releaseInFlight,
 	rememberPendingSkillUploadEcho,
@@ -83,10 +85,24 @@ describe("live-sync transient failure classification", () => {
 });
 
 describe("reconcileDelayMs", () => {
-	it("spreads 60s reconcile polls across a bounded jitter window", () => {
-		expect(reconcileDelayMs(() => 0)).toBe(45_000);
-		expect(reconcileDelayMs(() => 0.5)).toBe(60_000);
-		expect(reconcileDelayMs(() => 1)).toBe(75_000);
+	it("keeps cloud reconcile on the safety-net cadence", () => {
+		expect(reconcileDelayMs(() => 0)).toBe(240_000);
+		expect(reconcileDelayMs(() => 0.5)).toBe(300_000);
+		expect(reconcileDelayMs(() => 1)).toBe(360_000);
+	});
+});
+
+describe("daemon control-plane cadences", () => {
+	it("keeps heartbeat jitter inside the dashboard freshness window", () => {
+		expect(heartbeatDelayMs(() => 0)).toBe(45_000);
+		expect(heartbeatDelayMs(() => 0.5)).toBe(60_000);
+		expect(heartbeatDelayMs(() => 1)).toBe(75_000);
+	});
+
+	it("keeps project refresh off the heartbeat cadence", () => {
+		expect(projectRefreshDelayMs(() => 0)).toBe(240_000);
+		expect(projectRefreshDelayMs(() => 0.5)).toBe(300_000);
+		expect(projectRefreshDelayMs(() => 1)).toBe(360_000);
 	});
 });
 

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -75,12 +75,20 @@ import { watchSkills } from "./watcher";
 
 type SkillSummary = components["schemas"]["SkillSummaryResponse"];
 
-const HEARTBEAT_INTERVAL_MS = 30_000;
-// Reconcile cadence. The reconcile loop is how cloud-side changes
-// (dashboard install / delete) propagate to the machine; 60s is
-// the worst-case lag a user sees after acting on the dashboard.
-const RECONCILE_INTERVAL_MS = 60_000;
-const RECONCILE_JITTER_MS = 15_000;
+const HEARTBEAT_INTERVAL_MS = 60_000;
+const HEARTBEAT_JITTER_MS = 15_000;
+// Reconcile cadence. SSE is the primary path for cloud-side changes
+// (dashboard install / delete); this loop is a safety net for missed
+// events, stale local state, or a daemon that reconnects after a quiet
+// period. Keep it off the minute-level hot path so large fleets don't
+// turn no-op 304 checks into background load.
+const RECONCILE_INTERVAL_MS = 5 * 60_000;
+const RECONCILE_JITTER_MS = 60_000;
+// Project reassignment is an administrative control-plane change,
+// not a liveness signal. Keep it off the heartbeat cadence so a
+// large daemon fleet does not double its steady-state request load.
+const PROJECT_REFRESH_INTERVAL_MS = 5 * 60_000;
+const PROJECT_REFRESH_JITTER_MS = 60_000;
 const LAUNCHD_DAEMON_LABEL = "ai.clawdi.serve";
 
 function removeLaunchdDaemonSupervision(agentType: string): void {
@@ -420,10 +428,10 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 
 	// Periodically re-fetch the env's default_project_id so a
 	// runtime reassignment (rare in v1's 1:1 model, but possible
-	// after multi-project-per-env ships) converges within one
-	// heartbeat cycle. Without refresh, the daemon would keep
-	// the boot-time value forever and silently drop SSE events
-	// for the new project. Transient fetch errors keep the
+	// after multi-project-per-env ships) eventually converges.
+	// This is intentionally slower than heartbeat: liveness needs
+	// minute-level freshness, while project reassignment is rare
+	// administrative state. Transient fetch errors keep the
 	// last-known-good value but escalate to error-level logging
 	// after STALE_PROJECT_THRESHOLD consecutive failures so a
 	// long-running project-filter outage shows up in metrics.
@@ -431,7 +439,7 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 	const refreshDefaultProjectIdLoop = async (abort: AbortSignal): Promise<void> => {
 		let consecutiveFailures = 0;
 		while (!abort.aborted) {
-			await sleep(HEARTBEAT_INTERVAL_MS, abort);
+			await sleep(projectRefreshDelayMs(), abort);
 			if (abort.aborted) return;
 			try {
 				const fresh = await fetchDefaultProjectId();
@@ -1911,6 +1919,11 @@ export function reconcileDelayMs(random: () => number = Math.random): number {
 	return Math.round(RECONCILE_INTERVAL_MS + offset);
 }
 
+export function projectRefreshDelayMs(random: () => number = Math.random): number {
+	const offset = (random() - 0.5) * 2 * PROJECT_REFRESH_JITTER_MS;
+	return Math.round(PROJECT_REFRESH_INTERVAL_MS + offset);
+}
+
 async function reconcileFromCloud(
 	opts: EngineOpts,
 	api: ApiClient,
@@ -2257,16 +2270,19 @@ async function heartbeatLoop(
 	// happen on the normal interval.
 	await send();
 	while (!abort.aborted) {
-		// Per-cycle ±5s jitter so 10k daemons started by the same
-		// rollout don't all heartbeat in the same wall-clock
-		// second. Without jitter the backend sees a 30s sawtooth
-		// at every interval boundary; with jitter the load
-		// smooths into a flat ~33 writes/sec.
-		const jitter = (Math.random() - 0.5) * 10_000;
-		await sleep(HEARTBEAT_INTERVAL_MS + jitter, abort);
+		// Per-cycle jitter so daemons started by the same rollout
+		// don't all heartbeat in the same wall-clock second. The
+		// upper bound stays inside the dashboard's 90s freshness
+		// window after the eager first beat.
+		await sleep(heartbeatDelayMs(), abort);
 		if (abort.aborted) return;
 		await send();
 	}
+}
+
+export function heartbeatDelayMs(random: () => number = Math.random): number {
+	const offset = (random() - 0.5) * 2 * HEARTBEAT_JITTER_MS;
+	return Math.round(HEARTBEAT_INTERVAL_MS + offset);
 }
 
 async function touchHealthFile(agentType: string): Promise<void> {

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -6771,6 +6771,13 @@ export interface operations {
                     "application/json": components["schemas"]["EnvironmentResponse"];
                 };
             };
+            /** @description Not Modified */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation Error */
             422: {
                 headers: {


### PR DESCRIPTION
## Summary
- move daemon heartbeat to a 60s cadence with bounded jitter inside the dashboard freshness window
- move cloud skills reconcile and default-project refresh to 5-minute safety-net cadences
- reduce legacy 30s heartbeat write churn with a 40s backend freshness threshold
- make `GET /api/environments/{id}` cheaper with a single env/runtime query and conditional ETag support

## Prod signal before fix
120s backend sample after access logs were disabled:
- CPU around 96% on the backend container
- `request_failed=0`, `pool_timeouts=0`, S3/R2 errors `0`
- slow logs: `/api/environments/{id}` ~1041, `/sync-heartbeat` ~805, `/api/skills` ~580

This points at daemon control-plane request volume rather than DB pool exhaustion or object-store errors.

## Verification
- `bun test packages/cli/src/serve/sync-engine.test.ts`
- `bun run check`
- `bun run typecheck`
- `cd backend && uv run ruff check app/routes/sessions.py tests/test_sessions.py`
- `cd backend && uv run python -m py_compile app/routes/sessions.py`
- `cd backend && uv run python scripts/check_generated_api.py`

Backend focused pytest was attempted but local test Postgres was unavailable (`ConnectionRefusedError: 127.0.0.1:34703`) before test setup completed; no test assertion failed.
