### PR TITLE
Add Skills tab to hosted agent detail

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -196,6 +196,11 @@ const HOSTED_AGENT_SECTIONS: {
 		tooltip: "Sessions from this runtime",
 	},
 	{
+		id: "skills",
+		icon: Sparkles,
+		tooltip: "Skills installed in this agent's Agent Project",
+	},
+	{
 		id: "ai",
 		icon: Zap,
 		tooltip: "Runtime model provider binding",

--- a/apps/web/src/components/dashboard/agent-skills-tab.tsx
+++ b/apps/web/src/components/dashboard/agent-skills-tab.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { ApiErrorPanel } from "@/components/api-error-panel";
+import { isProjectOwner } from "@/components/projects/project-metadata";
+import { SkillCardGrid } from "@/components/skills/skill-card";
+import { unwrap, useApi } from "@/lib/api";
+import { fetchAllPages } from "@/lib/api-pagination";
+import type { components } from "@/lib/api-schemas";
+import { errorMessage } from "@/lib/utils";
+
+type SkillSummary = components["schemas"]["SkillSummaryResponse"];
+type ProjectRow = components["schemas"]["ProjectResponse"];
+
+export function useAgentProjectSkills(agentProjectId: string | null | undefined) {
+	const api = useApi();
+
+	// Fetch only this agent's Agent Project. The `project_id` query pushes the
+	// filter into the database, then we walk every page so a large agent library
+	// does not silently lose rows beyond the first page.
+	const query = useQuery({
+		queryKey: ["skills", agentProjectId, "all-pages"],
+		queryFn: async () => {
+			if (!agentProjectId) return { items: [], total: 0, page: 1, page_size: 200 };
+			return fetchAllPages<SkillSummary>(
+				async (page, pageSize) =>
+					unwrap(
+						await api.GET("/v1/skills", {
+							params: {
+								query: {
+									page,
+									page_size: pageSize,
+									project_id: agentProjectId,
+								},
+							},
+						}),
+					),
+				{ pageSize: 200, resourceName: "agent skills" },
+			);
+		},
+		enabled: !!agentProjectId,
+	});
+
+	const skills = query.data?.items;
+	return { ...query, skills };
+}
+
+export function AgentSkillsTab({
+	agentId,
+	agentProjectId,
+	isResolvingAgentProject = false,
+	writableProjectIds,
+}: {
+	agentId: string;
+	agentProjectId: string | null | undefined;
+	isResolvingAgentProject?: boolean;
+	writableProjectIds?: ReadonlySet<string> | null;
+}) {
+	const api = useApi();
+	const { data: projects } = useQuery({
+		queryKey: ["projects"],
+		queryFn: async (): Promise<ProjectRow[]> => unwrap(await api.GET("/v1/projects")),
+		enabled: writableProjectIds === undefined && !!agentProjectId,
+	});
+	const derivedWritableProjectIds =
+		writableProjectIds === undefined
+			? new Set(
+					(projects ?? [])
+						.filter((project) => isProjectOwner(project))
+						.map((project) => project.id),
+				)
+			: writableProjectIds;
+	const {
+		skills,
+		isLoading: skillsLoading,
+		error: skillsError,
+		refetch: refetchSkills,
+	} = useAgentProjectSkills(agentProjectId);
+	const uninstallSkill = useUninstallAgentSkill();
+
+	if (skillsError) {
+		return (
+			<ApiErrorPanel
+				error={skillsError}
+				onRetry={() => {
+					void refetchSkills();
+				}}
+				title="Couldn't load agent skills"
+			/>
+		);
+	}
+
+	return (
+		<SkillCardGrid
+			skills={skills ?? []}
+			isLoading={isResolvingAgentProject || skillsLoading}
+			emptyMessage="No skills installed on this agent yet."
+			readOnlySkillCheck={(s) =>
+				!s.project_id || !(derivedWritableProjectIds?.has(s.project_id) ?? false)
+			}
+			onUninstall={(skillKey, projectId) => uninstallSkill.mutate({ skillKey, projectId })}
+			uninstallPending={uninstallSkill.isPending}
+			skillLink={(skill) => ({
+				to: "/agents/$id/skills/$" as const,
+				params: { id: agentId, _splat: skill.skill_key },
+				search: skill.project_id ? { project: skill.project_id } : undefined,
+			})}
+		/>
+	);
+}
+
+function useUninstallAgentSkill() {
+	const api = useApi();
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: async ({ skillKey, projectId }: { skillKey: string; projectId: string }) =>
+			unwrap(
+				await api.DELETE("/v1/projects/{project_id}/skills/{skill_key}", {
+					params: { path: { project_id: projectId, skill_key: skillKey } },
+				}),
+			),
+		onSuccess: (_data, vars) => {
+			toast.success("Skill uninstalled", {
+				description: `${vars.skillKey} was removed from this agent. Other agents keep their copies.`,
+			});
+			queryClient.invalidateQueries({ queryKey: ["skills"] });
+		},
+		onError: (e) => toast.error("Couldn't uninstall skill", { description: errorMessage(e) }),
+	});
+}

