### PR TITLE
feat(v2): Hermes native channel parity (Telegram + Discord)

### DIFF
--- a/packages/cli/src/lib/hermes-config-merge.ts
+++ b/packages/cli/src/lib/hermes-config-merge.ts
@@ -57,6 +57,20 @@ export function mergeHermesMcpServer(
 	});
 }
 
+export function mergeHermesChannelConfig(
+	configPath: string,
+	platforms: Record<"telegram" | "discord", Record<string, unknown>>,
+): void {
+	const document = readHermesConfig(configPath);
+	for (const [platform, config] of Object.entries(platforms)) {
+		document.set(platform, document.createNode(config));
+	}
+	writePrivateFileAtomic(configPath, String(document), {
+		mode: PRIVATE_FILE_MODE,
+		dirMode: PRIVATE_DIR_MODE,
+	});
+}
+
 export function removeHermesMcpServer(configPath: string, name: string): void {
 	if (!existsSync(configPath)) return;
 	const document = readHermesConfig(configPath);

--- a/packages/cli/src/runtime/channels.ts
+++ b/packages/cli/src/runtime/channels.ts
@@ -10,6 +10,13 @@ import type { MitmProfileInputBundle } from "./mitm-profiles";
 type MitmProfile = MitmProfileInputBundle["profiles"][number];
 type ChannelProvider = RuntimeChannelAccount["provider"];
 
+const HERMES_MANAGED_CHANNEL_ENV = [
+	"TELEGRAM_ALLOW_ALL_USERS",
+	"DISCORD_ALLOW_ALL_USERS",
+	"HERMES_TELEGRAM_DISABLE_FALLBACK_IPS",
+] as const;
+const HERMES_MANAGED_CHANNEL_SECRET_ENV = ["TELEGRAM_BOT_TOKEN", "DISCORD_BOT_TOKEN"] as const;
+
 interface ManagedChannelLink {
 	account: RuntimeChannelAccount;
 	accountKey: string;
@@ -67,7 +74,7 @@ function applyRuntimeChannelProjection(
 	const managedProfiles = buildManagedChannelMitmProfiles(links, manifest.controlPlane.apiUrl);
 	const directProviderPassthrough =
 		managedProfiles.length > 0 ? directProviderPassthroughProfiles(manifest.projection ?? {}) : [];
-	return {
+	const projected: RuntimeManifest = {
 		...manifest,
 		projection: {
 			...(manifest.projection ?? {}),
@@ -78,6 +85,7 @@ function applyRuntimeChannelProjection(
 			...directProviderPassthrough,
 		]),
 	};
+	return applyHermesRuntimeChannelSettings(projected, links);
 }
 
 function buildOpenClawChannelsProjection(
@@ -130,6 +138,64 @@ function buildOpenClawChannelsProjection(
 		}
 	}
 	return channels;
+}
+
+function applyHermesRuntimeChannelSettings(
+	manifest: RuntimeManifest,
+	links: ManagedChannelLink[],
+): RuntimeManifest {
+	const hermes = manifest.runtimes.hermes;
+	if (!hermes?.enabled) return manifest;
+
+	const telegram = firstLinkForProvider(links, "telegram");
+	const discord = firstLinkForProvider(links, "discord");
+	const existingRun = hermes.run ?? { env: {}, prependPath: [] };
+	const env = omitKeys(existingRun.env ?? {}, HERMES_MANAGED_CHANNEL_ENV);
+	const secretEnv = omitKeys(existingRun.secretEnv ?? {}, HERMES_MANAGED_CHANNEL_SECRET_ENV);
+
+	if (telegram) {
+		env.TELEGRAM_ALLOW_ALL_USERS = "true";
+		env.HERMES_TELEGRAM_DISABLE_FALLBACK_IPS = "true";
+		secretEnv.TELEGRAM_BOT_TOKEN = telegram.secretRef;
+	}
+	if (discord) {
+		env.DISCORD_ALLOW_ALL_USERS = "true";
+		secretEnv.DISCORD_BOT_TOKEN = discord.secretRef;
+	}
+
+	return {
+		...manifest,
+		runtimes: {
+			...manifest.runtimes,
+			hermes: {
+				...hermes,
+				run: {
+					...existingRun,
+					env,
+					secretEnv,
+				},
+			},
+		},
+	};
+}
+
+function firstLinkForProvider(
+	links: ManagedChannelLink[],
+	provider: ChannelProvider,
+): ManagedChannelLink | null {
+	return links.find((link) => link.account.provider === provider) ?? null;
+}
+
+function omitKeys<T extends string>(
+	input: Record<string, string>,
+	keys: readonly T[],
+): Record<string, string> {
+	const omitted = new Set<string>(keys);
+	const output: Record<string, string> = {};
+	for (const [key, value] of Object.entries(input)) {
+		if (!omitted.has(key)) output[key] = value;
+	}
+	return output;
 }
 
 function ensureAccountChannel(

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -28,6 +28,7 @@ import { isAiProviderApiMode, isAiProviderType } from "@clawdi/shared";
 import { z } from "zod";
 import { type AgentPrimaryModel, buildAgentTargetProjection } from "../lib/ai-provider-projection";
 import {
+	mergeHermesChannelConfig,
 	mergeHermesConfig,
 	mergeHermesMcpServer,
 	removeHermesMcpServer,
@@ -1247,7 +1248,7 @@ function applyHostedChannelProjection(
 	manifest: RuntimeManifest,
 	workspaceRoot: string,
 ): string | null {
-	if (name !== "openclaw") return null;
+	if (name !== "openclaw" && name !== "hermes") return null;
 	if (!observation.enabled || observation.status === "install_failed" || !observation.commandPath) {
 		return null;
 	}
@@ -1255,6 +1256,15 @@ function applyHostedChannelProjection(
 	if (!channels) return null;
 
 	const home = projectionSystemHome(manifest) ?? process.env.HOME ?? "";
+	if (name === "hermes") {
+		const configPath = join(home, ".hermes", "config.yaml");
+		mergeHermesChannelConfig(
+			configPath,
+			hermesManagedChannelsPatch(channels, manifest.controlPlane.apiUrl),
+		);
+		makeRuntimeUserOwned(configPath);
+		return configPath;
+	}
 	installOpenClawChannelPlugins(observation.commandPath, channels, home, workspaceRoot);
 	runRuntimeUserCommand(
 		observation.commandPath,
@@ -1264,6 +1274,52 @@ function applyHostedChannelProjection(
 		workspaceRoot,
 	);
 	return observation.commandPath;
+}
+
+function hermesManagedChannelsPatch(
+	channels: Record<string, unknown>,
+	cloudApiUrl: string,
+): Record<"telegram" | "discord", Record<string, unknown>> {
+	const baseUrl = stripTrailingSlash(cloudApiUrl);
+	return {
+		telegram: channelHasAccounts(channels.telegram)
+			? {
+					enabled: true,
+					dm_policy: "open",
+					group_policy: "open",
+					allow_from: ["*"],
+					group_allow_from: ["*"],
+					group_allowed_chats: ["*"],
+					require_mention: false,
+					extra: {
+						base_url: `${baseUrl}/v1/channels/telegram/bot`,
+						base_file_url: `${baseUrl}/v1/channels/telegram/file/bot`,
+					},
+				}
+			: { enabled: false },
+		discord: channelHasAccounts(channels.discord)
+			? {
+					enabled: true,
+					dm_policy: "open",
+					group_policy: "open",
+					allow_from: ["*"],
+					group_allow_from: ["*"],
+					require_mention: false,
+					thread_require_mention: false,
+					bots_require_inline_mention: false,
+				}
+			: { enabled: false },
+	};
+}
+
+function channelHasAccounts(channel: unknown): boolean {
+	if (!isPlainRecord(channel)) return false;
+	const accounts = channel.accounts;
+	return isPlainRecord(accounts) && Object.keys(accounts).length > 0;
+}
+
+function stripTrailingSlash(value: string): string {
+	return value.replace(/\/+$/, "");
 }
 
 function openClawManagedChannelsPatch(channels: Record<string, unknown>): Record<string, unknown> {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -4349,6 +4349,242 @@ exit 64
 		}
 	});
 
+	it("converges Hermes native Telegram and Discord channel projection", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const workspace = join(home, "clawdi");
+		const hermesBin = join(home, ".local", "bin", "hermes");
+		mkdirSync(dirname(hermesBin), { recursive: true });
+		mkdirSync(workspace, { recursive: true });
+		writeFileSync(hermesBin, "#!/usr/bin/env bash\nexit 0\n");
+		chmodSync(hermesBin, 0o700);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_SYSTEMD_APPLY = "0";
+
+		const load: RuntimeManifestLoad = {
+			manifest: {
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				runtime: "hermes",
+				deploymentId: "dep_hermes_channels",
+				environmentId: "env_hermes_channels",
+				instanceId: "iid_hermes_channels",
+				generation: 12,
+				issuedAt: "2026-07-07T00:00:00Z",
+				controlPlane: { apiUrl: "https://cloud-api.test/" },
+				runtimes: {
+					hermes: {
+						enabled: true,
+						install: {
+							authority: "official",
+							method: "official-installer",
+							url: "https://hermes-agent.nousresearch.com/install.sh",
+							home,
+							args: [],
+						},
+						run: {
+							args: ["gateway", "run", "--replace"],
+							env: { HERMES_EXISTING_ENV: "kept" },
+							prependPath: [],
+						},
+						services: {},
+					},
+				},
+				projection: {
+					system: { home, workspace },
+				},
+				recovery: {},
+			},
+			source: "fixture-file",
+			sourcePath: "test://hermes-channels",
+			offline: false,
+			secretValues: {},
+		};
+		const channels: RuntimeChannelsLoad = {
+			channels: [
+				{
+					id: "acct-telegram-hermes",
+					provider: "telegram",
+					name: "Hermes Telegram",
+					status: "active",
+					visibility: "private",
+					runtime_links: [
+						{
+							id: "link-telegram-hermes",
+							account_id: "acct-telegram-hermes",
+							agent_id: "env_hermes_channels",
+							status: "active",
+							agent_token: "123456789:telegram-agent-token",
+						},
+					],
+				},
+				{
+					id: "acct-discord-hermes",
+					provider: "discord",
+					name: "Hermes Discord",
+					status: "active",
+					visibility: "private",
+					runtime_links: [
+						{
+							id: "link-discord-hermes",
+							account_id: "acct-discord-hermes",
+							agent_id: "env_hermes_channels",
+							status: "active",
+							agent_token: "discord-agent-token",
+						},
+					],
+				},
+			],
+			source: "remote-datasource",
+			sourcePath: "https://runtime.test/v1/channels",
+			etag: '"hermes-channels"',
+		};
+
+		const projected = applyRuntimeChannelsToManifestLoad(load, channels);
+		const convergence = convergeRuntimeManifest(projected, getRuntimePaths());
+
+		expect(convergence.installErrors).toEqual([]);
+		const hermesConfig = readFileSync(join(home, ".hermes", "config.yaml"), "utf-8");
+		expect(hermesConfig).toContain("telegram:");
+		expect(hermesConfig).toContain("enabled: true");
+		expect(hermesConfig).toContain("base_url: https://cloud-api.test/v1/channels/telegram/bot");
+		expect(hermesConfig).toContain(
+			"base_file_url: https://cloud-api.test/v1/channels/telegram/file/bot",
+		);
+		expect(hermesConfig).toContain("discord:");
+		expect(hermesConfig).toContain("thread_require_mention: false");
+		expect(hermesConfig).not.toContain("telegram-agent-token");
+		expect(hermesConfig).not.toContain("discord-agent-token");
+
+		const runConfig = JSON.parse(
+			readFileSync(join(state, "config", "run", "hermes.json"), "utf-8"),
+		);
+		expect(runConfig.env.HERMES_EXISTING_ENV).toBe("kept");
+		expect(runConfig.env.TELEGRAM_ALLOW_ALL_USERS).toBe("true");
+		expect(runConfig.env.DISCORD_ALLOW_ALL_USERS).toBe("true");
+		expect(runConfig.env.HERMES_TELEGRAM_DISABLE_FALLBACK_IPS).toBe("true");
+		expect(runConfig.secretEnv.TELEGRAM_BOT_TOKEN).toMatch(
+			/^secret:\/\/channels\/telegram\/clawdi_accttelegram\/agent-token$/,
+		);
+		expect(runConfig.secretEnv.DISCORD_BOT_TOKEN).toMatch(
+			/^secret:\/\/channels\/discord\/clawdi_acctdiscordh\/agent-token$/,
+		);
+		const hermesEnv = readSystemdEnvFile(getRuntimePaths(), "hermes-gateway");
+		expect(hermesEnv).toContain('TELEGRAM_BOT_TOKEN="123456789:telegram-agent-token"');
+		expect(hermesEnv).toContain('DISCORD_BOT_TOKEN="discord-agent-token"');
+		expect(hermesEnv).toContain('TELEGRAM_ALLOW_ALL_USERS="true"');
+		expect(hermesEnv).toContain('DISCORD_ALLOW_ALL_USERS="true"');
+		expect(hermesEnv).toContain('HERMES_TELEGRAM_DISABLE_FALLBACK_IPS="true"');
+		const profileBundle = readFileSync(join(state, "config", "mitm", "profiles.json"), "utf-8");
+		expect(profileBundle).toContain("/v1/channels/telegram");
+		expect(profileBundle).toContain("/v1/channels/discord");
+	});
+
+	it("clears Hermes native channel settings when no channel links are active", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const workspace = join(home, "clawdi");
+		const hermesBin = join(home, ".local", "bin", "hermes");
+		mkdirSync(dirname(hermesBin), { recursive: true });
+		mkdirSync(join(home, ".hermes"), { recursive: true });
+		mkdirSync(workspace, { recursive: true });
+		writeFileSync(hermesBin, "#!/usr/bin/env bash\nexit 0\n");
+		writeFileSync(
+			join(home, ".hermes", "config.yaml"),
+			[
+				"telegram:",
+				"  enabled: true",
+				"discord:",
+				"  enabled: true",
+				"  stale: should-be-removed",
+				"",
+			].join("\n"),
+		);
+		chmodSync(hermesBin, 0o700);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_SYSTEMD_APPLY = "0";
+
+		const load: RuntimeManifestLoad = {
+			manifest: {
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				runtime: "hermes",
+				deploymentId: "dep_hermes_channel_clear",
+				environmentId: "env_hermes_channel_clear",
+				instanceId: "iid_hermes_channel_clear",
+				generation: 13,
+				issuedAt: "2026-07-07T00:00:00Z",
+				controlPlane: { apiUrl: "https://cloud-api.test" },
+				runtimes: {
+					hermes: {
+						enabled: true,
+						install: {
+							authority: "official",
+							method: "official-installer",
+							url: "https://hermes-agent.nousresearch.com/install.sh",
+							home,
+							args: [],
+						},
+						run: {
+							args: ["gateway", "run", "--replace"],
+							env: {
+								HERMES_EXISTING_ENV: "kept",
+								TELEGRAM_ALLOW_ALL_USERS: "true",
+								DISCORD_ALLOW_ALL_USERS: "true",
+							},
+							secretEnv: {
+								TELEGRAM_BOT_TOKEN: "secret://channels/telegram/clawdi_stale/agent-token",
+								DISCORD_BOT_TOKEN: "secret://channels/discord/clawdi_stale/agent-token",
+							},
+							prependPath: [],
+						},
+						services: {},
+					},
+				},
+				projection: {
+					system: { home, workspace },
+				},
+				recovery: {},
+			},
+			source: "fixture-file",
+			sourcePath: "test://hermes-channel-clear",
+			offline: false,
+			secretValues: {},
+		};
+		const projected = applyRuntimeChannelsToManifestLoad(load, {
+			channels: [],
+			source: "remote-datasource",
+			sourcePath: "https://runtime.test/v1/channels",
+			etag: '"empty-hermes-channels"',
+		});
+
+		const convergence = convergeRuntimeManifest(projected, getRuntimePaths());
+
+		expect(convergence.installErrors).toEqual([]);
+		const hermesConfig = readFileSync(join(home, ".hermes", "config.yaml"), "utf-8");
+		expect(hermesConfig).toContain("telegram:");
+		expect(hermesConfig).toContain("discord:");
+		expect(hermesConfig).toContain("enabled: false");
+		expect(hermesConfig).not.toContain("stale: should-be-removed");
+		const runConfig = JSON.parse(
+			readFileSync(join(state, "config", "run", "hermes.json"), "utf-8"),
+		);
+		expect(runConfig.env.HERMES_EXISTING_ENV).toBe("kept");
+		expect(runConfig.env.TELEGRAM_ALLOW_ALL_USERS).toBeUndefined();
+		expect(runConfig.env.DISCORD_ALLOW_ALL_USERS).toBeUndefined();
+		expect(runConfig.secretEnv.TELEGRAM_BOT_TOKEN).toBeUndefined();
+		expect(runConfig.secretEnv.DISCORD_BOT_TOKEN).toBeUndefined();
+		const hermesEnv = readSystemdEnvFile(getRuntimePaths(), "hermes-gateway");
+		expect(hermesEnv).not.toContain("TELEGRAM_BOT_TOKEN");
+		expect(hermesEnv).not.toContain("DISCORD_BOT_TOKEN");
+	});
+
 	it("converges empty native channel projection with merge-patch deletes", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");


### PR DESCRIPTION
Closes the Hermes half of the channel completeness audit (hosted #706): a Hermes v2 agent now materializes Telegram + Discord from `/v1/channels` exactly like OpenClaw — owner decision: Hermes and OpenClaw are equally important at launch; Slack is cut.

**Ground truth (cited in the audit + verified against hermes-agent upstream 736fc4d):** Hermes natively supports Telegram/Discord platforms via `TELEGRAM_BOT_TOKEN`/`DISCORD_BOT_TOKEN` + `~/.hermes/config.yaml`; the Telegram adapter honors `extra.base_url`/`base_file_url`. So no relay needed — native connectors through the SAME cloud-api shim/MITM path OpenClaw uses.

**Implementation (OSS runtime only, additive):**
- `channels.ts`: inject scoped `agent_token` secret refs as `TELEGRAM_BOT_TOKEN`/`DISCORD_BOT_TOKEN` into the Hermes systemd run config (secretEnv — tokens never written to config files).
- `manifest.ts`: merge `telegram:`/`discord:` blocks into `~/.hermes/config.yaml` (runtime-user-owned); Telegram points at the cloud-api Bot API shim, Discord uses the existing REST/gateway MITM. Empty links write `enabled: false` and clear stale managed env/secretEnv.
- Open dm/group policy mirrors the EXISTING OpenClaw v2 materialization (`allowFrom: ["*"]`) — parity, not a new surface; adding allowlists to the link model for BOTH frameworks is a shared fast-follow (Hermes upstream supports `TELEGRAM_ALLOWED_USERS`).

**Known limit:** Hermes upstream is one token per platform (no multi-account map) → the FIRST active Telegram link and FIRST active Discord link are wired. Hosted follow-up: enforce/communicate one active link per provider for Hermes agents.

**Hosted follow-ups (no hosted changes here):** consume this CLI in the runtime image + Hermes TG/Discord systemd smoke.

Tests: focused runtime tests + full CLI suite 749 pass; typecheck + biome clean; re-verified after rebase (83 runtime tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)