### PR TITLE
Fix query cache invalidation

### DIFF
--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { QueryClient } from "@tanstack/react-query";
 import type { ComputeSubscriptionActionResult, HostedDeployment } from "@/hosted/billing/contracts";
-import { applyDeploymentSubscriptionResult, billingKeys } from "@/hosted/billing/hooks";
+import {
+	applyDeploymentSubscriptionResult,
+	billingKeys,
+	refreshCheckoutReturnQueries,
+} from "@/hosted/billing/hooks";
 
 function deployment(
 	computeSubscription: NonNullable<HostedDeployment["compute_subscription"]>,
@@ -60,5 +64,72 @@ describe("applyDeploymentSubscriptionResult", () => {
 		expect(patched?.[0]?.compute_subscription?.cancel_at_period_end).toBe(false);
 		expect(patched?.[0]?.compute_subscription?.cancel_at).toBeNull();
 		expect(qc.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(false);
+	});
+});
+
+describe("refreshCheckoutReturnQueries", () => {
+	test("forces deployments and wallet refetches even when cached data is fresh", async () => {
+		const qc = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+					staleTime: 30_000,
+				},
+			},
+		});
+		const beforeCheckout = deployment({
+			status: "active",
+			billing_term_months: 1,
+			price_cents: 2_000,
+			currency: "usd",
+			cancel_at_period_end: false,
+			current_period_end: "2026-07-01T00:00:00Z",
+			cancel_at: null,
+		});
+		const afterCheckout: HostedDeployment = {
+			...beforeCheckout,
+			name: "Performance agent after checkout",
+			compute_subscription: {
+				status: "active",
+				billing_term_months: 12,
+				price_cents: 20_000,
+				currency: "usd",
+				cancel_at_period_end: false,
+				current_period_end: "2027-07-01T00:00:00Z",
+				cancel_at: null,
+			},
+		};
+		const deploymentSnapshots: HostedDeployment[][] = [[beforeCheckout], [afterCheckout]];
+		const walletSnapshots = [{ balance_cents: 1_000 }, { balance_cents: 5_000 }];
+		let deploymentsCalls = 0;
+		let walletCalls = 0;
+
+		await qc.prefetchQuery({
+			queryKey: billingKeys.deployments,
+			queryFn: async () => {
+				deploymentsCalls += 1;
+				return deploymentSnapshots.shift() ?? [afterCheckout];
+			},
+		});
+		await qc.prefetchQuery({
+			queryKey: billingKeys.wallet,
+			queryFn: async () => {
+				walletCalls += 1;
+				return walletSnapshots.shift() ?? { balance_cents: 5_000 };
+			},
+		});
+		qc.setQueryData(billingKeys.plans, [{ id: "plan_before_checkout" }]);
+		qc.setQueryData(["agents"], [{ id: "agent_before_checkout" }]);
+
+		const result = await refreshCheckoutReturnQueries(qc);
+
+		expect(deploymentsCalls).toBe(2);
+		expect(walletCalls).toBe(2);
+		expect(result?.[0]?.name).toBe("Performance agent after checkout");
+		expect(qc.getQueryData<{ balance_cents: number }>(billingKeys.wallet)?.balance_cents).toBe(
+			5_000,
+		);
+		expect(qc.getQueryState(billingKeys.plans)?.isInvalidated).toBe(true);
+		expect(qc.getQueryState(["agents"])?.isInvalidated).toBe(true);
 	});
 });

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -244,17 +244,42 @@ export function useResumeSubscription() {
 }
 
 export function useCheckoutReturnRefresh() {
-	const client = useBillingClient();
 	const qc = useQueryClient();
-	return useCallback(async () => {
-		const [deploymentsResult] = await Promise.allSettled([
-			qc.fetchQuery({ queryKey: billingKeys.deployments, queryFn: () => client.listDeployments() }),
-			qc.fetchQuery({ queryKey: billingKeys.wallet, queryFn: () => client.getWallet() }),
-			qc.invalidateQueries({ queryKey: billingKeys.plans }),
-			qc.invalidateQueries({ queryKey: ["agents"] }),
-		]);
-		return deploymentsResult.status === "fulfilled" ? deploymentsResult.value : undefined;
-	}, [client, qc]);
+	return useCallback(() => refreshCheckoutReturnQueries(qc), [qc]);
+}
+
+export async function refreshCheckoutReturnQueries(
+	qc: QueryClient,
+): Promise<HostedDeployment[] | undefined> {
+	const [deploymentsResult] = await Promise.allSettled([
+		(async () => {
+			await qc.invalidateQueries({
+				queryKey: billingKeys.deployments,
+				exact: true,
+				refetchType: "none",
+			});
+			await qc.refetchQueries(
+				{ queryKey: billingKeys.deployments, exact: true, type: "all" },
+				{ throwOnError: true },
+			);
+		})(),
+		(async () => {
+			await qc.invalidateQueries({
+				queryKey: billingKeys.wallet,
+				exact: true,
+				refetchType: "none",
+			});
+			await qc.refetchQueries(
+				{ queryKey: billingKeys.wallet, exact: true, type: "all" },
+				{ throwOnError: true },
+			);
+		})(),
+		qc.invalidateQueries({ queryKey: billingKeys.plans }),
+		qc.invalidateQueries({ queryKey: ["agents"] }),
+	]);
+	return deploymentsResult.status === "fulfilled"
+		? qc.getQueryData<HostedDeployment[]>(billingKeys.deployments)
+		: undefined;
 }
 
 // ── Usage ────────────────────────────────────────────────────────────────────

