### PR TITLE
Release clawdi 0.12.10-beta.41

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.40",
+	"version": "0.12.10-beta.41",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Version bump → publishes to `beta`. Contains #365 (Phase 3 bridge redemption + OpenClaw loopback surface). Hosted #759 merges after the fleet self-upgrades to this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)