### PR TITLE
release(cli): stage agent v2 candidate

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -55,9 +55,11 @@ jobs:
         #      requires the package to already exist on the registry to accept
         #      a workflow as the publisher. Until that bootstrap happens, the
         #      workflow stays inert.
-        # The package may declare an isolated release channel through
+        # The package may declare an isolated upload channel through
         # `publishConfig.tag`; otherwise prereleases use `beta` and stable
-        # versions use `latest`.
+        # versions use `latest`. Managed agent-v2 releases upload to
+        # `agent-v2-candidate`; the production `agent-v2` tag is promoted only
+        # after the separate Hosted stable-envelope paired smoke.
         run: |
           LOCAL=$(node -p "require('./package.json').version")
           REMOTE_LATEST=$(npm view clawdi version 2>/dev/null || echo "0.0.0")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.12.10-beta.49
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.49
+
+Package: `clawdi@0.12.10-beta.49`
+
+### Changed
+
+- Added managed self-update support for the isolated floating `agent-v2`
+  channel. Agent-v2 builds upload first to `agent-v2-candidate`; the production
+  channel is promoted only after the Hosted stable-envelope paired smoke.
+
 ## Clawdi CLI v0.12.10-beta.48
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.48

--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.48",
+      "version": "0.12.10-beta.49",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -230,6 +230,12 @@ version bump. A merge with no version change is a no-op — the workflow
 diffs `packages/cli/package.json` against `npm view clawdi version` and
 exits early on a match.
 
+Managed agent-v2 packages upload to the non-production
+`agent-v2-candidate` dist-tag. The runtime never consumes that tag. Promote an
+exact candidate to `agent-v2` only after the Hosted stable-envelope paired
+smoke passes, following `docs/runbooks/release.md`. The production tag means
+paired-smoke-approved, not merely published.
+
 The monorepo has two GitHub Release lines:
 
 - `clawdi-cli-vX.Y.Z` for the published npm package. The CLI publish

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -73,6 +73,13 @@ releases.
 6. If the PR touches the CLI package and should publish, bump
    `packages/cli/package.json` using semver. If no npm publish is intended,
    leave the version unchanged.
+   For the managed `agent-v2` channel, do not treat a successful npm upload as
+   approval. `publishConfig.tag` uploads to the non-production
+   `agent-v2-candidate` tag. Promote the exact tested version to `agent-v2` only
+   after the Hosted stable-envelope paired smoke passes. Until a workflow with
+   the required Hosted smoke and npm promotion credentials exists, automatic
+   promotion is a release blocker/follow-up; do not replace it with
+   cross-repository polling or long-lived token automation.
 7. Decide whether `CHANGELOG.md` needs a curated entry. Add one for notable
    user-facing releases, especially when GitHub generated notes would be too
    noisy or too terse.
@@ -95,6 +102,19 @@ releases.
    npm view clawdi version
    npm view clawdi dist-tags
    ```
+
+   Agent-v2 releases appear first under `agent-v2-candidate`. After the Hosted
+   stable-envelope paired smoke passes for that exact version, a maintainer
+   with npm package permission promotes it explicitly:
+
+   ```bash
+   npm dist-tag add clawdi@<exact-version> agent-v2
+   npm view clawdi dist-tags
+   ```
+
+   Done: `agent-v2` points to the paired-smoke-approved exact version while
+   `beta` and `latest` are unchanged. Automated promotion remains blocked until
+   a reusable Hosted smoke and npm credential contract exists.
 
 4. For app/backend/web releases, run `Release Clawdi` manually with the
    deployed commit SHA, then verify the GitHub release exists and has

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.48",
+	"version": "0.12.10-beta.49",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",
@@ -20,7 +20,7 @@
 	},
 	"publishConfig": {
 		"access": "public",
-		"tag": "agent-v2"
+		"tag": "agent-v2-candidate"
 	},
 	"scripts": {
 		"dev": "bun run src/index.ts",

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -316,7 +316,7 @@ function isFloatingNpmPackageSpec(packageSpec: string): boolean {
 	const match = /^clawdi@(.+)$/.exec(packageSpec);
 	if (!match) return false;
 	const specifier = match[1] ?? "";
-	if (!/^(alpha|beta|canary|next|rc)$/.test(specifier)) return false;
+	if (!/^(agent-v2|alpha|beta|canary|next|rc)$/.test(specifier)) return false;
 	return !isExactNpmPackageVersion(specifier);
 }
 

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -5167,7 +5167,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		}
 	});
 
-	it("runtime CLI update resolves floating npm tags through the managed npm cache", () => {
+	it("runtime CLI update resolves the floating agent-v2 npm tag through the managed npm cache", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -5196,7 +5196,7 @@ if [ "\${1:-}" = "view" ]; then
 	fi
 	install -d "$cache"
 	touch "$cache/view-proof"
-  echo '"0.12.10-beta.22"'
+  echo '"0.12.10-beta.49"'
   exit 0
 fi
 prefix=""
@@ -5216,7 +5216,7 @@ install -d "$prefix/bin"
 cat > "$prefix/bin/clawdi" <<'SH'
 #!/usr/bin/env bash
 if [ "\${1:-}" = "--version" ]; then
-  echo "0.12.10-beta.22"
+  echo "0.12.10-beta.49"
   exit 0
 fi
 if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
@@ -5236,7 +5236,7 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_RUN_DIR = run;
 		try {
 			const paths = getRuntimePaths();
-			seedCurrentCliInstall(state, "clawdi@beta", "0.12.10-beta.21");
+			seedCurrentCliInstall(state, "clawdi@agent-v2", "0.12.10-beta.48");
 			const result = applyRuntimeCliDesiredState(
 				{
 					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
@@ -5248,18 +5248,18 @@ chmod +x "$prefix/bin/clawdi"
 					issuedAt: "2026-06-06T00:00:00Z",
 					system: { home, workspace: join(home, "clawdi") },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
-					clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@beta" },
+					clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@agent-v2" },
 					runtimes: { openclaw: hostedOpenClawRuntime() },
 				},
 				paths,
 			);
 
 			expect(result.status).toBe("installed");
-			expect(result.version).toBe("0.12.10-beta.22");
+			expect(result.version).toBe("0.12.10-beta.49");
 			expect(readlinkSync(paths.cliManagedBin)).toBe(result.activeTarget);
 			const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-			expect(status.packageSpec).toBe("clawdi@beta");
-			expect(status.version).toBe("0.12.10-beta.22");
+			expect(status.packageSpec).toBe("clawdi@agent-v2");
+			expect(status.version).toBe("0.12.10-beta.49");
 			const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
 			const npmViewCalls = npmCalls.filter((call) => call.startsWith("view "));
 			expect(npmViewCalls.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- release `clawdi@0.12.10-beta.49` with managed floating `agent-v2` self-update support
- upload the package to non-production `agent-v2-candidate`; do not move `agent-v2`, `beta`, or `latest`
- document that production `agent-v2` promotion requires the Hosted stable-envelope paired smoke

## Verification
- `scripts/test.sh cli` (`793 passed`)
- `bun run typecheck`
- `bun run check`
- `bun run --cwd packages/cli check:publish-manifest`

## Rollout
This is rollout step A only. Merge publishes `.49` to `agent-v2-candidate`. It does not change Cloud API manifests and does not promote the production tag. After Hosted paired smoke passes for the exact `.49` candidate, promote `.49` to `agent-v2`; only then may the separate Cloud API authority PR merge.

No database, backend manifest, deployment, production, or tenant-data changes are included.
