### PR TITLE
Fix web Turbo build outputs

### DIFF
--- a/apps/web/turbo.json
+++ b/apps/web/turbo.json
@@ -1,0 +1,19 @@
+{
+	"extends": ["//"],
+	"tasks": {
+		"build": {
+			"env": [
+				"$TURBO_EXTENDS$",
+				"MODE",
+				"VITE_*",
+				"CLERK_*",
+				"VERCEL",
+				"VERCEL_*",
+				"NITRO_*",
+				"SERVER_PRESET",
+				"SKIP_ENV_VALIDATION"
+			],
+			"outputs": ["$TURBO_EXTENDS$", ".output/**", ".vercel/output/**"]
+		}
+	}
+}

--- a/turbo.json
+++ b/turbo.json
@@ -14,8 +14,8 @@
 		},
 		"build": {
 			"dependsOn": ["^build"],
-			"env": ["NODE_ENV", "VITE_*", "CLERK_*", "CLAWDI_*", "VERCEL_*", "SKIP_ENV_VALIDATION"],
-			"outputs": [".output/**", "dist/**"]
+			"env": ["NODE_ENV"],
+			"outputs": ["dist/**"]
 		},
 		"typecheck": {
 			"dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- keep root `build` Turbo config generic for TypeScript packages
- add `apps/web/turbo.json` package config for TanStack Start/Nitro outputs
- whitelist web build env that affects Vite, Clerk, Nitro, and Vercel provider detection

## Why
`web#build` can emit either `.output/**` for normal Nitro builds or `.vercel/output/**` when Vercel is detected. The previous root config did not include the Vercel output path, so Turbo could warn that no output files were found. Keeping these outputs in the web package config avoids leaking web-specific build artifacts into every package.

## Verification
- `bunx biome check turbo.json apps/web/turbo.json`
- `git diff --check -- turbo.json apps/web/turbo.json`
- `bunx turbo build --dry=json --filter=web`
- `VITE_CLERK_PUBLISHABLE_KEY=pk_test_dummy VITE_CLAWDI_API_URL=http://localhost:8000 CLERK_SECRET_KEY=sk_test_dummy bunx turbo build --filter=web --force`
- `VERCEL=1 VITE_CLERK_PUBLISHABLE_KEY=pk_test_dummy VITE_CLAWDI_API_URL=http://localhost:8000 CLERK_SECRET_KEY=sk_test_dummy bunx turbo build --filter=web --force`
- `bunx vercel build --yes` from `apps/web`

## Review
Claude advisor reviewed the diff and found no blocking issues. It approved opening the PR; the only non-blocking note was a possible future cache-key optimization around Vercel envs.
