### PR TITLE
Add contributor dev and API compatibility guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,15 +6,137 @@ This is the canonical repo-wide instruction file for coding agents. Agent-specif
 entrypoints such as `CLAUDE.md` should point here instead of duplicating these
 instructions.
 
+## Start Here
+
+Clawdi Cloud is an OSS cross-agent sync and recall layer. The local CLI reads
+agent sessions and skills from Claude Code, Codex, Hermes, and OpenClaw, syncs
+them to a FastAPI backend, exposes shared memory/vault/project data, and powers
+a TanStack dashboard on the same backend.
+
+1. Read this file first, then use the linked docs below for details.
+2. Keep code, comments, docs, file names, and identifiers in English.
+3. Keep OSS boundaries clean: production and hosted operations are managed
+   outside this repository by first-party hosted control planes; this repo does
+   not contain production addresses or hosted-service runbooks.
+
 ## Project Structure
 
 ```
 apps/web/          TanStack Start dashboard (Clerk auth, shadcn/ui, Tailwind v4)
 packages/cli/      CLI tool (TypeScript, Bun)
 packages/shared/   Shared types, constants, utilities
+packages/whatsapp-baileys-sidecar/  WhatsApp channel sidecar package
 backend/           Python FastAPI backend (async PostgreSQL, Clerk JWT)
 docs/              Documentation, plans, scenarios
 ```
+
+## Local End-to-End
+
+Install dependencies once:
+
+```bash
+bun install
+```
+
+Configure the local backend in terminal 1, from the repository root:
+
+```bash
+docker compose up -d postgres
+cd backend
+cp .env.example .env
+uv sync
+```
+
+In `backend/.env`, set `DEV_AUTH_BYPASS=true`, keep
+`DEV_AUTH_TOKEN=dev-bypass`, and set different local-only
+`VAULT_ENCRYPTION_KEY` and `ENCRYPTION_KEY` values. Set `ADMIN_API_KEY` to your
+own local random value if you want to mint CLI keys through the local admin API.
+
+In that same `backend/` shell, run migrations and the backend:
+
+```bash
+pdm migrate
+pdm dev
+```
+
+Start the dashboard in terminal 2, from the repository root, with matching
+bypass values:
+
+```bash
+cd apps/web
+cp .env.example .env.local
+# Set VITE_DEV_AUTH_BYPASS=true and VITE_DEV_AUTH_TOKEN=dev-bypass in .env.local.
+bun run dev
+```
+
+Open `http://localhost:3000`. Create an API key in the local dashboard, or use
+`docs/backend-development.md#local-admin-api` with the `ADMIN_API_KEY` value
+from your own `backend/.env`.
+
+Then point the dev CLI at the local backend in terminal 3, from the repository
+root:
+
+```bash
+bun run packages/cli/src/index.ts config set apiUrl http://localhost:8000
+bun run packages/cli/src/index.ts auth login --manual  # paste the local API key
+bun run packages/cli/src/index.ts setup
+bun run packages/cli/src/index.ts doctor
+```
+
+## Test Suites
+
+```bash
+bun run typecheck                  # Turbo TypeScript check
+bun run test                       # Turbo JS/TS tests
+bun run check                      # Biome CI check
+```
+
+```bash
+bun run --cwd apps/web typecheck
+bun run --cwd apps/web test
+bun run --cwd apps/web build:oss
+bun run --cwd packages/cli typecheck
+bun run --cwd packages/cli test
+bun test packages/shared/src
+bun run --cwd packages/whatsapp-baileys-sidecar typecheck
+bun run --cwd packages/whatsapp-baileys-sidecar test
+```
+
+Backend tests require a Postgres database migrated to this branch's Alembic
+head. Use the throwaway-Postgres pattern in
+`docs/backend-development.md#verification`, then run:
+
+```bash
+cd backend
+uv run ruff check .
+uv run ruff format --check .
+uv run python -m compileall app scripts tests alembic
+uv run pytest -q
+```
+
+## Key Docs
+
+- `docs/backend-development.md` — backend dev loop, throwaway Postgres tests,
+  Alembic, generated API client, local DB/admin debugging.
+- `docs/frontend-development.md` — web dev loop, Bun commands, OSS build
+  boundary, frontend tests.
+- `docs/api-compatibility.md` — `/v1/agents`, deprecated environment aliases,
+  hidden `/api` aliases, additive-only compatibility.
+- `docs/architecture.md` — current system map and module ownership.
+- `docs/adr/0001-agent-identity-is-the-stable-domain-object.md` — Agent
+  identity terminology and compatibility invariants.
+- `docs/cli-development.md` — CLI-specific dev, tests, packaging, release notes.
+
+## Repeated Gotchas
+
+- Backend pytest does not bootstrap schema; always migrate a throwaway Postgres
+  to the current branch head before running tests.
+- Never hand-edit `packages/shared/src/api/api.generated.ts`; regenerate and run
+  `backend/scripts/check_generated_api.py`.
+- API compatibility is additive-only for released surfaces; old fields, shapes,
+  status codes, and error bodies stay stable.
+- Do not bulk-rewrite `/api` strings that belong to external wire formats such
+  as Discord v10, BlueBubbles, OpenAI-compatible URLs, Composio, or fixtures.
 
 ## Product Terminology
 
