### PR TITLE
Harden frontend auth guard and error handling

### DIFF
--- a/apps/web/src/components/auth-provider.tsx
+++ b/apps/web/src/components/auth-provider.tsx
@@ -8,7 +8,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 	if (isDevAuthBypass) return <>{children}</>;
 
 	return (
-		<ClerkProvider appearance={shadcn} publishableKey={env.VITE_CLERK_PUBLISHABLE_KEY}>
+		<ClerkProvider
+			appearance={shadcn}
+			publishableKey={env.VITE_CLERK_PUBLISHABLE_KEY}
+			signInFallbackRedirectUrl="/"
+			signInUrl="/sign-in"
+			signUpFallbackRedirectUrl="/"
+			signUpUrl="/sign-up"
+		>
 			{children}
 		</ClerkProvider>
 	);

--- a/apps/web/src/lib/env.test.ts
+++ b/apps/web/src/lib/env.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { isDevAuthBypassEnabled, isProductionRuntime } from "./env";
+
+describe("dev auth bypass env guard", () => {
+	test("keeps the bypass available in local development", () => {
+		expect(
+			isDevAuthBypassEnabled({
+				MODE: "development",
+				NODE_ENV: "development",
+				VITE_DEV_AUTH_BYPASS: "true",
+			}),
+		).toBe(true);
+	});
+
+	test("treats NODE_ENV=production as authoritative over MODE", () => {
+		expect(
+			isProductionRuntime({
+				MODE: "development",
+				NODE_ENV: "production",
+			}),
+		).toBe(true);
+		expect(
+			isDevAuthBypassEnabled({
+				MODE: "development",
+				NODE_ENV: "production",
+				VITE_DEV_AUTH_BYPASS: "true",
+			}),
+		).toBe(false);
+	});
+
+	test("disables the bypass for production Vite builds", () => {
+		expect(
+			isDevAuthBypassEnabled({
+				MODE: "production",
+				NODE_ENV: "development",
+				VITE_DEV_AUTH_BYPASS: "true",
+			}),
+		).toBe(false);
+	});
+});

--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -17,17 +17,27 @@ const metaEnv = ((import.meta as ImportMeta & { env?: RawEnv }).env ?? {}) as Ra
 const processEnv: RawEnv = typeof process === "undefined" ? {} : process.env;
 const runtimeEnv: RawEnv = typeof process === "undefined" ? metaEnv : { ...metaEnv, ...processEnv };
 
