### PR TITLE
Polish the hosted v2 UI

### DIFF
--- a/apps/web/src/components/entity-card.tsx
+++ b/apps/web/src/components/entity-card.tsx
@@ -22,6 +22,15 @@ import { cn } from "@/lib/utils";
 
 export const ENTITY_CARD_BASE = "min-w-0 rounded-lg border p-4";
 
+/** Responsive card grid every entity-card collection shares (providers,
+ * channels, shared bots). */
+export const ENTITY_GRID_CLASS = "grid gap-2 sm:grid-cols-2 xl:grid-cols-3";
+
+/** Stretched link that makes a whole card navigate while keeping inner
+ * controls independently clickable — pairs with a `relative z-0` wrapper. */
+export const ENTITY_STRETCHED_LINK_CLASS =
+	"absolute inset-0 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+
 /** Meta line — array items render middot-separated; truncates per item. */
 export function EntityMeta({
 	items,
@@ -168,8 +177,7 @@ export function EntityRow({
 	}
 
 	if (href) {
-		const linkClass =
-			"absolute inset-0 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+		const linkClass = ENTITY_STRETCHED_LINK_CLASS;
 		return (
 			<div className="group relative z-0 min-w-0">
 				<div

--- a/apps/web/src/components/entity-card.tsx
+++ b/apps/web/src/components/entity-card.tsx
@@ -20,7 +20,7 @@ import { cn } from "@/lib/utils";
  *     where they need a richer, bespoke body.
  */
 
-export const ENTITY_CARD_BASE = "rounded-lg border p-4";
+export const ENTITY_CARD_BASE = "min-w-0 rounded-lg border p-4";
 
 /** Meta line — array items render middot-separated; truncates per item. */
 export function EntityMeta({
@@ -85,9 +85,9 @@ export function EntityHeader({
 		>
 			{icon}
 			<div className="min-w-0 flex-1">
-				<div className="flex items-center gap-2">
-					<span className="truncate text-sm font-medium">{title}</span>
-					{titleAdornment}
+				<div className="flex min-w-0 items-center gap-2">
+					<span className="min-w-0 flex-1 truncate text-sm font-medium">{title}</span>
+					{titleAdornment ? <span className="shrink-0">{titleAdornment}</span> : null}
 				</div>
 				{meta !== undefined ? <EntityMeta items={meta} /> : null}
 			</div>
@@ -171,7 +171,7 @@ export function EntityRow({
 		const linkClass =
 			"absolute inset-0 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 		return (
-			<div className="group relative z-0">
+			<div className="group relative z-0 min-w-0">
 				<div
 					className={cn(
 						ENTITY_CARD_BASE,
@@ -229,11 +229,13 @@ export function EntityChoiceCard({
 		<>
 			{icon}
 			<div className="min-w-0 flex-1">
-				<div className="flex items-center gap-2">
-					<span className="truncate text-sm font-medium">{title}</span>
-					{badge}
+				<div className="flex min-w-0 items-center gap-2">
+					<span className="min-w-0 flex-1 truncate text-sm font-medium">{title}</span>
+					{badge ? <span className="shrink-0">{badge}</span> : null}
 				</div>
-				{description ? <p className="mt-0.5 text-sm text-muted-foreground">{description}</p> : null}
+				{description ? (
+					<p className="mt-0.5 break-words text-sm text-muted-foreground">{description}</p>
+				) : null}
 			</div>
 			{selected ? <Check className="mt-0.5 size-4 shrink-0 text-primary" aria-hidden /> : null}
 		</>

--- a/apps/web/src/components/section-label.tsx
+++ b/apps/web/src/components/section-label.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export function SectionLabel({
+	children,
+	count,
+	className,
+}: {
+	children: ReactNode;
+	count?: ReactNode;
+	className?: string;
+}) {
+	return (
+		<div className={cn("flex items-center gap-2 px-0.5", className)}>
+			<span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+				{children}
+			</span>
+			{count !== undefined ? <span className="text-xs text-muted-foreground">{count}</span> : null}
+		</div>
+	);
+}

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -280,29 +280,17 @@ function TimezoneCombobox({
 	);
 }
 
-function ComputeStatusLine({
-	compute,
-	freeSlotPending,
-	freeSlotUsed,
-	deploymentsError,
-	freePlan,
-	perfOffer,
-}: {
+interface ComputeStatusInput {
 	compute: Compute;
 	freeSlotPending: boolean;
 	freeSlotUsed: boolean;
 	deploymentsError: unknown;
 	freePlan: Plan | undefined;
 	perfOffer: BillingOffer | null;
-}) {
-	const status = computeStatusLine({
-		compute,
-		freeSlotPending,
-		freeSlotUsed,
-		deploymentsError,
-		freePlan,
-		perfOffer,
-	});
+}
+
+function ComputeStatusLine(input: ComputeStatusInput) {
+	const status = computeStatusLine(input);
 	if (!status) return null;
 	return (
 		<p
@@ -323,14 +311,7 @@ function computeStatusLine({
 	deploymentsError,
 	freePlan,
 	perfOffer,
-}: {
-	compute: Compute;
-	freeSlotPending: boolean;
-	freeSlotUsed: boolean;
-	deploymentsError: unknown;
-	freePlan: Plan | undefined;
-	perfOffer: BillingOffer | null;
-}): { message: string; tone: "destructive" | "muted" } | null {
+}: ComputeStatusInput): { message: string; tone: "destructive" | "muted" } | null {
 	if (compute === "free") {
 		if (deploymentsError) {
 			return {

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -1,7 +1,17 @@
 "use client";
 
+import { isFirstPartyManagedAiProvider } from "@clawdi/shared";
 import { useRouter } from "@tanstack/react-router";
-import { CalendarClock, Cpu, Plus, Rocket, Sparkles, Zap } from "lucide-react";
+import {
+	CalendarClock,
+	Check,
+	ChevronsUpDown,
+	Cpu,
+	Plus,
+	Rocket,
+	Sparkles,
+	Zap,
+} from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { EntityChoiceCard } from "@/components/entity-card";
@@ -11,7 +21,16 @@ import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command";
 import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
 	Select,
 	SelectContent,
@@ -23,7 +42,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { BillingError } from "@/hosted/billing/components/state-views";
 import { TermSwitcher } from "@/hosted/billing/components/term-switcher";
-import type { DeployRequest, Plan } from "@/hosted/billing/contracts";
+import type { BillingOffer, DeployRequest, Plan } from "@/hosted/billing/contracts";
 import { usesActiveFreeComputeSlot } from "@/hosted/billing/deploy/deploy-model";
 import { buildHostedDeployRequest } from "@/hosted/billing/deploy/deploy-request";
 import { normalizeBillingError } from "@/hosted/billing/errors";
@@ -45,6 +64,9 @@ import {
 	type RuntimeAiProviderAuthKind,
 } from "@/hosted/v2/ai-providers/runtime-bootstrap";
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
+import { providerMeta } from "@/hosted/v2/channels/channel-providers";
+import type { ChannelAccount } from "@/hosted/v2/channels/channel-types";
+import { useChannels } from "@/hosted/v2/channels/channels-hooks";
 import { ConnectBotDialog } from "@/hosted/v2/channels/connect-bot-dialog";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { cn } from "@/lib/utils";
@@ -52,7 +74,9 @@ import { cn } from "@/lib/utils";
 type Compute = "free" | "performance";
 type Engine = "openclaw" | "hermes";
 type ComputePlanSlug = DeployRequest["compute_plan_slug"];
-const DEPLOY_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.form, "flex flex-col gap-6 px-4 lg:px-6");
+const DEPLOY_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.detail, "flex flex-col gap-6 px-4 lg:px-6");
+const THREE_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2 lg:grid-cols-3";
+const TWO_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2";
 
 /** Personality presets accepted by hosted deployment onboarding. */
 const PERSONALITY_PRESETS = [
@@ -148,11 +172,217 @@ function IconChip({ tint, children }: { tint: string; children: React.ReactNode 
 	);
 }
 
+function AddTile({
+	title,
+	description,
+	onClick,
+}: {
+	title: string;
+	description: string;
+	onClick: () => void;
+}) {
+	return (
+		<EntityChoiceCard
+			selected={false}
+			onClick={onClick}
+			icon={
+				<IconChip tint="bg-muted text-muted-foreground">
+					<Plus />
+				</IconChip>
+			}
+			title={title}
+			description={description}
+			className="h-full border-dashed bg-card"
+		/>
+	);
+}
+
+function ChannelInfoTile({ channel }: { channel: ChannelAccount }) {
+	const meta = providerMeta(channel.provider);
+	return (
+		<EntityChoiceCard
+			selected={false}
+			icon={<EntityIcon kind="channel" id={channel.provider} label={meta.label} />}
+			title={channel.name}
+			description={`${meta.label} is ready. Link it from the agent page after deploy.`}
+			badge={
+				<Badge variant="outline" className="capitalize">
+					{channel.status}
+				</Badge>
+			}
+			className="h-full bg-card"
+		/>
+	);
+}
+
+function timezoneLabel(timezone: string): string {
+	return timezone.replaceAll("_", " ");
+}
+
+function TimezoneCombobox({
+	value,
+	onValueChange,
+	options,
+}: {
+	value: string;
+	onValueChange: (value: string) => void;
+	options: string[];
+}) {
+	const [open, setOpen] = useState(false);
+	return (
+		<Popover open={open} onOpenChange={setOpen}>
+			<PopoverTrigger asChild>
+				<Button
+					id="agent-timezone"
+					type="button"
+					variant="outline"
+					role="combobox"
+					aria-expanded={open}
+					className="w-full justify-between"
+				>
+					<span className={cn("truncate", !value && "text-muted-foreground")}>
+						{value ? timezoneLabel(value) : "Select a timezone"}
+					</span>
+					<ChevronsUpDown className="opacity-50" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-0">
+				<Command>
+					<CommandInput placeholder="Search timezones…" />
+					<CommandList className="max-h-72">
+						<CommandEmpty>No timezone found.</CommandEmpty>
+						<CommandGroup>
+							{options.map((tz) => {
+								const selected = value === tz;
+								return (
+									<CommandItem
+										key={tz}
+										value={tz}
+										keywords={[timezoneLabel(tz), tz.replaceAll("/", " ")]}
+										onSelect={() => {
+											onValueChange(tz);
+											setOpen(false);
+										}}
+									>
+										<Check className={cn("size-4", selected ? "opacity-100" : "opacity-0")} />
+										<span className="truncate">{timezoneLabel(tz)}</span>
+										{timezoneLabel(tz) !== tz ? (
+											<span className="ml-auto truncate text-xs text-muted-foreground">{tz}</span>
+										) : null}
+									</CommandItem>
+								);
+							})}
+						</CommandGroup>
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
+	);
+}
+
+function ComputeStatusLine({
+	compute,
+	freeSlotPending,
+	freeSlotUsed,
+	deploymentsError,
+	freePlan,
+	perfOffer,
+}: {
+	compute: Compute;
+	freeSlotPending: boolean;
+	freeSlotUsed: boolean;
+	deploymentsError: unknown;
+	freePlan: Plan | undefined;
+	perfOffer: BillingOffer | null;
+}) {
+	const status = computeStatusLine({
+		compute,
+		freeSlotPending,
+		freeSlotUsed,
+		deploymentsError,
+		freePlan,
+		perfOffer,
+	});
+	if (!status) return null;
+	return (
+		<p
+			className={cn(
+				"text-xs",
+				status.tone === "destructive" ? "text-destructive" : "text-muted-foreground",
+			)}
+		>
+			{status.message}
+		</p>
+	);
+}
+
+function computeStatusLine({
+	compute,
+	freeSlotPending,
+	freeSlotUsed,
+	deploymentsError,
+	freePlan,
+	perfOffer,
+}: {
+	compute: Compute;
+	freeSlotPending: boolean;
+	freeSlotUsed: boolean;
+	deploymentsError: unknown;
+	freePlan: Plan | undefined;
+	perfOffer: BillingOffer | null;
+}): { message: string; tone: "destructive" | "muted" } | null {
+	if (compute === "free") {
+		if (deploymentsError) {
+			return {
+				tone: "destructive",
+				message: "Couldn’t verify your Free slot. Retry this page before deploying Free.",
+			};
+		}
+		if (!freePlan) {
+			return {
+				tone: "destructive",
+				message:
+					"Free compute isn’t available from the billing service. Retry plans before deploying.",
+			};
+		}
+		if (freeSlotUsed) {
+			return {
+				tone: "muted",
+				message:
+					"You already have an active Free agent. Stop or delete it to reuse Free, or deploy a Performance agent.",
+			};
+		}
+		if (freeSlotPending) {
+			return {
+				tone: "muted",
+				message: "Checking whether your Free slot is available before deployment.",
+			};
+		}
+		return null;
+	}
+
+	if (perfOffer && perfOffer.billing_term_months !== 1) {
+		return {
+			tone: "muted",
+			message: `You’ll be sent to checkout. Billed ${formatCentsCompact(
+				perfOffer.price_cents,
+			)}${billingTermSuffix(
+				perfOffer.billing_term_months,
+			)}; each Performance agent uses its own subscription.`,
+		};
+	}
+	return {
+		tone: "muted",
+		message: "You’ll be sent to checkout. Each Performance agent uses its own subscription.",
+	};
+}
+
 export function DeployWizard() {
 	const router = useRouter();
 	const plans = usePlans();
 	const deployments = useHostedDeployments();
 	const aiProviders = useAiProviders();
+	const channels = useChannels();
 	const createDeployment = useCreateDeployment();
 	const checkout = useCheckout();
 	const runAction = useActionLock();
@@ -190,7 +420,14 @@ export function DeployWizard() {
 
 	const dualAllowed = compute === "performance";
 	const enginesSelected = (Object.keys(engines) as Engine[]).filter((e) => engines[e]);
-	const providerList = aiProviders.data?.providers ?? [];
+	const providerList = useMemo(
+		() =>
+			(aiProviders.data?.providers ?? []).filter(
+				(provider) => !isFirstPartyManagedAiProvider(provider),
+			),
+		[aiProviders.data?.providers],
+	);
+	const channelList = channels.data ?? [];
 	const computePlanReady =
 		compute === "performance" ? !!perfPlan : !!freePlan && !freeSlotUnavailable;
 	const planReady = !plans.isLoading && computePlanReady;
@@ -356,7 +593,7 @@ export function DeployWizard() {
 
 	if (plans.error) {
 		return (
-			<div data-hosted="true" className={DEPLOY_PAGE_CLASS}>
+			<div data-hosted="true" data-v2="true" className={DEPLOY_PAGE_CLASS}>
 				<PageHeader title="Deploy an agent" />
 				<BillingError error={plans.error} onRetry={() => plans.refetch()} />
 			</div>
@@ -365,7 +602,7 @@ export function DeployWizard() {
 
 	if (plans.isLoading) {
 		return (
-			<div data-hosted="true" className={DEPLOY_PAGE_CLASS}>
+			<div data-hosted="true" data-v2="true" className={DEPLOY_PAGE_CLASS}>
 				<PageHeader title="Deploy an agent" description="Preparing your compute options…" />
 				<Skeleton className="h-32 w-full rounded-lg" />
 				<Skeleton className="h-32 w-full rounded-lg" />
@@ -375,7 +612,7 @@ export function DeployWizard() {
 	}
 
 	return (
-		<div data-hosted="true" className={DEPLOY_PAGE_CLASS}>
+		<div data-hosted="true" data-v2="true" className={DEPLOY_PAGE_CLASS}>
 			<PageHeader
 				title="Deploy an agent"
 				description="Codex is included by default. Add optional runtimes and choose the AI provider for this hosted deployment."
@@ -391,7 +628,7 @@ export function DeployWizard() {
 							: "Codex stays on. Free can add one optional runtime."}
 					</CardDescription>
 				</CardHeader>
-				<CardContent className="grid gap-2 lg:grid-cols-3">
+				<CardContent className={THREE_TILE_GRID_CLASS}>
 					<Tile
 						selected
 						leading={<EntityIcon kind="framework" id="codex" label="Codex" />}
@@ -424,7 +661,7 @@ export function DeployWizard() {
 						Managed AI bills your wallet, or route through one of your own providers.
 					</CardDescription>
 				</CardHeader>
-				<CardContent className="grid gap-2 sm:grid-cols-2">
+				<CardContent className={TWO_TILE_GRID_CLASS}>
 					<Tile
 						selected={aiChoice === "managed"}
 						onClick={() => setAiChoice("managed")}
@@ -438,12 +675,12 @@ export function DeployWizard() {
 						badge={<Badge variant="secondary">Default</Badge>}
 					/>
 					{aiProviders.isLoading ? (
-						<Skeleton className="h-[60px] w-full rounded-lg" />
+						<Skeleton className="h-[74px] w-full rounded-lg" />
 					) : aiProviders.error ? (
 						<button
 							type="button"
 							onClick={() => aiProviders.refetch()}
-							className="rounded-lg border border-dashed px-3 py-2 text-left text-xs text-muted-foreground transition-colors hover:bg-accent/40 sm:col-span-2"
+							className="min-h-[74px] rounded-lg border border-dashed px-3 py-2 text-left text-xs text-muted-foreground transition-colors hover:bg-accent/40 sm:col-span-2"
 						>
 							Couldn’t load your providers — tap to retry. Managed AI still works.
 						</button>
@@ -459,15 +696,11 @@ export function DeployWizard() {
 							badge={<AuthBadge auth={provider.auth} />}
 						/>
 					))}
-					<Button
-						variant="ghost"
-						size="sm"
-						className="justify-start text-muted-foreground"
+					<AddTile
+						title="Add a provider"
+						description="Connect OpenAI, Anthropic, or another endpoint."
 						onClick={() => setAddProviderOpen(true)}
-					>
-						<Plus className="size-3.5" />
-						Add a provider
-					</Button>
+					/>
 				</CardContent>
 			</Card>
 
@@ -481,7 +714,7 @@ export function DeployWizard() {
 						Prepare a bot now, then link it from the agent page once deployment finishes.
 					</CardDescription>
 				</CardHeader>
-				<CardContent className="grid gap-2 sm:grid-cols-2">
+				<CardContent className={TWO_TILE_GRID_CLASS}>
 					<Tile
 						selected
 						leading={
@@ -493,15 +726,15 @@ export function DeployWizard() {
 						subtitle="Channel links need the agent identity created during provisioning."
 						badge={<Badge variant="secondary">Default</Badge>}
 					/>
-					<Button
-						variant="ghost"
-						size="sm"
-						className="justify-start text-muted-foreground"
+					{channels.isLoading ? <Skeleton className="h-[74px] w-full rounded-lg" /> : null}
+					{channels.error
+						? null
+						: channelList.map((channel) => <ChannelInfoTile key={channel.id} channel={channel} />)}
+					<AddTile
+						title="Connect a channel"
+						description="Prepare a bot; link it after provisioning."
 						onClick={() => setConnectChannelOpen(true)}
-					>
-						<Plus className="size-3.5" />
-						Connect a channel
-					</Button>
+					/>
 				</CardContent>
 			</Card>
 
@@ -514,7 +747,7 @@ export function DeployWizard() {
 						run both optional runtimes.
 					</CardDescription>
 				</CardHeader>
-				<CardContent className="space-y-3">
+				<CardContent className="flex flex-col gap-3">
 					<div className="grid gap-2 sm:grid-cols-2">
 						<Tile
 							selected={compute === "free"}
@@ -565,43 +798,19 @@ export function DeployWizard() {
 							disabled={!perfPlan}
 						/>
 					</div>
-					{compute === "free" && freeSlotPending ? (
-						<p className="text-xs text-muted-foreground">
-							Checking whether your Free slot is available before deployment.
-						</p>
-					) : null}
-					{compute === "free" && freeSlotUsed ? (
-						<p className="text-xs text-muted-foreground">
-							You already have an active Free agent. Stop or delete it to reuse Free, or deploy a
-							Performance agent.
-						</p>
-					) : null}
-					{compute === "free" && deployments.error ? (
-						<p className="text-xs text-destructive">
-							Couldn’t verify your Free slot. Retry this page before deploying Free.
-						</p>
-					) : null}
-					{compute === "free" && !freePlan ? (
-						<p className="text-xs text-destructive">
-							Free compute isn’t available from the billing service. Retry plans before deploying.
-						</p>
-					) : null}
 					{compute === "performance" && perfOffers.length > 1 ? (
-						<div className="space-y-2">
+						<div className="flex flex-col gap-2">
 							<TermSwitcher offers={perfOffers} value={term} onChange={setTerm} />
-							{perfOffer && perfOffer.billing_term_months !== 1 ? (
-								<p className="text-xs text-muted-foreground">
-									Billed {formatCentsCompact(perfOffer.price_cents)}
-									{billingTermSuffix(perfOffer.billing_term_months)}.
-								</p>
-							) : null}
 						</div>
 					) : null}
-					{compute === "performance" ? (
-						<p className="text-xs text-muted-foreground">
-							You’ll be sent to checkout. Each Performance agent uses its own subscription.
-						</p>
-					) : null}
+					<ComputeStatusLine
+						compute={compute}
+						freeSlotPending={freeSlotPending}
+						freeSlotUsed={freeSlotUsed}
+						deploymentsError={deployments.error}
+						freePlan={freePlan}
+						perfOffer={perfOffer}
+					/>
 				</CardContent>
 			</Card>
 
@@ -613,8 +822,8 @@ export function DeployWizard() {
 					</CardTitle>
 					<CardDescription>Give your agent a name, tone, language, and timezone.</CardDescription>
 				</CardHeader>
-				<CardContent className="space-y-4">
-					<div className="space-y-1.5">
+				<CardContent className="flex flex-col gap-4">
+					<div className="flex flex-col gap-1.5">
 						<label htmlFor="agent-name" className="text-sm text-muted-foreground">
 							Name
 						</label>
@@ -627,7 +836,7 @@ export function DeployWizard() {
 						/>
 					</div>
 					<div className="grid gap-4 sm:grid-cols-2">
-						<div className="space-y-1.5">
+						<div className="flex flex-col gap-1.5">
 							<label htmlFor="agent-personality" className="text-sm text-muted-foreground">
 								Personality
 							</label>
@@ -648,7 +857,7 @@ export function DeployWizard() {
 								</SelectContent>
 							</Select>
 						</div>
-						<div className="space-y-1.5">
+						<div className="flex flex-col gap-1.5">
 							<label htmlFor="agent-language" className="text-sm text-muted-foreground">
 								Language
 							</label>
@@ -671,22 +880,11 @@ export function DeployWizard() {
 						</div>
 					</div>
 					{tzOptions.length > 0 ? (
-						<div className="space-y-1.5">
+						<div className="flex flex-col gap-1.5">
 							<label htmlFor="agent-timezone" className="text-sm text-muted-foreground">
 								Timezone
 							</label>
-							<Select value={timezone} onValueChange={setTimezone}>
-								<SelectTrigger id="agent-timezone">
-									<SelectValue placeholder="Select a timezone" />
-								</SelectTrigger>
-								<SelectContent className="max-h-72">
-									{tzOptions.map((tz) => (
-										<SelectItem key={tz} value={tz}>
-											{tz}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
+							<TimezoneCombobox value={timezone} onValueChange={setTimezone} options={tzOptions} />
 						</div>
 					) : null}
 				</CardContent>

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -3,6 +3,8 @@
 import { CircleAlert, ExternalLink } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { EntityChoiceCard } from "@/components/entity-card";
+import { EntityIcon } from "@/components/entity-icon";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -77,6 +79,15 @@ function isLoopbackOrPrivateUrl(raw: string): boolean {
 	if (/^10\./.test(host) || /^192\.168\./.test(host)) return true;
 	if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
 	return false;
+}
+
+function providerTypeDescription(type: ProviderTypeId): string {
+	if (type === "openai") return "OpenAI APIs";
+	if (type === "anthropic") return "Claude models";
+	if (type === "openrouter") return "Router models";
+	if (type === "gemini") return "Google models";
+	if (type === "mistral") return "Mistral APIs";
+	return "Custom endpoint";
 }
 
 export function AddProviderDialog({
@@ -500,7 +511,7 @@ export function AddProviderDialog({
 								returns.
 							</DialogDescription>
 						</DialogHeader>
-						<div className="space-y-3">
+						<div className="flex flex-col gap-3">
 							<Button
 								variant="outline"
 								className="w-full"
@@ -547,7 +558,7 @@ export function AddProviderDialog({
 								<summary className="cursor-pointer font-medium text-foreground">
 									Didn’t return automatically?
 								</summary>
-								<div className="mt-2 space-y-2">
+								<div className="mt-2 flex flex-col gap-2">
 									<p>Paste the full address from the OpenAI page after signing in.</p>
 									<Input
 										value={oauthCode}
@@ -585,25 +596,25 @@ export function AddProviderDialog({
 							</DialogDescription>
 						</DialogHeader>
 
-						<div className="space-y-4">
-							<div className="space-y-1.5">
-								<Label htmlFor="provider-type">Provider</Label>
-								<Select
-									value={type}
-									onValueChange={(v) => changeType(v as ProviderTypeId)}
-									disabled={isEdit}
-								>
-									<SelectTrigger id="provider-type">
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										{PROVIDER_TYPES.map((t) => (
-											<SelectItem key={t} value={t}>
-												{providerTypeMeta(t).label}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
+						<div className="flex flex-col gap-4">
+							<div className="flex flex-col gap-1.5">
+								<Label>Provider</Label>
+								<div className="grid grid-cols-2 gap-2">
+									{PROVIDER_TYPES.map((t) => {
+										const option = providerTypeMeta(t);
+										return (
+											<EntityChoiceCard
+												key={t}
+												selected={type === t}
+												onClick={isEdit ? undefined : () => changeType(t)}
+												disabled={isEdit}
+												icon={<EntityIcon kind="provider" id={t} label={option.label} size="sm" />}
+												title={option.label}
+												description={providerTypeDescription(t)}
+											/>
+										);
+									})}
+								</div>
 							</div>
 
 							<div className="flex items-center gap-3 rounded-lg border bg-muted/30 p-3">
@@ -613,7 +624,7 @@ export function AddProviderDialog({
 								</div>
 							</div>
 
-							<div className="space-y-1.5">
+							<div className="flex flex-col gap-1.5">
 								<Label htmlFor="provider-label">Name</Label>
 								<Input
 									id="provider-label"
@@ -625,7 +636,7 @@ export function AddProviderDialog({
 							</div>
 
 							{/* Auth method */}
-							<div className="space-y-1.5">
+							<div className="flex flex-col gap-1.5">
 								<Label htmlFor="provider-auth">Authentication</Label>
 								<Select value={authMethod} onValueChange={(v) => setAuthMethod(v as AuthMethod)}>
 									<SelectTrigger id="provider-auth">
@@ -644,7 +655,7 @@ export function AddProviderDialog({
 
 							{authMethod === "api_key" || authMethod === "vault" ? (
 								<>
-									<div className="space-y-1.5">
+									<div className="flex flex-col gap-1.5">
 										<Label htmlFor="provider-key">
 											API key{canKeepManagedApiKey ? " (leave blank to keep)" : ""}
 										</Label>
@@ -668,7 +679,7 @@ export function AddProviderDialog({
 											</p>
 										) : null}
 									</div>
-									<div className="space-y-1.5">
+									<div className="flex flex-col gap-1.5">
 										<Label htmlFor="provider-env">Runtime env var</Label>
 										<Input
 											id="provider-env"
@@ -682,7 +693,7 @@ export function AddProviderDialog({
 								</>
 							) : null}
 
-							<div className="space-y-1.5">
+							<div className="flex flex-col gap-1.5">
 								<Label htmlFor="provider-base">Base URL</Label>
 								<Input
 									id="provider-base"
@@ -701,7 +712,7 @@ export function AddProviderDialog({
 							</div>
 
 							<div className="grid gap-3 sm:grid-cols-2">
-								<div className="space-y-1.5">
+								<div className="flex flex-col gap-1.5">
 									<Label htmlFor="provider-model">Default model</Label>
 									<Input
 										id="provider-model"
@@ -712,7 +723,7 @@ export function AddProviderDialog({
 										spellCheck={false}
 									/>
 								</div>
-								<div className="space-y-1.5">
+								<div className="flex flex-col gap-1.5">
 									<Label htmlFor="provider-mode">API mode</Label>
 									<Select value={apiMode} onValueChange={(v) => setApiMode(v as ApiMode)}>
 										<SelectTrigger id="provider-mode">

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { isFirstPartyManagedAiProvider } from "@clawdi/shared";
 import { BadgeCheck, Pencil, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -7,6 +8,8 @@ import { EmptyState } from "@/components/empty-state";
 import { ENTITY_CARD_BASE, EntityHeader } from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
 import { PageHeader } from "@/components/page-header";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
+import { SectionLabel } from "@/components/section-label";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -28,16 +31,20 @@ import { formatModelLabel } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Choose how your agents reach a model.";
+const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.wide, "flex flex-col gap-6 px-4 lg:px-6");
+const PROVIDER_GRID_CLASS = "grid gap-2 sm:grid-cols-2 xl:grid-cols-3";
 
 export function AiProvidersPage() {
 	const providers = useAiProviders();
 	const [addOpen, setAddOpen] = useState(false);
 	const [editing, setEditing] = useState<AiProvider | null>(null);
 
-	const list = providers.data?.providers ?? [];
+	const list = (providers.data?.providers ?? []).filter(
+		(provider) => !isFirstPartyManagedAiProvider(provider),
+	);
 
 	return (
-		<div data-hosted="true" data-v2="true" className="space-y-6 px-4 lg:px-6">
+		<div data-hosted="true" data-v2="true" className={PAGE_CLASS}>
 			<PageHeader
 				title="Model Providers"
 				description={DESCRIPTION}
@@ -56,10 +63,8 @@ export function AiProvidersPage() {
 
 			<ManagedProviderCard />
 
-			<div className="space-y-2">
-				<div className="px-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-					Your providers
-				</div>
+			<div className="flex flex-col gap-2">
+				<SectionLabel>Your providers</SectionLabel>
 				{providers.error ? (
 					<ChannelError
 						error={providers.error}
@@ -67,9 +72,9 @@ export function AiProvidersPage() {
 						title="Couldn’t load providers"
 					/>
 				) : providers.isLoading ? (
-					<div className="space-y-2">
-						{[0, 1].map((i) => (
-							<Skeleton key={i} className="h-24 w-full rounded-lg" />
+					<div className={PROVIDER_GRID_CLASS}>
+						{[0, 1, 2].map((i) => (
+							<ProviderCardSkeleton key={i} />
 						))}
 					</div>
 				) : list.length === 0 ? (
@@ -77,9 +82,10 @@ export function AiProvidersPage() {
 						title="No custom providers"
 						description="Add your own OpenAI, Anthropic, OpenRouter, Gemini, Mistral, or a custom OpenAI-compatible endpoint."
 						fillHeight={false}
+						bordered
 					/>
 				) : (
-					<div className="space-y-2">
+					<div className={PROVIDER_GRID_CLASS}>
 						{list.map((provider) => (
 							<ProviderCard
 								key={provider.provider_id}
@@ -114,7 +120,7 @@ function ProviderCard({ provider, onEdit }: { provider: AiProvider; onEdit: () =
 	}
 
 	return (
-		<div className={cn(ENTITY_CARD_BASE, "bg-card")}>
+		<div className={cn(ENTITY_CARD_BASE, "flex h-full flex-col bg-card")}>
 			<EntityHeader
 				align="start"
 				icon={
@@ -138,13 +144,13 @@ function ProviderCard({ provider, onEdit }: { provider: AiProvider; onEdit: () =
 					</span>,
 				]}
 			/>
-			<div className="mt-3 flex flex-wrap justify-end gap-2">
+			<div className="mt-auto flex flex-wrap items-center gap-2 pt-3">
 				<Button variant="ghost" size="sm" onClick={runValidate} disabled={validate.isPending}>
-					<BadgeCheck className="size-3.5" />
+					<BadgeCheck />
 					Validate
 				</Button>
 				<Button variant="outline" size="sm" onClick={onEdit}>
-					<Pencil className="size-3.5" />
+					<Pencil />
 					Edit
 				</Button>
 				<ConfirmAction
@@ -160,14 +166,34 @@ function ProviderCard({ provider, onEdit }: { provider: AiProvider; onEdit: () =
 				>
 					<Button
 						variant="ghost"
-						size="sm"
-						className="text-muted-foreground hover:text-destructive"
+						size="icon-sm"
+						className="ml-auto text-muted-foreground hover:text-destructive"
 						disabled={del.isPending}
+						aria-label={`Remove ${provider.label ?? provider.provider_id}`}
 					>
-						<Trash2 className="size-3.5" />
-						Remove
+						<Trash2 />
 					</Button>
 				</ConfirmAction>
+			</div>
+		</div>
+	);
+}
+
+function ProviderCardSkeleton() {
+	return (
+		<div className={cn(ENTITY_CARD_BASE, "bg-card")}>
+			<div className="flex items-start gap-3">
+				<Skeleton className="size-10 shrink-0 rounded-lg" />
+				<div className="min-w-0 flex-1">
+					<Skeleton className="h-4 w-28" />
+					<Skeleton className="mt-2 h-3 w-40" />
+					<Skeleton className="mt-1.5 h-3 w-full max-w-56" />
+				</div>
+			</div>
+			<div className="mt-3 flex items-center gap-2">
+				<Skeleton className="h-8 w-20 rounded-md" />
+				<Skeleton className="h-8 w-14 rounded-md" />
+				<Skeleton className="ml-auto size-8 rounded-md" />
 			</div>
 		</div>
 	);

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
@@ -5,7 +5,7 @@ import { BadgeCheck, Pencil, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { EmptyState } from "@/components/empty-state";
-import { ENTITY_CARD_BASE, EntityHeader } from "@/components/entity-card";
+import { ENTITY_CARD_BASE, ENTITY_GRID_CLASS, EntityHeader } from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
@@ -32,7 +32,7 @@ import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Choose how your agents reach a model.";
 const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.wide, "flex flex-col gap-6 px-4 lg:px-6");
-const PROVIDER_GRID_CLASS = "grid gap-2 sm:grid-cols-2 xl:grid-cols-3";
+const PROVIDER_GRID_CLASS = ENTITY_GRID_CLASS;
 
 export function AiProvidersPage() {
 	const providers = useAiProviders();

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { ShieldCheck, Sparkles } from "lucide-react";
+import { ENTITY_CARD_BASE, EntityHeader } from "@/components/entity-card";
 import { EntityIcon, type EntityIconSize } from "@/components/entity-icon";
 import { providerTypeMeta } from "@/hosted/v2/ai-providers/provider-types";
 import type { AiProviderAuth } from "@/hosted/v2/ai-providers/types";
+import { cn } from "@/lib/utils";
 
 /** Real brand-logo icon for a provider type (delegates to the unified EntityIcon). */
 export function ProviderTypeChip({
@@ -47,25 +49,23 @@ export function AuthBadge({ auth }: { auth: AiProviderAuth }) {
 /** The always-on managed default, no setup. */
 export function ManagedProviderCard() {
 	return (
-		<div data-hosted="true" data-v2="true" className="rounded-lg border bg-card p-4">
-			<div className="flex items-start gap-3">
-				<span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
-					<Sparkles className="size-5" />
-				</span>
-				<div className="min-w-0 flex-1 space-y-1">
-					<div className="flex flex-wrap items-center gap-2">
-						<span className="text-sm font-medium">Managed by Clawdi</span>
-						<span className="inline-flex items-center gap-1 rounded-full bg-success-muted px-2 py-0.5 text-xs font-medium text-success-muted-foreground">
-							<ShieldCheck className="size-3" />
-							Default
-						</span>
-					</div>
-					<p className="text-sm text-muted-foreground">
-						Managed agents use Clawdi-managed models out of the box — no API key, no setup. Usage
-						draws from your wallet balance.
-					</p>
-				</div>
-			</div>
+		<div data-hosted="true" data-v2="true" className={cn(ENTITY_CARD_BASE, "bg-card")}>
+			<EntityHeader
+				align="start"
+				icon={
+					<span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+						<Sparkles className="size-5" />
+					</span>
+				}
+				title="Managed by Clawdi"
+				titleAdornment={
+					<span className="inline-flex items-center gap-1 rounded-full bg-success-muted px-2 py-0.5 text-xs font-medium text-success-muted-foreground">
+						<ShieldCheck className="size-3" />
+						Default
+					</span>
+				}
+				meta={["No setup required", "Wallet billed"]}
+			/>
 		</div>
 	);
 }

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -346,8 +346,9 @@ function AgentsTab({ accountId, accountName }: { accountId: string; accountName:
 							<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
 								<div className="min-w-0">
 									<AgentName env={findEnv(envs.data, link.agent_id)} fallback={link.agent_id} />
-									<div className="text-xs capitalize text-muted-foreground">
-										{link.status} · linked {relativeTime(link.created_at)}
+									<div className="text-xs text-muted-foreground">
+										<span className="capitalize">{link.status}</span> · linked{" "}
+										{relativeTime(link.created_at)}
 									</div>
 								</div>
 								<div className="flex shrink-0 flex-wrap items-center gap-1.5">

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -15,7 +15,7 @@ import {
 	Trash2,
 	TriangleAlert,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import {
 	AgentLabel,
@@ -23,8 +23,12 @@ import {
 	agentTextLabel,
 } from "@/components/dashboard/agent-label";
 import { EmptyState } from "@/components/empty-state";
+import { ENTITY_CARD_BASE, EntityHeader } from "@/components/entity-card";
+import { EntityIcon } from "@/components/entity-icon";
 import { InfoCard } from "@/components/info-card";
 import { PageHeader } from "@/components/page-header";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
+import { SectionLabel } from "@/components/section-label";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Label } from "@/components/ui/label";
@@ -49,7 +53,6 @@ import {
 	CopyInline,
 	DeliveryBadge,
 	HealthBadge,
-	ProviderChip,
 	TokenReveal,
 } from "@/hosted/v2/channels/channel-ui";
 import {
@@ -74,20 +77,11 @@ import {
 	agentOwnershipKindFromId,
 	useAgentOwnership,
 } from "@/lib/agent-ownership";
+import { cn, relativeTime } from "@/lib/utils";
 
-function formatWhen(iso: string | null | undefined): string {
-	if (!iso) return "—";
-	const delta = new Date(iso).getTime() - Date.now(); // positive = future
-	const future = delta > 0;
-	const phrase = (value: number, unit: string) =>
-		future ? `in ${value}${unit}` : `${value}${unit} ago`;
-	const min = Math.round(Math.abs(delta) / 60000);
-	if (min < 1) return "just now";
-	if (min < 60) return phrase(min, "m");
-	const hr = Math.round(min / 60);
-	if (hr < 24) return phrase(hr, "h");
-	return new Date(iso).toLocaleDateString();
-}
+const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.detail, "flex flex-col gap-6 px-4 lg:px-6");
+const LIST_TAB_CLASS = "mt-4 min-w-0";
+const FORM_TAB_CLASS = "mt-4 min-w-0 max-w-xl";
 
 type EnvironmentList = ReturnType<typeof useEnvironments>["data"];
 type Environment = NonNullable<EnvironmentList>[number];
@@ -132,6 +126,31 @@ function AgentName({ env, fallback }: { env: Environment | null; fallback: strin
 	);
 }
 
+function DetailIcon({ children }: { children: ReactNode }) {
+	return (
+		<span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground [&_svg]:size-4">
+			{children}
+		</span>
+	);
+}
+
+function SectionHeader({
+	label,
+	count,
+	action,
+}: {
+	label: string;
+	count?: number;
+	action?: ReactNode;
+}) {
+	return (
+		<div className="flex flex-wrap items-center justify-between gap-2">
+			<SectionLabel count={count}>{label}</SectionLabel>
+			{action ? <div className="shrink-0">{action}</div> : null}
+		</div>
+	);
+}
+
 export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 	const channel = useChannel(id);
 	const health = useChannelHealth();
@@ -147,16 +166,26 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 
 	if (channel.isLoading) {
 		return (
-			<div data-hosted="true" data-v2="true" className="space-y-6 px-4 lg:px-6">
-				<Skeleton className="h-12 w-64" />
-				<Skeleton className="h-64 w-full rounded-lg" />
+			<div data-hosted="true" data-v2="true" className={PAGE_CLASS}>
+				<div className="flex items-center gap-3">
+					<Skeleton className="size-12 shrink-0 rounded-xl" />
+					<div className="min-w-0 flex-1">
+						<Skeleton className="h-6 w-52 max-w-full" />
+						<Skeleton className="mt-2 h-4 w-40 max-w-full" />
+						<Skeleton className="mt-2 h-5 w-32 max-w-full rounded-full" />
+					</div>
+				</div>
+				<div className="flex flex-col gap-4">
+					<Skeleton className="h-9 w-full max-w-xl rounded-lg" />
+					<Skeleton className="h-64 w-full rounded-lg" />
+				</div>
 			</div>
 		);
 	}
 
 	if (channel.error) {
 		return (
-			<div data-hosted="true" data-v2="true" className="px-4 lg:px-6">
+			<div data-hosted="true" data-v2="true" className={PAGE_CLASS}>
 				<ChannelError
 					error={channel.error}
 					onRetry={() => channel.refetch()}
@@ -168,7 +197,7 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 
 	if (!channel.data) {
 		return (
-			<div data-hosted="true" data-v2="true" className="px-4 lg:px-6">
+			<div data-hosted="true" data-v2="true" className={PAGE_CLASS}>
 				<EmptyState
 					icon={MessageSquareDashed}
 					title="Channel not found"
@@ -187,10 +216,17 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 	const meta = providerMeta(ch.provider);
 
 	return (
-		<div data-hosted="true" data-v2="true" className="space-y-6 px-4 lg:px-6">
+		<div data-hosted="true" data-v2="true" className={PAGE_CLASS}>
 			<PageHeader
 				title={ch.name}
 				description={`${meta.label} · ${ch.visibility === "public" ? "Shared bot" : "Private bot"}`}
+				adornment={<EntityIcon kind="channel" id={ch.provider} label={meta.label} size="lg" />}
+				status={
+					<div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+						<span className="capitalize">{ch.status}</span>
+						{healthItem ? <HealthBadge status={healthItem.health_status} /> : null}
+					</div>
+				}
 				actions={
 					<ConfirmAction
 						title={`Remove ${ch.name}?`}
@@ -213,16 +249,8 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 				}
 			/>
 
-			<div className="flex items-center gap-3">
-				<ProviderChip provider={ch.provider} />
-				<div className="flex items-center gap-2 text-sm text-muted-foreground">
-					<span className="capitalize">{ch.status}</span>
-					{healthItem ? <HealthBadge status={healthItem.health_status} /> : null}
-				</div>
-			</div>
-
-			<Tabs defaultValue="agents">
-				<TabsList className="flex-wrap">
+			<Tabs defaultValue="agents" className="min-w-0">
+				<TabsList className="h-auto flex-wrap justify-start">
 					<TabsTrigger value="agents">Agents</TabsTrigger>
 					{ch.provider === "whatsapp" ? (
 						<TabsTrigger value="devices">Linked devices</TabsTrigger>
@@ -234,27 +262,27 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 					<TabsTrigger value="commands">Commands</TabsTrigger>
 				</TabsList>
 
-				<TabsContent value="agents" className="mt-4">
+				<TabsContent value="agents" className={LIST_TAB_CLASS}>
 					<AgentsTab accountId={id} accountName={ch.name} />
 				</TabsContent>
 				{ch.provider === "whatsapp" ? (
-					<TabsContent value="devices" className="mt-4">
+					<TabsContent value="devices" className={FORM_TAB_CLASS}>
 						<WhatsAppDevicesTab accountId={id} />
 					</TabsContent>
 				) : null}
-				<TabsContent value="pair" className="mt-4">
+				<TabsContent value="pair" className={FORM_TAB_CLASS}>
 					<PairCodeTab accountId={id} provider={ch.provider} />
 				</TabsContent>
-				<TabsContent value="bindings" className="mt-4">
+				<TabsContent value="bindings" className={LIST_TAB_CLASS}>
 					<BindingsTab accountId={id} />
 				</TabsContent>
-				<TabsContent value="activity" className="mt-4">
+				<TabsContent value="activity" className={LIST_TAB_CLASS}>
 					<ActivityTab accountId={id} />
 				</TabsContent>
-				<TabsContent value="health" className="mt-4">
+				<TabsContent value="health" className={LIST_TAB_CLASS}>
 					<HealthTab accountId={id} />
 				</TabsContent>
-				<TabsContent value="commands" className="mt-4">
+				<TabsContent value="commands" className={FORM_TAB_CLASS}>
 					<CommandsTab accountId={id} provider={ch.provider} />
 				</TabsContent>
 			</Tabs>
@@ -285,7 +313,7 @@ function AgentsTab({ accountId, accountName }: { accountId: string; accountName:
 	const items = links.data ?? [];
 
 	return (
-		<div className="space-y-3">
+		<div className="flex flex-col gap-3">
 			{envs.error ? (
 				<ChannelError
 					error={envs.error}
@@ -293,12 +321,16 @@ function AgentsTab({ accountId, accountName }: { accountId: string; accountName:
 					title="Couldn't load agent names"
 				/>
 			) : null}
-			<div className="flex justify-end">
-				<Button size="sm" onClick={() => setLinkOpen(true)}>
-					<Link2 className="size-3.5" />
-					Link an agent
-				</Button>
-			</div>
+			<SectionHeader
+				label="Linked agents"
+				count={items.length}
+				action={
+					<Button size="sm" onClick={() => setLinkOpen(true)}>
+						<Link2 className="size-3.5" />
+						Link an agent
+					</Button>
+				}
+			/>
 
 			{items.length === 0 ? (
 				<EmptyState
@@ -308,17 +340,17 @@ function AgentsTab({ accountId, accountName }: { accountId: string; accountName:
 					fillHeight={false}
 				/>
 			) : (
-				<div className="space-y-2">
+				<div className="flex flex-col gap-2">
 					{items.map((link: ChannelAgentLink) => (
-						<div key={link.id} className="rounded-lg border p-3">
-							<div className="flex items-center justify-between gap-3">
+						<div key={link.id} className={cn(ENTITY_CARD_BASE, "bg-card")}>
+							<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
 								<div className="min-w-0">
 									<AgentName env={findEnv(envs.data, link.agent_id)} fallback={link.agent_id} />
 									<div className="text-xs capitalize text-muted-foreground">
-										{link.status} · linked {formatWhen(link.created_at)}
+										{link.status} · linked {relativeTime(link.created_at)}
 									</div>
 								</div>
-								<div className="flex shrink-0 items-center gap-1.5">
+								<div className="flex shrink-0 flex-wrap items-center gap-1.5">
 									<Button
 										variant="outline"
 										size="sm"
@@ -404,7 +436,7 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 	const effectiveLink = linkId || (linkItems.length === 1 ? linkItems[0].id : "");
 
 	return (
-		<div className="max-w-xl space-y-4">
+		<div className="flex flex-col gap-4">
 			<InfoCard icon={Smartphone} title="Link a WhatsApp number">
 				WhatsApp uses no bot token. Mint a device credential for an agent, then finish the link by
 				scanning it in WhatsApp → Linked devices. The credential is handed to the agent runtime to
@@ -427,7 +459,7 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 					description="A WhatsApp device is minted per agent. Link an agent on the Agents tab, then come back."
 				/>
 			) : (
-				<div className="space-y-2">
+				<div className="flex flex-col gap-2">
 					{envs.error ? (
 						<ChannelError
 							error={envs.error}
@@ -436,7 +468,7 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 						/>
 					) : null}
 					{linkItems.length > 1 ? (
-						<div className="space-y-1.5">
+						<div className="flex flex-col gap-1.5">
 							<Label htmlFor="wa-agent">Agent</Label>
 							<Select value={effectiveLink} onValueChange={setLinkId}>
 								<SelectTrigger id="wa-agent">
@@ -469,8 +501,8 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 				</div>
 			)}
 
-			<div className="space-y-2">
-				<div className="text-sm font-medium">Linked devices</div>
+			<div className="flex flex-col gap-2">
+				<SectionLabel count={devices.length}>Linked devices</SectionLabel>
 				{creds.isLoading ? (
 					<Skeleton className="h-16 w-full rounded-lg" />
 				) : creds.error ? (
@@ -487,21 +519,23 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 					devices.map((d) => (
 						<div
 							key={d.credential_id}
-							className="flex items-center justify-between gap-3 rounded-lg border p-3"
+							className={cn(ENTITY_CARD_BASE, "flex items-center justify-between gap-3 bg-card")}
 						>
-							<div className="min-w-0">
-								{d.jid ? (
-									<div className="truncate font-mono text-xs">{d.jid}</div>
-								) : (
-									<div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-										<Spinner className="size-3" />
-										Pending pairing
-									</div>
-								)}
-								<div className="text-xs text-muted-foreground">
-									{envName(envs.data, d.agent_id, ownership)} · added {formatWhen(d.created_at)}
-								</div>
-							</div>
+							<EntityHeader
+								className="min-w-0 flex-1"
+								icon={
+									<DetailIcon>
+										<Smartphone />
+									</DetailIcon>
+								}
+								title={
+									d.jid ? <span className="font-mono text-xs">{d.jid}</span> : "Pending pairing"
+								}
+								titleAdornment={!d.jid ? <Spinner className="size-3" /> : undefined}
+								meta={`${envName(envs.data, d.agent_id, ownership)} · added ${relativeTime(
+									d.created_at,
+								)}`}
+							/>
 							<ConfirmAction
 								title="Unlink this device?"
 								description={<p>The WhatsApp credential is revoked. This can't be undone.</p>}
@@ -554,14 +588,14 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 	}
 
 	return (
-		<div className="max-w-xl space-y-4">
+		<div className="flex flex-col gap-4">
 			<InfoCard icon={QrCode} title="Pair a chat">
 				Generate a one-time code, then send it from the {meta.label} chat you want to pair — the
 				agent links that conversation when it sees the code.
 			</InfoCard>
 
 			<div className="grid gap-3 sm:grid-cols-2">
-				<div className="space-y-1.5">
+				<div className="flex flex-col gap-1.5">
 					<Label htmlFor="pair-agent">Agent</Label>
 					{envs.isLoading ? (
 						<Skeleton className="h-10 w-full rounded-md" />
@@ -584,7 +618,7 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 						</Select>
 					)}
 				</div>
-				<div className="space-y-1.5">
+				<div className="flex flex-col gap-1.5">
 					<Label htmlFor="pair-ttl">Expires in</Label>
 					<Select value={ttl} onValueChange={setTtl}>
 						<SelectTrigger id="pair-ttl">
@@ -615,12 +649,12 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 			</Button>
 
 			{result ? (
-				<div className="space-y-3 rounded-lg border border-primary/30 bg-primary/5 p-4">
+				<div className="flex flex-col gap-3 rounded-lg border border-primary/30 bg-primary/5 p-4">
 					<div className="text-xs font-medium text-primary">Pairing code</div>
 					<div className="font-mono text-3xl font-semibold tracking-[0.2em]">{result.code}</div>
 					<p className="text-sm text-muted-foreground">
 						Send <span className="font-mono font-medium">{result.code}</span> from the chat you want
-						to pair. Expires {formatWhen(result.expires_at)}.
+						to pair. Expires {relativeTime(result.expires_at)}.
 					</p>
 				</div>
 			) : null}
@@ -655,17 +689,24 @@ function BindingsTab({ accountId }: { accountId: string }) {
 	}
 
 	return (
-		<div className="space-y-2">
+		<div className="flex flex-col gap-2">
 			{items.map((b: ChannelBinding) => (
-				<div key={b.id} className="flex items-center justify-between gap-3 rounded-lg border p-3">
-					<div className="min-w-0">
-						<div className="truncate text-sm font-medium">{b.external_chat_name ?? "Chat"}</div>
-						<div className="flex items-center gap-2 text-xs text-muted-foreground">
-							<span className="capitalize">{b.external_chat_type ?? "chat"}</span>
-							<span>·</span>
-							<CopyInline value={b.external_chat_id} />
-						</div>
-					</div>
+				<div key={b.id} className={cn(ENTITY_CARD_BASE, "flex items-center gap-3 bg-card")}>
+					<EntityHeader
+						className="min-w-0 flex-1"
+						icon={
+							<DetailIcon>
+								<MessageSquareDashed />
+							</DetailIcon>
+						}
+						title={b.external_chat_name ?? "Chat"}
+						meta={[
+							<span key="type" className="capitalize">
+								{b.external_chat_type ?? "chat"}
+							</span>,
+							<CopyInline key="chat-id" value={b.external_chat_id} />,
+						]}
+					/>
 					<span className="text-xs capitalize text-muted-foreground">{b.status}</span>
 				</div>
 			))}
@@ -700,7 +741,7 @@ function ActivityTab({ accountId }: { accountId: string }) {
 	}
 
 	return (
-		<div className="space-y-2">
+		<div className="flex flex-col gap-2">
 			{items.map((item: ChannelActivityItem) => (
 				<ActivityRow key={item.id} item={item} />
 			))}
@@ -714,24 +755,18 @@ function ActivityRow({ item }: { item: ChannelActivityItem }) {
 	const error = item.delivery_last_error ?? item.error;
 
 	return (
-		<div className="flex items-start gap-3 rounded-lg border p-3">
-			<span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
-				{isEvent ? (
-					<TerminalSquare className="size-3.5" />
-				) : inbound ? (
-					<ArrowDownLeft className="size-3.5" />
-				) : (
-					<ArrowUpRight className="size-3.5" />
-				)}
-			</span>
+		<div className={cn(ENTITY_CARD_BASE, "flex items-start gap-3 bg-card")}>
+			<DetailIcon>
+				{isEvent ? <TerminalSquare /> : inbound ? <ArrowDownLeft /> : <ArrowUpRight />}
+			</DetailIcon>
 			<div className="min-w-0 flex-1">
-				<div className="flex items-center gap-2">
+				<div className="flex flex-wrap items-center gap-2">
 					<span className="text-xs font-medium capitalize">
 						{isEvent ? (item.stage ?? "event") : inbound ? "Inbound" : "Outbound"}
 					</span>
 					{item.delivery_status ? <DeliveryBadge status={item.delivery_status} /> : null}
-					<span className="ml-auto shrink-0 text-xs text-muted-foreground">
-						{formatWhen(item.created_at)}
+					<span className="shrink-0 text-xs text-muted-foreground sm:ml-auto">
+						{relativeTime(item.created_at)}
 					</span>
 				</div>
 				{item.text ? <p className="mt-1 text-sm">{item.text}</p> : null}
@@ -777,7 +812,7 @@ function HealthTab({ accountId }: { accountId: string }) {
 	];
 
 	return (
-		<div className="space-y-4">
+		<div className="flex flex-col gap-4">
 			<div className="flex items-center gap-2">
 				<HealthBadge status={h.health_status} />
 				{(h.reasons ?? []).length > 0 ? (
@@ -791,7 +826,7 @@ function HealthTab({ accountId }: { accountId: string }) {
 
 			<div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
 				{stats.map((s) => (
-					<div key={s.label} className="rounded-lg border p-3">
+					<div key={s.label} className={cn(ENTITY_CARD_BASE, "bg-card")}>
 						<div className="text-2xl font-semibold tabular-nums">{s.value}</div>
 						<div className="text-xs text-muted-foreground">{s.label}</div>
 					</div>
@@ -799,7 +834,12 @@ function HealthTab({ accountId }: { accountId: string }) {
 			</div>
 
 			{h.last_error ? (
-				<div className="space-y-1 rounded-lg border border-destructive/30 bg-destructive/5 p-3">
+				<div
+					className={cn(
+						ENTITY_CARD_BASE,
+						"flex flex-col gap-1 border-destructive/30 bg-destructive/5",
+					)}
+				>
 					<div className="flex items-center gap-1.5 text-sm font-medium text-destructive">
 						<TriangleAlert className="size-4" />
 						Last error
@@ -807,16 +847,14 @@ function HealthTab({ accountId }: { accountId: string }) {
 					<p className="text-sm text-destructive/90">{h.last_error}</p>
 					<p className="text-xs text-muted-foreground">
 						{[h.last_error_stage, h.last_error_outcome].filter(Boolean).join(" · ")} ·{" "}
-						{formatWhen(h.last_error_at)}
+						{relativeTime(h.last_error_at)}
 					</p>
 				</div>
 			) : null}
 
 			{h.native_transport ? (
-				<div className="rounded-lg border p-3">
-					<div className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-						Native transport
-					</div>
+				<div className={cn(ENTITY_CARD_BASE, "bg-card")}>
+					<SectionLabel className="mb-2 px-0">Native transport</SectionLabel>
 					<pre className="overflow-x-auto text-xs text-muted-foreground">
 						{JSON.stringify(h.native_transport, null, 2)}
 					</pre>
@@ -835,7 +873,7 @@ function CommandsTab({ accountId, provider }: { accountId: string; provider: str
 	const commands = sync.data?.commands ?? [];
 
 	return (
-		<div className="max-w-xl space-y-4">
+		<div className="flex flex-col gap-4">
 			<InfoCard icon={KeyRound} title="Slash commands">
 				{supportsCommands
 					? `Publish this agent's slash commands to ${meta.label}.`
@@ -849,7 +887,7 @@ function CommandsTab({ accountId, provider }: { accountId: string; provider: str
 						{sync.isPending ? "Syncing…" : "Sync commands"}
 					</Button>
 					{commands.length > 0 ? (
-						<div className="space-y-2 rounded-lg border p-3">
+						<div className={cn(ENTITY_CARD_BASE, "flex flex-col gap-2 bg-card")}>
 							<div className="text-xs font-medium text-success-muted-foreground">
 								Synced {commands.length} command{commands.length === 1 ? "" : "s"}
 							</div>

--- a/apps/web/src/hosted/v2/channels/channel-ui.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-ui.tsx
@@ -144,7 +144,7 @@ export function TokenReveal({
 		<div
 			data-hosted="true"
 			data-v2="true"
-			className="space-y-2 rounded-lg border border-primary/30 bg-primary/5 p-3"
+			className="flex flex-col gap-2 rounded-lg border border-primary/30 bg-primary/5 p-3"
 		>
 			<div className="text-xs font-medium text-primary">{label}</div>
 			<div className="flex items-center gap-2">
@@ -176,7 +176,7 @@ export function CopyInline({ value, className }: { value: string; className?: st
 			data-v2="true"
 			onClick={() => copy(value)}
 			className={cn(
-				"inline-flex items-center gap-1 font-mono text-xs text-muted-foreground transition-colors hover:text-foreground",
+				"inline-flex min-w-0 max-w-full items-center gap-1 font-mono text-xs text-muted-foreground transition-colors hover:text-foreground",
 				className,
 			)}
 			aria-label="Copy"

--- a/apps/web/src/hosted/v2/channels/channels-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channels-page.tsx
@@ -1,11 +1,14 @@
 "use client";
 
+import { Link } from "@tanstack/react-router";
 import { MessagesSquare, Plus } from "lucide-react";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { EmptyState } from "@/components/empty-state";
-import { EntityRow } from "@/components/entity-card";
+import { ENTITY_CARD_BASE, EntityHeader } from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
 import { PageHeader } from "@/components/page-header";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
+import { SectionLabel } from "@/components/section-label";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -22,12 +25,14 @@ import { SharedBotsPool } from "@/hosted/v2/channels/shared-bots-pool";
 import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Connect Telegram, Discord, WhatsApp, and iMessage to your agents.";
+const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.wide, "flex flex-col gap-6 px-4 lg:px-6");
+const CHANNEL_GRID_CLASS = "grid gap-2 sm:grid-cols-2 xl:grid-cols-3";
 
 export function ChannelsPage() {
 	const [connectOpen, setConnectOpen] = useState(false);
 
 	return (
-		<div data-hosted="true" data-v2="true" className="space-y-6 px-4 lg:px-6">
+		<div data-hosted="true" data-v2="true" className={PAGE_CLASS}>
 			<PageHeader
 				title="Channels"
 				description={DESCRIPTION}
@@ -64,9 +69,9 @@ function YourChannels({ onConnect }: { onConnect: () => void }) {
 
 	if (channels.isLoading) {
 		return (
-			<div className="space-y-2">
+			<div className={CHANNEL_GRID_CLASS}>
 				{[0, 1, 2].map((i) => (
-					<Skeleton key={i} className="h-16 w-full rounded-lg" />
+					<ChannelCardSkeleton key={i} />
 				))}
 			</div>
 		);
@@ -112,7 +117,7 @@ function YourChannels({ onConnect }: { onConnect: () => void }) {
 	})).filter((g) => g.items.length > 0);
 
 	return (
-		<div className="space-y-4">
+		<div className="flex flex-col gap-4">
 			{health.error ? (
 				<ChannelError
 					error={health.error}
@@ -134,17 +139,15 @@ function YourChannels({ onConnect }: { onConnect: () => void }) {
 				))}
 			</div>
 
-			<div className="space-y-5">
+			<div className="flex flex-col gap-5">
 				{groups.map((group) => (
-					<div key={group.provider} className="space-y-2">
+					<div key={group.provider} className="flex flex-col gap-2">
 						{filter === "all" ? (
-							<div className="px-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-								{providerMeta(group.provider).label}
-							</div>
+							<SectionLabel>{providerMeta(group.provider).label}</SectionLabel>
 						) : null}
-						<div className="space-y-2">
+						<div className={CHANNEL_GRID_CLASS}>
 							{group.items.map((channel) => (
-								<ChannelRow
+								<ChannelCard
 									key={channel.id}
 									channel={channel}
 									health={healthByAccount.get(channel.id)}
@@ -165,7 +168,7 @@ function FilterChip({
 }: {
 	active: boolean;
 	onClick: () => void;
-	children: React.ReactNode;
+	children: ReactNode;
 }) {
 	return (
 		<button
@@ -184,20 +187,51 @@ function FilterChip({
 	);
 }
 
-function ChannelRow({ channel, health }: { channel: ChannelAccount; health?: string }) {
+function ChannelCard({ channel, health }: { channel: ChannelAccount; health?: string }) {
 	const meta = providerMeta(channel.provider);
+	const linkClassName =
+		"absolute inset-0 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+
 	return (
-		<EntityRow
-			href={`/channels/${channel.id}`}
-			icon={<EntityIcon kind="channel" id={channel.provider} label={meta.label} />}
-			title={channel.name}
-			meta={[
-				meta.label,
-				<span key="status" className="capitalize">
-					{channel.status}
-				</span>,
-			]}
-			status={health ? <HealthBadge status={health} /> : undefined}
-		/>
+		<div className="group relative z-0 h-full min-w-0">
+			<div
+				className={cn(
+					ENTITY_CARD_BASE,
+					"flex h-full items-start gap-3 bg-card transition-colors group-hover:bg-muted/50",
+				)}
+			>
+				<EntityHeader
+					className="w-full"
+					align="start"
+					icon={<EntityIcon kind="channel" id={channel.provider} label={meta.label} />}
+					title={channel.name}
+					titleAdornment={health ? <HealthBadge status={health} /> : undefined}
+					meta={[
+						meta.label,
+						<span key="status" className="capitalize">
+							{channel.status}
+						</span>,
+					]}
+				/>
+			</div>
+			<Link to="/channels/$id" params={{ id: channel.id }} className={linkClassName}>
+				<span className="sr-only">Open {channel.name}</span>
+			</Link>
+		</div>
+	);
+}
+
+function ChannelCardSkeleton() {
+	return (
+		<div className={cn(ENTITY_CARD_BASE, "bg-card")}>
+			<div className="flex items-start gap-3">
+				<Skeleton className="size-10 shrink-0 rounded-lg" />
+				<div className="min-w-0 flex-1">
+					<Skeleton className="h-4 w-28" />
+					<Skeleton className="mt-2 h-3 w-32" />
+				</div>
+				<Skeleton className="h-6 w-20 rounded-full" />
+			</div>
+		</div>
 	);
 }

--- a/apps/web/src/hosted/v2/channels/channels-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channels-page.tsx
@@ -4,7 +4,12 @@ import { Link } from "@tanstack/react-router";
 import { MessagesSquare, Plus } from "lucide-react";
 import { type ReactNode, useState } from "react";
 import { EmptyState } from "@/components/empty-state";
-import { ENTITY_CARD_BASE, EntityHeader } from "@/components/entity-card";
+import {
+	ENTITY_CARD_BASE,
+	ENTITY_GRID_CLASS,
+	ENTITY_STRETCHED_LINK_CLASS,
+	EntityHeader,
+} from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
@@ -26,7 +31,7 @@ import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Connect Telegram, Discord, WhatsApp, and iMessage to your agents.";
 const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.wide, "flex flex-col gap-6 px-4 lg:px-6");
-const CHANNEL_GRID_CLASS = "grid gap-2 sm:grid-cols-2 xl:grid-cols-3";
+const CHANNEL_GRID_CLASS = ENTITY_GRID_CLASS;
 
 export function ChannelsPage() {
 	const [connectOpen, setConnectOpen] = useState(false);
@@ -189,8 +194,6 @@ function FilterChip({
 
 function ChannelCard({ channel, health }: { channel: ChannelAccount; health?: string }) {
 	const meta = providerMeta(channel.provider);
-	const linkClassName =
-		"absolute inset-0 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
 	return (
 		<div className="group relative z-0 h-full min-w-0">
@@ -214,7 +217,7 @@ function ChannelCard({ channel, health }: { channel: ChannelAccount; health?: st
 					]}
 				/>
 			</div>
-			<Link to="/channels/$id" params={{ id: channel.id }} className={linkClassName}>
+			<Link to="/channels/$id" params={{ id: channel.id }} className={ENTITY_STRETCHED_LINK_CLASS}>
 				<span className="sr-only">Open {channel.name}</span>
 			</Link>
 		</div>

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -177,8 +177,8 @@ export function ConnectBotDialog({
 							</DialogDescription>
 						</DialogHeader>
 
-						<div className="space-y-4">
-							<div className="space-y-1.5">
+						<div className="flex flex-col gap-4">
+							<div className="flex flex-col gap-1.5">
 								<Label>Provider</Label>
 								<div className="grid grid-cols-2 gap-2">
 									{CHANNEL_PROVIDERS.map((p) => (
@@ -186,7 +186,14 @@ export function ConnectBotDialog({
 											key={p}
 											selected={provider === p}
 											onClick={() => changeProvider(p)}
-											icon={<EntityIcon kind="channel" id={p} label={PROVIDER_META[p].label} />}
+											icon={
+												<EntityIcon
+													kind="channel"
+													id={p}
+													label={PROVIDER_META[p].label}
+													size="sm"
+												/>
+											}
 											title={PROVIDER_META[p].label}
 										/>
 									))}
@@ -198,7 +205,7 @@ export function ConnectBotDialog({
 								<p className="text-xs text-muted-foreground">{meta.hint}</p>
 							</div>
 
-							<div className="space-y-1.5">
+							<div className="flex flex-col gap-1.5">
 								<Label htmlFor="connect-name">Name</Label>
 								<Input
 									id="connect-name"
@@ -211,7 +218,7 @@ export function ConnectBotDialog({
 
 							{/* Telegram / Discord bot token, or iMessage BlueBubbles password. */}
 							{meta.connect !== "whatsapp" ? (
-								<div className="space-y-1.5">
+								<div className="flex flex-col gap-1.5">
 									<Label htmlFor="connect-token">{meta.tokenLabel}</Label>
 									<Input
 										id="connect-token"
@@ -228,7 +235,7 @@ export function ConnectBotDialog({
 							{/* Discord: application_id (+ public_key, guild_id). */}
 							{meta.connect === "discord" ? (
 								<>
-									<div className="space-y-1.5">
+									<div className="flex flex-col gap-1.5">
 										<Label htmlFor="connect-app-id">Application ID</Label>
 										<Input
 											id="connect-app-id"
@@ -242,7 +249,7 @@ export function ConnectBotDialog({
 											Required to publish slash commands.
 										</p>
 									</div>
-									<div className="space-y-1.5">
+									<div className="flex flex-col gap-1.5">
 										<Label htmlFor="connect-public-key">
 											Public key <span className="text-muted-foreground">· recommended</span>
 										</Label>
@@ -258,7 +265,7 @@ export function ConnectBotDialog({
 											Verifies incoming interaction signatures.
 										</p>
 									</div>
-									<div className="space-y-1.5">
+									<div className="flex flex-col gap-1.5">
 										<Label htmlFor="connect-guild-id">
 											Guild ID <span className="text-muted-foreground">· optional</span>
 										</Label>
@@ -277,7 +284,7 @@ export function ConnectBotDialog({
 							{/* iMessage: BlueBubbles server URL + auth mode. */}
 							{meta.connect === "imessage" ? (
 								<>
-									<div className="space-y-1.5">
+									<div className="flex flex-col gap-1.5">
 										<Label htmlFor="connect-server-url">BlueBubbles server URL</Label>
 										<Input
 											id="connect-server-url"
@@ -288,7 +295,7 @@ export function ConnectBotDialog({
 											spellCheck={false}
 										/>
 									</div>
-									<div className="space-y-1.5">
+									<div className="flex flex-col gap-1.5">
 										<Label htmlFor="connect-auth-mode">Auth mode</Label>
 										<Select value={authMode} onValueChange={setAuthMode}>
 											<SelectTrigger id="connect-auth-mode">

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
@@ -119,7 +119,7 @@ export function LinkAgentDialog({
 						fillHeight={false}
 					/>
 				) : (
-					<div className="space-y-2">
+					<div className="flex flex-col gap-2">
 						<Select value={agentId} onValueChange={setAgentId}>
 							<SelectTrigger>
 								<SelectValue placeholder="Choose an agent" />

--- a/apps/web/src/hosted/v2/channels/shared-bots-pool.tsx
+++ b/apps/web/src/hosted/v2/channels/shared-bots-pool.tsx
@@ -4,7 +4,7 @@ import { Link } from "@tanstack/react-router";
 import { ArrowUpRight, Link2, Users } from "lucide-react";
 import { useState } from "react";
 import { EmptyState } from "@/components/empty-state";
-import { ENTITY_CARD_BASE, EntityHeader } from "@/components/entity-card";
+import { ENTITY_CARD_BASE, ENTITY_GRID_CLASS, EntityHeader } from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
 import { SectionLabel } from "@/components/section-label";
 import { Button } from "@/components/ui/button";
@@ -16,7 +16,7 @@ import { useBotPool } from "@/hosted/v2/channels/channels-hooks";
 import { LinkAgentDialog } from "@/hosted/v2/channels/link-agent-dialog";
 import { cn } from "@/lib/utils";
 
-const BOT_GRID_CLASS = "grid gap-2 sm:grid-cols-2 xl:grid-cols-3";
+const BOT_GRID_CLASS = ENTITY_GRID_CLASS;
 
 /**
  * Shared bot pool — public bots the user can link an agent to instantly (no

--- a/apps/web/src/hosted/v2/channels/shared-bots-pool.tsx
+++ b/apps/web/src/hosted/v2/channels/shared-bots-pool.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { EmptyState } from "@/components/empty-state";
 import { ENTITY_CARD_BASE, EntityHeader } from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
+import { SectionLabel } from "@/components/section-label";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { CHANNEL_PROVIDERS, providerMeta } from "@/hosted/v2/channels/channel-providers";
@@ -14,6 +15,8 @@ import { AccessBadge, ChannelError } from "@/hosted/v2/channels/channel-ui";
 import { useBotPool } from "@/hosted/v2/channels/channels-hooks";
 import { LinkAgentDialog } from "@/hosted/v2/channels/link-agent-dialog";
 import { cn } from "@/lib/utils";
+
+const BOT_GRID_CLASS = "grid gap-2 sm:grid-cols-2 xl:grid-cols-3";
 
 /**
  * Shared bot pool — public bots the user can link an agent to instantly (no
@@ -26,7 +29,7 @@ export function SharedBotsPool() {
 
 	if (pool.isLoading) {
 		return (
-			<div data-hosted="true" data-v2="true" className="space-y-3">
+			<div data-hosted="true" data-v2="true" className={BOT_GRID_CLASS}>
 				{[0, 1, 2].map((i) => (
 					<Skeleton key={i} className="h-20 w-full rounded-lg" />
 				))}
@@ -65,16 +68,13 @@ export function SharedBotsPool() {
 	}
 
 	return (
-		<div data-hosted="true" data-v2="true" className="space-y-6">
+		<div data-hosted="true" data-v2="true" className="flex flex-col gap-6">
 			{sections.map((section) => {
 				const meta = providerMeta(section.provider);
 				return (
-					<div key={section.provider} className="space-y-2">
-						<div className="flex items-center gap-2 px-0.5">
-							<span className="text-sm font-medium">{meta.label}</span>
-							<span className="text-xs text-muted-foreground">{section.items.length}</span>
-						</div>
-						<div className="grid gap-2 sm:grid-cols-2">
+					<div key={section.provider} className="flex flex-col gap-2">
+						<SectionLabel count={section.items.length}>{meta.label}</SectionLabel>
+						<div className={BOT_GRID_CLASS}>
 							{section.items.map((item) => (
 								<PoolCard
 									key={item.id}

--- a/apps/web/src/lib/utils.test.ts
+++ b/apps/web/src/lib/utils.test.ts
@@ -43,6 +43,11 @@ describe("relativeTime", () => {
 		expect(relativeTime(fiveDaysAgo)).toBe("5d ago");
 	});
 
+	test("returns future minute-granularity", () => {
+		const fiveMinFromNow = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+		expect(relativeTime(fiveMinFromNow)).toBe("in 5m");
+	});
+
 	test("switches to compact absolute at >=7 days (current year)", () => {
 		const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
 		const result = relativeTime(tenDaysAgo);

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -23,25 +23,17 @@ export function relativeTime(dateStr: string | null | undefined): string {
 	if (!dateStr) return "—";
 	const d = new Date(dateStr);
 	if (Number.isNaN(d.getTime())) return "—";
-	const futureDiff = d.getTime() - Date.now();
-	if (futureDiff > 0) {
-		const mins = Math.round(futureDiff / 60000);
-		if (mins < 1) return "just now";
-		if (mins < 60) return `in ${mins}m`;
-		const hours = Math.round(mins / 60);
-		if (hours < 24) return `in ${hours}h`;
-		const days = Math.round(hours / 24);
-		if (days < 7) return `in ${days}d`;
-	} else {
-		const diff = Date.now() - d.getTime();
-		const mins = Math.floor(diff / 60000);
-		if (mins < 1) return "just now";
-		if (mins < 60) return `${mins}m ago`;
-		const hours = Math.floor(mins / 60);
-		if (hours < 24) return `${hours}h ago`;
-		const days = Math.floor(hours / 24);
-		if (days < 7) return `${days}d ago`;
-	}
+	const diffMs = d.getTime() - Date.now();
+	const future = diffMs > 0;
+	const phrase = (value: number, unit: string) =>
+		future ? `in ${value}${unit}` : `${value}${unit} ago`;
+	const mins = Math.floor(Math.abs(diffMs) / 60000);
+	if (mins < 1) return "just now";
+	if (mins < 60) return phrase(mins, "m");
+	const hours = Math.floor(mins / 60);
+	if (hours < 24) return phrase(hours, "h");
+	const days = Math.floor(hours / 24);
+	if (days < 7) return phrase(days, "d");
 	const now = new Date();
 	const sameYear = d.getFullYear() === now.getFullYear();
 	if (sameYear) {

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -23,14 +23,25 @@ export function relativeTime(dateStr: string | null | undefined): string {
 	if (!dateStr) return "—";
 	const d = new Date(dateStr);
 	if (Number.isNaN(d.getTime())) return "—";
-	const diff = Date.now() - d.getTime();
-	const mins = Math.floor(diff / 60000);
-	if (mins < 1) return "just now";
-	if (mins < 60) return `${mins}m ago`;
-	const hours = Math.floor(mins / 60);
-	if (hours < 24) return `${hours}h ago`;
-	const days = Math.floor(hours / 24);
-	if (days < 7) return `${days}d ago`;
+	const futureDiff = d.getTime() - Date.now();
+	if (futureDiff > 0) {
+		const mins = Math.round(futureDiff / 60000);
+		if (mins < 1) return "just now";
+		if (mins < 60) return `in ${mins}m`;
+		const hours = Math.round(mins / 60);
+		if (hours < 24) return `in ${hours}h`;
+		const days = Math.round(hours / 24);
+		if (days < 7) return `in ${days}d`;
+	} else {
+		const diff = Date.now() - d.getTime();
+		const mins = Math.floor(diff / 60000);
+		if (mins < 1) return "just now";
+		if (mins < 60) return `${mins}m ago`;
+		const hours = Math.floor(mins / 60);
+		if (hours < 24) return `${hours}h ago`;
+		const days = Math.floor(hours / 24);
+		if (days < 7) return `${days}d ago`;
+	}
 	const now = new Date();
 	const sameYear = d.getFullYear() === now.getFullYear();
 	if (sameYear) {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -831,13 +831,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { startInstance } from './start.ts'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-    config: Awaited<ReturnType<typeof startInstance.getOptions>>
-  }
-}

--- a/packages/shared/src/ai-provider.test.ts
+++ b/packages/shared/src/ai-provider.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { isProviderAuthProfileId, validateAiProviderCatalog } from "./ai-provider";
+import {
+	CLAWDI_MANAGED_V1_PROVIDER_ID,
+	CLAWDI_MANAGED_V2_PROVIDER_ID,
+	isFirstPartyManagedAiProvider,
+	isProviderAuthProfileId,
+	validateAiProviderCatalog,
+} from "./ai-provider";
 
 describe("validateAiProviderCatalog", () => {
 	test("returns validation errors instead of throwing for malformed catalog entries", () => {
@@ -230,6 +236,29 @@ describe("validateAiProviderCatalog", () => {
 		expect(result.valid).toBe(false);
 		expect(result.errors).toContain(
 			"Provider clawdi-managed-v2 managed_by clawdi must use api_mode openai_chat.",
+		);
+	});
+});
+
+describe("isFirstPartyManagedAiProvider", () => {
+	test("matches first-party managed ids even when old rows are missing managed_by", () => {
+		expect(isFirstPartyManagedAiProvider({ provider_id: CLAWDI_MANAGED_V1_PROVIDER_ID })).toBe(
+			true,
+		);
+		expect(isFirstPartyManagedAiProvider({ provider_id: CLAWDI_MANAGED_V2_PROVIDER_ID })).toBe(
+			true,
+		);
+	});
+
+	test("matches managed_by clawdi for current rows", () => {
+		expect(isFirstPartyManagedAiProvider({ provider_id: "custom", managed_by: "clawdi" })).toBe(
+			true,
+		);
+	});
+
+	test("does not match user providers", () => {
+		expect(isFirstPartyManagedAiProvider({ provider_id: "openai-prod", managed_by: "user" })).toBe(
+			false,
 		);
 	});
 });

--- a/packages/shared/src/ai-provider.ts
+++ b/packages/shared/src/ai-provider.ts
@@ -120,15 +120,29 @@ const DEFAULT_BASE_URL: Partial<Record<AiProviderType, string>> = {
 	mistral: "https://api.mistral.ai/v1",
 };
 
-const CLAWDI_MANAGED_V1_PROVIDER_ID = "clawdi-managed";
+export const CLAWDI_MANAGED_V1_PROVIDER_ID = "clawdi-managed";
 const CLAWDI_MANAGED_V1_API_MODE = "openai_responses";
-const CLAWDI_MANAGED_V2_PROVIDER_ID = "clawdi-managed-v2";
+export const CLAWDI_MANAGED_V2_PROVIDER_ID = "clawdi-managed-v2";
 const CLAWDI_MANAGED_V2_API_MODE = "openai_chat";
-const CLAWDI_MANAGED_PROVIDER_IDS = new Set([
+export const CLAWDI_MANAGED_PROVIDER_IDS: ReadonlySet<string> = new Set([
 	CLAWDI_MANAGED_V1_PROVIDER_ID,
 	CLAWDI_MANAGED_V2_PROVIDER_ID,
 ]);
 const CLAWDI_MANAGED_RUNTIME_ENV = "CLAWDI_MANAGED_OPENAI_API_KEY";
+
+export interface AiProviderManagedIdentity {
+	id?: string | null;
+	provider_id?: string | null;
+	managed_by?: string | null;
+}
+
+export function isFirstPartyManagedAiProvider(provider: AiProviderManagedIdentity): boolean {
+	const id = provider.provider_id ?? provider.id;
+	return (
+		provider.managed_by === "clawdi" ||
+		(typeof id === "string" && CLAWDI_MANAGED_PROVIDER_IDS.has(id))
+	);
+}
 
 export function isAiProviderId(input: string): boolean {
 	return PROVIDER_ID_RE.test(input);


### PR DESCRIPTION
## Summary
- Brings hosted v2 pages onto shared page widths, denser card grids, entity-card geometry, and consistent section labels across Deploy, Model Providers, Channels, Shared bots, Channel detail, and dialogs.
- Refines the Deploy wizard with a wider detail layout, aligned add tiles, connected-channel info tiles, a searchable timezone combobox, and compact compute status copy while leaving deploy request building, free-slot checks, checkout, and runtime toggles unchanged.
- Converts Model Providers and Channels lists to responsive card grids whose loading and empty states match the final geometry; provider actions remain Validate/Edit/Remove, with ConfirmAction still guarding delete.
- Reworks Channel detail to use PageHeader slots, unified tab widths, and entity-card list rows, and consolidates future/past relative time formatting in `relativeTime`.
- Fixes first-party managed AI providers leaking into “Your providers” and deploy provider tiles by filtering `managed_by: "clawdi"` plus the canonical `clawdi-managed` / `clawdi-managed-v2` ids via `@clawdi/shared`.

## Screenshots
- Verified empty and populated Deploy, Model Providers, Channels, and Shared bots states at 1440px and 390px.
- Verified populated Channel detail tabs (Agents, Chats, Activity, Health) and Add Provider / Connect Bot dialogs at 1440px and 390px.
- Screenshots are not committed; image files are available locally for manual reviewer attachment.

## Verification
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`
- `bun test packages/shared/src/ai-provider.test.ts`
- `bun run check`
- Playwright screenshot harness with `VITE_CLAWDI_HOSTED=true`, mocked hosted provider/channel/deploy responses, horizontal overflow checks, and assertions that managed provider rows are not visible in `/ai-providers` or `/deploy`.

🤖 Generated with paseo codex.
