### PR TITLE
feat(v2): project managed model capabilities to OpenClaw/Hermes

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -264,6 +264,11 @@ async def admin_upsert_clawdi_managed_ai_provider(
             base_url=body.base_url,
             api_key=body.api_key.get_secret_value(),
             default_model=body.default_model,
+            models=(
+                [model.model_dump(exclude_none=True) for model in body.models]
+                if body.models is not None
+                else None
+            ),
             label=body.label,
             capabilities=body.capabilities,
         )

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -15,6 +15,13 @@ from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 AdminChannelProvider = Literal["telegram", "discord", "whatsapp", "imessage"]
 AdminChannelVisibility = Literal["private", "public"]
 AdminChannelStatus = Literal["active", "disabled"]
+AdminAiProviderApiMode = Literal[
+    "openai_chat",
+    "openai_responses",
+    "anthropic_messages",
+    "google_generate_content",
+]
+AdminAiProviderInputModality = Literal["text", "image", "video", "audio"]
 _SUPPORTED_HOSTED_RUNTIMES = {"codex", "hermes", "openclaw"}
 _BRIDGE_SURFACE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
 _BRIDGE_SURFACE_KEYS = {
@@ -179,6 +186,16 @@ class AdminRuntimeStateResponse(BaseModel):
     generation: int
 
 
+class AdminManagedAiProviderModel(BaseModel):
+    model_config = ConfigDict(extra="ignore", hide_input_in_errors=True)
+
+    id: str = Field(min_length=1, max_length=300)
+    api_mode: AdminAiProviderApiMode | None = None
+    input_modalities: list[AdminAiProviderInputModality] | None = None
+    context_window: int | None = Field(default=None, ge=0)
+    max_tokens: int | None = Field(default=None, ge=0)
+
+
 class AdminManagedAiProviderUpsert(BaseModel):
     """Create or rotate the first-party managed AI provider for a user."""
 
@@ -188,6 +205,7 @@ class AdminManagedAiProviderUpsert(BaseModel):
     base_url: str = Field(min_length=1, max_length=1000)
     api_key: SecretStr = Field(min_length=1)
     default_model: str | None = Field(default=None, max_length=300)
+    models: list[AdminManagedAiProviderModel] | None = None
     label: str | None = Field(default=None, max_length=200)
     capabilities: dict[str, Any] | None = None
 

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -192,6 +192,9 @@ class AdminManagedAiProviderModel(BaseModel):
     id: str = Field(min_length=1, max_length=300)
     api_mode: AdminAiProviderApiMode | None = None
     input_modalities: list[AdminAiProviderInputModality] | None = None
+    supports_vision: bool | None = None
+    supports_tools: bool | None = None
+    supports_reasoning: bool | None = None
     context_window: int | None = Field(default=None, ge=0)
     max_tokens: int | None = Field(default=None, ge=0)
 

--- a/backend/app/schemas/ai_provider.py
+++ b/backend/app/schemas/ai_provider.py
@@ -41,6 +41,8 @@ class AiProviderModel(BaseModel):
     label: str | None = Field(default=None, max_length=300)
     api_mode: ApiMode | None = None
     input_modalities: list[InputModality] | None = None
+    supports_vision: bool | None = None
+    supports_tools: bool | None = None
     supports_reasoning: bool | None = None
     context_window: int | None = Field(default=None, ge=0)
     max_tokens: int | None = Field(default=None, ge=0)

--- a/backend/app/services/managed_ai_provider.py
+++ b/backend/app/services/managed_ai_provider.py
@@ -47,6 +47,7 @@ async def upsert_clawdi_managed_provider(
     base_url: str,
     api_key: str,
     default_model: str | None = None,
+    models: list[dict] | None = None,
     label: str | None = None,
     capabilities: dict | None = None,
 ) -> AiProvider:
@@ -73,7 +74,10 @@ async def upsert_clawdi_managed_provider(
     provider.base_url = normalized_base_url
     provider.api_mode = MANAGED_AI_PROVIDER_API_MODE
     provider.capabilities = capabilities
-    provider.models = [{"id": default_model}] if default_model else None
+    if models is not None:
+        provider.models = models
+    else:
+        provider.models = [{"id": default_model}] if default_model else None
     provider.auth_type = "api_key"
     provider.auth_ref = None
     provider.auth_metadata = {"source": "managed", "profile": MANAGED_AI_PROVIDER_PROFILE}

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -470,6 +470,9 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
             "context_window": 272000,
             "max_tokens": 128000,
             "input_modalities": ["text", "image"],
+            "supports_vision": True,
+            "supports_tools": True,
+            "supports_reasoning": True,
         }
     ]
     r = await admin_client.put(

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -464,6 +464,14 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
     from app.services.vault_crypto import decrypt
 
     raw_key = "sk-admin-managed-secret"
+    managed_models = [
+        {
+            "id": "gpt-5.4-mini",
+            "context_window": 272000,
+            "max_tokens": 128000,
+            "input_modalities": ["text", "image"],
+        }
+    ]
     r = await admin_client.put(
         "/v1/admin/ai-providers/clawdi-managed-v2",
         headers=_AUTH,
@@ -472,6 +480,7 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
             "base_url": "https://ai-gateway.clawdi.ai/v1",
             "api_key": raw_key,
             "default_model": "gpt-5.4-mini",
+            "models": managed_models,
         },
     )
     assert r.status_code == 200, r.text
@@ -483,7 +492,7 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
         "api_mode": MANAGED_AI_PROVIDER_API_MODE,
         "runtime_env_name": MANAGED_AI_PROVIDER_RUNTIME_ENV,
         "base_url": "https://ai-gateway.clawdi.ai/v1",
-        "models": [{"id": "gpt-5.4-mini"}],
+        "models": managed_models,
         "has_api_key": True,
     }
 
@@ -502,7 +511,7 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
     assert provider.auth_metadata == {"source": "managed", "profile": "default"}
     assert provider.managed_by == "clawdi"
     assert provider.runtime_env_name == MANAGED_AI_PROVIDER_RUNTIME_ENV
