### PR TITLE
docs: optimize agent-facing documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,39 +1,31 @@
 # Clawdi
 
-iCloud for AI Agents. Centralized management of agent sessions, skills, vault, memory, and more.
-
-This is the canonical repo-wide instruction file for coding agents. Agent-specific
-entrypoints such as `CLAUDE.md` should point here instead of duplicating these
-instructions.
+iCloud for AI Agents: CLI, FastAPI backend, TanStack dashboard, shared types,
+agent adapters, memory, vault, skills, channels, and sync.
 
 ## Start Here
 
-Clawdi Cloud is an OSS cross-agent sync and recall layer. The local CLI reads
-agent sessions and skills from Claude Code, Codex, Hermes, and OpenClaw, syncs
-them to a FastAPI backend, exposes shared memory/vault/project data, and powers
-a TanStack dashboard on the same backend.
+1. Keep code, comments, docs, file names, and identifiers in English.
+2. Keep OSS boundaries clean. Hosted infrastructure is owned outside this repo
+   by first-party hosted control planes; this repo must not contain hosted
+   service runbooks, private addresses, or internal deployment details.
+3. Maintain agent docs with [`docs/agent-docs-guide.md`](docs/agent-docs-guide.md).
+4. Prefer repo-local conventions over new abstractions.
 
-1. Read this file first, then use the linked docs below for details.
-2. Keep code, comments, docs, file names, and identifiers in English.
-3. Keep OSS boundaries clean: production and hosted operations are managed
-   outside this repository by first-party hosted control planes; this repo does
-   not contain production addresses or hosted-service runbooks.
+## Repository Map
 
-## Project Structure
-
+```text
+apps/web/          TanStack Start dashboard
+backend/           FastAPI backend, async PostgreSQL, Alembic
+packages/cli/      TypeScript/Bun CLI, adapters, MCP stdio server
+packages/shared/   Shared types, constants, generated API client
+packages/whatsapp-baileys-sidecar/  WhatsApp Baileys sidecar package
+docs/              Contributor docs, ADRs, plans, scenarios
 ```
-apps/web/          TanStack Start dashboard (Clerk auth, shadcn/ui, Tailwind v4)
-packages/cli/      CLI tool (TypeScript, Bun)
-packages/shared/   Shared types, constants, utilities
-packages/whatsapp-baileys-sidecar/  WhatsApp channel sidecar package
-backend/           Python FastAPI backend (async PostgreSQL, Clerk JWT)
-docs/              Documentation, plans, scenarios
-```
+
+For architecture and ownership, read [`docs/architecture.md`](docs/architecture.md).
 
 ## Local End-to-End
-
-This is the canonical local-stack runbook. Other docs should link here instead
-of duplicating backend + web + CLI bring-up steps.
 
 Install dependencies once:
 
@@ -41,21 +33,13 @@ Install dependencies once:
 bun install
 ```
 
-Configure the local backend in terminal 1, from the repository root:
+Terminal 1, backend:
 
 ```bash
 docker compose up -d postgres
 cd backend
 cp .env.example .env
 uv sync
-```
-
-In `backend/.env`, set `DEV_AUTH_BYPASS=true`, keep
-`DEV_AUTH_TOKEN=dev-bypass`, and set different local-only values for
-`VAULT_ENCRYPTION_KEY`, `ENCRYPTION_KEY`, and `ADMIN_API_KEY`. Generate them
-with:
-
-```bash
 python3 - <<'PY'
 import secrets
 for name in ("VAULT_ENCRYPTION_KEY", "ENCRYPTION_KEY", "ADMIN_API_KEY"):
@@ -63,41 +47,46 @@ for name in ("VAULT_ENCRYPTION_KEY", "ENCRYPTION_KEY", "ADMIN_API_KEY"):
 PY
 ```
 
-In that same `backend/` shell, run migrations and the backend:
+Set those three generated values in `backend/.env`. Also set:
+
+```dotenv
+DEV_AUTH_BYPASS=true
+DEV_AUTH_TOKEN=dev-bypass
+```
+
+Run backend:
 
 ```bash
 pdm migrate
 pdm dev
 ```
 
-In another terminal, confirm the backend and database are reachable:
+Done: `curl -sS http://localhost:8000/health` returns `{"status":"ok"}`.
 
-```bash
-curl -sS http://localhost:8000/health
-```
-
-Expected response:
-
-```json
-{"status":"ok"}
-```
-
-Start the dashboard in terminal 2, from the repository root, with matching
-bypass values:
+Terminal 2, web:
 
 ```bash
 cd apps/web
 cp .env.example .env.local
-# Set these in .env.local:
-# VITE_CLAWDI_API_URL=http://localhost:8000
-# VITE_DEV_AUTH_BYPASS=true
-# VITE_DEV_AUTH_TOKEN=dev-bypass
+```
+
+Set:
+
+```dotenv
+VITE_CLAWDI_API_URL=http://localhost:8000
+VITE_DEV_AUTH_BYPASS=true
+VITE_DEV_AUTH_TOKEN=dev-bypass
+```
+
+Run:
+
+```bash
 bun run dev
 ```
 
-Open `http://localhost:3000`. Create an API key in the local dashboard, or mint
-one through the local admin API using the `ADMIN_API_KEY` value from
-`backend/.env`:
+Done: `http://localhost:3000` opens the dashboard without Clerk login.
+
+Terminal 3, CLI:
 
 ```bash
 export ADMIN_API_KEY="<value-from-backend-env>"
@@ -108,64 +97,65 @@ curl -sS -X POST http://localhost:8000/v1/admin/auth/keys \
   | jq -r .raw_key
 ```
 
-The command prints a `clawdi_...` API key. Paste that key into
-`auth login --manual` below.
-
-Then point the dev CLI at the local backend in terminal 3, from the repository
-root:
+Use the printed `clawdi_...` key:
 
 ```bash
 bun run packages/cli/src/index.ts config set apiUrl http://localhost:8000
-bun run packages/cli/src/index.ts auth login --manual  # paste the local API key
+bun run packages/cli/src/index.ts auth login --manual
 bun run packages/cli/src/index.ts setup
 bun run packages/cli/src/index.ts doctor
 ```
 
-On a machine where every supported agent is installed or detectable, expected
-`clawdi doctor` output has the same shape as:
-
-```text
-clawdi doctor
-
-  ✓ Auth — <user-id-or-email>
-  ✓ API reachability — http://localhost:8000
-  ✓ Agent: Claude Code — <version-or-detected>
-  ✓ Agent: Hermes — <version-or-detected>
-  ✓ Agent: OpenClaw — <version-or-detected>
-  ✓ Agent: Codex — <version-or-detected>
-  ✓ Environments — <registered-agent-types>
-  ✓ Vault metadata — 0 vaults reachable
-  ✓ MCP connectors — config reachable
-
-All checks passed.
-```
-
-Agent rows reflect what is installed on the machine. If a supported agent is
-not installed, `doctor` reports `not installed`; the local stack is still wired
-when `Auth`, `API reachability`, `Environments`, `Vault metadata`, and
-`MCP connectors` are green for the agents you registered.
+Done: `doctor` shows green `Auth`, `API reachability`, `Environments`, `Vault
+metadata`, and `MCP connectors`; unavailable local agents may show `not
+installed`.
 
 Cleanup:
 
 ```bash
-# Stop foreground backend/web/daemon processes with Ctrl-C.
 docker compose down
 ```
 
-Use a volume reset only when you intentionally want to wipe the local dev
-database, for example after Alembic reports a revision from another branch:
+Use `docker compose down -v` only when intentionally wiping the local database.
+
+## Verification
+
+Workspace checks:
 
 ```bash
-docker compose down -v
+bun run typecheck
+bun run test
+bun run check
 ```
 
-## Test Suites
+Done: all three commands exit 0 and do not modify the worktree.
+
+Backend checks:
 
 ```bash
-bun run typecheck                  # Turbo TypeScript check
-bun run test                       # Turbo JS/TS tests
-bun run check                      # Biome CI check
+cd backend
+uv run ruff check .
+uv run ruff format --check .
+uv run python -m compileall app scripts tests alembic
 ```
