### PR TITLE
Harden hosted CLI self-upgrade

### DIFF
--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -19,11 +19,18 @@ import { z } from "zod";
 import { ApiClient, unwrap } from "../lib/api-client";
 import { getConfig } from "../lib/config";
 import { PRIVATE_DIR_MODE, writePrivateFileAtomic } from "../lib/private-file";
+import { isSemverLessThan } from "../lib/semver";
 import { getCliVersion } from "../lib/version";
 import { ensureRuntimeAuthTokenFile, runtimeAuthTokenFileLabel } from "../runtime/auth-token";
 import { RUNTIME_BRIDGE_SURFACES_ENV, startRuntimeBridge } from "../runtime/bridge";
 import { applyRuntimeChannelsToManifestLoad } from "../runtime/channels";
-import { applyRuntimeCliDesiredState, type RuntimeCliUpdateResult } from "../runtime/cli-update";
+import {
+	applyRuntimeCliDesiredState,
+	completePendingRuntimeCliUpgrade,
+	type RuntimeCliRollbackResult,
+	type RuntimeCliUpdateResult,
+	rollbackPendingRuntimeCliUpgrade,
+} from "../runtime/cli-update";
 import { readHostPolicy } from "../runtime/host-policy";
 import {
 	cacheRuntimeLastGoodManifest,
@@ -31,6 +38,7 @@ import {
 	loadRuntimeManifest,
 	withRuntimeConvergeLock,
 } from "../runtime/manifest";
+import { manifestSchema as runtimeDesiredStateSchema } from "../runtime/manifest-contract";
 import {
 	loadRemoteRuntimeChannels,
 	loadRemoteRuntimeManifest,
@@ -1164,6 +1172,10 @@ interface RuntimeWatchOptions {
 	json?: boolean;
 }
 
+interface RuntimeVerifyOptions {
+	json?: boolean;
+}
+
 interface RuntimeDoctorCheck {
 	name: string;
 	ok: boolean;
@@ -1171,15 +1183,39 @@ interface RuntimeDoctorCheck {
 	hint?: string;
 }
 
-interface RuntimeApplyResult {
+interface MinimumCliVersionGate {
+	minimumCliVersion: string;
+	currentCliVersion: string;
+	rejectedGeneration: number;
+	activeGeneration: number | null;
+	error: string;
+}
+
+type RuntimeApplyResult = RuntimeApplyConvergedResult | RuntimeApplyGatedResult;
+
+interface RuntimeApplyConvergedResult {
+	kind: "converged";
 	convergence: ReturnType<typeof convergeRuntimeManifest>;
 	cliUpdate: RuntimeCliUpdateResult;
+}
+
+interface RuntimeApplyGatedResult {
+	kind: "minimum_cli_version_gated";
+	cliUpdate: RuntimeCliUpdateResult;
+	gate: MinimumCliVersionGate;
 }
 
 interface RuntimeApplyOptions {
 	continueOnCliUpdateError?: boolean;
 	deferCliInstall?: boolean;
 	deferCliInstallReason?: string;
+	manifestIdentity?: RuntimeManifestIdentity;
+}
+
+interface RuntimeManifestIdentity {
+	generation?: number | null;
+	etag?: string | null;
+	previouslyApplied?: boolean;
 }
 
 function hasRuntimeCredential(input: {
@@ -1495,6 +1531,44 @@ function repairStatus(
 	);
 }
 
+export async function runtimeVerify(opts: RuntimeVerifyOptions = {}) {
+	const paths = getRuntimePaths();
+	const manifestCacheExists = existsSync(paths.manifestLastGood);
+	const errors: string[] = [];
+	if (manifestCacheExists) {
+		try {
+			const raw = JSON.parse(readFileSync(paths.manifestLastGood, "utf-8")) as unknown;
+			const parsed = runtimeDesiredStateSchema.safeParse(raw);
+			if (!parsed.success) {
+				errors.push(`cached manifest parse failed: ${z.prettifyError(parsed.error)}`);
+			}
+		} catch (error) {
+			errors.push(
+				`cached manifest parse failed: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	}
+	const result = {
+		schemaVersion: "clawdi.runtimeVerify.v1",
+		status: errors.length === 0 ? "ok" : "error",
+		cliVersion: getCliVersion(),
+		manifestCache: {
+			path: paths.manifestLastGood,
+			exists: manifestCacheExists,
+			valid: errors.length === 0,
+		},
+		errors,
+	};
+	if (opts.json || !process.stdout.isTTY) {
+		console.log(JSON.stringify(result, null, 2));
+	} else if (errors.length === 0) {
+		console.log(chalk.green("runtime verify ok"));
+	} else {
+		console.log(chalk.red(errors[0]));
+	}
+	if (errors.length > 0) process.exitCode = 1;
+}
+
 export async function runtimeInit(opts: RuntimeInitOptions = {}) {
 	const paths = getRuntimePaths();
 	const mode = detectRuntimeMode();
@@ -1675,7 +1749,12 @@ export async function runtimeInit(opts: RuntimeInitOptions = {}) {
 		const previousSystemdUnits = readSystemdUnitSnapshot(paths);
 		try {
 			applyResult = withRuntimeConvergeLock(paths, () =>
-				applyRuntimeDesiredState(convergenceLoad, paths),
+				applyRuntimeDesiredState(convergenceLoad, paths, {
+					manifestIdentity: {
+						generation: convergenceLoad.manifest.generation,
+						etag: loaded.etag ?? null,
+					},
+				}),
 			);
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
@@ -1711,6 +1790,48 @@ export async function runtimeInit(opts: RuntimeInitOptions = {}) {
 				console.log(chalk.gray(`  status: ${paths.bootStatus}`));
 			}
 			process.exitCode = 23;
+			return;
+		}
+		if (applyResult.kind === "minimum_cli_version_gated") {
+			const status = buildRuntimeBootStatus(
+				{
+					mode: "repair",
+					status: "error",
+					stage: "config",
+					bootId,
+					runtimeMode: mode,
+					activeGeneration: applyResult.gate.activeGeneration,
+					rejectedGeneration: applyResult.gate.rejectedGeneration,
+					instanceId: convergenceLoad.manifest.instanceId,
+					enabledRuntimes: [],
+					error: applyResult.gate.error,
+					errors: [applyResult.gate.error],
+					exitCode: 24,
+					datasource: "RuntimeSource",
+					hostPolicy: hostPolicySummary(hostPolicy),
+					manifestSource: {
+						type: convergenceLoad.source,
+						path: convergenceLoad.sourcePath,
+						offline: convergenceLoad.offline,
+					},
+				},
+				paths,
+			);
+			writeRuntimeBootStatus(status, paths);
+			if (opts.json || !process.stdout.isTTY) {
+				console.log(
+					JSON.stringify(
+						{ ...status, cliUpdate: applyResult.cliUpdate, gate: applyResult.gate },
+						null,
+						2,
+					),
+				);
+			} else {
+				console.log(chalk.bold("clawdi runtime init"));
+				console.log(chalk.yellow(`  repair: ${applyResult.gate.error}`));
+				console.log(chalk.gray(`  status: ${paths.bootStatus}`));
+			}
+			process.exitCode = 24;
 			return;
 		}
 		const { convergence } = applyResult;
@@ -1853,13 +1974,41 @@ async function runtimeWatchTick(
 	try {
 		const previousSystemdUnits = readSystemdUnitSnapshot(paths);
 		const loaded = await runtimeWatchLoadForApply(paths, manifestLoad, channelsLoad);
-		const { convergence, cliUpdate } = withRuntimeConvergeLock(paths, () =>
+		const manifestIdentity = runtimeManifestIdentityForWatch(
+			manifestLoad,
+			manifestEtag,
+			loaded.manifest.generation,
+			paths,
+		);
+		const applyResult = withRuntimeConvergeLock(paths, () =>
 			applyRuntimeDesiredState(loaded, paths, {
 				continueOnCliUpdateError: true,
 				deferCliInstall: opts.deferCliInstall,
 				deferCliInstallReason: opts.deferCliInstallReason,
+				manifestIdentity,
 			}),
 		);
+		if (applyResult.kind === "minimum_cli_version_gated") {
+			const cliUpdateError =
+				applyResult.cliUpdate.status === "error"
+					? (applyResult.cliUpdate.error ?? "CLI update failed")
+					: null;
+			const errors = [...(cliUpdateError ? [cliUpdateError] : []), applyResult.gate.error];
+			return {
+				schemaVersion: "clawdi.runtimeWatchEvent.v1",
+				status: "error",
+				stage: cliUpdateError ? "cli-update" : "config",
+				mode: "minimum_cli_version_gated",
+				errors,
+				error: errors[0],
+				activeGeneration: applyResult.gate.activeGeneration,
+				rejectedGeneration: applyResult.gate.rejectedGeneration,
+				cliUpdate: applyResult.cliUpdate,
+				selfReexec: shouldSelfReexecForCliUpdate(applyResult.cliUpdate),
+				gate: applyResult.gate,
+			};
+		}
+		const { convergence, cliUpdate } = applyResult;
 		const cliUpdateError =
 			cliUpdate.status === "error" ? (cliUpdate.error ?? "CLI update failed") : null;
 		let systemdApplyResult = {
@@ -1887,7 +2036,7 @@ async function runtimeWatchTick(
 			...convergence.installErrors,
 			...(systemdApplyError ? [systemdApplyError] : []),
 		];
-		const selfReexec = shouldSelfReexecForCliUpdate(cliUpdate);
+		let selfReexec = shouldSelfReexecForCliUpdate(cliUpdate);
 		const systemdUnitsChanged =
 			systemdApplyResult.systemUnitsChanged.length > 0 ||
 			systemdApplyResult.userUnitsChanged.length > 0;
@@ -1901,6 +2050,8 @@ async function runtimeWatchTick(
 					writeRuntimeChannelsEtag(paths, channelsLoad.etag);
 				}
 			}
+			const cliRollback = maybeRollbackFailedCliUpgrade(paths, manifestIdentity, errors);
+			if (cliRollback.status === "rolled_back") selfReexec = false;
 			return {
 				schemaVersion: "clawdi.runtimeWatchEvent.v1",
 				status: "error",
@@ -1909,6 +2060,7 @@ async function runtimeWatchTick(
 				error: errors[0],
 				activeGeneration: convergence.manifest.generation,
 				cliUpdate,
+				cliRollback,
 				selfReexec,
 				systemdUnitsChanged,
 				systemdApply: systemdApplyResult,
@@ -1922,6 +2074,7 @@ async function runtimeWatchTick(
 		if (!("notModified" in channelsLoad)) {
 			writeRuntimeChannelsEtag(paths, channelsLoad.etag);
 		}
+		completePendingRuntimeCliUpgrade(paths, getCliVersion(), manifestIdentity);
 		return {
 			schemaVersion: "clawdi.runtimeWatchEvent.v1",
 			status: "applied",
@@ -1965,13 +2118,46 @@ function applyRuntimeDesiredState(
 		cliUpdate = applyRuntimeCliDesiredState(load.manifest, paths, {
 			deferInstall: opts.deferCliInstall,
 			deferReason: opts.deferCliInstallReason,
+			manifestIdentity: opts.manifestIdentity,
 		});
 	} catch (error) {
 		if (!opts.continueOnCliUpdateError) throw error;
 		cliUpdate = runtimeCliUpdateError(load.manifest, paths, error);
 	}
+	const gate = minimumCliVersionGate(load.manifest, paths);
+	if (gate) {
+		return { kind: "minimum_cli_version_gated", cliUpdate, gate };
+	}
 	const convergence = convergeRuntimeManifest(load, paths, { cacheLastGood: false });
-	return { cliUpdate, convergence };
+	return { kind: "converged", cliUpdate, convergence };
+}
+
+function minimumCliVersionGate(
+	manifest: RuntimeManifestLoad["manifest"],
+	paths: RuntimePaths,
+): MinimumCliVersionGate | null {
+	const minimumCliVersion = manifest.minimumCliVersion?.trim();
+	if (!minimumCliVersion) return null;
+	const currentCliVersion = getCliVersion();
+	if (!isSemverLessThan(currentCliVersion, minimumCliVersion)) return null;
+	return {
+		minimumCliVersion,
+		currentCliVersion,
+		rejectedGeneration: manifest.generation,
+		activeGeneration: readLastGoodManifestGeneration(paths),
+		error: `runtime desired state requires clawdi CLI >= ${minimumCliVersion}; current CLI is ${currentCliVersion}. Keeping last-good applied state while CLI self-upgrade runs.`,
+	};
+}
+
+function readLastGoodManifestGeneration(paths: RuntimePaths): number | null {
+	try {
+		const parsed = JSON.parse(readFileSync(paths.manifestLastGood, "utf-8")) as unknown;
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+		const generation = (parsed as Record<string, unknown>).generation;
+		return typeof generation === "number" && Number.isInteger(generation) ? generation : null;
+	} catch {
+		return null;
+	}
 }
 
 function runtimeCliUpdateError(
@@ -1997,6 +2183,46 @@ function shouldSelfReexecForCliUpdate(cliUpdate: RuntimeCliUpdateResult): boolea
 	if (cliUpdate.status === "installed") return true;
 	if (!cliUpdate.version || !cliUpdate.activeTarget) return false;
 	return cliUpdate.version !== getCliVersion();
+}
+
+function runtimeManifestIdentityForWatch(
+	manifestLoad: RuntimeManifestLoad | RuntimeManifestNotModified,
+	existingEtag: string | undefined,
+	generation: number,
+	paths: RuntimePaths,
+): RuntimeManifestIdentity {
+	const etag =
+		"notModified" in manifestLoad
+			? (manifestLoad.etag ?? existingEtag ?? null)
+			: (manifestLoad.etag ?? null);
+	const lastGoodGeneration = readLastGoodManifestGeneration(paths);
+	return {
+		generation,
+		etag,
+		previouslyApplied:
+			(existingEtag !== undefined && etag === existingEtag) ||
+			(existingEtag === undefined && lastGoodGeneration === generation),
+	};
+}
+
+function maybeRollbackFailedCliUpgrade(
+	paths: RuntimePaths,
+	manifestIdentity: RuntimeManifestIdentity,
+	errors: string[],
+): RuntimeCliRollbackResult {
+	const rollback = rollbackPendingRuntimeCliUpgrade(
+		paths,
+		`first converge after CLI upgrade failed: ${errors[0] ?? "unknown error"}`,
+		manifestIdentity,
+	);
+	if (rollback.status === "rolled_back") {
+		errors.push(
+			`rolled back clawdi CLI ${rollback.version} to previous version ${rollback.previousVersion ?? "unknown"}`,
+		);
+	} else if (rollback.status === "error") {
+		errors.push(`failed to roll back clawdi CLI ${rollback.version}: ${rollback.error}`);
+	}
+	return rollback;
 }
 
 async function runtimeWatchLoadForApply(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -726,6 +726,15 @@ runtimeCmd
 	);
 
 runtimeCmd
+	.command("verify")
+	.description("Validate hosted runtime CLI modules and cached manifest")
+	.option("--json", "Emit machine-readable JSON")
+	.action(async (opts: { json?: boolean }) => {
+		const { runtimeVerify } = await import("./commands/runtime.js");
+		await runtimeVerify(opts);
+	});
+
+runtimeCmd
 	.command("sidecar")
 	.description("Run hosted runtime support modules")
 	.action(async () => {

--- a/packages/cli/src/lib/semver.ts
+++ b/packages/cli/src/lib/semver.ts
@@ -1,0 +1,64 @@
+interface ParsedSemver {
+	major: number;
+	minor: number;
+	patch: number;
+	pre: string[];
+}
+
+const SEMVER_RE =
+	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/;
+
+export function isValidSemver(value: string): boolean {
+	return parseSemver(value) !== null;
+}
+
+export function compareSemver(a: string, b: string): number {
+	const left = parseSemver(a);
+	const right = parseSemver(b);
+	if (!left || !right) {
+		throw new Error(`invalid semver comparison: ${a} <=> ${b}`);
+	}
+	for (const key of ["major", "minor", "patch"] as const) {
+		if (left[key] !== right[key]) return left[key] < right[key] ? -1 : 1;
+	}
+	if (left.pre.length === 0 && right.pre.length === 0) return 0;
+	if (left.pre.length === 0) return 1;
+	if (right.pre.length === 0) return -1;
+	const length = Math.max(left.pre.length, right.pre.length);
+	for (let i = 0; i < length; i++) {
+		const l = left.pre[i];
+		const r = right.pre[i];
+		if (l === undefined) return -1;
+		if (r === undefined) return 1;
+		if (l === r) continue;
+		const lNum = numericIdentifier(l);
+		const rNum = numericIdentifier(r);
+		if (lNum !== null && rNum !== null) return lNum < rNum ? -1 : 1;
+		if (lNum !== null) return -1;
+		if (rNum !== null) return 1;
+		return l < r ? -1 : 1;
+	}
+	return 0;
+}
+
+export function isSemverLessThan(a: string, b: string): boolean {
+	return compareSemver(a, b) < 0;
+}
+
+function parseSemver(value: string): ParsedSemver | null {
+	const match = SEMVER_RE.exec(value.trim());
+	if (!match) return null;
+	const [, major, minor, patch, pre] = match;
+	if (!major || !minor || !patch) return null;
+	return {
+		major: Number.parseInt(major, 10),
+		minor: Number.parseInt(minor, 10),
+		patch: Number.parseInt(patch, 10),
+		pre: pre ? pre.split(".") : [],
+	};
+}
+
+function numericIdentifier(value: string): number | null {
+	if (!/^(0|[1-9]\d*)$/.test(value)) return null;
+	return Number.parseInt(value, 10);
+}

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -40,14 +40,64 @@ interface RuntimeCliBootstrapStatus {
 	version?: string;
 }
 
+interface RuntimeCliBadVersion {
+	packageSpec: string;
+	registry: string | null;
+	version: string;
+	reason: string;
+	markedAt: string;
+}
+
+interface RuntimeCliPendingUpgrade {
+	packageSpec: string;
+	registry: string | null;
+	version: string;
+	npmPrefix: string;
+	activeTarget: string;
+	previousStatus: RuntimeCliBootstrapStatus | null;
+	previousActiveTarget: string | null;
+	previousNpmPrefix: string | null;
+	previousVersion: string | null;
+	manifestGeneration: number | null;
+	manifestEtag: string | null;
+	rollbackEligible: boolean;
+	installedAt: string;
+}
+
+interface RuntimeCliUpgradeState {
+	schemaVersion?: string;
+	pendingUpgrade?: RuntimeCliPendingUpgrade | null;
+	badVersions?: RuntimeCliBadVersion[];
+}
+
+export interface RuntimeCliRollbackResult {
+	status: "not_pending" | "rolled_back" | "error";
+	version: string | null;
+	previousVersion: string | null;
+	activeTarget: string | null;
+	previousActiveTarget: string | null;
+	error?: string | null;
+}
+
 const NPM_INSTALL_TIMEOUT_MS = 180_000;
 const NPM_VIEW_TIMEOUT_MS = 30_000;
 const VERSION_SMOKE_TIMEOUT_MS = 20_000;
+const RUNTIME_VERIFY_TIMEOUT_MS = 20_000;
+
+interface RuntimeCliManifestIdentity {
+	generation?: number | null;
+	etag?: string | null;
+	previouslyApplied?: boolean;
+}
 
 export function applyRuntimeCliDesiredState(
 	manifest: RuntimeManifest,
 	paths: RuntimePaths,
-	opts: { deferInstall?: boolean; deferReason?: string } = {},
+	opts: {
+		deferInstall?: boolean;
+		deferReason?: string;
+		manifestIdentity?: RuntimeCliManifestIdentity;
+	} = {},
 ): RuntimeCliUpdateResult {
 	const packageSpec = manifest.clawdiCli?.packageSpec?.trim();
 	if (!packageSpec) {
@@ -98,9 +148,10 @@ export function applyRuntimeCliDesiredState(
 		});
 	}
 
-	const previousActivePrefix = current?.activeTarget
-		? prefixForActiveTarget(current.activeTarget)
-		: prefixForActiveLink(paths.cliManagedBin);
+	const previousActiveTarget = current?.activeTarget ?? activeLinkTarget(paths.cliManagedBin);
+	const previousActivePrefix = previousActiveTarget
+		? prefixForActiveTarget(previousActiveTarget)
+		: null;
 	const installed = installCliPackage(paths, packageSpec, registry);
 	swapActiveCli(paths.cliManagedBin, installed.activeTarget);
 	writeCliBootstrapStatus(paths, {
@@ -109,6 +160,14 @@ export function applyRuntimeCliDesiredState(
 		npmPrefix: installed.npmPrefix,
 		activeTarget: installed.activeTarget,
 		version: installed.version,
+	});
+	markPendingCliUpgrade(paths, {
+		packageSpec,
+		registry,
+		installed,
+		previousStatus: current,
+		previousActiveTarget,
+		manifestIdentity: opts.manifestIdentity,
 	});
 	pruneCliPackagePrefixes(paths, [installed.npmPrefix, previousActivePrefix]);
 	return baseResult("installed", paths, {
@@ -164,7 +223,11 @@ function validatePackageSpec(packageSpec: string): void {
 	if (packageSpec === "clawdi") {
 		return;
 	}
-	if (/^clawdi@[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z][0-9A-Za-z.-]*)?$/.test(packageSpec)) {
+	if (
+		/^clawdi@[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$/.test(
+			packageSpec,
+		)
+	) {
 		return;
 	}
 	if (/^clawdi@[A-Za-z0-9._-]+$/.test(packageSpec)) {
@@ -213,14 +276,22 @@ function recoverCurrentCliInstallFromActiveLink(
 	packageSpec: string,
 	registry: string | null,
 ): { npmPrefix: string; activeTarget: string; version: string } | null {
-	const npmPrefix = cliPackagePrefix(paths, packageSpec, registry);
+	const desiredVersion = desiredNpmPackageVersion(packageSpec, registry);
+	if (!desiredVersion) return null;
+	const npmPrefix = cliPackagePrefix(paths, desiredVersion);
+	const legacyNpmPrefix = cliPackagePrefixForLegacyHash(paths, packageSpec, registry);
 	const activeTarget = activeLinkTarget(paths.cliManagedBin);
-	if (activeTarget !== join(npmPrefix, "bin", "clawdi")) return null;
+	if (
+		activeTarget !== join(npmPrefix, "bin", "clawdi") &&
+		activeTarget !== join(legacyNpmPrefix, "bin", "clawdi")
+	) {
+		return null;
+	}
 	if (!isExecutable(activeTarget) || !isExecutable(paths.cliManagedBin)) return null;
 	const version = smokeCliVersion(activeTarget);
 	if (!installedFloatingSpecVersionIsCurrent({ version }, packageSpec, registry)) return null;
 	return {
-		npmPrefix,
+		npmPrefix: prefixForActiveTarget(activeTarget),
 		activeTarget,
 		version,
 	};
@@ -231,9 +302,11 @@ function installedFloatingSpecVersionIsCurrent(
 	packageSpec: string,
 	registry: string | null,
 ): boolean {
+	const exact = exactNpmPackageVersion(packageSpec);
+	if (exact) return !status.version || status.version === exact;
 	if (!isFloatingNpmPackageSpec(packageSpec)) return true;
 	if (!status.version) return false;
-	const desiredVersion = resolveNpmPackageVersion(packageSpec, registry);
+	const desiredVersion = desiredNpmPackageVersion(packageSpec, registry);
 	return desiredVersion === null || status.version === desiredVersion;
 }
 
@@ -242,7 +315,27 @@ function isFloatingNpmPackageSpec(packageSpec: string): boolean {
 	if (!match) return false;
 	const specifier = match[1] ?? "";
 	if (!/^(alpha|beta|canary|next|rc)$/.test(specifier)) return false;
-	return !/^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z][0-9A-Za-z.-]*)?$/.test(specifier);
+	return !isExactNpmPackageVersion(specifier);
+}
+
+function desiredNpmPackageVersion(packageSpec: string, registry: string | null): string | null {
+	const exact = exactNpmPackageVersion(packageSpec);
+	if (exact) return exact;
+	if (!isFloatingNpmPackageSpec(packageSpec)) return null;
+	return resolveNpmPackageVersion(packageSpec, registry);
+}
+
+function exactNpmPackageVersion(packageSpec: string): string | null {
+	const match = /^clawdi@(.+)$/.exec(packageSpec);
+	if (!match) return null;
+	const specifier = match[1] ?? "";
+	return isExactNpmPackageVersion(specifier) ? specifier : null;
+}
+
+function isExactNpmPackageVersion(value: string): boolean {
+	return /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$/.test(
+		value,
+	);
 }
 
 function resolveNpmPackageVersion(packageSpec: string, registry: string | null): string | null {
@@ -275,7 +368,13 @@ function installCliPackage(
 	packageSpec: string,
 	registry: string | null,
 ): { npmPrefix: string; activeTarget: string; version: string } {
-	const npmPrefix = cliPackagePrefix(paths, packageSpec, registry);
+	const installPlan = cliInstallPlan(paths, packageSpec, registry);
+	if (isBadCliVersion(paths, packageSpec, registry, installPlan.version)) {
+		throw new Error(
+			`clawdi CLI ${installPlan.version} is marked bad after rollback; waiting for a newer resolved version`,
+		);
+	}
+	const npmPrefix = installPlan.npmPrefix;
 	mkdirSync(dirname(paths.cliManagedBin), { recursive: true });
 	mkdirSync(npmPrefix, { recursive: true });
 	mkdirSync(paths.cliNpmCache, { recursive: true });
@@ -305,7 +404,7 @@ function installCliPackage(
 		"--no-fund",
 		"--no-update-notifier",
 		...(registry ? ["--registry", registry] : []),
-		packageSpec,
+		installPlan.installPackageSpec,
 	];
 	const result = spawnSync("npm", args, {
 		encoding: "utf8",
@@ -318,7 +417,7 @@ function installCliPackage(
 	});
 	if (result.status !== 0) {
 		throw new Error(
-			`npm install ${packageSpec} failed${result.status === null ? "" : ` (${result.status})`}${
+			`npm install ${installPlan.installPackageSpec} failed${result.status === null ? "" : ` (${result.status})`}${
 				result.error ? `: ${result.error.message}` : ""
 			}${commandOutput(result.stdout, result.stderr)}`,
 		);
@@ -329,10 +428,42 @@ function installCliPackage(
 		throw new Error(`npm install completed but clawdi bin is missing: ${activeTarget}`);
 	}
 	const version = smokeCliVersion(activeTarget);
+	verifyCliRuntime(activeTarget);
 	return { npmPrefix, activeTarget, version };
 }
 
-function cliPackagePrefix(
+function cliInstallPlan(
+	paths: RuntimePaths,
+	packageSpec: string,
+	registry: string | null,
+): { installPackageSpec: string; npmPrefix: string; version: string } {
+	const version = desiredNpmPackageVersion(packageSpec, registry);
+	if (version) {
+		return {
+			installPackageSpec: `clawdi@${version}`,
+			npmPrefix: cliPackagePrefix(paths, version),
+			version,
+		};
+	}
+	const hash = createHash("sha256")
+		.update(JSON.stringify({ packageSpec, registry }))
+		.digest("hex")
+		.slice(0, 16);
+	return {
+		installPackageSpec: packageSpec,
+		npmPrefix: join(paths.cliNpmPrefix, "packages", `tarball-${hash}`),
+		version: `tarball-${hash}`,
+	};
+}
+
+function cliPackagePrefix(paths: RuntimePaths, version: string): string {
+	if (!/^[0-9A-Za-z._+-]+$/.test(version)) {
+		throw new Error(`resolved clawdi CLI version contains unsafe path characters: ${version}`);
+	}
+	return join(paths.cliNpmPrefix, "packages", version);
+}
+
+function cliPackagePrefixForLegacyHash(
 	paths: RuntimePaths,
 	packageSpec: string,
 	registry: string | null,
@@ -354,11 +485,6 @@ function activeLinkTarget(activePath: string): string | null {
 	} catch {
 		return null;
 	}
-}
-
-function prefixForActiveLink(activePath: string): string | null {
-	const activeTarget = activeLinkTarget(activePath);
-	return activeTarget ? prefixForActiveTarget(activeTarget) : null;
 }
 
 function pruneCliPackagePrefixes(paths: RuntimePaths, keepPrefixes: Array<string | null>): void {
@@ -403,6 +529,49 @@ function smokeCliVersion(command: string): string {
 	const version = result.stdout.trim().split(/\r?\n/, 1)[0]?.trim();
 	if (!version) throw new Error("installed clawdi --version returned empty output");
 	return version;
+}
+
+function verifyCliRuntime(command: string): void {
+	const result = spawnSync(command, ["runtime", "verify", "--json"], {
+		encoding: "utf8",
+		timeout: RUNTIME_VERIFY_TIMEOUT_MS,
+		env: {
+			...process.env,
+			CLAWDI_NO_AUTO_UPDATE: "1",
+			CLAWDI_NO_UPDATE_CHECK: "1",
+		},
+	});
+	if (result.status !== 0) {
+		throw new Error(
+			`installed clawdi did not pass runtime verify self-check${
+				result.status === null ? "" : ` (${result.status})`
+			}${result.error ? `: ${result.error.message}` : ""}${commandOutput(
+				result.stdout,
+				result.stderr,
+			)}`,
+		);
+	}
+	const output = result.stdout.trim();
+	if (!output) {
+		throw new Error("installed clawdi runtime verify self-check returned empty output");
+	}
+	try {
+		const parsed = JSON.parse(output) as unknown;
+		if (
+			!parsed ||
+			typeof parsed !== "object" ||
+			Array.isArray(parsed) ||
+			(parsed as Record<string, unknown>).status !== "ok"
+		) {
+			throw new Error("status was not ok");
+		}
+	} catch (error) {
+		throw new Error(
+			`installed clawdi runtime verify self-check returned invalid JSON: ${
+				error instanceof Error ? error.message : String(error)
+			}${commandOutput(result.stdout, result.stderr)}`,
+		);
+	}
 }
 
 function swapActiveCli(activePath: string, activeTarget: string): void {
@@ -451,6 +620,220 @@ function writeCliBootstrapStatus(
 		)}\n`,
 		{ mode: 0o644, dirMode: 0o755 },
 	);
+}
+
+export function rollbackPendingRuntimeCliUpgrade(
+	paths: RuntimePaths,
+	reason: string,
+	manifestIdentity: RuntimeCliManifestIdentity = {},
+): RuntimeCliRollbackResult {
+	const state = readCliUpgradeState(paths);
+	const pending = state.pendingUpgrade ?? null;
+	if (!pending) {
+		return {
+			status: "not_pending",
+			version: null,
+			previousVersion: null,
+			activeTarget: null,
+			previousActiveTarget: null,
+		};
+	}
+	if (!pending.rollbackEligible) {
+		return {
+			status: "not_pending",
+			version: pending.version,
+			previousVersion: pending.previousVersion,
+			activeTarget: pending.activeTarget,
+			previousActiveTarget: pending.previousActiveTarget,
+		};
+	}
+	if (!pendingMatchesManifestIdentity(pending, manifestIdentity)) {
+		return {
+			status: "not_pending",
+			version: pending.version,
+			previousVersion: pending.previousVersion,
+			activeTarget: pending.activeTarget,
+			previousActiveTarget: pending.previousActiveTarget,
+		};
+	}
+	if (!pending.previousActiveTarget || !isExecutable(pending.previousActiveTarget)) {
+		return {
+			status: "error",
+			version: pending.version,
+			previousVersion: pending.previousVersion,
+			activeTarget: pending.activeTarget,
+			previousActiveTarget: pending.previousActiveTarget,
+			error: "previous clawdi CLI target is missing or not executable",
+		};
+	}
+	try {
+		swapActiveCli(paths.cliManagedBin, pending.previousActiveTarget);
+		if (pending.previousStatus?.packageSpec && pending.previousStatus.activeTarget) {
+			writeCliBootstrapStatus(paths, {
+				packageSpec: pending.previousStatus.packageSpec,
+				registry: pending.previousStatus.registry ?? null,
+				npmPrefix:
+					pending.previousStatus.npmPrefix ?? prefixForActiveTarget(pending.previousActiveTarget),
+				activeTarget: pending.previousActiveTarget,
+				version: pending.previousStatus.version ?? pending.previousVersion ?? "unknown",
+			});
+		}
+		const nextState = normalizeCliUpgradeState(state);
+		nextState.pendingUpgrade = null;
+		nextState.badVersions = upsertBadVersion(nextState.badVersions ?? [], {
+			packageSpec: pending.packageSpec,
+			registry: pending.registry,
+			version: pending.version,
+			reason,
+			markedAt: new Date().toISOString(),
+		});
+		writeCliUpgradeState(paths, nextState);
+		pruneCliPackagePrefixes(paths, [pending.previousNpmPrefix]);
+		return {
+			status: "rolled_back",
+			version: pending.version,
+			previousVersion: pending.previousVersion,
+			activeTarget: pending.activeTarget,
+			previousActiveTarget: pending.previousActiveTarget,
+			error: null,
+		};
+	} catch (error) {
+		return {
+			status: "error",
+			version: pending.version,
+			previousVersion: pending.previousVersion,
+			activeTarget: pending.activeTarget,
+			previousActiveTarget: pending.previousActiveTarget,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+export function completePendingRuntimeCliUpgrade(
+	paths: RuntimePaths,
+	currentVersion: string,
+	manifestIdentity: RuntimeCliManifestIdentity = {},
+): void {
+	const state = readCliUpgradeState(paths);
+	const pending = state.pendingUpgrade ?? null;
+	if (!pending) return;
+	if (pending.version !== currentVersion) return;
+	if (!pendingMatchesManifestIdentity(pending, manifestIdentity)) return;
+	const nextState = normalizeCliUpgradeState(state);
+	nextState.pendingUpgrade = null;
+	writeCliUpgradeState(paths, nextState);
+}
+
+function markPendingCliUpgrade(
+	paths: RuntimePaths,
+	input: {
+		packageSpec: string;
+		registry: string | null;
+		installed: { npmPrefix: string; activeTarget: string; version: string };
+		previousStatus: RuntimeCliBootstrapStatus | null;
+		previousActiveTarget: string | null;
+		manifestIdentity?: RuntimeCliManifestIdentity;
+	},
+): void {
+	const state = normalizeCliUpgradeState(readCliUpgradeState(paths));
+	state.pendingUpgrade = {
+		packageSpec: input.packageSpec,
+		registry: input.registry,
+		version: input.installed.version,
+		npmPrefix: input.installed.npmPrefix,
+		activeTarget: input.installed.activeTarget,
+		previousStatus: input.previousStatus,
+		previousActiveTarget: input.previousActiveTarget,
+		previousNpmPrefix: input.previousActiveTarget
+			? prefixForActiveTarget(input.previousActiveTarget)
+			: null,
+		previousVersion: input.previousStatus?.version ?? null,
+		manifestGeneration: input.manifestIdentity?.generation ?? null,
+		manifestEtag: input.manifestIdentity?.etag ?? null,
+		rollbackEligible: input.manifestIdentity?.previouslyApplied === true,
+		installedAt: new Date().toISOString(),
+	};
+	writeCliUpgradeState(paths, state);
+}
+
+function isBadCliVersion(
+	paths: RuntimePaths,
+	packageSpec: string,
+	registry: string | null,
+	version: string,
+): boolean {
+	const state = readCliUpgradeState(paths);
+	return (state.badVersions ?? []).some(
+		(entry) =>
+			entry.packageSpec === packageSpec &&
+			(entry.registry ?? null) === registry &&
+			entry.version === version,
+	);
+}
+
+function readCliUpgradeState(paths: RuntimePaths): RuntimeCliUpgradeState {
+	if (!existsSync(paths.cliUpgradeState)) return { schemaVersion: "clawdi.cliUpgradeState.v1" };
+	try {
+		const parsed = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8")) as unknown;
+		if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+			return { schemaVersion: "clawdi.cliUpgradeState.v1" };
+		}
+		return parsed as RuntimeCliUpgradeState;
+	} catch {
+		return { schemaVersion: "clawdi.cliUpgradeState.v1" };
+	}
+}
+
+function writeCliUpgradeState(paths: RuntimePaths, state: RuntimeCliUpgradeState): void {
+	writePrivateFileAtomic(
+		paths.cliUpgradeState,
+		`${JSON.stringify(normalizeCliUpgradeState(state), null, 2)}\n`,
+		{ mode: 0o644, dirMode: 0o755 },
+	);
+}
+
+function normalizeCliUpgradeState(state: RuntimeCliUpgradeState): RuntimeCliUpgradeState {
+	return {
+		schemaVersion: "clawdi.cliUpgradeState.v1",
+		pendingUpgrade: state.pendingUpgrade ?? null,
+		badVersions: state.badVersions ?? [],
+	};
+}
+
+function upsertBadVersion(
+	entries: RuntimeCliBadVersion[],
+	entry: RuntimeCliBadVersion,
+): RuntimeCliBadVersion[] {
+	const next = entries.filter(
+		(existing) =>
+			existing.packageSpec !== entry.packageSpec ||
+			(existing.registry ?? null) !== entry.registry ||
+			existing.version !== entry.version,
+	);
+	next.push(entry);
+	return next;
+}
+
+function pendingMatchesManifestIdentity(
+	pending: RuntimeCliPendingUpgrade,
+	manifestIdentity: RuntimeCliManifestIdentity,
+): boolean {
+	if (
+		pending.manifestEtag &&
+		manifestIdentity.etag &&
+		pending.manifestEtag !== manifestIdentity.etag
+	) {
+		return false;
+	}
+	if (
+		pending.manifestGeneration !== null &&
+		manifestIdentity.generation !== undefined &&
+		manifestIdentity.generation !== null &&
+		pending.manifestGeneration !== manifestIdentity.generation
+	) {
+		return false;
+	}
+	return true;
 }
 
 function isExecutable(path: string): boolean {

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isValidSemver } from "../lib/semver";
 import { mitmProfileInputBundleSchema } from "./mitm-profiles";
 import {
 	runtimeNameSchema,
@@ -19,6 +20,7 @@ export const OFFICIAL_INSTALL_ARGS: Record<string, string[]> = {
 };
 
 const hostedRuntimeChoiceSchema = z.enum(["openclaw", "hermes"]);
+const semverSchema = z.string().min(1).refine(isValidSemver, "must be a semver string");
 
 const installSchema = z
 	.object({
@@ -130,6 +132,7 @@ const runtimeDesiredStateShape = {
 	environmentId: z.string().min(1),
 	instanceId: z.string().min(1),
 	generation: z.number().int().nonnegative(),
+	minimumCliVersion: semverSchema.optional(),
 	issuedAt: z.string().min(1),
 	expiresAt: z.string().min(1).optional(),
 	workspaceRoot: z.string().min(1).optional(),
@@ -250,6 +253,7 @@ export const hostedRuntimeManifestSchema = z.preprocess(
 			appId: z.string().min(1).optional(),
 			instanceId: z.string().min(1),
 			generation: z.number().int().nonnegative(),
+			minimumCliVersion: semverSchema.optional(),
 			issuedAt: z.string().min(1),
 			expiresAt: z.string().min(1).optional(),
 			system: z

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -545,6 +545,7 @@ export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): 
 		environmentId: hosted.environmentId || hosted.appId || hosted.deploymentId,
 		instanceId: hosted.instanceId,
 		generation: hosted.generation,
+		minimumCliVersion: hosted.minimumCliVersion,
 		issuedAt: hosted.issuedAt,
 		expiresAt: hosted.expiresAt,
 		workspaceRoot,

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -26,6 +26,7 @@ export interface RuntimePaths {
 	cliNpmPrefix: string;
 	cliNpmCache: string;
 	cliBootstrapStatus: string;
+	cliUpgradeState: string;
 	providerHealthStatus: string;
 	mitmproxyStatus: string;
 	maintainedRoot: string;
@@ -138,6 +139,7 @@ export function getRuntimePaths(opts: { mode?: RuntimeMode } = {}): RuntimePaths
 		cliNpmPrefix: npmRoot,
 		cliNpmCache: join(serviceStateRoot, "npm-cache"),
 		cliBootstrapStatus: join(serviceStateRoot, "status", "cli-bootstrap.json"),
+		cliUpgradeState: join(serviceStateRoot, "status", "cli-upgrade-state.json"),
 		providerHealthStatus: join(serviceStateRoot, "status", "provider-health.json"),
 		mitmproxyStatus: join(serviceStateRoot, "status", "mitmproxy.json"),
 		maintainedRoot: join(serviceStateRoot, "maintained"),

--- a/packages/cli/src/runtime/state.ts
+++ b/packages/cli/src/runtime/state.ts
@@ -75,6 +75,7 @@ export interface RuntimeBootStatus {
 		cliManagedBin: string;
 		cliNpmPrefix: string;
 		cliBootstrapStatus: string;
+		cliUpgradeState: string;
 		bootStatus: string;
 		runtimeWatchStatus: string;
 		cloudStatus: string;
@@ -119,6 +120,7 @@ function pathSummary(paths: RuntimePaths): RuntimeBootStatus["paths"] {
 		cliManagedBin: paths.cliManagedBin,
 		cliNpmPrefix: paths.cliNpmPrefix,
 		cliBootstrapStatus: paths.cliBootstrapStatus,
+		cliUpgradeState: paths.cliUpgradeState,
 		bootStatus: paths.bootStatus,
 		runtimeWatchStatus: paths.runtimeWatchStatus,
 		cloudStatus: paths.cloudStatus,

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -4787,6 +4787,10 @@ if [ "\${1:-}" = "--version" ]; then
   echo "0.13.1-beta.0"
   exit 0
 fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
+  exit 0
+fi
 echo "fake clawdi"
 SH
 chmod +x "$prefix/bin/clawdi"
@@ -4939,6 +4943,10 @@ cat > "$prefix/bin/clawdi" <<'SH'
 #!/usr/bin/env bash
 if [ "\${1:-}" = "--version" ]; then
   echo "0.13.2-beta.0"
+  exit 0
+fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
   exit 0
 fi
 echo "fake upgraded clawdi"
@@ -5178,6 +5186,10 @@ if [ "\${1:-}" = "--version" ]; then
   echo "0.12.10-beta.22"
   exit 0
 fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
+  exit 0
+fi
 echo "fake clawdi"
 SH
 chmod +x "$prefix/bin/clawdi"
@@ -5255,6 +5267,10 @@ cat > "$prefix/bin/clawdi" <<'SH'
 #!/usr/bin/env bash
 if [ "\${1:-}" = "--version" ]; then
   echo "0.13.3-beta.0"
+  exit 0
+fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
   exit 0
 fi
 echo "fake clawdi"
@@ -5384,6 +5400,180 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 		}
 	});
 
+	it("rolls back a CLI upgrade when first converge fails for an already-applied manifest", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const sourcePath = join(root, "runtime-source.json");
+		const bin = join(root, "bin");
+		const npmLog = join(root, "npm.log");
+		const openclawInstaller = join(root, "install-openclaw.sh");
+		const previousExitCode = process.exitCode;
+		const previousLog = console.log;
+		const previousPath = process.env.PATH;
+		const logs: string[] = [];
+		mkdirSync(join(run, "secrets"), { recursive: true });
+		mkdirSync(bin, { recursive: true });
+		mkdirSync(home, { recursive: true });
+		writeFileSync(
+			join(bin, "npm"),
+			`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> '${npmLog}'
+if [ "\${1:-}" = "view" ]; then
+  echo '"0.13.5-beta.0"'
+  exit 0
+fi
+prefix=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--prefix" ]; then
+    prefix="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+install -d "$prefix/bin"
+cat > "$prefix/bin/clawdi" <<'SH'
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+  echo "0.13.5-beta.0"
+  exit 0
+fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
+  exit 0
+fi
+echo "fake clawdi"
+SH
+chmod +x "$prefix/bin/clawdi"
+`,
+		);
+		chmodSync(join(bin, "npm"), 0o700);
+		writeFileSync(openclawInstaller, "#!/usr/bin/env bash\necho install failed >&2\nexit 73\n");
+		chmodSync(openclawInstaller, 0o700);
+		process.env.PATH = `${bin}:${previousPath ?? ""}`;
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
+		process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER = openclawInstaller;
+		process.exitCode = undefined;
+		console.log = (value?: unknown) => {
+			logs.push(String(value));
+		};
+		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
+		writeFileSync(
+			sourcePath,
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeSource.v1",
+				type: "http",
+				url: "https://runtime.test/manifest",
+				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
+			}),
+		);
+		seedCurrentCliInstall(state, "clawdi@beta", "0.13.4-beta.0");
+		const paths = getRuntimePaths();
+		const oldTarget = readlinkSync(paths.cliManagedBin);
+		mkdirSync(dirname(paths.manifestEtag), { recursive: true });
+		writeFileSync(paths.manifestEtag, '"etag-cli-rollback"\n');
+		const manifest = {
+			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+			runtime: "openclaw",
+			deploymentId: "dep_cli_rollback",
+			environmentId: "env_cli_rollback",
+			instanceId: "iid_cli_rollback",
+			generation: 18,
+			issuedAt: "2026-06-06T00:00:00Z",
+			system: { home, workspace: join(home, "clawdi") },
+			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+			clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@beta" },
+			runtimes: {
+				openclaw: hostedOpenClawRuntime({
+					install: { source: "official", channel: "stable" },
+					paths: { home },
+				}),
+			},
+		};
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/manifest",
+				response: () =>
+					new Response(
+						JSON.stringify({
+							manifest,
+							secretValues: {},
+						}),
+						{
+							status: 200,
+							headers: { "content-type": "application/json", etag: '"etag-cli-rollback"' },
+						},
+					),
+			},
+			{
+				method: "GET",
+				path: "/v1/channels",
+				response: () =>
+					new Response(JSON.stringify([]), {
+						status: 200,
+						headers: { "content-type": "application/json", etag: '"channels-cli-rollback"' },
+					}),
+			},
+		]);
+
+		try {
+			await runtimeWatch({ once: true, json: true });
+
+			expect(process.exitCode).toBe(1);
+			const event = JSON.parse(logs[0]);
+			expect(event.status).toBe("error");
+			expect(event.cliUpdate.status).toBe("installed");
+			expect(event.cliRollback.status).toBe("rolled_back");
+			expect(event.cliRollback.version).toBe("0.13.5-beta.0");
+			expect(event.selfReexec).toBe(false);
+			expect(readlinkSync(paths.cliManagedBin)).toBe(oldTarget);
+			const upgradeState = JSON.parse(readFileSync(paths.cliUpgradeState, "utf-8"));
+			expect(upgradeState.pendingUpgrade).toBeNull();
+			expect(upgradeState.badVersions).toContainEqual(
+				expect.objectContaining({
+					packageSpec: "clawdi@beta",
+					version: "0.13.5-beta.0",
+				}),
+			);
+			const beforeRetryLog = readFileSync(npmLog, "utf-8");
+			expect(() =>
+				applyRuntimeCliDesiredState(
+					{
+						schemaVersion: "clawdi.runtimeDesiredState.v1",
+						deploymentId: "dep_cli_rollback",
+						environmentId: "env_cli_rollback",
+						instanceId: "iid_cli_rollback",
+						generation: 18,
+						issuedAt: "2026-06-06T00:00:00Z",
+						controlPlane: { apiUrl: "https://cloud-api.test" },
+						clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@beta" },
+						runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
+						recovery: {},
+					},
+					paths,
+				),
+			).toThrow(/marked bad/);
+			const afterRetryLog = readFileSync(npmLog, "utf-8");
+			expect(afterRetryLog.split("\n").filter((line) => line.startsWith("install ")).length).toBe(
+				beforeRetryLog.split("\n").filter((line) => line.startsWith("install ")).length,
+			);
+		} finally {
+			restore();
+			console.log = previousLog;
+			process.exitCode = previousExitCode;
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
+	});
+
 	it("runtime watch applies systemd state when CLI install fails", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -5490,6 +5680,134 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 		}
 	});
 
+	it("runs CLI update before blocking desired state below minimumCliVersion", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const sourcePath = join(root, "runtime-source.json");
+		const bin = join(root, "bin");
+		const previousExitCode = process.exitCode;
+		const previousLog = console.log;
+		const previousPath = process.env.PATH;
+		const logs: string[] = [];
+		mkdirSync(join(run, "secrets"), { recursive: true });
+		mkdirSync(bin, { recursive: true });
+		mkdirSync(home, { recursive: true });
+		writeFileSync(
+			join(bin, "npm"),
+			`#!/usr/bin/env bash
+set -euo pipefail
+prefix=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--prefix" ]; then
+    prefix="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+install -d "$prefix/bin"
+cat > "$prefix/bin/clawdi" <<'SH'
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+  echo "0.13.10-beta.0"
+  exit 0
+fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
+  exit 0
+fi
+SH
+chmod +x "$prefix/bin/clawdi"
+`,
+		);
+		chmodSync(join(bin, "npm"), 0o700);
+		process.env.PATH = `${bin}:${previousPath ?? ""}`;
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.exitCode = undefined;
+		console.log = (value?: unknown) => {
+			logs.push(String(value));
+		};
+		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
+		writeFileSync(
+			sourcePath,
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeSource.v1",
+				type: "http",
+				url: "https://runtime.test/manifest",
+				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
+			}),
+		);
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/manifest",
+				response: () =>
+					new Response(
+						JSON.stringify({
+							manifest: {
+								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								runtime: "openclaw",
+								deploymentId: "dep_min_cli",
+								environmentId: "env_min_cli",
+								instanceId: "iid_min_cli",
+								generation: 19,
+								minimumCliVersion: "999.0.0",
+								issuedAt: "2026-06-06T00:00:00Z",
+								system: { home, workspace: join(home, "clawdi") },
+								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+								clawdiCli: {
+									source: "npm:clawdi",
+									packageSpec: "clawdi@0.13.10-beta.0",
+								},
+								runtimes: { openclaw: hostedOpenClawRuntime() },
+							},
+							secretValues: {},
+						}),
+						{
+							status: 200,
+							headers: { "content-type": "application/json", etag: '"etag-min-cli"' },
+						},
+					),
+			},
+			{
+				method: "GET",
+				path: "/v1/channels",
+				response: () =>
+					new Response(JSON.stringify([]), {
+						status: 200,
+						headers: { "content-type": "application/json", etag: '"channels-min-cli"' },
+					}),
+			},
+		]);
+
+		try {
+			await runtimeWatch({ once: true, json: true });
+
+			expect(process.exitCode).toBe(1);
+			const event = JSON.parse(logs[0]);
+			expect(event.status).toBe("error");
+			expect(event.stage).toBe("config");
+			expect(event.mode).toBe("minimum_cli_version_gated");
+			expect(event.cliUpdate.status).toBe("installed");
+			expect(event.selfReexec).toBe(true);
+			expect(event.gate.minimumCliVersion).toBe("999.0.0");
+			const paths = getRuntimePaths();
+			expect(existsSync(paths.manifestEtag)).toBe(false);
+			expect(existsSync(paths.manifestLastGood)).toBe(false);
+		} finally {
+			restore();
+			console.log = previousLog;
+			process.exitCode = previousExitCode;
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
+	});
+
 	it("keeps the previous active CLI when installed CLI smoke fails", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -5557,6 +5875,81 @@ chmod +x "$prefix/bin/clawdi"
 
 		try {
 			expect(() => applyRuntimeCliDesiredState(manifest, paths)).toThrow(/smoke check/);
+			expect(readlinkSync(paths.cliManagedBin)).toBe(oldTarget);
+			const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+			expect(status).toEqual(oldStatus);
+		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
+	});
+
+	it("keeps the previous active CLI when installed CLI self-check fails", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const bin = join(root, "bin");
+		const previousPath = process.env.PATH;
+		mkdirSync(bin, { recursive: true });
+		writeFileSync(
+			join(bin, "npm"),
+			`#!/usr/bin/env bash
+set -euo pipefail
+prefix=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--prefix" ]; then
+    prefix="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+install -d "$prefix/bin"
+cat > "$prefix/bin/clawdi" <<'SH'
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+  echo "0.13.2-beta.1"
+  exit 0
+fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"error","errors":["manifest parse failed"]}'
+  exit 42
+fi
+SH
+chmod +x "$prefix/bin/clawdi"
+`,
+		);
+		chmodSync(join(bin, "npm"), 0o700);
+		process.env.PATH = `${bin}:${previousPath ?? ""}`;
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(state, "clawdi@0.13.1-beta.0", "0.13.1-beta.0");
+		const paths = getRuntimePaths();
+		const oldTarget = readlinkSync(paths.cliManagedBin);
+		const oldStatus = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+		const manifest: RuntimeManifest = {
+			schemaVersion: "clawdi.runtimeDesiredState.v1",
+			deploymentId: "dep_cli_selfcheck_failure",
+			environmentId: "env_cli_selfcheck_failure",
+			instanceId: "iid_cli_selfcheck_failure",
+			generation: 14,
+			issuedAt: "2026-06-06T00:00:00Z",
+			controlPlane: { apiUrl: "https://cloud-api.test" },
+			clawdiCli: {
+				source: "npm:clawdi",
+				packageSpec: "clawdi@0.13.2-beta.1",
+			},
+			runtimes: {
+				openclaw: { enabled: false },
+				hermes: { enabled: false },
+			},
+			recovery: {},
+		};
+
+		try {
+			expect(() => applyRuntimeCliDesiredState(manifest, paths)).toThrow(/self-check/);
 			expect(readlinkSync(paths.cliManagedBin)).toBe(oldTarget);
 			const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
 			expect(status).toEqual(oldStatus);
@@ -5646,6 +6039,10 @@ if [ "\${1:-}" = "--version" ]; then
   echo "0.13.6-beta.0"
   exit 0
 fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
+  exit 0
+fi
 SH
 chmod +x "$prefix/bin/clawdi"
 `,
@@ -5717,6 +6114,10 @@ cat > "$prefix/bin/clawdi" <<SH
 #!/usr/bin/env bash
 if [ "\\\${1:-}" = "--version" ]; then
   echo "$version"
+  exit 0
+fi
+if [ "\\\${1:-} \\\${2:-} \\\${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
   exit 0
 fi
 SH


### PR DESCRIPTION
## Summary
- Install resolved hosted CLI beta/canary-style dist-tags into version-isolated npm prefixes and keep the previous active prefix for rollback while pruning older prefixes.
- Add `clawdi runtime verify --json` as the post-install self-check and require it before swapping the managed symlink.
- Persist pending upgrade state in `status/cli-upgrade-state.json`; if the first converge for an already-applied same manifest fails, roll back to the previous prefix and mark the bad version so the same dist-tag resolution is skipped until it moves.
- Add optional `minimumCliVersion` to the runtime manifest contract and gate apply after CLI update, keeping last-good desired state active when the running CLI is too old.

## Rollout note
- The existing deployed CLI parser is top-level `strict()` for runtime desired-state manifests, so old CLIs reject an unknown `minimumCliVersion` field. Publish this CLI before hosted emits the field.
- After this lands, the gate is additive: CLI update still runs first, and apply is blocked only when the current CLI version is lower than `minimumCliVersion`.

## Verification
- `bun run check`
- `bun run typecheck`
- `bun test packages/cli`
