### PR TITLE
fix(web): v2 UI fast-follows from the final sweep (F1-F7)

### DIFF
--- a/apps/web/src/components/projects/project-metadata.tsx
+++ b/apps/web/src/components/projects/project-metadata.tsx
@@ -246,6 +246,12 @@ export function ProjectScopePicker({
 	const agentsById = new Map((agents ?? []).map((agent) => [agent.id, agent]));
 	const selectedAgent = selectedProject ? projectAgentFor(selectedProject, agentsById) : null;
 	const groupedProjects = projectPickerGroups(projects);
+	const projectItems = [
+		...(allowAll ? [{ value: "all", label: allLabel }] : []),
+		...projects.flatMap((project) =>
+			project.id ? [{ value: project.id, label: displayProjectName(project) }] : [],
+		),
+	];
 	const isStacked = layout === "stacked";
 	return (
 		<div
@@ -267,6 +273,7 @@ export function ProjectScopePicker({
 				</span>
 			) : null}
 			<Select
+				items={projectItems}
 				value={value}
 				onValueChange={(nextValue) => {
 					if (nextValue !== null) onValueChange(nextValue);
@@ -351,8 +358,15 @@ export function ProjectCompactPicker({
 }) {
 	const selectedProject = projects.find((project) => project.id === value) ?? null;
 	const agentsById = new Map((agents ?? []).map((agent) => [agent.id, agent]));
+	const projectItems = [
+		...(allowAll ? [{ value: "all", label: allLabel }] : []),
+		...projects.flatMap((project) =>
+			project.id ? [{ value: project.id, label: displayProjectName(project) }] : [],
+		),
+	];
 	return (
 		<Select
+			items={projectItems}
 			value={value}
 			onValueChange={(nextValue) => {
 				if (nextValue !== null) onValueChange(nextValue);

--- a/apps/web/src/components/skills/send-skill-dialog.tsx
+++ b/apps/web/src/components/skills/send-skill-dialog.tsx
@@ -122,6 +122,14 @@ export function SendSkillDialog({
 				})),
 		[projects, skills],
 	);
+	const targetItems = useMemo(
+		() =>
+			[...agentTargets, ...projectTargets].map((target) => ({
+				value: target.value,
+				label: target.label,
+			})),
+		[agentTargets, projectTargets],
+	);
 
 	const send = useMutation({
 		mutationFn: async () => {
@@ -227,6 +235,7 @@ export function SendSkillDialog({
 					<div className="space-y-1.5">
 						<Label htmlFor="send-skill-target">Destination</Label>
 						<Select
+							items={targetItems}
 							value={target}
 							onValueChange={(value) => {
 								if (value !== null) setTarget(value);

--- a/apps/web/src/components/vault/add-keys-dialog.tsx
+++ b/apps/web/src/components/vault/add-keys-dialog.tsx
@@ -72,6 +72,13 @@ export function AddKeysDialog({
 		() => (vaultsQuery.data?.items ?? []).filter((v) => v.is_owner !== false),
 		[vaultsQuery.data],
 	);
+	const vaultItems = useMemo(
+		() => [
+			...ownVaults.map((vault) => ({ value: vault.slug, label: vault.name })),
+			{ value: NEW_VAULT, label: "New vault…" },
+		],
+		[ownVaults],
+	);
 	// Default destination: pinned slug, else the first vault, else create-new.
 	const effectiveChoice = vaultChoice || (ownVaults.length > 0 ? ownVaults[0].slug : NEW_VAULT);
 	const selectedVault = ownVaults.find((v) => v.slug === effectiveChoice);
@@ -230,6 +237,7 @@ export function AddKeysDialog({
 							<div className="space-y-1.5">
 								<Label htmlFor="add-keys-vault">Into vault</Label>
 								<Select
+									items={vaultItems}
 									value={effectiveChoice}
 									onValueChange={(value) => {
 										if (value !== null) setVaultChoice(value);

--- a/apps/web/src/components/vault/copy-keys-dialog.tsx
+++ b/apps/web/src/components/vault/copy-keys-dialog.tsx
@@ -82,6 +82,16 @@ export function CopyKeysDialog({
 		() => ownVaults.filter((v) => v.slug !== vault.slug),
 		[ownVaults, vault.slug],
 	);
+	const targetVaultItems = useMemo(
+		() => [
+			...targetVaults.map((targetVault) => ({
+				value: targetVault.slug,
+				label: targetVault.name,
+			})),
+			{ value: NEW_VAULT, label: "New vault…" },
+		],
+		[targetVaults],
+	);
 	const effectiveChoice =
 		targetChoice || (targetVaults.length > 0 ? targetVaults[0].slug : NEW_VAULT);
 	const creatingNewVault = effectiveChoice === NEW_VAULT;
@@ -243,6 +253,7 @@ export function CopyKeysDialog({
 						<div className="space-y-1.5">
 							<Label htmlFor="copy-keys-target">Destination vault</Label>
 							<Select
+								items={targetVaultItems}
 								value={effectiveChoice}
 								onValueChange={(value) => {
 									if (value !== null) setTargetChoice(value);

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -78,6 +78,7 @@ import type {
 } from "@/hosted/billing/contracts";
 import {
 	LANGUAGE_OPTIONS,
+	LANGUAGE_SELECT_ITEMS,
 	supportedTimezones,
 	TimezoneCombobox,
 } from "@/hosted/billing/deploy/language-timezone-controls";
@@ -86,6 +87,7 @@ import { billingTermLabel, billingTermSuffix, formatCentsCompact } from "@/hoste
 import {
 	checkoutReturnDeploymentId,
 	checkoutReturnMarker,
+	checkoutReturnWasCanceled,
 	useCancelSubscription,
 	useCheckout,
 	useCheckoutReturnRefresh,
@@ -752,16 +754,7 @@ function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; run
 			<EmptyState
 				icon={MonitorPlay}
 				title="No Runtime UI URL yet"
-				description={
-					<span>
-						This {label} runtime is running but hasn&apos;t published its browser UI endpoint. Reach
-						it by linking a channel from{" "}
-						<Link to="/channels" className="underline">
-							Channels
-						</Link>
-						.
-					</span>
-				}
+				description={`This ${label} runtime is running but hasn't published its browser UI endpoint yet. Check the Overview status shortly or use Terminal while it finishes.`}
 			/>
 		);
 	}
@@ -1303,7 +1296,7 @@ function AiProviderTab({
 						) : null}
 					</div>
 					<p className="mt-0.5 text-sm text-muted-foreground">
-						Clawdi-managed Claude models, billed from your wallet.
+						Clawdi-managed models, billed from your wallet.
 					</p>
 				</button>
 				{providers.isLoading ? <ProviderOptionSkeleton /> : null}
@@ -1431,12 +1424,32 @@ function AgentPrimaryModelPicker({
 }) {
 	const catalogModelIds = modelIdsForProvider(primaryProviderChoice, providers);
 	const modelChoice = catalogModelIds.includes(primaryModel) ? primaryModel : CUSTOM_MODEL_CHOICE;
+	const primaryProviderItems = [
+		...(selectedProviderChoices.includes(MANAGED_AI_CHOICE)
+			? [{ value: MANAGED_AI_CHOICE, label: "Managed by Clawdi" }]
+			: []),
+		...selectedProviderChoices.filter(isUnresolvedProviderChoice).map((choice) => ({
+			value: choice,
+			label: unresolvedProviderRef(choice),
+		})),
+		...customProviders
+			.filter((provider) => selectedProviderChoices.includes(provider.provider_id))
+			.map((provider) => ({
+				value: provider.provider_id,
+				label: provider.label ?? provider.provider_id,
+			})),
+	];
+	const catalogModelItems = [
+		...catalogModelIds.map((model) => ({ value: model, label: formatModelLabel(model) })),
+		{ value: CUSTOM_MODEL_CHOICE, label: "Custom model" },
+	];
 	return (
 		<div className="flex max-w-2xl flex-col gap-3 rounded-lg border bg-muted/20 p-3">
 			<div className="grid gap-3 sm:grid-cols-2">
 				<div className="flex flex-col gap-1.5">
 					<Label htmlFor="agent-primary-provider">Primary provider</Label>
 					<Select
+						items={primaryProviderItems}
 						value={primaryProviderChoice}
 						onValueChange={(value) => {
 							if (value) onPrimaryProviderChange(value);
@@ -1468,6 +1481,7 @@ function AgentPrimaryModelPicker({
 					<div className="flex flex-col gap-1.5">
 						<Label htmlFor="agent-catalog-model">Catalog model</Label>
 						<Select
+							items={catalogModelItems}
 							value={modelChoice}
 							onValueChange={(value) => {
 								if (!value) return;
@@ -1540,6 +1554,10 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 			.map((b) => ({ id: b.id, provider: b.provider, name: b.name }));
 		return [...mine, ...shared].filter((c) => !linkedIds.has(c.id));
 	}, [channels.data, botPool.data, linkedIds]);
+	const linkableItems = linkable.map((channel) => ({
+		value: channel.id,
+		label: `${providerMeta(channel.provider).label} · ${channel.name}`,
+	}));
 
 	// Provider/name labels for linked rows whose API payload omits the nested
 	// `account` (the list-by-agent endpoint isn't guaranteed to embed it).
@@ -1634,6 +1652,7 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 				</p>
 				<div className="flex flex-col gap-2 sm:flex-row">
 					<Select
+						items={linkableItems}
 						value={accountId}
 						onValueChange={(value) => {
 							if (value !== null) setAccountId(value);
@@ -1843,6 +1862,7 @@ function LanguageTimezoneSettingsSection({
 					<div className="flex flex-col gap-1.5">
 						<Label htmlFor="settings-agent-language">Language</Label>
 						<Select
+							items={LANGUAGE_SELECT_ITEMS}
 							value={language || "default"}
 							onValueChange={(value) => {
 								setLanguage(value === null || value === "default" ? "" : value);
@@ -1985,6 +2005,12 @@ function ComputeSettingsSections({
 		if (!marker || checkoutReturnRef.current === marker) return;
 		checkoutReturnRef.current = marker;
 		void refreshCheckoutReturn().then(() => {
+			if (checkoutReturnWasCanceled(searchStr)) {
+				toast.message("Checkout canceled", {
+					description: "You were not charged. Your compute plan is unchanged.",
+				});
+				return;
+			}
 			const deploymentId = checkoutReturnDeploymentId(searchStr);
 			if (deploymentId && deploymentId !== deployment.id) {
 				void router.navigate({
@@ -2290,21 +2316,21 @@ function ComputeSettingsSections({
 				description="Restart, stop, or start the whole hosted compute."
 			>
 				<div className="flex flex-wrap gap-2.5">
-					<Button
-						variant="outline"
-						size="sm"
-						disabled={lifecycle.isPending || !canRestart}
-						onClick={() =>
-							void runAction(() => runLifecycleAction("restart")).catch(() => undefined)
-						}
+					<ConfirmAction
+						title="Restart compute?"
+						description={<p>This restarts this hosted agent.</p>}
+						confirmLabel="Restart compute"
+						onConfirm={() => runAction(() => runLifecycleAction("restart"))}
 					>
-						{lifecycle.isPending && lifecycle.variables?.action === "restart" ? (
-							<Spinner className="size-3.5" />
-						) : (
-							<RefreshCw className="size-3.5" />
-						)}
-						Restart
-					</Button>
+						<Button variant="outline" size="sm" disabled={lifecycle.isPending || !canRestart}>
+							{lifecycle.isPending && lifecycle.variables?.action === "restart" ? (
+								<Spinner className="size-3.5" />
+							) : (
+								<RefreshCw className="size-3.5" />
+							)}
+							Restart
+						</Button>
+					</ConfirmAction>
 					{canStop ? (
 						<ConfirmAction
 							title="Stop compute?"

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -38,6 +38,7 @@ import { buildHostedDeployRequest } from "@/hosted/billing/deploy/deploy-request
 import {
 	browserTimezone,
 	LANGUAGE_OPTIONS,
+	LANGUAGE_SELECT_ITEMS,
 	supportedTimezones,
 	TimezoneCombobox,
 } from "@/hosted/billing/deploy/language-timezone-controls";
@@ -46,6 +47,7 @@ import { billingTermSuffix, formatCentsCompact } from "@/hosted/billing/format";
 import {
 	checkoutReturnDeploymentId,
 	checkoutReturnMarker,
+	checkoutReturnWasCanceled,
 	useCheckout,
 	useCheckoutReturnRefresh,
 	useCreateDeployment,
@@ -334,6 +336,12 @@ export function DeployWizard() {
 		if (!marker || checkoutReturnRef.current === marker) return;
 		checkoutReturnRef.current = marker;
 		void refreshCheckoutReturn().then(() => {
+			if (checkoutReturnWasCanceled(searchStr)) {
+				toast.message("Checkout canceled", {
+					description: "You were not charged. Your agent was not deployed.",
+				});
+				return;
+			}
 			const deploymentId = checkoutReturnDeploymentId(searchStr);
 			if (deploymentId) {
 				void router.navigate({
@@ -864,6 +872,7 @@ export function DeployWizard() {
 									Language
 								</label>
 								<Select
+									items={LANGUAGE_SELECT_ITEMS}
 									value={language || "default"}
 									onValueChange={(v) => {
 										setLanguage(v === null || v === "default" ? "" : v);
@@ -960,12 +969,28 @@ function PrimaryModelPicker({
 }) {
 	const catalogModelIds = modelIdsForProvider(primaryProviderChoice, providers);
 	const modelChoice = catalogModelIds.includes(primaryModel) ? primaryModel : CUSTOM_MODEL_CHOICE;
+	const primaryProviderItems = [
+		...(selectedProviderChoices.includes(MANAGED_AI_CHOICE)
+			? [{ value: MANAGED_AI_CHOICE, label: "Managed by Clawdi" }]
+			: []),
+		...customProviders
+			.filter((provider) => selectedProviderChoices.includes(provider.provider_id))
+			.map((provider) => ({
+				value: provider.provider_id,
+				label: provider.label ?? provider.provider_id,
+			})),
+	];
+	const catalogModelItems = [
+		...catalogModelIds.map((model) => ({ value: model, label: model })),
+		{ value: CUSTOM_MODEL_CHOICE, label: "Custom model" },
+	];
 	return (
 		<div className="mt-4 flex max-w-2xl flex-col gap-3 rounded-lg border bg-muted/20 p-3">
 			<div className="grid gap-3 sm:grid-cols-2">
 				<div className="flex flex-col gap-1.5">
 					<Label htmlFor="deploy-primary-provider">Primary provider</Label>
 					<Select
+						items={primaryProviderItems}
 						value={primaryProviderChoice}
 						onValueChange={(value) => {
 							if (value) onPrimaryProviderChange(value);
@@ -992,6 +1017,7 @@ function PrimaryModelPicker({
 					<div className="flex flex-col gap-1.5">
 						<Label htmlFor="deploy-catalog-model">Catalog model</Label>
 						<Select
+							items={catalogModelItems}
 							value={modelChoice}
 							onValueChange={(value) => {
 								if (!value) return;

--- a/apps/web/src/hosted/billing/deploy/language-timezone-controls.tsx
+++ b/apps/web/src/hosted/billing/deploy/language-timezone-controls.tsx
@@ -27,6 +27,11 @@ export const LANGUAGE_OPTIONS = [
 	{ code: "pt", label: "Português" },
 ] as const;
 
+export const LANGUAGE_SELECT_ITEMS = [
+	{ value: "default", label: "Default" },
+	...LANGUAGE_OPTIONS.map((option) => ({ value: option.code, label: option.label })),
+] as const;
+
 // Static IANA timezone list keeps SSR and client markup deterministic.
 const TIMEZONE_OPTIONS = `
 Africa/Abidjan

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -4,6 +4,8 @@ import type { ComputeSubscriptionActionResult, HostedDeployment } from "@/hosted
 import {
 	applyDeploymentSubscriptionResult,
 	billingKeys,
+	checkoutReturnMarker,
+	checkoutReturnWasCanceled,
 	refreshCheckoutReturnQueries,
 } from "@/hosted/billing/hooks";
 
@@ -131,5 +133,18 @@ describe("refreshCheckoutReturnQueries", () => {
 		);
 		expect(qc.getQueryState(billingKeys.plans)?.isInvalidated).toBe(true);
 		expect(qc.getQueryState(["agents"])?.isInvalidated).toBe(true);
+	});
+});
+
+describe("checkout return parsing", () => {
+	test("recognizes Stripe cancel returns as checkout markers", () => {
+		expect(checkoutReturnWasCanceled("?checkout=cancel")).toBe(true);
+		expect(checkoutReturnWasCanceled("?settings=billing-plan&checkout=cancel")).toBe(true);
+		expect(checkoutReturnMarker("?checkout=cancel")).toBe("checkout=cancel");
+	});
+
+	test("does not treat passive checkout success copy as a refresh marker", () => {
+		expect(checkoutReturnWasCanceled("?checkout=success")).toBe(false);
+		expect(checkoutReturnMarker("?checkout=success")).toBeNull();
 	});
 });

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -51,7 +51,12 @@ export function checkoutReturnMarker(searchStr: string): string | null {
 		const value = params.get(key);
 		return value ? [`${key}=${value}`] : [];
 	});
+	if (checkoutReturnWasCanceled(searchStr)) values.push("checkout=cancel");
 	return values.length > 0 ? values.join("&") : null;
+}
+
+export function checkoutReturnWasCanceled(searchStr: string): boolean {
+	return new URLSearchParams(searchStr).get("checkout") === "cancel";
 }
 
 export function checkoutReturnDeploymentId(searchStr: string): string | null {

--- a/apps/web/src/hosted/billing/usage/usage-page.tsx
+++ b/apps/web/src/hosted/billing/usage/usage-page.tsx
@@ -13,7 +13,7 @@ import { useUsage } from "@/hosted/billing/hooks";
 import { formatShortDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
-const DESCRIPTION = "AI Credit consumption across your agents. Wallet credits do not reset.";
+const DESCRIPTION = "AI Credit consumption for the current reporting window across your agents.";
 const USAGE_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6");
 
 export function UsagePage() {
@@ -45,9 +45,10 @@ export function UsagePage() {
 	const hasDailyBreakdown = u.by_day.length > 0;
 	const firstDailyPoint = u.by_day[0];
 	const lastDailyPoint = u.by_day[u.by_day.length - 1];
+	const windowLabel = `${formatShortDate(u.period_start)} – ${formatShortDate(u.period_end)}`;
 	const dailyChartLabel =
 		hasDailyBreakdown && firstDailyPoint && lastDailyPoint
-			? `Daily AI Credit usage from ${formatShortDate(firstDailyPoint.date)} to ${formatShortDate(lastDailyPoint.date)}: ${formatCredits(u.total_credits)} total.`
+			? `Daily AI Credit usage returned for ${formatShortDate(firstDailyPoint.date)} to ${formatShortDate(lastDailyPoint.date)} within the ${windowLabel} reporting window.`
 			: undefined;
 	const maxDay = Math.max(1, ...u.by_day.map((d) => d.credits));
 	const maxModel = Math.max(1, ...u.by_model.map((m) => m.credits));
@@ -69,7 +70,7 @@ export function UsagePage() {
 		<div data-hosted="true" className={USAGE_PAGE_CLASS}>
 			<PageHeader
 				title="Usage"
-				description={`${formatShortDate(u.period_start)} – ${formatShortDate(u.period_end)} reporting window. Wallet credits do not reset.`}
+				description={`${windowLabel} reporting window. Totals below are for this window; wallet balance carries over.`}
 			/>
 
 			{/* Totals */}
@@ -79,7 +80,7 @@ export function UsagePage() {
 						<div className="text-3xl font-semibold tabular-nums">
 							{formatCredits(u.total_credits)}
 						</div>
-						<div className="text-sm text-muted-foreground">AI Credits used</div>
+						<div className="text-sm text-muted-foreground">AI Credits used in window</div>
 					</CardContent>
 				</Card>
 				<Card data-hosted="true">
@@ -87,7 +88,7 @@ export function UsagePage() {
 						<div className="text-3xl font-semibold tabular-nums">
 							{u.total_requests.toLocaleString()}
 						</div>
-						<div className="text-sm text-muted-foreground">Requests</div>
+						<div className="text-sm text-muted-foreground">Requests in window</div>
 					</CardContent>
 				</Card>
 			</div>
@@ -115,7 +116,7 @@ export function UsagePage() {
 								<span>{lastDailyPoint?.date.slice(5)}</span>
 							</div>
 							<table className="sr-only">
-								<caption>Daily consumption by day</caption>
+								<caption>Daily consumption by day in the reporting window</caption>
 								<thead>
 									<tr>
 										<th scope="col">Day</th>

--- a/apps/web/src/hosted/billing/wallet/ledger-table.tsx
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.tsx
@@ -50,6 +50,13 @@ const STATUS_LABELS: Record<WalletLedgerStatus, string> = {
 	pending: "Pending",
 	failed: "Failed",
 };
+const LEDGER_FILTER_ITEMS = [
+	{ value: "all", label: "All activity" },
+	{ value: "topup", label: "Top-ups" },
+	{ value: "grant", label: "Grants" },
+	{ value: "usage", label: "Usage" },
+	{ value: "refund", label: "Refunds" },
+] as const;
 
 function statusVariant(
 	status: WalletLedgerStatus,
@@ -136,6 +143,7 @@ export function LedgerTable({
 					Activity
 				</h2>
 				<Select
+					items={LEDGER_FILTER_ITEMS}
 					value={filter}
 					onValueChange={(value) => {
 						if (value !== null) handleFilterChange(value);
@@ -145,11 +153,11 @@ export function LedgerTable({
 						<SelectValue />
 					</SelectTrigger>
 					<SelectContent>
-						<SelectItem value="all">All activity</SelectItem>
-						<SelectItem value="topup">Top-ups</SelectItem>
-						<SelectItem value="grant">Grants</SelectItem>
-						<SelectItem value="usage">Usage</SelectItem>
-						<SelectItem value="refund">Refunds</SelectItem>
+						{LEDGER_FILTER_ITEMS.map((item) => (
+							<SelectItem key={item.value} value={item.value}>
+								{item.label}
+							</SelectItem>
+						))}
 					</SelectContent>
 				</Select>
 			</div>

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -241,6 +241,15 @@ export function AddProviderDialog({
 		Boolean(baseUrl.trim()) &&
 		noneAuthOk &&
 		(!keyRequired || apiKey.trim().length > 0);
+	const authMethodItems = [
+		{ value: "api_key", label: "API key" },
+		...(meta.oauth ? [{ value: "oauth", label: "Sign in with ChatGPT (Codex)" }] : []),
+		...(meta.custom ? [{ value: "none", label: "No auth (local)" }] : []),
+	];
+	const apiModeItems = meta.apiModes.map((mode) => ({
+		value: mode,
+		label: API_MODE_LABEL[mode],
+	}));
 
 	async function submit() {
 		if (!canSubmit) return;
@@ -712,6 +721,7 @@ export function AddProviderDialog({
 								<div className="flex flex-col gap-1.5">
 									<Label htmlFor="provider-auth">Authentication</Label>
 									<Select
+										items={authMethodItems}
 										value={authMethod}
 										onValueChange={(value) => {
 											if (isAuthMethod(value)) setAuthMethod(value);
@@ -819,6 +829,7 @@ export function AddProviderDialog({
 									<div className="flex flex-col gap-1.5">
 										<Label htmlFor="provider-mode">API mode</Label>
 										<Select
+											items={apiModeItems}
 											value={apiMode}
 											onValueChange={(value) => {
 												if (isApiMode(value)) setApiMode(value);

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -501,6 +501,10 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 	const devices = creds.data ?? [];
 	// Default to the only link when there's exactly one.
 	const effectiveLink = linkId || (linkItems.length === 1 ? linkItems[0].id : "");
+	const linkSelectItems = linkItems.map((link) => ({
+		value: link.id,
+		label: envName(envs.data, link.agent_id, ownership),
+	}));
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -537,6 +541,7 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 						<div className="flex flex-col gap-1.5">
 							<Label htmlFor="wa-agent">Agent</Label>
 							<Select
+								items={linkSelectItems}
 								value={effectiveLink}
 								onValueChange={(value) => {
 									if (value !== null) setLinkId(value);
@@ -665,6 +670,10 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 	const [result, setResult] = useState<PairCodeResult | null>(null);
 	const [revealedAgentToken, setRevealedAgentToken] = useState<RevealedAgentToken | null>(null);
 	const [nowMs, setNowMs] = useState(() => Date.now());
+	const agentItems = (envs.data ?? []).map((env) => ({
+		value: env.id,
+		label: envName(envs.data, env.id, ownership),
+	}));
 	const generateLocked = useRef(false);
 	const meta = providerMeta(provider);
 	const isGenerating = create.isPending || generateLocked.current;
@@ -722,6 +731,7 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 						<Skeleton className="h-10 w-full rounded-md" />
 					) : (
 						<Select
+							items={agentItems}
 							value={agentId}
 							onValueChange={(value) => {
 								if (value !== null) setAgentId(value);
@@ -748,6 +758,7 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 				<div className="flex flex-col gap-1.5">
 					<Label htmlFor="pair-ttl">Expires in</Label>
 					<Select
+						items={TTL_OPTIONS}
 						value={ttl}
 						onValueChange={(value) => {
 							if (value !== null) setTtl(value);

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
@@ -88,6 +88,17 @@ export function LinkAgentDialog({
 	}
 
 	const agents = useMemo(() => [...(envs.data ?? [])].sort(compareAgentEnvironments), [envs.data]);
+	const agentItems = useMemo(
+		() =>
+			agents.map((env) => {
+				const ownershipKind = agentOwnershipKindFromId(env.id, ownership);
+				return {
+					value: env.id,
+					label: agentTextLabel(env, { ownershipKind }),
+				};
+			}),
+		[agents, ownership],
+	);
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -130,6 +141,7 @@ export function LinkAgentDialog({
 							Agent
 						</Label>
 						<Select
+							items={agentItems}
 							value={agentId}
 							onValueChange={(value) => {
 								if (value !== null) setAgentId(value);

--- a/apps/web/src/pages/dashboard/memories/page.tsx
+++ b/apps/web/src/pages/dashboard/memories/page.tsx
@@ -61,6 +61,7 @@ const CATEGORIES = [
 // "no filter". Keep them separate so ToggleGroup can render a selected state
 // for the All chip (Radix does not treat "" as a selected value).
 const ALL = "all";
+const ADD_CATEGORY_ITEMS = CATEGORIES.filter((category) => category.value !== ALL);
 const MEMORIES_RESOURCE = getProjectResourceDefinition("memories");
 
 export default function MemoriesPage() {
@@ -460,6 +461,7 @@ function AddMemoryForm() {
 								Category
 							</Label>
 							<Select
+								items={ADD_CATEGORY_ITEMS}
 								value={addCategory}
 								onValueChange={(value) => {
 									if (value !== null) setAddCategory(value);
@@ -469,7 +471,7 @@ function AddMemoryForm() {
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent>
-									{CATEGORIES.filter((c) => c.value !== ALL).map((c) => (
+									{ADD_CATEGORY_ITEMS.map((c) => (
 										<SelectItem key={c.value} value={c.value}>
 											{c.label}
 										</SelectItem>

--- a/apps/web/src/pages/dashboard/projects/[id]/page.tsx
+++ b/apps/web/src/pages/dashboard/projects/[id]/page.tsx
@@ -861,6 +861,10 @@ function UseProjectWithAgentDialog({
 		() => [...environments].sort(compareEnvironmentsForUse),
 		[environments],
 	);
+	const agentItems = orderedEnvironments.map((env) => ({
+		value: env.id,
+		label: displayAgentName(env),
+	}));
 	const selectedEnv = orderedEnvironments.find((env) => env.id === selectedAgentId) ?? null;
 	const projectIsHome = selectedEnv?.default_project_id === project.id;
 	const selectedBindings = useQuery({
@@ -943,6 +947,7 @@ function UseProjectWithAgentDialog({
 						<div className="space-y-2">
 							<div className="text-sm font-medium">Agent</div>
 							<Select
+								items={agentItems}
 								value={selectedAgentId}
 								onValueChange={(value) => {
 									if (value !== null) setSelectedAgentId(value);

--- a/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
+++ b/apps/web/src/pages/dashboard/vault/[slug]/page.tsx
@@ -712,10 +712,15 @@ function AttachProjectPicker({
 	onAttach: (projectId: string) => void;
 }) {
 	const [value, setValue] = useState("");
+	const projectItems = projects.map((project) => ({
+		value: project.id,
+		label: displayProjectName(project),
+	}));
 	if (projects.length === 0) return null;
 	return (
 		<div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
 			<Select
+				items={projectItems}
 				value={value}
 				onValueChange={(nextValue) => {
 					if (nextValue !== null) setValue(nextValue);
@@ -778,6 +783,12 @@ function ShareKeysDialog({
 	const [isAttaching, setIsAttaching] = useState(false);
 
 	const candidates = shareable;
+	const candidateItems = candidates.map((project) => ({
+		value: project.id,
+		label: `${displayProjectName(project)}${
+			(vault.project_ids ?? []).includes(project.id) ? " (already added)" : ""
+		}`,
+	}));
 
 	const reset = () => {
 		setProjectId("");
@@ -828,6 +839,7 @@ function ShareKeysDialog({
 				<div className="space-y-1.5">
 					<Label htmlFor="share-keys-project">Project</Label>
 					<Select
+						items={candidateItems}
 						value={projectId}
 						onValueChange={(value) => {
 							if (value !== null) setProjectId(value);


### PR DESCRIPTION
Fixes the verified fast-follow findings from the v2 UI/UX final sweep (docs/v2-ui-ux-final-sweep-2026-07-07.md, #333):

- **F1** SelectValue raw-value flash: pass Base UI `Select.Root items` (value→label) at every call site where value ≠ label — deploy wizard primary provider (`__managed__`), agent AI provider, language selects, auth-kind, plus a full `<SelectValue>` sweep (vault/skills/projects/channels dialogs). No `components/ui/*` edits (verbatim-official preserved).
- **F2** managed-rebind stale BYOK display: **non-issue** — hosted `rebind_agent_ai_provider` clears the pool synchronously before responding (commit+refresh in-transaction; backend tests assert the cleared pool in both response and pushed runtime state). Documented, no code needed.
- **F3** usage copy/aria now states totals are the current reporting window (backend windowed since hosted #704); chart caption no longer asserts sum(by_day) == total.
- **F4** checkout cancel return: detects `checkout=cancel` (both hosted cancel URLs carry it — deploy `/onboarding?step=deploy&checkout=cancel`, subscription `/?settings=billing-plan&checkout=cancel`) and shows "Checkout canceled — you were not charged" on the wizard and settings billing plan.
- **F5** console "No Runtime UI URL" copy points to Overview/Terminal, not channels. **F6** Settings restart gets the same confirm dialog as Overview. **F7** managed AI card copy is provider-neutral ("Clawdi-managed models").

Tests: 18 web tests pass, biome check 592 files, web typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)