### PR TITLE
Fix wallet top-up false-success (card form never shown, nothing charged)

### DIFF
--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.test.ts
@@ -73,6 +73,11 @@ describe("handleTopupStartResult", () => {
 				flow_type: "payment_intent",
 				payment_intent_id: "pi_123",
 				client_secret: "pi_123_secret_456",
+				// The real backend response ALWAYS carries credits_added (the
+				// credits this top-up will add once paid). Regression guard: this
+				// used to be misread as "already succeeded", closing the dialog
+				// before the card form ever showed.
+				credits_added: 25_000,
 			}),
 			{
 				queryClient: qc,

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
@@ -45,7 +45,12 @@ export function handleTopupStartResult(
 	result: WalletTopupResult,
 	controls: TopupStartResultControls,
 ): void {
-	if (result.status === "succeeded" || result.credits_added != null) {
+	// Only the PaymentIntent STATUS decides success. The backend includes
+	// `credits_added` (the credits this top-up WILL add) on every response —
+	// including `requires_payment_method` — so treating its presence as success
+	// closed the dialog before the card form ever showed and the top-up never
+	// charged.
+	if (result.status === "succeeded") {
 		completeTopup("succeeded", controls);
 		return;
 	}

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import { CreditCard } from "lucide-react";
 import { useState } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
-import { Button } from "@/components/ui/button";
 import { LowBalanceBanner } from "@/hosted/billing/components/low-balance-banner";
 import { WalletSkeleton } from "@/hosted/billing/components/state-views";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
@@ -57,15 +55,9 @@ export function WalletPage() {
 
 	return (
 		<div data-hosted="true" className={WALLET_PAGE_CLASS}>
-			<PageHeader
-				title="Wallet"
-				description={DESCRIPTION}
-				actions={
-					<Button onClick={() => setTopUpOpen(true)}>
-						<CreditCard /> Top up
-					</Button>
-				}
-			/>
+			{/* The balance card below carries the primary Top up CTA; a second
+			    header button duplicated it in the same viewport. */}
+			<PageHeader title="Wallet" description={DESCRIPTION} />
 
 			<LowBalanceBanner
 				wallet={w}


### PR DESCRIPTION
## P0 — wallet top-up never charges

**Symptom (owner report):** clicked Top up, "paid", nothing happened — balance unchanged, no activity entry.

**Root cause** (`top-up-dialog.logic.ts`): `handleTopupStartResult` treated `credits_added != null` as terminal success. The backend returns `credits_added` (credits the top-up WILL add) on **every** response, including `status=requires_payment_method` (`clawdi-hosted backend/app/v2/money/topup.py:395-401`). So: Continue → PaymentIntent created → frontend instantly toasts **"Top-up complete"** and closes the dialog → the card form never renders → no confirm ever reaches Stripe → no charge, no credit.

**Prod evidence:** idempotency record `wallet_topup:payment_intent:2500 / pi_3TrR9g…` at 23:14; Stripe PI status `requires_payment_method`, no `last_payment_error`, zero confirm attempts; `v2_wallet_ledger` empty in 72h; `payment_intent.succeeded` webhooks from v1 flows process fine (webhook pipeline healthy). **No money was taken from the user.**

**Why tests missed it:** the payment-step test fixture used `credits_added: null`, which the real backend never sends. The regression test now uses the real shape.

## Fix
- Success is decided by `status === "succeeded"` only; `payment_intent + client_secret` proceeds to the card step as designed.
- Regression test with the real response shape.
- Removed the duplicate header "Top up" button (balance card keeps the primary CTA) — second owner report.

## Verification
- `bun run check` clean (0 warnings)
- `bunx turbo typecheck --filter=web` pass
- `bun test apps/web/src/hosted/billing/wallet/` — 9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)