--- a/apps/web/src/components/dashboard/connected-agent-detail.tsx
+++ b/apps/web/src/components/dashboard/connected-agent-detail.tsx
@@ -22,6 +22,7 @@ import {
 	agentDisplayName,
 } from "@/components/dashboard/agent-label";
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
+import { AgentSkillsTab, useAgentProjectSkills } from "@/components/dashboard/agent-skills-tab";
 import { DetailNotFound, DetailPanel, type DetailSectionMeta } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
 import { ENTITY_CARD_BASE } from "@/components/entity-card";
@@ -34,7 +35,6 @@ import {
 	ProjectScopePicker,
 } from "@/components/projects/project-metadata";
 import { SessionFeed } from "@/components/sessions/session-feed";
-import { SkillCardGrid } from "@/components/skills/skill-card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
@@ -49,12 +49,10 @@ import {
 } from "@/lib/agent-routes";
 import { unwrap, useApi } from "@/lib/api";
 import { isApiNotFoundError } from "@/lib/api-errors";
-import { fetchAllPages } from "@/lib/api-pagination";
 import type { components } from "@/lib/api-schemas";
 import { sessionListQueryOptions } from "@/lib/session-queries";
 import { cn, errorMessage } from "@/lib/utils";
 
-type SkillSummary = components["schemas"]["SkillSummaryResponse"];
 type AgentTab = "overview" | "sessions" | "skills" | "projects" | "settings";
 
 type ProjectRow = components["schemas"]["ProjectResponse"];
@@ -165,69 +163,12 @@ export function ConnectedAgentDetail({
 		enabled: !!agent,
 	});
 
-	// Skills section: fetch ONLY this env's project. The earlier
-	// shape loaded the first 200 account-wide rows and filtered
-	// client-side, which on a multi-agent account with >200
-	// skills could miss this agent's rows entirely if they fell
-	// past page 1 in the global sort. The `project_id` query
-	// pushes the filter into the database so the per-page cap
-	// applies within the agent's own inventory.
-	//
-	// Walk every page server-side: a single agent with >200
-	// skills (rare but possible — power users with sprawling
-	// skill libraries) would otherwise lose rows past the
-	// page-1 cap. Same loop pattern the cross-agent /skills
-	// page uses; hard cap at 50 pages = 10k skills as a
-	// runaway-listing guard.
 	const agentProjectId = agent?.default_project_id;
 	const {
-		data: skillsData,
-		isLoading: skillsLoading,
+		skills: skillsForThisEnv,
 		error: skillsError,
 		refetch: refetchSkills,
-	} = useQuery({
-		queryKey: ["skills", agentProjectId, "all-pages"],
-		queryFn: async () =>
-			fetchAllPages<SkillSummary>(
-				async (page, pageSize) =>
-					unwrap(
-						await api.GET("/v1/skills", {
-							params: {
-								query: {
-									page,
-									page_size: pageSize,
-									project_id: agentProjectId,
-								},
-							},
-						}),
-					),
-				{ pageSize: 200, resourceName: "agent skills" },
-			),
-		enabled: !!agentProjectId,
-	});
-	const skillsForThisEnv = useMemo(() => {
-		// `?project_id=<agentProjectId>` narrows the listing to the
-		// selected project. Row actions still resolve writability from
-		// the shared project ownership map in `skill-columns`.
-		if (!skillsData?.items || !agentProjectId) return undefined;
-		return skillsData.items;
-	}, [skillsData, agentProjectId]);
-
-	const uninstallSkill = useMutation({
-		mutationFn: async ({ skillKey, projectId }: { skillKey: string; projectId: string }) =>
-			unwrap(
-				await api.DELETE("/v1/projects/{project_id}/skills/{skill_key}", {
-					params: { path: { project_id: projectId, skill_key: skillKey } },
-				}),
-			),
-		onSuccess: (_data, vars) => {
-			toast.success("Skill uninstalled", {
-				description: `${vars.skillKey} was removed from this agent. Other agents keep their copies.`,
-			});
-			queryClient.invalidateQueries({ queryKey: ["skills"] });
-		},
-		onError: (e) => toast.error("Couldn't uninstall skill", { description: errorMessage(e) }),
-	});
+	} = useAgentProjectSkills(agentProjectId);
 
 	const sessionTotal = sessionsError ? "—" : (sessionsPage?.total ?? 0);
 	const activeTabMeta = AGENT_DETAIL_NAV_META[activeTab];
