### PR TITLE
Fix hosted hardening follow-ups (idempotency persistence, action rejection, starting recovery, subscription patch)

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1529,7 +1529,9 @@ function ComputeSettingsSections({
 													checked={enabled}
 													disabled={runtimePending || blockedByPlan}
 													onCheckedChange={(next) =>
-														void runAction(() => setRuntimeEnabled(r.id, next))
+														void runAction(() => setRuntimeEnabled(r.id, next)).catch(
+															() => undefined,
+														)
 													}
 													aria-label={`Toggle ${r.label}`}
 												/>
@@ -1543,7 +1545,9 @@ function ComputeSettingsSections({
 															? "Performance compute is required to run both runtimes"
 															: undefined
 													}
-													onClick={() => void runAction(() => addRuntime(r.id))}
+													onClick={() =>
+														void runAction(() => addRuntime(r.id)).catch(() => undefined)
+													}
 												>
 													{onboard.isPending && onboard.variables?.agentType === r.id ? (
 														<Spinner className="size-3.5" />
@@ -1627,7 +1631,7 @@ function ComputeSettingsSections({
 										!perfPlan ||
 										!perfOfferSelection
 									}
-									onClick={() => runAction(startPerformanceUpgrade)}
+									onClick={() => void runAction(startPerformanceUpgrade).catch(() => undefined)}
 								>
 									{checkout.isPending ? (
 										<Spinner className="size-3.5" />
@@ -1648,7 +1652,7 @@ function ComputeSettingsSections({
 									variant="outline"
 									size="sm"
 									disabled={portal.isPending || !canChangeBillingTerm}
-									onClick={() => runAction(changeBillingTerm)}
+									onClick={() => void runAction(changeBillingTerm).catch(() => undefined)}
 								>
 									{portal.isPending && portal.variables?.flow === "subscription_update_confirm" ? (
 										<Spinner className="size-3.5" />
@@ -1663,7 +1667,9 @@ function ComputeSettingsSections({
 										variant="outline"
 										size="sm"
 										disabled={resumeSubscription.isPending}
-										onClick={() => runAction(resumePerformanceSubscription)}
+										onClick={() =>
+											void runAction(resumePerformanceSubscription).catch(() => undefined)
+										}
 									>
 										{resumeSubscription.isPending ? (
 											<Spinner className="size-3.5" />
@@ -1737,7 +1743,9 @@ function ComputeSettingsSections({
 							variant="outline"
 							size="sm"
 							disabled={lifecycle.isPending || !canRestart}
-							onClick={() => void runAction(() => runLifecycleAction("restart"))}
+							onClick={() =>
+								void runAction(() => runLifecycleAction("restart")).catch(() => undefined)
+							}
 						>
 							{lifecycle.isPending && lifecycle.variables?.action === "restart" ? (
 								<Spinner className="size-3.5" />
@@ -1775,7 +1783,11 @@ function ComputeSettingsSections({
 							variant="outline"
 							size="sm"
 							disabled={lifecycle.isPending || !canRunPrimaryLifecycleAction}
-							onClick={() => void runAction(() => runLifecycleAction(primaryLifecycleAction))}
+							onClick={() =>
+								void runAction(() => runLifecycleAction(primaryLifecycleAction)).catch(
+									() => undefined,
+								)
+							}
 						>
 							{lifecycle.isPending && lifecycle.variables?.action === primaryLifecycleAction ? (
 								<Spinner className="size-3.5" />

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
+import type { ComputeSubscriptionActionResult, HostedDeployment } from "@/hosted/billing/contracts";
+import { applyDeploymentSubscriptionResult, billingKeys } from "@/hosted/billing/hooks";
+
+function deployment(
+	computeSubscription: NonNullable<HostedDeployment["compute_subscription"]>,
+): HostedDeployment {
+	return {
+		id: "dep_123",
+		user_id: "user_123",
+		name: "Performance agent",
+		app_id: "app_123",
+		backend: null,
+		status: "running",
+		endpoints: [],
+		openclaw_control_ui_url: null,
+		hermes_control_ui_url: null,
+		compute_subscription: computeSubscription,
+		created_at: "2026-06-22T00:00:00Z",
+		upgrade_available: false,
+	};
+}
+
+function subscriptionAction(cancelAtPeriodEnd: boolean): ComputeSubscriptionActionResult {
+	return {
+		status: "active",
+		billing_term_months: 12,
+		cancel_at_period_end: cancelAtPeriodEnd,
+		current_period_end: "2026-08-01T00:00:00Z",
+		cancel_at: cancelAtPeriodEnd ? "2026-08-01T00:00:00Z" : null,
+	};
+}
+
+describe("applyDeploymentSubscriptionResult", () => {
+	test("patches cancel and resume state without immediately invalidating deployments", () => {
+		const qc = new QueryClient();
+		qc.setQueryData<HostedDeployment[]>(billingKeys.deployments, [
+			deployment({
+				status: "active",
+				billing_term_months: 1,
+				price_cents: 2_000,
+				currency: "usd",
+				cancel_at_period_end: false,
+				current_period_end: "2026-07-01T00:00:00Z",
+				cancel_at: null,
+			}),
+		]);
+
+		applyDeploymentSubscriptionResult(qc, "dep_123", subscriptionAction(true));
+
+		let patched = qc.getQueryData<HostedDeployment[]>(billingKeys.deployments);
+		expect(patched?.[0]?.compute_subscription?.cancel_at_period_end).toBe(true);
+		expect(patched?.[0]?.compute_subscription?.billing_term_months).toBe(12);
+		expect(qc.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(false);
+
+		applyDeploymentSubscriptionResult(qc, "dep_123", subscriptionAction(false));
+
+		patched = qc.getQueryData<HostedDeployment[]>(billingKeys.deployments);
+		expect(patched?.[0]?.compute_subscription?.cancel_at_period_end).toBe(false);
+		expect(patched?.[0]?.compute_subscription?.cancel_at).toBeNull();
+		expect(qc.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(false);
+	});
+});

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -2,6 +2,7 @@
 
 import {
 	keepPreviousData,
+	type QueryClient,
 	type UseQueryOptions,
 	useMutation,
 	useQuery,
@@ -100,6 +101,16 @@ function patchDeploymentSubscription(
 		};
 	});
 	return patched ? updated : deployments;
+}
+
+export function applyDeploymentSubscriptionResult(
+	qc: QueryClient,
+	deploymentId: string,
+	next: ComputeSubscriptionActionResult,
+): void {
+	qc.setQueryData<HostedDeployment[]>(billingKeys.deployments, (deployments) =>
+		patchDeploymentSubscription(deployments, deploymentId, next),
+	);
 }
 
 /**
@@ -209,10 +220,7 @@ export function useCancelSubscription() {
 	return useMutation({
 		mutationFn: (body: ComputeSubscriptionCancelRequest) => client.cancelSubscription(body),
 		onSuccess: (next, body) => {
-			qc.setQueryData<HostedDeployment[]>(billingKeys.deployments, (deployments) =>
-				patchDeploymentSubscription(deployments, body.deployment_id, next),
-			);
-			qc.invalidateQueries({ queryKey: billingKeys.deployments });
+			applyDeploymentSubscriptionResult(qc, body.deployment_id, next);
 		},
 	});
 }
@@ -230,10 +238,7 @@ export function useResumeSubscription() {
 	return useMutation({
 		mutationFn: (body: ComputeSubscriptionResumeRequest) => client.resumeSubscription(body),
 		onSuccess: (next, body) => {
-			qc.setQueryData<HostedDeployment[]>(billingKeys.deployments, (deployments) =>
-				patchDeploymentSubscription(deployments, body.deployment_id, next),
-			);
-			qc.invalidateQueries({ queryKey: billingKeys.deployments });
+			applyDeploymentSubscriptionResult(qc, body.deployment_id, next);
 		},
 	});
 }

--- a/apps/web/src/hosted/billing/idempotency.test.ts
+++ b/apps/web/src/hosted/billing/idempotency.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, test } from "bun:test";
-import { idempotencyAttemptFor, idempotencyFingerprint, newIdempotencyKey } from "./idempotency";
+import {
+	IDEMPOTENCY_ATTEMPT_TTL_MS,
+	idempotencyAttemptFor,
+	idempotencyFingerprint,
+	newIdempotencyKey,
+} from "./idempotency";
+
+class MemoryStorage implements Storage {
+	private readonly items = new Map<string, string>();
+
+	get length(): number {
+		return this.items.size;
+	}
+
+	clear(): void {
+		this.items.clear();
+	}
+
+	getItem(key: string): string | null {
+		return this.items.get(key) ?? null;
+	}
+
+	key(index: number): string | null {
+		return Array.from(this.items.keys())[index] ?? null;
+	}
+
+	removeItem(key: string): void {
+		this.items.delete(key);
+	}
+
+	setItem(key: string, value: string): void {
+		this.items.set(key, value);
+	}
+}
 
 describe("newIdempotencyKey", () => {
 	test("carries the caller's prefix", () => {
@@ -66,5 +99,75 @@ describe("idempotencyAttemptFor", () => {
 
 		expect(changed.key).toBe("checkout-2");
 		expect(changed).not.toBe(first);
+	});
+
+	test("reuses a persisted key for the same fingerprint across remounts", () => {
+		const storage = new MemoryStorage();
+		let counter = 0;
+		const mint = (prefix: string) => `${prefix}-${++counter}`;
+
+		const firstMount = idempotencyAttemptFor(null, "checkout", "same-attempt", mint, {
+			storage,
+			now: () => 1_000,
+		});
+		const secondMount = idempotencyAttemptFor(null, "checkout", "same-attempt", mint, {
+			storage,
+			now: () => 2_000,
+		});
+
+		expect(secondMount).toEqual(firstMount);
+		expect(counter).toBe(1);
+	});
+
+	test("mints a new persisted key for a changed fingerprint", () => {
+		const storage = new MemoryStorage();
+		let counter = 0;
+		const mint = (prefix: string) => `${prefix}-${++counter}`;
+
+		const first = idempotencyAttemptFor(null, "checkout", "monthly", mint, {
+			storage,
+			now: () => 1_000,
+		});
+		const changed = idempotencyAttemptFor(first, "checkout", "annual", mint, {
+			storage,
+			now: () => 2_000,
+		});
+
+		expect(changed.key).toBe("checkout-2");
+		expect(changed.key).not.toBe(first.key);
+	});
+
+	test("mints a new persisted key after the TTL expires", () => {
+		const storage = new MemoryStorage();
+		let counter = 0;
+		const mint = (prefix: string) => `${prefix}-${++counter}`;
+
+		const first = idempotencyAttemptFor(null, "checkout", "same-attempt", mint, {
+			storage,
+			now: () => 1_000,
+		});
+		const expired = idempotencyAttemptFor(first, "checkout", "same-attempt", mint, {
+			storage,
+			now: () => 1_000 + IDEMPOTENCY_ATTEMPT_TTL_MS + 1,
+		});
+
+		expect(expired.key).toBe("checkout-2");
+		expect(expired.key).not.toBe(first.key);
+	});
+
+	test("is safe without browser storage", () => {
+		let counter = 0;
+		const mint = (prefix: string) => `${prefix}-${++counter}`;
+
+		const first = idempotencyAttemptFor(null, "checkout", "same-attempt", mint, {
+			storage: null,
+		});
+		const retry = idempotencyAttemptFor(first, "checkout", "same-attempt", mint, {
+			storage: null,
+		});
+
+		expect(retry).toBe(first);
+		expect(counter).toBe(1);
+		expect(() => idempotencyAttemptFor(null, "checkout", "ssr-safe", mint)).not.toThrow();
 	});
 });

--- a/apps/web/src/hosted/billing/idempotency.ts
+++ b/apps/web/src/hosted/billing/idempotency.ts
@@ -14,11 +14,29 @@ export function newIdempotencyKey(prefix: string): string {
 }
 
 export type IdempotencyAttempt = {
+	createdAt?: number;
 	fingerprint: string;
 	key: string;
 };
 
 type MintIdempotencyKey = (prefix: string) => string;
+
+export const IDEMPOTENCY_ATTEMPT_TTL_MS = 30 * 60_000;
+
+const IDEMPOTENCY_STORAGE_KEY = "clawdi:idempotency-attempts";
+
+type StoredAttempt = {
+	key: string;
+	createdAt: number;
+};
+
+type StoredAttempts = Record<string, StoredAttempt>;
+
+type IdempotencyPersistenceOptions = {
+	now?: () => number;
+	storage?: Storage | null;
+	ttlMs?: number;
+};
 
 function stableValue(value: unknown): unknown {
 	if (Array.isArray(value)) return value.map(stableValue);
@@ -34,12 +52,121 @@ export function idempotencyFingerprint(value: unknown): string {
 	return JSON.stringify(stableValue(value));
 }
 
+function storageEntryKey(prefix: string, fingerprint: string): string {
+	return `${prefix}:${fingerprint}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isStoredAttempt(value: unknown): value is StoredAttempt {
+	return (
+		isRecord(value) &&
+		typeof value.key === "string" &&
+		typeof value.createdAt === "number" &&
+		Number.isFinite(value.createdAt)
+	);
+}
+
+function readStoredAttempts(storage: Storage, now: number, ttlMs: number): StoredAttempts | null {
+	let raw: string | null;
+	try {
+		raw = storage.getItem(IDEMPOTENCY_STORAGE_KEY);
+	} catch {
+		return null;
+	}
+	if (!raw) return {};
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		try {
+			storage.removeItem(IDEMPOTENCY_STORAGE_KEY);
+		} catch {
+			// Ignore storage failures; idempotency still falls back to a fresh key.
+		}
+		return {};
+	}
+
+	if (!isRecord(parsed)) return {};
+
+	const attempts: StoredAttempts = {};
+	let changed = false;
+	for (const [key, value] of Object.entries(parsed)) {
+		if (!isStoredAttempt(value)) {
+			changed = true;
+			continue;
+		}
+		if (now - value.createdAt > ttlMs) {
+			changed = true;
+			continue;
+		}
+		attempts[key] = value;
+	}
+
+	if (changed) {
+		writeStoredAttempts(storage, attempts);
+	}
+	return attempts;
+}
+
+function writeStoredAttempts(storage: Storage, attempts: StoredAttempts): boolean {
+	try {
+		storage.setItem(IDEMPOTENCY_STORAGE_KEY, JSON.stringify(attempts));
+		return true;
+	} catch {
+		// Storage can be unavailable, full, or denied. The caller still receives
+		// a key, but remount persistence is best-effort in that environment.
+		return false;
+	}
+}
+
+function browserSessionStorage(): Storage | null {
+	if (typeof window === "undefined") return null;
+	try {
+		return window.sessionStorage ?? null;
+	} catch {
+		return null;
+	}
+}
+
 export function idempotencyAttemptFor(
 	current: IdempotencyAttempt | null,
 	prefix: string,
 	fingerprint: string,
 	mintKey: MintIdempotencyKey = newIdempotencyKey,
+	options: IdempotencyPersistenceOptions = {},
 ): IdempotencyAttempt {
-	if (current?.fingerprint === fingerprint) return current;
-	return { fingerprint, key: mintKey(prefix) };
+	const now = options.now?.() ?? Date.now();
+	const ttlMs = options.ttlMs ?? IDEMPOTENCY_ATTEMPT_TTL_MS;
+	const storage = options.storage === undefined ? browserSessionStorage() : options.storage;
+	const freshCurrent =
+		current?.fingerprint === fingerprint &&
+		(current.createdAt === undefined || now - current.createdAt <= ttlMs)
+			? current
+			: null;
+
+	if (storage) {
+		const entryKey = storageEntryKey(prefix, fingerprint);
+		const attempts = readStoredAttempts(storage, now, ttlMs);
+		if (!attempts) {
+			if (freshCurrent) return freshCurrent;
+			return { createdAt: now, fingerprint, key: mintKey(prefix) };
+		}
+		const persisted = attempts[entryKey];
+		if (persisted) {
+			if (freshCurrent && freshCurrent.key === persisted.key) return freshCurrent;
+			return { createdAt: persisted.createdAt, fingerprint, key: persisted.key };
+		}
+
+		const attempt = freshCurrent ?? { createdAt: now, fingerprint, key: mintKey(prefix) };
+		attempts[entryKey] = { key: attempt.key, createdAt: attempt.createdAt ?? now };
+		writeStoredAttempts(storage, attempts);
+		return attempt;
+	}
+
+	if (freshCurrent) return freshCurrent;
+	return { createdAt: now, fingerprint, key: mintKey(prefix) };
 }

--- a/apps/web/src/hosted/deployment-status.test.ts
+++ b/apps/web/src/hosted/deployment-status.test.ts
@@ -59,15 +59,17 @@ describe("DeploymentStatus", () => {
 		}
 	});
 
-	test("drives lifecycle gates from settled statuses only", () => {
+	test("drives lifecycle gates from recoverable statuses", () => {
 		expect(isRunningStatus(parseDeploymentStatus("running"))).toBe(true);
 		expect(isRunningStatus(parseDeploymentStatus("ready"))).toBe(true);
 		expect(canStop(parseDeploymentStatus("running"))).toBe(true);
-		expect(canStop(parseDeploymentStatus("starting"))).toBe(false);
+		expect(canStop(parseDeploymentStatus("starting"))).toBe(true);
 		expect(canStart(parseDeploymentStatus("stopped"))).toBe(true);
 		expect(canStart(parseDeploymentStatus("failed"))).toBe(true);
 		expect(canStart(parseDeploymentStatus("error"))).toBe(true);
+		expect(canStart(parseDeploymentStatus("starting"))).toBe(false);
 		expect(canRestart(parseDeploymentStatus("ready"))).toBe(true);
+		expect(canRestart(parseDeploymentStatus("starting"))).toBe(true);
 		expect(canRestart(parseDeploymentStatus("failed"))).toBe(true);
 		expect(canRestart(parseDeploymentStatus("restarting"))).toBe(false);
 		expect(canRestart(parseDeploymentStatus("future_status"))).toBe(false);

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -118,11 +118,16 @@ export function canStart(status: DeploymentStatus): boolean {
 }
 
 export function canStop(status: DeploymentStatus): boolean {
-	return isRunningStatus(status);
+	return isRunningStatus(status) || status.kind === "starting";
 }
 
 export function canRestart(status: DeploymentStatus): boolean {
-	return isRunningStatus(status) || status.kind === "failed" || status.kind === "error";
+	return (
+		isRunningStatus(status) ||
+		status.kind === "starting" ||
+		status.kind === "failed" ||
+		status.kind === "error"
+	);
 }
 
 export function shouldPollDeployments(


### PR DESCRIPTION
## What / why

- MONEY (HIGH), verifier refs `deploy-wizard.tsx` ~366 and `hosted-agent-detail.tsx` ~1255: persisted checkout/deploy idempotency attempts in `sessionStorage` as a `prefix + fingerprint` map with a 30-minute TTL. The same logical deployment/term/config now reuses the same key across Back/remount/reload within the TTL, while changed fingerprints mint fresh keys. The helper is SSR/no-window safe and falls back to the in-mount ref when storage is unavailable.
- LIFECYCLE, verifier refs `hosted-agent-detail.tsx` ~1493 and ~1701: direct fire-and-forget `runAction(...)` callers now attach a rejection handler. Mutation `onError`/local catch paths still own user-facing toasts, while discarded promises no longer produce browser `unhandledrejection`. `ConfirmAction` callers are unchanged.
- LIFECYCLE, verifier ref `deployment-status.ts` ~120: restored `starting` as stoppable/restartable so stuck starting deployments can recover. `canStart` remains limited to stopped/failed/error.
- MONEY/STATE, verifier refs `billing/hooks.ts` ~211 and ~232: cancel/resume subscription success now patches the deployments cache without immediately invalidating it, preventing eventually-consistent stale list responses from clobbering the correct `compute_subscription.cancel_at_period_end` state.

## Tests

- Added persisted idempotency tests for same fingerprint remount reuse, changed fingerprint, TTL expiry, and SSR/no-window fallback.
- Updated deployment-status lifecycle tests to lock in `starting` stop/restart recovery.
- Added a QueryClient-level subscription patch test that verifies cancel/resume state updates without immediate deployments invalidation.

## Verification

- `bun run check:fix`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`

## Still needs staging verification

- Real Stripe/deploy-api dedup across Back/remount/full reload: submit the same deployment/term/config after returning from Stripe and confirm the same `Idempotency-Key` is reused and no duplicate subscription/deployment is created. Also confirm changed plan/term/config mints a fresh key.