-    assert provider.models == [{"id": "gpt-5.4-mini"}]
+    assert provider.models == managed_models
     assert provider.archived_at is None
 
     payload = (

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -1545,6 +1545,9 @@ async def test_runtime_manifest_projects_provider_secret_values(
             "context_window": 272000,
             "max_tokens": 128000,
             "input_modalities": ["text", "image"],
+            "supports_vision": True,
+            "supports_tools": True,
+            "supports_reasoning": True,
         }
     ]
     db_session.add(

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -1539,13 +1539,21 @@ async def test_runtime_manifest_projects_provider_secret_values(
         agent_type="openclaw",
     )
     ciphertext, nonce = encrypt("sk-test-provider")
+    managed_models = [
+        {
+            "id": "gpt-5.5",
+            "context_window": 272000,
+            "max_tokens": 128000,
+            "input_modalities": ["text", "image"],
+        }
+    ]
     db_session.add(
         AiProvider(
             owner_user_id=seed_user.id,
             provider_id="clawdi-managed-v2",
             type="custom_openai_compatible",
             base_url="https://sub2api.test/v1",
-            models=[{"id": "gpt-5.5"}],
+            models=managed_models,
             # Simulate a stale v2 managed provider row from before the chat-completions contract.
             api_mode="openai_responses",
             auth_type="api_key",
@@ -1580,7 +1588,7 @@ async def test_runtime_manifest_projects_provider_secret_values(
         "type": "custom_openai_compatible",
         "baseUrl": "https://sub2api.test/v1",
         "apiMode": "openai_chat",
-        "models": [{"id": "gpt-5.5"}],
+        "models": managed_models,
         "runtimeEnvName": "CLAWDI_MANAGED_OPENAI_API_KEY",
         "apiKeySecretRef": "provider.clawdi-managed-v2.apiKey",
     }

--- a/docs/ai-providers.md
+++ b/docs/ai-providers.md
@@ -38,9 +38,11 @@ Supported catalog fields for v1 apply:
 - Declarative metadata: `capabilities`.
 - Optional model metadata through JSON catalog import: `models[].id`,
   `models[].label`, `models[].api_mode`, `models[].input_modalities`,
-  `models[].context_window`, and `models[].max_tokens`. Today this is projected
-  only where the pinned agent contract supports it, such as OpenClaw model
-  entries.
+  `models[].supports_vision`, `models[].supports_tools`,
+  `models[].supports_reasoning`, `models[].context_window`, and
+  `models[].max_tokens`. Today this is projected only where the pinned agent
+  contract supports it, such as OpenClaw model entries and Hermes custom
+  provider model overrides.
 
 Agent apply status:
 

--- a/packages/cli/docs/openclaw-hermes-model-capability-fields.md
+++ b/packages/cli/docs/openclaw-hermes-model-capability-fields.md
@@ -1,0 +1,144 @@
+# OpenClaw and Hermes model capability field investigation
+
+Date: 2026-07-07
+
+Source snapshots:
+
+- OpenClaw: `/tmp/openclaw-cap`, commit `e72dadbb3bb1`
+- Hermes: `/tmp/hermes-cap`, commit `536ffedbf470`
+
+This investigation used fresh official upstream clones, not Clawdi forks.
+
+## Verdict
+
+The earlier conclusion that these fields are all dead data is too broad.
+OpenClaw and Hermes both consume model capability metadata, but they do not
+consume the same field names or shapes.
+
+- OpenClaw consumes `contextWindow`, `maxTokens`, `input`, `reasoning`, and
+  `compat.supportsTools`.
+- Hermes consumes `context_length`, `max_tokens` / provider
+  `max_output_tokens`, and `supports_vision`.
+- Hermes does not use user/project per-model `supports_tools` or
+  `supports_reasoning` as runtime gates.
+- Neither agent uses `max_input_tokens` as the LLM runtime budget field.
+
+For a canonical Clawdi v2 managed-provider schema, the fields worth carrying are:
+
+```ts
+{
+  id: string;
+  context_window?: number;
+  max_tokens?: number; // output cap; keep current name unless doing a migration
+  input_modalities?: Array<"text" | "image" | "video" | "audio">;
+  supports_vision?: boolean;
+  supports_tools?: boolean;
+  supports_reasoning?: boolean;
+}
+```
+
+Do not add `max_input_tokens` for agent projection. It is redundant with the
+context window for these consumers. Do not add a separate `max_output_tokens`
+unless we intentionally migrate from the current `max_tokens` catalog field; for
+agent projection, `max_tokens` already means output cap and maps to the right
+agent-specific names.
+
+## Field Matrix
+
+| Candidate field | OpenClaw reads and acts? | Hermes reads and acts? | Projection verdict |
+| --- | --- | --- | --- |
+| `context_window` | Yes, if mapped to `contextWindow`. The OpenClaw model schema has `contextWindow` (`/tmp/openclaw-cap/src/config/types.models.ts:185`) and configured per-model entries are read from `models.providers.<id>.models[]` for context budgeting (`/tmp/openclaw-cap/src/agents/context-resolution.ts:106`, `/tmp/openclaw-cap/src/agents/context-resolution.ts:115`, `/tmp/openclaw-cap/src/agents/context-resolution.ts:118`). Missing configured model values default to `128000` in the registry (`/tmp/openclaw-cap/src/agents/sessions/model-registry.ts:559`) or can hit runtime fixed/fallback behavior (`/tmp/openclaw-cap/src/agents/context-resolution.ts:240`). | Yes, but Hermes wants `context_length`, not `context_window`, in config. Agent init reads `model.context_length` (`/tmp/hermes-cap/agent/agent_init.py:1620`) and custom provider per-model `context_length` (`/tmp/hermes-cap/agent/agent_init.py:1658`). `get_model_context_length` gives explicit config first priority (`/tmp/hermes-cap/agent/model_metadata.py:1886`, `/tmp/hermes-cap/agent/model_metadata.py:1896`). | Useful. Keep canonical `context_window`, but map per target: OpenClaw `contextWindow`; Hermes `context_length`. |
+| `max_tokens` | Yes, if mapped to `maxTokens`. The OpenClaw schema has `maxTokens` as completion/output budget (`/tmp/openclaw-cap/src/config/types.models.ts:193`), defaults missing values to `16384` (`/tmp/openclaw-cap/src/agents/sessions/model-registry.ts:560`), sends it as Responses `max_output_tokens` (`/tmp/openclaw-cap/src/agents/openai-transport-stream.ts:2380`), and uses it for Completions max-token resolution (`/tmp/openclaw-cap/src/agents/openai-transport-stream.ts:4383`). | Yes as runtime output cap, but through `model.max_tokens` or provider-level fallback, not a models.dev-style arbitrary capability. Gateway reads top-level `model.max_tokens` (`/tmp/hermes-cap/gateway/run.py:1846`) and falls back to runtime `max_output_tokens` (`/tmp/hermes-cap/gateway/run.py:1850`). Chat completions forwards `agent.max_tokens` (`/tmp/hermes-cap/agent/chat_completion_helpers.py:846`) and transport resolves the outgoing max-token param (`/tmp/hermes-cap/agent/transports/chat_completions.py:508`). | Useful. Keep current canonical `max_tokens` as output cap; map to OpenClaw `maxTokens`, Hermes `model.max_tokens` or provider `max_output_tokens` as appropriate. |
+| `input_modalities` | Yes, if mapped to OpenClaw `input`. The schema stores supported input modalities (`/tmp/openclaw-cap/src/config/types.models.ts:164`), accepts text/image in the registry schema (`/tmp/openclaw-cap/src/agents/sessions/model-registry.ts:165`), defaults to `["text"]` when absent (`/tmp/openclaw-cap/src/agents/sessions/model-registry.ts:557`), and checks `model.input.includes("image")` for native image handling (`/tmp/openclaw-cap/src/agents/embedded-agent-runner/run/images.ts:539`, `/tmp/openclaw-cap/src/agents/openai-transport-stream.ts:1193`, `/tmp/openclaw-cap/src/media-understanding/image.ts:198`). | Not as a config override. Hermes parses input modalities from models.dev metadata (`/tmp/hermes-cap/agent/models_dev.py:620`) and derives `supports_vision` from that metadata, but the user/project config override is `supports_vision`, not `input_modalities`. | Useful for OpenClaw. For Hermes, derive/project `supports_vision` from `input_modalities` when `image` is present. |
+| `supports_vision` | Not as a field. OpenClaw has no `supports_vision` / `supportsVision` model-config slot in `ModelDefinitionConfig`; vision is represented by `input` (`/tmp/openclaw-cap/src/config/types.models.ts:153`, `/tmp/openclaw-cap/src/config/types.models.ts:164`). | Yes. Hermes explicitly checks top-level `model.supports_vision` first (`/tmp/hermes-cap/agent/image_routing.py:202`), then `providers.<provider>.models.<model>.supports_vision` (`/tmp/hermes-cap/agent/image_routing.py:222`, `/tmp/hermes-cap/agent/image_routing.py:229`), then models.dev (`/tmp/hermes-cap/agent/image_routing.py:373`, `/tmp/hermes-cap/agent/image_routing.py:384`, `/tmp/hermes-cap/agent/image_routing.py:396`). Runtime message/image routing calls `_model_supports_vision()` (`/tmp/hermes-cap/run_agent.py:4872`, `/tmp/hermes-cap/run_agent.py:4892`) and strips or preserves image parts based on it (`/tmp/hermes-cap/run_agent.py:4988`, `/tmp/hermes-cap/run_agent.py:5018`, `/tmp/hermes-cap/run_agent.py:5051`). Missing config can misclassify custom/local vision models as non-vision (`/tmp/hermes-cap/run_agent.py:4883`). | Useful. Add to canonical schema if Hermes is a target. For OpenClaw, map this to `input: ["text", "image"]` or derive it from `input_modalities`; do not emit raw `supports_vision`. |
+| `supports_tools` | Yes only if mapped to `compat.supportsTools`. OpenClaw's compat schema has `supportsTools` (`/tmp/openclaw-cap/src/config/types.models.ts:81`, `/tmp/openclaw-cap/src/config/types.models.ts:93`). `supportsModelTools` defaults absent metadata to true and only disables tools when `compat.supportsTools === false` (`/tmp/openclaw-cap/src/agents/model-tool-support.ts:4`, `/tmp/openclaw-cap/src/agents/model-tool-support.ts:13`). Tool construction and compact paths gate on it (`/tmp/openclaw-cap/src/agents/embedded-agent-runner/run/attempt.ts:1221`, `/tmp/openclaw-cap/src/agents/embedded-agent-runner/compact.ts:916`), and OpenAI Completions only sends tools when supported (`/tmp/openclaw-cap/src/agents/openai-transport-stream.ts:4344`). | No user/project per-model runtime gate found. Hermes models.dev has `supports_tools` metadata (`/tmp/hermes-cap/agent/models_dev.py:401`) parsed from `tool_call`, and catalog listing filters agentic models by tool-call support (`/tmp/hermes-cap/agent/models_dev.py:575`). Runtime chat completions sends tools whenever `tools` is supplied (`/tmp/hermes-cap/agent/transports/chat_completions.py:312`, `/tmp/hermes-cap/agent/transports/chat_completions.py:502`). | Useful for OpenClaw only when mapped to `compat.supportsTools`. Dead data for Hermes runtime projection. |
+| `supports_reasoning` | Yes only if mapped to OpenClaw `reasoning`. The model schema has `reasoning` (`/tmp/openclaw-cap/src/config/types.models.ts:162`), missing values default to false (`/tmp/openclaw-cap/src/agents/sessions/model-registry.ts:555`), Responses only emits reasoning controls when `model.reasoning` is true (`/tmp/openclaw-cap/src/agents/openai-transport-stream.ts:2421`), and Completions similarly gates reasoning on `model.reasoning` (`/tmp/openclaw-cap/src/agents/openai-transport-stream.ts:3703`, `/tmp/openclaw-cap/src/agents/openai-transport-stream.ts:4452`). Thinking defaults also inspect configured `reasoning` (`/tmp/openclaw-cap/src/agents/model-thinking-default.ts:118`). | No user/project per-model runtime gate found. Hermes has `supports_reasoning` in models.dev metadata (`/tmp/hermes-cap/agent/models_dev.py:401`), but chat request reasoning support is passed from `agent._supports_reasoning_extra_body()` (`/tmp/hermes-cap/agent/chat_completion_helpers.py:826`, `/tmp/hermes-cap/agent/chat_completion_helpers.py:870`). That method derives support from provider/model/base-URL heuristics and probes, not config metadata (`/tmp/hermes-cap/run_agent.py:5303`, `/tmp/hermes-cap/run_agent.py:5310`, `/tmp/hermes-cap/run_agent.py:5322`, `/tmp/hermes-cap/run_agent.py:5331`). | Useful for OpenClaw only when mapped to `reasoning`. Dead data for Hermes runtime projection unless Hermes adds a config override later. |
+| `max_input_tokens` | No for LLM model config. OpenClaw's LLM model config uses `contextWindow` / `contextTokens`; `maxInputTokens` search hits embedding/provider internals, not `models.providers.<id>.models[]` LLM budgeting. | No as a config/runtime LLM budget. Hermes has a model metadata field named `max_input_tokens` in `agent/model_metadata.py`, and models.dev parses `limit.input` (`/tmp/hermes-cap/agent/models_dev.py:626`), but runtime context budgeting uses `context_length` resolution (`/tmp/hermes-cap/agent/model_metadata.py:1886`). | Dead data for this projection. Use `context_window` / `context_length`. |
+| `max_output_tokens` | Not as an OpenClaw model config field. OpenClaw model config uses `maxTokens`; outgoing Responses calls become `max_output_tokens` at transport time (`/tmp/openclaw-cap/src/agents/openai-transport-stream.ts:2380`). | Yes in provider/runtime fallback, not as a generic per-model capability object. Runtime provider accepts `max_output_tokens` or `max_tokens` on a custom provider entry (`/tmp/hermes-cap/hermes_cli/runtime_provider.py:586`, `/tmp/hermes-cap/hermes_cli/runtime_provider.py:589`, `/tmp/hermes-cap/hermes_cli/runtime_provider.py:594`) and gateway falls back to that when `model.max_tokens` is absent (`/tmp/hermes-cap/gateway/run.py:1850`). | Keep canonical `max_tokens` for now and map to the target's output-cap field. Adding a duplicate `max_output_tokens` is not necessary unless doing a schema rename/migration for clarity. |
+
+## Agent-Specific Notes
+
+### OpenClaw
+
+OpenClaw consumes model entries under `models.providers.<id>.models[]` through a
+typed model definition. That type includes `id`, `name`, `api`, `baseUrl`,
+`reasoning`, `input`, `cost`, `contextWindow`, `contextTokens`, `maxTokens`,
+`thinkingLevelMap`, `params`, runtime fields, headers, and `compat`
+(`/tmp/openclaw-cap/src/config/types.models.ts:153`). It does not include
+snake_case `supports_vision`, `supports_tools`, `supports_reasoning`,
+`max_input_tokens`, or `max_output_tokens`.
+
+Important defaults:
+
+- Missing `reasoning` becomes `false` (`/tmp/openclaw-cap/src/agents/sessions/model-registry.ts:555`).
+  This is wrong for reasoning models if we want OpenClaw to expose reasoning
+  controls.
+- Missing `input` becomes `["text"]` (`/tmp/openclaw-cap/src/agents/sessions/model-registry.ts:557`).
+  This is wrong for vision models because image parts will be dropped or routed
+  through fallback paths.
+- Missing `contextWindow` becomes `128000` in registry resolution
+  (`/tmp/openclaw-cap/src/agents/sessions/model-registry.ts:559`) and may also
+  interact with fixed/fallback runtime caps (`/tmp/openclaw-cap/src/agents/context-resolution.ts:240`).
+  This can be wrong for larger or smaller managed models.
+- Missing `maxTokens` becomes `16384` (`/tmp/openclaw-cap/src/agents/sessions/model-registry.ts:560`).
+  This can be wrong for models with very different output caps.
+- Missing `compat.supportsTools` defaults permissive (`true`) because only
+  explicit `false` disables tools (`/tmp/openclaw-cap/src/agents/model-tool-support.ts:13`).
+  This can be wrong for non-tool models because OpenClaw may send tool schemas.
+
+### Hermes
+
+Hermes has a mixed model-metadata story:
+
+- It really does consume `supports_vision` from config and uses it to decide
+  whether image content is sent natively or converted/stripped
+  (`/tmp/hermes-cap/agent/image_routing.py:180`,
+  `/tmp/hermes-cap/run_agent.py:4872`).
+- It consumes `context_length` from config/custom providers for runtime context
+  length (`/tmp/hermes-cap/agent/agent_init.py:1620`,
+  `/tmp/hermes-cap/agent/agent_init.py:1658`).
+- It consumes `model.max_tokens` and provider `max_output_tokens` as output
+  caps (`/tmp/hermes-cap/gateway/run.py:1846`,
+  `/tmp/hermes-cap/gateway/run.py:1850`).
+- It has models.dev capability metadata for tools, vision, reasoning, context,
+  and output caps (`/tmp/hermes-cap/agent/models_dev.py:401`), but that metadata
+  is not equivalent to a user/project config capability schema. Runtime tool
+  gating and reasoning gating are not driven by user per-model
+  `supports_tools` / `supports_reasoning` config fields.
+
+## Recommended Final Projection Set
+
+For the v2 managed provider, keep the backend/catalog schema small but carry the
+fields that can be mapped into real agent behavior:
+
+| Canonical Clawdi field | OpenClaw projection | Hermes projection |
+| --- | --- | --- |
+| `id` | `id` | model id |
+| `context_window` | `contextWindow` | `context_length` |
+| `max_tokens` | `maxTokens` | `model.max_tokens` or provider `max_output_tokens` |
+| `input_modalities` | `input` | derive `supports_vision` when `image` is present |
+| `supports_vision` | derive/confirm `input` contains `image`; do not emit raw field | `supports_vision` |
+| `supports_tools` | `compat.supportsTools` | do not project for runtime |
+| `supports_reasoning` | `reasoning` | do not project for runtime |
+
+Not recommended:
+
+- `max_input_tokens`: no useful agent runtime consumer in either target.
+- A duplicate `max_output_tokens` next to `max_tokens`: useful only if we choose
+  to rename the existing output-cap field. For now, `max_tokens` is already the
+  output cap in Clawdi and can map to each target's native field.
+
+## Answer to the Owner Question
+
+Yes, add more than the already projected `context_window`, `max_tokens`, and
+`input_modalities`, but only where the agent actually consumes them:
+
+- Add `supports_vision` because Hermes acts on it. It also provides a canonical
+  boolean that can be kept in sync with `input_modalities`.
+- Add `supports_tools` if OpenClaw is a target, and project it as
+  `compat.supportsTools`.
+- Add `supports_reasoning` if OpenClaw is a target, and project it as
+  `reasoning`.
+- Do not add `max_input_tokens`.
+- Do not add `max_output_tokens` as a second output-cap field unless we decide
+  to migrate away from the existing `max_tokens` name.

--- a/packages/cli/docs/openclaw-v2-model-projection.md
+++ b/packages/cli/docs/openclaw-v2-model-projection.md
@@ -1,0 +1,176 @@
+# OpenClaw v2 model projection investigation
+
+Date: 2026-07-07
+
+## Verdict
+
+For v2 hosted runtime manifests that carry only the current single-model provider
+contract (`baseUrl`, `model`, `apiMode`, `runtimeEnvName`, `apiKeySecretRef`),
+the Clawdi CLI projects a bare OpenClaw model entry:
+
+```json
+{
+  "id": "<manifest model>",
+  "name": "<manifest model>",
+  "api": "<OpenClaw api label, when non-default>"
+}
+```
+
+For a non-built-in model slug that OpenClaw does not already know, the projected
+OpenClaw `models.providers[].models[]` entry does **not** contain
+`contextWindow` or `maxTokens`. Therefore v2 OpenClaw does not know the real
+context window from Clawdi's projection. Any later context-window behavior is an
+OpenClaw fallback for missing metadata, not a correct value supplied by Clawdi.
+
+## CLI projection path
+
+`clawdi ai-provider apply --target openclaw` enters
+`buildAgentTargetProjection("openclaw", ...)` from
+`packages/cli/src/commands/ai-provider-apply.ts:122` and wraps the generated JSON
+as `openclaw config patch --stdin` at
+`packages/cli/src/commands/ai-provider-apply.ts:278`.
+
+The OpenClaw provider JSON is built in
+`packages/cli/src/lib/ai-provider-projection.ts:256`. Each provider gets:
+
+- `baseUrl`: from the normalized provider base URL
+  (`packages/cli/src/lib/ai-provider-projection.ts:267`).
+- `api`: OpenClaw API label mapped from provider `api_mode`
+  (`packages/cli/src/lib/ai-provider-projection.ts:268`,
+  `packages/cli/src/lib/ai-provider-projection.ts:347`).
+- `apiKey`: env-secret reference when an agent env name exists
+  (`packages/cli/src/lib/ai-provider-projection.ts:269`).
+- `models`: from `openClawModels(...)`
+  (`packages/cli/src/lib/ai-provider-projection.ts:272`).
+
+`openClawModels(...)` maps catalog model metadata as follows
+(`packages/cli/src/lib/ai-provider-projection.ts:313`):
+
+| Catalog field | OpenClaw field |
+| --- | --- |
+| `id` | `id` |
+| `label` | `name`, falling back to `id` |
+| model/provider `api_mode` | `api`, unless default OpenAI chat |
+| `input_modalities` | `input` |
+| `context_window` | `contextWindow` |
+| `max_tokens` | `maxTokens` |
+
+It does not project `supports_reasoning`, `capabilities`, or `cost`
+(`packages/cli/src/lib/ai-provider-projection.ts:320`). If the selected primary
+model is not already in `provider.models`, it prepends only `{id, name, api}`
+(`packages/cli/src/lib/ai-provider-projection.ts:335`).
+
+The shared catalog type can store richer model metadata:
+`input_modalities`, `supports_reasoning`, `context_window`, `max_tokens`, and
+`cost` (`packages/shared/src/ai-provider.ts:48`). Validation accepts
+`context_window` and `max_tokens` when numeric
+(`packages/shared/src/ai-provider.ts:407`).
+
+## v2 runtime init path
+
+Hosted `runtime init` uses `hostedAiProviderCatalog(...)` to convert
+`manifest.projection.providers` into the same AI-provider catalog type
+(`packages/cli/src/runtime/manifest.ts:782`). Runtime scoping selects
+`runtime.provider_ids`, a provider named after the runtime, or `default`
+(`packages/cli/src/runtime/manifest.ts:830`).
+
+The v2 manifest single-model value becomes catalog model metadata in
+`hostedProviderModels(...)`. If `input.models` is missing, the code prepends:
+
+```ts
+{ id: legacyModel, api_mode: hostedProviderApiMode(input) }
+```
+
+from `input.model` (`packages/cli/src/runtime/manifest.ts:893`) and similarly
+for runtime `primary_model` (`packages/cli/src/runtime/manifest.ts:897`). The
+default API mode is `openai_chat` unless `apiMode`/`api_mode` is valid
+(`packages/cli/src/runtime/manifest.ts:905`).
+
+`runtime init` then calls the same OpenClaw projection builder and applies it
+with:
+
+```text
+openclaw config patch --stdin --replace-path models.providers
+```
+
+(`packages/cli/src/runtime/manifest.ts:1095`). The v2 test fixture demonstrates
+the contract shape: provider `openclaw` has `baseUrl`, `model`, `apiMode`,
+`runtimeEnvName`, and `apiKeySecretRef` only
+(`packages/cli/tests/runtime.test.ts:1161`). The asserted primary ref is
+`openclaw/gpt-5.5` and the provider base URL is projected
+(`packages/cli/tests/runtime.test.ts:1188`), but no test asserts
+`contextWindow` or `maxTokens`.
+
+## Field comparison
+
+| Field in OpenClaw `models.providers[].models[]` | v1 legacy CLI apply | v1 bootstrap config | v2 single-model manifest projection |
+| --- | --- | --- | --- |
+| `id` | Present. From catalog model id; if the primary model is absent, a primary-only entry is prepended. | Present. Static model definitions include `id`. | Present. From manifest `model` or runtime `primary_model`. |
+| `name` | Present. From catalog `label`, otherwise `id`. | Present for static Codex/Kimi definitions. | Present, but only as the model id because no `label` exists. |
+| `api` | Present when mapped API mode is non-default, e.g. `openai-responses`; omitted for default OpenAI chat. | Provider-level API is present for Codex/Kimi providers; individual static models do not need per-model `api`. | Present when `apiMode` maps to non-default, e.g. `openai-responses`; otherwise absent. |
+| `input` / input modalities | Present only if catalog model has `input_modalities`. | Present in static Codex/Kimi definitions as `input`. | Absent with the current single-model contract. |
+| `contextWindow` | Present only if catalog model has numeric `context_window`. Preserved from existing OpenClaw config during apply when the same provider/model already exists (`packages/cli/src/commands/ai-provider-apply.ts:306`). | Present for static Codex and Kimi definitions (`/home/kingsley/clawdi-hosted/backend/app/services/openclaw_config.py:77`). | Absent with the current single-model contract. |
+| `maxTokens` / max output | Present only if catalog model has numeric `max_tokens`. | Present for static Codex and Kimi definitions as `maxTokens` (`/home/kingsley/clawdi-hosted/backend/app/services/openclaw_config.py:86`). | Absent with the current single-model contract. |
+| `reasoning` | Not projected from catalog `supports_reasoning`. | Present in static Codex/Kimi definitions as `reasoning` (`/home/kingsley/clawdi-hosted/backend/app/services/openclaw_config.py:83`). | Absent. |
+| `cost` | Not projected by the CLI. | Present in static Codex/Kimi definitions (`/home/kingsley/clawdi-hosted/backend/app/services/openclaw_config.py:85`). | Absent. |
+| provider `apiKey` | Present when env/runtime env auth is available. | Present as literal key or env secret ref depending migration gate. | Present as env secret ref derived from `runtimeEnvName`/`apiKeySecretRef`. |
+
+## Hosted cross-reference
+
+The v1/bootstrap hosted config path hardcodes rich Codex model definitions with
+`reasoning`, `input`, `cost`, `contextWindow`, and `maxTokens`
+(`/home/kingsley/clawdi-hosted/backend/app/services/openclaw_config.py:77`).
+`build_openclaw_config(...)` includes those definitions under
+`models.providers.openai-codex.models`
+(`/home/kingsley/clawdi-hosted/backend/app/services/openclaw_config.py:473`)
+and Kimi definitions under `models.providers.kimi-coding.models`
+(`/home/kingsley/clawdi-hosted/backend/app/services/openclaw_config.py:482`).
+
+The v2 hosted runtime state payload carries runtime provider ids and primary
+model refs (`/home/kingsley/clawdi-hosted/backend/app/v2/hosted/runtime_state.py:134`),
+but not model capabilities. The managed AI provider metadata saved to cloud-api
+also stores only `models: [{"id": default_model}]`
+(`/home/kingsley/clawdi-hosted/backend/app/services/clawdi_cloud.py:221`).
+
+The Sub2API metadata overlay has the desired upstream source. Production compose
+sets:
+
+```text
+CODEX_MODELS_URL=https://raw.githubusercontent.com/openai/codex/main/codex-rs/models-manager/models.json
+```
+
+(`/home/kingsley/clawdi-hosted/infra/v2/sub2api/docker-compose.yml:166`).
+The overlay code defines the same default URL
+(`/home/kingsley/clawdi-hosted/infra/v2/sub2api/metadata-overlay/internal/config/codex.go:12`),
+requires `slug` and `context_window`, and maps Codex `context_window` to
+metadata `ContextLength` and `MaxInputTokens`
+(`/home/kingsley/clawdi-hosted/infra/v2/sub2api/metadata-overlay/internal/config/codex.go:18`).
+The README documents that it polls Codex `models.json` and maps
+`context_window` to OpenAI-compatible `context_length` and `max_input_tokens`
+(`/home/kingsley/clawdi-hosted/infra/v2/sub2api/README.md:43`).
+The bundled fallback config carries `max_output_tokens`
+(`/home/kingsley/clawdi-hosted/infra/v2/sub2api/metadata-overlay/config/models-metadata.yaml:2`),
+and the overlay config schema validates that field
+(`/home/kingsley/clawdi-hosted/infra/v2/sub2api/metadata-overlay/internal/config/config.go:16`).
+
+## Recommendation
+
+Add capability enrichment inside the CLI before `buildAgentTargetProjection(...)`
+is called for hosted OpenClaw runtime projection. The smallest insertion point is
+`hostedProviderModels(...)` in `packages/cli/src/runtime/manifest.ts:874`, or a
+helper immediately after it, because that is where the v2 single `model` becomes
+catalog model metadata. For `clawdi ai-provider apply`, the analogous source is
+the local/remote AI provider catalog before `buildOpenClawProjection(...)`.
+
+The enrichment should use the same upstream contract as the metadata overlay:
+Codex `models.json` at the URL above. Map at least:
+
+- `slug` -> catalog `id`
+- `context_window` -> catalog `context_window`
+- overlay fallback `max_output_tokens`, when available, -> catalog `max_tokens`
+
+Then the existing OpenClaw projection will emit `contextWindow` and `maxTokens`
+without changing OpenClaw's provider patch format. Extending the projection to
+also map `supports_reasoning` -> `reasoning` and `cost` -> `cost` would close the
+remaining v1 bootstrap/v2 gap, but requires an explicit catalog contract because
+the current CLI projection does not emit those fields.

--- a/packages/cli/src/lib/ai-provider-projection.ts
+++ b/packages/cli/src/lib/ai-provider-projection.ts
@@ -3,6 +3,7 @@ import type {
 	AiProviderApiMode,
 	AiProviderAuth,
 	AiProviderCatalog,
+	AiProviderModel,
 } from "@clawdi/shared";
 import {
 	defaultAiProviderApiMode,
@@ -321,7 +322,10 @@ function openClawModels(
 				id: model.id,
 				name: model.label ?? model.id,
 				api,
-				input: model.input_modalities,
+				input: openClawInputModalities(model),
+				reasoning: model.supports_reasoning,
+				compat:
+					model.supports_tools === undefined ? undefined : { supportsTools: model.supports_tools },
 				contextWindow: positiveNumber(model.context_window),
 				maxTokens: positiveNumber(model.max_tokens),
 			});
@@ -342,6 +346,13 @@ function openClawModels(
 		);
 	}
 	return models;
+}
+
+function openClawInputModalities(model: AiProviderModel): AiProviderModel["input_modalities"] {
+	if (model.input_modalities && model.input_modalities.length > 0) return model.input_modalities;
+	if (model.supports_vision === true) return ["text", "image"];
+	if (model.supports_vision === false) return ["text"];
+	return undefined;
 }
 
 function openClawApiLabel(apiMode: AiProviderApiMode): string | undefined {
@@ -417,8 +428,63 @@ function buildHermesProjection(
 		lines.push(`    transport: ${quoteYaml(transport)}`);
 		const envName = hermesKeyEnvForProvider(provider);
 		if (envName) lines.push(`    key_env: ${quoteYaml(envName)}`);
+		lines.push(...hermesModelLines(provider));
 	}
 	return `${lines.join("\n")}\n`;
+}
+
+function hermesModelLines(provider: ProjectionProvider): string[] {
+	const models = hermesModels(provider);
+	if (models.length === 0) return [];
+	const lines = ["    models:"];
+	for (const model of models) {
+		lines.push(`      ${quoteYaml(model.id)}:`);
+		if (model.context_length !== undefined) {
+			lines.push(`        context_length: ${model.context_length}`);
+		}
+		if (model.max_tokens !== undefined) {
+			lines.push(`        max_tokens: ${model.max_tokens}`);
+		}
+		if (model.supports_vision !== undefined) {
+			lines.push(`        supports_vision: ${model.supports_vision}`);
+		}
+	}
+	return lines;
+}
+
+function hermesModels(
+	provider: ProjectionProvider,
+): Array<{ id: string; context_length?: number; max_tokens?: number; supports_vision?: boolean }> {
+	const seen = new Set<string>();
+	const entries: Array<{
+		id: string;
+		context_length?: number;
+		max_tokens?: number;
+		supports_vision?: boolean;
+	}> = [];
+	for (const model of provider.models ?? []) {
+		if (!model.id || seen.has(model.id)) continue;
+		seen.add(model.id);
+		const entry: {
+			id: string;
+			context_length?: number;
+			max_tokens?: number;
+			supports_vision?: boolean;
+		} = { id: model.id };
+		const contextLength = positiveNumber(model.context_window);
+		if (contextLength !== undefined) entry.context_length = contextLength;
+		const maxTokens = positiveNumber(model.max_tokens);
+		if (maxTokens !== undefined) entry.max_tokens = maxTokens;
+		const supportsVision = hermesSupportsVision(model);
+		if (supportsVision !== undefined) entry.supports_vision = supportsVision;
+		if (Object.keys(entry).length > 1) entries.push(entry);
+	}
+	return entries;
+}
+
+function hermesSupportsVision(model: AiProviderModel): boolean | undefined {
+	if (typeof model.supports_vision === "boolean") return model.supports_vision;
+	return model.input_modalities?.includes("image") ? true : undefined;
 }
 
 function hermesBaseUrlForProvider(provider: ProjectionProvider): string {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1163,6 +1163,14 @@ chmod +x "$HOME/.local/bin/hermes"
 							kind: "openai-compatible",
 							baseUrl: "https://openclaw-provider.example.test/v1",
 							model: "gpt-5.5",
+							models: [
+								{
+									id: "gpt-5.5",
+									context_window: 272000,
+									max_tokens: 128000,
+									input_modalities: ["text", "image"],
+								},
+							],
 							apiMode: "openai_responses",
 							runtimeEnvName: "OPENCLAW_PROVIDER_API_KEY",
 							apiKeySecretRef: "provider.openclaw.apiKey",
@@ -1190,6 +1198,13 @@ chmod +x "$HOME/.local/bin/hermes"
 		expect(patch.models.providers.openclaw.baseUrl).toBe(
 			"https://openclaw-provider.example.test/v1",
 		);
+		expect(patch.models.providers.openclaw.models[0]).toMatchObject({
+			id: "gpt-5.5",
+			contextWindow: 272000,
+			maxTokens: 128000,
+			input: ["text", "image"],
+			api: "openai-responses",
+		});
 		expect(JSON.stringify(patch)).not.toContain("hermes-provider.example.test");
 		const hermesConfig = readFileSync(join(home, ".hermes", "config.yaml"), "utf-8");
 		expect(hermesConfig).toContain("provider: custom:hermes");

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1169,6 +1169,9 @@ chmod +x "$HOME/.local/bin/hermes"
 									context_window: 272000,
 									max_tokens: 128000,
 									input_modalities: ["text", "image"],
+									supports_vision: true,
+									supports_tools: true,
+									supports_reasoning: true,
 								},
 							],
 							apiMode: "openai_responses",
