### PR TITLE
Pass BYOK model metadata through runtime projections

### DIFF
--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
@@ -229,6 +229,7 @@ describe("modelsFromText", () => {
 			{
 				id: "deepseek-v4-flash",
 				label: "DeepSeek V4 Flash",
+				alias: "DeepSeek V4 Flash",
 				context_window: 1_000_000,
 			},
 			{ id: "unknown-model" },

--- a/apps/web/src/hosted/v2/ai-providers/provider-presets.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-presets.ts
@@ -16,6 +16,7 @@ export interface ProviderPresetCatalogEntry {
 	id: string;
 	context_window?: number;
 	alias?: string;
+	cost?: ProviderCatalogModel["cost"];
 }
 
 export interface ProviderPresetRegionVariant {
@@ -308,6 +309,8 @@ export function presetCatalogToProviderModels(preset: ProviderPreset): ProviderC
 	return preset.catalog.map((model) => ({
 		id: model.id,
 		...(model.alias ? { label: model.alias } : {}),
+		...(model.alias ? { alias: model.alias } : {}),
 		...(model.context_window !== undefined ? { context_window: model.context_window } : {}),
+		...(model.cost ? { cost: { ...model.cost } } : {}),
 	}));
 }

--- a/apps/web/src/hosted/v2/ai-providers/provider-types.ts
+++ b/apps/web/src/hosted/v2/ai-providers/provider-types.ts
@@ -137,6 +137,7 @@ export function toProviderCatalogModels(
 	return models.map((model) => ({
 		id: model.id,
 		...(model.label ? { label: model.label } : {}),
+		...(model.alias ? { alias: model.alias } : {}),
 		...(model.api_mode ? { api_mode: model.api_mode } : {}),
 		...(model.input_modalities ? { input_modalities: [...model.input_modalities] } : {}),
 		...(model.supports_vision !== undefined ? { supports_vision: model.supports_vision } : {}),

--- a/apps/web/src/hosted/v2/ai-providers/runtime-bootstrap.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/runtime-bootstrap.test.ts
@@ -55,6 +55,25 @@ describe("AI provider runtime bootstrap", () => {
 		});
 	});
 
+	test("drops nullable model cost cache fields from the runtime catalog", () => {
+		const runtimeProvider = toRuntimeAiProvider({
+			...provider,
+			models: [
+				{
+					id: "gpt-5.1",
+					cost: { input: 5, output: 30, cache_read: null, cache_write: 0 },
+				},
+			],
+		});
+
+		expect(runtimeProvider.models).toEqual([
+			{
+				id: "gpt-5.1",
+				cost: { input: 5, output: 30, cache_write: 0 },
+			},
+		]);
+	});
+
 	test("builds a provider-pool bootstrap with the selected provider as chat default", () => {
 		const secondary: AiProvider = {
 			...provider,

--- a/apps/web/src/hosted/v2/ai-providers/runtime-bootstrap.ts
+++ b/apps/web/src/hosted/v2/ai-providers/runtime-bootstrap.ts
@@ -3,6 +3,7 @@ import type {
 	AiProvider as RuntimeAiProvider,
 	AiProviderAuth as RuntimeAiProviderAuth,
 	AiProviderModel as RuntimeAiProviderModel,
+	AiProviderModelCost as RuntimeAiProviderModelCost,
 } from "@clawdi/shared";
 import { validateAiProviderCatalog } from "@clawdi/shared";
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
@@ -86,6 +87,7 @@ function toRuntimeModels(models: AiProvider["models"]): RuntimeAiProviderModel[]
 	return models.map((model) => {
 		const runtimeModel: RuntimeAiProviderModel = { id: model.id };
 		if (model.label) runtimeModel.label = model.label;
+		if (model.alias) runtimeModel.alias = model.alias;
 		if (model.api_mode) runtimeModel.api_mode = model.api_mode;
 		if (model.input_modalities) runtimeModel.input_modalities = model.input_modalities;
 		if (model.supports_reasoning !== null && model.supports_reasoning !== undefined) {
@@ -97,10 +99,28 @@ function toRuntimeModels(models: AiProvider["models"]): RuntimeAiProviderModel[]
 		if (model.max_tokens !== null && model.max_tokens !== undefined) {
 			runtimeModel.max_tokens = model.max_tokens;
 		}
-		if (model.cost) runtimeModel.cost = model.cost;
+		const cost = toRuntimeModelCost(model.cost);
+		if (cost) runtimeModel.cost = cost;
 		if (model.capabilities) runtimeModel.capabilities = model.capabilities;
 		return runtimeModel;
 	});
+}
+
+function toRuntimeModelCost(
+	cost: NonNullable<NonNullable<AiProvider["models"]>[number]["cost"]> | null | undefined,
+): RuntimeAiProviderModelCost | undefined {
+	if (!cost) return undefined;
+	const runtimeCost: RuntimeAiProviderModelCost = {
+		input: cost.input,
+		output: cost.output,
+	};
+	if (cost.cache_read !== null && cost.cache_read !== undefined) {
+		runtimeCost.cache_read = cost.cache_read;
+	}
+	if (cost.cache_write !== null && cost.cache_write !== undefined) {
+		runtimeCost.cache_write = cost.cache_write;
+	}
+	return runtimeCost;
 }
 
 function toRuntimeAuth(auth: AiProvider["auth"]): RuntimeAiProviderAuth {

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -188,10 +188,20 @@ class AdminRuntimeStateResponse(BaseModel):
     generation: int
 
 
+class AdminManagedAiProviderModelCost(BaseModel):
+    model_config = ConfigDict(extra="ignore", hide_input_in_errors=True)
+
+    input: float = Field(ge=0)
+    output: float = Field(ge=0)
+    cache_read: float | None = Field(default=None, ge=0)
+    cache_write: float | None = Field(default=None, ge=0)
+
+
 class AdminManagedAiProviderModel(BaseModel):
     model_config = ConfigDict(extra="ignore", hide_input_in_errors=True)
 
     id: str = Field(min_length=1, max_length=300)
+    alias: str | None = Field(default=None, max_length=300)
     api_mode: AdminAiProviderApiMode | None = None
     input_modalities: list[AdminAiProviderInputModality] | None = None
     supports_vision: bool | None = None
@@ -199,6 +209,7 @@ class AdminManagedAiProviderModel(BaseModel):
     supports_reasoning: bool | None = None
     context_window: int | None = Field(default=None, ge=0)
     max_tokens: int | None = Field(default=None, ge=0)
+    cost: AdminManagedAiProviderModelCost | None = None
 
 
 class AdminManagedAiProviderUpsert(BaseModel):

--- a/backend/app/schemas/ai_provider.py
+++ b/backend/app/schemas/ai_provider.py
@@ -22,6 +22,15 @@ AuthType = Literal["secret_ref", "api_key", "oauth_profile", "agent_profile", "n
 InputModality = Literal["text", "image", "video", "audio"]
 
 
+class AiProviderModelCost(BaseModel):
+    model_config = ConfigDict(extra="ignore", hide_input_in_errors=True)
+
+    input: float = Field(ge=0)
+    output: float = Field(ge=0)
+    cache_read: float | None = Field(default=None, ge=0)
+    cache_write: float | None = Field(default=None, ge=0)
+
+
 class AiProviderAuth(BaseModel):
     model_config = ConfigDict(extra="ignore", hide_input_in_errors=True)
 
@@ -39,6 +48,7 @@ class AiProviderModel(BaseModel):
 
     id: str = Field(min_length=1, max_length=300)
     label: str | None = Field(default=None, max_length=300)
+    alias: str | None = Field(default=None, max_length=300)
     api_mode: ApiMode | None = None
     input_modalities: list[InputModality] | None = None
     supports_vision: bool | None = None
@@ -46,7 +56,7 @@ class AiProviderModel(BaseModel):
     supports_reasoning: bool | None = None
     context_window: int | None = Field(default=None, ge=0)
     max_tokens: int | None = Field(default=None, ge=0)
-    cost: dict[str, Any] | None = None
+    cost: AiProviderModelCost | None = None
     capabilities: dict[str, Any] | None = None
 
 

--- a/packages/cli/src/lib/ai-provider-projection.test.ts
+++ b/packages/cli/src/lib/ai-provider-projection.test.ts
@@ -81,4 +81,41 @@ describe("AI provider projection", () => {
 		expect(codex.files[0]?.content).toContain('model_provider = "openai"');
 		expect(codex.files[0]?.content).not.toContain('[model_providers."openai-codex"]');
 	});
+
+	test("projects model alias and cost metadata to runtime-native fields", () => {
+		const catalog: AiProviderCatalog = {
+			schema_version: 1,
+			providers: [
+				{
+					id: "custom-main",
+					type: "custom_openai_compatible",
+					base_url: "https://api.example.test/v1",
+					api_mode: "openai_chat",
+					auth: { type: "api_key", source: "env", ref: "env:CUSTOM_API_KEY" },
+					runtime_env_name: "CUSTOM_API_KEY",
+					models: [
+						{
+							id: "example-model",
+							alias: "Example Model",
+							context_window: 128_000,
+							cost: { input: 0.3, output: 1.2, cache_read: 0.06, cache_write: 0 },
+						},
+					],
+				},
+			],
+			defaults: { chat_provider_id: "custom-main" },
+		};
+
+		const openclaw = buildAgentTargetProjection("openclaw", catalog);
+		expect(openclaw.files[0]?.content).toContain('"name": "Example Model"');
+		expect(openclaw.files[0]?.content).toContain('"cost": {');
+		expect(openclaw.files[0]?.content).toContain('"cacheRead": 0.06');
+		expect(openclaw.files[0]?.content).toContain('"cacheWrite": 0');
+
+		const hermes = buildAgentTargetProjection("hermes", catalog);
+		expect(hermes.files[0]?.content).toContain("input_cost_per_million: 0.3");
+		expect(hermes.files[0]?.content).toContain("output_cost_per_million: 1.2");
+		expect(hermes.files[0]?.content).toContain("cache_read_cost_per_million: 0.06");
+		expect(hermes.files[0]?.content).toContain("cache_write_cost_per_million: 0");
+	});
 });

--- a/packages/cli/src/lib/ai-provider-projection.ts
+++ b/packages/cli/src/lib/ai-provider-projection.ts
@@ -321,7 +321,7 @@ function openClawModels(
 			const api = openClawApiLabel(model.api_mode ?? provider.api_mode);
 			return compactObject({
 				id: model.id,
-				name: model.label ?? model.id,
+				name: model.alias ?? model.label ?? model.id,
 				api,
 				input: openClawInputModalities(model),
 				reasoning: model.supports_reasoning,
@@ -329,6 +329,7 @@ function openClawModels(
 					model.supports_tools === undefined ? undefined : { supportsTools: model.supports_tools },
 				contextWindow: positiveNumber(model.context_window),
 				maxTokens: positiveNumber(model.max_tokens),
+				cost: openClawModelCost(model.cost),
 			});
 		})
 		.filter((model) => typeof model.id === "string" && model.id.length > 0)
@@ -395,6 +396,25 @@ function positiveNumber(input: number | undefined): number | undefined {
 	return typeof input === "number" && Number.isFinite(input) && input > 0 ? input : undefined;
 }
 
+function nonNegativeNumber(input: number | undefined): number | undefined {
+	return typeof input === "number" && Number.isFinite(input) && input >= 0 ? input : undefined;
+}
+
+function openClawModelCost(
+	cost: AiProviderModel["cost"] | undefined,
+): Record<string, number> | undefined {
+	if (!cost) return undefined;
+	const input = nonNegativeNumber(cost.input);
+	const output = nonNegativeNumber(cost.output);
+	if (input === undefined || output === undefined) return undefined;
+	return {
+		input,
+		output,
+		cacheRead: nonNegativeNumber(cost.cache_read) ?? 0,
+		cacheWrite: nonNegativeNumber(cost.cache_write) ?? 0,
+	};
+}
+
 function buildHermesProjection(
 	providers: ProjectionProvider[],
 	primaryProvider: ProjectionProvider,
@@ -449,38 +469,70 @@ function hermesModelLines(provider: ProjectionProvider): string[] {
 		if (model.supports_vision !== undefined) {
 			lines.push(`        supports_vision: ${model.supports_vision}`);
 		}
+		if (model.input_cost_per_million !== undefined) {
+			lines.push(`        input_cost_per_million: ${model.input_cost_per_million}`);
+		}
+		if (model.output_cost_per_million !== undefined) {
+			lines.push(`        output_cost_per_million: ${model.output_cost_per_million}`);
+		}
+		if (model.cache_read_cost_per_million !== undefined) {
+			lines.push(`        cache_read_cost_per_million: ${model.cache_read_cost_per_million}`);
+		}
+		if (model.cache_write_cost_per_million !== undefined) {
+			lines.push(`        cache_write_cost_per_million: ${model.cache_write_cost_per_million}`);
+		}
 	}
 	return lines;
 }
 
-function hermesModels(
-	provider: ProjectionProvider,
-): Array<{ id: string; context_length?: number; max_tokens?: number; supports_vision?: boolean }> {
+interface HermesProjectedModel {
+	id: string;
+	context_length?: number;
+	max_tokens?: number;
+	supports_vision?: boolean;
+	input_cost_per_million?: number;
+	output_cost_per_million?: number;
+	cache_read_cost_per_million?: number;
+	cache_write_cost_per_million?: number;
+}
+
+function hermesModels(provider: ProjectionProvider): HermesProjectedModel[] {
 	const seen = new Set<string>();
-	const entries: Array<{
-		id: string;
-		context_length?: number;
-		max_tokens?: number;
-		supports_vision?: boolean;
-	}> = [];
+	const entries: HermesProjectedModel[] = [];
 	for (const model of provider.models ?? []) {
 		if (!model.id || seen.has(model.id)) continue;
 		seen.add(model.id);
-		const entry: {
-			id: string;
-			context_length?: number;
-			max_tokens?: number;
-			supports_vision?: boolean;
-		} = { id: model.id };
+		const entry: HermesProjectedModel = { id: model.id };
 		const contextLength = positiveNumber(model.context_window);
 		if (contextLength !== undefined) entry.context_length = contextLength;
 		const maxTokens = positiveNumber(model.max_tokens);
 		if (maxTokens !== undefined) entry.max_tokens = maxTokens;
 		const supportsVision = hermesSupportsVision(model);
 		if (supportsVision !== undefined) entry.supports_vision = supportsVision;
+		const cost = hermesModelCost(model.cost);
+		if (cost) Object.assign(entry, cost);
 		if (Object.keys(entry).length > 1) entries.push(entry);
 	}
 	return entries;
+}
+
+function hermesModelCost(
+	cost: AiProviderModel["cost"] | undefined,
+): Omit<HermesProjectedModel, "id"> | undefined {
+	if (!cost) return undefined;
+	const input = nonNegativeNumber(cost.input);
+	const output = nonNegativeNumber(cost.output);
+	if (input === undefined || output === undefined) return undefined;
+	return {
+		input_cost_per_million: input,
+		output_cost_per_million: output,
+		...(nonNegativeNumber(cost.cache_read) !== undefined
+			? { cache_read_cost_per_million: nonNegativeNumber(cost.cache_read) }
+			: {}),
+		...(nonNegativeNumber(cost.cache_write) !== undefined
+			? { cache_write_cost_per_million: nonNegativeNumber(cost.cache_write) }
+			: {}),
+	};
 }
 
 function hermesSupportsVision(model: AiProviderModel): boolean | undefined {

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -476,6 +476,63 @@ describe("runtime manifest reconciliation invariants", () => {
 		]);
 	});
 
+	test("preserves hosted provider model alias and cost metadata", () => {
+		const paths = tempRuntimePaths();
+		const manifest = baseManifest(
+			paths,
+			{
+				openclaw: {
+					enabled: true,
+					run: runSettings("openclaw", ["gateway", "run"]),
+					provider_ids: ["custom"],
+					primary_model: { provider_id: "custom", model: "example-model" },
+					services: {},
+				},
+			},
+			{
+				projection: {
+					providers: {
+						custom: {
+							type: "custom_openai_compatible",
+							baseUrl: "https://api.example.test/v1",
+							apiMode: "openai_chat",
+							models: [
+								{
+									id: "example-model",
+									alias: "Example Model",
+									context_window: 128_000,
+									cost: {
+										input: 0.3,
+										output: 1.2,
+										cache_read: 0.06,
+										cache_write: 0,
+									},
+								},
+							],
+							runtimeEnvName: "CUSTOM_API_KEY",
+							apiKeySecretRef: "secret://providers/custom/api-key",
+						},
+					},
+				},
+			},
+		);
+
+		const projection = hostedAiProviderCatalog(manifest, "openclaw");
+		expect(projection?.catalog.providers[0]?.models).toEqual([
+			{
+				id: "example-model",
+				alias: "Example Model",
+				context_window: 128_000,
+				cost: {
+					input: 0.3,
+					output: 1.2,
+					cache_read: 0.06,
+					cache_write: 0,
+				},
+			},
+		]);
+	});
+
 	test("applies a managed primary model override to the hosted provider seed projection", () => {
 		const paths = tempRuntimePaths();
 		const manifest = baseManifest(

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -17,7 +17,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type {
 	AiProviderApiMode,
@@ -3385,15 +3385,27 @@ function convergeLockOwnerPath(lockDir: string): string {
 	return join(lockDir, "owner.json");
 }
 
+function writeConvergeFileAtomic(path: string, content: string, mode: number): void {
+	const tmp = join(dirname(path), `.${basename(path)}.${process.pid}.${Date.now()}.tmp`);
+	let renamed = false;
+	try {
+		writeFileSync(tmp, content, { mode });
+		renameSync(tmp, path);
+		renamed = true;
+	} finally {
+		if (!renamed) rmSync(tmp, { force: true });
+	}
+}
+
 function writeConvergeLockOwner(lockDir: string): void {
-	writeFileSync(
+	writeConvergeFileAtomic(
 		convergeLockOwnerPath(lockDir),
 		`${JSON.stringify({
 			schemaVersion: "clawdi.runtimeConvergeLockOwner.v1",
 			pid: process.pid,
 			acquiredAt: new Date().toISOString(),
 		})}\n`,
-		{ mode: 0o600 },
+		0o600,
 	);
 }
 

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -23,6 +23,7 @@ import type {
 	AiProviderApiMode,
 	AiProviderAuth,
 	AiProviderCatalog,
+	AiProviderModel,
 	AiProviderType,
 } from "@clawdi/shared";
 import { isAiProviderApiMode, isAiProviderType } from "@clawdi/shared";
@@ -2180,10 +2181,31 @@ function buildHermesHostedCompatibilityProviderModels(
 		if (contextLength !== undefined) metadata.context_length = contextLength;
 		const supportsVision = hermesHostedSupportsVision(model);
 		if (supportsVision !== undefined) metadata.supports_vision = supportsVision;
+		const cost = hermesHostedModelCost(model.cost);
+		if (cost) Object.assign(metadata, cost);
 		if (Object.keys(metadata).length === 0) continue;
 		models[modelId] = metadata;
 	}
 	return models;
+}
+
+function hermesHostedModelCost(
+	cost: AiProviderModel["cost"] | undefined,
+): Record<string, number> | undefined {
+	if (!cost) return undefined;
+	const input = nonNegativeNumber(cost.input);
+	const output = nonNegativeNumber(cost.output);
+	if (input === undefined || output === undefined) return undefined;
+	return {
+		input_cost_per_million: input,
+		output_cost_per_million: output,
+		...(nonNegativeNumber(cost.cache_read) !== undefined
+			? { cache_read_cost_per_million: nonNegativeNumber(cost.cache_read) }
+			: {}),
+		...(nonNegativeNumber(cost.cache_write) !== undefined
+			? { cache_write_cost_per_million: nonNegativeNumber(cost.cache_write) }
+			: {}),
+	};
 }
 
 function buildHermesHostedPluginModelPatch(
@@ -2250,6 +2272,10 @@ function hermesHostedSupportsVision(
 
 function positiveInteger(value: number | undefined): number | undefined {
 	return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+function nonNegativeNumber(value: number | undefined): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
 }
 
 function pythonStringLiteral(value: string): string {

--- a/packages/shared/src/ai-provider.test.ts
+++ b/packages/shared/src/ai-provider.test.ts
@@ -45,6 +45,29 @@ describe("validateAiProviderCatalog", () => {
 		);
 	});
 
+	test("accepts model alias and cost metadata", () => {
+		const result = validateAiProviderCatalog({
+			schema_version: 1,
+			providers: [
+				{
+					id: "openai-main",
+					type: "openai",
+					base_url: "https://api.openai.com/v1",
+					auth: { type: "api_key", source: "env", ref: "env:OPENAI_API_KEY" },
+					models: [
+						{
+							id: "gpt-5.5",
+							alias: "GPT-5.5",
+							cost: { input: 5, output: 30, cache_read: 0.5, cache_write: 0 },
+						},
+					],
+				},
+			],
+		});
+
+		expect(result.valid).toBe(true);
+	});
+
 	test("rejects malformed auth profile metadata", () => {
 		expect(isProviderAuthProfileId("default")).toBe(true);
 		expect(isProviderAuthProfileId("team/default")).toBe(false);

--- a/packages/shared/src/ai-provider.ts
+++ b/packages/shared/src/ai-provider.ts
@@ -39,15 +39,16 @@ export interface AiProviderCapabilities {
 }
 
 export interface AiProviderModelCost {
-	input_per_million?: number;
-	output_per_million?: number;
-	cache_read_per_million?: number;
-	cache_write_per_million?: number;
+	input: number;
+	output: number;
+	cache_read?: number;
+	cache_write?: number;
 }
 
 export interface AiProviderModel {
 	id: string;
 	label?: string;
+	alias?: string;
 	api_mode?: AiProviderApiMode;
 	input_modalities?: Array<"text" | "image" | "video" | "audio">;
 	supports_vision?: boolean;
@@ -470,6 +471,25 @@ function validateModels(prefix: string, models: unknown, errors: string[]): void
 				errors.push(`Provider ${prefix} model ${id || "<missing>"} has invalid ${field}.`);
 			}
 		}
+		if (model.alias !== undefined && typeof model.alias !== "string") {
+			errors.push(`Provider ${prefix} model ${id || "<missing>"} has invalid alias.`);
+		}
+		if (model.cost !== undefined) {
+			if (!isRecord(model.cost)) {
+				errors.push(`Provider ${prefix} model ${id || "<missing>"} has invalid cost.`);
+			} else {
+				for (const field of ["input", "output"] as const) {
+					if (!isNonNegativeNumber(model.cost[field])) {
+						errors.push(`Provider ${prefix} model ${id || "<missing>"} has invalid cost.${field}.`);
+					}
+				}
+				for (const field of ["cache_read", "cache_write"] as const) {
+					if (model.cost[field] !== undefined && !isNonNegativeNumber(model.cost[field])) {
+						errors.push(`Provider ${prefix} model ${id || "<missing>"} has invalid cost.${field}.`);
+					}
+				}
+			}
+		}
 	}
 }
 
@@ -479,6 +499,10 @@ function isLegacyOpenAiCodexModelRef(input: unknown): boolean {
 
 function isRecord(input: unknown): input is Record<string, unknown> {
 	return typeof input === "object" && input !== null && !Array.isArray(input);
+}
+
+function isNonNegativeNumber(input: unknown): input is number {
+	return typeof input === "number" && Number.isFinite(input) && input >= 0;
 }
 
 function isHttpUrl(input: string): boolean {

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -2653,6 +2653,8 @@ export interface components {
             id: string;
             /** Label */
             label?: string | null;
+            /** Alias */
+            alias?: string | null;
             /** Api Mode */
             api_mode?: ("openai_chat" | "openai_responses" | "anthropic_messages" | "google_generate_content") | null;
             /** Input Modalities */
@@ -2667,14 +2669,22 @@ export interface components {
             context_window?: number | null;
             /** Max Tokens */
             max_tokens?: number | null;
-            /** Cost */
-            cost?: {
-                [key: string]: unknown;
-            } | null;
+            cost?: components["schemas"]["AiProviderModelCost"] | null;
             /** Capabilities */
             capabilities?: {
                 [key: string]: unknown;
             } | null;
+        };
+        /** AiProviderModelCost */
+        AiProviderModelCost: {
+            /** Input */
+            input: number;
+            /** Output */
+            output: number;
+            /** Cache Read */
+            cache_read?: number | null;
+            /** Cache Write */
+            cache_write?: number | null;
         };
         /** AiProviderOAuthCompleteRequest */
         AiProviderOAuthCompleteRequest: {


### PR DESCRIPTION
## Summary
- Extends AI provider model entries with optional `alias` and `cost` metadata across web, backend schemas/OpenAPI, shared catalog validation, hosted runtime manifests, and CLI runtime projection.
- Projects metadata into runtime-native shapes while preserving existing behavior when metadata is absent.
- Hardens runtime converge writes with same-directory temp files plus `renameSync`, without changing lock handling or adding backups.

## Contract and runtime mappings
- Clawdi model metadata is additive: `alias?: string` and `cost?: { input, output, cache_read?, cache_write? }`.
- Backend storage remains JSONB passthrough for provider models, so no migration is needed.
- OpenClaw provider config accepts `models[]` entries with `id`, `name`, `cost`, `contextWindow`, and `maxTokens`: `/home/kingsley/openclaw/src/agents/sessions/model-registry.ts:915-925`.
- OpenClaw `ModelDefinitionConfig.cost` fields are `input`, `output`, `cacheRead`, and `cacheWrite`; its source documents the unit as USD / million tokens: `/home/kingsley/openclaw/src/config/types.models.ts:123-137`.
- Clawdi maps `alias -> name` and `cost.cache_read/cache_write -> cost.cacheRead/cacheWrite` for OpenClaw.
- Hermes normalizes provider `models` arrays into a per-model metadata dictionary while preserving model metadata keys other than `id`/`name`: `/home/kingsley/.hermes/hermes-agent/hermes_cli/config.py:4784-4796`.
- Hermes pricing uses `input_cost_per_million`, `output_cost_per_million`, `cache_read_cost_per_million`, and `cache_write_cost_per_million`: `/home/kingsley/.hermes/hermes-agent/agent/usage_pricing.py:76-81`.
- Hermes also recognizes pricing aliases including `input`, `output`, `input_cache_read`, and `input_cache_write`: `/home/kingsley/.hermes/hermes-agent/agent/model_metadata.py:752-757`.
- No verified Hermes per-model display alias field was found, so `alias` is not projected into Hermes config.

## Preset metadata
- Alias passthrough now applies to BYOK preset model catalogs for DeepSeek, Kimi / Moonshot, Qwen (DashScope), Zhipu GLM, StepFun, MiniMax, OpenRouter, Together AI, Groq, Mistral, xAI Grok, and Google Gemini (OpenAI-compatible).
- No preset cost values were added because current official pricing was not verified in this change.

## Verification
- `bun run check`
- `bunx turbo typecheck --filter=web --filter=@clawdi/shared --filter=clawdi`
- `bun test packages/cli` (776 passed)
- `bun test apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts apps/web/src/hosted/v2/ai-providers/model-binding.test.ts apps/web/src/hosted/v2/ai-providers/runtime-bootstrap.test.ts` (24 passed)
- `cd backend && uv run ruff check . && uv run ruff format --check . && uv run python -m compileall app scripts tests alembic && uv run python scripts/check_generated_api.py`
- Backend targeted pytest with throwaway migrated Postgres: `uv run alembic upgrade head && uv run pytest -q tests/test_ai_providers.py tests/test_runtime_manifest.py` (57 passed)