### PR TITLE
Simplify persona to language and timezone

### DIFF
--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -4,7 +4,10 @@ import { type QueryClient, useMutation, useQueryClient } from "@tanstack/react-q
 import { useMemo } from "react";
 import { toast } from "sonner";
 import { useBillingClient } from "@/hosted/billing/billing-client";
-import type { RebindAgentAiProviderRequest } from "@/hosted/billing/contracts";
+import type {
+	RebindAgentAiProviderRequest,
+	SetAgentEnabledRequest,
+} from "@/hosted/billing/contracts";
 import { BillingApiError, normalizeBillingError, toastBillingError } from "@/hosted/billing/errors";
 import { billingKeys, useHostedDeployments } from "@/hosted/billing/hooks";
 
@@ -22,6 +25,21 @@ class AiProviderRebindError extends Error {
 	) {
 		super("AI provider rebind failed for one or more runtimes");
 		this.name = "AiProviderRebindError";
+	}
+}
+
+type AgentLanguageTimezoneFailure = {
+	agentType: string;
+	error: unknown;
+};
+
+class AgentLanguageTimezoneError extends Error {
+	constructor(
+		readonly succeeded: string[],
+		readonly failures: AgentLanguageTimezoneFailure[],
+	) {
+		super("Language and timezone update failed for one or more runtimes");
+		this.name = "AgentLanguageTimezoneError";
 	}
 }
 
@@ -76,6 +94,26 @@ function toastAiProviderRebindError(error: unknown) {
 	}
 
 	toast.error("Couldn't update provider", {
+		description: `Couldn't update ${failed}. ${reason}`,
+	});
+}
+
+function toastAgentLanguageTimezoneError(error: unknown) {
+	if (!(error instanceof AgentLanguageTimezoneError)) {
+		toastBillingError("Couldn't update language and timezone")(error);
+		return;
+	}
+
+	const failed = listRuntimeLabels(error.failures.map((failure) => failure.agentType));
+	const reason = normalizeBillingError(error.failures[0]?.error);
+	if (error.succeeded.length > 0) {
+		toast.error("Language and timezone updated for some runtimes", {
+			description: `Couldn't update ${failed}. ${reason}`,
+		});
+		return;
+	}
+
+	toast.error("Couldn't update language and timezone", {
 		description: `Couldn't update ${failed}. ${reason}`,
 	});
 }
@@ -135,6 +173,58 @@ export function useSetAgentEnabled() {
 			toast.success(vars.enabled ? "Runtime enabled" : "Runtime disabled");
 		},
 		onError: toastBillingError("Couldn't update runtime"),
