### PR TITLE
Refine dashboard UX: flat deploy layout, uniform width, flicker fixes

### DIFF
--- a/apps/web/src/components/app-breadcrumb.tsx
+++ b/apps/web/src/components/app-breadcrumb.tsx
@@ -28,6 +28,7 @@ const SEGMENT_LABELS: Record<string, string> = {
 	vault: "Vaults",
 	connectors: "Connectors",
 	channels: "Channels",
+	deploy: "Deploy an Agent",
 	agents: "Agents",
 	"ai-providers": "Model Providers",
 };

--- a/apps/web/src/components/breadcrumb-title.tsx
+++ b/apps/web/src/components/breadcrumb-title.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useCallback, useContext, useEffect, useState } from "react";
 import { type AgentSectionId, agentSectionHref, agentSectionLabel } from "@/lib/agent-routes";
+import { APP_TITLE, formatDocumentTitle } from "@/lib/document-title";
 
 /**
  * Context for "what the breadcrumb's last segment should say".
@@ -84,8 +85,21 @@ export function useBreadcrumbSegmentTitles(): SegmentTitles {
 export function useSetBreadcrumbTitle(title: string | null | undefined) {
 	const setTitle = useContext(SetTitleContext);
 	useEffect(() => {
-		setTitle(title?.trim() || null);
-		return () => setTitle(null);
+		const trimmed = title?.trim() || null;
+		setTitle(trimmed);
+		if (!trimmed || typeof document === "undefined") {
+			return () => setTitle(null);
+		}
+
+		const previousTitle = document.title || APP_TITLE;
+		const nextTitle = formatDocumentTitle(trimmed);
+		document.title = nextTitle;
+		return () => {
+			setTitle(null);
+			if (document.title === nextTitle) {
+				document.title = previousTitle || APP_TITLE;
+			}
+		};
 	}, [setTitle, title]);
 }
 

--- a/apps/web/src/components/connectors/credentials-dialog.tsx
+++ b/apps/web/src/components/connectors/credentials-dialog.tsx
@@ -64,6 +64,7 @@ export function ConnectorCredentialsDialog({
 	const inflightSubmitRef = useRef(false);
 	useEffect(() => {
 		openGenRef.current += 1;
+		if (!open) return;
 		setValues({});
 		setSubmitError(null);
 	}, [open]);

--- a/apps/web/src/components/dashboard/agent-settings-panel.tsx
+++ b/apps/web/src/components/dashboard/agent-settings-panel.tsx
@@ -12,7 +12,6 @@ import {
 	agentDisplayName,
 	agentTypeLabel,
 } from "@/components/dashboard/agent-label";
-import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SettingsSection } from "@/components/settings-section";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
@@ -34,6 +33,7 @@ type EnvironmentUpdate = components["schemas"]["EnvironmentUpdate"];
 
 const MAX_AGENT_AVATAR_BYTES = 2 * 1024 * 1024;
 const AGENT_AVATAR_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/webp"]);
+const SETTINGS_PANEL_WIDTH_CLASS = "mx-auto w-full max-w-4xl";
 
 function updateEnvironmentCaches(queryClient: QueryClient, environment: Environment) {
 	queryClient.setQueryData(["agents", environment.id], environment);
@@ -158,7 +158,7 @@ export function AgentSettingsPanel({
 
 	if (isLoading) {
 		return (
-			<div className={cn(contained && CENTERED_PAGE_WIDTH_CLASS.settings, className)}>
+			<div className={cn(contained && SETTINGS_PANEL_WIDTH_CLASS, className)}>
 				<Skeleton className="h-[420px] w-full rounded-lg" />
 			</div>
 		);
@@ -169,7 +169,7 @@ export function AgentSettingsPanel({
 			<div
 				className={cn(
 					"flex flex-col gap-1 rounded-md border p-4",
-					contained && CENTERED_PAGE_WIDTH_CLASS.settings,
+					contained && SETTINGS_PANEL_WIDTH_CLASS,
 					className,
 				)}
 			>
@@ -205,13 +205,7 @@ export function AgentSettingsPanel({
 	const legacyDashboardUrl = ownershipKind === "legacy" ? legacyHostedDashboardUrl() : null;
 
 	return (
-		<div
-			className={cn(
-				"flex flex-col gap-9",
-				contained && CENTERED_PAGE_WIDTH_CLASS.settings,
-				className,
-			)}
-		>
+		<div className={cn("flex flex-col gap-9", contained && SETTINGS_PANEL_WIDTH_CLASS, className)}>
 			<input
 				ref={fileInputRef}
 				type="file"

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -78,11 +78,7 @@ const AGENT_DETAIL_NAV_META: Record<AgentTab, DetailSectionMeta> = {
 		description: "Name and avatar used across the dashboard.",
 	},
 };
-const AGENT_DETAIL_INNER_WIDTH_CLASS = {
-	default: "mx-auto w-full max-w-4xl",
-	skills: "mx-auto w-full max-w-6xl",
-	settings: "mx-auto w-full max-w-4xl",
-} as const;
+const AGENT_DETAIL_INNER_WIDTH_CLASS = "mx-auto w-full max-w-4xl";
 
 export function ConnectedAgentDetail({
 	environmentId,
@@ -214,7 +210,6 @@ export function ConnectedAgentDetail({
 	const activeTabMeta = AGENT_DETAIL_NAV_META[activeTab];
 	const activeTabLabel = agentSectionLabel(activeTab);
 	const ActiveTabIcon = activeTabMeta.icon;
-	const contentWidthClass = connectedAgentContentWidthClass(activeTab);
 	const scopedSessionLink = (sessionId: string) => ({
 		to: "/agents/$id/sessions/$sessionId" as const,
 		params: { id, sessionId },
@@ -243,36 +238,38 @@ export function ConnectedAgentDetail({
 					<h1 className="sr-only">{agentTitle || agentTypeLabel(agent.agent_type)}</h1>
 
 					<section className="flex flex-col gap-4">
-						<div className="flex flex-wrap items-start justify-between gap-3">
-							<div>
-								<div className="flex items-center gap-2">
-									{ActiveTabIcon ? (
-										<ActiveTabIcon className="size-4 text-muted-foreground" />
-									) : null}
-									<h2 className="text-xl font-semibold tracking-tight">{activeTabLabel}</h2>
-									{showSourceBadge ? (
-										<AgentSourceBadgeForEnvironment
-											env={agent}
-											ownershipKind={ownershipKind}
-											compact
-										/>
+						<div className={cn(AGENT_DETAIL_INNER_WIDTH_CLASS, "flex flex-col gap-4")}>
+							<div className="flex flex-wrap items-start justify-between gap-3">
+								<div>
+									<div className="flex items-center gap-2">
+										{ActiveTabIcon ? (
+											<ActiveTabIcon className="size-4 text-muted-foreground" />
+										) : null}
+										<h2 className="text-xl font-semibold tracking-tight">{activeTabLabel}</h2>
+										{showSourceBadge ? (
+											<AgentSourceBadgeForEnvironment
+												env={agent}
+												ownershipKind={ownershipKind}
+												compact
+											/>
+										) : null}
+									</div>
+									{activeTabMeta.description ? (
+										<p className="mt-1 text-sm text-muted-foreground">
+											{activeTabMeta.description}
+										</p>
 									) : null}
 								</div>
-								{activeTabMeta.description ? (
-									<p className="mt-1 text-sm text-muted-foreground">{activeTabMeta.description}</p>
+								{activeTab === "skills" ? (
+									<Button asChild variant="outline" size="sm">
+										<Link to="/skills" search={{ target: id }}>
+											<Plus />
+											Install skills
+										</Link>
+									</Button>
 								) : null}
 							</div>
-							{activeTab === "skills" ? (
-								<Button asChild variant="outline" size="sm">
-									<Link to="/skills" search={{ target: id }}>
-										<Plus />
-										Install skills
-									</Link>
-								</Button>
-							) : null}
-						</div>
 
-						<div className={contentWidthClass}>
 							{activeTab === "overview" ? (
 								<div className="flex flex-col gap-4">
 									<div className="grid gap-3 sm:grid-cols-3">
@@ -347,12 +344,6 @@ function parseAgentTab(value: AgentSectionId | string | null): AgentTab | null {
 	if (value === "overview") return "overview";
 	if (CONNECTED_AGENT_SECTION_IDS.includes(value as AgentTab)) return value as AgentTab;
 	return null;
-}
-
-function connectedAgentContentWidthClass(tab: AgentTab): string {
-	if (tab === "settings") return AGENT_DETAIL_INNER_WIDTH_CLASS.settings;
-	if (tab === "skills") return AGENT_DETAIL_INNER_WIDTH_CLASS.skills;
-	return AGENT_DETAIL_INNER_WIDTH_CLASS.default;
 }
 
 function AgentStatPanel({ label, value }: { label: string; value: React.ReactNode }) {

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -78,6 +78,11 @@ const AGENT_DETAIL_NAV_META: Record<AgentTab, DetailSectionMeta> = {
 		description: "Name and avatar used across the dashboard.",
 	},
 };
+const AGENT_DETAIL_INNER_WIDTH_CLASS = {
+	default: "mx-auto w-full max-w-4xl",
+	skills: "mx-auto w-full max-w-6xl",
+	settings: "mx-auto w-full max-w-4xl",
+} as const;
 
 export function ConnectedAgentDetail({
 	environmentId,
@@ -225,7 +230,7 @@ export function ConnectedAgentDetail({
 	useSetAgentBreadcrumbTitle({ agentId: id, agentTitle, section: activeTab });
 
 	return (
-		<div className="flex flex-col gap-6 px-4 lg:px-6">
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6")}>
 			{error ? (
 				<DetailNotFound title="Agent not found" message={errorMessage(error)} />
 			) : isLoading ? (
@@ -237,7 +242,7 @@ export function ConnectedAgentDetail({
 				<>
 					<h1 className="sr-only">{agentTitle || agentTypeLabel(agent.agent_type)}</h1>
 
-					<section className={cn("flex flex-col gap-4", contentWidthClass)}>
+					<section className="flex flex-col gap-4">
 						<div className="flex flex-wrap items-start justify-between gap-3">
 							<div>
 								<div className="flex items-center gap-2">
@@ -267,69 +272,70 @@ export function ConnectedAgentDetail({
 							) : null}
 						</div>
 
-						{activeTab === "overview" ? (
-							<div className="grid gap-3 sm:grid-cols-3">
-								<AgentStatPanel label="Sessions" value={sessionTotal} />
-								<AgentStatPanel
-									label="Skills"
-									value={skillsForThisEnv ? skillsForThisEnv.length : "—"}
+						<div className={contentWidthClass}>
+							{activeTab === "overview" ? (
+								<div className="flex flex-col gap-4">
+									<div className="grid gap-3 sm:grid-cols-3">
+										<AgentStatPanel label="Sessions" value={sessionTotal} />
+										<AgentStatPanel
+											label="Skills"
+											value={skillsForThisEnv ? skillsForThisEnv.length : "—"}
+										/>
+										<AgentStatPanel label="Projects" value={projectBindings?.length ?? "—"} />
+									</div>
+									<SessionFeed
+										sessions={(sessionsPage?.items ?? []).slice(0, 5)}
+										isLoading={sessionsLoading}
+										emptyMessage="No sessions synced from this agent yet."
+										showAgent={false}
+										sessionLink={(session) => scopedSessionLink(session.id)}
+									/>
+								</div>
+							) : null}
+
+							{activeTab === "sessions" ? (
+								<SessionFeed
+									sessions={sessionsPage?.items ?? []}
+									isLoading={sessionsLoading}
+									emptyMessage="No sessions synced from this agent yet."
+									showAgent={false}
+									sessionLink={(session) => scopedSessionLink(session.id)}
 								/>
-								<AgentStatPanel label="Projects" value={projectBindings?.length ?? "—"} />
-							</div>
-						) : null}
+							) : null}
 
-						{activeTab === "overview" ? (
-							<SessionFeed
-								sessions={(sessionsPage?.items ?? []).slice(0, 5)}
-								isLoading={sessionsLoading}
-								emptyMessage="No sessions synced from this agent yet."
-								showAgent={false}
-								sessionLink={(session) => scopedSessionLink(session.id)}
-							/>
-						) : null}
+							{activeTab === "skills" ? (
+								<SkillCardGrid
+									skills={skillsForThisEnv ?? []}
+									isLoading={skillsLoading}
+									emptyMessage="No skills installed on this agent yet."
+									readOnlySkillCheck={(s) =>
+										!s.project_id || !(writableProjectIds?.has(s.project_id) ?? false)
+									}
+									onUninstall={(skillKey, projectId) =>
+										uninstallSkill.mutate({ skillKey, projectId })
+									}
+									uninstallPending={uninstallSkill.isPending}
+									skillLink={scopedSkillLink}
+								/>
+							) : null}
 
-						{activeTab === "sessions" ? (
-							<SessionFeed
-								sessions={sessionsPage?.items ?? []}
-								isLoading={sessionsLoading}
-								emptyMessage="No sessions synced from this agent yet."
-								showAgent={false}
-								sessionLink={(session) => scopedSessionLink(session.id)}
-							/>
-						) : null}
+							{activeTab === "projects" ? (
+								<AgentProjectsPanel
+									agentId={id}
+									bindings={projectBindings ?? []}
+									projects={projects ?? []}
+									isLoading={projectBindingsLoading}
+									onChanged={() => {
+										queryClient.invalidateQueries({
+											queryKey: ["agent-project-bindings", id],
+										});
+										queryClient.invalidateQueries({ queryKey: ["projects"] });
+									}}
+								/>
+							) : null}
 
-						{activeTab === "skills" ? (
-							<SkillCardGrid
-								skills={skillsForThisEnv ?? []}
-								isLoading={skillsLoading}
-								emptyMessage="No skills installed on this agent yet."
-								readOnlySkillCheck={(s) =>
-									!s.project_id || !(writableProjectIds?.has(s.project_id) ?? false)
-								}
-								onUninstall={(skillKey, projectId) =>
-									uninstallSkill.mutate({ skillKey, projectId })
-								}
-								uninstallPending={uninstallSkill.isPending}
-								skillLink={scopedSkillLink}
-							/>
-						) : null}
-
-						{activeTab === "projects" ? (
-							<AgentProjectsPanel
-								agentId={id}
-								bindings={projectBindings ?? []}
-								projects={projects ?? []}
-								isLoading={projectBindingsLoading}
-								onChanged={() => {
-									queryClient.invalidateQueries({
-										queryKey: ["agent-project-bindings", id],
-									});
-									queryClient.invalidateQueries({ queryKey: ["projects"] });
-								}}
-							/>
-						) : null}
-
-						{activeTab === "settings" ? <AgentSettingsPanel environmentId={id} /> : null}
+							{activeTab === "settings" ? <AgentSettingsPanel environmentId={id} /> : null}
+						</div>
 					</section>
 				</>
 			) : null}
@@ -344,9 +350,9 @@ function parseAgentTab(value: AgentSectionId | string | null): AgentTab | null {
 }
 
 function connectedAgentContentWidthClass(tab: AgentTab): string {
-	if (tab === "settings") return CENTERED_PAGE_WIDTH_CLASS.settings;
-	if (tab === "skills") return CENTERED_PAGE_WIDTH_CLASS.wide;
-	return CENTERED_PAGE_WIDTH_CLASS.detail;
+	if (tab === "settings") return AGENT_DETAIL_INNER_WIDTH_CLASS.settings;
+	if (tab === "skills") return AGENT_DETAIL_INNER_WIDTH_CLASS.skills;
+	return AGENT_DETAIL_INNER_WIDTH_CLASS.default;
 }
 
 function AgentStatPanel({ label, value }: { label: string; value: React.ReactNode }) {

--- a/apps/web/src/components/meta/stat.tsx
+++ b/apps/web/src/components/meta/stat.tsx
@@ -1,4 +1,5 @@
 import type { LucideIcon } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 /**
@@ -24,13 +25,17 @@ export function Stat({
 	title?: string;
 	className?: string;
 }) {
-	return (
-		<span
-			title={title}
-			className={cn("inline-flex items-center gap-1 text-xs text-muted-foreground", className)}
-		>
+	const stat = (
+		<span className={cn("inline-flex items-center gap-1 text-xs text-muted-foreground", className)}>
 			<Icon className="size-3.5 shrink-0" />
 			<span className="truncate">{label}</span>
 		</span>
+	);
+	if (!title) return stat;
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>{stat}</TooltipTrigger>
+			<TooltipContent>{title}</TooltipContent>
+		</Tooltip>
 	);
 }

--- a/apps/web/src/components/page-width.ts
+++ b/apps/web/src/components/page-width.ts
@@ -1,6 +1,3 @@
 export const CENTERED_PAGE_WIDTH_CLASS = {
-	settings: "mx-auto w-full max-w-4xl",
-	form: "mx-auto w-full max-w-2xl",
-	detail: "mx-auto w-full max-w-4xl",
-	wide: "mx-auto w-full max-w-6xl",
+	page: "mx-auto w-full max-w-7xl",
 } as const;

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -6,10 +6,26 @@ import { useEffect, useRef, useState } from "react";
 import { AnalyticsProvider } from "@/components/providers/analytics-provider";
 import { ThemeProvider } from "@/components/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { ApiError } from "@/lib/api-errors";
 import { useCurrentUser } from "@/lib/auth-client";
 
 export function Providers({ children }: { children: React.ReactNode }) {
-	const [queryClient] = useState(() => new QueryClient());
+	const [queryClient] = useState(
+		() =>
+			new QueryClient({
+				defaultOptions: {
+					queries: {
+						staleTime: 30_000,
+						retry: (failureCount, error) => {
+							if (error instanceof ApiError && error.status >= 400 && error.status < 500) {
+								return false;
+							}
+							return failureCount < 2;
+						},
+					},
+				},
+			}),
+	);
 	return (
 		<ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
 			<NuqsAdapter>

--- a/apps/web/src/components/settings-section.tsx
+++ b/apps/web/src/components/settings-section.tsx
@@ -8,8 +8,8 @@ export function SettingsSection({
 	className,
 	tone = "default",
 }: {
-	title: string;
-	description?: string;
+	title: React.ReactNode;
+	description?: React.ReactNode;
 	children: React.ReactNode;
 	className?: string;
 	tone?: "default" | "danger";
@@ -22,7 +22,7 @@ export function SettingsSection({
 					{title}
 				</div>
 				{description ? (
-					<p className="text-sm leading-5 text-muted-foreground">{description}</p>
+					<div className="text-sm leading-5 text-muted-foreground">{description}</div>
 				) : null}
 			</div>
 			<div className="min-w-0">{children}</div>

--- a/apps/web/src/components/settings-section.tsx
+++ b/apps/web/src/components/settings-section.tsx
@@ -1,6 +1,7 @@
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 
+/** Flat form/settings section; use SectionLabel for list-group captions and DashboardSection for bordered content containers. */
 export function SettingsSection({
 	title,
 	description,
@@ -15,9 +16,9 @@ export function SettingsSection({
 	tone?: "default" | "danger";
 }) {
 	return (
-		<section className={cn("grid gap-4 lg:grid-cols-[15rem_minmax(0,1fr)] lg:gap-x-10", className)}>
-			<Separator className="lg:col-span-2" />
-			<div className="flex max-w-sm flex-col gap-1.5">
+		<section className={cn("flex flex-col gap-4", className)}>
+			<Separator />
+			<div className="flex max-w-2xl flex-col gap-1.5">
 				<div className={cn("text-sm font-semibold", tone === "danger" && "text-destructive")}>
 					{title}
 				</div>

--- a/apps/web/src/components/skills/send-skill-dialog.tsx
+++ b/apps/web/src/components/skills/send-skill-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, Send } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import {
 	AgentLabel,
@@ -186,24 +186,19 @@ export function SendSkillDialog({
 				},
 			);
 			setOpen(false);
-			setTarget("");
-			setRemoveFromSource(false);
 			onDone?.();
 		},
 		onError: (e) => toast.error("Couldn't send skills", { description: errorMessage(e) }),
 	});
 
+	useEffect(() => {
+		if (!open) return;
+		setTarget("");
+		setRemoveFromSource(false);
+	}, [open]);
+
 	return (
-		<Dialog
-			open={open}
-			onOpenChange={(next) => {
-				setOpen(next);
-				if (!next) {
-					setTarget("");
-					setRemoveFromSource(false);
-				}
-			}}
-		>
+		<Dialog open={open} onOpenChange={setOpen}>
 			<DialogTrigger asChild>
 				{children ?? (
 					<Button variant="ghost" size="icon-sm" aria-label={`Send ${batchLabel} to…`}>

--- a/apps/web/src/components/time-tooltip.tsx
+++ b/apps/web/src/components/time-tooltip.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { formatAbsoluteTooltip } from "@/lib/utils";
+
+export function TimeTooltip({
+	value,
+	children,
+}: {
+	value: string | null | undefined;
+	children: React.ReactNode;
+}) {
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>{children}</TooltipTrigger>
+			<TooltipContent>{formatAbsoluteTooltip(value)}</TooltipContent>
+		</Tooltip>
+	);
+}

--- a/apps/web/src/components/vault/add-keys-dialog.tsx
+++ b/apps/web/src/components/vault/add-keys-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertCircle, Check, Plus } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -180,26 +180,20 @@ export function AddKeysDialog({
 						: `In vault://${slug}. Agents read them through the CLI at runtime.`,
 			});
 			setOpen(false);
-			setText("");
-			setNewVaultName("");
-			setUpdateExisting(false);
 		},
 		onError: (e) => toast.error("Couldn't save keys", { description: errorMessage(e) }),
 	});
 
