### PR TITLE
Fix hosted runtime npm metadata cache isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.12.10-beta.46
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.46
+
+Package: `clawdi@0.12.10-beta.46`
+
+### Fixed
+
+- Isolated hosted runtime npm metadata lookups in the managed CLI cache so
+  root bootstrap does not leave root-owned npm files in the runtime user's
+  home directory.
+
 ## Clawdi CLI v0.12.10-beta.45
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.45

--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.45",
+      "version": "0.12.10-beta.46",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.45",
+	"version": "0.12.10-beta.46",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -267,7 +267,7 @@ function isCurrentCliInstall(
 	if ((status.registry ?? null) !== registry) return false;
 	if (status.activePath !== paths.cliManagedBin) return false;
 	if (!status.activeTarget || !isExecutable(status.activeTarget)) return false;
-	if (!installedFloatingSpecVersionIsCurrent(status, packageSpec, registry)) return false;
+	if (!installedFloatingSpecVersionIsCurrent(paths, status, packageSpec, registry)) return false;
 	return isExecutable(paths.cliManagedBin);
 }
 
@@ -276,7 +276,7 @@ function recoverCurrentCliInstallFromActiveLink(
 	packageSpec: string,
 	registry: string | null,
 ): { npmPrefix: string; activeTarget: string; version: string } | null {
-	const desiredVersion = desiredNpmPackageVersion(packageSpec, registry);
+	const desiredVersion = desiredNpmPackageVersion(paths, packageSpec, registry);
 	if (!desiredVersion) return null;
 	const npmPrefix = cliPackagePrefix(paths, desiredVersion);
 	const legacyNpmPrefix = cliPackagePrefixForLegacyHash(paths, packageSpec, registry);
@@ -289,7 +289,8 @@ function recoverCurrentCliInstallFromActiveLink(
 	}
 	if (!isExecutable(activeTarget) || !isExecutable(paths.cliManagedBin)) return null;
 	const version = smokeCliVersion(activeTarget);
-	if (!installedFloatingSpecVersionIsCurrent({ version }, packageSpec, registry)) return null;
+	if (!installedFloatingSpecVersionIsCurrent(paths, { version }, packageSpec, registry))
+		return null;
 	return {
 		npmPrefix: prefixForActiveTarget(activeTarget),
 		activeTarget,
@@ -298,6 +299,7 @@ function recoverCurrentCliInstallFromActiveLink(
 }
 
 function installedFloatingSpecVersionIsCurrent(
+	paths: RuntimePaths,
 	status: Pick<RuntimeCliBootstrapStatus, "version">,
 	packageSpec: string,
 	registry: string | null,
@@ -306,7 +308,7 @@ function installedFloatingSpecVersionIsCurrent(
 	if (exact) return !status.version || status.version === exact;
 	if (!isFloatingNpmPackageSpec(packageSpec)) return true;
 	if (!status.version) return false;
-	const desiredVersion = desiredNpmPackageVersion(packageSpec, registry);
+	const desiredVersion = desiredNpmPackageVersion(paths, packageSpec, registry);
 	return desiredVersion === null || status.version === desiredVersion;
 }
 
@@ -318,11 +320,15 @@ function isFloatingNpmPackageSpec(packageSpec: string): boolean {
 	return !isExactNpmPackageVersion(specifier);
 }
 
-function desiredNpmPackageVersion(packageSpec: string, registry: string | null): string | null {
+function desiredNpmPackageVersion(
+	paths: RuntimePaths,
+	packageSpec: string,
+	registry: string | null,
+): string | null {
 	const exact = exactNpmPackageVersion(packageSpec);
 	if (exact) return exact;
 	if (!isFloatingNpmPackageSpec(packageSpec)) return null;
-	return resolveNpmPackageVersion(packageSpec, registry);
+	return resolveNpmPackageVersion(paths, packageSpec, registry);
 }
 
 function exactNpmPackageVersion(packageSpec: string): string | null {
@@ -338,10 +344,22 @@ function isExactNpmPackageVersion(value: string): boolean {
 	);
 }
 
-function resolveNpmPackageVersion(packageSpec: string, registry: string | null): string | null {
+function resolveNpmPackageVersion(
+	paths: RuntimePaths,
+	packageSpec: string,
+	registry: string | null,
+): string | null {
 	const result = spawnSync(
 		"npm",
-		["view", packageSpec, "version", "--json", ...(registry ? ["--registry", registry] : [])],
+		[
+			"view",
+			packageSpec,
+			"version",
+			"--json",
+			"--cache",
+			paths.cliNpmCache,
+			...(registry ? ["--registry", registry] : []),
+		],
 		{
 			encoding: "utf8",
 			timeout: NPM_VIEW_TIMEOUT_MS,
@@ -437,7 +455,7 @@ function cliInstallPlan(
 	packageSpec: string,
 	registry: string | null,
 ): { installPackageSpec: string; npmPrefix: string; version: string } {
-	const version = desiredNpmPackageVersion(packageSpec, registry);
+	const version = desiredNpmPackageVersion(paths, packageSpec, registry);
 	if (version) {
 		return {
 			installPackageSpec: `clawdi@${version}`,

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -5153,7 +5153,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		}
 	});
 
-	it("runtime CLI update resolves floating npm tags before treating an install as current", () => {
+	it("runtime CLI update resolves floating npm tags through the managed npm cache", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -5167,6 +5167,21 @@ printf 'ActiveState=active\\nSubState=running\\n'
 set -euo pipefail
 printf '%s\\n' "$*" >> '${npmLog}'
 if [ "\${1:-}" = "view" ]; then
+	cache=""
+	while [ "$#" -gt 0 ]; do
+	  if [ "$1" = "--cache" ]; then
+	    cache="$2"
+	    shift 2
+	    continue
+	  fi
+	  shift
+	done
+	if [ -z "$cache" ]; then
+	  echo "missing --cache" >&2
+	  exit 65
+	fi
+	install -d "$cache"
+	touch "$cache/view-proof"
   echo '"0.12.10-beta.22"'
   exit 0
 fi
@@ -5231,8 +5246,15 @@ chmod +x "$prefix/bin/clawdi"
 			const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
 			expect(status.packageSpec).toBe("clawdi@beta");
 			expect(status.version).toBe("0.12.10-beta.22");
-			expect(readFileSync(npmLog, "utf-8")).toContain("view clawdi@beta version --json");
-			expect(readFileSync(npmLog, "utf-8")).toContain("install");
+			const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
+			const npmViewCalls = npmCalls.filter((call) => call.startsWith("view "));
+			expect(npmViewCalls.length).toBeGreaterThan(0);
+			for (const call of npmViewCalls) {
+				expect(call).toContain(`--cache ${paths.cliNpmCache}`);
+			}
+			expect(npmCalls.some((call) => call.startsWith("install "))).toBe(true);
+			expect(existsSync(join(paths.cliNpmCache, "view-proof"))).toBe(true);
+			expect(existsSync(join(home, ".npm"))).toBe(false);
 		} finally {
 			if (previousPath === undefined) delete process.env.PATH;
 			else process.env.PATH = previousPath;


### PR DESCRIPTION
## Summary

- pass `RuntimePaths` through hosted CLI version-resolution helpers
- run every runtime `npm view` with `--cache paths.cliNpmCache`
- add regression coverage proving metadata lookup uses managed state and leaves `$HOME/.npm` untouched
- release the fix as `clawdi@0.12.10-beta.46`

Paired Hosted PR: https://github.com/Clawdi-AI/clawdi-hosted/pull/779

## Verification

- `bun test packages/cli/tests/runtime.test.ts -t "runtime CLI update resolves floating npm tags through the managed npm cache"`
- `bun run --cwd packages/cli test` (785 pass)
- `bun run --cwd packages/cli typecheck`
- `bun run check`
- `bun run --cwd packages/cli check:publish-manifest`
- built and inspected `/tmp/clawdi-beta-46-pack/clawdi-0.12.10-beta.46.tgz`
- built Hosted runnable image from the local tarball
- installer-user smoke passed with an added assertion that `/home/clawdi/.npm` does not exist after root `runtime init`
- real OpenClaw and Hermes official installer smoke passed end to end

## Paired rollout

1. Merge this PR.
2. Publish `clawdi@0.12.10-beta.46` and verify the npm version/dist-tag.
3. Merge the paired Hosted PR.
4. Build and smoke the Hosted runtime image deliberately.

Do not merge the Hosted pin first: beta.46 must exist on npm before the Hosted release workflow resolves it. No database, production, deployment, or tenant changes are included.