### PR TITLE
Add micro-type tokens and unify the style layer

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -20,8 +20,9 @@ use them. When a PR and this document disagree, fix one of them.
    marketing whitespace. Tables and lists earn their vertical space.
 4. **Shadows are near-nonexistent.** `shadow-xs`/`shadow-sm` only (≤0.05
    tinted opacity). `shadow-md` and up are banned in app UI.
-5. **Sentence case everywhere.** No Title Case headers, no ALL-CAPS section
-   labels (exception: tiny `text-[11px] tracking-wider uppercase` meta labels).
+5. **Clear casing rules.** Page titles use Title Case. Dialog titles use
+   sentence case. ALL-CAPS is reserved for tiny `text-2xs tracking-wider`
+   meta labels.
 6. **No pills on containers.** Radius band is 6–14px (`rounded-sm` … `rounded-xl`).
    `rounded-full` is allowed only for avatars, status dots, and tiny count badges.
 7. **Never break the data.** Numbers, IDs, hashes, paths: `font-mono` or
@@ -80,24 +81,41 @@ in the Vite entry stylesheet.
 | Role | Classes |
 |---|---|
 | Page title | `text-xl font-semibold tracking-tight` |
-| Section heading | `text-sm font-medium` |
+| Section heading | `text-sm font-semibold` |
 | Body | `text-sm` (default), `leading-relaxed` for prose |
 | Meta/labels | `text-xs text-muted-foreground` |
+| Dense meta/count labels | `text-2xs` (11px), uppercase labels allowed |
+| Micro counters/axis labels | `text-3xs` (10px), only where space is constrained |
 | Data (counts, IDs, paths, tokens) | `font-mono text-xs` or `tabular-nums` |
 
 Large display headings (share pages, auth): `tracking-tight` (−0.02 to
 −0.04em), `leading-[1.1]`, `text-wrap: balance` (applied globally to h1–h4).
 Weights: use 500/600 for hierarchy; 400 body; avoid 700+.
 
+### Component conventions
+
+- Card tiers: entity cards are `rounded-lg p-4`; hero cards are
+  `rounded-xl p-5`. Do not add new card tiers without updating this contract.
+- Hover idioms: clickable rows/cards use `hover:bg-muted/50`; hero-card lift
+  uses `hover:-translate-y-px hover:border-foreground/20`.
+- Tinted panels: subtle inset wells use `bg-muted/30`. Reserve
+  `bg-muted/50` for hover fills and selected/active fills.
+- Icon glyph scale: badge `size-3`, meta `size-3.5`, button `size-4`,
+  tile `size-5`.
+- Destructive actions: primary destructive actions use
+  `variant="destructive"`. Menu or inline rows use ghost treatment plus
+  `text-destructive`.
+- Semantic colors: status and source colors use semantic tokens (`success`,
+  `warning`, `destructive`, `info`) rather than raw palette utilities. Raw
+  amber/sky status classes are banned.
+- Font weights: card titles use `font-medium`; section headings use
+  `font-semibold`.
+
 ### Motion
 
 150–250ms, `transform`/`opacity` only. Buttons: hover background shift +
 `active:scale-[0.98]` + visible `focus-visible` ring. Respect
 `prefers-reduced-motion` (tw-animate-css handles this for its presets).
-
-### Charts
-
-`--chart-1..5`: orange ramp + warm grays. No purple/blue "AI gradient".
 
 ### Identity palette
 

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -242,8 +242,7 @@ const AGENT_SECTION_TINTS = {
 	settings: "bg-identity-4-bg text-identity-4-fg",
 } satisfies Record<AgentSectionId, string>;
 
-const LEGACY_DASHBOARD_TINT =
-	"bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300";
+const LEGACY_DASHBOARD_TINT = "bg-warning-muted text-warning-muted-foreground";
 
 type SidebarEnvironment = components["schemas"]["AgentResponse"];
 
