### PR TITLE
Remove iMessage from native channels (outdated BlueBubbles path)

### DIFF
--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -76,7 +76,7 @@ const CLOUD_NAV_SHORTCUTS: NavShortcut[] = [
 		href: "/channels",
 		icon: MessagesSquare,
 		subtitle: "Account resources",
-		searchText: "channels telegram discord whatsapp imessage bots messaging",
+		searchText: "channels telegram discord whatsapp bots messaging",
 	},
 	{
 		label: "Model Providers",

--- a/apps/web/src/components/entity-icon.tsx
+++ b/apps/web/src/components/entity-icon.tsx
@@ -29,8 +29,6 @@ const CHANNEL_PNG: Record<string, string> = {
 	telegram: `${ICON_BASE}/telegram.png`,
 	discord: `${ICON_BASE}/discord.png`,
 	whatsapp: `${ICON_BASE}/whatsapp.png`,
-	imessage: `${ICON_BASE}/imessage.png`,
-	bluebubbles: `${ICON_BASE}/bluebubbles.png`,
 	slack: `${ICON_BASE}/slack.png`,
 };
 

--- a/apps/web/src/hosted/v2/README.md
+++ b/apps/web/src/hosted/v2/README.md
@@ -20,5 +20,5 @@ Route entrypoints still use the hosted build flag as a bundle gate plus
 
 ## What lives here today
 
-- `channels/` — Telegram, Discord, WhatsApp, and iMessage channel management.
+- `channels/` — Telegram, Discord, and WhatsApp channel management.
 - `ai-providers/` — Model provider catalog, BYOK credentials, and Codex OAuth.

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -231,6 +231,7 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 
 	const ch = channel.data;
 	const meta = providerMeta(ch.provider);
+	const providerUnavailable = meta.unavailable === true;
 
 	return (
 		<div data-hosted="true" data-v2="true" className={PAGE_CLASS}>
@@ -268,30 +269,39 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 				}
 			/>
 
+			{providerUnavailable ? (
+				<InfoCard icon={TriangleAlert} title="Provider unavailable">
+					This provider is no longer available for new native channels. Existing channel data
+					remains visible, and you can remove the channel.
+				</InfoCard>
+			) : null}
+
 			<Tabs defaultValue="agents" className="min-w-0">
 				<TabsList className="h-auto flex-wrap justify-start">
 					<TabsTrigger value="agents">Agents</TabsTrigger>
-					{ch.provider === "whatsapp" ? (
+					{ch.provider === "whatsapp" && !providerUnavailable ? (
 						<TabsTrigger value="devices">Linked devices</TabsTrigger>
 					) : null}
-					<TabsTrigger value="pair">Pair code</TabsTrigger>
+					{providerUnavailable ? null : <TabsTrigger value="pair">Pair code</TabsTrigger>}
 					<TabsTrigger value="bindings">Chats</TabsTrigger>
 					<TabsTrigger value="activity">Activity</TabsTrigger>
 					<TabsTrigger value="health">Health</TabsTrigger>
-					<TabsTrigger value="commands">Commands</TabsTrigger>
+					{providerUnavailable ? null : <TabsTrigger value="commands">Commands</TabsTrigger>}
 				</TabsList>
 
 				<TabsContent value="agents" className={LIST_TAB_CLASS}>
-					<AgentsTab accountId={id} accountName={ch.name} />
+					<AgentsTab accountId={id} accountName={ch.name} readOnly={providerUnavailable} />
 				</TabsContent>
-				{ch.provider === "whatsapp" ? (
+				{ch.provider === "whatsapp" && !providerUnavailable ? (
 					<TabsContent value="devices" className={FORM_TAB_CLASS}>
 						<WhatsAppDevicesTab accountId={id} />
 					</TabsContent>
 				) : null}
-				<TabsContent value="pair" className={FORM_TAB_CLASS}>
-					<PairCodeTab accountId={id} provider={ch.provider} />
-				</TabsContent>
+				{providerUnavailable ? null : (
+					<TabsContent value="pair" className={FORM_TAB_CLASS}>
+						<PairCodeTab accountId={id} provider={ch.provider} />
+					</TabsContent>
+				)}
 				<TabsContent value="bindings" className={LIST_TAB_CLASS}>
 					<BindingsTab accountId={id} />
 				</TabsContent>
@@ -301,9 +311,11 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 				<TabsContent value="health" className={LIST_TAB_CLASS}>
 					<HealthTab accountId={id} />
 				</TabsContent>
-				<TabsContent value="commands" className={FORM_TAB_CLASS}>
-					<CommandsTab accountId={id} provider={ch.provider} />
-				</TabsContent>
+				{providerUnavailable ? null : (
+					<TabsContent value="commands" className={FORM_TAB_CLASS}>
+						<CommandsTab accountId={id} provider={ch.provider} />
+					</TabsContent>
+				)}
 			</Tabs>
 		</div>
 	);
@@ -311,7 +323,15 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 
 // ── Agents ───────────────────────────────────────────────────────────────────
 
-function AgentsTab({ accountId, accountName }: { accountId: string; accountName: string }) {
+function AgentsTab({
+	accountId,
+	accountName,
+	readOnly = false,
+}: {
+	accountId: string;
+	accountName: string;
+	readOnly?: boolean;
+}) {
 	const links = useChannelAgentLinks(accountId);
 	const envs = useEnvironments();
 	const rotate = useRotateAgentToken(accountId);
@@ -344,10 +364,12 @@ function AgentsTab({ accountId, accountName }: { accountId: string; accountName:
 				label="Linked agents"
 				count={items.length}
 				action={
-					<Button size="sm" onClick={() => setLinkOpen(true)}>
-						<Link2 className="size-3.5" />
-						Link an agent
-					</Button>
+					readOnly ? null : (
+						<Button size="sm" onClick={() => setLinkOpen(true)}>
+							<Link2 className="size-3.5" />
+							Link an agent
+						</Button>
+					)
 				}
 			/>
 
@@ -355,7 +377,11 @@ function AgentsTab({ accountId, accountName }: { accountId: string; accountName:
 				<EmptyState
 					icon={Link2}
 					title="No agents linked"
-					description="Link an agent so it can send and receive on this channel."
+					description={
+						readOnly
+							? "No agents are linked to this channel."
+							: "Link an agent so it can send and receive on this channel."
+					}
 				/>
 			) : (
 				<div className="flex flex-col gap-2">
@@ -369,50 +395,52 @@ function AgentsTab({ accountId, accountName }: { accountId: string; accountName:
 										{relativeTime(link.created_at)}
 									</div>
 								</div>
-								<div className="flex shrink-0 flex-wrap items-center gap-1.5">
-									<Button
-										variant="outline"
-										size="sm"
-										// Per-row: only the acting row's button shows pending, not all.
-										disabled={rotate.isPending && rotate.variables === link.id}
-										onClick={() =>
-											rotate.mutate(link.id, {
-												onSuccess: (data) => {
-													const token = data.agent_token;
-													if (!token) return;
-													setRotated((prev) => ({
-														...prev,
-														[link.id]: token,
-													}));
-												},
-											})
-										}
-									>
-										{rotate.isPending && rotate.variables === link.id ? (
-											<Spinner className="size-3.5" />
-										) : (
-											<RefreshCw className="size-3.5" />
-										)}
-										Rotate token
-									</Button>
-									<ConfirmAction
-										title="Unlink this agent?"
-										description={<p>It stops sending and receiving on {accountName}.</p>}
-										confirmLabel="Unlink"
-										destructive
-										onConfirm={() => unlink.mutateAsync(link.id)}
-									>
+								{readOnly ? null : (
+									<div className="flex shrink-0 flex-wrap items-center gap-1.5">
 										<Button
-											variant="ghost"
-											size="icon-sm"
-											className="text-muted-foreground hover:text-destructive"
-											disabled={unlink.isPending && unlink.variables === link.id}
-											aria-label="Unlink agent"
+											variant="outline"
+											size="sm"
+											// Per-row: only the acting row's button shows pending, not all.
+											disabled={rotate.isPending && rotate.variables === link.id}
+											onClick={() =>
+												rotate.mutate(link.id, {
+													onSuccess: (data) => {
+														const token = data.agent_token;
+														if (!token) return;
+														setRotated((prev) => ({
+															...prev,
+															[link.id]: token,
+														}));
+													},
+												})
+											}
 										>
-											<Link2Off className="size-4" />
+											{rotate.isPending && rotate.variables === link.id ? (
+												<Spinner className="size-3.5" />
+											) : (
+												<RefreshCw className="size-3.5" />
+											)}
+											Rotate token
 										</Button>
-									</ConfirmAction>
-								</div>
+										<ConfirmAction
+											title="Unlink this agent?"
+											description={<p>It stops sending and receiving on {accountName}.</p>}
+											confirmLabel="Unlink"
+											destructive
+											onConfirm={() => unlink.mutateAsync(link.id)}
+										>
+											<Button
+												variant="ghost"
+												size="icon-sm"
+												className="text-muted-foreground hover:text-destructive"
+												disabled={unlink.isPending && unlink.variables === link.id}
+												aria-label="Unlink agent"
+											>
+												<Link2Off className="size-4" />
+											</Button>
+										</ConfirmAction>
+									</div>
+								)}
 							</div>
 							{rotated[link.id] ? (
 								<div className="mt-3">
@@ -428,12 +456,14 @@ function AgentsTab({ accountId, accountName }: { accountId: string; accountName:
 				</div>
 			)}
 
-			<LinkAgentDialog
-				open={linkOpen}
-				onOpenChange={setLinkOpen}
-				accountId={accountId}
-				accountName={accountName}
-			/>
+			{readOnly ? null : (
+				<LinkAgentDialog
+					open={linkOpen}
+					onOpenChange={setLinkOpen}
+					accountId={accountId}
+					accountName={accountName}
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/web/src/hosted/v2/channels/channel-providers.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-providers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import {
+	CHANNEL_PROVIDERS,
+	isChannelProvider,
+	orderedProviderIds,
+	providerMeta,
+} from "./channel-providers";
+
+describe("channel provider registry", () => {
+	test("only exposes providers that can be created from the v2 channels UI", () => {
+		expect(CHANNEL_PROVIDERS).toEqual(["telegram", "discord", "whatsapp"]);
+		expect(isChannelProvider("imessage")).toBe(false);
+	});
+
+	test("keeps legacy iMessage accounts renderable as unavailable", () => {
+		expect(providerMeta("imessage")).toMatchObject({
+			id: "imessage",
+			label: "iMessage (unavailable)",
+			unavailable: true,
+		});
+	});
+
+	test("orders supported providers first and appends legacy providers from data", () => {
+		expect(orderedProviderIds(["imessage", "discord", "telegram", "custom", "telegram"])).toEqual([
+			"telegram",
+			"discord",
+			"imessage",
+			"custom",
+		]);
+	});
+});

--- a/apps/web/src/hosted/v2/channels/channel-providers.ts
+++ b/apps/web/src/hosted/v2/channels/channel-providers.ts
@@ -1,32 +1,37 @@
 /**
- * The four native channel providers (backend `CHANNEL_PROVIDERS`). Each takes
- * DIFFERENT real connect inputs — grounded in cloud-api:
+ * Native channel providers that can be created from the v2 channels UI. Each
+ * takes different real connect inputs:
  *   - telegram:  bot token (BotFather)                → provider_token
  *   - discord:   bot token + application_id + public_key (+ optional guild_id)
  *                                                       → provider_token + config
  *   - whatsapp:  NO token — Baileys device link via the tenant-creds flow
- *   - imessage:  BlueBubbles server_url + password (+ auth_mode)
- *                                                       → provider_token + config
  * Tints reuse the app identity palette so channel chips match the chrome.
  */
-export const CHANNEL_PROVIDERS = ["telegram", "discord", "whatsapp", "imessage"] as const;
+export const CHANNEL_PROVIDERS = ["telegram", "discord", "whatsapp"] as const;
 export type ChannelProviderId = (typeof CHANNEL_PROVIDERS)[number];
 
 /** How the connect form behaves for this provider. */
-export type ChannelConnectMode = "token" | "discord" | "whatsapp" | "imessage";
+export type ChannelConnectMode = "token" | "discord" | "whatsapp";
 
 export interface ChannelProviderMeta {
-	id: ChannelProviderId;
+	id: string;
 	label: string;
 	tint: string;
-	connect: ChannelConnectMode;
+	connect?: ChannelConnectMode;
 	/** Label/placeholder for the single credential field (token / password). */
 	tokenLabel?: string;
 	tokenPlaceholder?: string;
 	hint: string;
+	unavailable?: boolean;
 }
 
-export const PROVIDER_META: Record<ChannelProviderId, ChannelProviderMeta> = {
+export type SupportedChannelProviderMeta = ChannelProviderMeta & {
+	id: ChannelProviderId;
+	connect: ChannelConnectMode;
+	unavailable?: false;
+};
+
+export const PROVIDER_META: Record<ChannelProviderId, SupportedChannelProviderMeta> = {
 	telegram: {
 		id: "telegram",
 		label: "Telegram",
@@ -52,36 +57,48 @@ export const PROVIDER_META: Record<ChannelProviderId, ChannelProviderMeta> = {
 		connect: "whatsapp",
 		hint: "No bot token — connect, then link your WhatsApp number by scanning a code (Linked devices).",
 	},
+};
+
+const LEGACY_PROVIDER_META: Record<string, ChannelProviderMeta> = {
 	imessage: {
 		id: "imessage",
-		label: "iMessage",
-		tint: "bg-identity-6-bg text-identity-6-fg",
-		connect: "imessage",
-		tokenLabel: "BlueBubbles password",
-		tokenPlaceholder: "Server password",
-		hint: "Connect your BlueBubbles server — its URL and password.",
+		label: "iMessage (unavailable)",
+		tint: "bg-muted text-muted-foreground",
+		hint: "iMessage native channels are no longer available in this surface.",
+		unavailable: true,
 	},
 };
 
-/** BlueBubbles auth modes the backend understands (channels.py `_send_imessage`). */
-export const IMESSAGE_AUTH_MODES = [
-	{ value: "password_query", label: "Password (query)" },
-	{ value: "x_api_key", label: "API key header" },
-	{ value: "bearer", label: "Bearer token" },
-] as const;
-
-const DEFAULT_PROVIDER_META: ChannelProviderMeta = {
-	id: "telegram",
-	label: "Channel",
-	tint: "bg-muted text-muted-foreground",
-	connect: "token",
-	hint: "",
-};
+function unknownProviderMeta(id: string): ChannelProviderMeta {
+	return {
+		id,
+		label: id || "Channel",
+		tint: "bg-muted text-muted-foreground",
+		hint: "This channel provider is no longer available in this surface.",
+		unavailable: true,
+	};
+}
 
 export function providerMeta(id: string): ChannelProviderMeta {
-	return PROVIDER_META[id as ChannelProviderId] ?? { ...DEFAULT_PROVIDER_META, label: id };
+	return (
+		PROVIDER_META[id as ChannelProviderId] ?? LEGACY_PROVIDER_META[id] ?? unknownProviderMeta(id)
+	);
 }
 
 export function isChannelProvider(id: string): id is ChannelProviderId {
 	return (CHANNEL_PROVIDERS as readonly string[]).includes(id);
+}
+
+export function orderedProviderIds(providers: Iterable<string>): string[] {
+	const providerList = Array.from(providers);
+	const present = new Set(providerList);
+	const ordered: string[] = CHANNEL_PROVIDERS.filter((provider) => present.has(provider));
+
+	for (const provider of providerList) {
+		if (!isChannelProvider(provider) && !ordered.includes(provider)) {
+			ordered.push(provider);
+		}
+	}
+
+	return ordered;
 }

--- a/apps/web/src/hosted/v2/channels/channels-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channels-page.tsx
@@ -20,11 +20,7 @@ import { SectionLabel } from "@/components/section-label";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-	CHANNEL_PROVIDERS,
-	type ChannelProviderId,
-	providerMeta,
-} from "@/hosted/v2/channels/channel-providers";
+import { orderedProviderIds, providerMeta } from "@/hosted/v2/channels/channel-providers";
 import type { ChannelAccount } from "@/hosted/v2/channels/channel-types";
 import { HealthBadge } from "@/hosted/v2/channels/channel-ui";
 import { useChannelHealth, useChannels } from "@/hosted/v2/channels/channels-hooks";
@@ -32,7 +28,7 @@ import { ConnectBotDialog } from "@/hosted/v2/channels/connect-bot-dialog";
 import { SharedBotsPool } from "@/hosted/v2/channels/shared-bots-pool";
 import { cn } from "@/lib/utils";
 
-const DESCRIPTION = "Connect Telegram, Discord, WhatsApp, and iMessage to your agents.";
+const DESCRIPTION = "Connect Telegram, Discord, and WhatsApp to your agents.";
 const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
 const CHANNEL_GRID_CLASS = ENTITY_GRID_CLASS;
 
@@ -64,7 +60,7 @@ export function ChannelsPage() {
 function YourChannels({ onConnect }: { onConnect: () => void }) {
 	const channels = useChannels();
 	const health = useChannelHealth();
-	const [filter, setFilter] = useState<ChannelProviderId | "all">("all");
+	const [filter, setFilter] = useState<string | "all">("all");
 
 	if (channels.isLoading) {
 		return (
@@ -110,10 +106,11 @@ function YourChannels({ onConnect }: { onConnect: () => void }) {
 	for (const c of all) counts.set(c.provider, (counts.get(c.provider) ?? 0) + 1);
 
 	const visible = filter === "all" ? all : all.filter((c) => c.provider === filter);
-	const groups = CHANNEL_PROVIDERS.map((p) => ({
+	const filterProviders = orderedProviderIds(all.map((channel) => channel.provider));
+	const groups = orderedProviderIds(visible.map((channel) => channel.provider)).map((p) => ({
 		provider: p,
 		items: visible.filter((c) => c.provider === p),
-	})).filter((g) => g.items.length > 0);
+	}));
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -131,7 +128,7 @@ function YourChannels({ onConnect }: { onConnect: () => void }) {
 							All
 							<span className="text-muted-foreground tabular-nums">{all.length}</span>
 						</FilterChip>
-						{CHANNEL_PROVIDERS.filter((p) => counts.has(p)).map((p) => (
+						{filterProviders.map((p) => (
 							<FilterChip key={p} active={filter === p} onClick={() => setFilter(p)}>
 								{providerMeta(p).label}
 								<span className="text-muted-foreground tabular-nums">{counts.get(p)}</span>

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -16,18 +16,9 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/ui/select";
-import {
 	CHANNEL_PROVIDERS,
 	type ChannelProviderId,
-	IMESSAGE_AUTH_MODES,
 	PROVIDER_META,
-	providerMeta,
 } from "@/hosted/v2/channels/channel-providers";
 import type { ChannelCreate, ChannelCreated } from "@/hosted/v2/channels/channel-types";
 import { ProviderChip, TokenReveal } from "@/hosted/v2/channels/channel-ui";
@@ -36,10 +27,9 @@ import { useCreateChannel } from "@/hosted/v2/channels/channels-hooks";
 /**
  * Connect a channel. Each provider takes its OWN real inputs (grounded in
  * cloud-api): Telegram = bot token; Discord = bot token + application_id +
- * public_key (+ guild_id); iMessage = BlueBubbles server_url + password
- * (+ auth_mode); WhatsApp = no token (device is linked afterwards via the
- * Baileys tenant-creds flow on the channel page). On success the webhook
- * secret is revealed once.
+ * public_key (+ guild_id); WhatsApp = no token (device is linked afterwards
+ * via the Baileys tenant-creds flow on the channel page). On success the
+ * webhook secret is revealed once.
  */
 export function ConnectBotDialog({
 	open,
@@ -51,14 +41,11 @@ export function ConnectBotDialog({
 	const create = useCreateChannel();
 	const [provider, setProvider] = useState<ChannelProviderId>("telegram");
 	const [name, setName] = useState("");
-	const [token, setToken] = useState(""); // bot token / BlueBubbles password
+	const [token, setToken] = useState(""); // Telegram / Discord bot token
 	// Discord
 	const [applicationId, setApplicationId] = useState("");
 	const [publicKey, setPublicKey] = useState("");
 	const [guildId, setGuildId] = useState("");
-	// iMessage
-	const [serverUrl, setServerUrl] = useState("");
-	const [authMode, setAuthMode] = useState<string>("password_query");
 	const [created, setCreated] = useState<ChannelCreated | null>(null);
 	const submitLocked = useRef(false);
 
@@ -70,12 +57,10 @@ export function ConnectBotDialog({
 		setApplicationId("");
 		setPublicKey("");
 		setGuildId("");
-		setServerUrl("");
-		setAuthMode("password_query");
 		setCreated(null);
 	}, [open]);
 
-	const meta = providerMeta(provider);
+	const meta = PROVIDER_META[provider];
 
 	function changeProvider(next: ChannelProviderId) {
 		setProvider(next);
@@ -83,8 +68,6 @@ export function ConnectBotDialog({
 		setApplicationId("");
 		setPublicKey("");
 		setGuildId("");
-		setServerUrl("");
-		setAuthMode("password_query");
 	}
 
 	const canSubmit =
@@ -95,9 +78,7 @@ export function ConnectBotDialog({
 				? token.trim().length > 0
 				: meta.connect === "discord"
 					? token.trim().length > 0 && applicationId.trim().length > 0
-					: meta.connect === "imessage"
-						? token.trim().length > 0 && serverUrl.trim().length > 0
-						: false);
+					: false);
 
 	function buildBody(): ChannelCreate {
 		const trimmedName = name.trim();
@@ -106,14 +87,6 @@ export function ConnectBotDialog({
 			if (publicKey.trim()) config.public_key = publicKey.trim();
 			if (guildId.trim()) config.guild_id = guildId.trim();
 			return { provider, name: trimmedName, provider_token: token.trim(), config };
-		}
-		if (meta.connect === "imessage") {
-			return {
-				provider,
-				name: trimmedName,
-				provider_token: token.trim(),
-				config: { server_url: serverUrl.trim(), auth_mode: authMode },
-			};
 		}
 		if (meta.connect === "token") {
 			return { provider, name: trimmedName, provider_token: token.trim() };
@@ -222,7 +195,7 @@ export function ConnectBotDialog({
 								/>
 							</div>
 
-							{/* Telegram / Discord bot token, or iMessage BlueBubbles password. */}
+							{/* Telegram / Discord bot token. */}
 							{meta.connect !== "whatsapp" ? (
 								<div className="flex flex-col gap-1.5">
 									<Label htmlFor="connect-token">{meta.tokenLabel}</Label>
@@ -283,38 +256,6 @@ export function ConnectBotDialog({
 											autoComplete="off"
 											spellCheck={false}
 										/>
-									</div>
-								</>
-							) : null}
-
-							{/* iMessage: BlueBubbles server URL + auth mode. */}
-							{meta.connect === "imessage" ? (
-								<>
-									<div className="flex flex-col gap-1.5">
-										<Label htmlFor="connect-server-url">BlueBubbles server URL</Label>
-										<Input
-											id="connect-server-url"
-											value={serverUrl}
-											onChange={(e) => setServerUrl(e.target.value)}
-											placeholder="https://your-bluebubbles.example.com"
-											autoComplete="off"
-											spellCheck={false}
-										/>
-									</div>
-									<div className="flex flex-col gap-1.5">
-										<Label htmlFor="connect-auth-mode">Auth mode</Label>
-										<Select value={authMode} onValueChange={setAuthMode}>
-											<SelectTrigger id="connect-auth-mode">
-												<SelectValue />
-											</SelectTrigger>
-											<SelectContent>
-												{IMESSAGE_AUTH_MODES.map((m) => (
-													<SelectItem key={m.value} value={m.value}>
-														{m.label}
-													</SelectItem>
-												))}
-											</SelectContent>
-										</Select>
 									</div>
 								</>
 							) : null}

--- a/apps/web/src/hosted/v2/channels/shared-bots-pool.tsx
+++ b/apps/web/src/hosted/v2/channels/shared-bots-pool.tsx
@@ -10,7 +10,7 @@ import { EntityIcon } from "@/components/entity-icon";
 import { SectionLabel } from "@/components/section-label";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { CHANNEL_PROVIDERS, providerMeta } from "@/hosted/v2/channels/channel-providers";
+import { orderedProviderIds, providerMeta } from "@/hosted/v2/channels/channel-providers";
 import type { ChannelBotPoolItem } from "@/hosted/v2/channels/channel-types";
 import { AccessBadge } from "@/hosted/v2/channels/channel-ui";
 import { useBotPool } from "@/hosted/v2/channels/channels-hooks";
@@ -51,10 +51,12 @@ export function SharedBotsPool() {
 	}
 
 	const providers = pool.data?.providers ?? {};
-	const sections = CHANNEL_PROVIDERS.map((p) => ({
-		provider: p,
-		items: providers[p] ?? [],
-	})).filter((s) => s.items.length > 0);
+	const sections = orderedProviderIds(Object.keys(providers))
+		.map((p) => ({
+			provider: p,
+			items: providers[p] ?? [],
+		}))
+		.filter((s) => s.items.length > 0);
 
 	if (sections.length === 0) {
 		return (
@@ -108,7 +110,7 @@ function PoolCard({ item, onLink }: { item: ChannelBotPoolItem; onLink: () => vo
 			: `${item.link_count} of ${item.max_links} linked`;
 
 	const meta = providerMeta(item.provider);
-	const linkable = item.available && item.capabilities.link_agent;
+	const linkable = !meta.unavailable && item.available && item.capabilities.link_agent;
 
 	return (
 		<div className={cn(ENTITY_CARD_BASE, "flex flex-col gap-3")}>
@@ -141,7 +143,7 @@ function PoolCard({ item, onLink }: { item: ChannelBotPoolItem; onLink: () => vo
 				<Button size="sm" variant="outline" className="w-full" disabled>
 					{/* `available` false = genuinely full; otherwise the bot just
 					    isn't linkable (capability-gated) — don't mislabel as capacity. */}
-					{item.available ? "Not linkable" : "At capacity"}
+					{meta.unavailable ? "Unavailable" : item.available ? "Not linkable" : "At capacity"}
 				</Button>
 			)}
 		</div>


### PR DESCRIPTION
## Why

iMessage does not fit the native-channel MITM gateway model: there is no public provider network API for the gateway to bridge to. The existing BlueBubbles server URL + password path is outdated, and the future iMessage path belongs in the runtime via Photon/spectrum-ts through Hermes rather than the channel gateway.

## What changed

- Removed iMessage from the v2 native-channel provider registry and connect dialog.
- Removed the BlueBubbles/iMessage-specific connect fields, auth modes, copy, and icon asset mappings.
- Kept Telegram, Discord, and WhatsApp connect flows intact.
- Updated channel list/search/docs copy to advertise only Telegram, Discord, and WhatsApp.

## Graceful fallback

Pre-existing `imessage` channel accounts still render as `iMessage (unavailable)`. They appear in the list/detail views, use the generic channel icon fallback, expose read-only account data, and can still be removed.