@@ -253,12 +194,6 @@ export function ConnectedAgentDetail({
 		to: "/agents/$id/sessions/$sessionId" as const,
 		params: { id, sessionId },
 	});
-	const scopedSkillLink = (skill: SkillSummary) => ({
-		to: "/agents/$id/skills/$" as const,
-		params: { id, _splat: skill.skill_key },
-		search: skill.project_id ? { project: skill.project_id } : undefined,
-	});
-
 	return (
 		<div className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6")}>
 			{error ? (
@@ -358,29 +293,11 @@ export function ConnectedAgentDetail({
 					) : null}
 
 					{activeTab === "skills" ? (
-						skillsError ? (
-							<ApiErrorPanel
-								error={skillsError}
-								onRetry={() => {
-									void refetchSkills();
-								}}
-								title="Couldn't load agent skills"
-							/>
-						) : (
-							<SkillCardGrid
-								skills={skillsForThisEnv ?? []}
-								isLoading={skillsLoading}
-								emptyMessage="No skills installed on this agent yet."
-								readOnlySkillCheck={(s) =>
-									!s.project_id || !(writableProjectIds?.has(s.project_id) ?? false)
-								}
-								onUninstall={(skillKey, projectId) =>
-									uninstallSkill.mutate({ skillKey, projectId })
-								}
-								uninstallPending={uninstallSkill.isPending}
-								skillLink={scopedSkillLink}
-							/>
-						)
+						<AgentSkillsTab
+							agentId={id}
+							agentProjectId={agentProjectId}
+							writableProjectIds={writableProjectIds}
+						/>
 					) : null}
 
 					{activeTab === "projects" ? (

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -19,6 +19,7 @@ import {
 	QrCode,
 	RefreshCw,
 	Settings,
+	Sparkles,
 	TerminalSquare,
 	Trash2,
 	Zap,
@@ -30,6 +31,7 @@ import { useSetAgentBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import { AgentSourceBadge, agentDisplayName } from "@/components/dashboard/agent-label";
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
+import { AgentSkillsTab } from "@/components/dashboard/agent-skills-tab";
 import type { DetailSectionMeta } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
 import { PageHeader } from "@/components/page-header";
@@ -166,6 +168,7 @@ type HostedAgentTab =
 	| "console"
 	| "terminal"
 	| "sessions"
+	| "skills"
 	| "ai"
 	| "channels"
 	| "settings";
@@ -179,6 +182,7 @@ const HOSTED_AGENT_TABS = new Set<HostedAgentTab>([
 	"console",
 	"terminal",
 	"sessions",
+	"skills",
 	"ai",
 	"channels",
 	"settings",
@@ -199,6 +203,10 @@ const HOSTED_AGENT_NAV_META: Record<HostedAgentTab, DetailSectionMeta> = {
 	sessions: {
 		description: "History synced by this hosted runtime.",
 		icon: RefreshCw,
+	},
+	skills: {
+		description: "Installed in this agent's Agent Project.",
+		icon: Sparkles,
 	},
 	ai: {
 		description: "Runtime-scoped provider and model binding.",
@@ -325,7 +333,7 @@ export function HostedAgentDetail({
 	const api = useApi();
 	const router = useRouter();
 	const ci = deployment.config_info;
-	const { data: agent } = useQuery({
+	const agentQuery = useQuery({
 		queryKey: ["agents", environmentId],
 		queryFn: async () =>
 			unwrap(
@@ -335,6 +343,7 @@ export function HostedAgentDetail({
 			),
 		enabled: isCloudEnvId(environmentId),
 	});
+	const agent = agentQuery.data;
 	const name = agent ? agentDisplayName(agent) : deploymentDisplayName(deployment.name);
 	const runtimeLabel = runtimeDisplayName(runtime);
 	const agentTitle = name === runtimeLabel ? name : `${name} · ${runtimeLabel}`;
@@ -370,14 +379,22 @@ export function HostedAgentDetail({
 	const activeTabLabel = agentSectionLabel(activeTab);
 	const ActiveTabIcon = activeNavItem.icon;
 	const isLiveToolTab = activeTab === "console" || activeTab === "terminal";
-	const headerActions = consoleUrl ? (
-		<Button asChild variant="outline" size="sm">
-			<a href={consoleUrl} target="_blank" rel="noopener noreferrer">
-				Open {runtimeBrowserUiLabel(runtime)}
-				<ExternalLink className="size-3.5" />
-			</a>
-		</Button>
-	) : null;
+	const headerActions =
+		activeTab === "skills" ? (
+			<Button asChild variant="outline" size="sm">
+				<Link to="/skills" search={{ target: environmentId }}>
+					<Plus />
+					Install skills
+				</Link>
+			</Button>
+		) : consoleUrl ? (
+			<Button asChild variant="outline" size="sm">
+				<a href={consoleUrl} target="_blank" rel="noopener noreferrer">
+					Open {runtimeBrowserUiLabel(runtime)}
+					<ExternalLink className="size-3.5" />
+				</a>
+			</Button>
+		) : null;
 
 	return (
 		<div
@@ -420,6 +437,23 @@ export function HostedAgentDetail({
 					{activeTab === "terminal" ? <TerminalTab deployment={deployment} /> : null}
 					{activeTab === "sessions" ? (
 						<HostedAgentSessionsTab environmentId={environmentId} />
+					) : null}
+					{activeTab === "skills" ? (
+						agentQuery.error ? (
+							<ApiErrorPanel
+								error={agentQuery.error}
+								onRetry={() => {
+									void agentQuery.refetch();
+								}}
+								title="Couldn't load agent skills"
+							/>
+						) : (
+							<AgentSkillsTab
+								agentId={environmentId}
+								agentProjectId={agent?.default_project_id}
+								isResolvingAgentProject={agentQuery.isLoading && isCloudEnvId(environmentId)}
+							/>
+						)
 					) : null}
 					{activeTab === "ai" ? <AiProviderTab deployment={deployment} runtime={runtime} /> : null}
 					{activeTab === "channels" ? <ChannelsTab environmentId={environmentId} /> : null}

--- a/apps/web/src/lib/agent-routes.test.ts
+++ b/apps/web/src/lib/agent-routes.test.ts
@@ -7,6 +7,8 @@ import {
 	agentSectionSegment,
 	agentSessionDetailHref,
 	agentSkillDetailHref,
+	CONNECTED_AGENT_SECTION_IDS,
+	HOSTED_AGENT_SECTION_IDS,
 	hasAgentTabQuery,
 	parseAgentPathname,
 	parseAgentSectionSegment,
@@ -61,6 +63,11 @@ describe("agent routes", () => {
 		expect(agentSectionLabelFromSegment("model-provider")).toBe("Model Provider");
 		expect(agentSectionLabelFromSegment("settings")).toBe("Settings");
 		expect(agentSectionLabelFromSegment("bad")).toBeNull();
+	});
+
+	it("keeps Skills available for connected and hosted agent detail", () => {
+		expect(CONNECTED_AGENT_SECTION_IDS).toContain("skills");
+		expect(HOSTED_AGENT_SECTION_IDS).toContain("skills");
 	});
 
 	it("detects and removes tab params without changing the canonical section", () => {

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -25,6 +25,7 @@ export const HOSTED_AGENT_SECTION_IDS = [
 	"console",
 	"terminal",
 	"sessions",
+	"skills",
 	"ai",
 	"channels",
 	"settings",


### PR DESCRIPTION
## Summary
- Add `skills` to hosted agent section routing/sidebar wiring so `/agents/<hosted-id>/skills` renders instead of redirecting to Overview.
- Extract and reuse the connected agent Skills tab implementation, including the all-pages `/v1/skills` query, `SkillCardGrid` loading/error/empty states, writable Project read-only checks, and uninstall `DELETE /v1/projects/{project_id}/skills/{skill_key}` flow.
- Scope hosted skills through the resolved cloud-api agent environment id: hosted detail loads `/v1/agents/{environmentId}` for the resolved env id, then filters `/v1/skills` by that agent's `default_project_id`, not by the deployment id.

## Verification
- `bun run check:fix`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`