@@ -1179,6 +1182,17 @@ chmod +x "$HOME/.local/bin/hermes"
 							kind: "openai-compatible",
 							baseUrl: "https://hermes-provider.example.test/v1",
 							model: "kimi/kimi-for-coding",
+							models: [
+								{
+									id: "kimi/kimi-for-coding",
+									context_window: 262144,
+									max_tokens: 32768,
+									input_modalities: ["text", "image"],
+									supports_vision: true,
+									supports_tools: true,
+									supports_reasoning: true,
+								},
+							],
 							apiMode: "openai_chat",
 							runtimeEnvName: "HERMES_PROVIDER_API_KEY",
 							apiKeySecretRef: "provider.hermes.apiKey",
@@ -1203,6 +1217,8 @@ chmod +x "$HOME/.local/bin/hermes"
 			contextWindow: 272000,
 			maxTokens: 128000,
 			input: ["text", "image"],
+			reasoning: true,
+			compat: { supportsTools: true },
 			api: "openai-responses",
 		});
 		expect(JSON.stringify(patch)).not.toContain("hermes-provider.example.test");
@@ -1210,6 +1226,11 @@ chmod +x "$HOME/.local/bin/hermes"
 		expect(hermesConfig).toContain("provider: custom:hermes");
 		expect(hermesConfig).toContain("api: https://hermes-provider.example.test/v1");
 		expect(hermesConfig).toContain("default: kimi/kimi-for-coding");
