### PR TITLE
Fix UI accessibility and SSR shell issues

### DIFF
--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -103,6 +103,9 @@ const TYPE_LABEL: Record<SearchHit["type"], string> = {
 	vault: "Vaults",
 };
 
+const COMMAND_RESULT_ROW_CLASS = "items-start gap-2 py-2.5";
+const COMMAND_RESULT_TEXT_CLASS = "flex min-w-0 flex-col gap-0.5";
+
 interface PaletteContextValue {
 	open: boolean;
 	setOpen: (open: boolean) => void;
@@ -256,7 +259,7 @@ function CommandPalette({
 			title="Search"
 			description="Open a page or search sessions, memories, skills, and vaults. Use the Search button in the sidebar or Cmd/Ctrl+K."
 		>
-			<Command shouldFilter={false}>
+			<Command label="Global search" shouldFilter={false}>
 				<div className="relative">
 					<CommandInput
 						value={query}
@@ -289,10 +292,10 @@ function CommandPalette({
 									key={s.href}
 									value={s.searchText}
 									onSelect={() => jump(s.href)}
-									className="gap-2"
+									className={COMMAND_RESULT_ROW_CLASS}
 								>
-									<s.icon className="size-4 shrink-0" />
-									<div className="flex min-w-0 flex-col">
+									<s.icon className="mt-0.5 size-4 shrink-0" />
+									<div className={COMMAND_RESULT_TEXT_CLASS}>
 										<span className="truncate">{s.label}</span>
 										<span className="truncate text-xs text-muted-foreground">{s.subtitle}</span>
 									</div>
@@ -315,10 +318,10 @@ function CommandPalette({
 													key={`${hit.type}-${hit.id}`}
 													value={`${hit.type}-${hit.id}`}
 													onSelect={() => jump(hit.href)}
-													className="gap-2"
+													className={COMMAND_RESULT_ROW_CLASS}
 												>
-													<Icon className="size-4 shrink-0 text-muted-foreground" />
-													<div className="flex min-w-0 flex-col">
+													<Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+													<div className={COMMAND_RESULT_TEXT_CLASS}>
 														<span className="truncate">{hit.title}</span>
 														{hit.subtitle ? (
 															<span className="truncate text-xs text-muted-foreground">

--- a/apps/web/src/components/ui/data-table-faceted-filter.tsx
+++ b/apps/web/src/components/ui/data-table-faceted-filter.tsx
@@ -87,7 +87,7 @@ export function DataTableFacetedFilter({
 				)}
 			</PopoverTrigger>
 			<PopoverContent className="w-[200px] p-0" align="start">
-				<Command>
+				<Command label={`${title} filter options`}>
 					<CommandInput placeholder={title} />
 					<CommandList>
 						<CommandEmpty>No results found.</CommandEmpty>

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1408,7 +1408,7 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 							if (value !== null) setAccountId(value);
 						}}
 					>
-						<SelectTrigger className="flex-1">
+						<SelectTrigger aria-label="Link a channel" className="flex-1">
 							<SelectValue placeholder="Choose a channel…" />
 						</SelectTrigger>
 						<SelectContent>

--- a/apps/web/src/hosted/billing/deploy/language-timezone-controls.tsx
+++ b/apps/web/src/hosted/billing/deploy/language-timezone-controls.tsx
@@ -80,7 +80,7 @@ export function TimezoneCombobox({
 					<ChevronsUpDown className="opacity-50" />
 				</PopoverTrigger>
 				<PopoverContent align="start" className="w-(--anchor-width) p-0">
-					<Command>
+					<Command label="Timezone options">
 						<CommandInput placeholder="Search timezones…" />
 						<CommandList className="max-h-72">
 							<CommandEmpty>No timezone found.</CommandEmpty>

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
@@ -58,6 +58,7 @@ export function TopUpDialog({
 		Number.isFinite(amountCents) &&
 		amountCents >= TOPUP_MIN_CENTS &&
 		amountCents <= TOPUP_MAX_CENTS;
+	const amountInvalid = !valid && Boolean(dollars);
 	const credits = valid ? formatCredits((amountCents / 100) * wallet.points_per_usd) : "";
 
 	function setAmount(next: string) {
@@ -167,10 +168,12 @@ export function TopUpDialog({
 									className="pl-6"
 									value={dollars}
 									onChange={(e) => setAmount(e.target.value)}
+									aria-invalid={amountInvalid}
+									aria-describedby={amountInvalid ? "topup-amount-err" : undefined}
 								/>
 							</div>
-							{!valid && dollars ? (
-								<p className="text-xs text-destructive">
+							{amountInvalid ? (
+								<p id="topup-amount-err" className="text-xs text-destructive">
 									Enter an amount between {formatCents(TOPUP_MIN_CENTS)} and{" "}
 									{formatCents(TOPUP_MAX_CENTS)}.
 								</p>

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { discordPublicKeyError } from "./connect-bot-dialog.logic";
+
+describe("discordPublicKeyError", () => {
+	test("allows blank optional public keys", () => {
+		expect(discordPublicKeyError("")).toBeNull();
+		expect(discordPublicKeyError("   ")).toBeNull();
+	});
+
+	test("requires a 32-byte hex string when provided", () => {
+		expect(discordPublicKeyError("a".repeat(63))).toBe("Enter a 64-character hex public key.");
+		expect(discordPublicKeyError("a".repeat(65))).toBe("Enter a 64-character hex public key.");
+		expect(discordPublicKeyError(`${"a".repeat(63)}g`)).toBe(
+			"Enter a 64-character hex public key.",
+		);
+		expect(discordPublicKeyError("A".repeat(64))).toBeNull();
+	});
+});

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.ts
@@ -1,0 +1,11 @@
+const DISCORD_PUBLIC_KEY_HEX_LENGTH = 64;
+const HEX_PATTERN = /^[0-9a-fA-F]+$/;
+
+export function discordPublicKeyError(value: string): string | null {
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+	if (trimmed.length !== DISCORD_PUBLIC_KEY_HEX_LENGTH || !HEX_PATTERN.test(trimmed)) {
+		return "Enter a 64-character hex public key.";
+	}
+	return null;
+}

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -23,6 +23,7 @@ import {
 import type { ChannelCreate, ChannelCreated } from "@/hosted/v2/channels/channel-types";
 import { ProviderChip, TokenReveal } from "@/hosted/v2/channels/channel-ui";
 import { useCreateChannel } from "@/hosted/v2/channels/channels-hooks";
+import { discordPublicKeyError } from "@/hosted/v2/channels/connect-bot-dialog.logic";
 
 /**
  * Connect a channel. Each provider takes its OWN real inputs (grounded in
@@ -61,6 +62,7 @@ export function ConnectBotDialog({
 	}, [open]);
 
 	const meta = PROVIDER_META[provider];
+	const publicKeyError = meta.connect === "discord" ? discordPublicKeyError(publicKey) : null;
 
 	function changeProvider(next: ChannelProviderId) {
 		setProvider(next);
@@ -77,7 +79,7 @@ export function ConnectBotDialog({
 			: meta.connect === "token"
 				? token.trim().length > 0
 				: meta.connect === "discord"
-					? token.trim().length > 0 && applicationId.trim().length > 0
+					? token.trim().length > 0 && applicationId.trim().length > 0 && !publicKeyError
 					: false);
 
 	function buildBody(): ChannelCreate {
@@ -235,10 +237,20 @@ export function ConnectBotDialog({
 											placeholder="Ed25519 public key (hex)"
 											autoComplete="off"
 											spellCheck={false}
+											aria-invalid={Boolean(publicKeyError)}
+											aria-describedby={
+												publicKeyError ? "connect-public-key-err" : "connect-public-key-help"
+											}
 										/>
-										<p className="text-xs text-muted-foreground">
-											Stored with the Discord application metadata.
-										</p>
+										{publicKeyError ? (
+											<p id="connect-public-key-err" className="text-xs text-destructive">
+												{publicKeyError}
+											</p>
+										) : (
+											<p id="connect-public-key-help" className="text-xs text-muted-foreground">
+												Stored with the Discord application metadata.
+											</p>
+										)}
 									</div>
 									<div className="flex flex-col gap-1.5">
 										<Label htmlFor="connect-guild-id">

--- a/apps/web/src/pages/dashboard/layout.tsx
+++ b/apps/web/src/pages/dashboard/layout.tsx
@@ -115,7 +115,11 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
 						{/* 1rem = SidebarInset's md:m-2 top+bottom when the sidebar uses
 						    dashboard-01's inset variant. Keep the scroll container inside
 						    the inset so the sticky SiteHeader pins correctly. */}
-						<SidebarInset className="md:h-[calc(100svh-1rem)] md:overflow-y-auto">
+						<SidebarInset
+							id="dashboard-scroll-container"
+							data-scroll-restoration-id="dashboard-scroll-container"
+							className="md:h-[calc(100svh-1rem)] md:overflow-y-auto"
+						>
 							<SiteHeader />
 							<div className="flex flex-1 flex-col">
 								<div className="@container/main flex flex-1 flex-col gap-2">

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -5,6 +5,7 @@ export function getRouter() {
 	return createRouter({
 		routeTree,
 		scrollRestoration: true,
+		scrollToTopSelectors: ["#dashboard-scroll-container"],
 	});
 }
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -36,7 +36,11 @@ export const Route = createRootRoute({
 			{ rel: "apple-touch-icon", href: "/apple-touch-icon.png" },
 		],
 	}),
-	errorComponent: ({ error, reset }) => <RootError error={error} reset={reset} />,
+	errorComponent: ({ error, reset }) => (
+		<RootDocument>
+			<RootError error={error} reset={reset} />
+		</RootDocument>
+	),
 	notFoundComponent: () => (
 		<div className="flex min-h-dvh items-center justify-center bg-background p-6">
 			<div className="space-y-2 text-center">


### PR DESCRIPTION
## Summary
- Added accessible names to Command roots and gave command palette two-line result rows more breathing room at the consumer level.
- Added missing field accessibility wiring for hosted channel linking and wallet top-up amount errors.
- Validated Discord public keys as optional 32-byte hex values before channel creation, with a field error and unit coverage.
- Wrapped root route errors in the document shell and wired TanStack Router scroll restoration to the dashboard scroll container.

## Verification
- `bun run check`
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test`
- `bun run --cwd apps/web e2e`
- `bun run --cwd apps/web e2e:hosted`
- `bun run --cwd apps/web build`

Not merged.
