### PR TITLE
Show v2 deployment failure and delete billing notices

### DIFF
--- a/apps/web/src/hosted/agents/delete-deployment-toast.logic.test.ts
+++ b/apps/web/src/hosted/agents/delete-deployment-toast.logic.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import type { DeleteDeploymentResult } from "@/hosted/billing/contracts";
+import { deleteDeploymentToastDecision } from "./delete-deployment-toast.logic";
+
+function deleteResult(overrides: Partial<DeleteDeploymentResult> = {}): DeleteDeploymentResult {
+	return {
+		status: "deleted",
+		cvm_deleted: true,
+		subscription_cancel_failed: false,
+		subscription: null,
+		...overrides,
+	};
+}
+
+describe("deleteDeploymentToastDecision", () => {
+	test("keeps the plain success toast when no subscription is returned", () => {
+		expect(deleteDeploymentToastDecision(deleteResult())).toEqual({
+			tone: "success",
+			title: "Agent deleted",
+		});
+	});
+
+	test("explains period-end subscription cancellation", () => {
+		expect(
+			deleteDeploymentToastDecision(
+				deleteResult({
+					subscription: {
+						cancel_at_period_end: true,
+						current_period_end: "2026-08-01T00:00:00Z",
+					},
+				}),
+			),
+		).toEqual({
+			tone: "success",
+			title: "Agent deleted",
+			description: "The subscription stays active until Aug 1, 2026 and won't renew.",
+		});
+	});
+
+	test("warns when subscription cancellation failed", () => {
+		expect(
+			deleteDeploymentToastDecision(
+				deleteResult({
+					subscription_cancel_failed: true,
+				}),
+			),
+		).toEqual({
+			tone: "warning",
+			title: "Check billing settings",
+			description:
+				"The compute was deleted, but we couldn't schedule subscription cancellation. Check billing settings before the next renewal.",
+		});
+	});
+});

