### PR TITLE
Replace hosted UI bridge with runtime bridge surfaces

### DIFF
--- a/backend/alembic/versions/c2f4a8b9d7e1_add_hosted_runtime_bridge_state.py
+++ b/backend/alembic/versions/c2f4a8b9d7e1_add_hosted_runtime_bridge_state.py
@@ -1,0 +1,29 @@
+"""add hosted runtime bridge state
+
+Revision ID: c2f4a8b9d7e1
+Revises: ab12cd34ef56
+Create Date: 2026-06-30 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "c2f4a8b9d7e1"
+down_revision: str | Sequence[str] | None = "ab12cd34ef56"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "hosted_runtime_states",
+        sa.Column("bridge", postgresql.JSONB(none_as_null=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("hosted_runtime_states", "bridge")

--- a/backend/app/models/hosted_runtime.py
+++ b/backend/app/models/hosted_runtime.py
@@ -25,6 +25,7 @@ class HostedRuntimeState(Base, TimestampMixin):
     control_plane: Mapped[dict | None] = mapped_column(JSONB(none_as_null=True))
     clawdi_cli: Mapped[dict | None] = mapped_column(JSONB(none_as_null=True))
     runtimes: Mapped[dict] = mapped_column(JSONB(none_as_null=True), nullable=False)
+    bridge: Mapped[dict | None] = mapped_column(JSONB(none_as_null=True))
     live_sync: Mapped[dict | None] = mapped_column(JSONB(none_as_null=True))
     recovery: Mapped[dict | None] = mapped_column(JSONB(none_as_null=True))
     mitm_profiles: Mapped[dict | None] = mapped_column(JSONB(none_as_null=True))

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -685,6 +685,7 @@ async def admin_upsert_runtime_state(
     state.control_plane = body.control_plane
     state.clawdi_cli = body.clawdi_cli
     state.runtimes = body.runtimes
+    state.bridge = body.bridge
     state.live_sync = body.live_sync
     state.recovery = body.recovery
     if state is not existing_state or body.mitm_profiles is not None:
@@ -710,6 +711,7 @@ async def admin_upsert_runtime_state(
             "previous_generation": previous_generation,
             "provider_id": body.provider_id,
             "enabled_runtimes": _enabled_runtime_names(body.runtimes),
+            "has_bridge": body.bridge is not None,
             "has_mcp": body.mcp is not None,
             "has_tools": body.tools is not None,
             "changed_fields": changed_fields,
@@ -846,6 +848,7 @@ def _runtime_state_changed_fields(
         "control_plane",
         "clawdi_cli",
         "runtimes",
+        "bridge",
         "live_sync",
         "recovery",
         "mitm_profiles",

--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -101,6 +101,8 @@ async def get_runtime_manifest(
         "liveSync": state.live_sync or _default_live_sync(env),
         "recovery": state.recovery or {"cacheManifest": True, "allowOfflineBoot": True},
     }
+    if state.bridge:
+        manifest["bridge"] = state.bridge
     if state.app_id:
         manifest["appId"] = state.app_id
     if state.mitm_profiles:

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -5,6 +5,7 @@ and are used by SaaS batch tooling + ops-side scripts. Kept in a
 separate file so they don't pollute user-facing schemas.
 """
 
+import re
 from datetime import datetime
 from typing import Any, Literal
 from uuid import UUID
@@ -15,6 +16,15 @@ AdminChannelProvider = Literal["telegram", "discord", "whatsapp", "imessage"]
 AdminChannelVisibility = Literal["private", "public"]
 AdminChannelStatus = Literal["active", "disabled"]
 _SUPPORTED_HOSTED_RUNTIMES = {"codex", "hermes", "openclaw"}
+_BRIDGE_SURFACE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+_BRIDGE_SURFACE_KEYS = {
+    "name",
+    "kind",
+    "listenHost",
+    "listenPort",
+    "upstreamHost",
+    "upstreamPort",
+}
 
 
 class AdminEnvironmentCreate(BaseModel):
@@ -76,6 +86,7 @@ class AdminRuntimeStateUpsert(BaseModel):
     control_plane: dict[str, Any] | None = None
     clawdi_cli: dict[str, Any] | None = None
     runtimes: dict[str, Any] = Field(default_factory=dict)
+    bridge: dict[str, Any] | None = None
     live_sync: dict[str, Any] | None = None
     recovery: dict[str, Any] | None = None
     mitm_profiles: dict[str, Any] | None = None