--- a/apps/web/src/hosted/v2/channels/channel-query-cache.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-query-cache.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
+import { channelKeys, removeDeletedChannelQueries } from "@/hosted/v2/channels/channel-query-cache";
+
+describe("removeDeletedChannelQueries", () => {
+	test("removes deleted channel detail caches and invalidates related summaries", async () => {
+		const qc = new QueryClient();
+		const channelId = "channel_123";
+
+		qc.setQueryData(channelKeys.list, [{ id: channelId }]);
+		qc.setQueryData(channelKeys.pool, [{ id: "bot_1" }]);
+		qc.setQueryData(channelKeys.health, [{ account_id: channelId }]);
+		qc.setQueryData(channelKeys.channel(channelId), { id: channelId });
+		qc.setQueryData(["channel", channelId, "commands"], [{ id: "command_1" }]);
+		qc.setQueryData(channelKeys.agentLinks(channelId), [{ id: "link_1" }]);
+		qc.setQueryData(channelKeys.bindings(channelId), [{ id: "binding_1" }]);
+		qc.setQueryData(channelKeys.activity(channelId), [{ id: "activity_1" }]);
+		qc.setQueryData(channelKeys.whatsappCreds(channelId), [{ id: "credential_1" }]);
+		qc.setQueryData(channelKeys.channel("channel_other"), { id: "channel_other" });
+		qc.setQueryData(["agent-channel-links", "agent_1"], [{ account_id: channelId }]);
+
+		await removeDeletedChannelQueries(qc, channelId);
+
+		expect(qc.getQueryData(channelKeys.channel(channelId))).toBeUndefined();
+		expect(qc.getQueryData(["channel", channelId, "commands"])).toBeUndefined();
+		expect(qc.getQueryData(channelKeys.agentLinks(channelId))).toBeUndefined();
+		expect(qc.getQueryData(channelKeys.bindings(channelId))).toBeUndefined();
+		expect(qc.getQueryData(channelKeys.activity(channelId))).toBeUndefined();
+		expect(qc.getQueryData(channelKeys.whatsappCreds(channelId))).toBeUndefined();
+		expect(qc.getQueryData<{ id: string }>(channelKeys.channel("channel_other"))).toEqual({
+			id: "channel_other",
+		});
+		expect(qc.getQueryState(channelKeys.list)?.isInvalidated).toBe(true);
+		expect(qc.getQueryState(channelKeys.pool)?.isInvalidated).toBe(true);
+		expect(qc.getQueryState(channelKeys.health)?.isInvalidated).toBe(true);
+		expect(qc.getQueryState(["agent-channel-links", "agent_1"])?.isInvalidated).toBe(true);
+	});
+});

