### PR TITLE
Unify page width across console and agent pages

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -94,6 +94,12 @@ Weights: use 500/600 for hierarchy; 400 body; avoid 700+.
 
 ### Component conventions
 
+- Page width: every dashboard route — console pages and agent sub-pages
+  alike — uses `CENTERED_PAGE_WIDTH_CLASS.page` (`max-w-7xl`) as its only
+  width container. No inner centered columns (`mx-auto max-w-*` wrappers
+  inside a page); content and `PageHeader` share the same left edge. Forms
+  cap individual controls or text blocks (`max-w-2xl` on the block), never
+  the page column.
 - Card tiers: entity cards are `rounded-lg p-4`; hero cards are
   `rounded-xl p-5`. Do not add new card tiers without updating this contract.
 - Empty states use `EmptyState` only. `variant="page"` (default) is for a

--- a/apps/web/src/components/dashboard/agent-settings-panel.tsx
+++ b/apps/web/src/components/dashboard/agent-settings-panel.tsx
@@ -33,7 +33,6 @@ type EnvironmentUpdate = components["schemas"]["EnvironmentUpdate"];
 
 const MAX_AGENT_AVATAR_BYTES = 2 * 1024 * 1024;
 const AGENT_AVATAR_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/webp"]);
-const SETTINGS_PANEL_WIDTH_CLASS = "mx-auto w-full max-w-4xl";
 
 function updateEnvironmentCaches(queryClient: QueryClient, environment: Environment) {
 	queryClient.setQueryData(["agents", environment.id], environment);
@@ -44,11 +43,9 @@ function updateEnvironmentCaches(queryClient: QueryClient, environment: Environm
 
 export function AgentSettingsPanel({
 	environmentId,
-	contained = true,
 	className,
 }: {
 	environmentId: string;
-	contained?: boolean;
 	className?: string;
 }) {
 	const api = useApi();
@@ -158,7 +155,7 @@ export function AgentSettingsPanel({
 
 	if (isLoading) {
 		return (
-			<div className={cn(contained && SETTINGS_PANEL_WIDTH_CLASS, className)}>
+			<div className={className}>
 				<Skeleton className="h-[420px] w-full rounded-lg" />
 			</div>
 		);
@@ -166,13 +163,7 @@ export function AgentSettingsPanel({
 
 	if (error || !agent) {
 		return (
-			<div
-				className={cn(
-					"flex flex-col gap-1 rounded-md border p-4",
-					contained && SETTINGS_PANEL_WIDTH_CLASS,
-					className,
-				)}
-			>
+			<div className={cn("flex flex-col gap-1 rounded-md border p-4", className)}>
 				<div className="text-sm font-semibold">Settings unavailable</div>
 				<p className="text-sm text-muted-foreground">{errorMessage(error ?? "Agent not found")}</p>
 			</div>
@@ -205,7 +196,7 @@ export function AgentSettingsPanel({
 	const legacyDashboardUrl = ownershipKind === "legacy" ? legacyHostedDashboardUrl() : null;
 
 	return (
-		<div className={cn("flex flex-col gap-9", contained && SETTINGS_PANEL_WIDTH_CLASS, className)}>
+		<div className={cn("flex flex-col gap-9", className)}>
 			<input
 				ref={fileInputRef}
 				type="file"
@@ -234,7 +225,7 @@ export function AgentSettingsPanel({
 				title="Display name"
 				description="Use a short name that distinguishes this agent from others."
 			>
-				<div className="flex flex-col gap-3">
+				<div className="flex max-w-2xl flex-col gap-3">
 					<div className="flex flex-col gap-2 lg:flex-row">
 						<Label htmlFor="agent-display-name" className="sr-only">
 							Display name

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -79,7 +79,6 @@ const AGENT_DETAIL_NAV_META: Record<AgentTab, DetailSectionMeta> = {
 		description: "Name and avatar used across the dashboard.",
 	},
 };
-const AGENT_DETAIL_INNER_WIDTH_CLASS = "mx-auto w-full max-w-4xl";
 
 export function ConnectedAgentDetail({
 	environmentId,
@@ -248,81 +247,75 @@ export function ConnectedAgentDetail({
 				</div>
 			) : agent ? (
 				<section className="flex flex-col gap-4">
-					<div className={cn(AGENT_DETAIL_INNER_WIDTH_CLASS, "flex flex-col gap-4")}>
-						<PageHeader
-							title={activeTabLabel}
-							description={activeTabMeta.description}
-							icon={
-								ActiveTabIcon ? <ActiveTabIcon className="size-4 text-muted-foreground" /> : null
-							}
-							status={headerStatus}
-							actions={headerActions}
-						/>
+					<PageHeader
+						title={activeTabLabel}
+						description={activeTabMeta.description}
+						icon={ActiveTabIcon ? <ActiveTabIcon className="size-4 text-muted-foreground" /> : null}
+						status={headerStatus}
+						actions={headerActions}
+					/>
 
-						{activeTab === "overview" ? (
-							<div className="flex flex-col gap-4">
-								<div className="grid gap-3 sm:grid-cols-3">
-									<AgentStatPanel label="Sessions" value={sessionTotal} />
-									<AgentStatPanel
-										label="Skills"
-										value={skillsForThisEnv ? skillsForThisEnv.length : "—"}
-									/>
-									<AgentStatPanel label="Projects" value={projectBindings?.length ?? "—"} />
-								</div>
-								<SessionFeed
-									sessions={(sessionsPage?.items ?? []).slice(0, 5)}
-									isLoading={sessionsLoading}
-									emptyMessage="No sessions synced from this agent yet."
-									emptyVariant="inset"
-									showAgent={false}
-									sessionLink={(session) => scopedSessionLink(session.id)}
+					{activeTab === "overview" ? (
+						<div className="flex flex-col gap-4">
+							<div className="grid gap-3 sm:grid-cols-3">
+								<AgentStatPanel label="Sessions" value={sessionTotal} />
+								<AgentStatPanel
+									label="Skills"
+									value={skillsForThisEnv ? skillsForThisEnv.length : "—"}
 								/>
+								<AgentStatPanel label="Projects" value={projectBindings?.length ?? "—"} />
 							</div>
-						) : null}
-
-						{activeTab === "sessions" ? (
 							<SessionFeed
-								sessions={sessionsPage?.items ?? []}
+								sessions={(sessionsPage?.items ?? []).slice(0, 5)}
 								isLoading={sessionsLoading}
 								emptyMessage="No sessions synced from this agent yet."
+								emptyVariant="inset"
 								showAgent={false}
 								sessionLink={(session) => scopedSessionLink(session.id)}
 							/>
-						) : null}
+						</div>
+					) : null}
 
-						{activeTab === "skills" ? (
-							<SkillCardGrid
-								skills={skillsForThisEnv ?? []}
-								isLoading={skillsLoading}
-								emptyMessage="No skills installed on this agent yet."
-								readOnlySkillCheck={(s) =>
-									!s.project_id || !(writableProjectIds?.has(s.project_id) ?? false)
-								}
-								onUninstall={(skillKey, projectId) =>
-									uninstallSkill.mutate({ skillKey, projectId })
-								}
-								uninstallPending={uninstallSkill.isPending}
-								skillLink={scopedSkillLink}
-							/>
-						) : null}
+					{activeTab === "sessions" ? (
+						<SessionFeed
+							sessions={sessionsPage?.items ?? []}
+							isLoading={sessionsLoading}
+							emptyMessage="No sessions synced from this agent yet."
+							showAgent={false}
+							sessionLink={(session) => scopedSessionLink(session.id)}
+						/>
+					) : null}
 
-						{activeTab === "projects" ? (
-							<AgentProjectsPanel
-								agentId={id}
-								bindings={projectBindings ?? []}
-								projects={projects ?? []}
-								isLoading={projectBindingsLoading}
-								onChanged={() => {
-									queryClient.invalidateQueries({
-										queryKey: ["agent-project-bindings", id],
-									});
-									queryClient.invalidateQueries({ queryKey: ["projects"] });
-								}}
-							/>
-						) : null}
+					{activeTab === "skills" ? (
+						<SkillCardGrid
+							skills={skillsForThisEnv ?? []}
+							isLoading={skillsLoading}
+							emptyMessage="No skills installed on this agent yet."
+							readOnlySkillCheck={(s) =>
+								!s.project_id || !(writableProjectIds?.has(s.project_id) ?? false)
+							}
+							onUninstall={(skillKey, projectId) => uninstallSkill.mutate({ skillKey, projectId })}
+							uninstallPending={uninstallSkill.isPending}
+							skillLink={scopedSkillLink}
+						/>
+					) : null}
 
-						{activeTab === "settings" ? <AgentSettingsPanel environmentId={id} /> : null}
-					</div>
+					{activeTab === "projects" ? (
+						<AgentProjectsPanel
+							agentId={id}
+							bindings={projectBindings ?? []}
+							projects={projects ?? []}
+							isLoading={projectBindingsLoading}
+							onChanged={() => {
+								queryClient.invalidateQueries({
+									queryKey: ["agent-project-bindings", id],
+								});
+								queryClient.invalidateQueries({ queryKey: ["projects"] });
+							}}
+						/>
+					) : null}
+
+					{activeTab === "settings" ? <AgentSettingsPanel environmentId={id} /> : null}
 				</section>
 			) : null}
 		</div>

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -172,7 +172,6 @@ const HOSTED_AGENT_NAV_META: Record<HostedAgentTab, DetailSectionMeta> = {
 		icon: Settings,
 	},
 };
-const HOSTED_AGENT_INNER_WIDTH_CLASS = "mx-auto w-full max-w-4xl";
 const STARTABLE_STATUSES = new Set(["stopped", "failed"]);
 const STOPPABLE_STATUSES = new Set(["running", "ready", "starting"]);
 const RESTARTABLE_STATUSES = new Set(["running", "ready", "starting", "failed"]);
@@ -307,12 +306,7 @@ export function HostedAgentDetail({
 			)}
 		>
 			{isLiveToolTab ? <h1 className="sr-only">{agentTitle}</h1> : null}
-			<section
-				className={cn(
-					isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : HOSTED_AGENT_INNER_WIDTH_CLASS,
-					!isLiveToolTab && "flex flex-col gap-4",
-				)}
-			>
+			<section className={isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : "flex flex-col gap-4"}>
 				{isLiveToolTab ? null : (
 					<PageHeader
 						title={activeTabLabel}
@@ -1222,7 +1216,7 @@ function HostedAgentSettingsTab({
 }) {
 	return (
 		<div className="flex flex-col gap-10">
-			<AgentSettingsPanel environmentId={environmentId} contained={false} />
+			<AgentSettingsPanel environmentId={environmentId} />
 			<ComputeSettingsSections
 				deployment={deployment}
 				isPerformance={isPerformance}

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -771,7 +771,7 @@ export function DeployWizard() {
 				}
 				description="Give your agent a name, tone, language, and timezone."
 			>
-				<div className="flex flex-col gap-4">
+				<div className="flex max-w-2xl flex-col gap-4">
 					<div className="flex flex-col gap-1.5">
 						<label htmlFor="agent-name" className="text-sm text-muted-foreground">
 							Name


### PR DESCRIPTION
## Problem

Console pages (/sessions, /skills, /memories, …) fill the `max-w-7xl` page chassis, but both agent detail views (connected and hosted) wrapped every tab — header included — in an inner centered `max-w-4xl` column. Navigating between a console page and an agent sub-page made the content width jump from ~1280px to ~896px.

## Fix

- Remove the inner centered column from `ConnectedAgentDetail` and `HostedAgentDetail`; all tabs now render at the shared page width, same as every console page.
- Remove `AgentSettingsPanel`'s `contained` self-centering (`mx-auto max-w-4xl`); the hosted caller's `contained={false}` special case goes away with it.
- Cap bare text-input blocks at `max-w-2xl` (agent display-name form, deploy Personalize section) so inputs don't stretch to 1280px; row-style entries and tile grids span the page like console list rows do.
- Write the page-width convention into DESIGN.md: one width container per route (`CENTERED_PAGE_WIDTH_CLASS.page`), no inner centered columns, forms cap blocks not the page.

## Verification

- `biome ci`, `typecheck`, and 253 unit tests pass.
- Width equality is by construction: after this change the only page-level width container in `apps/web/src` is `CENTERED_PAGE_WIDTH_CLASS.page` (swept for `mx-auto` + `max-w-*` wrappers; remaining hits are dialogs and auth/share pages).
- Before/after screenshots kept locally in ~/clawdi-ui-screenshots/ per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)