### PR TITLE
Release CLI control-plane cadence fix

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -59,7 +59,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.26",
+      "version": "0.12.10-beta.27",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.26",
+	"version": "0.12.10-beta.27",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/tests/commands/update.test.ts
+++ b/packages/cli/tests/commands/update.test.ts
@@ -258,13 +258,13 @@ describe("daemonAutoUpdateOnce", () => {
 				path: "/clawdi",
 				response: () =>
 					jsonResponse({
-						"dist-tags": { latest: "0.12.9", beta: "0.12.10-beta.26" },
+						"dist-tags": { latest: "0.12.9", beta: "0.12.10-beta.27" },
 					}),
 			},
 		]);
 		try {
 			const result = await daemonAutoUpdateOnce({
-				currentVersion: "0.12.10-beta.25",
+				currentVersion: "0.12.10-beta.26",
 				installer: "npm",
 				installRunner: async (installer, args) => {
 					calls.push({ installer, args });


### PR DESCRIPTION
## Summary
- bump CLI package from `0.12.10-beta.26` to `0.12.10-beta.27` so the daemon cadence changes from #218 actually publish to npm
- update the beta auto-update test fixture to exercise `0.12.10-beta.26 -> 0.12.10-beta.27`

## Why
#218 deployed the backend and merged the CLI cadence changes, but the Publish CLI workflow skipped because `0.12.10-beta.26` already exists on npm. Without a version bump, existing beta daemons cannot auto-update into the lower request cadence.

## Verification
- `bun test packages/cli/tests/commands/update.test.ts packages/cli/src/serve/sync-engine.test.ts`
- `bun run check`
- `bun run --cwd packages/cli typecheck`
