### PR TITLE
fix(v2): correct hosted-runtime manifest/CLI contract (provider protocol, offline boot, fail-closed secrets)

### DIFF
--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -37,7 +37,7 @@ class _RuntimeProviderBinding:
     explicit_provider_id: bool
 
 
-_SUPPORTED_PROVIDER_RUNTIMES = {"hermes", "openclaw"}
+_SUPPORTED_PROVIDER_RUNTIMES = {"codex", "hermes", "openclaw"}
 
 
 @router.get("/manifest")

--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -34,9 +34,10 @@ router = APIRouter(prefix="/runtime", tags=["runtime"])
 class _RuntimeProviderBinding:
     provider_id: str | None
     model: str | None
+    explicit_provider_id: bool
 
 
-_SUPPORTED_PROVIDER_RUNTIMES = {"codex", "hermes", "openclaw"}
+_SUPPORTED_PROVIDER_RUNTIMES = {"hermes", "openclaw"}
 
 
 @router.get("/manifest")
@@ -212,9 +213,16 @@ async def _provider_projection(
             db,
             auth=auth,
             provider_id=binding.provider_id,
+            allow_default_fallback=not binding.explicit_provider_id,
             provider_cache=provider_cache,
         )
         if provider is None:
+            providers[runtime_name] = _unhealthy_provider_manifest_entry(
+                provider_id=binding.provider_id,
+                model=binding.model,
+                code="provider_not_found",
+                message="explicit runtime provider is missing or archived",
+            )
             continue
 
         if provider.provider_id not in secret_cache:
@@ -225,10 +233,21 @@ async def _provider_projection(
             )
         secret, payload = secret_cache[provider.provider_id]
         secret_ref = _provider_secret_ref(runtime_name) if secret else None
+        missing_required_secret = _provider_requires_secret(provider) and not secret_ref
         providers[runtime_name] = _provider_manifest_entry(
             provider,
             model=binding.model,
             secret_ref=secret_ref,
+            error=(
+                {
+                    "code": "provider_secret_unavailable",
+                    "message": (
+                        "provider requires an API key but no runtime secret value is available"
+                    ),
+                }
+                if missing_required_secret
+                else None
+            ),
         )
         if secret and secret_ref:
             secret_values[secret_ref] = secret
