### PR TITLE
fix(v2): correct wallet top-up success + provider env/vault edit + channel health polling

### DIFF
--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -22,17 +22,10 @@ import type {
 	WalletTopupRequest,
 } from "@/hosted/billing/contracts";
 import { billingQueryRetry } from "@/hosted/billing/errors";
+import { billingKeys } from "@/hosted/billing/query-keys";
 import { shouldPollDeployments } from "@/hosted/deployment-status";
 
-export const billingKeys = {
-	wallet: ["billing", "wallet"] as const,
-	ledger: (limit: number) => ["billing", "ledger", limit] as const,
-	plans: ["billing", "plans"] as const,
-	deployments: ["billing", "deployments"] as const,
-	legacyAgentEnvironments: ["billing", "legacy-agent-environments"] as const,
-	me: ["billing", "me"] as const,
-	usage: ["billing", "usage"] as const,
-};
+export { billingKeys } from "@/hosted/billing/query-keys";
 
 type CheckoutMutationVariables = {
 	body: CheckoutRequest;

--- a/apps/web/src/hosted/billing/query-keys.ts
+++ b/apps/web/src/hosted/billing/query-keys.ts
@@ -1,0 +1,9 @@
+export const billingKeys = {
+	wallet: ["billing", "wallet"] as const,
+	ledger: (limit: number) => ["billing", "ledger", limit] as const,
+	plans: ["billing", "plans"] as const,
+	deployments: ["billing", "deployments"] as const,
+	legacyAgentEnvironments: ["billing", "legacy-agent-environments"] as const,
+	me: ["billing", "me"] as const,
+	usage: ["billing", "usage"] as const,
+};

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, mock, test } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
+import type { WalletTopupResult } from "@/hosted/billing/contracts";
+import { billingKeys } from "@/hosted/billing/query-keys";
+import { handleTopupStartResult } from "@/hosted/billing/wallet/top-up-dialog.logic";
+
+function result(overrides: Partial<WalletTopupResult>): WalletTopupResult {
+	return {
+		status: "requires_payment_method",
+		flow_type: null,
+		payment_intent_id: null,
+		client_secret: null,
+		credits_added: null,
+		...overrides,
+	};
+}
+
+function queryClientWithWalletActivity(): QueryClient {
+	const qc = new QueryClient();
+	qc.setQueryData(billingKeys.wallet, { balance_cents: 1_000 });
+	qc.setQueryData(billingKeys.ledger(50), { items: [] });
+	return qc;
+}
+
+describe("handleTopupStartResult", () => {
+	test("treats synchronous success as terminal success and refreshes wallet activity", () => {
+		const qc = queryClientWithWalletActivity();
+		const resetAttempt = mock(() => {});
+		const closeDialog = mock(() => {});
+		const startPayment = mock((_clientSecret: string) => {});
+		const toastSuccess = mock((_message: string, _options: { description: string }) => {});
+		const toastError = mock((_message: string, _options: { description: string }) => {});
+
+		handleTopupStartResult(
+			result({
+				status: "succeeded",
+				flow_type: "mock",
+				client_secret: null,
+				credits_added: 2500,
+			}),
+			{
+				queryClient: qc,
+				resetAttempt,
+				closeDialog,
+				startPayment,
+				toastSuccess,
+				toastError,
+			},
+		);
+
+		expect(qc.getQueryState(billingKeys.wallet)?.isInvalidated).toBe(true);
+		expect(qc.getQueryState(billingKeys.ledger(50))?.isInvalidated).toBe(true);
+		expect(resetAttempt).toHaveBeenCalledTimes(1);
+		expect(closeDialog).toHaveBeenCalledTimes(1);
+		expect(toastSuccess).toHaveBeenCalledWith("Top-up complete", {
+			description: "Your credits will appear in a moment.",
+		});
+		expect(toastError).not.toHaveBeenCalled();
+		expect(startPayment).not.toHaveBeenCalled();
+	});
+
+	test("keeps payment intent responses on the card payment step", () => {
+		const qc = queryClientWithWalletActivity();
+		const resetAttempt = mock(() => {});
+		const closeDialog = mock(() => {});
+		const startPayment = mock((_clientSecret: string) => {});
+		const toastSuccess = mock((_message: string, _options: { description: string }) => {});
+		const toastError = mock((_message: string, _options: { description: string }) => {});
+
+		handleTopupStartResult(
+			result({
+				status: "requires_payment_method",
+				flow_type: "payment_intent",
+				payment_intent_id: "pi_123",
+				client_secret: "pi_123_secret_456",
+			}),
+			{
+				queryClient: qc,
+				resetAttempt,
+				closeDialog,
+				startPayment,
+				toastSuccess,
+				toastError,
+			},
+		);
+
+		expect(startPayment).toHaveBeenCalledWith("pi_123_secret_456");
+		expect(closeDialog).not.toHaveBeenCalled();
+		expect(resetAttempt).not.toHaveBeenCalled();
+		expect(toastSuccess).not.toHaveBeenCalled();
+		expect(toastError).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
@@ -1,0 +1,67 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { WalletTopupResult } from "@/hosted/billing/contracts";
+import { billingKeys } from "@/hosted/billing/query-keys";
+
+type TopupToast = (message: string, options: { description: string }) => void;
+
+export type TopupCompletionStatus = "succeeded" | "processing";
+
+export interface TopupCompletionControls {
+	queryClient: QueryClient;
+	resetAttempt: () => void;
+	closeDialog: () => void;
+	toastSuccess: TopupToast;
+}
+
+export interface TopupStartResultControls extends TopupCompletionControls {
+	startPayment: (clientSecret: string) => void;
+	toastError: TopupToast;
+}
+
+export function invalidateWalletActivity(queryClient: QueryClient): void {
+	queryClient.invalidateQueries({ queryKey: billingKeys.wallet });
+	queryClient.invalidateQueries({ queryKey: ["billing", "ledger"] });
+}
+
+export function completeTopup(
+	status: TopupCompletionStatus,
+	controls: TopupCompletionControls,
+): void {
+	invalidateWalletActivity(controls.queryClient);
+	controls.resetAttempt();
+	if (status === "succeeded") {
+		controls.toastSuccess("Top-up complete", {
+			description: "Your credits will appear in a moment.",
+		});
+	} else {
+		controls.toastSuccess("Top-up processing", {
+			description: "We'll credit your wallet once the payment settles.",
+		});
+	}
+	controls.closeDialog();
+}
+
+export function handleTopupStartResult(
+	result: WalletTopupResult,
+	controls: TopupStartResultControls,
+): void {
+	if (result.status === "succeeded" || result.credits_added != null) {
+		completeTopup("succeeded", controls);
+		return;
+	}
+	if (result.flow_type === "payment_intent" && result.client_secret) {
+		controls.startPayment(result.client_secret);
+		return;
+	}
+	if (isProcessingTopupStatus(result.status)) {
+		completeTopup("processing", controls);
+		return;
+	}
+	controls.toastError("Couldn't start top-up", {
+		description: "No payment was returned. Please try again.",
+	});
+}
+
+function isProcessingTopupStatus(status: string): boolean {
+	return status === "processing" || status === "pending" || status === "requires_capture";
+}

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
@@ -17,13 +17,14 @@ import { Spinner } from "@/components/ui/spinner";
 import type { WalletState } from "@/hosted/billing/contracts";
 import { normalizeBillingError } from "@/hosted/billing/errors";
 import { formatCents, formatCredits } from "@/hosted/billing/format";
-import { billingKeys, useTopUp } from "@/hosted/billing/hooks";
+import { useTopUp } from "@/hosted/billing/hooks";
 import { newIdempotencyKey } from "@/hosted/billing/idempotency";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import {
 	type PaymentOutcome,
 	StripePaymentForm,
 } from "@/hosted/billing/wallet/stripe-payment-form";
+import { completeTopup, handleTopupStartResult } from "@/hosted/billing/wallet/top-up-dialog.logic";
 import {
 	TOPUP_MAX_CENTS,
 	TOPUP_MIN_CENTS,
@@ -92,13 +93,18 @@ export function TopUpDialog({
 				body: { amount_cents: amountCents },
 				idempotencyKey: topupKeyRef.current,
 			});
-			if (result.flow_type === "payment_intent" && result.client_secret) {
-				setClientSecret(result.client_secret);
-				setStep("pay");
-				return;
-			}
-			toast.error("Couldn’t start top-up", {
-				description: "No payment was returned. Please try again.",
+			handleTopupStartResult(result, {
+				queryClient: qc,
+				resetAttempt: () => {
+					topupKeyRef.current = null;
+				},
+				closeDialog: () => close(false),
+				toastSuccess: toast.success,
+				toastError: toast.error,
+				startPayment: (nextClientSecret) => {
+					setClientSecret(nextClientSecret);
+					setStep("pay");
+				},
 			});
 		} catch (e) {
 			toast.error("Couldn’t start top-up", { description: normalizeBillingError(e) });
@@ -109,18 +115,14 @@ export function TopUpDialog({
 	// inline by StripePaymentForm, which keeps the dialog open until it settles
 	// rather than closing on an unconfirmed payment.
 	function onPaid(status: PaymentOutcome) {
-		qc.invalidateQueries({ queryKey: billingKeys.wallet });
-		qc.invalidateQueries({ queryKey: ["billing", "ledger"] });
-		if (status === "succeeded") {
-			toast.success("Top-up complete", {
-				description: "Your credits will appear in a moment.",
-			});
-		} else {
-			toast.success("Top-up processing", {
-				description: "We’ll credit your wallet once the payment settles.",
-			});
-		}
-		close(false);
+		completeTopup(status === "succeeded" ? "succeeded" : "processing", {
+			queryClient: qc,
+			resetAttempt: () => {
+				topupKeyRef.current = null;
+			},
+			closeDialog: () => close(false),
+			toastSuccess: toast.success,
+		});
 	}
 
 	return (

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import {
+	apiKeyEditState,
+	providerAuthForSubmit,
+} from "@/hosted/v2/ai-providers/add-provider-dialog.logic";
+import type { AiProviderAuth } from "@/hosted/v2/ai-providers/types";
+
+describe("providerAuthForSubmit", () => {
+	test("preserves env-source API key auth when editing with a blank key", () => {
+		const auth = {
+			type: "api_key",
+			source: "env",
+			ref: "env:OPENAI_API_KEY",
+		} satisfies AiProviderAuth;
+
+		expect(
+			providerAuthForSubmit({
+				authMethod: "api_key",
+				editingAuth: auth,
+				hasNewManagedKey: false,
+			}),
+		).toBe(auth);
+		expect(apiKeyEditState("api_key", auth)).toMatchObject({
+			canKeepManagedApiKey: false,
+			canKeepExternalApiKeyRef: true,
+			keyRequired: false,
+			labelSuffix: " (leave blank to keep current env reference)",
+		});
+	});
+
+	test("preserves vault-source API key auth when editing with a blank key", () => {
+		const auth = {
+			type: "api_key",
+			source: "vault",
+			ref: "clawdi://project/proj_1/vault/ai-providers/section/onboarding/field/openai_api_key",
+		} satisfies AiProviderAuth;
+
+		expect(
+			providerAuthForSubmit({
+				authMethod: "api_key",
+				editingAuth: auth,
+				hasNewManagedKey: false,
+			}),
+		).toBe(auth);
+		expect(apiKeyEditState("api_key", auth)).toMatchObject({
+			canKeepManagedApiKey: false,
+			canKeepExternalApiKeyRef: true,
+			keyRequired: false,
+			labelSuffix: " (leave blank to keep current vault reference)",
+		});
+	});
+
+	test("switches to managed auth when the edit supplies a new key", () => {
+		const auth = {
+			type: "api_key",
+			source: "env",
+			ref: "env:OPENAI_API_KEY",
+		} satisfies AiProviderAuth;
+
+		expect(
+			providerAuthForSubmit({
+				authMethod: "api_key",
+				editingAuth: auth,
+				hasNewManagedKey: true,
+			}),
+		).toEqual({ type: "api_key", source: "managed" });
+	});
+});

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.ts
@@ -1,0 +1,93 @@
+import type { AiProviderAuth } from "@/hosted/v2/ai-providers/types";
+
+export type AuthMethod = "api_key" | "oauth" | "none";
+
+export type ApiKeyKeepKind = "managed" | "env" | "vault" | "legacy_secret_ref";
+
+export interface ApiKeyEditState {
+	canKeepManagedApiKey: boolean;
+	canKeepLegacySecretRef: boolean;
+	canKeepExternalApiKeyRef: boolean;
+	canKeepExistingKey: boolean;
+	keyRequired: boolean;
+	labelSuffix: string;
+	helpText: string;
+}
+
+export function isAuthMethod(value: string | null): value is AuthMethod {
+	return value === "api_key" || value === "oauth" || value === "none";
+}
+
+export function authFor(method: AuthMethod): AiProviderAuth {
+	if (method === "api_key") return { type: "api_key", source: "managed" };
+	if (method === "oauth") return { type: "agent_profile", tool: "codex", profile: "default" };
+	return { type: "none" };
+}
+
+export function apiKeyEditState(
+	authMethod: AuthMethod,
+	editingAuth: AiProviderAuth | null | undefined,
+): ApiKeyEditState {
+	const keepable = keepableExistingApiKeyAuth(editingAuth);
+	const keepKind = authMethod === "api_key" ? keepable?.kind : undefined;
+	const canKeepExistingKey = keepKind !== undefined;
+	return {
+		canKeepManagedApiKey: keepKind === "managed",
+		canKeepLegacySecretRef: keepKind === "legacy_secret_ref",
+		canKeepExternalApiKeyRef: keepKind === "env" || keepKind === "vault",
+		canKeepExistingKey,
+		keyRequired: authMethod === "api_key" && !canKeepExistingKey,
+		labelSuffix: apiKeyLabelSuffix(keepKind),
+		helpText: apiKeyHelpText(keepKind),
+	};
+}
+
+export function providerAuthForSubmit({
+	authMethod,
+	editingAuth,
+	hasNewManagedKey,
+}: {
+	authMethod: AuthMethod;
+	editingAuth: AiProviderAuth | null | undefined;
+	hasNewManagedKey: boolean;
+}): AiProviderAuth {
+	if (authMethod !== "api_key") return authFor(authMethod);
+	if (!hasNewManagedKey) {
+		const keepable = keepableExistingApiKeyAuth(editingAuth);
+		if (keepable) return keepable.auth;
+	}
+	return authFor("api_key");
+}
+
+function keepableExistingApiKeyAuth(
+	auth: AiProviderAuth | null | undefined,
+): { kind: ApiKeyKeepKind; auth: AiProviderAuth } | null {
+	if (!auth) return null;
+	if (auth.type === "secret_ref" && auth.ref) return { kind: "legacy_secret_ref", auth };
+	if (auth.type !== "api_key") return null;
+	if (auth.source === "managed") return { kind: "managed", auth };
+	if ((auth.source === "env" || auth.source === "vault") && auth.ref) {
+		return { kind: auth.source, auth };
+	}
+	return null;
+}
+
+function apiKeyLabelSuffix(kind: ApiKeyKeepKind | undefined): string {
+	if (!kind) return "";
+	if (kind === "managed") return " (leave blank to keep)";
+	if (kind === "legacy_secret_ref") return " (leave blank to keep legacy reference)";
+	return ` (leave blank to keep current ${kind} reference)`;
+}
+
+function apiKeyHelpText(kind: ApiKeyKeepKind | undefined): string {
+	if (kind === "legacy_secret_ref") {
+		return "Leave blank to preserve this provider's existing legacy secret reference. Enter a key to switch it to managed API-key auth.";
+	}
+	if (kind === "env" || kind === "vault") {
+		return `Leave blank to keep the current ${kind} reference. Enter a key to switch it to managed API-key auth.`;
+	}
+	if (kind === "managed") {
+		return "Leave blank to keep the current managed key. Enter a key to replace it.";
+	}
+	return "Stored encrypted for the hosted runtime and delivered as a manifest secret. The dashboard will not show it again.";
+}

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -25,6 +25,12 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import {
+	type AuthMethod,
+	apiKeyEditState,
+	isAuthMethod,
+	providerAuthForSubmit,
+} from "@/hosted/v2/ai-providers/add-provider-dialog.logic";
+import {
 	useAiProviders,
 	useDeleteProviderQuiet,
 	useOAuthComplete,
@@ -52,13 +58,7 @@ import {
 	providerTypeMeta,
 	toProviderId,
 } from "@/hosted/v2/ai-providers/provider-types";
-import type { AiProvider, AiProviderAuth } from "@/hosted/v2/ai-providers/types";
-
-type AuthMethod = "api_key" | "oauth" | "none";
-
-function isAuthMethod(value: string | null): value is AuthMethod {
-	return value === "api_key" || value === "oauth" || value === "none";
-}
+import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 
 function isApiMode(value: string | null): value is ApiMode {
 	return (
@@ -67,12 +67,6 @@ function isApiMode(value: string | null): value is ApiMode {
 		value === "anthropic_messages" ||
 		value === "google_generate_content"
 	);
-}
-
-function authFor(method: AuthMethod): AiProviderAuth {
-	if (method === "api_key") return { type: "api_key", source: "managed" };
-	if (method === "oauth") return { type: "agent_profile", tool: "codex", profile: "default" };
-	return { type: "none" };
 }
 
 // Backend rule (_validate_base_url): `none` auth is only allowed for a loopback
@@ -215,16 +209,10 @@ export function AddProviderDialog({
 	const providerId = isEdit ? (editing?.provider_id ?? "") : toProviderId(label || meta.label);
 	// `none` auth only works with a loopback/private base_url (backend rule).
 	const noneAuthOk = authMethod !== "none" || isLoopbackOrPrivateUrl(baseUrl.trim());
-	const canKeepManagedApiKey =
-		authMethod === "api_key" && isEdit && editing?.auth.type === "api_key";
-	const existingSecretRefAuth =
-		isEdit && editing?.auth.type === "secret_ref" && editing.auth.ref ? editing.auth : null;
-	const canKeepLegacySecretRef = authMethod === "api_key" && Boolean(existingSecretRefAuth);
-	const canKeepExistingKey = canKeepManagedApiKey || canKeepLegacySecretRef;
-	// A key is required for api_key unless this provider is already using a
-	// managed API key. Legacy secret_ref edits can keep the existing ref, but
-	// new providers and auth-method switches still need a managed key.
-	const keyRequired = authMethod === "api_key" && !canKeepExistingKey;
+	const apiKeyState = isEdit
+		? apiKeyEditState(authMethod, editing?.auth)
+		: apiKeyEditState(authMethod, null);
+	const { keyRequired, labelSuffix: apiKeyLabelSuffix, helpText: apiKeyHelpText } = apiKeyState;
 	const canSubmit =
 		Boolean(providerId) &&
 		Boolean(baseUrl.trim()) &&
@@ -297,10 +285,13 @@ export function AddProviderDialog({
 			return;
 		}
 
-		let auth = authFor(authMethod);
 		const isApiKeySubmit = authMethod === "api_key";
 		const hasNewManagedKey = isApiKeySubmit && Boolean(apiKey.trim());
-		if (isApiKeySubmit && existingSecretRefAuth) auth = existingSecretRefAuth;
+		const auth = providerAuthForSubmit({
+			authMethod,
+			editingAuth: editing?.auth,
+			hasNewManagedKey,
+		});
 
 		const keyBacked = auth.type === "api_key" || auth.type === "secret_ref";
 		const body = {
@@ -721,9 +712,7 @@ export function AddProviderDialog({
 								{authMethod === "api_key" ? (
 									<>
 										<div className="flex flex-col gap-1.5">
-											<Label htmlFor="provider-key">
-												API key{canKeepExistingKey ? " (leave blank to keep)" : ""}
-											</Label>
+											<Label htmlFor="provider-key">API key{apiKeyLabelSuffix}</Label>
 											<Input
 												id="provider-key"
 												name="provider-key"
@@ -734,11 +723,7 @@ export function AddProviderDialog({
 												autoComplete="off"
 												spellCheck={false}
 											/>
-											<p className="text-xs text-muted-foreground">
-												{canKeepLegacySecretRef
-													? "Leave blank to preserve this provider's existing legacy secret reference. Enter a key to switch it to managed API-key auth."
-													: "Stored encrypted for the hosted runtime and delivered as a manifest secret. The dashboard will not show it again."}
-											</p>
+											<p className="text-xs text-muted-foreground">{apiKeyHelpText}</p>
 											{keyRequired && isEdit && !apiKey.trim() ? (
 												<p className="text-xs text-destructive">
 													Enter a key to switch this provider to managed API-key auth.

--- a/apps/web/src/hosted/v2/channels/channel-health-query.ts
+++ b/apps/web/src/hosted/v2/channels/channel-health-query.ts
@@ -1,0 +1,11 @@
+import { channelKeys } from "@/hosted/v2/channels/channel-query-cache";
+
+export const CHANNEL_HEALTH_REFETCH_INTERVAL_MS = 20_000;
+
+export function channelHealthQueryOptions<TData>(queryFn: () => Promise<TData>) {
+	return {
+		queryKey: channelKeys.health,
+		queryFn,
+		refetchInterval: CHANNEL_HEALTH_REFETCH_INTERVAL_MS,
+	};
+}

--- a/apps/web/src/hosted/v2/channels/channels-hooks.test.ts
+++ b/apps/web/src/hosted/v2/channels/channels-hooks.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+	CHANNEL_HEALTH_REFETCH_INTERVAL_MS,
+	channelHealthQueryOptions,
+} from "@/hosted/v2/channels/channel-health-query";
+import { channelKeys } from "@/hosted/v2/channels/channel-query-cache";
+
+describe("channelHealthQueryOptions", () => {
+	test("polls live channel health on a modest interval", async () => {
+		const health = [{ account_id: "channel_123", status: "healthy" }];
+		const queryFn = mock(async () => health);
+
+		const options = channelHealthQueryOptions(queryFn);
+
+		expect(options.queryKey).toEqual(channelKeys.health);
+		expect(options.refetchInterval).toBe(CHANNEL_HEALTH_REFETCH_INTERVAL_MS);
+		expect(options.refetchInterval).toBe(20_000);
+		await expect(options.queryFn()).resolves.toEqual(health);
+		expect(queryFn).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/hosted/v2/channels/channels-hooks.ts
+++ b/apps/web/src/hosted/v2/channels/channels-hooks.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useChannelEditApi } from "@/hosted/v2/channels/channel-edit-client";
+import { channelHealthQueryOptions } from "@/hosted/v2/channels/channel-health-query";
 import {
 	channelKeys as keys,
 	removeDeletedChannelQueries,
@@ -35,10 +36,9 @@ export function useBotPool() {
 
 export function useChannelHealth() {
 	const api = useApi();
-	return useQuery({
-		queryKey: keys.health,
-		queryFn: async () => unwrap(await api.GET("/v1/channels/health")),
-	});
+	return useQuery(
+		channelHealthQueryOptions(async () => unwrap(await api.GET("/v1/channels/health"))),
+	);
 }
 
 export function useChannel(id: string) {


### PR DESCRIPTION
## Summary

Fixes confirmed behavioral bugs in the v2 hosted dashboard without touching v1/legacy or verbatim UI primitives.

## Bugs fixed

### P1-1 Wallet top-up synchronous success

Root cause: `TopUpDialog` only advanced when the top-up response returned `flow_type: "payment_intent"` plus `client_secret`; terminal success responses such as `status: "succeeded"`, `flow_type: "mock"`, `client_secret: null`, and `credits_added` fell through to a hard error.

Fix: classify the top-up response explicitly. Terminal success now invalidates wallet and ledger queries, resets the attempt idempotency key, shows the success toast, and closes the dialog. PaymentIntent responses still move to the Stripe payment step. Processing responses without a client secret now show processing copy and refresh instead of an error. Only unusable responses show the error toast.

### P1-2 Provider env/vault API-key edit preservation

Root cause: editing any `api_key` provider allowed a blank key as "keep existing", but submit rebuilt auth as `{ type: "api_key", source: "managed" }`. For `env` or `vault` sources, that silently converted the provider to managed auth without storing a managed payload.

Fix: preserve the original `editing.auth` verbatim for blank API-key edits when the existing auth is `env`, `vault`, managed, or legacy `secret_ref`. Entering a new key still intentionally switches to managed auth. The API-key label/help copy now distinguishes managed keys from env/vault/legacy references.

### P2-3 Channel health polling

Root cause: channel health only refreshed on local invalidations or focus, so external runtime/delivery state changes could remain stale while the page stayed mounted.

Fix: added a 20s React Query `refetchInterval` for channel health while the page has an active observer, preserving existing mutation invalidation behavior.

## Deferred

### P2-4 WhatsApp pending pairing

Left untouched. The honest fix needs backend metadata such as `pairing_status`, `paired_at`, and the real phone JID. The current frontend only receives synthetic JIDs, so client-side heuristics would misrepresent state.

## Tests

- `bun install`
- `cd apps/web && bunx @biomejs/biome@2.5.2 ci .`
- `bun run check`
- `bun run typecheck`
- `bun run test`
- `cd apps/web && bun run e2e:hosted`
- `cd apps/web && bun run e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
