### PR TITLE
fix(v2): remove Codex from hosted runtime UI

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -128,7 +128,6 @@ import {
 	type HostedRuntime,
 	OPTIONAL_HOSTED_RUNTIMES,
 	runtimeBlurb,
-	runtimeCanDisable,
 	runtimeConsoleUrl,
 	runtimeDisplayName,
 	runtimeIsConfigured,
@@ -320,10 +319,10 @@ function redirectToCheckout(url: string | null | undefined): boolean {
 }
 
 /**
- * PER-RUNTIME agent detail. A compute (deployment) hosts the always-on Codex
- * runtime plus optional sibling runtimes; each runtime has its own env id, AI
- * provider binding, channel links, sessions, and control UI. Terminal and compute
- * controls are deployment-wide because they attach to the shared hosted compute.
+ * PER-RUNTIME agent detail. A compute (deployment) hosts one or more execution
+ * runtimes; each runtime has its own env id, AI provider binding, channel links,
+ * sessions, and control UI. Terminal and compute controls are deployment-wide
+ * because they attach to the shared hosted compute.
  */
 export function HostedAgentDetail({
 	environmentId,
@@ -1111,16 +1110,6 @@ function AiProviderTab({
 		setPrimaryModel(currentModel);
 	}
 
-	if (runtime === "codex") {
-		return (
-			<EmptyState
-				icon={Info}
-				title="Codex AI access is set at deploy time"
-				description="This hosted runtime is always available. Runtime-specific AI provider changes are available for OpenClaw and Hermes."
-			/>
-		);
-	}
-
 	const dirty = selected !== initial || primaryModel !== currentModel;
 
 	function apply() {
@@ -1716,11 +1705,8 @@ function ComputeSettingsSections({
 	const [termChangeConfirmation, setTermChangeConfirmation] =
 		useState<TermChangeConfirmation | null>(null);
 	const envs = ci?.clawdi_cloud_environments ?? {};
-	const optionalEnabledCount = OPTIONAL_HOSTED_RUNTIMES.filter((runtimeId) =>
+	const enabledRuntimeCount = OPTIONAL_HOSTED_RUNTIMES.filter((runtimeId) =>
 		runtimeIsEnabled(ci, runtimeId),
-	).length;
-	const enabledRuntimeCount = RUNTIMES.filter((runtimeItem) =>
-		runtimeIsEnabled(ci, runtimeItem.id),
 	).length;
 	const restartNeedsConfirmation = enabledRuntimeCount > 1;
 	const runtimePending = setEnabled.isPending || onboard.isPending;
@@ -1947,7 +1933,7 @@ function ComputeSettingsSections({
 			>
 				<div className="flex flex-col gap-4">
 					<LiveNote>
-						Codex stays on by default. Optional runtime changes apply live, no restart.
+						Runtime changes apply live, no restart. Keep at least one runtime active.
 					</LiveNote>
 					<div className="flex flex-col">
 						{RUNTIMES.map((r, index) => {
@@ -1955,9 +1941,8 @@ function ComputeSettingsSections({
 							const isConfigured = runtimeIsConfigured(ci, r.id);
 							const isCurrent = r.id === runtime;
 							const siblingEnv = envs[r.id];
-							const canDisable = runtimeCanDisable(r.id);
-							const blockedByPlan =
-								canDisable && !isPerformance && !enabled && optionalEnabledCount >= 1;
+							const blockedByPlan = !isPerformance && !enabled && enabledRuntimeCount >= 1;
+							const blockedByLastRuntime = enabled && enabledRuntimeCount <= 1;
 							return (
 								<Fragment key={r.id}>
 									{index > 0 ? <Separator /> : null}
@@ -1967,7 +1952,6 @@ function ComputeSettingsSections({
 											<div className="flex flex-wrap items-center gap-1.5 text-sm font-medium">
 												{r.label}
 												{isCurrent ? <Badge variant="secondary">This agent</Badge> : null}
-												{canDisable ? null : <Badge variant="outline">Always on</Badge>}
 											</div>
 											<div className="text-xs text-muted-foreground">{r.blurb}</div>
 										</div>
@@ -1989,16 +1973,21 @@ function ComputeSettingsSections({
 													<ArrowUpRight className="size-3.5" />
 												</Button>
 											) : null}
-											{!canDisable ? null : isConfigured ? (
+											{isConfigured ? (
 												<Switch
 													checked={enabled}
-													disabled={runtimePending || blockedByPlan}
+													disabled={runtimePending || blockedByPlan || blockedByLastRuntime}
 													onCheckedChange={(next) =>
 														void runAction(() => setRuntimeEnabled(r.id, next)).catch(
 															() => undefined,
 														)
 													}
 													aria-label={`Toggle ${r.label}`}
+													title={
+														blockedByLastRuntime
+															? "At least one runtime must stay active"
+															: undefined
+													}
 												/>
 											) : (
 												<Button
@@ -2029,8 +2018,7 @@ function ComputeSettingsSections({
 						})}
 					</div>
 					<p className="text-xs text-muted-foreground">
-						Codex is always available. Free can add one optional runtime; Performance can add both
-						OpenClaw and Hermes.
+						Free can run one runtime; Performance can run OpenClaw and Hermes together.
 					</p>
 				</div>
 			</SettingsSection>

--- a/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
@@ -35,4 +35,18 @@ describe("buildHostedDeployRequest", () => {
 		expect("assistant_name" in (request.config ?? {})).toBe(false);
 		expect("personality" in (request.config ?? {})).toBe(false);
 	});
+
+	test("rejects deploys without an execution engine", () => {
+		expect(() =>
+			buildHostedDeployRequest({
+				computePlanSlug: "compute_free",
+				engines: { openclaw: false, hermes: false },
+				persona: {
+					language: "",
+					timezone: "",
+				},
+				aiFields: { ai_provider_auth_kind: "managed" },
+			}),
+		).toThrow("Select at least one execution engine.");
+	});
 });

--- a/apps/web/src/hosted/billing/deploy/deploy-request.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-request.ts
@@ -23,6 +23,10 @@ export function buildHostedDeployRequest({
 	persona: DeployPersona;
 	aiFields: Partial<DeployRequest>;
 }): DeployRequest {
+	if (!engines.openclaw && !engines.hermes) {
+		throw new Error("Select at least one execution engine.");
+	}
+
 	const personaFields = {
 		language: persona.language || null,
 		timezone: persona.timezone || null,

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -89,6 +89,7 @@ type ComputePlanSlug = DeployRequest["compute_plan_slug"];
 const DEPLOY_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
 const THREE_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2 lg:grid-cols-3";
 const TWO_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2";
+const RUNTIME_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2";
 /** Sentinel for the managed-AI choice. Underscores keep it outside the
  * provider-id charset so no user provider_id can ever collide with it. */
 const MANAGED_AI_CHOICE = "__managed__";
@@ -312,7 +313,8 @@ export function DeployWizard() {
 			? !!perfPlan && !!perfOfferSelection
 			: !!freePlan && !freeSlotUnavailable;
 	const planReady = !plans.isLoading && computePlanReady;
-	const canSubmit = planReady && !submitting;
+	const hasExecutionEngine = enginesSelected.length > 0;
+	const canSubmit = planReady && hasExecutionEngine && !submitting;
 
 	function selectCreatedProvider(providerId: string) {
 		createdProviderGuardRef.current = {
@@ -394,10 +396,11 @@ export function DeployWizard() {
 
 	function toggleEngine(engine: Engine) {
 		setEngines((prev) => {
+			const selectedCount = (Object.keys(prev) as Engine[]).filter((key) => prev[key]).length;
+			if (prev[engine] && selectedCount <= 1) return prev;
 			if (dualAllowed) {
 				return { ...prev, [engine]: !prev[engine] };
 			}
-			if (prev[engine]) return { ...prev, [engine]: false };
 			return { openclaw: engine === "openclaw", hermes: engine === "hermes" };
 		});
 	}
@@ -516,10 +519,9 @@ export function DeployWizard() {
 		aiChoice === MANAGED_AI_CHOICE
 			? "Managed AI"
 			: (providerList.find((p) => p.provider_id === aiChoice)?.label ?? "Your provider");
-	const runtimeSummary = [
-		runtimeDisplayName("codex"),
-		...enginesSelected.map((engine) => runtimeDisplayName(engine)),
-	].join(" + ");
+	const runtimeSummary =
+		enginesSelected.map((engine) => runtimeDisplayName(engine)).join(" + ") ||
+		"No execution engine selected";
 	const summaryLine = [
 		`${compute === "performance" ? "Performance" : "Free"} compute`,
 		aiSummary,
@@ -561,25 +563,18 @@ export function DeployWizard() {
 			<div className="flex flex-col gap-6 sm:pb-24">
 				<PageHeader
 					title="Deploy an Agent"
-					description="Codex is included by default. Add optional runtimes and choose the AI provider for this hosted deployment."
+					description="Choose the execution engine and AI provider for this hosted deployment."
 				/>
 
 				<SettingsSection
 					title="Runtimes"
 					description={
 						dualAllowed
-							? "Codex stays on. Performance can also run OpenClaw and Hermes together."
-							: "Codex stays on. Free can add one optional runtime."
+							? "Performance can run OpenClaw and Hermes together."
+							: "Free runs one execution engine at a time."
 					}
 				>
-					<div className={THREE_TILE_GRID_CLASS}>
-						<EntityChoiceCard
-							selected
-							icon={<EntityIcon kind="framework" id="codex" label={runtimeDisplayName("codex")} />}
-							title={runtimeDisplayName("codex")}
-							description={runtimeBlurb("codex")}
-							badge={<Badge variant="outline">Always on</Badge>}
-						/>
+					<div className={RUNTIME_TILE_GRID_CLASS}>
 						<EntityChoiceCard
 							selected={engines.openclaw}
 							onClick={() => toggleEngine("openclaw")}
@@ -712,7 +707,7 @@ export function DeployWizard() {
 												? "Free slot check unavailable"
 												: freePlan
 													? `${freePlan.vcpu} vCPU / ${freePlan.ram_gb} GB burst · one active deployment`
-													: "$0 · Codex included"
+													: "$0 · one active deployment"
 								}
 								badge={<Badge variant="secondary">$0</Badge>}
 								disabled={freeSlotUnavailable}

--- a/apps/web/src/hosted/billing/deployment-links.test.ts
+++ b/apps/web/src/hosted/billing/deployment-links.test.ts
@@ -49,10 +49,10 @@ describe("hostedEnvironmentHref", () => {
 		);
 	});
 
-	test("prefers Codex when multiple hosted runtime environments exist", () => {
+	test("ignores stale Codex mappings when execution runtime environments exist", () => {
 		expect(
 			hostedEnvironmentHref(deployment({ openclaw: "env openclaw", codex: "env codex" })),
-		).toBe("/agents/env%20codex?source=on-clawdi");
+		).toBe("/agents/env%20openclaw?source=on-clawdi");
 	});
 
 	test("does not treat the deployment id as an agent environment id", () => {

--- a/apps/web/src/hosted/runtimes.test.ts
+++ b/apps/web/src/hosted/runtimes.test.ts
@@ -48,7 +48,7 @@ function configInfo(
 }
 
 describe("deploymentRuntimes", () => {
-	test("always includes Codex before enabled runtime environments", () => {
+	test("returns enabled execution runtime environments", () => {
 		expect(
 			deploymentRuntimes(
 				deployment(
@@ -61,7 +61,7 @@ describe("deploymentRuntimes", () => {
 					}),
 				),
 			),
-		).toEqual(["codex", "openclaw", "hermes"]);
+		).toEqual(["openclaw", "hermes"]);
 	});
 
 	test("does not surface disabled runtimes just because they remain configured", () => {
@@ -80,7 +80,7 @@ describe("deploymentRuntimes", () => {
 					}),
 				),
 			),
-		).toEqual(["codex", "openclaw"]);
+		).toEqual(["openclaw"]);
 	});
 
 	test("falls back to legacy enable flags when explicit runtime lists are absent", () => {
@@ -96,6 +96,23 @@ describe("deploymentRuntimes", () => {
 					}),
 				),
 			),
-		).toEqual(["codex", "hermes"]);
+		).toEqual(["hermes"]);
+	});
+
+	test("does not surface Codex from stale hosted environment mappings", () => {
+		expect(
+			deploymentRuntimes(
+				deployment(
+					configInfo({
+						enable_openclaw: true,
+						enable_hermes: false,
+						clawdi_cloud_environments: {
+							codex: "env-codex",
+							openclaw: "env-openclaw",
+						},
+					}),
+				),
+			),
+		).toEqual(["openclaw"]);
 	});
 });

--- a/apps/web/src/hosted/runtimes.ts
+++ b/apps/web/src/hosted/runtimes.ts
@@ -1,35 +1,24 @@
 import type { DeploymentDetailsInfo, HostedDeployment } from "@/hosted/billing/contracts";
 
-export const HOSTED_RUNTIMES = ["codex", "openclaw", "hermes"] as const;
+export const HOSTED_RUNTIMES = ["openclaw", "hermes"] as const;
 export type HostedRuntime = (typeof HOSTED_RUNTIMES)[number];
 
-export const OPTIONAL_HOSTED_RUNTIMES = [
-	"openclaw",
-	"hermes",
-] as const satisfies readonly HostedRuntime[];
-export const ALWAYS_ON_HOSTED_RUNTIME = "codex" as const satisfies HostedRuntime;
+export const OPTIONAL_HOSTED_RUNTIMES = HOSTED_RUNTIMES;
 
 const RUNTIME_ORDER = new Map<HostedRuntime, number>(
 	HOSTED_RUNTIMES.map((runtime, index) => [runtime, index]),
 );
 
 const RUNTIME_META = {
-	codex: {
-		label: "Codex",
-		blurb: "OpenAI's software engineering agent.",
-		canDisable: false,
-	},
 	openclaw: {
 		label: "OpenClaw",
 		blurb: "Your own personal AI assistant.",
-		canDisable: true,
 	},
 	hermes: {
 		label: "Hermes",
 		blurb: "The agent that grows with you.",
-		canDisable: true,
 	},
-} as const satisfies Record<HostedRuntime, { label: string; blurb: string; canDisable: boolean }>;
+} as const satisfies Record<HostedRuntime, { label: string; blurb: string }>;
 
 export function isHostedRuntime(value: string): value is HostedRuntime {
 	return (HOSTED_RUNTIMES as readonly string[]).includes(value);
@@ -41,10 +30,6 @@ export function runtimeDisplayName(runtime: HostedRuntime): string {
 
 export function runtimeBlurb(runtime: HostedRuntime): string {
 	return RUNTIME_META[runtime].blurb;
-}
-
-export function runtimeCanDisable(runtime: HostedRuntime): boolean {
-	return RUNTIME_META[runtime].canDisable;
 }
 
 export function sortHostedRuntimes(values: Iterable<string>): HostedRuntime[] {
@@ -61,7 +46,6 @@ export function runtimeIsEnabled(
 	configInfo: DeploymentDetailsInfo | null | undefined,
 	runtime: HostedRuntime,
 ): boolean {
-	if (runtime === ALWAYS_ON_HOSTED_RUNTIME) return true;
 	if (runtime === "openclaw") return configInfo?.enable_openclaw === true;
 	return configInfo?.enable_hermes === true;
 }
@@ -70,7 +54,6 @@ export function runtimeIsConfigured(
 	configInfo: DeploymentDetailsInfo | null | undefined,
 	runtime: HostedRuntime,
 ): boolean {
-	if (runtime === ALWAYS_ON_HOSTED_RUNTIME) return true;
 	return new Set(configInfo?.configured_agents ?? []).has(runtime);
 }
 
@@ -85,7 +68,6 @@ export function runtimeConsoleUrl(
 	deployment: HostedDeployment,
 	runtime: HostedRuntime,
 ): string | null | undefined {
-	if (runtime === "codex") return null;
 	if (runtime === "openclaw") return deployment.openclaw_control_ui_url;
 	return deployment.hermes_control_ui_url;
 }
@@ -97,16 +79,15 @@ export function deploymentRuntimes(deployment: HostedDeployment): HostedRuntime[
 		...(configInfo?.onboarded_agents ?? []),
 	]);
 	if (explicit.length > 0) {
-		const enabledExplicit = explicit.filter((runtime) => runtimeIsEnabled(configInfo, runtime));
-		return sortHostedRuntimes([ALWAYS_ON_HOSTED_RUNTIME, ...enabledExplicit]);
+		return explicit.filter((runtime) => runtimeIsEnabled(configInfo, runtime));
 	}
 
-	const fallback = new Set<HostedRuntime>([ALWAYS_ON_HOSTED_RUNTIME]);
+	const fallback = new Set<HostedRuntime>();
 	if (runtimeIsEnabled(configInfo, "openclaw")) fallback.add("openclaw");
 	if (runtimeIsEnabled(configInfo, "hermes")) fallback.add("hermes");
 	return sortHostedRuntimes(fallback);
 }
 
 export function defaultDeploymentRuntime(deployment: HostedDeployment): HostedRuntime {
-	return deploymentRuntimes(deployment)[0] ?? ALWAYS_ON_HOSTED_RUNTIME;
+	return deploymentRuntimes(deployment)[0] ?? HOSTED_RUNTIMES[0];
 }

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -43,10 +43,10 @@ function hostedDeploymentToTiles(deployment: HostedDeployment, envs: Env[] = [])
 function env(overrides: Partial<Env> = {}): Env {
 	return {
 		id: "11111111-1111-4111-8111-111111111111",
-		name: "hosted-codex",
-		default_name: "hosted-codex",
-		machine_name: "hosted-codex",
-		agent_type: "codex",
+		name: "hosted-openclaw",
+		default_name: "hosted-openclaw",
+		machine_name: "hosted-openclaw",
+		agent_type: "openclaw",
 		agent_version: null,
 		os: "linux",
 		last_seen_at: null,
@@ -133,7 +133,7 @@ describe("deploymentToTiles", () => {
 			[openclawEnv],
 		);
 
-		expect(tiles.map((tile) => tile.agentType)).toEqual(["codex"]);
+		expect(tiles.map((tile) => tile.agentType)).toEqual([]);
 		expect(tiles.some((tile) => tile.id === "dep_123:openclaw")).toBe(false);
 		expect(tiles.some((tile) => tile.id === "dep_123:hermes")).toBe(false);
 	});

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -218,14 +218,13 @@ export function useHostedAgentTiles({
 }
 
 /**
- * One deployment fans out to one tile per hosted runtime. Codex is the default
- * always-on runtime; OpenClaw and Hermes are optional sibling runtimes.
+ * One deployment fans out to one tile per hosted execution runtime.
  *
  * Runtime resolution priority (see `deploymentRuntimes`):
  *   1. Enabled runtimes named by `clawdi_cloud_environments` keys. Each key
  *      corresponds to a live cloud-api env binding.
  *   2. Enabled `onboarded_agents`, when it names recognizable runtimes.
- *   3. Codex plus enabled legacy runtime flags for older payloads.
+ *   3. Enabled legacy runtime flags for older payloads.
  */
 export function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>): AgentTile[] {
 	const runtimes = deploymentRuntimes(d);


### PR DESCRIPTION
## Part A findings

Verdict: GAP. Codex is not already installed and configured to the managed Clawdi provider in the v2 hosted runtime pod.

Evidence:
- `infra/v2/hosted-runtime/image/Dockerfile:22` installs base OS tools plus Node/npm and the `clawdi` shim, but has no Codex CLI install step.
- `infra/v2/hosted-runtime/image/manifests/official-default.json:17` declares only `openclaw` and `hermes` runtime installers.
- `backend/app/v2/hosted/managed_ai_provider.py:18` exposes the v2 managed base URL and `backend/app/services/ai_provider_contract.py:12` names `CLAWDI_MANAGED_OPENAI_API_KEY`, but the v2 image/manifest does not write `~/.codex/config.toml` or inject that env for Codex.
- `backend/app/v2/hosted/infra.py:148` projects `openai_api_base_url` into runtime config, but there is no Codex config consumer in the hosted-runtime image.
- The OSS CLI has self-managed AI-provider projection support for Codex profiles in `packages/cli/src/lib/ai-provider-projection.ts:407`, but this is not currently wired into hosted runtime image bootstrap/converge.

## Changes

- Removed Codex from the hosted runtime taxonomy: hosted execution runtimes are now only OpenClaw and Hermes.
- Removed Codex from deploy wizard runtime cards/copy and from hosted dashboard runtime tiles.
- Added UI and request-builder guards so deploy cannot submit with zero execution engines, and settings cannot disable the last enabled execution runtime.
- Kept connected/self-managed Codex paths untouched.

## Deferred image/config plan

The v2 hosted runtime image work is not shipped in this PR. Proposed owner split:

1. `clawdi-hosted`: install the Codex CLI in `infra/v2/hosted-runtime/image/Dockerfile` or a terminal-tool installer contract.
2. `clawdi-hosted`: add a runtime/image smoke contract for `codex --version` and a managed-provider config that references `CLAWDI_MANAGED_OPENAI_API_KEY` without embedding secrets.
3. `clawdi-hosted`: inject the managed deployment key into the hosted runtime pod as `CLAWDI_MANAGED_OPENAI_API_KEY` without creating a Codex Clawdi Cloud environment or live-sync entry.
4. `clawdi` CLI/runtime: add or reuse converge logic to write `~/.codex/config.toml` with the managed provider base URL, `env_key = "CLAWDI_MANAGED_OPENAI_API_KEY"`, and a Responses-compatible wire API if approved for the installed Codex version.
5. Keep Codex invisible in dashboard runtime surfaces and absent from `/v1/agents` registration/live-sync.

## Verification

- `bun install`
- `cd apps/web && bunx @biomejs/biome@2.5.2 ci .`
- `bun run check`
- `bun run typecheck`
- `bun run test`
- `cd apps/web && bun run e2e:hosted`
- `cd apps/web && bun run e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)