### PR TITLE
Cover runtime reconciliation invariants

### DIFF
--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -1,0 +1,393 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+	convergeRuntimeManifest,
+	type RuntimeManifest,
+	runtimeProgramRevision,
+	runtimeSecretValue,
+	runtimeSidecarProgramRevision,
+} from "./manifest";
+import {
+	hostedRuntimeManifestSchema,
+	OFFICIAL_INSTALL_ARGS,
+	OFFICIAL_INSTALL_URLS,
+} from "./manifest-contract";
+import {
+	hostedManifestToRuntimeManifest,
+	normalizeManifestPayload,
+	type RuntimeManifestLoad,
+} from "./manifest-source";
+import { getRuntimePaths, type RuntimePaths } from "./paths";
+import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
+
+const originalEnv = { ...process.env };
+const tempRoots: string[] = [];
+
+function tempRuntimePaths(): RuntimePaths {
+	const root = mkdtempSync(join(tmpdir(), "clawdi-runtime-reconcile-test-"));
+	tempRoots.push(root);
+	process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+	process.env.CLAWDI_RUN_DIR = join(root, "run");
+	process.env.CLAWDI_SYSTEMD_SYSTEM_ROOT = join(root, "run", "systemd", "system");
+	process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
+	process.env.CLAWDI_HOME = join(root, "clawdi-home");
+	process.env.CLAWDI_AUTH_TOKEN = "test-token";
+	return getRuntimePaths({ mode: "hosted" });
+}
+
+function runSettings(command: string, args: string[]): RuntimeRunSettings {
+	return { command, args, env: {}, prependPath: [] };
+}
+
+function manifestLoad(
+	manifest: RuntimeManifest,
+	sourcePath: string,
+	secretValues?: Record<string, string>,
+): RuntimeManifestLoad {
+	return {
+		manifest,
+		source: "fixture-file",
+		sourcePath,
+		offline: false,
+		secretValues,
+	};
+}
+
+function baseManifest(
+	paths: RuntimePaths,
+	runtimes: RuntimeManifest["runtimes"],
+	overrides: Partial<RuntimeManifest> = {},
+): RuntimeManifest {
+	return {
+		schemaVersion: "clawdi.runtimeDesiredState.v1",
+		deploymentId: "hdep_reconcile",
+		environmentId: "env_reconcile",
+		instanceId: "hri_reconcile",
+		generation: 1,
+		issuedAt: "2026-07-01T00:00:00.000Z",
+		workspaceRoot: join(paths.userHome, "clawdi"),
+		controlPlane: { apiUrl: "https://cloud-api.example.test" },
+		runtimes,
+		recovery: {},
+		...overrides,
+	};
+}
+
+function writeFakeGatewayCli(input: {
+	path: string;
+	runtime: "openclaw" | "hermes";
+	unitPath: string;
+	failInstall?: boolean;
+}): void {
+	mkdirSync(dirname(input.path), { recursive: true });
+	writeFileSync(
+		input.path,
+		`#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  "gateway install --force --json"|"gateway install")
+    ${
+			input.failInstall
+				? "exit 41"
+				: `mkdir -p '${dirname(input.unitPath)}'
+    cat > '${input.unitPath}' <<'EOF'
+[Unit]
+Description=Official gateway
+
+[Service]
+ExecStart=official gateway run
+EOF`
+		}
+    ;;
+  *)
+    printf 'unexpected ${input.runtime} command: %s\\n' "$*" >&2
+    exit 64
+    ;;
+esac
+`,
+	);
+	chmodSync(input.path, 0o700);
+}
+
+afterEach(() => {
+	process.env = { ...originalEnv };
+	for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("runtime manifest reconciliation invariants", () => {
+	test("normalizes hosted manifest responses into runtime desired state without embedding secrets", () => {
+		const hostedResponse = {
+			manifest: {
+				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				deploymentId: "hdep_normalize",
+				environmentId: "env_normalize",
+				instanceId: "hri_normalize",
+				generation: 7,
+				issuedAt: "2026-07-01T00:00:00.000Z",
+				system: {
+					home: "/home/clawdi-test",
+					workspace: "/workspace/clawdi",
+				},
+				controlPlane: {
+					cloudApiUrl: "https://cloud-api.example.test",
+					manifestUrl: "https://cloud-api.example.test/v1/runtime/manifest",
+				},
+				runtimes: {
+					openclaw: {
+						enabled: true,
+						install: { source: "official", channel: "stable" },
+						run: {
+							command: "openclaw",
+							args: ["gateway", "run"],
+							env: { OPENCLAW_TEST: "1" },
+							prependPath: [],
+						},
+						paths: { home: "/home/clawdi-test", workspace: "/workspace/openclaw" },
+					},
+					hermes: {
+						enabled: true,
+						install: { source: "official", channel: "stable" },
+						run: {
+							command: "hermes",
+							args: ["gateway", "run"],
+							env: {},
+							prependPath: ["/opt/hermes/bin"],
+						},
+						services: {
+							dashboard: {
+								command: "hermes",
+								args: ["dashboard", "--host", "127.0.0.1", "--no-open"],
+								env: {},
+								prependPath: [],
+							},
+						},
+					},
+				},
+				providers: {
+					default: {
+						kind: "openai-compatible",
+						type: "custom_openai_compatible",
+						baseUrl: "https://api.example.test/v1",
+						model: "gpt-test",
+						apiMode: "openai_chat",
+						apiKeySecretRef: "secret://providers/default/api-key",
+					},
+				},
+				liveSync: {
+					enabled: true,
+					agents: [{ agentType: "openclaw", environmentId: "env_normalize" }],
+				},
+				mitmProfiles: {
+					profiles: [
+						{
+							id: "api-proxy",
+							enabled: true,
+							kind: "http",
+							match: {
+								scheme: "https",
+								host: "api.example.test",
+								pathPrefix: "/v1",
+								headers: {},
+								query: {},
+							},
+							rewrite: {
+								upstreamBaseUrl: "https://upstream.example.test/v1",
+								preservePath: true,
+								setHeaders: {
+									authorization: {
+										type: "secretRef",
+										secretRef: "secret://providers/default/api-key",
+										prefix: "Bearer ",
+									},
+								},
+							},
+							logging: { redactHeaders: ["authorization"], redactUrlPatterns: [] },
+							priority: 120,
+						},
+					],
+				},
+				recovery: { cacheManifest: true, allowOfflineBoot: true },
+			},
+			secretValues: {
+				"providers/default/api-key": "sk-normalized",
+			},
+		};
+
+		const normalized = normalizeManifestPayload(hostedResponse);
+		const hostedManifest = hostedRuntimeManifestSchema.parse(hostedResponse.manifest);
+		expect(normalized.manifest).toEqual(hostedManifestToRuntimeManifest(hostedManifest));
+		expect(normalized.manifest.schemaVersion).toBe("clawdi.runtimeDesiredState.v1");
+		expect(normalized.manifest.runtimes.openclaw.enabled).toBe(true);
+		expect(normalized.manifest.runtimes.openclaw.updateChannel).toBe("stable");
+		expect(normalized.manifest.runtimes.openclaw.install?.url).toBe(OFFICIAL_INSTALL_URLS.openclaw);
+		expect(normalized.manifest.runtimes.openclaw.install?.args).toEqual(
+			OFFICIAL_INSTALL_ARGS.openclaw,
+		);
+		expect(normalized.manifest.runtimes.hermes.enabled).toBe(true);
+		expect(normalized.manifest.runtimes.hermes.install?.url).toBe(OFFICIAL_INSTALL_URLS.hermes);
+		expect(normalized.manifest.runtimes.hermes.install?.args).toEqual(OFFICIAL_INSTALL_ARGS.hermes);
+		expect(normalized.manifest.projection?.providers).toEqual(hostedResponse.manifest.providers);
+		expect(normalized.manifest.mitmProfiles?.profiles.map((profile) => profile.id)).toEqual([
+			"api-proxy",
+		]);
+		expect(normalized.manifest.liveSync).toEqual(hostedResponse.manifest.liveSync);
+		expect("secretValues" in normalized.manifest).toBe(false);
+		expect(normalized.secretValues).toEqual({
+			"providers/default/api-key": "sk-normalized",
+			"secret://providers/default/api-key": "sk-normalized",
+		});
+	});
+
+	test("includes secret values in runtime and sidecar program revisions", () => {
+		const paths = tempRuntimePaths();
+		const manifest = baseManifest(paths, {
+			openclaw: {
+				enabled: true,
+				run: runSettings("openclaw", ["gateway", "run"]),
+				services: {},
+			},
+		});
+		const secretValues = {
+			"secret://providers/default/api-key": "sk-before",
+		};
+		const rotatedSecretValues = {
+			"secret://providers/default/api-key": "sk-after",
+		};
+		const metadataOnlyChange: RuntimeManifest = {
+			...manifest,
+			generation: 2,
+			issuedAt: "2026-07-01T00:01:00.000Z",
+		};
+
+		const runtimeRevision = runtimeProgramRevision(manifest, "openclaw", secretValues);
+		expect(runtimeProgramRevision(manifest, "openclaw", rotatedSecretValues)).not.toBe(
+			runtimeRevision,
+		);
+		expect(runtimeProgramRevision(metadataOnlyChange, "openclaw", secretValues)).toBe(
+			runtimeRevision,
+		);
+
+		const sidecarRevision = runtimeSidecarProgramRevision(manifest, secretValues);
+		expect(runtimeSidecarProgramRevision(manifest, rotatedSecretValues)).not.toBe(sidecarRevision);
+		expect(runtimeSidecarProgramRevision(metadataOnlyChange, secretValues)).toBe(sidecarRevision);
+	});
+
+	test("advances last-good manifest only after a clean converge", () => {
+		const paths = tempRuntimePaths();
+		const openclawCommand = join(paths.userHome, ".openclaw", "bin", "openclaw");
+		const unitPath = join(paths.systemdUserRoot, "openclaw-gateway.service");
+		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "1";
+		const manifest = baseManifest(paths, {
+			openclaw: {
+				enabled: true,
+				run: runSettings(openclawCommand, ["gateway", "run"]),
+				services: {},
+			},
+		});
+
+		writeFakeGatewayCli({ path: openclawCommand, runtime: "openclaw", unitPath });
+		const clean = convergeRuntimeManifest(manifestLoad(manifest, "inline-clean"), paths);
+		expect(clean.installErrors).toEqual([]);
+		expect(clean.outputs.manifestLastGood).toBe(paths.manifestLastGood);
+		expect(JSON.parse(readFileSync(paths.manifestLastGood, "utf8"))).toMatchObject({
+			generation: 1,
+		});
+
+		writeFakeGatewayCli({
+			path: openclawCommand,
+			runtime: "openclaw",
+			unitPath,
+			failInstall: true,
+		});
+		const failedManifest: RuntimeManifest = {
+			...manifest,
+			generation: 2,
+			issuedAt: "2026-07-01T00:02:00.000Z",
+		};
+		const failed = convergeRuntimeManifest(
+			manifestLoad(failedManifest, "inline-install-error"),
+			paths,
+		);
+
+		expect(failed.installErrors.join("\n")).toContain(
+			"official openclaw-gateway service install failed",
+		);
+		expect(failed.outputs.manifestLastGood).toBeNull();
+		expect(JSON.parse(readFileSync(paths.manifestLastGood, "utf8"))).toMatchObject({
+			generation: 1,
+		});
+	});
+
+	test("garbage collects stale run configs when a runtime is removed", () => {
+		const paths = tempRuntimePaths();
+		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "0";
+		const initialManifest = baseManifest(paths, {
+			hermes: {
+				enabled: true,
+				run: runSettings("hermes", ["gateway", "run"]),
+				services: {},
+			},
+			openclaw: {
+				enabled: true,
+				run: runSettings("openclaw", ["gateway", "run"]),
+				services: {},
+			},
+		});
+		const openclawRunConfig = runtimeRunConfigPath("openclaw", paths);
+		const hermesRunConfig = runtimeRunConfigPath("hermes", paths);
+
+		const initial = convergeRuntimeManifest(manifestLoad(initialManifest, "inline-initial"), paths);
+		expect(initial.installErrors).toEqual([]);
+		expect(existsSync(openclawRunConfig)).toBe(true);
+		expect(existsSync(hermesRunConfig)).toBe(true);
+
+		const nextManifest = baseManifest(
+			paths,
+			{
+				hermes: {
+					enabled: true,
+					run: runSettings("hermes", ["gateway", "run"]),
+					services: {},
+				},
+			},
+			{ generation: 2, issuedAt: "2026-07-01T00:03:00.000Z" },
+		);
+		const next = convergeRuntimeManifest(manifestLoad(nextManifest, "inline-removed"), paths);
+
+		expect(next.installErrors).toEqual([]);
+		expect(existsSync(openclawRunConfig)).toBe(false);
+		expect(existsSync(hermesRunConfig)).toBe(true);
+	});
+
+	test("resolves runtime secret refs by exact, normalized, and stripped forms", () => {
+		expect(
+			runtimeSecretValue(
+				{ "secret://providers/default/api-key": "sk-exact" },
+				"secret://providers/default/api-key",
+			),
+		).toBe("sk-exact");
+		expect(
+			runtimeSecretValue(
+				{ "secret://providers/default/api-key": "sk-normalized" },
+				"providers/default/api-key",
+			),
+		).toBe("sk-normalized");
+		expect(
+			runtimeSecretValue(
+				{ "providers/default/api-key": "sk-stripped" },
+				"secret://providers/default/api-key",
+			),
+		).toBe("sk-stripped");
+		expect(runtimeSecretValue({}, "secret://providers/default/api-key")).toBeNull();
+	});
+});

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -161,7 +161,7 @@ function parseManifestSafe(value: unknown): RuntimeManifest | null {
 	return result.success ? result.data : null;
 }
 
-function normalizeManifestPayload(value: unknown): {
+export function normalizeManifestPayload(value: unknown): {
 	manifest: RuntimeManifest;
 	secretValues?: Record<string, string>;
 } {
@@ -472,7 +472,7 @@ function runtimeFetchFailureStage(error: unknown): "network" | "auth" {
 	return error instanceof RuntimeAuthError ? "auth" : "network";
 }
 
-function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): RuntimeManifest {
+export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): RuntimeManifest {
 	const home = hosted.system?.home || "/home/clawdi";
 	const workspaceRoot = hosted.system?.workspace || join(home, "clawdi");
 	return {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1357,7 +1357,7 @@ export function withRuntimeConvergeLock<T>(
 	}
 }
 
-function runtimeProgramRevision(
+export function runtimeProgramRevision(
 	manifest: RuntimeManifest,
 	runtime: string,
 	secretValues: Record<string, string> | undefined,
@@ -1472,7 +1472,7 @@ function buildRuntimeSystemdUserProgram(input: {
 	};
 }
 
-function runtimeSecretValue(secrets: Record<string, string>, ref: string): string | null {
+export function runtimeSecretValue(secrets: Record<string, string>, ref: string): string | null {
 	const normalized = normalizeSecretRef(ref);
 	const raw = ref.startsWith("secret://") ? ref.slice("secret://".length) : null;
 	const candidates = [ref, normalized, raw].filter(
@@ -1490,7 +1490,7 @@ function hashToUInt16(input: string): number {
 	return createHash("sha256").update(input).digest().readUInt16BE(0);
 }
 
-function runtimeSidecarProgramRevision(
+export function runtimeSidecarProgramRevision(
 	manifest: RuntimeManifest,
 	secretValues: Record<string, string> | undefined,
 ): string {


### PR DESCRIPTION
## Summary
- Adds runtime reconciliation coverage for hosted manifest normalization into `clawdi.runtimeDesiredState.v1`, including provider projection, official openclaw/hermes installers, MITM profiles, liveSync, and keeping `secretValues` outside the manifest.
- Locks secret rotation restart behavior by asserting runtime and sidecar revisions change when secret values change, while metadata-only manifest changes do not.
- Covers clean-converge last-good advancement, failed official service install protection, stale run config GC for removed runtimes, and runtime secret ref resolution across exact, normalized, and `secret://`-stripped forms.

## Integration coverage notes
- Last-good advancement and stale run config GC are covered through `convergeRuntimeManifest` with the existing temp HOME/run/systemd sandbox and fake gateway CLI.
- Normalization, revision hashing, and secret ref resolution are covered through their core helpers to avoid coupling the assertions to incidental rendered systemd file formatting.
- No requested invariant was left untested.

## Verification
- `bun run check:fix`
- `bun run --cwd packages/cli typecheck`
- `bun run --cwd packages/cli test`