### PR TITLE
feat(cli): use Hermes model-provider plugins for hosted projection

### DIFF
--- a/packages/cli/src/lib/ai-provider-projection.ts
+++ b/packages/cli/src/lib/ai-provider-projection.ts
@@ -30,8 +30,9 @@ export const AGENT_TARGET_CONTRACTS: Record<
 		status: "enabled",
 	},
 	hermes: {
-		settingMethod: "structured merge into $HERMES_HOME/config.yaml providers dict",
-		supportedVersionRange: "Hermes Agent 0.12.0 through 0.17.0 with providers dict compatibility",
+		settingMethod:
+			"structured merge into $HERMES_HOME/config.yaml model/providers compatibility keys",
+		supportedVersionRange: "Hermes Agent 0.18.x config.yaml compatibility readers",
 		status: "enabled",
 	},
 	openclaw: {

--- a/packages/cli/src/lib/ai-provider-projection.ts
+++ b/packages/cli/src/lib/ai-provider-projection.ts
@@ -31,7 +31,7 @@ export const AGENT_TARGET_CONTRACTS: Record<
 	},
 	hermes: {
 		settingMethod: "structured merge into $HERMES_HOME/config.yaml providers dict",
-		supportedVersionRange: "Hermes Agent 0.13.0 through 0.17.0 with providers dict compatibility",
+		supportedVersionRange: "Hermes Agent 0.12.0 through 0.17.0 with providers dict compatibility",
 		status: "enabled",
 	},
 	openclaw: {

--- a/packages/cli/src/lib/hermes-config-merge.ts
+++ b/packages/cli/src/lib/hermes-config-merge.ts
@@ -17,6 +17,7 @@ const HERMES_GENERATED_PROVIDER_FIELDS = [
 	"base_url",
 	"default_model",
 	"model",
+	"models",
 	"transport",
 	"api_mode",
 	"key_env",
@@ -137,6 +138,12 @@ function applyHermesProviderPatch(
 	const patchModel = isPlainRecord(patchConfig.model) ? patchConfig.model : {};
 	removeHermesDirectModelFields(document, existingModel);
 	for (const [key, value] of Object.entries(patchModel)) {
+		if (value === null) {
+			if (Object.hasOwn(existingModel, key)) {
+				document.deleteIn(["model", key]);
+			}
+			continue;
+		}
 		document.setIn(["model", key], value);
 	}
 

--- a/packages/cli/src/lib/hermes-config-merge.ts
+++ b/packages/cli/src/lib/hermes-config-merge.ts
@@ -167,8 +167,19 @@ function applyHermesProviderPatch(
 			document.setIn(["providers", providerId], document.createNode({}));
 		}
 		removeHermesGeneratedProviderFields(document, providerId, existingProvider);
+		let wroteGeneratedField = false;
 		for (const [key, value] of Object.entries(patchValue)) {
+			if (value === null) {
+				if (Object.hasOwn(existingProvider, key)) {
+					document.deleteIn(["providers", providerId, key]);
+				}
+				continue;
+			}
 			document.setIn(["providers", providerId, key], value);
+			wroteGeneratedField = true;
+		}
+		if (!wroteGeneratedField && !hasHermesUserOwnedProviderFields(existingProvider)) {
+			document.deleteIn(["providers", providerId]);
 		}
 	}
 }
@@ -215,6 +226,12 @@ function removeHermesGeneratedProviderFields(
 	for (const key of HERMES_GENERATED_PROVIDER_FIELDS) {
 		if (Object.hasOwn(input, key)) document.deleteIn(["providers", providerId, key]);
 	}
+}
+
+function hasHermesUserOwnedProviderFields(input: Record<string, unknown>): boolean {
+	return Object.keys(input).some(
+		(key) => !(HERMES_GENERATED_PROVIDER_FIELDS as readonly string[]).includes(key),
+	);
 }
 
 function isPlainRecord(input: unknown): input is Record<string, unknown> {

--- a/packages/cli/src/lib/hermes-config-merge.ts
+++ b/packages/cli/src/lib/hermes-config-merge.ts
@@ -143,6 +143,12 @@ function applyHermesProviderPatch(
 	const existingProviders = isPlainRecord(root.providers) ? root.providers : {};
 	const patchProviders = isPlainRecord(patchConfig.providers) ? patchConfig.providers : {};
 	for (const [providerId, patchValue] of Object.entries(patchProviders)) {
+		if (patchValue === null) {
+			if (Object.hasOwn(existingProviders, providerId)) {
+				document.deleteIn(["providers", providerId]);
+			}
+			continue;
+		}
 		if (!isPlainRecord(patchValue)) continue;
 		const existingProvider = isPlainRecord(existingProviders[providerId])
 			? existingProviders[providerId]

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -27,7 +27,11 @@ import type {
 } from "@clawdi/shared";
 import { isAiProviderApiMode, isAiProviderType } from "@clawdi/shared";
 import { z } from "zod";
-import { type AgentPrimaryModel, buildAgentTargetProjection } from "../lib/ai-provider-projection";
+import {
+	type AgentPrimaryModel,
+	buildAgentTargetProjection,
+	type ProjectionFile,
+} from "../lib/ai-provider-projection";
 import {
 	mergeHermesChannelConfig,
 	mergeHermesConfig,
@@ -1356,31 +1360,41 @@ function isEnvKey(value: string): boolean {
 	return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
 }
 
+interface HostedAiProviderProjectionResult {
+	path: string | null;
+	revision: string | null;
+}
+
+interface HermesHostedProviderPluginProjection {
+	modelPatch: string;
+	pluginFiles: ProjectionFile[];
+	revision: string;
+}
+
+const HERMES_MODEL_PROVIDER_PLUGIN_NAME = "clawdi";
+const HERMES_MODEL_PROVIDER_PLUGIN_VERSION = "1.0.0";
+const HERMES_MODEL_PROVIDER_PLUGIN_MIN_VERSION = [0, 13, 0] as const;
+const HERMES_PROVIDER_PROFILE_API_MODES: Partial<Record<AiProviderApiMode, string>> = {
+	openai_chat: "chat_completions",
+	openai_responses: "codex_responses",
+	anthropic_messages: "anthropic_messages",
+};
+
 function applyHostedAiProviderProjection(
 	name: string,
 	observation: RuntimeInstallObservation,
 	manifest: RuntimeManifest,
 	workspaceRoot: string,
-): string | null {
+): HostedAiProviderProjectionResult {
 	if (!observation.enabled || observation.status === "install_failed" || !observation.commandPath) {
-		return null;
+		return { path: null, revision: null };
 	}
 	const projectionInput = hostedAiProviderCatalog(manifest, name);
-	if (!projectionInput) return null;
 	const home = projectionSystemHome(manifest) ?? process.env.HOME ?? "";
 	if (name === "hermes") {
-		const projection = buildAgentTargetProjection(
-			"hermes",
-			projectionInput.catalog,
-			projectionInput.primaryModel,
-		);
-		const file = projection.files.find((entry) => entry.path.endsWith(".hermes.yaml"));
-		if (!file) throw new Error("Hermes projection did not include a config merge YAML file.");
-		const configPath = join(home, ".hermes", "config.yaml");
-		mergeHermesConfig(configPath, file.content);
-		makeRuntimeUserOwned(configPath);
-		return configPath;
+		return applyHostedHermesAiProviderProjection(observation, projectionInput, home, workspaceRoot);
 	}
+	if (!projectionInput) return { path: null, revision: null };
 	if (name === "openclaw") {
 		applyOpenClawHostedProviderProjection(
 			observation.commandPath,
@@ -1389,9 +1403,313 @@ function applyHostedAiProviderProjection(
 			workspaceRoot,
 		);
 		applyOpenClawGatewayHostedProjection(observation.commandPath, manifest, home, workspaceRoot);
-		return observation.commandPath;
+		return { path: observation.commandPath, revision: null };
 	}
-	return null;
+	return { path: null, revision: null };
+}
+
+function applyHostedHermesAiProviderProjection(
+	observation: RuntimeInstallObservation,
+	projectionInput: {
+		catalog: AiProviderCatalog;
+		primaryModel: AgentPrimaryModel;
+	} | null,
+	home: string,
+	workspaceRoot: string,
+): HostedAiProviderProjectionResult {
+	const configPath = join(home, ".hermes", "config.yaml");
+	if (!projectionInput) {
+		removeHermesModelProviderPlugin(home);
+		return {
+			path: null,
+			revision: revisionHash({ hermesProviderProjection: "none" }),
+		};
+	}
+
+	const commandPath = observation.commandPath;
+	if (!commandPath) return { path: null, revision: null };
+	const version = detectHermesInstalledVersion(commandPath, home, workspaceRoot);
+	if (!supportsHermesModelProviderPlugins(version)) {
+		removeHermesModelProviderPlugin(home);
+		const projection = buildAgentTargetProjection(
+			"hermes",
+			projectionInput.catalog,
+			projectionInput.primaryModel,
+		);
+		const file = projection.files.find((entry) => entry.path.endsWith(".hermes.yaml"));
+		if (!file) throw new Error("Hermes projection did not include a config merge YAML file.");
+		mergeHermesConfig(configPath, file.content);
+		makeRuntimeUserOwned(configPath);
+		return {
+			path: configPath,
+			revision: revisionHash({
+				hermesProviderProjection: "yaml-merge",
+				patch: file.content,
+			}),
+		};
+	}
+
+	const pluginProjection = buildHermesHostedProviderPluginProjection(
+		projectionInput.catalog,
+		projectionInput.primaryModel,
+	);
+	const pluginDir = syncHermesModelProviderPlugin(home, pluginProjection.pluginFiles);
+	mergeHermesConfig(configPath, pluginProjection.modelPatch);
+	makeRuntimeUserOwned(configPath);
+	return {
+		path: pluginDir,
+		revision: pluginProjection.revision,
+	};
+}
+
+function detectHermesInstalledVersion(command: string, home: string, cwd: string): string | null {
+	const result = spawnRuntimeUserCommand(command, ["--version"], home, cwd);
+	if (result.status !== 0) return null;
+	const output = [result.stdout, result.stderr]
+		.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+		.join("\n");
+	const match = output.match(/v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)/);
+	return match?.[1] ?? null;
+}
+
+function supportsHermesModelProviderPlugins(version: string | null): boolean {
+	const parsed = parseSemverishVersion(version);
+	if (!parsed) return false;
+	return compareSemverParts(parsed, HERMES_MODEL_PROVIDER_PLUGIN_MIN_VERSION) >= 0;
+}
+
+function parseSemverishVersion(version: string | null): [number, number, number] | null {
+	if (!version) return null;
+	const match = version.match(/(\d+)\.(\d+)\.(\d+)/);
+	if (!match) return null;
+	const major = Number.parseInt(match[1] ?? "", 10);
+	const minor = Number.parseInt(match[2] ?? "", 10);
+	const patch = Number.parseInt(match[3] ?? "", 10);
+	if (![major, minor, patch].every((part) => Number.isInteger(part) && part >= 0)) {
+		return null;
+	}
+	return [major, minor, patch];
+}
+
+function compareSemverParts(
+	left: readonly [number, number, number],
+	right: readonly [number, number, number],
+): number {
+	const [leftMajor, leftMinor, leftPatch] = left;
+	const [rightMajor, rightMinor, rightPatch] = right;
+	return leftMajor - rightMajor || leftMinor - rightMinor || leftPatch - rightPatch;
+}
+
+function buildHermesHostedProviderPluginProjection(
+	catalog: AiProviderCatalog,
+	primaryModel: AgentPrimaryModel,
+): HermesHostedProviderPluginProjection {
+	if (catalog.providers.length !== 1) {
+		throw new Error(
+			`Hermes model-provider plugin projection currently supports exactly one provider for hosted runtimes; got ${catalog.providers.length}.`,
+		);
+	}
+	const provider = catalog.providers.find((entry) => entry.id === primaryModel.provider_id);
+	if (!provider) {
+		throw new Error(
+			`Hermes hosted provider projection cannot find primary provider ${primaryModel.provider_id}.`,
+		);
+	}
+	const envName = provider.runtime_env_name?.trim();
+	if (!envName || !isEnvKey(envName)) {
+		throw new Error(
+			`Hermes model-provider plugin projection requires a valid runtime_env_name for ${provider.id}.`,
+		);
+	}
+	if (provider.auth.type !== "api_key") {
+		throw new Error(
+			`Hermes model-provider plugin projection requires api_key auth for ${provider.id}; got ${provider.auth.type}.`,
+		);
+	}
+	const providerApiMode = provider.api_mode;
+	if (!providerApiMode) {
+		throw new Error(
+			`Hermes model-provider plugin projection requires api_mode for ${provider.id}.`,
+		);
+	}
+	const apiMode = HERMES_PROVIDER_PROFILE_API_MODES[providerApiMode];
+	if (!apiMode) {
+		throw new Error(
+			`Hermes model-provider plugin projection does not support api_mode ${providerApiMode} for ${provider.id}.`,
+		);
+	}
+
+	const primaryModelDetails = hermesHostedPrimaryModelDetails(provider, primaryModel.model);
+	const fallbackModels = hermesHostedFallbackModels(provider, primaryModel.model);
+	const displayName = provider.label?.trim() || "Clawdi";
+	const description = provider.label?.trim()
+		? `${provider.label.trim()} projected by Clawdi runtime converge`
+		: "Clawdi hosted AI provider projection";
+	const aliases = provider.id !== HERMES_MODEL_PROVIDER_PLUGIN_NAME ? [provider.id] : [];
+	const profileArgs = [
+		`name=${pythonStringLiteral(HERMES_MODEL_PROVIDER_PLUGIN_NAME)}`,
+		...(aliases.length > 0 ? [`aliases=${pythonTupleLiteral(aliases)}`] : []),
+		`display_name=${pythonStringLiteral(displayName)}`,
+		`description=${pythonStringLiteral(description)}`,
+		`env_vars=${pythonTupleLiteral([envName])}`,
+		`base_url=${pythonStringLiteral(provider.base_url)}`,
+		'auth_type="api_key"',
+		`api_mode=${pythonStringLiteral(apiMode)}`,
+		...(fallbackModels.length > 0 ? [`fallback_models=${pythonTupleLiteral(fallbackModels)}`] : []),
+	];
+	const pluginFiles: ProjectionFile[] = [
+		{
+			path: "__init__.py",
+			content: [
+				'"""Clawdi hosted AI provider projection."""',
+				"",
+				"from providers import register_provider",
+				"from providers.base import ProviderProfile",
+				"",
+				"register_provider(",
+				"    ProviderProfile(",
+				...profileArgs.map((line) => `        ${line},`),
+				"    )",
+				")",
+				"",
+			].join("\n"),
+		},
+		{
+			path: "plugin.yaml",
+			content: [
+				`name: ${quoteYaml(HERMES_MODEL_PROVIDER_PLUGIN_NAME)}`,
+				"kind: model-provider",
+				`version: ${quoteYaml(HERMES_MODEL_PROVIDER_PLUGIN_VERSION)}`,
+				'description: "Clawdi hosted AI provider projection"',
+				'author: "Clawdi"',
+				"",
+			].join("\n"),
+		},
+	];
+	const modelPatch = buildHermesHostedPluginModelPatch(
+		primaryModel,
+		primaryModelDetails,
+		catalog.providers.map((entry) => entry.id),
+	);
+	return {
+		modelPatch,
+		pluginFiles,
+		revision: revisionHash({
+			hermesProviderProjection: "plugin",
+			modelPatch,
+			pluginFiles,
+		}),
+	};
+}
+
+function buildHermesHostedPluginModelPatch(
+	primaryModel: AgentPrimaryModel,
+	primaryModelDetails: {
+		context_length?: number;
+		max_tokens?: number;
+		supports_vision?: boolean;
+	},
+	providerIdsToDelete: string[],
+): string {
+	const lines = [
+		"# Generated by Clawdi. Merge this patch into Hermes config.yaml.",
+		"# Contract: Hermes Agent 0.13.0+ discovers model-provider plugins from",
+		`# $HERMES_HOME/plugins/model-providers/${HERMES_MODEL_PROVIDER_PLUGIN_NAME}/.`,
+		"model:",
+		`  provider: ${quoteYaml(HERMES_MODEL_PROVIDER_PLUGIN_NAME)}`,
+		`  default: ${quoteYaml(primaryModel.model)}`,
+	];
+	if (primaryModelDetails.context_length !== undefined) {
+		lines.push(`  context_length: ${primaryModelDetails.context_length}`);
+	}
+	if (primaryModelDetails.max_tokens !== undefined) {
+		lines.push(`  max_tokens: ${primaryModelDetails.max_tokens}`);
+	}
+	if (primaryModelDetails.supports_vision !== undefined) {
+		lines.push(`  supports_vision: ${primaryModelDetails.supports_vision}`);
+	}
+	const deletions = [...new Set(providerIdsToDelete)].sort();
+	if (deletions.length > 0) {
+		lines.push("providers:");
+		for (const providerId of deletions) {
+			lines.push(`  ${quoteYaml(providerId)}: null`);
+		}
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+function hermesHostedPrimaryModelDetails(
+	provider: AiProviderCatalog["providers"][number],
+	modelId: string,
+): { context_length?: number; max_tokens?: number; supports_vision?: boolean } {
+	const model = provider.models?.find((entry) => entry.id === modelId);
+	return {
+		context_length: positiveInteger(model?.context_window),
+		max_tokens: positiveInteger(model?.max_tokens),
+		supports_vision: hermesHostedSupportsVision(model),
+	};
+}
+
+function hermesHostedFallbackModels(
+	provider: AiProviderCatalog["providers"][number],
+	primaryModelId: string,
+): string[] {
+	const ordered = [
+		primaryModelId,
+		...(provider.models ?? []).map((entry) => entry.id).filter((value) => value.trim().length > 0),
+	];
+	return ordered.filter((value, index, entries) => entries.indexOf(value) === index);
+}
+
+function hermesHostedSupportsVision(
+	model: NonNullable<AiProviderCatalog["providers"][number]["models"]>[number] | undefined,
+): boolean | undefined {
+	if (!model) return undefined;
+	if (typeof model.supports_vision === "boolean") return model.supports_vision;
+	return model.input_modalities?.includes("image") ? true : undefined;
+}
+
+function positiveInteger(value: number | undefined): number | undefined {
+	return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+function pythonStringLiteral(value: string): string {
+	return JSON.stringify(value);
+}
+
+function pythonTupleLiteral(values: readonly string[]): string {
+	if (values.length === 0) return "()";
+	return `(${values.map((value) => pythonStringLiteral(value)).join(", ")}${
+		values.length === 1 ? "," : ""
+	})`;
+}
+
+function quoteYaml(value: string): string {
+	return JSON.stringify(value);
+}
+
+function hermesModelProviderPluginDir(home: string): string {
+	return join(home, ".hermes", "plugins", "model-providers", HERMES_MODEL_PROVIDER_PLUGIN_NAME);
+}
+
+function syncHermesModelProviderPlugin(home: string, files: ProjectionFile[]): string {
+	const pluginsDir = join(home, ".hermes", "plugins");
+	const providersDir = join(pluginsDir, "model-providers");
+	const pluginDir = hermesModelProviderPluginDir(home);
+	rmSync(pluginDir, { recursive: true, force: true });
+	makeRuntimeUserPrivateDir(pluginsDir);
+	makeRuntimeUserPrivateDir(providersDir);
+	makeRuntimeUserPrivateDir(pluginDir);
+	for (const file of files) {
+		const path = join(pluginDir, file.path);
+		writePrivateFileAtomic(path, file.content);
+		makeRuntimeUserOwned(path);
+	}
+	return pluginDir;
+}
+
+function removeHermesModelProviderPlugin(home: string): void {
+	rmSync(hermesModelProviderPluginDir(home), { recursive: true, force: true });
 }
 
 function applyOpenClawHostedProviderProjection(
@@ -1808,6 +2126,46 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function runtimeUserCommandEnv(home: string): NodeJS.ProcessEnv {
+	return {
+		...process.env,
+		HOME: home,
+		PATH: [join(home, ".local", "bin"), join(home, ".openclaw", "bin"), process.env.PATH]
+			.filter(Boolean)
+			.join(":"),
+	};
+}
+
+function spawnRuntimeUserCommand(
+	command: string,
+	args: string[],
+	home: string,
+	cwd: string,
+): ReturnType<typeof spawnSync> {
+	const env = runtimeUserCommandEnv(home);
+	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
+	if (runningAsRoot() && runtimeUser && runtimeUser !== "root") {
+		if (commandExists("gosu")) {
+			return spawnSync("gosu", [runtimeUser, command, ...args], {
+				env: { ...env, USER: runtimeUser, LOGNAME: runtimeUser },
+				cwd,
+				encoding: "utf8",
+			});
+		}
+		if (commandExists("runuser")) {
+			return spawnSync(
+				"runuser",
+				["-u", runtimeUser, "--", "env", `HOME=${home}`, `PATH=${env.PATH}`, command, ...args],
+				{ env, cwd, encoding: "utf8" },
+			);
+		}
+		throw new Error(
+			`runtime init is running as root but cannot drop to CLAWDI_RUNTIME_USER=${runtimeUser}; install gosu or runuser`,
+		);
+	}
+	return spawnSync(command, args, { env, cwd, encoding: "utf8" });
+}
+
 function runRuntimeUserCommand(
 	command: string,
 	args: string[],
@@ -1815,13 +2173,7 @@ function runRuntimeUserCommand(
 	home: string,
 	cwd: string,
 ): void {
-	const env = {
-		...process.env,
-		HOME: home,
-		PATH: [join(home, ".local", "bin"), join(home, ".openclaw", "bin"), process.env.PATH]
-			.filter(Boolean)
-			.join(":"),
-	};
+	const env = runtimeUserCommandEnv(home);
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
 	if (runningAsRoot() && runtimeUser && runtimeUser !== "root") {
 		if (commandExists("gosu")) {
@@ -2148,12 +2500,14 @@ export function runtimeProgramRevision(
 	manifest: RuntimeManifest,
 	runtime: string,
 	secretValues: Record<string, string> | undefined,
+	providerProjectionRevision: string | null = null,
 ): string {
 	return revisionHash({
 		clawdiCli: manifest.clawdiCli ?? null,
 		controlPlane: manifest.controlPlane,
 		mitmProfiles: manifest.mitmProfiles ?? null,
 		projection: manifest.projection ?? null,
+		providerProjectionRevision,
 		runtime: manifest.runtimes[runtime] ?? null,
 		secretValues: secretValues ?? {},
 	});
@@ -2295,10 +2649,16 @@ function runtimeSystemdProgramRevision(
 	manifest: RuntimeManifest,
 	program: RuntimeSystemdUserProgram,
 	secretValues: Record<string, string> | undefined,
+	providerProjectionRevisions: Partial<Record<string, string | null>> = {},
 ): string {
 	if (program.service)
 		return runtimeServiceProgramRevision(manifest, program.runtime, program.service);
-	return runtimeProgramRevision(manifest, program.runtime, secretValues);
+	return runtimeProgramRevision(
+		manifest,
+		program.runtime,
+		secretValues,
+		providerProjectionRevisions[program.runtime] ?? null,
+	);
 }
 
 function shouldRunRuntime(runtime: string, manifest: RuntimeManifest): boolean {
@@ -2801,6 +3161,7 @@ function writeSystemdUnits(
 	workspaceRoot: string,
 	daemonAuthTokenFile: string | null,
 	secretValues: Record<string, string> | undefined,
+	providerProjectionRevisions: Partial<Record<string, string | null>>,
 ): { systemUnits: string[]; userUnits: string[]; serviceInstallErrors: string[] } {
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
 	const runtimeBridgeToken = hostedRuntimeBridgeToken();
@@ -2921,7 +3282,12 @@ function writeSystemdUnits(
 			...commonEnvironment,
 			...program.env,
 			CLAWDI_AUTH_TOKEN: "",
-			CLAWDI_RUNTIME_REV: runtimeSystemdProgramRevision(manifest, program, secretValues),
+			CLAWDI_RUNTIME_REV: runtimeSystemdProgramRevision(
+				manifest,
+				program,
+				secretValues,
+				providerProjectionRevisions,
+			),
 			...(officialRuntimeServiceDescriptorForProgram(program)?.unitEnv?.(unitName) ?? {}),
 		};
 		if (officialRuntimeServiceInstallArgs(program)) {
@@ -3091,6 +3457,7 @@ export function convergeRuntimeManifest(
 	writeProviderHealthStatus(manifest, load.secretValues, paths);
 	const liveSyncEnvironments = writeLiveSyncEnvironmentFiles(manifest, paths);
 	const writtenRunConfigIds = new Set<string>();
+	const providerProjectionRevisions: Partial<Record<string, string | null>> = {};
 
 	for (const [name, runtime] of Object.entries(manifest.runtimes).sort(([a], [b]) =>
 		a.localeCompare(b),
@@ -3128,7 +3495,13 @@ export function convergeRuntimeManifest(
 		writeJsonFile(projectionPath, projectionPayload(name, manifest));
 		projections.push(projectionPath);
 		try {
-			applyHostedAiProviderProjection(name, observation, manifest, workspaceRoot);
+			const providerProjection = applyHostedAiProviderProjection(
+				name,
+				observation,
+				manifest,
+				workspaceRoot,
+			);
+			providerProjectionRevisions[name] = providerProjection.revision;
 		} catch (error) {
 			installErrors.push(
 				`runtime ${name} provider projection failed: ${
@@ -3244,6 +3617,7 @@ export function convergeRuntimeManifest(
 		workspaceRoot,
 		daemonAuthTokenFile,
 		load.secretValues,
+		providerProjectionRevisions,
 	);
 	installErrors.push(...systemdUnits.serviceInstallErrors);
 

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -26,6 +26,7 @@ import type {
 	AiProviderType,
 } from "@clawdi/shared";
 import { isAiProviderApiMode, isAiProviderType } from "@clawdi/shared";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { z } from "zod";
 import {
 	type AgentPrimaryModel,
@@ -1371,9 +1372,24 @@ interface HermesHostedProviderPluginProjection {
 	revision: string;
 }
 
+interface HermesHostedPluginProviderProfile {
+	description: string;
+	displayName: string;
+	envName: string;
+	fallbackModels: string[];
+	pluginProviderName: string;
+	primaryModelDetails: {
+		context_length?: number;
+		max_tokens?: number;
+		supports_vision?: boolean;
+	} | null;
+	provider: AiProviderCatalog["providers"][number];
+	providerApiMode: string;
+}
+
 const HERMES_MODEL_PROVIDER_PLUGIN_NAME = "clawdi";
 const HERMES_MODEL_PROVIDER_PLUGIN_VERSION = "1.0.0";
-const HERMES_MODEL_PROVIDER_PLUGIN_MIN_VERSION = [0, 13, 0] as const;
+const HERMES_MODEL_PROVIDER_PLUGIN_MIN_VERSION = [0, 18, 0] as const;
 const HERMES_PROVIDER_PROFILE_API_MODES: Partial<Record<AiProviderApiMode, string>> = {
 	openai_chat: "chat_completions",
 	openai_responses: "codex_responses",
@@ -1504,17 +1520,57 @@ function buildHermesHostedProviderPluginProjection(
 	catalog: AiProviderCatalog,
 	primaryModel: AgentPrimaryModel,
 ): HermesHostedProviderPluginProjection {
-	if (catalog.providers.length !== 1) {
-		throw new Error(
-			`Hermes model-provider plugin projection currently supports exactly one provider for hosted runtimes; got ${catalog.providers.length}.`,
-		);
-	}
-	const provider = catalog.providers.find((entry) => entry.id === primaryModel.provider_id);
-	if (!provider) {
+	const profiles = catalog.providers.map((provider) =>
+		buildHermesHostedPluginProviderProfile(
+			provider,
+			provider.id === primaryModel.provider_id ? primaryModel.model : null,
+		),
+	);
+	const primaryProvider = profiles.find((entry) => entry.provider.id === primaryModel.provider_id);
+	if (!primaryProvider?.primaryModelDetails) {
 		throw new Error(
 			`Hermes hosted provider projection cannot find primary provider ${primaryModel.provider_id}.`,
 		);
 	}
+	const pluginFiles: ProjectionFile[] = [
+		{
+			path: "__init__.py",
+			content: buildHermesHostedPluginInit(profiles),
+		},
+		{
+			path: "plugin.yaml",
+			content: [
+				`name: ${quoteYaml(HERMES_MODEL_PROVIDER_PLUGIN_NAME)}`,
+				"kind: model-provider",
+				`version: ${quoteYaml(HERMES_MODEL_PROVIDER_PLUGIN_VERSION)}`,
+				'description: "Clawdi hosted AI provider projection"',
+				'author: "Clawdi"',
+				"",
+			].join("\n"),
+		},
+	];
+	const compatibilityProviders = buildHermesHostedCompatibilityProviders(catalog, primaryModel);
+	const modelPatch = buildHermesHostedPluginModelPatch(
+		primaryModel,
+		primaryProvider.pluginProviderName,
+		primaryProvider.primaryModelDetails,
+		compatibilityProviders,
+	);
+	return {
+		modelPatch,
+		pluginFiles,
+		revision: revisionHash({
+			hermesProviderProjection: "plugin",
+			modelPatch,
+			pluginFiles,
+		}),
+	};
+}
+
+function buildHermesHostedPluginProviderProfile(
+	provider: AiProviderCatalog["providers"][number],
+	primaryModelId: string | null,
+): HermesHostedPluginProviderProfile {
 	const envName = provider.runtime_env_name?.trim();
 	if (!envName || !isEnvKey(envName)) {
 		throw new Error(
@@ -1539,103 +1595,100 @@ function buildHermesHostedProviderPluginProjection(
 		);
 	}
 
-	const primaryModelDetails = hermesHostedPrimaryModelDetails(provider, primaryModel.model);
-	const fallbackModels = hermesHostedFallbackModels(provider, primaryModel.model);
-	const displayName = provider.label?.trim() || "Clawdi";
-	const description = provider.label?.trim()
-		? `${provider.label.trim()} projected by Clawdi runtime converge`
-		: "Clawdi hosted AI provider projection";
-	const aliases = provider.id !== HERMES_MODEL_PROVIDER_PLUGIN_NAME ? [provider.id] : [];
-	const profileArgs = [
-		`name=${pythonStringLiteral(HERMES_MODEL_PROVIDER_PLUGIN_NAME)}`,
-		...(aliases.length > 0 ? [`aliases=${pythonTupleLiteral(aliases)}`] : []),
-		`display_name=${pythonStringLiteral(displayName)}`,
-		`description=${pythonStringLiteral(description)}`,
-		`env_vars=${pythonTupleLiteral([envName])}`,
-		`base_url=${pythonStringLiteral(provider.base_url)}`,
-		'auth_type="api_key"',
-		`api_mode=${pythonStringLiteral(apiMode)}`,
-		...(fallbackModels.length > 0 ? [`fallback_models=${pythonTupleLiteral(fallbackModels)}`] : []),
-	];
-	const pluginFiles: ProjectionFile[] = [
-		{
-			path: "__init__.py",
-			content: [
-				'"""Clawdi hosted AI provider projection."""',
-				"",
-				"from providers import register_provider",
-				"from providers.base import ProviderProfile",
-				"",
-				"register_provider(",
-				"    ProviderProfile(",
-				...profileArgs.map((line) => `        ${line},`),
-				"    )",
-				")",
-				"",
-			].join("\n"),
-		},
-		{
-			path: "plugin.yaml",
-			content: [
-				`name: ${quoteYaml(HERMES_MODEL_PROVIDER_PLUGIN_NAME)}`,
-				"kind: model-provider",
-				`version: ${quoteYaml(HERMES_MODEL_PROVIDER_PLUGIN_VERSION)}`,
-				'description: "Clawdi hosted AI provider projection"',
-				'author: "Clawdi"',
-				"",
-			].join("\n"),
-		},
-	];
-	const modelPatch = buildHermesHostedPluginModelPatch(
-		primaryModel,
-		primaryModelDetails,
-		catalog.providers.map((entry) => entry.id),
-	);
+	const displayName = provider.label?.trim() || provider.id;
 	return {
-		modelPatch,
-		pluginFiles,
-		revision: revisionHash({
-			hermesProviderProjection: "plugin",
-			modelPatch,
-			pluginFiles,
-		}),
+		description: `${displayName} projected by Clawdi runtime converge`,
+		displayName,
+		envName,
+		fallbackModels: hermesHostedFallbackModels(provider, primaryModelId),
+		pluginProviderName: hermesHostedPluginProviderName(provider.id),
+		primaryModelDetails:
+			primaryModelId === null ? null : hermesHostedPrimaryModelDetails(provider, primaryModelId),
+		provider,
+		providerApiMode: apiMode,
 	};
+}
+
+function buildHermesHostedPluginInit(
+	profiles: readonly HermesHostedPluginProviderProfile[],
+): string {
+	const lines = [
+		'"""Clawdi hosted AI provider projection."""',
+		"",
+		"from providers import register_provider",
+		"from providers.base import ProviderProfile",
+		"",
+	];
+	for (const profile of profiles) {
+		const profileArgs = [
+			`name=${pythonStringLiteral(profile.pluginProviderName)}`,
+			`display_name=${pythonStringLiteral(profile.displayName)}`,
+			`description=${pythonStringLiteral(profile.description)}`,
+			`env_vars=${pythonTupleLiteral([profile.envName])}`,
+			`base_url=${pythonStringLiteral(profile.provider.base_url)}`,
+			'auth_type="api_key"',
+			`api_mode=${pythonStringLiteral(profile.providerApiMode)}`,
+			...(profile.fallbackModels.length > 0
+				? [`fallback_models=${pythonTupleLiteral(profile.fallbackModels)}`]
+				: []),
+		];
+		lines.push(
+			"register_provider(",
+			"    ProviderProfile(",
+			...profileArgs.map((line) => `        ${line},`),
+			"    )",
+			")",
+			"",
+		);
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+function buildHermesHostedCompatibilityProviders(
+	catalog: AiProviderCatalog,
+	primaryModel: AgentPrimaryModel,
+): Record<string, unknown> {
+	const legacyProjection = buildAgentTargetProjection("hermes", catalog, primaryModel);
+	const file = legacyProjection.files.find((entry) => entry.path.endsWith(".hermes.yaml"));
+	if (!file) {
+		throw new Error("Hermes projection did not include a config merge YAML file.");
+	}
+	const parsed = parseYaml(file.content);
+	if (!isPlainRecord(parsed)) {
+		throw new Error("Hermes hosted compatibility projection must be a YAML object.");
+	}
+	return isPlainRecord(parsed.providers) ? parsed.providers : {};
 }
 
 function buildHermesHostedPluginModelPatch(
 	primaryModel: AgentPrimaryModel,
+	primaryPluginProviderName: string,
 	primaryModelDetails: {
 		context_length?: number;
 		max_tokens?: number;
 		supports_vision?: boolean;
 	},
-	providerIdsToDelete: string[],
+	compatibilityProviders: Record<string, unknown>,
 ): string {
-	const lines = [
+	const patch: Record<string, unknown> = {
+		model: {
+			provider: primaryPluginProviderName,
+			default: primaryModel.model,
+			context_length: primaryModelDetails.context_length ?? null,
+			max_tokens: primaryModelDetails.max_tokens ?? null,
+			supports_vision: primaryModelDetails.supports_vision ?? null,
+		},
+	};
+	if (Object.keys(compatibilityProviders).length > 0) {
+		patch.providers = compatibilityProviders;
+	}
+	return [
 		"# Generated by Clawdi. Merge this patch into Hermes config.yaml.",
-		"# Contract: Hermes Agent 0.13.0+ discovers model-provider plugins from",
+		"# Contract: Hermes Agent 0.18.x discovers model-provider plugins from",
 		`# $HERMES_HOME/plugins/model-providers/${HERMES_MODEL_PROVIDER_PLUGIN_NAME}/.`,
-		"model:",
-		`  provider: ${quoteYaml(HERMES_MODEL_PROVIDER_PLUGIN_NAME)}`,
-		`  default: ${quoteYaml(primaryModel.model)}`,
-	];
-	if (primaryModelDetails.context_length !== undefined) {
-		lines.push(`  context_length: ${primaryModelDetails.context_length}`);
-	}
-	if (primaryModelDetails.max_tokens !== undefined) {
-		lines.push(`  max_tokens: ${primaryModelDetails.max_tokens}`);
-	}
-	if (primaryModelDetails.supports_vision !== undefined) {
-		lines.push(`  supports_vision: ${primaryModelDetails.supports_vision}`);
-	}
-	const deletions = [...new Set(providerIdsToDelete)].sort();
-	if (deletions.length > 0) {
-		lines.push("providers:");
-		for (const providerId of deletions) {
-			lines.push(`  ${quoteYaml(providerId)}: null`);
-		}
-	}
-	return `${lines.join("\n")}\n`;
+		stringifyYaml(patch).trimEnd(),
+		"",
+	].join("\n");
 }
 
 function hermesHostedPrimaryModelDetails(
@@ -1652,10 +1705,10 @@ function hermesHostedPrimaryModelDetails(
 
 function hermesHostedFallbackModels(
 	provider: AiProviderCatalog["providers"][number],
-	primaryModelId: string,
+	primaryModelId: string | null,
 ): string[] {
 	const ordered = [
-		primaryModelId,
+		...(primaryModelId ? [primaryModelId] : []),
 		...(provider.models ?? []).map((entry) => entry.id).filter((value) => value.trim().length > 0),
 	];
 	return ordered.filter((value, index, entries) => entries.indexOf(value) === index);
@@ -1686,6 +1739,15 @@ function pythonTupleLiteral(values: readonly string[]): string {
 
 function quoteYaml(value: string): string {
 	return JSON.stringify(value);
+}
+
+function hermesHostedPluginProviderName(providerId: string): string {
+	const normalized = providerId
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return `${HERMES_MODEL_PROVIDER_PLUGIN_NAME}-${normalized || "provider"}`;
 }
 
 function hermesModelProviderPluginDir(home: string): string {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -26,7 +26,7 @@ import type {
 	AiProviderType,
 } from "@clawdi/shared";
 import { isAiProviderApiMode, isAiProviderType } from "@clawdi/shared";
-import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { stringify as stringifyYaml } from "yaml";
 import { z } from "zod";
 import {
 	type AgentPrimaryModel,
@@ -1549,7 +1549,7 @@ function buildHermesHostedProviderPluginProjection(
 			].join("\n"),
 		},
 	];
-	const compatibilityProviders = buildHermesHostedCompatibilityProviders(catalog, primaryModel);
+	const compatibilityProviders = buildHermesHostedCompatibilityProviders(profiles);
 	const modelPatch = buildHermesHostedPluginModelPatch(
 		primaryModel,
 		primaryProvider.pluginProviderName,
@@ -1645,19 +1645,40 @@ function buildHermesHostedPluginInit(
 }
 
 function buildHermesHostedCompatibilityProviders(
-	catalog: AiProviderCatalog,
-	primaryModel: AgentPrimaryModel,
+	profiles: readonly HermesHostedPluginProviderProfile[],
 ): Record<string, unknown> {
-	const legacyProjection = buildAgentTargetProjection("hermes", catalog, primaryModel);
-	const file = legacyProjection.files.find((entry) => entry.path.endsWith(".hermes.yaml"));
-	if (!file) {
-		throw new Error("Hermes projection did not include a config merge YAML file.");
+	const providers: Record<string, unknown> = {};
+	for (const profile of profiles) {
+		const models = buildHermesHostedCompatibilityProviderModels(profile.provider);
+		providers[profile.pluginProviderName] =
+			Object.keys(models).length > 0
+				? {
+						api: profile.provider.base_url,
+						models,
+					}
+				: {
+						models: null,
+					};
 	}
-	const parsed = parseYaml(file.content);
-	if (!isPlainRecord(parsed)) {
-		throw new Error("Hermes hosted compatibility projection must be a YAML object.");
+	return providers;
+}
+
+function buildHermesHostedCompatibilityProviderModels(
+	provider: AiProviderCatalog["providers"][number],
+): Record<string, unknown> {
+	const models: Record<string, unknown> = {};
+	for (const model of provider.models ?? []) {
+		const modelId = model.id.trim();
+		if (!modelId || Object.hasOwn(models, modelId)) continue;
+		const metadata: Record<string, unknown> = {};
+		const contextLength = positiveInteger(model.context_window);
+		if (contextLength !== undefined) metadata.context_length = contextLength;
+		const supportsVision = hermesHostedSupportsVision(model);
+		if (supportsVision !== undefined) metadata.supports_vision = supportsVision;
+		if (Object.keys(metadata).length === 0) continue;
+		models[modelId] = metadata;
 	}
-	return isPlainRecord(parsed.providers) ? parsed.providers : {};
+	return models;
 }
 
 function buildHermesHostedPluginModelPatch(

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -263,6 +263,97 @@ function systemdEnvRevision(envFile: string): string {
 	return match?.[1] ?? "";
 }
 
+function hermesModelProviderPluginDir(home: string): string {
+	return join(home, ".hermes", "plugins", "model-providers", "clawdi");
+}
+
+function readHermesModelProviderPluginFile(
+	home: string,
+	name: "__init__.py" | "plugin.yaml",
+): string {
+	return readFileSync(join(hermesModelProviderPluginDir(home), name), "utf-8");
+}
+
+function writeHermesVersionBinary(home: string, version: string): string {
+	const hermesBin = join(home, ".local", "bin", "hermes");
+	mkdirSync(dirname(hermesBin), { recursive: true });
+	writeFileSync(
+		hermesBin,
+		[
+			"#!/usr/bin/env bash",
+			"set -euo pipefail",
+			`if [ "\${1:-}" = "--version" ]; then`,
+			`  echo "Hermes Agent v${version} (2026-07-01)"`,
+			"  exit 0",
+			"fi",
+			"exit 0",
+			"",
+		].join("\n"),
+	);
+	chmodSync(hermesBin, 0o700);
+	return hermesBin;
+}
+
+function hostedHermesProviderLoad(home: string): RuntimeManifestLoad {
+	return {
+		source: "remote-datasource",
+		sourcePath: "https://runtime-source.test/desired-state",
+		offline: false,
+		secretValues: {
+			"provider.hermes.apiKey": "sk-hermes-provider",
+		},
+		manifest: {
+			schemaVersion: "clawdi.runtimeDesiredState.v1",
+			deploymentId: "dep_hermes_provider",
+			environmentId: "env_hermes_provider",
+			instanceId: "iid_hermes_provider",
+			generation: 1,
+			issuedAt: "2026-06-22T00:00:00Z",
+			workspaceRoot: join(home, "clawdi"),
+			controlPlane: { apiUrl: "https://cloud-api.test" },
+			runtimes: {
+				hermes: {
+					enabled: true,
+					install: {
+						authority: "official",
+						method: "official-installer",
+						url: "https://hermes-agent.nousresearch.com/install.sh",
+						home,
+						args: ["--skip-setup", "--skip-browser", "--non-interactive"],
+					},
+				},
+			},
+			projection: {
+				sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				system: { home },
+				providers: {
+					hermes: {
+						kind: "openai-compatible",
+						baseUrl: "https://hermes-provider.example.test/v1",
+						model: "kimi/kimi-for-coding",
+						models: [
+							{
+								id: "kimi/kimi-for-coding",
+								context_window: 262144,
+								max_tokens: 32768,
+								input_modalities: ["text", "image"],
+								supports_vision: true,
+								supports_tools: true,
+								supports_reasoning: true,
+							},
+						],
+						apiMode: "openai_chat",
+						runtimeEnvName: "HERMES_PROVIDER_API_KEY",
+						apiKeySecretRef: "provider.hermes.apiKey",
+					},
+				},
+			},
+			mitmProfiles: { profiles: [] },
+			recovery: { cacheManifest: true, allowOfflineBoot: true },
+		},
+	};
+}
+
 describe("runtime paths", () => {
 	it("uses ~/.clawdi in local mode", () => {
 		const home = join(root, "home", "alice");
@@ -1338,10 +1429,8 @@ chmod +x "$HOME/.local/bin/hermes"
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const openclawBin = join(home, ".openclaw", "bin", "openclaw");
-		const hermesBin = join(home, ".local", "bin", "hermes");
 		const openclawPatch = join(root, "openclaw-runtime-provider-patch.json");
 		mkdirSync(dirname(openclawBin), { recursive: true });
-		mkdirSync(dirname(hermesBin), { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
@@ -1358,9 +1447,8 @@ chmod +x "$HOME/.local/bin/hermes"
 				"",
 			].join("\n"),
 		);
-		writeFileSync(hermesBin, "#!/bin/sh\nexit 0\n");
 		chmodSync(openclawBin, 0o700);
-		chmodSync(hermesBin, 0o700);
+		writeHermesVersionBinary(home, "0.17.0");
 
 		const loaded: RuntimeManifestLoad = {
 			source: "remote-datasource",
@@ -1469,15 +1557,25 @@ chmod +x "$HOME/.local/bin/hermes"
 		});
 		expect(JSON.stringify(patch)).not.toContain("hermes-provider.example.test");
 		const hermesConfig = readFileSync(join(home, ".hermes", "config.yaml"), "utf-8");
-		expect(hermesConfig).toContain("provider: custom:hermes");
-		expect(hermesConfig).toContain("api: https://hermes-provider.example.test/v1");
-		expect(hermesConfig).toContain("default: kimi/kimi-for-coding");
-		expect(hermesConfig).toContain("models:");
-		expect(hermesConfig).toContain("kimi/kimi-for-coding:");
+		expect(hermesConfig).toMatch(/provider: "?clawdi"?/);
+		expect(hermesConfig).toMatch(/default: "?kimi\/kimi-for-coding"?/);
 		expect(hermesConfig).toContain("context_length: 262144");
 		expect(hermesConfig).toContain("max_tokens: 32768");
 		expect(hermesConfig).toContain("supports_vision: true");
+		expect(hermesConfig).not.toContain("provider: custom:hermes");
+		expect(hermesConfig).not.toContain("providers:");
 		expect(hermesConfig).not.toContain("openclaw-provider.example.test");
+		const hermesPlugin = readHermesModelProviderPluginFile(home, "__init__.py");
+		const hermesPluginYaml = readHermesModelProviderPluginFile(home, "plugin.yaml");
+		expect(hermesPlugin).toContain('name="clawdi"');
+		expect(hermesPlugin).toContain('aliases=("hermes",)');
+		expect(hermesPlugin).toContain('base_url="https://hermes-provider.example.test/v1"');
+		expect(hermesPlugin).toContain('env_vars=("HERMES_PROVIDER_API_KEY",)');
+		expect(hermesPlugin).toContain('auth_type="api_key"');
+		expect(hermesPlugin).toContain('api_mode="chat_completions"');
+		expect(hermesPlugin).toContain('fallback_models=("kimi/kimi-for-coding",)');
+		expect(hermesPluginYaml).toContain("kind: model-provider");
+		expect(hermesPluginYaml).toContain('name: "clawdi"');
 		const openclawRunConfig = JSON.parse(
 			readFileSync(join(state, "config", "run", "openclaw.json"), "utf-8"),
 		);
@@ -1492,6 +1590,96 @@ chmod +x "$HOME/.local/bin/hermes"
 		});
 		expect(JSON.stringify(openclawRunConfig)).not.toContain("provider.hermes.apiKey");
 		expect(JSON.stringify(hermesRunConfig)).not.toContain("provider.openclaw.apiKey");
+	});
+
+	it("reconverges the Hermes model-provider plugin idempotently", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		writeHermesVersionBinary(home, "0.17.0");
+		const loaded = hostedHermesProviderLoad(home);
+		const paths = getRuntimePaths();
+
+		convergeRuntimeManifest(loaded, paths);
+		const firstPlugin = readHermesModelProviderPluginFile(home, "__init__.py");
+		const firstPluginYaml = readHermesModelProviderPluginFile(home, "plugin.yaml");
+		const firstRevision = systemdEnvRevision(readSystemdEnvFile(paths, "clawdi-hermes"));
+
+		convergeRuntimeManifest(loaded, paths);
+
+		expect(readHermesModelProviderPluginFile(home, "__init__.py")).toBe(firstPlugin);
+		expect(readHermesModelProviderPluginFile(home, "plugin.yaml")).toBe(firstPluginYaml);
+		expect(systemdEnvRevision(readSystemdEnvFile(paths, "clawdi-hermes"))).toBe(firstRevision);
+	});
+
+	it("removes the converge-owned Hermes model-provider plugin when the provider projection disappears", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		writeHermesVersionBinary(home, "0.17.0");
+		const withProvider = hostedHermesProviderLoad(home);
+		const withoutProvider: RuntimeManifestLoad = {
+			...withProvider,
+			manifest: {
+				...withProvider.manifest,
+				projection: {
+					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					system: { home },
+				},
+			},
+		};
+		const paths = getRuntimePaths();
+
+		convergeRuntimeManifest(withProvider, paths);
+		const firstRevision = systemdEnvRevision(readSystemdEnvFile(paths, "clawdi-hermes"));
+		expect(existsSync(hermesModelProviderPluginDir(home))).toBe(true);
+
+		convergeRuntimeManifest(withoutProvider, paths);
+
+		expect(existsSync(hermesModelProviderPluginDir(home))).toBe(false);
+		expect(systemdEnvRevision(readSystemdEnvFile(paths, "clawdi-hermes"))).not.toBe(firstRevision);
+	});
+
+	it("falls back to Hermes config.yaml provider merges before 0.13.0 and changes revision when plugin support appears", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		writeHermesVersionBinary(home, "0.12.0");
+		const loaded = hostedHermesProviderLoad(home);
+		const paths = getRuntimePaths();
+
+		convergeRuntimeManifest(loaded, paths);
+
+		const yamlRevision = systemdEnvRevision(readSystemdEnvFile(paths, "clawdi-hermes"));
+		const fallbackConfig = readFileSync(join(home, ".hermes", "config.yaml"), "utf-8");
+		expect(fallbackConfig).toContain("provider: custom:hermes");
+		expect(fallbackConfig).toMatch(/api: "?https:\/\/hermes-provider\.example\.test\/v1"?/);
+		expect(existsSync(hermesModelProviderPluginDir(home))).toBe(false);
+
+		writeHermesVersionBinary(home, "0.13.0");
+		convergeRuntimeManifest(loaded, paths);
+
+		const pluginRevision = systemdEnvRevision(readSystemdEnvFile(paths, "clawdi-hermes"));
+		const pluginConfig = readFileSync(join(home, ".hermes", "config.yaml"), "utf-8");
+		expect(pluginConfig).toMatch(/provider: "?clawdi"?/);
+		expect(pluginConfig).not.toContain("provider: custom:hermes");
+		expect(existsSync(hermesModelProviderPluginDir(home))).toBe(true);
+		expect(pluginRevision).not.toBe(yamlRevision);
 	});
 
 	it("projects runtime-scoped Codex OAuth providers as native agent profiles", () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1584,10 +1584,11 @@ chmod +x "$HOME/.local/bin/hermes"
 		expect(hermesModel.max_tokens).toBe(32768);
 		expect(hermesModel.supports_vision).toBe(true);
 		const hermesProviders = expectRecord(hermesConfig.providers, "Hermes providers config");
-		const hermesProvider = expectRecord(hermesProviders.hermes, "Hermes provider config");
+		expect(hermesProviders.hermes).toBeUndefined();
+		const hermesProvider = expectRecord(hermesProviders["clawdi-hermes"], "Hermes provider config");
 		expect(hermesProvider.api).toBe("https://hermes-provider.example.test/v1");
-		expect(hermesProvider.transport).toBe("chat_completions");
-		expect(hermesProvider.key_env).toBe("HERMES_PROVIDER_API_KEY");
+		expect(hermesProvider.transport).toBeUndefined();
+		expect(hermesProvider.key_env).toBeUndefined();
 		const hermesProviderModels = expectRecord(
 			hermesProvider.models,
 			"Hermes provider model metadata",
@@ -1597,8 +1598,8 @@ chmod +x "$HOME/.local/bin/hermes"
 			"Hermes provider kimi model metadata",
 		);
 		expect(kimiModel.context_length).toBe(262144);
-		expect(kimiModel.max_tokens).toBe(32768);
 		expect(kimiModel.supports_vision).toBe(true);
+		expect(kimiModel.max_tokens).toBeUndefined();
 		const hermesPlugin = readHermesModelProviderPluginFile(home, "__init__.py");
 		const hermesPluginYaml = readHermesModelProviderPluginFile(home, "plugin.yaml");
 		expect(hermesPlugin).toContain('name="clawdi-hermes"');
@@ -1709,12 +1710,38 @@ chmod +x "$HOME/.local/bin/hermes"
 		const hermesModel = expectRecord(hermesConfig.model, "Hermes model config");
 		expect(hermesModel.provider).toBe("clawdi-hermes");
 		const hermesProviders = expectRecord(hermesConfig.providers, "Hermes providers config");
-		expect(expectRecord(hermesProviders.hermes, "primary Hermes provider").api).toBe(
-			"https://hermes-provider.example.test/v1",
+		expect(hermesProviders.hermes).toBeUndefined();
+		expect(hermesProviders.moonshot).toBeUndefined();
+		const primaryHermesProvider = expectRecord(
+			hermesProviders["clawdi-hermes"],
+			"primary Hermes provider",
 		);
-		expect(expectRecord(hermesProviders.moonshot, "secondary Hermes provider").api).toBe(
-			"https://moonshot-provider.example.test/v1",
+		expect(primaryHermesProvider.api).toBe("https://hermes-provider.example.test/v1");
+		expect(primaryHermesProvider.transport).toBeUndefined();
+		expect(primaryHermesProvider.key_env).toBeUndefined();
+		const primaryHermesModels = expectRecord(
+			primaryHermesProvider.models,
+			"primary Hermes provider models",
 		);
+		expect(
+			expectRecord(primaryHermesModels["kimi/kimi-for-coding"], "primary Hermes model metadata")
+				.context_length,
+		).toBe(262144);
+		const moonshotProvider = expectRecord(
+			hermesProviders["clawdi-moonshot"],
+			"secondary Hermes provider",
+		);
+		expect(moonshotProvider.api).toBe("https://moonshot-provider.example.test/v1");
+		expect(moonshotProvider.transport).toBeUndefined();
+		expect(moonshotProvider.key_env).toBeUndefined();
+		const moonshotModels = expectRecord(
+			moonshotProvider.models,
+			"secondary Hermes provider models",
+		);
+		expect(
+			expectRecord(moonshotModels["moonshot-v1-8k"], "secondary Hermes model metadata")
+				.context_length,
+		).toBe(8192);
 		const hermesRunConfig = JSON.parse(
 			readFileSync(join(state, "config", "run", "hermes.json"), "utf-8"),
 		);
@@ -1792,7 +1819,7 @@ chmod +x "$HOME/.local/bin/hermes"
 		expect(initialModelConfig.supports_vision).toBe(true);
 		const initialProviderModels = expectRecord(
 			expectRecord(
-				expectRecord(initialConfig.providers, "initial Hermes providers").hermes,
+				expectRecord(initialConfig.providers, "initial Hermes providers")["clawdi-hermes"],
 				"initial Hermes provider",
 			).models,
 			"initial Hermes provider models",
@@ -1812,11 +1839,9 @@ chmod +x "$HOME/.local/bin/hermes"
 		expect(hermesModel.context_length).toBeUndefined();
 		expect(hermesModel.max_tokens).toBeUndefined();
 		expect(hermesModel.supports_vision).toBeUndefined();
-		const hermesProvider = expectRecord(
-			expectRecord(hermesConfig.providers, "Hermes providers config").hermes,
-			"Hermes provider config",
-		);
-		expect(hermesProvider.models).toBeUndefined();
+		expect(
+			expectRecord(hermesConfig.providers, "Hermes providers config")["clawdi-hermes"],
+		).toBeUndefined();
 	});
 
 	it("falls back to Hermes config.yaml provider merges before 0.18.0 and changes revision when plugin support appears", () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -14,6 +14,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { parse as parseYaml } from "yaml";
 import { runtimeInit, runtimeWatch } from "../src/commands/runtime";
 import {
 	RUNTIME_BRIDGE_LISTEN_HOST_ENV,
@@ -272,6 +273,25 @@ function readHermesModelProviderPluginFile(
 	name: "__init__.py" | "plugin.yaml",
 ): string {
 	return readFileSync(join(hermesModelProviderPluginDir(home), name), "utf-8");
+}
+
+function readHermesConfigYaml(home: string): Record<string, unknown> {
+	const parsed = parseYaml(readFileSync(join(home, ".hermes", "config.yaml"), "utf-8"));
+	if (!isRecord(parsed)) {
+		throw new Error("Expected Hermes config.yaml to parse to a YAML object.");
+	}
+	return parsed;
+}
+
+function expectRecord(input: unknown, label: string): Record<string, unknown> {
+	if (!isRecord(input)) {
+		throw new Error(`Expected ${label} to be a YAML object.`);
+	}
+	return input;
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+	return typeof input === "object" && input !== null && !Array.isArray(input);
 }
 
 function writeHermesVersionBinary(home: string, version: string): string {
@@ -1448,7 +1468,7 @@ chmod +x "$HOME/.local/bin/hermes"
 			].join("\n"),
 		);
 		chmodSync(openclawBin, 0o700);
-		writeHermesVersionBinary(home, "0.17.0");
+		writeHermesVersionBinary(home, "0.18.0");
 
 		const loaded: RuntimeManifestLoad = {
 			source: "remote-datasource",
@@ -1556,19 +1576,32 @@ chmod +x "$HOME/.local/bin/hermes"
 			api: "openai-responses",
 		});
 		expect(JSON.stringify(patch)).not.toContain("hermes-provider.example.test");
-		const hermesConfig = readFileSync(join(home, ".hermes", "config.yaml"), "utf-8");
-		expect(hermesConfig).toMatch(/provider: "?clawdi"?/);
-		expect(hermesConfig).toMatch(/default: "?kimi\/kimi-for-coding"?/);
-		expect(hermesConfig).toContain("context_length: 262144");
-		expect(hermesConfig).toContain("max_tokens: 32768");
-		expect(hermesConfig).toContain("supports_vision: true");
-		expect(hermesConfig).not.toContain("provider: custom:hermes");
-		expect(hermesConfig).not.toContain("providers:");
-		expect(hermesConfig).not.toContain("openclaw-provider.example.test");
+		const hermesConfig = readHermesConfigYaml(home);
+		const hermesModel = expectRecord(hermesConfig.model, "Hermes model config");
+		expect(hermesModel.provider).toBe("clawdi-hermes");
+		expect(hermesModel.default).toBe("kimi/kimi-for-coding");
+		expect(hermesModel.context_length).toBe(262144);
+		expect(hermesModel.max_tokens).toBe(32768);
+		expect(hermesModel.supports_vision).toBe(true);
+		const hermesProviders = expectRecord(hermesConfig.providers, "Hermes providers config");
+		const hermesProvider = expectRecord(hermesProviders.hermes, "Hermes provider config");
+		expect(hermesProvider.api).toBe("https://hermes-provider.example.test/v1");
+		expect(hermesProvider.transport).toBe("chat_completions");
+		expect(hermesProvider.key_env).toBe("HERMES_PROVIDER_API_KEY");
+		const hermesProviderModels = expectRecord(
+			hermesProvider.models,
+			"Hermes provider model metadata",
+		);
+		const kimiModel = expectRecord(
+			hermesProviderModels["kimi/kimi-for-coding"],
+			"Hermes provider kimi model metadata",
+		);
+		expect(kimiModel.context_length).toBe(262144);
+		expect(kimiModel.max_tokens).toBe(32768);
+		expect(kimiModel.supports_vision).toBe(true);
 		const hermesPlugin = readHermesModelProviderPluginFile(home, "__init__.py");
 		const hermesPluginYaml = readHermesModelProviderPluginFile(home, "plugin.yaml");
-		expect(hermesPlugin).toContain('name="clawdi"');
-		expect(hermesPlugin).toContain('aliases=("hermes",)');
+		expect(hermesPlugin).toContain('name="clawdi-hermes"');
 		expect(hermesPlugin).toContain('base_url="https://hermes-provider.example.test/v1"');
 		expect(hermesPlugin).toContain('env_vars=("HERMES_PROVIDER_API_KEY",)');
 		expect(hermesPlugin).toContain('auth_type="api_key"');
@@ -1601,7 +1634,7 @@ chmod +x "$HOME/.local/bin/hermes"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		writeHermesVersionBinary(home, "0.17.0");
+		writeHermesVersionBinary(home, "0.18.0");
 		const loaded = hostedHermesProviderLoad(home);
 		const paths = getRuntimePaths();
 
@@ -1617,6 +1650,80 @@ chmod +x "$HOME/.local/bin/hermes"
 		expect(systemdEnvRevision(readSystemdEnvFile(paths, "clawdi-hermes"))).toBe(firstRevision);
 	});
 
+	it("registers multiple Hermes hosted providers in a single plugin projection", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		writeHermesVersionBinary(home, "0.18.0");
+		const loaded = hostedHermesProviderLoad(home);
+		loaded.secretValues = {
+			...loaded.secretValues,
+			"provider.moonshot.apiKey": "sk-moonshot-provider",
+		};
+		loaded.manifest.runtimes.hermes = {
+			...loaded.manifest.runtimes.hermes,
+			provider_ids: ["hermes", "moonshot"],
+			primary_model: {
+				provider_id: "hermes",
+				model: "kimi/kimi-for-coding",
+			},
+		};
+		loaded.manifest.projection = {
+			...loaded.manifest.projection,
+			providers: {
+				...loaded.manifest.projection?.providers,
+				moonshot: {
+					kind: "openai-compatible",
+					baseUrl: "https://moonshot-provider.example.test/v1",
+					model: "moonshot-v1-8k",
+					models: [
+						{
+							id: "moonshot-v1-8k",
+							context_window: 8192,
+							max_tokens: 4096,
+							supports_tools: true,
+						},
+					],
+					apiMode: "openai_chat",
+					runtimeEnvName: "MOONSHOT_PROVIDER_API_KEY",
+					apiKeySecretRef: "provider.moonshot.apiKey",
+				},
+			},
+		};
+
+		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
+
+		expect(convergence.installErrors).toEqual([]);
+		const hermesPlugin = readHermesModelProviderPluginFile(home, "__init__.py");
+		expect(hermesPlugin.match(/register_provider\(/g)?.length).toBe(2);
+		expect(hermesPlugin).toContain('name="clawdi-hermes"');
+		expect(hermesPlugin).toContain('name="clawdi-moonshot"');
+		expect(hermesPlugin).toContain('env_vars=("HERMES_PROVIDER_API_KEY",)');
+		expect(hermesPlugin).toContain('env_vars=("MOONSHOT_PROVIDER_API_KEY",)');
+		const hermesConfig = readHermesConfigYaml(home);
+		const hermesModel = expectRecord(hermesConfig.model, "Hermes model config");
+		expect(hermesModel.provider).toBe("clawdi-hermes");
+		const hermesProviders = expectRecord(hermesConfig.providers, "Hermes providers config");
+		expect(expectRecord(hermesProviders.hermes, "primary Hermes provider").api).toBe(
+			"https://hermes-provider.example.test/v1",
+		);
+		expect(expectRecord(hermesProviders.moonshot, "secondary Hermes provider").api).toBe(
+			"https://moonshot-provider.example.test/v1",
+		);
+		const hermesRunConfig = JSON.parse(
+			readFileSync(join(state, "config", "run", "hermes.json"), "utf-8"),
+		);
+		expect(hermesRunConfig.secretEnv).toEqual({
+			HERMES_PROVIDER_API_KEY: "secret://provider.hermes.apiKey",
+			MOONSHOT_PROVIDER_API_KEY: "secret://provider.moonshot.apiKey",
+		});
+	});
+
 	it("removes the converge-owned Hermes model-provider plugin when the provider projection disappears", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -1626,7 +1733,7 @@ chmod +x "$HOME/.local/bin/hermes"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		writeHermesVersionBinary(home, "0.17.0");
+		writeHermesVersionBinary(home, "0.18.0");
 		const withProvider = hostedHermesProviderLoad(home);
 		const withoutProvider: RuntimeManifestLoad = {
 			...withProvider,
@@ -1650,7 +1757,7 @@ chmod +x "$HOME/.local/bin/hermes"
 		expect(systemdEnvRevision(readSystemdEnvFile(paths, "clawdi-hermes"))).not.toBe(firstRevision);
 	});
 
-	it("falls back to Hermes config.yaml provider merges before 0.13.0 and changes revision when plugin support appears", () => {
+	it("removes stale Hermes hosted capability keys when later manifests omit them", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -1659,7 +1766,69 @@ chmod +x "$HOME/.local/bin/hermes"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		writeHermesVersionBinary(home, "0.12.0");
+		writeHermesVersionBinary(home, "0.18.0");
+		const withCapabilities = hostedHermesProviderLoad(home);
+		const withoutCapabilities: RuntimeManifestLoad = {
+			...withCapabilities,
+			manifest: {
+				...withCapabilities.manifest,
+				projection: {
+					...withCapabilities.manifest.projection,
+					providers: {
+						...withCapabilities.manifest.projection?.providers,
+						hermes: {
+							...withCapabilities.manifest.projection?.providers?.hermes,
+							models: [{ id: "kimi/kimi-for-coding" }],
+						},
+					},
+				},
+			},
+		};
+
+		convergeRuntimeManifest(withCapabilities, getRuntimePaths());
+		const initialConfig = readHermesConfigYaml(home);
+		const initialModelConfig = expectRecord(initialConfig.model, "initial Hermes model config");
+		expect(initialModelConfig.context_length).toBe(262144);
+		expect(initialModelConfig.supports_vision).toBe(true);
+		const initialProviderModels = expectRecord(
+			expectRecord(
+				expectRecord(initialConfig.providers, "initial Hermes providers").hermes,
+				"initial Hermes provider",
+			).models,
+			"initial Hermes provider models",
+		);
+		expect(
+			expectRecord(
+				initialProviderModels["kimi/kimi-for-coding"],
+				"initial Hermes provider kimi model",
+			).supports_vision,
+		).toBe(true);
+
+		const convergence = convergeRuntimeManifest(withoutCapabilities, getRuntimePaths());
+
+		expect(convergence.installErrors).toEqual([]);
+		const hermesConfig = readHermesConfigYaml(home);
+		const hermesModel = expectRecord(hermesConfig.model, "Hermes model config");
+		expect(hermesModel.context_length).toBeUndefined();
+		expect(hermesModel.max_tokens).toBeUndefined();
+		expect(hermesModel.supports_vision).toBeUndefined();
+		const hermesProvider = expectRecord(
+			expectRecord(hermesConfig.providers, "Hermes providers config").hermes,
+			"Hermes provider config",
+		);
+		expect(hermesProvider.models).toBeUndefined();
+	});
+
+	it("falls back to Hermes config.yaml provider merges before 0.18.0 and changes revision when plugin support appears", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		writeHermesVersionBinary(home, "0.17.0");
 		const loaded = hostedHermesProviderLoad(home);
 		const paths = getRuntimePaths();
 
@@ -1671,13 +1840,14 @@ chmod +x "$HOME/.local/bin/hermes"
 		expect(fallbackConfig).toMatch(/api: "?https:\/\/hermes-provider\.example\.test\/v1"?/);
 		expect(existsSync(hermesModelProviderPluginDir(home))).toBe(false);
 
-		writeHermesVersionBinary(home, "0.13.0");
+		writeHermesVersionBinary(home, "0.18.0");
 		convergeRuntimeManifest(loaded, paths);
 
 		const pluginRevision = systemdEnvRevision(readSystemdEnvFile(paths, "clawdi-hermes"));
-		const pluginConfig = readFileSync(join(home, ".hermes", "config.yaml"), "utf-8");
-		expect(pluginConfig).toMatch(/provider: "?clawdi"?/);
-		expect(pluginConfig).not.toContain("provider: custom:hermes");
+		const pluginConfig = readHermesConfigYaml(home);
+		expect(expectRecord(pluginConfig.model, "Hermes plugin model config").provider).toBe(
+			"clawdi-hermes",
+		);
 		expect(existsSync(hermesModelProviderPluginDir(home))).toBe(true);
 		expect(pluginRevision).not.toBe(yamlRevision);
 	});


### PR DESCRIPTION
## Summary
- migrate the v2 hosted Hermes managed-AI-provider projection to the official Hermes model-provider plugin contract for the hosted/latest path: Hermes `0.18.x` writes a converge-owned `$HERMES_HOME/plugins/model-providers/clawdi/{plugin.yaml,__init__.py}` plugin, while unknown/older installs keep the existing YAML merge only as a safety fallback
- keep `model:` selection, channel projection, MCP config merges, secret delivery, placeholder-key behavior, and the MITM sidecar path unchanged
- support multiple runtime-scoped hosted providers inside one generated Hermes plugin by registering one `ProviderProfile(...)` per provider and pointing `model.provider` at a generated canonical plugin provider name
- keep a minimal `config.yaml providers:` compatibility shadow alongside the plugin, keyed by the generated plugin provider names, so Hermes `0.18.x` continues to honor per-model compatibility metadata during runtime resolution without duplicating auth/env/transport fields
- keep the projection/revision hashing converge-owned so plugin-vs-YAML transitions and capability changes trigger the same restart path as config changes

## Notes
- Re-verified the hosted projection contract against Hermes `v2026.7.1` / `v0.18.0` only.
- At `v2026.7.1`, `ProviderProfile` exposes plugin fields such as `name`, `api_mode`, `aliases`, `display_name`, `description`, `env_vars`, `base_url`, `auth_type`, `supports_vision`, `supports_vision_tool_messages`, `fallback_models`, and `default_max_tokens` ([`providers/base.py#L38-L94`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/providers/base.py#L38-L94)).
- Plugin discovery still loads bundled plugin dirs first, then `$HERMES_HOME/plugins/model-providers/*`, then legacy `providers/*.py`, and `register_provider()` is last-writer-wins, so user plugins override bundled ones ([`providers/__init__.py#L53-L63`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/providers/__init__.py#L53-L63), [`providers/__init__.py#L140-L191`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/providers/__init__.py#L140-L191), [`tests/providers/test_plugin_discovery.py#L76-L115`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/tests/providers/test_plugin_discovery.py#L76-L115)).
- Hermes `0.18.0` reads `model.max_tokens` and `model.context_length` from the top-level `model:` block during agent init ([`agent/agent_init.py#L1452-L1536`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/agent/agent_init.py#L1452-L1536)).
- Hermes `0.18.0` also reads `model.supports_vision` from the top-level `model:` block first, then falls back to `providers.<provider>.models.<model>.supports_vision`, then models.dev. That per-provider fallback uses the active runtime provider key / `model.provider` value, so the compatibility shadow must be keyed by the generated plugin provider names (`clawdi-...`) rather than the legacy manifest ids ([`agent/image_routing.py#L183-L221`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/agent/image_routing.py#L183-L221), [`run_agent.py#L4827-L4840`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/run_agent.py#L4827-L4840)).
- Hermes `0.18.0` still resolves per-model context-length compatibility through the config `providers:` / `custom_providers` readers, with top-level `model.context_length` taking precedence over per-provider model metadata ([`agent/model_metadata.py#L1779-L1858`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/agent/model_metadata.py#L1779-L1858), [`hermes_cli/config.py#L4641-L4714`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/hermes_cli/config.py#L4641-L4714), [`tests/hermes_cli/test_custom_provider_context_length.py#L163-L206`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/tests/hermes_cli/test_custom_provider_context_length.py#L163-L206)).
- The minimal compatibility shadow at `v2026.7.1` is therefore `providers.<plugin-provider>.api` plus `providers.<plugin-provider>.models.<model>.{context_length,supports_vision}`. `api` is required because Hermes' config normalizer drops provider entries with no URL at all ([`hermes_cli/config.py#L4500-L4538`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/hermes_cli/config.py#L4500-L4538)), while no `v2026.7.1` compat reader was found that consumes per-model `max_tokens`, so that field stays top-level under `model.max_tokens` rather than being duplicated into the shadow.
- `ProviderProfile.default_max_tokens` and `ProviderProfile.supports_vision` are provider-level hooks, not a per-model replacement for the config capability paths above; `default_max_tokens` is only consulted after explicit/user `max_tokens`, and `supports_vision` is used by vision-tool provider checks rather than the active-model routing path ([`providers/base.py#L66-L94`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/providers/base.py#L66-L94), [`providers/base.py#L148-L160`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/providers/base.py#L148-L160), [`agent/transports/chat_completions.py#L505-L516`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/agent/transports/chat_completions.py#L505-L516), [`tools/vision_tools.py#L700-L707`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/tools/vision_tools.py#L700-L707)).

## Verification
- `bun run check`
- `bun run --cwd packages/cli test tests/runtime.test.ts`

## Upstream sources relied on
- Hermes upstream repo: https://github.com/NousResearch/hermes-agent
- Latest verified release boundary: `v2026.7.1` / Hermes Agent `v0.18.0` https://github.com/NousResearch/hermes-agent/releases/tag/v2026.7.1
- Official plugin profile contract: [`providers/base.py`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/providers/base.py)
- Official model-provider discovery order / precedence: [`providers/__init__.py`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/providers/__init__.py)
- Upstream override / user-plugin precedence tests: [`tests/providers/test_plugin_discovery.py`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/tests/providers/test_plugin_discovery.py)
- Agent init reads `model.max_tokens` / `model.context_length`: [`agent/agent_init.py`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/agent/agent_init.py)
- Vision capability override resolution: [`agent/image_routing.py`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/agent/image_routing.py), [`run_agent.py`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/run_agent.py)
- Context-length compatibility readers and provider normalizer: [`agent/model_metadata.py`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/agent/model_metadata.py), [`hermes_cli/config.py`](https://github.com/NousResearch/hermes-agent/blob/v2026.7.1/hermes_cli/config.py)
