### PR TITLE
refactor(cli): own hosted bootstrap contract

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Skip if no publish needed
         id: check
-        # Three skip cases:
+        # Skip cases:
         #   1. Local exact version already exists on npm (no bump → no publish).
         #   2. Package has never been published (`npm view` fails, fallback "0.0.0").
         #      The first publish must be manual — `npm publish --access public`
@@ -55,12 +55,16 @@ jobs:
         #      requires the package to already exist on the registry to accept
         #      a workflow as the publisher. Until that bootstrap happens, the
         #      workflow stays inert.
-        #   3. Pre-release versions publish under the `beta` dist-tag so they
-        #      cannot accidentally replace `latest`.
+        # The package may declare an isolated release channel through
+        # `publishConfig.tag`; otherwise prereleases use `beta` and stable
+        # versions use `latest`.
         run: |
           LOCAL=$(node -p "require('./package.json').version")
           REMOTE_LATEST=$(npm view clawdi version 2>/dev/null || echo "0.0.0")
-          if [[ "$LOCAL" == *-* ]]; then
+          CONFIGURED_TAG=$(node -p "require('./package.json').publishConfig?.tag || ''")
+          if [ -n "$CONFIGURED_TAG" ]; then
+            NPM_TAG="$CONFIGURED_TAG"
+          elif [[ "$LOCAL" == *-* ]]; then
             NPM_TAG=beta
           else
             NPM_TAG=latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.12.10-beta.48
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.48
+
+Package: `clawdi@0.12.10-beta.48`
+
+### Changed
+
+- Made hosted policy and runtime datasource validation CLI-owned contracts, so
+  runtime images no longer carry command policy, control-plane URLs, or CLI
+  release-channel metadata.
+
 ## Clawdi CLI v0.12.10-beta.47
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.47

--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.47",
+      "version": "0.12.10-beta.48",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
+++ b/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
@@ -23,6 +23,14 @@ The runtime image supplies stable operating-system capabilities. The Clawdi CLI
 owns runtime-local module paths, generated configuration, permissions,
 privilege dropping, and lifecycle behavior.
 
+Hosted mode is an explicit CLI contract selected by
+`CLAWDI_RUNTIME_MODE=hosted`; it is not inferred from image files. The hosted
+command policy is built into the CLI. Deployment must provide
+`CLAWDI_RUNTIME_MANIFEST_URL` and `CLAWDI_RUNTIME_AUTH_ENV`, whose value names
+the environment variable containing the manifest bearer credential. The CLI
+validates both selectors and fails closed before datasource access. A hosted
+runtime does not read `host-policy.json` or `runtime-source.json`.
+
 For transparent egress:
 
 - `clawdi runtime sidecar` remains the only public support command;
@@ -68,9 +76,9 @@ envelope to provide `setpriv` or numeric `gosu` and reserve the configured IDs.
 - UID/GID `0`, malformed values, and unavailable privilege-drop tools prevent
   egress startup instead of silently running mitmproxy as root.
 - Hosted image changes that add runtime business logic violate this decision.
-- Coordinated rollout order is: merge and publish CLI `0.12.10-beta.47` first;
+- Coordinated rollout order is: merge and publish CLI `0.12.10-beta.48` first;
   merge the Hosted generic-envelope PR after Hosted main compatibility smoke
-  uses beta.47; release and promote the generic image; then recreate prelaunch
+  uses beta.48; release and promote the generic image; then recreate prelaunch
   development and canary instances. No old-state repair is required.
 
 ## Related Documentation

--- a/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
+++ b/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
@@ -76,10 +76,12 @@ envelope to provide `setpriv` or numeric `gosu` and reserve the configured IDs.
 - UID/GID `0`, malformed values, and unavailable privilege-drop tools prevent
   egress startup instead of silently running mitmproxy as root.
 - Hosted image changes that add runtime business logic violate this decision.
