### PR TITLE
Reconcile hosted compute vs sync status and fleet count

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -44,7 +44,7 @@ import {
 } from "lucide-react";
 import { useQueryState } from "nuqs";
 import { parseAsStringLiteral } from "nuqs/server";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useCommandPalette } from "@/components/command-palette";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
@@ -123,6 +123,14 @@ import {
 import { cn, errorMessage, relativeTime } from "@/lib/utils";
 
 type AgentChromeKind = AgentOwnershipKind;
+const IS_HOSTED_BUILD = import.meta.env.VITE_CLAWDI_HOSTED === "true";
+const HostedFocusRuntimeStatusBadge = IS_HOSTED_BUILD
+	? lazy(() =>
+			import("@/hosted/use-hosted-agent-tiles").then((m) => ({
+				default: m.HostedFocusRuntimeStatusBadge,
+			})),
+		)
+	: null;
 
 function useAgentChromeKind(agent: SidebarEnvironment | null): AgentChromeKind {
 	const ownership = useAgentOwnership();
@@ -1188,22 +1196,56 @@ function FocusHeader({
 					{meta.visibleLabel}
 				</div>
 			) : null}
-			<div className="mt-2 flex min-w-0 items-center justify-between gap-2 rounded-md border border-sidebar-border bg-sidebar-accent/45 px-2 py-1 text-xs leading-4">
+			<div
+				className={cn(
+					"mt-2 flex min-w-0 rounded-md border border-sidebar-border bg-sidebar-accent/45 px-2 py-1 text-xs leading-4",
+					kind === "cloud" ? "flex-col items-start gap-0.5" : "items-center justify-between gap-2",
+				)}
+			>
 				{/* Legacy agents share the hosted copy variant (supervised
 				 * daemon, no CLI steps), while remediation stays in the legacy
 				 * v1 dashboard when that URL is configured. */}
-				<DaemonStatusBadge
-					env={activeAgent}
-					source={kind !== "connected" ? "on-clawdi" : "self-managed"}
-					manageHref={manageHref}
-					compact
-					tooltipDetail={meta.detailLabel}
-				/>
-				<span className="min-w-0 truncate text-muted-foreground" title={meta.activityLabel}>
+				{kind === "cloud" && HostedFocusRuntimeStatusBadge ? (
+					<Suspense fallback={<FocusStatusFallback />}>
+						<HostedFocusRuntimeStatusBadge
+							env={activeAgent}
+							manageHref={manageHref}
+							compact
+							tooltipDetail={meta.detailLabel}
+						/>
+					</Suspense>
+				) : (
+					<DaemonStatusBadge
+						env={activeAgent}
+						source={kind !== "connected" ? "on-clawdi" : "self-managed"}
+						manageHref={manageHref}
+						compact
+						tooltipDetail={meta.detailLabel}
+					/>
+				)}
+				<span
+					className={cn(
+						"min-w-0 truncate text-muted-foreground",
+						kind === "cloud" && "w-full pl-3.5",
+					)}
+					title={meta.activityLabel}
+				>
 					{meta.activityLabel}
 				</span>
 			</div>
 		</div>
+	);
+}
+
+function FocusStatusFallback() {
+	return (
+		<span className="inline-flex items-center gap-1.5 whitespace-nowrap text-muted-foreground">
+			<span
+				aria-hidden
+				className="inline-block size-1.5 rounded-full border border-muted-foreground/50 bg-transparent"
+			/>
+			<span>Status</span>
+		</span>
 	);
 }
 

--- a/apps/web/src/components/dashboard/agents-card.test.ts
+++ b/apps/web/src/components/dashboard/agents-card.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import type { components } from "@clawdi/shared/api";
-import { selfManagedAgentTiles } from "@/components/dashboard/agents-card";
+import {
+	type AgentTile,
+	fleetSummaryFromTiles,
+	selfManagedAgentTiles,
+} from "@/components/dashboard/agents-card";
 
 type Env = components["schemas"]["AgentResponse"];
 
@@ -56,5 +60,47 @@ describe("selfManagedAgentTiles", () => {
 			name: "Launch runner",
 		});
 		expect("runtimeLabel" in tile).toBe(false);
