### PR TITLE
Separate v1 and v2 managed provider contracts

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -238,7 +238,7 @@ async def admin_revoke_api_key(
 
 
 @router.put(
-    "/ai-providers/clawdi-managed",
+    f"/ai-providers/{MANAGED_AI_PROVIDER_ID}",
     response_model=AdminManagedAiProviderResponse,
 )
 async def admin_upsert_clawdi_managed_ai_provider(

--- a/backend/app/routes/ai_providers.py
+++ b/backend/app/routes/ai_providers.py
@@ -38,9 +38,9 @@ from app.schemas.ai_provider import (
     AiProviderValidationResponse,
 )
 from app.services.managed_ai_provider import (
-    MANAGED_AI_PROVIDER_API_MODE,
-    MANAGED_AI_PROVIDER_ID,
+    MANAGED_AI_PROVIDER_IDS,
     MANAGED_AI_PROVIDER_RUNTIME_ENV,
+    managed_provider_api_mode,
 )
 from app.services.vault_crypto import decrypt, encrypt
 
@@ -880,7 +880,11 @@ def _validate_provider(body: AiProviderUpsert) -> list[str]:
     errors.extend(_validate_base_url(body.base_url, body.auth))
     if body.runtime_env_name is not None and not _is_runtime_env_name(body.runtime_env_name):
         errors.append("runtime_env_name must be an uppercase environment variable name")
-    if body.default_model and body.default_model.startswith("openai-codex/"):
+    if (
+        body.default_model
+        and body.default_model.startswith("openai-codex/")
+        and not _is_legacy_managed_provider(body)
+    ):
         errors.append(
             "default_model must use the OpenAI model id without the legacy openai-codex prefix"
         )
@@ -895,19 +899,21 @@ def _validate_provider(body: AiProviderUpsert) -> list[str]:
 
 
 def _validate_managed_provider_contract(body: AiProviderUpsert) -> list[str]:
-    is_managed_contract = body.provider_id == MANAGED_AI_PROVIDER_ID or body.managed_by == "clawdi"
+    is_managed_contract = body.provider_id in MANAGED_AI_PROVIDER_IDS or body.managed_by == "clawdi"
     if not is_managed_contract:
         return []
 
     errors: list[str] = []
-    if body.provider_id != MANAGED_AI_PROVIDER_ID:
-        errors.append(f"managed Clawdi provider must use provider_id {MANAGED_AI_PROVIDER_ID}")
+    expected_api_mode = managed_provider_api_mode(body.provider_id)
+    if expected_api_mode is None:
+        allowed_ids = ", ".join(sorted(MANAGED_AI_PROVIDER_IDS))
+        errors.append(f"managed Clawdi provider must use provider_id one of: {allowed_ids}")
     if body.managed_by != "clawdi":
-        errors.append("clawdi-managed provider must be managed_by clawdi")
+        errors.append("managed Clawdi provider must be managed_by clawdi")
     if body.type != "custom_openai_compatible":
         errors.append("managed Clawdi provider must use custom_openai_compatible")
-    if body.api_mode != MANAGED_AI_PROVIDER_API_MODE:
-        errors.append(f"managed Clawdi provider must use api_mode {MANAGED_AI_PROVIDER_API_MODE}")
+    if expected_api_mode is not None and body.api_mode != expected_api_mode:
+        errors.append(f"managed Clawdi provider must use api_mode {expected_api_mode}")
     if body.auth.type != "api_key" or body.auth.source != "managed":
         errors.append("managed Clawdi provider must use managed api_key auth")
     if body.runtime_env_name != MANAGED_AI_PROVIDER_RUNTIME_ENV:
@@ -915,6 +921,12 @@ def _validate_managed_provider_contract(body: AiProviderUpsert) -> list[str]:
             f"managed Clawdi provider must use runtime_env_name {MANAGED_AI_PROVIDER_RUNTIME_ENV}"
         )
     return errors
+
+
+def _is_legacy_managed_provider(body: AiProviderUpsert) -> bool:
+    return managed_provider_api_mode(body.provider_id) == "openai_responses" and (
+        body.managed_by == "clawdi"
+    )
 
 
 def _validate_auth(provider_id: str, auth: AiProviderAuth) -> list[str]:

--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -19,9 +19,11 @@ from app.models.hosted_runtime import HostedRuntimeState
 from app.models.session import AgentEnvironment
 from app.services.http_cache import if_none_match_contains, strong_json_etag
 from app.services.managed_ai_provider import (
-    MANAGED_AI_PROVIDER_API_MODE,
     MANAGED_AI_PROVIDER_ID,
+    MANAGED_AI_PROVIDER_IDS,
     MANAGED_AI_PROVIDER_RUNTIME_ENV,
+    V1_MANAGED_AI_PROVIDER_ID,
+    managed_provider_api_mode,
 )
 from app.services.vault_crypto import decrypt
 
@@ -253,7 +255,7 @@ def _provider_manifest_entry(
     api_mode = provider.api_mode
     runtime_env_name = provider.runtime_env_name
     if is_managed:
-        api_mode = MANAGED_AI_PROVIDER_API_MODE
+        api_mode = managed_provider_api_mode(provider.provider_id) or provider.api_mode
         runtime_env_name = MANAGED_AI_PROVIDER_RUNTIME_ENV
     selected_model = model or provider.default_model
     if selected_model:
@@ -293,7 +295,7 @@ def _provider_secret_ref(runtime_name: str) -> str:
 
 
 def _is_clawdi_managed_provider(provider: AiProvider) -> bool:
-    return provider.provider_id == MANAGED_AI_PROVIDER_ID or (
+    return provider.provider_id in MANAGED_AI_PROVIDER_IDS or (
         provider.managed_by == "clawdi"
         and provider.auth_type == "api_key"
         and (provider.auth_metadata or {}).get("source") == "managed"
@@ -359,12 +361,16 @@ async def _select_provider(
         )
         return result.scalar_one_or_none()
 
-    result = await db.execute(
-        select(AiProvider).where(*filters, AiProvider.provider_id == MANAGED_AI_PROVIDER_ID)
-    )
-    managed = result.scalar_one_or_none()
-    if managed is not None:
-        return managed
+    for managed_provider_id in (MANAGED_AI_PROVIDER_ID, V1_MANAGED_AI_PROVIDER_ID):
+        result = await db.execute(
+            select(AiProvider).where(
+                *filters,
+                AiProvider.provider_id == managed_provider_id,
+            )
+        )
+        managed = result.scalar_one_or_none()
+        if managed is not None:
+            return managed
 
     result = await db.execute(select(AiProvider).where(*filters).order_by(AiProvider.provider_id))
     return result.scalars().first()

--- a/backend/app/services/managed_ai_provider.py
+++ b/backend/app/services/managed_ai_provider.py
@@ -10,12 +10,28 @@ from app.models.ai_provider import AiProvider, AiProviderAuthPayload
 from app.models.user import User
 from app.services.vault_crypto import encrypt
 
-MANAGED_AI_PROVIDER_ID = "clawdi-managed"
-MANAGED_AI_PROVIDER_API_MODE = "openai_chat"
+V1_MANAGED_AI_PROVIDER_ID = "clawdi-managed"
+V1_MANAGED_AI_PROVIDER_API_MODE = "openai_responses"
+V2_MANAGED_AI_PROVIDER_ID = "clawdi-managed-v2"
+V2_MANAGED_AI_PROVIDER_API_MODE = "openai_chat"
+
+# The admin managed-provider path is owned by hosted v2. V1 writes its provider
+# through the user AI Provider endpoint with the v1-specific id/mode above.
+MANAGED_AI_PROVIDER_ID = V2_MANAGED_AI_PROVIDER_ID
+MANAGED_AI_PROVIDER_API_MODE = V2_MANAGED_AI_PROVIDER_API_MODE
+MANAGED_AI_PROVIDER_IDS = frozenset({V1_MANAGED_AI_PROVIDER_ID, V2_MANAGED_AI_PROVIDER_ID})
 MANAGED_AI_PROVIDER_RUNTIME_ENV = "CLAWDI_MANAGED_OPENAI_API_KEY"
 MANAGED_AI_PROVIDER_TYPE = "custom_openai_compatible"
 MANAGED_AI_PROVIDER_LABEL = "Clawdi managed"
 MANAGED_AI_PROVIDER_PROFILE = "default"
+
+
+def managed_provider_api_mode(provider_id: str) -> str | None:
+    if provider_id == V1_MANAGED_AI_PROVIDER_ID:
+        return V1_MANAGED_AI_PROVIDER_API_MODE
+    if provider_id == V2_MANAGED_AI_PROVIDER_ID:
+        return V2_MANAGED_AI_PROVIDER_API_MODE
+    return None
 
 
 def validate_managed_provider_base_url(base_url: str) -> None:

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -465,7 +465,7 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
 
     raw_key = "sk-admin-managed-secret"
     r = await admin_client.put(
-        "/api/admin/ai-providers/clawdi-managed",
+        "/api/admin/ai-providers/clawdi-managed-v2",
         headers=_AUTH,
         json={
             "target_clerk_id": seed_user.clerk_id,
@@ -530,7 +530,7 @@ async def test_admin_upsert_managed_ai_provider_rotates_existing_payload(
     from app.services.vault_crypto import decrypt
 
     first = await admin_client.put(
-        "/api/admin/ai-providers/clawdi-managed",
+        "/api/admin/ai-providers/clawdi-managed-v2",
         headers=_AUTH,
         json={
             "target_clerk_id": seed_user.clerk_id,
@@ -541,7 +541,7 @@ async def test_admin_upsert_managed_ai_provider_rotates_existing_payload(
     assert first.status_code == 200, first.text
     second_key = "sk-second-admin-managed-secret"
     second = await admin_client.put(
-        "/api/admin/ai-providers/clawdi-managed",
+        "/api/admin/ai-providers/clawdi-managed-v2",
         headers=_AUTH,
         json={
             "target_clerk_id": seed_user.clerk_id,
@@ -554,24 +554,32 @@ async def test_admin_upsert_managed_ai_provider_rotates_existing_payload(
     assert second_key not in second.text
 
     providers = (
-        await db_session.execute(
-            select(AiProvider).where(
-                AiProvider.owner_user_id == seed_user.id,
-                AiProvider.provider_id == MANAGED_AI_PROVIDER_ID,
+        (
+            await db_session.execute(
+                select(AiProvider).where(
+                    AiProvider.owner_user_id == seed_user.id,
+                    AiProvider.provider_id == MANAGED_AI_PROVIDER_ID,
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(providers) == 1
     assert providers[0].default_model == "gpt-5.4"
 
     payloads = (
-        await db_session.execute(
-            select(AiProviderAuthPayload).where(
-                AiProviderAuthPayload.owner_user_id == seed_user.id,
-                AiProviderAuthPayload.provider_id == MANAGED_AI_PROVIDER_ID,
+        (
+            await db_session.execute(
+                select(AiProviderAuthPayload).where(
+                    AiProviderAuthPayload.owner_user_id == seed_user.id,
+                    AiProviderAuthPayload.provider_id == MANAGED_AI_PROVIDER_ID,
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(payloads) == 1
     assert decrypt(payloads[0].encrypted_payload, payloads[0].nonce) == second_key
 
@@ -580,7 +588,7 @@ async def test_admin_upsert_managed_ai_provider_rotates_existing_payload(
 async def test_admin_upsert_managed_ai_provider_rejects_invalid_base_url(admin_client, seed_user):
     raw_key = "sk-invalid-url-secret"
     r = await admin_client.put(
-        "/api/admin/ai-providers/clawdi-managed",
+        "/api/admin/ai-providers/clawdi-managed-v2",
         headers=_AUTH,
         json={
             "target_clerk_id": seed_user.clerk_id,

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -138,7 +138,7 @@ async def test_ai_provider_rejects_invalid_auth_and_api_mode(client: httpx.Async
     managed = await client.post(
         "/api/ai-providers",
         json={
-            "provider_id": "clawdi-managed",
+            "provider_id": "clawdi-managed-v2",
             "type": "custom_openai_compatible",
             "base_url": "https://managed.example/v1",
             "default_model": "gpt-5.5",
@@ -149,7 +149,41 @@ async def test_ai_provider_rejects_invalid_auth_and_api_mode(client: httpx.Async
         },
     )
     assert managed.status_code == 200, managed.text
+    assert managed.json()["provider_id"] == "clawdi-managed-v2"
     assert managed.json()["api_mode"] == "openai_chat"
+
+    v1_managed = await client.post(
+        "/api/ai-providers",
+        json={
+            "provider_id": "clawdi-managed",
+            "type": "custom_openai_compatible",
+            "base_url": "https://managed.example/v1",
+            "default_model": "openai-codex/gpt-5.5",
+            "api_mode": "openai_responses",
+            "auth": {"type": "api_key", "source": "managed"},
+            "managed_by": "clawdi",
+            "runtime_env_name": "CLAWDI_MANAGED_OPENAI_API_KEY",
+        },
+    )
+    assert v1_managed.status_code == 200, v1_managed.text
+    assert v1_managed.json()["provider_id"] == "clawdi-managed"
+    assert v1_managed.json()["api_mode"] == "openai_responses"
+
+    v1_managed_wrong_mode = await client.post(
+        "/api/ai-providers",
+        json={
+            "provider_id": "clawdi-managed",
+            "type": "custom_openai_compatible",
+            "base_url": "https://managed.example/v1",
+            "default_model": "openai-codex/gpt-5.5",
+            "api_mode": "openai_chat",
+            "auth": {"type": "api_key", "source": "managed"},
+            "managed_by": "clawdi",
+            "runtime_env_name": "CLAWDI_MANAGED_OPENAI_API_KEY",
+        },
+    )
+    assert v1_managed_wrong_mode.status_code == 422, v1_managed_wrong_mode.text
+    assert "must use api_mode openai_responses" in v1_managed_wrong_mode.text
 
     plaintext_extra = await client.post(
         "/api/ai-providers",

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -61,7 +61,7 @@ async def _write_runtime_state(admin_client: httpx.AsyncClient, environment_id: 
         "app_id": "app-test",
         "instance_id": f"hri_{uuid4().hex}",
         "generation": 7,
-        "provider_id": "clawdi-managed",
+        "provider_id": "clawdi-managed-v2",
         "runtimes": {
             "openclaw": {
                 "enabled": True,
@@ -872,7 +872,7 @@ async def test_runtime_manifest_rejects_unknown_enabled_runtime_state(
             app_id="app-test",
             instance_id=f"hri_{uuid4().hex}",
             generation=7,
-            provider_id="clawdi-managed",
+            provider_id="clawdi-managed-v2",
             runtimes={
                 "claude_code": {"enabled": True},
                 "openclaw": {"enabled": False},
@@ -1062,11 +1062,11 @@ async def test_runtime_manifest_projects_provider_secret_values(
     db_session.add(
         AiProvider(
             owner_user_id=seed_user.id,
-            provider_id="clawdi-managed",
+            provider_id="clawdi-managed-v2",
             type="custom_openai_compatible",
             base_url="https://sub2api.test/v1",
             default_model="gpt-5.5",
-            # Simulate a stale managed provider row from before the chat-completions contract.
+            # Simulate a stale v2 managed provider row from before the chat-completions contract.
             api_mode="openai_responses",
             auth_type="api_key",
             auth_metadata={"source": "managed"},
@@ -1077,7 +1077,7 @@ async def test_runtime_manifest_projects_provider_secret_values(
     db_session.add(
         AiProviderAuthPayload(
             owner_user_id=seed_user.id,
-            provider_id="clawdi-managed",
+            provider_id="clawdi-managed-v2",
             auth_profile="default",
             kind="api_key",
             source="managed",
@@ -1111,7 +1111,7 @@ async def test_runtime_manifest_projects_provider_secret_values(
         await db_session.execute(
             AiProviderAuthPayload.__table__.select().where(
                 AiProviderAuthPayload.owner_user_id == seed_user.id,
-                AiProviderAuthPayload.provider_id == "clawdi-managed",
+                AiProviderAuthPayload.provider_id == "clawdi-managed-v2",
             )
         )
     ).first()
@@ -1120,7 +1120,7 @@ async def test_runtime_manifest_projects_provider_secret_values(
         AiProviderAuthPayload.__table__.update()
         .where(
             AiProviderAuthPayload.owner_user_id == seed_user.id,
-            AiProviderAuthPayload.provider_id == "clawdi-managed",
+            AiProviderAuthPayload.provider_id == "clawdi-managed-v2",
         )
         .values(encrypted_payload=ciphertext, nonce=nonce)
     )
@@ -1133,6 +1133,66 @@ async def test_runtime_manifest_projects_provider_secret_values(
     assert rotated.status_code == 200, rotated.text
     assert rotated.headers["etag"] != etag
     assert rotated.json()["secretValues"] == {"provider.openclaw.apiKey": "sk-rotated-provider"}
+
+
+@pytest.mark.asyncio
+async def test_runtime_manifest_projects_legacy_managed_provider_as_responses(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"legacy-provider-{uuid4().hex[:8]}",
+        machine_name="Runtime Legacy Provider",
+        agent_type="openclaw",
+    )
+    ciphertext, nonce = encrypt("sk-test-legacy-provider")
+    db_session.add(
+        AiProvider(
+            owner_user_id=seed_user.id,
+            provider_id="clawdi-managed",
+            type="custom_openai_compatible",
+            base_url="https://sub2api.test/v1",
+            default_model="openai-codex/gpt-5.5",
+            api_mode="openai_responses",
+            auth_type="api_key",
+            auth_metadata={"source": "managed"},
+            managed_by="clawdi",
+            runtime_env_name="CLAWDI_MANAGED_OPENAI_API_KEY",
+        )
+    )
+    db_session.add(
+        AiProviderAuthPayload(
+            owner_user_id=seed_user.id,
+            provider_id="clawdi-managed",
+            auth_profile="default",
+            kind="api_key",
+            source="managed",
+            encrypted_payload=ciphertext,
+            nonce=nonce,
+        )
+    )
+    await db_session.commit()
+    await _write_runtime_state(admin_client, str(env.id), provider_id="clawdi-managed")
+
+    api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        response = await client.get("/api/runtime/manifest")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["manifest"]["providers"]["openclaw"] == {
+        "kind": "openai-compatible",
+        "baseUrl": "https://sub2api.test/v1",
+        "model": "openai-codex/gpt-5.5",
+        "apiMode": "openai_responses",
+        "runtimeEnvName": "CLAWDI_MANAGED_OPENAI_API_KEY",
+        "apiKeySecretRef": "provider.openclaw.apiKey",
+    }
+    assert payload["secretValues"] == {"provider.openclaw.apiKey": "sk-test-legacy-provider"}
 
 
 @pytest.mark.asyncio

--- a/packages/cli/tests/commands/ai-provider.test.ts
+++ b/packages/cli/tests/commands/ai-provider.test.ts
@@ -741,7 +741,7 @@ describe("ai-provider commands", () => {
 				schema_version: 1,
 				providers: [
 					{
-						id: "clawdi-managed",
+						id: "clawdi-managed-v2",
 						type: "custom_openai_compatible",
 						base_url: "https://sub2api.example.test/v1",
 						default_model: "gpt-5.5",
@@ -768,7 +768,7 @@ describe("ai-provider commands", () => {
 		const { output, restore } = captureConsole();
 		try {
 			await aiProviderImportCommand(catalogPath, { json: true });
-			await aiProviderTestCommand("clawdi-managed", { live: true, json: true });
+			await aiProviderTestCommand("clawdi-managed-v2", { live: true, json: true });
 		} finally {
 			restore();
 			restoreFetch();
@@ -777,7 +777,9 @@ describe("ai-provider commands", () => {
 		}
 
 		expect(
-			captured.some((request) => request.path === "/api/ai-providers/clawdi-managed/auth/resolve"),
+			captured.some(
+				(request) => request.path === "/api/ai-providers/clawdi-managed-v2/auth/resolve",
+			),
 		).toBe(false);
 		const providerProbe = captured.find((request) => request.path === "/v1/models");
 		expect(providerProbe?.headers.authorization).toBe("Bearer sk-runtime-managed");
@@ -1723,7 +1725,7 @@ describe("ai-provider commands", () => {
 			schema_version: 1,
 			providers: [
 				{
-					id: "clawdi-managed",
+					id: "clawdi-managed-v2",
 					type: "custom_openai_compatible",
 					label: "Clawdi AI",
 					base_url: "https://sub2api.example.test/v1",
@@ -1734,24 +1736,24 @@ describe("ai-provider commands", () => {
 					runtime_env_name: "CLAWDI_MANAGED_OPENAI_API_KEY",
 				},
 			],
-			defaults: { chat_provider_id: "clawdi-managed" },
+			defaults: { chat_provider_id: "clawdi-managed-v2" },
 		} as const;
 
 		const projection = buildAgentTargetProjection("openclaw", catalog);
 		const patch = JSON.parse(projection.files[0]!.content);
 
-		expect(patch.agents.defaults.model.primary).toBe("clawdi-managed/gpt-5.5");
-		expect(patch.models.providers["clawdi-managed"].baseUrl).toBe(
+		expect(patch.agents.defaults.model.primary).toBe("clawdi-managed-v2/gpt-5.5");
+		expect(patch.models.providers["clawdi-managed-v2"].baseUrl).toBe(
 			"https://sub2api.example.test/v1",
 		);
-		expect(patch.models.providers["clawdi-managed"].api).toBeUndefined();
-		expect(patch.models.providers["clawdi-managed"].agentRuntime).toBeUndefined();
-		expect(patch.models.providers["clawdi-managed"].models[0]).toMatchObject({
+		expect(patch.models.providers["clawdi-managed-v2"].api).toBeUndefined();
+		expect(patch.models.providers["clawdi-managed-v2"].agentRuntime).toBeUndefined();
+		expect(patch.models.providers["clawdi-managed-v2"].models[0]).toMatchObject({
 			id: "gpt-5.5",
 			name: "gpt-5.5",
 		});
-		expect(patch.models.providers["clawdi-managed"].models[0].api).toBeUndefined();
-		expect(patch.models.providers["clawdi-managed"].apiKey).toEqual({
+		expect(patch.models.providers["clawdi-managed-v2"].models[0].api).toBeUndefined();
+		expect(patch.models.providers["clawdi-managed-v2"].apiKey).toEqual({
 			source: "env",
 			provider: "default",
 			id: "CLAWDI_MANAGED_OPENAI_API_KEY",
@@ -1763,7 +1765,7 @@ describe("ai-provider commands", () => {
 			schema_version: 1,
 			providers: [
 				{
-					id: "clawdi-managed",
+					id: "clawdi-managed-v2",
 					type: "custom_openai_compatible",
 					label: "Clawdi AI",
 					base_url: "https://sub2api.example.test/v1",
@@ -1774,11 +1776,11 @@ describe("ai-provider commands", () => {
 					runtime_env_name: "CLAWDI_MANAGED_OPENAI_API_KEY",
 				},
 			],
-			defaults: { chat_provider_id: "clawdi-managed" },
+			defaults: { chat_provider_id: "clawdi-managed-v2" },
 		});
 
 		const patch = projection.files[0]?.content ?? "";
-		expect(patch).toContain('provider: "custom:clawdi-managed"');
+		expect(patch).toContain('provider: "custom:clawdi-managed-v2"');
 		expect(patch).toContain('api: "https://sub2api.example.test/v1"');
 		expect(patch).toContain('transport: "chat_completions"');
 		expect(patch).toContain('default_model: "gpt-5.5"');

--- a/packages/shared/src/ai-provider.test.ts
+++ b/packages/shared/src/ai-provider.test.ts
@@ -165,7 +165,29 @@ describe("validateAiProviderCatalog", () => {
 		);
 	});
 
-	test("accepts Clawdi-managed providers in OpenAI chat mode", () => {
+	test("accepts v2 Clawdi-managed providers in OpenAI chat mode", () => {
+		const result = validateAiProviderCatalog({
+			schema_version: 1,
+			providers: [
+				{
+					id: "clawdi-managed-v2",
+					type: "custom_openai_compatible",
+					base_url: "https://managed.example/v1",
+					default_model: "gpt-5.5",
+					api_mode: "openai_chat",
+					auth: { type: "api_key", source: "managed" },
+					managed_by: "clawdi",
+					runtime_env_name: "CLAWDI_MANAGED_OPENAI_API_KEY",
+				},
+			],
+			defaults: { chat_provider_id: "clawdi-managed-v2" },
+		});
+
+		expect(result.valid).toBe(true);
+		expect(result.errors).toEqual([]);
+	});
+
+	test("accepts v1 Clawdi-managed providers in OpenAI responses mode", () => {
 		const result = validateAiProviderCatalog({
 			schema_version: 1,
 			providers: [
@@ -173,8 +195,8 @@ describe("validateAiProviderCatalog", () => {
 					id: "clawdi-managed",
 					type: "custom_openai_compatible",
 					base_url: "https://managed.example/v1",
-					default_model: "gpt-5.5",
-					api_mode: "openai_chat",
+					default_model: "openai-codex/gpt-5.5",
+					api_mode: "openai_responses",
 					auth: { type: "api_key", source: "managed" },
 					managed_by: "clawdi",
 					runtime_env_name: "CLAWDI_MANAGED_OPENAI_API_KEY",
@@ -187,12 +209,12 @@ describe("validateAiProviderCatalog", () => {
 		expect(result.errors).toEqual([]);
 	});
 
-	test("requires Clawdi-managed providers to use OpenAI chat mode", () => {
+	test("requires v2 Clawdi-managed providers to use OpenAI chat mode", () => {
 		const result = validateAiProviderCatalog({
 			schema_version: 1,
 			providers: [
 				{
-					id: "clawdi-managed",
+					id: "clawdi-managed-v2",
 					type: "custom_openai_compatible",
 					base_url: "https://managed.example/v1",
 					default_model: "gpt-5.5",
@@ -202,12 +224,12 @@ describe("validateAiProviderCatalog", () => {
 					runtime_env_name: "CLAWDI_MANAGED_OPENAI_API_KEY",
 				},
 			],
-			defaults: { chat_provider_id: "clawdi-managed" },
+			defaults: { chat_provider_id: "clawdi-managed-v2" },
 		});
 
 		expect(result.valid).toBe(false);
 		expect(result.errors).toContain(
-			"Provider clawdi-managed managed_by clawdi must use api_mode openai_chat.",
+			"Provider clawdi-managed-v2 managed_by clawdi must use api_mode openai_chat.",
 		);
 	});
 });

--- a/packages/shared/src/ai-provider.ts
+++ b/packages/shared/src/ai-provider.ts
@@ -120,8 +120,14 @@ const DEFAULT_BASE_URL: Partial<Record<AiProviderType, string>> = {
 	mistral: "https://api.mistral.ai/v1",
 };
 
-const CLAWDI_MANAGED_PROVIDER_ID = "clawdi-managed";
-const CLAWDI_MANAGED_API_MODE = "openai_chat";
+const CLAWDI_MANAGED_V1_PROVIDER_ID = "clawdi-managed";
+const CLAWDI_MANAGED_V1_API_MODE = "openai_responses";
+const CLAWDI_MANAGED_V2_PROVIDER_ID = "clawdi-managed-v2";
+const CLAWDI_MANAGED_V2_API_MODE = "openai_chat";
+const CLAWDI_MANAGED_PROVIDER_IDS = new Set([
+	CLAWDI_MANAGED_V1_PROVIDER_ID,
+	CLAWDI_MANAGED_V2_PROVIDER_ID,
+]);
 const CLAWDI_MANAGED_RUNTIME_ENV = "CLAWDI_MANAGED_OPENAI_API_KEY";
 
 export function isAiProviderId(input: string): boolean {
@@ -227,7 +233,7 @@ function validateProvider(
 	if (!isHttpUrl(provider.base_url)) {
 		errors.push(`Provider ${prefix} has invalid base_url.`);
 	}
-	if (isLegacyOpenAiCodexModelRef(provider.default_model)) {
+	if (isLegacyOpenAiCodexModelRef(provider.default_model) && !isLegacyManagedProvider(provider)) {
 		errors.push(
 			`Provider ${prefix} default_model must use the OpenAI model id without the legacy openai-codex prefix.`,
 		);
@@ -262,24 +268,25 @@ function validateManagedProviderContract(
 	errors: string[],
 ): void {
 	const isManagedContract =
-		provider.id === CLAWDI_MANAGED_PROVIDER_ID || provider.managed_by === "clawdi";
+		CLAWDI_MANAGED_PROVIDER_IDS.has(provider.id) || provider.managed_by === "clawdi";
 	if (!isManagedContract) return;
 
-	if (provider.id !== CLAWDI_MANAGED_PROVIDER_ID) {
-		errors.push(`Provider ${prefix} managed_by clawdi must use id ${CLAWDI_MANAGED_PROVIDER_ID}.`);
+	const expectedApiMode = clawdiManagedApiMode(provider.id);
+	if (!expectedApiMode) {
+		errors.push(
+			`Provider ${prefix} managed_by clawdi must use id ${Array.from(CLAWDI_MANAGED_PROVIDER_IDS)
+				.sort()
+				.join(" or ")}.`,
+		);
 	}
 	if (provider.managed_by !== "clawdi") {
-		errors.push(
-			`Provider ${prefix} with id ${CLAWDI_MANAGED_PROVIDER_ID} must be managed_by clawdi.`,
-		);
+		errors.push(`Provider ${prefix} with Clawdi-managed id must be managed_by clawdi.`);
 	}
 	if (provider.type !== "custom_openai_compatible") {
 		errors.push(`Provider ${prefix} managed_by clawdi must use custom_openai_compatible.`);
 	}
-	if (provider.api_mode !== CLAWDI_MANAGED_API_MODE) {
-		errors.push(
-			`Provider ${prefix} managed_by clawdi must use api_mode ${CLAWDI_MANAGED_API_MODE}.`,
-		);
+	if (expectedApiMode && provider.api_mode !== expectedApiMode) {
+		errors.push(`Provider ${prefix} managed_by clawdi must use api_mode ${expectedApiMode}.`);
 	}
 	if (provider.runtime_env_name !== CLAWDI_MANAGED_RUNTIME_ENV) {
 		errors.push(
@@ -290,6 +297,16 @@ function validateManagedProviderContract(
 	if (!isRecord(auth) || auth.type !== "api_key" || auth.source !== "managed") {
 		errors.push(`Provider ${prefix} managed_by clawdi must use managed api_key auth.`);
 	}
+}
+
+function clawdiManagedApiMode(providerId: string): AiProviderApiMode | null {
+	if (providerId === CLAWDI_MANAGED_V1_PROVIDER_ID) return CLAWDI_MANAGED_V1_API_MODE;
+	if (providerId === CLAWDI_MANAGED_V2_PROVIDER_ID) return CLAWDI_MANAGED_V2_API_MODE;
+	return null;
+}
+
+function isLegacyManagedProvider(provider: AiProvider): boolean {
+	return provider.managed_by === "clawdi" && provider.id === CLAWDI_MANAGED_V1_PROVIDER_ID;
 }
 
 function validateAuth(


### PR DESCRIPTION
## Summary
- keep the legacy v1 managed provider contract as `clawdi-managed` / `openai_responses`
- move the hosted v2 managed provider contract to `clawdi-managed-v2` / `openai_chat`
- update Cloud API validation, runtime manifest projection, and admin managed-provider writes to understand the two first-party contracts separately

## Production context
Production hosted v1 currently sends `clawdi-managed` with `openai_responses`; the live v1 agent image accepts that contract. The recent Cloud API contract tightened `clawdi-managed` to v2 `openai_chat`, causing hosted v1 managed-provider upserts to fail with 422.

## Verification
- `DATABASE_URL=postgresql+asyncpg://clawdi:clawdi_dev@127.0.0.1:40373/clawdi pdm run pytest tests/test_ai_providers.py tests/test_runtime_manifest.py tests/test_admin_endpoints.py`
- `bun test packages/shared/src/ai-provider.test.ts`
- `bun run check packages/shared/src/ai-provider.ts packages/shared/src/ai-provider.test.ts`
- `pdm run ruff format --check app/services/managed_ai_provider.py app/routes/ai_providers.py app/routes/runtime.py app/routes/admin.py tests/test_ai_providers.py tests/test_runtime_manifest.py tests/test_admin_endpoints.py`
- `pdm run ruff check app/services/managed_ai_provider.py app/routes/ai_providers.py app/routes/runtime.py app/routes/admin.py tests/test_ai_providers.py tests/test_runtime_manifest.py tests/test_admin_endpoints.py`
