### PR TITLE
feat(v2): WhatsApp channel creds provisioning for OpenClaw AND Hermes

### DIFF
--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -34,11 +34,13 @@ from app.models.channel import (
     DELIVERY_STATUS_IN_PROGRESS,
     DELIVERY_STATUS_PENDING,
     ChannelAccount,
+    ChannelAgentCredential,
     ChannelBinding,
     ChannelBotAgentLink,
     ChannelDebugEvent,
     ChannelDelivery,
     ChannelMessage,
+    ChannelWhatsAppAuthCert,
 )
 from app.models.session import AgentEnvironment
 from app.routes.channel_routers.shared import (
@@ -69,6 +71,7 @@ from app.schemas.channel import (
     ChannelPairCodeResponse,
     ChannelRuntimeAccountResponse,
     ChannelRuntimeAgentLinkResponse,
+    ChannelRuntimeCredentialResponse,
     ChannelSendMessageRequest,
 )
 from app.services.agent_bindings import get_owned_agent_or_404
@@ -97,6 +100,14 @@ from app.services.channels import (
     sync_channel_commands,
 )
 from app.services.http_cache import if_none_match_contains, strong_json_etag
+from app.services.vault_crypto import decrypt
+from app.services.whatsapp_baileys import (
+    buffer_json,
+    deserialize_creds,
+    encode_buffer_json,
+    whatsapp_agent_websocket_url,
+    whatsapp_media_proxy_base_url,
+)
 
 router = APIRouter(prefix="/channels", tags=["channels"])
 
@@ -144,7 +155,8 @@ def _runtime_agent_link_response(
     )
 
 
-def _runtime_account_response(
+async def _runtime_account_response(
+    db: AsyncSession,
     account: ChannelAccount,
     link: ChannelBotAgentLink,
 ) -> ChannelRuntimeAccountResponse:
@@ -155,7 +167,66 @@ def _runtime_account_response(
     return ChannelRuntimeAccountResponse(
         **_account_response(account).model_dump(),
         runtime_links=[runtime_link],
+        runtime_credentials=await _runtime_credentials_response(db, account=account, link=link),
     )
+
+
+async def _runtime_credentials_response(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    link: ChannelBotAgentLink,
+) -> list[ChannelRuntimeCredentialResponse]:
+    if account.provider != CHANNEL_PROVIDER_WHATSAPP:
+        return []
+    result = await db.execute(
+        select(ChannelAgentCredential, ChannelWhatsAppAuthCert)
+        .outerjoin(
+            ChannelWhatsAppAuthCert,
+            ChannelWhatsAppAuthCert.account_id == ChannelAgentCredential.account_id,
+        )
+        .where(
+            ChannelAgentCredential.account_id == account.id,
+            ChannelAgentCredential.bot_agent_link_id == link.id,
+            ChannelAgentCredential.provider == CHANNEL_PROVIDER_WHATSAPP,
+            ChannelAgentCredential.revoked_at.is_(None),
+        )
+        .order_by(ChannelAgentCredential.created_at.desc(), ChannelAgentCredential.id.desc())
+        .limit(1)
+    )
+    row = result.first()
+    if row is None:
+        return []
+    credential, auth_cert = row
+    creds = deserialize_creds(
+        decrypt(credential.encrypted_credentials, credential.credential_nonce)
+    )
+    material: dict[str, Any] = {
+        "schemaVersion": "clawdi.whatsappBaileysAuthState.v1",
+        "creds": encode_buffer_json(creds),
+        "websocketUrl": whatsapp_agent_websocket_url(account.id),
+        "mediaProxyBaseUrl": whatsapp_media_proxy_base_url(),
+    }
+    if auth_cert is not None:
+        material["authCert"] = {
+            "SERIAL": auth_cert.serial,
+            "ISSUER": "clawdi",
+            "PUBLIC_KEY": buffer_json(auth_cert.root_public_key),
+        }
+    return [
+        ChannelRuntimeCredentialResponse(
+            id=credential.id,
+            account_id=credential.account_id,
+            agent_link_id=credential.bot_agent_link_id,
+            agent_id=link.agent_id,
+            provider=CHANNEL_PROVIDER_WHATSAPP,
+            kind="whatsapp_baileys_auth_state",
+            created_at=credential.created_at,
+            jid=credential.synthetic_jid,
+            identity_pub_key_hex=credential.identity_public_key.hex(),
+            material=material,
+        )
+    ]
 
 
 def _agent_link_with_account_response(
@@ -300,7 +371,7 @@ async def list_channels(
             )
         )
         payload = [
-            _runtime_account_response(account, link).model_dump(mode="json")
+            (await _runtime_account_response(db, account, link)).model_dump(mode="json")
             for account, link in result.all()
         ]
         etag = strong_json_etag(payload)

--- a/backend/app/schemas/channel.py
+++ b/backend/app/schemas/channel.py
@@ -64,8 +64,22 @@ class ChannelRuntimeAgentLinkResponse(BaseModel):
     agent_token: str | None = None
 
 
+class ChannelRuntimeCredentialResponse(BaseModel):
+    id: UUID
+    account_id: UUID
+    agent_link_id: UUID
+    agent_id: UUID
+    provider: str
+    kind: str
+    created_at: datetime
+    jid: str | None = None
+    identity_pub_key_hex: str | None = None
+    material: dict[str, Any] | None = None
+
+
 class ChannelRuntimeAccountResponse(ChannelAccountResponse):
     runtime_links: list[ChannelRuntimeAgentLinkResponse] = Field(default_factory=list)
+    runtime_credentials: list[ChannelRuntimeCredentialResponse] = Field(default_factory=list)
 
 
 class ChannelBotPoolCapabilities(BaseModel):

--- a/backend/app/services/whatsapp_baileys.py
+++ b/backend/app/services/whatsapp_baileys.py
@@ -18,7 +18,7 @@ from cryptography.hazmat.primitives import padding, serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519, x25519
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -2182,6 +2182,17 @@ async def mint_whatsapp_agent_credential(
     name: str | None = None,
     self_identity: dict[str, str | None] | None = None,
 ) -> StoredWhatsAppCredential:
+    now = datetime.now(UTC)
+    await db.execute(
+        update(ChannelAgentCredential)
+        .where(
+            ChannelAgentCredential.account_id == account.id,
+            ChannelAgentCredential.bot_agent_link_id == bot_agent_link_id,
+            ChannelAgentCredential.provider == CHANNEL_PROVIDER_WHATSAPP,
+            ChannelAgentCredential.revoked_at.is_(None),
+        )
+        .values(revoked_at=now)
+    )
     minted = mint_tenant_creds(
         tenant_id=str(bot_agent_link_id),
         phone_user=phone_user,

--- a/backend/app/services/whatsapp_baileys.py
+++ b/backend/app/services/whatsapp_baileys.py
@@ -18,7 +18,7 @@ from cryptography.hazmat.primitives import padding, serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519, x25519
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from sqlalchemy import select, update
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -141,6 +141,13 @@ class WhatsAppAuthCert:
 class StoredWhatsAppCredential:
     credential: ChannelAgentCredential
     minted: MintedWhatsAppCreds
+
+
+@dataclass(frozen=True)
+class WhatsAppCredentialReplacementKey:
+    name: str | None
+    jid: str
+    lid: str | None
 
 
 @dataclass(frozen=True)
@@ -2183,22 +2190,24 @@ async def mint_whatsapp_agent_credential(
     self_identity: dict[str, str | None] | None = None,
 ) -> StoredWhatsAppCredential:
     now = datetime.now(UTC)
-    await db.execute(
-        update(ChannelAgentCredential)
-        .where(
-            ChannelAgentCredential.account_id == account.id,
-            ChannelAgentCredential.bot_agent_link_id == bot_agent_link_id,
-            ChannelAgentCredential.provider == CHANNEL_PROVIDER_WHATSAPP,
-            ChannelAgentCredential.revoked_at.is_(None),
-        )
-        .values(revoked_at=now)
-    )
     minted = mint_tenant_creds(
         tenant_id=str(bot_agent_link_id),
         phone_user=phone_user,
         device=device,
         name=name,
         self_identity=self_identity,
+    )
+    replacement_key = whatsapp_credential_replacement_key(
+        name=name,
+        jid=minted.jid,
+        self_identity=self_identity,
+    )
+    await revoke_replaced_whatsapp_agent_credentials(
+        db,
+        account=account,
+        bot_agent_link_id=bot_agent_link_id,
+        replacement_key=replacement_key,
+        revoked_at=now,
     )
     serialized = serialize_creds(minted.creds)
     ciphertext, nonce = encrypt(serialized)
@@ -2212,11 +2221,124 @@ async def mint_whatsapp_agent_credential(
         synthetic_jid=minted.jid,
         encrypted_credentials=ciphertext,
         credential_nonce=nonce,
-        config={"device": device, "name": name},
+        config=whatsapp_agent_credential_config(
+            device=device,
+            name=name,
+            phone_user=phone_user,
+            self_identity=self_identity,
+            replacement_key=replacement_key,
+        ),
     )
     db.add(credential)
     await db.flush()
     return StoredWhatsAppCredential(credential=credential, minted=minted)
+
+
+def whatsapp_credential_replacement_key(
+    *,
+    name: str | None,
+    jid: str,
+    self_identity: dict[str, str | None] | None,
+) -> WhatsAppCredentialReplacementKey:
+    return WhatsAppCredentialReplacementKey(
+        name=_clean_optional_whatsapp_text(name),
+        jid=jid,
+        lid=_clean_optional_whatsapp_text((self_identity or {}).get("lid")),
+    )
+
+
+async def revoke_replaced_whatsapp_agent_credentials(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    bot_agent_link_id: UUID,
+    replacement_key: WhatsAppCredentialReplacementKey,
+    revoked_at: datetime,
+) -> None:
+    result = await db.execute(
+        select(ChannelAgentCredential).where(
+            ChannelAgentCredential.account_id == account.id,
+            ChannelAgentCredential.bot_agent_link_id == bot_agent_link_id,
+            ChannelAgentCredential.provider == CHANNEL_PROVIDER_WHATSAPP,
+            ChannelAgentCredential.revoked_at.is_(None),
+        )
+    )
+    for credential in result.scalars():
+        if whatsapp_credential_replacement_keys_match(credential, replacement_key):
+            credential.revoked_at = revoked_at
+
+
+def whatsapp_credential_replacement_keys_match(
+    credential: ChannelAgentCredential,
+    replacement_key: WhatsAppCredentialReplacementKey,
+) -> bool:
+    existing_key = whatsapp_credential_replacement_key_for_existing_credential(credential)
+    if existing_key.name != replacement_key.name or existing_key.jid != replacement_key.jid:
+        return False
+    config = credential.config if isinstance(credential.config, dict) else {}
+    if not isinstance(config.get("replacement_key"), dict):
+        return True
+    return existing_key.lid == replacement_key.lid
+
+
+def whatsapp_credential_replacement_key_for_existing_credential(
+    credential: ChannelAgentCredential,
+) -> WhatsAppCredentialReplacementKey:
+    config = credential.config if isinstance(credential.config, dict) else {}
+    stored_key = config.get("replacement_key")
+    if isinstance(stored_key, dict):
+        jid = _clean_optional_whatsapp_text(stored_key.get("jid")) or credential.synthetic_jid
+        return WhatsAppCredentialReplacementKey(
+            name=_clean_optional_whatsapp_text(stored_key.get("name")),
+            jid=jid,
+            lid=_clean_optional_whatsapp_text(stored_key.get("lid")),
+        )
+    return WhatsAppCredentialReplacementKey(
+        name=_clean_optional_whatsapp_text(config.get("name")),
+        jid=credential.synthetic_jid,
+        lid=None,
+    )
+
+
+def whatsapp_agent_credential_config(
+    *,
+    device: int,
+    name: str | None,
+    phone_user: str | None,
+    self_identity: dict[str, str | None] | None,
+    replacement_key: WhatsAppCredentialReplacementKey,
+) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "device": device,
+        "name": _clean_optional_whatsapp_text(name),
+        "replacement_key": {
+            "name": replacement_key.name,
+            "jid": replacement_key.jid,
+            "lid": replacement_key.lid,
+        },
+    }
+    clean_phone_user = _clean_optional_whatsapp_text(phone_user)
+    if clean_phone_user is not None:
+        config["phone_user"] = clean_phone_user
+    clean_self_identity = {
+        key: value
+        for key, value in {
+            "id": _clean_optional_whatsapp_text((self_identity or {}).get("id")),
+            "lid": _clean_optional_whatsapp_text((self_identity or {}).get("lid")),
+            "name": _clean_optional_whatsapp_text((self_identity or {}).get("name")),
+        }.items()
+        if value is not None
+    }
+    if clean_self_identity:
+        config["self_identity"] = clean_self_identity
+    return config
+
+
+def _clean_optional_whatsapp_text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
 
 
 async def resolve_whatsapp_credential_by_identity(

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -43,6 +43,7 @@ from app.models.channel import (
     PAIR_CODE_STATUS_PENDING,
     PAIR_CODE_STATUS_REVOKED,
     ChannelAccount,
+    ChannelAgentCredential,
     ChannelBinding,
     ChannelBindingAlias,
     ChannelBotAgentLink,
@@ -1974,6 +1975,110 @@ async def test_public_whatsapp_bot_runtime_credentials_are_user_scoped(
     assert listed_b.json() == []
     assert auth_cert_b.status_code == 200
     assert auth_cert_b.json()["PUBLIC_KEY"] == auth_cert.json()["PUBLIC_KEY"]
+
+
+@pytest.mark.asyncio
+async def test_env_bound_list_channels_returns_latest_whatsapp_runtime_credential(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+):
+    created = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider="whatsapp",
+        name=f"runtime-whatsapp-{uuid4().hex}",
+        provider_token="wa-provider-token",
+        config={"phone_number_id": "phone-runtime"},
+    )
+    assert created.status_code == 201, created.text
+    account_id = created.json()["id"]
+    user, agent = await _create_user_with_channel_agent(db_session, label="runtime-wa-creds")
+
+    async with _client_for_user(db_session, user) as user_client:
+        first = await user_client.post(
+            f"/v1/channels/whatsapp/{account_id}/tenant-creds",
+            json={"agent_id": str(agent.id), "phone_user": "15551234567"},
+        )
+        second = await user_client.post(
+            f"/v1/channels/whatsapp/{account_id}/tenant-creds",
+            json={"agent_id": str(agent.id), "phone_user": "15557654321"},
+        )
+        browser_list = await user_client.get("/v1/channels")
+
+    assert first.status_code == 201, first.text
+    assert second.status_code == 201, second.text
+    assert browser_list.status_code == 200, browser_list.text
+    assert "runtime_credentials" not in browser_list.text
+    assert "advSecretKey" not in browser_list.text
+
+    active_credentials = (
+        (
+            await db_session.execute(
+                select(ChannelAgentCredential).where(
+                    ChannelAgentCredential.account_id == UUID(account_id),
+                    ChannelAgentCredential.revoked_at.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [str(credential.id) for credential in active_credentials] == [
+        second.json()["credential_id"]
+    ]
+
+    api_key = ApiKey(user_id=user.id, environment_id=agent.id, label="hosted-wa-runtime")
+    async with _client_for_api_key(db_session, user, api_key) as runtime_client:
+        listed = await runtime_client.get("/v1/channels")
+
+    assert listed.status_code == 200, listed.text
+    assert "wa-provider-token" not in listed.text
+    assert first.json()["credential_id"] not in listed.text
+    payload = listed.json()
+    assert len(payload) == 1
+    runtime_credentials = payload[0]["runtime_credentials"]
+    assert len(runtime_credentials) == 1
+    runtime_credential = runtime_credentials[0]
+    assert runtime_credential["id"] == second.json()["credential_id"]
+    assert runtime_credential["agent_id"] == str(agent.id)
+    assert runtime_credential["agent_link_id"] == second.json()["agent_link_id"]
+    assert runtime_credential["kind"] == "whatsapp_baileys_auth_state"
+    assert runtime_credential["jid"] == second.json()["jid"]
+    assert runtime_credential["identity_pub_key_hex"] == second.json()["identity_pub_key_hex"]
+    material = runtime_credential["material"]
+    assert material["schemaVersion"] == "clawdi.whatsappBaileysAuthState.v1"
+    assert material["creds"]["advSecretKey"]
+    assert material["creds"]["me"]["id"] == second.json()["jid"]
+    assert material["authCert"]["ISSUER"] == "clawdi"
+    assert material["websocketUrl"].endswith(f"/v1/channels/whatsapp/{account_id}/baileys")
+    assert material["mediaProxyBaseUrl"].endswith("/v1/channels/whatsapp/media")
+
+    async with _client_for_user(db_session, user) as user_client:
+        deleted = await user_client.delete(
+            f"/v1/channels/{account_id}/agent-links/{second.json()['agent_link_id']}"
+        )
+    assert deleted.status_code == 204, deleted.text
+
+    active_credentials_after_unlink = (
+        (
+            await db_session.execute(
+                select(ChannelAgentCredential).where(
+                    ChannelAgentCredential.account_id == UUID(account_id),
+                    ChannelAgentCredential.revoked_at.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert active_credentials_after_unlink == []
+
+    async with _client_for_api_key(db_session, user, api_key) as runtime_client:
+        listed_after_unlink = await runtime_client.get("/v1/channels")
+
+    assert listed_after_unlink.status_code == 200, listed_after_unlink.text
+    assert listed_after_unlink.json() == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -2024,9 +2024,10 @@ async def test_env_bound_list_channels_returns_latest_whatsapp_runtime_credentia
         .scalars()
         .all()
     )
-    assert [str(credential.id) for credential in active_credentials] == [
-        second.json()["credential_id"]
-    ]
+    assert {str(credential.id) for credential in active_credentials} == {
+        first.json()["credential_id"],
+        second.json()["credential_id"],
+    }
 
     api_key = ApiKey(user_id=user.id, environment_id=agent.id, label="hosted-wa-runtime")
     async with _client_for_api_key(db_session, user, api_key) as runtime_client:

--- a/backend/tests/test_whatsapp_baileys.py
+++ b/backend/tests/test_whatsapp_baileys.py
@@ -1555,6 +1555,83 @@ async def test_whatsapp_tenant_creds_route_resolves_same_self_jid_by_noise_ident
 
 
 @pytest.mark.asyncio
+async def test_whatsapp_tenant_creds_remint_replaces_same_link_name_and_target_only(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+):
+    created = (
+        await client.post(
+            "/v1/channels",
+            json={"provider": "whatsapp", "name": "wa-remint-replacement-key"},
+        )
+    ).json()
+    shared_self = {
+        "id": "16693773518:2@s.whatsapp.net",
+        "lid": "117901482786828:2@lid",
+    }
+
+    first_response = await client.post(
+        f"/v1/channels/whatsapp/{created['id']}/tenant-creds",
+        json={"name": "tenant-a", "self_identity": shared_self},
+    )
+    replacement_response = await client.post(
+        f"/v1/channels/whatsapp/{created['id']}/tenant-creds",
+        json={"name": "tenant-a", "self_identity": shared_self},
+    )
+    sibling_response = await client.post(
+        f"/v1/channels/whatsapp/{created['id']}/tenant-creds",
+        json={"name": "tenant-b", "self_identity": shared_self},
+    )
+
+    assert first_response.status_code == 201
+    assert replacement_response.status_code == 201
+    assert sibling_response.status_code == 201
+    first = first_response.json()
+    replacement = replacement_response.json()
+    sibling = sibling_response.json()
+
+    first_credential = await db_session.get(ChannelAgentCredential, UUID(first["credential_id"]))
+    replacement_credential = await db_session.get(
+        ChannelAgentCredential, UUID(replacement["credential_id"])
+    )
+    sibling_credential = await db_session.get(
+        ChannelAgentCredential, UUID(sibling["credential_id"])
+    )
+    assert first_credential is not None
+    assert replacement_credential is not None
+    assert sibling_credential is not None
+    assert first_credential.revoked_at is not None
+    assert replacement_credential.revoked_at is None
+    assert sibling_credential.revoked_at is None
+
+    assert (
+        await resolve_whatsapp_credential_by_identity(
+            db_session,
+            identity_public_key=bytes.fromhex(first["identity_pub_key_hex"]),
+        )
+        is None
+    )
+    replacement_found = await resolve_whatsapp_credential_by_identity(
+        db_session,
+        identity_public_key=bytes.fromhex(replacement["identity_pub_key_hex"]),
+    )
+    sibling_found = await resolve_whatsapp_credential_by_identity(
+        db_session,
+        identity_public_key=bytes.fromhex(sibling["identity_pub_key_hex"]),
+    )
+    assert replacement_found is not None
+    assert sibling_found is not None
+    assert replacement_found.id == UUID(replacement["credential_id"])
+    assert sibling_found.id == UUID(sibling["credential_id"])
+
+    listed = (await client.get(f"/v1/channels/whatsapp/{created['id']}/tenant-creds")).json()
+    assert {item["credential_id"] for item in listed} == {
+        replacement["credential_id"],
+        sibling["credential_id"],
+    }
+
+
+@pytest.mark.asyncio
 async def test_whatsapp_tenant_creds_revoke_removes_identity_lookup_and_allows_remint(
     client: httpx.AsyncClient,
     db_session: AsyncSession,

--- a/packages/cli/src/lib/hermes-config-merge.ts
+++ b/packages/cli/src/lib/hermes-config-merge.ts
@@ -59,10 +59,23 @@ export function mergeHermesMcpServer(
 
 export function mergeHermesChannelConfig(
 	configPath: string,
-	platforms: Record<"telegram" | "discord", Record<string, unknown>>,
+	platforms: Record<string, Record<string, unknown>>,
 ): void {
 	const document = readHermesConfig(configPath);
 	for (const [platform, config] of Object.entries(platforms)) {
+		if (platform === "platforms") {
+			const root = document.toJS();
+			if (isPlainRecord(root) && root.platforms !== undefined && !isPlainRecord(root.platforms)) {
+				throw new Error("Hermes config field platforms must be a YAML object.");
+			}
+			if (!isPlainRecord(root) || !isPlainRecord(root.platforms)) {
+				document.set("platforms", document.createNode({}));
+			}
+			for (const [nestedPlatform, nestedConfig] of Object.entries(config)) {
+				document.setIn(["platforms", nestedPlatform], document.createNode(nestedConfig));
+			}
+			continue;
+		}
 		document.set(platform, document.createNode(config));
 	}
 	writePrivateFileAtomic(configPath, String(document), {

--- a/packages/cli/src/runtime/channels.ts
+++ b/packages/cli/src/runtime/channels.ts
@@ -1,7 +1,9 @@
+import { join } from "node:path";
 import { directProviderPassthroughProfiles } from "./hosted-mitm-profiles";
 import type { RuntimeManifest } from "./manifest-contract";
 import type {
 	RuntimeChannelAccount,
+	RuntimeChannelCredential,
 	RuntimeChannelsLoad,
 	RuntimeManifestLoad,
 } from "./manifest-source";
@@ -24,6 +26,21 @@ interface ManagedChannelLink {
 	agentId: string;
 	agentToken: string;
 	secretRef: string;
+	credentials: RuntimeChannelCredential[];
+}
+
+interface RuntimeChannelCredentialProjection {
+	provider: "whatsapp";
+	kind: "whatsapp_baileys_auth_state";
+	accountId: string;
+	accountKey: string;
+	linkId: string;
+	credentialId: string;
+	authDir: string;
+	files: {
+		path: "creds.json";
+		secretRef: string;
+	}[];
 }
 
 export function applyRuntimeChannelsToManifestLoad(
@@ -57,6 +74,9 @@ function managedChannelLinks(channels: RuntimeChannelAccount[]): ManagedChannelL
 				agentId: link.agent_id,
 				agentToken: link.agent_token,
 				secretRef: channelSecretRef(account.provider, accountKey),
+				credentials: (account.runtime_credentials ?? []).filter(
+					(credential) => credential.agent_link_id === link.id,
+				),
 			});
 		}
 	}
@@ -74,11 +94,13 @@ function applyRuntimeChannelProjection(
 	const managedProfiles = buildManagedChannelMitmProfiles(links, manifest.controlPlane.apiUrl);
 	const directProviderPassthrough =
 		managedProfiles.length > 0 ? directProviderPassthroughProfiles(manifest.projection ?? {}) : [];
+	const runtimeHome = runtimeProjectionHome(manifest);
 	const projected: RuntimeManifest = {
 		...manifest,
 		projection: {
 			...(manifest.projection ?? {}),
-			channels: buildOpenClawChannelsProjection(links, manifest.controlPlane.apiUrl),
+			channels: buildOpenClawChannelsProjection(links, manifest.controlPlane.apiUrl, runtimeHome),
+			channelCredentials: buildRuntimeChannelCredentialsProjection(links, runtimeHome),
 		},
 		mitmProfiles: mergeMitmProfiles(manifest.mitmProfiles, [
 			...managedProfiles,
@@ -91,6 +113,7 @@ function applyRuntimeChannelProjection(
 function buildOpenClawChannelsProjection(
 	links: ManagedChannelLink[],
 	cloudApiUrl: string,
+	runtimeHome: string,
 ): Record<string, unknown> {
 	const channels: Record<string, unknown> = {};
 	for (const link of links) {
@@ -122,10 +145,12 @@ function buildOpenClawChannelsProjection(
 		}
 		if (provider === "whatsapp") {
 			const channel = ensureAccountChannel(channels, "whatsapp", link.accountKey);
+			const credential = whatsappBaileysCredentialProjection(link, runtimeHome);
 			channel.accounts[link.accountKey] = {
 				enabled: true,
 				wsUrl: `${toWebSocketUrl(stripTrailingSlash(cloudApiUrl))}/v1/channels/whatsapp/${link.account.id}/baileys`,
 				token: link.agentToken,
+				...(credential ? { authDir: credential.authDir } : {}),
 			};
 			continue;
 		}
@@ -138,6 +163,20 @@ function buildOpenClawChannelsProjection(
 		}
 	}
 	return channels;
+}
+
+function buildRuntimeChannelCredentialsProjection(
+	links: ManagedChannelLink[],
+	runtimeHome: string,
+): RuntimeChannelCredentialProjection[] {
+	return links
+		.map((link) => whatsappBaileysCredentialProjection(link, runtimeHome))
+		.filter((credential): credential is RuntimeChannelCredentialProjection => credential !== null)
+		.sort((left, right) =>
+			`${left.provider}:${left.accountKey}:${left.credentialId}`.localeCompare(
+				`${right.provider}:${right.accountKey}:${right.credentialId}`,
+			),
+		);
 }
 
 function applyHermesRuntimeChannelSettings(
@@ -364,14 +403,94 @@ function isChannelProjectionProfile(profile: MitmProfile): boolean {
 function channelSecretValues(links: ManagedChannelLink[]): Record<string, string> {
 	const values: Record<string, string> = {};
 	for (const link of links) {
-		values[link.secretRef] = link.agentToken;
-		values[link.secretRef.replace(/^secret:\/\//, "")] = link.agentToken;
+		addSecretValue(values, link.secretRef, link.agentToken);
+		for (const credential of whatsappBaileysCredentials(link)) {
+			const creds = whatsappCredentialCreds(credential);
+			if (creds === null) continue;
+			addSecretValue(
+				values,
+				whatsappBaileysCredsJsonSecretRef(link, credential),
+				JSON.stringify(creds),
+			);
+		}
 	}
 	return values;
 }
 
+function addSecretValue(values: Record<string, string>, ref: string, value: string): void {
+	values[ref] = value;
+	values[ref.replace(/^secret:\/\//, "")] = value;
+}
+
 function channelSecretRef(provider: ChannelProvider, accountKey: string): string {
 	return `secret://channels/${provider}/${accountKey}/agent-token`;
+}
+
+function whatsappBaileysCredentialProjection(
+	link: ManagedChannelLink,
+	runtimeHome: string,
+): RuntimeChannelCredentialProjection | null {
+	const credential = whatsappBaileysCredentials(link)[0];
+	if (!credential || whatsappCredentialCreds(credential) === null) return null;
+	return {
+		provider: "whatsapp",
+		kind: "whatsapp_baileys_auth_state",
+		accountId: link.account.id,
+		accountKey: link.accountKey,
+		linkId: link.linkId,
+		credentialId: credential.id,
+		authDir: openClawWhatsAppAuthDir(runtimeHome, link.accountKey),
+		files: [
+			{
+				path: "creds.json",
+				secretRef: whatsappBaileysCredsJsonSecretRef(link, credential),
+			},
+		],
+	};
+}
+
+function whatsappBaileysCredentials(link: ManagedChannelLink): RuntimeChannelCredential[] {
+	if (link.account.provider !== "whatsapp") return [];
+	return link.credentials.filter(
+		(credential) =>
+			credential.provider === "whatsapp" && credential.kind === "whatsapp_baileys_auth_state",
+	);
+}
+
+function whatsappCredentialCreds(credential: RuntimeChannelCredential): unknown | null {
+	const material = recordValue(credential.material);
+	if (material?.schemaVersion !== "clawdi.whatsappBaileysAuthState.v1") {
+		return null;
+	}
+	const creds = material.creds;
+	if (!creds || typeof creds !== "object" || Array.isArray(creds)) return null;
+	return creds;
+}
+
+function whatsappBaileysCredsJsonSecretRef(
+	link: ManagedChannelLink,
+	credential: RuntimeChannelCredential,
+): string {
+	return `secret://channels/whatsapp/${link.accountKey}/credentials/${credential.id}/creds-json`;
+}
+
+function openClawWhatsAppAuthDir(runtimeHome: string, accountKey: string): string {
+	return join(runtimeHome, ".openclaw", "credentials", "whatsapp", accountKey);
+}
+
+function runtimeProjectionHome(manifest: RuntimeManifest): string {
+	const system = recordValue(manifest.projection?.system);
+	const home = system ? stringValue(system.home) : null;
+	return home ?? process.env.HOME ?? "/home/clawdi";
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+	return value as Record<string, unknown>;
+}
+
+function stringValue(value: unknown): string | null {
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
 function channelAccountKey(account: RuntimeChannelAccount): string {

--- a/packages/cli/src/runtime/channels.ts
+++ b/packages/cli/src/runtime/channels.ts
@@ -16,8 +16,15 @@ const HERMES_MANAGED_CHANNEL_ENV = [
 	"TELEGRAM_ALLOW_ALL_USERS",
 	"DISCORD_ALLOW_ALL_USERS",
 	"HERMES_TELEGRAM_DISABLE_FALLBACK_IPS",
+	"WHATSAPP_ENABLED",
+	"WHATSAPP_MODE",
+	"WHATSAPP_ALLOWED_USERS",
 ] as const;
-const HERMES_MANAGED_CHANNEL_SECRET_ENV = ["TELEGRAM_BOT_TOKEN", "DISCORD_BOT_TOKEN"] as const;
+const HERMES_MANAGED_CHANNEL_SECRET_ENV = [
+	"TELEGRAM_BOT_TOKEN",
+	"DISCORD_BOT_TOKEN",
+	"HERMES_WA_CREDS_JSON",
+] as const;
 
 interface ManagedChannelLink {
 	account: RuntimeChannelAccount;
@@ -41,6 +48,15 @@ interface RuntimeChannelCredentialProjection {
 		path: "creds.json";
 		secretRef: string;
 	}[];
+	targets: {
+		openclaw?: {
+			authDir: string;
+		};
+		hermes?: {
+			sessionDir: string;
+			credsJsonEnv: "HERMES_WA_CREDS_JSON";
+		};
+	};
 }
 
 export function applyRuntimeChannelsToManifestLoad(
@@ -100,7 +116,11 @@ function applyRuntimeChannelProjection(
 		projection: {
 			...(manifest.projection ?? {}),
 			channels: buildOpenClawChannelsProjection(links, manifest.controlPlane.apiUrl, runtimeHome),
-			channelCredentials: buildRuntimeChannelCredentialsProjection(links, runtimeHome),
+			channelCredentials: buildRuntimeChannelCredentialsProjection(
+				links,
+				runtimeHome,
+				runtimeCredentialTargets(manifest),
+			),
 		},
 		mitmProfiles: mergeMitmProfiles(manifest.mitmProfiles, [
 			...managedProfiles,
@@ -145,7 +165,10 @@ function buildOpenClawChannelsProjection(
 		}
 		if (provider === "whatsapp") {
 			const channel = ensureAccountChannel(channels, "whatsapp", link.accountKey);
-			const credential = whatsappBaileysCredentialProjection(link, runtimeHome);
+			const credential = whatsappBaileysCredentialProjection(link, runtimeHome, {
+				openclaw: true,
+				hermes: false,
+			});
 			channel.accounts[link.accountKey] = {
 				enabled: true,
 				wsUrl: `${toWebSocketUrl(stripTrailingSlash(cloudApiUrl))}/v1/channels/whatsapp/${link.account.id}/baileys`,
@@ -168,9 +191,10 @@ function buildOpenClawChannelsProjection(
 function buildRuntimeChannelCredentialsProjection(
 	links: ManagedChannelLink[],
 	runtimeHome: string,
+	targets: RuntimeCredentialTargets,
 ): RuntimeChannelCredentialProjection[] {
 	return links
-		.map((link) => whatsappBaileysCredentialProjection(link, runtimeHome))
+		.map((link) => whatsappBaileysCredentialProjection(link, runtimeHome, targets))
 		.filter((credential): credential is RuntimeChannelCredentialProjection => credential !== null)
 		.sort((left, right) =>
 			`${left.provider}:${left.accountKey}:${left.credentialId}`.localeCompare(
@@ -188,6 +212,11 @@ function applyHermesRuntimeChannelSettings(
 
 	const telegram = firstLinkForProvider(links, "telegram");
 	const discord = firstLinkForProvider(links, "discord");
+	const whatsapp = firstLinkForProvider(links, "whatsapp");
+	const whatsappCredentials = whatsapp ? whatsappBaileysCredentials(whatsapp) : [];
+	const whatsappCredential = whatsappCredentials.find(
+		(credential) => whatsappCredentialCreds(credential) !== null,
+	);
 	const existingRun = hermes.run ?? { env: {}, prependPath: [] };
 	const env = omitKeys(existingRun.env ?? {}, HERMES_MANAGED_CHANNEL_ENV);
 	const secretEnv = omitKeys(existingRun.secretEnv ?? {}, HERMES_MANAGED_CHANNEL_SECRET_ENV);
@@ -200,6 +229,15 @@ function applyHermesRuntimeChannelSettings(
 	if (discord) {
 		env.DISCORD_ALLOW_ALL_USERS = "true";
 		secretEnv.DISCORD_BOT_TOKEN = discord.secretRef;
+	}
+	if (whatsapp && whatsappCredential) {
+		env.WHATSAPP_ENABLED = "true";
+		env.WHATSAPP_MODE = "bot";
+		env.WHATSAPP_ALLOWED_USERS = "*";
+		secretEnv.HERMES_WA_CREDS_JSON = whatsappBaileysCredsJsonSecretRef(
+			whatsapp,
+			whatsappCredential,
+		);
 	}
 
 	return {
@@ -429,9 +467,21 @@ function channelSecretRef(provider: ChannelProvider, accountKey: string): string
 function whatsappBaileysCredentialProjection(
 	link: ManagedChannelLink,
 	runtimeHome: string,
+	targets: RuntimeCredentialTargets,
 ): RuntimeChannelCredentialProjection | null {
 	const credential = whatsappBaileysCredentials(link)[0];
 	if (!credential || whatsappCredentialCreds(credential) === null) return null;
+	const openclawAuthDir = openClawWhatsAppAuthDir(runtimeHome, link.accountKey);
+	const targetProjection: RuntimeChannelCredentialProjection["targets"] = {};
+	if (targets.openclaw) {
+		targetProjection.openclaw = { authDir: openclawAuthDir };
+	}
+	if (targets.hermes) {
+		targetProjection.hermes = {
+			sessionDir: hermesWhatsAppSessionDir(runtimeHome),
+			credsJsonEnv: "HERMES_WA_CREDS_JSON",
+		};
+	}
 	return {
 		provider: "whatsapp",
 		kind: "whatsapp_baileys_auth_state",
@@ -439,13 +489,14 @@ function whatsappBaileysCredentialProjection(
 		accountKey: link.accountKey,
 		linkId: link.linkId,
 		credentialId: credential.id,
-		authDir: openClawWhatsAppAuthDir(runtimeHome, link.accountKey),
+		authDir: openclawAuthDir,
 		files: [
 			{
 				path: "creds.json",
 				secretRef: whatsappBaileysCredsJsonSecretRef(link, credential),
 			},
 		],
+		targets: targetProjection,
 	};
 }
 
@@ -476,6 +527,22 @@ function whatsappBaileysCredsJsonSecretRef(
 
 function openClawWhatsAppAuthDir(runtimeHome: string, accountKey: string): string {
 	return join(runtimeHome, ".openclaw", "credentials", "whatsapp", accountKey);
+}
+
+function hermesWhatsAppSessionDir(runtimeHome: string): string {
+	return join(runtimeHome, ".hermes", "platforms", "whatsapp", "session");
+}
+
+interface RuntimeCredentialTargets {
+	openclaw: boolean;
+	hermes: boolean;
+}
+
+function runtimeCredentialTargets(manifest: RuntimeManifest): RuntimeCredentialTargets {
+	return {
+		openclaw: manifest.runtimes.openclaw?.enabled === true,
+		hermes: manifest.runtimes.hermes?.enabled === true,
+	};
 }
 
 function runtimeProjectionHome(manifest: RuntimeManifest): string {

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -106,6 +106,7 @@ const runtimeProjectionSchema = z
 		system: z.unknown().nullable().optional(),
 		providers: z.record(z.string().min(1), z.unknown()).optional(),
 		channels: z.record(z.string().min(1), z.unknown()).optional(),
+		channelCredentials: z.array(z.unknown()).optional(),
 		aiProviders: z.record(z.string().min(1), z.unknown()).optional(),
 		mcp: z.unknown().optional(),
 		tools: z.unknown().optional(),

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -48,6 +48,19 @@ export interface RuntimeChannelAgentLink {
 	agent_token: string | null;
 }
 
+export interface RuntimeChannelCredential {
+	id: string;
+	account_id: string;
+	agent_link_id: string;
+	agent_id: string;
+	provider: string;
+	kind: string;
+	created_at?: string;
+	jid?: string | null;
+	identity_pub_key_hex?: string | null;
+	material?: unknown;
+}
+
 export interface RuntimeChannelAccount {
 	id: string;
 	provider: "telegram" | "discord" | "whatsapp" | "imessage";
@@ -55,6 +68,7 @@ export interface RuntimeChannelAccount {
 	status: string;
 	visibility: "private" | "public";
 	runtime_links: RuntimeChannelAgentLink[];
+	runtime_credentials: RuntimeChannelCredential[];
 }
 
 export interface RuntimeChannelsLoad {
@@ -129,6 +143,21 @@ const runtimeChannelAgentLinkSchema = z
 		agent_token: link.agent_token ?? null,
 	}));
 
+const runtimeChannelCredentialSchema = z
+	.object({
+		id: z.string().min(1),
+		account_id: z.string().min(1),
+		agent_link_id: z.string().min(1),
+		agent_id: z.string().min(1),
+		provider: z.string().min(1),
+		kind: z.string().min(1),
+		created_at: z.string().min(1).optional(),
+		jid: z.string().min(1).nullable().optional(),
+		identity_pub_key_hex: z.string().min(1).nullable().optional(),
+		material: z.unknown().optional(),
+	})
+	.passthrough();
+
 const runtimeChannelAccountSchema = z
 	.object({
 		id: z.string().min(1),
@@ -137,6 +166,7 @@ const runtimeChannelAccountSchema = z
 		status: z.string().min(1),
 		visibility: z.enum(["private", "public"]).default("private"),
 		runtime_links: z.array(runtimeChannelAgentLinkSchema).default([]),
+		runtime_credentials: z.array(runtimeChannelCredentialSchema).default([]),
 	})
 	.passthrough();
 

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -6,6 +6,7 @@ import {
 	chownSync,
 	constants,
 	existsSync,
+	lstatSync,
 	mkdirSync,
 	mkdtempSync,
 	readdirSync,
@@ -16,7 +17,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, isAbsolute, join } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type {
 	AiProviderApiMode,
@@ -206,6 +207,195 @@ function writeSecretValues(
 	makeManagedSecretRoot(dirname(path));
 	makeRootOwned(path);
 	return path;
+}
+
+interface ManagedWhatsAppAuthCredential {
+	accountKey: string;
+	credentialId: string;
+	authDir: string;
+	credsJsonSecretRef: string;
+}
+
+const MANAGED_WHATSAPP_AUTH_MARKER = ".clawdi-managed-whatsapp-auth.json";
+const MANAGED_WHATSAPP_AUTH_ROOT = [".openclaw", "credentials", "whatsapp"] as const;
+
+function materializeHostedChannelCredentials(
+	manifest: RuntimeManifest,
+	secretValues: Record<string, string> | undefined,
+): void {
+	if (!hostedChannelCredentialsDeclared(manifest)) return;
+	const credentials = hostedWhatsAppAuthCredentials(manifest);
+	const normalizedSecrets = normalizeSecretValues(secretValues);
+	const expectedAuthDirs = new Set<string>();
+	const errors: string[] = [];
+	for (const credential of credentials) {
+		const authDirError = managedWhatsAppAuthDirError(manifest, credential.authDir);
+		if (authDirError) {
+			errors.push(authDirError);
+			continue;
+		}
+		expectedAuthDirs.add(resolve(credential.authDir));
+		const credsJson = resolveRuntimeSecretValue(normalizedSecrets, credential.credsJsonSecretRef);
+		if (!credsJson) {
+			removeManagedWhatsAppAuthDir(credential.authDir);
+			errors.push(
+				`missing WhatsApp auth state secret for ${credential.accountKey}/${credential.credentialId}`,
+			);
+			continue;
+		}
+		try {
+			materializeManagedWhatsAppAuthDir(credential, credsJson);
+		} catch (error) {
+			errors.push(error instanceof Error ? error.message : String(error));
+		}
+	}
+	removeStaleManagedWhatsAppAuthDirs(manifest, expectedAuthDirs);
+	if (errors.length > 0) {
+		throw new Error(errors.join("; "));
+	}
+}
+
+function hostedChannelCredentialsDeclared(manifest: RuntimeManifest): boolean {
+	return Boolean(manifest.projection && Object.hasOwn(manifest.projection, "channelCredentials"));
+}
+
+function hostedWhatsAppAuthCredentials(manifest: RuntimeManifest): ManagedWhatsAppAuthCredential[] {
+	const raw = manifest.projection?.channelCredentials;
+	if (!Array.isArray(raw)) return [];
+	return raw
+		.map(parseManagedWhatsAppAuthCredential)
+		.filter((entry): entry is ManagedWhatsAppAuthCredential => entry !== null)
+		.sort((left, right) =>
+			`${left.accountKey}:${left.credentialId}`.localeCompare(
+				`${right.accountKey}:${right.credentialId}`,
+			),
+		);
+}
+
+function parseManagedWhatsAppAuthCredential(value: unknown): ManagedWhatsAppAuthCredential | null {
+	const record = recordValue(value);
+	if (!record) return null;
+	if (record.provider !== "whatsapp" || record.kind !== "whatsapp_baileys_auth_state") return null;
+	const accountKey = stringValue(record.accountKey);
+	const credentialId = stringValue(record.credentialId);
+	const authDir = stringValue(record.authDir);
+	const files = Array.isArray(record.files) ? record.files : [];
+	const credsFile = files
+		.map(recordValue)
+		.find((file) => file?.path === "creds.json" && typeof file.secretRef === "string");
+	const credsJsonSecretRef = credsFile ? stringValue(credsFile.secretRef) : null;
+	if (!accountKey || !credentialId || !authDir || !credsJsonSecretRef) {
+		throw new Error("WhatsApp auth credential projection is incomplete");
+	}
+	return { accountKey, credentialId, authDir, credsJsonSecretRef };
+}
+
+function materializeManagedWhatsAppAuthDir(
+	credential: ManagedWhatsAppAuthCredential,
+	credsJson: string,
+): void {
+	let parsedCreds: unknown;
+	try {
+		parsedCreds = JSON.parse(credsJson);
+		if (!recordValue(parsedCreds)) {
+			throw new Error("creds.json must be a JSON object");
+		}
+	} catch (error) {
+		removeManagedWhatsAppAuthDir(credential.authDir);
+		throw new Error(
+			`invalid WhatsApp auth state JSON for ${credential.accountKey}/${credential.credentialId}: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
+
+	if (existsSync(credential.authDir) && lstatSync(credential.authDir).isSymbolicLink()) {
+		throw new Error(
+			`refusing to overwrite symlinked WhatsApp auth directory ${credential.authDir}`,
+		);
+	}
+	const existingMarker = readManagedWhatsAppAuthMarker(credential.authDir);
+	if (existingMarker && existingMarker.credentialId !== credential.credentialId) {
+		rmSync(credential.authDir, { recursive: true, force: true });
+	} else if (existsSync(credential.authDir) && !existingMarker) {
+		const entries = readdirSync(credential.authDir);
+		if (entries.length > 0) {
+			throw new Error(
+				`refusing to overwrite unmanaged WhatsApp auth directory ${credential.authDir}`,
+			);
+		}
+	}
+
+	makeRuntimeUserPrivateDir(credential.authDir);
+	writePrivateFileAtomic(
+		join(credential.authDir, "creds.json"),
+		`${JSON.stringify(parsedCreds, null, 2)}\n`,
+		{
+			mode: 0o600,
+			dirMode: 0o700,
+		},
+	);
+	makeRuntimeUserOwned(join(credential.authDir, "creds.json"));
+	writeJsonFile(join(credential.authDir, MANAGED_WHATSAPP_AUTH_MARKER), {
+		schemaVersion: "clawdi.managedWhatsAppAuth.v1",
+		provider: "whatsapp",
+		accountKey: credential.accountKey,
+		credentialId: credential.credentialId,
+	});
+	makeRuntimeUserOwned(join(credential.authDir, MANAGED_WHATSAPP_AUTH_MARKER));
+}
+
+function managedWhatsAppAuthDirError(manifest: RuntimeManifest, authDir: string): string | null {
+	const root = managedWhatsAppAuthRoot(manifest);
+	if (!root) return "WhatsApp auth credential projection is missing runtime home";
+	const relativePath = relative(root, resolve(authDir));
+	if (!relativePath || relativePath.startsWith("..") || isAbsolute(relativePath)) {
+		return `WhatsApp auth directory must be under ${root}`;
+	}
+	return null;
+}
+
+function managedWhatsAppAuthRoot(manifest: RuntimeManifest): string | null {
+	const home = projectionSystemHome(manifest) ?? process.env.HOME ?? "";
+	return home ? resolve(home, ...MANAGED_WHATSAPP_AUTH_ROOT) : null;
+}
+
+function readManagedWhatsAppAuthMarker(authDir: string): { credentialId: string } | null {
+	const markerPath = join(authDir, MANAGED_WHATSAPP_AUTH_MARKER);
+	try {
+		if (!lstatSync(markerPath).isFile()) return null;
+		const parsed = JSON.parse(readFileSync(markerPath, "utf-8")) as unknown;
+		const record = recordValue(parsed);
+		const credentialId = record ? stringValue(record.credentialId) : null;
+		return credentialId ? { credentialId } : null;
+	} catch {
+		return null;
+	}
+}
+
+function removeManagedWhatsAppAuthDir(authDir: string): void {
+	if (!readManagedWhatsAppAuthMarker(authDir)) return;
+	rmSync(authDir, { recursive: true, force: true });
+}
+
+function removeStaleManagedWhatsAppAuthDirs(
+	manifest: RuntimeManifest,
+	expected: Set<string>,
+): void {
+	const root = managedWhatsAppAuthRoot(manifest);
+	if (!root) return;
+	if (!existsSync(root)) return;
+	for (const entry of readdirSync(root)) {
+		const authDir = join(root, entry);
+		try {
+			if (!lstatSync(authDir).isDirectory()) continue;
+		} catch {
+			continue;
+		}
+		if (!expected.has(authDir)) {
+			removeManagedWhatsAppAuthDir(authDir);
+		}
+	}
 }
 
 function writeScopedSecretValues(
@@ -2759,6 +2949,15 @@ export function convergeRuntimeManifest(
 		: clearMitmProfileBundle(paths);
 	const daemonAuthTokenFile = writeDaemonAuthToken(paths);
 	writeSecretValues(load.secretValues, paths);
+	try {
+		materializeHostedChannelCredentials(manifest, load.secretValues);
+	} catch (error) {
+		installErrors.push(
+			`runtime channel credential materialization failed: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
 	const mitmSecretFile = writeMitmSecretFile(manifest, load.secretValues, paths);
 	const mitmSystemdProgram = runtimeMitmSystemdProgram(
 		manifest,

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -214,10 +214,12 @@ interface ManagedWhatsAppAuthCredential {
 	credentialId: string;
 	authDir: string;
 	credsJsonSecretRef: string;
+	target: "openclaw" | "hermes" | "legacy";
 }
 
 const MANAGED_WHATSAPP_AUTH_MARKER = ".clawdi-managed-whatsapp-auth.json";
 const MANAGED_WHATSAPP_AUTH_ROOT = [".openclaw", "credentials", "whatsapp"] as const;
+const MANAGED_HERMES_WHATSAPP_AUTH_ROOT = [".hermes", "platforms", "whatsapp"] as const;
 
 function materializeHostedChannelCredentials(
 	manifest: RuntimeManifest,
@@ -229,7 +231,7 @@ function materializeHostedChannelCredentials(
 	const expectedAuthDirs = new Set<string>();
 	const errors: string[] = [];
 	for (const credential of credentials) {
-		const authDirError = managedWhatsAppAuthDirError(manifest, credential.authDir);
+		const authDirError = managedWhatsAppAuthDirError(manifest, credential);
 		if (authDirError) {
 			errors.push(authDirError);
 			continue;
@@ -263,31 +265,61 @@ function hostedWhatsAppAuthCredentials(manifest: RuntimeManifest): ManagedWhatsA
 	const raw = manifest.projection?.channelCredentials;
 	if (!Array.isArray(raw)) return [];
 	return raw
-		.map(parseManagedWhatsAppAuthCredential)
+		.flatMap(parseManagedWhatsAppAuthCredentials)
 		.filter((entry): entry is ManagedWhatsAppAuthCredential => entry !== null)
 		.sort((left, right) =>
-			`${left.accountKey}:${left.credentialId}`.localeCompare(
-				`${right.accountKey}:${right.credentialId}`,
+			`${left.target}:${left.accountKey}:${left.credentialId}`.localeCompare(
+				`${right.target}:${right.accountKey}:${right.credentialId}`,
 			),
 		);
 }
 
-function parseManagedWhatsAppAuthCredential(value: unknown): ManagedWhatsAppAuthCredential | null {
+function parseManagedWhatsAppAuthCredentials(value: unknown): ManagedWhatsAppAuthCredential[] {
 	const record = recordValue(value);
-	if (!record) return null;
-	if (record.provider !== "whatsapp" || record.kind !== "whatsapp_baileys_auth_state") return null;
+	if (!record) return [];
+	if (record.provider !== "whatsapp" || record.kind !== "whatsapp_baileys_auth_state") return [];
 	const accountKey = stringValue(record.accountKey);
 	const credentialId = stringValue(record.credentialId);
-	const authDir = stringValue(record.authDir);
 	const files = Array.isArray(record.files) ? record.files : [];
 	const credsFile = files
 		.map(recordValue)
 		.find((file) => file?.path === "creds.json" && typeof file.secretRef === "string");
 	const credsJsonSecretRef = credsFile ? stringValue(credsFile.secretRef) : null;
-	if (!accountKey || !credentialId || !authDir || !credsJsonSecretRef) {
+	if (!accountKey || !credentialId || !credsJsonSecretRef) {
 		throw new Error("WhatsApp auth credential projection is incomplete");
 	}
-	return { accountKey, credentialId, authDir, credsJsonSecretRef };
+	const targets = recordValue(record.targets);
+	const parsedTargets: ManagedWhatsAppAuthCredential[] = [];
+	const openclawTarget = targets ? recordValue(targets.openclaw) : null;
+	const openclawAuthDir = openclawTarget
+		? stringValue(openclawTarget.authDir)
+		: stringValue(record.authDir);
+	if (openclawAuthDir) {
+		parsedTargets.push({
+			accountKey,
+			credentialId,
+			authDir: openclawAuthDir,
+			credsJsonSecretRef,
+			target: targets ? "openclaw" : "legacy",
+		});
+	}
+	const hermesTarget = targets ? recordValue(targets.hermes) : null;
+	const hermesSessionDir = hermesTarget
+		? (stringValue(hermesTarget.sessionDir) ?? stringValue(hermesTarget.authDir))
+		: null;
+	if (hermesSessionDir) {
+		parsedTargets.push({
+			accountKey,
+			credentialId,
+			authDir: hermesSessionDir,
+			credsJsonSecretRef,
+			target: "hermes",
+		});
+	}
+	if (parsedTargets.length === 0) {
+		throw new Error("WhatsApp auth credential projection is incomplete");
+	}
+	return parsedTargets;
 }
 
 function materializeManagedWhatsAppAuthDir(
@@ -339,25 +371,52 @@ function materializeManagedWhatsAppAuthDir(
 	writeJsonFile(join(credential.authDir, MANAGED_WHATSAPP_AUTH_MARKER), {
 		schemaVersion: "clawdi.managedWhatsAppAuth.v1",
 		provider: "whatsapp",
+		target: credential.target,
 		accountKey: credential.accountKey,
 		credentialId: credential.credentialId,
 	});
 	makeRuntimeUserOwned(join(credential.authDir, MANAGED_WHATSAPP_AUTH_MARKER));
 }
 
-function managedWhatsAppAuthDirError(manifest: RuntimeManifest, authDir: string): string | null {
-	const root = managedWhatsAppAuthRoot(manifest);
-	if (!root) return "WhatsApp auth credential projection is missing runtime home";
-	const relativePath = relative(root, resolve(authDir));
-	if (!relativePath || relativePath.startsWith("..") || isAbsolute(relativePath)) {
-		return `WhatsApp auth directory must be under ${root}`;
+function managedWhatsAppAuthDirError(
+	manifest: RuntimeManifest,
+	credential: ManagedWhatsAppAuthCredential,
+): string | null {
+	const roots = managedWhatsAppAuthRootsForCredential(manifest, credential);
+	if (roots.length === 0) return "WhatsApp auth credential projection is missing runtime home";
+	const resolvedAuthDir = resolve(credential.authDir);
+	for (const root of roots) {
+		const relativePath = relative(root, resolvedAuthDir);
+		if (relativePath && !relativePath.startsWith("..") && !isAbsolute(relativePath)) {
+			return null;
+		}
 	}
-	return null;
+	return `WhatsApp auth directory must be under ${roots.join(" or ")}`;
 }
 
-function managedWhatsAppAuthRoot(manifest: RuntimeManifest): string | null {
+function managedWhatsAppAuthRootsForCredential(
+	manifest: RuntimeManifest,
+	credential: ManagedWhatsAppAuthCredential,
+): string[] {
+	const roots = managedWhatsAppAuthRoots(manifest);
+	if (credential.target === "hermes") {
+		return roots.hermes ? [roots.hermes] : [];
+	}
+	if (credential.target === "openclaw" || credential.target === "legacy") {
+		return roots.openclaw ? [roots.openclaw] : [];
+	}
+	return [roots.openclaw, roots.hermes].filter((root): root is string => Boolean(root));
+}
+
+function managedWhatsAppAuthRoots(manifest: RuntimeManifest): {
+	openclaw: string | null;
+	hermes: string | null;
+} {
 	const home = projectionSystemHome(manifest) ?? process.env.HOME ?? "";
-	return home ? resolve(home, ...MANAGED_WHATSAPP_AUTH_ROOT) : null;
+	return {
+		openclaw: home ? resolve(home, ...MANAGED_WHATSAPP_AUTH_ROOT) : null,
+		hermes: home ? resolve(home, ...MANAGED_HERMES_WHATSAPP_AUTH_ROOT) : null,
+	};
 }
 
 function readManagedWhatsAppAuthMarker(authDir: string): { credentialId: string } | null {
@@ -382,9 +441,13 @@ function removeStaleManagedWhatsAppAuthDirs(
 	manifest: RuntimeManifest,
 	expected: Set<string>,
 ): void {
-	const root = managedWhatsAppAuthRoot(manifest);
-	if (!root) return;
-	if (!existsSync(root)) return;
+	for (const root of Object.values(managedWhatsAppAuthRoots(manifest))) {
+		if (!root || !existsSync(root)) continue;
+		removeStaleManagedWhatsAppAuthDirsUnderRoot(root, expected);
+	}
+}
+
+function removeStaleManagedWhatsAppAuthDirsUnderRoot(root: string, expected: Set<string>): void {
 	for (const entry of readdirSync(root)) {
 		const authDir = join(root, entry);
 		try {
@@ -1450,7 +1513,11 @@ function applyHostedChannelProjection(
 		const configPath = join(home, ".hermes", "config.yaml");
 		mergeHermesChannelConfig(
 			configPath,
-			hermesManagedChannelsPatch(channels, manifest.controlPlane.apiUrl),
+			hermesManagedChannelsPatch(
+				channels,
+				manifest.controlPlane.apiUrl,
+				manifest.projection?.channelCredentials,
+			),
 		);
 		makeRuntimeUserOwned(configPath);
 		return configPath;
@@ -1469,8 +1536,10 @@ function applyHostedChannelProjection(
 function hermesManagedChannelsPatch(
 	channels: Record<string, unknown>,
 	cloudApiUrl: string,
-): Record<"telegram" | "discord", Record<string, unknown>> {
+	channelCredentials: unknown,
+): Record<string, Record<string, unknown>> {
 	const baseUrl = stripTrailingSlash(cloudApiUrl);
+	const whatsapp = hermesWhatsAppProjection(channels, channelCredentials, baseUrl);
 	return {
 		telegram: channelHasAccounts(channels.telegram)
 			? {
@@ -1499,7 +1568,55 @@ function hermesManagedChannelsPatch(
 					bots_require_inline_mention: false,
 				}
 			: { enabled: false },
+		whatsapp: whatsapp
+			? {
+					enabled: true,
+					dm_policy: "open",
+					group_policy: "open",
+					allow_from: ["*"],
+					group_allow_from: ["*"],
+					require_mention: false,
+				}
+			: { enabled: false },
+		platforms: {
+			whatsapp: whatsapp
+				? {
+						enabled: true,
+						extra: {
+							session_path: whatsapp.sessionDir,
+							ws_url: whatsapp.wsUrl,
+						},
+					}
+				: { enabled: false },
+		},
 	};
+}
+
+function hermesWhatsAppProjection(
+	channels: Record<string, unknown>,
+	channelCredentials: unknown,
+	baseUrl: string,
+): { sessionDir: string; wsUrl: string } | null {
+	if (!channelHasAccounts(channels.whatsapp)) return null;
+	if (!Array.isArray(channelCredentials)) return null;
+	for (const credential of channelCredentials) {
+		const record = recordValue(credential);
+		if (record?.provider !== "whatsapp" || record.kind !== "whatsapp_baileys_auth_state") {
+			continue;
+		}
+		const accountId = stringValue(record.accountId);
+		const targets = recordValue(record.targets);
+		const hermesTarget = targets ? recordValue(targets.hermes) : null;
+		const sessionDir = hermesTarget
+			? (stringValue(hermesTarget.sessionDir) ?? stringValue(hermesTarget.authDir))
+			: null;
+		if (!accountId || !sessionDir) continue;
+		return {
+			sessionDir,
+			wsUrl: `${toWebSocketUrl(baseUrl)}/v1/channels/whatsapp/${accountId}/baileys`,
+		};
+	}
+	return null;
 }
 
 function channelHasAccounts(channel: unknown): boolean {
@@ -1510,6 +1627,12 @@ function channelHasAccounts(channel: unknown): boolean {
 
 function stripTrailingSlash(value: string): string {
 	return value.replace(/\/+$/, "");
+}
+
+function toWebSocketUrl(baseUrl: string): string {
+	if (baseUrl.startsWith("https://")) return `wss://${baseUrl.slice("https://".length)}`;
+	if (baseUrl.startsWith("http://")) return `ws://${baseUrl.slice("http://".length)}`;
+	return baseUrl;
 }
 
 function openClawManagedChannelsPatch(channels: Record<string, unknown>): Record<string, unknown> {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -2198,6 +2198,113 @@ exit 64
 		expect(projected.secretValues).toEqual({ "provider.default.apiKey": "sk-provider" });
 	});
 
+	it("projects WhatsApp tenant credentials as secret-backed auth state", () => {
+		const accountId = "00000000-0000-0000-0000-000000000001";
+		const linkId = "link-whatsapp-1";
+		const credentialId = "credential-whatsapp-1";
+		const loaded: RuntimeManifestLoad = {
+			manifest: {
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				runtime: "openclaw",
+				deploymentId: "dep_whatsapp_creds_projection",
+				environmentId: "env_whatsapp_creds_projection",
+				instanceId: "iid_whatsapp_creds_projection",
+				generation: 5,
+				issuedAt: "2026-06-14T00:00:00Z",
+				controlPlane: { apiUrl: "https://cloud-api.test" },
+				runtimes: {
+					openclaw: { enabled: true },
+				},
+				projection: {
+					system: { home: "/home/clawdi", workspace: "/home/clawdi/clawdi" },
+				},
+			},
+			source: "remote-datasource",
+			sourcePath: "https://runtime.test/manifest",
+			secretValues: {},
+		};
+		const channels: RuntimeChannelsLoad = {
+			channels: [
+				{
+					id: accountId,
+					provider: "whatsapp",
+					name: "Hosted WhatsApp",
+					status: "active",
+					visibility: "private",
+					runtime_links: [
+						{
+							id: linkId,
+							account_id: accountId,
+							agent_id: "env_whatsapp_creds_projection",
+							status: "active",
+							agent_token: "wa-agent-token",
+						},
+					],
+					runtime_credentials: [
+						{
+							id: credentialId,
+							account_id: accountId,
+							agent_link_id: linkId,
+							agent_id: "env_whatsapp_creds_projection",
+							provider: "whatsapp",
+							kind: "whatsapp_baileys_auth_state",
+							created_at: "2026-07-07T00:00:00Z",
+							jid: "15551234567:1@s.whatsapp.net",
+							identity_pub_key_hex: "aabbcc",
+							material: {
+								schemaVersion: "clawdi.whatsappBaileysAuthState.v1",
+								creds: {
+									advSecretKey: "wa-adv-secret",
+									me: { id: "15551234567:1@s.whatsapp.net" },
+								},
+							},
+						},
+					],
+				},
+			],
+			source: "remote-datasource",
+			sourcePath: "https://runtime.test/v1/channels",
+			etag: '"whatsapp-creds"',
+		};
+
+		const projected = applyRuntimeChannelsToManifestLoad(loaded, channels);
+
+		const accountKey = "clawdi_000000000000";
+		const authDir = join("/home/clawdi", ".openclaw", "credentials", "whatsapp", accountKey);
+		const channelProjection = projected.manifest.projection?.channels as Record<string, unknown>;
+		const whatsapp = channelProjection.whatsapp as {
+			accounts: Record<string, { authDir?: string; token?: string }>;
+		};
+		expect(whatsapp.accounts[accountKey]).toMatchObject({
+			authDir,
+			token: "wa-agent-token",
+		});
+		const credentialProjection = projected.manifest.projection?.channelCredentials;
+		expect(credentialProjection).toEqual([
+			{
+				provider: "whatsapp",
+				kind: "whatsapp_baileys_auth_state",
+				accountId,
+				accountKey,
+				linkId,
+				credentialId,
+				authDir,
+				files: [
+					{
+						path: "creds.json",
+						secretRef: `secret://channels/whatsapp/${accountKey}/credentials/${credentialId}/creds-json`,
+					},
+				],
+			},
+		]);
+		expect(JSON.stringify(projected.manifest)).not.toContain("wa-adv-secret");
+		expect(
+			projected.secretValues?.[
+				`secret://channels/whatsapp/${accountKey}/credentials/${credentialId}/creds-json`
+			],
+		).toContain("wa-adv-secret");
+	});
+
 	it("removes stale channel-driven MITM profiles when runtime channels are disabled", () => {
 		const loaded: RuntimeManifestLoad = {
 			manifest: {
@@ -4659,6 +4766,305 @@ exit 0
 		expect(patchText).toContain('"bluebubbles": null');
 		expect(patchText).not.toContain('"$patch"');
 		expect(patchText).not.toContain('"botToken"');
+	});
+
+	it("materializes, rotates, and cleans up WhatsApp auth state for OpenClaw", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const workspace = join(home, "clawdi");
+		const accountKey = "clawdi_whatsapp_runtime";
+		const accountId = "00000000-0000-0000-0000-000000000001";
+		const authDir = join(home, ".openclaw", "credentials", "whatsapp", accountKey);
+		const openclawBin = join(home, ".openclaw", "bin", "openclaw");
+		const openclawPatch = join(root, "openclaw-whatsapp-auth-patch.jsonl");
+		const openclawPluginInstalls = join(root, "openclaw-whatsapp-plugin-installs.txt");
+		mkdirSync(dirname(openclawBin), { recursive: true });
+		mkdirSync(workspace, { recursive: true });
+		writeFileSync(
+			openclawBin,
+			`#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
+  cat >> '${openclawPatch}'
+  printf '\\n---\\n' >> '${openclawPatch}'
+  exit 0
+fi
+if [ "\${1:-}" = "plugins" ] && [ "\${2:-}" = "install" ]; then
+  printf '%s\\n' "\${3:-}" >> '${openclawPluginInstalls}'
+  exit 0
+fi
+printf 'unexpected openclaw command: %s\\n' "$*" >&2
+exit 64
+`,
+		);
+		chmodSync(openclawBin, 0o700);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+
+		const credentialSecretRef = (credentialId: string) =>
+			`secret://channels/whatsapp/${accountKey}/credentials/${credentialId}/creds-json`;
+		const manifestWithCredential = (
+			credentialId: string,
+			creds: Record<string, unknown>,
+			generation: number,
+		): RuntimeManifestLoad => {
+			const secretRef = credentialSecretRef(credentialId);
+			return {
+				manifest: {
+					schemaVersion: "clawdi.runtimeDesiredState.v1",
+					deploymentId: "dep_whatsapp_auth_state",
+					environmentId: "env_whatsapp_auth_state",
+					instanceId: "iid_whatsapp_auth_state",
+					generation,
+					issuedAt: "2026-07-07T00:00:00Z",
+					controlPlane: { apiUrl: "https://cloud-api.test" },
+					runtimes: {
+						openclaw: {
+							enabled: true,
+							install: {
+								authority: "official",
+								method: "official-installer",
+								url: "https://openclaw.ai/install-cli.sh",
+								home,
+								args: [],
+							},
+						},
+					},
+					projection: {
+						system: { home, workspace },
+						channels: {
+							whatsapp: {
+								enabled: true,
+								defaultAccount: accountKey,
+								accounts: {
+									[accountKey]: {
+										enabled: true,
+										wsUrl: `wss://cloud-api.test/v1/channels/whatsapp/${accountId}/baileys`,
+										token: "wa-runtime-agent-token",
+										authDir,
+									},
+								},
+							},
+						},
+						channelCredentials: [
+							{
+								provider: "whatsapp",
+								kind: "whatsapp_baileys_auth_state",
+								accountId,
+								accountKey,
+								linkId: "link-whatsapp-runtime",
+								credentialId,
+								authDir,
+								files: [{ path: "creds.json", secretRef }],
+							},
+						],
+					},
+					recovery: {},
+				},
+				source: "fixture-file",
+				sourcePath: `test://whatsapp-auth-state-${generation}`,
+				offline: false,
+				secretValues: { [secretRef]: JSON.stringify(creds) },
+			};
+		};
+		const unlinkedManifest: RuntimeManifestLoad = {
+			manifest: {
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				deploymentId: "dep_whatsapp_auth_state",
+				environmentId: "env_whatsapp_auth_state",
+				instanceId: "iid_whatsapp_auth_state",
+				generation: 12,
+				issuedAt: "2026-07-07T00:00:00Z",
+				controlPlane: { apiUrl: "https://cloud-api.test" },
+				runtimes: {
+					openclaw: {
+						enabled: true,
+						install: {
+							authority: "official",
+							method: "official-installer",
+							url: "https://openclaw.ai/install-cli.sh",
+							home,
+							args: [],
+						},
+					},
+				},
+				projection: {
+					system: { home, workspace },
+					channels: {},
+					channelCredentials: [],
+				},
+				recovery: {},
+			},
+			source: "fixture-file",
+			sourcePath: "test://whatsapp-auth-state-unlinked",
+			offline: false,
+			secretValues: {},
+		};
+
+		const initialCreds = {
+			advSecretKey: "wa-materialized-secret",
+			me: { id: "15551234567:1@s.whatsapp.net" },
+			noiseKey: { private: { type: "Buffer", data: "AQID" } },
+		};
+		const rotatedCreds = {
+			advSecretKey: "wa-rotated-secret",
+			me: { id: "15557654321:1@s.whatsapp.net" },
+			noiseKey: { private: { type: "Buffer", data: "BAUG" } },
+		};
+
+		const initial = convergeRuntimeManifest(
+			manifestWithCredential("credential-whatsapp-1", initialCreds, 10),
+			getRuntimePaths(),
+		);
+		const rotated = convergeRuntimeManifest(
+			manifestWithCredential("credential-whatsapp-2", rotatedCreds, 11),
+			getRuntimePaths(),
+		);
+
+		expect(initial.installErrors).toEqual([]);
+		expect(rotated.installErrors).toEqual([]);
+		expect(JSON.parse(readFileSync(join(authDir, "creds.json"), "utf-8"))).toEqual(rotatedCreds);
+		const markerText = readFileSync(join(authDir, ".clawdi-managed-whatsapp-auth.json"), "utf-8");
+		expect(markerText).toContain("credential-whatsapp-2");
+		expect(markerText).not.toContain("wa-rotated-secret");
+		const patchText = readFileSync(openclawPatch, "utf-8");
+		expect(patchText).toContain('"authDir"');
+		expect(patchText).toContain(authDir);
+		expect(patchText).not.toContain("wa-materialized-secret");
+		expect(patchText).not.toContain("wa-rotated-secret");
+		expect(readFileSync(openclawPluginInstalls, "utf-8")).toContain("clawhub:@openclaw/whatsapp");
+		const lastGoodManifest = readFileSync(join(state, "cache", "manifest.last-good.json"), "utf-8");
+		expect(lastGoodManifest).toContain("credential-whatsapp-2");
+		expect(lastGoodManifest).not.toContain("wa-rotated-secret");
+		const lastGoodSecrets = readFileSync(
+			join(state, "cache", "runtime-secrets.last-good.json"),
+			"utf-8",
+		);
+		expect(lastGoodSecrets).toContain("wa-rotated-secret");
+
+		const removed = convergeRuntimeManifest(unlinkedManifest, getRuntimePaths());
+
+		expect(removed.installErrors).toEqual([]);
+		expect(existsSync(authDir)).toBe(false);
+	});
+
+	it("fails closed and removes stale WhatsApp auth state when creds secret is missing", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const workspace = join(home, "clawdi");
+		const accountKey = "clawdi_missing_whatsapp";
+		const authDir = join(home, ".openclaw", "credentials", "whatsapp", accountKey);
+		const openclawBin = join(home, ".openclaw", "bin", "openclaw");
+		const openclawPatch = join(root, "openclaw-whatsapp-missing-secret-patch.jsonl");
+		const openclawPluginInstalls = join(root, "openclaw-whatsapp-missing-secret-installs.txt");
+		mkdirSync(dirname(openclawBin), { recursive: true });
+		mkdirSync(workspace, { recursive: true });
+		mkdirSync(authDir, { recursive: true });
+		writeFileSync(
+			join(authDir, "creds.json"),
+			`${JSON.stringify({ advSecretKey: "stale-whatsapp-secret" })}\n`,
+		);
+		writeFileSync(
+			join(authDir, ".clawdi-managed-whatsapp-auth.json"),
+			`${JSON.stringify({
+				schemaVersion: "clawdi.managedWhatsAppAuth.v1",
+				provider: "whatsapp",
+				accountKey,
+				credentialId: "credential-stale",
+			})}\n`,
+		);
+		writeFileSync(
+			openclawBin,
+			`#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
+  cat >> '${openclawPatch}'
+  printf '\\n---\\n' >> '${openclawPatch}'
+  exit 0
+fi
+if [ "\${1:-}" = "plugins" ] && [ "\${2:-}" = "install" ]; then
+  printf '%s\\n' "\${3:-}" >> '${openclawPluginInstalls}'
+  exit 0
+fi
+printf 'unexpected openclaw command: %s\\n' "$*" >&2
+exit 64
+`,
+		);
+		chmodSync(openclawBin, 0o700);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+
+		const missingSecretRef = `secret://channels/whatsapp/${accountKey}/credentials/credential-missing/creds-json`;
+		const loaded: RuntimeManifestLoad = {
+			manifest: {
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				deploymentId: "dep_whatsapp_missing_secret",
+				environmentId: "env_whatsapp_missing_secret",
+				instanceId: "iid_whatsapp_missing_secret",
+				generation: 9,
+				issuedAt: "2026-07-07T00:00:00Z",
+				controlPlane: { apiUrl: "https://cloud-api.test" },
+				runtimes: {
+					openclaw: {
+						enabled: true,
+						install: {
+							authority: "official",
+							method: "official-installer",
+							url: "https://openclaw.ai/install-cli.sh",
+							home,
+							args: [],
+						},
+					},
+				},
+				projection: {
+					system: { home, workspace },
+					channels: {
+						whatsapp: {
+							enabled: true,
+							defaultAccount: accountKey,
+							accounts: {
+								[accountKey]: {
+									enabled: true,
+									wsUrl: "wss://cloud-api.test/v1/channels/whatsapp/account/baileys",
+									token: "wa-runtime-agent-token",
+									authDir,
+								},
+							},
+						},
+					},
+					channelCredentials: [
+						{
+							provider: "whatsapp",
+							kind: "whatsapp_baileys_auth_state",
+							accountKey,
+							credentialId: "credential-missing",
+							authDir,
+							files: [{ path: "creds.json", secretRef: missingSecretRef }],
+						},
+					],
+				},
+				recovery: {},
+			},
+			source: "fixture-file",
+			sourcePath: "test://whatsapp-missing-secret",
+			offline: false,
+			secretValues: {},
+		};
+
+		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
+
+		expect(convergence.installErrors.join("\n")).toContain(
+			"runtime channel credential materialization failed: missing WhatsApp auth state secret",
+		);
+		expect(existsSync(authDir)).toBe(false);
+		expect(existsSync(join(state, "cache", "manifest.last-good.json"))).toBe(false);
+		expect(JSON.stringify(convergence.manifest)).not.toContain("stale-whatsapp-secret");
 	});
 
 	it("removes stale native channels when a later projection omits them", () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -2295,6 +2295,9 @@ exit 64
 						secretRef: `secret://channels/whatsapp/${accountKey}/credentials/${credentialId}/creds-json`,
 					},
 				],
+				targets: {
+					openclaw: { authDir },
+				},
 			},
 		]);
 		expect(JSON.stringify(projected.manifest)).not.toContain("wa-adv-secret");
@@ -4590,6 +4593,182 @@ exit 64
 		expect(profileBundle).toContain("/v1/channels/discord");
 	});
 
+	it("converges Hermes native WhatsApp channel projection with managed Baileys creds", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const workspace = join(home, "clawdi");
+		const hermesBin = join(home, ".local", "bin", "hermes");
+		const accountId = "00000000-0000-0000-0000-000000000001";
+		const accountKey = "clawdi_000000000000";
+		const credentialId = "credential-whatsapp-hermes";
+		const credentialSecretRef = `secret://channels/whatsapp/${accountKey}/credentials/${credentialId}/creds-json`;
+		const sessionDir = join(home, ".hermes", "platforms", "whatsapp", "session");
+		const creds = {
+			advSecretKey: "wa-hermes-secret",
+			me: { id: "15551234567:1@s.whatsapp.net" },
+		};
+		mkdirSync(dirname(hermesBin), { recursive: true });
+		mkdirSync(workspace, { recursive: true });
+		writeFileSync(hermesBin, "#!/usr/bin/env bash\nexit 0\n");
+		chmodSync(hermesBin, 0o700);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_SYSTEMD_APPLY = "0";
+
+		const load: RuntimeManifestLoad = {
+			manifest: {
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				runtime: "hermes",
+				deploymentId: "dep_hermes_whatsapp",
+				environmentId: "env_hermes_whatsapp",
+				instanceId: "iid_hermes_whatsapp",
+				generation: 14,
+				issuedAt: "2026-07-07T00:00:00Z",
+				controlPlane: { apiUrl: "https://cloud-api.test/" },
+				runtimes: {
+					hermes: {
+						enabled: true,
+						install: {
+							authority: "official",
+							method: "official-installer",
+							url: "https://hermes-agent.nousresearch.com/install.sh",
+							home,
+							args: [],
+						},
+						run: {
+							args: ["gateway", "run", "--replace"],
+							env: { HERMES_EXISTING_ENV: "kept" },
+							prependPath: [],
+						},
+						services: {},
+					},
+				},
+				projection: {
+					system: { home, workspace },
+				},
+				recovery: {},
+			},
+			source: "fixture-file",
+			sourcePath: "test://hermes-whatsapp",
+			offline: false,
+			secretValues: {},
+		};
+		const channels: RuntimeChannelsLoad = {
+			channels: [
+				{
+					id: accountId,
+					provider: "whatsapp",
+					name: "Hermes WhatsApp",
+					status: "active",
+					visibility: "private",
+					runtime_links: [
+						{
+							id: "link-whatsapp-hermes",
+							account_id: accountId,
+							agent_id: "env_hermes_whatsapp",
+							status: "active",
+							agent_token: "wa-hermes-agent-token",
+						},
+					],
+					runtime_credentials: [
+						{
+							id: credentialId,
+							account_id: accountId,
+							agent_link_id: "link-whatsapp-hermes",
+							agent_id: "env_hermes_whatsapp",
+							provider: "whatsapp",
+							kind: "whatsapp_baileys_auth_state",
+							created_at: "2026-07-07T00:00:00Z",
+							jid: "15551234567:1@s.whatsapp.net",
+							identity_pub_key_hex: "aabbcc",
+							material: {
+								schemaVersion: "clawdi.whatsappBaileysAuthState.v1",
+								creds,
+							},
+						},
+					],
+				},
+			],
+			source: "remote-datasource",
+			sourcePath: "https://runtime.test/v1/channels",
+			etag: '"hermes-whatsapp"',
+		};
+
+		const projected = applyRuntimeChannelsToManifestLoad(load, channels);
+		const credentialProjection = projected.manifest.projection?.channelCredentials as Array<{
+			targets?: { hermes?: { sessionDir?: string; credsJsonEnv?: string } };
+		}>;
+		expect(credentialProjection[0]?.targets?.hermes).toEqual({
+			sessionDir,
+			credsJsonEnv: "HERMES_WA_CREDS_JSON",
+		});
+		expect(JSON.stringify(projected.manifest)).not.toContain("wa-hermes-secret");
+		expect(projected.secretValues?.[credentialSecretRef]).toContain("wa-hermes-secret");
+
+		const convergence = convergeRuntimeManifest(projected, getRuntimePaths());
+
+		expect(convergence.installErrors).toEqual([]);
+		expect(JSON.parse(readFileSync(join(sessionDir, "creds.json"), "utf-8"))).toEqual(creds);
+		expect(readFileSync(join(sessionDir, ".clawdi-managed-whatsapp-auth.json"), "utf-8")).toContain(
+			credentialId,
+		);
+		const hermesConfig = readFileSync(join(home, ".hermes", "config.yaml"), "utf-8");
+		expect(hermesConfig).toContain("whatsapp:");
+		expect(hermesConfig).toContain("enabled: true");
+		expect(hermesConfig).toContain("dm_policy: open");
+		expect(hermesConfig).toContain("group_policy: open");
+		expect(hermesConfig).toContain("allow_from:");
+		expect(hermesConfig).toContain(`session_path: ${sessionDir}`);
+		expect(hermesConfig).toContain(
+			"ws_url: wss://cloud-api.test/v1/channels/whatsapp/00000000-0000-0000-0000-000000000001/baileys",
+		);
+		expect(hermesConfig).not.toContain("wa-hermes-secret");
+
+		const runConfig = JSON.parse(
+			readFileSync(join(state, "config", "run", "hermes.json"), "utf-8"),
+		);
+		expect(runConfig.env.HERMES_EXISTING_ENV).toBe("kept");
+		expect(runConfig.env.WHATSAPP_ENABLED).toBe("true");
+		expect(runConfig.env.WHATSAPP_MODE).toBe("bot");
+		expect(runConfig.env.WHATSAPP_ALLOWED_USERS).toBe("*");
+		expect(runConfig.secretEnv.HERMES_WA_CREDS_JSON).toBe(credentialSecretRef);
+		expect(JSON.stringify(runConfig)).not.toContain("wa-hermes-secret");
+		const hermesEnv = readSystemdEnvFile(getRuntimePaths(), "hermes-gateway");
+		expect(hermesEnv).toContain('WHATSAPP_ENABLED="true"');
+		expect(hermesEnv).toContain('WHATSAPP_MODE="bot"');
+		expect(hermesEnv).toContain('WHATSAPP_ALLOWED_USERS="*"');
+		expect(hermesEnv).toContain("HERMES_WA_CREDS_JSON=");
+		expect(hermesEnv).toContain("wa-hermes-secret");
+
+		const removed = convergeRuntimeManifest(
+			applyRuntimeChannelsToManifestLoad(load, {
+				channels: [],
+				source: "remote-datasource",
+				sourcePath: "https://runtime.test/v1/channels",
+				etag: '"empty-hermes-whatsapp"',
+			}),
+			getRuntimePaths(),
+		);
+
+		expect(removed.installErrors).toEqual([]);
+		expect(existsSync(sessionDir)).toBe(false);
+		const clearedConfig = readFileSync(join(home, ".hermes", "config.yaml"), "utf-8");
+		expect(clearedConfig).toContain("whatsapp:");
+		expect(clearedConfig).toContain("enabled: false");
+		expect(clearedConfig).not.toContain(sessionDir);
+		const clearedRunConfig = JSON.parse(
+			readFileSync(join(state, "config", "run", "hermes.json"), "utf-8"),
+		);
+		expect(clearedRunConfig.env.WHATSAPP_ENABLED).toBeUndefined();
+		expect(clearedRunConfig.secretEnv.HERMES_WA_CREDS_JSON).toBeUndefined();
+		expect(readSystemdEnvFile(getRuntimePaths(), "hermes-gateway")).not.toContain(
+			"HERMES_WA_CREDS_JSON",
+		);
+	});
+
 	it("clears Hermes native channel settings when no channel links are active", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -4608,6 +4787,14 @@ exit 64
 				"discord:",
 				"  enabled: true",
 				"  stale: should-be-removed",
+				"whatsapp:",
+				"  enabled: true",
+				"  stale: should-be-removed",
+				"platforms:",
+				"  whatsapp:",
+				"    enabled: true",
+				"    extra:",
+				"      session_path: /stale/session",
 				"",
 			].join("\n"),
 		);
@@ -4644,10 +4831,15 @@ exit 64
 								HERMES_EXISTING_ENV: "kept",
 								TELEGRAM_ALLOW_ALL_USERS: "true",
 								DISCORD_ALLOW_ALL_USERS: "true",
+								WHATSAPP_ENABLED: "true",
+								WHATSAPP_MODE: "bot",
+								WHATSAPP_ALLOWED_USERS: "*",
 							},
 							secretEnv: {
 								TELEGRAM_BOT_TOKEN: "secret://channels/telegram/clawdi_stale/agent-token",
 								DISCORD_BOT_TOKEN: "secret://channels/discord/clawdi_stale/agent-token",
+								HERMES_WA_CREDS_JSON:
+									"secret://channels/whatsapp/clawdi_stale/credentials/stale/creds-json",
 							},
 							prependPath: [],
 						},
@@ -4677,19 +4869,27 @@ exit 64
 		const hermesConfig = readFileSync(join(home, ".hermes", "config.yaml"), "utf-8");
 		expect(hermesConfig).toContain("telegram:");
 		expect(hermesConfig).toContain("discord:");
+		expect(hermesConfig).toContain("whatsapp:");
 		expect(hermesConfig).toContain("enabled: false");
 		expect(hermesConfig).not.toContain("stale: should-be-removed");
+		expect(hermesConfig).not.toContain("/stale/session");
 		const runConfig = JSON.parse(
 			readFileSync(join(state, "config", "run", "hermes.json"), "utf-8"),
 		);
 		expect(runConfig.env.HERMES_EXISTING_ENV).toBe("kept");
 		expect(runConfig.env.TELEGRAM_ALLOW_ALL_USERS).toBeUndefined();
 		expect(runConfig.env.DISCORD_ALLOW_ALL_USERS).toBeUndefined();
+		expect(runConfig.env.WHATSAPP_ENABLED).toBeUndefined();
+		expect(runConfig.env.WHATSAPP_MODE).toBeUndefined();
+		expect(runConfig.env.WHATSAPP_ALLOWED_USERS).toBeUndefined();
 		expect(runConfig.secretEnv.TELEGRAM_BOT_TOKEN).toBeUndefined();
 		expect(runConfig.secretEnv.DISCORD_BOT_TOKEN).toBeUndefined();
+		expect(runConfig.secretEnv.HERMES_WA_CREDS_JSON).toBeUndefined();
 		const hermesEnv = readSystemdEnvFile(getRuntimePaths(), "hermes-gateway");
 		expect(hermesEnv).not.toContain("TELEGRAM_BOT_TOKEN");
 		expect(hermesEnv).not.toContain("DISCORD_BOT_TOKEN");
+		expect(hermesEnv).not.toContain("HERMES_WA_CREDS_JSON");
+		expect(hermesEnv).not.toContain("WHATSAPP_ENABLED");
 	});
 
 	it("converges empty native channel projection with merge-patch deletes", () => {

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -3467,6 +3467,8 @@ export interface components {
             created_at: string;
             /** Runtime Links */
             runtime_links?: components["schemas"]["ChannelRuntimeAgentLinkResponse"][];
+            /** Runtime Credentials */
+            runtime_credentials?: components["schemas"]["ChannelRuntimeCredentialResponse"][];
         };
         /** ChannelRuntimeAgentLinkResponse */
         ChannelRuntimeAgentLinkResponse: {
@@ -3494,6 +3496,46 @@ export interface components {
             created_at: string;
             /** Agent Token */
             agent_token?: string | null;
+        };
+        /** ChannelRuntimeCredentialResponse */
+        ChannelRuntimeCredentialResponse: {
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /**
+             * Account Id
+             * Format: uuid
+             */
+            account_id: string;
+            /**
+             * Agent Link Id
+             * Format: uuid
+             */
+            agent_link_id: string;
+            /**
+             * Agent Id
+             * Format: uuid
+             */
+            agent_id: string;
+            /** Provider */
+            provider: string;
+            /** Kind */
+            kind: string;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Jid */
+            jid?: string | null;
+            /** Identity Pub Key Hex */
+            identity_pub_key_hex?: string | null;
+            /** Material */
+            material?: {
+                [key: string]: unknown;
+            } | null;
         };
         /** ChannelSendMessageRequest */
         ChannelSendMessageRequest: {


### PR DESCRIPTION
Closes the WhatsApp gap from the channel completeness audit (hosted #706) — for BOTH runtimes (owner: equal priority; my earlier OpenClaw-only framing was wrong — Hermes upstream has a built-in WhatsApp platform with a Baileys Node bridge).

**Backend (cloud-api):**
- `/v1/channels` returns WhatsApp `runtime_credentials` ONLY to env-bound CLI/runtime keys scoped to the linked agent; browser responses never include Baileys material.
- Re-minting a link's tenant creds revokes the old active credential, so the runtime always converges on the latest.

**Runtime (CLI):**
- Baileys creds go into runtime `secretValues`; the manifest carries only `secretRef` + target metadata (never plaintext).
- Runtime-neutral credential targets: OpenClaw → `~/.openclaw/credentials/whatsapp/<accountKey>/creds.json` (what `useMultiFileAuthState` expects); Hermes → `HERMES_WA_CREDS_JSON` secretEnv + `platforms.whatsapp.extra.session_path/ws_url` config (upstream's own creds-seed helper at gateway/platforms/whatsapp.py:133 consumes it; bridge is `@whiskeysockets/baileys` with `--ws-url` support).
- Materialization discipline both sides: managed-root validation, symlink/unmanaged-dir rejection, fail-closed on missing/invalid secret, stale-dir cleanup on unlink.
- `hermes-config-merge` generalized to nested `platforms` without clobbering the #335 TG/Discord blocks (merge verified — both features intact post-rebase).
- Hosted runtime image already ships node (verified Dockerfile) — no hosted change needed.

**Remaining (tracked):** hosted link/pairing UI must call the existing `POST /v1/channels/whatsapp/{account_id}/tenant-creds` for v2 agents; one live pairing drill per runtime (pair → restart re-materialization → rotation → unlink).

Tests: CLI 753 pass, shared 14 pass, backend focused + ruff + generated-api check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)