### PR TITLE
Fix hosted terminal responsiveness and runtime command shims

### DIFF
--- a/apps/web/src/hosted/agents/hosted-terminal-panel.tsx
+++ b/apps/web/src/hosted/agents/hosted-terminal-panel.tsx
@@ -175,7 +175,6 @@ export function HostedTerminalPanel({ websocketUrl, onStatusChange }: HostedTerm
 		term.loadAddon(fitAddon);
 		term.loadAddon(new WebLinksAddon());
 		term.open(container);
-		fitAddon.fit();
 		term.focus();
 
 		termRef.current = term;
@@ -183,6 +182,22 @@ export function HostedTerminalPanel({ websocketUrl, onStatusChange }: HostedTerm
 		setStatus("connecting");
 
 		let disposed = false;
+		let fitFrame: number | null = null;
+		const fitNow = () => {
+			if (fitFrame !== null) {
+				window.cancelAnimationFrame(fitFrame);
+				fitFrame = null;
+			}
+			if (!disposed) fitAddon.fit();
+		};
+		const scheduleFit = () => {
+			if (fitFrame !== null) return;
+			fitFrame = window.requestAnimationFrame(() => {
+				fitFrame = null;
+				if (!disposed) fitAddon.fit();
+			});
+		};
+		fitNow();
 
 		const openWebSocket = (target: TerminalWebSocketTarget) => {
 			let ws: WebSocket;
@@ -253,13 +268,17 @@ export function HostedTerminalPanel({ websocketUrl, onStatusChange }: HostedTerm
 			}
 		});
 
-		const resizeObserver = new ResizeObserver(() => fitAddon.fit());
+		const resizeObserver = new ResizeObserver(scheduleFit);
 		resizeObserver.observe(container);
 		const focusTerminal = () => term.focus();
 		container.addEventListener("pointerdown", focusTerminal);
 
 		const cleanup = () => {
 			disposed = true;
+			if (fitFrame !== null) {
+				window.cancelAnimationFrame(fitFrame);
+				fitFrame = null;
+			}
 			resizeObserver.disconnect();
 			container.removeEventListener("pointerdown", focusTerminal);
 			wsRef.current?.close();

--- a/bun.lock
+++ b/bun.lock
@@ -62,7 +62,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.27",
+      "version": "0.12.10-beta.28",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.27",
+	"version": "0.12.10-beta.28",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -43,6 +43,8 @@ import {
 	type RuntimeRunConfigRead,
 	type RuntimeRunInvocation,
 	readRuntimeRunConfigForCommand,
+	runtimeCommandShimDir,
+	withoutPathEntry,
 } from "../runtime/run-config";
 
 interface RunOpts {
@@ -90,8 +92,9 @@ export async function run(
 	const baseProcessEnv = { ...process.env };
 	const hostedGenericRun = hostedGenericRunInvocation(args, baseProcessEnv);
 	if (hostedRuntimeRun.status === "ok" && !requiresCloudResolution(opts)) {
+		const paths = getRuntimePaths({ mode: "hosted" });
 		await spawnRuntimeInvocation(
-			buildRuntimeRunInvocation(hostedRuntimeRun, args, baseProcessEnv),
+			buildRuntimeRunInvocation(hostedRuntimeRun, args, baseProcessEnv, paths),
 			spawnImpl,
 			brokerFactory,
 		);
@@ -191,8 +194,9 @@ export async function run(
 		detectRuntimeMode() === "hosted" ? {} : await resolveManagedAiProviderEnv(spawnEnv);
 	const childEnv = { ...spawnEnv, ...managedAiProviderEnv };
 	if (hostedRuntimeRun.status === "ok") {
+		const paths = getRuntimePaths({ mode: "hosted" });
 		await spawnRuntimeInvocation(
-			buildRuntimeRunInvocation(hostedRuntimeRun, args, childEnv),
+			buildRuntimeRunInvocation(hostedRuntimeRun, args, childEnv, paths),
 			spawnImpl,
 			brokerFactory,
 		);
@@ -274,18 +278,21 @@ function hostedGenericRunInvocation(
 	const [command, ...commandArgs] = args;
 	if (!command) return null;
 	const paths = getRuntimePaths({ mode: "hosted" });
-	if (!existsSync(paths.mitmProfileBundle)) return null;
+	const mitmProfileBundle = existsSync(paths.mitmProfileBundle) ? paths.mitmProfileBundle : null;
 	return {
 		runtime: "generic",
 		command,
 		args: commandArgs,
 		cwd: process.cwd(),
 		env: buildMitmBrokerEnv({
-			env: baseEnv,
-			profileBundlePath: paths.mitmProfileBundle,
+			env: {
+				...baseEnv,
+				PATH: withoutPathEntry(baseEnv.PATH ?? "", runtimeCommandShimDir(paths)),
+			},
+			profileBundlePath: mitmProfileBundle,
 			secretFile: paths.managedSecretFile,
 		}),
-		configPath: paths.mitmProfileBundle,
+		configPath: mitmProfileBundle ?? paths.managedConfig,
 	};
 }
 

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { mitmProfileInputBundleSchema } from "./mitm-profiles";
-import { runtimeRunSettingsSchema } from "./run-config";
+import { runtimeNameSchema, runtimeRunSettingsSchema } from "./run-config";
 
 export const RUNTIME_DESIRED_STATE_SCHEMA_VERSION = "clawdi.runtimeDesiredState.v1";
 
@@ -49,7 +49,7 @@ export const DEFAULT_CLAWDI_CLI_POLICY = {
 
 const liveSyncAgentSchema = z
 	.object({
-		agentType: z.enum(["openclaw", "hermes", "codex"]),
+		agentType: runtimeNameSchema,
 		environmentId: z.string().min(1),
 	})
 	.strict();
@@ -87,7 +87,7 @@ const runtimeDesiredStateShape = {
 		})
 		.strict(),
 	clawdiCli: cliPayloadPolicySchema.optional(),
-	runtimes: z.record(z.string().min(1), runtimeSchema),
+	runtimes: z.record(runtimeNameSchema, runtimeSchema),
 	projection: runtimeProjectionSchema.optional(),
 	mitmProfiles: mitmProfileInputBundleSchema.optional(),
 	liveSync: liveSyncSchema.optional(),
@@ -168,7 +168,7 @@ export const hostedRuntimeManifestSchema = z
 				path: ["apiUrl"],
 			}),
 		clawdiCli: cliPayloadPolicySchema.optional(),
-		runtimes: z.record(z.string().min(1), hostedRuntimeEntrySchema),
+		runtimes: z.record(runtimeNameSchema, hostedRuntimeEntrySchema),
 		providers: z
 			.record(
 				z.string().min(1),

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -13,7 +13,7 @@ import {
 	type RuntimeManifest,
 } from "./manifest-contract";
 import type { RuntimePaths } from "./paths";
-import type { RuntimeRunSettings } from "./run-config";
+import { isSupportedRuntimeName, type RuntimeRunSettings } from "./run-config";
 import { UI_ACCESS_TOKEN_ENV } from "./ui-bridge";
 
 export interface RuntimeManifestLoad {
@@ -499,15 +499,16 @@ function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): Runtime
 				{
 					enabled: runtime.enabled,
 					updateChannel: runtime.install?.channel,
-					install: runtime.enabled
-						? {
-								authority: "official" as const,
-								method: "official-installer" as const,
-								url: OFFICIAL_INSTALL_URLS[name] ?? "",
-								home: runtime.paths?.home || home,
-								args: runtime.install?.args ?? OFFICIAL_INSTALL_ARGS[name] ?? [],
-							}
-						: undefined,
+					install:
+						runtime.enabled && OFFICIAL_INSTALL_URLS[name]
+							? {
+									authority: "official" as const,
+									method: "official-installer" as const,
+									url: OFFICIAL_INSTALL_URLS[name] ?? "",
+									home: runtime.paths?.home || home,
+									args: runtime.install?.args ?? OFFICIAL_INSTALL_ARGS[name] ?? [],
+								}
+							: undefined,
 					run: hostedRuntimeRunSettings(runtime.run, runtime.paths?.workspace, workspaceRoot),
 				},
 			]),
@@ -629,14 +630,25 @@ function validateManifestSemantics(manifest: RuntimeManifest, paths: RuntimePath
 	}
 	for (const [name, runtime] of Object.entries(manifest.runtimes)) {
 		if (!runtime.enabled) continue;
-		if (name !== "openclaw" && name !== "hermes") {
-			errors.push(`runtime ${name} is not supported by the hosted runtime simulator`);
+		const runCommand = runtime.run?.command?.trim();
+		if (!isSupportedRuntimeName(name)) {
+			if (runtime.install) {
+				errors.push(
+					`runtime ${name} install metadata is not supported by this Clawdi CLI; provide run.command or upgrade the CLI`,
+				);
+			}
+			if (!runCommand) {
+				errors.push(
+					`runtime ${name} is not supported by this Clawdi CLI; provide run.command or upgrade the CLI`,
+				);
+			}
 			continue;
 		}
-		if (!runtime.install) {
+		if (!runtime.install && !runCommand) {
 			errors.push(`runtime ${name} is enabled but missing install metadata`);
 			continue;
 		}
+		if (!runtime.install) continue;
 		const expectedUrl = OFFICIAL_INSTALL_URLS[name];
 		if (runtime.install.url !== expectedUrl) {
 			errors.push(`runtime ${name} must use official installer ${expectedUrl}`);

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -8,10 +8,12 @@ import {
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
+	readdirSync,
 	readFileSync,
 	renameSync,
 	rmSync,
 	statSync,
+	symlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -24,6 +26,7 @@ import type {
 	AiProviderType,
 } from "@clawdi/shared";
 import { isAiProviderType } from "@clawdi/shared";
+import { z } from "zod";
 import { buildAgentTargetProjection } from "../lib/ai-provider-projection";
 import {
 	mergeHermesConfig,
@@ -51,6 +54,10 @@ import {
 import type { RuntimePaths } from "./paths";
 import {
 	buildRuntimeRunConfig,
+	isSupportedRuntimeName,
+	type RuntimeName,
+	runtimeCommandShimDir,
+	runtimeNameSchema,
 	runtimeRunConfigPath,
 	type SupportedRuntimeName,
 	writeRuntimeRunConfig,
@@ -88,7 +95,7 @@ export interface RuntimeConvergenceResult {
 interface RuntimeInstallObservation {
 	runtime: string;
 	enabled: boolean;
-	status: "disabled" | "present" | "installed" | "install_failed";
+	status: "disabled" | "present" | "installed" | "configured" | "install_failed";
 	executionUser: string | null;
 	commandPath: string | null;
 	appRoot: string | null;
@@ -325,11 +332,19 @@ const SUPPORTED_RUNTIME_NAMES = [
 	"openclaw",
 ] as const satisfies readonly SupportedRuntimeName[];
 
-type RuntimeCommandShimName = SupportedRuntimeName | "codex";
+const runtimeCommandShimIndexSchema = z
+	.object({
+		schemaVersion: z.literal("clawdi.runtimeCommandShims.v1"),
+		commands: z.array(runtimeNameSchema).default([]),
+	})
+	.strict();
 
-function isSupportedRuntimeName(name: string): name is SupportedRuntimeName {
-	return (SUPPORTED_RUNTIME_NAMES as readonly string[]).includes(name);
-}
+const liveSyncEnvironmentIndexSchema = z
+	.object({
+		schemaVersion: z.literal("clawdi.liveSyncEnvironments.v1"),
+		agentTypes: z.array(runtimeNameSchema).default([]),
+	})
+	.strict();
 
 function executableExists(path: string): boolean {
 	try {
@@ -596,6 +611,23 @@ function observeRuntimeInstall(name: string, runtime: RuntimeManifest["runtimes"
 		} satisfies RuntimeInstallObservation;
 	}
 	if (!runtime.install) {
+		if (runtime.run?.command?.trim()) {
+			return {
+				runtime: name,
+				enabled: true,
+				status: "configured",
+				executionUser: null,
+				commandPath: null,
+				appRoot: null,
+				install: null,
+				installerUrl: null,
+				executedInstallerUrl: null,
+				exitCode: null,
+				stdoutTail: null,
+				stderrTail: null,
+				error: null,
+			} satisfies RuntimeInstallObservation;
+		}
 		return {
 			runtime: name,
 			enabled: true,
@@ -1052,10 +1084,14 @@ function clearMitmProfileBundle(paths: RuntimePaths): null {
 }
 
 function removeStaleRuntimeRunConfigs(
-	writtenRuntimes: Set<SupportedRuntimeName>,
+	writtenRuntimes: Set<RuntimeName>,
 	paths: RuntimePaths,
 ): void {
-	for (const runtime of SUPPORTED_RUNTIME_NAMES) {
+	if (!existsSync(paths.runConfigRoot)) return;
+	for (const entry of readdirSync(paths.runConfigRoot)) {
+		if (!entry.endsWith(".json")) continue;
+		const runtime = entry.slice(0, -".json".length);
+		if (!runtimeNameSchema.safeParse(runtime).success) continue;
 		if (!writtenRuntimes.has(runtime)) {
 			rmSync(runtimeRunConfigPath(runtime, paths), { force: true });
 		}
@@ -1085,7 +1121,11 @@ function writeLiveSyncEnvironmentFiles(manifest: RuntimeManifest, paths: Runtime
 	makeRuntimeUserOwned(envDir);
 	const agents = desiredLiveSyncAgents(manifest);
 	const desiredTypes = new Set(agents.map((agent) => agent.agentType));
-	for (const agentType of MANAGED_LIVE_SYNC_AGENTS) {
+	const staleCandidates = new Set<RuntimeName>([
+		...readLiveSyncEnvironmentIndex(paths),
+		...MANAGED_LIVE_SYNC_AGENTS,
+	] as RuntimeName[]);
+	for (const agentType of staleCandidates) {
 		if (!desiredTypes.has(agentType)) {
 			rmSync(join(envDir, `${agentType}.json`), { force: true });
 		}
@@ -1111,7 +1151,38 @@ function writeLiveSyncEnvironmentFiles(manifest: RuntimeManifest, paths: Runtime
 		makeRuntimeUserOwned(path);
 		written.push(path);
 	}
+	writeLiveSyncEnvironmentIndex(desiredTypes, paths);
 	return written;
+}
+
+function liveSyncEnvironmentIndexPath(paths: RuntimePaths): string {
+	return join(paths.serviceStateRoot, "config", "runtime-live-sync-agents.json");
+}
+
+function readLiveSyncEnvironmentIndex(paths: RuntimePaths): RuntimeName[] {
+	const path = liveSyncEnvironmentIndexPath(paths);
+	if (!existsSync(path)) return [];
+	try {
+		const parsed = liveSyncEnvironmentIndexSchema.parse(JSON.parse(readFileSync(path, "utf-8")));
+		return parsed.agentTypes;
+	} catch {
+		return [];
+	}
+}
+
+function writeLiveSyncEnvironmentIndex(agentTypes: Set<RuntimeName>, paths: RuntimePaths): void {
+	writePrivateFileAtomic(
+		liveSyncEnvironmentIndexPath(paths),
+		`${JSON.stringify(
+			{
+				schemaVersion: "clawdi.liveSyncEnvironments.v1",
+				agentTypes: [...agentTypes].sort(),
+			},
+			null,
+			2,
+		)}\n`,
+		{ mode: 0o644, dirMode: 0o755 },
+	);
 }
 
 function writeDaemonAuthToken(paths: RuntimePaths): string | null {
@@ -1351,6 +1422,9 @@ function writeSupervisorConfig(
 		CLAWDI_RUNTIME_REV: daemonProgramRevision(manifest),
 	});
 	const supportedEnabled = enabledRuntimes.filter(isSupportedRuntimeName);
+	const supervisedEnabled = enabledRuntimes.filter((runtime) =>
+		shouldSuperviseRuntime(runtime, manifest),
+	);
 	const shouldRunDaemon =
 		daemonAuthTokenFile !== null && desiredLiveSyncAgents(manifest).length > 0;
 	const shouldRunUiBridge = supportedEnabled.length > 0;
@@ -1364,7 +1438,7 @@ function writeSupervisorConfig(
 				profiles: manifest.mitmProfiles,
 			}),
 		) ||
-		(supportedEnabled.length > 0 && Object.keys(providerSecretEnv).length > 0);
+		(supervisedEnabled.length > 0 && Object.keys(providerSecretEnv).length > 0);
 	const lines = [
 		"; Generated by clawdi runtime init. Do not edit inside hosted runtime.",
 		`; Desired-state generation: ${manifest.generation}`,
@@ -1388,7 +1462,7 @@ function writeSupervisorConfig(
 		"",
 	];
 
-	if (supportedEnabled.length === 0 && !shouldRunDaemon) {
+	if (supervisedEnabled.length === 0 && !shouldRunDaemon) {
 		lines.push("; No enabled agent runtimes in the current manifest.", "");
 	}
 
@@ -1462,7 +1536,7 @@ function writeSupervisorConfig(
 		);
 	}
 
-	for (const runtime of supportedEnabled) {
+	for (const runtime of supervisedEnabled) {
 		const runtimeEnvironment = supervisorEnvironment({
 			...commonEnvironment,
 			CLAWDI_AUTH_TOKEN: "",
@@ -1492,26 +1566,54 @@ function writeSupervisorConfig(
 	return paths.supervisorConfig;
 }
 
-function writeRuntimeCommandShims(commands: RuntimeCommandShimName[], paths: RuntimePaths): void {
-	const active = new Set(commands);
-	for (const command of ["codex", ...SUPPORTED_RUNTIME_NAMES] satisfies RuntimeCommandShimName[]) {
-		const shimPath = join(paths.serviceStateRoot, "bin", command);
-		if (!active.has(command)) {
-			rmSync(shimPath, { force: true });
-			continue;
-		}
-		writePrivateFileAtomic(shimPath, runtimeCommandShimScript(command, paths), {
-			mode: 0o755,
-			dirMode: 0o755,
-		});
-		makeRuntimeUserOwned(shimPath);
-	}
+function shouldSuperviseRuntime(runtime: string, manifest: RuntimeManifest): boolean {
+	const desired = manifest.runtimes[runtime];
+	if (!desired?.enabled) return false;
+	return isSupportedRuntimeName(runtime) || Boolean(desired.run?.command?.trim());
 }
 
-function runtimeCommandShimScript(command: RuntimeCommandShimName, paths: RuntimePaths): string {
+function writeRuntimeCommandShims(commands: Iterable<RuntimeName>, paths: RuntimePaths): void {
+	const binDir = runtimeCommandShimDir(paths);
+	const dispatcherPath = join(binDir, ".clawdi-runtime-command-shim");
+	const active = new Set(
+		[...commands]
+			.filter((command) => command !== "clawdi")
+			.filter((command) => runtimeNameSchema.safeParse(command).success)
+			.sort(),
+	);
+	const previous = readRuntimeCommandShimIndex(paths);
+	const staleCandidates = new Set<RuntimeName>([
+		...previous,
+		"codex",
+		...SUPPORTED_RUNTIME_NAMES,
+	] as RuntimeName[]);
+	for (const command of staleCandidates) {
+		if (!active.has(command)) rmSync(join(binDir, command), { force: true });
+	}
+	if (active.size === 0) {
+		rmSync(dispatcherPath, { force: true });
+		writeRuntimeCommandShimIndex(active, paths);
+		return;
+	}
+	writePrivateFileAtomic(dispatcherPath, runtimeCommandShimScript(paths), {
+		mode: 0o755,
+		dirMode: 0o755,
+	});
+	makeRuntimeUserOwned(dispatcherPath);
+	for (const command of active) {
+		const shimPath = join(binDir, command);
+		rmSync(shimPath, { force: true });
+		symlinkSync(".clawdi-runtime-command-shim", shimPath);
+		makeRuntimeUserOwned(shimPath);
+	}
+	writeRuntimeCommandShimIndex(active, paths);
+}
+
+function runtimeCommandShimScript(paths: RuntimePaths): string {
 	return [
 		"#!/usr/bin/env sh",
 		"set -eu",
+		"command_name=$" + "{0##*/}",
 		'shim_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)',
 		"old_ifs=$" + "{IFS-}",
 		"IFS=:",
@@ -1522,9 +1624,39 @@ function runtimeCommandShimScript(command: RuntimeCommandShimName, paths: Runtim
 		"done",
 		"IFS=$old_ifs",
 		"export PATH=$clean_path",
-		`exec ${shellQuote(paths.cliManagedBin)} run -- ${command} "$@"`,
+		`exec ${shellQuote(paths.cliManagedBin)} run -- "$command_name" "$@"`,
 		"",
 	].join("\n");
+}
+
+function runtimeCommandShimIndexPath(paths: RuntimePaths): string {
+	return join(paths.serviceStateRoot, "config", "runtime-command-shims.json");
+}
+
+function readRuntimeCommandShimIndex(paths: RuntimePaths): RuntimeName[] {
+	const path = runtimeCommandShimIndexPath(paths);
+	if (!existsSync(path)) return [];
+	try {
+		const parsed = runtimeCommandShimIndexSchema.parse(JSON.parse(readFileSync(path, "utf-8")));
+		return parsed.commands;
+	} catch {
+		return [];
+	}
+}
+
+function writeRuntimeCommandShimIndex(commands: Set<RuntimeName>, paths: RuntimePaths): void {
+	writePrivateFileAtomic(
+		runtimeCommandShimIndexPath(paths),
+		`${JSON.stringify(
+			{
+				schemaVersion: "clawdi.runtimeCommandShims.v1",
+				commands: [...commands].sort(),
+			},
+			null,
+			2,
+		)}\n`,
+		{ mode: 0o644, dirMode: 0o755 },
+	);
 }
 
 function hostedUiAccessToken(): string {
@@ -1589,7 +1721,7 @@ export function convergeRuntimeManifest(
 	const installInventory: string[] = [];
 	const projections: string[] = [];
 	const runConfigs: string[] = [];
-	const commandShims: RuntimeCommandShimName[] = ["codex", ...SUPPORTED_RUNTIME_NAMES];
+	const commandShims = new Set<RuntimeName>();
 	const installErrors: string[] = [];
 
 	mkdirSync(workspaceRoot, { recursive: true });
@@ -1671,7 +1803,11 @@ export function convergeRuntimeManifest(
 		daemonAuthTokenFile,
 		load.secretValues,
 	);
-	const writtenRunConfigRuntimes = new Set<SupportedRuntimeName>();
+	const writtenRunConfigRuntimes = new Set<RuntimeName>();
+	for (const agent of desiredLiveSyncAgents(manifest)) {
+		const parsed = runtimeNameSchema.safeParse(agent.agentType);
+		if (parsed.success) commandShims.add(parsed.data);
+	}
 
 	for (const [name, runtime] of Object.entries(manifest.runtimes).sort(([a], [b]) =>
 		a.localeCompare(b),
@@ -1735,27 +1871,27 @@ export function convergeRuntimeManifest(
 				}`,
 			);
 		}
-		if (isSupportedRuntimeName(name)) {
-			const runConfigPath = writeRuntimeRunConfig(
-				buildRuntimeRunConfig({
-					runtime: name,
-					enabled: runtime.enabled,
-					generatedAt,
-					generation: manifest.generation,
-					instanceId: manifest.instanceId,
-					commandPath: observation.commandPath,
-					appRoot: observation.appRoot,
-					workspaceRoot,
-					mitmProfileBundlePath,
-					settings: runtime.run,
-					secretFilePath: mitmSecretFile,
-					secretEnv: hostedProviderSecretEnv(manifest, name),
-				}),
-				paths,
-			);
-			runConfigs.push(runConfigPath);
-			writtenRunConfigRuntimes.add(name);
-		}
+		const runtimeName = runtimeNameSchema.parse(name);
+		const runConfigPath = writeRuntimeRunConfig(
+			buildRuntimeRunConfig({
+				runtime: runtimeName,
+				enabled: runtime.enabled,
+				generatedAt,
+				generation: manifest.generation,
+				instanceId: manifest.instanceId,
+				commandPath: observation.commandPath,
+				appRoot: observation.appRoot,
+				workspaceRoot,
+				mitmProfileBundlePath,
+				settings: runtime.run,
+				secretFilePath: mitmSecretFile,
+				secretEnv: hostedProviderSecretEnv(manifest, name),
+			}),
+			paths,
+		);
+		runConfigs.push(runConfigPath);
+		writtenRunConfigRuntimes.add(runtimeName);
+		commandShims.add(runtimeName);
 
 		const semaphorePath = join(semRoot, `${name}.enabled`);
 		if (runtime.enabled) {

--- a/packages/cli/src/runtime/run-config.ts
+++ b/packages/cli/src/runtime/run-config.ts
@@ -7,6 +7,12 @@ import { buildMitmBrokerEnv } from "./mitm-env";
 import type { RuntimePaths } from "./paths";
 import { getRuntimePaths } from "./paths";
 
+export const runtimeNameSchema = z
+	.string()
+	.regex(/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/)
+	.refine((name) => name !== "clawdi", "Runtime name is reserved.");
+export type RuntimeName = z.infer<typeof runtimeNameSchema>;
+
 const supportedRuntimeSchema = z.enum(["hermes", "openclaw"]);
 export type SupportedRuntimeName = z.infer<typeof supportedRuntimeSchema>;
 
@@ -27,7 +33,7 @@ export type RuntimeRunSettings = z.infer<typeof runtimeRunSettingsSchema>;
 const runtimeRunConfigSchema = z
 	.object({
 		schemaVersion: z.literal("clawdi.runtimeRunConfig.v1"),
-		runtime: supportedRuntimeSchema,
+		runtime: runtimeNameSchema,
 		enabled: z.boolean(),
 		generatedAt: z.string().min(1),
 		generation: z.number().int().nonnegative(),
@@ -63,10 +69,10 @@ const DEFAULT_RUNTIME_ARGS: Record<SupportedRuntimeName, string[]> = {
 
 export type RuntimeRunConfigRead =
 	| { status: "not-runtime"; runtime: null }
-	| { status: "missing"; runtime: SupportedRuntimeName; path: string }
-	| { status: "invalid"; runtime: SupportedRuntimeName; path: string; error: string }
-	| { status: "disabled"; runtime: SupportedRuntimeName; path: string; config: RuntimeRunConfig }
-	| { status: "ok"; runtime: SupportedRuntimeName; path: string; config: RuntimeRunConfig };
+	| { status: "missing"; runtime: RuntimeName; path: string }
+	| { status: "invalid"; runtime: RuntimeName; path: string; error: string }
+	| { status: "disabled"; runtime: RuntimeName; path: string; config: RuntimeRunConfig }
+	| { status: "ok"; runtime: RuntimeName; path: string; config: RuntimeRunConfig };
 
 export interface RuntimeRunInvocation {
 	runtime: string;
@@ -77,21 +83,22 @@ export interface RuntimeRunInvocation {
 	configPath: string;
 }
 
-export function runtimeNameForCommand(command: string): SupportedRuntimeName | null {
+export function isSupportedRuntimeName(name: string): name is SupportedRuntimeName {
+	return supportedRuntimeSchema.safeParse(name).success;
+}
+
+export function runtimeNameForCommand(command: string): RuntimeName | null {
 	const name = basename(command);
-	const parsed = supportedRuntimeSchema.safeParse(name);
+	const parsed = runtimeNameSchema.safeParse(name);
 	return parsed.success ? parsed.data : null;
 }
 
-export function runtimeRunConfigPath(
-	runtime: SupportedRuntimeName,
-	paths = getRuntimePaths(),
-): string {
+export function runtimeRunConfigPath(runtime: RuntimeName, paths = getRuntimePaths()): string {
 	return join(paths.runConfigRoot, `${runtime}.json`);
 }
 
 export function buildRuntimeRunConfig(input: {
-	runtime: SupportedRuntimeName;
+	runtime: RuntimeName;
 	enabled: boolean;
 	generatedAt: string;
 	generation: number;
@@ -116,7 +123,7 @@ export function buildRuntimeRunConfig(input: {
 		generation: input.generation,
 		instanceId: input.instanceId,
 		command: input.settings?.command ?? input.commandPath ?? input.runtime,
-		defaultArgs: input.settings?.args ?? DEFAULT_RUNTIME_ARGS[input.runtime],
+		defaultArgs: input.settings?.args ?? defaultRuntimeArgs(input.runtime),
 		env: input.settings?.env ?? {},
 		secretEnv: input.secretEnv ?? {},
 		secretFilePath: input.secretFilePath ?? null,
@@ -145,7 +152,11 @@ export function readRuntimeRunConfigForCommand(
 	if (!runtime) return { status: "not-runtime", runtime: null };
 
 	const path = runtimeRunConfigPath(runtime, paths);
-	if (!existsSync(path)) return { status: "missing", runtime, path };
+	if (!existsSync(path)) {
+		return isSupportedRuntimeName(runtime)
+			? { status: "missing", runtime, path }
+			: { status: "not-runtime", runtime: null };
+	}
 
 	try {
 		const parsed = runtimeRunConfigSchema.parse(JSON.parse(readFileSync(path, "utf8")));
@@ -165,9 +176,10 @@ export function buildRuntimeRunInvocation(
 	read: Extract<RuntimeRunConfigRead, { status: "ok" }>,
 	args: string[],
 	baseEnv: NodeJS.ProcessEnv,
+	paths = getRuntimePaths(),
 ): RuntimeRunInvocation {
 	const pathPrefix = read.config.prependPath.join(":");
-	const currentPath = baseEnv.PATH ?? "";
+	const currentPath = withoutPathEntry(baseEnv.PATH ?? "", runtimeCommandShimDir(paths));
 	const env = {
 		...baseEnv,
 		...read.config.env,
@@ -193,6 +205,22 @@ export function buildRuntimeRunInvocation(
 		env: brokerEnv,
 		configPath: read.path,
 	};
+}
+
+export function runtimeCommandShimDir(paths = getRuntimePaths()): string {
+	return join(paths.serviceStateRoot, "bin");
+}
+
+export function withoutPathEntry(path: string, entry: string): string {
+	return path
+		.split(":")
+		.filter((part) => part && part !== entry)
+		.join(":");
+}
+
+function defaultRuntimeArgs(runtime: RuntimeName): string[] {
+	const parsed = supportedRuntimeSchema.safeParse(runtime);
+	return parsed.success ? DEFAULT_RUNTIME_ARGS[parsed.data] : [];
 }
 
 function runtimeSecretEnv(

--- a/packages/cli/tests/commands/run.test.ts
+++ b/packages/cli/tests/commands/run.test.ts
@@ -765,6 +765,27 @@ describe("run command project folder selection", () => {
 		);
 	});
 
+	it("runs generic hosted commands without login when no MITM profile bundle exists", async () => {
+		unlinkSync(join(fakeClawdiHome, "auth.json"));
+		const serviceStateRoot = join(tmpRoot, "var", "lib", "clawdi");
+		const runRoot = join(tmpRoot, "run", "clawdi");
+		const { calls, spawnImpl } = recordSpawn();
+		const broker = recordBroker();
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = serviceStateRoot;
+		process.env.CLAWDI_RUN_DIR = runRoot;
+		process.env.PATH = `${join(serviceStateRoot, "bin")}:/usr/local/bin:/usr/bin`;
+		delete process.env.CLAWDI_AUTH_TOKEN;
+
+		await run(["node", "--version"], {}, spawnImpl, broker.brokerFactory);
+
+		expect(broker.calls).toHaveLength(0);
+		expect(calls).toHaveLength(1);
+		expect(calls[0].command).toBe("node");
+		expect(calls[0].args).toEqual(["--version"]);
+		expect(calls[0].env.PATH).toBe("/usr/local/bin:/usr/bin");
+	});
+
 	it("does not inject cloud-managed AI provider keys into hosted runtime commands", async () => {
 		const serviceStateRoot = join(tmpRoot, "var", "lib", "clawdi");
 		const runRoot = join(tmpRoot, "run", "clawdi");

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -3858,6 +3858,71 @@ exit 64
 		}
 	});
 
+	it("converges future runtimes from explicit run commands without image shims", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const manifestPath = join(root, "future-runtime.json");
+		const futureBin = join(home, "tools", "future-agent");
+		mkdirSync(dirname(futureBin), { recursive: true });
+		writeFileSync(futureBin, "#!/bin/sh\nexit 0\n");
+		chmodSync(futureBin, 0o700);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				deploymentId: "dep_future_runtime",
+				environmentId: "env_future_runtime",
+				instanceId: "iid_future_runtime",
+				generation: 1,
+				issuedAt: "2026-06-29T00:00:00Z",
+				workspaceRoot: join(home, "workspace"),
+				controlPlane: { apiUrl: "https://cloud-api.test" },
+				runtimes: {
+					"future-agent": {
+						enabled: true,
+						run: {
+							command: futureBin,
+							args: ["serve", "--host", "127.0.0.1"],
+							env: { FUTURE_AGENT_MODE: "hosted" },
+						},
+					},
+				},
+				recovery: { cacheManifest: true, allowOfflineBoot: true },
+			}),
+		);
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths(), { manifestPath });
+		expect("manifest" in loaded).toBe(true);
+		if (!("manifest" in loaded)) throw new Error("expected manifest load success");
+		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
+
+		expect(convergence.installErrors).toEqual([]);
+		const runConfig = JSON.parse(
+			readFileSync(join(state, "config", "run", "future-agent.json"), "utf-8"),
+		);
+		expect(runConfig.command).toBe(futureBin);
+		expect(runConfig.commandPath).toBeNull();
+		expect(runConfig.defaultArgs).toEqual(["serve", "--host", "127.0.0.1"]);
+		expect(runConfig.env).toEqual({ FUTURE_AGENT_MODE: "hosted" });
+		expect(readlinkSync(join(state, "bin", "future-agent"))).toBe(".clawdi-runtime-command-shim");
+		const dispatcher = readFileSync(join(state, "bin", ".clawdi-runtime-command-shim"), "utf-8");
+		expect(dispatcher).toContain("command_name=$" + "{0##*/}");
+		expect(dispatcher).toContain('run -- "$command_name" "$@"');
+		const shimIndex = JSON.parse(
+			readFileSync(join(state, "config", "runtime-command-shims.json"), "utf-8"),
+		);
+		expect(shimIndex.commands).toEqual(["future-agent"]);
+		const supervisorConfig = readFileSync(convergence.outputs.supervisorConfig, "utf-8");
+		expect(supervisorConfig).toContain("[program:clawdi-future-agent]");
+		expect(supervisorConfig).toContain("command=/usr/bin/env clawdi run -- future-agent");
+		expect(supervisorConfig).not.toContain("[program:clawdi-ui-bridge]");
+	});
+
 	it("rejects legacy hosted controlPlane apiUrl", async () => {
 		const home = join(root, "home", "clawdi");
 		const manifestPath = join(root, "hosted-legacy-api-url.json");

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -216,8 +216,16 @@ describe("CLI smoke — src entry", () => {
 
 	it("runtime init performs first-install convergence from a fixture manifest", async () => {
 		const { tmpdir } = await import("node:os");
-		const { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } =
-			await import("node:fs");
+		const {
+			chmodSync,
+			existsSync,
+			mkdirSync,
+			readFileSync,
+			readlinkSync,
+			rmSync,
+			statSync,
+			writeFileSync,
+		} = await import("node:fs");
 		const root = join(tmpdir(), `clawdi-smoke-runtime-full-${Date.now()}`);
 		const home = join(root, "home", "clawdi");
 		const policyPath = join(root, "etc", "clawdi", "host-policy.json");
@@ -344,6 +352,10 @@ chmod +x "$HOME/.local/bin/hermes"
 				},
 				mcp: { command: "clawdi mcp" },
 			},
+			liveSync: {
+				enabled: true,
+				agents: [{ agentType: "codex", environmentId: "env-codex" }],
+			},
 			recovery: { cacheManifest: true, allowOfflineBoot: true },
 		};
 		writeFileSync(manifestPath, JSON.stringify(manifest));
@@ -398,6 +410,7 @@ chmod +x "$HOME/.local/bin/hermes"
 				join(serviceStateRoot, "supervisor", "supervisord.conf"),
 				join(serviceStateRoot, "config", "mitm", "profiles.json"),
 				join(serviceStateRoot, "instances", "iid_test", "boot-finished"),
+				join(serviceStateRoot, "bin", ".clawdi-runtime-command-shim"),
 				join(serviceStateRoot, "bin", "openclaw"),
 				join(serviceStateRoot, "bin", "hermes"),
 				join(serviceStateRoot, "bin", "codex"),
@@ -407,13 +420,24 @@ chmod +x "$HOME/.local/bin/hermes"
 			]) {
 				expect(existsSync(outputPath)).toBe(true);
 			}
+			const dispatcher = readFileSync(
+				join(serviceStateRoot, "bin", ".clawdi-runtime-command-shim"),
+				"utf-8",
+			);
+			expect(dispatcher).toContain("clean_path=");
+			expect(dispatcher).toContain("command_name=$" + "{0##*/}");
+			expect(dispatcher).toContain(
+				`exec '${join(serviceStateRoot, "bin", "clawdi")}' run -- "$command_name" "$@"`,
+			);
 			for (const command of ["openclaw", "hermes", "codex"]) {
-				const shim = readFileSync(join(serviceStateRoot, "bin", command), "utf-8");
-				expect(shim).toContain("clean_path=");
-				expect(shim).toContain(
-					`exec '${join(serviceStateRoot, "bin", "clawdi")}' run -- ${command} "$@"`,
+				expect(readlinkSync(join(serviceStateRoot, "bin", command))).toBe(
+					".clawdi-runtime-command-shim",
 				);
 			}
+			const shimIndex = JSON.parse(
+				readFileSync(join(serviceStateRoot, "config", "runtime-command-shims.json"), "utf-8"),
+			);
+			expect(shimIndex.commands).toEqual(["codex", "hermes", "openclaw"]);
 			expect(statSync(join(serviceStateRoot, "cache", "boot-status.json")).mode & 0o777).toBe(
 				0o644,
 			);
@@ -621,9 +645,8 @@ chmod +x "$HOME/.local/bin/hermes"
 
 	it("runtime init installs only selected runtimes", async () => {
 		const { tmpdir } = await import("node:os");
-		const { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } = await import(
-			"node:fs"
-		);
+		const { chmodSync, existsSync, mkdirSync, readFileSync, readlinkSync, rmSync, writeFileSync } =
+			await import("node:fs");
 		const root = join(tmpdir(), `clawdi-smoke-runtime-selection-${Date.now()}`);
 		const home = join(root, "home", "clawdi");
 		const policyPath = join(root, "etc", "clawdi", "host-policy.json");
@@ -712,10 +735,17 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 			expect(existsSync(join(home, ".local", "bin", "hermes"))).toBe(false);
 			expect(existsSync(join(serviceStateRoot, "bin", "openclaw"))).toBe(true);
 			expect(existsSync(join(serviceStateRoot, "bin", "hermes"))).toBe(true);
-			expect(existsSync(join(serviceStateRoot, "bin", "codex"))).toBe(true);
-			for (const command of ["hermes", "codex"]) {
-				expect(readFileSync(join(serviceStateRoot, "bin", command), "utf-8")).toContain(
-					`exec '${join(serviceStateRoot, "bin", "clawdi")}' run -- ${command} "$@"`,
+			expect(existsSync(join(serviceStateRoot, "bin", "codex"))).toBe(false);
+			const dispatcher = readFileSync(
+				join(serviceStateRoot, "bin", ".clawdi-runtime-command-shim"),
+				"utf-8",
+			);
+			expect(dispatcher).toContain(
+				`exec '${join(serviceStateRoot, "bin", "clawdi")}' run -- "$command_name" "$@"`,
+			);
+			for (const command of ["openclaw", "hermes"]) {
+				expect(readlinkSync(join(serviceStateRoot, "bin", command))).toBe(
+					".clawdi-runtime-command-shim",
 				);
 			}
 


### PR DESCRIPTION
## Summary
- coalesce xterm fit calls through `requestAnimationFrame` and cancel pending fit work on unmount
- make hosted runtime command handling manifest-driven instead of baking per-agent command wrappers into the runtime image
- generate a single Clawdi-managed dispatcher shim with per-command symlinks from the runtime manifest/live-sync agents
- support future runtimes with explicit `run.command` without requiring an image update
- allow generic hosted `clawdi run -- <command>` without login or MITM config, while stripping the shim directory from child `PATH` to avoid recursion
- bump the CLI prerelease to `0.12.10-beta.28` so `clawdi@beta` hosted runtimes can pick up the new contract after merge

## Notes
- The runtime image contract stays stable: it only needs the managed `clawdi` launcher and `/var/lib/clawdi/bin` ahead of agent-installed binaries.
- Disabled manifest runtimes still get a managed shim/run config so stale installed binaries are intercepted and reported as disabled instead of bypassing desired state.
- Does not generate or inject an OpenClaw gateway token.

## Tests
- `bun install --frozen-lockfile`
- `bun run check`
- `bun run typecheck`
- `bun run test`
- `bun test packages/cli/tests/commands/run.test.ts packages/cli/tests/runtime.test.ts packages/cli/tests/smoke.test.ts`
- `bun run typecheck` from `packages/cli`
- `uv run pytest tests/test_v2_hosted_runtime_state.py tests/test_agent_runtime.py tests/test_v2_hosted_terminal.py` in the hosted backend worktree