@@ -26,9 +148,8 @@ docs/              Documentation, plans, scenarios
   repository may define API contracts, dashboard UI, and CLI behavior that
   integrate with hosted agents, but it does not contain the hosted agent runtime
   service itself.
-- Do not mention private repository names, internal checkout paths, production
-  hosts, runtime orchestration details, or deployment topology in this OSS
-  repository.
+- Do not add non-OSS repository names, checkout paths, production addresses, or
+  hosted-service run details to this OSS repository.
 - Avoid introducing legacy repo/path names in new examples unless the
   surrounding text is explicitly about public backwards compatibility.
 

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -831,3 +831,13 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { startInstance } from './start.ts'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>
+  }
+}

--- a/apps/web/tsr.config.json
+++ b/apps/web/tsr.config.json
@@ -1,0 +1,5 @@
+{
+	"routeTreeFileFooter": [
+		"import type { getRouter } from './router.tsx'\nimport type { startInstance } from './start.ts'\ndeclare module '@tanstack/react-start' {\n  interface Register {\n    ssr: true\n    router: Awaited<ReturnType<typeof getRouter>>\n    config: Awaited<ReturnType<typeof startInstance.getOptions>>\n  }\n}"
+	]
+}

--- a/docs/adr/0001-agent-identity-is-the-stable-domain-object.md
+++ b/docs/adr/0001-agent-identity-is-the-stable-domain-object.md
@@ -81,9 +81,10 @@ codes, and error bodies remain unchanged. New optional response fields such as
 `name`, `default_name`, and `explicit_identity` are additive safe fields for old
 clients.
 
-Hosted control planes register through the admin API. `/v1/admin/agents` accepts
-`agent_id` for agent-first callers. `/v1/admin/environments` remains intact for
-the hosted control plane until that separate service migrates.
+First-party hosted control planes register through the admin API.
+`/v1/admin/agents` accepts `agent_id` for agent-first callers.
+`/v1/admin/environments` remains intact for those control planes until that
+separate service migration is complete.
 
 They may supply an explicit caller-owned stable id. The supplied id is the
 agent identity. Re-registration with the same user and same id refreshes
@@ -110,6 +111,8 @@ conflict. Explicit-identity rows use `registration_key = NULL`.
 - User-facing deletion and disconnect behavior must preserve caller-owned
   explicit identities.
 - The legacy database and wire names remain supported for compatibility.
