### PR TITLE
Drop legacy runtime bridge token URLs

### DIFF
--- a/packages/cli/src/runtime/bridge.ts
+++ b/packages/cli/src/runtime/bridge.ts
@@ -49,8 +49,8 @@ interface ParsedHttpRequest {
 	rawHeaders: Array<[string, string]>;
 }
 
-interface AuthQueryToken {
-	status: "query-token";
+interface AuthRedeemedCode {
+	status: "redeemed-code";
 	redirectLocation: string;
 }
 
@@ -62,7 +62,7 @@ interface AuthUnauthorized {
 	status: "unauthorized";
 }
 
-type AuthResult = AuthQueryToken | AuthAuthorized | AuthUnauthorized;
+type AuthResult = AuthRedeemedCode | AuthAuthorized | AuthUnauthorized;
 
 interface RuntimeBridgeRedemptionState {
 	usedJtis: Map<string, number>;
@@ -379,7 +379,7 @@ function handleParsedRequest(
 		redemptionState,
 		surface.name,
 	);
-	if (auth.status === "query-token") {
+	if (auth.status === "redeemed-code") {
 		writeRedirectResponse(clientSocket, auth.redirectLocation, token);
 		return;
 	}
@@ -687,13 +687,7 @@ function authenticate(
 	) {
 		url.searchParams.delete(RUNTIME_BRIDGE_REDEMPTION_QUERY_PARAM);
 		const redirectLocation = relativeRedirectLocation(url);
-		return { status: "query-token", redirectLocation: redirectLocation || "/" };
-	}
-	const queryToken = url.searchParams.get("t");
-	if (constantTimeEquals(queryToken, token)) {
-		url.searchParams.delete("t");
-		const redirectLocation = relativeRedirectLocation(url);
-		return { status: "query-token", redirectLocation: redirectLocation || "/" };
+		return { status: "redeemed-code", redirectLocation: redirectLocation || "/" };
 	}
 	const cookie = parseCookies(headers.get("cookie")).get(RUNTIME_BRIDGE_COOKIE) ?? null;
 	if (constantTimeEquals(cookie, token)) return { status: "authorized" };
@@ -720,7 +714,6 @@ function requestUrl(requestTarget: string): URL | null {
 function proxyPath(requestTarget: string): string {
 	const url = requestUrl(requestTarget);
 	if (!url) return "/";
-	url.searchParams.delete("t");
 	url.searchParams.delete(RUNTIME_BRIDGE_REDEMPTION_QUERY_PARAM);
 	return `${url.pathname}${url.search}` || "/";
 }

--- a/packages/cli/tests/runtime-bridge.test.ts
+++ b/packages/cli/tests/runtime-bridge.test.ts
@@ -116,7 +116,7 @@ describe("runtime bridge", () => {
 		}
 	});
 
-	it("authenticates with query token, sets a cookie, and proxies cookie-authorized HTTP", async () => {
+	it("rejects legacy token query params and proxies cookie-authorized HTTP", async () => {
 		const seen: Array<{ url: string; host: string | undefined }> = [];
 		const upstream = createServer((req, res) => {
 			seen.push({ url: req.url ?? "", host: req.headers.host });
@@ -149,17 +149,12 @@ describe("runtime bridge", () => {
 				`http://127.0.0.1:${bridgePort}/control?x=1&t=secret-token&y=2`,
 				{ redirect: "manual" },
 			);
-			expect(redirect.status).toBe(302);
-			expect(redirect.headers.get("location")).toBe("control?x=1&y=2");
-			const setCookie = redirect.headers.get("set-cookie") ?? "";
-			expect(setCookie).toContain(`${RUNTIME_BRIDGE_COOKIE}=secret-token`);
-			expect(setCookie).toContain("Secure");
-			expect(setCookie).toContain("HttpOnly");
-			expect(setCookie).toContain("SameSite=Strict");
-			expect(setCookie).toContain("Path=/");
+			expect(redirect.status).toBe(401);
+			expect(redirect.headers.get("location")).toBeNull();
+			expect(redirect.headers.get("set-cookie")).toBeNull();
 			expect(seen).toEqual([]);
 
-			const proxied = await fetch(`http://127.0.0.1:${bridgePort}/control?x=1&t=ignored`, {
+			const proxied = await fetch(`http://127.0.0.1:${bridgePort}/control?x=1`, {
 				headers: { Cookie: `${RUNTIME_BRIDGE_COOKIE}=secret-token` },
 			});
 			expect(proxied.status).toBe(200);
@@ -172,8 +167,10 @@ describe("runtime bridge", () => {
 		}
 	});
 
-	it("redirects Hermes dashboard query-token logins back to the dashboard path", async () => {
+	it("rejects Hermes dashboard legacy token query-param logins", async () => {
+		let seen = 0;
 		const upstream = createServer((_req, res) => {
+			seen += 1;
 			res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8" });
 			res.end("hermes-dashboard");
 		});
@@ -196,11 +193,10 @@ describe("runtime bridge", () => {
 			const redirect = await fetch(`http://127.0.0.1:${bridgePort}/dashboard?t=hermes-token`, {
 				redirect: "manual",
 			});
-			expect(redirect.status).toBe(302);
-			expect(redirect.headers.get("location")).toBe("dashboard");
-			expect(redirect.headers.get("set-cookie") ?? "").toContain(
-				`${RUNTIME_BRIDGE_COOKIE}=hermes-token`,
-			);
+			expect(redirect.status).toBe(401);
+			expect(redirect.headers.get("location")).toBeNull();
+			expect(redirect.headers.get("set-cookie")).toBeNull();
+			expect(seen).toBe(0);
 		} finally {
 			await bridge.close();
 			await close(upstream);
@@ -711,13 +707,13 @@ describe("runtime bridge", () => {
 			});
 			expect(unauthorized.statusCode).toBe(401);
 
-			const redirect = await websocketRequest({
+			const legacyTokenParam = await websocketRequest({
 				port: bridgePort,
 				path: "/socket?t=ws-token&x=1",
 			});
-			expect(redirect.statusCode).toBe(302);
-			expect(redirect.location).toBe("socket?x=1");
-			expect(redirect.setCookie).toContain(`${RUNTIME_BRIDGE_COOKIE}=ws-token`);
+			expect(legacyTokenParam.statusCode).toBe(401);
+			expect(legacyTokenParam.location).toBe("");
+			expect(legacyTokenParam.setCookie).toBe("");
 
 			const authorized = await websocketRequest({
 				port: bridgePort,


### PR DESCRIPTION
## Summary
- Removed the runtime bridge `?t=` long-lived token acceptance path and the old query-token auth result state.
- Stopped treating `t` as a bridge auth parameter during proxy path construction; bridge auth now enters only through `clawdi_code` redemption or the scoped cookie it sets.
- Updated HTTP, Hermes dashboard, and WebSocket bridge tests so legacy token query params return 401 and do not set cookies.

## Proof
- `packages/cli/tests/runtime-bridge.test.ts`: `rejects legacy token query params and proxies cookie-authorized HTTP` asserts `&t=secret-token` is 401/no cookie/no upstream hit.
- `packages/cli/tests/runtime-bridge.test.ts`: `rejects Hermes dashboard legacy token query-param logins` asserts `?t=hermes-token` is 401/no cookie/no upstream hit.
- `packages/cli/tests/runtime-bridge.test.ts`: `passes through websocket upgrades after auth` asserts `?t=ws-token` upgrade is 401/no cookie while cookie auth still reaches upstream.
- `packages/cli/tests/runtime-bridge.test.ts`: `redeems short-lived one-time browser auth codes before cookie-authorized HTTP` remains green for `clawdi_code` redemption and scoped-cookie access.

## Verification
- `bun run check`
- `bunx turbo typecheck --filter=clawdi`
- `bun test packages/cli`