### PR TITLE
fix(v2): runtime channel provider allowlist + retire iMessage projection + channel token SecretRefs

### DIFF
--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -25,6 +25,8 @@ from app.core.database import get_session
 from app.models.channel import (
     BINDING_STATUS_ACTIVE,
     BOT_AGENT_LINK_STATUS_ACTIVE,
+    CHANNEL_PROVIDER_DISCORD,
+    CHANNEL_PROVIDER_TELEGRAM,
     CHANNEL_PROVIDER_WHATSAPP,
     CHANNEL_PROVIDERS,
     CHANNEL_STATUS_ACTIVE,
@@ -110,6 +112,12 @@ from app.services.whatsapp_baileys import (
 )
 
 router = APIRouter(prefix="/channels", tags=["channels"])
+
+RUNTIME_CHANNEL_PROVIDERS = (
+    CHANNEL_PROVIDER_TELEGRAM,
+    CHANNEL_PROVIDER_DISCORD,
+    CHANNEL_PROVIDER_WHATSAPP,
+)
 
 SECRETISH_ACTIVITY_DETAIL_KEYS = (
     "secret",
@@ -357,6 +365,7 @@ async def list_channels(
             .join(ChannelBotAgentLink, ChannelBotAgentLink.account_id == ChannelAccount.id)
             .where(
                 ChannelAccount.archived_at.is_(None),
+                ChannelAccount.provider.in_(RUNTIME_CHANNEL_PROVIDERS),
                 ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
                 ChannelBotAgentLink.archived_at.is_(None),
                 ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -33,6 +33,7 @@ from app.models.channel import (
     BINDING_STATUS_ARCHIVED,
     BOT_AGENT_LINK_STATUS_ARCHIVED,
     CHANNEL_PROVIDER_DISCORD,
+    CHANNEL_PROVIDER_IMESSAGE,
     CHANNEL_PROVIDER_TELEGRAM,
     CHANNEL_PROVIDER_WHATSAPP,
     CHANNEL_STATUS_DISABLED,
@@ -1109,6 +1110,44 @@ async def test_env_bound_list_channels_returns_runtime_agent_token(
     ]
     assert "telegram-secret" not in listed.text
     assert "webhook_secret" not in listed.text
+
+
+@pytest.mark.asyncio
+async def test_env_bound_list_channels_filters_non_v2_runtime_providers(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    channel_agent,
+):
+    telegram = await client.post(
+        "/v1/channels",
+        json={
+            "provider": CHANNEL_PROVIDER_TELEGRAM,
+            "name": f"runtime-allowlisted-{uuid4().hex}",
+            "provider_token": "123456:telegram-secret",
+        },
+    )
+    assert telegram.status_code == 201, telegram.text
+    imessage = await client.post(
+        "/v1/channels",
+        json={
+            "provider": CHANNEL_PROVIDER_IMESSAGE,
+            "name": f"runtime-imessage-{uuid4().hex}",
+            "provider_token": "bluebubbles-password",
+            "config": {"server_url": "https://bluebubbles.example"},
+        },
+    )
+    assert imessage.status_code == 201, imessage.text
+
+    api_key = ApiKey(user_id=seed_user.id, environment_id=channel_agent.id, label="hosted")
+    async with _client_for_api_key(db_session, seed_user, api_key) as runtime_client:
+        listed = await runtime_client.get("/v1/channels")
+
+    assert listed.status_code == 200, listed.text
+    providers = {item["provider"] for item in listed.json()}
+    assert providers == {CHANNEL_PROVIDER_TELEGRAM}
+    assert imessage.json()["id"] not in listed.text
+    assert "bluebubbles-password" not in listed.text
 
 
 @pytest.mark.asyncio

--- a/packages/cli/src/runtime/channels.ts
+++ b/packages/cli/src/runtime/channels.ts
@@ -26,6 +26,8 @@ const HERMES_MANAGED_CHANNEL_SECRET_ENV = [
 	"DISCORD_BOT_TOKEN",
 	"HERMES_WA_CREDS_JSON",
 ] as const;
+const OPENCLAW_CHANNEL_TOKEN_ENV_PREFIX = "CLAWDI_CHANNEL_";
+const OPENCLAW_CHANNEL_TOKEN_ENV_SUFFIX = "_AGENT_TOKEN";
 
 interface ManagedChannelLink {
 	account: RuntimeChannelAccount;
@@ -35,6 +37,12 @@ interface ManagedChannelLink {
 	agentToken: string;
 	secretRef: string;
 	credentials: RuntimeChannelCredential[];
+}
+
+interface OpenClawEnvSecretRef {
+	source: "env";
+	provider: "default";
+	id: string;
 }
 
 interface RuntimeChannelCredentialProjection {
@@ -130,7 +138,10 @@ function applyRuntimeChannelProjection(
 			...directProviderPassthrough,
 		]),
 	};
-	return applyHermesRuntimeChannelSettings(projected, links);
+	return applyHermesRuntimeChannelSettings(
+		applyOpenClawRuntimeChannelSettings(projected, links),
+		links,
+	);
 }
 
 function buildOpenClawChannelsProjection(
@@ -145,7 +156,7 @@ function buildOpenClawChannelsProjection(
 			const channel = ensureAccountChannel(channels, "telegram", link.accountKey);
 			channel.accounts[link.accountKey] = {
 				enabled: true,
-				botToken: link.agentToken,
+				botToken: openClawChannelTokenSecretRef(link),
 				dmPolicy: "open",
 				groupPolicy: "open",
 				allowFrom: ["*"],
@@ -158,7 +169,7 @@ function buildOpenClawChannelsProjection(
 			const channel = ensureAccountChannel(channels, "discord", link.accountKey);
 			channel.accounts[link.accountKey] = {
 				enabled: true,
-				token: link.agentToken,
+				token: openClawChannelTokenSecretRef(link),
 				dmPolicy: "open",
 				groupPolicy: "open",
 				allowFrom: ["*"],
@@ -175,16 +186,8 @@ function buildOpenClawChannelsProjection(
 			channel.accounts[link.accountKey] = {
 				enabled: true,
 				wsUrl: `${toWebSocketUrl(stripTrailingSlash(cloudApiUrl))}/v1/channels/whatsapp/${link.account.id}/baileys`,
-				token: link.agentToken,
+				token: openClawChannelTokenSecretRef(link),
 				...(credential ? { authDir: credential.authDir } : {}),
-			};
-			continue;
-		}
-		if (provider === "imessage") {
-			channels.bluebubbles = {
-				enabled: true,
-				serverUrl: `${stripTrailingSlash(cloudApiUrl)}/v1/channels/imessage/bluebubbles`,
-				password: link.agentToken,
 			};
 		}
 	}
@@ -204,6 +207,37 @@ function buildRuntimeChannelCredentialsProjection(
 				`${right.provider}:${right.accountKey}:${right.credentialId}`,
 			),
 		);
+}
+
+function applyOpenClawRuntimeChannelSettings(
+	manifest: RuntimeManifest,
+	links: ManagedChannelLink[],
+): RuntimeManifest {
+	const openclaw = manifest.runtimes.openclaw;
+	if (!openclaw?.enabled) return manifest;
+
+	const existingRun = openclaw.run ?? { env: {}, prependPath: [] };
+	const secretEnv = omitOpenClawManagedChannelSecretEnv(existingRun.secretEnv ?? {});
+	for (const link of links) {
+		secretEnv[openClawChannelTokenEnvName(link)] = link.secretRef;
+	}
+	if (!openclaw.run && Object.keys(secretEnv).length === 0) {
+		return manifest;
+	}
+
+	return {
+		...manifest,
+		runtimes: {
+			...manifest.runtimes,
+			openclaw: {
+				...openclaw,
+				run: {
+					...existingRun,
+					secretEnv,
+				},
+			},
+		},
+	};
 }
 
 function applyHermesRuntimeChannelSettings(
@@ -264,6 +298,43 @@ function firstLinkForProvider(
 	provider: ChannelProvider,
 ): ManagedChannelLink | null {
 	return links.find((link) => link.account.provider === provider) ?? null;
+}
+
+function openClawChannelTokenSecretRef(link: ManagedChannelLink): OpenClawEnvSecretRef {
+	return {
+		source: "env",
+		provider: "default",
+		id: openClawChannelTokenEnvName(link),
+	};
+}
+
+function openClawChannelTokenEnvName(link: ManagedChannelLink): string {
+	return `${OPENCLAW_CHANNEL_TOKEN_ENV_PREFIX}${envKeySegment(link.account.provider)}_${envKeySegment(
+		link.accountKey,
+	)}${OPENCLAW_CHANNEL_TOKEN_ENV_SUFFIX}`;
+}
+
+function envKeySegment(value: string): string {
+	const segment = value
+		.toUpperCase()
+		.replace(/[^A-Z0-9]+/g, "_")
+		.replace(/^_+|_+$/g, "");
+	return segment || "CHANNEL";
+}
+
+function omitOpenClawManagedChannelSecretEnv(
+	input: Record<string, string>,
+): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(input).filter(([key]) => !isOpenClawManagedChannelSecretEnv(key)),
+	);
+}
+
+function isOpenClawManagedChannelSecretEnv(key: string): boolean {
+	return (
+		key.startsWith(OPENCLAW_CHANNEL_TOKEN_ENV_PREFIX) &&
+		key.endsWith(OPENCLAW_CHANNEL_TOKEN_ENV_SUFFIX)
+	);
 }
 
 function omitKeys<T extends string>(

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -61,9 +61,13 @@ export interface RuntimeChannelCredential {
 	material?: unknown;
 }
 
+const RUNTIME_CHANNEL_PROVIDERS = ["telegram", "discord", "whatsapp"] as const;
+const runtimeChannelProviderSchema = z.enum(RUNTIME_CHANNEL_PROVIDERS);
+type RuntimeChannelProvider = z.infer<typeof runtimeChannelProviderSchema>;
+
 export interface RuntimeChannelAccount {
 	id: string;
-	provider: "telegram" | "discord" | "whatsapp" | "imessage";
+	provider: RuntimeChannelProvider;
 	name: string;
 	status: string;
 	visibility: "private" | "public";
@@ -161,7 +165,7 @@ const runtimeChannelCredentialSchema = z
 const runtimeChannelAccountSchema = z
 	.object({
 		id: z.string().min(1),
-		provider: z.enum(["telegram", "discord", "whatsapp", "imessage"]),
+		provider: runtimeChannelProviderSchema,
 		name: z.string().min(1),
 		status: z.string().min(1),
 		visibility: z.enum(["private", "public"]).default("private"),
@@ -170,10 +174,36 @@ const runtimeChannelAccountSchema = z
 	})
 	.passthrough();
 
-const runtimeChannelsSchema = z.array(runtimeChannelAccountSchema);
+const runtimeChannelsSchema = z.array(z.unknown()).transform((accounts, ctx) => {
+	const allowedAccounts: RuntimeChannelAccount[] = [];
+	for (const [index, account] of accounts.entries()) {
+		const provider = recordValue(account)?.provider;
+		if (typeof provider === "string" && !isRuntimeChannelProvider(provider)) {
+			continue;
+		}
+		const parsed = runtimeChannelAccountSchema.safeParse(account);
+		if (!parsed.success) {
+			for (const issue of parsed.error.issues) {
+				ctx.addIssue({ ...issue, path: [index, ...issue.path] });
+			}
+			continue;
+		}
+		allowedAccounts.push(parsed.data);
+	}
+	return allowedAccounts;
+});
 
 function readJsonFile(path: string): unknown {
 	return JSON.parse(readFileSync(path, "utf-8")) as unknown;
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+	return value as Record<string, unknown>;
+}
+
+function isRuntimeChannelProvider(value: string): value is RuntimeChannelProvider {
+	return runtimeChannelProviderSchema.safeParse(value).success;
 }
 
 function zodErrors(error: z.ZodError): string[] {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1643,6 +1643,12 @@ function channelHasAccounts(channel: unknown): boolean {
 	return isPlainRecord(accounts) && Object.keys(accounts).length > 0;
 }
 
+function openClawManagedChannelUsesEnvSecretRefs(channels: Record<string, unknown>): boolean {
+	return ["telegram", "discord", "whatsapp"].some((channel) =>
+		channelHasAccounts(channels[channel]),
+	);
+}
+
 function stripTrailingSlash(value: string): string {
 	return value.replace(/\/+$/, "");
 }
@@ -1656,6 +1662,7 @@ function toWebSocketUrl(baseUrl: string): string {
 function openClawManagedChannelsPatch(channels: Record<string, unknown>): Record<string, unknown> {
 	const deleteEntries = openClawManagedChannelDeletes();
 	const runtimeReadyChannels = openClawRuntimeReadyChannels(channels);
+	const usesEnvSecretRefs = openClawManagedChannelUsesEnvSecretRefs(runtimeReadyChannels);
 	return {
 		channels: {
 			...deleteEntries,
@@ -1667,6 +1674,16 @@ function openClawManagedChannelsPatch(channels: Record<string, unknown>): Record
 				...channelPluginEntries(runtimeReadyChannels),
 			},
 		},
+		secrets: usesEnvSecretRefs
+			? {
+					providers: {
+						default: { source: "env" },
+					},
+					defaults: {
+						env: "default",
+					},
+				}
+			: undefined,
 	};
 }
 
@@ -1919,10 +1936,9 @@ const MANAGED_LIVE_SYNC_AGENTS = ["openclaw", "hermes", "codex"] as const;
 const OPENCLAW_EXTERNAL_CHANNEL_PLUGIN_SPECS: Record<string, readonly string[]> = {
 	discord: ["@openclaw/discord"],
 	whatsapp: ["clawhub:@openclaw/whatsapp", "@openclaw/whatsapp"],
-	bluebubbles: ["@openclaw/bluebubbles@2026.5.7"],
 };
 
-const OPENCLAW_MANAGED_CHANNELS = ["telegram", "discord", "whatsapp", "bluebubbles"] as const;
+const OPENCLAW_MANAGED_CHANNELS = ["telegram", "discord", "whatsapp"] as const;
 const OPENCLAW_GATEWAY_TOKEN_ENV = "OPENCLAW_GATEWAY_TOKEN";
 
 function desiredLiveSyncAgents(manifest: RuntimeManifest): LiveSyncAgent[] {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -2134,6 +2134,22 @@ exit 64
 									},
 								],
 							},
+							{
+								id: "acct-imessage-legacy",
+								provider: "imessage",
+								name: "Legacy iMessage",
+								status: "active",
+								visibility: "private",
+								runtime_links: [
+									{
+										id: "link-imessage-legacy",
+										account_id: "acct-imessage-legacy",
+										agent_id: "env_runtime",
+										status: "active",
+										agent_token: "legacy-imessage-token",
+									},
+								],
+							},
 						]),
 						{
 							status: 200,
@@ -2154,6 +2170,8 @@ exit 64
 			expect("channels" in loaded).toBe(true);
 			if (!("channels" in loaded)) throw new Error("expected channels load success");
 			expect(loaded.etag).toBe('"channels-etag-1"');
+			expect(loaded.channels).toHaveLength(1);
+			expect(loaded.channels[0]?.provider).toBe("telegram");
 			expect(loaded.channels[0]?.runtime_links[0]?.agent_token).toBe("agent-token-runtime");
 			expect(captured).toHaveLength(1);
 			expect(captured[0].path).toBe("/prefix/v1/channels");
@@ -4408,11 +4426,28 @@ exit 64
 			const patchText = readFileSync(openclawPatch, "utf-8");
 			expect(patchText).not.toContain('"$patch"');
 			expect(patchText).toContain('"telegram"');
-			expect(patchText).toContain('"botToken": "agent-token-init"');
+			expect(patchText).toContain('"botToken": {');
+			expect(patchText).toContain(
+				'"id": "CLAWDI_CHANNEL_TELEGRAM_CLAWDI_ACCTTELEGRAM_AGENT_TOKEN"',
+			);
+			expect(patchText).not.toContain("agent-token-init");
 			expect(patchText).toContain('"discord"');
-			expect(patchText).toContain('"token": "discord-agent-token-init"');
+			expect(patchText).toContain('"token": {');
+			expect(patchText).toContain('"id": "CLAWDI_CHANNEL_DISCORD_CLAWDI_ACCTDISCORD1_AGENT_TOKEN"');
+			expect(patchText).not.toContain("discord-agent-token-init");
+			expect(patchText).toContain('"default": {');
+			expect(patchText).toContain('"source": "env"');
 			expect(patchText).toContain('"plugins"');
 			expect(readFileSync(openclawPluginInstalls, "utf-8")).toBe("@openclaw/discord\n");
+			const openclawRunConfig = JSON.parse(
+				readFileSync(join(state, "config", "run", "openclaw.json"), "utf-8"),
+			);
+			expect(openclawRunConfig.secretEnv).toMatchObject({
+				CLAWDI_CHANNEL_TELEGRAM_CLAWDI_ACCTTELEGRAM_AGENT_TOKEN:
+					"secret://channels/telegram/clawdi_accttelegram/agent-token",
+				CLAWDI_CHANNEL_DISCORD_CLAWDI_ACCTDISCORD1_AGENT_TOKEN:
+					"secret://channels/discord/clawdi_acctdiscord1/agent-token",
+			});
 			const secretsText = readFileSync(join(run, "secrets", "runtime-secrets.json"), "utf-8");
 			expect(secretsText).toContain("secret://channels/telegram/");
 			expect(secretsText).toContain("agent-token-init");
@@ -4925,7 +4960,7 @@ exit 0
 		expect(patchText).toContain('"telegram": null');
 		expect(patchText).toContain('"discord": null');
 		expect(patchText).toContain('"whatsapp": null');
-		expect(patchText).toContain('"bluebubbles": null');
+		expect(patchText).not.toContain("bluebubbles");
 		expect(patchText).not.toContain('"$patch"');
 		expect(patchText).not.toContain('"botToken"');
 	});


### PR DESCRIPTION
## Why

The v2 hosted runtime channel payload was provider-unfiltered. The v2 UI only offered Telegram/Discord/WhatsApp, but the environment-bound CLI `/v1/channels` runtime branch filtered only by active agent link/status. That allowed a legacy provider account such as `imessage` to reach a v2 runtime manifest and be projected by the CLI.

This PR closes that leak class in the authoritative backend emit path and keeps a defensive parser-side guard for old backends.

## What Changed

- Added a v2 runtime channel provider allowlist in the backend `/v1/channels` runtime branch: Telegram, Discord, and WhatsApp only.
- Defensively drop non-allowlisted providers in the CLI runtime channel parser.
- Removed iMessage/BlueBubbles from the v2 converge path: the CLI projection branch, the OpenClaw BlueBubbles plugin spec/managed-channel entry, and the `imessage` runtime parser type.
- Project OpenClaw channel tokens as env-backed SecretRefs instead of plaintext, with matching `openclaw.run.secretEnv` entries.
- Preserved #340 behavior: while `WHATSAPP_UPSTREAM_READY=false`, WhatsApp runtime links are skipped before projection/materialization.

## Source Checks

- Backend v2 runtime reachability is the CLI + environment-bound API key branch (`auth.is_cli && auth.api_key.environment_id is not None`) in `backend/app/routes/channel_routers/public.py:356-390`.
- Hosted context: `Clawdi-AI/clawdi-hosted#711`, Addendum 2026-07-08, identifies the unfiltered `/v1/channels` runtime payload, says BlueBubbles deletion is gated on adding the runtime provider allowlist, and notes no v2 BlueBubbles MITM profile exists.
- OpenClaw env SecretRef shape is `{ source: "env", provider, id }`: `/tmp/openclaw-src/src/config/zod-schema.core.ts:33-90` and `/tmp/openclaw-src/src/config/types.secrets.ts:14-25`.
- OpenClaw Telegram and Discord token fields are `SecretInputSchema`: `/tmp/openclaw-src/src/config/zod-schema.providers-core.ts:271` and `/tmp/openclaw-src/src/config/zod-schema.providers-core.ts:651`.
- OpenClaw WhatsApp remains owner-gated: current upstream strict account schema exposes `authDir` and does not accept the existing `wsUrl/token` projection shape (`/tmp/openclaw-src/src/config/zod-schema.providers-whatsapp.ts:156-165`). This PR keeps the #340 gate, leaves `wsUrl` untouched as requested, and does not materialize WhatsApp wiring while the gate is false.

## Retirement Cleanup

No retirement cleanup is included. The BlueBubbles plugin/config was only ever written when an `imessage` account was projected, and the v2 surface never offered iMessage; owner confirmed no existing stock.

## Verification

- `bun run check`: pass
- `bun run --cwd packages/cli test tests/runtime.test.ts`: pass (`87 pass`)
- Backend focused channel tests against a throwaway pgvector Postgres upgraded to Alembic head: pass (`2 passed, 156 deselected`)
