### PR TITLE
Polish wallet x402 gating and runtime manifest ETags

### DIFF
--- a/apps/web/src/hosted/billing/components/low-balance-banner.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/low-balance-banner.logic.test.ts
@@ -7,6 +7,7 @@ function wallet(over: Partial<WalletState> = {}): WalletState {
 		balance_credits: 50_000,
 		balance_snapshot_at: null,
 		payment_mode: "card",
+		x402_enabled: true,
 		auto_reload_enabled: false,
 		auto_reload_threshold_credits: 1000,
 		auto_reload_amount_cents: 2500,

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/hosted/billing/wallet/top-up-return.logic";
 import { LEDGER_MAX_ROWS, LEDGER_PAGE_SIZE } from "@/hosted/billing/wallet/wallet-constants";
 import { X402Card } from "@/hosted/billing/wallet/x402-card";
+import { shouldShowX402Card } from "@/hosted/billing/wallet/x402-card.logic";
 import { env } from "@/lib/env";
 import { cn } from "@/lib/utils";
 
@@ -144,7 +145,7 @@ export function WalletPage() {
 
 			<div id="auto-reload" className="grid gap-4 lg:grid-cols-2">
 				<AutoReloadCard wallet={w} onTopUp={() => setTopUpOpen(true)} />
-				<X402Card />
+				{shouldShowX402Card(w) ? <X402Card /> : null}
 			</div>
 
 			{ledger.error && !ledger.data ? (

--- a/apps/web/src/hosted/billing/wallet/x402-card.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/x402-card.logic.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { shouldShowX402Card } from "@/hosted/billing/wallet/x402-card.logic";
+
+describe("shouldShowX402Card", () => {
+	test("hides x402 while the wallet snapshot says the backend routes are disabled", () => {
+		expect(shouldShowX402Card({ x402_enabled: false })).toBe(false);
+		expect(shouldShowX402Card(undefined)).toBe(false);
+	});
+
+	test("shows x402 when the wallet snapshot says the backend routes are enabled", () => {
+		expect(shouldShowX402Card({ x402_enabled: true })).toBe(true);
+	});
+});

--- a/apps/web/src/hosted/billing/wallet/x402-card.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/x402-card.logic.ts
@@ -1,0 +1,5 @@
+import type { WalletState } from "@/hosted/billing/contracts";
+
+export function shouldShowX402Card(wallet: Pick<WalletState, "x402_enabled"> | undefined): boolean {
+	return wallet?.x402_enabled === true;
+}

--- a/apps/web/src/hosted/billing/wallet/x402-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/x402-card.tsx
@@ -11,6 +11,7 @@ import { useHostedUser } from "@/hosted/billing/hooks";
 /**
  * x402 self-funding block. Agents can top up their own wallet on-chain via the
  * x402 protocol; this surfaces the deposit address and a short explainer.
+ * WalletPage mounts this only when the wallet snapshot reports x402 enabled.
  */
 export function X402Card() {
 	const me = useHostedUser();

--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -129,8 +129,13 @@ async def get_runtime_manifest(
     if state.tools:
         manifest["tools"] = state.tools
     payload = {"manifest": manifest, "secretValues": secret_values}
+    # Include generation in the ETag. The hosted CLI does not treat generation
+    # as a no-op bookkeeping field: runtime watch applies any non-304 manifest,
+    # writes generation into managed state/run-config outputs, and caches it as
+    # last-good. A generation-only control-plane bump must therefore wake the
+    # watcher immediately instead of waiting for the self-heal refetch path.
     etag_payload = {
-        "manifest": {key: value for key, value in manifest.items() if key != "generation"},
+        "manifest": manifest,
         "secretValues": secret_values,
     }
     etag = strong_json_etag(etag_payload)

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -412,7 +412,7 @@ async def test_admin_delete_runtime_state_requires_admin_key(
 
 
 @pytest.mark.asyncio
-async def test_runtime_manifest_generation_reset_keeps_etag_but_returns_generation(
+async def test_runtime_manifest_generation_reset_changes_etag_and_returns_generation(
     admin_client,
     db_session,
     seed_user,
@@ -449,11 +449,11 @@ async def test_runtime_manifest_generation_reset_keeps_etag_but_returns_generati
     app.dependency_overrides.clear()
 
     assert reset.status_code == 200, reset.text
-    assert reset.headers["etag"] == etag
+    assert reset.headers["etag"] != etag
     assert reset.json()["manifest"]["generation"] == 6
-    assert not_modified.status_code == 304
-    assert not_modified.headers["etag"] == etag
-    assert not_modified.content == b""
+    assert not_modified.status_code == 200, not_modified.text
+    assert not_modified.headers["etag"] == reset.headers["etag"]
+    assert not_modified.json()["manifest"]["generation"] == 6
 
 
 @pytest.mark.asyncio

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -277,6 +277,12 @@ Normalization maps hosted fields into the internal shape:
 | `mitmProfiles` | Explicit local sidecar profiles |
 | `recovery` | Manifest cache and offline-boot behavior |
 
+Manifest `generation` is part of the remote manifest ETag. The CLI applies any
+non-304 manifest without monotonic generation gating, writes `generation` into
+managed state, sync state, MITM bundles, run configs, and projections, then
+caches the fetched manifest as last-good. A generation-only control-plane bump
+therefore must produce a new ETag so `runtime watch` converges immediately.
+
 Manifest validation is defensive. Enabled built-in runtimes must use the
 expected official installer metadata unless they provide an explicit run
 command. Unknown runtime names require `run.command`; otherwise the manifest is

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -888,6 +888,8 @@ export interface components {
             failure_reason?: string | null;
             /** Endpoints */
             endpoints?: string[];
+            /** Native Url */
+            native_url?: string | null;
             /** Openclaw Control Ui Url */
             openclaw_control_ui_url?: string | null;
             /** Hermes Control Ui Url */
@@ -1089,6 +1091,8 @@ export interface components {
              * @constant
              */
             payment_mode: "card";
+            /** X402 Enabled */
+            x402_enabled: boolean;
             /** Auto Reload Enabled */
             auto_reload_enabled: boolean;
             /** Auto Reload Threshold Credits */


### PR DESCRIPTION
## Summary

- Item 1: gate the wallet x402 card on the wallet snapshot `x402_enabled` flag and regenerate deploy API types from the hosted OpenAPI spec.
- Item 3: include runtime manifest `generation` in the cloud manifest ETag so generation-only changes wake `runtime watch` immediately.
- Add docs explaining that the CLI applies any non-304 manifest without monotonic generation gating and writes `generation` into managed outputs and last-good cache.

## Verification

- `bun test apps/web/src/hosted/billing/wallet/x402-card.logic.test.ts apps/web/src/hosted/billing/components/low-balance-banner.logic.test.ts`
- `bun run check`
- `bun run typecheck`
- `uv run ruff check app/routes/runtime.py tests/test_runtime_manifest.py`
- `git diff --check`

## Verification gap

- `uv run pytest tests/test_runtime_manifest.py::test_runtime_manifest_generation_reset_changes_etag_and_returns_generation` did not reach assertions because this checkout's backend test fixture requires a real Postgres `DATABASE_URL`, and the configured local port refused connections.