-- Coordinated rollout order is: merge and publish CLI `0.12.10-beta.48` first;
-  merge the Hosted generic-envelope PR after Hosted main compatibility smoke
-  uses beta.48; release and promote the generic image; then recreate prelaunch
-  development and canary instances. No old-state repair is required.
+- Coordinated rollout order is: merge and publish exact CLI version
+  `0.12.10-beta.48` under the isolated npm `agent-v2` dist-tag without moving
+  `beta`; configure the v2 deployment contract to use that exact version;
+  merge the Hosted generic-envelope PR; release and promote the generic image; then recreate
+  prelaunch development and canary instances. Do not promote this through the
+  legacy agent image controls; no old-state repair is required.
 
 ## Related Documentation
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,8 @@
 		"node": ">=22.5"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"tag": "agent-v2"
 	},
 	"scripts": {
 		"dev": "bun run src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.47",
+	"version": "0.12.10-beta.48",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/capabilities.ts
+++ b/packages/cli/src/commands/capabilities.ts
@@ -12,7 +12,8 @@ interface Capabilities {
 	commands: string[];
 	restrictedByHostedPolicy: Array<{ command: string; reason?: string }>;
 	hostPolicy: {
-		path: string;
+		source: "builtin" | "file";
+		path?: string;
 		exists: boolean;
 		valid: boolean;
 		error?: string;
@@ -68,7 +69,8 @@ function buildCapabilities(): Capabilities {
 		commands: COMMANDS,
 		restrictedByHostedPolicy: normalizeDeniedCommands(hostPolicy.policy),
 		hostPolicy: {
-			path: hostPolicy.path,
+			source: hostPolicy.source,
+			...(hostPolicy.path ? { path: hostPolicy.path } : {}),
 			exists: hostPolicy.exists,
 			valid: hostPolicy.valid,
 			error: hostPolicy.error,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -58,7 +58,10 @@ Environment:
   CLAWDI_NO_UPDATE_CHECK   Suppress the non-blocking update check
   CLAWDI_NO_AUTO_UPDATE    Skip CLI/daemon background auto-update (also disables via \`config set autoUpdate false\`)
   CLAWDI_RUNTIME_MODE      Explicit runtime mode override for hosted tests/operators
-  CLAWDI_AUTH_TOKEN        Clawdi Cloud auth token; the only hosted container credential
+  CLAWDI_RUNTIME_MANIFEST_URL
+                           Hosted runtime manifest datasource URL
+  CLAWDI_RUNTIME_AUTH_ENV  Name of the env var containing the hosted bearer credential
+  CLAWDI_AUTH_TOKEN        Default deployment-selected hosted bearer credential
   CLAWDI_RUNTIME_BRIDGE_TOKEN
                            Hosted runtime bridge token for authenticated surfaces
   CLAUDE_CONFIG_DIR        Custom Claude Code home (else ~/.claude)

--- a/packages/cli/src/runtime/auth-token.ts
+++ b/packages/cli/src/runtime/auth-token.ts
@@ -3,6 +3,20 @@ import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "../
 import type { RuntimePaths } from "./paths";
 
 export const RUNTIME_AUTH_TOKEN_ENV = "CLAWDI_AUTH_TOKEN";
+export const RUNTIME_AUTH_ENV_SELECTOR = "CLAWDI_RUNTIME_AUTH_ENV";
+
+export function runtimeAuthEnvName(): string {
+	const selected = process.env[RUNTIME_AUTH_ENV_SELECTOR]?.trim();
+	if (!selected) {
+		throw new Error(`missing ${RUNTIME_AUTH_ENV_SELECTOR}`);
+	}
+	if (!/^[A-Z_][A-Z0-9_]*$/.test(selected)) {
+		throw new Error(
+			`invalid ${RUNTIME_AUTH_ENV_SELECTOR}: expected an uppercase environment variable name`,
+		);
+	}
+	return selected;
+}
 
 export function readRuntimeAuthToken(paths: RuntimePaths): string | null {
 	try {
@@ -26,7 +40,8 @@ export function writeRuntimeAuthToken(paths: RuntimePaths, token: string): strin
 }
 
 export function ensureRuntimeAuthTokenFile(paths: RuntimePaths): string | null {
-	const token = process.env[RUNTIME_AUTH_TOKEN_ENV]?.trim();
+	const envName = paths.mode === "hosted" ? runtimeAuthEnvName() : RUNTIME_AUTH_TOKEN_ENV;
+	const token = process.env[envName]?.trim();
 	if (token) return writeRuntimeAuthToken(paths, token);
 	if (readRuntimeAuthToken(paths)) {
 		return paths.daemonAuthToken;

--- a/packages/cli/src/runtime/host-policy.ts
+++ b/packages/cli/src/runtime/host-policy.ts
@@ -20,7 +20,8 @@ export interface HostPolicy {
 }
 
 export interface HostPolicyReadResult {
-	path: string;
+	source: "builtin" | "file";
+	path?: string;
 	exists: boolean;
 	valid: boolean;
 	policy?: HostPolicy;
@@ -32,6 +33,7 @@ export interface HostPolicyCommandDecision {
 	command: string;
 	runtimeMode: RuntimeMode;
 	policyPath?: string;
+	policySource?: "builtin" | "file";
 	reason?: string;
 }
 
@@ -43,6 +45,22 @@ const POLICY_RECOVERY_COMMANDS = [
 	"status",
 	"doctor",
 ] as const;
+
+const HOSTED_POLICY: HostPolicy = {
+	schemaVersion: "clawdi.hostPolicy.v1",
+	mode: "hosted",
+	cliUpdateMode: "system-managed-npm",
+	immutableShim: true,
+	deniedCommands: [
+		{ command: "setup", reason: "runtime setup is managed by clawdi runtime init" },
+		{ command: "teardown", reason: "runtime teardown is managed by the host lifecycle" },
+		{ command: "update", reason: "CLI updates are managed by the hosted runtime installation" },
+	],
+	managedState: ["/var/lib/clawdi/config", "/var/lib/clawdi/sync", "/run/clawdi"],
+	systemWritableState: ["/var/lib/clawdi", "/run/clawdi"],
+	userWritableState: ["/home/clawdi", "/tmp"],
+	ordinaryUserDeniedState: ["/var/lib/clawdi"],
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -66,7 +84,10 @@ function parseDeniedCommands(value: unknown): Array<string | DeniedCommand> | un
 }
 
 export function readHostPolicy(path = getRuntimePaths().hostPolicy): HostPolicyReadResult {
-	if (!existsSync(path)) return { path, exists: false, valid: false };
+	if (detectRuntimeMode() === "hosted") {
+		return { source: "builtin", exists: true, valid: true, policy: HOSTED_POLICY };
+	}
+	if (!existsSync(path)) return { source: "file", path, exists: false, valid: false };
 
 	try {
 		const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
@@ -104,9 +125,10 @@ export function readHostPolicy(path = getRuntimePaths().hostPolicy): HostPolicyR
 			policy.ordinaryUserDeniedState = parsed.ordinaryUserDeniedState;
 		}
 
-		return { path, exists: true, valid: true, policy };
+		return { source: "file", path, exists: true, valid: true, policy };
 	} catch (e) {
 		return {
+			source: "file",
 			path,
 			exists: true,
 			valid: false,
@@ -152,26 +174,40 @@ export function evaluateHostPolicyForCommand(command: string): HostPolicyCommand
 	const policy = readHostPolicy();
 	if (!policy.exists) {
 		if (isPolicyRecoveryCommand(normalized)) {
-			return { allowed: true, command: normalized, runtimeMode, policyPath: policy.path };
+			return {
+				allowed: true,
+				command: normalized,
+				runtimeMode,
+				policySource: policy.source,
+				...(policy.path ? { policyPath: policy.path } : {}),
+			};
 		}
 		return {
 			allowed: false,
 			command: normalized,
 			runtimeMode,
-			policyPath: policy.path,
+			policySource: policy.source,
+			...(policy.path ? { policyPath: policy.path } : {}),
 			reason: `missing hosted runtime policy at ${policy.path}`,
 		};
 	}
 
 	if (!policy.valid) {
 		if (isPolicyRecoveryCommand(normalized)) {
-			return { allowed: true, command: normalized, runtimeMode, policyPath: policy.path };
+			return {
+				allowed: true,
+				command: normalized,
+				runtimeMode,
+				policySource: policy.source,
+				...(policy.path ? { policyPath: policy.path } : {}),
+			};
 		}
 		return {
 			allowed: false,
 			command: normalized,
 			runtimeMode,
-			policyPath: policy.path,
+			policySource: policy.source,
+			...(policy.path ? { policyPath: policy.path } : {}),
 			reason: `invalid hosted runtime policy at ${policy.path}: ${policy.error ?? "parse failed"}`,
 		};
 	}
@@ -182,10 +218,17 @@ export function evaluateHostPolicyForCommand(command: string): HostPolicyCommand
 			allowed: false,
 			command: normalized,
 			runtimeMode,
-			policyPath: policy.path,
+			policySource: policy.source,
+			...(policy.path ? { policyPath: policy.path } : {}),
 			reason,
 		};
 	}
 
-	return { allowed: true, command: normalized, runtimeMode, policyPath: policy.path };
+	return {
+		allowed: true,
+		command: normalized,
+		runtimeMode,
+		policySource: policy.source,
+		...(policy.path ? { policyPath: policy.path } : {}),
+	};
 }

--- a/packages/cli/src/runtime/host-policy.ts
+++ b/packages/cli/src/runtime/host-policy.ts
@@ -32,19 +32,9 @@ export interface HostPolicyCommandDecision {
 	allowed: boolean;
 	command: string;
 	runtimeMode: RuntimeMode;
-	policyPath?: string;
-	policySource?: "builtin" | "file";
+	policySource?: "builtin";
 	reason?: string;
 }
-
-const POLICY_RECOVERY_COMMANDS = [
-	"runtime",
-	"capabilities",
-	"auth status",
-	"config paths",
-	"status",
-	"doctor",
-] as const;
 
 const HOSTED_POLICY: HostPolicy = {
 	schemaVersion: "clawdi.hostPolicy.v1",
@@ -158,68 +148,18 @@ export function deniedCommandReason(
 	return null;
 }
 
-function commandMatches(command: string, prefix: string): boolean {
-	return command === prefix || command.startsWith(`${prefix} `);
-}
-
-function isPolicyRecoveryCommand(command: string): boolean {
-	return POLICY_RECOVERY_COMMANDS.some((allowed) => commandMatches(command, allowed));
-}
-
 export function evaluateHostPolicyForCommand(command: string): HostPolicyCommandDecision {
 	const normalized = command.trim().replace(/\s+/g, " ");
 	const runtimeMode = detectRuntimeMode();
 	if (runtimeMode !== "hosted") return { allowed: true, command: normalized, runtimeMode };
 
-	const policy = readHostPolicy();
-	if (!policy.exists) {
-		if (isPolicyRecoveryCommand(normalized)) {
-			return {
-				allowed: true,
-				command: normalized,
-				runtimeMode,
-				policySource: policy.source,
-				...(policy.path ? { policyPath: policy.path } : {}),
-			};
-		}
-		return {
-			allowed: false,
-			command: normalized,
-			runtimeMode,
-			policySource: policy.source,
-			...(policy.path ? { policyPath: policy.path } : {}),
-			reason: `missing hosted runtime policy at ${policy.path}`,
-		};
-	}
-
-	if (!policy.valid) {
-		if (isPolicyRecoveryCommand(normalized)) {
-			return {
-				allowed: true,
-				command: normalized,
-				runtimeMode,
-				policySource: policy.source,
-				...(policy.path ? { policyPath: policy.path } : {}),
-			};
-		}
-		return {
-			allowed: false,
-			command: normalized,
-			runtimeMode,
-			policySource: policy.source,
-			...(policy.path ? { policyPath: policy.path } : {}),
-			reason: `invalid hosted runtime policy at ${policy.path}: ${policy.error ?? "parse failed"}`,
-		};
-	}
-
-	const reason = deniedCommandReason(policy.policy, normalized);
+	const reason = deniedCommandReason(HOSTED_POLICY, normalized);
 	if (reason) {
 		return {
 			allowed: false,
 			command: normalized,
 			runtimeMode,
-			policySource: policy.source,
-			...(policy.path ? { policyPath: policy.path } : {}),
+			policySource: "builtin",
 			reason,
 		};
 	}
@@ -228,7 +168,6 @@ export function evaluateHostPolicyForCommand(command: string): HostPolicyCommand
 		allowed: true,
 		command: normalized,
 		runtimeMode,
-		policySource: policy.source,
-		...(policy.path ? { policyPath: policy.path } : {}),
+		policySource: "builtin",
 	};
 }

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -43,6 +43,7 @@ function tempRuntimePaths(): RuntimePaths {
 	process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
 	process.env.CLAWDI_HOME = join(root, "clawdi-home");
 	process.env.CLAWDI_AUTH_TOKEN = "test-token";
+	process.env.CLAWDI_RUNTIME_AUTH_ENV = "CLAWDI_AUTH_TOKEN";
 	process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
 	return getRuntimePaths({ mode: "hosted" });
 }

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -27,6 +27,7 @@ function tempRuntimePaths(): RuntimePaths {
 	process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
 	process.env.CLAWDI_HOME = join(root, "clawdi-home");
 	process.env.CLAWDI_AUTH_TOKEN = "test-token";
+	process.env.CLAWDI_RUNTIME_AUTH_ENV = "CLAWDI_AUTH_TOKEN";
 	return getRuntimePaths({ mode: "hosted" });
 }
 

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -277,11 +277,28 @@ function runtimeCredential(paths: RuntimePaths): string | null {
 function resolveRuntimeSource(paths: RuntimePaths): RuntimeSource {
 	const explicit = process.env.CLAWDI_RUNTIME_MANIFEST_URL?.trim();
 	if (explicit) {
+		let url: URL;
+		try {
+			url = new URL(explicit);
+		} catch {
+			throw new Error("invalid CLAWDI_RUNTIME_MANIFEST_URL: expected an absolute URL");
+		}
+		if (url.protocol !== "https:" && url.protocol !== "http:") {
+			throw new Error("invalid CLAWDI_RUNTIME_MANIFEST_URL: protocol must be http or https");
+		}
+		if (url.username || url.password || url.hash) {
+			throw new Error(
+				"invalid CLAWDI_RUNTIME_MANIFEST_URL: credentials and fragments are forbidden",
+			);
+		}
 		return {
 			schemaVersion: "clawdi.runtimeSource.v1",
 			type: "http",
 			url: explicit,
 		};
+	}
+	if (paths.mode === "hosted") {
+		throw new Error("missing CLAWDI_RUNTIME_MANIFEST_URL");
 	}
 	return readRuntimeSource(paths);
 }
@@ -682,6 +699,9 @@ function hostedControlPlaneApiUrl(hosted: HostedRuntimeManifest): string {
 function runtimeManifestUrlFromEnvOrSource(): string {
 	const explicit = process.env.CLAWDI_RUNTIME_MANIFEST_URL?.trim();
 	if (explicit) return explicit;
+	if (process.env.CLAWDI_RUNTIME_MODE?.trim().toLowerCase() === "hosted") {
+		throw new Error("missing CLAWDI_RUNTIME_MANIFEST_URL");
+	}
 	const sourcePath =
 		process.env.CLAWDI_RUNTIME_SOURCE_PATH?.trim() || "/etc/clawdi/runtime-source.json";
 	if (existsSync(sourcePath)) {

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -291,6 +291,11 @@ function resolveRuntimeSource(paths: RuntimePaths): RuntimeSource {
 				"invalid CLAWDI_RUNTIME_MANIFEST_URL: credentials and fragments are forbidden",
 			);
 		}
+		if (paths.mode === "hosted" && !url.pathname.endsWith("/v1/runtime/manifest")) {
+			throw new Error(
+				"invalid CLAWDI_RUNTIME_MANIFEST_URL: hosted manifest path must end with /v1/runtime/manifest",
+			);
+		}
 		return {
 			schemaVersion: "clawdi.runtimeSource.v1",
 			type: "http",
@@ -378,11 +383,8 @@ function runtimeChannelsUrl(source: RuntimeSource): string {
 	const url = new URL(source.url);
 	const environmentId = url.searchParams.get("environment_id");
 	const path = url.pathname.replace(/\/+$/, "");
-	// Manifest URLs persisted before the /v1 migration still use /api.
-	const manifestSuffix = ["/v1/runtime/manifest", "/api/runtime/manifest"].find((suffix) =>
-		path.endsWith(suffix),
-	);
-	if (manifestSuffix) {
+	const manifestSuffix = "/v1/runtime/manifest";
+	if (path.endsWith(manifestSuffix)) {
 		const prefix = path.slice(0, -manifestSuffix.length);
 		url.pathname = `${prefix}/v1/channels`;
 	} else {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -4523,9 +4523,6 @@ function writeSystemdUnits(
 		CLAWDI_SERVICE_STATE_DIR: paths.serviceStateRoot,
 		CLAWDI_RUN_DIR: paths.runRoot,
 		CLAWDI_RUNTIME_MANIFEST_URL: runtimeManifestUrlEnv(manifest, sourcePath),
-		CLAWDI_RUNTIME_SOURCE_PATH:
-			process.env.CLAWDI_RUNTIME_SOURCE_PATH?.trim() || paths.runtimeSource,
-		CLAWDI_HOST_POLICY_PATH: paths.hostPolicy,
 		[RUNTIME_BRIDGE_TOKEN_ENV]: "",
 		[RUNTIME_BRIDGE_LISTEN_HOST_ENV]: process.env[RUNTIME_BRIDGE_LISTEN_HOST_ENV]?.trim() ?? "",
 		[RUNTIME_BRIDGE_SURFACES_ENV]: "",

--- a/packages/cli/src/runtime/paths.ts
+++ b/packages/cli/src/runtime/paths.ts
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { getClawdiDir } from "../lib/config";
@@ -98,9 +97,8 @@ export function getRuntimeSourcePath(): string {
 
 export function detectRuntimeMode(): RuntimeMode {
 	const explicit = process.env.CLAWDI_RUNTIME_MODE?.trim().toLowerCase();
-	if (explicit === "hosted" || explicit === "hosted-runtime") return "hosted";
+	if (explicit === "hosted") return "hosted";
 	if (explicit === "local") return "local";
-	if (existsSync(getHostPolicyPath())) return "hosted";
 	return "local";
 }
 

--- a/packages/cli/src/runtime/state.ts
+++ b/packages/cli/src/runtime/state.ts
@@ -55,7 +55,8 @@ export interface RuntimeBootStatus {
 	exitCode: number;
 	datasource: "RuntimeSource";
 	hostPolicy: {
-		path: string;
+		source: "builtin" | "file";
+		path?: string;
 		exists: boolean;
 		valid: boolean;
 		mode?: string;
@@ -159,7 +160,8 @@ export function buildRuntimeBootStatus(
 
 export function hostPolicySummary(policy: HostPolicyReadResult): RuntimeBootStatus["hostPolicy"] {
 	return {
-		path: policy.path,
+		source: policy.source,
+		...(policy.path ? { path: policy.path } : {}),
 		exists: policy.exists,
 		valid: policy.valid,
 		mode: policy.policy?.mode,

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -60,6 +60,7 @@ const ENV_KEYS = [
 	"CLAWDI_RUN_DIR",
 	"CLAWDI_RUNTIME_HOME",
 	"CLAWDI_AUTH_TOKEN",
+	"CLAWDI_RUNTIME_AUTH_ENV",
 	"CLAWDI_RUNTIME_MANIFEST_PATH",
 	"CLAWDI_RUNTIME_MANIFEST_URL",
 	"CLAWDI_RUNTIME_SOURCE_PATH",
@@ -105,6 +106,7 @@ beforeEach(() => {
 	root = join(tmpdir(), `clawdi-runtime-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	mkdirSync(root, { recursive: true });
 	process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
+	process.env.CLAWDI_RUNTIME_AUTH_ENV = "CLAWDI_AUTH_TOKEN";
 });
 
 afterEach(() => {
@@ -747,47 +749,31 @@ describe("runtime run config", () => {
 });
 
 describe("host policy", () => {
-	it("parses denied commands from strings and objects", () => {
-		const path = join(root, "host-policy.json");
+	it("uses the first-class built-in hosted contract", () => {
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_HOST_POLICY_PATH = path;
-		writeFileSync(
-			path,
-			JSON.stringify({
-				schemaVersion: "clawdi.hostPolicy.v1",
-				mode: "hosted-runtime",
-				deniedCommands: ["setup", { command: "config set", reason: "managed config" }],
-				managedState: ["/var/lib/clawdi/config"],
-				systemWritableState: ["/var/lib/clawdi", "/run/clawdi"],
-				userWritableState: ["/home/clawdi", "/tmp"],
-				ordinaryUserDeniedState: ["/var/lib/clawdi"],
-			}),
-		);
-
-		const result = readHostPolicy(path);
+		const result = readHostPolicy();
 		expect(result.valid).toBe(true);
+		expect(result.source).toBe("builtin");
+		expect(result.path).toBeUndefined();
 		expect(result.policy?.systemWritableState).toEqual(["/var/lib/clawdi", "/run/clawdi"]);
 		expect(result.policy?.userWritableState).toEqual(["/home/clawdi", "/tmp"]);
 		expect(result.policy?.ordinaryUserDeniedState).toEqual(["/var/lib/clawdi"]);
-		expect(deniedCommandReason(result.policy, "setup")).toBe("disabled by hosted runtime policy");
-		expect(deniedCommandReason(result.policy, "config set apiUrl http://x")).toBe("managed config");
+		expect(deniedCommandReason(result.policy, "setup")).toBe(
+			"runtime setup is managed by clawdi runtime init",
+		);
+		expect(deniedCommandReason(result.policy, "update")).toBe(
+			"CLI updates are managed by the hosted runtime installation",
+		);
 		expect(deniedCommandReason(result.policy, "mcp")).toBe(null);
-		expect(evaluateHostPolicyForCommand("config set apiUrl http://x")).toEqual({
-			allowed: false,
-			command: "config set apiUrl http://x",
-			runtimeMode: "hosted",
-			policyPath: path,
-			reason: "managed config",
-		});
 		expect(evaluateHostPolicyForCommand("mcp")).toEqual({
 			allowed: true,
 			command: "mcp",
 			runtimeMode: "hosted",
-			policyPath: path,
+			policySource: "builtin",
 		});
 	});
 
-	it("fails closed for malformed policy JSON", () => {
+	it("ignores image policy files in hosted mode", () => {
 		const path = join(root, "host-policy.json");
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_HOST_POLICY_PATH = path;
@@ -795,22 +781,16 @@ describe("host policy", () => {
 
 		const result = readHostPolicy(path);
 		expect(result.exists).toBe(true);
-		expect(result.valid).toBe(false);
-		expect(result.error).toBeTruthy();
-		expect(evaluateHostPolicyForCommand("config set apiUrl http://x").allowed).toBe(false);
-		expect(evaluateHostPolicyForCommand("runtime doctor").allowed).toBe(true);
+		expect(result.valid).toBe(true);
+		expect(result.source).toBe("builtin");
+		expect(result.path).toBeUndefined();
 	});
 
-	it("fails closed for missing policy except recovery commands", () => {
-		const path = join(root, "missing-host-policy.json");
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+	it("does not infer hosted mode from a policy file", () => {
+		const path = join(root, "host-policy.json");
 		process.env.CLAWDI_HOST_POLICY_PATH = path;
-
-		const denied = evaluateHostPolicyForCommand("auth login");
-		expect(denied.allowed).toBe(false);
-		expect(denied.reason).toContain("missing hosted runtime policy");
-		expect(evaluateHostPolicyForCommand("config paths").allowed).toBe(true);
-		expect(evaluateHostPolicyForCommand("runtime status").allowed).toBe(true);
+		writeFileSync(path, "{}");
+		expect(detectRuntimeMode()).toBe("local");
 	});
 });
 
@@ -822,6 +802,7 @@ describe("runtime manifest datasource", () => {
 		mkdirSync(home, { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		delete process.env.CLAWDI_RUNTIME_MANIFEST_URL;
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 
@@ -831,7 +812,7 @@ describe("runtime manifest datasource", () => {
 		expect(loaded.mode).toBe("repair");
 		expect(loaded.stage).toBe("network");
 		expect(loaded.errors[0]).toContain("could not fetch runtime manifest");
-		expect(loaded.errors[0]).toContain("runtime source config does not exist");
+		expect(loaded.errors[0]).toContain("missing CLAWDI_RUNTIME_MANIFEST_URL");
 	});
 
 	it("loads last-good offline boot when cached secret values satisfy refs", async () => {
@@ -935,7 +916,7 @@ describe("runtime manifest datasource", () => {
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_AUTH_TOKEN = "auth-token";
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/manifest";
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({
@@ -1087,7 +1068,7 @@ chmod +x "$HOME/.local/bin/hermes"
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_AUTH_TOKEN = "auth-token";
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/manifest";
 		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
 		process.env.CLAWDI_RUNTIME_TEST_HERMES_INSTALLER = hermesInstaller;
 		process.env.CLAWDI_RUNTIME_PID1_ENVIRON_PATH = pid1EnvPath;
@@ -3019,7 +3000,7 @@ exit 64
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
 		process.env.CLAWDI_AUTH_TOKEN = "bootstrap-token";
 		process.env.CUSTOM_RUNTIME_TOKEN = "stale-token";
 		writeFileSync(join(run, "secrets", "auth-token"), "stale-file-token\n");
@@ -3076,7 +3057,7 @@ exit 64
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH = wrongSourcePath;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
 		process.env.CLAWDI_AUTH_TOKEN = "runtime-file-token";
 		writeFileSync(
 			wrongSourcePath,
@@ -3189,7 +3170,7 @@ exit 64
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
 		process.env.CLAWDI_AUTH_TOKEN = "";
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
@@ -3240,7 +3221,8 @@ exit 64
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL =
+			"https://runtime.test/prefix/v1/runtime/manifest?environment_id=env_runtime";
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
@@ -3749,7 +3731,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
 		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
 		process.exitCode = undefined;
 		console.log = (value?: unknown) => {
@@ -3885,7 +3867,7 @@ exit 42
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
 		process.env.CLAWDI_SYSTEMD_APPLY = "1";
 		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
 		process.exitCode = undefined;
@@ -4073,7 +4055,7 @@ exit 64
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
 		process.exitCode = undefined;
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
@@ -4207,7 +4189,7 @@ exit 64
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
@@ -4301,7 +4283,7 @@ exit 64
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
 		writeFileSync(join(run, "secrets", "auth-token"), "revoked-runtime-token\n");
 		writeFileSync(
 			sourcePath,
@@ -4807,7 +4789,7 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
 		process.exitCode = undefined;
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
@@ -4973,7 +4955,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
 		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
 		process.env.CLAWDI_SYSTEMD_APPLY = "1";
 		process.exitCode = undefined;
@@ -5331,7 +5313,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
 		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
 		process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER = openclawInstaller;
 		process.exitCode = undefined;
@@ -5483,7 +5465,7 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
 		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
 		process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER = openclawInstaller;
 		process.exitCode = undefined;
@@ -5620,7 +5602,7 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
 		process.exitCode = undefined;
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
@@ -5753,7 +5735,7 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
 		process.exitCode = undefined;
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
@@ -6244,7 +6226,7 @@ exit 64
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH = sourcePath;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
 		process.env.CLAWDI_HOST_POLICY_PATH = policyPath;
 		process.exitCode = undefined;
 		console.log = (value?: unknown) => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -16,6 +16,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { runtimeInit, runtimeWatch } from "../src/commands/runtime";
+import { runtimeAuthEnvName } from "../src/runtime/auth-token";
 import {
 	RUNTIME_BRIDGE_LISTEN_HOST_ENV,
 	RUNTIME_BRIDGE_SURFACES_ENV,
@@ -795,6 +796,17 @@ describe("host policy", () => {
 });
 
 describe("runtime manifest datasource", () => {
+	it("validates the deployment-selected auth environment name", () => {
+		delete process.env.CLAWDI_RUNTIME_AUTH_ENV;
+		expect(() => runtimeAuthEnvName()).toThrow("missing CLAWDI_RUNTIME_AUTH_ENV");
+
+		process.env.CLAWDI_RUNTIME_AUTH_ENV = "lowercase_token";
+		expect(() => runtimeAuthEnvName()).toThrow("expected an uppercase environment variable name");
+
+		process.env.CLAWDI_RUNTIME_AUTH_ENV = "CUSTOM_RUNTIME_TOKEN";
+		expect(runtimeAuthEnvName()).toBe("CUSTOM_RUNTIME_TOKEN");
+	});
+
 	it("reports missing runtime source when no fixture or cache exists", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -813,6 +825,24 @@ describe("runtime manifest datasource", () => {
 		expect(loaded.stage).toBe("network");
 		expect(loaded.errors[0]).toContain("could not fetch runtime manifest");
 		expect(loaded.errors[0]).toContain("missing CLAWDI_RUNTIME_MANIFEST_URL");
+	});
+
+	it("rejects noncanonical hosted manifest paths", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://cloud-api.example.test/api/runtime/manifest";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths());
+		expect("errors" in loaded).toBe(true);
+		if (!("errors" in loaded)) throw new Error("expected manifest load failure");
+		expect(loaded.mode).toBe("repair");
+		expect(loaded.errors[0]).toContain("hosted manifest path must end with /v1/runtime/manifest");
 	});
 
 	it("loads last-good offline boot when cached secret values satisfy refs", async () => {
@@ -916,20 +946,20 @@ describe("runtime manifest datasource", () => {
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_AUTH_TOKEN = "auth-token";
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/manifest";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({
 				schemaVersion: "clawdi.runtimeSource.v1",
 				type: "http",
-				url: "https://runtime.test/v1/manifest",
+				url: "https://runtime.test/v1/runtime/manifest",
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
 		const { captured, restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/v1/manifest",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					jsonResponse({
 						manifest: {
@@ -948,7 +978,7 @@ describe("runtime manifest datasource", () => {
 								persistentPaths: [home],
 							},
 							controlPlane: {
-								manifestUrl: "https://runtime-source.test/desired-state",
+								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							clawdiCli: {
@@ -1001,7 +1031,7 @@ describe("runtime manifest datasource", () => {
 			expect(captured).toHaveLength(1);
 			expect(captured[0].headers.authorization).toBe("Bearer auth-token");
 			expect(loaded.source).toBe("remote-datasource");
-			expect(loaded.sourcePath).toBe("https://runtime.test/v1/manifest");
+			expect(loaded.sourcePath).toBe("https://runtime.test/v1/runtime/manifest");
 			expect(loaded.manifest.schemaVersion).toBe("clawdi.runtimeDesiredState.v1");
 			expect(loaded.manifest.workspaceRoot).toBe(join(home, "managed-workspace"));
 			expect(loaded.manifest.environmentId).toBe("env_test");
@@ -1068,7 +1098,7 @@ chmod +x "$HOME/.local/bin/hermes"
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_AUTH_TOKEN = "auth-token";
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/manifest";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
 		process.env.CLAWDI_RUNTIME_TEST_HERMES_INSTALLER = hermesInstaller;
 		process.env.CLAWDI_RUNTIME_PID1_ENVIRON_PATH = pid1EnvPath;
@@ -1077,14 +1107,14 @@ chmod +x "$HOME/.local/bin/hermes"
 			JSON.stringify({
 				schemaVersion: "clawdi.runtimeSource.v1",
 				type: "http",
-				url: "https://runtime.test/v1/manifest",
+				url: "https://runtime.test/v1/runtime/manifest",
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
 		const { restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/v1/manifest",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					jsonResponse({
 						manifest: {
@@ -1098,7 +1128,7 @@ chmod +x "$HOME/.local/bin/hermes"
 							issuedAt: "2026-06-06T00:00:00Z",
 							system: { home, workspace: join(home, "managed-workspace") },
 							controlPlane: {
-								manifestUrl: "https://runtime-source.test/desired-state",
+								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							runtimes: {
@@ -1168,11 +1198,11 @@ chmod +x "$HOME/.local/bin/hermes"
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_AUTH_TOKEN = "auth-token";
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime-source.test/desired-state";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime-source.test/v1/runtime/manifest";
 		const { restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/desired-state",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					jsonResponse({
 						manifest: {
@@ -1186,7 +1216,7 @@ chmod +x "$HOME/.local/bin/hermes"
 							issuedAt: "2026-06-22T00:00:00Z",
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
-								manifestUrl: "https://runtime-source.test/desired-state",
+								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							runtimes: {
@@ -1256,7 +1286,7 @@ chmod +x "$HOME/.local/bin/hermes"
 		const run = join(root, "run", "clawdi");
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime-source.test/desired-state";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime-source.test/v1/runtime/manifest";
 		process.env.CLAWDI_AUTH_TOKEN = "runtime-auth-token";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
@@ -1264,7 +1294,7 @@ chmod +x "$HOME/.local/bin/hermes"
 		const { restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/desired-state",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					jsonResponse({
 						manifest: {
@@ -1278,7 +1308,7 @@ chmod +x "$HOME/.local/bin/hermes"
 							issuedAt: "2026-06-22T00:00:00Z",
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
-								manifestUrl: "https://runtime-source.test/desired-state",
+								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							runtimes: {
@@ -2989,7 +3019,7 @@ exit 64
 		);
 	});
 
-	it("ignores runtime source auth env and uses the runtime auth token env before the file", async () => {
+	it("uses the deployment-selected auth env and ignores runtime source file auth", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -3000,23 +3030,24 @@ exit 64
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
-		process.env.CLAWDI_AUTH_TOKEN = "bootstrap-token";
-		process.env.CUSTOM_RUNTIME_TOKEN = "stale-token";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
+		process.env.CLAWDI_RUNTIME_AUTH_ENV = "CUSTOM_RUNTIME_TOKEN";
+		process.env.CLAWDI_AUTH_TOKEN = "stale-default-token";
+		process.env.CUSTOM_RUNTIME_TOKEN = "bootstrap-token";
 		writeFileSync(join(run, "secrets", "auth-token"), "stale-file-token\n");
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({
 				schemaVersion: "clawdi.runtimeSource.v1",
 				type: "http",
-				url: "https://runtime.test/manifest",
+				url: "https://runtime.test/v1/runtime/manifest",
 				auth: { type: "bearer-env", env: "CUSTOM_RUNTIME_TOKEN" },
 			}),
 		);
 		const { captured, restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/manifest",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					jsonResponse({
 						manifest: {
@@ -3056,8 +3087,7 @@ exit 64
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.env.CLAWDI_AUTH_TOKEN = "runtime-file-token";
 		writeFileSync(
 			wrongSourcePath,
@@ -3071,7 +3101,7 @@ exit 64
 		const { captured, restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/manifest",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					jsonResponse({
 						manifest: {
@@ -3084,7 +3114,7 @@ exit 64
 							issuedAt: "2026-06-06T00:00:00Z",
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
-								manifestUrl: "https://runtime.test/manifest",
+								manifestUrl: "https://runtime.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							runtimes: { openclaw: hostedOpenClawRuntime() },
@@ -3098,7 +3128,7 @@ exit 64
 			},
 			{
 				method: "GET",
-				path: "/manifest",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					jsonResponse({
 						manifest: {
@@ -3111,7 +3141,7 @@ exit 64
 							issuedAt: "2026-06-06T00:01:00Z",
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
-								manifestUrl: "https://runtime.test/manifest",
+								manifestUrl: "https://runtime.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							runtimes: { openclaw: hostedOpenClawRuntime() },
@@ -3139,10 +3169,10 @@ exit 64
 			const watched = await loadRemoteRuntimeManifest(paths);
 
 			expect("manifest" in watched).toBe(true);
-			expect(watchManifestUrl).toBe("https://runtime.test/manifest");
+			expect(watchManifestUrl).toBe("https://runtime.test/v1/runtime/manifest");
 			expect(captured.map((entry) => entry.url)).toEqual([
-				"https://runtime.test/manifest",
-				"https://runtime.test/manifest",
+				"https://runtime.test/v1/runtime/manifest",
+				"https://runtime.test/v1/runtime/manifest",
 			]);
 			expect(captured.map((entry) => entry.headers.authorization)).toEqual([
 				"Bearer runtime-file-token",
@@ -3153,6 +3183,8 @@ exit 64
 				"runtime-file-token\n",
 			);
 			expect(watchEnv).toContain('CLAWDI_AUTH_TOKEN=""');
+			expect(watchEnv).not.toContain("CLAWDI_HOST_POLICY_PATH");
+			expect(watchEnv).not.toContain("CLAWDI_RUNTIME_SOURCE_PATH");
 			expect(watchEnv).not.toContain("runtime-file-token");
 		} finally {
 			restore();
@@ -3170,7 +3202,7 @@ exit 64
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.env.CLAWDI_AUTH_TOKEN = "";
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
@@ -3178,14 +3210,14 @@ exit 64
 			JSON.stringify({
 				schemaVersion: "clawdi.runtimeSource.v1",
 				type: "http",
-				url: "https://runtime.test/manifest",
+				url: "https://runtime.test/v1/runtime/manifest",
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
 		const { captured, restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/manifest",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					new Response(null, {
 						status: 304,
@@ -3731,7 +3763,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
 		process.exitCode = undefined;
 		console.log = (value?: unknown) => {
@@ -3744,14 +3776,14 @@ printf 'ActiveState=active\\nSubState=running\\n'
 			JSON.stringify({
 				schemaVersion: "clawdi.runtimeSource.v1",
 				type: "http",
-				url: "https://runtime.test/manifest",
+				url: "https://runtime.test/v1/runtime/manifest",
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
 		const { captured, restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/manifest",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					new Response(
 						JSON.stringify({
@@ -3867,7 +3899,7 @@ exit 42
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.env.CLAWDI_SYSTEMD_APPLY = "1";
 		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
 		process.exitCode = undefined;
@@ -3881,14 +3913,14 @@ exit 42
 			JSON.stringify({
 				schemaVersion: "clawdi.runtimeSource.v1",
 				type: "http",
-				url: "https://runtime.test/manifest",
+				url: "https://runtime.test/v1/runtime/manifest",
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
 		const { restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/manifest",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					new Response(
 						JSON.stringify({
@@ -4055,7 +4087,7 @@ exit 64
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.exitCode = undefined;
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
@@ -4067,13 +4099,13 @@ exit 64
 			JSON.stringify({
 				schemaVersion: "clawdi.runtimeSource.v1",
 				type: "http",
-				url: "https://runtime.test/manifest",
+				url: "https://runtime.test/v1/runtime/manifest",
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
 		const paths = getRuntimePaths();
 		const initial = mockFetch([
-			{ method: "GET", path: "/manifest", response: manifestResponse },
+			{ method: "GET", path: "/v1/runtime/manifest", response: manifestResponse },
 			{ method: "GET", path: "/v1/channels", response: channelsResponse },
 		]);
 		try {
@@ -4119,7 +4151,7 @@ exit 64
 		const watchFetch = mockFetch([
 			{
 				method: "GET",
-				path: "/manifest",
+				path: "/v1/runtime/manifest",
 				response: (request) =>
 					request.headers["if-none-match"]
 						? new Response(null, {
@@ -4138,9 +4170,9 @@ exit 64
 				throw new Error(logs.join("\n"));
 			}
 			expect(watchFetch.captured.map((request) => request.path)).toEqual([
-				"/manifest",
+				"/v1/runtime/manifest",
 				"/v1/channels",
-				"/manifest",
+				"/v1/runtime/manifest",
 			]);
 			expect(watchFetch.captured[0].headers["if-none-match"]).toBe('"manifest-etag-stable"');
 			expect(watchFetch.captured[1].headers["if-none-match"]).toBe('"channels-etag-current"');
@@ -4189,14 +4221,14 @@ exit 64
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({
 				schemaVersion: "clawdi.runtimeSource.v1",
 				type: "http",
-				url: "https://runtime.test/manifest",
+				url: "https://runtime.test/v1/runtime/manifest",
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
@@ -4211,7 +4243,7 @@ exit 64
 			process.exitCode = undefined;
 			logs.length = 0;
 			const { restore } = mockFetch([
-				{ method: "GET", path: "/manifest", response: manifestResponse },
+				{ method: "GET", path: "/v1/runtime/manifest", response: manifestResponse },
 				{ method: "GET", path: "/v1/channels", response: () => jsonResponse([]) },
 			]);
 			try {
@@ -4283,14 +4315,14 @@ exit 64
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		writeFileSync(join(run, "secrets", "auth-token"), "revoked-runtime-token\n");
 		writeFileSync(
 			sourcePath,
 			JSON.stringify({
 				schemaVersion: "clawdi.runtimeSource.v1",
 				type: "http",
-				url: "https://runtime.test/manifest",
+				url: "https://runtime.test/v1/runtime/manifest",
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
@@ -4300,7 +4332,7 @@ exit 64
 		const { restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/manifest",
+				path: "/v1/runtime/manifest",
 				response: () => new Response("revoked", { status: 401 }),
 			},
 			{ method: "GET", path: "/v1/channels", response: () => jsonResponse([]) },
@@ -4789,7 +4821,7 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.exitCode = undefined;
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
@@ -4800,14 +4832,14 @@ chmod +x "$prefix/bin/clawdi"
 			JSON.stringify({
 				schemaVersion: "clawdi.runtimeSource.v1",
 				type: "http",
-				url: "https://runtime.test/manifest",
+				url: "https://runtime.test/v1/runtime/manifest",
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
 		const { captured, restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/manifest",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					new Response(
 						JSON.stringify({
@@ -4955,7 +4987,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
 		process.env.CLAWDI_SYSTEMD_APPLY = "1";
 		process.exitCode = undefined;
@@ -4968,7 +5000,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 			JSON.stringify({
 				schemaVersion: "clawdi.runtimeSource.v1",
 				type: "http",
-				url: "https://runtime.test/manifest",
+				url: "https://runtime.test/v1/runtime/manifest",
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
@@ -5042,7 +5074,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		const { restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/manifest",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					new Response(
 						JSON.stringify({
@@ -5313,7 +5345,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
 		process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER = openclawInstaller;
 		process.exitCode = undefined;
@@ -5326,14 +5358,14 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 			JSON.stringify({
 				schemaVersion: "clawdi.runtimeSource.v1",
 				type: "http",
-				url: "https://runtime.test/manifest",
+				url: "https://runtime.test/v1/runtime/manifest",
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
 		const { restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/manifest",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					new Response(
 						JSON.stringify({
@@ -5465,7 +5497,7 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
 		process.env.CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER = openclawInstaller;
 		process.exitCode = undefined;
@@ -5478,7 +5510,7 @@ chmod +x "$prefix/bin/clawdi"
 			JSON.stringify({
 				schemaVersion: "clawdi.runtimeSource.v1",
 				type: "http",
-				url: "https://runtime.test/manifest",
+				url: "https://runtime.test/v1/runtime/manifest",
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
@@ -5508,7 +5540,7 @@ chmod +x "$prefix/bin/clawdi"
 		const { restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/manifest",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					new Response(
 						JSON.stringify({
@@ -5602,7 +5634,7 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.exitCode = undefined;
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
@@ -5613,14 +5645,14 @@ chmod +x "$prefix/bin/clawdi"
 			JSON.stringify({
 				schemaVersion: "clawdi.runtimeSource.v1",
 				type: "http",
-				url: "https://runtime.test/manifest",
+				url: "https://runtime.test/v1/runtime/manifest",
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
 		const { restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/manifest",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					new Response(
 						JSON.stringify({
@@ -5735,7 +5767,7 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.exitCode = undefined;
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
@@ -5746,14 +5778,14 @@ chmod +x "$prefix/bin/clawdi"
 			JSON.stringify({
 				schemaVersion: "clawdi.runtimeSource.v1",
 				type: "http",
-				url: "https://runtime.test/manifest",
+				url: "https://runtime.test/v1/runtime/manifest",
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
 		const { restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/manifest",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					new Response(
 						JSON.stringify({
@@ -6218,7 +6250,7 @@ exit 64
 			JSON.stringify({
 				schemaVersion: "clawdi.runtimeSource.v1",
 				type: "http",
-				url: "https://runtime.test/manifest",
+				url: "https://runtime.test/v1/runtime/manifest",
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
@@ -6226,7 +6258,7 @@ exit 64
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/manifest";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.env.CLAWDI_HOST_POLICY_PATH = policyPath;
 		process.exitCode = undefined;
 		console.log = (value?: unknown) => {
@@ -6236,7 +6268,7 @@ exit 64
 		const { captured, restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/manifest",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					new Response(
 						JSON.stringify({
@@ -6322,7 +6354,10 @@ exit 64
 
 			expect(process.exitCode).toBe(0);
 			expect(captured).toHaveLength(2);
-			expect(captured.map((request) => request.path)).toEqual(["/manifest", "/v1/channels"]);
+			expect(captured.map((request) => request.path)).toEqual([
+				"/v1/runtime/manifest",
+				"/v1/channels",
+			]);
 			expect(readFileSync(join(state, "cache", "manifest.etag"), "utf-8")).toBe(
 				'"manifest-etag-init-7"\n',
 			);
@@ -7374,11 +7409,11 @@ exit 64
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_AUTH_TOKEN = "auth-token";
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime-source.test/desired-state";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime-source.test/v1/runtime/manifest";
 		const { restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/desired-state",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					jsonResponse({
 						manifest: {
@@ -8411,11 +8446,11 @@ exit 64
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_AUTH_TOKEN = "auth-token";
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime-source.test/desired-state";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime-source.test/v1/runtime/manifest";
 		const { restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/desired-state",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					jsonResponse({
 						manifest: {
@@ -8458,12 +8493,12 @@ exit 64
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_AUTH_TOKEN = "auth-token";
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime-source.test/desired-state";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime-source.test/v1/runtime/manifest";
 		const mitmproxy = seedMitmproxyCache();
 		const { restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/desired-state",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					jsonResponse({
 						manifest: {
@@ -8476,7 +8511,7 @@ exit 64
 							issuedAt: "2026-06-06T00:00:00Z",
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
-								manifestUrl: "https://runtime-source.test/desired-state",
+								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							egressEngine: mitmproxy,
@@ -8733,11 +8768,11 @@ exit 64
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_AUTH_TOKEN = "runtime-auth-token";
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime-source.test/desired-state";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime-source.test/v1/runtime/manifest";
 		const { restore } = mockFetch([
 			{
 				method: "GET",
-				path: "/desired-state",
+				path: "/v1/runtime/manifest",
 				response: () =>
 					jsonResponse({
 						manifest: {
@@ -8750,7 +8785,7 @@ exit 64
 							issuedAt: "2026-06-06T00:00:00Z",
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
-								manifestUrl: "https://runtime-source.test/desired-state",
+								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							runtimes: {
@@ -8803,7 +8838,7 @@ exit 64
 			expect(systemUnitNames).toContain("clawdi-daemon.service");
 			expect(watchUnit).toContain('ExecStart="clawdi" "runtime" "watch"');
 			expect(watchEnv).toContain(
-				'CLAWDI_RUNTIME_MANIFEST_URL="https://runtime-source.test/desired-state"',
+				'CLAWDI_RUNTIME_MANIFEST_URL="https://runtime-source.test/v1/runtime/manifest"',
 			);
 			expect(watchEnv).not.toContain("runtime-auth-token");
 			expect(daemonUnit).toContain(
@@ -8818,7 +8853,7 @@ exit 64
 			expect(daemonEnv).toContain('CLAWDI_RUNTIME_REV="');
 			expect(daemonEnv).toContain("https://cloud-api.test");
 			expect(watchEnv).toContain(
-				'CLAWDI_RUNTIME_MANIFEST_URL="https://runtime-source.test/desired-state"',
+				'CLAWDI_RUNTIME_MANIFEST_URL="https://runtime-source.test/v1/runtime/manifest"',
 			);
 			expect(watchEnv).toContain('CLAWDI_AUTH_TOKEN=""');
 			expect(watchUnit).not.toContain("runtime-auth-token");

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -654,7 +654,7 @@ chmod +x "$HOME/.local/bin/hermes"
 
 	it("runtime init rejects fixture secretRefs without inline secretValues", async () => {
 		const { tmpdir } = await import("node:os");
-		const { mkdirSync, rmSync } = await import("node:fs");
+		const { mkdirSync, rmSync, writeFileSync } = await import("node:fs");
 		const root = join(tmpdir(), `clawdi-smoke-runtime-secretref-${Date.now()}`);
 		const home = join(root, "home", "clawdi");
 		const policyPath = join(root, "etc", "clawdi", "host-policy.json");

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -20,6 +20,7 @@ async function runCli(
 		...process.env,
 		CLAWDI_NO_AUTO_UPDATE: "1",
 		CLAWDI_NO_UPDATE_CHECK: "1",
+		CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
 	};
 	for (const [key, value] of Object.entries(envOverrides)) {
 		if (value === undefined) delete env[key];
@@ -653,7 +654,7 @@ chmod +x "$HOME/.local/bin/hermes"
 
 	it("runtime init rejects fixture secretRefs without inline secretValues", async () => {
 		const { tmpdir } = await import("node:os");
-		const { mkdirSync, rmSync, writeFileSync } = await import("node:fs");
+		const { mkdirSync, rmSync } = await import("node:fs");
 		const root = join(tmpdir(), `clawdi-smoke-runtime-secretref-${Date.now()}`);
 		const home = join(root, "home", "clawdi");
 		const policyPath = join(root, "etc", "clawdi", "host-policy.json");
@@ -861,7 +862,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 		}
 	});
 
-	it("runtime init writes repair status when host policy is missing", async () => {
+	it("runtime init uses built-in policy when image policy is missing", async () => {
 		const { tmpdir } = await import("node:os");
 		const { existsSync, mkdirSync, rmSync } = await import("node:fs");
 		const root = join(tmpdir(), `clawdi-smoke-runtime-no-policy-${Date.now()}`);
@@ -879,46 +880,38 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 				CLAWDI_RUN_DIR: join(root, "run", "clawdi"),
 				CLAWDI_AUTH_TOKEN: "auth-test-token",
 			});
-			expect(code).toBe(20);
+			expect(code).toBe(21);
 			const parsed = JSON.parse(stdout);
 			expect(parsed.mode).toBe("repair");
-			expect(parsed.stage).toBe("detect");
-			expect(parsed.hostPolicy.exists).toBe(false);
-			expect(parsed.errors[0]).toContain("missing hosted runtime policy");
+			expect(parsed.stage).toBe("network");
+			expect(parsed.hostPolicy.exists).toBe(true);
+			expect(parsed.hostPolicy.valid).toBe(true);
+			expect(parsed.hostPolicy.source).toBe("builtin");
+			expect(parsed.hostPolicy.path).toBeUndefined();
+			expect(parsed.errors[0]).toContain("missing CLAWDI_RUNTIME_MANIFEST_URL");
 			expect(existsSync(join(serviceStateRoot, "cache", "boot-status.json"))).toBe(true);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}
 	});
 
-	it("hosted policy denies local-user mutation commands", async () => {
+	it("built-in hosted policy denies CLI self-update", async () => {
 		const { tmpdir } = await import("node:os");
-		const { mkdirSync, rmSync, writeFileSync } = await import("node:fs");
+		const { mkdirSync, rmSync } = await import("node:fs");
 		const root = join(tmpdir(), `clawdi-smoke-policy-${Date.now()}`);
 		const home = join(root, "home", "clawdi");
-		const policyPath = join(root, "etc", "clawdi", "host-policy.json");
-		mkdirSync(dirname(policyPath), { recursive: true });
 		mkdirSync(home, { recursive: true });
-		writeFileSync(
-			policyPath,
-			JSON.stringify({
-				schemaVersion: "clawdi.hostPolicy.v1",
-				mode: "hosted-runtime",
-				deniedCommands: [{ command: "config set", reason: "managed config is runtime-owned" }],
-			}),
-		);
 
 		try {
-			const result = await runCli(["config", "set", "apiUrl", "http://example.test"], {
+			const result = await runCli(["update"], {
 				HOME: home,
 				CLAWDI_RUNTIME_MODE: "hosted",
-				CLAWDI_HOST_POLICY_PATH: policyPath,
 				CLAWDI_SERVICE_STATE_DIR: join(root, "var", "lib", "clawdi"),
 				CLAWDI_RUN_DIR: join(root, "run", "clawdi"),
 			});
 			expect(result.code).not.toBe(0);
 			expect(result.stderr).toContain("disabled in hosted runtime mode");
-			expect(result.stderr).toContain("managed config is runtime-owned");
+			expect(result.stderr).toContain("managed by the hosted runtime installation");
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Why

The hosted runtime image is a stable OS capability envelope. Hosted product policy, datasource validation, convergence, managed paths, egress, and lifecycle belong to the versioned CLI rather than baked image files.

## What changed

- make hosted command policy a first-class built-in CLI contract with honest `builtin` provenance
- select hosted mode only with `CLAWDI_RUNTIME_MODE=hosted`
- require deployment-provided `CLAWDI_RUNTIME_MANIFEST_URL` and `CLAWDI_RUNTIME_AUTH_ENV`
- require the hosted manifest URL path to end in canonical `/v1/runtime/manifest`
- remove the `/api/runtime/manifest` channels-URL compatibility branch
- stop hosted mode from reading `host-policy.json` or `runtime-source.json`
- publish `0.12.10-beta.48` on the isolated npm `agent-v2` dist-tag so the legacy `beta` channel does not move
- document the capability-envelope and release-channel boundary

## Verification

- CLI full suite: `793 passed`
- runtime datasource suite: `104 passed`
- workspace typecheck: 4 packages passed
- Biome check: 620 files passed
- publish manifest check passed; `publishConfig.tag` resolves to `agent-v2`
- paired local `.48` tarball smoke against Clawdi Hosted PR #780 passed end to end

## Rollout

Merge this PR, let the trusted-publisher workflow publish exact `clawdi@0.12.10-beta.48` under `agent-v2`, verify the exact version exists and the `beta` dist-tag is unchanged, then merge Hosted PR #780.

No merge, npm publish, image promotion, production, tenant, or database operation has been performed.