### PR TITLE
Fix hosted runtime supervisor env quoting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -62,7 +62,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.29",
+      "version": "0.12.10-beta.30",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.29",
+	"version": "0.12.10-beta.30",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1700,12 +1700,22 @@ function supervisorPath(paths: RuntimePaths): string {
 
 function supervisorEnvironment(values: Record<string, string>): string {
 	return Object.entries(values)
-		.map(([key, value]) => `${key}="${supervisorEscape(value)}"`)
+		.map(([key, value]) => `${key}=${supervisorQuoteValue(value)}`)
 		.join(",");
 }
 
-function supervisorEscape(value: string): string {
-	return value.replace(/%/g, "%%").replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+function supervisorQuoteValue(value: string): string {
+	if (/[\r\n]/.test(value)) {
+		throw new Error("supervisor environment values must be single-line strings");
+	}
+	const escaped = value.replace(/%/g, "%%");
+	if (!escaped.includes('"')) {
+		return `"${escaped.replace(/\\/g, "\\\\")}"`;
+	}
+	if (!escaped.includes("'")) {
+		return `'${escaped}'`;
+	}
+	throw new Error("supervisor environment values must not contain both quote types");
 }
 
 function runtimeWorkspaceRoot(manifest: RuntimeManifest, paths: RuntimePaths): string {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -4260,10 +4260,11 @@ exit 64
 		const runtimeBridgeSection = supervisorConfig.split("[program:clawdi-openclaw]")[0];
 		const openclawSection = supervisorConfig.split("[program:clawdi-openclaw]")[1] ?? "";
 		expect(runtimeBridgeSection).toContain('CLAWDI_RUNTIME_BRIDGE_TOKEN="bridge-secret"');
-		expect(runtimeBridgeSection).toContain('CLAWDI_RUNTIME_BRIDGE_SURFACES="');
-		expect(runtimeBridgeSection).toContain('\\"name\\":\\"openclaw\\"');
-		expect(runtimeBridgeSection).toContain('\\"listenPort\\":28789');
-		expect(runtimeBridgeSection).not.toContain('\\"name\\":\\"hermes\\"');
+		expect(runtimeBridgeSection).toContain("CLAWDI_RUNTIME_BRIDGE_SURFACES='");
+		expect(runtimeBridgeSection).toContain('"name":"openclaw"');
+		expect(runtimeBridgeSection).toContain('"kind":"control-ui"');
+		expect(runtimeBridgeSection).toContain('"listenPort":28789');
+		expect(runtimeBridgeSection).not.toContain('"name":"hermes"');
 		expect(openclawSection).toContain('CLAWDI_RUNTIME_BRIDGE_TOKEN=""');
 		expect(openclawSection).toContain('CLAWDI_RUNTIME_BRIDGE_SURFACES=""');
 		expect(openclawSection).not.toContain("bridge-secret");


### PR DESCRIPTION
## Summary
- quote generated supervisord environment values with the quote style supervisord can actually parse
- keep runtime bridge JSON surfaces as single-quoted values so embedded commas and double quotes do not break config parsing
- bump CLI to 0.12.10-beta.30 for npm beta publish

## Root cause
Hosted runtime pods were crash-looping before terminal/control UI could start because CLAWDI_RUNTIME_BRIDGE_SURFACES is JSON. The generated environment line wrapped it in double quotes while also containing escaped internal double quotes and commas, which supervisord parses as an invalid key/value list.

## Verification
- bun test packages/cli/tests/runtime.test.ts packages/cli/tests/runtime-bridge.test.ts packages/cli/tests/commands/run.test.ts
- bun run --filter clawdi typecheck
- bun run --filter clawdi build
- bun run check
- generated a hosted runtime supervisord.conf and parsed it with the current runtime image supervisord; no "Unexpected end of key/value pairs" error
