### PR TITLE
fix(web): resolve hosted SSR hydration mismatch

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -43,21 +43,13 @@ async function stubHostedApi(page: Page) {
 	});
 }
 
-// This smoke guards against Base UI RUNTIME crashes (e.g. the MenuGroupContext
-// error that unmounted the sidebar). React hydration-mismatch warnings are a
-// separate, pre-existing SSR-nondeterminism concern (not introduced by the Base
-// UI migration and unrelated to it), so they are excluded from the assertion.
-function isIgnorableWarning(text: string): boolean {
-	return /hydrat|didn't match|server rendered HTML/i.test(text);
-}
-
 function collectBrowserErrors(page: Page): string[] {
 	const errors: string[] = [];
 	page.on("console", (m) => {
-		if (m.type() === "error" && !isIgnorableWarning(m.text())) errors.push(m.text());
+		if (m.type() === "error") errors.push(m.text());
 	});
 	page.on("pageerror", (e) => {
-		if (!isIgnorableWarning(e.message)) errors.push(e.message);
+		errors.push(e.message);
 	});
 	return errors;
 }

--- a/apps/web/e2e/sidebar-runtime-smoke.pw.ts
+++ b/apps/web/e2e/sidebar-runtime-smoke.pw.ts
@@ -150,11 +150,11 @@ test("dashboard sidebar primitives run without browser errors", async ({ page })
 	await expect(page.getByTestId("app-sidebar-agent-rail")).toBeVisible();
 	const agentTiles = page.getByTestId("app-sidebar-agent-tiles");
 	await expect(agentTiles).toBeVisible();
-	const agentTile = agentTiles.getByRole("link", { name: /Smoke Codex.*Codex/ });
+	const agentTile = page.getByTestId("app-sidebar-agent-tile").filter({ hasText: "Smoke Codex" });
 	await expect(agentTile).toHaveCount(1);
 	await expectNoBrowserErrors(page, browserErrors, "dashboard render");
 
-	await agentTile.hover();
+	await agentTile.locator("a").hover();
 	await expect(
 		page.locator('[data-slot="tooltip-content"]').filter({ hasText: "Smoke Codex" }),
 	).toBeVisible();

--- a/apps/web/src/hosted/analytics-client.tsx
+++ b/apps/web/src/hosted/analytics-client.tsx
@@ -16,7 +16,7 @@ export function HostedAnalyticsClient() {
 		setMounted(true);
 	}, []);
 
-	if (!mounted) return <span data-hosted="true" hidden aria-hidden="true" />;
+	if (!mounted) return null;
 	return <HostedAnalyticsIdentity />;
 }
 
@@ -69,5 +69,5 @@ function HostedAnalyticsIdentity() {
 		});
 	}, [isSignedIn, userId, userLoaded, userEmail, userFullName]);
 
-	return <span data-hosted="true" hidden aria-hidden="true" />;
+	return null;
 }

--- a/apps/web/src/hosted/oss-clean.test.ts
+++ b/apps/web/src/hosted/oss-clean.test.ts
@@ -182,9 +182,15 @@ describe("hosted/ directory invariants", () => {
 	test('every .tsx file sets data-hosted="true" on its root', () => {
 		const files = listTsx(HOSTED_DIR);
 		expect(files.length).toBeGreaterThan(0);
+		// Effect-only hosted modules should render no DOM instead of a tagged sentinel.
+		const rootlessEffectOnlyFiles = new Set(["hosted/analytics-client.tsx"]);
 
 		for (const file of files) {
+			const rel = relative(SRC_DIR, file);
 			const src = stripComments(readFileSync(file, "utf8"));
+			if (rootlessEffectOnlyFiles.has(rel) && /\breturn\s+null\b/.test(src)) {
+				continue;
+			}
 			// Tight match: explicit `data-hosted="true"` or `data-hosted={"true"}`.
 			// Rejects `data-hosted="false"`, typos, and arbitrary expression forms
 			// that would slip past the original looser pattern. Source has had
@@ -193,9 +199,7 @@ describe("hosted/ directory invariants", () => {
 			// required.
 			const hasDataHosted = /\bdata-hosted=(?:"true"|\{"true"\})/.test(src);
 			if (!hasDataHosted) {
-				throw new Error(
-					`${relative(SRC_DIR, file)}: hosted .tsx must set data-hosted="true" on its rendered root`,
-				);
+				throw new Error(`${rel}: hosted .tsx must set data-hosted="true" on its rendered root`);
 			}
 		}
 	});


### PR DESCRIPTION
## Root cause

The hosted hydration warning came from `HostedAnalyticsClient` in `apps/web/src/hosted/analytics-client.tsx`. It rendered a hidden sentinel `<span data-hosted hidden aria-hidden>` even though the component only exists to run analytics effects.

When the hosted `/channels` connect dialog opened, Base UI marked non-dialog DOM as inert and added `data-base-ui-inert` to that hidden analytics span before the lazy analytics component finished hydrating. React then reported an SSR/CSR attribute mismatch on `HostedAnalyticsClient > span`.

## Fix

- Make the hosted analytics client effect-only by returning `null` instead of rendering the hidden sentinel DOM.
- Keep the hosted OSS invariant strict, with a narrow exception for this exact rootless effect-only module.
- Stop filtering hydration warnings out of the hosted smoke test so future hydration console errors fail the hosted e2e.
- Stabilize the regular sidebar smoke locator to use the existing agent tile test id.

## Evidence

The repro path was `/channels` -> "Connect a bot". Before the fix, the browser console warning pointed at `HostedAnalyticsClient > span` with `data-base-ui-inert` as the mismatched attribute. After the fix, the same Playwright repro reported `messages=0`.

Verification run locally:

- `bun install`
- `cd apps/web && bunx @biomejs/biome@2.5.2 ci .`
- `bun run check`
- `bun run typecheck`
- `bun run test`
- `cd apps/web && bun run e2e:hosted`
- `cd apps/web && bun run e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)