@@ -245,9 +264,11 @@ def _provider_manifest_entry(
     *,
     model: str | None,
     secret_ref: str | None,
+    error: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     projection: dict[str, Any] = {
         "kind": "openai-compatible",
+        "type": provider.type,
         "baseUrl": provider.base_url,
     }
     is_managed = _is_clawdi_managed_provider(provider)
@@ -263,12 +284,35 @@ def _provider_manifest_entry(
         projection["apiMode"] = api_mode
     if runtime_env_name:
         projection["runtimeEnvName"] = runtime_env_name
+    if _provider_requires_secret(provider) and not secret_ref:
+        projection["apiKeyRequired"] = True
     if secret_ref:
         projection["apiKeySecretRef"] = secret_ref
     auth = _provider_manifest_auth(provider)
     if auth is not None:
-        projection["type"] = provider.type
         projection["auth"] = auth
+    if error is not None:
+        projection["status"] = "error"
+        projection["error"] = error
+    return projection
+
+
+def _unhealthy_provider_manifest_entry(
+    *,
+    provider_id: str | None,
+    model: str | None,
+    code: str,
+    message: str,
+) -> dict[str, Any]:
+    projection: dict[str, Any] = {
+        "kind": "openai-compatible",
+        "status": "error",
+        "error": {"code": code, "message": message},
+    }
+    if provider_id:
+        projection["providerId"] = provider_id
+    if model:
+        projection["model"] = model
     return projection
 
 
@@ -285,6 +329,10 @@ def _provider_manifest_auth(provider: AiProvider) -> dict[str, str] | None:
         "tool": "codex",
         "profile": profile.strip(),
     }
+
+
+def _provider_requires_secret(provider: AiProvider) -> bool:
+    return provider.auth_type in {"api_key", "secret_ref"}
 
 
 def _provider_secret_ref(runtime_name: str) -> str:
@@ -313,6 +361,7 @@ def _runtime_provider_bindings(state: HostedRuntimeState) -> dict[str, _RuntimeP
                 f"unsupported enabled runtime: {runtime_key}",
             )
         raw_provider_id = runtime.get("provider_id", runtime.get("providerId"))
+        explicit_provider_id = raw_provider_id is not None
         if raw_provider_id is None:
             provider_id = state.provider_id
         elif isinstance(raw_provider_id, str) and raw_provider_id.strip():
@@ -338,11 +387,13 @@ def _runtime_provider_bindings(state: HostedRuntimeState) -> dict[str, _RuntimeP
         bindings[runtime_key] = _RuntimeProviderBinding(
             provider_id=provider_id,
             model=model.strip() if isinstance(model, str) else None,
+            explicit_provider_id=explicit_provider_id,
         )
     if not bindings and state.provider_id:
         bindings["default"] = _RuntimeProviderBinding(
             provider_id=state.provider_id,
             model=None,
+            explicit_provider_id=False,
         )
     return bindings
 
@@ -352,6 +403,7 @@ async def _select_provider_for_binding(
     *,
     auth: AuthContext,
     provider_id: str | None,
+    allow_default_fallback: bool,
     provider_cache: dict[str | None, AiProvider | None],
 ) -> AiProvider | None:
     if provider_id not in provider_cache:
@@ -363,6 +415,8 @@ async def _select_provider_for_binding(
     provider = provider_cache[provider_id]
     if provider is not None or provider_id is None:
         return provider
+    if not allow_default_fallback:
+        return None
     if None not in provider_cache:
         provider_cache[None] = await _select_provider(
             db,

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 AdminChannelProvider = Literal["telegram", "discord", "whatsapp", "imessage"]
 AdminChannelVisibility = Literal["private", "public"]
 AdminChannelStatus = Literal["active", "disabled"]
-_SUPPORTED_HOSTED_RUNTIMES = {"hermes", "openclaw"}
+_SUPPORTED_HOSTED_RUNTIMES = {"codex", "hermes", "openclaw"}
 _BRIDGE_SURFACE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
 _BRIDGE_SURFACE_KEYS = {
     "name",

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 AdminChannelProvider = Literal["telegram", "discord", "whatsapp", "imessage"]
 AdminChannelVisibility = Literal["private", "public"]
 AdminChannelStatus = Literal["active", "disabled"]
-_SUPPORTED_HOSTED_RUNTIMES = {"codex", "hermes", "openclaw"}
+_SUPPORTED_HOSTED_RUNTIMES = {"hermes", "openclaw"}
 _BRIDGE_SURFACE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
 _BRIDGE_SURFACE_KEYS = {
     "name",

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -1245,7 +1245,7 @@ async def test_runtime_manifest_rejects_unknown_enabled_runtime_state(
 
 
 @pytest.mark.asyncio
-async def test_runtime_manifest_rejects_codex_enabled_runtime_state(
+async def test_runtime_manifest_allows_codex_enabled_runtime_state(
     db_session,
     seed_user,
 ):
@@ -1256,28 +1256,41 @@ async def test_runtime_manifest_rejects_codex_enabled_runtime_state(
         machine_name="Manifest codex runtime",
         agent_type="codex",
     )
-    db_session.add(
-        HostedRuntimeState(
-            environment_id=env.id,
-            deployment_id=f"dep_{uuid4().hex}",
-            app_id="app-test",
-            instance_id=f"hri_{uuid4().hex}",
-            generation=7,
-            provider_id="clawdi-managed-v2",
-            runtimes={
-                "codex": {"enabled": True},
-                "openclaw": {"enabled": False},
-            },
-            system=None,
-            control_plane=None,
-            clawdi_cli=None,
-            live_sync=None,
-            recovery=None,
-            mitm_profiles=None,
-            mcp=None,
-            tools=None,
-            observed=None,
-        )
+    db_session.add_all(
+        [
+            AiProvider(
+                owner_user_id=seed_user.id,
+                provider_id="openai-codex",
+                type="openai",
+                base_url="https://api.openai.com/v1",
+                default_model="gpt-5.5",
+                api_mode="openai_responses",
+                auth_type="agent_profile",
+                auth_metadata={"tool": "codex", "profile": "default"},
+                managed_by="user",
+            ),
+            HostedRuntimeState(
+                environment_id=env.id,
+                deployment_id=f"dep_{uuid4().hex}",
+                app_id="app-test",
+                instance_id=f"hri_{uuid4().hex}",
+                generation=7,
+                provider_id="openai-codex",
+                runtimes={
+                    "codex": {"enabled": True},
+                    "openclaw": {"enabled": False},
+                },
+                system=None,
+                control_plane=None,
+                clawdi_cli=None,
+                live_sync=None,
+                recovery=None,
+                mitm_profiles=None,
+                mcp=None,
+                tools=None,
+                observed=None,
+            ),
+        ]
     )
     await db_session.commit()
 
@@ -1286,8 +1299,19 @@ async def test_runtime_manifest_rejects_codex_enabled_runtime_state(
         response = await client.get("/v1/runtime/manifest")
     app.dependency_overrides.clear()
 
-    assert response.status_code == 409, response.text
-    assert response.json() == {"detail": "unsupported enabled runtime: codex"}
+    assert response.status_code == 200, response.text
+    assert response.json()["manifest"]["providers"]["codex"] == {
+        "kind": "openai-compatible",
+        "type": "openai",
+        "baseUrl": "https://api.openai.com/v1",
+        "model": "gpt-5.5",
+        "apiMode": "openai_responses",
+        "auth": {
+            "type": "agent_profile",
+            "tool": "codex",
+            "profile": "default",
+        },
+    }
 
 
 @pytest.mark.asyncio
@@ -1723,7 +1747,7 @@ async def test_runtime_manifest_projects_codex_agent_profile_auth(
 
 
 @pytest.mark.asyncio
-async def test_admin_runtime_state_rejects_codex_hosted_runtime(
+async def test_admin_runtime_state_accepts_codex_hosted_runtime(
     admin_client,
     db_session,
     seed_user,
@@ -1750,5 +1774,5 @@ async def test_admin_runtime_state_rejects_codex_hosted_runtime(
         json=body,
     )
 
-    assert response.status_code == 422, response.text
-    assert "unsupported runtime desired state" in response.text
+    assert response.status_code == 200, response.text
+    assert response.json()["environment_id"] == str(env.id)

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -611,6 +611,7 @@ async def test_runtime_manifest_projects_per_runtime_provider_bindings(
     assert "default" not in payload["manifest"]["providers"]
     assert payload["manifest"]["providers"]["openclaw"] == {
         "kind": "openai-compatible",
+        "type": "custom_openai_compatible",
         "baseUrl": "https://openclaw-provider.test/v1",
         "model": "gpt-5.5",
         "apiMode": "openai_responses",
@@ -619,6 +620,7 @@ async def test_runtime_manifest_projects_per_runtime_provider_bindings(
     }
     assert payload["manifest"]["providers"]["hermes"] == {
         "kind": "openai-compatible",
+        "type": "custom_openai_compatible",
         "baseUrl": "https://hermes-provider.test/v1",
         "model": "claude-opus-4-6",
         "apiMode": "openai_chat",
@@ -632,7 +634,183 @@ async def test_runtime_manifest_projects_per_runtime_provider_bindings(
 
 
 @pytest.mark.asyncio
-async def test_runtime_manifest_falls_back_to_managed_provider_for_archived_binding(
+async def test_runtime_manifest_preserves_non_openai_provider_protocols(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"provider-protocol-{uuid4().hex[:8]}",
+        machine_name="Runtime provider protocol",
+        agent_type="openclaw",
+    )
+    anthropic_ciphertext, anthropic_nonce = encrypt("sk-anthropic-provider")
+    gemini_ciphertext, gemini_nonce = encrypt("sk-gemini-provider")
+    db_session.add_all(
+        [
+            AiProvider(
+                owner_user_id=seed_user.id,
+                provider_id="anthropic-byok",
+                type="anthropic",
+                base_url="https://api.anthropic.com",
+                default_model="claude-opus-4-6",
+                api_mode="anthropic_messages",
+                auth_type="api_key",
+                auth_metadata={"source": "managed"},
+                managed_by="user",
+                runtime_env_name="ANTHROPIC_API_KEY",
+            ),
+            AiProviderAuthPayload(
+                owner_user_id=seed_user.id,
+                provider_id="anthropic-byok",
+                auth_profile="default",
+                kind="api_key",
+                source="managed",
+                encrypted_payload=anthropic_ciphertext,
+                nonce=anthropic_nonce,
+            ),
+            AiProvider(
+                owner_user_id=seed_user.id,
+                provider_id="gemini-byok",
+                type="gemini",
+                base_url="https://generativelanguage.googleapis.com/v1beta",
+                default_model="gemini-2.5-pro",
+                api_mode="google_generate_content",
+                auth_type="api_key",
+                auth_metadata={"source": "managed"},
+                managed_by="user",
+                runtime_env_name="GEMINI_API_KEY",
+            ),
+            AiProviderAuthPayload(
+                owner_user_id=seed_user.id,
+                provider_id="gemini-byok",
+                auth_profile="default",
+                kind="api_key",
+                source="managed",
+                encrypted_payload=gemini_ciphertext,
+                nonce=gemini_nonce,
+            ),
+        ]
+    )
+    await db_session.commit()
+    await _write_runtime_state(
+        admin_client,
+        str(env.id),
+        runtimes={
+            "openclaw": {
+                "enabled": True,
+                "provider_id": "anthropic-byok",
+                "model": "claude-opus-4-6",
+            },
+            "hermes": {
+                "enabled": True,
+                "provider_id": "gemini-byok",
+                "model": "gemini-2.5-pro",
+            },
+        },
+    )
+
+    api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        response = await client.get("/v1/runtime/manifest")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["manifest"]["providers"]["openclaw"] == {
+        "kind": "openai-compatible",
+        "type": "anthropic",
+        "baseUrl": "https://api.anthropic.com",
+        "model": "claude-opus-4-6",
+        "apiMode": "anthropic_messages",
+        "runtimeEnvName": "ANTHROPIC_API_KEY",
+        "apiKeySecretRef": "provider.openclaw.apiKey",
+    }
+    assert payload["manifest"]["providers"]["hermes"] == {
+        "kind": "openai-compatible",
+        "type": "gemini",
+        "baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+        "model": "gemini-2.5-pro",
+        "apiMode": "google_generate_content",
+        "runtimeEnvName": "GEMINI_API_KEY",
+        "apiKeySecretRef": "provider.hermes.apiKey",
+    }
+    assert payload["secretValues"] == {
+        "provider.hermes.apiKey": "sk-gemini-provider",
+        "provider.openclaw.apiKey": "sk-anthropic-provider",
+    }
+
+
+@pytest.mark.asyncio
+async def test_runtime_manifest_marks_key_required_provider_unhealthy_without_secret(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"provider-missing-key-{uuid4().hex[:8]}",
+        machine_name="Runtime provider missing key",
+        agent_type="openclaw",
+    )
+    db_session.add(
+        AiProvider(
+            owner_user_id=seed_user.id,
+            provider_id="missing-key-provider",
+            type="anthropic",
+            base_url="https://api.anthropic.com",
+            default_model="claude-opus-4-6",
+            api_mode="anthropic_messages",
+            auth_type="api_key",
+            auth_metadata={"source": "managed"},
+            managed_by="user",
+            runtime_env_name="ANTHROPIC_API_KEY",
+        )
+    )
+    await db_session.commit()
+    await _write_runtime_state(
+        admin_client,
+        str(env.id),
+        runtimes={
+            "openclaw": {
+                "enabled": True,
+                "provider_id": "missing-key-provider",
+                "model": "claude-opus-4-6",
+            },
+            "hermes": {"enabled": False},
+        },
+    )
+
+    api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        response = await client.get("/v1/runtime/manifest")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200, response.text
+    provider = response.json()["manifest"]["providers"]["openclaw"]
+    assert provider == {
+        "kind": "openai-compatible",
+        "type": "anthropic",
+        "baseUrl": "https://api.anthropic.com",
+        "model": "claude-opus-4-6",
+        "apiMode": "anthropic_messages",
+        "runtimeEnvName": "ANTHROPIC_API_KEY",
+        "apiKeyRequired": True,
+        "status": "error",
+        "error": {
+            "code": "provider_secret_unavailable",
+            "message": "provider requires an API key but no runtime secret value is available",
+        },
+    }
+    assert "apiKeySecretRef" not in provider
+    assert response.json()["secretValues"] == {}
+
+
+@pytest.mark.asyncio
+async def test_runtime_manifest_marks_explicit_archived_provider_binding_unhealthy(
     admin_client,
     db_session,
     seed_user,
@@ -705,6 +883,89 @@ async def test_runtime_manifest_falls_back_to_managed_provider_for_archived_bind
     payload = response.json()
     assert payload["manifest"]["providers"]["openclaw"] == {
         "kind": "openai-compatible",
+        "status": "error",
+        "error": {
+            "code": "provider_not_found",
+            "message": "explicit runtime provider is missing or archived",
+        },
+        "providerId": "deleted-custom-provider",
+    }
+    assert payload["secretValues"] == {}
+
+
+@pytest.mark.asyncio
+async def test_runtime_manifest_keeps_default_archived_provider_fallback(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"default-archived-provider-{uuid4().hex[:8]}",
+        machine_name="Runtime default archived provider",
+        agent_type="openclaw",
+    )
+    ciphertext, nonce = encrypt("sk-managed-provider")
+    db_session.add_all(
+        [
+            AiProvider(
+                owner_user_id=seed_user.id,
+                provider_id="deleted-default-provider",
+                type="custom_openai_compatible",
+                base_url="https://deleted-provider.test/v1",
+                default_model="deleted-model",
+                api_mode="openai_responses",
+                auth_type="api_key",
+                auth_metadata={"source": "managed"},
+                managed_by="user",
+                runtime_env_name="DELETED_PROVIDER_API_KEY",
+                archived_at=datetime.now(UTC),
+            ),
+            AiProvider(
+                owner_user_id=seed_user.id,
+                provider_id="clawdi-managed-v2",
+                type="custom_openai_compatible",
+                base_url="https://managed-provider.test/v1",
+                default_model="gpt-5.5",
+                api_mode="openai_responses",
+                auth_type="api_key",
+                auth_metadata={"source": "managed"},
+                managed_by="clawdi",
+                runtime_env_name="CLAWDI_MANAGED_OPENAI_API_KEY",
+            ),
+            AiProviderAuthPayload(
+                owner_user_id=seed_user.id,
+                provider_id="clawdi-managed-v2",
+                auth_profile="default",
+                kind="api_key",
+                source="managed",
+                encrypted_payload=ciphertext,
+                nonce=nonce,
+            ),
+        ]
+    )
+    await db_session.commit()
+    await _write_runtime_state(
+        admin_client,
+        str(env.id),
+        provider_id="deleted-default-provider",
+        runtimes={
+            "openclaw": {"enabled": True},
+            "hermes": {"enabled": False},
+        },
+    )
+
+    api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        response = await client.get("/v1/runtime/manifest")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["manifest"]["providers"]["openclaw"] == {
+        "kind": "openai-compatible",
+        "type": "custom_openai_compatible",
         "baseUrl": "https://managed-provider.test/v1",
         "model": "gpt-5.5",
         "apiMode": "openai_chat",
@@ -984,6 +1245,52 @@ async def test_runtime_manifest_rejects_unknown_enabled_runtime_state(
 
 
 @pytest.mark.asyncio
+async def test_runtime_manifest_rejects_codex_enabled_runtime_state(
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"manifest-codex-runtime-{uuid4().hex[:8]}",
+        machine_name="Manifest codex runtime",
+        agent_type="codex",
+    )
+    db_session.add(
+        HostedRuntimeState(
+            environment_id=env.id,
+            deployment_id=f"dep_{uuid4().hex}",
+            app_id="app-test",
+            instance_id=f"hri_{uuid4().hex}",
+            generation=7,
+            provider_id="clawdi-managed-v2",
+            runtimes={
+                "codex": {"enabled": True},
+                "openclaw": {"enabled": False},
+            },
+            system=None,
+            control_plane=None,
+            clawdi_cli=None,
+            live_sync=None,
+            recovery=None,
+            mitm_profiles=None,
+            mcp=None,
+            tools=None,
+            observed=None,
+        )
+    )
+    await db_session.commit()
+
+    api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        response = await client.get("/v1/runtime/manifest")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 409, response.text
+    assert response.json() == {"detail": "unsupported enabled runtime: codex"}
+
+
+@pytest.mark.asyncio
 async def test_admin_runtime_state_rejects_legacy_control_plane_api_url(
     admin_client,
     db_session,
@@ -1181,6 +1488,7 @@ async def test_runtime_manifest_projects_provider_secret_values(
     payload = response.json()
     assert payload["manifest"]["providers"]["openclaw"] == {
         "kind": "openai-compatible",
+        "type": "custom_openai_compatible",
         "baseUrl": "https://sub2api.test/v1",
         "model": "gpt-5.5",
         "apiMode": "openai_chat",
@@ -1270,6 +1578,7 @@ async def test_runtime_manifest_projects_legacy_managed_provider_as_responses(
     payload = response.json()
     assert payload["manifest"]["providers"]["openclaw"] == {
         "kind": "openai-compatible",
+        "type": "custom_openai_compatible",
         "baseUrl": "https://sub2api.test/v1",
         "model": "openai-codex/gpt-5.5",
         "apiMode": "openai_responses",
@@ -1341,6 +1650,7 @@ async def test_runtime_manifest_uses_runtime_model_when_provider_default_is_miss
     assert response.status_code == 200, response.text
     assert response.json()["manifest"]["providers"]["openclaw"] == {
         "kind": "openai-compatible",
+        "type": "custom_openai_compatible",
         "baseUrl": "https://provider.test/v1",
         "model": "gpt-5.5",
         "apiMode": "openai_responses",
@@ -1360,7 +1670,7 @@ async def test_runtime_manifest_projects_codex_agent_profile_auth(
         user_id=seed_user.id,
         machine_id=f"runtime-codex-oauth-{uuid4().hex[:8]}",
         machine_name="Runtime Codex OAuth Provider",
-        agent_type="codex",
+        agent_type="openclaw",
     )
     db_session.add(
         AiProvider(
@@ -1382,12 +1692,11 @@ async def test_runtime_manifest_projects_codex_agent_profile_auth(
         str(env.id),
         provider_id="openai-codex",
         runtimes={
-            "codex": {
+            "openclaw": {
                 "enabled": True,
                 "provider_id": "openai-codex",
                 "model": "gpt-5.5",
             },
-            "openclaw": {"enabled": False},
             "hermes": {"enabled": False},
         },
     )
@@ -1398,7 +1707,7 @@ async def test_runtime_manifest_projects_codex_agent_profile_auth(
     app.dependency_overrides.clear()
 
     assert response.status_code == 200, response.text
-    assert response.json()["manifest"]["providers"]["codex"] == {
+    assert response.json()["manifest"]["providers"]["openclaw"] == {
         "kind": "openai-compatible",
         "type": "openai",
         "baseUrl": "https://api.openai.com/v1",
@@ -1411,3 +1720,35 @@ async def test_runtime_manifest_projects_codex_agent_profile_auth(
         },
     }
     assert response.json()["secretValues"] == {}
+
+
+@pytest.mark.asyncio
+async def test_admin_runtime_state_rejects_codex_hosted_runtime(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"codex-hosted-{uuid4().hex[:8]}",
+        machine_name="Codex hosted unsupported",
+        agent_type="codex",
+    )
+    body = {
+        "deployment_id": f"dep_{uuid4().hex}",
+        "app_id": "app-test",
+        "instance_id": f"hri_{uuid4().hex}",
+        "generation": 7,
+        "provider_id": "clawdi-managed",
+        "runtimes": {"codex": {"enabled": True}},
+    }
+
+    response = await admin_client.put(
+        f"/v1/admin/environments/{env.id}/runtime-state",
+        headers=_AUTH,
+        json=body,
+    )
+
+    assert response.status_code == 422, response.text
+    assert "unsupported runtime desired state" in response.text

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -15,6 +15,7 @@ import { applyRuntimeChannelsToManifestLoad } from "../runtime/channels";
 import { applyRuntimeCliDesiredState, type RuntimeCliUpdateResult } from "../runtime/cli-update";
 import { readHostPolicy } from "../runtime/host-policy";
 import {
+	cacheRuntimeLastGoodManifest,
 	convergeRuntimeManifest,
 	loadRuntimeManifest,
 	withRuntimeConvergeLock,
@@ -1714,10 +1715,21 @@ export async function runtimeInit(opts: RuntimeInitOptions = {}) {
 		];
 		const installOk = runtimeErrors.length === 0;
 		if (installOk && loaded.source === "remote-datasource") {
+			convergence.outputs.manifestLastGood = cacheRuntimeLastGoodManifest(
+				convergence.manifest,
+				paths,
+				convergenceLoad.secretValues,
+			);
 			writeRuntimeManifestEtag(paths, loaded.etag);
 			if (channelsLoad) {
 				writeRuntimeChannelsEtag(paths, channelsLoad.etag);
 			}
+		} else if (installOk) {
+			convergence.outputs.manifestLastGood = cacheRuntimeLastGoodManifest(
+				convergence.manifest,
+				paths,
+				convergenceLoad.secretValues,
+			);
 		}
 		const status = buildRuntimeBootStatus(
 			{
@@ -1872,11 +1884,18 @@ async function runtimeWatchTick(
 			systemdApplyResult.systemUnitsChanged.length > 0 ||
 			systemdApplyResult.userUnitsChanged.length > 0;
 		if (errors.length > 0) {
-			if (convergence.installErrors.length === 0 && !("notModified" in manifestLoad)) {
-				writeRuntimeManifestEtag(paths, manifestLoad.etag);
-			}
-			if (convergence.installErrors.length === 0 && !("notModified" in channelsLoad)) {
-				writeRuntimeChannelsEtag(paths, channelsLoad.etag);
+			if (convergence.installErrors.length === 0 && !systemdApplyError) {
+				convergence.outputs.manifestLastGood = cacheRuntimeLastGoodManifest(
+					convergence.manifest,
+					paths,
+					loaded.secretValues,
+				);
+				if (!("notModified" in manifestLoad)) {
+					writeRuntimeManifestEtag(paths, manifestLoad.etag);
+				}
+				if (!("notModified" in channelsLoad)) {
+					writeRuntimeChannelsEtag(paths, channelsLoad.etag);
+				}
 			}
 			return {
 				schemaVersion: "clawdi.runtimeWatchEvent.v1",
@@ -1892,6 +1911,11 @@ async function runtimeWatchTick(
 				convergence: convergence.outputs,
 			};
 		}
+		convergence.outputs.manifestLastGood = cacheRuntimeLastGoodManifest(
+			convergence.manifest,
+			paths,
+			loaded.secretValues,
+		);
 		if (!("notModified" in manifestLoad)) {
 			writeRuntimeManifestEtag(paths, manifestLoad.etag);
 		}
@@ -1946,7 +1970,7 @@ function applyRuntimeDesiredState(
 		if (!opts.continueOnCliUpdateError) throw error;
 		cliUpdate = runtimeCliUpdateError(load.manifest, paths, error);
 	}
-	const convergence = convergeRuntimeManifest(load, paths);
+	const convergence = convergeRuntimeManifest(load, paths, { cacheLastGood: false });
 	return { cliUpdate, convergence };
 }
 

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -161,13 +161,25 @@ const hostedRuntimeEntrySchema = z
 	})
 	.passthrough();
 
-const hostedProviderAuthSchema = z
-	.object({
-		type: z.literal("agent_profile"),
-		tool: z.literal("codex"),
-		profile: z.string().min(1),
-	})
-	.strict();
+const hostedProviderAuthSchema = z.discriminatedUnion("type", [
+	z
+		.object({
+			type: z.literal("agent_profile"),
+			tool: z.literal("codex"),
+			profile: z.string().min(1),
+		})
+		.strict(),
+	z
+		.object({
+			type: z.literal("api_key"),
+		})
+		.passthrough(),
+	z
+		.object({
+			type: z.literal("secret_ref"),
+		})
+		.passthrough(),
+]);
 
 export const hostedRuntimeManifestSchema = z
 	.object({
@@ -213,6 +225,15 @@ export const hostedRuntimeManifestSchema = z
 						apiMode: z.string().min(1).optional(),
 						runtimeEnvName: z.string().min(1).optional(),
 						apiKeySecretRef: z.string().min(1).nullable().optional(),
+						apiKeyRequired: z.boolean().optional(),
+						status: z.enum(["ok", "error", "disabled"]).optional(),
+						error: z
+							.object({
+								code: z.string().min(1),
+								message: z.string().min(1).optional(),
+							})
+							.passthrough()
+							.optional(),
 						auth: hostedProviderAuthSchema.optional(),
 					})
 					.passthrough(),

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { isAbsolute, join } from "node:path";
 import { z } from "zod";
-import { hostedManifestMitmProfiles, normalizeSecretRef } from "./hosted-mitm-profiles";
+import { hostedManifestMitmProfiles } from "./hosted-mitm-profiles";
 import {
 	DEFAULT_CLAWDI_CLI_POLICY,
 	type HostedRuntimeManifest,
@@ -14,6 +14,7 @@ import {
 } from "./manifest-contract";
 import type { RuntimePaths } from "./paths";
 import { isSupportedRuntimeName, type RuntimeRunSettings } from "./run-config";
+import { normalizeSecretValues } from "./secret-values";
 
 export interface RuntimeManifestLoad {
 	manifest: RuntimeManifest;
@@ -593,18 +594,6 @@ function runtimeManifestUrlFromEnvOrSource(): string {
 	return "https://runtime.invalid/manifest";
 }
 
-function normalizeSecretValues(secretValues: Record<string, string>): Record<string, string> {
-	const normalized: Record<string, string> = {};
-	for (const [ref, value] of Object.entries(secretValues)) {
-		normalized[ref] = value;
-		const secretRef = normalizeSecretRef(ref);
-		if (secretRef && normalized[secretRef] === undefined) {
-			normalized[secretRef] = value;
-		}
-	}
-	return normalized;
-}
-
 function loadExistingState(paths: RuntimePaths): ExistingManifestState {
 	if (!existsSync(paths.manifestLastGood)) return {};
 	const parsed = parseManifestSafe(readJsonFile(paths.manifestLastGood));
@@ -814,11 +803,23 @@ function loadLastGoodManifest(paths: RuntimePaths): RuntimeManifestLoad | Runtim
 		}
 		const secretRefs = manifestSecretRefs(manifest);
 		if (secretRefs.length > 0) {
+			const cached = loadCachedSecretValues(paths);
+			if ("errors" in cached) return cached;
+			const missingSecretRefs = manifestSecretRefsMissingValues(manifest, cached.secretValues);
+			if (missingSecretRefs.length === 0) {
+				return {
+					manifest,
+					source: "last-good-cache",
+					sourcePath: paths.manifestLastGood,
+					offline: true,
+					secretValues: cached.secretValues,
+				};
+			}
 			return {
 				mode: "repair",
 				stage: "local",
 				errors: [
-					`cached manifest references secretValues (${secretRefs.join(", ")}); refusing offline boot without a fresh runtime manifest`,
+					`cached manifest references secretValues (${missingSecretRefs.join(", ")}); refusing offline boot because cached secret values are missing`,
 				],
 			};
 		}
@@ -834,6 +835,36 @@ function loadLastGoodManifest(paths: RuntimePaths): RuntimeManifestLoad | Runtim
 			stage: "local",
 			errors: [
 				`could not read last-good runtime manifest at ${paths.manifestLastGood}: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			],
+		};
+	}
+}
+
+function loadCachedSecretValues(
+	paths: RuntimePaths,
+): { secretValues: Record<string, string> } | RuntimeManifestFailure {
+	if (!existsSync(paths.managedSecretCacheFile)) return { secretValues: {} };
+	try {
+		const raw = readJsonFile(paths.managedSecretCacheFile);
+		if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+			throw new Error("cached secret values must be a JSON object");
+		}
+		const secretValues: Record<string, string> = {};
+		for (const [ref, value] of Object.entries(raw as Record<string, unknown>)) {
+			if (typeof value !== "string") {
+				throw new Error(`cached secret value for ${ref} must be a string`);
+			}
+			secretValues[ref] = value;
+		}
+		return { secretValues: normalizeSecretValues(secretValues) };
+	} catch (error) {
+		return {
+			mode: "repair",
+			stage: "local",
+			errors: [
+				`could not read cached runtime secret values at ${paths.managedSecretCacheFile}: ${
 					error instanceof Error ? error.message : String(error)
 				}`,
 			],

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -24,7 +24,7 @@ import type {
 	AiProviderCatalog,
 	AiProviderType,
 } from "@clawdi/shared";
-import { isAiProviderType } from "@clawdi/shared";
+import { isAiProviderApiMode, isAiProviderType } from "@clawdi/shared";
 import { z } from "zod";
 import { buildAgentTargetProjection } from "../lib/ai-provider-projection";
 import {
@@ -35,6 +35,10 @@ import {
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { normalizeSecretRef } from "./hosted-mitm-profiles";
 import type { LiveSyncAgent, RuntimeInstall, RuntimeManifest } from "./manifest-contract";
+import {
+	normalizeSecretValues,
+	runtimeSecretValue as resolveRuntimeSecretValue,
+} from "./secret-values";
 
 export type { RuntimeInstall, RuntimeManifest } from "./manifest-contract";
 export {
@@ -131,13 +135,53 @@ function writeJsonFile(path: string, payload: unknown): void {
 	writePrivateFileAtomic(path, `${JSON.stringify(payload, null, 2)}\n`);
 }
 
-function writeLastGoodManifest(manifest: RuntimeManifest, paths: RuntimePaths): string | null {
+function writeLastGoodManifest(
+	manifest: RuntimeManifest,
+	paths: RuntimePaths,
+	secretValues: Record<string, string> | undefined,
+): string | null {
 	if (manifest.recovery.cacheManifest === false) {
 		rmSync(paths.manifestLastGood, { force: true });
+		rmSync(paths.managedSecretCacheFile, { force: true });
 		return null;
 	}
 	writeJsonFile(paths.manifestLastGood, manifest);
+	writeLastGoodSecretValues(secretValues, paths);
 	return paths.manifestLastGood;
+}
+
+export function cacheRuntimeLastGoodManifest(
+	manifest: RuntimeManifest,
+	paths: RuntimePaths,
+	secretValues?: Record<string, string>,
+): string | null {
+	return writeLastGoodManifest(manifest, paths, secretValues);
+}
+
+function writeLastGoodSecretValues(
+	secretValues: Record<string, string> | undefined,
+	paths: RuntimePaths,
+): void {
+	const normalized = normalizeSecretValues(secretValues);
+	if (Object.keys(normalized).length === 0) {
+		rmSync(paths.managedSecretCacheFile, { force: true });
+		return;
+	}
+	writePrivateFileAtomic(paths.managedSecretCacheFile, `${JSON.stringify(normalized, null, 2)}\n`, {
+		mode: 0o600,
+		dirMode: 0o755,
+	});
+	makeRootOwned(dirname(paths.managedSecretCacheFile));
+	makeRootOwned(paths.managedSecretCacheFile);
+}
+
+function makeManagedSecretRoot(path: string): void {
+	makeRootOwned(path);
+	try {
+		chmodSync(path, 0o711);
+	} catch {
+		// Best effort for non-POSIX local development environments.
+	}
 }
 
 function writeSecretValues(
@@ -146,24 +190,73 @@ function writeSecretValues(
 ): string | null {
 	const path = paths.managedSecretFile;
 	const legacyPath = join(paths.runRoot, "mitm", "secrets.json");
-	if (!secretValues || Object.keys(secretValues).length === 0) {
+	const normalized = normalizeSecretValues(secretValues);
+	if (Object.keys(normalized).length === 0) {
 		rmSync(path, { force: true });
 		rmSync(legacyPath, { force: true });
 		return null;
 	}
 	rmSync(legacyPath, { force: true });
-	writePrivateFileAtomic(path, `${JSON.stringify(secretValues, null, 2)}\n`, {
+	writePrivateFileAtomic(path, `${JSON.stringify(normalized, null, 2)}\n`, {
 		mode: 0o600,
 		dirMode: 0o700,
 	});
-	makeRootOwned(dirname(path));
-	makeRuntimeSecretReadable(path);
-	try {
-		chmodSync(path, 0o600);
-	} catch {
-		// Best effort for non-POSIX local development environments.
+	makeManagedSecretRoot(dirname(path));
+	makeRootOwned(path);
+	return path;
+}
+
+function writeScopedSecretValues(
+	path: string,
+	secretValues: Record<string, string> | undefined,
+	refs: readonly string[],
+	paths: RuntimePaths,
+	owner: "root" | "runtime-user",
+): string | null {
+	const scoped = scopedSecretValues(secretValues, refs);
+	if (Object.keys(scoped).length === 0) {
+		rmSync(path, { force: true });
+		return null;
+	}
+	writePrivateFileAtomic(path, `${JSON.stringify(scoped, null, 2)}\n`, {
+		mode: 0o600,
+		dirMode: 0o700,
+	});
+	if (owner === "runtime-user") {
+		if (dirname(path) !== paths.managedSecretRoot) {
+			makeRuntimeUserOwned(dirname(path));
+		}
+		makeRuntimeUserOwned(path);
+	} else {
+		makeRootOwned(dirname(path));
+		makeRootOwned(path);
+	}
+	if (path.startsWith(paths.managedSecretRoot)) {
+		makeManagedSecretRoot(paths.managedSecretRoot);
+		try {
+			chmodSync(path, 0o600);
+		} catch {
+			// Best effort for non-POSIX local development environments.
+		}
 	}
 	return path;
+}
+
+function scopedSecretValues(
+	secretValues: Record<string, string> | undefined,
+	refs: readonly string[],
+): Record<string, string> {
+	const normalizedValues = normalizeSecretValues(secretValues);
+	const scoped: Record<string, string> = {};
+	for (const ref of refs) {
+		const value = resolveRuntimeSecretValue(normalizedValues, ref);
+		if (!value) continue;
+		scoped[ref] = value;
+		const normalized = normalizeSecretRef(ref);
+		if (normalized) scoped[normalized] = value;
+		if (ref.startsWith("secret://")) scoped[ref.slice("secret://".length)] = value;
+	}
+	return scoped;
 }
 
 function writeProviderHealthStatus(
@@ -229,6 +322,15 @@ function providerHealthReasons(
 	secretAvailable: boolean | null,
 ): string[] {
 	const reasons: string[] = [];
+	const status = stringValue(provider.status);
+	if (status && status !== "ok") {
+		reasons.push(`provider_${status}`);
+	}
+	const error = recordValue(provider.error);
+	const errorCode = error ? stringValue(error.code) : null;
+	if (errorCode) {
+		reasons.push(errorCode);
+	}
 	const baseUrl = stringValue(provider.baseUrl);
 	if (!baseUrl) {
 		reasons.push("base_url_missing");
@@ -255,6 +357,9 @@ function providerHealthReasons(
 	}
 	if (stringValue(provider.apiKeySecretRef) && secretAvailable === false) {
 		reasons.push("secret_missing");
+	}
+	if (hostedProviderRequiresApiKey(provider) && !stringValue(provider.apiKeySecretRef)) {
+		reasons.push("api_key_secret_ref_missing");
 	}
 	return reasons;
 }
@@ -297,17 +402,6 @@ function makeRootOwned(path: string): void {
 	} catch {
 		// Best effort for local tests and non-root development environments.
 	}
-}
-
-function makeRuntimeSecretReadable(path: string): void {
-	const dir = dirname(path);
-	makeRootOwned(dir);
-	try {
-		chmodSync(dir, 0o711);
-	} catch {
-		// Best effort for non-POSIX local development environments.
-	}
-	makeRuntimeUserOwned(path);
 }
 
 function makeRuntimeUserPrivateDir(path: string): void {
@@ -689,8 +783,10 @@ function hostedAiProviderCatalog(
 			const apiKeySecretRef =
 				typeof input.apiKeySecretRef === "string" ? input.apiKeySecretRef : undefined;
 			const runtimeEnvName = hostedProviderRuntimeEnvName(id, input);
+			if (hostedProviderUnhealthy(input)) return null;
 			if (!baseUrl || !model) return null;
 			const auth = hostedProviderAuth(input, Boolean(apiKeySecretRef));
+			if (!auth) return null;
 			return {
 				id,
 				type: hostedProviderType(input),
@@ -729,7 +825,7 @@ function hostedProviderEntries(
 
 function hostedProviderApiMode(input: Record<string, unknown>): AiProviderApiMode {
 	const raw = typeof input.apiMode === "string" ? input.apiMode : input.api_mode;
-	if (raw === "openai_chat" || raw === "openai_responses") {
+	if (typeof raw === "string" && isAiProviderApiMode(raw)) {
 		return raw;
 	}
 	return "openai_chat";
@@ -743,7 +839,7 @@ function hostedProviderType(input: Record<string, unknown>): AiProviderType {
 function hostedProviderAuth(
 	input: Record<string, unknown>,
 	hasApiKeySecretRef: boolean,
-): AiProviderAuth {
+): AiProviderAuth | null {
 	const auth = recordValue(input.auth);
 	if (auth) {
 		const type = stringValue(auth.type);
@@ -752,11 +848,29 @@ function hostedProviderAuth(
 		if (type === "agent_profile" && tool === "codex" && profile) {
 			return { type: "agent_profile", tool: "codex", profile };
 		}
+		if ((type === "api_key" || type === "secret_ref") && !hasApiKeySecretRef) {
+			return null;
+		}
 	}
 	if (hasApiKeySecretRef) {
 		return { type: "api_key", source: "managed" };
 	}
+	if (hostedProviderRequiresApiKey(input)) {
+		return null;
+	}
 	return { type: "none" };
+}
+
+function hostedProviderUnhealthy(input: Record<string, unknown>): boolean {
+	const status = stringValue(input.status);
+	return Boolean(status && status !== "ok");
+}
+
+function hostedProviderRequiresApiKey(input: Record<string, unknown>): boolean {
+	if (input.apiKeyRequired === true) return true;
+	const auth = recordValue(input.auth);
+	const type = auth ? stringValue(auth.type) : null;
+	return type === "api_key" || type === "secret_ref";
 }
 
 function hostedProviderRuntimeEnvName(providerId: string, input: Record<string, unknown>): string {
@@ -787,6 +901,63 @@ function hostedProviderSecretEnv(
 		env[runtimeEnvName] = normalizeSecretRef(apiKeySecretRef) ?? apiKeySecretRef;
 	}
 	return env;
+}
+
+function runtimeSecretFilePath(paths: RuntimePaths, runtimeName: string): string {
+	return join(paths.runtimeSecretFileRoot, `${runtimeName}.json`);
+}
+
+function writeRuntimeProviderSecretFile(
+	runtimeName: string,
+	secretValues: Record<string, string> | undefined,
+	secretEnv: Record<string, string>,
+	paths: RuntimePaths,
+): string | null {
+	return writeScopedSecretValues(
+		runtimeSecretFilePath(paths, runtimeName),
+		secretValues,
+		Object.values(secretEnv),
+		paths,
+		"runtime-user",
+	);
+}
+
+function mitmSecretFilePath(paths: RuntimePaths): string {
+	return join(paths.managedSecretRoot, "mitm-secrets.json");
+}
+
+function writeMitmSecretFile(
+	manifest: RuntimeManifest,
+	secretValues: Record<string, string> | undefined,
+	paths: RuntimePaths,
+): string | null {
+	return writeScopedSecretValues(
+		mitmSecretFilePath(paths),
+		secretValues,
+		mitmSecretRefs(manifest),
+		paths,
+		"runtime-user",
+	);
+}
+
+function mitmSecretRefs(manifest: RuntimeManifest): string[] {
+	const refs = new Set<string>();
+	collectSecretRefs(manifest.mitmProfiles, refs);
+	return [...refs].sort();
+}
+
+function collectSecretRefs(value: unknown, refs: Set<string>): void {
+	if (!value || typeof value !== "object") return;
+	if (Array.isArray(value)) {
+		for (const item of value) collectSecretRefs(item, refs);
+		return;
+	}
+	for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+		if (typeof entry === "string" && (key === "secretRef" || key.endsWith("SecretRef"))) {
+			refs.add(entry);
+		}
+		collectSecretRefs(entry, refs);
+	}
 }
 
 function isEnvKey(value: string): boolean {
@@ -1094,6 +1265,21 @@ function removeStaleRuntimeRunConfigs(writtenRunConfigIds: Set<string>, paths: R
 	}
 }
 
+function removeStaleRuntimeSecretFiles(
+	writtenRuntimeSecretIds: Set<string>,
+	paths: RuntimePaths,
+): void {
+	if (!existsSync(paths.runtimeSecretFileRoot)) return;
+	for (const entry of readdirSync(paths.runtimeSecretFileRoot)) {
+		if (!entry.endsWith(".json")) continue;
+		const id = entry.slice(0, -".json".length);
+		if (!runtimeNameSchema.safeParse(id).success) continue;
+		if (!writtenRuntimeSecretIds.has(id)) {
+			rmSync(join(paths.runtimeSecretFileRoot, entry), { force: true });
+		}
+	}
+}
+
 function runtimeRunConfigIdIsValid(id: string): boolean {
 	const [runtime, service, ...rest] = id.split("+");
 	if (rest.length > 0) return false;
@@ -1201,7 +1387,7 @@ function writeDaemonAuthToken(paths: RuntimePaths): string | null {
 	}
 	rmSync(legacyPath, { force: true });
 	writePrivateFileAtomic(path, `${token}\n`, { mode: 0o600, dirMode: 0o700 });
-	makeRootOwned(dirname(path));
+	makeManagedSecretRoot(dirname(path));
 	makeRootOwned(path);
 	return path;
 }
@@ -1473,17 +1659,7 @@ function buildRuntimeSystemdUserProgram(input: {
 }
 
 export function runtimeSecretValue(secrets: Record<string, string>, ref: string): string | null {
-	const normalized = normalizeSecretRef(ref);
-	const raw = ref.startsWith("secret://") ? ref.slice("secret://".length) : null;
-	const candidates = [ref, normalized, raw].filter(
-		(candidate, index, values): candidate is string =>
-			Boolean(candidate) && values.indexOf(candidate) === index,
-	);
-	for (const candidate of candidates) {
-		const value = secrets[candidate];
-		if (typeof value === "string" && value.length > 0) return value;
-	}
-	return null;
+	return resolveRuntimeSecretValue(secrets, ref);
 }
 
 function hashToUInt16(input: string): number {
@@ -2182,6 +2358,7 @@ function runtimeWorkspaceRoot(manifest: RuntimeManifest, paths: RuntimePaths): s
 export function convergeRuntimeManifest(
 	load: RuntimeManifestLoad,
 	paths: RuntimePaths,
+	opts: { cacheLastGood?: boolean } = {},
 ): RuntimeConvergenceResult {
 	const { manifest } = load;
 	const workspaceRoot = runtimeWorkspaceRoot(manifest, paths);
@@ -2198,6 +2375,7 @@ export function convergeRuntimeManifest(
 	const runConfigs: string[] = [];
 	const runtimeSystemdUserPrograms: RuntimeSystemdUserProgram[] = [];
 	const installErrors: string[] = [];
+	const writtenRuntimeSecretIds = new Set<string>();
 
 	mkdirSync(workspaceRoot, { recursive: true });
 	makeRuntimeUserOwned(paths.userHome);
@@ -2206,6 +2384,8 @@ export function convergeRuntimeManifest(
 	mkdirSync(paths.installInventory, { recursive: true });
 	mkdirSync(paths.projectionRoot, { recursive: true });
 	mkdirSync(semRoot, { recursive: true });
+	mkdirSync(paths.managedSecretRoot, { recursive: true });
+	makeManagedSecretRoot(paths.managedSecretRoot);
 
 	let manifestLastGood: string | null = null;
 	writeJsonFile(paths.managedConfig, {
@@ -2267,7 +2447,8 @@ export function convergeRuntimeManifest(
 		? writeMitmProfileBundle(mitmProfileBundle, paths)
 		: clearMitmProfileBundle(paths);
 	const daemonAuthTokenFile = writeDaemonAuthToken(paths);
-	const mitmSecretFile = writeSecretValues(load.secretValues, paths);
+	writeSecretValues(load.secretValues, paths);
+	const mitmSecretFile = writeMitmSecretFile(manifest, load.secretValues, paths);
 	const mitmSystemdProgram = runtimeMitmSystemdProgram(
 		manifest,
 		paths,
@@ -2341,6 +2522,14 @@ export function convergeRuntimeManifest(
 			);
 		}
 		const runtimeName = runtimeNameSchema.parse(name);
+		const secretEnv = runtime.enabled ? hostedProviderSecretEnv(manifest, name) : {};
+		const runtimeProviderSecretFile = writeRuntimeProviderSecretFile(
+			name,
+			load.secretValues,
+			secretEnv,
+			paths,
+		);
+		if (runtimeProviderSecretFile) writtenRuntimeSecretIds.add(name);
 		const runConfig = buildRuntimeRunConfig({
 			runtime: runtimeName,
 			enabled: runtime.enabled,
@@ -2352,8 +2541,8 @@ export function convergeRuntimeManifest(
 			workspaceRoot,
 			mitmProfileBundlePath,
 			settings: runtime.run,
-			secretFilePath: mitmSecretFile,
-			secretEnv: hostedProviderSecretEnv(manifest, name),
+			secretFilePath: runtimeProviderSecretFile,
+			secretEnv,
 		});
 		const runConfigPath = writeRuntimeRunConfig(runConfig, paths);
 		runConfigs.push(runConfigPath);
@@ -2423,8 +2612,9 @@ export function convergeRuntimeManifest(
 	const bootFinished = join(instanceRoot, "boot-finished");
 	writePrivateFileAtomic(bootFinished, `${generatedAt}\n`);
 	removeStaleRuntimeRunConfigs(writtenRunConfigIds, paths);
-	if (installErrors.length === 0) {
-		manifestLastGood = writeLastGoodManifest(manifest, paths);
+	removeStaleRuntimeSecretFiles(writtenRuntimeSecretIds, paths);
+	if (installErrors.length === 0 && opts.cacheLastGood !== false) {
+		manifestLastGood = writeLastGoodManifest(manifest, paths, load.secretValues);
 	}
 
 	return {

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -176,7 +176,10 @@ function readProviderObserved(paths: RuntimePaths): JsonRecord | null {
 	const providers = recordValue(projection?.providers);
 	if (!providers || Object.keys(providers).length === 0) return null;
 
-	const secrets = readJsonRecord(join(paths.runRoot, "mitm", "secrets.json")) ?? {};
+	const secrets =
+		readJsonRecord(paths.managedSecretFile) ??
+		readJsonRecord(join(paths.runRoot, "mitm", "secrets.json")) ??
+		{};
 	const observed: JsonRecord = {};
 	for (const providerId of Object.keys(providers).sort()) {
 		const provider = recordValue(providers[providerId]);
@@ -206,6 +209,15 @@ function providerSecretAvailable(secrets: JsonRecord, ref: string): boolean {
 
 function providerReasons(provider: JsonRecord, secretAvailable: boolean | null): string[] {
 	const reasons: string[] = [];
+	const status = stringValue(provider.status);
+	if (status && status !== "ok") {
+		reasons.push(`provider_${status}`);
+	}
+	const error = recordValue(provider.error);
+	const errorCode = error ? stringValue(error.code) : null;
+	if (errorCode) {
+		reasons.push(errorCode);
+	}
 	const baseUrl = stringValue(provider.baseUrl);
 	if (!baseUrl) {
 		reasons.push("base_url_missing");
@@ -225,6 +237,9 @@ function providerReasons(provider: JsonRecord, secretAvailable: boolean | null):
 	}
 	if (stringValue(provider.apiKeySecretRef) && secretAvailable === false) {
 		reasons.push("secret_missing");
+	}
+	if (provider.apiKeyRequired === true && !stringValue(provider.apiKeySecretRef)) {
+		reasons.push("api_key_secret_ref_missing");
 	}
 	return reasons;
 }

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -31,6 +31,7 @@ export interface RuntimePaths {
 	manifestLastGood: string;
 	manifestEtag: string;
 	channelsEtag: string;
+	managedSecretCacheFile: string;
 	runConfigRoot: string;
 	mitmProfileRoot: string;
 	mitmProfileBundle: string;
@@ -48,6 +49,7 @@ export interface RuntimePaths {
 	runRoot: string;
 	managedSecretRoot: string;
 	managedSecretFile: string;
+	runtimeSecretFileRoot: string;
 	daemonAuthToken: string;
 	instanceData: string;
 	sensitiveInstanceData: string;
@@ -131,6 +133,7 @@ export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths
 		manifestLastGood: join(cacheRoot, "manifest.last-good.json"),
 		manifestEtag: join(cacheRoot, "manifest.etag"),
 		channelsEtag: join(cacheRoot, "channels.etag"),
+		managedSecretCacheFile: join(cacheRoot, "runtime-secrets.last-good.json"),
 		runConfigRoot: join(serviceStateRoot, "config", "run"),
 		mitmProfileRoot: join(serviceStateRoot, "config", "mitm"),
 		mitmProfileBundle: join(serviceStateRoot, "config", "mitm", "profiles.json"),
@@ -149,6 +152,7 @@ export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths
 		runRoot,
 		managedSecretRoot: join(runRoot, "secrets"),
 		managedSecretFile: join(runRoot, "secrets", "runtime-secrets.json"),
+		runtimeSecretFileRoot: join(runRoot, "secrets", "runtimes"),
 		daemonAuthToken: join(runRoot, "secrets", "auth-token"),
 		instanceData: join(runRoot, "instance-data.json"),
 		sensitiveInstanceData: join(runRoot, "instance-data-sensitive.json"),

--- a/packages/cli/src/runtime/run-config.ts
+++ b/packages/cli/src/runtime/run-config.ts
@@ -2,10 +2,10 @@ import { existsSync, readFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { z } from "zod";
 import { writePrivateFileAtomic } from "../lib/private-file";
-import { normalizeSecretRef } from "./hosted-mitm-profiles";
 import { buildMitmSidecarEnv } from "./mitm-env";
 import type { RuntimePaths } from "./paths";
 import { getRuntimePaths } from "./paths";
+import { runtimeSecretValue } from "./secret-values";
 
 export const runtimeNameSchema = z
 	.string()
@@ -305,18 +305,4 @@ function runtimeSecretEnv(
 		env[envName] = value;
 	}
 	return env;
-}
-
-function runtimeSecretValue(secrets: Record<string, unknown>, ref: string): string | null {
-	const normalized = normalizeSecretRef(ref);
-	const raw = ref.startsWith("secret://") ? ref.slice("secret://".length) : null;
-	const candidates = [ref, normalized, raw].filter(
-		(candidate, index, values): candidate is string =>
-			Boolean(candidate) && values.indexOf(candidate) === index,
-	);
-	for (const candidate of candidates) {
-		const value = secrets[candidate];
-		if (typeof value === "string" && value.length > 0) return value;
-	}
-	return null;
 }

--- a/packages/cli/src/runtime/secret-values.ts
+++ b/packages/cli/src/runtime/secret-values.ts
@@ -1,0 +1,29 @@
+import { normalizeSecretRef } from "./hosted-mitm-profiles";
+
+export function normalizeSecretValues(
+	secretValues: Record<string, string> | undefined,
+): Record<string, string> {
+	const normalized: Record<string, string> = {};
+	for (const [ref, value] of Object.entries(secretValues ?? {})) {
+		normalized[ref] = value;
+		const secretRef = normalizeSecretRef(ref);
+		if (secretRef && normalized[secretRef] === undefined) {
+			normalized[secretRef] = value;
+		}
+	}
+	return normalized;
+}
+
+export function runtimeSecretValue(secrets: Record<string, unknown>, ref: string): string | null {
+	const normalized = normalizeSecretRef(ref);
+	const raw = ref.startsWith("secret://") ? ref.slice("secret://".length) : null;
+	const candidates = [ref, normalized, raw].filter(
+		(candidate, index, values): candidate is string =>
+			Boolean(candidate) && values.indexOf(candidate) === index,
+	);
+	for (const candidate of candidates) {
+		const value = secrets[candidate];
+		if (typeof value === "string" && value.length > 0) return value;
+	}
+	return null;
+}

--- a/packages/cli/src/runtime/state.ts
+++ b/packages/cli/src/runtime/state.ts
@@ -65,6 +65,7 @@ export interface RuntimeBootStatus {
 		managedConfig: string;
 		syncState: string;
 		manifestLastGood: string;
+		managedSecretCacheFile: string;
 		runConfigRoot: string;
 		mitmProfileRoot: string;
 		mitmProfileBundle: string;
@@ -81,6 +82,7 @@ export interface RuntimeBootStatus {
 		runRoot: string;
 		managedSecretRoot: string;
 		managedSecretFile: string;
+		runtimeSecretFileRoot: string;
 		daemonAuthToken: string;
 		instanceData: string;
 		sensitiveInstanceData: string;
@@ -107,6 +109,7 @@ function pathSummary(paths: RuntimePaths): RuntimeBootStatus["paths"] {
 		managedConfig: paths.managedConfig,
 		syncState: paths.syncState,
 		manifestLastGood: paths.manifestLastGood,
+		managedSecretCacheFile: paths.managedSecretCacheFile,
 		runConfigRoot: paths.runConfigRoot,
 		mitmProfileRoot: paths.mitmProfileRoot,
 		mitmProfileBundle: paths.mitmProfileBundle,
@@ -123,6 +126,7 @@ function pathSummary(paths: RuntimePaths): RuntimeBootStatus["paths"] {
 		runRoot: paths.runRoot,
 		managedSecretRoot: paths.managedSecretRoot,
 		managedSecretFile: paths.managedSecretFile,
+		runtimeSecretFileRoot: paths.runtimeSecretFileRoot,
 		daemonAuthToken: paths.daemonAuthToken,
 		instanceData: paths.instanceData,
 		sensitiveInstanceData: paths.sensitiveInstanceData,
@@ -183,6 +187,8 @@ export function ensureRuntimeStateDirs(paths = getRuntimePaths()): void {
 		dirname(paths.managedConfig),
 		dirname(paths.syncState),
 		paths.runRoot,
+		paths.managedSecretRoot,
+		paths.runtimeSecretFileRoot,
 	]) {
 		mkdirSync(dir, { recursive: true });
 	}

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -7,6 +7,7 @@ import {
 	readFileSync,
 	readlinkSync,
 	rmSync,
+	statSync,
 	symlinkSync,
 	utimesSync,
 	writeFileSync,
@@ -439,7 +440,7 @@ describe("runtime manifest datasource", () => {
 		expect(loaded.errors[0]).toContain("runtime source config does not exist");
 	});
 
-	it("refuses last-good offline boot when cached manifest references secretValues", async () => {
+	it("loads last-good offline boot when cached secret values satisfy refs", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -471,13 +472,61 @@ describe("runtime manifest datasource", () => {
 				recovery: { cacheManifest: true, allowOfflineBoot: true },
 			}),
 		);
+		writeFileSync(
+			join(state, "cache", "runtime-secrets.last-good.json"),
+			JSON.stringify({ "provider.default.apiKey": "sk-cached-provider" }),
+		);
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths());
+		expect("manifest" in loaded).toBe(true);
+		if (!("manifest" in loaded)) throw new Error("expected offline manifest load success");
+		expect(loaded.source).toBe("last-good-cache");
+		expect(loaded.offline).toBe(true);
+		expect(loaded.secretValues).toEqual({
+			"provider.default.apiKey": "sk-cached-provider",
+			"secret://provider.default.apiKey": "sk-cached-provider",
+		});
+	});
+
+	it("refuses last-good offline boot when cached secret values are missing", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		mkdirSync(join(state, "cache"), { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		writeFileSync(
+			join(state, "cache", "manifest.last-good.json"),
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				deploymentId: "dep_cached_secret_missing",
+				environmentId: "env_cached_secret_missing",
+				instanceId: "iid_cached_secret_missing",
+				generation: 3,
+				issuedAt: "2026-06-06T00:00:00Z",
+				controlPlane: { apiUrl: "https://cloud-api.test" },
+				runtimes: { openclaw: { enabled: false } },
+				projection: {
+					providers: {
+						default: {
+							kind: "openai-compatible",
+							baseUrl: "https://sub2api.test/v1",
+							apiKeySecretRef: "provider.default.apiKey",
+						},
+					},
+				},
+				recovery: { cacheManifest: true, allowOfflineBoot: true },
+			}),
+		);
 
 		const loaded = await loadRuntimeManifest(getRuntimePaths());
 		expect("errors" in loaded).toBe(true);
 		if (!("errors" in loaded)) throw new Error("expected manifest load failure");
 		expect(loaded.mode).toBe("repair");
 		expect(loaded.errors).toContain(
-			"cached manifest references secretValues (provider.default.apiKey); refusing offline boot without a fresh runtime manifest",
+			"cached manifest references secretValues (provider.default.apiKey); refusing offline boot because cached secret values are missing",
 		);
 	});
 
@@ -984,7 +1033,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 		expect(runConfig.secretEnv).toEqual({
 			CLAWDI_MANAGED_OPENAI_API_KEY: "secret://provider.default.apiKey",
 		});
-		expect(runConfig.secretFilePath).toBe(join(run, "secrets", "runtime-secrets.json"));
+		expect(runConfig.secretFilePath).toBe(join(run, "secrets", "runtimes", "openclaw.json"));
 		expect(JSON.stringify(runConfig)).not.toContain("sk-runtime-provider");
 	});
 
@@ -1271,6 +1320,107 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 		expect(existsSync(join(home, ".hermes", "config.yaml"))).toBe(false);
 	});
 
+	it("preserves non-OpenAI hosted provider protocols in direct agent projection", () => {
+		for (const providerCase of [
+			{
+				id: "anthropic",
+				type: "anthropic",
+				baseUrl: "https://api.anthropic.com",
+				model: "claude-opus-4-6",
+				apiMode: "anthropic_messages",
+				expectedOpenClawApi: "anthropic-messages",
+			},
+			{
+				id: "gemini",
+				type: "gemini",
+				baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+				model: "gemini-2.5-pro",
+				apiMode: "google_generate_content",
+				expectedOpenClawApi: "google-generative-ai",
+			},
+		]) {
+			const caseRoot = join(root, `provider-${providerCase.id}`);
+			const home = join(caseRoot, "home", "clawdi");
+			const state = join(caseRoot, "var", "lib", "clawdi");
+			const run = join(caseRoot, "run", "clawdi");
+			const openclawBin = join(home, ".openclaw", "bin", "openclaw");
+			const openclawPatch = join(caseRoot, "openclaw-provider-patch.json");
+			mkdirSync(dirname(openclawBin), { recursive: true });
+			process.env.HOME = home;
+			process.env.CLAWDI_RUNTIME_MODE = "hosted";
+			process.env.CLAWDI_SERVICE_STATE_DIR = state;
+			process.env.CLAWDI_RUN_DIR = run;
+			writeFileSync(
+				openclawBin,
+				[
+					"#!/bin/sh",
+					'if [ "$1 $2 $3 $4 $5" = "config patch --stdin --replace-path models.providers" ]; then',
+					`  cat > '${openclawPatch}'`,
+					"  exit 0",
+					"fi",
+					"exit 2",
+					"",
+				].join("\n"),
+			);
+			chmodSync(openclawBin, 0o700);
+
+			const loaded: RuntimeManifestLoad = {
+				source: "remote-datasource",
+				sourcePath: "https://runtime-source.test/desired-state",
+				offline: false,
+				secretValues: {
+					"provider.openclaw.apiKey": `sk-${providerCase.id}`,
+					"secret://provider.openclaw.apiKey": `sk-${providerCase.id}`,
+				},
+				manifest: {
+					schemaVersion: "clawdi.runtimeDesiredState.v1",
+					deploymentId: `dep_${providerCase.id}_provider`,
+					environmentId: `env_${providerCase.id}_provider`,
+					instanceId: `iid_${providerCase.id}_provider`,
+					generation: 1,
+					issuedAt: "2026-06-22T00:00:00Z",
+					workspaceRoot: join(home, "clawdi"),
+					controlPlane: { apiUrl: "https://cloud-api.test" },
+					runtimes: {
+						openclaw: {
+							enabled: true,
+							install: {
+								authority: "official",
+								method: "official-installer",
+								url: "https://openclaw.ai/install-cli.sh",
+								home,
+								args: ["--json", "--no-onboard"],
+							},
+						},
+					},
+					projection: {
+						sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+						system: { home },
+						providers: {
+							openclaw: {
+								kind: "openai-compatible",
+								type: providerCase.type,
+								baseUrl: providerCase.baseUrl,
+								model: providerCase.model,
+								apiMode: providerCase.apiMode,
+								runtimeEnvName: `${providerCase.id.toUpperCase()}_API_KEY`,
+								apiKeySecretRef: "provider.openclaw.apiKey",
+							},
+						},
+					},
+					mitmProfiles: { profiles: [] },
+					recovery: { cacheManifest: true, allowOfflineBoot: true },
+				},
+			};
+
+			const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
+			expect(convergence.installErrors).toEqual([]);
+			const patch = JSON.parse(readFileSync(openclawPatch, "utf-8"));
+			expect(patch.models.providers.openclaw.api).toBe(providerCase.expectedOpenClawApi);
+			expect(patch.models.providers.openclaw.api).not.toBeUndefined();
+		}
+	});
+
 	it("injects provider secrets from hosted runtime manifest responses into runtime run config", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -1332,10 +1482,93 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 		expect(runConfig.secretEnv).toEqual({
 			CLAWDI_MANAGED_OPENAI_API_KEY: "secret://provider.default.apiKey",
 		});
-		expect(runConfig.secretFilePath).toBe(join(run, "secrets", "runtime-secrets.json"));
+		expect(runConfig.secretFilePath).toBe(join(run, "secrets", "runtimes", "openclaw.json"));
 		expect(JSON.stringify(runConfig)).not.toContain("sk-runtime-provider");
-		const secrets = JSON.parse(readFileSync(join(run, "secrets", "runtime-secrets.json"), "utf-8"));
-		expect(secrets["secret://provider.default.apiKey"]).toBe("sk-runtime-provider");
+		const aggregateSecrets = JSON.parse(
+			readFileSync(join(run, "secrets", "runtime-secrets.json"), "utf-8"),
+		);
+		expect(aggregateSecrets["secret://provider.default.apiKey"]).toBe("sk-runtime-provider");
+		const runtimeSecrets = JSON.parse(
+			readFileSync(join(run, "secrets", "runtimes", "openclaw.json"), "utf-8"),
+		);
+		expect(runtimeSecrets).toEqual({
+			"provider.default.apiKey": "sk-runtime-provider",
+			"secret://provider.default.apiKey": "sk-runtime-provider",
+		});
+	});
+
+	it("does not project a key-required hosted provider without a secret ref as no-auth", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const openclawBin = join(home, ".openclaw", "bin", "openclaw");
+		mkdirSync(dirname(openclawBin), { recursive: true });
+		writeFileSync(
+			openclawBin,
+			`#!/usr/bin/env bash
+printf 'provider projection should not run for unhealthy provider\\n' >&2
+exit 64
+`,
+		);
+		chmodSync(openclawBin, 0o700);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+
+		const convergence = convergeRuntimeManifest(
+			{
+				manifest: {
+					schemaVersion: "clawdi.runtimeDesiredState.v1",
+					deploymentId: "dep_key_required_missing_ref",
+					environmentId: "env_key_required_missing_ref",
+					instanceId: "iid_key_required_missing_ref",
+					generation: 1,
+					issuedAt: "2026-06-26T00:00:00Z",
+					controlPlane: { apiUrl: "https://cloud-api.test" },
+					runtimes: {
+						openclaw: {
+							enabled: true,
+							run: {
+								command: openclawBin,
+								args: ["gateway", "run"],
+								env: {},
+								prependPath: [],
+							},
+						},
+					},
+					projection: {
+						providers: {
+							openclaw: {
+								kind: "openai-compatible",
+								type: "anthropic",
+								baseUrl: "https://api.anthropic.com",
+								model: "claude-opus-4-6",
+								apiMode: "anthropic_messages",
+								apiKeyRequired: true,
+								status: "error",
+								error: { code: "provider_secret_unavailable" },
+							},
+						},
+					},
+					recovery: {},
+				},
+				source: "fixture-file",
+				sourcePath: "test://key-required-missing-ref",
+				offline: false,
+				secretValues: {},
+			},
+			getRuntimePaths(),
+		);
+
+		expect(convergence.installErrors).toEqual([]);
+		const providerHealth = JSON.parse(
+			readFileSync(join(state, "status", "provider-health.json"), "utf-8"),
+		);
+		expect(providerHealth.providers.openclaw.status).toBe("error");
+		expect(providerHealth.providers.openclaw.reasons).toContain("provider_error");
+		expect(providerHealth.providers.openclaw.reasons).toContain("provider_secret_unavailable");
+		expect(providerHealth.providers.openclaw.reasons).toContain("api_key_secret_ref_missing");
 	});
 
 	it("does not infer runtime entries from the runtime bridge token", async () => {
@@ -1946,6 +2179,111 @@ printf 'ActiveState=active\\nSubState=running\\n'
 				'ExecStart="clawdi" "runtime" "watch"',
 			);
 			expect(readSystemdEnvFile(paths, "clawdi-runtime-watch")).not.toContain("file-runtime-token");
+		} finally {
+			restore();
+			console.log = previousLog;
+			process.exitCode = previousExitCode;
+		}
+	});
+
+	it("runtime watch does not advance last-good or ETags when systemd apply fails", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const sourcePath = join(root, "runtime-source.json");
+		const bin = join(root, "bin");
+		const previousExitCode = process.exitCode;
+		const previousLog = console.log;
+		const logs: string[] = [];
+		mkdirSync(join(run, "secrets"), { recursive: true });
+		mkdirSync(bin, { recursive: true });
+		mkdirSync(home, { recursive: true });
+		writeFileSync(
+			join(bin, "systemctl"),
+			`#!/usr/bin/env bash
+printf 'systemctl failed\\n' >&2
+exit 42
+`,
+		);
+		chmodSync(join(bin, "systemctl"), 0o700);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_SYSTEMD_APPLY = "1";
+		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
+		process.exitCode = undefined;
+		console.log = (value?: unknown) => {
+			logs.push(String(value));
+		};
+		seedCurrentCliInstall(state);
+		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
+		writeFileSync(
+			sourcePath,
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeSource.v1",
+				type: "http",
+				url: "https://runtime.test/manifest",
+				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
+			}),
+		);
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/manifest",
+				response: () =>
+					new Response(
+						JSON.stringify({
+							manifest: {
+								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								deploymentId: "dep_watch_systemd_failure",
+								environmentId: "env_watch_systemd_failure",
+								instanceId: "iid_watch_systemd_failure",
+								generation: 13,
+								issuedAt: "2026-06-06T00:00:00Z",
+								system: { home, workspace: join(home, "clawdi") },
+								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+								runtimes: {
+									openclaw: { enabled: false },
+									hermes: { enabled: false },
+								},
+							},
+							secretValues: {},
+						}),
+						{
+							status: 200,
+							headers: {
+								"content-type": "application/json",
+								etag: '"etag-watch-systemd-failure"',
+							},
+						},
+					),
+			},
+			{
+				method: "GET",
+				path: "/v1/channels",
+				response: () =>
+					new Response(JSON.stringify([]), {
+						status: 200,
+						headers: {
+							"content-type": "application/json",
+							etag: '"channels-etag-systemd-failure"',
+						},
+					}),
+			},
+		]);
+
+		try {
+			await runtimeWatch({ once: true, json: true });
+
+			expect(process.exitCode).toBe(1);
+			const event = JSON.parse(logs[0]);
+			expect(event.status).toBe("error");
+			expect(event.error).toContain("systemd apply failed");
+			expect(existsSync(join(state, "cache", "manifest.etag"))).toBe(false);
+			expect(existsSync(join(state, "cache", "channels.etag"))).toBe(false);
+			expect(existsSync(join(state, "cache", "manifest.last-good.json"))).toBe(false);
 		} finally {
 			restore();
 			console.log = previousLog;
@@ -4461,6 +4799,7 @@ exit 64
 				secretValues: {
 					"provider.default.apiKey": "sk-runtime",
 					"secret://provider.default.apiKey": "sk-runtime",
+					"provider.hermes.apiKey": "sk-other-runtime",
 				},
 			},
 			getRuntimePaths(),
@@ -4483,6 +4822,15 @@ exit 64
 		expect(openclawUnit).not.toContain("sk-runtime");
 		expect(openclawEnv).toContain('CLAWDI_MANAGED_OPENAI_API_KEY="sk-runtime"');
 		expect(openclawEnv).not.toContain(join(state, "bin"));
+		expect(statSync(join(run, "secrets")).mode & 0o777).toBe(0o711);
+		const aggregateSecretPath = join(run, "secrets", "runtime-secrets.json");
+		expect(statSync(aggregateSecretPath).mode & 0o777).toBe(0o600);
+		expect(statSync(join(run, "secrets", "runtimes")).mode & 0o777).toBe(0o700);
+		const runtimeSecrets = JSON.parse(
+			readFileSync(join(run, "secrets", "runtimes", "openclaw.json"), "utf-8"),
+		);
+		expect(runtimeSecrets["secret://provider.default.apiKey"]).toBe("sk-runtime");
+		expect(JSON.stringify(runtimeSecrets)).not.toContain("sk-other-runtime");
 	});
 
 	it("fails closed when direct systemd launch cannot resolve a provider secret", () => {
@@ -4906,8 +5254,8 @@ exit 64
 
 			expect(convergence.mode).toBe("normal");
 			expect(convergence.outputs.mitmProfileBundle).toBe(null);
-			expect(convergence.outputs.mitmSecretFile).toBe(join(run, "secrets", "runtime-secrets.json"));
-			expect(existsSync(convergence.outputs.mitmSecretFile ?? "")).toBe(true);
+			expect(convergence.outputs.mitmSecretFile).toBeNull();
+			expect(existsSync(join(run, "secrets", "runtime-secrets.json"))).toBe(true);
 			const paths = getRuntimePaths();
 			expect(convergence.outputs.processManager).toBe("systemd");
 			expect(convergence.outputs.systemdSystemUnits).toEqual([


### PR DESCRIPTION
## Findings fixed

1. Non-OpenAI BYOK providers got the wrong wire protocol
- Root cause: the backend only emitted provider `type` with agent-profile auth, while the CLI narrowed `apiMode` to OpenAI modes and defaulted missing `type` to `custom_openai_compatible`.
- Fix: hosted manifest provider entries now always include `type`; the CLI accepts the full shared `AiProviderApiMode` union and skips unhealthy providers instead of downgrading them.
- Tests: backend Anthropic/Gemini manifest projection coverage; CLI direct projection coverage for `anthropic_messages` and `google_generate_content`.

2. Offline boot was impossible with real secret-backed manifests
- Root cause: last-good loading rejected any manifest containing secret refs, even when `allowOfflineBoot` was true and secrets had been resolved during a previous converge.
- Fix: successful converges now persist normalized last-good secret values in a durable root-owned `0600` cache; offline boot loads that cache and only refuses when required refs are actually missing.
- Tests: last-good offline boot succeeds with satisfied cached refs and refuses with missing refs.

3. Required provider keys could fail open
- Root cause: a key-required provider with no resolved secret omitted `apiKeySecretRef`, and the CLI interpreted that as no-auth.
- Fix: backend emits unhealthy provider entries with `status: "error"`, `apiKeyRequired`, and an explicit error; CLI refuses to project key-required providers without refs and surfaces provider health reasons.
- Tests: backend missing-key provider manifest test; CLI no-auth downgrade prevention and provider-health tests.

4. Aggregate secret file was readable by the runtime user
- Root cause: the aggregate `runtime-secrets.json` was written `0600` but made runtime-user-owned, so the agent UID could read the full secret bundle.
- Fix: aggregate and last-good bundles are root-owned `0600`; provider/runtime consumers get only scoped secret files or root-injected env vars. The `run/secrets` parent is root-owned traversable-only so scoped files are reachable without letting the runtime user own or delete the aggregate bundle.
- Tests: secret-boundary test asserts aggregate mode, scoped runtime secret contents, and secret directory modes.

5. Last-good/ETag advanced before systemd apply success
- Root cause: watch could save last-good and ETags after convergence but before systemd apply succeeded.
- Fix: last-good/ETag writes are gated on clean convergence plus successful systemd apply; CLI-update-only handling keeps the previous behavior.
- Tests: runtime watch test verifies failed systemd apply does not advance last-good, manifest ETag, or channels ETag.

6. Explicit archived/missing runtime provider bindings silently fell back
- Root cause: explicit runtime `provider_id` used the same fallback path as default provider binding.
- Fix: explicit missing/archived providers now produce an unhealthy manifest entry; default-binding fallback remains intact.
- Tests: backend explicit archived provider unhealthy test and default archived provider fallback test.

## Finding re-scoped

7. Hosted runtime set drift for `codex`
- Corrected resolution: `codex` is a valid backend/admin hosted runtime desired state. The backend must accept and emit it.
- Fix in this PR: reverted the backend restriction and added positive coverage that admin runtime-state and runtime manifest generation accept enabled `codex`.
- Follow-up: CLI hosted-runtime first-class `codex` support remains a CLI-side compatibility item; this PR does not break valid backend `codex` deployments.

## Deferred

- CLI first-class hosted `codex` converge support, because the immediate regression was caused by incorrectly rejecting valid backend desired state. The other provider protocol, offline boot, secret fail-closed, secret boundary, ETag, and explicit-provider fallback fixes remain in this PR.

## Verification

- Fresh migrated throwaway DB: `clawdi_test_pr315_1783230595`
- `DATABASE_URL=postgresql+asyncpg://clawdi:clawdi_dev@localhost:5433/clawdi_test_pr315_1783230595 uv run alembic upgrade head`
- `DATABASE_URL=postgresql+asyncpg://clawdi:clawdi_dev@localhost:5433/clawdi_test_pr315_1783230595 uv run pytest` -> 876 passed, 7 skipped
- `bun test` in `packages/cli` -> 732 passed, 0 failed
- `bun run check`
- `bun run --cwd packages/cli typecheck`
- `bun run --cwd packages/shared typecheck`
- `uv run ruff check app/routes/runtime.py app/schemas/admin.py tests/test_runtime_manifest.py tests/test_admin_endpoints.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)