### PR TITLE
Make runtime manifests forward compatible

### DIFF
--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -22,52 +22,44 @@ export const OFFICIAL_INSTALL_ARGS: Record<string, string[]> = {
 const hostedRuntimeChoiceSchema = z.enum(["openclaw", "hermes"]);
 const semverSchema = z.string().min(1).refine(isValidSemver, "must be a semver string");
 
-const installSchema = z
-	.object({
-		authority: z.literal("official"),
-		method: z.literal("official-installer"),
-		url: z.string().url(),
-		home: z.string().min(1),
-		args: z.array(z.string()).default([]),
-	})
-	.strict();
+const installSchema = z.object({
+	authority: z.literal("official"),
+	method: z.literal("official-installer"),
+	url: z.string().url(),
+	home: z.string().min(1),
+	args: z.array(z.string()).default([]),
+});
 
-const runtimeSchema = z
-	.object({
-		enabled: z.boolean(),
-		updateChannel: z.string().min(1).optional(),
-		install: installSchema.optional(),
-		run: runtimeRunSettingsSchema.optional(),
-		services: z.record(runtimeServiceNameSchema, runtimeRunSettingsSchema).default({}),
-		provider_ids: z.array(z.string().min(1)).optional(),
-		primary_model: z
-			.object({
-				provider_id: z.string().min(1),
-				model: z.string().min(1),
-			})
-			.strict()
-			.optional(),
-	})
-	.strict();
+const runtimeSchema = z.object({
+	enabled: z.boolean(),
+	updateChannel: z.string().min(1).optional(),
+	install: installSchema.optional(),
+	run: runtimeRunSettingsSchema.optional(),
+	services: z.record(runtimeServiceNameSchema, runtimeRunSettingsSchema).default({}),
+	provider_ids: z.array(z.string().min(1)).optional(),
+	primary_model: z
+		.object({
+			provider_id: z.string().min(1),
+			model: z.string().min(1),
+		})
+		.optional(),
+});
 
-const cliPayloadPolicySchema = z
-	.object({
-		version: z.string().min(1).optional(),
-		channel: z.string().min(1).optional(),
-		source: z.string().min(1).optional(),
-		packageSpec: z.string().min(1).optional(),
-	})
-	.passthrough();
+const cliPayloadPolicySchema = z.object({
+	version: z.string().min(1).optional(),
+	channel: z.string().min(1).optional(),
+	source: z.string().min(1).optional(),
+	packageSpec: z.string().min(1).optional(),
+	registry: z.string().min(1).optional(),
+});
 
 const sha256Schema = z.string().regex(/^[a-fA-F0-9]{64}$/);
 
-export const mitmproxyArtifactSchema = z
-	.object({
-		version: z.string().min(1),
-		url: z.string().url(),
-		sha256: sha256Schema,
-	})
-	.strict();
+export const mitmproxyArtifactSchema = z.object({
+	version: z.string().min(1),
+	url: z.string().url(),
+	sha256: sha256Schema,
+});
 
 export type MitmproxyArtifactPin = z.infer<typeof mitmproxyArtifactSchema>;
 
@@ -76,19 +68,15 @@ export const DEFAULT_CLAWDI_CLI_POLICY = {
 	packageSpec: "clawdi@latest",
 } satisfies z.infer<typeof cliPayloadPolicySchema>;
 
-const liveSyncAgentSchema = z
-	.object({
-		agentType: runtimeNameSchema,
-		environmentId: z.string().min(1),
-	})
-	.strict();
+const liveSyncAgentSchema = z.object({
+	agentType: runtimeNameSchema,
+	environmentId: z.string().min(1),
+});
 
-const liveSyncSchema = z
-	.object({
-		enabled: z.boolean().optional(),
-		agents: z.array(liveSyncAgentSchema).default([]),
-	})
-	.strict();
+const liveSyncSchema = z.object({
+	enabled: z.boolean().optional(),
+	agents: z.array(liveSyncAgentSchema).default([]),
+});
 
 const tcpPortSchema = z.number().int().min(1).max(65535);
 const runtimeBridgeSurfaceNameSchema = z
@@ -97,35 +85,29 @@ const runtimeBridgeSurfaceNameSchema = z
 	.max(64)
 	.regex(/^[a-z0-9][a-z0-9._-]*$/, "must be a lowercase surface id");
 
-export const runtimeBridgeSurfaceSchema = z
-	.object({
-		name: runtimeBridgeSurfaceNameSchema,
-		kind: z.enum(["control-ui"]),
-		listenHost: z.string().min(1).optional(),
-		listenPort: tcpPortSchema,
-		upstreamHost: z.string().min(1).default("127.0.0.1"),
-		upstreamPort: tcpPortSchema,
-	})
-	.strict();
+export const runtimeBridgeSurfaceSchema = z.object({
+	name: runtimeBridgeSurfaceNameSchema,
+	kind: z.enum(["control-ui"]),
+	listenHost: z.string().min(1).optional(),
+	listenPort: tcpPortSchema,
+	upstreamHost: z.string().min(1).default("127.0.0.1"),
+	upstreamPort: tcpPortSchema,
+});
 
-const runtimeBridgeSchema = z
-	.object({
-		surfaces: z.array(runtimeBridgeSurfaceSchema).default([]),
-	})
-	.strict();
+const runtimeBridgeSchema = z.object({
+	surfaces: z.array(runtimeBridgeSurfaceSchema).default([]),
+});
 
-const runtimeProjectionSchema = z
-	.object({
-		sourceSchemaVersion: z.string().min(1).optional(),
-		system: z.unknown().nullable().optional(),
-		providers: z.record(z.string().min(1), z.unknown()).optional(),
-		channels: z.record(z.string().min(1), z.unknown()).optional(),
-		channelCredentials: z.array(z.unknown()).optional(),
-		aiProviders: z.record(z.string().min(1), z.unknown()).optional(),
-		mcp: z.unknown().optional(),
-		tools: z.unknown().optional(),
-	})
-	.strict();
+const runtimeProjectionSchema = z.object({
+	sourceSchemaVersion: z.string().min(1).optional(),
+	system: z.unknown().nullable().optional(),
+	providers: z.record(z.string().min(1), z.unknown()).optional(),
+	channels: z.record(z.string().min(1), z.unknown()).optional(),
+	channelCredentials: z.array(z.unknown()).optional(),
+	aiProviders: z.record(z.string().min(1), z.unknown()).optional(),
+	mcp: z.unknown().optional(),
+	tools: z.unknown().optional(),
+});
 
 const runtimeDesiredStateShape = {
 	deploymentId: z.string().min(1),
@@ -137,11 +119,9 @@ const runtimeDesiredStateShape = {
 	expiresAt: z.string().min(1).optional(),
 	workspaceRoot: z.string().min(1).optional(),
 	runtime: hostedRuntimeChoiceSchema.optional(),
-	controlPlane: z
-		.object({
-			apiUrl: z.string().url(),
-		})
-		.strict(),
+	controlPlane: z.object({
+		apiUrl: z.string().url(),
+	}),
 	clawdiCli: cliPayloadPolicySchema.optional(),
 	mitmproxy: mitmproxyArtifactSchema.optional(),
 	runtimes: z.record(runtimeNameSchema, runtimeSchema),
@@ -154,82 +134,142 @@ const runtimeDesiredStateShape = {
 			cacheManifest: z.boolean().optional(),
 			allowOfflineBoot: z.boolean().optional(),
 		})
-		.strict()
 		.default({}),
 };
+
+function addForbiddenFieldIssue(ctx: z.RefinementCtx, field: string, message?: string): void {
+	ctx.addIssue({
+		code: "custom",
+		message: message ?? `Unrecognized key: "${field}"`,
+		path: [field],
+	});
+}
 
 export const manifestSchema = z
 	.object({
 		schemaVersion: z.literal(RUNTIME_DESIRED_STATE_SCHEMA_VERSION),
 		...runtimeDesiredStateShape,
+		secrets: z.unknown().optional(),
 	})
-	.strict();
-
-const hostedRuntimeInstallSchema = z
-	.object({
-		source: z.literal("official"),
-		channel: z.string().min(1).optional(),
-		args: z.array(z.string()).optional(),
+	.superRefine((manifest, ctx) => {
+		if ("secrets" in manifest) addForbiddenFieldIssue(ctx, "secrets");
 	})
-	.passthrough();
+	.transform(({ secrets: _secrets, ...manifest }) => manifest);
 
-const hostedRuntimeEntrySchema = z
+const hostedControlPlaneSchema = z
 	.object({
-		enabled: z.boolean(),
-		install: hostedRuntimeInstallSchema.optional(),
-		run: runtimeRunSettingsSchema.optional(),
-		services: z.record(runtimeServiceNameSchema, runtimeRunSettingsSchema).default({}),
-		provider_ids: z.array(z.string().min(1)).optional(),
-		providerIds: z.array(z.string().min(1)).optional(),
-		primary_model: z
-			.union([
-				z.string().min(1),
-				z
-					.object({
-						provider_id: z.string().min(1).optional(),
-						providerId: z.string().min(1).optional(),
-						model: z.string().min(1),
-					})
-					.passthrough(),
-			])
-			.optional(),
-		primaryModel: z
-			.object({
+		manifestUrl: z.string().url().optional(),
+		cloudApiUrl: z.string().url().optional(),
+		apiUrl: z.unknown().optional(),
+	})
+	.superRefine((controlPlane, ctx) => {
+		if ("apiUrl" in controlPlane) {
+			addForbiddenFieldIssue(ctx, "apiUrl", "hosted runtime controlPlane must use cloudApiUrl");
+		}
+	})
+	.transform(({ apiUrl: _apiUrl, ...controlPlane }) => controlPlane);
+
+const hostedRuntimeInstallSchema = z.object({
+	source: z.literal("official"),
+	channel: z.string().min(1).optional(),
+	args: z.array(z.string()).optional(),
+});
+
+const hostedRuntimeEntrySchema = z.object({
+	enabled: z.boolean(),
+	install: hostedRuntimeInstallSchema.optional(),
+	run: runtimeRunSettingsSchema.optional(),
+	services: z.record(runtimeServiceNameSchema, runtimeRunSettingsSchema).default({}),
+	provider_ids: z.array(z.string().min(1)).optional(),
+	providerIds: z.array(z.string().min(1)).optional(),
+	primary_model: z
+		.union([
+			z.string().min(1),
+			z.object({
 				provider_id: z.string().min(1).optional(),
 				providerId: z.string().min(1).optional(),
 				model: z.string().min(1),
-			})
-			.passthrough()
-			.optional(),
-		paths: z
-			.object({
-				home: z.string().min(1).optional(),
-				workspace: z.string().min(1).optional(),
-			})
-			.passthrough()
-			.optional(),
-	})
-	.passthrough();
+			}),
+		])
+		.optional(),
+	primaryModel: z
+		.object({
+			provider_id: z.string().min(1).optional(),
+			providerId: z.string().min(1).optional(),
+			model: z.string().min(1),
+		})
+		.optional(),
+	paths: z
+		.object({
+			home: z.string().min(1).optional(),
+			workspace: z.string().min(1).optional(),
+		})
+		.optional(),
+});
 
-const hostedProviderAuthSchema = z.discriminatedUnion("type", [
-	z
+const hostedProviderCapabilitiesSchema = z.object({
+	chat: z.boolean().optional(),
+	responses: z.boolean().optional(),
+	tools: z.boolean().optional(),
+	vision: z.boolean().optional(),
+	embeddings: z.boolean().optional(),
+	image_generation: z.boolean().optional(),
+});
+
+const hostedProviderModelCostSchema = z.object({
+	input: z.number().nonnegative(),
+	output: z.number().nonnegative(),
+	cache_read: z.number().nonnegative().optional(),
+	cache_write: z.number().nonnegative().optional(),
+});
+
+const hostedProviderModelSchema = z.object({
+	id: z.string().min(1),
+	label: z.string().min(1).optional(),
+	alias: z.string().min(1).optional(),
+	api_mode: z.string().min(1).optional(),
+	input_modalities: z.array(z.string().min(1)).optional(),
+	supports_vision: z.boolean().optional(),
+	supports_tools: z.boolean().optional(),
+	supports_reasoning: z.boolean().optional(),
+	context_window: z.number().int().positive().optional(),
+	max_tokens: z.number().int().positive().optional(),
+	cost: hostedProviderModelCostSchema.optional(),
+	capabilities: hostedProviderCapabilitiesSchema.optional(),
+});
+
+const hostedProviderAuthSchema = z.object({
+	type: z.string().min(1),
+	tool: z.string().min(1).optional(),
+	profile: z.string().min(1).optional(),
+	source: z.string().min(1).optional(),
+	ref: z.string().min(1).optional(),
+});
+
+const hostedProviderSchema = z.object({
+	kind: z.string().min(1).optional(),
+	type: z.string().min(1).optional(),
+	baseUrl: z.string().url().optional(),
+	base_url: z.string().url().optional(),
+	model: z.string().min(1).optional(),
+	models: z.array(hostedProviderModelSchema).optional(),
+	apiMode: z.string().min(1).optional(),
+	api_mode: z.string().min(1).optional(),
+	managed_by: z.string().min(1).optional(),
+	runtimeEnvName: z.string().min(1).optional(),
+	runtime_env_name: z.string().min(1).optional(),
+	apiKeySecretRef: z.string().min(1).nullable().optional(),
+	api_key_secret_ref: z.string().min(1).nullable().optional(),
+	apiKeyRequired: z.boolean().optional(),
+	status: z.string().min(1).optional(),
+	error: z
 		.object({
-			type: z.literal("agent_profile"),
-			tool: z.literal("codex"),
-			profile: z.string().min(1),
+			code: z.string().min(1),
+			message: z.string().min(1).optional(),
 		})
-		.strict(),
-	z
-		.object({
-			type: z.literal("api_key"),
-		})
-		.passthrough(),
-	z
-		.object({
-			type: z.literal("secret_ref"),
-		})
-		.passthrough(),
-]);
+		.optional(),
+	auth: hostedProviderAuthSchema.optional(),
+});
 
 export const hostedRuntimeManifestSchema = z.preprocess(
 	(value) => {
@@ -263,50 +303,13 @@ export const hostedRuntimeManifestSchema = z.preprocess(
 					workspace: z.string().min(1).optional(),
 					persistentPaths: z.array(z.string().min(1)).optional(),
 				})
-				.passthrough()
 				.optional(),
-			controlPlane: z
-				.object({
-					manifestUrl: z.string().url().optional(),
-					cloudApiUrl: z.string().url().optional(),
-				})
-				.passthrough()
-				.refine((value) => !("apiUrl" in value), {
-					message: "hosted runtime controlPlane must use cloudApiUrl",
-					path: ["apiUrl"],
-				}),
+			controlPlane: hostedControlPlaneSchema,
 			clawdiCli: cliPayloadPolicySchema.optional(),
 			mitmproxy: mitmproxyArtifactSchema.optional(),
 			runtimes: z.record(runtimeNameSchema, hostedRuntimeEntrySchema),
 			bridge: runtimeBridgeSchema.optional(),
-			providers: z
-				.record(
-					z.string().min(1),
-					z
-						.object({
-							kind: z.string().min(1).optional(),
-							type: z.string().min(1).optional(),
-							baseUrl: z.string().url().optional(),
-							model: z.string().min(1).optional(),
-							models: z.array(z.unknown()).optional(),
-							apiMode: z.string().min(1).optional(),
-							managed_by: z.enum(["user", "clawdi"]).optional(),
-							runtimeEnvName: z.string().min(1).optional(),
-							apiKeySecretRef: z.string().min(1).nullable().optional(),
-							apiKeyRequired: z.boolean().optional(),
-							status: z.enum(["ok", "error", "disabled"]).optional(),
-							error: z
-								.object({
-									code: z.string().min(1),
-									message: z.string().min(1).optional(),
-								})
-								.passthrough()
-								.optional(),
-							auth: hostedProviderAuthSchema.optional(),
-						})
-						.passthrough(),
-				)
-				.optional(),
+			providers: z.record(z.string().min(1), hostedProviderSchema).optional(),
 			liveSync: liveSyncSchema.optional(),
 			mitmProfiles: z.unknown().optional(),
 			mcp: z.unknown().optional(),
@@ -316,10 +319,8 @@ export const hostedRuntimeManifestSchema = z.preprocess(
 					cacheManifest: z.boolean().optional(),
 					allowOfflineBoot: z.boolean().optional(),
 				})
-				.passthrough()
 				.optional(),
 		})
