### PR TITLE
Release clawdi 0.12.10-beta.40

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.39",
+	"version": "0.12.10-beta.40",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Version bump → publishes to `beta`. Contains #363 (upgrade hardening + minimumCliVersion gate). Hosted #757 merges only after the fleet self-upgrades to this (old CLIs strict-reject unknown manifest fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)