+	useEffect(() => {
+		if (!open) return;
+		setText("");
+		setNewVaultName("");
+		setVaultChoice(vaultSlug ?? "");
+		setUpdateExisting(false);
+	}, [open, vaultSlug]);
+
 	return (
-		<Dialog
-			open={open}
-			onOpenChange={(next) => {
-				setOpen(next);
-				if (!next) {
-					setText("");
-					setNewVaultName("");
-					setVaultChoice(vaultSlug ?? "");
-					setUpdateExisting(false);
-				}
-			}}
-		>
+		<Dialog open={open} onOpenChange={setOpen}>
 			<DialogTrigger asChild>
 				{children ?? (
 					<Button size="sm">

--- a/apps/web/src/components/vault/copy-keys-dialog.tsx
+++ b/apps/web/src/components/vault/copy-keys-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, Plus } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -202,24 +202,19 @@ export function CopyKeysDialog({
 				},
 			);
 			setOpen(false);
-			setTargetChoice("");
-			setNewVaultName("");
 			onDone?.();
 		},
 		onError: (e) => toast.error(`Couldn't ${mode} keys`, { description: errorMessage(e) }),
 	});
 
+	useEffect(() => {
+		if (!open) return;
+		setTargetChoice("");
+		setNewVaultName("");
+	}, [open]);
+
 	return (
-		<Dialog
-			open={open}
-			onOpenChange={(next) => {
-				setOpen(next);
-				if (!next) {
-					setTargetChoice("");
-					setNewVaultName("");
-				}
-			}}
-		>
+		<Dialog open={open} onOpenChange={setOpen}>
 			<DialogTrigger asChild>{children}</DialogTrigger>
 			<DialogContent className="sm:max-w-md">
 				<DialogHeader>

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -2,6 +2,7 @@
 
 import { useLocation } from "@tanstack/react-router";
 import { ConnectedAgentDetail } from "@/components/dashboard/connected-agent-detail";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { Skeleton } from "@/components/ui/skeleton";
 import { isCloudEnvId } from "@/hosted/agent-identity";
 import { useAgentDeployment } from "@/hosted/agents/deployment-hooks";
@@ -41,7 +42,10 @@ export function AgentHome({
 	// doesn't flash the connected detail (and fire its queries) first.
 	if (isLoading || (requestedHostedAgent && !deployment && isFetching)) {
 		return (
-			<div data-hosted="true" className="space-y-4 px-4 lg:px-6 py-2">
+			<div
+				data-hosted="true"
+				className={`${CENTERED_PAGE_WIDTH_CLASS.page} space-y-4 px-4 py-2 lg:px-6`}
+			>
 				<Skeleton className="h-10 w-64" />
 				<Skeleton className="h-9 w-full max-w-md" />
 				<Skeleton className="h-48 w-full" />
@@ -51,7 +55,10 @@ export function AgentHome({
 
 	if (error && requestedHostedAgent) {
 		return (
-			<div data-hosted="true" className="space-y-4 px-4 py-2 lg:px-6">
+			<div
+				data-hosted="true"
+				className={`${CENTERED_PAGE_WIDTH_CLASS.page} space-y-4 px-4 py-2 lg:px-6`}
+			>
 				<BillingError error={error} title="Couldn’t load hosted agent" />
 			</div>
 		);
@@ -76,7 +83,10 @@ export function AgentHome({
 
 	if (requestedHostedAgent) {
 		return (
-			<div data-hosted="true" className="space-y-4 px-4 py-2 lg:px-6">
+			<div
+				data-hosted="true"
+				className={`${CENTERED_PAGE_WIDTH_CLASS.page} space-y-4 px-4 py-2 lg:px-6`}
+			>
 				<BillingEmpty
 					title="Clawdi Cloud agent not found"
 					description="This Clawdi Cloud agent may still be provisioning or may have been removed."

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -58,6 +58,7 @@ export function useSetAgentEnabled() {
 			client.setAgentEnabled(vars.id, vars.agentType, vars.enabled),
 		onSuccess: (_d, vars) => {
 			qc.invalidateQueries({ queryKey: billingKeys.deployments });
+			qc.invalidateQueries({ queryKey: ["agents"] });
 			toast.success(vars.enabled ? "Runtime enabled" : "Runtime disabled");
 		},
 		onError: toastBillingError("Couldn't update runtime"),
@@ -80,7 +81,10 @@ export function useSetAgentAiProvider() {
 			}
 			return last;
 		},
-		onSuccess: () => qc.invalidateQueries({ queryKey: billingKeys.deployments }),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: billingKeys.deployments });
+			qc.invalidateQueries({ queryKey: ["agents"] });
+		},
 		onError: toastBillingError("Couldn't update provider"),
 	});
 }
@@ -93,6 +97,7 @@ export function useOnboardAgent() {
 			client.onboardAgent(vars.id, vars.agentType),
 		onSuccess: () => {
 			qc.invalidateQueries({ queryKey: billingKeys.deployments });
+			qc.invalidateQueries({ queryKey: ["agents"] });
 			toast.success("Runtime added");
 		},
 		onError: toastBillingError("Couldn't add runtime"),
@@ -118,6 +123,7 @@ export function useDeploymentLifecycle() {
 		},
 		onSuccess: (_d, vars) => {
 			qc.invalidateQueries({ queryKey: billingKeys.deployments });
+			qc.invalidateQueries({ queryKey: ["agents"] });
 			const msg =
 				vars.action === "restart"
 					? "Restarting agent…"
@@ -135,7 +141,10 @@ export function useDeleteDeployment() {
 	const qc = useQueryClient();
 	return useMutation({
 		mutationFn: (id: string) => client.deleteDeployment(id),
-		onSuccess: () => qc.invalidateQueries({ queryKey: billingKeys.deployments }),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: billingKeys.deployments });
+			qc.invalidateQueries({ queryKey: ["agents"] });
+		},
 		onError: toastBillingError("Couldn't delete agent"),
 	});
 }

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -171,11 +171,7 @@ const HOSTED_AGENT_NAV_META: Record<HostedAgentTab, DetailSectionMeta> = {
 		icon: Settings,
 	},
 };
-const HOSTED_AGENT_INNER_WIDTH_CLASS = {
-	default: "mx-auto w-full max-w-4xl",
-	form: "mx-auto w-full max-w-2xl",
-	settings: "mx-auto w-full max-w-4xl",
-} as const;
+const HOSTED_AGENT_INNER_WIDTH_CLASS = "mx-auto w-full max-w-4xl";
 const STARTABLE_STATUSES = new Set(["stopped", "failed"]);
 const STOPPABLE_STATUSES = new Set(["running", "ready", "starting"]);
 const RESTARTABLE_STATUSES = new Set(["running", "ready", "starting", "failed"]);
@@ -202,14 +198,6 @@ function parseHostedAgentTab(value: AgentSectionId | string | null): HostedAgent
 		HOSTED_AGENT_TABS.has(value as HostedAgentTab)
 		? (value as HostedAgentTab)
 		: null;
-}
-
-function hostedAgentContentWidthClass(tab: HostedAgentTab): string {
-	if (tab === "settings") return HOSTED_AGENT_INNER_WIDTH_CLASS.settings;
-	if (tab === "ai" || tab === "channels") {
-		return HOSTED_AGENT_INNER_WIDTH_CLASS.form;
-	}
-	return HOSTED_AGENT_INNER_WIDTH_CLASS.default;
 }
 
 function LiveNote({ children }: { children: React.ReactNode }) {
@@ -298,7 +286,6 @@ export function HostedAgentDetail({
 	const activeTabLabel = agentSectionLabel(activeTab);
 	const ActiveTabIcon = activeNavItem.icon;
 	const isLiveToolTab = activeTab === "console" || activeTab === "terminal";
-	const contentWidthClass = hostedAgentContentWidthClass(activeTab);
 
 	return (
 		<div
@@ -312,7 +299,10 @@ export function HostedAgentDetail({
 		>
 			<h1 className="sr-only">{agentTitle}</h1>
 			<section
-				className={cn(isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : "flex flex-col gap-4")}
+				className={cn(
+					isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : HOSTED_AGENT_INNER_WIDTH_CLASS,
+					!isLiveToolTab && "flex flex-col gap-4",
+				)}
 			>
 				{isLiveToolTab ? null : (
 					<div className="flex flex-wrap items-start justify-between gap-3">
@@ -336,7 +326,7 @@ export function HostedAgentDetail({
 						) : null}
 					</div>
 				)}
-				<div className={isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : contentWidthClass}>
+				<div className={isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : "w-full"}>
 					{activeTab === "overview" ? (
 						<OverviewTab
 							deployment={deployment}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -171,6 +171,11 @@ const HOSTED_AGENT_NAV_META: Record<HostedAgentTab, DetailSectionMeta> = {
 		icon: Settings,
 	},
 };
+const HOSTED_AGENT_INNER_WIDTH_CLASS = {
+	default: "mx-auto w-full max-w-4xl",
+	form: "mx-auto w-full max-w-2xl",
+	settings: "mx-auto w-full max-w-4xl",
+} as const;
 const STARTABLE_STATUSES = new Set(["stopped", "failed"]);
 const STOPPABLE_STATUSES = new Set(["running", "ready", "starting"]);
 const RESTARTABLE_STATUSES = new Set(["running", "ready", "starting", "failed"]);
@@ -199,13 +204,12 @@ function parseHostedAgentTab(value: AgentSectionId | string | null): HostedAgent
 		: null;
 }
 
-function hostedAgentContentWidthClass(tab: HostedAgentTab): string | null {
-	if (tab === "console" || tab === "terminal") return null;
-	if (tab === "settings") return CENTERED_PAGE_WIDTH_CLASS.settings;
+function hostedAgentContentWidthClass(tab: HostedAgentTab): string {
+	if (tab === "settings") return HOSTED_AGENT_INNER_WIDTH_CLASS.settings;
 	if (tab === "ai" || tab === "channels") {
-		return CENTERED_PAGE_WIDTH_CLASS.form;
+		return HOSTED_AGENT_INNER_WIDTH_CLASS.form;
 	}
-	return CENTERED_PAGE_WIDTH_CLASS.detail;
+	return HOSTED_AGENT_INNER_WIDTH_CLASS.default;
 }
 
 function LiveNote({ children }: { children: React.ReactNode }) {
@@ -299,18 +303,16 @@ export function HostedAgentDetail({
 	return (
 		<div
 			data-hosted="true"
-			className={
+			className={cn(
+				CENTERED_PAGE_WIDTH_CLASS.page,
 				isLiveToolTab
 					? "-my-4 flex min-h-[calc(100svh-var(--header-height))] flex-col md:-my-5 md:min-h-[calc(100svh-var(--header-height)-1rem)]"
-					: "flex flex-col gap-6 px-4 lg:px-6"
-			}
+					: "flex flex-col gap-6 px-4 lg:px-6",
+			)}
 		>
 			<h1 className="sr-only">{agentTitle}</h1>
 			<section
-				className={cn(
-					isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : "flex flex-col gap-4",
-					contentWidthClass,
-				)}
+				className={cn(isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : "flex flex-col gap-4")}
 			>
 				{isLiveToolTab ? null : (
 					<div className="flex flex-wrap items-start justify-between gap-3">
@@ -334,47 +336,51 @@ export function HostedAgentDetail({
 						) : null}
 					</div>
 				)}
-				{activeTab === "overview" ? (
-					<OverviewTab
-						deployment={deployment}
-						runtime={runtime}
-						isPerformance={isPerformance}
-						sessions={sessions.data?.items ?? []}
-						sessionsLoading={sessions.isLoading}
-						sessionsError={sessions.error}
-						onRetrySessions={() => sessions.refetch()}
-						sessionLink={(session) => scopedSessionLink(session.id)}
-					/>
-				) : null}
-				{activeTab === "console" ? <ConsoleTab deployment={deployment} runtime={runtime} /> : null}
-				{activeTab === "terminal" ? <TerminalTab deployment={deployment} /> : null}
-				{activeTab === "sessions" ? (
-					sessions.error ? (
-						<ChannelError
-							error={sessions.error}
-							onRetry={() => sessions.refetch()}
-							title="Couldn't load sessions"
-						/>
-					) : (
-						<SessionFeed
+				<div className={isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : contentWidthClass}>
+					{activeTab === "overview" ? (
+						<OverviewTab
+							deployment={deployment}
+							runtime={runtime}
+							isPerformance={isPerformance}
 							sessions={sessions.data?.items ?? []}
-							isLoading={sessions.isLoading}
-							emptyMessage="No sessions from this agent yet."
-							showAgent={false}
+							sessionsLoading={sessions.isLoading}
+							sessionsError={sessions.error}
+							onRetrySessions={() => sessions.refetch()}
 							sessionLink={(session) => scopedSessionLink(session.id)}
 						/>
-					)
-				) : null}
-				{activeTab === "ai" ? <AiProviderTab deployment={deployment} runtime={runtime} /> : null}
-				{activeTab === "channels" ? <ChannelsTab environmentId={environmentId} /> : null}
-				{activeTab === "settings" ? (
-					<HostedAgentSettingsTab
-						environmentId={environmentId}
-						deployment={deployment}
-						isPerformance={isPerformance}
-						runtime={runtime}
-					/>
-				) : null}
+					) : null}
+					{activeTab === "console" ? (
+						<ConsoleTab deployment={deployment} runtime={runtime} />
+					) : null}
+					{activeTab === "terminal" ? <TerminalTab deployment={deployment} /> : null}
+					{activeTab === "sessions" ? (
+						sessions.error ? (
+							<ChannelError
+								error={sessions.error}
+								onRetry={() => sessions.refetch()}
+								title="Couldn't load sessions"
+							/>
+						) : (
+							<SessionFeed
+								sessions={sessions.data?.items ?? []}
+								isLoading={sessions.isLoading}
+								emptyMessage="No sessions from this agent yet."
+								showAgent={false}
+								sessionLink={(session) => scopedSessionLink(session.id)}
+							/>
+						)
+					) : null}
+					{activeTab === "ai" ? <AiProviderTab deployment={deployment} runtime={runtime} /> : null}
+					{activeTab === "channels" ? <ChannelsTab environmentId={environmentId} /> : null}
+					{activeTab === "settings" ? (
+						<HostedAgentSettingsTab
+							environmentId={environmentId}
+							deployment={deployment}
+							isPerformance={isPerformance}
+							runtime={runtime}
+						/>
+					) : null}
+				</div>
 			</section>
 		</div>
 	);
@@ -757,6 +763,22 @@ function selectableCard(active: boolean): string {
 	}`;
 }
 
+function ProviderOptionSkeleton() {
+	return (
+		<div className="flex items-center gap-3 rounded-lg border p-4">
+			<Skeleton className="size-10 shrink-0 rounded-lg" />
+			<div className="min-w-0 flex-1 space-y-2">
+				<div className="flex items-center gap-2">
+					<Skeleton className="h-4 w-32" />
+					<Skeleton className="h-5 w-16 rounded-full" />
+				</div>
+				<Skeleton className="h-3 w-40" />
+			</div>
+			<Skeleton className="h-5 w-14 rounded-full" />
+		</div>
+	);
+}
+
 function AiProviderTab({
 	deployment,
 	runtime,
@@ -876,7 +898,7 @@ function AiProviderTab({
 						Clawdi-managed Claude models, billed from your wallet.
 					</p>
 				</button>
-				{providers.isLoading ? <Skeleton className="h-20 w-full rounded-lg" /> : null}
+				{providers.isLoading ? <ProviderOptionSkeleton /> : null}
 				{providers.error ? (
 					<BillingError
 						error={providers.error}

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -18,9 +18,9 @@ import { EntityChoiceCard } from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
+import { SettingsSection } from "@/components/settings-section";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import {
 	Command,
 	CommandEmpty,
@@ -38,6 +38,7 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { BillingError } from "@/hosted/billing/components/state-views";
@@ -55,6 +56,7 @@ import {
 } from "@/hosted/billing/hooks";
 import { planOffers, selectOfferForTerm } from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
+import { runtimeBlurb, runtimeDisplayName } from "@/hosted/runtimes";
 import { AddProviderDialog } from "@/hosted/v2/ai-providers/add-provider-dialog";
 import { useAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import { AuthBadge, ProviderTypeChip } from "@/hosted/v2/ai-providers/ai-providers-ui";
@@ -74,7 +76,7 @@ import { cn } from "@/lib/utils";
 type Compute = "free" | "performance";
 type Engine = "openclaw" | "hermes";
 type ComputePlanSlug = DeployRequest["compute_plan_slug"];
-const DEPLOY_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.detail, "flex flex-col gap-6 px-4 lg:px-6");
+const DEPLOY_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
 const THREE_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2 lg:grid-cols-3";
 const TWO_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2";
 
@@ -301,6 +303,24 @@ function ComputeStatusLine(input: ComputeStatusInput) {
 		>
 			{status.message}
 		</p>
+	);
+}
+
+function DeploySectionSkeleton({ columns = 2 }: { columns?: 2 | 3 }) {
+	return (
+		<section className="grid gap-4 lg:grid-cols-[15rem_minmax(0,1fr)] lg:gap-x-10">
+			<Separator className="lg:col-span-2" />
+			<div className="flex max-w-sm flex-col gap-2">
+				<Skeleton className="h-4 w-24" />
+				<Skeleton className="h-3.5 w-full" />
+				<Skeleton className="h-3.5 w-3/4" />
+			</div>
+			<div className={columns === 3 ? THREE_TILE_GRID_CLASS : TWO_TILE_GRID_CLASS}>
+				{Array.from({ length: columns }).map((_, index) => (
+					<Skeleton key={index} className="h-[86px] w-full rounded-lg" />
+				))}
+			</div>
+		</section>
 	);
 }
 
@@ -551,14 +571,10 @@ export function DeployWizard() {
 		aiChoice === "managed"
 			? "Managed AI"
 			: (providerList.find((p) => p.provider_id === aiChoice)?.label ?? "Your provider");
-	const runtimeSummary =
-		enginesSelected.length === 2
-			? "Codex + OpenClaw + Hermes"
-			: enginesSelected[0] === "openclaw"
-				? "Codex + OpenClaw"
-				: enginesSelected[0] === "hermes"
-					? "Codex + Hermes"
-					: "Codex";
+	const runtimeSummary = [
+		runtimeDisplayName("codex"),
+		...enginesSelected.map((engine) => runtimeDisplayName(engine)),
+	].join(" + ");
 	const personalityLabel = PERSONALITY_PRESETS.find((p) => p.id === personality)?.label;
 	const summaryLine = [
 		agentName.trim() || null,
@@ -575,7 +591,7 @@ export function DeployWizard() {
 	if (plans.error) {
 		return (
 			<div data-hosted="true" data-v2="true" className={DEPLOY_PAGE_CLASS}>
-				<PageHeader title="Deploy an agent" />
+				<PageHeader title="Deploy an Agent" />
 				<BillingError error={plans.error} onRetry={() => plans.refetch()} />
 			</div>
 		);
@@ -584,10 +600,12 @@ export function DeployWizard() {
 	if (plans.isLoading) {
 		return (
 			<div data-hosted="true" data-v2="true" className={DEPLOY_PAGE_CLASS}>
-				<PageHeader title="Deploy an agent" description="Preparing your compute options…" />
-				<Skeleton className="h-32 w-full rounded-lg" />
-				<Skeleton className="h-32 w-full rounded-lg" />
-				<Skeleton className="h-40 w-full rounded-lg" />
+				<PageHeader title="Deploy an Agent" description="Preparing your compute options…" />
+				<DeploySectionSkeleton columns={3} />
+				<DeploySectionSkeleton />
+				<DeploySectionSkeleton />
+				<DeploySectionSkeleton />
+				<DeploySectionSkeleton />
 			</div>
 		);
 	}
@@ -595,54 +613,52 @@ export function DeployWizard() {
 	return (
 		<div data-hosted="true" data-v2="true" className={DEPLOY_PAGE_CLASS}>
 			<PageHeader
-				title="Deploy an agent"
+				title="Deploy an Agent"
 				description="Codex is included by default. Add optional runtimes and choose the AI provider for this hosted deployment."
 			/>
 
-			{/* 1. Runtime */}
-			<Card>
-				<CardHeader>
-					<CardTitle className="text-base">1. Hosted runtimes</CardTitle>
-					<CardDescription>
-						{dualAllowed
-							? "Codex stays on. Performance can also run OpenClaw and Hermes together."
-							: "Codex stays on. Free can add one optional runtime."}
-					</CardDescription>
-				</CardHeader>
-				<CardContent className={THREE_TILE_GRID_CLASS}>
+			<SettingsSection
+				title="Runtimes"
+				description={
+					dualAllowed
+						? "Codex stays on. Performance can also run OpenClaw and Hermes together."
+						: "Codex stays on. Free can add one optional runtime."
+				}
+			>
+				<div className={THREE_TILE_GRID_CLASS}>
 					<Tile
 						selected
-						leading={<EntityIcon kind="framework" id="codex" label="Codex" />}
-						title="Codex"
-						subtitle="Default hosted coding runtime."
+						leading={<EntityIcon kind="framework" id="codex" label={runtimeDisplayName("codex")} />}
+						title={runtimeDisplayName("codex")}
+						subtitle={runtimeBlurb("codex")}
 						badge={<Badge variant="outline">Always on</Badge>}
 					/>
 					<Tile
 						selected={engines.openclaw}
 						onClick={() => toggleEngine("openclaw")}
-						leading={<EntityIcon kind="framework" id="openclaw" label="OpenClaw" />}
-						title="OpenClaw"
-						subtitle="General-purpose agent runtime."
+						leading={
+							<EntityIcon kind="framework" id="openclaw" label={runtimeDisplayName("openclaw")} />
+						}
+						title={runtimeDisplayName("openclaw")}
+						subtitle={runtimeBlurb("openclaw")}
 					/>
 					<Tile
 						selected={engines.hermes}
 						onClick={() => toggleEngine("hermes")}
-						leading={<EntityIcon kind="framework" id="hermes" label="Hermes" />}
-						title="Hermes"
-						subtitle="Messaging-first agent runtime."
+						leading={
+							<EntityIcon kind="framework" id="hermes" label={runtimeDisplayName("hermes")} />
+						}
+						title={runtimeDisplayName("hermes")}
+						subtitle={runtimeBlurb("hermes")}
 					/>
-				</CardContent>
-			</Card>
+				</div>
+			</SettingsSection>
 
-			{/* 2. AI provider — mandatory, reuses /ai-providers */}
-			<Card>
-				<CardHeader>
-					<CardTitle className="text-base">2. AI provider</CardTitle>
-					<CardDescription>
-						Managed AI bills your wallet, or route through one of your own providers.
-					</CardDescription>
-				</CardHeader>
-				<CardContent className={TWO_TILE_GRID_CLASS}>
+			<SettingsSection
+				title="AI provider"
+				description="Managed AI bills your wallet, or route through one of your own providers."
+			>
+				<div className={TWO_TILE_GRID_CLASS}>
 					<Tile
 						selected={aiChoice === "managed"}
 						onClick={() => setAiChoice("managed")}
@@ -682,20 +698,18 @@ export function DeployWizard() {
 						description="Connect OpenAI, Anthropic, or another endpoint."
 						onClick={() => setAddProviderOpen(true)}
 					/>
-				</CardContent>
-			</Card>
+				</div>
+			</SettingsSection>
 
-			{/* 3. Channels — optional, reuses Channels */}
-			<Card>
-				<CardHeader>
-					<CardTitle className="text-base">
-						3. Channels <span className="font-normal text-muted-foreground">· optional</span>
-					</CardTitle>
-					<CardDescription>
-						Prepare a bot now, then link it from the agent page once deployment finishes.
-					</CardDescription>
-				</CardHeader>
-				<CardContent className={TWO_TILE_GRID_CLASS}>
+			<SettingsSection
+				title={
+					<>
+						Channels <span className="font-normal text-muted-foreground">· optional</span>
+					</>
+				}
+				description="Prepare a bot now, then link it from the agent page once deployment finishes."
+			>
+				<div className={TWO_TILE_GRID_CLASS}>
 					<Tile
 						selected
 						leading={
@@ -716,19 +730,14 @@ export function DeployWizard() {
 						description="Prepare a bot; link it after provisioning."
 						onClick={() => setConnectChannelOpen(true)}
 					/>
-				</CardContent>
-			</Card>
+				</div>
+			</SettingsSection>
 
-			{/* 4. Compute */}
-			<Card>
-				<CardHeader>
-					<CardTitle className="text-base">4. Compute</CardTitle>
-					<CardDescription>
-						Free gives one active hosted deployment. Performance is billed per deployment and can
-						run both optional runtimes.
-					</CardDescription>
-				</CardHeader>
-				<CardContent className="flex flex-col gap-3">
+			<SettingsSection
+				title="Compute"
+				description="Free gives one active hosted deployment. Performance is billed per deployment and can run both optional runtimes."
+			>
+				<div className="flex flex-col gap-3">
 					<div className="grid gap-2 sm:grid-cols-2">
 						<Tile
 							selected={compute === "free"}
@@ -792,18 +801,18 @@ export function DeployWizard() {
 						freePlan={freePlan}
 						perfOffer={perfOffer}
 					/>
-				</CardContent>
-			</Card>
+				</div>
+			</SettingsSection>
 
-			{/* 5. Personalize — name, personality, language, timezone */}
-			<Card>
-				<CardHeader>
-					<CardTitle className="text-base">
-						5. Personalize <span className="font-normal text-muted-foreground">· optional</span>
-					</CardTitle>
-					<CardDescription>Give your agent a name, tone, language, and timezone.</CardDescription>
-				</CardHeader>
-				<CardContent className="flex flex-col gap-4">
+			<SettingsSection
+				title={
+					<>
+						Personalize <span className="font-normal text-muted-foreground">· optional</span>
+					</>
+				}
+				description="Give your agent a name, tone, language, and timezone."
+			>
+				<div className="flex flex-col gap-4">
 					<div className="flex flex-col gap-1.5">
 						<label htmlFor="agent-name" className="text-sm text-muted-foreground">
 							Name
@@ -868,8 +877,8 @@ export function DeployWizard() {
 							<TimezoneCombobox value={timezone} onValueChange={setTimezone} options={tzOptions} />
 						</div>
 					) : null}
-				</CardContent>
-			</Card>
+				</div>
+			</SettingsSection>
 
 			{/* Sticky action bar */}
 			<div className="sticky bottom-0 -mx-4 border-t bg-background/90 px-4 py-3 backdrop-blur lg:-mx-6 lg:px-6">

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -308,12 +308,12 @@ function ComputeStatusLine(input: ComputeStatusInput) {
 
 function DeploySectionSkeleton({ columns = 2 }: { columns?: 2 | 3 }) {
 	return (
-		<section className="grid gap-4 lg:grid-cols-[15rem_minmax(0,1fr)] lg:gap-x-10">
-			<Separator className="lg:col-span-2" />
-			<div className="flex max-w-sm flex-col gap-2">
+		<section className="flex flex-col gap-4">
+			<Separator />
+			<div className="flex max-w-2xl flex-col gap-2">
 				<Skeleton className="h-4 w-24" />
-				<Skeleton className="h-3.5 w-full" />
-				<Skeleton className="h-3.5 w-3/4" />
+				<Skeleton className="h-3.5 w-80 max-w-full" />
+				<Skeleton className="h-3.5 w-56 max-w-full" />
 			</div>
 			<div className={columns === 3 ? THREE_TILE_GRID_CLASS : TWO_TILE_GRID_CLASS}>
 				{Array.from({ length: columns }).map((_, index) => (

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -188,6 +188,7 @@ export function useCreateDeployment() {
 		mutationFn: (body: DeployRequest) => client.createDeployment(body),
 		onSuccess: () => {
 			qc.invalidateQueries({ queryKey: billingKeys.deployments });
+			qc.invalidateQueries({ queryKey: ["agents"] });
 		},
 	});
 }

--- a/apps/web/src/hosted/billing/subscription/subscription-page.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-page.tsx
@@ -20,7 +20,7 @@ import { cn } from "@/lib/utils";
 const DESCRIPTION =
 	"Plan options for new hosted agents. Existing compute is managed from each agent’s Settings.";
 const SUBSCRIPTION_PAGE_CLASS = cn(
-	CENTERED_PAGE_WIDTH_CLASS.wide,
+	CENTERED_PAGE_WIDTH_CLASS.page,
 	"flex flex-col gap-6 px-4 lg:px-6",
 );
 

--- a/apps/web/src/hosted/billing/usage/usage-page.tsx
+++ b/apps/web/src/hosted/billing/usage/usage-page.tsx
@@ -11,7 +11,7 @@ import { formatShortDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "AI Credit consumption across your agents. Wallet credits do not reset.";
-const USAGE_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.wide, "space-y-6 px-4 lg:px-6");
+const USAGE_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6");
 
 export function UsagePage() {
 	const usage = useUsage();

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -73,9 +73,13 @@ export function TopUpDialog({
 	}
 
 	function close(next: boolean) {
-		if (!next) reset();
 		onOpenChange(next);
 	}
+
+	useEffect(() => {
+		if (!open) return;
+		reset();
+	}, [open]);
 
 	async function onContinue() {
 		// Guard double-submit: the button disables on pending, but a fast

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -17,7 +17,7 @@ import { X402Card } from "@/hosted/billing/wallet/x402-card";
 import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Your AI Credits balance, top-ups, and auto-reload.";
-const WALLET_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.wide, "space-y-6 px-4 lg:px-6");
+const WALLET_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6");
 
 function scrollToAutoReload() {
 	document.getElementById("auto-reload")?.scrollIntoView({ behavior: "smooth", block: "center" });

--- a/apps/web/src/hosted/runtimes.ts
+++ b/apps/web/src/hosted/runtimes.ts
@@ -16,17 +16,17 @@ const RUNTIME_ORDER = new Map<HostedRuntime, number>(
 const RUNTIME_META = {
 	codex: {
 		label: "Codex",
-		blurb: "Default hosted coding runtime.",
+		blurb: "OpenAI's software engineering agent.",
 		canDisable: false,
 	},
 	openclaw: {
 		label: "OpenClaw",
-		blurb: "General-purpose agent runtime.",
+		blurb: "Your own personal AI assistant.",
 		canDisable: true,
 	},
 	hermes: {
 		label: "Hermes",
-		blurb: "Messaging-first agent runtime.",
+		blurb: "The agent that grows with you.",
 		canDisable: true,
 	},
 } as const satisfies Record<HostedRuntime, { label: string; blurb: string; canDisable: boolean }>;

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
@@ -99,6 +99,7 @@ function exactVaultRef(projectId: string, slug: string, section: string, field: 
  */
 export function useSaveApiKeyToVault() {
 	const api = useApi();
+	const qc = useQueryClient();
 	return useMutation({
 		mutationFn: async (vars: { providerId: string; apiKey: string }): Promise<string> => {
 			const proj = unwrap(await api.GET("/v1/projects/default"));
@@ -120,6 +121,10 @@ export function useSaveApiKeyToVault() {
 				}),
 			);
 			return exactVaultRef(projectId, slug, section, field);
+		},
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: ["vaults"] });
+			qc.invalidateQueries({ queryKey: ["vault-items"] });
 		},
 		onError: toastApiError("Couldn't save to vault"),
 	});

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
@@ -31,7 +31,7 @@ import { formatModelLabel } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Choose how your agents reach a model.";
-const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.wide, "flex flex-col gap-6 px-4 lg:px-6");
+const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
 const PROVIDER_GRID_CLASS = ENTITY_GRID_CLASS;
 
 export function AiProvidersPage() {

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.tsx
@@ -3,6 +3,7 @@
 import { ShieldCheck, Sparkles } from "lucide-react";
 import { ENTITY_CARD_BASE, EntityHeader } from "@/components/entity-card";
 import { EntityIcon, type EntityIconSize } from "@/components/entity-icon";
+import { Badge } from "@/components/ui/badge";
 import { providerTypeMeta } from "@/hosted/v2/ai-providers/provider-types";
 import type { AiProviderAuth } from "@/hosted/v2/ai-providers/types";
 import { cn } from "@/lib/utils";
@@ -36,13 +37,14 @@ const AUTH_LABEL: Record<string, string> = {
 export function AuthBadge({ auth }: { auth: AiProviderAuth }) {
 	const label = AUTH_LABEL[auth.type] ?? auth.type;
 	return (
-		<span
+		<Badge
 			data-hosted="true"
 			data-v2="true"
-			className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
+			variant="secondary"
+			className="rounded-full px-2 py-0.5 text-[11px] text-muted-foreground"
 		>
 			{label}
-		</span>
+		</Badge>
 	);
 }
 

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -79,7 +79,7 @@ import {
 } from "@/lib/agent-ownership";
 import { cn, relativeTime } from "@/lib/utils";
 
-const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.detail, "flex flex-col gap-6 px-4 lg:px-6");
+const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
 const LIST_TAB_CLASS = "mt-4 min-w-0";
 const FORM_TAB_CLASS = "mt-4 min-w-0 max-w-xl";
 

--- a/apps/web/src/hosted/v2/channels/channels-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channels-page.tsx
@@ -30,7 +30,7 @@ import { SharedBotsPool } from "@/hosted/v2/channels/shared-bots-pool";
 import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Connect Telegram, Discord, WhatsApp, and iMessage to your agents.";
-const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.wide, "flex flex-col gap-6 px-4 lg:px-6");
+const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
 const CHANNEL_GRID_CLASS = ENTITY_GRID_CLASS;
 
 export function ChannelsPage() {

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -62,17 +62,16 @@ export function ConnectBotDialog({
 	const [created, setCreated] = useState<ChannelCreated | null>(null);
 
 	useEffect(() => {
-		if (!open) {
-			setProvider("telegram");
-			setName("");
-			setToken("");
-			setApplicationId("");
-			setPublicKey("");
-			setGuildId("");
-			setServerUrl("");
-			setAuthMode("password_query");
-			setCreated(null);
-		}
+		if (!open) return;
+		setProvider("telegram");
+		setName("");
+		setToken("");
+		setApplicationId("");
+		setPublicKey("");
+		setGuildId("");
+		setServerUrl("");
+		setAuthMode("password_query");
+		setCreated(null);
 	}, [open]);
 
 	const meta = providerMeta(provider);

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
@@ -64,11 +64,10 @@ export function LinkAgentDialog({
 	const [linkedNoToken, setLinkedNoToken] = useState(false);
 
 	useEffect(() => {
-		if (!open) {
-			setAgentId("");
-			setToken(null);
-			setLinkedNoToken(false);
-		}
+		if (!open) return;
+		setAgentId("");
+		setToken(null);
+		setLinkedNoToken(false);
 	}, [open]);
 
 	function submit() {

--- a/apps/web/src/lib/document-title.test.ts
+++ b/apps/web/src/lib/document-title.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { APP_TITLE, formatDocumentTitle } from "@/lib/document-title";
+
+describe("formatDocumentTitle", () => {
+	test("formats route titles with the app name", () => {
+		expect(formatDocumentTitle("Sessions")).toBe(`Sessions · ${APP_TITLE}`);
+	});
+
+	test("trims registered breadcrumb titles", () => {
+		expect(formatDocumentTitle("  Project Alpha  ")).toBe(`Project Alpha · ${APP_TITLE}`);
+	});
+
+	test("falls back to the app title for empty values", () => {
+		expect(formatDocumentTitle(null)).toBe(APP_TITLE);
+		expect(formatDocumentTitle("   ")).toBe(APP_TITLE);
+	});
+});

--- a/apps/web/src/lib/document-title.ts
+++ b/apps/web/src/lib/document-title.ts
@@ -1,0 +1,12 @@
+export const APP_TITLE = "Clawdi";
+
+export function formatDocumentTitle(title: string | null | undefined): string {
+	const trimmed = title?.trim();
+	return trimmed ? `${trimmed} · ${APP_TITLE}` : APP_TITLE;
+}
+
+export function routeHeadTitle(title: string) {
+	return {
+		meta: [{ title: formatDocumentTitle(title) }],
+	};
+}

--- a/apps/web/src/pages/dashboard/agents/agent-detail-client.tsx
+++ b/apps/web/src/pages/dashboard/agents/agent-detail-client.tsx
@@ -2,6 +2,7 @@
 
 import { lazy, Suspense } from "react";
 import { ConnectedAgentDetail } from "@/components/dashboard/connected-agent-detail";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { AgentSectionId } from "@/lib/agent-routes";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
@@ -48,7 +49,7 @@ export function AgentDetailClient({
 
 function AgentDetailSkeleton() {
 	return (
-		<div className="space-y-4 px-4 py-2 lg:px-6">
+		<div className={`${CENTERED_PAGE_WIDTH_CLASS.page} space-y-4 px-4 py-2 lg:px-6`}>
 			<Skeleton className="h-10 w-64" />
 			<Skeleton className="h-9 w-full max-w-md" />
 			<Skeleton className="h-48 w-full" />

--- a/apps/web/src/pages/dashboard/agents/page.tsx
+++ b/apps/web/src/pages/dashboard/agents/page.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { lazy, Suspense, useMemo } from "react";
 import { AgentsCard, selfManagedAgentTiles } from "@/components/dashboard/agents-card";
 import { PageHeader } from "@/components/page-header";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { unwrap, useApi } from "@/lib/api";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 
@@ -47,7 +48,7 @@ export default function AgentsIndexPage() {
 	const hostedSectionEnabled = hostedAgentsEnabled || legacyHostedAgentsEnabled;
 
 	return (
-		<div className="space-y-6 px-4 lg:px-6">
+		<div className={`${CENTERED_PAGE_WIDTH_CLASS.page} space-y-6 px-4 lg:px-6`}>
 			<PageHeader title="Agents" description="Every agent connected to your account." />
 			{hostedAccessLoading ? (
 				<AgentsCard agents={selfManagedTiles} isLoading />

--- a/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
+++ b/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
@@ -4,12 +4,14 @@ import { AlertCircle, Check, Link2Off, Plug, Wrench } from "lucide-react";
 import { parseAsString, useQueryStates } from "nuqs";
 import { Suspense, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { getConnectorAuthFlow } from "@/components/connectors/auth-flow.logic";
 import { ConnectorIcon } from "@/components/connectors/connector-icon";
 import { ConnectorCredentialsDialog } from "@/components/connectors/credentials-dialog";
 import { DashboardSection, DashboardSectionHeader } from "@/components/dashboard/section";
 import { DetailTitle } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -51,7 +53,7 @@ export default function ConnectorDetailPage({ name }: { name: string }) {
 
 function DetailSkeletonShell() {
 	return (
-		<div className="flex flex-col gap-4 px-4 lg:px-6">
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-4 px-4 lg:px-6")}>
 			<DetailSkeleton />
 		</div>
 	);
@@ -233,10 +235,11 @@ function ConnectorDetail({ name }: { name: string }) {
 	const isStarting = connectMutation.isPending;
 	const isConnectDisabled = isStarting || hasUnsupportedAuthType || isSetupBlocked;
 	const isReady = isConnected || usesNoAuth;
+	useSetBreadcrumbTitle(displayName);
 
 	if (isLoading) {
 		return (
-			<div className="flex flex-col gap-4 px-4 lg:px-6">
+			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-4 px-4 lg:px-6")}>
 				<DetailSkeleton />
 			</div>
 		);
@@ -248,7 +251,7 @@ function ConnectorDetail({ name }: { name: string }) {
 	// silently-broken connect page.
 	if (appQ.error) {
 		return (
-			<div className="flex flex-col gap-4 px-4 lg:px-6">
+			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-4 px-4 lg:px-6")}>
 				<EmptyState
 					icon={Plug}
 					title="Connector unavailable"
@@ -259,7 +262,7 @@ function ConnectorDetail({ name }: { name: string }) {
 	}
 
 	return (
-		<div className="flex flex-col gap-4 px-4 lg:px-6">
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-4 px-4 lg:px-6")}>
 			{/* Header — matches clawdi ConnectorHeader */}
 			<div className="flex items-start gap-5">
 				<ConnectorIcon logo={app?.logo} name={displayName} size="lg" />

--- a/apps/web/src/pages/dashboard/connectors/page.tsx
+++ b/apps/web/src/pages/dashboard/connectors/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/dashboard/section";
 import { EmptyState } from "@/components/empty-state";
 import { PageHeader } from "@/components/page-header";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -58,11 +59,8 @@ export default function ConnectorsPage() {
 
 function ConnectorsListSkeleton() {
 	return (
-		<div className="space-y-5 px-4 lg:px-6">
-			<div className="flex flex-col gap-2">
-				<Skeleton className="h-8 w-32" />
-				<Skeleton className="h-4 w-72" />
-			</div>
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
+			<PageHeader title="Connectors" description={CONNECTORS_RESOURCE.managementDescription} />
 			<Skeleton className="h-10 w-full" />
 			<div className={CONNECTOR_GRID_CLASS}>
 				{Array.from({ length: 16 }).map((_, i) => (
@@ -141,7 +139,7 @@ function ConnectorsList() {
 		!debouncedQuery && (connected.activeConnections.length > 0 || !!connected.error);
 
 	return (
-		<div className="space-y-5 px-4 lg:px-6">
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 			<PageHeader title="Connectors" description={CONNECTORS_RESOURCE.managementDescription} />
 
 			<DashboardSection>

--- a/apps/web/src/pages/dashboard/memories/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/memories/[id]/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useRouter } from "@tanstack/react-router";
 import { Brain, Laptop, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { DetailMeta, DetailNotFound, DetailPanel, DetailTitle } from "@/components/detail/layout";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
+import { TimeTooltip } from "@/components/time-tooltip";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
@@ -13,11 +15,12 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { unwrap, useApi } from "@/lib/api";
 import { MEMORY_CATEGORY_COLORS } from "@/lib/memory-utils";
 import { projectResourceHref } from "@/lib/project-resource-model";
-import { cn, errorMessage, formatAbsoluteTooltip, relativeTime } from "@/lib/utils";
+import { cn, errorMessage, relativeTime } from "@/lib/utils";
 
 export default function MemoryDetailPage({ memoryId }: { memoryId: string }) {
 	const router = useRouter();
 	const api = useApi();
+	const queryClient = useQueryClient();
 
 	const {
 		data: memory,
@@ -50,6 +53,7 @@ export default function MemoryDetailPage({ memoryId }: { memoryId: string }) {
 			toast.success("Memory Deleted", {
 				description: "Your agents will no longer recall it.",
 			});
+			queryClient.invalidateQueries({ queryKey: ["memories"] });
 			void router.navigate({ href: projectResourceHref("memories") });
 		},
 		onError: (e) => toast.error("Couldn't delete memory", { description: errorMessage(e) }),
@@ -58,7 +62,7 @@ export default function MemoryDetailPage({ memoryId }: { memoryId: string }) {
 	const onDelete = () => deleteMemory.mutate();
 
 	return (
-		<div className="space-y-5 px-4 lg:px-6">
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 			{error ? (
 				<DetailNotFound title="Memory not found" message={errorMessage(error)} />
 			) : isLoading ? (
@@ -89,9 +93,9 @@ export default function MemoryDetailPage({ memoryId }: { memoryId: string }) {
 								{memory.created_at ? (
 									<>
 										<span>·</span>
-										<span title={formatAbsoluteTooltip(memory.created_at)}>
-											Saved {relativeTime(memory.created_at)}
-										</span>
+										<TimeTooltip value={memory.created_at}>
+											<span>Saved {relativeTime(memory.created_at)}</span>
+										</TimeTooltip>
 									</>
 								) : null}
 								{/* Whether agents actually USE a memory is the

--- a/apps/web/src/pages/dashboard/memories/page.tsx
+++ b/apps/web/src/pages/dashboard/memories/page.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { findLikelySecret, formatSecretMemoryWarning } from "@clawdi/shared";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { AlertCircle, Brain, Database, Key, Laptop, Plus, Trash2 } from "lucide-react";
 import { type ReactNode, useCallback, useState } from "react";
 import { toast } from "sonner";
 import { EmptyState } from "@/components/empty-state";
 import { PageHeader } from "@/components/page-header";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
+import { TimeTooltip } from "@/components/time-tooltip";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -36,6 +38,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { unwrap, useApi } from "@/lib/api";
 import type { Memory } from "@/lib/api-schemas";
 import { MEMORY_CATEGORY_COLORS } from "@/lib/memory-utils";
@@ -87,7 +90,7 @@ export default function MemoriesPage() {
 		onError: (e) => toast.error("Couldn't update settings", { description: errorMessage(e) }),
 	});
 
-	const { data, isLoading, error } = useQuery({
+	const { data, isLoading, isFetching, error } = useQuery({
 		queryKey: ["memories", debouncedSearch, apiCategory, pagination.pageIndex, pagination.pageSize],
 		queryFn: async () =>
 			unwrap(
@@ -102,6 +105,7 @@ export default function MemoriesPage() {
 					},
 				}),
 			),
+		placeholderData: keepPreviousData,
 	});
 
 	const memories = data?.items;
@@ -134,7 +138,7 @@ export default function MemoriesPage() {
 		/>
 	);
 	return (
-		<div className="space-y-6 px-4 lg:px-6">
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6")}>
 			<PageHeader
 				title="Memories"
 				description={MEMORIES_RESOURCE.managementDescription}
@@ -208,7 +212,12 @@ export default function MemoriesPage() {
 					<AlertDescription>{errorMessage(error)}</AlertDescription>
 				</Alert>
 			) : (
-				<>
+				<div
+					className={cn(
+						"space-y-6 transition-opacity",
+						isFetching && !isLoading ? "opacity-60" : "opacity-100",
+					)}
+				>
 					<MemoryNotesGrid
 						memories={memories ?? []}
 						isLoading={isLoading}
@@ -216,7 +225,7 @@ export default function MemoriesPage() {
 						onDelete={requestDeleteMemory}
 					/>
 					{paginationFooter}
-				</>
+				</div>
 			)}
 		</div>
 	);
@@ -286,15 +295,21 @@ function MemoryNotesGrid({
 							</span>
 						))}
 						<span className="ml-auto inline-flex items-center gap-2 text-xs text-muted-foreground">
-							{memory.created_at ? <span>{relativeTime(memory.created_at)}</span> : null}
+							{memory.created_at ? (
+								<TimeTooltip value={memory.created_at}>
+									<span>{relativeTime(memory.created_at)}</span>
+								</TimeTooltip>
+							) : null}
 							{memory.source_machine_name ? (
-								<span
-									className="inline-flex min-w-0 items-center gap-1"
-									title={`Learned on ${memory.source_machine_name}`}
-								>
-									<Laptop className="size-3 shrink-0" />
-									<span className="max-w-28 truncate">{memory.source_machine_name}</span>
-								</span>
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<span className="inline-flex min-w-0 items-center gap-1">
+											<Laptop className="size-3 shrink-0" />
+											<span className="max-w-28 truncate">{memory.source_machine_name}</span>
+										</span>
+									</TooltipTrigger>
+									<TooltipContent>Learned on {memory.source_machine_name}</TooltipContent>
+								</Tooltip>
 							) : null}
 						</span>
 					</div>

--- a/apps/web/src/pages/dashboard/page.tsx
+++ b/apps/web/src/pages/dashboard/page.tsx
@@ -14,6 +14,7 @@ import { ContributionGraph } from "@/components/dashboard/contribution-graph";
 import { OnboardingCard } from "@/components/dashboard/onboarding-card";
 import { type ProjectTypeCounts, ResourcesCard } from "@/components/dashboard/resources-card";
 import { ThisWeekCard } from "@/components/dashboard/this-week-card";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SessionFeed } from "@/components/sessions/session-feed";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -22,7 +23,7 @@ import { unwrap, useApi } from "@/lib/api";
 import { useCurrentUser } from "@/lib/auth-client";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { sessionListQueryOptions } from "@/lib/session-queries";
-import { relativeTime } from "@/lib/utils";
+import { cn, relativeTime } from "@/lib/utils";
 
 const RECENT_SESSIONS_LIMIT = 15;
 const RECENT_SESSIONS_CACHE_PAGE_SIZE = 25;
@@ -76,7 +77,10 @@ export default function DashboardPage() {
 	const { data: stats, isLoading: statsLoading } = useQuery({
 		queryKey: ["dashboard-stats"],
 		queryFn: async () => unwrap(await api.GET("/v1/dashboard/stats")),
-		staleTime: DASHBOARD_STALE_MS,
+		// Overview counts are cheap and reflect recent mutations across many
+		// resources, so keep this query fresher than the global 30s default.
+		staleTime: 0,
+		refetchOnMount: "always",
 	});
 
 	const { data: projects, isLoading: projectsLoading } = useQuery({
@@ -138,7 +142,7 @@ export default function DashboardPage() {
 	const hostedSectionEnabled = hostedAgentsEnabled || legacyHostedAgentsEnabled;
 
 	return (
-		<div className="space-y-5 px-4 lg:px-6">
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 			<Greeting
 				activeCount={fleetAgents.filter((env) => isAgentActive(env.last_seen_at)).length}
 				total={fleetAgents.length}
@@ -182,7 +186,7 @@ export default function DashboardPage() {
 						</CardHeader>
 						<CardContent>
 							{statsLoading ? (
-								<Skeleton className="h-28 w-full rounded-md" />
+								<ActivityGraphSkeleton />
 							) : contribution ? (
 								<ContributionGraph data={contribution} />
 							) : null}
@@ -244,6 +248,52 @@ export default function DashboardPage() {
 					/>
 					<ThisWeekCard stats={stats} contribution={contribution} />
 				</div>
+			</div>
+		</div>
+	);
+}
+
+function ActivityGraphSkeleton() {
+	return (
+		<div className="w-full">
+			<div className="flex gap-1.5">
+				<div className="flex w-[22px] shrink-0 flex-col gap-[3px] pt-5">
+					{Array.from({ length: 7 }).map((_, index) => (
+						<Skeleton
+							key={index}
+							className={cn("h-[11px] rounded-sm", index % 2 === 1 ? "w-5" : "w-2")}
+						/>
+					))}
+				</div>
+				<div className="min-w-0 flex-1">
+					<div className="mb-1 flex h-4 items-center gap-10">
+						{Array.from({ length: 6 }).map((_, index) => (
+							<Skeleton key={index} className="h-2.5 w-6" />
+						))}
+					</div>
+					<div className="flex max-h-[95px] overflow-hidden gap-[3px]">
+						{Array.from({ length: 52 }).map((_, weekIndex) => (
+							<div key={weekIndex} className="flex flex-col gap-[3px]">
+								{Array.from({ length: 7 }).map((_, dayIndex) => (
+									<Skeleton
+										key={dayIndex}
+										className={cn(
+											"size-[11px] rounded-sm",
+											(weekIndex + dayIndex) % 5 === 0 && "opacity-50",
+										)}
+									/>
+								))}
+							</div>
+						))}
+					</div>
+				</div>
+			</div>
+			<div className="mt-3 flex justify-end gap-1.5">
+				<Skeleton className="h-3 w-7" />
+				{Array.from({ length: 5 }).map((_, index) => (
+					<Skeleton key={index} className="size-[11px] rounded-sm" />
+				))}
+				<Skeleton className="h-3 w-8" />
 			</div>
 		</div>
 	);

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -23,6 +23,7 @@ import {
 	compareAgentEnvironments,
 } from "@/components/dashboard/agent-label";
 import { DetailNotFound, DetailPanel, DetailTitle } from "@/components/detail/layout";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import {
 	displayProjectName,
 	isCustomProject,
@@ -151,7 +152,6 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 					),
 				{ pageSize: 200, resourceName: "project skills" },
 			),
-		enabled: !!project,
 	});
 
 	const vaults = useQuery({
@@ -166,7 +166,6 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 					),
 				{ pageSize: 200, resourceName: "project vaults" },
 			),
-		enabled: !!project,
 	});
 
 	// People tile/section — members list is owner-only on the API; viewers
@@ -241,7 +240,7 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 
 	if (projects.isLoading) {
 		return (
-			<div className="space-y-5 px-4 lg:px-6">
+			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 				<Skeleton className="h-8 w-24" />
 				<div className="flex items-start gap-3">
 					<Skeleton className="size-11 rounded-xl" />
@@ -263,7 +262,7 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 
 	if (projects.error) {
 		return (
-			<div className="space-y-5 px-4 lg:px-6">
+			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 				<Button asChild variant="ghost" size="sm" className="w-fit">
 					<Link to="/projects">
 						<ArrowLeft className="mr-1.5 size-4" />
@@ -280,7 +279,7 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 
 	if (!project) {
 		return (
-			<div className="space-y-5 px-4 lg:px-6">
+			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 				<Button asChild variant="ghost" size="sm" className="w-fit">
 					<Link to="/projects">
 						<ArrowLeft className="mr-1.5 size-4" />
@@ -313,7 +312,7 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 	);
 
 	return (
-		<div className="space-y-6 px-4 lg:px-6">
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6")}>
 			<Button asChild variant="ghost" size="sm" className="w-fit">
 				<Link to="/projects">
 					<ArrowLeft className="mr-1.5 size-4" />
@@ -846,7 +845,7 @@ function UseProjectWithAgentDialog({
 			<DialogTrigger asChild>{children}</DialogTrigger>
 			<DialogContent className="sm:max-w-lg">
 				<DialogHeader>
-					<DialogTitle>Add Project to Agent</DialogTitle>
+					<DialogTitle>Add project to agent</DialogTitle>
 					<DialogDescription>
 						Add {projectName} as an extra Project for an agent. The agent&apos;s main Project stays
 						the writable default; this Project is read by the agent.

--- a/apps/web/src/pages/dashboard/projects/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useRouter } from "@tanstack/react-router";
 import { ChevronDown, Key, Plus, Share2, Sparkles } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { PageHeader } from "@/components/page-header";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import {
 	displayProjectName,
 	isCustomProject,
@@ -57,6 +58,7 @@ export default function ProjectsPage() {
 	const projects = useQuery({
 		queryKey: ["projects"],
 		queryFn: async (): Promise<ProjectRow[]> => unwrap(await api.GET("/v1/projects")),
+		placeholderData: keepPreviousData,
 	});
 
 	const rows = projects.data ?? [];
@@ -80,11 +82,13 @@ export default function ProjectsPage() {
 					unwrap(await api.GET("/v1/skills", { params: { query: { page, page_size: pageSize } } })),
 				{ pageSize: 200, resourceName: "skills" },
 			),
+		placeholderData: keepPreviousData,
 	});
 	const vaults = useQuery({
 		queryKey: ["vaults", "all"],
 		queryFn: async () =>
 			unwrap(await api.GET("/v1/vault", { params: { query: { page_size: 200 } } })),
+		placeholderData: keepPreviousData,
 	});
 	const skillCounts = useMemo(() => {
 		const m = new Map<string, number>();
@@ -169,7 +173,7 @@ export default function ProjectsPage() {
 
 	if (projects.isLoading) {
 		return (
-			<div className="space-y-6 px-4 lg:px-6">
+			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6")}>
 				<PageHeader title="Projects" description={PROJECTS_RESOURCE.managementDescription} />
 				<div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
 					{Array.from({ length: 6 }).map((_, i) => (
@@ -181,7 +185,7 @@ export default function ProjectsPage() {
 	}
 
 	return (
-		<div className="space-y-6 px-4 lg:px-6">
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6")}>
 			<PageHeader
 				title="Projects"
 				description={PROJECTS_RESOURCE.managementDescription}
@@ -283,7 +287,12 @@ export default function ProjectsPage() {
 					No projects match “{search.trim()}”.
 				</p>
 			) : (
-				<div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+				<div
+					className={cn(
+						"grid gap-4 transition-opacity sm:grid-cols-2 xl:grid-cols-3",
+						projects.isFetching && !projects.isLoading ? "opacity-60" : "opacity-100",
+					)}
+				>
 					{gridProjects.map(({ project, shared }) => (
 						<ProjectCard
 							key={project.id}

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -17,10 +17,12 @@ import { DetailMeta, DetailPanel, DetailStats, DetailTitle } from "@/components/
 import { EmptyState } from "@/components/empty-state";
 import { ModelBadge } from "@/components/meta/model-badge";
 import { Stat } from "@/components/meta/stat";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { MessageList } from "@/components/sessions/message-list";
 import { sessionAgentIdentityInput } from "@/components/sessions/session-agent-label";
 import { SessionSidebar } from "@/components/sessions/session-sidebar";
 import { SessionShareControls } from "@/components/sessions/share-controls";
+import { TimeTooltip } from "@/components/time-tooltip";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -34,13 +36,7 @@ import {
 	SESSION_MESSAGES_GC_MS,
 	SESSION_MESSAGES_STALE_MS,
 } from "@/lib/session-queries";
-import {
-	cn,
-	formatAbsoluteTooltip,
-	formatNumber,
-	formatSessionSummary,
-	relativeTime,
-} from "@/lib/utils";
+import { cn, formatNumber, formatSessionSummary, relativeTime } from "@/lib/utils";
 
 export default function SessionDetailPage({ sessionId }: { sessionId: string }) {
 	return <SessionDetailContent sessionId={sessionId} />;
@@ -243,7 +239,7 @@ export function SessionDetailContent({
 
 	if (isSessionLoading) {
 		return (
-			<div className="space-y-5 px-4 lg:px-6">
+			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 				<DetailSkeleton />
 			</div>
 		);
@@ -251,7 +247,7 @@ export function SessionDetailContent({
 
 	if (!session || !summaryText) {
 		return (
-			<div className="space-y-5 px-4 lg:px-6">
+			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 				<p className="text-muted-foreground">Session not found.</p>
 			</div>
 		);
@@ -260,7 +256,7 @@ export function SessionDetailContent({
 	const totalTokens = (session.input_tokens ?? 0) + (session.output_tokens ?? 0);
 
 	return (
-		<div className="space-y-5 px-4 lg:px-6">
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 			<div className="flex items-start justify-between gap-3">
 				<div className="min-w-0 flex-1 space-y-2">
 					<DetailTitle>{summaryText}</DetailTitle>
@@ -279,9 +275,9 @@ export function SessionDetailContent({
 							</>
 						) : null}
 						<span>·</span>
-						<span title={formatAbsoluteTooltip(session.started_at)}>
-							Started {relativeTime(session.started_at)}
-						</span>
+						<TimeTooltip value={session.started_at}>
+							<span>Started {relativeTime(session.started_at)}</span>
+						</TimeTooltip>
 						{/* Surface "last activity" only when meaningfully
 					    different from started_at (long-running sessions).
 					    Threshold of 5 minutes — short sessions render
@@ -296,9 +292,9 @@ export function SessionDetailContent({
 						5 * 60_000 ? (
 							<>
 								<span>·</span>
-								<span title={formatAbsoluteTooltip(session.last_activity_at)}>
-									Last activity {relativeTime(session.last_activity_at)}
-								</span>
+								<TimeTooltip value={session.last_activity_at}>
+									<span>Last activity {relativeTime(session.last_activity_at)}</span>
+								</TimeTooltip>
 							</>
 						) : null}
 					</DetailMeta>

--- a/apps/web/src/pages/dashboard/sessions/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/page.tsx
@@ -14,6 +14,7 @@ import { Suspense, useEffect, useMemo, useState } from "react";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import { agentTypeLabel } from "@/components/dashboard/agent-label";
 import { PageHeader } from "@/components/page-header";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { sessionColumns } from "@/components/sessions/session-columns";
 import { SessionFeed } from "@/components/sessions/session-feed";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -65,7 +66,7 @@ export default function SessionsPage() {
 	return (
 		<Suspense
 			fallback={
-				<div className="space-y-5 px-4 lg:px-6">
+				<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 					<PageHeader title="Sessions" />
 				</div>
 			}
@@ -307,7 +308,7 @@ function SessionsListInner() {
 	);
 
 	return (
-		<div className="space-y-5 px-4 lg:px-6">
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 			<PageHeader
 				title="Sessions"
 				description={SESSIONS_RESOURCE.managementDescription}

--- a/apps/web/src/pages/dashboard/skills/[key]/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/[key]/page.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/components/detail/layout";
 import { Markdown } from "@/components/markdown";
 import { Stat } from "@/components/meta/stat";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { isProjectOwner, ProjectIdentity } from "@/components/projects/project-metadata";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -39,7 +40,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { ApiError, unwrap, useApi } from "@/lib/api";
 import { decodeResourceRouteParam, projectResourceHref } from "@/lib/project-resource-model";
-import { errorMessage, relativeTime } from "@/lib/utils";
+import { cn, errorMessage, relativeTime } from "@/lib/utils";
 
 // Strip the leading `---\n...\n---` YAML frontmatter so the markdown
 // renderer doesn't show "name:" / "description:" lines (already
@@ -304,7 +305,7 @@ export function SkillDetailContent({
 	);
 
 	return (
-		<div className="space-y-5 px-4 lg:px-6">
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 			{!skillKey ? (
 				<DetailNotFound title="Skill not found" message="The URL is missing a skill key." />
 			) : error ? (

--- a/apps/web/src/pages/dashboard/skills/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { FEATURED_SKILLS } from "@clawdi/shared/consts";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import {
 	AlertCircle,
@@ -23,6 +23,7 @@ import { toast } from "sonner";
 import { BulkActionBar } from "@/components/bulk-action-bar";
 import { agentIdentity } from "@/components/dashboard/agent-label";
 import { PageHeader } from "@/components/page-header";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import {
 	compareProjectsForUse,
 	displayProjectName,
@@ -155,6 +156,7 @@ function SkillsPageInner() {
 	const {
 		data: skillsData,
 		isLoading: skillsLoading,
+		isFetching: skillsFetching,
 		error: skillsError,
 	} = useQuery({
 		queryKey: ["skills", "all-projects"],
@@ -169,6 +171,7 @@ function SkillsPageInner() {
 				{ pageSize: 200, resourceName: "skills" },
 			),
 		enabled: !isResolvingTarget,
+		placeholderData: keepPreviousData,
 	});
 	// Tab row shows custom + personal projects; the per-agent long tail
 	// lives behind one overflow menu (a 16-tab row teaches nothing).
@@ -495,7 +498,7 @@ function SkillsPageInner() {
 		) : null;
 
 	return (
-		<div className="space-y-6 px-4 lg:px-6">
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6")}>
 			<PageHeader
 				title="Skills"
 				description={SKILLS_RESOURCE.managementDescription}
@@ -614,7 +617,12 @@ function SkillsPageInner() {
 				</Alert>
 			) : null}
 
-			<section className="space-y-3">
+			<section
+				className={cn(
+					"space-y-3 transition-opacity",
+					skillsFetching && !skillsLoading ? "opacity-60" : "opacity-100",
+				)}
+			>
 				<div className="flex flex-wrap items-center gap-2">
 					<div className="flex items-center gap-2">
 						<h2 className="text-sm font-semibold">Installed</h2>

--- a/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
@@ -19,6 +19,7 @@ import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { BulkActionBar } from "@/components/bulk-action-bar";
 import { DetailNotFound, DetailTitle } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { displayProjectName, isCustomProject } from "@/components/projects/project-metadata";
 import { ShareProjectDialog } from "@/components/sharing/share-project-dialog";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -45,6 +46,7 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { AddKeysDialog } from "@/components/vault/add-keys-dialog";
 import { CopyKeysDialog } from "@/components/vault/copy-keys-dialog";
 import { prefixGroupsFor, SplitVaultDialog } from "@/components/vault/split-vault-dialog";
@@ -247,7 +249,7 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 
 	if (vaults.isLoading) {
 		return (
-			<div className="space-y-5 px-4 lg:px-6">
+			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 				<Skeleton className="h-8 w-20" />
 				<div className="flex items-start gap-3">
 					<Skeleton className="size-11 rounded-xl" />
@@ -265,7 +267,7 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 
 	if (!vault) {
 		return (
-			<div className="space-y-5 px-4 lg:px-6">
+			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 				<Button asChild variant="ghost" size="sm" className="w-fit">
 					<Link to="/vault">
 						<ArrowLeft className="mr-1.5 size-4" />
@@ -285,7 +287,7 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 		.filter((p): p is ProjectRow => !!p);
 
 	return (
-		<div className="space-y-6 px-4 lg:px-6">
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6")}>
 			<Button asChild variant="ghost" size="sm" className="w-fit">
 				<Link to="/vault">
 					<ArrowLeft className="mr-1.5 size-4" />
@@ -472,11 +474,16 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 											className="pointer-events-none shrink-0"
 										/>
 									) : null}
-									<span className="min-w-0 flex-1 truncate font-mono text-xs" title={name}>
-										{/* "(default)" is the backend's implicit section — noise, hide it. */}
-										{section && section !== "(default)" ? `${section}/` : ""}
-										{name}
-									</span>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<span className="min-w-0 flex-1 truncate font-mono text-xs">
+												{/* "(default)" is the backend's implicit section — noise, hide it. */}
+												{section && section !== "(default)" ? `${section}/` : ""}
+												{name}
+											</span>
+										</TooltipTrigger>
+										<TooltipContent>{name}</TooltipContent>
+									</Tooltip>
 									<span className="shrink-0 font-mono text-[10px] text-muted-foreground select-none">
 										••••••
 									</span>

--- a/apps/web/src/pages/dashboard/vault/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useRouter } from "@tanstack/react-router";
 import { Lock, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { PageHeader } from "@/components/page-header";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { ProjectTab } from "@/components/projects/project-tab";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -22,6 +23,7 @@ import { Label } from "@/components/ui/label";
 import { SearchInput } from "@/components/ui/search-input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { AddKeysDialog } from "@/components/vault/add-keys-dialog";
 import { slugFromVaultName } from "@/components/vault/vault-slug";
 import { unwrap, useApi } from "@/lib/api";
@@ -47,11 +49,13 @@ export default function VaultPage() {
 		queryKey: ["vaults", "all"],
 		queryFn: async () =>
 			unwrap(await api.GET("/v1/vault", { params: { query: { page_size: 200 } } })),
+		placeholderData: keepPreviousData,
 	});
 
 	const projects = useQuery({
 		queryKey: ["projects"],
 		queryFn: async (): Promise<ProjectRow[]> => unwrap(await api.GET("/v1/projects")),
+		placeholderData: keepPreviousData,
 	});
 	const projectNameById = useMemo(
 		() => new Map((projects.data ?? []).map((p) => [p.id, p.name])),
@@ -95,7 +99,7 @@ export default function VaultPage() {
 	const shared = filtered.filter((v) => v.is_owner === false).sort(byKeysDesc);
 
 	return (
-		<div className="space-y-6 px-4 lg:px-6">
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6")}>
 			<PageHeader
 				title="Vaults"
 				description={VAULTS_RESOURCE.managementDescription}
@@ -153,7 +157,12 @@ export default function VaultPage() {
 				</div>
 			) : (
 				<>
-					<div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+					<div
+						className={cn(
+							"grid gap-4 transition-opacity sm:grid-cols-2 xl:grid-cols-3",
+							vaults.isFetching && !vaults.isLoading ? "opacity-60" : "opacity-100",
+						)}
+					>
 						{mine.map((vault) => (
 							<VaultCard key={vault.id} vault={vault} projectNameById={projectNameById} />
 						))}
@@ -246,10 +255,15 @@ function VaultCard({
 			<div className="mt-auto flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground tabular-nums">
 				<span>{keyCount === null ? "…" : `${keyCount} ${keyCount === 1 ? "key" : "keys"}`}</span>
 				{usedBy.length > 0 ? (
-					<span className="truncate" title={usedBy.join(", ")}>
-						used by {usedBy.slice(0, 2).join(", ")}
-						{usedBy.length > 2 ? ` +${usedBy.length - 2}` : ""}
-					</span>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<span className="truncate">
+								used by {usedBy.slice(0, 2).join(", ")}
+								{usedBy.length > 2 ? ` +${usedBy.length - 2}` : ""}
+							</span>
+						</TooltipTrigger>
+						<TooltipContent>{usedBy.join(", ")}</TooltipContent>
+					</Tooltip>
 				) : (
 					<span>not in any Project yet</span>
 				)}

--- a/apps/web/src/pages/public-share/session-page.tsx
+++ b/apps/web/src/pages/public-share/session-page.tsx
@@ -15,14 +15,10 @@ import { ShareHeaderUser } from "@/components/share/header-user";
 import { NoAccess } from "@/components/share/no-access";
 import { PublicShareControls } from "@/components/share/public-share-controls";
 import { SignInToView } from "@/components/share/sign-in-to-view";
+import { TimeTooltip } from "@/components/time-tooltip";
 import { env } from "@/lib/env";
 import { formatDuration } from "@/lib/format";
-import {
-	formatAbsoluteTooltip,
-	formatNumber,
-	formatSessionSummary,
-	relativeTime,
-} from "@/lib/utils";
+import { formatNumber, formatSessionSummary, relativeTime } from "@/lib/utils";
 
 /**
  * Public share page for a Clawdi session.
@@ -145,7 +141,7 @@ export default async function PublicSharePage({ id }: { id: string }) {
 			    scroll on narrow screens. `w-full` (`width: 100%`) restores
 			    the "fill body, capped at max-w-4xl, then centered"
 			    behavior that the visual design already assumed. */}
-			<div className={`${CENTERED_PAGE_WIDTH_CLASS.detail} space-y-5 px-4 py-6 lg:px-6`}>
+			<div className={`${CENTERED_PAGE_WIDTH_CLASS.page} space-y-5 px-4 py-6 lg:px-6`}>
 				{/* Below `sm` (640px), controls drop under the title block —
 				    a long summary then claims the full row instead of fighting
 				    two icon buttons for ~80px on a 320px screen. Reverts to
@@ -173,15 +169,15 @@ export default async function PublicSharePage({ id }: { id: string }) {
 								</>
 							) : null}
 							<span>·</span>
-							<span title={formatAbsoluteTooltip(share.started_at)}>
-								Started {relativeTime(share.started_at)}
-							</span>
+							<TimeTooltip value={share.started_at}>
+								<span>Started {relativeTime(share.started_at)}</span>
+							</TimeTooltip>
 							{showLastActivity ? (
 								<>
 									<span>·</span>
-									<span title={formatAbsoluteTooltip(share.last_activity_at)}>
-										Last activity {relativeTime(share.last_activity_at)}
-									</span>
+									<TimeTooltip value={share.last_activity_at}>
+										<span>Last activity {relativeTime(share.last_activity_at)}</span>
+									</TimeTooltip>
 								</>
 							) : null}
 						</DetailMeta>

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -831,3 +831,13 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { startInstance } from './start.ts'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>
+  }
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -831,13 +831,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { startInstance } from './start.ts'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-    config: Awaited<ReturnType<typeof startInstance.getOptions>>
-  }
-}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import "../../instrumentation-client";
 import { AuthProvider } from "@/components/auth-provider";
 import { Providers } from "@/components/providers";
 import RootError from "@/components/root-error";
+import { APP_TITLE } from "@/lib/document-title";
 import "@/styles/globals.css";
 
 const DESCRIPTION =
@@ -16,15 +17,15 @@ export const Route = createRootRoute({
 		meta: [
 			{ charSet: "utf-8" },
 			{ name: "viewport", content: "width=device-width, initial-scale=1" },
-			{ title: "Clawdi" },
+			{ title: APP_TITLE },
 			{ name: "description", content: DESCRIPTION },
 			{ name: "robots", content: "noindex,nofollow" },
 			{ property: "og:type", content: "website" },
-			{ property: "og:site_name", content: "Clawdi" },
-			{ property: "og:title", content: "Clawdi" },
+			{ property: "og:site_name", content: APP_TITLE },
+			{ property: "og:title", content: APP_TITLE },
 			{ property: "og:description", content: DESCRIPTION },
 			{ name: "twitter:card", content: "summary" },
-			{ name: "twitter:title", content: "Clawdi" },
+			{ name: "twitter:title", content: APP_TITLE },
 			{ name: "twitter:description", content: DESCRIPTION },
 		],
 		links: [

--- a/apps/web/src/routes/_protected/_dashboard/agents/$id/$section.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/agents/$id/$section.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, notFound, redirect } from "@tanstack/react-router";
 import { agentSectionHref, hasAgentTabQuery, parseAgentSectionSegment } from "@/lib/agent-routes";
+import { routeHeadTitle } from "@/lib/document-title";
 import { AgentDetailClient } from "@/pages/dashboard/agents/agent-detail-client";
 
 function safeDecodeURIComponent(value: string): string {
@@ -11,6 +12,7 @@ function safeDecodeURIComponent(value: string): string {
 }
 
 export const Route = createFileRoute("/_protected/_dashboard/agents/$id/$section")({
+	head: () => routeHeadTitle("Agent"),
 	beforeLoad: ({ params, search }) => {
 		const section = parseAgentSectionSegment(safeDecodeURIComponent(params.section));
 		if (!section || section === "overview") throw notFound();

--- a/apps/web/src/routes/_protected/_dashboard/agents/$id/index.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/agents/$id/index.tsx
@@ -1,8 +1,10 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { agentSectionHref, hasAgentTabQuery } from "@/lib/agent-routes";
+import { routeHeadTitle } from "@/lib/document-title";
 import { AgentDetailClient } from "@/pages/dashboard/agents/agent-detail-client";
 
 export const Route = createFileRoute("/_protected/_dashboard/agents/$id/")({
+	head: () => routeHeadTitle("Agent"),
 	beforeLoad: ({ params, search }) => {
 		if (hasAgentTabQuery(search)) {
 			throw redirect({ href: agentSectionHref(params.id, "overview", search), replace: true });

--- a/apps/web/src/routes/_protected/_dashboard/agents/$id/sessions/$sessionId.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/agents/$id/sessions/$sessionId.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import AgentSessionDetailPage from "@/pages/dashboard/agents/agent-session-detail-page";
 
 export const Route = createFileRoute("/_protected/_dashboard/agents/$id/sessions/$sessionId")({
+	head: () => routeHeadTitle("Session"),
 	component: AgentSessionDetailRoute,
 });
 

--- a/apps/web/src/routes/_protected/_dashboard/agents/$id/skills/$.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/agents/$id/skills/$.tsx
@@ -1,8 +1,10 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import { decodeResourceRouteParam } from "@/lib/project-resource-model";
 import { SkillDetailContent } from "@/pages/dashboard/skills/[key]/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/agents/$id/skills/$")({
+	head: () => routeHeadTitle("Skill"),
 	component: AgentSkillDetailRoute,
 });
 

--- a/apps/web/src/routes/_protected/_dashboard/agents/$id/skills/index.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/agents/$id/skills/index.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { agentSectionHref, hasAgentTabQuery } from "@/lib/agent-routes";
+import { routeHeadTitle } from "@/lib/document-title";
 import { AgentDetailClient } from "@/pages/dashboard/agents/agent-detail-client";
 
 // Explicit index route for the agent Skills tab. Without it the bare
@@ -9,6 +10,7 @@ import { AgentDetailClient } from "@/pages/dashboard/agents/agent-detail-client"
 // the tab rendered the skill DETAIL page with an empty key — which
 // fired `GET /v1/skills/` and 422'd.
 export const Route = createFileRoute("/_protected/_dashboard/agents/$id/skills/")({
+	head: () => routeHeadTitle("Skills"),
 	beforeLoad: ({ params, search }) => {
 		// Mirror `$section`'s legacy `?tab=` redirect: this URL no longer
 		// reaches `$section`, so old tab-query links normalize here.

--- a/apps/web/src/routes/_protected/_dashboard/agents/index.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/agents/index.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import AgentsIndexPage from "@/pages/dashboard/agents/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/agents/")({
+	head: () => routeHeadTitle("Agents"),
 	component: AgentsIndexPage,
 });

--- a/apps/web/src/routes/_protected/_dashboard/ai-providers.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/ai-providers.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import AiProvidersRoutePage from "@/pages/dashboard/ai-providers/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/ai-providers")({
+	head: () => routeHeadTitle("Model Providers"),
 	component: AiProvidersRoutePage,
 });

--- a/apps/web/src/routes/_protected/_dashboard/channels/$id.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/channels/$id.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import ChannelRoutePage from "@/pages/dashboard/channels/[id]/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/channels/$id")({
+	head: () => routeHeadTitle("Channel"),
 	component: ChannelDetailRoute,
 });
 

--- a/apps/web/src/routes/_protected/_dashboard/channels/index.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/channels/index.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import ChannelsRoutePage from "@/pages/dashboard/channels/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/channels/")({
+	head: () => routeHeadTitle("Channels"),
 	component: ChannelsRoutePage,
 });

--- a/apps/web/src/routes/_protected/_dashboard/connectors/$name.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/connectors/$name.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import ConnectorDetailPage from "@/pages/dashboard/connectors/[name]/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/connectors/$name")({
+	head: () => routeHeadTitle("Connector"),
 	component: ConnectorDetailRoute,
 });
 

--- a/apps/web/src/routes/_protected/_dashboard/connectors/index.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/connectors/index.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import ConnectorsPage from "@/pages/dashboard/connectors/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/connectors/")({
+	head: () => routeHeadTitle("Connectors"),
 	component: ConnectorsPage,
 });

--- a/apps/web/src/routes/_protected/_dashboard/deploy.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/deploy.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import DeployPage from "@/pages/dashboard/deploy/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/deploy")({
+	head: () => routeHeadTitle("Deploy an Agent"),
 	component: DeployPage,
 });

--- a/apps/web/src/routes/_protected/_dashboard/index.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/index.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import DashboardPage from "@/pages/dashboard/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/")({
+	head: () => routeHeadTitle("Overview"),
 	component: DashboardPage,
 });

--- a/apps/web/src/routes/_protected/_dashboard/memories/$id.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/memories/$id.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import MemoryDetailPage from "@/pages/dashboard/memories/[id]/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/memories/$id")({
+	head: () => routeHeadTitle("Memory"),
 	component: MemoryDetailRoute,
 });
 

--- a/apps/web/src/routes/_protected/_dashboard/memories/index.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/memories/index.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import MemoriesPage from "@/pages/dashboard/memories/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/memories/")({
+	head: () => routeHeadTitle("Memories"),
 	component: MemoriesPage,
 });

--- a/apps/web/src/routes/_protected/_dashboard/projects/$id.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/projects/$id.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import ProjectDetailPage from "@/pages/dashboard/projects/[id]/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/projects/$id")({
+	head: () => routeHeadTitle("Project"),
 	component: ProjectDetailRoute,
 });
 

--- a/apps/web/src/routes/_protected/_dashboard/projects/index.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/projects/index.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import ProjectsPage from "@/pages/dashboard/projects/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/projects/")({
+	head: () => routeHeadTitle("Projects"),
 	component: ProjectsPage,
 });

--- a/apps/web/src/routes/_protected/_dashboard/sessions/$id.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/sessions/$id.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import SessionDetailPage from "@/pages/dashboard/sessions/[id]/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/sessions/$id")({
+	head: () => routeHeadTitle("Session"),
 	component: SessionDetailRoute,
 });
 

--- a/apps/web/src/routes/_protected/_dashboard/sessions/index.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/sessions/index.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import SessionsPage from "@/pages/dashboard/sessions/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/sessions/")({
+	head: () => routeHeadTitle("Sessions"),
 	component: SessionsPage,
 });

--- a/apps/web/src/routes/_protected/_dashboard/skills/$key.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/skills/$key.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import SkillDetailPage from "@/pages/dashboard/skills/[key]/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/skills/$key")({
+	head: () => routeHeadTitle("Skill"),
 	component: SkillDetailRoute,
 });
 

--- a/apps/web/src/routes/_protected/_dashboard/skills/index.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/skills/index.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import SkillsPage from "@/pages/dashboard/skills/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/skills/")({
+	head: () => routeHeadTitle("Skills"),
 	component: SkillsPage,
 });

--- a/apps/web/src/routes/_protected/_dashboard/vault/$slug.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/vault/$slug.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import VaultDetailPage from "@/pages/dashboard/vault/[slug]/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/vault/$slug")({
+	head: () => routeHeadTitle("Vault"),
 	component: VaultDetailRoute,
 });
 

--- a/apps/web/src/routes/_protected/_dashboard/vault/index.tsx
+++ b/apps/web/src/routes/_protected/_dashboard/vault/index.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import VaultPage from "@/pages/dashboard/vault/page";
 
 export const Route = createFileRoute("/_protected/_dashboard/vault/")({
+	head: () => routeHeadTitle("Vaults"),
 	component: VaultPage,
 });

--- a/apps/web/src/routes/_protected/cli-authorize.tsx
+++ b/apps/web/src/routes/_protected/cli-authorize.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import CliAuthorizePage from "@/pages/cli-authorize/page";
 
 export const Route = createFileRoute("/_protected/cli-authorize")({
+	head: () => routeHeadTitle("CLI authorization"),
 	component: CliAuthorizePage,
 });

--- a/apps/web/src/routes/_protected/oauth/codex/callback.tsx
+++ b/apps/web/src/routes/_protected/oauth/codex/callback.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import CodexOAuthCallbackPage from "@/pages/oauth/codex/callback/page";
 
 export const Route = createFileRoute("/_protected/oauth/codex/callback")({
+	head: () => routeHeadTitle("Codex sign-in"),
 	component: CodexOAuthCallbackPage,
 });

--- a/apps/web/src/routes/s/$id.tsx
+++ b/apps/web/src/routes/s/$id.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import PublicSharePage from "@/pages/public-share/session-page";
 
 export const Route = createFileRoute("/s/$id")({
+	head: () => routeHeadTitle("Shared Session"),
 	component: PublicShareRoute,
 });
 

--- a/apps/web/src/routes/share/$token.tsx
+++ b/apps/web/src/routes/share/$token.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import ShareProjectPage from "@/pages/share/project-share-page";
 
 export const Route = createFileRoute("/share/$token")({
+	head: () => routeHeadTitle("Shared Project"),
 	component: ShareProjectRoute,
 });
 

--- a/apps/web/src/routes/sign-in.tsx
+++ b/apps/web/src/routes/sign-in.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import SignInPage from "@/pages/auth/sign-in";
 
 export const Route = createFileRoute("/sign-in")({
+	head: () => routeHeadTitle("Sign in"),
 	component: SignInPage,
 });

--- a/apps/web/src/routes/sign-in/$.tsx
+++ b/apps/web/src/routes/sign-in/$.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import SignInPage from "@/pages/auth/sign-in";
 
 export const Route = createFileRoute("/sign-in/$")({
+	head: () => routeHeadTitle("Sign in"),
 	component: SignInPage,
 });

--- a/apps/web/src/routes/sign-up.tsx
+++ b/apps/web/src/routes/sign-up.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import SignUpPage from "@/pages/auth/sign-up";
 
 export const Route = createFileRoute("/sign-up")({
+	head: () => routeHeadTitle("Sign up"),
 	component: SignUpPage,
 });

--- a/apps/web/src/routes/sign-up/$.tsx
+++ b/apps/web/src/routes/sign-up/$.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { routeHeadTitle } from "@/lib/document-title";
 import SignUpPage from "@/pages/auth/sign-up";
 
 export const Route = createFileRoute("/sign-up/$")({
+	head: () => routeHeadTitle("Sign up"),
 	component: SignUpPage,
 });


### PR DESCRIPTION
## Workstream 1: Deploy and settings section layout

- Redefined `SettingsSection` as a single-column flat form/settings section with the header and content in one stacked flow.
- Applied the primitive to the deploy wizard and agent settings surfaces, keeping tiles/cards as the only bordered content elements.
- Kept the existing deploy logic, sticky action bar, summary line, and optional markers.
- Updated the deploy loading state to mirror the five single-column sections.

## Workstream 2: Runtime copy

- Updated runtime blurbs to the official-based copy in `runtimes.ts`.
- Routed deploy wizard runtime labels and blurbs through `runtimeDisplayName()` / `runtimeBlurb()`.

## Workstream 3: Copy casing

- Changed deploy page titles to `Deploy an Agent`.
- Changed the project dialog title to sentence case: `Add project to agent`.

## Workstream 4: Uniform page width

- Added a single dashboard `page` width token and migrated dashboard, hosted, agent-detail chrome, and public-share containers.
- Kept narrower inner caps only where wide form/content surfaces would be awkward.
- Moved agent tab headers inside the same centered inner column as their content, and standardized non-live agent tabs on one `max-w-4xl` column so tab changes do not shift edges.
- Left live console/terminal tabs full-width inside the shared page container.

## Workstream 5: Scenario fixes

- Converted the audited dialogs to reset on open, avoiding close-animation flicker.
- Registered connector detail breadcrumb titles.
- Added React Query defaults for 30s stale reads and deterministic 4xx retry suppression.
- Added `keepPreviousData` to filter/search list queries, removed the project detail skills/vault waterfall, aligned skeletons, used Badge for AI provider auth, and replaced scoped native timestamp titles with shared tooltip UI.

## Workstream 6: Title consistency

- Added per-route document titles in route files using `<Page> · Clawdi`.
- Extended breadcrumb title registration so detail pages drive `document.title` from the same source as breadcrumbs.
- Added `/deploy` breadcrumb labeling and kept the connectors Suspense fallback header stable.

## Workstream 7: Cache invalidation

- Invalidated `["agents"]` after hosted deployment/lifecycle/provider/runtime mutations.
- Invalidated vault list and item queries after saving BYOK keys into Vault.
- Kept Overview stats always fresh on remount and invalidated memories after detail-page delete.

## Verification

- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`
- `bun run check`
- Playwright local verification with mocked APIs: dialog close/reopen behavior, static/dynamic tab titles, and a populated full dashboard screenshot sweep covering the audited dashboard, hosted, detail, mobile, and dark-mode routes.
- Full-sweep screenshots were generated locally for review and were not committed.

🤖 Generated with paseo codex.
