### PR TITLE
Drain the cloud-api listener on SIGTERM (same root fix as hosted#767)

### DIFF
--- a/backend/app/runtime_entrypoint.py
+++ b/backend/app/runtime_entrypoint.py
@@ -1,26 +1,59 @@
 import os
+import signal
+import subprocess
 import sys
+import time
 
 API_ROLE = "api"
 CHANNELS_WORKER_ROLE = "channels-worker"
+
+# How long the API keeps serving after SIGTERM. The Coolify proxy (traefik)
+# only stops routing to a container on its die event, so the listener must
+# stay open past the stop signal or every rolling deploy feeds a few seconds
+# of traffic to a closed socket (surfacing in browsers as CORS-less 502s).
+# Together with uvicorn's graceful shutdown this must stay under the 10s
+# docker stop timeout, after which the container is SIGKILLed.
+API_SIGTERM_DRAIN_SECONDS = 5
+
+_API_MIGRATE_ARGS = ["alembic", "upgrade", "head"]
+_API_SERVER_ARGS = [
+    "uvicorn",
+    "app.main:app",
+    "--host",
+    "0.0.0.0",
+    "--port",
+    "8000",
+    "--no-access-log",
+]
 
 
 def _exec(args: list[str]) -> None:
     os.execvp(args[0], args)
 
 
+def _run_api_with_drain() -> int:
+    migrate = subprocess.run(_API_MIGRATE_ARGS)
+    if migrate.returncode != 0:
+        return migrate.returncode
+
+    server = subprocess.Popen(_API_SERVER_ARGS)
+
+    def _drain_then_forward(_signum: int, _frame: object) -> None:
+        time.sleep(API_SIGTERM_DRAIN_SECONDS)
+        server.send_signal(signal.SIGTERM)
+
+    signal.signal(signal.SIGTERM, _drain_then_forward)
+    code = server.wait()
+    # Popen reports death-by-signal as a negative returncode; translate to
+    # the conventional 128+N shell encoding so docker records it faithfully.
+    return 128 - code if code < 0 else code
+
+
 def main() -> None:
     role = os.environ.get("CLAWDI_PROCESS_ROLE", API_ROLE).strip() or API_ROLE
 
     if role == API_ROLE:
-        _exec(
-            [
-                "sh",
-                "-c",
-                "alembic upgrade head && exec uvicorn app.main:app "
-                "--host 0.0.0.0 --port 8000 --no-access-log",
-            ]
-        )
+        raise SystemExit(_run_api_with_drain())
     if role == CHANNELS_WORKER_ROLE:
         _exec(["python", "-m", "app.workers.channels"])
 

--- a/backend/tests/test_runtime_entrypoint.py
+++ b/backend/tests/test_runtime_entrypoint.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import os
+import signal
+import threading
+import time
+
 import pytest
 
 from app import runtime_entrypoint
@@ -16,17 +21,12 @@ def _capture_exec(args: list[str]) -> None:
 
 def test_runtime_entrypoint_defaults_to_api_role(monkeypatch):
     monkeypatch.delenv("CLAWDI_PROCESS_ROLE", raising=False)
-    monkeypatch.setattr(runtime_entrypoint, "_exec", _capture_exec)
+    monkeypatch.setattr(runtime_entrypoint, "_run_api_with_drain", lambda: 0)
 
-    with pytest.raises(ExecCalled) as exc:
+    with pytest.raises(SystemExit) as exc:
         runtime_entrypoint.main()
 
-    assert exc.value.args_list == [
-        "sh",
-        "-c",
-        "alembic upgrade head && exec uvicorn app.main:app "
-        "--host 0.0.0.0 --port 8000 --no-access-log",
-    ]
+    assert exc.value.code == 0
 
 
 def test_runtime_entrypoint_starts_channels_worker_role(monkeypatch):
@@ -51,3 +51,46 @@ def test_runtime_entrypoint_rejects_unknown_role(monkeypatch):
         runtime_entrypoint.main()
 
     assert exc.value.code == 64
+
+
+def test_api_migration_failure_short_circuits(monkeypatch):
+    monkeypatch.setattr(runtime_entrypoint, "_API_MIGRATE_ARGS", ["sh", "-c", "exit 3"])
+    monkeypatch.setattr(
+        runtime_entrypoint,
+        "_API_SERVER_ARGS",
+        ["sh", "-c", "echo server-should-not-start >&2; exit 99"],
+    )
+
+    assert runtime_entrypoint._run_api_with_drain() == 3
+
+
+def test_api_server_exit_code_propagates(monkeypatch):
+    monkeypatch.setattr(runtime_entrypoint, "_API_MIGRATE_ARGS", ["true"])
+    monkeypatch.setattr(runtime_entrypoint, "_API_SERVER_ARGS", ["sh", "-c", "exit 7"])
+
+    assert runtime_entrypoint._run_api_with_drain() == 7
+
+
+def test_api_sigterm_drains_before_forwarding(monkeypatch):
+    """The listener must outlive the routing: on SIGTERM the entrypoint keeps
+    the server running for the drain window, then forwards the signal. Uses a
+    real subprocess and a real signal — no mocks of the mechanism under test.
+    """
+    monkeypatch.setattr(runtime_entrypoint, "_API_MIGRATE_ARGS", ["true"])
+    monkeypatch.setattr(runtime_entrypoint, "_API_SERVER_ARGS", ["sleep", "30"])
+    monkeypatch.setattr(runtime_entrypoint, "API_SIGTERM_DRAIN_SECONDS", 0.3)
+
+    timer = threading.Timer(0.2, os.kill, args=(os.getpid(), signal.SIGTERM))
+    timer.start()
+    started = time.monotonic()
+    try:
+        code = runtime_entrypoint._run_api_with_drain()
+    finally:
+        timer.cancel()
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+    elapsed = time.monotonic() - started
+
+    assert code == 128 + signal.SIGTERM
+    # SIGTERM at ~0.2s + 0.3s drain: the server must not die before ~0.5s.
+    assert elapsed >= 0.5
+    assert elapsed < 5


### PR DESCRIPTION
## Same defect, second service

The owner asked whether clawdi has the same problem as clawdi-hosted — it does. `clawdi-backend` (cloud-api) is the only other HTTP-serving app behind the same Coolify traefik on the same host, and its api role `exec`s straight into uvicorn: SIGTERM closes the listener immediately, traefik keeps routing until the `die` event, and every rolling deploy answers a slice of traffic with traefik's CORS-less 502 (a fetch failure in the browser).

Audit of all Coolify apps on the host: `clawdi-hosted-backend` (fixed in hosted#767), `clawdi-backend` (this PR); workers/beat/scheduler serve no HTTP and need nothing.

## Change

`runtime_entrypoint.py` api role: run the migration, start uvicorn as a child, and on SIGTERM keep serving for 5s (traefik is still routing — those requests succeed), then forward the signal. Death-by-signal → conventional 128+N exit code. channels-worker role untouched. Unlike hosted, this repo's deploy script does not sync Coolify fields, so the fix rides in the image itself — the entrypoint is already repo-owned Python.

## Verification

- 6/6 tests, incl. a drain test using a **real subprocess + real SIGTERM** (no mocks of the mechanism): server must outlive the signal by the drain window and exit 143
- migration-failure short-circuit and exit-code propagation covered
- ruff clean

## v1 note

cloud-api serves v1 and v2; this changes shutdown behavior only — a reliability defect both inherit. Request handling is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)