### PR TITLE
fix(cli): enable Node env proxy for MITM runtime env

### DIFF
--- a/packages/cli/src/runtime/mitm-env.ts
+++ b/packages/cli/src/runtime/mitm-env.ts
@@ -100,6 +100,7 @@ export function applyMitmSidecarRuntimeEnv(
 	env.http_proxy = output.proxyUrl;
 	env.NO_PROXY = buildNoProxy(output.proxyUrl);
 	env.no_proxy = env.NO_PROXY;
+	env.NODE_USE_ENV_PROXY = "1";
 	env.OPENCLAW_PROXY_URL = output.proxyUrl;
 	env.CLAWDI_MITM_CA_FILE = output.caFile;
 	env.SSL_CERT_FILE = output.caFile;

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -6534,6 +6534,7 @@ exit 64
 		expect(openclawEnv).not.toContain("CLAWDI_MITM_SECRET_FILE");
 		expect(openclawEnv).toContain('HTTPS_PROXY="http://127.0.0.1:');
 		expect(openclawEnv).toContain('OPENCLAW_PROXY_URL="http://127.0.0.1:');
+		expect(openclawEnv).toContain('NODE_USE_ENV_PROXY="1"');
 		expect(openclawEnv).toContain(
 			`NODE_EXTRA_CA_CERTS="${join(run, "mitm", "systemd", "ca.pem")}"`,
 		);


### PR DESCRIPTION
## Summary
- Add `NODE_USE_ENV_PROXY=1` when applying MITM sidecar runtime env for systemd-launched hosted runtimes.
- Assert the generated OpenClaw systemd env file includes the Node proxy knob.

## Verification
- `bun run --cwd packages/cli test tests/runtime.test.ts`
- `bun run check`

## Notes
- This is a pure parity add for the runtime proxy env. The other key differences between `buildMitmSidecarEnv` and `applyMitmSidecarRuntimeEnv` are control inputs for launching/configuring the sidecar (`CLAWDI_MITM_ENABLED`, profile bundle, secret file), not final runtime proxy env drift.
- Node CLI docs list `NODE_USE_ENV_PROXY=1` as the environment-variable form for using proxy settings from `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`, added in v24.0.0 / v22.21.0: https://nodejs.org/api/cli.html#node_use_env_proxy1
- Node globals docs state built-in `fetch()` is based on bundled `undici`, so this covers Node-native fetch paths in hosted runtimes: https://nodejs.org/api/globals.html#fetch