### PR TITLE
fix(web): restore base-ui orientation custom variants + refresh AI provider form

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -34,6 +34,8 @@ async function stubHostedApi(page: Page) {
 		if (p === "/v1/agents") return fulfillJson(r, []);
 		if (p === "/v1/ai-providers") return fulfillJson(r, []);
 		if (p === "/v1/channels") return fulfillJson(r, []);
+		if (p === "/v1/channels/bot-pool") return fulfillJson(r, { providers: {} });
+		if (p === "/v1/channels/health") return fulfillJson(r, { items: [] });
 		if (p === "/v1/projects") return fulfillJson(r, []);
 		if (p === "/v1/sessions") return fulfillJson(r, emptyPage);
 		if (p === "/v1/auth/keys") return fulfillJson(r, []);
@@ -58,6 +60,13 @@ function collectBrowserErrors(page: Page): string[] {
 		if (!isIgnorableWarning(e.message)) errors.push(e.message);
 	});
 	return errors;
+}
+
+async function expectNonZeroBox(locator: ReturnType<Page["locator"]>, label: string) {
+	const box = await locator.boundingBox();
+	expect(box, `${label} should render a layout box`).not.toBeNull();
+	expect(box?.width, `${label} width`).toBeGreaterThan(0);
+	expect(box?.height, `${label} height`).toBeGreaterThan(0);
 }
 
 test("deploy wizard Select opens without browser errors", async ({ page }) => {
@@ -88,6 +97,11 @@ test("channels connect dialog opens without browser errors", async ({ page }) =>
 	await expect(connect).toBeVisible();
 	await page.waitForTimeout(150);
 	expect(errors, `channels render: ${errors.join(" | ")}`).toEqual([]);
+
+	await expect(page.locator('[data-slot="tabs-list"]')).toHaveCount(0);
+	await expect(page.getByText("Your channels").first()).toBeVisible();
+	await expect(page.getByText("Shared bots").first()).toBeVisible();
+	await expectNonZeroBox(page.locator('[data-sidebar="separator"]').first(), "sidebar separator");
 
 	// Open the Base UI Dialog + interact with its provider picker.
 	await connect.click();

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -88,6 +88,19 @@ test("deploy wizard Select opens without browser errors", async ({ page }) => {
 	expect(errors, `language select: ${errors.join(" | ")}`).toEqual([]);
 });
 
+test("command palette opens with Ctrl+K", async ({ page }) => {
+	const errors = collectBrowserErrors(page);
+	await stubHostedApi(page);
+	await page.goto("/channels");
+	await expect(page.getByTestId("app-sidebar")).toBeVisible();
+	await page.waitForLoadState("networkidle");
+
+	await page.keyboard.press("Control+K");
+	await expect(page.locator('[data-slot="command"]')).toBeVisible();
+	await page.waitForTimeout(150);
+	expect(errors, `command palette: ${errors.join(" | ")}`).toEqual([]);
+});
+
 test("channels connect dialog opens without browser errors", async ({ page }) => {
 	const errors = collectBrowserErrors(page);
 	await stubHostedApi(page);

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -131,13 +131,13 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
 		// the user is typing in a form field other than our own search input;
 		// cmdk already grabs focus inside the dialog so we just need to open it.
 		const handler = (e: KeyboardEvent) => {
-			if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+			if (e.key.toLowerCase() === "k" && (e.metaKey || e.ctrlKey)) {
 				e.preventDefault();
 				setOpenInternal((prev) => !prev);
 			}
 		};
-		window.addEventListener("keydown", handler);
-		return () => window.removeEventListener("keydown", handler);
+		document.addEventListener("keydown", handler, true);
+		return () => document.removeEventListener("keydown", handler, true);
 	}, []);
 
 	const value = useMemo(() => ({ open, setOpen }), [open, setOpen]);

--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -152,47 +152,50 @@ export function SettingsDialog({
 								<div className="truncate text-xs text-muted-foreground">Clawdi preferences</div>
 							</div>
 						</div>
-						<nav
-							aria-label="Settings sections"
-							className="flex gap-1 overflow-x-auto px-2 pb-2 md:min-h-0 md:flex-1 md:flex-col md:overflow-y-auto md:px-3 md:pb-3"
-						>
-							{items.map((item) => {
-								const Icon = item.icon;
-								const active = activeSection === item.id;
-								return (
-									<Button
-										key={item.id}
-										ref={active ? activeButtonRef : undefined}
-										type="button"
-										variant="ghost"
-										aria-current={active ? "page" : undefined}
-										data-active={active}
-										onClick={() => onSectionChange(item.id)}
-										className={cn(
-											"h-auto min-w-44 shrink-0 justify-start gap-3 whitespace-normal rounded-md px-3 py-2 text-left text-sm text-muted-foreground hover:bg-background/70 hover:text-foreground md:min-w-0",
-											"data-[active=true]:bg-background data-[active=true]:text-foreground data-[active=true]:shadow-xs",
-										)}
-									>
-										<IconChip
-											size="sm"
-											tint={
-												active
-													? "bg-primary text-primary-foreground"
-													: "bg-background text-foreground"
-											}
+						<div className="relative min-w-0 md:min-h-0 md:flex-1">
+							<nav
+								aria-label="Settings sections"
+								className="flex gap-1 overflow-x-auto px-3 pb-3 [scrollbar-width:thin] md:min-h-0 md:flex-1 md:flex-col md:overflow-y-auto md:px-3 md:pb-3"
+							>
+								{items.map((item) => {
+									const Icon = item.icon;
+									const active = activeSection === item.id;
+									return (
+										<Button
+											key={item.id}
+											ref={active ? activeButtonRef : undefined}
+											type="button"
+											variant="ghost"
+											aria-current={active ? "page" : undefined}
+											data-active={active}
+											onClick={() => onSectionChange(item.id)}
+											className={cn(
+												"h-auto min-w-28 shrink-0 justify-start gap-2 rounded-md px-2.5 py-2 text-left text-sm text-muted-foreground hover:bg-background/70 hover:text-foreground md:min-w-0 md:gap-3 md:px-3",
+												"data-[active=true]:bg-background data-[active=true]:text-foreground data-[active=true]:shadow-xs",
+											)}
 										>
-											<Icon />
-										</IconChip>
-										<span className="grid min-w-0 flex-1 leading-tight">
-											<span className="truncate font-medium">{item.label}</span>
-											<span className="truncate text-xs text-muted-foreground">
-												{item.description}
+											<IconChip
+												size="sm"
+												tint={
+													active
+														? "bg-primary text-primary-foreground"
+														: "bg-background text-foreground"
+												}
+											>
+												<Icon />
+											</IconChip>
+											<span className="grid min-w-0 flex-1 leading-tight">
+												<span className="truncate font-medium">{item.label}</span>
+												<span className="hidden truncate text-xs text-muted-foreground md:block">
+													{item.description}
+												</span>
 											</span>
-										</span>
-									</Button>
-								);
-							})}
-						</nav>
+										</Button>
+									);
+								})}
+							</nav>
+							<div className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-linear-to-l from-muted/30 to-transparent md:hidden" />
+						</div>
 					</aside>
 
 					<section className="min-h-0 overflow-y-auto py-6 md:py-8">

--- a/apps/web/src/components/settings/api-keys-panel.tsx
+++ b/apps/web/src/components/settings/api-keys-panel.tsx
@@ -12,6 +12,7 @@ import { ConfirmAction } from "@/components/ui/confirm-action";
 import { DataTable } from "@/components/ui/data-table";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
 import { type ApiError, unwrap, useApi } from "@/lib/api";
 import type { ApiKey } from "@/lib/api-schemas";
 
@@ -154,7 +155,7 @@ export function ApiKeysPanel() {
 
 			{/* Create form */}
 			<form
-				className="flex gap-2"
+				className="flex flex-col gap-2 sm:flex-row"
 				onSubmit={(e) => {
 					e.preventDefault();
 					if (newLabel) createKey.mutate(newLabel);
@@ -168,11 +169,15 @@ export function ApiKeysPanel() {
 					value={newLabel}
 					onChange={(e) => setNewLabel(e.target.value)}
 					placeholder="my-laptop…"
-					className="flex-1"
+					className="min-w-0 flex-1"
 					name="new-key-label"
 					autoComplete="off"
 				/>
-				<Button type="submit" disabled={!newLabel || createKey.isPending}>
+				<Button
+					type="submit"
+					disabled={!newLabel || createKey.isPending}
+					className="w-full sm:w-auto"
+				>
 					<Plus />
 					Create
 				</Button>
@@ -184,7 +189,7 @@ export function ApiKeysPanel() {
 					<div className="text-sm font-medium text-primary">
 						Key created — copy it now, it won't be shown again.
 					</div>
-					<div className="flex items-center gap-2">
+					<div className="flex flex-col gap-2 sm:flex-row sm:items-center">
 						<code className="flex-1 break-all rounded bg-muted px-3 py-2 font-mono text-xs">
 							{createdKey}
 						</code>
@@ -206,12 +211,104 @@ export function ApiKeysPanel() {
 				</div>
 			) : null}
 
+			<div className="md:hidden">
+				<ApiKeysMobileList
+					keys={keys ?? []}
+					isLoading={isLoading}
+					isRevoking={revokeKey.isPending}
+					onRevoke={(keyId) => revokeKey.mutate(keyId)}
+				/>
+			</div>
 			<DataTable
 				columns={columns}
 				data={keys ?? []}
 				isLoading={isLoading}
 				emptyMessage="No API keys yet."
+				className="hidden md:block"
 			/>
+		</div>
+	);
+}
+
+function ApiKeysMobileList({
+	keys,
+	isLoading,
+	isRevoking,
+	onRevoke,
+}: {
+	keys: ApiKey[];
+	isLoading: boolean;
+	isRevoking: boolean;
+	onRevoke: (keyId: string) => void;
+}) {
+	if (isLoading) {
+		return (
+			<div className="flex flex-col gap-2">
+				{[0, 1, 2].map((i) => (
+					<div key={i} className="rounded-lg border bg-card p-3">
+						<Skeleton className="h-4 w-32" />
+						<Skeleton className="mt-2 h-3 w-24" />
+					</div>
+				))}
+			</div>
+		);
+	}
+
+	if (keys.length === 0) {
+		return (
+			<div className="rounded-lg border bg-card px-4 py-8 text-center text-sm text-muted-foreground">
+				No API keys yet.
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-2">
+			{keys.map((key) => (
+				<div key={key.id} className="rounded-lg border bg-card p-3">
+					<div className="flex min-w-0 items-start justify-between gap-3">
+						<div className="min-w-0">
+							<div className="flex min-w-0 flex-wrap items-center gap-2">
+								<span className="break-words text-sm font-medium">{key.label}</span>
+								{key.revoked_at ? <Badge variant="destructive">Off</Badge> : null}
+							</div>
+							<div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+								<span className="font-mono">{key.key_prefix}…</span>
+								<span>Created {new Date(key.created_at).toLocaleDateString()}</span>
+								<span>
+									Last used{" "}
+									{key.last_used_at ? new Date(key.last_used_at).toLocaleDateString() : "—"}
+								</span>
+							</div>
+						</div>
+						{key.revoked_at ? null : (
+							<ConfirmAction
+								title={`Turn off ${key.label}?`}
+								description={
+									<p>
+										If a machine is still using this key, sync will stop within a minute. Sign in
+										again from that machine to resume.
+									</p>
+								}
+								confirmLabel="Turn Off Key"
+								destructive
+								onConfirm={() => onRevoke(key.id)}
+							>
+								<Button
+									type="button"
+									variant="ghost"
+									size="icon-sm"
+									disabled={isRevoking}
+									aria-label="Turn off key"
+									className="shrink-0 text-muted-foreground hover:text-destructive"
+								>
+									<Trash2 className="size-3.5" />
+								</Button>
+							</ConfirmAction>
+						)}
+					</div>
+				</div>
+			))}
 		</div>
 	);
 }

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -558,258 +558,268 @@ export function DeployWizard() {
 
 	return (
 		<div data-hosted="true" data-v2="true" className={DEPLOY_PAGE_CLASS}>
-			<PageHeader
-				title="Deploy an Agent"
-				description="Codex is included by default. Add optional runtimes and choose the AI provider for this hosted deployment."
-			/>
+			<div className="flex flex-col gap-6 sm:pb-24">
+				<PageHeader
+					title="Deploy an Agent"
+					description="Codex is included by default. Add optional runtimes and choose the AI provider for this hosted deployment."
+				/>
 
-			<SettingsSection
-				title="Runtimes"
-				description={
-					dualAllowed
-						? "Codex stays on. Performance can also run OpenClaw and Hermes together."
-						: "Codex stays on. Free can add one optional runtime."
-				}
-			>
-				<div className={THREE_TILE_GRID_CLASS}>
-					<EntityChoiceCard
-						selected
-						icon={<EntityIcon kind="framework" id="codex" label={runtimeDisplayName("codex")} />}
-						title={runtimeDisplayName("codex")}
-						description={runtimeBlurb("codex")}
-						badge={<Badge variant="outline">Always on</Badge>}
-					/>
-					<EntityChoiceCard
-						selected={engines.openclaw}
-						onClick={() => toggleEngine("openclaw")}
-						icon={
-							<EntityIcon kind="framework" id="openclaw" label={runtimeDisplayName("openclaw")} />
-						}
-						title={runtimeDisplayName("openclaw")}
-						description={runtimeBlurb("openclaw")}
-					/>
-					<EntityChoiceCard
-						selected={engines.hermes}
-						onClick={() => toggleEngine("hermes")}
-						icon={<EntityIcon kind="framework" id="hermes" label={runtimeDisplayName("hermes")} />}
-						title={runtimeDisplayName("hermes")}
-						description={runtimeBlurb("hermes")}
-					/>
-				</div>
-			</SettingsSection>
-
-			<SettingsSection
-				title="AI provider"
-				description="Managed AI bills your wallet, or route through one of your own providers."
-			>
-				<div className={TWO_TILE_GRID_CLASS}>
-					<EntityChoiceCard
-						selected={aiChoice === MANAGED_AI_CHOICE}
-						onClick={() => setAiChoice(MANAGED_AI_CHOICE)}
-						icon={
-							<IconChip tint="bg-primary/10 text-primary">
-								<Sparkles />
-							</IconChip>
-						}
-						title="Managed by Clawdi"
-						description="AI Credits from your wallet."
-						badge={<Badge variant="secondary">Default</Badge>}
-					/>
-					{aiProviders.isLoading ? (
-						<Skeleton className="h-[74px] w-full rounded-lg" />
-					) : aiProviders.error ? (
-						<div className="sm:col-span-2">
-							<ApiErrorPanel
-								title="Couldn't load providers"
-								error={aiProviders.error}
-								onRetry={() => aiProviders.refetch()}
-								normalizer={aiProviderErrorNormalizer}
-							/>
-						</div>
-					) : null}
-					{providerList.map((provider) => (
+				<SettingsSection
+					title="Runtimes"
+					description={
+						dualAllowed
+							? "Codex stays on. Performance can also run OpenClaw and Hermes together."
+							: "Codex stays on. Free can add one optional runtime."
+					}
+				>
+					<div className={THREE_TILE_GRID_CLASS}>
 						<EntityChoiceCard
-							key={provider.provider_id}
-							selected={aiChoice === provider.provider_id}
-							onClick={() => setAiChoice(provider.provider_id)}
-							icon={<ProviderTypeChip type={provider.type} />}
-							title={provider.label ?? provider.provider_id}
-							description={provider.default_model ?? providerTypeLabelFallback(provider)}
-							badge={<AuthBadge auth={provider.auth} />}
-						/>
-					))}
-					<AddTile
-						title="Add a provider"
-						description="Connect OpenAI, Anthropic, or another endpoint."
-						onClick={() => setAddProviderOpen(true)}
-					/>
-				</div>
-			</SettingsSection>
-
-			<SettingsSection
-				title={
-					<>
-						Channels <span className="font-normal text-muted-foreground">· optional</span>
-					</>
-				}
-				description="Prepare a bot now, then link it from the agent page once deployment finishes."
-			>
-				<div className={TWO_TILE_GRID_CLASS}>
-					<EntityChoiceCard
-						selected
-						icon={
-							<IconChip tint="bg-muted text-muted-foreground">
-								<CalendarClock />
-							</IconChip>
-						}
-						title="Link after deploy"
-						description="Channel links need the agent identity created during provisioning."
-						badge={<Badge variant="secondary">Default</Badge>}
-					/>
-					{channels.isLoading ? <Skeleton className="h-[74px] w-full rounded-lg" /> : null}
-					{channels.error ? (
-						<div className="flex min-h-[74px] flex-col items-start justify-center gap-2 rounded-lg border bg-muted/30 p-3 text-xs text-muted-foreground sm:col-span-2">
-							<p>Couldn’t load your channels. You can still deploy and link later.</p>
-							<Button size="sm" variant="outline" onClick={() => channels.refetch()}>
-								<RefreshCw /> Retry
-							</Button>
-						</div>
-					) : (
-						channelList.map((channel) => <ChannelInfoTile key={channel.id} channel={channel} />)
-					)}
-					<AddTile
-						title="Connect a channel"
-						description="Prepare a bot; link it after provisioning."
-						onClick={() => setConnectChannelOpen(true)}
-					/>
-				</div>
-			</SettingsSection>
-
-			<SettingsSection
-				title="Compute"
-				description="Free gives one active hosted deployment. Performance is billed per deployment and can run both optional runtimes."
-			>
-				<div className="flex flex-col gap-3">
-					<div className="grid gap-2 sm:grid-cols-2">
-						<EntityChoiceCard
-							selected={compute === "free"}
-							onClick={!freeSlotUnavailable ? () => setComputeTier("free") : undefined}
-							icon={
-								<IconChip tint="bg-identity-3-bg text-identity-3-fg">
-									<Cpu />
-								</IconChip>
-							}
-							title="Free"
-							description={
-								freeSlotUsed
-									? "Free slot already in use"
-									: freeSlotPending
-										? "Checking Free slot…"
-										: deployments.error
-											? "Free slot check unavailable"
-											: freePlan
-												? `${freePlan.vcpu} vCPU / ${freePlan.ram_gb} GB burst · one active deployment`
-												: "$0 · Codex included"
-							}
-							badge={<Badge variant="secondary">$0</Badge>}
-							disabled={freeSlotUnavailable}
+							selected
+							icon={<EntityIcon kind="framework" id="codex" label={runtimeDisplayName("codex")} />}
+							title={runtimeDisplayName("codex")}
+							description={runtimeBlurb("codex")}
+							badge={<Badge variant="outline">Always on</Badge>}
 						/>
 						<EntityChoiceCard
-							selected={compute === "performance"}
-							onClick={perfPlan ? () => setComputeTier("performance") : undefined}
+							selected={engines.openclaw}
+							onClick={() => toggleEngine("openclaw")}
 							icon={
-								<IconChip tint="bg-identity-8-bg text-identity-8-fg">
-									<Zap />
-								</IconChip>
+								<EntityIcon kind="framework" id="openclaw" label={runtimeDisplayName("openclaw")} />
 							}
-							title="Performance"
-							description={
-								perfPlan
-									? `${perfPlan.vcpu} vCPU / ${perfPlan.ram_gb} GB · per-agent subscription`
-									: "Performance plan unavailable"
+							title={runtimeDisplayName("openclaw")}
+							description={runtimeBlurb("openclaw")}
+						/>
+						<EntityChoiceCard
+							selected={engines.hermes}
+							onClick={() => toggleEngine("hermes")}
+							icon={
+								<EntityIcon kind="framework" id="hermes" label={runtimeDisplayName("hermes")} />
 							}
-							badge={
-								<Badge>
-									{perfOffer
-										? `${formatCentsCompact(perfOffer.effective_monthly_price_cents)}/mo`
-										: perfPlan
-											? `${formatCentsCompact(perfPlan.price_cents)}/mo`
-											: "Unavailable"}
-								</Badge>
-							}
-							disabled={!perfPlan}
+							title={runtimeDisplayName("hermes")}
+							description={runtimeBlurb("hermes")}
 						/>
 					</div>
-					{compute === "performance" && perfOffers.length > 1 ? (
-						<div className="flex flex-col gap-2">
-							<TermSwitcher offers={perfOffers} value={perfBillingTermMonths} onChange={setTerm} />
-						</div>
-					) : null}
-					<ComputeStatusLine
-						compute={compute}
-						freeSlotPending={freeSlotPending}
-						freeSlotUsed={freeSlotUsed}
-						deploymentsError={deployments.error}
-						freePlan={freePlan}
-						perfOffer={perfOffer}
-					/>
-				</div>
-			</SettingsSection>
+				</SettingsSection>
 
-			<SettingsSection
-				title={
-					<>
-						Personalize <span className="font-normal text-muted-foreground">· optional</span>
-					</>
-				}
-				description="Choose the agent's language and timezone."
-			>
-				<div className="flex max-w-2xl flex-col gap-4">
-					<div className="grid gap-4 sm:grid-cols-2">
-						<div className="flex flex-col gap-1.5">
-							<label htmlFor="agent-language" className="text-sm text-muted-foreground">
-								Language
-							</label>
-							<Select
-								value={language || "default"}
-								onValueChange={(v) => {
-									setLanguage(v === null || v === "default" ? "" : v);
-								}}
-							>
-								<SelectTrigger id="agent-language">
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									<SelectItem value="default">Default</SelectItem>
-									{LANGUAGE_OPTIONS.map((l) => (
-										<SelectItem key={l.code} value={l.code}>
-											{l.label}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
-						</div>
+				<SettingsSection
+					title="AI provider"
+					description="Managed AI bills your wallet, or route through one of your own providers."
+				>
+					<div className={TWO_TILE_GRID_CLASS}>
+						<EntityChoiceCard
+							selected={aiChoice === MANAGED_AI_CHOICE}
+							onClick={() => setAiChoice(MANAGED_AI_CHOICE)}
+							icon={
+								<IconChip tint="bg-primary/10 text-primary">
+									<Sparkles />
+								</IconChip>
+							}
+							title="Managed by Clawdi"
+							description="AI Credits from your wallet."
+							badge={<Badge variant="secondary">Default</Badge>}
+						/>
+						{aiProviders.isLoading ? (
+							<Skeleton className="h-[74px] w-full rounded-lg" />
+						) : aiProviders.error ? (
+							<div className="sm:col-span-2">
+								<ApiErrorPanel
+									title="Couldn't load providers"
+									error={aiProviders.error}
+									onRetry={() => aiProviders.refetch()}
+									normalizer={aiProviderErrorNormalizer}
+								/>
+							</div>
+						) : null}
+						{providerList.map((provider) => (
+							<EntityChoiceCard
+								key={provider.provider_id}
+								selected={aiChoice === provider.provider_id}
+								onClick={() => setAiChoice(provider.provider_id)}
+								icon={<ProviderTypeChip type={provider.type} />}
+								title={provider.label ?? provider.provider_id}
+								description={provider.default_model ?? providerTypeLabelFallback(provider)}
+								badge={<AuthBadge auth={provider.auth} />}
+							/>
+						))}
+						<AddTile
+							title="Add a provider"
+							description="Connect OpenAI, Anthropic, or another endpoint."
+							onClick={() => setAddProviderOpen(true)}
+						/>
 					</div>
-					{tzOptions.length > 0 ? (
-						<div className="flex flex-col gap-1.5">
-							<label htmlFor="agent-timezone" className="text-sm text-muted-foreground">
-								Timezone
-							</label>
-							<TimezoneCombobox
-								id="agent-timezone"
-								value={timezone}
-								onValueChange={setTimezone}
-								options={tzOptions}
+				</SettingsSection>
+
+				<SettingsSection
+					title={
+						<>
+							Channels <span className="font-normal text-muted-foreground">· optional</span>
+						</>
+					}
+					description="Prepare a bot now, then link it from the agent page once deployment finishes."
+				>
+					<div className={TWO_TILE_GRID_CLASS}>
+						<EntityChoiceCard
+							selected
+							icon={
+								<IconChip tint="bg-muted text-muted-foreground">
+									<CalendarClock />
+								</IconChip>
+							}
+							title="Link after deploy"
+							description="Channel links need the agent identity created during provisioning."
+							badge={<Badge variant="secondary">Default</Badge>}
+						/>
+						{channels.isLoading ? <Skeleton className="h-[74px] w-full rounded-lg" /> : null}
+						{channels.error ? (
+							<div className="flex min-h-[74px] flex-col items-start justify-center gap-2 rounded-lg border bg-muted/30 p-3 text-xs text-muted-foreground sm:col-span-2">
+								<p>Couldn’t load your channels. You can still deploy and link later.</p>
+								<Button size="sm" variant="outline" onClick={() => channels.refetch()}>
+									<RefreshCw /> Retry
+								</Button>
+							</div>
+						) : (
+							channelList.map((channel) => <ChannelInfoTile key={channel.id} channel={channel} />)
+						)}
+						<AddTile
+							title="Connect a channel"
+							description="Prepare a bot; link it after provisioning."
+							onClick={() => setConnectChannelOpen(true)}
+						/>
+					</div>
+				</SettingsSection>
+
+				<SettingsSection
+					title="Compute"
+					description="Free gives one active hosted deployment. Performance is billed per deployment and can run both optional runtimes."
+				>
+					<div className="flex flex-col gap-3">
+						<div className="grid gap-2 sm:grid-cols-2">
+							<EntityChoiceCard
+								selected={compute === "free"}
+								onClick={!freeSlotUnavailable ? () => setComputeTier("free") : undefined}
+								icon={
+									<IconChip tint="bg-identity-3-bg text-identity-3-fg">
+										<Cpu />
+									</IconChip>
+								}
+								title="Free"
+								description={
+									freeSlotUsed
+										? "Free slot already in use"
+										: freeSlotPending
+											? "Checking Free slot…"
+											: deployments.error
+												? "Free slot check unavailable"
+												: freePlan
+													? `${freePlan.vcpu} vCPU / ${freePlan.ram_gb} GB burst · one active deployment`
+													: "$0 · Codex included"
+								}
+								badge={<Badge variant="secondary">$0</Badge>}
+								disabled={freeSlotUnavailable}
+							/>
+							<EntityChoiceCard
+								selected={compute === "performance"}
+								onClick={perfPlan ? () => setComputeTier("performance") : undefined}
+								icon={
+									<IconChip tint="bg-identity-8-bg text-identity-8-fg">
+										<Zap />
+									</IconChip>
+								}
+								title="Performance"
+								description={
+									perfPlan
+										? `${perfPlan.vcpu} vCPU / ${perfPlan.ram_gb} GB · per-agent subscription`
+										: "Performance plan unavailable"
+								}
+								badge={
+									<Badge>
+										{perfOffer
+											? `${formatCentsCompact(perfOffer.effective_monthly_price_cents)}/mo`
+											: perfPlan
+												? `${formatCentsCompact(perfPlan.price_cents)}/mo`
+												: "Unavailable"}
+									</Badge>
+								}
+								disabled={!perfPlan}
 							/>
 						</div>
-					) : null}
-				</div>
-			</SettingsSection>
+						{compute === "performance" && perfOffers.length > 1 ? (
+							<div className="flex flex-col gap-2">
+								<TermSwitcher
+									offers={perfOffers}
+									value={perfBillingTermMonths}
+									onChange={setTerm}
+								/>
+							</div>
+						) : null}
+						<ComputeStatusLine
+							compute={compute}
+							freeSlotPending={freeSlotPending}
+							freeSlotUsed={freeSlotUsed}
+							deploymentsError={deployments.error}
+							freePlan={freePlan}
+							perfOffer={perfOffer}
+						/>
+					</div>
+				</SettingsSection>
+
+				<SettingsSection
+					title={
+						<>
+							Personalize <span className="font-normal text-muted-foreground">· optional</span>
+						</>
+					}
+					description="Choose the agent's language and timezone."
+				>
+					<div className="flex max-w-2xl flex-col gap-4">
+						<div className="grid gap-4 sm:grid-cols-2">
+							<div className="flex flex-col gap-1.5">
+								<label htmlFor="agent-language" className="text-sm text-muted-foreground">
+									Language
+								</label>
+								<Select
+									value={language || "default"}
+									onValueChange={(v) => {
+										setLanguage(v === null || v === "default" ? "" : v);
+									}}
+								>
+									<SelectTrigger id="agent-language">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="default">Default</SelectItem>
+										{LANGUAGE_OPTIONS.map((l) => (
+											<SelectItem key={l.code} value={l.code}>
+												{l.label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+						</div>
+						{tzOptions.length > 0 ? (
+							<div className="flex flex-col gap-1.5">
+								<label htmlFor="agent-timezone" className="text-sm text-muted-foreground">
+									Timezone
+								</label>
+								<TimezoneCombobox
+									id="agent-timezone"
+									value={timezone}
+									onValueChange={setTimezone}
+									options={tzOptions}
+								/>
+							</div>
+						) : null}
+					</div>
+				</SettingsSection>
+			</div>
 
 			{/* Sticky action bar */}
-			<div className="sticky bottom-0 -mx-4 border-t bg-background/90 px-4 pt-3 pb-[calc(--spacing(3)+env(safe-area-inset-bottom))] backdrop-blur lg:-mx-6 lg:px-6">
+			<div className="-mx-4 border-t bg-background/90 px-4 pt-3 pb-[calc(--spacing(3)+env(safe-area-inset-bottom))] backdrop-blur sm:sticky sm:bottom-0 lg:-mx-6 lg:px-6">
 				<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-					<p className="min-w-0 truncate text-sm text-muted-foreground">{summaryLine}</p>
+					<p className="min-w-0 max-w-full truncate text-xs text-muted-foreground sm:text-sm">
+						{summaryLine}
+					</p>
 					<Button
 						size="lg"
 						onClick={() => runAction(onDeploy)}

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -158,6 +158,8 @@ export function AddProviderDialog({
 	const createdFreshRef = useRef(false);
 
 	const meta = providerTypeMeta(type);
+	const runtimeEnvForSubmit = runtimeEnv.trim() || meta.defaultRuntimeEnv;
+	const showRuntimeEnvField = authMethod === "api_key" && meta.custom === true;
 
 	// Initialize when (re)opened.
 	useEffect(() => {
@@ -310,7 +312,7 @@ export function AddProviderDialog({
 			api_mode: apiMode,
 			auth,
 			managed_by: "user" as const,
-			runtime_env_name: keyBacked ? runtimeEnv.trim() || null : null,
+			runtime_env_name: keyBacked ? runtimeEnvForSubmit : null,
 		};
 		const created = await upsert.mutateAsync(body).catch(() => null);
 		if (!created) return;
@@ -323,7 +325,7 @@ export function AddProviderDialog({
 				.mutateAsync({
 					providerId,
 					value: apiKey.trim(),
-					runtime_env_name: runtimeEnv.trim() || undefined,
+					runtime_env_name: runtimeEnvForSubmit,
 				})
 				.catch(() => null);
 			if (!keyStored) {
@@ -738,18 +740,32 @@ export function AddProviderDialog({
 											</p>
 										) : null}
 									</div>
-									<div className="flex flex-col gap-1.5">
-										<Label htmlFor="provider-env">Runtime env var</Label>
-										<Input
-											id="provider-env"
-											name="provider-env"
-											value={runtimeEnv}
-											onChange={(e) => setRuntimeEnv(e.target.value.toUpperCase())}
-											placeholder="OPENAI_API_KEY"
-											autoComplete="off"
-											spellCheck={false}
-										/>
-									</div>
+									{showRuntimeEnvField ? (
+										<details
+											className="rounded-md border bg-muted/30 p-3"
+											open={isEdit || undefined}
+										>
+											<summary className="cursor-pointer text-sm font-medium text-foreground">
+												Advanced
+											</summary>
+											<div className="mt-3 flex flex-col gap-1.5">
+												<Label htmlFor="provider-env">Runtime env var</Label>
+												<Input
+													id="provider-env"
+													name="provider-env"
+													value={runtimeEnv}
+													onChange={(e) => setRuntimeEnv(e.target.value.toUpperCase())}
+													placeholder="OPENAI_API_KEY"
+													autoComplete="off"
+													spellCheck={false}
+												/>
+												<p className="text-xs text-muted-foreground">
+													Environment variable your endpoint's API key is exposed under to the
+													agent, e.g. OPENAI_API_KEY.
+												</p>
+											</div>
+										</details>
+									) : null}
 								</>
 							) : null}
 

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -550,93 +550,95 @@ export function AddProviderDialog({
 			<DialogContent
 				data-hosted="true"
 				data-v2="true"
-				className="max-h-[90vh] overflow-y-auto sm:max-w-lg"
+				className="flex max-h-[min(90vh,calc(100dvh-2rem))] flex-col gap-0 overflow-hidden p-0 sm:max-w-lg"
 			>
 				{oauth ? (
 					<>
-						<DialogHeader>
+						<DialogHeader className="shrink-0 px-6 pt-6">
 							<DialogTitle>Sign in with ChatGPT</DialogTitle>
 							<DialogDescription>
 								Finish signing in in the ChatGPT window — we’ll connect Codex automatically when it
 								returns.
 							</DialogDescription>
 						</DialogHeader>
-						<div className="flex flex-col gap-3">
-							<Button
-								variant="outline"
-								className="w-full"
-								onClick={() => {
-									// An issue means the prior link is stale — mint a fresh one. With no
-									// issue the popup just opened on a still-valid link; reopening is fine.
-									if (oauthIssue) void restartSignIn();
-									else openSignIn(oauth.authUrl);
-								}}
-								disabled={oauthStart.isPending}
-							>
-								{oauthIssue ? "Restart ChatGPT sign-in" : "Open ChatGPT sign-in"}
-								{oauthStart.isPending ? (
-									<Spinner className="size-3.5" />
-								) : (
-									<ExternalLink className="size-3.5" />
-								)}
-							</Button>
-							{oauthIssue === "expired" ? (
-								<p className="flex items-center gap-2 text-xs text-destructive">
-									<CircleAlert className="size-3.5" /> This sign-in link expired. Restart to get a
-									fresh one.
-								</p>
-							) : oauthIssue === "blocked" ? (
-								<p className="flex items-center gap-2 text-xs text-destructive">
-									<CircleAlert className="size-3.5" /> Pop-up blocked. Allow pop-ups, then restart
-									sign-in — or paste the address below.
-								</p>
-							) : oauthIssue === "closed" ? (
-								<p className="flex items-center gap-2 text-xs text-muted-foreground">
-									<CircleAlert className="size-3.5" /> The sign-in window closed before finishing.
-									Restart it, or paste the address below.
-								</p>
-							) : oauthComplete.isPending ? (
-								<p className="flex items-center gap-2 text-xs text-muted-foreground">
-									<Spinner className="size-3.5" /> Connecting Codex…
-								</p>
-							) : (
-								<p className="flex items-center gap-2 text-xs text-muted-foreground">
-									<Spinner className="size-3.5" /> Waiting for sign-in to finish…
-								</p>
-							)}
-							<details className="rounded-md border bg-muted/30 p-3 text-xs text-muted-foreground">
-								<summary className="cursor-pointer font-medium text-foreground">
-									Didn’t return automatically?
-								</summary>
-								<div className="mt-2 flex flex-col gap-2">
-									<p>Paste the full address from the OpenAI page after signing in.</p>
-									<Label htmlFor="provider-oauth-callback" className="sr-only">
-										OAuth callback URL
-									</Label>
-									<Input
-										id="provider-oauth-callback"
-										name="provider-oauth-callback"
-										value={oauthCode}
-										onChange={(e) => setOauthCode(e.target.value)}
-										placeholder="https://…/callback?code=…&state=…"
-										autoComplete="off"
-										spellCheck={false}
-									/>
-									<Button
-										size="sm"
-										onClick={submitPastedCallback}
-										disabled={!oauthCode.trim() || oauthComplete.isPending}
-									>
-										{oauthComplete.isPending ? "Finishing…" : "Finish sign-in"}
-									</Button>
-									<p>
-										If it never returns, an admin may need to register this app’s callback URL in
-										the Codex OAuth config.
+						<div className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
+							<div className="flex flex-col gap-3">
+								<Button
+									variant="outline"
+									className="w-full"
+									onClick={() => {
+										// An issue means the prior link is stale — mint a fresh one. With no
+										// issue the popup just opened on a still-valid link; reopening is fine.
+										if (oauthIssue) void restartSignIn();
+										else openSignIn(oauth.authUrl);
+									}}
+									disabled={oauthStart.isPending}
+								>
+									{oauthIssue ? "Restart ChatGPT sign-in" : "Open ChatGPT sign-in"}
+									{oauthStart.isPending ? (
+										<Spinner className="size-3.5" />
+									) : (
+										<ExternalLink className="size-3.5" />
+									)}
+								</Button>
+								{oauthIssue === "expired" ? (
+									<p className="flex items-center gap-2 text-xs text-destructive">
+										<CircleAlert className="size-3.5" /> This sign-in link expired. Restart to get a
+										fresh one.
 									</p>
-								</div>
-							</details>
+								) : oauthIssue === "blocked" ? (
+									<p className="flex items-center gap-2 text-xs text-destructive">
+										<CircleAlert className="size-3.5" /> Pop-up blocked. Allow pop-ups, then restart
+										sign-in — or paste the address below.
+									</p>
+								) : oauthIssue === "closed" ? (
+									<p className="flex items-center gap-2 text-xs text-muted-foreground">
+										<CircleAlert className="size-3.5" /> The sign-in window closed before finishing.
+										Restart it, or paste the address below.
+									</p>
+								) : oauthComplete.isPending ? (
+									<p className="flex items-center gap-2 text-xs text-muted-foreground">
+										<Spinner className="size-3.5" /> Connecting Codex…
+									</p>
+								) : (
+									<p className="flex items-center gap-2 text-xs text-muted-foreground">
+										<Spinner className="size-3.5" /> Waiting for sign-in to finish…
+									</p>
+								)}
+								<details className="rounded-md border bg-muted/30 p-3 text-xs text-muted-foreground">
+									<summary className="cursor-pointer font-medium text-foreground">
+										Didn’t return automatically?
+									</summary>
+									<div className="mt-2 flex flex-col gap-2">
+										<p>Paste the full address from the OpenAI page after signing in.</p>
+										<Label htmlFor="provider-oauth-callback" className="sr-only">
+											OAuth callback URL
+										</Label>
+										<Input
+											id="provider-oauth-callback"
+											name="provider-oauth-callback"
+											value={oauthCode}
+											onChange={(e) => setOauthCode(e.target.value)}
+											placeholder="https://…/callback?code=…&state=…"
+											autoComplete="off"
+											spellCheck={false}
+										/>
+										<Button
+											size="sm"
+											onClick={submitPastedCallback}
+											disabled={!oauthCode.trim() || oauthComplete.isPending}
+										>
+											{oauthComplete.isPending ? "Finishing…" : "Finish sign-in"}
+										</Button>
+										<p>
+											If it never returns, an admin may need to register this app’s callback URL in
+											the Codex OAuth config.
+										</p>
+									</div>
+								</details>
+							</div>
 						</div>
-						<DialogFooter>
+						<DialogFooter className="shrink-0 border-t bg-background px-6 py-4">
 							<Button variant="outline" onClick={() => requestClose(false)}>
 								Cancel
 							</Button>
@@ -644,187 +646,191 @@ export function AddProviderDialog({
 					</>
 				) : (
 					<>
-						<DialogHeader>
+						<DialogHeader className="shrink-0 px-6 pt-6">
 							<DialogTitle>{isEdit ? "Edit provider" : "Add a provider"}</DialogTitle>
 							<DialogDescription>
 								Route inference through your own account by API key, sign-in, or a custom endpoint.
 							</DialogDescription>
 						</DialogHeader>
 
-						<div className="flex flex-col gap-4">
-							<div className="flex flex-col gap-1.5">
-								<Label>Provider</Label>
-								<div className="grid grid-cols-2 gap-2">
-									{PROVIDER_TYPES.map((t) => {
-										const option = providerTypeMeta(t);
-										return (
-											<EntityChoiceCard
-												key={t}
-												selected={type === t}
-												onClick={isEdit ? undefined : () => changeType(t)}
-												disabled={isEdit}
-												icon={<EntityIcon kind="provider" id={t} label={option.label} size="sm" />}
-												title={option.label}
-												description={providerTypeDescription(t)}
-											/>
-										);
-									})}
-								</div>
-							</div>
-
-							<div className="flex items-center gap-3 rounded-lg border bg-muted/30 p-3">
-								<ProviderTypeChip type={type} />
-								<div className="min-w-0 text-xs text-muted-foreground">
-									Saved as <code className="font-mono">{providerId || "—"}</code>
-								</div>
-							</div>
-
-							<div className="flex flex-col gap-1.5">
-								<Label htmlFor="provider-label">Name</Label>
-								<Input
-									id="provider-label"
-									name="provider-label"
-									value={label}
-									onChange={(e) => setLabel(e.target.value)}
-									placeholder={`${meta.label} (my key)`}
-									autoComplete="off"
-								/>
-							</div>
-
-							{/* Auth method */}
-							<div className="flex flex-col gap-1.5">
-								<Label htmlFor="provider-auth">Authentication</Label>
-								<Select
-									value={authMethod}
-									onValueChange={(value) => {
-										if (isAuthMethod(value)) setAuthMethod(value);
-									}}
-								>
-									<SelectTrigger id="provider-auth">
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										<SelectItem value="api_key">API key</SelectItem>
-										{meta.oauth ? (
-											<SelectItem value="oauth">Sign in with ChatGPT (Codex)</SelectItem>
-										) : null}
-										{meta.custom ? <SelectItem value="none">No auth (local)</SelectItem> : null}
-									</SelectContent>
-								</Select>
-							</div>
-
-							{authMethod === "api_key" ? (
-								<>
-									<div className="flex flex-col gap-1.5">
-										<Label htmlFor="provider-key">
-											API key{canKeepExistingKey ? " (leave blank to keep)" : ""}
-										</Label>
-										<Input
-											id="provider-key"
-											name="provider-key"
-											type="password"
-											value={apiKey}
-											onChange={(e) => setApiKey(e.target.value)}
-											placeholder="sk-…"
-											autoComplete="off"
-											spellCheck={false}
-										/>
-										<p className="text-xs text-muted-foreground">
-											{canKeepLegacySecretRef
-												? "Leave blank to preserve this provider's existing legacy secret reference. Enter a key to switch it to managed API-key auth."
-												: "Stored encrypted for the hosted runtime and delivered as a manifest secret. The dashboard will not show it again."}
-										</p>
-										{keyRequired && isEdit && !apiKey.trim() ? (
-											<p className="text-xs text-destructive">
-												Enter a key to switch this provider to managed API-key auth.
-											</p>
-										) : null}
-									</div>
-									{showRuntimeEnvField ? (
-										<details
-											className="rounded-md border bg-muted/30 p-3"
-											open={isEdit || undefined}
-										>
-											<summary className="cursor-pointer text-sm font-medium text-foreground">
-												Advanced
-											</summary>
-											<div className="mt-3 flex flex-col gap-1.5">
-												<Label htmlFor="provider-env">Runtime env var</Label>
-												<Input
-													id="provider-env"
-													name="provider-env"
-													value={runtimeEnv}
-													onChange={(e) => setRuntimeEnv(e.target.value.toUpperCase())}
-													placeholder="OPENAI_API_KEY"
-													autoComplete="off"
-													spellCheck={false}
-												/>
-												<p className="text-xs text-muted-foreground">
-													Environment variable your endpoint's API key is exposed under to the
-													agent, e.g. OPENAI_API_KEY.
-												</p>
-											</div>
-										</details>
-									) : null}
-								</>
-							) : null}
-
-							<div className="flex flex-col gap-1.5">
-								<Label htmlFor="provider-base">Base URL</Label>
-								<Input
-									id="provider-base"
-									name="provider-base"
-									value={baseUrl}
-									onChange={(e) => setBaseUrl(e.target.value)}
-									placeholder="https://api.example.com/v1"
-									autoComplete="off"
-									spellCheck={false}
-								/>
-								{authMethod === "none" && baseUrl.trim() && !noneAuthOk ? (
-									<p className="text-xs text-destructive">
-										No-auth providers must use a loopback or private-network URL (e.g.
-										http://127.0.0.1:11434/v1).
-									</p>
-								) : null}
-							</div>
-
-							<div className="grid gap-3 sm:grid-cols-2">
+						<div className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
+							<div className="flex flex-col gap-4">
 								<div className="flex flex-col gap-1.5">
-									<Label htmlFor="provider-model">Default model</Label>
+									<Label>Provider</Label>
+									<div className="grid gap-2 sm:grid-cols-2">
+										{PROVIDER_TYPES.map((t) => {
+											const option = providerTypeMeta(t);
+											return (
+												<EntityChoiceCard
+													key={t}
+													selected={type === t}
+													onClick={isEdit ? undefined : () => changeType(t)}
+													disabled={isEdit}
+													icon={
+														<EntityIcon kind="provider" id={t} label={option.label} size="sm" />
+													}
+													title={option.label}
+													description={providerTypeDescription(t)}
+												/>
+											);
+										})}
+									</div>
+								</div>
+
+								<div className="flex items-center gap-3 rounded-lg border bg-muted/30 p-3">
+									<ProviderTypeChip type={type} />
+									<div className="min-w-0 text-xs text-muted-foreground">
+										Saved as <code className="font-mono">{providerId || "—"}</code>
+									</div>
+								</div>
+
+								<div className="flex flex-col gap-1.5">
+									<Label htmlFor="provider-label">Name</Label>
 									<Input
-										id="provider-model"
-										name="provider-model"
-										value={defaultModel}
-										onChange={(e) => setDefaultModel(e.target.value)}
-										placeholder={meta.modelPlaceholder}
+										id="provider-label"
+										name="provider-label"
+										value={label}
+										onChange={(e) => setLabel(e.target.value)}
+										placeholder={`${meta.label} (my key)`}
 										autoComplete="off"
-										spellCheck={false}
 									/>
 								</div>
+
+								{/* Auth method */}
 								<div className="flex flex-col gap-1.5">
-									<Label htmlFor="provider-mode">API mode</Label>
+									<Label htmlFor="provider-auth">Authentication</Label>
 									<Select
-										value={apiMode}
+										value={authMethod}
 										onValueChange={(value) => {
-											if (isApiMode(value)) setApiMode(value);
+											if (isAuthMethod(value)) setAuthMethod(value);
 										}}
 									>
-										<SelectTrigger id="provider-mode">
+										<SelectTrigger id="provider-auth">
 											<SelectValue />
 										</SelectTrigger>
 										<SelectContent>
-											{meta.apiModes.map((m) => (
-												<SelectItem key={m} value={m}>
-													{API_MODE_LABEL[m]}
-												</SelectItem>
-											))}
+											<SelectItem value="api_key">API key</SelectItem>
+											{meta.oauth ? (
+												<SelectItem value="oauth">Sign in with ChatGPT (Codex)</SelectItem>
+											) : null}
+											{meta.custom ? <SelectItem value="none">No auth (local)</SelectItem> : null}
 										</SelectContent>
 									</Select>
+								</div>
+
+								{authMethod === "api_key" ? (
+									<>
+										<div className="flex flex-col gap-1.5">
+											<Label htmlFor="provider-key">
+												API key{canKeepExistingKey ? " (leave blank to keep)" : ""}
+											</Label>
+											<Input
+												id="provider-key"
+												name="provider-key"
+												type="password"
+												value={apiKey}
+												onChange={(e) => setApiKey(e.target.value)}
+												placeholder="sk-…"
+												autoComplete="off"
+												spellCheck={false}
+											/>
+											<p className="text-xs text-muted-foreground">
+												{canKeepLegacySecretRef
+													? "Leave blank to preserve this provider's existing legacy secret reference. Enter a key to switch it to managed API-key auth."
+													: "Stored encrypted for the hosted runtime and delivered as a manifest secret. The dashboard will not show it again."}
+											</p>
+											{keyRequired && isEdit && !apiKey.trim() ? (
+												<p className="text-xs text-destructive">
+													Enter a key to switch this provider to managed API-key auth.
+												</p>
+											) : null}
+										</div>
+										{showRuntimeEnvField ? (
+											<details
+												className="rounded-md border bg-muted/30 p-3"
+												open={isEdit || undefined}
+											>
+												<summary className="cursor-pointer text-sm font-medium text-foreground">
+													Advanced
+												</summary>
+												<div className="mt-3 flex flex-col gap-1.5">
+													<Label htmlFor="provider-env">Runtime env var</Label>
+													<Input
+														id="provider-env"
+														name="provider-env"
+														value={runtimeEnv}
+														onChange={(e) => setRuntimeEnv(e.target.value.toUpperCase())}
+														placeholder="OPENAI_API_KEY"
+														autoComplete="off"
+														spellCheck={false}
+													/>
+													<p className="text-xs text-muted-foreground">
+														Environment variable your endpoint's API key is exposed under to the
+														agent, e.g. OPENAI_API_KEY.
+													</p>
+												</div>
+											</details>
+										) : null}
+									</>
+								) : null}
+
+								<div className="flex flex-col gap-1.5">
+									<Label htmlFor="provider-base">Base URL</Label>
+									<Input
+										id="provider-base"
+										name="provider-base"
+										value={baseUrl}
+										onChange={(e) => setBaseUrl(e.target.value)}
+										placeholder="https://api.example.com/v1"
+										autoComplete="off"
+										spellCheck={false}
+									/>
+									{authMethod === "none" && baseUrl.trim() && !noneAuthOk ? (
+										<p className="text-xs text-destructive">
+											No-auth providers must use a loopback or private-network URL (e.g.
+											http://127.0.0.1:11434/v1).
+										</p>
+									) : null}
+								</div>
+
+								<div className="grid gap-3 sm:grid-cols-2">
+									<div className="flex flex-col gap-1.5">
+										<Label htmlFor="provider-model">Default model</Label>
+										<Input
+											id="provider-model"
+											name="provider-model"
+											value={defaultModel}
+											onChange={(e) => setDefaultModel(e.target.value)}
+											placeholder={meta.modelPlaceholder}
+											autoComplete="off"
+											spellCheck={false}
+										/>
+									</div>
+									<div className="flex flex-col gap-1.5">
+										<Label htmlFor="provider-mode">API mode</Label>
+										<Select
+											value={apiMode}
+											onValueChange={(value) => {
+												if (isApiMode(value)) setApiMode(value);
+											}}
+										>
+											<SelectTrigger id="provider-mode">
+												<SelectValue />
+											</SelectTrigger>
+											<SelectContent>
+												{meta.apiModes.map((m) => (
+													<SelectItem key={m} value={m}>
+														{API_MODE_LABEL[m]}
+													</SelectItem>
+												))}
+											</SelectContent>
+										</Select>
+									</div>
 								</div>
 							</div>
 						</div>
 
-						<DialogFooter>
+						<DialogFooter className="shrink-0 border-t bg-background px-6 py-4">
 							<Button variant="outline" onClick={() => requestClose(false)}>
 								Cancel
 							</Button>

--- a/apps/web/src/hosted/v2/ai-providers/provider-types.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-types.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import { PROVIDER_TYPE_META } from "@/hosted/v2/ai-providers/provider-types";
+
+describe("AI provider type metadata", () => {
+	test("uses current model placeholders for known providers", () => {
+		expect(PROVIDER_TYPE_META.openai.modelPlaceholder).toBe("gpt-5.5");
+		expect(PROVIDER_TYPE_META.anthropic.modelPlaceholder).toBe("claude-sonnet-5");
+		expect(PROVIDER_TYPE_META.openrouter.modelPlaceholder).toBe("anthropic/claude-sonnet-5");
+		expect(PROVIDER_TYPE_META.gemini.modelPlaceholder).toBe("gemini-3.5-flash");
+		expect(PROVIDER_TYPE_META.mistral.modelPlaceholder).toBe("mistral-large-latest");
+	});
+
+	test("uses canonical SDK environment variable names", () => {
+		expect(PROVIDER_TYPE_META.openai.defaultRuntimeEnv).toBe("OPENAI_API_KEY");
+		expect(PROVIDER_TYPE_META.anthropic.defaultRuntimeEnv).toBe("ANTHROPIC_API_KEY");
+		expect(PROVIDER_TYPE_META.openrouter.defaultRuntimeEnv).toBe("OPENROUTER_API_KEY");
+		expect(PROVIDER_TYPE_META.gemini.defaultRuntimeEnv).toBe("GEMINI_API_KEY");
+		expect(PROVIDER_TYPE_META.mistral.defaultRuntimeEnv).toBe("MISTRAL_API_KEY");
+	});
+});

--- a/apps/web/src/hosted/v2/ai-providers/provider-types.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-types.ts
@@ -43,7 +43,7 @@ export const PROVIDER_TYPE_META: Record<ProviderTypeId, ProviderTypeMeta> = {
 		apiModes: ["openai_chat", "openai_responses"],
 		defaultApiMode: "openai_chat",
 		defaultRuntimeEnv: "OPENAI_API_KEY",
-		modelPlaceholder: "gpt-4o",
+		modelPlaceholder: "gpt-5.5",
 		oauth: true,
 	},
 	anthropic: {
@@ -54,7 +54,7 @@ export const PROVIDER_TYPE_META: Record<ProviderTypeId, ProviderTypeMeta> = {
 		apiModes: ["anthropic_messages"],
 		defaultApiMode: "anthropic_messages",
 		defaultRuntimeEnv: "ANTHROPIC_API_KEY",
-		modelPlaceholder: "claude-sonnet-4-5",
+		modelPlaceholder: "claude-sonnet-5",
 	},
 	openrouter: {
 		id: "openrouter",
@@ -64,7 +64,7 @@ export const PROVIDER_TYPE_META: Record<ProviderTypeId, ProviderTypeMeta> = {
 		apiModes: ["openai_chat"],
 		defaultApiMode: "openai_chat",
 		defaultRuntimeEnv: "OPENROUTER_API_KEY",
-		modelPlaceholder: "anthropic/claude-3.7-sonnet",
+		modelPlaceholder: "anthropic/claude-sonnet-5",
 	},
 	gemini: {
 		id: "gemini",
@@ -74,7 +74,7 @@ export const PROVIDER_TYPE_META: Record<ProviderTypeId, ProviderTypeMeta> = {
 		apiModes: ["google_generate_content"],
 		defaultApiMode: "google_generate_content",
 		defaultRuntimeEnv: "GEMINI_API_KEY",
-		modelPlaceholder: "gemini-2.0-flash",
+		modelPlaceholder: "gemini-3.5-flash",
 	},
 	mistral: {
 		id: "mistral",

--- a/apps/web/src/hosted/v2/channels/channels-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channels-page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Link } from "@tanstack/react-router";
-import { MessagesSquare, Plus } from "lucide-react";
+import { ArrowUpRight, Link2, MessagesSquare, Plus, Users } from "lucide-react";
+import type { ReactNode } from "react";
 import { useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { EmptyState } from "@/components/empty-state";
@@ -19,76 +20,178 @@ import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SectionLabel } from "@/components/section-label";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { orderedProviderIds, providerMeta } from "@/hosted/v2/channels/channel-providers";
-import type { ChannelAccount } from "@/hosted/v2/channels/channel-types";
-import { HealthBadge } from "@/hosted/v2/channels/channel-ui";
-import { useChannelHealth, useChannels } from "@/hosted/v2/channels/channels-hooks";
+import {
+	CHANNEL_PROVIDERS,
+	type ChannelProviderId,
+	orderedProviderIds,
+	providerMeta,
+} from "@/hosted/v2/channels/channel-providers";
+import type { ChannelAccount, ChannelBotPoolItem } from "@/hosted/v2/channels/channel-types";
+import { AccessBadge, HealthBadge } from "@/hosted/v2/channels/channel-ui";
+import { useBotPool, useChannelHealth, useChannels } from "@/hosted/v2/channels/channels-hooks";
 import { ConnectBotDialog } from "@/hosted/v2/channels/connect-bot-dialog";
-import { SharedBotsPool } from "@/hosted/v2/channels/shared-bots-pool";
+import { LinkAgentDialog } from "@/hosted/v2/channels/link-agent-dialog";
 import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Connect Telegram, Discord, and WhatsApp to your agents.";
 const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
 const CHANNEL_GRID_CLASS = ENTITY_GRID_CLASS;
+type ProviderFilter = "all" | ChannelProviderId;
 
 export function ChannelsPage() {
 	const [connectOpen, setConnectOpen] = useState(false);
+	const [filter, setFilter] = useState<ProviderFilter>("all");
+	const channels = useChannels();
+	const botPool = useBotPool();
+	const health = useChannelHealth();
+
+	const channelItems = channels.data ?? [];
+	const poolProviders = botPool.data?.providers ?? {};
+	const counts = providerCounts(channelItems, poolProviders);
+	const totalCount = CHANNEL_PROVIDERS.reduce((sum, provider) => sum + counts[provider], 0);
 
 	return (
 		<div data-hosted="true" data-v2="true" className={PAGE_CLASS}>
 			<PageHeader title="Channels" description={DESCRIPTION} />
 
-			<Tabs defaultValue="mine">
-				<TabsList>
-					<TabsTrigger value="mine">Your channels</TabsTrigger>
-					<TabsTrigger value="shared">Shared bots</TabsTrigger>
-				</TabsList>
-				<TabsContent value="mine" className="mt-4">
-					<YourChannels onConnect={() => setConnectOpen(true)} />
-				</TabsContent>
-				<TabsContent value="shared" className="mt-4">
-					<SharedBotsPool />
-				</TabsContent>
-			</Tabs>
+			<ListToolbar
+				filters={
+					<>
+						<FilterChip active={filter === "all"} onClick={() => setFilter("all")}>
+							All
+							<span className="text-muted-foreground tabular-nums">{totalCount}</span>
+						</FilterChip>
+						{CHANNEL_PROVIDERS.map((provider) => (
+							<FilterChip
+								key={provider}
+								active={filter === provider}
+								onClick={() => setFilter(provider)}
+							>
+								{providerMeta(provider).label}
+								<span className="text-muted-foreground tabular-nums">{counts[provider]}</span>
+							</FilterChip>
+						))}
+					</>
+				}
+				actions={
+					<Button size="sm" onClick={() => setConnectOpen(true)}>
+						<Plus />
+						Connect a bot
+					</Button>
+				}
+			/>
+
+			<div className="flex flex-col gap-7">
+				<YourChannelsSection
+					channels={channelItems}
+					isLoading={channels.isLoading}
+					error={channels.error}
+					onRetry={() => channels.refetch()}
+					healthItems={health.data?.items ?? []}
+					healthError={health.error}
+					onRetryHealth={() => health.refetch()}
+					filter={filter}
+					onConnect={() => setConnectOpen(true)}
+				/>
+				<SharedBotsSection
+					providers={poolProviders}
+					isLoading={botPool.isLoading}
+					error={botPool.error}
+					onRetry={() => botPool.refetch()}
+					filter={filter}
+				/>
+			</div>
 
 			<ConnectBotDialog open={connectOpen} onOpenChange={setConnectOpen} />
 		</div>
 	);
 }
 
-function YourChannels({ onConnect }: { onConnect: () => void }) {
-	const channels = useChannels();
-	const health = useChannelHealth();
-	const [filter, setFilter] = useState<string | "all">("all");
+function providerCounts(
+	channels: ChannelAccount[],
+	poolProviders: Record<string, ChannelBotPoolItem[]>,
+): Record<ChannelProviderId, number> {
+	const counts = Object.fromEntries(CHANNEL_PROVIDERS.map((p) => [p, 0])) as Record<
+		ChannelProviderId,
+		number
+	>;
+	for (const channel of channels) {
+		if (isKnownProvider(channel.provider)) counts[channel.provider] += 1;
+	}
+	for (const provider of CHANNEL_PROVIDERS) {
+		counts[provider] += poolProviders[provider]?.length ?? 0;
+	}
+	return counts;
+}
 
-	if (channels.isLoading) {
-		return (
+function isKnownProvider(provider: string): provider is ChannelProviderId {
+	return (CHANNEL_PROVIDERS as readonly string[]).includes(provider);
+}
+
+function providerLabel(filter: ProviderFilter): string {
+	return filter === "all" ? "selected providers" : providerMeta(filter).label;
+}
+
+function channelGroups(channels: ChannelAccount[], filter: ProviderFilter) {
+	const visible = filter === "all" ? channels : channels.filter((c) => c.provider === filter);
+	return orderedProviderIds(visible.map((channel) => channel.provider)).map((provider) => ({
+		provider,
+		items: visible.filter((channel) => channel.provider === provider),
+	}));
+}
+
+function poolGroups(providers: Record<string, ChannelBotPoolItem[]>, filter: ProviderFilter) {
+	const providerIds = filter === "all" ? orderedProviderIds(Object.keys(providers)) : [filter];
+	return providerIds
+		.map((provider) => ({
+			provider,
+			items: providers[provider] ?? [],
+		}))
+		.filter((section) => section.items.length > 0);
+}
+
+function YourChannelsSection({
+	channels,
+	isLoading,
+	error,
+	onRetry,
+	healthItems,
+	healthError,
+	onRetryHealth,
+	filter,
+	onConnect,
+}: {
+	channels: ChannelAccount[];
+	isLoading: boolean;
+	error: Error | null;
+	onRetry: () => void;
+	healthItems: { account_id: string; health_status: string }[];
+	healthError: Error | null;
+	onRetryHealth: () => void;
+	filter: ProviderFilter;
+	onConnect: () => void;
+}) {
+	const groups = channelGroups(channels, filter);
+	const visibleCount = groups.reduce((sum, group) => sum + group.items.length, 0);
+
+	let content: ReactNode;
+
+	if (isLoading) {
+		content = (
 			<div className={CHANNEL_GRID_CLASS}>
 				{[0, 1, 2].map((i) => (
 					<ChannelCardSkeleton key={i} />
 				))}
 			</div>
 		);
-	}
-
-	if (channels.error) {
-		return (
-			<ApiErrorPanel
-				error={channels.error}
-				onRetry={() => channels.refetch()}
-				title="Couldn't load channels"
-			/>
-		);
-	}
-
-	const all = channels.data ?? [];
-	if (all.length === 0) {
-		return (
+	} else if (error) {
+		content = <ApiErrorPanel error={error} onRetry={onRetry} title="Couldn't load channels" />;
+	} else if (channels.length === 0) {
+		content = (
 			<EmptyState
 				icon={MessagesSquare}
 				title="No channels yet"
-				description="Connect a bot, or link a shared bot to an agent from the Shared bots tab."
+				description="Connect a bot, or link a shared bot to an agent from the Shared bots section."
 				action={
 					<Button onClick={onConnect}>
 						<Plus />
@@ -97,69 +200,70 @@ function YourChannels({ onConnect }: { onConnect: () => void }) {
 				}
 			/>
 		);
-	}
-
-	const healthByAccount = new Map(
-		(health.data?.items ?? []).map((h) => [h.account_id, h.health_status]),
-	);
-	const counts = new Map<string, number>();
-	for (const c of all) counts.set(c.provider, (counts.get(c.provider) ?? 0) + 1);
-
-	const visible = filter === "all" ? all : all.filter((c) => c.provider === filter);
-	const filterProviders = orderedProviderIds(all.map((channel) => channel.provider));
-	const groups = orderedProviderIds(visible.map((channel) => channel.provider)).map((p) => ({
-		provider: p,
-		items: visible.filter((c) => c.provider === p),
-	}));
-
-	return (
-		<div className="flex flex-col gap-4">
-			{health.error ? (
-				<ApiErrorPanel
-					error={health.error}
-					onRetry={() => health.refetch()}
-					title="Couldn't load channel health"
-				/>
-			) : null}
-			<ListToolbar
-				filters={
-					<>
-						<FilterChip active={filter === "all"} onClick={() => setFilter("all")}>
-							All
-							<span className="text-muted-foreground tabular-nums">{all.length}</span>
-						</FilterChip>
-						{filterProviders.map((p) => (
-							<FilterChip key={p} active={filter === p} onClick={() => setFilter(p)}>
-								{providerMeta(p).label}
-								<span className="text-muted-foreground tabular-nums">{counts.get(p)}</span>
-							</FilterChip>
-						))}
-					</>
-				}
-				actions={
-					<Button size="sm" onClick={onConnect}>
+	} else if (visibleCount === 0) {
+		content = (
+			<EmptyState
+				icon={MessagesSquare}
+				title={`No ${providerLabel(filter)} channels`}
+				description="Try another provider filter, or connect a new bot."
+				action={
+					<Button onClick={onConnect}>
 						<Plus />
 						Connect a bot
 					</Button>
 				}
 			/>
-
+		);
+	} else {
+		const healthByAccount = new Map(healthItems.map((h) => [h.account_id, h.health_status]));
+		content = (
 			<div className="flex flex-col gap-5">
 				{groups.map((group) => (
-					<div key={group.provider} className="flex flex-col gap-2">
-						{filter === "all" ? (
-							<SectionLabel>{providerMeta(group.provider).label}</SectionLabel>
-						) : null}
-						<div className={CHANNEL_GRID_CLASS}>
-							{group.items.map((channel) => (
-								<ChannelCard
-									key={channel.id}
-									channel={channel}
-									health={healthByAccount.get(channel.id)}
-								/>
-							))}
-						</div>
-					</div>
+					<ProviderChannelGroup
+						key={group.provider}
+						provider={group.provider}
+						items={group.items}
+						healthByAccount={healthByAccount}
+					/>
+				))}
+			</div>
+		);
+	}
+
+	return (
+		<section className="flex flex-col gap-3">
+			<SectionLabel count={!isLoading ? visibleCount : undefined}>Your channels</SectionLabel>
+			{healthError ? (
+				<ApiErrorPanel
+					error={healthError}
+					onRetry={onRetryHealth}
+					title="Couldn't load channel health"
+				/>
+			) : null}
+			{content}
+		</section>
+	);
+}
+
+function ProviderChannelGroup({
+	provider,
+	items,
+	healthByAccount,
+}: {
+	provider: string;
+	items: ChannelAccount[];
+	healthByAccount: Map<string, string>;
+}) {
+	return (
+		<div className="flex flex-col gap-2">
+			<SectionLabel count={items.length}>{providerMeta(provider).label}</SectionLabel>
+			<div className={CHANNEL_GRID_CLASS}>
+				{items.map((channel) => (
+					<ChannelCard
+						key={channel.id}
+						channel={channel}
+						health={healthByAccount.get(channel.id)}
+					/>
 				))}
 			</div>
 		</div>
@@ -209,6 +313,138 @@ function ChannelCardSkeleton() {
 				</div>
 				<Skeleton className="h-6 w-20 rounded-full" />
 			</div>
+		</div>
+	);
+}
+
+function SharedBotsSection({
+	providers,
+	isLoading,
+	error,
+	onRetry,
+	filter,
+}: {
+	providers: Record<string, ChannelBotPoolItem[]>;
+	isLoading: boolean;
+	error: Error | null;
+	onRetry: () => void;
+	filter: ProviderFilter;
+}) {
+	const [linkTarget, setLinkTarget] = useState<{ id: string; name: string } | null>(null);
+	const groups = poolGroups(providers, filter);
+	const visibleCount = groups.reduce((sum, group) => sum + group.items.length, 0);
+
+	let content: ReactNode;
+	if (isLoading) {
+		content = (
+			<div className={CHANNEL_GRID_CLASS}>
+				{[0, 1, 2].map((i) => (
+					<Skeleton key={i} className="h-20 w-full rounded-lg" />
+				))}
+			</div>
+		);
+	} else if (error) {
+		content = <ApiErrorPanel error={error} onRetry={onRetry} title="Couldn't load shared bots" />;
+	} else if (groups.length === 0) {
+		content = (
+			<EmptyState
+				icon={Users}
+				title={
+					filter === "all" ? "No shared bots available" : `No ${providerLabel(filter)} shared bots`
+				}
+				description={
+					filter === "all"
+						? "Shared bots you can link to instantly will appear here."
+						: "Try another provider filter to see linkable shared bots."
+				}
+			/>
+		);
+	} else {
+		content = (
+			<div className="flex flex-col gap-5">
+				{groups.map((group) => {
+					const meta = providerMeta(group.provider);
+					return (
+						<div key={group.provider} className="flex flex-col gap-2">
+							<SectionLabel count={group.items.length}>{meta.label}</SectionLabel>
+							<div className={CHANNEL_GRID_CLASS}>
+								{group.items.map((item) => (
+									<PoolCard
+										key={item.id}
+										item={item}
+										onLink={() => setLinkTarget({ id: item.id, name: item.name })}
+									/>
+								))}
+							</div>
+						</div>
+					);
+				})}
+			</div>
+		);
+	}
+
+	return (
+		<section className="flex flex-col gap-3">
+			<SectionLabel count={!isLoading ? visibleCount : undefined}>Shared bots</SectionLabel>
+			{content}
+			{linkTarget ? (
+				<LinkAgentDialog
+					open={Boolean(linkTarget)}
+					onOpenChange={(open) => !open && setLinkTarget(null)}
+					accountId={linkTarget.id}
+					accountName={linkTarget.name}
+				/>
+			) : null}
+		</section>
+	);
+}
+
+function PoolCard({ item, onLink }: { item: ChannelBotPoolItem; onLink: () => void }) {
+	const owner = item.access === "owner";
+	const capacity =
+		item.max_links == null
+			? `${item.link_count} linked · unlimited`
+			: `${item.link_count} of ${item.max_links} linked`;
+
+	const meta = providerMeta(item.provider);
+	const linkable = !meta.unavailable && item.available && item.capabilities.link_agent;
+
+	return (
+		<div className={cn(ENTITY_CARD_BASE, "flex flex-col gap-3")}>
+			<EntityHeader
+				align="start"
+				icon={<EntityIcon kind="channel" id={item.provider} label={meta.label} />}
+				title={item.name}
+				titleAdornment={<AccessBadge access={item.access} />}
+				meta={
+					<span className="inline-flex items-center gap-1.5">
+						<Users className="size-3" />
+						{capacity}
+					</span>
+				}
+			/>
+
+			{owner ? (
+				<Button
+					render={<Link to="/channels/$id" params={{ id: item.id }} />}
+					nativeButton={false}
+					variant="outline"
+					size="sm"
+					className="w-full"
+				>
+					Manage
+					<ArrowUpRight />
+				</Button>
+			) : linkable ? (
+				<Button size="sm" className="w-full" onClick={onLink}>
+					<Link2 />
+					Link to an agent
+				</Button>
+			) : (
+				<Button size="sm" variant="outline" className="w-full" disabled>
+					{meta.unavailable ? "Unavailable" : item.available ? "Not linkable" : "At capacity"}
+				</Button>
+			)}
 		</div>
 	);
 }

--- a/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
@@ -391,8 +391,8 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 
 			{/* Keys */}
 			<section className="space-y-3">
-				<div className="flex items-end justify-between gap-2">
-					<div>
+				<div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+					<div className="min-w-0">
 						<div className="flex items-center gap-2">
 							<h2 className="text-sm font-semibold">Keys</h2>
 							{keys.error ? (
@@ -409,17 +409,17 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 							Values are write-only here — agents read them at runtime through the CLI.
 						</p>
 					</div>
-					<div className="flex shrink-0 items-center gap-2">
+					<div className="flex w-full flex-col gap-2 sm:w-auto sm:shrink-0 sm:flex-row sm:items-center">
 						{keyNames.length > 0 ? (
 							<>
-								<div className="relative">
+								<div className="relative w-full sm:w-auto">
 									<Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
 									<Input
 										value={search}
 										onChange={(e) => setSearch(e.target.value)}
 										placeholder="Search keys…"
 										aria-label="Search keys"
-										className="h-8 w-40 pl-8 text-sm sm:w-52"
+										className="h-8 w-full pl-8 text-sm sm:w-52"
 									/>
 								</div>
 								{isOwner ? (
@@ -433,6 +433,7 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 											});
 										}}
 										aria-pressed={selectMode}
+										className="w-full sm:w-auto"
 									>
 										<ListChecks className="size-3.5" />
 										{selectMode ? "Done" : "Select"}
@@ -449,7 +450,12 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 						) : null}
 						{isOwner ? (
 							<AddKeysDialog vaultSlug={slug}>
-								<Button variant="outline" size="sm" disabled={!anyProjectId}>
+								<Button
+									variant="outline"
+									size="sm"
+									disabled={!anyProjectId}
+									className="w-full sm:w-auto"
+								>
 									<Plus className="size-3.5" />
 									Add keys
 								</Button>
@@ -616,8 +622,8 @@ export default function VaultDetailPage({ slug: rawSlug }: { slug: string }) {
 
 			{/* Projects */}
 			<section className="space-y-3">
-				<div className="flex items-end justify-between gap-2">
-					<div>
+				<div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+					<div className="min-w-0">
 						<div className="flex items-center gap-2">
 							<h2 className="text-sm font-semibold">Projects</h2>
 							{projects.isLoading ? null : (
@@ -708,14 +714,18 @@ function AttachProjectPicker({
 	const [value, setValue] = useState("");
 	if (projects.length === 0) return null;
 	return (
-		<div className="flex items-center gap-2">
+		<div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
 			<Select
 				value={value}
 				onValueChange={(nextValue) => {
 					if (nextValue !== null) setValue(nextValue);
 				}}
 			>
-				<SelectTrigger size="sm" className="w-44" aria-label="Project to add this vault to">
+				<SelectTrigger
+					size="sm"
+					className="w-full sm:w-44"
+					aria-label="Project to add this vault to"
+				>
 					<SelectValue placeholder="Add to Project…" />
 				</SelectTrigger>
 				<SelectContent>
@@ -730,6 +740,7 @@ function AttachProjectPicker({
 				size="sm"
 				variant="outline"
 				disabled={!value || isPending}
+				className="w-full sm:w-auto"
 				onClick={() => {
 					onAttach(value);
 					setValue("");

--- a/packages/shared/src/style/theme.css
+++ b/packages/shared/src/style/theme.css
@@ -13,6 +13,57 @@
  */
 
 @custom-variant dark (&:is(.dark *));
+@custom-variant data-open {
+	&:where([data-state="open"]),
+	&:where([data-open]:not([data-open="false"])) {
+		@slot;
+	}
+}
+@custom-variant data-closed {
+	&:where([data-state="closed"]),
+	&:where([data-closed]:not([data-closed="false"])) {
+		@slot;
+	}
+}
+@custom-variant data-checked {
+	&:where([data-state="checked"]),
+	&:where([data-checked]:not([data-checked="false"])) {
+		@slot;
+	}
+}
+@custom-variant data-unchecked {
+	&:where([data-state="unchecked"]),
+	&:where([data-unchecked]:not([data-unchecked="false"])) {
+		@slot;
+	}
+}
+@custom-variant data-selected {
+	&:where([data-selected="true"]) {
+		@slot;
+	}
+}
+@custom-variant data-disabled {
+	&:where([data-disabled="true"]),
+	&:where([data-disabled]:not([data-disabled="false"])) {
+		@slot;
+	}
+}
+@custom-variant data-active {
+	&:where([data-state="active"]),
+	&:where([data-active]:not([data-active="false"])) {
+		@slot;
+	}
+}
+@custom-variant data-horizontal {
+	&:where([data-orientation="horizontal"]) {
+		@slot;
+	}
+}
+@custom-variant data-vertical {
+	&:where([data-orientation="vertical"]) {
+		@slot;
+	}
+}
 
 :root {
 	/* surfaces — page sits on a faintly warm near-white; cards lift to pure


### PR DESCRIPTION
## Summary
- Restores the official shadcn/Base UI custom variants in `packages/shared/src/style/theme.css`, including the missing `data-horizontal:` and `data-vertical:` orientation variants that Base UI components rely on for `data-orientation="horizontal|vertical"`.
- Leaves `apps/web/src/components/ui/` untouched so the base-vega registry components remain verbatim-official; the fix is in the shared CSS/theme layer.
- Refreshes hosted v2 AI provider model placeholders and adds metadata tests for current placeholder IDs and canonical SDK env vars.
- Hides the internal runtime env var field for known providers while still submitting the canonical `runtime_env_name`; keeps it editable for `custom_openai_compatible` under Advanced.
- Redesigns the v2 Channels page from tabs into the Collections pattern: one `ListToolbar`, provider filter chips with counts, and stacked `Your channels` / `Shared bots` sections grouped by provider with `ENTITY_GRID_CLASS` cards.
- Fixes responsive v2 launch blockers found in visual QA: add-provider dialog/footer clipping, vault detail header overflow, settings mobile navigation/API-key reflow, deploy mobile CTA overlap, and Ctrl+K command palette opening on Linux/Windows.

## Details
The broken Channels tabs and invisible separators came from missing official custom variants. Tailwind v4 was compiling `data-horizontal:` / `data-vertical:` as bare `[data-horizontal]` / `[data-vertical]`, which never matched Base UI's `data-orientation` attributes. Adding the official shadcn variant block restores orientation styling globally, including separators and any remaining Base UI orientation-dependent components.

Model placeholders were verified against official/current provider docs before updating:
- OpenAI models: https://platform.openai.com/docs/models (`gpt-5.5`)
- Anthropic models: https://docs.anthropic.com/en/docs/about-claude/models/overview (`claude-sonnet-5`)
- OpenRouter model page: https://openrouter.ai/anthropic/claude-sonnet-5/api (`anthropic/claude-sonnet-5`)
- Gemini API models: https://ai.google.dev/gemini-api/docs/models (`gemini-3.5-flash`)
- Mistral model aliases: https://docs.mistral.ai/getting-started/models/models_overview/ (`mistral-large-latest`)

For runtime env vars, `runtime_env_name` is still preserved in the backend contract and projected into manifests as `runtimeEnvName`. The form now keeps canonical env vars auto-derived for OpenAI, Anthropic, OpenRouter, Gemini, and Mistral, and only exposes the field where it can genuinely vary: custom OpenAI-compatible endpoints. Backend managed-provider rules remain untouched.

Responsive follow-up:
- Add-provider dialog now has a fixed header/footer with a scrollable body; mobile provider picker cards use a single column so `Custom (OpenAI-compatible)` is readable.
- Vault detail key/project toolbars stack on narrow screens so descriptions and `Add keys` stay inside the viewport.
- Settings navigation is horizontally scrollable on mobile with a fade affordance, and API keys render as stacked mobile cards instead of a clipped table.
- Deploy keeps the desktop sticky action bar with bottom clearance; on narrow mobile, the CTA footer is in normal document flow so it cannot cover provider/channel selection cards.
- Command palette key handling is case-insensitive and listens for both `Ctrl+K` and `Meta+K`; hosted e2e now asserts `Ctrl+K` opens the palette.

## Verification
- `bun install`
- `cd apps/web && bunx @biomejs/biome@2.5.2 ci .`
- `bun run check`
- `bun run typecheck`
- `bun run test`
- `cd apps/web && bun run e2e:hosted`
- `cd apps/web && bun run e2e`

Custom variant regression check was clean with the full official block, so no narrowing to only orientation variants was needed. Responsive visual QA screenshots were kept outside the repo under `~/clawdi-ui-screenshots/pr314-responsive-fixes/`, including mobile 390px and desktop 1440x1000 captures for provider dialog, vault detail, settings API keys, settings wallet, and deploy (`mobile390__deploy-scrolled-viewport.png` / `mobile390__deploy-bottom-viewport.png` confirm the mobile CTA no longer covers channel/provider selection and remains reachable). No screenshots are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
