### PR TITLE
Bound agent version probes

### DIFF
--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -11,6 +11,7 @@ import type {
 	SessionMessage,
 } from "./base";
 import { getClaudeHome, SKIP_DIRS } from "./paths";
+import { readCommandVersion } from "./version";
 
 function claudeDir() {
 	return getClaudeHome();
@@ -70,12 +71,7 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 	}
 
 	async getVersion(): Promise<string | null> {
-		try {
-			const { execSync } = await import("node:child_process");
-			return execSync("claude --version", { encoding: "utf-8", stdio: "pipe" }).trim();
-		} catch {
-			return null;
-		}
+		return readCommandVersion("claude", ["--version"]);
 	}
 
 	/**

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -11,6 +11,7 @@ import type {
 	SessionMessage,
 } from "./base";
 import { getCodexHome, SKIP_DIRS } from "./paths";
+import { readCommandVersion } from "./version";
 
 function codexDir() {
 	return getCodexHome();
@@ -98,13 +99,7 @@ export class CodexAdapter implements AgentAdapter {
 	}
 
 	async getVersion(): Promise<string | null> {
-		try {
-			const { execSync } = await import("node:child_process");
-			const out = execSync("codex --version", { encoding: "utf-8", stdio: "pipe" }).trim();
-			return out.split("\n")[0] || null;
-		} catch {
-			return null;
-		}
+		return readCommandVersion("codex", ["--version"]);
 	}
 
 	async collectSessions(opts: CollectSessionsOptions = {}): Promise<CollectSessionsResult> {

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -12,6 +12,7 @@ import type {
 	SessionMessage,
 } from "./base";
 import { getHermesHome, SKIP_DIRS } from "./paths";
+import { readCommandVersion } from "./version";
 
 /**
  * Minimal SQLite shape that both `bun:sqlite` and Node's built-in
@@ -94,14 +95,7 @@ export class HermesAdapter implements AgentAdapter {
 	}
 
 	async getVersion(): Promise<string | null> {
-		try {
-			const { execSync } = await import("node:child_process");
-			const output = execSync("hermes --version", { encoding: "utf-8", stdio: "pipe" }).trim();
-			// Hermes outputs multi-line version info, take first line only
-			return output.split("\n")[0] || null;
-		} catch {
-			return null;
-		}
+		return readCommandVersion("hermes", ["--version"]);
 	}
 
 	async collectSessions(_opts: CollectSessionsOptions = {}): Promise<CollectSessionsResult> {

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -11,6 +11,7 @@ import type {
 	SessionMessage,
 } from "./base";
 import { getOpenClawHome, SKIP_DIRS } from "./paths";
+import { readCommandVersion } from "./version";
 
 function openclawDir() {
 	return getOpenClawHome();
@@ -134,23 +135,9 @@ export class OpenClawAdapter implements AgentAdapter {
 	}
 
 	async getVersion(): Promise<string | null> {
-		const { execSync } = await import("node:child_process");
-		try {
-			return (
-				execSync("openclaw --version", { encoding: "utf-8", stdio: "pipe" })
-					.trim()
-					.split("\n")[0] || null
-			);
-		} catch {
-			try {
-				return (
-					execSync("openclaw --help", { encoding: "utf-8", stdio: "pipe" }).trim().split("\n")[0] ||
-					null
-				);
-			} catch {
-				return null;
-			}
-		}
+		return (
+			readCommandVersion("openclaw", ["--version"]) ?? readCommandVersion("openclaw", ["--help"])
+		);
 	}
 
 	async collectSessions(opts: CollectSessionsOptions = {}): Promise<CollectSessionsResult> {

--- a/packages/cli/src/adapters/version.ts
+++ b/packages/cli/src/adapters/version.ts
@@ -1,0 +1,17 @@
+import { execFileSync } from "node:child_process";
+
+const VERSION_COMMAND_TIMEOUT_MS = 1500;
+
+export function readCommandVersion(command: string, args: string[]): string | null {
+	try {
+		const output = execFileSync(command, args, {
+			encoding: "utf-8",
+			stdio: "pipe",
+			timeout: VERSION_COMMAND_TIMEOUT_MS,
+			windowsHide: true,
+		}).trim();
+		return output.split("\n")[0] || null;
+	} catch {
+		return null;
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared bounded agent version probe helper
- use execFileSync with a timeout instead of unbounded shell execs for Claude, Codex, Hermes, and OpenClaw version detection
- keeps `clawdi doctor` from hanging on slow or stuck local agent binaries

## Verification
- bun test packages/cli/tests/commands/doctor.test.ts packages/cli/tests/adapters/claude-code.test.ts packages/cli/tests/adapters/openclaw.test.ts packages/cli/tests/adapters/hermes.test.ts packages/cli/tests/adapters/codex.test.ts
- bun test --isolate --max-concurrency=1 (packages/cli)
- bun run --filter clawdi typecheck
- bun run --filter clawdi build
- bun run check
