### PR TITLE
fix(cli): honor OpenClaw gateway token auth

### DIFF
--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -406,12 +406,13 @@ use official service installers for each runtime-owned surface when both are
 needed. Clawdi should not emulate that fan-out with shell wrappers or a
 runtime-owned-looking `hermes-dashboard.service`.
 
-OpenClaw's bridge-only hosted default stays loopback and unauthenticated because
-the runtime is reachable only through the Clawdi bridge and hosted access
-controls:
+OpenClaw's hosted default stays loopback and leaves auth selection to the
+runtime config projection. In v2 hosted, Clawdi patches
+`gateway.auth.mode=token` from `OPENCLAW_GATEWAY_TOKEN`; the launch command must
+not pass a conflicting `--auth` override:
 
 ```bash
-openclaw gateway run --allow-unconfigured --auth none --bind loopback --force
+openclaw gateway run --allow-unconfigured --bind loopback --force
 ```
 
 Production manifests should provide OpenClaw configuration and a real gateway

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1862,6 +1862,11 @@ function openClawGatewayHostedPatch(manifest: RuntimeManifest): Record<string, u
 				? {
 						controlUi: {
 							allowedOrigins,
+							// OpenClaw is exposed natively in v2 hosted manifests, not through
+							// Clawdi runtime bridge surfaces, so the first proxied Control UI
+							// load has no separate bridge flow that can complete OpenClaw device
+							// pairing before the operator session connects. Gateway token auth is
+							// the hosted boundary for this Control UI path.
 							dangerouslyDisableDeviceAuth: true,
 						},
 					}

--- a/packages/cli/src/runtime/run-config.ts
+++ b/packages/cli/src/runtime/run-config.ts
@@ -63,16 +63,7 @@ export type RuntimeRunConfig = z.infer<typeof runtimeRunConfigSchema>;
 
 const DEFAULT_RUNTIME_ARGS: Record<SupportedRuntimeName, string[]> = {
 	hermes: ["dashboard", "--host", "127.0.0.1", "--no-open"],
-	openclaw: [
-		"gateway",
-		"run",
-		"--allow-unconfigured",
-		"--auth",
-		"none",
-		"--bind",
-		"loopback",
-		"--force",
-	],
+	openclaw: ["gateway", "run", "--allow-unconfigured", "--bind", "loopback", "--force"],
 };
 
 export type RuntimeRunConfigRead =

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -509,8 +509,6 @@ describe("runtime run config", () => {
 			"gateway",
 			"run",
 			"--allow-unconfigured",
-			"--auth",
-			"none",
 			"--bind",
 			"loopback",
 			"--force",
@@ -1220,6 +1218,15 @@ chmod +x "$HOME/.local/bin/hermes"
 		const runConfig = JSON.parse(
 			readFileSync(join(state, "config", "run", "openclaw.json"), "utf-8"),
 		);
+		expect(runConfig.defaultArgs).toEqual([
+			"gateway",
+			"run",
+			"--allow-unconfigured",
+			"--bind",
+			"loopback",
+			"--force",
+		]);
+		expect(runConfig.defaultArgs).not.toContain("--auth");
 		expect(runConfig.secretEnv).toEqual({
 			CLAWDI_MANAGED_OPENAI_API_KEY: "secret://provider.default.apiKey",
 		});
@@ -1442,6 +1449,11 @@ chmod +x "$HOME/.local/bin/hermes"
 				},
 			},
 		});
