### PR TITLE
feat(admin): fail-closed ownership + credential-mint audit

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -137,6 +137,31 @@ async def _resolve_or_create_user(db: AsyncSession, clerk_id: str) -> User:
     return user
 
 
+async def _assert_admin_target_owns_environment(
+    db: AsyncSession,
+    *,
+    env: AgentEnvironment,
+    target_clerk_id: str | None,
+) -> UUID:
+    if target_clerk_id is None:
+        return env.user_id
+    target = (
+        await db.execute(select(User).where(User.clerk_id == target_clerk_id))
+    ).scalar_one_or_none()
+    if target is None or env.user_id != target.id:
+        logger.warning(
+            "admin_environment_owner_rejected target_clerk_id=%s env_id=%s owner_user_id=%s",
+            target_clerk_id,
+            env.id,
+            env.user_id,
+        )
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            "Agent environment is not owned by target user",
+        )
+    return target.id
+
+
 @router.post("/auth/keys", response_model=ApiKeyCreated)
 async def admin_mint_api_key(
     body: AdminApiKeyCreate,
@@ -201,6 +226,24 @@ async def admin_mint_api_key(
         api_key.environment_id,
         api_key.managed,
     )
+    record_control_plane_audit(
+        db,
+        actor_type="admin",
+        action="api_key.mint",
+        resource_type="api_key",
+        resource_id=str(api_key.id),
+        environment_id=api_key.environment_id,
+        target_user_id=target.id,
+        source="api.admin",
+        details={
+            "label": api_key.label,
+            "key_prefix": api_key.key_prefix,
+            "managed": api_key.managed,
+            "has_environment_binding": api_key.environment_id is not None,
+            "scope_count": None if api_key.scopes is None else len(api_key.scopes),
+        },
+    )
+    await db.commit()
     return ApiKeyCreated(
         id=str(api_key.id),
         label=api_key.label,
@@ -234,6 +277,22 @@ async def admin_revoke_api_key(
         return ApiKeyRevokeResponse(status="revoked")
 
     api_key.revoked_at = datetime.now(UTC)
+    record_control_plane_audit(
+        db,
+        actor_type="admin",
+        action="api_key.revoke",
+        resource_type="api_key",
+        resource_id=str(api_key.id),
+        environment_id=api_key.environment_id,
+        target_user_id=api_key.user_id,
+        source="api.admin",
+        details={
+            "label": api_key.label,
+            "key_prefix": api_key.key_prefix,
+            "managed": api_key.managed,
+            "has_environment_binding": api_key.environment_id is not None,
+        },
+    )
     await db.commit()
     invalidate_api_key_auth_cache(api_key.id)
     logger.info(
@@ -624,6 +683,7 @@ async def admin_register_environment(
 
 async def _admin_delete_environment(
     environment_id: UUID,
+    target_clerk_id: str | None,
     db: AsyncSession,
 ) -> None:
     env = (
@@ -631,18 +691,43 @@ async def _admin_delete_environment(
     ).scalar_one_or_none()
     if env is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
+    target_user_id = await _assert_admin_target_owns_environment(
+        db,
+        env=env,
+        target_clerk_id=target_clerk_id,
+    )
+    record_control_plane_audit(
+        db,
+        actor_type="admin",
+        action="agent_environment.delete",
+        resource_type="agent_environment",
+        resource_id=str(env.id),
+        environment_id=env.id,
+        target_user_id=target_user_id,
+        source="api.admin",
+        details={
+            "agent_type": env.agent_type,
+            "machine_id": env.machine_id,
+            "explicit_identity": env.registration_key is None,
+        },
+    )
     await db.delete(env)
     await db.commit()
-    logger.info("admin_environment_deleted env_id=%s", environment_id)
+    logger.info(
+        "admin_environment_deleted target_clerk_id=%s env_id=%s",
+        target_clerk_id,
+        environment_id,
+    )
 
 
 @router.delete("/agents/{agent_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def admin_delete_agent(
     agent_id: UUID,
+    target_clerk_id: str | None = None,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> None:
-    await _admin_delete_environment(agent_id, db)
+    await _admin_delete_environment(agent_id, target_clerk_id, db)
 
 
 @router.delete(
@@ -652,6 +737,7 @@ async def admin_delete_agent(
 )
 async def admin_delete_environment(
     environment_id: UUID,
+    target_clerk_id: str | None = None,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> None:
@@ -661,7 +747,7 @@ async def admin_delete_environment(
     user-facing `/v1/environments/{id}` semantics. Unlike the dashboard route,
     first-party cleanup may delete explicit-identity rows.
     """
-    await _admin_delete_environment(environment_id, db)
+    await _admin_delete_environment(environment_id, target_clerk_id, db)
 
 
 async def _next_environment_sort_order(db: AsyncSession, user_id: UUID) -> int:
@@ -685,6 +771,11 @@ async def _admin_upsert_runtime_state(
     ).scalar_one_or_none()
     if env is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent environment not found")
+    target_user_id = await _assert_admin_target_owns_environment(
+        db,
+        env=env,
+        target_clerk_id=body.target_clerk_id,
+    )
 
     state = (
         await db.execute(
@@ -727,7 +818,7 @@ async def _admin_upsert_runtime_state(
         resource_type="hosted_runtime_state",
         resource_id=str(environment_id),
         environment_id=environment_id,
-        target_user_id=env.user_id,
+        target_user_id=target_user_id,
         source="api.admin",
         details={
             "deployment_id": body.deployment_id,
@@ -745,7 +836,9 @@ async def _admin_upsert_runtime_state(
     )
     await db.commit()
     logger.info(
-        "admin_runtime_state_upserted environment_id=%s deployment_id=%s generation=%s",
+        "admin_runtime_state_upserted target_clerk_id=%s environment_id=%s "
+        "deployment_id=%s generation=%s",
+        body.target_clerk_id,
         environment_id,
         body.deployment_id,
         body.generation,
@@ -787,6 +880,7 @@ async def admin_upsert_runtime_state(
 
 async def _admin_delete_runtime_state(
     environment_id: UUID,
+    target_clerk_id: str | None,
     db: AsyncSession,
 ) -> None:
     env = (
@@ -794,6 +888,11 @@ async def _admin_delete_runtime_state(
     ).scalar_one_or_none()
     if env is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent environment not found")
+    target_user_id = await _assert_admin_target_owns_environment(
+        db,
+        env=env,
+        target_clerk_id=target_clerk_id,
+    )
 
     state = (
         await db.execute(
@@ -825,13 +924,14 @@ async def _admin_delete_runtime_state(
         resource_type="hosted_runtime_state",
         resource_id=str(environment_id),
         environment_id=environment_id,
-        target_user_id=env.user_id,
+        target_user_id=target_user_id,
         source="api.admin",
         details=details,
     )
     await db.commit()
     logger.info(
-        "admin_runtime_state_deleted environment_id=%s existed=%s",
+        "admin_runtime_state_deleted target_clerk_id=%s environment_id=%s existed=%s",
+        target_clerk_id,
         environment_id,
         state is not None,
     )
@@ -843,10 +943,11 @@ async def _admin_delete_runtime_state(
 )
 async def admin_delete_agent_runtime_state(
     agent_id: UUID,
+    target_clerk_id: str | None = None,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> None:
-    await _admin_delete_runtime_state(agent_id, db)
+    await _admin_delete_runtime_state(agent_id, target_clerk_id, db)
 
 
 @router.delete(
@@ -856,10 +957,11 @@ async def admin_delete_agent_runtime_state(
 )
 async def admin_delete_runtime_state(
     environment_id: UUID,
+    target_clerk_id: str | None = None,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> None:
-    await _admin_delete_runtime_state(environment_id, db)
+    await _admin_delete_runtime_state(environment_id, target_clerk_id, db)
 
 
 async def _admin_get_channel_row(

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -106,6 +106,7 @@ class AdminRuntimeStateUpsert(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    target_clerk_id: str | None = None
     deployment_id: str = Field(min_length=1, max_length=200)
     app_id: str | None = Field(default=None, min_length=1, max_length=200)
     instance_id: str = Field(min_length=1, max_length=200)

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -210,6 +210,43 @@ async def test_admin_mint_accepts_arbitrary_scopes(admin_client, db_session, see
 
 
 @pytest.mark.asyncio
+async def test_admin_mint_api_key_writes_control_plane_audit(admin_client, db_session, seed_user):
+    from sqlalchemy import select
+
+    from app.models.audit import ControlPlaneAuditEvent
+
+    response = await admin_client.post(
+        "/v1/admin/auth/keys",
+        headers=_AUTH,
+        json={
+            "target_clerk_id": seed_user.clerk_id,
+            "label": "audit-mint",
+            "managed": True,
+        },
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    event = (
+        await db_session.execute(
+            select(ControlPlaneAuditEvent).where(
+                ControlPlaneAuditEvent.action == "api_key.mint",
+                ControlPlaneAuditEvent.resource_id == body["id"],
+            )
+        )
+    ).scalar_one()
+    assert event.actor_type == "admin"
+    assert event.resource_type == "api_key"
+    assert event.target_user_id == seed_user.id
+    assert event.source == "api.admin"
+    assert event.details["label"] == "audit-mint"
+    assert event.details["key_prefix"] == body["key_prefix"]
+    assert event.details["managed"] is True
+    assert event.details["has_environment_binding"] is False
+    assert body["raw_key"] not in str(event.details)
+
+
+@pytest.mark.asyncio
 async def test_admin_mint_lazy_creates_user(admin_client, db_session):
     """First-time deploy path: a user who's never visited cloud-api
     directly (no row yet) clicks Deploy on the upstream SaaS
@@ -439,6 +476,43 @@ async def test_admin_revoke_happy_path(admin_client, db_session, seed_user):
     db_session.expire_all()
     row = (await db_session.execute(select(ApiKey).where(ApiKey.id == key_id))).scalar_one()
     assert row.revoked_at is not None
+
+
+@pytest.mark.asyncio
+async def test_admin_revoke_api_key_writes_control_plane_audit(admin_client, db_session, seed_user):
+    from sqlalchemy import select
+
+    from app.models.audit import ControlPlaneAuditEvent
+
+    minted_resp = await admin_client.post(
+        "/v1/admin/auth/keys",
+        headers=_AUTH,
+        json={"target_clerk_id": seed_user.clerk_id, "label": "audit-revoke"},
+    )
+    assert minted_resp.status_code == 200, minted_resp.text
+    minted = minted_resp.json()
+
+    response = await admin_client.delete(
+        f"/v1/admin/auth/keys/{minted['id']}",
+        headers=_AUTH,
+    )
+    assert response.status_code == 200, response.text
+
+    event = (
+        await db_session.execute(
+            select(ControlPlaneAuditEvent).where(
+                ControlPlaneAuditEvent.action == "api_key.revoke",
+                ControlPlaneAuditEvent.resource_id == minted["id"],
+            )
+        )
+    ).scalar_one()
+    assert event.actor_type == "admin"
+    assert event.resource_type == "api_key"
+    assert event.target_user_id == seed_user.id
+    assert event.source == "api.admin"
+    assert event.details["label"] == "audit-revoke"
+    assert event.details["key_prefix"] == minted["key_prefix"]
+    assert minted["raw_key"] not in str(event.details)
 
 
 @pytest.mark.asyncio
@@ -918,7 +992,11 @@ async def test_admin_register_env_auto_assigns_explicit_default_names(
     codex = await register_explicit("codex")
     claude_code = await register_explicit("claude_code")
 
-    deleted = await admin_client.delete(f"/v1/admin/environments/{first_openclaw}", headers=_AUTH)
+    deleted = await admin_client.delete(
+        f"/v1/admin/environments/{first_openclaw}",
+        headers=_AUTH,
+        params={"target_clerk_id": seed_user.clerk_id},
+    )
     assert deleted.status_code == 204, deleted.text
 
     third_openclaw = await register_explicit("openclaw")
@@ -1012,6 +1090,7 @@ async def test_admin_agents_alias_registers_with_agent_id_and_runtime_state(
         f"/v1/admin/agents/{agent_id}/runtime-state",
         headers=_AUTH,
         json={
+            "target_clerk_id": seed_user.clerk_id,
             "deployment_id": "dep-admin-agent-alias",
             "instance_id": "iid-admin-agent-alias",
             "generation": 7,
@@ -1033,6 +1112,7 @@ async def test_admin_agents_alias_registers_with_agent_id_and_runtime_state(
     deleted_state = await admin_client.delete(
         f"/v1/admin/agents/{agent_id}/runtime-state",
         headers=_AUTH,
+        params={"target_clerk_id": seed_user.clerk_id},
     )
     assert deleted_state.status_code == 204, deleted_state.text
 
@@ -1043,7 +1123,11 @@ async def test_admin_agents_alias_registers_with_agent_id_and_runtime_state(
     ).scalar_one_or_none()
     assert state is None
 
-    deleted_agent = await admin_client.delete(f"/v1/admin/agents/{agent_id}", headers=_AUTH)
+    deleted_agent = await admin_client.delete(
+        f"/v1/admin/agents/{agent_id}",
+        headers=_AUTH,
+        params={"target_clerk_id": seed_user.clerk_id},
+    )
     assert deleted_agent.status_code == 204, deleted_agent.text
 
     env = (
@@ -1249,6 +1333,7 @@ async def test_admin_delete_env_removes_environment_and_orphans_sessions(
 
     from sqlalchemy import select
 
+    from app.models.audit import ControlPlaneAuditEvent
     from app.models.session import AgentEnvironment, Session
 
     created = await admin_client.post(
@@ -1275,7 +1360,11 @@ async def test_admin_delete_env_removes_environment_and_orphans_sessions(
     db_session.add(session_row)
     await db_session.commit()
 
-    deleted = await admin_client.delete(f"/api/admin/environments/{env_id}", headers=_AUTH)
+    deleted = await admin_client.delete(
+        f"/api/admin/environments/{env_id}",
+        headers=_AUTH,
+        params={"target_clerk_id": seed_user.clerk_id},
+    )
     assert deleted.status_code == 204, deleted.text
 
     env = (
@@ -1284,12 +1373,100 @@ async def test_admin_delete_env_removes_environment_and_orphans_sessions(
     assert env is None
     await db_session.refresh(session_row)
     assert session_row.environment_id is None
+    event = (
+        await db_session.execute(
+            select(ControlPlaneAuditEvent).where(
+                ControlPlaneAuditEvent.action == "agent_environment.delete",
+                ControlPlaneAuditEvent.resource_id == str(env_id),
+            )
+        )
+    ).scalar_one()
+    assert event.actor_type == "admin"
+    assert event.resource_type == "agent_environment"
+    assert event.target_user_id == seed_user.id
+    assert event.source == "api.admin"
+    assert event.details["agent_type"] == "codex"
+    assert event.details["machine_id"] == "delete-machine-1"
 
     deleted_again = await admin_client.delete(
         f"/api/admin/environments/{env_id}",
         headers=_AUTH,
+        params={"target_clerk_id": seed_user.clerk_id},
     )
     assert deleted_again.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path_template",
+    ["/v1/admin/agents/{env_id}", "/v1/admin/environments/{env_id}"],
+)
+async def test_admin_delete_env_without_target_clerk_id_preserves_backward_compat(
+    admin_client, db_session, seed_user, path_template
+):
+    import uuid as _uuid
+
+    from app.models.session import AgentEnvironment
+    from tests.conftest import create_env_with_project
+
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"delete-compat-{_uuid.uuid4().hex[:8]}",
+        machine_name="delete-compat-pod",
+        agent_type="codex",
+    )
+
+    response = await admin_client.delete(
+        path_template.format(env_id=env.id),
+        headers=_AUTH,
+    )
+
+    assert response.status_code == 204, response.text
+    assert await db_session.get(AgentEnvironment, env.id) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path_template",
+    ["/v1/admin/agents/{env_id}", "/v1/admin/environments/{env_id}"],
+)
+async def test_admin_delete_env_rejects_cross_tenant_target(
+    admin_client, db_session, seed_user, path_template
+):
+    import uuid as _uuid
+
+    from app.models.session import AgentEnvironment
+    from app.models.user import User
+    from tests.conftest import create_env_with_project
+
+    other = User(
+        clerk_id=f"other_delete_{_uuid.uuid4().hex[:8]}",
+        email="other-delete@x.dev",
+        name="Other Delete",
+    )
+    db_session.add(other)
+    await db_session.commit()
+    await db_session.refresh(other)
+    env = await create_env_with_project(
+        db_session,
+        user_id=other.id,
+        machine_id=f"delete-cross-{_uuid.uuid4().hex[:8]}",
+        machine_name="delete-cross-pod",
+        agent_type="codex",
+    )
+
+    try:
+        response = await admin_client.delete(
+            path_template.format(env_id=env.id),
+            headers=_AUTH,
+            params={"target_clerk_id": seed_user.clerk_id},
+        )
+        assert response.status_code == 403, response.text
+        assert await db_session.get(AgentEnvironment, env.id) is not None
+    finally:
+        await db_session.delete(other)
+        await db_session.commit()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -61,7 +61,12 @@ async def _runtime_client(db_session, seed_user, api_key: ApiKey | None):
     return httpx.AsyncClient(transport=transport, base_url="http://test")
 
 
-async def _write_runtime_state(admin_client: httpx.AsyncClient, environment_id: str, **overrides):
+async def _write_runtime_state(
+    admin_client: httpx.AsyncClient,
+    environment_id: str,
+    target_clerk_id: str | None = None,
+    **overrides,
+):
     body = {
         "deployment_id": f"dep_{uuid4().hex}",
         "app_id": "app-test",
@@ -77,6 +82,8 @@ async def _write_runtime_state(admin_client: httpx.AsyncClient, environment_id: 
             "hermes": {"enabled": False},
         },
     }
+    if target_clerk_id is not None:
+        body["target_clerk_id"] = target_clerk_id
     body.update(overrides)
     response = await admin_client.put(
         f"/v1/admin/environments/{environment_id}/runtime-state",
@@ -84,7 +91,7 @@ async def _write_runtime_state(admin_client: httpx.AsyncClient, environment_id: 
         json=body,
     )
     assert response.status_code == 200, response.text
-    return body
+    return {key: value for key, value in body.items() if key != "target_clerk_id"}
 
 
 @pytest.mark.asyncio
@@ -100,7 +107,7 @@ async def test_admin_upsert_runtime_state_and_manifest_omit_channels(
         machine_name="Runtime v2",
         agent_type="openclaw",
     )
-    expected = await _write_runtime_state(admin_client, str(env.id))
+    expected = await _write_runtime_state(admin_client, str(env.id), seed_user.clerk_id)
 
     api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
     async with await _runtime_client(db_session, seed_user, api_key) as client:
@@ -151,7 +158,9 @@ async def test_runtime_manifest_includes_mitmproxy_pin(
         machine_name="Runtime mitmproxy",
         agent_type="openclaw",
     )
-    await _write_runtime_state(admin_client, str(env.id), mitmproxy=TEST_MITMPROXY_PIN)
+    await _write_runtime_state(
+        admin_client, str(env.id), seed_user.clerk_id, mitmproxy=TEST_MITMPROXY_PIN
+    )
 
     api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
     async with await _runtime_client(db_session, seed_user, api_key) as client:
@@ -186,7 +195,7 @@ async def test_runtime_manifest_includes_declared_bridge_surfaces(
             }
         ]
     }
-    await _write_runtime_state(admin_client, str(env.id), bridge=bridge)
+    await _write_runtime_state(admin_client, str(env.id), seed_user.clerk_id, bridge=bridge)
 
     api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
     async with await _runtime_client(db_session, seed_user, api_key) as client:
@@ -211,7 +220,7 @@ async def test_runtime_manifest_etag_ignores_heartbeat_liveness(
         machine_name="Runtime heartbeat",
         agent_type="openclaw",
     )
-    expected = await _write_runtime_state(admin_client, str(env.id))
+    expected = await _write_runtime_state(admin_client, str(env.id), seed_user.clerk_id)
 
     api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
     async with await _runtime_client(db_session, seed_user, api_key) as client:
@@ -258,9 +267,9 @@ async def test_admin_runtime_state_upsert_writes_redacted_audit_event(
         machine_name="Runtime Audit",
         agent_type="openclaw",
     )
-    initial = await _write_runtime_state(admin_client, str(env.id))
+    initial = await _write_runtime_state(admin_client, str(env.id), seed_user.clerk_id)
     updated = {**initial, "generation": 8}
-    await _write_runtime_state(admin_client, str(env.id), **updated)
+    await _write_runtime_state(admin_client, str(env.id), seed_user.clerk_id, **updated)
 
     async with await _runtime_client(db_session, seed_user, None) as client:
         response = await client.get(
@@ -301,7 +310,7 @@ async def test_admin_delete_runtime_state_clears_existing_state_and_writes_audit
         machine_name="Runtime Delete",
         agent_type="openclaw",
     )
-    expected = await _write_runtime_state(admin_client, str(env.id))
+    expected = await _write_runtime_state(admin_client, str(env.id), seed_user.clerk_id)
 
     api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
     async with await _runtime_client(db_session, seed_user, api_key) as client:
@@ -312,6 +321,7 @@ async def test_admin_delete_runtime_state_clears_existing_state_and_writes_audit
     deleted = await admin_client.delete(
         f"/v1/admin/environments/{env.id}/runtime-state",
         headers=_AUTH,
+        params={"target_clerk_id": seed_user.clerk_id},
     )
 
     assert deleted.status_code == 204, deleted.text
@@ -366,6 +376,7 @@ async def test_admin_delete_runtime_state_missing_row_is_idempotent(
     deleted = await admin_client.delete(
         f"/v1/admin/environments/{env.id}/runtime-state",
         headers=_AUTH,
+        params={"target_clerk_id": seed_user.clerk_id},
     )
 
     assert deleted.status_code == 204, deleted.text
@@ -403,12 +414,102 @@ async def test_admin_delete_runtime_state_requires_admin_key(
         machine_name="Runtime Delete Auth",
         agent_type="openclaw",
     )
-    await _write_runtime_state(admin_client, str(env.id))
+    await _write_runtime_state(admin_client, str(env.id), seed_user.clerk_id)
 
-    rejected = await admin_client.delete(f"/v1/admin/environments/{env.id}/runtime-state")
+    rejected = await admin_client.delete(
+        f"/v1/admin/environments/{env.id}/runtime-state",
+        params={"target_clerk_id": seed_user.clerk_id},
+    )
 
     assert rejected.status_code == 401, rejected.text
     assert await db_session.get(HostedRuntimeState, env.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_admin_runtime_state_without_target_clerk_id_preserves_backward_compat(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"runtime-compat-{uuid4().hex[:8]}",
+        machine_name="Runtime Compat",
+        agent_type="openclaw",
+    )
+
+    body = await _write_runtime_state(admin_client, str(env.id))
+    state = await db_session.get(HostedRuntimeState, env.id)
+    assert state is not None
+    assert state.deployment_id == body["deployment_id"]
+
+    deleted = await admin_client.delete(
+        f"/v1/admin/environments/{env.id}/runtime-state",
+        headers=_AUTH,
+    )
+
+    assert deleted.status_code == 204, deleted.text
+    assert await db_session.get(HostedRuntimeState, env.id) is None
+
+
+@pytest.mark.asyncio
+async def test_admin_runtime_state_rejects_cross_tenant_target_without_mutating(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    other_user = User(
+        clerk_id=f"runtime_owner_{uuid4().hex[:12]}",
+        email=f"runtime-owner-{uuid4().hex[:8]}@clawdi.local",
+        name="Runtime Owner",
+    )
+    db_session.add(other_user)
+    await db_session.commit()
+    await db_session.refresh(other_user)
+    upsert_env = await create_env_with_project(
+        db_session,
+        user_id=other_user.id,
+        machine_id=f"runtime-upsert-owner-{uuid4().hex[:8]}",
+        machine_name="Runtime Upsert Owner",
+        agent_type="openclaw",
+    )
+    delete_env = await create_env_with_project(
+        db_session,
+        user_id=other_user.id,
+        machine_id=f"runtime-delete-owner-{uuid4().hex[:8]}",
+        machine_name="Runtime Delete Owner",
+        agent_type="openclaw",
+    )
+    await _write_runtime_state(admin_client, str(delete_env.id), other_user.clerk_id)
+
+    try:
+        upsert_response = await admin_client.put(
+            f"/v1/admin/environments/{upsert_env.id}/runtime-state",
+            headers=_AUTH,
+            json={
+                "target_clerk_id": seed_user.clerk_id,
+                "deployment_id": f"dep_{uuid4().hex}",
+                "app_id": "app-test",
+                "instance_id": f"hri_{uuid4().hex}",
+                "generation": 7,
+                "provider_id": "clawdi-managed",
+                "runtimes": {"openclaw": {"enabled": True}},
+            },
+        )
+        assert upsert_response.status_code == 403, upsert_response.text
+        assert await db_session.get(HostedRuntimeState, upsert_env.id) is None
+
+        delete_response = await admin_client.delete(
+            f"/v1/admin/environments/{delete_env.id}/runtime-state",
+            headers=_AUTH,
+            params={"target_clerk_id": seed_user.clerk_id},
+        )
+        assert delete_response.status_code == 403, delete_response.text
+        assert await db_session.get(HostedRuntimeState, delete_env.id) is not None
+    finally:
+        await db_session.delete(other_user)
+        await db_session.commit()
 
 
 @pytest.mark.asyncio
@@ -424,7 +525,9 @@ async def test_runtime_manifest_generation_reset_keeps_etag_but_returns_generati
         machine_name="Runtime generation reset",
         agent_type="openclaw",
     )
-    initial = await _write_runtime_state(admin_client, str(env.id), generation=7)
+    initial = await _write_runtime_state(
+        admin_client, str(env.id), seed_user.clerk_id, generation=7
+    )
 
     api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
     async with await _runtime_client(db_session, seed_user, api_key) as client:
@@ -434,7 +537,9 @@ async def test_runtime_manifest_generation_reset_keeps_etag_but_returns_generati
     etag = response.headers["etag"]
     assert response.json()["manifest"]["generation"] == 7
 
-    await _write_runtime_state(admin_client, str(env.id), **{**initial, "generation": 6})
+    await _write_runtime_state(
+        admin_client, str(env.id), seed_user.clerk_id, **{**initial, "generation": 6}
+    )
 
     state = await db_session.get(HostedRuntimeState, env.id)
     assert state is not None
@@ -472,6 +577,7 @@ async def test_admin_runtime_state_preserves_optional_state_when_omitted_as_none
     initial = await _write_runtime_state(
         admin_client,
         str(env.id),
+        seed_user.clerk_id,
         mitmproxy=TEST_MITMPROXY_PIN,
         mitm_profiles={"profiles": [{"id": "profile-1", "enabled": True}]},
         mcp={"enabled": True},
@@ -480,6 +586,7 @@ async def test_admin_runtime_state_preserves_optional_state_when_omitted_as_none
     await _write_runtime_state(
         admin_client,
         str(env.id),
+        seed_user.clerk_id,
         **{
             key: value
             for key, value in {**initial, "generation": 8}.items()
@@ -534,6 +641,7 @@ async def test_runtime_manifest_projects_mcp_and_tools_desired_state(
     await _write_runtime_state(
         admin_client,
         str(env.id),
+        seed_user.clerk_id,
         mcp={"enabled": True, "profile": "clawdi-default"},
         tools={"catalog": "clawdi-default", "enabled": ["memory", "connectors"]},
     )
@@ -618,6 +726,7 @@ async def test_runtime_manifest_projects_per_runtime_provider_bindings(
     await _write_runtime_state(
         admin_client,
         str(env.id),
+        seed_user.clerk_id,
         runtimes={
             "openclaw": {
                 "enabled": True,
@@ -752,6 +861,7 @@ async def test_runtime_manifest_preserves_non_openai_provider_protocols(
     await _write_runtime_state(
         admin_client,
         str(env.id),
+        seed_user.clerk_id,
         runtimes={
             "openclaw": {
                 "enabled": True,
@@ -836,6 +946,7 @@ async def test_runtime_manifest_marks_key_required_provider_unhealthy_without_se
     await _write_runtime_state(
         admin_client,
         str(env.id),
+        seed_user.clerk_id,
         runtimes={
             "openclaw": {
                 "enabled": True,
@@ -933,6 +1044,7 @@ async def test_runtime_manifest_marks_explicit_archived_provider_binding_unhealt
     await _write_runtime_state(
         admin_client,
         str(env.id),
+        seed_user.clerk_id,
         runtimes={
             "openclaw": {
                 "enabled": True,
@@ -1021,6 +1133,7 @@ async def test_runtime_manifest_keeps_default_archived_provider_fallback(
     await _write_runtime_state(
         admin_client,
         str(env.id),
+        seed_user.clerk_id,
         provider_id="deleted-default-provider",
         runtimes={
             "openclaw": {"enabled": True},
@@ -1069,6 +1182,7 @@ async def test_admin_runtime_state_rejects_legacy_top_level_fields(
         agent_type="openclaw",
     )
     body = {
+        "target_clerk_id": seed_user.clerk_id,
         "deployment_id": f"dep_{uuid4().hex}",
         "app_id": "app-test",
         "instance_id": f"hri_{uuid4().hex}",
@@ -1148,6 +1262,7 @@ async def test_admin_runtime_state_rejects_invalid_bridge_surfaces(
         agent_type="openclaw",
     )
     body = {
+        "target_clerk_id": seed_user.clerk_id,
         "deployment_id": f"dep_{uuid4().hex}",
         "app_id": "app-test",
         "instance_id": f"hri_{uuid4().hex}",
@@ -1189,6 +1304,7 @@ async def test_admin_runtime_state_rejects_mcp_tool_plaintext_secrets(
         agent_type="openclaw",
     )
     body = {
+        "target_clerk_id": seed_user.clerk_id,
         "deployment_id": f"dep_{uuid4().hex}",
         "app_id": "app-test",
         "instance_id": f"hri_{uuid4().hex}",
@@ -1221,6 +1337,7 @@ async def test_admin_runtime_state_rejects_nested_runtime_channels(
         agent_type="openclaw",
     )
     body = {
+        "target_clerk_id": seed_user.clerk_id,
         "deployment_id": f"dep_{uuid4().hex}",
         "app_id": "app-test",
         "instance_id": f"hri_{uuid4().hex}",
@@ -1255,6 +1372,7 @@ async def test_admin_runtime_state_rejects_unknown_runtime_names(
         agent_type="openclaw",
     )
     body = {
+        "target_clerk_id": seed_user.clerk_id,
         "deployment_id": f"dep_{uuid4().hex}",
         "app_id": "app-test",
         "instance_id": f"hri_{uuid4().hex}",
@@ -1419,6 +1537,7 @@ async def test_admin_runtime_state_rejects_legacy_control_plane_api_url(
         agent_type="openclaw",
     )
     body = {
+        "target_clerk_id": seed_user.clerk_id,
         "deployment_id": f"dep_{uuid4().hex}",
         "app_id": "app-test",
         "instance_id": f"hri_{uuid4().hex}",
@@ -1469,7 +1588,7 @@ async def test_runtime_manifest_allows_unbound_cli_key_with_explicit_environment
         machine_name="Runtime Unbound",
         agent_type="openclaw",
     )
-    await _write_runtime_state(admin_client, str(env.id))
+    await _write_runtime_state(admin_client, str(env.id), seed_user.clerk_id)
 
     api_key = ApiKey(user_id=seed_user.id, label="unbound")
     async with await _runtime_client(db_session, seed_user, api_key) as client:
@@ -1503,7 +1622,7 @@ async def test_runtime_manifest_rejects_unbound_cli_key_for_other_user_environme
         machine_name="Runtime Cross User",
         agent_type="openclaw",
     )
-    await _write_runtime_state(admin_client, str(other_env.id))
+    await _write_runtime_state(admin_client, str(other_env.id), other_user.clerk_id)
 
     api_key = ApiKey(user_id=seed_user.id, label="unbound")
     async with await _runtime_client(db_session, seed_user, api_key) as client:
@@ -1537,8 +1656,8 @@ async def test_runtime_manifest_rejects_bound_cli_key_environment_id_mismatch(
         machine_name="Runtime Other",
         agent_type="codex",
     )
-    await _write_runtime_state(admin_client, str(env.id))
-    await _write_runtime_state(admin_client, str(other_env.id))
+    await _write_runtime_state(admin_client, str(env.id), seed_user.clerk_id)
+    await _write_runtime_state(admin_client, str(other_env.id), seed_user.clerk_id)
 
     api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="bound")
     async with await _runtime_client(db_session, seed_user, api_key) as client:
@@ -1603,7 +1722,7 @@ async def test_runtime_manifest_projects_provider_secret_values_for_managed_acco
         )
     )
     await db_session.commit()
-    await _write_runtime_state(admin_client, str(env.id))
+    await _write_runtime_state(admin_client, str(env.id), seed_user.clerk_id)
 
     api_key = ApiKey(user_id=seed_user.id, environment_id=None, managed=True, label="hosted")
     async with await _runtime_client(db_session, seed_user, api_key) as client:
@@ -1708,7 +1827,9 @@ async def test_runtime_manifest_projects_legacy_managed_provider_as_responses(
         )
     )
     await db_session.commit()
-    await _write_runtime_state(admin_client, str(env.id), provider_id="clawdi-managed")
+    await _write_runtime_state(
+        admin_client, str(env.id), seed_user.clerk_id, provider_id="clawdi-managed"
+    )
 
     api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
     async with await _runtime_client(db_session, seed_user, api_key) as client:
@@ -1776,6 +1897,7 @@ async def test_runtime_manifest_uses_runtime_model_when_provider_default_is_miss
     await _write_runtime_state(
         admin_client,
         str(env.id),
+        seed_user.clerk_id,
         provider_id="custom-openai",
         runtimes={
             "openclaw": {
@@ -1840,6 +1962,7 @@ async def test_runtime_manifest_projects_codex_agent_profile_auth(
     await _write_runtime_state(
         admin_client,
         str(env.id),
+        seed_user.clerk_id,
         provider_id="openai-codex",
         runtimes={
             "openclaw": {
@@ -1891,6 +2014,7 @@ async def test_admin_runtime_state_accepts_codex_hosted_runtime(
         agent_type="codex",
     )
     body = {
+        "target_clerk_id": seed_user.clerk_id,
         "deployment_id": f"dep_{uuid4().hex}",
         "app_id": "app-test",
         "instance_id": f"hri_{uuid4().hex}",


### PR DESCRIPTION
## Summary

Execution-plan step A0.1 (partner-integration prerequisite). This PR hardens the cloud-api admin surface only; it does not build the partner integration.

This is intentionally backward-compatible because these admin runtime/env routes are frozen cross-repo contract surfaces currently called by `clawdi-hosted`.

1. Runtime-state upsert/delete can enforce owner assertion, without breaking existing callers:
   - `backend/app/schemas/admin.py:109` adds optional `target_clerk_id` to admin runtime-state upsert bodies.
   - `backend/app/routes/admin.py:140` resolves a provided Clerk id to an existing `User` and asserts `AgentEnvironment.user_id == User.id`; if omitted, it preserves the previous behavior and returns `env.user_id` for audit targeting.
   - `backend/app/routes/admin.py:764` applies that staged assertion before `_admin_upsert_runtime_state` writes.
   - `backend/app/routes/admin.py:881` applies the same staged assertion before `_admin_delete_runtime_state` deletes.
2. Env/agent delete can enforce owner assertion and now writes control-plane audit:
   - `backend/app/routes/admin.py:684` threads optional `target_clerk_id` into `_admin_delete_environment`.
   - `backend/app/routes/admin.py:694` fails closed before delete when a provided target user does not own the env.
   - `backend/app/routes/admin.py:699` records `agent_environment.delete` audit before deleting.
   - `backend/app/routes/admin.py:723` and `backend/app/routes/admin.py:733` keep `/agents/{id}` and `/environments/{id}` admin delete aliases backward-compatible by making the target principal optional.
3. Admin credential issuance/revocation now writes control-plane audit:
   - `backend/app/routes/admin.py:227` records `api_key.mint` after admin key mint.
   - `backend/app/routes/admin.py:278` records `api_key.revoke` when admin revoke marks a key revoked.

## Security rationale

The ownership model is grounded in the existing deploy-key invariant in `backend/app/services/api_key.py`: an environment is owned by the user whose `User.id` equals `AgentEnvironment.user_id`. Admin callers that provide `target_clerk_id` now get a fail-closed check before runtime-state writes/deletes and env/agent deletes. Missing target user or mismatch returns the repo's 403-style `HTTPException` and does not mutate runtime state or agent rows.

When `target_clerk_id` is omitted, behavior is preserved for existing first-party cross-repo callers. Audit entries remain unconditional; their `target_user_id` uses the resolved target when supplied, otherwise falls back to `env.user_id` as the existing runtime-state audit did.

Credential mint/revoke audit closes the blind spot where root admin operations changed API-key authority with only a process log line. The audit rows capture key id/prefix/managed/binding metadata, not raw credentials.

## Rollout notes

These routes touch frozen cross-repo contract surfaces. The staged path is:

1. Merge this backward-compatible cloud-api hardening.
2. Follow up in `clawdi-hosted` so runtime-state upsert/delete and env/agent delete always send `target_clerk_id`.
3. Later cloud-api tightening PR can make `target_clerk_id` required and remove the compatibility fallback once all callers comply.

## Verification

Local/test only; no prod or tenant data touched.

- `bun run typecheck` — pass (4/4 packages)
- `bun run check` — pass (Biome checked 598 files)
- `cd backend && uv run ruff check .` — pass
- `cd backend && uv run ruff format --check .` — pass
- `cd backend && uv run python -m compileall app scripts tests alembic` — pass
- `cd backend && uv run alembic upgrade head && uv run pytest -q tests/test_admin_endpoints.py tests/test_runtime_manifest.py` against a throwaway local `pgvector/pgvector:pg16` Postgres — pass: `83 passed, 1 warning in 6.02s`

A first pytest attempt before using the documented throwaway DB failed before test execution because local settings pointed at inactive `127.0.0.1:34399`; the passing run above used a fresh migrated throwaway database as documented in `docs/backend-development.md`.