### PR TITLE
Cover critical-path ownership, idempotency, and status logic

### DIFF
--- a/apps/web/src/hosted/billing/idempotency.test.ts
+++ b/apps/web/src/hosted/billing/idempotency.test.ts
@@ -67,6 +67,23 @@ describe("idempotencyFingerprint", () => {
 			}),
 		);
 	});
+
+	test("changes when launch-critical request body fields change", () => {
+		const baseBody = {
+			plan_slug: "compute_performance",
+			deploy_config: { enable_hermes: true, enable_openclaw: true },
+			billing_term_months: 1,
+		};
+		const baseFingerprint = idempotencyFingerprint(baseBody);
+
+		for (const changedBody of [
+			{ ...baseBody, plan_slug: "compute_basic" },
+			{ ...baseBody, billing_term_months: 12 },
+			{ ...baseBody, deploy_config: { ...baseBody.deploy_config, enable_hermes: false } },
+		]) {
+			expect(idempotencyFingerprint(changedBody)).not.toBe(baseFingerprint);
+		}
+	});
 });
 
 describe("idempotencyAttemptFor", () => {

--- a/apps/web/src/lib/agent-ownership.test.ts
+++ b/apps/web/src/lib/agent-ownership.test.ts
@@ -17,6 +17,20 @@ describe("agentOwnershipKindFromId", () => {
 		expect(agentOwnershipKindFromId("cccc", ownership)).toBe("connected");
 	});
 
+	it("trims environment ids and treats missing ids as connected for cosmetic callers", () => {
+		const ownership = {
+			cloudEnvIds: new Set(["aaaa"]),
+			legacyEnvIds: new Set(["bbbb"]),
+		};
+
+		expect(agentOwnershipKindFromId("  AAAA  ", ownership)).toBe("cloud");
+		expect(agentOwnershipKindFromId("  BBBB  ", ownership)).toBe("legacy");
+
+		for (const envId of [null, undefined, "", "   "]) {
+			expect(agentOwnershipKindFromId(envId, ownership)).toBe("connected");
+		}
+	});
+
 	it("defaults to connected while ownership is unknown", () => {
 		// Cosmetic fallback only — destructive consumers (Disconnect) must
 		// additionally require a non-null (resolved) ownership value.
@@ -68,6 +82,18 @@ describe("agentDisconnectUnavailable", () => {
 		).toBe(true);
 	});
 
+	it("fails closed while ownership is unresolved for edge environment ids", () => {
+		for (const envId of ["aaaa", null, undefined, "", "   "]) {
+			expect(
+				agentDisconnectUnavailable({
+					envId,
+					explicitIdentity: false,
+					ownership: null,
+				}),
+			).toBe(true);
+		}
+	});
+
 	it("blocks disconnect while ownership is unresolved or externally owned", () => {
 		expect(
 			agentDisconnectUnavailable({
@@ -81,6 +107,13 @@ describe("agentDisconnectUnavailable", () => {
 				envId: "aaaa",
 				explicitIdentity: false,
 				ownership: { cloudEnvIds: new Set(["aaaa"]), legacyEnvIds: new Set() },
+			}),
+		).toBe(true);
+		expect(
+			agentDisconnectUnavailable({
+				envId: "aaaa",
+				explicitIdentity: false,
+				ownership: { cloudEnvIds: new Set(), legacyEnvIds: new Set(["aaaa"]) },
 			}),
 		).toBe(true);
 	});


### PR DESCRIPTION
## Summary
- Added focused edge coverage for `agentOwnershipKindFromId` normalization/null handling and `agentDisconnectUnavailable` fail-closed behavior for unresolved ownership plus cloud/legacy-owned agents.
- Added `idempotencyFingerprint` coverage proving launch-critical request body changes produce distinct fingerprints; existing `idempotencyAttemptFor` tests already cover same-fingerprint reuse and changed-fingerprint new-key behavior.
- Deployment status predicates, the 7-status enum, terminal/transitional classification, lifecycle gates, polling, and the ready-to-running alias were already covered in `deployment-status.test.ts`, so no duplicate status tests were added.

## Skipped
- `apps/web/src/hosted/agents/ownership-sensor.ts` exports only hook/component surfaces (`useLegacyEnvIds`, `HostedAgentOwnershipSensor`); its pure helper is internal, so I did not add a hook/DOM harness.

## Verification
- `bun run check:fix`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`