### PR TITLE
Adopt one collection framework across the dashboard

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -123,6 +123,52 @@ Weights: use 500/600 for hierarchy; 400 body; avoid 700+.
 `active:scale-[0.98]` + visible `focus-visible` ring. Respect
 `prefers-reduced-motion` (tw-animate-css handles this for its presets).
 
+## Collections
+
+Collection surfaces use one framework. Page-specific content can vary; the
+toolbar chassis, group headers, error surface, card tier, and grid rhythm do
+not.
+
+### Item anatomies
+
+- **Entity item** (`ENTITY_CARD_BASE`, `rounded-lg p-4`): `[leading icon] [title
+  + titleAdornment] / [meta line]` with optional trailing status or actions.
+  Use for operational objects: agents, channels, providers, connectors,
+  session rows, linked agents, and devices.
+- **Hero item** (`HERO_CARD_BASE`, `rounded-xl p-5`): `[top icon tile] / [title
+  + badges] / [description] / [stats footer meta row]`. Use for top-level
+  resource grids: projects, vaults, skills, and memories. The footer is always
+  an `EntityMeta`-style middot row; keep page-specific facts, not page-specific
+  footer layouts.
+
+### Grid rhythm
+
+- Entity grids use `ENTITY_GRID_CLASS`: `grid gap-2 sm:grid-cols-2
+  xl:grid-cols-3`.
+- Hero grids use `HERO_GRID_CLASS`: `grid gap-4 sm:grid-cols-2
+  xl:grid-cols-3`.
+- Masonry content can keep masonry columns, but each card still follows the
+  hero tier padding, radius, hover, and footer conventions.
+
+### Toolbar
+
+Use `ListToolbar` for collection controls. Slot order is always:
+
+1. `search` — `SearchInput`.
+2. `filters` — `FilterChip` rows, selects, or `ToggleGroup`s.
+3. `actions` — view switchers, selects, and command buttons.
+
+The toolbar is a single flex row that wraps on small screens. Do not place list
+search, filters, or view switches in `PageHeader.actions`.
+
+### Group Headers And Errors
+
+- `SectionLabel` is the only group header inside lists. Use its `leading` slot
+  for identity icons and `count` for totals.
+- `ApiErrorPanel` is the only API error surface on collection list/detail
+  pages. Wire `onRetry` to the failing query's `refetch` when a query produced
+  the error.
+
 ### Identity palette
 
 `--identity-1..8` (bg+fg pairs, light and dark): vivid flat hues assigned by

--- a/apps/web/src/components/connectors/connector-card.tsx
+++ b/apps/web/src/components/connectors/connector-card.tsx
@@ -2,7 +2,7 @@
 
 import { Check } from "lucide-react";
 import { ConnectorIcon } from "@/components/connectors/connector-icon";
-import { ENTITY_CARD_BASE, EntityRow } from "@/components/entity-card";
+import { ENTITY_CARD_BASE, ENTITY_GRID_CLASS, EntityRow } from "@/components/entity-card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { connectorDetailHref } from "@/lib/project-resource-model";
 import { cn } from "@/lib/utils";
@@ -48,5 +48,4 @@ export function ConnectorCardSkeleton() {
 	);
 }
 
-/** Two-column rows on wide screens — dense but readable for a directory. */
-export const CONNECTOR_GRID_CLASS = "grid grid-cols-1 gap-2 lg:grid-cols-2";
+export const CONNECTOR_GRID_CLASS = ENTITY_GRID_CLASS;

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -4,16 +4,23 @@ import type { components } from "@clawdi/shared/api";
 import { Link } from "@tanstack/react-router";
 import { AlertCircle, ArrowUpRight } from "lucide-react";
 import { type ReactNode, useState } from "react";
+import { AgentIcon } from "@/components/dashboard/agent-icon";
 import {
-	AgentLabel,
 	AgentSourceBadge,
 	agentDisplayName,
+	agentIdentity,
 	compareAgentEnvironments,
+	displayMachineName,
 	LegacyAgentBadge,
 } from "@/components/dashboard/agent-label";
 import { DaemonStatusBadge } from "@/components/dashboard/daemon-status";
 import { EmptyState } from "@/components/empty-state";
