### PR TITLE
fix: tolerate negative session durations (stop dropping session batches)

### DIFF
--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -1284,6 +1284,7 @@ async def sync_heartbeat(
 @router.post("/sessions/batch")
 async def batch_create_sessions(
     body: SessionBatchRequest,
+    request: Request,
     auth: AuthContext = Depends(require_scope("sessions:write")),
     db: AsyncSession = Depends(get_session),
 ) -> SessionBatchResponse:
@@ -1297,6 +1298,17 @@ async def batch_create_sessions(
     if not body.sessions:
         return SessionBatchResponse(
             created=0, updated=0, unchanged=0, needs_content=[], rejected=[]
+        )
+
+    clamped_duration_ids = [
+        s.local_session_id for s in body.sessions if s.duration_seconds_was_clamped
+    ]
+    if clamped_duration_ids:
+        log.warning(
+            "session_batch_duration_clamped user_agent=%r count=%d local_session_ids=%s",
+            request.headers.get("user-agent", ""),
+            len(clamped_duration_ids),
+            clamped_duration_ids[:20],
         )
 
     # Agent API keys must NOT be able to write sessions

--- a/backend/app/schemas/session.py
+++ b/backend/app/schemas/session.py
@@ -1,9 +1,18 @@
 import re
 import uuid
 from datetime import UTC, datetime
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ModelWrapValidatorHandler,
+    PrivateAttr,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
 
 # Lone UTF-16 surrogates (U+D800..U+DFFF) are valid Python `str`
 # but cannot be encoded as UTF-8, so asyncpg rejects the bound
@@ -36,7 +45,27 @@ SafeLocalSessionId = Annotated[
 ]
 
 
+def _is_negative_int_like(v: Any) -> bool:
+    if v is None or isinstance(v, bool):
+        return False
+    if isinstance(v, int):
+        return v < 0
+    if isinstance(v, float):
+        return v.is_integer() and v < 0
+    if isinstance(v, str):
+        value = v.strip()
+        if not value:
+            return False
+        try:
+            return int(value) < 0
+        except ValueError:
+            return False
+    return False
+
+
 class SessionCreate(BaseModel):
+    _duration_seconds_clamped: bool = PrivateAttr(default=False)
+
     # Typed as UUID so Pydantic returns a 422 on garbage input — without this
     # the route's `uuid.UUID(...)` raises and FastAPI surfaces a 500.
     environment_id: uuid.UUID
@@ -54,8 +83,9 @@ class SessionCreate(BaseModel):
     last_activity_at: datetime | None = None
     # Non-negative numeric observables. Without `ge=0` a malformed
     # client could post negative tokens / duration and corrupt the
-    # dashboard's aggregate counters. The CLI never sends negatives
-    # for legitimate sessions; this is a boundary defense.
+    # dashboard's aggregate counters. Duration can go negative when
+    # client clocks move backward; clamp that measurement noise at
+    # the boundary while keeping counters strict.
     duration_seconds: int | None = Field(default=None, ge=0)
     message_count: int = Field(default=0, ge=0)
     input_tokens: int = Field(default=0, ge=0)
@@ -71,6 +101,22 @@ class SessionCreate(BaseModel):
     # Optional so old clients that don't compute hashes still get inserted;
     # legacy rows with NULL hash are always treated as "needs content".
     content_hash: str | None = None
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def _clamp_negative_duration(cls, data: Any, handler: ModelWrapValidatorHandler[Self]) -> Self:
+        clamped = False
+        if isinstance(data, dict) and _is_negative_int_like(data.get("duration_seconds")):
+            data = {**data, "duration_seconds": 0}
+            clamped = True
+        model = handler(data)
+        if clamped:
+            model._duration_seconds_clamped = True
+        return model
+
+    @property
+    def duration_seconds_was_clamped(self) -> bool:
+        return self._duration_seconds_clamped
 
     @field_validator("summary", mode="after")
     @classmethod

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import UTC, datetime
 
@@ -357,6 +358,65 @@ async def test_session_batch_upserts_and_returns_needs_content(client: httpx.Asy
     listing = (await client.get("/v1/sessions")).json()
     assert listing["total"] == 2
     assert {s["local_session_id"] for s in listing["items"]} == {"sess-abc", "sess-xyz"}
+
+
+@pytest.mark.asyncio
+async def test_session_batch_clamps_negative_duration_and_logs_user_agent(
+    client: httpx.AsyncClient, caplog: pytest.LogCaptureFixture
+):
+    env_id = await _register_env(client)
+    started = datetime(2026, 1, 1, 12, 0, tzinfo=UTC).isoformat()
+    ended = datetime(2026, 1, 1, 12, 0, 5, tzinfo=UTC).isoformat()
+    payload = {
+        "sessions": [
+            {
+                "environment_id": env_id,
+                "local_session_id": "sess-clock-skew",
+                "started_at": started,
+                "ended_at": started,
+                "duration_seconds": -3,
+                "message_count": 1,
+                "content_hash": "c" * 64,
+            },
+            {
+                "environment_id": env_id,
+                "local_session_id": "sess-normal-duration",
+                "started_at": started,
+                "ended_at": ended,
+                "duration_seconds": 5,
+                "message_count": 1,
+                "content_hash": "d" * 64,
+            },
+        ]
+    }
+    caplog.set_level(logging.WARNING, logger="app.routes.sessions")
+
+    r = await client.post(
+        "/v1/sessions/batch",
+        json=payload,
+        headers={"user-agent": "clawdi-cli/0.12.9"},
+    )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["created"] == 2
+    assert body["rejected"] == []
+
+    listing = (await client.get("/v1/sessions")).json()
+    by_local_id = {s["local_session_id"]: s for s in listing["items"]}
+    assert by_local_id["sess-clock-skew"]["duration_seconds"] == 0
+    assert by_local_id["sess-normal-duration"]["duration_seconds"] == 5
+
+    clamp_logs = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "app.routes.sessions"
+        and record.getMessage().startswith("session_batch_duration_clamped")
+    ]
+    assert len(clamp_logs) == 1
+    assert "user_agent='clawdi-cli/0.12.9'" in clamp_logs[0]
+    assert "count=1" in clamp_logs[0]
+    assert "sess-clock-skew" in clamp_logs[0]
 
 
 @pytest.mark.asyncio

--- a/packages/cli/src/adapters/claude-code.ts
+++ b/packages/cli/src/adapters/claude-code.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { basename, join } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
+import { durationSecondsBetween } from "../lib/session-duration";
 import { extractSharedSkillTarGz, extractTarGz } from "../lib/tar";
 import type {
 	AgentAdapter,
@@ -231,9 +232,7 @@ export class ClaudeCodeAdapter implements AgentAdapter {
 
 		if (!startedAt || messages.length === 0) return null;
 
-		const durationSeconds = endedAt
-			? Math.floor((endedAt.getTime() - startedAt.getTime()) / 1000)
-			: null;
+		const durationSeconds = durationSecondsBetween(startedAt, endedAt);
 
 		return {
 			projectPath,

--- a/packages/cli/src/adapters/codex.ts
+++ b/packages/cli/src/adapters/codex.ts
@@ -1,6 +1,7 @@
 import { type Dirent, existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
+import { durationSecondsBetween } from "../lib/session-duration";
 import { extractSharedSkillTarGz, extractTarGz } from "../lib/tar";
 import type {
 	AgentAdapter,
@@ -202,7 +203,7 @@ export class CodexAdapter implements AgentAdapter {
 			}
 
 			if (!endedAt) endedAt = startedAt;
-			const durationSeconds = Math.floor((endedAt.getTime() - startedAt.getTime()) / 1000);
+			const durationSeconds = durationSecondsBetween(startedAt, endedAt);
 
 			const firstRealUser = messages.find(
 				(m) => m.role === "user" && !m.content.startsWith("<environment_context>"),

--- a/packages/cli/src/adapters/hermes.ts
+++ b/packages/cli/src/adapters/hermes.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { join, relative } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
+import { durationSecondsBetween } from "../lib/session-duration";
 import { isValidSkillKey } from "../lib/skill-key";
 import { extractSharedSkillTarGz, extractTarGz } from "../lib/tar";
 import type {
@@ -147,9 +148,7 @@ export class HermesAdapter implements AgentAdapter {
 				const model = parseModelField(row.model);
 				const startedAt = new Date(row.started_at * 1000);
 				const endedAt = row.ended_at ? new Date(row.ended_at * 1000) : null;
-				const durationSeconds = endedAt
-					? Math.floor((endedAt.getTime() - startedAt.getTime()) / 1000)
-					: null;
+				const durationSeconds = durationSecondsBetween(startedAt, endedAt);
 
 				const msgRows = msgStmt.all(row.id) as MessageRow[];
 				const messages: SessionMessage[] = msgRows.map((m) => ({

--- a/packages/cli/src/adapters/openclaw.ts
+++ b/packages/cli/src/adapters/openclaw.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { isAbsolute, join } from "node:path";
 import { safeTruncate } from "../lib/sanitize";
+import { durationSecondsBetween } from "../lib/session-duration";
 import { extractSharedSkillTarGz, extractTarGz } from "../lib/tar";
 import type {
 	AgentAdapter,
@@ -254,7 +255,7 @@ export class OpenClawAdapter implements AgentAdapter {
 				startedAt ??= new Date(updatedAt);
 				endedAt ??= new Date(updatedAt);
 
-				const durationSeconds = Math.floor((endedAt.getTime() - startedAt.getTime()) / 1000);
+				const durationSeconds = durationSecondsBetween(startedAt, endedAt);
 
 				const firstUserContent = messages.find((m) => m.role === "user")?.content;
 				const summary =

--- a/packages/cli/src/lib/session-duration.ts
+++ b/packages/cli/src/lib/session-duration.ts
@@ -1,0 +1,4 @@
+export function durationSecondsBetween(startedAt: Date, endedAt: Date | null): number | null {
+	if (!endedAt) return null;
+	return Math.max(0, Math.floor((endedAt.getTime() - startedAt.getTime()) / 1000));
+}

--- a/packages/cli/tests/lib/session-duration.test.ts
+++ b/packages/cli/tests/lib/session-duration.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { durationSecondsBetween } from "../../src/lib/session-duration";
+
+describe("durationSecondsBetween", () => {
+	it("computes whole seconds for normal sessions", () => {
+		expect(
+			durationSecondsBetween(
+				new Date("2026-01-01T12:00:00.000Z"),
+				new Date("2026-01-01T12:00:05.900Z"),
+			),
+		).toBe(5);
+	});
+
+	it("returns null when endedAt is missing", () => {
+		expect(durationSecondsBetween(new Date("2026-01-01T12:00:00.000Z"), null)).toBeNull();
+	});
+
+	it("clamps clock-skewed negative durations to zero", () => {
+		expect(
+			durationSecondsBetween(
+				new Date("2026-01-01T12:00:05.000Z"),
+				new Date("2026-01-01T12:00:00.000Z"),
+			),
+		).toBe(0);
+	});
+});


### PR DESCRIPTION
## Bug (observed on prod: 230 hits / 24h)

`POST /api/sessions/batch` rejects the ENTIRE batch with 422 when any session has `duration_seconds < 0`. Clients in the wild (`node`, `clawdi-cli/0.12.9`) send negative durations from clock skew / out-of-order timestamps → those users' session-tracking batches are silently DROPPED. Ongoing v1 data loss, predates recent work.

## Fix
- **Server tolerance**: clamp negative `duration_seconds` to 0 at the validation boundary so the batch is ACCEPTED (a skewed duration is better recorded as 0 than the whole batch lost). Count-type fields keep strict `ge=0` (a negative count means corruption, not measurement noise). `git blame`: the bound came from serve-v1 dashboard-aggregation protection — preserved for counts, relaxed only for duration.
- **Observability**: WARNING log on clamp with `user_agent` + count + up to 20 local IDs, so the client bug stays visible.
- **Client fix**: new `durationSecondsBetween()` helper (`max(0, end-start)`) used by all four CLI adapters — new CLIs stop emitting negatives; the server tolerance still covers old deployed CLIs (0.12.9).

## Verification
72 backend pytest passed (sessions suites) incl. mixed-batch accept + clamp + persistence + log; ruff/format clean; 60 bun tests; `bun run check` + CLI typecheck passed; alembic upgrade on throwaway PG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)