### PR TITLE
Keep slot-occupying hosted deployments visible

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -108,6 +108,8 @@ import {
 	newIdempotencyKey,
 } from "@/hosted/billing/idempotency";
 import {
+	isComputeSubscriptionCancelable,
+	isComputeSubscriptionTermChangeable,
 	planOffers,
 	resolvePerformancePlan,
 	selectOfferForTerm,
@@ -2085,11 +2087,13 @@ function ComputeSettingsSections({
 		currentSubscription?.cancel_at ?? currentSubscription?.current_period_end ?? null;
 	const subscriptionPeriodLabel = formatShortDate(subscriptionEndsAt);
 	const subscriptionCancelPending = !!currentSubscription?.cancel_at_period_end;
+	const subscriptionCancelable = isComputeSubscriptionCancelable(currentSubscription);
 	const canChangeBillingTerm =
 		isPerformance &&
 		!!perfPlan &&
 		!!perfOfferSelection &&
 		!!currentSubscription &&
+		isComputeSubscriptionTermChangeable(currentSubscription) &&
 		!subscriptionCancelPending &&
 		selectedBillingTerm !== currentBillingTerm;
 	const canUpgrade = !isPerformance && deployment.upgrade_available;
@@ -2217,6 +2221,7 @@ function ComputeSettingsSections({
 	}
 
 	async function cancelPerformanceSubscription() {
+		if (!subscriptionCancelable || subscriptionCancelPending) return;
 		try {
 			const res = await cancelSubscription.mutateAsync({ deployment_id: deployment.id });
 			toast.success("Subscription cancellation scheduled", {
@@ -2230,6 +2235,7 @@ function ComputeSettingsSections({
 	}
 
 	async function resumePerformanceSubscription() {
+		if (!subscriptionCancelable || !subscriptionCancelPending) return;
 		try {
 			await resumeSubscription.mutateAsync({ deployment_id: deployment.id });
 			toast.success("Subscription resumed");
@@ -2369,7 +2375,7 @@ function ComputeSettingsSections({
 										type="button"
 										variant="outline"
 										size="sm"
-										disabled={resumeSubscription.isPending}
+										disabled={resumeSubscription.isPending || !subscriptionCancelable}
 										onClick={() =>
 											void runAction(resumePerformanceSubscription).catch(() => undefined)
 										}
@@ -2398,7 +2404,7 @@ function ComputeSettingsSections({
 											type="button"
 											variant="outline"
 											size="sm"
-											disabled={cancelSubscription.isPending}
+											disabled={cancelSubscription.isPending || !subscriptionCancelable}
 										>
 											{cancelSubscription.isPending ? (
 												<Spinner className="size-3.5" />

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -3,6 +3,8 @@ import type { BillingOffer, Plan } from "@/hosted/billing/contracts";
 import {
 	COMPUTE_FREE_SLUG,
 	COMPUTE_PERFORMANCE_SLUG,
+	isComputeSubscriptionCancelable,
+	isComputeSubscriptionTermChangeable,
 	resolveFreePlan,
 	resolvePerformancePlan,
 	selectOfferForTerm,
@@ -106,5 +108,27 @@ describe("selectOfferForTerm", () => {
 			},
 			billingTermMonths: 1,
 		});
+	});
+});
+
+describe("compute subscription action status gates", () => {
+	test("matches the backend cancel and resume status set", () => {
+		expect(isComputeSubscriptionCancelable({ status: "trialing" })).toBe(true);
+		expect(isComputeSubscriptionCancelable({ status: "active" })).toBe(true);
+		expect(isComputeSubscriptionCancelable({ status: "past_due" })).toBe(true);
+
+		expect(isComputeSubscriptionCancelable({ status: "incomplete" })).toBe(false);
+		expect(isComputeSubscriptionCancelable({ status: "unpaid" })).toBe(false);
+		expect(isComputeSubscriptionCancelable({ status: "canceled" })).toBe(false);
+		expect(isComputeSubscriptionCancelable(null)).toBe(false);
+	});
+
+	test("keeps term changes stricter than cancel or resume", () => {
+		expect(isComputeSubscriptionTermChangeable({ status: "trialing" })).toBe(true);
+		expect(isComputeSubscriptionTermChangeable({ status: "active" })).toBe(true);
+
+		expect(isComputeSubscriptionTermChangeable({ status: "past_due" })).toBe(false);
+		expect(isComputeSubscriptionTermChangeable({ status: "unpaid" })).toBe(false);
+		expect(isComputeSubscriptionTermChangeable(undefined)).toBe(false);
 	});
 });

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -2,11 +2,32 @@ import type { BillingOffer, Plan } from "@/hosted/billing/contracts";
 
 export const COMPUTE_FREE_SLUG = "compute_free";
 export const COMPUTE_PERFORMANCE_SLUG = "compute_performance";
+export const COMPUTE_SUBSCRIPTION_CANCELABLE_STATUSES = new Set(["trialing", "active", "past_due"]);
+export const COMPUTE_SUBSCRIPTION_TERM_CHANGEABLE_STATUSES = new Set(["trialing", "active"]);
 
 export type ResolvedBillingOffer = {
 	offer: BillingOffer;
 	billingTermMonths: number;
 };
+
+type ComputeSubscriptionStatusInput =
+	| {
+			status?: string | null;
+	  }
+	| null
+	| undefined;
+
+export function isComputeSubscriptionCancelable(
+	subscription: ComputeSubscriptionStatusInput,
+): boolean {
+	return COMPUTE_SUBSCRIPTION_CANCELABLE_STATUSES.has(subscription?.status ?? "");
+}
+
+export function isComputeSubscriptionTermChangeable(
+	subscription: ComputeSubscriptionStatusInput,
+): boolean {
+	return COMPUTE_SUBSCRIPTION_TERM_CHANGEABLE_STATUSES.has(subscription?.status ?? "");
+}
 
 export function resolveFreePlan(plans: Plan[] | undefined): Plan | undefined {
 	return (

--- a/apps/web/src/hosted/hosted-agents-section.tsx
+++ b/apps/web/src/hosted/hosted-agents-section.tsx
@@ -13,9 +13,10 @@ import { OnboardingCard } from "@/components/dashboard/onboarding-card";
 import { SectionLabel } from "@/components/section-label";
 import { useLegacyEnvIds } from "@/hosted/agents/ownership-sensor";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
-import { legacyConnectedAgentTiles } from "@/hosted/legacy-agent-tiles";
-import { useHostedAgentTiles } from "@/hosted/use-hosted-agent-tiles";
-import { normalizeAgentEnvId } from "@/lib/agent-ownership";
+import {
+	connectedAgentTilesForHostedView,
+	useHostedAgentTiles,
+} from "@/hosted/use-hosted-agent-tiles";
 
 type Env = components["schemas"]["AgentResponse"];
 
@@ -75,26 +76,15 @@ export function HostedAgentsSection({
 	});
 	const legacyEnvIds = useLegacyEnvIds();
 	const legacyOwnershipLoading = showLegacyAgents && legacyEnvIds === null;
-	const ownershipLoading = (showCloudDeployments && hosted.isLoading) || legacyOwnershipLoading;
-	const legacyConnectedTiles = legacyConnectedTilesForAccess({
-		showLegacyAgents,
-		showCloudDeployments,
-		hosted,
+	const hostedDeploymentsLoading = showCloudDeployments && hosted.isLoading;
+	const connectedTiles = connectedAgentTilesForHostedView({
+		selfManagedTiles,
+		claimedEnvIds: hosted.claimedEnvIds,
 		legacyEnvIds,
 		cloudEnvs,
+		showLegacyAgents,
 	});
-	// Drop self-managed tiles whose env is already represented by a
-	// hosted tile. Without this, a hosted deployment's cloud-api env (created
-	// by the admin endpoint) would render twice — once with the
-	// "Clawdi" pill and external manage URL, once as a generic
-	// self-managed tile.
-	// `claimedEnvIds` is lower-cased at insertion in `useHostedAgentTiles`
-	// (see comment there); compare on the lower-cased tile id so an
-	// uppercase / mixed-case env_id on either side still matches.
-	const dedupedSelfManaged = ownershipLoading
-		? []
-		: selfManagedTiles.filter((t) => !isOwnedEnvId(t.id, hosted.claimedEnvIds, legacyEnvIds));
-	const agentTiles: AgentTile[] = [...hosted.tiles, ...legacyConnectedTiles, ...dedupedSelfManaged];
+	const agentTiles: AgentTile[] = [...hosted.tiles, ...connectedTiles];
 	// Empty state must consider BOTH sources of agents. Hidden behind
 	// `!hosted.error` so a transient hosted-fetch failure surfaces in
 	// AgentsCard's error banner instead of dropping silently into the
@@ -104,8 +94,8 @@ export function HostedAgentsSection({
 		!selfManagedError &&
 		selfManagedCount === 0 &&
 		hosted.tiles.length === 0 &&
-		legacyConnectedTiles.length === 0 &&
-		!hosted.isLoading &&
+		connectedTiles.length === 0 &&
+		!hostedDeploymentsLoading &&
 		!legacyOwnershipLoading &&
 		!hosted.error;
 	return (
@@ -119,7 +109,7 @@ export function HostedAgentsSection({
 					error={selfManagedError}
 					onRetry={onRetrySelfManaged}
 					hostedStatus={{
-						isLoading: ownershipLoading,
+						isLoading: hostedDeploymentsLoading || legacyOwnershipLoading,
 						error: hosted.error,
 						onRetry: () => {
 							void hosted.refetch();
@@ -130,40 +120,6 @@ export function HostedAgentsSection({
 			)}
 		</div>
 	);
-}
-
-function legacyConnectedTilesForAccess({
-	showLegacyAgents,
-	showCloudDeployments,
-	hosted,
-	legacyEnvIds,
-	cloudEnvs,
-}: {
-	showLegacyAgents: boolean;
-	showCloudDeployments: boolean;
-	hosted: ReturnType<typeof useHostedAgentTiles>;
-	legacyEnvIds: ReadonlySet<string> | null;
-	cloudEnvs: Env[];
-}): AgentTile[] {
-	if (!showLegacyAgents) return [];
-	// Visible taxonomy in hosted builds:
-	// - Cloud deploy API records render as Clawdi Cloud agent tiles.
-	// - v1 hosted environments render like connected agents in this dashboard.
-	//
-	// When Cloud deployments are enabled, wait for the deployment query before
-	// projecting legacy environments so a Cloud-claimed env is not briefly duplicated.
-	if (showCloudDeployments && hosted.isLoading) return [];
-	if (!legacyEnvIds) return [];
-	return legacyConnectedAgentTiles(cloudEnvs, legacyEnvIds, hosted.claimedEnvIds);
-}
-
-function isOwnedEnvId(
-	id: string,
-	claimedEnvIds: ReadonlySet<string>,
-	legacyEnvIds: ReadonlySet<string> | null,
-): boolean {
-	const envId = normalizeAgentEnvId(id);
-	return Boolean(envId && (claimedEnvIds.has(envId) || legacyEnvIds?.has(envId)));
 }
 
 /**
@@ -197,20 +153,21 @@ export function HostedSecondaryCTA({
 	});
 	const legacyEnvIds = useLegacyEnvIds();
 	const legacyOwnershipLoading = showLegacyAgents && legacyEnvIds === null;
-	const ownershipLoading = (showCloudDeployments && hosted.isLoading) || legacyOwnershipLoading;
-	const legacyConnectedTiles = legacyConnectedTilesForAccess({
-		showLegacyAgents,
-		showCloudDeployments,
-		hosted,
+	const hostedDeploymentsLoading = showCloudDeployments && hosted.isLoading;
+	const legacyConnectedTiles = connectedAgentTilesForHostedView({
+		selfManagedTiles: [],
+		claimedEnvIds: hosted.claimedEnvIds,
 		legacyEnvIds,
 		cloudEnvs,
+		showLegacyAgents,
 	});
-	// Loading: don't flash an empty slot then pop in. Wait for both
-	// sources to settle before deciding whether to show the CTA.
-	if (envsLoading || ownershipLoading) return null;
 	const hasAnyAgent =
 		selfManagedCount > 0 || hosted.tiles.length > 0 || legacyConnectedTiles.length > 0;
-	return hasAnyAgent ? <OnboardingCard variant="additional-agent" /> : null;
+	if (hasAnyAgent) return <OnboardingCard variant="additional-agent" />;
+	// Loading: don't flash an empty slot then pop in. Wait for pending
+	// sources only when none has already proven there is an agent.
+	if (envsLoading || hostedDeploymentsLoading || legacyOwnershipLoading) return null;
+	return null;
 }
 
 /**
@@ -242,19 +199,15 @@ export function HostedAgentsByCompute({
 	});
 	const legacyEnvIds = useLegacyEnvIds();
 	const legacyOwnershipLoading = showLegacyAgents && legacyEnvIds === null;
-	const ownershipLoading = (showCloudDeployments && hosted.isLoading) || legacyOwnershipLoading;
-	const legacyConnectedTiles = legacyConnectedTilesForAccess({
-		showLegacyAgents,
-		showCloudDeployments,
-		hosted,
+	const hostedDeploymentsLoading = showCloudDeployments && hosted.isLoading;
+	const hostedTiles = hosted.tiles;
+	const connectedTiles = connectedAgentTilesForHostedView({
+		selfManagedTiles,
+		claimedEnvIds: hosted.claimedEnvIds,
 		legacyEnvIds,
 		cloudEnvs,
+		showLegacyAgents,
 	});
-	const dedupedSelfManaged = ownershipLoading
-		? []
-		: selfManagedTiles.filter((t) => !isOwnedEnvId(t.id, hosted.claimedEnvIds, legacyEnvIds));
-	const hostedTiles = hosted.tiles;
-	const connectedTiles = [...legacyConnectedTiles, ...dedupedSelfManaged];
 
 	const isEmptyState =
 		!envsLoading &&
@@ -262,7 +215,7 @@ export function HostedAgentsByCompute({
 		selfManagedCount === 0 &&
 		hostedTiles.length === 0 &&
 		connectedTiles.length === 0 &&
-		!hosted.isLoading &&
+		!hostedDeploymentsLoading &&
 		!legacyOwnershipLoading &&
 		!hosted.error;
 	if (isEmptyState) {
@@ -274,7 +227,7 @@ export function HostedAgentsByCompute({
 	}
 
 	if (
-		(envsLoading || ownershipLoading) &&
+		(envsLoading || hostedDeploymentsLoading || legacyOwnershipLoading) &&
 		hostedTiles.length === 0 &&
 		connectedTiles.length === 0
 	) {

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -1,16 +1,20 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import type { components } from "@clawdi/shared/api";
+import type { AgentTile } from "@/components/dashboard/agents-card";
 import type { HostedDeployment } from "@/hosted/billing/contracts";
 
 type HostedAgentTileStatus = typeof import("@/hosted/use-hosted-agent-tiles").hostedAgentTileStatus;
 type DeploymentToTiles = typeof import("@/hosted/use-hosted-agent-tiles").deploymentToTiles;
 type HostedRuntimeStatusView =
 	typeof import("@/hosted/use-hosted-agent-tiles").hostedRuntimeStatusView;
+type UnifiedHostedAgentTiles =
+	typeof import("@/hosted/use-hosted-agent-tiles").unifiedHostedAgentTiles;
 type Env = components["schemas"]["AgentResponse"];
 
 let getTileStatus: HostedAgentTileStatus | null = null;
 let getDeploymentToTiles: DeploymentToTiles | null = null;
 let getRuntimeStatusView: HostedRuntimeStatusView | null = null;
+let getUnifiedHostedAgentTiles: UnifiedHostedAgentTiles | null = null;
 
 beforeAll(async () => {
 	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
@@ -20,6 +24,7 @@ beforeAll(async () => {
 	getTileStatus = module.hostedAgentTileStatus;
 	getDeploymentToTiles = module.deploymentToTiles;
 	getRuntimeStatusView = module.hostedRuntimeStatusView;
+	getUnifiedHostedAgentTiles = module.unifiedHostedAgentTiles;
 });
 
 function hostedAgentTileStatus(rawStatus: string) {
@@ -42,6 +47,11 @@ function hostedDeploymentToTiles(deployment: HostedDeployment, envs: Env[] = [])
 		deployment,
 		new Map(envs.map((item) => [item.id.toLowerCase(), item])),
 	);
+}
+
+function unifiedHostedAgentTiles(args: Parameters<UnifiedHostedAgentTiles>[0]) {
+	if (!getUnifiedHostedAgentTiles) throw new Error("unifiedHostedAgentTiles was not loaded");
+	return getUnifiedHostedAgentTiles(args);
 }
 
 function env(overrides: Partial<Env> = {}): Env {
@@ -103,6 +113,20 @@ function deployment(
 		},
 		created_at: "2026-06-22T00:00:00Z",
 		upgrade_available: false,
+		...overrides,
+	};
+}
+
+function agentTile(overrides: Partial<AgentTile> = {}): AgentTile {
+	return {
+		id: "11111111-1111-4111-8111-111111111111",
+		source: "self-managed",
+		name: "connected-agent",
+		agentType: "openclaw",
+		statusLabel: "Never seen",
+		href: "/agents/11111111-1111-4111-8111-111111111111",
+		active: false,
+		env: null,
 		...overrides,
 	};
 }
@@ -189,6 +213,75 @@ describe("deploymentToTiles", () => {
 			title: "startup_probe_failing; restart_count=2; container failed readiness probe",
 			textClass: "text-destructive-muted-foreground font-medium",
 		});
+	});
+
+	test("routes a failed never-provisioned deployment by deployment id so delete stays reachable", () => {
+		const failureReason = "startup_probe_failing; restart_count=2";
+		const [tile] = hostedDeploymentToTiles(
+			deployment(
+				{
+					status: "failed",
+					failure_reason: failureReason,
+				},
+				{
+					clawdi_cloud_environments: {},
+				},
+			),
+		);
+
+		expect(tile).toMatchObject({
+			id: "dep_123",
+			source: "on-clawdi",
+			href: "/agents/dep_123",
+			manageHref: "/agents/dep_123/settings",
+			env: null,
+			secondaryStatus: {
+				label: "Failure: startup_probe_failing; restart_count=2",
+				title: failureReason,
+				textClass: "text-destructive-muted-foreground font-medium",
+			},
+		});
+	});
+});
+
+describe("unifiedHostedAgentTiles", () => {
+	test("keeps hosted tiles visible while legacy ownership is unresolved", () => {
+		const claimedEnv = "33333333-3333-4333-8333-333333333333";
+		const hostedTile = agentTile({
+			id: "dep_failed",
+			source: "on-clawdi",
+			name: "OpenClaw",
+			href: "/agents/dep_failed",
+			manageHref: "/agents/dep_failed/settings",
+			statusLabel: "Failed",
+			secondaryStatus: {
+				label: "Failure: startup_probe_failing",
+				title: "startup_probe_failing",
+				textClass: "text-destructive-muted-foreground font-medium",
+			},
+		});
+		const claimedSelfManaged = agentTile({
+			id: claimedEnv,
+			name: "cloud-env",
+			href: `/agents/${claimedEnv}`,
+		});
+		const connected = agentTile({
+			id: "44444444-4444-4444-8444-444444444444",
+			name: "connected-agent",
+			href: "/agents/44444444-4444-4444-8444-444444444444",
+		});
+
+		const tiles = unifiedHostedAgentTiles({
+			selfManagedTiles: [claimedSelfManaged, connected],
+			hostedTiles: [hostedTile],
+			claimedEnvIds: new Set([claimedEnv.toLowerCase()]),
+			legacyEnvIds: null,
+			cloudEnvs: [],
+			showLegacyAgents: true,
+		});
+
+		expect(tiles.map((tile) => tile.id)).toEqual(["dep_failed", connected.id]);
+		expect(tiles[0]?.secondaryStatus?.label).toBe("Failure: startup_probe_failing");
 	});
 });
 

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -313,27 +313,54 @@ export function unifiedHostedAgentTiles({
 	selfManagedTiles: AgentTile[];
 	hostedTiles: AgentTile[];
 	claimedEnvIds: ReadonlySet<string>;
-	legacyEnvIds: ReadonlySet<string>;
+	legacyEnvIds: ReadonlySet<string> | null;
+	cloudEnvs: Env[];
+	showLegacyAgents: boolean;
+}): AgentTile[] {
+	return [
+		...hostedTiles,
+		...connectedAgentTilesForHostedView({
+			selfManagedTiles,
+			claimedEnvIds,
+			legacyEnvIds,
+			cloudEnvs,
+			showLegacyAgents,
+		}),
+	];
+}
+
+export function connectedAgentTilesForHostedView({
+	selfManagedTiles,
+	claimedEnvIds,
+	legacyEnvIds,
+	cloudEnvs,
+	showLegacyAgents,
+}: {
+	selfManagedTiles: AgentTile[];
+	claimedEnvIds: ReadonlySet<string>;
+	legacyEnvIds: ReadonlySet<string> | null;
 	cloudEnvs: Env[];
 	showLegacyAgents: boolean;
 }): AgentTile[] {
 	const legacyConnectedTiles = showLegacyAgents
-		? legacyConnectedAgentTiles(cloudEnvs, legacyEnvIds, claimedEnvIds)
+		? legacyEnvIds
+			? legacyConnectedAgentTiles(cloudEnvs, legacyEnvIds, claimedEnvIds)
+			: []
 		: [];
 	const dedupedSelfManaged = selfManagedTiles.filter(
 		(tile) =>
 			!isOwnedEnvId(tile.id, claimedEnvIds, showLegacyAgents ? legacyEnvIds : EMPTY_ENV_IDS),
 	);
-	return [...hostedTiles, ...legacyConnectedTiles, ...dedupedSelfManaged];
+	return [...legacyConnectedTiles, ...dedupedSelfManaged];
 }
 
 function isOwnedEnvId(
 	id: string,
 	claimedEnvIds: ReadonlySet<string>,
-	legacyEnvIds: ReadonlySet<string>,
+	legacyEnvIds: ReadonlySet<string> | null,
 ): boolean {
 	const envId = normalizeAgentEnvId(id);
-	return Boolean(envId && (claimedEnvIds.has(envId) || legacyEnvIds.has(envId)));
+	return Boolean(envId && (claimedEnvIds.has(envId) || legacyEnvIds?.has(envId)));
 }
 
 export function HostedFleetSummary({
@@ -354,11 +381,8 @@ export function HostedFleetSummary({
 		includeDeployments: showCloudDeployments,
 	});
 	const ownership = useAgentOwnership();
-	const legacyEnvIds = showLegacyAgents ? ownership?.legacyEnvIds : EMPTY_ENV_IDS;
-	const ownershipLoading =
-		(showCloudDeployments && hosted.isLoading) || (showLegacyAgents && ownership === null);
+	const legacyEnvIds = showLegacyAgents ? (ownership?.legacyEnvIds ?? null) : EMPTY_ENV_IDS;
 	const tiles = useMemo(() => {
-		if (ownershipLoading || !legacyEnvIds) return selfManagedTiles;
 		return unifiedHostedAgentTiles({
 			selfManagedTiles,
 			hostedTiles: hosted.tiles,
@@ -372,7 +396,6 @@ export function HostedFleetSummary({
 		hosted.claimedEnvIds,
 		hosted.tiles,
 		legacyEnvIds,
-		ownershipLoading,
 		selfManagedTiles,
 		showLegacyAgents,
 	]);


### PR DESCRIPTION
## Invariant

Any hosted deployment that occupies a compute slot must be visible and deletable from the Agents view, even if it never provisioned a cloud-api environment. The Agents page still merges `/v1/agents` with deploy-API deployments, but deploy-API tiles are no longer hidden behind unresolved ownership reads.

## What changed

- `apps/web/src/hosted/hosted-agents-section.tsx:80` and `apps/web/src/hosted/hosted-agents-section.tsx:204` now compose connected/legacy tiles with a shared helper while rendering hosted deploy tiles independently of legacy ownership resolution.
- `apps/web/src/hosted/hosted-agents-section.tsx:229` keeps the skeleton/loading state only when no hosted or connected tile is known yet, instead of returning `null` for the whole hosted surface.
- `apps/web/src/hosted/use-hosted-agent-tiles.ts:305` and `apps/web/src/hosted/use-hosted-agent-tiles.ts:332` allow legacy ownership to be `null`: cloud-claimed self-managed duplicates are still removed, legacy classification waits, and hosted tiles remain visible.
- `apps/web/src/hosted/use-hosted-agent-tiles.ts:366` makes `HostedFleetSummary` use the same composition path so the overview count does not drop hosted deployments while ownership is resolving.
- `apps/web/src/hosted/use-hosted-agent-tiles.ts:246` routes no-env hosted deployments by deployment id; `apps/web/src/hosted/use-hosted-agent-tiles.test.ts:218` pins failed/never-provisioned tiles showing `failure_reason` with `/agents/<deployment_id>/settings` reachable for delete.
- `apps/web/src/hosted/billing/subscription/subscription-utils.ts:5` and `apps/web/src/hosted/agents/hosted-agent-detail.tsx:2090` make subscription cancel/resume and term-change buttons fail closed from the frontend for unsupported statuses.

## Sweep results

- Slot predicate: already clean. `apps/web/src/hosted/deployment-status.ts:128` is the shared `occupiesComputeSlot()` predicate, `apps/web/src/hosted/billing/deploy/deploy-model.ts:4` delegates free-slot usage to it, and `apps/web/src/hosted/billing/deploy/deploy-wizard.tsx:338` uses `usesActiveFreeComputeSlot(deployments.data)`. Targeted `rg` found no other inline compute-slot predicate outside those modules.
- Other deployment-list derivations are not slot predicates: `apps/web/src/hosted/cloud-deployment-management.ts:8` and `apps/web/src/hosted/billing/subscription/welcome-credits-card.tsx:34` intentionally use “has any deployment” for management/onboarding copy, and `apps/web/src/hosted/billing/deploy/deploy-wizard.tsx:659` only snapshots deployment ids for checkout completion.
- Cross-list consistency: `apps/web/src/pages/dashboard/agents/page.tsx:39` still fetches `/v1/agents`, but `apps/web/src/pages/dashboard/agents/page.tsx:60` delegates the actual hosted index to `HostedAgentsByCompute`. `apps/web/src/components/app-sidebar.tsx:1564`, project/skill/session/channel pickers, and connected-agent detail views use `/v1/agents` as minted identity lists; they can omit never-provisioned deployments, but they are not the compute-slot inventory or delete surface.
- Subscription semantics are many lists, not one. Read-only check of `clawdi-hosted` `FETCH_HEAD` found delete-linked-subscription cancelability at `backend/app/v2/hosted/service.py:142` as `{"active", "past_due"}`, cancel/resume route cancelability at `backend/app/v2/compute/routes.py:50` as `{"trialing", "active", "past_due"}`, term changes at `backend/app/v2/compute/routes.py:51` as `{"trialing", "active"}`, payment-management at `backend/app/v2/compute/routes.py:52`, reconciliation at `backend/app/v2/compute/subscription_reconciliation.py:27`, and entitlement/autodeploy semantics through `backend/app/v2/billing/stripe_primitives.py:24` plus `backend/app/v2/compute/subscriptions.py:379`. This PR fixes the frontend cancel/resume and term-change gates only; the backend status-list divergence remains in `clawdi-hosted` and is intentionally not modified here.

## Verification

- `bun run check`
- `bunx turbo typecheck --filter=web --filter=@clawdi/shared`
- `VITE_CLAWDI_API_URL=http://localhost:8000 VITE_CLAWDI_DEPLOY_API_URL=http://localhost:50021 VITE_CLERK_PUBLISHABLE_KEY=pk_test_dummy bun test apps/web/src/hosted/`

Note: plain `bun test apps/web/src/hosted/` fails in this shell before tests run because `VITE_CLERK_PUBLISHABLE_KEY` is unset and `apps/web/src/lib/env.ts` validates Vite env at import time.
