### PR TITLE
Add ADR for the agent identity domain model

### DIFF
--- a/docs/adr/0001-agent-identity-is-the-stable-domain-object.md
+++ b/docs/adr/0001-agent-identity-is-the-stable-domain-object.md
@@ -1,0 +1,94 @@
+# ADR-0001: Agent Identity Is the Stable Domain Object
+
+**Status:** Accepted
+**Date:** 2026-07-03
+**Deciders:** Clawdi maintainers
+
+## Context
+
+Clawdi stores the agent identity used by sessions, runtime state, channel
+links, and API-key scoping in the `agent_environments` table. Existing code and
+wire contracts still use names such as `AgentEnvironment` and `environment_id`
+because the first implementation modeled the row as a local machine
+environment.
+
+That name is now misleading. A Clawdi Agent is the first-class domain object:
+one stable agent identity that may refresh its machine metadata over time.
+Compatibility still matters, so the current table and API field names remain in
+place until there is a strong reason to migrate them.
+
+## Decision
+
+The first-class domain object is the **Agent**, meaning the stable agent
+identity.
+
+`AgentEnvironment` and the `agent_environments` table are legacy persistence
+names for that object. `environment_id` is the legacy wire and database field
+name for the stable agent id. New product and architecture language should say
+**Agent**, **agent identity**, or **agent id** when describing the domain model,
+while accepting the legacy names in existing API and database contracts.
+
+In code today:
+
+- `AgentEnvironment.id` is the stable `agent_id`.
+- `Session.environment_id` points at that stable agent identity.
+- `registration_key` exists only for legacy/self-managed setup idempotency.
+
+## Invariants
+
+- `agent_id` means `AgentEnvironment.id`.
+- `agent_id` is the identity and remains stable across re-registrations.
+- `machine_id`, `machine_name`, `os`, and `agent_version` are refreshable
+  metadata. They are never identity.
+- `registration_key` is only a legacy/self-managed setup idempotency key. The
+  current self-managed registration key is machine-derived from `machine_id`
+  and `agent_type`.
+- `(user, machine_id)` must never be treated as identity.
+- `(user, machine_id, agent_type)` must never be treated as identity.
+- Rows with `registration_key IS NULL` are explicit-identity rows. They are
+  caller-owned and must not be deleted by user-facing disconnect flows.
+- User-facing disconnect can remove legacy/self-managed rows that have a
+  `registration_key`, while preserving historical sessions through the existing
+  nullable `sessions.environment_id` relationship.
+
+## Registration Contract
+
+Self-managed agents register through `POST /v1/environments`.
+
+That endpoint derives a legacy registration key from the submitted machine
+metadata and is idempotent for that user's setup flow. Re-registration refreshes
+machine metadata and returns the same stable `AgentEnvironment.id`.
+
+First-party hosted control planes register through the admin API.
+
+They may supply an explicit caller-owned stable id. The supplied id is the
+agent identity. Re-registration with the same user and same id refreshes
+metadata in place. Reusing an id that already belongs to another user is a
+conflict. Explicit-identity rows use `registration_key = NULL`.
+
+## Consequences
+
+- Documentation should describe the domain object as Agent or agent identity,
+  even where code still says `AgentEnvironment`.
+- New code should not derive ownership, identity, or uniqueness from machine
+  metadata.
+- Public API clients should continue to treat existing `environment_id` fields
+  as stable agent ids.
+- User-facing deletion and disconnect behavior must preserve caller-owned
+  explicit identities.
+- The legacy database and wire names remain supported for compatibility.
+
+## Migration Direction
+
+These are non-binding future improvements, not requirements for the current
+decision:
+
+- Rename service-layer concepts toward agent identity, for example
+  `register_agent_identity`.
+- Add an agent-first admin API such as `/v1/admin/agents` while keeping the
+  existing environment endpoint compatible.
+- Add a runtime manifest `agentId` alias for the current legacy field.
+- Consider a database/table rename only much later, after API and service
+  terminology have settled.
+
+Database and table renames are explicitly deferred.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,15 @@
+# Architecture Decision Records
+
+Architecture Decision Records (ADRs) capture durable technical and product
+model decisions that future contributors need to preserve or intentionally
+change.
+
+Use four-digit, monotonic file numbers:
+
+```text
+0001-short-kebab-case-title.md
+0002-next-decision.md
+```
+
+Each ADR should state its status, date, context, decision, consequences, and
+any non-binding future direction.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,13 +63,13 @@ All keyed off Clerk `user_id`:
 |---|---|---|
 | `users` | Clerk user mirror + email | Sign-in |
 | `api_keys` | SHA-256-hashed CLI bearer tokens | Dashboard |