+	});
+}
+
+export function useSetAgentLanguageTimezone() {
+	const client = useBillingClient();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (vars: {
+			id: string;
+			agentTypes: string[];
+			enabledByAgentType: Record<string, boolean>;
+			language: string;
+			timezone: string;
+		}) => {
+			const succeeded: string[] = [];
+			const failures: AgentLanguageTimezoneFailure[] = [];
+			let last: Awaited<ReturnType<typeof client.setAgentLanguageTimezone>> | undefined;
+			for (const agentType of vars.agentTypes) {
+				const enabled = vars.enabledByAgentType[agentType];
+				if (typeof enabled !== "boolean") {
+					failures.push({
+						agentType,
+						error: new BillingApiError(400, `Missing enabled state for ${runtimeLabel(agentType)}`),
+					});
+					continue;
+				}
+				const body: SetAgentEnabledRequest = {
+					enabled,
+					language: vars.language || null,
+					timezone: vars.timezone || null,
+				};
+				try {
+					last = await client.setAgentLanguageTimezone(vars.id, agentType, body);
+					succeeded.push(agentType);
+				} catch (error) {
+					failures.push({ agentType, error });
+				}
+			}
+			if (failures.length > 0) {
+				throw new AgentLanguageTimezoneError(succeeded, failures);
+			}
+			return last;
+		},
+		onSuccess: () => {
+			invalidateDeploymentSnapshots(qc);
+			scheduleDeploymentSettlingRefresh(qc);
+			toast.success("Language and timezone updated");
+		},
+		onError: (error) => {
+			invalidateDeploymentSnapshots(qc);
+			toastAgentLanguageTimezoneError(error);
+		},
 	});
 }
 

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -70,6 +70,7 @@ import {
 	useOnboardAgent,
 	useSetAgentAiProvider,
 	useSetAgentEnabled,
+	useSetAgentLanguageTimezone,
 } from "@/hosted/agents/deployment-hooks";
 import {
 	HostedTerminalPanel,
@@ -81,6 +82,11 @@ import type {
 	HostedDeployment,
 	RebindAgentAiProviderRequest,
 } from "@/hosted/billing/contracts";
+import {
+	LANGUAGE_OPTIONS,
+	supportedTimezones,
+	TimezoneCombobox,
+} from "@/hosted/billing/deploy/language-timezone-controls";
 import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
 import { billingTermLabel, billingTermSuffix, formatCentsCompact } from "@/hosted/billing/format";
 import {
@@ -1500,12 +1506,136 @@ function HostedAgentSettingsTab({
 	return (
 		<div className="flex flex-col gap-10">
 			<AgentSettingsPanel environmentId={environmentId} />
+			<LanguageTimezoneSettingsSection deployment={deployment} />
 			<ComputeSettingsSections
 				deployment={deployment}
 				isPerformance={isPerformance}
 				runtime={runtime}
 			/>
 		</div>
+	);
+}
+
+function LanguageTimezoneSettingsSection({ deployment }: { deployment: HostedDeployment }) {
+	const setLanguageTimezone = useSetAgentLanguageTimezone();
+	const runAction = useActionLock();
+	const ci = deployment.config_info;
+	// Generated V2HostedDeploymentDetailsInfo currently exposes no language/timezone fields.
+	const configLanguage = "";
+	const configTimezone = "";
+	const configIdentity = JSON.stringify([deployment.id, configLanguage, configTimezone]);
+	const [syncedIdentity, setSyncedIdentity] = useState(configIdentity);
+	const [savedLanguage, setSavedLanguage] = useState(configLanguage);
+	const [savedTimezone, setSavedTimezone] = useState(configTimezone);
+	const [language, setLanguage] = useState(configLanguage);
+	const [timezone, setTimezone] = useState(configTimezone);
+	if (configIdentity !== syncedIdentity) {
+		setSyncedIdentity(configIdentity);
+		setSavedLanguage(configLanguage);
+		setSavedTimezone(configTimezone);
+		setLanguage(configLanguage);
+		setTimezone(configTimezone);
+	}
+	const tzOptions = useMemo(() => {
+		const all = supportedTimezones();
+		if (timezone && !all.includes(timezone)) return [timezone, ...all];
+		return all;
+	}, [timezone]);
+	const targetRuntimes = OPTIONAL_HOSTED_RUNTIMES.filter((runtimeId) =>
+		runtimeIsEnabled(ci, runtimeId),
+	);
+	const targetRuntimeLabels = targetRuntimes.map(runtimeDisplayName).join(", ");
+	const dirty = language !== savedLanguage || timezone !== savedTimezone;
+	const canSave = dirty && targetRuntimes.length > 0 && !setLanguageTimezone.isPending;
+
+	async function saveLanguageTimezone() {
+		if (!canSave) return;
+		await setLanguageTimezone.mutateAsync({
+			id: deployment.id,
+			agentTypes: targetRuntimes,
+			enabledByAgentType: Object.fromEntries(
+				targetRuntimes.map((runtimeId) => [runtimeId, runtimeIsEnabled(ci, runtimeId)]),
+			),
+			language,
+			timezone,
+		});
+		setSavedLanguage(language);
+		setSavedTimezone(timezone);
+	}
+
+	function resetLanguageTimezone() {
+		setLanguage(savedLanguage);
+		setTimezone(savedTimezone);
+	}
+
+	return (
+		<SettingsSection
+			title="Language & timezone"
+			description="Set locale context for enabled hosted runtimes."
+		>
+			<div className="flex max-w-2xl flex-col gap-4">
+				<LiveNote>
+					{targetRuntimes.length > 0
+						? `Changes apply live to ${targetRuntimeLabels}.`
+						: "Add OpenClaw or Hermes before saving language and timezone."}
+				</LiveNote>
+				<div className="grid gap-4 sm:grid-cols-2">
+					<div className="flex flex-col gap-1.5">
+						<Label htmlFor="settings-agent-language">Language</Label>
+						<Select
+							value={language || "default"}
+							onValueChange={(value) => setLanguage(value === "default" ? "" : value)}
+						>
+							<SelectTrigger id="settings-agent-language">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="default">Default</SelectItem>
+								{LANGUAGE_OPTIONS.map((option) => (
+									<SelectItem key={option.code} value={option.code}>
+										{option.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+					{tzOptions.length > 0 ? (
+						<div className="flex flex-col gap-1.5">
+							<Label htmlFor="settings-agent-timezone">Timezone</Label>
+							<TimezoneCombobox
+								id="settings-agent-timezone"
+								value={timezone}
+								onValueChange={setTimezone}
+								options={tzOptions}
+							/>
+						</div>
+					) : null}
+				</div>
+				<div className="flex flex-wrap items-center gap-2">
+					<Button
+						type="button"
+						size="sm"
+						disabled={!canSave}
+						onClick={() => void runAction(saveLanguageTimezone).catch(() => undefined)}
+					>
+						{setLanguageTimezone.isPending ? <Spinner className="size-3.5" /> : null}
+						Save changes
+					</Button>
+					<Button
+						type="button"
+						variant="ghost"
+						size="sm"
+						disabled={!dirty || setLanguageTimezone.isPending}
+						onClick={resetLanguageTimezone}
+					>
+						Reset
+					</Button>
+					{setLanguageTimezone.isPending ? (
+						<span className="text-xs text-muted-foreground">Updating runtime settings...</span>
+					) : null}
+				</div>
+			</div>
+		</SettingsSection>
 	);
 }
 

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -11,6 +11,7 @@ import type {
 	DeployRequest,
 	PortalRequest,
 	RuntimeAgentType,
+	SetAgentEnabledRequest,
 	WalletAutoReloadRequest,
 	WalletTopupRequest,
 } from "@/hosted/billing/contracts";
@@ -140,6 +141,19 @@ export function useBillingClient() {
 							path: { deployment_id: id, agent_type: runtimeAgentType(agentType) },
 						},
 						body: { enabled },
+					}),
+				),
+			setAgentLanguageTimezone: async (
+				id: string,
+				agentType: string,
+				body: SetAgentEnabledRequest,
+			) =>
+				unwrapDeploy(
+					await api.PATCH("/v2/deployments/{deployment_id}/agents/{agent_type}", {
+						params: {
+							path: { deployment_id: id, agent_type: runtimeAgentType(agentType) },
+						},
+						body,
 					}),
 				),
 			setAgentAiProvider: async (

--- a/apps/web/src/hosted/billing/contracts.ts
+++ b/apps/web/src/hosted/billing/contracts.ts
@@ -22,6 +22,7 @@ export type PortalResult = Schemas["V2PortalResponse"];
 export type RebindAgentAiProviderRequest = Schemas["V2RebindAgentAiProviderRequest"];
 export type RuntimeAgentType =
 	DeployPaths["/v2/deployments/{deployment_id}/agents/{agent_type}"]["patch"]["parameters"]["path"]["agent_type"];
+export type SetAgentEnabledRequest = Schemas["V2SetAgentEnabledRequest"];
 export type TerminalSessionResponse = Schemas["V2DeploymentTerminalSessionResponse"];
 export type UsageDay = Schemas["V2HostedUsageDay"];
 export type UsageModelBreakdown = Schemas["V2HostedUsageModelBreakdown"];

--- a/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
@@ -7,8 +7,6 @@ describe("buildHostedDeployRequest", () => {
 			computePlanSlug: "compute_performance",
 			engines: { openclaw: true, hermes: false },
 			persona: {
-				assistantName: "  Test Agent  ",
-				personality: "concise",
 				language: "en",
 				timezone: "America/Los_Angeles",
 			},
@@ -16,13 +14,13 @@ describe("buildHostedDeployRequest", () => {
 		});
 
 		expect("profile" in request).toBe(false);
+		expect("assistant_name" in request).toBe(false);
+		expect("personality" in request).toBe(false);
 		expect(request).toMatchObject({
 			compute_plan_slug: "compute_performance",
 			channel: null,
 			enable_openclaw: true,
 			enable_hermes: false,
-			assistant_name: "Test Agent",
-			personality: "concise",
 			language: "en",
 			timezone: "America/Los_Angeles",
 			ai_provider_auth_kind: "managed",
@@ -30,8 +28,11 @@ describe("buildHostedDeployRequest", () => {
 				channel: null,
 				enable_openclaw: true,
 				enable_hermes: false,
-				assistant_name: "Test Agent",
+				language: "en",
+				timezone: "America/Los_Angeles",
 			},
 		});
+		expect("assistant_name" in (request.config ?? {})).toBe(false);
+		expect("personality" in (request.config ?? {})).toBe(false);
 	});
 });

--- a/apps/web/src/hosted/billing/deploy/deploy-request.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-request.ts
@@ -6,8 +6,6 @@ type EngineSelection = {
 };
 
 type DeployPersona = {
-	assistantName: string;
-	personality: string;
 	language: string;
 	timezone: string;
 };
@@ -26,8 +24,6 @@ export function buildHostedDeployRequest({
 	aiFields: Partial<DeployRequest>;
 }): DeployRequest {
 	const personaFields = {
-		assistant_name: persona.assistantName.trim() || null,
-		personality: persona.personality || null,
 		language: persona.language || null,
 		timezone: persona.timezone || null,
 	};

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -2,17 +2,7 @@
 
 import { isFirstPartyManagedAiProvider } from "@clawdi/shared";
 import { useLocation, useRouter } from "@tanstack/react-router";
-import {
-	CalendarClock,
-	Check,
-	ChevronsUpDown,
-	Cpu,
-	Plus,
-	RefreshCw,
-	Rocket,
-	Sparkles,
-	Zap,
-} from "lucide-react";
+import { CalendarClock, Cpu, Plus, RefreshCw, Rocket, Sparkles, Zap } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { type ApiErrorNormalizer, ApiErrorPanel } from "@/components/api-error-panel";
@@ -24,16 +14,6 @@ import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SettingsSection } from "@/components/settings-section";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-	Command,
-	CommandEmpty,
-	CommandGroup,
-	CommandInput,
-	CommandItem,
-	CommandList,
-} from "@/components/ui/command";
-import { Input } from "@/components/ui/input";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
 	Select,
 	SelectContent,
@@ -53,6 +33,12 @@ import type {
 } from "@/hosted/billing/contracts";
 import { usesActiveFreeComputeSlot } from "@/hosted/billing/deploy/deploy-model";
 import { buildHostedDeployRequest } from "@/hosted/billing/deploy/deploy-request";
+import {
+	browserTimezone,
+	LANGUAGE_OPTIONS,
+	supportedTimezones,
+	TimezoneCombobox,
+} from "@/hosted/billing/deploy/language-timezone-controls";
 import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
 import { billingTermSuffix, formatCentsCompact } from "@/hosted/billing/format";
 import {
@@ -112,43 +98,6 @@ const aiProviderErrorNormalizer: ApiErrorNormalizer = {
 	normalizeError: (error) => `${normalizeApiError(error)} Managed AI still works.`,
 };
 
-/** Personality presets accepted by hosted deployment onboarding. */
-const PERSONALITY_PRESETS = [
-	{ id: "friendly", label: "Friendly" },
-	{ id: "professional", label: "Professional" },
-	{ id: "creative", label: "Creative" },
-	{ id: "concise", label: "Concise" },
-] as const;
-
-/** Common UI languages offered during onboarding. */
-const LANGUAGE_OPTIONS = [
-	{ code: "en", label: "English" },
-	{ code: "zh-CN", label: "简体中文" },
-	{ code: "zh-TW", label: "繁體中文" },
-	{ code: "ja", label: "日本語" },
-	{ code: "ko", label: "한국어" },
-	{ code: "es", label: "Español" },
-	{ code: "fr", label: "Français" },
-	{ code: "de", label: "Deutsch" },
-	{ code: "pt", label: "Português" },
-];
-
-function browserTimezone(): string {
-	try {
-		return Intl.DateTimeFormat().resolvedOptions().timeZone || "";
-	} catch {
-		return "";
-	}
-}
-
-function supportedTimezones(): string[] {
-	try {
-		return Intl.supportedValuesOf("timeZone");
-	} catch {
-		return [];
-	}
-}
-
 function aiAuthKind(provider: AiProvider): RuntimeAiProviderAuthKind {
 	return provider.auth.type === "agent_profile" || provider.auth.type === "oauth_profile"
 		? "codex_oauth"
@@ -195,71 +144,6 @@ function ChannelInfoTile({ channel }: { channel: ChannelAccount }) {
 			}
 			className="h-full bg-card"
 		/>
-	);
-}
-
-function timezoneLabel(timezone: string): string {
-	return timezone.replaceAll("_", " ");
-}
-
-function TimezoneCombobox({
-	value,
-	onValueChange,
-	options,
-}: {
-	value: string;
-	onValueChange: (value: string) => void;
-	options: string[];
-}) {
-	const [open, setOpen] = useState(false);
-	return (
-		<Popover open={open} onOpenChange={setOpen}>
-			<PopoverTrigger asChild>
-				<Button
-					id="agent-timezone"
-					type="button"
-					variant="outline"
-					role="combobox"
-					aria-expanded={open}
-					className="w-full justify-between"
-				>
-					<span className={cn("truncate", !value && "text-muted-foreground")}>
-						{value ? timezoneLabel(value) : "Select a timezone"}
-					</span>
-					<ChevronsUpDown className="opacity-50" />
-				</Button>
-			</PopoverTrigger>
-			<PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-0">
-				<Command>
-					<CommandInput placeholder="Search timezones…" />
-					<CommandList className="max-h-72">
-						<CommandEmpty>No timezone found.</CommandEmpty>
-						<CommandGroup>
-							{options.map((tz) => {
-								const selected = value === tz;
-								return (
-									<CommandItem
-										key={tz}
-										value={tz}
-										keywords={[timezoneLabel(tz), tz.replaceAll("/", " ")]}
-										onSelect={() => {
-											onValueChange(tz);
-											setOpen(false);
-										}}
-									>
-										<Check className={cn("size-4", selected ? "opacity-100" : "opacity-0")} />
-										<span className="truncate">{timezoneLabel(tz)}</span>
-										{timezoneLabel(tz) !== tz ? (
-											<span className="ml-auto truncate text-xs text-muted-foreground">{tz}</span>
-										) : null}
-									</CommandItem>
-								);
-							})}
-						</CommandGroup>
-					</CommandList>
-				</Command>
-			</PopoverContent>
-		</Popover>
 	);
 }
 
@@ -383,8 +267,6 @@ export function DeployWizard() {
 	});
 	const [aiChoice, setAiChoice] = useState<string>(MANAGED_AI_CHOICE); // sentinel | provider_id
 	const [compute, setCompute] = useState<Compute>("free");
-	const [agentName, setAgentName] = useState("");
-	const [personality, setPersonality] = useState("");
 	const [language, setLanguage] = useState("");
 	const [timezone, setTimezone] = useState("");
 	const [addProviderOpen, setAddProviderOpen] = useState(false);
@@ -559,8 +441,6 @@ export function DeployWizard() {
 			computePlanSlug,
 			engines,
 			persona: {
-				assistantName: agentName,
-				personality,
 				language,
 				timezone,
 			},
@@ -640,13 +520,10 @@ export function DeployWizard() {
 		runtimeDisplayName("codex"),
 		...enginesSelected.map((engine) => runtimeDisplayName(engine)),
 	].join(" + ");
-	const personalityLabel = PERSONALITY_PRESETS.find((p) => p.id === personality)?.label;
 	const summaryLine = [
-		agentName.trim() || null,
 		`${compute === "performance" ? "Performance" : "Free"} compute`,
 		aiSummary,
 		runtimeSummary,
-		personalityLabel ?? null,
 		LANGUAGE_OPTIONS.find((l) => l.code === language)?.label ?? null,
 		timezone || null,
 	]
@@ -885,45 +762,10 @@ export function DeployWizard() {
 						Personalize <span className="font-normal text-muted-foreground">· optional</span>
 					</>
 				}
-				description="Give your agent a name, tone, language, and timezone."
+				description="Choose the agent's language and timezone."
 			>
 				<div className="flex max-w-2xl flex-col gap-4">
-					<div className="flex flex-col gap-1.5">
-						<label htmlFor="agent-name" className="text-sm text-muted-foreground">
-							Name
-						</label>
-						<Input
-							id="agent-name"
-							name="agent-name"
-							value={agentName}
-							onChange={(e) => setAgentName(e.target.value)}
-							placeholder="My assistant"
-							autoComplete="off"
-							maxLength={60}
-						/>
-					</div>
 					<div className="grid gap-4 sm:grid-cols-2">
-						<div className="flex flex-col gap-1.5">
-							<label htmlFor="agent-personality" className="text-sm text-muted-foreground">
-								Personality
-							</label>
-							<Select
-								value={personality || "default"}
-								onValueChange={(v) => setPersonality(v === "default" ? "" : v)}
-							>
-								<SelectTrigger id="agent-personality">
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									<SelectItem value="default">Default</SelectItem>
-									{PERSONALITY_PRESETS.map((p) => (
-										<SelectItem key={p.id} value={p.id}>
-											{p.label}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
-						</div>
 						<div className="flex flex-col gap-1.5">
 							<label htmlFor="agent-language" className="text-sm text-muted-foreground">
 								Language

--- a/apps/web/src/hosted/billing/deploy/language-timezone-controls.tsx
+++ b/apps/web/src/hosted/billing/deploy/language-timezone-controls.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { Check, ChevronsUpDown } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+/** Common UI languages offered during onboarding and hosted runtime settings. */
+export const LANGUAGE_OPTIONS = [
+	{ code: "en", label: "English" },
+	{ code: "zh-CN", label: "简体中文" },
+	{ code: "zh-TW", label: "繁體中文" },
+	{ code: "ja", label: "日本語" },
+	{ code: "ko", label: "한국어" },
+	{ code: "es", label: "Español" },
+	{ code: "fr", label: "Français" },
+	{ code: "de", label: "Deutsch" },
+	{ code: "pt", label: "Português" },
+] as const;
+
+export function browserTimezone(): string {
+	try {
+		return Intl.DateTimeFormat().resolvedOptions().timeZone || "";
+	} catch {
+		return "";
+	}
+}
+
+export function supportedTimezones(): string[] {
+	try {
+		return Intl.supportedValuesOf("timeZone");
+	} catch {
+		return [];
+	}
+}
+
+function timezoneLabel(timezone: string): string {
+	return timezone.replaceAll("_", " ");
+}
+
+export function TimezoneCombobox({
+	id = "agent-timezone",
+	value,
+	onValueChange,
+	options,
+}: {
+	id?: string;
+	value: string;
+	onValueChange: (value: string) => void;
+	options: string[];
+}) {
+	const [open, setOpen] = useState(false);
+	return (
+		<div data-hosted="true" className="contents">
+			<Popover open={open} onOpenChange={setOpen}>
+				<PopoverTrigger asChild>
+					<Button
+						id={id}
+						type="button"
+						variant="outline"
+						role="combobox"
+						aria-expanded={open}
+						className="w-full justify-between"
+					>
+						<span className={cn("truncate", !value && "text-muted-foreground")}>
+							{value ? timezoneLabel(value) : "Select a timezone"}
+						</span>
+						<ChevronsUpDown className="opacity-50" />
+					</Button>
+				</PopoverTrigger>
+				<PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-0">
+					<Command>
+						<CommandInput placeholder="Search timezones…" />
+						<CommandList className="max-h-72">
+							<CommandEmpty>No timezone found.</CommandEmpty>
+							<CommandGroup>
+								{options.map((tz) => {
+									const selected = value === tz;
+									const label = timezoneLabel(tz);
+									return (
+										<CommandItem
+											key={tz}
+											value={tz}
+											keywords={[label, tz.replaceAll("/", " ")]}
+											onSelect={() => {
+												onValueChange(tz);
+												setOpen(false);
+											}}
+										>
+											<Check className={cn("size-4", selected ? "opacity-100" : "opacity-0")} />
+											<span className="truncate">{label}</span>
+											{label !== tz ? (
+												<span className="ml-auto truncate text-xs text-muted-foreground">{tz}</span>
+											) : null}
+										</CommandItem>
+									);
+								})}
+							</CommandGroup>
+						</CommandList>
+					</Command>
+				</PopoverContent>
+			</Popover>
+		</div>
+	);
+}

--- a/apps/web/src/hosted/billing/idempotency.test.ts
+++ b/apps/web/src/hosted/billing/idempotency.test.ts
@@ -87,12 +87,12 @@ describe("idempotencyAttemptFor", () => {
 		const monthly = idempotencyFingerprint({
 			plan_slug: "compute_performance",
 			billing_term_months: 1,
-			deploy_config: { assistant_name: "Agent" },
+			deploy_config: { language: "en", timezone: "America/Los_Angeles" },
 		});
 		const annual = idempotencyFingerprint({
 			plan_slug: "compute_performance",
 			billing_term_months: 12,
-			deploy_config: { assistant_name: "Agent" },
+			deploy_config: { language: "en", timezone: "America/Los_Angeles" },
 		});
 		const first = idempotencyAttemptFor(null, "checkout", monthly, mint);
 		const changed = idempotencyAttemptFor(first, "checkout", annual, mint);


### PR DESCRIPTION
## Summary
- Removed assistant_name and personality from the hosted deploy wizard and deploy request payload; deploy now sends only language and timezone for persona fields.
- Added editable language/timezone settings on the hosted agent Settings tab using the per-agent PATCH /v2/deployments/{deployment_id}/agents/{agent_type}.
- The PATCH body passes each target runtime's current enabled value unchanged alongside language/timezone.
- Prefill source: generated V2HostedDeploymentDetailsInfo does not expose language/timezone today, so the settings form starts empty instead of guessing untyped config_info field names.

## Verification
- bun run check:fix
- bun run --cwd apps/web typecheck
- bun run --cwd apps/web test