### PR TITLE
fix(cli): own numeric egress isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.12.10-beta.47
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.47
+
+Package: `clawdi@0.12.10-beta.47`
+
+### Changed
+
+- Made the CLI the owner of hosted egress module paths, numeric UID/GID
+  permissions, and name-free privilege dropping. Runtime images no longer need
+  a dedicated named egress account.
+
 ## Clawdi CLI v0.12.10-beta.46
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.46

--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.46",
+      "version": "0.12.10-beta.47",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
+++ b/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
@@ -1,0 +1,80 @@
+# ADR-0002: Runtime Image Is a Stable Capability Envelope
+
+**Status:** Accepted
+**Date:** 2026-07-10
+**Deciders:** Clawdi maintainers
+
+## Context
+
+The managed runtime image must remain a generic, stable host envelope rather
+than accumulate Clawdi runtime business logic. Hosted
+[PR #755, "Remove hosted image business logic"](https://github.com/Clawdi-AI/clawdi-hosted/pull/755)
+established this direction. The Hosted architecture describes the host
+envelope as stable and the image as absolutely stable.
+
+Transparent egress needs filesystem paths, private CA and secret ownership, a
+non-root mitmproxy identity, and nftables lifecycle management. Encoding those
+details as named image accounts or image bootstrap logic would couple runtime
+behavior to image releases and split ownership between the image and CLI.
+
+## Decision
+
+The runtime image supplies stable operating-system capabilities. The Clawdi CLI
+owns runtime-local module paths, generated configuration, permissions,
+privilege dropping, and lifecycle behavior.
+
+For transparent egress:
+
+- `clawdi runtime sidecar` remains the only public support command;
+  `mitmdump` is an internal engine.
+- `CLAWDI_EGRESS_UID` and `CLAWDI_EGRESS_GID` are explicit numeric identities,
+  defaulting to `10002`. Both must be decimal Linux IDs from `1` through
+  `4294967294`; `0` and the `4294967295` chown sentinel are forbidden.
+- Private egress CA and secret material is owned directly by that numeric
+  UID/GID. Root-readable egress configuration and the projected system CA
+  remain root-owned.
+- When the sidecar starts as root, it drops privileges with `setpriv --reuid`
+  and `--regid` plus `--clear-groups`, or with numeric `gosu UID:GID` when
+  `setpriv` is unavailable. Startup fails closed if neither mechanism exists.
+- When the sidecar starts as non-root, its current UID and GID must exactly
+  match the configured egress identity before `mitmdump` can start.
+- No named egress account, passwd lookup, account creation, compatibility
+  alias, or old-account cleanup is part of the runtime contract.
+- The nftables program remains the minimal managed table: bypass the egress
+  UID, redirect the runtime UID's TCP ports 80 and 443, and remove only that
+  table during cleanup.
+- Bridge credentials and surfaces are excluded from the egress engine child
+  environment.
+
+## Options Considered
+
+### Named account owned by the image
+
+This gives conventional passwd metadata but makes the image responsible for a
+Clawdi-specific identity and requires image rollout for runtime policy changes.
+It conflicts with the stable capability-envelope boundary.
+
+### CLI-owned numeric identity
+
+This keeps the image generic, makes ownership explicit, avoids account lookup,
+and permits deterministic fail-closed privilege dropping. It requires the host
+envelope to provide `setpriv` or numeric `gosu` and reserve the configured IDs.
+
+## Consequences
+
+- Runtime egress behavior can evolve through CLI rollout without image churn.
+- Files remain accessible to an egress process even when no matching
+  `/etc/passwd` entry exists.
+- UID/GID `0`, malformed values, and unavailable privilege-drop tools prevent
+  egress startup instead of silently running mitmproxy as root.
+- Hosted image changes that add runtime business logic violate this decision.
+- Coordinated rollout order is: merge and publish CLI `0.12.10-beta.47` first;
+  merge the Hosted generic-envelope PR after Hosted main compatibility smoke
+  uses beta.47; release and promote the generic image; then recreate prelaunch
+  development and canary instances. No old-state repair is required.
+
+## Related Documentation
+
+- [Managed runtime architecture](../managed-runtime.md)
+- [Managed runtime CLI plan](../plans/managed-runtime-cli.md)
+- [Managed runtime roadmap](../plans/managed-runtime-roadmap.md)

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -402,8 +402,11 @@ ExecStart="/home/clawdi/.openclaw/bin/openclaw" "gateway" "run" "--allow-unconfi
 
 When bridge surfaces or egress profiles are enabled, systemd runs the Clawdi
 support processes: the bridge surface process and, for egress interception, a
-runtime-fetched `mitmdump` (mitmproxy) transparent gateway owned by a dedicated
-`clawdi-egress` user. Engagement is a minimal nft redirect of the runtime UID's
+runtime-fetched `mitmdump` (mitmproxy) transparent gateway running under the
+explicit non-root `CLAWDI_EGRESS_UID` and `CLAWDI_EGRESS_GID` numeric identity
+(both default to `10002`). The CLI owns its paths, permissions, and privilege
+drop; the image does not need a named egress account. Engagement is a minimal
+nft redirect of the runtime UID's
 outbound :80/:443 to the local mitmproxy port (default-allow: non-profiled hosts
 pass through end-to-end against the real upstream CA); no forward-proxy env is
 injected. Bridge token/surface config and egress profile/CA/secret config stay
@@ -411,6 +414,9 @@ inside those support processes. Runtime programs therefore receive only CA-trust
 env such as `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, and `SSL_CERT_FILE`;
 support control env and secret-file paths stay out of the official runtime
 process.
+
+This ownership boundary is codified in
+[ADR-0002](adr/0002-runtime-image-is-a-stable-capability-envelope.md).
 
 Hermes has multiple official long-running surfaces. The Linux-like host should
 use official service installers for each runtime-owned surface when both are

--- a/docs/plans/managed-runtime-cli.md
+++ b/docs/plans/managed-runtime-cli.md
@@ -157,6 +157,10 @@ Their tokens, network direction, and failure domains must stay visible in
 manifest state, status, and logs. The sidecar must not become a hidden wrapper
 around official runtime commands.
 
+The runtime image is a stable capability envelope, while the CLI owns egress
+module paths, numeric UID/GID permissions, and name-free privilege dropping.
+See [ADR-0002](../adr/0002-runtime-image-is-a-stable-capability-envelope.md).
+
 Hermes deployments that need both gateway and dashboard should declare two
 official Hermes user services. The official Hermes Docker image is useful
 prior art for this fan-out, but the Linux-like host keeps in-place

--- a/docs/plans/managed-runtime-roadmap.md
+++ b/docs/plans/managed-runtime-roadmap.md
@@ -25,6 +25,10 @@ this repository.
   bridge, optional egress, status, and diagnostics.
 - Stable-image contract: runtime behavior is driven by manifest + CLI, not
   image-level per-agent wrappers.
+- The detailed ownership boundary is recorded in
+  [ADR-0002](../adr/0002-runtime-image-is-a-stable-capability-envelope.md):
+  the image supplies stable host capabilities and the CLI owns runtime-local
+  egress paths, permissions, and numeric privilege dropping.
 - Systemd service rendering that starts official runtime binaries directly with
   manifest-derived args, cwd, and env when upstream service installers do not
   cover the complete hosted contract.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.46",
+	"version": "0.12.10-beta.47",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -2497,34 +2497,76 @@ function startMitmdump(config: TransparentEgressEnvConfig): ChildProcess {
 	});
 	const command = config.engineBinaryPath;
 	const args = mitmdumpArgs;
-	const child =
-		runningAsRootCommand() && config.egressUser !== "root"
-			? spawnAsUser(config.egressUser, command, args, childEnv)
-			: spawn(command, args, { env: childEnv, stdio: ["ignore", "pipe", "pipe"] });
+	const child = runningAsRootCommand()
+		? spawnWithNumericIdentity(config.egressUid, config.egressGid, command, args, childEnv)
+		: spawnWithCurrentEgressIdentity(config.egressUid, config.egressGid, command, args, childEnv);
 	child.stdout?.pipe(process.stdout);
 	child.stderr?.pipe(process.stderr);
 	return child;
 }
 
-function spawnAsUser(
-	user: string,
+export function buildEgressEngineSpawnCommand(
+	commandExists: (command: string) => boolean,
+	uid: number,
+	gid: number,
+	command: string,
+	args: string[],
+): { command: string; args: string[] } {
+	if (uid === 0 || gid === 0) throw new Error("egress engine identity must be non-root");
+	if (commandExists("setpriv")) {
+		return {
+			command: "setpriv",
+			args: [`--reuid=${uid}`, `--regid=${gid}`, "--clear-groups", "--", command, ...args],
+		};
+	}
+	if (commandExists("gosu")) {
+		return { command: "gosu", args: [`${uid}:${gid}`, command, ...args] };
+	}
+	throw new Error(`cannot drop egress engine to ${uid}:${gid}; install setpriv or gosu`);
+}
+
+export function assertCurrentEgressIdentity(
+	currentUid: number | undefined,
+	currentGid: number | undefined,
+	configuredUid: number,
+	configuredGid: number,
+): void {
+	if (currentUid === undefined || currentGid === undefined) {
+		throw new Error("cannot verify non-root egress engine UID/GID on this platform");
+	}
+	if (currentUid === 0 || currentGid === 0) {
+		throw new Error("egress engine identity must be non-root");
+	}
+	if (currentUid !== configuredUid || currentGid !== configuredGid) {
+		throw new Error(
+			`current egress engine identity ${currentUid}:${currentGid} does not match configured ${configuredUid}:${configuredGid}`,
+		);
+	}
+}
+
+function spawnWithCurrentEgressIdentity(
+	uid: number,
+	gid: number,
 	command: string,
 	args: string[],
 	env: NodeJS.ProcessEnv,
 ): ChildProcess {
-	if (commandExistsOnPath("gosu")) {
-		return spawn("gosu", [user, command, ...args], {
-			env: { ...env, USER: user, LOGNAME: user },
-			stdio: ["ignore", "pipe", "pipe"],
-		});
-	}
-	if (commandExistsOnPath("runuser")) {
-		return spawn("runuser", ["-u", user, "--", command, ...args], {
-			env,
-			stdio: ["ignore", "pipe", "pipe"],
-		});
-	}
-	throw new Error(`cannot drop egress engine to ${user}; install gosu or runuser`);
+	assertCurrentEgressIdentity(process.getuid?.(), process.getgid?.(), uid, gid);
+	return spawn(command, args, { env, stdio: ["ignore", "pipe", "pipe"] });
+}
+
+function spawnWithNumericIdentity(
+	uid: number,
+	gid: number,
+	command: string,
+	args: string[],
+	env: NodeJS.ProcessEnv,
+): ChildProcess {
+	const child = buildEgressEngineSpawnCommand(commandExistsOnPath, uid, gid, command, args);
+	return spawn(child.command, child.args, {
+		env,
+		stdio: ["ignore", "pipe", "pipe"],
+	});
 }
 
 function waitForChildExit(

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -101,6 +101,7 @@ import {
 	isGeneratedRuntimeSystemdFile,
 } from "./systemd-user";
 import {
+	parsePositiveLinuxId,
 	TRANSPARENT_EGRESS_TABLE,
 	TRANSPARENT_EGRESS_TRANSPORT_VERSION,
 } from "./transparent-egress";
@@ -528,7 +529,7 @@ function writeScopedSecretValues(
 	secretValues: Record<string, string> | undefined,
 	refs: readonly string[],
 	paths: RuntimePaths,
-	owner: "root" | "runtime-user" | "egress-user",
+	owner: "root" | "runtime-user" | "egress-identity",
 ): string | null {
 	const scoped = scopedSecretValues(secretValues, refs);
 	if (Object.keys(scoped).length === 0) {
@@ -544,9 +545,9 @@ function writeScopedSecretValues(
 			makeRuntimeUserOwned(dirname(path));
 		}
 		makeRuntimeUserOwned(path);
-	} else if (owner === "egress-user") {
+	} else if (owner === "egress-identity") {
 		makeRootOwned(dirname(path));
-		makeEgressUserOwned(path);
+		makeEgressIdentityOwned(path);
 	} else {
 		makeRootOwned(dirname(path));
 		makeRootOwned(path);
@@ -713,8 +714,11 @@ function makeRuntimeUserOwned(path: string): void {
 	makeSystemUserOwned(path, process.env.CLAWDI_RUNTIME_USER?.trim() ?? "");
 }
 
-function makeEgressUserOwned(path: string): void {
-	makeSystemUserOwned(path, process.env.CLAWDI_EGRESS_USER?.trim() || "clawdi-egress");
+function makeEgressIdentityOwned(path: string): void {
+	if (!runningAsRoot()) return;
+	const uid = runtimeEgressUid();
+	const gid = runtimeEgressGid();
+	chownSync(path, uid, gid);
 }
 
 function makeSystemUserOwned(path: string, user: string): void {
@@ -764,9 +768,9 @@ function makeRuntimeUserPrivateDir(path: string): void {
 	}
 }
 
-function makeEgressUserPrivateDir(path: string): void {
+function makeEgressIdentityPrivateDir(path: string): void {
 	mkdirSync(path, { recursive: true });
-	makeEgressUserOwned(path);
+	makeEgressIdentityOwned(path);
 	try {
 		chmodSync(path, 0o700);
 	} catch {
@@ -1723,7 +1727,7 @@ function writeEgressSecretFile(
 		secretValues,
 		egressSecretRefs(manifest),
 		paths,
-		"egress-user",
+		"egress-identity",
 	);
 }
 
@@ -3419,8 +3423,8 @@ function writeTransparentEgressEnvFile(input: {
 	paths: RuntimePaths;
 	runtimeUser: string;
 	runtimeUid: number;
-	egressUser: string;
 	egressUid: number;
+	egressGid: number;
 }): string | null {
 	if (!input.program) {
 		rmSync(input.paths.egressTransparentEnv, { force: true });
@@ -3429,8 +3433,8 @@ function writeTransparentEgressEnvFile(input: {
 	const env: Record<string, string> = {
 		CLAWDI_RUNTIME_USER: input.runtimeUser,
 		CLAWDI_RUNTIME_UID: String(input.runtimeUid),
-		CLAWDI_EGRESS_USER: input.egressUser,
 		CLAWDI_EGRESS_UID: String(input.egressUid),
+		CLAWDI_EGRESS_GID: String(input.egressGid),
 		CLAWDI_EGRESS_TRANSPARENT_PORT: String(input.program.transparentPort),
 		CLAWDI_EGRESS_NFT_TABLE: TRANSPARENT_EGRESS_TABLE,
 		CLAWDI_EGRESS_PROFILE_BUNDLE: input.program.profileBundlePath,
@@ -3815,6 +3819,12 @@ interface RuntimeEgressSystemdProgram {
 	secretFilePath: string | null;
 }
 
+interface RuntimeEgressIdentity {
+	runtimeUid: number;
+	egressUid: number;
+	egressGid: number;
+}
+
 function runtimeEgressSystemdProgram(
 	manifest: RuntimeManifest,
 	paths: RuntimePaths,
@@ -3894,7 +3904,11 @@ export function runtimeSidecarProgramRevision(
 	manifest: RuntimeManifest,
 	secretValues: Record<string, string> | undefined,
 	egressProgram: RuntimeEgressSystemdProgram | null = null,
+	egressIdentity: RuntimeEgressIdentity | null = null,
 ): string {
+	if (egressProgram && !egressIdentity) {
+		throw new Error("runtime sidecar egress revision requires the configured numeric identity");
+	}
 	return revisionHash({
 		clawdiCli: manifest.clawdiCli ?? null,
 		bridgeSurfaces: runtimeBridgeSurfaceSpecsForManifest(manifest),
@@ -3910,6 +3924,7 @@ export function runtimeSidecarProgramRevision(
 					engine: egressProgram.engine,
 					addonSha256: egressProgram.addonSha256,
 					transport: TRANSPARENT_EGRESS_TRANSPORT_VERSION,
+					identity: egressIdentity,
 				}
 			: null,
 	});
@@ -3923,12 +3938,18 @@ function runtimeUserUid(runtimeUser: string): number {
 	return systemUserUid(runtimeUser, runtimeUser === "clawdi" ? 10_001 : null);
 }
 
-function runtimeEgressUid(egressUser: string): number {
-	const explicit = Number.parseInt(process.env.CLAWDI_EGRESS_UID?.trim() ?? "", 10);
-	if (Number.isInteger(explicit) && explicit >= 0 && explicit <= 4_294_967_295) {
-		return explicit;
-	}
-	return systemUserUid(egressUser, egressUser === "clawdi-egress" ? 10_002 : null);
+function runtimeEgressUid(): number {
+	return positiveLinuxIdEnv("CLAWDI_EGRESS_UID", 10_002);
+}
+
+function runtimeEgressGid(): number {
+	return positiveLinuxIdEnv("CLAWDI_EGRESS_GID", 10_002);
+}
+
+function positiveLinuxIdEnv(key: string, fallback: number): number {
+	const raw = process.env[key]?.trim();
+	if (!raw) return fallback;
+	return parsePositiveLinuxId(raw, key);
 }
 
 function systemUserUid(user: string, fallback: number | null): number {
@@ -4481,6 +4502,7 @@ function runtimeManifestUrlEnv(manifest: RuntimeManifest, sourcePath: string): s
 function writeSystemdUnits(
 	runtimePrograms: RuntimeSystemdUserProgram[],
 	egressProgram: RuntimeEgressSystemdProgram | null,
+	egressIdentity: RuntimeEgressIdentity | null,
 	manifest: RuntimeManifest,
 	sourcePath: string,
 	paths: RuntimePaths,
@@ -4512,6 +4534,8 @@ function writeSystemdUnits(
 	const systemUnits: string[] = [];
 	const shouldRunBridge = bridgeSurfaceSpecs.length > 0;
 	const shouldRunEgress = egressProgram !== null && runtimePrograms.length > 0;
+	const activeEgressProgram = shouldRunEgress ? egressProgram : null;
+	const activeEgressIdentity = shouldRunEgress ? egressIdentity : null;
 	const shouldRunSidecar = shouldRunBridge || shouldRunEgress;
 	const shouldRunDaemon =
 		daemonAuthTokenFile !== null && desiredLiveSyncAgents(manifest).length > 0;
@@ -4573,7 +4597,12 @@ function writeSystemdUnits(
 					CLAWDI_EGRESS_ENV_FILE: shouldRunEgress && egressProgram ? egressProgram.envFilePath : "",
 					[RUNTIME_BRIDGE_TOKEN_ENV]: shouldRunBridge ? runtimeBridgeToken : "",
 					[RUNTIME_BRIDGE_SURFACES_ENV]: shouldRunBridge ? JSON.stringify(bridgeSurfaceSpecs) : "",
-					CLAWDI_RUNTIME_REV: runtimeSidecarProgramRevision(manifest, secretValues, egressProgram),
+					CLAWDI_RUNTIME_REV: runtimeSidecarProgramRevision(
+						manifest,
+						secretValues,
+						activeEgressProgram,
+						activeEgressIdentity,
+					),
 				},
 				serviceType: "notify",
 				extraUnitLines: runtimeUid === null ? undefined : [`Before=user@${runtimeUid}.service`],
@@ -4723,7 +4752,7 @@ export function convergeRuntimeManifest(
 	makeManagedSecretRoot(paths.managedSecretRoot);
 	makeRootReadableDir(paths.egressProfileRoot);
 	makeRootReadableDir(paths.egressRoot);
-	makeEgressUserPrivateDir(paths.egressCaDir);
+	makeEgressIdentityPrivateDir(paths.egressCaDir);
 	makeRootReadableDir(dirname(paths.egressSystemCaFile));
 	makeRuntimeUserPrivateDir(paths.egressScratchRoot);
 
@@ -4805,7 +4834,6 @@ export function convergeRuntimeManifest(
 	}
 	const egressSecretFile = writeEgressSecretFile(manifest, secretValues, paths);
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
-	const egressUser = process.env.CLAWDI_EGRESS_USER?.trim() || "clawdi-egress";
 	const egressSystemdProgram = runtimeEgressSystemdProgram(
 		manifest,
 		paths,
@@ -4815,14 +4843,16 @@ export function convergeRuntimeManifest(
 		egressAddon,
 	);
 	const runtimeUid = egressSystemdProgram ? runtimeUserUid(runtimeUser) : 0;
-	const egressUid = egressSystemdProgram ? runtimeEgressUid(egressUser) : 0;
+	const egressUid = egressSystemdProgram ? runtimeEgressUid() : 0;
+	const egressGid = egressSystemdProgram ? runtimeEgressGid() : 0;
+	const egressIdentity = egressSystemdProgram ? { runtimeUid, egressUid, egressGid } : null;
 	const egressTransparentEnv = writeTransparentEgressEnvFile({
 		program: egressSystemdProgram,
 		paths,
 		runtimeUser,
 		runtimeUid,
-		egressUser,
 		egressUid,
+		egressGid,
 	});
 	writeProviderHealthStatus(manifest, load.secretValues, paths);
 	const liveSyncEnvironments = writeLiveSyncEnvironmentFiles(manifest, paths);
@@ -5022,6 +5052,7 @@ export function convergeRuntimeManifest(
 	const systemdUnits = writeSystemdUnits(
 		runtimeSystemdUserPrograms,
 		egressSystemdProgram,
+		egressIdentity,
 		manifest,
 		load.sourcePath,
 		paths,

--- a/packages/cli/src/runtime/transparent-egress.ts
+++ b/packages/cli/src/runtime/transparent-egress.ts
@@ -16,9 +16,9 @@ export interface TransparentEgressNftRulesInput {
 export interface TransparentEgressEnvConfig {
 	envFile?: string;
 	runtimeUser: string;
-	egressUser: string;
 	runtimeUid: number;
 	egressUid: number;
+	egressGid: number;
 	transparentPort: number;
 	nftTable: string;
 	profileBundlePath: string;
@@ -107,18 +107,18 @@ export function loadTransparentEgressEnvConfig(
 		if (key.startsWith("CLAWDI_")) config[key] = value;
 	}
 	const runtimeUser = requiredConfig(config, "CLAWDI_RUNTIME_USER");
-	const egressUser = requiredConfig(config, "CLAWDI_EGRESS_USER");
 	const runtimeUid = numericConfig(config, "CLAWDI_RUNTIME_UID");
-	const egressUid = numericConfig(config, "CLAWDI_EGRESS_UID");
+	const egressUid = positiveLinuxIdConfig(config, "CLAWDI_EGRESS_UID");
+	const egressGid = positiveLinuxIdConfig(config, "CLAWDI_EGRESS_GID");
 	const transparentPort = numericConfig(config, "CLAWDI_EGRESS_TRANSPARENT_PORT");
 	const nftTable = requiredConfig(config, "CLAWDI_EGRESS_NFT_TABLE");
 	validateNftIdentifier(nftTable, "CLAWDI_EGRESS_NFT_TABLE");
 	return {
 		envFile,
 		runtimeUser,
-		egressUser,
 		runtimeUid,
 		egressUid,
+		egressGid,
 		transparentPort,
 		nftTable,
 		profileBundlePath: requiredConfig(config, "CLAWDI_EGRESS_PROFILE_BUNDLE"),
@@ -146,6 +146,15 @@ export function parseEnvFile(path: string): Record<string, string> {
 		output[normalizedKey] = unquoteEnvValue(rest.join("=").trim());
 	}
 	return output;
+}
+
+export function parsePositiveLinuxId(raw: string, key: string): number {
+	if (!/^[0-9]+$/.test(raw)) throw new Error(`${key} must be a positive Linux UID/GID`);
+	const parsed = Number(raw);
+	if (!Number.isInteger(parsed) || parsed < 1 || parsed > 4_294_967_294) {
+		throw new Error(`${key} must be a positive Linux UID/GID`);
+	}
+	return parsed;
 }
 
 function applyNftRules(rules: string, action: "apply" | "cleanup"): void {
@@ -182,6 +191,10 @@ function numericConfig(config: Record<string, string | undefined>, key: string):
 		throw new Error(`${key} must be numeric`);
 	}
 	return parsed;
+}
+
+function positiveLinuxIdConfig(config: Record<string, string | undefined>, key: string): number {
+	return parsePositiveLinuxId(requiredConfig(config, key), key);
 }
 
 function firstNonempty(value: string | undefined): string | undefined {

--- a/packages/cli/tests/commands/runtime.test.ts
+++ b/packages/cli/tests/commands/runtime.test.ts
@@ -12,6 +12,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+	assertCurrentEgressIdentity,
+	buildEgressEngineSpawnCommand,
 	runtimeApplyCommand,
 	runtimePlanCommand,
 	runtimeStatusCommand,
@@ -21,6 +23,76 @@ import { jsonResponse, mockFetch } from "./helpers";
 let tmpHome: string;
 let origHome: string | undefined;
 let origApiUrl: string | undefined;
+
+describe("runtime sidecar egress privilege drop", () => {
+	it("prefers setpriv with an explicit non-root numeric identity", () => {
+		expect(
+			buildEgressEngineSpawnCommand(
+				(command) => command === "setpriv" || command === "gosu",
+				10002,
+				10003,
+				"/opt/mitmdump",
+				["--mode", "transparent"],
+			),
+		).toEqual({
+			command: "setpriv",
+			args: [
+				"--reuid=10002",
+				"--regid=10003",
+				"--clear-groups",
+				"--",
+				"/opt/mitmdump",
+				"--mode",
+				"transparent",
+			],
+		});
+	});
+
+	it("uses a numeric gosu identity and never runuser", () => {
+		const checked: string[] = [];
+		const child = buildEgressEngineSpawnCommand(
+			(command) => {
+				checked.push(command);
+				return command === "gosu";
+			},
+			10002,
+			10003,
+			"/opt/mitmdump",
+			[],
+		);
+
+		expect(child).toEqual({
+			command: "gosu",
+			args: ["10002:10003", "/opt/mitmdump"],
+		});
+		expect(checked).toEqual(["setpriv", "gosu"]);
+	});
+
+	it("fails closed for root or unavailable privilege-drop tools", () => {
+		expect(() => buildEgressEngineSpawnCommand(() => true, 0, 10002, "mitmdump", [])).toThrow(
+			"egress engine identity must be non-root",
+		);
+		expect(() => buildEgressEngineSpawnCommand(() => false, 10002, 10002, "mitmdump", [])).toThrow(
+			"install setpriv or gosu",
+		);
+	});
+
+	it("allows a matching non-root current identity", () => {
+		expect(() => assertCurrentEgressIdentity(10002, 10003, 10002, 10003)).not.toThrow();
+	});
+
+	it("rejects mismatching or unverifiable non-root current identities", () => {
+		expect(() => assertCurrentEgressIdentity(10001, 10001, 10002, 10002)).toThrow(
+			"current egress engine identity 10001:10001 does not match configured 10002:10002",
+		);
+		expect(() => assertCurrentEgressIdentity(undefined, 10002, 10002, 10002)).toThrow(
+			"cannot verify non-root egress engine UID/GID",
+		);
+		expect(() => assertCurrentEgressIdentity(10002, 0, 10002, 10002)).toThrow(
+			"egress engine identity must be non-root",
+		);
+	});
+});
 
 beforeEach(() => {
 	origHome = process.env.HOME;

--- a/packages/cli/tests/runtime-transparent-egress.test.ts
+++ b/packages/cli/tests/runtime-transparent-egress.test.ts
@@ -51,8 +51,8 @@ describe("runtime transparent egress nftables", () => {
 				[
 					'CLAWDI_RUNTIME_USER="clawdi"',
 					'CLAWDI_RUNTIME_UID="10001"',
-					'CLAWDI_EGRESS_USER="clawdi-egress"',
 					'CLAWDI_EGRESS_UID="10002"',
+					'CLAWDI_EGRESS_GID="10003"',
 					'CLAWDI_EGRESS_TRANSPARENT_PORT="25080"',
 					'CLAWDI_EGRESS_NFT_TABLE="clawdi_transparent_egress"',
 					`CLAWDI_EGRESS_PROFILE_BUNDLE="${join(root, "profiles.json")}"`,
@@ -76,15 +76,49 @@ describe("runtime transparent egress nftables", () => {
 			});
 
 			expect(config.runtimeUser).toBe("clawdi");
-			expect(config.egressUser).toBe("clawdi-egress");
 			expect(config.runtimeUid).toBe(10001);
 			expect(config.egressUid).toBe(10002);
+			expect(config.egressGid).toBe(10003);
 			expect(config.transparentPort).toBe(26080);
 			expect(config.nftTable).toBe("clawdi_transparent_egress");
 			expect(config.engineSha256).toBe("b".repeat(64));
 			expect(config.addonSha256).toBe("a".repeat(64));
 		} finally {
 			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects invalid or root egress numeric identities", () => {
+		const base = {
+			CLAWDI_RUNTIME_USER: "clawdi",
+			CLAWDI_RUNTIME_UID: "10001",
+			CLAWDI_EGRESS_UID: "10002",
+			CLAWDI_EGRESS_GID: "10002",
+			CLAWDI_EGRESS_TRANSPARENT_PORT: "25080",
+			CLAWDI_EGRESS_NFT_TABLE: "clawdi_transparent_egress",
+			CLAWDI_EGRESS_PROFILE_BUNDLE: "/tmp/profiles.json",
+			CLAWDI_EGRESS_CA_DIR: "/tmp/ca",
+			CLAWDI_EGRESS_CA_CERT: "/tmp/ca/mitmproxy-ca-cert.pem",
+			CLAWDI_EGRESS_SYSTEM_CA_BUNDLE: "/tmp/ca.pem",
+			CLAWDI_EGRESS_ENGINE_VERSION: "12.2.3",
+			CLAWDI_EGRESS_ENGINE_URL: "https://example.invalid/mitmproxy.tar.gz",
+			CLAWDI_EGRESS_ENGINE_SHA256: "b".repeat(64),
+			CLAWDI_EGRESS_ENGINE_BINARY_PATH: "/tmp/mitmdump",
+			CLAWDI_EGRESS_ADDON_PATH: "/tmp/addon.py",
+			CLAWDI_EGRESS_ADDON_SHA256: "a".repeat(64),
+		};
+
+		for (const [key, value] of [
+			["CLAWDI_EGRESS_UID", "0"],
+			["CLAWDI_EGRESS_UID", "-1"],
+			["CLAWDI_EGRESS_UID", "4294967295"],
+			["CLAWDI_EGRESS_UID", "4294967296"],
+			["CLAWDI_EGRESS_GID", "0"],
+			["CLAWDI_EGRESS_GID", "1.5"],
+		] as const) {
+			expect(() => loadTransparentEgressEnvConfig({ ...base, [key]: value })).toThrow(
+				`${key} must be a positive Linux UID/GID`,
+			);
 		}
 	});
 });

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -81,8 +81,8 @@ const ENV_KEYS = [
 	"CLAWDI_SYSTEMCTL_PATH",
 	"CLAWDI_RUNTIME_USER",
 	"CLAWDI_RUNTIME_UID",
-	"CLAWDI_EGRESS_USER",
 	"CLAWDI_EGRESS_UID",
+	"CLAWDI_EGRESS_GID",
 	"OPENCLAW_GATEWAY_TOKEN",
 	RUNTIME_BRIDGE_TOKEN_ENV,
 	RUNTIME_BRIDGE_LISTEN_HOST_ENV,
@@ -8001,8 +8001,8 @@ exit 64
 		expect(runtimeSidecarEnv).toContain(`CLAWDI_EGRESS_ENV_FILE="${paths.egressTransparentEnv}"`);
 		expect(transparentEgressEnv).toContain('CLAWDI_RUNTIME_USER="clawdi"');
 		expect(transparentEgressEnv).toContain('CLAWDI_RUNTIME_UID="10001"');
-		expect(transparentEgressEnv).toContain('CLAWDI_EGRESS_USER="clawdi-egress"');
 		expect(transparentEgressEnv).toContain('CLAWDI_EGRESS_UID="10002"');
+		expect(transparentEgressEnv).toContain('CLAWDI_EGRESS_GID="10002"');
 		expect(transparentEgressEnv).toContain('CLAWDI_EGRESS_NFT_TABLE="clawdi_transparent_egress"');
 		expect(transparentEgressEnv).toContain(
 			`CLAWDI_EGRESS_PROFILE_BUNDLE="${join(state, "config", "egress", "profiles.json")}"`,
@@ -8024,6 +8024,10 @@ exit 64
 		expect(statSync(aggregateSecretPath).mode & 0o777).toBe(0o600);
 		expect(existsSync(join(run, "secrets", "runtimes", "openclaw.json"))).toBe(false);
 		expect(statSync(egressSecretPath).mode & 0o777).toBe(0o600);
+		if (typeof process.getuid === "function" && process.getuid() === 0) {
+			expect(statSync(egressSecretPath).uid).toBe(10002);
+			expect(statSync(egressSecretPath).gid).toBe(10002);
+		}
 		const egressSecrets = JSON.parse(readFileSync(egressSecretPath, "utf-8"));
 		expect(egressSecrets["secret://provider.default.apiKey"]).toBe("sk-runtime");
 		expect(JSON.stringify(egressSecrets)).not.toContain("sk-other-runtime");
@@ -8092,49 +8096,48 @@ exit 64
 		process.env.CLAWDI_RUN_DIR = run;
 		const mitmproxy = seedMitmproxyCache();
 
-		convergeRuntimeManifest(
-			{
-				manifest: {
-					schemaVersion: "clawdi.runtimeDesiredState.v1",
-					deploymentId: "dep_transparent_egress",
-					environmentId: "env_transparent_egress",
-					instanceId: "iid_transparent_egress",
-					generation: 1,
-					issuedAt: "2026-06-26T00:00:00Z",
-					controlPlane: { apiUrl: "https://cloud-api.test" },
-					egressEngine: mitmproxy,
-					runtimes: {
-						openclaw: { enabled: true },
-						hermes: { enabled: false },
-					},
-					egressProfiles: {
-						profiles: [
-							{
-								id: "deny-metadata",
-								enabled: true,
-								kind: "deny",
-								match: {
-									scheme: "https",
-									host: "169.254.169.254",
-									pathPrefix: "/",
-								},
-								priority: 1,
-							},
-						],
-					},
-					recovery: {},
+		const load: RuntimeManifestLoad = {
+			manifest: {
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				deploymentId: "dep_transparent_egress",
+				environmentId: "env_transparent_egress",
+				instanceId: "iid_transparent_egress",
+				generation: 1,
+				issuedAt: "2026-06-26T00:00:00Z",
+				controlPlane: { apiUrl: "https://cloud-api.test" },
+				egressEngine: mitmproxy,
+				runtimes: {
+					openclaw: { enabled: true },
+					hermes: { enabled: false },
 				},
-				source: "fixture-file",
-				sourcePath: "test://transparent-egress",
-				offline: false,
-				secretValues: {},
+				egressProfiles: {
+					profiles: [
+						{
+							id: "deny-metadata",
+							enabled: true,
+							kind: "deny",
+							match: {
+								scheme: "https",
+								host: "169.254.169.254",
+								pathPrefix: "/",
+							},
+							priority: 1,
+						},
+					],
+				},
+				recovery: {},
 			},
-			getRuntimePaths(),
-		);
+			source: "fixture-file",
+			sourcePath: "test://transparent-egress",
+			offline: false,
+			secretValues: {},
+		};
+		convergeRuntimeManifest(load, getRuntimePaths());
 
 		const paths = getRuntimePaths();
 		const sidecarUnit = readSystemdSystemUnit(paths, "clawdi-runtime-sidecar");
 		const sidecarEnv = readSystemdEnvFile(paths, "clawdi-runtime-sidecar");
+		const initialSidecarRevision = systemdEnvRevision(sidecarEnv);
 		const transparentEgressEnv = readFileSync(paths.egressTransparentEnv, "utf-8");
 		const openclawUnit = readSystemdUserServiceConfig(paths, "openclaw-gateway");
 		const openclawEnv = readSystemdEnvFile(paths, "openclaw-gateway");
@@ -8148,6 +8151,7 @@ exit 64
 		expect(transparentEgressEnv).toContain('CLAWDI_EGRESS_NFT_TABLE="clawdi_transparent_egress"');
 		expect(transparentEgressEnv).toContain('CLAWDI_RUNTIME_UID="10001"');
 		expect(transparentEgressEnv).toContain('CLAWDI_EGRESS_UID="10002"');
+		expect(transparentEgressEnv).toContain('CLAWDI_EGRESS_GID="10002"');
 		expect(sidecarEnv).toContain(
 			`CLAWDI_EGRESS_ENV_FILE="${join(run, "egress", "transparent-egress.env")}"`,
 		);
@@ -8172,6 +8176,10 @@ exit 64
 		expect(statSync(paths.egressAddon).mode & 0o777).toBe(0o644);
 		expect(statSync(paths.egressTransparentEnv).mode & 0o777).toBe(0o644);
 		expect(statSync(paths.egressCaDir).mode & 0o777).toBe(0o700);
+		if (typeof process.getuid === "function" && process.getuid() === 0) {
+			expect(statSync(paths.egressCaDir).uid).toBe(10002);
+			expect(statSync(paths.egressCaDir).gid).toBe(10002);
+		}
 		expect(statSync(join(run, "egress-scratch")).mode & 0o777).toBe(0o700);
 		expect(openclawUnit).toContain('ExecStart="openclaw" "gateway" "run"');
 		expect(openclawEnv).not.toContain("CLAWDI_EGRESS_PROFILE_BUNDLE");
@@ -8183,6 +8191,19 @@ exit 64
 			`NODE_EXTRA_CA_CERTS="${join(run, "egress", "systemd", "ca.pem")}"`,
 		);
 		expect(openclawUnit).not.toContain("clawdi run -- openclaw");
+
+		process.env.CLAWDI_EGRESS_UID = "10012";
+		process.env.CLAWDI_EGRESS_GID = "10013";
+		convergeRuntimeManifest(load, paths);
+		const updatedSidecarEnv = readSystemdEnvFile(paths, "clawdi-runtime-sidecar");
+		const updatedTransparentEgressEnv = readFileSync(paths.egressTransparentEnv, "utf-8");
+		expect(systemdEnvRevision(updatedSidecarEnv)).not.toBe(initialSidecarRevision);
+		expect(updatedTransparentEgressEnv).toContain('CLAWDI_EGRESS_UID="10012"');
+		expect(updatedTransparentEgressEnv).toContain('CLAWDI_EGRESS_GID="10013"');
+		if (typeof process.getuid === "function" && process.getuid() === 0) {
+			expect(statSync(paths.egressCaDir).uid).toBe(10012);
+			expect(statSync(paths.egressCaDir).gid).toBe(10013);
+		}
 	});
 
 	it("does not advance last-good manifest cache when convergence has install errors", async () => {


### PR DESCRIPTION
## Why

The hosted runtime image should remain a stable Linux capability envelope. Runtime module identities, directories, ownership, privilege dropping, nftables policy, and engine lifecycle belong to the versioned CLI so runtime behavior can evolve without rebuilding the base image.

## What changed

- remove the named egress account contract and use explicit `CLAWDI_EGRESS_UID` / `CLAWDI_EGRESS_GID`, defaulting to `10002`
- chown private egress CA and secret material directly to the numeric identity
- drop mitmdump privileges with `setpriv` first and numeric `gosu` fallback; non-root startup requires an exact current UID/GID match
- reject root, malformed, overflow, and `4294967295` chown-sentinel identities and fail closed when identity verification or privilege-drop tools are unavailable
- include runtime UID and egress UID/GID in the sidecar revision so identity changes restart the engine and update nftables/ownership atomically
- preserve the existing nftables transparent redirect and bridge child-environment isolation
- document the image/CLI ownership boundary in ADR-0002 and release CLI `0.12.10-beta.47` metadata

No desired-state/schema migration, database change, compatibility alias, old-state repair, or production operation is included.

## Coordinated rollout

1. Merge and publish CLI `0.12.10-beta.47`.
2. Confirm the package and `beta` dist-tag are visible from npm.
3. Merge Clawdi Hosted PR #780.
4. Release and promote the generic runtime image, then recreate prelaunch development and canary instances.

## Verification

- CLI full suite: `791 pass, 0 fail`
- focused UID/GID and sidecar revision regression tests
- CLI typecheck and repository checks
- explicit local-tarball paired release smoke covering base image, local bootstrap, cloud datasource with transparent egress, installer boundaries, official installers, and systemd runtime services
