### PR TITLE
Don't auto-poll agent-home for legacy agents

### DIFF
--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -46,9 +46,12 @@ export function AgentHome({
 		error,
 		refetch,
 	} = useAgentDeployment(environmentId);
-	const requestedHostedAgent =
-		searchParams.get("source") === "on-clawdi" || !isCloudEnvId(environmentId);
+	const isCloudEnvironmentId = isCloudEnvId(environmentId);
+	const requestedFromCloudRedirect = searchParams.get("source") === "on-clawdi";
+	const requestedHostedAgent = requestedFromCloudRedirect || !isCloudEnvironmentId;
 	const unresolvedHostedAgent = requestedHostedAgent && !deployment && !error && !isLoading;
+	const shouldAutoRefetchUnresolvedHostedAgent =
+		unresolvedHostedAgent && (requestedFromCloudRedirect || isCloudEnvironmentId);
 	const isFetchingRef = useRef(isFetching);
 
 	useEffect(() => {
@@ -56,7 +59,7 @@ export function AgentHome({
 	}, [isFetching]);
 
 	useEffect(() => {
-		if (!unresolvedHostedAgent || typeof window === "undefined") return;
+		if (!shouldAutoRefetchUnresolvedHostedAgent || typeof window === "undefined") return;
 
 		let attempts = 0;
 		const intervalId = window.setInterval(() => {
@@ -73,7 +76,7 @@ export function AgentHome({
 		return () => {
 			window.clearInterval(intervalId);
 		};
-	}, [refetch, unresolvedHostedAgent]);
+	}, [refetch, shouldAutoRefetchUnresolvedHostedAgent]);
 
 	const handleCheckAgain = () => {
 		if (isFetchingRef.current) return;


### PR DESCRIPTION
## Summary
- Prevent the bounded agent-home auto-refetch interval from starting for plain legacy agent environment ids that have no v2 deployment.
- Keep auto-refetch enabled for fresh Cloud redirects (`source=on-clawdi`) and actual Cloud environment ids.
- Leave the manual "Check again" refresh available in all unresolved cases.

## Edge case
Users with both legacy and Cloud access can open a legacy agent whose environment id is not a Cloud env id and has no v2 deployment. That previously satisfied the hosted unresolved state and started the bounded 2-minute background poll even though the deployment could never resolve.

## Verification
- `bun run check:fix`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`