### PR TITLE
Release clawdi 0.12.10-beta.43

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.42",
+	"version": "0.12.10-beta.43",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Version bump → publishes to `beta`. Contains #369 (drop legacy ?t= bridge path). After this, the only agent-UI auth path in a running pod is the 60s redemption code → scoped cookie flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)