### PR TITLE
Add official runtime sidecar model

### DIFF
--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -56,6 +56,7 @@ concurrency:
 env:
   BACKEND_IMAGE_NAME: ghcr.io/clawdi-ai/clawdi-backend
   WEB_IMAGE_NAME: ghcr.io/clawdi-ai/clawdi-web
+  SIDECAR_IMAGE_NAME: ghcr.io/clawdi-ai/clawdi-runtime-sidecar
 
 jobs:
   build:
@@ -67,7 +68,9 @@ jobs:
     timeout-minutes: 30
     outputs:
       image_tag: ${{ steps.rev.outputs.sha }}
-      build_required: ${{ steps.runtime-changes.outputs.build }}
+      build_required: ${{ steps.image-changes.outputs.any }}
+      backend_build_required: ${{ steps.image-changes.outputs.backend }}
+      sidecar_build_required: ${{ steps.image-changes.outputs.sidecar }}
       deploy_scope: ${{ steps.deploy-mode.outputs.deploy_scope }}
       should_deploy: ${{ steps.deploy-mode.outputs.should_deploy }}
     steps:
@@ -113,11 +116,13 @@ jobs:
           echo "deploy_scope=${deploy_scope}" >> "$GITHUB_OUTPUT"
           echo "should_deploy=${should_deploy}" >> "$GITHUB_OUTPUT"
 
-      - name: Detect backend image changes
-        id: runtime-changes
+      - name: Detect image changes
+        id: image-changes
         run: |
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            echo "build=true" >> "$GITHUB_OUTPUT"
+            echo "backend=true" >> "$GITHUB_OUTPUT"
+            echo "sidecar=true" >> "$GITHUB_OUTPUT"
+            echo "any=true" >> "$GITHUB_OUTPUT"
             echo "reason=workflow_dispatch" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -125,35 +130,46 @@ jobs:
           changed_files="$(git diff-tree --no-commit-id --name-only -r -m --first-parent "${{ steps.rev.outputs.sha }}")"
           printf '%s\n' "$changed_files"
 
-          build=false
+          backend=false
+          sidecar=false
           readarray -t files <<< "$changed_files"
           for file in "${files[@]}"; do
             case "$file" in
               backend/*|.dockerignore|infra/deploy/coolify/production-stack.json|infra/deploy/coolify/deploy_ghcr_runtime.py|.github/workflows/clawdi-image-release.yml)
-                build=true
+                backend=true
+                ;;
+            esac
+            case "$file" in
+              packages/cli/*|packages/shared/*|package.json|bun.lock|turbo.json|tsconfig.base.json|biome.json|.dockerignore|.github/workflows/clawdi-image-release.yml)
+                sidecar=true
                 ;;
             esac
           done
 
-          echo "build=${build}" >> "$GITHUB_OUTPUT"
-          if [ "$build" = "true" ]; then
-            echo "reason=backend_image_inputs_changed" >> "$GITHUB_OUTPUT"
+          if [ "$backend" = "true" ] || [ "$sidecar" = "true" ]; then
+            any=true
+            reason=image_inputs_changed
           else
-            echo "reason=no_backend_image_inputs_changed" >> "$GITHUB_OUTPUT"
+            any=false
+            reason=no_image_inputs_changed
           fi
+          echo "backend=${backend}" >> "$GITHUB_OUTPUT"
+          echo "sidecar=${sidecar}" >> "$GITHUB_OUTPUT"
+          echo "any=${any}" >> "$GITHUB_OUTPUT"
+          echo "reason=${reason}" >> "$GITHUB_OUTPUT"
 
       - uses: docker/setup-buildx-action@v4
-        if: steps.runtime-changes.outputs.build == 'true'
+        if: steps.image-changes.outputs.any == 'true'
 
       - uses: docker/login-action@v4
-        if: steps.runtime-changes.outputs.build == 'true'
+        if: steps.image-changes.outputs.any == 'true'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Resolve OCI label metadata
-        if: steps.runtime-changes.outputs.build == 'true'
+        if: steps.image-changes.outputs.any == 'true'
         id: labels
         run: |
           created="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -162,7 +178,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Build and push backend image
-        if: steps.runtime-changes.outputs.build == 'true'
+        if: steps.image-changes.outputs.backend == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -182,7 +198,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=clawdi-backend-image
 
       - name: Validate web image inputs
-        if: steps.runtime-changes.outputs.build == 'true' && inputs.build_web
+        if: steps.image-changes.outputs.backend == 'true' && inputs.build_web
         env:
           WEB_CLERK_PUBLISHABLE_KEY: ${{ inputs.web_clerk_publishable_key }}
         run: |
@@ -192,7 +208,7 @@ jobs:
           fi
 
       - name: Build and push web image
-        if: steps.runtime-changes.outputs.build == 'true' && inputs.build_web
+        if: steps.image-changes.outputs.backend == 'true' && inputs.build_web
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -216,30 +232,59 @@ jobs:
           cache-from: type=gha,scope=clawdi-web-image
           cache-to: type=gha,mode=max,scope=clawdi-web-image
 
+      - name: Build and push runtime sidecar image
+        if: steps.image-changes.outputs.sidecar == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: packages/cli/Dockerfile.runtime-sidecar
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.SIDECAR_IMAGE_NAME }}:${{ steps.rev.outputs.sha }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ steps.rev.outputs.sha }}
+            org.opencontainers.image.version=${{ steps.rev.outputs.sha }}
+            org.opencontainers.image.created=${{ steps.labels.outputs.created }}
+            org.opencontainers.image.title=Clawdi Runtime Sidecar
+            org.opencontainers.image.description=Clawdi managed-runtime sidecar image for official external agent containers.
+          provenance: false
+          cache-from: type=gha,scope=clawdi-runtime-sidecar-image
+          cache-to: type=gha,mode=max,scope=clawdi-runtime-sidecar-image
+
       - name: Print image summary
-        if: steps.runtime-changes.outputs.build == 'true'
+        if: steps.image-changes.outputs.any == 'true'
         run: |
           echo "### Clawdi Images" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Backend: \`${{ env.BACKEND_IMAGE_NAME }}:${{ steps.rev.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
-          if [ "${{ inputs.build_web }}" = "true" ]; then
+          if [ "${{ steps.image-changes.outputs.backend }}" = "true" ]; then
+            echo "- Backend: \`${{ env.BACKEND_IMAGE_NAME }}:${{ steps.rev.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- Backend: skipped" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ "${{ steps.image-changes.outputs.backend }}" = "true" ] && [ "${{ inputs.build_web }}" = "true" ]; then
             echo "- Web: \`${{ env.WEB_IMAGE_NAME }}:${{ steps.rev.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- Web: skipped" >> "$GITHUB_STEP_SUMMARY"
           fi
+          if [ "${{ steps.image-changes.outputs.sidecar }}" = "true" ]; then
+            echo "- Runtime sidecar: \`${{ env.SIDECAR_IMAGE_NAME }}:${{ steps.rev.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- Runtime sidecar: skipped" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Print skipped image summary
-        if: steps.runtime-changes.outputs.build != 'true'
+        if: steps.image-changes.outputs.any != 'true'
         run: |
           echo "### Clawdi Images" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Backend image build: skipped" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Reason: \`${{ steps.runtime-changes.outputs.reason }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Image build: skipped" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Reason: \`${{ steps.image-changes.outputs.reason }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Ref: \`${{ steps.rev.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
 
   deploy:
     needs: build
-    if: needs.build.outputs.build_required == 'true' && needs.build.outputs.should_deploy == 'true'
+    if: needs.build.outputs.backend_build_required == 'true' && needs.build.outputs.should_deploy == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -288,7 +333,7 @@ jobs:
 
   audit:
     needs: build
-    if: needs.build.outputs.build_required != 'true' && needs.build.outputs.should_deploy == 'true'
+    if: needs.build.outputs.backend_build_required != 'true' && needs.build.outputs.should_deploy == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@ High-level map of what's actually in Clawdi Cloud today — updated as the code 
 
 ## One-paragraph overview
 
-Clawdi Cloud is a cross-agent sync + recall layer. A local CLI (`clawdi`) reads per-agent data (Claude Code, Codex, Hermes, OpenClaw) from well-known directories, pushes sessions and skills to a FastAPI backend, pulls shared skills back down, and exposes a long-term memory store to each agent via the Model Context Protocol. Projects are the collaboration and data ownership boundary; each Agent has one fixed Agent Project plus optional attached Projects for read-time composition. The web app is a dashboard on the same backend, including hosted deployment surfaces such as Control UI and Terminal. The same CLI also owns the public managed runtime command surface for controlled environments: runtime manifests, convergence, support process state, explicit `clawdi run`, optional local UI bridging, and diagnostics. The memory store is the differentiator: it gives every connected agent the same cross-session, cross-machine context without the agents having to know about each other.
+Clawdi Cloud is a cross-agent sync + recall layer. A local CLI (`clawdi`) reads per-agent data (Claude Code, Codex, Hermes, OpenClaw) from well-known directories, pushes sessions and skills to a FastAPI backend, pulls shared skills back down, and exposes a long-term memory store to each agent via the Model Context Protocol. Projects are the collaboration and data ownership boundary; each Agent has one fixed Agent Project plus optional attached Projects for read-time composition. The web app is a dashboard on the same backend, including hosted deployment surfaces such as Control UI and Terminal. The same CLI also owns the public managed runtime command surface for controlled environments: runtime manifests, convergence, command shims, `clawdi run`, backend MCP URL projection for external official containers, optional local UI bridging, and diagnostics. The memory store is the differentiator: it gives every connected agent the same cross-session, cross-machine context without the agents having to know about each other.
 
 ---
 
@@ -37,14 +37,15 @@ Clawdi Cloud is a cross-agent sync + recall layer. A local CLI (`clawdi`) reads 
 ┌──────────────────────┐  Runtime manifest / state ┌──────────────────────┐
 │ Hosted control plane │──────────────────────────▶│ Managed runtime CLI  │
 │ (external service)   │                           │  - runtime init/watch│
-└──────────────────────┘                           │  - run configs       │
-        ▲                                          │  - sidecar modules        │
-        │ Control UI + Terminal contracts          └──────────┬───────────┘
-        └─────────────────────────────────────────────────────▼
+└──────────────────────┘                           │  - run configs/shims │
+        ▲                                          │  - backend MCP config│
+        │ Control UI + Terminal contracts          │  - optional UI bridge│
+        └──────────────────────────────────────────┴──────────┬───────────┘
+                                                              ▼
                                                    ┌──────────────────────┐
                                                    │ Agent runtimes       │
-                                                   │ Hermes / OpenClaw /  │
-                                                   │ manifest run.command │
+                                                   │ official containers  │
+                                                   │ or manifest commands │
                                                    └──────────────────────┘
 ```
 
@@ -163,20 +164,17 @@ Public contract: [`managed-runtime.md`](managed-runtime.md).
 
 ### Design Principles
 
-- The host image is a stable envelope. It should provide the OS user, base
-  packages, host policy, CLI bootstrap path, and PATH ordering, but runtime
-  semantics come from the CLI and runtime manifest.
+- The runtime sidecar image is a stable envelope. It provides the OS user, base
+  packages, host policy entrypoint, CLI bootstrap tarball, native MITM broker,
+  supervisor, and PATH ordering. It does not bundle OpenClaw or Hermes; those
+  run from official upstream images.
 - `clawdi runtime init --non-interactive` is the convergence boundary. It
-  validates desired state, installs or verifies runtimes when the CLI is used
-  in a local/single-container fallback, writes projections, writes run configs,
-  and prepares support process state.
-- The primary hosted runtime model is a Linux-like host. Supervisor starts
-  Clawdi support programs and official Hermes/OpenClaw programs directly from
-  the manifest-derived process plan. It does not go through `clawdi run`, a
-  generated shell script, or a PATH shim.
-- `clawdi run -- <command>` remains an explicit interactive/local execution
-  boundary. Shell commands such as `openclaw` and `hermes` resolve to official
-  binaries directly.
+  validates desired state, installs or verifies runtimes through supported
+  installers, writes projections, writes run configs, writes command shims, and
+  renders supervisor config.
+- `clawdi run -- <command>` is the execution boundary. Runtime commands such as
+  `openclaw` and `hermes` resolve through generated run config. Ordinary shell
+  commands keep normal shell behavior.
 - Runtime-specific behavior is manifest-driven. Known runtimes can use built-in
   install/projection support; future runtimes can be launched through an
   explicit `run.command` without adding per-agent wrappers to the image.
@@ -190,15 +188,16 @@ Public contract: [`managed-runtime.md`](managed-runtime.md).
 |---|---|
 | Contract schemas | `packages/cli/src/runtime/manifest-contract.ts` |
 | Datasource fetch, normalization, validation | `packages/cli/src/runtime/manifest-source.ts` |
-| Local convergence, projections, and fallback process plan | `packages/cli/src/runtime/manifest.ts` |
+| Local convergence, projections, supervisor config, command shims | `packages/cli/src/runtime/manifest.ts` |
 | Runtime path contract | `packages/cli/src/runtime/paths.ts` |
 | Host policy | `packages/cli/src/runtime/host-policy.ts` |
 | Runtime boot status and observed state | `packages/cli/src/runtime/state.ts`, `packages/cli/src/runtime/observed.ts` |
 | Run config and invocation | `packages/cli/src/runtime/run-config.ts`, `packages/cli/src/commands/run.ts` |
 | CLI self-management in hosted runtime | `packages/cli/src/runtime/cli-update.ts` |
-| Runtime bridge | `packages/cli/src/runtime/bridge.ts` |
-| Sidecar profile schema and profile generation | `packages/cli/src/runtime/mitm-profiles.ts`, `packages/cli/src/runtime/hosted-mitm-profiles.ts` |
-| Runtime MITM sidecar invocation and env projection | `packages/cli/src/runtime/mitm-sidecar.ts`, `packages/cli/src/runtime/mitm-env.ts` |
+| Runtime sidecar image | `packages/cli/Dockerfile.runtime-sidecar`, `packages/cli/docker/runtime-sidecar-entrypoint.sh` |
+| Runtime bridge (optional Control UI compatibility surface) | `packages/cli/src/runtime/bridge.ts` |
+| Broker profile schema and profile generation | `packages/cli/src/runtime/mitm-profiles.ts`, `packages/cli/src/runtime/hosted-mitm-profiles.ts` |
+| Native MITM sidecar launcher and env projection | `packages/cli/src/runtime/mitm-sidecar.ts`, `packages/cli/src/runtime/mitm-env.ts` |
 | Native MITM sidecar implementation | `packages/cli/native/mitm-sidecar/` |
 | Hosted deployment UI and terminal panel | `apps/web/src/hosted/agents/hosted-agent-detail.tsx`, `apps/web/src/hosted/agents/hosted-terminal-panel.tsx` |
 | Local mock deploy API | `backend/scripts/mock_deploy_api.py` |
@@ -206,130 +205,78 @@ Public contract: [`managed-runtime.md`](managed-runtime.md).
 ### Runtime Flow
 
 ```mermaid
-flowchart TB
+flowchart TD
     CP[Hosted control plane] -->|hosted manifest response| Source[manifest-source]
-    Source -->|normalized desired state| Init[clawdi runtime init]
-
-    subgraph Durable["Durable non-secret state"]
-        State[/var/lib/clawdi]
-        RunConfigs[config/run/<runtime>.json]
-        Projections[config/projections/<runtime>.json]
-        Inventory[install-inventory/<runtime>.json]
-    end
-
-    subgraph Ephemeral["Ephemeral runtime state"]
-        SupervisorConfig[$CLAWDI_RUN_DIR/supervisor/supervisord.conf]
-        RuntimeSecrets[$CLAWDI_RUN_DIR/secrets/*]
-        MitmCA[$CLAWDI_RUN_DIR/mitm/supervisor/ca.pem + sidecar-private key]
-    end
-
-    subgraph Support["Clawdi support programs"]
-        Watch[clawdi runtime watch]
-        Daemon[clawdi daemon run]
-        Sidecar[optional runtime sidecar]
-        Bridge[bridge module]
-        Mitm[MITM module]
-    end
-
-    subgraph Runtimes["Official runtime programs"]
-        HermesGateway[hermes gateway run]
-        HermesDashboard[hermes dashboard]
-        OpenClaw[openclaw gateway run]
-    end
-
-    Init --> Durable
-    Init --> Ephemeral
-    SupervisorConfig --> Supervisor[supervisord or equivalent]
-    Watch --> Durable
-    Daemon --> Durable
-    Supervisor --> Watch
-    Supervisor --> Daemon
-    Supervisor --> Sidecar
-    Sidecar --> Bridge
-    Sidecar --> Mitm
-    Supervisor --> HermesGateway
-    Supervisor --> HermesDashboard
-    Supervisor --> OpenClaw
-    Bridge -->|Control UI HTTP/WebSocket| HermesDashboard
-    Bridge -->|Control UI HTTP/WebSocket| OpenClaw
-    Mitm -. proxy and CA env .-> HermesGateway
-    Mitm -. proxy and CA env .-> HermesDashboard
-    Mitm -. proxy and CA env .-> OpenClaw
+    Source -->|target-id desired state| Init[clawdi runtime init]
+    Init --> Paths[/var/lib/clawdi state]
+    Init --> Targets[runtimeTargets.<agent_id><br/>type + image + execution]
+    Init --> Supervisor[supervisord.conf]
+    Supervisor --> Watch[clawdi runtime watch]
+    BackendMcp[Backend /mcp/clawdi]
+    Supervisor -. compatibility .-> McpHttp[clawdi mcp http]
+    Supervisor -. optional .-> Bridge[clawdi runtime bridge]
+    Init -->|write native config| External[official runtime containers<br/>agent_id selects exact target]
+    Targets --> External
+    External --> BackendMcp
+    External -. sidecar-local compatibility .-> McpHttp
 ```
 
 The hosted manifest schema is `clawdi.hosted-runtime.manifest.v1`. The CLI
 normalizes it to `clawdi.runtimeDesiredState.v1`, which is the internal
-convergence shape. The normalized state includes deployment identity,
-environment identity, instance identity, generation, workspace root, control
-plane API origin, CLI package policy, runtime entries, provider projections,
-MCP/tool projections, MITM profiles, live-sync settings, and recovery policy.
+convergence shape. The normalized state is keyed by runtime target id
+(`agent_id`). Each target explicitly declares `type`; the CLI does not infer the
+adapter from the key name. Provider bindings, live sync, terminal requests, and
+dashboard routes all use the same target id.
 
-### Runtime Launch
+One Clawdi sidecar manages only same-Pod runtime targets. It can mount several
+isolated target volumes, but each enabled `agent_id` must own a distinct
+`execution.stateDir` or `execution.home`. Hermes projections are direct
+same-volume YAML merges. External OpenClaw projections that require native
+config patching must declare `execution.controlCommand`; otherwise the manifest
+is rejected instead of assuming the Clawdi sidecar contains OpenClaw.
 
-Hosted daemon runtimes are direct supervisor programs. Each `[program:*]` entry
-names the official binary, args, cwd, and env. Clawdi does not become a wrapper
-around the runtime command.
+### Command Shims
 
-Interactive shell commands are not intercepted. If a user or an official UI
-runs `openclaw update`, the command resolves to OpenClaw's own binary and update
-flow. `clawdi run -- <command>` remains available only when the caller asks for
-that explicit Clawdi execution boundary.
+Runtime command shims live under the service state bin directory. The host
+environment puts that directory first on PATH, so typing a managed runtime name
+such as `openclaw` or `hermes` enters the dispatcher before any native binary.
+The dispatcher removes the shim directory from PATH and executes the managed CLI
+as:
 
-When bridge surfaces or MITM profiles are enabled, supervisor starts one Clawdi
-runtime sidecar. Runtime programs receive only final proxy and trust env such as
-`HTTPS_PROXY`, `OPENCLAW_PROXY_URL`, and `NODE_EXTRA_CA_CERTS`; sidecar control
-env and secret-file paths stay out of the agent runtime process.
+```bash
+clawdi run -- "$command_name" "$@"
+```
 
-The sidecar consolidates Clawdi-owned runtime-local support modules, but their
-authority boundaries stay explicit:
+This keeps the image stable: the image does not need one wrapper script per
+agent. Disabled runtimes write disabled run config, and `clawdi run` reports the
+runtime as disabled instead of falling back to a native binary.
 
-- `clawdi daemon run` owns live sync and may use the Clawdi API auth token from
-  a short-lived file.
-- the sidecar bridge module owns inbound browser UI proxying for declared
-  Control UI surfaces and uses only the runtime bridge token.
-- the sidecar MITM module owns outbound MITM proxying, CA material, and
-  profile-level request rewriting. It starts only when explicit MITM profiles
-  are enabled and must not inherit the Clawdi auth token.
+### Control UI And Terminal
 
-The MITM module stores its root CA certificate and private key under
-`$CLAWDI_RUN_DIR` so sidecar restarts reuse the same trust root for already
-running runtimes. Runtime programs receive only the CA certificate path in trust
-environment variables; the private key path remains sidecar-private.
+Control UI and Terminal are separate hosted deployment surfaces:
 
-Hermes dashboard and Hermes gateway both run as official Hermes commands when a
-deployment needs both. The dashboard is the browser Control UI surface. The
-gateway is supervised directly, but it is not a bridge target unless a
-deployment configures an actual HTTP/WebSocket listener for it. The Hermes
-official Docker image is useful prior art for that fan-out, but the Linux-like
-host preserves in-place official updater behavior. The sidecar bridge module is
-optional and exists only when Clawdi must own browser-facing auth, cookie,
-header, WebSocket, or path policy.
-
-### Runtime UI And Terminal
-
-Runtime UI and Terminal are separate hosted deployment surfaces:
-
-- **Control UI** is the runtime's browser UI endpoint. It can be exposed through
-  the official runtime port when platform ingress owns auth and browser policy,
-  or through the sidecar bridge module as an explicitly declared `control-ui`
-  surface when Clawdi owns those controls. It is runtime-specific, so the
-  dashboard labels it as `<Runtime> Control UI`.
-- **Terminal** is a deployment shell, not an agent-specific surface. The
-  dashboard requests a terminal session for the deployment and then opens one
-  xterm WebSocket. The terminal uses tty-style frames (`0` for input/output,
-  `1` for resize), follows the dashboard light/dark theme, and sends the
-  short-lived terminal token through a WebSocket subprotocol by default.
+- **Control UI** is the runtime's browser UI endpoint. The optimized
+  official-container path exposes that upstream UI through the deployment
+  layer's authenticated route. The local runtime bridge is an explicitly
+  declared compatibility surface for same-origin, CSP, or header mediation.
+- **Terminal** is a deployment shell. For external runtimes, the terminal target
+  should be the selected runtime container, not the Clawdi sidecar. The
+  dashboard requests a terminal session for the deployment with the selected
+  `agent_id` and then opens one xterm WebSocket. The terminal uses tty-style
+  frames (`0` for input/output, `1` for resize), follows the dashboard
+  light/dark theme, and sends the short-lived terminal token through a
+  WebSocket subprotocol.
 
 The service-side terminal bridge is outside this repository. The public
 contract is: authenticate the user, require the deployment to be running, bind
-the terminal token to that deployment, and bridge the WebSocket to a shell as
-the default runtime user.
+the terminal token to that deployment and selected `agent_id`, resolve the
+runtime target's `execution.terminal` contract, and bridge the WebSocket to a
+shell in that exact runtime container.
 
-The sidecar bridge module is a general authenticated surface bridge, but each
-surface must be declared with listen/upstream targets and policy. It is optional
-when official ports are exposed behind sufficient platform ingress auth.
-Terminal stays separate because it grants shell execution rather than proxying a
-runtime web application.
+The runtime bridge is a general authenticated surface bridge, but each surface
+must be declared with listen/upstream targets and policy. The current surface
+kind is browser Control UI traffic. Terminal stays separate because it grants
+shell execution rather than proxying a runtime web application.
 
 ### Ownership Boundaries
 
@@ -337,13 +284,13 @@ runtime web application.
   deployment selection, rollout, billing policy, and terminal session
   authorization.
 - The CLI owns manifest validation, local convergence, runtime install
-  orchestration where the CLI is the local convergence tool, non-secret
-  projections, run config, support process state, short-lived secret projection,
-  optional local UI bridging, diagnostics, and the Clawdi support modules.
+  orchestration, non-secret projections, run config, command shims, short-lived
+  secret projection, local UI bridging, diagnostics, and broker lifecycle.
 - The web dashboard owns the user-facing hosted deployment surfaces and calls
   only public API contracts.
-- OpenClaw and Hermes keep their official installer/updater and runtime process
-  authority.
+- OpenClaw and Hermes keep their official image and updater authority. Clawdi
+  publishes only the runtime sidecar image; a controller rolls agent images by
+  changing Pod specs and lets the sidecar observe version drift.
 - Clawdi native Channels own shared channel protocol state.
 - User BYOK provider traffic must not be silently proxied.
 
@@ -395,7 +342,13 @@ Agent runtime resolution is separate from folder links. `clawdi vault resolve KE
 
 ## MCP server
 
-`clawdi mcp` runs a stdio MCP server. Registered by `clawdi setup` with each agent, so the agent spawns it on startup. Two native tools:
+`clawdi mcp` runs a stdio MCP server for local agents. Registered by `clawdi
+setup` with each agent, so the agent spawns it on startup. Hosted external
+runtime containers use the backend direct `/mcp/clawdi` Streamable HTTP
+endpoint by default, with runtime-native URL MCP config and the deployment API
+key in an `Authorization` header. The sidecar-owned `clawdi mcp http` endpoint
+is compatibility mode only for runtimes that explicitly declare
+`execution.mcp.source: "sidecar-local"`. Native tools include:
 
 - `memory_search(query, limit?)` — proxies to `GET /api/memories?q=...`
 - `memory_add(content, category?)` — proxies to `POST /api/memories`

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -19,12 +19,13 @@ Related public docs:
 
 ## Scope
 
-The open-source CLI owns local runtime convergence, explicit `clawdi run`
-env-injection, runtime UI bridging, and diagnostics. The web app owns the
-hosted deployment dashboard surfaces, including Control UI and Terminal tabs. A
-separate control plane may provide desired state, credentials, terminal
-authorization, rollout policy, and deployment lifecycle, but that
-platform-specific implementation is outside this repository.
+The open-source CLI owns local runtime convergence, command wrapping, external
+runtime projections, agent-facing MCP, optional runtime UI bridging, and
+diagnostics. The web app owns the hosted deployment dashboard surfaces,
+including Control UI and Terminal tabs. A separate control plane may provide
+desired state, credentials, terminal authorization, rollout policy, and
+deployment lifecycle, but that platform-specific implementation is outside this
+repository.
 
 The public contract covers:
 
@@ -33,15 +34,15 @@ The public contract covers:
   installers;
 - writing non-secret local run configuration;
 - projecting short-lived secrets only for the current runtime session;
-- running final hosted runtimes from direct process-manager entries that name
-  official Hermes/OpenClaw binaries;
-- running Clawdi-owned support programs under the runtime process manager;
-- supporting explicit `clawdi run -- <command>` when a caller opts into Clawdi
-  runtime env injection;
-- optionally proxying runtime browser UIs through the sidecar bridge module when
-  Clawdi, rather than the official runtime or platform ingress, owns browser
-  auth and header policy;
+- starting commands through `clawdi run -- <command>`;
+- providing stable command shims for managed runtime names;
+- projecting backend URL-based MCP for official external runtime containers;
+- exposing sidecar-local MCP only for explicitly declared compatibility
+  targets;
+- optionally proxying local runtime browser UIs through the runtime bridge when
+  a manifest explicitly declares bridge surfaces;
 - exposing a dashboard Terminal contract for one deployment shell;
+- publishing a stable Clawdi runtime sidecar image contract;
 - reporting status and diagnostics through runtime commands.
 
 The public contract does not cover:
@@ -50,154 +51,141 @@ The public contract does not cover:
 - private control-plane endpoints;
 - tenant or billing policy;
 - internal service implementation;
-- image build pipelines or platform rollout details.
+- private platform rollout implementation details.
 
 ## Core Architecture
 
-The primary hosted runtime model is a Linux-like runtime host. The host image
-provides the OS envelope, a runtime user, a stable `clawdi` bootstrap path,
-official Hermes/OpenClaw installs, and a process manager. Runtime behavior
-comes from the manifest and official runtime binaries, not from per-agent
-wrappers.
+Managed runtime mode keeps the Clawdi sidecar stable and runs agent processes in
+their official runtime containers. The stable identity is the runtime target id
+(`agent_id`). Runtime `type` is adapter and image metadata only.
 
 ```mermaid
-flowchart TB
-    CP[Hosted runtime manifest] --> Init[clawdi runtime init]
-    Init --> Durable
-    Init --> Ephemeral
-    Ephemeral --> Supervisor[supervisord or equivalent]
+flowchart LR
+    Dashboard[Dashboard] -->|target route id<br/>env_id or deployment_id:agent_id| DeployAPI[Hosted deployment API]
+    Dashboard -->|POST terminal<br/>{ agent_id }| DeployAPI
+    ControlPlane[Control plane<br/>desired state + secrets] --> Controller[Deployment controller<br/>Pod spec + rollout]
+    BackendMcp[Clawdi backend<br/>/mcp/clawdi]
+    ControlPlane -->|manifest| Sidecar
+    Controller -->|creates/updates| Pod
 
-    subgraph Durable["Durable non-secret state: /var/lib/clawdi"]
-        RunConfigs[config/run/<runtime>.json]
-        Projections[config/projections/<runtime>.json]
-        Inventory[install-inventory/<runtime>.json]
-        CliBin[managed bin/clawdi]
+    subgraph Pod["One Kubernetes Pod / localhost network namespace"]
+        Sidecar[Clawdi sidecar<br/>runtime init/watch<br/>config projection]
+        OpenClawA[Official OpenClaw container<br/>agent_id=openclaw-a<br/>type=openclaw]
+        OpenClawB[Official OpenClaw container<br/>agent_id=openclaw-b<br/>type=openclaw]
+        HermesA[Official Hermes container<br/>agent_id=hermes-a<br/>type=hermes]
+        VolA[(PVC /state/openclaw-a)]
+        VolB[(PVC /state/openclaw-b)]
+        VolH[(PVC /state/hermes-a)]
+
+        Sidecar -->|controlCommand<br/>native config projection| OpenClawA
+        Sidecar -->|controlCommand<br/>native config projection| OpenClawB
+        Sidecar -->|config file merge| HermesA
+        Sidecar -->|project backend MCP URL + bearer header| OpenClawA
+        Sidecar -->|project backend MCP URL + bearer header| OpenClawB
+        Sidecar -->|project backend MCP URL + bearer header| HermesA
+        OpenClawA --- VolA
+        OpenClawB --- VolB
+        HermesA --- VolH
     end
 
-    subgraph Ephemeral["Ephemeral runtime state: $CLAWDI_RUN_DIR"]
-        SupervisorConfig[supervisor/supervisord.conf]
-        Secrets[secrets and auth-token files]
-        MitmCA[mitm/supervisor/ca.pem + sidecar-private key]
-    end
-
-    subgraph Support["Clawdi support programs"]
-        Watch[clawdi runtime watch]
-        Daemon[clawdi daemon run]
-        Sidecar[optional clawdi runtime sidecar]
-        Bridge[bridge module]
-        Mitm[MITM module]
-    end
-
-    subgraph Runtime["Official runtime programs"]
-        HermesGateway[hermes gateway run]
-        HermesDashboard[hermes dashboard]
-        OpenClaw[openclaw gateway run]
-    end
-
-    Supervisor --> Watch
-    Supervisor --> Daemon
-    Supervisor --> Sidecar
-    Sidecar --> Bridge
-    Sidecar --> Mitm
-    Supervisor --> HermesGateway
-    Supervisor --> HermesDashboard
-    Supervisor --> OpenClaw
-
-    Bridge -->|optional Control UI proxy| HermesDashboard
-    Bridge -->|optional Control UI proxy| OpenClaw
-    Mitm -. proxy URL + CA trust .-> HermesGateway
-    Mitm -. proxy URL + CA trust .-> HermesDashboard
-    Mitm -. proxy URL + CA trust .-> OpenClaw
+    OpenClawA --> BackendMcp
+    OpenClawB --> BackendMcp
+    HermesA --> BackendMcp
+    DeployAPI -->|terminal broker<br/>exec into exact container| OpenClawA
+    DeployAPI -->|terminal broker<br/>exec into exact container| OpenClawB
+    DeployAPI -->|terminal broker<br/>exec into exact container| HermesA
 ```
 
-`supervisord` is an implementation choice, not a behavior boundary. The
-important contract is that each long-running program is declared directly with
-its official command, args, cwd, and env. The supervisor entry must not point at
-`clawdi run -- openclaw`, `clawdi run -- hermes`, a generated launch shell, or a
-PATH shim.
+The Clawdi runtime sidecar image contains only the stable host envelope:
 
-The Linux-like host preserves official updater behavior. If a user or an
-official UI runs `openclaw update` or `hermes update`, PATH resolves to the
-official binary. Clawdi does not intercept that command. After an updater
-replaces files, the process manager may restart the relevant official program,
-but the update transaction remains owned by the runtime.
+- runtime user and home directory;
+- base packages required by the CLI and supported installers;
+- a host policy file that marks the environment as hosted;
+- a stable CLI bootstrap path;
+- PATH ordering that puts the service-state shim directory first;
+- supervisor or equivalent process entrypoint;
+- the native Clawdi MITM broker bundle.
 
-Hermes gateway and dashboard are separate official commands in this model. A
-deployment that needs both declares both supervisor programs explicitly. The
-dashboard is the browser Control UI surface. The gateway is still supervised
-directly, but it is not treated as a bridge target unless a deployment configures
-an actual HTTP/WebSocket listener for it. This mimics the useful process fan-out
-of the Hermes official Docker image without adopting Docker image rollout as the
-update mechanism.
+The sidecar image must not include OpenClaw or Hermes binaries. Those processes
+run from official upstream images. The published OSS image is:
 
-### Runtime Host Contents
+```text
+ghcr.io/clawdi-ai/clawdi-runtime-sidecar:<git-sha>
+```
 
-| Area | Contains | Must not contain |
-| --- | --- | --- |
-| Host envelope | runtime user, home directory, base packages, process manager, host policy | runtime-specific shell wrappers |
-| Clawdi | managed `clawdi`, native `clawdi-mitm-sidecar`, status/doctor tooling | per-agent command shims |
-| Hermes | official install and official `hermes` binary | Clawdi-owned `hermes` wrapper |
-| OpenClaw | official install and official `openclaw` binary | Clawdi-owned `openclaw` wrapper |
-| Runtime state | `/var/lib/clawdi`, `$CLAWDI_RUN_DIR`, workspace, short-lived secret files | durable plaintext provider secrets |
+The image entrypoint creates the hosted policy files when they are not mounted,
+optionally materializes `/etc/clawdi/runtime-source.json` from
+`CLAWDI_RUNTIME_MANIFEST_URL`, loads the configured auth token from env or an
+`*_FILE` secret, runs `clawdi runtime init --non-interactive --json`, and then
+execs `supervisord` with the rendered supervisor config.
 
-The host should not add:
+The image also contains an image-built CLI bootstrap tarball at:
 
-- `/usr/local/bin/openclaw` or `/usr/local/bin/hermes` wrappers owned by
-  Clawdi;
-- generated launch scripts that call `clawdi run -- openclaw` or
-  `clawdi run -- hermes`;
-- a Clawdi process as PID 1 for Hermes or OpenClaw;
-- direct public exposure of `--auth none` runtime ports.
+```text
+/usr/local/share/clawdi/bootstrap/clawdi-runtime-bootstrap.tgz
+```
 
-The image must not contain per-agent command wrappers, generated launch scripts,
-or PATH shims for `openclaw`, `hermes`, or future runtime names. Official
-runtime commands still resolve to official binaries, so native commands such as
-`openclaw update` and `hermes update` keep their own updater behavior.
+When the hosted manifest does not declare `clawdiCli.packageSpec`, the sidecar
+image sets `CLAWDI_RUNTIME_DEFAULT_CLI_PACKAGE_SPEC` to that tarball. A
+controller can still roll the CLI independently by pinning
+`clawdiCli.packageSpec` to a specific npm version or managed tarball in desired
+state.
 
-## Support Module Boundaries
+Runtime behavior should come from:
 
-The Clawdi support programs run under the same process manager as the runtime
-programs. `clawdi runtime sidecar` is one support process with optional modules,
-and those modules keep explicit authority boundaries:
+- the runtime manifest;
+- the `clawdi` CLI package selected by manifest policy;
+- `execution.mode = external` entries for runtimes supplied by official
+  containers instead of launched by the sidecar;
+- explicit `run.command` entries for future or externally installed runtimes.
 
-| Module | Starts when | Direction | Sensitive input | Network exposure | Must not own |
-| --- | --- | --- | --- | --- | --- |
-| manifest/watch | an auth token file exists | control-plane polling | Clawdi auth token from file | outbound API only | official runtime PID 1 |
-| live-sync daemon | `liveSync.agents` is non-empty | live sync and local daemon APIs | Clawdi auth token from file | local daemon surface | MITM rewrite policy |
-| sidecar bridge module | `bridge.surfaces` is non-empty and platform chooses Clawdi auth/proxy | browser reverse proxy | bridge token only | declared listen ports | outbound MITM policy |
-| sidecar MITM module | enabled MITM profiles exist | runtime outbound proxy | profile bundle, CA cert/key under `$CLAWDI_RUN_DIR`, optional secret file | loopback/private proxy | live-sync/API authority |
-| official runtime program | runtime is enabled | normal runtime behavior | runtime-specific env/config only | official runtime ports | Clawdi auth secrets |
+Adding a new target should not require adding a new image-level wrapper. The
+controller chooses the official image and Pod layout; the manifest names the
+target id, type, image metadata, mounted paths, control command, MCP source, and
+terminal target. Runtime availability and enabled/disabled policy belong to the
+manifest and control plane, not to the sidecar image.
 
-The sidecar is still not a hidden wrapper around Hermes/OpenClaw. It only hosts
-Clawdi-owned support modules; official runtime programs remain direct process
-manager entries.
+### Target Identity
 
-The MITM module keeps its root CA certificate and private key under the
-ephemeral run directory so a sidecar restart does not change the trust root for
-already-running runtimes. Runtime programs receive only the CA certificate path
-as trust env; the private key path is not projected into runtime env.
+Every hosted runtime instance has one stable target id:
 
-The sidecar bridge module is optional, not a replacement for official ports. If
-the platform exposes the official ports behind trusted ingress auth and the
-runtime native UI works with that auth/CORS/path policy, the bridge can be
-disabled. If Clawdi needs cookie/token auth, tenant isolation, CSP/header
-rewriting, WebSocket/SSE mediation, or a single hosted Control UI URL, the
-bridge remains the correct inbound module.
+- `agent_id` / runtime target id: unique instance identity, for example
+  `openclaw-a`, `openclaw-b`, or `hermes-a`.
+- `type`: adapter metadata, one of `codex`, `openclaw`, or `hermes`.
+- `environmentId`: cloud-api agent environment id when minted.
+- `image` and `version`: controller-declared desired image and sidecar-observed
+  native CLI/runtime version.
 
-### Official Container Reference Research
+No dashboard, terminal, provider, channel, or live-sync path selects a runtime by
+`type`. If two OpenClaw targets exist, every operation names `openclaw-a` or
+`openclaw-b` explicitly.
 
-Official runtime images are useful references, but they are not the primary
-hosted architecture while in-place official UI updates are a requirement:
+One Clawdi sidecar naturally manages only the targets in its own Pod because it
+depends on same-Pod networking, mounted volumes, and local control commands.
+Multiple Pods require a controller/operator that renders one target manifest per
+Pod and rolls Pod specs forward. A single sidecar must not reach across Pod
+boundaries to mutate another Pod's volumes or containers.
 
-| Image | Useful reference | Update implication |
-| --- | --- | --- |
-| `nousresearch/hermes-agent` | s6 starts `hermes gateway run` and, with `HERMES_DASHBOARD=1`, also starts `hermes dashboard`; ports are `8642` and `9119` | Docker installs update by pulling/recreating the image, so dashboard update cannot be the normal in-place updater path |
-| `ghcr.io/openclaw/openclaw` | `tini` runs the gateway; official container rejects unauthenticated non-loopback binds; `--auth token --bind auto` works for directly exposed ports | Docker installs update by image rollout; in-place `openclaw update` belongs to non-Docker installs |
+### Same-Pod Config Injection
 
-The Linux-like host can adopt these lessons without switching to container
-rollout updates: declare Hermes gateway and dashboard as separate official
-supervisor programs, keep OpenClaw loopback when behind the bridge, and require
-runtime-native auth when exposing the official OpenClaw port directly.
+Config injection is same-Pod and explicit:
+
+- The sidecar owns `/var/lib/clawdi`, `/run/clawdi`, and `/home/clawdi`.
+- Each runtime target owns a distinct state volume, for example
+  `/state/openclaw-a`, `/state/openclaw-b`, and `/state/hermes-a`.
+- The sidecar may mount several target volumes, but each mounted path must map
+  to exactly one `agent_id`; two enabled targets must not share the same
+  `execution.stateDir` or `execution.home`.
+- Hermes config projection is a direct merge into
+  `runtimeTargets.<agent_id>.execution.home/config.yaml`.
+- OpenClaw provider, channel, and MCP projection uses OpenClaw's native config
+  patch contract. In external mode, manifests that declare those projections
+  must provide `execution.controlCommand`; otherwise the manifest is rejected.
+  This keeps the Clawdi sidecar image free of OpenClaw binaries while making the
+  deployment's control adapter explicit.
+- Terminal injection is not config injection. The deployment-side terminal
+  broker resolves `execution.terminal` after the dashboard selects `agent_id`
+  and execs into the exact target container.
 
 ## Manifest Shapes
 
@@ -217,21 +205,63 @@ Normalization maps hosted fields into the internal shape:
 | `system.home`, `system.workspace` | Runtime HOME and workspace root |
 | `controlPlane.manifestUrl`, `controlPlane.cloudApiUrl` | Manifest datasource and API origin |
 | `clawdiCli.packageSpec` | System-managed CLI package selection |
-| `runtimes.<name>.enabled` | Run config and supervisor program state |
-| `runtimes.<name>.install` | Supported official installer input |
-| `runtimes.<name>.run` | Command, args, cwd, env, and PATH projection |
-| `runtimes.<name>.services` | Runtime-owned auxiliary processes, such as a browser dashboard, supervised without user command shims |
-| `bridge.surfaces` | Optional authenticated runtime surface listen/upstream mappings |
-| `providers` | Runtime-scoped AI provider projections and secret refs |
+| `runtimeTargets.<agent_id>.type` | Adapter/image family metadata |
+| `runtimeTargets.<agent_id>.enabled` | Target availability |
+| `runtimeTargets.<agent_id>.environmentId` | Cloud-api agent environment id |
+| `runtimeTargets.<agent_id>.image` | Desired official image ref/tag/digest |
+| `runtimeTargets.<agent_id>.version` | Desired/observed runtime version metadata |
+| `runtimeTargets.<agent_id>.execution` | External-container execution facts |
+| `runtimeTargets.<agent_id>.run` | Explicit managed-process command override |
+| `bridge.surfaces` | Optional authenticated compatibility surface mappings |
+| `providers.<agent_id>` | Target-scoped AI provider projections and secret refs |
 | `mcp`, `tools` | Runtime MCP/tool projection input |
-| `liveSync` | Optional daemon sync configuration |
-| `mitmProfiles` | Explicit local sidecar profiles |
+| `liveSync.agents[].agentId` | Target id for daemon sync |
+| `mitmProfiles` | Explicit local broker profiles |
 | `recovery` | Manifest cache and offline-boot behavior |
 
-Manifest validation is defensive. Enabled built-in runtimes must use the
-expected official installer metadata unless they provide an explicit run
-command. Unknown runtime names require `run.command`; otherwise the manifest is
-rejected so the image does not need to know every future agent.
+The normalized `clawdi.runtimeDesiredState.v1` keeps a target-id keyed
+`runtimes` map for convergence, plus `runtimeTargets` for the public target
+contract. Each entry must declare `type`; the CLI never infers type from the key
+name.
+
+External official containers use `runtimeTargets.<agent_id>.execution` as the
+deployment boundary:
+
+- `mode: "external"` tells the sidecar not to install, supervise, or launch the
+  agent process.
+- `home`, `stateDir`, and `workspace` describe the agent-native mounted paths.
+  Each enabled target must have its own writable state path. For example,
+  `openclaw-a` and `openclaw-b` must not share `/home/node/.openclaw`.
+- `controlCommand` is the deployment-provided command that runs the native agent
+  CLI in the target runtime environment for config projection.
+- `execution.mcp.source` defaults to backend direct MCP when omitted. A custom
+  URL must explicitly set `source` to `backend-direct` or `sidecar-local`.
+- `execution.mcp.url` is only required for `source: "sidecar-local"`, where it
+  must use `http://` and `streamable-http`. Backend direct MCP derives the URL
+  from `controlPlane.apiUrl` when omitted.
+- `terminal` is consumed by the deployment-side terminal broker after the
+  dashboard selects `agent_id`; it describes the exact container/user/cwd/env
+  for the real shell target.
+
+Image upgrades are not performed by the sidecar. The sidecar records desired
+image metadata and observes the native runtime version through
+`execution.versionCommand`, `controlCommand --version`, or the installed CLI when
+available. A controller/operator performs the actual upgrade by changing the Pod
+spec image tag/digest and rolling the Pod. The sidecar then reports observed
+version drift through install inventory and sync state.
+
+Production rollouts should treat images as three independent tracks:
+
+| Image | Owner | Upgrade mechanism |
+| --- | --- | --- |
+| `ghcr.io/clawdi-ai/clawdi-runtime-sidecar:<git-sha>` | Clawdi OSS release workflow | Controller changes the sidecar image tag/digest and rolls the Pod |
+| Official OpenClaw image | OpenClaw upstream / deployment controller | Controller changes the OpenClaw target container image tag/digest |
+| Official Hermes image | Hermes upstream / deployment controller | Controller changes the Hermes target container image tag/digest |
+
+The sidecar observes agent versions; it does not mutate agent image tags. If an
+agent image update changes config contracts, the controller must update both the
+target image and the manifest fields (`image`, `version`, `execution`, and
+projection settings) in the same rollout.
 
 ## Commands
 
@@ -240,7 +270,8 @@ Runtime operators can use these commands in controlled environments:
 ```bash
 clawdi runtime init --non-interactive
 clawdi runtime watch
-clawdi runtime sidecar
+clawdi runtime bridge
+clawdi mcp http --host 0.0.0.0 --port 8788 --path /mcp --auth-token-file <file>
 clawdi runtime status --json
 clawdi runtime doctor --json
 clawdi run -- <command>
@@ -251,34 +282,33 @@ managed environments where configuration is supplied by policy or a manifest,
 not by an interactive user setup flow.
 
 `runtime watch` is the long-running reconciliation loop. It refreshes remote
-manifest state using ETags, applies changes, records status, and falls back to
-last-good cached manifests only when recovery policy allows it. `runtime
-sidecar` is the single Clawdi support process for optional runtime-local modules:
-the bridge module exposes manifest-declared browser surfaces behind hosted access
-controls, and the MITM module proxies outbound runtime traffic when explicit
-MITM profiles are enabled.
+manifest state using ETags, applies changes, records status, and uses
+last-good cached manifests only when recovery policy explicitly allows it.
+`runtime bridge` exposes manifest-declared runtime surfaces behind hosted access
+controls when a deployment needs a local compatibility proxy.
 
-The current hosted bridge surfaces are browser-facing runtime UIs. Each surface
-declares its listen address, upstream target, protocol behavior, auth model, and
-header rewrite rules. The bridge must not become a generic arbitrary-port
-forwarder. Terminal is deliberately out of scope because it is a shell-exec
-authorization path, not a browser UI proxy.
+Official external runtime containers use backend direct MCP by default:
+`<controlPlane.apiUrl>/mcp/clawdi` with the deployment API key projected as
+an `Authorization` header. The backend endpoint is stateless Streamable HTTP,
+handles `initialize`, `ping`, `tools/list`, and `tools/call`, and enforces the
+same user and environment binding as the rest of the API.
 
-## Bridge Policy
+`clawdi mcp http` is compatibility mode only. It exposes a sidecar-owned MCP
+server for runtimes that cannot reach the backend route directly. A runtime must
+declare `execution.mcp.source: "sidecar-local"` and an explicit `http://` URL
+before the sidecar starts this program. The endpoint requires a sidecar-local
+bearer token from `CLAWDI_MCP_HTTP_TOKEN` or `--auth-token-file`, and projected
+URL MCP configs pass that token in an `Authorization` header, not in the URL.
+When multiple sidecar-local external runtimes are enabled, their projected MCP
+URLs must share the same sidecar port and path.
 
-The sidecar bridge module stays in the architecture as an optional inbound
-module. The default safe mode is bridge-on with loopback runtime upstreams.
-Direct official port exposure is an explicit manifest/platform choice.
-
-| Mode | Runtime bind/auth | External exposure | Bridge |
-| --- | --- | --- | --- |
-| Bridge mode | runtime may bind loopback and use local/no auth | Dashboard reaches the runtime through Clawdi access controls | enabled |
-| Direct official port mode | runtime must use runtime-native auth or trusted ingress auth | Platform ingress exposes the official runtime port | disabled or bypassed |
-
-Use bridge mode when Clawdi owns browser-facing auth, tenant isolation,
-cookie/token handling, CSP/frame header rewriting, WebSocket/SSE mediation, or a
-single hosted Control UI URL. Disable the bridge only when platform ingress and
-the official runtime together cover those responsibilities.
+Bridge surfaces are browser-facing compatibility surfaces. Each surface declares
+its listen address, upstream target, protocol behavior, auth model, and header
+rewrite rules. The bridge must not become a generic arbitrary-port forwarder.
+Static upstream headers should be non-secret policy values; bearer tokens,
+cookies, and API keys should be injected through `upstreamHeaderEnv`.
+Terminal is deliberately out of scope because it is a shell-exec authorization
+path, not a browser UI proxy.
 
 ## Desired State Boundary
 
@@ -305,96 +335,47 @@ outputs include:
 | `cache/manifest.etag`, `cache/channels.etag` | Remote refresh cache validators |
 | `install-inventory/<runtime>.json` | Install/verify observation |
 | `config/projections/<runtime>.json` | Runtime projection payload |
-| `config/run/<runtime>.json`, `config/run/<runtime>+<service>.json` | `clawdi run` launch config for runtime main processes and internal runtime-owned services |
-| `$CLAWDI_RUN_DIR/secrets/*` | Short-lived token and secret files for the current runtime session |
-| `$CLAWDI_RUN_DIR/supervisor/supervisord.conf` | Ephemeral process plan for Clawdi support programs and official runtime programs |
+| `config/run/<runtime>.json` | `clawdi run` launch config |
+| `config/runtime-command-shims.json` | Active generated command shims |
+| `supervisor/supervisord.conf` | Process supervision plan |
 
 Short-lived secrets belong under the runtime run directory, not in durable
 config. Status and diagnostic output must redact secrets.
 
-## Command And Launch Model
+## Command And Shim Model
 
-`clawdi run -- <command>` is a local vault-injection command and an interactive
-hosted shell boundary. In hosted mode, it first tries to resolve the command
-against a generated runtime run config. If a matching enabled config exists, it
-launches that runtime with the configured command, args, cwd, env, PATH, secret
-refs, and optional sidecar profile. If the config exists but is disabled,
-`clawdi run` exits with a disabled-runtime error.
+`clawdi run -- <command>` is both a local vault-injection command and the hosted
+runtime activation boundary. In hosted mode, it first tries to resolve the
+command against a generated runtime run config. If a matching enabled config
+exists, it launches that runtime with the configured command, args, cwd, env,
+PATH, secret refs, and optional broker profile. If the config exists but is
+disabled, `clawdi run` exits with a disabled-runtime error.
 
-Interactive shell commands are not intercepted. `openclaw`, `hermes`, and
-future runtime names resolve to official binaries on PATH. Clawdi only
-participates when the caller explicitly invokes `clawdi run` or when
-`runtime init` projects manifest-selected config.
+Generated shims make managed runtime commands feel native:
 
-Hosted daemon startup avoids `clawdi run`. `runtime init` renders private
-`$CLAWDI_RUN_DIR/supervisor/supervisord.conf` entries that contain the official
-binary, args, cwd, and env:
+1. `runtime init` writes one dispatcher script under the service-state bin
+   directory.
+2. Each managed runtime command, such as `openclaw` or `hermes`, is a symlink to
+   that dispatcher.
+3. The host PATH puts the shim directory first for login and non-login shells.
+4. The dispatcher removes its own directory from PATH and executes:
 
-```ini
-command='/home/clawdi/.openclaw/bin/openclaw' 'gateway' 'run' '--allow-unconfigured' '--auth' 'none' '--bind' 'loopback' '--force'
-directory=/home/clawdi/clawdi
-environment=HOME="/home/clawdi",PATH="/home/clawdi/.openclaw/bin:..."
-```
+   ```bash
+   clawdi run -- "$command_name" "$@"
+   ```
 
-When bridge surfaces or MITM profiles are enabled, supervisor runs one Clawdi
-support process (`clawdi runtime sidecar`). Bridge token/surface config and MITM
-profile/CA config stay inside that sidecar process. Runtime programs receive
-only final proxy and CA env such as `HTTPS_PROXY`, `OPENCLAW_PROXY_URL`, and
-`NODE_EXTRA_CA_CERTS`; sidecar control env and secret-file paths stay out of the
-official runtime process.
+This prevents accidental fallback to native binaries for disabled runtimes while
+keeping ordinary shell commands real. A user typing `ls`, `git`, or `python`
+gets the normal shell binary. A user typing a managed runtime name gets the
+manifest-controlled `clawdi run` path.
 
-Hermes has multiple official long-running surfaces. The Linux-like host should
-declare `hermes gateway run` and `hermes dashboard --host 127.0.0.1 --no-open`
-as separate official supervisor programs when both are needed. Clawdi should not
-emulate that fan-out with shell wrappers.
-
-OpenClaw's bridge-only hosted default stays loopback and unauthenticated because
-the runtime is reachable only through the Clawdi bridge and hosted access
-controls:
-
-```bash
-openclaw gateway run --allow-unconfigured --auth none --bind loopback --force
-```
-
-Production manifests should provide OpenClaw configuration and a real gateway
-token or password when the official OpenClaw port is exposed directly. The
-official Docker test showed `--auth none --bind lan` fails closed; direct-port
-manifests should use runtime-native auth and a non-loopback/container-aware
-bind such as `--auth token --bind auto`. `--allow-unconfigured` is acceptable
-for development, diagnostics, or first-boot recovery, but it should not hide
-missing production configuration.
-
-## Official Update Compatibility
-
-Supervisor is compatible with official updater behavior only when it stays a
-process manager:
-
-- supervisor entries name official binaries directly;
-- install roots are writable by the runtime user expected by the official
-  installer;
-- `openclaw`, `hermes`, and their update subcommands are not shadowed by
-  Clawdi wrappers or PATH shims;
-- `clawdi run` is used only when explicitly requested by a caller;
-- after an updater replaces files, the process manager restarts the relevant
-  official programs, or autorestart picks them up when they exit.
-
-The update transaction belongs to Hermes/OpenClaw. Clawdi may observe status,
-surface diagnostics, and restart programs, but it must not emulate or wrap
-`hermes update` or `openclaw update`.
-
-Runtime-owned services use the same generated run-config and supervisor model,
-but they are not user commands and do not receive command shims. A manifest entry
-such as `runtimes.hermes.services.dashboard` writes
-`config/run/hermes+dashboard.json` and supervisor starts the official command
-directly:
+Supervisor uses the same boundary:
 
 ```ini
-command='hermes' 'dashboard' '--host' '127.0.0.1' '--no-open'
+command=/usr/bin/env clawdi run -- <runtime>
 ```
 
-This covers browser helper processes such as a runtime dashboard while keeping
-the user's shell PATH clean: typing `hermes` enters the managed Hermes runtime,
-not a dashboard alias.
+The image does not need per-agent supervisor wrappers.
 
 ## Provider And Channel Routing
 
@@ -415,34 +396,36 @@ Channel configuration follows the same rule: the open-source contract describes
 the local projection shape and validation rules, while service-specific channel
 control planes remain outside this repository.
 
-## Runtime UI And Terminal
+## Control UI And Terminal
 
 Hosted deployment pages expose two live surfaces:
 
-- **Control UI** embeds or links to the runtime's browser UI. It can use the
-  official runtime port directly when platform ingress owns auth and header
-  policy, or the sidecar bridge module when Clawdi owns those browser-facing
-  controls. It is runtime-specific and should be labelled as `<Runtime> Control
-  UI`.
-- **Terminal** opens a shell for the deployment. It is not split per agent; a
-  deployment has one Terminal surface.
+- **Control UI** embeds or links to the runtime's browser UI. In the optimized
+  official-container model, the deployment layer should publish the upstream
+  runtime UI directly through its own authenticated route. `clawdi runtime
+  bridge` is an opt-in compatibility surface for runtimes or deployment targets
+  that cannot expose the upstream UI directly and need same-origin, CSP, or
+  header mediation.
+- **Terminal** opens a shell for the deployment and should exec into the
+  selected runtime container when the runtime is external. The sidecar is not
+  the terminal target for agent work.
 
 ```mermaid
 flowchart LR
-    Dashboard[Dashboard] -->|Control UI URL| Ingress[Platform ingress]
-    Ingress -->|direct mode| RuntimeUI[Official runtime UI port]
-    Ingress -->|bridge mode| Bridge[sidecar bridge module]
-    Bridge --> RuntimeUI
-    Dashboard -->|Terminal WebSocket| HostedAPI[Hosted API]
-    HostedAPI --> Shell[Deployment shell<br/>default runtime user]
+    Dashboard[Dashboard] -->|Control UI URL| RuntimeUI[Runtime browser UI<br/>authenticated route]
+    Dashboard -. compatibility Control UI URL .-> Bridge[clawdi runtime bridge]
+    Bridge -. declared surface .-> RuntimeUI
+    Dashboard -->|POST terminal { agent_id }| HostedAPI[Hosted API]
+    HostedAPI --> Shell[Exact target container shell]
 ```
 
 The browser Terminal contract is:
 
-1. The dashboard calls `POST /v2/deployments/{deployment_id}/terminal`.
+1. The dashboard calls `POST /v2/deployments/{deployment_id}/terminal` with
+   the selected `agent_id`.
 2. The API returns a short-lived `websocket_url`.
-3. The frontend removes any fragment token from the URL and sends it as a
-   WebSocket subprotocol named `clawdi-terminal.<token>` when possible.
+3. The frontend removes the fragment token from the URL and sends it only as a
+   WebSocket subprotocol named `clawdi-terminal.<token>`.
 4. The frontend also sends the `tty` subprotocol and uses tty-style frames:
    `0` for terminal input/output and `1` for resize.
 5. The terminal uses xterm, auto-fits to the panel, focuses on pointer down, and
@@ -450,29 +433,37 @@ The browser Terminal contract is:
 
 The service-side implementation is outside this repository. It must
 authenticate the user, require the deployment to be running, bind the terminal
-token to the deployment, and bridge the WebSocket to a shell as the default
-runtime user. Query-param token transport is kept only as a compatibility
-fallback for environments that reject custom WebSocket subprotocols.
+token to the deployment and exact `agent_id`, and bridge the WebSocket to a
+shell in that target container.
 
 ## Security Rules
 
-- Do not persist auth tokens, private keys, provider secrets, or resolved vault
-  values in durable runtime config.
+- Do not persist control-plane auth tokens, private keys, provider secrets, or
+  resolved vault values in durable runtime config.
+- Official external runtime MCP should point at `/mcp/clawdi` on the
+  backend. It uses the deployment API key and backend-side user/environment
+  isolation; the sidecar does not host a multi-tenant MCP control plane.
+- A sidecar-local MCP bearer may be projected into official agent MCP config
+  only for explicit compatibility mode, because upstream URL MCP clients need
+  an `Authorization` header. Scope it to the private container network and
+  rotate it through runtime convergence.
 - Keep non-secret desired state separate from secret values.
 - Treat runtime policy as an input to the CLI, not as hardcoded private logic.
 - Prefer official runtime configuration and installers before proxying or
   request rewriting.
-- Expose official runtime ports only behind runtime-native auth, platform
-  ingress auth, or the sidecar bridge module.
 - Keep defensive validation at every boundary: manifests, provider references,
   channel descriptors, filesystem paths, and process launch arguments.
 - Remove `CLAWDI_AUTH_TOKEN` from agent child process environments unless that
   process is explicitly the Clawdi daemon or runtime reconciler.
-- Start runtime browser UIs without public gateway auth only when they are
-  reachable solely through the local sidecar bridge module and hosted access
-  controls.
-- Prefer WebSocket subprotocol auth for Terminal sessions so bearer tokens do
-  not normally appear in URLs or proxy access logs.
+- Start runtime browser UIs behind authenticated deployment routes. Disable
+  public gateway auth inside the runtime only when access is otherwise confined
+  to a private route or an explicitly declared local runtime bridge.
+- Expose `clawdi mcp http` only on a trusted container/pod network and only
+  when `execution.mcp.source` is `sidecar-local`. It uses plaintext bearer auth
+  because it is a compatibility integration endpoint, not an internet-facing
+  API.
+- Require WebSocket subprotocol auth for Terminal sessions so bearer tokens do
+  not appear in URLs or proxy access logs.
 
 ## Recovery Rules
 

--- a/docs/plans/managed-runtime-cli.md
+++ b/docs/plans/managed-runtime-cli.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Status | Public implementation notes |
-| Last updated | 2026-07-01 |
+| Last updated | 2026-06-30 |
 | Owner | CLI runtime layer |
 
 This note documents the open-source CLI surface for managed runtime
@@ -23,10 +23,7 @@ Related public contract: [`../managed-runtime.md`](../managed-runtime.md).
 - Avoid storing secrets in durable manifests, caches, shell startup files, or
   generated config.
 - Keep the runtime image stable by avoiding image-level per-agent wrappers.
-- Start hosted runtimes from direct supervisor entries that name official
-  Hermes/OpenClaw binaries.
-- Preserve official in-place updater paths by leaving shell commands on
-  official runtime binaries.
+- Route managed runtime commands through generated run config and `clawdi run`.
 
 ## Command Surface
 
@@ -36,7 +33,9 @@ Runtime commands are intentionally small:
 clawdi runtime init --non-interactive [--json]
 clawdi runtime init --manifest-file <path> [--json]
 clawdi runtime watch [--self-heal-ms <ms>]
-clawdi runtime sidecar
+clawdi runtime bridge
+# Compatibility only; backend /mcp/clawdi is the default hosted MCP target.
+clawdi mcp http --host 0.0.0.0 --port 8788 --path /mcp --auth-token-file <file>
 clawdi runtime status [--json]
 clawdi runtime doctor [--json]
 clawdi run -- <command>
@@ -64,9 +63,8 @@ operator-provided manifest.
 3. Install or verify selected runtimes through their normal installers.
 4. Write non-secret run configuration.
 5. Project short-lived secret files only when needed for the current session.
-6. Render the ephemeral supervisor process plan with direct Clawdi support
-   programs and direct official runtime commands.
-7. Leave unrelated legacy wrapper or launcher files untouched.
+6. Write command shims for active runtime names.
+7. Render supervisor config.
 8. Record status and diagnostics.
 
 The command should be idempotent. Re-running it with the same desired state
@@ -75,11 +73,11 @@ should not produce unnecessary config churn.
 Key generated outputs:
 
 - `config/run/<runtime>.json` for `clawdi run`;
-- `config/run/<runtime>+<service>.json` for runtime-owned auxiliary services;
 - `config/projections/<runtime>.json` for runtime-specific config projection;
-- `$CLAWDI_RUN_DIR/supervisor/supervisord.conf` with Clawdi support programs
-  and official runtime commands;
-- `$CLAWDI_RUN_DIR/secrets/*` for short-lived auth and provider secret material;
+- `config/runtime-command-shims.json` plus symlinks under the service-state bin
+  directory;
+- `supervisor/supervisord.conf` with each runtime launched as
+  `clawdi run -- <runtime>`;
 - `cache/manifest.last-good.json` and ETag files for recovery and refresh;
 - `install-inventory/<runtime>.json` for diagnostics.
 
@@ -89,10 +87,9 @@ last-good manifest only after successful convergence.
 
 ## Run Boundary
 
-`clawdi run -- <command>` is the explicit local/debug execution boundary for
-managed configuration. It reads local run configuration, prepares the child
-process environment, and then executes the requested command when the caller
-opts into Clawdi env injection.
+`clawdi run -- <command>` is the activation boundary for managed configuration.
+It reads local run configuration, prepares the child process environment, and
+then executes the requested command.
 
 Rules:
 
@@ -103,16 +100,22 @@ Rules:
 - keep request rewriting behind explicit runtime profiles.
 - delete `CLAWDI_AUTH_TOKEN` before launching agent child processes.
 
-Hosted runtime mode does not install per-runtime command wrappers. The hosted
-terminal remains a real shell, so `openclaw`, `hermes`, and future runtime
-names resolve to official binaries on PATH. `clawdi run -- <command>` remains
-available only as an explicit Clawdi env-injection boundary.
+In hosted mode, runtime command shims make managed runtimes feel native. The
+host PATH points at the shim directory first. A shim named `openclaw`, `hermes`,
+or another manifest runtime removes the shim directory from PATH, then calls:
 
-Hosted daemon startup uses supervisor directly, not `clawdi run` and not a
-Clawdi wrapper. The supervisor config is written under `$CLAWDI_RUN_DIR` with
-owner-only permissions because it can contain resolved, short-lived runtime env
-secrets. Durable `/var/lib/clawdi` state remains limited to non-secret desired
-state, inventory, projections, and cache files.
+```bash
+clawdi run -- "$command_name" "$@"
+```
+
+This is the only per-runtime command wrapper. The image should not grow a new
+wrapper each time a runtime is added. Disabled run configs must fail closed:
+`clawdi run` reports the runtime as disabled and never falls back to a native
+binary later on PATH.
+
+For ordinary shell commands that are not managed runtime names, the hosted
+terminal remains a real shell. The command shim model only intercepts command
+names that `runtime init` generated.
 
 ## Runtime Support Model
 
@@ -127,25 +130,8 @@ Rules:
 - unknown runtime names with install metadata are rejected unless the CLI has
   been upgraded to support them;
 - unknown runtime names without `run.command` are rejected;
-- unknown runtime names with `run.command` can be supervised without
+- unknown runtime names with `run.command` can be launched and shimmed without
   image changes.
-
-The support modules are not interchangeable:
-
-- `runtime watch` reconciles manifests and can use Clawdi API auth.
-- `daemon run` serves live sync only when live-sync agents are declared.
-- `runtime sidecar` hosts runtime-local support modules: the bridge module
-  proxies inbound browser Control UI surfaces, and the MITM module proxies
-  outbound runtime traffic only when MITM profiles are enabled.
-
-Their tokens, network direction, and failure domains must stay visible in
-manifest state, status, and logs. The sidecar must not become a hidden wrapper
-around official runtime commands.
-
-Hermes deployments that need both gateway and dashboard should declare two
-official Hermes supervisor programs. The official Hermes Docker image is useful
-prior art for this fan-out, but the Linux-like host keeps in-place
-`hermes update` available.
 
 ## Provider Projection
 
@@ -179,22 +165,27 @@ Channel projection follows the same contract-driven pattern:
 The public CLI contract describes local projection and validation only. Service
 specific channel management remains outside this repository.
 
-## Runtime UI And Terminal Notes
+## Control UI And Terminal Notes
 
-The sidecar bridge module is the local authenticated bridge for
-manifest-declared runtime surfaces. The current hosted surfaces use
-`kind: "control-ui"` and the dashboard labels them as `<Runtime> Control UI`
-because each is a runtime-specific browser application.
+`clawdi runtime bridge` is the optional local authenticated bridge for
+manifest-declared runtime surfaces. In the optimized official-container model,
+Control UI should normally be exposed by the deployment layer as an
+authenticated route to the upstream runtime UI. Bridge surfaces remain a
+compatibility path for same-origin, CSP, or header mediation.
 
 Bridge surfaces declare listen/upstream targets, protocol handling, auth
 behavior, and header rewrite rules explicitly. The bridge is not an arbitrary
-port forwarder. Terminal is not a bridge surface.
+port forwarder. Static upstream headers are for non-secret policy values;
+sensitive upstream auth should use environment-backed header injection. Terminal
+is not a bridge surface.
 
 The hosted Terminal is a dashboard/API contract, not a CLI command. The frontend
-requests a short-lived terminal WebSocket URL, moves fragment tokens into a
-`clawdi-terminal.<token>` WebSocket subprotocol by default, uses `tty` framing,
-and falls back to query-token transport only for compatibility. Terminal is
-deployment-scoped and should not be duplicated per agent.
+requests a short-lived terminal WebSocket URL with the selected `agent_id`,
+moves fragment tokens into a `clawdi-terminal.<token>` WebSocket subprotocol,
+and uses `tty` framing. Terminal is deployment-scoped and should exec into the
+selected runtime container when the runtime is external;
+deployment-side shell brokers resolve that container/user/cwd from the target
+id's `execution.terminal`.
 
 ## Testing Expectations
 
@@ -205,11 +196,10 @@ Runtime changes should include focused tests for:
 - channel projection and secret redaction;
 - `runtime init` idempotence;
 - `runtime status` and `runtime doctor` JSON output;
-- direct supervisor runtime command rendering;
-- interactive `clawdi run -- <command>` environment construction;
-- absence of newly generated runtime wrappers or launchers;
-- supervisor config rendering for watch, sidecar bridge/MITM modules, daemon,
-  runtimes, and runtime-owned services;
+- `clawdi run -- <runtime>` environment construction.
+- command shim routing, PATH cleanup, stale-shim cleanup, and disabled-runtime
+  behavior;
+- supervisor config rendering for watch, runtime bridge, daemon, and runtimes;
 - terminal URL token transport and light/dark xterm theme behavior when web UI
   code changes.
 

--- a/docs/plans/managed-runtime-roadmap.md
+++ b/docs/plans/managed-runtime-roadmap.md
@@ -14,22 +14,24 @@ this repository.
 ## Current Capabilities
 
 - Runtime policy and desired-state validation.
-- `clawdi runtime init/watch/sidecar/status/doctor` command surface.
+- `clawdi runtime init/watch/bridge/status/doctor` command surface, backend
+  direct MCP projection by default, and `clawdi mcp http` as explicit
+  compatibility mode.
 - Local fixture manifests for tests and diagnostics.
 - Deterministic provider and channel projection.
 - Non-secret desired-state cache and secret redaction.
-- Explicit local/runtime debug launch through `clawdi run -- <command>`.
-- Direct supervisor launch for managed daemon runtime processes.
-- Clawdi support program boundaries for manifest watch, live sync, optional
-  bridge, optional MITM, status, and diagnostics.
+- Runtime launch through `clawdi run -- <command>`.
+- Generated command shims for managed runtime names.
 - Stable-image contract: runtime behavior is driven by manifest + CLI, not
   image-level per-agent wrappers.
-- Supervisor rendering that starts official runtime binaries directly with
-  manifest-derived args, cwd, and env.
-- Sidecar bridge module for Control UI surfaces.
+- Supervisor rendering that launches runtimes through `clawdi run -- <runtime>`.
+- External runtime mode for official agent containers that are not launched by
+  the sidecar.
+- Runtime bridge as an explicitly declared Control UI compatibility surface.
 - Hosted Terminal dashboard contract with xterm, tty-style framing, and
-  WebSocket subprotocol token transport.
-- Sidecar profile validation and local sidecar lifecycle tests.
+  WebSocket subprotocol token transport; terminal target resolution belongs to
+  the deployment-side broker through `execution.terminal`.
+- Broker profile validation and local broker lifecycle tests.
 
 ## Active Work
 
@@ -41,16 +43,8 @@ this repository.
    `google_generate_content`.
 4. Keep target-runtime transport names inside projection code only.
 5. Improve diagnostics without printing secrets.
-6. Expand focused tests for provider, channel, run-environment, direct
-   supervisor rendering, runtime-owned services, Control UI, and Terminal
-   projection.
-
-## Reference Research
-
-Official Hermes/OpenClaw Docker images remain useful references for process
-shape, ports, health checks, and safe network defaults. They are not the primary
-hosted update model while official in-place UI updates remain a requirement,
-because Docker installs update by image rollout.
+6. Expand focused tests for provider, channel, run-environment, command-shim,
+   Control UI, and Terminal projection.
 
 ## Non-Goals
 

--- a/docs/plans/runtime-projection-boundary.md
+++ b/docs/plans/runtime-projection-boundary.md
@@ -3,7 +3,7 @@
 | Field | Value |
 | --- | --- |
 | Status | Public boundary note |
-| Last updated | 2026-07-01 |
+| Last updated | 2026-06-30 |
 | Owner | CLI runtime layer |
 
 This note defines what belongs in the open-source runtime projection layer. It
@@ -17,20 +17,27 @@ surface. Use Clawdi projection code to translate the standard provider/channel
 contract into target-runtime config. Use request rewriting only behind explicit
 profiles when native configuration cannot express the required behavior.
 
-The explicit local execution boundary is:
+The activation boundary is:
 
 ```bash
 clawdi run -- <command>
 ```
 
-`clawdi run` prepares environment variables and local config, then executes the
-target command when a caller explicitly opts into Clawdi env injection. Normal
-hosted daemon startup uses direct supervisor process entries instead.
+The wrapper prepares environment variables and local config, then executes the
+target command. Normal runtime startup should not require users to pass
+endpoint, token, or certificate flags manually.
 
-Hosted runtime mode does not intercept managed runtime names. Shell commands
-resolve to official runtime binaries. Clawdi only participates when a caller
-explicitly invokes `clawdi run -- <command>` or when supervisor starts a direct
-runtime program from the rendered process plan.
+In hosted runtime mode, managed runtime names are also exposed through generated
+command shims. The shim dispatcher immediately calls the same boundary:
+
+```bash
+clawdi run -- "$command_name" "$@"
+```
+
+This keeps the host image stable. The image only needs a generic shim directory
+at the front of PATH; runtime-specific behavior comes from the manifest and the
+CLI. If a runtime is disabled in the current manifest, `clawdi run` rejects it
+and the shim must not fall back to any native binary later on PATH.
 
 ## Projection Flow
 
@@ -44,19 +51,18 @@ flowchart LR
     subgraph Projection["Open-source projection layer"]
         CLI --> Provider[Provider projection]
         CLI --> Channel[Channel projection]
-        CLI --> Sidecar[Optional MITM profile projection]
+        CLI --> Broker[Optional MITM profile projection]
         CLI --> RunConfig[Runtime run config]
-        CLI --> SupervisorPlan[Supervisor process plan]
+        CLI --> Shims[Command shims]
     end
 
     Provider --> OpenClaw[OpenClaw config]
     Provider --> Hermes[Hermes config]
     Channel --> OpenClaw
-    Sidecar --> Runner[clawdi run environment]
+    Broker --> Runner[clawdi run environment]
     RunConfig --> Runner
-    SupervisorPlan --> Target
+    Shims --> Runner
     Runner --> Target[Target agent process]
-    Sidecar -. proxy and CA env .-> Target
 ```
 
 The diagram is intentionally limited to public contracts. It does not describe
@@ -76,12 +82,10 @@ example, a target runtime may need a native transport string that differs from
 `openai_responses`; that name should be generated only in the target runtime's
 projection file.
 
-Hosted runtime manifests should scope provider projections by runtime name when
-agents can have different provider bindings. For example,
-`providers.openclaw` is the OpenClaw provider projection and `providers.hermes`
-is the Hermes provider projection. The CLI must select the runtime-scoped entry
-for the runtime it is configuring instead of relying on a global default. The
-legacy `providers.default` shape remains valid for single-provider fixtures.
+Hosted runtime manifests scope provider projections by runtime target id. For
+example, `providers.openclaw-a` and `providers.openclaw-b` are distinct
+OpenClaw provider projections even though both targets have `type: openclaw`.
+The CLI selects only the target-id entry for the runtime it is configuring.
 
 ## Channel Boundary
 
@@ -93,16 +97,15 @@ Channel projection should:
 - redact secrets in logs and diagnostics;
 - avoid embedding private service assumptions in the CLI.
 
-## Sidecar Boundary
+## Broker Boundary
 
-The `clawdi runtime sidecar` command is the runtime-local Clawdi support process.
-It hosts the inbound bridge module when `bridge.surfaces` are declared and the
-outbound MITM module when a manifest profile requires it.
+The broker is an optional local transport child process used by `clawdi run`
+when an explicit profile requires it.
 
 The CLI may own:
 
 - profile validation;
-- local bridge and MITM module lifecycle;
+- local broker process lifecycle;
 - proxy and trust environment projection;
 - request matching for explicit profiles;
 - secret reference lookup from short-lived runtime state.
@@ -115,24 +118,15 @@ The CLI must not own:
 - target runtime update channels;
 - user BYOK provider traffic interception by default.
 
-The MITM module is not the bridge module and not the Clawdi daemon. They share
-the sidecar process, but module boundaries stay explicit: MITM owns outbound
-proxy and CA behavior, bridge owns inbound browser surface auth, and the daemon
-owns live-sync/API authority. Manifest state, status, token scope, and logs must
-keep those responsibilities separate.
-
 ## Runtime Command Boundary
 
 The CLI may own:
 
 - generated run config files;
-- direct supervisor process entries for daemon runtime startup;
-- no new wrapper or launcher generation for daemon runtime startup;
-- PATH cleanup before launching runtime child processes;
+- command shim creation and stale-shim cleanup;
+- PATH cleanup inside the shim dispatcher;
 - disabled-runtime enforcement;
-- supervisor commands that start official runtime binaries directly;
-- runtime-owned auxiliary services as explicit official service commands,
-  without user command shims;
+- supervisor commands that start runtimes through `clawdi run -- <runtime>`;
 - support for future runtime names when an explicit `run.command` is supplied.
 
 The CLI must not own:
@@ -146,32 +140,23 @@ Built-in installer/projection support is currently explicit. Unknown runtime
 names are acceptable only when the manifest includes enough `run.command`
 information for the CLI to launch them deterministically.
 
-Hosted runtime processes map to official runtime commands. If an official
-runtime exposes multiple long-running commands, such as Hermes dashboard and
-Hermes gateway, declare those commands explicitly in the process plan. Clawdi
-must not add a shell wrapper to multiplex the commands.
-
-Official runtime Docker images remain useful reference implementations. Hermes'
-Docker image demonstrates that gateway and dashboard can be supervised as
-separate official services. OpenClaw's Docker image demonstrates that direct
-non-loopback exposure should require runtime-native auth. Docker image rollout
-updates are a different update model, so they are not the primary path when
-in-place official UI updates are required.
-
 ## Control UI And Terminal Boundary
 
-Control UI is a runtime browser UI surface proxied by the sidecar bridge module.
-Terminal is a deployment shell surface exposed by the dashboard and hosted API
-contract. They are intentionally separate:
+Control UI is a runtime browser UI surface. In the official-container model it
+should be published by the deployment layer through an authenticated route to
+the upstream runtime UI. The local runtime bridge is an optional compatibility
+surface, not the default path. Terminal is a deployment shell surface exposed by
+the dashboard and hosted API contract. They are intentionally separate:
 
-- Runtime UI is runtime-specific and should use the runtime's own product
-  wording, such as OpenClaw Control UI or Hermes Dashboard.
+- Control UI is runtime-specific.
 - The bridge accepts explicitly declared runtime surfaces with listen/upstream
   targets and surface-specific policy; it must not become arbitrary port
   forwarding.
-- Terminal is deployment-scoped and not split per agent.
-- Terminal token transport should prefer WebSocket subprotocols, with query
-  string transport only as a compatibility fallback.
+- Terminal is deployment-scoped and should target the runtime container selected
+  by `agent_id` when the runtime is external. The dashboard carries the selection as
+  `agent_id`; the deployment-side broker should resolve the shell target from
+  the runtime target's `execution.terminal` contract.
+- Terminal token transport should use WebSocket subprotocols only.
 - The service-side shell bridge and deployment lifecycle are outside this
   repository.
 
@@ -182,9 +167,9 @@ In-repo tests should use local fixtures or fake upstreams for:
 - profile schema validation;
 - secret redaction;
 - deterministic provider and channel projection;
-- sidecar startup and shutdown around a child process;
-- explicit request rewrite behavior;
-- direct runtime routing and disabled-runtime behavior;
+- broker startup and shutdown around a child process;
+- explicit request rewrite behavior.
+- command shim routing and disabled-runtime behavior;
 - terminal WebSocket URL handling and theme/status behavior.
 
 Real service credentials and deployment-specific canaries belong outside the

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -11,6 +11,10 @@ create a Clawdi release from an already-deployed commit.
   day.
 - CLI/npm changes use semver GitHub releases and npm package versions:
   `clawdi-cli-vX.Y.Z` and `clawdi@X.Y.Z`.
+- Runtime sidecar image changes publish immutable Git-SHA tags to
+  `ghcr.io/clawdi-ai/clawdi-runtime-sidecar:<git-sha>`. The sidecar image is
+  an operational artifact, not an agent runtime image; OpenClaw and Hermes
+  containers stay on their official upstream image tracks.
 - GitHub generated notes seed the release body. Keep PR labels accurate; use
   `skip-changelog` for implementation-only PRs, then review and edit the body
   before treating it as final release copy.
@@ -83,6 +87,9 @@ releases.
    - `.github/workflows/cli-publish.yml` runs for `packages/cli/**` and the
      CLI publish workflow file, then publishes only when the local CLI version
      differs from npm.
+   - `.github/workflows/clawdi-image-release.yml` publishes backend/web images
+     and the runtime sidecar image independently. A sidecar-only change must
+     not trigger a backend deploy.
 3. For CLI releases, verify npm after the workflow succeeds:
 
    ```bash
@@ -101,6 +108,10 @@ releases.
    release body when PR titles are too implementation-focused, a PR touched
    both release lines, generated notes include unrelated entries, or the notes
    omit user impact.
+6. For runtime sidecar changes, verify the image workflow summary includes:
+   `ghcr.io/clawdi-ai/clawdi-runtime-sidecar:<git-sha>`. Controller rollouts
+   should pin that tag or its digest separately from OpenClaw/Hermes image
+   tags.
 
 ## Production Deployment Checks
 
@@ -124,6 +135,9 @@ run these checks before traffic is considered healthy:
    - Backend health/API requests return 2xx.
    - CLI can authenticate and run `clawdi vault list --json`.
    - A Vault key resolves only through CLI/API-key auth, never through web auth.
+   - Runtime sidecar deployments run `clawdi runtime doctor --json`, expose MCP
+     HTTP only on the trusted pod network, and project terminal requests by
+     exact `agent_id`.
 4. Check logs for migration errors, 5xx spikes, auth failures, and frontend
    build/runtime errors.
 

--- a/packages/cli/Dockerfile.runtime-sidecar
+++ b/packages/cli/Dockerfile.runtime-sidecar
@@ -1,0 +1,101 @@
+# syntax=docker/dockerfile:1.7
+
+FROM oven/bun:1.3.14 AS cli-builder
+
+WORKDIR /app
+
+COPY package.json bun.lock turbo.json tsconfig.base.json biome.json ./
+COPY apps/web/package.json apps/web/package.json
+COPY packages/shared/package.json packages/shared/package.json
+COPY packages/cli/package.json packages/cli/package.json
+COPY packages/whatsapp-baileys-sidecar/package.json packages/whatsapp-baileys-sidecar/package.json
+
+RUN bun install --frozen-lockfile --ignore-scripts
+
+COPY packages/shared packages/shared
+COPY packages/cli packages/cli
+
+RUN bun run --cwd packages/cli build
+
+FROM golang:1.26-bookworm AS mitm-builder
+
+WORKDIR /src
+
+COPY packages/cli/native/mitm-sidecar/go.mod packages/cli/native/mitm-sidecar/go.mod
+COPY packages/cli/native/mitm-sidecar/*.go packages/cli/native/mitm-sidecar/
+
+RUN cd packages/cli/native/mitm-sidecar \
+    && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/clawdi-mitm-sidecar .
+
+FROM node:24-bookworm-slim AS runtime
+
+ARG CLAWDI_UID=10001
+ARG CLAWDI_GID=10001
+
+ENV NODE_ENV=production \
+    HOME=/home/clawdi \
+    CLAWDI_RUNTIME_MODE=hosted \
+    CLAWDI_RUNTIME_HOME=/home/clawdi \
+    CLAWDI_RUNTIME_USER=clawdi \
+    CLAWDI_SERVICE_STATE_DIR=/var/lib/clawdi \
+    CLAWDI_RUN_DIR=/run/clawdi \
+    CLAWDI_HOST_POLICY_PATH=/etc/clawdi/host-policy.json \
+    CLAWDI_RUNTIME_SOURCE_PATH=/etc/clawdi/runtime-source.json \
+    CLAWDI_SHARE_DIR=/usr/local/share/clawdi \
+    CLAWDI_IMAGE_SHIM_PATH=/usr/local/bin/clawdi \
+    CLAWDI_MITM_SIDECAR_BUNDLE=/usr/local/lib/clawdi/clawdi-mitm-sidecar \
+    CLAWDI_RUNTIME_DEFAULT_CLI_PACKAGE_SPEC=/usr/local/share/clawdi/bootstrap/clawdi-runtime-bootstrap.tgz \
+    PATH=/var/lib/clawdi/bin:/home/clawdi/.local/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        gosu \
+        supervisor \
+        util-linux \
+        tini \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid "${CLAWDI_GID}" clawdi \
+    && useradd --uid "${CLAWDI_UID}" --gid "${CLAWDI_GID}" --create-home --home-dir /home/clawdi --shell /bin/bash clawdi \
+    && mkdir -p \
+        /etc/clawdi \
+        /run/clawdi \
+        /usr/local/lib/clawdi/bin \
+        /usr/local/lib/clawdi/clawdi-mitm-sidecar/bin \
+        /usr/local/share/clawdi/bootstrap \
+        /var/lib/clawdi \
+        /home/clawdi/clawdi \
+    && chown -R clawdi:clawdi /home/clawdi \
+    && chmod 0755 /etc/clawdi /run/clawdi /usr/local/lib/clawdi /usr/local/share/clawdi /var/lib/clawdi
+
+COPY --from=cli-builder /app/packages/cli/bin /usr/local/lib/clawdi/bin
+COPY --from=cli-builder /app/packages/cli/dist /usr/local/lib/clawdi/dist
+COPY --from=cli-builder /app/packages/cli/package.json /usr/local/lib/clawdi/package.json
+COPY --from=cli-builder /app/packages/cli/README.md /usr/local/lib/clawdi/README.md
+COPY --from=cli-builder /app/packages/cli/LICENSE /usr/local/lib/clawdi/LICENSE
+COPY --from=mitm-builder /out/clawdi-mitm-sidecar /usr/local/lib/clawdi/clawdi-mitm-sidecar/bin/clawdi-mitm-sidecar
+COPY packages/cli/docker/runtime-sidecar-entrypoint.sh /usr/local/bin/clawdi-runtime-sidecar
+COPY packages/cli/docker/runtime-nsenter-control.sh /usr/local/bin/clawdi-runtime-nsenter
+
+RUN chmod 0755 \
+        /usr/local/lib/clawdi/bin/clawdi.mjs \
+        /usr/local/lib/clawdi/clawdi-mitm-sidecar/bin/clawdi-mitm-sidecar \
+        /usr/local/bin/clawdi-runtime-sidecar \
+        /usr/local/bin/clawdi-runtime-nsenter \
+    && printf '%s\n' '#!/usr/bin/env sh' 'exec node /usr/local/lib/clawdi/bin/clawdi.mjs "$@"' > /usr/local/bin/clawdi \
+    && chmod 0755 /usr/local/bin/clawdi \
+    && cd /usr/local/lib/clawdi \
+    && npm pack --pack-destination /usr/local/share/clawdi/bootstrap \
+    && mv /usr/local/share/clawdi/bootstrap/clawdi-*.tgz /usr/local/share/clawdi/bootstrap/clawdi-runtime-bootstrap.tgz \
+    && chmod 0644 /usr/local/share/clawdi/bootstrap/clawdi-runtime-bootstrap.tgz
+
+WORKDIR /home/clawdi/clawdi
+
+EXPOSE 8788
+
+ENTRYPOINT ["/usr/bin/tini", "-s", "--", "/usr/local/bin/clawdi-runtime-sidecar"]
+CMD ["serve"]

--- a/packages/cli/docker/runtime-nsenter-control.sh
+++ b/packages/cli/docker/runtime-nsenter-control.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+state_dir=""
+marker=""
+workdir="/"
+
+usage() {
+	cat >&2 <<'EOF'
+Usage:
+  clawdi-runtime-nsenter --state-dir <path> --marker <path> [--workdir <path>] -- <command> [args...]
+
+Finds a same-Pod runtime container by its mounted state directory and marker
+file, enters that container's namespaces/root, and executes the command there.
+Requires a shared PID namespace and sufficient nsenter capabilities.
+EOF
+	exit 64
+}
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--state-dir)
+			[ "$#" -ge 2 ] || usage
+			state_dir="$2"
+			shift 2
+			;;
+		--marker)
+			[ "$#" -ge 2 ] || usage
+			marker="$2"
+			shift 2
+			;;
+		--workdir)
+			[ "$#" -ge 2 ] || usage
+			workdir="$2"
+			shift 2
+			;;
+		--)
+			shift
+			break
+			;;
+		*)
+			usage
+			;;
+	esac
+done
+
+[ -n "$state_dir" ] || usage
+[ -n "$marker" ] || usage
+[ "$#" -gt 0 ] || usage
+
+case "$state_dir" in
+	/*) ;;
+	*) echo "state-dir must be absolute: $state_dir" >&2; exit 64 ;;
+esac
+
+case "$marker" in
+	/*) ;;
+	*) echo "marker must be absolute: $marker" >&2; exit 64 ;;
+esac
+
+command -v nsenter >/dev/null 2>&1 || {
+	echo "nsenter is required for runtime control" >&2
+	exit 127
+}
+
+target_pid=""
+for proc in /proc/[0-9]*; do
+	[ -d "$proc/root$state_dir" ] || continue
+	[ -e "$proc/root$marker" ] || continue
+	target_pid="${proc#/proc/}"
+	break
+done
+
+if [ -z "$target_pid" ]; then
+	echo "could not find runtime process with state_dir=$state_dir marker=$marker" >&2
+	exit 69
+fi
+
+target_uid="$(awk '/^Uid:/ { print $2; exit }' "/proc/$target_pid/status")"
+target_gid="$(awk '/^Gid:/ { print $2; exit }' "/proc/$target_pid/status")"
+[ -n "$target_uid" ] || target_uid=0
+[ -n "$target_gid" ] || target_gid=0
+
+exec nsenter \
+	--target "$target_pid" \
+	--mount \
+	--uts \
+	--ipc \
+	--net \
+	--pid \
+	--root="/proc/$target_pid/root" \
+	--wdns="$workdir" \
+	--setgid="$target_gid" \
+	--setuid="$target_uid" \
+	-- "$@"

--- a/packages/cli/docker/runtime-sidecar-entrypoint.sh
+++ b/packages/cli/docker/runtime-sidecar-entrypoint.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command="${1:-serve}"
+
+ensure_dirs() {
+	install -d -m 0755 \
+		"${CLAWDI_HOST_POLICY_PATH%/*}" \
+		"${CLAWDI_RUNTIME_SOURCE_PATH%/*}" \
+		"${CLAWDI_SERVICE_STATE_DIR}" \
+		"${CLAWDI_RUN_DIR}" \
+		"${CLAWDI_SHARE_DIR}" \
+		"${HOME}" \
+		"${HOME}/clawdi"
+
+	if [ "$(id -u)" = "0" ]; then
+		chown -R "${CLAWDI_RUNTIME_USER}:${CLAWDI_RUNTIME_USER}" "${HOME}"
+	fi
+}
+
+write_host_policy() {
+	if [ -f "${CLAWDI_HOST_POLICY_PATH}" ]; then
+		return
+	fi
+
+	node <<'NODE'
+const fs = require("node:fs");
+
+const policyPath = process.env.CLAWDI_HOST_POLICY_PATH;
+const serviceState = process.env.CLAWDI_SERVICE_STATE_DIR;
+const runDir = process.env.CLAWDI_RUN_DIR;
+const home = process.env.HOME;
+
+const policy = {
+  schemaVersion: "clawdi.hostPolicy.v1",
+  mode: "hosted",
+  cliUpdateMode: "managed",
+  immutableShim: true,
+  deniedCommands: [
+    { command: "setup", reason: "hosted runtime uses controller-supplied desired state" },
+    { command: "teardown", reason: "hosted runtime lifecycle is controller-owned" },
+    { command: "update", reason: "runtime CLI updates are manifest-controlled" },
+    { command: "config set", reason: "hosted runtime config is manifest-controlled" },
+    { command: "config unset", reason: "hosted runtime config is manifest-controlled" }
+  ],
+  managedState: ["/etc/clawdi", serviceState, runDir],
+  writableState: [home, serviceState, runDir, "/tmp"],
+  systemWritableState: ["/etc/clawdi", serviceState, runDir],
+  userWritableState: [home, "/tmp"],
+  ordinaryUserDeniedState: ["/etc/clawdi", serviceState, runDir]
+};
+
+fs.writeFileSync(policyPath, `${JSON.stringify(policy, null, 2)}\n`, { mode: 0o644 });
+NODE
+}
+
+write_runtime_source() {
+	if [ -f "${CLAWDI_RUNTIME_SOURCE_PATH}" ] || [ -z "${CLAWDI_RUNTIME_MANIFEST_URL:-}" ]; then
+		return
+	fi
+
+	node <<'NODE'
+const fs = require("node:fs");
+
+const sourcePath = process.env.CLAWDI_RUNTIME_SOURCE_PATH;
+const url = process.env.CLAWDI_RUNTIME_MANIFEST_URL;
+const authEnv = process.env.CLAWDI_RUNTIME_AUTH_ENV || "CLAWDI_AUTH_TOKEN";
+
+const source = {
+  schemaVersion: "clawdi.runtimeSource.v1",
+  type: "http",
+  url,
+  auth: { type: "bearer-env", env: authEnv }
+};
+
+fs.writeFileSync(sourcePath, `${JSON.stringify(source, null, 2)}\n`, { mode: 0o644 });
+NODE
+}
+
+load_auth_token_file() {
+	local auth_env="${CLAWDI_RUNTIME_AUTH_ENV:-CLAWDI_AUTH_TOKEN}"
+	local file_env="${auth_env}_FILE"
+	local token_value="${!auth_env-}"
+	local token_file="${!file_env-}"
+
+	if [ -z "${token_value}" ] && [ -n "${token_file}" ]; then
+		if [ ! -r "${token_file}" ]; then
+			echo "auth token file is not readable: ${token_file}" >&2
+			exit 20
+		fi
+		token_value="$(tr -d '\r\n' < "${token_file}")"
+		export "${auth_env}=${token_value}"
+	fi
+}
+
+case "${command}" in
+	serve)
+		ensure_dirs
+		write_host_policy
+		write_runtime_source
+		load_auth_token_file
+		clawdi runtime init --non-interactive --json
+		exec supervisord -c "${CLAWDI_RUN_DIR}/supervisor/supervisord.conf"
+		;;
+	*)
+		exec "$@"
+		;;
+esac

--- a/packages/cli/src/runtime/bridge.test.ts
+++ b/packages/cli/src/runtime/bridge.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { createServer, type IncomingHttpHeaders } from "node:http";
+import { RUNTIME_BRIDGE_COOKIE, startRuntimeBridge } from "./bridge";
+
+const closers: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+	await Promise.allSettled(closers.splice(0).map((close) => close()));
+	delete process.env.CLAWDI_TEST_UPSTREAM_TOKEN;
+});
+
+function listen(server: ReturnType<typeof createServer>): Promise<number> {
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			server.off("error", reject);
+			const address = server.address();
+			if (typeof address !== "object" || !address) {
+				reject(new Error("server did not expose a TCP address"));
+				return;
+			}
+			resolve(address.port);
+		});
+	});
+}
+
+function closeHttpServer(server: ReturnType<typeof createServer>): Promise<void> {
+	return new Promise((resolve, reject) => {
+		server.close((error) => {
+			if (error) reject(error);
+			else resolve();
+		});
+	});
+}
+
+describe("runtime bridge", () => {
+	it("rejects env-backed upstream headers when the env value is missing", async () => {
+		await expect(
+			startRuntimeBridge({
+				token: "bridge-token",
+				surfaces: [
+					{
+						name: "control",
+						kind: "control-ui",
+						listenHost: "127.0.0.1",
+						listenPort: 0,
+						upstreamHost: "127.0.0.1",
+						upstreamPort: 1,
+						upstreamHeaders: {},
+						upstreamHeaderEnv: { Authorization: "CLAWDI_TEST_UPSTREAM_TOKEN" },
+					},
+				],
+			}),
+		).rejects.toThrow("Authorization requires CLAWDI_TEST_UPSTREAM_TOKEN");
+	});
+
+	it("rejects duplicate static and env-backed upstream header declarations", async () => {
+		process.env.CLAWDI_TEST_UPSTREAM_TOKEN = "Bearer env-token";
+		await expect(
+			startRuntimeBridge({
+				token: "bridge-token",
+				surfaces: [
+					{
+						name: "control",
+						kind: "control-ui",
+						listenHost: "127.0.0.1",
+						listenPort: 0,
+						upstreamHost: "127.0.0.1",
+						upstreamPort: 1,
+						upstreamHeaders: { Authorization: "Bearer static-token" },
+						upstreamHeaderEnv: { authorization: "CLAWDI_TEST_UPSTREAM_TOKEN" },
+					},
+				],
+			}),
+		).rejects.toThrow("duplicate upstream header declarations");
+	});
+
+	it("injects controlled upstream headers and strips bridge auth cookies", async () => {
+		const upstreamHeaders: IncomingHttpHeaders[] = [];
+		const upstream = createServer((req, res) => {
+			upstreamHeaders.push(req.headers);
+			res.writeHead(200, { "Content-Type": "text/plain" });
+			res.end("ok");
+		});
+		closers.push(() => closeHttpServer(upstream));
+		const upstreamPort = await listen(upstream);
+		process.env.CLAWDI_TEST_UPSTREAM_TOKEN = "Bearer env-token";
+
+		const bridge = await startRuntimeBridge({
+			token: "bridge-token",
+			surfaces: [
+				{
+					name: "control",
+					kind: "control-ui",
+					listenHost: "127.0.0.1",
+					listenPort: 0,
+					upstreamHost: "127.0.0.1",
+					upstreamPort,
+					upstreamHeaders: { "X-Controlled": "fixed" },
+					upstreamHeaderEnv: { Authorization: "CLAWDI_TEST_UPSTREAM_TOKEN" },
+				},
+			],
+		});
+		closers.push(() => bridge.close());
+
+		const response = await fetch(`http://127.0.0.1:${bridge.surfaces[0]?.listenPort}/ui`, {
+			headers: {
+				Authorization: "Bearer client-token",
+				Cookie: `${RUNTIME_BRIDGE_COOKIE}=bridge-token; theme=dark`,
+				"X-Controlled": "client",
+				"X-Forwarded-For": "198.51.100.1",
+			},
+		});
+
+		expect(await response.text()).toBe("ok");
+		const headers = upstreamHeaders[0];
+		expect(headers?.authorization).toBe("Bearer env-token");
+		expect(headers?.["x-controlled"]).toBe("fixed");
+		expect(headers?.cookie).toBe("theme=dark");
+		expect(headers?.["x-forwarded-for"]).toBeUndefined();
+	});
+});

--- a/packages/cli/src/runtime/bridge.ts
+++ b/packages/cli/src/runtime/bridge.ts
@@ -27,6 +27,8 @@ export interface RuntimeBridgeSurface {
 	listenPort: number;
 	upstreamHost: string;
 	upstreamPort: number;
+	upstreamHeaders: Record<string, string>;
+	upstreamHeaderEnv: Record<string, string>;
 }
 
 export interface RuntimeBridgeServer {
@@ -186,6 +188,8 @@ function resolveRuntimeBridgeSurfaceInputs(
 			listenHost: parsed.data.listenHost?.trim() || defaultListenHost,
 			upstreamHost: parsed.data.upstreamHost.trim(),
 		};
+		assertNoDuplicateUpstreamHeaders(surface, index);
+		assertUpstreamHeaderEnvValues(surface, index);
 		const key = `${surface.listenHost}:${surface.listenPort}`;
 		if (surface.listenPort !== 0 && seen.has(key)) {
 			throw new Error(`duplicate runtime bridge listen address: ${key}`);
@@ -193,6 +197,33 @@ function resolveRuntimeBridgeSurfaceInputs(
 		if (surface.listenPort !== 0) seen.add(key);
 		return surface;
 	});
+}
+
+function assertNoDuplicateUpstreamHeaders(surface: RuntimeBridgeSurface, index: number): void {
+	const staticHeaders = new Set(
+		Object.keys(surface.upstreamHeaders).map((name) => name.toLowerCase()),
+	);
+	const duplicates = Object.keys(surface.upstreamHeaderEnv).filter((name) =>
+		staticHeaders.has(name.toLowerCase()),
+	);
+	if (duplicates.length > 0) {
+		throw new Error(
+			`invalid runtime bridge surface ${index}: duplicate upstream header declarations: ${duplicates.join(
+				", ",
+			)}`,
+		);
+	}
+}
+
+function assertUpstreamHeaderEnvValues(surface: RuntimeBridgeSurface, index: number): void {
+	for (const [headerName, envName] of Object.entries(surface.upstreamHeaderEnv)) {
+		const value = process.env[envName]?.trim();
+		if (!value) {
+			throw new Error(
+				`invalid runtime bridge surface ${index}: ${headerName} requires ${envName} to be set`,
+			);
+		}
+	}
 }
 
 function createBridgeServer(
@@ -548,6 +579,10 @@ function buildProxyRequestHead(parsed: ParsedHttpRequest, surface: RuntimeBridge
 	const isUpgrade = isUpgradeRequest(parsed.headers);
 	const authority = upstreamAuthority(surface);
 	const origin = `http://${authority}`;
+	const upstreamHeaders = resolvedUpstreamHeaders(surface);
+	const controlledUpstreamHeaders = new Set(
+		Object.keys(upstreamHeaders).map((name) => name.toLowerCase()),
+	);
 	let originWritten = false;
 	let refererWritten = false;
 	const lines = [
@@ -561,6 +596,7 @@ function buildProxyRequestHead(parsed: ParsedHttpRequest, surface: RuntimeBridge
 		const lowerName = name.toLowerCase();
 		if (isProxyForwardingHeader(lowerName)) continue;
 		if (lowerName === "host" || HOP_BY_HOP_HEADERS.has(lowerName)) continue;
+		if (controlledUpstreamHeaders.has(lowerName)) continue;
 		if (lowerName === "origin") {
 			if (!originWritten) {
 				lines.push(`Origin: ${origin}`);
@@ -582,7 +618,28 @@ function buildProxyRequestHead(parsed: ParsedHttpRequest, surface: RuntimeBridge
 		}
 		lines.push(`${name}: ${value}`);
 	}
+	for (const [name, value] of Object.entries(upstreamHeaders)) {
+		if (value) lines.push(`${name}: ${value}`);
+	}
 	return `${lines.join("\r\n")}\r\n\r\n`;
+}
+
+function resolvedUpstreamHeaders(surface: RuntimeBridgeSurface): Record<string, string> {
+	const headers: Record<string, string> = {};
+	for (const [name, value] of Object.entries(surface.upstreamHeaders)) {
+		if (isForwardableUpstreamHeader(name)) headers[name] = value;
+	}
+	for (const [name, envName] of Object.entries(surface.upstreamHeaderEnv)) {
+		if (!isForwardableUpstreamHeader(name)) continue;
+		const value = process.env[envName]?.trim();
+		if (value) headers[name] = value;
+	}
+	return headers;
+}
+
+function isForwardableUpstreamHeader(name: string): boolean {
+	const lowerName = name.toLowerCase();
+	return lowerName !== "host" && !HOP_BY_HOP_HEADERS.has(lowerName);
 }
 
 function isProxyForwardingHeader(lowerName: string): boolean {

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -8,6 +8,13 @@ import {
 
 export const RUNTIME_DESIRED_STATE_SCHEMA_VERSION = "clawdi.runtimeDesiredState.v1";
 
+const runtimeTypeSchema = z.enum(["codex", "openclaw", "hermes"]);
+const runtimeTargetIdSchema = z
+	.string()
+	.min(1)
+	.max(64)
+	.regex(/^[a-z0-9][a-z0-9._-]*$/, "must be a lowercase runtime target id");
+
 export const OFFICIAL_INSTALL_URLS: Record<string, string> = {
 	openclaw: "https://openclaw.ai/install-cli.sh",
 	hermes: "https://hermes-agent.nousresearch.com/install.sh",
@@ -28,15 +35,84 @@ const installSchema = z
 	})
 	.strict();
 
+const envKeySchema = z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/);
+
+const runtimeExecutionCommandSchema = z
+	.object({
+		command: z.string().min(1),
+		args: z.array(z.string()).default([]),
+		env: z.record(envKeySchema, z.string()).default({}),
+		cwd: z.string().min(1).optional(),
+	})
+	.strict();
+
+const runtimeExternalMcpSchema = z
+	.object({
+		source: z.enum(["backend-direct", "sidecar-local"]).optional(),
+		url: z.string().url().optional(),
+		transport: z.enum(["streamable-http"]).default("streamable-http"),
+	})
+	.strict();
+
+const runtimeTerminalSchema = z
+	.object({
+		container: z.string().min(1).optional(),
+		user: z.string().min(1).optional(),
+		cwd: z.string().min(1).optional(),
+		env: z.record(envKeySchema, z.string()).default({}),
+	})
+	.strict();
+
+const runtimeExecutionSchema = z
+	.object({
+		mode: z.enum(["managed-process", "external"]).default("managed-process"),
+		home: z.string().min(1).optional(),
+		stateDir: z.string().min(1).optional(),
+		workspace: z.string().min(1).optional(),
+		controlCommand: runtimeExecutionCommandSchema.optional(),
+		versionCommand: runtimeExecutionCommandSchema.optional(),
+		mcp: runtimeExternalMcpSchema.optional(),
+		terminal: runtimeTerminalSchema.optional(),
+	})
+	.strict();
+
+const runtimeImageSchema = z
+	.object({
+		ref: z.string().min(1).optional(),
+		repository: z.string().min(1).optional(),
+		tag: z.string().min(1).optional(),
+		digest: z.string().min(1).optional(),
+		pullPolicy: z.enum(["IfNotPresent", "Always", "Never"]).optional(),
+	})
+	.strict();
+
+const runtimeVersionSchema = z
+	.object({
+		desired: z.string().min(1).optional(),
+		observed: z.string().min(1).optional(),
+		observedAt: z.string().min(1).optional(),
+		upgradeAvailable: z.boolean().optional(),
+		upgradePolicy: z.enum(["pinned", "track-channel", "manual"]).optional(),
+	})
+	.strict();
+
 const runtimeSchema = z
 	.object({
+		type: runtimeTypeSchema,
 		enabled: z.boolean(),
+		displayName: z.string().min(1).optional(),
+		environmentId: z.string().min(1).optional(),
+		image: runtimeImageSchema.optional(),
+		version: runtimeVersionSchema.optional(),
 		updateChannel: z.string().min(1).optional(),
+		execution: runtimeExecutionSchema.optional(),
 		install: installSchema.optional(),
 		run: runtimeRunSettingsSchema.optional(),
 		services: z.record(runtimeServiceNameSchema, runtimeRunSettingsSchema).default({}),
 	})
 	.strict();
+
+const runtimeTargetSchema = runtimeSchema;
 
 const cliPayloadPolicySchema = z
 	.object({
@@ -54,7 +130,8 @@ export const DEFAULT_CLAWDI_CLI_POLICY = {
 
 const liveSyncAgentSchema = z
 	.object({
-		agentType: runtimeNameSchema,
+		agentType: runtimeTypeSchema,
+		agentId: runtimeTargetIdSchema,
 		environmentId: z.string().min(1),
 	})
 	.strict();
@@ -72,6 +149,11 @@ const runtimeBridgeSurfaceNameSchema = z
 	.min(1)
 	.max(64)
 	.regex(/^[a-z0-9][a-z0-9._-]*$/, "must be a lowercase surface id");
+const httpHeaderNameSchema = z
+	.string()
+	.min(1)
+	.max(128)
+	.regex(/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/, "must be a valid HTTP header name");
 
 export const runtimeBridgeSurfaceSchema = z
 	.object({
@@ -81,6 +163,8 @@ export const runtimeBridgeSurfaceSchema = z
 		listenPort: tcpPortSchema,
 		upstreamHost: z.string().min(1).default("127.0.0.1"),
 		upstreamPort: tcpPortSchema,
+		upstreamHeaders: z.record(httpHeaderNameSchema, z.string()).default({}),
+		upstreamHeaderEnv: z.record(httpHeaderNameSchema, envKeySchema).default({}),
 	})
 	.strict();
 
@@ -116,11 +200,12 @@ const runtimeDesiredStateShape = {
 		})
 		.strict(),
 	clawdiCli: cliPayloadPolicySchema.optional(),
-	runtimes: z.record(runtimeNameSchema, runtimeSchema),
+	runtimes: z.record(runtimeNameSchema, runtimeSchema).default({}),
 	bridge: runtimeBridgeSchema.optional(),
 	projection: runtimeProjectionSchema.optional(),
 	mitmProfiles: mitmProfileInputBundleSchema.optional(),
 	liveSync: liveSyncSchema.optional(),
+	runtimeTargets: z.record(runtimeTargetIdSchema, runtimeTargetSchema).default({}),
 	recovery: z
 		.object({
 			cacheManifest: z.boolean().optional(),
@@ -147,19 +232,28 @@ const hostedRuntimeInstallSchema = z
 
 const hostedRuntimeEntrySchema = z
 	.object({
+		type: runtimeTypeSchema,
 		enabled: z.boolean(),
+		displayName: z.string().min(1).optional(),
+		environmentId: z.string().min(1).optional(),
+		image: runtimeImageSchema.optional(),
+		version: runtimeVersionSchema.optional(),
 		install: hostedRuntimeInstallSchema.optional(),
 		run: runtimeRunSettingsSchema.optional(),
 		services: z.record(runtimeServiceNameSchema, runtimeRunSettingsSchema).default({}),
 		paths: z
 			.object({
 				home: z.string().min(1).optional(),
+				stateDir: z.string().min(1).optional(),
 				workspace: z.string().min(1).optional(),
 			})
 			.passthrough()
 			.optional(),
+		execution: runtimeExecutionSchema.optional(),
 	})
 	.passthrough();
+
+const hostedRuntimeTargetEntrySchema = hostedRuntimeEntrySchema;
 
 const hostedProviderAuthSchema = z
 	.object({
@@ -199,7 +293,8 @@ export const hostedRuntimeManifestSchema = z
 				path: ["apiUrl"],
 			}),
 		clawdiCli: cliPayloadPolicySchema.optional(),
-		runtimes: z.record(runtimeNameSchema, hostedRuntimeEntrySchema),
+		runtimes: z.record(runtimeNameSchema, hostedRuntimeEntrySchema).default({}),
+		runtimeTargets: z.record(runtimeTargetIdSchema, hostedRuntimeTargetEntrySchema).default({}),
 		bridge: runtimeBridgeSchema.optional(),
 		providers: z
 			.record(
@@ -241,7 +336,10 @@ export const hostedRuntimeManifestResponseSchema = z
 
 export type RuntimeManifest = z.output<typeof manifestSchema>;
 export type RuntimeInstall = z.infer<typeof installSchema>;
+export type RuntimeExecution = z.output<typeof runtimeExecutionSchema>;
+export type RuntimeExecutionCommand = z.output<typeof runtimeExecutionCommandSchema>;
 export type HostedRuntimeManifest = z.infer<typeof hostedRuntimeManifestSchema>;
 export type LiveSyncAgent = z.infer<typeof liveSyncAgentSchema>;
+export type RuntimeType = z.infer<typeof runtimeTypeSchema>;
 export type RuntimeBridgeSurfaceInput = z.input<typeof runtimeBridgeSurfaceSchema>;
 export type RuntimeBridgeSurfaceSpec = z.output<typeof runtimeBridgeSurfaceSchema>;

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -43,6 +43,7 @@ describe("runtime manifest services", () => {
 			controlPlane: { apiUrl: "https://cloud-api.example.test" },
 			runtimes: {
 				hermes: {
+					type: "hermes",
 					enabled: true,
 					run: runSettings("hermes", ["gateway", "run"]),
 					services: {
@@ -57,6 +58,7 @@ describe("runtime manifest services", () => {
 					},
 				},
 			},
+			runtimeTargets: {},
 			recovery: {},
 		};
 		const load: RuntimeManifestLoad = {

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -11,6 +11,7 @@ import {
 	OFFICIAL_INSTALL_URLS,
 	RUNTIME_DESIRED_STATE_SCHEMA_VERSION,
 	type RuntimeManifest,
+	type RuntimeType,
 } from "./manifest-contract";
 import type { RuntimePaths } from "./paths";
 import { isSupportedRuntimeName, type RuntimeRunSettings } from "./run-config";
@@ -153,12 +154,23 @@ function zodErrors(error: z.ZodError): string[] {
 }
 
 function parseManifest(value: unknown): RuntimeManifest {
-	return manifestSchema.parse(value);
+	return normalizeRuntimeManifestTargets(manifestSchema.parse(value));
 }
 
 function parseManifestSafe(value: unknown): RuntimeManifest | null {
 	const result = manifestSchema.safeParse(value);
-	return result.success ? result.data : null;
+	return result.success ? normalizeRuntimeManifestTargets(result.data) : null;
+}
+
+function normalizeRuntimeManifestTargets(manifest: RuntimeManifest): RuntimeManifest {
+	if (!manifest.runtimeTargets || Object.keys(manifest.runtimeTargets).length === 0) {
+		return manifest;
+	}
+	const runtimes = { ...manifest.runtimes };
+	for (const [id, target] of Object.entries(manifest.runtimeTargets)) {
+		runtimes[id] = { ...target, type: target.type };
+	}
+	return { ...manifest, runtimes };
 }
 
 function normalizeManifestPayload(value: unknown): {
@@ -166,7 +178,7 @@ function normalizeManifestPayload(value: unknown): {
 	secretValues?: Record<string, string>;
 } {
 	const internal = manifestSchema.safeParse(value);
-	if (internal.success) return { manifest: internal.data };
+	if (internal.success) return { manifest: normalizeRuntimeManifestTargets(internal.data) };
 
 	const hostedResponse = hostedRuntimeManifestResponseSchema.safeParse(value);
 	if (hostedResponse.success) {
@@ -472,6 +484,40 @@ function runtimeFetchFailureStage(error: unknown): "network" | "auth" {
 function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): RuntimeManifest {
 	const home = hosted.system?.home || "/home/clawdi";
 	const workspaceRoot = hosted.system?.workspace || join(home, "clawdi");
+	const targets = hostedRuntimeTargetEntries(hosted);
+	const defaultCliPolicy = defaultClawdiCliPolicy();
+	const runtimeEntries = targets.map(({ id, type, runtime }) => {
+		const execution = hostedRuntimeExecution(type, runtime, home);
+		const external = execution?.mode === "external";
+		const entry: RuntimeManifest["runtimes"][string] = {
+			type,
+			enabled: runtime.enabled,
+			displayName: runtime.displayName,
+			environmentId: runtime.environmentId,
+			image: runtime.image,
+			version: runtime.version,
+			updateChannel: runtime.install?.channel,
+			install:
+				runtime.enabled && !external && OFFICIAL_INSTALL_URLS[type]
+					? {
+							authority: "official" as const,
+							method: "official-installer" as const,
+							url: OFFICIAL_INSTALL_URLS[type] ?? "",
+							home: runtime.paths?.home || home,
+							args: runtime.install?.args ?? OFFICIAL_INSTALL_ARGS[type] ?? [],
+						}
+					: undefined,
+			execution,
+			run: hostedRuntimeRunSettings(runtime.run, runtime.paths?.workspace, workspaceRoot),
+			services: Object.fromEntries(
+				Object.entries(runtime.services ?? {}).map(([service, run]) => [
+					service,
+					hostedRuntimeServiceRunSettings(run, runtime.paths?.workspace, workspaceRoot),
+				]),
+			),
+		};
+		return [id, entry] as const;
+	});
 	return {
 		schemaVersion: RUNTIME_DESIRED_STATE_SCHEMA_VERSION,
 		deploymentId: hosted.deploymentId,
@@ -486,37 +532,13 @@ function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): Runtime
 		},
 		clawdiCli: hosted.clawdiCli
 			? {
-					...DEFAULT_CLAWDI_CLI_POLICY,
+					...defaultCliPolicy,
 					...hosted.clawdiCli,
-					source: hosted.clawdiCli.source ?? DEFAULT_CLAWDI_CLI_POLICY.source,
+					source: hosted.clawdiCli.source ?? defaultCliPolicy.source,
 				}
-			: { ...DEFAULT_CLAWDI_CLI_POLICY },
-		runtimes: Object.fromEntries(
-			Object.entries(hosted.runtimes).map(([name, runtime]) => [
-				name,
-				{
-					enabled: runtime.enabled,
-					updateChannel: runtime.install?.channel,
-					install:
-						runtime.enabled && OFFICIAL_INSTALL_URLS[name]
-							? {
-									authority: "official" as const,
-									method: "official-installer" as const,
-									url: OFFICIAL_INSTALL_URLS[name] ?? "",
-									home: runtime.paths?.home || home,
-									args: runtime.install?.args ?? OFFICIAL_INSTALL_ARGS[name] ?? [],
-								}
-							: undefined,
-					run: hostedRuntimeRunSettings(runtime.run, runtime.paths?.workspace, workspaceRoot),
-					services: Object.fromEntries(
-						Object.entries(runtime.services ?? {}).map(([service, run]) => [
-							service,
-							hostedRuntimeServiceRunSettings(run, runtime.paths?.workspace, workspaceRoot),
-						]),
-					),
-				},
-			]),
-		),
+			: defaultCliPolicy,
+		runtimes: Object.fromEntries(runtimeEntries),
+		runtimeTargets: Object.fromEntries(runtimeEntries),
 		bridge: hosted.bridge,
 		projection: {
 			sourceSchemaVersion: hosted.schemaVersion,
@@ -532,6 +554,58 @@ function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): Runtime
 			allowOfflineBoot: hosted.recovery?.allowOfflineBoot ?? true,
 		},
 	};
+}
+
+function defaultClawdiCliPolicy(): NonNullable<RuntimeManifest["clawdiCli"]> {
+	const packageSpec = process.env.CLAWDI_RUNTIME_DEFAULT_CLI_PACKAGE_SPEC?.trim();
+	if (!packageSpec) return { ...DEFAULT_CLAWDI_CLI_POLICY };
+	return {
+		...DEFAULT_CLAWDI_CLI_POLICY,
+		packageSpec,
+	};
+}
+
+function hostedRuntimeTargetEntries(hosted: HostedRuntimeManifest): Array<{
+	id: string;
+	type: RuntimeType;
+	runtime: HostedRuntimeManifest["runtimes"][string];
+}> {
+	const targets = new Map<
+		string,
+		{ id: string; type: RuntimeType; runtime: HostedRuntimeManifest["runtimes"][string] }
+	>();
+	for (const [name, runtime] of Object.entries(hosted.runtimes)) {
+		targets.set(name, { id: name, type: runtime.type, runtime });
+	}
+	for (const [id, runtime] of Object.entries(hosted.runtimeTargets ?? {})) {
+		targets.set(id, { id, type: runtime.type, runtime });
+	}
+	return [...targets.values()].sort((left, right) => left.id.localeCompare(right.id));
+}
+
+function hostedRuntimeExecution(
+	type: RuntimeType,
+	runtime: HostedRuntimeManifest["runtimes"][string],
+	defaultHome: string,
+): RuntimeManifest["runtimes"][string]["execution"] | undefined {
+	const explicit = runtime.execution;
+	if (!explicit) return undefined;
+	const home = explicit.home ?? runtime.paths?.home ?? defaultHome;
+	const workspace = explicit.workspace ?? runtime.paths?.workspace;
+	const stateDir =
+		explicit.stateDir ?? runtime.paths?.stateDir ?? defaultExternalStateDir(type, home);
+	return {
+		...explicit,
+		home,
+		...(stateDir ? { stateDir } : {}),
+		...(workspace ? { workspace } : {}),
+	};
+}
+
+function defaultExternalStateDir(type: RuntimeType, home: string): string | undefined {
+	if (type === "openclaw") return join(home, ".openclaw");
+	if (type === "hermes") return home;
+	return undefined;
 }
 
 function hostedRuntimeRunSettings(
@@ -634,8 +708,70 @@ function validateManifestSemantics(manifest: RuntimeManifest, paths: RuntimePath
 	}
 	for (const [name, runtime] of Object.entries(manifest.runtimes)) {
 		if (!runtime.enabled) continue;
+		const type = runtime.type;
+		const executionMode = runtime.execution?.mode ?? "managed-process";
+		if (executionMode === "external") {
+			if (runtime.install) {
+				errors.push(
+					`runtime ${name} uses external execution and must not declare install metadata`,
+				);
+			}
+			if (runtime.execution?.home && !isAbsolute(runtime.execution.home)) {
+				errors.push(`runtime ${name} execution.home must be absolute`);
+			}
+			if (runtime.execution?.stateDir && !isAbsolute(runtime.execution.stateDir)) {
+				errors.push(`runtime ${name} execution.stateDir must be absolute`);
+			}
+			if (runtime.execution?.workspace && !isAbsolute(runtime.execution.workspace)) {
+				errors.push(`runtime ${name} execution.workspace must be absolute`);
+			}
+			if (
+				runtime.execution?.controlCommand?.cwd &&
+				!isAbsolute(runtime.execution.controlCommand.cwd)
+			) {
+				errors.push(`runtime ${name} execution.controlCommand.cwd must be absolute`);
+			}
+			if (runtime.execution?.mcp?.url) {
+				const url = new URL(runtime.execution.mcp.url);
+				if (runtime.execution.mcp.source === "sidecar-local" && url.protocol !== "http:") {
+					errors.push(`runtime ${name} execution.mcp.url must use http:// for sidecar-local MCP`);
+				}
+				if (runtime.execution.mcp.source === undefined) {
+					errors.push(
+						`runtime ${name} execution.mcp.source is required when execution.mcp.url is set`,
+					);
+				}
+			}
+			if (runtime.execution?.mcp?.source === "sidecar-local" && !runtime.execution.mcp.url) {
+				errors.push(`runtime ${name} sidecar-local MCP requires execution.mcp.url`);
+			}
+			if (
+				runtime.execution?.mcp?.transport &&
+				runtime.execution.mcp.transport !== "streamable-http"
+			) {
+				errors.push(`runtime ${name} execution.mcp.transport must be streamable-http`);
+			}
+			if (type === "openclaw" && !runtime.execution?.stateDir) {
+				errors.push(`runtime ${name} external execution requires execution.stateDir`);
+			}
+			if (
+				type === "openclaw" &&
+				externalOpenClawProjectionDeclared(name, manifest) &&
+				!runtime.execution?.controlCommand
+			) {
+				errors.push(
+					`runtime ${name} external OpenClaw projection requires execution.controlCommand`,
+				);
+			}
+			if (type === "hermes" && !runtime.execution?.home && !runtime.execution?.stateDir) {
+				errors.push(
+					`runtime ${name} external execution requires execution.home or execution.stateDir`,
+				);
+			}
+			continue;
+		}
 		const runCommand = runtime.run?.command?.trim();
-		if (!isSupportedRuntimeName(name)) {
+		if (!type || !isSupportedRuntimeName(type)) {
 			if (runtime.install) {
 				errors.push(
 					`runtime ${name} install metadata is not supported by this Clawdi CLI; provide run.command or upgrade the CLI`,
@@ -653,7 +789,7 @@ function validateManifestSemantics(manifest: RuntimeManifest, paths: RuntimePath
 			continue;
 		}
 		if (!runtime.install) continue;
-		const expectedUrl = OFFICIAL_INSTALL_URLS[name];
+		const expectedUrl = OFFICIAL_INSTALL_URLS[type];
 		if (runtime.install.url !== expectedUrl) {
 			errors.push(`runtime ${name} must use official installer ${expectedUrl}`);
 		}
@@ -671,6 +807,16 @@ function validateManifestSemantics(manifest: RuntimeManifest, paths: RuntimePath
 		}
 	}
 	return errors;
+}
+
+function externalOpenClawProjectionDeclared(name: string, manifest: RuntimeManifest): boolean {
+	if (!manifest.projection) return false;
+	const providers = manifest.projection.providers;
+	if (providers && Object.hasOwn(providers, name)) return true;
+	if (manifest.projection.channels !== undefined) return true;
+	if (manifest.projection.mcp !== undefined) return true;
+	if (manifest.projection.tools !== undefined) return true;
+	return false;
 }
 
 export function runtimeManifestFixturePath(): string | undefined {

--- a/packages/cli/src/runtime/manifest.test.ts
+++ b/packages/cli/src/runtime/manifest.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runtimeCommandShimScript } from "./manifest";
+import type { RuntimePaths } from "./paths";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function makeTempDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "clawdi-runtime-shim-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function executable(path: string, content: string): void {
+	writeFileSync(path, content, { mode: 0o755 });
+	chmodSync(path, 0o755);
+}
+
+function minimalPaths(serviceStateRoot: string, cliManagedBin: string): RuntimePaths {
+	return {
+		mode: "hosted",
+		userHome: "/tmp/clawdi-user",
+		clawdiHome: "/tmp/clawdi-home",
+		localConfig: "/tmp/clawdi-home/config.json",
+		localAuth: "/tmp/clawdi-home/auth.json",
+		localPendingAuth: "/tmp/clawdi-home/pending-auth.json",
+		localEnvironments: "/tmp/clawdi-home/environments",
+		serveState: "/tmp/clawdi-home/serve",
+		imageShim: "/usr/local/bin/clawdi",
+		hostPolicy: "/etc/clawdi/host-policy.json",
+		runtimeSource: "/etc/clawdi/runtime-source.json",
+		shareRoot: "/usr/share/clawdi",
+		serviceStateRoot,
+		managedConfig: join(serviceStateRoot, "config", "clawdi.json"),
+		syncState: join(serviceStateRoot, "sync", "runtimes.json"),
+		cliShim: "/usr/local/bin/clawdi",
+		cliManagedBin,
+		cliNpmPrefix: join(serviceStateRoot, "npm"),
+		cliNpmCache: join(serviceStateRoot, "npm-cache"),
+		cliBootstrapStatus: join(serviceStateRoot, "status", "cli-bootstrap.json"),
+		providerHealthStatus: join(serviceStateRoot, "status", "provider-health.json"),
+		cacheRoot: join(serviceStateRoot, "cache"),
+		manifestLastGood: join(serviceStateRoot, "cache", "manifest.last-good.json"),
+		manifestEtag: join(serviceStateRoot, "cache", "manifest.etag"),
+		channelsEtag: join(serviceStateRoot, "cache", "channels.etag"),
+		runConfigRoot: join(serviceStateRoot, "config", "run"),
+		mitmProfileRoot: join(serviceStateRoot, "config", "mitm"),
+		mitmProfileBundle: join(serviceStateRoot, "config", "mitm", "profiles.json"),
+		supervisorRoot: join(serviceStateRoot, "supervisor"),
+		supervisorConfig: join(serviceStateRoot, "supervisor", "supervisord.conf"),
+		bootRoot: join(serviceStateRoot, "boot"),
+		bootStatus: join(serviceStateRoot, "cache", "boot-status.json"),
+		runtimeWatchStatus: join(serviceStateRoot, "status", "runtime-watch.json"),
+		cloudStatus: join(serviceStateRoot, "boot", "status.json"),
+		cloudResult: join(serviceStateRoot, "boot", "result.json"),
+		instanceRoot: join(serviceStateRoot, "instances"),
+		installInventory: join(serviceStateRoot, "install-inventory"),
+		projectionRoot: join(serviceStateRoot, "config", "projections"),
+		runRoot: join(serviceStateRoot, "run"),
+		managedSecretRoot: join(serviceStateRoot, "run", "secrets"),
+		managedSecretFile: join(serviceStateRoot, "run", "secrets", "runtime-secrets.json"),
+		daemonAuthToken: join(serviceStateRoot, "run", "secrets", "auth-token"),
+		instanceData: join(serviceStateRoot, "run", "instance-data.json"),
+		sensitiveInstanceData: join(serviceStateRoot, "run", "instance-data-sensitive.json"),
+		workspaceRoot: "/tmp/clawdi-user/clawdi",
+	};
+}
+
+describe("runtime command shim", () => {
+	it("lets OpenClaw's official update CLI bypass the runtime wrapper", () => {
+		const root = makeTempDir();
+		const shimDir = join(root, "service", "bin");
+		const realBin = join(root, "real-bin");
+		const logPath = join(root, "calls.log");
+		mkdirSync(shimDir, { recursive: true });
+		mkdirSync(realBin, { recursive: true });
+		executable(join(realBin, "openclaw"), `#!/usr/bin/env sh\necho "openclaw:$*" >> ${logPath}\n`);
+		executable(join(root, "clawdi"), `#!/usr/bin/env sh\necho "clawdi:$*" >> ${logPath}\n`);
+		const shimPath = join(shimDir, "openclaw");
+		writeFileSync(
+			shimPath,
+			runtimeCommandShimScript(minimalPaths(join(root, "service"), join(root, "clawdi"))),
+			{ mode: 0o755 },
+		);
+		chmodSync(shimPath, 0o755);
+
+		const env = { ...process.env, PATH: [shimDir, realBin, process.env.PATH ?? ""].join(":") };
+		expect(spawnSync(shimPath, ["update", "--dry-run"], { env }).status).toBe(0);
+		expect(spawnSync(shimPath, ["tui"], { env }).status).toBe(0);
+
+		expect(readFileSync(logPath, "utf8").trim().split("\n")).toEqual([
+			"openclaw:update --dry-run",
+			"clawdi:run -- openclaw tui",
+		]);
+	});
+});

--- a/packages/cli/src/runtime/manifest.test.ts
+++ b/packages/cli/src/runtime/manifest.test.ts
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runtimeCommandShimScript } from "./manifest";
+import { convergeRuntimeManifest, loadRuntimeManifest, runtimeCommandShimScript } from "./manifest";
 import type { RuntimePaths } from "./paths";
 
 const tempDirs: string[] = [];
@@ -69,6 +69,7 @@ function minimalPaths(serviceStateRoot: string, cliManagedBin: string): RuntimeP
 		managedSecretRoot: join(serviceStateRoot, "run", "secrets"),
 		managedSecretFile: join(serviceStateRoot, "run", "secrets", "runtime-secrets.json"),
 		daemonAuthToken: join(serviceStateRoot, "run", "secrets", "auth-token"),
+		mcpHttpAuthToken: join(serviceStateRoot, "run", "secrets", "mcp-http-token"),
 		instanceData: join(serviceStateRoot, "run", "instance-data.json"),
 		sensitiveInstanceData: join(serviceStateRoot, "run", "instance-data-sensitive.json"),
 		workspaceRoot: "/tmp/clawdi-user/clawdi",
@@ -101,5 +102,666 @@ describe("runtime command shim", () => {
 			"openclaw:update --dry-run",
 			"clawdi:run -- openclaw tui",
 		]);
+	});
+});
+
+describe("external runtime manifest mode", () => {
+	it("normalizes hosted runtimeTargets into target-id keyed runtimes", async () => {
+		const root = makeTempDir();
+		const manifestPath = join(root, "hosted-runtime-targets.json");
+		writeFileSync(
+			manifestPath,
+			`${JSON.stringify({
+				manifest: {
+					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					deploymentId: "hdep_targets",
+					environmentId: "env_targets",
+					instanceId: "inst_targets",
+					generation: 1,
+					issuedAt: "2026-07-01T00:00:00Z",
+					system: {
+						home: "/home/clawdi",
+						workspace: "/home/clawdi/clawdi",
+					},
+					controlPlane: {
+						cloudApiUrl: "https://api.example.test",
+					},
+					runtimes: {},
+					runtimeTargets: {
+						"openclaw-a": {
+							type: "openclaw",
+							enabled: true,
+							environmentId: "env-openclaw-a",
+							execution: {
+								mode: "external",
+								stateDir: "/state/openclaw-a",
+							},
+						},
+						"openclaw-b": {
+							type: "openclaw",
+							enabled: true,
+							environmentId: "env-openclaw-b",
+							execution: {
+								mode: "external",
+								stateDir: "/state/openclaw-b",
+							},
+						},
+						"hermes-a": {
+							type: "hermes",
+							enabled: true,
+							environmentId: "env-hermes-a",
+							execution: {
+								mode: "external",
+								home: "/home/hermes-a",
+							},
+						},
+					},
+				},
+				secretValues: {},
+			})}\n`,
+		);
+
+		const loaded = await loadRuntimeManifest(
+			minimalPaths(join(root, "service"), join(root, "clawdi")),
+			{ manifestPath },
+		);
+
+		expect("manifest" in loaded).toBe(true);
+		if (!("manifest" in loaded)) return;
+		expect(Object.keys(loaded.manifest.runtimes).sort()).toEqual([
+			"hermes-a",
+			"openclaw-a",
+			"openclaw-b",
+		]);
+		expect(loaded.manifest.runtimes["openclaw-a"]?.type).toBe("openclaw");
+		expect(loaded.manifest.runtimes["openclaw-b"]?.execution?.stateDir).toBe("/state/openclaw-b");
+		expect(loaded.manifest.runtimeTargets["hermes-a"]?.type).toBe("hermes");
+	});
+
+	it("rejects liveSync agentType values that are not runtime families", async () => {
+		const root = makeTempDir();
+		const manifestPath = join(root, "hosted-runtime-livesync-type.json");
+		writeFileSync(
+			manifestPath,
+			`${JSON.stringify({
+				manifest: {
+					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					deploymentId: "hdep_livesync",
+					environmentId: "env_livesync",
+					instanceId: "inst_livesync",
+					generation: 1,
+					issuedAt: "2026-07-01T00:00:00Z",
+					controlPlane: {
+						cloudApiUrl: "https://api.example.test",
+					},
+					runtimeTargets: {
+						"openclaw-a": {
+							type: "openclaw",
+							enabled: true,
+							environmentId: "env-openclaw-a",
+						},
+					},
+					liveSync: {
+						enabled: true,
+						agents: [
+							{
+								agentType: "openclaw-a",
+								agentId: "openclaw-a",
+								environmentId: "env-openclaw-a",
+							},
+						],
+					},
+				},
+				secretValues: {},
+			})}\n`,
+		);
+
+		const loaded = await loadRuntimeManifest(
+			minimalPaths(join(root, "service"), join(root, "clawdi")),
+			{ manifestPath },
+		);
+
+		expect("mode" in loaded && loaded.mode).toBe("manifest-rejected");
+		expect("errors" in loaded ? loaded.errors.join("\n") : "").toContain(
+			"manifest.liveSync.agents.0.agentType",
+		);
+	});
+
+	it("normalizes hosted external runtimes without installer metadata", async () => {
+		const root = makeTempDir();
+		const manifestPath = join(root, "hosted-runtime.json");
+		writeFileSync(
+			manifestPath,
+			`${JSON.stringify({
+				manifest: {
+					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					deploymentId: "hdep_external",
+					environmentId: "env_external",
+					instanceId: "inst_external",
+					generation: 1,
+					issuedAt: "2026-07-01T00:00:00Z",
+					system: {
+						home: "/home/clawdi",
+						workspace: "/home/clawdi/clawdi",
+					},
+					controlPlane: {
+						cloudApiUrl: "https://api.example.test",
+					},
+					runtimes: {
+						openclaw: {
+							type: "openclaw",
+							enabled: true,
+							install: { source: "official" },
+							execution: { mode: "external" },
+							paths: {
+								home: "/home/node",
+								stateDir: "/home/node/.openclaw",
+								workspace: "/home/node/.openclaw/workspace",
+							},
+						},
+					},
+				},
+				secretValues: {},
+			})}\n`,
+		);
+
+		const loaded = await loadRuntimeManifest(
+			minimalPaths(join(root, "service"), join(root, "clawdi")),
+			{ manifestPath },
+		);
+
+		expect("manifest" in loaded).toBe(true);
+		if (!("manifest" in loaded)) return;
+		const runtime = loaded.manifest.runtimes.openclaw;
+		expect(runtime.install).toBeUndefined();
+		expect(runtime.execution).toEqual({
+			mode: "external",
+			home: "/home/node",
+			stateDir: "/home/node/.openclaw",
+			workspace: "/home/node/.openclaw/workspace",
+		});
+	});
+
+	it("keeps external runtimes out of sidecar run configs and supervisor programs", () => {
+		const root = makeTempDir();
+		const serviceRoot = join(root, "service");
+		const paths = minimalPaths(serviceRoot, join(root, "clawdi"));
+		const previousAuthToken = process.env.CLAWDI_AUTH_TOKEN;
+		process.env.CLAWDI_AUTH_TOKEN = "test-runtime-token";
+		try {
+			const result = convergeRuntimeManifest(
+				{
+					manifest: {
+						schemaVersion: "clawdi.runtimeDesiredState.v1",
+						deploymentId: "hdep_external",
+						environmentId: "env_external",
+						instanceId: "inst_external",
+						generation: 1,
+						issuedAt: "2026-07-01T00:00:00Z",
+						workspaceRoot: join(root, "workspace"),
+						controlPlane: { apiUrl: "https://api.example.test" },
+						runtimes: {
+							openclaw: {
+								type: "openclaw",
+								enabled: true,
+								services: {},
+								execution: {
+									mode: "external",
+									home: "/home/node",
+									stateDir: "/home/node/.openclaw",
+									workspace: "/home/node/.openclaw/workspace",
+								},
+							},
+						},
+						liveSync: {
+							enabled: true,
+							agents: [
+								{ agentType: "openclaw", agentId: "openclaw", environmentId: "env_external" },
+							],
+						},
+						runtimeTargets: {},
+						recovery: {},
+					},
+					source: "fixture-file",
+					sourcePath: "test",
+					offline: false,
+				},
+				paths,
+			);
+
+			expect(result.installErrors).toEqual([]);
+			expect(result.outputs.runConfigs).toEqual([]);
+			expect(readFileSync(paths.supervisorConfig, "utf8")).not.toContain(
+				"[program:clawdi-openclaw]",
+			);
+			expect(readFileSync(paths.supervisorConfig, "utf8")).not.toContain(
+				"[program:clawdi-runtime-bridge]",
+			);
+			expect(readFileSync(paths.supervisorConfig, "utf8")).toContain(
+				'OPENCLAW_STATE_DIR="/home/node/.openclaw"',
+			);
+			expect(readFileSync(join(paths.installInventory, "openclaw.json"), "utf8")).toContain(
+				'"status": "external"',
+			);
+			expect(readFileSync(paths.syncState, "utf8")).toContain('"executionMode": "external"');
+			expect(readFileSync(join(paths.localEnvironments, "openclaw.json"), "utf8")).toContain(
+				'"agentType": "openclaw"',
+			);
+		} finally {
+			if (previousAuthToken === undefined) delete process.env.CLAWDI_AUTH_TOKEN;
+			else process.env.CLAWDI_AUTH_TOKEN = previousAuthToken;
+		}
+	});
+
+	it("projects external MCP directly to the backend by default", () => {
+		const root = makeTempDir();
+		const paths = minimalPaths(join(root, "service"), join(root, "clawdi"));
+		const controlPath = join(root, "agent-control");
+		const logPath = join(root, "agent-control.log");
+		executable(
+			controlPath,
+			`#!/usr/bin/env sh\nprintf '%s\\n' "$*" >> ${logPath}\ncat >/dev/null\n`,
+		);
+		const previousAuthToken = process.env.CLAWDI_AUTH_TOKEN;
+		process.env.CLAWDI_AUTH_TOKEN = "test-runtime-token";
+		try {
+			const result = convergeRuntimeManifest(
+				{
+					manifest: {
+						schemaVersion: "clawdi.runtimeDesiredState.v1",
+						deploymentId: "hdep_external",
+						environmentId: "env_external",
+						instanceId: "inst_external",
+						generation: 1,
+						issuedAt: "2026-07-01T00:00:00Z",
+						workspaceRoot: join(root, "workspace"),
+						controlPlane: { apiUrl: "https://api.example.test" },
+						runtimes: {
+							openclaw: {
+								type: "openclaw",
+								enabled: true,
+								services: {},
+								execution: {
+									mode: "external",
+									home: "/home/node",
+									stateDir: "/home/node/.openclaw",
+									controlCommand: { command: controlPath, args: [], env: {} },
+								},
+							},
+						},
+						projection: { mcp: {} },
+						runtimeTargets: {},
+						recovery: {},
+					},
+					source: "fixture-file",
+					sourcePath: "test",
+					offline: false,
+				},
+				paths,
+			);
+
+			expect(result.installErrors).toEqual([]);
+			const supervisor = readFileSync(paths.supervisorConfig, "utf8");
+			expect(supervisor).not.toContain("[program:clawdi-mcp-http]");
+			expect(result.outputs.mcpHttpAuthTokenFile).toBeNull();
+			const log = readFileSync(logPath, "utf8");
+			expect(log).toContain("mcp set clawdi");
+			expect(log).toContain('"url":"https://api.example.test/mcp/clawdi"');
+			expect(log).toContain('"transport":"streamable-http"');
+			expect(log).toContain('"Authorization":"Bearer test-runtime-token"');
+		} finally {
+			if (previousAuthToken === undefined) delete process.env.CLAWDI_AUTH_TOKEN;
+			else process.env.CLAWDI_AUTH_TOKEN = previousAuthToken;
+		}
+	});
+
+	it("starts sidecar MCP HTTP only for explicit sidecar-local MCP", () => {
+		const root = makeTempDir();
+		const paths = minimalPaths(join(root, "service"), join(root, "clawdi"));
+		const controlPath = join(root, "agent-control");
+		const logPath = join(root, "agent-control.log");
+		executable(
+			controlPath,
+			`#!/usr/bin/env sh\nprintf '%s\\n' "$*" >> ${logPath}\nprintf 'OPENCLAW_STATE_DIR=%s\\n' "$OPENCLAW_STATE_DIR" >> ${logPath}\ncat >/dev/null\n`,
+		);
+		const previousAuthToken = process.env.CLAWDI_AUTH_TOKEN;
+		process.env.CLAWDI_AUTH_TOKEN = "test-runtime-token";
+		try {
+			const result = convergeRuntimeManifest(
+				{
+					manifest: {
+						schemaVersion: "clawdi.runtimeDesiredState.v1",
+						deploymentId: "hdep_external",
+						environmentId: "env_external",
+						instanceId: "inst_external",
+						generation: 1,
+						issuedAt: "2026-07-01T00:00:00Z",
+						workspaceRoot: join(root, "workspace"),
+						controlPlane: { apiUrl: "https://api.example.test" },
+						runtimes: {
+							openclaw: {
+								type: "openclaw",
+								enabled: true,
+								services: {},
+								execution: {
+									mode: "external",
+									home: "/home/node",
+									stateDir: "/home/node/.openclaw",
+									controlCommand: { command: controlPath, args: [], env: {} },
+									mcp: {
+										source: "sidecar-local",
+										url: "http://clawdi-sidecar:8788/mcp",
+										transport: "streamable-http",
+									},
+								},
+							},
+						},
+						projection: { mcp: {} },
+						runtimeTargets: {},
+						recovery: {},
+					},
+					source: "fixture-file",
+					sourcePath: "test",
+					offline: false,
+				},
+				paths,
+			);
+
+			expect(result.installErrors).toEqual([]);
+			const supervisor = readFileSync(paths.supervisorConfig, "utf8");
+			expect(supervisor).toContain("[program:clawdi-mcp-http]");
+			expect(supervisor).toContain("clawdi mcp http");
+			expect(supervisor).toContain("--host");
+			expect(supervisor).toContain("0.0.0.0");
+			expect(supervisor).toContain("--port");
+			expect(supervisor).toContain("8788");
+			expect(supervisor).toContain("--path");
+			expect(supervisor).toContain("/mcp");
+			expect(supervisor).toContain("--auth-token-file");
+			expect(supervisor).toContain(paths.mcpHttpAuthToken);
+			expect(result.outputs.mcpHttpAuthTokenFile).toBe(paths.mcpHttpAuthToken);
+			expect(readFileSync(logPath, "utf8")).toContain("mcp set clawdi");
+			expect(readFileSync(logPath, "utf8")).toContain('"transport":"streamable-http"');
+			expect(readFileSync(logPath, "utf8")).toContain('"headers"');
+			expect(readFileSync(logPath, "utf8")).toContain('"Authorization":"Bearer ');
+			expect(readFileSync(logPath, "utf8")).toContain("OPENCLAW_STATE_DIR=/home/node/.openclaw");
+		} finally {
+			if (previousAuthToken === undefined) delete process.env.CLAWDI_AUTH_TOKEN;
+			else process.env.CLAWDI_AUTH_TOKEN = previousAuthToken;
+		}
+	});
+
+	it("rejects external OpenClaw projections without an explicit control command", async () => {
+		const root = makeTempDir();
+		const manifestPath = join(root, "hosted-openclaw-no-control.json");
+		writeFileSync(
+			manifestPath,
+			`${JSON.stringify({
+				manifest: {
+					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					deploymentId: "hdep_no_control",
+					environmentId: "env_no_control",
+					instanceId: "inst_no_control",
+					generation: 1,
+					issuedAt: "2026-07-01T00:00:00Z",
+					controlPlane: {
+						cloudApiUrl: "https://api.example.test",
+					},
+					runtimeTargets: {
+						"openclaw-a": {
+							type: "openclaw",
+							enabled: true,
+							execution: {
+								mode: "external",
+								stateDir: "/state/openclaw-a",
+								mcp: {
+									source: "sidecar-local",
+									url: "http://clawdi-sidecar:8788/mcp",
+									transport: "streamable-http",
+								},
+							},
+						},
+					},
+					mcp: { enabled: true },
+				},
+				secretValues: {},
+			})}\n`,
+		);
+
+		const loaded = await loadRuntimeManifest(
+			minimalPaths(join(root, "service"), join(root, "clawdi")),
+			{ manifestPath },
+		);
+
+		expect("mode" in loaded && loaded.mode).toBe("manifest-rejected");
+		expect("errors" in loaded ? loaded.errors.join("\n") : "").toContain(
+			"runtime openclaw-a external OpenClaw projection requires execution.controlCommand",
+		);
+	});
+
+	it("projects two external OpenClaw targets with separate state directories", () => {
+		const root = makeTempDir();
+		const paths = minimalPaths(join(root, "service"), join(root, "clawdi"));
+		const controlPath = join(root, "agent-control");
+		const logPath = join(root, "agent-control.log");
+		executable(
+			controlPath,
+			[
+				"#!/usr/bin/env sh",
+				`printf 'ARGS=%s\\n' "$*" >> ${logPath}`,
+				`printf 'STATE=%s\\n' "$OPENCLAW_STATE_DIR" >> ${logPath}`,
+				"cat >/dev/null",
+				"",
+			].join("\n"),
+		);
+		const previousAuthToken = process.env.CLAWDI_AUTH_TOKEN;
+		process.env.CLAWDI_AUTH_TOKEN = "test-runtime-token";
+		try {
+			const result = convergeRuntimeManifest(
+				{
+					manifest: {
+						schemaVersion: "clawdi.runtimeDesiredState.v1",
+						deploymentId: "hdep_multi",
+						environmentId: "env_multi",
+						instanceId: "inst_multi",
+						generation: 1,
+						issuedAt: "2026-07-01T00:00:00Z",
+						workspaceRoot: join(root, "workspace"),
+						controlPlane: { apiUrl: "https://api.example.test" },
+						runtimes: {
+							"openclaw-a": {
+								type: "openclaw",
+								enabled: true,
+								environmentId: "env-openclaw-a",
+								services: {},
+								execution: {
+									mode: "external",
+									stateDir: "/state/openclaw-a",
+									controlCommand: { command: controlPath, args: ["openclaw-a"], env: {} },
+								},
+							},
+							"openclaw-b": {
+								type: "openclaw",
+								enabled: true,
+								environmentId: "env-openclaw-b",
+								services: {},
+								execution: {
+									mode: "external",
+									stateDir: "/state/openclaw-b",
+									controlCommand: { command: controlPath, args: ["openclaw-b"], env: {} },
+								},
+							},
+						},
+						runtimeTargets: {},
+						projection: {
+							providers: {
+								"openclaw-a": {
+									baseUrl: "https://provider-a.example.test/v1",
+									model: "model-a",
+									apiKeySecretRef: "provider.openclaw-a.apiKey",
+								},
+								"openclaw-b": {
+									baseUrl: "https://provider-b.example.test/v1",
+									model: "model-b",
+									apiKeySecretRef: "provider.openclaw-b.apiKey",
+								},
+							},
+						},
+						liveSync: { enabled: true, agents: [] },
+						recovery: {},
+					},
+					source: "fixture-file",
+					sourcePath: "test",
+					offline: false,
+					secretValues: {
+						"provider.openclaw-a.apiKey": "sk-a",
+						"provider.openclaw-b.apiKey": "sk-b",
+					},
+				},
+				paths,
+			);
+
+			expect(result.installErrors).toEqual([]);
+			const log = readFileSync(logPath, "utf8");
+			expect(log).toContain("ARGS=openclaw-a config patch --stdin --replace-path models.providers");
+			expect(log).toContain("STATE=/state/openclaw-a");
+			expect(log).toContain("ARGS=openclaw-b config patch --stdin --replace-path models.providers");
+			expect(log).toContain("STATE=/state/openclaw-b");
+			expect(readFileSync(join(paths.localEnvironments, "openclaw-a.json"), "utf8")).toContain(
+				'"agentId": "openclaw-a"',
+			);
+			expect(readFileSync(join(paths.localEnvironments, "openclaw-b.json"), "utf8")).toContain(
+				'"agentId": "openclaw-b"',
+			);
+			const supervisor = readFileSync(paths.supervisorConfig, "utf8");
+			expect(supervisor).toContain("[program:clawdi-daemon-openclaw-a]");
+			expect(supervisor).toContain("[program:clawdi-daemon-openclaw-b]");
+			expect(supervisor).toContain('CLAWDI_AGENT_ID="openclaw-a"');
+			expect(supervisor).toContain('CLAWDI_AGENT_ID="openclaw-b"');
+			expect(supervisor).toContain('OPENCLAW_STATE_DIR="/state/openclaw-a"');
+			expect(supervisor).toContain('OPENCLAW_STATE_DIR="/state/openclaw-b"');
+		} finally {
+			if (previousAuthToken === undefined) delete process.env.CLAWDI_AUTH_TOKEN;
+			else process.env.CLAWDI_AUTH_TOKEN = previousAuthToken;
+		}
+	});
+
+	it("records observed versions from explicit external version commands", () => {
+		const root = makeTempDir();
+		const paths = minimalPaths(join(root, "service"), join(root, "clawdi"));
+		const controlPath = join(root, "agent-control");
+		const versionPath = join(root, "agent-version");
+		executable(controlPath, "#!/usr/bin/env sh\ncat >/dev/null\n");
+		executable(versionPath, "#!/usr/bin/env sh\nprintf 'OpenClaw 2026.6.11\\n'\n");
+
+		const result = convergeRuntimeManifest(
+			{
+				manifest: {
+					schemaVersion: "clawdi.runtimeDesiredState.v1",
+					deploymentId: "hdep_version",
+					environmentId: "env_version",
+					instanceId: "inst_version",
+					generation: 1,
+					issuedAt: "2026-07-01T00:00:00Z",
+					workspaceRoot: join(root, "workspace"),
+					controlPlane: { apiUrl: "https://api.example.test" },
+					runtimes: {
+						"openclaw-a": {
+							type: "openclaw",
+							enabled: true,
+							version: { desired: "2026.6.11" },
+							services: {},
+							execution: {
+								mode: "external",
+								stateDir: "/state/openclaw-a",
+								controlCommand: { command: controlPath, args: [], env: {} },
+								versionCommand: { command: versionPath, args: [], env: {} },
+							},
+						},
+					},
+					runtimeTargets: {},
+					recovery: {},
+				},
+				source: "fixture-file",
+				sourcePath: "test",
+				offline: false,
+			},
+			paths,
+		);
+
+		expect(result.installErrors).toEqual([]);
+		const inventory = JSON.parse(
+			readFileSync(join(paths.installInventory, "openclaw-a.json"), "utf8"),
+		) as { version: { observed: string; source: string; upgradeAvailable: boolean } };
+		expect(inventory.version.observed).toBe("OpenClaw 2026.6.11");
+		expect(inventory.version.source).toBe("version-command");
+		expect(inventory.version.upgradeAvailable).toBe(true);
+	});
+
+	it("rejects external runtimes that do not share one sidecar MCP endpoint", () => {
+		const root = makeTempDir();
+		const paths = minimalPaths(join(root, "service"), join(root, "clawdi"));
+		const previousAuthToken = process.env.CLAWDI_AUTH_TOKEN;
+		process.env.CLAWDI_AUTH_TOKEN = "test-runtime-token";
+		try {
+			expect(() =>
+				convergeRuntimeManifest(
+					{
+						manifest: {
+							schemaVersion: "clawdi.runtimeDesiredState.v1",
+							deploymentId: "hdep_external",
+							environmentId: "env_external",
+							instanceId: "inst_external",
+							generation: 1,
+							issuedAt: "2026-07-01T00:00:00Z",
+							workspaceRoot: join(root, "workspace"),
+							controlPlane: { apiUrl: "https://api.example.test" },
+							runtimes: {
+								openclaw: {
+									type: "openclaw",
+									enabled: true,
+									services: {},
+									execution: {
+										mode: "external",
+										home: "/home/node",
+										stateDir: "/home/node/.openclaw",
+										mcp: {
+											source: "sidecar-local",
+											url: "http://clawdi-sidecar:8788/mcp",
+											transport: "streamable-http",
+										},
+									},
+								},
+								hermes: {
+									type: "hermes",
+									enabled: true,
+									services: {},
+									execution: {
+										mode: "external",
+										home: "/opt/data",
+										stateDir: "/opt/data",
+										mcp: {
+											source: "sidecar-local",
+											url: "http://clawdi-sidecar:8789/mcp",
+											transport: "streamable-http",
+										},
+									},
+								},
+							},
+							projection: { mcp: {} },
+							runtimeTargets: {},
+							recovery: {},
+						},
+						source: "fixture-file",
+						sourcePath: "test",
+						offline: false,
+					},
+					paths,
+				),
+			).toThrow("sidecar-local MCP runtimes must share one sidecar port and path");
+		} finally {
+			if (previousAuthToken === undefined) delete process.env.CLAWDI_AUTH_TOKEN;
+			else process.env.CLAWDI_AUTH_TOKEN = previousAuthToken;
+		}
 	});
 });

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import {
 	accessSync,
 	chmodSync,
@@ -13,6 +13,7 @@ import {
 	renameSync,
 	rmSync,
 	statSync,
+	symlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -34,7 +35,12 @@ import {
 } from "../lib/hermes-config-merge";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { normalizeSecretRef } from "./hosted-mitm-profiles";
-import type { LiveSyncAgent, RuntimeInstall, RuntimeManifest } from "./manifest-contract";
+import type {
+	LiveSyncAgent,
+	RuntimeInstall,
+	RuntimeManifest,
+	RuntimeType,
+} from "./manifest-contract";
 
 export type { RuntimeInstall, RuntimeManifest } from "./manifest-contract";
 export {
@@ -68,6 +74,7 @@ import {
 	runtimeNameSchema,
 	runtimeRunConfigId,
 	runtimeServiceNameSchema,
+	type SupportedRuntimeName,
 	withoutPathEntry,
 	writeRuntimeRunConfig,
 } from "./run-config";
@@ -95,6 +102,7 @@ export interface RuntimeConvergenceResult {
 		mitmSecretFile: string | null;
 		liveSyncEnvironments: string[];
 		daemonAuthTokenFile: string | null;
+		mcpHttpAuthTokenFile: string | null;
 		instanceSemaphores: string[];
 		bootFinished: string;
 	};
@@ -102,8 +110,9 @@ export interface RuntimeConvergenceResult {
 
 interface RuntimeInstallObservation {
 	runtime: string;
+	runtimeType: RuntimeType | null;
 	enabled: boolean;
-	status: "disabled" | "present" | "installed" | "configured" | "install_failed";
+	status: "disabled" | "present" | "installed" | "configured" | "external" | "install_failed";
 	executionUser: string | null;
 	commandPath: string | null;
 	appRoot: string | null;
@@ -117,6 +126,32 @@ interface RuntimeInstallObservation {
 	stdoutTail: string | null;
 	stderrTail: string | null;
 	error: string | null;
+}
+
+type RuntimeEntry = RuntimeManifest["runtimes"][string];
+
+interface RuntimeVersionObservation {
+	desired: string | null;
+	observed: string | null;
+	observedAt: string | null;
+	upgradeAvailable: boolean | null;
+	upgradePolicy: string | null;
+	source: "manifest" | "version-command" | "control-command" | "native-cli" | "unavailable";
+	error: string | null;
+}
+
+function runtimeTypeForEntry(_name: string, runtime?: RuntimeEntry | null): RuntimeType | null {
+	if (runtime?.type) return runtime.type;
+	return null;
+}
+const MCP_HTTP_AUTH_TOKEN_ENV = "CLAWDI_MCP_HTTP_TOKEN";
+
+export function runtimeExecutionMode(runtime: RuntimeEntry): "managed-process" | "external" {
+	return runtime.execution?.mode ?? "managed-process";
+}
+
+export function isExternalRuntime(runtime: RuntimeEntry): boolean {
+	return runtimeExecutionMode(runtime) === "external";
 }
 
 function writeJsonFile(path: string, payload: unknown): void {
@@ -312,33 +347,50 @@ function makeRuntimeUserPrivateDir(path: string): void {
 	}
 }
 
-function runtimeInstallerCommand(name: string, install: RuntimeInstall | undefined): string[] {
+function runtimeInstallerCommand(
+	_name: string,
+	type: RuntimeType | null,
+	install: RuntimeInstall | undefined,
+): string[] {
 	if (!install) return [];
-	if (name === "openclaw") {
+	if (type === "openclaw") {
 		return ["bash", "<downloaded-official-openclaw-installer>", ...install.args];
 	}
-	if (name === "hermes") {
+	if (type === "hermes") {
 		return ["bash", "<downloaded-official-hermes-installer>", ...install.args];
 	}
 	return [];
 }
 
-function runtimeCommandPath(name: string, home: string): string | null {
-	if (name === "openclaw") return join(home, ".openclaw", "bin", "openclaw");
-	if (name === "hermes") return join(home, ".local", "bin", "hermes");
+function runtimeCommandPath(type: RuntimeType | null, home: string): string | null {
+	if (type === "openclaw") return join(home, ".openclaw", "bin", "openclaw");
+	if (type === "hermes") return join(home, ".local", "bin", "hermes");
 	return null;
 }
 
-function runtimeAppRoot(name: string, home: string): string | null {
-	if (name === "openclaw") return join(home, ".openclaw");
-	if (name === "hermes") return join(home, ".hermes", "hermes-agent");
+function runtimeAppRoot(type: RuntimeType | null, home: string): string | null {
+	if (type === "openclaw") return join(home, ".openclaw");
+	if (type === "hermes") return join(home, ".hermes", "hermes-agent");
 	return null;
 }
+
+const SUPPORTED_RUNTIME_NAMES = [
+	"hermes",
+	"openclaw",
+] as const satisfies readonly SupportedRuntimeName[];
+
+const runtimeCommandShimIndexSchema = z
+	.object({
+		schemaVersion: z.literal("clawdi.runtimeCommandShims.v1"),
+		commands: z.array(runtimeNameSchema).default([]),
+	})
+	.strict();
 
 const liveSyncEnvironmentIndexSchema = z
 	.object({
 		schemaVersion: z.literal("clawdi.liveSyncEnvironments.v1"),
 		agentTypes: z.array(runtimeNameSchema).default([]),
+		agentIds: z.array(runtimeNameSchema).default([]),
 	})
 	.strict();
 
@@ -436,14 +488,14 @@ function tail(value: string | null | undefined): string | null {
 	return value.slice(-4000);
 }
 
-function testInstallerEnvName(name: string): string | null {
-	if (name === "openclaw") return "CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER";
-	if (name === "hermes") return "CLAWDI_RUNTIME_TEST_HERMES_INSTALLER";
+function testInstallerEnvName(type: RuntimeType | null): string | null {
+	if (type === "openclaw") return "CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER";
+	if (type === "hermes") return "CLAWDI_RUNTIME_TEST_HERMES_INSTALLER";
 	return null;
 }
 
-function executionInstallerUrl(name: string, officialUrl: string): string {
-	const envName = testInstallerEnvName(name);
+function executionInstallerUrl(type: RuntimeType | null, officialUrl: string): string {
+	const envName = testInstallerEnvName(type);
 	const override = envName ? process.env[envName]?.trim() : undefined;
 	if (override) {
 		if (process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS !== "1") {
@@ -485,7 +537,11 @@ function materializeInstaller(
 	return { path, cleanup: dir };
 }
 
-function runOfficialInstaller(name: string, install: RuntimeInstall): RuntimeInstallObservation {
+function runOfficialInstaller(
+	name: string,
+	type: RuntimeType | null,
+	install: RuntimeInstall,
+): RuntimeInstallObservation {
 	const installStartedAt = new Date().toISOString();
 	const installStartedMs = Date.now();
 	const finish = (
@@ -499,11 +555,12 @@ function runOfficialInstaller(name: string, install: RuntimeInstall): RuntimeIns
 		installFinishedAt: new Date().toISOString(),
 		installDurationMs: Math.max(0, Date.now() - installStartedMs),
 	});
-	const commandPath = runtimeCommandPath(name, install.home);
-	const appRoot = runtimeAppRoot(name, install.home);
+	const commandPath = runtimeCommandPath(type, install.home);
+	const appRoot = runtimeAppRoot(type, install.home);
 	if (!commandPath || !appRoot) {
 		return finish({
 			runtime: name,
+			runtimeType: type,
 			enabled: true,
 			status: "install_failed",
 			executionUser: null,
@@ -521,6 +578,7 @@ function runOfficialInstaller(name: string, install: RuntimeInstall): RuntimeIns
 	if (executableExists(commandPath)) {
 		return finish({
 			runtime: name,
+			runtimeType: type,
 			enabled: true,
 			status: "present",
 			executionUser: null,
@@ -538,7 +596,7 @@ function runOfficialInstaller(name: string, install: RuntimeInstall): RuntimeIns
 
 	mkdirSync(install.home, { recursive: true });
 	makeRuntimeUserOwned(install.home);
-	const url = executionInstallerUrl(name, install.url);
+	const url = executionInstallerUrl(type, install.url);
 	const materialized = materializeInstaller(name, url);
 	try {
 		const execution = runtimeInstallerExecution(install, materialized.path);
@@ -552,6 +610,7 @@ function runOfficialInstaller(name: string, install: RuntimeInstall): RuntimeIns
 		const installed = exitCode === 0 && executableExists(commandPath);
 		return finish({
 			runtime: name,
+			runtimeType: type,
 			enabled: true,
 			status: installed ? "installed" : "install_failed",
 			executionUser: execution.executionUser,
@@ -570,6 +629,7 @@ function runOfficialInstaller(name: string, install: RuntimeInstall): RuntimeIns
 	} catch (error) {
 		return finish({
 			runtime: name,
+			runtimeType: type,
 			enabled: true,
 			status: "install_failed",
 			executionUser: null,
@@ -589,9 +649,11 @@ function runOfficialInstaller(name: string, install: RuntimeInstall): RuntimeIns
 }
 
 function observeRuntimeInstall(name: string, runtime: RuntimeManifest["runtimes"][string]) {
+	const type = runtimeTypeForEntry(name, runtime);
 	if (!runtime.enabled) {
 		return {
 			runtime: name,
+			runtimeType: type,
 			enabled: false,
 			status: "disabled",
 			executionUser: null,
@@ -606,10 +668,29 @@ function observeRuntimeInstall(name: string, runtime: RuntimeManifest["runtimes"
 			error: null,
 		} satisfies RuntimeInstallObservation;
 	}
+	if (isExternalRuntime(runtime)) {
+		return {
+			runtime: name,
+			runtimeType: type,
+			enabled: true,
+			status: "external",
+			executionUser: null,
+			commandPath: null,
+			appRoot: null,
+			install: null,
+			installerUrl: null,
+			executedInstallerUrl: null,
+			exitCode: null,
+			stdoutTail: null,
+			stderrTail: null,
+			error: null,
+		} satisfies RuntimeInstallObservation;
+	}
 	if (!runtime.install) {
 		if (runtime.run?.command?.trim()) {
 			return {
 				runtime: name,
+				runtimeType: type,
 				enabled: true,
 				status: "configured",
 				executionUser: null,
@@ -626,6 +707,7 @@ function observeRuntimeInstall(name: string, runtime: RuntimeManifest["runtimes"
 		}
 		return {
 			runtime: name,
+			runtimeType: type,
 			enabled: true,
 			status: "install_failed",
 			executionUser: null,
@@ -640,7 +722,148 @@ function observeRuntimeInstall(name: string, runtime: RuntimeManifest["runtimes"
 			error: `runtime ${name} is enabled but missing install metadata`,
 		} satisfies RuntimeInstallObservation;
 	}
-	return runOfficialInstaller(name, runtime.install);
+	return runOfficialInstaller(name, type, runtime.install);
+}
+
+function observeRuntimeVersion(
+	name: string,
+	runtime: RuntimeEntry,
+	observation: RuntimeInstallObservation,
+	manifest: RuntimeManifest,
+	workspaceRoot: string,
+): RuntimeVersionObservation {
+	const desired =
+		runtime.version?.desired ??
+		runtime.image?.tag ??
+		runtime.updateChannel ??
+		runtime.image?.digest ??
+		runtime.image?.ref ??
+		null;
+	const explicitObserved = runtime.version?.observed ?? null;
+	if (explicitObserved) {
+		return {
+			desired,
+			observed: explicitObserved,
+			observedAt: runtime.version?.observedAt ?? null,
+			upgradeAvailable: runtime.version?.upgradeAvailable ?? null,
+			upgradePolicy: runtime.version?.upgradePolicy ?? null,
+			source: "manifest",
+			error: null,
+		};
+	}
+	if (
+		!runtime.enabled ||
+		observation.status === "disabled" ||
+		observation.status === "install_failed"
+	) {
+		return {
+			desired,
+			observed: null,
+			observedAt: null,
+			upgradeAvailable: runtime.version?.upgradeAvailable ?? null,
+			upgradePolicy: runtime.version?.upgradePolicy ?? null,
+			source: "unavailable",
+			error: observation.error,
+		};
+	}
+
+	const observed = runRuntimeVersionCommand(name, runtime, observation, manifest, workspaceRoot);
+	const upgradeAvailable =
+		runtime.version?.upgradeAvailable ??
+		(observed.observed && desired ? observed.observed !== desired : null);
+	return {
+		desired,
+		observed: observed.observed,
+		observedAt: observed.observed ? new Date().toISOString() : null,
+		upgradeAvailable,
+		upgradePolicy: runtime.version?.upgradePolicy ?? null,
+		source: observed.source,
+		error: observed.error,
+	};
+}
+
+function runRuntimeVersionCommand(
+	name: string,
+	runtime: RuntimeEntry,
+	observation: RuntimeInstallObservation,
+	manifest: RuntimeManifest,
+	workspaceRoot: string,
+): Pick<RuntimeVersionObservation, "observed" | "source" | "error"> {
+	const timeout = Number.parseInt(process.env.CLAWDI_RUNTIME_VERSION_TIMEOUT ?? "5000", 10);
+	const home = runtimeProjectionHome(name, runtime, manifest);
+	const run = (
+		command: string,
+		args: string[],
+		env: NodeJS.ProcessEnv,
+		cwd: string,
+		source: RuntimeVersionObservation["source"],
+	): Pick<RuntimeVersionObservation, "observed" | "source" | "error"> => {
+		try {
+			const output = execFileSync(command, args, {
+				env,
+				cwd,
+				timeout: Number.isFinite(timeout) && timeout > 0 ? timeout : 5000,
+				encoding: "utf8",
+				stdio: ["ignore", "pipe", "pipe"],
+			}).trim();
+			return { observed: firstVersionLine(output), source, error: null };
+		} catch (error) {
+			return {
+				observed: null,
+				source,
+				error: commandErrorText(error) || (error instanceof Error ? error.message : String(error)),
+			};
+		}
+	};
+
+	const explicit = runtime.execution?.versionCommand;
+	if (explicit) {
+		return run(
+			explicit.command,
+			explicit.args ?? [],
+			{
+				...process.env,
+				HOME: home,
+				...externalRuntimeExecutionEnvironment(name, runtime),
+				...(explicit.env ?? {}),
+			},
+			explicit.cwd ?? workspaceRoot,
+			"version-command",
+		);
+	}
+	if (isExternalRuntime(runtime) && runtime.execution?.controlCommand) {
+		const control = runtime.execution.controlCommand;
+		return run(
+			control.command,
+			[...(control.args ?? []), "--version"],
+			{
+				...process.env,
+				HOME: home,
+				...externalRuntimeExecutionEnvironment(name, runtime),
+				...(control.env ?? {}),
+			},
+			control.cwd ?? workspaceRoot,
+			"control-command",
+		);
+	}
+	if (observation.commandPath) {
+		return run(
+			observation.commandPath,
+			["--version"],
+			{ ...process.env, HOME: home },
+			workspaceRoot,
+			"native-cli",
+		);
+	}
+	return { observed: null, source: "unavailable", error: null };
+}
+
+function firstVersionLine(output: string): string | null {
+	const line = output
+		.split(/\r?\n/)
+		.map((value) => value.trim())
+		.find(Boolean);
+	return line || null;
 }
 
 function projectionPayload(name: string, manifest: RuntimeManifest): unknown {
@@ -648,16 +871,18 @@ function projectionPayload(name: string, manifest: RuntimeManifest): unknown {
 		typeof manifest.projection === "object" && manifest.projection !== null
 			? manifest.projection
 			: undefined;
+	const type = runtimeTypeForEntry(name, manifest.runtimes[name]);
 	return {
 		schemaVersion: "clawdi.runtimeProjection.v1",
 		runtime: name,
+		runtimeType: type,
 		generation: manifest.generation,
 		instanceId: manifest.instanceId,
 		managedBy: "clawdi runtime init",
 		target:
-			name === "openclaw"
+			type === "openclaw"
 				? "openclaw config patch --stdin --replace-path models.providers"
-				: name === "hermes"
+				: type === "hermes"
 					? "official Hermes user config"
 					: "clawdi mcp",
 		projection: projection ?? null,
@@ -781,43 +1006,98 @@ function hostedProviderSecretEnv(
 	return env;
 }
 
+function externalRuntimeExecutionEnvironment(
+	name: string,
+	runtime: RuntimeEntry,
+): Record<string, string> {
+	const env: Record<string, string> = {};
+	const type = runtimeTypeForEntry(name, runtime);
+	if (type === "openclaw") {
+		const stateDir = runtime.execution?.stateDir ?? externalRuntimeDefaultStateDir(type, runtime);
+		if (stateDir) env.OPENCLAW_STATE_DIR = stateDir;
+	}
+	if (type === "hermes") {
+		const home = runtime.execution?.home ?? runtime.execution?.stateDir;
+		if (home) env.HERMES_HOME = home;
+	}
+	return env;
+}
+
+function externalRuntimeDefaultStateDir(
+	type: RuntimeType | null,
+	runtime: RuntimeEntry,
+): string | null {
+	const home = runtime.execution?.home;
+	if (!home) return null;
+	if (type === "openclaw") return join(home, ".openclaw");
+	if (type === "hermes") return home;
+	return null;
+}
+
+function runtimeProjectionHome(
+	name: string,
+	runtime: RuntimeEntry,
+	manifest: RuntimeManifest,
+): string {
+	if (isExternalRuntime(runtime)) {
+		const explicit = runtime.execution?.home ?? runtime.execution?.stateDir;
+		if (explicit) return explicit;
+	}
+	const type = runtimeTypeForEntry(name, runtime);
+	if (type === "hermes") {
+		return (
+			process.env.HERMES_HOME?.trim() ||
+			join(projectionSystemHome(manifest) ?? process.env.HOME ?? "", ".hermes")
+		);
+	}
+	return projectionSystemHome(manifest) ?? process.env.HOME ?? "";
+}
+
+function hermesConfigPath(name: string, runtime: RuntimeEntry, manifest: RuntimeManifest): string {
+	return join(runtimeProjectionHome(name, runtime, manifest), "config.yaml");
+}
+
 function isEnvKey(value: string): boolean {
 	return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
 }
 
 function applyHostedAiProviderProjection(
 	name: string,
+	runtime: RuntimeEntry,
 	observation: RuntimeInstallObservation,
 	manifest: RuntimeManifest,
 	workspaceRoot: string,
 ): string | null {
-	if (!observation.enabled || observation.status === "install_failed" || !observation.commandPath) {
+	if (!observation.enabled || observation.status === "install_failed") {
 		return null;
 	}
+	const type = runtimeTypeForEntry(name, runtime);
 	const catalog = hostedAiProviderCatalog(manifest, name);
 	if (!catalog) return null;
-	const home = projectionSystemHome(manifest) ?? process.env.HOME ?? "";
-	if (name === "hermes") {
+	const home = runtimeProjectionHome(name, runtime, manifest);
+	if (type === "hermes") {
 		const projection = buildAgentTargetProjection("hermes", catalog);
 		const file = projection.files.find((entry) => entry.path.endsWith(".hermes.yaml"));
 		if (!file) throw new Error("Hermes projection did not include a config merge YAML file.");
-		const configPath = join(home, ".hermes", "config.yaml");
+		const configPath = hermesConfigPath(name, runtime, manifest);
 		mergeHermesConfig(configPath, file.content);
 		makeRuntimeUserOwned(configPath);
 		return configPath;
 	}
-	if (name === "openclaw") {
+	if (type === "openclaw") {
 		const projection = buildAgentTargetProjection("openclaw", catalog);
 		const file = projection.files.find((entry) => entry.path.endsWith(".openclaw.json"));
 		if (!file) throw new Error("OpenClaw projection did not include a config patch JSON file.");
-		runRuntimeUserCommand(
-			observation.commandPath,
+		runRuntimeControlCommand(
+			name,
+			runtime,
+			observation,
 			["config", "patch", "--stdin", "--replace-path", "models.providers"],
 			file.content,
 			home,
 			workspaceRoot,
 		);
-		return observation.commandPath;
+		return observation.commandPath ?? runtime.execution?.controlCommand?.command ?? null;
 	}
 	return null;
 }
@@ -833,27 +1113,31 @@ function hostedChannelProjection(manifest: RuntimeManifest): Record<string, unkn
 
 function applyHostedChannelProjection(
 	name: string,
+	runtime: RuntimeEntry,
 	observation: RuntimeInstallObservation,
 	manifest: RuntimeManifest,
 	workspaceRoot: string,
 ): string | null {
-	if (name !== "openclaw") return null;
-	if (!observation.enabled || observation.status === "install_failed" || !observation.commandPath) {
+	const type = runtimeTypeForEntry(name, runtime);
+	if (type !== "openclaw") return null;
+	if (!observation.enabled || observation.status === "install_failed") {
 		return null;
 	}
 	const channels = hostedChannelProjection(manifest);
 	if (!channels) return null;
 
-	const home = projectionSystemHome(manifest) ?? process.env.HOME ?? "";
-	installOpenClawChannelPlugins(observation.commandPath, channels, home, workspaceRoot);
-	runRuntimeUserCommand(
-		observation.commandPath,
+	const home = runtimeProjectionHome(name, runtime, manifest);
+	installOpenClawChannelPlugins(name, runtime, observation, channels, home, workspaceRoot);
+	runRuntimeControlCommand(
+		name,
+		runtime,
+		observation,
 		["config", "patch", "--stdin"],
 		`${JSON.stringify(openClawManagedChannelsPatch(channels), null, 2)}\n`,
 		home,
 		workspaceRoot,
 	);
-	return observation.commandPath;
+	return observation.commandPath ?? runtime.execution?.controlCommand?.command ?? null;
 }
 
 function openClawManagedChannelsPatch(channels: Record<string, unknown>): Record<string, unknown> {
@@ -880,7 +1164,9 @@ function openClawManagedChannelDeletes(): Record<string, null> {
 }
 
 function installOpenClawChannelPlugins(
-	commandPath: string,
+	name: string,
+	runtime: RuntimeEntry,
+	observation: RuntimeInstallObservation,
 	channels: Record<string, unknown>,
 	home: string,
 	workspaceRoot: string,
@@ -888,12 +1174,14 @@ function installOpenClawChannelPlugins(
 	for (const channel of Object.keys(channels).sort()) {
 		const specs = OPENCLAW_EXTERNAL_CHANNEL_PLUGIN_SPECS[channel];
 		if (!specs) continue;
-		runPluginInstallWithFallback(commandPath, specs, home, workspaceRoot);
+		runPluginInstallWithFallback(name, runtime, observation, specs, home, workspaceRoot);
 	}
 }
 
 function runPluginInstallWithFallback(
-	commandPath: string,
+	name: string,
+	runtime: RuntimeEntry,
+	observation: RuntimeInstallObservation,
 	specs: readonly string[],
 	home: string,
 	workspaceRoot: string,
@@ -901,7 +1189,15 @@ function runPluginInstallWithFallback(
 	let lastError: unknown = null;
 	for (const spec of specs) {
 		try {
-			runRuntimeUserCommand(commandPath, ["plugins", "install", spec], "", home, workspaceRoot);
+			runRuntimeControlCommand(
+				name,
+				runtime,
+				observation,
+				["plugins", "install", spec],
+				"",
+				home,
+				workspaceRoot,
+			);
 			return;
 		} catch (error) {
 			if (isOpenClawPluginAlreadyInstalledError(error)) return;
@@ -950,45 +1246,92 @@ function hostedMcpProjectionDeclared(manifest: RuntimeManifest): boolean {
 	return Boolean(projection && (projection.mcp !== undefined || projection.tools !== undefined));
 }
 
+type HostedMcpServerConfig =
+	| { command: string; args: string[] }
+	| { url: string; transport?: "streamable-http"; headers?: Record<string, string> };
+
+function backendMcpUrl(manifest: RuntimeManifest): string {
+	const url = new URL(manifest.controlPlane.apiUrl);
+	url.pathname = "/mcp/clawdi";
+	url.search = "";
+	url.hash = "";
+	return url.toString();
+}
+
 function hostedMcpServerConfig(
 	manifest: RuntimeManifest,
 	authTokenFile: string,
-): { command: string; args: string[] } {
+): HostedMcpServerConfig {
 	return {
 		command: "clawdi",
 		args: ["mcp", "--api-url", manifest.controlPlane.apiUrl, "--auth-token-file", authTokenFile],
 	};
 }
 
+function externalHostedMcpServerConfig(
+	runtime: RuntimeEntry,
+	manifest: RuntimeManifest,
+	daemonAuthTokenFile?: string | null,
+	mcpHttpAuthTokenFile?: string | null,
+): HostedMcpServerConfig | null {
+	const source = runtime.execution?.mcp?.source ?? "backend-direct";
+	const url =
+		source === "sidecar-local"
+			? (runtime.execution?.mcp?.url?.trim() ?? "")
+			: runtime.execution?.mcp?.url?.trim() || backendMcpUrl(manifest);
+	if (!url) return null;
+	const tokenFile = source === "sidecar-local" ? mcpHttpAuthTokenFile : daemonAuthTokenFile;
+	const token = tokenFile ? readFileSync(tokenFile, "utf-8").trim() : "";
+	return {
+		url,
+		transport: runtime.execution?.mcp?.transport ?? "streamable-http",
+		...(token ? { headers: { Authorization: `Bearer ${token}` } } : {}),
+	};
+}
+
 function applyHostedMcpProjection(
 	name: string,
+	runtime: RuntimeEntry,
 	observation: RuntimeInstallObservation,
 	manifest: RuntimeManifest,
 	workspaceRoot: string,
 	daemonAuthTokenFile: string | null,
+	mcpHttpAuthTokenFile: string | null,
 ): string | null {
-	const home = projectionSystemHome(manifest) ?? process.env.HOME ?? "";
+	const home = runtimeProjectionHome(name, runtime, manifest);
 	if (!hostedMcpProjectionDeclared(manifest)) return null;
 	if (!hostedMcpProjectionEnabled(manifest)) {
-		return removeHostedMcpProjection(name, observation, manifest, home, workspaceRoot);
+		return removeHostedMcpProjection(name, runtime, observation, manifest, home, workspaceRoot);
 	}
-	if (!daemonAuthTokenFile) return null;
-	if (!observation.enabled || observation.status === "install_failed" || !observation.commandPath) {
+	if (!observation.enabled || observation.status === "install_failed") {
 		return null;
 	}
-	const server = hostedMcpServerConfig(manifest, daemonAuthTokenFile);
-	if (name === "openclaw") {
-		runRuntimeUserCommand(
-			observation.commandPath,
+	const server = isExternalRuntime(runtime)
+		? externalHostedMcpServerConfig(runtime, manifest, daemonAuthTokenFile, mcpHttpAuthTokenFile)
+		: daemonAuthTokenFile
+			? hostedMcpServerConfig(manifest, daemonAuthTokenFile)
+			: null;
+	if (!server) {
+		if (isExternalRuntime(runtime)) {
+			throw new Error(`runtime ${name} external MCP projection requires MCP auth token`);
+		}
+		return null;
+	}
+	const type = runtimeTypeForEntry(name, runtime);
+	if (type === "openclaw") {
+		runRuntimeControlCommand(
+			name,
+			runtime,
+			observation,
 			["mcp", "set", "clawdi", JSON.stringify(server)],
 			"",
 			home,
 			workspaceRoot,
 		);
-		return observation.commandPath;
+		return observation.commandPath ?? runtime.execution?.controlCommand?.command ?? null;
 	}
-	if (name === "hermes") {
-		const configPath = join(home, ".hermes", "config.yaml");
+	if (type === "hermes") {
+		const configPath = hermesConfigPath(name, runtime, manifest);
 		mergeHermesMcpServer(configPath, "clawdi", server);
 		makeRuntimeUserOwned(configPath);
 		return configPath;
@@ -998,19 +1341,31 @@ function applyHostedMcpProjection(
 
 function removeHostedMcpProjection(
 	name: string,
+	runtime: RuntimeEntry,
 	observation: RuntimeInstallObservation,
 	_manifest: RuntimeManifest,
 	home: string,
 	workspaceRoot: string,
 ): string | null {
-	if (name === "openclaw") {
-		const commandPath = observation.commandPath ?? runtimeCommandPath(name, home);
-		if (!commandPath || !executableExists(commandPath)) return null;
-		runRuntimeUserCommand(commandPath, ["mcp", "unset", "clawdi"], "", home, workspaceRoot);
-		return commandPath;
+	const type = runtimeTypeForEntry(name, runtime);
+	if (type === "openclaw") {
+		if (!isExternalRuntime(runtime)) {
+			const commandPath = observation.commandPath ?? runtimeCommandPath(type, home);
+			if (!commandPath || !executableExists(commandPath)) return null;
+		}
+		runRuntimeControlCommand(
+			name,
+			runtime,
+			observation,
+			["mcp", "unset", "clawdi"],
+			"",
+			home,
+			workspaceRoot,
+		);
+		return observation.commandPath ?? runtime.execution?.controlCommand?.command ?? null;
 	}
-	if (name === "hermes") {
-		const configPath = join(home, ".hermes", "config.yaml");
+	if (type === "hermes") {
+		const configPath = hermesConfigPath(name, runtime, _manifest);
 		removeHermesMcpServer(configPath, "clawdi");
 		makeRuntimeUserOwned(configPath);
 		return configPath;
@@ -1069,6 +1424,41 @@ function runRuntimeUserCommand(
 	execFileSync(command, args, { input: stdin, env, cwd, stdio: "pipe" });
 }
 
+function runRuntimeControlCommand(
+	name: string,
+	runtime: RuntimeEntry,
+	observation: RuntimeInstallObservation,
+	args: string[],
+	stdin: string,
+	home: string,
+	cwd: string,
+): void {
+	if (isExternalRuntime(runtime)) {
+		const control = runtime.execution?.controlCommand;
+		if (!control) {
+			throw new Error(
+				`runtime ${name} external execution requires execution.controlCommand for native CLI projection`,
+			);
+		}
+		execFileSync(control.command, [...(control.args ?? []), ...args], {
+			input: stdin,
+			env: {
+				...process.env,
+				HOME: home,
+				...externalRuntimeExecutionEnvironment(name, runtime),
+				...(control.env ?? {}),
+			},
+			cwd: control.cwd ?? cwd,
+			stdio: "pipe",
+		});
+		return;
+	}
+	if (!observation.commandPath) {
+		throw new Error(`runtime ${name} native CLI is unavailable`);
+	}
+	runRuntimeUserCommand(observation.commandPath, args, stdin, home, cwd);
+}
+
 function clearMitmProfileBundle(paths: RuntimePaths): null {
 	rmSync(paths.mitmProfileBundle, { force: true });
 	return null;
@@ -1105,10 +1495,34 @@ const OPENCLAW_MANAGED_CHANNELS = ["telegram", "discord", "whatsapp", "bluebubbl
 
 function desiredLiveSyncAgents(manifest: RuntimeManifest): LiveSyncAgent[] {
 	if (manifest.liveSync?.enabled === false) return [];
-	const agents = manifest.liveSync?.agents ?? [];
-	const byAgent = new Map<LiveSyncAgent["agentType"], LiveSyncAgent>();
-	for (const agent of agents) byAgent.set(agent.agentType, agent);
-	return [...byAgent.values()].sort((a, b) => a.agentType.localeCompare(b.agentType));
+	const agents = [...runtimeTargetLiveSyncAgents(manifest), ...(manifest.liveSync?.agents ?? [])];
+	const byAgent = new Map<string, LiveSyncAgent>();
+	for (const agent of agents) byAgent.set(liveSyncAgentKey(agent), agent);
+	return [...byAgent.values()].sort((a, b) =>
+		liveSyncAgentKey(a).localeCompare(liveSyncAgentKey(b)),
+	);
+}
+
+function runtimeTargetLiveSyncAgents(manifest: RuntimeManifest): LiveSyncAgent[] {
+	const targets = Object.entries(manifest.runtimes)
+		.map(([name, runtime]) => {
+			const environmentId = runtime.environmentId;
+			const type = runtimeTypeForEntry(name, runtime);
+			if (!runtime.enabled || !environmentId || type === null) return null;
+			return { environmentId, name, type };
+		})
+		.filter((target): target is { environmentId: string; name: string; type: RuntimeType } =>
+			Boolean(target),
+		);
+	return targets.map((target) => ({
+		agentType: target.type,
+		agentId: target.name,
+		environmentId: target.environmentId,
+	}));
+}
+
+function liveSyncAgentKey(agent: LiveSyncAgent): RuntimeName {
+	return runtimeNameSchema.parse(agent.agentId);
 }
 
 function writeLiveSyncEnvironmentFiles(manifest: RuntimeManifest, paths: RuntimePaths): string[] {
@@ -1116,28 +1530,40 @@ function writeLiveSyncEnvironmentFiles(manifest: RuntimeManifest, paths: Runtime
 	mkdirSync(envDir, { recursive: true });
 	makeRuntimeUserOwned(envDir);
 	const agents = desiredLiveSyncAgents(manifest);
-	const desiredTypes = new Set(agents.map((agent) => agent.agentType));
+	const desiredKeys = new Set(agents.map((agent) => liveSyncAgentKey(agent)));
 	const staleCandidates = new Set<RuntimeName>([
 		...readLiveSyncEnvironmentIndex(paths),
 		...MANAGED_LIVE_SYNC_AGENTS,
 	] as RuntimeName[]);
-	for (const agentType of staleCandidates) {
-		if (!desiredTypes.has(agentType)) {
-			rmSync(join(envDir, `${agentType}.json`), { force: true });
+	for (const key of staleCandidates) {
+		if (!desiredKeys.has(key)) {
+			rmSync(join(envDir, `${key}.json`), { force: true });
 		}
 	}
 	const written: string[] = [];
 	for (const agent of agents) {
-		const path = join(envDir, `${agent.agentType}.json`);
+		const key = liveSyncAgentKey(agent);
+		const runtime = manifest.runtimes[key];
+		const type = runtime ? runtimeTypeForEntry(key, runtime) : agent.agentType;
+		const path = join(envDir, `${key}.json`);
 		writePrivateFileAtomic(
 			path,
 			`${JSON.stringify(
 				{
 					id: agent.environmentId,
+					agentId: key,
 					agentType: agent.agentType,
 					managedBy: "clawdi runtime init",
 					deploymentId: manifest.deploymentId,
 					instanceId: manifest.instanceId,
+					executionMode: runtime ? runtimeExecutionMode(runtime) : null,
+					home: runtime ? runtimeProjectionHome(key, runtime, manifest) : null,
+					stateDir: runtime
+						? (runtime.execution?.stateDir ?? externalRuntimeDefaultStateDir(type, runtime))
+						: null,
+					workspace: runtime?.execution?.workspace ?? null,
+					image: runtime?.image ?? null,
+					version: runtime?.version ?? null,
 				},
 				null,
 				2,
@@ -1147,7 +1573,7 @@ function writeLiveSyncEnvironmentFiles(manifest: RuntimeManifest, paths: Runtime
 		makeRuntimeUserOwned(path);
 		written.push(path);
 	}
-	writeLiveSyncEnvironmentIndex(desiredTypes, paths);
+	writeLiveSyncEnvironmentIndex(desiredKeys, agents, paths);
 	return written;
 }
 
@@ -1160,19 +1586,24 @@ function readLiveSyncEnvironmentIndex(paths: RuntimePaths): RuntimeName[] {
 	if (!existsSync(path)) return [];
 	try {
 		const parsed = liveSyncEnvironmentIndexSchema.parse(JSON.parse(readFileSync(path, "utf-8")));
-		return parsed.agentTypes;
+		return [...new Set([...parsed.agentIds, ...parsed.agentTypes])];
 	} catch {
 		return [];
 	}
 }
 
-function writeLiveSyncEnvironmentIndex(agentTypes: Set<RuntimeName>, paths: RuntimePaths): void {
+function writeLiveSyncEnvironmentIndex(
+	agentIds: Set<RuntimeName>,
+	agents: LiveSyncAgent[],
+	paths: RuntimePaths,
+): void {
 	writePrivateFileAtomic(
 		liveSyncEnvironmentIndexPath(paths),
 		`${JSON.stringify(
 			{
 				schemaVersion: "clawdi.liveSyncEnvironments.v1",
-				agentTypes: [...agentTypes].sort(),
+				agentIds: [...agentIds].sort(),
+				agentTypes: [...new Set(agents.map((agent) => agent.agentType))].sort(),
 			},
 			null,
 			2,
@@ -1192,6 +1623,17 @@ function writeDaemonAuthToken(paths: RuntimePaths): string | null {
 		return null;
 	}
 	rmSync(legacyPath, { force: true });
+	writePrivateFileAtomic(path, `${token}\n`, { mode: 0o600, dirMode: 0o700 });
+	makeRootOwned(dirname(path));
+	makeRootOwned(path);
+	return path;
+}
+
+function writeMcpHttpAuthToken(paths: RuntimePaths): string {
+	const path = paths.mcpHttpAuthToken;
+	const explicit = process.env[MCP_HTTP_AUTH_TOKEN_ENV]?.trim();
+	const existing = existsSync(path) ? readFileSync(path, "utf-8").trim() : "";
+	const token = explicit || existing || randomBytes(32).toString("base64url");
 	writePrivateFileAtomic(path, `${token}\n`, { mode: 0o600, dirMode: 0o700 });
 	makeRootOwned(dirname(path));
 	makeRootOwned(path);
@@ -1386,6 +1828,75 @@ function daemonProgramRevision(manifest: RuntimeManifest): string {
 	});
 }
 
+function mcpHttpProgramRevision(manifest: RuntimeManifest): string {
+	return revisionHash({
+		clawdiCli: manifest.clawdiCli ?? null,
+		controlPlane: manifest.controlPlane,
+		mcp: manifest.projection?.mcp ?? null,
+		tools: manifest.projection?.tools ?? null,
+		runtimes: Object.fromEntries(
+			Object.entries(manifest.runtimes).map(([name, runtime]) => [
+				name,
+				isExternalRuntime(runtime) ? (runtime.execution?.mcp ?? null) : null,
+			]),
+		),
+	});
+}
+
+function externalMcpHttpEndpoint(
+	manifest: RuntimeManifest,
+): { host: string; port: number; path: string } | null {
+	if (!hostedMcpProjectionEnabled(manifest)) return null;
+	const endpoints: Array<{
+		runtime: string;
+		hostname: string;
+		port: number;
+		path: string;
+		url: string;
+	}> = [];
+	for (const [name, runtime] of Object.entries(manifest.runtimes)) {
+		if (!runtime.enabled || !isExternalRuntime(runtime)) continue;
+		if (runtime.execution?.mcp?.source !== "sidecar-local") continue;
+		const rawUrl = runtime.execution.mcp.url?.trim();
+		if (!rawUrl) continue;
+		const url = new URL(rawUrl);
+		if (url.protocol !== "http:") {
+			throw new Error(`sidecar-local MCP URL must use http://: ${rawUrl}`);
+		}
+		const port = Number.parseInt(url.port || "80", 10);
+		if (!Number.isInteger(port) || port < 1 || port > 65535) {
+			throw new Error(`sidecar-local MCP URL has an invalid TCP port: ${rawUrl}`);
+		}
+		endpoints.push({
+			runtime: name,
+			hostname: url.hostname,
+			port,
+			path: url.pathname || "/mcp",
+			url: rawUrl,
+		});
+	}
+	if (endpoints.length === 0) return null;
+	const first = endpoints[0];
+	const mismatch = endpoints.find(
+		(endpoint) => endpoint.port !== first.port || endpoint.path !== first.path,
+	);
+	if (mismatch) {
+		throw new Error(
+			`sidecar-local MCP runtimes must share one sidecar port and path; ${first.runtime} uses ${first.url}, ${mismatch.runtime} uses ${mismatch.url}`,
+		);
+	}
+	const explicitHost = process.env.CLAWDI_MCP_HTTP_LISTEN_HOST?.trim();
+	const allHostsAreLocal = endpoints.every((endpoint) =>
+		["localhost", "127.0.0.1", "0.0.0.0", "::1"].includes(endpoint.hostname),
+	);
+	const host = explicitHost || (allHostsAreLocal ? first.hostname : "0.0.0.0");
+	return {
+		host,
+		port: first.port,
+		path: first.path,
+	};
+}
+
 function shellQuote(value: string): string {
 	return `'${value.replace(/'/g, `'\\''`)}'`;
 }
@@ -1523,6 +2034,26 @@ function runtimeSupervisorProgramRevision(
 	return runtimeProgramRevision(manifest, program.runtime, secretValues);
 }
 
+function supervisorProgramSuffix(value: string): string {
+	return value.replace(/[^A-Za-z0-9_-]/g, "_");
+}
+
+function liveSyncDaemonEnvironment(
+	agent: LiveSyncAgent,
+	manifest: RuntimeManifest,
+	paths: RuntimePaths,
+): Record<string, string> {
+	const runtime = manifest.runtimes[agent.agentId];
+	return {
+		CLAWDI_AGENT_ID: agent.agentId,
+		CLAWDI_AGENT_TYPE: agent.agentType,
+		CLAWDI_ENVIRONMENT_ID: agent.environmentId,
+		CLAWDI_STATE_DIR: join(paths.serviceStateRoot, "serve"),
+		CLAWDI_DAEMON_RPC_DISABLED: "1",
+		...(runtime ? externalRuntimeExecutionEnvironment(agent.agentId, runtime) : {}),
+	};
+}
+
 function writeSupervisorConfig(
 	runtimePrograms: RuntimeSupervisorProgram[],
 	mitmProgram: RuntimeMitmSupervisorProgram | null,
@@ -1530,6 +2061,7 @@ function writeSupervisorConfig(
 	paths: RuntimePaths,
 	workspaceRoot: string,
 	daemonAuthTokenFile: string | null,
+	mcpHttpAuthTokenFile: string | null,
 	secretValues: Record<string, string> | undefined,
 ): string {
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
@@ -1552,17 +2084,12 @@ function writeSupervisorConfig(
 		CLAWDI_AUTH_TOKEN: "",
 		[RUNTIME_BRIDGE_TOKEN_ENV]: runtimeBridgeToken,
 	});
-	const daemonEnvironment = supervisorEnvironment({
-		...commonEnvironment,
-		CLAWDI_SERVE_MODE: "container",
-		CLAWDI_API_URL: manifest.controlPlane.apiUrl,
-		CLAWDI_NO_AUTO_UPDATE: "1",
-		CLAWDI_NO_UPDATE_CHECK: "1",
-		CLAWDI_RUNTIME_REV: daemonProgramRevision(manifest),
-	});
-	const shouldRunDaemon =
-		daemonAuthTokenFile !== null && desiredLiveSyncAgents(manifest).length > 0;
+	const liveSyncAgents = desiredLiveSyncAgents(manifest);
+	const shouldRunDaemon = daemonAuthTokenFile !== null && liveSyncAgents.length > 0;
 	const shouldRunBridge = bridgeSurfaceSpecs.length > 0;
+	const mcpHttpEndpoint = externalMcpHttpEndpoint(manifest);
+	const shouldRunMcpHttp =
+		daemonAuthTokenFile !== null && mcpHttpAuthTokenFile !== null && mcpHttpEndpoint !== null;
 	const shouldRunMitm = mitmProgram !== null && runtimePrograms.length > 0;
 	const shouldRunSidecar = shouldRunBridge || shouldRunMitm;
 	const lines = [
@@ -1588,7 +2115,7 @@ function writeSupervisorConfig(
 		"",
 	];
 
-	if (runtimePrograms.length === 0 && !shouldRunDaemon) {
+	if (runtimePrograms.length === 0 && !shouldRunDaemon && !shouldRunMcpHttp && !shouldRunSidecar) {
 		lines.push("; No enabled agent runtimes in the current manifest.", "");
 	}
 
@@ -1613,9 +2140,59 @@ function writeSupervisorConfig(
 	}
 
 	if (shouldRunDaemon && daemonAuthTokenFile) {
+		const script = `export CLAWDI_AUTH_TOKEN="$(cat ${shellQuote(
+			daemonAuthTokenFile,
+		)})"; exec /usr/bin/env clawdi daemon run`;
+		for (const agent of liveSyncAgents) {
+			const daemonEnvironment = supervisorEnvironment({
+				...commonEnvironment,
+				...liveSyncDaemonEnvironment(agent, manifest, paths),
+				CLAWDI_SERVE_MODE: "container",
+				CLAWDI_API_URL: manifest.controlPlane.apiUrl,
+				CLAWDI_NO_AUTO_UPDATE: "1",
+				CLAWDI_NO_UPDATE_CHECK: "1",
+				CLAWDI_RUNTIME_REV: daemonProgramRevision(manifest),
+			});
+			lines.push(
+				`[program:clawdi-daemon-${supervisorProgramSuffix(agent.agentId)}]`,
+				`command=/bin/sh -lc ${shellQuote(script)}`,
+				`directory=${workspaceRoot}`,
+				"autostart=true",
+				"autorestart=true",
+				"startsecs=2",
+				"startretries=5",
+				"stopasgroup=true",
+				"killasgroup=true",
+				"stdout_logfile=/dev/fd/1",
+				"stdout_logfile_maxbytes=0",
+				"stderr_logfile=/dev/fd/2",
+				"stderr_logfile_maxbytes=0",
+				`environment=${daemonEnvironment}`,
+				"",
+			);
+		}
+	}
+
+	if (shouldRunMcpHttp && daemonAuthTokenFile && mcpHttpAuthTokenFile && mcpHttpEndpoint) {
+		const script = [
+			`export CLAWDI_AUTH_TOKEN="$(cat ${shellQuote(daemonAuthTokenFile)})"`,
+			`export ${MCP_HTTP_AUTH_TOKEN_ENV}="$(cat ${shellQuote(mcpHttpAuthTokenFile)})"`,
+			`exec /usr/bin/env clawdi mcp http --host ${shellQuote(mcpHttpEndpoint.host)} --port ${shellQuote(
+				String(mcpHttpEndpoint.port),
+			)} --path ${shellQuote(mcpHttpEndpoint.path)} --auth-token-file ${shellQuote(
+				mcpHttpAuthTokenFile,
+			)}`,
+		].join("; ");
+		const mcpHttpEnvironment = supervisorEnvironment({
+			...commonEnvironment,
+			CLAWDI_API_URL: manifest.controlPlane.apiUrl,
+			CLAWDI_NO_AUTO_UPDATE: "1",
+			CLAWDI_NO_UPDATE_CHECK: "1",
+			CLAWDI_RUNTIME_REV: mcpHttpProgramRevision(manifest),
+		});
 		lines.push(
-			"[program:clawdi-daemon]",
-			`command=/usr/bin/env clawdi daemon run --auth-token-file ${shellQuote(daemonAuthTokenFile)}`,
+			"[program:clawdi-mcp-http]",
+			`command=/bin/sh -lc ${shellQuote(script)}`,
 			`directory=${workspaceRoot}`,
 			"autostart=true",
 			"autorestart=true",
@@ -1627,7 +2204,7 @@ function writeSupervisorConfig(
 			"stdout_logfile_maxbytes=0",
 			"stderr_logfile=/dev/fd/2",
 			"stderr_logfile_maxbytes=0",
-			`environment=${daemonEnvironment}`,
+			`environment=${mcpHttpEnvironment}`,
 			"",
 		);
 	}
@@ -1701,18 +2278,54 @@ function writeSupervisorConfig(
 	return paths.supervisorConfig;
 }
 
-function shouldSuperviseRuntime(runtime: string, manifest: RuntimeManifest): boolean {
-	const desired = manifest.runtimes[runtime];
-	if (!desired?.enabled) return false;
-	return isSupportedRuntimeName(runtime) || Boolean(desired.run?.command?.trim());
-}
-
 function runtimeServiceProgramName(runtime: string, service: string): string {
 	return `clawdi-${supervisorProgramSegment(runtime)}-${supervisorProgramSegment(service)}`;
 }
 
 function supervisorProgramSegment(value: string): string {
 	return value.replace(/[^A-Za-z0-9_-]+/g, "-");
+}
+
+function shouldWriteRuntimeRunConfig(name: string, runtime: RuntimeEntry): boolean {
+	if (isExternalRuntime(runtime)) return false;
+	return runtimeNameSchema.safeParse(name).success;
+}
+
+function writeRuntimeCommandShims(commands: Iterable<RuntimeName>, paths: RuntimePaths): void {
+	const binDir = runtimeManagedBinDir(paths);
+	const dispatcherPath = join(binDir, ".clawdi-runtime-command-shim");
+	const active: Set<RuntimeName> = new Set(
+		[...commands]
+			.filter((command) => command !== "clawdi")
+			.filter((command) => isSupportedRuntimeName(command))
+			.sort(),
+	);
+	const previous = readRuntimeCommandShimIndex(paths);
+	const staleCandidates = new Set<RuntimeName>([
+		...previous,
+		"codex",
+		...SUPPORTED_RUNTIME_NAMES,
+	] as RuntimeName[]);
+	for (const command of staleCandidates) {
+		if (!active.has(command)) rmSync(join(binDir, command), { force: true });
+	}
+	if (active.size === 0) {
+		rmSync(dispatcherPath, { force: true });
+		rmSync(runtimeCommandShimIndexPath(paths), { force: true });
+		return;
+	}
+	writePrivateFileAtomic(dispatcherPath, runtimeCommandShimScript(paths), {
+		mode: 0o755,
+		dirMode: 0o755,
+	});
+	makeRuntimeUserOwned(dispatcherPath);
+	for (const command of active) {
+		const shimPath = join(binDir, command);
+		rmSync(shimPath, { force: true });
+		symlinkSync(".clawdi-runtime-command-shim", shimPath);
+		makeRuntimeUserOwned(shimPath);
+	}
+	writeRuntimeCommandShimIndex(active, paths);
 }
 
 export function runtimeCommandShimScript(paths: RuntimePaths): string {
@@ -1737,6 +2350,36 @@ export function runtimeCommandShimScript(paths: RuntimePaths): string {
 		`exec ${shellQuote(paths.cliManagedBin)} run -- "$command_name" "$@"`,
 		"",
 	].join("\n");
+}
+
+function runtimeCommandShimIndexPath(paths: RuntimePaths): string {
+	return join(paths.serviceStateRoot, "config", "runtime-command-shims.json");
+}
+
+function readRuntimeCommandShimIndex(paths: RuntimePaths): RuntimeName[] {
+	const path = runtimeCommandShimIndexPath(paths);
+	if (!existsSync(path)) return [];
+	try {
+		const parsed = runtimeCommandShimIndexSchema.parse(JSON.parse(readFileSync(path, "utf-8")));
+		return parsed.commands;
+	} catch {
+		return [];
+	}
+}
+
+function writeRuntimeCommandShimIndex(commands: Set<RuntimeName>, paths: RuntimePaths): void {
+	writePrivateFileAtomic(
+		runtimeCommandShimIndexPath(paths),
+		`${JSON.stringify(
+			{
+				schemaVersion: "clawdi.runtimeCommandShims.v1",
+				commands: [...commands].sort(),
+			},
+			null,
+			2,
+		)}\n`,
+		{ mode: 0o644, dirMode: 0o755 },
+	);
 }
 
 function hostedRuntimeBridgeToken(): string {
@@ -1813,6 +2456,7 @@ export function convergeRuntimeManifest(
 	const runConfigs: string[] = [];
 	const runtimeSupervisorPrograms: RuntimeSupervisorProgram[] = [];
 	const installErrors: string[] = [];
+	const runtimeVersionObservations: Record<string, RuntimeVersionObservation> = {};
 
 	mkdirSync(workspaceRoot, { recursive: true });
 	makeRuntimeUserOwned(paths.userHome);
@@ -1845,14 +2489,27 @@ export function convergeRuntimeManifest(
 		instanceId: manifest.instanceId,
 		generation: manifest.generation,
 		runtimes: Object.fromEntries(
-			Object.entries(manifest.runtimes).map(([name, runtime]) => [
-				name,
-				{
-					enabled: runtime.enabled,
-					updateChannel: runtime.updateChannel ?? null,
-					workspaceRoot,
-				},
-			]),
+			Object.entries(manifest.runtimes).map(([name, runtime]) => {
+				const type = runtimeTypeForEntry(name, runtime);
+				return [
+					name,
+					{
+						runtimeType: type,
+						displayName: runtime.displayName ?? null,
+						environmentId: runtime.environmentId ?? null,
+						enabled: runtime.enabled,
+						image: runtime.image ?? null,
+						version: runtime.version ?? null,
+						updateChannel: runtime.updateChannel ?? null,
+						executionMode: runtimeExecutionMode(runtime),
+						externalHome: isExternalRuntime(runtime) ? (runtime.execution?.home ?? null) : null,
+						externalStateDir: isExternalRuntime(runtime)
+							? (runtime.execution?.stateDir ?? externalRuntimeDefaultStateDir(type, runtime))
+							: null,
+						workspaceRoot,
+					},
+				];
+			}),
 		),
 	});
 	writeJsonFile(paths.instanceData, {
@@ -1891,12 +2548,25 @@ export function convergeRuntimeManifest(
 	);
 	writeProviderHealthStatus(manifest, load.secretValues, paths);
 	const liveSyncEnvironments = writeLiveSyncEnvironmentFiles(manifest, paths);
+	const mcpHttpAuthTokenFile =
+		daemonAuthTokenFile !== null && externalMcpHttpEndpoint(manifest) !== null
+			? writeMcpHttpAuthToken(paths)
+			: null;
 	const writtenRunConfigIds = new Set<string>();
+	const commandShims = new Set<RuntimeName>();
 
 	for (const [name, runtime] of Object.entries(manifest.runtimes).sort(([a], [b]) =>
 		a.localeCompare(b),
 	)) {
 		const observation = observeRuntimeInstall(name, runtime);
+		const versionObservation = observeRuntimeVersion(
+			name,
+			runtime,
+			observation,
+			manifest,
+			workspaceRoot,
+		);
+		runtimeVersionObservations[name] = versionObservation;
 		if (observation.error) installErrors.push(observation.error);
 
 		const inventoryPath = join(paths.installInventory, `${name}.json`);
@@ -1904,13 +2574,19 @@ export function convergeRuntimeManifest(
 			schemaVersion: "clawdi.runtimeInstallInventory.v1",
 			generatedAt,
 			runtime: name,
+			runtimeType: runtimeTypeForEntry(name, runtime),
+			displayName: runtime.displayName ?? null,
+			environmentId: runtime.environmentId ?? null,
 			enabled: runtime.enabled,
+			image: runtime.image ?? null,
+			version: versionObservation,
 			updateChannel: runtime.updateChannel ?? null,
 			simulation: false,
 			status: observation.status,
 			executionUser: observation.executionUser,
+			execution: runtime.execution ?? null,
 			install: observation.install,
-			command: runtimeInstallerCommand(name, runtime.install),
+			command: runtimeInstallerCommand(name, runtimeTypeForEntry(name, runtime), runtime.install),
 			commandPath: observation.commandPath,
 			appRoot: observation.appRoot,
 			installerUrl: observation.installerUrl,
@@ -1929,7 +2605,7 @@ export function convergeRuntimeManifest(
 		writeJsonFile(projectionPath, projectionPayload(name, manifest));
 		projections.push(projectionPath);
 		try {
-			applyHostedAiProviderProjection(name, observation, manifest, workspaceRoot);
+			applyHostedAiProviderProjection(name, runtime, observation, manifest, workspaceRoot);
 		} catch (error) {
 			installErrors.push(
 				`runtime ${name} provider projection failed: ${
@@ -1938,7 +2614,7 @@ export function convergeRuntimeManifest(
 			);
 		}
 		try {
-			applyHostedChannelProjection(name, observation, manifest, workspaceRoot);
+			applyHostedChannelProjection(name, runtime, observation, manifest, workspaceRoot);
 		} catch (error) {
 			installErrors.push(
 				`runtime ${name} channel projection failed: ${
@@ -1947,7 +2623,15 @@ export function convergeRuntimeManifest(
 			);
 		}
 		try {
-			applyHostedMcpProjection(name, observation, manifest, workspaceRoot, daemonAuthTokenFile);
+			applyHostedMcpProjection(
+				name,
+				runtime,
+				observation,
+				manifest,
+				workspaceRoot,
+				daemonAuthTokenFile,
+				mcpHttpAuthTokenFile,
+			);
 		} catch (error) {
 			installErrors.push(
 				`runtime ${name} mcp projection failed: ${
@@ -1955,25 +2639,25 @@ export function convergeRuntimeManifest(
 				}`,
 			);
 		}
-		const runtimeName = runtimeNameSchema.parse(name);
-		const runConfig = buildRuntimeRunConfig({
-			runtime: runtimeName,
-			enabled: runtime.enabled,
-			generatedAt,
-			generation: manifest.generation,
-			instanceId: manifest.instanceId,
-			commandPath: observation.commandPath,
-			appRoot: observation.appRoot,
-			workspaceRoot,
-			mitmProfileBundlePath,
-			settings: runtime.run,
-			secretFilePath: mitmSecretFile,
-			secretEnv: hostedProviderSecretEnv(manifest, name),
-		});
-		const runConfigPath = writeRuntimeRunConfig(runConfig, paths);
-		runConfigs.push(runConfigPath);
-		writtenRunConfigIds.add(runtimeRunConfigId(runtimeName));
-		if (runtime.enabled && shouldSuperviseRuntime(name, manifest)) {
+		if (shouldWriteRuntimeRunConfig(name, runtime)) {
+			const runtimeName = runtimeNameSchema.parse(name);
+			const runConfig = buildRuntimeRunConfig({
+				runtime: runtimeName,
+				enabled: runtime.enabled,
+				generatedAt,
+				generation: manifest.generation,
+				instanceId: manifest.instanceId,
+				commandPath: observation.commandPath,
+				appRoot: observation.appRoot,
+				workspaceRoot,
+				mitmProfileBundlePath,
+				settings: runtime.run,
+				secretFilePath: mitmSecretFile,
+				secretEnv: hostedProviderSecretEnv(manifest, name),
+			});
+			const runConfigPath = writeRuntimeRunConfig(runConfig, paths);
+			runConfigs.push(runConfigPath);
+			writtenRunConfigIds.add(runtimeRunConfigId(runtimeName));
 			const program = buildRuntimeSupervisorProgram({
 				config: runConfig,
 				paths,
@@ -1983,34 +2667,34 @@ export function convergeRuntimeManifest(
 			if (program) {
 				runtimeSupervisorPrograms.push(program);
 			}
-		}
-		for (const [serviceName, serviceSettings] of Object.entries(runtime.services ?? {})) {
-			const service = runtimeServiceNameSchema.parse(serviceName);
-			const serviceRunConfig = buildRuntimeRunConfig({
-				runtime: runtimeName,
-				service,
-				enabled: runtime.enabled,
-				generatedAt,
-				generation: manifest.generation,
-				instanceId: manifest.instanceId,
-				commandPath: observation.commandPath,
-				appRoot: observation.appRoot,
-				workspaceRoot,
-				settings: serviceSettings,
-				secretFilePath: null,
-				secretEnv: {},
-			});
-			const serviceRunConfigPath = writeRuntimeRunConfig(serviceRunConfig, paths);
-			runConfigs.push(serviceRunConfigPath);
-			writtenRunConfigIds.add(runtimeRunConfigId(runtimeName, service));
-			const program = buildRuntimeSupervisorProgram({
-				config: serviceRunConfig,
-				paths,
-				secretValues: load.secretValues,
-				mitm: mitmSupervisorProgram,
-			});
-			if (program) {
-				runtimeSupervisorPrograms.push(program);
+			for (const [serviceName, serviceSettings] of Object.entries(runtime.services ?? {})) {
+				const service = runtimeServiceNameSchema.parse(serviceName);
+				const serviceRunConfig = buildRuntimeRunConfig({
+					runtime: runtimeName,
+					service,
+					enabled: runtime.enabled,
+					generatedAt,
+					generation: manifest.generation,
+					instanceId: manifest.instanceId,
+					commandPath: observation.commandPath,
+					appRoot: observation.appRoot,
+					workspaceRoot,
+					settings: serviceSettings,
+					secretFilePath: null,
+					secretEnv: {},
+				});
+				const serviceRunConfigPath = writeRuntimeRunConfig(serviceRunConfig, paths);
+				runConfigs.push(serviceRunConfigPath);
+				writtenRunConfigIds.add(runtimeRunConfigId(runtimeName, service));
+				const serviceProgram = buildRuntimeSupervisorProgram({
+					config: serviceRunConfig,
+					paths,
+					secretValues: load.secretValues,
+					mitm: mitmSupervisorProgram,
+				});
+				if (serviceProgram) {
+					runtimeSupervisorPrograms.push(serviceProgram);
+				}
 			}
 		}
 
@@ -2021,9 +2705,42 @@ export function convergeRuntimeManifest(
 		}
 	}
 
+	writeJsonFile(paths.syncState, {
+		schemaVersion: "clawdi.runtimeSyncState.v1",
+		generatedAt,
+		deploymentId: manifest.deploymentId,
+		environmentId: manifest.environmentId,
+		instanceId: manifest.instanceId,
+		generation: manifest.generation,
+		runtimes: Object.fromEntries(
+			Object.entries(manifest.runtimes).map(([name, runtime]) => {
+				const type = runtimeTypeForEntry(name, runtime);
+				return [
+					name,
+					{
+						runtimeType: type,
+						displayName: runtime.displayName ?? null,
+						environmentId: runtime.environmentId ?? null,
+						enabled: runtime.enabled,
+						image: runtime.image ?? null,
+						version: runtimeVersionObservations[name] ?? runtime.version ?? null,
+						updateChannel: runtime.updateChannel ?? null,
+						executionMode: runtimeExecutionMode(runtime),
+						externalHome: isExternalRuntime(runtime) ? (runtime.execution?.home ?? null) : null,
+						externalStateDir: isExternalRuntime(runtime)
+							? (runtime.execution?.stateDir ?? externalRuntimeDefaultStateDir(type, runtime))
+							: null,
+						workspaceRoot,
+					},
+				];
+			}),
+		),
+	});
+
 	const mcpProjection = join(paths.projectionRoot, "clawdi-mcp.json");
 	writeJsonFile(mcpProjection, projectionPayload("clawdi-mcp", manifest));
 	projections.push(mcpProjection);
+	writeRuntimeCommandShims(commandShims, paths);
 	const supervisorConfig = writeSupervisorConfig(
 		runtimeSupervisorPrograms,
 		mitmSupervisorProgram,
@@ -2031,6 +2748,7 @@ export function convergeRuntimeManifest(
 		paths,
 		workspaceRoot,
 		daemonAuthTokenFile,
+		mcpHttpAuthTokenFile,
 		load.secretValues,
 	);
 
@@ -2064,6 +2782,7 @@ export function convergeRuntimeManifest(
 			mitmSecretFile,
 			liveSyncEnvironments,
 			daemonAuthTokenFile,
+			mcpHttpAuthTokenFile,
 			instanceSemaphores,
 			bootFinished,
 		},

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1715,6 +1715,30 @@ function supervisorProgramSegment(value: string): string {
 	return value.replace(/[^A-Za-z0-9_-]+/g, "-");
 }
 
+export function runtimeCommandShimScript(paths: RuntimePaths): string {
+	return [
+		"#!/usr/bin/env sh",
+		"set -eu",
+		"command_name=$" + "{0##*/}",
+		'shim_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)',
+		"old_ifs=$" + "{IFS-}",
+		"IFS=:",
+		"clean_path=",
+		"for dir in $" + "{PATH-}; do",
+		'  [ "$dir" = "$shim_dir" ] && continue',
+		'  if [ -z "$clean_path" ]; then clean_path=$dir; else clean_path=$clean_path:$dir; fi',
+		"done",
+		"IFS=$old_ifs",
+		"export PATH=$clean_path",
+		"first_arg=$" + "{1-}",
+		'if [ "$command_name" = "openclaw" ] && { [ "$first_arg" = "update" ] || [ "$first_arg" = "--update" ]; }; then',
+		'  exec "$command_name" "$@"',
+		"fi",
+		`exec ${shellQuote(paths.cliManagedBin)} run -- "$command_name" "$@"`,
+		"",
+	].join("\n");
+}
+
 function hostedRuntimeBridgeToken(): string {
 	const direct = process.env[RUNTIME_BRIDGE_TOKEN_ENV]?.trim();
 	if (direct) return direct;

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -48,6 +48,7 @@ export interface RuntimePaths {
 	managedSecretRoot: string;
 	managedSecretFile: string;
 	daemonAuthToken: string;
+	mcpHttpAuthToken: string;
 	instanceData: string;
 	sensitiveInstanceData: string;
 	workspaceRoot: string;
@@ -138,6 +139,7 @@ export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths
 		managedSecretRoot: join(runRoot, "secrets"),
 		managedSecretFile: join(runRoot, "secrets", "runtime-secrets.json"),
 		daemonAuthToken: join(runRoot, "secrets", "auth-token"),
+		mcpHttpAuthToken: join(runRoot, "secrets", "mcp-http-token"),
 		instanceData: join(runRoot, "instance-data.json"),
 		sensitiveInstanceData: join(runRoot, "instance-data-sensitive.json"),
 		workspaceRoot: join(userHome, "clawdi"),

--- a/packages/cli/src/runtime/sidecar-image.test.ts
+++ b/packages/cli/src/runtime/sidecar-image.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const runtimeDir = fileURLToPath(new URL(".", import.meta.url));
+const repoRoot = resolve(runtimeDir, "../../../..");
+
+function repoFile(path: string): string {
+	return readFileSync(resolve(repoRoot, path), "utf8");
+}
+
+describe("runtime sidecar image contract", () => {
+	it("builds a dedicated sidecar envelope without bundling agent runtimes", () => {
+		const dockerfile = repoFile("packages/cli/Dockerfile.runtime-sidecar");
+
+		expect(dockerfile).toContain("FROM node:24-bookworm-slim AS runtime");
+		expect(dockerfile).toContain("FROM golang:1.26-bookworm AS mitm-builder");
+		expect(dockerfile).toContain("supervisor");
+		expect(dockerfile).toContain("gosu");
+		expect(dockerfile).toContain("util-linux");
+		expect(dockerfile).toContain("clawdi-runtime-nsenter");
+		expect(dockerfile).toContain("packages/cli/native/mitm-sidecar");
+		expect(dockerfile).toContain("CLAWDI_MITM_SIDECAR_BUNDLE");
+		expect(dockerfile).toContain("CLAWDI_RUNTIME_DEFAULT_CLI_PACKAGE_SPEC");
+		expect(dockerfile).toContain("npm pack --pack-destination");
+		expect(dockerfile).toContain("ENTRYPOINT");
+		expect(dockerfile).toContain('ENTRYPOINT ["/usr/bin/tini", "-s", "--"');
+		expect(dockerfile).not.toContain("mitm-broker");
+		expect(dockerfile).not.toContain("openclaw.ai/install-cli.sh");
+		expect(dockerfile).not.toContain("hermes-agent.nousresearch.com/install.sh");
+	});
+
+	it("includes a same-Pod nsenter control adapter without embedding agent CLIs", () => {
+		const helper = repoFile("packages/cli/docker/runtime-nsenter-control.sh");
+
+		expect(helper).toContain("Usage:");
+		expect(helper).toContain("--state-dir");
+		expect(helper).toContain("--marker");
+		expect(helper).toContain("nsenter");
+		expect(helper).toContain('--root="/proc/$target_pid/root"');
+		expect(helper).toContain('--wdns="$workdir"');
+		expect(helper).toContain('--setuid="$target_uid"');
+		expect(helper).not.toContain("openclaw config");
+		expect(helper).not.toContain("hermes");
+	});
+
+	it("starts by converging desired state and then hands off to supervisor", () => {
+		const entrypoint = repoFile("packages/cli/docker/runtime-sidecar-entrypoint.sh");
+
+		expect(entrypoint).toContain("clawdi runtime init --non-interactive --json");
+		expect(entrypoint).toContain(
+			'exec supervisord -c "$' + '{CLAWDI_RUN_DIR}/supervisor/supervisord.conf"',
+		);
+		expect(entrypoint).toContain('schemaVersion: "clawdi.hostPolicy.v1"');
+		expect(entrypoint).toContain("CLAWDI_RUNTIME_MANIFEST_URL");
+		expect(entrypoint).toContain("CLAWDI_RUNTIME_AUTH_ENV");
+	});
+
+	it("publishes the sidecar image independently of backend deploys", () => {
+		const workflow = repoFile(".github/workflows/clawdi-image-release.yml");
+
+		expect(workflow).toContain("SIDECAR_IMAGE_NAME: ghcr.io/clawdi-ai/clawdi-runtime-sidecar");
+		expect(workflow).toContain("packages/cli/Dockerfile.runtime-sidecar");
+		expect(workflow).toContain("sidecar_build_required");
+		expect(workflow).toContain(
+			"if: needs.build.outputs.backend_build_required == 'true' && needs.build.outputs.should_deploy == 'true'",
+		);
+	});
+});

--- a/packages/cli/tests/runtime-bridge.test.ts
+++ b/packages/cli/tests/runtime-bridge.test.ts
@@ -56,6 +56,8 @@ describe("runtime bridge configuration", () => {
 					listenPort,
 					upstreamHost: "127.0.0.1",
 					upstreamPort: serverPort(upstream),
+					upstreamHeaders: {},
+					upstreamHeaderEnv: {},
 				},
 			]);
 			const response = await fetch(`http://127.0.0.1:${listenPort}/`, {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -61,6 +61,7 @@ const ENV_KEYS = [
 	"CLAWDI_RUNTIME_MANIFEST_URL",
 	"CLAWDI_RUNTIME_SOURCE_PATH",
 	"CLAWDI_RUNTIME_AUTH_ENV",
+	"CLAWDI_RUNTIME_DEFAULT_CLI_PACKAGE_SPEC",
 	"CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS",
 	"CLAWDI_RUNTIME_INSTALL_TIMEOUT",
 	"CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER",
@@ -418,7 +419,7 @@ describe("runtime manifest datasource", () => {
 				generation: 3,
 				issuedAt: "2026-06-06T00:00:00Z",
 				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: { openclaw: { enabled: false } },
+				runtimes: { openclaw: { type: "openclaw", enabled: false } },
 				projection: {
 					providers: {
 						default: {
@@ -493,11 +494,13 @@ describe("runtime manifest datasource", () => {
 							},
 							runtimes: {
 								openclaw: {
+									type: "openclaw",
 									enabled: true,
 									install: { source: "official", channel: "stable" },
 									paths: { home },
 								},
 								hermes: {
+									type: "hermes",
 									enabled: false,
 									install: { source: "official", channel: "stable" },
 									paths: { home },
@@ -575,7 +578,55 @@ describe("runtime manifest datasource", () => {
 		}
 	});
 
-	it("recovers hosted bridge token from pid1 env for runtime-watch and runtime sidecar bridge module", async () => {
+	it("uses the sidecar image CLI bootstrap package as the hosted default when configured", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const manifestPath = join(root, "hosted-manifest.json");
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_RUNTIME_DEFAULT_CLI_PACKAGE_SPEC =
+			"/usr/local/share/clawdi/bootstrap/clawdi-runtime-bootstrap.tgz";
+		writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				manifest: {
+					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					deploymentId: "dep_bootstrap",
+					environmentId: "env_bootstrap",
+					instanceId: "iid_bootstrap",
+					generation: 1,
+					issuedAt: "2026-07-01T00:00:00Z",
+					system: { home },
+					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+					runtimeTargets: {
+						"openclaw-a": {
+							type: "openclaw",
+							enabled: true,
+							execution: {
+								mode: "external",
+								stateDir: "/state/openclaw-a",
+							},
+						},
+					},
+				},
+				secretValues: {},
+			}),
+		);
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths(), { manifestPath });
+
+		expect("manifest" in loaded).toBe(true);
+		if (!("manifest" in loaded)) throw new Error("expected manifest load success");
+		expect(loaded.manifest.clawdiCli?.source).toBe("npm:clawdi");
+		expect(loaded.manifest.clawdiCli?.packageSpec).toBe(
+			"/usr/local/share/clawdi/bootstrap/clawdi-runtime-bootstrap.tgz",
+		);
+	});
+
+	it("recovers hosted bridge token from pid1 env for runtime-watch and runtime bridge supervisor programs", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -643,11 +694,13 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 							},
 							runtimes: {
 								openclaw: {
+									type: "openclaw",
 									enabled: true,
 									install: { source: "official", channel: "stable" },
 									paths: { home },
 								},
 								hermes: {
+									type: "hermes",
 									enabled: false,
 									install: { source: "official", channel: "stable" },
 									paths: { home },
@@ -734,8 +787,8 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							runtimes: {
-								openclaw: { enabled: false },
-								hermes: { enabled: false },
+								openclaw: { type: "openclaw", enabled: false },
+								hermes: { type: "hermes", enabled: false },
 							},
 							providers: {
 								default: {
@@ -802,8 +855,8 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							runtimes: {
-								openclaw: { enabled: false },
-								hermes: { enabled: false },
+								openclaw: { type: "openclaw", enabled: false },
+								hermes: { type: "hermes", enabled: false },
 							},
 							providers: {
 								default: {
@@ -850,6 +903,10 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 			openclawBin,
 			[
 				"#!/bin/sh",
+				'if [ "$1" = "--version" ]; then',
+				"  printf 'OpenClaw test\\n'",
+				"  exit 0",
+				"fi",
 				`printf '%s\\n' "$*" > '${openclawCommand}'`,
 				'if [ "$1 $2 $3 $4 $5" = "config patch --stdin --replace-path models.providers" ]; then',
 				`  cat > '${openclawPatch}'`,
@@ -867,8 +924,8 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 			sourcePath: "https://runtime-source.test/desired-state",
 			offline: false,
 			secretValues: {
-				"provider.default.apiKey": "sk-runtime-provider",
-				"secret://provider.default.apiKey": "sk-runtime-provider",
+				"provider.openclaw.apiKey": "sk-runtime-provider",
+				"secret://provider.openclaw.apiKey": "sk-runtime-provider",
 			},
 			manifest: {
 				schemaVersion: "clawdi.runtimeDesiredState.v1",
@@ -881,6 +938,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 				controlPlane: { apiUrl: "https://cloud-api.test" },
 				runtimes: {
 					openclaw: {
+						type: "openclaw",
 						enabled: true,
 						install: {
 							authority: "official",
@@ -890,19 +948,19 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 							args: ["--json", "--no-onboard"],
 						},
 					},
-					hermes: { enabled: false },
+					hermes: { type: "hermes", enabled: false },
 				},
 				projection: {
 					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
 					system: { home },
 					providers: {
-						default: {
+						openclaw: {
 							kind: "openai-compatible",
 							baseUrl: "https://ai-gateway.example.test/v1",
 							model: "gpt-5.4-mini",
 							apiMode: "openai_chat",
 							runtimeEnvName: "CLAWDI_MANAGED_OPENAI_API_KEY",
-							apiKeySecretRef: "provider.default.apiKey",
+							apiKeySecretRef: "provider.openclaw.apiKey",
 						},
 					},
 				},
@@ -918,7 +976,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 			"config patch --stdin --replace-path models.providers",
 		);
 		const patch = JSON.parse(readFileSync(openclawPatch, "utf-8"));
-		expect(patch.agents.defaults.model.primary).toBe("default/gpt-5.4-mini");
+		expect(patch.agents.defaults.model.primary).toBe("openclaw/gpt-5.4-mini");
 		expect(patch.secrets).toEqual({
 			providers: {
 				default: { source: "env" },
@@ -927,7 +985,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 				env: "default",
 			},
 		});
-		expect(patch.models.providers.default).toMatchObject({
+		expect(patch.models.providers.openclaw).toMatchObject({
 			baseUrl: "https://ai-gateway.example.test/v1",
 			apiKey: {
 				source: "env",
@@ -935,14 +993,14 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 				id: "CLAWDI_MANAGED_OPENAI_API_KEY",
 			},
 		});
-		expect(patch.models.providers.default.api).toBeUndefined();
+		expect(patch.models.providers.openclaw.api).toBeUndefined();
 		expect(JSON.stringify(patch)).not.toContain("agentRuntime");
 		expect(JSON.stringify(patch)).not.toContain("chatgpt.com");
 		const runConfig = JSON.parse(
 			readFileSync(join(state, "config", "run", "openclaw.json"), "utf-8"),
 		);
 		expect(runConfig.secretEnv).toEqual({
-			CLAWDI_MANAGED_OPENAI_API_KEY: "secret://provider.default.apiKey",
+			CLAWDI_MANAGED_OPENAI_API_KEY: "secret://provider.openclaw.apiKey",
 		});
 		expect(runConfig.secretFilePath).toBe(join(run, "secrets", "runtime-secrets.json"));
 		expect(JSON.stringify(runConfig)).not.toContain("sk-runtime-provider");
@@ -996,6 +1054,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 				controlPlane: { apiUrl: "https://cloud-api.test" },
 				runtimes: {
 					openclaw: {
+						type: "openclaw",
 						enabled: true,
 						install: {
 							authority: "official",
@@ -1006,6 +1065,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 						},
 					},
 					hermes: {
+						type: "hermes",
 						enabled: true,
 						install: {
 							authority: "official",
@@ -1114,6 +1174,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 				controlPlane: { apiUrl: "https://cloud-api.test" },
 				runtimes: {
 					openclaw: {
+						type: "openclaw",
 						enabled: true,
 						install: {
 							authority: "official",
@@ -1192,6 +1253,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 				controlPlane: { apiUrl: "https://cloud-api.test" },
 				runtimes: {
 					hermes: {
+						type: "hermes",
 						enabled: true,
 						install: {
 							authority: "official",
@@ -1258,23 +1320,23 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 					system: { home, workspace: join(home, "clawdi") },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					runtimes: {
-						openclaw: { enabled: true },
-						hermes: { enabled: false },
+						openclaw: { type: "openclaw", enabled: true },
+						hermes: { type: "hermes", enabled: false },
 					},
 					providers: {
-						default: {
+						openclaw: {
 							kind: "openai-compatible",
 							baseUrl: "https://ai-gateway.example.test/v1",
 							model: "gpt-5.5",
 							apiMode: "openai_responses",
 							runtimeEnvName: "CLAWDI_MANAGED_OPENAI_API_KEY",
-							apiKeySecretRef: "provider.default.apiKey",
+							apiKeySecretRef: "provider.openclaw.apiKey",
 						},
 					},
 					recovery: { cacheManifest: true, allowOfflineBoot: true },
 				},
 				secretValues: {
-					"provider.default.apiKey": "sk-runtime-provider",
+					"provider.openclaw.apiKey": "sk-runtime-provider",
 				},
 			}),
 		);
@@ -1290,12 +1352,12 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 			readFileSync(join(state, "config", "run", "openclaw.json"), "utf-8"),
 		);
 		expect(runConfig.secretEnv).toEqual({
-			CLAWDI_MANAGED_OPENAI_API_KEY: "secret://provider.default.apiKey",
+			CLAWDI_MANAGED_OPENAI_API_KEY: "secret://provider.openclaw.apiKey",
 		});
 		expect(runConfig.secretFilePath).toBe(join(run, "secrets", "runtime-secrets.json"));
 		expect(JSON.stringify(runConfig)).not.toContain("sk-runtime-provider");
 		const secrets = JSON.parse(readFileSync(join(run, "secrets", "runtime-secrets.json"), "utf-8"));
-		expect(secrets["secret://provider.default.apiKey"]).toBe("sk-runtime-provider");
+		expect(secrets["secret://provider.openclaw.apiKey"]).toBe("sk-runtime-provider");
 	});
 
 	it("does not infer runtime entries from the runtime bridge token", async () => {
@@ -1322,7 +1384,12 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 					system: { home },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					runtimes: {
-						openclaw: { enabled: true, install: { source: "official" }, paths: { home } },
+						openclaw: {
+							type: "openclaw",
+							enabled: true,
+							install: { source: "official" },
+							paths: { home },
+						},
 					},
 				},
 				secretValues: {},
@@ -1361,8 +1428,18 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 					system: { home },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					runtimes: {
-						openclaw: { enabled: true, install: { source: "official" }, paths: { home } },
-						hermes: { enabled: false, install: { source: "official" }, paths: { home } },
+						openclaw: {
+							type: "openclaw",
+							enabled: true,
+							install: { source: "official" },
+							paths: { home },
+						},
+						hermes: {
+							type: "hermes",
+							enabled: false,
+							install: { source: "official" },
+							paths: { home },
+						},
 					},
 				},
 				secretValues: {},
@@ -1412,7 +1489,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 							issuedAt: "2026-06-06T00:00:00Z",
 							system: { home },
 							controlPlane: { cloudApiUrl: "https://cloud-api.test" },
-							runtimes: { hermes: { enabled: false } },
+							runtimes: { hermes: { type: "hermes", enabled: false } },
 						},
 						secretValues: {},
 					}),
@@ -1565,8 +1642,8 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 				system: { home: "/home/clawdi", workspace: "/home/clawdi/clawdi" },
 				controlPlane: { apiUrl: "https://cloud-api.test" },
 				runtimes: {
-					openclaw: { enabled: true },
-					hermes: { enabled: false },
+					openclaw: { type: "openclaw", enabled: true },
+					hermes: { type: "hermes", enabled: false },
 				},
 			},
 			source: "remote-datasource",
@@ -1599,8 +1676,8 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 				system: { home: "/home/clawdi", workspace: "/home/clawdi/clawdi" },
 				controlPlane: { apiUrl: "https://cloud-api.test" },
 				runtimes: {
-					openclaw: { enabled: true },
-					hermes: { enabled: false },
+					openclaw: { type: "openclaw", enabled: true },
+					hermes: { type: "hermes", enabled: false },
 				},
 				mitmProfiles: {
 					profiles: [
@@ -1695,8 +1772,8 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 				issuedAt: "2026-06-14T00:00:00Z",
 				controlPlane: { apiUrl: "https://cloud-api.test" },
 				runtimes: {
-					openclaw: { enabled: true },
-					hermes: { enabled: false },
+					openclaw: { type: "openclaw", enabled: true },
+					hermes: { type: "hermes", enabled: false },
 				},
 				projection: {
 					providers: {
@@ -1843,8 +1920,8 @@ fi
 								system: { home, workspace: join(home, "clawdi") },
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								runtimes: {
-									openclaw: { enabled: false },
-									hermes: { enabled: false },
+									openclaw: { type: "openclaw", enabled: false },
+									hermes: { type: "hermes", enabled: false },
 								},
 							},
 							secretValues: {},
@@ -1953,11 +2030,12 @@ fi
 				controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 				runtimes: {
 					openclaw: {
+						type: "openclaw",
 						enabled: true,
 						install: { source: "official", channel: "stable" },
 						paths: { home },
 					},
-					hermes: { enabled: false },
+					hermes: { type: "hermes", enabled: false },
 				},
 				providers: {
 					default: {
@@ -2233,7 +2311,10 @@ fi
 								issuedAt: "2026-06-06T00:00:00Z",
 								system: { home, workspace: join(home, "clawdi") },
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
-								runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
+								runtimes: {
+									openclaw: { type: "openclaw", enabled: false },
+									hermes: { type: "hermes", enabled: false },
+								},
 							},
 							secretValues: {},
 						}),
@@ -2488,7 +2569,7 @@ fi
 				generation: 9,
 				issuedAt: "2026-06-06T00:00:00Z",
 				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: { openclaw: { enabled: true } },
+				runtimes: { openclaw: { type: "openclaw", enabled: true } },
 				projection: {
 					providers: {
 						default: {
@@ -2571,7 +2652,7 @@ fi
 				generation: 10,
 				issuedAt: "2026-06-06T00:00:00Z",
 				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: { openclaw: { enabled: true } },
+				runtimes: { openclaw: { type: "openclaw", enabled: true } },
 				projection: {
 					providers: {
 						default: {
@@ -2729,8 +2810,8 @@ fi
 									packageSpec: "clawdi@0.13.1-beta.0",
 								},
 								runtimes: {
-									openclaw: { enabled: false },
-									hermes: { enabled: false },
+									openclaw: { type: "openclaw", enabled: false },
+									hermes: { type: "hermes", enabled: false },
 								},
 							},
 							secretValues: {},
@@ -2869,7 +2950,10 @@ chmod +x "$prefix/bin/clawdi"
 					system: { home, workspace: join(home, "clawdi") },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@beta" },
-					runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
+					runtimes: {
+						openclaw: { type: "openclaw", enabled: false },
+						hermes: { type: "hermes", enabled: false },
+					},
 				},
 				paths,
 			);
@@ -2989,8 +3073,8 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@0.13.3-beta.0" },
 								runtimes: {
-									openclaw: { enabled: true },
-									hermes: { enabled: false },
+									openclaw: { type: "openclaw", enabled: true },
+									hermes: { type: "hermes", enabled: false },
 								},
 							},
 							secretValues: {},
@@ -3114,8 +3198,8 @@ fi
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@0.13.4-beta.0" },
 								runtimes: {
-									openclaw: { enabled: false },
-									hermes: { enabled: false },
+									openclaw: { type: "openclaw", enabled: false },
+									hermes: { type: "hermes", enabled: false },
 								},
 							},
 							secretValues: {},
@@ -3218,8 +3302,8 @@ chmod +x "$prefix/bin/clawdi"
 				packageSpec: "clawdi@0.13.2-beta.0",
 			},
 			runtimes: {
-				openclaw: { enabled: false },
-				hermes: { enabled: false },
+				openclaw: { type: "openclaw", enabled: false },
+				hermes: { type: "hermes", enabled: false },
 			},
 			recovery: {},
 		};
@@ -3254,7 +3338,10 @@ chmod +x "$prefix/bin/clawdi"
 			issuedAt: "2026-06-06T00:00:00Z",
 			controlPlane: { apiUrl: "https://cloud-api.test" },
 			clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@0.13.2-beta.0" },
-			runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
+			runtimes: {
+				openclaw: { type: "openclaw", enabled: false },
+				hermes: { type: "hermes", enabled: false },
+			},
 			recovery: {},
 		};
 
@@ -3335,7 +3422,10 @@ chmod +x "$prefix/bin/clawdi"
 			issuedAt: "2026-06-06T00:00:00Z",
 			controlPlane: { apiUrl: "https://cloud-api.test" },
 			clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@0.13.6-beta.0" },
-			runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
+			runtimes: {
+				openclaw: { type: "openclaw", enabled: false },
+				hermes: { type: "hermes", enabled: false },
+			},
 			recovery: {},
 		};
 
@@ -3408,7 +3498,10 @@ chmod +x "$prefix/bin/clawdi"
 			issuedAt: "2026-06-06T00:00:00Z",
 			controlPlane: { apiUrl: "https://cloud-api.test" },
 			clawdiCli: { source: "npm:clawdi", packageSpec },
-			runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
+			runtimes: {
+				openclaw: { type: "openclaw", enabled: false },
+				hermes: { type: "hermes", enabled: false },
+			},
 			recovery: {},
 		});
 
@@ -3511,10 +3604,11 @@ exit 64
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								runtimes: {
 									openclaw: {
+										type: "openclaw",
 										enabled: true,
 										install: { source: "official", args: [] },
 									},
-									hermes: { enabled: false },
+									hermes: { type: "hermes", enabled: false },
 								},
 							},
 							secretValues: {},
@@ -3657,6 +3751,7 @@ exit 0
 				controlPlane: { apiUrl: "https://cloud-api.test" },
 				runtimes: {
 					openclaw: {
+						type: "openclaw",
 						enabled: true,
 						install: {
 							authority: "official",
@@ -3666,7 +3761,7 @@ exit 0
 							args: [],
 						},
 					},
-					hermes: { enabled: false },
+					hermes: { type: "hermes", enabled: false },
 				},
 				projection: {
 					system: { home, workspace },
@@ -3738,6 +3833,7 @@ exit 64
 				controlPlane: { apiUrl: "https://cloud-api.test" },
 				runtimes: {
 					openclaw: {
+						type: "openclaw",
 						enabled: true,
 						install: {
 							authority: "official",
@@ -3747,7 +3843,7 @@ exit 64
 							args: [],
 						},
 					},
-					hermes: { enabled: false },
+					hermes: { type: "hermes", enabled: false },
 				},
 				projection: {
 					system: { home, workspace },
@@ -3837,6 +3933,7 @@ exit 64
 				controlPlane: { apiUrl: "https://cloud-api.test" },
 				runtimes: {
 					openclaw: {
+						type: "openclaw",
 						enabled: true,
 						install: {
 							authority: "official",
@@ -3846,7 +3943,7 @@ exit 64
 							args: [],
 						},
 					},
-					hermes: { enabled: false },
+					hermes: { type: "hermes", enabled: false },
 				},
 				projection: {
 					system: { home, workspace },
@@ -3900,7 +3997,7 @@ exit 64
 							system: { home, workspace },
 							controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 							runtimes: {
-								hermes: { enabled: false },
+								hermes: { type: "hermes", enabled: false },
 							},
 						},
 						secretValues: {},
@@ -3954,6 +4051,7 @@ exit 64
 				controlPlane: { apiUrl: "https://cloud-api.test" },
 				runtimes: {
 					"future-agent": {
+						type: "codex",
 						enabled: true,
 						run: {
 							command: futureBin,
@@ -4009,7 +4107,7 @@ exit 64
 					system: { home },
 					controlPlane: { apiUrl: "https://api.test" },
 					runtimes: {
-						hermes: { enabled: false },
+						hermes: { type: "hermes", enabled: false },
 					},
 				},
 				secretValues: {},
@@ -4048,6 +4146,7 @@ exit 64
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					runtimes: {
 						hermes: {
+							type: "hermes",
 							enabled: false,
 							paths: { workspace: runtimeWorkspace },
 						},
@@ -4118,6 +4217,7 @@ exit 64
 				controlPlane: { apiUrl: "https://cloud-api.test" },
 				runtimes: {
 					openclaw: {
+						type: "openclaw",
 						enabled: true,
 						install: {
 							authority: "official",
@@ -4128,6 +4228,7 @@ exit 64
 						},
 					},
 					hermes: {
+						type: "hermes",
 						enabled: true,
 						install: {
 							authority: "official",
@@ -4195,6 +4296,7 @@ exit 64
 				controlPlane: { apiUrl: "https://cloud-api.test" },
 				runtimes: {
 					openclaw: {
+						type: "openclaw",
 						enabled: true,
 						install: {
 							authority: "official",
@@ -4205,6 +4307,7 @@ exit 64
 						},
 					},
 					hermes: {
+						type: "hermes",
 						enabled: true,
 						install: {
 							authority: "official",
@@ -4253,8 +4356,8 @@ exit 64
 					issuedAt: "2026-06-15T00:00:00Z",
 					controlPlane: { apiUrl: "https://cloud-api.test" },
 					runtimes: {
-						openclaw: { enabled: true },
-						hermes: { enabled: false },
+						openclaw: { type: "openclaw", enabled: true },
+						hermes: { type: "hermes", enabled: false },
 					},
 					recovery: {},
 				},
@@ -4294,8 +4397,8 @@ exit 64
 					issuedAt: "2026-06-15T00:00:00Z",
 					controlPlane: { apiUrl: "https://cloud-api.test" },
 					runtimes: {
-						openclaw: { enabled: true },
-						hermes: { enabled: false },
+						openclaw: { type: "openclaw", enabled: true },
+						hermes: { type: "hermes", enabled: false },
 					},
 					bridge: {
 						surfaces: [
@@ -4361,8 +4464,8 @@ exit 64
 					issuedAt: "2026-06-26T00:00:00Z",
 					controlPlane: { apiUrl: "https://cloud-api.test" },
 					runtimes: {
-						openclaw: { enabled: true },
-						hermes: { enabled: false },
+						openclaw: { type: "openclaw", enabled: true },
+						hermes: { type: "hermes", enabled: false },
 					},
 					bridge: {
 						surfaces: [
@@ -4564,7 +4667,10 @@ exit 64
 			generation: 1,
 			issuedAt: "2026-06-06T00:00:00Z",
 			controlPlane: { apiUrl: "https://cloud-api.test" },
-			runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
+			runtimes: {
+				openclaw: { type: "openclaw", enabled: false },
+				hermes: { type: "hermes", enabled: false },
+			},
 			recovery: { cacheManifest: true, allowOfflineBoot: true },
 		};
 		writeFileSync(cachePath, JSON.stringify(previousManifest));
@@ -4572,7 +4678,10 @@ exit 64
 			manifest: {
 				...previousManifest,
 				generation: 2,
-				runtimes: { openclaw: { enabled: true }, hermes: { enabled: false } },
+				runtimes: {
+					openclaw: { type: "openclaw", enabled: true },
+					hermes: { type: "hermes", enabled: false },
+				},
 			} as RuntimeManifest,
 			source: "fixture-file",
 			sourcePath: "test://install-error",
@@ -4608,8 +4717,8 @@ exit 64
 			controlPlane: { apiUrl: "https://cloud-api.test" },
 			clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@0.13.0-test" },
 			runtimes: {
-				openclaw: { enabled: true },
-				hermes: { enabled: false },
+				openclaw: { type: "openclaw", enabled: true },
+				hermes: { type: "hermes", enabled: false },
 			},
 			recovery: {},
 		};
@@ -4645,7 +4754,7 @@ exit 64
 				...baseManifest,
 				runtimes: {
 					...baseManifest.runtimes,
-					hermes: { enabled: true },
+					hermes: { type: "hermes", enabled: true },
 				},
 			},
 			"openclaw",
@@ -4674,7 +4783,10 @@ exit 64
 			generation: 42,
 			issuedAt: "2026-06-06T00:00:00Z",
 			controlPlane: { apiUrl: "https://cloud-api.test" },
-			runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
+			runtimes: {
+				openclaw: { type: "openclaw", enabled: false },
+				hermes: { type: "hermes", enabled: false },
+			},
 			recovery: { cacheManifest: true, allowOfflineBoot: true },
 		};
 		writeFileSync(paths.manifestLastGood, JSON.stringify(previousManifest));
@@ -4714,7 +4826,10 @@ exit 64
 				generation: 1,
 				issuedAt: "2026-06-06T00:00:00Z",
 				controlPlane: { apiUrl: "https://cloud-api.test" },
-				runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
+				runtimes: {
+					openclaw: { type: "openclaw", enabled: false },
+					hermes: { type: "hermes", enabled: false },
+				},
 				mitmProfiles: {
 					profiles: [
 						{
@@ -4774,8 +4889,8 @@ exit 64
 								manifestUrl: "https://runtime-source.test/v1/desired-state/",
 							},
 							runtimes: {
-								openclaw: { enabled: false },
-								hermes: { enabled: false },
+								openclaw: { type: "openclaw", enabled: false },
+								hermes: { type: "hermes", enabled: false },
 							},
 						},
 						secretValues: {},
@@ -4823,8 +4938,18 @@ exit 64
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							runtimes: {
-								openclaw: { enabled: false, install: { source: "official" }, paths: { home } },
-								hermes: { enabled: false, install: { source: "official" }, paths: { home } },
+								openclaw: {
+									type: "openclaw",
+									enabled: false,
+									install: { source: "official" },
+									paths: { home },
+								},
+								hermes: {
+									type: "hermes",
+									enabled: false,
+									install: { source: "official" },
+									paths: { home },
+								},
 							},
 							providers: {
 								default: {
@@ -4913,7 +5038,7 @@ exit 64
 				issuedAt: "2026-06-06T00:00:00Z",
 				controlPlane: { apiUrl: "https://cloud-api.example.test" },
 				runtimes: {
-					hermes: { enabled: false },
+					hermes: { type: "hermes", enabled: false },
 				},
 				mitmProfiles: { profiles: [] },
 				recovery: { cacheManifest: true, allowOfflineBoot: true },
@@ -4954,7 +5079,7 @@ exit 64
 			issuedAt: "2026-06-06T00:00:00Z",
 			controlPlane: { apiUrl: "https://cloud-api.example.test" },
 			runtimes: {
-				hermes: { enabled: false },
+				hermes: { type: "hermes", enabled: false },
 			},
 			recovery: { cacheManifest: true, allowOfflineBoot: true },
 		};
@@ -4999,7 +5124,7 @@ exit 64
 				expiresAt: "2000-01-01T00:00:00Z",
 				controlPlane: { apiUrl: "https://cloud-api.example.test" },
 				runtimes: {
-					hermes: { enabled: false },
+					hermes: { type: "hermes", enabled: false },
 				},
 				recovery: { cacheManifest: true, allowOfflineBoot: true },
 			}),
@@ -5034,7 +5159,7 @@ exit 64
 				issuedAt: "2026-06-06T00:00:00Z",
 				controlPlane: { apiUrl: "https://cloud-api.example.test" },
 				runtimes: {
-					hermes: { enabled: false },
+					hermes: { type: "hermes", enabled: false },
 				},
 				secrets: [{ ref: "secret://old", exposeAs: "OLD_SECRET" }],
 				recovery: { cacheManifest: true, allowOfflineBoot: true },
@@ -5050,7 +5175,7 @@ exit 64
 		expect(loaded.errors.join("\n")).toContain("secrets");
 	});
 
-	it("registers live-sync environments and starts one hosted daemon", async () => {
+	it("registers live-sync environments and starts target-scoped hosted daemons", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -5080,14 +5205,28 @@ exit 64
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							runtimes: {
-								openclaw: { enabled: false, install: { source: "official" }, paths: { home } },
-								hermes: { enabled: false, install: { source: "official" }, paths: { home } },
+								openclaw: {
+									type: "openclaw",
+									enabled: false,
+									install: { source: "official" },
+									paths: { home },
+								},
+								hermes: {
+									type: "hermes",
+									enabled: false,
+									install: { source: "official" },
+									paths: { home },
+								},
 							},
 							liveSync: {
 								enabled: true,
 								agents: [
-									{ agentType: "openclaw", environmentId: "env-openclaw" },
-									{ agentType: "codex", environmentId: "env-codex" },
+									{
+										agentType: "openclaw",
+										agentId: "openclaw",
+										environmentId: "env-openclaw",
+									},
+									{ agentType: "codex", agentId: "codex", environmentId: "env-codex" },
 								],
 							},
 						},
@@ -5126,16 +5265,17 @@ exit 64
 			} else {
 				expect(supervisorConfig).not.toContain("chown=root:root");
 			}
-			expect(supervisorConfig).toContain("[program:clawdi-daemon]");
-			expect(supervisorConfig).toContain(
-				`command=/usr/bin/env clawdi daemon run --auth-token-file '${join(
-					run,
-					"secrets",
-					"auth-token",
-				)}'`,
-			);
-			expect(supervisorConfig).not.toContain("command=/bin/sh -lc");
+			expect(supervisorConfig).toContain("[program:clawdi-daemon-openclaw]");
+			expect(supervisorConfig).toContain("[program:clawdi-daemon-codex]");
+			expect(supervisorConfig).toContain("clawdi daemon run");
 			expect(supervisorConfig).toContain('CLAWDI_SERVE_MODE="container"');
+			expect(supervisorConfig).toContain('CLAWDI_AGENT_ID="openclaw"');
+			expect(supervisorConfig).toContain('CLAWDI_AGENT_TYPE="openclaw"');
+			expect(supervisorConfig).toContain('CLAWDI_ENVIRONMENT_ID="env-openclaw"');
+			expect(supervisorConfig).toContain('CLAWDI_AGENT_ID="codex"');
+			expect(supervisorConfig).toContain('CLAWDI_AGENT_TYPE="codex"');
+			expect(supervisorConfig).toContain('CLAWDI_ENVIRONMENT_ID="env-codex"');
+			expect(supervisorConfig).toContain('CLAWDI_DAEMON_RPC_DISABLED="1"');
 			expect(supervisorConfig).toContain('CLAWDI_RUNTIME_REV="');
 			expect(supervisorConfig).toContain("https://cloud-api.test");
 			expect(supervisorConfig).not.toContain("runtime-auth-token");
@@ -5163,8 +5303,18 @@ exit 64
 					system: { home, workspace: join(home, "clawdi") },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					runtimes: {
-						openclaw: { enabled: false, install: { source: "official" }, paths: { home } },
-						hermes: { enabled: false, install: { source: "official" }, paths: { home } },
+						openclaw: {
+							type: "openclaw",
+							enabled: false,
+							install: { source: "official" },
+							paths: { home },
+						},
+						hermes: {
+							type: "hermes",
+							enabled: false,
+							install: { source: "official" },
+							paths: { home },
+						},
 					},
 					providers: {
 						default: { kind: "openai-compatible", baseUrl: "https://sub2api.test/v1" },
@@ -5200,7 +5350,7 @@ exit 64
 					system: { home, workspace: join(home, "clawdi") },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					runtimes: {
-						hermes: { enabled: false },
+						hermes: { type: "hermes", enabled: false },
 					},
 					mitmProfiles: {
 						profiles: [
@@ -5254,8 +5404,8 @@ exit 64
 					packageSpec: "clawdi@0.13.0-test",
 				},
 				runtimes: {
-					openclaw: { enabled: false },
-					hermes: { enabled: false },
+					openclaw: { type: "openclaw", enabled: false },
+					hermes: { type: "hermes", enabled: false },
 				},
 				recovery: { cacheManifest: true, allowOfflineBoot: true },
 			}),
@@ -5293,7 +5443,7 @@ exit 64
 				issuedAt: "2026-06-04T00:00:00Z",
 				controlPlane: { apiUrl: "https://cloud-api.example.test" },
 				runtimes: {
-					hermes: { enabled: false },
+					hermes: { type: "hermes", enabled: false },
 				},
 				mitmProfiles: {
 					profiles: [

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -281,6 +281,7 @@ chmod +x "$HOME/.local/bin/hermes"
 			clawdiCli: { version: "0.10.1", channel: "stable", source: "npm:clawdi@stable" },
 			runtimes: {
 				openclaw: {
+					type: "openclaw",
 					enabled: true,
 					updateChannel: "stable",
 					install: {
@@ -292,6 +293,7 @@ chmod +x "$HOME/.local/bin/hermes"
 					},
 				},
 				hermes: {
+					type: "hermes",
 					enabled: true,
 					updateChannel: "main",
 					install: {
@@ -346,7 +348,7 @@ chmod +x "$HOME/.local/bin/hermes"
 			},
 			liveSync: {
 				enabled: true,
-				agents: [{ agentType: "codex", environmentId: "env-codex" }],
+				agents: [{ agentType: "codex", agentId: "codex", environmentId: "env-codex" }],
 			},
 			recovery: { cacheManifest: true, allowOfflineBoot: true },
 		};
@@ -579,8 +581,8 @@ chmod +x "$HOME/.local/bin/hermes"
 				issuedAt: "2026-06-04T00:00:00Z",
 				controlPlane: { apiUrl: "https://cloud-api.example.test" },
 				runtimes: {
-					openclaw: { enabled: false },
-					hermes: { enabled: false },
+					openclaw: { type: "openclaw", enabled: false },
+					hermes: { type: "hermes", enabled: false },
 				},
 				mitmProfiles: {
 					profiles: [
@@ -688,6 +690,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 				controlPlane: { apiUrl: "https://cloud-api.example.test" },
 				runtimes: {
 					openclaw: {
+						type: "openclaw",
 						enabled: true,
 						updateChannel: "stable",
 						install: {
@@ -699,6 +702,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 						},
 					},
 					hermes: {
+						type: "hermes",
 						enabled: false,
 					},
 				},

--- a/scripts/runtime-k3d-production-pod-e2e.sh
+++ b/scripts/runtime-k3d-production-pod-e2e.sh
@@ -1,0 +1,765 @@
+#!/usr/bin/env bash
+# Production Kubernetes hosted runtime smoke test.
+#
+# This creates a temporary k3d cluster and validates the production Pod shape:
+#   - one Clawdi runtime sidecar running the default "serve" entrypoint
+#   - multiple official OpenClaw/Hermes runtime containers in the same Pod
+#   - spec.shareProcessNamespace: true
+#   - no Docker socket in the sidecar
+#   - runtime config projected through the same-Pod nsenter control adapter
+#   - manifest fetched over HTTP with bearer auth, like production
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OPENCLAW_IMAGE="${OPENCLAW_IMAGE:-ghcr.io/openclaw/openclaw:latest}"
+HERMES_IMAGE="${HERMES_IMAGE:-nousresearch/hermes-agent:latest}"
+SIDECAR_IMAGE="${SIDECAR_IMAGE:-clawdi-runtime-sidecar:k3d-production-pod-e2e}"
+SKIP_SIDECAR_BUILD="${SKIP_SIDECAR_BUILD:-0}"
+PULL_IMAGES="${PULL_IMAGES:-0}"
+KEEP_CLUSTER="${KEEP_CLUSTER:-0}"
+
+RUN_ID="clawdi-k3d-e2e-$RANDOM"
+CLUSTER="${CLUSTER:-$RUN_ID}"
+CONTEXT="k3d-${CLUSTER}"
+NAMESPACE="clawdi-runtime-e2e"
+RUNTIME_POD="runtime-pod"
+MANIFEST_POD="manifest-api"
+MANIFEST_SERVICE="manifest-api"
+AUTH_TOKEN="clawdi-runtime-k3d-production-pod-e2e-token"
+SCRATCH="$(mktemp -d -t clawdi-runtime-k3d-prod-pod-e2e.XXXXXX)"
+LOG_DIR="/tmp/clawdi-runtime-k3d-production-pod-e2e-last"
+PREVIOUS_CONTEXT="$(kubectl config current-context 2>/dev/null || true)"
+FAILED=0
+CLUSTER_CREATED=0
+
+rm -rf "$LOG_DIR"
+mkdir -p "$LOG_DIR"
+
+cleanup() {
+	set +e
+	if [ "$FAILED" = 1 ]; then
+		echo
+		echo "=== FAILURE - logs at $LOG_DIR/ ==="
+		kubectl --context "$CONTEXT" -n "$NAMESPACE" get all -o wide \
+			>"$LOG_DIR/kubectl-get-all.txt" 2>&1 || true
+		kubectl --context "$CONTEXT" -n "$NAMESPACE" describe pod "$RUNTIME_POD" \
+			>"$LOG_DIR/runtime-pod-describe.txt" 2>&1 || true
+		kubectl --context "$CONTEXT" -n "$NAMESPACE" describe pod "$MANIFEST_POD" \
+			>"$LOG_DIR/manifest-api-describe.txt" 2>&1 || true
+		for container in sidecar openclaw-a openclaw-b hermes-a; do
+			kubectl --context "$CONTEXT" -n "$NAMESPACE" logs "$RUNTIME_POD" -c "$container" \
+				>"$LOG_DIR/runtime-${container}.log" 2>&1 || true
+		done
+		kubectl --context "$CONTEXT" -n "$NAMESPACE" logs "$MANIFEST_POD" \
+			>"$LOG_DIR/manifest-api.log" 2>&1 || true
+		for file in "$LOG_DIR"/*; do
+			[ -e "$file" ] || continue
+			echo "=== $(basename "$file") ==="
+			tail -120 "$file" 2>/dev/null
+		done
+	fi
+
+	if [ "$KEEP_CLUSTER" != 1 ] && [ "$CLUSTER_CREATED" = 1 ]; then
+		k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
+	fi
+	if [ -n "$PREVIOUS_CONTEXT" ]; then
+		kubectl config use-context "$PREVIOUS_CONTEXT" >/dev/null 2>&1 || true
+	fi
+	rm -rf "$SCRATCH" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+bold() { printf "\033[1m%s\033[0m\n" "$*"; }
+ok() { printf "  ✓ %s\n" "$*"; }
+fail() {
+	printf "  ✗ %s\n" "$*" >&2
+	FAILED=1
+	exit 1
+}
+
+require_command() {
+	command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+require_image() {
+	local image="$1"
+	if docker image inspect "$image" >/dev/null 2>&1; then
+		return
+	fi
+	if [ "$PULL_IMAGES" = 1 ]; then
+		docker pull "$image" >"$LOG_DIR/pull-${image//[\/:]/_}.log" 2>&1 \
+			|| fail "failed to pull $image; see $LOG_DIR"
+		return
+	fi
+	fail "missing image $image; rerun with PULL_IMAGES=1"
+}
+
+kubectl_e2e() {
+	kubectl --context "$CONTEXT" -n "$NAMESPACE" "$@"
+}
+
+runtime_exec() {
+	local container="$1"
+	shift
+	kubectl_e2e exec "$RUNTIME_POD" -c "$container" -- "$@"
+}
+
+write_manifest_payload() {
+	OPENCLAW_IMAGE="$OPENCLAW_IMAGE" \
+	HERMES_IMAGE="$HERMES_IMAGE" \
+	OPENCLAW_VERSION="$OPENCLAW_VERSION" \
+	HERMES_VERSION="$HERMES_VERSION" \
+	python3 - "$SCRATCH/manifest.json" <<'PY'
+import json
+import os
+import sys
+
+out = sys.argv[1]
+
+def openclaw_target(agent_id, state_dir, workspace, model, base_url):
+    return {
+        "type": "openclaw",
+        "enabled": True,
+        "environmentId": f"env-{agent_id}",
+        "image": {"ref": os.environ["OPENCLAW_IMAGE"], "pullPolicy": "IfNotPresent"},
+        "version": {"desired": os.environ["OPENCLAW_VERSION"], "upgradePolicy": "pinned"},
+        "execution": {
+            "mode": "external",
+            "home": "/home/node",
+            "stateDir": state_dir,
+            "workspace": workspace,
+            "controlCommand": {
+                "command": "/usr/local/bin/clawdi-runtime-nsenter",
+                "args": [
+                    "--state-dir",
+                    state_dir,
+                    "--marker",
+                    "/app/openclaw.mjs",
+                    "--workdir",
+                    workspace,
+                    "--",
+                    "/usr/local/bin/openclaw",
+                ],
+                "env": {},
+            },
+            "versionCommand": {
+                "command": "/usr/local/bin/clawdi-runtime-nsenter",
+                "args": [
+                    "--state-dir",
+                    state_dir,
+                    "--marker",
+                    "/app/openclaw.mjs",
+                    "--workdir",
+                    workspace,
+                    "--",
+                    "/usr/local/bin/openclaw",
+                    "--version",
+                ],
+                "env": {},
+            },
+            "terminal": {"container": agent_id, "user": "node", "cwd": workspace, "env": {}},
+        },
+    }
+
+manifest = {
+    "schemaVersion": "clawdi.hosted-runtime.manifest.v1",
+    "deploymentId": "runtime-k3d-production-pod-e2e",
+    "environmentId": "env-runtime-k3d-production-pod-e2e",
+    "instanceId": "pod-runtime-k3d-production-pod-e2e",
+    "generation": 1,
+    "issuedAt": "2026-07-02T00:00:00Z",
+    "system": {"home": "/home/clawdi", "workspace": "/workspace"},
+    "controlPlane": {"cloudApiUrl": "https://api.example.test"},
+    "runtimeTargets": {
+        "openclaw-a": openclaw_target(
+            "openclaw-a",
+            "/state/openclaw-a",
+            "/workspace/openclaw-a",
+            "gpt-openclaw-a",
+            "https://provider-a.example.test/v1",
+        ),
+        "openclaw-b": openclaw_target(
+            "openclaw-b",
+            "/state/openclaw-b",
+            "/workspace/openclaw-b",
+            "gpt-openclaw-b",
+            "https://provider-b.example.test/v1",
+        ),
+        "hermes-a": {
+            "type": "hermes",
+            "enabled": True,
+            "environmentId": "env-hermes-a",
+            "image": {"ref": os.environ["HERMES_IMAGE"], "pullPolicy": "IfNotPresent"},
+            "version": {"desired": os.environ["HERMES_VERSION"], "upgradePolicy": "pinned"},
+            "execution": {
+                "mode": "external",
+                "home": "/state/hermes-a",
+                "stateDir": "/state/hermes-a",
+                "workspace": "/workspace/hermes-a",
+                "versionCommand": {
+                    "command": "/usr/local/bin/clawdi-runtime-nsenter",
+                    "args": [
+                        "--state-dir",
+                        "/state/hermes-a",
+                        "--marker",
+                        "/opt/hermes/bin/hermes",
+                        "--workdir",
+                        "/workspace/hermes-a",
+                        "--",
+                        "/opt/hermes/bin/hermes",
+                        "--version",
+                    ],
+                    "env": {},
+                },
+                "terminal": {
+                    "container": "hermes-a",
+                    "user": "hermes",
+                    "cwd": "/workspace/hermes-a",
+                    "env": {"HERMES_HOME": "/state/hermes-a"},
+                },
+            },
+        },
+    },
+    "providers": {
+        "openclaw-a": {
+            "type": "openai",
+            "baseUrl": "https://provider-a.example.test/v1",
+            "model": "gpt-openclaw-a",
+            "apiMode": "openai_responses",
+            "runtimeEnvName": "OPENCLAW_A_API_KEY",
+            "apiKeySecretRef": "provider.openclaw-a.apiKey",
+        },
+        "openclaw-b": {
+            "type": "openai",
+            "baseUrl": "https://provider-b.example.test/v1",
+            "model": "gpt-openclaw-b",
+            "apiMode": "openai_responses",
+            "runtimeEnvName": "OPENCLAW_B_API_KEY",
+            "apiKeySecretRef": "provider.openclaw-b.apiKey",
+        },
+        "hermes-a": {
+            "type": "openai",
+            "baseUrl": "https://provider-h.example.test/v1",
+            "model": "gpt-hermes-a",
+            "apiMode": "openai_responses",
+            "runtimeEnvName": "HERMES_A_API_KEY",
+            "apiKeySecretRef": "provider.hermes-a.apiKey",
+        },
+    },
+    "mcp": {},
+    "tools": {"catalog": "runtime-k3d-production-pod-e2e"},
+    "recovery": {},
+}
+
+response = {
+    "manifest": manifest,
+    "secretValues": {
+        "provider.openclaw-a.apiKey": "sk-openclaw-a-k3d-prod-pod-e2e",
+        "provider.openclaw-b.apiKey": "sk-openclaw-b-k3d-prod-pod-e2e",
+        "provider.hermes-a.apiKey": "sk-hermes-a-k3d-prod-pod-e2e",
+    },
+}
+
+with open(out, "w") as f:
+    json.dump(response, f, indent=2)
+    f.write("\n")
+PY
+}
+
+write_k8s_resources() {
+	cat >"$SCRATCH/channels.json" <<'JSON'
+[]
+JSON
+	cat >"$SCRATCH/host-policy.json" <<'JSON'
+{
+  "schemaVersion": "clawdi.hostPolicy.v1",
+  "mode": "hosted",
+  "cliUpdateMode": "managed",
+  "immutableShim": true,
+  "deniedCommands": [
+    { "command": "setup", "reason": "hosted runtime uses controller-supplied desired state" },
+    { "command": "teardown", "reason": "hosted runtime lifecycle is controller-owned" },
+    { "command": "update", "reason": "runtime CLI updates are manifest-controlled" },
+    { "command": "config set", "reason": "hosted runtime config is manifest-controlled" },
+    { "command": "config unset", "reason": "hosted runtime config is manifest-controlled" }
+  ],
+  "managedState": ["/etc/clawdi", "/var/lib/clawdi", "/run/clawdi"],
+  "writableState": ["/home/clawdi", "/var/lib/clawdi", "/run/clawdi", "/tmp", "/workspace", "/state"],
+  "systemWritableState": ["/etc/clawdi", "/var/lib/clawdi", "/run/clawdi", "/state"],
+  "userWritableState": ["/home/clawdi", "/tmp", "/workspace"],
+  "ordinaryUserDeniedState": ["/etc/clawdi", "/var/lib/clawdi", "/run/clawdi"]
+}
+JSON
+	SIDECAR_IMAGE="$SIDECAR_IMAGE" \
+	OPENCLAW_IMAGE="$OPENCLAW_IMAGE" \
+	HERMES_IMAGE="$HERMES_IMAGE" \
+	AUTH_TOKEN="$AUTH_TOKEN" \
+	NAMESPACE="$NAMESPACE" \
+	MANIFEST_POD="$MANIFEST_POD" \
+	MANIFEST_SERVICE="$MANIFEST_SERVICE" \
+	RUNTIME_POD="$RUNTIME_POD" \
+	python3 - "$SCRATCH/manifest.json" "$SCRATCH/channels.json" "$SCRATCH/host-policy.json" "$SCRATCH/k8s-resources.json" <<'PY'
+import json
+import os
+import sys
+
+manifest_path, channels_path, policy_path, out = sys.argv[1:]
+namespace = os.environ["NAMESPACE"]
+sidecar_image = os.environ["SIDECAR_IMAGE"]
+openclaw_image = os.environ["OPENCLAW_IMAGE"]
+hermes_image = os.environ["HERMES_IMAGE"]
+auth_token = os.environ["AUTH_TOKEN"]
+manifest_pod = os.environ["MANIFEST_POD"]
+manifest_service = os.environ["MANIFEST_SERVICE"]
+runtime_pod = os.environ["RUNTIME_POD"]
+
+manifest_server = r'''
+const fs = require("node:fs");
+const http = require("node:http");
+const token = process.env.AUTH_TOKEN;
+const manifest = fs.readFileSync("/e2e/manifest.json");
+const channels = fs.readFileSync("/e2e/channels.json");
+http.createServer((req, res) => {
+  const path = new URL(req.url, "http://manifest-api.local").pathname;
+  if (req.headers.authorization !== `Bearer ${token}`) {
+    res.writeHead(401, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "unauthorized" }));
+    return;
+  }
+  if (path === "/api/runtime/manifest") {
+    res.writeHead(200, {
+      "content-type": "application/json",
+      "etag": "\"runtime-k3d-production-pod-e2e-1\""
+    });
+    res.end(manifest);
+    return;
+  }
+  if (path === "/api/channels") {
+    res.writeHead(200, {
+      "content-type": "application/json",
+      "etag": "\"runtime-k3d-production-pod-e2e-channels-1\""
+    });
+    res.end(channels);
+    return;
+  }
+  res.writeHead(404, { "content-type": "application/json" });
+  res.end(JSON.stringify({ error: "not_found" }));
+}).listen(19090, "0.0.0.0", () => {
+  console.log("manifest-api listening on :19090");
+});
+'''
+
+volumes = [
+    {"name": "state-openclaw-a", "emptyDir": {}},
+    {"name": "state-openclaw-b", "emptyDir": {}},
+    {"name": "state-hermes-a", "emptyDir": {}},
+    {"name": "workspace-openclaw-a", "emptyDir": {}},
+    {"name": "workspace-openclaw-b", "emptyDir": {}},
+    {"name": "workspace-hermes-a", "emptyDir": {}},
+    {"name": "sidecar-home", "emptyDir": {}},
+    {"name": "sidecar-service", "emptyDir": {}},
+    {"name": "sidecar-run", "emptyDir": {}},
+    {"name": "host-policy", "configMap": {"name": "runtime-host-policy"}},
+]
+
+all_volume_mounts = [
+    {"name": "state-openclaw-a", "mountPath": "/state/openclaw-a"},
+    {"name": "state-openclaw-b", "mountPath": "/state/openclaw-b"},
+    {"name": "state-hermes-a", "mountPath": "/state/hermes-a"},
+    {"name": "workspace-openclaw-a", "mountPath": "/workspace/openclaw-a"},
+    {"name": "workspace-openclaw-b", "mountPath": "/workspace/openclaw-b"},
+    {"name": "workspace-hermes-a", "mountPath": "/workspace/hermes-a"},
+]
+
+runtime_sleep = {
+    "command": ["sh", "-lc"],
+    "args": ['trap "exit 0" TERM INT; while :; do sleep 3600; done'],
+}
+
+resources = [
+    {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {"name": "runtime-manifest", "namespace": namespace},
+        "data": {
+            "manifest.json": open(manifest_path).read(),
+            "channels.json": open(channels_path).read(),
+        },
+    },
+    {
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": {"name": "runtime-host-policy", "namespace": namespace},
+        "data": {"host-policy.json": open(policy_path).read()},
+    },
+    {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": manifest_pod, "namespace": namespace, "labels": {"app": manifest_pod}},
+        "spec": {
+            "restartPolicy": "Never",
+            "containers": [
+                {
+                    "name": "manifest-api",
+                    "image": sidecar_image,
+                    "imagePullPolicy": "IfNotPresent",
+                    "command": ["node", "-e", manifest_server],
+                    "env": [{"name": "AUTH_TOKEN", "value": auth_token}],
+                    "ports": [{"containerPort": 19090, "name": "http"}],
+                    "volumeMounts": [
+                        {"name": "manifest-data", "mountPath": "/e2e", "readOnly": True}
+                    ],
+                }
+            ],
+            "volumes": [{"name": "manifest-data", "configMap": {"name": "runtime-manifest"}}],
+        },
+    },
+    {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {"name": manifest_service, "namespace": namespace},
+        "spec": {
+            "selector": {"app": manifest_pod},
+            "ports": [{"name": "http", "port": 19090, "targetPort": "http"}],
+        },
+    },
+    {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {"name": runtime_pod, "namespace": namespace},
+        "spec": {
+            "shareProcessNamespace": True,
+            "restartPolicy": "Never",
+            "terminationGracePeriodSeconds": 5,
+            "initContainers": [
+                {
+                    "name": "volume-permissions",
+                    "image": sidecar_image,
+                    "imagePullPolicy": "IfNotPresent",
+                    "command": ["sh", "-lc", "chmod -R 0777 /state /workspace /home/clawdi /var/lib/clawdi /run/clawdi"],
+                    "volumeMounts": [
+                        *all_volume_mounts,
+                        {"name": "sidecar-home", "mountPath": "/home/clawdi"},
+                        {"name": "sidecar-service", "mountPath": "/var/lib/clawdi"},
+                        {"name": "sidecar-run", "mountPath": "/run/clawdi"},
+                    ],
+                }
+            ],
+            "containers": [
+                {
+                    "name": "openclaw-a",
+                    "image": openclaw_image,
+                    "imagePullPolicy": "IfNotPresent",
+                    **runtime_sleep,
+                    "env": [{"name": "OPENCLAW_STATE_DIR", "value": "/state/openclaw-a"}],
+                    "volumeMounts": [
+                        {"name": "state-openclaw-a", "mountPath": "/state/openclaw-a"},
+                        {"name": "workspace-openclaw-a", "mountPath": "/workspace/openclaw-a"},
+                    ],
+                },
+                {
+                    "name": "openclaw-b",
+                    "image": openclaw_image,
+                    "imagePullPolicy": "IfNotPresent",
+                    **runtime_sleep,
+                    "env": [{"name": "OPENCLAW_STATE_DIR", "value": "/state/openclaw-b"}],
+                    "volumeMounts": [
+                        {"name": "state-openclaw-b", "mountPath": "/state/openclaw-b"},
+                        {"name": "workspace-openclaw-b", "mountPath": "/workspace/openclaw-b"},
+                    ],
+                },
+                {
+                    "name": "hermes-a",
+                    "image": hermes_image,
+                    "imagePullPolicy": "IfNotPresent",
+                    **runtime_sleep,
+                    "env": [{"name": "HERMES_HOME", "value": "/state/hermes-a"}],
+                    "volumeMounts": [
+                        {"name": "state-hermes-a", "mountPath": "/state/hermes-a"},
+                        {"name": "workspace-hermes-a", "mountPath": "/workspace/hermes-a"},
+                    ],
+                },
+                {
+                    "name": "sidecar",
+                    "image": sidecar_image,
+                    "imagePullPolicy": "IfNotPresent",
+                    "securityContext": {
+                        "privileged": True,
+                        "allowPrivilegeEscalation": True,
+                    },
+                    "env": [
+                        {"name": "CLAWDI_RUNTIME_MODE", "value": "hosted"},
+                        {"name": "CLAWDI_AUTH_TOKEN", "value": auth_token},
+                        {"name": "CLAWDI_NO_AUTO_UPDATE", "value": "1"},
+                        {"name": "CLAWDI_RUNTIME_VERSION_TIMEOUT", "value": "30000"},
+                        {
+                            "name": "CLAWDI_RUNTIME_MANIFEST_URL",
+                            "value": f"http://{manifest_service}.{namespace}.svc.cluster.local:19090/api/runtime/manifest",
+                        },
+                    ],
+                    "volumeMounts": [
+                        *all_volume_mounts,
+                        {"name": "sidecar-home", "mountPath": "/home/clawdi"},
+                        {"name": "sidecar-service", "mountPath": "/var/lib/clawdi"},
+                        {"name": "sidecar-run", "mountPath": "/run/clawdi"},
+                        {
+                            "name": "host-policy",
+                            "mountPath": "/etc/clawdi/host-policy.json",
+                            "subPath": "host-policy.json",
+                            "readOnly": True,
+                        },
+                    ],
+                },
+            ],
+            "volumes": volumes,
+        },
+    },
+]
+
+with open(out, "w") as f:
+    json.dump({"apiVersion": "v1", "kind": "List", "items": resources}, f, indent=2)
+    f.write("\n")
+PY
+}
+
+wait_for_boot_status() {
+	local attempt
+	for attempt in $(seq 1 120); do
+		if kubectl_e2e exec "$RUNTIME_POD" -c sidecar -- sh -lc \
+			'test -s /var/lib/clawdi/cache/boot-status.json && cat /var/lib/clawdi/cache/boot-status.json' \
+			>"$LOG_DIR/boot-status.json" 2>"$LOG_DIR/boot-status.stderr"; then
+			if python3 - "$LOG_DIR/boot-status.json" <<'PY'
+import json
+import sys
+
+status = json.load(open(sys.argv[1]))
+assert status["status"] == "ok", status
+assert status["stage"] == "final", status
+assert sorted(status["enabledRuntimes"]) == ["hermes-a", "openclaw-a", "openclaw-b"], status
+conv = status["convergence"]
+assert conv["mcpHttpAuthTokenFile"] is None, conv
+assert conv["runConfigs"] == [], conv
+assert len(conv["liveSyncEnvironments"]) == 3, conv
+PY
+			then
+				return
+			fi
+		fi
+		sleep 2
+	done
+	fail "sidecar did not converge to ok boot status"
+}
+
+require_command docker
+require_command kubectl
+require_command k3d
+require_command python3
+
+bold "1) checking and building images"
+require_image "$OPENCLAW_IMAGE"
+require_image "$HERMES_IMAGE"
+if [ "$SKIP_SIDECAR_BUILD" != 1 ]; then
+	docker build \
+		-f "$REPO_ROOT/packages/cli/Dockerfile.runtime-sidecar" \
+		-t "$SIDECAR_IMAGE" \
+		"$REPO_ROOT" \
+		>"$LOG_DIR/sidecar-build.log" 2>&1 \
+		|| fail "sidecar image build failed; see $LOG_DIR/sidecar-build.log"
+fi
+require_image "$SIDECAR_IMAGE"
+ok "images ready"
+
+bold "2) reading official runtime versions"
+docker run --rm --entrypoint sh "$OPENCLAW_IMAGE" -lc 'OPENCLAW_STATE_DIR=/tmp/openclaw openclaw --version' \
+	>"$LOG_DIR/openclaw-version.raw.log" 2>"$LOG_DIR/openclaw-version.stderr" \
+	|| fail "failed to read OpenClaw version"
+docker run --rm --entrypoint /opt/hermes/bin/hermes "$HERMES_IMAGE" --version \
+	>"$LOG_DIR/hermes-version.raw.log" 2>"$LOG_DIR/hermes-version.stderr" \
+	|| fail "failed to read Hermes version"
+OPENCLAW_VERSION="$(sed -n '1p' "$LOG_DIR/openclaw-version.raw.log")"
+HERMES_VERSION="$(sed -n '1p' "$LOG_DIR/hermes-version.raw.log")"
+printf "%s\n" "$OPENCLAW_VERSION" >"$LOG_DIR/openclaw-version.log"
+printf "%s\n" "$HERMES_VERSION" >"$LOG_DIR/hermes-version.log"
+ok "OpenClaw: $OPENCLAW_VERSION"
+ok "Hermes: $HERMES_VERSION"
+
+bold "3) creating temporary k3d cluster"
+k3d cluster create "$CLUSTER" \
+	--servers 1 \
+	--agents 0 \
+	--wait \
+	--k3s-arg "--disable=traefik@server:*" \
+	>"$LOG_DIR/k3d-create.log" 2>&1 \
+	|| fail "failed to create k3d cluster; see $LOG_DIR/k3d-create.log"
+CLUSTER_CREATED=1
+kubectl config use-context "$CONTEXT" >/dev/null
+kubectl --context "$CONTEXT" create namespace "$NAMESPACE" \
+	>"$LOG_DIR/namespace-create.log" 2>&1 \
+	|| fail "failed to create namespace"
+ok "cluster $CLUSTER ready"
+
+bold "4) importing images into k3d"
+for image in "$SIDECAR_IMAGE" "$OPENCLAW_IMAGE" "$HERMES_IMAGE"; do
+	k3d image import -c "$CLUSTER" "$image" \
+		>"$LOG_DIR/import-${image//[\/:]/_}.log" 2>&1 \
+		|| fail "failed to import $image"
+done
+ok "images imported"
+
+bold "5) applying manifest API and runtime Pod"
+write_manifest_payload
+write_k8s_resources
+kubectl --context "$CONTEXT" apply -f "$SCRATCH/k8s-resources.json" \
+	>"$LOG_DIR/kubectl-apply.log" 2>&1 \
+	|| fail "failed to apply k8s resources; see $LOG_DIR/kubectl-apply.log"
+kubectl_e2e wait --for=condition=Ready "pod/$MANIFEST_POD" --timeout=120s \
+	>"$LOG_DIR/manifest-api-wait.log" 2>&1 \
+	|| fail "manifest API pod did not become ready"
+kubectl_e2e wait --for=condition=Ready "pod/$RUNTIME_POD" --timeout=180s \
+	>"$LOG_DIR/runtime-pod-wait.log" 2>&1 \
+	|| fail "runtime pod did not become ready"
+ok "pods ready"
+
+bold "6) waiting for sidecar serve convergence"
+wait_for_boot_status
+ok "sidecar serve fetched remote manifest and converged"
+
+bold "7) validating official OpenClaw containers"
+runtime_exec openclaw-a env OPENCLAW_STATE_DIR=/state/openclaw-a openclaw config get models.providers --json \
+	>"$LOG_DIR/openclaw-a-providers.json" 2>"$LOG_DIR/openclaw-a-providers.stderr"
+runtime_exec openclaw-b env OPENCLAW_STATE_DIR=/state/openclaw-b openclaw config get models.providers --json \
+	>"$LOG_DIR/openclaw-b-providers.json" 2>"$LOG_DIR/openclaw-b-providers.stderr"
+runtime_exec openclaw-a env OPENCLAW_STATE_DIR=/state/openclaw-a openclaw config get agents.defaults.model.primary --json \
+	>"$LOG_DIR/openclaw-a-default.json" 2>"$LOG_DIR/openclaw-a-default.stderr"
+runtime_exec openclaw-b env OPENCLAW_STATE_DIR=/state/openclaw-b openclaw config get agents.defaults.model.primary --json \
+	>"$LOG_DIR/openclaw-b-default.json" 2>"$LOG_DIR/openclaw-b-default.stderr"
+runtime_exec openclaw-a env OPENCLAW_STATE_DIR=/state/openclaw-a openclaw mcp show clawdi --json \
+	>"$LOG_DIR/openclaw-a-mcp.json" 2>"$LOG_DIR/openclaw-a-mcp.stderr"
+runtime_exec openclaw-b env OPENCLAW_STATE_DIR=/state/openclaw-b openclaw mcp show clawdi --json \
+	>"$LOG_DIR/openclaw-b-mcp.json" 2>"$LOG_DIR/openclaw-b-mcp.stderr"
+python3 - "$LOG_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+a = json.load(open(root / "openclaw-a-providers.json"))
+b = json.load(open(root / "openclaw-b-providers.json"))
+assert sorted(a.keys()) == ["openclaw-a"], a
+assert sorted(b.keys()) == ["openclaw-b"], b
+assert a["openclaw-a"]["baseUrl"] == "https://provider-a.example.test/v1", a
+assert b["openclaw-b"]["baseUrl"] == "https://provider-b.example.test/v1", b
+assert json.load(open(root / "openclaw-a-default.json")) == "openclaw-a/gpt-openclaw-a"
+assert json.load(open(root / "openclaw-b-default.json")) == "openclaw-b/gpt-openclaw-b"
+for name in ["openclaw-a-mcp.json", "openclaw-b-mcp.json"]:
+    mcp = json.load(open(root / name))
+    assert mcp["url"] == "https://api.example.test/mcp/clawdi", mcp
+    assert mcp["transport"] == "streamable-http", mcp
+    assert mcp["headers"]["Authorization"].startswith("Bearer "), mcp
+PY
+ok "OpenClaw config is isolated per agent_id"
+
+bold "8) validating official Hermes container"
+runtime_exec hermes-a sh -lc 'cat /state/hermes-a/config.yaml' \
+	>"$LOG_DIR/hermes-a-config.yaml" 2>"$LOG_DIR/hermes-a-config.stderr"
+kubectl_e2e exec -i "$RUNTIME_POD" -c hermes-a -- \
+	env HERMES_HOME=/state/hermes-a /opt/hermes/.venv/bin/python - <<'PY' >"$LOG_DIR/hermes-a-runtime.json"
+import json
+from hermes_cli.config import load_config
+
+cfg = load_config()
+model = cfg["model"]
+provider = cfg["providers"]["hermes-a"]
+print(json.dumps({
+    "model_provider": model["provider"],
+    "model_default": model["default"],
+    "provider_api": provider["api"],
+    "provider_transport": provider["transport"],
+    "provider_default_model": provider["default_model"],
+    "mcp_url": cfg["mcp_servers"]["clawdi"]["url"],
+    "mcp_transport": cfg["mcp_servers"]["clawdi"]["transport"],
+    "mcp_has_auth": cfg["mcp_servers"]["clawdi"]["headers"]["Authorization"].startswith("Bearer "),
+}, sort_keys=True))
+PY
+python3 - "$LOG_DIR/hermes-a-runtime.json" <<'PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1]))
+assert data["model_provider"] == "custom:hermes-a", data
+assert data["model_default"] == "gpt-hermes-a", data
+assert data["provider_api"] == "https://provider-h.example.test/v1", data
+assert data["provider_transport"] == "codex_responses", data
+assert data["provider_default_model"] == "gpt-hermes-a", data
+assert data["mcp_url"] == "https://api.example.test/mcp/clawdi", data
+assert data["mcp_transport"] == "streamable-http", data
+assert data["mcp_has_auth"] is True, data
+PY
+ok "Hermes config loads in the official container"
+
+bold "9) validating sidecar state and default-off surfaces"
+runtime_exec sidecar sh -lc 'cat /run/clawdi/supervisor/supervisord.conf' \
+	>"$LOG_DIR/supervisord.conf" 2>"$LOG_DIR/supervisord.stderr"
+runtime_exec sidecar clawdi runtime status --json \
+	>"$LOG_DIR/runtime-status.json" 2>"$LOG_DIR/runtime-status.stderr"
+runtime_exec sidecar clawdi runtime doctor --json \
+	>"$LOG_DIR/runtime-doctor.json" 2>"$LOG_DIR/runtime-doctor.stderr"
+runtime_exec sidecar python3 - <<'PY' >"$LOG_DIR/sidecar-state.json"
+import json
+import os
+from pathlib import Path
+
+token = os.environ["CLAWDI_AUTH_TOKEN"]
+service = Path("/var/lib/clawdi")
+run = Path("/run/clawdi")
+home = Path("/home/clawdi")
+supervisor = (run / "supervisor" / "supervisord.conf").read_text()
+assert "[program:clawdi-runtime-bridge]" not in supervisor, supervisor
+assert "[program:clawdi-mcp-http]" not in supervisor, supervisor
+for agent_id in ["openclaw-a", "openclaw-b", "hermes-a"]:
+    assert f"[program:clawdi-daemon-{agent_id}]" in supervisor, supervisor
+    assert f'CLAWDI_AGENT_ID="{agent_id}"' in supervisor, supervisor
+
+env_dir = home / ".clawdi" / "environments"
+for agent_id, agent_type, state_dir in [
+    ("openclaw-a", "openclaw", "/state/openclaw-a"),
+    ("openclaw-b", "openclaw", "/state/openclaw-b"),
+    ("hermes-a", "hermes", "/state/hermes-a"),
+]:
+    env = json.load(open(env_dir / f"{agent_id}.json"))
+    assert env["agentId"] == agent_id, env
+    assert env["agentType"] == agent_type, env
+    assert env["stateDir"] == state_dir, env
+    inv = json.load(open(service / "install-inventory" / f"{agent_id}.json"))
+    assert inv["status"] == "external", inv
+    assert inv["version"]["observed"], inv
+    assert inv["version"]["upgradeAvailable"] is False, inv
+
+sync = json.load(open(service / "sync" / "runtimes.json"))
+assert sorted(sync["runtimes"].keys()) == ["hermes-a", "openclaw-a", "openclaw-b"], sync
+assert sync["runtimes"]["openclaw-a"]["externalStateDir"] == "/state/openclaw-a", sync
+assert sync["runtimes"]["openclaw-b"]["externalStateDir"] == "/state/openclaw-b", sync
+assert sync["runtimes"]["hermes-a"]["externalStateDir"] == "/state/hermes-a", sync
+
+leaks = []
+for root, _, files in os.walk(service):
+    for file in files:
+        path = Path(root) / file
+        try:
+            if token in path.read_text(errors="ignore"):
+                leaks.append(str(path.relative_to(service)))
+        except OSError:
+            pass
+assert leaks == [], leaks
+print(json.dumps({"status": "ok", "agent_ids": sorted(sync["runtimes"].keys())}))
+PY
+ok "sidecar is target-id keyed; bridge and sidecar-local MCP stay off"
+
+bold "all checks passed"
+echo
+echo "Artifacts: $LOG_DIR"
+echo "Cluster: $CLUSTER (deleted on exit unless KEEP_CLUSTER=1)"
+echo "OpenClaw A default: $(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])))' "$LOG_DIR/openclaw-a-default.json")"
+echo "OpenClaw B default: $(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])))' "$LOG_DIR/openclaw-b-default.json")"
+echo "Hermes runtime: $(cat "$LOG_DIR/hermes-a-runtime.json")"

--- a/scripts/runtime-multi-container-e2e.sh
+++ b/scripts/runtime-multi-container-e2e.sh
@@ -1,0 +1,534 @@
+#!/usr/bin/env bash
+# End-to-end smoke test for the hosted runtime multi-container topology.
+#
+# Runs one Clawdi runtime sidecar container against multiple external
+# official agent containers:
+#   - openclaw-a: official OpenClaw image, isolated state volume
+#   - openclaw-b: official OpenClaw image, isolated state volume
+#   - hermes-a:   official Hermes image, isolated state volume
+#
+# The sidecar does not launch agent processes. It converges an external runtime
+# manifest, projects config through deployment-provided control commands, records
+# observed versions, writes live-sync target ids, and leaves bridge/MCP HTTP
+# disabled unless the manifest explicitly requests them.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OPENCLAW_IMAGE="${OPENCLAW_IMAGE:-ghcr.io/openclaw/openclaw:latest}"
+HERMES_IMAGE="${HERMES_IMAGE:-nousresearch/hermes-agent:latest}"
+SIDECAR_IMAGE="${SIDECAR_IMAGE:-clawdi-runtime-sidecar:multi-container-e2e}"
+SKIP_SIDECAR_BUILD="${SKIP_SIDECAR_BUILD:-0}"
+PULL_IMAGES="${PULL_IMAGES:-0}"
+
+RUN_ID="clawdi-mc-e2e-$(date +%s)-$RANDOM"
+SCRATCH="$(mktemp -d -t clawdi-runtime-mc-e2e.XXXXXX)"
+LOG_DIR="/tmp/clawdi-runtime-multi-container-e2e-last"
+rm -rf "$LOG_DIR"
+mkdir -p "$LOG_DIR"
+
+OPENCLAW_A="${RUN_ID}-openclaw-a"
+OPENCLAW_B="${RUN_ID}-openclaw-b"
+HERMES_A="${RUN_ID}-hermes-a"
+SIDECAR="${RUN_ID}-sidecar"
+AUTH_TOKEN="clawdi-runtime-multi-container-e2e-token"
+FAILED=0
+
+cleanup() {
+  set +e
+  if [ "$FAILED" = 1 ]; then
+    echo
+    echo "=== FAILURE — logs at $LOG_DIR/ ==="
+    for file in "$LOG_DIR"/*.log "$LOG_DIR"/*.json "$LOG_DIR"/*.yaml; do
+      [ -e "$file" ] || continue
+      echo "=== $(basename "$file") ==="
+      tail -120 "$file" 2>/dev/null
+    done
+  fi
+  docker rm -f "$SIDECAR" "$OPENCLAW_A" "$OPENCLAW_B" "$HERMES_A" >/dev/null 2>&1 || true
+  chmod -R u+rwX "$SCRATCH" >/dev/null 2>&1 || true
+  rm -rf "$SCRATCH" >/dev/null 2>&1 || \
+    docker run --rm -v /tmp:/host-tmp --entrypoint sh node:24-bookworm-slim \
+      -lc "rm -rf /host-tmp/$(basename "$SCRATCH")" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+bold() { printf "\033[1m%s\033[0m\n" "$*"; }
+ok() { printf "  ✓ %s\n" "$*"; }
+fail() {
+  printf "  ✗ %s\n" "$*" >&2
+  FAILED=1
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+require_image() {
+  local image="$1"
+  if docker image inspect "$image" >/dev/null 2>&1; then
+    return
+  fi
+  if [ "$PULL_IMAGES" = 1 ]; then
+    docker pull "$image" >"$LOG_DIR/pull-${image//[\/:]/_}.log" 2>&1 \
+      || fail "failed to pull $image; see $LOG_DIR"
+    return
+  fi
+  fail "missing image $image; rerun with PULL_IMAGES=1"
+}
+
+runtime_container() {
+  local name="$1"
+  local image="$2"
+  shift 2
+  docker run -d \
+    --name "$name" \
+    --network none \
+    "$@" \
+    --entrypoint sh \
+    "$image" \
+    -lc 'trap "exit 0" TERM INT; while :; do sleep 3600; done' \
+    >"$LOG_DIR/${name}.cid" 2>"$LOG_DIR/${name}.log" \
+    || fail "failed to start $name; see $LOG_DIR/${name}.log"
+}
+
+docker_exec_json() {
+  local out="$1"
+  shift
+  docker exec "$@" >"$out" 2>"$out.stderr"
+}
+
+json_string_file_value() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+
+value = json.load(open(sys.argv[1]))
+if isinstance(value, str):
+    print(value)
+else:
+    print(json.dumps(value, sort_keys=True))
+PY
+}
+
+require_command docker
+require_command python3
+
+DOCKER_BIN="$(command -v docker)"
+DOCKER_SOCK="${DOCKER_SOCK:-/var/run/docker.sock}"
+[ -S "$DOCKER_SOCK" ] || fail "Docker socket not found at $DOCKER_SOCK"
+
+bold "1) checking images"
+require_image "$OPENCLAW_IMAGE"
+require_image "$HERMES_IMAGE"
+if [ "$SKIP_SIDECAR_BUILD" != 1 ]; then
+  docker build \
+    -f "$REPO_ROOT/packages/cli/Dockerfile.runtime-sidecar" \
+    -t "$SIDECAR_IMAGE" \
+    "$REPO_ROOT" \
+    >"$LOG_DIR/sidecar-build.log" 2>&1 \
+    || fail "sidecar image build failed; see $LOG_DIR/sidecar-build.log"
+fi
+require_image "$SIDECAR_IMAGE"
+ok "images ready"
+
+bold "2) preparing isolated volumes"
+mkdir -p \
+  "$SCRATCH/etc" \
+  "$SCRATCH/home" \
+  "$SCRATCH/run" \
+  "$SCRATCH/service" \
+  "$SCRATCH/workspace/openclaw-a" \
+  "$SCRATCH/workspace/openclaw-b" \
+  "$SCRATCH/workspace/hermes-a" \
+  "$SCRATCH/state/openclaw-a" \
+  "$SCRATCH/state/openclaw-b" \
+  "$SCRATCH/state/hermes-a"
+chmod -R 0777 "$SCRATCH/state" "$SCRATCH/workspace"
+cat >"$SCRATCH/etc/host-policy.json" <<'JSON'
+{
+  "schemaVersion": "clawdi.hostPolicy.v1",
+  "mode": "hosted",
+  "cliUpdateMode": "managed",
+  "immutableShim": true,
+  "deniedCommands": [
+    { "command": "setup", "reason": "hosted runtime uses controller-supplied desired state" },
+    { "command": "teardown", "reason": "hosted runtime lifecycle is controller-owned" },
+    { "command": "update", "reason": "runtime CLI updates are manifest-controlled" }
+  ],
+  "managedState": ["/etc/clawdi", "/var/lib/clawdi", "/run/clawdi"],
+  "writableState": ["/home/clawdi", "/var/lib/clawdi", "/run/clawdi", "/tmp", "/workspace", "/state"],
+  "systemWritableState": ["/etc/clawdi", "/var/lib/clawdi", "/run/clawdi", "/state"],
+  "userWritableState": ["/home/clawdi", "/tmp", "/workspace"],
+  "ordinaryUserDeniedState": ["/etc/clawdi", "/var/lib/clawdi", "/run/clawdi"]
+}
+JSON
+ok "volumes at $SCRATCH"
+
+bold "3) starting official runtime containers"
+runtime_container "$OPENCLAW_A" "$OPENCLAW_IMAGE" \
+  -v "$SCRATCH/state/openclaw-a:/state/openclaw-a" \
+  -v "$SCRATCH/workspace/openclaw-a:/workspace/openclaw-a"
+runtime_container "$OPENCLAW_B" "$OPENCLAW_IMAGE" \
+  -v "$SCRATCH/state/openclaw-b:/state/openclaw-b" \
+  -v "$SCRATCH/workspace/openclaw-b:/workspace/openclaw-b"
+runtime_container "$HERMES_A" "$HERMES_IMAGE" \
+  -e HERMES_HOME=/state/hermes-a \
+  -v "$SCRATCH/state/hermes-a:/state/hermes-a" \
+  -v "$SCRATCH/workspace/hermes-a:/workspace/hermes-a"
+docker exec -e OPENCLAW_STATE_DIR=/state/openclaw-a "$OPENCLAW_A" openclaw --version \
+  >"$LOG_DIR/openclaw-version.log" 2>&1
+docker exec "$HERMES_A" /opt/hermes/bin/hermes --version \
+  >"$LOG_DIR/hermes-version.log" 2>&1
+OPENCLAW_VERSION="$(sed -n '1p' "$LOG_DIR/openclaw-version.log")"
+HERMES_VERSION="$(sed -n '1p' "$LOG_DIR/hermes-version.log")"
+ok "OpenClaw: $OPENCLAW_VERSION"
+ok "Hermes: $HERMES_VERSION"
+
+bold "4) writing external runtime manifest"
+OPENCLAW_A="$OPENCLAW_A" \
+OPENCLAW_B="$OPENCLAW_B" \
+HERMES_A="$HERMES_A" \
+OPENCLAW_IMAGE="$OPENCLAW_IMAGE" \
+HERMES_IMAGE="$HERMES_IMAGE" \
+OPENCLAW_VERSION="$OPENCLAW_VERSION" \
+HERMES_VERSION="$HERMES_VERSION" \
+python3 - "$SCRATCH/manifest.json" <<'PY'
+import json
+import os
+import sys
+
+out = sys.argv[1]
+
+def openclaw_target(agent_id, container, state_dir, workspace, model, base_url, key_env):
+    return {
+        "type": "openclaw",
+        "enabled": True,
+        "environmentId": f"env-{agent_id}",
+        "image": {"ref": os.environ["OPENCLAW_IMAGE"], "pullPolicy": "IfNotPresent"},
+        "version": {"desired": os.environ["OPENCLAW_VERSION"], "upgradePolicy": "pinned"},
+        "execution": {
+            "mode": "external",
+            "home": "/home/node",
+            "stateDir": state_dir,
+            "workspace": workspace,
+            "controlCommand": {
+                "command": "docker",
+                "args": [
+                    "exec",
+                    "-i",
+                    "-e",
+                    f"OPENCLAW_STATE_DIR={state_dir}",
+                    "-e",
+                    "HOME=/home/node",
+                    container,
+                    "openclaw",
+                ],
+                "env": {},
+            },
+            "versionCommand": {
+                "command": "docker",
+                "args": [
+                    "exec",
+                    "-e",
+                    f"OPENCLAW_STATE_DIR={state_dir}",
+                    container,
+                    "openclaw",
+                    "--version",
+                ],
+                "env": {},
+            },
+            "terminal": {"container": container, "user": "node", "cwd": workspace, "env": {}},
+        },
+    }
+
+manifest = {
+    "schemaVersion": "clawdi.hosted-runtime.manifest.v1",
+    "deploymentId": "runtime-multi-container-e2e",
+    "environmentId": "env-runtime-multi-container-e2e",
+    "instanceId": "pod-runtime-multi-container-e2e",
+    "generation": 1,
+    "issuedAt": "2026-07-01T00:00:00Z",
+    "system": {"home": "/home/clawdi", "workspace": "/workspace"},
+    "controlPlane": {"cloudApiUrl": "https://api.example.test"},
+    "runtimeTargets": {
+        "openclaw-a": openclaw_target(
+            "openclaw-a",
+            os.environ["OPENCLAW_A"],
+            "/state/openclaw-a",
+            "/workspace/openclaw-a",
+            "gpt-openclaw-a",
+            "https://provider-a.example.test/v1",
+            "OPENCLAW_A_API_KEY",
+        ),
+        "openclaw-b": openclaw_target(
+            "openclaw-b",
+            os.environ["OPENCLAW_B"],
+            "/state/openclaw-b",
+            "/workspace/openclaw-b",
+            "gpt-openclaw-b",
+            "https://provider-b.example.test/v1",
+            "OPENCLAW_B_API_KEY",
+        ),
+        "hermes-a": {
+            "type": "hermes",
+            "enabled": True,
+            "environmentId": "env-hermes-a",
+            "image": {"ref": os.environ["HERMES_IMAGE"], "pullPolicy": "IfNotPresent"},
+            "version": {"desired": os.environ["HERMES_VERSION"], "upgradePolicy": "pinned"},
+            "execution": {
+                "mode": "external",
+                "home": "/state/hermes-a",
+                "stateDir": "/state/hermes-a",
+                "workspace": "/workspace/hermes-a",
+                "versionCommand": {
+                    "command": "docker",
+                    "args": [
+                        "exec",
+                        os.environ["HERMES_A"],
+                        "/opt/hermes/bin/hermes",
+                        "--version",
+                    ],
+                    "env": {},
+                },
+                "terminal": {
+                    "container": os.environ["HERMES_A"],
+                    "user": "hermes",
+                    "cwd": "/workspace/hermes-a",
+                    "env": {"HERMES_HOME": "/state/hermes-a"},
+                },
+            },
+        },
+    },
+    "providers": {
+        "openclaw-a": {
+            "type": "openai",
+            "baseUrl": "https://provider-a.example.test/v1",
+            "model": "gpt-openclaw-a",
+            "apiMode": "openai_responses",
+            "runtimeEnvName": "OPENCLAW_A_API_KEY",
+            "apiKeySecretRef": "provider.openclaw-a.apiKey",
+        },
+        "openclaw-b": {
+            "type": "openai",
+            "baseUrl": "https://provider-b.example.test/v1",
+            "model": "gpt-openclaw-b",
+            "apiMode": "openai_responses",
+            "runtimeEnvName": "OPENCLAW_B_API_KEY",
+            "apiKeySecretRef": "provider.openclaw-b.apiKey",
+        },
+        "hermes-a": {
+            "type": "openai",
+            "baseUrl": "https://provider-h.example.test/v1",
+            "model": "gpt-hermes-a",
+            "apiMode": "openai_responses",
+            "runtimeEnvName": "HERMES_A_API_KEY",
+            "apiKeySecretRef": "provider.hermes-a.apiKey",
+        },
+    },
+    "mcp": {},
+    "tools": {"catalog": "runtime-multi-container-e2e"},
+    "recovery": {},
+}
+response = {
+    "manifest": manifest,
+    "secretValues": {
+        "provider.openclaw-a.apiKey": "sk-openclaw-a-e2e",
+        "provider.openclaw-b.apiKey": "sk-openclaw-b-e2e",
+        "provider.hermes-a.apiKey": "sk-hermes-a-e2e",
+    },
+}
+with open(out, "w") as f:
+    json.dump(response, f, indent=2)
+    f.write("\n")
+PY
+ok "manifest ready"
+
+run_sidecar_clawdi() {
+  local output="$1"
+  shift
+  docker run --rm \
+    --name "$SIDECAR" \
+    --network none \
+    -e CLAWDI_RUNTIME_MODE=hosted \
+    -e CLAWDI_AUTH_TOKEN="$AUTH_TOKEN" \
+    -e CLAWDI_NO_AUTO_UPDATE=1 \
+    -e CLAWDI_RUNTIME_VERSION_TIMEOUT=30000 \
+    -v "$DOCKER_SOCK:/var/run/docker.sock" \
+    -v "$DOCKER_BIN:/usr/local/bin/docker:ro" \
+    -v "$SCRATCH/etc:/etc/clawdi" \
+    -v "$SCRATCH/home:/home/clawdi" \
+    -v "$SCRATCH/service:/var/lib/clawdi" \
+    -v "$SCRATCH/run:/run/clawdi" \
+    -v "$SCRATCH/workspace:/workspace" \
+    -v "$SCRATCH/state:/state" \
+    -v "$SCRATCH/manifest.json:/e2e/manifest.json:ro" \
+    "$SIDECAR_IMAGE" \
+    "$@" \
+    >"$output" 2>"$output.stderr"
+}
+
+bold "5) converging manifest in sidecar container"
+run_sidecar_clawdi "$LOG_DIR/runtime-init.json" \
+  clawdi runtime init --manifest-file /e2e/manifest.json --non-interactive --json \
+  || fail "runtime init failed; see $LOG_DIR/runtime-init.json.stderr"
+python3 - "$LOG_DIR/runtime-init.json" <<'PY'
+import json
+import sys
+
+status = json.load(open(sys.argv[1]))
+assert status["status"] == "ok", status
+assert sorted(status["enabledRuntimes"]) == ["hermes-a", "openclaw-a", "openclaw-b"], status
+conv = status["convergence"]
+assert conv["mcpHttpAuthTokenFile"] is None, conv
+assert conv["runConfigs"] == [], conv
+assert len(conv["liveSyncEnvironments"]) == 3, conv
+PY
+ok "runtime init converged"
+
+bold "6) validating OpenClaw official containers"
+docker_exec_json "$LOG_DIR/openclaw-a-providers.json" \
+  -e OPENCLAW_STATE_DIR=/state/openclaw-a \
+  "$OPENCLAW_A" openclaw config get models.providers --json
+docker_exec_json "$LOG_DIR/openclaw-b-providers.json" \
+  -e OPENCLAW_STATE_DIR=/state/openclaw-b \
+  "$OPENCLAW_B" openclaw config get models.providers --json
+docker_exec_json "$LOG_DIR/openclaw-a-default.json" \
+  -e OPENCLAW_STATE_DIR=/state/openclaw-a \
+  "$OPENCLAW_A" openclaw config get agents.defaults.model.primary --json
+docker_exec_json "$LOG_DIR/openclaw-b-default.json" \
+  -e OPENCLAW_STATE_DIR=/state/openclaw-b \
+  "$OPENCLAW_B" openclaw config get agents.defaults.model.primary --json
+docker_exec_json "$LOG_DIR/openclaw-a-mcp.json" \
+  -e OPENCLAW_STATE_DIR=/state/openclaw-a \
+  "$OPENCLAW_A" openclaw mcp show clawdi --json
+docker_exec_json "$LOG_DIR/openclaw-b-mcp.json" \
+  -e OPENCLAW_STATE_DIR=/state/openclaw-b \
+  "$OPENCLAW_B" openclaw mcp show clawdi --json
+python3 - "$LOG_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+a = json.load(open(root / "openclaw-a-providers.json"))
+b = json.load(open(root / "openclaw-b-providers.json"))
+assert sorted(a.keys()) == ["openclaw-a"], a
+assert sorted(b.keys()) == ["openclaw-b"], b
+assert a["openclaw-a"]["baseUrl"] == "https://provider-a.example.test/v1", a
+assert b["openclaw-b"]["baseUrl"] == "https://provider-b.example.test/v1", b
+assert json.load(open(root / "openclaw-a-default.json")) == "openclaw-a/gpt-openclaw-a"
+assert json.load(open(root / "openclaw-b-default.json")) == "openclaw-b/gpt-openclaw-b"
+for name in ["openclaw-a-mcp.json", "openclaw-b-mcp.json"]:
+    mcp = json.load(open(root / name))
+    assert mcp["url"] == "https://api.example.test/mcp/clawdi", mcp
+    assert mcp["transport"] == "streamable-http", mcp
+    assert mcp["headers"]["Authorization"].startswith("Bearer "), mcp
+PY
+ok "OpenClaw provider/default/MCP projections are isolated"
+
+bold "7) validating Hermes official container"
+docker exec "$HERMES_A" sh -lc 'cat /state/hermes-a/config.yaml' >"$LOG_DIR/hermes-a-config.yaml"
+docker exec -i \
+  -e HERMES_HOME=/state/hermes-a \
+  "$HERMES_A" \
+  /opt/hermes/.venv/bin/python - <<'PY' >"$LOG_DIR/hermes-a-runtime.json"
+import json
+from hermes_cli.config import load_config
+
+cfg = load_config()
+model = cfg["model"]
+provider = cfg["providers"]["hermes-a"]
+print(json.dumps({
+    "model_provider": model["provider"],
+    "model_default": model["default"],
+    "provider_api": provider["api"],
+    "provider_transport": provider["transport"],
+    "provider_default_model": provider["default_model"],
+    "mcp_url": cfg["mcp_servers"]["clawdi"]["url"],
+    "mcp_transport": cfg["mcp_servers"]["clawdi"]["transport"],
+    "mcp_has_auth": cfg["mcp_servers"]["clawdi"]["headers"]["Authorization"].startswith("Bearer "),
+}, sort_keys=True))
+PY
+python3 - "$LOG_DIR/hermes-a-runtime.json" <<'PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1]))
+assert data["model_provider"] == "custom:hermes-a", data
+assert data["model_default"] == "gpt-hermes-a", data
+assert data["provider_api"] == "https://provider-h.example.test/v1", data
+assert data["provider_transport"] == "codex_responses", data
+assert data["provider_default_model"] == "gpt-hermes-a", data
+assert data["mcp_url"] == "https://api.example.test/mcp/clawdi", data
+assert data["mcp_transport"] == "streamable-http", data
+assert data["mcp_has_auth"] is True, data
+PY
+ok "Hermes config loads in the official container"
+
+bold "8) validating sidecar state, identity, and defaults"
+run_sidecar_clawdi "$LOG_DIR/runtime-status.json" clawdi runtime status --json \
+  || fail "runtime status failed; see $LOG_DIR/runtime-status.json.stderr"
+run_sidecar_clawdi "$LOG_DIR/runtime-doctor.json" clawdi runtime doctor --json \
+  || fail "runtime doctor failed; see $LOG_DIR/runtime-doctor.json.stderr"
+docker run --rm -v "$SCRATCH:/scratch" --entrypoint sh node:24-bookworm-slim \
+  -lc 'chmod -R a+rX /scratch/service /scratch/home /scratch/run /scratch/state' \
+  >/dev/null 2>&1 || true
+python3 - "$SCRATCH" "$AUTH_TOKEN" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+scratch = Path(sys.argv[1])
+token = sys.argv[2]
+service = scratch / "service"
+run = scratch / "run"
+supervisor = (run / "supervisor" / "supervisord.conf").read_text()
+assert "[program:clawdi-runtime-bridge]" not in supervisor, supervisor
+assert "[program:clawdi-mcp-http]" not in supervisor, supervisor
+for agent_id in ["openclaw-a", "openclaw-b", "hermes-a"]:
+    assert f"[program:clawdi-daemon-{agent_id}]" in supervisor, supervisor
+    assert f'CLAWDI_AGENT_ID="{agent_id}"' in supervisor, supervisor
+
+env_dir = scratch / "home" / ".clawdi" / "environments"
+for agent_id, agent_type, state_dir in [
+    ("openclaw-a", "openclaw", "/state/openclaw-a"),
+    ("openclaw-b", "openclaw", "/state/openclaw-b"),
+    ("hermes-a", "hermes", "/state/hermes-a"),
+]:
+    env = json.load(open(env_dir / f"{agent_id}.json"))
+    assert env["agentId"] == agent_id, env
+    assert env["agentType"] == agent_type, env
+    assert env["stateDir"] == state_dir, env
+    inv = json.load(open(service / "install-inventory" / f"{agent_id}.json"))
+    assert inv["status"] == "external", inv
+    assert inv["version"]["observed"], inv
+    assert inv["version"]["upgradeAvailable"] is False, inv
+
+sync = json.load(open(service / "sync" / "runtimes.json"))
+assert sorted(sync["runtimes"].keys()) == ["hermes-a", "openclaw-a", "openclaw-b"], sync
+assert sync["runtimes"]["openclaw-a"]["externalStateDir"] == "/state/openclaw-a", sync
+assert sync["runtimes"]["openclaw-b"]["externalStateDir"] == "/state/openclaw-b", sync
+assert sync["runtimes"]["hermes-a"]["externalStateDir"] == "/state/hermes-a", sync
+
+leaks = []
+for root, _, files in os.walk(service):
+    for file in files:
+        path = Path(root) / file
+        try:
+            if token in path.read_text(errors="ignore"):
+                leaks.append(str(path.relative_to(service)))
+        except OSError:
+            pass
+assert leaks == [], leaks
+PY
+ok "sidecar state uses unique agent ids and keeps bridge/MCP HTTP off"
+
+bold "all checks passed"
+echo
+echo "Artifacts: $LOG_DIR"
+echo "OpenClaw A default: $(json_string_file_value "$LOG_DIR/openclaw-a-default.json")"
+echo "OpenClaw B default: $(json_string_file_value "$LOG_DIR/openclaw-b-default.json")"
+echo "Hermes runtime: $(cat "$LOG_DIR/hermes-a-runtime.json")"

--- a/scripts/runtime-production-pod-e2e.sh
+++ b/scripts/runtime-production-pod-e2e.sh
@@ -1,0 +1,537 @@
+#!/usr/bin/env bash
+# Production-model hosted runtime smoke test.
+#
+# This simulates the Kubernetes Pod shape locally:
+#   - one Clawdi runtime sidecar
+#   - multiple official runtime containers
+#   - shared Pod PID/network namespace
+#   - no Docker socket inside the sidecar
+#   - native OpenClaw/Hermes commands executed through the sidecar's
+#     same-Pod nsenter control adapter
+#
+# Production Kubernetes equivalent:
+#   spec.shareProcessNamespace: true
+#   sidecar securityContext with the capabilities required by nsenter
+#   runtimeTargets.<agent_id>.execution.controlCommand:
+#     /usr/local/bin/clawdi-runtime-nsenter --state-dir ... --marker ... -- <native-cli>
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OPENCLAW_IMAGE="${OPENCLAW_IMAGE:-ghcr.io/openclaw/openclaw:latest}"
+HERMES_IMAGE="${HERMES_IMAGE:-nousresearch/hermes-agent:latest}"
+SIDECAR_IMAGE="${SIDECAR_IMAGE:-clawdi-runtime-sidecar:production-pod-e2e}"
+SKIP_SIDECAR_BUILD="${SKIP_SIDECAR_BUILD:-0}"
+PULL_IMAGES="${PULL_IMAGES:-0}"
+
+RUN_ID="clawdi-prod-pod-e2e-$(date +%s)-$RANDOM"
+SCRATCH="$(mktemp -d -t clawdi-runtime-prod-pod-e2e.XXXXXX)"
+LOG_DIR="/tmp/clawdi-runtime-production-pod-e2e-last"
+rm -rf "$LOG_DIR"
+mkdir -p "$LOG_DIR"
+
+OPENCLAW_A="${RUN_ID}-openclaw-a"
+OPENCLAW_B="${RUN_ID}-openclaw-b"
+HERMES_A="${RUN_ID}-hermes-a"
+SIDECAR="${RUN_ID}-sidecar"
+AUTH_TOKEN="clawdi-runtime-production-pod-e2e-token"
+FAILED=0
+
+cleanup() {
+  set +e
+  if [ "$FAILED" = 1 ]; then
+    echo
+    echo "=== FAILURE — logs at $LOG_DIR/ ==="
+    for file in "$LOG_DIR"/*.log "$LOG_DIR"/*.json "$LOG_DIR"/*.yaml; do
+      [ -e "$file" ] || continue
+      echo "=== $(basename "$file") ==="
+      tail -120 "$file" 2>/dev/null
+    done
+  fi
+  docker rm -f "$SIDECAR" "$OPENCLAW_B" "$HERMES_A" "$OPENCLAW_A" >/dev/null 2>&1 || true
+  chmod -R u+rwX "$SCRATCH" >/dev/null 2>&1 || true
+  rm -rf "$SCRATCH" >/dev/null 2>&1 || \
+    docker run --rm -v /tmp:/host-tmp --entrypoint sh node:24-bookworm-slim \
+      -lc "rm -rf /host-tmp/$(basename "$SCRATCH")" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+bold() { printf "\033[1m%s\033[0m\n" "$*"; }
+ok() { printf "  ✓ %s\n" "$*"; }
+fail() {
+  printf "  ✗ %s\n" "$*" >&2
+  FAILED=1
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+require_image() {
+  local image="$1"
+  if docker image inspect "$image" >/dev/null 2>&1; then
+    return
+  fi
+  if [ "$PULL_IMAGES" = 1 ]; then
+    docker pull "$image" >"$LOG_DIR/pull-${image//[\/:]/_}.log" 2>&1 \
+      || fail "failed to pull $image; see $LOG_DIR"
+    return
+  fi
+  fail "missing image $image; rerun with PULL_IMAGES=1"
+}
+
+runtime_owner_container() {
+  docker run -d \
+    --name "$OPENCLAW_A" \
+    --network none \
+    -v "$SCRATCH/state/openclaw-a:/state/openclaw-a" \
+    -v "$SCRATCH/workspace/openclaw-a:/workspace/openclaw-a" \
+    --entrypoint sh \
+    "$OPENCLAW_IMAGE" \
+    -lc 'trap "exit 0" TERM INT; while :; do sleep 3600; done' \
+    >"$LOG_DIR/${OPENCLAW_A}.cid" 2>"$LOG_DIR/${OPENCLAW_A}.log" \
+    || fail "failed to start $OPENCLAW_A"
+}
+
+runtime_sibling_container() {
+  local name="$1"
+  local image="$2"
+  shift 2
+  docker run -d \
+    --name "$name" \
+    --pid "container:$OPENCLAW_A" \
+    --network "container:$OPENCLAW_A" \
+    "$@" \
+    --entrypoint sh \
+    "$image" \
+    -lc 'trap "exit 0" TERM INT; while :; do sleep 3600; done' \
+    >"$LOG_DIR/${name}.cid" 2>"$LOG_DIR/${name}.log" \
+    || fail "failed to start $name"
+}
+
+run_sidecar_clawdi() {
+  local output="$1"
+  shift
+  docker run --rm \
+    --name "$SIDECAR" \
+    --pid "container:$OPENCLAW_A" \
+    --network "container:$OPENCLAW_A" \
+    --cap-add SYS_ADMIN \
+    --cap-add SYS_PTRACE \
+    --security-opt apparmor=unconfined \
+    -e CLAWDI_RUNTIME_MODE=hosted \
+    -e CLAWDI_AUTH_TOKEN="$AUTH_TOKEN" \
+    -e CLAWDI_NO_AUTO_UPDATE=1 \
+    -e CLAWDI_RUNTIME_VERSION_TIMEOUT=30000 \
+    -v "$SCRATCH/etc:/etc/clawdi" \
+    -v "$SCRATCH/home:/home/clawdi" \
+    -v "$SCRATCH/service:/var/lib/clawdi" \
+    -v "$SCRATCH/run:/run/clawdi" \
+    -v "$SCRATCH/workspace:/workspace" \
+    -v "$SCRATCH/state:/state" \
+    -v "$SCRATCH/manifest.json:/e2e/manifest.json:ro" \
+    "$SIDECAR_IMAGE" \
+    "$@" \
+    >"$output" 2>"$output.stderr"
+}
+
+docker_exec_json() {
+  local out="$1"
+  shift
+  docker exec "$@" >"$out" 2>"$out.stderr"
+}
+
+require_command docker
+require_command python3
+
+bold "1) checking images"
+require_image "$OPENCLAW_IMAGE"
+require_image "$HERMES_IMAGE"
+if [ "$SKIP_SIDECAR_BUILD" != 1 ]; then
+  docker build \
+    -f "$REPO_ROOT/packages/cli/Dockerfile.runtime-sidecar" \
+    -t "$SIDECAR_IMAGE" \
+    "$REPO_ROOT" \
+    >"$LOG_DIR/sidecar-build.log" 2>&1 \
+    || fail "sidecar image build failed; see $LOG_DIR/sidecar-build.log"
+fi
+require_image "$SIDECAR_IMAGE"
+ok "images ready"
+
+bold "2) preparing Pod volumes"
+mkdir -p \
+  "$SCRATCH/etc" \
+  "$SCRATCH/home" \
+  "$SCRATCH/run" \
+  "$SCRATCH/service" \
+  "$SCRATCH/workspace/openclaw-a" \
+  "$SCRATCH/workspace/openclaw-b" \
+  "$SCRATCH/workspace/hermes-a" \
+  "$SCRATCH/state/openclaw-a" \
+  "$SCRATCH/state/openclaw-b" \
+  "$SCRATCH/state/hermes-a"
+chmod -R 0777 "$SCRATCH/state" "$SCRATCH/workspace"
+cat >"$SCRATCH/etc/host-policy.json" <<'JSON'
+{
+  "schemaVersion": "clawdi.hostPolicy.v1",
+  "mode": "hosted",
+  "cliUpdateMode": "managed",
+  "immutableShim": true,
+  "deniedCommands": [
+    { "command": "setup", "reason": "hosted runtime uses controller-supplied desired state" },
+    { "command": "teardown", "reason": "hosted runtime lifecycle is controller-owned" },
+    { "command": "update", "reason": "runtime CLI updates are manifest-controlled" }
+  ],
+  "managedState": ["/etc/clawdi", "/var/lib/clawdi", "/run/clawdi"],
+  "writableState": ["/home/clawdi", "/var/lib/clawdi", "/run/clawdi", "/tmp", "/workspace", "/state"],
+  "systemWritableState": ["/etc/clawdi", "/var/lib/clawdi", "/run/clawdi", "/state"],
+  "userWritableState": ["/home/clawdi", "/tmp", "/workspace"],
+  "ordinaryUserDeniedState": ["/etc/clawdi", "/var/lib/clawdi", "/run/clawdi"]
+}
+JSON
+ok "volumes at $SCRATCH"
+
+bold "3) starting official runtime containers in one Pod namespace"
+runtime_owner_container
+runtime_sibling_container "$OPENCLAW_B" "$OPENCLAW_IMAGE" \
+  -v "$SCRATCH/state/openclaw-b:/state/openclaw-b" \
+  -v "$SCRATCH/workspace/openclaw-b:/workspace/openclaw-b"
+runtime_sibling_container "$HERMES_A" "$HERMES_IMAGE" \
+  -e HERMES_HOME=/state/hermes-a \
+  -v "$SCRATCH/state/hermes-a:/state/hermes-a" \
+  -v "$SCRATCH/workspace/hermes-a:/workspace/hermes-a"
+docker exec -e OPENCLAW_STATE_DIR=/state/openclaw-a "$OPENCLAW_A" openclaw --version \
+  >"$LOG_DIR/openclaw-version.log" 2>&1
+docker exec "$HERMES_A" /opt/hermes/bin/hermes --version \
+  >"$LOG_DIR/hermes-version.log" 2>&1
+OPENCLAW_VERSION="$(sed -n '1p' "$LOG_DIR/openclaw-version.log")"
+HERMES_VERSION="$(sed -n '1p' "$LOG_DIR/hermes-version.log")"
+ok "OpenClaw: $OPENCLAW_VERSION"
+ok "Hermes: $HERMES_VERSION"
+
+bold "4) writing hosted runtime manifest"
+OPENCLAW_IMAGE="$OPENCLAW_IMAGE" \
+HERMES_IMAGE="$HERMES_IMAGE" \
+OPENCLAW_VERSION="$OPENCLAW_VERSION" \
+HERMES_VERSION="$HERMES_VERSION" \
+python3 - "$SCRATCH/manifest.json" <<'PY'
+import json
+import os
+import sys
+
+out = sys.argv[1]
+
+def openclaw_target(agent_id, state_dir, workspace, model, base_url, key_env):
+    return {
+        "type": "openclaw",
+        "enabled": True,
+        "environmentId": f"env-{agent_id}",
+        "image": {"ref": os.environ["OPENCLAW_IMAGE"], "pullPolicy": "IfNotPresent"},
+        "version": {"desired": os.environ["OPENCLAW_VERSION"], "upgradePolicy": "pinned"},
+        "execution": {
+            "mode": "external",
+            "home": "/home/node",
+            "stateDir": state_dir,
+            "workspace": workspace,
+            "controlCommand": {
+                "command": "/usr/local/bin/clawdi-runtime-nsenter",
+                "args": [
+                    "--state-dir",
+                    state_dir,
+                    "--marker",
+                    "/app/openclaw.mjs",
+                    "--workdir",
+                    workspace,
+                    "--",
+                    "/usr/local/bin/openclaw",
+                ],
+                "env": {},
+            },
+            "versionCommand": {
+                "command": "/usr/local/bin/clawdi-runtime-nsenter",
+                "args": [
+                    "--state-dir",
+                    state_dir,
+                    "--marker",
+                    "/app/openclaw.mjs",
+                    "--workdir",
+                    workspace,
+                    "--",
+                    "/usr/local/bin/openclaw",
+                    "--version",
+                ],
+                "env": {},
+            },
+            "terminal": {"container": agent_id, "user": "node", "cwd": workspace, "env": {}},
+        },
+    }
+
+manifest = {
+    "schemaVersion": "clawdi.hosted-runtime.manifest.v1",
+    "deploymentId": "runtime-production-pod-e2e",
+    "environmentId": "env-runtime-production-pod-e2e",
+    "instanceId": "pod-runtime-production-pod-e2e",
+    "generation": 1,
+    "issuedAt": "2026-07-02T00:00:00Z",
+    "system": {"home": "/home/clawdi", "workspace": "/workspace"},
+    "controlPlane": {"cloudApiUrl": "https://api.example.test"},
+    "runtimeTargets": {
+        "openclaw-a": openclaw_target(
+            "openclaw-a",
+            "/state/openclaw-a",
+            "/workspace/openclaw-a",
+            "gpt-openclaw-a",
+            "https://provider-a.example.test/v1",
+            "OPENCLAW_A_API_KEY",
+        ),
+        "openclaw-b": openclaw_target(
+            "openclaw-b",
+            "/state/openclaw-b",
+            "/workspace/openclaw-b",
+            "gpt-openclaw-b",
+            "https://provider-b.example.test/v1",
+            "OPENCLAW_B_API_KEY",
+        ),
+        "hermes-a": {
+            "type": "hermes",
+            "enabled": True,
+            "environmentId": "env-hermes-a",
+            "image": {"ref": os.environ["HERMES_IMAGE"], "pullPolicy": "IfNotPresent"},
+            "version": {"desired": os.environ["HERMES_VERSION"], "upgradePolicy": "pinned"},
+            "execution": {
+                "mode": "external",
+                "home": "/state/hermes-a",
+                "stateDir": "/state/hermes-a",
+                "workspace": "/workspace/hermes-a",
+                "versionCommand": {
+                    "command": "/usr/local/bin/clawdi-runtime-nsenter",
+                    "args": [
+                        "--state-dir",
+                        "/state/hermes-a",
+                        "--marker",
+                        "/opt/hermes/bin/hermes",
+                        "--workdir",
+                        "/workspace/hermes-a",
+                        "--",
+                        "/opt/hermes/bin/hermes",
+                        "--version",
+                    ],
+                    "env": {},
+                },
+                "terminal": {
+                    "container": "hermes-a",
+                    "user": "hermes",
+                    "cwd": "/workspace/hermes-a",
+                    "env": {"HERMES_HOME": "/state/hermes-a"},
+                },
+            },
+        },
+    },
+    "providers": {
+        "openclaw-a": {
+            "type": "openai",
+            "baseUrl": "https://provider-a.example.test/v1",
+            "model": "gpt-openclaw-a",
+            "apiMode": "openai_responses",
+            "runtimeEnvName": "OPENCLAW_A_API_KEY",
+            "apiKeySecretRef": "provider.openclaw-a.apiKey",
+        },
+        "openclaw-b": {
+            "type": "openai",
+            "baseUrl": "https://provider-b.example.test/v1",
+            "model": "gpt-openclaw-b",
+            "apiMode": "openai_responses",
+            "runtimeEnvName": "OPENCLAW_B_API_KEY",
+            "apiKeySecretRef": "provider.openclaw-b.apiKey",
+        },
+        "hermes-a": {
+            "type": "openai",
+            "baseUrl": "https://provider-h.example.test/v1",
+            "model": "gpt-hermes-a",
+            "apiMode": "openai_responses",
+            "runtimeEnvName": "HERMES_A_API_KEY",
+            "apiKeySecretRef": "provider.hermes-a.apiKey",
+        },
+    },
+    "mcp": {},
+    "tools": {"catalog": "runtime-production-pod-e2e"},
+    "recovery": {},
+}
+response = {
+    "manifest": manifest,
+    "secretValues": {
+        "provider.openclaw-a.apiKey": "sk-openclaw-a-prod-pod-e2e",
+        "provider.openclaw-b.apiKey": "sk-openclaw-b-prod-pod-e2e",
+        "provider.hermes-a.apiKey": "sk-hermes-a-prod-pod-e2e",
+    },
+}
+with open(out, "w") as f:
+    json.dump(response, f, indent=2)
+    f.write("\n")
+PY
+ok "manifest ready"
+
+bold "5) converging from the sidecar without Docker socket"
+run_sidecar_clawdi "$LOG_DIR/runtime-init.json" \
+  clawdi runtime init --manifest-file /e2e/manifest.json --non-interactive --json \
+  || fail "runtime init failed; see $LOG_DIR/runtime-init.json.stderr"
+python3 - "$LOG_DIR/runtime-init.json" <<'PY'
+import json
+import sys
+
+status = json.load(open(sys.argv[1]))
+assert status["status"] == "ok", status
+assert sorted(status["enabledRuntimes"]) == ["hermes-a", "openclaw-a", "openclaw-b"], status
+conv = status["convergence"]
+assert conv["mcpHttpAuthTokenFile"] is None, conv
+assert conv["runConfigs"] == [], conv
+assert len(conv["liveSyncEnvironments"]) == 3, conv
+PY
+ok "runtime init converged"
+
+bold "6) validating official OpenClaw containers"
+docker_exec_json "$LOG_DIR/openclaw-a-providers.json" \
+  -e OPENCLAW_STATE_DIR=/state/openclaw-a \
+  "$OPENCLAW_A" openclaw config get models.providers --json
+docker_exec_json "$LOG_DIR/openclaw-b-providers.json" \
+  -e OPENCLAW_STATE_DIR=/state/openclaw-b \
+  "$OPENCLAW_B" openclaw config get models.providers --json
+docker_exec_json "$LOG_DIR/openclaw-a-default.json" \
+  -e OPENCLAW_STATE_DIR=/state/openclaw-a \
+  "$OPENCLAW_A" openclaw config get agents.defaults.model.primary --json
+docker_exec_json "$LOG_DIR/openclaw-b-default.json" \
+  -e OPENCLAW_STATE_DIR=/state/openclaw-b \
+  "$OPENCLAW_B" openclaw config get agents.defaults.model.primary --json
+docker_exec_json "$LOG_DIR/openclaw-a-mcp.json" \
+  -e OPENCLAW_STATE_DIR=/state/openclaw-a \
+  "$OPENCLAW_A" openclaw mcp show clawdi --json
+docker_exec_json "$LOG_DIR/openclaw-b-mcp.json" \
+  -e OPENCLAW_STATE_DIR=/state/openclaw-b \
+  "$OPENCLAW_B" openclaw mcp show clawdi --json
+python3 - "$LOG_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+a = json.load(open(root / "openclaw-a-providers.json"))
+b = json.load(open(root / "openclaw-b-providers.json"))
+assert sorted(a.keys()) == ["openclaw-a"], a
+assert sorted(b.keys()) == ["openclaw-b"], b
+assert a["openclaw-a"]["baseUrl"] == "https://provider-a.example.test/v1", a
+assert b["openclaw-b"]["baseUrl"] == "https://provider-b.example.test/v1", b
+assert json.load(open(root / "openclaw-a-default.json")) == "openclaw-a/gpt-openclaw-a"
+assert json.load(open(root / "openclaw-b-default.json")) == "openclaw-b/gpt-openclaw-b"
+for name in ["openclaw-a-mcp.json", "openclaw-b-mcp.json"]:
+    mcp = json.load(open(root / name))
+    assert mcp["url"] == "https://api.example.test/mcp/clawdi", mcp
+    assert mcp["transport"] == "streamable-http", mcp
+    assert mcp["headers"]["Authorization"].startswith("Bearer "), mcp
+PY
+ok "OpenClaw config was injected through nsenter and remains isolated"
+
+bold "7) validating official Hermes container"
+docker exec "$HERMES_A" sh -lc 'cat /state/hermes-a/config.yaml' >"$LOG_DIR/hermes-a-config.yaml"
+docker exec -i \
+  -e HERMES_HOME=/state/hermes-a \
+  "$HERMES_A" \
+  /opt/hermes/.venv/bin/python - <<'PY' >"$LOG_DIR/hermes-a-runtime.json"
+import json
+from hermes_cli.config import load_config
+
+cfg = load_config()
+model = cfg["model"]
+provider = cfg["providers"]["hermes-a"]
+print(json.dumps({
+    "model_provider": model["provider"],
+    "model_default": model["default"],
+    "provider_api": provider["api"],
+    "provider_transport": provider["transport"],
+    "provider_default_model": provider["default_model"],
+    "mcp_url": cfg["mcp_servers"]["clawdi"]["url"],
+    "mcp_transport": cfg["mcp_servers"]["clawdi"]["transport"],
+    "mcp_has_auth": cfg["mcp_servers"]["clawdi"]["headers"]["Authorization"].startswith("Bearer "),
+}, sort_keys=True))
+PY
+python3 - "$LOG_DIR/hermes-a-runtime.json" <<'PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1]))
+assert data["model_provider"] == "custom:hermes-a", data
+assert data["model_default"] == "gpt-hermes-a", data
+assert data["provider_api"] == "https://provider-h.example.test/v1", data
+assert data["provider_transport"] == "codex_responses", data
+assert data["provider_default_model"] == "gpt-hermes-a", data
+assert data["mcp_url"] == "https://api.example.test/mcp/clawdi", data
+assert data["mcp_transport"] == "streamable-http", data
+assert data["mcp_has_auth"] is True, data
+PY
+ok "Hermes config loads in the official container"
+
+bold "8) validating sidecar state and default-off surfaces"
+run_sidecar_clawdi "$LOG_DIR/runtime-status.json" clawdi runtime status --json \
+  || fail "runtime status failed; see $LOG_DIR/runtime-status.json.stderr"
+run_sidecar_clawdi "$LOG_DIR/runtime-doctor.json" clawdi runtime doctor --json \
+  || fail "runtime doctor failed; see $LOG_DIR/runtime-doctor.json.stderr"
+docker run --rm -v "$SCRATCH:/scratch" --entrypoint sh node:24-bookworm-slim \
+  -lc 'chmod -R a+rX /scratch/service /scratch/home /scratch/run /scratch/state' \
+  >/dev/null 2>&1 || true
+python3 - "$SCRATCH" "$AUTH_TOKEN" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+scratch = Path(sys.argv[1])
+token = sys.argv[2]
+service = scratch / "service"
+run = scratch / "run"
+supervisor = (run / "supervisor" / "supervisord.conf").read_text()
+assert "[program:clawdi-runtime-bridge]" not in supervisor, supervisor
+assert "[program:clawdi-mcp-http]" not in supervisor, supervisor
+for agent_id in ["openclaw-a", "openclaw-b", "hermes-a"]:
+    assert f"[program:clawdi-daemon-{agent_id}]" in supervisor, supervisor
+    assert f'CLAWDI_AGENT_ID="{agent_id}"' in supervisor, supervisor
+
+env_dir = scratch / "home" / ".clawdi" / "environments"
+for agent_id, agent_type, state_dir in [
+    ("openclaw-a", "openclaw", "/state/openclaw-a"),
+    ("openclaw-b", "openclaw", "/state/openclaw-b"),
+    ("hermes-a", "hermes", "/state/hermes-a"),
+]:
+    env = json.load(open(env_dir / f"{agent_id}.json"))
+    assert env["agentId"] == agent_id, env
+    assert env["agentType"] == agent_type, env
+    assert env["stateDir"] == state_dir, env
+    inv = json.load(open(service / "install-inventory" / f"{agent_id}.json"))
+    assert inv["status"] == "external", inv
+    assert inv["version"]["observed"], inv
+    assert inv["version"]["upgradeAvailable"] is False, inv
+
+sync = json.load(open(service / "sync" / "runtimes.json"))
+assert sorted(sync["runtimes"].keys()) == ["hermes-a", "openclaw-a", "openclaw-b"], sync
+assert sync["runtimes"]["openclaw-a"]["externalStateDir"] == "/state/openclaw-a", sync
+assert sync["runtimes"]["openclaw-b"]["externalStateDir"] == "/state/openclaw-b", sync
+assert sync["runtimes"]["hermes-a"]["externalStateDir"] == "/state/hermes-a", sync
+
+leaks = []
+for root, _, files in os.walk(service):
+    for file in files:
+        path = Path(root) / file
+        try:
+            if token in path.read_text(errors="ignore"):
+                leaks.append(str(path.relative_to(service)))
+        except OSError:
+            pass
+assert leaks == [], leaks
+PY
+ok "sidecar state is target-id keyed and default surfaces stay off"
+
+bold "all checks passed"
+echo
+echo "Artifacts: $LOG_DIR"
+echo "OpenClaw A default: $(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])))' "$LOG_DIR/openclaw-a-default.json")"
+echo "OpenClaw B default: $(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])))' "$LOG_DIR/openclaw-b-default.json")"
+echo "Hermes runtime: $(cat "$LOG_DIR/hermes-a-runtime.json")"


### PR DESCRIPTION
## Summary
- Add the dedicated Clawdi runtime sidecar image and same-Pod nsenter control adapter.
- Move hosted OpenClaw/Hermes toward official external runtime containers with target-id keyed config/state.
- Keep bridge and sidecar-local MCP opt-in; backend direct /mcp/clawdi is the default MCP target.
- Add production-pod, k3d, and multi-container E2E harnesses plus runtime docs.

## Verification
- bun run check
- bun run typecheck
- bun test packages/cli/src/runtime/sidecar-image.test.ts packages/cli/src/runtime/manifest.test.ts packages/cli/src/runtime/bridge.test.ts packages/cli/tests/runtime.test.ts
- scripts/runtime-production-pod-e2e.sh

## Rollback
- This PR is stacked on #243 and contains only the container/sidecar layer. Drop or revert this PR to return to the common runtime sync/MCP contract layer.