### PR TITLE
fix(cli): keep channel secrets out of deploy manifest secretValues

### DIFF
--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -30,7 +30,7 @@ import {
 	runtimeSourceAuthEnv,
 } from "../runtime/manifest-source";
 import { startRuntimeMitmSidecar } from "../runtime/mitm-sidecar";
-import { detectRuntimeMode, getRuntimePaths } from "../runtime/paths";
+import { detectRuntimeMode, getRuntimePaths, type RuntimePaths } from "../runtime/paths";
 import {
 	buildRuntimeBootStatus,
 	ensureRuntimeStateDirs,
@@ -1228,6 +1228,14 @@ function writeRuntimeManifestEtag(
 	writePrivateFileAtomic(paths.manifestEtag, `${etag}\n`, { mode: 0o644, dirMode: 0o755 });
 }
 
+function cacheRuntimeSourceManifest(load: RuntimeManifestLoad, paths: RuntimePaths): string | null {
+	return cacheRuntimeLastGoodManifest(
+		load.sourceManifest ?? load.manifest,
+		paths,
+		load.secretValues,
+	);
+}
+
 function readRuntimeChannelsEtag(paths: ReturnType<typeof getRuntimePaths>): string | undefined {
 	if (!existsSync(paths.channelsEtag)) return undefined;
 	const etag = readFileSync(paths.channelsEtag, "utf-8").trim();
@@ -1722,21 +1730,13 @@ export async function runtimeInit(opts: RuntimeInitOptions = {}) {
 		];
 		const installOk = runtimeErrors.length === 0;
 		if (installOk && loaded.source === "remote-datasource") {
-			convergence.outputs.manifestLastGood = cacheRuntimeLastGoodManifest(
-				convergence.manifest,
-				paths,
-				convergenceLoad.secretValues,
-			);
+			convergence.outputs.manifestLastGood = cacheRuntimeSourceManifest(convergenceLoad, paths);
 			writeRuntimeManifestEtag(paths, loaded.etag);
 			if (channelsLoad) {
 				writeRuntimeChannelsEtag(paths, channelsLoad.etag);
 			}
 		} else if (installOk) {
-			convergence.outputs.manifestLastGood = cacheRuntimeLastGoodManifest(
-				convergence.manifest,
-				paths,
-				convergenceLoad.secretValues,
-			);
+			convergence.outputs.manifestLastGood = cacheRuntimeSourceManifest(convergenceLoad, paths);
 		}
 		const status = buildRuntimeBootStatus(
 			{
@@ -1892,11 +1892,7 @@ async function runtimeWatchTick(
 			systemdApplyResult.userUnitsChanged.length > 0;
 		if (errors.length > 0) {
 			if (convergence.installErrors.length === 0 && !systemdApplyError) {
-				convergence.outputs.manifestLastGood = cacheRuntimeLastGoodManifest(
-					convergence.manifest,
-					paths,
-					loaded.secretValues,
-				);
+				convergence.outputs.manifestLastGood = cacheRuntimeSourceManifest(loaded, paths);
 				if (!("notModified" in manifestLoad)) {
 					writeRuntimeManifestEtag(paths, manifestLoad.etag);
 				}
@@ -1918,11 +1914,7 @@ async function runtimeWatchTick(
 				convergence: convergence.outputs,
 			};
 		}
-		convergence.outputs.manifestLastGood = cacheRuntimeLastGoodManifest(
-			convergence.manifest,
-			paths,
-			loaded.secretValues,
-		);
+		convergence.outputs.manifestLastGood = cacheRuntimeSourceManifest(loaded, paths);
 		if (!("notModified" in manifestLoad)) {
 			writeRuntimeManifestEtag(paths, manifestLoad.etag);
 		}

--- a/packages/cli/src/runtime/channels.ts
+++ b/packages/cli/src/runtime/channels.ts
@@ -75,13 +75,15 @@ export function applyRuntimeChannelsToManifestLoad(
 	if (!channels) return load;
 	const managedLinks = managedChannelLinks(channels.channels);
 	const manifest = applyRuntimeChannelProjection(load.manifest, managedLinks);
+	const localSecretValues = {
+		...(load.localSecretValues ?? {}),
+		...channelSecretValues(managedLinks, manifest.projection?.channelCredentials),
+	};
 	return {
 		...load,
 		manifest,
-		secretValues: {
-			...(load.secretValues ?? {}),
-			...channelSecretValues(managedLinks, manifest.projection?.channelCredentials),
-		},
+		sourceManifest: load.sourceManifest ?? load.manifest,
+		localSecretValues: Object.keys(localSecretValues).length > 0 ? localSecretValues : undefined,
 	};
 }
 
@@ -89,7 +91,6 @@ function managedChannelLinks(channels: RuntimeChannelAccount[]): ManagedChannelL
 	const links: ManagedChannelLink[] = [];
 	for (const account of channels) {
 		if (account.status !== "active") continue;
-		if (account.provider === "whatsapp" && !WHATSAPP_UPSTREAM_READY) continue;
 		for (const link of account.runtime_links) {
 			if (link.status !== "active" || !link.agent_token) continue;
 			const accountKey = channelAccountKey(account);
@@ -152,6 +153,7 @@ function buildOpenClawChannelsProjection(
 	const channels: Record<string, unknown> = {};
 	for (const link of links) {
 		const provider = link.account.provider;
+		if (provider === "whatsapp" && !WHATSAPP_UPSTREAM_READY) continue;
 		if (provider === "telegram") {
 			const channel = ensureAccountChannel(channels, "telegram", link.accountKey);
 			channel.accounts[link.accountKey] = {
@@ -219,6 +221,7 @@ function applyOpenClawRuntimeChannelSettings(
 	const existingRun = openclaw.run ?? { env: {}, prependPath: [] };
 	const secretEnv = omitOpenClawManagedChannelSecretEnv(existingRun.secretEnv ?? {});
 	for (const link of links) {
+		if (link.account.provider === "whatsapp" && !WHATSAPP_UPSTREAM_READY) continue;
 		secretEnv[openClawChannelTokenEnvName(link)] = link.secretRef;
 	}
 	if (!openclaw.run && Object.keys(secretEnv).length === 0) {

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -21,7 +21,12 @@ export interface RuntimeManifestLoad {
 	source: "fixture-file" | "remote-datasource" | "last-good-cache";
 	sourcePath: string;
 	offline: boolean;
+	// Values supplied by the manifest datasource. Keep this deploy-surface map provider-only.
 	secretValues?: Record<string, string>;
+	// Values synthesized from separate local/runtime datasources, such as /v1/channels.
+	localSecretValues?: Record<string, string>;
+	// Original datasource manifest before local runtime projections are applied.
+	sourceManifest?: RuntimeManifest;
 	etag?: string;
 }
 

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -3476,12 +3476,21 @@ function runtimeWorkspaceRoot(manifest: RuntimeManifest, paths: RuntimePaths): s
 	return manifest.workspaceRoot ?? paths.workspaceRoot;
 }
 
+function runtimeSecretValues(load: RuntimeManifestLoad): Record<string, string> | undefined {
+	const merged = {
+		...(load.secretValues ?? {}),
+		...(load.localSecretValues ?? {}),
+	};
+	return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
 export function convergeRuntimeManifest(
 	load: RuntimeManifestLoad,
 	paths: RuntimePaths,
 	opts: { cacheLastGood?: boolean } = {},
 ): RuntimeConvergenceResult {
 	const { manifest } = load;
+	const secretValues = runtimeSecretValues(load);
 	const workspaceRoot = runtimeWorkspaceRoot(manifest, paths);
 	const enabledRuntimes = Object.entries(manifest.runtimes)
 		.filter(([, runtime]) => runtime.enabled)
@@ -3568,9 +3577,9 @@ export function convergeRuntimeManifest(
 		? writeMitmProfileBundle(mitmProfileBundle, paths)
 		: clearMitmProfileBundle(paths);
 	const daemonAuthTokenFile = writeDaemonAuthToken(paths);
-	writeSecretValues(load.secretValues, paths);
+	writeSecretValues(secretValues, paths);
 	try {
-		materializeHostedChannelCredentials(manifest, load.secretValues);
+		materializeHostedChannelCredentials(manifest, secretValues);
 	} catch (error) {
 		installErrors.push(
 			`runtime channel credential materialization failed: ${
@@ -3578,7 +3587,7 @@ export function convergeRuntimeManifest(
 			}`,
 		);
 	}
-	const mitmSecretFile = writeMitmSecretFile(manifest, load.secretValues, paths);
+	const mitmSecretFile = writeMitmSecretFile(manifest, secretValues, paths);
 	const mitmSystemdProgram = runtimeMitmSystemdProgram(
 		manifest,
 		paths,
@@ -3664,7 +3673,7 @@ export function convergeRuntimeManifest(
 			: {};
 		const runtimeProviderSecretFile = writeRuntimeProviderSecretFile(
 			name,
-			load.secretValues,
+			secretValues,
 			secretEnv,
 			paths,
 		);
@@ -3690,7 +3699,7 @@ export function convergeRuntimeManifest(
 			const program = buildRuntimeSystemdUserProgram({
 				config: runConfig,
 				paths,
-				secretValues: load.secretValues,
+				secretValues,
 				mitm: mitmSystemdProgram,
 			});
 			if (program) {
@@ -3722,7 +3731,7 @@ export function convergeRuntimeManifest(
 			const program = buildRuntimeSystemdUserProgram({
 				config: serviceRunConfig,
 				paths,
-				secretValues: load.secretValues,
+				secretValues,
 				mitm: mitmSystemdProgram,
 			});
 			if (program) {
@@ -3747,7 +3756,7 @@ export function convergeRuntimeManifest(
 		paths,
 		workspaceRoot,
 		daemonAuthTokenFile,
-		load.secretValues,
+		secretValues,
 		providerProjectionRevisions,
 	);
 	installErrors.push(...systemdUnits.serviceInstallErrors);
@@ -3757,7 +3766,11 @@ export function convergeRuntimeManifest(
 	removeStaleRuntimeRunConfigs(writtenRunConfigIds, paths);
 	removeStaleRuntimeSecretFiles(writtenRuntimeSecretIds, paths);
 	if (installErrors.length === 0 && opts.cacheLastGood !== false) {
-		manifestLastGood = writeLastGoodManifest(manifest, paths, load.secretValues);
+		manifestLastGood = writeLastGoodManifest(
+			load.sourceManifest ?? manifest,
+			paths,
+			load.secretValues,
+		);
 	}
 
 	return {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -2611,6 +2611,108 @@ exit 64
 		expect(projected.secretValues).toEqual({ "provider.default.apiKey": "sk-provider" });
 	});
 
+	it("keeps deploy manifest secretValues provider-only when channel links are projected", () => {
+		const loaded: RuntimeManifestLoad = {
+			manifest: {
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				runtime: "openclaw",
+				deploymentId: "dep_channel_secret_boundary",
+				environmentId: "env_channel_secret_boundary",
+				instanceId: "iid_channel_secret_boundary",
+				generation: 6,
+				issuedAt: "2026-07-08T00:00:00Z",
+				controlPlane: { apiUrl: "https://cloud-api.test" },
+				runtimes: {
+					openclaw: { enabled: true },
+					hermes: { enabled: true },
+				},
+			},
+			source: "remote-datasource",
+			sourcePath: "https://runtime.test/manifest",
+			offline: false,
+			secretValues: { "provider.default.apiKey": "sk-provider" },
+		};
+		const channels: RuntimeChannelsLoad = {
+			channels: [
+				{
+					id: "acct-telegram-1",
+					provider: "telegram",
+					name: "Runtime Telegram",
+					status: "active",
+					visibility: "private",
+					runtime_links: [
+						{
+							id: "link-telegram-1",
+							account_id: "acct-telegram-1",
+							agent_id: "env_channel_secret_boundary",
+							status: "active",
+							agent_token: "telegram-agent-token",
+						},
+					],
+					runtime_credentials: [],
+				},
+				{
+					id: "acct-discord-1",
+					provider: "discord",
+					name: "Runtime Discord",
+					status: "active",
+					visibility: "private",
+					runtime_links: [
+						{
+							id: "link-discord-1",
+							account_id: "acct-discord-1",
+							agent_id: "env_channel_secret_boundary",
+							status: "active",
+							agent_token: "discord-agent-token",
+						},
+					],
+					runtime_credentials: [],
+				},
+				{
+					id: "acct-whatsapp-1",
+					provider: "whatsapp",
+					name: "Runtime WhatsApp",
+					status: "active",
+					visibility: "private",
+					runtime_links: [
+						{
+							id: "link-whatsapp-1",
+							account_id: "acct-whatsapp-1",
+							agent_id: "env_channel_secret_boundary",
+							status: "active",
+							agent_token: "whatsapp-agent-token",
+						},
+					],
+					runtime_credentials: [],
+				},
+			],
+			source: "remote-datasource",
+			sourcePath: "https://runtime.test/v1/channels",
+			etag: '"channel-secret-boundary"',
+		};
+
+		const projected = applyRuntimeChannelsToManifestLoad(loaded, channels);
+
+		expect(projected.secretValues).toEqual({ "provider.default.apiKey": "sk-provider" });
+		expect(JSON.stringify(projected.secretValues ?? {})).not.toContain("channels/");
+		expect(projected.sourceManifest).toEqual(loaded.manifest);
+		expect(JSON.stringify(projected.sourceManifest)).not.toContain('"channels"');
+		expect(
+			projected.localSecretValues?.["secret://channels/telegram/clawdi_accttelegram/agent-token"],
+		).toBe("telegram-agent-token");
+		expect(
+			projected.localSecretValues?.["secret://channels/discord/clawdi_acctdiscord1/agent-token"],
+		).toBe("discord-agent-token");
+		expect(
+			projected.localSecretValues?.["secret://channels/whatsapp/clawdi_acctwhatsapp/agent-token"],
+		).toBe("whatsapp-agent-token");
+		expect(projected.manifest.projection?.channels).toMatchObject({
+			telegram: { enabled: true },
+			discord: { enabled: true },
+		});
+		expect(JSON.stringify(projected.manifest.projection?.channels ?? {})).not.toContain("whatsapp");
+	});
+
 	it("gates WhatsApp runtime channel projection until upstream support is ready", () => {
 		const accountId = "00000000-0000-0000-0000-000000000001";
 		const linkId = "link-whatsapp-1";
@@ -2684,7 +2786,13 @@ exit 64
 
 		expect(projected.manifest.projection?.channels).toEqual({});
 		expect(projected.manifest.projection?.channelCredentials).toEqual([]);
-		expect(projected.manifest.mitmProfiles?.profiles ?? []).toEqual([]);
+		expect(projected.manifest.mitmProfiles?.profiles).toEqual([
+			expect.objectContaining({
+				id: "native-whatsapp-clawdi_000000000000-graph-managed",
+				kind: "http",
+				owner: "clawdi-native-channels",
+			}),
+		]);
 		expect(JSON.stringify(projected.manifest)).not.toContain(accountId);
 		expect(JSON.stringify(projected.manifest)).not.toContain("baileys");
 		expect(JSON.stringify(projected.manifest)).not.toContain("wa-agent-token");
@@ -4848,6 +4956,14 @@ exit 64
 			expect(secretsText).toContain("agent-token-init");
 			expect(secretsText).toContain("secret://channels/discord/");
 			expect(secretsText).toContain("discord-agent-token-init");
+			const cachedManifestText = readFileSync(
+				join(state, "cache", "manifest.last-good.json"),
+				"utf-8",
+			);
+			expect(cachedManifestText).not.toContain('"channels"');
+			expect(cachedManifestText).not.toContain("agent-token-init");
+			expect(cachedManifestText).not.toContain("discord-agent-token-init");
+			expect(existsSync(join(state, "cache", "runtime-secrets.last-good.json"))).toBe(false);
 			const profileBundle = readFileSync(join(state, "config", "mitm", "profiles.json"), "utf-8");
 			expect(profileBundle).toContain("clawdi-native-channels");
 			expect(profileBundle).toContain("/v1/channels/telegram");


### PR DESCRIPTION
Regression caught by the hosted image smoke (smoke-cloud-datasource.sh) on the beta.36 release — clawdi CI missed it because the smoke lives in clawdi-hosted. beta.35 passed; beta.36 failed the "deploy manifest secretValues must be provider-only" invariant.

**Root cause:** `applyRuntimeChannelsToManifestLoad` (channels.ts) merged `channelSecretValues(...)` INTO the deploy datasource's `secretValues`, so telegram/discord channel tokens leaked into the deploy manifest's secret map (and the last-good cache). The correct architecture: the deploy manifest stays provider-only; channels come from the separate `/api/channels` fetch and are synthesized LOCALLY.

**Fix:**
- Deploy `secretValues` stays provider-only; channel token/credential material now goes into a separate `localSecretValues`.
- Local materialization aggregates deploy + local secrets; provider health + last-good cache use provider-only `load.secretValues` and persist the original datasource `sourceManifest` (no `projection.channels`, no channel tokens cached).
- WhatsApp gating (WHATSAPP_UPSTREAM_READY) preserved; it no longer blocks local MITM/token synthesis.
- New CLI unit tests lock the provider-only invariant + cache boundary so clawdi CI catches this next time.

Rebased onto current origin/main — #337 (Hermes model-provider plugin projection) fully intact (verified applyHostedHermesAiProviderProjection / HermesHostedProviderPluginProjection / detectHermesInstalledVersion unchanged). Net +164/-35.

Verify: CLI typecheck + 759 tests + biome; and the actual hosted smoke-cloud-datasource.sh green with a locally-packed CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)