### PR TITLE
Fix v1/v2 user-facing taxonomy copy and form accessibility

### DIFF
--- a/apps/web/src/components/dashboard/agent-settings-panel.tsx
+++ b/apps/web/src/components/dashboard/agent-settings-panel.tsx
@@ -318,11 +318,11 @@ export function AgentSettingsPanel({
 			{legacyDashboardUrl ? (
 				<SettingsSection
 					title="Legacy dashboard"
-					description="Manage this v1 hosted agent in the legacy dashboard."
+					description="Manage this Legacy hosted agent in the legacy dashboard."
 				>
 					<div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
 						<p className="max-w-md text-sm text-muted-foreground">
-							This agent uses the legacy v1 management surface for runtime actions.
+							This agent uses the legacy management surface for runtime actions.
 						</p>
 						<Button variant="outline" size="sm" asChild>
 							<a href={legacyDashboardUrl} target="_blank" rel="noopener noreferrer">

--- a/apps/web/src/hosted/billing/components/term-switcher.tsx
+++ b/apps/web/src/hosted/billing/components/term-switcher.tsx
@@ -31,6 +31,7 @@ export function TermSwitcher({
 			variant="outline"
 			size="sm"
 			className="w-full"
+			aria-label="Billing term"
 		>
 			{sorted.map((offer) => (
 				<ToggleGroupItem

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
@@ -114,8 +114,10 @@ export function AutoReloadCard({ wallet, onTopUp }: { wallet: WalletState; onTop
 						<Label htmlFor="ar-threshold">When below ($)</Label>
 						<Input
 							id="ar-threshold"
+							name="ar-threshold"
 							type="number"
 							inputMode="decimal"
+							autoComplete="off"
 							min={1}
 							step="1"
 							className="tabular-nums"
@@ -134,8 +136,10 @@ export function AutoReloadCard({ wallet, onTopUp }: { wallet: WalletState; onTop
 						<Label htmlFor="ar-amount">Add ($)</Label>
 						<Input
 							id="ar-amount"
+							name="ar-amount"
 							type="number"
 							inputMode="decimal"
+							autoComplete="off"
 							min={AUTORELOAD_AMOUNT_MIN_CENTS / 100}
 							max={AUTORELOAD_AMOUNT_MAX_CENTS / 100}
 							step="1"
@@ -155,8 +159,10 @@ export function AutoReloadCard({ wallet, onTopUp }: { wallet: WalletState; onTop
 						<Label htmlFor="ar-cap">Monthly cap ($)</Label>
 						<Input
 							id="ar-cap"
+							name="ar-cap"
 							type="number"
 							inputMode="decimal"
+							autoComplete="off"
 							min={0}
 							step="1"
 							className="tabular-nums"

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
@@ -157,8 +157,10 @@ export function TopUpDialog({
 								</span>
 								<Input
 									id="topup-amount"
+									name="topup-amount"
 									type="number"
 									inputMode="decimal"
+									autoComplete="off"
 									min={TOPUP_MIN_CENTS / 100}
 									max={TOPUP_MAX_CENTS / 100}
 									step="1"

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -560,7 +560,12 @@ export function AddProviderDialog({
 								</summary>
 								<div className="mt-2 flex flex-col gap-2">
 									<p>Paste the full address from the OpenAI page after signing in.</p>
+									<Label htmlFor="provider-oauth-callback" className="sr-only">
+										OAuth callback URL
+									</Label>
 									<Input
+										id="provider-oauth-callback"
+										name="provider-oauth-callback"
 										value={oauthCode}
 										onChange={(e) => setOauthCode(e.target.value)}
 										placeholder="https://…/callback?code=…&state=…"
@@ -628,6 +633,7 @@ export function AddProviderDialog({
 								<Label htmlFor="provider-label">Name</Label>
 								<Input
 									id="provider-label"
+									name="provider-label"
 									value={label}
 									onChange={(e) => setLabel(e.target.value)}
 									placeholder={`${meta.label} (my key)`}
@@ -661,6 +667,7 @@ export function AddProviderDialog({
 										</Label>
 										<Input
 											id="provider-key"
+											name="provider-key"
 											type="password"
 											value={apiKey}
 											onChange={(e) => setApiKey(e.target.value)}
@@ -683,6 +690,7 @@ export function AddProviderDialog({
 										<Label htmlFor="provider-env">Runtime env var</Label>
 										<Input
 											id="provider-env"
+											name="provider-env"
 											value={runtimeEnv}
 											onChange={(e) => setRuntimeEnv(e.target.value.toUpperCase())}
 											placeholder="OPENAI_API_KEY"
@@ -697,6 +705,7 @@ export function AddProviderDialog({
 								<Label htmlFor="provider-base">Base URL</Label>
 								<Input
 									id="provider-base"
+									name="provider-base"
 									value={baseUrl}
 									onChange={(e) => setBaseUrl(e.target.value)}
 									placeholder="https://api.example.com/v1"
@@ -716,6 +725,7 @@ export function AddProviderDialog({
 									<Label htmlFor="provider-model">Default model</Label>
 									<Input
 										id="provider-model"
+										name="provider-model"
 										value={defaultModel}
 										onChange={(e) => setDefaultModel(e.target.value)}
 										placeholder={meta.modelPlaceholder}

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
@@ -112,6 +112,7 @@ function ProviderCard({ provider, onEdit }: { provider: AiProvider; onEdit: () =
 	const meta = providerTypeMeta(provider.type);
 	const del = useDeleteProvider();
 	const validate = useValidateProvider();
+	const providerLabel = provider.label ?? provider.provider_id;
 
 	function runValidate() {
 		validate.mutate(provider.provider_id, {
@@ -126,14 +127,8 @@ function ProviderCard({ provider, onEdit }: { provider: AiProvider; onEdit: () =
 		<div className={cn(ENTITY_CARD_BASE, "flex h-full flex-col")}>
 			<EntityHeader
 				align="start"
-				icon={
-					<EntityIcon
-						kind="provider"
-						id={provider.type}
-						label={provider.label ?? provider.provider_id}
-					/>
-				}
-				title={provider.label ?? provider.provider_id}
+				icon={<EntityIcon kind="provider" id={provider.type} label={providerLabel} />}
+				title={providerLabel}
 				titleAdornment={<AuthBadge auth={provider.auth} />}
 				meta={[
 					`${meta.label}${provider.default_model ? ` · ${formatModelLabel(provider.default_model)}` : ""}${
@@ -148,16 +143,22 @@ function ProviderCard({ provider, onEdit }: { provider: AiProvider; onEdit: () =
 				]}
 			/>
 			<div className="mt-auto flex flex-wrap items-center gap-2 pt-3">
-				<Button variant="ghost" size="sm" onClick={runValidate} disabled={validate.isPending}>
+				<Button
+					variant="ghost"
+					size="sm"
+					onClick={runValidate}
+					disabled={validate.isPending}
+					aria-label={`Validate ${providerLabel}`}
+				>
 					<BadgeCheck />
 					Validate
 				</Button>
-				<Button variant="outline" size="sm" onClick={onEdit}>
+				<Button variant="outline" size="sm" onClick={onEdit} aria-label={`Edit ${providerLabel}`}>
 					<Pencil />
 					Edit
 				</Button>
 				<ConfirmAction
-					title={`Remove ${provider.label ?? provider.provider_id}?`}
+					title={`Remove ${providerLabel}?`}
 					description={
 						<p>
 							Agents using this provider fall back to the managed default. This can't be undone.
@@ -172,7 +173,7 @@ function ProviderCard({ provider, onEdit }: { provider: AiProvider; onEdit: () =
 						size="icon-sm"
 						className="ml-auto text-muted-foreground hover:text-destructive"
 						disabled={del.isPending}
-						aria-label={`Remove ${provider.label ?? provider.provider_id}`}
+						aria-label={`Remove ${providerLabel}`}
 					>
 						<Trash2 />
 					</Button>

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -764,7 +764,7 @@ function BindingsTab({ accountId }: { accountId: string }) {
 							<span key="type" className="capitalize">
 								{b.external_chat_type ?? "chat"}
 							</span>,
-							<CopyInline key="chat-id" value={b.external_chat_id} />,
+							<CopyInline key="chat-id" value={b.external_chat_id} label="chat ID" />,
 						]}
 					/>
 					<span className="text-xs capitalize text-muted-foreground">{b.status}</span>
@@ -838,7 +838,7 @@ function ActivityRow({ item }: { item: ChannelActivityItem }) {
 				) : null}
 				{item.external_chat_id ? (
 					<div className="mt-1">
-						<CopyInline value={item.external_chat_id} />
+						<CopyInline value={item.external_chat_id} label="external chat ID" />
 					</div>
 				) : null}
 			</div>

--- a/apps/web/src/hosted/v2/channels/channel-ui.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-ui.tsx
@@ -111,7 +111,15 @@ export function TokenReveal({
 }
 
 /** Inline copyable monospace value (chat ids, webhook urls). */
-export function CopyInline({ value, className }: { value: string; className?: string }) {
+export function CopyInline({
+	value,
+	label,
+	className,
+}: {
+	value: string;
+	label: string;
+	className?: string;
+}) {
 	const { copied, copy } = useCopy();
 	return (
 		<button
@@ -123,7 +131,7 @@ export function CopyInline({ value, className }: { value: string; className?: st
 				"inline-flex min-w-0 max-w-full items-center gap-1 font-mono text-xs text-muted-foreground transition-colors hover:text-foreground",
 				className,
 			)}
-			aria-label="Copy"
+			aria-label={`Copy ${label}`}
 		>
 			<span className="truncate">{value}</span>
 			{copied ? <Check className="size-3 shrink-0" /> : <Copy className="size-3 shrink-0" />}

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
@@ -20,6 +20,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
 import {
 	Select,
 	SelectContent,
@@ -125,8 +126,11 @@ export function LinkAgentDialog({
 					/>
 				) : (
 					<div className="flex flex-col gap-2">
+						<Label htmlFor="link-agent-select" className="sr-only">
+							Agent
+						</Label>
 						<Select value={agentId} onValueChange={setAgentId}>
-							<SelectTrigger>
+							<SelectTrigger id="link-agent-select">
 								<SelectValue placeholder="Choose an agent" />
 							</SelectTrigger>
 							<SelectContent>


### PR DESCRIPTION
## Summary

### Taxonomy strings changed
- `Manage this v1 hosted agent in the legacy dashboard.` -> `Manage this Legacy hosted agent in the legacy dashboard.`
- `This agent uses the legacy v1 management surface for runtime actions.` -> `This agent uses the legacy management surface for runtime actions.`

### Accessibility and form attributes added
- `apps/web/src/hosted/v2/channels/link-agent-dialog.tsx`: added sr-only `Label htmlFor="link-agent-select"` and `id="link-agent-select"` on the agent select trigger.
- `apps/web/src/hosted/v2/channels/channel-ui.tsx`: changed `CopyInline` from bare `aria-label="Copy"` to contextual `aria-label={\`Copy ${label}\`}`.
- `apps/web/src/hosted/v2/channels/channel-detail-page.tsx`: added `label="chat ID"` and `label="external chat ID"` for `CopyInline` call sites.
- `apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx`: added sr-only `Label htmlFor="provider-oauth-callback"`, plus `id="provider-oauth-callback"` and `name="provider-oauth-callback"` on the manual OAuth callback input.
- `apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx`: added `name` attributes for `provider-label`, `provider-key`, `provider-env`, `provider-base`, and `provider-model` inputs.
- `apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx`: added contextual `aria-label` attributes for provider `Validate` and `Edit` controls.
- `apps/web/src/hosted/billing/components/term-switcher.tsx`: added `aria-label="Billing term"` on the billing term toggle group.
- `apps/web/src/hosted/billing/wallet/top-up-dialog.tsx`: added `name="topup-amount"` and `autoComplete="off"` on the top-up amount input.
- `apps/web/src/hosted/billing/wallet/auto-reload-card.tsx`: added `name` and `autoComplete="off"` on `ar-threshold`, `ar-amount`, and `ar-cap` numeric inputs.

## Verification
- `bun run check:fix`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`

## Notes
- Remaining `v1`/`v2` grep hits in `apps/web/src` are comments, tests, internal docs, type names, route/API/internal identifiers, or hidden compatibility strings.
- Pair-code selects in `channel-detail-page.tsx` already had associated visible labels and trigger IDs in this worktree, so no duplicate label changes were made there.