### PR TITLE
Handle wallet top-up redirect returns

### DIFF
--- a/apps/web/src/hosted/billing/wallet/stripe-payment-form.tsx
+++ b/apps/web/src/hosted/billing/wallet/stripe-payment-form.tsx
@@ -8,6 +8,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { getStripe, resetStripeCache } from "@/hosted/billing/stripe";
+import { buildWalletTopupReturnUrl } from "@/hosted/billing/wallet/top-up-return.logic";
 import { env } from "@/lib/env";
 
 /** Terminal outcomes only — `requires_action` (3DS) is resolved inside the form. */
@@ -34,7 +35,13 @@ function InnerForm({
 		// `redirect: "if_required"` keeps card payments inline; only methods that
 		// truly need a redirect (some wallets) navigate away.
 		try {
-			const result = await stripe.confirmPayment({ elements, redirect: "if_required" });
+			const result = await stripe.confirmPayment({
+				elements,
+				redirect: "if_required",
+				confirmParams: {
+					return_url: buildWalletTopupReturnUrl(window.location.href),
+				},
+			});
 			if (result.error) {
 				setError(result.error.message ?? "We couldn't process that card. Please try again.");
 				setSubmitting(false);

--- a/apps/web/src/hosted/billing/wallet/top-up-return.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-return.logic.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildWalletTopupReturnUrl,
+	cleanWalletTopupReturnUrl,
+	readWalletTopupReturn,
+	walletTopupReturnToast,
+} from "@/hosted/billing/wallet/top-up-return.logic";
+
+describe("wallet top-up return URL helpers", () => {
+	test("builds a wallet settings return URL with the top-up marker", () => {
+		const url = buildWalletTopupReturnUrl("https://cloud.clawdi.ai/?settings=general&x=1");
+
+		expect(url).toBe("https://cloud.clawdi.ai/?settings=billing-wallet&x=1&topup_return=1");
+	});
+
+	test("reads only marked Stripe PaymentIntent returns", () => {
+		expect(
+			readWalletTopupReturn(
+				"?settings=billing-wallet&topup_return=1&payment_intent_client_secret=pi_secret",
+			),
+		).toEqual({ clientSecret: "pi_secret" });
+		expect(
+			readWalletTopupReturn("?settings=billing-wallet&payment_intent_client_secret=pi_secret"),
+		).toBe(null);
+		expect(readWalletTopupReturn("?settings=billing-wallet&topup_return=1")).toBe(null);
+	});
+
+	test("cleans Stripe return params while preserving the wallet settings section", () => {
+		const clean = cleanWalletTopupReturnUrl(
+			"https://cloud.clawdi.ai/?settings=billing-wallet&topup_return=1&payment_intent=pi_1&payment_intent_client_secret=secret&redirect_status=succeeded&keep=1",
+		);
+
+		expect(clean).toBe("https://cloud.clawdi.ai/?settings=billing-wallet&keep=1");
+	});
+});
+
+describe("walletTopupReturnToast", () => {
+	test("maps succeeded to success copy", () => {
+		expect(walletTopupReturnToast("succeeded")).toEqual({
+			kind: "success",
+			title: "Top-up complete",
+			description: "Your credits will appear in a moment.",
+		});
+	});
+
+	test("maps processing to settlement copy", () => {
+		expect(walletTopupReturnToast("processing")).toEqual({
+			kind: "info",
+			title: "Top-up processing",
+			description: "We'll credit your wallet once the payment settles.",
+		});
+	});
+
+	test("maps requires_payment_method to retry guidance", () => {
+		expect(walletTopupReturnToast("requires_payment_method")).toEqual({
+			kind: "error",
+			title: "Top-up didn't finish",
+			description: "No payment was collected. Start a new top-up and choose another method.",
+		});
+	});
+});

--- a/apps/web/src/hosted/billing/wallet/top-up-return.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-return.logic.ts
@@ -1,0 +1,71 @@
+import { SETTINGS_QUERY_KEY } from "@/lib/settings-routes";
+
+export const WALLET_TOPUP_RETURN_PARAM = "topup_return";
+export const STRIPE_PAYMENT_INTENT_PARAM = "payment_intent";
+export const STRIPE_PAYMENT_INTENT_CLIENT_SECRET_PARAM = "payment_intent_client_secret";
+export const STRIPE_REDIRECT_STATUS_PARAM = "redirect_status";
+
+export type WalletTopupReturnToastKind = "success" | "info" | "error";
+
+export interface WalletTopupReturnState {
+	clientSecret: string;
+}
+
+export interface WalletTopupReturnToast {
+	kind: WalletTopupReturnToastKind;
+	title: string;
+	description: string;
+}
+
+export function buildWalletTopupReturnUrl(currentHref: string): string {
+	const url = new URL(currentHref);
+	url.searchParams.set(SETTINGS_QUERY_KEY, "billing-wallet");
+	url.searchParams.set(WALLET_TOPUP_RETURN_PARAM, "1");
+	return url.toString();
+}
+
+export function readWalletTopupReturn(search: string): WalletTopupReturnState | null {
+	const params = new URLSearchParams(search);
+	if (params.get(WALLET_TOPUP_RETURN_PARAM) !== "1") return null;
+	const clientSecret = params.get(STRIPE_PAYMENT_INTENT_CLIENT_SECRET_PARAM);
+	if (!clientSecret) return null;
+	return { clientSecret };
+}
+
+export function cleanWalletTopupReturnUrl(currentHref: string): string {
+	const url = new URL(currentHref);
+	url.searchParams.delete(WALLET_TOPUP_RETURN_PARAM);
+	url.searchParams.delete(STRIPE_PAYMENT_INTENT_PARAM);
+	url.searchParams.delete(STRIPE_PAYMENT_INTENT_CLIENT_SECRET_PARAM);
+	url.searchParams.delete(STRIPE_REDIRECT_STATUS_PARAM);
+	return url.toString();
+}
+
+export function walletTopupReturnToast(status: string | null | undefined): WalletTopupReturnToast {
+	if (status === "succeeded") {
+		return {
+			kind: "success",
+			title: "Top-up complete",
+			description: "Your credits will appear in a moment.",
+		};
+	}
+	if (status === "processing") {
+		return {
+			kind: "info",
+			title: "Top-up processing",
+			description: "We'll credit your wallet once the payment settles.",
+		};
+	}
+	if (status === "requires_payment_method") {
+		return {
+			kind: "error",
+			title: "Top-up didn't finish",
+			description: "No payment was collected. Start a new top-up and choose another method.",
+		};
+	}
+	return {
+		kind: "info",
+		title: "Top-up status refreshed",
+		description: "We'll update your wallet when Stripe reports the final status.",
+	};
+}

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
@@ -8,12 +10,21 @@ import { LowBalanceBanner } from "@/hosted/billing/components/low-balance-banner
 import { WalletSkeleton } from "@/hosted/billing/components/state-views";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { useWallet, useWalletLedger } from "@/hosted/billing/hooks";
+import { getStripe } from "@/hosted/billing/stripe";
 import { AutoReloadCard } from "@/hosted/billing/wallet/auto-reload-card";
 import { BalanceCard } from "@/hosted/billing/wallet/balance-card";
 import { LedgerTable } from "@/hosted/billing/wallet/ledger-table";
 import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
+import { invalidateWalletActivity } from "@/hosted/billing/wallet/top-up-dialog.logic";
+import {
+	cleanWalletTopupReturnUrl,
+	readWalletTopupReturn,
+	type WalletTopupReturnToast,
+	walletTopupReturnToast,
+} from "@/hosted/billing/wallet/top-up-return.logic";
 import { LEDGER_MAX_ROWS, LEDGER_PAGE_SIZE } from "@/hosted/billing/wallet/wallet-constants";
 import { X402Card } from "@/hosted/billing/wallet/x402-card";
+import { env } from "@/lib/env";
 import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Your AI Credits balance, top-ups, and auto-reload.";
@@ -23,11 +34,75 @@ function scrollToAutoReload() {
 	document.getElementById("auto-reload")?.scrollIntoView({ behavior: "smooth", block: "center" });
 }
 
+function showWalletTopupReturnToast(result: WalletTopupReturnToast) {
+	if (result.kind === "success") {
+		toast.success(result.title, { description: result.description });
+		return;
+	}
+	if (result.kind === "error") {
+		toast.error(result.title, { description: result.description });
+		return;
+	}
+	toast.info(result.title, { description: result.description });
+}
+
 export function WalletPage() {
 	const wallet = useWallet();
+	const queryClient = useQueryClient();
 	const [ledgerLimit, setLedgerLimit] = useState(LEDGER_PAGE_SIZE);
 	const ledger = useWalletLedger(ledgerLimit);
 	const [topUpOpen, setTopUpOpen] = useState(false);
+
+	useEffect(() => {
+		const topupReturn = readWalletTopupReturn(window.location.search);
+		if (!topupReturn) return;
+		const { clientSecret } = topupReturn;
+		let cancelled = false;
+
+		async function refreshReturnedTopup() {
+			try {
+				const key = env.VITE_STRIPE_PUBLISHABLE_KEY;
+				if (!key) {
+					toast.error("Couldn't refresh top-up", {
+						description: "Stripe isn't configured in this environment.",
+					});
+					return;
+				}
+				const stripe = await getStripe(key);
+				if (!stripe) {
+					toast.error("Couldn't refresh top-up", {
+						description: "Reload the page and try again.",
+					});
+					return;
+				}
+				const result = await stripe.retrievePaymentIntent(clientSecret);
+				if (cancelled) return;
+				if (result.error) {
+					toast.error("Couldn't refresh top-up", {
+						description: result.error.message ?? "Open Wallet and try again.",
+					});
+					return;
+				}
+				showWalletTopupReturnToast(walletTopupReturnToast(result.paymentIntent?.status));
+				invalidateWalletActivity(queryClient);
+			} catch {
+				if (!cancelled) {
+					toast.error("Couldn't refresh top-up", {
+						description: "Check your connection and reload Wallet.",
+					});
+				}
+			} finally {
+				if (!cancelled) {
+					window.history.replaceState(null, "", cleanWalletTopupReturnUrl(window.location.href));
+				}
+			}
+		}
+
+		void refreshReturnedTopup();
+		return () => {
+			cancelled = true;
+		};
+	}, [queryClient]);
 
 	if (wallet.isLoading) {
 		return (


### PR DESCRIPTION
## Summary
- Pass `confirmParams.return_url` to wallet top-up `stripe.confirmPayment` while keeping `redirect: \"if_required\"`, so cards remain inline and redirect-capable methods can return to Wallet.
- Add wallet top-up return handling for Stripe-appended `payment_intent_client_secret`: retrieve the PaymentIntent, toast succeeded/processing/retry states, refresh wallet queries, and clean return params from the URL.
- Keep PaymentElement method rendering fully automatic; the frontend does not hardcode payment method lists.

## Stripe verification
- Stripe.js `confirmPayment` supports `confirmParams.return_url` and `redirect: \"if_required\"`: https://docs.stripe.com/js/payment_intents/confirm_payment
- PaymentIntents can be retrieved client-side using the `client_secret`: https://docs.stripe.com/api/payment_intents/retrieve
- This pairs with backend automatic payment methods, where redirect-capable methods may require a `return_url`: https://docs.stripe.com/api/payment_intents/create

## Verification
- `bun run check`
- `bun x turbo typecheck --filter=web`
- `bun test apps/web/src/hosted/billing/wallet/top-up-dialog.logic.test.ts apps/web/src/hosted/billing/wallet/top-up-return.logic.test.ts` (8 passed)