### PR TITLE
Fall back to managed AI when a bound provider is deleted

### DIFF
--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -208,13 +208,12 @@ async def _provider_projection(
     secret_cache: dict[str, tuple[str | None, AiProviderAuthPayload | None]] = {}
 
     for runtime_name, binding in sorted(bindings.items()):
-        if binding.provider_id not in provider_cache:
-            provider_cache[binding.provider_id] = await _select_provider(
-                db,
-                auth=auth,
-                provider_id=binding.provider_id,
-            )
-        provider = provider_cache[binding.provider_id]
+        provider = await _select_provider_for_binding(
+            db,
+            auth=auth,
+            provider_id=binding.provider_id,
+            provider_cache=provider_cache,
+        )
         if provider is None:
             continue
 
@@ -346,6 +345,31 @@ def _runtime_provider_bindings(state: HostedRuntimeState) -> dict[str, _RuntimeP
             model=None,
         )
     return bindings
+
+
+async def _select_provider_for_binding(
+    db: AsyncSession,
+    *,
+    auth: AuthContext,
+    provider_id: str | None,
+    provider_cache: dict[str | None, AiProvider | None],
+) -> AiProvider | None:
+    if provider_id not in provider_cache:
+        provider_cache[provider_id] = await _select_provider(
+            db,
+            auth=auth,
+            provider_id=provider_id,
+        )
+    provider = provider_cache[provider_id]
+    if provider is not None or provider_id is None:
+        return provider
+    if None not in provider_cache:
+        provider_cache[None] = await _select_provider(
+            db,
+            auth=auth,
+            provider_id=None,
+        )
+    return provider_cache[None]
 
 
 async def _select_provider(

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime
 from uuid import uuid4
 
 import httpx
@@ -628,6 +629,89 @@ async def test_runtime_manifest_projects_per_runtime_provider_bindings(
         "provider.hermes.apiKey": "sk-hermes-provider",
         "provider.openclaw.apiKey": "sk-openclaw-provider",
     }
+
+
+@pytest.mark.asyncio
+async def test_runtime_manifest_falls_back_to_managed_provider_for_archived_binding(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"archived-provider-{uuid4().hex[:8]}",
+        machine_name="Runtime archived provider",
+        agent_type="openclaw",
+    )
+    ciphertext, nonce = encrypt("sk-managed-provider")
+    db_session.add_all(
+        [
+            AiProvider(
+                owner_user_id=seed_user.id,
+                provider_id="deleted-custom-provider",
+                type="custom_openai_compatible",
+                base_url="https://deleted-provider.test/v1",
+                default_model="deleted-model",
+                api_mode="openai_responses",
+                auth_type="api_key",
+                auth_metadata={"source": "managed"},
+                managed_by="user",
+                runtime_env_name="DELETED_PROVIDER_API_KEY",
+                archived_at=datetime.now(UTC),
+            ),
+            AiProvider(
+                owner_user_id=seed_user.id,
+                provider_id="clawdi-managed-v2",
+                type="custom_openai_compatible",
+                base_url="https://managed-provider.test/v1",
+                default_model="gpt-5.5",
+                api_mode="openai_responses",
+                auth_type="api_key",
+                auth_metadata={"source": "managed"},
+                managed_by="clawdi",
+                runtime_env_name="CLAWDI_MANAGED_OPENAI_API_KEY",
+            ),
+            AiProviderAuthPayload(
+                owner_user_id=seed_user.id,
+                provider_id="clawdi-managed-v2",
+                auth_profile="default",
+                kind="api_key",
+                source="managed",
+                encrypted_payload=ciphertext,
+                nonce=nonce,
+            ),
+        ]
+    )
+    await db_session.commit()
+    await _write_runtime_state(
+        admin_client,
+        str(env.id),
+        runtimes={
+            "openclaw": {
+                "enabled": True,
+                "provider_id": "deleted-custom-provider",
+            },
+            "hermes": {"enabled": False},
+        },
+    )
+
+    api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        response = await client.get("/v1/runtime/manifest")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["manifest"]["providers"]["openclaw"] == {
+        "kind": "openai-compatible",
+        "baseUrl": "https://managed-provider.test/v1",
+        "model": "gpt-5.5",
+        "apiMode": "openai_chat",
+        "runtimeEnvName": "CLAWDI_MANAGED_OPENAI_API_KEY",
+        "apiKeySecretRef": "provider.openclaw.apiKey",
+    }
+    assert payload["secretValues"] == {"provider.openclaw.apiKey": "sk-managed-provider"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fix runtime provider binding resolution so an explicit `provider_id` that no longer resolves to a live `AiProvider` falls back to the managed default provider.
- Keep existing behavior unchanged when the bound provider is still live.
- Add a regression test covering a hosted runtime bound to an archived provider.

## Mechanism
Provider deletion from the dashboard archives the provider by setting `archived_at`. Runtime manifest generation filters provider lookup with `AiProvider.archived_at.is_(None)`, so a runtime explicitly bound to the archived provider previously resolved to `None`. The projection loop then skipped that runtime provider entry, removing the AI config from the manifest.

## Fix
`_provider_projection` now resolves bindings through a helper that first attempts the bound provider. If a non-null bound `provider_id` is missing, archived, or otherwise not live, it retries the existing managed-default lookup path (`provider_id=None`, which checks `MANAGED_AI_PROVIDER_ID` / `V1_MANAGED_AI_PROVIDER_ID`). The runtime is skipped only if the managed fallback is also absent.

## UI promise
The AI Providers remove confirmation says: "Agents using this provider fall back to the managed default." This change makes the backend manifest honor that promise instead of silently dropping the runtime's provider config.

## Verification
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m compileall app scripts tests alembic`
- `uv run pytest -q tests/test_runtime_manifest.py` against a migrated throwaway PostgreSQL database
