### PR TITLE
Use stable agent ids for hosted registration

### DIFF
--- a/backend/alembic/versions/d7a9c3f2b4e1_agent_registration_key.py
+++ b/backend/alembic/versions/d7a9c3f2b4e1_agent_registration_key.py
@@ -1,0 +1,55 @@
+"""agent registration key
+
+Revision ID: d7a9c3f2b4e1
+Revises: c2f4a8b9d7e1
+Create Date: 2026-07-02 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d7a9c3f2b4e1"
+down_revision: str | Sequence[str] | None = "c2f4a8b9d7e1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_environments",
+        sa.Column("registration_key", sa.String(length=300), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE agent_environments
+        SET registration_key = 'machine:' || machine_id || ':agent:' || agent_type
+        WHERE registration_key IS NULL
+        """
+    )
+    op.drop_constraint(
+        "uq_agent_envs_user_machine_agent",
+        "agent_environments",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq_agent_envs_user_registration_key",
+        "agent_environments",
+        ["user_id", "registration_key"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "uq_agent_envs_user_registration_key",
+        "agent_environments",
+        type_="unique",
+    )
+    op.create_unique_constraint(
+        "uq_agent_envs_user_machine_agent",
+        "agent_environments",
+        ["user_id", "machine_id", "agent_type"],
+    )
+    op.drop_column("agent_environments", "registration_key")

--- a/backend/app/models/session.py
+++ b/backend/app/models/session.py
@@ -21,18 +21,14 @@ from app.models.project import Project  # noqa: F401 — register `projects` tab
 
 class AgentEnvironment(Base, TimestampMixin):
     __tablename__ = "agent_environments"
-    # Phase-1 unique constraint. Without it, two parallel `clawdi
-    # setup` runs for the same user+machine+agent both pass the
-    # check-then-insert in `register_environment` and create
-    # duplicate envs. The DB-level guard is the only correctness
-    # boundary; the route's IntegrityError catch reconverges to
-    # the winning row.
+    # `id` is the stable agent identity. `registration_key` is only
+    # an idempotency key for self-managed setup flows that do not
+    # provide an explicit agent id; hosted agents leave it NULL.
     __table_args__ = (
         UniqueConstraint(
             "user_id",
-            "machine_id",
-            "agent_type",
-            name="uq_agent_envs_user_machine_agent",
+            "registration_key",
+            name="uq_agent_envs_user_registration_key",
         ),
     )
 
@@ -48,6 +44,7 @@ class AgentEnvironment(Base, TimestampMixin):
     agent_type: Mapped[str] = mapped_column(String(50), nullable=False)
     agent_version: Mapped[str | None] = mapped_column(String(50))
     os: Mapped[str] = mapped_column(String(50), nullable=False)
+    registration_key: Mapped[str | None] = mapped_column(String(300))
     last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     # User-facing identity overrides. Runtime registration keeps
     # machine_name/agent_type accurate; dashboard preferences live here.

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -27,7 +27,6 @@ can land in this file under the same auth dep.
 """
 
 import logging
-import uuid
 from datetime import UTC, datetime
 from uuid import UUID
 
@@ -44,7 +43,6 @@ from app.models.channel import (
     ChannelAccount,
 )
 from app.models.hosted_runtime import HostedRuntimeState
-from app.models.project import PROJECT_KIND_ENVIRONMENT, Project
 from app.models.session import AgentEnvironment
 from app.models.user import User
 from app.schemas.admin import (
@@ -64,6 +62,11 @@ from app.schemas.admin import (
 from app.schemas.api_key import ApiKeyCreated, ApiKeyRevokeResponse
 from app.schemas.channel import ChannelCommandSyncRequest, ChannelCommandSyncResponse
 from app.schemas.session import EnvironmentCreatedResponse
+from app.services.agent_environments import (
+    AgentEnvironmentIdConflict,
+    local_machine_registration_key,
+    register_agent_environment,
+)
 from app.services.api_key import mint_api_key
 from app.services.audit import record_control_plane_audit
 from app.services.channel_config import validate_channel_account_config_urls
@@ -536,101 +539,45 @@ async def admin_register_environment(
     api_key request; this admin variant is gated by the shared
     `X-Admin-Key` header instead.
 
-    Idempotent: re-registering (target_clerk_id, machine_id,
-    agent_type) returns the existing env id and refreshes
-    `machine_name` / `agent_version` / `last_seen_at`. Concurrent
-    callers race-safe via `with_for_update` on the lookup, mirror-
-    ing the heal logic in `register_environment` for the
-    user-facing endpoint.
+    If `environment_id` is supplied, it is the stable agent id and
+    machine metadata is refreshed in place. If omitted, legacy callers
+    remain idempotent through the local machine registration key.
 
     User row is lazy-created if absent — see `_resolve_or_create_user`.
     """
     target = await _resolve_or_create_user(db, body.target_clerk_id)
-
-    # FOR UPDATE row-locks the env so concurrent admin-registers
-    # for the same (user, machine) serialize through the heal
-    # branch — without this both writers would see
-    # default_project_id IS NULL and create competing projects.
-    existing = (
-        await db.execute(
-            select(AgentEnvironment)
-            .where(
-                AgentEnvironment.user_id == target.id,
-                AgentEnvironment.machine_id == body.machine_id,
-                AgentEnvironment.agent_type == body.agent_type,
-            )
-            .with_for_update()
-        )
-    ).scalar_one_or_none()
-
-    if existing is not None:
-        existing.machine_name = body.machine_name
-        existing.agent_version = body.agent_version
-        existing.last_seen_at = datetime.now(UTC)
-        # Heal envs missing default_project_id (older rows or
-        # interrupted creates) — same logic the user-facing route
-        # runs.
-        if existing.default_project_id is None:
-            healing_project = Project(
-                user_id=target.id,
-                name=f"{body.machine_name} ({body.agent_type})",
-                slug=f"env-{uuid.uuid4().hex[:12]}",
-                kind=PROJECT_KIND_ENVIRONMENT,
-                origin_environment_id=existing.id,
-            )
-            db.add(healing_project)
-            await db.flush()
-            existing.default_project_id = healing_project.id
-        await db.commit()
-        return EnvironmentCreatedResponse(id=str(existing.id))
-
-    # Create project first (no origin_environment_id yet — env doesn't
-    # exist), then env pointing at the project, then back-fill
-    # project.origin_environment_id. Mirror of register_environment's
-    # mutual-FK insertion order.
-    project = Project(
-        user_id=target.id,
-        name=f"{body.machine_name} ({body.agent_type})",
-        slug=f"env-{uuid.uuid4().hex[:12]}",
-        kind=PROJECT_KIND_ENVIRONMENT,
-    )
-    db.add(project)
     try:
-        await db.flush()
-        env = AgentEnvironment(
+        registered = await register_agent_environment(
+            db,
             user_id=target.id,
             machine_id=body.machine_id,
             machine_name=body.machine_name,
             agent_type=body.agent_type,
             agent_version=body.agent_version,
-            os=body.os_name,
-            last_seen_at=datetime.now(UTC),
+            os_name=body.os_name,
             sort_order=await _next_environment_sort_order(db, target.id),
-            default_project_id=project.id,
+            environment_id=body.environment_id,
+            registration_key=None
+            if body.environment_id is not None
+            else local_machine_registration_key(body.machine_id, body.agent_type),
         )
-        db.add(env)
-        await db.flush()
-        project.origin_environment_id = env.id
-        await db.commit()
-        await db.refresh(env)
-    except IntegrityError:
-        # Race: another admin-register won. Re-query.
+        env = registered.env
+    except AgentEnvironmentIdConflict as exc:
         await db.rollback()
-        env = (
-            await db.execute(
-                select(AgentEnvironment).where(
-                    AgentEnvironment.user_id == target.id,
-                    AgentEnvironment.machine_id == body.machine_id,
-                    AgentEnvironment.agent_type == body.agent_type,
-                )
-            )
-        ).scalar_one()
+        raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from None
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "concurrent registration race; retry the request",
+        ) from None
 
     logger.info(
-        "admin_environment_registered target_clerk_id=%s env_id=%s machine_id=%s",
+        "admin_environment_registered target_clerk_id=%s env_id=%s machine_id=%s explicit_id=%s",
         body.target_clerk_id,
         env.id,
         body.machine_id,
+        body.environment_id is not None,
     )
     return EnvironmentCreatedResponse(id=str(env.id))
 

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -190,10 +190,7 @@ async def register_environment(
                 )
             )
         ).scalar_one_or_none()