@@ -745,7 +744,7 @@ function RailFocusButton({
 				{caption ? (
 					<span
 						className={cn(
-							"line-clamp-2 block h-[26px] max-w-16 overflow-hidden text-center text-[11px] leading-[13px] font-medium break-words",
+							"line-clamp-2 block h-[26px] max-w-16 overflow-hidden text-center text-2xs font-medium break-words",
 							active ? "text-sidebar-accent-foreground" : "text-muted-foreground",
 						)}
 						title={label}
@@ -853,14 +852,14 @@ function SortableAgentRailItem({
 					{kind === "cloud" ? (
 						<span
 							title="Clawdi Cloud agent"
-							className="-top-1 -right-1 pointer-events-none absolute z-20 flex size-4 items-center justify-center rounded-full bg-sky-500 text-white ring-2 ring-sidebar dark:bg-sky-400 dark:text-sky-950"
+							className="-top-1 -right-1 pointer-events-none absolute z-20 flex size-4 items-center justify-center rounded-full bg-info text-info-foreground ring-2 ring-sidebar"
 						>
 							<Cloud aria-hidden="true" className="size-2.5" />
 						</span>
 					) : kind === "legacy" ? (
 						<span
 							title="Legacy agent"
-							className="-top-1 -right-1 pointer-events-none absolute z-20 flex size-4 items-center justify-center rounded-full bg-amber-500 text-white ring-2 ring-sidebar dark:bg-amber-400 dark:text-amber-950"
+							className="-top-1 -right-1 pointer-events-none absolute z-20 flex size-4 items-center justify-center rounded-full bg-warning text-warning-foreground ring-2 ring-sidebar"
 						>
 							<History aria-hidden="true" className="size-2.5" />
 						</span>

--- a/apps/web/src/components/dashboard/add-agent-setup.tsx
+++ b/apps/web/src/components/dashboard/add-agent-setup.tsx
@@ -129,7 +129,7 @@ export function AddAgentSetup() {
 				</div>
 				<div className="mt-2 rounded-lg border bg-muted/30">
 					<div className="flex items-center justify-between border-b border-border/40 px-3 py-1.5">
-						<span className="text-[11px] uppercase tracking-wider text-muted-foreground">
+						<span className="text-2xs uppercase tracking-wider text-muted-foreground">
 							One command
 						</span>
 						<Button
@@ -209,9 +209,7 @@ export function AddAgentSetup() {
 			<Disclosure summary="Prefer to let the AI set itself up? Send it this prompt">
 				<div className="rounded-lg border bg-muted/30">
 					<div className="flex items-center justify-between border-b border-border/40 px-3 py-1.5">
-						<span className="text-[11px] uppercase tracking-wider text-muted-foreground">
-							Prompt
-						</span>
+						<span className="text-2xs uppercase tracking-wider text-muted-foreground">Prompt</span>
 						<CopyButton text={prompt} />
 					</div>
 					<pre className="whitespace-pre-wrap p-3 font-mono text-xs leading-relaxed">{prompt}</pre>

--- a/apps/web/src/components/dashboard/agent-label.tsx
+++ b/apps/web/src/components/dashboard/agent-label.tsx
@@ -169,8 +169,7 @@ export function AgentSourceBadge({
 	const Icon = source === "hosted" ? Cloud : Laptop;
 	const label = agentSourceLabel(source);
 	const title = agentSourceDescription(source);
-	const iconClass =
-		source === "hosted" ? "text-sky-600 dark:text-sky-300" : "text-muted-foreground";
+	const iconClass = source === "hosted" ? "text-info-muted-foreground" : "text-muted-foreground";
 	return (
 		<span
 			title={title}
@@ -179,10 +178,10 @@ export function AgentSourceBadge({
 				iconOnly
 					? "size-4 justify-center rounded-full p-0"
 					: compact
-						? "h-5 gap-1 rounded-full px-1.5 text-[11px]"
-						: "h-5 gap-1.5 rounded-full px-2 text-[11px]",
+						? "h-5 gap-1 rounded-full px-1.5 text-2xs"
+						: "h-5 gap-1.5 rounded-full px-2 text-2xs",
 				source === "hosted"
-					? "border-sky-200 bg-background text-foreground dark:border-sky-500/35 dark:bg-background/80"
+					? "border-info-muted bg-info-muted text-info-muted-foreground"
 					: "border-border bg-background text-muted-foreground",
 				className,
 			)}
@@ -204,14 +203,14 @@ export function LegacyAgentBadge({
 		<span
 			title="Managed in the legacy hosted dashboard"
 			className={cn(
-				"inline-flex shrink-0 items-center whitespace-nowrap border border-amber-200 bg-background font-medium leading-none text-foreground shadow-sm dark:border-amber-500/35 dark:bg-background/80",
+				"inline-flex shrink-0 items-center whitespace-nowrap border border-warning-muted bg-warning-muted font-medium leading-none text-warning-muted-foreground shadow-sm",
 				compact
-					? "h-5 gap-1 rounded-full px-1.5 text-[11px]"
-					: "h-5 gap-1.5 rounded-full px-2 text-[11px]",
+					? "h-5 gap-1 rounded-full px-1.5 text-2xs"
+					: "h-5 gap-1.5 rounded-full px-2 text-2xs",
 				className,
 			)}
 		>
-			<History className="size-3.5 text-amber-600 dark:text-amber-300" />
+			<History className="size-3.5 text-warning-muted-foreground" />
 			Legacy
 		</span>
 	);

--- a/apps/web/src/components/dashboard/contribution-graph.tsx
+++ b/apps/web/src/components/dashboard/contribution-graph.tsx
@@ -93,7 +93,7 @@ export function ContributionGraph({ data }: { data: ContributionDay[] }) {
 			<div className="flex gap-1.5">
 				{/* Day-of-week labels: only label odd rows so they don't overflow the cell heights. */}
 				<div
-					className="flex shrink-0 flex-col gap-[3px] pt-5 text-[10px] text-muted-foreground tabular-nums"
+					className="flex shrink-0 flex-col gap-[3px] pt-5 text-3xs text-muted-foreground tabular-nums"
 					style={{ width: DAY_LABEL_W - 6 }}
 					aria-hidden
 				>
@@ -108,7 +108,7 @@ export function ContributionGraph({ data }: { data: ContributionDay[] }) {
 
 				<div className="min-w-0 flex-1">
 					{/* Month labels, positioned absolutely above the week they start. */}
-					<div className="relative mb-1 h-4 text-[10px] leading-4 text-muted-foreground">
+					<div className="relative mb-1 h-4 text-3xs leading-4 text-muted-foreground">
 						{monthLabels.map((m, i) =>
 							m ? (
 								<span

--- a/apps/web/src/components/dashboard/daemon-status.tsx
+++ b/apps/web/src/components/dashboard/daemon-status.tsx
@@ -401,12 +401,10 @@ function SyncHelpDialog({
 												This won&apos;t auto-recover — the daemon dropped the change after the
 												server rejected it. Common cause: skill folder bigger than the 25 MB upload
 												cap (check for{" "}
-												<code className="rounded bg-muted px-1 py-0.5 text-[11px]">
-													node_modules
-												</code>
-												, <code className="rounded bg-muted px-1 py-0.5 text-[11px]">.git</code>,
-												build output). Fix the source and re-save to retry — the daemon is still
-												healthy and will pick up the next edit.
+												<code className="rounded bg-muted px-1 py-0.5 text-2xs">node_modules</code>,{" "}
+												<code className="rounded bg-muted px-1 py-0.5 text-2xs">.git</code>, build
+												output). Fix the source and re-save to retry — the daemon is still healthy
+												and will pick up the next edit.
 											</p>
 											{isHosted ? null : <CommandLine command="clawdi daemon status" />}
 										</>
@@ -603,7 +601,7 @@ function AuthLoginHint() {
 	return (
 		<p className="text-xs text-muted-foreground">
 			Token turned off or expired? Log in again with{" "}
-			<code className="rounded bg-muted px-1 py-0.5 text-[11px]">clawdi auth login</code>.
+			<code className="rounded bg-muted px-1 py-0.5 text-2xs">clawdi auth login</code>.
 		</p>
 	);
 }
@@ -655,10 +653,10 @@ function CommandLine({ command, hint }: { command: string; hint?: string }) {
 					});
 			}}
 			title={hint}
-			className="flex w-full items-center justify-between gap-3 rounded-md border bg-muted/40 px-3 py-2 text-left font-mono text-xs hover:bg-muted/60"
+			className="flex w-full items-center justify-between gap-3 rounded-md border bg-muted/30 px-3 py-2 text-left font-mono text-xs hover:bg-muted/50"
 		>
 			<code className="truncate">{command}</code>
-			<span className="flex shrink-0 items-center gap-2 text-[10px] text-muted-foreground">
+			<span className="flex shrink-0 items-center gap-2 text-3xs text-muted-foreground">
 				{hint ? <span className="hidden font-sans not-italic sm:inline">{hint}</span> : null}
 				<span>{copied ? "Copied" : "Copy"}</span>
 			</span>

--- a/apps/web/src/components/dashboard/new-agent-button.tsx
+++ b/apps/web/src/components/dashboard/new-agent-button.tsx
@@ -144,7 +144,7 @@ function ChoiceCard({
 			variant="outline"
 			className={cn(
 				"h-auto min-h-32 w-full flex-col items-start justify-start gap-2 whitespace-normal p-4 text-left",
-				!disabled && "hover:border-primary/40 hover:bg-accent/40",
+				!disabled && "hover:border-primary/40 hover:bg-muted/50",
 			)}
 		>
 			<span className="flex size-9 items-center justify-center rounded-md bg-primary/10 text-primary transition-colors">

--- a/apps/web/src/components/dashboard/resources-card.tsx
+++ b/apps/web/src/components/dashboard/resources-card.tsx
@@ -220,7 +220,7 @@ function ResourceRow({
 	return (
 		<Link
 			to={RESOURCE_ROUTES[definition.id]}
-			className="group flex items-center gap-3 px-6 py-3 transition-colors hover:bg-accent/40"
+			className="group flex items-center gap-3 px-6 py-3 transition-colors hover:bg-muted/50"
 		>
 			{/* Same identity hue as this resource's sidebar chip — the rail
 			    and the nav read as one system. */}
@@ -240,11 +240,11 @@ function ResourceRow({
 						<ProjectTypeBreakdown counts={projectTypeCounts} />
 					) : null}
 					{empty ? (
-						<span className="shrink-0 rounded-sm bg-muted px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+						<span className="shrink-0 rounded-sm bg-muted px-1.5 py-0.5 text-2xs font-medium text-muted-foreground">
 							{isProjectRow ? "Start here" : `Start: ${definition.emptyCta}`}
 						</span>
 					) : (
-						<span className="inline-flex shrink-0 items-center gap-1 rounded-sm bg-muted/60 px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+						<span className="inline-flex shrink-0 items-center gap-1 rounded-sm bg-muted/60 px-1.5 py-0.5 text-2xs font-medium text-muted-foreground">
 							<CheckCircle2 className="size-3" />
 							Active
 						</span>
@@ -277,7 +277,7 @@ function ProjectTypeBreakdown({ counts }: { counts: ProjectTypeCounts }) {
 			{items.map((item) => (
 				<span
 					key={item.label}
-					className="rounded-sm border bg-background px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground"
+					className="rounded-sm border bg-background px-1.5 py-0.5 text-2xs font-medium text-muted-foreground"
 				>
 					<span className="tabular-nums">{formatNumber(item.count)}</span> {item.label}
 				</span>

--- a/apps/web/src/components/empty-state.tsx
+++ b/apps/web/src/components/empty-state.tsx
@@ -50,7 +50,7 @@ export function EmptyState({
 				// shadcn's default already includes `rounded-lg border-dashed p-6
 				// md:p-12`. The flat variant (default) strips the border + padding
 				// because most of our usages live inside existing card chrome.
-				bordered ? "border bg-muted/20" : "border-none p-0 md:p-0",
+				bordered ? "border bg-muted/30" : "border-none p-0 md:p-0",
 				fillHeight ? "min-h-[320px]" : "py-8 md:py-8",
 				className,
 			)}

--- a/apps/web/src/components/entity-icon.tsx
+++ b/apps/web/src/components/entity-icon.tsx
@@ -56,7 +56,7 @@ const PROVIDER_SIMPLEICON: Record<string, { slug: string; hex: string } | null> 
 };
 
 const SIZE = {
-	sm: { px: 24, box: "size-6 rounded-md", mono: "text-[10px]" },
+	sm: { px: 24, box: "size-6 rounded-md", mono: "text-3xs" },
 	md: { px: 40, box: "size-10 rounded-lg", mono: "text-sm" },
 	lg: { px: 48, box: "size-12 rounded-xl", mono: "text-base" },
 } as const;

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -104,7 +104,7 @@ function InlineCode({ className, children, ...props }: ComponentPropsWithoutRef<
 	}
 	return (
 		<code
-			className="rounded-md border border-border/50 bg-muted/50 px-1.5 py-0.5 font-mono text-[0.85em]"
+			className="rounded-md border border-border/50 bg-muted/50 px-1.5 py-0.5 font-mono text-xs"
 			{...props}
 		>
 			{children}

--- a/apps/web/src/components/meta/model-badge.tsx
+++ b/apps/web/src/components/meta/model-badge.tsx
@@ -24,7 +24,7 @@ export function ModelBadge({
 			className={cn(
 				// Match the visual weight of a `Stat` (text-xs, baseline-aligned).
 				// `h-5` keeps the pill from making the row taller than the icons.
-				"h-5 border-primary/30 px-1.5 font-mono text-[0.7rem] text-primary leading-none",
+				"h-5 border-primary/30 px-1.5 font-mono text-2xs text-primary leading-none",
 				className,
 			)}
 		>

--- a/apps/web/src/components/notification-center.tsx
+++ b/apps/web/src/components/notification-center.tsx
@@ -124,7 +124,7 @@ export function NotificationCenter() {
 				>
 					<InboxIcon className="size-4" />
 					{count > 0 ? (
-						<Badge className="-right-1 -top-1 absolute h-4 min-w-4 rounded-full px-1 text-[10px] leading-none">
+						<Badge className="-right-1 -top-1 absolute h-4 min-w-4 rounded-full px-1 text-3xs leading-none">
 							{count > 99 ? "99+" : count}
 						</Badge>
 					) : null}

--- a/apps/web/src/components/projects/project-metadata.tsx
+++ b/apps/web/src/components/projects/project-metadata.tsx
@@ -165,7 +165,7 @@ function ProjectIcon({
 	return (
 		<span
 			className={cn(
-				"mt-0.5 flex size-6 shrink-0 select-none items-center justify-center rounded-md text-[13px] leading-none",
+				"mt-0.5 flex size-6 shrink-0 select-none items-center justify-center rounded-md text-xs leading-none",
 				id.colorClasses,
 				className,
 			)}
@@ -270,7 +270,7 @@ export function ProjectScopePicker({
 				<SelectTrigger
 					aria-label={label}
 					className={cn(
-						"h-auto min-h-16 w-full max-w-full justify-between rounded-[10px] border-border/80 bg-background/70 px-3 py-2.5 whitespace-normal shadow-xs transition-colors hover:bg-muted/20",
+						"h-auto min-h-16 w-full max-w-full justify-between rounded-md border bg-card px-3 py-2.5 whitespace-normal transition-colors hover:bg-muted/50",
 						isStacked ? "min-w-0" : "min-w-[260px] sm:w-[420px]",
 						triggerClassName,
 					)}
@@ -296,7 +296,7 @@ export function ProjectScopePicker({
 					{allowAll && groupedProjects.length > 0 ? <SelectSeparator /> : null}
 					{groupedProjects.map((group, groupIndex) => (
 						<SelectGroup key={group.id}>
-							<SelectLabel className="px-2 py-1.5 text-[11px] font-medium uppercase tracking-wide">
+							<SelectLabel className="px-2 py-1.5 text-2xs font-medium uppercase tracking-wide">
 								{group.label}
 							</SelectLabel>
 							{group.projects.map((project) =>
@@ -366,7 +366,7 @@ export function ProjectCompactPicker({
 					</span>
 				) : value === "all" && allowAll ? (
 					<span className="flex min-w-0 items-center gap-2 text-left">
-						<span className="flex size-5 shrink-0 items-center justify-center rounded-md border bg-muted/40 text-muted-foreground">
+						<span className="flex size-5 shrink-0 items-center justify-center rounded-md border bg-muted/30 text-muted-foreground">
 							<FolderKanban className="size-3" />
 						</span>
 						<span className="truncate font-medium">{allLabel}</span>
@@ -383,7 +383,7 @@ export function ProjectCompactPicker({
 				{allowAll ? (
 					<SelectItem value="all" className="py-2">
 						<div className="flex min-w-0 items-center gap-2">
-							<span className="flex size-6 shrink-0 items-center justify-center rounded-md border bg-muted/40 text-muted-foreground">
+							<span className="flex size-6 shrink-0 items-center justify-center rounded-md border bg-muted/30 text-muted-foreground">
 								<FolderKanban className="size-3.5" />
 							</span>
 							<div className="min-w-0">
@@ -421,9 +421,9 @@ function ProjectPickerValue({
 }) {
 	return (
 		<span className="flex min-w-0 flex-1 items-center gap-3 pr-1 text-left">
-			<ProjectIcon project={project} agent={agent} className="mt-0 size-7 rounded-[8px]" />
+			<ProjectIcon project={project} agent={agent} className="mt-0 size-7 rounded-md" />
 			<span className="grid min-w-0 flex-1 gap-0.5">
-				<span className="truncate text-[15px] leading-5 font-semibold">
+				<span className="truncate text-sm leading-5 font-semibold">
 					{displayProjectName(project)}
 				</span>
 				<span className="flex min-w-0 items-center gap-1.5 text-xs leading-4 text-muted-foreground">
@@ -488,14 +488,14 @@ function ProjectPickerAllItem({
 		<span className="flex min-w-0 items-center gap-2 text-left">
 			<span
 				className={cn(
-					"flex shrink-0 items-center justify-center rounded-[8px] border bg-muted/40 text-muted-foreground",
+					"flex shrink-0 items-center justify-center rounded-md border bg-muted/30 text-muted-foreground",
 					compact ? "size-7" : "size-6",
 				)}
 			>
 				<FolderKanban className={compact ? "size-3.5" : "size-3.5"} />
 			</span>
 			<span className={cn("min-w-0", compact && "grid gap-0.5")}>
-				<span className={cn("block truncate font-medium", compact && "text-[15px] leading-5")}>
+				<span className={cn("block truncate font-medium", compact && "text-sm leading-5")}>
 					{label}
 				</span>
 				<span className="block truncate text-xs text-muted-foreground">{description}</span>
@@ -539,7 +539,7 @@ function ProjectTypeBadge({
 		<Badge
 			variant="outline"
 			className={cn(
-				"shrink-0 border-border/70 px-1.5 py-0 text-[11px] font-normal text-muted-foreground",
+				"shrink-0 border-border/70 px-1.5 py-0 text-2xs font-normal text-muted-foreground",
 				compact && "hidden sm:inline-flex",
 			)}
 		>
@@ -597,8 +597,8 @@ export function projectKindMeta(kind: string): {
 		groupLabel: "Other Projects",
 		description: `Project type: ${kind}`,
 		icon: FolderKanban,
-		iconClassName: "border-border bg-muted/40 text-muted-foreground",
-		badgeClassName: "border-border bg-muted/40 text-muted-foreground",
+		iconClassName: "border-border bg-muted/30 text-muted-foreground",
+		badgeClassName: "border-border bg-muted/30 text-muted-foreground",
 	};
 }
 

--- a/apps/web/src/components/projects/project-tab.tsx
+++ b/apps/web/src/components/projects/project-tab.tsx
@@ -32,11 +32,11 @@ export function ProjectTab({
 				"inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-sm transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-ring focus:outline-none",
 				active
 					? "border-foreground/20 bg-accent font-medium text-foreground"
-					: "border-transparent text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+					: "border-transparent text-muted-foreground hover:bg-muted/50 hover:text-foreground",
 			)}
 		>
 			{emoji ? (
-				<span aria-hidden className="select-none text-[13px] leading-none">
+				<span aria-hidden className="select-none text-xs leading-none">
 					{emoji}
 				</span>
 			) : null}

--- a/apps/web/src/components/sessions/message-list.tsx
+++ b/apps/web/src/components/sessions/message-list.tsx
@@ -121,7 +121,7 @@ function MessageBlock({
 					// so without this fallback mobile users lose the
 					// timestamp entirely on grouped continuation rows.
 					<div
-						className="hidden h-5 w-8 items-center justify-end pr-1 text-[10px] tabular-nums text-muted-foreground/60 group-hover:flex [@media(hover:none)]:flex"
+						className="hidden h-5 w-8 items-center justify-end pr-1 text-3xs tabular-nums text-muted-foreground/60 group-hover:flex [@media(hover:none)]:flex"
 						title={formatAbsoluteTooltip(message.timestamp)}
 					>
 						{new Date(message.timestamp).toLocaleTimeString([], {
@@ -238,7 +238,7 @@ function SlashCommandPill({ name, args }: { name: string; args?: string }) {
 function CollapsibleBlock({ label, content }: { label: string; content: string }) {
 	const [open, setOpen] = useState(false);
 	return (
-		<div className="rounded-md border border-dashed border-border/70 bg-muted/20">
+		<div className="rounded-md border border-dashed border-border/70 bg-muted/30">
 			<Button
 				variant="ghost"
 				size="sm"

--- a/apps/web/src/components/sessions/session-feed.tsx
+++ b/apps/web/src/components/sessions/session-feed.tsx
@@ -96,7 +96,7 @@ export function SessionFeed({
 		<div className="space-y-5">
 			{groups.map((group) => (
 				<section key={group.key} className="space-y-2">
-					<h3 className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+					<h3 className="text-2xs font-medium uppercase tracking-wider text-muted-foreground">
 						{group.label}
 					</h3>
 					<div className="space-y-2">
@@ -137,7 +137,7 @@ function SessionFeedCard({
 		<article
 			className={cn(
 				"group relative z-0 rounded-lg border bg-card transition-all duration-150 hover:-translate-y-px hover:border-foreground/20",
-				isAutomated ? "border-transparent bg-muted/40 p-3" : "p-4",
+				isAutomated ? "border-transparent bg-muted/30 p-3" : "p-4",
 			)}
 		>
 			<Link

--- a/apps/web/src/components/sharing/share-project-dialog.tsx
+++ b/apps/web/src/components/sharing/share-project-dialog.tsx
@@ -368,7 +368,7 @@ function FreshLinkBanner({ link, onDismiss }: { link: ShareLinkCreated; onDismis
 					<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
 						<div className="min-w-0">
 							<div className="text-xs font-medium">Agent Handoff Prompt</div>
-							<div className="truncate font-mono text-[11px] text-muted-foreground">
+							<div className="truncate font-mono text-2xs text-muted-foreground">
 								Viewer access · add to an agent later · {link.prefix}
 							</div>
 						</div>
@@ -468,7 +468,7 @@ function LinkRow({
 								<AlertDialogCancel>Cancel</AlertDialogCancel>
 								<AlertDialogAction
 									onClick={onRevoke}
-									className="bg-destructive text-white hover:bg-destructive/90"
+									className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 								>
 									Turn Off Link
 								</AlertDialogAction>
@@ -639,7 +639,7 @@ function InvitationsPanel({ projectId }: { projectId: string }) {
 										<AlertDialogCancel>Keep invitation</AlertDialogCancel>
 										<AlertDialogAction
 											onClick={() => cancel.mutate(inv.id)}
-											className="bg-destructive text-white hover:bg-destructive/90"
+											className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 										>
 											Cancel invitation
 										</AlertDialogAction>
@@ -746,7 +746,7 @@ function MembersPanel({ projectId }: { projectId: string }) {
 							<AlertDialogCancel>Keep Sharing</AlertDialogCancel>
 							<AlertDialogAction
 								onClick={() => unshare.mutate()}
-								className="bg-destructive text-white hover:bg-destructive/90"
+								className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 							>
 								Stop all sharing
 							</AlertDialogAction>
@@ -811,7 +811,7 @@ function MembersPanel({ projectId }: { projectId: string }) {
 											<AlertDialogCancel>Cancel</AlertDialogCancel>
 											<AlertDialogAction
 												onClick={() => remove.mutate(member.user_id)}
-												className="bg-destructive text-white hover:bg-destructive/90"
+												className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 											>
 												Remove Member
 											</AlertDialogAction>

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -12,7 +12,7 @@ const badgeVariants = cva(
 				default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
 				secondary: "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
 				destructive:
-					"bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
+					"bg-destructive text-destructive-foreground focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
 				outline:
 					"border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
 				ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -11,7 +11,7 @@ const buttonVariants = cva(
 			variant: {
 				default: "bg-primary text-primary-foreground hover:bg-primary/90",
 				destructive:
-					"bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+					"bg-destructive text-destructive-foreground hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
 				outline:
 					"border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
 				secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",

--- a/apps/web/src/components/vault/add-keys-dialog.tsx
+++ b/apps/web/src/components/vault/add-keys-dialog.tsx
@@ -287,7 +287,7 @@ export function AddKeysDialog({
 						</Alert>
 					) : null}
 					{importPlan.conflicts.length > 0 && importPlan.parsed.errors.length === 0 ? (
-						<div className="flex items-start gap-3 rounded-md border bg-muted/20 p-3">
+						<div className="flex items-start gap-3 rounded-md border bg-muted/30 p-3">
 							<Checkbox
 								id="add-keys-update-existing"
 								checked={updateExisting}

--- a/apps/web/src/components/vault/split-vault-dialog.tsx
+++ b/apps/web/src/components/vault/split-vault-dialog.tsx
@@ -202,7 +202,7 @@ export function SplitVaultDialog({
 								<label
 									key={g.slug}
 									htmlFor={`split-prefix-${g.slug}`}
-									className="flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 hover:bg-accent/40"
+									className="flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 hover:bg-muted/50"
 								>
 									<Checkbox
 										id={`split-prefix-${g.slug}`}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -584,9 +584,9 @@ function TerminalStatusIndicator({ status }: { status: HostedTerminalStatus }) {
 				className={cn(
 					"size-2 rounded-full",
 					status === "connected"
-						? "bg-emerald-500"
+						? "bg-success"
 						: status === "connecting"
-							? "bg-amber-500"
+							? "bg-warning"
 							: "bg-destructive",
 				)}
 			/>
@@ -700,7 +700,7 @@ function TerminalTab({ deployment }: { deployment: HostedDeployment }) {
 			<LiveToolFrame icon={TerminalSquare} title="Terminal" detail={label} action={terminalAction}>
 				<div className="flex min-h-0 flex-1 items-center justify-center bg-background px-4 py-10">
 					<div className="flex w-full max-w-sm flex-col items-center gap-4 text-center">
-						<div className="flex size-11 items-center justify-center rounded-lg border bg-muted/40">
+						<div className="flex size-11 items-center justify-center rounded-lg border bg-muted/30">
 							{terminalFailure ? (
 								<TerminalSquare className="size-5 text-muted-foreground" />
 							) : (
@@ -749,7 +749,7 @@ function selectableCard(active: boolean): string {
 	return `w-full rounded-lg border p-4 text-left transition-colors ${
 		active
 			? "border-primary bg-primary/5 ring-1 ring-primary/30"
-			: "border-border hover:bg-accent/40"
+			: "border-border hover:bg-muted/50"
 	}`;
 }
 

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -677,7 +677,7 @@ export function DeployWizard() {
 						<button
 							type="button"
 							onClick={() => aiProviders.refetch()}
-							className="min-h-[74px] rounded-lg border border-dashed px-3 py-2 text-left text-xs text-muted-foreground transition-colors hover:bg-accent/40 sm:col-span-2"
+							className="min-h-[74px] rounded-lg border border-dashed px-3 py-2 text-left text-xs text-muted-foreground transition-colors hover:bg-muted/50 sm:col-span-2"
 						>
 							Couldn’t load your providers — tap to retry. Managed AI still works.
 						</button>

--- a/apps/web/src/hosted/billing/usage/usage-page.tsx
+++ b/apps/web/src/hosted/billing/usage/usage-page.tsx
@@ -94,7 +94,7 @@ export function UsagePage() {
 							/>
 						))}
 					</div>
-					<div className="mt-1.5 flex justify-between text-[11px] text-muted-foreground">
+					<div className="mt-1.5 flex justify-between text-2xs text-muted-foreground">
 						<span>{u.by_day[0]?.date.slice(5)}</span>
 						<span>{u.by_day[u.by_day.length - 1]?.date.slice(5)}</span>
 					</div>

--- a/apps/web/src/hosted/billing/wallet/x402-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/x402-card.tsx
@@ -38,7 +38,7 @@ export function X402Card() {
 				) : address ? (
 					<div className="space-y-1.5">
 						<span className="text-xs text-muted-foreground">Deposit address</span>
-						<div className="flex items-center gap-2 rounded-md border bg-muted/40 p-2">
+						<div className="flex items-center gap-2 rounded-md border bg-muted/30 p-2">
 							<code className="min-w-0 flex-1 truncate font-mono text-xs">{address}</code>
 							<CopyButton
 								value={address}

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.tsx
@@ -41,7 +41,7 @@ export function AuthBadge({ auth }: { auth: AiProviderAuth }) {
 			data-hosted="true"
 			data-v2="true"
 			variant="secondary"
-			className="rounded-full px-2 py-0.5 text-[11px] text-muted-foreground"
+			className="rounded-full px-2 py-0.5 text-2xs text-muted-foreground"
 		>
 			{label}
 		</Badge>

--- a/apps/web/src/hosted/v2/channels/channels-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channels-page.tsx
@@ -184,7 +184,7 @@ function FilterChip({
 				"rounded-full border px-3 py-1 text-xs font-medium transition-colors",
 				active
 					? "border-primary bg-primary/10 text-primary"
-					: "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+					: "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
 			)}
 		>
 			{children}

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -600,7 +600,7 @@ function StatTile({ label, value, href }: { label: string; value?: number; href:
 		<a
 			href={href}
 			className={cn(
-				"group rounded-xl border border-transparent p-4 transition-all duration-150 hover:-translate-y-px hover:border-foreground/15 focus-visible:ring-2 focus-visible:ring-ring focus:outline-none",
+				"group rounded-xl border border-transparent p-4 transition-all duration-150 hover:-translate-y-px hover:border-foreground/20 focus-visible:ring-2 focus-visible:ring-ring focus:outline-none",
 				STAT_TILE_TINTS[label] ?? "bg-card",
 			)}
 		>
@@ -751,7 +751,7 @@ function SharedAccessPanel({
 						<AlertDialogCancel>Cancel</AlertDialogCancel>
 						<AlertDialogAction
 							onClick={onLeave}
-							className="bg-destructive text-white hover:bg-destructive/90"
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
 						>
 							Leave Project
 						</AlertDialogAction>
@@ -916,7 +916,7 @@ function UseProjectWithAgentDialog({
 							</Select>
 						</div>
 
-						<div className="rounded-md border bg-muted/20 p-3 text-sm">
+						<div className="rounded-md border bg-muted/30 p-3 text-sm">
 							{projectIsHome ? (
 								<div className="flex items-start gap-2">
 									<CheckCircle2 className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
@@ -1039,7 +1039,7 @@ function InstallSkillInProjectForm({
 	};
 
 	return (
-		<div className="grid max-w-3xl gap-2 rounded-lg border bg-muted/20 p-3">
+		<div className="grid max-w-3xl gap-2 rounded-lg border bg-muted/30 p-3">
 			<Label htmlFor={`project-skill-repo-${projectId}`} className="text-xs font-medium">
 				GitHub skill repository
 			</Label>
@@ -1104,7 +1104,7 @@ function CreateVaultInProjectForm({
 	});
 
 	return (
-		<div className="grid max-w-3xl gap-2 rounded-lg border bg-muted/20 p-3">
+		<div className="grid max-w-3xl gap-2 rounded-lg border bg-muted/30 p-3">
 			<Label htmlFor={`project-vault-slug-${projectId}`} className="text-xs font-medium">
 				Vault name
 			</Label>

--- a/apps/web/src/pages/dashboard/projects/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/page.tsx
@@ -433,7 +433,7 @@ function ProjectCardSkeleton() {
 
 function StatusChip({ children }: { children: React.ReactNode }) {
 	return (
-		<span className="shrink-0 rounded-sm bg-info-muted px-1.5 py-0.5 text-[11px] font-medium text-info-muted-foreground">
+		<span className="shrink-0 rounded-sm bg-info-muted px-1.5 py-0.5 text-2xs font-medium text-info-muted-foreground">
 			{children}
 		</span>
 	);
@@ -444,7 +444,7 @@ function NewProjectCard({ onClick }: { onClick: () => void }) {
 		<button
 			type="button"
 			onClick={onClick}
-			className="flex min-h-36 flex-col items-center justify-center gap-2 rounded-xl border border-dashed text-muted-foreground transition-colors duration-150 hover:border-foreground/25 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus:outline-none"
+			className="flex min-h-36 flex-col items-center justify-center gap-2 rounded-xl border border-dashed text-muted-foreground transition-colors duration-150 hover:border-foreground/20 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus:outline-none"
 		>
 			<span className="flex size-9 items-center justify-center rounded-lg bg-muted">
 				<Plus className="size-4" />
@@ -467,7 +467,7 @@ function SystemProjectRow({
 }) {
 	const isGlobal = project.kind === "personal";
 	return (
-		<div className="group relative flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/20">
+		<div className="group relative flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/50">
 			<span
 				className={cn(
 					"flex size-7 shrink-0 select-none items-center justify-center rounded-md text-sm leading-none",

--- a/apps/web/src/pages/dashboard/skills/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/page.tsx
@@ -545,7 +545,7 @@ function SkillsPageInner() {
 										"inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-sm transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-ring focus:outline-none",
 										overflowActive
 											? "border-foreground/20 bg-accent font-medium text-foreground"
-											: "border-transparent text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+											: "border-transparent text-muted-foreground hover:bg-muted/50 hover:text-foreground",
 									)}
 								>
 									{overflowActive && targetProject
@@ -945,7 +945,7 @@ function SkillsPageInner() {
 						</Alert>
 					) : null}
 
-					<p className="pt-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+					<p className="pt-2 text-2xs font-medium uppercase tracking-wider text-muted-foreground">
 						Suggested
 					</p>
 					<div className="grid grid-cols-1 gap-3 md:grid-cols-2">

--- a/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
@@ -484,7 +484,7 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 										</TooltipTrigger>
 										<TooltipContent>{name}</TooltipContent>
 									</Tooltip>
-									<span className="shrink-0 font-mono text-[10px] text-muted-foreground select-none">
+									<span className="shrink-0 font-mono text-3xs text-muted-foreground select-none">
 										••••••
 									</span>
 									{selectMode ? (

--- a/apps/web/src/pages/dashboard/vault/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/page.tsx
@@ -301,7 +301,7 @@ function NewVaultCard() {
 			trigger={
 				<button
 					type="button"
-					className="flex min-h-36 flex-col items-center justify-center gap-2 rounded-xl border border-dashed text-muted-foreground transition-colors duration-150 hover:border-foreground/25 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus:outline-none"
+					className="flex min-h-36 flex-col items-center justify-center gap-2 rounded-xl border border-dashed text-muted-foreground transition-colors duration-150 hover:border-foreground/20 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus:outline-none"
 				>
 					<span className="flex size-9 items-center justify-center rounded-lg bg-muted">
 						<Plus className="size-4" />

--- a/apps/web/src/pages/share/project-share-page.tsx
+++ b/apps/web/src/pages/share/project-share-page.tsx
@@ -250,7 +250,7 @@ function ViewerAccessCard({ hasVaults }: { hasVaults: boolean }) {
 		? "Use Vault values through CLI runtime reads"
 		: "Use Vault values through CLI runtime reads if added later";
 	return (
-		<div className="grid gap-3 rounded-lg border bg-muted/20 p-4 text-sm sm:grid-cols-2">
+		<div className="grid gap-3 rounded-lg border bg-muted/30 p-4 text-sm sm:grid-cols-2">
 			<div className="space-y-2">
 				<p className="font-medium">Viewer Can</p>
 				<ul className="space-y-1.5 text-muted-foreground">
@@ -295,7 +295,7 @@ function ContentTile({
 	muted?: boolean;
 }) {
 	return (
-		<div className={`rounded-lg border p-4 ${muted ? "bg-muted/20 text-muted-foreground" : ""}`}>
+		<div className={`rounded-lg border p-4 ${muted ? "bg-muted/30 text-muted-foreground" : ""}`}>
 			<div className="flex items-center gap-2 text-sm">
 				{icon}
 				<span className="font-medium">{label}</span>

--- a/packages/shared/src/style/theme.css
+++ b/packages/shared/src/style/theme.css
@@ -60,13 +60,6 @@
 	--info-muted: oklch(0.96 0.018 245);
 	--info-muted-foreground: oklch(0.44 0.085 245);
 
-	/* charts — orange ramp + warm grays only (no off-brand hues) */
-	--chart-1: oklch(0.6171 0.1375 39);
-	--chart-2: oklch(0.5 0.11 42);
-	--chart-3: oklch(0.75 0.08 45);
-	--chart-4: oklch(0.62 0.01 95);
-	--chart-5: oklch(0.42 0.008 95);
-
 	/* identity palette — vivid flat pairs for object avatars (projects,
 	 * vaults). Deterministically assigned by name hash; these are the ONLY
 	 * sanctioned multi-hue colors besides the semantic status set. */
@@ -98,23 +91,18 @@
 	--sidebar-ring: oklch(0.6171 0.1375 39.0427);
 
 	--font-sans: "Geist Sans", sans-serif;
-	--font-serif: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
 	--font-mono: "Geist Mono", ui-monospace, monospace;
 
 	/* radius band: sm 6 / md 8 / lg 10 / xl 14 — no pills on containers */
 	--radius: 0.625rem;
 
 	/* shadows are near-nonexistent; hierarchy comes from hairline borders */
-	--shadow-2xs: 0 1px 2px 0px oklch(0.25 0.01 95 / 0.03);
 	--shadow-xs: 0 1px 2px 0px oklch(0.25 0.01 95 / 0.03);
 	--shadow-sm: 0 1px 2px 0px oklch(0.25 0.01 95 / 0.04);
 	--shadow: 0 1px 2px 0px oklch(0.25 0.01 95 / 0.04);
 	--shadow-md: 0 1px 3px 0px oklch(0.25 0.01 95 / 0.045);
 	--shadow-lg: 0 2px 4px -1px oklch(0.25 0.01 95 / 0.05);
-	--shadow-xl: 0 2px 6px -1px oklch(0.25 0.01 95 / 0.05);
-	--shadow-2xl: 0 3px 8px -2px oklch(0.25 0.01 95 / 0.05);
 
-	--tracking-normal: 0em;
 	--spacing: 0.25rem;
 }
 
@@ -142,7 +130,7 @@
 	--ring: oklch(0.6724 0.1308 38.7559);
 
 	--destructive: oklch(0.62 0.19 27);
-	--destructive-foreground: oklch(0.145 0.004 95);
+	--destructive-foreground: oklch(0.985 0.002 95);
 	--destructive-muted: oklch(0.245 0.045 27);
 	--destructive-muted-foreground: oklch(0.74 0.13 27);
 	--success: oklch(0.66 0.11 150);
@@ -157,12 +145,6 @@
 	--info-foreground: oklch(0.145 0.004 95);
 	--info-muted: oklch(0.24 0.03 245);
 	--info-muted-foreground: oklch(0.75 0.08 245);
-
-	--chart-1: oklch(0.6724 0.1308 39);
-	--chart-2: oklch(0.55 0.11 42);
-	--chart-3: oklch(0.78 0.08 45);
-	--chart-4: oklch(0.6 0.008 95);
-	--chart-5: oklch(0.8 0.006 95);
 
 	--identity-1-bg: oklch(0.32 0.07 25);
 	--identity-1-fg: oklch(0.84 0.09 30);
@@ -225,11 +207,6 @@
 	--color-border: var(--border);
 	--color-input: var(--input);
 	--color-ring: var(--ring);
-	--color-chart-1: var(--chart-1);
-	--color-chart-2: var(--chart-2);
-	--color-chart-3: var(--chart-3);
-	--color-chart-4: var(--chart-4);
-	--color-chart-5: var(--chart-5);
 	--color-identity-1-bg: var(--identity-1-bg);
 	--color-identity-1-fg: var(--identity-1-fg);
 	--color-identity-2-bg: var(--identity-2-bg);
@@ -257,21 +234,22 @@
 
 	--font-sans: var(--font-sans);
 	--font-mono: var(--font-mono);
-	--font-serif: var(--font-serif);
+
+	--text-2xs: 0.6875rem;
+	--text-2xs--line-height: 0.8125rem;
+	--text-3xs: 0.625rem;
+	--text-3xs--line-height: 0.75rem;
 
 	--radius-sm: calc(var(--radius) - 4px);
 	--radius-md: calc(var(--radius) - 2px);
 	--radius-lg: var(--radius);
 	--radius-xl: calc(var(--radius) + 4px);
 
-	--shadow-2xs: var(--shadow-2xs);
 	--shadow-xs: var(--shadow-xs);
 	--shadow-sm: var(--shadow-sm);
 	--shadow: var(--shadow);
 	--shadow-md: var(--shadow-md);
 	--shadow-lg: var(--shadow-lg);
-	--shadow-xl: var(--shadow-xl);
-	--shadow-2xl: var(--shadow-2xl);
 }
 
 @layer base {


### PR DESCRIPTION
## Summary

### Micro-typography tokens
- Added Tailwind v4 `text-2xs` and `text-3xs` theme tokens in `packages/shared/src/style/theme.css`.
- Replaced the audited 10-11px arbitrary text sizes, relative micro sizes, 13px/15px project metadata text, and the paired `leading-[13px]` rail caption magic.

### Semantic colors and destructive foregrounds
- Replaced hosted/legacy source sky/amber pairs with `info`/`warning` semantic tokens in agent labels and sidebar chrome.
- Replaced hosted terminal status dots with `bg-success`/`bg-warning`.
- Swapped destructive action foregrounds from `text-white` to `text-destructive-foreground` and made the dark destructive foreground white-ish.

### Style-layer cleanup
- Removed dead chart tokens plus unreferenced `shadow-2xs`, `shadow-xl`, `shadow-2xl`, `font-serif`, and `tracking-normal` theme registrations.
- Normalized audited clickable hover fills to `hover:bg-muted/50` and hero-card lift borders to `hover:border-foreground/20`.
- Normalized the project picker trigger to `border bg-card rounded-md hover:bg-muted/50` without shadow.
- Normalized subtle inset panels to `bg-muted/30` across project metadata icon/all-project tiles, daemon command row, bordered empty state, add-keys conflict well, session collapsible/automated card, hosted terminal empty tile, wallet address well, project detail panels, and share-page muted panels. Left data-table headers/strips and stock shadcn checkbox/tooltip radii unchanged.

### Documentation
- Updated `DESIGN.md` with the finalized type scale, card tiers, hover idioms, panel scale, icon scale, destructive action convention, semantic color rule, casing rule, and font-weight roles.

## Verification
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`
- `bun test packages/shared/src`
- `bun run check`
- Browser screenshot pass with `VITE_CLAWDI_HOSTED=true` and mocked data at 1440px. Local-only screenshots written to `/home/kingsley/clawdi-ui-screenshots/ds-tokens/` covering agents list light/dark, sidebar source dots, hosted terminal status, project detail metadata, projects cards, and vault cards.

🤖 Generated with paseo codex.
