### PR TITLE
feat(v2): channel link follow-ups — WA pairing on link, Hermes one-link rule, Hermes-WA gate

### DIFF
--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -290,7 +290,12 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 				</TabsList>
 
 				<TabsContent value="agents" className={LIST_TAB_CLASS}>
-					<AgentsTab accountId={id} accountName={ch.name} readOnly={providerUnavailable} />
+					<AgentsTab
+						accountId={id}
+						accountName={ch.name}
+						provider={ch.provider}
+						readOnly={providerUnavailable}
+					/>
 				</TabsContent>
 				{ch.provider === "whatsapp" && !providerUnavailable ? (
 					<TabsContent value="devices" className={FORM_TAB_CLASS}>
@@ -326,10 +331,12 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 function AgentsTab({
 	accountId,
 	accountName,
+	provider,
 	readOnly = false,
 }: {
 	accountId: string;
 	accountName: string;
+	provider: string;
 	readOnly?: boolean;
 }) {
 	const links = useChannelAgentLinks(accountId);
@@ -480,6 +487,7 @@ function AgentsTab({
 					onOpenChange={setLinkOpen}
 					accountId={accountId}
 					accountName={accountName}
+					provider={provider}
 				/>
 			)}
 		</div>

--- a/apps/web/src/hosted/v2/channels/channels-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channels-page.tsx
@@ -330,7 +330,11 @@ function SharedBotsSection({
 	onRetry: () => void;
 	filter: ProviderFilter;
 }) {
-	const [linkTarget, setLinkTarget] = useState<{ id: string; name: string } | null>(null);
+	const [linkTarget, setLinkTarget] = useState<{
+		id: string;
+		name: string;
+		provider: string;
+	} | null>(null);
 	const groups = poolGroups(providers, filter);
 	const visibleCount = groups.reduce((sum, group) => sum + group.items.length, 0);
 
@@ -372,7 +376,13 @@ function SharedBotsSection({
 									<PoolCard
 										key={item.id}
 										item={item}
-										onLink={() => setLinkTarget({ id: item.id, name: item.name })}
+										onLink={() =>
+											setLinkTarget({
+												id: item.id,
+												name: item.name,
+												provider: item.provider,
+											})
+										}
 									/>
 								))}
 							</div>
@@ -393,6 +403,7 @@ function SharedBotsSection({
 					onOpenChange={(open) => !open && setLinkTarget(null)}
 					accountId={linkTarget.id}
 					accountName={linkTarget.name}
+					provider={linkTarget.provider}
 				/>
 			) : null}
 		</section>

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import {
+	HERMES_WHATSAPP_UNSUPPORTED_MESSAGE,
+	linkAgentBlockReason,
+	shouldMintWhatsappTenantCredential,
+} from "./link-agent-dialog.logic";
+
+describe("linkAgentBlockReason", () => {
+	test("blocks WhatsApp for Hermes agents", () => {
+		expect(
+			linkAgentBlockReason({
+				provider: "whatsapp",
+				selectedAgent: { agent_type: "hermes" },
+				existingAgentLinks: [],
+				accountId: "wa-current",
+			}),
+		).toBe(HERMES_WHATSAPP_UNSUPPORTED_MESSAGE);
+	});
+
+	test("blocks a second Telegram or Discord link for Hermes agents", () => {
+		expect(
+			linkAgentBlockReason({
+				provider: "telegram",
+				selectedAgent: { agent_type: "hermes" },
+				existingAgentLinks: [
+					{
+						account_id: "tg-existing",
+						status: "active",
+						account: { provider: "telegram" },
+					},
+				],
+				accountId: "tg-current",
+			}),
+		).toContain("one-telegram-link-per-Hermes-agent");
+	});
+
+	test("allows the current existing link and non-Hermes multi-link behavior", () => {
+		expect(
+			linkAgentBlockReason({
+				provider: "telegram",
+				selectedAgent: { agent_type: "hermes" },
+				existingAgentLinks: [
+					{
+						account_id: "tg-current",
+						status: "active",
+						account: { provider: "telegram" },
+					},
+				],
+				accountId: "tg-current",
+			}),
+		).toBeNull();
+		expect(
+			linkAgentBlockReason({
+				provider: "telegram",
+				selectedAgent: { agent_type: "openclaw" },
+				existingAgentLinks: [
+					{
+						account_id: "tg-existing",
+						status: "active",
+						account: { provider: "telegram" },
+					},
+				],
+				accountId: "tg-current",
+			}),
+		).toBeNull();
+	});
+});
+
+describe("shouldMintWhatsappTenantCredential", () => {
+	test("mints only for non-Hermes WhatsApp links", () => {
+		expect(shouldMintWhatsappTenantCredential("whatsapp", { agent_type: "openclaw" })).toBe(true);
+		expect(shouldMintWhatsappTenantCredential("whatsapp", { agent_type: "hermes" })).toBe(false);
+		expect(shouldMintWhatsappTenantCredential("telegram", { agent_type: "openclaw" })).toBe(false);
+	});
+});

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.ts
@@ -1,0 +1,49 @@
+import type { components } from "@clawdi/shared/api";
+
+type Agent = Pick<components["schemas"]["AgentResponse"], "agent_type"> | null | undefined;
+type AgentChannelLink = {
+	account_id: string;
+	status: string;
+	account: {
+		provider: string;
+	};
+};
+
+export const HERMES_WHATSAPP_UNSUPPORTED_MESSAGE =
+	"WhatsApp for Hermes agents is coming soon - pending an upstream Hermes release.";
+
+const HERMES_SINGLE_LINK_PROVIDERS = new Set(["telegram", "discord"]);
+
+export function shouldMintWhatsappTenantCredential(provider: string, agent: Agent): boolean {
+	return (
+		provider === "whatsapp" &&
+		agent !== null &&
+		agent !== undefined &&
+		agent.agent_type !== "hermes"
+	);
+}
+
+export function linkAgentBlockReason({
+	provider,
+	selectedAgent,
+	existingAgentLinks,
+	accountId,
+}: {
+	provider: string;
+	selectedAgent: Agent;
+	existingAgentLinks: AgentChannelLink[];
+	accountId: string;
+}): string | null {
+	if (selectedAgent?.agent_type !== "hermes") return null;
+	if (provider === "whatsapp") return HERMES_WHATSAPP_UNSUPPORTED_MESSAGE;
+	if (!HERMES_SINGLE_LINK_PROVIDERS.has(provider)) return null;
+
+	const hasExistingProviderLink = existingAgentLinks.some(
+		(link) =>
+			link.status === "active" &&
+			link.account_id !== accountId &&
+			link.account.provider === provider,
+	);
+	if (!hasExistingProviderLink) return null;
+	return `one-${provider}-link-per-Hermes-agent: Hermes agents support one active ${provider} link. Unlink the existing ${provider} channel before linking another.`;
+}

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { components } from "@clawdi/shared/api";
-import { CircleCheck } from "lucide-react";
+import { CircleCheck, TriangleAlert } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import {
@@ -30,7 +30,16 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TokenReveal } from "@/hosted/v2/channels/channel-ui";
-import { useEnvironments, useLinkAgent } from "@/hosted/v2/channels/channels-hooks";
+import {
+	useAgentChannelLinks,
+	useCreateWhatsappTenantCred,
+	useEnvironments,
+	useLinkAgent,
+} from "@/hosted/v2/channels/channels-hooks";
+import {
+	linkAgentBlockReason,
+	shouldMintWhatsappTenantCredential,
+} from "@/hosted/v2/channels/link-agent-dialog.logic";
 import {
 	type AgentOwnershipKind,
 	agentOwnershipKindFromId,
@@ -49,14 +58,17 @@ export function LinkAgentDialog({
 	onOpenChange,
 	accountId,
 	accountName,
+	provider,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	accountId: string;
 	accountName: string;
+	provider: string;
 }) {
 	const envs = useEnvironments();
 	const link = useLinkAgent(accountId);
+	const createWhatsappCredential = useCreateWhatsappTenantCred(accountId);
 	const ownership = useAgentOwnership();
 	// Empty string is the "no selection" sentinel: keeps the Select controlled
 	// (never flips undefined↔string, which warns), and reads as falsy so submit
@@ -64,30 +76,67 @@ export function LinkAgentDialog({
 	const [agentId, setAgentId] = useState("");
 	const [token, setToken] = useState<string | null>(null);
 	const [linkedNoToken, setLinkedNoToken] = useState(false);
+	const [whatsappCredentialMinted, setWhatsappCredentialMinted] = useState(false);
 	const submitLocked = useRef(false);
+
+	const agents = useMemo(() => [...(envs.data ?? [])].sort(compareAgentEnvironments), [envs.data]);
+	const selectedAgent = agents.find((env) => env.id === agentId);
+	const shouldCheckHermesSingleLink =
+		open &&
+		Boolean(agentId) &&
+		selectedAgent?.agent_type === "hermes" &&
+		(provider === "telegram" || provider === "discord");
+	const selectedAgentLinks = useAgentChannelLinks(agentId, shouldCheckHermesSingleLink);
+	const blockReason = linkAgentBlockReason({
+		provider,
+		selectedAgent,
+		existingAgentLinks: selectedAgentLinks.data ?? [],
+		accountId,
+	});
+	const guardLoading = shouldCheckHermesSingleLink && selectedAgentLinks.isLoading;
+	const isSubmitting = link.isPending || createWhatsappCredential.isPending || submitLocked.current;
 
 	useEffect(() => {
 		if (!open) return;
 		setAgentId("");
 		setToken(null);
 		setLinkedNoToken(false);
+		setWhatsappCredentialMinted(false);
 	}, [open]);
 
 	function submit() {
-		if (!agentId || submitLocked.current) return;
+		if (!agentId || blockReason || guardLoading || submitLocked.current) return;
+		const agent = selectedAgent;
 		submitLocked.current = true;
+		let credentialMutationStarted = false;
 		link.mutate(agentId, {
 			onSuccess: (data) => {
+				if (shouldMintWhatsappTenantCredential(provider, agent)) {
+					credentialMutationStarted = true;
+					createWhatsappCredential.mutate(
+						{ agent_link_id: data.id },
+						{
+							onSuccess: () => {
+								setWhatsappCredentialMinted(true);
+							},
+							onSettled: () => {
+								submitLocked.current = false;
+							},
+						},
+					);
+					return;
+				}
 				if (data.agent_token) setToken(data.agent_token);
 				else setLinkedNoToken(true);
 			},
 			onSettled: () => {
-				submitLocked.current = false;
+				if (!credentialMutationStarted) {
+					submitLocked.current = false;
+				}
 			},
 		});
 	}
 
-	const agents = useMemo(() => [...(envs.data ?? [])].sort(compareAgentEnvironments), [envs.data]);
 	const agentItems = useMemo(
 		() =>
 			agents.map((env) => {
@@ -116,6 +165,11 @@ export function LinkAgentDialog({
 						value={token}
 						note="Copy it now — it won't be shown again. The agent runtime uses this to send and receive on this channel."
 					/>
+				) : whatsappCredentialMinted ? (
+					<div className="flex items-center gap-2 rounded-lg border border-success/30 bg-success-muted p-3 text-sm text-success-muted-foreground">
+						<CircleCheck className="size-4 shrink-0" />
+						Device credential minted. Finish pairing from the agent runtime to link the number.
+					</div>
 				) : linkedNoToken ? (
 					<div className="flex items-center gap-2 rounded-lg border border-success/30 bg-success-muted p-3 text-sm text-success-muted-foreground">
 						<CircleCheck className="size-4 shrink-0" />
@@ -165,11 +219,22 @@ export function LinkAgentDialog({
 								})}
 							</SelectContent>
 						</Select>
+						{guardLoading ? (
+							<p className="text-xs text-muted-foreground">
+								Checking existing Hermes channel links...
+							</p>
+						) : null}
+						{blockReason ? (
+							<div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning-muted p-3 text-sm text-warning-muted-foreground">
+								<TriangleAlert className="mt-0.5 size-4 shrink-0" />
+								<span>{blockReason}</span>
+							</div>
+						) : null}
 					</div>
 				)}
 
 				<DialogFooter>
-					{token || linkedNoToken ? (
+					{token || linkedNoToken || whatsappCredentialMinted ? (
 						<Button onClick={() => onOpenChange(false)}>Done</Button>
 					) : (
 						<>
@@ -178,9 +243,13 @@ export function LinkAgentDialog({
 							</Button>
 							<Button
 								onClick={submit}
-								disabled={!agentId || link.isPending || submitLocked.current}
+								disabled={!agentId || Boolean(blockReason) || guardLoading || isSubmitting}
 							>
-								{link.isPending ? "Linking…" : "Link agent"}
+								{createWhatsappCredential.isPending
+									? "Minting device…"
+									: link.isPending
+										? "Linking…"
+										: "Link agent"}
 							</Button>
 						</>
 					)}

--- a/apps/web/src/hosted/v2/channels/shared-bots-pool.tsx
+++ b/apps/web/src/hosted/v2/channels/shared-bots-pool.tsx
@@ -26,7 +26,11 @@ const BOT_GRID_CLASS = ENTITY_GRID_CLASS;
  */
 export function SharedBotsPool() {
 	const pool = useBotPool();
-	const [linkTarget, setLinkTarget] = useState<{ id: string; name: string } | null>(null);
+	const [linkTarget, setLinkTarget] = useState<{
+		id: string;
+		name: string;
+		provider: string;
+	} | null>(null);
 
 	if (pool.isLoading) {
 		return (
@@ -82,7 +86,13 @@ export function SharedBotsPool() {
 								<PoolCard
 									key={item.id}
 									item={item}
-									onLink={() => setLinkTarget({ id: item.id, name: item.name })}
+									onLink={() =>
+										setLinkTarget({
+											id: item.id,
+											name: item.name,
+											provider: item.provider,
+										})
+									}
 								/>
 							))}
 						</div>
@@ -96,6 +106,7 @@ export function SharedBotsPool() {
 					onOpenChange={(o) => !o && setLinkTarget(null)}
 					accountId={linkTarget.id}
 					accountName={linkTarget.name}
+					provider={linkTarget.provider}
 				/>
 			) : null}
 		</div>

--- a/backend/app/routes/channel_routers/whatsapp.py
+++ b/backend/app/routes/channel_routers/whatsapp.py
@@ -53,6 +53,7 @@ from app.schemas.channel import (
 from app.services.agent_bindings import get_owned_agent_or_404
 from app.services.channel_debug_events import record_channel_debug_event
 from app.services.channels import (
+    ensure_hermes_agent_provider_link_available,
     get_active_channel_account,
     get_channel_secret,
     get_or_create_bot_agent_link,
@@ -130,6 +131,13 @@ async def create_whatsapp_tenant_credential(
     )
     auth_cert = await load_or_create_whatsapp_auth_cert(db, account=account)
     link = await _resolve_whatsapp_tenant_link(db, auth=auth, account=account, body=body)
+    await ensure_hermes_agent_provider_link_available(
+        db,
+        account=account,
+        agent_id=link.agent_id,
+        user_id=link.user_id,
+        existing_same_account_link=True,
+    )
     stored = await mint_whatsapp_agent_credential(
         db,
         account=account,

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -54,6 +54,7 @@ from app.models.channel import (
     ChannelPairCode,
     ChannelSecret,
 )
+from app.models.session import AgentEnvironment
 from app.services.channel_debug_events import record_channel_debug_event
 from app.services.discord_rate_limiter import discord_rate_limiter
 from app.services.imessage_routing import (
@@ -96,6 +97,11 @@ DEFAULT_CHANNEL_COMMANDS: tuple[dict[str, Any], ...] = (
 )
 DELIVERY_LINK_LOCK_CONTENTION_ERROR = "channel agent link is being updated"
 DELIVERY_LINK_LOCK_CONTENTION_MAX_DELAY_SECONDS = 30
+HERMES_AGENT_TYPE = "hermes"
+HERMES_SINGLE_LINK_PROVIDERS = frozenset({CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD})
+HERMES_WHATSAPP_UNSUPPORTED_DETAIL = (
+    "WhatsApp for Hermes agents is coming soon - pending an upstream Hermes release."
+)
 
 TELEGRAM_REF_CALLBACK_QUERY_ID = "telegram_callback_query_id"
 TELEGRAM_REF_FILE_ID = "telegram_file_id"
@@ -322,8 +328,22 @@ async def get_or_create_bot_agent_link(
     )
     link = result.scalar_one_or_none()
     if link is not None:
+        await ensure_hermes_agent_provider_link_available(
+            db,
+            account=account,
+            agent_id=agent_id,
+            user_id=link_user_id,
+            existing_same_account_link=True,
+        )
         return link, None
 
+    await ensure_hermes_agent_provider_link_available(
+        db,
+        account=account,
+        agent_id=agent_id,
+        user_id=link_user_id,
+        existing_same_account_link=False,
+    )
     await ensure_bot_agent_link_capacity(db, account=account)
     raw_token = agent_token or generate_agent_token(account.provider)
     link = ChannelBotAgentLink(
@@ -335,6 +355,64 @@ async def get_or_create_bot_agent_link(
     db.add(link)
     await db.flush()
     return link, raw_token
+
+
+async def ensure_hermes_agent_provider_link_available(
+    db: AsyncSession,
+    *,
+    account: ChannelAccount,
+    agent_id: UUID,
+    user_id: UUID,
+    existing_same_account_link: bool,
+) -> None:
+    agent = (
+        await db.execute(
+            select(AgentEnvironment)
+            .where(
+                AgentEnvironment.id == agent_id,
+                AgentEnvironment.user_id == user_id,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if agent is None or agent.agent_type != HERMES_AGENT_TYPE:
+        return
+
+    if account.provider == CHANNEL_PROVIDER_WHATSAPP:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=HERMES_WHATSAPP_UNSUPPORTED_DETAIL,
+        )
+    if existing_same_account_link or account.provider not in HERMES_SINGLE_LINK_PROVIDERS:
+        return
+
+    existing_link = (
+        await db.execute(
+            select(ChannelBotAgentLink.id)
+            .join(ChannelAccount, ChannelAccount.id == ChannelBotAgentLink.account_id)
+            .where(
+                ChannelBotAgentLink.agent_id == agent_id,
+                ChannelBotAgentLink.user_id == user_id,
+                ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+                ChannelBotAgentLink.archived_at.is_(None),
+                ChannelAccount.provider == account.provider,
+                ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+                ChannelAccount.archived_at.is_(None),
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if existing_link is None:
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail=(
+            f"one-{account.provider}-link-per-Hermes-agent: Hermes agents support one "
+            f"active {account.provider} link. Unlink the existing {account.provider} "
+            "channel before linking another."
+        ),
+    )
 
 
 def channel_bot_link_limit(account: ChannelAccount) -> int | None:

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -32,7 +32,9 @@ from app.models.channel import (
     BINDING_STATUS_ACTIVE,
     BINDING_STATUS_ARCHIVED,
     BOT_AGENT_LINK_STATUS_ARCHIVED,
+    CHANNEL_PROVIDER_DISCORD,
     CHANNEL_PROVIDER_TELEGRAM,
+    CHANNEL_PROVIDER_WHATSAPP,
     CHANNEL_STATUS_DISABLED,
     CHANNEL_VISIBILITY_PUBLIC,
     DELIVERY_STATUS_FAILED,
@@ -146,6 +148,7 @@ async def _create_user_with_channel_agent(
     db_session: AsyncSession,
     *,
     label: str,
+    agent_type: str = "claude_code",
 ):
     from app.models.project import PROJECT_KIND_ENVIRONMENT, PROJECT_KIND_PERSONAL, Project
     from app.models.session import AgentEnvironment
@@ -182,7 +185,7 @@ async def _create_user_with_channel_agent(
         user_id=user.id,
         machine_id=f"{label}-agent-{suffix}",
         machine_name=f"{label.title()} Agent",
-        agent_type="claude_code",
+        agent_type=agent_type,
         os="darwin",
         default_project_id=agent_project.id,
     )
@@ -1416,6 +1419,178 @@ async def test_public_bot_pool_capacity_rejects_new_agent_links(
     assert second_link.json()["detail"] == "channel bot link capacity reached"
     assert second_pair.status_code == 409
     assert second_pair.json()["detail"] == "channel bot link capacity reached"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", [CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD])
+async def test_hermes_agent_rejects_second_active_link_for_single_token_provider(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    provider: str,
+):
+    first_account = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider=provider,
+        name=f"hermes-{provider}-first-{uuid4().hex}",
+    )
+    second_account = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider=provider,
+        name=f"hermes-{provider}-second-{uuid4().hex}",
+    )
+    assert first_account.status_code == 201, first_account.text
+    assert second_account.status_code == 201, second_account.text
+    user, agent = await _create_user_with_channel_agent(
+        db_session,
+        label=f"hermes-{provider}",
+        agent_type="hermes",
+    )
+
+    async with _client_for_user(db_session, user) as user_client:
+        first_link = await user_client.post(
+            f"/v1/channels/{first_account.json()['id']}/agent-links",
+            json={"agent_id": str(agent.id)},
+        )
+        second_link = await user_client.post(
+            f"/v1/channels/{second_account.json()['id']}/agent-links",
+            json={"agent_id": str(agent.id)},
+        )
+
+    assert first_link.status_code == 201, first_link.text
+    assert second_link.status_code == 409
+    assert second_link.json()["detail"].startswith(f"one-{provider}-link-per-Hermes-agent")
+
+
+@pytest.mark.asyncio
+async def test_hermes_agent_rejects_whatsapp_links_and_tenant_credentials(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+):
+    created = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider=CHANNEL_PROVIDER_WHATSAPP,
+        name=f"hermes-whatsapp-{uuid4().hex}",
+        config={"phone_number_id": "phone-hermes-wa"},
+    )
+    assert created.status_code == 201, created.text
+    account_id = created.json()["id"]
+    user, agent = await _create_user_with_channel_agent(
+        db_session,
+        label="hermes-whatsapp",
+        agent_type="hermes",
+    )
+
+    async with _client_for_user(db_session, user) as user_client:
+        link = await user_client.post(
+            f"/v1/channels/{account_id}/agent-links",
+            json={"agent_id": str(agent.id)},
+        )
+        tenant_credential = await user_client.post(
+            f"/v1/channels/whatsapp/{account_id}/tenant-creds",
+            json={"agent_id": str(agent.id)},
+        )
+
+    expected_detail = (
+        "WhatsApp for Hermes agents is coming soon - pending an upstream Hermes release."
+    )
+    assert link.status_code == 409
+    assert link.json()["detail"] == expected_detail
+    assert tenant_credential.status_code == 409
+    assert tenant_credential.json()["detail"] == expected_detail
+    links = (
+        (
+            await db_session.execute(
+                select(ChannelBotAgentLink).where(
+                    ChannelBotAgentLink.account_id == UUID(account_id),
+                    ChannelBotAgentLink.agent_id == agent.id,
+                    ChannelBotAgentLink.archived_at.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert links == []
+
+    legacy_link = ChannelBotAgentLink(
+        account_id=UUID(account_id),
+        user_id=user.id,
+        agent_id=agent.id,
+    )
+    db_session.add(legacy_link)
+    await db_session.commit()
+    await db_session.refresh(legacy_link)
+
+    async with _client_for_user(db_session, user) as user_client:
+        tenant_credential_by_link = await user_client.post(
+            f"/v1/channels/whatsapp/{account_id}/tenant-creds",
+            json={"agent_link_id": str(legacy_link.id)},
+        )
+
+    assert tenant_credential_by_link.status_code == 409
+    assert tenant_credential_by_link.json()["detail"] == expected_detail
+    credentials = (
+        (
+            await db_session.execute(
+                select(ChannelAgentCredential).where(
+                    ChannelAgentCredential.bot_agent_link_id == legacy_link.id,
+                    ChannelAgentCredential.revoked_at.is_(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert credentials == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", [CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_WHATSAPP])
+async def test_openclaw_agent_keeps_multi_link_behavior_for_same_provider(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    provider: str,
+):
+    first_account = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider=provider,
+        name=f"openclaw-{provider}-first-{uuid4().hex}",
+        config={"phone_number_id": "phone-openclaw-first"} if provider == "whatsapp" else None,
+    )
+    second_account = await _create_admin_channel(
+        client,
+        target_clerk_id=seed_user.clerk_id,
+        provider=provider,
+        name=f"openclaw-{provider}-second-{uuid4().hex}",
+        config={"phone_number_id": "phone-openclaw-second"} if provider == "whatsapp" else None,
+    )
+    assert first_account.status_code == 201, first_account.text
+    assert second_account.status_code == 201, second_account.text
+    user, agent = await _create_user_with_channel_agent(
+        db_session,
+        label=f"openclaw-{provider}",
+        agent_type="openclaw",
+    )
+
+    async with _client_for_user(db_session, user) as user_client:
+        first_link = await user_client.post(
+            f"/v1/channels/{first_account.json()['id']}/agent-links",
+            json={"agent_id": str(agent.id)},
+        )
+        second_link = await user_client.post(
+            f"/v1/channels/{second_account.json()['id']}/agent-links",
+            json={"agent_id": str(agent.id)},
+        )
+
+    assert first_link.status_code == 201, first_link.text
+    assert second_link.status_code == 201, second_link.text
 
 
 @pytest.mark.asyncio

--- a/packages/cli/src/runtime/channels.ts
+++ b/packages/cli/src/runtime/channels.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { HERMES_WHATSAPP_UPSTREAM_READY } from "./hermes-whatsapp-gate";
 import { directProviderPassthroughProfiles } from "./hosted-mitm-profiles";
 import type { RuntimeManifest } from "./manifest-contract";
 import type {
@@ -71,7 +72,7 @@ export function applyRuntimeChannelsToManifestLoad(
 		manifest,
 		secretValues: {
 			...(load.secretValues ?? {}),
-			...channelSecretValues(managedLinks),
+			...channelSecretValues(managedLinks, manifest.projection?.channelCredentials),
 		},
 	};
 }
@@ -111,16 +112,17 @@ function applyRuntimeChannelProjection(
 	const directProviderPassthrough =
 		managedProfiles.length > 0 ? directProviderPassthroughProfiles(manifest.projection ?? {}) : [];
 	const runtimeHome = runtimeProjectionHome(manifest);
+	const channelCredentials = buildRuntimeChannelCredentialsProjection(
+		links,
+		runtimeHome,
+		runtimeCredentialTargets(manifest),
+	);
 	const projected: RuntimeManifest = {
 		...manifest,
 		projection: {
 			...(manifest.projection ?? {}),
 			channels: buildOpenClawChannelsProjection(links, manifest.controlPlane.apiUrl, runtimeHome),
-			channelCredentials: buildRuntimeChannelCredentialsProjection(
-				links,
-				runtimeHome,
-				runtimeCredentialTargets(manifest),
-			),
+			channelCredentials,
 		},
 		mitmProfiles: mergeMitmProfiles(manifest.mitmProfiles, [
 			...managedProfiles,
@@ -212,7 +214,7 @@ function applyHermesRuntimeChannelSettings(
 
 	const telegram = firstLinkForProvider(links, "telegram");
 	const discord = firstLinkForProvider(links, "discord");
-	const whatsapp = firstLinkForProvider(links, "whatsapp");
+	const whatsapp = HERMES_WHATSAPP_UPSTREAM_READY ? firstLinkForProvider(links, "whatsapp") : null;
 	const whatsappCredentials = whatsapp ? whatsappBaileysCredentials(whatsapp) : [];
 	const whatsappCredential = whatsappCredentials.find(
 		(credential) => whatsappCredentialCreds(credential) !== null,
@@ -438,21 +440,41 @@ function isChannelProjectionProfile(profile: MitmProfile): boolean {
 	);
 }
 
-function channelSecretValues(links: ManagedChannelLink[]): Record<string, string> {
+function channelSecretValues(
+	links: ManagedChannelLink[],
+	channelCredentials: unknown,
+): Record<string, string> {
 	const values: Record<string, string> = {};
+	const projectedCredentialSecrets = projectedWhatsAppCredentialSecretRefs(channelCredentials);
 	for (const link of links) {
 		addSecretValue(values, link.secretRef, link.agentToken);
 		for (const credential of whatsappBaileysCredentials(link)) {
 			const creds = whatsappCredentialCreds(credential);
 			if (creds === null) continue;
-			addSecretValue(
-				values,
-				whatsappBaileysCredsJsonSecretRef(link, credential),
-				JSON.stringify(creds),
-			);
+			const secretRef = whatsappBaileysCredsJsonSecretRef(link, credential);
+			if (!projectedCredentialSecrets.has(secretRef)) continue;
+			addSecretValue(values, secretRef, JSON.stringify(creds));
 		}
 	}
 	return values;
+}
+
+function projectedWhatsAppCredentialSecretRefs(channelCredentials: unknown): Set<string> {
+	const refs = new Set<string>();
+	if (!Array.isArray(channelCredentials)) return refs;
+	for (const credential of channelCredentials) {
+		const record = recordValue(credential);
+		if (record?.provider !== "whatsapp" || record.kind !== "whatsapp_baileys_auth_state") {
+			continue;
+		}
+		const files = Array.isArray(record.files) ? record.files : [];
+		for (const file of files) {
+			const fileRecord = recordValue(file);
+			const secretRef = stringValue(fileRecord?.secretRef);
+			if (fileRecord?.path === "creds.json" && secretRef) refs.add(secretRef);
+		}
+	}
+	return refs;
 }
 
 function addSecretValue(values: Record<string, string>, ref: string, value: string): void {
@@ -476,12 +498,13 @@ function whatsappBaileysCredentialProjection(
 	if (targets.openclaw) {
 		targetProjection.openclaw = { authDir: openclawAuthDir };
 	}
-	if (targets.hermes) {
+	if (targets.hermes && HERMES_WHATSAPP_UPSTREAM_READY) {
 		targetProjection.hermes = {
 			sessionDir: hermesWhatsAppSessionDir(runtimeHome),
 			credsJsonEnv: "HERMES_WA_CREDS_JSON",
 		};
 	}
+	if (!targetProjection.openclaw && !targetProjection.hermes) return null;
 	return {
 		provider: "whatsapp",
 		kind: "whatsapp_baileys_auth_state",

--- a/packages/cli/src/runtime/hermes-whatsapp-gate.ts
+++ b/packages/cli/src/runtime/hermes-whatsapp-gate.ts
@@ -1,0 +1,5 @@
+// Official Hermes does not yet support a custom Baileys websocket URL
+// (--ws-url). Enabling WhatsApp before that lands would make Hermes connect
+// directly to WhatsApp with the relay credentials, risking session conflicts
+// and bypassing the Clawdi broker path.
+export const HERMES_WHATSAPP_UPSTREAM_READY = false;

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -35,6 +35,7 @@ import {
 	removeHermesMcpServer,
 } from "../lib/hermes-config-merge";
 import { writePrivateFileAtomic } from "../lib/private-file";
+import { HERMES_WHATSAPP_UPSTREAM_READY } from "./hermes-whatsapp-gate";
 import { normalizeSecretRef } from "./hosted-mitm-profiles";
 import type { LiveSyncAgent, RuntimeInstall, RuntimeManifest } from "./manifest-contract";
 import {
@@ -1609,6 +1610,7 @@ function hermesWhatsAppProjection(
 	channelCredentials: unknown,
 	baseUrl: string,
 ): { sessionDir: string; wsUrl: string } | null {
+	if (!HERMES_WHATSAPP_UPSTREAM_READY) return null;
 	if (!channelHasAccounts(channels.whatsapp)) return null;
 	if (!Array.isArray(channelCredentials)) return null;
 	for (const credential of channelCredentials) {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -4593,7 +4593,7 @@ exit 64
 		expect(profileBundle).toContain("/v1/channels/discord");
 	});
 
-	it("converges Hermes native WhatsApp channel projection with managed Baileys creds", () => {
+	it("keeps Hermes native WhatsApp disabled until upstream websocket support is ready", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -4698,32 +4698,22 @@ exit 64
 		};
 
 		const projected = applyRuntimeChannelsToManifestLoad(load, channels);
-		const credentialProjection = projected.manifest.projection?.channelCredentials as Array<{
-			targets?: { hermes?: { sessionDir?: string; credsJsonEnv?: string } };
-		}>;
-		expect(credentialProjection[0]?.targets?.hermes).toEqual({
-			sessionDir,
-			credsJsonEnv: "HERMES_WA_CREDS_JSON",
-		});
+		const credentialProjection = projected.manifest.projection?.channelCredentials as unknown[];
+		expect(credentialProjection).toEqual([]);
 		expect(JSON.stringify(projected.manifest)).not.toContain("wa-hermes-secret");
-		expect(projected.secretValues?.[credentialSecretRef]).toContain("wa-hermes-secret");
+		expect(projected.secretValues?.[credentialSecretRef]).toBeUndefined();
+		expect(JSON.stringify(projected.secretValues ?? {})).not.toContain("wa-hermes-secret");
 
 		const convergence = convergeRuntimeManifest(projected, getRuntimePaths());
 
 		expect(convergence.installErrors).toEqual([]);
-		expect(JSON.parse(readFileSync(join(sessionDir, "creds.json"), "utf-8"))).toEqual(creds);
-		expect(readFileSync(join(sessionDir, ".clawdi-managed-whatsapp-auth.json"), "utf-8")).toContain(
-			credentialId,
-		);
+		expect(existsSync(sessionDir)).toBe(false);
 		const hermesConfig = readFileSync(join(home, ".hermes", "config.yaml"), "utf-8");
 		expect(hermesConfig).toContain("whatsapp:");
-		expect(hermesConfig).toContain("enabled: true");
-		expect(hermesConfig).toContain("dm_policy: open");
-		expect(hermesConfig).toContain("group_policy: open");
-		expect(hermesConfig).toContain("allow_from:");
-		expect(hermesConfig).toContain(`session_path: ${sessionDir}`);
-		expect(hermesConfig).toContain(
-			"ws_url: wss://cloud-api.test/v1/channels/whatsapp/00000000-0000-0000-0000-000000000001/baileys",
+		expect(hermesConfig).toContain("enabled: false");
+		expect(hermesConfig).not.toContain(`session_path: ${sessionDir}`);
+		expect(hermesConfig).not.toContain(
+			"/v1/channels/whatsapp/00000000-0000-0000-0000-000000000001/baileys",
 		);
 		expect(hermesConfig).not.toContain("wa-hermes-secret");
 
@@ -4731,17 +4721,17 @@ exit 64
 			readFileSync(join(state, "config", "run", "hermes.json"), "utf-8"),
 		);
 		expect(runConfig.env.HERMES_EXISTING_ENV).toBe("kept");
-		expect(runConfig.env.WHATSAPP_ENABLED).toBe("true");
-		expect(runConfig.env.WHATSAPP_MODE).toBe("bot");
-		expect(runConfig.env.WHATSAPP_ALLOWED_USERS).toBe("*");
-		expect(runConfig.secretEnv.HERMES_WA_CREDS_JSON).toBe(credentialSecretRef);
+		expect(runConfig.env.WHATSAPP_ENABLED).toBeUndefined();
+		expect(runConfig.env.WHATSAPP_MODE).toBeUndefined();
+		expect(runConfig.env.WHATSAPP_ALLOWED_USERS).toBeUndefined();
+		expect(runConfig.secretEnv.HERMES_WA_CREDS_JSON).toBeUndefined();
 		expect(JSON.stringify(runConfig)).not.toContain("wa-hermes-secret");
 		const hermesEnv = readSystemdEnvFile(getRuntimePaths(), "hermes-gateway");
-		expect(hermesEnv).toContain('WHATSAPP_ENABLED="true"');
-		expect(hermesEnv).toContain('WHATSAPP_MODE="bot"');
-		expect(hermesEnv).toContain('WHATSAPP_ALLOWED_USERS="*"');
-		expect(hermesEnv).toContain("HERMES_WA_CREDS_JSON=");
-		expect(hermesEnv).toContain("wa-hermes-secret");
+		expect(hermesEnv).not.toContain("WHATSAPP_ENABLED");
+		expect(hermesEnv).not.toContain("WHATSAPP_MODE");
+		expect(hermesEnv).not.toContain("WHATSAPP_ALLOWED_USERS");
+		expect(hermesEnv).not.toContain("HERMES_WA_CREDS_JSON");
+		expect(hermesEnv).not.toContain("wa-hermes-secret");
 
 		const removed = convergeRuntimeManifest(
 			applyRuntimeChannelsToManifestLoad(load, {


### PR DESCRIPTION
Final three channel follow-ups (context: #706 audit, #335/#336, external-dependency factcheck hosted #713):

1. **WhatsApp link flow no longer dead-ends**: linking a WhatsApp account to a (non-Hermes) agent now mints the tenant credential immediately and shows the finish-pairing state — previously `useLinkAgent` only created the link row and creds had to be minted from a separate tab.
2. **Hermes one-link-per-provider (API + UI)**: link creation resolves the target agent's runtime via `AgentEnvironment.agent_type` (row locked `with_for_update` against concurrent link races); a second active telegram/discord link for the same Hermes agent gets a clear 409. OpenClaw multi-link unchanged; non-Hermes agents pass through untouched.
3. **Hermes WhatsApp gated OFF (factcheck launch-blocker)**: the OFFICIAL Hermes release lacks `--ws-url`, so its Baileys bridge would bypass our cloud-api relay and risk session conflicts. Gated at three layers: API 409 ("coming soon — pending an upstream Hermes release") including the `agent_link_id` tenant-creds mint path, UI preemption/copy, and a CLI runtime flag `HERMES_WHATSAPP_UPSTREAM_READY=false` (hermes-whatsapp-gate.ts, comment cites the missing upstream support) that disables the env/creds-target/config projection. OpenClaw WA and Hermes TG/Discord stay fully enabled; tests flip-ready for when upstream lands.

Verify: backend 6 passed + ruff + generated-api; web typecheck/tests/biome; CLI typecheck + runtime tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)