### PR TITLE
Release CLI beta 38

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -73,7 +73,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.37",
+      "version": "0.12.10-beta.38",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.37",
+	"version": "0.12.10-beta.38",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Bumps `clawdi` 0.12.10-beta.37 → beta.38 to publish the default-allow transparent mitmproxy egress gateway + account-level managed provider key handling landed in #345.

**Why:** v2 hosted runtimes install the full CLI at runtime tracking the `clawdi@beta` dist-tag (the image is a stable clean base and does not bake the CLI). beta.37 predates the #345 merge, so a new beta is required for runtimes to self-upgrade and activate the gateway. No image rebuild, no pod/manifest change.

**Rollout:** merge → `cli-publish.yml` auto-publishes beta.38 under the `beta` tag → dev/canary v2 pods self-upgrade → validate gateway e2e on a dev CVM before any production rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)