### PR TITLE
Embed v2 performance checkout in the deploy wizard

### DIFF
--- a/apps/web/src/hosted/billing/components/embedded-checkout.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/embedded-checkout.logic.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildHostedCheckoutFallbackRequest,
+	checkoutRedirectUrl,
+	findNewDeploymentId,
+	hasEmbeddedCheckoutClientSecret,
+} from "@/hosted/billing/components/embedded-checkout.logic";
+import type { CheckoutRequest, CheckoutResult, HostedDeployment } from "@/hosted/billing/contracts";
+
+describe("embedded checkout logic", () => {
+	test("prefers the action_url for hosted fallback redirects", () => {
+		const result: CheckoutResult = {
+			flow_type: "checkout_session",
+			action_url: "https://checkout.stripe.com/primary",
+			checkout_url: "https://checkout.stripe.com/secondary",
+			client_secret: null,
+		};
+
+		expect(checkoutRedirectUrl(result)).toBe("https://checkout.stripe.com/primary");
+	});
+
+	test("detects embedded checkout responses from a client secret", () => {
+		const result: CheckoutResult = {
+			flow_type: "checkout_session",
+			action_url: null,
+			checkout_url: "",
+			client_secret: "cs_test_embedded",
+		};
+
+		expect(hasEmbeddedCheckoutClientSecret(result)).toBe(true);
+	});
+
+	test("builds an explicit hosted fallback request", () => {
+		const request: CheckoutRequest = {
+			plan_slug: "compute_performance",
+			billing_term_months: 12,
+			ui_mode: "embedded",
+			deploy_config: { compute_plan_slug: "compute_performance" },
+		};
+
+		expect(buildHostedCheckoutFallbackRequest(request)).toEqual({
+			...request,
+			ui_mode: "hosted",
+		});
+	});
+
+	test("finds a deployment created after embedded checkout completes", () => {
+		const deployments = [{ id: "dep_old" }, { id: "dep_new" }] as HostedDeployment[];
+
+		expect(findNewDeploymentId(["dep_old"], deployments)).toBe("dep_new");
+		expect(findNewDeploymentId(["dep_old", "dep_new"], deployments)).toBeNull();
+	});
+});

--- a/apps/web/src/hosted/billing/components/embedded-checkout.logic.ts
+++ b/apps/web/src/hosted/billing/components/embedded-checkout.logic.ts
@@ -1,0 +1,25 @@
+import type { CheckoutRequest, CheckoutResult, HostedDeployment } from "@/hosted/billing/contracts";
+
+export function checkoutRedirectUrl(result: CheckoutResult): string | null {
+	return result.action_url || result.checkout_url || null;
+}
+
+export function hasEmbeddedCheckoutClientSecret(
+	result: CheckoutResult,
+): result is CheckoutResult & { client_secret: string } {
+	return typeof result.client_secret === "string" && result.client_secret.length > 0;
+}
+
+export function buildHostedCheckoutFallbackRequest(request: CheckoutRequest): CheckoutRequest {
+	return { ...request, ui_mode: "hosted" };
+}
+
+export function findNewDeploymentId(
+	previousDeploymentIds: readonly string[],
+	deployments: readonly HostedDeployment[] | undefined,
+): string | null {
+	if (!deployments?.length) return null;
+	const previousIds = new Set(previousDeploymentIds);
+	const created = deployments.find((deployment) => !previousIds.has(deployment.id));
+	return created?.id ?? null;
+}

