### PR TITLE
Unify agent identity labels

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -242,6 +242,9 @@ const AGENT_SECTION_TINTS = {
 	settings: "bg-identity-4-bg text-identity-4-fg",
 } satisfies Record<AgentSectionId, string>;
 
+const LEGACY_DASHBOARD_TINT =
+	"bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300";
+
 type SidebarEnvironment = components["schemas"]["EnvironmentResponse"];
 
 type SidebarNavItem = {
@@ -318,7 +321,12 @@ function SidebarNavSection({
 							<SidebarMenuItem key={item.id}>
 								<SidebarMenuButton asChild isActive={item.active} tooltip={item.tooltip}>
 									{item.external ? (
-										<a href={item.href} onClick={onNavigate}>
+										<a
+											href={item.href}
+											target="_blank"
+											rel="noopener noreferrer"
+											onClick={onNavigate}
+										>
 											<NavIconChip tint={item.tint}>
 												<Icon />
 											</NavIconChip>
@@ -428,11 +436,13 @@ function AgentSectionList({
 	agentId,
 	sections,
 	activeSection,
+	extraPrimaryItems = [],
 	onNavigate,
 }: {
 	agentId: string;
 	sections: readonly AgentSectionDefinition[];
 	activeSection: AgentSectionId;
+	extraPrimaryItems?: SidebarNavItem[];
 	onNavigate?: () => void;
 }) {
 	const normalizedActiveSection = sections.some((section) => section.id === activeSection)
@@ -445,18 +455,21 @@ function AgentSectionList({
 		(section) => section.id !== "overview" && section.id !== "console" && section.id !== "terminal",
 	);
 
-	const primaryItems = primarySections.map((section): SidebarNavItem => {
-		const Icon = section.icon;
-		return {
-			id: section.id,
-			label: agentSectionLabel(section.id),
-			href: agentSectionHref(agentId, section.id),
-			icon: Icon,
-			tint: AGENT_SECTION_TINTS[section.id],
-			tooltip: section.tooltip,
-			active: normalizedActiveSection === section.id,
-		};
-	});
+	const primaryItems = [
+		...primarySections.map((section): SidebarNavItem => {
+			const Icon = section.icon;
+			return {
+				id: section.id,
+				label: agentSectionLabel(section.id),
+				href: agentSectionHref(agentId, section.id),
+				icon: Icon,
+				tint: AGENT_SECTION_TINTS[section.id],
+				tooltip: section.tooltip,
+				active: normalizedActiveSection === section.id,
+			};
+		}),
+		...extraPrimaryItems,
+	];
 	const resourceItems = resourceSections.map((section): SidebarNavItem => {
 		const Icon = section.icon;
 		return {
@@ -488,11 +501,27 @@ function AgentFocusSections({
 	onNavigate?: () => void;
 }) {
 	const kind = useAgentChromeKind(agent);
+	const legacyDashboardHref = kind === "legacy" ? legacyHostedDashboardUrl() : null;
+	const extraPrimaryItems: SidebarNavItem[] = legacyDashboardHref
+		? [
+				{
+					id: "legacy-dashboard",
+					label: "Legacy dashboard",
+					href: legacyDashboardHref,
+					icon: History,
+					tint: LEGACY_DASHBOARD_TINT,
+					tooltip: "Open legacy dashboard",
+					active: false,
+					external: true,
+				},
+			]
+		: [];
 	return (
 		<AgentSectionList
 			agentId={agent.id}
 			sections={kind === "cloud" ? HOSTED_AGENT_SECTIONS : CONNECTED_AGENT_SECTIONS}
 			activeSection={activeSection}
+			extraPrimaryItems={extraPrimaryItems}
 			onNavigate={onNavigate}
 		/>
 	);

--- a/apps/web/src/components/dashboard/agent-label.test.ts
+++ b/apps/web/src/components/dashboard/agent-label.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
 	agentDisplayName,
+	agentTextLabel,
 	cleanMachineName,
 	compareAgentEnvironments,
 } from "@/components/dashboard/agent-label";
@@ -17,7 +18,7 @@ describe("cleanMachineName", () => {
 });
 
 describe("agentDisplayName", () => {
-	test("uses runtime as the default Cloud agent name", () => {
+	test("uses the registered machine name as the default Cloud agent name", () => {
 		expect(
 			agentDisplayName(
 				{
@@ -26,13 +27,25 @@ describe("agentDisplayName", () => {
 				},
 				{ ownershipKind: "cloud" },
 			),
-		).toBe("OpenClaw");
+		).toBe("Shared Hosted Compute");
 	});
 
 	test("uses machine name as the default connected agent name", () => {
 		expect(agentDisplayName({ machine_name: "Jing-Mac.local", agent_type: "codex" })).toBe(
 			"Jing-Mac",
 		);
+	});
+
+	test("uses the registered machine name as the default Legacy agent name", () => {
+		expect(
+			agentDisplayName(
+				{
+					machine_name: "v1-hosted-runtime",
+					agent_type: "hermes",
+				},
+				{ ownershipKind: "legacy" },
+			),
+		).toBe("v1-hosted-runtime");
 	});
 
 	test("prefers user display name for every source", () => {
@@ -46,6 +59,18 @@ describe("agentDisplayName", () => {
 				{ ownershipKind: "legacy" },
 			),
 		).toBe("Launch runner");
+	});
+
+	test("keeps runtime as a secondary label when the primary name is not the runtime", () => {
+		expect(
+			agentTextLabel(
+				{
+					machine_name: "Research Agent",
+					agent_type: "codex",
+				},
+				{ ownershipKind: "cloud" },
+			),
+		).toBe("Cloud · Research Agent · Codex");
 	});
 });
 

--- a/apps/web/src/components/dashboard/agent-label.tsx
+++ b/apps/web/src/components/dashboard/agent-label.tsx
@@ -24,11 +24,11 @@ export function AgentInline({
 	type: string | null | undefined;
 	className?: string;
 }) {
-	const machine = cleanMachineName(machineName);
-	const typeLabel = agentTypeLabel(type);
-	const title = machine || typeLabel;
-	const subtitle = machine && type ? typeLabel : null;
-	if (!machine && !type) return null;
+	const hasIdentity = Boolean(cleanMachineName(machineName) || type);
+	const identity = agentIdentity({ machine_name: machineName, agent_type: type });
+	const title = identity.primaryLabel;
+	const subtitle = identity.secondaryLabel;
+	if (!hasIdentity) return null;
 	return (
 		<span className={cn("inline-flex items-center gap-1.5", className)}>
 			<AgentIcon agent={type} size="xs" />
@@ -50,11 +50,10 @@ export function AgentInline({
  * fits both "many agents on one screen" and "one agent in a hero":
  *
  *   primary="machine"  (default — every list and the detail hero)
- *     [icon] Jings-MacBook-Pro.local
+ *     [icon] Launch runner
  *            Hermes · meta…
- *     The machine name is the H1 because that's the label the
- *     user picked themselves; agent_type drops to the subtitle
- *     where it disambiguates 4 agents on the same laptop.
+ *     The canonical agent name is the H1; agent_type drops to
+ *     the subtitle where it disambiguates sibling runtimes.
  *
  *   primary="type"
  *     [icon] Hermes
@@ -86,18 +85,48 @@ function sourceFromOwnershipKind(kind: AgentOwnershipKind): AgentSourceKind {
 	return kind === "cloud" ? "hosted" : "connected";
 }
 
+export type AgentIdentityInput = {
+	display_name?: string | null;
+	machine_name?: string | null;
+	agent_type?: string | null;
+};
+
+export type AgentIdentity = {
+	/** User-edited override stored on AgentEnvironment.display_name. */
+	customName: string | null;
+	/** Registration/default name stored on AgentEnvironment.machine_name. */
+	machineName: string | null;
+	/** Friendly runtime label derived from AgentEnvironment.agent_type. */
+	runtimeName: string;
+	/** Canonical primary label for this agent in dashboard chrome. */
+	primaryLabel: string;
+	/** Runtime disambiguator when it is not already the primary label. */
+	secondaryLabel: string | null;
+};
+
+export function agentIdentity(env: AgentIdentityInput): AgentIdentity {
+	const customName = cleanMachineName(env.display_name) || null;
+	const machineName = cleanMachineName(env.machine_name) || null;
+	const runtimeName = agentTypeLabel(env.agent_type);
+	const primaryLabel = customName ?? machineName ?? runtimeName;
+	const secondaryLabel = runtimeName !== primaryLabel ? runtimeName : null;
+	return {
+		customName,
+		machineName,
+		runtimeName,
+		primaryLabel,
+		secondaryLabel,
+	};
+}
+
 export function agentDisplayName(
-	env: {
-		display_name?: string | null;
-		machine_name?: string | null;
-		agent_type?: string | null;
-	},
-	{ ownershipKind = "connected" }: { ownershipKind?: AgentOwnershipKind } = {},
+	env: AgentIdentityInput,
+	_options: { ownershipKind?: AgentOwnershipKind } = {},
 ): string {
-	const custom = cleanMachineName(env.display_name);
-	if (custom) return custom;
-	if (ownershipKind !== "connected") return agentTypeLabel(env.agent_type);
-	return cleanMachineName(env.machine_name) || agentTypeLabel(env.agent_type);
+	// Ownership affects badges, actions, and lifecycle chrome, not naming.
+	// The Cloud API AgentEnvironment is the identity record for every agent
+	// source, so all sources share the same display fallback.
+	return agentIdentity(env).primaryLabel;
 }
 
 export function agentSourceLabel(source: AgentSourceKind): string {
@@ -207,24 +236,18 @@ export function AgentSourceBadgeForEnvironment({
 }
 
 export function agentTextLabel(
-	env: {
-		id?: string | null;
-		display_name?: string | null;
-		machine_name?: string | null;
-		agent_type?: string | null;
-	},
+	env: AgentIdentityInput & { id?: string | null },
 	{
 		includeSource = true,
 		ownershipKind = "connected",
 	}: { includeSource?: boolean; ownershipKind?: AgentOwnershipKind } = {},
 ): string {
-	const identity = agentDisplayName(env, { ownershipKind });
-	const runtime = agentTypeLabel(env.agent_type);
+	const identity = agentIdentity(env);
 	const source = sourceFromOwnershipKind(ownershipKind);
 	const parts = [
 		includeSource && source === "hosted" ? agentSourceLabel(source) : null,
-		identity,
-		runtime !== identity ? runtime : null,
+		identity.primaryLabel,
+		identity.secondaryLabel,
 	].filter((part): part is string => Boolean(part));
 	return parts.join(" · ");
 }
@@ -318,9 +341,8 @@ export function AgentLabel({
 	type: string | null | undefined;
 	avatarUrl?: string | null | undefined;
 	size?: AgentIconSize;
-	/** Which field is the H1 line. Defaults to "machine" — the
-	 * machine name is the user's own label; agent_type drops to
-	 * the subtitle as a disambiguator. */
+	/** Which field is the H1 line. Defaults to "machine": display name
+	 * if present, then registered machine name, then runtime type. */
 	primary?: "type" | "machine";
 	/** Inline meta items rendered in the subtitle row after the
 	 * primary disambiguator (e.g. last-seen, DaemonStatusBadge).

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -30,23 +30,6 @@ export function isAgentActive(lastSeenAt: string | null | undefined): boolean {
 	return Date.now() - new Date(lastSeenAt).getTime() < ACTIVE_WINDOW_MS;
 }
 
-/** Agent-type → friendly runtime label (OpenClaw, Claude Code, …). */
-export function formatRuntime(agentType: string): string {
-	switch (agentType) {
-		case "openclaw":
-			return "OpenClaw";
-		case "hermes":
-			return "Hermes";
-		case "claude_code":
-		case "claude-code":
-			return "Claude Code";
-		case "codex":
-			return "Codex";
-		default:
-			return agentType;
-	}
-}
-
 /**
  * Build self-managed AgentTiles from cloud-api environments. Shared by the
  * Overview grid and the `/agents` index so the tile shape stays identical
@@ -61,7 +44,6 @@ export function selfManagedAgentTiles(environments: Env[] | undefined): AgentTil
 		avatarUrl: env.avatar_url,
 		sortOrder: env.sort_order,
 		agentType: env.agent_type,
-		runtimeLabel: formatRuntime(env.agent_type),
 		statusLabel: env.last_seen_at ? `Active ${relativeTime(env.last_seen_at)}` : "Never seen",
 		lastSeenAt: env.last_seen_at,
 		href: agentSectionHref(env.id),
@@ -84,8 +66,8 @@ export interface AgentTile {
 	avatarUrl?: string | null;
 	sortOrder?: number | null;
 	agentType: string | null;
-	/** "OpenClaw", "Claude Code", etc. — agent name only, no jargon suffix. */
-	runtimeLabel: string;
+	/** Optional deployment/source context shown after the runtime disambiguator. */
+	contextLabel?: string | null;
 	/** "Synced 2m ago", "Running", "Provisioning…" — already humanized. */
 	statusLabel: string;
 	/** Used to compute the "N active now" count in the card description. */
@@ -248,14 +230,7 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 	// "sync state under the agent name" — pre-fix-attempt the
 	// badge was floated to the trailing edge.
 	const meta: ReactNode[] = [];
-	// Hosted (on-clawdi) tiles use `runtimeLabel` to carry the
-	// deployment slug — without it two OpenClaw / Hermes deployments
-	// linking to different deploy URLs would render
-	// indistinguishably ('OpenClaw · Running' on both). Self-
-	// managed tiles already convey the runtime via the
-	// AgentLabel `type` prop (the icon badge), so adding
-	// runtimeLabel there would just duplicate the agent type.
-	if ((onClawdi || legacyHosted) && tile.runtimeLabel) meta.push(tile.runtimeLabel);
+	if (tile.contextLabel) meta.push(tile.contextLabel);
 	if (tile.statusLabel) meta.push(tile.statusLabel);
 	if (tile.env) {
 		meta.push(

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -20,7 +20,6 @@ import {
 	AgentSourceBadgeForEnvironment,
 	agentDisplayName,
 	agentTypeLabel,
-	cleanMachineName,
 } from "@/components/dashboard/agent-label";
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
 import { DetailNotFound, DetailPanel, type DetailSectionMeta } from "@/components/detail/layout";
@@ -236,9 +235,7 @@ export function ConnectedAgentDetail({
 				</div>
 			) : agent ? (
 				<>
-					<h1 className="sr-only">
-						{cleanMachineName(agent.machine_name) || agentTypeLabel(agent.agent_type)}
-					</h1>
+					<h1 className="sr-only">{agentTitle || agentTypeLabel(agent.agent_type)}</h1>
 
 					<section className={cn("flex flex-col gap-4", contentWidthClass)}>
 						<div className="flex flex-wrap items-start justify-between gap-3">

--- a/apps/web/src/hosted/legacy-agent-tiles.test.ts
+++ b/apps/web/src/hosted/legacy-agent-tiles.test.ts
@@ -57,10 +57,12 @@ describe("legacyConnectedAgentTiles", () => {
 				id: legacy.id,
 				source: "legacy-hosted",
 				name: "v1-hosted-runtime",
-				runtimeLabel: "OpenClaw",
 				href: `/agents/${legacy.id}`,
 			}),
 		]);
+		expect(
+			legacyConnectedAgentTiles([legacy], new Set([legacy.id]))[0]?.contextLabel,
+		).toBeUndefined();
 	});
 
 	it("carries env so the sync badge renders (with the hosted copy variant)", () => {

--- a/apps/web/src/hosted/legacy-agent-tiles.ts
+++ b/apps/web/src/hosted/legacy-agent-tiles.ts
@@ -1,6 +1,6 @@
 import type { components } from "@clawdi/shared/api";
-import { cleanMachineName } from "@/components/dashboard/agent-label";
-import { type AgentTile, formatRuntime, isAgentActive } from "@/components/dashboard/agents-card";
+import { agentDisplayName } from "@/components/dashboard/agent-label";
+import { type AgentTile, isAgentActive } from "@/components/dashboard/agents-card";
 import { normalizeAgentEnvId } from "@/lib/agent-ownership";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { legacyHostedDashboardUrl } from "@/lib/legacy-hosted-dashboard";
@@ -39,15 +39,11 @@ export function legacyConnectedAgentTiles(
 		.map((env) => ({
 			id: env.id,
 			source: "legacy-hosted" as const,
-			name:
-				cleanMachineName(env.display_name) ||
-				cleanMachineName(env.machine_name) ||
-				formatRuntime(env.agent_type),
+			name: agentDisplayName(env, { ownershipKind: "legacy" }),
 			displayName: env.display_name,
 			avatarUrl: env.avatar_url,
 			sortOrder: env.sort_order,
 			agentType: env.agent_type,
-			runtimeLabel: formatRuntime(env.agent_type),
 			statusLabel: env.last_seen_at ? `Active ${relativeTime(env.last_seen_at)}` : "Never seen",
 			lastSeenAt: env.last_seen_at,
 			href: agentSectionHref(env.id),

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -3,6 +3,7 @@
 import type { components } from "@clawdi/shared/api";
 import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
+import { agentDisplayName } from "@/components/dashboard/agent-label";
 import type { AgentTile } from "@/components/dashboard/agents-card";
 import { deploymentDisplayName } from "@/hosted/agent-identity";
 import { isDeployApiConfigured, useBillingClient } from "@/hosted/billing/billing-client";
@@ -166,22 +167,19 @@ function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>): Agen
 		const settingsHref = matchedEnv
 			? agentSectionHref(matchedEnv.id, "settings", "source=on-clawdi")
 			: agentSectionHref(d.id, "settings");
+		const name = matchedEnv
+			? agentDisplayName(matchedEnv, { ownershipKind: "cloud" })
+			: runtimeDisplayName(runtime);
+		const contextLabel = slug !== name ? slug : null;
 		return {
 			id: `${d.id}:${runtime}`,
 			source: "on-clawdi" as const,
-			// Runtime is the primary identifier on hosted tiles since the
-			// AgentIcon already brands it and one deployment fans out to
-			// multiple tiles — using `d.name` here would print
-			// "openclaw-b5451f9c" on a Hermes tile.
-			name: matchedEnv?.display_name?.trim() || runtimeDisplayName(runtime),
+			name,
 			displayName: matchedEnv?.display_name ?? null,
 			avatarUrl: matchedEnv?.avatar_url ?? null,
 			sortOrder: matchedEnv?.sort_order ?? null,
 			agentType: runtime,
-			// Deployment slug as the secondary line lets users disambiguate
-			// when they have more than one hosted deployment. Mode info ("Daemon") is
-			// implied by the "Clawdi" badge — every hosted runtime is daemon.
-			runtimeLabel: slug,
+			contextLabel,
 			statusLabel,
 			lastSeenAt: matchedEnv?.last_seen_at ?? null,
 			// `?source=on-clawdi` is the breadcrumb the agent detail page

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -12,7 +12,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSetAgentBreadcrumbTitle } from "@/components/breadcrumb-title";
-import { AgentInline, agentTypeLabel, cleanMachineName } from "@/components/dashboard/agent-label";
+import { AgentInline, agentDisplayName } from "@/components/dashboard/agent-label";
 import { DetailMeta, DetailPanel, DetailStats, DetailTitle } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
 import { ModelBadge } from "@/components/meta/model-badge";
@@ -73,6 +73,16 @@ export function SessionDetailContent({
 		},
 		staleTime: SESSION_DETAIL_STALE_MS,
 		gcTime: SESSION_DETAIL_GC_MS,
+	});
+	const { data: scopedAgent } = useQuery({
+		queryKey: ["agent", agentId],
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/v1/environments/{environment_id}", {
+					params: { path: { environment_id: agentId ?? "" } },
+				}),
+			),
+		enabled: !!agentId,
 	});
 
 	// Direction toggle: "desc" (newest-first, default) is the most
@@ -215,7 +225,9 @@ export function SessionDetailContent({
 		? formatSessionSummary(session.summary) || session.local_session_id.slice(0, 12)
 		: null;
 	const agentBreadcrumbTitle = session
-		? cleanMachineName(session.machine_name) || agentTypeLabel(session.agent_type)
+		? scopedAgent
+			? agentDisplayName(scopedAgent)
+			: agentDisplayName({ machine_name: session.machine_name, agent_type: session.agent_type })
 		: null;
 	useSetAgentBreadcrumbTitle({
 		agentId,
@@ -248,7 +260,10 @@ export function SessionDetailContent({
 				<div className="min-w-0 flex-1 space-y-2">
 					<DetailTitle>{summaryText}</DetailTitle>
 					<DetailMeta>
-						<AgentInline machineName={session.machine_name} type={session.agent_type} />
+						<AgentInline
+							machineName={scopedAgent ? agentDisplayName(scopedAgent) : session.machine_name}
+							type={session.agent_type}
+						/>
 						{session.project_path ? (
 							<>
 								<span>·</span>

--- a/apps/web/src/pages/dashboard/skills/[key]/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/[key]/page.tsx
@@ -19,7 +19,7 @@ import { parseAsString, useQueryState } from "nuqs";
 import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useSetBreadcrumbSegmentTitle, useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
-import { cleanMachineName } from "@/components/dashboard/agent-label";
+import { agentDisplayName, cleanMachineName } from "@/components/dashboard/agent-label";
 import {
 	DetailMeta,
 	DetailNotFound,
@@ -115,9 +115,24 @@ export function SkillDetailContent({
 		},
 	});
 
+	const agentEnvironmentId = agentId ?? skill?.environment_id ?? null;
+	const { data: skillAgent } = useQuery({
+		queryKey: ["agent", agentEnvironmentId],
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/v1/environments/{environment_id}", {
+					params: { path: { environment_id: agentEnvironmentId ?? "" } },
+				}),
+			),
+		enabled: !!agentEnvironmentId,
+	});
+	const skillAgentLabel = skillAgent
+		? agentDisplayName(skillAgent)
+		: skill?.machine_name
+			? cleanMachineName(skill.machine_name)
+			: null;
 	const breadcrumbTitle = skill?.name || (skill ? skillKey : null);
-	const agentTitle = skill?.machine_name ? cleanMachineName(skill.machine_name) : null;
-	useSetBreadcrumbSegmentTitle(agentId ? agentSectionHref(agentId) : null, agentTitle);
+	useSetBreadcrumbSegmentTitle(agentId ? agentSectionHref(agentId) : null, skillAgentLabel);
 	useSetBreadcrumbTitle(breadcrumbTitle);
 
 	const { data: defaultProject, error: projectError } = useQuery({
@@ -210,8 +225,8 @@ export function SkillDetailContent({
 		},
 		onSuccess: () => {
 			toast.success("Skill Saved", {
-				description: skill?.machine_name
-					? `${skill.machine_name} picks up the new version within a couple seconds via sync.`
+				description: skillAgentLabel
+					? `${skillAgentLabel} picks up the new version within a couple seconds via sync.`
 					: "The change applies on this agent within a couple seconds via sync.",
 			});
 			setIsEditing(false);
@@ -250,8 +265,8 @@ export function SkillDetailContent({
 		},
 		onSuccess: () => {
 			toast.success("Skill Uninstalled", {
-				description: skill?.machine_name
-					? `Removed from ${skill.machine_name}. Other agents keep their copies.`
+				description: skillAgentLabel
+					? `Removed from ${skillAgentLabel}. Other agents keep their copies.`
 					: "Removed from this agent. Other agents keep their copies.",
 			});
 			queryClient.invalidateQueries({ queryKey: ["skills"] });
@@ -273,9 +288,9 @@ export function SkillDetailContent({
 	};
 
 	const sourceProjectName = skill?.project_name ?? null;
-	const uninstallLocation = skill?.machine_name ? `from ${skill.machine_name}` : "from this agent";
-	const agentCaption = skill?.machine_name
-		? `on ${skill.machine_name}`
+	const uninstallLocation = skillAgentLabel ? `from ${skillAgentLabel}` : "from this agent";
+	const agentCaption = skillAgentLabel
+		? `on ${skillAgentLabel}`
 		: sourceProjectName
 			? `in ${sourceProjectName}`
 			: null;

--- a/apps/web/src/pages/dashboard/skills/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/page.tsx
@@ -21,7 +21,7 @@ import { parseAsString, useQueryState } from "nuqs";
 import { Suspense, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { BulkActionBar } from "@/components/bulk-action-bar";
-import { agentTypeLabel, cleanMachineName } from "@/components/dashboard/agent-label";
+import { agentIdentity } from "@/components/dashboard/agent-label";
 import { PageHeader } from "@/components/page-header";
 import {
 	compareProjectsForUse,
@@ -209,11 +209,14 @@ function SkillsPageInner() {
 
 	const targetAgentLabel = useMemo(() => {
 		if (!envs || envs.length === 0 || !targetEnv) return FALLBACK_TARGET_LABEL;
-		const baseName = cleanMachineName(targetEnv.machine_name) || FALLBACK_TARGET_LABEL;
+		const identity = agentIdentity(targetEnv);
+		const baseName = identity.primaryLabel || FALLBACK_TARGET_LABEL;
 		const collidesWithSibling = envs.some(
-			(e) => e.id !== targetEnv.id && e.machine_name === targetEnv.machine_name,
+			(e) => e.id !== targetEnv.id && agentIdentity(e).primaryLabel === baseName,
 		);
-		if (collidesWithSibling) return `${baseName} · ${agentTypeLabel(targetEnv.agent_type)}`;
+		if (collidesWithSibling && identity.secondaryLabel) {
+			return `${baseName} · ${identity.secondaryLabel}`;
+		}
 		return baseName;
 	}, [envs, targetEnv]);
 


### PR DESCRIPTION
## Summary
- centralize agent display identity around AgentEnvironment: display_name -> machine_name -> agent_type
- make Cloud, Legacy, and connected agents share the same primary-label fallback while source ownership only controls chrome/actions
- remove duplicate runtime labels from agent tiles and show deployment context only when it differs from the primary agent name
- add a Legacy dashboard primary sidebar entry for legacy-owned agents when the URL is configured
- reuse canonical agent labels in agent detail, scoped session detail, and skill install/detail flows

## Verification
- VITE_CLERK_PUBLISHABLE_KEY=pk_test_dummy bun test apps/web/src/components/dashboard/agent-label.test.ts apps/web/src/hosted/legacy-agent-tiles.test.ts apps/web/src/components/dashboard/agents-card.test.ts
- VITE_CLERK_PUBLISHABLE_KEY=pk_test_dummy bun run --cwd apps/web typecheck
- bun run check