+- Contributor-facing API compatibility rules live in
+  [`docs/api-compatibility.md`](../api-compatibility.md).
 
 ## Migration Direction
 

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -1,0 +1,104 @@
+# API compatibility
+
+This policy describes the API compatibility contract currently in force for
+Clawdi Cloud. It is grounded in the FastAPI routes and regression tests in this
+repository, especially `backend/app/main.py`,
+`backend/app/routes/sessions.py`, `backend/app/routes/admin.py`,
+`backend/tests/test_api_version_alias.py`, and
+`backend/tests/test_agent_endpoints.py`.
+
+For the domain decision behind the naming, read
+[`ADR-0001`](adr/0001-agent-identity-is-the-stable-domain-object.md). For the
+system map, read [`architecture.md`](architecture.md#api-surface).
+
+## Canonical surface
+
+`/v1/agents` is the canonical first-party API for Agent identity. New dashboard
+and CLI code should use `/v1/agents` and `agent_id` path parameters for
+registration, listing, detail reads, updates, ordering, avatars, disconnect, and
+sync heartbeat.
+
+`/v1/admin/agents` is the agent-first admin route family for local/admin callers
+that use `X-Admin-Key`. Admin routes are live but hidden from the public OpenAPI
+schema because `backend/app/routes/admin.py` sets `include_in_schema=False`.
+
+The stable agent id is still stored in `agent_environments.id`; code and older
+wire contracts still use `AgentEnvironment` and `environment_id` names in many
+places. Treat `environment_id` as the legacy wire name for the same stable
+Agent identity wherever that field still exists.
+
+## Compatibility aliases
+
+`/v1/environments*` endpoints are deprecated compatibility aliases. Public
+environment routes are marked `deprecated=True` in OpenAPI and invoke the same
+shared helpers as the corresponding agent routes. They keep existing
+`environment_id` request and response shapes.
+
+`/v1/admin/environments*` endpoints are the admin compatibility aliases. They
+delegate to the same admin helpers as `/v1/admin/agents*`, but admin routes are
+hidden from public OpenAPI.
+
+Legacy `/api/*` mounts are hidden aliases for clients built before the `/v1`
+prefix migration. `backend/app/main.py` mounts every versioned router once under
+`/v1` and once under `/api` with `include_in_schema=False`.
+`backend/tests/test_api_version_alias.py` enforces that every `/v1` route has
+the `/api` alias and that public OpenAPI advertises only `/v1/*` plus
+`/health`.
+
+## Additive-only contract
+
+Compatibility surfaces are additive-only:
+
+- Do not remove or rename pre-existing request fields, response fields,
+  response shapes, status codes, or error bodies.
+- Do not change the semantics of existing fields. For example,
+  `environment_id` remains the stable agent id on legacy/session payloads.
+- New optional response fields are allowed when old clients can ignore them.
+  Existing examples include `name`, `default_name`, and `explicit_identity`.
+- New canonical agent routes may expose agent-shaped responses, but legacy
+  environment aliases must preserve their environment-shaped response fields.
+
+Released CLIs from `v0.7.0` onward must keep working against supported servers.
+When in doubt, add a regression test that exercises the old path and payload
+before changing the handler.
+
+## Generated clients
+
+OpenAPI feeds the shared TypeScript client used by both web and CLI:
+
+- Source: `packages/shared/src/api/api.generated.ts`
+- Ergonomic web aliases: `packages/shared/src/api/schemas.ts`
+- CLI aliases: `packages/cli/src/lib/api-schemas.ts`
+
+Never hand-edit `api.generated.ts`. After backend schema changes, run the
+workflow in [`backend-development.md`](backend-development.md#generated-api-client)
+and commit the generated file with the schema change.
+
+Because `/api/*` aliases and admin routes are hidden from public OpenAPI, the
+generated client should use `/v1/*` paths only.
+
+## Do not bulk-rewrite every `/api` string
+
+Some `/api` strings are external protocol shapes, persisted compatibility data,
+or test fixtures. They are not Clawdi's legacy route prefix and must not be
+rewritten mechanically. Examples in this repository include:
+
+- Discord REST paths such as `/api/v10/*`.
+- BlueBubbles-compatible paths such as `/api/v1/*`.
+- OpenAI-compatible base URLs ending in `/api/v1`.
+- Composio API URLs.
+- Captured provider fixtures under `backend/tests/fixtures/`.
+- Runtime MITM profile tests that intentionally match external `/api/` paths.
+
+Only rewrite a `/api` string after verifying the owning protocol and call site.
+
+## Change checklist
+
+Before merging API-shape changes:
+
+1. Prefer new first-party code on `/v1/agents` and `agent_id`.
+2. Preserve `/v1/environments*` and hidden `/api/*` behavior for old clients.
+3. Keep legacy fields, status codes, and error bodies stable.
+4. Add or update compatibility tests for old paths.
+5. Regenerate and check `packages/shared/src/api/api.generated.ts`.
+6. Audit external `/api` strings before broad search-and-replace edits.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-High-level map of what's actually in Clawdi Cloud today — updated as the code changes. For end-user docs, see the top-level [`README.md`](../README.md) and [`using-clawdi-with-claude-code.md`](using-clawdi-with-claude-code.md).
+High-level map of what's actually in Clawdi Cloud today — updated as the code changes. For end-user docs, see the top-level [`README.md`](../README.md) and [`using-clawdi-with-claude-code.md`](using-clawdi-with-claude-code.md). For contributor workflow docs, start in [`AGENTS.md`](../AGENTS.md).
 
 ---
 
@@ -35,10 +35,10 @@ Clawdi Cloud is a cross-agent sync + recall layer. A local CLI (`clawdi`) reads 
 └──────────────────────┘                          └────────────────┘
 
 ┌──────────────────────┐  Runtime manifest / state ┌──────────────────────┐
-│ Hosted control plane │──────────────────────────▶│ Managed runtime CLI  │
-│ (external service)   │                           │  - runtime init/watch│
-└──────────────────────┘                           │  - run configs       │
-        ▲                                          │  - sidecar modules        │
+│ First-party hosted   │──────────────────────────▶│ Managed runtime CLI  │
+│ control planes       │                           │  - runtime init/watch│
+│ (external services)  │                           │  - run configs       │
+└──────────────────────┘                           │  - sidecar modules   │
         │ Control UI + Terminal contracts          └──────────┬───────────┘
         └─────────────────────────────────────────────────────▼
                                                    ┌──────────────────────┐
@@ -71,8 +71,12 @@ the stable agent id.
 
 Admin has both `/v1/admin/agents` and `/v1/admin/environments`. The agent route
 accepts `agent_id` for new first-party admin callers. The environment route is
-still fully supported because the hosted control plane migration is a separate
-cross-service change.
+still fully supported because first-party hosted control planes migrate on a
+separate service timeline.
+
+Contributor policy: [`api-compatibility.md`](api-compatibility.md) is the
+source of truth for additive-only compatibility, generated clients, and `/api`
+alias handling.
 
 ---
 
@@ -84,7 +88,7 @@ All keyed off Clerk `user_id`:
 |---|---|---|
 | `users` | Clerk user mirror + email | Sign-in |
 | `api_keys` | SHA-256-hashed CLI bearer tokens | Dashboard |
-| `agent_environments` | Agent identity rows. The domain object is Agent; `AgentEnvironment` and `environment_id` are legacy persistence/wire names kept for compatibility. `id` is the stable agent id; self-managed agents use `registration_key` only for setup idempotency; hosted control planes may supply caller-owned stable agent ids. See [ADR-0001](adr/0001-agent-identity-is-the-stable-domain-object.md). `agent_type ∈ {claude_code, codex, hermes, openclaw}` | `POST /v1/agents`, admin hosted agent registration |
+| `agent_environments` | Agent identity rows. The domain object is Agent; `AgentEnvironment` and `environment_id` are legacy persistence/wire names kept for compatibility. `id` is the stable agent id; self-managed agents use `registration_key` only for setup idempotency; first-party hosted control planes may supply caller-owned stable agent ids. See [ADR-0001](adr/0001-agent-identity-is-the-stable-domain-object.md). `agent_type ∈ {claude_code, codex, hermes, openclaw}` | `POST /v1/agents`, admin hosted agent registration |
 | `projects` | Resource availability boundaries for skills, vault attachments, and future memory/session grouping. Kinds are `personal`, `environment`, and `workspace`; `environment` is the internal Agent Project kind | Provisioning, `clawdi setup`, `clawdi project create` |
 | `project_memberships` | Viewer-only shared Project access granted by invite or share link | Share accept / invite accept |
 | `project_share_links` | Hashed bearer links for read-only Project access. Raw tokens are only returned once | `clawdi project share` |
@@ -97,7 +101,7 @@ All keyed off Clerk `user_id`:
 | `user_settings` | Opaque JSONB per-user prefs: `memory_provider` (`builtin` / `mem0`), `mem0_api_key` | `PATCH /v1/settings` |
 | `channel_accounts` + `channel_bot_agent_links` + `channel_secrets` + `channel_bindings` + `channel_binding_aliases` + `channel_pair_codes` + `channel_messages` + `channel_deliveries` + `channel_agent_credentials` + `channel_whatsapp_auth_certs` | Native Channels control plane and agent-facing emulation state. Accounts own external bot/provider identity, visibility, webhook secrets, and provider credentials; public preconfigured accounts can be linked by many users while private accounts stay owner-only; bot-agent links own hashed agent SDK tokens and agent routing; extra provider secrets are AES-GCM encrypted; bindings and aliases map each external chat session to one active bot-agent link and actor-scoped pair control; pair codes authorize chat binding or re-binding; messages record routed traffic and inbox cursors; deliveries provide the DB outbox; WhatsApp agent credentials and auth certs persist Baileys-facing identity material. See `docs/designs/native-channels-product-model.md` for the product model. | `/v1/channels`, `/v1/channels/telegram/*`, `/v1/channels/discord/*`, `/v1/channels/whatsapp/*`, `/v1/channels/imessage/*`, `pdm run channels-worker` |
 
-Hosted deployment persistence is owned by the hosted agent service, not by the OSS backend tables above. This repository consumes that service through generated API contracts, the dashboard UI, the mock deploy API used for local development, and the CLI managed-runtime contract.
+Hosted deployment persistence is owned by first-party hosted control planes, not by the OSS backend tables above. This repository consumes those services through generated API contracts, the dashboard UI, the mock deploy API used for local development, and the CLI managed-runtime contract.
 
 There is no `cron_job` / `celery` / `background_task` table — those were in the original plan but never built. See [What's not implemented](#whats-not-implemented) below.
 
@@ -228,7 +232,7 @@ Public contract: [`managed-runtime.md`](managed-runtime.md).
 
 ```mermaid
 flowchart TB
-    CP[Hosted control plane] -->|hosted manifest response| Source[manifest-source]
+    CP[First-party hosted control planes] -->|hosted manifest response| Source[manifest-source]
     Source -->|normalized desired state| Init[clawdi runtime init]
 
     subgraph Durable["Durable non-secret state"]
@@ -380,9 +384,9 @@ runtime web application.
 
 ### Ownership Boundaries
 
-- The control plane owns identity, desired-state generation, secret resolution,
-  deployment selection, rollout, billing policy, and terminal session
-  authorization.
+- First-party hosted control planes own identity, desired-state generation,
+  secret resolution, deployment selection, rollout, billing policy, and terminal
+  session authorization.
 - The CLI owns manifest validation, local convergence, runtime install
   orchestration where the CLI is the local convergence tool, non-secret
   projections, run config, support process state, short-lived secret projection,
@@ -459,7 +463,6 @@ Several items were considered but not built. Named for discoverability if someon
 - **CronJobs** — no `cron_job` table, no scheduler. `scripts/embed_memories.py` exists as a manual operator-level tool.
 - **Channels provider coverage** — the Clawdi-native control plane plus Python-native Telegram Bot API, Discord REST/Gateway/rate-limit handling, WhatsApp Cloud API/Graph plus Baileys credential/Noise/IQ/relay/media boundary handling, and iMessage/BlueBubbles HTTP/query/webhook/attachment/Socket.IO slices exist. Outbound delivery, agent webhook redelivery, and Discord Gateway inbound dispatch run through the DB-backed `pdm run channels-worker` stack; WhatsApp Baileys outbound relay reaches that outbox through a transparent channel runtime adapter that converts sendable WAProto into validated Cloud API `providerPayload` for text/reply/public-link image/audio, relays Cloud-native raw status nodes for read receipts and typing indicators, and routes remaining Baileys-only media, voice-note/audio, group proto, and relay-attr messages to a registered native transport instead of route-local persistence. The FastAPI websocket reaches real Baileys `connection: open` plus DB-inbox `messages.upsert` delivery in the opt-in smoke, including quoted reply, image envelope, and group participant/sender-key fixture shapes. Discord Gateway capture uses per-account Postgres advisory locks inside that worker stack. WhatsApp debug health reports whether the native transport is unavailable, disconnected, `in_process`, or `sidecar` and which native relay capabilities it exposes. A minimal Clawdi-owned Baileys sidecar runtime package and FastAPI registration path exist for the remaining WhatsApp Web live protocol adapter; the legacy TypeScript router remains excluded. Opt-in smoke starts the sidecar against the FastAPI Baileys runtime; remaining work is deployment-level sidecar supervision and real linked-account upstream smoke.
 - **Cognee memory provider** — only `Builtin` and `Mem0`.
-- **Browser-based `clawdi auth login`** — the implemented flow is "paste your API key", same UX but no OAuth dance.
 - **`bun build --compile` single-binary distribution** — currently `bun link` over the workspace.
 
 If you pick any of these up, add an ADR or module plan under `docs/plans/` before implementing — this top-level doc is descriptive of what exists, not speculative.

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -1,0 +1,240 @@
+# Backend development
+
+Guide for contributors working on `backend/`. Commands in this document assume
+you start at the repository root unless a command changes directory.
+
+## Local backend loop
+
+Start the development Postgres service first. The root `docker-compose.yml`
+uses `pgvector/pgvector:pg16`, exposes Postgres on `127.0.0.1:5433`, and keeps
+the backend process on the host for reload speed.
+
+```bash
+docker compose up -d postgres
+cd backend
+cp .env.example .env
+uv sync
+pdm migrate
+pdm dev
+```
+
+`pdm dev` is defined in `backend/pyproject.toml` as:
+
+```bash
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+For local dashboard testing without Clerk, set these local-only values before
+starting the backend and web app:
+
+```dotenv
+# backend/.env
+DEV_AUTH_BYPASS=true
+DEV_AUTH_TOKEN=dev-bypass
+```
+
+`backend/.env.example` also leaves `VAULT_ENCRYPTION_KEY` and
+`ENCRYPTION_KEY` blank. Generate different local-only values before exercising
+vault or MCP bridge paths:
+
+```bash
+python3 -c 'import os; print(os.urandom(32).hex())'
+```
+
+## Verification
+
+Run these before sending backend changes for review:
+
+```bash
+cd backend
+uv run ruff check .
+uv run ruff format --check .
+uv run python -m compileall app scripts tests alembic
+```
+
+Backend tests require a real PostgreSQL database with `pgvector` and `pg_trgm`
+available. The pytest fixtures read `DATABASE_URL` and do not create or migrate
+the schema for you; the database must already be at this branch's Alembic head.
+
+Long-lived shared test databases rot because other branches migrate or stamp
+them differently. The reliable pattern is a throwaway Postgres on a free port:
+
+```bash
+CID=$(
+  docker run --rm -d \
+    -e POSTGRES_USER=clawdi \
+    -e POSTGRES_PASSWORD=clawdi_test \
+    -e POSTGRES_DB=clawdi_test \
+    -p 127.0.0.1::5432 \
+    pgvector/pgvector:pg16
+)
+cleanup() {
+  docker rm -f "$CID" >/dev/null
+}
+trap cleanup EXIT
+until docker exec "$CID" pg_isready -U clawdi -d clawdi_test >/dev/null 2>&1; do
+  sleep 1
+done
+PORT=$(docker port "$CID" 5432/tcp | sed 's/.*://')
+export DATABASE_URL="postgresql+asyncpg://clawdi:clawdi_test@127.0.0.1:${PORT}/clawdi_test"
+
+cd backend
+uv run alembic upgrade head
+uv run pytest -q
+```
+
+For focused work, keep the same throwaway database and run targeted tests:
+
+```bash
+cd backend
+uv run pytest tests/test_agent_endpoints.py -q
+uv run pytest tests/test_api_version_alias.py -q
+uv run pytest tests/test_agent_default_name_migration.py -q
+```
+
+## Alembic migrations
+
+Alembic versions live in `backend/alembic/versions/`. The current branch has a
+single Alembic head; verify before adding a migration:
+
+```bash
+cd backend
+uv run alembic heads
+```
+
+Conventions:
+
+- Chain new revisions from the current head. Do not create a side head unless
+  you are intentionally writing a merge revision.
+- Keep `upgrade()` transactional where PostgreSQL allows it. Avoid manual
+  commits inside migrations unless the lock profile requires a separate
+  migration and the behavior is documented in the migration file.
+- Write `downgrade()` deliberately. Reverse schema changes where practical; if
+  a data cleanup cannot be perfectly reversed, keep the schema downgrade safe
+  and explain the irreversible part in the migration comments.
+- Add a focused migration test when a revision performs data backfills, complex
+  PostgreSQL DDL, compatibility cleanup, or an irreversible operation. Existing
+  migration tests load the migration module, run real Alembic operations through
+  `Operations(MigrationContext.configure(...))`, and isolate scratch tables in a
+  temporary schema.
+
+## Generated API client
+
+`packages/shared/src/api/api.generated.ts` is generated from FastAPI OpenAPI.
+Never hand-edit it.
+
+When backend request or response schemas change:
+
+```bash
+# Terminal 1
+cd backend
+pdm dev
+
+# Terminal 2, from repo root
+bun run generate-api
+cd backend
+uv run python scripts/check_generated_api.py
+```
+
+`scripts/check_generated_api.py` imports the FastAPI app, generates a temporary
+OpenAPI TypeScript client with `bunx openapi-typescript`, and diffs it against
+the committed file. Commit generated updates together with the backend schema
+change so both web and CLI callers see the same types.
+
+## Local database inspection
+
+For the default dev database:
+
+```bash
+psql postgresql://clawdi:clawdi_dev@localhost:5433/clawdi
+```
+
+For a custom async SQLAlchemy URL, strip the `+asyncpg` driver when invoking
+`psql`:
+
+```bash
+psql "${DATABASE_URL/+asyncpg/}"
+```
+
+Useful tables while debugging local setup, sync, auth, and session uploads:
+
+```sql
+select id, clerk_id, email, skills_revision, created_at
+from users
+order by created_at desc
+limit 10;
+
+select id, user_id, machine_name, agent_type,
+       registration_key is null as explicit_identity,
+       default_project_id, last_seen_at
+from agent_environments
+order by created_at desc
+limit 10;
+
+select id, user_id, environment_id, key_prefix, label,
+       scopes, revoked_at, last_used_at
+from api_keys
+order by created_at desc
+limit 10;
+
+select id, user_id, environment_id, local_session_id,
+       project_path, status, last_activity_at, updated_at
+from sessions
+order by updated_at desc
+limit 10;
+```
+
+## Local admin API
+
+Admin endpoints are disabled by default. To exercise them locally, set
+`ADMIN_API_KEY` in `backend/.env` to your own local-only random value and
+restart `pdm dev`. Do not commit or share that value.
+
+The backend reads that value as `settings.admin_api_key`; requests must send it
+in the `X-Admin-Key` header. Empty configuration returns `503`, and an
+incorrect header returns `401`.
+
+Mint a local API key for the dev-auth dashboard user. Use the same
+`ADMIN_API_KEY` value that your local backend read from `backend/.env`:
+
+```bash
+export ADMIN_API_KEY="<value-from-backend-env>"
+curl -sS -X POST http://localhost:8000/v1/admin/auth/keys \
+  -H "X-Admin-Key: ${ADMIN_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{"target_clerk_id":"dev_browser","label":"local-cli"}' \
+  | jq -r .raw_key
+```
+
+Register an explicit local agent identity through the agent-first admin route:
+
+```bash
+export AGENT_ID=$(python3 -c 'import uuid; print(uuid.uuid4())')
+curl -sS -X POST http://localhost:8000/v1/admin/agents \
+  -H "X-Admin-Key: ${ADMIN_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"target_clerk_id\":\"dev_browser\",
+    \"agent_id\":\"${AGENT_ID}\",
+    \"machine_id\":\"local-debug\",
+    \"machine_name\":\"Local Debug\",
+    \"agent_type\":\"codex\",
+    \"agent_version\":\"dev\",
+    \"os_name\":\"linux\"
+  }"
+```
+
+Use `/v1/admin/agents` for new local debugging. `/v1/admin/environments`
+remains a compatibility alias, but admin routes are hidden from the public
+OpenAPI schema.
+
+## Logs in development
+
+Backend logs go to the terminal running `pdm dev`; there is no repo-managed log
+file in local development. Uvicorn prints reload and access output, and the app
+uses Python `logging` with `logging.basicConfig(level=logging.INFO)` in
+`app/main.py`.
+
+`RequestTimingMiddleware` adds `X-Process-Time-Ms` to HTTP responses. Requests
+at or above `SLOW_REQUEST_LOG_MS` log as `request_slow`; 5xx responses log as
+`request_error`, and uncaught exceptions log as `request_failed`.

--- a/docs/backend-development.md
+++ b/docs/backend-development.md
@@ -143,10 +143,21 @@ change so both web and CLI callers see the same types.
 
 ## Local database inspection
 
+If Alembic cannot locate a revision on the persistent dev database, the Docker
+volume was likely stamped by another branch; reset it with
+`docker compose down -v`, then restart Postgres and rerun `pdm migrate`.
+
 For the default dev database:
 
 ```bash
 psql postgresql://clawdi:clawdi_dev@localhost:5433/clawdi
+```
+
+That command requires the `psql` client on your host. If it is not installed,
+use the repo's compose service instead:
+
+```bash
+docker compose exec postgres psql -U clawdi -d clawdi
 ```
 
 For a custom async SQLAlchemy URL, strip the `+asyncpg` driver when invoking

--- a/docs/frontend-development.md
+++ b/docs/frontend-development.md
@@ -1,0 +1,99 @@
+# Frontend development
+
+Guide for contributors working on `apps/web/`. The web app is a TanStack Start
+dashboard built with React 19, TanStack Router, Tailwind v4, shadcn/ui, TanStack
+Query, Zustand, and Clerk.
+
+## Local web loop
+
+Install workspace dependencies from the repository root:
+
+```bash
+bun install
+```
+
+Run the backend first if you need real data. For local browser testing without
+Clerk, pair the backend dev auth bypass with these web values:
+
+```dotenv
+# apps/web/.env.local
+VITE_CLAWDI_API_URL=http://localhost:8000
+VITE_DEV_AUTH_BYPASS=true
+VITE_DEV_AUTH_TOKEN=dev-bypass
+```
+
+Then start the web app:
+
+```bash
+bun run --cwd apps/web dev
+```
+
+Open `http://localhost:3000`.
+
+## Verification
+
+Use the workspace package manager declared in `package.json`:
+
+```bash
+bun run --cwd apps/web typecheck
+bun run --cwd apps/web test
+bun run --cwd apps/web build:oss
+bunx biome check apps/web/src
+```
+
+`typecheck` runs `tsr generate` before `tsc --noEmit`, so TanStack Router's
+generated route tree stays current.
+
+For targeted tests, pass the file or directory to the package script:
+
+```bash
+bun run --cwd apps/web test src/hosted/oss-clean.test.ts
+bun run --cwd apps/web test src/hosted/posthog.test.ts
+```
+
+`apps/web/bunfig.toml` preloads `test-setup.ts`, which sets
+`VITE_CLERK_PUBLISHABLE_KEY=pk_test_dummy_for_unit_tests` when tests import the
+validated env module. If you bypass that Bun config, seed
+`VITE_CLERK_PUBLISHABLE_KEY` yourself.
+
+## OSS build boundary
+
+`bun run --cwd apps/web build:oss` is defined as:
+
+```bash
+VITE_CLAWDI_HOSTED=false VITE_CLERK_PUBLISHABLE_KEY=pk_test_dummy vite build
+```
+
+That verifies the self-hosted bundle path without relying on hosted `.env`
+values. It does not remove source files from the repository; it relies on
+compile-time gates so OSS builds do not include hosted-only UI chunks.
+
+The hosted boundary is documented in `apps/web/src/hosted/README.md` and
+guarded by `apps/web/src/hosted/oss-clean.test.ts`. The current invariants are:
+
+- Hosted-only components live under `apps/web/src/hosted/`.
+- Hosted route entrypoints construct lazy imports only when
+  `import.meta.env.VITE_CLAWDI_HOSTED === "true"`.
+- Hosted product routes render through `<HostedProductGate>`.
+- `posthog-js` and `@xterm/*` imports stay under hosted-only code paths.
+- Hosted `.tsx` roots set `data-hosted="true"`; `hosted/v2` roots also set
+  `data-v2="true"`.
+
+In OSS builds, hosted deployment, billing, wallet, subscription, hosted-only AI
+provider, hosted-only channel, terminal, control UI, and hosted analytics
+surfaces must remain unreachable from the client graph.
+
+## User-visible copy
+
+There is no repo-wide i18n system in `apps/web` today: no translation
+dependencies, locale directories, or `useTranslation` layer are present. Keep
+new user-visible copy in English and colocated with the UI, matching existing
+copy style. If a future change introduces an i18n system, route new product copy
+through that system instead of adding another hardcoded string layer.
+
+## Generated API types
+
+The web app imports API types from `@clawdi/shared/api`, which re-exports
+`packages/shared/src/api/api.generated.ts`. Do not edit the generated file by
+hand. Backend schema changes must follow the workflow in
+[`backend-development.md`](backend-development.md#generated-api-client).


### PR DESCRIPTION
## Summary

Gap analysis: what was missing -> what this adds

- AGENTS.md was mostly a conventions file -> added an ordered start-here flow with product context, repo layout, local backend/Postgres/web/CLI setup, test-suite commands, key doc pointers, and recurring gotchas.
- Backend development workflow was scattered across README, scripts, and tests -> added `docs/backend-development.md` with uv/Ruff/compileall commands, throwaway Postgres pytest workflow, Alembic conventions, generated API client workflow, local DB inspection, local admin API examples, and dev log behavior.
- Frontend development workflow was implicit in package scripts and hosted-boundary tests -> added `docs/frontend-development.md` with Bun commands, targeted test guidance, dummy Clerk test env behavior, OSS build boundaries, and current user-copy/i18n expectations.
- API compatibility policy lived in code/tests/ADR details -> added `docs/api-compatibility.md` covering canonical `/v1/agents`, deprecated `/v1/environments` aliases, hidden `/api/*` aliases, additive-only compatibility, released CLI compatibility, generated-client rules, and external `/api` string cautions.
- Architecture/ADR wording had stale or incomplete contributor links -> cross-linked AGENTS, ADR 0001, architecture, and API compatibility docs, normalized hosted-infra references to first-party hosted control planes, and removed a stale auth-login statement.

## Verification

- `git diff --check`
- `git diff --cached --check`
- Boundary grep over changed docs for forbidden leak categories: no matches
- `bun run check`
- `bun run --cwd apps/web build:oss`
- `bun run --cwd apps/web test src/hosted/oss-clean.test.ts`
- `bun test packages/shared/src`
- `cd backend && uv run ruff check .`
- `cd backend && uv run ruff format --check .`
- `cd backend && uv run python -m compileall app scripts tests alembic`
- `cd backend && uv run python scripts/check_generated_api.py`
- Throwaway Postgres: `cd backend && uv run alembic upgrade head && uv run pytest tests/test_api_version_alias.py tests/test_agent_endpoints.py tests/test_admin_endpoints.py -q` (49 passed, 1 existing deprecation warning)
