### PR TITLE
fix(dev): correct web dev server host flag in paseo dev script

### DIFF
--- a/scripts/paseo/dev.sh
+++ b/scripts/paseo/dev.sh
@@ -93,7 +93,7 @@ trap 'cleanup; exit 143' TERM
     VITE_CLAWDI_DEPLOY_API_URL="$VITE_CLAWDI_DEPLOY_API_URL" \
     VITE_DEV_AUTH_BYPASS="${VITE_DEV_AUTH_BYPASS:-}" \
     VITE_DEV_AUTH_TOKEN="${VITE_DEV_AUTH_TOKEN:-}" \
-    bun run dev -- --hostname "$WEB_BIND_HOST" --port "$WEB_RUNTIME_PORT"
+    bun run dev -- --host "$WEB_BIND_HOST" --port "$WEB_RUNTIME_PORT"
 ) &
 pids+=("$!")
 


### PR DESCRIPTION
`bun run dev -- --hostname` is not a valid flag for the web dev server; use `--host`. Found while standing up the local full-stack e2e (web bound to the wrong interface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)