### PR TITLE
Drop the v2-hosted machine-name heuristic from env responses

### DIFF
--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -832,6 +832,7 @@ async def _hosted_deployment_id_for_machine(
         )
     ).scalar_one_or_none()
 
+
 def _runtime_observed_desired(
     state: HostedRuntimeState,
 ) -> RuntimeObservedDesiredResponse:

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -85,7 +85,6 @@ _AGENT_AVATAR_KEY_RE = re.compile(r"^agent-avatars/[0-9a-f]{32}\.(png|jpg|webp)$
 _RUNTIME_OBSERVED_STALE_AFTER = timedelta(seconds=90)
 _HEARTBEAT_FRESHNESS_WRITE_INTERVAL = timedelta(seconds=40)
 _HOSTED_MANAGED_AGENT_TYPES = {"codex", "hermes", "openclaw"}
-_LEGACY_HOSTED_MACHINE_NAME_RE = re.compile(r"^v2-hosted-[a-f0-9]{6,16}$")
 _MANUAL_SESSION_SUMMARY_FILTER = text(
     "(sessions.summary IS NULL OR "
     "(sessions.summary NOT LIKE 'Cron:%' AND sessions.summary NOT LIKE '[%'))"
@@ -736,7 +735,10 @@ def _env_to_response(
     resolved_hosted_deployment_id = (
         hosted_state.deployment_id if hosted_state is not None else hosted_deployment_id
     )
-    hosted_managed = resolved_hosted_deployment_id is not None or _is_legacy_hosted_managed_env(env)
+    # Deprecated signal: dashboards now classify agents through their control
+    # plane's ownership surface. Kept (runtime-state-derived only) for older
+    # API consumers until the field is removed from EnvironmentResponse.
+    hosted_managed = resolved_hosted_deployment_id is not None
     return EnvironmentResponse(
         id=str(env.id),
         machine_name=env.machine_name,
@@ -829,18 +831,6 @@ async def _hosted_deployment_id_for_machine(
             .limit(1)
         )
     ).scalar_one_or_none()
-
-
-def _is_legacy_hosted_managed_env(env: AgentEnvironment) -> bool:
-    # Older hosted runtimes registered cloud-api envs before the dedicated
-    # hosted_runtime_states table existed. Keep those envs out of the
-    # self-managed UI, but keep hosted_deployment_id null because there is no
-    # authoritative deployment id to expose.
-    return (
-        env.agent_type in _HOSTED_MANAGED_AGENT_TYPES
-        and _LEGACY_HOSTED_MACHINE_NAME_RE.fullmatch(env.machine_name.strip().lower()) is not None
-    )
-
 
 def _runtime_observed_desired(
     state: HostedRuntimeState,

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -200,14 +200,14 @@ class EnvironmentResponse(BaseModel):
     queue_depth_high_water: int = 0
     dropped_count: int = 0
     sync_enabled: bool = False
-    # Present when this cloud-api env is registered by the hosted agent
-    # service. UI uses it to keep hosted-managed runtimes out of the
-    # self-managed/connected agent list without relying on machine-name
-    # conventions.
+    # DEPRECATED: derives from hosted-runtime desired state only. Dashboards
+    # now classify externally-managed agents through their control plane's
+    # ownership surface instead of this proxy; both fields remain for older
+    # API consumers and will be removed in a future schema revision.
     hosted_managed: bool = False
-    # Real deployment id when cloud-api has runtime desired state for this
-    # env or a sibling env in the same hosted compute. Legacy hosted envs may
-    # be marked hosted_managed without a known deployment id.
+    # DEPRECATED: see hosted_managed. Real deployment id when cloud-api has
+    # runtime desired state for this env or a sibling env in the same
+    # hosted compute.
     hosted_deployment_id: str | None = None
     # Schema-enforced NOT NULL on agent_environments — every env
     # has a default project after register_environment runs (which

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -143,12 +143,16 @@ async def test_environments_mark_hosted_runtime_siblings(
 
 
 @pytest.mark.asyncio
-async def test_legacy_hosted_runtime_envs_are_marked_without_fake_deployment_id(
+async def test_machine_name_conventions_never_mark_envs_hosted_managed(
     client: httpx.AsyncClient, db_session: AsyncSession, seed_user
 ):
+    """hosted_managed derives from runtime state only. Machine-name patterns
+    (e.g. the old `v2-hosted-*` convention) are external-product naming that
+    cloud-api must not interpret — control planes classify their own agents
+    through their own ownership surfaces."""
     from tests.conftest import create_env_with_project
 
-    legacy = await create_env_with_project(
+    old_convention = await create_env_with_project(
         db_session,
         user_id=seed_user.id,
         machine_id=f"legacy-hosted-{uuid.uuid4().hex[:8]}",
@@ -167,8 +171,8 @@ async def test_legacy_hosted_runtime_envs_are_marked_without_fake_deployment_id(
     assert r.status_code == 200, r.text
     by_id = {item["id"]: item for item in r.json()}
 
-    assert by_id[str(legacy.id)]["hosted_managed"] is True
-    assert by_id[str(legacy.id)]["hosted_deployment_id"] is None
+    assert by_id[str(old_convention.id)]["hosted_managed"] is False
+    assert by_id[str(old_convention.id)]["hosted_deployment_id"] is None
     assert by_id[str(similarly_named_self_managed.id)]["hosted_managed"] is False
 
 


### PR DESCRIPTION
## Why

The `^v2-hosted-[a-f0-9]{6,16}$` regex in `_env_to_response` leaked an external control plane's machine-naming convention into cloud-api — environments were classified `hosted_managed` by name pattern alone. Per the ownership-surface direction (clawdi-hosted#641), control planes classify their own agents; cloud-api should not interpret machine names.

## What

- Remove `_LEGACY_HOSTED_MACHINE_NAME_RE` / `_is_legacy_hosted_managed_env`; `hosted_managed` now derives from hosted-runtime desired state only.
- Mark `hosted_managed` / `hosted_deployment_id` as DEPRECATED in `EnvironmentResponse` (kept for older consumers; removal in a future schema revision once the dashboard's ownership-set migration lands).
- Rewrite the regex-pinning test to pin the new invariant: machine-name conventions never mark an env hosted-managed.

Production note: a prod scan found **zero** environments matching the regex, so this is behavior-neutral to ship immediately; the companion dashboard change (ownership sets from the deploy API) removes the web's remaining reads of these fields.

## Tests

Full backend suite against a migrated throwaway Postgres: **850 passed, 7 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)