### PR TITLE
Fix agent Skills tab hijacked by skill-detail splat route (422 on GET /v1/skills/)

### DIFF
--- a/apps/web/src/pages/dashboard/skills/[key]/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/[key]/page.tsx
@@ -97,6 +97,10 @@ export function SkillDetailContent({
 		error,
 	} = useQuery({
 		queryKey: ["skill", skillKey, selectedProjectId],
+		// An empty key would interpolate to `GET /v1/skills/`, which the
+		// backend's `{skill_key:path}` catch-all rejects with a 422.
+		// Nothing useful can load without a key, so don't fire at all.
+		enabled: skillKey.length > 0,
 		queryFn: async () => {
 			if (selectedProjectId) {
 				return unwrap(
@@ -286,7 +290,9 @@ export function SkillDetailContent({
 
 	return (
 		<div className="space-y-5 px-4 lg:px-6">
-			{error ? (
+			{!skillKey ? (
+				<DetailNotFound title="Skill not found" message="The URL is missing a skill key." />
+			) : error ? (
 				<DetailNotFound title="Skill not found" message={errorMessage(error)} />
 			) : isLoading ? (
 				<div className="space-y-3 py-2">

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -41,6 +41,7 @@ import { Route as ProtectedDashboardConnectorsNameRouteImport } from './routes/_
 import { Route as ProtectedDashboardChannelsIdRouteImport } from './routes/_protected/_dashboard/channels/$id'
 import { Route as ProtectedDashboardAgentsIdIndexRouteImport } from './routes/_protected/_dashboard/agents/$id/index'
 import { Route as ProtectedDashboardAgentsIdSectionRouteImport } from './routes/_protected/_dashboard/agents/$id/$section'
+import { Route as ProtectedDashboardAgentsIdSkillsIndexRouteImport } from './routes/_protected/_dashboard/agents/$id/skills/index'
 import { Route as ProtectedDashboardAgentsIdSkillsSplatRouteImport } from './routes/_protected/_dashboard/agents/$id/skills/$'
 import { Route as ProtectedDashboardAgentsIdSessionsSessionIdRouteImport } from './routes/_protected/_dashboard/agents/$id/sessions/$sessionId'
 
@@ -223,6 +224,12 @@ const ProtectedDashboardAgentsIdSectionRoute =
     path: '/agents/$id/$section',
     getParentRoute: () => ProtectedDashboardRoute,
   } as any)
+const ProtectedDashboardAgentsIdSkillsIndexRoute =
+  ProtectedDashboardAgentsIdSkillsIndexRouteImport.update({
+    id: '/agents/$id/skills/',
+    path: '/agents/$id/skills/',
+    getParentRoute: () => ProtectedDashboardRoute,
+  } as any)
 const ProtectedDashboardAgentsIdSkillsSplatRoute =
   ProtectedDashboardAgentsIdSkillsSplatRouteImport.update({
     id: '/agents/$id/skills/$',
@@ -269,6 +276,7 @@ export interface FileRoutesByFullPath {
   '/agents/$id/': typeof ProtectedDashboardAgentsIdIndexRoute
   '/agents/$id/sessions/$sessionId': typeof ProtectedDashboardAgentsIdSessionsSessionIdRoute
   '/agents/$id/skills/$': typeof ProtectedDashboardAgentsIdSkillsSplatRoute
+  '/agents/$id/skills/': typeof ProtectedDashboardAgentsIdSkillsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof ProtectedDashboardIndexRoute
@@ -303,6 +311,7 @@ export interface FileRoutesByTo {
   '/agents/$id': typeof ProtectedDashboardAgentsIdIndexRoute
   '/agents/$id/sessions/$sessionId': typeof ProtectedDashboardAgentsIdSessionsSessionIdRoute
   '/agents/$id/skills/$': typeof ProtectedDashboardAgentsIdSkillsSplatRoute
+  '/agents/$id/skills': typeof ProtectedDashboardAgentsIdSkillsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -340,6 +349,7 @@ export interface FileRoutesById {
   '/_protected/_dashboard/agents/$id/': typeof ProtectedDashboardAgentsIdIndexRoute
   '/_protected/_dashboard/agents/$id/sessions/$sessionId': typeof ProtectedDashboardAgentsIdSessionsSessionIdRoute
   '/_protected/_dashboard/agents/$id/skills/$': typeof ProtectedDashboardAgentsIdSkillsSplatRoute
+  '/_protected/_dashboard/agents/$id/skills/': typeof ProtectedDashboardAgentsIdSkillsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -376,6 +386,7 @@ export interface FileRouteTypes {
     | '/agents/$id/'
     | '/agents/$id/sessions/$sessionId'
     | '/agents/$id/skills/$'
+    | '/agents/$id/skills/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -410,6 +421,7 @@ export interface FileRouteTypes {
     | '/agents/$id'
     | '/agents/$id/sessions/$sessionId'
     | '/agents/$id/skills/$'
+    | '/agents/$id/skills'
   id:
     | '__root__'
     | '/_protected'
@@ -446,6 +458,7 @@ export interface FileRouteTypes {
     | '/_protected/_dashboard/agents/$id/'
     | '/_protected/_dashboard/agents/$id/sessions/$sessionId'
     | '/_protected/_dashboard/agents/$id/skills/$'
+    | '/_protected/_dashboard/agents/$id/skills/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -684,6 +697,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProtectedDashboardAgentsIdSectionRouteImport
       parentRoute: typeof ProtectedDashboardRoute
     }
+    '/_protected/_dashboard/agents/$id/skills/': {
+      id: '/_protected/_dashboard/agents/$id/skills/'
+      path: '/agents/$id/skills'
+      fullPath: '/agents/$id/skills/'
+      preLoaderRoute: typeof ProtectedDashboardAgentsIdSkillsIndexRouteImport
+      parentRoute: typeof ProtectedDashboardRoute
+    }
     '/_protected/_dashboard/agents/$id/skills/$': {
       id: '/_protected/_dashboard/agents/$id/skills/$'
       path: '/agents/$id/skills/$'
@@ -724,6 +744,7 @@ interface ProtectedDashboardRouteChildren {
   ProtectedDashboardAgentsIdIndexRoute: typeof ProtectedDashboardAgentsIdIndexRoute
   ProtectedDashboardAgentsIdSessionsSessionIdRoute: typeof ProtectedDashboardAgentsIdSessionsSessionIdRoute
   ProtectedDashboardAgentsIdSkillsSplatRoute: typeof ProtectedDashboardAgentsIdSkillsSplatRoute
+  ProtectedDashboardAgentsIdSkillsIndexRoute: typeof ProtectedDashboardAgentsIdSkillsIndexRoute
 }
 
 const ProtectedDashboardRouteChildren: ProtectedDashboardRouteChildren = {
@@ -753,6 +774,8 @@ const ProtectedDashboardRouteChildren: ProtectedDashboardRouteChildren = {
     ProtectedDashboardAgentsIdSessionsSessionIdRoute,
   ProtectedDashboardAgentsIdSkillsSplatRoute:
     ProtectedDashboardAgentsIdSkillsSplatRoute,
+  ProtectedDashboardAgentsIdSkillsIndexRoute:
+    ProtectedDashboardAgentsIdSkillsIndexRoute,
 }
 
 const ProtectedDashboardRouteWithChildren =

--- a/apps/web/src/routes/_protected/_dashboard/agents/$id/skills/index.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/agents/$id/skills/index.tsx
@@ -1,0 +1,25 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { agentSectionHref, hasAgentTabQuery } from "@/lib/agent-routes";
+import { AgentDetailClient } from "@/pages/dashboard/agents/agent-detail-client";
+
+// Explicit index route for the agent Skills tab. Without it the bare
+// `/agents/<id>/skills` URL falls through to the sibling splat route
+// (`skills/$` outranks `$section` because its static `skills` segment
+// beats the dynamic one, and a splat also matches the empty path), so
+// the tab rendered the skill DETAIL page with an empty key — which
+// fired `GET /v1/skills/` and 422'd.
+export const Route = createFileRoute("/_protected/_dashboard/agents/$id/skills/")({
+	beforeLoad: ({ params, search }) => {
+		// Mirror `$section`'s legacy `?tab=` redirect: this URL no longer
+		// reaches `$section`, so old tab-query links normalize here.
+		if (hasAgentTabQuery(search)) {
+			throw redirect({ href: agentSectionHref(params.id, "skills", search), replace: true });
+		}
+	},
+	component: AgentSkillsRoute,
+});
+
+function AgentSkillsRoute() {
+	const { id } = Route.useParams();
+	return <AgentDetailClient environmentId={id} section="skills" />;
+}


### PR DESCRIPTION
## Problem

The dashboard console showed `GET https://cloud-api.clawdi.ai/v1/skills/ 422` and the agent **Skills tab** rendered "Skill not found" instead of the skills list.

Root cause is TanStack Router route ranking: the splat route `/agents/$id/skills/$` outranks `/agents/$id/$section` for the bare `/agents/<id>/skills` tab URL — its static `skills` segment beats the dynamic `$section`, and a splat also matches the **empty** path. The tab therefore rendered the skill *detail* page with `skillKey=""`, which openapi-fetch interpolated into `/v1/skills/{skill_key}` as `GET /v1/skills/`. The backend's `{skill_key:path}` catch-all takes that as an empty skill key, fails `SKILL_KEY_PATTERN` validation, and returns 422.

Verified against the real router (`router.matchRoutes`):

```
/agents/x/skills      -> /agents/$id/skills/$   {"_splat":""}    (before)
/agents/x/skills      -> /agents/$id/skills/    {"id":"x"}       (after)
/agents/x/skills/foo  -> /agents/$id/skills/$   {"_splat":"foo"} (unchanged)
/agents/x/sessions    -> /agents/$id/$section                    (unchanged)
```

## Fix

- Add an explicit index route `/_protected/_dashboard/agents/$id/skills/` that renders the Skills section (`AgentDetailClient section="skills"`), so the splat route only ever receives non-empty keys. Index routes outrank splats, so both `/agents/<id>/skills` and `/agents/<id>/skills/` resolve to the list again.
- Mirror `$section`'s legacy `?tab=` redirect in the new route, since this URL no longer reaches `$section`.
- Defense in depth in the skill detail page: the query is `enabled` only for a non-empty key (an empty key can never load anything and would reproduce the 422), and an empty key renders the not-found state instead of a blank page.

## Verification

- `bun run --cwd apps/web typecheck` (regenerates `routeTree.gen.ts`) — clean
- `bun test` in `apps/web` — 227 pass
- `bun run --cwd apps/web lint` — clean
- Route-ranking behavior confirmed with a standalone `matchRoutes` script (output above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)