### PR TITLE
Release clawdi 0.12.10-beta.42

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.41",
+	"version": "0.12.10-beta.42",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Version bump → publishes to `beta`. Contains #367 (manifest forward-compat). The last release that needs any sequencing discipline — after the fleet self-upgrades to this, additive contract changes are order-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)