### PR TITLE
Fix wallet spend-cap safety and filtered ledger paging

### DIFF
--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { autoReloadFormState } from "./auto-reload-card.logic";
+
+const validForm = {
+	amount: "25",
+	threshold: "1",
+	cap: "100",
+	pointsPerUsd: 1000,
+};
+
+describe("autoReloadFormState", () => {
+	test("rejects a blank monthly cap instead of converting it to no cap", () => {
+		const state = autoReloadFormState({ ...validForm, cap: "" });
+
+		expect(Number.isNaN(state.capCents)).toBe(true);
+		expect(state.capValid).toBe(false);
+		expect(state.formValid).toBe(false);
+	});
+
+	test("keeps an explicit 0 monthly cap as the no-cap value", () => {
+		const state = autoReloadFormState({ ...validForm, cap: "0" });
+
+		expect(state.capCents).toBe(0);
+		expect(state.capValid).toBe(true);
+		expect(state.formValid).toBe(true);
+	});
+
+	test("preserves the $1 threshold floor at 1000 points per USD", () => {
+		expect(autoReloadFormState({ ...validForm, threshold: "0.99" }).thresholdValid).toBe(false);
+		expect(autoReloadFormState({ ...validForm, threshold: "1" }).thresholdValid).toBe(true);
+	});
+});

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.ts
@@ -1,0 +1,54 @@
+import {
+	AUTORELOAD_AMOUNT_MAX_CENTS,
+	AUTORELOAD_AMOUNT_MIN_CENTS,
+	AUTORELOAD_THRESHOLD_MIN_CREDITS,
+} from "@/hosted/billing/wallet/wallet-constants";
+
+export interface AutoReloadFormInput {
+	amount: string;
+	threshold: string;
+	cap: string;
+	pointsPerUsd: number;
+}
+
+export interface AutoReloadFormState {
+	amountCents: number;
+	thresholdCredits: number;
+	capCents: number;
+	amountValid: boolean;
+	thresholdValid: boolean;
+	capValid: boolean;
+	formValid: boolean;
+}
+
+function centsFromDollars(value: string): number {
+	return Math.round(Number(value) * 100);
+}
+
+export function autoReloadFormState({
+	amount,
+	threshold,
+	cap,
+	pointsPerUsd,
+}: AutoReloadFormInput): AutoReloadFormState {
+	const amountCents = centsFromDollars(amount);
+	const thresholdCredits = Math.round(Number(threshold) * pointsPerUsd);
+	const capCents = cap.trim() === "" ? Number.NaN : centsFromDollars(cap);
+
+	const amountValid =
+		amountCents >= AUTORELOAD_AMOUNT_MIN_CENTS && amountCents <= AUTORELOAD_AMOUNT_MAX_CENTS;
+	const thresholdValid = thresholdCredits >= AUTORELOAD_THRESHOLD_MIN_CREDITS;
+	// 0 = no cap; any positive value is a cap. Blank / negative / non-numeric is invalid.
+	const capValid = Number.isFinite(capCents) && capCents >= 0;
+	const formValid = amountValid && thresholdValid && capValid;
+
+	return {
+		amountCents,
+		thresholdCredits,
+		capCents,
+		amountValid,
+		thresholdValid,
+		capValid,
+		formValid,
+	};
+}

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
@@ -13,10 +13,10 @@ import type { WalletState } from "@/hosted/billing/contracts";
 import { normalizeBillingError } from "@/hosted/billing/errors";
 import { useSetAutoReload } from "@/hosted/billing/hooks";
 import { AutoReloadActionConfirm } from "@/hosted/billing/wallet/auto-reload-action";