--- a/apps/web/src/hosted/billing/components/stripe-embedded-checkout-dialog.tsx
+++ b/apps/web/src/hosted/billing/components/stripe-embedded-checkout-dialog.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { EmbeddedCheckout, EmbeddedCheckoutProvider } from "@stripe/react-stripe-js";
+import type { Stripe } from "@stripe/stripe-js";
+import { AlertCircle, RefreshCw } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { preflightEmbeddedCheckout, resetStripeCache } from "@/hosted/billing/stripe";
+import { env } from "@/lib/env";
+
+type StripeEmbeddedCheckoutDialogProps = {
+	clientSecret: string | null;
+	description: string;
+	onComplete: () => void;
+	onFallback: () => Promise<void>;
+	onOpenChange: (open: boolean) => void;
+	open: boolean;
+	title: string;
+};
+
+type DialogState = "loading" | "ready" | "redirecting" | "error";
+
+export function StripeEmbeddedCheckoutDialog({
+	clientSecret,
+	description,
+	onComplete,
+	onFallback,
+	onOpenChange,
+	open,
+	title,
+}: StripeEmbeddedCheckoutDialogProps) {
+	const key = env.VITE_STRIPE_PUBLISHABLE_KEY;
+	const [stripe, setStripe] = useState<Stripe | null>(null);
+	const [state, setState] = useState<DialogState>("loading");
+	const [message, setMessage] = useState<string | null>(null);
+	const [attempt, setAttempt] = useState(0);
+	const onCompleteRef = useRef(onComplete);
+	const onFallbackRef = useRef(onFallback);
+	const fallbackStartedRef = useRef(false);
+	const [stableOnComplete] = useState(() => () => onCompleteRef.current());
+
+	useEffect(() => {
+		onCompleteRef.current = onComplete;
+	}, [onComplete]);
+
+	useEffect(() => {
+		onFallbackRef.current = onFallback;
+	}, [onFallback]);
+
+	async function startHostedFallback(nextMessage: string) {
+		if (fallbackStartedRef.current) return;
+		fallbackStartedRef.current = true;
+		setState("redirecting");
+		setMessage(nextMessage);
+		try {
+			await onFallbackRef.current();
+		} catch {
+			fallbackStartedRef.current = false;
+			setState("error");
+			setMessage("We couldn’t open Stripe checkout. Please try again.");
+		}
+	}
+
+	useEffect(() => {
+		if (!open || !clientSecret) return;
+		let cancelled = false;
+		fallbackStartedRef.current = false;
+		setStripe(null);
+		setMessage(null);
+		setState("loading");
+		void (async () => {
+			if (!key) {
+				if (!cancelled) {
+					await startHostedFallback(
+						"Secure checkout isn’t configured in this environment. Opening Stripe instead.",
+					);
+				}
+				return;
+			}
+			try {
+				const nextStripe = await preflightEmbeddedCheckout(key, clientSecret);
+				if (cancelled) return;
+				setStripe(nextStripe);
+				setState("ready");
+			} catch {
+				resetStripeCache();
+				if (!cancelled) {
+					await startHostedFallback(
+						"We couldn’t load the embedded checkout. Opening Stripe instead.",
+					);
+				}
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [attempt, clientSecret, key, open]);
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent
+				className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-4xl"
+				data-hosted="true"
+				showCloseButton={state !== "redirecting"}
+			>
+				<DialogHeader>
+					<DialogTitle>{title}</DialogTitle>
+					<DialogDescription>{description}</DialogDescription>
+				</DialogHeader>
+				{state === "ready" && stripe && clientSecret ? (
+					<div className="overflow-hidden rounded-lg border">
+						<EmbeddedCheckoutProvider
+							key={clientSecret}
+							stripe={stripe}
+							options={{ clientSecret, onComplete: stableOnComplete }}
+						>
+							<EmbeddedCheckout className="min-h-[32rem]" />
+						</EmbeddedCheckoutProvider>
+					</div>
+				) : state === "error" ? (
+					<Alert data-hosted="true" variant="destructive">
+						<AlertCircle />
+						<AlertDescription className="flex flex-col items-start gap-3">
+							<span>{message ?? "We couldn’t load the secure checkout."}</span>
+							<div className="flex flex-wrap gap-2">
+								<Button
+									size="sm"
+									variant="outline"
+									onClick={() => {
+										resetStripeCache();
+										setAttempt((value) => value + 1);
+									}}
+								>
+									<RefreshCw /> Retry embedded checkout
+								</Button>
+								<Button
+									size="sm"
+									onClick={() => {
+										void startHostedFallback("Opening Stripe checkout…");
+									}}
+								>
+									Continue in Stripe
+								</Button>
+							</div>
+						</AlertDescription>
+					</Alert>
+				) : (
+					<div
+						data-hosted="true"
+						className="flex min-h-40 items-center gap-2 py-6 text-sm text-muted-foreground"
+					>
+						<Spinner />
+						<span>{message ?? "Loading secure checkout…"}</span>
+					</div>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -26,6 +26,13 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import {
+	buildHostedCheckoutFallbackRequest,
+	checkoutRedirectUrl,
+	findNewDeploymentId,
+	hasEmbeddedCheckoutClientSecret,
+} from "@/hosted/billing/components/embedded-checkout.logic";
+import { StripeEmbeddedCheckoutDialog } from "@/hosted/billing/components/stripe-embedded-checkout-dialog";
 import { TermSwitcher } from "@/hosted/billing/components/term-switcher";
 import type {
 	BillingOffer,
@@ -99,6 +106,11 @@ import { cn } from "@/lib/utils";
 
 type Compute = "free" | "performance";
 type ComputePlanSlug = DeployRequest["compute_plan_slug"];
+type EmbeddedDeployCheckout = {
+	clientSecret: string;
+	previousDeploymentIds: string[];
+	request: CheckoutRequest;
+};
 const DEPLOY_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
 const THREE_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2 lg:grid-cols-3";
 const TWO_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2";
@@ -242,7 +254,7 @@ function computeStatusLine({
 	if (perfOffer && perfOffer.billing_term_months !== 1) {
 		return {
 			tone: "muted",
-			message: `You’ll be sent to checkout. Billed ${formatCentsCompact(
+			message: `Checkout opens here. Billed ${formatCentsCompact(
 				perfOffer.price_cents,
 			)}${billingTermSuffix(
 				perfOffer.billing_term_months,
@@ -251,7 +263,7 @@ function computeStatusLine({
 	}
 	return {
 		tone: "muted",
-		message: "You’ll be sent to checkout. Each Performance agent uses its own subscription.",
+		message: "Checkout opens here. Each Performance agent uses its own subscription.",
 	};
 }
 
@@ -281,6 +293,7 @@ export function DeployWizard() {
 	const [language, setLanguage] = useState("");
 	const [timezone, setTimezone] = useState("");
 	const [addProviderOpen, setAddProviderOpen] = useState(false);
+	const [embeddedCheckout, setEmbeddedCheckout] = useState<EmbeddedDeployCheckout | null>(null);
 	const [term, setTerm] = useState(1);
 	const [submitting, setSubmitting] = useState(false);
 
@@ -544,6 +557,51 @@ export function DeployWizard() {
 		return false;
 	}
 
+	async function fallbackToHostedCheckout(request: CheckoutRequest) {
+		const hostedBody = buildHostedCheckoutFallbackRequest(request);
+		checkoutAttemptRef.current = idempotencyAttemptFor(
+			checkoutAttemptRef.current,
+			"subscription-checkout-hosted-fallback",
+			idempotencyFingerprint(hostedBody),
+			newIdempotencyKey,
+		);
+		const result = await checkout.mutateAsync({
+			body: hostedBody,
+			idempotencyKey: checkoutAttemptRef.current.key,
+		});
+		if (redirectTo(checkoutRedirectUrl(result))) return;
+		throw new Error("No checkout URL was returned.");
+	}
+
+	async function handleEmbeddedCheckoutComplete(previousDeploymentIds: readonly string[]) {
+		setEmbeddedCheckout(null);
+		let refreshedDeployments: Awaited<ReturnType<typeof refreshCheckoutReturn>>;
+		try {
+			refreshedDeployments = await refreshCheckoutReturn();
+		} catch {
+			toast.success("Checkout complete", {
+				description:
+					"Your Performance deployment is provisioning. We’ll refresh it on the next load.",
+			});
+			return;
+		}
+		const deploymentId = findNewDeploymentId(previousDeploymentIds, refreshedDeployments);
+		if (deploymentId) {
+			toast.success("Checkout complete", {
+				description: "Your Performance deployment is provisioning now.",
+			});
+			void router.navigate({
+				href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"),
+				replace: true,
+			});
+			return;
+		}
+		toast.success("Checkout complete", {
+			description:
+				"Your Performance deployment is provisioning. Check your agents list in a moment.",
+		});
+	}
+
 	async function onDeploy() {
 		if (!canSubmit) return;
 		setSubmitting(true);
@@ -556,7 +614,7 @@ export function DeployWizard() {
 				const body: CheckoutRequest = {
 					plan_slug: perfPlan.slug,
 					billing_term_months: perfOfferSelection.billingTermMonths,
-					ui_mode: "hosted",
+					ui_mode: "embedded",
 					deploy_config: deployConfig,
 				};
 				checkoutAttemptRef.current = idempotencyAttemptFor(
@@ -569,7 +627,15 @@ export function DeployWizard() {
 					body,
 					idempotencyKey: checkoutAttemptRef.current.key,
 				});
-				if (redirectTo(result.action_url || result.checkout_url)) return;
+				if (hasEmbeddedCheckoutClientSecret(result)) {
+					setEmbeddedCheckout({
+						clientSecret: result.client_secret,
+						previousDeploymentIds: (deployments.data ?? []).map((deployment) => deployment.id),
+						request: body,
+					});
+					return;
+				}
+				if (redirectTo(checkoutRedirectUrl(result))) return;
 				toast.error("Couldn't start checkout", {
 					description: "No checkout URL was returned. Please try again.",
 				});
@@ -931,6 +997,23 @@ export function DeployWizard() {
 				open={addProviderOpen}
 				onOpenChange={setAddProviderOpen}
 				onCreated={selectCreatedProvider}
+			/>
+			<StripeEmbeddedCheckoutDialog
+				open={embeddedCheckout !== null}
+				onOpenChange={(next) => {
+					if (!next) setEmbeddedCheckout(null);
+				}}
+				clientSecret={embeddedCheckout?.clientSecret ?? null}
+				title="Complete Performance checkout"
+				description="Secure checkout stays on this page. Redirect-based payment methods may briefly open Stripe and then return."
+				onComplete={() =>
+					void handleEmbeddedCheckoutComplete(embeddedCheckout?.previousDeploymentIds ?? [])
+				}
+				onFallback={() =>
+					embeddedCheckout
+						? fallbackToHostedCheckout(embeddedCheckout.request)
+						: Promise.reject(new Error("Missing checkout request."))
+				}
 			/>
 		</div>
 	);

--- a/apps/web/src/hosted/billing/stripe.ts
+++ b/apps/web/src/hosted/billing/stripe.ts
@@ -1,0 +1,30 @@
+import { loadStripe, type Stripe } from "@stripe/stripe-js";
+
+let stripePromise: Promise<Stripe | null> | null = null;
+
+export function getStripe(key: string): Promise<Stripe | null> {
+	if (!stripePromise) stripePromise = loadStripe(key);
+	return stripePromise;
+}
+
+export function resetStripeCache() {
+	stripePromise = null;
+}
+
+/**
+ * Stripe's React Embedded Checkout wrapper doesn't surface initialization
+ * failures. Preflight one checkout instance so the caller can fall back before
+ * showing a blank dialog, then destroy it and let the real provider remount.
+ */
+export async function preflightEmbeddedCheckout(
+	key: string,
+	clientSecret: string,
+): Promise<Stripe> {
+	const stripe = await getStripe(key);
+	if (!stripe) {
+		throw new Error("Stripe.js failed to initialize.");
+	}
+	const embeddedCheckout = await stripe.createEmbeddedCheckoutPage({ clientSecret });
+	embeddedCheckout.destroy();
+	return stripe;
+}

--- a/apps/web/src/hosted/billing/wallet/stripe-payment-form.tsx
+++ b/apps/web/src/hosted/billing/wallet/stripe-payment-form.tsx
@@ -1,28 +1,14 @@
 "use client";
 
 import { Elements, PaymentElement, useElements, useStripe } from "@stripe/react-stripe-js";
-import { loadStripe, type Stripe } from "@stripe/stripe-js";
+import type { Stripe } from "@stripe/stripe-js";
 import { AlertCircle, RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
+import { getStripe, resetStripeCache } from "@/hosted/billing/stripe";
 import { env } from "@/lib/env";
-
-/**
- * Stripe.js singleton. `loadStripe` injects the v3 script; keep one promise so
- * remounting the top-up dialog doesn't re-inject it. `resetStripeCache` clears
- * it so a retry after a failed (network) load actually re-injects rather than
- * re-awaiting the same rejected promise.
- */
-let stripePromise: Promise<Stripe | null> | null = null;
-function getStripe(key: string): Promise<Stripe | null> {
-	if (!stripePromise) stripePromise = loadStripe(key);
-	return stripePromise;
-}
-function resetStripeCache() {
-	stripePromise = null;
-}
 
 /** Terminal outcomes only — `requires_action` (3DS) is resolved inside the form. */
 export type PaymentOutcome = "succeeded" | "processing";

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -482,7 +482,7 @@ export interface components {
             upgrade_deployment_id?: string | null;
             /**
              * Ui Mode
-             * @default hosted
+             * @default embedded
              */
             ui_mode: string;
             /** Locale */


### PR DESCRIPTION
## Summary
- mount Stripe Embedded Checkout in the v2 deploy wizard instead of immediately redirecting to Stripe-hosted Checkout when the subscription checkout response returns a `client_secret`
- reuse the existing checkout return refresh path after completion, and fall back to an explicit hosted checkout redirect if embedded initialization fails
- extract the shared Stripe.js singleton so wallet `PaymentElement` and deploy `EmbeddedCheckout` use the same loader
- regenerate `packages/shared/src/api/deploy.generated.ts` for the backend schema default change

## Phase 1 findings
- On `origin/main`, the Performance deploy path forces hosted checkout by sending `ui_mode: "hosted"` at `apps/web/src/hosted/billing/deploy/deploy-wizard.tsx:555-560`, then immediately redirecting to `result.action_url || result.checkout_url` at `apps/web/src/hosted/billing/deploy/deploy-wizard.tsx:568-572`.
- The deploy wizard already has reusable checkout return plumbing: it watches checkout markers and refreshes deployment / wallet / plan queries at `apps/web/src/hosted/billing/deploy/deploy-wizard.tsx:334-357`, backed by `checkoutReturnMarker`, `checkoutReturnDeploymentId`, and `useCheckoutReturnRefresh` in `apps/web/src/hosted/billing/hooks.ts:40-69` and `apps/web/src/hosted/billing/hooks.ts:244-280`.
- The frontend already loads Stripe.js locally for wallet top-ups through `@stripe/react-stripe-js` + `loadStripe` at `apps/web/src/hosted/billing/wallet/stripe-payment-form.tsx:3-25` and mounts `Elements` + `PaymentElement` against a PaymentIntent `client_secret` at `apps/web/src/hosted/billing/wallet/stripe-payment-form.tsx:113-199`.
- For an embedded Checkout Session, the correct Stripe React primitive is `EmbeddedCheckoutProvider` + `EmbeddedCheckout` with the Checkout Session `client_secret`, not `PaymentElement` (Stripe docs: https://docs.stripe.com/checkout/embedded/quickstart?client=react and https://docs.stripe.com/stripe-js/react).

## Notes for review
- This ships with the paired backend PR https://github.com/Clawdi-AI/clawdi-hosted/pull/734 ; do not merge one without the other.
- Hosted fallback depends on the backend PR's `ui_mode`-aware Stripe idempotency key so an embedded-init failure can safely request a hosted Checkout Session.

## Verification
- `bun run check`
- `bun x turbo typecheck --filter=web --filter=@clawdi/shared`
- `bun test apps/web/src/hosted/billing/components/embedded-checkout.logic.test.ts`

