### PR TITLE
Harden hosted billing money-path (idempotency, plan/term, subscription state)

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -65,20 +65,33 @@ import {
 } from "@/hosted/agents/hosted-terminal-panel";
 import { TermSwitcher } from "@/hosted/billing/components/term-switcher";
 import type {
+	CheckoutRequest,
 	HostedDeployment,
-	Plan,
 	RebindAgentAiProviderRequest,
 } from "@/hosted/billing/contracts";
 import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
 import { billingTermLabel, billingTermSuffix, formatCentsCompact } from "@/hosted/billing/format";
 import {
+	checkoutReturnDeploymentId,
+	checkoutReturnMarker,
 	useCancelSubscription,
 	useCheckout,
+	useCheckoutReturnRefresh,
 	usePlans,
 	usePortal,
 	useResumeSubscription,
 } from "@/hosted/billing/hooks";
-import { planOffers, selectOfferForTerm } from "@/hosted/billing/subscription/subscription-utils";
+import {
+	type IdempotencyAttempt,
+	idempotencyAttemptFor,
+	idempotencyFingerprint,
+	newIdempotencyKey,
+} from "@/hosted/billing/idempotency";
+import {
+	planOffers,
+	resolvePerformancePlan,
+	selectOfferForTerm,
+} from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import {
 	HOSTED_RUNTIMES,
@@ -206,12 +219,6 @@ function LiveNote({ children }: { children: React.ReactNode }) {
 			<Info className="size-3.5 shrink-0" />
 			{children}
 		</p>
-	);
-}
-
-function performancePlan(plans: Plan[] | undefined): Plan | undefined {
-	return (
-		plans?.find((p) => p.slug === "compute_performance") ?? plans?.find((p) => p.price_cents > 0)
 	);
 }
 
