### PR TITLE
Support hosted runtime-owned services

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -70,7 +70,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.30",
+      "version": "0.12.10-beta.31",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -111,6 +111,7 @@ Normalization maps hosted fields into the internal shape:
 | `runtimes.<name>.enabled` | Run config, supervisor entry, and command shim state |
 | `runtimes.<name>.install` | Supported official installer input |
 | `runtimes.<name>.run` | Command, args, cwd, env, and PATH projection |
+| `runtimes.<name>.services` | Runtime-owned auxiliary processes, such as a browser dashboard, supervised without user command shims |
 | `bridge.surfaces` | Authenticated runtime surface listen/upstream mappings |
 | `providers` | Runtime-scoped AI provider projections and secret refs |
 | `mcp`, `tools` | Runtime MCP/tool projection input |
@@ -177,7 +178,7 @@ outputs include:
 | `cache/manifest.etag`, `cache/channels.etag` | Remote refresh cache validators |
 | `install-inventory/<runtime>.json` | Install/verify observation |
 | `config/projections/<runtime>.json` | Runtime projection payload |
-| `config/run/<runtime>.json` | `clawdi run` launch config |
+| `config/run/<runtime>.json`, `config/run/<runtime>+<service>.json` | `clawdi run` launch config for runtime main processes and internal runtime-owned services |
 | `config/runtime-command-shims.json` | Active generated command shims |
 | `supervisor/supervisord.conf` | Process supervision plan |
 
