### PR TITLE
Harden channel mutation and confirm hygiene

### DIFF
--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -16,7 +16,7 @@ import {
 	Trash2,
 	TriangleAlert,
 } from "lucide-react";
-import { type ReactNode, useMemo, useState } from "react";
+import { type ReactNode, useMemo, useRef, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import {
@@ -255,7 +255,9 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 						confirmLabel="Remove channel"
 						destructive
 						onConfirm={() =>
-							del.mutate(id, { onSuccess: () => void router.navigate({ href: "/channels" }) })
+							del.mutateAsync(id, {
+								onSuccess: () => void router.navigate({ href: "/channels" }),
+							})
 						}
 					>
 						<Button variant="outline" className="text-muted-foreground hover:text-destructive">
@@ -398,7 +400,7 @@ function AgentsTab({ accountId, accountName }: { accountId: string; accountName:
 										description={<p>It stops sending and receiving on {accountName}.</p>}
 										confirmLabel="Unlink"
 										destructive
-										onConfirm={() => unlink.mutate(link.id)}
+										onConfirm={() => unlink.mutateAsync(link.id)}
 									>
 										<Button
 											variant="ghost"
@@ -555,7 +557,7 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 								description={<p>The WhatsApp credential is revoked. This can't be undone.</p>}
 								confirmLabel="Unlink"
 								destructive
-								onConfirm={() => revoke.mutate(d.credential_id)}
+								onConfirm={() => revoke.mutateAsync(d.credential_id)}
 							>
 								<Button
 									variant="ghost"
@@ -592,12 +594,22 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 	const [agentId, setAgentId] = useState("");
 	const [ttl, setTtl] = useState("900");
 	const [result, setResult] = useState<{ code: string; expires_at: string } | null>(null);
+	const generateLocked = useRef(false);
 	const meta = providerMeta(provider);
+	const isGenerating = create.isPending || generateLocked.current;
 
 	function generate() {
+		if (generateLocked.current) return;
+		generateLocked.current = true;
+		setResult(null);
 		create.mutate(
 			{ agent_id: agentId || undefined, ttl_seconds: Number(ttl) },
-			{ onSuccess: (data) => setResult({ code: data.code, expires_at: data.expires_at }) },
+			{
+				onSuccess: (data) => setResult({ code: data.code, expires_at: data.expires_at }),
+				onSettled: () => {
+					generateLocked.current = false;
+				},
+			},
 		);
 	}
 
@@ -614,7 +626,11 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 					{envs.isLoading ? (
 						<Skeleton className="h-10 w-full rounded-md" />
 					) : (
-						<Select value={agentId} onValueChange={setAgentId} disabled={!!envs.error}>
+						<Select
+							value={agentId}
+							onValueChange={setAgentId}
+							disabled={!!envs.error || isGenerating}
+						>
 							<SelectTrigger id="pair-agent">
 								<SelectValue placeholder="Use linked agent" />
 							</SelectTrigger>
@@ -634,7 +650,7 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 				</div>
 				<div className="flex flex-col gap-1.5">
 					<Label htmlFor="pair-ttl">Expires in</Label>
-					<Select value={ttl} onValueChange={setTtl}>
+					<Select value={ttl} onValueChange={setTtl} disabled={isGenerating}>
 						<SelectTrigger id="pair-ttl">
 							<SelectValue />
 						</SelectTrigger>
@@ -657,9 +673,9 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 				/>
 			) : null}
 
-			<Button onClick={generate} disabled={create.isPending}>
+			<Button onClick={generate} disabled={isGenerating}>
 				<QrCode className="size-4" />
-				{create.isPending ? "Generating…" : "Generate pairing code"}
+				{isGenerating ? "Generating…" : "Generate pairing code"}
 			</Button>
 
 			{result ? (

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Link } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { EntityChoiceCard } from "@/components/entity-card";
 import { EntityIcon } from "@/components/entity-icon";
 import { Button } from "@/components/ui/button";
@@ -60,6 +60,7 @@ export function ConnectBotDialog({
 	const [serverUrl, setServerUrl] = useState("");
 	const [authMode, setAuthMode] = useState<string>("password_query");
 	const [created, setCreated] = useState<ChannelCreated | null>(null);
+	const submitLocked = useRef(false);
 
 	useEffect(() => {
 		if (!open) return;
@@ -122,8 +123,14 @@ export function ConnectBotDialog({
 	}
 
 	function submit() {
-		if (!canSubmit) return;
-		create.mutate(buildBody(), { onSuccess: (data) => setCreated(data) });
+		if (!canSubmit || submitLocked.current) return;
+		submitLocked.current = true;
+		create.mutate(buildBody(), {
+			onSuccess: (data) => setCreated(data),
+			onSettled: () => {
+				submitLocked.current = false;
+			},
+		});
 	}
 
 	return (
@@ -317,7 +324,10 @@ export function ConnectBotDialog({
 							<Button variant="outline" onClick={() => onOpenChange(false)}>
 								Cancel
 							</Button>
-							<Button onClick={submit} disabled={!canSubmit || create.isPending}>
+							<Button
+								onClick={submit}
+								disabled={!canSubmit || create.isPending || submitLocked.current}
+							>
 								{create.isPending ? "Connecting…" : "Connect"}
 							</Button>
 						</DialogFooter>

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
@@ -2,7 +2,7 @@
 
 import type { components } from "@clawdi/shared/api";
 import { CircleCheck } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import {
 	AgentLabel,
@@ -63,6 +63,7 @@ export function LinkAgentDialog({
 	const [agentId, setAgentId] = useState("");
 	const [token, setToken] = useState<string | null>(null);
 	const [linkedNoToken, setLinkedNoToken] = useState(false);
+	const submitLocked = useRef(false);
 
 	useEffect(() => {
 		if (!open) return;
@@ -72,11 +73,15 @@ export function LinkAgentDialog({
 	}, [open]);
 
 	function submit() {
-		if (!agentId) return;
+		if (!agentId || submitLocked.current) return;
+		submitLocked.current = true;
 		link.mutate(agentId, {
 			onSuccess: (data) => {
 				if (data.agent_token) setToken(data.agent_token);
 				else setLinkedNoToken(true);
+			},
+			onSettled: () => {
+				submitLocked.current = false;
 			},
 		});
 	}
@@ -150,7 +155,10 @@ export function LinkAgentDialog({
 							<Button variant="outline" onClick={() => onOpenChange(false)}>
 								Cancel
 							</Button>
-							<Button onClick={submit} disabled={!agentId || link.isPending}>
+							<Button
+								onClick={submit}
+								disabled={!agentId || link.isPending || submitLocked.current}
+							>
 								{link.isPending ? "Linking…" : "Link agent"}
 							</Button>
 						</>


### PR DESCRIPTION
## Summary
- Updated destructive channel confirmations to return mutation promises via `mutateAsync`: delete channel, unlink agent, and revoke WhatsApp device.
- Added local synchronous ref guards to non-confirm channel submissions: connect channel, link agent, and generate pair code.
- Pair code generation now clears the previously displayed code while minting a replacement and disables pair inputs during that request, so a deliberate new generation has one unambiguous displayed result.

## Reasoning
- `ConfirmAction` keeps its in-flight lock only while `onConfirm` is pending; `mutate` returns void, so those destructive actions could unlock immediately.
- `disabled={isPending}` only applies after React rerenders, so the guarded non-confirm triggers now reject same-frame re-entry before a second POST can start.

## Verification
- `bun run check:fix`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`