+import { autoReloadFormState } from "@/hosted/billing/wallet/auto-reload-card.logic";
 import {
 	AUTORELOAD_AMOUNT_MAX_CENTS,
 	AUTORELOAD_AMOUNT_MIN_CENTS,
-	AUTORELOAD_THRESHOLD_MIN_CREDITS,
 } from "@/hosted/billing/wallet/wallet-constants";
 
 function dollars(n: number): string {
@@ -51,16 +51,20 @@ export function AutoReloadCard({ wallet, onTopUp }: { wallet: WalletState; onTop
 		pointsPerUsd,
 	]);
 
-	const amountCents = Math.round(Number(amount) * 100);
-	const thresholdCredits = Math.round(Number(threshold) * pointsPerUsd);
-	const capCents = Math.round(Number(cap) * 100);
-
-	const amountValid =
-		amountCents >= AUTORELOAD_AMOUNT_MIN_CENTS && amountCents <= AUTORELOAD_AMOUNT_MAX_CENTS;
-	const thresholdValid = thresholdCredits >= AUTORELOAD_THRESHOLD_MIN_CREDITS;
-	// 0 = no cap; any positive value is a cap. Negative / non-numeric is invalid.
-	const capValid = Number.isFinite(capCents) && capCents >= 0;
-	const formValid = amountValid && thresholdValid && capValid;
+	const {
+		amountCents,
+		thresholdCredits,
+		capCents,
+		amountValid,
+		thresholdValid,
+		capValid,
+		formValid,
+	} = autoReloadFormState({
+		amount,
+		threshold,
+		cap,
+		pointsPerUsd,
+	});
 
 	async function persist(nextEnabled: boolean) {
 		// Belt-and-braces against a double-fire while the switch/button repaint.
@@ -169,13 +173,15 @@ export function AutoReloadCard({ wallet, onTopUp }: { wallet: WalletState; onTop
 							value={cap}
 							onChange={(e) => setCap(e.target.value)}
 							aria-invalid={!capValid}
-							aria-describedby={capValid ? undefined : "ar-cap-err"}
+							aria-describedby={capValid ? "ar-cap-help" : "ar-cap-err"}
 						/>
 						{capValid ? (
-							<p className="text-xs text-muted-foreground">0 = no cap.</p>
+							<p id="ar-cap-help" className="text-xs text-muted-foreground">
+								Enter 0 only if you want no monthly cap.
+							</p>
 						) : (
 							<p id="ar-cap-err" className="text-xs text-destructive">
-								Enter 0 (no cap) or a positive amount.
+								Enter a monthly cap, or enter 0 for no cap.
 							</p>
 						)}
 					</div>

--- a/apps/web/src/hosted/billing/wallet/ledger-table.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.logic.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import type { WalletLedgerEntry } from "@/hosted/billing/contracts";
+import { filteredLedgerEntries, ledgerEmptyStateCopy } from "./ledger-table.logic";
+
+function entry(overrides: Partial<WalletLedgerEntry> = {}): WalletLedgerEntry {
+	return {
+		id: "entry_1",
+		operation: "topup",
+		request_id: "request_1",
+		credits_amount: 1000,
+		status: "applied",
+		notes: null,
+		created_at: "2026-07-01T00:00:00Z",
+		applied_at: "2026-07-01T00:00:00Z",
+		...overrides,
+	};
+}
+
+describe("filteredLedgerEntries", () => {
+	test("can return an empty filtered page while older pages may still match", () => {
+		const filtered = filteredLedgerEntries([entry({ operation: "topup" })], "refund");
+
+		expect(filtered).toEqual([]);
+	});
+});
+
+describe("ledgerEmptyStateCopy", () => {
+	test("prompts the user to load more when the current filtered page is empty", () => {
+		expect(ledgerEmptyStateCopy({ entriesCount: 1, filter: "refund", canLoadMore: true })).toEqual({
+			title: "No matching activity on this page",
+			description: "Load more to search older activity.",
+		});
+	});
+
+	test("uses the terminal no-match copy only when there is nothing more to load", () => {
+		expect(ledgerEmptyStateCopy({ entriesCount: 1, filter: "refund", canLoadMore: false })).toEqual(
+			{
+				title: "No matching activity",
+				description: "Change the filter to see other wallet entries.",
+			},
+		);
+	});
+
+	test("keeps the empty-wallet copy for wallets with no loaded entries", () => {
+		expect(ledgerEmptyStateCopy({ entriesCount: 0, filter: "all", canLoadMore: false })).toEqual({
+			title: "No activity yet",
+			description: "Top-ups, grants, and usage will show up here.",
+		});
+	});
+});

--- a/apps/web/src/hosted/billing/wallet/ledger-table.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.logic.ts
@@ -1,0 +1,68 @@
+import type { WalletLedgerEntry } from "@/hosted/billing/contracts";
+
+export type LedgerFilter = "all" | "topup" | "grant" | "usage" | "refund";
+
+const LEDGER_FILTERS: readonly LedgerFilter[] = ["all", "topup", "grant", "usage", "refund"];
+
+export interface LedgerEmptyStateCopyInput {
+	entriesCount: number;
+	filter: LedgerFilter;
+	canLoadMore: boolean;
+}
+
+export interface LedgerEmptyStateCopy {
+	title: string;
+	description: string;
+}
+
+export function isLedgerFilter(value: string): value is LedgerFilter {
+	return LEDGER_FILTERS.some((filter) => filter === value);
+}
+
+export function ledgerOperationGroup(op: string): LedgerFilter {
+	if (op === "topup" || op === "invoice" || op === "x402") return "topup";
+	if (op.startsWith("grant_")) return "grant";
+	if (op === "proxy") return "usage";
+	if (op === "refund") return "refund";
+	return "all";
+}
+
+export function filteredLedgerEntries(
+	entries: WalletLedgerEntry[],
+	filter: LedgerFilter,
+): WalletLedgerEntry[] {
+	return (
+		filter === "all"
+			? entries
+			: entries.filter((entry) => ledgerOperationGroup(entry.operation) === filter)
+	).filter(
+		// Defensive: skip malformed rows (missing id) rather than emit a
+		// React key warning or render an "undefined" row.
+		(entry): entry is WalletLedgerEntry => entry != null && typeof entry.id === "string",
+	);
+}
+
+export function ledgerEmptyStateCopy({
+	entriesCount,
+	filter,
+	canLoadMore,
+}: LedgerEmptyStateCopyInput): LedgerEmptyStateCopy {
+	if (canLoadMore) {
+		return {
+			title: filter === "all" ? "No activity on this page" : "No matching activity on this page",
+			description: "Load more to search older activity.",
+		};
+	}
+
+	if (entriesCount === 0) {
+		return {
+			title: "No activity yet",
+			description: "Top-ups, grants, and usage will show up here.",
+		};
+	}
+
+	return {
+		title: "No matching activity",
+		description: "Change the filter to see other wallet entries.",
+	};
+}

--- a/apps/web/src/hosted/billing/wallet/ledger-table.tsx
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.tsx
@@ -24,6 +24,12 @@ import {
 } from "@/components/ui/table";
 import type { WalletLedgerEntry, WalletLedgerStatus } from "@/hosted/billing/contracts";
 import { creditsToUsd, formatCredits } from "@/hosted/billing/format";
+import {
+	filteredLedgerEntries,
+	isLedgerFilter,
+	type LedgerFilter,
+	ledgerEmptyStateCopy,
+} from "@/hosted/billing/wallet/ledger-table.logic";
 import { cn, relativeTime } from "@/lib/utils";
 
 const OPERATION_LABELS: Record<string, string> = {
@@ -44,16 +50,6 @@ const STATUS_LABELS: Record<WalletLedgerStatus, string> = {
 	pending: "Pending",
 	failed: "Failed",
 };
-
-type Filter = "all" | "topup" | "grant" | "usage" | "refund";
-
-function groupOf(op: string): Filter {
-	if (op === "topup" || op === "invoice" || op === "x402") return "topup";
-	if (op.startsWith("grant_")) return "grant";
-	if (op === "proxy") return "usage";
-	if (op === "refund") return "refund";
-	return "all";
-}
 
 function statusVariant(
 	status: WalletLedgerStatus,
@@ -102,18 +98,36 @@ export function LedgerTable({
 	isFetchingMore?: boolean;
 	onShowMore?: () => void;
 }) {
-	const [filter, setFilter] = useState<Filter>("all");
+	const [filter, setFilter] = useState<LedgerFilter>("all");
 	const headingId = useId();
 
-	const filtered = useMemo(
-		() =>
-			(filter === "all" ? entries : entries.filter((e) => groupOf(e.operation) === filter)).filter(
-				// Defensive: skip malformed rows (missing id) rather than emit a
-				// React key warning or render an "undefined" row.
-				(e): e is WalletLedgerEntry => e != null && typeof e.id === "string",
-			),
-		[entries, filter],
-	);
+	const filtered = useMemo(() => filteredLedgerEntries(entries, filter), [entries, filter]);
+	const canLoadMore = !atCap && hasMore && onShowMore != null;
+	const emptyState = ledgerEmptyStateCopy({ entriesCount: entries.length, filter, canLoadMore });
+
+	function handleFilterChange(value: string) {
+		if (isLedgerFilter(value)) {
+			setFilter(value);
+		}
+	}
+
+	function renderLoadMoreControl() {
+		if (!canLoadMore || !onShowMore) return null;
+
+		return (
+			<div className="flex justify-center">
+				<Button size="sm" variant="outline" onClick={onShowMore} disabled={isFetchingMore}>
+					{isFetchingMore ? (
+						<>
+							<Spinner /> Loading…
+						</>
+					) : (
+						"Show more"
+					)}
+				</Button>
+			</div>
+		);
+	}
 
 	return (
 		<section data-hosted="true" className="space-y-3" aria-labelledby={headingId}>
@@ -121,7 +135,7 @@ export function LedgerTable({
 				<h2 id={headingId} className="text-base font-semibold">
 					Activity
 				</h2>
-				<Select value={filter} onValueChange={(v) => setFilter(v as Filter)}>
+				<Select value={filter} onValueChange={handleFilterChange}>
 					<SelectTrigger size="sm" className="w-40" aria-label="Filter activity">
 						<SelectValue />
 					</SelectTrigger>
@@ -145,16 +159,15 @@ export function LedgerTable({
 					))}
 				</div>
 			) : filtered.length === 0 ? (
-				<EmptyState
-					variant="inset"
-					icon={Receipt}
-					title={entries.length === 0 ? "No activity yet" : "No matching activity"}
-					description={
-						entries.length === 0
-							? "Top-ups, grants, and usage will show up here."
-							: "Change the filter to see other wallet entries."
-					}
-				/>
+				<>
+					<EmptyState
+						variant="inset"
+						icon={Receipt}
+						title={emptyState.title}
+						description={emptyState.description}
+					/>
+					{renderLoadMoreControl()}
+				</>
 			) : (
 				<>
 					{/* Mobile: a stacked list — a 4-column table would clip on narrow
@@ -241,19 +254,9 @@ export function LedgerTable({
 						<p className="text-center text-xs text-muted-foreground">
 							Showing your most recent activity. Older entries are archived.
 						</p>
-					) : hasMore && onShowMore ? (
-						<div className="flex justify-center">
-							<Button size="sm" variant="outline" onClick={onShowMore} disabled={isFetchingMore}>
-								{isFetchingMore ? (
-									<>
-										<Spinner /> Loading…
-									</>
-								) : (
-									"Show more"
-								)}
-							</Button>
-						</div>
-					) : null}
+					) : (
+						renderLoadMoreControl()
+					)}
 				</>
 			)}
 		</section>


### PR DESCRIPTION
## Bugs fixed

- Auto-reload monthly cap: a blank cap field previously became `0` through `Number("")`, which saved as no cap. Blank cap input is now invalid/incomplete, blocks save, and shows clear copy while explicit `0` remains the labeled no-cap value.
- Filtered wallet ledger paging: an empty filtered current page previously returned before rendering the load-more control. Empty filtered pages now show page-scoped copy and keep the Show more control available when older pages can still be loaded.

## Verification

- `bun run check:fix`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`