@@ -218,6 +219,19 @@ command=/usr/bin/env clawdi run -- <runtime>
 ```
 
 The image does not need per-agent supervisor wrappers.
+
+Runtime-owned services use the same generated run-config and supervisor model,
+but they are not user commands and do not receive command shims. A manifest entry
+such as `runtimes.hermes.services.dashboard` writes
+`config/run/hermes+dashboard.json` and supervisor starts it through:
+
+```ini
+command=/usr/bin/env clawdi run --runtime-service hermes+dashboard -- hermes
+```
+
+This covers browser helper processes such as a runtime dashboard while keeping
+the user's shell PATH clean: typing `hermes` enters the managed Hermes runtime,
+not a dashboard alias.
 
 ## Provider And Channel Routing
 

--- a/docs/plans/managed-runtime-cli.md
+++ b/docs/plans/managed-runtime-cli.md
@@ -71,6 +71,7 @@ should not produce unnecessary config churn.
 Key generated outputs:
 
 - `config/run/<runtime>.json` for `clawdi run`;
+- `config/run/<runtime>+<service>.json` for runtime-owned auxiliary services;
 - `config/projections/<runtime>.json` for runtime-specific config projection;
 - `config/runtime-command-shims.json` plus symlinks under the service-state bin
   directory;
@@ -193,6 +194,7 @@ Runtime changes should include focused tests for:
 - command shim routing, PATH cleanup, stale-shim cleanup, and disabled-runtime
   behavior;
 - supervisor config rendering for watch, runtime bridge, daemon, and runtimes;
+- runtime-owned service rendering without generating user command shims;
 - terminal URL token transport and light/dark xterm theme behavior when web UI
   code changes.
 

--- a/docs/plans/runtime-projection-boundary.md
+++ b/docs/plans/runtime-projection-boundary.md
@@ -129,6 +129,8 @@ The CLI may own:
 - PATH cleanup inside the shim dispatcher;
 - disabled-runtime enforcement;
 - supervisor commands that start runtimes through `clawdi run -- <runtime>`;
+- runtime-owned auxiliary services through `clawdi run --runtime-service`,
+  without user command shims;
 - support for future runtime names when an explicit `run.command` is supplied.
 
 The CLI must not own:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.30",
+	"version": "0.12.10-beta.31",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -43,6 +43,7 @@ import {
 	type RuntimeRunConfigRead,
 	type RuntimeRunInvocation,
 	readRuntimeRunConfigForCommand,
+	readRuntimeServiceRunConfig,
 	runtimeCommandShimDir,
 	withoutPathEntry,
 } from "../runtime/run-config";
@@ -56,6 +57,7 @@ interface RunOpts {
 	allVaultEnv?: boolean;
 	allowConflicts?: boolean;
 	dryRun?: boolean;
+	runtimeService?: string;
 }
 
 interface SelectedProject {
@@ -83,13 +85,37 @@ export async function run(
 	spawnImpl: SpawnFn = spawn,
 	brokerFactory: RuntimeMitmBrokerFactory = startRuntimeMitmBroker,
 ) {
-	if (args.length === 0) {
+	if (args.length === 0 && !opts.runtimeService) {
 		console.log(chalk.red("No command specified. Usage: clawdi run -- <command>"));
 		process.exit(1);
 	}
 
-	const hostedRuntimeRun = hostedRuntimeRunConfig(args[0]);
 	const baseProcessEnv = { ...process.env };
+	const hostedServiceRun = hostedRuntimeServiceRunConfig(opts.runtimeService);
+	if (hostedServiceRun.status === "ok" && !requiresCloudResolution(opts)) {
+		const paths = getRuntimePaths({ mode: "hosted" });
+		await spawnRuntimeInvocation(
+			buildRuntimeRunInvocation(
+				hostedServiceRun,
+				[hostedServiceRun.runtime],
+				baseProcessEnv,
+				paths,
+			),
+			spawnImpl,
+			brokerFactory,
+		);
+		return;
+	}
+	if (
+		hostedServiceRun.status !== "not-runtime" &&
+		hostedServiceRun.status !== "ok" &&
+		!requiresCloudResolution(opts)
+	) {
+		console.log(chalk.red(hostedRuntimeRunError(hostedServiceRun)));
+		process.exit(1);
+	}
+
+	const hostedRuntimeRun = hostedRuntimeRunConfig(args[0]);
 	const hostedGenericRun = hostedGenericRunInvocation(args, baseProcessEnv);
 	if (hostedRuntimeRun.status === "ok" && !requiresCloudResolution(opts)) {
 		const paths = getRuntimePaths({ mode: "hosted" });
@@ -265,9 +291,18 @@ function requiresCloudResolution(opts: RunOpts): boolean {
 	);
 }
 
-function hostedRuntimeRunConfig(command: string): RuntimeRunConfigRead {
+function hostedRuntimeRunConfig(command: string | undefined): RuntimeRunConfigRead {
 	if (detectRuntimeMode() !== "hosted") return { status: "not-runtime", runtime: null };
+	if (!command) return { status: "not-runtime", runtime: null };
 	return readRuntimeRunConfigForCommand(command, getRuntimePaths({ mode: "hosted" }));
+}
+
+function hostedRuntimeServiceRunConfig(selector: string | undefined): RuntimeRunConfigRead {
+	if (detectRuntimeMode() !== "hosted") return { status: "not-runtime", runtime: null };
+	if (!selector) return { status: "not-runtime", runtime: null };
+	const [runtime, service, ...rest] = selector.split("+");
+	if (!runtime || !service || rest.length > 0) return { status: "not-runtime", runtime: null };
+	return readRuntimeServiceRunConfig(runtime, service, getRuntimePaths({ mode: "hosted" }));
 }
 
 function hostedGenericRunInvocation(
@@ -281,6 +316,7 @@ function hostedGenericRunInvocation(
 	const mitmProfileBundle = existsSync(paths.mitmProfileBundle) ? paths.mitmProfileBundle : null;
 	return {
 		runtime: "generic",
+		service: null,
 		command,
 		args: commandArgs,
 		cwd: process.cwd(),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { registerServeCommand } from "./commands/serve-cli.js";
 import { handleError } from "./lib/errors.js";
 import { getCliVersion } from "./lib/version.js";
@@ -1242,6 +1242,12 @@ program
 	.option("--allow-conflicts", "Allow first-match wins for agent project conflicts")
 	.option("--no-project-folder", "Skip linked-folder Project lookup")
 	.option("--dry-run", "Show reference resolution plan without launching the command")
+	.addOption(
+		new Option(
+			"--runtime-service <runtime+service>",
+			"Run an internal hosted runtime service",
+		).hideHelp(),
+	)
 	.argument("<command...>", "Command to run")
 	.addHelpText(
 		"after",

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import { mitmProfileInputBundleSchema } from "./mitm-profiles";
-import { runtimeNameSchema, runtimeRunSettingsSchema } from "./run-config";
+import {
+	runtimeNameSchema,
+	runtimeRunSettingsSchema,
+	runtimeServiceNameSchema,
+} from "./run-config";
 
 export const RUNTIME_DESIRED_STATE_SCHEMA_VERSION = "clawdi.runtimeDesiredState.v1";
 
@@ -30,6 +34,7 @@ const runtimeSchema = z
 		updateChannel: z.string().min(1).optional(),
 		install: installSchema.optional(),
 		run: runtimeRunSettingsSchema.optional(),
+		services: z.record(runtimeServiceNameSchema, runtimeRunSettingsSchema).default({}),
 	})
 	.strict();
 
@@ -145,6 +150,7 @@ const hostedRuntimeEntrySchema = z
 		enabled: z.boolean(),
 		install: hostedRuntimeInstallSchema.optional(),
 		run: runtimeRunSettingsSchema.optional(),
+		services: z.record(runtimeServiceNameSchema, runtimeRunSettingsSchema).default({}),
 		paths: z
 			.object({
 				home: z.string().min(1).optional(),

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, readlinkSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { convergeRuntimeManifest, type RuntimeManifest } from "./manifest";
+import type { RuntimeManifestLoad } from "./manifest-source";
+import { getRuntimePaths, type RuntimePaths } from "./paths";
+import type { RuntimeRunSettings } from "./run-config";
+
+const originalEnv = { ...process.env };
+const tempRoots: string[] = [];
+
+function tempRuntimePaths(): RuntimePaths {
+	const root = mkdtempSync(join(tmpdir(), "clawdi-manifest-service-test-"));
+	tempRoots.push(root);
+	process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+	process.env.CLAWDI_RUN_DIR = join(root, "run");
+	process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
+	process.env.CLAWDI_HOME = join(root, "clawdi-home");
+	return getRuntimePaths({ mode: "hosted" });
+}
+
+function runSettings(command: string, args: string[]): RuntimeRunSettings {
+	return { command, args, env: {}, prependPath: [] };
+}
+
+afterEach(() => {
+	process.env = { ...originalEnv };
+	for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("runtime manifest services", () => {
+	test("supervises runtime-owned services without creating user command shims", () => {
+		const paths = tempRuntimePaths();
+		const manifest: RuntimeManifest = {
+			schemaVersion: "clawdi.runtimeDesiredState.v1",
+			deploymentId: "hdep_test",
+			environmentId: "env_test",
+			instanceId: "hri_test",
+			generation: 1,
+			issuedAt: "2026-07-01T00:00:00.000Z",
+			workspaceRoot: join(paths.userHome, "clawdi"),
+			controlPlane: { apiUrl: "https://cloud-api.example.test" },
+			runtimes: {
+				hermes: {
+					enabled: true,
+					run: runSettings("hermes", ["gateway", "run"]),
+					services: {
+						dashboard: runSettings("hermes", [
+							"dashboard",
+							"--host",
+							"127.0.0.1",
+							"--port",
+							"9119",
+							"--no-open",
+						]),
+					},
+				},
+			},
+			recovery: {},
+		};
+		const load: RuntimeManifestLoad = {
+			manifest,
+			source: "fixture-file",
+			sourcePath: "inline-test",
+			offline: false,
+		};
+
+		const result = convergeRuntimeManifest(load, paths);
+		expect(result.installErrors).toEqual([]);
+		expect(result.outputs.runConfigs.map((path) => path.split("/").at(-1)).sort()).toEqual([
+			"hermes+dashboard.json",
+			"hermes.json",
+		]);
+
+		const supervisor = readFileSync(paths.supervisorConfig, "utf8");
+		expect(supervisor).toContain("[program:clawdi-hermes]");
+		expect(supervisor).toContain("command=/usr/bin/env clawdi run -- hermes");
+		expect(supervisor).toContain("[program:clawdi-hermes-dashboard]");
+		expect(supervisor).toContain(
+			"command=/usr/bin/env clawdi run --runtime-service hermes+dashboard -- hermes",
+		);
+
+		const serviceConfig = JSON.parse(
+			readFileSync(join(paths.runConfigRoot, "hermes+dashboard.json"), "utf8"),
+		) as {
+			runtime?: string;
+			service?: string;
+			defaultArgs?: string[];
+			mitmProfileBundlePath?: string | null;
+		};
+		expect(serviceConfig.runtime).toBe("hermes");
+		expect(serviceConfig.service).toBe("dashboard");
+		expect(serviceConfig.defaultArgs).toEqual([
+			"dashboard",
+			"--host",
+			"127.0.0.1",
+			"--port",
+			"9119",
+			"--no-open",
+		]);
+		expect(serviceConfig.mitmProfileBundlePath).toBeNull();
+
+		expect(existsSync(join(paths.serviceStateRoot, "bin", "hermes"))).toBe(true);
+		expect(readlinkSync(join(paths.serviceStateRoot, "bin", "hermes"))).toBe(
+			".clawdi-runtime-command-shim",
+		);
+		expect(existsSync(join(paths.serviceStateRoot, "bin", "hermes+dashboard"))).toBe(false);
+	});
+});

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -508,6 +508,12 @@ function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): Runtime
 								}
 							: undefined,
 					run: hostedRuntimeRunSettings(runtime.run, runtime.paths?.workspace, workspaceRoot),
+					services: Object.fromEntries(
+						Object.entries(runtime.services ?? {}).map(([service, run]) => [
+							service,
+							hostedRuntimeServiceRunSettings(run, runtime.paths?.workspace, workspaceRoot),
+						]),
+					),
 				},
 			]),
 		),
@@ -542,6 +548,21 @@ function hostedRuntimeRunSettings(
 		cwd,
 		prependPath: run?.prependPath ?? [],
 	};
+}
+
+function hostedRuntimeServiceRunSettings(
+	run: RuntimeRunSettings,
+	runtimeWorkspace: string | undefined,
+	workspaceRoot: string,
+): RuntimeRunSettings {
+	return (
+		hostedRuntimeRunSettings(run, runtimeWorkspace, workspaceRoot) ?? {
+			args: [],
+			env: {},
+			cwd: runtimeWorkspace ?? workspaceRoot,
+			prependPath: [],
+		}
+	);
 }
 
 function hostedControlPlaneApiUrl(hosted: HostedRuntimeManifest): string {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -62,9 +62,11 @@ import {
 	buildRuntimeRunConfig,
 	isSupportedRuntimeName,
 	type RuntimeName,
+	type RuntimeServiceName,
 	runtimeCommandShimDir,
 	runtimeNameSchema,
-	runtimeRunConfigPath,
+	runtimeRunConfigId,
+	runtimeServiceNameSchema,
 	type SupportedRuntimeName,
 	writeRuntimeRunConfig,
 } from "./run-config";
@@ -1088,19 +1090,24 @@ function clearMitmProfileBundle(paths: RuntimePaths): null {
 	return null;
 }
 
-function removeStaleRuntimeRunConfigs(
-	writtenRuntimes: Set<RuntimeName>,
-	paths: RuntimePaths,
-): void {
+function removeStaleRuntimeRunConfigs(writtenRunConfigIds: Set<string>, paths: RuntimePaths): void {
 	if (!existsSync(paths.runConfigRoot)) return;
 	for (const entry of readdirSync(paths.runConfigRoot)) {
 		if (!entry.endsWith(".json")) continue;
-		const runtime = entry.slice(0, -".json".length);
-		if (!runtimeNameSchema.safeParse(runtime).success) continue;
-		if (!writtenRuntimes.has(runtime)) {
-			rmSync(runtimeRunConfigPath(runtime, paths), { force: true });
+		const id = entry.slice(0, -".json".length);
+		if (!runtimeRunConfigIdIsValid(id)) continue;
+		if (!writtenRunConfigIds.has(id)) {
+			rmSync(join(paths.runConfigRoot, entry), { force: true });
 		}
 	}
+}
+
+function runtimeRunConfigIdIsValid(id: string): boolean {
+	const [runtime, service, ...rest] = id.split("+");
+	if (rest.length > 0) return false;
+	if (!runtimeNameSchema.safeParse(runtime).success) return false;
+	if (service === undefined) return true;
+	return runtimeServiceNameSchema.safeParse(service).success;
 }
 
 const MANAGED_LIVE_SYNC_AGENTS = ["openclaw", "hermes", "codex"] as const;
@@ -1373,6 +1380,20 @@ function runtimeProgramRevision(
 	});
 }
 
+function runtimeServiceProgramRevision(
+	manifest: RuntimeManifest,
+	runtime: string,
+	service: string,
+): string {
+	return revisionHash({
+		clawdiCli: manifest.clawdiCli ?? null,
+		controlPlane: manifest.controlPlane,
+		runtime: runtime,
+		service,
+		settings: manifest.runtimes[runtime]?.services?.[service] ?? null,
+	});
+}
+
 function daemonProgramRevision(manifest: RuntimeManifest): string {
 	return revisionHash({
 		clawdiCli: manifest.clawdiCli ?? null,
@@ -1568,6 +1589,31 @@ function writeSupervisorConfig(
 			`environment=${runtimeEnvironment}`,
 			"",
 		);
+		for (const service of runtimeServiceNames(manifest, runtime)) {
+			const serviceEnvironment = supervisorEnvironment({
+				...commonEnvironment,
+				CLAWDI_AUTH_TOKEN: "",
+				CLAWDI_RUNTIME_REV: runtimeServiceProgramRevision(manifest, runtime, service),
+			});
+			lines.push(
+				`[program:${runtimeServiceProgramName(runtime, service)}]`,
+				`command=/usr/bin/env clawdi run --runtime-service ${runtimeRunConfigId(runtimeNameSchema.parse(runtime), service)} -- ${runtime}`,
+				`directory=${workspaceRoot}`,
+				...(runtimeNeedsSystemBoundary ? [] : [`user=${runtimeUser}`]),
+				"autostart=true",
+				"autorestart=true",
+				"startsecs=2",
+				"startretries=5",
+				"stopasgroup=true",
+				"killasgroup=true",
+				"stdout_logfile=/dev/fd/1",
+				"stdout_logfile_maxbytes=0",
+				"stderr_logfile=/dev/fd/2",
+				"stderr_logfile_maxbytes=0",
+				`environment=${serviceEnvironment}`,
+				"",
+			);
+		}
 	}
 
 	writePrivateFileAtomic(paths.supervisorConfig, `${lines.join("\n")}\n`, { mode: 0o644 });
@@ -1578,6 +1624,22 @@ function shouldSuperviseRuntime(runtime: string, manifest: RuntimeManifest): boo
 	const desired = manifest.runtimes[runtime];
 	if (!desired?.enabled) return false;
 	return isSupportedRuntimeName(runtime) || Boolean(desired.run?.command?.trim());
+}
+
+function runtimeServiceNames(manifest: RuntimeManifest, runtime: string): RuntimeServiceName[] {
+	const desired = manifest.runtimes[runtime];
+	if (!desired?.enabled) return [];
+	return Object.keys(desired.services ?? {})
+		.map((service) => runtimeServiceNameSchema.parse(service))
+		.sort();
+}
+
+function runtimeServiceProgramName(runtime: string, service: string): string {
+	return `clawdi-${supervisorProgramSegment(runtime)}-${supervisorProgramSegment(service)}`;
+}
+
+function supervisorProgramSegment(value: string): string {
+	return value.replace(/[^A-Za-z0-9_-]+/g, "-");
 }
 
 function writeRuntimeCommandShims(commands: Iterable<RuntimeName>, paths: RuntimePaths): void {
@@ -1821,7 +1883,7 @@ export function convergeRuntimeManifest(
 		daemonAuthTokenFile,
 		load.secretValues,
 	);
-	const writtenRunConfigRuntimes = new Set<RuntimeName>();
+	const writtenRunConfigIds = new Set<string>();
 	for (const agent of desiredLiveSyncAgents(manifest)) {
 		const parsed = runtimeNameSchema.safeParse(agent.agentType);
 		if (parsed.success) commandShims.add(parsed.data);
@@ -1908,8 +1970,30 @@ export function convergeRuntimeManifest(
 			paths,
 		);
 		runConfigs.push(runConfigPath);
-		writtenRunConfigRuntimes.add(runtimeName);
+		writtenRunConfigIds.add(runtimeRunConfigId(runtimeName));
 		commandShims.add(runtimeName);
+		for (const [serviceName, serviceSettings] of Object.entries(runtime.services ?? {})) {
+			const service = runtimeServiceNameSchema.parse(serviceName);
+			const serviceRunConfigPath = writeRuntimeRunConfig(
+				buildRuntimeRunConfig({
+					runtime: runtimeName,
+					service,
+					enabled: runtime.enabled,
+					generatedAt,
+					generation: manifest.generation,
+					instanceId: manifest.instanceId,
+					commandPath: observation.commandPath,
+					appRoot: observation.appRoot,
+					workspaceRoot,
+					settings: serviceSettings,
+					secretFilePath: null,
+					secretEnv: {},
+				}),
+				paths,
+			);
+			runConfigs.push(serviceRunConfigPath);
+			writtenRunConfigIds.add(runtimeRunConfigId(runtimeName, service));
+		}
 
 		const semaphorePath = join(semRoot, `${name}.enabled`);
 		if (runtime.enabled) {
@@ -1925,7 +2009,7 @@ export function convergeRuntimeManifest(
 
 	const bootFinished = join(instanceRoot, "boot-finished");
 	writePrivateFileAtomic(bootFinished, `${generatedAt}\n`);
-	removeStaleRuntimeRunConfigs(writtenRunConfigRuntimes, paths);
+	removeStaleRuntimeRunConfigs(writtenRunConfigIds, paths);
 	if (installErrors.length === 0) {
 		manifestLastGood = writeLastGoodManifest(manifest, paths);
 	}

--- a/packages/cli/src/runtime/run-config.test.ts
+++ b/packages/cli/src/runtime/run-config.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getRuntimePaths, type RuntimePaths } from "./paths";
+import {
+	buildRuntimeRunConfig,
+	buildRuntimeRunInvocation,
+	type RuntimeRunSettings,
+	readRuntimeRunConfigForCommand,
+	readRuntimeServiceRunConfig,
+	runtimeRunConfigPath,
+	writeRuntimeRunConfig,
+} from "./run-config";
+
+const originalEnv = { ...process.env };
+const tempRoots: string[] = [];
+
+function tempRuntimePaths(): RuntimePaths {
+	const root = mkdtempSync(join(tmpdir(), "clawdi-run-config-test-"));
+	tempRoots.push(root);
+	process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+	process.env.CLAWDI_RUN_DIR = join(root, "run");
+	process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
+	return getRuntimePaths({ mode: "hosted" });
+}
+
+function runSettings(command: string, args: string[]): RuntimeRunSettings {
+	return { command, args, env: {}, prependPath: [] };
+}
+
+afterEach(() => {
+	process.env = { ...originalEnv };
+	for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("runtime run config services", () => {
+	test("keeps runtime services out of ordinary runtime command lookup", () => {
+		const paths = tempRuntimePaths();
+		writeRuntimeRunConfig(
+			buildRuntimeRunConfig({
+				runtime: "hermes",
+				enabled: true,
+				generatedAt: "2026-07-01T00:00:00.000Z",
+				generation: 1,
+				instanceId: "hri_test",
+				commandPath: null,
+				appRoot: null,
+				workspaceRoot: "/home/clawdi/clawdi",
+				settings: runSettings("hermes", ["gateway", "run"]),
+			}),
+			paths,
+		);
+		writeRuntimeRunConfig(
+			buildRuntimeRunConfig({
+				runtime: "hermes",
+				service: "dashboard",
+				enabled: true,
+				generatedAt: "2026-07-01T00:00:00.000Z",
+				generation: 1,
+				instanceId: "hri_test",
+				commandPath: null,
+				appRoot: null,
+				workspaceRoot: "/home/clawdi/clawdi",
+				settings: runSettings("hermes", [
+					"dashboard",
+					"--host",
+					"127.0.0.1",
+					"--port",
+					"9119",
+					"--no-open",
+				]),
+			}),
+			paths,
+		);
+
+		expect(runtimeRunConfigPath("hermes", paths).endsWith("/hermes.json")).toBe(true);
+		expect(
+			runtimeRunConfigPath("hermes", paths, "dashboard").endsWith("/hermes+dashboard.json"),
+		).toBe(true);
+
+		const runtime = readRuntimeRunConfigForCommand("hermes", paths);
+		expect(runtime.status).toBe("ok");
+		if (runtime.status !== "ok") throw new Error("expected hermes run config");
+		expect(runtime.config.service).toBeNull();
+		expect(buildRuntimeRunInvocation(runtime, ["hermes"], {}, paths).args).toEqual([
+			"gateway",
+			"run",
+		]);
+
+		expect(readRuntimeRunConfigForCommand("hermes+dashboard", paths).status).toBe("not-runtime");
+		const service = readRuntimeServiceRunConfig("hermes", "dashboard", paths);
+		expect(service.status).toBe("ok");
+		if (service.status !== "ok") throw new Error("expected hermes dashboard run config");
+		expect(service.config.service).toBe("dashboard");
+		expect(buildRuntimeRunInvocation(service, ["hermes"], {}, paths).args).toEqual([
+			"dashboard",
+			"--host",
+			"127.0.0.1",
+			"--port",
+			"9119",
+			"--no-open",
+		]);
+	});
+});

--- a/packages/cli/src/runtime/run-config.ts
+++ b/packages/cli/src/runtime/run-config.ts
@@ -13,6 +13,12 @@ export const runtimeNameSchema = z
 	.refine((name) => name !== "clawdi", "Runtime name is reserved.");
 export type RuntimeName = z.infer<typeof runtimeNameSchema>;
 
+export const runtimeServiceNameSchema = z
+	.string()
+	.regex(/^[a-z0-9][a-z0-9._-]{0,63}$/)
+	.refine((name) => name !== "main", "Runtime service name is reserved.");
+export type RuntimeServiceName = z.infer<typeof runtimeServiceNameSchema>;
+
 const supportedRuntimeSchema = z.enum(["hermes", "openclaw"]);
 export type SupportedRuntimeName = z.infer<typeof supportedRuntimeSchema>;
 
@@ -34,6 +40,7 @@ const runtimeRunConfigSchema = z
 	.object({
 		schemaVersion: z.literal("clawdi.runtimeRunConfig.v1"),
 		runtime: runtimeNameSchema,
+		service: runtimeServiceNameSchema.nullable().default(null),
 		enabled: z.boolean(),
 		generatedAt: z.string().min(1),
 		generation: z.number().int().nonnegative(),
@@ -76,6 +83,7 @@ export type RuntimeRunConfigRead =
 
 export interface RuntimeRunInvocation {
 	runtime: string;
+	service: string | null;
 	command: string;
 	args: string[];
 	cwd?: string;
@@ -93,12 +101,24 @@ export function runtimeNameForCommand(command: string): RuntimeName | null {
 	return parsed.success ? parsed.data : null;
 }
 
-export function runtimeRunConfigPath(runtime: RuntimeName, paths = getRuntimePaths()): string {
-	return join(paths.runConfigRoot, `${runtime}.json`);
+export function runtimeRunConfigId(
+	runtime: RuntimeName,
+	service?: RuntimeServiceName | null,
+): string {
+	return service ? `${runtime}+${service}` : runtime;
+}
+
+export function runtimeRunConfigPath(
+	runtime: RuntimeName,
+	paths = getRuntimePaths(),
+	service?: RuntimeServiceName | null,
+): string {
+	return join(paths.runConfigRoot, `${runtimeRunConfigId(runtime, service)}.json`);
 }
 
 export function buildRuntimeRunConfig(input: {
 	runtime: RuntimeName;
+	service?: RuntimeServiceName | null;
 	enabled: boolean;
 	generatedAt: string;
 	generation: number;
@@ -118,6 +138,7 @@ export function buildRuntimeRunConfig(input: {
 	return {
 		schemaVersion: "clawdi.runtimeRunConfig.v1",
 		runtime: input.runtime,
+		service: input.service ?? null,
 		enabled: input.enabled,
 		generatedAt: input.generatedAt,
 		generation: input.generation,
@@ -136,7 +157,7 @@ export function buildRuntimeRunConfig(input: {
 }
 
 export function writeRuntimeRunConfig(config: RuntimeRunConfig, paths: RuntimePaths): string {
-	const path = runtimeRunConfigPath(config.runtime, paths);
+	const path = runtimeRunConfigPath(config.runtime, paths, config.service);
 	writePrivateFileAtomic(path, `${JSON.stringify(config, null, 2)}\n`, {
 		mode: 0o644,
 		dirMode: 0o755,
@@ -172,6 +193,36 @@ export function readRuntimeRunConfigForCommand(
 	}
 }
 
+export function readRuntimeServiceRunConfig(
+	runtime: string,
+	service: string,
+	paths = getRuntimePaths(),
+): RuntimeRunConfigRead {
+	const parsedRuntime = runtimeNameSchema.safeParse(runtime);
+	if (!parsedRuntime.success) return { status: "not-runtime", runtime: null };
+	const parsedService = runtimeServiceNameSchema.safeParse(service);
+	if (!parsedService.success) return { status: "not-runtime", runtime: null };
+
+	const path = runtimeRunConfigPath(parsedRuntime.data, paths, parsedService.data);
+	if (!existsSync(path)) {
+		return { status: "missing", runtime: parsedRuntime.data, path };
+	}
+
+	try {
+		const parsed = runtimeRunConfigSchema.parse(JSON.parse(readFileSync(path, "utf8")));
+		if (!parsed.enabled)
+			return { status: "disabled", runtime: parsedRuntime.data, path, config: parsed };
+		return { status: "ok", runtime: parsedRuntime.data, path, config: parsed };
+	} catch (error) {
+		return {
+			status: "invalid",
+			runtime: parsedRuntime.data,
+			path,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
 export function buildRuntimeRunInvocation(
 	read: Extract<RuntimeRunConfigRead, { status: "ok" }>,
 	args: string[],
@@ -199,6 +250,7 @@ export function buildRuntimeRunInvocation(
 			: read.config.command;
 	return {
 		runtime: read.runtime,
+		service: read.config.service,
 		command,
 		args: args.length > 1 ? args.slice(1) : read.config.defaultArgs,
 		cwd: read.config.cwd,

--- a/packages/cli/tests/commands/run.test.ts
+++ b/packages/cli/tests/commands/run.test.ts
@@ -139,6 +139,7 @@ describe("run command project folder selection", () => {
 		const child = buildRuntimeChildSpawn(
 			{
 				runtime: "openclaw",
+				service: null,
 				command: "/home/clawdi/.openclaw/bin/openclaw",
 				args: ["gateway", "run"],
 				cwd: "/home/clawdi/clawdi",
@@ -170,6 +171,7 @@ describe("run command project folder selection", () => {
 		const child = buildRuntimeChildSpawn(
 			{
 				runtime: "hermes",
+				service: null,
 				command: "/home/clawdi/.local/bin/hermes",
 				args: ["dashboard"],
 				cwd: "/home/clawdi/clawdi",
@@ -210,6 +212,7 @@ describe("run command project folder selection", () => {
 			buildRuntimeChildSpawn(
 				{
 					runtime: "openclaw",
+					service: null,
 					command: "openclaw",
 					args: [],
 					cwd: "/home/clawdi/clawdi",
@@ -266,6 +269,58 @@ describe("run command project folder selection", () => {
 		expect(calls[0].env.PATH?.startsWith(join(tmpRoot, "home", "clawdi", ".local", "bin"))).toBe(
 			true,
 		);
+	});
+
+	it("runs hosted runtime services from managed service run config", async () => {
+		unlinkSync(join(fakeClawdiHome, "auth.json"));
+		const serviceStateRoot = join(tmpRoot, "var", "lib", "clawdi");
+		const runRoot = join(tmpRoot, "run", "clawdi");
+		const hermesPath = join(tmpRoot, "home", "clawdi", ".local", "bin", "hermes");
+		const runConfigRoot = join(serviceStateRoot, "config", "run");
+		mkdirSync(runConfigRoot, { recursive: true });
+		mkdirSync(join(tmpRoot, "home", "clawdi", ".local", "bin"), { recursive: true });
+		writeFileSync(
+			join(runConfigRoot, "hermes+dashboard.json"),
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeRunConfig.v1",
+				runtime: "hermes",
+				service: "dashboard",
+				enabled: true,
+				generatedAt: "2026-07-01T00:00:00Z",
+				generation: 1,
+				instanceId: "iid_test",
+				command: "hermes",
+				defaultArgs: ["dashboard", "--host", "127.0.0.1", "--port", "9119", "--no-open"],
+				env: {
+					HERMES_CONFIG: "/home/clawdi/.hermes/config.toml",
+				},
+				prependPath: [join(tmpRoot, "home", "clawdi", ".local", "bin")],
+				cwd: projectRoot,
+				commandPath: hermesPath,
+				appRoot: join(tmpRoot, "home", "clawdi", ".hermes", "hermes-agent"),
+			}),
+		);
+		writeFileSync(hermesPath, "#!/usr/bin/env sh\n");
+		const { calls, spawnImpl } = recordSpawn();
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = serviceStateRoot;
+		process.env.CLAWDI_RUN_DIR = runRoot;
+		delete process.env.CLAWDI_AUTH_TOKEN;
+
+		await run(["hermes"], { runtimeService: "hermes+dashboard" }, spawnImpl);
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].command).toBe(hermesPath);
+		expect(calls[0].args).toEqual([
+			"dashboard",
+			"--host",
+			"127.0.0.1",
+			"--port",
+			"9119",
+			"--no-open",
+		]);
+		expect(calls[0].cwd).toBe(projectRoot);
+		expect(calls[0].env.HERMES_CONFIG).toBe("/home/clawdi/.hermes/config.toml");
 	});
 
 	it("rejects disabled hosted runtime commands before native binaries can run", async () => {


### PR DESCRIPTION
## Summary
- add `runtimes.<runtime>.services` to the hosted runtime manifest contract
- project service run configs like `config/run/hermes+dashboard.json` without creating user command shims
- let supervisor start services through the hidden `clawdi run --runtime-service <runtime>+<service>` entrypoint
- bump the CLI package to `0.12.10-beta.31` so the service-aware runtime CLI can publish to npm
- document the stable-image contract for runtime-owned auxiliary services

## Why
Hermes Dashboard is an official separate foreground service, not part of `hermes gateway run`. Hosted runtimes need a generic way to supervise runtime-owned browser services while keeping the image stable and avoiding per-agent wrapper scripts or PATH aliases.

## Rollout
After this lands on `main`, the CLI publish workflow should publish `clawdi@0.12.10-beta.31`. Hosted runtime images/manifests that use `runtimes.<runtime>.services` should pin or install that published version or newer.

## Verification
- `bun test packages/cli/src/runtime/run-config.test.ts packages/cli/src/runtime/manifest-services.test.ts packages/cli/tests/commands/run.test.ts packages/cli/tests/smoke.test.ts`
- `bun run typecheck --filter=clawdi`
- `git diff --check`

Enables Clawdi-AI/clawdi-hosted#631.