### PR TITLE
Simplify hosted AI provider configuration

### DIFF
--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
 	apiKeyEditState,
+	derivedProviderFields,
+	modelsFromText,
 	providerAuthForSubmit,
+	providerFormIdentity,
+	shouldUseCatalogModels,
 } from "@/hosted/v2/ai-providers/add-provider-dialog.logic";
 import type { AiProviderAuth } from "@/hosted/v2/ai-providers/types";
 
@@ -64,5 +68,113 @@ describe("providerAuthForSubmit", () => {
 				hasNewManagedKey: true,
 			}),
 		).toEqual({ type: "api_key", source: "managed" });
+	});
+});
+
+describe("providerFormIdentity", () => {
+	test("derives a stable label and provider id for known providers", () => {
+		expect(
+			providerFormIdentity({
+				type: "openai",
+				authMethod: "api_key",
+				labelInput: "",
+				existingProviderIds: [],
+			}),
+		).toEqual({
+			providerId: "openai",
+			label: "OpenAI",
+		});
+	});
+
+	test("suffixes duplicate known providers instead of requiring a manual name", () => {
+		expect(
+			providerFormIdentity({
+				type: "openai",
+				authMethod: "api_key",
+				labelInput: "",
+				existingProviderIds: ["openai", "openai-2"],
+			}),
+		).toEqual({
+			providerId: "openai-3",
+			label: "OpenAI 3",
+		});
+	});
+
+	test("pins Codex OAuth to the canonical provider identity", () => {
+		expect(
+			providerFormIdentity({
+				type: "openai",
+				authMethod: "oauth",
+				labelInput: "",
+				existingProviderIds: ["openai", "openai-2"],
+			}),
+		).toEqual({
+			providerId: "openai-codex",
+			label: "Codex (ChatGPT)",
+		});
+	});
+
+	test("preserves provider id while allowing label edits", () => {
+		expect(
+			providerFormIdentity({
+				type: "custom_openai_compatible",
+				authMethod: "api_key",
+				labelInput: "Team proxy",
+				existingProviderIds: ["team-proxy"],
+				editing: {
+					provider_id: "legacy-proxy",
+					label: "Legacy proxy",
+				},
+			}),
+		).toEqual({
+			providerId: "legacy-proxy",
+			label: "Team proxy",
+		});
+	});
+});
+
+describe("derivedProviderFields", () => {
+	test("uses shared defaults for known providers", () => {
+		expect(derivedProviderFields("openai", "api_key")).toEqual({
+			baseUrl: "https://api.openai.com/v1",
+			apiMode: "openai_responses",
+			runtimeEnv: "OPENAI_API_KEY",
+			modelsText: "gpt-5.5\ngpt-5.4\ngpt-5.4-mini",
+		});
+		expect(shouldUseCatalogModels("openai", "api_key")).toBe(true);
+	});
+
+	test("uses the Codex catalog for ChatGPT sign-in", () => {
+		expect(derivedProviderFields("openai", "oauth")).toEqual({
+			baseUrl: "https://api.openai.com/v1",
+			apiMode: "openai_responses",
+			runtimeEnv: "OPENAI_API_KEY",
+			modelsText: "gpt-5.5\ngpt-5.4\ngpt-5.3-codex\ngpt-5.4-mini",
+		});
+		expect(shouldUseCatalogModels("openai", "oauth")).toBe(true);
+	});
+
+	test("leaves custom providers empty until the user fills advanced fields", () => {
+		expect(derivedProviderFields("custom_openai_compatible", "api_key")).toEqual({
+			baseUrl: "",
+			apiMode: "openai_chat",
+			runtimeEnv: "CUSTOM_API_KEY",
+			modelsText: "",
+		});
+		expect(shouldUseCatalogModels("custom_openai_compatible", "api_key")).toBe(false);
+	});
+});
+
+describe("modelsFromText", () => {
+	test("deduplicates model ids while preserving known metadata", () => {
+		expect(
+			modelsFromText("gpt-5.5\ngpt-5.4\ngpt-5.5", [
+				{ id: "gpt-5.4", label: "GPT-5.4" },
+				{ id: "gpt-5.5", label: "GPT-5.5" },
+			]),
+		).toEqual([
+			{ id: "gpt-5.5", label: "GPT-5.5" },
+			{ id: "gpt-5.4", label: "GPT-5.4" },
+		]);
 	});
 });

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.ts
@@ -1,4 +1,12 @@
-import type { AiProviderAuth } from "@/hosted/v2/ai-providers/types";
+import { CODEX_OAUTH_MODEL_CATALOG } from "@clawdi/shared";
+import { CLAWDI_CODEX_OAUTH_PROVIDER_ID } from "@/hosted/v2/ai-providers/codex-oauth";
+import {
+	type ApiMode,
+	type ProviderTypeId,
+	providerTypeMeta,
+	toProviderId,
+} from "@/hosted/v2/ai-providers/provider-types";
+import type { AiProvider, AiProviderAuth, AiProviderUpsert } from "@/hosted/v2/ai-providers/types";
 
 export type AuthMethod = "api_key" | "oauth" | "none";
 
