### PR TITLE
Unify empty states, flatten connectors, align agent tab headers

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -96,6 +96,12 @@ Weights: use 500/600 for hierarchy; 400 body; avoid 700+.
 
 - Card tiers: entity cards are `rounded-lg p-4`; hero cards are
   `rounded-xl p-5`. Do not add new card tiers without updating this contract.
+- Empty states use `EmptyState` only. `variant="page"` (default) is for a
+  page or tab whose main region is empty: flat, centered, generous height, and
+  an icon tile. `variant="inset"` is for an empty sub-region inside existing
+  page/card/dialog chrome: solid border, `bg-muted/30`, compact padding, and
+  no large icon. Do not add appearance axes like bordered/fillHeight/iconVariant
+  or hand-roll dashed centered text placeholders.
 - Hover idioms: clickable rows/cards use `hover:bg-muted/50`; hero-card lift
   uses `hover:-translate-y-px hover:border-foreground/20`.
 - Tinted panels: subtle inset wells use `bg-muted/30`. Reserve

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -44,7 +44,7 @@ import {
 } from "lucide-react";
 import { useQueryState } from "nuqs";
 import { parseAsStringLiteral } from "nuqs/server";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useCommandPalette } from "@/components/command-palette";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
@@ -101,6 +101,7 @@ import {
 } from "@/lib/agent-routes";
 import { unwrap, useApi } from "@/lib/api";
 import { useCurrentUser } from "@/lib/auth-client";
+import { availableAppsQueryOptions, CONNECTOR_CATALOG_PAGE_SIZE } from "@/lib/connectors-data";
 import { IS_HOSTED } from "@/lib/hosted";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { legacyHostedDashboardUrl } from "@/lib/legacy-hosted-dashboard";