+	});
+});
+
+describe("fleetSummaryFromTiles", () => {
+	it("counts active tiles instead of requiring a fresh cloud-api last-seen timestamp", () => {
+		const freshSeenAt = new Date().toISOString();
+		const newestSeenAt = new Date(Date.now() + 1000).toISOString();
+		const selfManaged = selfManagedAgentTiles([
+			env({
+				last_seen_at: freshSeenAt,
+			}),
+		]);
+		const hostedRunningWithoutEnv: AgentTile = {
+			id: "dep_123:codex",
+			source: "on-clawdi",
+			name: "Codex",
+			agentType: "codex",
+			statusLabel: "Running",
+			lastSeenAt: null,
+			href: "/agents/dep_123",
+			active: true,
+			env: null,
+		};
+		const hostedStoppedWithFreshEnv: AgentTile = {
+			id: "dep_456:codex",
+			source: "on-clawdi",
+			name: "Stopped Codex",
+			agentType: "codex",
+			statusLabel: "Stopped",
+			lastSeenAt: newestSeenAt,
+			href: "/agents/dep_456",
+			active: true,
+			env: null,
+		};
+
+		expect(
+			fleetSummaryFromTiles([...selfManaged, hostedRunningWithoutEnv, hostedStoppedWithFreshEnv]),
+		).toEqual({
+			activeCount: 3,
+			total: 3,
+			lastActive: newestSeenAt,
+		});
 	});
 });

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -13,7 +13,7 @@ import {
 	displayMachineName,
 	LegacyAgentBadge,
 } from "@/components/dashboard/agent-label";
-import { type DaemonStatusVisual, daemonStatusVisual } from "@/components/dashboard/daemon-status";
+import { daemonStatusVisual } from "@/components/dashboard/daemon-status";
 import { EmptyState } from "@/components/empty-state";
 import {
 	ENTITY_CARD_BASE,
@@ -56,6 +56,17 @@ export function selfManagedAgentTiles(environments: Env[] | undefined): AgentTil
 	}));
 }
 
+export interface AgentTileStatusDot {
+	label: string;
+	dotClass: string;
+}
+
+export interface AgentTileSecondaryStatus {
+	label: string;
+	title?: string;
+	textClass?: string;
+}
+
 /**
  * UI-side projection of an agent for the dashboard grid. The dashboard
  * page composes this from cloud-api environments and (for hosted users)
@@ -87,7 +98,13 @@ export interface AgentTile {
 	 * status dialogs. Tiles render daemon status as a non-interactive dot. */
 	manageHref?: string;
 	/** Counted in the "N active now" header line; no per-tile indicator rendered. */
-	active?: boolean;
+	active: boolean;
+	/** Primary status dot. Hosted tiles use compute status here; connected tiles
+	 * omit it and fall back to live-sync status. */
+	statusDot?: AgentTileStatusDot;
+	/** Secondary qualifier appended to the tile meta line. Hosted tiles use this
+	 * only for meaningful sync qualifiers such as "Sync paused". */
+	secondaryStatus?: AgentTileSecondaryStatus | null;
 	/** Self-managed envs carry the full EnvironmentResponse so the
 	 * tile can render a sync indicator. Hosted tiles join their
 	 * cloud-api env via `clawdi_cloud_environments` and end up with
@@ -99,6 +116,24 @@ export interface AgentTile {
 	 * deployment. Self-managed tiles leave these undefined. */
 	computeId?: string;
 	computeName?: string;
+}
+
+export interface AgentFleetSummary {
+	activeCount: number;
+	total: number;
+	lastActive: string | null;
+}
+
+export function fleetSummaryFromTiles(agents: readonly AgentTile[]): AgentFleetSummary {
+	return {
+		activeCount: agents.filter((agent) => agent.active).length,
+		total: agents.length,
+		lastActive:
+			agents
+				.map((agent) => agent.lastSeenAt)
+				.filter((value): value is string => Boolean(value))
+				.sort((a, b) => b.localeCompare(a))[0] ?? null,
+	};
 }
 
 export function AgentsCard({
@@ -218,36 +253,48 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 	});
 	const meta: string[] = [];
 	if (identity.secondaryLabel) meta.push(identity.secondaryLabel);
+	if (onClawdi) meta.push(tile.statusLabel);
 	const activityLabel = agentTileActivityLabel(tile);
-	if (activityLabel) meta.push(activityLabel);
-	const metaLabel = meta.join(" · ");
+	if (activityLabel && !onClawdi) meta.push(activityLabel);
 	const statusVisual = daemonStatusVisual(
 		tile.env,
 		onClawdi || legacyHosted ? "on-clawdi" : "self-managed",
 	);