-| `agent_environments` | Stable agent identity rows. Self-managed agents use `registration_key` for local setup idempotency; hosted agents use explicit ids. `agent_type ∈ {claude_code, codex, hermes, openclaw}` | `clawdi setup`, hosted agent registration |
+| `agent_environments` | Agent identity rows. The domain object is Agent; `AgentEnvironment` and `environment_id` are legacy persistence/wire names kept for compatibility. `id` is the stable agent id; self-managed agents use `registration_key` only for setup idempotency; first-party hosted control planes supply caller-owned stable agent ids. See [ADR-0001](adr/0001-agent-identity-is-the-stable-domain-object.md). `agent_type ∈ {claude_code, codex, hermes, openclaw}` | `clawdi setup`, hosted agent registration |
 | `projects` | Resource availability boundaries for skills, vault attachments, and future memory/session grouping. Kinds are `personal`, `environment`, and `workspace`; `environment` is the internal Agent Project kind | Provisioning, `clawdi setup`, `clawdi project create` |
 | `project_memberships` | Viewer-only shared Project access granted by invite or share link | Share accept / invite accept |
 | `project_share_links` | Hashed bearer links for read-only Project access. Raw tokens are only returned once | `clawdi project share` |
 | `project_invitations` | Pending directed invites to existing Clawdi users | `clawdi project invite` |
 | `agent_project_bindings` | Runtime Agent composition: one fixed `primary` Agent Project row plus ordered `context` attachments | `clawdi setup`, `clawdi agent projects ...` |
-| `sessions` | Per-conversation metadata: `environment_id`, `local_session_id`, `project_path`, token counts, model, summary, status. **Raw transcript body is in the file store**, keyed by `file_key` | `clawdi push` |
+| `sessions` | Per-conversation metadata: `environment_id` (legacy field name for the stable agent id), `local_session_id`, `project_path`, token counts, model, summary, status. **Raw transcript body is in the file store**, keyed by `file_key` | `clawdi push` |
 | `skills` | Per-skill metadata + tar.gz body in file store | CLI `skill add / install`, dashboard upload |
 | `vaults` + `vault_project_attachments` + `vault_items` | Three-level secrets: vault → section → field. Vaults own their keys; Projects only attach to a vault to make those keys available. Values are AES-256-GCM encrypted. `/vault/resolve` decrypts readable Project values for CLI/API-key callers | `clawdi vault set` |
 | `memories` | Long-term recall. `content` (text), `category`, `tags`, plus three search columns (`content_tsv` generated tsvector, `embedding vector(768)`) | CLI and MCP `memory_add` |


### PR DESCRIPTION
## Summary
- Add an ADR directory with numbering guidance.
- Document the Agent / agent identity domain model and legacy `AgentEnvironment` / `environment_id` naming.
- Update the architecture data-model table to reference ADR-0001 and describe `sessions.environment_id` as the stable agent id field.

## Notes
- Verified the registration, explicit-id, registration-key, disconnect, and dashboard ownership behavior against the current code before writing the ADR.
- Docs-only change; `git diff --check` passed. Pre-commit ran and skipped Biome because there were no inspectable files.