### PR TITLE
DRAFT: hosted OpenClaw update handoff investigation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -70,7 +70,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.30",
+      "version": "0.12.10-beta.31",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -21,7 +21,7 @@ Related public docs:
 
 The open-source CLI owns local runtime convergence, command wrapping, runtime
 UI bridging, and diagnostics. The web app owns the hosted deployment dashboard
-surfaces, including Control UI and Terminal tabs. A separate control plane may
+surfaces, including runtime UI and Terminal tabs. A separate control plane may
 provide desired state, credentials, terminal authorization, rollout policy, and
 deployment lifecycle, but that platform-specific implementation is outside this
 repository.
@@ -90,6 +90,21 @@ an explicit `run.command` or the CLI rejects the manifest instead of guessing.
 Runtime availability and default enabled/disabled policy belong to the manifest
 and control plane, not to the host image.
 
+## Runtime Update Boundary
+
+Managed runtime updates are driven by desired-state convergence, not by the
+native agent UI running inside the live gateway process. `clawdi runtime init`
+owns supported runtime install checks, local config projection, run config, and
+supervisor restart semantics.
+
+For OpenClaw, hosted convergence patches the native config with
+`update.checkOnStart=false` and `update.auto.enabled=false`, and launches the
+supervised gateway with `OPENCLAW_NO_AUTO_UPDATE=1`. This prevents the native
+Control UI from advertising a self-update path that requires an external
+managed-service handoff unavailable inside the hosted `supervisord` envelope.
+The hosted control plane should update runtime versions by changing desired
+state and letting `clawdi runtime watch`/`runtime init` converge.
+
 ## Manifest Shapes
 
 The CLI accepts two related shapes:
@@ -146,7 +161,7 @@ last-good cached manifests only when recovery policy allows it. `runtime
 bridge` exposes manifest-declared runtime surfaces behind hosted access
 controls.
 
-The current hosted bridge surfaces are browser-facing Control UIs. Each surface
+The current hosted bridge surfaces are browser-facing runtime UIs. Each surface
 declares its listen address, upstream target, protocol behavior, auth model, and
 header rewrite rules. The bridge must not become a generic arbitrary-port
 forwarder. Terminal is deliberately out of scope because it is a shell-exec
@@ -238,19 +253,19 @@ Channel configuration follows the same rule: the open-source contract describes
 the local projection shape and validation rules, while service-specific channel
 control planes remain outside this repository.
 
-## Control UI And Terminal
+## Runtime UI And Terminal
 
 Hosted deployment pages expose two live surfaces:
 
