### PR TITLE
Release clawdi 0.12.10-beta.39

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.38",
+	"version": "0.12.10-beta.39",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Version bump → publishes to the `beta` dist-tag via cli-publish.yml.

Contains #360 (Codex managed-config projection in CLI converge + runtime codex add-on installer). Publishing this unblocks hosted #755 (image drops codex-managed script, baked @openai/codex, pinned bootstrap spec — zero-bake image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)