### PR TITLE
Validate managed runtime model seeds against live gateway models

### DIFF
--- a/packages/cli/src/runtime/managed-model-resolution.test.ts
+++ b/packages/cli/src/runtime/managed-model-resolution.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildManagedModelsEndpoint,
+	extractManagedLiveModelIds,
+	resolveManagedPrimaryModel,
+} from "./managed-model-resolution";
+
+describe("managed model resolution", () => {
+	test("keeps a configured managed model when it is still live", () => {
+		expect(
+			resolveManagedPrimaryModel({
+				seedModel: "gpt-5.5",
+				liveModelIds: ["gpt-5.4", "gpt-5.5", "gpt-5.6"],
+			}),
+		).toEqual({
+			resolvedModel: "gpt-5.5",
+			reason: "kept_valid_seed",
+		});
+	});
+
+	test("upgrades an invalid or absent managed seed to the latest live model", () => {
+		expect(
+			resolveManagedPrimaryModel({
+				seedModel: "gpt-5.4",
+				liveModelIds: ["gpt-5.5", "gpt-5.6", "gpt-5.6-pro"],
+			}),
+		).toEqual({
+			resolvedModel: "gpt-5.6-pro",
+			reason: "upgraded_to_latest",
+		});
+
+		expect(
+			resolveManagedPrimaryModel({
+				seedModel: null,
+				liveModelIds: ["gpt-5.5", "gpt-5.6"],
+			}),
+		).toEqual({
+			resolvedModel: "gpt-5.6",
+			reason: "upgraded_to_latest",
+		});
+	});
+
+	test("keeps the existing seed when the live fetch fails", () => {
+		expect(
+			resolveManagedPrimaryModel({
+				seedModel: "gpt-5.5",
+				liveModelIds: null,
+			}),
+		).toEqual({
+			resolvedModel: "gpt-5.5",
+			reason: "kept_seed_after_fetch_failure",
+		});
+	});
+
+	test("builds the managed OpenAI-compatible /v1/models endpoint and parses live ids", () => {
+		expect(buildManagedModelsEndpoint("https://api.example.test/v1/")).toBe(
+			"https://api.example.test/v1/models",
+		);
+		expect(
+			extractManagedLiveModelIds({
+				data: [{ id: "gpt-5.5" }, { id: "gpt-5.6" }, { id: "gpt-5.6" }, { bad: true }],
+			}),
+		).toEqual(["gpt-5.5", "gpt-5.6"]);
+	});
+});

