### PR TITLE
Move sidebar user avatar to the left of the footer bar

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1369,7 +1369,7 @@ function UserControl({
 			) : (
 				trigger
 			)}
-			<DropdownMenuContent className="min-w-56 rounded-lg" side="top" align="end">
+			<DropdownMenuContent className="min-w-56 rounded-lg" side="top" align="start">
 				<UserMenuItems />
 			</DropdownMenuContent>
 		</DropdownMenu>
@@ -1392,6 +1392,9 @@ function GlobalControls({
 	return (
 		<SidebarMenu className="w-full flex-row items-center gap-1">
 			<SidebarMenuItem>
+				<UserControl user={user} showTooltip={showTooltips} />
+			</SidebarMenuItem>
+			<SidebarMenuItem className="ml-auto">
 				<GlobalControlButton label="Search" onClick={onSearch} showTooltip={showTooltips}>
 					<Search />
 				</GlobalControlButton>
@@ -1408,9 +1411,6 @@ function GlobalControls({
 				>
 					<Settings />
 				</GlobalControlButton>
-			</SidebarMenuItem>
-			<SidebarMenuItem className="ml-auto">
-				<UserControl user={user} showTooltip={showTooltips} />
 			</SidebarMenuItem>
 		</SidebarMenu>
 	);


### PR DESCRIPTION
Swaps the sidebar footer bar layout per design: the account **avatar anchors the left edge** (standard identity anchor), and **Search / Help / Settings group to the right** (`ml-auto` moved onto the Search item).

Also flips the user-menu `DropdownMenuContent` from `align="end"` to `align="start"` so the menu still opens **upward and on-screen** from the now-left-aligned avatar (with `align="end"` a left-edge avatar would push the 224px menu off the left edge).

Scope: only `GlobalControls` + `UserControl` in app-sidebar.tsx; does not touch the full-width footer bar structure (#273) or the FocusHeader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)