### PR TITLE
Phase 3: redeem hosted runtime UI browser auth

### DIFF
--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -151,6 +151,14 @@ export function useCreateTerminalSession() {
 	});
 }
 
+export function useCreateRuntimeUiRedemption() {
+	const client = useBillingClient();
+	return useMutation({
+		mutationFn: (vars: { id: string }) => client.createRuntimeUiRedemption(vars.id),
+		onError: toastBillingError("Couldn't open runtime UI"),
+	});
+}
+
 export function useDeploymentLifecycle() {
 	const client = useBillingClient();
 	const qc = useQueryClient();

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -63,6 +63,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { deploymentDisplayName, isCloudEnvId } from "@/hosted/agent-identity";
 import {
+	useCreateRuntimeUiRedemption,
 	useCreateTerminalSession,
 	useDeleteDeployment,
 	useDeploymentLifecycle,
@@ -73,6 +74,7 @@ import {
 	HostedTerminalPanel,
 	type HostedTerminalStatus,
 } from "@/hosted/agents/hosted-terminal-panel";
+import { openRuntimeUiWithRedemption } from "@/hosted/agents/runtime-ui-redemption";
 import { ComputeDunningBanner } from "@/hosted/billing/components/compute-dunning-banner";
 import { TermSwitcher } from "@/hosted/billing/components/term-switcher";
 import type {
@@ -403,22 +405,15 @@ export function HostedAgentDetail({
 				Install skills
 			</Button>
 		) : consoleUrl ? (
-			<Button
-				render={
-					<a
-						href={consoleUrl}
-						target="_blank"
-						rel="noopener noreferrer"
-						aria-label={`Open ${runtimeBrowserUiLabel(runtime)}`}
-					/>
-				}
-				nativeButton={false}
+			<RuntimeUiOpenButton
+				deployment={deployment}
+				label={runtimeBrowserUiLabel(runtime)}
 				variant="outline"
 				size="sm"
 			>
 				Open {runtimeBrowserUiLabel(runtime)}
 				<ExternalLink className="size-3.5" />
-			</Button>
+			</RuntimeUiOpenButton>
 		) : null;
 
 	return (
@@ -761,6 +756,54 @@ function OverviewTab({
 
 // ── Runtime UI ───────────────────────────────────────────────────────────────
 
+function RuntimeUiOpenButton({
+	deployment,
+	label,
+	children,
+	className,
+	variant = "outline",
+	size = "sm",
+}: {
+	deployment: HostedDeployment;
+	label: string;
+	children: React.ReactNode;
+	className?: string;
+	variant?: React.ComponentProps<typeof Button>["variant"];
+	size?: React.ComponentProps<typeof Button>["size"];
+}) {
+	const redemption = useCreateRuntimeUiRedemption();
+	const openUi = useCallback(async () => {
+		try {
+			const result = await openRuntimeUiWithRedemption({
+				redeem: () => redemption.mutateAsync({ id: deployment.id }),
+				openPopup: (url, target, features) => window.open(url, target, features),
+			});
+			if (result === "blocked") {
+				toast.error("Couldn't open runtime UI", {
+					description: "Your browser blocked the new window.",
+				});
+			}
+		} catch {
+			// useCreateRuntimeUiRedemption owns the user-facing error toast.
+		}
+	}, [deployment.id, redemption.mutateAsync]);
+
+	return (
+		<Button
+			type="button"
+			variant={variant}
+			size={size}
+			className={className}
+			disabled={redemption.isPending}
+			aria-label={`Open ${label}`}
+			onClick={() => void openUi()}
+		>
+			{redemption.isPending ? <Spinner className="size-3.5" /> : null}
+			{children}
+		</Button>
+	);
+}
+
 /**
  * Live agent browser UI embedded inline. The deployment's selected runtime UI
  * URL points at owner-only exposure. When the runtime
@@ -774,6 +817,25 @@ function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; run
 	const label = runtimeDisplayName(runtime);
 	const browserUiLabel = runtimeBrowserUiLabel(runtime);
 	const url = runtimeConsoleUrl(deployment, runtime);
+	const redemption = useCreateRuntimeUiRedemption();
+	const [frameUrl, setFrameUrl] = useState<string | null>(null);
+
+	useEffect(() => {
+		setFrameUrl(null);
+		if (!isRunning || !url) return;
+		let cancelled = false;
+		redemption
+			.mutateAsync({ id: deployment.id })
+			.then((result) => {
+				if (!cancelled) setFrameUrl(result.url);
+			})
+			.catch(() => {
+				if (!cancelled) setFrameUrl(null);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [deployment.id, isRunning, redemption.mutateAsync, url]);
 
 	// Not running yet — the runtime UI and bridge only exist once the agent boots.
 	if (!isRunning) {
@@ -807,49 +869,46 @@ function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; run
 			icon={MonitorPlay}
 			title={browserUiLabel}
 			action={
-				<Button
-					render={
-						<a href={url} target="_blank" rel="noopener noreferrer" aria-label="Open full screen" />
-					}
-					nativeButton={false}
+				<RuntimeUiOpenButton
+					deployment={deployment}
+					label={browserUiLabel}
 					variant="outline"
 					size="sm"
 					className="hidden sm:inline-flex"
 				>
 					Open full screen
 					<Maximize2 className="size-3.5" />
-				</Button>
+				</RuntimeUiOpenButton>
 			}
 		>
 			{/* Desktop: embed the live UI. Mobile is too cramped, so offer the
 			    full-screen link instead. */}
-			<iframe
-				key={`${runtime}:${url}`}
-				src={url}
-				title={browserUiLabel}
-				className="hidden min-h-0 flex-1 border-0 bg-background sm:block"
-				allow="clipboard-read; clipboard-write"
-			/>
+			{frameUrl ? (
+				<iframe
+					key={`${runtime}:${frameUrl}`}
+					src={frameUrl}
+					title={browserUiLabel}
+					className="hidden min-h-0 flex-1 border-0 bg-background sm:block"
+					allow="clipboard-read; clipboard-write"
+				/>
+			) : (
+				<div className="hidden min-h-0 flex-1 items-center justify-center bg-background sm:flex">
+					<Spinner className="size-4 text-muted-foreground" />
+				</div>
+			)}
 			<div className="flex min-h-[420px] flex-1 flex-col items-center justify-center gap-3 p-6 text-center sm:hidden">
 				<p className="text-sm text-muted-foreground">
 					This runtime UI is best viewed full screen on a small screen.
 				</p>
-				<Button
-					render={
-						<a
-							href={url}
-							target="_blank"
-							rel="noopener noreferrer"
-							aria-label={`Open ${browserUiLabel}`}
-						/>
-					}
-					nativeButton={false}
+				<RuntimeUiOpenButton
+					deployment={deployment}
+					label={browserUiLabel}
 					variant="outline"
 					size="sm"
 				>
 					Open {browserUiLabel}
 					<Maximize2 className="size-3.5" />
-				</Button>
+				</RuntimeUiOpenButton>
 			</div>
 		</LiveToolFrame>
 	);

--- a/apps/web/src/hosted/agents/runtime-ui-redemption.test.ts
+++ b/apps/web/src/hosted/agents/runtime-ui-redemption.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import {
+	openRuntimeUiWithRedemption,
+	type RuntimeUiPopup,
+	type RuntimeUiPopupOpen,
+} from "@/hosted/agents/runtime-ui-redemption";
+
+describe("runtime UI redemption open flow", () => {
+	test("opens a blank popup synchronously and navigates it to the redemption URL", async () => {
+		const popup = popupWindow();
+		const opened: string[] = [];
+		const result = await openRuntimeUiWithRedemption({
+			redeem: async () => ({ url: "https://app-18789.example/control/?clawdi_code=code" }),
+			openPopup: (url) => {
+				opened.push(url);
+				return popup;
+			},
+		});
+
+		expect(result).toBe("opened_reserved_popup");
+		expect(opened).toEqual(["about:blank"]);
+		expect(popup.opener).toBeNull();
+		expect(popup.location.href).toBe("https://app-18789.example/control/?clawdi_code=code");
+	});
+
+	test("falls back to direct open when the reserved popup is blocked", async () => {
+		const opened: string[] = [];
+		const openPopup: RuntimeUiPopupOpen = (url) => {
+			opened.push(url);
+			return url === "about:blank" ? null : popupWindow();
+		};
+
+		const result = await openRuntimeUiWithRedemption({
+			redeem: async () => ({ url: "https://app-9119.example/dashboard?clawdi_code=code" }),
+			openPopup,
+		});
+
+		expect(result).toBe("opened_direct");
+		expect(opened).toEqual(["about:blank", "https://app-9119.example/dashboard?clawdi_code=code"]);
+	});
+
+	test("propagates redemption failures without opening a clean native URL", async () => {
+		const opened: string[] = [];
+		const popup = popupWindow();
+
+		await expect(
+			openRuntimeUiWithRedemption({
+				redeem: async () => {
+					throw new Error("forbidden");
+				},
+				openPopup: (url) => {
+					opened.push(url);
+					return popup;
+				},
+			}),
+		).rejects.toThrow("forbidden");
+		expect(opened).toEqual(["about:blank"]);
+		expect(popup.closed).toBe(true);
+	});
+});
+
+function popupWindow(): RuntimeUiPopup {
+	return {
+		opener: {},
+		location: { href: "about:blank" },
+		closed: false,
+		close() {
+			this.closed = true;
+		},
+	};
+}

--- a/apps/web/src/hosted/agents/runtime-ui-redemption.ts
+++ b/apps/web/src/hosted/agents/runtime-ui-redemption.ts
@@ -1,0 +1,54 @@
+export interface RuntimeUiRedemptionResult {
+	url: string;
+}
+
+export interface RuntimeUiPopup {
+	opener: unknown;
+	location: {
+		href: string;
+	};
+	closed?: boolean;
+	close?: () => void;
+}
+
+export type RuntimeUiPopupOpen = (
+	url: string,
+	target: "_blank",
+	features?: string,
+) => RuntimeUiPopup | null;
+
+export type RuntimeUiOpenResult = "opened_reserved_popup" | "opened_direct" | "blocked";
+
+export async function openRuntimeUiWithRedemption({
+	redeem,
+	openPopup,
+}: {
+	redeem: () => Promise<RuntimeUiRedemptionResult>;
+	openPopup: RuntimeUiPopupOpen;
+}): Promise<RuntimeUiOpenResult> {
+	const reserved = openPopup("about:blank", "_blank");
+	if (reserved) {
+		try {
+			reserved.opener = null;
+		} catch {
+			// Some browsers expose opener as readonly for cross-process popups.
+		}
+	}
+	let redemption: RuntimeUiRedemptionResult;
+	try {
+		redemption = await redeem();
+	} catch (error) {
+		try {
+			reserved?.close?.();
+		} catch {
+			// A blocked or cross-process popup may refuse programmatic close.
+		}
+		throw error;
+	}
+	if (reserved) {
+		reserved.location.href = redemption.url;
+		return "opened_reserved_popup";
+	}
+	const direct = openPopup(redemption.url, "_blank", "noopener,noreferrer");
+	return direct ? "opened_direct" : "blocked";
+}

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -175,6 +175,12 @@ export function useBillingClient() {
 						params: { path: { deployment_id: id } },
 					}),
 				),
+			createRuntimeUiRedemption: async (id: string) =>
+				unwrapDeploy(
+					await api.POST("/v2/deployments/{deployment_id}/runtime-ui/redemption", {
+						params: { path: { deployment_id: id } },
+					}),
+				),
 			restartDeployment: async (id: string) =>
 				unwrapDeploy(
 					await api.POST("/v2/deployments/{deployment_id}/restart", {

--- a/apps/web/src/hosted/billing/contracts.ts
+++ b/apps/web/src/hosted/billing/contracts.ts
@@ -18,6 +18,7 @@ export type DeployRequest = Schemas["V2HostedDeployRequest"];
 export type DeleteDeploymentResult = Schemas["V2DeploymentDeleteResponse"];
 export type DeploymentDetailsInfo = Schemas["V2HostedDeploymentDetailsInfo"];
 export type HostedDeployment = Schemas["V2HostedDeploymentResponse"];
+export type RuntimeUiRedemption = Schemas["V2DeploymentRuntimeUiRedemptionResponse"];
 export type HostedUser = Schemas["V1UserResponse"];
 export type HostedConfigRequest = Schemas["V2HostedConfigRequest"];
 export type Plan = Schemas["V2PlanResponse"];

--- a/apps/web/src/hosted/runtimes.test.ts
+++ b/apps/web/src/hosted/runtimes.test.ts
@@ -96,16 +96,23 @@ describe("deploymentRuntime", () => {
 		expect(
 			runtimeConsoleUrl({
 				...deployment(configInfo({ runtime: "openclaw" })),
-				openclaw_control_ui_url: "https://app-18789.example/control/#token=abc",
-				hermes_control_ui_url: "https://app-9119.example/?t=bridge",
+				native_url: "https://app-native.example/control/",
+				openclaw_control_ui_url: "https://app-18789.example/control/",
 			}),
-		).toBe("https://app-18789.example/control/#token=abc");
+		).toBe("https://app-native.example/control/");
+		expect(
+			runtimeConsoleUrl({
+				...deployment(configInfo({ runtime: "openclaw" })),
+				openclaw_control_ui_url: "https://app-18789.example/control/",
+				hermes_control_ui_url: "https://app-9119.example/dashboard",
+			}),
+		).toBe("https://app-18789.example/control/");
 		expect(
 			runtimeConsoleUrl({
 				...deployment(configInfo({ runtime: "hermes" })),
-				openclaw_control_ui_url: "https://app-18789.example/control/#token=abc",
-				hermes_control_ui_url: "https://app-9119.example/?t=bridge",
+				openclaw_control_ui_url: "https://app-18789.example/control/",
+				hermes_control_ui_url: "https://app-9119.example/dashboard",
 			}),
-		).toBe("https://app-9119.example/?t=bridge");
+		).toBe("https://app-9119.example/dashboard");
 	});
 });

--- a/apps/web/src/hosted/runtimes.ts
+++ b/apps/web/src/hosted/runtimes.ts
@@ -60,6 +60,7 @@ export function runtimeConsoleUrl(
 	deployment: HostedDeployment,
 	runtime: HostedRuntime = deploymentRuntime(deployment),
 ): string | null | undefined {
+	if (deployment.native_url) return deployment.native_url;
 	if (runtime === "openclaw") return deployment.openclaw_control_ui_url;
 	return deployment.hermes_control_ui_url;
 }

--- a/packages/cli/src/runtime/bridge.ts
+++ b/packages/cli/src/runtime/bridge.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from "node:crypto";
+import { createHmac, timingSafeEqual } from "node:crypto";
 import { createConnection, createServer, isIP, type Server, type Socket } from "node:net";
 import { z } from "zod";
 import {
@@ -10,6 +10,7 @@ import {
 
 export const RUNTIME_BRIDGE_TOKEN_ENV = "CLAWDI_RUNTIME_BRIDGE_TOKEN";
 export const RUNTIME_BRIDGE_COOKIE = "clawdi_runtime_bridge";
+export const RUNTIME_BRIDGE_REDEMPTION_QUERY_PARAM = "clawdi_code";
 export const RUNTIME_BRIDGE_FRAME_ANCESTORS_ENV = "CLAWDI_RUNTIME_BRIDGE_FRAME_ANCESTORS";
 export const RUNTIME_BRIDGE_LISTEN_HOST_ENV = "CLAWDI_RUNTIME_BRIDGE_LISTEN_HOST";
 export const RUNTIME_BRIDGE_SURFACES_ENV = "CLAWDI_RUNTIME_BRIDGE_SURFACES";
@@ -63,11 +64,23 @@ interface AuthUnauthorized {
 
 type AuthResult = AuthQueryToken | AuthAuthorized | AuthUnauthorized;
 
+interface RuntimeBridgeRedemptionState {
+	usedJtis: Map<string, number>;
+	nowMs: () => number;
+}
+
+interface RuntimeBridgeRedemptionClaims {
+	jti: string;
+	expiresAtMs: number;
+	runtime: "openclaw" | "hermes";
+}
+
 const HEADER_TIMEOUT_MS = 60_000;
 const UPSTREAM_CONNECT_TIMEOUT_MS = 10_000;
 const HEALTH_CONNECT_TIMEOUT_MS = 1_000;
 const MAX_HEADER_BYTES = 64 * 1024;
 const BRIDGE_PUBLIC_PREFIX_SCRIPT_PATH = "/__clawdi_runtime_bridge_prefix.js";
+const RUNTIME_UI_REDEMPTION_SUBJECT = "v2_hosted_runtime_ui";
 const BRIDGE_PUBLIC_PREFIX_SCRIPT = String.raw`
 (() => {
 	const script = document.currentScript;
@@ -185,9 +198,13 @@ export async function startRuntimeBridge(
 		DEFAULT_RUNTIME_BRIDGE_FRAME_ANCESTORS;
 	const servers: Server[] = [];
 	const listeningSurfaces: RuntimeBridgeSurface[] = [];
+	const redemptionState: RuntimeBridgeRedemptionState = {
+		usedJtis: new Map(),
+		nowMs: () => Date.now(),
+	};
 	try {
 		for (const surface of surfaces) {
-			const server = createBridgeServer(surface, token, frameAncestors);
+			const server = createBridgeServer(surface, token, frameAncestors, redemptionState);
 			await listen(server, surface.listenHost, surface.listenPort);
 			const address = server.address();
 			const listenPort = typeof address === "object" && address ? address.port : surface.listenPort;
@@ -279,9 +296,10 @@ function createBridgeServer(
 	surface: RuntimeBridgeSurface,
 	token: string,
 	frameAncestors: string,
+	redemptionState: RuntimeBridgeRedemptionState,
 ): Server {
 	return createServer((clientSocket) => {
-		handleClientConnection(surface, token, frameAncestors, clientSocket);
+		handleClientConnection(surface, token, frameAncestors, redemptionState, clientSocket);
 	});
 }
 
@@ -289,6 +307,7 @@ function handleClientConnection(
 	surface: RuntimeBridgeSurface,
 	token: string,
 	frameAncestors: string,
+	redemptionState: RuntimeBridgeRedemptionState,
 	clientSocket: Socket,
 ): void {
 	let buffer = Buffer.alloc(0);
@@ -327,7 +346,15 @@ function handleClientConnection(
 			writeRawHttpResponse(clientSocket, 400, "Bad Request", "Bad Request");
 			return;
 		}
-		handleParsedRequest(surface, token, frameAncestors, clientSocket, parsed, remaining);
+		handleParsedRequest(
+			surface,
+			token,
+			frameAncestors,
+			redemptionState,
+			clientSocket,
+			parsed,
+			remaining,
+		);
 	};
 	clientSocket.on("data", onData);
 }
@@ -336,6 +363,7 @@ function handleParsedRequest(
 	surface: RuntimeBridgeSurface,
 	token: string,
 	frameAncestors: string,
+	redemptionState: RuntimeBridgeRedemptionState,
 	clientSocket: Socket,
 	parsed: ParsedHttpRequest,
 	remaining: Buffer,
@@ -344,7 +372,13 @@ function handleParsedRequest(
 		void respondToHealthCheck(surface, clientSocket);
 		return;
 	}
-	const auth = authenticate(parsed.requestTarget, parsed.headers, token);
+	const auth = authenticate(
+		parsed.requestTarget,
+		parsed.headers,
+		token,
+		redemptionState,
+		surface.name,
+	);
 	if (auth.status === "query-token") {
 		writeRedirectResponse(clientSocket, auth.redirectLocation, token);
 		return;
@@ -641,9 +675,20 @@ function authenticate(
 	requestTarget: string,
 	headers: Map<string, string[]>,
 	token: string,
+	redemptionState: RuntimeBridgeRedemptionState,
+	surfaceName: string,
 ): AuthResult {
 	const url = requestUrl(requestTarget);
 	if (!url) return { status: "unauthorized" };
+	const redemptionCode = url.searchParams.get(RUNTIME_BRIDGE_REDEMPTION_QUERY_PARAM);
+	if (
+		redemptionCode &&
+		redeemRuntimeBridgeCode(redemptionCode, token, redemptionState, surfaceName)
+	) {
+		url.searchParams.delete(RUNTIME_BRIDGE_REDEMPTION_QUERY_PARAM);
+		const redirectLocation = relativeRedirectLocation(url);
+		return { status: "query-token", redirectLocation: redirectLocation || "/" };
+	}
 	const queryToken = url.searchParams.get("t");
 	if (constantTimeEquals(queryToken, token)) {
 		url.searchParams.delete("t");
@@ -676,7 +721,91 @@ function proxyPath(requestTarget: string): string {
 	const url = requestUrl(requestTarget);
 	if (!url) return "/";
 	url.searchParams.delete("t");
+	url.searchParams.delete(RUNTIME_BRIDGE_REDEMPTION_QUERY_PARAM);
 	return `${url.pathname}${url.search}` || "/";
+}
+
+function redeemRuntimeBridgeCode(
+	code: string,
+	token: string,
+	state: RuntimeBridgeRedemptionState,
+	surfaceName: string,
+): boolean {
+	const claims = verifyRuntimeBridgeRedemptionCode(code, token, state.nowMs());
+	if (!claims) return false;
+	if (claims.runtime !== surfaceName) return false;
+	pruneUsedRedemptionCodes(state, state.nowMs());
+	if (state.usedJtis.has(claims.jti)) return false;
+	state.usedJtis.set(claims.jti, claims.expiresAtMs);
+	return true;
+}
+
+function verifyRuntimeBridgeRedemptionCode(
+	code: string,
+	token: string,
+	nowMs: number,
+): RuntimeBridgeRedemptionClaims | null {
+	if (!token) return null;
+	const parts = code.split(".");
+	if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+	const payloadPart = parts[0];
+	const signaturePart = parts[1];
+	const expectedSignature = hmacSha256Base64Url(token, payloadPart);
+	if (!constantTimeEquals(signaturePart, expectedSignature)) return null;
+	const payload = parseRedemptionPayload(payloadPart);
+	if (!payload) return null;
+	if (payload.expiresAtMs <= nowMs) return null;
+	return payload;
+}
+
+function parseRedemptionPayload(payloadPart: string): RuntimeBridgeRedemptionClaims | null {
+	let raw: unknown;
+	try {
+		raw = JSON.parse(base64UrlDecode(payloadPart).toString("utf8"));
+	} catch {
+		return null;
+	}
+	const parsed = runtimeBridgeRedemptionPayloadSchema.safeParse(raw);
+	if (!parsed.success) return null;
+	return {
+		jti: parsed.data.jti,
+		expiresAtMs: parsed.data.exp * 1000,
+		runtime: parsed.data.runtime,
+	};
+}
+
+const runtimeBridgeRedemptionPayloadSchema = z
+	.object({
+		v: z.literal(1),
+		sub: z.literal(RUNTIME_UI_REDEMPTION_SUBJECT),
+		deployment_id: z.string().min(1),
+		runtime: z.enum(["openclaw", "hermes"]),
+		jti: z.string().min(1).max(128),
+		iat: z.number().int().nonnegative(),
+		exp: z.number().int().nonnegative(),
+	})
+	.strict();
+
+function pruneUsedRedemptionCodes(state: RuntimeBridgeRedemptionState, nowMs: number): void {
+	for (const [jti, expiresAtMs] of state.usedJtis) {
+		if (expiresAtMs <= nowMs) state.usedJtis.delete(jti);
+	}
+}
+
+function hmacSha256Base64Url(token: string, payloadPart: string): string {
+	return base64UrlEncode(
+		createHmac("sha256", Buffer.from(token, "utf8")).update(payloadPart, "ascii").digest(),
+	);
+}
+
+function base64UrlEncode(raw: Buffer): string {
+	return raw.toString("base64").replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+function base64UrlDecode(value: string): Buffer {
+	const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+	const padding = "=".repeat((4 - (normalized.length % 4)) % 4);
+	return Buffer.from(`${normalized}${padding}`, "base64");
 }
 
 function parseCookies(values: string[] | undefined): Map<string, string> {

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -342,11 +342,21 @@ export const hostedRuntimeManifestSchema = z.preprocess(
 			}
 			const surfaces = manifest.bridge?.surfaces ?? [];
 			if (manifest.runtime === "openclaw" && surfaces.length > 0) {
-				ctx.addIssue({
-					code: "custom",
-					message: "openclaw is exposed natively and must not declare bridge surfaces",
-					path: ["bridge", "surfaces"],
-				});
+				const surface = surfaces.at(0);
+				if (
+					surfaces.length !== 1 ||
+					surface?.name !== "openclaw" ||
+					surface?.kind !== "control-ui" ||
+					surface?.listenPort !== 28789 ||
+					surface?.upstreamHost !== "127.0.0.1" ||
+					surface?.upstreamPort !== 18789
+				) {
+					ctx.addIssue({
+						code: "custom",
+						message: "openclaw bridge surface must be openclaw control-ui 28789 -> 127.0.0.1:18789",
+						path: ["bridge", "surfaces"],
+					});
+				}
 			}
 			if (manifest.runtime === "hermes") {
 				if (surfaces.length !== 1) {

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -741,7 +741,18 @@ function validateManifestSemantics(manifest: RuntimeManifest, paths: RuntimePath
 		}
 		const surfaces = manifest.bridge?.surfaces ?? [];
 		if (runtime === "openclaw" && surfaces.length > 0) {
-			errors.push("openclaw runtime must not declare runtime bridge surfaces");
+			const surface = surfaces[0];
+			if (
+				surfaces.length !== 1 ||
+				!surface ||
+				surface.name !== "openclaw" ||
+				surface.kind !== "control-ui" ||
+				surface.listenPort !== 28789 ||
+				surface.upstreamHost !== "127.0.0.1" ||
+				surface.upstreamPort !== 18789
+			) {
+				errors.push("openclaw bridge surface must be openclaw control-ui 28789 -> 127.0.0.1:18789");
+			}
 		}
 		if (runtime === "hermes") {
 			const surface = surfaces[0];

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -2828,11 +2828,9 @@ function openClawGatewayHostedPatch(manifest: RuntimeManifest): Record<string, u
 				? {
 						controlUi: {
 							allowedOrigins,
-							// OpenClaw is exposed natively in v2 hosted manifests, not through
-							// Clawdi runtime bridge surfaces, so the first proxied Control UI
-							// load has no separate bridge flow that can complete OpenClaw device
-							// pairing before the operator session connects. Gateway token auth is
-							// the hosted boundary for this Control UI path.
+							// Clawdi's runtime bridge owns browser auth for hosted Control UI
+							// traffic, so OpenClaw's local device-auth prompt would be a second
+							// owner gate behind the already-authenticated edge.
 							dangerouslyDisableDeviceAuth: true,
 						},
 					}

--- a/packages/cli/tests/runtime-bridge.test.ts
+++ b/packages/cli/tests/runtime-bridge.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test";
+import { createHmac } from "node:crypto";
 import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
 import { connect, createServer as createNetServer, type Server as NetServer } from "node:net";
 import {
 	RUNTIME_BRIDGE_COOKIE,
 	RUNTIME_BRIDGE_FRAME_ANCESTORS_ENV,
+	RUNTIME_BRIDGE_REDEMPTION_QUERY_PARAM,
 	RUNTIME_BRIDGE_SURFACES_ENV,
 	startRuntimeBridge,
 } from "../src/runtime/bridge";
@@ -199,6 +201,81 @@ describe("runtime bridge", () => {
 			expect(redirect.headers.get("set-cookie") ?? "").toContain(
 				`${RUNTIME_BRIDGE_COOKIE}=hermes-token`,
 			);
+		} finally {
+			await bridge.close();
+			await close(upstream);
+		}
+	});
+
+	it("redeems short-lived one-time browser auth codes before cookie-authorized HTTP", async () => {
+		const seen: string[] = [];
+		const upstream = createServer((req, res) => {
+			seen.push(req.url ?? "");
+			res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8" });
+			res.end("openclaw-ui");
+		});
+		await listen(upstream, "127.0.0.1", 0);
+		const bridge = await startRuntimeBridge({
+			token: "redemption-secret",
+			surfaces: [
+				{
+					...OPENCLAW_SURFACE,
+					listenHost: "127.0.0.1",
+					listenPort: 0,
+					upstreamPort: serverPort(upstream),
+				},
+			],
+		});
+		const bridgePort = bridge.surfaces[0]?.listenPort;
+		if (bridgePort === undefined) throw new Error("bridge did not expose a port");
+		try {
+			const code = runtimeUiRedemptionCode("redemption-secret", {
+				jti: "single-use-code",
+				exp: Math.floor(Date.now() / 1000) + 60,
+			});
+			const redirect = await fetch(
+				`http://127.0.0.1:${bridgePort}/control?x=1&${RUNTIME_BRIDGE_REDEMPTION_QUERY_PARAM}=${code}`,
+				{ redirect: "manual" },
+			);
+			expect(redirect.status).toBe(302);
+			expect(redirect.headers.get("location")).toBe("control?x=1");
+			const setCookie = redirect.headers.get("set-cookie") ?? "";
+			expect(setCookie).toContain(`${RUNTIME_BRIDGE_COOKIE}=redemption-secret`);
+			expect(seen).toEqual([]);
+
+			const replay = await fetch(
+				`http://127.0.0.1:${bridgePort}/control?${RUNTIME_BRIDGE_REDEMPTION_QUERY_PARAM}=${code}`,
+				{ redirect: "manual" },
+			);
+			expect(replay.status).toBe(401);
+
+			const expiredCode = runtimeUiRedemptionCode("redemption-secret", {
+				jti: "expired-code",
+				exp: Math.floor(Date.now() / 1000) - 1,
+			});
+			const expired = await fetch(
+				`http://127.0.0.1:${bridgePort}/control?${RUNTIME_BRIDGE_REDEMPTION_QUERY_PARAM}=${expiredCode}`,
+				{ redirect: "manual" },
+			);
+			expect(expired.status).toBe(401);
+
+			const wrongRuntimeCode = runtimeUiRedemptionCode("redemption-secret", {
+				jti: "wrong-runtime",
+				runtime: "hermes",
+			});
+			const wrongRuntime = await fetch(
+				`http://127.0.0.1:${bridgePort}/control?${RUNTIME_BRIDGE_REDEMPTION_QUERY_PARAM}=${wrongRuntimeCode}`,
+				{ redirect: "manual" },
+			);
+			expect(wrongRuntime.status).toBe(401);
+
+			const proxied = await fetch(
+				`http://127.0.0.1:${bridgePort}/control?x=1&${RUNTIME_BRIDGE_REDEMPTION_QUERY_PARAM}=ignored`,
+				{ headers: { Cookie: `${RUNTIME_BRIDGE_COOKIE}=redemption-secret` } },
+			);
+			expect(proxied.status).toBe(200);
+			expect(await proxied.text()).toBe("openclaw-ui");
+			expect(seen).toEqual(["/control?x=1"]);
 		} finally {
 			await bridge.close();
 			await close(upstream);
@@ -878,6 +955,44 @@ function hasForwardingHeader(rawRequest: string): boolean {
 			lowerName.startsWith("cf-")
 		);
 	});
+}
+
+function runtimeUiRedemptionCode(
+	token: string,
+	overrides: Partial<{
+		deployment_id: string;
+		runtime: "openclaw" | "hermes";
+		jti: string;
+		iat: number;
+		exp: number;
+	}> = {},
+): string {
+	const now = Math.floor(Date.now() / 1000);
+	const payload = {
+		deployment_id: "hdep_test",
+		exp: now + 60,
+		iat: now,
+		jti: "test-redemption",
+		runtime: "openclaw",
+		sub: "v2_hosted_runtime_ui",
+		v: 1,
+		...overrides,
+	};
+	const payloadPart = base64UrlEncode(Buffer.from(JSON.stringify(sortObject(payload)), "utf8"));
+	const signaturePart = base64UrlEncode(
+		createHmac("sha256", Buffer.from(token, "utf8")).update(payloadPart, "ascii").digest(),
+	);
+	return `${payloadPart}.${signaturePart}`;
+}
+
+function sortObject(value: Record<string, unknown>): Record<string, unknown> {
+	return Object.fromEntries(
+		Object.entries(value).sort(([left], [right]) => left.localeCompare(right)),
+	);
+}
+
+function base64UrlEncode(raw: Buffer): string {
+	return raw.toString("base64").replace(/=/g, "").replace(/\+/g, "-").replace(/\//g, "_");
 }
 
 function listen(server: Server | NetServer, host: string, port: number): Promise<void> {

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -126,6 +126,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v2/deployments/{deployment_id}/runtime-ui/redemption": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create V2 Deployment Runtime Ui Redemption */
+        post: operations["create_v2_deployment_runtime_ui_redemption_v2_deployments__deployment_id__runtime_ui_redemption_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v2/deployments/{deployment_id}/restart": {
         parameters: {
             query?: never;
@@ -654,6 +671,16 @@ export interface components {
              */
             expires_at: string;
         };
+        /** V2DeploymentRuntimeUiRedemptionResponse */
+        V2DeploymentRuntimeUiRedemptionResponse: {
+            /** Url */
+            url: string;
+            /**
+             * Expires At
+             * Format: date-time
+             */
+            expires_at: string;
+        };
         /** V2HostedComputeSubscriptionInfo */
         V2HostedComputeSubscriptionInfo: {
             /** Status */
@@ -888,6 +915,8 @@ export interface components {
             failure_reason?: string | null;
             /** Endpoints */
             endpoints?: string[];
+            /** Native Url */
+            native_url?: string | null;
             /** Openclaw Control Ui Url */
             openclaw_control_ui_url?: string | null;
             /** Hermes Control Ui Url */
@@ -1406,6 +1435,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["V2HostedDeploymentResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_v2_deployment_runtime_ui_redemption_v2_deployments__deployment_id__runtime_ui_redemption_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                deployment_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["V2DeploymentRuntimeUiRedemptionResponse"];
                 };
             };
             /** @description Validation Error */

--- a/scripts/filter-deploy-openapi.py
+++ b/scripts/filter-deploy-openapi.py
@@ -44,6 +44,7 @@ KEEP_OPERATIONS_BY_PATH: dict[str, set[str]] = {
     "/v2/deployments/{deployment_id}/agents/{agent_type}": {"patch"},
     "/v2/deployments/{deployment_id}/agents/{agent_type}/ai-provider": {"patch"},
     "/v2/deployments/{deployment_id}/terminal": {"post"},
+    "/v2/deployments/{deployment_id}/runtime-ui/redemption": {"post"},
     "/v2/deployments/{deployment_id}/restart": {"post"},
     "/v2/deployments/{deployment_id}/start": {"post"},
     "/v2/deployments/{deployment_id}/stop": {"post"},


### PR DESCRIPTION
## Summary

Companion PR for v2 hosted runtime Phase 3 browser auth. Dashboard Open UI actions now request a short-lived deploy-api redemption URL, while the CLI runtime bridge accepts that redemption code and converts it into the existing scoped bridge cookie.

Design basis: hosted runtime UI exposure keeps OpenClaw/Hermes loopback-only behind `runtime bridge`; the bridge owns scoped cookie auth and HTTP/WebSocket proxying. The hosted companion PR removes user-visible token-bearing URLs from deploy-api responses.

## Dashboard flow

- Adds deploy client contract for `POST /v2/deployments/{deployment_id}/runtime-ui/redemption`.
- Header, fullscreen, mobile, and iframe runtime UI paths request redemption before navigation.
- Popup flow reserves `about:blank` synchronously to avoid browser blockers, then navigates to the redemption URL; redemption failures close the reserved blank popup.
- `native_url` is treated as a clean runtime URL, not a token-bearing URL.

## CLI bridge flow

- Adds `clawdi_code` redemption support to `runtime bridge`.
- Verifies HMAC signature using `CLAWDI_RUNTIME_BRIDGE_TOKEN`, expiry, single-use `jti`, and runtime/surface binding.
- On success, strips `clawdi_code`, sets the existing scoped bridge cookie, and redirects to the clean path.
- Keeps legacy `?t=` query-token support server-side for fleet convergence.
- Allows the hosted manifest to declare OpenClaw bridge surface `28789 -> 127.0.0.1:18789`.

## Rollout order

1. Publish this CLI change to the runtime `@beta` image first.
2. Deploy the hosted companion PR after runtime pods can accept `clawdi_code` and OpenClaw bridge surfaces.
3. Keep legacy `?t=` acceptance until existing pods have converged; remove it in a follow-up.

## Verification

- `bun test apps/web/src/hosted/agents/runtime-ui-redemption.test.ts apps/web/src/hosted/runtimes.test.ts`
- `bun test packages/cli/tests/runtime-bridge.test.ts apps/web/src/hosted/agents/runtime-ui-redemption.test.ts apps/web/src/hosted/runtimes.test.ts`
- `bun run check`
- `bun run typecheck`
- `bun test packages/cli` (780 passed)
- `git diff --check`

Hosted companion PR: https://github.com/Clawdi-AI/clawdi-hosted/pull/759