+
+Backend pytest needs a migrated throwaway PostgreSQL. Use
+[`docs/backend-development.md#verification`](docs/backend-development.md#verification).
+Done: `uv run pytest -q` exits 0 against that database.
+
+Frontend checks:
+
+```bash
+bun run --cwd apps/web typecheck
+bun run --cwd apps/web test src/hosted/oss-clean.test.ts
+bunx biome check apps/web/src
+bun run --cwd apps/web build:oss
+```
+
+Done: all web commands exit 0. See
+[`docs/frontend-development.md#verification`](docs/frontend-development.md#verification).
+
+CLI checks:
 
 ```bash
 bun run --cwd packages/cli typecheck
@@ -175,144 +165,50 @@ bun run --cwd packages/whatsapp-baileys-sidecar typecheck
 bun run --cwd packages/whatsapp-baileys-sidecar test
 ```
 
-The canonical web verification set lives in
-`docs/frontend-development.md#verification`.
+Done: command output reports passing tests/typechecks.
 
-Backend tests require a Postgres database migrated to this branch's Alembic
-head. Use the throwaway-Postgres pattern in
-`docs/backend-development.md#verification`, then run:
+## Owner Docs
 
-```bash
-cd backend
-uv run ruff check .
-uv run ruff format --check .
-uv run python -m compileall app scripts tests alembic
-uv run pytest -q
-```
+- Backend: [`docs/backend-development.md`](docs/backend-development.md)
+- Frontend: [`docs/frontend-development.md`](docs/frontend-development.md)
+- CLI: [`docs/cli-development.md`](docs/cli-development.md)
+- API compatibility: [`docs/api-compatibility.md`](docs/api-compatibility.md)
+- Architecture: [`docs/architecture.md`](docs/architecture.md)
+- Agent identity ADR: [`docs/adr/0001-agent-identity-is-the-stable-domain-object.md`](docs/adr/0001-agent-identity-is-the-stable-domain-object.md)
+- AI Providers: [`docs/ai-providers.md`](docs/ai-providers.md)
+- Managed runtime: [`docs/managed-runtime.md`](docs/managed-runtime.md)
+- Daemon testing: [`docs/clawdi-daemon-test-guide.md`](docs/clawdi-daemon-test-guide.md)
+- Releases: [`docs/runbooks/release.md`](docs/runbooks/release.md)
 
-## Key Docs
+## Compatibility Rules
 
-- `docs/backend-development.md` — backend dev loop, throwaway Postgres tests,
-  Alembic, generated API client, local DB/admin debugging.
-- `docs/frontend-development.md` — web dev loop, Bun commands, OSS build
-  boundary, frontend tests.
-- `docs/api-compatibility.md` — `/v1/agents`, deprecated environment aliases,
-  hidden `/api` aliases, additive-only compatibility.
-- `docs/clawdi-daemon-test-guide.md` — daemon e2e and manual verification.
-- `docs/architecture.md` — current system map and module ownership.
-- `docs/adr/0001-agent-identity-is-the-stable-domain-object.md` — Agent
-  identity terminology and compatibility invariants.
-- `docs/cli-development.md` — CLI-specific dev, tests, packaging, release notes.
+- `/v1/agents` is canonical for Agent identity.
+- `/v1/environments` and hidden `/api/*` routes are compatibility aliases.
+- Session payloads still use `environment_id` as the legacy wire name for the
+  stable agent id.
+- API compatibility is additive-only for released surfaces.
+- Do not bulk-rewrite `/api` strings; many belong to external protocols or
+  fixtures. Follow [`docs/api-compatibility.md`](docs/api-compatibility.md).
+- Never hand-edit `packages/shared/src/api/api.generated.ts`; regenerate it
+  with the backend workflow.
 
-## Repeated Gotchas
+Done: compatibility changes include focused backend tests for canonical and
+legacy paths.
 
-- Backend pytest does not bootstrap schema; always migrate a throwaway Postgres
-  to the current branch head before running tests.
-- Never hand-edit `packages/shared/src/api/api.generated.ts`; regenerate and run
-  `backend/scripts/check_generated_api.py`.
-- API compatibility is additive-only for released surfaces; old fields, shapes,
-  status codes, and error bodies stay stable.
-- Do not bulk-rewrite `/api` strings that belong to external wire formats such
-  as Discord v10, BlueBubbles, OpenAI-compatible URLs, Composio, or fixtures.
+## Package Managers
 
-## Product Terminology
-
-- **Clawdi Cloud** is this open-source repository and product surface: CLI,
-  backend, dashboard, shared packages, and docs.
-- Use **hosted agents** or **hosted agent service** only as generic product
-  terms for managed remote agent runtime behavior.
-- The hosted agent service implementation is outside this repository. This
-  repository may define API contracts, dashboard UI, and CLI behavior that
-  integrate with hosted agents, but it does not contain the hosted agent runtime
-  service itself.
-- Do not add non-OSS repository names, checkout paths, production addresses, or
-  hosted-service run details to this OSS repository.
-- Avoid introducing legacy repo/path names in new examples unless the
-  surrounding text is explicitly about public backwards compatibility.
-
-## Commands
-
-### Development
-
-```bash
-bun install              # Install all dependencies
-bun run dev              # Start workspace dev servers
-bun run build            # Build all workspaces
-bun run typecheck        # Type-check all workspaces
-```
-
-### Code Quality
-
-```bash
-bun run check            # Biome CI check (lint + format, read-only)
-bun run check:fix        # Biome check + auto-fix
-```
-
-### CLI (from repo root)
-
-```bash
-bun run packages/cli/src/index.ts --help        # Run CLI in dev
-bun run packages/cli/src/index.ts sync --help   # Test subcommands
-```
-
-### Backend (from backend/)
-
-```bash
-uv sync                  # Install Python dependencies
-pdm dev                  # Start FastAPI dev server
-pdm migrate              # Run Alembic migrations
-pdm lint                 # Ruff lint
-pdm format               # Ruff format
-```
-
-## Release Management
-
-Release operations live in `docs/runbooks/release.md`; CLI-specific release
-details live in `docs/cli-development.md#releasing`; the user-facing changelog
-lives in `CHANGELOG.md`.
-
-- CLI/npm releases use `clawdi-cli-vX.Y.Z`; bump `packages/cli/package.json`
-  and let `.github/workflows/cli-publish.yml` publish.
-- Clawdi app/backend/web releases use `clawdi-YYYY-MM-DD` for the first UTC
-  release of a day, then `clawdi-YYYY-MM-DD-2`, `-3`, and so on for
-  additional releases that same day. They are created by
-  `.github/workflows/clawdi-release.yml`.
-- Release notes and `CHANGELOG.md` entries should be user-facing only. Include
-  notable features, behavior changes, fixes, deprecations, removals, security
-  notes, and user actions. Omit migrations, CI, deployment steps, refactors,
-  generated files, and other implementation-only details.
-
-## Tech Stack
-
-- **Web**: TanStack Start, TanStack Router, React 19, Tailwind CSS v4, shadcn/ui, TanStack Query, Zustand, Clerk
-- **CLI**: TypeScript, Bun, Commander
-- **Backend**: FastAPI, SQLAlchemy 2.0 async, asyncpg, Alembic, Pydantic Settings
-- **Database**: PostgreSQL with `pgvector` (embeddings) and `pg_trgm` (fuzzy search)
-- **File Store**: S3/R2/local filesystem (sessions JSONL, skills MD)
-- **Embeddings**: fastembed (local ONNX) or OpenAI-compatible API
-- **Tooling**: Bun, Turbo, Biome, Ruff, TypeScript strict mode
-
-PostgreSQL setup (including `pgvector` + `pg_trgm`) is documented in `README.md`.
-
-## Architecture
-
-- **Storage split**: PG for metadata, File Store (S3/R2/local) for file-type data (sessions, skills)
-- **Provider pattern**: Memory uses pluggable providers (Builtin pgvector, Mem0)
-- **Dual auth**: Clerk JWT for web dashboard, ApiKey for CLI
-- **Vault secrets never reach the web**: `vault/resolve` endpoint only accepts ApiKey (CLI)
-- **Vault data model**: Three-level Jingui-style (Vault -> Section -> Field), `clawdi://` URI references
-- **Two encryption keys**: `VAULT_ENCRYPTION_KEY` (AES-256-GCM for vault data at rest) and `ENCRYPTION_KEY` (HS256 for MCP bridge JWTs) are kept separate for key separation
-- **Sync state is client-side**: stored in `~/.clawdi/sync.json`, server API is stateless
-- **Agent adapters**: each agent (Claude Code, Codex, OpenClaw, Hermes) has its own adapter in `packages/cli/src/adapters/`
-
-## Data Model
-
-Core tables: User, UserSetting, AgentEnvironment, Session, Skill, Memory, Vault, VaultItem, ApiKey
+- Use Bun for JavaScript/TypeScript; the repo declares `packageManager:
+  bun@1.3.14`.
+- Do not introduce Yarn/Corepack globally.
+- Use `uv` and PDM scripts for backend workflows.
 
 ## Conventions
 
-- All comments in code must be in English
-- Use Biome for JS/TS formatting and linting
-- Use Ruff for Python linting and formatting
-- UI components in `apps/web/src/components/ui/` (shadcn pattern)
-- Shared types in `packages/shared/src/types/`
+- Use Biome for JS/TS formatting and linting.
+- Use Ruff for Python linting and formatting.
+- Keep UI primitives under `apps/web/src/components/ui/`.
+- Keep shared public types under `packages/shared/src/types/`.
+- Store local MCP launch wrappers in `~/.agents/mcp`; Codex and Claude Code
+  registrations should point at those wrappers.
+- Do not store plaintext tokens or private keys in shell startup files,
+  dotfiles, or repo files.

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -1,0 +1,33 @@
+# Clawdi
+> Open-source cross-agent sync and recall layer for agent sessions, skills,
+> memory, vaults, projects, channels, AI Providers, and local agent adapters.
+
+Use `/v1/*` as the canonical public API prefix. Hosted infrastructure internals
+are outside this OSS repository; public docs refer only to first-party hosted
+control planes when that boundary matters.
+
+## Start Here
+- [README](https://github.com/Clawdi-AI/clawdi/blob/main/README.md): Product overview, user quickstart, CLI examples, and self-hosting entry point.
+- [AGENTS](https://github.com/Clawdi-AI/clawdi/blob/main/AGENTS.md): Command-first contributor index for local stack setup, verification, and repo conventions.
+- [Agent Docs Guide](https://github.com/Clawdi-AI/clawdi/blob/main/docs/agent-docs-guide.md): Rules for keeping agent-facing docs short, verified, and maintainable.
+- [Architecture](https://github.com/Clawdi-AI/clawdi/blob/main/docs/architecture.md): Current system map, storage/auth model, API identity, and module ownership.
+- [API Compatibility](https://github.com/Clawdi-AI/clawdi/blob/main/docs/api-compatibility.md): `/v1/agents` canonical surface, deprecated aliases, generated-client rules, and additive API policy.
+
+## Development
+- [Backend Development](https://github.com/Clawdi-AI/clawdi/blob/main/docs/backend-development.md): FastAPI, Alembic, throwaway Postgres tests, and generated API client workflow.
+- [Frontend Development](https://github.com/Clawdi-AI/clawdi/blob/main/docs/frontend-development.md): TanStack Start dashboard loop, OSS build boundary, and web verification commands.
+- [CLI Development](https://github.com/Clawdi-AI/clawdi/blob/main/docs/cli-development.md): Bun CLI workflows, adapters, daemon testing, packaging, and release notes.
+- [Daemon Test Guide](https://github.com/Clawdi-AI/clawdi/blob/main/docs/clawdi-daemon-test-guide.md): Manual and automated verification for `clawdi daemon`.
+- [Release Runbook](https://github.com/Clawdi-AI/clawdi/blob/main/docs/runbooks/release.md): Release tags, CLI/npm publishing, changelog, and rollback checks.
+
+## Domain Contracts
+- [ADR-0001 Agent Identity](https://github.com/Clawdi-AI/clawdi/blob/main/docs/adr/0001-agent-identity-is-the-stable-domain-object.md): Stable Agent identity model and one-name fallback.
+- [AI Providers](https://github.com/Clawdi-AI/clawdi/blob/main/docs/ai-providers.md): Portable model-provider layer, auth references, target apply behavior, and BYOK boundary.
+- [AI Provider Agent Contract Audit](https://github.com/Clawdi-AI/clawdi/blob/main/docs/ai-provider-agent-contract-audit.md): Verified target contracts for Codex, Hermes, and OpenClaw AI Provider projections.
+- [Managed Runtime](https://github.com/Clawdi-AI/clawdi/blob/main/docs/managed-runtime.md): Public CLI/dashboard runtime contract without deployment-specific internals.
+- [Native Channels Product Model](https://github.com/Clawdi-AI/clawdi/blob/main/docs/designs/native-channels-product-model.md): Backend-owned channel accounts, bot-agent links, pair codes, bindings, and provider SDK emulation.
+- [Channel Runtime Manifest](https://github.com/Clawdi-AI/clawdi/blob/main/docs/designs/channel-runtime-manifest.md): `clawdi.runtime.yaml` channel projection contract and backend APIs used by the CLI.
+
+## Optional
+- [Using Clawdi with Claude Code](https://github.com/Clawdi-AI/clawdi/blob/main/docs/using-clawdi-with-claude-code.md): End-to-end Claude Code usage guide for setup, vault, skills, memory, and session sync.
+- [Project Sharing Demo](https://github.com/Clawdi-AI/clawdi/blob/main/docs/scenarios/project-sharing-agent-bindings-demo.md): Ship-state walkthrough for Project sharing and Agent Project bindings.

--- a/docs/agent-docs-guide.md
+++ b/docs/agent-docs-guide.md
@@ -1,0 +1,70 @@
+# Agent Docs Guide
+Use this when editing `AGENTS.md`, `CLAUDE.md`, `apps/web/public/skill.md`, and
+contributor docs under `docs/`.
+
+## Rule
+
+Agent docs are command-first, minimal, and verified against code. Use one
+executable example per convention. Put detail in `docs/`; keep `AGENTS.md` as
+the loaded index.
+
+## When To Add
+
+Add a section only when an agent repeatedly gets a real task wrong. Before
+adding text, search for the owner doc:
+
+```bash
+rg -n "the behavior or command" AGENTS.md docs README.md
+```
+
+Done: the new text links to the owner doc or replaces stale duplication.
+
+## When To Delete
+
+Delete or archive docs when the convention changes, the feature ships, or the
+content describes a retired design. Do not silently remove historical context;
+add this banner first:
+
+```markdown
+> HISTORICAL - <why>, see <current doc>.
+```
+
+Done: inbound links still resolve and the stale doc is listed in the PR body.
+
+## Done Criteria
+
+Every task-shaped section needs a check the agent can run. Use this format:
+
+```markdown
+Done: `command` exits 0 and output includes `<specific success text>`.
+```
+
+If the check needs services, say which service must already be running.
+
+## Verification
+
+Verify every claim about code, routes, commands, or files from the repo before
+publishing:
+
+```bash
+rg -n "route|command|table|setting" backend packages apps docs
+```
+
+Done: the doc cites the current file or links to the current owner doc.
+
+## Acceptance Gate
+
+Use a blank-agent simulation before merging major doc changes. Start from a
+fresh clone and only the repo docs. A fresh agent must be able to:
+
+1. Start the local backend, web dashboard, and dev CLI.
+2. Run the documented TypeScript, backend, web, and CLI checks.
+3. Debug a failed local auth, API, sync, or generated-client workflow.
+
+Done: the agent reaches the documented success output without private notes.
+
+## LLM-Drafted Docs
+
+LLM-authored docs are drafts. Human review must prune them. Keep load-bearing
+commands, invariants, and links. Remove broad claims, unverified roadmap
+language, repeated prose, and examples that do not run.

--- a/docs/ai-provider-isolated-e2e.md
+++ b/docs/ai-provider-isolated-e2e.md
@@ -1,5 +1,10 @@
 # AI Provider Isolated Smoke Record
 
+> HISTORICAL - recorded smoke evidence for the 2026-06 AI Provider slice. Use
+> [`ai-providers.md`](ai-providers.md) for current user behavior and
+> [`ai-provider-agent-contract-audit.md`](ai-provider-agent-contract-audit.md)
+> for pinned target contracts.
+
 This document records the Docker-isolated smoke test for the first non-UI AI
 Provider slice.
 

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -9,7 +9,7 @@ repository, especially `backend/app/main.py`,
 
 For the domain decision behind the naming, read
 [`ADR-0001`](adr/0001-agent-identity-is-the-stable-domain-object.md). For the
-system map, read [`architecture.md`](architecture.md#api-surface).
+system map, read [`architecture.md`](architecture.md#api-and-identity).
 
 ## Canonical surface
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,468 +1,263 @@
 # Architecture
 
-High-level map of what's actually in Clawdi Cloud today — updated as the code changes. For end-user docs, see the top-level [`README.md`](../README.md) and [`using-clawdi-with-claude-code.md`](using-clawdi-with-claude-code.md). For contributor workflow docs, start in [`AGENTS.md`](../AGENTS.md).
+This is the current system map for Clawdi Cloud. Verify changes against code
+before editing this file. For user setup, start in [`README.md`](../README.md).
+For contributor commands, start in [`AGENTS.md`](../AGENTS.md).
 
----
+## System Map
 
-## One-paragraph overview
+```text
+Self-managed machine
+  Claude Code / Codex / Hermes / OpenClaw
+        | local files + stdio MCP
+        v
+  clawdi CLI
+    adapters: claude_code, codex, hermes, openclaw
+    commands: setup, push, pull, run, daemon, mcp
+        |
+        | HTTPS /v1, bearer API key
+        v
++-------------------------+        +-----------------------------+
+| cloud-api               |<-------| TanStack web dashboard      |
+| FastAPI                 | Clerk  | Clerk auth, generated types |
+| routes + services       | JWT    +-----------------------------+
++-----------+-------------+
+            ^
+            |
+            | public API contracts
+            |
+First-party hosted control planes
+  opaque outside this OSS repo
 
-Clawdi Cloud is a cross-agent sync + recall layer. A local CLI (`clawdi`) reads per-agent data (Claude Code, Codex, Hermes, OpenClaw) from well-known directories, pushes sessions and skills to a FastAPI backend, pulls shared skills back down, and exposes a long-term memory store to each agent via the Model Context Protocol. Projects are the collaboration and data ownership boundary; each Agent has one fixed Agent Project plus optional attached Projects for read-time composition. The web app is a dashboard on the same backend, including hosted deployment surfaces such as Control UI and Terminal. The same CLI also owns the public managed runtime command surface for controlled environments: runtime manifests, convergence, support process state, explicit `clawdi run`, optional local UI bridging, and diagnostics. The memory store is the differentiator: it gives every connected agent the same cross-session, cross-machine context without the agents having to know about each other.
-
----
-
-## Topology
-
-```
-┌──────────────────────┐  HTTP (Bearer API key)   ┌──────────────────────┐
-│ clawdi CLI (local)   │─────────────────────────▶│ FastAPI backend      │
-│  - adapters/         │                          │  - routes/           │
-│  - mcp/server.ts     │                          │  - services/         │
-│  - commands/         │                          │  - models/ (SQLA)    │
-└──────────────────────┘                          └──────────┬───────────┘
-        │                                                    │
-        │ stdio MCP                                          │
-        ▼                                                    ▼
-┌──────────────────────┐                        ┌────────────────────────┐
-│ Claude Code / Codex /│                        │ PostgreSQL             │
-│ Hermes / OpenClaw    │                        │  - pgvector + pg_trgm  │
-│ (reads local state   │                        │  - tsvector GIN idx    │
-│  dirs, invokes MCP)  │                        └──────────┬─────────────┘
-└──────────────────────┘                                   │
-                                                           │
-┌──────────────────────┐  HTTP (Clerk JWT)         ┌───────┴────────┐
-│ TanStack web dashboard│────────────────────────▶│ File store     │
-│ (read-mostly)        │                          │ (local / S3)   │
-└──────────────────────┘                          └────────────────┘
-
-┌──────────────────────┐  Runtime manifest / state ┌──────────────────────┐
-│ First-party hosted   │──────────────────────────▶│ Managed runtime CLI  │
-│ control planes       │                           │  - runtime init/watch│
-│ (external services)  │                           │  - run configs       │
-└──────────────────────┘                           │  - sidecar modules   │
-        │ Control UI + Terminal contracts          └──────────┬───────────┘
-        └─────────────────────────────────────────────────────▼
-                                                   ┌──────────────────────┐
-                                                   │ Agent runtimes       │
-                                                   │ Hermes / OpenClaw /  │
-                                                   │ manifest run.command │
-                                                   └──────────────────────┘
+cloud-api stores:
+  PostgreSQL: metadata, pgvector memories, pg_trgm/FTS indexes
+  object store: session JSONL bodies, skill tarballs, asset blobs
 ```
 
-Two auth paths hit the same backend:
+The hosted box is intentionally opaque. This repo defines API contracts,
+dashboard surfaces, CLI behavior, local mock helpers, and runtime convergence
+code. Hosted service internals live outside this repository.
 
-- **Clerk JWT** — from the web dashboard. Gets most endpoints. Cannot resolve vault secret values.
-- **Bearer API key** (`clawdi_...`) — from the CLI and the MCP server it spawns. Required for `/v1/vault/resolve` and for any agent-local operation that needs to read secrets.
+## Overview
 
----
+Clawdi Cloud is a cross-agent sync and recall layer. The CLI reads supported
+agent state from local homes, syncs sessions and skills to the backend, installs
+a local MCP bridge, resolves vault references for runtime commands, and exposes
+shared memory to agents. The web dashboard uses the same backend for sessions,
+agents, projects, skills, vaults, memories, connectors, channels, AI Providers,
+and hosted surfaces.
 
-## API Surface
+## API And Identity
 
 `/v1/agents` is the canonical first-party API for Agent identity. New dashboard
-and CLI code registers, lists, updates, reorders, disconnects, uploads avatars,
-and posts sync heartbeats through `/v1/agents` using `agent_id` path parameters.
+and CLI code use `agent_id` path parameters.
 
-`/v1/environments` and legacy `/api/*` routes are compatibility aliases. They
-keep all pre-existing request fields, response fields, request/response shapes,
-status codes, and error bodies unchanged, including `environment_id` naming.
-New optional response fields such as `name`, `default_name`, and
-`explicit_identity` are additive safe fields for old clients. Session payloads
-and filters still use `environment_id`; that field is the legacy wire name for
-the stable agent id.
-
-Admin has both `/v1/admin/agents` and `/v1/admin/environments`. The agent route
-accepts `agent_id` for new first-party admin callers. The environment route is
-still fully supported because first-party hosted control planes migrate on a
-separate service timeline.
+`/v1/environments` remains a deprecated compatibility alias, and hidden
+`/api/*` mounts remain for released clients. Session payloads still use
+`environment_id` as the legacy wire name for the stable agent id. Admin has
+both `/v1/admin/agents` and `/v1/admin/environments`; admin routes are hidden
+from public OpenAPI.
 
-Contributor policy: [`api-compatibility.md`](api-compatibility.md) is the
-source of truth for additive-only compatibility, generated clients, and `/api`
-alias handling.
+The first-class object is **Agent**. `AgentEnvironment` and the
+`agent_environments` table are legacy persistence names. `AgentEnvironment.id`
+is the stable agent id. `registration_key` is only setup idempotency for
+self-managed agents; explicit identities have `registration_key = NULL`.
 
----
+Agent naming follows the one-name model from
+[`ADR-0001`](adr/0001-agent-identity-is-the-stable-domain-object.md): the
+primary label resolves from `display_name`, then `default_name`, then
+`machine_name`, then `agent_type`. Ownership changes badges and actions, not
+the name fallback.
 
-## Data model
+API compatibility policy lives in [`api-compatibility.md`](api-compatibility.md).
 
-All keyed off Clerk `user_id`:
+## CLI And Adapters
 
-| Table | What it holds | Written by |
-|---|---|---|
-| `users` | Clerk user mirror + email | Sign-in |
-| `api_keys` | SHA-256-hashed CLI bearer tokens | Dashboard |
-| `agent_environments` | Agent identity rows. The domain object is Agent; `AgentEnvironment` and `environment_id` are legacy persistence/wire names kept for compatibility. `id` is the stable agent id; self-managed agents use `registration_key` only for setup idempotency; first-party hosted control planes may supply caller-owned stable agent ids. See [ADR-0001](adr/0001-agent-identity-is-the-stable-domain-object.md). `agent_type ∈ {claude_code, codex, hermes, openclaw}` | `POST /v1/agents`, admin hosted agent registration |
-| `projects` | Resource availability boundaries for skills, vault attachments, and future memory/session grouping. Kinds are `personal`, `environment`, and `workspace`; `environment` is the internal Agent Project kind | Provisioning, `clawdi setup`, `clawdi project create` |
-| `project_memberships` | Viewer-only shared Project access granted by invite or share link | Share accept / invite accept |
-| `project_share_links` | Hashed bearer links for read-only Project access. Raw tokens are only returned once | `clawdi project share` |
-| `project_invitations` | Pending directed invites to existing Clawdi users | `clawdi project invite` |
-| `agent_project_bindings` | Runtime Agent composition: one fixed `primary` Agent Project row plus ordered `context` attachments | `clawdi setup`, `clawdi agent projects ...` |
-| `sessions` | Per-conversation metadata: `environment_id` (legacy field name for the stable agent id), `local_session_id`, `project_path`, token counts, model, summary, status. **Raw transcript body is in the file store**, keyed by `file_key` | `clawdi push` |
-| `skills` | Per-skill metadata + tar.gz body in file store | CLI `skill add / install`, dashboard upload |
-| `vaults` + `vault_project_attachments` + `vault_items` | Three-level secrets: vault → section → field. Vaults own their keys; Projects only attach to a vault to make those keys available. Values are AES-256-GCM encrypted. `/vault/resolve` decrypts readable Project values for CLI/API-key callers | `clawdi vault set` |
-| `memories` | Long-term recall. `content` (text), `category`, `tags`, plus three search columns (`content_tsv` generated tsvector, `embedding vector(768)`) | CLI and MCP `memory_add` |
-| `user_settings` | Opaque JSONB per-user prefs: `memory_provider` (`builtin` / `mem0`), `mem0_api_key` | `PATCH /v1/settings` |
-| `channel_accounts` + `channel_bot_agent_links` + `channel_secrets` + `channel_bindings` + `channel_binding_aliases` + `channel_pair_codes` + `channel_messages` + `channel_deliveries` + `channel_agent_credentials` + `channel_whatsapp_auth_certs` | Native Channels control plane and agent-facing emulation state. Accounts own external bot/provider identity, visibility, webhook secrets, and provider credentials; public preconfigured accounts can be linked by many users while private accounts stay owner-only; bot-agent links own hashed agent SDK tokens and agent routing; extra provider secrets are AES-GCM encrypted; bindings and aliases map each external chat session to one active bot-agent link and actor-scoped pair control; pair codes authorize chat binding or re-binding; messages record routed traffic and inbox cursors; deliveries provide the DB outbox; WhatsApp agent credentials and auth certs persist Baileys-facing identity material. See `docs/designs/native-channels-product-model.md` for the product model. | `/v1/channels`, `/v1/channels/telegram/*`, `/v1/channels/discord/*`, `/v1/channels/whatsapp/*`, `/v1/channels/imessage/*`, `pdm run channels-worker` |
-
-Hosted deployment persistence is owned by first-party hosted control planes, not by the OSS backend tables above. This repository consumes those services through generated API contracts, the dashboard UI, the mock deploy API used for local development, and the CLI managed-runtime contract.
-
-There is no `cron_job` / `celery` / `background_task` table — those were in the original plan but never built. See [What's not implemented](#whats-not-implemented) below.
-
----
-
-## Storage split
-
-- **PostgreSQL** — structured metadata + memory search. Alembic manages the schema. Extensions enabled: `pg_trgm` (trigram fuzzy match), `vector` (pgvector for embeddings).
-- **File store** — session transcripts (JSONL) and skill bodies (tar.gz). Abstracted via `app/services/file_store.py`; dev uses local filesystem (`./data/files/`), prod can be S3 / R2.
-- **No Redis yet** — originally planned for task queue + cache; currently unused.
-
-The separation is intentional: sessions can be multi-MB of JSONL; storing them in PG would bloat the DB and make dashboard queries slow. Metadata in PG, blobs in file store, metadata rows carry `file_key` pointers.
-
----
-
-## Memory retrieval
-
-The highest-signal path in the system. Four layers, hybrid-merged:
-
-1. **`tsvector` full-text search** (always on). `content_tsv` is a generated column with `to_tsvector('simple', content)`. Ranks with `ts_rank_cd` against `websearch_to_tsquery`. The `simple` dictionary is language-agnostic — mixed EN/CN memories just work, no per-language config.
-2. **`pg_trgm` trigram similarity** (always on). Handles typos, out-of-order words, partial terms. GIN index on `content` with `gin_trgm_ops`.
-3. **`pgvector` semantic search** (active when `MEMORY_EMBEDDING_MODE=local` or `=api`). HNSW index on a 768-dim column. Default embedder is `sentence-transformers/paraphrase-multilingual-mpnet-base-v2` via [fastembed](https://github.com/qdrant/fastembed) — CPU ONNX, no API key, first use downloads ~1GB. API mode swaps in OpenAI / OpenRouter.
-4. **Merge + rerank** — vector and FTS results are normalized, weighted (0.7 / 0.3), a 30-day-half-life temporal decay is applied, and a Jaccard-token MMR pass diversifies the top-N so near-duplicates don't crowd out distinct memories.
-
-Both vector and FTS have **strict / relaxed** score floors — strict first, relaxed fallback if empty — so abstract queries against narrowly-phrased memories still surface something instead of returning empty.
-
-The `BuiltinProvider` (`backend/app/services/memory_provider.py`) owns this. `Mem0Provider` is the alternative — thin wrapper around [Mem0's](https://mem0.ai) cloud API, selected per-user via `user_settings.memory_provider = "mem0"` + a `mem0_api_key`. Selection precedence:
-
-```
-user's memory_provider = "mem0" + mem0_api_key present     → Mem0Provider
-otherwise                                                   → BuiltinProvider
-  with embedder determined by deployment env:
-    MEMORY_EMBEDDING_MODE=local → fastembed              (default)
-    MEMORY_EMBEDDING_MODE=api   → OpenAI-compatible
-    anything else / missing key → FTS + trigram only
-```
-
-The embedder choice is **deployment-level**, not per-user — it's an operator concern (which GPU / API bill / privacy posture you want), not something users should pick.
-
----
-
-## Agent adapters
-
-All four agents implement the same interface (`packages/cli/src/adapters/base.ts`):
-
-```ts
-interface AgentAdapter {
-  agentType: AgentType;
-  detect(): Promise<boolean>;
-  getVersion(): Promise<string | null>;
-  collectSessions(since?, projectFilter?): Promise<RawSession[]>;
-  collectSkills(): Promise<RawSkill[]>;
-  getSkillPath(key: string): string;
-  writeSkillArchive(key: string, tarGzBytes: Buffer): Promise<void>;
-  buildRunCommand(args: string[], env: Record<string, string>): string[];
-}
-```
-
-Per-agent specifics:
-
-| Agent | Sessions at | Skills at | Version command |
-|---|---|---|---|
-| **Claude Code** | `~/.claude/projects/<hash>/*.jsonl` (one JSONL per session) | `~/.claude/skills/<key>/SKILL.md` (flat) | `claude --version` |
-| **Codex** | `~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl` | `~/.codex/skills/<key>/SKILL.md` (skips `.system/`) | `codex --version` |
-| **Hermes** | `~/.hermes/state.db` (SQLite) | `~/.hermes/skills/<category>/<key>/SKILL.md` (recursive) | `hermes --version` |
-| **OpenClaw** | `~/.openclaw/agents/<agentId>/sessions/sessions.json` index + per-session JSONL | `~/.openclaw/agents/<agentId>/skills/<key>/SKILL.md` (flat) | `openclaw --version` |
-
-The MCP server registration path also differs per agent — see `commands/setup.ts`:
-
-- Claude Code → `claude mcp add-json clawdi ...`
-- Codex → `codex mcp add clawdi ...`
-- Hermes → direct YAML edit of `~/.hermes/config.yaml`
-- OpenClaw → prints a manual-config hint (its ACP bridge rejects per-session MCP declarations)
-
----
-
-## Managed runtime
-
-Managed runtime mode is a controlled environment that reuses the same
-open-source `clawdi` CLI. It is not a separate private init binary and it does
-not add a private runtime-control RPC surface for ordinary agent actions.
-
-Public contract: [`managed-runtime.md`](managed-runtime.md).
-
-### Design Principles
-
-- The host image is a stable envelope. It should provide the OS user, base
-  packages, host policy, CLI bootstrap path, and PATH ordering, but runtime
-  semantics come from the CLI and runtime manifest.
-- `clawdi runtime init --non-interactive` is the convergence boundary. It
-  validates desired state, installs or verifies runtimes when the CLI is used
-  in a local/single-container fallback, writes projections, writes run configs,
-  and prepares support process state.
-- The primary hosted runtime model is a Linux-like host. Systemd starts Clawdi
-  support programs and official Hermes/OpenClaw programs directly from local
-  service definitions. The bootstrap only prepares the user manager and calls
-  `clawdi runtime init`; it does not supervise OpenClaw or Hermes itself.
-- `clawdi run -- <command>` remains an explicit interactive/local execution
-  boundary. Shell commands such as `openclaw` and `hermes` resolve to official
-  binaries directly.
-- Runtime-specific behavior is manifest-driven. Known runtimes can use built-in
-  install/projection support; future runtimes can be launched through an
-  explicit `run.command` without adding per-agent wrappers to the image.
-- Secrets stay out of durable config. The CLI may project short-lived secret
-  files under the runtime run directory and removes `CLAWDI_AUTH_TOKEN` before
-  launching agent child processes.
-
-### Module Map
-
-| Area | Files |
-|---|---|
-| Contract schemas | `packages/cli/src/runtime/manifest-contract.ts` |
-| Datasource fetch, normalization, validation | `packages/cli/src/runtime/manifest-source.ts` |
-| Local convergence, projections, and fallback process plan | `packages/cli/src/runtime/manifest.ts` |
-| Runtime path contract | `packages/cli/src/runtime/paths.ts` |
-| Host policy | `packages/cli/src/runtime/host-policy.ts` |
-| Runtime boot status and observed state | `packages/cli/src/runtime/state.ts`, `packages/cli/src/runtime/observed.ts` |
-| Run config and invocation | `packages/cli/src/runtime/run-config.ts`, `packages/cli/src/commands/run.ts` |
-| CLI self-management in hosted runtime | `packages/cli/src/runtime/cli-update.ts` |
-| Runtime bridge | `packages/cli/src/runtime/bridge.ts` |
-| Sidecar profile schema and profile generation | `packages/cli/src/runtime/mitm-profiles.ts`, `packages/cli/src/runtime/hosted-mitm-profiles.ts` |
-| Runtime MITM sidecar invocation and env projection | `packages/cli/src/runtime/mitm-sidecar.ts`, `packages/cli/src/runtime/mitm-env.ts` |
-| Native MITM sidecar implementation | `packages/cli/native/mitm-sidecar/` |
-| Hosted deployment UI and terminal panel | `apps/web/src/hosted/agents/hosted-agent-detail.tsx`, `apps/web/src/hosted/agents/hosted-terminal-panel.tsx` |
-| Local mock deploy API | `backend/scripts/mock_deploy_api.py` |
-
-### Runtime Flow
-
-```mermaid
-flowchart TB
-    CP[First-party hosted control planes] -->|hosted manifest response| Source[manifest-source]
-    Source -->|normalized desired state| Init[clawdi runtime init]
-
-    subgraph Durable["Durable non-secret state"]
-        State[/var/lib/clawdi]
-        RunConfigs[config/run/<runtime>.json]
-        Projections[config/projections/<runtime>.json]
-        Inventory[install-inventory/<runtime>.json]
-        UserUnits[$HOME/.config/systemd/user/*.service]
-    end
-
-    subgraph Ephemeral["Ephemeral runtime state"]
-        SystemUnits[$CLAWDI_RUN_DIR or /run/systemd/system/clawdi-*.service]
-        UnitEnv[$CLAWDI_RUN_DIR/systemd/env/*.service.env]
-        RuntimeSecrets[$CLAWDI_RUN_DIR/secrets/*]
-        MitmCA[$CLAWDI_RUN_DIR/mitm/systemd/ca.pem + sidecar-private key]
-    end
-
-    subgraph Support["Clawdi support programs"]
-        Watch[clawdi runtime watch]
-        Daemon[clawdi daemon run]
-        Sidecar[optional runtime sidecar]
-        Bridge[bridge module]
-        Mitm[MITM module]
-    end
-
-    subgraph Runtimes["Official runtime programs"]
-        HermesGateway[hermes gateway run]
-        HermesDashboard[hermes dashboard]
-        OpenClaw[openclaw gateway run]
-    end
-
-    Init --> Durable
-    Init --> Ephemeral
-    SystemUnits --> Systemd[systemd PID 1]
-    UserUnits --> UserSystemd[systemd --user]
-    UnitEnv --> Systemd
-    UnitEnv --> UserSystemd
-    Watch --> Durable
-    Daemon --> Durable
-    Systemd --> Watch
-    Systemd --> Daemon
-    UserSystemd --> Sidecar
-    Sidecar --> Bridge
-    Sidecar --> Mitm
-    UserSystemd --> HermesGateway
-    UserSystemd --> HermesDashboard
-    UserSystemd --> OpenClaw
-    Bridge -->|Control UI HTTP/WebSocket| HermesDashboard
-    Bridge -->|Control UI HTTP/WebSocket| OpenClaw
-    Mitm -. proxy and CA env .-> HermesGateway
-    Mitm -. proxy and CA env .-> HermesDashboard
-    Mitm -. proxy and CA env .-> OpenClaw
-```
-
-The hosted manifest schema is `clawdi.hosted-runtime.manifest.v1`. The CLI
-normalizes it to `clawdi.runtimeDesiredState.v1`, which is the internal
-convergence shape. The normalized state includes deployment identity,
-environment identity, instance identity, generation, workspace root, control
-plane API origin, CLI package policy, runtime entries, provider projections,
-MCP/tool projections, MITM profiles, live-sync settings, and recovery policy.
-
-### Runtime Launch
-
-Hosted daemon runtimes are direct systemd services. Clawdi support processes
-that need root-owned state are `clawdi-*` system units; official runtime
-gateway base units are runtime-user services under `systemd --user` generated
-by the runtime's official service installer, with names such as
-`openclaw-gateway.service` and `hermes-gateway.service`. Clawdi may add only a
-transparent hosted drop-in/env file for those units. Clawdi does not become a
-wrapper around the runtime command.
-
-OpenClaw and Hermes own their installers, user HOME state, native config
-semantics, update commands, and foreground runtime programs. `clawdi runtime
-init` acts as the local machine administrator: it invokes official installers
-and config surfaces, then invokes official non-interactive service installers
-for runtime gateway units. When desired state removes one of those gateway
-services, it invokes the matching official uninstaller before removing the
-hosted drop-in/env files. Clawdi-owned support or compatibility units must use
-`clawdi-*` names.
-
-Interactive shell commands are not intercepted. If a user or an official UI
-runs `openclaw update`, the command resolves to OpenClaw's own binary and update
-flow. `clawdi run -- <command>` remains available only when the caller asks for
-that explicit Clawdi execution boundary.
-
-When bridge surfaces or MITM profiles are enabled, the user manager starts one
-Clawdi runtime sidecar. Runtime programs receive only final proxy and trust env
-such as `HTTPS_PROXY`, `OPENCLAW_PROXY_URL`, and `NODE_EXTRA_CA_CERTS`;
-sidecar control env and secret-file paths stay out of the agent runtime
-process.
-
-The sidecar consolidates Clawdi-owned runtime-local support modules, but their
-authority boundaries stay explicit:
-
-- `clawdi daemon run` owns live sync and may use the Clawdi API auth token from
-  a short-lived file.
-- the sidecar bridge module owns inbound browser UI proxying for declared
-  Control UI surfaces and uses only the runtime bridge token.
-- the sidecar MITM module owns outbound MITM proxying, CA material, and
-  profile-level request rewriting. It starts only when explicit MITM profiles
-  are enabled and must not inherit the Clawdi auth token.
-
-The MITM module stores its root CA certificate and private key under
-`$CLAWDI_RUN_DIR` so sidecar restarts reuse the same trust root for already
-running runtimes. Runtime programs receive only the CA certificate path in trust
-environment variables; the private key path remains sidecar-private.
-
-Hermes dashboard and Hermes gateway are separate official Hermes commands, but
-runtime-owned systemd units should exist only when Hermes provides official
-service installers for them. The hosted default starts the official Hermes
-gateway service and does not synthesize `hermes-dashboard.service`. The sidecar
-bridge module is optional and exists only when Clawdi must own browser-facing
-auth, cookie, header, WebSocket, or path policy.
-
-Official gateway units follow a two-owner contract: the runtime's official
-installer owns the base unit file (`openclaw-gateway.service`,
-`hermes-gateway.service`), and Clawdi owns only its transparent drop-in
-(`<unit>.service.d/10-clawdi-hosted.conf`) and env file
-(`$CLAWDI_RUN_DIR/systemd/env/<unit>.service.env`). Clawdi installs and removes
-official units exclusively through the official install/uninstall commands and
-never edits a base unit it did not generate; failure semantics for that
-convergence live in `docs/managed-runtime.md`.
-
-### Runtime UI And Terminal
-
-Runtime UI and Terminal are separate hosted deployment surfaces:
-
-- **Control UI** is the runtime's browser UI endpoint. It can be exposed through
-  the official runtime port when platform ingress owns auth and browser policy,
-  or through the sidecar bridge module as an explicitly declared `control-ui`
-  surface when Clawdi owns those controls. It is runtime-specific, so the
-  dashboard labels it as `<Runtime> Control UI`.
-- **Terminal** is a deployment shell, not an agent-specific surface. The
-  dashboard requests a terminal session for the deployment and then opens one
-  xterm WebSocket. The terminal uses tty-style frames (`0` for input/output,
-  `1` for resize), follows the dashboard light/dark theme, and sends the
-  short-lived terminal token through a WebSocket subprotocol by default.
-
-The service-side terminal bridge is outside this repository. The public
-contract is: authenticate the user, require the deployment to be running, bind
-the terminal token to that deployment, and bridge the WebSocket to a shell as
-the default runtime user.
-
-The sidecar bridge module is a general authenticated surface bridge, but each
-surface must be declared with listen/upstream targets and policy. It is optional
-when official ports are exposed behind sufficient platform ingress auth.
-Terminal stays separate because it grants shell execution rather than proxying a
-runtime web application.
-
-### Ownership Boundaries
-
-- First-party hosted control planes own identity, desired-state generation,
-  secret resolution, deployment selection, rollout, billing policy, and terminal
-  session authorization.
-- The CLI owns manifest validation, local convergence, runtime install
-  orchestration where the CLI is the local convergence tool, non-secret
-  projections, run config, support process state, short-lived secret projection,
-  optional local UI bridging, diagnostics, and the Clawdi support modules.
-- The web dashboard owns the user-facing hosted deployment surfaces and calls
-  only public API contracts.
-- OpenClaw and Hermes keep their official installer/updater and runtime process
-  authority.
-- Clawdi native Channels own shared channel protocol state.
-- User BYOK provider traffic must not be silently proxied.
-
----
-
-## Sync engine
-
-`clawdi push` and `clawdi pull` share a selector that picks the target agent:
-
-1. Explicit `--agent <type>` flag wins.
-2. Else look at `~/.clawdi/environments/*.json` — if exactly one registered, pick it.
-3. Else fall back to `adapter.detect()` on all four; if exactly one matches, pick it.
-4. Else prompt (arrow-key picker).
-
-Sync state (`sessions.lastSyncedAt`, `skills.lastSyncedAt`) lives in `~/.clawdi/sync.json` — **the server is stateless about sync**. The CLI sends `?since=` filters on upload. This keeps the server simple and lets multiple machines sync independently.
-
-Per-project filter: `clawdi push` defaults to the current working directory as a local path filter for sessions. `--all` disables it, `--project <path>` overrides. This is not the cloud Project alias used by Project sharing commands. Hermes ignores the filter (its sessions have no `cwd`); it prints a yellow warning and syncs everything instead of silently dropping the filter.
-
----
+The CLI owns local agent detection, data collection, sync, setup, MCP stdio,
+vault/env injection, and runtime convergence commands.
+
+Adapter roots are verified in `packages/cli/src/adapters/*`:
+
+| Agent | Sessions | Skills | Version |
+| --- | --- | --- | --- |
+| Claude Code | `~/.claude/projects/<encoded-cwd>/*.jsonl` | `~/.claude/skills/<key>/SKILL.md` | `claude --version` |
+| Codex | `~/.codex/sessions/YYYY/MM/DD/*.jsonl` | `~/.codex/skills/<key>/SKILL.md` except `.system/` | `codex --version` |
+| Hermes | `$HERMES_HOME/state.db` or `~/.hermes/state.db` | `$HERMES_HOME/skills/<category>/<key>/SKILL.md` | `hermes --version` |
+| OpenClaw | `$OPENCLAW_STATE_DIR/agents/<id>/sessions/` or `~/.openclaw/agents/<id>/sessions/` | `agents/<id>/skills/<key>/SKILL.md` | `openclaw --version` |
+
+`AgentAdapter` also exposes skill-key listing, session watch paths, shared-skill
+paths, local skill removal, and `buildRunCommand`; do not document a smaller
+interface than `packages/cli/src/adapters/base.ts`.
+
+## Sync Engine
+
+`clawdi push` uploads sessions and skills. `clawdi pull` downloads skills.
+`clawdi daemon run` keeps skill state live through local watchers, SSE, and
+heartbeat updates.
+
+Target selection:
+
+1. Explicit `--agent <type>`.
+2. Registered local environments in `~/.clawdi/environments/*.json`.
+3. Adapter detection.
+4. Prompt when more than one candidate remains.
+
+Sync state is client-side under `~/.clawdi/`, including session/skill lock
+files. The backend stores metadata and file bodies, but it does not own each
+machine's upload watermark.
+
+## Sessions
+
+The `sessions` table stores metadata: user, stable agent id as
+`environment_id`, local session id, project path, timestamps, model/token
+counts, status, content hash, and `file_key`.
+
+Raw transcript bodies are stored in the object store. Public session sharing is
+controlled by `session_permissions`; public reads use `/v1/public/sessions/*`.
+Deleting an Agent sets `sessions.environment_id` to NULL instead of deleting
+history.
+
+## Projects And Agent Use
+
+Projects are resource and collaboration boundaries. Kinds are `personal`,
+`environment`, and `workspace`.
+
+Every Agent has one fixed Agent Project through `default_project_id` and a
+`primary` `agent_project_bindings` row. Extra Projects are ordered `context`
+bindings. Sharing grants Project membership only; using a shared Project at
+runtime requires an explicit Agent attachment.
+
+Local folder links are CLI selection hints for `clawdi run`. They do not grant
+membership, attach Projects, or mutate cloud Project relationships.
+
+## Skills
+
+Skills are project-scoped metadata rows plus tar.gz bodies in the object store.
+Active skills are unique by `(user_id, project_id, skill_key)`. The CLI uploads
+local skills with `clawdi push`, downloads cloud skills with `clawdi pull`, and
+can add or install skills through `clawdi skill ...`.
 
 ## Vault
 
-Three-level layout: vault → section → field. A vault owns the key rows once; one or more Projects can attach to that vault to make the same keys available to agents. Example paths:
+Vaults are account-owned secret bundles. Projects attach to vaults through
+`vault_project_attachments`; keys remain on the vault. `vault_items` stores
+sectioned fields encrypted with AES-256-GCM using `VAULT_ENCRYPTION_KEY`.
 
-```
-clawdi://project/<project-id>/vault/default/field/OPENAI_API_KEY
-clawdi://project/<project-id>/vault/api-service/section/openai/field/api_key
-clawdi://default/OPENAI_API_KEY
-clawdi://api-service/openai/api_key
-clawdi://payments/stripe/secret_key
-clawdi://api-service/database/url
-```
+The dashboard can list and mutate metadata but never receives plaintext values.
+Plaintext resolution is restricted to API-key auth through `/v1/vault/resolve`
+and `/v1/vault/resolve/bulk`. Agent-scoped resolution reads the Agent Project
+first, then attached Projects in order; conflicts block unless explicitly
+allowed.
 
-`.env` imports and `clawdi vault set OPENAI_API_KEY` store fields without a section by default, so that key resolves as `clawdi://default/OPENAI_API_KEY`. Use `clawdi vault import --section openai ...` or `clawdi vault set default/openai/api_key` for sectioned fields.
-Exact references include the Project ID and are the default Web/CLI copy UX. In project-relative references, `default` is the vault slug, not the Project; Project selection happens outside the URI through `--project`, `--agent`, local folder links, or the caller's default Project.
+Credential profile payloads live in `vault_credential_profiles` and are used by
+CLI credential import/materialization flows.
 
-Project access and key mutation are separate operations. `clawdi vault attach` and `clawdi vault detach` add or remove a Project's access to the whole Vault without changing stored values. `clawdi vault rm` deletes a key from the shared Vault itself; for Vaults attached to multiple Projects, the CLI and API require explicit global confirmation.
+## Memory
 
-Values encrypted with AES-256-GCM (`vault_encryption_key` env var is the master key). The backend has two vault surfaces:
+The built-in memory provider stores account-scoped `memories` with text,
+category, source, tags, optional source session id, access counters, JSONB
+metadata, and a 768-dimensional embedding.
 
-- `/v1/vault/*` — CRUD, accessible from the web dashboard, but **never returns plain values**
-- `/v1/vault/resolve` — returns `{ KEY: plain_value, ... }` or one resolved key, **only accepts CLI API keys**, rejects Clerk JWTs at the auth layer. User-level CLI/API keys can resolve plaintext from Projects the caller can read, including shared viewer Projects; env-bound Agent keys can read attached shared Projects only through the matching Agent boundary.
+Retrieval merges available signals:
 
-`clawdi run -- <cmd>` hits `/vault/resolve`, merges the returned env into the child process's environment, and `exec`s. `clawdi run --project <project> -- <cmd>` resolves from that explicit cloud Project. Without `--project`, a local `clawdi project folder link --project <project>` can select the Project for the current folder or a parent folder. Folder links are local CLI selection hints only: they do not grant Project access, attach Projects to Agents, or compose Projects.
+- PostgreSQL full-text search through generated `content_tsv`.
+- `pg_trgm` fuzzy matching.
+- `pgvector` semantic search when local or API embeddings are enabled.
 
-Agent runtime resolution is separate from folder links. `clawdi vault resolve KEY --agent <agent-id>` reads the fixed Agent Project first, then attached Projects by explicit order. Conflicting keys across that order block by default and require `--allow-conflicts` for first-match wins.
+`Mem0Provider` is the alternate provider when the user's settings choose Mem0
+and an API key is present. No session-to-memory automatic pipeline exists;
+agents or users add memories explicitly.
 
----
+## MCP And Connectors
 
-## MCP server
+The backend MCP endpoint is `POST /v1/mcp/clawdi`, a stateless JSON-RPC surface
+authenticated with a Clawdi API key. It exposes native tools such as memory and
+session tools, then dynamically lists connector tools and forwards those calls
+through the connector bridge.
 
-The single source of truth for Clawdi's MCP tools is the backend endpoint `POST /v1/mcp/clawdi` — a stateless JSON-RPC surface authenticated with a Clawdi API key. It serves the native tools (`memory_search`, `memory_add`, `memory_extract`, `session_search`, `session_read`) plus the user's **dynamically-listed connector tools**, which it forwards to the Composio Tool Router bridge (`/v1/mcp/composio`, with `/api/mcp/composio` kept as a legacy alias). The bridge mediates auth so the connector's real OAuth token and the Composio project API key never leave the backend. Connector tool listings are cached per-user for 60 seconds.
+For agents that only support stdio MCP, `clawdi mcp` registers local tool
+schemas and forwards calls to the backend. The backend keeps connector OAuth
+tokens and bridge credentials out of the agent process.
 
-Agents that speak streamable HTTP connect to `/v1/mcp/clawdi` directly with a bearer API key. For agents that can only spawn local stdio MCP servers, `clawdi mcp` (registered by `clawdi setup`) runs a thin stdio adapter: at init it calls `tools/list` on the backend, registers each tool locally with a zod schema built from the MCP `inputSchema` (or older `parameters`) metadata, and forwards every `tools/call` back to the backend.
+## Channels
 
-Tool descriptions on `memory_search` / `memory_add` are intentionally verbose and list concrete trigger patterns — the failure mode for a new agent is "didn't call memory when it obviously should have", and short descriptions leave too much to the agent's judgment. The `clawdi` skill installed to `~/.claude/skills/clawdi/` (and the equivalent paths on other agents) reinforces the same triggers in long-form.
+Native Channels are owned by the FastAPI backend and PostgreSQL. They support
+Telegram, Discord, WhatsApp, and iMessage/BlueBubbles provider families through
+channel accounts, bot-agent links, pair codes, bindings, message rows,
+delivery outbox rows, credentials, and provider-specific adapters.
 
----
+Channels bind external bots to Agents, not Projects. A conversation session
+routes to exactly one active bot-agent link. Public bots are shared provider
+infrastructure, but each user's links, pair codes, bindings, messages,
+deliveries, and agent SDK tokens remain user-owned.
 
-## What's not implemented
+The product model is in
+[`designs/native-channels-product-model.md`](designs/native-channels-product-model.md).
+The WhatsApp Baileys sidecar is a protocol adapter only; routing and persistence
+stay in FastAPI/PostgreSQL.
 
-Several items were considered but not built. Named for discoverability if someone picks them up:
+## AI Providers
 
-- **Celery / background tasks** — no async task queue. Memory is embedded synchronously on `memory_add`.
-- **Session → Memory LLM pipeline** — sessions are just stored; nothing auto-extracts memories from transcripts. Users / agents add memories explicitly.
-- **CronJobs** — no `cron_job` table, no scheduler. `scripts/embed_memories.py` exists as a manual operator-level tool.
-- **Channels provider coverage** — the Clawdi-native control plane plus Python-native Telegram Bot API, Discord REST/Gateway/rate-limit handling, WhatsApp Cloud API/Graph plus Baileys credential/Noise/IQ/relay/media boundary handling, and iMessage/BlueBubbles HTTP/query/webhook/attachment/Socket.IO slices exist. Outbound delivery, agent webhook redelivery, and Discord Gateway inbound dispatch run through the DB-backed `pdm run channels-worker` stack; WhatsApp Baileys outbound relay reaches that outbox through a transparent channel runtime adapter that converts sendable WAProto into validated Cloud API `providerPayload` for text/reply/public-link image/audio, relays Cloud-native raw status nodes for read receipts and typing indicators, and routes remaining Baileys-only media, voice-note/audio, group proto, and relay-attr messages to a registered native transport instead of route-local persistence. The FastAPI websocket reaches real Baileys `connection: open` plus DB-inbox `messages.upsert` delivery in the opt-in smoke, including quoted reply, image envelope, and group participant/sender-key fixture shapes. Discord Gateway capture uses per-account Postgres advisory locks inside that worker stack. WhatsApp debug health reports whether the native transport is unavailable, disconnected, `in_process`, or `sidecar` and which native relay capabilities it exposes. A minimal Clawdi-owned Baileys sidecar runtime package and FastAPI registration path exist for the remaining WhatsApp Web live protocol adapter; the legacy TypeScript router remains excluded. Opt-in smoke starts the sidecar against the FastAPI Baileys runtime; remaining work is deployment-level sidecar supervision and real linked-account upstream smoke.
-- **Cognee memory provider** — only `Builtin` and `Mem0`.
-- **`bun build --compile` single-binary distribution** — currently `bun link` over the workspace.
+AI Providers are account-global model-provider definitions with auth references
+and target-specific projection support. Metadata lives in `ai_providers`; stored
+auth payloads live in `ai_provider_auth_payloads`.
 
-If you pick any of these up, add an ADR or module plan under `docs/plans/` before implementing — this top-level doc is descriptive of what exists, not speculative.
+The current apply targets are Codex, Hermes, and OpenClaw. Claude Code OAuth is
+not supported in AI Provider v1. BYOK model traffic goes directly from the
+agent/runtime to the configured provider; Clawdi does not proxy those calls.
+
+User docs live in [`ai-providers.md`](ai-providers.md); pinned target contracts
+live in [`ai-provider-agent-contract-audit.md`](ai-provider-agent-contract-audit.md).
+
+## Managed Runtime
+
+Managed runtime mode is a public CLI/dashboard contract for controlled runtime
+environments. The CLI validates desired state, writes non-secret local
+projections, creates short-lived secret files under the runtime run directory,
+renders support/runtime service plans, and exposes `runtime init`, `watch`,
+`sidecar`, `status`, `doctor`, and explicit `clawdi run -- <command>`.
+
+The detailed contract is [`managed-runtime.md`](managed-runtime.md). This
+architecture page should not duplicate that runtime specification.
+
+## Data Model
+
+Core tables verified under `backend/app/models/`:
+
+| Tables | Purpose |
+| --- | --- |
+| `users`, `user_settings` | Clerk user mirror, profile fields, skill revision counter, user settings such as memory provider. |
+| `api_keys` | SHA-256-hashed CLI/API tokens, optionally scoped to an Agent. |
+| `agent_environments` | Stable Agent identities plus refreshable machine metadata, labels, daemon observability, and fixed Agent Project id. |
+| `hosted_runtime_states` | Runtime desired/observed state rows keyed to an Agent identity for hosted surfaces and local mock flows. |
+| `projects`, `project_memberships`, `project_share_links`, `project_invitations`, `share_redeem_attempts` | Project ownership, viewer access, share links, directed invites, and redeem throttling/idempotency. |
+| `agent_project_bindings` | One fixed `primary` Agent Project plus ordered `context` attached Projects. |
+| `sessions`, `session_permissions` | Conversation metadata, object-store body pointer, public/user/email sharing permissions. |
+| `skills` | Project-scoped skill metadata and object-store tarball pointer. |
+| `vaults`, `vault_project_attachments`, `vault_project_slug_aliases`, `vault_items`, `vault_credential_profiles` | Account-owned vaults, Project access attachments, compatibility slug aliases, encrypted secret fields, encrypted local auth profiles. |
+| `memories` | Built-in memory text, tags, source, metadata, access counters, and optional embedding vector. |
+| `ai_providers`, `ai_provider_auth_payloads` | Account-global provider metadata and encrypted provider auth payloads. |
+| `channel_accounts`, `channel_bot_agent_links`, `channel_secrets`, `channel_bindings`, `channel_binding_aliases`, `channel_pair_codes`, `channel_messages`, `channel_deliveries`, `channel_agent_credentials`, `channel_whatsapp_auth_certs`, `channel_debug_events`, `channel_attachment_uploads`, `channel_scheduled_messages`, `channel_agent_references` | Native channel control state, routing, inbox/outbox, credentials, debug and provider-specific state. |
+| `control_plane_audit_events` | Audit events for control-plane-facing operations exposed by this backend. |
+| `device_authorizations` | CLI device authorization flow state. |
+
+## Storage And Auth
+
+- PostgreSQL stores structured metadata and search indexes.
+- Object store stores session bodies, skill archives, and assets.
+- Clerk JWT auth powers the dashboard.
+- API-key auth powers CLI, local MCP, vault plaintext resolution, daemon sync,
+  and agent-local operations.
+- `VAULT_ENCRYPTION_KEY` encrypts vault and credential payloads at rest.
+- `ENCRYPTION_KEY` signs MCP bridge JWTs and must remain separate.
+
+## Known Absences
+
+- No Redis dependency.
+- No Celery or async job table.
+- No automatic session-to-memory extraction pipeline.
+- No Cognee provider; memory providers are built-in PostgreSQL search and Mem0.
+- No single-file Bun compiled CLI distribution.
+
+Add an ADR or focused design note before turning a known absence into a new
+module.

--- a/docs/clawdi-daemon-test-guide.md
+++ b/docs/clawdi-daemon-test-guide.md
@@ -266,7 +266,7 @@ TLS-terminating reverse proxy.
 `CLAWDI_AUTH_TOKEN` env. Run `clawdi auth login` or set the env.
 
 **`serve.no_environment`** — no `~/.clawdi/environments/<agent>.json`.
-Run `clawdi setup`; in a single-agent container, set both
+Run `clawdi setup`; in a single-agent runtime, set both
 `CLAWDI_AGENT_TYPE` and `CLAWDI_ENVIRONMENT_ID`.
 
 **`watcher.fs_watch_failed` → falls back to poll** — expected
@@ -284,21 +284,21 @@ exist only for released clients built before the `/v1` prefix migration. Test
 them deliberately when changing compatibility behavior; do not use them as the
 default path in new documentation.
 
-## Running `clawdi daemon` inside a hosted agent image
+## Running `clawdi daemon` inside a managed runtime
 
-The daemon was designed for laptops but works inside a hosted agent container
-with three caveats. A hosted agent service can drive the dashboard's
+The daemon was designed for laptops but also works inside a managed runtime
+with three caveats. First-party hosted control planes can drive the dashboard's
 `POST /v1/auth/keys` flow on the user's behalf to mint a deploy key bound to
 the Agent, then inject that key into the runtime environment. No
 backend-to-backend secret is required; the user's Clerk JWT is the conduit.
 
-### Env vars the container must set
+### Env vars the runtime must set
 
 | Var | Role |
 |---|---|
 | `CLAWDI_AUTH_TOKEN` | Deploy key. Bypasses `~/.clawdi/auth.json` so no interactive login is needed. |
 | `CLAWDI_AGENT_TYPE` | Agent adapter to load when the container has no `~/.clawdi/environments/*.json` registry. |
-| `CLAWDI_ENVIRONMENT_ID` | The env this single-agent pod represents. Bypasses `~/.clawdi/environments/*.json`. |
+| `CLAWDI_ENVIRONMENT_ID` | The Agent id this single-agent runtime represents. Bypasses `~/.clawdi/environments/*.json`. |
 | `CLAWDI_API_URL` | Cloud backend (for example, `https://api.example.test`). |
 | `CLAWDI_SERVE_MODE=container` | Forces poll mode (overlay-fs doesn't fire fs.watch reliably). |
 | `CLAWDI_DAEMON_RPC_HOST` | HTTP host for the daemon control RPC. Defaults to `127.0.0.1`. |
@@ -310,20 +310,18 @@ backend-to-backend secret is required; the user's Clerk JWT is the conduit.
 
 | Agent | What you need to set |
 |---|---|
-| Hermes | `HERMES_HOME=<hermes-state-dir>` when the pod does not use Hermes' default HOME path. The adapter reads SQLite via `node:sqlite` (Node 22.5+) or `bun:sqlite` — both are built-in, no native bindings to ship. |
-| OpenClaw | `OPENCLAW_STATE_DIR=<openclaw-state-dir>` when the pod does not use OpenClaw's default HOME path. `OPENCLAW_AGENT_ID=<id>` if the pod runs a single agent personality; omit to sync every agent under `agents/`. |
+| Hermes | `HERMES_HOME=<hermes-state-dir>` when the runtime does not use Hermes' default HOME path. The adapter reads SQLite via `node:sqlite` (Node 22.5+) or `bun:sqlite` — both are built-in, no native bindings to ship. |
+| OpenClaw | `OPENCLAW_STATE_DIR=<openclaw-state-dir>` when the runtime does not use OpenClaw's default HOME path. `OPENCLAW_AGENT_ID=<id>` if the runtime runs a single agent personality; omit to sync every agent under `agents/`. |
 
 ### What NOT to do
 
-- **Don't run `clawdi daemon install`** inside the container. Install
+- **Don't run `clawdi daemon install`** inside the runtime. Install
   is for laptop / VPS users where launchd or systemd will respawn
-  the daemon. The agent image's entrypoint (Docker / k8s) is
-  already supervising; install would write a unit file inside
-  the ephemeral container fs.
-- **Don't expect `~/.clawdi/sessions-lock.json` to survive a pod
-  restart** unless `~/.clawdi/` is on a persistent volume. Without
-  the volume, every restart re-pushes every session. Mount
-  `~/.clawdi/` as a named volume to avoid this.
+  the daemon. The runtime's own process supervisor should own restart behavior;
+  install would write a unit file inside ephemeral runtime storage.
+- **Don't expect `~/.clawdi/sessions-lock.json` to survive a runtime restart**
+  unless `~/.clawdi/` is on durable storage. Without durable storage, every
+  restart re-pushes every session.
 
 ### Entrypoint shape
 
@@ -331,5 +329,5 @@ backend-to-backend secret is required; the user's Clerk JWT is the conduit.
 exec clawdi daemon run
 ```
 
-Set `CLAWDI_AGENT_TYPE` when the image does not contain a
+Set `CLAWDI_AGENT_TYPE` when the runtime does not contain a
 `~/.clawdi/environments/<agent>.json` registry file.

--- a/docs/designs/channel-runtime-manifest.md
+++ b/docs/designs/channel-runtime-manifest.md
@@ -12,7 +12,7 @@ materializes agent-facing SDK config into explicit local runtime outputs.
 What exists today:
 
 - `clawdi channel ...` manages the user-facing channel control plane through
-  `/api/channels`.
+  `/v1/channels`.
 - `clawdi run ...` injects Vault and AI Provider runtime env into a child
   process.
 - `clawdi ai-provider apply ...` materializes AI Provider config into selected
@@ -55,11 +55,11 @@ source of truth is Clawdi-native channel state:
 
 ## Requirements
 
-- User CLI only. No `/api/admin/*` calls, no admin key, no public bot creation.
+- User CLI only. No `/v1/admin/*` calls, no admin key, no public bot creation.
 - No Project concept. Channels link bots to agents.
 - Public bots are referenced by id. Public bot publishing and provider
   credential rotation stay admin API concerns.
-- Private bots are created by the user through `/api/channels`.
+- Private bots are created by the user through `/v1/channels`.
 - One external chat session still routes to exactly one active bot-agent link.
 - A bot can link to many agents, and one agent can link to many bots.
 - Local runtime outputs must be written under explicit manifest output paths
@@ -142,18 +142,18 @@ outputs:
 
 1. Parse and validate the manifest.
 2. Resolve all provider token and secret env refs.
-3. List caller-owned private channels through `GET /api/channels` when the
+3. List caller-owned private channels through `GET /v1/channels` when the
    manifest needs to create or reuse a private bot.
-4. For provider selection UX, optionally read `GET /api/channels/bot-pool` so
+4. For provider selection UX, optionally read `GET /v1/channels/bot-pool` so
    the user or managed runtime can choose among owned private and public bots
    without hardcoding ids. Selection should use `capabilities` instead of
    inferring permissions from `visibility`.
 5. For `account.id`, fetch and validate the channel account.
 6. For `account.private`, reuse an existing private channel by
-   `(provider, name)` or create it through `POST /api/channels`.
+   `(provider, name)` or create it through `POST /v1/channels`.
 7. List the caller's links for the account.
 8. Reuse an existing link by `(account, agent_id)` or create one through
-   `POST /api/channels/{account_id}/agent-links`.
+   `POST /v1/channels/{account_id}/agent-links`.
 9. Rotate only when requested by the manifest or CLI flag.
 10. Create pair codes when requested.
 11. Sync provider commands when requested.
@@ -204,29 +204,29 @@ Telegram:
 
 ```dotenv
 TELEGRAM_BOT_TOKEN=<agent-sdk-token>
-TELEGRAM_BOT_API_BASE_URL=https://channels.example.test/api/channels/telegram
+TELEGRAM_BOT_API_BASE_URL=https://channels.example.test/v1/channels/telegram
 ```
 
 Discord:
 
 ```dotenv
 DISCORD_BOT_TOKEN=<agent-sdk-token>
-DISCORD_BOT_API_BASE_URL=https://channels.example.test/api/channels/discord
-DISCORD_GATEWAY_URL=wss://channels.example.test/api/channels/discord/gateway
+DISCORD_BOT_API_BASE_URL=https://channels.example.test/v1/channels/discord
+DISCORD_GATEWAY_URL=wss://channels.example.test/v1/channels/discord/gateway
 ```
 
 WhatsApp Graph-compatible runtime:
 
 ```dotenv
 WHATSAPP_ACCESS_TOKEN=<agent-sdk-token>
-WHATSAPP_GRAPH_API_BASE_URL=https://channels.example.test/api/channels/whatsapp/graph
+WHATSAPP_GRAPH_API_BASE_URL=https://channels.example.test/v1/channels/whatsapp/graph
 ```
 
 iMessage / BlueBubbles-compatible runtime:
 
 ```dotenv
-BLUEBUBBLES_SERVER_URL=https://channels.example.test/api/channels/imessage/bluebubbles
-BLUEBUBBLES_API_BASE_URL=https://channels.example.test/api/channels/imessage/bluebubbles/v1
+BLUEBUBBLES_SERVER_URL=https://channels.example.test/v1/channels/imessage/bluebubbles
+BLUEBUBBLES_API_BASE_URL=https://channels.example.test/v1/channels/imessage/bluebubbles/v1
 BLUEBUBBLES_PASSWORD=<agent-sdk-token>
 ```
 
@@ -236,14 +236,14 @@ intentionally absent. SDK compatibility should use provider-prefixed routes or
 target-native adapters.
 
 For Telegram specifically, current FastAPI routes are
-`/api/channels/telegram/bot/{token}/{method}` and
-`/api/channels/telegram/file/bot/{token}/{file_path}`. Many Telegram SDKs build
+`/v1/channels/telegram/bot/{token}/{method}` and
+`/v1/channels/telegram/file/bot/{token}/{file_path}`. Many Telegram SDKs build
 the official shape `/bot<token>/<method>` from an `apiRoot`, so full
 drop-in compatibility needs one of:
 
 - a provider-prefixed alias
-  `/api/channels/telegram/bot<token>/<method>` plus matching
-  `/api/channels/telegram/file/bot<token>/<file_path>`, or
+  `/v1/channels/telegram/bot<token>/<method>` plus matching
+  `/v1/channels/telegram/file/bot<token>/<file_path>`, or
 - a target adapter that knows Clawdi's slashful `/bot/{token}` route shape.
 
 The Telegram `agent_token` is intentionally generated in Bot API-looking
@@ -252,8 +252,8 @@ OpenClaw-compatible clients may validate it before sending requests.
 
 For BlueBubbles, many clients append `/api/v1` under `BLUEBUBBLES_SERVER_URL`.
 Full drop-in compatibility needs either
-`/api/channels/imessage/bluebubbles/api/v1/*` aliases or a target adapter that
-uses the existing `/api/channels/imessage/bluebubbles/v1/*` routes directly.
+`/v1/channels/imessage/bluebubbles/api/v1/*` aliases or a target adapter that
+uses the existing `/v1/channels/imessage/bluebubbles/v1/*` routes directly.
 
 ### OpenClaw Projection
 
@@ -283,8 +283,8 @@ platforms:
     enabled: true
     token: "${TELEGRAM_BOT_TOKEN}"
     extra:
-      base_url: "https://channels.example.test/api/channels/telegram/bot"
-      base_file_url: "https://channels.example.test/api/channels/telegram/file/bot"
+      base_url: "https://channels.example.test/v1/channels/telegram/bot"
+      base_file_url: "https://channels.example.test/v1/channels/telegram/file/bot"
 ```
 
 This Hermes Telegram shape assumes the provider-prefixed `/bot<token>` alias
@@ -300,8 +300,8 @@ platforms:
     enabled: true
     token: "${DISCORD_BOT_TOKEN}"
     extra:
-      base_url: "https://channels.example.test/api/channels/discord/v10"
-      gateway_url: "wss://channels.example.test/api/channels/discord/gateway"
+      base_url: "https://channels.example.test/v1/channels/discord/v10"
+      gateway_url: "wss://channels.example.test/v1/channels/discord/gateway"
 ```
 
 Hermes currently supports one profile per platform in the old integration
@@ -331,16 +331,16 @@ channels:
 
 Apply should call:
 
-- `POST /api/channels/whatsapp/{account_id}/tenant-creds` to mint or reuse a
+- `POST /v1/channels/whatsapp/{account_id}/tenant-creds` to mint or reuse a
   link-scoped credential.
-- `GET /api/channels/whatsapp/{account_id}/auth-cert` when the runtime needs
+- `GET /v1/channels/whatsapp/{account_id}/auth-cert` when the runtime needs
   shared account public auth material.
 
 It should write the Baileys auth state into the requested credential directory
 with private permissions and emit:
 
 ```dotenv
-WA_WEBSOCKET_URL=wss://channels.example.test/api/channels/whatsapp/<account-id>/baileys
+WA_WEBSOCKET_URL=wss://channels.example.test/v1/channels/whatsapp/<account-id>/baileys
 CLAWDI_WHATSAPP_AUTH_DIR=.clawdi/whatsapp/default
 ```
 
@@ -371,25 +371,25 @@ Do not add admin subcommands under `runtime`.
 
 The CLI should use only existing user APIs:
 
-- `GET /api/channels`
-- `GET /api/channels/bot-pool`
-- `POST /api/channels`
-- `GET /api/channels/{account_id}`
-- `GET /api/channels/{account_id}/agent-links`
-- `POST /api/channels/{account_id}/agent-links`
-- `POST /api/channels/{account_id}/agent-links/{link_id}/token`
-- `POST /api/channels/{account_id}/pair-codes`
-- `POST /api/channels/{account_id}/commands/sync`
-- `POST /api/channels/whatsapp/{account_id}/tenant-creds`
-- `GET /api/channels/whatsapp/{account_id}/tenant-creds`
-- `GET /api/channels/whatsapp/{account_id}/auth-cert`
+- `GET /v1/channels`
+- `GET /v1/channels/bot-pool`
+- `POST /v1/channels`
+- `GET /v1/channels/{account_id}`
+- `GET /v1/channels/{account_id}/agent-links`
+- `POST /v1/channels/{account_id}/agent-links`
+- `POST /v1/channels/{account_id}/agent-links/{link_id}/token`
+- `POST /v1/channels/{account_id}/pair-codes`
+- `POST /v1/channels/{account_id}/commands/sync`
+- `POST /v1/channels/whatsapp/{account_id}/tenant-creds`
+- `GET /v1/channels/whatsapp/{account_id}/tenant-creds`
+- `GET /v1/channels/whatsapp/{account_id}/auth-cert`
 
 No admin endpoint is needed for user runtime setup.
 
-Hosted deployment code should follow the same boundary. It may invoke the CLI
-inside the runtime or call these user APIs directly before launch, but it should
-not store its own pair-code state, implement provider webhooks, or recreate the
-legacy channel bridge tenant router.
+First-party hosted control planes should follow the same boundary. They may
+invoke the CLI inside the runtime or call these user APIs directly before
+launch, but they should not store their own pair-code state, implement provider
+webhooks, or recreate the legacy channel bridge tenant router.
 
 ## Compatibility Mapping
 

--- a/docs/designs/native-channels-product-model.md
+++ b/docs/designs/native-channels-product-model.md
@@ -31,9 +31,9 @@ provider protocol requires them, such as the WhatsApp Web Baileys sidecar.
 | Provider | The external network family: Telegram, Discord, WhatsApp, or iMessage/BlueBubbles. | `ChannelAccount.provider` |
 | External bot | A concrete external bot identity or provider endpoint, such as one Telegram bot token, one Discord application, one WhatsApp phone identity, or one BlueBubbles server. | `channel_accounts` |
 | Visibility | Whether an external bot is private to its owner or available as a Clawdi-managed public bot. | `ChannelAccount.visibility` |
-| Bot access | The caller's effective relationship to a selectable bot account: `owner` for caller-owned private bots, `public` for Clawdi-managed public bots. | `/api/channels/bot-pool` response |
-| Bot capabilities | The caller's allowed actions for a selectable bot account, such as link, pair, send, manage account, or sync commands. | `/api/channels/bot-pool` response |
-| Bot pool | The authenticated user's selectable bot candidates: owned private bots and active Clawdi-managed public bots. This is a read-only view, not a separate state table. | `/api/channels/bot-pool` |
+| Bot access | The caller's effective relationship to a selectable bot account: `owner` for caller-owned private bots, `public` for Clawdi-managed public bots. | `/v1/channels/bot-pool` response |
+| Bot capabilities | The caller's allowed actions for a selectable bot account, such as link, pair, send, manage account, or sync commands. | `/v1/channels/bot-pool` response |
+| Bot pool | The authenticated user's selectable bot candidates: owned private bots and active Clawdi-managed public bots. This is a read-only view, not a separate state table. | `/v1/channels/bot-pool` |
 | Bot-agent link | A user's authorization edge from one external bot to one Clawdi agent. This is the unit that owns the mock provider SDK token. | `channel_bot_agent_links` |
 | Agent SDK token | The token an agent process uses when it calls a Telegram Bot API, Discord REST/Gateway, WhatsApp Graph/Baileys, or BlueBubbles-compatible endpoint hosted by Clawdi. Tokens are scoped to one bot-agent link. | `ChannelBotAgentLink.agent_token_hash` |
 | External chat | The provider conversation id: Telegram chat id, Discord guild/channel route id, WhatsApp JID, or iMessage chat GUID. | `ChannelBinding.external_chat_id` |
@@ -117,7 +117,7 @@ These rules define the product, not just the current implementation:
 
 Private bots:
 
-- Created through the ordinary user `/api/channels` API.
+- Created through the ordinary user `/v1/channels` API.
 - Owned by the creating user.
 - Visible only to that owner.
 - Linkable only to that owner's agents.
@@ -125,7 +125,7 @@ Private bots:
 
 Public bots:
 
-- Created and managed only through `/api/admin/channels`.
+- Created and managed only through `/v1/admin/channels`.
 - Stored as `visibility = public`.
 - Visible to authenticated users for linking and pairing.
 - Provider credentials, webhook secret rotation, archive, and provider-wide
@@ -157,7 +157,7 @@ can access the account. The difference is account management, not runtime use:
 
 Bot pool:
 
-- `GET /api/channels/bot-pool` returns the user's selectable bot candidates
+- `GET /v1/channels/bot-pool` returns the user's selectable bot candidates
   grouped by provider.
 - Owned private bots appear only for their owner.
 - Only active bots appear in the selectable pool. Disabled private bots remain
@@ -363,41 +363,42 @@ Repository and service ownership:
 | Owner | Responsibility |
 | --- | --- |
 | `clawdi` repo | Native channel tables, user/admin channel APIs, provider webhooks, pair/unpair state machine, visible command replies, provider protocol adapters, workers, agent SDK emulation, and CLI/runtime channel materialization. |
-| Managed runtime control plane | Deployment profile selection, feature flags, and calls into `clawdi` native channel APIs to create or reuse accounts, links, pair codes, and runtime manifests. |
+| First-party hosted control planes | Hosted profile selection, feature flags, and calls into `clawdi` native channel APIs to create or reuse accounts, links, pair codes, and runtime manifests. |
 
-The managed runtime control plane must not duplicate channel bindings, pair-code claiming,
-provider webhook handlers, provider protocol state, or `/bot_pair` behavior.
+First-party hosted control planes must not duplicate channel bindings,
+pair-code claiming, provider webhook handlers, provider protocol state, or
+`/bot_pair` behavior.
 Those are product-state concerns owned by `clawdi` native Channels. Managed
-deployment code may pass a Clawdi auth token and selected channel intent into a
-runtime, or call user-facing channel APIs before launch, but the canonical
-channel state remains in the native channel backend.
+runtime code may pass a Clawdi auth token and selected channel intent into a
+runtime, or call user-facing channel APIs before launch, but canonical channel
+state remains in the native channel backend.
 
 User-facing control plane:
 
 | API | Scope |
 | --- | --- |
-| `GET /api/channels` | Lists caller-owned private bots only. Use bot-pool for selectable public bots. |
-| `GET /api/channels/bot-pool` | Lists selectable bot candidates grouped by provider, including caller access and capabilities. |
-| `POST /api/channels` | Creates private bots only. |
-| `GET /api/channels/{id}` | Reads an owned private bot or accessible public bot. |
-| `POST /api/channels/{id}/agent-links` | Creates a user-owned link from an active accessible bot to one of the user's agents. |
-| `GET /api/channels/{id}/agent-links` | Lists only the caller's links. |
-| `POST /api/channels/{id}/agent-links/{link_id}/token` | Rotates only the caller's link token. |
-| `POST /api/channels/{id}/pair-codes` | Creates a one-time code for one caller-owned link on an active accessible bot. |
-| `GET /api/channels/{id}/bindings` | Lists only the caller's active bindings. |
-| `POST /api/channels/{id}/messages` | Sends only through the caller's active binding on an active accessible bot. |
-| `DELETE /api/channels/{id}` | Archives only caller-owned private bots. Public bots must use admin API. |
-| `POST /api/channels/{id}/commands/sync` | Syncs commands only for caller-owned private bots. Public bots must use admin API. |
-| `POST /api/channels/whatsapp/{id}/tenant-creds` | Creates or reuses caller-owned WhatsApp runtime credentials for an accessible WhatsApp bot. |
-| `GET /api/channels/whatsapp/{id}/tenant-creds` | Lists only caller-owned WhatsApp runtime credentials. |
-| `GET /api/channels/whatsapp/{id}/auth-cert` | Returns WhatsApp account public auth material for an active accessible WhatsApp bot. |
+| `GET /v1/channels` | Lists caller-owned private bots only. Use bot-pool for selectable public bots. |
+| `GET /v1/channels/bot-pool` | Lists selectable bot candidates grouped by provider, including caller access and capabilities. |
+| `POST /v1/channels` | Creates private bots only. |
+| `GET /v1/channels/{id}` | Reads an owned private bot or accessible public bot. |
+| `POST /v1/channels/{id}/agent-links` | Creates a user-owned link from an active accessible bot to one of the user's agents. |
+| `GET /v1/channels/{id}/agent-links` | Lists only the caller's links. |
+| `POST /v1/channels/{id}/agent-links/{link_id}/token` | Rotates only the caller's link token. |
+| `POST /v1/channels/{id}/pair-codes` | Creates a one-time code for one caller-owned link on an active accessible bot. |
+| `GET /v1/channels/{id}/bindings` | Lists only the caller's active bindings. |
+| `POST /v1/channels/{id}/messages` | Sends only through the caller's active binding on an active accessible bot. |
+| `DELETE /v1/channels/{id}` | Archives only caller-owned private bots. Public bots must use admin API. |
+| `POST /v1/channels/{id}/commands/sync` | Syncs commands only for caller-owned private bots. Public bots must use admin API. |
+| `POST /v1/channels/whatsapp/{id}/tenant-creds` | Creates or reuses caller-owned WhatsApp runtime credentials for an accessible WhatsApp bot. |
+| `GET /v1/channels/whatsapp/{id}/tenant-creds` | Lists only caller-owned WhatsApp runtime credentials. |
+| `GET /v1/channels/whatsapp/{id}/auth-cert` | Returns WhatsApp account public auth material for an active accessible WhatsApp bot. |
 
 CLI control plane:
 
 | CLI | Scope |
 | --- | --- |
 | `clawdi channel list` | Lists caller-owned private bots only. |
-| `clawdi channel available` | Lists selectable owned private and public bots from `/api/channels/bot-pool`. |
+| `clawdi channel available` | Lists selectable owned private and public bots from `/v1/channels/bot-pool`. |
 | `clawdi channel create <provider> <name>` | Creates a private bot, optionally with an initial `--agent` link. |
 | `clawdi channel links <channel-id>` | Lists only the caller's bot-agent links for that bot. |
 | `clawdi channel link <channel-id> --agent <agent-id>` | Creates a caller-owned link from an accessible bot to one of the caller's agents. |
@@ -412,41 +413,41 @@ operations.
 Declarative runtime setup belongs in `clawdi runtime apply` using
 `clawdi.runtime.yaml`, described in
 `docs/designs/channel-runtime-manifest.md`. That manifest composes the same
-user-facing `/api/channels` APIs, materializes agent SDK tokens and target
+user-facing `/v1/channels` APIs, materializes agent SDK tokens and target
 runtime config, and still does not expose admin channel management in the CLI.
 
 Admin control plane:
 
 | API | Scope |
 | --- | --- |
-| `GET /api/admin/channels` | Lists managed channel accounts. |
-| `POST /api/admin/channels` | Creates private or public managed channel accounts. |
-| `GET /api/admin/channels/{id}` | Reads a managed channel account. |
-| `PATCH /api/admin/channels/{id}` | Updates account metadata, provider token, config, and encrypted secrets. |
-| `POST /api/admin/channels/{id}/webhook-secret/rotate` | Rotates provider ingress secret. |
-| `POST /api/admin/channels/{id}/commands/sync` | Syncs provider-wide pair/unpair commands. |
-| `DELETE /api/admin/channels/{id}` | Archives the account and active child state. |
+| `GET /v1/admin/channels` | Lists managed channel accounts. |
+| `POST /v1/admin/channels` | Creates private or public managed channel accounts. |
+| `GET /v1/admin/channels/{id}` | Reads a managed channel account. |
+| `PATCH /v1/admin/channels/{id}` | Updates account metadata, provider token, config, and encrypted secrets. |
+| `POST /v1/admin/channels/{id}/webhook-secret/rotate` | Rotates provider ingress secret. |
+| `POST /v1/admin/channels/{id}/commands/sync` | Syncs provider-wide pair/unpair commands. |
+| `DELETE /v1/admin/channels/{id}` | Archives the account and active child state. |
 
 Provider ingress:
 
-- `/api/channels/telegram/{id}/webhook`
-- `/api/channels/discord/{id}/webhook`
-- `/api/channels/whatsapp/{id}/webhook`
-- `/api/channels/imessage/{id}/webhook`
-- `/api/channels/discord/gateway` for agent-facing replay
-- `/api/channels/whatsapp/{id}/baileys` for Baileys-compatible WhatsApp Web
+- `/v1/channels/telegram/{id}/webhook`
+- `/v1/channels/discord/{id}/webhook`
+- `/v1/channels/whatsapp/{id}/webhook`
+- `/v1/channels/imessage/{id}/webhook`
+- `/v1/channels/discord/gateway` for agent-facing replay
+- `/v1/channels/whatsapp/{id}/baileys` for Baileys-compatible WhatsApp Web
   runtime ingress
 
 Agent SDK emulation:
 
-- Telegram Bot API-compatible routes under `/api/channels/telegram/bot/{token}`.
+- Telegram Bot API-compatible routes under `/v1/channels/telegram/bot/{token}`.
   Telegram `agent_token` values deliberately keep a Bot API-looking
   `<9-digit bot id>:<secret>` shape so SDKs and OpenClaw-compatible clients
   that validate token syntax continue to work.
-- Discord REST and Gateway-compatible routes under `/api/channels/discord`.
-- WhatsApp Graph and Baileys-compatible routes under `/api/channels/whatsapp`.
+- Discord REST and Gateway-compatible routes under `/v1/channels/discord`.
+- WhatsApp Graph and Baileys-compatible routes under `/v1/channels/whatsapp`.
 - BlueBubbles-compatible REST and Socket.IO routes under
-  `/api/channels/imessage`.
+  `/v1/channels/imessage`.
 
 ## Provider Adapter Contract
 

--- a/docs/designs/whatsapp-baileys-sidecar-runtime.md
+++ b/docs/designs/whatsapp-baileys-sidecar-runtime.md
@@ -95,7 +95,7 @@ channel account id:
 ```
 
 Startup health checks are best-effort. A configured but unavailable sidecar is
-still registered so `/api/channels/debug/health` can report `mode=sidecar` and
+still registered so `/v1/channels/debug/health` can report `mode=sidecar` and
 `shared-bot-transport-disconnected` instead of hiding the configured runtime.
 
 ## Non-Goals

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -22,11 +22,10 @@ Related public docs:
 The open-source CLI owns local runtime convergence, explicit `clawdi run`
 env-injection, runtime UI bridging, and diagnostics. It does not own
 OpenClaw/Hermes binaries, native update flows, or runtime process behavior.
-The web app owns the
-hosted deployment dashboard surfaces, including Control UI and Terminal tabs. A
-separate control plane may provide desired state, credentials, terminal
-authorization, rollout policy, and deployment lifecycle, but that
-platform-specific implementation is outside this repository.
+The web app owns the hosted deployment dashboard surfaces, including Control UI
+and Terminal tabs. First-party hosted control planes may provide desired state,
+credentials, terminal authorization, rollout policy, and deployment lifecycle,
+but those platform-specific implementations are outside this repository.
 
 The public contract covers:
 

--- a/docs/plans/ai-provider-catalog.md
+++ b/docs/plans/ai-provider-catalog.md
@@ -1,5 +1,10 @@
 # AI Provider Catalog Design
 
+> HISTORICAL - design plan that led to the current AI Provider implementation.
+> Use [`../ai-providers.md`](../ai-providers.md) for current user behavior and
+> [`../ai-provider-agent-contract-audit.md`](../ai-provider-agent-contract-audit.md)
+> for pinned target contracts.
+
 **Status:** implementation slice in progress
 **Last updated:** 2026-06-01
 **Owner:** product + platform

--- a/docs/plans/channels-native-backend.md
+++ b/docs/plans/channels-native-backend.md
@@ -1,5 +1,10 @@
 # Channels Native Backend Migration
 
+> HISTORICAL - completed migration plan. Use
+> [`../designs/native-channels-product-model.md`](../designs/native-channels-product-model.md)
+> for the current product model and [`../architecture.md#channels`](../architecture.md#channels)
+> for the current system summary.
+
 This branch replaces the legacy channel bridge wrapper plan with a Clawdi-native backend
 module. The backend owns channel data directly in Postgres and exposes new
 Clawdi routes plus Python-native channel-emulation surfaces for agent SDKs. It

--- a/docs/plans/clawdi-vault-password-manager-research.md
+++ b/docs/plans/clawdi-vault-password-manager-research.md
@@ -1,5 +1,10 @@
 # Clawdi Vault Password Manager Research
 
+> HISTORICAL - research notes, not current product behavior. Use
+> [`../architecture.md#vault`](../architecture.md#vault) and
+> [`../using-clawdi-with-claude-code.md#b-vault-inject-secrets-at-runtime-without-putting-them-on-disk`](../using-clawdi-with-claude-code.md#b-vault-inject-secrets-at-runtime-without-putting-them-on-disk)
+> for current vault behavior.
+
 **Status:** reviewed; Phase 1 implementation target
 **Last updated:** 2026-05-19
 **Owner:** product + platform
@@ -84,8 +89,8 @@ Decision impact from the second pass:
   `local_agent_profile`, `service_binding`, `proxy_binding`,
   `workload_identity`, and `delegated_tool_grant`.
 - The product must label credential custody explicitly. Client-managed vault
-  items, server-managed connected accounts, TEE-managed proxy sessions, and
-  external workload identities have different security claims.
+  items, server-managed connected accounts, attested-runtime proxy sessions,
+  and external workload identities have different security claims.
 - Agent Vault-style proxying is still the right hosted-agent security track,
   but it remains a later proof of concept because its guarantee depends on
   controlled egress and proxy enforcement.
@@ -524,11 +529,11 @@ material into follow-up actions. The core risks are:
 This threat model pushes Clawdi toward several distinct delivery modes: local
 dev env injection for compatibility, lease-scoped hosted-agent plaintext for
 the near-term hosted path, local/sidecar service for workload ergonomics,
-authorization/tool grants for SaaS tools, and proxy/TEE-backed access for
+authorization/tool grants for SaaS tools, and proxy/attested-runtime access for
 hosted agents with stronger controls. Reference UX and scoped runtime leases
-are near-term product work. Proxy/TEE belongs behind a separate proof of
-concept because it needs runtime network control to make the security claim
-honest.
+are near-term product work. Proxy/attested-runtime work belongs behind a
+separate proof of concept because it needs runtime network control to make the
+security claim honest.
 
 Second-pass research adds a fourth direction: **authorization instead of
 secret delivery**. For SaaS tools and MCP servers, the safer primitive is often
@@ -556,7 +561,7 @@ credential-and-capability layer, not only a secret-string store.
 6. **Move toward a client-managed trust model**
    - For ordinary user vault items, the target state is server-stored
      ciphertext with client-held or client-unwrapped keys.
-7. **Reserve proxy/TEE for controlled managed runtimes**
+7. **Reserve proxy/attested-runtime work for controlled managed runtimes**
    - Agent Vault-style proxying remains a strategic track, but only where
      Clawdi can enforce network/proxy behavior.
 8. **Keep key-management infrastructure behind adapters**
@@ -1013,11 +1018,11 @@ Deep Module responsible for delivering secrets to processes and agents:
      careful request/response logging policy.
    - Treat as a later proof of concept, not Phase 1 or Phase 2.
 
-7. **TEE-backed mode**
+7. **Attested-runtime mode**
    - Decryption or proxy runs inside an attested confidential VM.
    - Useful for stronger "operator cannot inspect runtime memory" claims.
    - Requires separate confidential compute evaluation.
-   - Second-pass search found strong TEE material for confidential agent
+   - Second-pass search found strong confidential-runtime material for agent
      runtimes, but no public evidence that OpenBao or Agent Vault has already
      been productized inside a reusable attested-runtime reference stack.
 
@@ -1339,7 +1344,7 @@ Properties:
 - Scopes, consent, refresh, revocation, and audit are first-class product
   objects.
 - Clawdi may still hold or refresh tokens unless the integration is
-  client-managed, external-provider managed, or TEE-managed.
+  client-managed, external-provider managed, or attested-runtime managed.
 
 This is the recommended direction for SaaS and MCP integrations. It should be
 designed with Vault because it shares Project/Agent grants and audit, but it
@@ -1359,7 +1364,7 @@ This is the recommended secure-agent direction, but it is not recommended for
 Phase 1. Treat it as a hosted-agent proof of concept after reference UX and
 basic Vault maturity are in place.
 
-### Option G: TEE Runtime
+### Option G: Attested Runtime
 
 Properties:
 
@@ -1619,7 +1624,8 @@ Deliver:
 - Tool/capability gateway for one OAuth-backed integration, so Clawdi can test
   whether "authorize an agent action" is a better UX than "give an agent a
   token" for SaaS tools.
-- TEE proof-of-concept only if product wants verifiable runtime privacy.
+- Attested-runtime proof of concept only if product wants verifiable runtime
+  privacy.
 
 Security statement:
 
@@ -1641,8 +1647,8 @@ Recommended decision:
    egress and CA/proxy bootstrapping.
 5. Treat OAuth connected accounts, delegated tool grants, and workload identity
    as typed future credential modes, not as generic secret fields.
-6. Treat TEE deployment as a separate high-trust hosted agent feasibility
-   project.
+6. Treat attested-runtime deployment as a separate high-trust hosted agent
+   feasibility project.
 
 Rejected alternatives:
 
@@ -1670,7 +1676,7 @@ Do say:
 - "Resolve secrets through Project and Agent context at runtime."
 - "Audit, expire, and revoke runtime secret access."
 - "Credential custody is explicit: client-managed, server-managed,
-  TEE-managed, or external-provider managed."
+  attested-runtime managed, or external-provider managed."
 - "Future client-managed vaults can prevent Clawdi servers from decrypting
   ordinary item values."
 
@@ -1723,8 +1729,8 @@ semantics, without turning every workflow into plaintext env sprawl."
    - OAuth refresh tokens for hosted tools may need server custody.
    - Ordinary static API keys and `.env` replacements should move toward
      client-managed custody.
-   - Enterprise customers may ask for external-provider or TEE-managed custody
-     before allowing hosted agent execution.
+   - Enterprise customers may ask for external-provider or attested-runtime
+     managed custody before allowing hosted agent execution.
 
 ## Source Notes
 
@@ -1813,5 +1819,5 @@ semantics, without turning every workflow into plaintext env sprawl."
   <https://openbao.org/docs/secrets/transit/>
   <https://openbao.org/docs/audit/>
   <https://openbao.org/docs/concepts/policies/>
-- TEE-based confidential compute is relevant for future attested hosted-agent
-  runtimes, not as the immediate Vault replacement.
+- Confidential compute is relevant for future attested hosted-agent runtimes,
+  not as the immediate Vault replacement.

--- a/docs/plans/project-agent-bindings.md
+++ b/docs/plans/project-agent-bindings.md
@@ -1,5 +1,11 @@
 # Project + Agent Project Design
 
+> HISTORICAL - PR design record for the Project + Agent Project rollout. Use
+> [`../architecture.md#projects-and-agent-use`](../architecture.md#projects-and-agent-use)
+> and
+> [`../scenarios/project-sharing-agent-bindings-demo.md`](../scenarios/project-sharing-agent-bindings-demo.md)
+> for the current summary and runnable demo.
+
 **Status:** CLI/backend ship-state for PR #88; web surfaces are split out
 **Last updated:** 2026-05-16
 **Owner:** product + platform

--- a/docs/plans/runtime-projection-boundary.md
+++ b/docs/plans/runtime-projection-boundary.md
@@ -36,7 +36,7 @@ runtime program from the local service plan.
 
 ```mermaid
 flowchart LR
-    ControlPlane[Control plane API] --> Manifest[Runtime manifest]
+    ControlPlane[First-party hosted control plane] --> Manifest[Runtime manifest]
     ControlPlane --> Channels[Runtime channel state]
     Manifest --> CLI[clawdi runtime reconciler]
     Channels --> CLI
@@ -110,7 +110,7 @@ The CLI may own:
 The CLI must not own:
 
 - private service routing policy;
-- production control-plane behavior;
+- first-party hosted control-plane behavior;
 - long-lived protocol credentials;
 - target runtime update channels;
 - user BYOK provider traffic interception by default.

--- a/docs/plans/ui-2.0-baseline-survey.md
+++ b/docs/plans/ui-2.0-baseline-survey.md
@@ -1,5 +1,9 @@
 # Cloud UI 2.0 — Baseline survey (Phase 0)
 
+> HISTORICAL - UI redesign survey from the 2026-06 pass. Use
+> [`../frontend-development.md`](../frontend-development.md) for current web
+> verification and `apps/web/src/` for current UI state.
+
 Surveyed on branch `cloud-ui-redesign` (off main @ b54b7d0), local dev at
 `http://localhost:3001` (web) + `:8001` (backend, DB clone `clawdi_cloud_ui2`).
 Screenshots: `/tmp/ui2b/{light,dark}-{desktop,mobile}/*.png` (15 pages × 4 combos).

--- a/docs/plans/ui-2.0-journey-evaluation.md
+++ b/docs/plans/ui-2.0-journey-evaluation.md
@@ -1,5 +1,9 @@
 # UI 2.0 — simulated journey evaluation (10 goals)
 
+> HISTORICAL - UI journey evaluation from the 2026-06 redesign pass. Use
+> [`../frontend-development.md`](../frontend-development.md) for current web
+> verification and `apps/web/src/` for current UI state.
+
 Driven live in a real browser against the full prod-mirrored dataset
 (2026-06-03, post-vivid-identity build). Each journey lists steps actually
 taken, the felt experience, and negative feelings found. Severity:

--- a/docs/plans/ui-2.0-taste-audit.md
+++ b/docs/plans/ui-2.0-taste-audit.md
@@ -1,5 +1,9 @@
 # UI 2.0 — taste audit (redesign-skill + minimalist-skill rubric)
 
+> HISTORICAL - UI taste audit from the 2026-06 redesign pass. Use
+> [`../frontend-development.md`](../frontend-development.md) for current web
+> verification and `apps/web/src/` for current UI state.
+
 Surveyed 2026-06-03 against `Leonxlnx/taste-skill` (redesign-skill §Design
 Audit + minimalist-skill §Protocol), on the post-B1–B8 build with full prod
 data. Compliant areas omitted; findings ordered by severity.

--- a/docs/plans/ui-2.0-ux-redesign.md
+++ b/docs/plans/ui-2.0-ux-redesign.md
@@ -1,5 +1,9 @@
 # Cloud UI 2.0 — UX redesign: domain map, user journeys, refactor plan
 
+> HISTORICAL - UI redesign plan from the 2026-06 pass. Use
+> [`../frontend-development.md`](../frontend-development.md) for current web
+> verification and `apps/web/src/` for current UI state.
+
 Status: proposal (2026-06-03). Phase A (tokens/primitives/casing) already landed
 on `cloud-ui-redesign`. This doc is the contract for Phase B — the structural,
 user-centric redesign replacing the "CRM" feel.

--- a/docs/scenarios/scenario-1-connectors-claude-code.md
+++ b/docs/scenarios/scenario-1-connectors-claude-code.md
@@ -1,5 +1,10 @@
 # Scenario 1: Clawdi + Claude Code (CLI-First)
 
+> HISTORICAL - early 2026-04 CLI-first scenario. Current Claude Code setup is in
+> [`../using-clawdi-with-claude-code.md`](../using-clawdi-with-claude-code.md);
+> current API/MCP compatibility is in
+> [`../api-compatibility.md`](../api-compatibility.md).
+
 **Date:** 2026-04-15
 **Context:** Based on product-design.md, adopting CLI-first approach over remote MCP endpoint.
 

--- a/docs/scenarios/scenario-2-vault-claude-code.md
+++ b/docs/scenarios/scenario-2-vault-claude-code.md
@@ -1,5 +1,9 @@
 # Scenario 2: Vault + Claude Code (CLI-First)
 
+> HISTORICAL - early 2026-04 vault scenario. Current vault behavior is in
+> [`../architecture.md#vault`](../architecture.md#vault) and
+> [`../using-clawdi-with-claude-code.md`](../using-clawdi-with-claude-code.md).
+
 **Date:** 2026-04-15
 **Context:** Vault is Layer 2 infrastructure — secrets never enter LLM context.
 

--- a/docs/scenarios/scenario-3-memory-session-sync.md
+++ b/docs/scenarios/scenario-3-memory-session-sync.md
@@ -1,5 +1,10 @@
 # Scenario 3: Memory — Claude Code Session Sync
 
+> HISTORICAL - early 2026-04 memory extraction scenario. Current memory behavior
+> is explicit user/agent writes through MCP or CLI; see
+> [`../architecture.md#memory`](../architecture.md#memory) and
+> [`../using-clawdi-with-claude-code.md`](../using-clawdi-with-claude-code.md).
+
 **Date:** 2026-04-15
 **Context:** Memory is Layer 1 (LLM-facing). Cross-agent recall via `memory_search` MCP tool.
 

--- a/docs/scenarios/scenario-4-channels-telegram-claude-code.md
+++ b/docs/scenarios/scenario-4-channels-telegram-claude-code.md
@@ -1,5 +1,10 @@
 # Scenario 4: Channels — Telegram ↔ Claude Code Bridge
 
+> HISTORICAL - early 2026-04 local channel-serve concept. Current native
+> Channels are backend-owned; see
+> [`../designs/native-channels-product-model.md`](../designs/native-channels-product-model.md)
+> and [`../architecture.md#channels`](../architecture.md#channels).
+
 **Date:** 2026-04-15
 **Context:** Channels decouple bot tokens from deployments. This scenario focuses on using Telegram to remotely drive Claude Code on your local machine.
 

--- a/docs/scenarios/scenario-5-gateway-unified-api.md
+++ b/docs/scenarios/scenario-5-gateway-unified-api.md
@@ -1,5 +1,10 @@
 # Scenario 5: Managed API Gateway
 
+> HISTORICAL - early 2026-04 managed-gateway concept. Current AI Provider
+> behavior does not proxy BYOK model traffic; see
+> [`../ai-providers.md`](../ai-providers.md) and
+> [`../architecture.md#ai-providers`](../architecture.md#ai-providers).
+
 **Date:** 2026-04-15
 **Context:** A managed API gateway can provide a zero-config fallback when a
 user does not bring provider keys through Vault.

--- a/docs/scenarios/scenario-6-skills-portable-instructions.md
+++ b/docs/scenarios/scenario-6-skills-portable-instructions.md
@@ -1,5 +1,10 @@
 # Scenario 6: Skills — Portable Agent Instructions
 
+> HISTORICAL - early 2026-04 skills registry scenario. Current commands use
+> `clawdi skill ...`, `clawdi push`, and `clawdi pull`; see
+> [`../using-clawdi-with-claude-code.md#c-skills-portable-instructions-that-all-your-agents-share`](../using-clawdi-with-claude-code.md#c-skills-portable-instructions-that-all-your-agents-share)
+> and [`../cli-development.md`](../cli-development.md).
+
 **Date:** 2026-04-15
 **Context:** Skills are static config (markdown files), not MCP tools. Loaded at session start, synced via CLI.
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,33 @@
+# Clawdi
+> Open-source cross-agent sync and recall layer for agent sessions, skills,
+> memory, vaults, projects, channels, AI Providers, and local agent adapters.
+
+Use `/v1/*` as the canonical public API prefix. Hosted infrastructure internals
+are outside this OSS repository; public docs refer only to first-party hosted
+control planes when that boundary matters.
+
+## Start Here
+- [README](https://github.com/Clawdi-AI/clawdi/blob/main/README.md): Product overview, user quickstart, CLI examples, and self-hosting entry point.
+- [AGENTS](https://github.com/Clawdi-AI/clawdi/blob/main/AGENTS.md): Command-first contributor index for local stack setup, verification, and repo conventions.
+- [Agent Docs Guide](https://github.com/Clawdi-AI/clawdi/blob/main/docs/agent-docs-guide.md): Rules for keeping agent-facing docs short, verified, and maintainable.
+- [Architecture](https://github.com/Clawdi-AI/clawdi/blob/main/docs/architecture.md): Current system map, storage/auth model, API identity, and module ownership.
+- [API Compatibility](https://github.com/Clawdi-AI/clawdi/blob/main/docs/api-compatibility.md): `/v1/agents` canonical surface, deprecated aliases, generated-client rules, and additive API policy.
+
+## Development
+- [Backend Development](https://github.com/Clawdi-AI/clawdi/blob/main/docs/backend-development.md): FastAPI, Alembic, throwaway Postgres tests, and generated API client workflow.
+- [Frontend Development](https://github.com/Clawdi-AI/clawdi/blob/main/docs/frontend-development.md): TanStack Start dashboard loop, OSS build boundary, and web verification commands.
+- [CLI Development](https://github.com/Clawdi-AI/clawdi/blob/main/docs/cli-development.md): Bun CLI workflows, adapters, daemon testing, packaging, and release notes.
+- [Daemon Test Guide](https://github.com/Clawdi-AI/clawdi/blob/main/docs/clawdi-daemon-test-guide.md): Manual and automated verification for `clawdi daemon`.
+- [Release Runbook](https://github.com/Clawdi-AI/clawdi/blob/main/docs/runbooks/release.md): Release tags, CLI/npm publishing, changelog, and rollback checks.
+
+## Domain Contracts
+- [ADR-0001 Agent Identity](https://github.com/Clawdi-AI/clawdi/blob/main/docs/adr/0001-agent-identity-is-the-stable-domain-object.md): Stable Agent identity model and one-name fallback.
+- [AI Providers](https://github.com/Clawdi-AI/clawdi/blob/main/docs/ai-providers.md): Portable model-provider layer, auth references, target apply behavior, and BYOK boundary.
+- [AI Provider Agent Contract Audit](https://github.com/Clawdi-AI/clawdi/blob/main/docs/ai-provider-agent-contract-audit.md): Verified target contracts for Codex, Hermes, and OpenClaw AI Provider projections.
+- [Managed Runtime](https://github.com/Clawdi-AI/clawdi/blob/main/docs/managed-runtime.md): Public CLI/dashboard runtime contract without deployment-specific internals.
+- [Native Channels Product Model](https://github.com/Clawdi-AI/clawdi/blob/main/docs/designs/native-channels-product-model.md): Backend-owned channel accounts, bot-agent links, pair codes, bindings, and provider SDK emulation.
+- [Channel Runtime Manifest](https://github.com/Clawdi-AI/clawdi/blob/main/docs/designs/channel-runtime-manifest.md): `clawdi.runtime.yaml` channel projection contract and backend APIs used by the CLI.
+
+## Optional
+- [Using Clawdi with Claude Code](https://github.com/Clawdi-AI/clawdi/blob/main/docs/using-clawdi-with-claude-code.md): End-to-end Claude Code usage guide for setup, vault, skills, memory, and session sync.
+- [Project Sharing Demo](https://github.com/Clawdi-AI/clawdi/blob/main/docs/scenarios/project-sharing-agent-bindings-demo.md): Ship-state walkthrough for Project sharing and Agent Project bindings.


### PR DESCRIPTION
## Summary

- Slimmed `AGENTS.md` into a command-first contributor index with explicit done criteria and links to owner docs.
- Added `docs/agent-docs-guide.md` and curated `llms.txt` discovery files at the repo root and `apps/web/public/llms.txt` for the served `/llms.txt` path.
- Refreshed `docs/architecture.md` around Agent identity, `/v1/agents`, compatibility aliases, adapters, sync, core domains, and storage/auth.
- Audited docs for stale/historical material, added historical banners instead of deleting, and updated current channel/runtime docs to use canonical `/v1` examples.

## Verification

- `bun run typecheck` ✅
- `bun run test` ✅
- `bun run check` ✅
- `git diff --check` ✅
- Local Markdown link checker over `AGENTS.md`, `README.md`, `llms.txt`, `apps/web/public/llms.txt`, and all `docs/**/*.md` ✅
- Leak grep over current `AGENTS.md`, `docs`, `llms.txt`, and `apps/web/public/llms.txt` ✅
- Targeted `bunx biome ci <touched docs>` processed 0 files because `biome.json` excludes `docs/` and ignores Markdown/TXT; pre-commit reported the same. Full `bun run check` passed.
- Backend pytest not run; this was docs-only and no migrated throwaway Postgres was provisioned.

## STALE INVENTORY

| File | Verdict | Reason |
| --- | --- | --- |
| `docs/adr/0001-agent-identity-is-the-stable-domain-object.md` | current | Accepted Agent identity ADR; cross-linked from architecture/API docs. |
| `docs/adr/README.md` | current | ADR index/process doc. |
| `docs/agent-docs-guide.md` | current | New agent-doc maintenance doctrine. |
| `docs/ai-provider-agent-contract-audit.md` | current | Pinned target contract audit for AI Provider adapters. |
| `docs/ai-provider-isolated-e2e.md` | banner-added | Historical smoke record; points to current AI Provider docs/contracts. |
| `docs/ai-providers.md` | current | Current AI Provider user/contract doc. |
| `docs/api-compatibility.md` | current | Current compatibility policy; fixed architecture anchor. |
| `docs/architecture.md` | current | Rewritten current system map and module fact sheet. |
| `docs/backend-development.md` | current | Backend contributor workflow remains active. |
| `docs/clawdi-daemon-test-guide.md` | current | Current daemon test guide; refreshed hosted-boundary wording. |
| `docs/cli-development.md` | current | CLI contributor workflow remains active. |
| `docs/designs/channel-runtime-manifest.md` | current | Implemented baseline; refreshed canonical `/v1` API examples. |
| `docs/designs/native-channels-product-model.md` | current | Current Channels product model; refreshed `/v1` and hosted-boundary wording. |
| `docs/designs/whatsapp-baileys-sidecar-runtime.md` | current | Adopted sidecar runtime design; refreshed debug-health route prefix. |
| `docs/frontend-development.md` | current | Web contributor workflow remains active. |
| `docs/managed-runtime.md` | current | Public runtime contract; refreshed first-party hosted control-plane boundary. |
| `docs/plans/ai-provider-catalog.md` | banner-added | Historical implementation plan; current behavior lives in AI Provider docs. |
| `docs/plans/channels-native-backend.md` | banner-added | Completed migration plan; current model lives in Channels design/architecture. |
| `docs/plans/clawdi-vault-password-manager-research.md` | banner-added | Historical research; points to current Vault behavior and pruned sensitive infra terminology. |
| `docs/plans/managed-runtime-cli.md` | current | Public implementation notes for runtime CLI. |
| `docs/plans/managed-runtime-roadmap.md` | current | Public roadmap with explicit OSS boundary. |
| `docs/plans/project-agent-bindings.md` | banner-added | Historical rollout design; current model is architecture plus runnable demo. |
| `docs/plans/runtime-projection-boundary.md` | current | Public boundary note; refreshed hosted control-plane wording. |
| `docs/plans/ui-2.0-baseline-survey.md` | banner-added | Historical UI redesign survey. |
| `docs/plans/ui-2.0-journey-evaluation.md` | banner-added | Historical UI journey evaluation. |
| `docs/plans/ui-2.0-taste-audit.md` | banner-added | Historical UI taste audit. |
| `docs/plans/ui-2.0-ux-redesign.md` | banner-added | Historical UI redesign plan. |
| `docs/runbooks/release.md` | current | Current release runbook. |
| `docs/scenarios/project-sharing-agent-bindings-demo.md` | current | Ship-state Project sharing demo. |
| `docs/scenarios/scenario-1-connectors-claude-code.md` | banner-added | Early CLI/MCP scenario; current setup docs linked. |
| `docs/scenarios/scenario-2-vault-claude-code.md` | banner-added | Early Vault scenario; current Vault docs linked. |
| `docs/scenarios/scenario-3-memory-session-sync.md` | banner-added | Early memory extraction scenario; current memory behavior linked. |
| `docs/scenarios/scenario-4-channels-telegram-claude-code.md` | banner-added | Early local channel-serve concept; current native Channels docs linked. |
| `docs/scenarios/scenario-5-gateway-unified-api.md` | banner-added | Early managed-gateway concept; current AI Provider boundary linked. |
| `docs/scenarios/scenario-6-skills-portable-instructions.md` | banner-added | Early skills registry scenario; current CLI commands linked. |
| `docs/using-clawdi-with-claude-code.md` | current | Current end-to-end Claude Code usage guide. |

No docs were archived or marked `needs-owner-decision` in this pass.