+		expect(hermesConfig).toContain("models:");
+		expect(hermesConfig).toContain("kimi/kimi-for-coding:");
+		expect(hermesConfig).toContain("context_length: 262144");
+		expect(hermesConfig).toContain("max_tokens: 32768");
+		expect(hermesConfig).toContain("supports_vision: true");
 		expect(hermesConfig).not.toContain("openclaw-provider.example.test");
 		const openclawRunConfig = JSON.parse(
 			readFileSync(join(state, "config", "run", "openclaw.json"), "utf-8"),

--- a/packages/shared/src/ai-provider.test.ts
+++ b/packages/shared/src/ai-provider.test.ts
@@ -24,7 +24,7 @@ describe("validateAiProviderCatalog", () => {
 					type: "openai",
 					base_url: "https://api.openai.com/v1",
 					auth: { type: "secret_ref" },
-					models: [{ id: "gpt-5.2", context_window: "large" }],
+					models: [{ id: "gpt-5.2", context_window: "large", supports_tools: "yes" }],
 				},
 			],
 		} as never);
@@ -36,6 +36,9 @@ describe("validateAiProviderCatalog", () => {
 		expect(result.errors).toContain("Provider openai-alt has unsupported secret ref.");
 		expect(result.errors).toContain(
 			"Provider openai-alt model gpt-5.2 has invalid context_window.",
+		);
+		expect(result.errors).toContain(
+			"Provider openai-alt model gpt-5.2 has invalid supports_tools.",
 		);
 	});
 

