### PR TITLE
Correct channel connect success copy for transparent ingress

### DIFF
--- a/apps/web/src/hosted/v2/channels/channel-providers.ts
+++ b/apps/web/src/hosted/v2/channels/channel-providers.ts
@@ -48,7 +48,7 @@ export const PROVIDER_META: Record<ChannelProviderId, SupportedChannelProviderMe
 		connect: "discord",
 		tokenLabel: "Bot token",
 		tokenPlaceholder: "Bot token",
-		hint: "From the Discord developer portal: the bot token, plus the application ID and public key for slash commands and interactions.",
+		hint: "Paste the bot token and application ID from your Discord application. Include the public key when available.",
 	},
 	whatsapp: {
 		id: "whatsapp",

--- a/apps/web/src/hosted/v2/channels/channel-ui.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-ui.tsx
@@ -73,7 +73,7 @@ function useCopy() {
 	return useCopyToClipboard({ error: "Copy failed" });
 }
 
-/** Copyable secret box — used for revealed agent tokens, webhook secrets. */
+/** Copyable token box for values revealed once. */
 export function TokenReveal({
 	label,
 	value,
@@ -110,7 +110,7 @@ export function TokenReveal({
 	);
 }
 
-/** Inline copyable monospace value (chat ids, webhook urls). */
+/** Inline copyable monospace value (chat ids, ids, urls). */
 export function CopyInline({
 	value,
 	label,

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -29,7 +29,7 @@ import { useCreateChannel } from "@/hosted/v2/channels/channels-hooks";
  * cloud-api): Telegram = bot token; Discord = bot token + application_id +
  * public_key (+ guild_id); WhatsApp = no token (device is linked afterwards
  * via the Baileys tenant-creds flow on the channel page). On success the
- * webhook secret is revealed once.
+ * scoped agent token may be revealed once when an agent is auto-linked.
  */
 export function ConnectBotDialog({
 	open,
@@ -114,15 +114,10 @@ export function ConnectBotDialog({
 						<DialogHeader>
 							<DialogTitle>Channel connected</DialogTitle>
 							<DialogDescription>
-								<span className="font-medium">{created.name}</span> is ready. Keep the webhook
-								secret safe — it signs incoming updates.
+								<span className="font-medium">{created.name}</span> is connected. Clawdi handles
+								message delivery automatically. There is nothing else to configure.
 							</DialogDescription>
 						</DialogHeader>
-						<TokenReveal
-							label="Webhook secret"
-							value={created.webhook_secret}
-							note="Shown once. Configure this as the secret token on your bot's webhook."
-						/>
 						{created.agent_token ? (
 							<TokenReveal
 								label="Agent token"
@@ -241,7 +236,7 @@ export function ConnectBotDialog({
 											spellCheck={false}
 										/>
 										<p className="text-xs text-muted-foreground">
-											Verifies incoming interaction signatures.
+											Stored with the Discord application metadata.
 										</p>
 									</div>
 									<div className="flex flex-col gap-1.5">


### PR DESCRIPTION
## Summary
- Removed the hosted v2 connect success screen's `Webhook secret` reveal and the instruction to configure it on a bot webhook.
- Rewrote the success description to say the channel is connected, Clawdi handles message delivery automatically, and there is nothing else to configure.
- Kept the `Agent token` reveal because it is the per-link credential for the auto-linked agent to send and receive on the channel.
- Kept the WhatsApp next step to link the device under Linked devices.
- Updated adjacent Discord helper copy/comments that still implied interaction-webhook-style ingress.

## Why
Hosted v2 uses the sidecar MITM proxy and Clawdi-owned provider ingress. Users do not configure a provider webhook, endpoint URL, or webhook secret. The returned `webhook_secret` is internal Clawdi ingress plumbing for Clawdi-namespaced emulated endpoints, so surfacing it as a bot webhook secret was product-inaccurate.

## Verification
- `bun run check:fix`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`
