### PR TITLE
Align web deployment status model with real backend enum

### DIFF
--- a/apps/web/src/hosted/billing/deploy/deploy-model.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-model.test.ts
@@ -39,10 +39,12 @@ describe("usesActiveFreeComputeSlot", () => {
 		expect(usesActiveFreeComputeSlot([deployment("running", "compute_free")])).toBe(true);
 		expect(usesActiveFreeComputeSlot([deployment("starting", "compute_free")])).toBe(true);
 		expect(usesActiveFreeComputeSlot([deployment("failed", "compute_free")])).toBe(true);
+		expect(usesActiveFreeComputeSlot([deployment("deleting", "compute_free")])).toBe(true);
 	});
 
-	test("does not count stopped Free or Performance deployments", () => {
+	test("does not count stopped or deleted Free deployments or Performance deployments", () => {
 		expect(usesActiveFreeComputeSlot([deployment("stopped", "compute_free")])).toBe(false);
+		expect(usesActiveFreeComputeSlot([deployment("deleted", "compute_free")])).toBe(false);
 		expect(usesActiveFreeComputeSlot([deployment("running", "compute_performance")])).toBe(false);
 	});
 });

--- a/apps/web/src/hosted/billing/deploy/deploy-model.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-model.ts
@@ -1,9 +1,10 @@
 import type { HostedDeployment } from "@/hosted/billing/contracts";
+import { parseDeploymentStatus } from "@/hosted/deployment-status";
 
 export function usesActiveFreeComputeSlot(deployments: HostedDeployment[] | undefined): boolean {
-	return (deployments ?? []).some(
-		(deployment) =>
-			deployment.config_info?.compute_plan_slug === "compute_free" &&
-			deployment.status !== "stopped",
-	);
+	return (deployments ?? []).some((deployment) => {
+		if (deployment.config_info?.compute_plan_slug !== "compute_free") return false;
+		const status = parseDeploymentStatus(deployment.status);
+		return status.kind !== "stopped" && status.kind !== "deleted";
+	});
 }

