### PR TITLE
Expose explicit agent identity

### DIFF
--- a/apps/web/src/components/dashboard/agent-settings-panel.tsx
+++ b/apps/web/src/components/dashboard/agent-settings-panel.tsx
@@ -20,7 +20,11 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
-import { agentOwnershipKindFromId, useAgentOwnership } from "@/lib/agent-ownership";
+import {
+	agentDisconnectUnavailable,
+	agentOwnershipKindFromId,
+	useAgentOwnership,
+} from "@/lib/agent-ownership";
 import { unwrap, useAgentAvatarUploader, useApi } from "@/lib/api";
 import { legacyHostedDashboardUrl } from "@/lib/legacy-hosted-dashboard";
 import { cn, errorMessage } from "@/lib/utils";
@@ -184,7 +188,11 @@ export function AgentSettingsPanel({
 	// for RESOLVED ownership (`ownership !== null`). While the hosted sensor
 	// is still resolving, a live hosted/legacy agent would otherwise briefly
 	// classify as connected and expose a working Disconnect.
-	const disconnectUnavailable = ownership === null || ownershipKind !== "connected";
+	const disconnectUnavailable = agentDisconnectUnavailable({
+		envId: agent.id,
+		explicitIdentity: agent.explicit_identity,
+		ownership,
+	});
 	const isBusy =
 		updateIdentity.isPending ||
 		uploadMutation.isPending ||

--- a/apps/web/src/lib/agent-ownership.test.ts
+++ b/apps/web/src/lib/agent-ownership.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { agentOwnershipKindFromId, EMPTY_AGENT_OWNERSHIP } from "@/lib/agent-ownership";
+import {
+	agentDisconnectUnavailable,
+	agentOwnershipKindFromId,
+	EMPTY_AGENT_OWNERSHIP,
+} from "@/lib/agent-ownership";
 
 describe("agentOwnershipKindFromId", () => {
 	it("classifies environments from ownership sets with case-insensitive ids", () => {
@@ -31,5 +35,53 @@ describe("agentOwnershipKindFromId", () => {
 		};
 
 		expect(agentOwnershipKindFromId("aaaa", ownership)).toBe("cloud");
+	});
+});
+
+describe("agentDisconnectUnavailable", () => {
+	it("keeps connected machine-key agents disconnectable after ownership resolves", () => {
+		expect(
+			agentDisconnectUnavailable({
+				envId: "aaaa",
+				explicitIdentity: false,
+				ownership: EMPTY_AGENT_OWNERSHIP,
+			}),
+		).toBe(false);
+	});
+
+	it("treats an absent explicit identity field as the existing connected behavior", () => {
+		expect(
+			agentDisconnectUnavailable({
+				envId: "aaaa",
+				ownership: EMPTY_AGENT_OWNERSHIP,
+			}),
+		).toBe(false);
+	});
+
+	it("blocks disconnect for explicit-identity agents outside ownership sets", () => {
+		expect(
+			agentDisconnectUnavailable({
+				envId: "aaaa",
+				explicitIdentity: true,
+				ownership: EMPTY_AGENT_OWNERSHIP,
+			}),
+		).toBe(true);
+	});
+
+	it("blocks disconnect while ownership is unresolved or externally owned", () => {
+		expect(
+			agentDisconnectUnavailable({
+				envId: "aaaa",
+				explicitIdentity: false,
+				ownership: null,
+			}),
+		).toBe(true);
+		expect(
+			agentDisconnectUnavailable({
+				envId: "aaaa",
+				explicitIdentity: false,
+				ownership: { cloudEnvIds: new Set(["aaaa"]), legacyEnvIds: new Set() },
+			}),
+		).toBe(true);
 	});
 });

--- a/apps/web/src/lib/agent-ownership.ts
+++ b/apps/web/src/lib/agent-ownership.ts
@@ -60,3 +60,19 @@ export function agentOwnershipKindFromId(
 	if (ownership.legacyEnvIds.has(normalized)) return "legacy";
 	return "connected";
 }
+
+export function agentDisconnectUnavailable({
+	envId,
+	explicitIdentity,
+	ownership,
+}: {
+	envId: string | null | undefined;
+	explicitIdentity?: boolean | null;
+	ownership: AgentOwnership | null;
+}): boolean {
+	return (
+		explicitIdentity === true ||
+		ownership === null ||
+		agentOwnershipKindFromId(envId, ownership) !== "connected"
+	);
+}

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -591,7 +591,8 @@ async def admin_delete_environment(
     """Delete an AgentEnvironment row on behalf of first-party hosted infra.
 
     Sessions keep their history via ON DELETE SET NULL, matching the
-    dashboard-only `/api/environments/{id}` semantics.
+    dashboard-only `/api/environments/{id}` semantics. Unlike the dashboard
+    route, first-party cleanup may delete explicit-identity rows.
     """
     env = (
         await db.execute(select(AgentEnvironment).where(AgentEnvironment.id == environment_id))

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -661,6 +661,7 @@ def _env_to_response(
         sync_enabled=env.sync_enabled,
         hosted_managed=hosted_managed,
         hosted_deployment_id=resolved_hosted_deployment_id,
+        explicit_identity=env.registration_key is None,
         # NOT NULL per schema; the heal path in register_environment
         # backfills any legacy row missing this column before the
         # response is built, so we always have a value here.

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -209,6 +209,10 @@ class EnvironmentResponse(BaseModel):
     # runtime desired state for this env or a sibling env in the same
     # hosted compute.
     hosted_deployment_id: str | None = None
+    # True when the row was registered with a caller-owned stable identity.
+    # These rows have no local registration key and cannot be disconnected
+    # through the user-facing dashboard route.
+    explicit_identity: bool = False
     # Schema-enforced NOT NULL on agent_environments — every env
     # has a default project after register_environment runs (which
     # heals legacy rows that lost their value). Daemons rely on this

--- a/backend/app/services/agent_environments.py
+++ b/backend/app/services/agent_environments.py
@@ -54,8 +54,13 @@ async def register_agent_environment(
     Explicit `environment_id` callers own the agent identity and bypass machine
     idempotency. Implicit callers must pass `registration_key`; concurrent
     retries converge through the database unique constraint on
-    `(user_id, registration_key)`.
+    `(user_id, registration_key)`. At least one of `environment_id` or
+    `registration_key` must be supplied so every create path has a stable
+    identity or an idempotency key.
     """
+
+    if environment_id is None and registration_key is None:
+        raise ValueError("register_agent_environment requires environment_id or registration_key")
 
     if environment_id is not None:
         existing = (

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -703,7 +703,7 @@ async def test_admin_channel_create_requires_admin_key(admin_client, seed_user):
 
 
 @pytest.mark.asyncio
-async def test_admin_register_env_creates_with_project(admin_client, db_session, seed_user):
+async def test_admin_register_env_creates_with_project(admin_client, client, db_session, seed_user):
     """Admin env registration creates an AgentEnvironment AND a
     default project, matching the user-facing register_environment
     contract. Migration tooling depends on default_project_id being
@@ -733,9 +733,17 @@ async def test_admin_register_env_creates_with_project(admin_client, db_session,
     assert env.registration_key == "machine:migrate-machine-1:agent:openclaw"
     assert env.default_project_id is not None  # heal logic ran
 
+    detail = await client.get(f"/v1/environments/{env_id}")
+    assert detail.status_code == 200, detail.text
+    body = detail.json()
+    assert body["explicit_identity"] is False
+    assert "registration_key" not in body
+
 
 @pytest.mark.asyncio
-async def test_admin_register_env_accepts_explicit_agent_id(admin_client, db_session, seed_user):
+async def test_admin_register_env_accepts_explicit_agent_id(
+    admin_client, client, db_session, seed_user
+):
     """Hosted registration owns the stable agent id. Machine fields are metadata."""
     import uuid
 
@@ -764,6 +772,12 @@ async def test_admin_register_env_accepts_explicit_agent_id(admin_client, db_ses
     assert env.user_id == seed_user.id
     assert env.machine_id == "hosted-machine-explicit"
     assert env.registration_key is None
+
+    detail = await client.get(f"/v1/environments/{agent_id}")
+    assert detail.status_code == 200, detail.text
+    body = detail.json()
+    assert body["explicit_identity"] is True
+    assert "registration_key" not in body
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -751,6 +751,19 @@ async def test_admin_register_env_accepts_explicit_agent_id(
 
     from app.models.session import AgentEnvironment
 
+    machine_key = await admin_client.post(
+        "/v1/admin/environments",
+        headers=_AUTH,
+        json={
+            "target_clerk_id": seed_user.clerk_id,
+            "machine_id": "machine-key-before-explicit",
+            "machine_name": "machine-key-pod",
+            "agent_type": "openclaw",
+        },
+    )
+    assert machine_key.status_code == 200, machine_key.text
+    machine_key_env_id = machine_key.json()["id"]
+
     agent_id = uuid.uuid4()
     r = await admin_client.post(
         "/v1/admin/environments",
@@ -778,6 +791,14 @@ async def test_admin_register_env_accepts_explicit_agent_id(
     body = detail.json()
     assert body["explicit_identity"] is True
     assert "registration_key" not in body
+
+    listing = await client.get("/v1/environments")
+    assert listing.status_code == 200, listing.text
+    by_id = {item["id"]: item for item in listing.json()}
+    assert {
+        machine_key_env_id: by_id[machine_key_env_id]["explicit_identity"],
+        str(agent_id): by_id[str(agent_id)]["explicit_identity"],
+    } == {machine_key_env_id: False, str(agent_id): True}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -36,6 +36,53 @@ async def test_environment_register_is_idempotent(client: httpx.AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_environment_register_uses_machine_key_identity(
+    client: httpx.AsyncClient, db_session: AsyncSession
+):
+    from sqlalchemy import select
+
+    from app.models.session import AgentEnvironment
+
+    machine_id = f"machine-key-{uuid.uuid4().hex}"
+    env_id = await _register_env(client, machine_id=machine_id)
+
+    env = (
+        await db_session.execute(select(AgentEnvironment).where(AgentEnvironment.id == env_id))
+    ).scalar_one()
+    assert env.registration_key == f"machine:{machine_id}:agent:claude-code"
+
+    detail = await client.get(f"/v1/environments/{env_id}")
+    assert detail.status_code == 200, detail.text
+    body = detail.json()
+    assert body["explicit_identity"] is False
+    assert "registration_key" not in body
+
+
+@pytest.mark.asyncio
+async def test_register_agent_environment_requires_identity_or_registration_key(
+    db_session: AsyncSession, seed_user
+):
+    from app.services.agent_environments import register_agent_environment
+
+    with pytest.raises(
+        ValueError,
+        match="requires environment_id or registration_key",
+    ):
+        await register_agent_environment(
+            db_session,
+            user_id=seed_user.id,
+            machine_id="missing-idempotency",
+            machine_name="Missing Idempotency",
+            agent_type="codex",
+            agent_version=None,
+            os_name="linux",
+            sort_order=0,
+            environment_id=None,
+            registration_key=None,
+        )
+
+
+@pytest.mark.asyncio
 async def test_environments_support_conditional_get(client: httpx.AsyncClient):
     env_id = await _register_env(client, machine_id=f"etag-{uuid.uuid4().hex}")
 

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -3733,6 +3733,11 @@ export interface components {
             hosted_managed: boolean;
             /** Hosted Deployment Id */
             hosted_deployment_id?: string | null;
+            /**
+             * Explicit Identity
+             * @default false
+             */
+            explicit_identity: boolean;
             /** Default Project Id */
             default_project_id: string;
         };


### PR DESCRIPTION
Summary
- Add explicit_identity to environment API responses without exposing registration_key.
- Reject register_agent_environment calls that have neither environment_id nor registration_key.
- Gate dashboard Disconnect on explicit_identity in addition to existing ownership checks.

Tests
- uv run ruff check app/schemas/session.py app/routes/sessions.py app/services/agent_environments.py app/routes/admin.py tests/test_sessions.py tests/test_admin_endpoints.py
- uv run ruff format --check app/schemas/session.py app/routes/sessions.py app/services/agent_environments.py app/routes/admin.py tests/test_sessions.py tests/test_admin_endpoints.py
- DATABASE_URL=postgresql+asyncpg://clawdi:clawdi_dev@127.0.0.1:39435/clawdi uv run alembic upgrade head
- DATABASE_URL=postgresql+asyncpg://clawdi:clawdi_dev@127.0.0.1:39435/clawdi uv run pytest tests/test_sessions.py tests/test_admin_endpoints.py -q
- bun test apps/web/src/lib/agent-ownership.test.ts
- bun run typecheck
- bunx biome check apps/web/src/components/dashboard/agent-settings-panel.tsx apps/web/src/lib/agent-ownership.ts apps/web/src/lib/agent-ownership.test.ts packages/shared/src/api/api.generated.ts
- uv run python scripts/check_generated_api.py