### PR TITLE
Unify dashboard UI conventions

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -77,11 +77,7 @@ import {
 	usePortal,
 	useResumeSubscription,
 } from "@/hosted/billing/hooks";
-import {
-	planOffers,
-	selectOfferForTerm,
-	shortDate,
-} from "@/hosted/billing/subscription/subscription-utils";
+import { planOffers, selectOfferForTerm } from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import {
 	HOSTED_RUNTIMES,
@@ -118,7 +114,7 @@ import {
 } from "@/lib/agent-routes";
 import { toastApiError, unwrap, useApi } from "@/lib/api";
 import type { SessionListItem } from "@/lib/api-schemas";
-import { formatModelLabel } from "@/lib/format";
+import { formatModelLabel, formatShortDate } from "@/lib/format";
 import { sessionListQueryOptions } from "@/lib/session-queries";
 import { cn } from "@/lib/utils";
 
@@ -1278,7 +1274,7 @@ function ComputeSettingsSections({
 	);
 	const subscriptionEndsAt =
 		currentSubscription?.cancel_at ?? currentSubscription?.current_period_end ?? null;
-	const subscriptionPeriodLabel = shortDate(subscriptionEndsAt);
+	const subscriptionPeriodLabel = formatShortDate(subscriptionEndsAt);
 	const subscriptionCancelPending = !!currentSubscription?.cancel_at_period_end;
 	const canChangeBillingTerm =
 		isPerformance &&
@@ -1360,7 +1356,7 @@ function ComputeSettingsSections({
 			const res = await cancelSubscription.mutateAsync({ deployment_id: deployment.id });
 			toast.success("Subscription cancellation scheduled", {
 				description: res.current_period_end
-					? `Performance stays active until ${shortDate(res.current_period_end)}.`
+					? `Performance stays active until ${formatShortDate(res.current_period_end)}.`
 					: (res.message ?? undefined),
 			});
 		} catch (error) {

--- a/apps/web/src/hosted/billing/components/state-views.tsx
+++ b/apps/web/src/hosted/billing/components/state-views.tsx
@@ -85,6 +85,39 @@ export function WalletSkeleton() {
 	);
 }
 
+/** Usage: total cards + daily chart + by-model rows. */
+export function UsageSkeleton() {
+	return (
+		<div data-hosted="true" className="space-y-6">
+			<div className="grid gap-3 sm:grid-cols-2">
+				<CardSkeleton lines={1} />
+				<CardSkeleton lines={1} />
+			</div>
+			<Card data-hosted="true">
+				<CardHeader>
+					<Skeleton className="h-5 w-36" />
+				</CardHeader>
+				<CardContent>
+					<div className="flex h-28 items-end gap-1">
+						{Array.from({ length: 14 }, (_, i) => `day-${i}`).map((key, index) => (
+							<Skeleton
+								key={key}
+								className="flex-1 rounded-t"
+								style={{ height: `${Math.max(16, ((index % 7) + 2) * 10)}%` }}
+							/>
+						))}
+					</div>
+					<div className="mt-2 flex justify-between">
+						<Skeleton className="h-3 w-10" />
+						<Skeleton className="h-3 w-10" />
+					</div>
+				</CardContent>
+			</Card>
+			<CardSkeleton lines={5} />
+		</div>
+	);
+}
+
 /**
  * Normalized error panel with an optional retry. When the failure is a
  * session-expiry 401 we lead with a "Sign in again" action (a fresh retry

--- a/apps/web/src/hosted/billing/subscription/subscription-page.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-page.tsx
@@ -20,7 +20,7 @@ import { cn } from "@/lib/utils";
 const DESCRIPTION =
 	"Plan options for new hosted agents. Existing compute is managed from each agent’s Settings.";
 const SUBSCRIPTION_PAGE_CLASS = cn(
-	CENTERED_PAGE_WIDTH_CLASS.detail,
+	CENTERED_PAGE_WIDTH_CLASS.wide,
 	"flex flex-col gap-6 px-4 lg:px-6",
 );
 

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -1,13 +1,5 @@
 import type { BillingOffer, Plan } from "@/hosted/billing/contracts";
 
-/** Format an ISO date as a short, local calendar date. */
-export function shortDate(iso: string | null): string {
-	if (!iso) return "—";
-	const d = new Date(iso);
-	if (Number.isNaN(d.getTime())) return "—";
-	return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
-}
-
 /**
  * The plan's offer for a billing term, with a synthetic monthly offer when the
  * backend returns no offers — so callers always have a price to show.

--- a/apps/web/src/hosted/billing/usage/usage-page.tsx
+++ b/apps/web/src/hosted/billing/usage/usage-page.tsx
@@ -2,31 +2,32 @@
 
 import { Activity } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
-import { BillingEmpty, BillingError } from "@/hosted/billing/components/state-views";
+import { BillingEmpty, BillingError, UsageSkeleton } from "@/hosted/billing/components/state-views";
 import { formatCredits } from "@/hosted/billing/format";
 import { useUsage } from "@/hosted/billing/hooks";
-import { shortDate } from "@/hosted/billing/subscription/subscription-utils";
+import { formatShortDate } from "@/lib/format";
+import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "AI Credit consumption across your agents. Wallet credits do not reset.";
+const USAGE_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.wide, "space-y-6 px-4 lg:px-6");
 
 export function UsagePage() {
 	const usage = useUsage();
 
 	if (usage.isLoading) {
 		return (
-			<div data-hosted="true" className="space-y-6 px-4 lg:px-6">
+			<div data-hosted="true" className={USAGE_PAGE_CLASS}>
 				<PageHeader title="Usage" description={DESCRIPTION} />
-				<Skeleton className="h-28 w-full rounded-lg" />
-				<Skeleton className="h-48 w-full rounded-lg" />
+				<UsageSkeleton />
 			</div>
 		);
 	}
 
 	if (usage.error || !usage.data) {
 		return (
-			<div data-hosted="true" className="space-y-6 px-4 lg:px-6">
+			<div data-hosted="true" className={USAGE_PAGE_CLASS}>
 				<PageHeader title="Usage" description={DESCRIPTION} />
 				<BillingError error={usage.error} onRetry={() => usage.refetch()} />
 			</div>
@@ -39,7 +40,7 @@ export function UsagePage() {
 
 	if (u.total_credits === 0 && u.by_model.length === 0) {
 		return (
-			<div data-hosted="true" className="space-y-6 px-4 lg:px-6">
+			<div data-hosted="true" className={USAGE_PAGE_CLASS}>
 				<PageHeader title="Usage" description={DESCRIPTION} />
 				<BillingEmpty
 					icon={<Activity />}
@@ -51,10 +52,10 @@ export function UsagePage() {
 	}
 
 	return (
-		<div data-hosted="true" className="space-y-6 px-4 lg:px-6">
+		<div data-hosted="true" className={USAGE_PAGE_CLASS}>
 			<PageHeader
 				title="Usage"
-				description={`${shortDate(u.period_start)} – ${shortDate(u.period_end)} reporting window. Wallet credits do not reset.`}
+				description={`${formatShortDate(u.period_start)} – ${formatShortDate(u.period_end)} reporting window. Wallet credits do not reset.`}
 			/>
 
 			{/* Totals */}

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -3,6 +3,7 @@
 import { CreditCard } from "lucide-react";
 import { useState } from "react";
 import { PageHeader } from "@/components/page-header";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { Button } from "@/components/ui/button";
 import { LowBalanceBanner } from "@/hosted/billing/components/low-balance-banner";
 import { BillingError, WalletSkeleton } from "@/hosted/billing/components/state-views";
@@ -13,8 +14,10 @@ import { LedgerTable } from "@/hosted/billing/wallet/ledger-table";
 import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
 import { LEDGER_MAX_ROWS, LEDGER_PAGE_SIZE } from "@/hosted/billing/wallet/wallet-constants";
 import { X402Card } from "@/hosted/billing/wallet/x402-card";
+import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Your AI Credits balance, top-ups, and auto-reload.";
+const WALLET_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.wide, "space-y-6 px-4 lg:px-6");
 
 function scrollToAutoReload() {
 	document.getElementById("auto-reload")?.scrollIntoView({ behavior: "smooth", block: "center" });
@@ -28,7 +31,7 @@ export function WalletPage() {
 
 	if (wallet.isLoading) {
 		return (
-			<div data-hosted="true" className="space-y-6 px-4 lg:px-6">
+			<div data-hosted="true" className={WALLET_PAGE_CLASS}>
 				<PageHeader title="Wallet" description={DESCRIPTION} />
 				<WalletSkeleton />
 			</div>
@@ -37,7 +40,7 @@ export function WalletPage() {
 
 	if (wallet.error || !wallet.data) {
 		return (
-			<div data-hosted="true" className="space-y-6 px-4 lg:px-6">
+			<div data-hosted="true" className={WALLET_PAGE_CLASS}>
 				<PageHeader title="Wallet" description={DESCRIPTION} />
 				<BillingError error={wallet.error} onRetry={() => wallet.refetch()} />
 			</div>
@@ -47,7 +50,7 @@ export function WalletPage() {
 	const w = wallet.data;
 
 	return (
-		<div data-hosted="true" className="space-y-6 px-4 lg:px-6">
+		<div data-hosted="true" className={WALLET_PAGE_CLASS}>
 			<PageHeader
 				title="Wallet"
 				description={DESCRIPTION}

--- a/apps/web/src/lib/format.test.ts
+++ b/apps/web/src/lib/format.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { formatDuration, formatModelLabel } from "./format";
+import { formatDuration, formatModelLabel, formatShortDate } from "./format";
 
 describe("formatModelLabel", () => {
 	it.each([
@@ -68,5 +68,23 @@ describe("formatDuration", () => {
 		[7200, "2h 0m"],
 	])("%s → %s", (input, expected) => {
 		expect(formatDuration(input)).toBe(expected);
+	});
+});
+
+describe("formatShortDate", () => {
+	it("formats a short absolute date with year by default", () => {
+		const result = formatShortDate("2026-04-05T14:30:00Z");
+		expect(result).toMatch(/2026/);
+		expect(result).not.toBe("—");
+	});
+
+	it("can omit the year for compact meta labels", () => {
+		expect(formatShortDate("2026-04-05T14:30:00Z", { includeYear: false })).not.toMatch(/2026/);
+	});
+
+	it("returns em-dash for nullish or invalid values", () => {
+		expect(formatShortDate(null)).toBe("—");
+		expect(formatShortDate(undefined)).toBe("—");
+		expect(formatShortDate("garbage")).toBe("—");
 	});
 });

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -107,3 +107,16 @@ export function formatDuration(seconds: number | null | undefined): string {
 	if (mins < 60) return `${mins}m`;
 	return `${Math.floor(mins / 60)}h ${mins % 60}m`;
 }
+
+/** Short absolute calendar date for UI copy and compact meta labels. */
+export function formatShortDate(
+	value: string | null | undefined,
+	{ includeYear = true }: { includeYear?: boolean } = {},
+): string {
+	if (!value) return "—";
+	const d = new Date(value);
+	if (Number.isNaN(d.getTime())) return "—";
+	const options: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
+	if (includeYear) options.year = "numeric";
+	return d.toLocaleDateString(undefined, options);
+}

--- a/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
+++ b/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
@@ -8,6 +8,7 @@ import { getConnectorAuthFlow } from "@/components/connectors/auth-flow.logic";
 import { ConnectorIcon } from "@/components/connectors/connector-icon";
 import { ConnectorCredentialsDialog } from "@/components/connectors/credentials-dialog";
 import { DashboardSection, DashboardSectionHeader } from "@/components/dashboard/section";
+import { DetailTitle } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -264,7 +265,7 @@ function ConnectorDetail({ name }: { name: string }) {
 				<ConnectorIcon logo={app?.logo} name={displayName} size="lg" />
 				<div className="min-w-0 flex-1">
 					<div className="flex items-center gap-2">
-						<h1 className="text-lg font-semibold tracking-tight">{displayName}</h1>
+						<DetailTitle>{displayName}</DetailTitle>
 						{isReady && (
 							<Badge variant="secondary">
 								<Check />
@@ -348,7 +349,7 @@ function ConnectorDetail({ name }: { name: string }) {
 							/>
 						)
 					) : (
-						<div className="divide-y overflow-hidden rounded-lg border bg-background/60">
+						<div className="divide-y overflow-hidden rounded-lg border bg-card">
 							{activeConnections.map((c) => (
 								<div key={c.id} className="flex items-center justify-between gap-3 px-4 py-3">
 									<div className="min-w-0">

--- a/apps/web/src/pages/dashboard/connectors/page.tsx
+++ b/apps/web/src/pages/dashboard/connectors/page.tsx
@@ -208,9 +208,7 @@ function ConnectedRail({
 }) {
 	return (
 		<section>
-			<h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-				Connected
-			</h2>
+			<h2 className="mb-3 text-sm font-semibold">Connected</h2>
 			{error ? (
 				// Without this, a connections-fetch failure makes the rail
 				// silently disappear and the user only sees "X active" in
@@ -297,11 +295,7 @@ function CatalogSection({
 	}
 	return (
 		<section>
-			{labelled ? (
-				<h2 className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-					All Connectors
-				</h2>
-			) : null}
+			{labelled ? <h2 className="mb-3 text-sm font-semibold">All Connectors</h2> : null}
 			<div className={cn(CONNECTOR_GRID_CLASS, isFetching && "opacity-60 transition-opacity")}>
 				{items.map((app) => (
 					<ConnectorCard key={app.name} app={app} isConnected={connectedNames.has(app.name)} />

--- a/apps/web/src/pages/dashboard/memories/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/memories/[id]/page.tsx
@@ -6,7 +6,6 @@ import { Brain, Laptop, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { DetailMeta, DetailNotFound, DetailPanel, DetailTitle } from "@/components/detail/layout";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
@@ -14,7 +13,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { unwrap, useApi } from "@/lib/api";
 import { MEMORY_CATEGORY_COLORS } from "@/lib/memory-utils";
 import { projectResourceHref } from "@/lib/project-resource-model";
-import { cn, errorMessage, relativeTime } from "@/lib/utils";
+import { cn, errorMessage, formatAbsoluteTooltip, relativeTime } from "@/lib/utils";
 
 export default function MemoryDetailPage({ memoryId }: { memoryId: string }) {
 	const router = useRouter();
@@ -90,7 +89,7 @@ export default function MemoryDetailPage({ memoryId }: { memoryId: string }) {
 								{memory.created_at ? (
 									<>
 										<span>·</span>
-										<span title={new Date(memory.created_at).toLocaleString()}>
+										<span title={formatAbsoluteTooltip(memory.created_at)}>
 											Saved {relativeTime(memory.created_at)}
 										</span>
 									</>
@@ -177,11 +176,7 @@ export default function MemoryDetailPage({ memoryId }: { memoryId: string }) {
 					</DetailPanel>
 				</>
 			) : (
-				<Alert>
-					<Brain />
-					<AlertTitle>Nothing to show</AlertTitle>
-					<AlertDescription>This memory doesn't exist.</AlertDescription>
-				</Alert>
+				<DetailNotFound title="Memory not found" message="This memory doesn't exist." />
 			)}
 		</div>
 	);

--- a/apps/web/src/pages/dashboard/memories/page.tsx
+++ b/apps/web/src/pages/dashboard/memories/page.tsx
@@ -6,6 +6,7 @@ import { Link } from "@tanstack/react-router";
 import { AlertCircle, Brain, Database, Key, Laptop, Plus, Trash2 } from "lucide-react";
 import { type ReactNode, useCallback, useState } from "react";
 import { toast } from "sonner";
+import { EmptyState } from "@/components/empty-state";
 import { PageHeader } from "@/components/page-header";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -233,13 +234,24 @@ function MemoryNotesGrid({
 	onDelete: (id: string) => void;
 }) {
 	if (isLoading) {
+		const cardLineCounts = [4, 7, 3, 5, 6, 4, 8, 3, 5];
 		return (
 			<div className="columns-1 gap-4 sm:columns-2 xl:columns-3 [&>*]:mb-4 [&>*]:break-inside-avoid">
-				{Array.from({ length: 9 }).map((_, index) => (
+				{cardLineCounts.map((lineCount, index) => (
 					<div key={index} className="rounded-xl border bg-card p-4">
-						<Skeleton className="h-4 w-5/6" />
-						<Skeleton className="mt-2 h-4 w-2/3" />
-						<Skeleton className="mt-4 h-5 w-24" />
+						<div className="space-y-2">
+							{Array.from({ length: lineCount }).map((_, lineIndex) => (
+								<Skeleton
+									key={lineIndex}
+									className={cn("h-4", lineIndex === lineCount - 1 ? "w-2/3" : "w-full")}
+								/>
+							))}
+						</div>
+						<div className="mt-4 flex items-center gap-2">
+							<Skeleton className="h-5 w-24 rounded-full" />
+							<Skeleton className="h-3 w-14" />
+							<Skeleton className="ml-auto h-3 w-20" />
+						</div>
 					</div>
 				))}
 			</div>
@@ -247,11 +259,7 @@ function MemoryNotesGrid({
 	}
 
 	if (!memories.length) {
-		return (
-			<div className="rounded-xl border border-dashed px-4 py-16 text-center text-sm text-muted-foreground">
-				{emptyMessage}
-			</div>
-		);
+		return <EmptyState bordered fillHeight={false} description={emptyMessage} />;
 	}
 
 	return (

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -22,7 +22,7 @@ import {
 	agentDisplayName,
 	compareAgentEnvironments,
 } from "@/components/dashboard/agent-label";
-import { DetailPanel } from "@/components/detail/layout";
+import { DetailNotFound, DetailPanel, DetailTitle } from "@/components/detail/layout";
 import {
 	displayProjectName,
 	isCustomProject,
@@ -73,6 +73,7 @@ import { ApiError, unwrap, useApi } from "@/lib/api";
 import { formatApiError } from "@/lib/api-errors";
 import { fetchAllPages } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
+import { formatShortDate } from "@/lib/format";
 import { identityFor } from "@/lib/identity";
 import { projectDetailHref, projectResourceHref } from "@/lib/project-resource-model";
 import { cn, errorMessage } from "@/lib/utils";
@@ -241,9 +242,21 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 	if (projects.isLoading) {
 		return (
 			<div className="space-y-5 px-4 lg:px-6">
-				<Skeleton className="h-10 w-52" />
-				<Skeleton className="h-28 w-full" />
-				<Skeleton className="h-48 w-full" />
+				<Skeleton className="h-8 w-24" />
+				<div className="flex items-start gap-3">
+					<Skeleton className="size-11 rounded-xl" />
+					<div className="min-w-0 flex-1 space-y-2">
+						<Skeleton className="h-6 w-56 max-w-full" />
+						<Skeleton className="h-4 w-96 max-w-full" />
+						<Skeleton className="h-3 w-40" />
+					</div>
+				</div>
+				<div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+					{Array.from({ length: 4 }).map((_, i) => (
+						<Skeleton key={i} className="h-24 w-full rounded-xl" />
+					))}
+				</div>
+				<Skeleton className="h-40 w-full rounded-lg" />
 			</div>
 		);
 	}
@@ -274,12 +287,10 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 						Projects
 					</Link>
 				</Button>
-				<Alert>
-					<AlertTitle>Project not found</AlertTitle>
-					<AlertDescription>
-						This Project may have been removed, or your account no longer has access.
-					</AlertDescription>
-				</Alert>
+				<DetailNotFound
+					title="Project not found"
+					message="This Project may have been removed, or your account no longer has access."
+				/>
 			</div>
 		);
 	}
@@ -323,9 +334,7 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 					</span>
 					<div className="min-w-0">
 						<div className="flex min-w-0 flex-wrap items-center gap-2">
-							<h1 className="truncate text-xl font-semibold tracking-tight">
-								{displayProjectName(project)}
-							</h1>
+							<DetailTitle className="truncate">{displayProjectName(project)}</DetailTitle>
 							<ProjectKindBadge kind={project.kind} />
 						</div>
 						<p className="mt-1 text-sm text-muted-foreground">
@@ -898,7 +907,7 @@ function UseProjectWithAgentDialog({
 												titleAdornment={<AgentSourceBadgeForEnvironment env={env} compact />}
 												meta={[
 													env.last_sync_at
-														? `synced ${formatShortDate(env.last_sync_at)}`
+														? `synced ${formatShortDate(env.last_sync_at, { includeYear: false })}`
 														: "not synced yet",
 												]}
 											/>
@@ -1167,12 +1176,6 @@ function displayAgentName(env: Env) {
 	return agentDisplayName(env);
 }
 
-function formatShortDate(value: string) {
-	return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(
-		new Date(value),
-	);
-}
-
 function EmptyLine({ message }: { message: string }) {
 	return (
 		<div className="rounded-lg border border-dashed px-4 py-6 text-sm text-muted-foreground">
@@ -1183,8 +1186,8 @@ function EmptyLine({ message }: { message: string }) {
 
 function ErrorLine({ message }: { message: string }) {
 	return (
-		<div className="rounded-lg border border-dashed border-destructive/40 px-4 py-4 text-sm text-destructive">
-			{message}
+		<div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+			<span className="font-medium">Section unavailable.</span> {message}
 		</div>
 	);
 }

--- a/apps/web/src/pages/dashboard/projects/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/page.tsx
@@ -173,7 +173,7 @@ export default function ProjectsPage() {
 				<PageHeader title="Projects" description={PROJECTS_RESOURCE.managementDescription} />
 				<div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
 					{Array.from({ length: 6 }).map((_, i) => (
-						<Skeleton key={i} className="h-40 w-full rounded-xl" />
+						<ProjectCardSkeleton key={i} />
 					))}
 				</div>
 			</div>
@@ -402,6 +402,22 @@ function ProjectCard({
 			>
 				<span className="sr-only">Open {projectName}</span>
 			</Link>
+		</div>
+	);
+}
+
+function ProjectCardSkeleton() {
+	return (
+		<div className="flex min-h-36 flex-col gap-3 rounded-xl border bg-card p-5">
+			<Skeleton className="size-10 rounded-lg" />
+			<div className="min-w-0 space-y-2">
+				<Skeleton className="h-5 w-44 max-w-full" />
+				<Skeleton className="h-3 w-32" />
+			</div>
+			<div className="mt-auto flex items-center gap-3">
+				<Skeleton className="h-3 w-16" />
+				<Skeleton className="h-3 w-16" />
+			</div>
 		</div>
 	);
 }

--- a/apps/web/src/pages/dashboard/sessions/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/page.tsx
@@ -385,7 +385,7 @@ function SessionsListInner() {
 							/>
 						</div>
 					) : null}
-					<div className={cn("max-w-4xl", params.view === "table" && "md:hidden")}>
+					<div className={cn(params.view === "table" && "md:hidden")}>
 						<SessionFeed
 							sessions={data?.items ?? []}
 							isLoading={isLoading}

--- a/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
@@ -17,6 +17,8 @@ import { type ReactNode, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { BulkActionBar } from "@/components/bulk-action-bar";
+import { DetailNotFound, DetailTitle } from "@/components/detail/layout";
+import { EmptyState } from "@/components/empty-state";
 import { displayProjectName, isCustomProject } from "@/components/projects/project-metadata";
 import { ShareProjectDialog } from "@/components/sharing/share-project-dialog";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -246,8 +248,17 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 	if (vaults.isLoading) {
 		return (
 			<div className="space-y-5 px-4 lg:px-6">
-				<Skeleton className="h-10 w-52" />
-				<Skeleton className="h-40 w-full rounded-xl" />
+				<Skeleton className="h-8 w-20" />
+				<div className="flex items-start gap-3">
+					<Skeleton className="size-11 rounded-xl" />
+					<div className="min-w-0 flex-1 space-y-2">
+						<Skeleton className="h-6 w-48 max-w-full" />
+						<Skeleton className="h-4 w-96 max-w-full" />
+						<Skeleton className="h-3 w-40" />
+					</div>
+				</div>
+				<Skeleton className="h-36 w-full rounded-lg" />
+				<Skeleton className="h-24 w-full rounded-lg" />
 			</div>
 		);
 	}
@@ -261,12 +272,10 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 						Vaults
 					</Link>
 				</Button>
-				<Alert>
-					<AlertTitle>Vault not found</AlertTitle>
-					<AlertDescription>
-						This vault may have been removed, or your account no longer has access.
-					</AlertDescription>
-				</Alert>
+				<DetailNotFound
+					title="Vault not found"
+					message="This vault may have been removed, or your account no longer has access."
+				/>
 			</div>
 		);
 	}
@@ -295,7 +304,7 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 						{identityFor(vault.name).emoji}
 					</span>
 					<div className="min-w-0">
-						<h1 className="truncate text-xl font-semibold tracking-tight">{vault.name}</h1>
+						<DetailTitle className="truncate">{vault.name}</DetailTitle>
 						<p className="mt-1 text-sm text-muted-foreground">
 							{isOwner
 								? "Keys live here once and work in every Project this vault is added to."
@@ -426,13 +435,19 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 				{keys.isLoading ? (
 					<Skeleton className="h-32 w-full rounded-lg" />
 				) : keyNames.length === 0 ? (
-					<div className="rounded-lg border border-dashed px-4 py-10 text-center text-sm text-muted-foreground">
-						No keys yet. Add one above or paste several at once with Import.
-					</div>
+					<EmptyState
+						bordered
+						fillHeight={false}
+						title="No keys yet"
+						description="Add one above or paste several at once with Import."
+					/>
 				) : filteredKeyNames.length === 0 ? (
-					<div className="rounded-lg border border-dashed px-4 py-10 text-center text-sm text-muted-foreground">
-						No keys match that search.
-					</div>
+					<EmptyState
+						bordered
+						fillHeight={false}
+						title="No keys match that search"
+						description="Try another key name or section."
+					/>
 				) : (
 					/* Keys as compact cards: a 200-key vault scans far better in a
 				   multi-column grid than a one-column ledger. */
@@ -567,9 +582,12 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 					) : null}
 				</div>
 				{attachedProjects.length === 0 ? (
-					<div className="rounded-lg border border-dashed px-4 py-10 text-center text-sm text-muted-foreground">
-						Not added to any Project yet — agents can&apos;t use these keys until it is.
-					</div>
+					<EmptyState
+						bordered
+						fillHeight={false}
+						title="Not added to any Project yet"
+						description="Agents can't use these keys until this vault is added to a Project."
+					/>
 				) : (
 					<div className="divide-y overflow-hidden rounded-lg border bg-card">
 						{attachedProjects.map((project) => (

--- a/apps/web/src/pages/dashboard/vault/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/page.tsx
@@ -148,7 +148,7 @@ export default function VaultPage() {
 			) : vaults.isLoading ? (
 				<div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
 					{Array.from({ length: 3 }).map((_, i) => (
-						<Skeleton key={i} className="h-36 w-full rounded-xl" />
+						<VaultCardSkeleton key={i} />
 					))}
 				</div>
 			) : (
@@ -261,6 +261,22 @@ function VaultCard({
 			>
 				<span className="sr-only">Open vault {vault.name}</span>
 			</Link>
+		</div>
+	);
+}
+
+function VaultCardSkeleton() {
+	return (
+		<div className="flex min-h-36 flex-col gap-3 rounded-xl border bg-card p-5">
+			<Skeleton className="size-10 rounded-lg" />
+			<div className="min-w-0 space-y-2">
+				<Skeleton className="h-5 w-40 max-w-full" />
+				<Skeleton className="h-3 w-28" />
+			</div>
+			<div className="mt-auto flex items-center gap-3">
+				<Skeleton className="h-3 w-12" />
+				<Skeleton className="h-3 w-32" />
+			</div>
 		</div>
 	);
 }

--- a/apps/web/src/pages/public-share/session-page.tsx
+++ b/apps/web/src/pages/public-share/session-page.tsx
@@ -8,6 +8,7 @@ import { AgentInline } from "@/components/dashboard/agent-label";
 import { DetailMeta, DetailStats, DetailTitle } from "@/components/detail/layout";
 import { ModelBadge } from "@/components/meta/model-badge";
 import { Stat } from "@/components/meta/stat";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { MessageList } from "@/components/sessions/message-list";
 import { SessionSidebar } from "@/components/sessions/session-sidebar";
 import { ShareHeaderUser } from "@/components/share/header-user";
@@ -144,7 +145,7 @@ export default async function PublicSharePage({ id }: { id: string }) {
 			    scroll on narrow screens. `w-full` (`width: 100%`) restores
 			    the "fill body, capped at max-w-4xl, then centered"
 			    behavior that the visual design already assumed. */}
-			<div className="mx-auto w-full max-w-4xl space-y-5 px-4 py-6 lg:px-6">
+			<div className={`${CENTERED_PAGE_WIDTH_CLASS.detail} space-y-5 px-4 py-6 lg:px-6`}>
 				{/* Below `sm` (640px), controls drop under the title block —
 				    a long summary then claims the full row instead of fighting
 				    two icon buttons for ~80px on a 320px screen. Reverts to


### PR DESCRIPTION
## Summary

### Width
- Unified billing usage, wallet, and compute settings pages on `CENTERED_PAGE_WIDTH_CLASS.wide`.
- Replaced public share session hand-rolled `max-w-4xl` with `CENTERED_PAGE_WIDTH_CLASS.detail`.
- Kept resource list pages full-bleed and made sessions feed/table share that same page width.

### Titles
- Switched project detail, vault detail, and connector detail headers to `DetailTitle`.

### Labels
- Normalized connector list in-page headings to `h2 text-sm font-semibold` for Connected and All Connectors.
- Kept small grouped captions, such as Suggested skills, in the uppercase-xs style.

### States
- Replaced memories list and vault detail dashed empty boxes with `EmptyState`.
- Replaced memory, vault, and project detail not-found fallbacks with `DetailNotFound`.
- Kept project detail `ErrorLine` as a lighter inline section error, with a consistent destructive panel shape.

### Skeletons
- Added content-shaped skeletons for usage, projects list, vault list, memories list, project detail, and vault detail.

### Tokens
- Changed connector detail account rows from `bg-background/60` to `bg-card`.
- Added shared `formatShortDate` in `lib/format` with tests and moved billing/hosted/project date callsites to it.

## Verification
- `bun run --cwd apps/web typecheck`
- `bun run check`
- `bun run --cwd apps/web test`
- Local screenshots captured at 1440px and 390px for billing trio, memories, vault list/detail, projects list/detail, connector detail, and sessions feed/table.

🤖 Generated with paseo codex.