@@ -1236,16 +1243,20 @@ function ComputeSettingsSections({
 	runtime: Runtime;
 }) {
 	const router = useRouter();
+	const searchStr = useLocation({ select: (location) => location.searchStr });
 	const lifecycle = useDeploymentLifecycle();
 	const del = useDeleteDeployment();
 	const setEnabled = useSetAgentEnabled();
 	const onboard = useOnboardAgent();
 	const plans = usePlans();
 	const checkout = useCheckout();
+	const refreshCheckoutReturn = useCheckoutReturnRefresh();
 	const portal = usePortal();
 	const cancelSubscription = useCancelSubscription();
 	const resumeSubscription = useResumeSubscription();
 	const runAction = useActionLock();
+	const checkoutAttemptRef = useRef<IdempotencyAttempt | null>(null);
+	const checkoutReturnRef = useRef<string | null>(null);
 	const ci = deployment.config_info;
 	const canStop = STOPPABLE_STATUSES.has(deployment.status);
 	const canStart = STARTABLE_STATUSES.has(deployment.status);
@@ -1260,16 +1271,26 @@ function ComputeSettingsSections({
 		runtimeIsEnabled(ci, runtimeId),
 	).length;
 	const runtimePending = setEnabled.isPending || onboard.isPending;
-	const perfPlan = useMemo(() => performancePlan(plans.data), [plans.data]);
+	const perfPlan = useMemo(() => resolvePerformancePlan(plans.data), [plans.data]);
 	const perfOffers = useMemo(() => (perfPlan ? planOffers(perfPlan) : []), [perfPlan]);
-	const perfOffer = useMemo(
+	const perfOfferSelection = useMemo(
 		() => (perfPlan ? selectOfferForTerm(perfPlan, term) : null),
 		[perfPlan, term],
 	);
-	const currentOffer = useMemo(
+	const perfOffer = perfOfferSelection?.offer ?? null;
+	const selectedBillingTerm = perfOfferSelection?.billingTermMonths ?? term;
+	const currentOfferSelection = useMemo(
 		() => (perfPlan ? selectOfferForTerm(perfPlan, currentBillingTerm) : null),
 		[perfPlan, currentBillingTerm],
 	);
+	const currentOffer =
+		currentOfferSelection?.billingTermMonths === currentBillingTerm
+			? currentOfferSelection.offer
+			: null;
+	const currentPriceCents =
+		typeof currentSubscription?.price_cents === "number"
+			? currentSubscription.price_cents
+			: (currentOffer?.price_cents ?? null);
 	const subscriptionEndsAt =
 		currentSubscription?.cancel_at ?? currentSubscription?.current_period_end ?? null;
 	const subscriptionPeriodLabel = formatShortDate(subscriptionEndsAt);
@@ -1277,9 +1298,10 @@ function ComputeSettingsSections({
 	const canChangeBillingTerm =
 		isPerformance &&
 		!!perfPlan &&
+		!!perfOfferSelection &&
 		!!currentSubscription &&
 		!subscriptionCancelPending &&
-		term !== currentBillingTerm;
+		selectedBillingTerm !== currentBillingTerm;
 	const canUpgrade = !isPerformance && deployment.upgrade_available;
 	const upgradeUnavailableMessage = plans.isLoading
 		? "Checking Performance availability..."
@@ -1297,9 +1319,27 @@ function ComputeSettingsSections({
 	useEffect(() => {
 		setTerm(currentBillingTerm);
 	}, [deployment.id, currentBillingTerm]);
+	useEffect(() => {
+		const marker = checkoutReturnMarker(searchStr);
+		if (!marker || checkoutReturnRef.current === marker) return;
+		checkoutReturnRef.current = marker;
+		void refreshCheckoutReturn().then(() => {
+			const deploymentId = checkoutReturnDeploymentId(searchStr);
+			if (deploymentId && deploymentId !== deployment.id) {
+				void router.navigate({
+					href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"),
+					replace: true,
+				});
+				return;
+			}
+			toast.message("Checkout status refreshed", {
+				description: "We checked your deployments, subscription, and wallet.",
+			});
+		});
+	}, [deployment.id, refreshCheckoutReturn, router, searchStr]);
 
 	async function startPerformanceUpgrade() {
-		if (!perfPlan) {
+		if (!perfPlan || !perfOfferSelection) {
 			toast.error("Performance unavailable", {
 				description: "No Performance compute plan is available right now.",
 			});
@@ -1312,11 +1352,21 @@ function ComputeSettingsSections({
 			return;
 		}
 		try {
-			const result = await checkout.mutateAsync({
+			const body: CheckoutRequest = {
 				plan_slug: perfPlan.slug,
-				billing_term_months: term,
+				billing_term_months: perfOfferSelection.billingTermMonths,
 				ui_mode: "hosted",
 				upgrade_deployment_id: deployment.id,
+			};
+			checkoutAttemptRef.current = idempotencyAttemptFor(
+				checkoutAttemptRef.current,
+				"subscription-upgrade",
+				idempotencyFingerprint(body),
+				newIdempotencyKey,
+			);
+			const result = await checkout.mutateAsync({
+				body,
+				idempotencyKey: checkoutAttemptRef.current.key,
 			});
 			if (redirectToCheckout(result.action_url || result.checkout_url)) {
 				return;
@@ -1335,7 +1385,7 @@ function ComputeSettingsSections({
 			const res = await portal.mutateAsync({
 				deployment_id: deployment.id,
 				flow: "subscription_update_confirm",
-				billing_term_months: term,
+				billing_term_months: selectedBillingTerm,
 			});
 			if (res.url || res.portal_url) {
 				window.location.href = res.url || res.portal_url;
@@ -1477,10 +1527,10 @@ function ComputeSettingsSections({
 						{isPerformance && currentSubscription ? (
 							<p className="mt-2 text-xs text-muted-foreground">
 								{billingTermLabel(currentBillingTerm)}
-								{currentOffer ? (
+								{currentPriceCents !== null ? (
 									<>
 										{" "}
-										· {formatCentsCompact(currentOffer.price_cents)}
+										· {formatCentsCompact(currentPriceCents)}
 										{billingTermSuffix(currentBillingTerm)}
 									</>
 								) : null}
@@ -1509,10 +1559,16 @@ function ComputeSettingsSections({
 						) : null}
 						{!isPerformance ? (
 							<div className="flex w-full flex-col gap-2 lg:w-64">
-								<TermSwitcher offers={perfOffers} value={term} onChange={setTerm} />
+								<TermSwitcher offers={perfOffers} value={selectedBillingTerm} onChange={setTerm} />
 								<Button
 									size="sm"
-									disabled={plans.isLoading || checkout.isPending || !canUpgrade || !perfPlan}
+									disabled={
+										plans.isLoading ||
+										checkout.isPending ||
+										!canUpgrade ||
+										!perfPlan ||
+										!perfOfferSelection
+									}
 									onClick={() => runAction(startPerformanceUpgrade)}
 								>
 									{checkout.isPending ? (
@@ -1528,7 +1584,7 @@ function ComputeSettingsSections({
 							</div>
 						) : (
 							<div className="flex w-full flex-col gap-2 lg:w-72">
-								<TermSwitcher offers={perfOffers} value={term} onChange={setTerm} />
+								<TermSwitcher offers={perfOffers} value={selectedBillingTerm} onChange={setTerm} />
 								<Button
 									type="button"
 									variant="outline"

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -106,8 +106,13 @@ export function useBillingClient() {
 				unwrapDeploy(await api.PUT("/v2/wallet/auto-reload", { body })),
 
 			getPlans: async () => unwrapDeploy(await api.GET("/v2/subscription/plans")),
-			checkout: async (body: CheckoutRequest) =>
-				unwrapDeploy(await api.POST("/v2/subscription/checkout", { body })),
+			checkout: async (body: CheckoutRequest, idempotencyKey: string) =>
+				unwrapDeploy(
+					await api.POST("/v2/subscription/checkout", {
+						body,
+						headers: { "Idempotency-Key": idempotencyKey },
+					}),
+				),
 			cancelSubscription: async (body: ComputeSubscriptionCancelRequest) =>
 				unwrapDeploy(await api.POST("/v2/subscription/cancel", { body })),
 			portal: async (body: PortalRequest) =>
@@ -120,8 +125,13 @@ export function useBillingClient() {
 			getLegacyAgentEnvironments: async () => unwrapDeploy(await api.GET("/agent-environments")),
 
 			listDeployments: async () => unwrapDeploy(await api.GET("/v2/deployments")),
-			createDeployment: async (body: DeployRequest) =>
-				unwrapDeploy(await api.POST("/v2/deployments", { body })),
+			createDeployment: async (body: DeployRequest, idempotencyKey: string) =>
+				unwrapDeploy(
+					await api.POST("/v2/deployments", {
+						body,
+						headers: { "Idempotency-Key": idempotencyKey },
+					}),
+				),
 
 			setAgentEnabled: async (id: string, agentType: string, enabled: boolean) =>
 				unwrapDeploy(

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { isFirstPartyManagedAiProvider } from "@clawdi/shared";
-import { useRouter } from "@tanstack/react-router";
+import { useLocation, useRouter } from "@tanstack/react-router";
 import {
 	CalendarClock,
 	Check,
@@ -12,7 +12,7 @@ import {
 	Sparkles,
 	Zap,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { EntityChoiceCard } from "@/components/entity-card";
@@ -44,18 +44,39 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { TermSwitcher } from "@/hosted/billing/components/term-switcher";
-import type { BillingOffer, DeployRequest, Plan } from "@/hosted/billing/contracts";
+import type {
+	BillingOffer,
+	CheckoutRequest,
+	DeployRequest,
+	Plan,
+} from "@/hosted/billing/contracts";
 import { usesActiveFreeComputeSlot } from "@/hosted/billing/deploy/deploy-model";
 import { buildHostedDeployRequest } from "@/hosted/billing/deploy/deploy-request";
 import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
 import { billingTermSuffix, formatCentsCompact } from "@/hosted/billing/format";
 import {
+	checkoutReturnDeploymentId,
+	checkoutReturnMarker,
 	useCheckout,
+	useCheckoutReturnRefresh,
 	useCreateDeployment,
 	useHostedDeployments,
 	usePlans,
 } from "@/hosted/billing/hooks";
-import { planOffers, selectOfferForTerm } from "@/hosted/billing/subscription/subscription-utils";
+import {
+	type IdempotencyAttempt,
+	idempotencyAttemptFor,
+	idempotencyFingerprint,
+	newIdempotencyKey,
+} from "@/hosted/billing/idempotency";
+import {
+	COMPUTE_FREE_SLUG,
+	COMPUTE_PERFORMANCE_SLUG,
+	planOffers,
+	resolveFreePlan,
+	resolvePerformancePlan,
+	selectOfferForTerm,
+} from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { runtimeBlurb, runtimeDisplayName } from "@/hosted/runtimes";
 import { AddProviderDialog } from "@/hosted/v2/ai-providers/add-provider-dialog";
@@ -119,10 +140,6 @@ function supportedTimezones(): string[] {
 	} catch {
 		return [];
 	}
-}
-
-function activePlan(plans: Plan[] | undefined, paid: boolean): Plan | undefined {
-	return plans?.find((p) => (paid ? p.price_cents > 0 : p.price_cents === 0));
 }
 
 function aiAuthKind(provider: AiProvider): RuntimeAiProviderAuthKind {
@@ -337,13 +354,18 @@ function computeStatusLine({
 
 export function DeployWizard() {
 	const router = useRouter();
+	const searchStr = useLocation({ select: (location) => location.searchStr });
 	const plans = usePlans();
 	const deployments = useHostedDeployments();
 	const aiProviders = useAiProviders();
 	const channels = useChannels();
 	const createDeployment = useCreateDeployment();
 	const checkout = useCheckout();
+	const refreshCheckoutReturn = useCheckoutReturnRefresh();
 	const runAction = useActionLock();
+	const checkoutAttemptRef = useRef<IdempotencyAttempt | null>(null);
+	const deployAttemptRef = useRef<IdempotencyAttempt | null>(null);
+	const checkoutReturnRef = useRef<string | null>(null);
 
 	const [engines, setEngines] = useState<Record<Engine, boolean>>({
 		openclaw: true,
@@ -370,11 +392,18 @@ export function DeployWizard() {
 		return all;
 	}, [timezone]);
 
-	const freePlan = activePlan(plans.data, false);
-	const perfPlan = activePlan(plans.data, true);
+	const freePlan = resolveFreePlan(plans.data);
+	const perfPlan = resolvePerformancePlan(plans.data);
 	const freeSlotUsed = usesActiveFreeComputeSlot(deployments.data);
 	const freeSlotPending = deployments.isLoading;
 	const freeSlotUnavailable = freeSlotUsed || freeSlotPending || !!deployments.error;
+	const perfOfferSelection = useMemo(
+		() => (perfPlan ? selectOfferForTerm(perfPlan, term) : null),
+		[perfPlan, term],
+	);
+	const perfOffer = perfOfferSelection?.offer ?? null;
+	const perfBillingTermMonths = perfOfferSelection?.billingTermMonths ?? term;
+	const perfOffers = perfPlan ? planOffers(perfPlan) : [];
 
 	const dualAllowed = compute === "performance";
 	const enginesSelected = (Object.keys(engines) as Engine[]).filter((e) => engines[e]);
@@ -387,15 +416,47 @@ export function DeployWizard() {
 	);
 	const channelList = channels.data ?? [];
 	const computePlanReady =
-		compute === "performance" ? !!perfPlan : !!freePlan && !freeSlotUnavailable;
+		compute === "performance"
+			? !!perfPlan && !!perfOfferSelection
+			: !!freePlan && !freeSlotUnavailable;
 	const planReady = !plans.isLoading && computePlanReady;
 	const canSubmit = planReady && !submitting;
+
+	useEffect(() => {
+		const marker = checkoutReturnMarker(searchStr);
+		if (!marker || checkoutReturnRef.current === marker) return;
+		checkoutReturnRef.current = marker;
+		void refreshCheckoutReturn().then(() => {
+			const deploymentId = checkoutReturnDeploymentId(searchStr);
+			if (deploymentId) {
+				void router.navigate({
+					href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"),
+					replace: true,
+				});
+				return;
+			}
+			toast.message("Checkout status refreshed", {
+				description: "We checked your deployments, subscription, and wallet.",
+			});
+		});
+	}, [refreshCheckoutReturn, router, searchStr]);
 
 	useEffect(() => {
 		if (compute !== "performance" || !plans.isSuccess || perfPlan) return;
 		setCompute("free");
 		setEngines((prev) => (prev.openclaw && prev.hermes ? { openclaw: true, hermes: false } : prev));
 	}, [compute, plans.isSuccess, perfPlan]);
+
+	useEffect(() => {
+		if (
+			compute !== "performance" ||
+			!perfOfferSelection ||
+			term === perfOfferSelection.billingTermMonths
+		) {
+			return;
+		}
+		setTerm(perfOfferSelection.billingTermMonths);
+	}, [compute, perfOfferSelection, term]);
 
 	// Don't let the selection silently degrade to managed: if the chosen
 	// provider vanishes from a SUCCESSFULLY-loaded list (deleted elsewhere),
@@ -414,12 +475,6 @@ export function DeployWizard() {
 		if (compute !== "free" || !freeSlotUsed || !perfPlan) return;
 		setCompute("performance");
 	}, [compute, freeSlotUsed, perfPlan]);
-
-	const perfOffer = useMemo(
-		() => (perfPlan ? selectOfferForTerm(perfPlan, term) : null),
-		[perfPlan, term],
-	);
-	const perfOffers = perfPlan ? planOffers(perfPlan) : [];
 
 	function toggleEngine(engine: Engine) {
 		setEngines((prev) => {
@@ -465,7 +520,7 @@ export function DeployWizard() {
 
 	function buildDeployRequest(aiFields: Partial<DeployRequest>): DeployRequest {
 		const computePlanSlug: ComputePlanSlug =
-			compute === "performance" ? "compute_performance" : "compute_free";
+			compute === "performance" ? COMPUTE_PERFORMANCE_SLUG : COMPUTE_FREE_SLUG;
 		return buildHostedDeployRequest({
 			computePlanSlug,
 			engines,
@@ -495,12 +550,22 @@ export function DeployWizard() {
 			if (!aiFields) return;
 			const deployConfig = buildDeployRequest(aiFields);
 
-			if (compute === "performance" && perfPlan) {
-				const result = await checkout.mutateAsync({
+			if (compute === "performance" && perfPlan && perfOfferSelection) {
+				const body: CheckoutRequest = {
 					plan_slug: perfPlan.slug,
-					billing_term_months: term,
+					billing_term_months: perfOfferSelection.billingTermMonths,
 					ui_mode: "hosted",
 					deploy_config: deployConfig,
+				};
+				checkoutAttemptRef.current = idempotencyAttemptFor(
+					checkoutAttemptRef.current,
+					"subscription-checkout",
+					idempotencyFingerprint(body),
+					newIdempotencyKey,
+				);
+				const result = await checkout.mutateAsync({
+					body,
+					idempotencyKey: checkoutAttemptRef.current.key,
 				});
 				if (redirectTo(result.action_url || result.checkout_url)) return;
 				toast.error("Couldn't start checkout", {
@@ -509,7 +574,16 @@ export function DeployWizard() {
 				return;
 			}
 
-			const deployment = await createDeployment.mutateAsync(deployConfig);
+			deployAttemptRef.current = idempotencyAttemptFor(
+				deployAttemptRef.current,
+				"deploy",
+				idempotencyFingerprint(deployConfig),
+				newIdempotencyKey,
+			);
+			const deployment = await createDeployment.mutateAsync({
+				body: deployConfig,
+				idempotencyKey: deployAttemptRef.current.key,
+			});
 			toast.success("Deploying your agent", {
 				description: "It’ll appear in your agents in a moment.",
 			});
@@ -749,7 +823,7 @@ export function DeployWizard() {
 					</div>
 					{compute === "performance" && perfOffers.length > 1 ? (
 						<div className="flex flex-col gap-2">
-							<TermSwitcher offers={perfOffers} value={term} onChange={setTerm} />
+							<TermSwitcher offers={perfOffers} value={perfBillingTermMonths} onChange={setTerm} />
 						</div>
 					) : null}
 					<ComputeStatusLine

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -7,12 +7,15 @@ import {
 	useQuery,
 	useQueryClient,
 } from "@tanstack/react-query";
+import { useCallback } from "react";
 import { isDeployApiConfigured, useBillingClient } from "@/hosted/billing/billing-client";
 import type {
 	CheckoutRequest,
+	ComputeSubscriptionActionResult,
 	ComputeSubscriptionCancelRequest,
 	ComputeSubscriptionResumeRequest,
 	DeployRequest,
+	HostedDeployment,
 	PortalRequest,
 	WalletAutoReloadRequest,
 	WalletTopupRequest,
@@ -28,6 +31,75 @@ export const billingKeys = {
 	me: ["billing", "me"] as const,
 	usage: ["billing", "usage"] as const,
 };
+
+type CheckoutMutationVariables = {
+	body: CheckoutRequest;
+	idempotencyKey: string;
+};
+
+type CreateDeploymentMutationVariables = {
+	body: DeployRequest;
+	idempotencyKey: string;
+};
+
+const CHECKOUT_RETURN_DEPLOYMENT_PARAMS = ["deployment_id", "upgrade_deployment_id"] as const;
+const CHECKOUT_RETURN_MARKER_PARAMS = [
+	"session_id",
+	"checkout_session_id",
+	...CHECKOUT_RETURN_DEPLOYMENT_PARAMS,
+	"mockCheckout",
+] as const;
+
+export function checkoutReturnMarker(searchStr: string): string | null {
+	const params = new URLSearchParams(searchStr);
+	const values = CHECKOUT_RETURN_MARKER_PARAMS.flatMap((key) => {
+		const value = params.get(key);
+		return value ? [`${key}=${value}`] : [];
+	});
+	return values.length > 0 ? values.join("&") : null;
+}
+
+export function checkoutReturnDeploymentId(searchStr: string): string | null {
+	const params = new URLSearchParams(searchStr);
+	for (const key of CHECKOUT_RETURN_DEPLOYMENT_PARAMS) {
+		const value = params.get(key);
+		if (value) return value;
+	}
+	return null;
+}
+
+function subscriptionFromAction(
+	previous: HostedDeployment["compute_subscription"] | null | undefined,
+	next: ComputeSubscriptionActionResult,
+): NonNullable<HostedDeployment["compute_subscription"]> {
+	return {
+		...(previous ?? {}),
+		status: next.status,
+		billing_term_months: next.billing_term_months,
+		currency: previous?.currency ?? "usd",
+		cancel_at_period_end: next.cancel_at_period_end,
+		current_period_end: next.current_period_end ?? previous?.current_period_end ?? null,
+		cancel_at: next.cancel_at ?? null,
+	};
+}
+
+function patchDeploymentSubscription(
+	deployments: HostedDeployment[] | undefined,
+	deploymentId: string,
+	next: ComputeSubscriptionActionResult,
+): HostedDeployment[] | undefined {
+	if (!deployments) return deployments;
+	let patched = false;
+	const updated = deployments.map((deployment) => {
+		if (deployment.id !== deploymentId) return deployment;
+		patched = true;
+		return {
+			...deployment,
+			compute_subscription: subscriptionFromAction(deployment.compute_subscription, next),
+		};
+	});
+	return patched ? updated : deployments;
+}
 
 /**
  * Shared billing read: gates fetches on `isDeployApiConfigured()` and applies
@@ -119,8 +191,14 @@ export function usePlans() {
 
 export function useCheckout() {
 	const client = useBillingClient();
+	const qc = useQueryClient();
 	return useMutation({
-		mutationFn: (body: CheckoutRequest) => client.checkout(body),
+		mutationFn: ({ body, idempotencyKey }: CheckoutMutationVariables) =>
+			client.checkout(body, idempotencyKey),
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: billingKeys.deployments });
+			qc.invalidateQueries({ queryKey: billingKeys.wallet });
+		},
 	});
 }
 
@@ -129,7 +207,10 @@ export function useCancelSubscription() {
 	const qc = useQueryClient();
 	return useMutation({
 		mutationFn: (body: ComputeSubscriptionCancelRequest) => client.cancelSubscription(body),
-		onSuccess: () => {
+		onSuccess: (next, body) => {
+			qc.setQueryData<HostedDeployment[]>(billingKeys.deployments, (deployments) =>
+				patchDeploymentSubscription(deployments, body.deployment_id, next),
+			);
 			qc.invalidateQueries({ queryKey: billingKeys.deployments });
 		},
 	});
@@ -147,10 +228,27 @@ export function useResumeSubscription() {
 	const qc = useQueryClient();
 	return useMutation({
 		mutationFn: (body: ComputeSubscriptionResumeRequest) => client.resumeSubscription(body),
-		onSuccess: () => {
+		onSuccess: (next, body) => {
+			qc.setQueryData<HostedDeployment[]>(billingKeys.deployments, (deployments) =>
+				patchDeploymentSubscription(deployments, body.deployment_id, next),
+			);
 			qc.invalidateQueries({ queryKey: billingKeys.deployments });
 		},
 	});
+}
+
+export function useCheckoutReturnRefresh() {
+	const client = useBillingClient();
+	const qc = useQueryClient();
+	return useCallback(async () => {
+		const [deploymentsResult] = await Promise.allSettled([
+			qc.fetchQuery({ queryKey: billingKeys.deployments, queryFn: () => client.listDeployments() }),
+			qc.fetchQuery({ queryKey: billingKeys.wallet, queryFn: () => client.getWallet() }),
+			qc.invalidateQueries({ queryKey: billingKeys.plans }),
+			qc.invalidateQueries({ queryKey: ["agents"] }),
+		]);
+		return deploymentsResult.status === "fulfilled" ? deploymentsResult.value : undefined;
+	}, [client, qc]);
 }
 
 // ── Usage ────────────────────────────────────────────────────────────────────
@@ -185,7 +283,8 @@ export function useCreateDeployment() {
 	const client = useBillingClient();
 	const qc = useQueryClient();
 	return useMutation({
-		mutationFn: (body: DeployRequest) => client.createDeployment(body),
+		mutationFn: ({ body, idempotencyKey }: CreateDeploymentMutationVariables) =>
+			client.createDeployment(body, idempotencyKey),
 		onSuccess: () => {
 			qc.invalidateQueries({ queryKey: billingKeys.deployments });
 			qc.invalidateQueries({ queryKey: ["agents"] });

--- a/apps/web/src/hosted/billing/idempotency.test.ts
+++ b/apps/web/src/hosted/billing/idempotency.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { newIdempotencyKey } from "./idempotency";
+import { idempotencyAttemptFor, idempotencyFingerprint, newIdempotencyKey } from "./idempotency";
 
 describe("newIdempotencyKey", () => {
 	test("carries the caller's prefix", () => {
@@ -15,5 +15,56 @@ describe("newIdempotencyKey", () => {
 	test("is a non-trivial token, not just the bare prefix", () => {
 		const key = newIdempotencyKey("topup");
 		expect(key.length).toBeGreaterThan("topup-".length);
+	});
+});
+
+describe("idempotencyFingerprint", () => {
+	test("is stable for equivalent nested request bodies", () => {
+		expect(
+			idempotencyFingerprint({
+				plan_slug: "compute_performance",
+				deploy_config: { enable_hermes: true, enable_openclaw: true },
+				billing_term_months: 12,
+			}),
+		).toBe(
+			idempotencyFingerprint({
+				billing_term_months: 12,
+				deploy_config: { enable_openclaw: true, enable_hermes: true },
+				plan_slug: "compute_performance",
+			}),
+		);
+	});
+});
+
+describe("idempotencyAttemptFor", () => {
+	test("reuses a key for the same logical attempt", () => {
+		let counter = 0;
+		const mint = (prefix: string) => `${prefix}-${++counter}`;
+		const first = idempotencyAttemptFor(null, "checkout", "same-attempt", mint);
+		const retry = idempotencyAttemptFor(first, "checkout", "same-attempt", mint);
+
+		expect(retry).toBe(first);
+		expect(retry.key).toBe("checkout-1");
+		expect(counter).toBe(1);
+	});
+
+	test("mints a new key when plan, term, or deploy config changes", () => {
+		let counter = 0;
+		const mint = (prefix: string) => `${prefix}-${++counter}`;
+		const monthly = idempotencyFingerprint({
+			plan_slug: "compute_performance",
+			billing_term_months: 1,
+			deploy_config: { assistant_name: "Agent" },
+		});
+		const annual = idempotencyFingerprint({
+			plan_slug: "compute_performance",
+			billing_term_months: 12,
+			deploy_config: { assistant_name: "Agent" },
+		});
+		const first = idempotencyAttemptFor(null, "checkout", monthly, mint);
+		const changed = idempotencyAttemptFor(first, "checkout", annual, mint);
+
+		expect(changed.key).toBe("checkout-2");
+		expect(changed).not.toBe(first);
 	});
 });

--- a/apps/web/src/hosted/billing/idempotency.ts
+++ b/apps/web/src/hosted/billing/idempotency.ts
@@ -12,3 +12,34 @@ export function newIdempotencyKey(prefix: string): string {
 	}
 	return `${prefix}-${Date.now()}`;
 }
+
+export type IdempotencyAttempt = {
+	fingerprint: string;
+	key: string;
+};
+
+type MintIdempotencyKey = (prefix: string) => string;
+
+function stableValue(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(stableValue);
+	if (!value || typeof value !== "object") return value;
+	return Object.fromEntries(
+		Object.entries(value)
+			.sort(([a], [b]) => a.localeCompare(b))
+			.map(([key, next]) => [key, stableValue(next)]),
+	);
+}
+
+export function idempotencyFingerprint(value: unknown): string {
+	return JSON.stringify(stableValue(value));
+}
+
+export function idempotencyAttemptFor(
+	current: IdempotencyAttempt | null,
+	prefix: string,
+	fingerprint: string,
+	mintKey: MintIdempotencyKey = newIdempotencyKey,
+): IdempotencyAttempt {
+	if (current?.fingerprint === fingerprint) return current;
+	return { fingerprint, key: mintKey(prefix) };
+}

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -18,14 +18,19 @@ import { TermSwitcher } from "@/hosted/billing/components/term-switcher";
 import type { Plan } from "@/hosted/billing/contracts";
 import { billingTermSuffix, creditsToUsd, formatCentsCompact } from "@/hosted/billing/format";
 import { usePlans } from "@/hosted/billing/hooks";
-import { planOffers, selectOfferForTerm } from "@/hosted/billing/subscription/subscription-utils";
+import {
+	planOffers,
+	resolveFreePlan,
+	resolvePerformancePlan,
+	selectOfferForTerm,
+} from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { settingsQueryHref } from "@/lib/settings-routes";
 
 function partitionPlans(plans: Plan[]): { free?: Plan; performance?: Plan } {
 	return {
-		free: plans.find((p) => p.price_cents === 0),
-		performance: plans.find((p) => p.price_cents > 0),
+		free: resolveFreePlan(plans),
+		performance: resolvePerformancePlan(plans),
 	};
 }
 
@@ -66,10 +71,12 @@ export function PlanComparison({
 		[plansQuery.data],
 	);
 
-	const performanceOffer = useMemo(
+	const performanceOfferSelection = useMemo(
 		() => (performance ? selectOfferForTerm(performance, term) : null),
 		[performance, term],
 	);
+	const performanceOffer = performanceOfferSelection?.offer ?? null;
+	const performanceBillingTermMonths = performanceOfferSelection?.billingTermMonths ?? term;
 
 	async function startPerformanceCheckout() {
 		if (!performance) return;
@@ -173,7 +180,11 @@ export function PlanComparison({
 						</CardDescription>
 						{performanceOffers.length > 1 ? (
 							<div className="mt-3">
-								<TermSwitcher offers={performanceOffers} value={term} onChange={setTerm} />
+								<TermSwitcher
+									offers={performanceOffers}
+									value={performanceBillingTermMonths}
+									onChange={setTerm}
+								/>
 							</div>
 						) : null}
 					</CardHeader>

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import type { BillingOffer, Plan } from "@/hosted/billing/contracts";
+import {
+	COMPUTE_FREE_SLUG,
+	COMPUTE_PERFORMANCE_SLUG,
+	resolveFreePlan,
+	resolvePerformancePlan,
+	selectOfferForTerm,
+} from "@/hosted/billing/subscription/subscription-utils";
+
+function offer(term: number, priceCents: number): BillingOffer {
+	return {
+		billing_term_months: term,
+		price_cents: priceCents,
+		effective_monthly_price_cents: Math.round(priceCents / term),
+		discount_percent: 0,
+	};
+}
+
+function plan(overrides: Partial<Plan> & Pick<Plan, "slug" | "price_cents">): Plan {
+	const { slug, price_cents: priceCents, ...rest } = overrides;
+	return {
+		slug,
+		name: slug,
+		price_cents: priceCents,
+		points_per_usd: 100,
+		signup_grant_credits: 0,
+		subscription_grant_credits: 0,
+		vcpu: 1,
+		ram_gb: 1,
+		disk_size: 10,
+		...rest,
+	};
+}
+
+describe("compute plan resolvers", () => {
+	test("resolvePerformancePlan prefers the canonical slug before price fallback", () => {
+		const priceFallback = plan({ slug: "legacy_paid", price_cents: 1900 });
+		const canonical = plan({ slug: COMPUTE_PERFORMANCE_SLUG, price_cents: 0 });
+
+		expect(resolvePerformancePlan([priceFallback, canonical])).toBe(canonical);
+	});
+
+	test("resolvePerformancePlan falls back to the first paid plan when the slug is absent", () => {
+		const free = plan({ slug: COMPUTE_FREE_SLUG, price_cents: 0 });
+		const paid = plan({ slug: "paid", price_cents: 1900 });
+
+		expect(resolvePerformancePlan([free, paid])).toBe(paid);
+	});
+
+	test("resolveFreePlan prefers the canonical slug before price fallback", () => {
+		const priceFallback = plan({ slug: "legacy_free", price_cents: 0 });
+		const canonical = plan({ slug: COMPUTE_FREE_SLUG, price_cents: 500 });
+
+		expect(resolveFreePlan([priceFallback, canonical])).toBe(canonical);
+	});
+});
+
+describe("selectOfferForTerm", () => {
+	test("returns the requested offer and canonical term for a valid term", () => {
+		const annual = offer(12, 19_000);
+		const selected = selectOfferForTerm(
+			plan({
+				slug: COMPUTE_PERFORMANCE_SLUG,
+				price_cents: 1900,
+				offers: [offer(1, 1900), annual],
+			}),
+			12,
+		);
+
+		expect(selected.offer).toBe(annual);
+		expect(selected.billingTermMonths).toBe(12);
+	});
+
+	test("falls back to the first offer and returns its canonical term for a missing term", () => {
+		const monthly = offer(1, 1900);
+		const selected = selectOfferForTerm(
+			plan({
+				slug: COMPUTE_PERFORMANCE_SLUG,
+				price_cents: 1900,
+				offers: [monthly, offer(12, 19_000)],
+			}),
+			3,
+		);
+
+		expect(selected.offer).toBe(monthly);
+		expect(selected.billingTermMonths).toBe(1);
+	});
+
+	test("uses a synthetic monthly offer when the plan has empty offers", () => {
+		const selected = selectOfferForTerm(
+			plan({
+				slug: COMPUTE_PERFORMANCE_SLUG,
+				price_cents: 1900,
+				offers: [],
+			}),
+			12,
+		);
+
+		expect(selected).toEqual({
+			offer: {
+				billing_term_months: 1,
+				price_cents: 1900,
+				effective_monthly_price_cents: 1900,
+				discount_percent: 0,
+			},
+			billingTermMonths: 1,
+		});
+	});
+});

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -1,5 +1,27 @@
 import type { BillingOffer, Plan } from "@/hosted/billing/contracts";
 
+export const COMPUTE_FREE_SLUG = "compute_free";
+export const COMPUTE_PERFORMANCE_SLUG = "compute_performance";
+
+export type ResolvedBillingOffer = {
+	offer: BillingOffer;
+	billingTermMonths: number;
+};
+
+export function resolveFreePlan(plans: Plan[] | undefined): Plan | undefined {
+	return (
+		plans?.find((plan) => plan.slug === COMPUTE_FREE_SLUG) ??
+		plans?.find((plan) => plan.price_cents === 0)
+	);
+}
+
+export function resolvePerformancePlan(plans: Plan[] | undefined): Plan | undefined {
+	return (
+		plans?.find((plan) => plan.slug === COMPUTE_PERFORMANCE_SLUG) ??
+		plans?.find((plan) => plan.price_cents > 0)
+	);
+}
+
 /**
  * The plan's offer for a billing term, with a synthetic monthly offer when the
  * backend returns no offers — so callers always have a price to show.
@@ -17,7 +39,8 @@ export function planOffers(plan: Plan): BillingOffer[] {
 			];
 }
 
-export function selectOfferForTerm(plan: Plan, term: number): BillingOffer {
+export function selectOfferForTerm(plan: Plan, term: number): ResolvedBillingOffer {
 	const offers = planOffers(plan);
-	return offers.find((o) => o.billing_term_months === term) ?? offers[0];
+	const offer = offers.find((o) => o.billing_term_months === term) ?? offers[0];
+	return { offer, billingTermMonths: offer.billing_term_months };
 }


### PR DESCRIPTION
## Summary

Hardens the hosted v2 USER-CHARGE flows around subscription checkout, free deployment creation, plan/term resolution, and subscription action state reconciliation.

## Fixes

- R1 - Idempotency + checkout return. Audit refs: `billing-client.ts:98` vs `billing-client.ts:108`, `hooks.ts:120`, `billing-client.ts:122`. Checkout and free deployment creation now send `Idempotency-Key` values minted per logical attempt, stable for same-attempt retries and reset when plan/term/deploy config changes. Deploy and agent subscription-management landing surfaces detect checkout return params (`session_id`, `checkout_session_id`, `deployment_id`, `upgrade_deployment_id`, mock checkout) and refetch deployments/subscription state plus wallet.
- R4 - One plan resolver. Audit refs: `plan-comparison.tsx:25`, `deploy-wizard.tsx:124`, `hosted-agent-detail.tsx:212`. Added shared slug-first `resolvePerformancePlan` / `resolveFreePlan` constants and replaced the three divergent performance-plan selections. Price is only the fallback.
- R7 - Canonical term. Audit refs: `subscription-utils.ts:20`, `deploy-wizard.tsx:501`, `hosted-agent-detail.tsx:1291`. `selectOfferForTerm` now returns `{ offer, billingTermMonths }`; checkout, upgrade, and billing-term change submissions use the resolved canonical term, so displayed price and submitted term cannot diverge on missing terms.
- R8 - Reconcile cancel/resume. Audit refs: `hooks.ts:127`, `hooks.ts:145`, `hosted-agent-detail.tsx:1273`. Cancel/resume mutations patch the affected deployment's embedded `compute_subscription` in query cache before invalidating, so the UI flips immediately and cannot re-fire the stale action.

## Tests

- Added pure-logic coverage for slug-first plan resolution, canonical term resolution including missing/empty offers, and idempotency attempt lifecycle.

## Verification

- `bun run check:fix`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`

## Staging / Stripe Sandbox Manual Verification Required

These cannot be proven in-loop without live Stripe/backend idempotency behavior:

- Complete a real Performance deploy checkout and verify the return URL refreshes deployments/subscription/wallet state without stale re-submit pressure.
- Complete a real Free-to-Performance upgrade checkout from an agent and verify return refresh plus subscription state.
- Retry/back/double-submit the same checkout attempt and confirm Stripe/backend deduplicate to one subscription/charge.
- Retry/back/double-submit the same free deployment request and confirm backend deduplicates to one deployment.
- Cancel and resume a real subscription and confirm the immediate UI patch matches the post-refetch backend state.
- Verify plans with missing requested terms (for example monthly-only or annual-only) show and submit the same canonical billing term.