--- a/packages/cli/src/runtime/managed-model-resolution.ts
+++ b/packages/cli/src/runtime/managed-model-resolution.ts
@@ -1,0 +1,242 @@
+export interface ManagedPrimaryModelResolutionInput {
+	seedModel: string | null;
+	liveModelIds: readonly string[] | null;
+}
+
+export interface ManagedPrimaryModelResolution {
+	resolvedModel: string | null;
+	reason:
+		| "kept_valid_seed"
+		| "upgraded_to_latest"
+		| "kept_seed_after_fetch_failure"
+		| "kept_seed_without_live_models"
+		| "no_candidate_model";
+}
+
+export function buildManagedModelsEndpoint(baseUrl: string): string {
+	return `${baseUrl.replace(/\/+$/, "")}/models`;
+}
+
+export function extractManagedLiveModelIds(payload: unknown): string[] {
+	if (!isPlainRecord(payload) || !Array.isArray(payload.data)) return [];
+	const ids: string[] = [];
+	const seen = new Set<string>();
+	for (const entry of payload.data) {
+		if (!isPlainRecord(entry)) continue;
+		const id = normalizeModelId(entry.id);
+		if (!id || seen.has(id)) continue;
+		seen.add(id);
+		ids.push(id);
+	}
+	return ids;
+}
+
+export function resolveManagedPrimaryModel(
+	input: ManagedPrimaryModelResolutionInput,
+): ManagedPrimaryModelResolution {
+	const seedModel = normalizeModelId(input.seedModel);
+	if (input.liveModelIds === null) {
+		return {
+			resolvedModel: seedModel,
+			reason: seedModel ? "kept_seed_after_fetch_failure" : "no_candidate_model",
+		};
+	}
+
+	const liveModelIds = dedupeModelIds(input.liveModelIds);
+	if (seedModel && liveModelIds.includes(seedModel)) {
+		return { resolvedModel: seedModel, reason: "kept_valid_seed" };
+	}
+
+	const preferredPrefix = seedModel ? inferManagedModelFamilyPrefix(seedModel) : null;
+	const latestModel = pickLatestManagedModel(liveModelIds, preferredPrefix);
+	if (latestModel) {
+		return { resolvedModel: latestModel, reason: "upgraded_to_latest" };
+	}
+
+	if (seedModel) {
+		return { resolvedModel: seedModel, reason: "kept_seed_without_live_models" };
+	}
+	return { resolvedModel: null, reason: "no_candidate_model" };
+}
+
+export function pickLatestManagedModel(
+	modelIds: readonly string[],
+	preferredPrefix?: string | null,
+): string | null {
+	const normalized = dedupeModelIds(modelIds);
+	if (normalized.length === 0) return null;
+	const prefix = normalizeSortPrefix(preferredPrefix);
+	const preferred =
+		prefix === null
+			? normalized
+			: normalized.filter((modelId) => inferManagedModelFamilyPrefix(modelId) === prefix);
+	const candidates = preferred.length > 0 ? preferred : normalized;
+	const sorted = [...candidates].sort(compareManagedModelIds);
+	return sorted[0] ?? null;
+}
+
+function compareManagedModelIds(left: string, right: string): number {
+	const leftPrefix = inferManagedModelFamilyPrefix(left);
+	const rightPrefix = inferManagedModelFamilyPrefix(right);
+	const byKey = compareSortKeys(
+		managedModelSortKey(left, leftPrefix),
+		managedModelSortKey(right, rightPrefix),
+	);
+	if (byKey !== 0) return byKey;
+	const byPrefix = leftPrefix.localeCompare(rightPrefix);
+	if (byPrefix !== 0) return byPrefix;
+	return left.localeCompare(right);
+}
+
+function managedModelSortKey(modelId: string, prefix: string): Array<number | string> {
+	let rest = modelId.slice(prefix.length);
+	if (rest.startsWith("/")) rest = rest.slice(1);
+	rest = rest.replace(/^-+/, "").trim();
+
+	const nums: number[] = [];
+	let suffix = "";
+	let state: "start" | "in_version" | "between" | "in_suffix" = "start";
+	let numBuf = "";
+
+	for (const ch of rest) {
+		if (state === "start") {
+			if (ch === "v" || ch === "V") {
+				state = "in_version";
+				continue;
+			}
+			if (isAsciiDigit(ch)) {
+				state = "in_version";
+				numBuf += ch;
+				continue;
+			}
+			if (ch === "-" || ch === "_" || ch === ".") continue;
+			state = "in_suffix";
+			suffix += ch;
+			continue;
+		}
+		if (state === "in_version") {
+			if (isAsciiDigit(ch)) {
+				numBuf += ch;
+				continue;
+			}
+			if (ch === ".") {
+				if (numBuf.includes(".")) {
+					pushParsedNumber(nums, numBuf);
+					numBuf = "";
+				} else {
+					numBuf += ch;
+				}
+				continue;
+			}
+			if (ch === "-" || ch === "_" || ch === ".") {
+				pushParsedNumber(nums, numBuf);
+				numBuf = "";
+				state = "between";
+				continue;
+			}
+			pushParsedNumber(nums, numBuf);
+			numBuf = "";
+			state = "in_suffix";
+			suffix += ch;
+			continue;
+		}
+		if (state === "between") {
+			if (isAsciiDigit(ch)) {
+				state = "in_version";
+				numBuf = ch;
+				continue;
+			}
+			if (ch === "v" || ch === "V") {
+				state = "in_version";
+				continue;
+			}
+			if (ch === "-" || ch === "_" || ch === ".") continue;
+			state = "in_suffix";
+			suffix += ch;
+			continue;
+		}
+		suffix += ch;
+	}
+
+	if (state === "in_version") pushParsedNumber(nums, numBuf);
+
+	const versionKey = nums.map((value) => -value);
+	const normalizedSuffix = suffix
+		.toLowerCase()
+		.replace(/^[-_.]+|[-_.]+$/g, "")
+		.trim();
+	const suffixRank = normalizedSuffix && MANAGED_MODEL_SUFFIX_RANK[normalizedSuffix] === 0 ? 0 : 1;
+	return [...versionKey, suffixRank, normalizedSuffix];
+}
+
+function compareSortKeys(
+	left: readonly (number | string)[],
+	right: readonly (number | string)[],
+): number {
+	const length = Math.min(left.length, right.length);
+	for (let index = 0; index < length; index += 1) {
+		const a = left[index];
+		const b = right[index];
+		if (a === b) continue;
+		if (typeof a === "number" && typeof b === "number") return a - b;
+		return String(a).localeCompare(String(b));
+	}
+	return left.length - right.length;
+}
+
+function inferManagedModelFamilyPrefix(modelId: string): string {
+	const normalized = normalizeModelId(modelId);
+	if (!normalized) return "";
+	const slashIndex = normalized.lastIndexOf("/");
+	const scope = slashIndex >= 0 ? normalized.slice(0, slashIndex + 1) : "";
+	const localId = slashIndex >= 0 ? normalized.slice(slashIndex + 1) : normalized;
+	const versionIndex = localId.search(/[0-9]/);
+	if (versionIndex <= 0) return normalized;
+	const family = localId.slice(0, versionIndex).replace(/[-_.]+$/g, "");
+	return `${scope}${family || localId}`;
+}
+
+function dedupeModelIds(modelIds: readonly string[]): string[] {
+	const ids: string[] = [];
+	const seen = new Set<string>();
+	for (const modelId of modelIds) {
+		const normalized = normalizeModelId(modelId);
+		if (!normalized || seen.has(normalized)) continue;
+		seen.add(normalized);
+		ids.push(normalized);
+	}
+	return ids;
+}
+
+function normalizeModelId(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeSortPrefix(value: string | null | undefined): string | null {
+	const trimmed = value?.trim();
+	return trimmed ? trimmed : null;
+}
+
+function pushParsedNumber(target: number[], raw: string): void {
+	const trimmed = raw.replace(/\.+$/g, "");
+	if (!trimmed) return;
+	const parsed = Number.parseFloat(trimmed);
+	if (Number.isFinite(parsed)) target.push(parsed);
+}
+
+function isAsciiDigit(value: string): boolean {
+	return value >= "0" && value <= "9";
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const MANAGED_MODEL_SUFFIX_RANK: Record<string, 0> = {
+	max: 0,
+	plus: 0,
+	pro: 0,
+	turbo: 0,
+};

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -476,6 +476,41 @@ describe("runtime manifest reconciliation invariants", () => {
 		]);
 	});
 
