### PR TITLE
Fix hosted terminal theme and websocket fallback

### DIFF
--- a/apps/web/src/hosted/agents/hosted-terminal-panel.test.ts
+++ b/apps/web/src/hosted/agents/hosted-terminal-panel.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import {
+	terminalConnectionClosedMessage,
+	terminalWebSocketTarget,
+} from "@/hosted/agents/hosted-terminal-panel";
+
+describe("terminalWebSocketTarget", () => {
+	test("moves a fragment token into a websocket subprotocol by default", () => {
+		const target = terminalWebSocketTarget(
+			"wss://api.example.test/v2/deployments/hdep_123/terminal/ws#token=header.payload.signature",
+		);
+
+		expect(target.url).toBe("wss://api.example.test/v2/deployments/hdep_123/terminal/ws");
+		expect(target.protocols).toEqual(["tty", "clawdi-terminal.header.payload.signature"]);
+		expect(target.authMode).toBe("subprotocol");
+		expect(target.token).toBe("header.payload.signature");
+	});
+
+	test("can fall back to query-token auth when subprotocol auth is not viable", () => {
+		const target = terminalWebSocketTarget(
+			"wss://api.example.test/v2/deployments/hdep_123/terminal/ws#token=header.payload.signature",
+			"query",
+		);
+
+		expect(target.url).toBe(
+			"wss://api.example.test/v2/deployments/hdep_123/terminal/ws?token=header.payload.signature",
+		);
+		expect(target.protocols).toEqual(["tty"]);
+		expect(target.authMode).toBe("query");
+	});
+
+	test("preserves existing query params when adding the fallback token", () => {
+		const target = terminalWebSocketTarget(
+			"wss://api.example.test/v2/deployments/hdep_123/terminal/ws?trace=1#token=tok",
+			"query",
+		);
+
+		expect(target.url).toBe(
+			"wss://api.example.test/v2/deployments/hdep_123/terminal/ws?trace=1&token=tok",
+		);
+		expect(target.protocols).toEqual(["tty"]);
+	});
+});
+
+describe("terminalConnectionClosedMessage", () => {
+	test("formats close code without leaking control characters from reason", () => {
+		const event = new CloseEvent("close", {
+			code: 1008,
+			reason: "policy\u0000violation",
+		});
+
+		expect(terminalConnectionClosedMessage(event)).toBe(
+			"terminal connection closed: code 1008, policy violation",
+		);
+	});
+});

--- a/apps/web/src/hosted/agents/hosted-terminal-panel.tsx
+++ b/apps/web/src/hosted/agents/hosted-terminal-panel.tsx
@@ -2,49 +2,168 @@
 
 import type { FitAddon as FitAddonType } from "@xterm/addon-fit";
 import type { Terminal as XTerm } from "@xterm/xterm";
+import { useTheme } from "next-themes";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
 
 const TTYD_OUTPUT = "0";
 const TTYD_INPUT = "0";
 const TTYD_RESIZE = "1";
 const TERMINAL_TOKEN_PROTOCOL_PREFIX = "clawdi-terminal.";
+const TERMINAL_NOTICE_STYLE = "\u001b[90m";
+const TERMINAL_RESET_STYLE = "\u001b[0m";
+const TERMINAL_CLOSE_REASON_MAX_LENGTH = 120;
 
 export type HostedTerminalStatus = "connecting" | "connected" | "disconnected";
+type TerminalAuthMode = "subprotocol" | "query";
+type TerminalThemeMode = "dark" | "light";
+
+type TerminalWebSocketTarget = {
+	url: string;
+	protocols: string[];
+	token: string | null;
+	authMode: TerminalAuthMode;
+};
 
 type HostedTerminalPanelProps = {
 	websocketUrl: string;
 	onStatusChange?: (status: HostedTerminalStatus) => void;
 };
 