+		const openclawUnit = readSystemdUserServiceConfig(getRuntimePaths(), "openclaw-gateway");
+		expect(openclawUnit).toContain(
+			'"gateway" "run" "--allow-unconfigured" "--bind" "loopback" "--force"',
+		);
+		expect(openclawUnit).not.toContain('"--auth"');
 	});
 
 	it("projects runtime-scoped hosted providers into each enabled agent config", () => {

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -538,8 +538,6 @@ chmod +x "$HOME/.local/bin/hermes"
 				"gateway",
 				"run",
 				"--allow-unconfigured",
-				"--auth",
-				"none",
 				"--bind",
 				"loopback",
 				"--force",


### PR DESCRIPTION
## Summary

- Remove the OpenClaw default runtime `--auth none` launch override so v2 hosted gateway config token auth can take effect.
- Keep `--bind loopback` and keep the hosted `gateway.auth.mode=token` / Control UI allowed-origin patch coherent.
- Keep `gateway.controlUi.dangerouslyDisableDeviceAuth=true`, with an inline code comment explaining the v2 hosted native-Control-UI constraint.
- Update runtime tests and managed-runtime docs so the systemd drop-in args and gateway patch no longer disagree.

## Runtime behavior checked

OpenClaw upstream checked against `openclaw/openclaw` local clone `/tmp/openclaw-src`, HEAD `ef91bb370bee`.

- Upstream auth resolution gives a CLI auth override precedence over config: `src/gateway/auth-resolve.ts:87-95` (`authOverride.mode` sets `modeSource = "override"`). Link: https://github.com/openclaw/openclaw/blob/ef91bb370bee/src/gateway/auth-resolve.ts#L87-L95
- Therefore Clawdi's previous `openclaw gateway run --allow-unconfigured --auth none --bind loopback --force` made the hosted `gateway.auth = { mode: "token", token: OPENCLAW_GATEWAY_TOKEN }` patch dead config.
- The v2 hosted OpenClaw dashboard URL can present the gateway token without the Clawdi runtime bridge: hosted injects `OPENCLAW_GATEWAY_TOKEN` for OpenClaw and reserves `CLAWDI_RUNTIME_BRIDGE_TOKEN` for non-OpenClaw runtime surfaces (`/home/kingsley/clawdi-hosted/backend/app/v2/hosted/service.py:995-1003`), and returns OpenClaw as `/control/#token=...` while Hermes gets the runtime-bridge URL (`/home/kingsley/clawdi-hosted/backend/app/v2/hosted/service.py:2688-2693`, `:3343-3350`).
- The local Clawdi manifest contract also forbids OpenClaw bridge surfaces: `packages/cli/src/runtime/manifest-contract.ts:329-334`.
- Upstream OpenClaw Control UI accepts the fragment/query token and stores it (`ui/src/app/settings.ts:223-253`), resolves it to `Authorization: Bearer ...` (`ui/src/app/control-ui-auth.ts:24-35`), sends it on bootstrap fetches (`ui/src/app/config.ts:181-186`), and includes it in the WebSocket connect plan/request path (`ui/src/api/gateway.ts:793-849`, `:965-985`). Links: https://github.com/openclaw/openclaw/blob/ef91bb370bee/ui/src/app/settings.ts#L223-L253, https://github.com/openclaw/openclaw/blob/ef91bb370bee/ui/src/app/control-ui-auth.ts#L24-L35, https://github.com/openclaw/openclaw/blob/ef91bb370bee/ui/src/app/config.ts#L181-L186, https://github.com/openclaw/openclaw/blob/ef91bb370bee/ui/src/api/gateway.ts#L793-L849, https://github.com/openclaw/openclaw/blob/ef91bb370bee/ui/src/api/gateway.ts#L965-L985
- `dangerouslyDisableDeviceAuth` is still required for this v2 hosted native Control UI path: upstream allows operator Control UI sessions with device auth bypass only when that flag is set (`src/gateway/server/ws-connection/connect-policy.ts:121-127`), while Clawdi v2 has no separate OpenClaw runtime bridge surface where device pairing can complete before the operator session connects. Link: https://github.com/openclaw/openclaw/blob/ef91bb370bee/src/gateway/server/ws-connection/connect-policy.ts#L121-L127
- Upstream security audit flags loopback Control UI without gateway auth as critical (`src/security/audit-gateway-config.ts:155-164`), which this PR fixes by making token auth effective. It also flags `dangerouslyDisableDeviceAuth` as critical (`src/security/audit-gateway-config.ts:271-279`), which remains an intentional hosted constraint documented in code. Links: https://github.com/openclaw/openclaw/blob/ef91bb370bee/src/security/audit-gateway-config.ts#L155-L164, https://github.com/openclaw/openclaw/blob/ef91bb370bee/src/security/audit-gateway-config.ts#L271-L279

## Verification

- `bun run --cwd packages/cli test tests/runtime.test.ts` passed: 87 tests.
- `bun run check` passed: `biome ci .` checked 595 files.
- `git diff --check` passed.

No live/prod operations were performed.

I did not find a runnable local e2e that starts a real hosted OpenClaw gateway and drives the dashboard Control UI token bridge. Existing hosted Playwright smoke tests stub hosted APIs rather than exercising a live gateway.

Manual canary verification for reviewers:

1. Deploy a v2 hosted OpenClaw canary.
2. Confirm the generated systemd drop-in ExecStart contains `openclaw gateway run --allow-unconfigured --bind loopback --force` and no `--auth` override.
3. Confirm OpenClaw config contains `gateway.auth.mode=token` with the hosted `OPENCLAW_GATEWAY_TOKEN` value and the expected Control UI allowed origins.
4. Open the dashboard `openclaw_control_ui_url` ending in `/control/#token=...`; confirm bootstrap/API/WebSocket traffic succeeds.
5. Confirm unauthenticated direct `/control` or gateway access fails.
6. Run `openclaw doctor` or the security audit on the tenant. Expected: no `gateway.loopback_no_auth`; `gateway.control_ui.device_auth_disabled` may remain and is the documented hosted v2 tradeoff.
