### PR TITLE
Give fetch-level failures a longer retry budget

### DIFF
--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -20,6 +20,14 @@ export function Providers({ children }: { children: React.ReactNode }) {
 							if (error instanceof ApiError && error.status >= 400 && error.status < 500) {
 								return false;
 							}
+							// Fetch-level failures (no HTTP response) get a longer budget
+							// (~7s of backoff) than server errors (~3s): backend deploys
+							// swap containers behind the proxy, and for a few seconds the
+							// proxy answers with its own CORS-less 502, which the browser
+							// can only see as a fetch failure.
+							if (!(error instanceof ApiError)) {
+								return failureCount < 3;
+							}
 							return failureCount < 2;
 						},
 					},

--- a/apps/web/src/hosted/billing/errors.test.ts
+++ b/apps/web/src/hosted/billing/errors.test.ts
@@ -60,8 +60,16 @@ describe("error classification", () => {
 });
 
 describe("billingQueryRetry", () => {
-	test("retries transient errors at most twice", () => {
+	test("network errors get a third retry to ride over the deploy swap window", () => {
 		const e = new BillingNetworkError("offline");
+		expect(billingQueryRetry(0, e)).toBe(true);
+		expect(billingQueryRetry(1, e)).toBe(true);
+		expect(billingQueryRetry(2, e)).toBe(true);
+		expect(billingQueryRetry(3, e)).toBe(false);
+	});
+
+	test("server errors keep the shorter two-retry budget", () => {
+		const e = new BillingApiError(503, "unavailable");
 		expect(billingQueryRetry(0, e)).toBe(true);
 		expect(billingQueryRetry(1, e)).toBe(true);
 		expect(billingQueryRetry(2, e)).toBe(false);

--- a/apps/web/src/hosted/billing/errors.ts
+++ b/apps/web/src/hosted/billing/errors.ts
@@ -85,12 +85,19 @@ export function isRetryableError(error: unknown): boolean {
 }
 
 /**
- * Shared TanStack Query `retry` predicate for the billing surfaces. Retries
- * transient failures up to twice; lets deterministic 4xx (validation errors,
- * auth, not-found, conflict) fall through on the first attempt so their
- * tailored UI shows without a multi-second spinner.
+ * Shared TanStack Query `retry` predicate for the billing surfaces. Lets
+ * deterministic 4xx (validation errors, auth, not-found, conflict) fall
+ * through on the first attempt so their tailored UI shows without a
+ * multi-second spinner.
+ *
+ * Network errors get a longer budget (~7s of backoff) than 5xx/429 (~3s):
+ * every backend deploy swaps containers behind the proxy, and for a few
+ * seconds the proxy answers with its own CORS-less 502, which the browser
+ * can only see as a fetch failure. Two retries give up inside that window
+ * and strand the error banner on a service that is already healthy again.
  */
 export function billingQueryRetry(failureCount: number, error: unknown): boolean {
+	if (isNetworkError(error)) return failureCount < 3;
 	return failureCount < 2 && isRetryableError(error);
 }
 


### PR DESCRIPTION
## Why the owner kept seeing "We couldn't reach the billing service"

Investigated on the prod host. The Coolify rolling update is actually working — dockerd journal for today's #765 deploy:

- `11:26:58` new API container starts (runs alembic, then uvicorn)
- `~11:27:10` healthcheck passes (5s interval)
- `11:27:18` old container gets SIGTERM (exit 143) — only **after** the new one is healthy

So there is no minute-long outage. The residual gap is a few-second race while traefik deregisters the stopping container: uvicorn closes its listener on SIGTERM, traefik keeps routing to it until the `die` event propagates, and those requests get **traefik's own 502 — which has no CORS headers**. A cross-origin response without `Access-Control-Allow-Origin` is invisible to the browser: fetch rejects with a TypeError, which our client maps to `BillingNetworkError` and renders as "check your connection".

The query layer retried network errors twice (~3s of backoff) — smaller than the swap window, so the banner stranded on a healthy service. With ~30 merges today, the owner hit this twice.

## Change

Network-shaped errors (no HTTP response) now retry 3× (~1s+2s+4s of backoff) in both the global `QueryClient` and `billingQueryRetry`. Deterministic 4xx still fail fast; 5xx/429 keep the two-retry budget.

## Also verified while investigating (no code change)

- Backend healthy: only 200/401/402 in the last 30min; migration 0037 landed; CORS preflight from cloud.clawdi.ai correct
- The 402s are the wallet gate correctly denying `/internal/llm/authorize` for an out-of-credits managed-AI key — by design
- Server-side complement (owner, optional): a traefik retry middleware on the Coolify app labels would close the race for all clients; panel is at coolify-internal.faraday.cloud

## Verification

`bun test src/hosted/billing/errors.test.ts` 16 pass · `tsc --noEmit` clean · biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)