-function terminalWebSocketTarget(websocketUrl: string): { url: string; protocols: string[] } {
+const TERMINAL_THEMES = {
+	dark: {
+		background: "#0a0a0a",
+		foreground: "#e4e4e7",
+		cursor: "#e4e4e7",
+		selectionBackground: "#27272a",
+		black: "#18181b",
+		red: "#f87171",
+		green: "#34d399",
+		yellow: "#fbbf24",
+		blue: "#60a5fa",
+		magenta: "#c084fc",
+		cyan: "#22d3ee",
+		white: "#e4e4e7",
+		brightBlack: "#71717a",
+		brightRed: "#fca5a5",
+		brightGreen: "#86efac",
+		brightYellow: "#fde68a",
+		brightBlue: "#93c5fd",
+		brightMagenta: "#d8b4fe",
+		brightCyan: "#67e8f9",
+		brightWhite: "#fafafa",
+	},
+	light: {
+		background: "#ffffff",
+		foreground: "#18181b",
+		cursor: "#18181b",
+		selectionBackground: "#d4d4d8",
+		black: "#27272a",
+		red: "#dc2626",
+		green: "#059669",
+		yellow: "#ca8a04",
+		blue: "#2563eb",
+		magenta: "#9333ea",
+		cyan: "#0891b2",
+		white: "#f4f4f5",
+		brightBlack: "#71717a",
+		brightRed: "#ef4444",
+		brightGreen: "#10b981",
+		brightYellow: "#eab308",
+		brightBlue: "#3b82f6",
+		brightMagenta: "#a855f7",
+		brightCyan: "#06b6d4",
+		brightWhite: "#ffffff",
+	},
+} as const;
+
+export function terminalWebSocketTarget(
+	websocketUrl: string,
+	authMode: TerminalAuthMode = "subprotocol",
+): TerminalWebSocketTarget {
 	const protocols = ["tty"];
 	try {
 		const parsed = new URL(websocketUrl);
-		const token = new URLSearchParams(parsed.hash.replace(/^#/, "")).get("token");
-		if (!token) return { url: websocketUrl, protocols };
+		const queryToken = parsed.searchParams.get("token");
+		const fragmentToken = new URLSearchParams(parsed.hash.replace(/^#/, "")).get("token");
+		const token = queryToken || fragmentToken;
 		parsed.hash = "";
+		if (!token) return { url: parsed.toString(), protocols, token: null, authMode };
+		if (queryToken || authMode === "query") {
+			parsed.searchParams.set("token", token);
+			return {
+				url: parsed.toString(),
+				protocols,
+				token,
+				authMode: "query",
+			};
+		}
 		return {
 			url: parsed.toString(),
 			protocols: [...protocols, `${TERMINAL_TOKEN_PROTOCOL_PREFIX}${token}`],
+			token,
+			authMode: "subprotocol",
 		};
 	} catch {
-		return { url: websocketUrl, protocols };
+		return { url: websocketUrl, protocols, token: null, authMode };
+	}
+}
+
+function sanitizedCloseReason(reason: string): string {
+	return Array.from(reason, (char) => {
+		const code = char.charCodeAt(0);
+		return code < 32 || code === 127 ? " " : char;
+	})
+		.join("")
+		.trim()
+		.slice(0, TERMINAL_CLOSE_REASON_MAX_LENGTH);
+}
+
+export function terminalConnectionClosedMessage(event: CloseEvent): string {
+	const reason = sanitizedCloseReason(event.reason);
+	return `terminal connection closed: code ${event.code}${reason ? `, ${reason}` : ""}`;
+}
+
+function writeTerminalNotice(term: XTerm, message: string) {
+	term.write(`\r\n${TERMINAL_NOTICE_STYLE}[${message}]${TERMINAL_RESET_STYLE}\r\n`);
+}
+
+function applyTerminalDomTheme(container: HTMLDivElement | null, mode: TerminalThemeMode) {
+	if (!container) return;
+	const background = TERMINAL_THEMES[mode].background;
+	container.style.backgroundColor = background;
+	for (const element of container.querySelectorAll<HTMLElement>(
+		".xterm, .xterm-viewport, .xterm-screen",
+	)) {
+		element.style.backgroundColor = background;
 	}
 }
 
 export function HostedTerminalPanel({ websocketUrl, onStatusChange }: HostedTerminalPanelProps) {
+	const { resolvedTheme } = useTheme();
 	const containerRef = useRef<HTMLDivElement>(null);
 	const termRef = useRef<XTerm | null>(null);
 	const fitRef = useRef<FitAddonType | null>(null);
 	const wsRef = useRef<WebSocket | null>(null);
 	const cleanupRef = useRef<(() => void) | null>(null);
+	const terminalThemeMode: TerminalThemeMode = resolvedTheme === "dark" ? "dark" : "light";
+	const terminalTheme = TERMINAL_THEMES[terminalThemeMode];
+	const themeRef = useRef(terminalTheme);
+	const themeModeRef = useRef(terminalThemeMode);
 	const [status, setStatus] = useState<HostedTerminalStatus>("connecting");
-	const { url: wsUrl, protocols } = terminalWebSocketTarget(websocketUrl);
-	const wsProtocols = protocols.join(",");
 
 	useEffect(() => {
 		onStatusChange?.(status);
 	}, [onStatusChange, status]);
+
+	useEffect(() => {
+		themeRef.current = terminalTheme;
+		themeModeRef.current = terminalThemeMode;
+		if (termRef.current) {
+			termRef.current.options.theme = terminalTheme;
+		}
+		applyTerminalDomTheme(containerRef.current, terminalThemeMode);
+	}, [terminalTheme, terminalThemeMode]);
 
 	const connect = useCallback(async () => {
 		cleanupRef.current?.();
@@ -62,12 +181,7 @@ export function HostedTerminalPanel({ websocketUrl, onStatusChange }: HostedTerm
 		const term = new Terminal({
 			fontSize: 14,
 			fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace",
-			theme: {
-				background: "#0a0a0a",
-				foreground: "#e4e4e7",
-				cursor: "#e4e4e7",
-				selectionBackground: "#27272a",
-			},
+			theme: themeRef.current,
 			cursorBlink: true,
 			allowProposedApi: true,
 		});
@@ -76,49 +190,80 @@ export function HostedTerminalPanel({ websocketUrl, onStatusChange }: HostedTerm
 		term.loadAddon(fitAddon);
 		term.loadAddon(new WebLinksAddon());
 		term.open(container);
+		applyTerminalDomTheme(container, themeModeRef.current);
 		fitAddon.fit();
 
 		termRef.current = term;
 		fitRef.current = fitAddon;
 		setStatus("connecting");
 
-		const ws = new WebSocket(wsUrl, wsProtocols.split(","));
-		ws.binaryType = "arraybuffer";
-		wsRef.current = ws;
 		let disposed = false;
 
-		ws.onopen = () => {
-			if (disposed) return;
-			setStatus("connected");
-			ws.send(JSON.stringify({ AuthToken: "", columns: term.cols, rows: term.rows }));
-		};
-
-		ws.onmessage = (ev) => {
-			if (disposed) return;
-			const data =
-				ev.data instanceof ArrayBuffer ? new TextDecoder().decode(ev.data) : (ev.data as string);
-			if (data.length === 0) return;
-			if (data[0] === TTYD_OUTPUT) {
-				term.write(data.slice(1));
+		const openWebSocket = (target: TerminalWebSocketTarget) => {
+			let ws: WebSocket;
+			let opened = false;
+			try {
+				ws = new WebSocket(target.url, target.protocols);
+			} catch {
+				if (target.authMode === "subprotocol" && target.token) {
+					writeTerminalNotice(term, "terminal websocket handshake failed; retrying");
+					openWebSocket(terminalWebSocketTarget(websocketUrl, "query"));
+					return;
+				}
+				setStatus("disconnected");
+				writeTerminalNotice(term, "terminal websocket could not be opened");
+				return;
 			}
+			ws.binaryType = "arraybuffer";
+			wsRef.current = ws;
+
+			ws.onopen = () => {
+				if (disposed) return;
+				opened = true;
+				setStatus("connected");
+				ws.send(JSON.stringify({ AuthToken: "", columns: term.cols, rows: term.rows }));
+			};
+
+			ws.onmessage = (ev) => {
+				if (disposed) return;
+				const data =
+					ev.data instanceof ArrayBuffer ? new TextDecoder().decode(ev.data) : (ev.data as string);
+				if (data.length === 0) return;
+				if (data[0] === TTYD_OUTPUT) {
+					term.write(data.slice(1));
+				}
+			};
+
+			ws.onclose = (event) => {
+				if (disposed) return;
+				if (wsRef.current === ws) {
+					wsRef.current = null;
+				}
+				if (!opened && target.authMode === "subprotocol" && target.token) {
+					writeTerminalNotice(term, "terminal websocket handshake closed; retrying");
+					setStatus("connecting");
+					openWebSocket(terminalWebSocketTarget(websocketUrl, "query"));
+					return;
+				}
+				setStatus("disconnected");
+				writeTerminalNotice(term, terminalConnectionClosedMessage(event));
+			};
+			ws.onerror = () => {
+				if (!disposed) setStatus("disconnected");
+			};
 		};
 
-		ws.onclose = () => {
-			if (disposed) return;
-			setStatus("disconnected");
-			term.write("\r\n\u001b[90m[terminal connection closed]\u001b[0m\r\n");
-		};
-		ws.onerror = () => {
-			if (!disposed) setStatus("disconnected");
-		};
+		openWebSocket(terminalWebSocketTarget(websocketUrl));
 
 		term.onData((data) => {
-			if (ws.readyState === WebSocket.OPEN) {
+			const ws = wsRef.current;
+			if (ws?.readyState === WebSocket.OPEN) {
 				ws.send(TTYD_INPUT + data);
 			}
 		});
 		term.onResize(({ cols, rows }) => {
-			if (ws.readyState === WebSocket.OPEN) {
+			const ws = wsRef.current;
+			if (ws?.readyState === WebSocket.OPEN) {
 				ws.send(TTYD_RESIZE + JSON.stringify({ columns: cols, rows }));
 			}
 		});
@@ -129,7 +274,7 @@ export function HostedTerminalPanel({ websocketUrl, onStatusChange }: HostedTerm
 		const cleanup = () => {
 			disposed = true;
 			resizeObserver.disconnect();
-			ws.close();
+			wsRef.current?.close();
 			term.dispose();
 			termRef.current = null;
 			fitRef.current = null;
@@ -137,13 +282,17 @@ export function HostedTerminalPanel({ websocketUrl, onStatusChange }: HostedTerm
 		};
 		cleanupRef.current = cleanup;
 		return cleanup;
-	}, [wsUrl, wsProtocols]);
+	}, [websocketUrl]);
 
 	useEffect(() => {
 		let cancelled = false;
-		connect().then((fn) => {
-			if (cancelled) fn?.();
-		});
+		connect()
+			.then((fn) => {
+				if (cancelled) fn?.();
+			})
+			.catch(() => {
+				if (!cancelled) setStatus("disconnected");
+			});
 		return () => {
 			cancelled = true;
 			cleanupRef.current?.();
@@ -153,7 +302,13 @@ export function HostedTerminalPanel({ websocketUrl, onStatusChange }: HostedTerm
 
 	return (
 		<div data-hosted="true" className="flex min-h-0 flex-1 flex-col">
-			<div ref={containerRef} className="min-h-0 flex-1 bg-[#0a0a0a] p-1" />
+			<div
+				ref={containerRef}
+				className={cn(
+					"min-h-0 flex-1 p-1 transition-colors",
+					terminalThemeMode === "dark" ? "bg-[#0a0a0a]" : "bg-background",
+				)}
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- Make the hosted terminal xterm palette follow the app light/dark theme, including the xterm viewport background.
- Retry once with query-token auth when the websocket closes before opening with subprotocol auth.
- Show sanitized terminal close codes in the terminal output and cover token handling with tests.

## Verification
- bun run check
- bun run typecheck
- bun test apps/web/src/hosted/agents/hosted-terminal-panel.test.ts apps/web/src/hosted/runtimes.test.ts apps/web/src/hosted/agent-identity.test.ts apps/web/src/hosted/billing/deployment-links.test.ts
- Playwright local mock: terminal auto-connects and dark/light viewport backgrounds switch correctly