--- a/apps/web/src/hosted/billing/deployment-links.test.ts
+++ b/apps/web/src/hosted/billing/deployment-links.test.ts
@@ -9,7 +9,7 @@ function deployment(envs: Record<string, string> | null): HostedDeployment {
 		name: "openclaw-test",
 		app_id: "app_123",
 		backend: null,
-		status: "provisioning",
+		status: "creating",
 		endpoints: [],
 		openclaw_control_ui_url: null,
 		hermes_control_ui_url: null,

--- a/apps/web/src/hosted/deployment-status.test.ts
+++ b/apps/web/src/hosted/deployment-status.test.ts
@@ -14,11 +14,31 @@ import {
 } from "@/hosted/deployment-status";
 
 describe("DeploymentStatus", () => {
-	test("normalizes known deploy-api statuses", () => {
+	test("matches the hosted backend deployment status enum", () => {
+		expect(KNOWN_DEPLOYMENT_STATUSES).toEqual([
+			"creating",
+			"starting",
+			"running",
+			"stopped",
+			"failed",
+			"deleting",
+			"deleted",
+		]);
+	});
+
+	test("normalizes known hosted backend statuses", () => {
 		for (const raw of KNOWN_DEPLOYMENT_STATUSES) {
 			const status = parseDeploymentStatus(raw.toUpperCase());
 			expect(status).toEqual({ kind: raw, raw, known: true });
 		}
+	});
+
+	test("maps the ready legacy alias to running", () => {
+		expect(parseDeploymentStatus(" ready ")).toEqual({
+			kind: "running",
+			raw: "running",
+			known: true,
+		});
 	});
 
 	test("preserves and labels unknown statuses", () => {
@@ -28,56 +48,74 @@ describe("DeploymentStatus", () => {
 		expect(deploymentStatusTone(status)).toBe("warning");
 	});
 
-	test("labels and tones known statuses", () => {
-		expect(deploymentStatusLabel(parseDeploymentStatus("ready"))).toBe("Ready");
-		expect(deploymentStatusLabel(parseDeploymentStatus("error"))).toBe("Failed");
-		expect(deploymentStatusTone(parseDeploymentStatus("running"))).toBe("success");
-		expect(deploymentStatusTone(parseDeploymentStatus("stopped"))).toBe("neutral");
-		expect(deploymentStatusTone(parseDeploymentStatus("failed"))).toBe("destructive");
-		expect(deploymentStatusTone(parseDeploymentStatus("restarting"))).toBe("info");
+	test("labels and tones the hosted backend statuses", () => {
+		const expected = [
+			["creating", "Provisioning", "info"],
+			["starting", "Starting", "info"],
+			["running", "Running", "success"],
+			["stopped", "Stopped", "neutral"],
+			["failed", "Failed", "destructive"],
+			["deleting", "Deleting", "info"],
+			["deleted", "Deleted", "neutral"],
+		] as const;
+
+		for (const [raw, label, tone] of expected) {
+			const status = parseDeploymentStatus(raw);
+			expect(deploymentStatusLabel(status)).toBe(label);
+			expect(deploymentStatusTone(status)).toBe(tone);
+		}
 	});
 
 	test("classifies terminal and transitional states", () => {
-		for (const raw of ["running", "ready", "stopped", "failed", "error"]) {
+		for (const raw of ["running", "stopped", "failed", "deleted"]) {
 			const status = parseDeploymentStatus(raw);
 			expect(isTerminalStatus(status)).toBe(true);
 			expect(isTransitionalStatus(status)).toBe(false);
 		}
 
-		for (const raw of [
-			"pending",
-			"provisioning",
-			"starting",
-			"stopping",
-			"restarting",
-			"deleting",
-			"future_status",
-		]) {
+		for (const raw of ["creating", "starting", "deleting", "future_status"]) {
 			const status = parseDeploymentStatus(raw);
 			expect(isTerminalStatus(status)).toBe(false);
 			expect(isTransitionalStatus(status)).toBe(true);
 		}
 	});
 
-	test("drives lifecycle gates from recoverable statuses", () => {
+	test("drives lifecycle gates from hosted backend statuses", () => {
+		const expectations = [
+			["creating", false, false, false],
+			["starting", false, true, true],
+			["running", false, true, true],
+			["stopped", true, false, false],
+			["failed", true, false, true],
+			["deleting", false, false, false],
+			["deleted", false, false, false],
+			["future_status", false, false, false],
+		] as const;
+
 		expect(isRunningStatus(parseDeploymentStatus("running"))).toBe(true);
 		expect(isRunningStatus(parseDeploymentStatus("ready"))).toBe(true);
-		expect(canStop(parseDeploymentStatus("running"))).toBe(true);
-		expect(canStop(parseDeploymentStatus("starting"))).toBe(true);
-		expect(canStart(parseDeploymentStatus("stopped"))).toBe(true);
-		expect(canStart(parseDeploymentStatus("failed"))).toBe(true);
-		expect(canStart(parseDeploymentStatus("error"))).toBe(true);
-		expect(canStart(parseDeploymentStatus("starting"))).toBe(false);
-		expect(canRestart(parseDeploymentStatus("ready"))).toBe(true);
-		expect(canRestart(parseDeploymentStatus("starting"))).toBe(true);
-		expect(canRestart(parseDeploymentStatus("failed"))).toBe(true);
-		expect(canRestart(parseDeploymentStatus("restarting"))).toBe(false);
-		expect(canRestart(parseDeploymentStatus("future_status"))).toBe(false);
+		expect(isRunningStatus(parseDeploymentStatus("stopped"))).toBe(false);
+
+		for (const [raw, start, stop, restart] of expectations) {
+			const status = parseDeploymentStatus(raw);
+			expect(canStart(status)).toBe(start);
+			expect(canStop(status)).toBe(stop);
+			expect(canRestart(status)).toBe(restart);
+		}
 	});
 
 	test("polls while any deployment is non-terminal", () => {
-		expect(shouldPollDeployments([{ status: "running" }, { status: "stopped" }])).toBe(false);
-		expect(shouldPollDeployments([{ status: "running" }, { status: "restarting" }])).toBe(true);
+		expect(
+			shouldPollDeployments([
+				{ status: "running" },
+				{ status: "stopped" },
+				{ status: "failed" },
+				{ status: "deleted" },
+			]),
+		).toBe(false);
+		expect(shouldPollDeployments([{ status: "running" }, { status: "creating" }])).toBe(true);
+		expect(shouldPollDeployments([{ status: "running" }, { status: "starting" }])).toBe(true);
+		expect(shouldPollDeployments([{ status: "running" }, { status: "deleting" }])).toBe(true);
 		expect(shouldPollDeployments([{ status: "new_backend_status" }])).toBe(true);
 		expect(shouldPollDeployments([])).toBe(false);
 		expect(shouldPollDeployments(undefined)).toBe(false);

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -1,15 +1,11 @@
 export const KNOWN_DEPLOYMENT_STATUSES = [
-	"pending",
-	"provisioning",
+	"creating",
 	"starting",
 	"running",
-	"ready",
 	"stopped",
 	"failed",
-	"error",
-	"stopping",
-	"restarting",
 	"deleting",
+	"deleted",
 ] as const;
 
 export type KnownDeploymentStatus = (typeof KNOWN_DEPLOYMENT_STATUSES)[number];
@@ -30,10 +26,15 @@ export type UnknownDeploymentStatus = {
 export type DeploymentStatus = KnownDeploymentStatusModel | UnknownDeploymentStatus;
 
 const KNOWN_STATUS_SET = new Set<string>(KNOWN_DEPLOYMENT_STATUSES);
+const LEGACY_STATUS_ALIASES = new Map<string, KnownDeploymentStatus>([["ready", "running"]]);
 
 export function parseDeploymentStatus(raw: string | null | undefined): DeploymentStatus {
 	const value = raw?.trim() ?? "";
 	const normalized = value.toLowerCase();
+	const alias = LEGACY_STATUS_ALIASES.get(normalized);
+	if (alias) {
+		return { kind: alias, raw: alias, known: true };
+	}
 	if (KNOWN_STATUS_SET.has(normalized)) {
 		const kind = normalized as KnownDeploymentStatus;
 		return { kind, raw: kind, known: true };
@@ -43,27 +44,20 @@ export function parseDeploymentStatus(raw: string | null | undefined): Deploymen
 
 export function deploymentStatusLabel(status: DeploymentStatus): string {
 	switch (status.kind) {
-		case "pending":
-			return "Pending";
-		case "provisioning":
+		case "creating":
 			return "Provisioning";
 		case "starting":
 			return "Starting";
 		case "running":
 			return "Running";
-		case "ready":
-			return "Ready";
 		case "stopped":
 			return "Stopped";
 		case "failed":
-		case "error":
 			return "Failed";
-		case "stopping":
-			return "Stopping";
-		case "restarting":
-			return "Restarting";
 		case "deleting":
 			return "Deleting";
+		case "deleted":
+			return "Deleted";
 		case "unknown":
 			return titleCaseStatus(status.raw);
 		default:
@@ -74,20 +68,16 @@ export function deploymentStatusLabel(status: DeploymentStatus): string {
 export function deploymentStatusTone(status: DeploymentStatus): DeploymentStatusTone {
 	switch (status.kind) {
 		case "running":
-		case "ready":
 			return "success";
 		case "failed":
-		case "error":
 			return "destructive";
 		case "stopped":
+		case "deleted":
 			return "neutral";
-		case "pending":
-		case "provisioning":
+		case "creating":
 		case "starting":
-		case "restarting":
-			return "info";
-		case "stopping":
 		case "deleting":
+			return "info";
 		case "unknown":
 			return "warning";
 		default:
@@ -96,38 +86,105 @@ export function deploymentStatusTone(status: DeploymentStatus): DeploymentStatus
 }
 
 export function isRunningStatus(status: DeploymentStatus): boolean {
-	return status.kind === "running" || status.kind === "ready";
+	switch (status.kind) {
+		case "running":
+			return true;
+		case "creating":
+		case "starting":
+		case "stopped":
+		case "failed":
+		case "deleting":
+		case "deleted":
+		case "unknown":
+			return false;
+		default:
+			return exhaustive(status);
+	}
 }
 
 export function isTerminalStatus(status: DeploymentStatus): boolean {
-	return (
-		status.kind === "running" ||
-		status.kind === "ready" ||
-		status.kind === "stopped" ||
-		status.kind === "failed" ||
-		status.kind === "error"
-	);
+	switch (status.kind) {
+		case "running":
+		case "stopped":
+		case "failed":
+		case "deleted":
+			return true;
+		case "creating":
+		case "starting":
+		case "deleting":
+		case "unknown":
+			return false;
+		default:
+			return exhaustive(status);
+	}
 }
 
 export function isTransitionalStatus(status: DeploymentStatus): boolean {
-	return !isTerminalStatus(status);
+	switch (status.kind) {
+		case "creating":
+		case "starting":
+		case "deleting":
+		case "unknown":
+			return true;
+		case "running":
+		case "stopped":
+		case "failed":
+		case "deleted":
+			return false;
+		default:
+			return exhaustive(status);
+	}
 }
 
 export function canStart(status: DeploymentStatus): boolean {
-	return status.kind === "stopped" || status.kind === "failed" || status.kind === "error";
+	switch (status.kind) {
+		case "stopped":
+		case "failed":
+			return true;
+		case "creating":
+		case "starting":
+		case "running":
+		case "deleting":
+		case "deleted":
+		case "unknown":
+			return false;
+		default:
+			return exhaustive(status);
+	}
 }
 
 export function canStop(status: DeploymentStatus): boolean {
-	return isRunningStatus(status) || status.kind === "starting";
+	switch (status.kind) {
+		case "running":
+		case "starting":
+			return true;
+		case "creating":
+		case "stopped":
+		case "failed":
+		case "deleting":
+		case "deleted":
+		case "unknown":
+			return false;
+		default:
+			return exhaustive(status);
+	}
 }
 
 export function canRestart(status: DeploymentStatus): boolean {
-	return (
-		isRunningStatus(status) ||
-		status.kind === "starting" ||
-		status.kind === "failed" ||
-		status.kind === "error"
-	);
+	switch (status.kind) {
+		case "running":
+		case "starting":
+		case "failed":
+			return true;
+		case "creating":
+		case "stopped":
+		case "deleting":
+		case "deleted":
+		case "unknown":
+			return false;
+		default:
+			return exhaustive(status);
+	}
 }
 
 export function shouldPollDeployments(

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -52,14 +52,18 @@ function env(overrides: Partial<Env> = {}): Env {
 }
 
 describe("hostedAgentTileStatus", () => {
-	test("marks running and ready deployments active", () => {
+	test("marks running deployments active and normalizes the ready alias", () => {
 		expect(hostedAgentTileStatus("running")).toEqual({ label: "Running", active: true });
-		expect(hostedAgentTileStatus("ready")).toEqual({ label: "Ready", active: true });
+		expect(hostedAgentTileStatus("ready")).toEqual({ label: "Running", active: true });
 	});
 
 	test("keeps transitional and failed deployments inactive with readable labels", () => {
-		expect(hostedAgentTileStatus("restarting")).toEqual({
-			label: "Restarting",
+		expect(hostedAgentTileStatus("creating")).toEqual({
+			label: "Provisioning",
+			active: false,
+		});
+		expect(hostedAgentTileStatus("starting")).toEqual({
+			label: "Starting",
 			active: false,
 		});
 		expect(hostedAgentTileStatus("failed")).toEqual({ label: "Failed", active: false });
@@ -116,10 +120,10 @@ describe("hostedRuntimeStatusView", () => {
 
 	test("shows pending sync only when running without a registered environment", () => {
 		const running = hostedRuntimeStatusView("running", null);
-		const provisioning = hostedRuntimeStatusView("provisioning", null);
+		const creating = hostedRuntimeStatusView("creating", null);
 
 		expect(running.secondary?.label).toBe("Sync pending");
-		expect(provisioning.primary.label).toBe("Provisioning");
-		expect(provisioning.secondary).toBeNull();
+		expect(creating.primary.label).toBe("Provisioning");
+		expect(creating.secondary).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary
- Align the web deployment status model with the real hosted backend `/v2/deployments` contract: `creating`, `starting`, `running`, `stopped`, `failed`, `deleting`, `deleted`.
- Keep only the defensive legacy alias `ready -> running`; unknown future values still render safely and continue polling.
- Remove mock-only statuses from the typed model and tests: `pending`, `provisioning`, `ready`, `error`, `stopping`, `restarting`.
- Treat `deleted` as terminal so deployment polling stops once a deleted deployment is returned.
- Route Free-slot occupancy through the status parser so deleted Free deployments do not block slot reuse.

## Ground Truth
- Hosted `_status_for_backend()` normalizes k3s-derived statuses into the seven-value backend contract.
- The `v2_hosted_deployment` DB enum is exactly: `creating`, `starting`, `running`, `stopped`, `failed`, `deleting`, `deleted`.
- `ready` is normalized to `running`; `not_found` is normalized to `failed`; all other unready k3s states normalize to `starting` before reaching the web.

## Verification
- `bun run check:fix`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`