-import { ENTITY_CARD_BASE } from "@/components/entity-card";
+import {
+	ENTITY_CARD_BASE,
+	ENTITY_GRID_CLASS,
+	ENTITY_STRETCHED_LINK_CLASS,
+	EntityHeader,
+} from "@/components/entity-card";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { agentSectionHref } from "@/lib/agent-routes";
@@ -126,14 +133,14 @@ export function AgentsCard({
 		<section className="space-y-3">
 			<div className="space-y-3">
 				{isLoading ? (
-					<div className="grid gap-2 sm:grid-cols-2">
+					<div className={ENTITY_GRID_CLASS}>
 						{Array.from({ length: 4 }).map((_, i) => (
 							<TileSkeleton key={i} />
 						))}
 					</div>
 				) : agents.length || hostedStatus?.isLoading ? (
 					<>
-						<div className="grid gap-2 sm:grid-cols-2">
+						<div className={ENTITY_GRID_CLASS}>
 							{visible.map((tile) => (
 								<AgentTileView key={`${tile.source}:${tile.id}`} tile={tile} />
 							))}
@@ -186,7 +193,7 @@ export function HostedUnavailableBanner() {
  * supply their own section headers. */
 export function AgentTileGrid({ tiles }: { tiles: AgentTile[] }) {
 	return (
-		<div className="grid gap-2 sm:grid-cols-2">
+		<div className={ENTITY_GRID_CLASS}>
 			{tiles.map((tile) => (
 				<AgentTileView key={`${tile.source}:${tile.id}`} tile={tile} />
 			))}
@@ -209,6 +216,11 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 	) : legacyHosted ? (
 		<LegacyAgentBadge />
 	) : null;
+	const identity = agentIdentity({
+		name: tile.name,
+		machine_name: tile.name,
+		agent_type: tile.agentType,
+	});
 	// `tile.env` adds a sync badge that renders a `<button>`
 	// (clicks open a status dialog). It MUST live in the meta
 	// line under the agent name — same row as `statusLabel` so
@@ -227,6 +239,7 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 	// "sync state under the agent name" — pre-fix-attempt the
 	// badge was floated to the trailing edge.
 	const meta: ReactNode[] = [];
+	if (identity.secondaryLabel) meta.push(identity.secondaryLabel);
 	if (tile.contextLabel) meta.push(tile.contextLabel);
 	if (tile.statusLabel) meta.push(tile.statusLabel);
 	if (tile.env) {
@@ -256,12 +269,9 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 				"flex h-full items-center gap-3 transition-colors group-hover:bg-muted/50",
 			)}
 		>
-			<AgentLabel
-				name={tile.name}
-				machineName={tile.name}
-				type={tile.agentType}
-				avatarUrl={tile.avatarUrl}
-				size="lg"
+			<EntityHeader
+				icon={<AgentIcon agent={tile.agentType} size="lg" avatarUrl={tile.avatarUrl} />}
+				title={<span title={tile.name}>{displayMachineName(tile.name)}</span>}
 				meta={meta}
 				titleAdornment={sourcePill}
 				className="min-w-0 flex-1"
@@ -269,9 +279,6 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 			{trailing}
 		</div>
 	);
-
-	const linkClassName =
-		"absolute inset-0 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
 	return (
 		// `z-0` is load-bearing: without an explicit z-index on this
@@ -290,11 +297,16 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 		<div className="group relative z-0 h-full">
 			{card}
 			{tile.external ? (
-				<a href={tile.href} target="_blank" rel="noopener noreferrer" className={linkClassName}>
+				<a
+					href={tile.href}
+					target="_blank"
+					rel="noopener noreferrer"
+					className={ENTITY_STRETCHED_LINK_CLASS}
+				>
 					<span className="sr-only">{tile.name}</span>
 				</a>
 			) : (
-				<Link to={tile.href} className={linkClassName}>
+				<Link to={tile.href} className={ENTITY_STRETCHED_LINK_CLASS}>
 					<span className="sr-only">{tile.name}</span>
 				</Link>
 			)}

--- a/apps/web/src/components/entity-card.tsx
+++ b/apps/web/src/components/entity-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Link } from "@tanstack/react-router";
+import { Link, type LinkProps } from "@tanstack/react-router";
 import { Check, ChevronRight } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
@@ -26,6 +26,9 @@ export const ENTITY_CARD_BASE = "min-w-0 rounded-lg border bg-card p-4";
 /** Top-level resource card tier: projects, vaults, skills, memories. */
 export const HERO_CARD_BASE = "min-w-0 rounded-xl border bg-card p-5";
 
+/** Responsive grid every top-level hero-card collection shares. */
+export const HERO_GRID_CLASS = "grid gap-4 sm:grid-cols-2 xl:grid-cols-3";
+
 /** Responsive card grid every entity-card collection shares (providers,
  * channels, shared bots). */
 export const ENTITY_GRID_CLASS = "grid gap-2 sm:grid-cols-2 xl:grid-cols-3";
@@ -34,6 +37,9 @@ export const ENTITY_GRID_CLASS = "grid gap-2 sm:grid-cols-2 xl:grid-cols-3";
  * controls independently clickable — pairs with a `relative z-0` wrapper. */
 export const ENTITY_STRETCHED_LINK_CLASS =
 	"absolute inset-0 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+
+export const HERO_STRETCHED_LINK_CLASS =
+	"absolute inset-0 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
 
 /** Focus ring for whole-card buttons matching the stretched-link treatment. */
 export const ENTITY_CARD_BUTTON_FOCUS_CLASS =
@@ -108,6 +114,97 @@ export function EntityHeader({
 				</div>
 				{meta !== undefined ? <EntityMeta items={meta} /> : null}
 			</div>
+		</div>
+	);
+}
+
+type HeroCardLinkOptions = Pick<LinkProps, "to" | "params" | "search" | "hash">;
+
+/**
+ * Top-level resource card — `[icon tile] / [title + badges] / [description] /
+ * [middot meta footer]`. Projects, vaults, skills, and memories share this
+ * tier so their grids read as one collection language.
+ */
+export function HeroCard({
+	icon,
+	title,
+	badges,
+	description,
+	footer,
+	actions,
+	link,
+	ariaLabel,
+	selected,
+	interactive = true,
+	className,
+	titleClassName,
+	descriptionClassName,
+	footerClassName,
+	children,
+}: {
+	icon?: ReactNode;
+	title: ReactNode;
+	badges?: ReactNode;
+	description?: ReactNode;
+	footer?: ReactNode | ReactNode[];
+	actions?: ReactNode;
+	link?: HeroCardLinkOptions;
+	ariaLabel?: string;
+	selected?: boolean;
+	interactive?: boolean;
+	className?: string;
+	titleClassName?: string;
+	descriptionClassName?: string;
+	footerClassName?: string;
+	children?: ReactNode;
+}) {
+	return (
+		<div
+			className={cn(
+				HERO_CARD_BASE,
+				"group relative z-0 flex min-h-36 flex-col gap-3 transition-all duration-150",
+				selected
+					? "border-foreground/40 bg-accent/50"
+					: interactive && "hover:-translate-y-px hover:border-foreground/20",
+				className,
+			)}
+		>
+			{icon || actions ? (
+				<div className="flex items-start justify-between gap-2">
+					{icon ? <div className="shrink-0">{icon}</div> : <span aria-hidden />}
+					{actions ? <div className="relative z-10 shrink-0">{actions}</div> : null}
+				</div>
+			) : null}
+			<div className="min-w-0">
+				<div className="flex min-w-0 items-center gap-1.5">
+					<h3 className={cn("min-w-0 flex-1 truncate text-sm font-medium", titleClassName)}>
+						{title}
+					</h3>
+					{badges ? <div className="flex shrink-0 items-center gap-1.5">{badges}</div> : null}
+				</div>
+				{description ? (
+					<p
+						className={cn(
+							"mt-1 line-clamp-2 text-xs leading-relaxed text-muted-foreground",
+							descriptionClassName,
+						)}
+					>
+						{description}
+					</p>
+				) : null}
+			</div>
+			{children}
+			{footer !== undefined ? (
+				<EntityMeta
+					items={footer}
+					className={cn("mt-auto text-xs text-muted-foreground tabular-nums", footerClassName)}
+				/>
+			) : null}
+			{link ? (
+				<Link {...link} className={HERO_STRETCHED_LINK_CLASS}>
+					<span className="sr-only">{ariaLabel ?? "Open"}</span>
+				</Link>
+			) : null}
 		</div>
 	);
 }

--- a/apps/web/src/components/filter-chip.tsx
+++ b/apps/web/src/components/filter-chip.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { ENTITY_CARD_BUTTON_FOCUS_CLASS } from "@/components/entity-card";
+import { cn } from "@/lib/utils";
+
+export function filterChipClass(active: boolean, className?: string) {
+	return cn(
+		"inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors",
+		ENTITY_CARD_BUTTON_FOCUS_CLASS,
+		active
+			? "border-primary bg-primary/10 text-primary"
+			: "border-transparent text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+		className,
+	);
+}
+
+export function FilterChip({
+	active,
+	onClick,
+	children,
+	className,
+}: {
+	active: boolean;
+	onClick: () => void;
+	children: ReactNode;
+	className?: string;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			aria-pressed={active}
+			className={filterChipClass(active, className)}
+		>
+			{children}
+		</button>
+	);
+}

--- a/apps/web/src/components/list-toolbar.tsx
+++ b/apps/web/src/components/list-toolbar.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export function ListToolbar({
+	search,
+	filters,
+	actions,
+	className,
+}: {
+	search?: ReactNode;
+	filters?: ReactNode;
+	actions?: ReactNode;
+	className?: string;
+}) {
+	return (
+		<div className={cn("flex flex-wrap items-center gap-2", className)}>
+			{search ? (
+				<div className="min-w-0 flex-1 basis-full sm:max-w-sm sm:basis-64">{search}</div>
+			) : null}
+			{filters ? (
+				<div className="flex min-w-0 flex-wrap items-center gap-1.5">{filters}</div>
+			) : null}
+			{actions ? (
+				<div className="ml-auto flex flex-wrap items-center justify-end gap-2">{actions}</div>
+			) : null}
+		</div>
+	);
+}

--- a/apps/web/src/components/section-label.tsx
+++ b/apps/web/src/components/section-label.tsx
@@ -4,14 +4,17 @@ import { cn } from "@/lib/utils";
 export function SectionLabel({
 	children,
 	count,
+	leading,
 	className,
 }: {
 	children: ReactNode;
 	count?: ReactNode;
+	leading?: ReactNode;
 	className?: string;
 }) {
 	return (
 		<div className={cn("flex items-center gap-2 px-0.5", className)}>
+			{leading ? <span className="shrink-0 text-sm leading-none">{leading}</span> : null}
 			<span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
 				{children}
 			</span>

--- a/apps/web/src/components/sessions/mobile-session-list.tsx
+++ b/apps/web/src/components/sessions/mobile-session-list.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { Link } from "@tanstack/react-router";
-import { MessageSquare, Zap } from "lucide-react";
-import { Stat } from "@/components/meta/stat";
-import { SessionAgentLabel } from "@/components/sessions/session-agent-label";
+import { AgentIcon } from "@/components/dashboard/agent-icon";
+import { agentIdentity } from "@/components/dashboard/agent-label";
+import { EntityHeader } from "@/components/entity-card";
+import { sessionAgentIdentityInput } from "@/components/sessions/session-agent-label";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { SessionListItem } from "@/lib/api-schemas";
 import { formatNumber, formatSessionSummary, relativeTime } from "@/lib/utils";
@@ -41,26 +42,23 @@ export function MobileSessionList({
 				const title = formatSessionSummary(session.summary) || session.local_session_id.slice(0, 8);
 				const projectFolder = session.project_path?.split("/").pop();
 				const totalTokens = session.input_tokens + session.output_tokens;
+				const agent = agentIdentity(sessionAgentIdentityInput(session)).primaryLabel;
 				return (
 					<article key={session.id} className="px-4 py-3">
 						<Link to="/sessions/$id" params={{ id: session.id }} className="block min-w-0">
-							<div className="min-w-0">
-								<h3 className="truncate text-sm font-medium">{title}</h3>
-								{projectFolder ? (
-									<p className="mt-0.5 truncate text-xs text-muted-foreground">{projectFolder}</p>
-								) : null}
-							</div>
-							<div className="mt-3 flex items-center justify-between gap-3">
-								<SessionAgentLabel session={session} size="sm" />
-								<span className="shrink-0 text-xs text-muted-foreground">
-									{relativeTime(session.last_activity_at)}
-								</span>
-							</div>
-							<div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-								<Stat icon={MessageSquare} label={`${session.message_count} messages`} />
-								<Stat icon={Zap} label={`${formatNumber(totalTokens)} tokens`} />
-								<span>Started {relativeTime(session.started_at)}</span>
-							</div>
+							<EntityHeader
+								align="start"
+								icon={<AgentIcon agent={session.agent_type} size="lg" />}
+								title={title}
+								meta={[
+									agent,
+									projectFolder,
+									`${session.message_count} messages`,
+									`${formatNumber(totalTokens)} tokens`,
+									relativeTime(session.last_activity_at),
+									`started ${relativeTime(session.started_at)}`,
+								]}
+							/>
 						</Link>
 					</article>
 				);

--- a/apps/web/src/components/sessions/session-feed.tsx
+++ b/apps/web/src/components/sessions/session-feed.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { Link, type LinkProps } from "@tanstack/react-router";
-import { MessageSquare, Zap } from "lucide-react";
+import { MessageSquare } from "lucide-react";
+import { AgentIcon } from "@/components/dashboard/agent-icon";
+import { agentIdentity } from "@/components/dashboard/agent-label";
 import { EmptyState, type EmptyStateVariant } from "@/components/empty-state";
-import { Stat } from "@/components/meta/stat";
-import { SessionAgentLabel } from "@/components/sessions/session-agent-label";
+import { ENTITY_CARD_BASE, EntityHeader } from "@/components/entity-card";
+import { SectionLabel } from "@/components/section-label";
+import { sessionAgentIdentityInput } from "@/components/sessions/session-agent-label";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { SessionListItem } from "@/lib/api-schemas";
 import {
@@ -50,9 +53,9 @@ export function SessionFeed({
 }) {
 	if (isLoading) {
 		return (
-			<div className="space-y-3">
+			<div className="flex flex-col gap-2">
 				{Array.from({ length: 5 }).map((_, index) => (
-					<div key={index} className="rounded-lg border bg-card p-4">
+					<div key={index} className={ENTITY_CARD_BASE}>
 						<Skeleton className="h-4 w-4/5" />
 						<Skeleton className="mt-3 h-3 w-1/2" />
 					</div>
@@ -67,7 +70,7 @@ export function SessionFeed({
 
 	if (!grouped) {
 		return (
-			<div className="space-y-3">
+			<div className="flex flex-col gap-2">
 				{sessions.map((session) => (
 					<SessionFeedCard
 						key={session.id}
@@ -92,13 +95,11 @@ export function SessionFeed({
 	}
 
 	return (
-		<div className="space-y-5">
+		<div className="flex flex-col gap-5">
 			{groups.map((group) => (
-				<section key={group.key} className="space-y-2">
-					<h3 className="text-2xs font-medium uppercase tracking-wider text-muted-foreground">
-						{group.label}
-					</h3>
-					<div className="space-y-2">
+				<section key={group.key} className="flex flex-col gap-2">
+					<SectionLabel>{group.label}</SectionLabel>
+					<div className="flex flex-col gap-2">
 						{group.items.map((session) => (
 							<SessionFeedCard
 								key={session.id}
@@ -129,48 +130,44 @@ function SessionFeedCard({
 	const title = formatSessionSummary(session.summary) || session.local_session_id.slice(0, 8);
 	const projectFolder = session.project_path?.split("/").pop();
 	const totalTokens = session.input_tokens + session.output_tokens;
+	const agent = agentIdentity(sessionAgentIdentityInput(session)).primaryLabel;
 	// Cron jobs and bracketed heartbeats are routine noise — keep them in the
 	// timeline but visually quieter than human work (taste audit round 2).
 	const isAutomated = quietAutomated && /^(Cron:|\[)/.test(title);
 	return (
-		<article
-			className={cn(
-				"group relative z-0 rounded-lg border bg-card transition-all duration-150 hover:-translate-y-px hover:border-foreground/20",
-				isAutomated ? "border-transparent bg-muted/30 p-3" : "p-4",
-			)}
-		>
+		<article className="group relative z-0">
+			<div
+				className={cn(
+					ENTITY_CARD_BASE,
+					"transition-colors group-hover:bg-muted/50",
+					isAutomated && "bg-muted/30",
+				)}
+			>
+				<EntityHeader
+					align="start"
+					icon={<AgentIcon agent={session.agent_type} size="lg" />}
+					title={title}
+					meta={[
+						showAgent ? agent : null,
+						projectFolder ? (
+							<span key="folder" className="font-mono" title={session.project_path ?? undefined}>
+								{projectFolder}
+							</span>
+						) : null,
+						`${session.message_count} ${session.message_count === 1 ? "message" : "messages"}`,
+						`${formatNumber(totalTokens)} tokens`,
+						<span key="time" title={formatAbsoluteTooltip(session.last_activity_at)}>
+							{relativeTime(session.last_activity_at)}
+						</span>,
+					]}
+				/>
+			</div>
 			<Link
 				{...link}
-				className="absolute inset-0 z-10 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				className="absolute inset-0 z-10 rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
 			>
 				<span className="sr-only">Open session {session.local_session_id}</span>
 			</Link>
-			<div className="flex items-start justify-between gap-3">
-				<h4
-					className={cn(
-						"min-w-0 truncate text-sm",
-						isAutomated ? "font-normal text-muted-foreground" : "font-medium",
-					)}
-				>
-					{title}
-				</h4>
-				<span
-					className="shrink-0 text-xs text-muted-foreground"
-					title={formatAbsoluteTooltip(session.last_activity_at)}
-				>
-					{relativeTime(session.last_activity_at)}
-				</span>
-			</div>
-			<div className="mt-2.5 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-muted-foreground">
-				{showAgent ? <SessionAgentLabel session={session} size="sm" /> : null}
-				{projectFolder ? (
-					<span className="truncate font-mono" title={session.project_path ?? undefined}>
-						{projectFolder}
-					</span>
-				) : null}
-				<Stat icon={MessageSquare} label={`${session.message_count}`} />
-				<Stat icon={Zap} label={formatNumber(totalTokens)} />
-			</div>
 		</article>
 	);
 }

--- a/apps/web/src/components/skills/skill-card.tsx
+++ b/apps/web/src/components/skills/skill-card.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Link, type LinkProps } from "@tanstack/react-router";
+import type { LinkProps } from "@tanstack/react-router";
 import { Sparkles, Trash2 } from "lucide-react";
 import { EmptyState, type EmptyStateVariant } from "@/components/empty-state";
-import { HERO_CARD_BASE } from "@/components/entity-card";
+import { HERO_GRID_CLASS, HeroCard } from "@/components/entity-card";
 import { IconChip } from "@/components/icon-chip";
 import { SendSkillDialog } from "@/components/skills/send-skill-dialog";
 import { Badge } from "@/components/ui/badge";
@@ -13,7 +13,7 @@ import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
-import { cn, relativeTime } from "@/lib/utils";
+import { relativeTime } from "@/lib/utils";
 
 type SkillSummary = components["schemas"]["SkillSummaryResponse"];
 type SkillLinkOptions = Pick<LinkProps, "to" | "params" | "search" | "hash">;
@@ -59,20 +59,48 @@ export function SkillCard({
 		search: skill.project_id ? { project: skill.project_id } : undefined,
 	};
 	return (
-		<div
-			className={cn(
-				HERO_CARD_BASE,
-				"group relative z-0 flex min-h-28 flex-col gap-2 transition-all duration-150",
-				selectMode && selected
-					? "border-foreground/40 bg-accent/50"
-					: "hover:-translate-y-px hover:border-foreground/20",
-			)}
-		>
-			<div className="flex items-start justify-between gap-2">
+		<HeroCard
+			className="min-h-28 gap-2"
+			selected={selectMode && selected}
+			interactive={!selectMode}
+			icon={
 				<IconChip size="sm" tint={id.colorClasses} className="rounded-lg text-base">
 					{id.emoji}
 				</IconChip>
-				{selectMode ? (
+			}
+			title={skill.name}
+			badges={
+				<>
+					<Badge variant="outline" className="shrink-0">
+						v{skill.version}
+					</Badge>
+					{readOnly ? (
+						<Badge variant="secondary" className="shrink-0">
+							Shared
+						</Badge>
+					) : null}
+				</>
+			}
+			description={skill.description}
+			footer={[
+				sourceLabel ? (
+					<span
+						key="source-label"
+						className="inline-flex max-w-44 items-center gap-1 rounded-md bg-muted px-1.5 py-0.5"
+					>
+						<span aria-hidden className="select-none">
+							{sourceLabel.emoji}
+						</span>
+						<span className="truncate">{sourceLabel.name}</span>
+					</span>
+				) : null,
+				<span key="source" className="font-mono" translate="no">
+					{skill.source_repo ?? skill.source}
+				</span>,
+				skill.updated_at ? relativeTime(skill.updated_at) : null,
+			]}
+			actions={
+				selectMode ? (
 					<Checkbox
 						checked={selected}
 						tabIndex={-1}
@@ -80,7 +108,7 @@ export function SkillCard({
 						className="pointer-events-none shrink-0"
 					/>
 				) : (
-					<span className="relative z-10 flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100">
+					<div className="flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100">
 						{skill.project_id ? <SendSkillDialog skills={[skill]} /> : null}
 						{canUninstall ? (
 							<ConfirmAction
@@ -103,43 +131,12 @@ export function SkillCard({
 								</Button>
 							</ConfirmAction>
 						) : null}
-					</span>
-				)}
-			</div>
-			<div className="min-w-0">
-				<div className="flex min-w-0 items-center gap-1.5">
-					<h3 className="truncate text-sm font-semibold tracking-tight">{skill.name}</h3>
-					<Badge variant="outline" className="shrink-0">
-						v{skill.version}
-					</Badge>
-					{readOnly ? (
-						<Badge variant="secondary" className="shrink-0">
-							Shared
-						</Badge>
-					) : null}
-				</div>
-				{skill.description ? (
-					<p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
-						{skill.description}
-					</p>
-				) : null}
-			</div>
-			<div className="mt-auto flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground">
-				{sourceLabel ? (
-					<span className="inline-flex max-w-44 items-center gap-1 rounded-md bg-muted px-1.5 py-0.5">
-						<span aria-hidden className="select-none">
-							{sourceLabel.emoji}
-						</span>
-						<span className="truncate">{sourceLabel.name}</span>
-					</span>
-				) : null}
-				<span className="truncate font-mono" translate="no">
-					{skill.source_repo ?? skill.source}
-				</span>
-				{skill.updated_at ? (
-					<span className="shrink-0">{relativeTime(skill.updated_at)}</span>
-				) : null}
-			</div>
+					</div>
+				)
+			}
+			link={selectMode ? undefined : detailLink}
+			ariaLabel={`Open ${skill.name}`}
+		>
 			{selectMode ? (
 				<button
 					type="button"
@@ -151,15 +148,8 @@ export function SkillCard({
 						{selected ? "Deselect" : "Select"} {skill.name}
 					</span>
 				</button>
-			) : (
-				<Link
-					{...detailLink}
-					className="absolute inset-0 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-				>
-					<span className="sr-only">Open {skill.name}</span>
-				</Link>
-			)}
-		</div>
+			) : null}
+		</HeroCard>
 	);
 }
 
@@ -195,7 +185,7 @@ export function SkillCardGrid({
 }) {
 	if (isLoading) {
 		return (
-			<div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+			<div className={HERO_GRID_CLASS}>
 				{Array.from({ length: 6 }).map((_, i) => (
 					<Skeleton key={i} className="h-28 w-full rounded-xl" />
 				))}
@@ -206,7 +196,7 @@ export function SkillCardGrid({
 		return <EmptyState variant={emptyVariant} icon={Sparkles} description={emptyMessage} />;
 	}
 	return (
-		<div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+		<div className={HERO_GRID_CLASS}>
 			{skills.map((skill) => (
 				<SkillCard
 					key={skillSelectionKey(skill)}

--- a/apps/web/src/components/ui/data-table-toolbar.tsx
+++ b/apps/web/src/components/ui/data-table-toolbar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import { ListToolbar } from "@/components/list-toolbar";
 import { SearchInput } from "@/components/ui/search-input";
-import { cn } from "@/lib/utils";
 
 interface Props {
 	value: string;
@@ -19,14 +19,10 @@ export function DataTableToolbar({
 	children,
 }: Props) {
 	return (
-		<div className={cn("flex flex-wrap items-center gap-2", className)}>
-			<SearchInput
-				value={value}
-				onChange={onChange}
-				placeholder={placeholder}
-				className="w-full flex-1 basis-full sm:max-w-sm sm:basis-auto"
-			/>
-			{children}
-		</div>
+		<ListToolbar
+			className={className}
+			search={<SearchInput value={value} onChange={onChange} placeholder={placeholder} />}
+			filters={children}
+		/>
 	);
 }

--- a/apps/web/src/hosted/hosted-agents-section.tsx
+++ b/apps/web/src/hosted/hosted-agents-section.tsx
@@ -9,6 +9,7 @@ import {
 	HostedUnavailableBanner,
 } from "@/components/dashboard/agents-card";
 import { OnboardingCard } from "@/components/dashboard/onboarding-card";
+import { SectionLabel } from "@/components/section-label";
 import { useLegacyEnvIds } from "@/hosted/agents/ownership-sensor";
 import { legacyConnectedAgentTiles } from "@/hosted/legacy-agent-tiles";
 import { useHostedAgentTiles } from "@/hosted/use-hosted-agent-tiles";
@@ -282,22 +283,19 @@ export function HostedAgentsByCompute({
 		<div data-hosted="true" className="space-y-6">
 			{groups.map((group) => (
 				<section key={group.key} className="space-y-2">
-					<div className="flex items-center gap-2 px-0.5">
-						<span className="text-sm font-medium">{group.name}</span>
-						<AgentSourceBadge source="hosted" compact />
-						<span className="text-xs text-muted-foreground">
-							{`${group.tiles.length} runtime${group.tiles.length === 1 ? "" : "s"}`}
-						</span>
-					</div>
+					<SectionLabel
+						leading={<AgentSourceBadge source="hosted" compact />}
+						count={`${group.tiles.length} runtime${group.tiles.length === 1 ? "" : "s"}`}
+					>
+						{group.name}
+					</SectionLabel>
 					<AgentTileGrid tiles={group.tiles} />
 				</section>
 			))}
 
 			{connectedTiles.length > 0 ? (
 				<section className="space-y-2">
-					<div className="flex items-center gap-2 px-0.5">
-						<span className="text-sm font-medium">Other agents</span>
-					</div>
+					<SectionLabel>Other agents</SectionLabel>
 					<AgentTileGrid tiles={connectedTiles} />
 				</section>
 			) : null}

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
@@ -8,6 +8,7 @@ import { ApiErrorPanel } from "@/components/api-error-panel";
 import { EmptyState } from "@/components/empty-state";
 import { ENTITY_CARD_BASE, ENTITY_GRID_CLASS, EntityHeader } from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
+import { ListToolbar } from "@/components/list-toolbar";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SectionLabel } from "@/components/section-label";
@@ -45,11 +46,12 @@ export function AiProvidersPage() {
 
 	return (
 		<div data-hosted="true" data-v2="true" className={PAGE_CLASS}>
-			<PageHeader
-				title="Model Providers"
-				description={DESCRIPTION}
+			<PageHeader title="Model Providers" description={DESCRIPTION} />
+
+			<ListToolbar
 				actions={
 					<Button
+						size="sm"
 						onClick={() => {
 							setEditing(null);
 							setAddOpen(true);
@@ -61,7 +63,10 @@ export function AiProvidersPage() {
 				}
 			/>
 
-			<ManagedProviderCard />
+			<div className="flex flex-col gap-2">
+				<SectionLabel>Managed default</SectionLabel>
+				<ManagedProviderCard />
+			</div>
 
 			<div className="flex flex-col gap-2">
 				<SectionLabel>Your providers</SectionLabel>

--- a/apps/web/src/hosted/v2/channels/channels-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channels-page.tsx
@@ -2,17 +2,18 @@
 
 import { Link } from "@tanstack/react-router";
 import { MessagesSquare, Plus } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import { useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { EmptyState } from "@/components/empty-state";
 import {
 	ENTITY_CARD_BASE,
-	ENTITY_CARD_BUTTON_FOCUS_CLASS,
 	ENTITY_GRID_CLASS,
 	ENTITY_STRETCHED_LINK_CLASS,
 	EntityHeader,
 } from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
+import { FilterChip } from "@/components/filter-chip";
+import { ListToolbar } from "@/components/list-toolbar";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SectionLabel } from "@/components/section-label";
@@ -40,16 +41,7 @@ export function ChannelsPage() {
 
 	return (
 		<div data-hosted="true" data-v2="true" className={PAGE_CLASS}>
-			<PageHeader
-				title="Channels"
-				description={DESCRIPTION}
-				actions={
-					<Button onClick={() => setConnectOpen(true)}>
-						<Plus />
-						Connect a bot
-					</Button>
-				}
-			/>
+			<PageHeader title="Channels" description={DESCRIPTION} />
 
 			<Tabs defaultValue="mine">
 				<TabsList>
@@ -132,19 +124,28 @@ function YourChannels({ onConnect }: { onConnect: () => void }) {
 					title="Couldn't load channel health"
 				/>
 			) : null}
-			{/* Provider filter */}
-			<div className="flex flex-wrap gap-1.5">
-				<FilterChip active={filter === "all"} onClick={() => setFilter("all")}>
-					All
-					<span className="ml-1 text-muted-foreground">{all.length}</span>
-				</FilterChip>
-				{CHANNEL_PROVIDERS.filter((p) => counts.has(p)).map((p) => (
-					<FilterChip key={p} active={filter === p} onClick={() => setFilter(p)}>
-						{providerMeta(p).label}
-						<span className="ml-1 text-muted-foreground">{counts.get(p)}</span>
-					</FilterChip>
-				))}
-			</div>
+			<ListToolbar
+				filters={
+					<>
+						<FilterChip active={filter === "all"} onClick={() => setFilter("all")}>
+							All
+							<span className="text-muted-foreground tabular-nums">{all.length}</span>
+						</FilterChip>
+						{CHANNEL_PROVIDERS.filter((p) => counts.has(p)).map((p) => (
+							<FilterChip key={p} active={filter === p} onClick={() => setFilter(p)}>
+								{providerMeta(p).label}
+								<span className="text-muted-foreground tabular-nums">{counts.get(p)}</span>
+							</FilterChip>
+						))}
+					</>
+				}
+				actions={
+					<Button size="sm" onClick={onConnect}>
+						<Plus />
+						Connect a bot
+					</Button>
+				}
+			/>
 
 			<div className="flex flex-col gap-5">
 				{groups.map((group) => (
@@ -165,33 +166,6 @@ function YourChannels({ onConnect }: { onConnect: () => void }) {
 				))}
 			</div>
 		</div>
-	);
-}
-
-function FilterChip({
-	active,
-	onClick,
-	children,
-}: {
-	active: boolean;
-	onClick: () => void;
-	children: ReactNode;
-}) {
-	return (
-		<button
-			type="button"
-			onClick={onClick}
-			aria-pressed={active}
-			className={cn(
-				"rounded-full border px-3 py-1 text-xs font-medium transition-colors",
-				ENTITY_CARD_BUTTON_FOCUS_CLASS,
-				active
-					? "border-primary bg-primary/10 text-primary"
-					: "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
-			)}
-		>
-			{children}
-		</button>
 	);
 }
 

--- a/apps/web/src/lib/api-errors.ts
+++ b/apps/web/src/lib/api-errors.ts
@@ -79,6 +79,7 @@ export function isApiNetworkError(error: unknown): boolean {
  * makes snake_case error codes readable while passing real sentences through.
  */
 export function normalizeApiError(error: unknown): string {
+	if (typeof error === "string") return error;
 	if (error instanceof ApiNetworkError) {
 		return error.kind === "timeout"
 			? "This is taking longer than usual. Check your connection and try again."

--- a/apps/web/src/lib/connectors-data.ts
+++ b/apps/web/src/lib/connectors-data.ts
@@ -222,8 +222,12 @@ export function useConnectedAppCards() {
 	const data = useMemo(() => lookup.flatMap((q) => (q.data ? [q.data] : [])), [lookup]);
 	const isLoading = connectionsQ.isLoading || lookup.some((q) => q.isLoading);
 	const error = connectionsQ.error ?? lookup.find((q) => q.error)?.error ?? null;
+	const refetch = () => {
+		void connectionsQ.refetch();
+		for (const q of lookup) void q.refetch();
+	};
 
-	return { activeConnections, data, isLoading, error };
+	return { activeConnections, data, isLoading, error, refetch };
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
+++ b/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
@@ -4,6 +4,7 @@ import { AlertCircle, Check, Link2Off, Plug, Wrench } from "lucide-react";
 import { parseAsString, useQueryStates } from "nuqs";
 import { Suspense, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { getConnectorAuthFlow } from "@/components/connectors/auth-flow.logic";
 import { ConnectorIcon } from "@/components/connectors/connector-icon";
@@ -312,21 +313,23 @@ function ConnectorDetail({ name }: { name: string }) {
 						// the "No connected accounts yet" empty state — the user
 						// would think they have nothing connected when really we
 						// just couldn't load the list.
-						<Alert variant="destructive">
-							<AlertCircle />
-							<AlertTitle>Couldn't load connections</AlertTitle>
-							<AlertDescription>{errorMessage(connectionsQ.error)}</AlertDescription>
-						</Alert>
+						<ApiErrorPanel
+							error={connectionsQ.error}
+							onRetry={() => {
+								void connectionsQ.refetch();
+							}}
+							title="Couldn't load connections"
+						/>
 					) : usesNoAuth ? (
 						<EmptyState variant="inset" description="No account connection is required." />
 					) : hasUnsupportedAuthType ? (
-						<Alert variant="destructive">
-							<AlertCircle />
-							<AlertTitle>Connector metadata error</AlertTitle>
-							<AlertDescription>
-								This connector did not return a supported auth type. Refresh the page and try again.
-							</AlertDescription>
-						</Alert>
+						<ApiErrorPanel
+							error="This connector did not return a supported auth type. Refresh the page and try again."
+							onRetry={() => {
+								void appQ.refetch();
+							}}
+							title="Connector metadata error"
+						/>
 					) : activeConnections.length === 0 ? (
 						isSetupBlocked ? (
 							<Alert>
@@ -398,6 +401,9 @@ function ConnectorDetail({ name }: { name: string }) {
 				tools={tools ?? []}
 				isLoading={isToolsLoading}
 				error={toolsQ.error}
+				onRetry={() => {
+					void toolsQ.refetch();
+				}}
 				requiresConnection={!usesNoAuth}
 			/>
 
@@ -454,11 +460,13 @@ function ConnectorToolsList({
 	tools,
 	isLoading,
 	error,
+	onRetry,
 	requiresConnection,
 }: {
 	tools: ConnectorTool[];
 	isLoading: boolean;
 	error: Error | null;
+	onRetry: () => void;
 	requiresConnection: boolean;
 }) {
 	const [search, setSearch] = useState("");
@@ -506,11 +514,7 @@ function ConnectorToolsList({
 					}
 				/>
 				<div className="p-4">
-					<Alert variant="destructive">
-						<AlertCircle />
-						<AlertTitle>Couldn't load tools</AlertTitle>
-						<AlertDescription>{errorMessage(error)}</AlertDescription>
-					</Alert>
+					<ApiErrorPanel error={error} onRetry={onRetry} title="Couldn't load tools" />
 				</div>
 			</DashboardSection>
 		);

--- a/apps/web/src/pages/dashboard/connectors/page.tsx
+++ b/apps/web/src/pages/dashboard/connectors/page.tsx
@@ -1,18 +1,19 @@
 "use client";
 
-import { AlertCircle, ChevronLeft, ChevronRight, Plug } from "lucide-react";
+import { ChevronLeft, ChevronRight, Plug } from "lucide-react";
 import { createParser, parseAsString, useQueryState } from "nuqs";
 import { type ReactNode, Suspense, useEffect, useMemo } from "react";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import {
 	CONNECTOR_GRID_CLASS,
 	ConnectorCard,
 	ConnectorCardSkeleton,
 } from "@/components/connectors/connector-card";
 import { EmptyState } from "@/components/empty-state";
+import { ListToolbar } from "@/components/list-toolbar";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SectionLabel } from "@/components/section-label";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/search-input";
@@ -24,7 +25,7 @@ import {
 } from "@/lib/connectors-data";
 import { getProjectResourceDefinition } from "@/lib/project-resource-model";
 import { useDebouncedValue } from "@/lib/use-debounced";
-import { cn, errorMessage } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 
 // Multiple of 12 (LCM of 1/2/3/4 col grid breakpoints) so the last row is
 // always full at every viewport — no orphan cards on the bottom.
@@ -167,9 +168,15 @@ function ConnectorsList() {
 				status={headerStatus}
 			/>
 
-			<div className="max-w-xl">
-				<SearchInput value={query} onChange={handleQueryChange} placeholder="Search connectors…" />
-			</div>
+			<ListToolbar
+				search={
+					<SearchInput
+						value={query}
+						onChange={handleQueryChange}
+						placeholder="Search connectors…"
+					/>
+				}
+			/>
 
 			{showConnectedRail ? (
 				<ConnectedRail
@@ -177,6 +184,7 @@ function ConnectorsList() {
 					activeCount={connected.activeConnections.length}
 					isLoading={connected.isLoading}
 					error={connected.error}
+					onRetry={connected.refetch}
 				/>
 			) : null}
 
@@ -190,6 +198,9 @@ function ConnectorsList() {
 				isFetching={isCatalogFetching}
 				error={catalogError}
 				query={query}
+				onRetry={() => {
+					void catalogQ.refetch();
+				}}
 				onPrev={() => setPage((p) => Math.max(1, p - 1))}
 				onNext={() => setPage((p) => Math.min(totalPages, p + 1))}
 			/>
@@ -207,11 +218,13 @@ function ConnectedRail({
 	activeCount,
 	isLoading,
 	error,
+	onRetry,
 }: {
 	apps: { name: string; display_name: string; description: string; logo: string }[];
 	activeCount: number;
 	isLoading: boolean;
 	error: Error | null;
+	onRetry: () => void;
 }) {
 	return (
 		<section className="space-y-3">
@@ -222,11 +235,7 @@ function ConnectedRail({
 				// Without this, a connections-fetch failure makes the rail
 				// silently disappear and the user only sees "X active" in
 				// the header with no way to find their connections.
-				<Alert variant="destructive">
-					<AlertCircle />
-					<AlertTitle>Couldn't load connections</AlertTitle>
-					<AlertDescription>{errorMessage(error)}</AlertDescription>
-				</Alert>
+				<ApiErrorPanel error={error} onRetry={onRetry} title="Couldn't load connections" />
 			) : isLoading && apps.length === 0 ? (
 				<div className={CONNECTOR_GRID_CLASS}>
 					{Array.from({ length: 4 }).map((_, i) => (
@@ -254,6 +263,7 @@ function CatalogSection({
 	isFetching,
 	error,
 	query,
+	onRetry,
 	onPrev,
 	onNext,
 }: {
@@ -266,19 +276,14 @@ function CatalogSection({
 	isFetching: boolean;
 	error: Error | null;
 	query: string;
+	onRetry: () => void;
 	onPrev: () => void;
 	onNext: () => void;
 }) {
 	const count = !isLoading && total > 0 ? `${total.toLocaleString()} available` : undefined;
 	let content: ReactNode;
 	if (error) {
-		content = (
-			<Alert variant="destructive">
-				<AlertCircle />
-				<AlertTitle>Couldn't load connectors</AlertTitle>
-				<AlertDescription>{errorMessage(error)}</AlertDescription>
-			</Alert>
-		);
+		content = <ApiErrorPanel error={error} onRetry={onRetry} title="Couldn't load connectors" />;
 	} else if (isLoading) {
 		content = (
 			<div className={CONNECTOR_GRID_CLASS}>

--- a/apps/web/src/pages/dashboard/memories/page.tsx
+++ b/apps/web/src/pages/dashboard/memories/page.tsx
@@ -3,15 +3,16 @@
 import { findLikelySecret, formatSecretMemoryWarning } from "@clawdi/shared";
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { AlertCircle, Brain, Database, Key, Laptop, Plus, Trash2 } from "lucide-react";
+import { Brain, Database, Key, Laptop, Plus, Trash2 } from "lucide-react";
 import { type ReactNode, useCallback, useState } from "react";
 import { toast } from "sonner";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { EmptyState } from "@/components/empty-state";
-import { HERO_CARD_BASE } from "@/components/entity-card";
+import { EntityMeta, HERO_CARD_BASE } from "@/components/entity-card";
+import { ListToolbar } from "@/components/list-toolbar";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { TimeTooltip } from "@/components/time-tooltip";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -91,7 +92,7 @@ export default function MemoriesPage() {
 		onError: (e) => toast.error("Couldn't update settings", { description: errorMessage(e) }),
 	});
 
-	const { data, isLoading, isFetching, error } = useQuery({
+	const { data, isLoading, isFetching, error, refetch } = useQuery({
 		queryKey: ["memories", debouncedSearch, apiCategory, pagination.pageIndex, pagination.pageSize],
 		queryFn: async () =>
 			unwrap(
@@ -140,9 +141,47 @@ export default function MemoriesPage() {
 	);
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6")}>
-			<PageHeader
-				title="Memories"
-				description={MEMORIES_RESOURCE.managementDescription}
+			<PageHeader title="Memories" description={MEMORIES_RESOURCE.managementDescription} />
+
+			{provider === "mem0" && !hasMem0Key ? (
+				<Mem0KeyForm
+					onSave={(key) => updateSettings.mutate({ mem0_api_key: key })}
+					isPending={updateSettings.isPending}
+				/>
+			) : null}
+
+			<ListToolbar
+				search={
+					<SearchInput
+						value={search}
+						onChange={(v) => {
+							setSearch(v);
+							setPagination((p) => ({ ...p, pageIndex: 0 }));
+						}}
+						placeholder="Search memories…"
+					/>
+				}
+				filters={
+					<ToggleGroup
+						type="single"
+						value={category}
+						onValueChange={(v) => {
+							if (!v) return;
+							setCategory(v);
+							setPagination((p) => ({ ...p, pageIndex: 0 }));
+						}}
+						variant="outline"
+						size="sm"
+						spacing={1}
+						className="flex-wrap justify-start"
+					>
+						{CATEGORIES.map((c) => (
+							<ToggleGroupItem key={c.value} value={c.value}>
+								{c.label}
+							</ToggleGroupItem>
+						))}
+					</ToggleGroup>
+				}
 				actions={
 					<>
 						<ToggleGroup
@@ -167,51 +206,14 @@ export default function MemoriesPage() {
 				}
 			/>
 
-			{provider === "mem0" && !hasMem0Key ? (
-				<Mem0KeyForm
-					onSave={(key) => updateSettings.mutate({ mem0_api_key: key })}
-					isPending={updateSettings.isPending}
-				/>
-			) : null}
-
-			{/* Notes toolbar — search front and center, category chips beside. */}
-			<div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-				<SearchInput
-					value={search}
-					onChange={(v) => {
-						setSearch(v);
-						setPagination((p) => ({ ...p, pageIndex: 0 }));
-					}}
-					placeholder="Search memories…"
-					className="w-full sm:max-w-md"
-				/>
-				<ToggleGroup
-					type="single"
-					value={category}
-					onValueChange={(v) => {
-						if (!v) return;
-						setCategory(v);
-						setPagination((p) => ({ ...p, pageIndex: 0 }));
-					}}
-					variant="outline"
-					size="sm"
-					spacing={1}
-					className="w-full flex-wrap justify-start sm:w-fit"
-				>
-					{CATEGORIES.map((c) => (
-						<ToggleGroupItem key={c.value} value={c.value}>
-							{c.label}
-						</ToggleGroupItem>
-					))}
-				</ToggleGroup>
-			</div>
-
 			{error ? (
-				<Alert variant="destructive">
-					<AlertCircle />
-					<AlertTitle>Couldn't load memories</AlertTitle>
-					<AlertDescription>{errorMessage(error)}</AlertDescription>
-				</Alert>
+				<ApiErrorPanel
+					error={error}
+					onRetry={() => {
+						void refetch();
+					}}
+					title="Couldn't load memories"
+				/>
 			) : (
 				<div
 					className={cn(
@@ -289,23 +291,24 @@ function MemoryNotesGrid({
 						className="absolute inset-0 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 					/>
 					<p className="line-clamp-[8] break-words text-sm leading-relaxed">{memory.content}</p>
-					<div className="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1.5">
-						<Badge variant="secondary" className={cn(MEMORY_CATEGORY_COLORS[memory.category])}>
-							{memory.category}
-						</Badge>
-						{memory.tags?.slice(0, 3).map((tag) => (
-							<span key={tag} className="text-xs text-muted-foreground">
-								#{tag}
-							</span>
-						))}
-						<span className="ml-auto inline-flex items-center gap-2 text-xs text-muted-foreground">
-							{memory.created_at ? (
-								<TimeTooltip value={memory.created_at}>
+					<EntityMeta
+						className="mt-3 text-xs"
+						items={[
+							<Badge
+								key="category"
+								variant="secondary"
+								className={cn(MEMORY_CATEGORY_COLORS[memory.category])}
+							>
+								{memory.category}
+							</Badge>,
+							...(memory.tags?.slice(0, 3).map((tag) => `#${tag}`) ?? []),
+							memory.created_at ? (
+								<TimeTooltip key="created" value={memory.created_at}>
 									<span>{relativeTime(memory.created_at)}</span>
 								</TimeTooltip>
-							) : null}
-							{memory.source_machine_name ? (
-								<Tooltip>
+							) : null,
+							memory.source_machine_name ? (
+								<Tooltip key="machine">
 									<TooltipTrigger asChild>
 										<span className="inline-flex min-w-0 items-center gap-1">
 											<Laptop className="size-3 shrink-0" />
@@ -314,9 +317,9 @@ function MemoryNotesGrid({
 									</TooltipTrigger>
 									<TooltipContent>Learned on {memory.source_machine_name}</TooltipContent>
 								</Tooltip>
-							) : null}
-						</span>
-					</div>
+							) : null,
+						]}
+					/>
 					<span className="absolute right-2 top-2 z-10 opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100">
 						<ConfirmAction
 							title="Delete this memory?"
@@ -444,11 +447,10 @@ function AddMemoryForm() {
 						/>
 					</div>
 					{secretFinding ? (
-						<Alert variant="destructive">
-							<AlertCircle />
-							<AlertTitle>Use Vault for secrets</AlertTitle>
-							<AlertDescription>{formatSecretMemoryWarning(secretFinding)}</AlertDescription>
-						</Alert>
+						<ApiErrorPanel
+							error={formatSecretMemoryWarning(secretFinding)}
+							title="Use Vault for secrets"
+						/>
 					) : null}
 					<div className="flex items-center justify-between gap-2">
 						<div className="flex items-center gap-2">

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import {
 	AgentLabel,
@@ -270,10 +271,13 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 						Projects
 					</Link>
 				</Button>
-				<Alert variant="destructive">
-					<AlertTitle>Couldn&apos;t load project</AlertTitle>
-					<AlertDescription>{errorMessage(projects.error)}</AlertDescription>
-				</Alert>
+				<ApiErrorPanel
+					error={projects.error}
+					onRetry={() => {
+						void projects.refetch();
+					}}
+					title="Couldn't load project"
+				/>
 			</div>
 		);
 	}

--- a/apps/web/src/pages/dashboard/projects/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/page.tsx
@@ -2,11 +2,13 @@
 
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useRouter } from "@tanstack/react-router";
-import { ChevronDown, Key, Plus, Share2, Sparkles } from "lucide-react";
+import { ChevronDown, Plus, Share2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
-import { HERO_CARD_BASE } from "@/components/entity-card";
+import { ApiErrorPanel } from "@/components/api-error-panel";
+import { HERO_CARD_BASE, HERO_GRID_CLASS, HeroCard } from "@/components/entity-card";
 import { IconChip } from "@/components/icon-chip";
+import { ListToolbar } from "@/components/list-toolbar";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import {
@@ -17,9 +19,8 @@ import {
 	projectAgentFor,
 	projectKindSortRank,
 } from "@/components/projects/project-metadata";
+import { SectionLabel } from "@/components/section-label";
 import { ShareProjectDialog } from "@/components/sharing/share-project-dialog";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -177,7 +178,7 @@ export default function ProjectsPage() {
 		return (
 			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6")}>
 				<PageHeader title="Projects" description={PROJECTS_RESOURCE.managementDescription} />
-				<div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+				<div className={HERO_GRID_CLASS}>
 					{Array.from({ length: 6 }).map((_, i) => (
 						<ProjectCardSkeleton key={i} />
 					))}
@@ -188,30 +189,26 @@ export default function ProjectsPage() {
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6")}>
-			<PageHeader
-				title="Projects"
-				description={PROJECTS_RESOURCE.managementDescription}
+			<PageHeader title="Projects" description={PROJECTS_RESOURCE.managementDescription} />
+
+			<ListToolbar
+				search={<SearchInput value={search} onChange={setSearch} placeholder="Search projects…" />}
 				actions={
-					<>
-						<SearchInput
-							value={search}
-							onChange={setSearch}
-							placeholder="Search projects…"
-							className="w-full sm:w-56"
-						/>
-						<Button size="sm" onClick={openCreateDialog}>
-							<Plus className="size-3.5" />
-							New project
-						</Button>
-					</>
+					<Button size="sm" onClick={openCreateDialog}>
+						<Plus className="size-3.5" />
+						New project
+					</Button>
 				}
 			/>
 
 			{projects.error ? (
-				<Alert variant="destructive">
-					<AlertTitle>Couldn&apos;t load projects</AlertTitle>
-					<AlertDescription>{errorMessage(projects.error)}</AlertDescription>
-				</Alert>
+				<ApiErrorPanel
+					error={projects.error}
+					onRetry={() => {
+						void projects.refetch();
+					}}
+					title="Couldn't load projects"
+				/>
 			) : null}
 
 			<Dialog
@@ -291,7 +288,8 @@ export default function ProjectsPage() {
 			) : (
 				<div
 					className={cn(
-						"grid gap-4 transition-opacity sm:grid-cols-2 xl:grid-cols-3",
+						HERO_GRID_CLASS,
+						"transition-opacity",
 						projects.isFetching && !projects.isLoading ? "opacity-60" : "opacity-100",
 					)}
 				>
@@ -304,7 +302,6 @@ export default function ProjectsPage() {
 							vaultCount={vaultCounts.get(project.id) ?? 0}
 						/>
 					))}
-					{!search.trim() ? <NewProjectCard onClick={openCreateDialog} /> : null}
 				</div>
 			)}
 
@@ -313,7 +310,7 @@ export default function ProjectsPage() {
 					<button
 						type="button"
 						onClick={() => setSystemOpen((v) => !v)}
-						className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+						className="flex flex-wrap items-center gap-1.5 text-muted-foreground transition-colors hover:text-foreground"
 						aria-expanded={systemOpen}
 					>
 						<ChevronDown
@@ -322,11 +319,10 @@ export default function ProjectsPage() {
 								!systemOpen && "-rotate-90",
 							)}
 						/>
-						System projects
-						<Badge variant="secondary" className="tabular-nums">
-							{systemProjects.length}
-						</Badge>
-						<span className="ml-1 font-normal text-xs">
+						<SectionLabel className="px-0" count={systemProjects.length}>
+							System projects
+						</SectionLabel>
+						<span className="ml-1 text-xs">
 							account default and one per connected agent — managed automatically
 						</span>
 					</button>
@@ -362,18 +358,23 @@ function ProjectCard({
 }) {
 	const projectName = displayProjectName(project);
 	return (
-		<div
-			className={cn(
-				HERO_CARD_BASE,
-				"group relative z-0 flex min-h-36 flex-col gap-3 transition-all duration-150 hover:-translate-y-px hover:border-foreground/20",
-			)}
-		>
-			<div className="flex items-start justify-between gap-2">
+		<HeroCard
+			icon={
 				<IconChip tint={identityFor(projectName).colorClasses} className="text-xl">
 					{identityFor(projectName).emoji}
 				</IconChip>
-				{!shared && isCustomProject(project) ? (
-					<span className="relative z-10 opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100">
+			}
+			title={projectName}
+			badges={shared ? <StatusChip>Shared with you</StatusChip> : null}
+			description={<span className="font-mono">{project.slug}</span>}
+			footer={[
+				`${skillCount} ${skillCount === 1 ? "skill" : "skills"}`,
+				`${vaultCount} ${vaultCount === 1 ? "vault" : "vaults"}`,
+				shared && project.owner_display ? `by ${project.owner_display}` : null,
+			]}
+			actions={
+				!shared && isCustomProject(project) ? (
+					<div className="opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100">
 						<ShareProjectDialog
 							projectId={project.id}
 							projectName={projectName}
@@ -383,37 +384,12 @@ function ProjectCard({
 								<Share2 className="size-3.5" />
 							</Button>
 						</ShareProjectDialog>
-					</span>
-				) : null}
-			</div>
-			<div className="min-w-0">
-				<div className="flex min-w-0 items-center gap-2">
-					<h3 className="truncate text-base font-semibold tracking-tight">{projectName}</h3>
-					{shared ? <StatusChip>Shared with you</StatusChip> : null}
-				</div>
-				<p className="truncate font-mono text-xs text-muted-foreground">{project.slug}</p>
-			</div>
-			<div className="mt-auto flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground tabular-nums">
-				<span className="inline-flex items-center gap-1">
-					<Sparkles className="size-3" />
-					{skillCount} {skillCount === 1 ? "skill" : "skills"}
-				</span>
-				<span className="inline-flex items-center gap-1">
-					<Key className="size-3" />
-					{vaultCount} {vaultCount === 1 ? "vault" : "vaults"}
-				</span>
-				{shared && project.owner_display ? (
-					<span className="truncate">by {project.owner_display}</span>
-				) : null}
-			</div>
-			<Link
-				to="/projects/$id"
-				params={{ id: project.id }}
-				className="absolute inset-0 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-			>
-				<span className="sr-only">Open {projectName}</span>
-			</Link>
-		</div>
+					</div>
+				) : null
+			}
+			link={{ to: "/projects/$id", params: { id: project.id } }}
+			ariaLabel={`Open ${projectName}`}
+		/>
 	);
 }
 
@@ -438,21 +414,6 @@ function StatusChip({ children }: { children: React.ReactNode }) {
 		<span className="shrink-0 rounded-sm bg-info-muted px-1.5 py-0.5 text-2xs font-medium text-info-muted-foreground">
 			{children}
 		</span>
-	);
-}
-
-function NewProjectCard({ onClick }: { onClick: () => void }) {
-	return (
-		<button
-			type="button"
-			onClick={onClick}
-			className="flex min-h-36 flex-col items-center justify-center gap-2 rounded-xl border border-dashed text-muted-foreground transition-colors duration-150 hover:border-foreground/20 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus:outline-none"
-		>
-			<IconChip size="sm" tint="bg-muted text-muted-foreground" className="size-9 rounded-lg">
-				<Plus className="size-4" />
-			</IconChip>
-			<span className="text-sm font-medium">New project</span>
-		</button>
 	);
 }
 

--- a/apps/web/src/pages/dashboard/sessions/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/page.tsx
@@ -2,7 +2,7 @@
 
 import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { SortingState } from "@tanstack/react-table";
-import { AlertCircle, LayoutList, Table2 } from "lucide-react";
+import { LayoutList, Table2 } from "lucide-react";
 import {
 	createParser,
 	parseAsBoolean,
@@ -11,25 +11,26 @@ import {
 	useQueryStates,
 } from "nuqs";
 import { Suspense, useEffect, useMemo, useState } from "react";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import { agentTypeLabel } from "@/components/dashboard/agent-label";
+import { ListToolbar } from "@/components/list-toolbar";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { sessionColumns } from "@/components/sessions/session-columns";
 import { SessionFeed } from "@/components/sessions/session-feed";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
 import { DataTableFacetedFilter } from "@/components/ui/data-table-faceted-filter";
 import { DataTablePagination } from "@/components/ui/data-table-pagination";
-import { DataTableToolbar } from "@/components/ui/data-table-toolbar";
+import { SearchInput } from "@/components/ui/search-input";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { unwrap, useApi } from "@/lib/api";
 import type { SessionListItem } from "@/lib/api-schemas";
 import { getProjectResourceDefinition } from "@/lib/project-resource-model";
 import { type SessionListQuery, sessionListQueryOptions } from "@/lib/session-queries";
 import { useDebouncedValue } from "@/lib/use-debounced";
-import { cn, errorMessage, recencyBucketFor } from "@/lib/utils";
+import { cn, recencyBucketFor } from "@/lib/utils";
 
 // `relevance` (trgm similarity) joins the legacy date/count sorts.
 // Relevance is special-cased server-side: it's only meaningful when q
@@ -141,7 +142,7 @@ function SessionsListInner() {
 		],
 	);
 
-	const { data, isLoading, isFetching, error } = useQuery({
+	const { data, isLoading, isFetching, error, refetch } = useQuery({
 		...sessionListQueryOptions(api, sessionQuery),
 		// Keep previous results visible during refetch; the
 		// `isFetching && !isLoading` opacity transition below is
@@ -218,101 +219,90 @@ function SessionsListInner() {
 		? "No sessions match your filters."
 		: "No sessions yet. Once your agent has a conversation, it'll show up here.";
 	const sessionToolbar = (
-		<DataTableToolbar
-			value={params.q}
-			onChange={(v) => {
-				// Switch sort to relevance the moment the user
-				// starts typing — mirrors Amp's "type and rank by
-				// match quality" UX. Restore the date sort if the
-				// box is cleared so the empty-search default goes
-				// back to the activity timeline.
-				void setParams({
-					q: v,
-					page: 1,
-					sort:
-						v && params.sort === "last_activity_at"
-							? "relevance"
-							: !v && params.sort === "relevance"
-								? "last_activity_at"
-								: params.sort,
-				});
-			}}
-			placeholder="Search summary, folder, or session ID…"
-		>
-			{agentOptions.length > 0 ? (
-				<DataTableFacetedFilter
-					title="Agent"
-					options={agentOptions}
-					selected={params.agent ? [params.agent] : []}
-					onChange={(arr) => {
-						void setParams({ agent: arr[0] ?? "", page: 1 });
-					}}
-				/>
-			) : null}
-			<DataTableFacetedFilter
-				title="Type"
-				options={typeFilterOptions}
-				selected={
-					params.automated === true ? ["true"] : params.automated === false ? ["false"] : []
-				}
-				onChange={(arr) => {
-					const v = arr[0];
-					void setParams({
-						automated: v === "true" ? true : v === "false" ? false : null,
-						page: 1,
-					});
-				}}
-			/>
-			<DataTableFacetedFilter
-				title="PR links"
-				options={prFilterOptions}
-				selected={params.has_pr === true ? ["true"] : params.has_pr === false ? ["false"] : []}
-				onChange={(arr) => {
-					const v = arr[0];
-					void setParams({
-						has_pr: v === "true" ? true : v === "false" ? false : null,
-						page: 1,
-					});
-				}}
-			/>
-			{isFiltered ? (
-				<Button
-					variant="ghost"
-					size="sm"
-					className="h-8 px-2"
-					onClick={() =>
+		<ListToolbar
+			search={
+				<SearchInput
+					value={params.q}
+					onChange={(v) => {
+						// Switch sort to relevance the moment the user
+						// starts typing — mirrors Amp's "type and rank by
+						// match quality" UX. Restore the date sort if the
+						// box is cleared so the empty-search default goes
+						// back to the activity timeline.
 						void setParams({
-							q: "",
-							agent: "",
-							has_pr: null,
-							automated: null,
+							q: v,
 							page: 1,
-						})
-					}
-				>
-					Reset
-				</Button>
-			) : null}
-		</DataTableToolbar>
-	);
-	const sessionFooter = (
-		<div>
-			<DataTablePagination
-				page={params.page}
-				pageSize={params.pageSize}
-				total={total}
-				onPageChange={(p) => void setParams({ page: p })}
-				onPageSizeChange={(size) => void setParams({ pageSize: size, page: 1 })}
-			/>
-		</div>
-	);
-
-	return (
-		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
-			<PageHeader
-				title="Sessions"
-				description={SESSIONS_RESOURCE.managementDescription}
-				actions={
+							sort:
+								v && params.sort === "last_activity_at"
+									? "relevance"
+									: !v && params.sort === "relevance"
+										? "last_activity_at"
+										: params.sort,
+						});
+					}}
+					placeholder="Search summary, folder, or session ID…"
+				/>
+			}
+			filters={
+				<>
+					{agentOptions.length > 0 ? (
+						<DataTableFacetedFilter
+							title="Agent"
+							options={agentOptions}
+							selected={params.agent ? [params.agent] : []}
+							onChange={(arr) => {
+								void setParams({ agent: arr[0] ?? "", page: 1 });
+							}}
+						/>
+					) : null}
+					<DataTableFacetedFilter
+						title="Type"
+						options={typeFilterOptions}
+						selected={
+							params.automated === true ? ["true"] : params.automated === false ? ["false"] : []
+						}
+						onChange={(arr) => {
+							const v = arr[0];
+							void setParams({
+								automated: v === "true" ? true : v === "false" ? false : null,
+								page: 1,
+							});
+						}}
+					/>
+					<DataTableFacetedFilter
+						title="PR links"
+						options={prFilterOptions}
+						selected={params.has_pr === true ? ["true"] : params.has_pr === false ? ["false"] : []}
+						onChange={(arr) => {
+							const v = arr[0];
+							void setParams({
+								has_pr: v === "true" ? true : v === "false" ? false : null,
+								page: 1,
+							});
+						}}
+					/>
+				</>
+			}
+			actions={
+				<>
+					{isFiltered ? (
+						<Button
+							variant="ghost"
+							size="sm"
+							className="h-8 px-2"
+							onClick={() =>
+								void setParams({
+									q: "",
+									agent: "",
+									has_pr: null,
+									automated: null,
+									page: 1,
+								})
+							}
+						>
+							Reset
+						</Button>
+					) : null}
 					<ToggleGroup
 						type="single"
 						value={params.view}
@@ -329,15 +319,34 @@ function SessionsListInner() {
 							<Table2 />
 						</ToggleGroupItem>
 					</ToggleGroup>
-				}
+				</>
+			}
+		/>
+	);
+	const sessionFooter = (
+		<div>
+			<DataTablePagination
+				page={params.page}
+				pageSize={params.pageSize}
+				total={total}
+				onPageChange={(p) => void setParams({ page: p })}
+				onPageSizeChange={(size) => void setParams({ pageSize: size, page: 1 })}
 			/>
+		</div>
+	);
+
+	return (
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
+			<PageHeader title="Sessions" description={SESSIONS_RESOURCE.managementDescription} />
 
 			{error ? (
-				<Alert variant="destructive">
-					<AlertCircle />
-					<AlertTitle>Couldn't load sessions</AlertTitle>
-					<AlertDescription>{errorMessage(error)}</AlertDescription>
-				</Alert>
+				<ApiErrorPanel
+					error={error}
+					onRetry={() => {
+						void refetch();
+					}}
+					title="Couldn't load sessions"
+				/>
 			) : (
 				<div
 					className={cn(

--- a/apps/web/src/pages/dashboard/skills/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/page.tsx
@@ -20,9 +20,12 @@ import {
 import { parseAsString, useQueryState } from "nuqs";
 import { Suspense, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { BulkActionBar } from "@/components/bulk-action-bar";
 import { agentIdentity } from "@/components/dashboard/agent-label";
 import { EmptyState } from "@/components/empty-state";
+import { FilterChip, filterChipClass } from "@/components/filter-chip";
+import { ListToolbar } from "@/components/list-toolbar";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import {
@@ -31,7 +34,7 @@ import {
 	isCustomProject,
 	isProjectOwner,
 } from "@/components/projects/project-metadata";
-import { ProjectTab } from "@/components/projects/project-tab";
+import { SectionLabel } from "@/components/section-label";
 import { ShareProjectDialog } from "@/components/sharing/share-project-dialog";
 import { SendSkillDialog } from "@/components/skills/send-skill-dialog";
 import { SkillCardGrid, skillSelectionKey } from "@/components/skills/skill-card";
@@ -47,6 +50,7 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
+import { SearchInput } from "@/components/ui/search-input";
 import { Spinner } from "@/components/ui/spinner";
 import { ensureBlob, unwrap, useApi, useSkillArchiveUploader } from "@/lib/api";
 import { fetchAllPages } from "@/lib/api-pagination";
@@ -96,7 +100,11 @@ function SkillsPageInner() {
 	const [customRepo, setCustomRepo] = useState("");
 	const [customRepoError, setCustomRepoError] = useState<string | null>(null);
 
-	const { data: projects, error: projectsError } = useQuery({
+	const {
+		data: projects,
+		error: projectsError,
+		refetch: refetchProjects,
+	} = useQuery({
 		queryKey: ["projects"],
 		queryFn: async () => unwrap(await api.GET("/v1/projects")),
 	});
@@ -159,6 +167,7 @@ function SkillsPageInner() {
 		isLoading: skillsLoading,
 		isFetching: skillsFetching,
 		error: skillsError,
+		refetch: refetchSkills,
 	} = useQuery({
 		queryKey: ["skills", "all-projects"],
 		queryFn: async () =>
@@ -478,6 +487,10 @@ function SkillsPageInner() {
 		if (ok) setCustomRepo("");
 	};
 
+	const retryCustomInstall = () => {
+		void handleCustom();
+	};
+
 	const installedSkillsEmptyMessage = isStaleProject
 		? "This link points to a Project that is no longer available. Pick another Project."
 		: isStaleTarget
@@ -500,157 +513,90 @@ function SkillsPageInner() {
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6")}>
-			<PageHeader
-				title="Skills"
-				description={SKILLS_RESOURCE.managementDescription}
-				actions={orderedProjects.length > 0 ? renderShareProjectAction() : null}
-			/>
+			<PageHeader title="Skills" description={SKILLS_RESOURCE.managementDescription} />
 
-			{/* Project scope as visible tabs, mirroring the vault page: custom
-			    projects + Global up front, the long tail of per-agent projects
-			    behind one overflow menu. */}
-			{orderedProjects.length > 0 ? (
-				<div
-					className="flex flex-wrap items-center gap-1.5"
-					role="tablist"
-					aria-label="Project scope for skills"
-				>
-					<ProjectTab
-						active={isAllScope}
-						onClick={() => {
-							void setProjectParam("");
-							void setTargetEnvId("");
-						}}
-						label="All projects"
-						count={skillsData?.items.length}
-					/>
-					{tabProjects.map((p) => (
-						<ProjectTab
-							key={p.id}
-							active={targetProjectId === p.id}
-							onClick={() => {
-								void setProjectParam(p.id);
-								void setTargetEnvId("");
-							}}
-							label={displayProjectName(p)}
-							emoji={identityFor(displayProjectName(p)).emoji}
-							count={skillCountByProject.get(p.id) ?? 0}
-						/>
-					))}
-					{overflowProjects.length > 0 ? (
-						<DropdownMenu>
-							<DropdownMenuTrigger asChild>
-								<button
-									type="button"
-									className={cn(
-										"inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-sm transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-ring focus:outline-none",
-										overflowActive
-											? "border-foreground/20 bg-accent font-medium text-foreground"
-											: "border-transparent text-muted-foreground hover:bg-muted/50 hover:text-foreground",
-									)}
+			<ListToolbar
+				search={<SearchInput value={search} onChange={setSearch} placeholder="Search skills…" />}
+				filters={
+					orderedProjects.length > 0 ? (
+						<>
+							<FilterChip
+								active={isAllScope}
+								onClick={() => {
+									void setProjectParam("");
+									void setTargetEnvId("");
+								}}
+							>
+								All projects
+								<span className="text-muted-foreground tabular-nums">
+									{skillsData?.items.length ?? 0}
+								</span>
+							</FilterChip>
+							{tabProjects.map((p) => (
+								<FilterChip
+									key={p.id}
+									active={targetProjectId === p.id}
+									onClick={() => {
+										void setProjectParam(p.id);
+										void setTargetEnvId("");
+									}}
 								>
-									{overflowActive && targetProject
-										? `${identityFor(displayProjectName(targetProject)).emoji} ${displayProjectName(targetProject)}`
-										: `Agent projects (${overflowProjects.length})`}
-									<ChevronDown className="size-3.5" />
-								</button>
-							</DropdownMenuTrigger>
-							<DropdownMenuContent align="start" className="max-h-80 overflow-y-auto">
-								{overflowProjects.map((p) => (
-									<DropdownMenuItem
-										key={p.id}
-										onSelect={() => {
-											void setProjectParam(p.id);
-											void setTargetEnvId("");
-										}}
-									>
-										<span aria-hidden className="select-none">
-											{identityFor(displayProjectName(p)).emoji}
-										</span>
-										<span className="min-w-0 flex-1 truncate">{displayProjectName(p)}</span>
-										<span className="text-xs text-muted-foreground tabular-nums">
-											{skillCountByProject.get(p.id) ?? 0}
-										</span>
-									</DropdownMenuItem>
-								))}
-							</DropdownMenuContent>
-						</DropdownMenu>
-					) : null}
-				</div>
-			) : null}
-
-			{projectsError ? (
-				<Alert variant="destructive">
-					<AlertCircle />
-					<AlertTitle>Couldn&apos;t load Projects</AlertTitle>
-					<AlertDescription>
-						Project-scoped install and uninstall are temporarily disabled.{" "}
-						{errorMessage(projectsError)}
-					</AlertDescription>
-				</Alert>
-			) : null}
-
-			{/* Skills inventory failure: a load error must not look
-			    like an empty inventory — pre-fix the page swallowed
-			    `skillsError` and fell through to the empty-state copy
-			    'No skills installed on this agent yet,' which is
-			    indistinguishable from a real /api/skills outage from
-			    the user's perspective. */}
-			{skillsError ? (
-				<Alert variant="destructive">
-					<AlertCircle />
-					<AlertTitle>Couldn&apos;t load skills</AlertTitle>
-					<AlertDescription>
-						Your installed skills aren&apos;t showing because of an API error. Refresh to retry.{" "}
-						{errorMessage(skillsError)}
-					</AlertDescription>
-				</Alert>
-			) : null}
-
-			{!canWriteTargetProject && targetProject ? (
-				<Alert>
-					<AlertCircle />
-					<AlertTitle>Read-only Project</AlertTitle>
-					<AlertDescription>
-						You can view skills in {displayProjectName(targetProject)}, but only the owner can
-						install or remove them.
-					</AlertDescription>
-				</Alert>
-			) : null}
-
-			<section
-				className={cn(
-					"space-y-3 transition-opacity",
-					skillsFetching && !skillsLoading ? "opacity-60" : "opacity-100",
-				)}
-			>
-				<div className="flex flex-wrap items-center gap-2">
-					<div className="flex items-center gap-2">
-						<h2 className="text-sm font-semibold">Installed</h2>
-						{skillsForTarget ? (
-							<Badge variant="secondary" className="tabular-nums">
-								{skillsForTarget.length}
-							</Badge>
-						) : null}
-						{targetProject ? (
-							<span className="text-xs text-muted-foreground">
-								in {displayProjectName(targetProject)}
-							</span>
-						) : isAllScope ? (
-							<span className="text-xs text-muted-foreground">across every Project</span>
-						) : null}
-					</div>
-					<div className="ml-auto flex items-center gap-2">
-						<div className="relative">
-							<Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
-							<Input
-								value={search}
-								onChange={(e) => setSearch(e.target.value)}
-								placeholder="Search skills…"
-								aria-label="Search skills"
-								className="h-8 w-44 pl-8 text-sm sm:w-56"
-							/>
-						</div>
+									<span aria-hidden className="select-none">
+										{identityFor(displayProjectName(p)).emoji}
+									</span>
+									{displayProjectName(p)}
+									<span className="text-muted-foreground tabular-nums">
+										{skillCountByProject.get(p.id) ?? 0}
+									</span>
+								</FilterChip>
+							))}
+							{overflowProjects.length > 0 ? (
+								<DropdownMenu>
+									<DropdownMenuTrigger asChild>
+										<button type="button" className={filterChipClass(overflowActive)}>
+											{overflowActive && targetProject ? (
+												<>
+													<span aria-hidden className="select-none">
+														{identityFor(displayProjectName(targetProject)).emoji}
+													</span>
+													{displayProjectName(targetProject)}
+												</>
+											) : (
+												<>Agent projects</>
+											)}
+											<span className="text-muted-foreground tabular-nums">
+												{overflowProjects.length}
+											</span>
+											<ChevronDown className="size-3.5" />
+										</button>
+									</DropdownMenuTrigger>
+									<DropdownMenuContent align="start" className="max-h-80 overflow-y-auto">
+										{overflowProjects.map((p) => (
+											<DropdownMenuItem
+												key={p.id}
+												onSelect={() => {
+													void setProjectParam(p.id);
+													void setTargetEnvId("");
+												}}
+											>
+												<span aria-hidden className="select-none">
+													{identityFor(displayProjectName(p)).emoji}
+												</span>
+												<span className="min-w-0 flex-1 truncate">{displayProjectName(p)}</span>
+												<span className="text-xs text-muted-foreground tabular-nums">
+													{skillCountByProject.get(p.id) ?? 0}
+												</span>
+											</DropdownMenuItem>
+										))}
+									</DropdownMenuContent>
+								</DropdownMenu>
+							) : null}
+						</>
+					) : null
+				}
+				actions={
+					<>
+						{orderedProjects.length > 0 ? renderShareProjectAction() : null}
 						{isAllScope && duplicateGroups.length > 0 ? (
 							<Button
 								variant={showDuplicates ? "secondary" : "outline"}
@@ -679,8 +625,68 @@ function SkillsPageInner() {
 							<ListChecks className="size-3.5" />
 							{selectMode ? "Done" : "Select"}
 						</Button>
-					</div>
-				</div>
+					</>
+				}
+			/>
+
+			{projectsError ? (
+				<ApiErrorPanel
+					error={projectsError}
+					onRetry={() => {
+						void refetchProjects();
+					}}
+					title="Couldn't load Projects"
+				/>
+			) : null}
+
+			{/* Skills inventory failure: a load error must not look
+			    like an empty inventory — pre-fix the page swallowed
+			    `skillsError` and fell through to the empty-state copy
+			    'No skills installed on this agent yet,' which is
+			    indistinguishable from a real /api/skills outage from
+			    the user's perspective. */}
+			{skillsError ? (
+				<ApiErrorPanel
+					error={skillsError}
+					onRetry={() => {
+						void refetchSkills();
+					}}
+					title="Couldn't load skills"
+				/>
+			) : null}
+
+			{!canWriteTargetProject && targetProject ? (
+				<Alert>
+					<AlertCircle />
+					<AlertTitle>Read-only Project</AlertTitle>
+					<AlertDescription>
+						You can view skills in {displayProjectName(targetProject)}, but only the owner can
+						install or remove them.
+					</AlertDescription>
+				</Alert>
+			) : null}
+
+			<section
+				className={cn(
+					"space-y-3 transition-opacity",
+					skillsFetching && !skillsLoading ? "opacity-60" : "opacity-100",
+				)}
+			>
+				<SectionLabel
+					count={
+						skillsForTarget
+							? `${skillsForTarget.length}${
+									targetProject
+										? ` in ${displayProjectName(targetProject)}`
+										: isAllScope
+											? " across every Project"
+											: ""
+								}`
+							: undefined
+					}
+				>
+					Installed
+				</SectionLabel>
 				{duplicatesView ? (
 					duplicateGroups.length === 0 ? (
 						<EmptyState
@@ -698,13 +704,16 @@ function SkillsPageInner() {
 								return (
 									<div key={group.key} className="space-y-2">
 										<div className="flex flex-wrap items-center gap-2">
-											<span aria-hidden className="select-none text-sm leading-none">
-												{identityFor(group.newest.name || group.key).emoji}
-											</span>
-											<span className="text-sm font-medium">{group.newest.name}</span>
-											<span className="text-xs text-muted-foreground tabular-nums">
-												in {group.copies.length} projects
-											</span>
+											<SectionLabel
+												leading={
+													<span aria-hidden className="select-none">
+														{identityFor(group.newest.name || group.key).emoji}
+													</span>
+												}
+												count={`in ${group.copies.length} projects`}
+											>
+												{group.newest.name}
+											</SectionLabel>
 											{group.drift ? (
 												<Badge
 													variant="secondary"
@@ -785,23 +794,26 @@ function SkillsPageInner() {
 								return (
 									<div key={group.pid || "other"} className="space-y-2">
 										<div className="flex items-center gap-2">
-											<span aria-hidden className="select-none text-sm leading-none">
-												{identityFor(group.label).emoji}
-											</span>
-											{group.project ? (
-												<button
-													type="button"
-													onClick={() => void setProjectParam(group.pid)}
-													className="text-sm font-medium hover:underline"
-												>
-													{group.label}
-												</button>
-											) : (
-												<span className="text-sm font-medium">{group.label}</span>
-											)}
-											<span className="text-xs text-muted-foreground tabular-nums">
-												{group.skills.length}
-											</span>
+											<SectionLabel
+												leading={
+													<span aria-hidden className="select-none">
+														{identityFor(group.label).emoji}
+													</span>
+												}
+												count={group.skills.length}
+											>
+												{group.project ? (
+													<button
+														type="button"
+														onClick={() => void setProjectParam(group.pid)}
+														className="hover:underline"
+													>
+														{group.label}
+													</button>
+												) : (
+													group.label
+												)}
+											</SectionLabel>
 											{selectMode ? (
 												<Button
 													variant="ghost"
@@ -942,15 +954,14 @@ function SkillsPageInner() {
 					</div>
 					{customRepoError ? <p className="text-xs text-destructive">{customRepoError}</p> : null}
 					{installError ? (
-						<Alert variant="destructive">
-							<AlertTitle>Install failed</AlertTitle>
-							<AlertDescription>{installError}</AlertDescription>
-						</Alert>
+						<ApiErrorPanel
+							error={installError}
+							onRetry={customRepo.trim() ? retryCustomInstall : undefined}
+							title="Install failed"
+						/>
 					) : null}
 
-					<p className="pt-2 text-2xs font-medium uppercase tracking-wider text-muted-foreground">
-						Suggested
-					</p>
+					<SectionLabel className="pt-2">Suggested</SectionLabel>
 					<div className="grid grid-cols-1 gap-3 md:grid-cols-2">
 						{FEATURED_SKILLS.map((skill) => {
 							const key = `${skill.repo}/${skill.path ?? ""}`;

--- a/apps/web/src/pages/dashboard/vault/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/page.tsx
@@ -1,16 +1,18 @@
 "use client";
 
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link, useRouter } from "@tanstack/react-router";
+import { useRouter } from "@tanstack/react-router";
 import { Lock, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
-import { HERO_CARD_BASE } from "@/components/entity-card";
+import { ApiErrorPanel } from "@/components/api-error-panel";
+import { HERO_CARD_BASE, HERO_GRID_CLASS, HeroCard } from "@/components/entity-card";
+import { FilterChip } from "@/components/filter-chip";
 import { IconChip } from "@/components/icon-chip";
+import { ListToolbar } from "@/components/list-toolbar";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
-import { ProjectTab } from "@/components/projects/project-tab";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { SectionLabel } from "@/components/section-label";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -102,57 +104,53 @@ export default function VaultPage() {
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6")}>
-			<PageHeader
-				title="Vaults"
-				description={VAULTS_RESOURCE.managementDescription}
+			<PageHeader title="Vaults" description={VAULTS_RESOURCE.managementDescription} />
+
+			<ListToolbar
+				search={<SearchInput value={search} onChange={setSearch} placeholder="Search vaults…" />}
+				filters={
+					filterableProjects.length > 1 ? (
+						<>
+							<FilterChip active={projectFilter === "all"} onClick={() => setProjectFilter("all")}>
+								All projects
+								<span className="text-muted-foreground tabular-nums">{items.length}</span>
+							</FilterChip>
+							{filterableProjects.map((p) => (
+								<FilterChip
+									key={p.id}
+									active={projectFilter === p.id}
+									onClick={() => setProjectFilter(p.id)}
+								>
+									<span aria-hidden className="select-none">
+										{identityFor(p.name).emoji}
+									</span>
+									{p.name}
+									<span className="text-muted-foreground tabular-nums">
+										{vaultCountByProject.get(p.id) ?? 0}
+									</span>
+								</FilterChip>
+							))}
+						</>
+					) : null
+				}
 				actions={
 					<>
-						<SearchInput
-							value={search}
-							onChange={setSearch}
-							placeholder="Search vaults…"
-							className="w-full sm:w-56"
-						/>
 						<AddKeysDialog />
 						<NewVaultDialog />
 					</>
 				}
 			/>
 
-			{/* Project tabs, not a dropdown — a visible row teaches that vaults
-			    are scoped through Projects (Marvin: dropdowns get ignored). */}
-			{filterableProjects.length > 1 ? (
-				<div
-					className="flex flex-wrap items-center gap-1.5"
-					role="tablist"
-					aria-label="Filter vaults by Project"
-				>
-					<ProjectTab
-						active={projectFilter === "all"}
-						onClick={() => setProjectFilter("all")}
-						label="All projects"
-						count={items.length}
-					/>
-					{filterableProjects.map((p) => (
-						<ProjectTab
-							key={p.id}
-							active={projectFilter === p.id}
-							onClick={() => setProjectFilter(p.id)}
-							label={p.name}
-							emoji={identityFor(p.name).emoji}
-							count={vaultCountByProject.get(p.id) ?? 0}
-						/>
-					))}
-				</div>
-			) : null}
-
 			{vaults.error ? (
-				<Alert variant="destructive">
-					<AlertTitle>Couldn&apos;t load vaults</AlertTitle>
-					<AlertDescription>{errorMessage(vaults.error)}</AlertDescription>
-				</Alert>
+				<ApiErrorPanel
+					error={vaults.error}
+					onRetry={() => {
+						void vaults.refetch();
+					}}
+					title="Couldn't load vaults"
+				/>
 			) : vaults.isLoading ? (
-				<div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+				<div className={HERO_GRID_CLASS}>
 					{Array.from({ length: 3 }).map((_, i) => (
 						<VaultCardSkeleton key={i} />
 					))}
@@ -161,22 +159,22 @@ export default function VaultPage() {
 				<>
 					<div
 						className={cn(
-							"grid gap-4 transition-opacity sm:grid-cols-2 xl:grid-cols-3",
+							HERO_GRID_CLASS,
+							"transition-opacity",
 							vaults.isFetching && !vaults.isLoading ? "opacity-60" : "opacity-100",
 						)}
 					>
 						{mine.map((vault) => (
 							<VaultCard key={vault.id} vault={vault} projectNameById={projectNameById} />
 						))}
-						{!search.trim() ? <NewVaultCard /> : null}
 					</div>
 					{shared.length > 0 ? (
 						<section className="space-y-2">
-							<h2 className="text-sm font-semibold">Shared with you</h2>
+							<SectionLabel count={shared.length}>Shared with you</SectionLabel>
 							<p className="text-xs text-muted-foreground">
 								Read-only — your agents can use these keys; only the owner can edit them.
 							</p>
-							<div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+							<div className={HERO_GRID_CLASS}>
 								{shared.map((vault) => (
 									<VaultCard
 										key={vault.id}
@@ -236,27 +234,22 @@ function VaultCard({
 		.filter((n): n is string => !!n);
 
 	return (
-		<div
-			className={cn(
-				HERO_CARD_BASE,
-				"group relative z-0 flex min-h-36 flex-col gap-3 transition-all duration-150 hover:-translate-y-px hover:border-foreground/20",
-			)}
-		>
-			<IconChip tint={identityFor(vault.name).colorClasses} className="relative text-xl">
-				{identityFor(vault.name).emoji}
-				{shared ? (
-					<span className="absolute -right-1 -bottom-1 flex size-4 items-center justify-center rounded-full border bg-card">
-						<Lock className="size-2.5 text-muted-foreground" />
-					</span>
-				) : null}
-			</IconChip>
-			<div className="min-w-0">
-				<h3 className="truncate text-base font-semibold tracking-tight">{vault.name}</h3>
-				<p className="truncate font-mono text-xs text-muted-foreground">{vault.slug}</p>
-			</div>
-			<div className="mt-auto flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground tabular-nums">
-				<span>{keyCount === null ? "…" : `${keyCount} ${keyCount === 1 ? "key" : "keys"}`}</span>
-				{usedBy.length > 0 ? (
+		<HeroCard
+			icon={
+				<IconChip tint={identityFor(vault.name).colorClasses} className="relative text-xl">
+					{identityFor(vault.name).emoji}
+					{shared ? (
+						<span className="absolute -right-1 -bottom-1 flex size-4 items-center justify-center rounded-full border bg-card">
+							<Lock className="size-2.5 text-muted-foreground" />
+						</span>
+					) : null}
+				</IconChip>
+			}
+			title={vault.name}
+			description={<span className="font-mono">{vault.slug}</span>}
+			footer={[
+				keyCount === null ? "…" : `${keyCount} ${keyCount === 1 ? "key" : "keys"}`,
+				usedBy.length > 0 ? (
 					<Tooltip>
 						<TooltipTrigger asChild>
 							<span className="truncate">
@@ -267,17 +260,12 @@ function VaultCard({
 						<TooltipContent>{usedBy.join(", ")}</TooltipContent>
 					</Tooltip>
 				) : (
-					<span>not in any Project yet</span>
-				)}
-			</div>
-			<Link
-				to="/vault/$slug"
-				params={{ slug: vault.slug }}
-				className="absolute inset-0 rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-			>
-				<span className="sr-only">Open vault {vault.name}</span>
-			</Link>
-		</div>
+					"not in any Project yet"
+				),
+			]}
+			link={{ to: "/vault/$slug", params: { slug: vault.slug } }}
+			ariaLabel={`Open vault ${vault.name}`}
+		/>
 	);
 }
 
@@ -294,24 +282,6 @@ function VaultCardSkeleton() {
 				<Skeleton className="h-3 w-32" />
 			</div>
 		</div>
-	);
-}
-
-function NewVaultCard() {
-	return (
-		<NewVaultDialog
-			trigger={
-				<button
-					type="button"
-					className="flex min-h-36 flex-col items-center justify-center gap-2 rounded-xl border border-dashed text-muted-foreground transition-colors duration-150 hover:border-foreground/20 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus:outline-none"
-				>
-					<IconChip size="sm" tint="bg-muted text-muted-foreground" className="size-9 rounded-lg">
-						<Plus className="size-4" />
-					</IconChip>
-					<span className="text-sm font-medium">New vault</span>
-				</button>
-			}
-		/>
 	);
 }
 


### PR DESCRIPTION
## Summary

- Adds shared collection primitives: `ListToolbar`, `FilterChip`, `HeroCard`, and a leading slot for `SectionLabel`.
- Migrates collection pages to the shared toolbar, group header, item anatomy, grid rhythm, and `ApiErrorPanel` error surface.
- Documents the Collections contract in `DESIGN.md`.

## Page contract

- Agents: Entity anatomy through `EntityHeader`; no page-specific list controls; hosted agent groups use `SectionLabel`.
- Sessions: `ListToolbar` for search, filters, and feed/table switcher; feed cards use Entity anatomy; date groups use `SectionLabel`.
- Skills: `ListToolbar` for project chips, search, and actions; skill cards use Hero anatomy; project/source groups use `SectionLabel`.
- Connectors: `ListToolbar` for search; connector cards use Entity anatomy; Connected and All Connectors groups use `SectionLabel`.
- Memories: `ListToolbar` for search, category/source toggles, and New action; masonry cards use Hero tier padding/radius/footer conventions; no custom group header.
- Projects: `ListToolbar` for search and New action; project cards use Hero anatomy; system-project group label uses `SectionLabel`.
- Vault: `ListToolbar` for search, project chips, and actions; vault cards use Hero anatomy; shared vaults use `SectionLabel`.
- Channels: `ListToolbar` for provider chips and Connect action; channel cards use Entity anatomy; provider groups use `SectionLabel`.
- Model Providers: `ListToolbar` for Add provider action; provider cards use Entity anatomy; managed/custom provider sections use `SectionLabel`.

## Verification

- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`
- `bun run check`
- Local screenshot contact sheet and mobile shots saved under `/home/kingsley/clawdi-ui-screenshots/collection-framework/`.

🤖 Generated with paseo codex.
