### PR TITLE
Add BYOK provider preset catalog

### DIFF
--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
@@ -7,7 +7,17 @@ import {
 	providerFormIdentity,
 	shouldUseCatalogModels,
 } from "@/hosted/v2/ai-providers/add-provider-dialog.logic";
+import {
+	presetCatalogToProviderModels,
+	providerPresetById,
+} from "@/hosted/v2/ai-providers/provider-presets";
 import type { AiProviderAuth } from "@/hosted/v2/ai-providers/types";
+
+function testPreset(id: string) {
+	const preset = providerPresetById(id);
+	if (!preset) throw new Error(`Missing test preset: ${id}`);
+	return preset;
+}
 
 describe("providerAuthForSubmit", () => {
 	test("preserves env-source API key auth when editing with a blank key", () => {
@@ -131,6 +141,21 @@ describe("providerFormIdentity", () => {
 			label: "Team proxy",
 		});
 	});
+
+	test("derives duplicate-safe ids and labels from presets", () => {
+		expect(
+			providerFormIdentity({
+				type: "custom_openai_compatible",
+				authMethod: "api_key",
+				labelInput: "",
+				existingProviderIds: ["deepseek"],
+				preset: testPreset("deepseek"),
+			}),
+		).toEqual({
+			providerId: "deepseek-2",
+			label: "DeepSeek 2",
+		});
+	});
 });
 
 describe("derivedProviderFields", () => {
@@ -163,6 +188,19 @@ describe("derivedProviderFields", () => {
 		});
 		expect(shouldUseCatalogModels("custom_openai_compatible", "api_key")).toBe(false);
 	});
