### PR TITLE
fix(runtime): isolate agent v2 minimum CLI protocol

### DIFF
--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -47,7 +47,7 @@ class _RuntimeProviderManifestBinding:
 
 
 _SUPPORTED_PROVIDER_RUNTIMES = {"codex", "hermes", "openclaw"}
-_HOSTED_MANIFEST_MINIMUM_CLI_VERSION = "0.12.10-beta.48"
+_AGENT_V2_MANIFEST_MINIMUM_CLI_VERSION = "0.12.10-beta.48"
 
 
 @router.get("/manifest")
@@ -104,7 +104,6 @@ async def get_runtime_manifest(
     issued_at = _runtime_manifest_issued_at(state, provider_version_sources)
     manifest: dict[str, Any] = {
         "schemaVersion": "clawdi.hosted-runtime.manifest.v1",
-        "minimumCliVersion": _HOSTED_MANIFEST_MINIMUM_CLI_VERSION,
         "deploymentId": state.deployment_id,
         "environmentId": str(environment_id),
         "instanceId": state.instance_id,
@@ -118,6 +117,8 @@ async def get_runtime_manifest(
         "liveSync": state.live_sync or _default_live_sync(env),
         "recovery": state.recovery or {"cacheManifest": True, "allowOfflineBoot": True},
     }
+    if request.scope["path"] == "/v1/runtime/manifest":
+        manifest["minimumCliVersion"] = _AGENT_V2_MANIFEST_MINIMUM_CLI_VERSION
     if state.bridge:
         manifest["bridge"] = state.bridge
     if state.app_id:

--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -47,6 +47,7 @@ class _RuntimeProviderManifestBinding:
 
 
 _SUPPORTED_PROVIDER_RUNTIMES = {"codex", "hermes", "openclaw"}
+_HOSTED_MANIFEST_MINIMUM_CLI_VERSION = "0.12.10-beta.48"
 
 
 @router.get("/manifest")
@@ -103,6 +104,7 @@ async def get_runtime_manifest(
     issued_at = _runtime_manifest_issued_at(state, provider_version_sources)
     manifest: dict[str, Any] = {
         "schemaVersion": "clawdi.hosted-runtime.manifest.v1",
+        "minimumCliVersion": _HOSTED_MANIFEST_MINIMUM_CLI_VERSION,
         "deploymentId": state.deployment_id,
         "environmentId": str(environment_id),
         "instanceId": state.instance_id,

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -139,6 +139,13 @@ async def test_admin_upsert_runtime_state_and_manifest_omit_channels(
     assert not_modified.headers["cache-control"] == "no-store"
     assert not_modified.content == b""
 
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        legacy_response = await client.get("/api/runtime/manifest")
+    app.dependency_overrides.clear()
+
+    assert legacy_response.status_code == 200, legacy_response.text
+    assert "minimumCliVersion" not in legacy_response.json()["manifest"]
+
 
 @pytest.mark.asyncio
 async def test_admin_runtime_state_rejects_manifest_protocol_metadata(

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -115,6 +115,7 @@ async def test_admin_upsert_runtime_state_and_manifest_omit_channels(
     payload = response.json()
     manifest = payload["manifest"]
     assert manifest["schemaVersion"] == "clawdi.hosted-runtime.manifest.v1"
+    assert manifest["minimumCliVersion"] == "0.12.10-beta.48"
     assert manifest["deploymentId"] == expected["deployment_id"]
     assert manifest["environmentId"] == str(env.id)
     assert manifest["instanceId"] == expected["instance_id"]
@@ -137,6 +138,35 @@ async def test_admin_upsert_runtime_state_and_manifest_omit_channels(
     assert not_modified.headers["etag"] == etag
     assert not_modified.headers["cache-control"] == "no-store"
     assert not_modified.content == b""
+
+
+@pytest.mark.asyncio
+async def test_admin_runtime_state_rejects_manifest_protocol_metadata(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"runtime-protocol-metadata-{uuid4().hex[:8]}",
+        machine_name="Runtime protocol metadata",
+        agent_type="openclaw",
+    )
+
+    response = await admin_client.put(
+        f"/v1/admin/environments/{env.id}/runtime-state",
+        headers=_AUTH,
+        json={
+            "deployment_id": "dep-protocol-metadata",
+            "instance_id": "hri-protocol-metadata",
+            "generation": 1,
+            "runtimes": {"openclaw": {"enabled": True}},
+            "minimumCliVersion": "0.12.10-beta.48",
+        },
+    )
+
+    assert response.status_code == 422, response.text
 
 
 @pytest.mark.asyncio

--- a/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
+++ b/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
@@ -31,6 +31,12 @@ the environment variable containing the manifest bearer credential. The CLI
 validates both selectors and fails closed before datasource access. A hosted
 runtime does not read `host-policy.json` or `runtime-source.json`.
 
+API route versions and agent deployment generations are separate dimensions.
+Agent deployment v2 uses the canonical `/v1/runtime/manifest` route, including
+historical backend `app/v1` rows with `profile=hosted-runtime`. Actual agent
+deployment v1 keeps the legacy `/api/runtime/manifest` alias and does not
+receive the agent-v2 minimum-CLI protocol gate.
+
 For transparent egress:
 
 - `clawdi runtime sidecar` remains the only public support command;


### PR DESCRIPTION
## Why

Agent deployment v2 needs a protocol floor for the hosted manifest shape, but API route versions, backend app generations, and agent deployment generations are separate dimensions. The actual agent-v1 fleet still consumes the legacy `/api/runtime/manifest` route and must not inherit the v2 CLI gate.

Cloud API is the manifest assembler, so it owns `minimumCliVersion`. Hosted deploy-api remains a desired-state producer and is not allowed to inject protocol metadata.

## What changed

- emit `minimumCliVersion: 0.12.10-beta.48` only from `/v1/runtime/manifest`
- keep `/api/runtime/manifest` unchanged for actual agent deployment v1
- verify admin runtime-state rejects caller-provided `minimumCliVersion`
- document that API route versions, backend app/v1-v2, and agent deployment v1-v2 are independent dimensions

No database migration, state repair, compatibility parser, alias, SQL, or backfill is included.

## Verification

- Docker-isolated Cloud API runtime manifest tests: `42 passed`
- empty PostgreSQL Alembic upgrade to the existing head: passed as part of the test runner
- `bun run check`: `620 files`
- paired Hosted runtime image smoke with exact `clawdi@0.12.10-beta.48`: passed
- independent two-repository architecture review: no blockers

## Rollout

1. Merge this PR so Cloud API serves the agent-v2 protocol floor.
2. Keep actual agent-v1 callers on `/api/runtime/manifest`.
3. Merge Clawdi Hosted PR #780.
4. Promote the capability image and exact package spec as a separate controlled operation.
