### PR TITLE
Full-width sidebar footer bar and faster connectors load

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -101,7 +101,11 @@ import {
 } from "@/lib/agent-routes";
 import { unwrap, useApi } from "@/lib/api";
 import { useCurrentUser } from "@/lib/auth-client";
-import { availableAppsQueryOptions, CONNECTOR_CATALOG_PAGE_SIZE } from "@/lib/connectors-data";
+import {
+	availableAppsQueryOptions,
+	CONNECTOR_CATALOG_PAGE_SIZE,
+	connectionsQueryOptions,
+} from "@/lib/connectors-data";
 import { IS_HOSTED } from "@/lib/hosted";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { legacyHostedDashboardUrl } from "@/lib/legacy-hosted-dashboard";
@@ -376,6 +380,7 @@ function ConsoleResourcesSection({
 				pageSize: CONNECTOR_CATALOG_PAGE_SIZE,
 			}),
 		);
+		void queryClient.prefetchQuery(connectionsQueryOptions(api));
 	}, [api, queryClient]);
 	const resourceItems: SidebarNavItem[] = PROJECT_RESOURCE_GROUPS.flatMap((group) =>
 		projectResourceDefinitionsForGroup(group.id).map((definition) => {
@@ -683,14 +688,16 @@ function FocusNavigationPane({
 					onNavigate={onNavigate}
 				/>
 			</SidebarContent>
-			<SidebarFooter className="border-t px-3 py-2">
-				<GlobalControls
-					user={user}
-					onSearch={onSearch}
-					onSettings={onSettings}
-					settingsOpen={settingsOpen}
-					showTooltips={showTooltips}
-				/>
+			<SidebarFooter className="p-0">
+				<div className="w-full border-border border-t px-3 py-2">
+					<GlobalControls
+						user={user}
+						onSearch={onSearch}
+						onSettings={onSettings}
+						settingsOpen={settingsOpen}
+						showTooltips={showTooltips}
+					/>
+				</div>
 			</SidebarFooter>
 		</div>
 	);

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -74,7 +74,6 @@ import {
 import {
 	Sidebar,
 	SidebarContent,
-	SidebarFooter,
 	SidebarGroup,
 	SidebarGroupContent,
 	SidebarGroupLabel,
@@ -645,12 +644,7 @@ type FocusNavigationPaneProps = {
 	activeAgent: SidebarEnvironment | null;
 	agentsLoaded: boolean;
 	activeSection: AgentSectionId;
-	user: ReturnType<typeof useCurrentUser>["user"];
-	onSearch: () => void;
-	onSettings: () => void;
-	settingsOpen: boolean;
 	onNavigate?: () => void;
-	showTooltips?: boolean;
 };
 
 function FocusNavigationPane({
@@ -661,12 +655,7 @@ function FocusNavigationPane({
 	activeAgent,
 	agentsLoaded,
 	activeSection,
-	user,
-	onSearch,
-	onSettings,
-	settingsOpen,
 	onNavigate,
-	showTooltips = true,
 }: FocusNavigationPaneProps) {
 	return (
 		<div className={cn("flex min-h-0 flex-1 flex-col", className)}>
@@ -677,7 +666,7 @@ function FocusNavigationPane({
 					showCloudFeatures={showCloudFeatures}
 				/>
 			</SidebarHeader>
-			<SidebarContent>
+			<SidebarContent className="pb-[calc(var(--header-height)+0.75rem)]">
 				<SidebarMainNavigation
 					pathname={pathname}
 					showCloudFeatures={showCloudFeatures}
@@ -688,17 +677,6 @@ function FocusNavigationPane({
 					onNavigate={onNavigate}
 				/>
 			</SidebarContent>
-			<SidebarFooter className="p-0">
-				<div className="w-full border-border border-t px-3 py-2">
-					<GlobalControls
-						user={user}
-						onSearch={onSearch}
-						onSettings={onSettings}
-						settingsOpen={settingsOpen}
-						showTooltips={showTooltips}
-					/>
-				</div>
-			</SidebarFooter>
 		</div>
 	);
 }
@@ -1053,7 +1031,7 @@ function FocusRailContent({
 
 			<SidebarSeparator className="mx-auto w-8" />
 
-			<SidebarContent className="items-center gap-2 overflow-x-hidden overflow-y-auto px-2.5 py-2.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+			<SidebarContent className="items-center gap-2 overflow-x-hidden overflow-y-auto px-2.5 pt-2.5 pb-[calc(var(--header-height)+0.75rem)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
 				<SidebarMenu className="items-center">
 					<SidebarMenuItem>
 						<RailFocusButton
@@ -1412,7 +1390,7 @@ function GlobalControls({
 	showTooltips?: boolean;
 }) {
 	return (
-		<SidebarMenu className="flex-row items-center gap-1">
+		<SidebarMenu className="w-full flex-row items-center gap-1">
 			<SidebarMenuItem>
 				<GlobalControlButton label="Search" onClick={onSearch} showTooltip={showTooltips}>
 					<Search />
@@ -1438,6 +1416,45 @@ function GlobalControls({
 	);
 }
 
+function SidebarGlobalControlsBar({
+	user,
+	onSearch,
+	onSettings,
+	settingsOpen,
+	showTooltips = true,
+	mobile = false,
+	collapsed = false,
+}: {
+	user: ReturnType<typeof useCurrentUser>["user"];
+	onSearch: () => void;
+	onSettings: () => void;
+	settingsOpen: boolean;
+	showTooltips?: boolean;
+	mobile?: boolean;
+	collapsed?: boolean;
+}) {
+	if (!mobile && collapsed) return null;
+	return (
+		<div
+			data-sidebar="global-controls"
+			className={cn(
+				"z-30 h-(--header-height) items-center border-border border-t bg-sidebar px-3 text-sidebar-foreground",
+				mobile
+					? "absolute inset-x-0 bottom-0 flex"
+					: "fixed bottom-0 left-0 hidden w-[calc(var(--clawdi-rail-width)+var(--sidebar-width))] md:flex",
+			)}
+		>
+			<GlobalControls
+				user={user}
+				onSearch={onSearch}
+				onSettings={onSettings}
+				settingsOpen={settingsOpen}
+				showTooltips={showTooltips}
+			/>
+		</div>
+	);
+}
+
 export function AppSidebar({
 	className,
 	variant,
@@ -1447,7 +1464,7 @@ export function AppSidebar({
 	const pathname = useLocation({ select: (location) => location.pathname });
 	const { user } = useCurrentUser();
 	const { setOpen: setPaletteOpen } = useCommandPalette();
-	const { isMobile, setOpenMobile } = useSidebar();
+	const { isMobile, setOpenMobile, state: sidebarState } = useSidebar();
 	const api = useApi();
 	const hostedAccess = useHostedProductAccess();
 	const [mounted, setMounted] = useState(false);
@@ -1519,15 +1536,19 @@ export function AppSidebar({
 						activeAgent={activeAgent ?? null}
 						agentsLoaded={agentsLoaded}
 						activeSection={activeSection}
-						user={user}
-						onSearch={openSearch}
-						onSettings={openSettingsFromSidebar}
-						settingsOpen={settingsOpen}
 					/>
 				) : null}
 
 				{isMobile ? (
-					<div className="flex min-h-0 flex-1">
+					<div
+						className="relative flex min-h-0 flex-1"
+						style={
+							{
+								"--clawdi-rail-width": "calc(var(--spacing) * 20)",
+								"--header-height": "calc(var(--spacing) * 12)",
+							} as React.CSSProperties
+						}
+					>
 						<nav
 							className="flex w-(--clawdi-rail-width) shrink-0 flex-col border-r bg-sidebar/95"
 							aria-label="Focus rail"
@@ -1547,16 +1568,28 @@ export function AppSidebar({
 							activeAgent={activeAgent ?? null}
 							agentsLoaded={agentsLoaded}
 							activeSection={activeSection}
+							onNavigate={closeMobileSidebar}
+						/>
+						<SidebarGlobalControlsBar
 							user={user}
 							onSearch={openSearch}
 							onSettings={openSettingsFromSidebar}
 							settingsOpen={settingsOpen}
-							onNavigate={closeMobileSidebar}
 							showTooltips={false}
+							mobile
 						/>
 					</div>
 				) : null}
 			</Sidebar>
+			{!isMobile ? (
+				<SidebarGlobalControlsBar
+					user={user}
+					onSearch={openSearch}
+					onSettings={openSettingsFromSidebar}
+					settingsOpen={settingsOpen}
+					collapsed={sidebarState === "collapsed"}
+				/>
+			) : null}
 			<SettingsDialog
 				open={settingsOpen}
 				section={activeSettingsSection}

--- a/apps/web/src/components/connectors/connector-card.tsx
+++ b/apps/web/src/components/connectors/connector-card.tsx
@@ -1,9 +1,19 @@
 "use client";
 
-import { Check } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { Check, ChevronRight } from "lucide-react";
+import { useCallback } from "react";
 import { ConnectorIcon } from "@/components/connectors/connector-icon";
-import { ENTITY_CARD_BASE, ENTITY_GRID_CLASS, EntityRow } from "@/components/entity-card";
+import {
+	ENTITY_CARD_BASE,
+	ENTITY_GRID_CLASS,
+	ENTITY_STRETCHED_LINK_CLASS,
+	EntityRow,
+} from "@/components/entity-card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useApi } from "@/lib/api";
+import { availableAppQueryOptions, connectorToolsQueryOptions } from "@/lib/connectors-data";
 import { connectorDetailHref } from "@/lib/project-resource-model";
 import { cn } from "@/lib/utils";
 
@@ -20,19 +30,38 @@ export function ConnectorCard({
 	app: { name: string; display_name: string; description: string; logo: string };
 	isConnected?: boolean;
 }) {
+	const api = useApi();
+	const queryClient = useQueryClient();
+	const prefetchDetail = useCallback(() => {
+		void queryClient.prefetchQuery(availableAppQueryOptions(api, app.name));
+		void queryClient.prefetchQuery(connectorToolsQueryOptions(api, app.name));
+	}, [api, app.name, queryClient]);
+	const href = connectorDetailHref(app.name);
+
 	return (
-		<EntityRow
-			href={connectorDetailHref(app.name)}
-			ariaLabel={app.display_name}
-			icon={<ConnectorIcon logo={app.logo} name={app.display_name} size="md" />}
-			title={app.display_name}
-			titleAdornment={
-				isConnected ? (
-					<Check className="size-3.5 shrink-0 text-success" aria-label="Connected" />
-				) : undefined
-			}
-			meta={app.description}
-		/>
+		<div className="group relative z-0 min-w-0">
+			<EntityRow
+				ariaLabel={app.display_name}
+				icon={<ConnectorIcon logo={app.logo} name={app.display_name} size="md" />}
+				title={app.display_name}
+				titleAdornment={
+					isConnected ? (
+						<Check className="size-3.5 shrink-0 text-success" aria-label="Connected" />
+					) : undefined
+				}
+				meta={app.description}
+				trailing={<ChevronRight className="size-4 text-muted-foreground/60" aria-hidden />}
+				className="transition-colors group-hover:bg-muted/50"
+			/>
+			<Link
+				to={href}
+				className={ENTITY_STRETCHED_LINK_CLASS}
+				onMouseEnter={prefetchDetail}
+				onFocus={prefetchDetail}
+			>
+				<span className="sr-only">{app.display_name}</span>
+			</Link>
+		</div>
 	);
 }
 

--- a/apps/web/src/components/connectors/connector-icon.tsx
+++ b/apps/web/src/components/connectors/connector-icon.tsx
@@ -41,6 +41,8 @@ export function ConnectorIcon({
 				<img
 					src={logo}
 					alt=""
+					loading="lazy"
+					decoding="async"
 					className={cn("h-full w-full object-contain", s.pad)}
 					onError={() => setImgError(true)}
 				/>

--- a/apps/web/src/lib/connectors-data.ts
+++ b/apps/web/src/lib/connectors-data.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import type { components } from "@clawdi/shared/api";
 import {
 	keepPreviousData,
 	useMutation,
@@ -7,7 +8,7 @@ import {
 	useQuery,
 	useQueryClient,
 } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { unwrap, useApi } from "@/lib/api";
 
 /**
@@ -31,6 +32,7 @@ export const CONNECTOR_CATALOG_STALE_TIME_MS = 10 * 60 * 1000;
 export const CONNECTOR_CATALOG_GC_TIME_MS = CONNECTOR_CATALOG_STALE_TIME_MS;
 
 type ApiClient = ReturnType<typeof useApi>;
+type ConnectorAvailableApp = components["schemas"]["ConnectorAvailableAppResponse"];
 
 export type AvailableAppsQueryArgs = {
 	page: number;
@@ -59,46 +61,79 @@ export function availableAppsQueryOptions(api: ApiClient, args: AvailableAppsQue
 	};
 }
 
-export function useConnections() {
-	const api = useApi();
-	return useQuery({
-		queryKey: ["connections"],
-		queryFn: async () => unwrap(await api.GET("/v1/connectors")),
-	});
+export function availableAppQueryKey(appName: string) {
+	return ["available-app", appName] as const;
 }
 
-export function useAvailableApp(appName: string) {
-	const api = useApi();
-	return useQuery({
-		queryKey: ["available-app", appName],
+export function availableAppQueryOptions(api: ApiClient, appName: string) {
+	return {
+		queryKey: availableAppQueryKey(appName),
 		queryFn: async () =>
 			unwrap(
 				await api.GET("/v1/connectors/available/{app_name}", {
 					params: { path: { app_name: appName } },
 				}),
 			),
-	});
+		staleTime: CONNECTOR_CATALOG_STALE_TIME_MS,
+		gcTime: CONNECTOR_CATALOG_GC_TIME_MS,
+	};
 }
 
-export function useAvailableApps({ page, pageSize, search }: AvailableAppsQueryArgs) {
-	const api = useApi();
-	return useQuery({
-		...availableAppsQueryOptions(api, { page, pageSize, search }),
-		placeholderData: keepPreviousData,
-	});
+export function connectionsQueryOptions(api: ApiClient) {
+	return {
+		queryKey: ["connections"] as const,
+		queryFn: async () => unwrap(await api.GET("/v1/connectors")),
+	};
 }
 
-export function useConnectorTools(appName: string) {
-	const api = useApi();
-	return useQuery({
-		queryKey: ["connector-tools", appName],
+export function connectorToolsQueryKey(appName: string) {
+	return ["connector-tools", appName] as const;
+}
+
+export function connectorToolsQueryOptions(api: ApiClient, appName: string) {
+	return {
+		queryKey: connectorToolsQueryKey(appName),
 		queryFn: async () =>
 			unwrap(
 				await api.GET("/v1/connectors/{app_name}/tools", {
 					params: { path: { app_name: appName } },
 				}),
 			),
+		staleTime: CONNECTOR_CATALOG_STALE_TIME_MS,
+		gcTime: CONNECTOR_CATALOG_GC_TIME_MS,
+	};
+}
+
+export function useConnections() {
+	const api = useApi();
+	return useQuery(connectionsQueryOptions(api));
+}
+
+export function useAvailableApp(appName: string) {
+	const api = useApi();
+	return useQuery(availableAppQueryOptions(api, appName));
+}
+
+export function useAvailableApps({ page, pageSize, search }: AvailableAppsQueryArgs) {
+	const api = useApi();
+	const queryClient = useQueryClient();
+	const query = useQuery({
+		...availableAppsQueryOptions(api, { page, pageSize, search }),
+		placeholderData: keepPreviousData,
 	});
+	useEffect(() => {
+		const apps = query.data?.items;
+		if (!apps) return;
+		for (const app of apps) {
+			queryClient.setQueryData<ConnectorAvailableApp>(availableAppQueryKey(app.name), app);
+		}
+	}, [query.data?.items, queryClient]);
+	return query;
+}
+
+export function useConnectorTools(appName: string) {
+	const api = useApi();
+	return useQuery(connectorToolsQueryOptions(api, appName));
 }
 
 export function useAuthFields(appName: string, { enabled }: { enabled: boolean }) {
@@ -208,15 +243,7 @@ export function useConnectedAppCards() {
 	);
 
 	const lookup = useQueries({
-		queries: names.map((name) => ({
-			queryKey: ["available-app", name] as const,
-			queryFn: async () =>
-				unwrap(
-					await api.GET("/v1/connectors/available/{app_name}", {
-						params: { path: { app_name: name } },
-					}),
-				),
-		})),
+		queries: names.map((name) => availableAppQueryOptions(api, name)),
 	});
 
 	const data = useMemo(() => lookup.flatMap((q) => (q.data ? [q.data] : [])), [lookup]);

--- a/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
+++ b/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
@@ -139,7 +139,7 @@ function ConnectorDetail({ name }: { name: string }) {
 	const activeConnections =
 		connections?.filter((c) => c.app_name === name && isActiveConnection(c)) ?? [];
 	const isConnected = activeConnections.length > 0;
-	const isLoading = isAppLoading || isConnectionsLoading;
+	const isLoading = isAppLoading;
 
 	const displayName = app?.display_name || formatName(name);
 
@@ -287,14 +287,23 @@ function ConnectorDetail({ name }: { name: string }) {
 				<DashboardSectionHeader
 					icon={Plug}
 					title="Connected accounts"
-					count={usesNoAuth ? "No account required" : `${activeConnections.length} connected`}
+					count={
+						usesNoAuth
+							? "No account required"
+							: isConnectionsLoading
+								? "Checking accounts"
+								: `${activeConnections.length} connected`
+					}
 					description={
 						usesNoAuth
 							? "This connector does not require an account connection."
 							: "Connect an account once. Approved tools become available to agents through this connector."
 					}
 					actions={
-						!usesNoAuth && !isSetupBlocked && activeConnections.length > 0 ? (
+						!usesNoAuth &&
+						!isSetupBlocked &&
+						!isConnectionsLoading &&
+						activeConnections.length > 0 ? (
 							<Button
 								variant="outline"
 								size="sm"
@@ -308,7 +317,7 @@ function ConnectorDetail({ name }: { name: string }) {
 					}
 				/>
 				<div className="p-4">
-					{connectionsQ.error ? (
+					{!usesNoAuth && connectionsQ.error ? (
 						// Without this, a failed connections fetch silently renders
 						// the "No connected accounts yet" empty state — the user
 						// would think they have nothing connected when really we
@@ -320,6 +329,16 @@ function ConnectorDetail({ name }: { name: string }) {
 							}}
 							title="Couldn't load connections"
 						/>
+					) : !usesNoAuth && isConnectionsLoading ? (
+						<div className="rounded-lg border bg-card p-4">
+							<div className="flex items-center gap-3">
+								<Skeleton className="size-9 shrink-0 rounded-lg" />
+								<div className="min-w-0 flex-1 space-y-2">
+									<Skeleton className="h-3.5 w-40" />
+									<Skeleton className="h-3 w-28" />
+								</div>
+							</div>
+						</div>
 					) : usesNoAuth ? (
 						<EmptyState variant="inset" description="No account connection is required." />
 					) : hasUnsupportedAuthType ? (


### PR DESCRIPTION
## Sidebar footer bar

- Moves the global controls out of `FocusNavigationPane` into one sidebar-wide bottom bar.
- Desktop: fixed `bottom-0 left-0`, `height: var(--header-height)`, width `calc(var(--clawdi-rail-width) + var(--sidebar-width))`, `border-t border-border bg-sidebar`, so the top hairline spans the 80px rail plus the 256px pane as one strip.
- Mobile: renders the same controls as one absolute bottom bar inside the sidebar sheet, spanning the sheet rail + pane region. The sheet portal now receives the rail/footer CSS variables directly.
- Keeps existing behavior: Search opens the command palette, Settings opens the settings dialog and active ring, Help/User dropdowns use `side="top"`, and mobile tooltips stay disabled.
- Adds bottom padding to both rail and pane scroll areas so nav content does not scroll under the fixed bar.

Geometry verified in Chromium:

- Desktop bar: left `0`, right `336`, height `48`, top border `1px`; rail is `0-80`, pane container is `80-336`.
- Mobile 390 sheet: bar height `48`, rail `0-80`, sheet `0-320`.
- User menu screenshot: dropdown `data-side="top"`, menu bottom `852.5`, bar top `852`, unclipped.

## Connectors performance

- Reuses shared connector query options with catalog stale/gc windows.
- Seeds each `/connectors/available/{app}` detail query from the paginated catalog response, so a connector opened from the list can render detail metadata from cache.
- Prefetches detail metadata and tools on connector-card hover/focus.
- The sidebar Connectors nav prefetch now warms both the catalog page and the connections query; after the click, the list navigation hits cache and makes no connector API request.
- The detail page no longer blocks first paint on `GET /v1/connectors`; the accounts section renders its own progressive skeleton/error state while the header and metadata paint from the app query/cache.
- Connector logos now use lazy/async image loading.

### Timings

Measured locally with Chromium against the real dev backend on `localhost:8002`. Before = `main`/`fcbbeac9` on port `40642`; after = this branch on port `40643`. Dev servers were warmed before the recorded run. Payload sizes are response body bytes from the browser capture.

| Scenario | Before | After | Dominant endpoint / notes |
| --- | ---: | ---: | --- |
| Cold `/connectors` direct | `1913ms` interactive | `2260ms` interactive | Warmed backend did not reproduce the historical slow catalog list. Before: `GET /v1/connectors` `271.2ms` server, `2B`; `GET /v1/connectors/available?page=1&page_size=24` `39.8ms` server, `8344B`. After: `GET /v1/connectors` `234.1ms` server, `2B`; catalog `44.3ms` server, `8344B`. Remaining cold-list cost in this dev run is frontend/dev render, not the catalog endpoint. |
| Warm `/connectors` via sidebar hover/focus prefetch | `392ms` interactive | `346ms` interactive | Before prefetch warmed only catalog (`32.5ms` server) and nav still started `GET /v1/connectors`. After prefetch warmed catalog (`26.5ms`, `8344B`) and connections (`215.3ms`, `2B`); navigation made no connector API calls. |
| Cold `/connectors/gmail` direct | `3257ms` interactive | `2172ms` interactive | Before was dominated by `GET /v1/connectors/available/gmail` at `1305.8ms` server (`324B`) and also waited on connections. After first paint no longer waits on connections; recorded endpoints: app `237.7ms` server (`324B`), connections `318.0ms` server (`2B`), tools `434.6ms` server (`22223B`, non-critical for header paint). |
| Warm `/connectors/gmail` from loaded list | `1024ms` interactive | `321ms` interactive | Before hover did not prefetch; navigation fetched app (`265.6ms`, `324B`) and tools (`239.8ms`, `22223B`). After list seeding + card hover prefetch fetched tools before click (`362.8ms`, `22223B`); navigation made no connector API calls. |

Backend note: an earlier direct cold probe against this backend returned `GET /v1/connectors/available?page=1&page_size=2` at `1887.1ms` server-side. The warmed recorded UI run above saw `/available?page=1&page_size=24` at `26-44ms` server-side, so the remaining true-cold catalog latency is still a backend/cache follow-up when that Composio catalog cache is cold.

## Verification

- `bun run check:fix`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`

Screenshots are local only and not committed:

- `/home/kingsley/clawdi-ui-screenshots/sidebar-connectors/sidebar-footer-desktop-light.png`
- `/home/kingsley/clawdi-ui-screenshots/sidebar-connectors/sidebar-footer-desktop-dark.png`
- `/home/kingsley/clawdi-ui-screenshots/sidebar-connectors/sidebar-footer-mobile-390.png`
- `/home/kingsley/clawdi-ui-screenshots/sidebar-connectors/sidebar-footer-user-menu-open.png`
- `/home/kingsley/clawdi-ui-screenshots/sidebar-connectors/connectors-page-loaded.png`