@@ -12,6 +20,18 @@ export interface ApiKeyEditState {
 	keyRequired: boolean;
 	labelSuffix: string;
 	helpText: string;
+}
+
+export interface ProviderFormIdentity {
+	providerId: string;
+	label: string | null;
+}
+
+export interface DerivedProviderFields {
+	baseUrl: string;
+	apiMode: ApiMode;
+	runtimeEnv: string;
+	modelsText: string;
 }
 
 export function isAuthMethod(value: string | null): value is AuthMethod {
@@ -59,6 +79,100 @@ export function providerAuthForSubmit({
 	return authFor("api_key");
 }
 
+export function modelsToText(models: ReadonlyArray<{ id: string }> | null | undefined): string {
+	return (models ?? []).map((model) => model.id).join("\n");
+}
+
+export function parseModelIds(input: string): string[] {
+	const seen = new Set<string>();
+	const ids: string[] = [];
+	for (const raw of input.split(/[,\n]/)) {
+		const id = raw.trim();
+		if (!id || seen.has(id)) continue;
+		seen.add(id);
+		ids.push(id);
+	}
+	return ids;
+}
+
+export function modelsFromText(
+	input: string,
+	existing: AiProvider["models"],
+): AiProviderUpsert["models"] {
+	const existingById = new Map((existing ?? []).map((model) => [model.id, model]));
+	const models = parseModelIds(input).map((id) => existingById.get(id) ?? { id });
+	return models.length > 0 ? models : null;
+}
+
+export function derivedProviderFields(
+	type: ProviderTypeId,
+	authMethod: AuthMethod,
+): DerivedProviderFields {
+	const meta = providerTypeMeta(type);
+	if (authMethod === "oauth") {
+		return {
+			baseUrl: providerTypeMeta("openai").defaultBaseUrl,
+			apiMode: "openai_responses",
+			runtimeEnv: providerTypeMeta("openai").defaultRuntimeEnv,
+			modelsText: modelsToText(CODEX_OAUTH_MODEL_CATALOG),
+		};
+	}
+	return {
+		baseUrl: meta.defaultBaseUrl,
+		apiMode: meta.defaultApiMode,
+		runtimeEnv: meta.defaultRuntimeEnv,
+		modelsText: modelsToText(meta.defaultModels),
+	};
+}
+
+export function shouldUseCatalogModels(type: ProviderTypeId, authMethod: AuthMethod): boolean {
+	return authMethod === "oauth" || providerTypeMeta(type).custom !== true;
+}
+
+export function providerFormIdentity({
+	type,
+	authMethod,
+	labelInput,
+	existingProviderIds,
+	editing,
+}: {
+	type: ProviderTypeId;
+	authMethod: AuthMethod;
+	labelInput: string;
+	existingProviderIds: readonly string[];
+	editing?: Pick<AiProvider, "provider_id" | "label"> | null;
+}): ProviderFormIdentity {
+	if (authMethod === "oauth") {
+		return {
+			providerId: CLAWDI_CODEX_OAUTH_PROVIDER_ID,
+			label: "Codex (ChatGPT)",
+		};
+	}
+	if (editing) {
+		return {
+			providerId: editing.provider_id,
+			label: normalizeLabel(labelInput) ?? null,
+		};
+	}
+	const baseLabel =
+		providerTypeMeta(type).custom === true
+			? (normalizeLabel(labelInput) ?? defaultProviderLabel(type))
+			: defaultProviderLabel(type);
+	const baseId = toProviderId(baseLabel);
+	if (!baseId) return { providerId: "", label: baseLabel };
+	if (!existingProviderIds.includes(baseId)) {
+		return { providerId: baseId, label: baseLabel };
+	}
+	let suffix = 2;
+	while (existingProviderIds.includes(`${baseId}-${suffix}`)) {
+		suffix += 1;
+	}
+	return {
+		providerId: `${baseId}-${suffix}`,
+		label: `${baseLabel} ${suffix}`,
+	};
+}
+
 function keepableExistingApiKeyAuth(
 	auth: AiProviderAuth | null | undefined,
 ): { kind: ApiKeyKeepKind; auth: AiProviderAuth } | null {
@@ -90,4 +204,14 @@ function apiKeyHelpText(kind: ApiKeyKeepKind | undefined): string {
 		return "Leave blank to keep the current managed key. Enter a key to replace it.";
 	}
 	return "Stored encrypted for the hosted runtime and delivered as a manifest secret. The dashboard will not show it again.";
+}
+
+function normalizeLabel(value: string | null | undefined): string | null {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : null;
+}
+
+function defaultProviderLabel(type: ProviderTypeId): string {
+	if (type === "custom_openai_compatible") return "Custom endpoint";
+	return providerTypeMeta(type).label;
 }

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -28,8 +28,14 @@ import { Textarea } from "@/components/ui/textarea";
 import {
 	type AuthMethod,
 	apiKeyEditState,
+	derivedProviderFields,
 	isAuthMethod,
+	modelsFromText,
+	modelsToText,
+	parseModelIds,
 	providerAuthForSubmit,
+	providerFormIdentity,
+	shouldUseCatalogModels,
 } from "@/hosted/v2/ai-providers/add-provider-dialog.logic";
 import {
 	useAiProviders,
@@ -57,9 +63,8 @@ import {
 	PROVIDER_TYPES,
 	type ProviderTypeId,
 	providerTypeMeta,
-	toProviderId,
 } from "@/hosted/v2/ai-providers/provider-types";
-import type { AiProvider, AiProviderUpsert } from "@/hosted/v2/ai-providers/types";
+import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 
 function isApiMode(value: string | null): value is ApiMode {
 	return (
@@ -94,28 +99,6 @@ function providerTypeDescription(type: ProviderTypeId): string {
 	if (type === "gemini") return "Google models";
 	if (type === "mistral") return "Mistral APIs";
 	return "Custom endpoint";
-}
-
-function modelsToText(models: AiProvider["models"]): string {
-	return (models ?? []).map((model) => model.id).join("\n");
-}
-
-function parseModelIds(input: string): string[] {
-	const seen = new Set<string>();
-	const ids: string[] = [];
-	for (const raw of input.split(/[,\n]/)) {
-		const id = raw.trim();
-		if (!id || seen.has(id)) continue;
-		seen.add(id);
-		ids.push(id);
-	}
-	return ids;
-}
-
-function modelsFromText(input: string, existing: AiProvider["models"]): AiProviderUpsert["models"] {
-	const existingById = new Map((existing ?? []).map((model) => [model.id, model]));
-	const models = parseModelIds(input).map((id) => existingById.get(id) ?? { id });
-	return models.length > 0 ? models : null;
 }
 
 export function AddProviderDialog({
@@ -175,8 +158,37 @@ export function AddProviderDialog({
 	const createdFreshRef = useRef(false);
 
 	const meta = providerTypeMeta(type);
+	const existingProviderIds =
+		providers.data?.providers.map((provider) => provider.provider_id) ?? [];
+	const catalogManaged = shouldUseCatalogModels(type, authMethod);
+	const identity = providerFormIdentity({
+		type,
+		authMethod,
+		labelInput: label,
+		existingProviderIds,
+		editing,
+	});
+	const providerId = identity.providerId;
+	const providerLabel = identity.label ?? (providerId || meta.label);
 	const runtimeEnvForSubmit = runtimeEnv.trim() || meta.defaultRuntimeEnv;
-	const showRuntimeEnvField = authMethod === "api_key" && meta.custom === true;
+	const authMethodItems = [
+		{ value: "api_key", label: "API key" },
+		...(meta.oauth ? [{ value: "oauth", label: "Sign in with ChatGPT (Codex)" }] : []),
+		...(meta.custom ? [{ value: "none", label: "No auth (local)" }] : []),
+	];
+	const showAuthMethodField = authMethodItems.length > 1;
+	const showNameField = meta.custom === true;
+	const showAdvancedFields = meta.custom === true;
+	const showRuntimeEnvField = authMethod === "api_key" && showAdvancedFields;
+	const apiModeItems = meta.apiModes.map((mode) => ({
+		value: mode,
+		label: API_MODE_LABEL[mode],
+	}));
+	const catalogModelIds = parseModelIds(modelsText);
+	const catalogSummary =
+		catalogModelIds.length > 3
+			? `${catalogModelIds.slice(0, 3).join(", ")} +${catalogModelIds.length - 3} more`
+			: catalogModelIds.join(", ");
 
 	// Initialize when (re)opened.
 	useEffect(() => {
@@ -190,46 +202,66 @@ export function AddProviderDialog({
 		createdFreshRef.current = false;
 		popupRef.current = null;
 		if (editing) {
-			const m = providerTypeMeta(editing.type);
-			setType(editing.type as ProviderTypeId);
-			setLabel(editing.label ?? "");
-			setBaseUrl(editing.base_url);
-			setModelsText(modelsToText(editing.models));
-			setApiMode(editing.api_mode ?? m.defaultApiMode);
-			setRuntimeEnv(editing.runtime_env_name ?? m.defaultRuntimeEnv);
-			setAuthMethod(
+			const nextType = editing.type as ProviderTypeId;
+			const nextAuthMethod =
 				editing.auth.type === "none"
 					? "none"
 					: editing.auth.type === "api_key" || editing.auth.type === "secret_ref"
 						? "api_key"
-						: "oauth",
+						: "oauth";
+			const defaults = derivedProviderFields(nextType, nextAuthMethod);
+			const existingModels = editing.models ?? [];
+			setType(nextType);
+			setLabel(editing.label ?? "");
+			setBaseUrl(editing.base_url || defaults.baseUrl);
+			setModelsText(
+				existingModels.length > 0 || !shouldUseCatalogModels(nextType, nextAuthMethod)
+					? modelsToText(existingModels)
+					: defaults.modelsText,
 			);
+			setApiMode(editing.api_mode ?? defaults.apiMode);
+			setRuntimeEnv(editing.runtime_env_name ?? defaults.runtimeEnv);
+			setAuthMethod(nextAuthMethod);
 		} else {
-			const m = providerTypeMeta("openai");
+			const defaults = derivedProviderFields("openai", "api_key");
 			setType("openai");
 			setLabel("");
-			setBaseUrl(m.defaultBaseUrl);
-			setModelsText("");
-			setApiMode(m.defaultApiMode);
-			setRuntimeEnv(m.defaultRuntimeEnv);
+			setBaseUrl(defaults.baseUrl);
+			setModelsText(defaults.modelsText);
+			setApiMode(defaults.apiMode);
+			setRuntimeEnv(defaults.runtimeEnv);
 			setAuthMethod("api_key");
 		}
 	}, [open, editing]);
 
 	// Prefill when the type changes (add mode only).
 	function changeType(next: ProviderTypeId) {
-		setType(next);
 		const m = providerTypeMeta(next);
-		setBaseUrl(m.defaultBaseUrl);
-		setModelsText("");
-		setApiMode(m.defaultApiMode);
-		setRuntimeEnv(m.defaultRuntimeEnv);
+		let nextAuthMethod = authMethod;
+		if (!m.oauth && nextAuthMethod === "oauth") nextAuthMethod = "api_key";
+		if (!m.custom && nextAuthMethod === "none") nextAuthMethod = "api_key";
+		const defaults = derivedProviderFields(next, nextAuthMethod);
+		setType(next);
+		setBaseUrl(defaults.baseUrl);
+		setModelsText(defaults.modelsText);
+		setApiMode(defaults.apiMode);
+		setRuntimeEnv(defaults.runtimeEnv);
+		setAuthMethod(nextAuthMethod);
 		setApiKey("");
-		if (!m.oauth && authMethod === "oauth") setAuthMethod("api_key");
-		if (!m.custom && authMethod === "none") setAuthMethod("api_key");
+		if (next === "custom_openai_compatible") setLabel("");
 	}
 
-	const providerId = isEdit ? (editing?.provider_id ?? "") : toProviderId(label || meta.label);
+	function changeAuthMethod(next: AuthMethod) {
+		setAuthMethod(next);
+		setApiKey("");
+		if (meta.custom) return;
+		const defaults = derivedProviderFields(type, next);
+		setBaseUrl(defaults.baseUrl);
+		setModelsText(defaults.modelsText);
+		setApiMode(defaults.apiMode);
+		setRuntimeEnv(defaults.runtimeEnv);
+	}
+
 	// `none` auth only works with a loopback/private base_url (backend rule).
 	const noneAuthOk = authMethod !== "none" || isLoopbackOrPrivateUrl(baseUrl.trim());
 	const apiKeyState = isEdit
@@ -241,15 +273,6 @@ export function AddProviderDialog({
 		Boolean(baseUrl.trim()) &&
 		noneAuthOk &&
 		(!keyRequired || apiKey.trim().length > 0);
-	const authMethodItems = [
-		{ value: "api_key", label: "API key" },
-		...(meta.oauth ? [{ value: "oauth", label: "Sign in with ChatGPT (Codex)" }] : []),
-		...(meta.custom ? [{ value: "none", label: "No auth (local)" }] : []),
-	];
-	const apiModeItems = meta.apiModes.map((mode) => ({
-		value: mode,
-		label: API_MODE_LABEL[mode],
-	}));
 
 	async function submit() {
 		if (!canSubmit) return;
@@ -327,7 +350,7 @@ export function AddProviderDialog({
 		const body = {
 			provider_id: providerId,
 			type,
-			label: label.trim() || null,
+			label: identity.label,
 			base_url: baseUrl.trim(),
 			models: modelsFromText(modelsText, editing?.models),
 			api_mode: apiMode,
@@ -700,154 +723,173 @@ export function AddProviderDialog({
 
 								<div className="flex items-center gap-3 rounded-lg border bg-muted/30 p-3">
 									<ProviderTypeChip type={type} />
-									<div className="min-w-0 text-xs text-muted-foreground">
-										Saved as <code className="font-mono">{providerId || "—"}</code>
+									<div className="min-w-0 flex-1">
+										<p className="text-sm font-medium text-foreground">{providerLabel}</p>
+										<p className="text-xs text-muted-foreground">
+											Saved as <code className="font-mono">{providerId || "—"}</code>
+										</p>
+										{catalogManaged ? (
+											<>
+												<p className="mt-1 text-xs text-muted-foreground">
+													{authMethod === "oauth"
+														? `ChatGPT/Codex mapping · ${catalogSummary || "No catalog models"}`
+														: `Runtime mapping · ${API_MODE_LABEL[apiMode]} · ${catalogSummary || "No catalog models"}`}
+												</p>
+												<p className="mt-1 break-all font-mono text-xs text-muted-foreground">
+													{baseUrl}
+													{authMethod === "api_key" && runtimeEnvForSubmit
+														? ` · ${runtimeEnvForSubmit}`
+														: ""}
+												</p>
+											</>
+										) : null}
 									</div>
 								</div>
 
-								<div className="flex flex-col gap-1.5">
-									<Label htmlFor="provider-label">Name</Label>
-									<Input
-										id="provider-label"
-										name="provider-label"
-										value={label}
-										onChange={(e) => setLabel(e.target.value)}
-										placeholder={`${meta.label} (my key)`}
-										autoComplete="off"
-									/>
-								</div>
-
-								{/* Auth method */}
-								<div className="flex flex-col gap-1.5">
-									<Label htmlFor="provider-auth">Authentication</Label>
-									<Select
-										items={authMethodItems}
-										value={authMethod}
-										onValueChange={(value) => {
-											if (isAuthMethod(value)) setAuthMethod(value);
-										}}
-									>
-										<SelectTrigger id="provider-auth">
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											<SelectItem value="api_key">API key</SelectItem>
-											{meta.oauth ? (
-												<SelectItem value="oauth">Sign in with ChatGPT (Codex)</SelectItem>
-											) : null}
-											{meta.custom ? <SelectItem value="none">No auth (local)</SelectItem> : null}
-										</SelectContent>
-									</Select>
-								</div>
-
-								{authMethod === "api_key" ? (
-									<>
-										<div className="flex flex-col gap-1.5">
-											<Label htmlFor="provider-key">API key{apiKeyLabelSuffix}</Label>
-											<Input
-												id="provider-key"
-												name="provider-key"
-												type="password"
-												value={apiKey}
-												onChange={(e) => setApiKey(e.target.value)}
-												placeholder="sk-…"
-												autoComplete="off"
-												spellCheck={false}
-											/>
-											<p className="text-xs text-muted-foreground">{apiKeyHelpText}</p>
-											{keyRequired && isEdit && !apiKey.trim() ? (
-												<p className="text-xs text-destructive">
-													Enter a key to switch this provider to managed API-key auth.
-												</p>
-											) : null}
-										</div>
-										{showRuntimeEnvField ? (
-											<details
-												className="rounded-md border bg-muted/30 p-3"
-												open={isEdit || undefined}
-											>
-												<summary className="cursor-pointer text-sm font-medium text-foreground">
-													Advanced
-												</summary>
-												<div className="mt-3 flex flex-col gap-1.5">
-													<Label htmlFor="provider-env">Runtime env var</Label>
-													<Input
-														id="provider-env"
-														name="provider-env"
-														value={runtimeEnv}
-														onChange={(e) => setRuntimeEnv(e.target.value.toUpperCase())}
-														placeholder="OPENAI_API_KEY"
-														autoComplete="off"
-														spellCheck={false}
-													/>
-													<p className="text-xs text-muted-foreground">
-														Environment variable your endpoint's API key is exposed under to the
-														agent, e.g. OPENAI_API_KEY.
-													</p>
-												</div>
-											</details>
-										) : null}
-									</>
-								) : null}
-
-								<div className="flex flex-col gap-1.5">
-									<Label htmlFor="provider-base">Base URL</Label>
-									<Input
-										id="provider-base"
-										name="provider-base"
-										value={baseUrl}
-										onChange={(e) => setBaseUrl(e.target.value)}
-										placeholder="https://api.example.com/v1"
-										autoComplete="off"
-										spellCheck={false}
-									/>
-									{authMethod === "none" && baseUrl.trim() && !noneAuthOk ? (
-										<p className="text-xs text-destructive">
-											No-auth providers must use a loopback or private-network URL (e.g.
-											http://127.0.0.1:11434/v1).
-										</p>
-									) : null}
-								</div>
-
-								<div className="grid gap-3 sm:grid-cols-2">
+								{showNameField ? (
 									<div className="flex flex-col gap-1.5">
-										<Label htmlFor="provider-models">Model catalog</Label>
-										<Textarea
-											id="provider-models"
-											name="provider-models"
-											value={modelsText}
-											onChange={(e) => setModelsText(e.target.value)}
-											placeholder={meta.modelPlaceholder}
+										<Label htmlFor="provider-label">Name</Label>
+										<Input
+											id="provider-label"
+											name="provider-label"
+											value={label}
+											onChange={(e) => setLabel(e.target.value)}
+											placeholder="Custom endpoint"
 											autoComplete="off"
-											spellCheck={false}
-											className="min-h-24 resize-y"
 										/>
 										<p className="text-xs text-muted-foreground">
-											Optional. Enter one model id per line, or separate ids with commas.
+											Optional. Used only to label this custom endpoint.
 										</p>
 									</div>
+								) : null}
+
+								{showAuthMethodField ? (
 									<div className="flex flex-col gap-1.5">
-										<Label htmlFor="provider-mode">API mode</Label>
+										<Label htmlFor="provider-auth">Authentication</Label>
 										<Select
-											items={apiModeItems}
-											value={apiMode}
+											items={authMethodItems}
+											value={authMethod}
 											onValueChange={(value) => {
-												if (isApiMode(value)) setApiMode(value);
+												if (isAuthMethod(value)) changeAuthMethod(value);
 											}}
 										>
-											<SelectTrigger id="provider-mode">
+											<SelectTrigger id="provider-auth">
 												<SelectValue />
 											</SelectTrigger>
 											<SelectContent>
-												{meta.apiModes.map((m) => (
-													<SelectItem key={m} value={m}>
-														{API_MODE_LABEL[m]}
-													</SelectItem>
-												))}
+												<SelectItem value="api_key">API key</SelectItem>
+												{meta.oauth ? (
+													<SelectItem value="oauth">Sign in with ChatGPT (Codex)</SelectItem>
+												) : null}
+												{meta.custom ? <SelectItem value="none">No auth (local)</SelectItem> : null}
 											</SelectContent>
 										</Select>
 									</div>
-								</div>
+								) : null}
+
+								{authMethod === "api_key" ? (
+									<div className="flex flex-col gap-1.5">
+										<Label htmlFor="provider-key">API key{apiKeyLabelSuffix}</Label>
+										<Input
+											id="provider-key"
+											name="provider-key"
+											type="password"
+											value={apiKey}
+											onChange={(e) => setApiKey(e.target.value)}
+											placeholder="sk-…"
+											autoComplete="off"
+											spellCheck={false}
+										/>
+										<p className="text-xs text-muted-foreground">{apiKeyHelpText}</p>
+										{keyRequired && isEdit && !apiKey.trim() ? (
+											<p className="text-xs text-destructive">
+												Enter a key to switch this provider to managed API-key auth.
+											</p>
+										) : null}
+									</div>
+								) : null}
+
+								{showAdvancedFields ? (
+									<div className="rounded-md border bg-muted/30 p-3">
+										<div className="text-sm font-medium text-foreground">Advanced</div>
+										<div className="mt-3 flex flex-col gap-3">
+											<div className="flex flex-col gap-1.5">
+												<Label htmlFor="provider-base">Base URL</Label>
+												<Input
+													id="provider-base"
+													name="provider-base"
+													value={baseUrl}
+													onChange={(e) => setBaseUrl(e.target.value)}
+													placeholder="https://api.example.com/v1"
+													autoComplete="off"
+													spellCheck={false}
+												/>
+												{authMethod === "none" && baseUrl.trim() && !noneAuthOk ? (
+													<p className="text-xs text-destructive">
+														No-auth providers must use a loopback or private-network URL (e.g.
+														http://127.0.0.1:11434/v1).
+													</p>
+												) : null}
+											</div>
+
+											<div className="grid gap-3 sm:grid-cols-2">
+												<div className="flex flex-col gap-1.5">
+													<Label htmlFor="provider-mode">API mode</Label>
+													<Select
+														items={apiModeItems}
+														value={apiMode}
+														onValueChange={(value) => {
+															if (isApiMode(value)) setApiMode(value);
+														}}
+													>
+														<SelectTrigger id="provider-mode">
+															<SelectValue />
+														</SelectTrigger>
+														<SelectContent>
+															{meta.apiModes.map((m) => (
+																<SelectItem key={m} value={m}>
+																	{API_MODE_LABEL[m]}
+																</SelectItem>
+															))}
+														</SelectContent>
+													</Select>
+												</div>
+
+												{showRuntimeEnvField ? (
+													<div className="flex flex-col gap-1.5">
+														<Label htmlFor="provider-env">Runtime env var</Label>
+														<Input
+															id="provider-env"
+															name="provider-env"
+															value={runtimeEnv}
+															onChange={(e) => setRuntimeEnv(e.target.value.toUpperCase())}
+															placeholder="OPENAI_API_KEY"
+															autoComplete="off"
+															spellCheck={false}
+														/>
+													</div>
+												) : null}
+											</div>
+
+											<div className="flex flex-col gap-1.5">
+												<Label htmlFor="provider-models">Model catalog</Label>
+												<Textarea
+													id="provider-models"
+													name="provider-models"
+													value={modelsText}
+													onChange={(e) => setModelsText(e.target.value)}
+													placeholder={meta.modelPlaceholder}
+													autoComplete="off"
+													spellCheck={false}
+													className="min-h-24 resize-y"
+												/>
+												<p className="text-xs text-muted-foreground">
+													Optional. Enter one model id per line, or separate ids with commas.
+												</p>
+											</div>
+										</div>
+									</div>
+								) : null}
 							</div>
 						</div>
 

--- a/apps/web/src/hosted/v2/ai-providers/codex-oauth.ts
+++ b/apps/web/src/hosted/v2/ai-providers/codex-oauth.ts
@@ -1,5 +1,11 @@
 "use client";
 
+import {
+	CODEX_OAUTH_MODEL_CATALOG,
+	defaultAiProviderBaseUrl,
+	defaultAiProviderModels,
+} from "@clawdi/shared";
+import { toProviderCatalogModels } from "@/hosted/v2/ai-providers/provider-types";
 import type { AiProviderUpsert } from "@/hosted/v2/ai-providers/types";
 
 /**
@@ -34,7 +40,8 @@ export function codexRedirectUri(): string {
 }
 
 /** Catalog seed for a fresh Codex provider (OpenAI Responses / GPT-5). */
-export const CODEX_DEFAULT_MODEL = "gpt-5";
+export const CODEX_DEFAULT_MODEL =
+	CODEX_OAUTH_MODEL_CATALOG[0]?.id ?? defaultAiProviderModels("openai")[0]?.id;
 
 /** Upsert body for the canonical Codex provider (pre-sign-in placeholder auth). */
 export function codexProviderBody(): AiProviderUpsert {
@@ -42,8 +49,8 @@ export function codexProviderBody(): AiProviderUpsert {
 		provider_id: CLAWDI_CODEX_OAUTH_PROVIDER_ID,
 		type: "openai",
 		label: "Codex (ChatGPT)",
-		base_url: "https://api.openai.com/v1",
-		models: [{ id: CODEX_DEFAULT_MODEL }],
+		base_url: defaultAiProviderBaseUrl("openai") ?? "https://api.openai.com/v1",
+		models: toProviderCatalogModels(CODEX_OAUTH_MODEL_CATALOG),
 		api_mode: "openai_responses",
 		auth: { type: "agent_profile", tool: "codex", profile: "default" },
 		managed_by: "user",

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
@@ -4,10 +4,34 @@ import {
 	MANAGED_AI_CHOICE,
 	MANAGED_PRIMARY_MODEL_FALLBACK,
 } from "@/hosted/v2/ai-providers/model-binding";
+import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 
 describe("model binding", () => {
 	test("uses the served managed model as the fallback", () => {
 		expect(MANAGED_PRIMARY_MODEL_FALLBACK).toBe("gpt-5.5");
 		expect(firstModelForProvider(MANAGED_AI_CHOICE, [])).toBe("gpt-5.5");
+	});
+
+	test("uses the first catalog model for a selected provider", () => {
+		const providers = [
+			{
+				id: "row-openai",
+				provider_id: "openai-main",
+				scope: "account_global",
+				type: "openai",
+				base_url: "https://api.openai.com/v1",
+				models: [{ id: "gpt-5.5" }, { id: "gpt-5.4" }],
+				api_mode: "openai_responses",
+				auth: { type: "api_key", source: "managed" },
+				managed_by: "user",
+				runtime_env_name: "OPENAI_API_KEY",
+				capabilities: null,
+				created_at: "2026-01-01T00:00:00Z",
+				updated_at: "2026-01-01T00:00:00Z",
+				label: "OpenAI",
+			} satisfies AiProvider,
+		];
+
+		expect(firstModelForProvider("openai-main", providers)).toBe("gpt-5.5");
 	});
 });

--- a/apps/web/src/hosted/v2/ai-providers/provider-types.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-types.test.ts
@@ -6,7 +6,7 @@ describe("AI provider type metadata", () => {
 		expect(PROVIDER_TYPE_META.openai.modelPlaceholder).toBe("gpt-5.5");
 		expect(PROVIDER_TYPE_META.anthropic.modelPlaceholder).toBe("claude-sonnet-5");
 		expect(PROVIDER_TYPE_META.openrouter.modelPlaceholder).toBe("anthropic/claude-sonnet-5");
-		expect(PROVIDER_TYPE_META.gemini.modelPlaceholder).toBe("gemini-3.5-flash");
+		expect(PROVIDER_TYPE_META.gemini.modelPlaceholder).toBe("gemini-2.5-pro");
 		expect(PROVIDER_TYPE_META.mistral.modelPlaceholder).toBe("mistral-large-latest");
 	});
 
@@ -16,5 +16,15 @@ describe("AI provider type metadata", () => {
 		expect(PROVIDER_TYPE_META.openrouter.defaultRuntimeEnv).toBe("OPENROUTER_API_KEY");
 		expect(PROVIDER_TYPE_META.gemini.defaultRuntimeEnv).toBe("GEMINI_API_KEY");
 		expect(PROVIDER_TYPE_META.mistral.defaultRuntimeEnv).toBe("MISTRAL_API_KEY");
+	});
+
+	test("keeps shared catalog defaults aligned for models and API modes", () => {
+		expect(PROVIDER_TYPE_META.openai.defaultApiMode).toBe("openai_responses");
+		expect(PROVIDER_TYPE_META.openai.defaultModels.map((model) => model.id)).toEqual([
+			"gpt-5.5",
+			"gpt-5.4",
+			"gpt-5.4-mini",
+		]);
+		expect(PROVIDER_TYPE_META.custom_openai_compatible.defaultModels).toEqual([]);
 	});
 });

--- a/apps/web/src/hosted/v2/ai-providers/provider-types.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-types.ts
@@ -1,3 +1,12 @@
+import type { AiProviderModel as CatalogAiProviderModel } from "@clawdi/shared";
+import {
+	defaultAiProviderApiMode,
+	defaultAiProviderBaseUrl,
+	defaultAiProviderModels,
+	defaultAiProviderRuntimeEnvName,
+} from "@clawdi/shared";
+import type { AiProvider } from "@/hosted/v2/ai-providers/types";
+
 /**
  * The six AI provider types (backend `ProviderType`) with the defaults the
  * add flow prefills: base URL, allowed API modes, runtime env var, and a
@@ -19,6 +28,8 @@ export type ApiMode =
 	| "anthropic_messages"
 	| "google_generate_content";
 
+export type ProviderCatalogModel = NonNullable<AiProvider["models"]>[number];
+
 export interface ProviderTypeMeta {
 	id: ProviderTypeId;
 	label: string;
@@ -28,63 +39,72 @@ export interface ProviderTypeMeta {
 	defaultApiMode: ApiMode;
 	defaultRuntimeEnv: string;
 	modelPlaceholder: string;
+	defaultModels: readonly ProviderCatalogModel[];
 	/** base_url + api_mode are user-supplied / required. */
 	custom?: boolean;
 	/** Offers "Sign in with ChatGPT" (Codex OAuth). */
 	oauth?: boolean;
 }
 
+const CUSTOM_OPENAI_COMPATIBLE_RUNTIME_ENV = "CUSTOM_API_KEY";
+const CUSTOM_OPENAI_COMPATIBLE_MODEL_PLACEHOLDER = "model name";
+
 export const PROVIDER_TYPE_META: Record<ProviderTypeId, ProviderTypeMeta> = {
 	openai: {
 		id: "openai",
 		label: "OpenAI",
 		tint: "bg-identity-2-bg text-identity-2-fg",
-		defaultBaseUrl: "https://api.openai.com/v1",
+		defaultBaseUrl: defaultAiProviderBaseUrl("openai") ?? "",
 		apiModes: ["openai_chat", "openai_responses"],
-		defaultApiMode: "openai_chat",
-		defaultRuntimeEnv: "OPENAI_API_KEY",
-		modelPlaceholder: "gpt-5.5",
+		defaultApiMode: defaultAiProviderApiMode("openai") ?? "openai_responses",
+		defaultRuntimeEnv: defaultAiProviderRuntimeEnvName("openai") ?? "",
+		modelPlaceholder: defaultAiProviderModels("openai")[0]?.id ?? "",
+		defaultModels: toProviderCatalogModels(defaultAiProviderModels("openai")),
 		oauth: true,
 	},
 	anthropic: {
 		id: "anthropic",
 		label: "Anthropic",
 		tint: "bg-identity-1-bg text-identity-1-fg",
-		defaultBaseUrl: "https://api.anthropic.com",
+		defaultBaseUrl: defaultAiProviderBaseUrl("anthropic") ?? "",
 		apiModes: ["anthropic_messages"],
-		defaultApiMode: "anthropic_messages",
-		defaultRuntimeEnv: "ANTHROPIC_API_KEY",
-		modelPlaceholder: "claude-sonnet-5",
+		defaultApiMode: defaultAiProviderApiMode("anthropic") ?? "anthropic_messages",
+		defaultRuntimeEnv: defaultAiProviderRuntimeEnvName("anthropic") ?? "",
+		modelPlaceholder: defaultAiProviderModels("anthropic")[0]?.id ?? "",
+		defaultModels: toProviderCatalogModels(defaultAiProviderModels("anthropic")),
 	},
 	openrouter: {
 		id: "openrouter",
 		label: "OpenRouter",
 		tint: "bg-identity-7-bg text-identity-7-fg",
-		defaultBaseUrl: "https://openrouter.ai/api/v1",
+		defaultBaseUrl: defaultAiProviderBaseUrl("openrouter") ?? "",
 		apiModes: ["openai_chat"],
-		defaultApiMode: "openai_chat",
-		defaultRuntimeEnv: "OPENROUTER_API_KEY",
-		modelPlaceholder: "anthropic/claude-sonnet-5",
+		defaultApiMode: defaultAiProviderApiMode("openrouter") ?? "openai_chat",
+		defaultRuntimeEnv: defaultAiProviderRuntimeEnvName("openrouter") ?? "",
+		modelPlaceholder: defaultAiProviderModels("openrouter")[0]?.id ?? "",
+		defaultModels: toProviderCatalogModels(defaultAiProviderModels("openrouter")),
 	},
 	gemini: {
 		id: "gemini",
 		label: "Gemini",
 		tint: "bg-identity-3-bg text-identity-3-fg",
-		defaultBaseUrl: "https://generativelanguage.googleapis.com/v1beta",
+		defaultBaseUrl: defaultAiProviderBaseUrl("gemini") ?? "",
 		apiModes: ["google_generate_content"],
-		defaultApiMode: "google_generate_content",
-		defaultRuntimeEnv: "GEMINI_API_KEY",
-		modelPlaceholder: "gemini-3.5-flash",
+		defaultApiMode: defaultAiProviderApiMode("gemini") ?? "google_generate_content",
+		defaultRuntimeEnv: defaultAiProviderRuntimeEnvName("gemini") ?? "",
+		modelPlaceholder: defaultAiProviderModels("gemini")[0]?.id ?? "",
+		defaultModels: toProviderCatalogModels(defaultAiProviderModels("gemini")),
 	},
 	mistral: {
 		id: "mistral",
 		label: "Mistral",
 		tint: "bg-identity-4-bg text-identity-4-fg",
-		defaultBaseUrl: "https://api.mistral.ai/v1",
+		defaultBaseUrl: defaultAiProviderBaseUrl("mistral") ?? "",
 		apiModes: ["openai_chat"],
-		defaultApiMode: "openai_chat",
-		defaultRuntimeEnv: "MISTRAL_API_KEY",
-		modelPlaceholder: "mistral-large-latest",
+		defaultApiMode: defaultAiProviderApiMode("mistral") ?? "openai_chat",
+		defaultRuntimeEnv: defaultAiProviderRuntimeEnvName("mistral") ?? "",
+		modelPlaceholder: defaultAiProviderModels("mistral")[0]?.id ?? "",
+		defaultModels: toProviderCatalogModels(defaultAiProviderModels("mistral")),
 	},
 	custom_openai_compatible: {
 		id: "custom_openai_compatible",
@@ -93,8 +113,9 @@ export const PROVIDER_TYPE_META: Record<ProviderTypeId, ProviderTypeMeta> = {
 		defaultBaseUrl: "",
 		apiModes: ["openai_chat", "openai_responses"],
 		defaultApiMode: "openai_chat",
-		defaultRuntimeEnv: "CUSTOM_API_KEY",
-		modelPlaceholder: "model name",
+		defaultRuntimeEnv: CUSTOM_OPENAI_COMPATIBLE_RUNTIME_ENV,
+		modelPlaceholder: CUSTOM_OPENAI_COMPATIBLE_MODEL_PLACEHOLDER,
+		defaultModels: [],
 		custom: true,
 	},
 };
@@ -108,6 +129,26 @@ export const API_MODE_LABEL: Record<ApiMode, string> = {
 
 export function providerTypeMeta(id: string): ProviderTypeMeta {
 	return PROVIDER_TYPE_META[id as ProviderTypeId] ?? PROVIDER_TYPE_META.custom_openai_compatible;
+}
+
+export function toProviderCatalogModels(
+	models: readonly CatalogAiProviderModel[],
+): ProviderCatalogModel[] {
+	return models.map((model) => ({
+		id: model.id,
+		...(model.label ? { label: model.label } : {}),
+		...(model.api_mode ? { api_mode: model.api_mode } : {}),
+		...(model.input_modalities ? { input_modalities: [...model.input_modalities] } : {}),
+		...(model.supports_vision !== undefined ? { supports_vision: model.supports_vision } : {}),
+		...(model.supports_tools !== undefined ? { supports_tools: model.supports_tools } : {}),
+		...(model.supports_reasoning !== undefined
+			? { supports_reasoning: model.supports_reasoning }
+			: {}),
+		...(model.context_window !== undefined ? { context_window: model.context_window } : {}),
+		...(model.max_tokens !== undefined ? { max_tokens: model.max_tokens } : {}),
+		...(model.cost ? { cost: { ...model.cost } } : {}),
+		...(model.capabilities ? { capabilities: { ...model.capabilities } } : {}),
+	}));
 }
 
 /** Slugify a label into a valid provider_id (`^[a-z][a-z0-9._-]{1,62}$`). */

--- a/apps/web/src/hosted/v2/ai-providers/runtime-bootstrap.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/runtime-bootstrap.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { providerTypeMeta } from "@/hosted/v2/ai-providers/provider-types";
 import {
 	aiProviderRuntimeId,
 	buildAiProviderBootstrap,
@@ -123,5 +124,26 @@ describe("AI provider runtime bootstrap", () => {
 		);
 
 		expect(bootstrap.selected_provider_id).toBe("local-no-auth");
+	});
+
+	test("passes through the derived catalog and runtime env for known providers", () => {
+		const defaults = providerTypeMeta("openai");
+		const bootstrap = buildAiProviderBootstrap(
+			{
+				...provider,
+				provider_id: "openai-main",
+				label: "OpenAI",
+				auth: { type: "api_key", source: "managed" },
+				models: defaults.defaultModels.map((model) => ({ ...model })),
+				runtime_env_name: defaults.defaultRuntimeEnv,
+			},
+			"api_key",
+		);
+
+		expect(bootstrap.catalog.providers[0]).toMatchObject({
+			id: "openai-main",
+			models: defaults.defaultModels,
+			runtime_env_name: "OPENAI_API_KEY",
+		});
 	});
 });

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -90,6 +90,60 @@ async def test_ai_provider_crud_is_account_scoped_metadata(client: httpx.AsyncCl
 
 
 @pytest.mark.asyncio
+async def test_ai_provider_accepts_catalog_derived_known_provider_bodies(
+    client: httpx.AsyncClient,
+):
+    known = await client.post(
+        "/v1/ai-providers",
+        json={
+            "provider_id": "openai-derived",
+            "type": "openai",
+            "label": "OpenAI",
+            "base_url": "https://api.openai.com/v1",
+            "models": [{"id": "gpt-5.5"}, {"id": "gpt-5.4"}, {"id": "gpt-5.4-mini"}],
+            "api_mode": "openai_responses",
+            "auth": {"type": "api_key", "source": "managed"},
+            "managed_by": "user",
+            "runtime_env_name": "OPENAI_API_KEY",
+        },
+    )
+    assert known.status_code == 200, known.text
+    assert known.json()["provider_id"] == "openai-derived"
+    assert known.json()["runtime_env_name"] == "OPENAI_API_KEY"
+    assert known.json()["models"] == [
+        {"id": "gpt-5.5"},
+        {"id": "gpt-5.4"},
+        {"id": "gpt-5.4-mini"},
+    ]
+
+    codex = await client.post(
+        "/v1/ai-providers",
+        json={
+            "provider_id": "openai-codex",
+            "type": "openai",
+            "label": "Codex (ChatGPT)",
+            "base_url": "https://api.openai.com/v1",
+            "models": [
+                {"id": "gpt-5.5"},
+                {"id": "gpt-5.4"},
+                {"id": "gpt-5.3-codex"},
+                {"id": "gpt-5.4-mini"},
+            ],
+            "api_mode": "openai_responses",
+            "auth": {"type": "agent_profile", "tool": "codex", "profile": "default"},
+            "managed_by": "user",
+        },
+    )
+    assert codex.status_code == 200, codex.text
+    assert codex.json()["provider_id"] == "openai-codex"
+    assert codex.json()["auth"] == {
+        "type": "agent_profile",
+        "tool": "codex",
+        "profile": "default",
+    }
+
+
+@pytest.mark.asyncio
 async def test_ai_provider_rejects_invalid_auth_and_api_mode(client: httpx.AsyncClient):
     invalid_mode = await client.post(
         "/v1/ai-providers",

--- a/docs/plans/ai-provider-v2-simplification-findings.md
+++ b/docs/plans/ai-provider-v2-simplification-findings.md
@@ -1,0 +1,91 @@
+# AI Provider V2 Simplification Findings
+
+## Scope
+
+This note records the runtime-facing evidence behind the hosted v2 AI Provider
+simplification. It focuses on the fields the agent runtimes actually consume,
+not the legacy dashboard form shape.
+
+## Runtime evidence
+
+- The hosted dashboard bootstrap forwards provider metadata almost verbatim into
+  the runtime catalog: `provider_id`, `type`, `base_url`, `auth`,
+  `managed_by`, `models`, `api_mode`, and `runtime_env_name`
+  (`apps/web/src/hosted/v2/ai-providers/runtime-bootstrap.ts:39-81`).
+- The Clawdi CLI projection is the authoritative apply path. It rejects
+  providers that lack a usable auth env name or `api_mode`, preserves
+  `base_url`, `auth`, `managed_by`, `models`, and `runtime_env_name`, and picks
+  the primary model from the provider catalog/defaults
+  (`packages/cli/src/lib/ai-provider-projection.ts:175-255`).
+- OpenClaw projection consumes `baseUrl`, `api`, API-key env wiring, and
+  provider/model catalogs; Codex OAuth is a special native OpenAI path
+  (`packages/cli/src/lib/ai-provider-projection.ts:258-392`).
+- Hermes projection consumes `provider`, `base_url`, `transport`, optional
+  `key_env`, and model metadata; native Codex OAuth is a distinct
+  `openai-codex` path (`packages/cli/src/lib/ai-provider-projection.ts:398-520`).
+- Codex projection consumes Responses-compatible `base_url`, optional `env_key`,
+  and the primary model; native Codex auth projects to built-in OpenAI auth
+  instead of a custom provider block
+  (`packages/cli/src/lib/ai-provider-projection.ts:523-570`).
+- The managed transparent-gateway path is gated by `managed_by === "clawdi"`
+  plus `baseUrl`, `apiMode`, and a secret ref; user BYOK providers do not go
+  through that MITM profile path
+  (`packages/cli/src/runtime/hosted-mitm-profiles.ts:124-197`).
+
+## Upstream contract checks
+
+- OpenClaw documents custom-provider consumption via
+  `models.providers.*.{api,apiKey,baseUrl,models}`
+  (`/home/kingsley/openclaw/docs/gateway/config-tools.md:455-519`) and merge
+  precedence for `baseUrl`/`apiKey`/catalog refresh
+  (`/home/kingsley/openclaw/docs/concepts/models.md:343-354`).
+- OpenClaw documents that `openai/<model>` plus an `openai-codex` auth profile
+  is the Codex-auth runtime path
+  (`/home/kingsley/openclaw/docs/concepts/agent-runtimes.md:92-105`).
+- Hermes defines a native `openai-codex` overlay with
+  `transport="codex_responses"` and
+  `base_url_override="https://chatgpt.com/backend-api/codex"`
+  (`/home/kingsley/.hermes/hermes-agent/hermes_cli/providers.py:62-71`).
+- Hermes determines effective API mode from provider/base URL heuristics and
+  reads user-config providers from `api|url|base_url`, `key_env`, and
+  `transport`
+  (`/home/kingsley/.hermes/hermes-agent/hermes_cli/providers.py:533-613`).
+- Hermes model switching carries user-config `base_url`, `key_env`, and
+  resolved `api_mode` into runtime provider resolution
+  (`/home/kingsley/.hermes/hermes-agent/hermes_cli/model_switch.py:1168-1199`).
+- Hermes runtime swaps `api_key` and `base_url` directly on the OpenAI client
+  and re-applies URL-specific headers
+  (`/home/kingsley/.hermes/hermes-agent/run_agent.py:4386-4505`).
+- Hermes detects the Codex backend from `api_mode == "codex_responses"` plus
+  the ChatGPT Codex URL/provider shape
+  (`/home/kingsley/.hermes/hermes-agent/run_agent.py:1290-1317`).
+- Hermes loads stored `openai-codex` OAuth credentials from its auth store and
+  rehydrates them into the credential pool
+  (`/home/kingsley/.hermes/hermes-agent/agent/credential_pool.py:2028-2060`).
+
+## What is essential vs derivable
+
+- Essential runtime inputs:
+  - `base_url`
+  - `api_mode`
+  - auth path: `auth` plus either `runtime_env_name`/`env:` ref for BYOK, or
+    native Codex auth metadata for OAuth
+  - `models`, because the projection chooses the primary/default model from the
+    catalog and emits provider model metadata
+- System-owned but runtime-significant:
+  - `managed_by`, because the hosted managed gateway path keys off it
+    (`packages/cli/src/runtime/hosted-mitm-profiles.ts:144-197`)
+- Fully derivable from a provider-type catalog for known providers:
+  - default `base_url`
+  - default `api_mode`
+  - default `runtime_env_name`
+  - default model catalog / first model
+  - the Codex OAuth model catalog for ChatGPT sign-in
+
+## Product implication
+
+- Known providers can be reduced to provider choice plus credential input.
+- ChatGPT/Codex OAuth should never ask for a typed model catalog; the runtime
+  already expects a known OpenAI/Codex path.
+- Only a genuine custom OpenAI-compatible endpoint needs advanced fields
+  (`base_url`, `api_mode`, `runtime_env_name`, `models`).

--- a/packages/cli/src/lib/ai-provider-projection.test.ts
+++ b/packages/cli/src/lib/ai-provider-projection.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type AiProviderCatalog,
+	CODEX_OAUTH_MODEL_CATALOG,
+	defaultAiProviderApiMode,
+	defaultAiProviderBaseUrl,
+	defaultAiProviderModels,
+	defaultAiProviderRuntimeEnvName,
+} from "@clawdi/shared";
+import { buildAgentTargetProjection } from "./ai-provider-projection";
+
+const byokOpenAiCatalog: AiProviderCatalog = {
+	schema_version: 1,
+	providers: [
+		{
+			id: "openai-main",
+			type: "openai",
+			label: "OpenAI",
+			base_url: defaultAiProviderBaseUrl("openai") ?? "https://api.openai.com/v1",
+			api_mode: defaultAiProviderApiMode("openai") ?? "openai_responses",
+			auth: { type: "api_key", source: "managed" },
+			managed_by: "user",
+			runtime_env_name: defaultAiProviderRuntimeEnvName("openai") ?? "OPENAI_API_KEY",
+			models: defaultAiProviderModels("openai").map((model) => ({ ...model })),
+		},
+	],
+	defaults: { chat_provider_id: "openai-main" },
+};
+
+const codexOAuthCatalog: AiProviderCatalog = {
+	schema_version: 1,
+	providers: [
+		{
+			id: "openai-codex",
+			type: "openai",
+			label: "Codex (ChatGPT)",
+			base_url: defaultAiProviderBaseUrl("openai") ?? "https://api.openai.com/v1",
+			api_mode: "openai_responses",
+			auth: { type: "agent_profile", tool: "codex", profile: "default" },
+			managed_by: "user",
+			models: CODEX_OAUTH_MODEL_CATALOG.map((model) => ({ ...model })),
+		},
+	],
+	defaults: { chat_provider_id: "openai-codex" },
+};
+
+describe("AI provider projection", () => {
+	test("maps known BYOK OpenAI providers to all runtime targets without extra user fields", () => {
+		const openclaw = buildAgentTargetProjection("openclaw", byokOpenAiCatalog);
+		expect(openclaw.provider_ids).toEqual(["openai-main"]);
+		expect(openclaw.primary_model).toEqual({ provider_id: "openai-main", model: "gpt-5.5" });
+		expect(openclaw.files[0]?.content).toContain('"baseUrl": "https://api.openai.com/v1"');
+		expect(openclaw.files[0]?.content).toContain('"api": "openai-responses"');
+		expect(openclaw.files[0]?.content).toContain('"id": "OPENAI_API_KEY"');
+
+		const hermes = buildAgentTargetProjection("hermes", byokOpenAiCatalog);
+		expect(hermes.files[0]?.content).toContain('provider: "custom:openai-main"');
+		expect(hermes.files[0]?.content).toContain('api: "https://api.openai.com/v1"');
+		expect(hermes.files[0]?.content).toContain('transport: "codex_responses"');
+		expect(hermes.files[0]?.content).toContain('key_env: "OPENAI_API_KEY"');
+
+		const codex = buildAgentTargetProjection("codex", byokOpenAiCatalog);
+		expect(codex.files[0]?.content).toContain('model = "gpt-5.5"');
+		expect(codex.files[0]?.content).toContain('model_provider = "openai-main"');
+		expect(codex.files[0]?.content).toContain('[model_providers."openai-main"]');
+		expect(codex.files[0]?.content).toContain('env_key = "OPENAI_API_KEY"');
+	});
+
+	test("keeps native Codex OAuth projections on the verified OpenAI/Codex path", () => {
+		const openclaw = buildAgentTargetProjection("openclaw", codexOAuthCatalog);
+		expect(openclaw.files[0]?.content).toContain('"plugins": {');
+		expect(openclaw.files[0]?.content).toContain('"primary": "openai/gpt-5.5"');
+
+		const hermes = buildAgentTargetProjection("hermes", codexOAuthCatalog);
+		expect(hermes.files[0]?.content).toContain('provider: "openai-codex"');
+		expect(hermes.files[0]?.content).toContain('default: "gpt-5.5"');
+		expect(hermes.files[0]?.content).toContain('base_url: "https://chatgpt.com/backend-api/codex"');
+
+		const codex = buildAgentTargetProjection("codex", codexOAuthCatalog);
+		expect(codex.files[0]?.content).toContain('model = "gpt-5.5"');
+		expect(codex.files[0]?.content).toContain('model_provider = "openai"');
+		expect(codex.files[0]?.content).not.toContain('[model_providers."openai-codex"]');
+	});
+});

--- a/packages/shared/src/ai-provider.test.ts
+++ b/packages/shared/src/ai-provider.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, test } from "bun:test";
 import {
 	CLAWDI_MANAGED_V1_PROVIDER_ID,
 	CLAWDI_MANAGED_V2_PROVIDER_ID,
+	CODEX_OAUTH_MODEL_CATALOG,
+	defaultAiProviderModels,
+	defaultAiProviderRuntimeEnvName,
 	isFirstPartyManagedAiProvider,
 	isProviderAuthProfileId,
 	validateAiProviderCatalog,
@@ -259,5 +262,36 @@ describe("isFirstPartyManagedAiProvider", () => {
 		expect(isFirstPartyManagedAiProvider({ provider_id: "openai-prod", managed_by: "user" })).toBe(
 			false,
 		);
+	});
+});
+
+describe("known AI provider defaults", () => {
+	test("exposes runtime env defaults for built-in providers", () => {
+		expect(defaultAiProviderRuntimeEnvName("openai")).toBe("OPENAI_API_KEY");
+		expect(defaultAiProviderRuntimeEnvName("anthropic")).toBe("ANTHROPIC_API_KEY");
+		expect(defaultAiProviderRuntimeEnvName("openrouter")).toBe("OPENROUTER_API_KEY");
+		expect(defaultAiProviderRuntimeEnvName("gemini")).toBe("GEMINI_API_KEY");
+		expect(defaultAiProviderRuntimeEnvName("mistral")).toBe("MISTRAL_API_KEY");
+		expect(defaultAiProviderRuntimeEnvName("custom_openai_compatible")).toBeUndefined();
+	});
+
+	test("provides a non-empty model catalog for built-in providers and Codex OAuth", () => {
+		expect(defaultAiProviderModels("openai").map((model) => model.id)).toEqual([
+			"gpt-5.5",
+			"gpt-5.4",
+			"gpt-5.4-mini",
+		]);
+		expect(defaultAiProviderModels("anthropic").map((model) => model.id)).toEqual([
+			"claude-sonnet-5",
+			"claude-opus-4-6",
+			"claude-haiku-4-5",
+		]);
+		expect(defaultAiProviderModels("custom_openai_compatible")).toEqual([]);
+		expect(CODEX_OAUTH_MODEL_CATALOG.map((model) => model.id)).toEqual([
+			"gpt-5.5",
+			"gpt-5.4",
+			"gpt-5.3-codex",
+			"gpt-5.4-mini",
+		]);
 	});
 });

--- a/packages/shared/src/ai-provider.ts
+++ b/packages/shared/src/ai-provider.ts
@@ -121,6 +121,33 @@ const DEFAULT_BASE_URL: Partial<Record<AiProviderType, string>> = {
 	mistral: "https://api.mistral.ai/v1",
 };
 
+const DEFAULT_RUNTIME_ENV_NAME: Partial<Record<AiProviderType, string>> = {
+	openai: "OPENAI_API_KEY",
+	anthropic: "ANTHROPIC_API_KEY",
+	openrouter: "OPENROUTER_API_KEY",
+	gemini: "GEMINI_API_KEY",
+	mistral: "MISTRAL_API_KEY",
+};
+
+const DEFAULT_MODEL_CATALOG: Partial<Record<AiProviderType, readonly AiProviderModel[]>> = {
+	openai: [{ id: "gpt-5.5" }, { id: "gpt-5.4" }, { id: "gpt-5.4-mini" }],
+	anthropic: [{ id: "claude-sonnet-5" }, { id: "claude-opus-4-6" }, { id: "claude-haiku-4-5" }],
+	openrouter: [
+		{ id: "anthropic/claude-sonnet-5" },
+		{ id: "anthropic/claude-opus-4.6" },
+		{ id: "openai/gpt-5.5" },
+	],
+	gemini: [{ id: "gemini-2.5-pro" }, { id: "gemini-3.5-flash" }],
+	mistral: [{ id: "mistral-large-latest" }],
+};
+
+export const CODEX_OAUTH_MODEL_CATALOG: readonly AiProviderModel[] = [
+	{ id: "gpt-5.5" },
+	{ id: "gpt-5.4" },
+	{ id: "gpt-5.3-codex" },
+	{ id: "gpt-5.4-mini" },
+];
+
 export const CLAWDI_MANAGED_V1_PROVIDER_ID = "clawdi-managed";
 const CLAWDI_MANAGED_V1_API_MODE = "openai_responses";
 export const CLAWDI_MANAGED_V2_PROVIDER_ID = "clawdi-managed-v2";
@@ -188,6 +215,14 @@ export function defaultAiProviderApiMode(type: AiProviderType): AiProviderApiMod
 
 export function defaultAiProviderBaseUrl(type: AiProviderType): string | undefined {
 	return DEFAULT_BASE_URL[type];
+}
+
+export function defaultAiProviderRuntimeEnvName(type: AiProviderType): string | undefined {
+	return DEFAULT_RUNTIME_ENV_NAME[type];
+}
+
+export function defaultAiProviderModels(type: AiProviderType): readonly AiProviderModel[] {
+	return DEFAULT_MODEL_CATALOG[type] ?? [];
 }
 
 export function validateAiProviderCatalog(


### PR DESCRIPTION
## Summary
- simplify the hosted v2 add/edit flow so known providers use catalog-derived runtime fields instead of asking the user to type them
- auto-populate the Codex/ChatGPT OAuth provider model set and remove the manual model catalog path for OAuth
- keep custom OpenAI-compatible endpoints as the only path that exposes advanced runtime fields
- add web/shared/CLI/backend tests plus a research note at `docs/plans/ai-provider-v2-simplification-findings.md`

## Phase 1 findings
Essential runtime inputs:
- `base_url`: the dashboard bootstrap forwards it into the runtime catalog unchanged (`apps/web/src/hosted/v2/ai-providers/runtime-bootstrap.ts:66-81`), and the CLI projection emits it into OpenClaw/Hermes/Codex target configs (`packages/cli/src/lib/ai-provider-projection.ts:201-210`, `packages/cli/src/lib/ai-provider-projection.ts:258-312`, `packages/cli/src/lib/ai-provider-projection.ts:398-434`, `packages/cli/src/lib/ai-provider-projection.ts:523-548`).
- `api_mode`: the CLI refuses providers that cannot resolve an API mode before apply (`packages/cli/src/lib/ai-provider-projection.ts:197-200`) and maps it to OpenClaw/Hermes/Codex transport/wire config (`packages/cli/src/lib/ai-provider-projection.ts:269-277`, `packages/cli/src/lib/ai-provider-projection.ts:420-431`, `packages/cli/src/lib/ai-provider-projection.ts:556-565`). Upstream OpenClaw consumes this as `models.providers.*.api` (`/home/kingsley/openclaw/docs/gateway/config-tools.md:508-519`); Hermes derives/consumes it as transport/api mode from provider or base URL (`/home/kingsley/.hermes/hermes-agent/hermes_cli/providers.py:533-572`, `/home/kingsley/.hermes/hermes-agent/hermes_cli/providers.py:577-613`).
- auth path plus env/ref metadata: the CLI requires either native Codex auth or an env name from `runtime_env_name` / `env:` refs (`packages/cli/src/lib/ai-provider-projection.ts:187-195`, `packages/cli/src/lib/ai-provider-projection.ts:246-255`). OpenClaw consumes provider API-key env wiring (`packages/cli/src/lib/ai-provider-projection.ts:271-273`, `/home/kingsley/openclaw/docs/gateway/config-tools.md:508-519`); Hermes consumes `key_env` / OAuth state and swaps `api_key` + `base_url` on the runtime client (`packages/cli/src/lib/ai-provider-projection.ts:428-431`, `/home/kingsley/.hermes/hermes-agent/run_agent.py:4477-4505`, `/home/kingsley/.hermes/hermes-agent/agent/credential_pool.py:2028-2060`).
- `models`: the CLI picks the primary model from provider defaults/catalog (`packages/cli/src/lib/ai-provider-projection.ts:153-172`, `packages/cli/src/lib/ai-provider-projection.ts:227-238`) and emits provider model catalogs for OpenClaw/Hermes/Codex (`packages/cli/src/lib/ai-provider-projection.ts:274-349`, `packages/cli/src/lib/ai-provider-projection.ts:437-483`, `packages/cli/src/lib/ai-provider-projection.ts:533-548`). OpenClaw documents `models.providers.*.models` directly (`/home/kingsley/openclaw/docs/gateway/config-tools.md:455-474`), and Hermes user-provider switching carries the chosen provider/model/base URL into runtime resolution (`/home/kingsley/.hermes/hermes-agent/hermes_cli/model_switch.py:1168-1199`).
- `managed_by` is system-owned but runtime-significant because the hosted transparent-gateway path keys off `managed_by == "clawdi"` plus `baseUrl`, `apiMode`, and a secret ref (`packages/cli/src/runtime/hosted-mitm-profiles.ts:128-197`).

Derivable for known providers:
- default `base_url`, `api_mode`, `runtime_env_name`, and model catalogs already live in the shared provider catalog (`packages/shared/src/ai-provider.ts:108-149`, `packages/shared/src/ai-provider.ts:220-225`).
- Codex OAuth also has a fixed known model catalog in the same shared module (`packages/shared/src/ai-provider.ts:144-149`), and upstream OpenClaw/Hermes both treat the OpenAI/Codex path as a special known runtime (`/home/kingsley/openclaw/docs/concepts/agent-runtimes.md:92-105`, `/home/kingsley/.hermes/hermes-agent/hermes_cli/providers.py:62-71`, `/home/kingsley/.hermes/hermes-agent/run_agent.py:1290-1317`).

## Implementation
- known provider add flow now auto-derives label/provider id, base URL, API mode, runtime env, and model catalog from the shared catalog; only the credential remains user-entered
- OpenAI OAuth now uses the existing popup/callback flow but seeds the canonical Codex provider with the shared Codex model catalog; there is no manual model-catalog input on the OAuth path
- custom OpenAI-compatible providers are the only path that still exposes `base_url`, `api_mode`, `runtime_env_name`, and `models`
- runtime/bootstrap/projection tests now pin the simplified mapping for BYOK OpenAI and native Codex OAuth across OpenClaw, Hermes, and Codex

## Verification
- `bun run check`
- `bunx turbo typecheck --filter=web --filter=@clawdi/shared`
- `bun run --cwd packages/cli typecheck`
- `bun run --cwd apps/web test src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts src/hosted/v2/ai-providers/provider-types.test.ts src/hosted/v2/ai-providers/runtime-bootstrap.test.ts src/hosted/v2/ai-providers/model-binding.test.ts`
- `bun test packages/shared/src/ai-provider.test.ts`
- `bun run --cwd packages/cli test src/lib/ai-provider-projection.test.ts`
- `cd backend && uv run python -m pytest tests/test_ai_providers.py -q` against a throwaway migrated `pgvector/pgvector:pg16` container
