### PR TITLE
Surface load errors on core agent surfaces (error vs empty)

### DIFF
--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -2,8 +2,9 @@
 
 import type { components } from "@clawdi/shared/api";
 import { Link } from "@tanstack/react-router";
-import { AlertCircle, ArrowUpRight } from "lucide-react";
+import { ArrowUpRight } from "lucide-react";
 import { useState } from "react";
+import { type ApiErrorNormalizer, ApiErrorPanel } from "@/components/api-error-panel";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import {
 	AgentSourceBadge,
@@ -139,16 +140,25 @@ export function fleetSummaryFromTiles(agents: readonly AgentTile[]): AgentFleetS
 export function AgentsCard({
 	agents,
 	isLoading,
+	error,
+	onRetry,
 	hostedStatus,
 }: {
 	agents: AgentTile[];
 	isLoading: boolean;
+	error?: unknown;
+	onRetry?: () => void;
 	/**
 	 * Optional secondary loading/error slice for hosted deployments.
 	 * Lets the card show "fetching hosted agents" or surface a network
 	 * problem inline without blocking the self-managed list.
 	 */
-	hostedStatus?: { isLoading: boolean; error?: Error | null };
+	hostedStatus?: {
+		isLoading: boolean;
+		error?: unknown;
+		onRetry?: () => void;
+		normalizer?: ApiErrorNormalizer;
+	};
 }) {
 	const [showAll, setShowAll] = useState(false);
 	const total = agents.length;
@@ -164,7 +174,9 @@ export function AgentsCard({
 	return (
 		<section className="space-y-3">
 			<div className="space-y-3">
-				{isLoading ? (
+				{error ? (
+					<ApiErrorPanel error={error} onRetry={onRetry} title="Couldn't load agents" />
+				) : isLoading ? (
 					<div className={ENTITY_GRID_CLASS}>
 						{Array.from({ length: 4 }).map((_, i) => (
 							<TileSkeleton key={i} />
@@ -197,7 +209,13 @@ export function AgentsCard({
 						description="Connect an agent to see it here."
 					/>
 				)}
-				{hostedStatus?.error ? <HostedUnavailableBanner /> : null}
+				{hostedStatus?.error ? (
+					<HostedUnavailableBanner
+						error={hostedStatus.error}
+						onRetry={hostedStatus.onRetry}
+						normalizer={hostedStatus.normalizer}
+					/>
+				) : null}
 			</div>
 		</section>
 	);
@@ -209,14 +227,22 @@ export function AgentsCard({
  * /agents view so the copy + chrome match. Self-managed and connected agents
  * are the same thing here, so the copy stays neutral.
  */
-export function HostedUnavailableBanner() {
+export function HostedUnavailableBanner({
+	error,
+	onRetry,
+	normalizer,
+}: {
+	error: unknown;
+	onRetry?: () => void;
+	normalizer?: ApiErrorNormalizer;
+}) {
 	return (
-		<div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-muted-foreground">
-			<AlertCircle className="size-3.5 shrink-0 text-destructive" />
-			<span>
-				Clawdi Cloud agents are unavailable right now. Other agents can still appear here.
-			</span>
-		</div>
+		<ApiErrorPanel
+			error={error}
+			onRetry={onRetry}
+			normalizer={normalizer}
+			title="Couldn't load Clawdi Cloud agents"
+		/>
 	);
 }
 

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetAgentBreadcrumbTitle } from "@/components/breadcrumb-title";
 import {
 	AgentSourceBadgeForEnvironment,
@@ -47,6 +48,7 @@ import {
 	CONNECTED_AGENT_SECTION_IDS,
 } from "@/lib/agent-routes";
 import { unwrap, useApi } from "@/lib/api";
+import { isApiNotFoundError } from "@/lib/api-errors";
 import { fetchAllPages } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
 import { sessionListQueryOptions } from "@/lib/session-queries";
@@ -107,6 +109,7 @@ export function ConnectedAgentDetail({
 		data: agent,
 		isLoading,
 		error,
+		refetch: refetchAgent,
 	} = useQuery({
 		queryKey: ["agents", id],
 		queryFn: async () =>
@@ -117,7 +120,11 @@ export function ConnectedAgentDetail({
 			),
 	});
 
-	const { data: projects } = useQuery({
+	const {
+		data: projects,
+		error: projectsError,
+		refetch: refetchProjects,
+	} = useQuery({
 		queryKey: ["projects"],
 		queryFn: async (): Promise<ProjectRow[]> => unwrap(await api.GET("/v1/projects")),
 		enabled: !!agent,
@@ -132,7 +139,12 @@ export function ConnectedAgentDetail({
 		[projects],
 	);
 
-	const { data: projectBindings, isLoading: projectBindingsLoading } = useQuery({
+	const {
+		data: projectBindings,
+		isLoading: projectBindingsLoading,
+		error: projectBindingsError,
+		refetch: refetchProjectBindings,
+	} = useQuery({
 		queryKey: ["agent-project-bindings", id],
 		queryFn: async (): Promise<ProjectBindingRow[]> =>
 			unwrap(
@@ -143,7 +155,12 @@ export function ConnectedAgentDetail({
 		enabled: !!agent,
 	});
 
-	const { data: sessionsPage, isLoading: sessionsLoading } = useQuery({
+	const {
+		data: sessionsPage,
+		isLoading: sessionsLoading,
+		error: sessionsError,
+		refetch: refetchSessions,
+	} = useQuery({
 		...sessionListQueryOptions(api, { environment_id: id, page_size: 50 }),
 		enabled: !!agent,
 	});
@@ -163,7 +180,12 @@ export function ConnectedAgentDetail({
 	// page uses; hard cap at 50 pages = 10k skills as a
 	// runaway-listing guard.
 	const agentProjectId = agent?.default_project_id;
-	const { data: skillsData, isLoading: skillsLoading } = useQuery({
+	const {
+		data: skillsData,
+		isLoading: skillsLoading,
+		error: skillsError,
+		refetch: refetchSkills,
+	} = useQuery({
 		queryKey: ["skills", agentProjectId, "all-pages"],
 		queryFn: async () =>
 			fetchAllPages<SkillSummary>(
@@ -207,7 +229,7 @@ export function ConnectedAgentDetail({
 		onError: (e) => toast.error("Couldn't uninstall skill", { description: errorMessage(e) }),
 	});
 
-	const sessionTotal = sessionsPage?.total ?? 0;
+	const sessionTotal = sessionsError ? "—" : (sessionsPage?.total ?? 0);
 	const activeTabMeta = AGENT_DETAIL_NAV_META[activeTab];
 	const activeTabLabel = agentSectionLabel(activeTab);
 	const ActiveTabIcon = activeTabMeta.icon;
@@ -240,7 +262,17 @@ export function ConnectedAgentDetail({
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6")}>
 			{error ? (
-				<DetailNotFound title="Agent not found" message={errorMessage(error)} />
+				isApiNotFoundError(error) ? (
+					<DetailNotFound title="Agent not found" message={errorMessage(error)} />
+				) : (
+					<ApiErrorPanel
+						error={error}
+						onRetry={() => {
+							void refetchAgent();
+						}}
+						title="Couldn't load agent"
+					/>
+				)
 			) : isLoading ? (
 				<AgentDetailContentSkeleton />
 			) : agent ? (
@@ -259,43 +291,96 @@ export function ConnectedAgentDetail({
 								<AgentStatPanel label="Sessions" value={sessionTotal} />
 								<AgentStatPanel
 									label="Skills"
-									value={skillsForThisEnv ? skillsForThisEnv.length : "—"}
+									value={skillsError ? "—" : skillsForThisEnv ? skillsForThisEnv.length : "—"}
 								/>
-								<AgentStatPanel label="Projects" value={projectBindings?.length ?? "—"} />
+								<AgentStatPanel
+									label="Projects"
+									value={projectBindingsError ? "—" : (projectBindings?.length ?? "—")}
+								/>
 							</div>
-							<SessionFeed
-								sessions={(sessionsPage?.items ?? []).slice(0, 5)}
-								isLoading={sessionsLoading}
-								emptyMessage="No sessions synced from this agent yet."
-								emptyVariant="inset"
-								showAgent={false}
-								sessionLink={(session) => scopedSessionLink(session.id)}
-							/>
+							{skillsError ? (
+								<ApiErrorPanel
+									error={skillsError}
+									onRetry={() => {
+										void refetchSkills();
+									}}
+									title="Couldn't load agent skills"
+								/>
+							) : null}
+							{projectBindingsError ? (
+								<ApiErrorPanel
+									error={projectBindingsError}
+									onRetry={() => {
+										void refetchProjectBindings();
+									}}
+									title="Couldn't load agent Projects"
+								/>
+							) : null}
+							{sessionsError ? (
+								<ApiErrorPanel
+									error={sessionsError}
+									onRetry={() => {
+										void refetchSessions();
+									}}
+									title="Couldn't load agent sessions"
+								/>
+							) : (
+								<SessionFeed
+									sessions={(sessionsPage?.items ?? []).slice(0, 5)}
+									isLoading={sessionsLoading}
+									emptyMessage="No sessions synced from this agent yet."
+									emptyVariant="inset"
+									showAgent={false}
+									sessionLink={(session) => scopedSessionLink(session.id)}
+								/>
+							)}
 						</div>
 					) : null}
 
 					{activeTab === "sessions" ? (
-						<SessionFeed
-							sessions={sessionsPage?.items ?? []}
-							isLoading={sessionsLoading}
-							emptyMessage="No sessions synced from this agent yet."
-							showAgent={false}
-							sessionLink={(session) => scopedSessionLink(session.id)}
-						/>
+						sessionsError ? (
+							<ApiErrorPanel
+								error={sessionsError}
+								onRetry={() => {
+									void refetchSessions();
+								}}
+								title="Couldn't load agent sessions"
+							/>
+						) : (
+							<SessionFeed
+								sessions={sessionsPage?.items ?? []}
+								isLoading={sessionsLoading}
+								emptyMessage="No sessions synced from this agent yet."
+								showAgent={false}
+								sessionLink={(session) => scopedSessionLink(session.id)}
+							/>
+						)
 					) : null}
 
 					{activeTab === "skills" ? (
-						<SkillCardGrid
-							skills={skillsForThisEnv ?? []}
-							isLoading={skillsLoading}
-							emptyMessage="No skills installed on this agent yet."
-							readOnlySkillCheck={(s) =>
-								!s.project_id || !(writableProjectIds?.has(s.project_id) ?? false)
-							}
-							onUninstall={(skillKey, projectId) => uninstallSkill.mutate({ skillKey, projectId })}
-							uninstallPending={uninstallSkill.isPending}
-							skillLink={scopedSkillLink}
-						/>
+						skillsError ? (
+							<ApiErrorPanel
+								error={skillsError}
+								onRetry={() => {
+									void refetchSkills();
+								}}
+								title="Couldn't load agent skills"
+							/>
+						) : (
+							<SkillCardGrid
+								skills={skillsForThisEnv ?? []}
+								isLoading={skillsLoading}
+								emptyMessage="No skills installed on this agent yet."
+								readOnlySkillCheck={(s) =>
+									!s.project_id || !(writableProjectIds?.has(s.project_id) ?? false)
+								}
+								onUninstall={(skillKey, projectId) =>
+									uninstallSkill.mutate({ skillKey, projectId })
+								}
+								uninstallPending={uninstallSkill.isPending}
+								skillLink={scopedSkillLink}
+							/>
+						)
 					) : null}
 
 					{activeTab === "projects" ? (
@@ -304,6 +389,14 @@ export function ConnectedAgentDetail({
 							bindings={projectBindings ?? []}
 							projects={projects ?? []}
 							isLoading={projectBindingsLoading}
+							bindingsError={projectBindingsError}
+							onRetryBindings={() => {
+								void refetchProjectBindings();
+							}}
+							projectsError={projectsError}
+							onRetryProjects={() => {
+								void refetchProjects();
+							}}
 							onChanged={() => {
 								queryClient.invalidateQueries({
 									queryKey: ["agent-project-bindings", id],
@@ -384,12 +477,20 @@ function AgentProjectsPanel({
 	bindings,
 	projects,
 	isLoading,
+	bindingsError,
+	onRetryBindings,
+	projectsError,
+	onRetryProjects,
 	onChanged,
 }: {
 	agentId: string;
 	bindings: ProjectBindingRow[];
 	projects: ProjectRow[];
 	isLoading: boolean;
+	bindingsError?: unknown;
+	onRetryBindings?: () => void;
+	projectsError?: unknown;
+	onRetryProjects?: () => void;
 	onChanged: () => void;
 }) {
 	const api = useApi();
@@ -467,6 +568,26 @@ function AgentProjectsPanel({
 	};
 
 	if (isLoading) return <Skeleton className="h-40 w-full" />;
+
+	if (bindingsError) {
+		return (
+			<ApiErrorPanel
+				error={bindingsError}
+				onRetry={onRetryBindings}
+				title="Couldn't load agent Projects"
+			/>
+		);
+	}
+
+	if (projectsError) {
+		return (
+			<ApiErrorPanel
+				error={projectsError}
+				onRetry={onRetryProjects}
+				title="Couldn't load Projects"
+			/>
+		);
+	}
 
 	return (
 		<div className="space-y-4">

--- a/apps/web/src/components/dashboard/resources-card.tsx
+++ b/apps/web/src/components/dashboard/resources-card.tsx
@@ -3,6 +3,7 @@
 import { Link } from "@tanstack/react-router";
 import type { LucideIcon } from "lucide-react";
 import { CheckCircle2 } from "lucide-react";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { PROJECT_RESOURCE_ICONS } from "@/components/project-resource-icons";
 import { ProjectResourcePath } from "@/components/project-resource-path";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -26,7 +27,7 @@ import { cn, formatNumber } from "@/lib/utils";
 type Resource = {
 	icon: LucideIcon;
 	definition: ProjectResourceDefinition;
-	count: number;
+	count: number | null;
 };
 
 export type ProjectTypeCounts = {
@@ -49,37 +50,53 @@ function formatProjectTypeCounts(counts: ProjectTypeCounts) {
 	return `${formatNumber(counts.custom)} Custom · ${formatNumber(counts.global)} Global · ${formatNumber(counts.agent)} Agent`;
 }
 
-function buildResources(stats: DashboardStats, projectCount: number): Resource[] {
+function buildResources(stats: DashboardStats, projectCount: number | null): Resource[] {
 	return PROJECT_RESOURCE_NAV_IDS.map((id) => {
 		const definition = getProjectResourceDefinition(id);
 		return {
 			icon: PROJECT_RESOURCE_ICONS[id],
 			definition,
-			count: projectResourceCount(definition, stats, projectCount),
+			count:
+				id === "projects" && projectCount === null
+					? null
+					: projectResourceCount(definition, stats, projectCount ?? 0),
 		};
 	});
 }
 
 export function ResourcesCard({
 	stats,
+	statsError,
+	onRetryStats,
 	projectCount,
 	projectTypeCounts,
 	projectCountLoading = false,
+	projectCountError,
+	onRetryProjectCount,
 	hasConnectedAgent,
 }: {
 	stats: DashboardStats | undefined;
+	statsError?: unknown;
+	onRetryStats?: () => void;
 	projectCount: number | undefined;
 	projectTypeCounts?: ProjectTypeCounts;
 	projectCountLoading?: boolean;
+	projectCountError?: unknown;
+	onRetryProjectCount?: () => void;
 	hasConnectedAgent?: boolean;
 }) {
-	const ready = stats && (!projectCountLoading || projectCount !== undefined);
+	const projectCountUnavailable = Boolean(projectCountError && projectCount === undefined);
+	const ready =
+		stats &&
+		!statsError &&
+		(!projectCountLoading || projectCount !== undefined || projectCountUnavailable);
 	const waitingForAgent = hasConnectedAgent === false;
 	const finalStep = waitingForAgent ? "Ready to Add to agent" : "Add to agent";
 	// The "First path" walkthrough is onboarding — once the user has
 	// created a custom Project they've walked the path, and the banner
 	// is just permanent noise above their real counts. Hide it then.
 	const established = (projectTypeCounts?.custom ?? 0) > 0;
+	const showFirstPath = !projectCountUnavailable && !established;
 	return (
 		<Card className="gap-0 pb-0">
 			<CardHeader className="border-b">
@@ -90,49 +107,73 @@ export function ResourcesCard({
 				</CardDescription>
 			</CardHeader>
 			<CardContent className="p-0">
-				{established ? null : (
-					<div className="grid gap-3 border-b bg-muted/15 px-6 py-4 text-xs">
-						<div className="flex flex-wrap items-center gap-2">
-							<span className="font-medium text-foreground">
-								{waitingForAgent ? "After connecting an agent" : "First path"}
-							</span>
-							{[...FIRST_PATH_STEPS, finalStep].map((step, index) => (
-								<span
-									key={step}
-									className={cn(
-										"inline-flex items-center gap-1 rounded-sm border bg-background px-2 py-1 text-muted-foreground",
-										waitingForAgent && index === 2 && "border-dashed opacity-60",
-									)}
-								>
-									<span className="font-medium tabular-nums text-foreground">{index + 1}.</span>
-									{step}
-								</span>
-							))}
-						</div>
-						<p className="text-muted-foreground">
-							Create Projects to share with teammates. Use the Global Project for defaults. Agent
-							Projects stay private to one agent. Skills and Vaults live in Projects; Sessions,
-							Memories, and Connectors apply account-wide.
-						</p>
-					</div>
-				)}
-				<div className="divide-y">
-					{ready ? (
-						<ProjectResourceGroups
-							resources={buildResources(stats, projectCount ?? 0)}
-							projectTypeCounts={projectTypeCounts}
+				{statsError ? (
+					<div className="p-6">
+						<ApiErrorPanel
+							error={statsError}
+							onRetry={onRetryStats}
+							title="Couldn't load resources"
 						/>
-					) : (
-						PROJECT_RESOURCE_GROUPS.map((group) => (
-							<div key={group.id}>
-								<ResourceGroupLabel label={group.label} />
-								{group.resourceIds.map((id) => (
-									<ResourceRowSkeleton key={id} />
-								))}
+					</div>
+				) : (
+					<>
+						{projectCountError ? (
+							<div className="border-b px-6 py-4">
+								<ApiErrorPanel
+									error={projectCountError}
+									onRetry={onRetryProjectCount}
+									title="Couldn't load project count"
+								/>
 							</div>
-						))
-					)}
-				</div>
+						) : null}
+						{showFirstPath ? (
+							<div className="grid gap-3 border-b bg-muted/15 px-6 py-4 text-xs">
+								<div className="flex flex-wrap items-center gap-2">
+									<span className="font-medium text-foreground">
+										{waitingForAgent ? "After connecting an agent" : "First path"}
+									</span>
+									{[...FIRST_PATH_STEPS, finalStep].map((step, index) => (
+										<span
+											key={step}
+											className={cn(
+												"inline-flex items-center gap-1 rounded-sm border bg-background px-2 py-1 text-muted-foreground",
+												waitingForAgent && index === 2 && "border-dashed opacity-60",
+											)}
+										>
+											<span className="font-medium tabular-nums text-foreground">{index + 1}.</span>
+											{step}
+										</span>
+									))}
+								</div>
+								<p className="text-muted-foreground">
+									Create Projects to share with teammates. Use the Global Project for defaults.
+									Agent Projects stay private to one agent. Skills and Vaults live in Projects;
+									Sessions, Memories, and Connectors apply account-wide.
+								</p>
+							</div>
+						) : null}
+						<div className="divide-y">
+							{ready ? (
+								<ProjectResourceGroups
+									resources={buildResources(
+										stats,
+										projectCountUnavailable ? null : (projectCount ?? 0),
+									)}
+									projectTypeCounts={projectCountUnavailable ? undefined : projectTypeCounts}
+								/>
+							) : (
+								PROJECT_RESOURCE_GROUPS.map((group) => (
+									<div key={group.id}>
+										<ResourceGroupLabel label={group.label} />
+										{group.resourceIds.map((id) => (
+											<ResourceRowSkeleton key={id} />
+										))}
+									</div>
+								))
+							)}
+						</div>
+					</>
+				)}
 			</CardContent>
 		</Card>
 	);
@@ -190,6 +231,7 @@ function ResourceRow({
 	resource: Resource;
 	projectTypeCounts?: ProjectTypeCounts;
 }) {
+	const countUnavailable = resource.count === null;
 	const empty = resource.count === 0;
 	const Icon = resource.icon;
 	const { definition } = resource;
@@ -200,10 +242,13 @@ function ResourceRow({
 	const isProjectRow = definition.id === "projects";
 	const count = (
 		<span
-			className={cn("text-sm tabular-nums", empty ? "text-muted-foreground" : "font-semibold")}
+			className={cn(
+				"text-sm tabular-nums",
+				empty || countUnavailable ? "text-muted-foreground" : "font-semibold",
+			)}
 			title={scopeLabel}
 		>
-			{formatNumber(resource.count)}
+			{countUnavailable ? "—" : formatNumber(resource.count ?? 0)}
 		</span>
 	);
 	const countCluster =

--- a/apps/web/src/components/dashboard/this-week-card.tsx
+++ b/apps/web/src/components/dashboard/this-week-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { ContributionDay, DashboardStats } from "@/lib/api-schemas";
@@ -14,9 +15,13 @@ function sessionsInLastDays(contribution: ContributionDay[] | undefined, days: n
 export function ThisWeekCard({
 	stats,
 	contribution,
+	error,
+	onRetry,
 }: {
 	stats: DashboardStats | undefined;
 	contribution: ContributionDay[] | undefined;
+	error?: unknown;
+	onRetry?: () => void;
 }) {
 	const ready = !!stats;
 	const weekSessions = sessionsInLastDays(contribution, 7);
@@ -32,32 +37,38 @@ export function ThisWeekCard({
 				<CardDescription>Last 7 days of agent activity.</CardDescription>
 			</CardHeader>
 			<CardContent className="space-y-5">
-				{/* Hero — the user's own sessions. Fleet automation is the quiet
+				{error ? (
+					<ApiErrorPanel error={error} onRetry={onRetry} title="Couldn't load weekly activity" />
+				) : (
+					<>
+						{/* Hero — the user's own sessions. Fleet automation is the quiet
 				    sub-line, not the headline. */}
-				<div>
-					<div className="text-xs text-muted-foreground">Your sessions</div>
-					{ready && manualWeek !== undefined ? (
-						<>
-							<div className="text-3xl font-semibold tabular-nums leading-none">
-								{formatNumber(Math.min(manualWeek, weekSessions))}
-							</div>
-							{automatedWeek !== null && automatedWeek > 0 ? (
-								<div className="mt-1 text-xs text-muted-foreground tabular-nums">
-									+ {formatNumber(automatedWeek)} automated (cron, heartbeat)
-								</div>
-							) : null}
-						</>
-					) : (
-						<Skeleton className="h-9 w-16" />
-					)}
-				</div>
+						<div>
+							<div className="text-xs text-muted-foreground">Your sessions</div>
+							{ready && manualWeek !== undefined ? (
+								<>
+									<div className="text-3xl font-semibold tabular-nums leading-none">
+										{formatNumber(Math.min(manualWeek, weekSessions))}
+									</div>
+									{automatedWeek !== null && automatedWeek > 0 ? (
+										<div className="mt-1 text-xs text-muted-foreground tabular-nums">
+											+ {formatNumber(automatedWeek)} automated (cron, heartbeat)
+										</div>
+									) : null}
+								</>
+							) : (
+								<Skeleton className="h-9 w-16" />
+							)}
+						</div>
 
-				{/* Secondary stats — smaller, grouped. */}
-				<dl className="grid grid-cols-3 gap-3 text-sm">
-					<SecondaryStat label="Today" value={ready ? formatNumber(todaySessions) : null} />
-					<SecondaryStat label="Streak" value={ready ? `${stats.current_streak}d` : null} />
-					<SecondaryStat label="Top model" value={ready ? (topModel ?? "—") : null} small />
-				</dl>
+						{/* Secondary stats — smaller, grouped. */}
+						<dl className="grid grid-cols-3 gap-3 text-sm">
+							<SecondaryStat label="Today" value={ready ? formatNumber(todaySessions) : null} />
+							<SecondaryStat label="Streak" value={ready ? `${stats.current_streak}d` : null} />
+							<SecondaryStat label="Top model" value={ready ? (topModel ?? "—") : null} small />
+						</dl>
+					</>
+				)}
 			</CardContent>
 		</Card>
 	);

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -38,6 +38,7 @@ export function AgentHome({
 		isLoading,
 		isFetching,
 		error,
+		refetch,
 	} = useAgentDeployment(environmentId);
 	const requestedHostedAgent =
 		searchParams.get("source") === "on-clawdi" || !isCloudEnvId(environmentId);
@@ -57,6 +58,9 @@ export function AgentHome({
 				<ApiErrorPanel
 					normalizer={billingErrorNormalizer}
 					error={error}
+					onRetry={() => {
+						void refetch();
+					}}
 					title="Couldn’t load hosted agent"
 				/>
 			</div>

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -119,6 +119,7 @@ export function useAgentDeployment(environmentId: string) {
 		isLoading: query.isLoading,
 		isFetching: query.isFetching,
 		error: query.error,
+		refetch: query.refetch,
 	};
 }
 

--- a/apps/web/src/hosted/hosted-agents-section.tsx
+++ b/apps/web/src/hosted/hosted-agents-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { components } from "@clawdi/shared/api";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { AgentSourceBadge } from "@/components/dashboard/agent-label";
 import {
 	AgentsCard,
@@ -11,6 +12,7 @@ import {
 import { OnboardingCard } from "@/components/dashboard/onboarding-card";
 import { SectionLabel } from "@/components/section-label";
 import { useLegacyEnvIds } from "@/hosted/agents/ownership-sensor";
+import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { legacyConnectedAgentTiles } from "@/hosted/legacy-agent-tiles";
 import { useHostedAgentTiles } from "@/hosted/use-hosted-agent-tiles";
 import { normalizeAgentEnvId } from "@/lib/agent-ownership";
@@ -43,6 +45,8 @@ type Env = components["schemas"]["AgentResponse"];
 export function HostedAgentsSection({
 	selfManagedTiles,
 	envsLoading,
+	selfManagedError,
+	onRetrySelfManaged,
 	selfManagedCount,
 	cloudEnvs,
 	showCloudDeployments = true,
@@ -50,6 +54,8 @@ export function HostedAgentsSection({
 }: {
 	selfManagedTiles: AgentTile[];
 	envsLoading: boolean;
+	selfManagedError?: unknown;
+	onRetrySelfManaged?: () => void;
 	selfManagedCount: number;
 	/**
 	 * Cloud-api environments the parent already fetched for the
@@ -95,6 +101,7 @@ export function HostedAgentsSection({
 	// onboarding hero.
 	const isEmptyState =
 		!envsLoading &&
+		!selfManagedError &&
 		selfManagedCount === 0 &&
 		hosted.tiles.length === 0 &&
 		legacyConnectedTiles.length === 0 &&
@@ -109,9 +116,15 @@ export function HostedAgentsSection({
 				<AgentsCard
 					agents={agentTiles}
 					isLoading={envsLoading}
+					error={selfManagedError}
+					onRetry={onRetrySelfManaged}
 					hostedStatus={{
 						isLoading: ownershipLoading,
 						error: hosted.error,
+						onRetry: () => {
+							void hosted.refetch();
+						},
+						normalizer: billingErrorNormalizer,
 					}}
 				/>
 			)}
@@ -209,6 +222,8 @@ export function HostedSecondaryCTA({
 export function HostedAgentsByCompute({
 	selfManagedTiles,
 	envsLoading,
+	selfManagedError,
+	onRetrySelfManaged,
 	selfManagedCount,
 	cloudEnvs,
 	showCloudDeployments = true,
@@ -216,6 +231,8 @@ export function HostedAgentsByCompute({
 }: {
 	selfManagedTiles: AgentTile[];
 	envsLoading: boolean;
+	selfManagedError?: unknown;
+	onRetrySelfManaged?: () => void;
 	selfManagedCount: number;
 	cloudEnvs: Env[];
 	showCloudDeployments?: boolean;
@@ -257,6 +274,7 @@ export function HostedAgentsByCompute({
 
 	const isEmptyState =
 		!envsLoading &&
+		!selfManagedError &&
 		selfManagedCount === 0 &&
 		hostedTiles.length === 0 &&
 		connectedTiles.length === 0 &&
@@ -300,7 +318,26 @@ export function HostedAgentsByCompute({
 				</section>
 			) : null}
 
-			{hosted.error ? <HostedUnavailableBanner /> : null}
+			{selfManagedError ? (
+				<section className="space-y-2">
+					<SectionLabel>Other agents</SectionLabel>
+					<ApiErrorPanel
+						error={selfManagedError}
+						onRetry={onRetrySelfManaged}
+						title="Couldn't load agents"
+					/>
+				</section>
+			) : null}
+
+			{hosted.error ? (
+				<HostedUnavailableBanner
+					error={hosted.error}
+					onRetry={() => {
+						void hosted.refetch();
+					}}
+					normalizer={billingErrorNormalizer}
+				/>
+			) : null}
 		</div>
 	);
 }

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -213,6 +213,7 @@ export function useHostedAgentTiles({
 		// stays 'pending'); mask both flags when we never fetch.
 		isLoading: configured && includeDeployments ? query.isLoading : false,
 		error: configured && includeDeployments && !unreachableFromOrigin ? query.error : null,
+		refetch: query.refetch,
 	};
 }
 

--- a/apps/web/src/lib/api-errors.test.ts
+++ b/apps/web/src/lib/api-errors.test.ts
@@ -5,6 +5,7 @@ import {
 	formatApiError,
 	isApiAuthError,
 	isApiNetworkError,
+	isApiNotFoundError,
 	isApiServerError,
 	normalizeApiError,
 	parseApiDetail,
@@ -51,6 +52,15 @@ describe("cloud-api error classification", () => {
 	test("401 is an auth error, not server", () => {
 		const e = new ApiError(401, "token expired");
 		expect(isApiAuthError(e)).toBe(true);
+		expect(isApiNotFoundError(e)).toBe(false);
+		expect(isApiServerError(e)).toBe(false);
+		expect(isApiNetworkError(e)).toBe(false);
+	});
+
+	test("404 is a not-found error, not transport", () => {
+		const e = new ApiError(404, "agent not found");
+		expect(isApiNotFoundError(e)).toBe(true);
+		expect(isApiAuthError(e)).toBe(false);
 		expect(isApiServerError(e)).toBe(false);
 		expect(isApiNetworkError(e)).toBe(false);
 	});
@@ -66,6 +76,7 @@ describe("cloud-api error classification", () => {
 			const e = new ApiNetworkError(kind);
 			expect(isApiNetworkError(e)).toBe(true);
 			expect(isApiAuthError(e)).toBe(false);
+			expect(isApiNotFoundError(e)).toBe(false);
 			expect(isApiServerError(e)).toBe(false);
 		}
 	});
@@ -73,6 +84,7 @@ describe("cloud-api error classification", () => {
 	test("non-api errors classify as nothing", () => {
 		const e = new Error("random");
 		expect(isApiAuthError(e)).toBe(false);
+		expect(isApiNotFoundError(e)).toBe(false);
 		expect(isApiServerError(e)).toBe(false);
 		expect(isApiNetworkError(e)).toBe(false);
 	});

--- a/apps/web/src/lib/api-errors.ts
+++ b/apps/web/src/lib/api-errors.ts
@@ -63,6 +63,11 @@ export function isApiAuthError(error: unknown): boolean {
 	return error instanceof ApiError && error.status === 401;
 }
 
+/** True not-found from the API. Transport failures must not collapse to 404 UI. */
+export function isApiNotFoundError(error: unknown): boolean {
+	return error instanceof ApiError && error.status === 404;
+}
+
 /** Backend fault (5xx) or rate-limit (429) — transient; safe to retry. */
 export function isApiServerError(error: unknown): boolean {
 	return error instanceof ApiError && (error.status >= 500 || error.status === 429);

--- a/apps/web/src/pages/dashboard/agents/page.tsx
+++ b/apps/web/src/pages/dashboard/agents/page.tsx
@@ -30,7 +30,12 @@ const HostedAgentsByCompute = IS_HOSTED_BUILD
 export default function AgentsIndexPage() {
 	const api = useApi();
 	const hostedAccess = useHostedProductAccess();
-	const { data: environments, isLoading: envsLoading } = useQuery({
+	const {
+		data: environments,
+		isLoading: envsLoading,
+		error: envsError,
+		refetch: refetchEnvs,
+	} = useQuery({
 		queryKey: ["agents"],
 		queryFn: async () => unwrap(await api.GET("/v1/agents")),
 		// Match the Overview/agent-detail 10s cadence so the live status badges
@@ -57,6 +62,10 @@ export default function AgentsIndexPage() {
 					<HostedAgentsByCompute
 						selfManagedTiles={selfManagedTiles}
 						envsLoading={envsLoading}
+						selfManagedError={envsError}
+						onRetrySelfManaged={() => {
+							void refetchEnvs();
+						}}
 						selfManagedCount={selfManagedCount}
 						cloudEnvs={environments ?? []}
 						showCloudDeployments={hostedAgentsEnabled}
@@ -64,7 +73,14 @@ export default function AgentsIndexPage() {
 					/>
 				</Suspense>
 			) : (
-				<AgentsCard agents={selfManagedTiles} isLoading={envsLoading} />
+				<AgentsCard
+					agents={selfManagedTiles}
+					isLoading={envsLoading}
+					error={envsError}
+					onRetry={() => {
+						void refetchEnvs();
+					}}
+				/>
 			)}
 		</div>
 	);

--- a/apps/web/src/pages/dashboard/page.tsx
+++ b/apps/web/src/pages/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { AddAgentDialog } from "@/components/dashboard/add-agent-dialog";
 import {
 	type AgentFleetSummary,
@@ -82,7 +83,12 @@ export default function DashboardPage() {
 	const api = useApi();
 	const hostedAccess = useHostedProductAccess();
 
-	const { data: stats, isLoading: statsLoading } = useQuery({
+	const {
+		data: stats,
+		isLoading: statsLoading,
+		error: statsError,
+		refetch: refetchStats,
+	} = useQuery({
 		queryKey: ["dashboard-stats"],
 		queryFn: async () => unwrap(await api.GET("/v1/dashboard/stats")),
 		// Overview counts are cheap and reflect recent mutations across many
@@ -91,13 +97,23 @@ export default function DashboardPage() {
 		refetchOnMount: "always",
 	});
 
-	const { data: projects, isLoading: projectsLoading } = useQuery({
+	const {
+		data: projects,
+		isLoading: projectsLoading,
+		error: projectsError,
+		refetch: refetchProjects,
+	} = useQuery({
 		queryKey: ["projects"],
 		queryFn: async () => unwrap(await api.GET("/v1/projects")),
 		staleTime: DASHBOARD_STALE_MS,
 	});
 
-	const { data: environments, isLoading: envsLoading } = useQuery({
+	const {
+		data: environments,
+		isLoading: envsLoading,
+		error: envsError,
+		refetch: refetchEnvs,
+	} = useQuery({
 		queryKey: ["agents"],
 		queryFn: async () => unwrap(await api.GET("/v1/agents")),
 		// Daemon-status badge classification is time-sensitive — a
@@ -110,7 +126,12 @@ export default function DashboardPage() {
 	// Manual sessions only: on a working fleet ~3/4 of sessions are
 	// cron/heartbeat ticks, and "Recent sessions" buried the user's own
 	// work under them. Automation is one click away via View all.
-	const { data: sessionsPage, isLoading: sessionsLoading } = useQuery(
+	const {
+		data: sessionsPage,
+		isLoading: sessionsLoading,
+		error: sessionsError,
+		refetch: refetchSessions,
+	} = useQuery(
 		sessionListQueryOptions(api, {
 			page_size: RECENT_SESSIONS_CACHE_PAGE_SIZE,
 			automated: false,
@@ -137,16 +158,21 @@ export default function DashboardPage() {
 	// `<HostedAgentsSection>` so this page doesn't need the hosted
 	// counts at all.
 	const selfManagedCount = selfManagedTiles.length;
-	const hasAgents = !envsLoading && selfManagedCount > 0;
-	const ossIsEmptyState = !envsLoading && selfManagedCount === 0;
-	const projectTypeCounts = useMemo(() => countProjectTypes(projects), [projects]);
+	const hasAgents = !envsLoading && !envsError && selfManagedCount > 0;
+	const ossIsEmptyState = !envsLoading && !envsError && selfManagedCount === 0;
+	const projectTypeCounts = useMemo(
+		() => (projects ? countProjectTypes(projects) : undefined),
+		[projects],
+	);
 	const hostedAccessLoading = Boolean(HostedAgentsSection && hostedAccess.isLoading);
 	const hostedAgentsEnabled = Boolean(HostedAgentsSection && hostedAccess.canUseCloudAgents);
 	const legacyHostedAgentsEnabled = Boolean(
 		HostedAgentsSection && hostedAccess.canUseLegacyHostedDashboard,
 	);
 	const hostedSectionEnabled = hostedAgentsEnabled || legacyHostedAgentsEnabled;
-	const greeting = renderGreeting(selfManagedFleetSummary);
+	const greeting = renderGreeting(selfManagedFleetSummary, {
+		agentStatusUnavailable: Boolean(envsError),
+	});
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
@@ -160,7 +186,11 @@ export default function DashboardPage() {
 						showCloudDeployments={hostedAgentsEnabled}
 						showLegacyAgents={legacyHostedAgentsEnabled}
 					>
-						{renderGreeting}
+						{(summary) =>
+							renderGreeting(summary, {
+								agentStatusUnavailable: Boolean(envsError) && summary.total === 0,
+							})
+						}
 					</HostedFleetSummary>
 				</Suspense>
 			) : (
@@ -182,6 +212,10 @@ export default function DashboardPage() {
 							<HostedAgentsSection
 								selfManagedTiles={selfManagedTiles}
 								envsLoading={envsLoading}
+								selfManagedError={envsError}
+								onRetrySelfManaged={() => {
+									void refetchEnvs();
+								}}
 								selfManagedCount={selfManagedCount}
 								cloudEnvs={environments ?? []}
 								showCloudDeployments={hostedAgentsEnabled}
@@ -191,7 +225,14 @@ export default function DashboardPage() {
 					) : ossIsEmptyState ? (
 						<OnboardingCard />
 					) : (
-						<AgentsCard agents={selfManagedTiles} isLoading={envsLoading} />
+						<AgentsCard
+							agents={selfManagedTiles}
+							isLoading={envsLoading}
+							error={envsError}
+							onRetry={() => {
+								void refetchEnvs();
+							}}
+						/>
 					)}
 
 					<Card>
@@ -203,7 +244,15 @@ export default function DashboardPage() {
 							</CardDescription>
 						</CardHeader>
 						<CardContent>
-							{statsLoading ? (
+							{statsError ? (
+								<ApiErrorPanel
+									error={statsError}
+									onRetry={() => {
+										void refetchStats();
+									}}
+									title="Couldn't load activity"
+								/>
+							) : statsLoading ? (
 								<ActivityGraphSkeleton />
 							) : contribution ? (
 								<ContributionGraph data={contribution} />
@@ -226,13 +275,23 @@ export default function DashboardPage() {
 								</Link>
 							</Button>
 						</div>
-						<SessionFeed
-							sessions={sessions ?? []}
-							isLoading={sessionsLoading}
-							grouped={false}
-							emptyMessage="No sessions yet. Once your agent starts a conversation, it'll show up here."
-							emptyVariant="inset"
-						/>
+						{sessionsError ? (
+							<ApiErrorPanel
+								error={sessionsError}
+								onRetry={() => {
+									void refetchSessions();
+								}}
+								title="Couldn't load recent sessions"
+							/>
+						) : (
+							<SessionFeed
+								sessions={sessions ?? []}
+								isLoading={sessionsLoading}
+								grouped={false}
+								emptyMessage="No sessions yet. Once your agent starts a conversation, it'll show up here."
+								emptyVariant="inset"
+							/>
+						)}
 					</section>
 				</div>
 
@@ -258,26 +317,47 @@ export default function DashboardPage() {
 					) : null}
 					<ResourcesCard
 						stats={stats}
+						statsError={statsError}
+						onRetryStats={() => {
+							void refetchStats();
+						}}
 						projectCount={projects?.length}
 						projectTypeCounts={projectTypeCounts}
 						projectCountLoading={projectsLoading}
+						projectCountError={projectsError}
+						onRetryProjectCount={() => {
+							void refetchProjects();
+						}}
 						hasConnectedAgent={
-							hostedAccessLoading || hostedSectionEnabled || envsLoading ? undefined : hasAgents
+							hostedAccessLoading || hostedSectionEnabled || envsLoading || envsError
+								? undefined
+								: hasAgents
 						}
 					/>
-					<ThisWeekCard stats={stats} contribution={contribution} />
+					<ThisWeekCard
+						stats={stats}
+						contribution={contribution}
+						error={statsError}
+						onRetry={() => {
+							void refetchStats();
+						}}
+					/>
 				</div>
 			</div>
 		</div>
 	);
 }
 
-function renderGreeting(summary: AgentFleetSummary) {
+function renderGreeting(
+	summary: AgentFleetSummary,
+	options: { agentStatusUnavailable?: boolean } = {},
+) {
 	return (
 		<Greeting
 			activeCount={summary.activeCount}
 			total={summary.total}
 			lastActive={summary.lastActive}
+			agentStatusUnavailable={options.agentStatusUnavailable}
 		/>
 	);
 }
@@ -358,12 +438,14 @@ function Greeting({
 	activeCount,
 	total,
 	lastActive,
+	agentStatusUnavailable = false,
 }: {
 	activeCount: number;
 	total: number;
 	/** Most recent last-seen timestamp across the fleet — the one fact the
 	 * old AgentsCard header carried that the greeting didn't. */
 	lastActive?: string | null;
+	agentStatusUnavailable?: boolean;
 }) {
 	const { user } = useCurrentUser();
 	const [daypart, setDaypart] = useState<ReturnType<typeof currentDaypart> | null>(null);
@@ -371,8 +453,9 @@ function Greeting({
 		setDaypart(currentDaypart());
 	}, []);
 	const firstName = user?.fullName?.split(" ")[0];
-	const summary =
-		total === 0
+	const summary = agentStatusUnavailable
+		? "Agent status is unavailable right now."
+		: total === 0
 			? "Connect your first agent to start syncing."
 			: activeCount > 0
 				? `${activeCount} of ${total} agents active right now.`


### PR DESCRIPTION
## Summary
- Overview now captures failures from dashboard stats, projects, agents, and recent sessions, rendering retryable `ApiErrorPanel` surfaces instead of zero/empty states; count-only project/resource failures show unavailable counts instead of `0`.
- Agents index and shared `AgentsCard` now surface `/v1/agents` failures as a retryable self-managed list error, while keeping hosted deployment errors distinct.
- Connected agent detail now distinguishes true API 404s from transport/API failures: only 404 renders `DetailNotFound`; other primary agent failures render a retryable `ApiErrorPanel`. Section queries for Projects, project bindings, sessions, and skills now render section-local retry panels instead of empty states.
- Hosted agent home and hosted agent sections now pass refetch callbacks into hosted deployment error panels/banners.

## Tests
- `bun run check:fix`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`