@@ -99,6 +110,37 @@ class AdminRuntimeStateUpsert(BaseModel):
     def _validate_control_plane(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
         if value is not None and "apiUrl" in value:
             raise ValueError("hosted runtime controlPlane must use cloudApiUrl")
+        return value
+
+    @field_validator("bridge")
+    @classmethod
+    def _validate_bridge(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
+        if value is None:
+            return None
+        surfaces = value.get("surfaces")
+        if set(value) != {"surfaces"} or not isinstance(surfaces, list):
+            raise ValueError("bridge must contain only a surfaces array")
+        for index, surface in enumerate(surfaces):
+            if not isinstance(surface, dict):
+                raise ValueError(f"bridge.surfaces[{index}] must be an object")
+            unknown = sorted(set(surface) - _BRIDGE_SURFACE_KEYS)
+            if unknown:
+                raise ValueError(
+                    f"bridge.surfaces[{index}] has unsupported fields: {', '.join(unknown)}"
+                )
+            name = surface.get("name")
+            if not isinstance(name, str) or not _BRIDGE_SURFACE_NAME_RE.fullmatch(name):
+                raise ValueError(f"bridge.surfaces[{index}].name must be a lowercase surface id")
+            if surface.get("kind") != "control-ui":
+                raise ValueError(f"bridge.surfaces[{index}].kind must be control-ui")
+            for field in ("listenPort", "upstreamPort"):
+                port = surface.get(field)
+                if not isinstance(port, int) or isinstance(port, bool) or port < 1 or port > 65535:
+                    raise ValueError(f"bridge.surfaces[{index}].{field} must be a TCP port")
+            for field in ("listenHost", "upstreamHost"):
+                host = surface.get(field)
+                if host is not None and (not isinstance(host, str) or not host.strip()):
+                    raise ValueError(f"bridge.surfaces[{index}].{field} must be a non-empty string")
         return value
 
     @field_validator("mcp", "tools")

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -133,6 +133,42 @@ async def test_admin_upsert_runtime_state_and_manifest_omit_channels(
 
 
 @pytest.mark.asyncio
+async def test_runtime_manifest_includes_declared_bridge_surfaces(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"runtime-bridge-{uuid4().hex[:8]}",
+        machine_name="Runtime bridge",
+        agent_type="openclaw",
+    )
+    bridge = {
+        "surfaces": [
+            {
+                "name": "openclaw",
+                "kind": "control-ui",
+                "listenPort": 28789,
+                "upstreamHost": "127.0.0.1",
+                "upstreamPort": 18789,
+            }
+        ]
+    }
+    await _write_runtime_state(admin_client, str(env.id), bridge=bridge)
+
+    api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        response = await client.get("/api/runtime/manifest")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["manifest"]["bridge"] == bridge
+
+
+@pytest.mark.asyncio
 async def test_runtime_manifest_etag_ignores_heartbeat_liveness(
     admin_client,
     db_session,
@@ -617,6 +653,85 @@ async def test_admin_runtime_state_rejects_legacy_top_level_fields(
         "provider_id": "clawdi-managed",
         "runtimes": {"openclaw": {"enabled": True}},
         field: {},
+    }
+
+    response = await admin_client.put(
+        f"/api/admin/environments/{env.id}/runtime-state",
+        headers=_AUTH,
+        json=body,
+    )
+
+    assert response.status_code == 422, response.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bridge",
+    [
+        {
+            "surfaces": [
+                {
+                    "name": "openclaw",
+                    "kind": "shell",
+                    "listenPort": 28789,
+                    "upstreamPort": 18789,
+                }
+            ]
+        },
+        {
+            "surfaces": [
+                {
+                    "name": "OpenClaw",
+                    "kind": "control-ui",
+                    "listenPort": 28789,
+                    "upstreamPort": 18789,
+                }
+            ]
+        },
+        {
+            "surfaces": [
+                {
+                    "name": "openclaw",
+                    "kind": "control-ui",
+                    "listenPort": 0,
+                    "upstreamPort": 18789,
+                }
+            ]
+        },
+        {
+            "surfaces": [
+                {
+                    "name": "openclaw",
+                    "kind": "control-ui",
+                    "listenPort": 28789,
+                    "upstreamPort": 18789,
+                    "token": "must-not-be-here",
+                }
+            ]
+        },
+    ],
+)
+async def test_admin_runtime_state_rejects_invalid_bridge_surfaces(
+    admin_client,
+    db_session,
+    seed_user,
+    bridge,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"bridge-invalid-{uuid4().hex[:8]}",
+        machine_name="Runtime invalid bridge",
+        agent_type="openclaw",
+    )
+    body = {
+        "deployment_id": f"dep_{uuid4().hex}",
+        "app_id": "app-test",
+        "instance_id": f"hri_{uuid4().hex}",
+        "generation": 7,
+        "provider_id": "clawdi-managed",
+        "runtimes": {"openclaw": {"enabled": True}},
+        "bridge": bridge,
     }
 
     response = await admin_client.put(

--- a/bun.lock
+++ b/bun.lock
@@ -62,7 +62,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.28",
+      "version": "0.12.10-beta.29",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@ High-level map of what's actually in Clawdi Cloud today — updated as the code 
 
 ## One-paragraph overview
 
-Clawdi Cloud is a cross-agent sync + recall layer. A local CLI (`clawdi`) reads per-agent data (Claude Code, Codex, Hermes, OpenClaw) from well-known directories, pushes sessions and skills to a FastAPI backend, pulls shared skills back down, and exposes a long-term memory store to each agent via the Model Context Protocol. Projects are the collaboration and data ownership boundary; each Agent has one fixed Agent Project plus optional attached Projects for read-time composition. The web app is a read-mostly dashboard on the same backend. The same CLI also owns the public managed runtime command surface for controlled environments. The memory store is the differentiator: it gives every connected agent the same cross-session, cross-machine context without the agents having to know about each other.
+Clawdi Cloud is a cross-agent sync + recall layer. A local CLI (`clawdi`) reads per-agent data (Claude Code, Codex, Hermes, OpenClaw) from well-known directories, pushes sessions and skills to a FastAPI backend, pulls shared skills back down, and exposes a long-term memory store to each agent via the Model Context Protocol. Projects are the collaboration and data ownership boundary; each Agent has one fixed Agent Project plus optional attached Projects for read-time composition. The web app is a dashboard on the same backend, including hosted deployment surfaces such as Control UI and Terminal. The same CLI also owns the public managed runtime command surface for controlled environments: runtime manifests, convergence, command shims, `clawdi run`, local UI bridging, and diagnostics. The memory store is the differentiator: it gives every connected agent the same cross-session, cross-machine context without the agents having to know about each other.
 
 ---
 
@@ -33,6 +33,19 @@ Clawdi Cloud is a cross-agent sync + recall layer. A local CLI (`clawdi`) reads 
 │ Next.js web dashboard│─────────────────────────▶│ File store     │
 │ (read-mostly)        │                          │ (local / S3)   │
 └──────────────────────┘                          └────────────────┘
+
+┌──────────────────────┐  Runtime manifest / state ┌──────────────────────┐
+│ Hosted control plane │──────────────────────────▶│ Managed runtime CLI  │
+│ (external service)   │                           │  - runtime init/watch│
+└──────────────────────┘                           │  - run configs/shims │
+        ▲                                          │  - runtime bridge         │
+        │ Control UI + Terminal contracts          └──────────┬───────────┘
+        └─────────────────────────────────────────────────────▼
+                                                   ┌──────────────────────┐
+                                                   │ Agent runtimes       │
+                                                   │ Hermes / OpenClaw /  │
+                                                   │ manifest run.command │
+                                                   └──────────────────────┘
 ```
 
 Two auth paths hit the same backend:
@@ -62,6 +75,8 @@ All keyed off Clerk `user_id`:
 | `memories` | Long-term recall. `content` (text), `category`, `tags`, plus three search columns (`content_tsv` generated tsvector, `embedding vector(768)`) | CLI and MCP `memory_add` |
 | `user_settings` | Opaque JSONB per-user prefs: `memory_provider` (`builtin` / `mem0`), `mem0_api_key` | `PATCH /api/settings` |
 | `channel_accounts` + `channel_bot_agent_links` + `channel_secrets` + `channel_bindings` + `channel_binding_aliases` + `channel_pair_codes` + `channel_messages` + `channel_deliveries` + `channel_agent_credentials` + `channel_whatsapp_auth_certs` | Native Channels control plane and agent-facing emulation state. Accounts own external bot/provider identity, visibility, webhook secrets, and provider credentials; public preconfigured accounts can be linked by many users while private accounts stay owner-only; bot-agent links own hashed agent SDK tokens and agent routing; extra provider secrets are AES-GCM encrypted; bindings and aliases map each external chat session to one active bot-agent link and actor-scoped pair control; pair codes authorize chat binding or re-binding; messages record routed traffic and inbox cursors; deliveries provide the DB outbox; WhatsApp agent credentials and auth certs persist Baileys-facing identity material. See `docs/designs/native-channels-product-model.md` for the product model. | `/api/channels`, `/api/channels/telegram/*`, `/api/channels/discord/*`, `/api/channels/whatsapp/*`, `/api/channels/imessage/*`, `pdm run channels-worker` |
+
+Hosted deployment persistence is owned by the hosted agent service, not by the OSS backend tables above. This repository consumes that service through generated API contracts, the dashboard UI, the mock deploy API used for local development, and the CLI managed-runtime contract.
 
 There is no `cron_job` / `celery` / `background_task` table — those were in the original plan but never built. See [What's not implemented](#whats-not-implemented) below.
 
@@ -146,28 +161,117 @@ not add a private runtime-control RPC surface for ordinary agent actions.
 
 Public contract: [`managed-runtime.md`](managed-runtime.md).
 
+### Design Principles
+
+- The host image is a stable envelope. It should provide the OS user, base
+  packages, host policy, CLI bootstrap path, and PATH ordering, but runtime
+  semantics come from the CLI and runtime manifest.
+- `clawdi runtime init --non-interactive` is the convergence boundary. It
+  validates desired state, installs or verifies runtimes through supported
+  installers, writes projections, writes run configs, writes command shims, and
+  renders supervisor config.
+- `clawdi run -- <command>` is the execution boundary. Runtime commands such as
+  `openclaw` and `hermes` resolve through generated run config. Ordinary shell
+  commands keep normal shell behavior.
+- Runtime-specific behavior is manifest-driven. Known runtimes can use built-in
+  install/projection support; future runtimes can be launched through an
+  explicit `run.command` without adding per-agent wrappers to the image.
+- Secrets stay out of durable config. The CLI may project short-lived secret
+  files under the runtime run directory and removes `CLAWDI_AUTH_TOKEN` before
+  launching agent child processes.
+
 ### Module Map
 
 | Area | Files |
 |---|---|
 | Contract schemas | `packages/cli/src/runtime/manifest-contract.ts` |
 | Datasource fetch, normalization, validation | `packages/cli/src/runtime/manifest-source.ts` |
-| Local convergence and install inventory | `packages/cli/src/runtime/manifest.ts` |
+| Local convergence, projections, supervisor config, command shims | `packages/cli/src/runtime/manifest.ts` |
 | Runtime path contract | `packages/cli/src/runtime/paths.ts` |
-| Runtime boot status | `packages/cli/src/runtime/state.ts` |
+| Host policy | `packages/cli/src/runtime/host-policy.ts` |
+| Runtime boot status and observed state | `packages/cli/src/runtime/state.ts`, `packages/cli/src/runtime/observed.ts` |
 | Run config and invocation | `packages/cli/src/runtime/run-config.ts`, `packages/cli/src/commands/run.ts` |
+| CLI self-management in hosted runtime | `packages/cli/src/runtime/cli-update.ts` |
+| Runtime bridge | `packages/cli/src/runtime/bridge.ts` |
 | Broker profile schema and profile generation | `packages/cli/src/runtime/mitm-profiles.ts`, `packages/cli/src/runtime/hosted-mitm-profiles.ts` |
 | Native broker launcher and env projection | `packages/cli/src/runtime/mitm-broker.ts`, `packages/cli/src/runtime/mitm-env.ts` |
 | Native broker implementation | `packages/cli/native/mitm-broker/` |
+| Hosted deployment UI and terminal panel | `apps/web/src/hosted/agents/hosted-agent-detail.tsx`, `apps/web/src/hosted/agents/hosted-terminal-panel.tsx` |
+| Local mock deploy API | `backend/scripts/mock_deploy_api.py` |
+
+### Runtime Flow
+
+```mermaid
+flowchart TD
+    CP[Hosted control plane] -->|hosted manifest response| Source[manifest-source]
+    Source -->|normalized desired state| Init[clawdi runtime init]
+    Init --> Paths[/var/lib/clawdi state]
+    Init --> RunConfigs[config/run/<runtime>.json]
+    Init --> Shims[bin/<runtime> -> .clawdi-runtime-command-shim]
+    Init --> Supervisor[supervisord.conf]
+    Supervisor --> Watch[clawdi runtime watch]
+    Supervisor --> Bridge[clawdi runtime bridge]
+    Supervisor --> Runtime[clawdi run -- <runtime>]
+    Shims --> Runtime
+    Runtime --> Agent[Agent runtime process]
+```
+
+The hosted manifest schema is `clawdi.hosted-runtime.manifest.v1`. The CLI
+normalizes it to `clawdi.runtimeDesiredState.v1`, which is the internal
+convergence shape. The normalized state includes deployment identity,
+environment identity, instance identity, generation, workspace root, control
+plane API origin, CLI package policy, runtime entries, provider projections,
+MCP/tool projections, MITM profiles, live-sync settings, and recovery policy.
+
+### Command Shims
+
+Runtime command shims live under the service state bin directory. The host
+environment puts that directory first on PATH, so typing a managed runtime name
+such as `openclaw` or `hermes` enters the dispatcher before any native binary.
+The dispatcher removes the shim directory from PATH and executes the managed CLI
+as:
+
+```bash
+clawdi run -- "$command_name" "$@"
+```
+
+This keeps the image stable: the image does not need one wrapper script per
+agent. Disabled runtimes write disabled run config, and `clawdi run` reports the
+runtime as disabled instead of falling back to a native binary.
+
+### Control UI And Terminal
+
+Control UI and Terminal are separate hosted deployment surfaces:
+
+- **Control UI** is the runtime's browser UI endpoint, proxied through the
+  runtime bridge as an explicitly declared `control-ui` surface. It is
+  runtime-specific, so the dashboard labels it as `<Runtime> Control UI`.
+- **Terminal** is a deployment shell, not an agent-specific surface. The
+  dashboard requests a terminal session for the deployment and then opens one
+  xterm WebSocket. The terminal uses tty-style frames (`0` for input/output,
+  `1` for resize), follows the dashboard light/dark theme, and sends the
+  short-lived terminal token through a WebSocket subprotocol by default.
+
+The service-side terminal bridge is outside this repository. The public
+contract is: authenticate the user, require the deployment to be running, bind
+the terminal token to that deployment, and bridge the WebSocket to a shell as
+the default runtime user.
+
+The runtime bridge is a general authenticated surface bridge, but each surface
+must be declared with listen/upstream targets and policy. The current hosted
+surface kind is browser Control UI traffic. Terminal stays separate because it
+grants shell execution rather than proxying a runtime web application.
 
 ### Ownership Boundaries
 
-- The control plane owns identity, desired-state generation, and secret
-  resolution. Deployment selection, rollout, and UI policy stay outside this
-  repository.
-- The CLI owns manifest validation, non-secret convergence, runtime install
-  orchestration, run config, short-lived secret projection, and broker
-  lifecycle.
+- The control plane owns identity, desired-state generation, secret resolution,
+  deployment selection, rollout, billing policy, and terminal session
+  authorization.
+- The CLI owns manifest validation, local convergence, runtime install
+  orchestration, non-secret projections, run config, command shims, short-lived
+  secret projection, local UI bridging, diagnostics, and broker lifecycle.
+- The web dashboard owns the user-facing hosted deployment surfaces and calls
+  only public API contracts.
 - OpenClaw and Hermes keep their official installer/updater authority.
 - Clawdi native Channels own shared channel protocol state.
 - User BYOK provider traffic must not be silently proxied.

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -2,13 +2,13 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Public CLI contract |
-| Last updated | 2026-06-29 |
+| Status | Public runtime contract |
+| Last updated | 2026-06-30 |
 | Owner | CLI runtime layer |
 
-This document describes the public Clawdi CLI contract for managed runtime
-environments. It intentionally avoids deployment-specific topology, private
-service details, live service hosts, and internal runtime orchestration.
+This document describes the public Clawdi CLI and dashboard contract for managed
+runtime environments. It intentionally avoids deployment-specific topology,
+private service details, live service hosts, and internal runtime orchestration.
 
 Related public docs:
 
@@ -19,9 +19,12 @@ Related public docs:
 
 ## Scope
 
-The open-source CLI owns local runtime convergence and command wrapping. A
-separate control plane may provide desired state, credentials, and policy, but
-that platform-specific implementation is outside this repository.
+The open-source CLI owns local runtime convergence, command wrapping, runtime
+UI bridging, and diagnostics. The web app owns the hosted deployment dashboard
+surfaces, including Control UI and Terminal tabs. A separate control plane may
+provide desired state, credentials, terminal authorization, rollout policy, and
+deployment lifecycle, but that platform-specific implementation is outside this
+repository.
 
 The public contract covers:
 
@@ -31,6 +34,9 @@ The public contract covers:
 - writing non-secret local run configuration;
 - projecting short-lived secrets only for the current runtime session;
 - starting commands through `clawdi run -- <command>`;
+- providing stable command shims for managed runtime names;
+- proxying local runtime browser UIs through the runtime bridge;
+- exposing a dashboard Terminal contract for one deployment shell;
 - reporting status and diagnostics through runtime commands.
 
 The public contract does not cover:
@@ -41,12 +47,90 @@ The public contract does not cover:
 - internal service implementation;
 - image build pipelines or platform rollout details.
 
+## Core Architecture
+
+Managed runtime mode keeps the image stable and moves runtime behavior into the
+CLI plus manifest:
+
+```mermaid
+flowchart TD
+    Manifest[Hosted runtime manifest] --> Source[Manifest source and validation]
+    Source --> Init[clawdi runtime init --non-interactive]
+    Init --> State[/var/lib/clawdi state]
+    Init --> RunConfigs[config/run/<runtime>.json]
+    Init --> Shims[bin/<runtime> shims]
+    Init --> Supervisor[supervisord.conf]
+    Supervisor --> Watch[clawdi runtime watch]
+    Supervisor --> Bridge[clawdi runtime bridge<br/>authenticated surfaces]
+    Supervisor --> Runtime[clawdi run -- <runtime>]
+    Shims --> Runtime
+    Runtime --> AgentProcess[Agent runtime process]
+```
+
+The host image should contain only the stable host envelope:
+
+- runtime user and home directory;
+- base packages required by the CLI and supported installers;
+- a host policy file that marks the environment as hosted;
+- a stable CLI bootstrap path;
+- PATH ordering that puts the service-state shim directory first;
+- supervisor or equivalent process entrypoint.
+
+Runtime behavior should come from:
+
+- the runtime manifest;
+- the `clawdi` CLI package selected by manifest policy;
+- official runtime installers where supported;
+- explicit `run.command` entries for future or externally installed runtimes.
+
+Adding a new runtime should not require adding a new image-level wrapper. If the
+CLI already supports the runtime, the manifest can enable it. If the CLI does
+not have first-class installer/projection support yet, the manifest must provide
+an explicit `run.command` or the CLI rejects the manifest instead of guessing.
+Runtime availability and default enabled/disabled policy belong to the manifest
+and control plane, not to the host image.
+
+## Manifest Shapes
+
+The CLI accepts two related shapes:
+
+- `clawdi.hosted-runtime.manifest.v1` is the hosted control-plane response
+  shape. It can include `system`, `controlPlane`, `clawdiCli`, `runtimes`,
+  `providers`, `liveSync`, `mitmProfiles`, `mcp`, `tools`, and `recovery`.
+- `clawdi.runtimeDesiredState.v1` is the normalized internal convergence shape
+  consumed by `runtime init`.
+
+Normalization maps hosted fields into the internal shape:
+
+| Hosted field | Internal purpose |
+| --- | --- |
+| `deploymentId`, `environmentId`, `instanceId`, `generation` | Identity, cache keys, status, and idempotence |
+| `system.home`, `system.workspace` | Runtime HOME and workspace root |
+| `controlPlane.manifestUrl`, `controlPlane.cloudApiUrl` | Manifest datasource and API origin |
+| `clawdiCli.packageSpec` | System-managed CLI package selection |
+| `runtimes.<name>.enabled` | Run config, supervisor entry, and command shim state |
+| `runtimes.<name>.install` | Supported official installer input |
+| `runtimes.<name>.run` | Command, args, cwd, env, and PATH projection |
+| `bridge.surfaces` | Authenticated runtime surface listen/upstream mappings |
+| `providers` | Runtime-scoped AI provider projections and secret refs |
+| `mcp`, `tools` | Runtime MCP/tool projection input |
+| `liveSync` | Optional daemon sync configuration |
+| `mitmProfiles` | Explicit local broker profiles |
+| `recovery` | Manifest cache and offline-boot behavior |
+
+Manifest validation is defensive. Enabled built-in runtimes must use the
+expected official installer metadata unless they provide an explicit run
+command. Unknown runtime names require `run.command`; otherwise the manifest is
+rejected so the image does not need to know every future agent.
+
 ## Commands
 
 Runtime operators can use these commands in controlled environments:
 
 ```bash
 clawdi runtime init --non-interactive
+clawdi runtime watch
+clawdi runtime bridge
 clawdi runtime status --json
 clawdi runtime doctor --json
 clawdi run -- <command>
@@ -55,6 +139,18 @@ clawdi run -- <command>
 Normal local onboarding still uses `clawdi setup`. Runtime commands are for
 managed environments where configuration is supplied by policy or a manifest,
 not by an interactive user setup flow.
+
+`runtime watch` is the long-running reconciliation loop. It refreshes remote
+manifest state using ETags, applies changes, records status, and falls back to
+last-good cached manifests only when recovery policy allows it. `runtime
+bridge` exposes manifest-declared runtime surfaces behind hosted access
+controls.
+
+The current hosted bridge surfaces are browser-facing Control UIs. Each surface
+declares its listen address, upstream target, protocol behavior, auth model, and
+header rewrite rules. The bridge must not become a generic arbitrary-port
+forwarder. Terminal is deliberately out of scope because it is a shell-exec
+authorization path, not a browser UI proxy.
 
 ## Desired State Boundary
 
@@ -69,6 +165,59 @@ At the boundary:
 - the control plane owns desired-state generation and secret resolution;
 - the CLI owns local validation, projection, diagnostics, and command launch;
 - the runtime process owns normal agent behavior after launch.
+
+The CLI writes durable non-secret state under the service state root. Important
+outputs include:
+
+| Output | Purpose |
+| --- | --- |
+| `config/clawdi.json` | Redacted managed runtime config |
+| `sync/runtimes.json` | Runtime sync state |
+| `cache/manifest.last-good.json` | Last accepted manifest |
+| `cache/manifest.etag`, `cache/channels.etag` | Remote refresh cache validators |
+| `install-inventory/<runtime>.json` | Install/verify observation |
+| `config/projections/<runtime>.json` | Runtime projection payload |
+| `config/run/<runtime>.json` | `clawdi run` launch config |
+| `config/runtime-command-shims.json` | Active generated command shims |
+| `supervisor/supervisord.conf` | Process supervision plan |
+
+Short-lived secrets belong under the runtime run directory, not in durable
+config. Status and diagnostic output must redact secrets.
+
+## Command And Shim Model
+
+`clawdi run -- <command>` is both a local vault-injection command and the hosted
+runtime activation boundary. In hosted mode, it first tries to resolve the
+command against a generated runtime run config. If a matching enabled config
+exists, it launches that runtime with the configured command, args, cwd, env,
+PATH, secret refs, and optional broker profile. If the config exists but is
+disabled, `clawdi run` exits with a disabled-runtime error.
+
+Generated shims make managed runtime commands feel native:
+
+1. `runtime init` writes one dispatcher script under the service-state bin
+   directory.
+2. Each managed runtime command, such as `openclaw` or `hermes`, is a symlink to
+   that dispatcher.
+3. The host PATH puts the shim directory first for login and non-login shells.
+4. The dispatcher removes its own directory from PATH and executes:
+
+   ```bash
+   clawdi run -- "$command_name" "$@"
+   ```
+
+This prevents accidental fallback to native binaries for disabled runtimes while
+keeping ordinary shell commands real. A user typing `ls`, `git`, or `python`
+gets the normal shell binary. A user typing a managed runtime name gets the
+manifest-controlled `clawdi run` path.
+
+Supervisor uses the same boundary:
+
+```ini
+command=/usr/bin/env clawdi run -- <runtime>
+```
+
+The image does not need per-agent supervisor wrappers.
 
 ## Provider And Channel Routing
 
@@ -89,6 +238,41 @@ Channel configuration follows the same rule: the open-source contract describes
 the local projection shape and validation rules, while service-specific channel
 control planes remain outside this repository.
 
+## Control UI And Terminal
+
+Hosted deployment pages expose two live surfaces:
+
+- **Control UI** embeds or links to the runtime's browser UI through the
+  runtime bridge. It is runtime-specific and should be labelled as
+  `<Runtime> Control UI`.
+- **Terminal** opens a shell for the deployment. It is not split per agent; a
+  deployment has one Terminal surface.
+
+```mermaid
+flowchart LR
+    Dashboard[Dashboard] -->|Control UI URL| Bridge[clawdi runtime bridge]
+    Bridge --> RuntimeUI[Runtime browser UI<br/>loopback upstream]
+    Dashboard -->|Terminal WebSocket| HostedAPI[Hosted API]
+    HostedAPI --> Shell[Deployment shell<br/>default runtime user]
+```
+
+The browser Terminal contract is:
+
+1. The dashboard calls `POST /v2/deployments/{deployment_id}/terminal`.
+2. The API returns a short-lived `websocket_url`.
+3. The frontend removes any fragment token from the URL and sends it as a
+   WebSocket subprotocol named `clawdi-terminal.<token>` when possible.
+4. The frontend also sends the `tty` subprotocol and uses tty-style frames:
+   `0` for terminal input/output and `1` for resize.
+5. The terminal uses xterm, auto-fits to the panel, focuses on pointer down, and
+   switches theme when the dashboard switches light/dark mode.
+
+The service-side implementation is outside this repository. It must
+authenticate the user, require the deployment to be running, bind the terminal
+token to the deployment, and bridge the WebSocket to a shell as the default
+runtime user. Query-param token transport is kept only as a compatibility
+fallback for environments that reject custom WebSocket subprotocols.
+
 ## Security Rules
 
 - Do not persist auth tokens, private keys, provider secrets, or resolved vault
@@ -99,6 +283,23 @@ control planes remain outside this repository.
   request rewriting.
 - Keep defensive validation at every boundary: manifests, provider references,
   channel descriptors, filesystem paths, and process launch arguments.
+- Remove `CLAWDI_AUTH_TOKEN` from agent child process environments unless that
+  process is explicitly the Clawdi daemon or runtime reconciler.
+- Start runtime browser UIs without requiring public gateway auth when they are
+  reachable only through the local runtime bridge and hosted access controls.
+- Prefer WebSocket subprotocol auth for Terminal sessions so bearer tokens do
+  not normally appear in URLs or proxy access logs.
+
+## Recovery Rules
+
+- Cache only manifests that validate and converge without install/projection
+  errors.
+- Use ETags for remote refreshes where the datasource supports them.
+- Offline boot is allowed only when `recovery.allowOfflineBoot` is true and the
+  cached manifest does not require missing secret values.
+- `runtime status --json` and `runtime doctor --json` should surface enough
+  state to distinguish manifest fetch failures, manifest rejection, degraded
+  offline boot, install failures, and disabled runtimes.
 
 ## Implementation Notes
 
@@ -109,3 +310,19 @@ The CLI implementation should remain portable and testable:
 - generated provider and channel projections should be deterministic;
 - diagnostics should report actionable local state without exposing secrets;
 - operator-only behavior should not change normal laptop onboarding.
+
+Primary implementation files:
+
+| Area | Files |
+| --- | --- |
+| Manifest schema | `packages/cli/src/runtime/manifest-contract.ts` |
+| Manifest fetch/normalize/validate | `packages/cli/src/runtime/manifest-source.ts` |
+| Runtime convergence | `packages/cli/src/runtime/manifest.ts` |
+| Runtime paths | `packages/cli/src/runtime/paths.ts` |
+| Host policy | `packages/cli/src/runtime/host-policy.ts` |
+| Run config | `packages/cli/src/runtime/run-config.ts` |
+| Command execution | `packages/cli/src/commands/run.ts` |
+| CLI update policy | `packages/cli/src/runtime/cli-update.ts` |
+| Runtime bridge | `packages/cli/src/runtime/bridge.ts` |
+| Dashboard terminal | `apps/web/src/hosted/agents/hosted-terminal-panel.tsx` |
+| Dashboard hosted detail page | `apps/web/src/hosted/agents/hosted-agent-detail.tsx` |

--- a/docs/plans/managed-runtime-cli.md
+++ b/docs/plans/managed-runtime-cli.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Status | Public implementation notes |
-| Last updated | 2026-06-29 |
+| Last updated | 2026-06-30 |
 | Owner | CLI runtime layer |
 
 This note documents the open-source CLI surface for managed runtime
@@ -22,6 +22,8 @@ Related public contract: [`../managed-runtime.md`](../managed-runtime.md).
   runtimes.
 - Avoid storing secrets in durable manifests, caches, shell startup files, or
   generated config.
+- Keep the runtime image stable by avoiding image-level per-agent wrappers.
+- Route managed runtime commands through generated run config and `clawdi run`.
 
 ## Command Surface
 
@@ -30,6 +32,8 @@ Runtime commands are intentionally small:
 ```bash
 clawdi runtime init --non-interactive [--json]
 clawdi runtime init --manifest-file <path> [--json]
+clawdi runtime watch [--self-heal-ms <ms>]
+clawdi runtime bridge
 clawdi runtime status [--json]
 clawdi runtime doctor [--json]
 clawdi run -- <command>
@@ -57,10 +61,27 @@ operator-provided manifest.
 3. Install or verify selected runtimes through their normal installers.
 4. Write non-secret run configuration.
 5. Project short-lived secret files only when needed for the current session.
-6. Record status and diagnostics.
+6. Write command shims for active runtime names.
+7. Render supervisor config.
+8. Record status and diagnostics.
 
 The command should be idempotent. Re-running it with the same desired state
 should not produce unnecessary config churn.
+
+Key generated outputs:
+
+- `config/run/<runtime>.json` for `clawdi run`;
+- `config/projections/<runtime>.json` for runtime-specific config projection;
+- `config/runtime-command-shims.json` plus symlinks under the service-state bin
+  directory;
+- `supervisor/supervisord.conf` with each runtime launched as
+  `clawdi run -- <runtime>`;
+- `cache/manifest.last-good.json` and ETag files for recovery and refresh;
+- `install-inventory/<runtime>.json` for diagnostics.
+
+`runtime watch` is the remote refresh loop. It should use cache validators,
+apply only validated desired state, record rejected generations, and keep a
+last-good manifest only after successful convergence.
 
 ## Run Boundary
 
@@ -75,6 +96,40 @@ Rules:
 - keep provider and channel projection deterministic;
 - avoid source patching of target runtimes;
 - keep request rewriting behind explicit runtime profiles.
+- delete `CLAWDI_AUTH_TOKEN` before launching agent child processes.
+
+In hosted mode, runtime command shims make managed runtimes feel native. The
+host PATH points at the shim directory first. A shim named `openclaw`, `hermes`,
+or another manifest runtime removes the shim directory from PATH, then calls:
+
+```bash
+clawdi run -- "$command_name" "$@"
+```
+
+This is the only per-runtime command wrapper. The image should not grow a new
+wrapper each time a runtime is added. Disabled run configs must fail closed:
+`clawdi run` reports the runtime as disabled and never falls back to a native
+binary later on PATH.
+
+For ordinary shell commands that are not managed runtime names, the hosted
+terminal remains a real shell. The command shim model only intercepts command
+names that `runtime init` generated.
+
+## Runtime Support Model
+
+Built-in support is explicit. The CLI currently knows official installer and
+default run settings for supported runtimes such as OpenClaw and Hermes. A
+future or externally supplied runtime can still be represented in the manifest
+when it includes an explicit `run.command`.
+
+Rules:
+
+- supported runtimes with installer metadata must use official installer URLs;
+- unknown runtime names with install metadata are rejected unless the CLI has
+  been upgraded to support them;
+- unknown runtime names without `run.command` are rejected;
+- unknown runtime names with `run.command` can be launched and shimmed without
+  image changes.
 
 ## Provider Projection
 
@@ -108,6 +163,23 @@ Channel projection follows the same contract-driven pattern:
 The public CLI contract describes local projection and validation only. Service
 specific channel management remains outside this repository.
 
+## Control UI And Terminal Notes
+
+`clawdi runtime bridge` is the local authenticated bridge for manifest-declared
+runtime surfaces. The current hosted surfaces use `kind: "control-ui"` and the
+dashboard labels them as `<Runtime> Control UI` because each is a
+runtime-specific browser application.
+
+Bridge surfaces declare listen/upstream targets, protocol handling, auth
+behavior, and header rewrite rules explicitly. The bridge is not an arbitrary
+port forwarder. Terminal is not a bridge surface.
+
+The hosted Terminal is a dashboard/API contract, not a CLI command. The frontend
+requests a short-lived terminal WebSocket URL, moves fragment tokens into a
+`clawdi-terminal.<token>` WebSocket subprotocol by default, uses `tty` framing,
+and falls back to query-token transport only for compatibility. Terminal is
+deployment-scoped and should not be duplicated per agent.
+
 ## Testing Expectations
 
 Runtime changes should include focused tests for:
@@ -118,5 +190,10 @@ Runtime changes should include focused tests for:
 - `runtime init` idempotence;
 - `runtime status` and `runtime doctor` JSON output;
 - `clawdi run -- <runtime>` environment construction.
+- command shim routing, PATH cleanup, stale-shim cleanup, and disabled-runtime
+  behavior;
+- supervisor config rendering for watch, runtime bridge, daemon, and runtimes;
+- terminal URL token transport and light/dark xterm theme behavior when web UI
+  code changes.
 
 Generated API clients should be regenerated whenever backend contracts change.

--- a/docs/plans/managed-runtime-roadmap.md
+++ b/docs/plans/managed-runtime-roadmap.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Status | Public roadmap |
-| Last updated | 2026-06-29 |
+| Last updated | 2026-06-30 |
 | Owner | CLI runtime layer |
 
 This roadmap tracks the open-source CLI work needed for managed runtime
@@ -14,22 +14,32 @@ this repository.
 ## Current Capabilities
 
 - Runtime policy and desired-state validation.
-- `clawdi runtime init/status/doctor` command surface.
+- `clawdi runtime init/watch/bridge/status/doctor` command surface.
 - Local fixture manifests for tests and diagnostics.
 - Deterministic provider and channel projection.
 - Non-secret desired-state cache and secret redaction.
 - Runtime launch through `clawdi run -- <command>`.
+- Generated command shims for managed runtime names.
+- Stable-image contract: runtime behavior is driven by manifest + CLI, not
+  image-level per-agent wrappers.
+- Supervisor rendering that launches runtimes through `clawdi run -- <runtime>`.
+- Runtime bridge for Control UI surfaces.
+- Hosted Terminal dashboard contract with xterm, tty-style framing, and
+  WebSocket subprotocol token transport.
 - Broker profile validation and local broker lifecycle tests.
 
 ## Active Work
 
 1. Keep the runtime desired-state schema small and explicit.
-2. Keep provider modes provider-oriented:
+2. Keep the stable-image contract intact: new runtime behavior should come from
+   CLI support or manifest `run.command`, not image wrapper churn.
+3. Keep provider modes provider-oriented:
    `openai_chat`, `openai_responses`, `anthropic_messages`, and
    `google_generate_content`.
-3. Keep target-runtime transport names inside projection code only.
-4. Improve diagnostics without printing secrets.
-5. Expand focused tests for provider, channel, and run-environment projection.
+4. Keep target-runtime transport names inside projection code only.
+5. Improve diagnostics without printing secrets.
+6. Expand focused tests for provider, channel, run-environment, command-shim,
+   Control UI, and Terminal projection.
 
 ## Non-Goals
 
@@ -38,3 +48,4 @@ this repository.
 - No source patching of upstream agent runtimes.
 - No durable storage of resolved secrets.
 - No runtime-specific transport names as Clawdi provider API modes.
+- No image-level per-agent command wrappers.

--- a/docs/plans/runtime-projection-boundary.md
+++ b/docs/plans/runtime-projection-boundary.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Status | Public boundary note |
-| Last updated | 2026-06-29 |
+| Last updated | 2026-06-30 |
 | Owner | CLI runtime layer |
 
 This note defines what belongs in the open-source runtime projection layer. It
@@ -27,6 +27,18 @@ The wrapper prepares environment variables and local config, then executes the
 target command. Normal runtime startup should not require users to pass
 endpoint, token, or certificate flags manually.
 
+In hosted runtime mode, managed runtime names are also exposed through generated
+command shims. The shim dispatcher immediately calls the same boundary:
+
+```bash
+clawdi run -- "$command_name" "$@"
+```
+
+This keeps the host image stable. The image only needs a generic shim directory
+at the front of PATH; runtime-specific behavior comes from the manifest and the
+CLI. If a runtime is disabled in the current manifest, `clawdi run` rejects it
+and the shim must not fall back to any native binary later on PATH.
+
 ## Projection Flow
 
 ```mermaid
@@ -40,12 +52,16 @@ flowchart LR
         CLI --> Provider[Provider projection]
         CLI --> Channel[Channel projection]
         CLI --> Broker[Optional MITM profile projection]
+        CLI --> RunConfig[Runtime run config]
+        CLI --> Shims[Command shims]
     end
 
     Provider --> OpenClaw[OpenClaw config]
     Provider --> Hermes[Hermes config]
     Channel --> OpenClaw
     Broker --> Runner[clawdi run environment]
+    RunConfig --> Runner
+    Shims --> Runner
     Runner --> Target[Target agent process]
 ```
 
@@ -104,6 +120,44 @@ The CLI must not own:
 - target runtime update channels;
 - user BYOK provider traffic interception by default.
 
+## Runtime Command Boundary
+
+The CLI may own:
+
+- generated run config files;
+- command shim creation and stale-shim cleanup;
+- PATH cleanup inside the shim dispatcher;
+- disabled-runtime enforcement;
+- supervisor commands that start runtimes through `clawdi run -- <runtime>`;
+- support for future runtime names when an explicit `run.command` is supplied.
+
+The CLI must not own:
+
+- image-level per-agent wrapper scripts;
+- private deployment selection or rollout policy;
+- silent fallback from a disabled managed runtime to a native binary;
+- target runtime source patching as the default integration path.
+
+Built-in installer/projection support is currently explicit. Unknown runtime
+names are acceptable only when the manifest includes enough `run.command`
+information for the CLI to launch them deterministically.
+
+## Control UI And Terminal Boundary
+
+Control UI is a runtime browser UI surface proxied by the local runtime bridge.
+Terminal is a deployment shell surface exposed by the dashboard and hosted API
+contract. They are intentionally separate:
+
+- Control UI is runtime-specific.
+- The bridge accepts explicitly declared runtime surfaces with listen/upstream
+  targets and surface-specific policy; it must not become arbitrary port
+  forwarding.
+- Terminal is deployment-scoped and not split per agent.
+- Terminal token transport should prefer WebSocket subprotocols, with query
+  string transport only as a compatibility fallback.
+- The service-side shell bridge and deployment lifecycle are outside this
+  repository.
+
 ## Testing Scope
 
 In-repo tests should use local fixtures or fake upstreams for:
@@ -113,6 +167,8 @@ In-repo tests should use local fixtures or fake upstreams for:
 - deterministic provider and channel projection;
 - broker startup and shutdown around a child process;
 - explicit request rewrite behavior.
+- command shim routing and disabled-runtime behavior;
+- terminal WebSocket URL handling and theme/status behavior.
 
 Real service credentials and deployment-specific canaries belong outside the
 open-source repository.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.28",
+	"version": "0.12.10-beta.29",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -10,6 +10,7 @@ import { ApiClient, unwrap } from "../lib/api-client";
 import { getConfig } from "../lib/config";
 import { PRIVATE_DIR_MODE, writePrivateFileAtomic } from "../lib/private-file";
 import { getCliVersion } from "../lib/version";
+import { startRuntimeBridge } from "../runtime/bridge";
 import { applyRuntimeChannelsToManifestLoad } from "../runtime/channels";
 import { applyRuntimeCliDesiredState, type RuntimeCliUpdateResult } from "../runtime/cli-update";
 import { readHostPolicy } from "../runtime/host-policy";
@@ -37,7 +38,6 @@ import {
 	writeRuntimeBootStatus,
 	writeRuntimeWatchStatus,
 } from "../runtime/state";
-import { startRuntimeUiBridge } from "../runtime/ui-bridge";
 
 type ChannelAccount = components["schemas"]["ChannelAccountResponse"];
 type ChannelAccountCreate = components["schemas"]["ChannelAccountCreate"];
@@ -1962,16 +1962,16 @@ function nextCliInstallBackoffMs(previousMs: number): number {
 	return Math.min(previousMs * 2, 300_000);
 }
 
-export async function runtimeUiBridge(): Promise<void> {
+export async function runtimeBridge(): Promise<void> {
 	if (detectRuntimeMode() !== "hosted") {
-		throw new Error("runtime ui-bridge is only available in hosted runtime mode");
+		throw new Error("runtime bridge is only available in hosted runtime mode");
 	}
-	const bridge = await startRuntimeUiBridge();
+	const bridge = await startRuntimeBridge();
 	console.error(
-		`runtime ui bridge listening on ${bridge.targets
+		`runtime bridge listening on ${bridge.surfaces
 			.map(
-				(target) =>
-					`${target.listenHost}:${target.listenPort}->${target.targetHost}:${target.targetPort}`,
+				(surface) =>
+					`${surface.listenHost}:${surface.listenPort}->${surface.upstreamHost}:${surface.upstreamPort}`,
 			)
 			.join(", ")}`,
 	);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -58,7 +58,8 @@ Environment:
   CLAWDI_NO_AUTO_UPDATE    Skip CLI/daemon background auto-update (also disables via \`config set autoUpdate false\`)
   CLAWDI_RUNTIME_MODE      Explicit runtime mode override for hosted tests/operators
   CLAWDI_AUTH_TOKEN        Clawdi Cloud auth token; the only hosted container credential
-  UI_ACCESS_TOKEN          Hosted runtime UI bridge token for OpenClaw/Hermes dashboards
+  CLAWDI_RUNTIME_BRIDGE_TOKEN
+                           Hosted runtime bridge token for authenticated surfaces
   CLAUDE_CONFIG_DIR        Custom Claude Code home (else ~/.claude)
   CODEX_HOME               Custom Codex home (else ~/.codex)
   HERMES_HOME              Custom Hermes home (else ~/.hermes)
@@ -724,11 +725,11 @@ runtimeCmd
 	);
 
 runtimeCmd
-	.command("ui-bridge")
-	.description("Run the hosted runtime authenticated UI bridge")
+	.command("bridge")
+	.description("Run the hosted runtime authenticated bridge")
 	.action(async () => {
-		const { runtimeUiBridge } = await import("./commands/runtime.js");
-		await runtimeUiBridge();
+		const { runtimeBridge } = await import("./commands/runtime.js");
+		await runtimeBridge();
 	});
 
 runtimeCmd

--- a/packages/cli/src/runtime/bridge.ts
+++ b/packages/cli/src/runtime/bridge.ts
@@ -1,28 +1,42 @@
 import { timingSafeEqual } from "node:crypto";
 import { createConnection, createServer, isIP, type Server, type Socket } from "node:net";
+import { z } from "zod";
+import {
+	type RuntimeBridgeSurfaceInput,
+	type RuntimeBridgeSurfaceSpec,
+	type RuntimeManifest,
+	runtimeBridgeSurfaceSchema,
+} from "./manifest-contract";
 
-export const UI_ACCESS_TOKEN_ENV = "UI_ACCESS_TOKEN";
-export const UI_ACCESS_COOKIE = "clawdi_ui";
-export const UI_FRAME_ANCESTORS_ENV = "CLAWDI_UI_FRAME_ANCESTORS";
-export const UI_BRIDGE_LISTEN_HOST_ENV = "CLAWDI_UI_BRIDGE_LISTEN_HOST";
-export const DEFAULT_UI_FRAME_ANCESTORS = "'self' https://*.clawdi.ai";
+export const RUNTIME_BRIDGE_TOKEN_ENV = "CLAWDI_RUNTIME_BRIDGE_TOKEN";
+export const RUNTIME_BRIDGE_COOKIE = "clawdi_runtime_bridge";
+export const RUNTIME_BRIDGE_FRAME_ANCESTORS_ENV = "CLAWDI_RUNTIME_BRIDGE_FRAME_ANCESTORS";
+export const RUNTIME_BRIDGE_LISTEN_HOST_ENV = "CLAWDI_RUNTIME_BRIDGE_LISTEN_HOST";
+export const RUNTIME_BRIDGE_SURFACES_ENV = "CLAWDI_RUNTIME_BRIDGE_SURFACES";
+export const DEFAULT_RUNTIME_BRIDGE_FRAME_ANCESTORS = "'self' https://*.clawdi.ai";
 
-export interface RuntimeUiBridgeTarget {
+export type RuntimeBridgeSurfaceKind = "control-ui";
+const runtimeBridgeRuntimeSurfaceSchema = runtimeBridgeSurfaceSchema.extend({
+	listenPort: z.number().int().min(0).max(65535),
+});
+
+export interface RuntimeBridgeSurface {
 	name: string;
+	kind: RuntimeBridgeSurfaceKind;
 	listenHost: string;
 	listenPort: number;
-	targetHost: string;
-	targetPort: number;
+	upstreamHost: string;
+	upstreamPort: number;
 }
 
-export interface RuntimeUiBridgeServer {
-	targets: RuntimeUiBridgeTarget[];
+export interface RuntimeBridgeServer {
+	surfaces: RuntimeBridgeSurface[];
 	close: () => Promise<void>;
 }
 
-export interface RuntimeUiBridgeOptions {
+export interface RuntimeBridgeOptions {
 	token?: string;
-	targets?: RuntimeUiBridgeTarget[];
+	surfaces?: RuntimeBridgeSurfaceInput[];
 	frameAncestors?: string;
 }
 
@@ -48,23 +62,6 @@ interface AuthUnauthorized {
 }
 
 type AuthResult = AuthQueryToken | AuthAuthorized | AuthUnauthorized;
-
-export const DEFAULT_UI_BRIDGE_TARGETS: RuntimeUiBridgeTarget[] = [
-	{
-		name: "openclaw",
-		listenHost: "0.0.0.0",
-		listenPort: 28789,
-		targetHost: "127.0.0.1",
-		targetPort: 18789,
-	},
-	{
-		name: "hermes",
-		listenHost: "0.0.0.0",
-		listenPort: 28793,
-		targetHost: "127.0.0.1",
-		targetPort: 9119,
-	},
-];
 
 const HEADER_TIMEOUT_MS = 60_000;
 const UPSTREAM_CONNECT_TIMEOUT_MS = 10_000;
@@ -92,24 +89,29 @@ const PROXY_FORWARDING_HEADERS = new Set([
 	"x-real-ip",
 ]);
 
-export async function startRuntimeUiBridge(
-	options: RuntimeUiBridgeOptions = {},
-): Promise<RuntimeUiBridgeServer> {
-	const token = options.token ?? process.env[UI_ACCESS_TOKEN_ENV]?.trim() ?? "";
-	const targets = options.targets ?? defaultRuntimeUiBridgeTargets();
+export async function startRuntimeBridge(
+	options: RuntimeBridgeOptions = {},
+): Promise<RuntimeBridgeServer> {
+	const token = options.token ?? process.env[RUNTIME_BRIDGE_TOKEN_ENV]?.trim() ?? "";
+	const surfaces = resolveRuntimeBridgeSurfaceInputs(
+		options.surfaces ?? runtimeBridgeSurfaceInputsFromEnv() ?? [],
+	);
+	if (surfaces.length === 0) {
+		throw new Error("no runtime bridge surfaces configured");
+	}
 	const frameAncestors =
 		options.frameAncestors?.trim() ||
-		process.env[UI_FRAME_ANCESTORS_ENV]?.trim() ||
-		DEFAULT_UI_FRAME_ANCESTORS;
+		process.env[RUNTIME_BRIDGE_FRAME_ANCESTORS_ENV]?.trim() ||
+		DEFAULT_RUNTIME_BRIDGE_FRAME_ANCESTORS;
 	const servers: Server[] = [];
-	const listeningTargets: RuntimeUiBridgeTarget[] = [];
+	const listeningSurfaces: RuntimeBridgeSurface[] = [];
 	try {
-		for (const target of targets) {
-			const server = createBridgeServer(target, token, frameAncestors);
-			await listen(server, target.listenHost, target.listenPort);
+		for (const surface of surfaces) {
+			const server = createBridgeServer(surface, token, frameAncestors);
+			await listen(server, surface.listenHost, surface.listenPort);
 			const address = server.address();
-			const listenPort = typeof address === "object" && address ? address.port : target.listenPort;
-			listeningTargets.push({ ...target, listenPort });
+			const listenPort = typeof address === "object" && address ? address.port : surface.listenPort;
+			listeningSurfaces.push({ ...surface, listenPort });
 			servers.push(server);
 		}
 	} catch (error) {
@@ -117,30 +119,94 @@ export async function startRuntimeUiBridge(
 		throw error;
 	}
 	return {
-		targets: listeningTargets,
+		surfaces: listeningSurfaces,
 		close: async () => {
 			await Promise.allSettled(servers.map((server) => closeServer(server)));
 		},
 	};
 }
 
-export function defaultRuntimeUiBridgeTargets(): RuntimeUiBridgeTarget[] {
-	const listenHost = process.env[UI_BRIDGE_LISTEN_HOST_ENV]?.trim() || "0.0.0.0";
-	return DEFAULT_UI_BRIDGE_TARGETS.map((target) => ({ ...target, listenHost }));
+export function runtimeBridgeSurfaceSpecsForManifest(
+	manifest: Pick<RuntimeManifest, "bridge">,
+): RuntimeBridgeSurfaceInput[] {
+	return manifest.bridge ? [...manifest.bridge.surfaces] : [];
+}
+
+export function runtimeBridgeSurfacesForManifest(
+	manifest: Pick<RuntimeManifest, "bridge">,
+): RuntimeBridgeSurface[] {
+	return resolveRuntimeBridgeSurfaceInputs(runtimeBridgeSurfaceSpecsForManifest(manifest));
+}
+
+function runtimeBridgeSurfaceInputsFromEnv(): RuntimeBridgeSurfaceInput[] | null {
+	const raw = process.env[RUNTIME_BRIDGE_SURFACES_ENV]?.trim();
+	if (!raw) return null;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (error) {
+		throw new Error(
+			`invalid ${RUNTIME_BRIDGE_SURFACES_ENV}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+	if (!Array.isArray(parsed)) {
+		throw new Error(`invalid ${RUNTIME_BRIDGE_SURFACES_ENV}: expected a JSON array`);
+	}
+	return parsed.map((item, index) => parseRuntimeBridgeSurfaceInput(item, index));
+}
+
+function parseRuntimeBridgeSurfaceInput(value: unknown, index: number): RuntimeBridgeSurfaceSpec {
+	const parsed = runtimeBridgeSurfaceSchema.safeParse(value);
+	if (parsed.success) return parsed.data;
+	throw new Error(
+		`invalid ${RUNTIME_BRIDGE_SURFACES_ENV}[${index}]: ${parsed.error.issues
+			.map((issue) => issue.message)
+			.join("; ")}`,
+	);
+}
+
+function resolveRuntimeBridgeSurfaceInputs(
+	inputs: RuntimeBridgeSurfaceInput[],
+	defaultListenHost = process.env[RUNTIME_BRIDGE_LISTEN_HOST_ENV]?.trim() || "0.0.0.0",
+): RuntimeBridgeSurface[] {
+	const seen = new Set<string>();
+	return inputs.map((input, index) => {
+		const parsed = runtimeBridgeRuntimeSurfaceSchema.safeParse(input);
+		if (!parsed.success) {
+			throw new Error(
+				`invalid runtime bridge surface ${index}: ${parsed.error.issues
+					.map((issue) => issue.message)
+					.join("; ")}`,
+			);
+		}
+		const surface = {
+			...parsed.data,
+			listenHost: parsed.data.listenHost?.trim() || defaultListenHost,
+			upstreamHost: parsed.data.upstreamHost.trim(),
+		};
+		const key = `${surface.listenHost}:${surface.listenPort}`;
+		if (surface.listenPort !== 0 && seen.has(key)) {
+			throw new Error(`duplicate runtime bridge listen address: ${key}`);
+		}
+		if (surface.listenPort !== 0) seen.add(key);
+		return surface;
+	});
 }
 
 function createBridgeServer(
-	target: RuntimeUiBridgeTarget,
+	surface: RuntimeBridgeSurface,
 	token: string,
 	frameAncestors: string,
 ): Server {
 	return createServer((clientSocket) => {
-		handleClientConnection(target, token, frameAncestors, clientSocket);
+		handleClientConnection(surface, token, frameAncestors, clientSocket);
 	});
 }
 
 function handleClientConnection(
-	target: RuntimeUiBridgeTarget,
+	surface: RuntimeBridgeSurface,
 	token: string,
 	frameAncestors: string,
 	clientSocket: Socket,
@@ -181,13 +247,13 @@ function handleClientConnection(
 			writeRawHttpResponse(clientSocket, 400, "Bad Request", "Bad Request");
 			return;
 		}
-		handleParsedRequest(target, token, frameAncestors, clientSocket, parsed, remaining);
+		handleParsedRequest(surface, token, frameAncestors, clientSocket, parsed, remaining);
 	};
 	clientSocket.on("data", onData);
 }
 
 function handleParsedRequest(
-	target: RuntimeUiBridgeTarget,
+	surface: RuntimeBridgeSurface,
 	token: string,
 	frameAncestors: string,
 	clientSocket: Socket,
@@ -195,7 +261,7 @@ function handleParsedRequest(
 	remaining: Buffer,
 ): void {
 	if (isHealthCheckRequest(parsed)) {
-		void respondToHealthCheck(target, clientSocket);
+		void respondToHealthCheck(surface, clientSocket);
 		return;
 	}
 	const auth = authenticate(parsed.requestTarget, parsed.headers, token);
@@ -209,14 +275,14 @@ function handleParsedRequest(
 		]);
 		return;
 	}
-	proxyRawRequest(target, frameAncestors, clientSocket, parsed, remaining);
+	proxyRawRequest(surface, frameAncestors, clientSocket, parsed, remaining);
 }
 
 async function respondToHealthCheck(
-	target: RuntimeUiBridgeTarget,
+	surface: RuntimeBridgeSurface,
 	clientSocket: Socket,
 ): Promise<void> {
-	const healthy = await canConnectToTarget(target);
+	const healthy = await canConnectToUpstream(surface);
 	if (healthy) {
 		writeRawHttpResponse(clientSocket, 200, "OK", "OK", [["Cache-Control", "no-store"]]);
 		return;
@@ -232,11 +298,11 @@ function isHealthCheckRequest(parsed: ParsedHttpRequest): boolean {
 	return url?.pathname === "/health";
 }
 
-function canConnectToTarget(target: RuntimeUiBridgeTarget): Promise<boolean> {
+function canConnectToUpstream(surface: RuntimeBridgeSurface): Promise<boolean> {
 	return new Promise((resolve) => {
 		const socket = createConnection({
-			host: target.targetHost,
-			port: target.targetPort,
+			host: surface.upstreamHost,
+			port: surface.upstreamPort,
 		});
 		let done = false;
 		const finish = (healthy: boolean) => {
@@ -253,15 +319,15 @@ function canConnectToTarget(target: RuntimeUiBridgeTarget): Promise<boolean> {
 }
 
 function proxyRawRequest(
-	target: RuntimeUiBridgeTarget,
+	surface: RuntimeBridgeSurface,
 	frameAncestors: string,
 	clientSocket: Socket,
 	parsed: ParsedHttpRequest,
 	remaining: Buffer,
 ): void {
 	const upstreamSocket = createConnection({
-		host: target.targetHost,
-		port: target.targetPort,
+		host: surface.upstreamHost,
+		port: surface.upstreamPort,
 	});
 	const isUpgrade = isUpgradeRequest(parsed.headers);
 	let connected = false;
@@ -280,7 +346,7 @@ function proxyRawRequest(
 		connected = true;
 		clearTimeout(timer);
 		if (!isUpgrade) pipeUpstreamHttpResponse(upstreamSocket, clientSocket, frameAncestors);
-		upstreamSocket.write(buildProxyRequestHead(parsed, target));
+		upstreamSocket.write(buildProxyRequestHead(parsed, surface));
 		if (remaining.length > 0) upstreamSocket.write(remaining);
 		clientSocket.pipe(upstreamSocket);
 		if (isUpgrade) upstreamSocket.pipe(clientSocket);
@@ -416,14 +482,14 @@ function authenticate(
 		const redirectLocation = `${url.pathname}${url.search}`;
 		return { status: "query-token", redirectLocation: redirectLocation || "/" };
 	}
-	const cookie = parseCookies(headers.get("cookie")).get(UI_ACCESS_COOKIE) ?? null;
+	const cookie = parseCookies(headers.get("cookie")).get(RUNTIME_BRIDGE_COOKIE) ?? null;
 	if (constantTimeEquals(cookie, token)) return { status: "authorized" };
 	return { status: "unauthorized" };
 }
 
 function requestUrl(requestTarget: string): URL | null {
 	try {
-		return new URL(requestTarget, "http://clawdi-runtime-ui.local");
+		return new URL(requestTarget, "http://clawdi-runtime-bridge.local");
 	} catch {
 		return null;
 	}
@@ -473,14 +539,14 @@ function constantTimeEquals(input: string | null | undefined, expected: string):
 }
 
 function sessionCookie(token: string): string {
-	return `${UI_ACCESS_COOKIE}=${encodeURIComponent(
+	return `${RUNTIME_BRIDGE_COOKIE}=${encodeURIComponent(
 		token,
 	)}; Secure; HttpOnly; SameSite=Strict; Path=/`;
 }
 
-function buildProxyRequestHead(parsed: ParsedHttpRequest, target: RuntimeUiBridgeTarget): string {
+function buildProxyRequestHead(parsed: ParsedHttpRequest, surface: RuntimeBridgeSurface): string {
 	const isUpgrade = isUpgradeRequest(parsed.headers);
-	const authority = targetAuthority(target);
+	const authority = upstreamAuthority(surface);
 	const origin = `http://${authority}`;
 	let originWritten = false;
 	let refererWritten = false;
@@ -549,7 +615,7 @@ function removeBridgeCookie(value: string): string {
 			if (!part) return false;
 			const index = part.indexOf("=");
 			const name = (index === -1 ? part : part.slice(0, index)).trim();
-			return name !== UI_ACCESS_COOKIE;
+			return name !== RUNTIME_BRIDGE_COOKIE;
 		})
 		.join("; ");
 }
@@ -563,9 +629,10 @@ function rewriteReferer(value: string, origin: string): string {
 	}
 }
 
-function targetAuthority(target: RuntimeUiBridgeTarget): string {
-	const host = isIP(target.targetHost) === 6 ? `[${target.targetHost}]` : target.targetHost;
-	return `${host}:${target.targetPort}`;
+function upstreamAuthority(surface: RuntimeBridgeSurface): string {
+	const host =
+		isIP(surface.upstreamHost) === 6 ? `[${surface.upstreamHost}]` : surface.upstreamHost;
+	return `${host}:${surface.upstreamPort}`;
 }
 
 function writeRedirectResponse(socket: Socket, location: string, token: string): void {

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -61,6 +61,30 @@ const liveSyncSchema = z
 	})
 	.strict();
 
+const tcpPortSchema = z.number().int().min(1).max(65535);
+const runtimeBridgeSurfaceNameSchema = z
+	.string()
+	.min(1)
+	.max(64)
+	.regex(/^[a-z0-9][a-z0-9._-]*$/, "must be a lowercase surface id");
+
+export const runtimeBridgeSurfaceSchema = z
+	.object({
+		name: runtimeBridgeSurfaceNameSchema,
+		kind: z.enum(["control-ui"]),
+		listenHost: z.string().min(1).optional(),
+		listenPort: tcpPortSchema,
+		upstreamHost: z.string().min(1).default("127.0.0.1"),
+		upstreamPort: tcpPortSchema,
+	})
+	.strict();
+
+const runtimeBridgeSchema = z
+	.object({
+		surfaces: z.array(runtimeBridgeSurfaceSchema).default([]),
+	})
+	.strict();
+
 const runtimeProjectionSchema = z
 	.object({
 		sourceSchemaVersion: z.string().min(1).optional(),
@@ -88,6 +112,7 @@ const runtimeDesiredStateShape = {
 		.strict(),
 	clawdiCli: cliPayloadPolicySchema.optional(),
 	runtimes: z.record(runtimeNameSchema, runtimeSchema),
+	bridge: runtimeBridgeSchema.optional(),
 	projection: runtimeProjectionSchema.optional(),
 	mitmProfiles: mitmProfileInputBundleSchema.optional(),
 	liveSync: liveSyncSchema.optional(),
@@ -169,6 +194,7 @@ export const hostedRuntimeManifestSchema = z
 			}),
 		clawdiCli: cliPayloadPolicySchema.optional(),
 		runtimes: z.record(runtimeNameSchema, hostedRuntimeEntrySchema),
+		bridge: runtimeBridgeSchema.optional(),
 		providers: z
 			.record(
 				z.string().min(1),
@@ -211,3 +237,5 @@ export type RuntimeManifest = z.output<typeof manifestSchema>;
 export type RuntimeInstall = z.infer<typeof installSchema>;
 export type HostedRuntimeManifest = z.infer<typeof hostedRuntimeManifestSchema>;
 export type LiveSyncAgent = z.infer<typeof liveSyncAgentSchema>;
+export type RuntimeBridgeSurfaceInput = z.input<typeof runtimeBridgeSurfaceSchema>;
+export type RuntimeBridgeSurfaceSpec = z.output<typeof runtimeBridgeSurfaceSchema>;

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -14,7 +14,6 @@ import {
 } from "./manifest-contract";
 import type { RuntimePaths } from "./paths";
 import { isSupportedRuntimeName, type RuntimeRunSettings } from "./run-config";
-import { UI_ACCESS_TOKEN_ENV } from "./ui-bridge";
 
 export interface RuntimeManifestLoad {
 	manifest: RuntimeManifest;
@@ -473,7 +472,6 @@ function runtimeFetchFailureStage(error: unknown): "network" | "auth" {
 function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): RuntimeManifest {
 	const home = hosted.system?.home || "/home/clawdi";
 	const workspaceRoot = hosted.system?.workspace || join(home, "clawdi");
-	const runtimes = hostedRuntimeEntries(hosted.runtimes);
 	return {
 		schemaVersion: RUNTIME_DESIRED_STATE_SCHEMA_VERSION,
 		deploymentId: hosted.deploymentId,
@@ -494,7 +492,7 @@ function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): Runtime
 				}
 			: { ...DEFAULT_CLAWDI_CLI_POLICY },
 		runtimes: Object.fromEntries(
-			Object.entries(runtimes).map(([name, runtime]) => [
+			Object.entries(hosted.runtimes).map(([name, runtime]) => [
 				name,
 				{
 					enabled: runtime.enabled,
@@ -513,6 +511,7 @@ function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): Runtime
 				},
 			]),
 		),
+		bridge: hosted.bridge,
 		projection: {
 			sourceSchemaVersion: hosted.schemaVersion,
 			system: hosted.system ?? null,
@@ -525,23 +524,6 @@ function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): Runtime
 		recovery: {
 			cacheManifest: hosted.recovery?.cacheManifest ?? true,
 			allowOfflineBoot: hosted.recovery?.allowOfflineBoot ?? true,
-		},
-	};
-}
-
-function hostedRuntimeEntries(
-	runtimes: HostedRuntimeManifest["runtimes"],
-): HostedRuntimeManifest["runtimes"] {
-	const token = process.env[UI_ACCESS_TOKEN_ENV]?.trim();
-	if (!token) return runtimes;
-	const hermes = runtimes.hermes;
-	if (hermes?.enabled === false) return runtimes;
-	return {
-		...runtimes,
-		hermes: {
-			...hermes,
-			enabled: true,
-			install: hermes?.install ?? { source: "official" },
 		},
 	};
 }

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -45,6 +45,12 @@ export {
 	runtimeManifestFixturePath,
 } from "./manifest-source";
 
+import {
+	RUNTIME_BRIDGE_LISTEN_HOST_ENV,
+	RUNTIME_BRIDGE_SURFACES_ENV,
+	RUNTIME_BRIDGE_TOKEN_ENV,
+	runtimeBridgeSurfaceSpecsForManifest,
+} from "./bridge";
 import type { RuntimeManifestLoad } from "./manifest-source";
 import {
 	buildMitmProfileBundle,
@@ -62,7 +68,6 @@ import {
 	type SupportedRuntimeName,
 	writeRuntimeRunConfig,
 } from "./run-config";
-import { UI_ACCESS_TOKEN_ENV, UI_BRIDGE_LISTEN_HOST_ENV } from "./ui-bridge";
 
 export interface RuntimeConvergenceResult {
 	manifest: RuntimeManifest;
@@ -1376,10 +1381,11 @@ function daemonProgramRevision(manifest: RuntimeManifest): string {
 	});
 }
 
-function uiBridgeProgramRevision(manifest: RuntimeManifest): string {
+function runtimeBridgeProgramRevision(manifest: RuntimeManifest): string {
 	return revisionHash({
 		clawdiCli: manifest.clawdiCli ?? null,
-		uiBridge: "hosted-runtime-auth-bridge-v1",
+		bridgeSurfaces: runtimeBridgeSurfaceSpecsForManifest(manifest),
+		runtimeBridge: "hosted-runtime-bridge-v1",
 	});
 }
 
@@ -1396,7 +1402,8 @@ function writeSupervisorConfig(
 	secretValues: Record<string, string> | undefined,
 ): string {
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
-	const uiAccessToken = hostedUiAccessToken();
+	const runtimeBridgeToken = hostedRuntimeBridgeToken();
+	const bridgeSurfaceSpecs = runtimeBridgeSurfaceSpecsForManifest(manifest);
 	const commonEnvironment = {
 		HOME: paths.userHome,
 		CLAWDI_RUNTIME_MODE: "hosted",
@@ -1404,14 +1411,15 @@ function writeSupervisorConfig(
 		CLAWDI_SERVICE_STATE_DIR: paths.serviceStateRoot,
 		CLAWDI_RUN_DIR: paths.runRoot,
 		CLAWDI_HOST_POLICY_PATH: paths.hostPolicy,
-		[UI_ACCESS_TOKEN_ENV]: "",
-		[UI_BRIDGE_LISTEN_HOST_ENV]: process.env[UI_BRIDGE_LISTEN_HOST_ENV]?.trim() ?? "",
+		[RUNTIME_BRIDGE_TOKEN_ENV]: "",
+		[RUNTIME_BRIDGE_LISTEN_HOST_ENV]: process.env[RUNTIME_BRIDGE_LISTEN_HOST_ENV]?.trim() ?? "",
+		[RUNTIME_BRIDGE_SURFACES_ENV]: "",
 		PATH: supervisorPath(paths),
 	};
 	const watcherEnvironment = supervisorEnvironment({
 		...commonEnvironment,
 		CLAWDI_AUTH_TOKEN: "",
-		[UI_ACCESS_TOKEN_ENV]: uiAccessToken,
+		[RUNTIME_BRIDGE_TOKEN_ENV]: runtimeBridgeToken,
 	});
 	const daemonEnvironment = supervisorEnvironment({
 		...commonEnvironment,
@@ -1421,13 +1429,12 @@ function writeSupervisorConfig(
 		CLAWDI_NO_UPDATE_CHECK: "1",
 		CLAWDI_RUNTIME_REV: daemonProgramRevision(manifest),
 	});
-	const supportedEnabled = enabledRuntimes.filter(isSupportedRuntimeName);
 	const supervisedEnabled = enabledRuntimes.filter((runtime) =>
 		shouldSuperviseRuntime(runtime, manifest),
 	);
 	const shouldRunDaemon =
 		daemonAuthTokenFile !== null && desiredLiveSyncAgents(manifest).length > 0;
-	const shouldRunUiBridge = supportedEnabled.length > 0;
+	const shouldRunBridge = bridgeSurfaceSpecs.length > 0;
 	const providerSecretEnv = hostedProviderSecretEnv(manifest);
 	const runtimeNeedsSystemBoundary =
 		hasEnabledMitmProfiles(
@@ -1509,16 +1516,17 @@ function writeSupervisorConfig(
 		);
 	}
 
-	if (shouldRunUiBridge) {
-		const uiBridgeEnvironment = supervisorEnvironment({
+	if (shouldRunBridge) {
+		const runtimeBridgeEnvironment = supervisorEnvironment({
 			...commonEnvironment,
 			CLAWDI_AUTH_TOKEN: "",
-			[UI_ACCESS_TOKEN_ENV]: uiAccessToken,
-			CLAWDI_RUNTIME_REV: uiBridgeProgramRevision(manifest),
+			[RUNTIME_BRIDGE_TOKEN_ENV]: runtimeBridgeToken,
+			[RUNTIME_BRIDGE_SURFACES_ENV]: JSON.stringify(bridgeSurfaceSpecs),
+			CLAWDI_RUNTIME_REV: runtimeBridgeProgramRevision(manifest),
 		});
 		lines.push(
-			"[program:clawdi-ui-bridge]",
-			"command=/usr/bin/env clawdi runtime ui-bridge",
+			"[program:clawdi-runtime-bridge]",
+			"command=/usr/bin/env clawdi runtime bridge",
 			`directory=${workspaceRoot}`,
 			`user=${runtimeUser}`,
 			"autostart=true",
@@ -1531,7 +1539,7 @@ function writeSupervisorConfig(
 			"stdout_logfile_maxbytes=0",
 			"stderr_logfile=/dev/fd/2",
 			"stderr_logfile_maxbytes=0",
-			`environment=${uiBridgeEnvironment}`,
+			`environment=${runtimeBridgeEnvironment}`,
 			"",
 		);
 	}
@@ -1659,12 +1667,12 @@ function writeRuntimeCommandShimIndex(commands: Set<RuntimeName>, paths: Runtime
 	);
 }
 
-function hostedUiAccessToken(): string {
-	const direct = process.env[UI_ACCESS_TOKEN_ENV]?.trim();
+function hostedRuntimeBridgeToken(): string {
+	const direct = process.env[RUNTIME_BRIDGE_TOKEN_ENV]?.trim();
 	if (direct) return direct;
 	return readProcEnvironmentValue(
 		process.env.CLAWDI_RUNTIME_PID1_ENVIRON_PATH?.trim() || "/proc/1/environ",
-		UI_ACCESS_TOKEN_ENV,
+		RUNTIME_BRIDGE_TOKEN_ENV,
 	);
 }
 
@@ -1676,7 +1684,7 @@ function readProcEnvironmentValue(path: string, key: string): string {
 			if (part.startsWith(prefix)) return part.slice(prefix.length).trim();
 		}
 	} catch {
-		// Best effort: runtime managers can still run without hosted UI access.
+		// Best effort: runtime managers can still run without hosted bridge access.
 	}
 	return "";
 }

--- a/packages/cli/tests/runtime-bridge.test.ts
+++ b/packages/cli/tests/runtime-bridge.test.ts
@@ -2,65 +2,100 @@ import { describe, expect, it } from "bun:test";
 import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
 import { connect, createServer as createNetServer, type Server as NetServer } from "node:net";
 import {
-	DEFAULT_UI_BRIDGE_TARGETS,
-	defaultRuntimeUiBridgeTargets,
-	startRuntimeUiBridge,
-	UI_ACCESS_COOKIE,
-	UI_BRIDGE_LISTEN_HOST_ENV,
-} from "../src/runtime/ui-bridge";
+	RUNTIME_BRIDGE_COOKIE,
+	RUNTIME_BRIDGE_FRAME_ANCESTORS_ENV,
+	RUNTIME_BRIDGE_SURFACES_ENV,
+	startRuntimeBridge,
+} from "../src/runtime/bridge";
 
-describe("runtime UI bridge defaults", () => {
-	it("uses bridge listen ports that do not collide with runtime loopback ports", () => {
-		withBridgeListenEnv({}, () => {
-			expect(defaultRuntimeUiBridgeTargets()).toEqual([
-				{
-					name: "openclaw",
-					listenHost: "0.0.0.0",
-					listenPort: 28789,
-					targetHost: "127.0.0.1",
-					targetPort: 18789,
-				},
-				{
-					name: "hermes",
-					listenHost: "0.0.0.0",
-					listenPort: 28793,
-					targetHost: "127.0.0.1",
-					targetPort: 9119,
-				},
-			]);
-		});
+const OPENCLAW_SURFACE = {
+	name: "openclaw",
+	kind: "control-ui",
+	listenPort: 28789,
+	upstreamPort: 18789,
+} as const;
+
+const HERMES_SURFACE = {
+	name: "hermes",
+	kind: "control-ui",
+	listenPort: 28793,
+	upstreamPort: 9119,
+} as const;
+
+describe("runtime bridge configuration", () => {
+	it("requires explicit bridge surfaces", async () => {
+		await expect(startRuntimeBridge({ token: "env-token" })).rejects.toThrow(
+			"no runtime bridge surfaces configured",
+		);
 	});
 
-	it("honors the explicit bridge listen host", () => {
-		withBridgeListenEnv({ [UI_BRIDGE_LISTEN_HOST_ENV]: "10.42.0.20" }, () => {
-			expect(defaultRuntimeUiBridgeTargets().map((target) => target.listenHost)).toEqual([
-				"10.42.0.20",
-				"10.42.0.20",
-			]);
+	it("uses bridge surfaces declared in the supervisor environment", async () => {
+		const upstream = createServer((_req, res) => {
+			res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8" });
+			res.end("env-surface");
 		});
+		await listen(upstream, "127.0.0.1", 0);
+		const listenPort = await unusedTcpPort();
+		const previousSurfaces = process.env[RUNTIME_BRIDGE_SURFACES_ENV];
+		process.env[RUNTIME_BRIDGE_SURFACES_ENV] = JSON.stringify([
+			{
+				name: "openclaw",
+				kind: "control-ui",
+				listenHost: "127.0.0.1",
+				listenPort,
+				upstreamPort: serverPort(upstream),
+			},
+		]);
+		const bridge = await startRuntimeBridge({ token: "env-token" });
+		try {
+			expect(bridge.surfaces).toEqual([
+				{
+					name: "openclaw",
+					kind: "control-ui",
+					listenHost: "127.0.0.1",
+					listenPort,
+					upstreamHost: "127.0.0.1",
+					upstreamPort: serverPort(upstream),
+				},
+			]);
+			const response = await fetch(`http://127.0.0.1:${listenPort}/`, {
+				headers: { Cookie: `${RUNTIME_BRIDGE_COOKIE}=env-token` },
+			});
+
+			expect(response.status).toBe(200);
+			expect(await response.text()).toBe("env-surface");
+		} finally {
+			await bridge.close();
+			await close(upstream);
+			if (previousSurfaces === undefined) {
+				delete process.env[RUNTIME_BRIDGE_SURFACES_ENV];
+			} else {
+				process.env[RUNTIME_BRIDGE_SURFACES_ENV] = previousSurfaces;
+			}
+		}
 	});
 });
 
-describe("runtime UI bridge", () => {
-	it("reports health only after the target runtime is reachable", async () => {
+describe("runtime bridge", () => {
+	it("reports health only after the surface runtime is reachable", async () => {
 		const upstream = createServer((_req, res) => {
 			res.writeHead(200);
 			res.end("upstream");
 		});
 		await listen(upstream, "127.0.0.1", 0);
 		const upstreamPort = serverPort(upstream);
-		const bridge = await startRuntimeUiBridge({
+		const bridge = await startRuntimeBridge({
 			token: "secret-token",
-			targets: [
+			surfaces: [
 				{
-					...DEFAULT_UI_BRIDGE_TARGETS[0],
+					...OPENCLAW_SURFACE,
 					listenHost: "127.0.0.1",
 					listenPort: 0,
-					targetPort: upstreamPort,
+					upstreamPort: upstreamPort,
 				},
 			],
 		});
-		const bridgePort = bridge.targets[0]?.listenPort;
+		const bridgePort = bridge.surfaces[0]?.listenPort;
 		if (bridgePort === undefined) throw new Error("bridge did not expose a port");
 		let upstreamClosed = false;
 		try {
@@ -91,18 +126,18 @@ describe("runtime UI bridge", () => {
 		});
 		await listen(upstream, "127.0.0.1", 0);
 		const upstreamPort = serverPort(upstream);
-		const bridge = await startRuntimeUiBridge({
+		const bridge = await startRuntimeBridge({
 			token: "secret-token",
-			targets: [
+			surfaces: [
 				{
-					...DEFAULT_UI_BRIDGE_TARGETS[0],
+					...OPENCLAW_SURFACE,
 					listenHost: "127.0.0.1",
 					listenPort: 0,
-					targetPort: upstreamPort,
+					upstreamPort: upstreamPort,
 				},
 			],
 		});
-		const bridgePort = bridge.targets[0]?.listenPort;
+		const bridgePort = bridge.surfaces[0]?.listenPort;
 		if (bridgePort === undefined) throw new Error("bridge did not expose a port");
 		try {
 			const unauthorized = await fetch(`http://127.0.0.1:${bridgePort}/`);
@@ -115,7 +150,7 @@ describe("runtime UI bridge", () => {
 			expect(redirect.status).toBe(302);
 			expect(redirect.headers.get("location")).toBe("/control?x=1&y=2");
 			const setCookie = redirect.headers.get("set-cookie") ?? "";
-			expect(setCookie).toContain(`${UI_ACCESS_COOKIE}=secret-token`);
+			expect(setCookie).toContain(`${RUNTIME_BRIDGE_COOKIE}=secret-token`);
 			expect(setCookie).toContain("Secure");
 			expect(setCookie).toContain("HttpOnly");
 			expect(setCookie).toContain("SameSite=Strict");
@@ -123,7 +158,7 @@ describe("runtime UI bridge", () => {
 			expect(seen).toEqual([]);
 
 			const proxied = await fetch(`http://127.0.0.1:${bridgePort}/control?x=1&t=ignored`, {
-				headers: { Cookie: `${UI_ACCESS_COOKIE}=secret-token` },
+				headers: { Cookie: `${RUNTIME_BRIDGE_COOKIE}=secret-token` },
 			});
 			expect(proxied.status).toBe(200);
 			expect(proxied.headers.get("x-upstream")).toBe("openclaw");
@@ -149,22 +184,22 @@ describe("runtime UI bridge", () => {
 		});
 		await listen(upstream, "127.0.0.1", 0);
 		const upstreamPort = serverPort(upstream);
-		const bridge = await startRuntimeUiBridge({
+		const bridge = await startRuntimeBridge({
 			token: "sse-token",
-			targets: [
+			surfaces: [
 				{
-					...DEFAULT_UI_BRIDGE_TARGETS[0],
+					...OPENCLAW_SURFACE,
 					listenHost: "127.0.0.1",
 					listenPort: 0,
-					targetPort: upstreamPort,
+					upstreamPort: upstreamPort,
 				},
 			],
 		});
-		const bridgePort = bridge.targets[0]?.listenPort;
+		const bridgePort = bridge.surfaces[0]?.listenPort;
 		if (bridgePort === undefined) throw new Error("bridge did not expose a port");
 		try {
 			const response = await fetch(`http://127.0.0.1:${bridgePort}/events`, {
-				headers: { Cookie: `${UI_ACCESS_COOKIE}=sse-token` },
+				headers: { Cookie: `${RUNTIME_BRIDGE_COOKIE}=sse-token` },
 			});
 
 			expect(response.status).toBe(200);
@@ -192,32 +227,32 @@ describe("runtime UI bridge", () => {
 		const hermesUpstream = makeUpstream("hermes");
 		await listen(openclawUpstream, "127.0.0.1", 0);
 		await listen(hermesUpstream, "127.0.0.1", 0);
-		const bridge = await startRuntimeUiBridge({
+		const bridge = await startRuntimeBridge({
 			token: "frame-token",
-			targets: [
+			surfaces: [
 				{
-					...DEFAULT_UI_BRIDGE_TARGETS[0],
+					...OPENCLAW_SURFACE,
 					listenHost: "127.0.0.1",
 					listenPort: 0,
-					targetPort: serverPort(openclawUpstream),
+					upstreamPort: serverPort(openclawUpstream),
 				},
 				{
-					...DEFAULT_UI_BRIDGE_TARGETS[1],
+					...HERMES_SURFACE,
 					listenHost: "127.0.0.1",
 					listenPort: 0,
-					targetPort: serverPort(hermesUpstream),
+					upstreamPort: serverPort(hermesUpstream),
 				},
 			],
 		});
 		try {
-			for (const target of bridge.targets) {
-				const response = await fetch(`http://127.0.0.1:${target.listenPort}/dashboard`, {
-					headers: { Cookie: `${UI_ACCESS_COOKIE}=frame-token` },
+			for (const surface of bridge.surfaces) {
+				const response = await fetch(`http://127.0.0.1:${surface.listenPort}/dashboard`, {
+					headers: { Cookie: `${RUNTIME_BRIDGE_COOKIE}=frame-token` },
 				});
 				const csp = response.headers.get("content-security-policy") ?? "";
 
 				expect(response.status).toBe(200);
-				expect(response.headers.get("x-upstream")).toBe(target.name);
+				expect(response.headers.get("x-upstream")).toBe(surface.name);
 				expect(response.headers.get("x-frame-options")).toBeNull();
 				expect(csp).toContain("default-src 'self'");
 				expect(csp).toContain("script-src 'self'");
@@ -231,9 +266,9 @@ describe("runtime UI bridge", () => {
 		}
 	});
 
-	it("uses CLAWDI_UI_FRAME_ANCESTORS to configure allowed iframe ancestors", async () => {
-		const previousFrameAncestors = process.env.CLAWDI_UI_FRAME_ANCESTORS;
-		process.env.CLAWDI_UI_FRAME_ANCESTORS = "'self' https://console.clawdi.ai";
+	it("uses CLAWDI_RUNTIME_BRIDGE_FRAME_ANCESTORS to configure allowed iframe ancestors", async () => {
+		const previousFrameAncestors = process.env[RUNTIME_BRIDGE_FRAME_ANCESTORS_ENV];
+		process.env[RUNTIME_BRIDGE_FRAME_ANCESTORS_ENV] = "'self' https://console.clawdi.ai";
 		const upstream = createServer((req, res) => {
 			res.writeHead(200, {
 				"Content-Security-Policy": "connect-src 'self'",
@@ -243,22 +278,22 @@ describe("runtime UI bridge", () => {
 			res.end(`<html><body>${req.url ?? ""}</body></html>`);
 		});
 		await listen(upstream, "127.0.0.1", 0);
-		const bridge = await startRuntimeUiBridge({
+		const bridge = await startRuntimeBridge({
 			token: "custom-frame-token",
-			targets: [
+			surfaces: [
 				{
-					...DEFAULT_UI_BRIDGE_TARGETS[0],
+					...OPENCLAW_SURFACE,
 					listenHost: "127.0.0.1",
 					listenPort: 0,
-					targetPort: serverPort(upstream),
+					upstreamPort: serverPort(upstream),
 				},
 			],
 		});
-		const bridgePort = bridge.targets[0]?.listenPort;
+		const bridgePort = bridge.surfaces[0]?.listenPort;
 		if (bridgePort === undefined) throw new Error("bridge did not expose a port");
 		try {
 			const response = await fetch(`http://127.0.0.1:${bridgePort}/`, {
-				headers: { Cookie: `${UI_ACCESS_COOKIE}=custom-frame-token` },
+				headers: { Cookie: `${RUNTIME_BRIDGE_COOKIE}=custom-frame-token` },
 			});
 			const csp = response.headers.get("content-security-policy") ?? "";
 
@@ -271,9 +306,9 @@ describe("runtime UI bridge", () => {
 			await bridge.close();
 			await close(upstream);
 			if (previousFrameAncestors === undefined) {
-				delete process.env.CLAWDI_UI_FRAME_ANCESTORS;
+				delete process.env[RUNTIME_BRIDGE_FRAME_ANCESTORS_ENV];
 			} else {
-				process.env.CLAWDI_UI_FRAME_ANCESTORS = previousFrameAncestors;
+				process.env[RUNTIME_BRIDGE_FRAME_ANCESTORS_ENV] = previousFrameAncestors;
 			}
 		}
 	});
@@ -287,23 +322,23 @@ describe("runtime UI bridge", () => {
 		});
 		await listen(upstream, "127.0.0.1", 0);
 		const upstreamPort = serverPort(upstream);
-		const bridge = await startRuntimeUiBridge({
+		const bridge = await startRuntimeBridge({
 			token: "http-strip-token",
-			targets: [
+			surfaces: [
 				{
-					...DEFAULT_UI_BRIDGE_TARGETS[0],
+					...OPENCLAW_SURFACE,
 					listenHost: "127.0.0.1",
 					listenPort: 0,
-					targetPort: upstreamPort,
+					upstreamPort: upstreamPort,
 				},
 			],
 		});
-		const bridgePort = bridge.targets[0]?.listenPort;
+		const bridgePort = bridge.surfaces[0]?.listenPort;
 		if (bridgePort === undefined) throw new Error("bridge did not expose a port");
 		try {
 			const response = await fetch(`http://127.0.0.1:${bridgePort}/control`, {
 				headers: {
-					Cookie: `${UI_ACCESS_COOKIE}=http-strip-token`,
+					Cookie: `${RUNTIME_BRIDGE_COOKIE}=http-strip-token`,
 					"X-App-Header": "keep-me",
 					"X-Forwarded": "legacy",
 					"X-Forwarded-For": "10.42.0.1",
@@ -363,18 +398,18 @@ describe("runtime UI bridge", () => {
 		});
 		await listen(upstream, "127.0.0.1", 0);
 		const upstreamPort = serverPort(upstream);
-		const bridge = await startRuntimeUiBridge({
+		const bridge = await startRuntimeBridge({
 			token: "ws-token",
-			targets: [
+			surfaces: [
 				{
-					...DEFAULT_UI_BRIDGE_TARGETS[0],
+					...OPENCLAW_SURFACE,
 					listenHost: "127.0.0.1",
 					listenPort: 0,
-					targetPort: upstreamPort,
+					upstreamPort: upstreamPort,
 				},
 			],
 		});
-		const bridgePort = bridge.targets[0]?.listenPort;
+		const bridgePort = bridge.surfaces[0]?.listenPort;
 		if (bridgePort === undefined) throw new Error("bridge did not expose a port");
 		try {
 			const unauthorized = await websocketRequest({
@@ -389,12 +424,12 @@ describe("runtime UI bridge", () => {
 			});
 			expect(redirect.statusCode).toBe(302);
 			expect(redirect.location).toBe("/socket?x=1");
-			expect(redirect.setCookie).toContain(`${UI_ACCESS_COOKIE}=ws-token`);
+			expect(redirect.setCookie).toContain(`${RUNTIME_BRIDGE_COOKIE}=ws-token`);
 
 			const authorized = await websocketRequest({
 				port: bridgePort,
 				path: "/socket?x=1",
-				cookie: `${UI_ACCESS_COOKIE}=ws-token`,
+				cookie: `${RUNTIME_BRIDGE_COOKIE}=ws-token`,
 			});
 			expect(authorized.statusCode).toBe(101);
 			expect(authorized.setCookie).toBe("");
@@ -403,14 +438,14 @@ describe("runtime UI bridge", () => {
 			expect(upstreamRequest).toContain("Connection: Upgrade");
 			expect(upstreamRequest).toContain("Upgrade: websocket");
 			expect(upstreamRequest).not.toContain("ws-token");
-			expect(upstreamRequest).not.toContain(UI_ACCESS_COOKIE);
+			expect(upstreamRequest).not.toContain(RUNTIME_BRIDGE_COOKIE);
 		} finally {
 			await bridge.close();
 			await close(upstream);
 		}
 	});
 
-	it("rewrites websocket browser authority headers to the OpenClaw loopback target", async () => {
+	it("rewrites websocket browser authority headers to the OpenClaw loopback surface", async () => {
 		let upstreamRequest = "";
 		const upstream = createNetServer((socket) => {
 			socket.once("data", (chunk) => {
@@ -428,24 +463,24 @@ describe("runtime UI bridge", () => {
 		});
 		await listen(upstream, "127.0.0.1", 0);
 		const upstreamPort = serverPort(upstream);
-		const bridge = await startRuntimeUiBridge({
+		const bridge = await startRuntimeBridge({
 			token: "openclaw-token",
-			targets: [
+			surfaces: [
 				{
-					...DEFAULT_UI_BRIDGE_TARGETS[0],
+					...OPENCLAW_SURFACE,
 					listenHost: "127.0.0.1",
 					listenPort: 0,
-					targetPort: upstreamPort,
+					upstreamPort: upstreamPort,
 				},
 			],
 		});
-		const bridgePort = bridge.targets[0]?.listenPort;
+		const bridgePort = bridge.surfaces[0]?.listenPort;
 		if (bridgePort === undefined) throw new Error("bridge did not expose a port");
 		try {
 			const authorized = await websocketRequest({
 				port: bridgePort,
 				path: "/control/?session=abc",
-				cookie: `${UI_ACCESS_COOKIE}=openclaw-token; app_cookie=keep`,
+				cookie: `${RUNTIME_BRIDGE_COOKIE}=openclaw-token; app_cookie=keep`,
 				host: "agent-18789.gateway.example.test",
 				origin: "https://agent-18789.gateway.example.test",
 				referer: "https://agent-18789.gateway.example.test/control/?session=abc",
@@ -463,7 +498,7 @@ describe("runtime UI bridge", () => {
 			expect(upstreamRequest).toContain("X-App-Header: keep-me");
 			expectForwardingHeadersStripped(upstreamRequest);
 			expect(upstreamRequest).not.toContain("agent-18789.gateway.example.test");
-			expect(upstreamRequest).not.toContain(UI_ACCESS_COOKIE);
+			expect(upstreamRequest).not.toContain(RUNTIME_BRIDGE_COOKIE);
 		} finally {
 			await bridge.close();
 			await close(upstream);
@@ -497,24 +532,24 @@ describe("runtime UI bridge", () => {
 		});
 		await listen(upstream, "127.0.0.1", 0);
 		const upstreamPort = serverPort(upstream);
-		const bridge = await startRuntimeUiBridge({
+		const bridge = await startRuntimeBridge({
 			token: "hermes-bridge-token",
-			targets: [
+			surfaces: [
 				{
-					...DEFAULT_UI_BRIDGE_TARGETS[1],
+					...HERMES_SURFACE,
 					listenHost: "127.0.0.1",
 					listenPort: 0,
-					targetPort: upstreamPort,
+					upstreamPort: upstreamPort,
 				},
 			],
 		});
-		const bridgePort = bridge.targets[0]?.listenPort;
+		const bridgePort = bridge.surfaces[0]?.listenPort;
 		if (bridgePort === undefined) throw new Error("bridge did not expose a port");
 		try {
 			const authorized = await websocketRequest({
 				port: bridgePort,
 				path: "/api/ws?token=hermes-session&channel=chat-1",
-				cookie: `${UI_ACCESS_COOKIE}=hermes-bridge-token`,
+				cookie: `${RUNTIME_BRIDGE_COOKIE}=hermes-bridge-token`,
 				host: "agent-9119.gateway.example.test",
 				origin: "https://agent-9119.gateway.example.test",
 				referer: "https://agent-9119.gateway.example.test/chat",
@@ -529,7 +564,7 @@ describe("runtime UI bridge", () => {
 			expect(upstreamRequest).toContain("X-App-Header: keep-me");
 			expectForwardingHeadersStripped(upstreamRequest);
 			expect(upstreamRequest).not.toContain("agent-9119.gateway.example.test");
-			expect(upstreamRequest).not.toContain(UI_ACCESS_COOKIE);
+			expect(upstreamRequest).not.toContain(RUNTIME_BRIDGE_COOKIE);
 		} finally {
 			await bridge.close();
 			await close(upstream);
@@ -610,25 +645,6 @@ function forwardingHeaderLines(): string[] {
 	];
 }
 
-function withBridgeListenEnv(values: Record<string, string>, fn: () => void): void {
-	const keys = [UI_BRIDGE_LISTEN_HOST_ENV];
-	const previous = new Map(keys.map((key) => [key, process.env[key]]));
-	try {
-		for (const key of keys) delete process.env[key];
-		for (const [key, value] of Object.entries(values)) process.env[key] = value;
-		fn();
-	} finally {
-		for (const key of keys) {
-			const value = previous.get(key);
-			if (value === undefined) {
-				delete process.env[key];
-			} else {
-				process.env[key] = value;
-			}
-		}
-	}
-}
-
 function expectForwardingHeadersStripped(rawRequest: string): void {
 	expect(hasForwardingHeader(rawRequest)).toBe(false);
 }
@@ -662,6 +678,14 @@ function listen(server: Server | NetServer, host: string, port: number): Promise
 		server.once("listening", onListening);
 		server.listen(port, host);
 	});
+}
+
+async function unusedTcpPort(): Promise<number> {
+	const server = createNetServer();
+	await listen(server, "127.0.0.1", 0);
+	const port = serverPort(server);
+	await close(server);
+	return port;
 }
 
 function close(server: Server | NetServer): Promise<void> {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -14,6 +14,11 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { runtimeInit, runtimeWatch } from "../src/commands/runtime";
+import {
+	RUNTIME_BRIDGE_LISTEN_HOST_ENV,
+	RUNTIME_BRIDGE_SURFACES_ENV,
+	RUNTIME_BRIDGE_TOKEN_ENV,
+} from "../src/runtime/bridge";
 import { applyRuntimeChannelsToManifestLoad } from "../src/runtime/channels";
 import { applyRuntimeCliDesiredState } from "../src/runtime/cli-update";
 import {
@@ -41,7 +46,6 @@ import {
 	writeRuntimeBootStatus,
 	writeRuntimeWatchStatus,
 } from "../src/runtime/state";
-import { UI_ACCESS_TOKEN_ENV, UI_BRIDGE_LISTEN_HOST_ENV } from "../src/runtime/ui-bridge";
 import { jsonResponse, mockFetch } from "./commands/helpers";
 
 const ENV_KEYS = [
@@ -67,8 +71,9 @@ const ENV_KEYS = [
 	"CLAWDI_API_URL",
 	"CLAWDI_SUPERVISORCTL_PATH",
 	"CLAWDI_RUNTIME_USER",
-	UI_ACCESS_TOKEN_ENV,
-	UI_BRIDGE_LISTEN_HOST_ENV,
+	RUNTIME_BRIDGE_TOKEN_ENV,
+	RUNTIME_BRIDGE_LISTEN_HOST_ENV,
+	RUNTIME_BRIDGE_SURFACES_ENV,
 ] as const;
 
 type EnvKey = (typeof ENV_KEYS)[number];
@@ -521,7 +526,7 @@ describe("runtime manifest datasource", () => {
 		}
 	});
 
-	it("recovers hosted UI access token from pid1 env for runtime-watch and ui bridge supervisor programs", async () => {
+	it("recovers hosted bridge token from pid1 env for runtime-watch and runtime bridge supervisor programs", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -529,7 +534,7 @@ describe("runtime manifest datasource", () => {
 		const pid1EnvPath = join(root, "pid1-environ");
 		const openclawInstaller = join(root, "install-openclaw.sh");
 		mkdirSync(home, { recursive: true });
-		writeFileSync(pid1EnvPath, `PATH=/usr/bin\0${UI_ACCESS_TOKEN_ENV}=ui-runtime-token\0`);
+		writeFileSync(pid1EnvPath, `PATH=/usr/bin\0${RUNTIME_BRIDGE_TOKEN_ENV}=bridge-token\0`);
 		writeFileSync(
 			openclawInstaller,
 			`#!/usr/bin/env bash
@@ -576,10 +581,10 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 					jsonResponse({
 						manifest: {
 							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
-							deploymentId: "dep_ui_bridge",
-							environmentId: "env_ui_bridge",
-							appId: "app_ui_bridge",
-							instanceId: "iid_ui_bridge",
+							deploymentId: "dep_runtime_bridge",
+							environmentId: "env_runtime_bridge",
+							appId: "app_runtime_bridge",
+							instanceId: "iid_runtime_bridge",
 							generation: 4,
 							issuedAt: "2026-06-06T00:00:00Z",
 							system: { home, workspace: join(home, "managed-workspace") },
@@ -598,6 +603,16 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 									install: { source: "official", channel: "stable" },
 									paths: { home },
 								},
+							},
+							bridge: {
+								surfaces: [
+									{
+										name: "openclaw",
+										kind: "control-ui",
+										listenPort: 28789,
+										upstreamPort: 18789,
+									},
+								],
 							},
 							providers: {
 								default: {
@@ -625,9 +640,13 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 			const section = (name: string) =>
 				supervisorConfig.split(`[program:${name}]`)[1]?.split("\n[")[0] ?? "";
 
-			expect(section("clawdi-runtime-watch")).toContain('UI_ACCESS_TOKEN="ui-runtime-token"');
-			expect(section("clawdi-ui-bridge")).toContain('UI_ACCESS_TOKEN="ui-runtime-token"');
-			expect(section("clawdi-openclaw")).toContain('UI_ACCESS_TOKEN=""');
+			expect(section("clawdi-runtime-watch")).toContain(
+				'CLAWDI_RUNTIME_BRIDGE_TOKEN="bridge-token"',
+			);
+			expect(section("clawdi-runtime-bridge")).toContain(
+				'CLAWDI_RUNTIME_BRIDGE_TOKEN="bridge-token"',
+			);
+			expect(section("clawdi-openclaw")).toContain('CLAWDI_RUNTIME_BRIDGE_TOKEN=""');
 			expect(supervisorConfig).not.toContain("sk-runtime");
 		} finally {
 			restore();
@@ -1221,25 +1240,25 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 		expect(secrets["secret://provider.default.apiKey"]).toBe("sk-runtime-provider");
 	});
 
-	it("adds Hermes to legacy hosted-runtime manifests when the UI bridge token is present", async () => {
+	it("does not infer runtime entries from the runtime bridge token", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
-		const manifestPath = join(root, "hosted-ui-token.json");
+		const manifestPath = join(root, "hosted-runtime-bridge-token.json");
 		mkdirSync(home, { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env[UI_ACCESS_TOKEN_ENV] = "ui-token";
+		process.env[RUNTIME_BRIDGE_TOKEN_ENV] = "bridge-token";
 		writeFileSync(
 			manifestPath,
 			JSON.stringify({
 				manifest: {
 					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
-					deploymentId: "dep_ui_token",
-					environmentId: "env_ui_token",
-					instanceId: "iid_ui_token",
+					deploymentId: "dep_bridge_token",
+					environmentId: "env_bridge_token",
+					instanceId: "iid_bridge_token",
 					generation: 1,
 					issuedAt: "2026-06-15T00:00:00Z",
 					system: { home },
@@ -1256,36 +1275,29 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 
 		expect("manifest" in loaded).toBe(true);
 		if (!("manifest" in loaded)) throw new Error("expected manifest load success");
-		expect(loaded.manifest.runtimes.hermes.enabled).toBe(true);
-		expect(loaded.manifest.runtimes.hermes.install?.url).toBe(
-			"https://hermes-agent.nousresearch.com/install.sh",
-		);
-		expect(loaded.manifest.runtimes.hermes.install?.args).toEqual([
-			"--skip-setup",
-			"--skip-browser",
-			"--non-interactive",
-		]);
+		expect(loaded.manifest.runtimes.openclaw.enabled).toBe(true);
+		expect(loaded.manifest.runtimes).not.toHaveProperty("hermes");
 	});
 
 	it("keeps Hermes disabled when a hosted-runtime manifest explicitly disables it", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
-		const manifestPath = join(root, "hosted-ui-token-hermes-disabled.json");
+		const manifestPath = join(root, "hosted-bridge-token-hermes-disabled.json");
 		mkdirSync(home, { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env[UI_ACCESS_TOKEN_ENV] = "ui-token";
+		process.env[RUNTIME_BRIDGE_TOKEN_ENV] = "bridge-token";
 		writeFileSync(
 			manifestPath,
 			JSON.stringify({
 				manifest: {
 					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
-					deploymentId: "dep_ui_token_explicit",
-					environmentId: "env_ui_token_explicit",
-					instanceId: "iid_ui_token_explicit",
+					deploymentId: "dep_bridge_token_explicit",
+					environmentId: "env_bridge_token_explicit",
+					instanceId: "iid_bridge_token_explicit",
 					generation: 1,
 					issuedAt: "2026-06-15T00:00:00Z",
 					system: { home },
@@ -3920,7 +3932,7 @@ exit 64
 		const supervisorConfig = readFileSync(convergence.outputs.supervisorConfig, "utf-8");
 		expect(supervisorConfig).toContain("[program:clawdi-future-agent]");
 		expect(supervisorConfig).toContain("command=/usr/bin/env clawdi run -- future-agent");
-		expect(supervisorConfig).not.toContain("[program:clawdi-ui-bridge]");
+		expect(supervisorConfig).not.toContain("[program:clawdi-runtime-bridge]");
 	});
 
 	it("rejects legacy hosted controlPlane apiUrl", async () => {
@@ -4155,7 +4167,7 @@ exit 64
 		expect(readFileSync(join(home, ".hermes", "config.yaml"), "utf-8")).not.toContain("clawdi:");
 	});
 
-	it("adds the hosted UI bridge supervisor program for enabled UI runtimes", () => {
+	it("does not add the hosted runtime bridge supervisor program without declared surfaces", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -4164,16 +4176,15 @@ exit 64
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env[UI_ACCESS_TOKEN_ENV] = "ui-secret";
-		process.env[UI_BRIDGE_LISTEN_HOST_ENV] = "10.42.0.20";
+		process.env[RUNTIME_BRIDGE_TOKEN_ENV] = "bridge-secret";
 
 		const convergence = convergeRuntimeManifest(
 			{
 				manifest: {
 					schemaVersion: "clawdi.runtimeDesiredState.v1",
-					deploymentId: "dep_ui_bridge",
-					environmentId: "env_ui_bridge",
-					instanceId: "iid_ui_bridge",
+					deploymentId: "dep_runtime_no_bridge",
+					environmentId: "env_runtime_no_bridge",
+					instanceId: "iid_runtime_no_bridge",
 					generation: 1,
 					issuedAt: "2026-06-15T00:00:00Z",
 					controlPlane: { apiUrl: "https://cloud-api.test" },
@@ -4184,7 +4195,7 @@ exit 64
 					recovery: {},
 				},
 				source: "fixture-file",
-				sourcePath: "test://ui-bridge",
+				sourcePath: "test://runtime-no-bridge",
 				offline: false,
 				secretValues: {},
 			},
@@ -4192,15 +4203,70 @@ exit 64
 		);
 
 		const supervisorConfig = readFileSync(convergence.outputs.supervisorConfig, "utf-8");
-		expect(supervisorConfig).toContain("[program:clawdi-ui-bridge]");
-		expect(supervisorConfig).toContain("command=/usr/bin/env clawdi runtime ui-bridge");
-		expect(supervisorConfig).toContain('CLAWDI_UI_BRIDGE_LISTEN_HOST="10.42.0.20"');
+		expect(supervisorConfig).not.toContain("[program:clawdi-runtime-bridge]");
+	});
+
+	it("adds the hosted runtime bridge supervisor program for declared control UI surfaces", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env[RUNTIME_BRIDGE_TOKEN_ENV] = "bridge-secret";
+		process.env[RUNTIME_BRIDGE_LISTEN_HOST_ENV] = "10.42.0.20";
+
+		const convergence = convergeRuntimeManifest(
+			{
+				manifest: {
+					schemaVersion: "clawdi.runtimeDesiredState.v1",
+					deploymentId: "dep_runtime_bridge",
+					environmentId: "env_runtime_bridge",
+					instanceId: "iid_runtime_bridge",
+					generation: 1,
+					issuedAt: "2026-06-15T00:00:00Z",
+					controlPlane: { apiUrl: "https://cloud-api.test" },
+					runtimes: {
+						openclaw: { enabled: true },
+						hermes: { enabled: false },
+					},
+					bridge: {
+						surfaces: [
+							{
+								name: "openclaw",
+								kind: "control-ui",
+								listenPort: 28789,
+								upstreamPort: 18789,
+							},
+						],
+					},
+					recovery: {},
+				},
+				source: "fixture-file",
+				sourcePath: "test://runtime-bridge",
+				offline: false,
+				secretValues: {},
+			},
+			getRuntimePaths(),
+		);
+
+		const supervisorConfig = readFileSync(convergence.outputs.supervisorConfig, "utf-8");
+		expect(supervisorConfig).toContain("[program:clawdi-runtime-bridge]");
+		expect(supervisorConfig).toContain("command=/usr/bin/env clawdi runtime bridge");
+		expect(supervisorConfig).toContain('CLAWDI_RUNTIME_BRIDGE_LISTEN_HOST="10.42.0.20"');
 		expect(supervisorConfig).toContain('CLAWDI_RUNTIME_REV="');
-		const uiBridgeSection = supervisorConfig.split("[program:clawdi-openclaw]")[0];
+		const runtimeBridgeSection = supervisorConfig.split("[program:clawdi-openclaw]")[0];
 		const openclawSection = supervisorConfig.split("[program:clawdi-openclaw]")[1] ?? "";
-		expect(uiBridgeSection).toContain('UI_ACCESS_TOKEN="ui-secret"');
-		expect(openclawSection).toContain('UI_ACCESS_TOKEN=""');
-		expect(openclawSection).not.toContain("ui-secret");
+		expect(runtimeBridgeSection).toContain('CLAWDI_RUNTIME_BRIDGE_TOKEN="bridge-secret"');
+		expect(runtimeBridgeSection).toContain('CLAWDI_RUNTIME_BRIDGE_SURFACES="');
+		expect(runtimeBridgeSection).toContain('\\"name\\":\\"openclaw\\"');
+		expect(runtimeBridgeSection).toContain('\\"listenPort\\":28789');
+		expect(runtimeBridgeSection).not.toContain('\\"name\\":\\"hermes\\"');
+		expect(openclawSection).toContain('CLAWDI_RUNTIME_BRIDGE_TOKEN=""');
+		expect(openclawSection).toContain('CLAWDI_RUNTIME_BRIDGE_SURFACES=""');
+		expect(openclawSection).not.toContain("bridge-secret");
 	});
 
 	it("keeps provider-secret runtime launchers at the system boundary", () => {
@@ -4228,6 +4294,16 @@ exit 64
 						openclaw: { enabled: true },
 						hermes: { enabled: false },
 					},
+					bridge: {
+						surfaces: [
+							{
+								name: "openclaw",
+								kind: "control-ui",
+								listenPort: 28789,
+								upstreamPort: 18789,
+							},
+						],
+					},
 					projection: {
 						providers: {
 							default: {
@@ -4251,10 +4327,10 @@ exit 64
 		);
 
 		const supervisorConfig = readFileSync(convergence.outputs.supervisorConfig, "utf-8");
-		const uiBridgeSection = supervisorConfig.split("[program:clawdi-openclaw]")[0];
+		const runtimeBridgeSection = supervisorConfig.split("[program:clawdi-openclaw]")[0];
 		const openclawSection = supervisorConfig.split("[program:clawdi-openclaw]")[1] ?? "";
-		expect(uiBridgeSection).toContain("[program:clawdi-ui-bridge]");
-		expect(uiBridgeSection).toContain("user=clawdi");
+		expect(runtimeBridgeSection).toContain("[program:clawdi-runtime-bridge]");
+		expect(runtimeBridgeSection).toContain("user=clawdi");
 		expect(openclawSection).toContain("command=/usr/bin/env clawdi run -- openclaw");
 		expect(openclawSection).not.toMatch(/^user=clawdi$/m);
 		expect(openclawSection).not.toContain("sk-runtime");


### PR DESCRIPTION
## Summary
- Replace the hosted `runtime ui-bridge` command with `clawdi runtime bridge` and manifest-declared `bridge.surfaces`.
- Remove token-driven default OpenClaw/Hermes bridge targets; bridge surfaces are explicit desired state only.
- Add `HostedRuntimeState.bridge` persistence, admin validation, and runtime manifest projection.
- Bump the CLI package to `0.12.10-beta.29` so the publish workflow can update `clawdi@beta` for hosted runtime use.
- Update English architecture/docs and focused tests.

## Verification
- `bun test packages/cli/tests/runtime-bridge.test.ts packages/cli/tests/runtime.test.ts`
- `bun run check`
- `bun run typecheck`
- `cd backend && uv run --group dev ruff check app tests`
- `cd backend && uv run --group dev ruff format --check app/schemas/admin.py tests/test_runtime_manifest.py`
- `git diff --check`

## Local Blocked Check
- `cd backend && uv run --group dev pytest tests/test_runtime_manifest.py -q` is blocked locally because PostgreSQL at `127.0.0.1:41329` refuses connections; failures are setup connection errors, not assertions.

## Release Order
1. Merge/deploy this cloud-api/backend support first.
2. Let `clawdi@0.12.10-beta.29` publish and confirm the `beta` dist-tag points to it.
3. Then merge/deploy the hosted PR that emits `bridge.surfaces`.