-		.strict()
 		.superRefine((manifest, ctx) => {
 			const runtimeKeys = Object.keys(manifest.runtimes);
 			const unexpectedRuntimeKeys = runtimeKeys.filter((runtime) => runtime !== manifest.runtime);
@@ -389,12 +390,10 @@ export const hostedRuntimeManifestSchema = z.preprocess(
 		}),
 );
 
-export const hostedRuntimeManifestResponseSchema = z
-	.object({
-		manifest: hostedRuntimeManifestSchema,
-		secretValues: z.record(z.string().min(1), z.string()).default({}),
-	})
-	.strict();
+export const hostedRuntimeManifestResponseSchema = z.object({
+	manifest: hostedRuntimeManifestSchema,
+	secretValues: z.record(z.string().min(1), z.string()).default({}),
+});
 
 export type RuntimeManifest = z.output<typeof manifestSchema>;
 export type RuntimeInstall = z.infer<typeof installSchema>;

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -282,6 +282,52 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(hostedManifestToRuntimeManifest(hostedManifest).runtime).toBe("openclaw");
 	});
 
+	test("strips unknown hosted manifest fields while preserving the known contract", () => {
+		const cleanManifest = {
+			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+			runtime: "openclaw",
+			deploymentId: "hdep_forward_compat",
+			environmentId: "env_forward_compat",
+			instanceId: "hri_forward_compat",
+			generation: 1,
+			issuedAt: "2026-07-01T00:00:00.000Z",
+			controlPlane: {
+				cloudApiUrl: "https://cloud-api.example.test",
+			},
+			runtimes: {
+				openclaw: {
+					enabled: true,
+					run: {
+						command: "openclaw",
+						args: ["gateway", "run"],
+						env: {},
+						prependPath: [],
+					},
+				},
+			},
+		};
+
+		const parsed = hostedRuntimeManifestSchema.parse({
+			...cleanManifest,
+			futureTopLevelField: { deployApiCanShipFirst: true },
+			runtimes: {
+				openclaw: {
+					...cleanManifest.runtimes.openclaw,
+					futureRuntimeField: "ignored",
+					run: {
+						...cleanManifest.runtimes.openclaw.run,
+						futureRunField: "ignored",
+					},
+				},
+			},
+		});
+
+		expect(parsed).toEqual(hostedRuntimeManifestSchema.parse(cleanManifest));
+		expect(parsed).not.toHaveProperty("futureTopLevelField");
+		expect(parsed.runtimes.openclaw).not.toHaveProperty("futureRuntimeField");
+		expect(parsed.runtimes.openclaw.run).not.toHaveProperty("futureRunField");
+	});
+
 	test("rejects hosted manifests that still declare multiple execution runtimes", () => {
 		expect(() =>
 			hostedRuntimeManifestSchema.parse({

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -152,38 +152,33 @@ const runtimeChannelAgentLinkSchema = z
 		status: z.string().min(1),
 		agent_token: z.string().min(1).nullable().optional(),
 	})
-	.passthrough()
 	.transform((link) => ({
 		...link,
 		agent_token: link.agent_token ?? null,
 	}));
 
-const runtimeChannelCredentialSchema = z
-	.object({
-		id: z.string().min(1),
-		account_id: z.string().min(1),
-		agent_link_id: z.string().min(1),
-		agent_id: z.string().min(1),
-		provider: z.string().min(1),
-		kind: z.string().min(1),
-		created_at: z.string().min(1).optional(),
-		jid: z.string().min(1).nullable().optional(),
-		identity_pub_key_hex: z.string().min(1).nullable().optional(),
-		material: z.unknown().optional(),
-	})
-	.passthrough();
+const runtimeChannelCredentialSchema = z.object({
+	id: z.string().min(1),
+	account_id: z.string().min(1),
+	agent_link_id: z.string().min(1),
+	agent_id: z.string().min(1),
+	provider: z.string().min(1),
+	kind: z.string().min(1),
+	created_at: z.string().min(1).optional(),
+	jid: z.string().min(1).nullable().optional(),
+	identity_pub_key_hex: z.string().min(1).nullable().optional(),
+	material: z.unknown().optional(),
+});
 
-const runtimeChannelAccountSchema = z
-	.object({
-		id: z.string().min(1),
-		provider: runtimeChannelProviderSchema,
-		name: z.string().min(1),
-		status: z.string().min(1),
-		visibility: z.enum(["private", "public"]).default("private"),
-		runtime_links: z.array(runtimeChannelAgentLinkSchema).default([]),
-		runtime_credentials: z.array(runtimeChannelCredentialSchema).default([]),
-	})
-	.passthrough();
+const runtimeChannelAccountSchema = z.object({
+	id: z.string().min(1),
+	provider: runtimeChannelProviderSchema,
+	name: z.string().min(1),
+	status: z.string().min(1),
+	visibility: z.enum(["private", "public"]).default("private"),
+	runtime_links: z.array(runtimeChannelAgentLinkSchema).default([]),
+	runtime_credentials: z.array(runtimeChannelCredentialSchema).default([]),
+});
 
 const runtimeChannelsSchema = z.array(z.unknown()).transform((accounts, ctx) => {
 	const allowedAccounts: RuntimeChannelAccount[] = [];

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1491,9 +1491,13 @@ function hostedProviderAuth(
 		if (type === "agent_profile" && tool === "codex" && profile) {
 			return { type: "agent_profile", tool: "codex", profile };
 		}
-		if ((type === "api_key" || type === "secret_ref") && !hasApiKeySecretRef) {
+		if (type === "api_key" || type === "secret_ref") {
+			if (hasApiKeySecretRef) {
+				return { type: "api_key", source: "managed" };
+			}
 			return null;
 		}
+		if (type && type !== "none") return null;
 	}
 	if (hasApiKeySecretRef) {
 		return { type: "api_key", source: "managed" };

--- a/packages/cli/src/runtime/mitm-profiles.ts
+++ b/packages/cli/src/runtime/mitm-profiles.ts
@@ -53,25 +53,19 @@ function isSafeUpstreamBaseUrl(value: string): boolean {
 
 const headerMatcherSchema = z
 	.discriminatedUnion("type", [
-		z
-			.object({
-				type: z.literal("exists"),
-			})
-			.strict(),
-		z
-			.object({
-				type: z.literal("equals"),
-				value: z.string(),
-				prefix: z.string().optional(),
-			})
-			.strict(),
-		z
-			.object({
-				type: z.literal("secretRefEquals"),
-				secretRef: secretRefSchema,
-				prefix: z.string().optional(),
-			})
-			.strict(),
+		z.object({
+			type: z.literal("exists"),
+		}),
+		z.object({
+			type: z.literal("equals"),
+			value: z.string(),
+			prefix: z.string().optional(),
+		}),
+		z.object({
+			type: z.literal("secretRefEquals"),
+			secretRef: secretRefSchema,
+			prefix: z.string().optional(),
+		}),
 	])
 	.describe(
 		"Header matchers must never inline secret values unless type=equals is intentionally public.",
@@ -79,103 +73,82 @@ const headerMatcherSchema = z
 
 const pathMatcherSchema = z
 	.discriminatedUnion("type", [
-		z
-			.object({
-				type: z.literal("equals"),
-				value: z.string().min(1),
-			})
-			.strict(),
-		z
-			.object({
-				type: z.literal("prefix"),
-				value: z.string().min(1),
-			})
-			.strict(),
-		z
-			.object({
-				type: z.literal("secretRefEquals"),
-				secretRef: secretRefSchema,
-				prefix: z.string().default(""),
-				suffix: z.string().default(""),
-			})
-			.strict(),
-		z
-			.object({
-				type: z.literal("secretRefPrefix"),
-				secretRef: secretRefSchema,
-				prefix: z.string().default(""),
-				suffix: z.string().default(""),
-			})
-			.strict(),
+		z.object({
+			type: z.literal("equals"),
+			value: z.string().min(1),
+		}),
+		z.object({
+			type: z.literal("prefix"),
+			value: z.string().min(1),
+		}),
+		z.object({
+			type: z.literal("secretRefEquals"),
+			secretRef: secretRefSchema,
+			prefix: z.string().default(""),
+			suffix: z.string().default(""),
+		}),
+		z.object({
+			type: z.literal("secretRefPrefix"),
+			secretRef: secretRefSchema,
+			prefix: z.string().default(""),
+			suffix: z.string().default(""),
+		}),
 	])
 	.describe("Path matchers allow URL-embedded tokens such as Telegram Bot API tokens.");
 
 const headerSetterSchema = z
 	.union([
 		z.string(),
-		z
-			.object({
-				type: z.literal("secretRef"),
-				secretRef: secretRefSchema,
-				prefix: z.string().default(""),
-			})
-			.strict(),
+		z.object({
+			type: z.literal("secretRef"),
+			secretRef: secretRefSchema,
+			prefix: z.string().default(""),
+		}),
 	])
 	.describe(
 		"Rewrite headers can be literal public values or secretRef-backed values resolved only by the sidecar.",
 	);
 
-const pathReplaceSchema = z
-	.object({
-		type: z.literal("secretRefPrefix"),
-		secretRef: secretRefSchema,
-		replacementSecretRef: secretRefSchema,
-		prefix: z.string().default(""),
-		suffix: z.string().default(""),
-	})
-	.strict();
+const pathReplaceSchema = z.object({
+	type: z.literal("secretRefPrefix"),
+	secretRef: secretRefSchema,
+	replacementSecretRef: secretRefSchema,
+	prefix: z.string().default(""),
+	suffix: z.string().default(""),
+});
 
-const mitmProfileMatchSchema = z
-	.object({
-		scheme: z.enum(["http", "https", "ws", "wss"]).optional(),
-		host: z.string().min(1),
-		pathPrefix: z
-			.string()
-			.min(1)
-			.refine((value) => value.startsWith("/"), "pathPrefix must start with /")
-			.optional(),
-		path: pathMatcherSchema.optional(),
-		headers: z.record(headerNameSchema, headerMatcherSchema).default({}),
-		query: z.record(queryNameSchema, headerMatcherSchema).default({}),
-	})
-	.strict();
+const mitmProfileMatchSchema = z.object({
+	scheme: z.enum(["http", "https", "ws", "wss"]).optional(),
+	host: z.string().min(1),
+	pathPrefix: z
+		.string()
+		.min(1)
+		.refine((value) => value.startsWith("/"), "pathPrefix must start with /")
+		.optional(),
+	path: pathMatcherSchema.optional(),
+	headers: z.record(headerNameSchema, headerMatcherSchema).default({}),
+	query: z.record(queryNameSchema, headerMatcherSchema).default({}),
+});
 
-const mitmProfileRewriteSchema = z
-	.object({
-		upstreamBaseUrl: z
-			.string()
-			.url()
-			.refine(
-				(value) => ["http:", "https:", "ws:", "wss:"].includes(new URL(value).protocol),
-				"upstreamBaseUrl must use http, https, ws, or wss",
-			)
-			.refine(
-				isSafeUpstreamBaseUrl,
-				"upstreamBaseUrl must not include credentials or an unsafe host",
-			)
-			.optional(),
-		preservePath: z.boolean().default(true),
-		pathReplace: pathReplaceSchema.optional(),
-		setHeaders: z.record(headerNameSchema, headerSetterSchema).default({}),
-	})
-	.strict();
+const mitmProfileRewriteSchema = z.object({
+	upstreamBaseUrl: z
+		.string()
+		.url()
+		.refine(
+			(value) => ["http:", "https:", "ws:", "wss:"].includes(new URL(value).protocol),
+			"upstreamBaseUrl must use http, https, ws, or wss",
+		)
+		.refine(isSafeUpstreamBaseUrl, "upstreamBaseUrl must not include credentials or an unsafe host")
+		.optional(),
+	preservePath: z.boolean().default(true),
+	pathReplace: pathReplaceSchema.optional(),
+	setHeaders: z.record(headerNameSchema, headerSetterSchema).default({}),
+});
 
-const mitmProfileLoggingSchema = z
-	.object({
-		redactHeaders: z.array(headerNameSchema).default([]),
-		redactUrlPatterns: z.array(z.string().min(1)).default([]),
-	})
-	.strict();
+const mitmProfileLoggingSchema = z.object({
+	redactHeaders: z.array(headerNameSchema).default([]),
+	redactUrlPatterns: z.array(z.string().min(1)).default([]),
+});
 
 export const mitmProfileSchema = z
 	.object({
@@ -189,7 +162,6 @@ export const mitmProfileSchema = z
 		owner: z.string().min(1).optional(),
 		description: z.string().min(1).optional(),
 	})
-	.strict()
 	.superRefine((profile, ctx) => {
 		if (
 			(profile.kind === "http" || profile.kind === "websocket") &&
@@ -217,21 +189,17 @@ export const mitmProfileSchema = z
 		}
 	});
 
-export const mitmProfileInputBundleSchema = z
-	.object({
-		profiles: z.array(mitmProfileSchema).default([]),
-	})
-	.strict();
+export const mitmProfileInputBundleSchema = z.object({
+	profiles: z.array(mitmProfileSchema).default([]),
+});
 
-export const mitmProfileBundleSchema = z
-	.object({
-		schemaVersion: z.literal("clawdi.mitmProfiles.v1"),
-		generatedAt: z.string().min(1),
-		generation: z.number().int().nonnegative(),
-		instanceId: z.string().min(1),
-		profiles: z.array(mitmProfileSchema),
-	})
-	.strict();
+export const mitmProfileBundleSchema = z.object({
+	schemaVersion: z.literal("clawdi.mitmProfiles.v1"),
+	generatedAt: z.string().min(1),
+	generation: z.number().int().nonnegative(),
+	instanceId: z.string().min(1),
+	profiles: z.array(mitmProfileSchema),
+});
 
 export type MitmProfileInputBundle = z.infer<typeof mitmProfileInputBundleSchema>;
 export type MitmProfileBundle = z.infer<typeof mitmProfileBundleSchema>;

--- a/packages/cli/src/runtime/run-config.ts
+++ b/packages/cli/src/runtime/run-config.ts
@@ -24,16 +24,14 @@ export type SupportedRuntimeName = z.infer<typeof supportedRuntimeSchema>;
 
 const envKeySchema = z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/);
 
-export const runtimeRunSettingsSchema = z
-	.object({
-		command: z.string().min(1).optional(),
-		args: z.array(z.string()).optional(),
-		env: z.record(envKeySchema, z.string()).default({}),
-		secretEnv: z.record(envKeySchema, z.string().min(1)).optional(),
-		cwd: z.string().min(1).optional(),
-		prependPath: z.array(z.string().min(1)).default([]),
-	})
-	.strict();
+export const runtimeRunSettingsSchema = z.object({
+	command: z.string().min(1).optional(),
+	args: z.array(z.string()).optional(),
+	env: z.record(envKeySchema, z.string()).default({}),
+	secretEnv: z.record(envKeySchema, z.string().min(1)).optional(),
+	cwd: z.string().min(1).optional(),
+	prependPath: z.array(z.string().min(1)).default([]),
+});
 
 export type RuntimeRunSettings = z.infer<typeof runtimeRunSettingsSchema>;
 


### PR DESCRIPTION
## Summary

- Make runtime/cloud manifest parsing tolerate additive fields by using Zod's default strip behavior instead of strict rejection or passthrough preservation.
- Strip unknown fields from hosted/runtime manifest objects, manifest-embedded run settings, explicit MITM profile inputs, and `/v1/channels` datasource payloads before they can be cached or re-serialized.
- Preserve fail-closed drift checks for fields that still matter operationally: hosted `controlPlane.apiUrl` and embedded runtime desired-state `secrets` remain rejected.

## Operational win

Additive deploy-api/cloud-api emitter changes can now deploy in either order. Existing CLIs will ignore and strip fields they do not understand, so additive contract rollout no longer needs a publish CLI first -> wait for fleet self-upgrade -> deploy emitter sequence.

`minimumCliVersion` remains the sequencing gate for genuinely breaking changes where an old CLI cannot safely apply the desired state. That should now be the only case requiring a fleet window.

## Zod behavior checked

Verified against the installed `zod@4.4.3`: plain `z.object()` strips unknown keys by default; `.strict()` rejects them; `.passthrough()` preserves them.

## Parser changes

Changed to tolerate-and-strip wire/datasource payloads:

- `packages/cli/src/runtime/manifest-contract.ts`: runtime desired state, hosted runtime manifest response, and nested runtime/install/bridge/liveSync/controlPlane/provider objects.
- `packages/cli/src/runtime/run-config.ts`: `runtimeRunSettingsSchema`, which is embedded in remote manifests under `run` and `services`.
- `packages/cli/src/runtime/mitm-profiles.ts`: MITM profile input/bundle objects used by hosted manifest `mitmProfiles`.
- `packages/cli/src/runtime/manifest-source.ts`: `/v1/channels` account/link/credential datasource payloads.

Deliberately left strict:

- `packages/cli/src/runtime/manifest-source.ts`: `runtimeSourceSchema` and legacy source auth parse local runtime source config; strictness catches operator typos.
- `packages/cli/src/runtime/run-config.ts`: `runtimeRunConfigSchema` reads generated local run config from disk, not deploy-api/cloud-api wire payloads.
- `packages/cli/src/runtime/manifest.ts`: `liveSyncEnvironmentIndexSchema` reads a generated local index.
- `packages/cli/src/runtime/bridge.ts`: `runtimeBridgeRedemptionPayloadSchema` validates signed bridge redemption token claims, not additive manifest data.

## Verification

- `bun run check`
- `bunx turbo typecheck --filter=clawdi`
- `bun test packages/cli`
