### PR TITLE
fix(runtime): keep manifest aliases protocol-identical

### DIFF
--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -116,9 +116,8 @@ async def get_runtime_manifest(
         "providers": providers,
         "liveSync": state.live_sync or _default_live_sync(env),
         "recovery": state.recovery or {"cacheManifest": True, "allowOfflineBoot": True},
+        "minimumCliVersion": _AGENT_V2_MANIFEST_MINIMUM_CLI_VERSION,
     }
-    if request.scope["path"] == "/v1/runtime/manifest":
-        manifest["minimumCliVersion"] = _AGENT_V2_MANIFEST_MINIMUM_CLI_VERSION
     if state.bridge:
         manifest["bridge"] = state.bridge
     if state.app_id:

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -144,7 +144,10 @@ async def test_admin_upsert_runtime_state_and_manifest_omit_channels(
     app.dependency_overrides.clear()
 
     assert legacy_response.status_code == 200, legacy_response.text
-    assert "minimumCliVersion" not in legacy_response.json()["manifest"]
+    assert legacy_response.json() == payload
+    assert legacy_response.json()["manifest"]["minimumCliVersion"] == "0.12.10-beta.48"
+    assert legacy_response.headers["etag"] == etag
+    assert legacy_response.headers["cache-control"] == "no-store"
 
 
 @pytest.mark.asyncio

--- a/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
+++ b/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
@@ -32,10 +32,16 @@ validates both selectors and fails closed before datasource access. A hosted
 runtime does not read `host-policy.json` or `runtime-source.json`.
 
 API route versions and agent deployment generations are separate dimensions.
-Agent deployment v2 uses the canonical `/v1/runtime/manifest` route, including
-historical backend `app/v1` rows with `profile=hosted-runtime`. Actual agent
-deployment v1 keeps the legacy `/api/runtime/manifest` alias and does not
-receive the agent-v2 minimum-CLI protocol gate.
+`/v1/runtime/manifest` is the canonical manifest resource and
+`/api/runtime/manifest` is only a hidden compatibility alias for that same
+resource, so both paths carry identical protocol metadata. Agent deployment v2
+uses the canonical route with the capability image, exact CLI bootstrap, and
+CLI-owned convergence. Historical backend `app/v1` rows with
+`profile=hosted-runtime` may select the v2 image, but those row names do not
+describe the actual deployment generation. Actual agent deployment v1 is the
+unified baked image started by its entrypoint and supervisord, including
+`clawdi daemon run`; it does not run `clawdi runtime init` and is not driven by
+the runtime manifest.
 
 For transparent egress:
 

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -53,6 +53,23 @@ The public contract does not cover:
 - internal service implementation;
 - image build pipelines or platform rollout details.
 
+## Version Dimensions
+
+These version labels are independent and must not be inferred from one
+another:
+
+| Dimension | Meaning |
+| --- | --- |
+| Agent deployment v1 | Unified baked image launched by entrypoint/supervisord; runs `clawdi daemon run`, not manifest-driven `clawdi runtime init` |
+| Agent deployment v2 | Stable capability image plus exact CLI bootstrap, canonical `/v1/runtime/manifest`, and CLI convergence |
+| API `/v1` and `/api` | Canonical API prefix and hidden compatibility alias mounting the same router; `/api/runtime/manifest` is not agent deployment v1 |
+| Manifest schema `clawdi.hosted-runtime.manifest.v1` | Wire-format version for the hosted runtime manifest |
+| Internal desired-state v1 | CLI-local desired-state contract, independent of deployment and API route versions |
+
+Historical backend `app/v1` rows whose profile is `hosted-runtime` may select
+the deployment-v2 image. That storage naming does not make them the actual
+agent deployment v1 generation.
+
 ## Core Architecture
 
 The primary hosted runtime model is a Linux-like runtime host. The host image


### PR DESCRIPTION
Summary:
- Make the canonical v1 runtime manifest and hidden api compatibility alias return identical protocol metadata.
- Assert payload, ETag, cache policy, and minimum CLI version parity.
- Separate deployment generation, API prefix, manifest schema, and desired-state versioning in current docs.

Verification:
- scripts/test.sh backend: 898 passed, 7 skipped.
- Ruff check and format check passed.
- Python compileall passed.

No production, cluster, tenant, database, publish, deploy, merge, or production-settings operations were performed.