--- a/apps/web/src/hosted/v2/channels/channel-query-cache.ts
+++ b/apps/web/src/hosted/v2/channels/channel-query-cache.ts
@@ -1,0 +1,30 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+export const channelKeys = {
+	list: ["channels"] as const,
+	pool: ["channel-bot-pool"] as const,
+	health: ["channel-health"] as const,
+	channel: (id: string) => ["channel", id] as const,
+	agentLinks: (id: string) => ["channel-agent-links", id] as const,
+	bindings: (id: string) => ["channel-bindings", id] as const,
+	activity: (id: string) => ["channel-activity", id] as const,
+	whatsappCreds: (id: string) => ["whatsapp-tenant-creds", id] as const,
+};
+
+export async function removeDeletedChannelQueries(
+	qc: QueryClient,
+	channelId: string,
+): Promise<void> {
+	qc.removeQueries({ queryKey: channelKeys.channel(channelId) });
+	qc.removeQueries({ queryKey: channelKeys.agentLinks(channelId) });
+	qc.removeQueries({ queryKey: channelKeys.bindings(channelId) });
+	qc.removeQueries({ queryKey: channelKeys.activity(channelId) });
+	qc.removeQueries({ queryKey: channelKeys.whatsappCreds(channelId) });
+
+	await Promise.all([
+		qc.invalidateQueries({ queryKey: channelKeys.list }),
+		qc.invalidateQueries({ queryKey: channelKeys.pool }),
+		qc.invalidateQueries({ queryKey: channelKeys.health }),
+		qc.invalidateQueries({ queryKey: ["agent-channel-links"] }),
+	]);
+}

--- a/apps/web/src/hosted/v2/channels/channels-hooks.ts
+++ b/apps/web/src/hosted/v2/channels/channels-hooks.ts
@@ -3,6 +3,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useChannelEditApi } from "@/hosted/v2/channels/channel-edit-client";
+import {
+	channelKeys as keys,
+	removeDeletedChannelQueries,
+} from "@/hosted/v2/channels/channel-query-cache";
 import type { ChannelCreate } from "@/hosted/v2/channels/channel-types";
 import { toastApiError, unwrap, useApi } from "@/lib/api";
 
@@ -12,17 +16,6 @@ import { toastApiError, unwrap, useApi } from "@/lib/api";
  * `/v1/channels/*`; mutations invalidate the affected queries and surface
  * recoverable errors as toasts.
  */
-
-const keys = {
-	list: ["channels"] as const,
-	pool: ["channel-bot-pool"] as const,
-	health: ["channel-health"] as const,
-	channel: (id: string) => ["channel", id] as const,
-	agentLinks: (id: string) => ["channel-agent-links", id] as const,
-	bindings: (id: string) => ["channel-bindings", id] as const,
-	activity: (id: string) => ["channel-activity", id] as const,
-	whatsappCreds: (id: string) => ["whatsapp-tenant-creds", id] as const,
-};
 
 export function useChannels() {
 	const api = useApi();
@@ -137,10 +130,8 @@ export function useDeleteChannel() {
 					params: { path: { account_id: id } },
 				}),
 			),
-		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: keys.list });
-			qc.invalidateQueries({ queryKey: keys.pool });
-			qc.invalidateQueries({ queryKey: keys.health });
+		onSuccess: async (_data, id) => {
+			await removeDeletedChannelQueries(qc, id);
 			toast.success("Channel removed");
 		},
 		onError: toastApiError("Couldn't remove channel"),

--- a/apps/web/src/lib/connectors-data.ts
+++ b/apps/web/src/lib/connectors-data.ts
@@ -83,6 +83,7 @@ export function connectionsQueryOptions(api: ApiClient) {
 	return {
 		queryKey: ["connections"] as const,
 		queryFn: async () => unwrap(await api.GET("/v1/connectors")),
+		refetchOnWindowFocus: "always" as const,
 	};
 }
 
@@ -155,7 +156,6 @@ export function useAuthFields(appName: string, { enabled }: { enabled: boolean }
 
 export function useConnect() {
 	const api = useApi();
-	const qc = useQueryClient();
 	return useMutation({
 		mutationFn: async ({ appName, redirectUrl }: { appName: string; redirectUrl?: string }) =>
 			unwrap(
@@ -164,7 +164,6 @@ export function useConnect() {
 					body: redirectUrl ? { redirect_url: redirectUrl } : {},
 				}),
 			),
-		onSuccess: () => qc.invalidateQueries({ queryKey: ["connections"] }),
 	});
 }
 

