### PR TITLE
Fix agent tile alignment and skeleton consistency

### DIFF
--- a/apps/web/src/components/dashboard/agent-label.tsx
+++ b/apps/web/src/components/dashboard/agent-label.tsx
@@ -196,9 +196,11 @@ export function AgentSourceBadge({
 
 export function LegacyAgentBadge({
 	compact = false,
+	iconOnly = false,
 	className,
 }: {
 	compact?: boolean;
+	iconOnly?: boolean;
 	className?: string;
 }) {
 	return (
@@ -207,14 +209,18 @@ export function LegacyAgentBadge({
 			title="Managed in the legacy hosted dashboard"
 			className={cn(
 				"shrink-0 whitespace-nowrap border border-warning-muted bg-warning-muted font-medium leading-none text-warning-muted-foreground shadow-sm",
-				compact
-					? "h-5 gap-1 rounded-full px-1.5 text-2xs"
-					: "h-5 gap-1.5 rounded-full px-2 text-2xs",
+				iconOnly
+					? "size-4 justify-center rounded-full p-0"
+					: compact
+						? "h-5 gap-1 rounded-full px-1.5 text-2xs"
+						: "h-5 gap-1.5 rounded-full px-2 text-2xs",
 				className,
 			)}
 		>
-			<History className="size-3.5 text-warning-muted-foreground" />
-			Legacy
+			<History
+				className={cn(iconOnly ? "size-2.5" : "size-3.5", "text-warning-muted-foreground")}
+			/>
+			{iconOnly ? <span className="sr-only">Legacy</span> : "Legacy"}
 		</StatusBadge>
 	);
 }

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -3,7 +3,7 @@
 import type { components } from "@clawdi/shared/api";
 import { Link } from "@tanstack/react-router";
 import { AlertCircle, ArrowUpRight } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import { useState } from "react";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import {
 	AgentSourceBadge,
@@ -21,7 +21,6 @@ import {
 	ENTITY_STRETCHED_LINK_CLASS,
 	EntityHeader,
 } from "@/components/entity-card";
-import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { cn, relativeTime } from "@/lib/utils";
@@ -70,9 +69,9 @@ export interface AgentTile {
 	avatarUrl?: string | null;
 	sortOrder?: number | null;
 	agentType: string | null;
-	/** Optional deployment/source context shown after the runtime disambiguator. */
+	/** Optional deployment/source context for callers that group or label hosted tiles. */
 	contextLabel?: string | null;
-	/** "Synced 2m ago", "Running", "Provisioning…" — already humanized. */
+	/** Humanized fallback when there is no last-seen timestamp ("Running", "Never seen"). */
 	statusLabel: string;
 	/** Used to compute the "N active now" count in the card description. */
 	lastSeenAt?: string | null;
@@ -221,62 +220,64 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 		machine_name: tile.name,
 		agent_type: tile.agentType,
 	});
+	const meta: string[] = [];
+	if (identity.secondaryLabel) meta.push(identity.secondaryLabel);
+	const activityLabel = agentTileActivityLabel(tile);
+	if (activityLabel) meta.push(activityLabel);
+	const metaLabel = meta.join(" · ");
+
 	// `tile.env` adds a sync badge that renders a `<button>`
-	// (clicks open a status dialog). It MUST live in the meta
-	// line under the agent name — same row as `statusLabel` so
-	// the user sees one tidy "agent + state" stack per tile.
-	// But putting that button as a descendant of a wrapping
-	// <Link>/<a> is invalid HTML (nested interactive), trips a
-	// React hydration warning, and on some browsers swallows the
-	// dialog click entirely.
+	// (clicks open a status dialog). Putting that button as a
+	// descendant of a wrapping <Link>/<a> is invalid HTML (nested
+	// interactive), trips a React hydration warning, and on some
+	// browsers swallows the dialog click entirely.
 	//
 	// Stretched-link pattern fixes both: the link sits as an
 	// absolute overlay (`inset-0`) covering the whole tile but
-	// is NOT an ancestor of the meta. The badge wrapper has
+	// is NOT an ancestor of the badge. The badge wrapper has
 	// `relative z-10` so it stacks above the absolute link and
 	// captures its own clicks; clicks anywhere else hit the
-	// link and navigate. Visual layout matches the original
-	// "sync state under the agent name" — pre-fix-attempt the
-	// badge was floated to the trailing edge.
-	const meta: ReactNode[] = [];
-	if (identity.secondaryLabel) meta.push(identity.secondaryLabel);
-	if (tile.contextLabel) meta.push(tile.contextLabel);
-	if (tile.statusLabel) meta.push(tile.statusLabel);
-	if (tile.env) {
-		meta.push(
-			<span className="relative z-10">
-				{/* Legacy hosted envs run a supervised daemon in the v1 runtime
-				 * image — same story as on-clawdi, so they share the hosted copy
-				 * variant. The self-managed copy would tell the user to run CLI
-				 * commands they have no shell for. */}
-				<DaemonStatusBadge
-					env={tile.env}
-					source={onClawdi || legacyHosted ? "on-clawdi" : "self-managed"}
-					manageHref={tile.manageHref}
-				/>
-			</span>,
-		);
-	}
-
-	const trailing = tile.external ? (
-		<ArrowUpRight className="size-3.5 shrink-0 text-muted-foreground" />
+	// link and navigate.
+	const status = tile.env ? (
+		<span className="relative z-10 shrink-0 pt-0.5">
+			{/* Legacy hosted envs run a supervised daemon in the v1 runtime
+			 * image — same story as on-clawdi, so they share the hosted copy
+			 * variant. The self-managed copy would tell the user to run CLI
+			 * commands they have no shell for. */}
+			<DaemonStatusBadge
+				env={tile.env}
+				source={onClawdi || legacyHosted ? "on-clawdi" : "self-managed"}
+				manageHref={tile.manageHref}
+				compact
+			/>
+		</span>
 	) : null;
+
+	const trailing = (
+		<div className="flex shrink-0 items-start gap-2">
+			{status}
+			{tile.external ? (
+				<ArrowUpRight className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+			) : null}
+		</div>
+	);
 
 	const card = (
 		<div
 			className={cn(
 				ENTITY_CARD_BASE,
-				"flex h-full items-center gap-3 transition-colors group-hover:bg-muted/50",
+				"flex h-full items-start gap-3 transition-colors group-hover:bg-muted/50",
 			)}
 		>
 			<EntityHeader
+				align="start"
 				icon={<AgentIcon agent={tile.agentType} size="lg" avatarUrl={tile.avatarUrl} />}
 				title={<span title={tile.name}>{displayMachineName(tile.name)}</span>}
-				meta={meta}
+				meta={metaLabel || undefined}
 				titleAdornment={sourcePill}
 				className="min-w-0 flex-1"
 			/>
-			{trailing}
+			{status || tile.external ? trailing : null}
 		</div>
 	);
 
@@ -314,6 +315,11 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 	);
 }
 
+function agentTileActivityLabel(tile: AgentTile): string | null {
+	if (tile.lastSeenAt) return relativeTime(tile.lastSeenAt);
+	return tile.statusLabel || null;
+}
+
 function compareAgentTiles(a: AgentTile, b: AgentTile): number {
 	if (a.env && b.env) return compareAgentEnvironments(a.env, b.env);
 	const aOrder = a.sortOrder ?? Number.MAX_SAFE_INTEGER;
@@ -326,14 +332,19 @@ function compareAgentTiles(a: AgentTile, b: AgentTile): number {
 
 function TileSkeleton() {
 	return (
-		<Card className="py-0">
-			<CardContent className="flex items-center gap-3 p-4">
-				<Skeleton className="size-8 shrink-0 rounded-md" />
-				<div className="min-w-0 flex-1 space-y-1.5">
-					<Skeleton className="h-4 w-24" />
-					<Skeleton className="h-3 w-32" />
+		<div className={cn(ENTITY_CARD_BASE, "flex h-full items-start gap-3")}>
+			<Skeleton className="size-8 shrink-0 rounded-md" />
+			<div className="min-w-0 flex-1">
+				<div className="flex min-w-0 items-center gap-2">
+					<Skeleton className="h-4 w-28 max-w-[70%]" />
+					<Skeleton className="h-5 w-12 shrink-0 rounded-sm" />
 				</div>
-			</CardContent>
-		</Card>
+				<div className="mt-1 flex min-w-0 items-center gap-2 overflow-hidden">
+					<Skeleton className="h-3 w-14 shrink-0" />
+					<Skeleton className="h-3 w-16 shrink-0" />
+				</div>
+			</div>
+			<Skeleton className="mt-0.5 h-4 w-10 shrink-0" />
+		</div>
 	);
 }

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -13,12 +13,12 @@ import {
 	displayMachineName,
 	LegacyAgentBadge,
 } from "@/components/dashboard/agent-label";
-import { DaemonStatusBadge } from "@/components/dashboard/daemon-status";
+import { type DaemonStatusVisual, daemonStatusVisual } from "@/components/dashboard/daemon-status";
 import { EmptyState } from "@/components/empty-state";
 import {
 	ENTITY_CARD_BASE,
+	ENTITY_CARD_BUTTON_FOCUS_CLASS,
 	ENTITY_GRID_CLASS,
-	ENTITY_STRETCHED_LINK_CLASS,
 	EntityHeader,
 } from "@/components/entity-card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -83,10 +83,8 @@ export interface AgentTile {
 	 * been registered yet. `external` reflects whichever applies. */
 	href: string;
 	external?: boolean;
-	/** Optional hosted remediation target passed into DaemonStatusBadge.
-	 * Points at the in-app hosted agent settings page, where lifecycle ops
-	 * (Restart / Stop / Delete) live. Self-managed tiles leave this
-	 * undefined. */
+	/** Optional hosted remediation target retained for surfaces that open
+	 * status dialogs. Tiles render daemon status as a non-interactive dot. */
 	manageHref?: string;
 	/** Counted in the "N active now" header line; no per-tile indicator rendered. */
 	active?: boolean;
@@ -205,15 +203,13 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 	const legacyHosted = tile.source === "legacy-hosted";
 	// Source pill is an identity adornment, not metadata — it sits
 	// next to the title so it stays glued to the agent name no matter
-	// how the meta wraps. Hosted agents get the same live-sync badge
-	// as self-managed ones; the platform will wire up sync automatically
-	// in a future release, so the surface stays consistent today and
-	// the data reflects reality once that lands.
+	// how the meta wraps. Status is a separate leading dot so the title
+	// and meta keep their width in the narrow overview grid.
 	const source = onClawdi ? "hosted" : "connected";
 	const sourcePill = onClawdi ? (
-		<AgentSourceBadge source={source} />
+		<AgentSourceBadge source={source} iconOnly />
 	) : legacyHosted ? (
-		<LegacyAgentBadge />
+		<LegacyAgentBadge iconOnly />
 	) : null;
 	const identity = agentIdentity({
 		name: tile.name,
@@ -225,99 +221,80 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 	const activityLabel = agentTileActivityLabel(tile);
 	if (activityLabel) meta.push(activityLabel);
 	const metaLabel = meta.join(" · ");
-
-	// `tile.env` adds a sync badge that renders a `<button>`
-	// (clicks open a status dialog). Putting that button as a
-	// descendant of a wrapping <Link>/<a> is invalid HTML (nested
-	// interactive), trips a React hydration warning, and on some
-	// browsers swallows the dialog click entirely.
-	//
-	// Stretched-link pattern fixes both: the link sits as an
-	// absolute overlay (`inset-0`) covering the whole tile but
-	// is NOT an ancestor of the badge. The badge wrapper has
-	// `relative z-10` so it stacks above the absolute link and
-	// captures its own clicks; clicks anywhere else hit the
-	// link and navigate.
-	const status = tile.env ? (
-		<span className="relative z-10 shrink-0 pt-0.5">
-			{/* Legacy hosted envs run a supervised daemon in the v1 runtime
-			 * image — same story as on-clawdi, so they share the hosted copy
-			 * variant. The self-managed copy would tell the user to run CLI
-			 * commands they have no shell for. */}
-			<DaemonStatusBadge
-				env={tile.env}
-				source={onClawdi || legacyHosted ? "on-clawdi" : "self-managed"}
-				manageHref={tile.manageHref}
-				compact
-			/>
-		</span>
-	) : null;
-
-	const trailing = (
-		<div className="flex shrink-0 items-start gap-2">
-			{status}
-			{tile.external ? (
-				<ArrowUpRight className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
-			) : null}
-		</div>
+	const statusVisual = daemonStatusVisual(
+		tile.env,
+		onClawdi || legacyHosted ? "on-clawdi" : "self-managed",
 	);
 
 	const card = (
 		<div
 			className={cn(
 				ENTITY_CARD_BASE,
-				"flex h-full items-start gap-3 transition-colors group-hover:bg-muted/50",
+				"relative flex h-full items-start gap-3 transition-colors group-hover:bg-muted/50",
 			)}
 		>
 			<EntityHeader
 				align="start"
 				icon={<AgentIcon agent={tile.agentType} size="lg" avatarUrl={tile.avatarUrl} />}
-				title={<span title={tile.name}>{displayMachineName(tile.name)}</span>}
+				title={
+					<span className="flex min-w-0 items-center gap-1.5">
+						<AgentStatusDot visual={statusVisual} />
+						<span className="min-w-0 truncate" title={tile.name}>
+							{displayMachineName(tile.name)}
+						</span>
+					</span>
+				}
 				meta={metaLabel || undefined}
 				titleAdornment={sourcePill}
 				className="min-w-0 flex-1"
 			/>
-			{status || tile.external ? trailing : null}
+			{tile.external ? (
+				<ArrowUpRight
+					aria-hidden
+					className="pointer-events-none absolute right-3 top-3.5 size-3.5 text-muted-foreground"
+				/>
+			) : null}
 		</div>
 	);
+	const linkClassName = cn(
+		"group block h-full rounded-lg text-inherit no-underline",
+		ENTITY_CARD_BUTTON_FOCUS_CLASS,
+	);
+	const linkLabel = `Open ${tile.name}. Status: ${statusVisual.label}`;
+
+	if (tile.external) {
+		return (
+			<a
+				href={tile.href}
+				target="_blank"
+				rel="noopener noreferrer"
+				className={linkClassName}
+				aria-label={linkLabel}
+			>
+				{card}
+			</a>
+		);
+	}
 
 	return (
-		// `z-0` is load-bearing: without an explicit z-index on this
-		// `relative` wrapper the browser doesn't create a new stacking
-		// context, so the `relative z-10` children inside `card`
-		// (DaemonStatusBadge button) and the absolute `linkClassName`
-		// overlay all compete in the
-		// PARENT stacking context. Paint order then depends on DOM
-		// sibling order: the overlay link is rendered AFTER the card,
-		// so in the parent context it paints on top of the card's
-		// interactive children — clicks on the badge silently go to
-		// the primary link instead. Adding `z-0`
-		// promotes this wrapper to its own stacking context, isolating
-		// the link overlay (z-auto inside this context) below the
-		// `z-10` children. Standard stretched-link defense.
-		<div className="group relative z-0 h-full">
+		<Link to={tile.href} className={linkClassName} aria-label={linkLabel}>
 			{card}
-			{tile.external ? (
-				<a
-					href={tile.href}
-					target="_blank"
-					rel="noopener noreferrer"
-					className={ENTITY_STRETCHED_LINK_CLASS}
-				>
-					<span className="sr-only">{tile.name}</span>
-				</a>
-			) : (
-				<Link to={tile.href} className={ENTITY_STRETCHED_LINK_CLASS}>
-					<span className="sr-only">{tile.name}</span>
-				</Link>
-			)}
-		</div>
+		</Link>
+	);
+}
+
+function AgentStatusDot({ visual }: { visual: DaemonStatusVisual }) {
+	return (
+		<span title={visual.label} className="inline-flex shrink-0 items-center">
+			<span aria-hidden className={cn("size-1.5 rounded-full", visual.dotClass)} />
+			<span className="sr-only">{visual.label}</span>
+		</span>
 	);
 }
 
 function agentTileActivityLabel(tile: AgentTile): string | null {
 	if (tile.lastSeenAt) return relativeTime(tile.lastSeenAt);
-	return tile.statusLabel || null;
+	return null;
 }
 
 function compareAgentTiles(a: AgentTile, b: AgentTile): number {
@@ -335,16 +312,13 @@ function TileSkeleton() {
 		<div className={cn(ENTITY_CARD_BASE, "flex h-full items-start gap-3")}>
 			<Skeleton className="size-8 shrink-0 rounded-md" />
 			<div className="min-w-0 flex-1">
-				<div className="flex min-w-0 items-center gap-2">
-					<Skeleton className="h-4 w-28 max-w-[70%]" />
-					<Skeleton className="h-5 w-12 shrink-0 rounded-sm" />
+				<div className="flex min-w-0 items-center gap-1.5">
+					<Skeleton className="size-1.5 shrink-0 rounded-full" />
+					<Skeleton className="h-4 min-w-16 flex-1 max-w-28" />
+					<Skeleton className="ml-0.5 size-4 shrink-0 rounded-full" />
 				</div>
-				<div className="mt-1 flex min-w-0 items-center gap-2 overflow-hidden">
-					<Skeleton className="h-3 w-14 shrink-0" />
-					<Skeleton className="h-3 w-16 shrink-0" />
-				</div>
+				<Skeleton className="mt-1 h-3 w-28 max-w-[80%]" />
 			</div>
-			<Skeleton className="mt-0.5 h-4 w-10 shrink-0" />
 		</div>
 	);
 }

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -23,6 +23,7 @@ import {
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
 import { DetailNotFound, DetailPanel, type DetailSectionMeta } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
+import { ENTITY_CARD_BASE } from "@/components/entity-card";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import {
@@ -241,10 +242,7 @@ export function ConnectedAgentDetail({
 			{error ? (
 				<DetailNotFound title="Agent not found" message={errorMessage(error)} />
 			) : isLoading ? (
-				<div className="flex flex-col gap-3 py-2">
-					<Skeleton className="h-6 w-48" />
-					<Skeleton className="h-4 w-64" />
-				</div>
+				<AgentDetailContentSkeleton />
 			) : agent ? (
 				<section className="flex flex-col gap-4">
 					<PageHeader
@@ -319,6 +317,50 @@ export function ConnectedAgentDetail({
 				</section>
 			) : null}
 		</div>
+	);
+}
+
+export function ConnectedAgentDetailSkeleton({ hosted = false }: { hosted?: boolean }) {
+	return (
+		<div
+			data-hosted={hosted ? "true" : undefined}
+			className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6")}
+		>
+			<AgentDetailContentSkeleton />
+		</div>
+	);
+}
+
+function AgentDetailContentSkeleton() {
+	return (
+		<section className="flex flex-col gap-4">
+			<div className="flex flex-col gap-2">
+				<div className="flex items-center gap-2">
+					<Skeleton className="size-4 rounded-sm" />
+					<Skeleton className="h-5 w-28" />
+				</div>
+				<Skeleton className="h-4 w-80 max-w-full" />
+			</div>
+			<div className="grid gap-3 sm:grid-cols-3">
+				{Array.from({ length: 3 }).map((_, index) => (
+					<DetailPanel key={index} className="p-3">
+						<Skeleton className="h-7 w-12" />
+						<Skeleton className="mt-1.5 h-3 w-16" />
+					</DetailPanel>
+				))}
+			</div>
+			<div className="flex flex-col gap-2">
+				{Array.from({ length: 3 }).map((_, index) => (
+					<div key={index} className={cn(ENTITY_CARD_BASE, "flex items-start gap-3")}>
+						<Skeleton className="size-8 shrink-0 rounded-md" />
+						<div className="min-w-0 flex-1">
+							<Skeleton className="h-4 w-4/5" />
+							<Skeleton className="mt-3 h-3 w-1/2" />
+						</div>
+					</div>
+				))}
+			</div>
+		</section>
 	);
 }
 

--- a/apps/web/src/components/dashboard/daemon-status.tsx
+++ b/apps/web/src/components/dashboard/daemon-status.tsx
@@ -121,14 +121,14 @@ const DOT_TONE: Record<DaemonStatusKind, string> = {
 	live: "bg-success ring-2 ring-success/20",
 	"set-up": "border-dashed border border-muted-foreground/50 bg-transparent",
 	errored: "bg-destructive ring-2 ring-destructive/20",
-	paused: "bg-destructive ring-2 ring-destructive/20",
+	paused: "bg-warning ring-2 ring-warning/20",
 };
 
 const TEXT_TONE: Record<DaemonStatusKind, string> = {
 	live: "text-muted-foreground",
 	"set-up": "text-muted-foreground",
 	errored: "text-destructive-muted-foreground font-medium",
-	paused: "text-destructive-muted-foreground font-medium",
+	paused: "text-warning-muted-foreground font-medium",
 };
 
 /** Inline meta item — sits in the SAME meta/sub-line as

--- a/apps/web/src/components/dashboard/daemon-status.tsx
+++ b/apps/web/src/components/dashboard/daemon-status.tsx
@@ -1,13 +1,9 @@
 /**
  * Live-sync indicator for agents on the dashboard.
  *
- * One badge component used everywhere an agent renders — overview
- * tile, agent detail hero meta line, picker. Four states (live /
- * set-up / errored / paused) each get a colored dot + short label
- * in muted tone so the badge reads as one more meta item next to
- * "darwin · last seen 16m ago". Clicking opens `<SyncHelpDialog>`
- * with the install command, last error, restart instructions —
- * whatever's relevant to the current state.
+ * One badge component for compact status surfaces such as the sidebar.
+ * The visual status mapping is exported so non-interactive surfaces can
+ * render the same dot without drifting from this badge.
  */
 
 "use client";
@@ -25,7 +21,18 @@ type Env = components["schemas"]["AgentResponse"];
 
 const FRESH_WINDOW_MS = 90_000;
 
-type Status = "live" | "set-up" | "errored" | "paused";
+export type DaemonStatusKind = "live" | "set-up" | "errored" | "paused";
+export type DaemonStatusSource = "self-managed" | "on-clawdi";
+
+export type DaemonStatusVisual = {
+	kind: DaemonStatusKind;
+	label: string;
+	badgeLabel: string;
+	compactLabel: string;
+	tooltip: string;
+	dotClass: string;
+	textClass: string;
+};
 
 // Tolerate small clock skew between server and browser (server
 // timestamps can land 1-2s ahead of `Date.now()` on a fast NTP
@@ -77,7 +84,8 @@ function isRetryExhaustedError(raw: string | null | undefined): boolean {
 	return typeof raw === "string" && raw.startsWith("retry_exhausted: ");
 }
 
-function classify(env: Env): Status {
+function classify(env: Env | null | undefined): DaemonStatusKind {
+	if (!env) return "set-up";
 	// Treat "never heartbeated" the same as "sync disabled" from
 	// the user's POV — both mean the daemon isn't running on this
 	// machine, both have the same fix (install + run it).
@@ -102,24 +110,24 @@ function classify(env: Env): Status {
 	return "live";
 }
 
-const STATUS_TOOLTIP: Record<Status, string> = {
+const STATUS_TOOLTIP: Record<DaemonStatusKind, string> = {
 	live: "Sync is live.",
 	"set-up": "Run setup to enable sync.",
 	errored: "Last sync failed.",
 	paused: "Daemon isn't checking in.",
 };
 
-const DOT_TONE: Record<Status, string> = {
+const DOT_TONE: Record<DaemonStatusKind, string> = {
 	live: "bg-success ring-2 ring-success/20",
 	"set-up": "border-dashed border border-muted-foreground/50 bg-transparent",
-	errored: "bg-warning ring-2 ring-warning/20",
+	errored: "bg-destructive ring-2 ring-destructive/20",
 	paused: "bg-destructive ring-2 ring-destructive/20",
 };
 
-const TEXT_TONE: Record<Status, string> = {
-	live: "text-foreground",
+const TEXT_TONE: Record<DaemonStatusKind, string> = {
+	live: "text-muted-foreground",
 	"set-up": "text-muted-foreground",
-	errored: "text-warning-muted-foreground font-medium",
+	errored: "text-destructive-muted-foreground font-medium",
 	paused: "text-destructive-muted-foreground font-medium",
 };
 
@@ -132,19 +140,55 @@ const TEXT_TONE: Record<Status, string> = {
  *
  * Click on a non-live state opens the help dialog with the right
  * fix command. Click on `live` is a no-op (informational only). */
-const SHORT_LABEL: Record<Status, string> = {
+const SHORT_LABEL: Record<DaemonStatusKind, string> = {
 	live: "Live sync",
 	"set-up": "Set up live sync",
 	errored: "Sync error",
 	paused: "Sync paused",
 };
 
-const COMPACT_LABEL: Record<Status, string> = {
+const COMPACT_LABEL: Record<DaemonStatusKind, string> = {
 	live: "Live",
 	"set-up": "Setup",
 	errored: "Error",
 	paused: "Paused",
 };
+
+const DOT_LABEL: Record<DaemonStatusKind, string> = {
+	live: "Live",
+	"set-up": "Setup",
+	errored: "Sync error",
+	paused: "Sync paused",
+};
+
+export function daemonStatusVisual(
+	env: Env | null | undefined,
+	source: DaemonStatusSource = "self-managed",
+): DaemonStatusVisual {
+	const kind = classify(env);
+	const isHosted = source === "on-clawdi";
+	const setupLabel = isHosted ? "Sync pending" : DOT_LABEL[kind];
+	const label = kind === "set-up" ? setupLabel : DOT_LABEL[kind];
+	const badgeLabel = isHosted && kind === "set-up" ? "Sync pending" : SHORT_LABEL[kind];
+	const compactLabel = isHosted && kind === "set-up" ? "Pending" : COMPACT_LABEL[kind];
+	const tooltip = isHosted
+		? kind === "set-up"
+			? "Sync activates on the next image rollout."
+			: kind === "paused"
+				? "Pod isn't checking in. Manage it from agent settings."
+				: STATUS_TOOLTIP[kind]
+		: STATUS_TOOLTIP[kind];
+
+	return {
+		kind,
+		label,
+		badgeLabel,
+		compactLabel,
+		tooltip,
+		dotClass: DOT_TONE[kind],
+		textClass: TEXT_TONE[kind],
+	};
+}
 
 export function DaemonStatusBadge({
 	env,
@@ -161,7 +205,7 @@ export function DaemonStatusBadge({
 	 * remediation copy points back at hosted agent settings
 	 * (`manageHref`) instead. Self-managed installs see the
 	 * existing CLI instructions across every state. */
-	source?: "self-managed" | "on-clawdi";
+	source?: DaemonStatusSource;
 	/** When provided on a hosted (`source="on-clawdi"`) tile, errored /
 	 * paused dialog branches render a link to this URL (the hosted
 	 * agent settings page) so the dead-end
@@ -175,41 +219,22 @@ export function DaemonStatusBadge({
 	/** Extra context shown only in the tooltip for crowded layouts. */
 	tooltipDetail?: string;
 }) {
-	const status = classify(env);
-	const isHosted = source === "on-clawdi";
+	const visual = daemonStatusVisual(env, source);
 	const [open, setOpen] = useState(false);
-	const label =
-		isHosted && status === "set-up"
-			? compact
-				? "Pending"
-				: "Sync pending"
-			: compact
-				? COMPACT_LABEL[status]
-				: SHORT_LABEL[status];
+	const label = compact ? visual.compactLabel : visual.badgeLabel;
 	const inner = (
 		<span
 			className={cn(
 				"inline-flex items-center gap-1.5 whitespace-nowrap",
 				compact && "gap-1",
-				status === "live" ? "text-muted-foreground" : TEXT_TONE[status],
+				visual.textClass,
 				"cursor-pointer hover:text-foreground",
 			)}
 		>
-			<span aria-hidden className={cn("inline-block size-1.5 rounded-full", DOT_TONE[status])} />
+			<span aria-hidden className={cn("inline-block size-1.5 rounded-full", visual.dotClass)} />
 			<span className="whitespace-nowrap">{label}</span>
 		</span>
 	);
-	// Hosted users see a tooltip that doesn't promise a CLI fix.
-	// "Run setup" is meaningless when there's nothing to install;
-	// "Daemon isn't checking in" is true but the actionable next
-	// step lives in agent settings, not the user's terminal.
-	const tooltip = isHosted
-		? status === "set-up"
-			? "Sync activates on the next image rollout."
-			: status === "paused"
-				? "Pod isn't checking in. Manage it from agent settings."
-				: STATUS_TOOLTIP[status]
-		: STATUS_TOOLTIP[status];
 	return (
 		<>
 			<Tooltip>
@@ -217,9 +242,8 @@ export function DaemonStatusBadge({
 					<button
 						type="button"
 						onClick={(e) => {
-							// Tile is wrapped in <Link>/<a>; without these
-							// the badge click both navigates AND opens the
-							// dialog over the next page.
+							// Some callers sit next to stretched links; keep
+							// the status dialog click local to the badge.
 							e.preventDefault();
 							e.stopPropagation();
 							setOpen(true);
@@ -238,7 +262,7 @@ export function DaemonStatusBadge({
 				</TooltipTrigger>
 				<TooltipContent side="bottom" className="text-xs">
 					<div className="flex flex-col gap-0.5">
-						<span>{tooltip}</span>
+						<span>{visual.tooltip}</span>
 						{tooltipDetail ? (
 							<span className="font-normal text-muted-foreground">{tooltipDetail}</span>
 						) : null}
@@ -246,21 +270,17 @@ export function DaemonStatusBadge({
 				</TooltipContent>
 			</Tooltip>
 			{/* Dialog content portals into document.body, but React events
-			    bubble through the COMPONENT tree, not the DOM tree — so a
-			    click on the X / backdrop / inside-content still bubbles
-			    up to the wrapping <Link> and navigates. The wrapper here
-			    catches everything before the Link sees it. Without this,
-			    closing the help dialog would silently send the user to
-			    the agent detail page they thought they were dismissing. */}
+				    bubble through the COMPONENT tree, not the DOM tree. The
+				    wrapper here catches propagated dialog clicks before a
+				    nearby stretched link can see them. */}
 			{/* biome-ignore lint/a11y/noStaticElementInteractions: this div
-			    intentionally swallows bubbled events from the portaled
-			    Dialog so the wrapping <Link> doesn't navigate when the
-			    user closes the help modal. It's a propagation barrier,
-			    not a real interactive control. */}
+				    intentionally swallows bubbled events from the portaled
+				    Dialog. It's a propagation barrier, not a real interactive
+				    control. */}
 			<div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
 				<SyncHelpDialog
 					env={env}
-					status={status}
+					status={visual.kind}
 					source={source}
 					manageHref={manageHref}
 					open={open}
@@ -296,8 +316,8 @@ function SyncHelpDialog({
 	onOpenChange,
 }: {
 	env: Env;
-	status: Status;
-	source: "self-managed" | "on-clawdi";
+	status: DaemonStatusKind;
+	source: DaemonStatusSource;
 	manageHref?: string;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -2,10 +2,12 @@
 
 import { useLocation } from "@tanstack/react-router";
 import { ApiErrorPanel } from "@/components/api-error-panel";
-import { ConnectedAgentDetail } from "@/components/dashboard/connected-agent-detail";
+import {
+	ConnectedAgentDetail,
+	ConnectedAgentDetailSkeleton,
+} from "@/components/dashboard/connected-agent-detail";
 import { EmptyState } from "@/components/empty-state";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
-import { Skeleton } from "@/components/ui/skeleton";
 import { isCloudEnvId } from "@/hosted/agent-identity";
 import { useAgentDeployment } from "@/hosted/agents/deployment-hooks";
 import { HostedAgentDetail } from "@/hosted/agents/hosted-agent-detail";
@@ -43,16 +45,7 @@ export function AgentHome({
 	// Hold a skeleton until the deployment lookup settles, so a hosted agent
 	// doesn't flash the connected detail (and fire its queries) first.
 	if (isLoading || (requestedHostedAgent && !deployment && isFetching)) {
-		return (
-			<div
-				data-hosted="true"
-				className={`${CENTERED_PAGE_WIDTH_CLASS.page} space-y-4 px-4 py-2 lg:px-6`}
-			>
-				<Skeleton className="h-10 w-64" />
-				<Skeleton className="h-9 w-full max-w-md" />
-				<Skeleton className="h-48 w-full" />
-			</div>
-		);
+		return <ConnectedAgentDetailSkeleton hosted />;
 	}
 
 	if (error && requestedHostedAgent) {

--- a/apps/web/src/pages/dashboard/agents/agent-detail-client.tsx
+++ b/apps/web/src/pages/dashboard/agents/agent-detail-client.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { lazy, Suspense } from "react";
-import { ConnectedAgentDetail } from "@/components/dashboard/connected-agent-detail";
-import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
-import { Skeleton } from "@/components/ui/skeleton";
+import {
+	ConnectedAgentDetail,
+	ConnectedAgentDetailSkeleton,
+} from "@/components/dashboard/connected-agent-detail";
 import type { AgentSectionId } from "@/lib/agent-routes";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 
@@ -26,11 +27,11 @@ export function AgentDetailClient({
 }) {
 	const hostedAccess = useHostedProductAccess();
 	if (AgentHome && hostedAccess.isLoading) {
-		return <AgentDetailSkeleton />;
+		return <ConnectedAgentDetailSkeleton hosted />;
 	}
 	if (AgentHome && hostedAccess.canUseCloudAgents) {
 		return (
-			<Suspense fallback={<AgentDetailSkeleton />}>
+			<Suspense fallback={<ConnectedAgentDetailSkeleton hosted />}>
 				<AgentHome environmentId={environmentId} section={section} />
 			</Suspense>
 		);
@@ -44,15 +45,5 @@ export function AgentDetailClient({
 			section={section}
 			showSourceBadge={showSourceBadge}
 		/>
-	);
-}
-
-function AgentDetailSkeleton() {
-	return (
-		<div className={`${CENTERED_PAGE_WIDTH_CLASS.page} space-y-4 px-4 py-2 lg:px-6`}>
-			<Skeleton className="h-10 w-64" />
-			<Skeleton className="h-9 w-full max-w-md" />
-			<Skeleton className="h-48 w-full" />
-		</div>
 	);
 }

--- a/apps/web/src/pages/dashboard/deploy/page.tsx
+++ b/apps/web/src/pages/dashboard/deploy/page.tsx
@@ -2,7 +2,10 @@
 
 import { lazy, Suspense } from "react";
 import { HostedProductGate } from "@/components/hosted-product-gate";
-import { HostedRouteSkeleton } from "@/components/hosted-route-skeleton";
+import { PageHeader } from "@/components/page-header";
+import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
 
 const IS_HOSTED_BUILD = import.meta.env.VITE_CLAWDI_HOSTED === "true";
 
@@ -16,10 +19,34 @@ export default function Page() {
 	return (
 		<HostedProductGate fallbackHref="/">
 			{DeployWizard ? (
-				<Suspense fallback={<HostedRouteSkeleton />}>
+				<Suspense fallback={<DeployRouteSkeleton />}>
 					<DeployWizard />
 				</Suspense>
 			) : null}
 		</HostedProductGate>
+	);
+}
+
+function DeployRouteSkeleton() {
+	return (
+		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6")}>
+			<PageHeader title="Deploy an Agent" description="Preparing your compute options…" />
+			{Array.from({ length: 4 }).map((_, sectionIndex) => (
+				<section key={sectionIndex} className="flex flex-col gap-4">
+					<div className="flex max-w-2xl flex-col gap-2">
+						<Skeleton className="h-4 w-24" />
+						<Skeleton className="h-3.5 w-80 max-w-full" />
+						<Skeleton className="h-3.5 w-56 max-w-full" />
+					</div>
+					<div
+						className={cn("grid gap-2", sectionIndex === 0 ? "sm:grid-cols-3" : "sm:grid-cols-2")}
+					>
+						{Array.from({ length: sectionIndex === 0 ? 3 : 2 }).map((_, tileIndex) => (
+							<Skeleton key={tileIndex} className="h-[86px] w-full rounded-lg" />
+						))}
+					</div>
+				</section>
+			))}
+		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- Replace agent tile daemon status badges with compact leading status dots that share `daemonStatusVisual` with `DaemonStatusBadge`, so badge and dot state/color/labels stay in sync.
- Give tile titles and meta full width by removing the trailing status slot, using a single whole-card link, compacting Cloud/Legacy identity adornments, and keeping meta to `runtime · relative-time` only.
- Update the tile skeleton to match the new dot + title + identity adornment anatomy, with no trailing badge placeholder.
- Keep the earlier dashboard skeleton width/shape fixes for connected agent detail, hosted agent lookup fallback, agent detail Suspense fallback, and deploy route lazy fallback without touching connectors, channels, or sidebar-owned files.

## Verification
- `bun run check:fix`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`
- Browser checked the dashboard Overview 3-column grid and `/agents` index with Cloud, Legacy, self-managed, live, paused, error, and setup states in light/dark mode. Confirmed title/meta text does not truncate in the narrow grid, tile contains no nested interactive button, whole-tile click navigates, and status dot title exposes the status text.

## Screenshot References
- `/home/kingsley/clawdi-ui-screenshots/agent-tiles/overview-light.png`
- `/home/kingsley/clawdi-ui-screenshots/agent-tiles/overview-dark.png`
- `/home/kingsley/clawdi-ui-screenshots/agent-tiles/agents-index-light.png`

## Trade-off
- The tile no longer opens the quick daemon status dialog. Troubleshooting and hosted manage actions remain reachable from the agent detail page and the sidebar status badge.

## Notes
- Connectors pages/files, channels pages, and `app-sidebar.tsx` were intentionally left untouched per ownership scope.