--- a/packages/shared/src/ai-provider.ts
+++ b/packages/shared/src/ai-provider.ts
@@ -50,6 +50,8 @@ export interface AiProviderModel {
 	label?: string;
 	api_mode?: AiProviderApiMode;
 	input_modalities?: Array<"text" | "image" | "video" | "audio">;
+	supports_vision?: boolean;
+	supports_tools?: boolean;
 	supports_reasoning?: boolean;
 	context_window?: number;
 	max_tokens?: number;
@@ -420,6 +422,11 @@ function validateModels(prefix: string, models: unknown, errors: string[]): void
 			(typeof model.api_mode !== "string" || !isAiProviderApiMode(model.api_mode))
 		) {
 			errors.push(`Provider ${prefix} model ${id || "<missing>"} has invalid api_mode.`);
+		}
+		for (const field of ["supports_vision", "supports_tools", "supports_reasoning"] as const) {
+			if (model[field] !== undefined && typeof model[field] !== "boolean") {
+				errors.push(`Provider ${prefix} model ${id || "<missing>"} has invalid ${field}.`);
+			}
 		}
 	}
 }

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -2657,6 +2657,10 @@ export interface components {
             api_mode?: ("openai_chat" | "openai_responses" | "anthropic_messages" | "google_generate_content") | null;
             /** Input Modalities */
             input_modalities?: ("text" | "image" | "video" | "audio")[] | null;
+            /** Supports Vision */
+            supports_vision?: boolean | null;
+            /** Supports Tools */
+            supports_tools?: boolean | null;
             /** Supports Reasoning */
             supports_reasoning?: boolean | null;
             /** Context Window */


### PR DESCRIPTION
Makes v2 agents actually KNOW our models' capabilities (owner priority). Pairs with the clawdi-hosted PR — **merge this OSS PR first** (it adds the schema fields + regenerated client the hosted contract guard reads).

## Problem
The v2 managed provider projected only a bare model id, so OpenClaw/Hermes didn't know context window, token limits, or capabilities — they fell back to wrong defaults.

## Change
- Admin/provider schemas + shared types accept per-model `context_window, max_tokens, input_modalities, supports_vision, supports_tools, supports_reasoning` (regenerated `api.generated.ts`).
- **CLI projection maps each to the agent's OWN schema** (not a blind copy): OpenClaw → `contextWindow / maxTokens / input / reasoning / compat.supportsTools`; Hermes → `context_length / max_tokens / supports_vision` model overrides. (Field set + per-agent mapping verified against OpenClaw & Hermes upstream source — see the included docs; `supports_*` ARE consumed, not dead data.)
- Source stays our in-repo catalog (models.dev evaluated + rejected as sole source — doesn't cover our models / wrong gpt-5.x context; see the SSOT eval doc). Includes the #1/#2 investigation + capability-consumers + models.dev + SSOT docs.

## E2E proof
OpenClaw projection now yields `{contextWindow:272000, maxTokens:128000, input:[text,image], reasoning:true, compat:{supportsTools:true}}` for gpt-5.5.

## Verification
CLI runtime e2e + shared catalog/validation + generated-API check + `bun run check` + backend targeted pytest + `pdm lint` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)