-        if (
-            bound_env is None
-            or bound_env.registration_key != registration_key
-        ):
+        if bound_env is None or bound_env.registration_key != registration_key:
             raise HTTPException(
                 status.HTTP_403_FORBIDDEN,
                 detail={

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -29,7 +29,6 @@ from app.core.auth import AuthContext, get_auth, require_scope, require_web_auth
 from app.core.config import settings
 from app.core.database import get_session
 from app.models.hosted_runtime import HostedRuntimeState
-from app.models.project import PROJECT_KIND_ENVIRONMENT, Project
 from app.models.session import AgentEnvironment, Session
 from app.models.session_permission import (
     PERMISSION_KIND_LINK,
@@ -61,6 +60,10 @@ from app.schemas.session import (
     SessionPermissionResponse,
     SessionPermissionsResponse,
     SessionUploadResponse,
+)
+from app.services.agent_environments import (
+    local_machine_registration_key,
+    register_agent_environment,
 )
 from app.services.file_store import get_file_store
 from app.services.http_cache import if_none_match_contains, strong_json_etag
@@ -164,6 +167,7 @@ async def register_environment(
     auth: AuthContext = Depends(require_scope("skills:write")),
     db: AsyncSession = Depends(get_session),
 ) -> EnvironmentCreatedResponse:
+    registration_key = local_machine_registration_key(body.machine_id, body.agent_type)
     # Bound deploy keys are pinned to a single env. Letting them
     # create *new* envs (and new env-local projects) would let a
     # leaked key expand the account's footprint — beyond the project
@@ -188,8 +192,7 @@ async def register_environment(
         ).scalar_one_or_none()
         if (
             bound_env is None
-            or bound_env.machine_id != body.machine_id
-            or bound_env.agent_type != body.agent_type
+            or bound_env.registration_key != registration_key
         ):
             raise HTTPException(
                 status.HTTP_403_FORBIDDEN,
@@ -204,119 +207,24 @@ async def register_environment(
                 },
             )
 
-    # Check if environment already exists for this user + machine.
-    # `with_for_update()` row-locks the env so concurrent
-    # `clawdi setup` re-registrations serialize through the
-    # heal path below — without the lock both requests would
-    # read default_project_id IS NULL, both would INSERT a new
-    # project, and the second writer would overwrite env's
-    # default_project_id with its own project, orphaning the first.
-    result = await db.execute(
-        select(AgentEnvironment)
-        .where(
-            AgentEnvironment.user_id == auth.user_id,
-            AgentEnvironment.machine_id == body.machine_id,
-            AgentEnvironment.agent_type == body.agent_type,
-        )
-        .with_for_update()
-    )
-    env = result.scalar_one_or_none()
-
-    if env:
-        env.machine_name = body.machine_name
-        env.agent_version = body.agent_version
-        env.last_seen_at = datetime.now(UTC)
-        # Heal envs that somehow ended up without a default_project_id —
-        # this row predates the project migration, was created via a
-        # path that bypassed the new-env branch below, or had its
-        # project dropped by an earlier broken cleanup. The daemon's
-        # boot path requires a project to upload anything; without
-        # this backfill, re-running `clawdi setup` against an old
-        # env still leaves the daemon dead at startup with the
-        # opaque "environment X has no default_project_id" fatal.
-        # Concurrent calls are serialized by the FOR UPDATE row
-        # lock above — the second writer sees default_project_id
-        # already set and skips this branch.
-        if env.default_project_id is None:
-            import uuid as _uuid
-
-            healing_slug = f"env-{_uuid.uuid4().hex[:12]}"
-            healing_project = Project(
-                user_id=auth.user_id,
-                name=f"{body.machine_name} ({body.agent_type})",
-                slug=healing_slug,
-                kind=PROJECT_KIND_ENVIRONMENT,
-                origin_environment_id=env.id,
-            )
-            db.add(healing_project)
-            await db.flush()
-            env.default_project_id = healing_project.id
-        await db.commit()
-        return EnvironmentCreatedResponse(id=str(env.id))
-
-    # Mutual FK between env.default_project_id (NOT NULL → project) and
-    # project.origin_environment_id (NULLABLE → env). Insert order:
-    #   1. project without origin_environment_id (slug pre-computed
-    #      from a fresh UUID so it's stable across the two writes)
-    #   2. env with default_project_id = project.id
-    #   3. update project.origin_environment_id = env.id
-    #
-    # Concurrent `clawdi setup` runs for the same (user, machine,
-    # agent) race here. The new
-    # `uq_agent_envs_user_machine_agent` constraint at the model
-    # layer means the second writer's commit raises IntegrityError;
-    # we catch it, rollback, and re-query for the winner's row.
-    import uuid as _uuid
-
-    from sqlalchemy.exc import IntegrityError
-
-    pending_slug = f"env-{_uuid.uuid4().hex[:12]}"
-    project = Project(
-        user_id=auth.user_id,
-        name=f"{body.machine_name} ({body.agent_type})",
-        slug=pending_slug,
-        kind=PROJECT_KIND_ENVIRONMENT,
-    )
-    db.add(project)
     try:
-        await db.flush()
-
-        env = AgentEnvironment(
+        registered = await register_agent_environment(
+            db,
             user_id=auth.user_id,
             machine_id=body.machine_id,
             machine_name=body.machine_name,
             agent_type=body.agent_type,
             agent_version=body.agent_version,
-            os=body.os,
-            last_seen_at=datetime.now(UTC),
+            os_name=body.os,
             sort_order=await _next_environment_sort_order(db, auth.user_id),
-            default_project_id=project.id,
+            registration_key=registration_key,
         )
-        db.add(env)
-        await db.flush()
-
-        project.origin_environment_id = env.id
-        await db.commit()
-        await db.refresh(env)
-        return EnvironmentCreatedResponse(id=str(env.id))
     except IntegrityError:
-        await db.rollback()
-        # Winner's row is committed; re-fetch and return its id
-        # so both clients see the same env.
-        result = await db.execute(
-            select(AgentEnvironment).where(
-                AgentEnvironment.user_id == auth.user_id,
-                AgentEnvironment.machine_id == body.machine_id,
-                AgentEnvironment.agent_type == body.agent_type,
-            )
-        )
-        winner = result.scalar_one_or_none()
-        if winner is None:
-            raise HTTPException(
-                status.HTTP_409_CONFLICT,
-                "concurrent registration race; retry the request",
-            ) from None
-        return EnvironmentCreatedResponse(id=str(winner.id))
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "concurrent registration race; retry the request",
+        ) from None
+    return EnvironmentCreatedResponse(id=str(registered.env.id))
 
 
 @router.get(

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -172,9 +172,8 @@ async def register_environment(
     # create *new* envs (and new env-local projects) would let a
     # leaked key expand the account's footprint — beyond the project
     # of the binding. Allow the idempotent re-register of the same
-    # env (machine_id / agent_type match the one the key is bound
-    # to) so daemons can survive `clawdi setup` re-runs without
-    # rotating keys, but reject everything else with 403.
+    # registration key so daemons can survive `clawdi setup` re-runs
+    # without rotating keys, but reject everything else with 403.
     if auth.is_cli and auth.api_key is not None and auth.api_key.environment_id is not None:
         bound = auth.api_key.environment_id
         # Defense-in-depth: a key bound to env X must also belong to

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -32,12 +32,13 @@ class AdminEnvironmentCreate(BaseModel):
     user-facing EnvironmentCreate but takes target_clerk_id
     instead of relying on auth context to resolve the user.
 
-    Idempotent — re-registering the same (user, machine_id) pair
-    updates `machine_name` / `agent_version` / `last_seen_at` and
-    returns the existing env id.
+    If `environment_id` is set, it is the caller-owned stable agent id.
+    Otherwise this uses the legacy self-managed registration key derived from
+    `(user, machine_id, agent_type)` for idempotent retries.
     """
 
     target_clerk_id: str
+    environment_id: UUID | None = None
     machine_id: str
     machine_name: str
     agent_type: str

--- a/backend/app/services/agent_environments.py
+++ b/backend/app/services/agent_environments.py
@@ -78,6 +78,7 @@ async def register_agent_environment(
                 machine_name=machine_name,
                 agent_type=agent_type,
                 agent_version=agent_version,
+                os_name=os_name,
                 registration_key=registration_key,
             )
             await db.commit()
@@ -102,6 +103,7 @@ async def register_agent_environment(
                 machine_name=machine_name,
                 agent_type=agent_type,
                 agent_version=agent_version,
+                os_name=os_name,
                 registration_key=registration_key,
             )
             await db.commit()
@@ -138,9 +140,32 @@ async def register_agent_environment(
     except IntegrityError:
         await db.rollback()
         if environment_id is not None:
-            raise AgentEnvironmentIdConflict(
-                f"environment {environment_id} could not be registered"
-            ) from None
+            winner = (
+                await db.execute(
+                    select(AgentEnvironment).where(AgentEnvironment.id == environment_id)
+                )
+            ).scalar_one_or_none()
+            if winner is None:
+                raise AgentEnvironmentIdConflict(
+                    f"environment {environment_id} could not be registered"
+                ) from None
+            if winner.user_id != user_id:
+                raise AgentEnvironmentIdConflict(
+                    f"environment {environment_id} is owned by another user"
+                )
+            await _refresh_agent_environment(
+                db,
+                winner,
+                user_id=user_id,
+                machine_id=machine_id,
+                machine_name=machine_name,
+                agent_type=agent_type,
+                agent_version=agent_version,
+                os_name=os_name,
+                registration_key=registration_key,
+            )
+            await db.commit()
+            return AgentEnvironmentRegistration(env=winner, created=False)
         if registration_key is None:
             raise
         winner = (
@@ -165,12 +190,14 @@ async def _refresh_agent_environment(
     machine_name: str,
     agent_type: str,
     agent_version: str | None,
+    os_name: str,
     registration_key: str | None,
 ) -> None:
     env.machine_id = machine_id
     env.machine_name = machine_name
     env.agent_type = agent_type
     env.agent_version = agent_version
+    env.os = os_name
     env.last_seen_at = datetime.now(UTC)
     env.registration_key = registration_key
     if env.default_project_id is None:

--- a/backend/app/services/agent_environments.py
+++ b/backend/app/services/agent_environments.py
@@ -1,0 +1,186 @@
+"""Agent environment registration.
+
+`AgentEnvironment.id` is the stable agent identity used by sessions, runtime
+state, channel links, and deploy-key scoping. `registration_key` is only an
+idempotency key for self-managed clients that do not bring their own agent id.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.project import PROJECT_KIND_ENVIRONMENT, Project
+from app.models.session import AgentEnvironment
+
+
+class AgentEnvironmentIdConflict(ValueError):
+    """Raised when an explicit agent id already belongs to a different user."""
+
+
+@dataclass(frozen=True)
+class AgentEnvironmentRegistration:
+    env: AgentEnvironment
+    created: bool
+
+
+def local_machine_registration_key(machine_id: str, agent_type: str) -> str:
+    """Idempotency key for legacy/self-managed setup flows."""
+
+    return f"machine:{machine_id}:agent:{agent_type}"
+
+
+async def register_agent_environment(
+    db: AsyncSession,
+    *,
+    user_id: UUID,
+    machine_id: str,
+    machine_name: str,
+    agent_type: str,
+    agent_version: str | None,
+    os_name: str,
+    sort_order: int,
+    environment_id: UUID | None = None,
+    registration_key: str | None = None,
+) -> AgentEnvironmentRegistration:
+    """Create or refresh an agent row.
+
+    Explicit `environment_id` callers own the agent identity and bypass machine
+    idempotency. Implicit callers must pass `registration_key`; concurrent
+    retries converge through the database unique constraint on
+    `(user_id, registration_key)`.
+    """
+
+    if environment_id is not None:
+        existing = (
+            await db.execute(
+                select(AgentEnvironment)
+                .where(AgentEnvironment.id == environment_id)
+                .with_for_update()
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            if existing.user_id != user_id:
+                raise AgentEnvironmentIdConflict(
+                    f"environment {environment_id} is owned by another user"
+                )
+            await _refresh_agent_environment(
+                db,
+                existing,
+                user_id=user_id,
+                machine_id=machine_id,
+                machine_name=machine_name,
+                agent_type=agent_type,
+                agent_version=agent_version,
+                registration_key=registration_key,
+            )
+            await db.commit()
+            return AgentEnvironmentRegistration(env=existing, created=False)
+    elif registration_key is not None:
+        existing = (
+            await db.execute(
+                select(AgentEnvironment)
+                .where(
+                    AgentEnvironment.user_id == user_id,
+                    AgentEnvironment.registration_key == registration_key,
+                )
+                .with_for_update()
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            await _refresh_agent_environment(
+                db,
+                existing,
+                user_id=user_id,
+                machine_id=machine_id,
+                machine_name=machine_name,
+                agent_type=agent_type,
+                agent_version=agent_version,
+                registration_key=registration_key,
+            )
+            await db.commit()
+            return AgentEnvironmentRegistration(env=existing, created=False)
+
+    project = Project(
+        user_id=user_id,
+        name=f"{machine_name} ({agent_type})",
+        slug=f"env-{uuid.uuid4().hex[:12]}",
+        kind=PROJECT_KIND_ENVIRONMENT,
+    )
+    db.add(project)
+    try:
+        await db.flush()
+        env = AgentEnvironment(
+            id=environment_id or uuid.uuid4(),
+            user_id=user_id,
+            machine_id=machine_id,
+            machine_name=machine_name,
+            agent_type=agent_type,
+            agent_version=agent_version,
+            os=os_name,
+            last_seen_at=datetime.now(UTC),
+            sort_order=sort_order,
+            default_project_id=project.id,
+            registration_key=registration_key,
+        )
+        db.add(env)
+        await db.flush()
+        project.origin_environment_id = env.id
+        await db.commit()
+        await db.refresh(env)
+        return AgentEnvironmentRegistration(env=env, created=True)
+    except IntegrityError:
+        await db.rollback()
+        if environment_id is not None:
+            raise AgentEnvironmentIdConflict(
+                f"environment {environment_id} could not be registered"
+            ) from None
+        if registration_key is None:
+            raise
+        winner = (
+            await db.execute(
+                select(AgentEnvironment).where(
+                    AgentEnvironment.user_id == user_id,
+                    AgentEnvironment.registration_key == registration_key,
+                )
+            )
+        ).scalar_one_or_none()
+        if winner is None:
+            raise
+        return AgentEnvironmentRegistration(env=winner, created=False)
+
+
+async def _refresh_agent_environment(
+    db: AsyncSession,
+    env: AgentEnvironment,
+    *,
+    user_id: UUID,
+    machine_id: str,
+    machine_name: str,
+    agent_type: str,
+    agent_version: str | None,
+    registration_key: str | None,
+) -> None:
+    env.machine_id = machine_id
+    env.machine_name = machine_name
+    env.agent_type = agent_type
+    env.agent_version = agent_version
+    env.last_seen_at = datetime.now(UTC)
+    env.registration_key = registration_key
+    if env.default_project_id is None:
+        healing_project = Project(
+            user_id=user_id,
+            name=f"{machine_name} ({agent_type})",
+            slug=f"env-{uuid.uuid4().hex[:12]}",
+            kind=PROJECT_KIND_ENVIRONMENT,
+            origin_environment_id=env.id,
+        )
+        db.add(healing_project)
+        await db.flush()
+        env.default_project_id = healing_project.id

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -130,6 +130,7 @@ async def create_env_with_project(
     """
     from app.models.project import PROJECT_KIND_ENVIRONMENT, Project
     from app.models.session import AgentEnvironment
+    from app.services.agent_environments import local_machine_registration_key
 
     # Mutual FK: env.default_project_id (NOT NULL) → project.id;
     # project.origin_environment_id (NULLABLE) → env.id. Insert
@@ -152,6 +153,7 @@ async def create_env_with_project(
         agent_type=agent_type,
         os=os,
         default_project_id=project.id,
+        registration_key=local_machine_registration_key(machine_id, agent_type),
     )
     db_session.add(env)
     await db_session.flush()

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -767,6 +767,59 @@ async def test_admin_register_env_accepts_explicit_agent_id(admin_client, db_ses
 
 
 @pytest.mark.asyncio
+async def test_admin_register_env_explicit_agent_id_is_idempotent(
+    admin_client, db_session, seed_user
+):
+    """Stable agent ids remain the identity while machine fields refresh."""
+    import uuid
+
+    from sqlalchemy import select
+
+    from app.models.session import AgentEnvironment
+
+    agent_id = uuid.uuid4()
+    body = {
+        "target_clerk_id": seed_user.clerk_id,
+        "environment_id": str(agent_id),
+        "machine_id": "hosted-agent-initial",
+        "machine_name": "hosted-pod-initial",
+        "agent_type": "codex",
+        "agent_version": "1.0.0",
+        "os_name": "linux",
+    }
+    first = await admin_client.post("/v1/admin/environments", headers=_AUTH, json=body)
+    second = await admin_client.post(
+        "/v1/admin/environments",
+        headers=_AUTH,
+        json={
+            **body,
+            "machine_id": "hosted-agent-moved",
+            "machine_name": "hosted-pod-moved",
+            "agent_version": "1.1.0",
+            "os_name": "darwin",
+        },
+    )
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.json()["id"] == str(agent_id)
+    assert second.json()["id"] == str(agent_id)
+
+    envs = (
+        (await db_session.execute(select(AgentEnvironment).where(AgentEnvironment.id == agent_id)))
+        .scalars()
+        .all()
+    )
+    assert len(envs) == 1
+    env = envs[0]
+    assert env.machine_id == "hosted-agent-moved"
+    assert env.machine_name == "hosted-pod-moved"
+    assert env.agent_version == "1.1.0"
+    assert env.os == "darwin"
+    assert env.registration_key is None
+
+
+@pytest.mark.asyncio
 async def test_admin_register_env_explicit_ids_allow_same_machine_metadata(
     admin_client, db_session, seed_user
 ):
@@ -866,7 +919,7 @@ async def test_admin_register_env_explicit_id_rejects_cross_tenant_id(
         env = (
             await db_session.execute(
                 select(AgentEnvironment).where(AgentEnvironment.id == agent_id)
-        )
+            )
         ).scalar_one()
         assert env.user_id == other_id
     finally:

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -730,13 +730,153 @@ async def test_admin_register_env_creates_with_project(admin_client, db_session,
     ).scalar_one()
     assert env.user_id == seed_user.id
     assert env.machine_id == "migrate-machine-1"
+    assert env.registration_key == "machine:migrate-machine-1:agent:openclaw"
     assert env.default_project_id is not None  # heal logic ran
 
 
 @pytest.mark.asyncio
+async def test_admin_register_env_accepts_explicit_agent_id(admin_client, db_session, seed_user):
+    """Hosted registration owns the stable agent id. Machine fields are metadata."""
+    import uuid
+
+    from sqlalchemy import select
+
+    from app.models.session import AgentEnvironment
+
+    agent_id = uuid.uuid4()
+    r = await admin_client.post(
+        "/v1/admin/environments",
+        headers=_AUTH,
+        json={
+            "target_clerk_id": seed_user.clerk_id,
+            "environment_id": str(agent_id),
+            "machine_id": "hosted-machine-explicit",
+            "machine_name": "hosted-pod",
+            "agent_type": "codex",
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["id"] == str(agent_id)
+
+    env = (
+        await db_session.execute(select(AgentEnvironment).where(AgentEnvironment.id == agent_id))
+    ).scalar_one()
+    assert env.user_id == seed_user.id
+    assert env.machine_id == "hosted-machine-explicit"
+    assert env.registration_key is None
+
+
+@pytest.mark.asyncio
+async def test_admin_register_env_explicit_ids_allow_same_machine_metadata(
+    admin_client, db_session, seed_user
+):
+    """Two hosted agents can share machine metadata without sharing identity."""
+    import uuid
+
+    from sqlalchemy import select
+
+    from app.models.session import AgentEnvironment
+
+    machine_id = "same-hosted-machine"
+    first_id = uuid.uuid4()
+    second_id = uuid.uuid4()
+    body = {
+        "target_clerk_id": seed_user.clerk_id,
+        "machine_id": machine_id,
+        "machine_name": "hosted-pod",
+        "agent_type": "codex",
+    }
+    r1 = await admin_client.post(
+        "/v1/admin/environments",
+        headers=_AUTH,
+        json={**body, "environment_id": str(first_id)},
+    )
+    r2 = await admin_client.post(
+        "/v1/admin/environments",
+        headers=_AUTH,
+        json={**body, "environment_id": str(second_id)},
+    )
+    assert r1.status_code == 200, r1.text
+    assert r2.status_code == 200, r2.text
+    assert r1.json()["id"] == str(first_id)
+    assert r2.json()["id"] == str(second_id)
+
+    envs = (
+        (
+            await db_session.execute(
+                select(AgentEnvironment).where(
+                    AgentEnvironment.user_id == seed_user.id,
+                    AgentEnvironment.machine_id == machine_id,
+                    AgentEnvironment.agent_type == "codex",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {env.id for env in envs} == {first_id, second_id}
+    assert all(env.registration_key is None for env in envs)
+
+
+@pytest.mark.asyncio
+async def test_admin_register_env_explicit_id_rejects_cross_tenant_id(
+    admin_client, db_session, seed_user
+):
+    import uuid
+
+    from sqlalchemy import select
+
+    from app.models.session import AgentEnvironment
+    from app.models.user import User
+
+    other = User(clerk_id=f"other_env_{uuid.uuid4().hex[:8]}", email="other@x.dev", name="Other")
+    db_session.add(other)
+    await db_session.commit()
+    await db_session.refresh(other)
+    other_id = other.id
+
+    agent_id = uuid.uuid4()
+    try:
+        created = await admin_client.post(
+            "/v1/admin/environments",
+            headers=_AUTH,
+            json={
+                "target_clerk_id": other.clerk_id,
+                "environment_id": str(agent_id),
+                "machine_id": "other-explicit",
+                "machine_name": "other-pod",
+                "agent_type": "codex",
+            },
+        )
+        assert created.status_code == 200, created.text
+
+        rejected = await admin_client.post(
+            "/v1/admin/environments",
+            headers=_AUTH,
+            json={
+                "target_clerk_id": seed_user.clerk_id,
+                "environment_id": str(agent_id),
+                "machine_id": "seed-explicit",
+                "machine_name": "seed-pod",
+                "agent_type": "codex",
+            },
+        )
+        assert rejected.status_code == 409, rejected.text
+
+        env = (
+            await db_session.execute(
+                select(AgentEnvironment).where(AgentEnvironment.id == agent_id)
+        )
+        ).scalar_one()
+        assert env.user_id == other_id
+    finally:
+        await db_session.delete(other)
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
 async def test_admin_register_env_idempotent(admin_client, db_session, seed_user):
-    """Re-registering same (user, machine_id, agent_type) returns
-    the same env id — migration retry safety."""
+    """Legacy admin registration without an explicit id remains idempotent."""
     body = {
         "target_clerk_id": seed_user.clerk_id,
         "machine_id": "idempotent-machine",

--- a/backend/tests/test_project_isolation.py
+++ b/backend/tests/test_project_isolation.py
@@ -39,6 +39,7 @@ from app.models.project import PROJECT_KIND_ENVIRONMENT, Project
 from app.models.session import AgentEnvironment, Session
 from app.models.user import User
 from app.models.vault import Vault, VaultItem, VaultProjectAttachment
+from app.services.agent_environments import local_machine_registration_key
 
 
 async def _override_factory(db_session: AsyncSession, user: User, api_key: ApiKey | None = None):
@@ -89,6 +90,7 @@ async def env_without_project(db_session: AsyncSession, seed_user: User) -> Agen
         agent_type="claude_code",
         os="darwin",
         default_project_id=project.id,
+        registration_key=local_machine_registration_key("heal-test-mac", "claude_code"),
     )
     db_session.add(env)
     await db_session.flush()

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -30,8 +30,8 @@ async def _register_env(client: httpx.AsyncClient, machine_id: str = "test-machi
 async def test_environment_register_is_idempotent(client: httpx.AsyncClient):
     first = await _register_env(client)
     second = await _register_env(client)
-    # Same (user, machine_id, agent_type) must return the same environment row,
-    # not create a duplicate.
+    # Same local registration key must return the same environment row, not
+    # create a duplicate.
     assert first == second
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,7 +63,7 @@ All keyed off Clerk `user_id`:
 |---|---|---|
 | `users` | Clerk user mirror + email | Sign-in |
 | `api_keys` | SHA-256-hashed CLI bearer tokens | Dashboard |
-| `agent_environments` | One row per (machine × agent). `agent_type ∈ {claude_code, codex, hermes, openclaw}` | `clawdi setup` |
+| `agent_environments` | Stable agent identity rows. Self-managed agents use `registration_key` for local setup idempotency; hosted agents use explicit ids. `agent_type ∈ {claude_code, codex, hermes, openclaw}` | `clawdi setup`, hosted agent registration |
 | `projects` | Resource availability boundaries for skills, vault attachments, and future memory/session grouping. Kinds are `personal`, `environment`, and `workspace`; `environment` is the internal Agent Project kind | Provisioning, `clawdi setup`, `clawdi project create` |
 | `project_memberships` | Viewer-only shared Project access granted by invite or share link | Share accept / invite accept |
 | `project_share_links` | Hashed bearer links for read-only Project access. Raw tokens are only returned once | `clawdi project share` |

--- a/docs/plans/ui-2.0-ux-redesign.md
+++ b/docs/plans/ui-2.0-ux-redesign.md
@@ -19,7 +19,7 @@ colleagues (viewer-only v1).
 
 ```
 User (account root)
-├── AgentEnvironment ("agent") — one per (machine × agent-type)
+├── AgentEnvironment ("agent") — stable agent identity row
 │     ├── default Project (kind=environment, auto-created, not shareable)
 │     ├── AgentProjectBinding: primary (its own project) + context (added
 │     │   workspace projects, read-only) — THIS is "add project to agent"


### PR DESCRIPTION
## Summary
- Treat `AgentEnvironment.id` as the stable agent identity and move local setup idempotency to `registration_key`.
- Add explicit `environment_id` support to the admin environment registration path for hosted callers.
- Consolidate agent environment create/refresh/heal logic behind `app.services.agent_environments`.
- Update architecture docs and regression coverage for explicit hosted ids and legacy local idempotency.

## Tests
- `cd backend && uv run ruff check app/models/session.py app/services/agent_environments.py app/routes/sessions.py app/routes/admin.py app/schemas/admin.py tests/conftest.py tests/test_admin_endpoints.py tests/test_project_isolation.py tests/test_sessions.py alembic/versions/d7a9c3f2b4e1_agent_registration_key.py`
- `cd backend && uv run python -m py_compile app/models/session.py app/services/agent_environments.py app/routes/sessions.py app/routes/admin.py app/schemas/admin.py alembic/versions/d7a9c3f2b4e1_agent_registration_key.py`
- `cd backend && DATABASE_URL=postgresql+asyncpg://clawdi:clawdi_dev@127.0.0.1:41056/clawdi uv run alembic upgrade head`
- `cd backend && DATABASE_URL=postgresql+asyncpg://clawdi:clawdi_dev@127.0.0.1:41056/clawdi uv run pytest tests/test_admin_endpoints.py::test_admin_register_env_creates_with_project tests/test_admin_endpoints.py::test_admin_register_env_accepts_explicit_agent_id tests/test_admin_endpoints.py::test_admin_register_env_explicit_ids_allow_same_machine_metadata tests/test_admin_endpoints.py::test_admin_register_env_explicit_id_rejects_cross_tenant_id tests/test_admin_endpoints.py::test_admin_register_env_idempotent tests/test_sessions.py::test_environment_register_is_idempotent tests/test_project_isolation.py::test_register_environment_heals_missing_project`
