### PR TITLE
Harden hosted lifecycle (typed status, polling, action safety)

### DIFF
--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -1,12 +1,84 @@
 "use client";
 
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { type QueryClient, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { toast } from "sonner";
 import { useBillingClient } from "@/hosted/billing/billing-client";
 import type { RebindAgentAiProviderRequest } from "@/hosted/billing/contracts";
-import { toastBillingError } from "@/hosted/billing/errors";
+import { BillingApiError, normalizeBillingError, toastBillingError } from "@/hosted/billing/errors";
 import { billingKeys, useHostedDeployments } from "@/hosted/billing/hooks";
+
+const SETTLING_REFRESH_DELAYS_MS = [2_000, 10_000, 20_000, 30_000] as const;
+
+type AiProviderRebindFailure = {
+	agentType: string;
+	error: unknown;
+};
+
+class AiProviderRebindError extends Error {
+	constructor(
+		readonly succeeded: string[],
+		readonly failures: AiProviderRebindFailure[],
+	) {
+		super("AI provider rebind failed for one or more runtimes");
+		this.name = "AiProviderRebindError";
+	}
+}
+
+function invalidateDeploymentSnapshots(qc: QueryClient) {
+	qc.invalidateQueries({ queryKey: billingKeys.deployments });
+	qc.invalidateQueries({ queryKey: ["agents"] });
+}
+
+function scheduleDeploymentSettlingRefresh(qc: QueryClient) {
+	for (const delay of SETTLING_REFRESH_DELAYS_MS) {
+		globalThis.setTimeout(() => {
+			void qc.invalidateQueries({ queryKey: billingKeys.deployments });
+			void qc.invalidateQueries({ queryKey: ["agents"] });
+		}, delay);
+	}
+}
+
+function runtimeLabel(agentType: string): string {
+	if (agentType === "codex") return "Codex";
+	if (agentType === "openclaw") return "OpenClaw";
+	if (agentType === "hermes") return "Hermes";
+	return agentType;
+}
+
+function listRuntimeLabels(agentTypes: readonly string[]): string {
+	return agentTypes.map(runtimeLabel).join(", ");
+}
+
+function isLifecycleStateConflict(error: unknown): boolean {
+	if (!(error instanceof BillingApiError)) return false;
+	return (
+		error.status === 409 ||
+		/invalid[_\s-]?state|state conflict|conflict|not (running|stopped|ready)|already/i.test(
+			error.detail,
+		)
+	);
+}
+
+function toastAiProviderRebindError(error: unknown) {
+	if (!(error instanceof AiProviderRebindError)) {
+		toastBillingError("Couldn't update provider")(error);
+		return;
+	}
+
+	const failed = listRuntimeLabels(error.failures.map((failure) => failure.agentType));
+	const reason = normalizeBillingError(error.failures[0]?.error);
+	if (error.succeeded.length > 0) {
+		toast.error("Provider updated for some runtimes", {
+			description: `Couldn't update ${failed}. ${reason}`,
+		});
+		return;
+	}
+
+	toast.error("Couldn't update provider", {
+		description: `Couldn't update ${failed}. ${reason}`,
+	});
+}
 
 /**
  * Resolve the hosted deployment that backs a cloud-api environment, joined via
@@ -57,8 +129,8 @@ export function useSetAgentEnabled() {
 		mutationFn: (vars: { id: string; agentType: string; enabled: boolean }) =>
 			client.setAgentEnabled(vars.id, vars.agentType, vars.enabled),
 		onSuccess: (_d, vars) => {
-			qc.invalidateQueries({ queryKey: billingKeys.deployments });
-			qc.invalidateQueries({ queryKey: ["agents"] });
+			invalidateDeploymentSnapshots(qc);
+			scheduleDeploymentSettlingRefresh(qc);
 			toast.success(vars.enabled ? "Runtime enabled" : "Runtime disabled");
 		},
 		onError: toastBillingError("Couldn't update runtime"),
@@ -75,17 +147,29 @@ export function useSetAgentAiProvider() {
 			agentTypes: string[];
 			body: RebindAgentAiProviderRequest;
 		}) => {
+			const succeeded: string[] = [];
+			const failures: AiProviderRebindFailure[] = [];
 			let last: Awaited<ReturnType<typeof client.setAgentAiProvider>> | undefined;
 			for (const agentType of vars.agentTypes) {
-				last = await client.setAgentAiProvider(vars.id, agentType, vars.body);
+				try {
+					last = await client.setAgentAiProvider(vars.id, agentType, vars.body);
+					succeeded.push(agentType);
+				} catch (error) {
+					failures.push({ agentType, error });
+				}
+			}
+			if (failures.length > 0) {
+				throw new AiProviderRebindError(succeeded, failures);
 			}
 			return last;
 		},
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: billingKeys.deployments });
-			qc.invalidateQueries({ queryKey: ["agents"] });
+			invalidateDeploymentSnapshots(qc);
 		},
-		onError: toastBillingError("Couldn't update provider"),
+		onError: (error) => {
+			invalidateDeploymentSnapshots(qc);
+			toastAiProviderRebindError(error);
+		},
 	});
 }
 
@@ -96,8 +180,8 @@ export function useOnboardAgent() {
 		mutationFn: (vars: { id: string; agentType: string }) =>
 			client.onboardAgent(vars.id, vars.agentType),
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: billingKeys.deployments });
-			qc.invalidateQueries({ queryKey: ["agents"] });
+			invalidateDeploymentSnapshots(qc);
+			scheduleDeploymentSettlingRefresh(qc);
 			toast.success("Runtime added");
 		},
 		onError: toastBillingError("Couldn't add runtime"),
@@ -122,17 +206,27 @@ export function useDeploymentLifecycle() {
 			return client.startDeployment(vars.id);
 		},
 		onSuccess: (_d, vars) => {
-			qc.invalidateQueries({ queryKey: billingKeys.deployments });
-			qc.invalidateQueries({ queryKey: ["agents"] });
+			invalidateDeploymentSnapshots(qc);
+			scheduleDeploymentSettlingRefresh(qc);
 			const msg =
 				vars.action === "restart"
 					? "Restarting agent…"
 					: vars.action === "stop"
-						? "Agent stopped"
-						: "Agent started";
+						? "Stopping agent…"
+						: "Starting agent…";
 			toast.success(msg);
 		},
-		onError: toastBillingError("Action failed"),
+		onError: (error) => {
+			qc.invalidateQueries({ queryKey: billingKeys.deployments });
+			if (isLifecycleStateConflict(error)) {
+				toast.error("Agent state changed", {
+					description:
+						"The deployment state changed before the action ran. We refreshed the controls.",
+				});
+				return;
+			}
+			toast.error("Couldn't update lifecycle", { description: normalizeBillingError(error) });
+		},
 	});
 }
 
@@ -142,8 +236,8 @@ export function useDeleteDeployment() {
 	return useMutation({
 		mutationFn: (id: string) => client.deleteDeployment(id),
 		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: billingKeys.deployments });
-			qc.invalidateQueries({ queryKey: ["agents"] });
+			invalidateDeploymentSnapshots(qc);
+			scheduleDeploymentSettlingRefresh(qc);
 		},
 		onError: toastBillingError("Couldn't delete agent"),
 	});

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CLAWDI_MANAGED_PROVIDER_IDS, isFirstPartyManagedAiProvider } from "@clawdi/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useLocation, useRouter } from "@tanstack/react-router";
 import {
@@ -94,6 +95,14 @@ import {
 } from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import {
+	canRestart as canRestartDeployment,
+	canStart as canStartDeployment,
+	canStop as canStopDeployment,
+	deploymentStatusLabel,
+	isRunningStatus,
+	parseDeploymentStatus,
+} from "@/hosted/deployment-status";
+import {
 	HOSTED_RUNTIMES,
 	type HostedRuntime,
 	OPTIONAL_HOSTED_RUNTIMES,
@@ -185,24 +194,11 @@ const HOSTED_AGENT_NAV_META: Record<HostedAgentTab, DetailSectionMeta> = {
 		icon: Settings,
 	},
 };
-const STARTABLE_STATUSES = new Set(["stopped", "failed"]);
-const STOPPABLE_STATUSES = new Set(["running", "ready", "starting"]);
-const RESTARTABLE_STATUSES = new Set(["running", "ready", "starting", "failed"]);
-
 /** Map an AI provider's auth type to the deploy `ai_provider_auth_kind`. */
 function aiAuthKind(provider: { auth: { type: string } }): "api_key" | "codex_oauth" {
 	return provider.auth.type === "agent_profile" || provider.auth.type === "oauth_profile"
 		? "codex_oauth"
 		: "api_key";
-}
-
-function statusLabel(status: string): string {
-	if (status === "running" || status === "ready") return "Running";
-	if (status === "provisioning") return "Provisioning";
-	if (status === "starting") return "Starting";
-	if (status === "stopped") return "Stopped";
-	if (status === "failed" || status === "error") return "Failed";
-	return status;
 }
 
 function parseHostedAgentTab(value: AgentSectionId | string | null): HostedAgentTab | null {
@@ -409,10 +405,11 @@ function OverviewTab({
 	const ci = deployment.config_info;
 	const binding = ci?.ai_provider_bindings?.[runtime];
 	const model = binding?.primary_model ?? ci?.primary_model ?? "Managed default";
+	const status = parseDeploymentStatus(deployment.status);
 	return (
 		<div className="flex flex-col gap-5">
 			<div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-				<StatCard label="Status" value={statusLabel(deployment.status)} />
+				<StatCard label="Status" value={deploymentStatusLabel(status)} />
 				<StatCard label="Compute" value={isPerformance ? "Performance" : "Free"} />
 				<StatCard label="Model" value={model} />
 				<StatCard
@@ -452,7 +449,8 @@ function OverviewTab({
  * the full-screen link is the alternate path.
  */
 function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; runtime: Runtime }) {
-	const isRunning = deployment.status === "running" || deployment.status === "ready";
+	const status = parseDeploymentStatus(deployment.status);
+	const isRunning = isRunningStatus(status);
 	const label = runtimeDisplayName(runtime);
 	const browserUiLabel = runtimeBrowserUiLabel(runtime);
 	const url = runtimeConsoleUrl(deployment, runtime);
@@ -463,9 +461,7 @@ function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; run
 			<EmptyState
 				icon={MonitorPlay}
 				title="Runtime UI available once running"
-				description={`The live ${browserUiLabel} opens here as soon as the agent is running — currently ${statusLabel(
-					deployment.status,
-				).toLowerCase()}.`}
+				description={`The live ${browserUiLabel} opens here as soon as the agent is running — currently ${deploymentStatusLabel(status).toLowerCase()}.`}
 			/>
 		);
 	}
@@ -592,7 +588,8 @@ function TerminalStatusIndicator({ status }: { status: HostedTerminalStatus }) {
 }
 
 function TerminalTab({ deployment }: { deployment: HostedDeployment }) {
-	const isRunning = deployment.status === "running" || deployment.status === "ready";
+	const status = parseDeploymentStatus(deployment.status);
+	const isRunning = isRunningStatus(status);
 	const label = deploymentDisplayName(deployment.name);
 	const terminal = useCreateTerminalSession();
 	const { isPending: isOpeningTerminal, mutateAsync: createTerminalSession } = terminal;
@@ -661,9 +658,7 @@ function TerminalTab({ deployment }: { deployment: HostedDeployment }) {
 			<EmptyState
 				icon={TerminalSquare}
 				title="Terminal available once running"
-				description={`A deployment shell can be opened when the hosted compute is running. Current status: ${statusLabel(
-					deployment.status,
-				).toLowerCase()}.`}
+				description={`A deployment shell can be opened when the hosted compute is running. Current status: ${deploymentStatusLabel(status).toLowerCase()}.`}
 			/>
 		);
 	}
@@ -779,15 +774,17 @@ function AiProviderTab({
 	// its own provider in ai_provider_bindings[runtime].
 	const binding = ci?.ai_provider_bindings?.[runtime];
 	const boundRef = binding?.provider_id ?? ci?.ai_provider_id ?? null;
+	const boundProvider = boundRef
+		? (list.find((p) => p.id === boundRef || p.provider_id === boundRef) ?? null)
+		: null;
 	const currentManaged =
 		!boundRef ||
-		boundRef === "clawdi-managed" ||
+		CLAWDI_MANAGED_PROVIDER_IDS.has(boundRef) ||
+		(boundProvider ? isFirstPartyManagedAiProvider(boundProvider) : false) ||
 		(binding?.auth_kind ?? ci?.ai_provider_auth_kind) === "managed";
 	// The binding stores the provider's id (UUID); map it back to the slug the
 	// select uses as its value.
-	const inUseSlug = currentManaged
-		? null
-		: (list.find((p) => p.id === boundRef || p.provider_id === boundRef)?.provider_id ?? null);
+	const inUseSlug = currentManaged ? null : (boundProvider?.provider_id ?? null);
 	const unresolvedProviderRef = !currentManaged && !inUseSlug ? boundRef : null;
 	const showUnresolvedProvider =
 		Boolean(unresolvedProviderRef) && !providers.isLoading && !providers.error;
@@ -1258,10 +1255,11 @@ function ComputeSettingsSections({
 	const checkoutAttemptRef = useRef<IdempotencyAttempt | null>(null);
 	const checkoutReturnRef = useRef<string | null>(null);
 	const ci = deployment.config_info;
-	const canStop = STOPPABLE_STATUSES.has(deployment.status);
-	const canStart = STARTABLE_STATUSES.has(deployment.status);
-	const canRestart = RESTARTABLE_STATUSES.has(deployment.status);
-	const primaryLifecycleAction = canStop ? "stop" : "start";
+	const deploymentStatus = parseDeploymentStatus(deployment.status);
+	const canStop = canStopDeployment(deploymentStatus);
+	const canStart = canStartDeployment(deploymentStatus);
+	const canRestart = canRestartDeployment(deploymentStatus);
+	const primaryLifecycleAction: "stop" | "start" = canStop ? "stop" : "start";
 	const canRunPrimaryLifecycleAction = canStop || canStart;
 	const currentSubscription = deployment.compute_subscription;
 	const currentBillingTerm = currentSubscription?.billing_term_months ?? 1;
@@ -1270,6 +1268,10 @@ function ComputeSettingsSections({
 	const optionalEnabledCount = OPTIONAL_HOSTED_RUNTIMES.filter((runtimeId) =>
 		runtimeIsEnabled(ci, runtimeId),
 	).length;
+	const enabledRuntimeCount = RUNTIMES.filter((runtimeItem) =>
+		runtimeIsEnabled(ci, runtimeItem.id),
+	).length;
+	const restartNeedsConfirmation = enabledRuntimeCount > 1;
 	const runtimePending = setEnabled.isPending || onboard.isPending;
 	const perfPlan = useMemo(() => resolvePerformancePlan(plans.data), [plans.data]);
 	const perfOffers = useMemo(() => (perfPlan ? planOffers(perfPlan) : []), [perfPlan]);
@@ -1307,7 +1309,7 @@ function ComputeSettingsSections({
 		? "Checking Performance availability..."
 		: !perfPlan
 			? "Performance compute is unavailable right now."
-			: deployment.status === "running" || deployment.status === "stopped"
+			: isRunningStatus(deploymentStatus) || deploymentStatus.kind === "stopped"
 				? "An upgrade may already be pending for this Free agent."
 				: "Upgrade is available once this Free agent is running or stopped.";
 	useEffect(() => {
@@ -1421,6 +1423,23 @@ function ComputeSettingsSections({
 		}
 	}
 
+	async function setRuntimeEnabled(agentType: Runtime, enabled: boolean) {
+		await setEnabled.mutateAsync({ id: deployment.id, agentType, enabled });
+	}
+
+	async function addRuntime(agentType: Runtime) {
+		await onboard.mutateAsync({ id: deployment.id, agentType });
+	}
+
+	async function runLifecycleAction(action: "restart" | "stop" | "start") {
+		await lifecycle.mutateAsync({ id: deployment.id, action });
+	}
+
+	async function deleteCompute() {
+		await del.mutateAsync(deployment.id);
+		await router.navigate({ href: "/" });
+	}
+
 	return (
 		<div className="flex flex-col gap-9">
 			<SettingsSection
@@ -1471,7 +1490,7 @@ function ComputeSettingsSections({
 													checked={enabled}
 													disabled={runtimePending || blockedByPlan}
 													onCheckedChange={(next) =>
-														setEnabled.mutate({ id: deployment.id, agentType: r.id, enabled: next })
+														void runAction(() => setRuntimeEnabled(r.id, next))
 													}
 													aria-label={`Toggle ${r.label}`}
 												/>
@@ -1485,7 +1504,7 @@ function ComputeSettingsSections({
 															? "Performance compute is required to run both runtimes"
 															: undefined
 													}
-													onClick={() => onboard.mutate({ id: deployment.id, agentType: r.id })}
+													onClick={() => void runAction(() => addRuntime(r.id))}
 												>
 													{onboard.isPending && onboard.variables?.agentType === r.id ? (
 														<Spinner className="size-3.5" />
@@ -1658,30 +1677,73 @@ function ComputeSettingsSections({
 				description="Restart, stop, or start the whole hosted compute."
 			>
 				<div className="flex flex-wrap gap-2.5">
-					<Button
-						variant="outline"
-						size="sm"
-						disabled={lifecycle.isPending || !canRestart}
-						onClick={() => lifecycle.mutate({ id: deployment.id, action: "restart" })}
-					>
-						{lifecycle.isPending && lifecycle.variables?.action === "restart" ? (
-							<Spinner className="size-3.5" />
-						) : (
-							<RefreshCw className="size-3.5" />
-						)}
-						Restart
-					</Button>
-					<Button
-						variant="outline"
-						size="sm"
-						disabled={lifecycle.isPending || !canRunPrimaryLifecycleAction}
-						onClick={() => lifecycle.mutate({ id: deployment.id, action: primaryLifecycleAction })}
-					>
-						{lifecycle.isPending && lifecycle.variables?.action === primaryLifecycleAction ? (
-							<Spinner className="size-3.5" />
-						) : null}
-						{canStop ? "Stop" : "Start"}
-					</Button>
+					{restartNeedsConfirmation ? (
+						<ConfirmAction
+							title="Restart shared compute?"
+							description={<p>This restarts every enabled runtime on this compute.</p>}
+							confirmLabel="Restart compute"
+							onConfirm={() => runAction(() => runLifecycleAction("restart"))}
+						>
+							<Button variant="outline" size="sm" disabled={lifecycle.isPending || !canRestart}>
+								{lifecycle.isPending && lifecycle.variables?.action === "restart" ? (
+									<Spinner className="size-3.5" />
+								) : (
+									<RefreshCw className="size-3.5" />
+								)}
+								Restart
+							</Button>
+						</ConfirmAction>
+					) : (
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={lifecycle.isPending || !canRestart}
+							onClick={() => void runAction(() => runLifecycleAction("restart"))}
+						>
+							{lifecycle.isPending && lifecycle.variables?.action === "restart" ? (
+								<Spinner className="size-3.5" />
+							) : (
+								<RefreshCw className="size-3.5" />
+							)}
+							Restart
+						</Button>
+					)}
+					{canStop ? (
+						<ConfirmAction
+							title="Stop shared compute?"
+							description={
+								<p>
+									This stops the shared compute for every enabled runtime. Runtime UIs, terminal
+									access, sessions, and channels pause until you start it again.
+								</p>
+							}
+							confirmLabel="Stop compute"
+							onConfirm={() => runAction(() => runLifecycleAction("stop"))}
+						>
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={lifecycle.isPending || !canRunPrimaryLifecycleAction}
+							>
+								{lifecycle.isPending && lifecycle.variables?.action === "stop" ? (
+									<Spinner className="size-3.5" />
+								) : null}
+								Stop
+							</Button>
+						</ConfirmAction>
+					) : (
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={lifecycle.isPending || !canRunPrimaryLifecycleAction}
+							onClick={() => void runAction(() => runLifecycleAction(primaryLifecycleAction))}
+						>
+							{lifecycle.isPending && lifecycle.variables?.action === primaryLifecycleAction ? (
+								<Spinner className="size-3.5" />
+							) : null}
+							Start
+						</Button>
+					)}
 				</div>
 			</SettingsSection>
 
@@ -1704,9 +1766,7 @@ function ComputeSettingsSections({
 						}
 						confirmLabel="Delete compute"
 						destructive
-						onConfirm={() =>
-							del.mutate(deployment.id, { onSuccess: () => void router.navigate({ href: "/" }) })
-						}
+						onConfirm={() => runAction(deleteCompute)}
 					>
 						<Button
 							variant="outline"

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -21,6 +21,7 @@ import type {
 	WalletTopupRequest,
 } from "@/hosted/billing/contracts";
 import { billingQueryRetry } from "@/hosted/billing/errors";
+import { shouldPollDeployments } from "@/hosted/deployment-status";
 
 export const billingKeys = {
 	wallet: ["billing", "wallet"] as const,
@@ -263,19 +264,13 @@ export function useUsage() {
 
 // ── Deployments ────────────────────────────────────────────────────────────────
 
-function hasTransientDeployment(items: { status: string }[] | undefined): boolean {
-	return (items ?? []).some(
-		(d) => d.status === "pending" || d.status === "provisioning" || d.status === "starting",
-	);
-}
-
 export function useHostedDeployments({ enabled = true }: { enabled?: boolean } = {}) {
 	const client = useBillingClient();
 	return useBillingQuery({
 		queryKey: billingKeys.deployments,
 		enabled: isDeployApiConfigured() && enabled,
 		queryFn: () => client.listDeployments(),
-		refetchInterval: (q) => (hasTransientDeployment(q.state.data) ? 10_000 : false),
+		refetchInterval: (q) => (shouldPollDeployments(q.state.data) ? 10_000 : false),
 	});
 }
 

--- a/apps/web/src/hosted/deployment-status.test.ts
+++ b/apps/web/src/hosted/deployment-status.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import {
+	canRestart,
+	canStart,
+	canStop,
+	deploymentStatusLabel,
+	deploymentStatusTone,
+	isRunningStatus,
+	isTerminalStatus,
+	isTransitionalStatus,
+	KNOWN_DEPLOYMENT_STATUSES,
+	parseDeploymentStatus,
+	shouldPollDeployments,
+} from "@/hosted/deployment-status";
+
+describe("DeploymentStatus", () => {
+	test("normalizes known deploy-api statuses", () => {
+		for (const raw of KNOWN_DEPLOYMENT_STATUSES) {
+			const status = parseDeploymentStatus(raw.toUpperCase());
+			expect(status).toEqual({ kind: raw, raw, known: true });
+		}
+	});
+
+	test("preserves and labels unknown statuses", () => {
+		const status = parseDeploymentStatus("queued_for_drain");
+		expect(status).toEqual({ kind: "unknown", raw: "queued_for_drain", known: false });
+		expect(deploymentStatusLabel(status)).toBe("Queued For Drain");
+		expect(deploymentStatusTone(status)).toBe("warning");
+	});
+
+	test("labels and tones known statuses", () => {
+		expect(deploymentStatusLabel(parseDeploymentStatus("ready"))).toBe("Ready");
+		expect(deploymentStatusLabel(parseDeploymentStatus("error"))).toBe("Failed");
+		expect(deploymentStatusTone(parseDeploymentStatus("running"))).toBe("success");
+		expect(deploymentStatusTone(parseDeploymentStatus("stopped"))).toBe("neutral");
+		expect(deploymentStatusTone(parseDeploymentStatus("failed"))).toBe("destructive");
+		expect(deploymentStatusTone(parseDeploymentStatus("restarting"))).toBe("info");
+	});
+
+	test("classifies terminal and transitional states", () => {
+		for (const raw of ["running", "ready", "stopped", "failed", "error"]) {
+			const status = parseDeploymentStatus(raw);
+			expect(isTerminalStatus(status)).toBe(true);
+			expect(isTransitionalStatus(status)).toBe(false);
+		}
+
+		for (const raw of [
+			"pending",
+			"provisioning",
+			"starting",
+			"stopping",
+			"restarting",
+			"deleting",
+			"future_status",
+		]) {
+			const status = parseDeploymentStatus(raw);
+			expect(isTerminalStatus(status)).toBe(false);
+			expect(isTransitionalStatus(status)).toBe(true);
+		}
+	});
+
+	test("drives lifecycle gates from settled statuses only", () => {
+		expect(isRunningStatus(parseDeploymentStatus("running"))).toBe(true);
+		expect(isRunningStatus(parseDeploymentStatus("ready"))).toBe(true);
+		expect(canStop(parseDeploymentStatus("running"))).toBe(true);
+		expect(canStop(parseDeploymentStatus("starting"))).toBe(false);
+		expect(canStart(parseDeploymentStatus("stopped"))).toBe(true);
+		expect(canStart(parseDeploymentStatus("failed"))).toBe(true);
+		expect(canStart(parseDeploymentStatus("error"))).toBe(true);
+		expect(canRestart(parseDeploymentStatus("ready"))).toBe(true);
+		expect(canRestart(parseDeploymentStatus("failed"))).toBe(true);
+		expect(canRestart(parseDeploymentStatus("restarting"))).toBe(false);
+		expect(canRestart(parseDeploymentStatus("future_status"))).toBe(false);
+	});
+
+	test("polls while any deployment is non-terminal", () => {
+		expect(shouldPollDeployments([{ status: "running" }, { status: "stopped" }])).toBe(false);
+		expect(shouldPollDeployments([{ status: "running" }, { status: "restarting" }])).toBe(true);
+		expect(shouldPollDeployments([{ status: "new_backend_status" }])).toBe(true);
+		expect(shouldPollDeployments([])).toBe(false);
+		expect(shouldPollDeployments(undefined)).toBe(false);
+	});
+});

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -1,0 +1,148 @@
+export const KNOWN_DEPLOYMENT_STATUSES = [
+	"pending",
+	"provisioning",
+	"starting",
+	"running",
+	"ready",
+	"stopped",
+	"failed",
+	"error",
+	"stopping",
+	"restarting",
+	"deleting",
+] as const;
+
+export type KnownDeploymentStatus = (typeof KNOWN_DEPLOYMENT_STATUSES)[number];
+export type DeploymentStatusTone = "success" | "warning" | "destructive" | "info" | "neutral";
+
+type KnownDeploymentStatusModel = {
+	kind: KnownDeploymentStatus;
+	raw: KnownDeploymentStatus;
+	known: true;
+};
+
+export type UnknownDeploymentStatus = {
+	kind: "unknown";
+	raw: string;
+	known: false;
+};
+
+export type DeploymentStatus = KnownDeploymentStatusModel | UnknownDeploymentStatus;
+
+const KNOWN_STATUS_SET = new Set<string>(KNOWN_DEPLOYMENT_STATUSES);
+
+export function parseDeploymentStatus(raw: string | null | undefined): DeploymentStatus {
+	const value = raw?.trim() ?? "";
+	const normalized = value.toLowerCase();
+	if (KNOWN_STATUS_SET.has(normalized)) {
+		const kind = normalized as KnownDeploymentStatus;
+		return { kind, raw: kind, known: true };
+	}
+	return { kind: "unknown", raw: value || "unknown", known: false };
+}
+
+export function deploymentStatusLabel(status: DeploymentStatus): string {
+	switch (status.kind) {
+		case "pending":
+			return "Pending";
+		case "provisioning":
+			return "Provisioning";
+		case "starting":
+			return "Starting";
+		case "running":
+			return "Running";
+		case "ready":
+			return "Ready";
+		case "stopped":
+			return "Stopped";
+		case "failed":
+		case "error":
+			return "Failed";
+		case "stopping":
+			return "Stopping";
+		case "restarting":
+			return "Restarting";
+		case "deleting":
+			return "Deleting";
+		case "unknown":
+			return titleCaseStatus(status.raw);
+		default:
+			return exhaustive(status);
+	}
+}
+
+export function deploymentStatusTone(status: DeploymentStatus): DeploymentStatusTone {
+	switch (status.kind) {
+		case "running":
+		case "ready":
+			return "success";
+		case "failed":
+		case "error":
+			return "destructive";
+		case "stopped":
+			return "neutral";
+		case "pending":
+		case "provisioning":
+		case "starting":
+		case "restarting":
+			return "info";
+		case "stopping":
+		case "deleting":
+		case "unknown":
+			return "warning";
+		default:
+			return exhaustive(status);
+	}
+}
+
+export function isRunningStatus(status: DeploymentStatus): boolean {
+	return status.kind === "running" || status.kind === "ready";
+}
+
+export function isTerminalStatus(status: DeploymentStatus): boolean {
+	return (
+		status.kind === "running" ||
+		status.kind === "ready" ||
+		status.kind === "stopped" ||
+		status.kind === "failed" ||
+		status.kind === "error"
+	);
+}
+
+export function isTransitionalStatus(status: DeploymentStatus): boolean {
+	return !isTerminalStatus(status);
+}
+
+export function canStart(status: DeploymentStatus): boolean {
+	return status.kind === "stopped" || status.kind === "failed" || status.kind === "error";
+}
+
+export function canStop(status: DeploymentStatus): boolean {
+	return isRunningStatus(status);
+}
+
+export function canRestart(status: DeploymentStatus): boolean {
+	return isRunningStatus(status) || status.kind === "failed" || status.kind === "error";
+}
+
+export function shouldPollDeployments(
+	items: readonly { status: string | null | undefined }[] | null | undefined,
+): boolean {
+	return (items ?? []).some((deployment) =>
+		isTransitionalStatus(parseDeploymentStatus(deployment.status)),
+	);
+}
+
+function titleCaseStatus(raw: string): string {
+	const cleaned = raw.trim();
+	if (!cleaned) return "Unknown";
+	return cleaned
+		.split(/[\s_-]+/)
+		.filter(Boolean)
+		.map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1).toLowerCase()}`)
+		.join(" ");
+}
+
+function exhaustive(value: never): never {
+	throw new Error(`Unhandled deployment status: ${JSON.stringify(value)}`);
+}

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -1,0 +1,39 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+
+type HostedAgentTileStatus = typeof import("@/hosted/use-hosted-agent-tiles").hostedAgentTileStatus;
+
+let getTileStatus: HostedAgentTileStatus | null = null;
+
+beforeAll(async () => {
+	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
+	process.env.VITE_CLAWDI_DEPLOY_API_URL = "http://localhost:50021";
+	process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
+	getTileStatus = (await import("@/hosted/use-hosted-agent-tiles")).hostedAgentTileStatus;
+});
+
+function hostedAgentTileStatus(rawStatus: string) {
+	if (!getTileStatus) throw new Error("hostedAgentTileStatus was not loaded");
+	return getTileStatus(rawStatus);
+}
+
+describe("hostedAgentTileStatus", () => {
+	test("marks running and ready deployments active", () => {
+		expect(hostedAgentTileStatus("running")).toEqual({ label: "Running", active: true });
+		expect(hostedAgentTileStatus("ready")).toEqual({ label: "Ready", active: true });
+	});
+
+	test("keeps transitional and failed deployments inactive with readable labels", () => {
+		expect(hostedAgentTileStatus("restarting")).toEqual({
+			label: "Restarting",
+			active: false,
+		});
+		expect(hostedAgentTileStatus("failed")).toEqual({ label: "Failed", active: false });
+	});
+
+	test("passes unknown deploy-api statuses through as readable labels", () => {
+		expect(hostedAgentTileStatus("queued_for_drain")).toEqual({
+			label: "Queued For Drain",
+			active: false,
+		});
+	});
+});

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -10,6 +10,12 @@ import { isDeployApiConfigured, useBillingClient } from "@/hosted/billing/billin
 import type { HostedDeployment } from "@/hosted/billing/contracts";
 import { billingQueryRetry, isNetworkError } from "@/hosted/billing/errors";
 import { billingKeys } from "@/hosted/billing/hooks";
+import {
+	deploymentStatusLabel,
+	isRunningStatus,
+	parseDeploymentStatus,
+	shouldPollDeployments,
+} from "@/hosted/deployment-status";
 import { deploymentRuntimes, runtimeDisplayName, runtimeEnvironmentId } from "@/hosted/runtimes";
 import { agentSectionHref } from "@/lib/agent-routes";
 
@@ -65,14 +71,10 @@ export function useHostedAgentTiles({
 		enabled: configured && includeDeployments,
 		queryFn: () => client.listDeployments(),
 		retry: billingQueryRetry,
-		// Status changes (Provisioning → Ready) — refetch periodically
-		// while a deployment is still spinning up. 10s is the balance
-		// between snappy feedback and avoiding excess deploy API load.
-		refetchInterval: (q) => {
-			const items = q.state.data ?? [];
-			const transient = items.some((d) => isTransientStatus(d.status));
-			return transient ? 10_000 : false;
-		},
+		// Poll while deployments are unsettled. The deploy API status is a string,
+		// so unknown future states are treated as non-terminal until a settled
+		// state arrives.
+		refetchInterval: (q) => (shouldPollDeployments(q.state.data) ? 10_000 : false),
 	});
 
 	// Memoize the env-by-id index so the tile join is O(N+M) instead
@@ -143,9 +145,8 @@ export function useHostedAgentTiles({
 function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>): AgentTile[] {
 	const runtimes = deploymentRuntimes(d);
 	const slug = deploymentDisplayName(d.name);
-	const statusLabel = displayStatus(d.status);
+	const tileStatus = hostedAgentTileStatus(d.status);
 	// Hosted deployments don't use last_seen_at; status is the freshness signal
-	const active = d.status === "running" || d.status === "ready";
 	return runtimes.map((runtime) => {
 		// Hosted env join: each hosted runtime registers a cloud-api env
 		// via the admin endpoint. Match by agent_type → environment_id
@@ -177,7 +178,7 @@ function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>): Agen
 			sortOrder: matchedEnv?.sort_order ?? null,
 			agentType: runtime,
 			contextLabel,
-			statusLabel,
+			statusLabel: tileStatus.label,
 			lastSeenAt: matchedEnv?.last_seen_at ?? null,
 			// `?source=on-clawdi` is the breadcrumb the agent detail page
 			// reads so its sync badge can mirror the hosted-aware copy
@@ -188,7 +189,7 @@ function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>): Agen
 			href: detailHref,
 			external: false,
 			manageHref: settingsHref,
-			active,
+			active: tileStatus.active,
 			env: matchedEnv ?? null,
 			// Group sibling runtime-agents under their shared compute on /agents.
 			computeId: d.id,
@@ -197,16 +198,10 @@ function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>): Agen
 	});
 }
 
-function displayStatus(status: string): string {
-	if (status === "running" || status === "ready") return "Running";
-	if (status === "pending") return "Pending";
-	if (status === "provisioning") return "Provisioning…";
-	if (status === "starting") return "Starting…";
-	if (status === "failed" || status === "error") return "Failed";
-	if (status === "stopped") return "Stopped";
-	return status;
-}
-
-function isTransientStatus(status: string): boolean {
-	return status === "pending" || status === "provisioning" || status === "starting";
+export function hostedAgentTileStatus(rawStatus: string): { label: string; active: boolean } {
+	const status = parseDeploymentStatus(rawStatus);
+	return {
+		label: deploymentStatusLabel(status),
+		active: isRunningStatus(status),
+	};
 }


### PR DESCRIPTION
## Summary

- R9: add a central `DeploymentStatus` model for deploy-api string statuses, including known states, unknown passthrough, labels, tones, terminal/transitional classification, and lifecycle gates.
- R9: replace the divergent deployment status labels in hosted agent detail and hosted agent tiles with the shared model.
- R2: poll deployments while any status is non-terminal, including `stopping`, `restarting`, `deleting`, and unknown future statuses.
- R2: add bounded post-mutation deployment refreshes after lifecycle, runtime enable/onboard, and delete mutations so polling resumes even when the first list snapshot lags the mutation response.
- R5: invalidate deployment snapshots on lifecycle errors and show a specific stale-state/conflict message instead of the generic action failure toast.
- R6/R11: route runtime Switch/Add, Start/Stop/Restart, and Delete through `useActionLock` with awaited `mutateAsync`; Stop now confirms, and Restart confirms when multiple runtimes are enabled.
- AI-provider rebind partial failure: collect per-runtime outcomes, report failed runtime names, invalidate snapshots, and detect first-party managed providers via shared `CLAWDI_MANAGED_PROVIDER_IDS` / `isFirstPartyManagedAiProvider`.

## Tests

- Added pure status model coverage for parse/label/tone/gates/terminal/transitional/unknown passthrough/polling predicate.
- Added tile status derivation coverage for active state, transitional labels, failed labels, and unknown passthrough.

## Verification

- `bun run check:fix`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`

## Staging verification notes

- Verify real deploy-api lifecycle transitions continue polling through `stop -> stopping -> stopped`, `restart -> restarting -> running/ready`, and delete disappearance.
- Verify runtime enable/onboard settles from the real deploy-api response shape after the bounded refresh window starts.
- Verify a partial AI provider rebind failure reports the failed runtime(s) and leaves the UI reflecting the mixed server state after invalidation.