+
+	test("uses preset fields for BYOK provider presets", () => {
+		const preset = testPreset("deepseek");
+
+		expect(derivedProviderFields("custom_openai_compatible", "api_key", preset)).toEqual({
+			baseUrl: "https://api.deepseek.com/v1",
+			apiMode: "openai_chat",
+			runtimeEnv: "DEEPSEEK_API_KEY",
+			modelsText: "deepseek-v4-flash\ndeepseek-v4",
+			suggestedPrimaryModel: "deepseek-v4-flash",
+		});
+		expect(shouldUseCatalogModels("custom_openai_compatible", "api_key", preset)).toBe(true);
+	});
 });
 
 describe("modelsFromText", () => {
@@ -175,6 +213,25 @@ describe("modelsFromText", () => {
 		).toEqual([
 			{ id: "gpt-5.5", label: "GPT-5.5" },
 			{ id: "gpt-5.4", label: "GPT-5.4" },
+		]);
+	});
+
+	test("builds preset request models with catalog metadata", () => {
+		const preset = testPreset("deepseek");
+
+		expect(
+			modelsFromText(
+				"deepseek-v4-flash\nunknown-model\ndeepseek-v4-flash",
+				null,
+				presetCatalogToProviderModels(preset),
+			),
+		).toEqual([
+			{
+				id: "deepseek-v4-flash",
+				label: "DeepSeek V4 Flash",
+				context_window: 1_000_000,
+			},
+			{ id: "unknown-model" },
 		]);
 	});
 });

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.ts
@@ -1,6 +1,11 @@
 import { CODEX_OAUTH_MODEL_CATALOG } from "@clawdi/shared";
 import { CLAWDI_CODEX_OAUTH_PROVIDER_ID } from "@/hosted/v2/ai-providers/codex-oauth";
 import {
+	type ProviderPreset,
+	presetCatalogToProviderModels,
+	presetRuntimeEnvName,
+} from "@/hosted/v2/ai-providers/provider-presets";
+import {
 	type ApiMode,
 	type ProviderTypeId,
 	providerTypeMeta,
@@ -32,6 +37,7 @@ export interface DerivedProviderFields {
 	apiMode: ApiMode;
 	runtimeEnv: string;
 	modelsText: string;
+	suggestedPrimaryModel?: string;
 }
 
 export function isAuthMethod(value: string | null): value is AuthMethod {
@@ -98,15 +104,24 @@ export function parseModelIds(input: string): string[] {
 export function modelsFromText(
 	input: string,
 	existing: AiProvider["models"],
+	catalog: AiProvider["models"] = [],
 ): AiProviderUpsert["models"] {
-	const existingById = new Map((existing ?? []).map((model) => [model.id, model]));
-	const models = parseModelIds(input).map((id) => existingById.get(id) ?? { id });
+	type UpsertModel = NonNullable<AiProviderUpsert["models"]>[number];
+	const knownById = new Map<string, UpsertModel>();
+	for (const model of catalog ?? []) {
+		knownById.set(model.id, model);
+	}
+	for (const model of existing ?? []) {
+		knownById.set(model.id, model);
+	}
+	const models = parseModelIds(input).map((id) => knownById.get(id) ?? { id });
 	return models.length > 0 ? models : null;
 }
 
 export function derivedProviderFields(
 	type: ProviderTypeId,
 	authMethod: AuthMethod,
+	preset?: ProviderPreset | null,
 ): DerivedProviderFields {
 	const meta = providerTypeMeta(type);
 	if (authMethod === "oauth") {
@@ -117,6 +132,15 @@ export function derivedProviderFields(
 			modelsText: modelsToText(CODEX_OAUTH_MODEL_CATALOG),
 		};
 	}
+	if (preset) {
+		return {
+			baseUrl: preset.base_url,
+			apiMode: preset.api_mode,
+			runtimeEnv: presetRuntimeEnvName(preset),
+			modelsText: modelsToText(presetCatalogToProviderModels(preset)),
+			suggestedPrimaryModel: preset.suggested_primary_model,
+		};
+	}
 	return {
 		baseUrl: meta.defaultBaseUrl,
 		apiMode: meta.defaultApiMode,
@@ -125,7 +149,12 @@ export function derivedProviderFields(
 	};
 }
 
-export function shouldUseCatalogModels(type: ProviderTypeId, authMethod: AuthMethod): boolean {
+export function shouldUseCatalogModels(
+	type: ProviderTypeId,
+	authMethod: AuthMethod,
+	preset?: ProviderPreset | null,
+): boolean {
+	if (preset) return true;
 	return authMethod === "oauth" || providerTypeMeta(type).custom !== true;
 }
 
@@ -135,12 +164,14 @@ export function providerFormIdentity({
 	labelInput,
 	existingProviderIds,
 	editing,
+	preset,
 }: {
 	type: ProviderTypeId;
 	authMethod: AuthMethod;
 	labelInput: string;
 	existingProviderIds: readonly string[];
 	editing?: Pick<AiProvider, "provider_id" | "label"> | null;
+	preset?: ProviderPreset | null;
 }): ProviderFormIdentity {
 	if (authMethod === "oauth") {
 		return {
@@ -155,10 +186,11 @@ export function providerFormIdentity({
 		};
 	}
 	const baseLabel =
-		providerTypeMeta(type).custom === true
+		preset?.label ??
+		(providerTypeMeta(type).custom === true
 			? (normalizeLabel(labelInput) ?? defaultProviderLabel(type))
-			: defaultProviderLabel(type);
-	const baseId = toProviderId(baseLabel);
+			: defaultProviderLabel(type));
+	const baseId = toProviderId(preset?.id ?? baseLabel);
 	if (!baseId) return { providerId: "", label: baseLabel };
 	if (!existingProviderIds.includes(baseId)) {
 		return { providerId: baseId, label: baseLabel };

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -58,6 +58,15 @@ import {
 	parseCodexCallback,
 } from "@/hosted/v2/ai-providers/codex-oauth";
 import {
+	PROVIDER_PRESET_CATEGORIES,
+	PROVIDER_PRESET_CATEGORY_LABEL,
+	PROVIDER_PRESETS,
+	type ProviderPreset,
+	presetCatalogToProviderModels,
+	providerPresetById,
+	providerTypeForPreset,
+} from "@/hosted/v2/ai-providers/provider-presets";
+import {
 	API_MODE_LABEL,
 	type ApiMode,
 	PROVIDER_TYPES,
@@ -130,6 +139,7 @@ export function AddProviderDialog({
 	const [runtimeEnv, setRuntimeEnv] = useState("");
 	const [authMethod, setAuthMethod] = useState<AuthMethod>("api_key");
 	const [apiKey, setApiKey] = useState("");
+	const [presetId, setPresetId] = useState<string | null>(null);
 
 	// OAuth sub-flow
 	const [oauth, setOauth] = useState<{
@@ -158,15 +168,19 @@ export function AddProviderDialog({
 	const createdFreshRef = useRef(false);
 
 	const meta = providerTypeMeta(type);
+	const selectedPreset = isEdit ? null : providerPresetById(presetId);
+	const presetLocked = selectedPreset !== null;
 	const existingProviderIds =
 		providers.data?.providers.map((provider) => provider.provider_id) ?? [];
-	const catalogManaged = shouldUseCatalogModels(type, authMethod);
+	const catalogManaged = shouldUseCatalogModels(type, authMethod, selectedPreset);
+	const presetCatalogModels = selectedPreset ? presetCatalogToProviderModels(selectedPreset) : [];
 	const identity = providerFormIdentity({
 		type,
 		authMethod,
 		labelInput: label,
 		existingProviderIds,
 		editing,
+		preset: selectedPreset,
 	});
 	const providerId = identity.providerId;
 	const providerLabel = identity.label ?? (providerId || meta.label);
@@ -176,9 +190,9 @@ export function AddProviderDialog({
 		...(meta.oauth ? [{ value: "oauth", label: "Sign in with ChatGPT (Codex)" }] : []),
 		...(meta.custom ? [{ value: "none", label: "No auth (local)" }] : []),
 	];
-	const showAuthMethodField = authMethodItems.length > 1;
-	const showNameField = meta.custom === true;
-	const showAdvancedFields = meta.custom === true;
+	const showAuthMethodField = authMethodItems.length > 1 && !presetLocked;
+	const showNameField = meta.custom === true && !presetLocked;
+	const showAdvancedFields = meta.custom === true && !presetLocked;
 	const showRuntimeEnvField = authMethod === "api_key" && showAdvancedFields;
 	const apiModeItems = meta.apiModes.map((mode) => ({
 		value: mode,
@@ -201,6 +215,7 @@ export function AddProviderDialog({
 		abandonedRef.current = false;
 		createdFreshRef.current = false;
 		popupRef.current = null;
+		setPresetId(null);
 		if (editing) {
 			const nextType = editing.type as ProviderTypeId;
 			const nextAuthMethod =
@@ -241,6 +256,7 @@ export function AddProviderDialog({
 		if (!m.oauth && nextAuthMethod === "oauth") nextAuthMethod = "api_key";
 		if (!m.custom && nextAuthMethod === "none") nextAuthMethod = "api_key";
 		const defaults = derivedProviderFields(next, nextAuthMethod);
+		setPresetId(null);
 		setType(next);
 		setBaseUrl(defaults.baseUrl);
 		setModelsText(defaults.modelsText);
@@ -249,6 +265,20 @@ export function AddProviderDialog({
 		setAuthMethod(nextAuthMethod);
 		setApiKey("");
 		if (next === "custom_openai_compatible") setLabel("");
+	}
+
+	function changePreset(next: ProviderPreset) {
+		const nextType = providerTypeForPreset(next);
+		const defaults = derivedProviderFields(nextType, "api_key", next);
+		setPresetId(next.id);
+		setType(nextType);
+		setLabel("");
+		setBaseUrl(defaults.baseUrl);
+		setModelsText(defaults.modelsText);
+		setApiMode(defaults.apiMode);
+		setRuntimeEnv(defaults.runtimeEnv);
+		setAuthMethod("api_key");
+		setApiKey("");
 	}
 
 	function changeAuthMethod(next: AuthMethod) {
@@ -352,7 +382,7 @@ export function AddProviderDialog({
 			type,
 			label: identity.label,
 			base_url: baseUrl.trim(),
-			models: modelsFromText(modelsText, editing?.models),
+			models: modelsFromText(modelsText, editing?.models, presetCatalogModels),
 			api_mode: apiMode,
 			auth,
 			managed_by: "user" as const,
@@ -699,6 +729,45 @@ export function AddProviderDialog({
 
 						<div className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
 							<div className="flex flex-col gap-4">
+								{!isEdit ? (
+									<div className="flex flex-col gap-2">
+										<Label>Provider preset</Label>
+										<div className="flex flex-col gap-3">
+											{PROVIDER_PRESET_CATEGORIES.map((category) => {
+												const presets = PROVIDER_PRESETS.filter(
+													(preset) => preset.category === category,
+												);
+												return (
+													<div key={category} className="flex flex-col gap-1.5">
+														<p className="text-xs font-medium text-muted-foreground">
+															{PROVIDER_PRESET_CATEGORY_LABEL[category]}
+														</p>
+														<div className="grid gap-2 sm:grid-cols-2">
+															{presets.map((preset) => (
+																<EntityChoiceCard
+																	key={preset.id}
+																	selected={selectedPreset?.id === preset.id}
+																	onClick={() => changePreset(preset)}
+																	icon={
+																		<EntityIcon
+																			kind="provider"
+																			id={preset.id}
+																			label={preset.label}
+																			size="sm"
+																		/>
+																	}
+																	title={preset.label}
+																	description={`${API_MODE_LABEL[preset.api_mode]} · ${preset.catalog.length} models`}
+																/>
+															))}
+														</div>
+													</div>
+												);
+											})}
+										</div>
+									</div>
+								) : null}
+
 								<div className="flex flex-col gap-1.5">
 									<Label>Provider</Label>
 									<div className="grid gap-2 sm:grid-cols-2">
@@ -707,7 +776,7 @@ export function AddProviderDialog({
 											return (
 												<EntityChoiceCard
 													key={t}
-													selected={type === t}
+													selected={!selectedPreset && type === t}
 													onClick={isEdit ? undefined : () => changeType(t)}
 													disabled={isEdit}
 													icon={
@@ -722,7 +791,16 @@ export function AddProviderDialog({
 								</div>
 
 								<div className="flex items-center gap-3 rounded-lg border bg-muted/30 p-3">
-									<ProviderTypeChip type={type} />
+									{selectedPreset ? (
+										<EntityIcon
+											kind="provider"
+											id={selectedPreset.id}
+											label={selectedPreset.label}
+											size="md"
+										/>
+									) : (
+										<ProviderTypeChip type={type} />
+									)}
 									<div className="min-w-0 flex-1">
 										<p className="text-sm font-medium text-foreground">{providerLabel}</p>
 										<p className="text-xs text-muted-foreground">
@@ -731,9 +809,11 @@ export function AddProviderDialog({
 										{catalogManaged ? (
 											<>
 												<p className="mt-1 text-xs text-muted-foreground">
-													{authMethod === "oauth"
-														? `ChatGPT/Codex mapping · ${catalogSummary || "No catalog models"}`
-														: `Runtime mapping · ${API_MODE_LABEL[apiMode]} · ${catalogSummary || "No catalog models"}`}
+													{selectedPreset
+														? `Preset mapping · ${API_MODE_LABEL[apiMode]} · primary ${selectedPreset.suggested_primary_model}`
+														: authMethod === "oauth"
+															? `ChatGPT/Codex mapping · ${catalogSummary || "No catalog models"}`
+															: `Runtime mapping · ${API_MODE_LABEL[apiMode]} · ${catalogSummary || "No catalog models"}`}
 												</p>
 												<p className="mt-1 break-all font-mono text-xs text-muted-foreground">
 													{baseUrl}
@@ -801,6 +881,17 @@ export function AddProviderDialog({
 											spellCheck={false}
 										/>
 										<p className="text-xs text-muted-foreground">{apiKeyHelpText}</p>
+										{selectedPreset ? (
+											<a
+												href={selectedPreset.api_key_url}
+												target="_blank"
+												rel="noreferrer"
+												className="inline-flex w-fit items-center gap-1 text-xs font-medium text-primary hover:underline"
+											>
+												Get API key
+												<ExternalLink className="size-3" />
+											</a>
+										) : null}
 										{keyRequired && isEdit && !apiKey.trim() ? (
 											<p className="text-xs text-destructive">
 												Enter a key to switch this provider to managed API-key auth.

--- a/apps/web/src/hosted/v2/ai-providers/provider-presets.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-presets.ts
@@ -1,0 +1,313 @@
+import type {
+	ApiMode,
+	ProviderCatalogModel,
+	ProviderTypeId,
+} from "@/hosted/v2/ai-providers/provider-types";
+
+// Provider-preset design derived from cc-switch (MIT). Preset data is maintained
+// by Clawdi and mapped onto the hosted v2 provider form/API contract.
+export type ProviderPresetCategory =
+	| "cn_official"
+	| "aggregator"
+	| "third_party"
+	| "cloud_provider";
+
+export interface ProviderPresetCatalogEntry {
+	id: string;
+	context_window?: number;
+	alias?: string;
+}
+
+export interface ProviderPresetRegionVariant {
+	id: string;
+	label: string;
+	base_url: string;
+	website_url?: string;
+	api_key_url?: string;
+}
+
+export interface ProviderPreset {
+	id: string;
+	label: string;
+	category: ProviderPresetCategory;
+	base_url: string;
+	api_mode: ApiMode;
+	suggested_primary_model: string;
+	catalog: readonly ProviderPresetCatalogEntry[];
+	api_key_url: string;
+	website_url: string;
+	region_variants?: readonly ProviderPresetRegionVariant[];
+	/** Internal backend type to use when the preset matches a first-class type. */
+	provider_type?: ProviderTypeId;
+}
+
+export const PROVIDER_PRESET_CATEGORIES = [
+	"cn_official",
+	"aggregator",
+	"third_party",
+	"cloud_provider",
+] as const satisfies readonly ProviderPresetCategory[];
+
+export const PROVIDER_PRESET_CATEGORY_LABEL: Record<ProviderPresetCategory, string> = {
+	cn_official: "CN official",
+	aggregator: "Aggregators",
+	third_party: "Third-party providers",
+	cloud_provider: "Cloud providers",
+};
+
+export const PROVIDER_PRESETS = [
+	{
+		id: "deepseek",
+		label: "DeepSeek",
+		category: "cn_official",
+		base_url: "https://api.deepseek.com/v1",
+		api_mode: "openai_chat",
+		suggested_primary_model: "deepseek-v4-flash",
+		catalog: [
+			{ id: "deepseek-v4-flash", context_window: 1_000_000, alias: "DeepSeek V4 Flash" },
+			{ id: "deepseek-v4", context_window: 1_000_000, alias: "DeepSeek V4" },
+		],
+		api_key_url: "https://platform.deepseek.com/api_keys",
+		website_url: "https://www.deepseek.com",
+	},
+	{
+		id: "kimi-moonshot",
+		label: "Kimi / Moonshot",
+		category: "cn_official",
+		base_url: "https://api.moonshot.cn/v1",
+		api_mode: "openai_chat",
+		suggested_primary_model: "kimi-k2.7-code",
+		catalog: [
+			{ id: "kimi-k2.7-code", context_window: 262_144, alias: "Kimi K2.7 Code" },
+			{
+				id: "kimi-k2.7-code-highspeed",
+				context_window: 262_144,
+				alias: "Kimi K2.7 Code High Speed",
+			},
+			{ id: "moonshot-v1-128k", context_window: 131_072, alias: "Moonshot v1 128K" },
+		],
+		api_key_url: "https://platform.kimi.ai/console/api-keys",
+		website_url: "https://platform.kimi.ai",
+	},
+	{
+		id: "qwen-dashscope",
+		label: "Qwen (DashScope)",
+		category: "cn_official",
+		base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+		api_mode: "openai_chat",
+		suggested_primary_model: "qwen3.7-plus",
+		catalog: [
+			{ id: "qwen3.7-plus", context_window: 1_000_000, alias: "Qwen3.7 Plus" },
+			{ id: "qwen3.7-max", context_window: 1_000_000, alias: "Qwen3.7 Max" },
+			{ id: "qwen3-coder-next", context_window: 262_144, alias: "Qwen3 Coder Next" },
+		],
+		api_key_url: "https://bailian.console.aliyun.com/?tab=model#/api-key",
+		website_url: "https://bailian.console.aliyun.com",
+	},
+	{
+		id: "zhipu-glm",
+		label: "Zhipu GLM",
+		category: "cn_official",
+		base_url: "https://open.bigmodel.cn/api/paas/v4",
+		api_mode: "openai_chat",
+		suggested_primary_model: "glm-5.2",
+		catalog: [
+			{ id: "glm-5.2", context_window: 1_000_000, alias: "GLM-5.2" },
+			{ id: "glm-5.1", context_window: 262_144, alias: "GLM-5.1" },
+			{ id: "glm-4.7", context_window: 262_144, alias: "GLM-4.7" },
+		],
+		api_key_url: "https://bigmodel.cn/usercenter/proj-mgmt/apikeys",
+		website_url: "https://bigmodel.cn",
+		region_variants: [
+			{
+				id: "cn",
+				label: "China",
+				base_url: "https://open.bigmodel.cn/api/paas/v4",
+				api_key_url: "https://bigmodel.cn/usercenter/proj-mgmt/apikeys",
+				website_url: "https://bigmodel.cn",
+			},
+			{
+				id: "global",
+				label: "Global",
+				base_url: "https://api.z.ai/api/paas/v4",
+				api_key_url: "https://z.ai/manage-apikey/apikey-list",
+				website_url: "https://z.ai",
+			},
+		],
+	},
+	{
+		id: "stepfun",
+		label: "StepFun",
+		category: "cn_official",
+		base_url: "https://api.stepfun.ai/v1",
+		api_mode: "openai_chat",
+		suggested_primary_model: "step-3.7-flash",
+		catalog: [
+			{ id: "step-3.7-flash", context_window: 262_144, alias: "Step 3.7 Flash" },
+			{ id: "step-3.7-pro", context_window: 262_144, alias: "Step 3.7 Pro" },
+		],
+		api_key_url: "https://platform.stepfun.ai/account/api-keys",
+		website_url: "https://platform.stepfun.ai",
+		region_variants: [
+			{
+				id: "global",
+				label: "Global",
+				base_url: "https://api.stepfun.ai/v1",
+				api_key_url: "https://platform.stepfun.ai/account/api-keys",
+				website_url: "https://platform.stepfun.ai",
+			},
+			{
+				id: "cn",
+				label: "China",
+				base_url: "https://api.stepfun.com/v1",
+				api_key_url: "https://platform.stepfun.com/account/api-keys",
+				website_url: "https://platform.stepfun.com",
+			},
+		],
+	},
+	{
+		id: "minimax",
+		label: "MiniMax",
+		category: "cn_official",
+		base_url: "https://api.minimax.io/v1",
+		api_mode: "openai_chat",
+		suggested_primary_model: "MiniMax-M3",
+		catalog: [
+			{ id: "MiniMax-M3", context_window: 1_000_000, alias: "MiniMax M3" },
+			{ id: "MiniMax-M2", context_window: 200_000, alias: "MiniMax M2" },
+		],
+		api_key_url: "https://platform.minimax.io/user-center/basic-information/interface-key",
+		website_url: "https://platform.minimax.io",
+	},
+	{
+		id: "openrouter",
+		label: "OpenRouter",
+		category: "aggregator",
+		base_url: "https://openrouter.ai/api/v1",
+		api_mode: "openai_chat",
+		suggested_primary_model: "openrouter/auto",
+		catalog: [
+			{ id: "openrouter/auto", alias: "OpenRouter Auto" },
+			{ id: "~openai/gpt-latest", alias: "OpenAI latest" },
+			{ id: "anthropic/claude-sonnet-5", context_window: 1_000_000, alias: "Claude Sonnet" },
+		],
+		api_key_url: "https://openrouter.ai/settings/keys",
+		website_url: "https://openrouter.ai",
+		provider_type: "openrouter",
+	},
+	{
+		id: "together-ai",
+		label: "Together AI",
+		category: "cloud_provider",
+		base_url: "https://api.together.ai/v1",
+		api_mode: "openai_chat",
+		suggested_primary_model: "MiniMaxAI/MiniMax-M3",
+		catalog: [
+			{ id: "MiniMaxAI/MiniMax-M3", context_window: 524_288, alias: "MiniMax M3" },
+			{
+				id: "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+				context_window: 262_144,
+				alias: "Qwen3 Coder 480B",
+			},
+			{ id: "zai-org/GLM-5.2", context_window: 262_144, alias: "GLM-5.2" },
+		],
+		api_key_url: "https://api.together.ai/settings/api-keys",
+		website_url: "https://www.together.ai",
+	},
+	{
+		id: "groq",
+		label: "Groq",
+		category: "third_party",
+		base_url: "https://api.groq.com/openai/v1",
+		api_mode: "openai_chat",
+		suggested_primary_model: "openai/gpt-oss-120b",
+		catalog: [
+			{ id: "openai/gpt-oss-120b", context_window: 131_072, alias: "GPT OSS 120B" },
+			{
+				id: "meta-llama/llama-4-maverick-17b-128e-instruct",
+				context_window: 131_072,
+				alias: "Llama 4 Maverick",
+			},
+			{ id: "qwen/qwen3-32b", context_window: 131_072, alias: "Qwen3 32B" },
+		],
+		api_key_url: "https://console.groq.com/keys",
+		website_url: "https://groq.com",
+	},
+	{
+		id: "mistral",
+		label: "Mistral",
+		category: "third_party",
+		base_url: "https://api.mistral.ai/v1",
+		api_mode: "openai_chat",
+		suggested_primary_model: "mistral-large-latest",
+		catalog: [
+			{ id: "mistral-large-latest", context_window: 128_000, alias: "Mistral Large" },
+			{ id: "mistral-medium-latest", context_window: 128_000, alias: "Mistral Medium" },
+			{ id: "codestral-latest", context_window: 256_000, alias: "Codestral" },
+		],
+		api_key_url: "https://console.mistral.ai/api-keys",
+		website_url: "https://mistral.ai",
+		provider_type: "mistral",
+	},
+	{
+		id: "xai-grok",
+		label: "xAI Grok",
+		category: "third_party",
+		base_url: "https://api.x.ai/v1",
+		api_mode: "openai_chat",
+		suggested_primary_model: "grok-4.5",
+		catalog: [
+			{ id: "grok-4.5", context_window: 256_000, alias: "Grok 4.5" },
+			{ id: "grok-4.5-fast", context_window: 256_000, alias: "Grok 4.5 Fast" },
+			{ id: "grok-4", context_window: 256_000, alias: "Grok 4" },
+		],
+		api_key_url: "https://console.x.ai/team/default/api-keys",
+		website_url: "https://x.ai",
+	},
+	{
+		id: "google-gemini-openai",
+		label: "Google Gemini (OpenAI-compatible)",
+		category: "cloud_provider",
+		base_url: "https://generativelanguage.googleapis.com/v1beta/openai",
+		api_mode: "openai_chat",
+		suggested_primary_model: "gemini-3.5-flash",
+		catalog: [
+			{ id: "gemini-3.5-flash", context_window: 1_000_000, alias: "Gemini 3.5 Flash" },
+			{ id: "gemini-3.5-pro", context_window: 1_000_000, alias: "Gemini 3.5 Pro" },
+			{ id: "gemini-2.5-pro", context_window: 1_000_000, alias: "Gemini 2.5 Pro" },
+		],
+		api_key_url: "https://aistudio.google.com/apikey",
+		website_url: "https://ai.google.dev/gemini-api",
+	},
+] as const satisfies readonly ProviderPreset[];
+
+export type ProviderPresetId = (typeof PROVIDER_PRESETS)[number]["id"];
+
+const PROVIDER_PRESET_BY_ID: ReadonlyMap<string, ProviderPreset> = new Map(
+	PROVIDER_PRESETS.map((preset) => [preset.id, preset]),
+);
+
+export function providerPresetById(id: string | null | undefined): ProviderPreset | null {
+	if (!id) return null;
+	return PROVIDER_PRESET_BY_ID.get(id) ?? null;
+}
+
+export function providerTypeForPreset(preset: ProviderPreset): ProviderTypeId {
+	return preset.provider_type ?? "custom_openai_compatible";
+}
+
+export function presetRuntimeEnvName(preset: ProviderPreset): string {
+	const name = preset.id
+		.toUpperCase()
+		.replace(/[^A-Z0-9]+/g, "_")
+		.replace(/^_+|_+$/g, "");
+	return `${name || "PROVIDER"}_API_KEY`;
+}
+
+export function presetCatalogToProviderModels(preset: ProviderPreset): ProviderCatalogModel[] {
+	return preset.catalog.map((model) => ({
+		id: model.id,
+		...(model.alias ? { label: model.alias } : {}),
+		...(model.context_window !== undefined ? { context_window: model.context_window } : {}),
+	}));
+}


### PR DESCRIPTION
## Summary
- Added a BYOK provider preset registry for the v2 add-provider dialog, with cc-switch MIT design attribution.
- Wired a grouped preset picker into the add-provider flow; selecting a preset pre-fills base URL, API mode, runtime env, model catalog, and suggested primary model while leaving only the API-key credential field visible.
- Kept first-party provider/Codex OAuth behavior unchanged and preserved Custom as the advanced-edit escape hatch.
- Extended logic tests so preset catalog metadata is preserved in the provider upsert models.

## Preset catalog
| Provider | base_url | api_mode | Primary model | verified-against |
| --- | --- | --- | --- | --- |
| DeepSeek | `https://api.deepseek.com/v1` | `openai_chat` | `deepseek-v4-flash` | Official DeepSeek API/model docs |
| Kimi / Moonshot | `https://api.moonshot.cn/v1` | `openai_chat` | `kimi-k2.7-code` | Official Moonshot/Kimi API docs; primary from reference digest |
| Qwen (DashScope) | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `openai_chat` | `qwen3.7-plus` | Official Alibaba Model Studio/DashScope OpenAI-compatible docs |
| Zhipu GLM | `https://open.bigmodel.cn/api/paas/v4` | `openai_chat` | `glm-5.2` | Official BigModel/Z.ai OpenAI-compatible docs; includes CN/global variants |
| StepFun | `https://api.stepfun.ai/v1` | `openai_chat` | `step-3.7-flash` | Official StepFun docs; includes global/CN variants |
| MiniMax | `https://api.minimax.io/v1` | `openai_chat` | `MiniMax-M3` | Official MiniMax OpenAI API docs |
| OpenRouter | `https://openrouter.ai/api/v1` | `openai_chat` | `openrouter/auto` | Official OpenRouter API docs |
| Together AI | `https://api.together.ai/v1` | `openai_chat` | `MiniMaxAI/MiniMax-M3` | Official Together AI OpenAI-compatible docs |
| Groq | `https://api.groq.com/openai/v1` | `openai_chat` | `openai/gpt-oss-120b` | Official Groq OpenAI-compatible/model docs |
| Mistral | `https://api.mistral.ai/v1` | `openai_chat` | `mistral-large-latest` | Official Mistral API/model docs |
| xAI Grok | `https://api.x.ai/v1` | `openai_chat` | `grok-4.5` | Official xAI API/model docs |
| Google Gemini (OpenAI-compatible) | `https://generativelanguage.googleapis.com/v1beta/openai` | `openai_chat` | `gemini-3.5-flash` | Official Google Gemini OpenAI compatibility/model docs |

## Notes
- Model cost metadata, cross-provider model aliases, CLI changes, and backend changes are intentionally out of scope for this part.
- Preset `alias` values are local registry display metadata and are mapped to the existing provider model `label` field for the hosted API payload.

## Verification
- `bun run check`
- `bun x turbo typecheck --filter=web`
- `bun test apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts`