--- a/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
+++ b/apps/web/src/pages/dashboard/connectors/[name]/page.tsx
@@ -99,8 +99,9 @@ function ConnectorDetail({ name }: { name: string }) {
 	// programmatic and block them) and points it at the OAuth URL once
 	// the backend responds. The popup eventually lands on this same
 	// detail page via the `redirect_url` we send to Composio; React
-	// Query's window-focus refetch picks up the new ACTIVE connection
-	// when the user returns to this tab. No polling loop needed.
+	// Query's per-connection window-focus refetch always checks for the
+	// new ACTIVE connection when the user returns to this tab. No polling
+	// loop needed.
 	const connectMutation = useConnect();
 
 	// Per-row disconnect single-flight guard.
@@ -215,8 +216,8 @@ function ConnectorDetail({ name }: { name: string }) {
 		// Send our detail page URL as `redirect_url` so Composio sends the
 		// user back here after OAuth instead of its default callback.
 		// Lets us drop a polling loop — the popup eventually navigates
-		// back to our origin and React Query's window-focus refetch
-		// reflects the new ACTIVE connection.
+		// back to our origin and the connections query force-refetches on
+		// window focus to reflect the new ACTIVE connection.
 		const redirectUrl = window.location.href;
 		connectMutation.mutate(
 			{ appName: name, redirectUrl },

--- a/apps/web/src/pages/dashboard/skills/[key]/page.tsx
+++ b/apps/web/src/pages/dashboard/skills/[key]/page.tsx
@@ -44,6 +44,11 @@ import { ApiError, unwrap, useApi } from "@/lib/api";
 import { isApiNotFoundError } from "@/lib/api-errors";
 import { decodeResourceRouteParam, projectResourceHref } from "@/lib/project-resource-model";
 import { cn, errorMessage, relativeTime } from "@/lib/utils";
+import {
+	removeDeletedSkillQueries,
+	skillDetailQueryKey,
+	skillDetailQueryPrefix,
+} from "@/pages/dashboard/skills/skill-query-cache";
 
 // Strip the leading `---\n...\n---` YAML frontmatter so the markdown
 // renderer doesn't show "name:" / "description:" lines (already
@@ -101,7 +106,7 @@ export function SkillDetailContent({
 		error,
 		refetch,
 	} = useQuery({
-		queryKey: ["skill", skillKey, selectedProjectId],
+		queryKey: skillDetailQueryKey(skillKey, selectedProjectId),
 		// An empty key would interpolate to `GET /v1/skills/`, which the
 		// backend's `{skill_key:path}` catch-all rejects with a 422.
 		// Nothing useful can load without a key, so don't fire at all.
@@ -237,7 +242,7 @@ export function SkillDetailContent({
 			setIsEditing(false);
 			setDraft("");
 			setEditingHash(null);
-			queryClient.invalidateQueries({ queryKey: ["skill", skillKey] });
+			queryClient.invalidateQueries({ queryKey: skillDetailQueryPrefix(skillKey) });
 			queryClient.invalidateQueries({ queryKey: ["skills"] });
 		},
 		onError: (e) => {
@@ -252,7 +257,7 @@ export function SkillDetailContent({
 					description:
 						"Another edit landed while you were typing. Reload to see the latest, then re-apply your change.",
 				});
-				queryClient.invalidateQueries({ queryKey: ["skill", skillKey] });
+				queryClient.invalidateQueries({ queryKey: skillDetailQueryPrefix(skillKey) });
 				return;
 			}
 			toast.error("Couldn't save skill", { description: errorMessage(e) });
@@ -268,13 +273,13 @@ export function SkillDetailContent({
 				}),
 			);
 		},
-		onSuccess: () => {
+		onSuccess: async () => {
 			toast.success("Skill Uninstalled", {
 				description: skillAgentLabel
 					? `Removed from ${skillAgentLabel}. Other agents keep their copies.`
 					: "Removed from this agent. Other agents keep their copies.",
 			});
-			queryClient.invalidateQueries({ queryKey: ["skills"] });
+			await removeDeletedSkillQueries(queryClient, skillKey);
 			void router.navigate({ href: skillListHref });
 		},
 		onError: (e) => toast.error("Couldn't uninstall skill", { description: errorMessage(e) }),

--- a/apps/web/src/pages/dashboard/skills/skill-query-cache.test.ts
+++ b/apps/web/src/pages/dashboard/skills/skill-query-cache.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
+import {
+	removeDeletedSkillQueries,
+	skillDetailQueryKey,
+	skillDetailQueryPrefix,
+} from "@/pages/dashboard/skills/skill-query-cache";
+
+describe("removeDeletedSkillQueries", () => {
+	test("removes deleted skill detail queries by prefix and invalidates skill lists", async () => {
+		const qc = new QueryClient();
+		const skillKey = "review/code";
+
+		qc.setQueryData(skillDetailQueryKey(skillKey, "project_a"), { key: skillKey });
+		qc.setQueryData(skillDetailQueryKey(skillKey, "project_b"), { key: skillKey });
+		qc.setQueryData(skillDetailQueryKey("other/skill", "project_a"), { key: "other/skill" });
+		qc.setQueryData(["skills"], [{ key: skillKey }]);
+		qc.setQueryData(["skills", "all-projects"], [{ key: skillKey }]);
+
+		await removeDeletedSkillQueries(qc, skillKey);
+
+		expect(qc.getQueryData(skillDetailQueryKey(skillKey, "project_a"))).toBeUndefined();
+		expect(qc.getQueryData(skillDetailQueryKey(skillKey, "project_b"))).toBeUndefined();
+		expect(qc.getQueryData(skillDetailQueryPrefix(skillKey))).toBeUndefined();
+		expect(
+			qc.getQueryData<{ key: string }>(skillDetailQueryKey("other/skill", "project_a")),
+		).toEqual({
+			key: "other/skill",
+		});
+		expect(qc.getQueryState(["skills"])?.isInvalidated).toBe(true);
+		expect(qc.getQueryState(["skills", "all-projects"])?.isInvalidated).toBe(true);
+	});
+});

--- a/apps/web/src/pages/dashboard/skills/skill-query-cache.ts
+++ b/apps/web/src/pages/dashboard/skills/skill-query-cache.ts
@@ -1,0 +1,17 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+export function skillDetailQueryKey(skillKey: string, selectedProjectId: string) {
+	return ["skill", skillKey, selectedProjectId] as const;
+}
+
+export function skillDetailQueryPrefix(skillKey: string) {
+	return ["skill", skillKey] as const;
+}
+
+export async function removeDeletedSkillQueries(
+	queryClient: QueryClient,
+	skillKey: string,
+): Promise<void> {
+	queryClient.removeQueries({ queryKey: skillDetailQueryPrefix(skillKey) });
+	await queryClient.invalidateQueries({ queryKey: ["skills"] });
+}


### PR DESCRIPTION
## Summary
- Stop treating connector OAuth start as connection completion; the connections query now refetches on every window focus so returning from OAuth bypasses the global 30s stale window.
- Replace checkout-return fetchQuery calls with explicit invalidation plus refetchQueries so cached fresh deployments/wallet data is not reused after payment/SCA return.
- Remove deleted channel detail/related caches and invalidate shared channel and agent-link summaries.
- Remove deleted skill detail caches by the skill detail prefix and invalidate skill lists.

## TanStack Query grounding
- fetchQuery can return cached data when it is not invalidated or older than staleTime: https://github.com/TanStack/query/blob/main/docs/reference/QueryClient.md
- refetchQueries explicitly refetches matching queries and supports exact/prefix key filters: https://github.com/TanStack/query/blob/main/docs/reference/QueryClient.md
- invalidateQueries and query filters support prefix matching; removeQueries removes matching cached entries: https://github.com/TanStack/query/blob/main/docs/framework/react/guides/query-invalidation.md and https://github.com/TanStack/query/blob/main/docs/framework/react/guides/filters.md#query-filters

## Verification
- bun run check
- bun run --cwd apps/web typecheck
- bun run --cwd apps/web test
- bun run --cwd apps/web e2e
- bun run --cwd apps/web build