-function readRawEnv(key: string): string | undefined {
-	const value = runtimeEnv[key];
+function readRawEnvValue(rawEnv: RawEnv, key: string): string | undefined {
+	const value = rawEnv[key];
 	return typeof value === "string" ? value : undefined;
 }
 
-function readMode(): string {
-	return readRawEnv("MODE") ?? readRawEnv("NODE_ENV") ?? "development";
+function readRawEnv(key: string): string | undefined {
+	return readRawEnvValue(runtimeEnv, key);
 }
 
-const isLocalDevAuthBypass =
-	readRawEnv("VITE_DEV_AUTH_BYPASS") === "true" && readMode() !== "production";
+export function isProductionRuntime(rawEnv: RawEnv = runtimeEnv): boolean {
+	return (
+		readRawEnvValue(rawEnv, "NODE_ENV") === "production" ||
+		readRawEnvValue(rawEnv, "MODE") === "production"
+	);
+}
+
+export function isDevAuthBypassEnabled(rawEnv: RawEnv = runtimeEnv): boolean {
+	return readRawEnvValue(rawEnv, "VITE_DEV_AUTH_BYPASS") === "true" && !isProductionRuntime(rawEnv);
+}
+
+const isLocalDevAuthBypass = isDevAuthBypassEnabled();
 
 /**
  * Typed, validated environment variables.
@@ -74,7 +84,7 @@ export const env = createEnv({
 		VITE_DEV_AUTH_BYPASS: z
 			.string()
 			.optional()
-			.transform((v) => v === "true" && readMode() !== "production"),
+			.transform((v) => v === "true" && !isProductionRuntime()),
 		VITE_DEV_AUTH_TOKEN: z.string().min(1).default("dev-bypass"),
 		// Cosmetic identity for the bypass user so a local preview can
 		// mirror the signed-in account it impersonates (DEV_AUTH_CLERK_ID

--- a/apps/web/src/pages/cli-authorize/page.tsx
+++ b/apps/web/src/pages/cli-authorize/page.tsx
@@ -1,22 +1,33 @@
 "use client";
 
+import type { DeviceLookupResponse } from "@clawdi/shared/api";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { AlertCircle, CheckCircle2, Clock, Terminal, XCircle } from "lucide-react";
 import { parseAsString, useQueryState } from "nuqs";
 import { Suspense, useState } from "react";
+import { type ApiErrorNormalizer, ApiErrorPanel } from "@/components/api-error-panel";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ApiError, unwrap, useApi } from "@/lib/api";
+import { isApiAuthError, normalizeApiError } from "@/lib/api-errors";
 
-interface DeviceLookup {
-	user_code: string;
-	client_label: string | null;
-	status: "pending" | "approved" | "denied" | "expired" | "consumed";
-	expires_at: string;
-}
+const CLI_AUTHORIZE_ERROR_NORMALIZER: ApiErrorNormalizer = {
+	isAuthError: isApiAuthError,
+	normalizeError: (error) => {
+		if (error instanceof ApiError) {
+			if (error.status === 404) {
+				return "We don't recognize this authorization code. It may have expired. Start over with `clawdi auth login`.";
+			}
+			if (error.status === 410) {
+				return "This authorization code has expired. Run `clawdi auth login` again to get a new one.";
+			}
+		}
+		return normalizeApiError(error);
+	},
+};
 
 // Keep the URL-state body under Suspense and preserve the existing loading shell.
 export default function CliAuthorizePage() {
@@ -46,12 +57,12 @@ function CliAuthorizeContent() {
 	const lookup = useQuery({
 		enabled: code.length > 0,
 		queryKey: ["cli-authorize", code],
-		queryFn: async (): Promise<DeviceLookup> =>
+		queryFn: async (): Promise<DeviceLookupResponse> =>
 			unwrap(
 				await api.GET("/v1/cli/auth/lookup", {
 					params: { query: { code } },
 				}),
-			) as DeviceLookup,
+			),
 	});
 
 	const approve = useMutation({
@@ -94,22 +105,13 @@ function CliAuthorizeContent() {
 	}
 
 	if (lookup.error) {
-		const status = lookup.error instanceof ApiError ? lookup.error.status : 0;
-		const message =
-			status === 404
-				? "We don't recognize this authorization code. It may have expired — start over with `clawdi auth login`."
-				: status === 410
-					? "This authorization code has expired. Run `clawdi auth login` again to get a new one."
-					: lookup.error instanceof Error
-						? lookup.error.message
-						: "Authorization request unavailable. Run `clawdi auth login` again.";
 		return (
 			<Shell>
-				<Alert variant="destructive">
-					<AlertCircle />
-					<AlertTitle>Authorization request unavailable</AlertTitle>
-					<AlertDescription>{message}</AlertDescription>
-				</Alert>
+				<ApiErrorPanel
+					error={lookup.error}
+					normalizer={CLI_AUTHORIZE_ERROR_NORMALIZER}
+					title="Authorization request unavailable"
+				/>
 			</Shell>
 		);
 	}
@@ -204,14 +206,7 @@ function CliAuthorizeContent() {
 					</div>
 
 					{(approve.error || deny.error) && (
-						<Alert variant="destructive">
-							<AlertCircle />
-							<AlertDescription>
-								{(approve.error || deny.error) instanceof Error
-									? (approve.error || deny.error)?.message
-									: "Action failed. Please retry."}
-							</AlertDescription>
-						</Alert>
+						<ApiErrorPanel error={approve.error || deny.error} title="Action failed" />
 					)}
 				</CardContent>
 			</Card>

--- a/apps/web/src/pages/public-share/session-export-route.test.ts
+++ b/apps/web/src/pages/public-share/session-export-route.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { publicSessionExportErrorMessage } from "./session-export-route";
+
+describe("public session export errors", () => {
+	test("maps known public access statuses without leaking backend details", () => {
+		expect(publicSessionExportErrorMessage(401)).toBe("Authentication required.");
+		expect(publicSessionExportErrorMessage(403)).toBe(
+			"You do not have access to this shared session.",
+		);
+		expect(publicSessionExportErrorMessage(404)).toBe("Not found");
+		expect(publicSessionExportErrorMessage(410)).toBe("This shared session link has expired.");
+	});
+
+	test("uses generic copy for internal and unknown errors", () => {
+		expect(publicSessionExportErrorMessage(500)).toBe(
+			"The service is having trouble right now. Please try again in a moment.",
+		);
+		expect(publicSessionExportErrorMessage(418)).toBe("Unable to export this shared session.");
+	});
+});

--- a/apps/web/src/pages/public-share/session-export-route.ts
+++ b/apps/web/src/pages/public-share/session-export-route.ts
@@ -31,6 +31,24 @@ const FORMAT_MEDIA_TYPE: Record<string, string> = {
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+export function publicSessionExportErrorMessage(status: number): string {
+	switch (status) {
+		case 401:
+			return "Authentication required.";
+		case 403:
+			return "You do not have access to this shared session.";
+		case 404:
+			return "Not found";
+		case 410:
+			return "This shared session link has expired.";
+		default:
+			if (status >= 500) {
+				return "The service is having trouble right now. Please try again in a moment.";
+			}
+			return "Unable to export this shared session.";
+	}
+}
+
 export async function GET(
 	_request: Request,
 	{ id, format }: { id: string; format: string },
@@ -57,7 +75,7 @@ export async function GET(
 				});
 
 	if (result.error !== undefined) {
-		return new Response(String(result.error), {
+		return new Response(publicSessionExportErrorMessage(result.response.status), {
 			status: result.response.status,
 			headers: { "content-type": "text/plain; charset=utf-8" },
 		});

--- a/packages/shared/src/api/schemas.ts
+++ b/packages/shared/src/api/schemas.ts
@@ -19,6 +19,7 @@ export type ApiKey = Schemas["ApiKeyResponse"];
 export type ApiKeyCreated = Schemas["ApiKeyCreated"];
 export type ApiKeyCreate = Schemas["ApiKeyCreate"];
 export type ApiKeyRevoked = Schemas["ApiKeyRevokeResponse"];
+export type DeviceLookupResponse = Schemas["DeviceLookupResponse"];
 
 // ── Dashboard ────────────────────────────────────────────────────────────
 export type DashboardStats = Schemas["DashboardStatsResponse"];


### PR DESCRIPTION
## Summary
- Disable the frontend dev-auth bypass whenever runtime/build env is production, with NODE_ENV=production treated as authoritative over MODE.
- Configure ClerkProvider with custom sign-in/sign-up URLs and fallback redirects matching the middleware custom pages.
- Normalize CLI authorization errors, sanitize public share export errors, and use the generated DeviceLookupResponse type.

## Verification
- bun run check
- bun run --cwd apps/web typecheck
- bun run --cwd apps/web test
- bun run --cwd apps/web e2e
- bun run --cwd apps/web build