+	test("applies a managed primary model override to the hosted provider seed projection", () => {
+		const paths = tempRuntimePaths();
+		const manifest = baseManifest(
+			paths,
+			{
+				openclaw: {
+					enabled: true,
+					run: runSettings("openclaw", ["gateway", "run"]),
+					services: {},
+				},
+			},
+			{
+				projection: {
+					providers: {
+						default: {
+							type: "custom_openai_compatible",
+							managed_by: "clawdi",
+							baseUrl: "https://api.example.test/v1",
+							apiMode: "openai_chat",
+							apiKeySecretRef: "secret://providers/default/api-key",
+						},
+					},
+				},
+			},
+		);
+
+		const projection = hostedAiProviderCatalog(manifest, "openclaw", {
+			primaryModelOverride: { provider_id: "default", model: "gpt-5.6" },
+		});
+		expect(projection?.primaryModel).toEqual({ provider_id: "default", model: "gpt-5.6" });
+		expect(projection?.catalog.providers[0]?.models).toEqual([
+			{ id: "gpt-5.6", api_mode: "openai_chat" },
+		]);
+	});
+
 	test("keeps runtime secret revisions separate from bridge sidecar revisions", () => {
 		const paths = tempRuntimePaths();
 		const manifest = baseManifest(paths, {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -42,6 +42,11 @@ import {
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { ensureRuntimeAuthTokenFile } from "./auth-token";
 import { isClawdiManagedProviderProjection, normalizeSecretRef } from "./hosted-mitm-profiles";
+import {
+	buildManagedModelsEndpoint,
+	extractManagedLiveModelIds,
+	resolveManagedPrimaryModel,
+} from "./managed-model-resolution";
 import type { LiveSyncAgent, RuntimeInstall, RuntimeManifest } from "./manifest-contract";
 import { manifestSchema } from "./manifest-contract";
 import {
@@ -1151,11 +1156,13 @@ function projectionPayload(name: string, manifest: RuntimeManifest): unknown {
 export function hostedAiProviderCatalog(
 	manifest: RuntimeManifest,
 	runtimeName?: string,
+	options: { primaryModelOverride?: AgentPrimaryModel } = {},
 ): { catalog: AiProviderCatalog; primaryModel: AgentPrimaryModel } | null {
 	const providers = manifest.projection?.providers;
 	if (!providers || Object.keys(providers).length === 0) return null;
 	const rawEntries = hostedProviderEntries(providers, runtimeName, manifest);
-	const primaryModel = hostedRuntimePrimaryModel(manifest, runtimeName, rawEntries);
+	const primaryModel =
+		options.primaryModelOverride ?? hostedRuntimePrimaryModel(manifest, runtimeName, rawEntries);
 	if (!primaryModel) return null;
 	const entries = rawEntries
 		.map(([id, raw]) => {
@@ -1293,6 +1300,177 @@ function hostedProviderApiMode(input: Record<string, unknown>): AiProviderApiMod
 		return raw;
 	}
 	return "openai_chat";
+}
+
+function managedProviderSupportsLiveModelProbe(apiMode: AiProviderApiMode): boolean {
+	return apiMode === "openai_chat" || apiMode === "openai_responses";
+}
+
+function managedGatewayPrimaryModelTarget(
+	manifest: RuntimeManifest,
+	runtimeName: string,
+): {
+	baseUrl: string;
+	providerId: string;
+	seedModel: string | null;
+} | null {
+	const providers = recordValue(manifest.projection?.providers);
+	if (!providers) return null;
+	const rawEntries = hostedProviderEntries(providers, runtimeName, manifest);
+	if (rawEntries.length === 0) return null;
+	const currentPrimary = hostedRuntimePrimaryModel(manifest, runtimeName, rawEntries);
+	const selectedProviderId = currentPrimary?.provider_id ?? rawEntries[0]?.[0] ?? null;
+	if (!selectedProviderId) return null;
+	const selectedProvider = rawEntries.find(
+		([providerId]) => providerId === selectedProviderId,
+	)?.[1];
+	const provider = recordValue(selectedProvider);
+	if (!provider || !isClawdiManagedProviderProjection(provider)) return null;
+	const baseUrl = stringValue(provider.baseUrl);
+	if (!baseUrl) return null;
+	const apiMode = hostedProviderApiMode(provider);
+	if (!managedProviderSupportsLiveModelProbe(apiMode)) return null;
+	return {
+		baseUrl,
+		providerId: selectedProviderId,
+		seedModel:
+			currentPrimary && currentPrimary.provider_id === selectedProviderId
+				? currentPrimary.model
+				: null,
+	};
+}
+
+function resolveManagedGatewayPrimaryModelOverrides(
+	manifest: RuntimeManifest,
+	enabledRuntimes: readonly string[],
+	home: string,
+	workspaceRoot: string,
+	mitmSystemCaFile: string | null,
+	fetcher: ManagedGatewayModelListFetcher,
+): Partial<Record<string, AgentPrimaryModel>> {
+	const overrides: Partial<Record<string, AgentPrimaryModel>> = {};
+	const fetchCache = new Map<string, ManagedGatewayModelFetchResult>();
+	for (const runtimeName of enabledRuntimes) {
+		const target = managedGatewayPrimaryModelTarget(manifest, runtimeName);
+		if (!target) continue;
+		const cacheKey = `${target.providerId}\n${target.baseUrl}`;
+		let fetchResult = fetchCache.get(cacheKey);
+		if (!fetchResult) {
+			fetchResult = fetcher({
+				baseUrl: target.baseUrl,
+				home,
+				mitmSystemCaFile,
+				providerId: target.providerId,
+				runtimeName,
+				workspaceRoot,
+			});
+			fetchCache.set(cacheKey, fetchResult);
+			if (fetchResult.status === "failed") {
+				console.warn(
+					`managed model probe failed for ${runtimeName}/${target.providerId} at ${fetchResult.endpoint}: ${fetchResult.detail}; keeping configured seed`,
+				);
+			}
+		}
+		const resolution = resolveManagedPrimaryModel({
+			seedModel: target.seedModel,
+			liveModelIds: fetchResult.status === "ok" ? fetchResult.modelIds : null,
+		});
+		if (!resolution.resolvedModel) continue;
+		if (resolution.resolvedModel === target.seedModel) continue;
+		overrides[runtimeName] = {
+			provider_id: target.providerId,
+			model: resolution.resolvedModel,
+		};
+	}
+	return overrides;
+}
+
+const MANAGED_GATEWAY_MODEL_FETCH_TIMEOUT_MS = 3_000;
+
+const MANAGED_GATEWAY_MODEL_FETCH_SCRIPT = [
+	"const [url, timeoutRaw] = process.argv.slice(1);",
+	"const timeoutMs = Number.parseInt(timeoutRaw ?? '', 10) || 3000;",
+	"const controller = new AbortController();",
+	"const timer = setTimeout(() => controller.abort(), timeoutMs);",
+	"(async () => {",
+	"  try {",
+	"    const response = await fetch(url, {",
+	"      method: 'GET',",
+	"      headers: { accept: 'application/json' },",
+	"      signal: controller.signal,",
+	"    });",
+	"    const body = await response.text();",
+	"    process.stdout.write(JSON.stringify({ ok: response.ok, status: response.status, body }));",
+	"    process.exit(response.ok ? 0 : 1);",
+	"  } catch (error) {",
+	"    const detail = error && typeof error === 'object' && 'name' in error && error.name === 'AbortError'",
+	"      ? 'request timed out'",
+	"      : (error instanceof Error ? error.message : String(error));",
+	"    process.stderr.write(detail);",
+	"    process.exit(2);",
+	"  } finally {",
+	"    clearTimeout(timer);",
+	"  }",
+	"})();",
+].join("\n");
+
+function fetchManagedGatewayModelList(
+	input: ManagedGatewayModelFetchInput,
+): ManagedGatewayModelFetchResult {
+	const endpoint = buildManagedModelsEndpoint(input.baseUrl);
+	if (!input.mitmSystemCaFile || !existsSync(input.mitmSystemCaFile)) {
+		return {
+			status: "failed",
+			detail: "transparent managed gateway CA bundle is unavailable",
+			endpoint,
+		};
+	}
+	const result = spawnRuntimeUserCommand(
+		process.execPath,
+		[
+			"-e",
+			MANAGED_GATEWAY_MODEL_FETCH_SCRIPT,
+			endpoint,
+			String(MANAGED_GATEWAY_MODEL_FETCH_TIMEOUT_MS),
+		],
+		input.home,
+		input.workspaceRoot,
+		{
+			transparentMitmCaFile: input.mitmSystemCaFile,
+		},
+	);
+	const stdout = typeof result.stdout === "string" ? result.stdout : result.stdout.toString("utf8");
+	const stderr = typeof result.stderr === "string" ? result.stderr : result.stderr.toString("utf8");
+	if (result.status !== 0) {
+		const detail = parseManagedGatewayFetchFailure(stdout, stderr, result.status);
+		return { status: "failed", detail, endpoint };
+	}
+	try {
+		const payload = JSON.parse(stdout) as { body?: string };
+		const body = payload.body ? JSON.parse(payload.body) : null;
+		return { status: "ok", endpoint, modelIds: extractManagedLiveModelIds(body) };
+	} catch (error) {
+		return {
+			status: "failed",
+			detail: `invalid /models response: ${error instanceof Error ? error.message : String(error)}`,
+			endpoint,
+		};
+	}
+}
+
+function parseManagedGatewayFetchFailure(
+	stdout: string,
+	stderr: string,
+	status: number | null,
+): string {
+	try {
+		const payload = JSON.parse(stdout) as { status?: unknown };
+		if (typeof payload.status === "number") return `HTTP ${payload.status}`;
+	} catch {
+		// Best-effort parse only.
+	}
+	const detail = stderr.trim() || stdout.trim();
+	return detail || `exit ${status ?? "unknown"}`;
 }
 
 function hostedProviderType(input: Record<string, unknown>): AiProviderType {
@@ -1614,6 +1792,31 @@ type HostedAiProviderProjectionInput = {
 	primaryModel: AgentPrimaryModel;
 };
 
+interface ManagedGatewayModelFetchInput {
+	baseUrl: string;
+	home: string;
+	mitmSystemCaFile: string | null;
+	providerId: string;
+	runtimeName: string;
+	workspaceRoot: string;
+}
+
+type ManagedGatewayModelFetchResult =
+	| {
+			status: "ok";
+			endpoint: string;
+			modelIds: string[];
+	  }
+	| {
+			status: "failed";
+			detail: string;
+			endpoint: string;
+	  };
+
+type ManagedGatewayModelListFetcher = (
+	input: ManagedGatewayModelFetchInput,
+) => ManagedGatewayModelFetchResult;
+
 interface HermesHostedProviderPluginProjection {
 	modelPatch: string;
 	pluginFiles: ProjectionFile[];
@@ -1650,11 +1853,14 @@ function applyHostedAiProviderProjection(
 	manifest: RuntimeManifest,
 	workspaceRoot: string,
 	previousManifest: RuntimeManifest | null,
+	managedPrimaryModelOverrides: Partial<Record<string, AgentPrimaryModel>>,
 ): HostedAiProviderProjectionResult {
 	if (!observation.enabled || observation.status === "install_failed" || !observation.commandPath) {
 		return { path: null, revision: null };
 	}
-	const projectionInput = hostedAiProviderCatalog(manifest, name);
+	const projectionInput = hostedAiProviderCatalog(manifest, name, {
+		primaryModelOverride: managedPrimaryModelOverrides[name],
+	});
 	const previousProjectionInput = previousManifest
 		? hostedAiProviderCatalog(previousManifest, name)
 		: null;
@@ -2137,8 +2343,11 @@ function applyOpenClawHostedProjectionAfterOfficialInstall(
 	manifest: RuntimeManifest,
 	home: string,
 	workspaceRoot: string,
+	primaryModelOverride?: AgentPrimaryModel,
 ): void {
-	const projectionInput = hostedAiProviderCatalog(manifest, "openclaw");
+	const projectionInput = hostedAiProviderCatalog(manifest, "openclaw", {
+		primaryModelOverride,
+	});
 	if (projectionInput) {
 		applyOpenClawHostedProviderProjection(command, projectionInput, [], home, workspaceRoot);
 	}
@@ -2755,14 +2964,17 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function runtimeUserCommandEnv(home: string): NodeJS.ProcessEnv {
+function runtimeUserCommandEnv(
+	home: string,
+	options: { transparentMitmCaFile?: string } = {},
+): NodeJS.ProcessEnv {
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
 	const uid =
 		runtimeUser && runtimeUser !== "root" && runningAsRoot()
 			? String(runtimeUserUid(runtimeUser))
 			: null;
 	const runtimeDir = uid ? `/run/user/${uid}` : null;
-	return {
+	const env = {
 		...process.env,
 		HOME: home,
 		PATH: [join(home, ".local", "bin"), join(home, ".openclaw", "bin"), process.env.PATH]
@@ -2775,6 +2987,10 @@ function runtimeUserCommandEnv(home: string): NodeJS.ProcessEnv {
 				}
 			: {}),
 	};
+	if (options.transparentMitmCaFile) {
+		applyMitmTransparentRuntimeEnv(env, { caFile: options.transparentMitmCaFile });
+	}
+	return env;
 }
 
 function runtimeUserGid(runtimeUser: string): number {
@@ -2827,8 +3043,9 @@ function spawnRuntimeUserCommand(
 	args: string[],
 	home: string,
 	cwd: string,
+	options: { transparentMitmCaFile?: string } = {},
 ): ReturnType<typeof spawnSync> {
-	const env = runtimeUserCommandEnv(home);
+	const env = runtimeUserCommandEnv(home, options);
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
 	if (runningAsRoot() && runtimeUser && runtimeUser !== "root") {
 		ensureRuntimeUserManagerReady(runtimeUser);
@@ -2859,8 +3076,9 @@ function runRuntimeUserCommand(
 	stdin: string,
 	home: string,
 	cwd: string,
+	options: { transparentMitmCaFile?: string } = {},
 ): void {
-	const env = runtimeUserCommandEnv(home);
+	const env = runtimeUserCommandEnv(home, options);
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
 	if (runningAsRoot() && runtimeUser && runtimeUser !== "root") {
 		ensureRuntimeUserManagerReady(runtimeUser);
@@ -4001,6 +4219,7 @@ function writeSystemdUnits(
 	daemonAuthTokenFile: string | null,
 	secretValues: Record<string, string> | undefined,
 	providerProjectionRevisions: Partial<Record<string, string | null>>,
+	managedPrimaryModelOverrides: Partial<Record<string, AgentPrimaryModel>>,
 ): { systemUnits: string[]; userUnits: string[]; serviceInstallErrors: string[] } {
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
 	const runtimeBridgeToken = hostedRuntimeBridgeToken();
@@ -4131,6 +4350,7 @@ function writeSystemdUnits(
 					manifest,
 					paths.userHome,
 					workspaceRoot,
+					managedPrimaryModelOverrides.openclaw,
 				);
 			} catch (error) {
 				serviceInstallErrors.push(
@@ -4218,7 +4438,10 @@ function runtimeSecretValues(load: RuntimeManifestLoad): Record<string, string> 
 export function convergeRuntimeManifest(
 	load: RuntimeManifestLoad,
 	paths: RuntimePaths,
-	opts: { cacheLastGood?: boolean } = {},
+	opts: {
+		cacheLastGood?: boolean;
+		managedGatewayModelListFetcher?: ManagedGatewayModelListFetcher;
+	} = {},
 ): RuntimeConvergenceResult {
 	const { manifest } = load;
 	const secretValues = runtimeSecretValues(load);
@@ -4355,6 +4578,14 @@ export function convergeRuntimeManifest(
 	const liveSyncEnvironments = writeLiveSyncEnvironmentFiles(manifest, paths);
 	const writtenRunConfigIds = new Set<string>();
 	const providerProjectionRevisions: Partial<Record<string, string | null>> = {};
+	const managedPrimaryModelOverrides = resolveManagedGatewayPrimaryModelOverrides(
+		manifest,
+		enabledRuntimes,
+		paths.userHome,
+		workspaceRoot,
+		mitmSystemdProgram?.systemCaBundle ?? null,
+		opts.managedGatewayModelListFetcher ?? fetchManagedGatewayModelList,
+	);
 
 	for (const [name, runtime] of Object.entries(manifest.runtimes).sort(([a], [b]) =>
 		a.localeCompare(b),
@@ -4398,6 +4629,7 @@ export function convergeRuntimeManifest(
 				manifest,
 				workspaceRoot,
 				previousManifest,
+				managedPrimaryModelOverrides,
 			);
 			providerProjectionRevisions[name] = providerProjection.revision;
 		} catch (error) {
@@ -4533,6 +4765,7 @@ export function convergeRuntimeManifest(
 		daemonAuthTokenFile,
 		secretValues,
 		providerProjectionRevisions,
+		managedPrimaryModelOverrides,
 	);
 	installErrors.push(...systemdUnits.serviceInstallErrors);
 


### PR DESCRIPTION
## Summary
- add a runtime-side managed-model resolver that validates the managed seed against the live gateway `/models` list and only upgrades when the seed is missing or invalid
- run the probe once per converge per managed provider/base URL, through the runtime-user transparent-MITM path, with warning-only fallback on fetch failure
- plumb the resolved primary model into the normal OpenClaw/Hermes provider projection path and the OpenClaw post-official-install re-projection path

## Phase 1 findings
- The managed provider projection was static: `hostedProviderModels()` emitted only the managed primary seed and ignored the live gateway catalog for `managed_by == "clawdi"` (`packages/cli/src/runtime/manifest.ts:1258-1268`), and projection selection blindly trusted the provided `primaryModel` (`packages/cli/src/lib/ai-provider-projection.ts:153-156`).
- The dashboard-side managed fallback is currently hardcoded to `gpt-5.5`, so dashboard time cannot guarantee the model is still live by the time the pod converges (`apps/web/src/hosted/v2/ai-providers/model-binding.ts:4-6`).
- For OpenAI-compatible providers, Clawdi's own probe path is `${baseUrl}/models`, so a managed base URL like `.../v1` maps to the live `.../v1/models` endpoint (`packages/cli/src/lib/ai-provider-test.ts:142-152`).
- Managed provider auth is injected by the transparent MITM, not by explicit pod config: the managed profile host-matches the provider base URL and rewrites `authorization` from `apiKeySecretRef` (`packages/cli/src/runtime/hosted-mitm-profiles.ts:144-187`), and the mitm addon applies that provider rewrite while preserving the upstream authority (`packages/cli/mitmproxy-addon/clawdi_mitm_addon.py:128-145`, `packages/cli/mitmproxy-addon/clawdi_mitm_addon.py:393-440`).
- The probe has to run in-pod as the runtime user, not at dashboard time and not as an arbitrary root-side fetch: the transparent path is an nft redirect on the runtime UID's outbound `:80/:443` traffic (`packages/cli/src/runtime/transparent-mitm.ts:55-58`), while runtime programs only receive CA trust env and do not get proxy secrets or a forward-proxy env (`docs/managed-runtime.md:397-406`).
- Hermes' “prefer latest” behavior sorts matching model ids by `_model_sort_key()` and returns the first descending-version match (`/home/kingsley/.hermes/hermes-agent/hermes_cli/model_switch.py:450-554`, `/home/kingsley/.hermes/hermes-agent/hermes_cli/model_switch.py:628-631`).
- OpenClaw does not live-discover: it only registers models that exist in `providerConfig.models` (`/home/kingsley/openclaw/src/agents/sessions/model-registry.ts:439-445`, `/home/kingsley/openclaw/src/agents/sessions/model-registry.ts:523-559`), and the embedded runner raises an unknown-model error when the selected model is not registered there (`/home/kingsley/openclaw/src/agents/embedded-agent-runner/model.ts:1437-1495`).

## Implementation
- Added `packages/cli/src/runtime/managed-model-resolution.ts` with:
  - `buildManagedModelsEndpoint()` for the managed OpenAI-compatible `/models` endpoint (`packages/cli/src/runtime/managed-model-resolution.ts:16-18`)
  - `resolveManagedPrimaryModel()` for sticky keep / upgrade / failure fallback behavior (`packages/cli/src/runtime/managed-model-resolution.ts:34-60`)
  - a port of Hermes' version/suffix ordering logic via `managedModelSortKey()` (`packages/cli/src/runtime/managed-model-resolution.ts:62-169`)
- Converge now computes managed primary-model overrides before projecting runtime config (`packages/cli/src/runtime/manifest.ts:4438-4588`).
  - It targets only managed OpenAI-compatible providers (`packages/cli/src/runtime/manifest.ts:1305-1341`).
  - It caches the live fetch once per provider/base URL and warns instead of failing when the fetch misses (`packages/cli/src/runtime/manifest.ts:1343-1386`).
  - The live fetch runs as the runtime user through `spawnRuntimeUserCommand(...)` with transparent-MITM CA env and a 3s timeout (`packages/cli/src/runtime/manifest.ts:1388-1459`, `packages/cli/src/runtime/manifest.ts:2967-3071`).
- The resolved model is then written into the actual runtime projections:
  - `hostedAiProviderCatalog()` accepts a `primaryModelOverride` and uses it as the managed seed (`packages/cli/src/runtime/manifest.ts:1156-1204`).
  - Normal runtime projection uses that override for both Hermes and OpenClaw (`packages/cli/src/runtime/manifest.ts:1850-1867`, `packages/cli/src/runtime/manifest.ts:4622-4634`).
  - OpenClaw's post-official-install re-projection also receives the same override (`packages/cli/src/runtime/manifest.ts:2341-2354`, `packages/cli/src/runtime/manifest.ts:4343-4355`).
- This stays scoped to `managed_by == "clawdi"`; BYOK/custom/Codex OAuth paths are unchanged.

## Tests
- Added resolver coverage for:
  - valid configured model stays sticky
  - invalid or absent model upgrades to latest live model
  - fetch failure keeps the existing seed
  - endpoint construction + live model parsing
  - `packages/cli/src/runtime/managed-model-resolution.test.ts:8-64`
- Added projection coverage for managed primary-model overrides:
  - `packages/cli/src/runtime/manifest-reconciliation.test.ts:479-512`
- Verification:
  - `bun run check`
  - `bunx turbo typecheck --filter=clawdi --filter=@clawdi/shared --filter=web`
  - `bun test packages/cli`
