### PR TITLE
Restore legacy agent dashboard entry

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -23,6 +23,12 @@ VITE_DEV_AUTH_TOKEN=dev-bypass
 # Dev fallback: http://localhost:50021 (clawdi.ai).
 VITE_CLAWDI_DEPLOY_API_URL=http://localhost:50021
 
+# Hosted-only legacy v1 dashboard app URL. The new Clawdi dashboard links to
+# this full app surface only from legacy agent management paths.
+# Production value should point at the v1 dashboard entry.
+# Dev fallback: http://localhost:3000/dashboard.
+VITE_CLAWDI_LEGACY_DASHBOARD_URL=http://localhost:3000/dashboard
+
 # Build-time flag — `true` enables the hosted-only UI surfaces:
 # the deployed-agents tile listing on the dashboard and the Deploy
 # CTA in the sidebar. OSS / self-host instances should leave this

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -102,6 +102,7 @@ import { unwrap, useApi } from "@/lib/api";
 import { useCurrentUser } from "@/lib/auth-client";
 import { IS_HOSTED } from "@/lib/hosted";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
+import { legacyHostedDashboardUrl } from "@/lib/legacy-hosted-dashboard";
 import {
 	PROJECT_RESOURCE_GROUPS,
 	projectResourceDefinitionsForGroup,
@@ -1163,6 +1164,12 @@ function FocusHeader({
 	const displayName = displayMachineName(name);
 	const meta = agentHeaderMeta(activeAgent, kind);
 	const title = [name, meta.detailLabel, meta.activityLabel].filter(Boolean).join(" · ");
+	const manageHref =
+		kind === "cloud"
+			? agentSectionHref(activeAgent.id, "settings")
+			: kind === "legacy"
+				? (legacyHostedDashboardUrl() ?? undefined)
+				: undefined;
 	return (
 		<div className="min-w-0 text-left">
 			<div className="flex min-w-0 items-center gap-2" title={title}>
@@ -1183,12 +1190,12 @@ function FocusHeader({
 			) : null}
 			<div className="mt-2 flex min-w-0 items-center justify-between gap-2 rounded-md border border-sidebar-border bg-sidebar-accent/45 px-2 py-1 text-xs leading-4">
 				{/* Legacy agents share the hosted copy variant (supervised
-				 * daemon, no CLI steps), but the legacy management app is no
-				 * longer linked from this dashboard. */}
+				 * daemon, no CLI steps), while remediation stays in the legacy
+				 * v1 dashboard when that URL is configured. */}
 				<DaemonStatusBadge
 					env={activeAgent}
 					source={kind !== "connected" ? "on-clawdi" : "self-managed"}
-					manageHref={kind === "cloud" ? agentSectionHref(activeAgent.id, "settings") : undefined}
+					manageHref={manageHref}
 					compact
 					tooltipDetail={meta.detailLabel}
 				/>

--- a/apps/web/src/components/dashboard/agent-settings-panel.tsx
+++ b/apps/web/src/components/dashboard/agent-settings-panel.tsx
@@ -3,7 +3,7 @@
 import type { components } from "@clawdi/shared/api";
 import { type QueryClient, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "@tanstack/react-router";
-import { RotateCcw, Save, Trash2, Unplug, Upload } from "lucide-react";
+import { ExternalLink, RotateCcw, Save, Trash2, Unplug, Upload } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
@@ -22,6 +22,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { agentOwnershipKindFromId, useAgentOwnership } from "@/lib/agent-ownership";
 import { unwrap, useAgentAvatarUploader, useApi } from "@/lib/api";
+import { legacyHostedDashboardUrl } from "@/lib/legacy-hosted-dashboard";
 import { cn, errorMessage } from "@/lib/utils";
 
 type Environment = components["schemas"]["EnvironmentResponse"];
@@ -193,6 +194,7 @@ export function AgentSettingsPanel({
 	const defaultDisplayName = agentDisplayName({ ...agent, display_name: null }, { ownershipKind });
 	const runtimeLabel = agentTypeLabel(agent.agent_type);
 	const currentAvatarLabel = hasCustomAvatar ? "Custom upload" : `${runtimeLabel} default`;
+	const legacyDashboardUrl = ownershipKind === "legacy" ? legacyHostedDashboardUrl() : null;
 
 	return (
 		<div
@@ -319,6 +321,25 @@ export function AgentSettingsPanel({
 					</div>
 				</div>
 			</SettingsSection>
+
+			{legacyDashboardUrl ? (
+				<SettingsSection
+					title="Legacy dashboard"
+					description="Manage this v1 hosted agent in the legacy dashboard."
+				>
+					<div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+						<p className="max-w-md text-sm text-muted-foreground">
+							This agent uses the legacy v1 management surface for runtime actions.
+						</p>
+						<Button variant="outline" size="sm" asChild>
+							<a href={legacyDashboardUrl} target="_blank" rel="noopener noreferrer">
+								<ExternalLink data-icon="inline-start" />
+								Open legacy dashboard
+							</a>
+						</Button>
+					</div>
+				</SettingsSection>
+			) : null}
 
 			{!disconnectUnavailable ? (
 				<SettingsSection

--- a/apps/web/src/hosted/legacy-agent-tiles.test.ts
+++ b/apps/web/src/hosted/legacy-agent-tiles.test.ts
@@ -1,8 +1,27 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import type { components } from "@clawdi/shared/api";
 import { legacyConnectedAgentTiles } from "@/hosted/legacy-agent-tiles";
 
 type Env = components["schemas"]["EnvironmentResponse"];
+const originalWindow = (globalThis as unknown as Record<string, unknown>).window;
+
+function setBrowserHostname(hostname: string) {
+	Object.defineProperty(globalThis, "window", {
+		value: { location: { hostname } },
+		configurable: true,
+	});
+}
+
+afterEach(() => {
+	if (originalWindow === undefined) {
+		Reflect.deleteProperty(globalThis, "window");
+		return;
+	}
+	Object.defineProperty(globalThis, "window", {
+		value: originalWindow,
+		configurable: true,
+	});
+});
 
 function env(overrides: Partial<Env> = {}): Env {
 	return {
@@ -51,6 +70,16 @@ describe("legacyConnectedAgentTiles", () => {
 
 		const [tile] = legacyConnectedAgentTiles([legacy], new Set([legacy.id]));
 		expect(tile.env).toBe(legacy);
+	});
+
+	it("carries the legacy dashboard href when the URL is available", () => {
+		setBrowserHostname("localhost");
+		const legacy = env({
+			id: "33333333-3333-4333-8333-333333333333",
+		});
+
+		const [tile] = legacyConnectedAgentTiles([legacy], new Set([legacy.id]));
+		expect(tile.manageHref).toBe("http://localhost:3000/dashboard");
 	});
 
 	it("excludes environments already claimed by a Cloud deploy-API tile", () => {

--- a/apps/web/src/hosted/legacy-agent-tiles.ts
+++ b/apps/web/src/hosted/legacy-agent-tiles.ts
@@ -3,6 +3,7 @@ import { cleanMachineName } from "@/components/dashboard/agent-label";
 import { type AgentTile, formatRuntime, isAgentActive } from "@/components/dashboard/agents-card";
 import { normalizeAgentEnvId } from "@/lib/agent-ownership";
 import { agentSectionHref } from "@/lib/agent-routes";
+import { legacyHostedDashboardUrl } from "@/lib/legacy-hosted-dashboard";
 import { relativeTime } from "@/lib/utils";
 
 type Env = components["schemas"]["EnvironmentResponse"];
@@ -10,13 +11,15 @@ type Env = components["schemas"]["EnvironmentResponse"];
 /**
  * Fallback projection for legacy v1 environments that are already present in
  * cloud-api but intentionally not fetched through the Cloud deploy API.
- * Product-wise these behave like connected agents in the new dashboard.
+ * Product-wise these behave like connected agents in the new dashboard; their
+ * v1-only management surface stays behind the separate legacy dashboard entry.
  *
  * `source: "legacy-hosted"` gives the tile the Legacy pill (the v1 counterpart
  * of the Cloud pill on deploy-API tiles). The tile keeps `env`: v1 runtimes
  * run the real clawdi daemon with live sync on, so the sync badge carries real
  * signal — AgentTileView renders it with the hosted copy variant (supervised
- * daemon, no CLI instructions).
+ * daemon, no CLI instructions), and `manageHref` points remediation at the
+ * legacy dashboard when its URL is configured.
  *
  * `claimedEnvIds` (lower-cased env ids, from `useHostedAgentTiles`) excludes
  * environments already represented by a Cloud deploy-API tile so an env is
@@ -27,6 +30,7 @@ export function legacyConnectedAgentTiles(
 	legacyEnvIds: ReadonlySet<string>,
 	claimedEnvIds?: ReadonlySet<string>,
 ): AgentTile[] {
+	const manageHref = legacyHostedDashboardUrl() ?? undefined;
 	return (environments ?? [])
 		.filter((env) => {
 			const envId = normalizeAgentEnvId(env.id);
@@ -47,6 +51,7 @@ export function legacyConnectedAgentTiles(
 			statusLabel: env.last_seen_at ? `Active ${relativeTime(env.last_seen_at)}` : "Never seen",
 			lastSeenAt: env.last_seen_at,
 			href: agentSectionHref(env.id),
+			manageHref,
 			active: isAgentActive(env.last_seen_at),
 			env,
 		}));

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -47,6 +47,11 @@ export const env = createEnv({
 		// profile calls in hosted builds.
 		VITE_CLAWDI_DEPLOY_API_URL: httpsOrHttp().default("http://localhost:50021"),
 
+		// Hosted-only legacy v1 dashboard URL. The localhost default is
+		// gated by `legacyHostedDashboardUrl()` so production builds only
+		// expose this entry when a real URL is configured.
+		VITE_CLAWDI_LEGACY_DASHBOARD_URL: httpsOrHttp().default("http://localhost:3000/dashboard"),
+
 		// Clerk publishable key. Local auth bypass can run without
 		// Clerk; every normal dashboard run still requires a real key.
 		VITE_CLERK_PUBLISHABLE_KEY: isLocalDevAuthBypass

--- a/apps/web/src/lib/legacy-hosted-dashboard.test.ts
+++ b/apps/web/src/lib/legacy-hosted-dashboard.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { isLegacyHostedDashboardUrlAvailable } from "@/lib/legacy-hosted-dashboard";
+
+describe("isLegacyHostedDashboardUrlAvailable", () => {
+	it("treats production URLs as configured without browser host gating", () => {
+		expect(isLegacyHostedDashboardUrlAvailable("https://legacy.example.com/dashboard", null)).toBe(
+			true,
+		);
+	});
+
+	it("only exposes localhost defaults to localhost browser sessions", () => {
+		expect(isLegacyHostedDashboardUrlAvailable("http://localhost:3000/dashboard", null)).toBe(
+			false,
+		);
+		expect(
+			isLegacyHostedDashboardUrlAvailable("http://localhost:3000/dashboard", "cloud.clawdi.ai"),
+		).toBe(false);
+		expect(
+			isLegacyHostedDashboardUrlAvailable("http://localhost:3000/dashboard", "localhost"),
+		).toBe(true);
+	});
+});

--- a/apps/web/src/lib/legacy-hosted-dashboard.ts
+++ b/apps/web/src/lib/legacy-hosted-dashboard.ts
@@ -1,0 +1,40 @@
+import { env } from "@/lib/env";
+
+function isLocalhostName(hostname: string): boolean {
+	const host = hostname.toLowerCase();
+	return (
+		host === "localhost" ||
+		host.endsWith(".localhost") ||
+		host === "127.0.0.1" ||
+		host === "::1" ||
+		host === "[::1]"
+	);
+}
+
+function isLocalhostUrl(rawUrl: string): boolean {
+	try {
+		return isLocalhostName(new URL(rawUrl).hostname);
+	} catch {
+		return false;
+	}
+}
+
+function currentBrowserHostname(): string | null {
+	if (typeof window === "undefined") return null;
+	return window.location.hostname;
+}
+
+export function isLegacyHostedDashboardUrlAvailable(
+	rawUrl: string,
+	browserHostname: string | null = currentBrowserHostname(),
+): boolean {
+	const url = rawUrl.trim();
+	if (!url) return false;
+	if (!isLocalhostUrl(url)) return true;
+	return browserHostname !== null && isLocalhostName(browserHostname);
+}
+
+export function legacyHostedDashboardUrl(): string | null {
+	const url = env.VITE_CLAWDI_LEGACY_DASHBOARD_URL.trim();
+	return isLegacyHostedDashboardUrlAvailable(url) ? url : null;
+}


### PR DESCRIPTION
## Summary
- restore the typed legacy v1 dashboard URL with localhost-only dev gating
- add the legacy dashboard link back to legacy agent settings, sidebar remediation, and legacy agent tiles
- keep the old global legacy dashboard entry removed from dashboard home and command palette

## Tests
- bun test src/lib/legacy-hosted-dashboard.test.ts src/hosted/legacy-agent-tiles.test.ts src/hosted/oss-clean.test.ts
- bun run typecheck
- bunx biome check apps/web/src/lib/legacy-hosted-dashboard.ts apps/web/src/lib/legacy-hosted-dashboard.test.ts apps/web/src/hosted/legacy-agent-tiles.ts apps/web/src/hosted/legacy-agent-tiles.test.ts apps/web/src/components/app-sidebar.tsx apps/web/src/components/dashboard/agent-settings-panel.tsx apps/web/src/lib/env.ts apps/web/.env.example
- bun run build:oss