--- a/apps/web/src/hosted/agents/delete-deployment-toast.logic.ts
+++ b/apps/web/src/hosted/agents/delete-deployment-toast.logic.ts
@@ -1,0 +1,35 @@
+import type { DeleteDeploymentResult } from "@/hosted/billing/contracts";
+import { formatShortDate } from "@/lib/format";
+
+type DeleteDeploymentToastTone = "success" | "warning";
+
+export type DeleteDeploymentToastDecision = {
+	tone: DeleteDeploymentToastTone;
+	title: string;
+	description?: string;
+};
+
+export function deleteDeploymentToastDecision(
+	result: DeleteDeploymentResult,
+): DeleteDeploymentToastDecision {
+	if (result.subscription_cancel_failed) {
+		return {
+			tone: "warning",
+			title: "Check billing settings",
+			description:
+				"The compute was deleted, but we couldn't schedule subscription cancellation. Check billing settings before the next renewal.",
+		};
+	}
+
+	if (result.subscription?.cancel_at_period_end) {
+		const periodEnd = formatShortDate(result.subscription.current_period_end);
+		const periodText = periodEnd === "—" ? "through the current period" : `until ${periodEnd}`;
+		return {
+			tone: "success",
+			title: "Agent deleted",
+			description: `The subscription stays active ${periodText} and won't renew.`,
+		};
+	}
+
+	return { tone: "success", title: "Agent deleted" };
+}

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -3,6 +3,7 @@
 import { type QueryClient, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { toast } from "sonner";
+import { deleteDeploymentToastDecision } from "@/hosted/agents/delete-deployment-toast.logic";
 import { useBillingClient } from "@/hosted/billing/billing-client";
 import type {
 	RebindAgentAiProviderRequest,
@@ -189,9 +190,15 @@ export function useDeleteDeployment() {
 	const qc = useQueryClient();
 	return useMutation({
 		mutationFn: (id: string) => client.deleteDeployment(id),
-		onSuccess: () => {
+		onSuccess: (result) => {
 			invalidateDeploymentSnapshots(qc);
 			scheduleDeploymentSettlingRefresh(qc);
+			const decision = deleteDeploymentToastDecision(result);
+			if (decision.tone === "warning") {
+				toast.warning(decision.title, { description: decision.description });
+				return;
+			}
+			toast.success(decision.title, { description: decision.description });
 		},
 		onError: toastBillingError("Couldn't delete agent"),
 	});

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -5,6 +5,7 @@ import type { components } from "@clawdi/shared/api";
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useLocation, useRouter } from "@tanstack/react-router";
 import {
+	AlertCircle,
 	Cpu,
 	CreditCard,
 	ExternalLink,
@@ -36,6 +37,7 @@ import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SessionFeed } from "@/components/sessions/session-feed";
 import { SettingsSection } from "@/components/settings-section";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
@@ -58,6 +60,7 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { deploymentDisplayName, isCloudEnvId } from "@/hosted/agent-identity";
 import {
 	useCreateTerminalSession,
@@ -112,6 +115,10 @@ import {
 	type PaymentOutcome,
 	StripePaymentForm,
 } from "@/hosted/billing/wallet/stripe-payment-form";
+import {
+	compactDeploymentFailureReason,
+	deploymentFailureReason,
+} from "@/hosted/deployment-failure";
 import {
 	canRestart as canRestartDeployment,
 	canStart as canStartDeployment,
@@ -618,8 +625,42 @@ function OverviewProvisioningPanel({ status }: { status: DeploymentStatus }) {
 	);
 }
 
+function DeploymentFailureReasonText({ reason }: { reason: string }) {
+	const preview = compactDeploymentFailureReason(reason);
+	return (
+		<Tooltip>
+			<TooltipTrigger
+				render={<span className="mt-2 block max-w-full truncate font-mono text-xs" />}
+			>
+				{preview}
+			</TooltipTrigger>
+			<TooltipContent className="max-w-sm whitespace-normal break-words">{reason}</TooltipContent>
+		</Tooltip>
+	);
+}
+
 function OverviewFailedPanel({ deployment }: { deployment: HostedDeployment }) {
 	const status = parseDeploymentStatus(deployment.status);
+	const failureReason = deploymentFailureReason(deployment);
+	if (failureReason) {
+		return (
+			<Alert data-hosted="true" variant="destructive">
+				<AlertCircle className="size-4" />
+				<AlertTitle>Agent setup failed</AlertTitle>
+				<AlertDescription className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+					<div className="min-w-0">
+						<p>
+							Restart the compute to retry startup. Current status: {deploymentStatusLabel(status)}.
+						</p>
+						<DeploymentFailureReasonText reason={failureReason} />
+					</div>
+					<div className="shrink-0">
+						<RestartComputeAction deployment={deployment} />
+					</div>
+				</AlertDescription>
+			</Alert>
+		);
+	}
 	return (
 		<div className="rounded-xl border border-destructive-muted bg-destructive-muted p-5 text-destructive-muted-foreground">
 			<div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">

--- a/apps/web/src/hosted/billing/contracts.ts
+++ b/apps/web/src/hosted/billing/contracts.ts
@@ -15,6 +15,7 @@ export type ComputeInvoice = Schemas["V2ComputeInvoiceInfo"];
 export type ComputeInvoicesPage = Schemas["V2ComputeInvoicesResponse"];
 export type ComputeSubscriptionResumeRequest = Schemas["V2ComputeSubscriptionResumeRequest"];
 export type DeployRequest = Schemas["V2HostedDeployRequest"];
+export type DeleteDeploymentResult = Schemas["V2DeploymentDeleteResponse"];
 export type DeploymentDetailsInfo = Schemas["V2HostedDeploymentDetailsInfo"];
 export type HostedDeployment = Schemas["V2HostedDeploymentResponse"];
 export type HostedUser = Schemas["V1UserResponse"];

--- a/apps/web/src/hosted/deployment-failure.ts
+++ b/apps/web/src/hosted/deployment-failure.ts
@@ -1,0 +1,16 @@
+const DEFAULT_FAILURE_REASON_MAX_LENGTH = 96;
+
+export function deploymentFailureReason(input: { failure_reason?: string | null }): string | null {
+	const reason = input.failure_reason?.replace(/\s+/g, " ").trim();
+	return reason ? reason : null;
+}
+
+export function compactDeploymentFailureReason(
+	reason: string,
+	maxLength = DEFAULT_FAILURE_REASON_MAX_LENGTH,
+): string {
+	const compact = reason.replace(/\s+/g, " ").trim();
+	if (compact.length <= maxLength) return compact;
+	if (maxLength <= 3) return compact.slice(0, maxLength);
+	return `${compact.slice(0, maxLength - 3)}...`;
+}

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -27,9 +27,13 @@ function hostedAgentTileStatus(rawStatus: string) {
 	return getTileStatus(rawStatus);
 }
 
-function hostedRuntimeStatusView(rawStatus: string, environment: Env | null | undefined) {
+function hostedRuntimeStatusView(
+	rawStatus: string,
+	environment: Env | null | undefined,
+	failureReason?: string | null,
+) {
 	if (!getRuntimeStatusView) throw new Error("hostedRuntimeStatusView was not loaded");
-	return getRuntimeStatusView({ status: rawStatus }, environment);
+	return getRuntimeStatusView({ status: rawStatus, failure_reason: failureReason }, environment);
 }
 
 function hostedDeploymentToTiles(deployment: HostedDeployment, envs: Env[] = []) {
@@ -157,6 +161,35 @@ describe("deploymentToTiles", () => {
 			textClass: "text-warning-muted-foreground",
 		});
 	});
+
+	test("projects failed deployment reasons ahead of dunning state", () => {
+		const [tile] = hostedDeploymentToTiles(
+			deployment({
+				status: "failed",
+				failure_reason: "startup_probe_failing; restart_count=2; container failed readiness probe",
+				compute_subscription: {
+					status: "past_due",
+					payment_state: "requires_action",
+					billing_term_months: 1,
+					price_cents: 1_900,
+					currency: "usd",
+					cancel_at_period_end: false,
+					current_period_end: "2026-08-01T00:00:00Z",
+					cancel_at: null,
+					canceled_at: null,
+					latest_failed_invoice_id: "in_action_required",
+					latest_failed_invoice_hosted_url: "https://invoice.stripe.test/action",
+					next_payment_attempt_at: null,
+				},
+			}),
+		);
+
+		expect(tile?.secondaryStatus).toEqual({
+			label: "Failure: startup_probe_failing; restart_count=2; container failed readiness probe",
+			title: "startup_probe_failing; restart_count=2; container failed readiness probe",
+			textClass: "text-destructive-muted-foreground font-medium",
+		});
+	});
 });
 
 describe("hostedAgentTileStatus", () => {
@@ -233,5 +266,21 @@ describe("hostedRuntimeStatusView", () => {
 		expect(running.secondary?.label).toBe("Sync pending");
 		expect(creating.primary.label).toBe("Provisioning");
 		expect(creating.secondary).toBeNull();
+	});
+
+	test("shows failed deployment reason as secondary status", () => {
+		const view = hostedRuntimeStatusView(
+			"failed",
+			null,
+			" startup_probe_failing;   restart_count=2 ",
+		);
+
+		expect(view.primary.label).toBe("Failed");
+		expect(view.secondary).toEqual({
+			kind: "failure_reason",
+			label: "Failure: startup_probe_failing; restart_count=2",
+			tooltip: "startup_probe_failing; restart_count=2",
+			textClass: "text-destructive-muted-foreground font-medium",
+		});
 	});
 });

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -23,6 +23,10 @@ import { billingQueryRetry, isNetworkError } from "@/hosted/billing/errors";
 import { billingKeys } from "@/hosted/billing/hooks";
 import { hasExistingCloudDeployments } from "@/hosted/cloud-deployment-management";
 import {
+	compactDeploymentFailureReason,
+	deploymentFailureReason,
+} from "@/hosted/deployment-failure";
+import {
 	type DeploymentStatus,
 	type DeploymentStatusTone,
 	deploymentStatusLabel,
@@ -37,7 +41,7 @@ import { normalizeAgentEnvId, useAgentOwnership } from "@/lib/agent-ownership";
 import { agentSectionHref } from "@/lib/agent-routes";
 
 type Env = components["schemas"]["AgentResponse"];
-type DeploymentStatusInput = Pick<HostedDeployment, "status">;
+type DeploymentStatusInput = Pick<HostedDeployment, "status" | "failure_reason">;
 
 const EMPTY_ENV_IDS: ReadonlySet<string> = new Set();
 
@@ -66,7 +70,7 @@ export interface HostedRuntimeStatusView {
 		textClass: string;
 	};
 	secondary: {
-		kind: DaemonStatusVisual["kind"];
+		kind: DaemonStatusVisual["kind"] | "failure_reason";
 		label: string;
 		tooltip: string;
 		textClass: string;
@@ -83,16 +87,24 @@ export function hostedRuntimeStatusView(
 	const computeTone = deploymentStatusTone(compute);
 	const sync = env === undefined ? null : daemonStatusVisual(env, "on-clawdi");
 	const computeIsRunning = isRunningStatus(compute);
+	const failureReason = compute.kind === "failed" ? deploymentFailureReason(deployment) : null;
 	const envIsFresh = isAgentActive(env?.last_seen_at);
-	const secondary =
-		computeIsRunning && sync && sync.kind !== "live"
-			? {
-					kind: sync.kind,
-					label: sync.badgeLabel,
-					tooltip: sync.tooltip,
-					textClass: sync.textClass,
-				}
-			: null;
+	let secondary: HostedRuntimeStatusView["secondary"] = null;
+	if (failureReason) {
+		secondary = {
+			kind: "failure_reason",
+			label: `Failure: ${compactDeploymentFailureReason(failureReason)}`,
+			tooltip: failureReason,
+			textClass: COMPUTE_TEXT_TONE.destructive,
+		};
+	} else if (computeIsRunning && sync && sync.kind !== "live") {
+		secondary = {
+			kind: sync.kind,
+			label: sync.badgeLabel,
+			tooltip: sync.tooltip,
+			textClass: sync.textClass,
+		};
+	}
 
 	return {
 		compute,
@@ -241,6 +253,8 @@ export function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>
 	const contextLabel = slug !== name ? slug : null;
 	const runtimeStatus = hostedRuntimeStatusView(d, matchedEnv ?? null);
 	const dunningStatus = computeDunningTileStatus(d);
+	const failureReasonStatus =
+		runtimeStatus.secondary?.kind === "failure_reason" ? runtimeStatus.secondary : null;
 	return [
 		{
 			id: d.id,
@@ -260,15 +274,21 @@ export function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>
 				label: runtimeStatus.primary.label,
 				dotClass: runtimeStatus.primary.dotClass,
 			},
-			secondaryStatus: dunningStatus
-				? dunningStatus
-				: runtimeStatus.secondary
-					? {
-							label: runtimeStatus.secondary.label,
-							title: runtimeStatus.secondary.tooltip,
-							textClass: runtimeStatus.secondary.textClass,
-						}
-					: null,
+			secondaryStatus: failureReasonStatus
+				? {
+						label: failureReasonStatus.label,
+						title: failureReasonStatus.tooltip,
+						textClass: failureReasonStatus.textClass,
+					}
+				: dunningStatus
+					? dunningStatus
+					: runtimeStatus.secondary
+						? {
+								label: runtimeStatus.secondary.label,
+								title: runtimeStatus.secondary.tooltip,
+								textClass: runtimeStatus.secondary.textClass,
+							}
+						: null,
 			env: matchedEnv ?? null,
 		},
 	];

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -615,6 +615,19 @@ export interface components {
             status: string;
             /** Cvm Deleted */
             cvm_deleted: boolean;
+            /**
+             * Subscription Cancel Failed
+             * @default false
+             */
+            subscription_cancel_failed: boolean;
+            subscription?: components["schemas"]["V2DeploymentDeleteSubscriptionInfo"] | null;
+        };
+        /** V2DeploymentDeleteSubscriptionInfo */
+        V2DeploymentDeleteSubscriptionInfo: {
+            /** Cancel At Period End */
+            cancel_at_period_end: boolean;
+            /** Current Period End */
+            current_period_end?: string | null;
         };
         /** V2DeploymentLifecycleResponse */
         V2DeploymentLifecycleResponse: {

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -871,6 +871,8 @@ export interface components {
              * @default unknown
              */
             status: string;
+            /** Failure Reason */
+            failure_reason?: string | null;
             /** Endpoints */
             endpoints?: string[];
             /** Openclaw Control Ui Url */


### PR DESCRIPTION
## Summary
- show v2 hosted deployment `failure_reason` in the agent detail failed state and hosted agent tile status
- surface delete-deployment subscription cancellation results through success/warning toasts
- update deploy-api generated types and focused logic tests

## Verification
- `bun run check`
- `bun x turbo typecheck --filter=web --filter=@clawdi/shared`
- `bun test apps/web/src/hosted/agents/delete-deployment-toast.logic.test.ts apps/web/src/hosted/use-hosted-agent-tiles.test.ts`