### PR TITLE
Hide disabled runtimes from agent tiles

### DIFF
--- a/apps/web/src/hosted/runtimes.test.ts
+++ b/apps/web/src/hosted/runtimes.test.ts
@@ -53,6 +53,7 @@ describe("deploymentRuntimes", () => {
 			deploymentRuntimes(
 				deployment(
 					configInfo({
+						enable_hermes: true,
 						clawdi_cloud_environments: {
 							hermes: "env-hermes",
 							openclaw: "env-openclaw",
@@ -73,6 +74,7 @@ describe("deploymentRuntimes", () => {
 						onboarded_agents: ["openclaw"],
 						configured_agents: ["openclaw", "hermes"],
 						clawdi_cloud_environments: {
+							hermes: "env-hermes",
 							openclaw: "env-openclaw",
 						},
 					}),

--- a/apps/web/src/hosted/runtimes.ts
+++ b/apps/web/src/hosted/runtimes.ts
@@ -62,7 +62,7 @@ export function runtimeIsEnabled(
 	runtime: HostedRuntime,
 ): boolean {
 	if (runtime === ALWAYS_ON_HOSTED_RUNTIME) return true;
-	if (runtime === "openclaw") return configInfo?.enable_openclaw !== false;
+	if (runtime === "openclaw") return configInfo?.enable_openclaw === true;
 	return configInfo?.enable_hermes === true;
 }
 
@@ -97,15 +97,11 @@ export function deploymentRuntimes(deployment: HostedDeployment): HostedRuntime[
 		...(configInfo?.onboarded_agents ?? []),
 	]);
 	if (explicit.length > 0) {
-		return sortHostedRuntimes([ALWAYS_ON_HOSTED_RUNTIME, ...explicit]);
+		const enabledExplicit = explicit.filter((runtime) => runtimeIsEnabled(configInfo, runtime));
+		return sortHostedRuntimes([ALWAYS_ON_HOSTED_RUNTIME, ...enabledExplicit]);
 	}
 
 	const fallback = new Set<HostedRuntime>([ALWAYS_ON_HOSTED_RUNTIME]);
-	for (const runtime of sortHostedRuntimes(
-		Object.keys(configInfo?.clawdi_cloud_environments ?? {}),
-	)) {
-		fallback.add(runtime);
-	}
 	if (runtimeIsEnabled(configInfo, "openclaw")) fallback.add("openclaw");
 	if (runtimeIsEnabled(configInfo, "hermes")) fallback.add("hermes");
 	return sortHostedRuntimes(fallback);

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -1,12 +1,15 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import type { components } from "@clawdi/shared/api";
+import type { HostedDeployment } from "@/hosted/billing/contracts";
 
 type HostedAgentTileStatus = typeof import("@/hosted/use-hosted-agent-tiles").hostedAgentTileStatus;
+type DeploymentToTiles = typeof import("@/hosted/use-hosted-agent-tiles").deploymentToTiles;
 type HostedRuntimeStatusView =
 	typeof import("@/hosted/use-hosted-agent-tiles").hostedRuntimeStatusView;
 type Env = components["schemas"]["AgentResponse"];
 
 let getTileStatus: HostedAgentTileStatus | null = null;
+let getDeploymentToTiles: DeploymentToTiles | null = null;
 let getRuntimeStatusView: HostedRuntimeStatusView | null = null;
 
 beforeAll(async () => {
@@ -15,6 +18,7 @@ beforeAll(async () => {
 	process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
 	const module = await import("@/hosted/use-hosted-agent-tiles");
 	getTileStatus = module.hostedAgentTileStatus;
+	getDeploymentToTiles = module.deploymentToTiles;
 	getRuntimeStatusView = module.hostedRuntimeStatusView;
 });
 
@@ -26,6 +30,14 @@ function hostedAgentTileStatus(rawStatus: string) {
 function hostedRuntimeStatusView(rawStatus: string, environment: Env | null | undefined) {
 	if (!getRuntimeStatusView) throw new Error("hostedRuntimeStatusView was not loaded");
 	return getRuntimeStatusView({ status: rawStatus }, environment);
+}
+
+function hostedDeploymentToTiles(deployment: HostedDeployment, envs: Env[] = []) {
+	if (!getDeploymentToTiles) throw new Error("deploymentToTiles was not loaded");
+	return getDeploymentToTiles(
+		deployment,
+		new Map(envs.map((item) => [item.id.toLowerCase(), item])),
+	);
 }
 
 function env(overrides: Partial<Env> = {}): Env {
@@ -50,6 +62,82 @@ function env(overrides: Partial<Env> = {}): Env {
 		...overrides,
 	};
 }
+
+function deployment(
+	overrides: Partial<HostedDeployment> = {},
+	configInfoOverrides: Partial<NonNullable<HostedDeployment["config_info"]>> = {},
+): HostedDeployment {
+	return {
+		id: "dep_123",
+		user_id: "user_123",
+		name: "hosted-test",
+		app_id: "app_123",
+		backend: null,
+		status: "running",
+		endpoints: [],
+		openclaw_control_ui_url: null,
+		hermes_control_ui_url: null,
+		config_info: {
+			compute_plan_slug: "compute_free",
+			mux_enabled: true,
+			telegram_mux_enabled: false,
+			discord_mux_enabled: false,
+			whatsapp_mux_enabled: false,
+			imessage_mux_enabled: false,
+			kobb_available: false,
+			channel: null,
+			primary_model: null,
+			ai_provider_id: null,
+			ai_provider_auth_kind: "managed",
+			public_ports: [],
+			enable_openclaw: true,
+			enable_hermes: false,
+			onboarded_agents: ["openclaw"],
+			configured_agents: ["openclaw"],
+			clawdi_cloud_environments: {},
+			vcpu: null,
+			ram_gb: null,
+			disk_gb: null,
+			...configInfoOverrides,
+		},
+		created_at: "2026-06-22T00:00:00Z",
+		upgrade_available: false,
+		...overrides,
+	};
+}
+
+describe("deploymentToTiles", () => {
+	test("omits disabled optional runtimes even when stale environment mappings remain", () => {
+		const openclawEnv = env({
+			id: "33333333-3333-4333-8333-333333333333",
+			name: "hosted-openclaw",
+			default_name: "hosted-openclaw",
+			machine_name: "hosted-openclaw",
+			agent_type: "openclaw",
+			last_seen_at: new Date().toISOString(),
+		});
+		const tiles = hostedDeploymentToTiles(
+			deployment(
+				{},
+				{
+					enable_openclaw: false,
+					enable_hermes: false,
+					onboarded_agents: ["openclaw", "hermes"],
+					configured_agents: ["openclaw", "hermes"],
+					clawdi_cloud_environments: {
+						openclaw: openclawEnv.id,
+						hermes: "44444444-4444-4444-8444-444444444444",
+					},
+				},
+			),
+			[openclawEnv],
+		);
+
+		expect(tiles.map((tile) => tile.agentType)).toEqual(["codex"]);
+		expect(tiles.some((tile) => tile.id === "dep_123:openclaw")).toBe(false);
+		expect(tiles.some((tile) => tile.id === "dep_123:hermes")).toBe(false);
+	});
+});
 
 describe("hostedAgentTileStatus", () => {
 	test("marks running deployments active and normalizes the ready alias", () => {

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -221,13 +221,13 @@ export function useHostedAgentTiles({
  * One deployment fans out to one tile per hosted runtime. Codex is the default
  * always-on runtime; OpenClaw and Hermes are optional sibling runtimes.
  *
- * Runtime resolution priority (see `resolveRuntimes` below):
- *   1. `clawdi_cloud_environments` keys. Each key corresponds to a
- *      runtime with a live cloud-api env binding.
- *   2. `onboarded_agents`, when it names recognizable runtimes.
+ * Runtime resolution priority (see `deploymentRuntimes`):
+ *   1. Enabled runtimes named by `clawdi_cloud_environments` keys. Each key
+ *      corresponds to a live cloud-api env binding.
+ *   2. Enabled `onboarded_agents`, when it names recognizable runtimes.
  *   3. Codex plus enabled legacy runtime flags for older payloads.
  */
-function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>): AgentTile[] {
+export function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>): AgentTile[] {
 	const runtimes = deploymentRuntimes(d);
 	const slug = deploymentDisplayName(d.name);
 	// Hosted deployments don't use last_seen_at; status is the freshness signal


### PR DESCRIPTION
## Bug
A disabled optional hosted runtime could still render as an active /agents tile when its stale environment id remained in config_info.clawdi_cloud_environments and the deployment compute was running.

## Fix
Gate optional runtime enumeration on config_info enable flags before tile projection. Codex remains always-on. OpenClaw only appears when enable_openclaw is explicitly true, and Hermes only appears when enable_hermes is explicitly true; enabled runtimes still use clawdi_cloud_environments for the environment-id join.

## Confirmed generated fields
packages/shared/src/api/deploy.generated.ts defines V2HostedDeploymentResponse.config_info as V2HostedDeploymentDetailsInfo | null, and V2HostedDeploymentDetailsInfo includes enable_openclaw: boolean, enable_hermes: boolean, and optional clawdi_cloud_environments?: { [key: string]: string }. The implementation treats missing config_info or missing optional-runtime flags defensively by not showing optional runtimes unless the flag is true.

## Verification
- bun run check:fix
- bun run --cwd apps/web typecheck
- bun run --cwd apps/web test