+	const statusDot = tile.statusDot ?? {
+		label: statusVisual.label,
+		dotClass: statusVisual.dotClass,
+	};
 
 	const card = (
 		<div
-			className={cn(
-				ENTITY_CARD_BASE,
-				"relative flex h-full items-start gap-3 transition-colors group-hover:bg-muted/50",
-			)}
+			className={cn(ENTITY_CARD_BASE, "relative h-full transition-colors group-hover:bg-muted/50")}
 		>
 			<EntityHeader
 				align="start"
 				icon={<AgentIcon agent={tile.agentType} size="lg" avatarUrl={tile.avatarUrl} />}
 				title={
 					<span className="flex min-w-0 items-center gap-1.5">
-						<AgentStatusDot visual={statusVisual} />
+						<AgentStatusDot visual={statusDot} />
 						<span className="min-w-0 truncate" title={tile.name}>
 							{displayMachineName(tile.name)}
 						</span>
 					</span>
 				}
-				meta={metaLabel || undefined}
+				meta={meta.length > 0 ? meta : undefined}
 				titleAdornment={sourcePill}
 				className="min-w-0 flex-1"
 			/>
+			{onClawdi && tile.secondaryStatus ? (
+				<div
+					className={cn(
+						"mt-0.5 pl-11 text-xs leading-4",
+						tile.secondaryStatus.textClass ?? "text-muted-foreground",
+					)}
+					title={tile.secondaryStatus.title}
+				>
+					{tile.secondaryStatus.label}
+				</div>
+			) : null}
 			{tile.external ? (
 				<ArrowUpRight
 					aria-hidden
@@ -260,7 +307,8 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 		"group block h-full rounded-lg text-inherit no-underline",
 		ENTITY_CARD_BUTTON_FOCUS_CLASS,
 	);
-	const linkLabel = `Open ${tile.name}. Status: ${statusVisual.label}`;
+	const linkStatus = [statusDot.label, tile.secondaryStatus?.label].filter(Boolean).join(", ");
+	const linkLabel = `Open ${tile.name}. Status: ${linkStatus}`;
 
 	if (tile.external) {
 		return (
@@ -283,7 +331,7 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 	);
 }
 
-function AgentStatusDot({ visual }: { visual: DaemonStatusVisual }) {
+function AgentStatusDot({ visual }: { visual: AgentTileStatusDot }) {
 	return (
 		<span title={visual.label} className="inline-flex shrink-0 items-center">
 			<span aria-hidden className={cn("size-1.5 rounded-full", visual.dotClass)} />

--- a/apps/web/src/components/dashboard/daemon-status.tsx
+++ b/apps/web/src/components/dashboard/daemon-status.tsx
@@ -196,6 +196,8 @@ export function DaemonStatusBadge({
 	manageHref,
 	compact = false,
 	tooltipDetail,
+	showDot = true,
+	labelOverride,
 }: {
 	env: Env;
 	/** "on-clawdi" tiles change the dialog copy across every non-
@@ -218,10 +220,15 @@ export function DaemonStatusBadge({
 	compact?: boolean;
 	/** Extra context shown only in the tooltip for crowded layouts. */
 	tooltipDetail?: string;
+	/** Hosted compute-primary surfaces can render sync as text-only context. */
+	showDot?: boolean;
+	/** Hosted compute-primary surfaces may need the fully-qualified sync label
+	 * even in compact layouts. */
+	labelOverride?: string;
 }) {
 	const visual = daemonStatusVisual(env, source);
 	const [open, setOpen] = useState(false);
-	const label = compact ? visual.compactLabel : visual.badgeLabel;
+	const label = labelOverride ?? (compact ? visual.compactLabel : visual.badgeLabel);
 	const inner = (
 		<span
 			className={cn(
@@ -231,7 +238,9 @@ export function DaemonStatusBadge({
 				"cursor-pointer hover:text-foreground",
 			)}
 		>
-			<span aria-hidden className={cn("inline-block size-1.5 rounded-full", visual.dotClass)} />
+			{showDot ? (
+				<span aria-hidden className={cn("inline-block size-1.5 rounded-full", visual.dotClass)} />
+			) : null}
 			<span className="whitespace-nowrap">{label}</span>
 		</span>
 	);

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CLAWDI_MANAGED_PROVIDER_IDS, isFirstPartyManagedAiProvider } from "@clawdi/shared";
+import type { components } from "@clawdi/shared/api";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useLocation, useRouter } from "@tanstack/react-router";
 import {
@@ -113,6 +114,7 @@ import {
 	runtimeIsConfigured,
 	runtimeIsEnabled,
 } from "@/hosted/runtimes";
+import { hostedRuntimeStatusView } from "@/hosted/use-hosted-agent-tiles";
 import { useAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import { AuthBadge, ProviderTypeChip } from "@/hosted/v2/ai-providers/ai-providers-ui";
 import {
@@ -323,6 +325,7 @@ export function HostedAgentDetail({
 					{activeTab === "overview" ? (
 						<OverviewTab
 							deployment={deployment}
+							agent={isCloudEnvId(environmentId) ? agent : null}
 							runtime={runtime}
 							isPerformance={isPerformance}
 							sessions={sessions.data?.items ?? []}
@@ -380,8 +383,41 @@ function StatCard({ label, value }: { label: string; value: React.ReactNode }) {
 	);
 }
 
+function RuntimeStatusValue({
+	deployment,
+	agent,
+}: {
+	deployment: HostedDeployment;
+	agent: components["schemas"]["AgentResponse"] | null | undefined;
+}) {
+	const status = hostedRuntimeStatusView(deployment, agent);
+	return (
+		<div className="flex min-w-0 flex-col gap-1">
+			<span
+				className={cn("inline-flex min-w-0 items-center gap-1.5", status.primary.textClass)}
+				title={`Compute ${status.primary.label}`}
+			>
+				<span
+					aria-hidden
+					className={cn("inline-block size-1.5 shrink-0 rounded-full", status.primary.dotClass)}
+				/>
+				<span className="truncate">{status.primary.label}</span>
+			</span>
+			{status.secondary ? (
+				<span
+					className={cn("truncate text-xs", status.secondary.textClass)}
+					title={status.secondary.tooltip}
+				>
+					{status.secondary.label}
+				</span>
+			) : null}
+		</div>
+	);
+}
+
 function OverviewTab({
 	deployment,
+	agent,
 	runtime,
 	isPerformance,
 	sessions,
@@ -391,6 +427,7 @@ function OverviewTab({
 	sessionLink,
 }: {
 	deployment: HostedDeployment;
+	agent: components["schemas"]["AgentResponse"] | null | undefined;
 	runtime: Runtime;
 	isPerformance: boolean;
 	sessions: SessionListItem[];
@@ -405,11 +442,13 @@ function OverviewTab({
 	const ci = deployment.config_info;
 	const binding = ci?.ai_provider_bindings?.[runtime];
 	const model = binding?.primary_model ?? ci?.primary_model ?? "Managed default";
-	const status = parseDeploymentStatus(deployment.status);
 	return (
 		<div className="flex flex-col gap-5">
 			<div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-				<StatCard label="Status" value={deploymentStatusLabel(status)} />
+				<StatCard
+					label="Status"
+					value={<RuntimeStatusValue deployment={deployment} agent={agent} />}
+				/>
 				<StatCard label="Compute" value={isPerformance ? "Performance" : "Free"} />
 				<StatCard label="Model" value={model} />
 				<StatCard

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -1,19 +1,54 @@
 import { beforeAll, describe, expect, test } from "bun:test";
+import type { components } from "@clawdi/shared/api";
 
 type HostedAgentTileStatus = typeof import("@/hosted/use-hosted-agent-tiles").hostedAgentTileStatus;
+type HostedRuntimeStatusView =
+	typeof import("@/hosted/use-hosted-agent-tiles").hostedRuntimeStatusView;
+type Env = components["schemas"]["AgentResponse"];
 
 let getTileStatus: HostedAgentTileStatus | null = null;
+let getRuntimeStatusView: HostedRuntimeStatusView | null = null;
 
 beforeAll(async () => {
 	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
 	process.env.VITE_CLAWDI_DEPLOY_API_URL = "http://localhost:50021";
 	process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
-	getTileStatus = (await import("@/hosted/use-hosted-agent-tiles")).hostedAgentTileStatus;
+	const module = await import("@/hosted/use-hosted-agent-tiles");
+	getTileStatus = module.hostedAgentTileStatus;
+	getRuntimeStatusView = module.hostedRuntimeStatusView;
 });
 
 function hostedAgentTileStatus(rawStatus: string) {
 	if (!getTileStatus) throw new Error("hostedAgentTileStatus was not loaded");
 	return getTileStatus(rawStatus);
+}
+
+function hostedRuntimeStatusView(rawStatus: string, environment: Env | null | undefined) {
+	if (!getRuntimeStatusView) throw new Error("hostedRuntimeStatusView was not loaded");
+	return getRuntimeStatusView({ status: rawStatus }, environment);
+}
+
+function env(overrides: Partial<Env> = {}): Env {
+	return {
+		id: "11111111-1111-4111-8111-111111111111",
+		name: "hosted-codex",
+		default_name: "hosted-codex",
+		machine_name: "hosted-codex",
+		agent_type: "codex",
+		agent_version: null,
+		os: "linux",
+		last_seen_at: null,
+		last_sync_at: new Date().toISOString(),
+		last_sync_error: null,
+		last_revision_seen: null,
+		sort_order: 0,
+		queue_depth_high_water: 0,
+		dropped_count: 0,
+		sync_enabled: true,
+		explicit_identity: false,
+		default_project_id: "22222222-2222-4222-8222-222222222222",
+		...overrides,
+	};
 }
 
 describe("hostedAgentTileStatus", () => {
@@ -35,5 +70,56 @@ describe("hostedAgentTileStatus", () => {
 			label: "Queued For Drain",
 			active: false,
 		});
+	});
+});
+
+describe("hostedRuntimeStatusView", () => {
+	test("keeps compute primary and sync paused secondary while running", () => {
+		const view = hostedRuntimeStatusView(
+			"running",
+			env({ last_sync_at: new Date(Date.now() - 5 * 60 * 1000).toISOString() }),
+		);
+
+		expect(view.primary.label).toBe("Running");
+		expect(view.active).toBe(true);
+		expect(view.sync?.kind).toBe("paused");
+		expect(view.secondary?.label).toBe("Sync paused");
+	});
+
+	test("suppresses reassuring live sync when compute is stopped", () => {
+		const view = hostedRuntimeStatusView("stopped", env());
+
+		expect(view.primary.label).toBe("Stopped");
+		expect(view.active).toBe(false);
+		expect(view.sync?.kind).toBe("live");
+		expect(view.secondary).toBeNull();
+	});
+
+	test("counts a hosted runtime active when its joined environment is fresh", () => {
+		const view = hostedRuntimeStatusView(
+			"stopped",
+			env({ last_seen_at: new Date().toISOString() }),
+		);
+
+		expect(view.primary.label).toBe("Stopped");
+		expect(view.active).toBe(true);
+		expect(view.secondary).toBeNull();
+	});
+
+	test("suppresses live sync when compute is running", () => {
+		const view = hostedRuntimeStatusView("running", env());
+
+		expect(view.primary.label).toBe("Running");
+		expect(view.sync?.kind).toBe("live");
+		expect(view.secondary).toBeNull();
+	});
+
+	test("shows pending sync only when running without a registered environment", () => {
+		const running = hostedRuntimeStatusView("running", null);
+		const provisioning = hostedRuntimeStatusView("provisioning", null);
+
+		expect(running.secondary?.label).toBe("Sync pending");
+		expect(provisioning.primary.label).toBe("Provisioning");
+		expect(provisioning.secondary).toBeNull();
 	});
 });

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -2,24 +2,108 @@
 
 import type { components } from "@clawdi/shared/api";
 import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { createElement, type ReactNode, useMemo } from "react";
 import { agentDisplayName } from "@/components/dashboard/agent-label";
-import type { AgentTile } from "@/components/dashboard/agents-card";
+import {
+	type AgentFleetSummary,
+	type AgentTile,
+	fleetSummaryFromTiles,
+	isAgentActive,
+} from "@/components/dashboard/agents-card";
+import {
+	DaemonStatusBadge,
+	type DaemonStatusVisual,
+	daemonStatusVisual,
+} from "@/components/dashboard/daemon-status";
 import { deploymentDisplayName } from "@/hosted/agent-identity";
 import { isDeployApiConfigured, useBillingClient } from "@/hosted/billing/billing-client";
 import type { HostedDeployment } from "@/hosted/billing/contracts";
 import { billingQueryRetry, isNetworkError } from "@/hosted/billing/errors";
 import { billingKeys } from "@/hosted/billing/hooks";
 import {
+	type DeploymentStatus,
+	type DeploymentStatusTone,
 	deploymentStatusLabel,
+	deploymentStatusTone,
 	isRunningStatus,
 	parseDeploymentStatus,
 	shouldPollDeployments,
 } from "@/hosted/deployment-status";
+import { legacyConnectedAgentTiles } from "@/hosted/legacy-agent-tiles";
 import { deploymentRuntimes, runtimeDisplayName, runtimeEnvironmentId } from "@/hosted/runtimes";
+import { normalizeAgentEnvId, useAgentOwnership } from "@/lib/agent-ownership";
 import { agentSectionHref } from "@/lib/agent-routes";
 
 type Env = components["schemas"]["AgentResponse"];
+type DeploymentStatusInput = Pick<HostedDeployment, "status">;
+
+const EMPTY_ENV_IDS: ReadonlySet<string> = new Set();
+
+const COMPUTE_DOT_TONE: Record<DeploymentStatusTone, string> = {
+	success: "bg-success ring-2 ring-success/20",
+	warning: "bg-warning ring-2 ring-warning/20",
+	destructive: "bg-destructive ring-2 ring-destructive/20",
+	info: "bg-info ring-2 ring-info/20",
+	neutral: "border border-muted-foreground/50 bg-transparent",
+};
+
+const COMPUTE_TEXT_TONE: Record<DeploymentStatusTone, string> = {
+	success: "text-muted-foreground",
+	warning: "text-warning-muted-foreground font-medium",
+	destructive: "text-destructive-muted-foreground font-medium",
+	info: "text-info-muted-foreground",
+	neutral: "text-muted-foreground",
+};
+
+export interface HostedRuntimeStatusView {
+	compute: DeploymentStatus;
+	sync: DaemonStatusVisual | null;
+	primary: {
+		label: string;
+		dotClass: string;
+		textClass: string;
+	};
+	secondary: {
+		kind: DaemonStatusVisual["kind"];
+		label: string;
+		tooltip: string;
+		textClass: string;
+	} | null;
+	active: boolean;
+}
+
+export function hostedRuntimeStatusView(
+	deployment: DeploymentStatusInput,
+	env: Env | null | undefined,
+): HostedRuntimeStatusView {
+	const compute = parseDeploymentStatus(deployment.status);
+	const computeLabel = deploymentStatusLabel(compute);
+	const computeTone = deploymentStatusTone(compute);
+	const sync = env === undefined ? null : daemonStatusVisual(env, "on-clawdi");
+	const computeIsRunning = isRunningStatus(compute);
+	const envIsFresh = isAgentActive(env?.last_seen_at);
+	const secondary =
+		computeIsRunning && sync && sync.kind !== "live"
+			? {
+					kind: sync.kind,
+					label: sync.badgeLabel,
+					tooltip: sync.tooltip,
+					textClass: sync.textClass,
+				}
+			: null;
+
+	return {
+		compute,
+		sync,
+		primary: {
+			label: computeLabel,
+			dotClass: COMPUTE_DOT_TONE[computeTone],
+			textClass: COMPUTE_TEXT_TONE[computeTone],
+		},
+		secondary,
+		active: computeIsRunning || envIsFresh,
+	};
+}
 
 /**
  * Env ids claimed by Cloud deploy-API deployments (lower-cased —
@@ -145,7 +229,6 @@ export function useHostedAgentTiles({
 function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>): AgentTile[] {
 	const runtimes = deploymentRuntimes(d);
 	const slug = deploymentDisplayName(d.name);
-	const tileStatus = hostedAgentTileStatus(d.status);
 	// Hosted deployments don't use last_seen_at; status is the freshness signal
 	return runtimes.map((runtime) => {
 		// Hosted env join: each hosted runtime registers a cloud-api env
@@ -170,6 +253,7 @@ function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>): Agen
 			: agentSectionHref(d.id, "settings");
 		const name = matchedEnv ? agentDisplayName(matchedEnv) : runtimeDisplayName(runtime);
 		const contextLabel = slug !== name ? slug : null;
+		const runtimeStatus = hostedRuntimeStatusView(d, matchedEnv ?? null);
 		return {
 			id: `${d.id}:${runtime}`,
 			source: "on-clawdi" as const,
@@ -178,7 +262,7 @@ function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>): Agen
 			sortOrder: matchedEnv?.sort_order ?? null,
 			agentType: runtime,
 			contextLabel,
-			statusLabel: tileStatus.label,
+			statusLabel: runtimeStatus.primary.label,
 			lastSeenAt: matchedEnv?.last_seen_at ?? null,
 			// `?source=on-clawdi` is the breadcrumb the agent detail page
 			// reads so its sync badge can mirror the hosted-aware copy
@@ -189,7 +273,18 @@ function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>): Agen
 			href: detailHref,
 			external: false,
 			manageHref: settingsHref,
-			active: tileStatus.active,
+			active: runtimeStatus.active,
+			statusDot: {
+				label: runtimeStatus.primary.label,
+				dotClass: runtimeStatus.primary.dotClass,
+			},
+			secondaryStatus: runtimeStatus.secondary
+				? {
+						label: runtimeStatus.secondary.label,
+						title: runtimeStatus.secondary.tooltip,
+						textClass: runtimeStatus.secondary.textClass,
+					}
+				: null,
 			env: matchedEnv ?? null,
 			// Group sibling runtime-agents under their shared compute on /agents.
 			computeId: d.id,
@@ -204,4 +299,203 @@ export function hostedAgentTileStatus(rawStatus: string): { label: string; activ
 		label: deploymentStatusLabel(status),
 		active: isRunningStatus(status),
 	};
+}
+
+export function unifiedHostedAgentTiles({
+	selfManagedTiles,
+	hostedTiles,
+	claimedEnvIds,
+	legacyEnvIds,
+	cloudEnvs,
+	showLegacyAgents,
+}: {
+	selfManagedTiles: AgentTile[];
+	hostedTiles: AgentTile[];
+	claimedEnvIds: ReadonlySet<string>;
+	legacyEnvIds: ReadonlySet<string>;
+	cloudEnvs: Env[];
+	showLegacyAgents: boolean;
+}): AgentTile[] {
+	const legacyConnectedTiles = showLegacyAgents
+		? legacyConnectedAgentTiles(cloudEnvs, legacyEnvIds, claimedEnvIds)
+		: [];
+	const dedupedSelfManaged = selfManagedTiles.filter(
+		(tile) =>
+			!isOwnedEnvId(tile.id, claimedEnvIds, showLegacyAgents ? legacyEnvIds : EMPTY_ENV_IDS),
+	);
+	return [...hostedTiles, ...legacyConnectedTiles, ...dedupedSelfManaged];
+}
+
+function isOwnedEnvId(
+	id: string,
+	claimedEnvIds: ReadonlySet<string>,
+	legacyEnvIds: ReadonlySet<string>,
+): boolean {
+	const envId = normalizeAgentEnvId(id);
+	return Boolean(envId && (claimedEnvIds.has(envId) || legacyEnvIds.has(envId)));
+}
+
+export function HostedFleetSummary({
+	selfManagedTiles,
+	cloudEnvs,
+	showCloudDeployments = true,
+	showLegacyAgents = false,
+	children,
+}: {
+	selfManagedTiles: AgentTile[];
+	cloudEnvs: Env[];
+	showCloudDeployments?: boolean;
+	showLegacyAgents?: boolean;
+	children: (summary: AgentFleetSummary) => ReactNode;
+}) {
+	const hosted = useHostedAgentTiles({
+		cloudEnvs,
+		includeDeployments: showCloudDeployments,
+	});
+	const ownership = useAgentOwnership();
+	const legacyEnvIds = showLegacyAgents ? ownership?.legacyEnvIds : EMPTY_ENV_IDS;
+	const ownershipLoading =
+		(showCloudDeployments && hosted.isLoading) || (showLegacyAgents && ownership === null);
+	const tiles = useMemo(() => {
+		if (ownershipLoading || !legacyEnvIds) return selfManagedTiles;
+		return unifiedHostedAgentTiles({
+			selfManagedTiles,
+			hostedTiles: hosted.tiles,
+			claimedEnvIds: hosted.claimedEnvIds,
+			legacyEnvIds,
+			cloudEnvs,
+			showLegacyAgents,
+		});
+	}, [
+		cloudEnvs,
+		hosted.claimedEnvIds,
+		hosted.tiles,
+		legacyEnvIds,
+		ownershipLoading,
+		selfManagedTiles,
+		showLegacyAgents,
+	]);
+	const summary = useMemo(() => fleetSummaryFromTiles(tiles), [tiles]);
+	return children(summary);
+}
+
+export function HostedFocusRuntimeStatusBadge({
+	env,
+	manageHref,
+	compact = false,
+	tooltipDetail,
+}: {
+	env: Env;
+	manageHref?: string;
+	compact?: boolean;
+	tooltipDetail?: string;
+}) {
+	const hosted = useHostedAgentTiles({ cloudEnvs: [env] });
+	const envId = normalizeAgentEnvId(env.id);
+	const tile = hosted.tiles.find((item) => normalizeAgentEnvId(item.env?.id) === envId);
+	if (!tile?.statusDot) {
+		if (hosted.isLoading) return createLoadingStatus(compact);
+		return createElement(DaemonStatusBadge, {
+			env,
+			source: "on-clawdi",
+			manageHref,
+			compact,
+			tooltipDetail,
+		});
+	}
+
+	return createElement(
+		"span",
+		{
+			className: "inline-flex min-w-0 items-center gap-1.5 whitespace-nowrap text-muted-foreground",
+			title: tile.secondaryStatus?.title ?? tile.statusDot.label,
+		},
+		createElement("span", {
+			key: "dot",
+			"aria-hidden": true,
+			className: `inline-block size-1.5 shrink-0 rounded-full ${tile.statusDot.dotClass}`,
+		}),
+		createElement(
+			"span",
+			{
+				key: "primary",
+				className: "whitespace-nowrap",
+			},
+			tile.statusDot.label,
+		),
+		createSecondarySyncStatus({
+			key: "secondary",
+			tile,
+			env,
+			manageHref,
+			tooltipDetail,
+		}),
+	);
+}
+
+function createLoadingStatus(compact: boolean) {
+	return createElement(
+		"span",
+		{
+			className: "inline-flex items-center gap-1.5 whitespace-nowrap text-muted-foreground",
+		},
+		createElement("span", {
+			key: "dot",
+			"aria-hidden": true,
+			className:
+				"inline-block size-1.5 rounded-full border border-muted-foreground/50 bg-transparent",
+		}),
+		createElement("span", { key: "label" }, compact ? "Loading" : "Loading status"),
+	);
+}
+
+function createSecondarySyncStatus({
+	key,
+	tile,
+	env,
+	manageHref,
+	tooltipDetail,
+}: {
+	key: string;
+	tile: AgentTile;
+	env: Env;
+	manageHref?: string;
+	tooltipDetail?: string;
+}) {
+	if (!tile.secondaryStatus) return null;
+	const label = tile.secondaryStatus.label;
+	return createElement(
+		"span",
+		{
+			key,
+			className: "inline-flex min-w-0 items-center gap-1.5",
+		},
+		createElement(
+			"span",
+			{
+				key: "separator",
+				className: "text-muted-foreground/70",
+				"aria-hidden": true,
+			},
+			"·",
+		),
+		tile.env
+			? createElement(DaemonStatusBadge, {
+					key: "badge",
+					env,
+					source: "on-clawdi",
+					manageHref,
+					tooltipDetail,
+					showDot: false,
+					labelOverride: label,
+				})
+			: createElement(
+					"span",
+					{
+						key: "text",
+						className: tile.secondaryStatus.textClass ?? "text-muted-foreground",
+					},
+					label,
+				),
+	);
 }

--- a/apps/web/src/pages/dashboard/page.tsx
+++ b/apps/web/src/pages/dashboard/page.tsx
@@ -6,8 +6,9 @@ import { ArrowRight } from "lucide-react";
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import { AddAgentDialog } from "@/components/dashboard/add-agent-dialog";
 import {
+	type AgentFleetSummary,
 	AgentsCard,
-	isAgentActive,
+	fleetSummaryFromTiles,
 	selfManagedAgentTiles,
 } from "@/components/dashboard/agents-card";
 import { ContributionGraph } from "@/components/dashboard/contribution-graph";
@@ -69,6 +70,13 @@ const HostedSecondaryCTA = IS_HOSTED_BUILD
 			})),
 		)
 	: null;
+const HostedFleetSummary = IS_HOSTED_BUILD
+	? lazy(() =>
+			import("@/hosted/use-hosted-agent-tiles").then((m) => ({
+				default: m.HostedFleetSummary,
+			})),
+		)
+	: null;
 
 export default function DashboardPage() {
 	const api = useApi();
@@ -117,12 +125,10 @@ export default function DashboardPage() {
 			: null;
 
 	const selfManagedTiles = useMemo(() => selfManagedAgentTiles(environments), [environments]);
-	const fleetAgents = environments ?? [];
-	const fleetLastActive =
-		fleetAgents
-			.map((env) => env.last_seen_at)
-			.filter((value): value is string => Boolean(value))
-			.sort((a, b) => b.localeCompare(a))[0] ?? null;
+	const selfManagedFleetSummary = useMemo(
+		() => fleetSummaryFromTiles(selfManagedTiles),
+		[selfManagedTiles],
+	);
 
 	// Zero-state promotion: when the user has no agents yet, the
 	// secondary CTA (connect one) lives in the right column. The
@@ -140,14 +146,26 @@ export default function DashboardPage() {
 		HostedAgentsSection && hostedAccess.canUseLegacyHostedDashboard,
 	);
 	const hostedSectionEnabled = hostedAgentsEnabled || legacyHostedAgentsEnabled;
+	const greeting = renderGreeting(selfManagedFleetSummary);
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
-			<Greeting
-				activeCount={fleetAgents.filter((env) => isAgentActive(env.last_seen_at)).length}
-				total={fleetAgents.length}
-				lastActive={fleetLastActive}
-			/>
+			{hostedAccessLoading ? (
+				greeting
+			) : hostedSectionEnabled && HostedFleetSummary ? (
+				<Suspense fallback={greeting}>
+					<HostedFleetSummary
+						selfManagedTiles={selfManagedTiles}
+						cloudEnvs={environments ?? []}
+						showCloudDeployments={hostedAgentsEnabled}
+						showLegacyAgents={legacyHostedAgentsEnabled}
+					>
+						{renderGreeting}
+					</HostedFleetSummary>
+				</Suspense>
+			) : (
+				greeting
+			)}
 
 			<div className="grid gap-4 lg:grid-cols-3">
 				{/* Left column — live status + activity. `min-w-0` is load-bearing:
@@ -251,6 +269,16 @@ export default function DashboardPage() {
 				</div>
 			</div>
 		</div>
+	);
+}
+
+function renderGreeting(summary: AgentFleetSummary) {
+	return (
+		<Greeting
+			activeCount={summary.activeCount}
+			total={summary.total}
+			lastActive={summary.lastActive}
+		/>
 	);
 }
 


### PR DESCRIPTION
## Summary
- Reconciles v2 hosted runtime display so compute status is primary and sync appears only as a meaningful secondary qualifier, e.g. `Running` plus `Sync paused`.
- Suppresses reassuring hosted sync labels such as `Live` when compute is not running, including stopped/failed/provisioning states.
- Moves the dashboard fleet active summary to the unified `AgentTile[]` source of truth, where hosted agents count active when compute is running or their joined env is fresh.

## Tests
- `bun run check:fix`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`

## Local screenshots
Screenshots are local only and are not committed:
- `/home/kingsley/clawdi-ui-screenshots/hosted-status/dashboard-running-paused-stopped-light.png`
- `/home/kingsley/clawdi-ui-screenshots/hosted-status/dashboard-running-paused-stopped-dark.png`
- `/home/kingsley/clawdi-ui-screenshots/hosted-status/detail-running-sync-paused-light.png`
- `/home/kingsley/clawdi-ui-screenshots/hosted-status/detail-running-sync-paused-dark.png`
- `/home/kingsley/clawdi-ui-screenshots/hosted-status/detail-stopped-light.png`
- `/home/kingsley/clawdi-ui-screenshots/hosted-status/detail-stopped-dark.png`