@@ -225,6 +226,7 @@ type SidebarNavItem = {
 	tooltip: string;
 	active: boolean;
 	external?: boolean;
+	prefetch?: () => void;
 };
 
 type AgentSectionDefinition = {
@@ -303,7 +305,12 @@ function SidebarNavSection({
 											<ExternalLink className="ml-auto size-3 text-muted-foreground" />
 										</a>
 									) : (
-										<Link to={item.href} onClick={onNavigate}>
+										<Link
+											to={item.href}
+											onClick={onNavigate}
+											onMouseEnter={item.prefetch}
+											onFocus={item.prefetch}
+										>
 											<IconChip size="xs" tint={item.tint}>
 												<Icon />
 											</IconChip>
@@ -360,6 +367,16 @@ function ConsoleResourcesSection({
 	showCloudFeatures: boolean;
 	onNavigate?: () => void;
 }) {
+	const api = useApi();
+	const queryClient = useQueryClient();
+	const prefetchConnectorsCatalog = useCallback(() => {
+		void queryClient.prefetchQuery(
+			availableAppsQueryOptions(api, {
+				page: 1,
+				pageSize: CONNECTOR_CATALOG_PAGE_SIZE,
+			}),
+		);
+	}, [api, queryClient]);
 	const resourceItems: SidebarNavItem[] = PROJECT_RESOURCE_GROUPS.flatMap((group) =>
 		projectResourceDefinitionsForGroup(group.id).map((definition) => {
 			const Icon = PROJECT_RESOURCE_ICONS[definition.id];
@@ -371,6 +388,7 @@ function ConsoleResourcesSection({
 				tint: RESOURCE_TINT_CLASSES[definition.id],
 				tooltip: `${definition.navLabel} - ${projectResourceScopeLabel(definition.projectScope)}`,
 				active: pathname === definition.href || pathname.startsWith(`${definition.href}/`),
+				prefetch: definition.id === "connectors" ? prefetchConnectorsCatalog : undefined,
 			};
 		}),
 	);

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -153,7 +153,7 @@ export function AgentsCard({
 					// When the hosted fetch failed, the error banner below carries
 					// the message — render no empty state to avoid contradicting it.
 					<EmptyState
-						fillHeight={false}
+						variant="inset"
 						title="No agents yet"
 						description="Connect an agent to see it here."
 					/>

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -19,10 +19,11 @@ import { useSetAgentBreadcrumbTitle } from "@/components/breadcrumb-title";
 import {
 	AgentSourceBadgeForEnvironment,
 	agentDisplayName,
-	agentTypeLabel,
 } from "@/components/dashboard/agent-label";
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
 import { DetailNotFound, DetailPanel, type DetailSectionMeta } from "@/components/detail/layout";
+import { EmptyState } from "@/components/empty-state";
+import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import {
 	isCustomProject,
@@ -210,6 +211,22 @@ export function ConnectedAgentDetail({
 	const activeTabMeta = AGENT_DETAIL_NAV_META[activeTab];
 	const activeTabLabel = agentSectionLabel(activeTab);
 	const ActiveTabIcon = activeTabMeta.icon;
+	const ownershipKind = agent ? agentOwnershipKindFromId(agent.id, ownership) : "connected";
+	const agentTitle = agent ? agentDisplayName(agent) : null;
+	useSetAgentBreadcrumbTitle({ agentId: id, agentTitle, section: activeTab });
+	const headerStatus =
+		agent && showSourceBadge ? (
+			<AgentSourceBadgeForEnvironment env={agent} ownershipKind={ownershipKind} compact />
+		) : null;
+	const headerActions =
+		activeTab === "skills" ? (
+			<Button asChild variant="outline" size="sm">
+				<Link to="/skills" search={{ target: id }}>
+					<Plus />
+					Install skills
+				</Link>
+			</Button>
+		) : null;
 	const scopedSessionLink = (sessionId: string) => ({
 		to: "/agents/$id/sessions/$sessionId" as const,
 		params: { id, sessionId },
@@ -219,10 +236,6 @@ export function ConnectedAgentDetail({
 		params: { id, _splat: skill.skill_key },
 		search: skill.project_id ? { project: skill.project_id } : undefined,
 	});
-
-	const ownershipKind = agent ? agentOwnershipKindFromId(agent.id, ownership) : "connected";
-	const agentTitle = agent ? agentDisplayName(agent) : null;
-	useSetAgentBreadcrumbTitle({ agentId: id, agentTitle, section: activeTab });
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6")}>
@@ -234,107 +247,83 @@ export function ConnectedAgentDetail({
 					<Skeleton className="h-4 w-64" />
 				</div>
 			) : agent ? (
-				<>
-					<h1 className="sr-only">{agentTitle || agentTypeLabel(agent.agent_type)}</h1>
+				<section className="flex flex-col gap-4">
+					<div className={cn(AGENT_DETAIL_INNER_WIDTH_CLASS, "flex flex-col gap-4")}>
+						<PageHeader
+							title={activeTabLabel}
+							description={activeTabMeta.description}
+							icon={
+								ActiveTabIcon ? <ActiveTabIcon className="size-4 text-muted-foreground" /> : null
+							}
+							status={headerStatus}
+							actions={headerActions}
+						/>
 
-					<section className="flex flex-col gap-4">
-						<div className={cn(AGENT_DETAIL_INNER_WIDTH_CLASS, "flex flex-col gap-4")}>
-							<div className="flex flex-wrap items-start justify-between gap-3">
-								<div>
-									<div className="flex items-center gap-2">
-										{ActiveTabIcon ? (
-											<ActiveTabIcon className="size-4 text-muted-foreground" />
-										) : null}
-										<h2 className="text-xl font-semibold tracking-tight">{activeTabLabel}</h2>
-										{showSourceBadge ? (
-											<AgentSourceBadgeForEnvironment
-												env={agent}
-												ownershipKind={ownershipKind}
-												compact
-											/>
-										) : null}
-									</div>
-									{activeTabMeta.description ? (
-										<p className="mt-1 text-sm text-muted-foreground">
-											{activeTabMeta.description}
-										</p>
-									) : null}
-								</div>
-								{activeTab === "skills" ? (
-									<Button asChild variant="outline" size="sm">
-										<Link to="/skills" search={{ target: id }}>
-											<Plus />
-											Install skills
-										</Link>
-									</Button>
-								) : null}
-							</div>
-
-							{activeTab === "overview" ? (
-								<div className="flex flex-col gap-4">
-									<div className="grid gap-3 sm:grid-cols-3">
-										<AgentStatPanel label="Sessions" value={sessionTotal} />
-										<AgentStatPanel
-											label="Skills"
-											value={skillsForThisEnv ? skillsForThisEnv.length : "—"}
-										/>
-										<AgentStatPanel label="Projects" value={projectBindings?.length ?? "—"} />
-									</div>
-									<SessionFeed
-										sessions={(sessionsPage?.items ?? []).slice(0, 5)}
-										isLoading={sessionsLoading}
-										emptyMessage="No sessions synced from this agent yet."
-										showAgent={false}
-										sessionLink={(session) => scopedSessionLink(session.id)}
+						{activeTab === "overview" ? (
+							<div className="flex flex-col gap-4">
+								<div className="grid gap-3 sm:grid-cols-3">
+									<AgentStatPanel label="Sessions" value={sessionTotal} />
+									<AgentStatPanel
+										label="Skills"
+										value={skillsForThisEnv ? skillsForThisEnv.length : "—"}
 									/>
+									<AgentStatPanel label="Projects" value={projectBindings?.length ?? "—"} />
 								</div>
-							) : null}
-
-							{activeTab === "sessions" ? (
 								<SessionFeed
-									sessions={sessionsPage?.items ?? []}
+									sessions={(sessionsPage?.items ?? []).slice(0, 5)}
 									isLoading={sessionsLoading}
 									emptyMessage="No sessions synced from this agent yet."
+									emptyVariant="inset"
 									showAgent={false}
 									sessionLink={(session) => scopedSessionLink(session.id)}
 								/>
-							) : null}
+							</div>
+						) : null}
 
-							{activeTab === "skills" ? (
-								<SkillCardGrid
-									skills={skillsForThisEnv ?? []}
-									isLoading={skillsLoading}
-									emptyMessage="No skills installed on this agent yet."
-									readOnlySkillCheck={(s) =>
-										!s.project_id || !(writableProjectIds?.has(s.project_id) ?? false)
-									}
-									onUninstall={(skillKey, projectId) =>
-										uninstallSkill.mutate({ skillKey, projectId })
-									}
-									uninstallPending={uninstallSkill.isPending}
-									skillLink={scopedSkillLink}
-								/>
-							) : null}
+						{activeTab === "sessions" ? (
+							<SessionFeed
+								sessions={sessionsPage?.items ?? []}
+								isLoading={sessionsLoading}
+								emptyMessage="No sessions synced from this agent yet."
+								showAgent={false}
+								sessionLink={(session) => scopedSessionLink(session.id)}
+							/>
+						) : null}
 
-							{activeTab === "projects" ? (
-								<AgentProjectsPanel
-									agentId={id}
-									bindings={projectBindings ?? []}
-									projects={projects ?? []}
-									isLoading={projectBindingsLoading}
-									onChanged={() => {
-										queryClient.invalidateQueries({
-											queryKey: ["agent-project-bindings", id],
-										});
-										queryClient.invalidateQueries({ queryKey: ["projects"] });
-									}}
-								/>
-							) : null}
+						{activeTab === "skills" ? (
+							<SkillCardGrid
+								skills={skillsForThisEnv ?? []}
+								isLoading={skillsLoading}
+								emptyMessage="No skills installed on this agent yet."
+								readOnlySkillCheck={(s) =>
+									!s.project_id || !(writableProjectIds?.has(s.project_id) ?? false)
+								}
+								onUninstall={(skillKey, projectId) =>
+									uninstallSkill.mutate({ skillKey, projectId })
+								}
+								uninstallPending={uninstallSkill.isPending}
+								skillLink={scopedSkillLink}
+							/>
+						) : null}
 
-							{activeTab === "settings" ? <AgentSettingsPanel environmentId={id} /> : null}
-						</div>
-					</section>
-				</>
+						{activeTab === "projects" ? (
+							<AgentProjectsPanel
+								agentId={id}
+								bindings={projectBindings ?? []}
+								projects={projects ?? []}
+								isLoading={projectBindingsLoading}
+								onChanged={() => {
+									queryClient.invalidateQueries({
+										queryKey: ["agent-project-bindings", id],
+									});
+									queryClient.invalidateQueries({ queryKey: ["projects"] });
+								}}
+							/>
+						) : null}
+
+						{activeTab === "settings" ? <AgentSettingsPanel environmentId={id} /> : null}
+					</div>
+				</section>
 			) : null}
 		</div>
 	);
@@ -460,9 +449,7 @@ function AgentProjectsPanel({
 						{primary ? (
 							<ProjectUseLine binding={primary} project={projectsById.get(primary.project_id)} />
 						) : (
-							<div className="rounded-md border border-dashed px-3 py-4 text-sm text-muted-foreground">
-								Agent Project is not loaded yet.
-							</div>
+							<EmptyState variant="inset" description="Agent Project is not loaded yet." />
 						)}
 					</div>
 					<div className="rounded-md border bg-background/60 p-3 text-xs text-muted-foreground">
@@ -520,10 +507,10 @@ function AgentProjectsPanel({
 					<Badge variant="secondary">{contexts.length}</Badge>
 				</div>
 				{contexts.length === 0 ? (
-					<div className="rounded-lg border border-dashed px-4 py-6 text-sm text-muted-foreground">
-						No added Projects yet. Add a Custom or shared Project to make it available to this
-						agent.
-					</div>
+					<EmptyState
+						variant="inset"
+						description="No added Projects yet. Add a Custom or shared Project to make it available to this agent."
+					/>
 				) : (
 					<div className="divide-y rounded-lg border bg-card/60">
 						{contexts.map((binding, index) => {

--- a/apps/web/src/components/dashboard/section.tsx
+++ b/apps/web/src/components/dashboard/section.tsx
@@ -1,5 +1,6 @@
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
+import { EmptyState } from "@/components/empty-state";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
@@ -76,12 +77,5 @@ export function DashboardSectionToolbar({ children }: { children: ReactNode }) {
 }
 
 export function DashboardEmptyLine({ title, message }: { title: string; message: ReactNode }) {
-	return (
-		<div className="m-4 rounded-lg border border-dashed px-4 py-6">
-			<div className="space-y-1">
-				<h3 className="text-sm font-medium">{title}</h3>
-				<p className="max-w-2xl text-sm text-muted-foreground">{message}</p>
-			</div>
-		</div>
-	);
+	return <EmptyState variant="inset" title={title} description={message} className="m-4" />;
 }

--- a/apps/web/src/components/empty-state.tsx
+++ b/apps/web/src/components/empty-state.tsx
@@ -1,4 +1,4 @@
-import type { LucideIcon } from "lucide-react";
+import { Inbox, type LucideIcon } from "lucide-react";
 import { isValidElement, type ReactNode } from "react";
 import {
 	Empty,
@@ -10,58 +10,45 @@ import {
 } from "@/components/ui/empty";
 import { cn } from "@/lib/utils";
 
+export type EmptyStateVariant = "page" | "inset";
+
 interface EmptyStateProps {
 	icon?: LucideIcon | ReactNode;
 	title?: string;
 	description?: ReactNode;
 	action?: ReactNode;
-	/** Use `icon` for the shadcn icon tile used by standalone empty panels. */
-	iconVariant?: "default" | "icon";
-	/** When set, wraps in a rounded muted tile. Default is flat — just centered text. */
-	bordered?: boolean;
-	/**
-	 * When true (default), reserve vertical space so the hint sits mid-pane
-	 * instead of floating near the top. Set false inside cards / sub-regions
-	 * where surrounding chrome already sets the visual weight.
-	 */
-	fillHeight?: boolean;
+	variant?: EmptyStateVariant;
 	className?: string;
 }
 
 /**
- * Centered empty-state message. Thin wrapper around shadcn's `<Empty>`
- * primitives so call sites get a single prop-driven API while everything
- * styling / aria comes from upstream.
- *
- * If a page needs unusual composition (multiple actions, custom media,
- * nested sections), import the `<Empty>` parts from `@/components/ui/empty`
- * directly instead of expanding this component's props.
+ * Canonical empty placeholder.
+ * Page: flat centered panel with generous height and an icon tile.
+ * Inset: compact muted tile inside existing page/card chrome.
  */
 export function EmptyState({
 	icon: Icon,
 	title,
 	description,
 	action,
-	iconVariant = "default",
-	bordered = false,
-	fillHeight = true,
+	variant = "page",
 	className,
 }: EmptyStateProps) {
-	const icon = renderEmptyIcon(Icon, iconVariant);
+	const icon = variant === "page" ? renderEmptyIcon(Icon === undefined ? Inbox : Icon) : null;
 	return (
 		<Empty
 			className={cn(
-				// shadcn's default already includes `rounded-lg border-dashed p-6
-				// md:p-12`. The flat variant (default) strips the border + padding
-				// because most of our usages live inside existing card chrome.
-				bordered ? "border bg-muted/30" : "border-none p-0 md:p-0",
-				fillHeight ? "min-h-[320px]" : "py-8 md:py-8",
+				variant === "page"
+					? "min-h-[320px] border-none bg-transparent p-0 md:p-0"
+					: "min-h-0 flex-none gap-3 border border-solid bg-muted/30 px-4 py-6 md:p-6",
 				className,
 			)}
 		>
-			<EmptyHeader>
-				{icon ? <EmptyMedia variant={iconVariant}>{icon}</EmptyMedia> : null}
-				{title ? <EmptyTitle className="text-sm">{title}</EmptyTitle> : null}
+			<EmptyHeader className={cn(variant === "inset" && "gap-1")}>
+				{icon ? <EmptyMedia variant="icon">{icon}</EmptyMedia> : null}
+				{title ? (
+					<EmptyTitle className="text-sm font-medium tracking-normal">{title}</EmptyTitle>
+				) : null}
 				{description ? <EmptyDescription>{description}</EmptyDescription> : null}
 			</EmptyHeader>
 			{action ? <EmptyContent>{action}</EmptyContent> : null}
@@ -69,14 +56,9 @@ export function EmptyState({
 	);
 }
 
-function renderEmptyIcon(icon: EmptyStateProps["icon"], variant: EmptyStateProps["iconVariant"]) {
+function renderEmptyIcon(icon: EmptyStateProps["icon"]) {
 	if (!icon) return null;
 	if (isValidElement(icon) || typeof icon === "string" || typeof icon === "number") return icon;
 	const Icon = icon as LucideIcon;
-	return (
-		<Icon
-			className={variant === "icon" ? "size-5" : "size-8 text-muted-foreground/60"}
-			aria-hidden
-		/>
-	);
+	return <Icon className="size-5" aria-hidden />;
 }

--- a/apps/web/src/components/sessions/session-feed.tsx
+++ b/apps/web/src/components/sessions/session-feed.tsx
@@ -2,6 +2,7 @@
 
 import { Link, type LinkProps } from "@tanstack/react-router";
 import { MessageSquare, Zap } from "lucide-react";
+import { EmptyState, type EmptyStateVariant } from "@/components/empty-state";
 import { Stat } from "@/components/meta/stat";
 import { SessionAgentLabel } from "@/components/sessions/session-agent-label";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -25,6 +26,7 @@ export function SessionFeed({
 	sessions,
 	isLoading,
 	emptyMessage,
+	emptyVariant = "page",
 	grouped = true,
 	groupBy = "last_activity_at",
 	showAgent = true,
@@ -34,6 +36,7 @@ export function SessionFeed({
 	sessions: SessionListItem[];
 	isLoading: boolean;
 	emptyMessage: string;
+	emptyVariant?: EmptyStateVariant;
 	/** Group under Today / Yesterday / … headers (only meaningful for date sorts). */
 	grouped?: boolean;
 	groupBy?: "last_activity_at" | "started_at";
@@ -59,11 +62,7 @@ export function SessionFeed({
 	}
 
 	if (sessions.length === 0) {
-		return (
-			<div className="rounded-lg border border-dashed px-4 py-16 text-center text-sm text-muted-foreground">
-				{emptyMessage}
-			</div>
-		);
+		return <EmptyState variant={emptyVariant} icon={MessageSquare} description={emptyMessage} />;
 	}
 
 	if (!grouped) {

--- a/apps/web/src/components/skills/skill-card.tsx
+++ b/apps/web/src/components/skills/skill-card.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Link, type LinkProps } from "@tanstack/react-router";
-import { Trash2 } from "lucide-react";
+import { Sparkles, Trash2 } from "lucide-react";
+import { EmptyState, type EmptyStateVariant } from "@/components/empty-state";
 import { HERO_CARD_BASE } from "@/components/entity-card";
 import { IconChip } from "@/components/icon-chip";
 import { SendSkillDialog } from "@/components/skills/send-skill-dialog";
@@ -166,6 +167,7 @@ export function SkillCardGrid({
 	skills,
 	isLoading,
 	emptyMessage,
+	emptyVariant = "page",
 	readOnlySkillCheck,
 	onUninstall,
 	uninstallPending,
@@ -178,6 +180,7 @@ export function SkillCardGrid({
 	skills: SkillSummary[];
 	isLoading: boolean;
 	emptyMessage: React.ReactNode;
+	emptyVariant?: EmptyStateVariant;
 	/** Returns true when the current user cannot uninstall this skill. */
 	readOnlySkillCheck?: (skill: SkillSummary) => boolean;
 	onUninstall?: (skillKey: string, projectId: string) => void;
@@ -200,11 +203,7 @@ export function SkillCardGrid({
 		);
 	}
 	if (skills.length === 0) {
-		return (
-			<div className="rounded-xl border border-dashed px-4 py-12 text-center text-sm text-muted-foreground">
-				{emptyMessage}
-			</div>
-		);
+		return <EmptyState variant={emptyVariant} icon={Sparkles} description={emptyMessage} />;
 	}
 	return (
 		<div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -94,8 +94,6 @@ export function AgentHome({
 				className={`${CENTERED_PAGE_WIDTH_CLASS.page} space-y-4 px-4 py-2 lg:px-6`}
 			>
 				<EmptyState
-					bordered
-					fillHeight={false}
 					title="Clawdi Cloud agent not found"
 					description="This Clawdi Cloud agent may still be provisioning or may have been removed."
 				/>

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -30,6 +30,7 @@ import { AgentSourceBadge, agentDisplayName } from "@/components/dashboard/agent
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
 import type { DetailSectionMeta } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
+import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SessionFeed } from "@/components/sessions/session-feed";
 import { SettingsSection } from "@/components/settings-section";
@@ -286,6 +287,14 @@ export function HostedAgentDetail({
 	const activeTabLabel = agentSectionLabel(activeTab);
 	const ActiveTabIcon = activeNavItem.icon;
 	const isLiveToolTab = activeTab === "console" || activeTab === "terminal";
+	const headerActions = consoleUrl ? (
+		<Button asChild variant="outline" size="sm">
+			<a href={consoleUrl} target="_blank" rel="noopener noreferrer">
+				Open {runtimeBrowserUiLabel(runtime)}
+				<ExternalLink className="size-3.5" />
+			</a>
+		</Button>
+	) : null;
 
 	return (
 		<div
@@ -297,7 +306,7 @@ export function HostedAgentDetail({
 					: "flex flex-col gap-6 px-4 lg:px-6",
 			)}
 		>
-			<h1 className="sr-only">{agentTitle}</h1>
+			{isLiveToolTab ? <h1 className="sr-only">{agentTitle}</h1> : null}
 			<section
 				className={cn(
 					isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : HOSTED_AGENT_INNER_WIDTH_CLASS,
@@ -305,26 +314,13 @@ export function HostedAgentDetail({
 				)}
 			>
 				{isLiveToolTab ? null : (
-					<div className="flex flex-wrap items-start justify-between gap-3">
-						<div>
-							<div className="flex items-center gap-2">
-								{ActiveTabIcon ? <ActiveTabIcon className="size-4 text-muted-foreground" /> : null}
-								<h2 className="text-xl font-semibold tracking-tight">{activeTabLabel}</h2>
-								<AgentSourceBadge source="hosted" compact />
-							</div>
-							{activeNavItem.description ? (
-								<p className="mt-1 text-sm text-muted-foreground">{activeNavItem.description}</p>
-							) : null}
-						</div>
-						{consoleUrl ? (
-							<Button asChild variant="outline" size="sm">
-								<a href={consoleUrl} target="_blank" rel="noopener noreferrer">
-									Open {runtimeBrowserUiLabel(runtime)}
-									<ExternalLink className="size-3.5" />
-								</a>
-							</Button>
-						) : null}
-					</div>
+					<PageHeader
+						title={activeTabLabel}
+						description={activeNavItem.description}
+						icon={ActiveTabIcon ? <ActiveTabIcon className="size-4 text-muted-foreground" /> : null}
+						status={<AgentSourceBadge source="hosted" compact />}
+						actions={headerActions}
+					/>
 				)}
 				<div className={isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : "w-full"}>
 					{activeTab === "overview" ? (
@@ -436,6 +432,7 @@ function OverviewTab({
 						sessions={sessions}
 						isLoading={sessionsLoading}
 						emptyMessage="No sessions from this agent yet."
+						emptyVariant="inset"
 						showAgent={false}
 						sessionLink={sessionLink}
 					/>
@@ -463,7 +460,6 @@ function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; run
 	if (!isRunning) {
 		return (
 			<EmptyState
-				bordered
 				icon={MonitorPlay}
 				title="Runtime UI available once running"
 				description={`The live ${browserUiLabel} opens here as soon as the agent is running — currently ${statusLabel(
@@ -477,7 +473,6 @@ function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; run
 	if (!url) {
 		return (
 			<EmptyState
-				bordered
 				icon={MonitorPlay}
 				title="No Runtime UI URL yet"
 				description={
@@ -663,7 +658,6 @@ function TerminalTab({ deployment }: { deployment: HostedDeployment }) {
 	if (!isRunning) {
 		return (
 			<EmptyState
-				bordered
 				icon={TerminalSquare}
 				title="Terminal available once running"
 				description={`A deployment shell can be opened when the hosted compute is running. Current status: ${statusLabel(
@@ -819,7 +813,6 @@ function AiProviderTab({
 	if (runtime === "codex") {
 		return (
 			<EmptyState
-				bordered
 				icon={Info}
 				title="Codex AI access is set at deploy time"
 				description="This hosted runtime is always available. Runtime-specific AI provider changes are available for OpenClaw and Hermes."
@@ -1045,7 +1038,6 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 	if (!hasEnvironmentId) {
 		return (
 			<EmptyState
-				bordered
 				icon={Link2}
 				title="Channels available once provisioning finishes"
 				description="The deployment is still minting its cloud agent id. When the agent is ready, link channels here."
@@ -1070,8 +1062,7 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 					/>
 				) : (linked.data ?? []).length === 0 ? (
 					<EmptyState
-						bordered
-						fillHeight={false}
+						variant="inset"
 						title="No channels linked"
 						description="Link a channel below so this agent can send and receive messages."
 					/>

--- a/apps/web/src/hosted/billing/usage/usage-page.tsx
+++ b/apps/web/src/hosted/billing/usage/usage-page.tsx
@@ -50,10 +50,7 @@ export function UsagePage() {
 			<div data-hosted="true" className={USAGE_PAGE_CLASS}>
 				<PageHeader title="Usage" description={DESCRIPTION} />
 				<EmptyState
-					bordered
-					fillHeight={false}
 					icon={Activity}
-					iconVariant="icon"
 					title="No usage yet"
 					description="Once your agents start running, credit consumption shows up here."
 				/>

--- a/apps/web/src/hosted/billing/wallet/ledger-table.tsx
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.tsx
@@ -146,10 +146,8 @@ export function LedgerTable({
 				</div>
 			) : filtered.length === 0 ? (
 				<EmptyState
-					bordered
-					fillHeight={false}
+					variant="inset"
 					icon={Receipt}
-					iconVariant="icon"
 					title={entries.length === 0 ? "No activity yet" : "No matching activity"}
 					description={
 						entries.length === 0

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
@@ -81,8 +81,6 @@ export function AiProvidersPage() {
 					<EmptyState
 						title="No custom providers"
 						description="Add your own OpenAI, Anthropic, OpenRouter, Gemini, Mistral, or a custom OpenAI-compatible endpoint."
-						fillHeight={false}
-						bordered
 					/>
 				) : (
 					<div className={PROVIDER_GRID_CLASS}>

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -354,7 +354,6 @@ function AgentsTab({ accountId, accountName }: { accountId: string; accountName:
 					icon={Link2}
 					title="No agents linked"
 					description="Link an agent so it can send and receive on this channel."
-					fillHeight={false}
 				/>
 			) : (
 				<div className="flex flex-col gap-2">
@@ -471,8 +470,7 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 				/>
 			) : linkItems.length === 0 ? (
 				<EmptyState
-					bordered
-					fillHeight={false}
+					variant="inset"
 					title="Link an agent first"
 					description="A WhatsApp device is minted per agent. Link an agent on the Agents tab, then come back."
 				/>
@@ -530,9 +528,7 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 						title="Couldn't load linked devices"
 					/>
 				) : devices.length === 0 ? (
-					<div className="rounded-lg border border-dashed px-3 py-6 text-center text-sm text-muted-foreground">
-						No devices linked yet.
-					</div>
+					<EmptyState variant="inset" description="No devices linked yet." />
 				) : (
 					devices.map((d) => (
 						<div
@@ -917,9 +913,10 @@ function CommandsTab({ accountId, provider }: { accountId: string; provider: str
 							))}
 						</div>
 					) : sync.data ? (
-						<div className="rounded-lg border border-dashed px-3 py-3 text-sm text-muted-foreground">
-							Command sync completed. The runtime returned no commands to publish.
-						</div>
+						<EmptyState
+							variant="inset"
+							description="Command sync completed. The runtime returned no commands to publish."
+						/>
 					) : null}
 				</>
 			) : null}

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
@@ -114,9 +114,9 @@ export function LinkAgentDialog({
 					/>
 				) : agents.length === 0 ? (
 					<EmptyState
+						variant="inset"
 						title="No agents yet"
 						description="Connect an agent first, then link it to this channel."
-						fillHeight={false}
 					/>
 				) : (
 					<div className="flex flex-col gap-2">

--- a/apps/web/src/lib/connectors-data.ts
+++ b/apps/web/src/lib/connectors-data.ts
@@ -26,6 +26,39 @@ import { unwrap, useApi } from "@/lib/api";
 // ─────────────────────────────────────────────────────────────────────
 // Reads
 
+export const CONNECTOR_CATALOG_PAGE_SIZE = 24;
+export const CONNECTOR_CATALOG_STALE_TIME_MS = 10 * 60 * 1000;
+export const CONNECTOR_CATALOG_GC_TIME_MS = CONNECTOR_CATALOG_STALE_TIME_MS;
+
+type ApiClient = ReturnType<typeof useApi>;
+
+export type AvailableAppsQueryArgs = {
+	page: number;
+	pageSize: number;
+	search?: string;
+};
+
+export function availableAppsQueryKey({ page, pageSize, search }: AvailableAppsQueryArgs) {
+	return ["available-apps", { page, pageSize, search }] as const;
+}
+
+export function availableAppsQueryOptions(api: ApiClient, args: AvailableAppsQueryArgs) {
+	const { page, pageSize, search } = args;
+	return {
+		queryKey: availableAppsQueryKey(args),
+		queryFn: async () =>
+			unwrap(
+				await api.GET("/v1/connectors/available", {
+					params: {
+						query: { page, page_size: pageSize, ...(search ? { search } : {}) },
+					},
+				}),
+			),
+		staleTime: CONNECTOR_CATALOG_STALE_TIME_MS,
+		gcTime: CONNECTOR_CATALOG_GC_TIME_MS,
+	};
+}
+
 export function useConnections() {
 	const api = useApi();
 	return useQuery({
@@ -47,26 +80,10 @@ export function useAvailableApp(appName: string) {
 	});
 }
 
-export function useAvailableApps({
-	page,
-	pageSize,
-	search,
-}: {
-	page: number;
-	pageSize: number;
-	search?: string;
-}) {
+export function useAvailableApps({ page, pageSize, search }: AvailableAppsQueryArgs) {
 	const api = useApi();
 	return useQuery({
-		queryKey: ["available-apps", { page, pageSize, search }] as const,
-		queryFn: async () =>
-			unwrap(
-				await api.GET("/v1/connectors/available", {
-					params: {
-						query: { page, page_size: pageSize, ...(search ? { search } : {}) },
-					},
-				}),
-			),
+		...availableAppsQueryOptions(api, { page, pageSize, search }),
 		placeholderData: keepPreviousData,
 	});
 }

--- a/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
+++ b/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
@@ -318,11 +318,7 @@ function ConnectorDetail({ name }: { name: string }) {
 							<AlertDescription>{errorMessage(connectionsQ.error)}</AlertDescription>
 						</Alert>
 					) : usesNoAuth ? (
-						<EmptyState
-							fillHeight={false}
-							bordered
-							description="No account connection is required."
-						/>
+						<EmptyState variant="inset" description="No account connection is required." />
 					) : hasUnsupportedAuthType ? (
 						<Alert variant="destructive">
 							<AlertCircle />
@@ -340,8 +336,7 @@ function ConnectorDetail({ name }: { name: string }) {
 							</Alert>
 						) : (
 							<EmptyState
-								fillHeight={false}
-								bordered
+								variant="inset"
 								description="No connected accounts yet."
 								action={
 									<Button onClick={startConnect} disabled={isConnectDisabled}>
@@ -534,7 +529,7 @@ function ConnectorToolsList({
 							: "Tools this connector exposes."
 					}
 				/>
-				<EmptyState fillHeight={false} description="No tools are available for this connector." />
+				<EmptyState variant="inset" description="No tools are available for this connector." />
 			</DashboardSection>
 		);
 	}

--- a/apps/web/src/pages/dashboard/connectors/page.tsx
+++ b/apps/web/src/pages/dashboard/connectors/page.tsx
@@ -2,33 +2,33 @@
 
 import { AlertCircle, ChevronLeft, ChevronRight, Plug } from "lucide-react";
 import { createParser, parseAsString, useQueryState } from "nuqs";
-import { Suspense, useEffect, useMemo } from "react";
+import { type ReactNode, Suspense, useEffect, useMemo } from "react";
 import {
 	CONNECTOR_GRID_CLASS,
 	ConnectorCard,
 	ConnectorCardSkeleton,
 } from "@/components/connectors/connector-card";
-import {
-	DashboardSection,
-	DashboardSectionHeader,
-	DashboardSectionToolbar,
-} from "@/components/dashboard/section";
 import { EmptyState } from "@/components/empty-state";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
+import { SectionLabel } from "@/components/section-label";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/search-input";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useAvailableApps, useConnectedAppCards } from "@/lib/connectors-data";
+import {
+	CONNECTOR_CATALOG_PAGE_SIZE,
+	useAvailableApps,
+	useConnectedAppCards,
+} from "@/lib/connectors-data";
 import { getProjectResourceDefinition } from "@/lib/project-resource-model";
 import { useDebouncedValue } from "@/lib/use-debounced";
 import { cn, errorMessage } from "@/lib/utils";
 
 // Multiple of 12 (LCM of 1/2/3/4 col grid breakpoints) so the last row is
 // always full at every viewport — no orphan cards on the bottom.
-const PAGE_SIZE = 24;
+const PAGE_SIZE = CONNECTOR_CATALOG_PAGE_SIZE;
 const CONNECTORS_RESOURCE = getProjectResourceDefinition("connectors");
 
 // 1-indexed page parser. Rejects non-integer / 0 / negative URL values
@@ -61,12 +61,23 @@ function ConnectorsListSkeleton() {
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 			<PageHeader title="Connectors" description={CONNECTORS_RESOURCE.managementDescription} />
-			<Skeleton className="h-10 w-full" />
-			<div className={CONNECTOR_GRID_CLASS}>
-				{Array.from({ length: 16 }).map((_, i) => (
-					<ConnectorCardSkeleton key={i} />
-				))}
-			</div>
+			<Skeleton className="h-10 w-full max-w-xl" />
+			<section className="space-y-3">
+				<SectionLabel>Connected</SectionLabel>
+				<div className={CONNECTOR_GRID_CLASS}>
+					{Array.from({ length: 4 }).map((_, i) => (
+						<ConnectorCardSkeleton key={i} />
+					))}
+				</div>
+			</section>
+			<section className="space-y-3">
+				<SectionLabel>All Connectors</SectionLabel>
+				<div className={CONNECTOR_GRID_CLASS}>
+					{Array.from({ length: 16 }).map((_, i) => (
+						<ConnectorCardSkeleton key={i} />
+					))}
+				</div>
+			</section>
 		</div>
 	);
 }
@@ -136,56 +147,52 @@ function ConnectorsList() {
 	// otherwise a connections-fetch failure makes the section silently
 	// disappear and the user has no signal anything went wrong.
 	const showConnectedRail =
-		!debouncedQuery && (connected.activeConnections.length > 0 || !!connected.error);
+		!debouncedQuery &&
+		(connected.isLoading || connected.activeConnections.length > 0 || !!connected.error);
+	const headerStatus =
+		total > 0 || connected.activeConnections.length > 0 ? (
+			<div className="flex flex-wrap items-center gap-2">
+				{total > 0 ? <Badge variant="secondary">{total.toLocaleString()} available</Badge> : null}
+				{connected.activeConnections.length > 0 ? (
+					<Badge>{connected.activeConnections.length} active</Badge>
+				) : null}
+			</div>
+		) : null;
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
-			<PageHeader title="Connectors" description={CONNECTORS_RESOURCE.managementDescription} />
+			<PageHeader
+				title="Connectors"
+				description={CONNECTORS_RESOURCE.managementDescription}
+				status={headerStatus}
+			/>
 
-			<DashboardSection>
-				<DashboardSectionHeader
-					icon={Plug}
-					title="Connector catalog"
-					count={total > 0 ? `${total.toLocaleString()} available` : undefined}
-					description="Connectors let agents use outside apps after you approve access. They are account-level, not tied to one Project."
-					actions={
-						connected.activeConnections.length > 0 ? (
-							<Badge>{connected.activeConnections.length} active</Badge>
-						) : null
-					}
+			<div className="max-w-xl">
+				<SearchInput value={query} onChange={handleQueryChange} placeholder="Search connectors…" />
+			</div>
+
+			{showConnectedRail ? (
+				<ConnectedRail
+					apps={connected.data}
+					activeCount={connected.activeConnections.length}
+					isLoading={connected.isLoading}
+					error={connected.error}
 				/>
-				<DashboardSectionToolbar>
-					<SearchInput
-						value={query}
-						onChange={handleQueryChange}
-						placeholder="Search connectors…"
-					/>
-				</DashboardSectionToolbar>
-				<div className="space-y-5 p-4">
-					{showConnectedRail ? (
-						<ConnectedRail
-							apps={connected.data}
-							isLoading={connected.isLoading}
-							error={connected.error}
-						/>
-					) : null}
+			) : null}
 
-					<CatalogSection
-						items={items}
-						total={total}
-						page={page}
-						totalPages={totalPages}
-						connectedNames={connectedNames}
-						isLoading={isCatalogLoading}
-						isFetching={isCatalogFetching}
-						error={catalogError}
-						query={query}
-						labelled={showConnectedRail}
-						onPrev={() => setPage((p) => Math.max(1, p - 1))}
-						onNext={() => setPage((p) => Math.min(totalPages, p + 1))}
-					/>
-				</div>
-			</DashboardSection>
+			<CatalogSection
+				items={items}
+				total={total}
+				page={page}
+				totalPages={totalPages}
+				connectedNames={connectedNames}
+				isLoading={isCatalogLoading}
+				isFetching={isCatalogFetching}
+				error={catalogError}
+				query={query}
+				onPrev={() => setPage((p) => Math.max(1, p - 1))}
+				onNext={() => setPage((p) => Math.min(totalPages, p + 1))}
+			/>
 		</div>
 	);
 }
@@ -197,16 +204,20 @@ function ConnectorsList() {
  */
 function ConnectedRail({
 	apps,
+	activeCount,
 	isLoading,
 	error,
 }: {
 	apps: { name: string; display_name: string; description: string; logo: string }[];
+	activeCount: number;
 	isLoading: boolean;
 	error: Error | null;
 }) {
 	return (
-		<section>
-			<h2 className="mb-3 text-sm font-semibold">Connected</h2>
+		<section className="space-y-3">
+			<SectionLabel count={activeCount > 0 ? `${activeCount} active` : undefined}>
+				Connected
+			</SectionLabel>
 			{error ? (
 				// Without this, a connections-fetch failure makes the rail
 				// silently disappear and the user only sees "X active" in
@@ -243,7 +254,6 @@ function CatalogSection({
 	isFetching,
 	error,
 	query,
-	labelled,
 	onPrev,
 	onNext,
 }: {
@@ -256,30 +266,29 @@ function CatalogSection({
 	isFetching: boolean;
 	error: Error | null;
 	query: string;
-	labelled: boolean;
 	onPrev: () => void;
 	onNext: () => void;
 }) {
+	const count = !isLoading && total > 0 ? `${total.toLocaleString()} available` : undefined;
+	let content: ReactNode;
 	if (error) {
-		return (
+		content = (
 			<Alert variant="destructive">
 				<AlertCircle />
 				<AlertTitle>Couldn't load connectors</AlertTitle>
 				<AlertDescription>{errorMessage(error)}</AlertDescription>
 			</Alert>
 		);
-	}
-	if (isLoading) {
-		return (
+	} else if (isLoading) {
+		content = (
 			<div className={CONNECTOR_GRID_CLASS}>
 				{Array.from({ length: 16 }).map((_, i) => (
 					<ConnectorCardSkeleton key={i} />
 				))}
 			</div>
 		);
-	}
-	if (items.length === 0) {
-		return (
+	} else if (items.length === 0) {
+		content = (
 			<EmptyState
 				icon={Plug}
 				title={query ? "No matches" : "No connectors available"}
@@ -290,41 +299,47 @@ function CatalogSection({
 				}
 			/>
 		);
+	} else {
+		content = (
+			<>
+				<div className={cn(CONNECTOR_GRID_CLASS, isFetching && "opacity-60 transition-opacity")}>
+					{items.map((app) => (
+						<ConnectorCard key={app.name} app={app} isConnected={connectedNames.has(app.name)} />
+					))}
+				</div>
+				{totalPages > 1 ? (
+					<div className="flex items-center justify-center gap-2 pt-3">
+						<Button
+							variant="outline"
+							size="icon-sm"
+							onClick={onPrev}
+							disabled={page <= 1}
+							aria-label="Previous page"
+						>
+							<ChevronLeft className="size-4" />
+						</Button>
+						<span className="px-3 text-xs tabular-nums text-muted-foreground">
+							{(page - 1) * PAGE_SIZE + 1}–{Math.min(page * PAGE_SIZE, total)} of{" "}
+							{total.toLocaleString()}
+						</span>
+						<Button
+							variant="outline"
+							size="icon-sm"
+							onClick={onNext}
+							disabled={page >= totalPages}
+							aria-label="Next page"
+						>
+							<ChevronRight className="size-4" />
+						</Button>
+					</div>
+				) : null}
+			</>
+		);
 	}
 	return (
-		<section>
-			{labelled ? <h2 className="mb-3 text-sm font-semibold">All Connectors</h2> : null}
-			<div className={cn(CONNECTOR_GRID_CLASS, isFetching && "opacity-60 transition-opacity")}>
-				{items.map((app) => (
-					<ConnectorCard key={app.name} app={app} isConnected={connectedNames.has(app.name)} />
-				))}
-			</div>
-			{totalPages > 1 ? (
-				<div className="flex items-center justify-center gap-2 pt-3">
-					<Button
-						variant="outline"
-						size="icon-sm"
-						onClick={onPrev}
-						disabled={page <= 1}
-						aria-label="Previous page"
-					>
-						<ChevronLeft className="size-4" />
-					</Button>
-					<span className="px-3 text-xs tabular-nums text-muted-foreground">
-						{(page - 1) * PAGE_SIZE + 1}–{Math.min(page * PAGE_SIZE, total)} of{" "}
-						{total.toLocaleString()}
-					</span>
-					<Button
-						variant="outline"
-						size="icon-sm"
-						onClick={onNext}
-						disabled={page >= totalPages}
-						aria-label="Next page"
-					>
-						<ChevronRight className="size-4" />
-					</Button>
-				</div>
-			) : null}
+		<section className="space-y-3">
+			<SectionLabel count={count}>All Connectors</SectionLabel>
+			{content}
 		</section>
 	);
 }

--- a/apps/web/src/pages/dashboard/memories/page.tsx
+++ b/apps/web/src/pages/dashboard/memories/page.tsx
@@ -269,7 +269,7 @@ function MemoryNotesGrid({
 	}
 
 	if (!memories.length) {
-		return <EmptyState bordered fillHeight={false} description={emptyMessage} />;
+		return <EmptyState description={emptyMessage} />;
 	}
 
 	return (

--- a/apps/web/src/pages/dashboard/page.tsx
+++ b/apps/web/src/pages/dashboard/page.tsx
@@ -213,6 +213,7 @@ export default function DashboardPage() {
 							isLoading={sessionsLoading}
 							grouped={false}
 							emptyMessage="No sessions yet. Once your agent starts a conversation, it'll show up here."
+							emptyVariant="inset"
 						/>
 					</section>
 				</div>

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -23,6 +23,7 @@ import {
 	compareAgentEnvironments,
 } from "@/components/dashboard/agent-label";
 import { DetailNotFound, DetailPanel, DetailTitle } from "@/components/detail/layout";
+import { EmptyState } from "@/components/empty-state";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import {
 	displayProjectName,
@@ -424,6 +425,7 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 						skills={skills.data?.items ?? []}
 						isLoading={skills.isLoading}
 						emptyMessage="No skills are visible in this Project yet."
+						emptyVariant="inset"
 					/>
 				)}
 			</HubSection>
@@ -1176,11 +1178,7 @@ function displayAgentName(env: Env) {
 }
 
 function EmptyLine({ message }: { message: string }) {
-	return (
-		<div className="rounded-lg border border-dashed px-4 py-6 text-sm text-muted-foreground">
-			{message}
-		</div>
-	);
+	return <EmptyState variant="inset" description={message} />;
 }
 
 function ErrorLine({ message }: { message: string }) {

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -391,7 +391,7 @@ export function SessionDetailContent({
 						</p>
 					</div>
 					<EmptyState
-						fillHeight={false}
+						variant="inset"
 						description="Conversation not uploaded yet. To back-fill history from that machine, run: clawdi push --modules sessions --all-agents --all"
 					/>
 				</DetailPanel>
@@ -577,13 +577,13 @@ function MessagesSkeleton() {
 }
 
 function EmptyContent() {
-	return <EmptyState fillHeight={false} description="No messages in this session." />;
+	return <EmptyState variant="inset" description="No messages in this session." />;
 }
 
 function ContentFetchError() {
 	return (
 		<EmptyState
-			fillHeight={false}
+			variant="inset"
 			description="Session content is unavailable. Check your connection and refresh this page."
 		/>
 	);

--- a/apps/web/src/pages/dashboard/skills/[key]/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/[key]/page.tsx
@@ -27,6 +27,7 @@ import {
 	DetailStats,
 	DetailTitle,
 } from "@/components/detail/layout";
+import { EmptyState } from "@/components/empty-state";
 import { Markdown } from "@/components/markdown";
 import { Stat } from "@/components/meta/stat";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
@@ -487,9 +488,10 @@ export function SkillDetailContent({
 								</p>
 							</div>
 						) : (
-							<p className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
-								No Project information is available for this Skill.
-							</p>
+							<EmptyState
+								variant="inset"
+								description="No Project information is available for this Skill."
+							/>
 						)}
 					</DetailPanel>
 
@@ -535,9 +537,10 @@ export function SkillDetailContent({
 									<Markdown content={skillBody} />
 								</div>
 							) : (
-								<p className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
-									No additional instruction body is stored for this Skill.
-								</p>
+								<EmptyState
+									variant="inset"
+									description="No additional instruction body is stored for this Skill."
+								/>
 							)}
 						</DetailPanel>
 					) : (
@@ -557,10 +560,10 @@ export function SkillDetailContent({
 									{skill.file_count} file{skill.file_count === 1 ? "" : "s"}
 								</Badge>
 							</div>
-							<p className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
-								When the agent uploads the Skill file content, the preview and editor will appear
-								here.
-							</p>
+							<EmptyState
+								variant="inset"
+								description="When the agent uploads the Skill file content, the preview and editor will appear here."
+							/>
 						</DetailPanel>
 					)}
 				</>

--- a/apps/web/src/pages/dashboard/skills/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/page.tsx
@@ -22,6 +22,7 @@ import { Suspense, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { BulkActionBar } from "@/components/bulk-action-bar";
 import { agentIdentity } from "@/components/dashboard/agent-label";
+import { EmptyState } from "@/components/empty-state";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import {
@@ -682,9 +683,9 @@ function SkillsPageInner() {
 				</div>
 				{duplicatesView ? (
 					duplicateGroups.length === 0 ? (
-						<div className="rounded-xl border border-dashed px-4 py-12 text-center text-sm text-muted-foreground">
-							No duplicated skills{search.trim() ? " match that search" : ""}.
-						</div>
+						<EmptyState
+							description={`No duplicated skills${search.trim() ? " match that search" : ""}.`}
+						/>
 					) : (
 						<div className="space-y-6">
 							{duplicateGroups.map((group) => {
@@ -768,11 +769,13 @@ function SkillsPageInner() {
 					skillsLoading || isResolvingTarget ? (
 						<SkillCardGrid skills={[]} isLoading emptyMessage={null} />
 					) : allGroups.length === 0 ? (
-						<div className="rounded-xl border border-dashed px-4 py-12 text-center text-sm text-muted-foreground">
-							{search.trim()
-								? "No skills match that search."
-								: "No skills installed anywhere yet. Pick a Project tab to install one."}
-						</div>
+						<EmptyState
+							description={
+								search.trim()
+									? "No skills match that search."
+									: "No skills installed anywhere yet. Pick a Project tab to install one."
+							}
+						/>
 					) : (
 						<div className="space-y-6">
 							{allGroups.map((group) => {

--- a/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
@@ -438,15 +438,13 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 					<Skeleton className="h-32 w-full rounded-lg" />
 				) : keyNames.length === 0 ? (
 					<EmptyState
-						bordered
-						fillHeight={false}
+						variant="inset"
 						title="No keys yet"
 						description="Add one above or paste several at once with Import."
 					/>
 				) : filteredKeyNames.length === 0 ? (
 					<EmptyState
-						bordered
-						fillHeight={false}
+						variant="inset"
 						title="No keys match that search"
 						description="Try another key name or section."
 					/>
@@ -590,8 +588,7 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 				</div>
 				{attachedProjects.length === 0 ? (
 					<EmptyState
-						bordered
-						fillHeight={false}
+						variant="inset"
 						title="Not added to any Project yet"
 						description="Agents can't use these keys until this vault is added to a Project."
 					/>


### PR DESCRIPTION
## Summary

### Empty states
- Collapsed `EmptyState` to `variant="page" | "inset"` and removed the old `bordered`, `fillHeight`, and `iconVariant` axes.
- Migrated call sites and hand-rolled dashed empty placeholders to the canonical variants.
- Documented the two-variant rule in `DESIGN.md`.

### Connectors catalog
- Added 10 minute `staleTime` and matching `gcTime` for the connector catalog query, while keeping `keepPreviousData` for search/pagination.
- Added sidebar hover/focus prefetch for the first catalog page using the shared query options.
- Kept `connections` on the normal fresher cadence and split the Connected rail from the catalog grid so each renders independently.

Timing from the dev server with Playwright route mocks and an intentional 1.2s catalog delay:
- Cold direct `/connectors` load: 3893ms until catalog content was visible.
- Catalog mock response time: 1200ms.
- Sidebar hover prefetch: 3299ms.
- Warm navigation after prefetch: 651ms until catalog content was visible.
- Catalog requests during warm page open: 0.

This measurement isolates frontend caching/prefetch behavior under mock latency; it is not a backend server-side timing. No real backend endpoint >1s follow-up was identified from this run.

### Connectors layout
- Removed the outer `DashboardSection` wrapper from the connectors page.
- Kept `PageHeader` as the page chassis, placed search flat under it, and made Connected / All Connectors flat sections.
- Updated the loading skeleton to match the flattened layout.

### Agent tab headers
- Replaced connected and hosted agent tab header markup with `PageHeader` inside the centered content column.
- Preserved tab-specific icons, meta badges, and actions through `PageHeader` slots.
- Captured connected Sessions/Skills/Settings and hosted Sessions/Model Provider/Settings; hosted agent nav does not include a Skills tab.

## Verification

- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`
- `bun run check`
- Browser screenshots reviewed under `/home/kingsley/clawdi-ui-screenshots/ui-round2/`:
  - empty-state contact sheet
  - connectors flat layout at 1440 and 390
  - connectors loading state
  - agent tab headers and console Sessions/Skills comparisons

🤖 Generated with paseo codex.
