### PR TITLE
feat(v2): mark WhatsApp coming-soon for beta (both runtimes)

### DIFF
--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -74,6 +74,10 @@ import {
 } from "@/hosted/v2/channels/channels-hooks";
 import { LinkAgentDialog } from "@/hosted/v2/channels/link-agent-dialog";
 import {
+	WHATSAPP_COMING_SOON_MESSAGE,
+	WHATSAPP_LINKING_READY,
+} from "@/hosted/v2/channels/link-agent-dialog.logic";
+import {
 	type AgentOwnership,
 	agentOwnershipKindFromId,
 	useAgentOwnership,
@@ -516,13 +520,21 @@ function WhatsAppDevicesTab({ accountId }: { accountId: string }) {
 
 	return (
 		<div className="flex flex-col gap-4">
-			<InfoCard icon={Smartphone} title="Link a WhatsApp number">
-				WhatsApp uses no bot token. Mint a device credential for an agent, then finish the link by
-				scanning it in WhatsApp → Linked devices. The credential is handed to the agent runtime to
-				complete pairing.
+			<InfoCard
+				icon={Smartphone}
+				title={WHATSAPP_LINKING_READY ? "Link a WhatsApp number" : "WhatsApp is coming soon"}
+			>
+				{WHATSAPP_LINKING_READY
+					? "WhatsApp uses no bot token. Mint a device credential for an agent, then finish the link by scanning it in WhatsApp -> Linked devices. The credential is handed to the agent runtime to complete pairing."
+					: WHATSAPP_COMING_SOON_MESSAGE}
 			</InfoCard>
 
-			{links.isLoading ? (
+			{!WHATSAPP_LINKING_READY ? (
+				<Button disabled>
+					<Smartphone className="size-4" />
+					Coming soon
+				</Button>
+			) : links.isLoading ? (
 				<Skeleton className="h-16 w-full rounded-lg" />
 			) : links.error ? (
 				<ApiErrorPanel
@@ -722,6 +734,14 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 					generateLocked.current = false;
 				},
 			},
+		);
+	}
+
+	if (provider === "whatsapp" && !WHATSAPP_LINKING_READY) {
+		return (
+			<InfoCard icon={TriangleAlert} title="WhatsApp is coming soon">
+				{WHATSAPP_COMING_SOON_MESSAGE}
+			</InfoCard>
 		);
 	}
 

--- a/apps/web/src/hosted/v2/channels/channel-providers.ts
+++ b/apps/web/src/hosted/v2/channels/channel-providers.ts
@@ -4,7 +4,7 @@
  *   - telegram:  bot token (BotFather)                → provider_token
  *   - discord:   bot token + application_id + public_key (+ optional guild_id)
  *                                                       → provider_token + config
- *   - whatsapp:  NO token — Baileys device link via the tenant-creds flow
+ *   - whatsapp:  no token; agent/device linking is gated during the beta
  * Tints reuse the app identity palette so channel chips match the chrome.
  */
 export const CHANNEL_PROVIDERS = ["telegram", "discord", "whatsapp"] as const;
@@ -55,7 +55,7 @@ export const PROVIDER_META: Record<ChannelProviderId, SupportedChannelProviderMe
 		label: "WhatsApp",
 		tint: "bg-identity-2-bg text-identity-2-fg",
 		connect: "whatsapp",
-		hint: "No bot token — connect, then link your WhatsApp number by scanning a code (Linked devices).",
+		hint: "No bot token. WhatsApp agent linking is coming soon for hosted agents.",
 	},
 };
 

--- a/apps/web/src/hosted/v2/channels/channels-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channels-page.tsx
@@ -31,9 +31,10 @@ import { AccessBadge, HealthBadge } from "@/hosted/v2/channels/channel-ui";
 import { useBotPool, useChannelHealth, useChannels } from "@/hosted/v2/channels/channels-hooks";
 import { ConnectBotDialog } from "@/hosted/v2/channels/connect-bot-dialog";
 import { LinkAgentDialog } from "@/hosted/v2/channels/link-agent-dialog";
+import { WHATSAPP_LINKING_READY } from "@/hosted/v2/channels/link-agent-dialog.logic";
 import { cn } from "@/lib/utils";
 
-const DESCRIPTION = "Connect Telegram, Discord, and WhatsApp to your agents.";
+const DESCRIPTION = "Connect Telegram and Discord to your agents. WhatsApp is coming soon.";
 const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
 const CHANNEL_GRID_CLASS = ENTITY_GRID_CLASS;
 type ProviderFilter = "all" | ChannelProviderId;
@@ -418,7 +419,9 @@ function PoolCard({ item, onLink }: { item: ChannelBotPoolItem; onLink: () => vo
 			: `${item.link_count} of ${item.max_links} linked`;
 
 	const meta = providerMeta(item.provider);
-	const linkable = !meta.unavailable && item.available && item.capabilities.link_agent;
+	const whatsappLinkingGated = item.provider === "whatsapp" && !WHATSAPP_LINKING_READY;
+	const linkable =
+		!whatsappLinkingGated && !meta.unavailable && item.available && item.capabilities.link_agent;
 
 	return (
 		<div className={cn(ENTITY_CARD_BASE, "flex flex-col gap-3")}>
@@ -453,7 +456,13 @@ function PoolCard({ item, onLink }: { item: ChannelBotPoolItem; onLink: () => vo
 				</Button>
 			) : (
 				<Button size="sm" variant="outline" className="w-full" disabled>
-					{meta.unavailable ? "Unavailable" : item.available ? "Not linkable" : "At capacity"}
+					{whatsappLinkingGated
+						? "Coming soon"
+						: meta.unavailable
+							? "Unavailable"
+							: item.available
+								? "Not linkable"
+								: "At capacity"}
 				</Button>
 			)}
 		</div>

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -24,12 +24,13 @@ import type { ChannelCreate, ChannelCreated } from "@/hosted/v2/channels/channel
 import { ProviderChip, TokenReveal } from "@/hosted/v2/channels/channel-ui";
 import { useCreateChannel } from "@/hosted/v2/channels/channels-hooks";
 import { discordPublicKeyError } from "@/hosted/v2/channels/connect-bot-dialog.logic";
+import { WHATSAPP_COMING_SOON_MESSAGE } from "@/hosted/v2/channels/link-agent-dialog.logic";
 
 /**
  * Connect a channel. Each provider takes its OWN real inputs (grounded in
  * cloud-api): Telegram = bot token; Discord = bot token + application_id +
- * public_key (+ guild_id); WhatsApp = no token (device is linked afterwards
- * via the Baileys tenant-creds flow on the channel page). On success the
+ * public_key (+ guild_id); WhatsApp = no token (agent/device linking is
+ * gated during the beta). On success the
  * scoped agent token may be revealed once when an agent is auto-linked.
  */
 export function ConnectBotDialog({
@@ -93,7 +94,7 @@ export function ConnectBotDialog({
 		if (meta.connect === "token") {
 			return { provider, name: trimmedName, provider_token: token.trim() };
 		}
-		// whatsapp — no token; the device is linked afterwards (tenant-creds)
+		// whatsapp — no token; device linking is gated during the beta
 		return { provider, name: trimmedName };
 	}
 
@@ -128,10 +129,7 @@ export function ConnectBotDialog({
 							/>
 						) : null}
 						{provider === "whatsapp" ? (
-							<p className="text-sm text-muted-foreground">
-								Next: open the channel and link your WhatsApp number under{" "}
-								<span className="font-medium">Linked devices</span>.
-							</p>
+							<p className="text-sm text-muted-foreground">{WHATSAPP_COMING_SOON_MESSAGE}</p>
 						) : null}
 						<DialogFooter>
 							<Button variant="outline" onClick={() => onOpenChange(false)}>

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
-	HERMES_WHATSAPP_UNSUPPORTED_MESSAGE,
 	linkAgentBlockReason,
 	shouldMintWhatsappTenantCredential,
+	WHATSAPP_COMING_SOON_MESSAGE,
 } from "./link-agent-dialog.logic";
 
 describe("linkAgentBlockReason", () => {
-	test("blocks WhatsApp for Hermes agents", () => {
+	test("blocks WhatsApp for all selected runtime agents", () => {
 		expect(
 			linkAgentBlockReason({
 				provider: "whatsapp",
@@ -14,7 +14,15 @@ describe("linkAgentBlockReason", () => {
 				existingAgentLinks: [],
 				accountId: "wa-current",
 			}),
-		).toBe(HERMES_WHATSAPP_UNSUPPORTED_MESSAGE);
+		).toBe(WHATSAPP_COMING_SOON_MESSAGE);
+		expect(
+			linkAgentBlockReason({
+				provider: "whatsapp",
+				selectedAgent: { agent_type: "openclaw" },
+				existingAgentLinks: [],
+				accountId: "wa-current",
+			}),
+		).toBe(WHATSAPP_COMING_SOON_MESSAGE);
 	});
 
 	test("blocks a second Telegram or Discord link for Hermes agents", () => {
@@ -67,9 +75,12 @@ describe("linkAgentBlockReason", () => {
 });
 
 describe("shouldMintWhatsappTenantCredential", () => {
-	test("mints only for non-Hermes WhatsApp links", () => {
-		expect(shouldMintWhatsappTenantCredential("whatsapp", { agent_type: "openclaw" })).toBe(true);
+	test("does not mint WhatsApp credentials while linking is gated", () => {
+		expect(shouldMintWhatsappTenantCredential("whatsapp", { agent_type: "openclaw" })).toBe(false);
 		expect(shouldMintWhatsappTenantCredential("whatsapp", { agent_type: "hermes" })).toBe(false);
+		expect(shouldMintWhatsappTenantCredential("whatsapp", { agent_type: "claude_code" })).toBe(
+			false,
+		);
 		expect(shouldMintWhatsappTenantCredential("telegram", { agent_type: "openclaw" })).toBe(false);
 	});
 });

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.ts
@@ -9,18 +9,14 @@ type AgentChannelLink = {
 	};
 };
 
-export const HERMES_WHATSAPP_UNSUPPORTED_MESSAGE =
-	"WhatsApp for Hermes agents is coming soon - pending an upstream Hermes release.";
+export const WHATSAPP_LINKING_READY = false;
+export const WHATSAPP_COMING_SOON_MESSAGE =
+	"WhatsApp channels are coming soon for hosted agents. Telegram and Discord are available now.";
 
 const HERMES_SINGLE_LINK_PROVIDERS = new Set(["telegram", "discord"]);
 
 export function shouldMintWhatsappTenantCredential(provider: string, agent: Agent): boolean {
-	return (
-		provider === "whatsapp" &&
-		agent !== null &&
-		agent !== undefined &&
-		agent.agent_type !== "hermes"
-	);
+	return WHATSAPP_LINKING_READY && provider === "whatsapp" && agent !== null && agent !== undefined;
 }
 
 export function linkAgentBlockReason({
@@ -34,8 +30,8 @@ export function linkAgentBlockReason({
 	existingAgentLinks: AgentChannelLink[];
 	accountId: string;
 }): string | null {
+	if (provider === "whatsapp" && !WHATSAPP_LINKING_READY) return WHATSAPP_COMING_SOON_MESSAGE;
 	if (selectedAgent?.agent_type !== "hermes") return null;
-	if (provider === "whatsapp") return HERMES_WHATSAPP_UNSUPPORTED_MESSAGE;
 	if (!HERMES_SINGLE_LINK_PROVIDERS.has(provider)) return null;
 
 	const hasExistingProviderLink = existingAgentLinks.some(

--- a/apps/web/src/hosted/v2/channels/shared-bots-pool.tsx
+++ b/apps/web/src/hosted/v2/channels/shared-bots-pool.tsx
@@ -15,6 +15,7 @@ import type { ChannelBotPoolItem } from "@/hosted/v2/channels/channel-types";
 import { AccessBadge } from "@/hosted/v2/channels/channel-ui";
 import { useBotPool } from "@/hosted/v2/channels/channels-hooks";
 import { LinkAgentDialog } from "@/hosted/v2/channels/link-agent-dialog";
+import { WHATSAPP_LINKING_READY } from "@/hosted/v2/channels/link-agent-dialog.logic";
 import { cn } from "@/lib/utils";
 
 const BOT_GRID_CLASS = ENTITY_GRID_CLASS;
@@ -121,7 +122,9 @@ function PoolCard({ item, onLink }: { item: ChannelBotPoolItem; onLink: () => vo
 			: `${item.link_count} of ${item.max_links} linked`;
 
 	const meta = providerMeta(item.provider);
-	const linkable = !meta.unavailable && item.available && item.capabilities.link_agent;
+	const whatsappLinkingGated = item.provider === "whatsapp" && !WHATSAPP_LINKING_READY;
+	const linkable =
+		!whatsappLinkingGated && !meta.unavailable && item.available && item.capabilities.link_agent;
 
 	return (
 		<div className={cn(ENTITY_CARD_BASE, "flex flex-col gap-3")}>
@@ -157,8 +160,14 @@ function PoolCard({ item, onLink }: { item: ChannelBotPoolItem; onLink: () => vo
 			) : (
 				<Button size="sm" variant="outline" className="w-full" disabled>
 					{/* `available` false = genuinely full; otherwise the bot just
-					    isn't linkable (capability-gated) — don't mislabel as capacity. */}
-					{meta.unavailable ? "Unavailable" : item.available ? "Not linkable" : "At capacity"}
+						    isn't linkable (capability-gated) — don't mislabel as capacity. */}
+					{whatsappLinkingGated
+						? "Coming soon"
+						: meta.unavailable
+							? "Unavailable"
+							: item.available
+								? "Not linkable"
+								: "At capacity"}
 				</Button>
 			)}
 		</div>

--- a/backend/app/routes/channel_routers/whatsapp.py
+++ b/backend/app/routes/channel_routers/whatsapp.py
@@ -53,7 +53,7 @@ from app.schemas.channel import (
 from app.services.agent_bindings import get_owned_agent_or_404
 from app.services.channel_debug_events import record_channel_debug_event
 from app.services.channels import (
-    ensure_hermes_agent_provider_link_available,
+    ensure_hosted_agent_provider_link_available,
     get_active_channel_account,
     get_channel_secret,
     get_or_create_bot_agent_link,
@@ -131,7 +131,7 @@ async def create_whatsapp_tenant_credential(
     )
     auth_cert = await load_or_create_whatsapp_auth_cert(db, account=account)
     link = await _resolve_whatsapp_tenant_link(db, auth=auth, account=account, body=body)
-    await ensure_hermes_agent_provider_link_available(
+    await ensure_hosted_agent_provider_link_available(
         db,
         account=account,
         agent_id=link.agent_id,

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -98,9 +98,11 @@ DEFAULT_CHANNEL_COMMANDS: tuple[dict[str, Any], ...] = (
 DELIVERY_LINK_LOCK_CONTENTION_ERROR = "channel agent link is being updated"
 DELIVERY_LINK_LOCK_CONTENTION_MAX_DELAY_SECONDS = 30
 HERMES_AGENT_TYPE = "hermes"
+OPENCLAW_AGENT_TYPE = "openclaw"
+HOSTED_RUNTIME_AGENT_TYPES = frozenset({HERMES_AGENT_TYPE, OPENCLAW_AGENT_TYPE})
 HERMES_SINGLE_LINK_PROVIDERS = frozenset({CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD})
-HERMES_WHATSAPP_UNSUPPORTED_DETAIL = (
-    "WhatsApp for Hermes agents is coming soon - pending an upstream Hermes release."
+WHATSAPP_COMING_SOON_DETAIL = (
+    "WhatsApp channels are coming soon for hosted agents. Telegram and Discord are available now."
 )
 
 TELEGRAM_REF_CALLBACK_QUERY_ID = "telegram_callback_query_id"
@@ -328,7 +330,7 @@ async def get_or_create_bot_agent_link(
     )
     link = result.scalar_one_or_none()
     if link is not None:
-        await ensure_hermes_agent_provider_link_available(
+        await ensure_hosted_agent_provider_link_available(
             db,
             account=account,
             agent_id=agent_id,
@@ -337,7 +339,7 @@ async def get_or_create_bot_agent_link(
         )
         return link, None
 
-    await ensure_hermes_agent_provider_link_available(
+    await ensure_hosted_agent_provider_link_available(
         db,
         account=account,
         agent_id=agent_id,
@@ -357,7 +359,7 @@ async def get_or_create_bot_agent_link(
     return link, raw_token
 
 
-async def ensure_hermes_agent_provider_link_available(
+async def ensure_hosted_agent_provider_link_available(
     db: AsyncSession,
     *,
     account: ChannelAccount,
@@ -375,14 +377,19 @@ async def ensure_hermes_agent_provider_link_available(
             .with_for_update()
         )
     ).scalar_one_or_none()
-    if agent is None or agent.agent_type != HERMES_AGENT_TYPE:
+    if agent is None:
         return
 
-    if account.provider == CHANNEL_PROVIDER_WHATSAPP:
+    if (
+        account.provider == CHANNEL_PROVIDER_WHATSAPP
+        and agent.agent_type in HOSTED_RUNTIME_AGENT_TYPES
+    ):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=HERMES_WHATSAPP_UNSUPPORTED_DETAIL,
+            detail=WHATSAPP_COMING_SOON_DETAIL,
         )
+    if agent.agent_type != HERMES_AGENT_TYPE:
+        return
     if existing_same_account_link or account.provider not in HERMES_SINGLE_LINK_PROVIDERS:
         return
 

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -1465,24 +1465,26 @@ async def test_hermes_agent_rejects_second_active_link_for_single_token_provider
 
 
 @pytest.mark.asyncio
-async def test_hermes_agent_rejects_whatsapp_links_and_tenant_credentials(
+@pytest.mark.parametrize("agent_type", ["hermes", "openclaw"])
+async def test_hosted_runtime_agent_rejects_whatsapp_links_and_tenant_credentials(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user,
+    agent_type: str,
 ):
     created = await _create_admin_channel(
         client,
         target_clerk_id=seed_user.clerk_id,
         provider=CHANNEL_PROVIDER_WHATSAPP,
-        name=f"hermes-whatsapp-{uuid4().hex}",
-        config={"phone_number_id": "phone-hermes-wa"},
+        name=f"{agent_type}-whatsapp-{uuid4().hex}",
+        config={"phone_number_id": f"phone-{agent_type}-wa"},
     )
     assert created.status_code == 201, created.text
     account_id = created.json()["id"]
     user, agent = await _create_user_with_channel_agent(
         db_session,
-        label="hermes-whatsapp",
-        agent_type="hermes",
+        label=f"{agent_type}-whatsapp",
+        agent_type=agent_type,
     )
 
     async with _client_for_user(db_session, user) as user_client:
@@ -1495,9 +1497,7 @@ async def test_hermes_agent_rejects_whatsapp_links_and_tenant_credentials(
             json={"agent_id": str(agent.id)},
         )
 
-    expected_detail = (
-        "WhatsApp for Hermes agents is coming soon - pending an upstream Hermes release."
-    )
+    expected_detail = channel_service.WHATSAPP_COMING_SOON_DETAIL
     assert link.status_code == 409
     assert link.json()["detail"] == expected_detail
     assert tenant_credential.status_code == 409
@@ -1550,8 +1550,8 @@ async def test_hermes_agent_rejects_whatsapp_links_and_tenant_credentials(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("provider", [CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_WHATSAPP])
-async def test_openclaw_agent_keeps_multi_link_behavior_for_same_provider(
+@pytest.mark.parametrize("provider", [CHANNEL_PROVIDER_TELEGRAM, CHANNEL_PROVIDER_DISCORD])
+async def test_openclaw_agent_keeps_multi_link_behavior_for_telegram_and_discord(
     client: httpx.AsyncClient,
     db_session: AsyncSession,
     seed_user,
@@ -1562,14 +1562,12 @@ async def test_openclaw_agent_keeps_multi_link_behavior_for_same_provider(
         target_clerk_id=seed_user.clerk_id,
         provider=provider,
         name=f"openclaw-{provider}-first-{uuid4().hex}",
-        config={"phone_number_id": "phone-openclaw-first"} if provider == "whatsapp" else None,
     )
     second_account = await _create_admin_channel(
         client,
         target_clerk_id=seed_user.clerk_id,
         provider=provider,
         name=f"openclaw-{provider}-second-{uuid4().hex}",
-        config={"phone_number_id": "phone-openclaw-second"} if provider == "whatsapp" else None,
     )
     assert first_account.status_code == 201, first_account.text
     assert second_account.status_code == 201, second_account.text

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -45,6 +45,7 @@ import {
 	runtimeUserName,
 	runtimeUserSystemdEnvArgs,
 } from "../runtime/systemd-user";
+import { WHATSAPP_UPSTREAM_READY } from "../runtime/whatsapp-gate";
 
 type ChannelAccount = components["schemas"]["ChannelAccountResponse"];
 type ChannelAccountCreate = components["schemas"]["ChannelAccountCreate"];
@@ -536,6 +537,7 @@ async function applyLink(
 
 	let token = link.agent_token ?? null;
 	let tokenWritten = false;
+	const runtimeOutputGated = channel.provider === "whatsapp" && !WHATSAPP_UPSTREAM_READY;
 	if (
 		ctx.rotateAllTokens ||
 		(ctx.rotateMissingTokens &&
@@ -563,10 +565,10 @@ async function applyLink(
 		});
 	}
 
-	if (token) {
+	if (token && !runtimeOutputGated) {
 		addRuntimeEnv(ctx, channel.provider, account.id, linkManifest, token);
 		tokenWritten = true;
-	} else {
+	} else if (!runtimeOutputGated) {
 		const existingToken = readDotenvValue(
 			ctx.manifestDir,
 			ctx.manifest.outputs.dotenv,
@@ -582,7 +584,7 @@ async function applyLink(
 		}
 	}
 
-	if (linkManifest.pair_code) {
+	if (linkManifest.pair_code && !runtimeOutputGated) {
 		const pairCode = unwrap(
 			await ctx.api.POST("/v1/channels/{account_id}/pair-codes", {
 				params: { path: { account_id: account.id } },
@@ -610,7 +612,11 @@ async function applyLink(
 		});
 	}
 
-	if (channel.provider === "whatsapp" && linkManifest.whatsapp?.baileys_credentials_dir) {
+	if (
+		channel.provider === "whatsapp" &&
+		WHATSAPP_UPSTREAM_READY &&
+		linkManifest.whatsapp?.baileys_credentials_dir
+	) {
 		await writeWhatsAppCredentials(ctx, account.id, link, linkManifest);
 	}
 
@@ -797,6 +803,7 @@ function preflightRuntimeOutputs(manifest: RuntimeManifest, manifestDir: string)
 	for (const channel of manifest.channels) {
 		const accountKey = runtimeAccountKey(channel);
 		for (const link of channel.links) {
+			if (channel.provider === "whatsapp" && !WHATSAPP_UPSTREAM_READY) continue;
 			claim(link.runtime.token_env, `token:${link.ref}`, link.ref);
 			if (link.pair_code?.command_env) {
 				claim(link.pair_code.command_env, `pair-code:${link.ref}`, link.ref);

--- a/packages/cli/src/runtime/channels.ts
+++ b/packages/cli/src/runtime/channels.ts
@@ -1,5 +1,4 @@
 import { join } from "node:path";
-import { HERMES_WHATSAPP_UPSTREAM_READY } from "./hermes-whatsapp-gate";
 import { directProviderPassthroughProfiles } from "./hosted-mitm-profiles";
 import type { RuntimeManifest } from "./manifest-contract";
 import type {
@@ -9,6 +8,7 @@ import type {
 	RuntimeManifestLoad,
 } from "./manifest-source";
 import type { MitmProfileInputBundle } from "./mitm-profiles";
+import { WHATSAPP_UPSTREAM_READY } from "./whatsapp-gate";
 
 type MitmProfile = MitmProfileInputBundle["profiles"][number];
 type ChannelProvider = RuntimeChannelAccount["provider"];
@@ -81,6 +81,7 @@ function managedChannelLinks(channels: RuntimeChannelAccount[]): ManagedChannelL
 	const links: ManagedChannelLink[] = [];
 	for (const account of channels) {
 		if (account.status !== "active") continue;
+		if (account.provider === "whatsapp" && !WHATSAPP_UPSTREAM_READY) continue;
 		for (const link of account.runtime_links) {
 			if (link.status !== "active" || !link.agent_token) continue;
 			const accountKey = channelAccountKey(account);
@@ -214,7 +215,7 @@ function applyHermesRuntimeChannelSettings(
 
 	const telegram = firstLinkForProvider(links, "telegram");
 	const discord = firstLinkForProvider(links, "discord");
-	const whatsapp = HERMES_WHATSAPP_UPSTREAM_READY ? firstLinkForProvider(links, "whatsapp") : null;
+	const whatsapp = WHATSAPP_UPSTREAM_READY ? firstLinkForProvider(links, "whatsapp") : null;
 	const whatsappCredentials = whatsapp ? whatsappBaileysCredentials(whatsapp) : [];
 	const whatsappCredential = whatsappCredentials.find(
 		(credential) => whatsappCredentialCreds(credential) !== null,
@@ -491,6 +492,7 @@ function whatsappBaileysCredentialProjection(
 	runtimeHome: string,
 	targets: RuntimeCredentialTargets,
 ): RuntimeChannelCredentialProjection | null {
+	if (!WHATSAPP_UPSTREAM_READY) return null;
 	const credential = whatsappBaileysCredentials(link)[0];
 	if (!credential || whatsappCredentialCreds(credential) === null) return null;
 	const openclawAuthDir = openClawWhatsAppAuthDir(runtimeHome, link.accountKey);
@@ -498,7 +500,7 @@ function whatsappBaileysCredentialProjection(
 	if (targets.openclaw) {
 		targetProjection.openclaw = { authDir: openclawAuthDir };
 	}
-	if (targets.hermes && HERMES_WHATSAPP_UPSTREAM_READY) {
+	if (targets.hermes) {
 		targetProjection.hermes = {
 			sessionDir: hermesWhatsAppSessionDir(runtimeHome),
 			credsJsonEnv: "HERMES_WA_CREDS_JSON",

--- a/packages/cli/src/runtime/hermes-whatsapp-gate.ts
+++ b/packages/cli/src/runtime/hermes-whatsapp-gate.ts
@@ -1,5 +1,0 @@
-// Official Hermes does not yet support a custom Baileys websocket URL
-// (--ws-url). Enabling WhatsApp before that lands would make Hermes connect
-// directly to WhatsApp with the relay credentials, risking session conflicts
-// and bypassing the Clawdi broker path.
-export const HERMES_WHATSAPP_UPSTREAM_READY = false;

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -35,7 +35,6 @@ import {
 	removeHermesMcpServer,
 } from "../lib/hermes-config-merge";
 import { writePrivateFileAtomic } from "../lib/private-file";
-import { HERMES_WHATSAPP_UPSTREAM_READY } from "./hermes-whatsapp-gate";
 import { normalizeSecretRef } from "./hosted-mitm-profiles";
 import type { LiveSyncAgent, RuntimeInstall, RuntimeManifest } from "./manifest-contract";
 import {
@@ -83,6 +82,7 @@ import {
 	GENERATED_RUNTIME_SYSTEMD_FILE_HEADER,
 	isGeneratedRuntimeSystemdFile,
 } from "./systemd-user";
+import { WHATSAPP_UPSTREAM_READY } from "./whatsapp-gate";
 
 export interface RuntimeConvergenceResult {
 	manifest: RuntimeManifest;
@@ -227,6 +227,10 @@ function materializeHostedChannelCredentials(
 	secretValues: Record<string, string> | undefined,
 ): void {
 	if (!hostedChannelCredentialsDeclared(manifest)) return;
+	if (!WHATSAPP_UPSTREAM_READY) {
+		removeStaleManagedWhatsAppAuthDirs(manifest, new Set());
+		return;
+	}
 	const credentials = hostedWhatsAppAuthCredentials(manifest);
 	const normalizedSecrets = normalizeSecretValues(secretValues);
 	const expectedAuthDirs = new Set<string>();
@@ -1610,7 +1614,7 @@ function hermesWhatsAppProjection(
 	channelCredentials: unknown,
 	baseUrl: string,
 ): { sessionDir: string; wsUrl: string } | null {
-	if (!HERMES_WHATSAPP_UPSTREAM_READY) return null;
+	if (!WHATSAPP_UPSTREAM_READY) return null;
 	if (!channelHasAccounts(channels.whatsapp)) return null;
 	if (!Array.isArray(channelCredentials)) return null;
 	for (const credential of channelCredentials) {
@@ -1651,18 +1655,26 @@ function toWebSocketUrl(baseUrl: string): string {
 
 function openClawManagedChannelsPatch(channels: Record<string, unknown>): Record<string, unknown> {
 	const deleteEntries = openClawManagedChannelDeletes();
+	const runtimeReadyChannels = openClawRuntimeReadyChannels(channels);
 	return {
 		channels: {
 			...deleteEntries,
-			...channels,
+			...runtimeReadyChannels,
 		},
 		plugins: {
 			entries: {
 				...deleteEntries,
-				...channelPluginEntries(channels),
+				...channelPluginEntries(runtimeReadyChannels),
 			},
 		},
 	};
+}
+
+function openClawRuntimeReadyChannels(channels: Record<string, unknown>): Record<string, unknown> {
+	if (WHATSAPP_UPSTREAM_READY || !Object.hasOwn(channels, "whatsapp")) return channels;
+	const runtimeReadyChannels = { ...channels };
+	delete runtimeReadyChannels.whatsapp;
+	return runtimeReadyChannels;
 }
 
 function openClawManagedChannelDeletes(): Record<string, null> {
@@ -1679,6 +1691,7 @@ function installOpenClawChannelPlugins(
 	workspaceRoot: string,
 ): void {
 	for (const channel of Object.keys(channels).sort()) {
+		if (channel === "whatsapp" && !WHATSAPP_UPSTREAM_READY) continue;
 		const specs = OPENCLAW_EXTERNAL_CHANNEL_PLUGIN_SPECS[channel];
 		if (!specs) continue;
 		runPluginInstallWithFallback(commandPath, specs, home, workspaceRoot);

--- a/packages/cli/src/runtime/whatsapp-gate.ts
+++ b/packages/cli/src/runtime/whatsapp-gate.ts
@@ -1,0 +1,5 @@
+// WhatsApp runtime wiring is disabled for the gated beta across OpenClaw and
+// Hermes. OpenClaw's wsUrl path is a stopgap that has not passed a live pairing
+// drill, and Hermes needs the Baileys WSS MITM profile before it can reach the
+// Clawdi relay instead of upstream WhatsApp directly.
+export const WHATSAPP_UPSTREAM_READY = false;

--- a/packages/cli/tests/commands/runtime.test.ts
+++ b/packages/cli/tests/commands/runtime.test.ts
@@ -619,7 +619,7 @@ channels:
 		expect(captured).toHaveLength(0);
 	});
 
-	it("writes WhatsApp Baileys credentials when requested", async () => {
+	it("skips WhatsApp Baileys credentials while upstream support is gated", async () => {
 		const manifestPath = writeManifest(`
 version: 1
 channels:
@@ -640,7 +640,7 @@ outputs:
 		const credsDir = join(tmpHome, ".wa-creds");
 		mkdirSync(credsDir, { recursive: true, mode: 0o755 });
 		if (process.platform !== "win32") chmodSync(credsDir, 0o755);
-		const { restore } = mockFetch([
+		const { captured, restore } = mockFetch([
 			{
 				method: "GET",
 				path: /^\/v1\/channels\/channel-wa$/,
@@ -671,42 +671,21 @@ outputs:
 						},
 					]),
 			},
-			{
-				method: "POST",
-				path: /^\/v1\/channels\/whatsapp\/channel-wa\/tenant-creds$/,
-				response: () =>
-					jsonResponse(
-						{
-							channel: "whatsapp",
-							credential_id: "cred-1",
-							agent_link_id: "link-1",
-							agent_id: "agent-1",
-							jid: "1@s.whatsapp.net",
-							identity_pub_key_hex: "abcd",
-							creds: { noiseKey: "n" },
-							auth_cert: { cert: "c" },
-							websocket_url: "wss://api.test/v1/channels/whatsapp/channel-wa/baileys",
-							media_proxy_base_url: "https://api.test/v1/channels/whatsapp/media",
-						},
-						201,
-					),
-			},
 		]);
 
 		await captureStdout(() => runtimeApplyCommand({ file: manifestPath, json: true }));
 		restore();
 
-		expect(JSON.parse(readFileSync(join(tmpHome, ".wa-creds", "creds.json"), "utf-8"))).toEqual({
-			noiseKey: "n",
-		});
-		expect(readFileSync(join(tmpHome, ".env.channels"), "utf-8")).toContain(
-			"WHATSAPP_AGENT_TOKEN=wa-token",
-		);
-		expect(readFileSync(join(tmpHome, ".env.channels"), "utf-8")).toContain(
-			`CLAWDI_WHATSAPP_AUTH_DIR=${join(tmpHome, ".wa-creds")}`,
-		);
+		expect(captured.map((request) => `${request.method} ${request.path}`)).toEqual([
+			"GET /v1/channels/channel-wa",
+			"GET /v1/channels/channel-wa/agent-links",
+		]);
+		expect(existsSync(join(tmpHome, ".wa-creds", "creds.json"))).toBe(false);
+		expect(existsSync(join(tmpHome, ".wa-creds", "auth-cert.json"))).toBe(false);
+		expect(existsSync(join(tmpHome, ".wa-creds", "clawdi-whatsapp.json"))).toBe(false);
+		expect(existsSync(join(tmpHome, ".env.channels"))).toBe(false);
 		if (process.platform !== "win32") {
-			expect(statSync(credsDir).mode & 0o777).toBe(0o700);
+			expect(statSync(credsDir).mode & 0o777).toBe(0o755);
 		}
 	});
 
@@ -789,7 +768,7 @@ outputs:
 		expect(captured).toHaveLength(0);
 	});
 
-	it("preflights channel-specific runtime env conflicts before API calls", async () => {
+	it("skips WhatsApp runtime env conflict preflight while upstream support is gated", async () => {
 		const manifestPath = writeManifest(`
 version: 1
 channels:
@@ -814,17 +793,77 @@ channels:
 outputs:
   dotenv: .env.channels
 `);
-		const { captured, restore } = mockFetch([]);
-		await expect(runtimeApplyCommand({ file: manifestPath, json: true })).rejects.toThrow(
-			"Runtime output WA_WEBSOCKET_URL has conflicting values before apply",
-		);
+		const { captured, restore } = mockFetch([
+			{
+				method: "GET",
+				path: /^\/v1\/channels\/channel-wa-a$/,
+				response: () =>
+					jsonResponse({
+						id: "channel-wa-a",
+						provider: "whatsapp",
+						name: "wa-a",
+						status: "active",
+						visibility: "public",
+						has_provider_token: true,
+						webhook_url: "https://api.test/v1/channels/whatsapp/channel-wa-a/webhook",
+						created_at: "2026-06-08T00:00:00Z",
+					}),
+			},
+			{
+				method: "GET",
+				path: /^\/v1\/channels\/channel-wa-a\/agent-links$/,
+				response: () =>
+					jsonResponse([
+						{
+							id: "link-a",
+							account_id: "channel-wa-a",
+							agent_id: "agent-1",
+							status: "active",
+							created_at: "2026-06-08T00:00:01Z",
+							agent_token: "token-a",
+						},
+					]),
+			},
+			{
+				method: "GET",
+				path: /^\/v1\/channels\/channel-wa-b$/,
+				response: () =>
+					jsonResponse({
+						id: "channel-wa-b",
+						provider: "whatsapp",
+						name: "wa-b",
+						status: "active",
+						visibility: "public",
+						has_provider_token: true,
+						webhook_url: "https://api.test/v1/channels/whatsapp/channel-wa-b/webhook",
+						created_at: "2026-06-08T00:00:00Z",
+					}),
+			},
+			{
+				method: "GET",
+				path: /^\/v1\/channels\/channel-wa-b\/agent-links$/,
+				response: () =>
+					jsonResponse([
+						{
+							id: "link-b",
+							account_id: "channel-wa-b",
+							agent_id: "agent-2",
+							status: "active",
+							created_at: "2026-06-08T00:00:01Z",
+							agent_token: "token-b",
+						},
+					]),
+			},
+		]);
+
+		await captureStdout(() => runtimeApplyCommand({ file: manifestPath, json: true }));
 		restore();
 
-		expect(captured).toHaveLength(0);
+		expect(captured).toHaveLength(4);
 		expect(existsSync(join(tmpHome, ".env.channels"))).toBe(false);
 	});
 
-	it("allows explicit env names for multiple WhatsApp runtime accounts", async () => {
+	it("skips explicit WhatsApp runtime env names while upstream support is gated", async () => {
 		const manifestPath = writeManifest(`
 version: 1
 channels:
@@ -920,13 +959,7 @@ outputs:
 		restore();
 
 		expect(captured).toHaveLength(4);
-		const dotenv = readFileSync(join(tmpHome, ".env.channels"), "utf-8");
-		expect(dotenv).toContain(
-			"WA_A_WEBSOCKET_URL=wss://api.test/v1/channels/whatsapp/channel-wa-a/baileys",
-		);
-		expect(dotenv).toContain(
-			"WA_B_WEBSOCKET_URL=wss://api.test/v1/channels/whatsapp/channel-wa-b/baileys",
-		);
+		expect(existsSync(join(tmpHome, ".env.channels"))).toBe(false);
 	});
 
 	it("reuses account link reads across multiple links for the same bot", async () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -2198,7 +2198,7 @@ exit 64
 		expect(projected.secretValues).toEqual({ "provider.default.apiKey": "sk-provider" });
 	});
 
-	it("projects WhatsApp tenant credentials as secret-backed auth state", () => {
+	it("gates WhatsApp runtime channel projection until upstream support is ready", () => {
 		const accountId = "00000000-0000-0000-0000-000000000001";
 		const linkId = "link-whatsapp-1";
 		const credentialId = "credential-whatsapp-1";
@@ -2269,43 +2269,15 @@ exit 64
 
 		const projected = applyRuntimeChannelsToManifestLoad(loaded, channels);
 
-		const accountKey = "clawdi_000000000000";
-		const authDir = join("/home/clawdi", ".openclaw", "credentials", "whatsapp", accountKey);
-		const channelProjection = projected.manifest.projection?.channels as Record<string, unknown>;
-		const whatsapp = channelProjection.whatsapp as {
-			accounts: Record<string, { authDir?: string; token?: string }>;
-		};
-		expect(whatsapp.accounts[accountKey]).toMatchObject({
-			authDir,
-			token: "wa-agent-token",
-		});
-		const credentialProjection = projected.manifest.projection?.channelCredentials;
-		expect(credentialProjection).toEqual([
-			{
-				provider: "whatsapp",
-				kind: "whatsapp_baileys_auth_state",
-				accountId,
-				accountKey,
-				linkId,
-				credentialId,
-				authDir,
-				files: [
-					{
-						path: "creds.json",
-						secretRef: `secret://channels/whatsapp/${accountKey}/credentials/${credentialId}/creds-json`,
-					},
-				],
-				targets: {
-					openclaw: { authDir },
-				},
-			},
-		]);
+		expect(projected.manifest.projection?.channels).toEqual({});
+		expect(projected.manifest.projection?.channelCredentials).toEqual([]);
+		expect(projected.manifest.mitmProfiles?.profiles ?? []).toEqual([]);
+		expect(JSON.stringify(projected.manifest)).not.toContain(accountId);
+		expect(JSON.stringify(projected.manifest)).not.toContain("baileys");
+		expect(JSON.stringify(projected.manifest)).not.toContain("wa-agent-token");
 		expect(JSON.stringify(projected.manifest)).not.toContain("wa-adv-secret");
-		expect(
-			projected.secretValues?.[
-				`secret://channels/whatsapp/${accountKey}/credentials/${credentialId}/creds-json`
-			],
-		).toContain("wa-adv-secret");
+		expect(JSON.stringify(projected.secretValues ?? {})).not.toContain("wa-agent-token");
+		expect(JSON.stringify(projected.secretValues ?? {})).not.toContain("wa-adv-secret");
 	});
 
 	it("removes stale channel-driven MITM profiles when runtime channels are disabled", () => {
@@ -4958,7 +4930,7 @@ exit 0
 		expect(patchText).not.toContain('"botToken"');
 	});
 
-	it("materializes, rotates, and cleans up WhatsApp auth state for OpenClaw", () => {
+	it("keeps OpenClaw WhatsApp materialization disabled until upstream support is ready", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -5116,24 +5088,16 @@ exit 64
 
 		expect(initial.installErrors).toEqual([]);
 		expect(rotated.installErrors).toEqual([]);
-		expect(JSON.parse(readFileSync(join(authDir, "creds.json"), "utf-8"))).toEqual(rotatedCreds);
-		const markerText = readFileSync(join(authDir, ".clawdi-managed-whatsapp-auth.json"), "utf-8");
-		expect(markerText).toContain("credential-whatsapp-2");
-		expect(markerText).not.toContain("wa-rotated-secret");
 		const patchText = readFileSync(openclawPatch, "utf-8");
-		expect(patchText).toContain('"authDir"');
-		expect(patchText).toContain(authDir);
+		expect(patchText).toContain('"whatsapp": null');
+		expect(patchText).not.toContain('"wsUrl"');
+		expect(patchText).not.toContain('"authDir"');
+		expect(patchText).not.toContain(authDir);
+		expect(patchText).not.toContain("wa-runtime-agent-token");
 		expect(patchText).not.toContain("wa-materialized-secret");
 		expect(patchText).not.toContain("wa-rotated-secret");
-		expect(readFileSync(openclawPluginInstalls, "utf-8")).toContain("clawhub:@openclaw/whatsapp");
-		const lastGoodManifest = readFileSync(join(state, "cache", "manifest.last-good.json"), "utf-8");
-		expect(lastGoodManifest).toContain("credential-whatsapp-2");
-		expect(lastGoodManifest).not.toContain("wa-rotated-secret");
-		const lastGoodSecrets = readFileSync(
-			join(state, "cache", "runtime-secrets.last-good.json"),
-			"utf-8",
-		);
-		expect(lastGoodSecrets).toContain("wa-rotated-secret");
+		expect(existsSync(openclawPluginInstalls)).toBe(false);
+		expect(existsSync(authDir)).toBe(false);
 
 		const removed = convergeRuntimeManifest(unlinkedManifest, getRuntimePaths());
 
@@ -5141,7 +5105,7 @@ exit 64
 		expect(existsSync(authDir)).toBe(false);
 	});
 
-	it("fails closed and removes stale WhatsApp auth state when creds secret is missing", () => {
+	it("removes stale OpenClaw WhatsApp auth state while upstream support is gated", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -5249,11 +5213,13 @@ exit 64
 
 		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
 
-		expect(convergence.installErrors.join("\n")).toContain(
-			"runtime channel credential materialization failed: missing WhatsApp auth state secret",
-		);
+		expect(convergence.installErrors).toEqual([]);
 		expect(existsSync(authDir)).toBe(false);
-		expect(existsSync(join(state, "cache", "manifest.last-good.json"))).toBe(false);
+		const patchText = readFileSync(openclawPatch, "utf-8");
+		expect(patchText).toContain('"whatsapp": null');
+		expect(patchText).not.toContain('"wsUrl"');
+		expect(patchText).not.toContain("wa-runtime-agent-token");
+		expect(existsSync(openclawPluginInstalls)).toBe(false);
 		expect(JSON.stringify(convergence.manifest)).not.toContain("stale-whatsapp-secret");
 	});
 


### PR DESCRIPTION
Owner decision: for gated beta, WhatsApp is "coming soon" for BOTH runtimes (not just Hermes). Rationale: OpenClaw WhatsApp only works via a wsUrl stopgap and was never live-paired; Hermes WhatsApp was already gated (node/Baileys websockets don't honor proxy env, so the official Hermes bridge can't reach our relay — MITM transport doc #339). Beta ships Telegram + Discord (both real-e2e-proven, both runtimes). WhatsApp lands for both once the Baileys WSS MITM profile fast-follow is done.

Generalizes the #338 Hermes-WhatsApp gate:
- **Backend** `ensure_hosted_agent_provider_link_available` (renamed from Hermes-specific): linking a WhatsApp account to ANY hosted agent (openclaw|hermes) → 409 "coming soon". Hermes one-link rule for Telegram/Discord preserved; OpenClaw TG/Discord multi-link unchanged. tenant-creds mint path gated too.
- **Web**: link dialog / detail / provider copy / shared bot pools show WhatsApp as coming-soon for all agents (`WHATSAPP_LINKING_READY=false`).
- **CLI runtime**: `whatsapp-gate.ts` `WHATSAPP_UPSTREAM_READY=false` disables WhatsApp materialization for BOTH runtimes (was Hermes-only). All flip-ready for when WhatsApp lands.

Gate matrix: OpenClaw/Hermes × Telegram/Discord = enabled; both × WhatsApp = coming-soon.

Tests: backend 6 + web 8 + CLI runtime 103 pass; typecheck/biome/ruff/generated-api clean (one preexisting ruff-format issue on unrelated test_runtime_manifest.py, not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)