### PR TITLE
Move hosted Codex projection into CLI converge

### DIFF
--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -43,6 +43,7 @@ function tempRuntimePaths(): RuntimePaths {
 	process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
 	process.env.CLAWDI_HOME = join(root, "clawdi-home");
 	process.env.CLAWDI_AUTH_TOKEN = "test-token";
+	process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
 	return getRuntimePaths({ mode: "hosted" });
 }
 

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1788,6 +1788,24 @@ interface HostedAiProviderProjectionResult {
 	revision: string | null;
 }
 
+const CODEX_MANAGED_PROVIDER_ID = "clawdi-managed";
+const CODEX_MANAGED_PROVIDER_STATE_FILE = "clawdi-managed-provider.json";
+const CODEX_MANAGED_ENV_KEY = "OPENAI_API_KEY";
+const CODEX_LEGACY_MANAGED_ENV_KEY = "CLAWDI_MANAGED_OPENAI_API_KEY";
+const CODEX_NPM_PACKAGE_SPEC = "@openai/codex@latest";
+const CODEX_MANAGED_PROVIDER_ENV_KEYS = new Set([
+	CODEX_MANAGED_ENV_KEY,
+	CODEX_LEGACY_MANAGED_ENV_KEY,
+]);
+
+interface HostedCodexManagedProvider {
+	providerId: string;
+	baseUrl: string;
+	model: string | null;
+	apiMode: string | null;
+	apiKeySecretRef: string | null;
+}
+
 type HostedAiProviderProjectionInput = {
 	catalog: AiProviderCatalog;
 	primaryModel: AgentPrimaryModel;
@@ -1900,6 +1918,218 @@ function applyHostedAiProviderProjection(
 		return { path: observation.commandPath, revision: null };
 	}
 	return { path: null, revision: null };
+}
+
+function applyHostedCodexManagedProviderProjection(
+	manifest: RuntimeManifest,
+	paths: RuntimePaths,
+	home: string,
+): HostedAiProviderProjectionResult {
+	const provider = hostedCodexManagedProvider(manifest);
+	if (!provider) return { path: null, revision: null };
+
+	const codexHome = hostedCodexHome(home);
+	makeRuntimeUserPrivateDir(codexHome);
+	const configPath = join(codexHome, "config.toml");
+	const statePath = join(codexHome, CODEX_MANAGED_PROVIDER_STATE_FILE);
+	const codexCli = ensureHostedCodexCli(paths);
+	const configContent = hostedCodexManagedConfigToml(provider);
+	const statePayload = hostedCodexManagedProviderState(provider);
+	writePrivateFileAtomic(configPath, configContent, { mode: 0o600, dirMode: 0o700 });
+	writePrivateFileAtomic(statePath, `${JSON.stringify(statePayload, null, 2)}\n`, {
+		mode: 0o600,
+		dirMode: 0o700,
+	});
+	makeRuntimeUserOwned(configPath);
+	makeRuntimeUserOwned(statePath);
+	makeRuntimeUserPrivateDir(codexHome);
+
+	return {
+		path: configPath,
+		revision: revisionHash({
+			codexManagedProviderProjection: "config.toml",
+			configContent,
+			codexCli,
+			statePayload,
+		}),
+	};
+}
+
+function hostedCodexManagedProvider(manifest: RuntimeManifest): HostedCodexManagedProvider | null {
+	const providers = recordValue(manifest.projection?.providers);
+	if (!providers) return null;
+	const entries: Array<{
+		priority: number;
+		providerId: string;
+		provider: HostedCodexManagedProvider;
+	}> = [];
+	for (const [providerId, raw] of Object.entries(providers)) {
+		const provider = recordValue(raw);
+		if (!provider) continue;
+		if (provider.managed_by === "user") continue;
+		const runtimeEnvName =
+			stringValue(provider.runtimeEnvName) ?? stringValue(provider.runtime_env_name);
+		if (!runtimeEnvName || !CODEX_MANAGED_PROVIDER_ENV_KEYS.has(runtimeEnvName)) continue;
+		const baseUrl = stringValue(provider.baseUrl) ?? stringValue(provider.base_url);
+		if (!baseUrl?.trim()) continue;
+		entries.push({
+			priority: hostedCodexManagedProviderPriority(providerId),
+			providerId,
+			provider: {
+				providerId,
+				baseUrl: baseUrl.trim(),
+				model: stringValue(provider.model),
+				apiMode: stringValue(provider.apiMode) ?? stringValue(provider.api_mode),
+				apiKeySecretRef:
+					stringValue(provider.apiKeySecretRef) ?? stringValue(provider.api_key_secret_ref),
+			},
+		});
+	}
+	if (entries.length === 0) return null;
+	entries.sort(
+		(left, right) =>
+			left.priority - right.priority || left.providerId.localeCompare(right.providerId),
+	);
+	return entries[0]?.provider ?? null;
+}
+
+function hostedCodexManagedProviderPriority(providerId: string): number {
+	if (providerId === "openclaw") return 0;
+	if (providerId === "hermes") return 1;
+	return 2;
+}
+
+function hostedCodexHome(home: string): string {
+	const configured = process.env.CODEX_HOME?.trim();
+	if (!configured) return join(home, ".codex");
+	if (configured === "~") return home;
+	if (configured.startsWith("~/")) return join(home, configured.slice(2));
+	return configured;
+}
+
+function hostedCodexManagedConfigToml(provider: HostedCodexManagedProvider): string {
+	const lines = ["# Managed by Clawdi hosted runtime. Do not put API keys in this file."];
+	const model = provider.model?.trim();
+	if (model) lines.push(`model = ${quoteTomlString(model)}`);
+	lines.push(
+		`model_provider = ${quoteTomlString(CODEX_MANAGED_PROVIDER_ID)}`,
+		"",
+		`[model_providers.${CODEX_MANAGED_PROVIDER_ID}]`,
+		'name = "Clawdi Managed OpenAI"',
+		`base_url = ${quoteTomlString(provider.baseUrl)}`,
+		'wire_api = "responses"',
+		`env_key = ${quoteTomlString(CODEX_MANAGED_ENV_KEY)}`,
+		"",
+	);
+	return lines.join("\n");
+}
+
+function hostedCodexManagedProviderState(
+	provider: HostedCodexManagedProvider,
+): Record<string, unknown> {
+	return {
+		schemaVersion: "clawdi.hostedCodexManagedProvider.v1",
+		managedBy: "clawdi hosted runtime",
+		provider: {
+			baseUrl: provider.baseUrl,
+			model: provider.model,
+			apiMode: provider.apiMode,
+			runtimeEnvName: CODEX_MANAGED_ENV_KEY,
+			apiKeySecretRef: provider.apiKeySecretRef,
+		},
+	};
+}
+
+function ensureHostedCodexCli(paths: RuntimePaths): Record<string, string> | null {
+	if (process.env.CLAWDI_CODEX_INSTALL_DISABLED === "1") return null;
+	const packageSpec = hostedCodexPackageSpec();
+	const npmPrefix = join(paths.serviceStateRoot, "codex", "npm");
+	const npmCache = join(paths.serviceStateRoot, "codex", "npm-cache");
+	const realBin = join(npmPrefix, "bin", "codex");
+	const commandPath = join(runtimeManagedBinDir(paths), "codex");
+	if (!executableExists(realBin)) {
+		installHostedCodexCli(packageSpec, npmPrefix, npmCache);
+	}
+	if (!executableExists(realBin)) {
+		throw new Error(`Codex npm install did not create ${realBin}`);
+	}
+	writeHostedCodexCommandShim(commandPath, realBin);
+	return {
+		commandPath,
+		npmCache,
+		npmPrefix,
+		packageSpec,
+		realBin,
+	};
+}
+
+function hostedCodexPackageSpec(): string {
+	const packageSpec = process.env.CLAWDI_CODEX_PACKAGE_SPEC?.trim() || CODEX_NPM_PACKAGE_SPEC;
+	if (packageSpec === "@openai/codex" || packageSpec.startsWith("@openai/codex@")) {
+		return packageSpec;
+	}
+	throw new Error("CLAWDI_CODEX_PACKAGE_SPEC must be @openai/codex or @openai/codex@...");
+}
+
+function installHostedCodexCli(packageSpec: string, npmPrefix: string, npmCache: string): void {
+	if (!commandExists("npm")) {
+		throw new Error("Codex runtime add-on install requires npm on PATH");
+	}
+	mkdirSync(npmPrefix, { recursive: true });
+	mkdirSync(npmCache, { recursive: true });
+	const result = spawnSync(
+		"npm",
+		[
+			"install",
+			"-g",
+			"--prefix",
+			npmPrefix,
+			"--cache",
+			npmCache,
+			"--ignore-scripts",
+			"--fetch-retries",
+			"2",
+			"--fetch-retry-mintimeout",
+			"1000",
+			"--fetch-retry-maxtimeout",
+			"10000",
+			"--fetch-timeout",
+			"60000",
+			"--omit=dev",
+			"--no-audit",
+			"--no-fund",
+			"--no-update-notifier",
+			packageSpec,
+		],
+		{
+			encoding: "utf8",
+			env: {
+				...process.env,
+				NO_UPDATE_NOTIFIER: "1",
+				NPM_CONFIG_UPDATE_NOTIFIER: "false",
+			},
+			timeout: Number.parseInt(process.env.CLAWDI_CODEX_INSTALL_TIMEOUT ?? "600000", 10),
+		},
+	);
+	if (result.status !== 0) {
+		throw new Error(
+			`Codex runtime add-on install failed: ${tail(result.stderr) ?? tail(result.stdout) ?? "npm failed"}`,
+		);
+	}
+}
+
+function writeHostedCodexCommandShim(commandPath: string, realBin: string): void {
+	const binDir = dirname(commandPath);
+	makeRootReadableDir(binDir);
+	writePrivateFileAtomic(commandPath, `#!/usr/bin/env sh\nexec ${shellQuote(realBin)} "$@"\n`, {
+		mode: 0o755,
+		dirMode: 0o755,
+	});
+	makeRootOwned(commandPath);
+}
+
+function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 function applyHostedHermesAiProviderProjection(
@@ -2290,6 +2520,10 @@ function pythonTupleLiteral(values: readonly string[]): string {
 }
 
 function quoteYaml(value: string): string {
+	return JSON.stringify(value);
+}
+
+function quoteTomlString(value: string): string {
 	return JSON.stringify(value);
 }
 
@@ -4624,6 +4858,20 @@ export function convergeRuntimeManifest(
 		mitmSystemdProgram?.systemCaBundle ?? null,
 		opts.managedGatewayModelListFetcher ?? fetchManagedGatewayModelList,
 	);
+	try {
+		const codexProjection = applyHostedCodexManagedProviderProjection(
+			manifest,
+			paths,
+			projectionSystemHome(manifest) ?? paths.userHome,
+		);
+		providerProjectionRevisions.codex = codexProjection.revision;
+	} catch (error) {
+		installErrors.push(
+			`runtime codex provider projection failed: ${
+				error instanceof Error ? error.message : String(error)
+			}`,
+		);
+	}
 
 	for (const [name, runtime] of Object.entries(manifest.runtimes).sort(([a], [b]) =>
 		a.localeCompare(b),

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -69,6 +69,10 @@ const ENV_KEYS = [
 	"CLAWDI_RUNTIME_TEST_HERMES_INSTALLER",
 	"CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES",
 	"CLAWDI_RUNTIME_PID1_ENVIRON_PATH",
+	"CODEX_HOME",
+	"CLAWDI_CODEX_INSTALL_DISABLED",
+	"CLAWDI_CODEX_INSTALL_TIMEOUT",
+	"CLAWDI_CODEX_PACKAGE_SPEC",
 	"CUSTOM_RUNTIME_TOKEN",
 	"CLAWDI_RUNTIME_MANIFEST_TIMEOUT_MS",
 	"CLAWDI_API_URL",
@@ -100,6 +104,7 @@ beforeEach(() => {
 	}
 	root = join(tmpdir(), `clawdi-runtime-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	mkdirSync(root, { recursive: true });
+	process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
 });
 
 afterEach(() => {
@@ -1489,6 +1494,256 @@ chmod +x "$HOME/.local/bin/hermes"
 		expect(runConfig.secretEnv).toEqual({ OPENAI_API_KEY: "provider.default.apiKey" });
 		expect(runConfig.secretFilePath).toBe(join(run, "secrets", "runtimes", "openclaw.json"));
 		expect(JSON.stringify(runConfig)).not.toContain("sk-runtime-provider");
+	});
+
+	it("writes Codex managed provider config from hosted runtime converge", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const codexHome = join(home, ".codex");
+		mkdirSync(codexHome, { recursive: true });
+		writeFileSync(join(codexHome, "config.toml"), "stale image config\n");
+		writeFileSync(join(codexHome, "clawdi-managed-provider.json"), '{"stale":true}\n');
+		chmodSync(codexHome, 0o755);
+		chmodSync(join(codexHome, "config.toml"), 0o644);
+		chmodSync(join(codexHome, "clawdi-managed-provider.json"), 0o644);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+
+		const convergence = convergeRuntimeManifest(
+			{
+				source: "remote-datasource",
+				sourcePath: "https://runtime-source.test/desired-state",
+				offline: false,
+				manifest: {
+					schemaVersion: "clawdi.runtimeDesiredState.v1",
+					deploymentId: "dep_codex_provider",
+					environmentId: "env_codex_provider",
+					instanceId: "iid_codex_provider",
+					generation: 1,
+					issuedAt: "2026-07-10T00:00:00Z",
+					workspaceRoot: join(home, "clawdi"),
+					controlPlane: { apiUrl: "https://cloud-api.test" },
+					runtimes: {
+						openclaw: { enabled: false },
+						hermes: { enabled: false },
+					},
+					projection: {
+						sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+						system: { home },
+						providers: {
+							hermes: {
+								kind: "openai-compatible",
+								baseUrl: "https://hermes-provider.example.test/v1",
+								model: "kimi/kimi-for-coding",
+								apiMode: "openai_chat",
+								managed_by: "clawdi",
+								runtimeEnvName: "CLAWDI_MANAGED_OPENAI_API_KEY",
+								apiKeySecretRef: "provider.hermes.apiKey",
+							},
+							openclaw: {
+								kind: "openai-compatible",
+								baseUrl: "https://openclaw-provider.example.test/v1",
+								model: "gpt-5.5",
+								apiMode: "openai_responses",
+								managed_by: "clawdi",
+								runtimeEnvName: "CLAWDI_MANAGED_OPENAI_API_KEY",
+								apiKeySecretRef: "provider.openclaw.apiKey",
+							},
+						},
+					},
+					mitmProfiles: { profiles: [] },
+					recovery: { cacheManifest: true, allowOfflineBoot: true },
+				},
+			},
+			getRuntimePaths(),
+		);
+
+		expect(convergence.installErrors).toEqual([]);
+		expect(statSync(codexHome).mode & 0o777).toBe(0o700);
+		const configPath = join(codexHome, "config.toml");
+		expect(statSync(configPath).mode & 0o777).toBe(0o600);
+		expect(readFileSync(configPath, "utf-8")).toBe(
+			[
+				"# Managed by Clawdi hosted runtime. Do not put API keys in this file.",
+				'model = "gpt-5.5"',
+				'model_provider = "clawdi-managed"',
+				"",
+				"[model_providers.clawdi-managed]",
+				'name = "Clawdi Managed OpenAI"',
+				'base_url = "https://openclaw-provider.example.test/v1"',
+				'wire_api = "responses"',
+				'env_key = "OPENAI_API_KEY"',
+				"",
+			].join("\n"),
+		);
+		const statePath = join(codexHome, "clawdi-managed-provider.json");
+		expect(statSync(statePath).mode & 0o777).toBe(0o600);
+		expect(JSON.parse(readFileSync(statePath, "utf-8"))).toEqual({
+			schemaVersion: "clawdi.hostedCodexManagedProvider.v1",
+			managedBy: "clawdi hosted runtime",
+			provider: {
+				baseUrl: "https://openclaw-provider.example.test/v1",
+				model: "gpt-5.5",
+				apiMode: "openai_responses",
+				runtimeEnvName: "OPENAI_API_KEY",
+				apiKeySecretRef: "provider.openclaw.apiKey",
+			},
+		});
+	});
+
+	it("installs the Codex runtime add-on through npm when managed config is projected", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const binDir = join(root, "fake-bin");
+		const npmArgsPath = join(root, "npm-args.txt");
+		const previousPath = process.env.PATH;
+		mkdirSync(binDir, { recursive: true });
+		writeFileSync(
+			join(binDir, "npm"),
+			[
+				"#!/usr/bin/env bash",
+				"set -euo pipefail",
+				`printf '%s\\n' "$@" > '${npmArgsPath}'`,
+				"prefix=''",
+				'while [ "$#" -gt 0 ]; do',
+				'  case "$1" in',
+				"    --prefix)",
+				'      prefix="$2"',
+				"      shift 2",
+				"      ;;",
+				"    *)",
+				"      shift",
+				"      ;;",
+				"  esac",
+				"done",
+				'mkdir -p "$prefix/bin"',
+				"cat > \"$prefix/bin/codex\" <<'SH'",
+				"#!/usr/bin/env sh",
+				"echo fake codex",
+				"SH",
+				'chmod 755 "$prefix/bin/codex"',
+				"",
+			].join("\n"),
+		);
+		chmodSync(join(binDir, "npm"), 0o755);
+		delete process.env.CLAWDI_CODEX_INSTALL_DISABLED;
+		process.env.CLAWDI_CODEX_PACKAGE_SPEC = "@openai/codex@latest";
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.PATH = [binDir, previousPath].filter(Boolean).join(":");
+
+		try {
+			const convergence = convergeRuntimeManifest(
+				{
+					source: "remote-datasource",
+					sourcePath: "https://runtime-source.test/desired-state",
+					offline: false,
+					manifest: {
+						schemaVersion: "clawdi.runtimeDesiredState.v1",
+						deploymentId: "dep_codex_addon",
+						environmentId: "env_codex_addon",
+						instanceId: "iid_codex_addon",
+						generation: 1,
+						issuedAt: "2026-07-10T00:00:00Z",
+						workspaceRoot: join(home, "clawdi"),
+						controlPlane: { apiUrl: "https://cloud-api.test" },
+						runtimes: {
+							openclaw: { enabled: false },
+						},
+						projection: {
+							system: { home },
+							providers: {
+								default: {
+									kind: "openai-compatible",
+									baseUrl: "https://managed-provider.example.test/v1",
+									model: "gpt-5.5",
+									apiMode: "openai_responses",
+									managed_by: "clawdi",
+									runtimeEnvName: "CLAWDI_MANAGED_OPENAI_API_KEY",
+									apiKeySecretRef: "provider.default.apiKey",
+								},
+							},
+						},
+						mitmProfiles: { profiles: [] },
+						recovery: { cacheManifest: true, allowOfflineBoot: true },
+					},
+				},
+				getRuntimePaths(),
+			);
+
+			expect(convergence.installErrors).toEqual([]);
+		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+			process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
+		}
+
+		const npmArgs = readFileSync(npmArgsPath, "utf-8");
+		expect(npmArgs).toContain("@openai/codex@latest");
+		expect(npmArgs).toContain(`${join(state, "codex", "npm")}\n`);
+		const realBin = join(state, "codex", "npm", "bin", "codex");
+		const commandShim = join(state, "bin", "codex");
+		expect(statSync(realBin).mode & 0o777).toBe(0o755);
+		expect(statSync(commandShim).mode & 0o777).toBe(0o755);
+		expect(readFileSync(commandShim, "utf-8")).toBe(`#!/usr/bin/env sh\nexec '${realBin}' "$@"\n`);
+	});
+
+	it("does not write Codex managed provider config for user-owned providers", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+
+		const convergence = convergeRuntimeManifest(
+			{
+				source: "remote-datasource",
+				sourcePath: "https://runtime-source.test/desired-state",
+				offline: false,
+				manifest: {
+					schemaVersion: "clawdi.runtimeDesiredState.v1",
+					deploymentId: "dep_codex_byok_provider",
+					environmentId: "env_codex_byok_provider",
+					instanceId: "iid_codex_byok_provider",
+					generation: 1,
+					issuedAt: "2026-07-10T00:00:00Z",
+					workspaceRoot: join(home, "clawdi"),
+					controlPlane: { apiUrl: "https://cloud-api.test" },
+					runtimes: {
+						openclaw: { enabled: false },
+					},
+					projection: {
+						system: { home },
+						providers: {
+							default: {
+								kind: "openai-compatible",
+								baseUrl: "https://byok-provider.example.test/v1",
+								model: "gpt-5.5",
+								apiMode: "openai_responses",
+								managed_by: "user",
+								runtimeEnvName: "OPENAI_API_KEY",
+								apiKeySecretRef: "provider.byok.apiKey",
+							},
+						},
+					},
+					mitmProfiles: { profiles: [] },
+					recovery: { cacheManifest: true, allowOfflineBoot: true },
+				},
+			},
+			getRuntimePaths(),
+		);
+
+		expect(convergence.installErrors).toEqual([]);
+		expect(existsSync(join(home, ".codex", "config.toml"))).toBe(false);
+		expect(existsSync(join(home, ".codex", "clawdi-managed-provider.json"))).toBe(false);
 	});
 
 	it("preserves Clawdi-managed provider ownership when projecting hosted providers", () => {


### PR DESCRIPTION
## Summary
- Move hosted Codex managed-provider config projection into CLI runtime converge.
- Write the managed Codex files with the old image-script semantics and permissions: `$CODEX_HOME/config.toml` or `$HOME/.codex/config.toml`, plus `clawdi-managed-provider.json`; `.codex` is `0700` and files are `0600`.
- Install the hosted Codex runtime add-on from the CLI at converge time into `/var/lib/clawdi/codex/npm`, with `/var/lib/clawdi/bin/codex` as the managed shim.
- Keep old-image coexistence safe: converge overwrites stale image-script output, and user-owned providers do not trigger managed Codex projection.

## Rollout Order
1. Merge this CLI PR.
2. Publish a new `clawdi@beta` containing this change.
3. Only after that beta is live, merge the companion hosted image cleanup PR: https://github.com/Clawdi-AI/clawdi-hosted/pull/755.

The hosted image cleanup depends on this PR because it removes the image-local Codex wrapper/config script and expects `clawdi@beta` to own all product behavior. Do not merge the hosted image cleanup before this PR has shipped via `clawdi@beta`.

## Verification
- `bun run check`
- `bunx turbo typecheck`
- `bun test packages/cli/tests/runtime.test.ts`
- `bun test packages/cli/src/runtime/manifest-reconciliation.test.ts`
- `bun test packages/cli`
