### PR TITLE
Protect explicit agent identities from dashboard disconnect

### DIFF
--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -937,6 +937,11 @@ async def delete_environment(
     env = result.scalar_one_or_none()
     if not env:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
+    if env.registration_key is None:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "This agent uses an explicit identity and cannot be disconnected here",
+        )
     await db.delete(env)
     await db.commit()
 

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -1293,6 +1293,47 @@ async def test_delete_environment_orphans_sessions_via_fk(
 
 
 @pytest.mark.asyncio
+async def test_delete_environment_rejects_explicit_agent_identity(
+    client: httpx.AsyncClient, db_session: AsyncSession, seed_user
+):
+    """Dashboard Disconnect is for self-managed local registrations only.
+
+    Agents registered with an explicit id keep their identity independent from
+    local machine registration metadata. Cloud-api stays generic here: it only
+    knows whether the environment originated from the registration-key path.
+    """
+    from sqlalchemy import select
+
+    from app.models.session import AgentEnvironment
+    from app.services.agent_environments import register_agent_environment
+
+    agent_id = uuid.uuid4()
+    registered = await register_agent_environment(
+        db_session,
+        user_id=seed_user.id,
+        environment_id=agent_id,
+        machine_id="external-agent-machine",
+        machine_name="External Agent",
+        agent_type="codex",
+        agent_version="1.0.0",
+        os_name="linux",
+        sort_order=0,
+        registration_key=None,
+    )
+
+    r = await client.delete(f"/v1/environments/{registered.env.id}")
+    assert r.status_code == 409, r.text
+
+    env = (
+        await db_session.execute(
+            select(AgentEnvironment).where(AgentEnvironment.id == registered.env.id)
+        )
+    ).scalar_one_or_none()
+    assert env is not None
+    assert env.registration_key is None
+
+
+@pytest.mark.asyncio
 async def test_delete_environment_404_for_unknown(client: httpx.AsyncClient):
     r = await client.delete(f"/v1/environments/{uuid.uuid4()}")
     assert r.status_code == 404


### PR DESCRIPTION
## Summary
- block dashboard disconnect for agent environments created with explicit ids
- keep cloud-api generic: it only distinguishes explicit identity from registration-key self-managed setup
- add a regression test that preserves the environment row on delete attempts

## Tests
- `DATABASE_URL=postgresql+asyncpg://clawdi:clawdi_dev@127.0.0.1:39435/clawdi uv run alembic upgrade head`
- `DATABASE_URL=postgresql+asyncpg://clawdi:clawdi_dev@127.0.0.1:39435/clawdi uv run pytest tests/test_sessions.py -k 'delete_environment' -q`\n- `DATABASE_URL=postgresql+asyncpg://clawdi:clawdi_dev@127.0.0.1:39435/clawdi uv run pytest tests/test_admin_endpoints.py -k 'admin_register_env' -q`\n- `uv run ruff check app/routes/sessions.py tests/test_sessions.py`