### PR TITLE
Surface load errors on detail pages and dialogs (error vs empty, wave 2)

### DIFF
--- a/apps/web/src/components/connectors/credentials-dialog.tsx
+++ b/apps/web/src/components/connectors/credentials-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -114,9 +115,13 @@ export function ConnectorCredentialsDialog({
 							<Spinner className="size-5 text-muted-foreground" />
 						</div>
 					) : fields.error ? (
-						<p role="alert" className="text-sm text-destructive">
-							{errorMessage(fields.error)}
-						</p>
+						<ApiErrorPanel
+							error={fields.error}
+							onRetry={() => {
+								void fields.refetch();
+							}}
+							title="Couldn't load credential fields"
+						/>
 					) : visibleFields.length === 0 ? (
 						<p className="text-sm text-muted-foreground">
 							This connector doesn't need any credentials configured here. Try OAuth from the

--- a/apps/web/src/components/skills/send-skill-dialog.tsx
+++ b/apps/web/src/components/skills/send-skill-dialog.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, Send } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import {
 	AgentLabel,
 	AgentSourceBadgeForEnvironment,
@@ -69,16 +70,19 @@ export function SendSkillDialog({
 	const single = skills.length === 1 ? skills[0] : null;
 	const batchLabel = single ? single.name : `${skills.length} skills`;
 
-	const { data: projects } = useQuery({
+	const projectsQuery = useQuery({
 		queryKey: ["projects"],
 		queryFn: async () => unwrap(await api.GET("/v1/projects")),
 		enabled: open,
 	});
-	const { data: envs } = useQuery({
+	const envsQuery = useQuery({
 		queryKey: ["agents"],
 		queryFn: async () => unwrap(await api.GET("/v1/agents")),
 		enabled: open,
 	});
+	const projects = projectsQuery.data;
+	const envs = envsQuery.data;
+	const destinationLoadError = projectsQuery.error ?? envsQuery.error;
 
 	// Target value encodes the destination project id. Agents are listed
 	// first (that's how users think) and resolve to their own project.
@@ -253,6 +257,16 @@ export function SendSkillDialog({
 							</SelectContent>
 						</Select>
 					</div>
+					{destinationLoadError ? (
+						<ApiErrorPanel
+							error={destinationLoadError}
+							onRetry={() => {
+								if (projectsQuery.error) void projectsQuery.refetch();
+								if (envsQuery.error) void envsQuery.refetch();
+							}}
+							title="Couldn't load destinations"
+						/>
+					) : null}
 					<div className="flex items-center gap-2">
 						<Checkbox
 							id="send-skill-move"
@@ -265,7 +279,7 @@ export function SendSkillDialog({
 					</div>
 					<Button
 						className="w-full"
-						disabled={!target || send.isPending}
+						disabled={!target || send.isPending || !!destinationLoadError}
 						onClick={() => send.mutate()}
 					>
 						{send.isPending ? <Spinner /> : <ArrowRight className="size-3.5" />}

--- a/apps/web/src/components/vault/add-keys-dialog.tsx
+++ b/apps/web/src/components/vault/add-keys-dialog.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertCircle, Check, Plus } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -95,6 +96,8 @@ export function AddKeysDialog({
 		!vaultSlug &&
 		!vaultsQuery.isLoading &&
 		!projectsQuery.isLoading &&
+		!vaultsQuery.error &&
+		!projectsQuery.error &&
 		writableProject === undefined;
 	const existingItems = useQuery({
 		queryKey: ["vault-items", effectiveChoice, selectedVaultProjectId],
@@ -123,6 +126,8 @@ export function AddKeysDialog({
 		open &&
 		effectiveChoice !== NEW_VAULT &&
 		(vaultsQuery.isLoading || selectedVault === undefined || existingItems.isLoading);
+	const destinationLoadError =
+		vaultsQuery.error ?? (effectiveChoice === NEW_VAULT ? projectsQuery.error : null);
 	const canSave =
 		importPlan.parsed.errors.length === 0 &&
 		importableCount > 0 &&
@@ -131,6 +136,7 @@ export function AddKeysDialog({
 		!newVaultPending &&
 		!newVaultUnavailable &&
 		!destinationPending &&
+		!destinationLoadError &&
 		!existingItems.error;
 
 	const save = useMutation({
@@ -266,6 +272,18 @@ export function AddKeysDialog({
 							) : null}
 						</div>
 					) : null}
+					{destinationLoadError ? (
+						<ApiErrorPanel
+							error={destinationLoadError}
+							onRetry={() => {
+								if (vaultsQuery.error) void vaultsQuery.refetch();
+								if (effectiveChoice === NEW_VAULT && projectsQuery.error) {
+									void projectsQuery.refetch();
+								}
+							}}
+							title="Couldn't load destinations"
+						/>
+					) : null}
 					{importPlan.parsed.errors.length > 0 ? (
 						<Alert variant="destructive">
 							<AlertCircle className="size-4" />
@@ -280,11 +298,13 @@ export function AddKeysDialog({
 						</Alert>
 					) : null}
 					{existingItems.error ? (
-						<Alert variant="destructive">
-							<AlertCircle className="size-4" />
-							<AlertTitle>Couldn't check existing keys</AlertTitle>
-							<AlertDescription>{errorMessage(existingItems.error)}</AlertDescription>
-						</Alert>
+						<ApiErrorPanel
+							error={existingItems.error}
+							onRetry={() => {
+								void existingItems.refetch();
+							}}
+							title="Couldn't check existing keys"
+						/>
 					) : null}
 					{importPlan.conflicts.length > 0 && importPlan.parsed.errors.length === 0 ? (
 						<div className="flex items-start gap-3 rounded-md border bg-muted/30 p-3">

--- a/apps/web/src/components/vault/copy-keys-dialog.tsx
+++ b/apps/web/src/components/vault/copy-keys-dialog.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowRight, Plus } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -98,9 +99,13 @@ export function CopyKeysDialog({
 		creatingNewVault &&
 		!projectsQuery.isLoading &&
 		!vaultsQuery.isLoading &&
+		!projectsQuery.error &&
+		!vaultsQuery.error &&
 		writableProject === undefined;
+	const destinationLoadError = vaultsQuery.error ?? (creatingNewVault ? projectsQuery.error : null);
 	const canRun =
 		keys.length > 0 &&
+		!destinationLoadError &&
 		!runIsBlockedForNewVault(
 			creatingNewVault,
 			newVaultName,
@@ -279,6 +284,16 @@ export function CopyKeysDialog({
 							</div>
 						) : null}
 					</div>
+					{destinationLoadError ? (
+						<ApiErrorPanel
+							error={destinationLoadError}
+							onRetry={() => {
+								if (vaultsQuery.error) void vaultsQuery.refetch();
+								if (creatingNewVault && projectsQuery.error) void projectsQuery.refetch();
+							}}
+							title="Couldn't load destinations"
+						/>
+					) : null}
 					{mode === "move" && attachedCount > 1 ? (
 						<p className="text-xs font-medium text-warning-muted-foreground">
 							{vault.name} is used by {attachedCount} Projects — moving these keys removes them from

--- a/apps/web/src/components/vault/split-vault-dialog.tsx
+++ b/apps/web/src/components/vault/split-vault-dialog.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Scissors } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -80,11 +81,12 @@ export function SplitVaultDialog({
 	const selected = useMemo(() => groups.filter((g) => !excluded.has(g.slug)), [groups, excluded]);
 	const selectedKeyCount = selected.reduce((n, g) => n + g.keys.length, 0);
 
-	const { data: projects } = useQuery({
+	const projectsQuery = useQuery({
 		queryKey: ["projects"],
 		queryFn: async () => unwrap(await api.GET("/v1/projects")),
 		enabled: open,
 	});
+	const projects = projectsQuery.data;
 
 	const run = useMutation({
 		mutationFn: async () => {
@@ -243,9 +245,23 @@ export function SplitVaultDialog({
 							them. Add the new vaults to those Projects afterwards.
 						</p>
 					) : null}
+					{projectsQuery.error ? (
+						<ApiErrorPanel
+							error={projectsQuery.error}
+							onRetry={() => {
+								void projectsQuery.refetch();
+							}}
+							title="Couldn't load destinations"
+						/>
+					) : null}
 					<Button
 						className="w-full"
-						disabled={selected.length === 0 || run.isPending}
+						disabled={
+							selected.length === 0 ||
+							run.isPending ||
+							projectsQuery.isLoading ||
+							!!projectsQuery.error
+						}
 						onClick={() => run.mutate()}
 					>
 						{run.isPending ? <Spinner /> : <Scissors className="size-3.5" />}

--- a/apps/web/src/hosted/billing/subscription/welcome-credits-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/welcome-credits-card.tsx
@@ -2,10 +2,12 @@
 
 import { useRouter } from "@tanstack/react-router";
 import { Gift, PartyPopper, Rocket } from "lucide-react";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
 import type { Plan } from "@/hosted/billing/contracts";
+import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { creditsToUsd } from "@/hosted/billing/format";
 import { useHostedDeployments, usePlans, useWallet, useWalletLedger } from "@/hosted/billing/hooks";
 
@@ -31,7 +33,26 @@ export function WelcomeCreditsCard() {
 	// Past onboarding — they already have at least one agent.
 	if ((deployments.data?.length ?? 0) > 0) return null;
 	if (ledger.isLoading || wallet.isLoading || deployments.isLoading) return null;
-	if (wallet.error || ledger.error || deployments.error || !wallet.data) return null;
+	const loadError = wallet.error ?? ledger.error ?? deployments.error;
+	if (loadError) {
+		return (
+			<Card data-hosted="true">
+				<CardContent>
+					<ApiErrorPanel
+						normalizer={billingErrorNormalizer}
+						error={loadError}
+						onRetry={() => {
+							if (wallet.error) void wallet.refetch();
+							if (ledger.error) void ledger.refetch();
+							if (deployments.error) void deployments.refetch();
+						}}
+						title="Couldn't load welcome credits"
+					/>
+				</CardContent>
+			</Card>
+		);
+	}
+	if (!wallet.data) return null;
 
 	const grant = ledger.data?.items.find((e) => e.operation === "grant_signup");
 	const grantApplied = grant?.status === "applied";

--- a/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
+++ b/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
@@ -20,6 +20,7 @@ import { ConfirmAction } from "@/components/ui/confirm-action";
 import { SearchInput } from "@/components/ui/search-input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { isApiNotFoundError } from "@/lib/api-errors";
 import type { ConnectorTool } from "@/lib/api-schemas";
 import {
 	isActiveConnection,
@@ -253,11 +254,21 @@ function ConnectorDetail({ name }: { name: string }) {
 	if (appQ.error) {
 		return (
 			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-4 px-4 lg:px-6")}>
-				<EmptyState
-					icon={Plug}
-					title="Connector unavailable"
-					description={errorMessage(appQ.error)}
-				/>
+				{isApiNotFoundError(appQ.error) ? (
+					<EmptyState
+						icon={Plug}
+						title="Connector unavailable"
+						description={errorMessage(appQ.error)}
+					/>
+				) : (
+					<ApiErrorPanel
+						error={appQ.error}
+						onRetry={() => {
+							void appQ.refetch();
+						}}
+						title="Couldn't load connector"
+					/>
+				)}
 			</div>
 		);
 	}

--- a/apps/web/src/pages/dashboard/memories/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/memories/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useRouter } from "@tanstack/react-router";
 import { Brain, Laptop, Trash2 } from "lucide-react";
 import { toast } from "sonner";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { DetailMeta, DetailNotFound, DetailPanel, DetailTitle } from "@/components/detail/layout";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
@@ -13,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Skeleton } from "@/components/ui/skeleton";
 import { unwrap, useApi } from "@/lib/api";
+import { isApiNotFoundError } from "@/lib/api-errors";
 import { MEMORY_CATEGORY_COLORS } from "@/lib/memory-utils";
 import { projectResourceHref } from "@/lib/project-resource-model";
 import { cn, errorMessage, relativeTime } from "@/lib/utils";
@@ -26,6 +28,7 @@ export default function MemoryDetailPage({ memoryId }: { memoryId: string }) {
 		data: memory,
 		isLoading,
 		error,
+		refetch,
 	} = useQuery({
 		queryKey: ["memory", memoryId],
 		queryFn: async () =>
@@ -63,8 +66,16 @@ export default function MemoryDetailPage({ memoryId }: { memoryId: string }) {
 
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
-			{error ? (
+			{error && isApiNotFoundError(error) ? (
 				<DetailNotFound title="Memory not found" message={errorMessage(error)} />
+			) : error ? (
+				<ApiErrorPanel
+					error={error}
+					onRetry={() => {
+						void refetch();
+					}}
+					title="Couldn't load memory"
+				/>
 			) : isLoading ? (
 				<div className="space-y-4 py-2">
 					<Skeleton className="h-5 w-24" />

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -73,7 +73,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { ApiError, unwrap, useApi } from "@/lib/api";
-import { formatApiError } from "@/lib/api-errors";
+import { formatApiError, isApiNotFoundError } from "@/lib/api-errors";
 import { fetchAllPages } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
 import { formatShortDate } from "@/lib/format";
@@ -88,6 +88,7 @@ type AgentProjectBinding = components["schemas"]["AgentProjectBindingResponse"];
 
 type ProjectRow = components["schemas"]["ProjectResponse"];
 type Member = components["schemas"]["MemberResponse"];
+type CountValue = number | "unavailable";
 
 export default function ProjectDetailPage({ projectId }: { projectId: string }) {
 	const api = useApi();
@@ -193,18 +194,14 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 			const results = await Promise.all(
 				envs.map(async (env) => {
 					if (env.default_project_id === projectId) return { env, home: true };
-					try {
-						const bindings = unwrap(
-							await api.GET("/v1/agents/{agent_id}/project-bindings", {
-								params: { path: { agent_id: env.id } },
-							}),
-						);
-						return bindings.some((b: AgentProjectBinding) => b.project_id === projectId)
-							? { env, home: false }
-							: null;
-					} catch {
-						return null;
-					}
+					const bindings = unwrap(
+						await api.GET("/v1/agents/{agent_id}/project-bindings", {
+							params: { path: { agent_id: env.id } },
+						}),
+					);
+					return bindings.some((b: AgentProjectBinding) => b.project_id === projectId)
+						? { env, home: false }
+						: null;
 				}),
 			);
 			return results.filter((r): r is { env: Env; home: boolean } => r !== null);
@@ -271,13 +268,20 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 						Projects
 					</Link>
 				</Button>
-				<ApiErrorPanel
-					error={projects.error}
-					onRetry={() => {
-						void projects.refetch();
-					}}
-					title="Couldn't load project"
-				/>
+				{isApiNotFoundError(projects.error) ? (
+					<DetailNotFound
+						title="Project not found"
+						message="This Project may have been removed, or your account no longer has access."
+					/>
+				) : (
+					<ApiErrorPanel
+						error={projects.error}
+						onRetry={() => {
+							void projects.refetch();
+						}}
+						title="Couldn't load project"
+					/>
+				)}
 			</div>
 		);
 	}
@@ -299,10 +303,19 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 		);
 	}
 
-	const skillCount = skills.data?.items.length;
-	const vaultCount = vaults.data?.items.length;
-	const peopleCount = members.data ? members.data.length + 1 : undefined; // +1 = owner
-	const agentCount = boundAgents.data?.length;
+	const skillCount: CountValue | undefined = skills.error
+		? "unavailable"
+		: skills.data?.items.length;
+	const vaultCount: CountValue | undefined = vaults.error
+		? "unavailable"
+		: vaults.data?.items.length;
+	const peopleCount: CountValue | undefined = members.error
+		? "unavailable"
+		: members.data
+			? members.data.length + 1
+			: undefined; // +1 = owner
+	const agentCount: CountValue | undefined =
+		environments.error || boundAgents.error ? "unavailable" : boundAgents.data?.length;
 
 	const addToAgentDialog = (trigger: ReactNode) => (
 		<UseProjectWithAgentDialog
@@ -423,7 +436,13 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 					<InstallSkillInProjectForm projectId={project.id} onChanged={refresh} />
 				) : null}
 				{skills.error ? (
-					<ErrorLine message={errorMessage(skills.error)} />
+					<ApiErrorPanel
+						error={skills.error}
+						onRetry={() => {
+							void skills.refetch();
+						}}
+						title="Couldn't load Project skills"
+					/>
 				) : (
 					<SkillCardGrid
 						skills={skills.data?.items ?? []}
@@ -463,7 +482,13 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 				{vaults.isLoading ? (
 					<Skeleton className="h-24 w-full" />
 				) : vaults.error ? (
-					<ErrorLine message={errorMessage(vaults.error)} />
+					<ApiErrorPanel
+						error={vaults.error}
+						onRetry={() => {
+							void vaults.refetch();
+						}}
+						title="Couldn't load Project vaults"
+					/>
 				) : vaults.data?.items.length ? (
 					<div className="divide-y overflow-hidden rounded-lg border bg-card">
 						{vaults.data.items.map((vault) => (
@@ -496,6 +521,14 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 				>
 					{members.isLoading ? (
 						<Skeleton className="h-16 w-full" />
+					) : members.error ? (
+						<ApiErrorPanel
+							error={members.error}
+							onRetry={() => {
+								void members.refetch();
+							}}
+							title="Couldn't load Project members"
+						/>
 					) : (members.data?.length ?? 0) === 0 ? (
 						<EmptyLine message="Only you so far. Share this Project to give a teammate viewer access." />
 					) : (
@@ -551,6 +584,22 @@ export default function ProjectDetailPage({ projectId }: { projectId: string }) 
 			>
 				{boundAgents.isLoading || environments.isLoading ? (
 					<Skeleton className="h-16 w-full" />
+				) : environments.error ? (
+					<ApiErrorPanel
+						error={environments.error}
+						onRetry={() => {
+							void environments.refetch();
+						}}
+						title="Couldn't load agents"
+					/>
+				) : boundAgents.error ? (
+					<ApiErrorPanel
+						error={boundAgents.error}
+						onRetry={() => {
+							void boundAgents.refetch();
+						}}
+						title="Couldn't load Project agent bindings"
+					/>
 				) : (boundAgents.data?.length ?? 0) === 0 ? (
 					<EmptyLine message="No agents use this Project yet. Add it to an agent to sync its skills and keys." />
 				) : (
@@ -601,7 +650,7 @@ const STAT_TILE_TINTS: Record<string, string> = {
 	Agents: "bg-identity-5-bg/50",
 };
 
-function StatTile({ label, value, href }: { label: string; value?: number; href: string }) {
+function StatTile({ label, value, href }: { label: string; value?: CountValue; href: string }) {
 	return (
 		<a
 			href={href}
@@ -611,7 +660,7 @@ function StatTile({ label, value, href }: { label: string; value?: number; href:
 			)}
 		>
 			<div className="text-2xl font-semibold tabular-nums">
-				{value === undefined ? <Skeleton className="h-8 w-8" /> : value}
+				{value === undefined ? <Skeleton className="h-8 w-8" /> : formatCountValue(value)}
 			</div>
 			<div className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
 				{label}
@@ -631,7 +680,7 @@ function HubSection({
 }: {
 	id: string;
 	title: string;
-	count?: number;
+	count?: CountValue;
 	description: string;
 	action?: ReactNode;
 	children: ReactNode;
@@ -644,7 +693,7 @@ function HubSection({
 						<h2 className="text-sm font-semibold">{title}</h2>
 						{count !== undefined ? (
 							<Badge variant="secondary" className="tabular-nums">
-								{count}
+								{formatCountValue(count)}
 							</Badge>
 						) : null}
 					</div>
@@ -960,7 +1009,13 @@ function UseProjectWithAgentDialog({
 						</div>
 
 						{selectedBindings.error ? (
-							<ErrorLine message="Couldn’t check this agent’s project list. Refresh and retry." />
+							<ApiErrorPanel
+								error={selectedBindings.error}
+								onRetry={() => {
+									void selectedBindings.refetch();
+								}}
+								title="Couldn't check this agent's Project list"
+							/>
 						) : null}
 
 						<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
@@ -1185,10 +1240,6 @@ function EmptyLine({ message }: { message: string }) {
 	return <EmptyState variant="inset" description={message} />;
 }
 
-function ErrorLine({ message }: { message: string }) {
-	return (
-		<div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
-			<span className="font-medium">Section unavailable.</span> {message}
-		</div>
-	);
+function formatCountValue(value: CountValue) {
+	return value === "unavailable" ? "—" : value;
 }

--- a/apps/web/src/pages/dashboard/projects/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/page.tsx
@@ -45,6 +45,7 @@ type Env = components["schemas"]["AgentResponse"];
 type SkillSummary = components["schemas"]["SkillSummaryResponse"];
 
 type ProjectRow = components["schemas"]["ProjectResponse"];
+type CountValue = number | "unavailable";
 
 const PROJECTS_RESOURCE = getProjectResourceDefinition("projects");
 
@@ -298,8 +299,8 @@ export default function ProjectsPage() {
 							key={project.id}
 							project={project}
 							shared={shared}
-							skillCount={skillCounts.get(project.id) ?? 0}
-							vaultCount={vaultCounts.get(project.id) ?? 0}
+							skillCount={skills.error ? "unavailable" : (skillCounts.get(project.id) ?? 0)}
+							vaultCount={vaults.error ? "unavailable" : (vaultCounts.get(project.id) ?? 0)}
 						/>
 					))}
 				</div>
@@ -333,8 +334,8 @@ export default function ProjectsPage() {
 									key={project.id}
 									project={project}
 									agent={projectAgentFor(project, agentsById)}
-									skillCount={skillCounts.get(project.id) ?? 0}
-									vaultCount={vaultCounts.get(project.id) ?? 0}
+									skillCount={skills.error ? "unavailable" : (skillCounts.get(project.id) ?? 0)}
+									vaultCount={vaults.error ? "unavailable" : (vaultCounts.get(project.id) ?? 0)}
 								/>
 							))}
 						</div>
@@ -353,8 +354,8 @@ function ProjectCard({
 }: {
 	project: ProjectRow;
 	shared: boolean;
-	skillCount: number;
-	vaultCount: number;
+	skillCount: CountValue;
+	vaultCount: CountValue;
 }) {
 	const projectName = displayProjectName(project);
 	return (
@@ -368,8 +369,8 @@ function ProjectCard({
 			badges={shared ? <StatusChip>Shared with you</StatusChip> : null}
 			description={<span className="font-mono">{project.slug}</span>}
 			footer={[
-				`${skillCount} ${skillCount === 1 ? "skill" : "skills"}`,
-				`${vaultCount} ${vaultCount === 1 ? "vault" : "vaults"}`,
+				formatCountLabel(skillCount, "skill"),
+				formatCountLabel(vaultCount, "vault"),
 				shared && project.owner_display ? `by ${project.owner_display}` : null,
 			]}
 			actions={
@@ -425,8 +426,8 @@ function SystemProjectRow({
 }: {
 	project: ProjectRow;
 	agent?: ProjectAgentMetadata | null;
-	skillCount: number;
-	vaultCount: number;
+	skillCount: CountValue;
+	vaultCount: CountValue;
 }) {
 	const isGlobal = project.kind === "personal";
 	return (
@@ -449,7 +450,7 @@ function SystemProjectRow({
 				/>
 			</div>
 			<span className="hidden shrink-0 text-xs text-muted-foreground tabular-nums sm:inline">
-				{skillCount} skills · {vaultCount} vaults
+				{formatCountLabel(skillCount, "skill")} · {formatCountLabel(vaultCount, "vault")}
 			</span>
 			<Link
 				to="/projects/$id"
@@ -464,6 +465,11 @@ function SystemProjectRow({
 
 function normalizeSlugInput(value: string) {
 	return normalizeSlugDraft(value).replace(/-+$/, "");
+}
+
+function formatCountLabel(value: CountValue, noun: string) {
+	if (value === "unavailable") return `— ${noun}s`;
+	return `${value} ${value === 1 ? noun : `${noun}s`}`;
 }
 
 function normalizeSlugDraft(value: string) {

--- a/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/sessions/[id]/page.tsx
@@ -11,9 +11,16 @@ import {
 	Zap,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetAgentBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { AgentInline, agentDisplayName } from "@/components/dashboard/agent-label";
-import { DetailMeta, DetailPanel, DetailStats, DetailTitle } from "@/components/detail/layout";
+import {
+	DetailMeta,
+	DetailNotFound,
+	DetailPanel,
+	DetailStats,
+	DetailTitle,
+} from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
 import { ModelBadge } from "@/components/meta/model-badge";
 import { Stat } from "@/components/meta/stat";
@@ -27,6 +34,7 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ApiError, unwrap, useApi } from "@/lib/api";
+import { isApiNotFoundError } from "@/lib/api-errors";
 import type { SessionMessage } from "@/lib/api-schemas";
 import { useCurrentUser } from "@/lib/auth-client";
 import { formatDuration } from "@/lib/format";
@@ -52,7 +60,12 @@ export function SessionDetailContent({
 	const api = useApi();
 	const { user } = useCurrentUser();
 
-	const { data: session, isLoading: isSessionLoading } = useQuery({
+	const {
+		data: session,
+		isLoading: isSessionLoading,
+		error: sessionError,
+		refetch: refetchSession,
+	} = useQuery({
 		queryKey: ["session", sessionId],
 		queryFn: async () =>
 			unwrap(
@@ -138,6 +151,8 @@ export function SessionDetailContent({
 		data: pagesData,
 		isLoading: isContentLoading,
 		isError: isContentError,
+		error: contentError,
+		refetch: refetchContent,
 		fetchNextPage,
 		hasNextPage,
 		isFetchingNextPage,
@@ -245,10 +260,28 @@ export function SessionDetailContent({
 		);
 	}
 
+	if (sessionError) {
+		return (
+			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
+				{isApiNotFoundError(sessionError) ? (
+					<DetailNotFound title="Session not found" message="This session doesn't exist." />
+				) : (
+					<ApiErrorPanel
+						error={sessionError}
+						onRetry={() => {
+							void refetchSession();
+						}}
+						title="Couldn't load session"
+					/>
+				)}
+			</div>
+		);
+	}
+
 	if (!session || !summaryText) {
 		return (
 			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
-				<p className="text-muted-foreground">Session not found.</p>
+				<DetailNotFound title="Session not found" message="This session doesn't exist." />
 			</div>
 		);
 	}
@@ -354,7 +387,13 @@ export function SessionDetailContent({
 				isContentLoading ? (
 					<MessagesSkeleton />
 				) : isContentError ? (
-					<ContentFetchError />
+					<ApiErrorPanel
+						error={contentError}
+						onRetry={() => {
+							void refetchContent();
+						}}
+						title="Couldn't load messages"
+					/>
 				) : messages?.length ? (
 					// Spacing comes from MessageBlock's `pt-4` on
 					// group-start rows; continuation rows render flush
@@ -578,13 +617,4 @@ function MessagesSkeleton() {
 
 function EmptyContent() {
 	return <EmptyState variant="inset" description="No messages in this session." />;
-}
-
-function ContentFetchError() {
-	return (
-		<EmptyState
-			variant="inset"
-			description="Session content is unavailable. Check your connection and refresh this page."
-		/>
-	);
 }

--- a/apps/web/src/pages/dashboard/skills/[key]/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/[key]/page.tsx
@@ -18,6 +18,7 @@ import {
 import { parseAsString, useQueryState } from "nuqs";
 import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetBreadcrumbSegmentTitle, useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { agentDisplayName, cleanMachineName } from "@/components/dashboard/agent-label";
 import {
@@ -40,6 +41,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { ApiError, unwrap, useApi } from "@/lib/api";
+import { isApiNotFoundError } from "@/lib/api-errors";
 import { decodeResourceRouteParam, projectResourceHref } from "@/lib/project-resource-model";
 import { cn, errorMessage, relativeTime } from "@/lib/utils";
 
@@ -97,6 +99,7 @@ export function SkillDetailContent({
 		data: skill,
 		isLoading,
 		error,
+		refetch,
 	} = useQuery({
 		queryKey: ["skill", skillKey, selectedProjectId],
 		// An empty key would interpolate to `GET /v1/skills/`, which the
@@ -309,8 +312,16 @@ export function SkillDetailContent({
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
 			{!skillKey ? (
 				<DetailNotFound title="Skill not found" message="The URL is missing a skill key." />
-			) : error ? (
+			) : error && isApiNotFoundError(error) ? (
 				<DetailNotFound title="Skill not found" message={errorMessage(error)} />
+			) : error ? (
+				<ApiErrorPanel
+					error={error}
+					onRetry={() => {
+						void refetch();
+					}}
+					title="Couldn't load skill"
+				/>
 			) : isLoading ? (
 				<div className="space-y-3 py-2">
 					<Skeleton className="h-6 w-48" />

--- a/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { type ReactNode, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { useSetBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { BulkActionBar } from "@/components/bulk-action-bar";
 import { DetailNotFound, DetailTitle } from "@/components/detail/layout";
@@ -51,6 +52,7 @@ import { AddKeysDialog } from "@/components/vault/add-keys-dialog";
 import { CopyKeysDialog } from "@/components/vault/copy-keys-dialog";
 import { prefixGroupsFor, SplitVaultDialog } from "@/components/vault/split-vault-dialog";
 import { unwrap, useApi } from "@/lib/api";
+import { isApiNotFoundError } from "@/lib/api-errors";
 import type { components } from "@/lib/api-schemas";
 import { identityFor } from "@/lib/identity";
 import { cn, errorMessage } from "@/lib/utils";
@@ -265,6 +267,33 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 		);
 	}
 
+	if (vaults.error) {
+		return (
+			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
+				<Button asChild variant="ghost" size="sm" className="w-fit">
+					<Link to="/vault">
+						<ArrowLeft className="mr-1.5 size-4" />
+						Vaults
+					</Link>
+				</Button>
+				{isApiNotFoundError(vaults.error) ? (
+					<DetailNotFound
+						title="Vault not found"
+						message="This vault may have been removed, or your account no longer has access."
+					/>
+				) : (
+					<ApiErrorPanel
+						error={vaults.error}
+						onRetry={() => {
+							void vaults.refetch();
+						}}
+						title="Couldn't load vault"
+					/>
+				)}
+			</div>
+		);
+	}
+
 	if (!vault) {
 		return (
 			<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-5 px-4 lg:px-6")}>
@@ -354,7 +383,11 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 					<div>
 						<div className="flex items-center gap-2">
 							<h2 className="text-sm font-semibold">Keys</h2>
-							{keys.data ? (
+							{keys.error ? (
+								<Badge variant="secondary" className="tabular-nums">
+									—
+								</Badge>
+							) : keys.data ? (
 								<Badge variant="secondary" className="tabular-nums">
 									{keyNames.length}
 								</Badge>
@@ -436,6 +469,14 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 
 				{keys.isLoading ? (
 					<Skeleton className="h-32 w-full rounded-lg" />
+				) : keys.error ? (
+					<ApiErrorPanel
+						error={keys.error}
+						onRetry={() => {
+							void keys.refetch();
+						}}
+						title="Couldn't load vault keys"
+					/>
 				) : keyNames.length === 0 ? (
 					<EmptyState
 						variant="inset"
@@ -567,16 +608,18 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 					<div>
 						<div className="flex items-center gap-2">
 							<h2 className="text-sm font-semibold">Projects</h2>
-							<Badge variant="secondary" className="tabular-nums">
-								{attachedProjects.length}
-							</Badge>
+							{projects.isLoading ? null : (
+								<Badge variant="secondary" className="tabular-nums">
+									{projects.error ? "—" : attachedProjects.length}
+								</Badge>
+							)}
 						</div>
 						<p className="mt-0.5 text-xs text-muted-foreground">
 							Same vault everywhere — key changes apply to every Project here. Agents bound to these
 							Projects resolve the keys at runtime.
 						</p>
 					</div>
-					{isOwner ? (
+					{isOwner && !projects.error ? (
 						<AttachProjectPicker
 							projects={(projects.data ?? []).filter(
 								(p) => p.is_owner !== false && !(vault.project_ids ?? []).includes(p.id),
@@ -586,7 +629,17 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 						/>
 					) : null}
 				</div>
-				{attachedProjects.length === 0 ? (
+				{projects.isLoading ? (
+					<Skeleton className="h-16 w-full" />
+				) : projects.error ? (
+					<ApiErrorPanel
+						error={projects.error}
+						onRetry={() => {
+							void projects.refetch();
+						}}
+						title="Couldn't load attached Projects"
+					/>
+				) : attachedProjects.length === 0 ? (
 					<EmptyState
 						variant="inset"
 						title="Not added to any Project yet"

--- a/apps/web/src/pages/dashboard/vault/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/page.tsx
@@ -6,6 +6,7 @@ import { Lock, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
+import { EmptyState } from "@/components/empty-state";
 import { HERO_CARD_BASE, HERO_GRID_CLASS, HeroCard } from "@/components/entity-card";
 import { FilterChip } from "@/components/filter-chip";
 import { IconChip } from "@/components/icon-chip";
@@ -67,6 +68,7 @@ export default function VaultPage() {
 	);
 
 	const items = vaults.data?.items ?? [];
+	const hasActiveFilter = search.trim().length > 0 || projectFilter !== "all";
 	const filtered = useMemo(() => {
 		const q = search.trim().toLowerCase();
 		let rows = items;
@@ -155,8 +157,38 @@ export default function VaultPage() {
 						<VaultCardSkeleton key={i} />
 					))}
 				</div>
+			) : filtered.length === 0 ? (
+				<EmptyState
+					title={hasActiveFilter ? "No vaults match these filters" : "No vaults yet"}
+					description={
+						hasActiveFilter
+							? "Try a different search or Project filter."
+							: "Create a vault to group API keys for your agents."
+					}
+					action={
+						hasActiveFilter ? null : (
+							<NewVaultDialog
+								trigger={
+									<Button size="sm">
+										<Plus className="size-3.5" />
+										New vault
+									</Button>
+								}
+							/>
+						)
+					}
+				/>
 			) : (
 				<>
+					{projects.error ? (
+						<ApiErrorPanel
+							error={projects.error}
+							onRetry={() => {
+								void projects.refetch();
+							}}
+							title="Couldn't load Project names"
+						/>
+					) : null}
 					<div
 						className={cn(
 							HERO_GRID_CLASS,
@@ -165,7 +197,12 @@ export default function VaultPage() {
 						)}
 					>
 						{mine.map((vault) => (
-							<VaultCard key={vault.id} vault={vault} projectNameById={projectNameById} />
+							<VaultCard
+								key={vault.id}
+								vault={vault}
+								projectNameById={projectNameById}
+								projectNamesUnavailable={!!projects.error}
+							/>
 						))}
 					</div>
 					{shared.length > 0 ? (
@@ -180,16 +217,12 @@ export default function VaultPage() {
 										key={vault.id}
 										vault={vault}
 										projectNameById={projectNameById}
+										projectNamesUnavailable={!!projects.error}
 										shared
 									/>
 								))}
 							</div>
 						</section>
-					) : null}
-					{filtered.length === 0 && search.trim() ? (
-						<p className="py-12 text-center text-sm text-muted-foreground">
-							No vaults match “{search.trim()}”.
-						</p>
 					) : null}
 				</>
 			)}
@@ -200,10 +233,12 @@ export default function VaultPage() {
 function VaultCard({
 	vault,
 	projectNameById,
+	projectNamesUnavailable,
 	shared = false,
 }: {
 	vault: VaultSummary;
 	projectNameById: ReadonlyMap<string, string>;
+	projectNamesUnavailable: boolean;
 	shared?: boolean;
 }) {
 	const api = useApi();
@@ -259,6 +294,8 @@ function VaultCard({
 						</TooltipTrigger>
 						<TooltipContent>{usedBy.join(", ")}</TooltipContent>
 					</Tooltip>
+				) : projectNamesUnavailable && (vault.project_ids?.length ?? 0) > 0 ? (
+					"Project details unavailable"
 				) : (
 					"not in any Project yet"
 				),


### PR DESCRIPTION
## Summary

Extends the shipped error-vs-empty pattern across the requested apps/web surfaces. No new helper was needed; all API error UI uses the shared `ApiErrorPanel` with query `refetch` retry wiring.

## Surfaces

- Sessions detail: splits session 404 into `DetailNotFound`, shows retryable API/network failures, and replaces message-load empty fallback with retryable `ApiErrorPanel`.
- Project detail: keeps not-found treatment for missing Projects, shows retryable API failures for the primary load, and surfaces skills, vaults, members, agents, and binding load failures per section. Failed section counts now show `—` instead of undercounting.
- Skill and memory details: preserve true 404 not-found UI and show retryable `ApiErrorPanel` for non-404 load failures.
- Vault detail: splits vault load failure from not-found, surfaces vault-key and attached-Project load failures with retry, and marks failed key/Project counts as `—`.
- Connector detail and credentials schema: preserves connector 404 unavailable UI, shows retryable connector load failures, and replaces credential-schema text errors with `ApiErrorPanel`.
- Projects index: failed skill/vault count queries render `—` count labels instead of `0`.
- Vault index: keeps list load errors explicit, adds true empty versus filtered no-match states, and surfaces Project-name load failures instead of implying vaults are unused.
- Move/copy/import dialogs: Add Keys, Copy/Move Keys, Split Vault, and Send Skill now show destination-load `ApiErrorPanel` with retry before inferring no writable destinations.
- Welcome credits card: wallet, ledger, and deployment load failures render a compact retryable billing error panel; genuine non-applicability still returns `null`.

## Verification

- `bun run check:fix`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`