-- **Control UI** embeds or links to the runtime's browser UI through the
-  runtime bridge. It is runtime-specific and should be labelled as
-  `<Runtime> Control UI`.
+- **Runtime UI** embeds or links to the runtime's browser UI through the
+  runtime bridge. It is runtime-specific and should use the runtime's own
+  label, such as OpenClaw Control UI or Hermes Dashboard.
 - **Terminal** opens a shell for the deployment. It is not split per agent; a
   deployment has one Terminal surface.
 
 ```mermaid
 flowchart LR
-    Dashboard[Dashboard] -->|Control UI URL| Bridge[clawdi runtime bridge]
+    Dashboard[Dashboard] -->|Runtime UI URL| Bridge[clawdi runtime bridge]
     Bridge --> RuntimeUI[Runtime browser UI<br/>loopback upstream]
     Dashboard -->|Terminal WebSocket| HostedAPI[Hosted API]
     HostedAPI --> Shell[Deployment shell<br/>default runtime user]

--- a/docs/plans/runtime-projection-boundary.md
+++ b/docs/plans/runtime-projection-boundary.md
@@ -111,6 +111,9 @@ The CLI may own:
 - proxy and trust environment projection;
 - request matching for explicit profiles;
 - secret reference lookup from short-lived runtime state.
+- target-native policy projection required to preserve managed-runtime
+  boundaries, such as disabling OpenClaw gateway self-update prompts in hosted
+  mode.
 
 The CLI must not own:
 
@@ -142,13 +145,14 @@ Built-in installer/projection support is currently explicit. Unknown runtime
 names are acceptable only when the manifest includes enough `run.command`
 information for the CLI to launch them deterministically.
 
-## Control UI And Terminal Boundary
+## Runtime UI And Terminal Boundary
 
-Control UI is a runtime browser UI surface proxied by the local runtime bridge.
+Runtime UI is a runtime browser UI surface proxied by the local runtime bridge.
 Terminal is a deployment shell surface exposed by the dashboard and hosted API
 contract. They are intentionally separate:
 
-- Control UI is runtime-specific.
+- Runtime UI is runtime-specific and should use the runtime's official
+  user-facing name.
 - The bridge accepts explicitly declared runtime surfaces with listen/upstream
   targets and surface-specific policy; it must not become arbitrary port
   forwarding.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.30",
+	"version": "0.12.10-beta.31",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -831,6 +831,38 @@ function applyHostedAiProviderProjection(
 	return null;
 }
 
+function applyHostedOpenClawPolicy(
+	name: string,
+	observation: RuntimeInstallObservation,
+	manifest: RuntimeManifest,
+	workspaceRoot: string,
+): string | null {
+	if (name !== "openclaw") return null;
+	if (!observation.enabled || observation.status === "install_failed" || !observation.commandPath) {
+		return null;
+	}
+	const home = projectionSystemHome(manifest) ?? process.env.HOME ?? "";
+	runRuntimeUserCommand(
+		observation.commandPath,
+		["config", "patch", "--stdin"],
+		`${JSON.stringify(hostedOpenClawPolicyPatch(), null, 2)}\n`,
+		home,
+		workspaceRoot,
+	);
+	return observation.commandPath;
+}
+
+function hostedOpenClawPolicyPatch(): Record<string, unknown> {
+	return {
+		update: {
+			checkOnStart: false,
+			auto: {
+				enabled: false,
+			},
+		},
+	};
+}
+
 function hostedChannelProjection(manifest: RuntimeManifest): Record<string, unknown> | null {
 	if (!manifest.projection || !Object.hasOwn(manifest.projection, "channels")) {
 		return null;
@@ -1548,6 +1580,7 @@ function writeSupervisorConfig(
 		const runtimeEnvironment = supervisorEnvironment({
 			...commonEnvironment,
 			CLAWDI_AUTH_TOKEN: "",
+			...(runtime === "openclaw" ? { OPENCLAW_NO_AUTO_UPDATE: "1" } : {}),
 			CLAWDI_RUNTIME_REV: runtimeProgramRevision(manifest, runtime, secretValues),
 		});
 		lines.push(
@@ -1862,6 +1895,15 @@ export function convergeRuntimeManifest(
 		const projectionPath = join(paths.projectionRoot, `${name}.json`);
 		writeJsonFile(projectionPath, projectionPayload(name, manifest));
 		projections.push(projectionPath);
+		try {
+			applyHostedOpenClawPolicy(name, observation, manifest, workspaceRoot);
+		} catch (error) {
+			installErrors.push(
+				`runtime ${name} hosted policy projection failed: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
 		try {
 			applyHostedAiProviderProjection(name, observation, manifest, workspaceRoot);
 		} catch (error) {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -805,6 +805,10 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 				`  cat > '${openclawPatch}'`,
 				"  exit 0",
 				"fi",
+				'if [ "$1 $2 $3" = "config patch --stdin" ]; then',
+				"  cat >/dev/null",
+				"  exit 0",
+				"fi",
 				"printf 'unexpected openclaw command: %s\\n' \"$*\" >&2",
 				"exit 2",
 				"",
@@ -909,6 +913,10 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 				"#!/bin/sh",
 				'if [ "$1 $2 $3 $4 $5" = "config patch --stdin --replace-path models.providers" ]; then',
 				`  cat > '${openclawPatch}'`,
+				"  exit 0",
+				"fi",
+				'if [ "$1 $2 $3" = "config patch --stdin" ]; then',
+				"  cat >/dev/null",
 				"  exit 0",
 				"fi",
 				"exit 2",
@@ -1032,6 +1040,10 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 				"#!/bin/sh",
 				'if [ "$1 $2 $3 $4 $5" = "config patch --stdin --replace-path models.providers" ]; then',
 				`  cat > '${openclawPatch}'`,
+				"  exit 0",
+				"fi",
+				'if [ "$1 $2 $3" = "config patch --stdin" ]; then',
+				"  cat >/dev/null",
 				"  exit 0",
 				"fi",
 				"exit 2",
@@ -2876,6 +2888,10 @@ install -d "$HOME/.openclaw/bin"
 cat > "$HOME/.openclaw/bin/openclaw" <<'SH'
 #!/usr/bin/env bash
 if [ "\${1:-} \${2:-} \${3:-}" = "config patch --stdin" ]; then
+  payload="$(cat)"
+  if printf '%s' "$payload" | grep -q '"checkOnStart"'; then
+    exit 0
+  fi
   echo "projection boom" >&2
   exit 73
 fi
@@ -3724,11 +3740,14 @@ exit 64
 			.split("\n---\n")
 			.filter((entry) => entry.trim().length > 0)
 			.map((entry) => JSON.parse(entry));
-		expect(patches).toHaveLength(2);
-		expect(patches[0].channels.discord).toEqual({ enabled: true, token: "discord-token" });
-		expect(patches[1].channels.discord).toBeNull();
-		expect(patches[1].plugins.entries.discord).toBeNull();
-		expect(patches[1].channels.telegram).toEqual({
+		const policyPatches = patches.filter((patch) => Object.hasOwn(patch, "update"));
+		const channelPatches = patches.filter((patch) => Object.hasOwn(patch, "channels"));
+		expect(policyPatches).toHaveLength(2);
+		expect(channelPatches).toHaveLength(2);
+		expect(channelPatches[0].channels.discord).toEqual({ enabled: true, token: "discord-token" });
+		expect(channelPatches[1].channels.discord).toBeNull();
+		expect(channelPatches[1].plugins.entries.discord).toBeNull();
+		expect(channelPatches[1].channels.telegram).toEqual({
 			enabled: true,
 			botToken: "telegram-token",
 		});
@@ -4036,6 +4055,10 @@ if [ "\${1:-}" = "mcp" ] && [ "\${2:-}" = "unset" ] && [ "\${3:-}" = "clawdi" ];
   rm -f '${openclawMcp}'
   exit 0
 fi
+if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ]; then
+  cat >/dev/null
+  exit 0
+fi
 printf 'unexpected openclaw command: %s\\n' "$*" >&2
 exit 64
 `,
@@ -4267,6 +4290,7 @@ exit 64
 		expect(runtimeBridgeSection).not.toContain('"name":"hermes"');
 		expect(openclawSection).toContain('CLAWDI_RUNTIME_BRIDGE_TOKEN=""');
 		expect(openclawSection).toContain('CLAWDI_RUNTIME_BRIDGE_SURFACES=""');
+		expect(openclawSection).toContain('OPENCLAW_NO_AUTO_UPDATE="1"');
 		expect(openclawSection).not.toContain("bridge-secret");
 	});
 

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -256,6 +256,11 @@ printf '%s\\n' "\${NPM_CONFIG_PREFIX:-}" > "$HOME/.openclaw/install-proof/npm-co
 printf '%s\\n' "\${NPM_CONFIG_CACHE:-}" > "$HOME/.openclaw/install-proof/npm-config-cache"
 cat > "$HOME/.openclaw/bin/openclaw" <<'SH'
 #!/usr/bin/env bash
+if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ]; then
+  install -d "$HOME/.openclaw/install-proof"
+  printf '%s\n' "$*" > "$HOME/.openclaw/install-proof/config-patch-args"
+  cat > "$HOME/.openclaw/install-proof/config-patch-stdin"
+fi
 echo "openclaw fixture"
 SH
 chmod +x "$HOME/.openclaw/bin/openclaw"
@@ -481,7 +486,22 @@ chmod +x "$HOME/.local/bin/hermes"
 				supervisorConfig.indexOf("\n\n", openclawStart),
 			);
 			expect(openclawSection).not.toContain("user=clawdi");
+			expect(openclawSection).toContain('OPENCLAW_NO_AUTO_UPDATE="1"');
 			expect(supervisorConfig).not.toContain("auth-test-token");
+			expect(
+				readFileSync(join(home, ".openclaw", "install-proof", "config-patch-args"), "utf-8").trim(),
+			).toBe("config patch --stdin");
+			const openclawPolicyPatch = JSON.parse(
+				readFileSync(join(home, ".openclaw", "install-proof", "config-patch-stdin"), "utf-8"),
+			);
+			expect(openclawPolicyPatch).toEqual({
+				update: {
+					checkOnStart: false,
+					auto: {
+						enabled: false,
+					},
+				},
+			});
 			const inventory = JSON.parse(
 				readFileSync(join(serviceStateRoot, "install-inventory", "openclaw.json"), "utf-8"),
 			);


### PR DESCRIPTION
## Status\n\nDraft only. Do not merge.\n\nThis branch currently disables OpenClaw native update prompts/auto-update in hosted runtime convergence. That is not the requested fix and should be replaced by a real hosted update handoff design or closed.\n\n## Current finding\n\nKingsley's v2 deployment showed `managed-service-handoff-unavailable` because OpenClaw `update.run` expects a managed service handoff boundary. Hosted v2 currently runs under `supervisord`, so the correct next step is to design the handoff path, not silently disable OpenClaw updates.\n\n## Local verification from the discarded approach\n\n- `bun test packages/cli/tests/runtime.test.ts --test-name-pattern "runtime bridge|hosted"`\n- `bun test packages/cli/tests/smoke.test.ts --test-name-pattern "runtime init performs first-install convergence"`\n- `cd packages/cli && bun run typecheck`\n- `cd packages/cli && bun run build`\n- `cd packages/cli && node scripts/check-publish-manifest.mjs`