### PR TITLE
release(cli): finalize agent v2 contract and repository-local OIDC publish

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -15,8 +15,8 @@ concurrency:
 env:
   CLI_ARTIFACT_NAME: clawdi-cli-release
 
-# This repository builds, verifies, and publishes one immutable release artifact.
-# There is intentionally no candidate upload or later dist-tag mutation.
+# This repository builds, verifies, and publishes one immutable candidate artifact.
+# It does not modify latest, beta, or a production agent-v2 selection.
 jobs:
   build-immutable-artifact:
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
@@ -111,7 +111,8 @@ jobs:
   publish-immutable-artifact-with-oidc:
     if: needs['build-immutable-artifact'].outputs.should_publish == 'true'
     needs: build-immutable-artifact
-    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
+    # npm trusted publishing supports GitHub-hosted runners, not self-hosted runners.
+    runs-on: ubuntu-latest
     environment: npm
     permissions:
       contents: write
@@ -125,6 +126,12 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Verify trusted publishing toolchain
+        run: |
+          npm install --global npm@11.5.1
+          node -e 'const [major, minor] = process.versions.node.split(".").map(Number); if (major < 22 || (major === 22 && minor < 14)) process.exit(1)'
+          test "$(npm --version)" = "11.5.1"
 
       - name: Download immutable CLI release artifact
         uses: actions/download-artifact@v4
@@ -149,10 +156,10 @@ jobs:
           test "$(node -e "const fs=require('node:fs'); console.log(JSON.parse(fs.readFileSync(0,'utf8')).name)" <<< "$manifest")" = "clawdi"
           test "$(node -e "const fs=require('node:fs'); console.log(JSON.parse(fs.readFileSync(0,'utf8')).version)" <<< "$manifest")" = "$VERSION"
 
-      - name: Publish immutable tarball to agent-v2
+      - name: Publish immutable tarball to agent-v2-candidate
         env:
           CLI_TARBALL_FILENAME: ${{ needs['build-immutable-artifact'].outputs.cli_tarball_filename }}
-        run: npm publish "release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag agent-v2
+        run: npm publish "release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag agent-v2-candidate
 
       - name: Create GitHub release
         env:
@@ -164,10 +171,11 @@ jobs:
           notes=$(cat <<EOF
           ## Package
 
-          \`npm install -g clawdi@agent-v2\`
+          \`npm install -g clawdi@$VERSION\`
 
-          Published as \`clawdi@$VERSION\` from the immutable artifact verified
-          by this repository's release workflow.
+          Published as the \`agent-v2-candidate\` for exact version
+          \`clawdi@$VERSION\` from the immutable artifact verified by this
+          repository's release workflow. No production npm dist-tag is changed.
 
           This is the release for the published \`packages/cli\` package.
           Clawdi app/backend/web changes are versioned separately as

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -1,10 +1,4 @@
-name: Publish CLI
-
-# Auto-publishes `clawdi` to npm whenever `packages/cli/` lands on main with
-# a new version. The `skip-if-same-version` gate means a merge with no
-# version bump is a no-op, so every PR to main is safe — only deliberate
-# `"version": "..."` changes trigger a release. Mirrors the pattern used by
-# `@clawdi/openclaw-plugin` in the main clawdi repo.
+name: Publish Agent v2 CLI
 
 on:
   workflow_dispatch:
@@ -18,19 +12,20 @@ concurrency:
   group: cli-publish
   cancel-in-progress: false
 
+env:
+  CLI_ARTIFACT_NAME: clawdi-cli-release
+
+# This one artifact is the release identity: Hosted smokes it, then npm publishes it once.
+# There is intentionally no candidate upload or later dist-tag mutation.
 jobs:
-  publish:
+  build-immutable-artifact:
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
-    # `environment: npm` gates the job behind the repo's `npm` environment
-    # secrets/rules. Combined with `id-token: write` this enables npm
-    # trusted-publisher OIDC so no NPM_TOKEN secret is needed.
-    environment: npm
     permissions:
-      contents: write
-      id-token: write
-    defaults:
-      run:
-        working-directory: packages/cli
+      contents: read
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+      version: ${{ steps.check.outputs.version }}
+      cli_tarball_filename: ${{ steps.check.outputs.cli_tarball_filename }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -45,158 +40,168 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Skip if no publish needed
+      - name: Check whether the exact version needs publishing
         id: check
-        # Skip cases:
-        #   1. Local exact version already exists on npm (no bump → no publish).
-        #   2. Package has never been published (`npm view` fails, fallback "0.0.0").
-        #      The first publish must be manual — `npm publish --access public`
-        #      from a maintainer's machine — because npm trusted-publisher OIDC
-        #      requires the package to already exist on the registry to accept
-        #      a workflow as the publisher. Until that bootstrap happens, the
-        #      workflow stays inert.
-        # The package may declare an isolated upload channel through
-        # `publishConfig.tag`; otherwise prereleases use `beta` and stable
-        # versions use `latest`. Managed agent-v2 releases upload to
-        # `agent-v2-candidate`; the production `agent-v2` tag is promoted only
-        # after the separate Hosted stable-envelope paired smoke.
+        working-directory: packages/cli
         run: |
-          LOCAL=$(node -p "require('./package.json').version")
-          REMOTE_LATEST=$(npm view clawdi version 2>/dev/null || echo "0.0.0")
-          CONFIGURED_TAG=$(node -p "require('./package.json').publishConfig?.tag || ''")
-          if [ -n "$CONFIGURED_TAG" ]; then
-            NPM_TAG="$CONFIGURED_TAG"
-          elif [[ "$LOCAL" == *-* ]]; then
-            NPM_TAG=beta
+          version=$(node -p "require('./package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "cli_tarball_filename=clawdi-$version.tgz" >> "$GITHUB_OUTPUT"
+          if npm view "clawdi@$version" version >/dev/null 2>&1; then
+            echo "clawdi@$version already exists on npm"
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
           else
-            NPM_TAG=latest
-          fi
-          echo "local=$LOCAL remote_latest=$REMOTE_LATEST npm_tag=$NPM_TAG"
-          echo "npm_tag=$NPM_TAG" >> "$GITHUB_OUTPUT"
-          if [ "$REMOTE_LATEST" = "0.0.0" ]; then
-            echo "Package not on npm yet — bootstrap with manual publish first."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          elif npm view "clawdi@$LOCAL" version >/dev/null 2>&1; then
-            echo "Package version clawdi@$LOCAL already exists on npm."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install workspace deps
-        if: steps.check.outputs.skip != 'true'
-        working-directory: ${{ github.workspace }}
+      - name: Install workspace dependencies
+        if: steps.check.outputs.should_publish == 'true'
         run: bun install --frozen-lockfile
 
       - name: Typecheck
-        if: steps.check.outputs.skip != 'true'
+        if: steps.check.outputs.should_publish == 'true'
+        working-directory: packages/cli
         run: bun run typecheck
 
-      # Build before Test so the smoke test in tests/smoke.test.ts — which
-      # execs the bundled `dist/index.js` — has its artifact ready.
-      - name: Build
-        if: steps.check.outputs.skip != 'true'
-        run: bun run build
-
-      - name: Build standalone CLI binary
-        if: steps.check.outputs.skip != 'true'
+      - name: Build package and standalone binary
+        if: steps.check.outputs.should_publish == 'true'
+        working-directory: packages/cli
         run: |
+          bun run build
           bun run build:binary
           ./dist-bin/clawdi --version
           bun run package:binary-release
-          test -f dist-release/clawdi-cli-linux-x64.tar.gz
-          test -f dist-release/clawdi-cli-linux-x64.tar.gz.sha256
 
       - name: Test
-        if: steps.check.outputs.skip != 'true'
+        if: steps.check.outputs.should_publish == 'true'
+        working-directory: packages/cli
         run: bun test --isolate --max-concurrency=1
 
-      - name: Validate npm tarball install
-        if: steps.check.outputs.skip != 'true'
+      - name: Pack and verify immutable release artifact
+        if: steps.check.outputs.should_publish == 'true'
+        working-directory: packages/cli
         run: |
           node scripts/check-publish-manifest.mjs
-          TMP=$(mktemp -d)
-          PACK_DIR=$(mktemp -d)
-          cleanup() {
-            rm -rf "$TMP"
-            rm -rf "$PACK_DIR"
-          }
-          trap cleanup EXIT
-          PACK_JSON=$(npm pack --json --ignore-scripts --pack-destination "$PACK_DIR")
-          TARBALL=$(node -e "const fs=require('node:fs'); const data=JSON.parse(fs.readFileSync(0,'utf8')); console.log(data[0].filename)" <<< "$PACK_JSON")
-          TARBALL_PATH="$PACK_DIR/$TARBALL"
-          cd "$TMP"
+          release_dir="$RUNNER_TEMP/clawdi-cli-release"
+          install_dir="$RUNNER_TEMP/clawdi-cli-install"
+          mkdir -p "$release_dir" "$install_dir"
+          pack_json=$(npm pack --json --ignore-scripts --pack-destination "$release_dir")
+          tarball=$(node -e "const fs=require('node:fs'); const data=JSON.parse(fs.readFileSync(0,'utf8')); console.log(data[0].filename)" <<< "$pack_json")
+          tarball_path="$release_dir/$tarball"
+          tarball_sha=$(sha256sum "$tarball_path" | cut -d' ' -f1)
+          printf '%s  %s\n' "$tarball_sha" "$tarball" > "$release_dir/$tarball.sha256"
+          cp dist-release/clawdi-cli-linux-x64.tar.gz "$release_dir/"
+          cp dist-release/clawdi-cli-linux-x64.tar.gz.sha256 "$release_dir/"
+          cd "$install_dir"
           npm init -y >/dev/null
-          npm install "$TARBALL_PATH" --ignore-scripts --no-audit --no-fund
+          npm install "$tarball_path" --ignore-scripts --no-audit --no-fund
+          "$install_dir/node_modules/.bin/clawdi" --version
 
-      # `prepublishOnly` would re-run the build. We pass `--ignore-scripts`
-      # because the step above already built everything; rerunning wastes
-      # ~10s of CI time and risks a silent re-bundle with stale env.
-      #
-      # `--provenance` attaches a SLSA provenance attestation. Requires:
-      #   - `repository.url` in package.json points at a public GitHub repo
-      #     (Clawdi-AI/clawdi — confirmed public)
-      #   - workflow has `id-token: write` (above) for OIDC token minting
-      #   - npm trusted-publisher OIDC enabled for the package (env: npm)
-      # Once published, `npm view clawdi --json` shows a `dist.attestations`
-      # block, and the package page on npmjs.com gets the green "provenance"
-      # badge linking back to this exact workflow run.
-      - name: Publish to npm
-        if: steps.check.outputs.skip != 'true'
-        run: npm publish --access public --provenance --ignore-scripts --tag "${{ steps.check.outputs.npm_tag }}"
+      - name: Upload immutable CLI release artifact
+        if: steps.check.outputs.should_publish == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.CLI_ARTIFACT_NAME }}
+          path: ${{ runner.temp }}/clawdi-cli-release/
+          if-no-files-found: error
+          retention-days: 7
+
+  hosted-paired-smoke:
+    if: needs['build-immutable-artifact'].outputs.should_publish == 'true'
+    needs: build-immutable-artifact
+    permissions:
+      contents: read
+      actions: read
+    uses: Clawdi-AI/clawdi-hosted/.github/workflows/hosted-runtime-paired-smoke.yml@main
+    with:
+      cli_artifact_name: clawdi-cli-release
+      cli_tarball_filename: ${{ needs['build-immutable-artifact'].outputs.cli_tarball_filename }}
+
+  publish-paired-artifact-with-oidc:
+    if: needs['build-immutable-artifact'].outputs.should_publish == 'true'
+    needs: [build-immutable-artifact, hosted-paired-smoke]
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: write
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Download paired-smoked CLI release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.CLI_ARTIFACT_NAME }}
+          path: release
+
+      - name: Verify release artifact
+        env:
+          VERSION: ${{ needs['build-immutable-artifact'].outputs.version }}
+          CLI_TARBALL_FILENAME: ${{ needs['build-immutable-artifact'].outputs.cli_tarball_filename }}
+        run: |
+          cd release
+          tarball="$CLI_TARBALL_FILENAME"
+          test -s "$tarball"
+          test -s "$tarball.sha256"
+          test -s clawdi-cli-linux-x64.tar.gz
+          test -s clawdi-cli-linux-x64.tar.gz.sha256
+          sha256sum --check "$tarball.sha256"
+          sha256sum --check clawdi-cli-linux-x64.tar.gz.sha256
+          manifest=$(tar -xOf "$tarball" package/package.json)
+          test "$(node -e "const fs=require('node:fs'); console.log(JSON.parse(fs.readFileSync(0,'utf8')).name)" <<< "$manifest")" = "clawdi"
+          test "$(node -e "const fs=require('node:fs'); console.log(JSON.parse(fs.readFileSync(0,'utf8')).version)" <<< "$manifest")" = "$VERSION"
+
+      - name: Publish paired-smoked tarball to agent-v2
+        env:
+          CLI_TARBALL_FILENAME: ${{ needs['build-immutable-artifact'].outputs.cli_tarball_filename }}
+        run: npm publish "release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag agent-v2
 
       - name: Create GitHub release
-        if: steps.check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs['build-immutable-artifact'].outputs.version }}
         run: |
-          VERSION=$(node -p "require('./package.json').version")
-          NPM_TAG="${{ steps.check.outputs.npm_tag }}"
-          TAG="clawdi-cli-v${VERSION}"
+          tag="clawdi-cli-v$VERSION"
+          previous=$(git tag --list 'clawdi-cli-v*' --sort=-version:refname | grep -Fxv "$tag" | head -n 1 || true)
+          notes=$(cat <<EOF
+          ## Package
 
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "GitHub release $TAG already exists; uploading standalone CLI assets."
-            gh release upload "$TAG" \
-              dist-release/clawdi-cli-linux-x64.tar.gz \
-              dist-release/clawdi-cli-linux-x64.tar.gz.sha256 \
-              --clobber
-            exit 0
-          fi
+          \`npm install -g clawdi@agent-v2\`
 
-          PREVIOUS=$(
-            git tag --list 'clawdi-cli-v*' --sort=-v:refname \
-              | grep -v "^${TAG}$" \
-              | head -n 1 || true
-          )
+          Published as \`clawdi@$VERSION\` after the mandatory Hosted paired smoke.
 
-          NOTES=$(cat <<EOF
-          ## npm
-          - Package: \`clawdi@${VERSION}\`
-          - Dist tag: \`${NPM_TAG}\`
-          - Install: \`npm i -g clawdi@${VERSION}\`
-          - Dist-tag install: \`npm i -g clawdi@${NPM_TAG}\`
-
-          ## Scope
           This is the release for the published \`packages/cli\` package.
           Clawdi app/backend/web changes are versioned separately as
           \`clawdi-YYYY-MM-DD[-N]\` releases.
           EOF
           )
-
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" \
+              release/clawdi-cli-linux-x64.tar.gz \
+              release/clawdi-cli-linux-x64.tar.gz.sha256 \
+              --clobber
+            exit 0
+          fi
           args=(
-            release create "$TAG"
-            dist-release/clawdi-cli-linux-x64.tar.gz
-            dist-release/clawdi-cli-linux-x64.tar.gz.sha256
+            release create "$tag"
+            release/clawdi-cli-linux-x64.tar.gz
+            release/clawdi-cli-linux-x64.tar.gz.sha256
             --target "$GITHUB_SHA"
-            --title "Clawdi CLI v${VERSION}"
-            --notes "$NOTES"
+            --title "Clawdi CLI v$VERSION"
+            --notes "$notes"
             --generate-notes
             --latest=false
+            --prerelease
           )
-          if [ "$NPM_TAG" != "latest" ]; then
-            args+=(--prerelease)
-          fi
-          if [ -n "$PREVIOUS" ]; then
-            args+=(--notes-start-tag "$PREVIOUS")
+          if [ -n "$previous" ]; then
+            args+=(--notes-start-tag "$previous")
           fi
           gh "${args[@]}"

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -120,7 +120,7 @@ jobs:
   publish-paired-artifact-with-oidc:
     if: needs['build-immutable-artifact'].outputs.should_publish == 'true'
     needs: [build-immutable-artifact, hosted-paired-smoke]
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     environment: npm
     permissions:
       contents: write

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -16,7 +16,7 @@ env:
   CLI_ARTIFACT_NAME: clawdi-cli-release
 
 # This repository builds, verifies, and publishes one immutable artifact.
-# Package metadata may pin a safety tag; otherwise prereleases use beta and stable releases use latest.
+# Prereleases publish to beta; stable releases publish to latest.
 jobs:
   build-immutable-artifact:
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
@@ -46,7 +46,7 @@ jobs:
         working-directory: packages/cli
         run: |
           version=$(node -p "require('./package.json').version")
-          npm_tag=$(node -e "const p=require('./package.json'); console.log(p.publishConfig?.tag || (p.version.includes('-') ? 'beta' : 'latest'))")
+          npm_tag=$(node -e "const p=require('./package.json'); console.log(p.version.includes('-') ? 'beta' : 'latest')")
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "npm_tag=$npm_tag" >> "$GITHUB_OUTPUT"
           echo "cli_tarball_filename=clawdi-$version.tgz" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -15,8 +15,8 @@ concurrency:
 env:
   CLI_ARTIFACT_NAME: clawdi-cli-release
 
-# This repository builds, verifies, and publishes one immutable candidate artifact.
-# It does not modify latest, beta, or a production agent-v2 selection.
+# This repository builds, verifies, and publishes one immutable artifact.
+# Package metadata may pin a safety tag; otherwise prereleases use beta and stable releases use latest.
 jobs:
   build-immutable-artifact:
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
@@ -25,6 +25,7 @@ jobs:
     outputs:
       should_publish: ${{ steps.check.outputs.should_publish }}
       version: ${{ steps.check.outputs.version }}
+      npm_tag: ${{ steps.check.outputs.npm_tag }}
       cli_tarball_filename: ${{ steps.check.outputs.cli_tarball_filename }}
     steps:
       - uses: actions/checkout@v6
@@ -45,7 +46,9 @@ jobs:
         working-directory: packages/cli
         run: |
           version=$(node -p "require('./package.json').version")
+          npm_tag=$(node -e "const p=require('./package.json'); console.log(p.publishConfig?.tag || (p.version.includes('-') ? 'beta' : 'latest'))")
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "npm_tag=$npm_tag" >> "$GITHUB_OUTPUT"
           echo "cli_tarball_filename=clawdi-$version.tgz" >> "$GITHUB_OUTPUT"
           if npm view "clawdi@$version" version >/dev/null 2>&1; then
             echo "clawdi@$version already exists on npm"
@@ -156,15 +159,17 @@ jobs:
           test "$(node -e "const fs=require('node:fs'); console.log(JSON.parse(fs.readFileSync(0,'utf8')).name)" <<< "$manifest")" = "clawdi"
           test "$(node -e "const fs=require('node:fs'); console.log(JSON.parse(fs.readFileSync(0,'utf8')).version)" <<< "$manifest")" = "$VERSION"
 
-      - name: Publish immutable tarball to agent-v2-candidate
+      - name: Publish immutable tarball
         env:
           CLI_TARBALL_FILENAME: ${{ needs['build-immutable-artifact'].outputs.cli_tarball_filename }}
-        run: npm publish "release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag agent-v2-candidate
+          NPM_TAG: ${{ needs['build-immutable-artifact'].outputs.npm_tag }}
+        run: npm publish "release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag "$NPM_TAG"
 
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs['build-immutable-artifact'].outputs.version }}
+          NPM_TAG: ${{ needs['build-immutable-artifact'].outputs.npm_tag }}
         run: |
           tag="clawdi-cli-v$VERSION"
           previous=$(git tag --list 'clawdi-cli-v*' --sort=-version:refname | grep -Fxv "$tag" | head -n 1 || true)
@@ -173,9 +178,9 @@ jobs:
 
           \`npm install -g clawdi@$VERSION\`
 
-          Published as the \`agent-v2-candidate\` for exact version
+          Published with npm tag \`$NPM_TAG\` for exact version
           \`clawdi@$VERSION\` from the immutable artifact verified by this
-          repository's release workflow. No production npm dist-tag is changed.
+          repository's release workflow.
 
           This is the release for the published \`packages/cli\` package.
           Clawdi app/backend/web changes are versioned separately as

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   CLI_ARTIFACT_NAME: clawdi-cli-release
 
-# This one artifact is the release identity: Hosted smokes it, then npm publishes it once.
+# This repository builds, verifies, and publishes one immutable release artifact.
 # There is intentionally no candidate upload or later dist-tag mutation.
 jobs:
   build-immutable-artifact:
@@ -92,6 +92,8 @@ jobs:
           printf '%s  %s\n' "$tarball_sha" "$tarball" > "$release_dir/$tarball.sha256"
           cp dist-release/clawdi-cli-linux-x64.tar.gz "$release_dir/"
           cp dist-release/clawdi-cli-linux-x64.tar.gz.sha256 "$release_dir/"
+          (cd "$release_dir" && sha256sum --check "$tarball.sha256")
+          (cd "$release_dir" && sha256sum --check clawdi-cli-linux-x64.tar.gz.sha256)
           cd "$install_dir"
           npm init -y >/dev/null
           npm install "$tarball_path" --ignore-scripts --no-audit --no-fund
@@ -106,26 +108,14 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  hosted-paired-smoke:
+  publish-immutable-artifact-with-oidc:
     if: needs['build-immutable-artifact'].outputs.should_publish == 'true'
     needs: build-immutable-artifact
-    permissions:
-      contents: read
-      actions: read
-    uses: Clawdi-AI/clawdi-hosted/.github/workflows/hosted-runtime-paired-smoke.yml@main
-    with:
-      cli_artifact_name: clawdi-cli-release
-      cli_tarball_filename: ${{ needs['build-immutable-artifact'].outputs.cli_tarball_filename }}
-
-  publish-paired-artifact-with-oidc:
-    if: needs['build-immutable-artifact'].outputs.should_publish == 'true'
-    needs: [build-immutable-artifact, hosted-paired-smoke]
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     environment: npm
     permissions:
       contents: write
       id-token: write
-      actions: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -136,7 +126,7 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Download paired-smoked CLI release artifact
+      - name: Download immutable CLI release artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.CLI_ARTIFACT_NAME }}
@@ -159,7 +149,7 @@ jobs:
           test "$(node -e "const fs=require('node:fs'); console.log(JSON.parse(fs.readFileSync(0,'utf8')).name)" <<< "$manifest")" = "clawdi"
           test "$(node -e "const fs=require('node:fs'); console.log(JSON.parse(fs.readFileSync(0,'utf8')).version)" <<< "$manifest")" = "$VERSION"
 
-      - name: Publish paired-smoked tarball to agent-v2
+      - name: Publish immutable tarball to agent-v2
         env:
           CLI_TARBALL_FILENAME: ${{ needs['build-immutable-artifact'].outputs.cli_tarball_filename }}
         run: npm publish "release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag agent-v2
@@ -176,7 +166,8 @@ jobs:
 
           \`npm install -g clawdi@agent-v2\`
 
-          Published as \`clawdi@$VERSION\` after the mandatory Hosted paired smoke.
+          Published as \`clawdi@$VERSION\` from the immutable artifact verified
+          by this repository's release workflow.
 
           This is the release for the published \`packages/cli\` package.
           Clawdi app/backend/web changes are versioned separately as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,9 @@ Package: `clawdi@0.12.10-beta.50`
   the strict `clawdiCli` source, package spec, and official npm registry; they
   can no longer implicitly select `clawdi@latest` or inherit npm registry
   configuration.
-- Made agent-v2 publishing contingent on the reusable Hosted paired smoke and
-  publish the exact tested tarball directly to the `agent-v2` channel with npm
-  trusted-publisher OIDC.
+- Made agent-v2 publishing repository-autonomous: build, test, pack, install,
+  and SHA-verify one immutable tarball, then publish that artifact directly to
+  the `agent-v2` channel with npm trusted-publisher OIDC.
 
 ## Clawdi CLI v0.12.10-beta.49
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,19 @@ Package: `clawdi@0.12.10-beta.51`
 - Added immediate hosted runtime manifest convergence from environment-scoped
   SSE notifications while retaining 15-second ETag polling and five-minute
   self-healing when the notification channel is unavailable.
+- Made the hosted manifest fail closed on unknown fields and require explicit
+  `runtime`, `minimumCliVersion`, `controlPlane.cloudApiUrl`, and the canonical
+  `environmentId` identity, without inference, `appId`, datasource, or
+  deployment fallbacks.
+- Restricted hosted CLI package selection to `clawdi@agent-v2`, exact semver,
+  or immutable tarballs under `/usr/local/share/clawdi/bootstrap/`.
 
 ### Fixed
 
 - Kept headless runtime convergence independent of a systemd user manager while
   still requiring the manager for official runtime service installation.
+- Restored SSE subscriptions after authentication failure or terminal task
+  completion while retaining polling as the bounded retry cadence.
 
 ## Clawdi CLI v0.12.10-beta.50
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,12 @@ Package: `clawdi@0.12.10-beta.51`
 - Required Hosted provider `kind` to be exactly `openai-compatible`, and
   rejected singular Hosted provider `model` and empty provider objects while
   accepting Cloud's healthy, `provider_not_found`, and
-  `provider_secret_unavailable` projections. Generic runtime desired state
+  `provider_secret_unavailable` projections with required non-empty error
+  messages. Generic runtime desired state
   keeps its existing provider and installer behavior.
 - Restricted remote Hosted CLI package selection to exact
   `clawdi@<semver>` without build metadata, using strict SemVer prerelease
-  identifier rules. Managed bootstrap tgz paths are
+  identifier rules and the Cloud 200-character limit. Managed bootstrap tgz paths are
   accepted only through `CLAWDI_RUNTIME_MANIFEST_PATH` test fixtures; generic
   desired state retains floating package support.
 - Restored `agent-v2-candidate` as the repository-local OIDC publication tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,23 @@ Package: `clawdi@0.12.10-beta.51`
   runtime home/workspace paths instead of deriving image-default locations.
 - Required a non-empty unique Hosted runtime provider selection and a structured
   primary model constrained to that selection.
-- Restricted hosted CLI package selection to `clawdi@agent-v2`, exact semver,
-  or immutable tarballs under `/usr/local/share/clawdi/bootstrap/`.
+- Required the selected Hosted runtime to include exactly
+  `install: {source: "official"}` while the CLI remains the sole owner of the
+  official installer URL and argument vector.
+- Required Hosted provider `kind` to be exactly `openai-compatible`, and
+  rejected singular Hosted provider `model` and empty provider objects while
+  accepting Cloud's healthy, `provider_not_found`, and
+  `provider_secret_unavailable` projections. Generic runtime desired state
+  keeps its existing provider and installer behavior.
+- Restricted remote Hosted CLI package selection to exact
+  `clawdi@<semver>` without build metadata, using strict SemVer prerelease
+  identifier rules. Managed bootstrap tgz paths are
+  accepted only through `CLAWDI_RUNTIME_MANIFEST_PATH` test fixtures; generic
+  desired state retains floating package support.
+- Restored `agent-v2-candidate` as the repository-local OIDC publication tag.
+  The protected publish job runs on GitHub-hosted `ubuntu-latest` and does not
+  modify `latest` or `beta`. Hosted runtime updates consume the public exact
+  version from the Cloud manifest and never resolve a production dist-tag.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Package: `clawdi@0.12.10-beta.51`
   SSE notifications while retaining 15-second ETag polling and five-minute
   self-healing when the notification channel is unavailable.
 
+### Fixed
+
+- Kept headless runtime convergence independent of a systemd user manager while
+  still requiring the manager for official runtime service installation.
+
 ## Clawdi CLI v0.12.10-beta.50
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.50

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.12.10-beta.51
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.51
+
+Package: `clawdi@0.12.10-beta.51`
+
+### Changed
+
+- Added the strict hosted locale contract for supported response languages and
+  IANA timezones. The CLI now preserves user-authored agent identity files while
+  maintaining a delimited locale instruction block, projects runtime-native
+  timezone settings, and restarts only affected runtime services.
+- Added immediate hosted runtime manifest convergence from environment-scoped
+  SSE notifications while retaining 15-second ETag polling and five-minute
+  self-healing when the notification channel is unavailable.
+
 ## Clawdi CLI v0.12.10-beta.50
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.50

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ Package: `clawdi@0.12.10-beta.51`
   deployment fallbacks.
 - Restricted runtime bindings, provider transport fields, runtime paths, and
   OpenClaw Control UI origins to the canonical Hosted wire shape.
+- Required explicit Hosted system and runtime home/workspace paths instead of
+  deriving image-default locations during normalization.
+- Required a non-empty unique Hosted runtime provider selection and a structured
+  primary model constrained to that selection.
 - Restricted hosted CLI package selection to `clawdi@agent-v2`, exact semver,
   or immutable tarballs under `/usr/local/share/clawdi/bootstrap/`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ Package: `clawdi@0.12.10-beta.51`
   deployment fallbacks.
 - Restricted runtime bindings, provider transport fields, runtime paths, and
   OpenClaw Control UI origins to the canonical Hosted wire shape.
-- Required explicit Hosted system and runtime home/workspace paths instead of
-  deriving image-default locations during normalization.
+- Required explicit Hosted system user, home, workspace, persistent paths, and
+  runtime home/workspace paths instead of deriving image-default locations.
 - Required a non-empty unique Hosted runtime provider selection and a structured
   primary model constrained to that selection.
 - Restricted hosted CLI package selection to `clawdi@agent-v2`, exact semver,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Package: `clawdi@0.12.10-beta.51`
   `runtime`, `minimumCliVersion`, `controlPlane.cloudApiUrl`, and the canonical
   `environmentId` identity, without inference, `appId`, datasource, or
   deployment fallbacks.
+- Restricted runtime bindings, provider transport fields, runtime paths, and
+  OpenClaw Control UI origins to the canonical Hosted wire shape.
 - Restricted hosted CLI package selection to `clawdi@agent-v2`, exact semver,
   or immutable tarballs under `/usr/local/share/clawdi/bootstrap/`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,12 +47,12 @@ Package: `clawdi@0.12.10-beta.51`
 - Restricted remote Hosted CLI package selection to exact
   `clawdi@<semver>` without build metadata, using strict SemVer prerelease
   identifier rules and the Cloud 200-character limit. Managed bootstrap tgz paths are
-  accepted only through `CLAWDI_RUNTIME_MANIFEST_PATH` test fixtures; generic
-  desired state retains floating package support.
-- Restored `agent-v2-candidate` as the repository-local OIDC publication tag.
-  The protected publish job runs on GitHub-hosted `ubuntu-latest` and does not
-  modify `latest` or `beta`. Hosted runtime updates consume the public exact
-  version from the Cloud manifest and never resolve a production dist-tag.
+  accepted only through strict Hosted test fixtures. Runtime desired state no
+  longer resolves floating package tags.
+- Restored `agent-v2-candidate` as the package-level safety default while the
+  release workflow retains metadata override, prerelease `beta`, and stable
+  `latest` tag selection. Hosted runtime updates consume the public exact
+  version from the Cloud manifest and never resolve a dist-tag.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,10 +49,10 @@ Package: `clawdi@0.12.10-beta.51`
   identifier rules and the Cloud 200-character limit. Managed bootstrap tgz paths are
   accepted only through strict Hosted test fixtures. Runtime desired state no
   longer resolves floating package tags.
-- Restored `agent-v2-candidate` as the package-level safety default while the
-  release workflow retains metadata override, prerelease `beta`, and stable
-  `latest` tag selection. Hosted runtime updates consume the public exact
-  version from the Cloud manifest and never resolve a dist-tag.
+- Standardized npm publication on `beta` for prereleases and `latest` for
+  stable releases, with no package-level tag override. Hosted runtime updates
+  consume the public exact version from the Cloud manifest and never resolve a
+  dist-tag.
 
 ### Fixed
 
@@ -75,8 +75,8 @@ Package: `clawdi@0.12.10-beta.50`
   can no longer implicitly select `clawdi@latest` or inherit npm registry
   configuration.
 - Made agent-v2 publishing repository-autonomous: build, test, pack, install,
-  and SHA-verify one immutable tarball, then publish that artifact directly to
-  the `agent-v2` channel with npm trusted-publisher OIDC.
+  and SHA-verify one immutable tarball, then publish prereleases to the standard
+  npm `beta` channel with trusted-publisher OIDC.
 
 ## Clawdi CLI v0.12.10-beta.49
 
@@ -86,9 +86,8 @@ Package: `clawdi@0.12.10-beta.49`
 
 ### Changed
 
-- Added managed self-update support for the isolated floating `agent-v2`
-  channel. Agent-v2 builds upload first to `agent-v2-candidate`; the production
-  channel is promoted only after the Hosted stable-envelope paired smoke.
+- Added managed self-update support for beta builds through the standard npm
+  `beta` channel while Hosted rollout remains pinned to an exact CLI version.
 
 ## Clawdi CLI v0.12.10-beta.48
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.12.10-beta.50
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.50
+
+Package: `clawdi@0.12.10-beta.50`
+
+### Changed
+
+- Made the Cloud hosted manifest the fail-closed authority for the ongoing
+  managed CLI channel. Hosted manifests must explicitly provide
+  the strict `clawdiCli` source, package spec, and official npm registry; they
+  can no longer implicitly select `clawdi@latest` or inherit npm registry
+  configuration.
+- Made agent-v2 publishing contingent on the reusable Hosted paired smoke and
+  publish the exact tested tarball directly to the `agent-v2` channel with npm
+  trusted-publisher OIDC.
+
 ## Clawdi CLI v0.12.10-beta.49
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.49

--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.49",
+      "version": "0.12.10-beta.50",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
       },
       "devDependencies": {
         "@clack/prompts": "^1.7.0",
-        "@clawdi/shared": "0.1.0",
+        "@clawdi/shared": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@types/bun": "^1.3.12",
         "@types/node": "^22.20.0",
@@ -86,9 +86,9 @@
         "commander": "^15.0.0",
         "openapi-fetch": "^0.17.0",
         "tar": "^7.5.19",
-        "typescript": "^7.0.2",
+        "typescript": "catalog:",
         "yaml": "^2.9.0",
-        "zod": "^4.4.3",
+        "zod": "catalog:",
       },
     },
     "packages/shared": {

--- a/bun.lock
+++ b/bun.lock
@@ -72,13 +72,13 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.50",
+      "version": "0.12.10-beta.51",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },
       "devDependencies": {
         "@clack/prompts": "^1.7.0",
-        "@clawdi/shared": "workspace:*",
+        "@clawdi/shared": "0.1.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@types/bun": "^1.3.12",
         "@types/node": "^22.20.0",
@@ -86,9 +86,9 @@
         "commander": "^15.0.0",
         "openapi-fetch": "^0.17.0",
         "tar": "^7.5.19",
-        "typescript": "catalog:",
+        "typescript": "^7.0.2",
         "yaml": "^2.9.0",
-        "zod": "catalog:",
+        "zod": "^4.4.3",
       },
     },
     "packages/shared": {

--- a/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
+++ b/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
@@ -80,15 +80,19 @@ envelope to provide `setpriv` or numeric `gosu` and reserve the configured IDs.
 - UID/GID `0`, malformed values, and unavailable privilege-drop tools prevent
   egress startup instead of silently running mitmproxy as root.
 - Hosted image changes that add runtime business logic violate this decision.
-- The coordinated release uses exact CLI version `0.12.10-beta.51` on the
-  isolated npm `agent-v2` dist-tag without moving `beta`. The Hosted paired
-  smoke must pass the exact tarball before trusted-publisher OIDC publishes it.
-  Follow the cross-repository release runbook linked below; no legacy image
-  controls or old-state repair are part of this contract.
+- The CLI release uses exact version `0.12.10-beta.51` on the isolated npm
+  `agent-v2` dist-tag without moving `beta`. The CLI repository independently
+  builds, tests, packs, installs, and SHA-verifies one tarball before
+  trusted-publisher OIDC publishes that artifact. The Hosted image repository
+  independently resolves the published CLI to an exact npm semver and runs its
+  image/CLI pairing smoke as part of its own image release. Neither repository
+  calls the other repository's Actions workflows. No legacy image controls or
+  old-state repair are part of this contract.
 
 ## Related Documentation
 
 - [Managed runtime architecture](../managed-runtime.md)
 - [Managed runtime CLI plan](../plans/managed-runtime-cli.md)
 - [Managed runtime roadmap](../plans/managed-runtime-roadmap.md)
-- [Agent v2 cross-repository release runbook](https://github.com/Clawdi-AI/clawdi-hosted/blob/main/docs/v2/ops/2026-07-12-agent-v2-cross-repo-release-runbook.md)
+- [CLI development and release](../cli-development.md#releasing)
+- [Clawdi release runbook](../runbooks/release.md)

--- a/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
+++ b/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
@@ -83,11 +83,12 @@ envelope to provide `setpriv` or numeric `gosu` and reserve the configured IDs.
   egress startup instead of silently running mitmproxy as root.
 - Hosted image changes that add runtime business logic violate this decision.
 - Coordinated rollout order is: merge and publish exact CLI version
-  `0.12.10-beta.48` under the isolated npm `agent-v2` dist-tag without moving
-  `beta`; configure the v2 deployment contract to use that exact version;
-  merge the Hosted generic-envelope PR; release and promote the generic image; then recreate
-  prelaunch development and canary instances. Do not promote this through the
-  legacy agent image controls; no old-state repair is required.
+  `0.12.10-beta.48` to the standard npm `beta` channel; configure the v2
+  deployment contract to use that exact version; merge the Hosted
+  generic-envelope PR; release and promote the generic image; then recreate
+  prelaunch development and canary instances. The `beta` tag is publication
+  metadata and is not consumed by Hosted. Do not promote this through the legacy
+  agent image controls; no old-state repair is required.
 
 ## Related Documentation
 

--- a/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
+++ b/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
@@ -83,12 +83,11 @@ envelope to provide `setpriv` or numeric `gosu` and reserve the configured IDs.
   egress startup instead of silently running mitmproxy as root.
 - Hosted image changes that add runtime business logic violate this decision.
 - Coordinated rollout order is: merge and publish exact CLI version
-  `0.12.10-beta.48` to the standard npm `beta` channel; configure the v2
-  deployment contract to use that exact version; merge the Hosted
-  generic-envelope PR; release and promote the generic image; then recreate
-  prelaunch development and canary instances. The `beta` tag is publication
-  metadata and is not consumed by Hosted. Do not promote this through the legacy
-  agent image controls; no old-state repair is required.
+  `0.12.10-beta.48` under the isolated npm `agent-v2` dist-tag without moving
+  `beta`; configure the v2 deployment contract to use that exact version;
+  merge the Hosted generic-envelope PR; release and promote the generic image; then recreate
+  prelaunch development and canary instances. Do not promote this through the
+  legacy agent image controls; no old-state repair is required.
 
 ## Related Documentation
 

--- a/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
+++ b/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
@@ -31,9 +31,11 @@ the environment variable containing the manifest bearer credential. The CLI
 validates both selectors and fails closed before datasource access. A hosted
 runtime does not read `host-policy.json` or `runtime-source.json`.
 
-Hosted runtime manifests use the single canonical `/v1/runtime/manifest`
-datasource contract. `CLAWDI_RUNTIME_MANIFEST_URL` may carry normal query
-parameters, but its path must end with `/v1/runtime/manifest`.
+API route versions and agent deployment generations are separate dimensions.
+Agent deployment v2 uses the canonical `/v1/runtime/manifest` route, including
+historical backend `app/v1` rows with `profile=hosted-runtime`. Actual agent
+deployment v1 keeps the legacy `/api/runtime/manifest` alias and does not
+receive the agent-v2 minimum-CLI protocol gate.
 
 For transparent egress:
 
@@ -80,19 +82,15 @@ envelope to provide `setpriv` or numeric `gosu` and reserve the configured IDs.
 - UID/GID `0`, malformed values, and unavailable privilege-drop tools prevent
   egress startup instead of silently running mitmproxy as root.
 - Hosted image changes that add runtime business logic violate this decision.
-- The CLI release uses exact version `0.12.10-beta.51` on the isolated npm
-  `agent-v2` dist-tag without moving `beta`. The CLI repository independently
-  builds, tests, packs, installs, and SHA-verifies one tarball before
-  trusted-publisher OIDC publishes that artifact. The Hosted image repository
-  independently resolves the published CLI to an exact npm semver and runs its
-  image/CLI pairing smoke as part of its own image release. Neither repository
-  calls the other repository's Actions workflows. No legacy image controls or
-  old-state repair are part of this contract.
+- Coordinated rollout order is: merge and publish exact CLI version
+  `0.12.10-beta.48` under the isolated npm `agent-v2` dist-tag without moving
+  `beta`; configure the v2 deployment contract to use that exact version;
+  merge the Hosted generic-envelope PR; release and promote the generic image; then recreate
+  prelaunch development and canary instances. Do not promote this through the
+  legacy agent image controls; no old-state repair is required.
 
 ## Related Documentation
 
 - [Managed runtime architecture](../managed-runtime.md)
 - [Managed runtime CLI plan](../plans/managed-runtime-cli.md)
 - [Managed runtime roadmap](../plans/managed-runtime-roadmap.md)
-- [CLI development and release](../cli-development.md#releasing)
-- [Clawdi release runbook](../runbooks/release.md)

--- a/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
+++ b/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
@@ -80,15 +80,15 @@ envelope to provide `setpriv` or numeric `gosu` and reserve the configured IDs.
 - UID/GID `0`, malformed values, and unavailable privilege-drop tools prevent
   egress startup instead of silently running mitmproxy as root.
 - Hosted image changes that add runtime business logic violate this decision.
-- Coordinated rollout order is: merge and publish exact CLI version
-  `0.12.10-beta.48` under the isolated npm `agent-v2` dist-tag without moving
-  `beta`; configure the v2 deployment contract to use that exact version;
-  merge the Hosted generic-envelope PR; release and promote the generic image; then recreate
-  prelaunch development and canary instances. Do not promote this through the
-  legacy agent image controls; no old-state repair is required.
+- The coordinated release uses exact CLI version `0.12.10-beta.51` on the
+  isolated npm `agent-v2` dist-tag without moving `beta`. The Hosted paired
+  smoke must pass the exact tarball before trusted-publisher OIDC publishes it.
+  Follow the cross-repository release runbook linked below; no legacy image
+  controls or old-state repair are part of this contract.
 
 ## Related Documentation
 
 - [Managed runtime architecture](../managed-runtime.md)
 - [Managed runtime CLI plan](../plans/managed-runtime-cli.md)
 - [Managed runtime roadmap](../plans/managed-runtime-roadmap.md)
+- [Agent v2 cross-repository release runbook](https://github.com/Clawdi-AI/clawdi-hosted/blob/main/docs/v2/ops/2026-07-12-agent-v2-cross-repo-release-runbook.md)

--- a/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
+++ b/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
@@ -31,11 +31,9 @@ the environment variable containing the manifest bearer credential. The CLI
 validates both selectors and fails closed before datasource access. A hosted
 runtime does not read `host-policy.json` or `runtime-source.json`.
 
-API route versions and agent deployment generations are separate dimensions.
-Agent deployment v2 uses the canonical `/v1/runtime/manifest` route, including
-historical backend `app/v1` rows with `profile=hosted-runtime`. Actual agent
-deployment v1 keeps the legacy `/api/runtime/manifest` alias and does not
-receive the agent-v2 minimum-CLI protocol gate.
+Hosted runtime manifests use the single canonical `/v1/runtime/manifest`
+datasource contract. `CLAWDI_RUNTIME_MANIFEST_URL` may carry normal query
+parameters, but its path must end with `/v1/runtime/manifest`.
 
 For transparent egress:
 

--- a/docs/ai-provider-agent-contract-audit.md
+++ b/docs/ai-provider-agent-contract-audit.md
@@ -67,6 +67,9 @@ Verified sources:
 - `website/docs/integrations/providers.md`: `config.yaml` is the source of truth
   for model, provider, and base URL. Multiple custom providers use
   `custom_providers` list entries and `model.provider: custom:<name>`.
+- `website/docs/user-guide/configuration.md` defines top-level `timezone` as an
+  IANA timezone; `website/docs/guides/migrate-from-openclaw.md` maps OpenClaw
+  `agents.defaults.userTimezone` directly to it.
 - `hermes_cli/config.py`: current config supports a v12 `providers` dict,
   normalizes it into the legacy custom-provider view, and validates
   `custom_providers` as a list.

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -236,6 +236,10 @@ paired smoke, then the protected npm job publishes that exact tarball once to
 the `agent-v2` tag with trusted-publisher OIDC. There is no candidate tag or
 separate dist-tag promotion.
 
+Cross-repository rollout ownership and ordering live in the
+[Hosted agent v2 release runbook](https://github.com/Clawdi-AI/clawdi-hosted/blob/main/docs/v2/ops/2026-07-12-agent-v2-cross-repo-release-runbook.md).
+This document covers only CLI package mechanics.
+
 The reusable workflow is private at
 `Clawdi-AI/clawdi-hosted/.github/workflows/hosted-runtime-paired-smoke.yml@main`.
 Before this release workflow can run, the focused smoke-only Hosted PR that
@@ -248,7 +252,7 @@ PAT, GitHub App token, or copied smoke implementation.
 
 Agent deployment v2 is not live, so there is no rolling compatibility window.
 Keep v2 creation and runtime-state reconciliation disabled until the smoke-only
-workflow, final Hosted capability envelope, this `.51` release, and the Cloud
+workflow, final Hosted capability envelope, `0.12.10-beta.51`, and the Cloud
 manifest contract are all landed and deployed. Then verify a fresh deployment's
 runtime-state write, canonical `/v1/runtime/manifest` fetch, SSE invalidation,
 and runtime services before enabling v2. Do not add legacy fields or aliases.

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -239,27 +239,19 @@ separate dist-tag promotion.
 The reusable workflow is private at
 `Clawdi-AI/clawdi-hosted/.github/workflows/hosted-runtime-paired-smoke.yml@main`.
 Before this release workflow can run, the focused smoke-only Hosted PR that
-adds this reusable workflow must be merged to Hosted `main`, and the Hosted
-repository Actions access must be changed from `none` to `organization` so
-organization repositories can call it. Do not use Hosted #780 as the workflow
-prerequisite: its runtime behavior must deploy only after Cloud #387 owns the
-hosted manifest channel. Do not bypass the repository-level workflow contract
-with a PAT, GitHub App token, or a copied smoke implementation.
+adds the reusable workflow must be merged to Hosted `main`, and the Hosted
+repository Actions access must be `organization` so organization repositories
+can call it. The final capability-envelope change must then be on Hosted
+`main` before this CLI release runs, because the reusable workflow checks out
+its own exact Hosted source. Do not bypass that cross-repository gate with a
+PAT, GitHub App token, or copied smoke implementation.
 
-Safe rollout order: merge the smoke-only Hosted workflow PR, enable
-organization Actions access, then merge this CLI release and publish `.51`.
-Cloud #387 and Hosted #780 require a controlled short maintenance window, not
-a rolling cross-service deploy: pause agent-v2 creation and every Hosted
-runtime-state writer/reconciliation path, deploy Cloud #387, immediately deploy
-Hosted #780, verify runtime-state writes and hosted manifests, then resume.
-Brief runtime unavailability is possible and expected during the window:
-pre-#780 pods do not have `CLAWDI_RUNTIME_AUTH_ENV`, so a pod that self-updates
-to `.51` after Cloud #387 starts serving `agent-v2` can fail closed. After
-deploying Hosted #780, force or reconcile affected prelaunch pods so they
-receive the final bootstrap environment, then verify manifest fetch and runtime
-services before resuming creation and writers. Do not add a temporary
-accepted-but-ignored `clawdi_cli` field; Cloud #387 intentionally removes or
-rejects it while pre-#780 Hosted still sends it.
+Agent deployment v2 is not live, so there is no rolling compatibility window.
+Keep v2 creation and runtime-state reconciliation disabled until the smoke-only
+workflow, final Hosted capability envelope, this `.51` release, and the Cloud
+manifest contract are all landed and deployed. Then verify a fresh deployment's
+runtime-state write, canonical `/v1/runtime/manifest` fetch, SSE invalidation,
+and runtime services before enabling v2. Do not add legacy fields or aliases.
 
 The monorepo has two GitHub Release lines:
 

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -300,7 +300,8 @@ first version has to be published manually:
 cd packages/cli
 npm login                    # use a maintainer account that owns the org
 bun run build                # produces dist/
-npm publish --access public  # plain publish, no --provenance
+NPM_TAG=$(node -e "const p=require('./package.json'); console.log(p.publishConfig?.tag || (p.version.includes('-') ? 'beta' : 'latest'))")
+npm publish --access public --tag "$NPM_TAG"  # plain publish, no --provenance
 ```
 
 The workflow detects this case (`npm view clawdi` returns nothing → falls

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -234,13 +234,20 @@ Managed agent-v2 releases are repository-autonomous. The CLI workflow builds,
 typechecks, runs the full CLI suite, and packs one immutable tarball. It installs
 the tarball, records and checks its SHA-256, transfers the same artifact to the
 protected npm job, checks it again, and publishes it exactly once to the
-`agent-v2` tag with trusted-publisher OIDC. There is no candidate tag or
-separate dist-tag promotion.
+non-production `agent-v2-candidate` tag with trusted-publisher OIDC. The
+build/test job may use the configured fast runner, but the protected publish
+job is fixed to GitHub-hosted `ubuntu-latest`: npm trusted publishing does not
+support self-hosted or third-party GitHub Actions runners. The publish job uses
+Node 24 and npm 11.5.1, satisfying npm's minimum Node 22.14 and npm 11.5.1.
 
 The CLI workflow neither calls nor checks out the Hosted repository. The Hosted
 image repository owns a separate release: it resolves the published CLI package
 to an exact npm semver and runs its image/CLI pairing smoke before publishing
-the image. That independent image release is not a gate for npm publication.
+the image. This workflow stops after making the exact candidate version public;
+it does not modify `latest` or `beta` and does not coordinate with the Hosted
+repository. Cloud-owned Hosted manifests select `clawdi@<exact-semver>` only.
+The runtime installs that exact public version directly and never resolves an
+npm dist-tag or calls `npm view` for Hosted desired state.
 
 Agent deployment v2 is not live, so there is no rolling compatibility window.
 Keep v2 creation and runtime-state reconciliation disabled until the final
@@ -301,10 +308,16 @@ onward releases are automatic.
 2. Merge to `main`.
 3. The workflow builds, typechecks, runs the full CLI suite, packs and installs
    one artifact, verifies its SHA-256 in both jobs, then publishes that tarball
-   with `npm publish <tarball> --access public --provenance --ignore-scripts --tag agent-v2`.
+   from GitHub-hosted `ubuntu-latest` with
+   `npm publish <tarball> --access public --provenance --ignore-scripts --tag agent-v2-candidate`.
 4. The workflow creates `clawdi-cli-v<version>` with changelog notes.
-5. Watch the Actions tab; on green, `npm view clawdi@agent-v2 version` will
-   reflect the new number within ~60s while `latest` and `beta` stay unchanged.
+5. Watch the Actions tab; on green,
+   `npm view clawdi@agent-v2-candidate version` and
+   `npm view clawdi@<exact-version> version` reflect the new number while
+   `latest` and `beta` remain unchanged.
+
+Stop here for this release workflow. Hosted rollout selects the approved exact
+version through its Cloud manifest; no production runtime reads a dist-tag.
 
 A manual run is available under `workflow_dispatch` if the auto-run
 needs a nudge (e.g. npm was transiently unavailable).
@@ -339,3 +352,8 @@ this one-time on npmjs.com:
 2. Select GitHub Actions, enter `Clawdi-AI/clawdi`, workflow
    `cli-publish.yml`, environment `npm`
 3. Save. Subsequent pushes to `main` with a version bump auto-publish.
+
+The OIDC publish job must remain on a GitHub-hosted runner. Do not replace its
+`ubuntu-latest` runner with `vars.CI_RUNNER`, Blacksmith, or another self-hosted
+runner. OIDC is used only to publish the non-production candidate in this
+workflow; production selection is outside this PR.

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -234,7 +234,8 @@ Managed agent-v2 releases are repository-autonomous. The CLI workflow builds,
 typechecks, runs the full CLI suite, and packs one immutable tarball. It installs
 the tarball, records and checks its SHA-256, transfers the same artifact to the
 protected npm job, checks it again, and publishes it exactly once to the
-non-production `agent-v2-candidate` tag with trusted-publisher OIDC. The
+package-selected npm tag with trusted-publisher OIDC. The current package
+metadata selects the non-production `agent-v2-candidate` tag. The
 build/test job may use the configured fast runner, but the protected publish
 job is fixed to GitHub-hosted `ubuntu-latest`: npm trusted publishing does not
 support self-hosted or third-party GitHub Actions runners. The publish job uses
@@ -246,9 +247,10 @@ verifies the exact package publication, then explicitly supplies the exact
 workflow fails closed when the exact input is missing, verifies registry
 integrity, signatures, and provenance, never resolves `agent-v2-candidate` or
 any other npm dist-tag, and runs its image/CLI pairing smoke before publishing
-the image. The candidate tag is only a workflow implementation detail that
-avoids moving `latest`; it is not an operator gate or rollout authority. The CLI
-workflow does not modify `latest` or `beta` and does not coordinate with the
+the image. The candidate tag is the current package safety default; it is not an
+operator gate or rollout authority. When package metadata does not specify a
+tag, the CLI workflow retains the normal prerelease `beta` and stable `latest`
+fallbacks and does not coordinate with the
 Hosted repository. Cloud-owned Hosted manifests select `clawdi@<exact-semver>`
 only. The runtime installs that exact public version directly and never calls
 `npm view` for Hosted desired state.
@@ -313,11 +315,11 @@ onward releases are automatic.
 3. The workflow builds, typechecks, runs the full CLI suite, packs and installs
    one artifact, verifies its SHA-256 in both jobs, then publishes that tarball
    from GitHub-hosted `ubuntu-latest` with
-   `npm publish <tarball> --access public --provenance --ignore-scripts --tag agent-v2-candidate`.
+   `npm publish <tarball> --access public --provenance --ignore-scripts --tag <resolved-tag>`.
 4. The workflow creates `clawdi-cli-v<version>` with changelog notes.
 5. Watch the Actions tab; on green,
    `npm view clawdi@<exact-version> version` reflects the new number while
-   `latest` and `beta` remain unchanged. The workflow's non-production
+   `latest` and `beta` remain unchanged for the current candidate release. The workflow's non-production
    `agent-v2-candidate` tag is diagnostic metadata, not a release gate.
 
 Stop here for this release workflow. Hosted rollout selects the approved exact

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -230,32 +230,24 @@ version bump. A merge with no version change is a no-op — the workflow
 diffs `packages/cli/package.json` against `npm view clawdi version` and
 exits early on a match.
 
-Managed agent-v2 releases build, test, and pack one immutable tarball. The
-release workflow passes that artifact through the mandatory reusable Hosted
-paired smoke, then the protected npm job publishes that exact tarball once to
-the `agent-v2` tag with trusted-publisher OIDC. There is no candidate tag or
+Managed agent-v2 releases are repository-autonomous. The CLI workflow builds,
+typechecks, runs the full CLI suite, and packs one immutable tarball. It installs
+the tarball, records and checks its SHA-256, transfers the same artifact to the
+protected npm job, checks it again, and publishes it exactly once to the
+`agent-v2` tag with trusted-publisher OIDC. There is no candidate tag or
 separate dist-tag promotion.
 
-Cross-repository rollout ownership and ordering live in the
-[Hosted agent v2 release runbook](https://github.com/Clawdi-AI/clawdi-hosted/blob/main/docs/v2/ops/2026-07-12-agent-v2-cross-repo-release-runbook.md).
-This document covers only CLI package mechanics.
-
-The reusable workflow is private at
-`Clawdi-AI/clawdi-hosted/.github/workflows/hosted-runtime-paired-smoke.yml@main`.
-Before this release workflow can run, the focused smoke-only Hosted PR that
-adds the reusable workflow must be merged to Hosted `main`, and the Hosted
-repository Actions access must be `organization` so organization repositories
-can call it. The final capability-envelope change must then be on Hosted
-`main` before this CLI release runs, because the reusable workflow checks out
-its own exact Hosted source. Do not bypass that cross-repository gate with a
-PAT, GitHub App token, or copied smoke implementation.
+The CLI workflow neither calls nor checks out the Hosted repository. The Hosted
+image repository owns a separate release: it resolves the published CLI package
+to an exact npm semver and runs its image/CLI pairing smoke before publishing
+the image. That independent image release is not a gate for npm publication.
 
 Agent deployment v2 is not live, so there is no rolling compatibility window.
-Keep v2 creation and runtime-state reconciliation disabled until the smoke-only
-workflow, final Hosted capability envelope, `0.12.10-beta.51`, and the Cloud
-manifest contract are all landed and deployed. Then verify a fresh deployment's
-runtime-state write, canonical `/v1/runtime/manifest` fetch, SSE invalidation,
-and runtime services before enabling v2. Do not add legacy fields or aliases.
+Keep v2 creation and runtime-state reconciliation disabled until the final
+Hosted capability envelope, exact CLI release, and Cloud manifest contract are
+all deployed. Then verify a fresh deployment's runtime-state write, canonical
+`/v1/runtime/manifest` fetch, SSE invalidation, and runtime services before
+enabling v2. Do not add legacy fields or aliases.
 
 The monorepo has two GitHub Release lines:
 
@@ -307,9 +299,9 @@ onward releases are automatic.
 
 1. Bump `version` in `packages/cli/package.json` (follow semver).
 2. Merge to `main`.
-3. The workflow builds, tests, and packs one artifact, runs the mandatory
-   Hosted paired smoke, then publishes the same tarball with
-   `npm publish <tarball> --access public --provenance --ignore-scripts --tag agent-v2`.
+3. The workflow builds, typechecks, runs the full CLI suite, packs and installs
+   one artifact, verifies its SHA-256 in both jobs, then publishes that tarball
+   with `npm publish <tarball> --access public --provenance --ignore-scripts --tag agent-v2`.
 4. The workflow creates `clawdi-cli-v<version>` with changelog notes.
 5. Watch the Actions tab; on green, `npm view clawdi version` will
    reflect the new number within ~60s.

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -240,14 +240,16 @@ job is fixed to GitHub-hosted `ubuntu-latest`: npm trusted publishing does not
 support self-hosted or third-party GitHub Actions runners. The publish job uses
 Node 24 and npm 11.5.1, satisfying npm's minimum Node 22.14 and npm 11.5.1.
 
-The CLI workflow neither calls nor checks out the Hosted repository. The Hosted
-image repository owns a separate release: it resolves the published CLI package
-to an exact npm semver and runs its image/CLI pairing smoke before publishing
-the image. This workflow stops after making the exact candidate version public;
-it does not modify `latest` or `beta` and does not coordinate with the Hosted
-repository. Cloud-owned Hosted manifests select `clawdi@<exact-semver>` only.
-The runtime installs that exact public version directly and never resolves an
-npm dist-tag or calls `npm view` for Hosted desired state.
+The CLI workflow neither calls nor checks out the Hosted repository. An operator
+verifies the candidate tag and exact package publication, then explicitly
+supplies the exact `clawdi@<semver>` package spec to the separate Hosted image
+workflow. That workflow fails closed when the exact input is missing, never
+resolves `agent-v2-candidate` or any other npm dist-tag, and runs its image/CLI
+pairing smoke before publishing the image. The CLI workflow stops after making
+the exact candidate version public; it does not modify `latest` or `beta` and
+does not coordinate with the Hosted repository. Cloud-owned Hosted manifests
+select `clawdi@<exact-semver>` only. The runtime installs that exact public
+version directly and never calls `npm view` for Hosted desired state.
 
 Agent deployment v2 is not live, so there is no rolling compatibility window.
 Keep v2 creation and runtime-state reconciliation disabled until the final

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -230,11 +230,36 @@ version bump. A merge with no version change is a no-op — the workflow
 diffs `packages/cli/package.json` against `npm view clawdi version` and
 exits early on a match.
 
-Managed agent-v2 packages upload to the non-production
-`agent-v2-candidate` dist-tag. The runtime never consumes that tag. Promote an
-exact candidate to `agent-v2` only after the Hosted stable-envelope paired
-smoke passes, following `docs/runbooks/release.md`. The production tag means
-paired-smoke-approved, not merely published.
+Managed agent-v2 releases build, test, and pack one immutable tarball. The
+release workflow passes that artifact through the mandatory reusable Hosted
+paired smoke, then the protected npm job publishes that exact tarball once to
+the `agent-v2` tag with trusted-publisher OIDC. There is no candidate tag or
+separate dist-tag promotion.
+
+The reusable workflow is private at
+`Clawdi-AI/clawdi-hosted/.github/workflows/hosted-runtime-paired-smoke.yml@main`.
+Before this release workflow can run, the focused smoke-only Hosted PR that
+adds this reusable workflow must be merged to Hosted `main`, and the Hosted
+repository Actions access must be changed from `none` to `organization` so
+organization repositories can call it. Do not use Hosted #780 as the workflow
+prerequisite: its runtime behavior must deploy only after Cloud #387 owns the
+hosted manifest channel. Do not bypass the repository-level workflow contract
+with a PAT, GitHub App token, or a copied smoke implementation.
+
+Safe rollout order: merge the smoke-only Hosted workflow PR, enable
+organization Actions access, then merge this CLI release and publish `.50`.
+Cloud #387 and Hosted #780 require a controlled short maintenance window, not
+a rolling cross-service deploy: pause agent-v2 creation and every Hosted
+runtime-state writer/reconciliation path, deploy Cloud #387, immediately deploy
+Hosted #780, verify runtime-state writes and hosted manifests, then resume.
+Brief runtime unavailability is possible and expected during the window:
+pre-#780 pods do not have `CLAWDI_RUNTIME_AUTH_ENV`, so a pod that self-updates
+to `.50` after Cloud #387 starts serving `agent-v2` can fail closed. After
+deploying Hosted #780, force or reconcile affected prelaunch pods so they
+receive the final bootstrap environment, then verify manifest fetch and runtime
+services before resuming creation and writers. Do not add a temporary
+accepted-but-ignored `clawdi_cli` field; Cloud #387 intentionally removes or
+rejects it while pre-#780 Hosted still sends it.
 
 The monorepo has two GitHub Release lines:
 
@@ -286,9 +311,9 @@ onward releases are automatic.
 
 1. Bump `version` in `packages/cli/package.json` (follow semver).
 2. Merge to `main`.
-3. The workflow runs typecheck → `bun run build` → `bun test` →
-   `npm publish --access public --provenance`. Each step is a separate
-   job so a failing test doesn't pollute the publish log.
+3. The workflow builds, tests, and packs one artifact, runs the mandatory
+   Hosted paired smoke, then publishes the same tarball with
+   `npm publish <tarball> --access public --provenance --ignore-scripts --tag agent-v2`.
 4. The workflow creates `clawdi-cli-v<version>` with changelog notes.
 5. Watch the Actions tab; on green, `npm view clawdi version` will
    reflect the new number within ~60s.

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -303,8 +303,8 @@ onward releases are automatic.
    one artifact, verifies its SHA-256 in both jobs, then publishes that tarball
    with `npm publish <tarball> --access public --provenance --ignore-scripts --tag agent-v2`.
 4. The workflow creates `clawdi-cli-v<version>` with changelog notes.
-5. Watch the Actions tab; on green, `npm view clawdi version` will
-   reflect the new number within ~60s.
+5. Watch the Actions tab; on green, `npm view clawdi@agent-v2 version` will
+   reflect the new number within ~60s while `latest` and `beta` stay unchanged.
 
 A manual run is available under `workflow_dispatch` if the auto-run
 needs a nudge (e.g. npm was transiently unavailable).

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -234,26 +234,25 @@ Managed agent-v2 releases are repository-autonomous. The CLI workflow builds,
 typechecks, runs the full CLI suite, and packs one immutable tarball. It installs
 the tarball, records and checks its SHA-256, transfers the same artifact to the
 protected npm job, checks it again, and publishes it exactly once to the
-package-selected npm tag with trusted-publisher OIDC. The current package
-metadata selects the non-production `agent-v2-candidate` tag. The
-build/test job may use the configured fast runner, but the protected publish
-job is fixed to GitHub-hosted `ubuntu-latest`: npm trusted publishing does not
-support self-hosted or third-party GitHub Actions runners. The publish job uses
-Node 24 and npm 11.5.1, satisfying npm's minimum Node 22.14 and npm 11.5.1.
+standard npm channel derived from the package version: prereleases use `beta`
+and stable releases use `latest`. Package-level tag overrides are rejected.
+The build/test job may use the configured fast runner, but the protected
+publish job is fixed to GitHub-hosted `ubuntu-latest`: npm trusted publishing
+does not support self-hosted or third-party GitHub Actions runners. The publish
+job uses Node 24 and npm 11.5.1, satisfying npm's minimum Node 22.14 and npm
+11.5.1.
 
 The CLI workflow neither calls nor checks out the Hosted repository. An operator
 verifies the exact package publication, then explicitly supplies the exact
 `clawdi@<semver>` package spec to the separate Hosted image workflow. That
 workflow fails closed when the exact input is missing, verifies registry
-integrity, signatures, and provenance, never resolves `agent-v2-candidate` or
-any other npm dist-tag, and runs its image/CLI pairing smoke before publishing
-the image. The candidate tag is the current package safety default; it is not an
-operator gate or rollout authority. When package metadata does not specify a
-tag, the CLI workflow retains the normal prerelease `beta` and stable `latest`
-fallbacks and does not coordinate with the
-Hosted repository. Cloud-owned Hosted manifests select `clawdi@<exact-semver>`
-only. The runtime installs that exact public version directly and never calls
-`npm view` for Hosted desired state.
+integrity, signatures, and provenance, never resolves an npm dist-tag, and runs
+its image/CLI pairing smoke before publishing the image. The `beta` tag is npm
+publication metadata for prereleases, not an operator gate or rollout
+authority. The CLI workflow does not coordinate with the Hosted repository.
+Cloud-owned Hosted manifests select `clawdi@<exact-semver>` only. The runtime
+installs that exact public version directly and never calls `npm view` for
+Hosted desired state.
 
 Agent deployment v2 is not live, so there is no rolling compatibility window.
 Keep v2 creation and runtime-state reconciliation disabled until the final
@@ -300,7 +299,7 @@ first version has to be published manually:
 cd packages/cli
 npm login                    # use a maintainer account that owns the org
 bun run build                # produces dist/
-NPM_TAG=$(node -e "const p=require('./package.json'); console.log(p.publishConfig?.tag || (p.version.includes('-') ? 'beta' : 'latest'))")
+NPM_TAG=$(node -e "const p=require('./package.json'); console.log(p.version.includes('-') ? 'beta' : 'latest')")
 npm publish --access public --tag "$NPM_TAG"  # plain publish, no --provenance
 ```
 
@@ -319,12 +318,12 @@ onward releases are automatic.
    `npm publish <tarball> --access public --provenance --ignore-scripts --tag <resolved-tag>`.
 4. The workflow creates `clawdi-cli-v<version>` with changelog notes.
 5. Watch the Actions tab; on green,
-   `npm view clawdi@<exact-version> version` reflects the new number while
-   `latest` and `beta` remain unchanged for the current candidate release. The workflow's non-production
-   `agent-v2-candidate` tag is diagnostic metadata, not a release gate.
+   `npm view clawdi@<exact-version> version` reflects the new number. A
+   prerelease updates `beta`; a stable release updates `latest`.
 
 Stop here for this release workflow. Hosted rollout selects the approved exact
-version through its Cloud manifest; no production runtime reads a dist-tag.
+version through its Cloud manifest. The `beta` tag is publication metadata;
+production and Hosted never resolve an npm dist-tag.
 
 A manual run is available under `workflow_dispatch` if the auto-run
 needs a nudge (e.g. npm was transiently unavailable).

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -241,15 +241,17 @@ support self-hosted or third-party GitHub Actions runners. The publish job uses
 Node 24 and npm 11.5.1, satisfying npm's minimum Node 22.14 and npm 11.5.1.
 
 The CLI workflow neither calls nor checks out the Hosted repository. An operator
-verifies the candidate tag and exact package publication, then explicitly
-supplies the exact `clawdi@<semver>` package spec to the separate Hosted image
-workflow. That workflow fails closed when the exact input is missing, never
-resolves `agent-v2-candidate` or any other npm dist-tag, and runs its image/CLI
-pairing smoke before publishing the image. The CLI workflow stops after making
-the exact candidate version public; it does not modify `latest` or `beta` and
-does not coordinate with the Hosted repository. Cloud-owned Hosted manifests
-select `clawdi@<exact-semver>` only. The runtime installs that exact public
-version directly and never calls `npm view` for Hosted desired state.
+verifies the exact package publication, then explicitly supplies the exact
+`clawdi@<semver>` package spec to the separate Hosted image workflow. That
+workflow fails closed when the exact input is missing, verifies registry
+integrity, signatures, and provenance, never resolves `agent-v2-candidate` or
+any other npm dist-tag, and runs its image/CLI pairing smoke before publishing
+the image. The candidate tag is only a workflow implementation detail that
+avoids moving `latest`; it is not an operator gate or rollout authority. The CLI
+workflow does not modify `latest` or `beta` and does not coordinate with the
+Hosted repository. Cloud-owned Hosted manifests select `clawdi@<exact-semver>`
+only. The runtime installs that exact public version directly and never calls
+`npm view` for Hosted desired state.
 
 Agent deployment v2 is not live, so there is no rolling compatibility window.
 Keep v2 creation and runtime-state reconciliation disabled until the final
@@ -314,9 +316,9 @@ onward releases are automatic.
    `npm publish <tarball> --access public --provenance --ignore-scripts --tag agent-v2-candidate`.
 4. The workflow creates `clawdi-cli-v<version>` with changelog notes.
 5. Watch the Actions tab; on green,
-   `npm view clawdi@agent-v2-candidate version` and
-   `npm view clawdi@<exact-version> version` reflect the new number while
-   `latest` and `beta` remain unchanged.
+   `npm view clawdi@<exact-version> version` reflects the new number while
+   `latest` and `beta` remain unchanged. The workflow's non-production
+   `agent-v2-candidate` tag is diagnostic metadata, not a release gate.
 
 Stop here for this release workflow. Hosted rollout selects the approved exact
 version through its Cloud manifest; no production runtime reads a dist-tag.

--- a/docs/cli-development.md
+++ b/docs/cli-development.md
@@ -247,14 +247,14 @@ hosted manifest channel. Do not bypass the repository-level workflow contract
 with a PAT, GitHub App token, or a copied smoke implementation.
 
 Safe rollout order: merge the smoke-only Hosted workflow PR, enable
-organization Actions access, then merge this CLI release and publish `.50`.
+organization Actions access, then merge this CLI release and publish `.51`.
 Cloud #387 and Hosted #780 require a controlled short maintenance window, not
 a rolling cross-service deploy: pause agent-v2 creation and every Hosted
 runtime-state writer/reconciliation path, deploy Cloud #387, immediately deploy
 Hosted #780, verify runtime-state writes and hosted manifests, then resume.
 Brief runtime unavailability is possible and expected during the window:
 pre-#780 pods do not have `CLAWDI_RUNTIME_AUTH_ENV`, so a pod that self-updates
-to `.50` after Cloud #387 starts serving `agent-v2` can fail closed. After
+to `.51` after Cloud #387 starts serving `agent-v2` can fail closed. After
 deploying Hosted #780, force or reconcile affected prelaunch pods so they
 receive the final bootstrap environment, then verify manifest fetch and runtime
 services before resuming creation and writers. Do not add a temporary

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -266,7 +266,7 @@ Normalization maps hosted fields into the internal shape:
 | Hosted field | Internal purpose |
 | --- | --- |
 | `deploymentId`, `environmentId`, `instanceId`, `generation` | Identity, cache keys, status, and idempotence |
-| `system.home`, `system.workspace` | Required runtime HOME and workspace root; Hosted does not derive defaults |
+| `system.user`, `system.home`, `system.workspace`, `system.persistentPaths` | Required runtime identity and persistent filesystem contract; Hosted does not derive defaults |
 | `system.openclawControlUiAllowedOrigins` | Optional validated HTTP(S) origins for the OpenClaw gateway Control UI patch |
 | `controlPlane.cloudApiUrl` | Required API origin; manifest datasource selection stays out of band |
 | `minimumCliVersion` | Required hosted CLI protocol floor |

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -267,6 +267,7 @@ Normalization maps hosted fields into the internal shape:
 | --- | --- |
 | `deploymentId`, `environmentId`, `instanceId`, `generation` | Identity, cache keys, status, and idempotence |
 | `system.home`, `system.workspace` | Runtime HOME and workspace root |
+| `system.openclawControlUiAllowedOrigins` | Optional validated HTTP(S) origins for the OpenClaw gateway Control UI patch |
 | `controlPlane.cloudApiUrl` | Required API origin; manifest datasource selection stays out of band |
 | `minimumCliVersion` | Required hosted CLI protocol floor |
 | `clawdiCli.source` | Required literal `npm:clawdi` for Hosted managed CLI updates |
@@ -275,6 +276,10 @@ Normalization maps hosted fields into the internal shape:
 | `runtimes.<name>.enabled` | Run config and systemd unit state |
 | `runtimes.<name>.install` | Supported official installer input |
 | `runtimes.<name>.run` | Command, args, cwd, env, and PATH projection |
+| `runtimes.<name>.provider_ids` | Canonical runtime provider selection |
+| `runtimes.<name>.primary_model.{provider_id,model}` | Canonical runtime primary model selection |
+| `runtimes.<name>.paths.{home,workspace}` | Canonical runtime paths; legacy `stateDir` is rejected |
+| `providers.<id>.{baseUrl,apiMode,runtimeEnvName,apiKeySecretRef}` | Canonical Hosted provider transport and secret-reference fields |
 | `runtimes.<name>.services` | Runtime-owned auxiliary processes, such as a browser dashboard, managed without user command shims |
 | `bridge.surfaces` | Optional authenticated runtime surface listen/upstream mappings |
 | `providers` | Runtime-scoped AI provider projections and secret refs |
@@ -282,6 +287,11 @@ Normalization maps hosted fields into the internal shape:
 | `liveSync` | Optional daemon sync configuration |
 | `egressProfiles` | Explicit local sidecar profiles |
 | `recovery` | Manifest cache and offline-boot behavior |
+
+Hosted parsing does not accept camel-case runtime binding aliases, snake-case
+provider transport aliases, or string `primary_model` values. Provider model
+catalog fields such as `models[].api_mode` and ownership metadata such as
+`managed_by` remain canonical snake-case wire fields.
 
 Manifest `generation` is part of the remote manifest ETag. The CLI applies any
 non-304 manifest without monotonic generation gating, writes `generation` into

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -271,7 +271,7 @@ Normalization maps hosted fields into the internal shape:
 | `controlPlane.cloudApiUrl` | Required API origin; manifest datasource selection stays out of band |
 | `minimumCliVersion` | Required hosted CLI protocol floor |
 | `clawdiCli.source` | Required literal `npm:clawdi` for Hosted managed CLI updates |
-| `clawdiCli.packageSpec` | Required exact `clawdi@<semver>` without build metadata; remote Hosted manifests never select an npm dist-tag or local path |
+| `clawdiCli.packageSpec` | Required exact `clawdi@<semver>` without build metadata, at most 200 characters; remote Hosted manifests never select an npm dist-tag or local path |
 | `clawdiCli.registry` | Required literal `https://registry.npmjs.org`; Hosted does not use npm registry defaults or overrides |
 | `runtimes.<name>.enabled` | Run config and systemd unit state |
 | `runtimes.<name>.install` | Required strict `{source: "official"}` selector; CLI owns installer URL and args |
@@ -294,7 +294,8 @@ catalog fields such as `models[].api_mode` and ownership metadata such as
 `managed_by` remain canonical snake-case wire fields. Singular provider
 `model` is not a Hosted alias; model selection lives in runtime
 `primary_model`, while provider catalogs use `models[]`. Provider error
-projections require `status: "error"` and `error` together. A
+projections require `status: "error"` and `error` together, including a
+non-empty `error.message`. A
 `provider_not_found` entry contains `kind` plus that error pair; other error and
 healthy entries retain the normal `kind`, `type`, and `baseUrl` projection.
 

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -255,9 +255,9 @@ The CLI accepts two related shapes:
 - `clawdi.hosted-runtime.manifest.v1` is the hosted control-plane response
   shape served only from `/v1/runtime/manifest`. It requires explicit `runtime`
   and `environmentId` fields and rejects unknown fields instead of accepting
-  compatibility payloads. It can include `system`, `controlPlane`, `clawdiCli`,
-  `runtimes`, `providers`, `liveSync`, `egressProfiles`, `mcp`, `tools`, and
-  `recovery`.
+  compatibility payloads. `system`, `controlPlane`, `clawdiCli`, `runtimes`,
+  `liveSync`, and `recovery` are required. `providers`, `egressProfiles`, `mcp`,
+  and `tools` remain explicit optional projections.
 - `clawdi.runtimeDesiredState.v1` is the normalized internal convergence shape
   consumed by `runtime init`.
 
@@ -284,9 +284,9 @@ Normalization maps hosted fields into the internal shape:
 | `bridge.surfaces` | Optional authenticated runtime surface listen/upstream mappings |
 | `providers` | Runtime-scoped AI provider projections and secret refs |
 | `mcp`, `tools` | Runtime MCP/tool projection input |
-| `liveSync` | Optional daemon sync configuration |
+| `liveSync.{enabled,agents}` | Required explicit daemon sync configuration; Hosted does not infer it from agent metadata |
 | `egressProfiles` | Explicit local sidecar profiles |
-| `recovery` | Manifest cache and offline-boot behavior |
+| `recovery.{cacheManifest,allowOfflineBoot}` | Required explicit manifest cache and offline-boot behavior |
 
 Hosted parsing does not accept camel-case runtime binding aliases, snake-case
 provider transport aliases, or string `primary_model` values. Provider model

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -266,7 +266,7 @@ Normalization maps hosted fields into the internal shape:
 | Hosted field | Internal purpose |
 | --- | --- |
 | `deploymentId`, `environmentId`, `instanceId`, `generation` | Identity, cache keys, status, and idempotence |
-| `system.home`, `system.workspace` | Runtime HOME and workspace root |
+| `system.home`, `system.workspace` | Required runtime HOME and workspace root; Hosted does not derive defaults |
 | `system.openclawControlUiAllowedOrigins` | Optional validated HTTP(S) origins for the OpenClaw gateway Control UI patch |
 | `controlPlane.cloudApiUrl` | Required API origin; manifest datasource selection stays out of band |
 | `minimumCliVersion` | Required hosted CLI protocol floor |
@@ -276,9 +276,9 @@ Normalization maps hosted fields into the internal shape:
 | `runtimes.<name>.enabled` | Run config and systemd unit state |
 | `runtimes.<name>.install` | Supported official installer input |
 | `runtimes.<name>.run` | Command, args, cwd, env, and PATH projection |
-| `runtimes.<name>.provider_ids` | Canonical runtime provider selection |
-| `runtimes.<name>.primary_model.{provider_id,model}` | Canonical runtime primary model selection |
-| `runtimes.<name>.paths.{home,workspace}` | Canonical runtime paths; legacy `stateDir` is rejected |
+| `runtimes.<name>.provider_ids` | Required non-empty unique runtime provider selection |
+| `runtimes.<name>.primary_model.{provider_id,model}` | Required primary model whose provider belongs to `provider_ids` |
+| `runtimes.<name>.paths.{home,workspace}` | Required canonical runtime paths; missing values and legacy `stateDir` are rejected |
 | `providers.<id>.{baseUrl,apiMode,runtimeEnvName,apiKeySecretRef}` | Canonical Hosted provider transport and secret-reference fields |
 | `runtimes.<name>.services` | Runtime-owned auxiliary processes, such as a browser dashboard, managed without user command shims |
 | `bridge.surfaces` | Optional authenticated runtime surface listen/upstream mappings |

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -271,15 +271,15 @@ Normalization maps hosted fields into the internal shape:
 | `controlPlane.cloudApiUrl` | Required API origin; manifest datasource selection stays out of band |
 | `minimumCliVersion` | Required hosted CLI protocol floor |
 | `clawdiCli.source` | Required literal `npm:clawdi` for Hosted managed CLI updates |
-| `clawdiCli.packageSpec` | Required `clawdi@agent-v2`, exact `clawdi@<semver>`, or immutable managed bootstrap tgz |
+| `clawdiCli.packageSpec` | Required exact `clawdi@<semver>` without build metadata; remote Hosted manifests never select an npm dist-tag or local path |
 | `clawdiCli.registry` | Required literal `https://registry.npmjs.org`; Hosted does not use npm registry defaults or overrides |
 | `runtimes.<name>.enabled` | Run config and systemd unit state |
-| `runtimes.<name>.install` | Supported official installer input |
+| `runtimes.<name>.install` | Required strict `{source: "official"}` selector; CLI owns installer URL and args |
 | `runtimes.<name>.run` | Command, args, cwd, env, and PATH projection |
 | `runtimes.<name>.provider_ids` | Required non-empty unique runtime provider selection |
 | `runtimes.<name>.primary_model.{provider_id,model}` | Required primary model whose provider belongs to `provider_ids` |
 | `runtimes.<name>.paths.{home,workspace}` | Required canonical runtime paths; missing values and legacy `stateDir` are rejected |
-| `providers.<id>.{baseUrl,apiMode,runtimeEnvName,apiKeySecretRef}` | Canonical Hosted provider transport and secret-reference fields |
+| `providers.<id>` | Canonical Hosted provider projection: `kind` is exactly `openai-compatible`; normal entries also require `type` and `baseUrl`, while `provider_not_found` is the only reduced error entry |
 | `runtimes.<name>.services` | Runtime-owned auxiliary processes, such as a browser dashboard, managed without user command shims |
 | `bridge.surfaces` | Optional authenticated runtime surface listen/upstream mappings |
 | `providers` | Required runtime-scoped AI provider projections whose keys exactly match selected `provider_ids` |
@@ -291,7 +291,35 @@ Normalization maps hosted fields into the internal shape:
 Hosted parsing does not accept camel-case runtime binding aliases, snake-case
 provider transport aliases, or string `primary_model` values. Provider model
 catalog fields such as `models[].api_mode` and ownership metadata such as
-`managed_by` remain canonical snake-case wire fields.
+`managed_by` remain canonical snake-case wire fields. Singular provider
+`model` is not a Hosted alias; model selection lives in runtime
+`primary_model`, while provider catalogs use `models[]`. Provider error
+projections require `status: "error"` and `error` together. A
+`provider_not_found` entry contains `kind` plus that error pair; other error and
+healthy entries retain the normal `kind`, `type`, and `baseUrl` projection.
+
+This strict typing claim applies only to the Hosted fields modeled in this
+release. `mcp` and `tools` remain explicit pass-through projections, while
+egress retains its existing separate handling; this pass does not claim a
+complete product schema for any of those surfaces. Further `mcp`, `tools`, and
+egress modeling is separate future schema work. They are not compatibility
+aliases and are not removed or remodeled here. The normalized generic
+`clawdi.runtimeDesiredState.v1` shape also retains optional install metadata,
+default install args, and arbitrary provider projection data such as singular
+`model` for non-Hosted inputs.
+
+Remote Hosted CLI policy is exact-version only. Values such as npm dist-tags,
+bare package names, build-metadata versions such as `clawdi@1.2.3+build.1`, and
+malformed SemVer prereleases are rejected before normalization. Valid
+prereleases follow SemVer identifier rules, including forms such as `beta.51`
+and `rc-1.2`; empty identifiers and numeric identifiers with leading zeroes are
+invalid. A managed bootstrap tgz
+under `/usr/local/share/clawdi/bootstrap/` is accepted only when the entire
+manifest is loaded from the explicit `CLAWDI_RUNTIME_MANIFEST_PATH` test-fixture
+entry point. Remote fetches cannot use that fixture schema. Generic
+`clawdi.runtimeDesiredState.v1` manifests retain their existing floating package
+support; exact Hosted updates do not call `npm view` and can move to either a
+higher or lower exact version.
 
 Manifest `generation` is part of the remote manifest ETag. The CLI applies any
 non-304 manifest without monotonic generation gating, writes `generation` into
@@ -299,10 +327,13 @@ managed state, sync state, egress bundles, run configs, and projections, then
 caches the fetched manifest as last-good. A generation-only control-plane bump
 therefore must produce a new ETag so `runtime watch` converges immediately.
 
-Manifest validation is defensive. Enabled built-in runtimes must use the
-expected official installer metadata unless they provide an explicit run
-command. Unknown runtime names require `run.command`; otherwise the manifest is
-rejected so the image does not need to know every future agent.
+Manifest validation is defensive. The selected Hosted runtime must be enabled
+and provide exactly `install: {source: "official"}`. Hosted cannot select an
+installer channel, URL, or arguments; the CLI unconditionally owns the official
+URL and argument vector for the selected runtime. Generic desired-state
+manifests keep their existing optional installer, channel, and argument
+behavior. Unknown generic runtime names require `run.command`; otherwise the
+manifest is rejected so the image does not need to know every future agent.
 
 ## Commands
 

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -253,11 +253,8 @@ OpenClaw port directly.
 The CLI accepts two related shapes:
 
 - `clawdi.hosted-runtime.manifest.v1` is the hosted control-plane response
-  shape served only from `/v1/runtime/manifest`. It requires explicit `runtime`
-  and `environmentId` fields and rejects unknown fields instead of accepting
-  compatibility payloads. `system`, `controlPlane`, `clawdiCli`, `runtimes`,
-  `providers`, `liveSync`, and `recovery` are required. `egressProfiles`, `mcp`,
-  and `tools` remain explicit optional projections.
+  shape. It can include `system`, `controlPlane`, `clawdiCli`, `runtimes`,
+  `providers`, `liveSync`, `egressProfiles`, `mcp`, `tools`, and `recovery`.
 - `clawdi.runtimeDesiredState.v1` is the normalized internal convergence shape
   consumed by `runtime init`.
 
@@ -266,61 +263,19 @@ Normalization maps hosted fields into the internal shape:
 | Hosted field | Internal purpose |
 | --- | --- |
 | `deploymentId`, `environmentId`, `instanceId`, `generation` | Identity, cache keys, status, and idempotence |
-| `system.user`, `system.home`, `system.workspace`, `system.persistentPaths` | Required runtime identity and persistent filesystem contract; Hosted does not derive defaults |
-| `system.openclawControlUiAllowedOrigins` | Optional validated HTTP(S) origins for the OpenClaw gateway Control UI patch |
-| `controlPlane.cloudApiUrl` | Required API origin; manifest datasource selection stays out of band |
-| `minimumCliVersion` | Required hosted CLI protocol floor |
-| `clawdiCli.source` | Required literal `npm:clawdi` for Hosted managed CLI updates |
-| `clawdiCli.packageSpec` | Required exact `clawdi@<semver>` without build metadata, at most 200 characters; remote Hosted manifests never select an npm dist-tag or local path |
-| `clawdiCli.registry` | Required literal `https://registry.npmjs.org`; Hosted does not use npm registry defaults or overrides |
+| `system.home`, `system.workspace` | Runtime HOME and workspace root |
+| `controlPlane.manifestUrl`, `controlPlane.cloudApiUrl` | Manifest datasource and API origin |
+| `clawdiCli.packageSpec` | System-managed CLI package selection |
 | `runtimes.<name>.enabled` | Run config and systemd unit state |
-| `runtimes.<name>.install` | Required strict `{source: "official"}` selector; CLI owns installer URL and args |
+| `runtimes.<name>.install` | Supported official installer input |
 | `runtimes.<name>.run` | Command, args, cwd, env, and PATH projection |
-| `runtimes.<name>.provider_ids` | Required non-empty unique runtime provider selection |
-| `runtimes.<name>.primary_model.{provider_id,model}` | Required primary model whose provider belongs to `provider_ids` |
-| `runtimes.<name>.paths.{home,workspace}` | Required canonical runtime paths; missing values and legacy `stateDir` are rejected |
-| `providers.<id>` | Canonical Hosted provider projection: `kind` is exactly `openai-compatible`; normal entries also require `type` and `baseUrl`, while `provider_not_found` is the only reduced error entry |
 | `runtimes.<name>.services` | Runtime-owned auxiliary processes, such as a browser dashboard, managed without user command shims |
 | `bridge.surfaces` | Optional authenticated runtime surface listen/upstream mappings |
-| `providers` | Required runtime-scoped AI provider projections whose keys exactly match selected `provider_ids` |
+| `providers` | Runtime-scoped AI provider projections and secret refs |
 | `mcp`, `tools` | Runtime MCP/tool projection input |
-| `liveSync.{enabled,agents}` | Required explicit daemon sync configuration; Hosted does not infer it from agent metadata |
+| `liveSync` | Optional daemon sync configuration |
 | `egressProfiles` | Explicit local sidecar profiles |
-| `recovery.{cacheManifest,allowOfflineBoot}` | Required explicit manifest cache and offline-boot behavior |
-
-Hosted parsing does not accept camel-case runtime binding aliases, snake-case
-provider transport aliases, or string `primary_model` values. Provider model
-catalog fields such as `models[].api_mode` and ownership metadata such as
-`managed_by` remain canonical snake-case wire fields. Singular provider
-`model` is not a Hosted alias; model selection lives in runtime
-`primary_model`, while provider catalogs use `models[]`. Provider error
-projections require `status: "error"` and `error` together, including a
-non-empty `error.message`. A
-`provider_not_found` entry contains `kind` plus that error pair; other error and
-healthy entries retain the normal `kind`, `type`, and `baseUrl` projection.
-
-This strict typing claim applies only to the Hosted fields modeled in this
-release. `mcp` and `tools` remain explicit pass-through projections, while
-egress retains its existing separate handling; this pass does not claim a
-complete product schema for any of those surfaces. Further `mcp`, `tools`, and
-egress modeling is separate future schema work. They are not compatibility
-aliases and are not removed or remodeled here. The normalized generic
-`clawdi.runtimeDesiredState.v1` shape also retains optional install metadata,
-default install args, and arbitrary provider projection data such as singular
-`model` for non-Hosted inputs.
-
-Remote Hosted CLI policy is exact-version only. Values such as npm dist-tags,
-bare package names, build-metadata versions such as `clawdi@1.2.3+build.1`, and
-malformed SemVer prereleases are rejected before normalization. Valid
-prereleases follow SemVer identifier rules, including forms such as `beta.51`
-and `rc-1.2`; empty identifiers and numeric identifiers with leading zeroes are
-invalid. A managed bootstrap tgz
-under `/usr/local/share/clawdi/bootstrap/` is accepted only when the entire
-manifest is loaded from the explicit `CLAWDI_RUNTIME_MANIFEST_PATH` test-fixture
-entry point. Remote fetches cannot use that fixture schema. Generic
-`clawdi.runtimeDesiredState.v1` manifests retain their existing floating package
-support; exact Hosted updates do not call `npm view` and can move to either a
-higher or lower exact version.
+| `recovery` | Manifest cache and offline-boot behavior |
 
 Manifest `generation` is part of the remote manifest ETag. The CLI applies any
 non-304 manifest without monotonic generation gating, writes `generation` into
@@ -328,13 +283,10 @@ managed state, sync state, egress bundles, run configs, and projections, then
 caches the fetched manifest as last-good. A generation-only control-plane bump
 therefore must produce a new ETag so `runtime watch` converges immediately.
 
-Manifest validation is defensive. The selected Hosted runtime must be enabled
-and provide exactly `install: {source: "official"}`. Hosted cannot select an
-installer channel, URL, or arguments; the CLI unconditionally owns the official
-URL and argument vector for the selected runtime. Generic desired-state
-manifests keep their existing optional installer, channel, and argument
-behavior. Unknown generic runtime names require `run.command`; otherwise the
-manifest is rejected so the image does not need to know every future agent.
+Manifest validation is defensive. Enabled built-in runtimes must use the
+expected official installer metadata unless they provide an explicit run
+command. Unknown runtime names require `run.command`; otherwise the manifest is
+rejected so the image does not need to know every future agent.
 
 ## Commands
 

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -256,7 +256,7 @@ The CLI accepts two related shapes:
   shape served only from `/v1/runtime/manifest`. It requires explicit `runtime`
   and `environmentId` fields and rejects unknown fields instead of accepting
   compatibility payloads. `system`, `controlPlane`, `clawdiCli`, `runtimes`,
-  `liveSync`, and `recovery` are required. `providers`, `egressProfiles`, `mcp`,
+  `providers`, `liveSync`, and `recovery` are required. `egressProfiles`, `mcp`,
   and `tools` remain explicit optional projections.
 - `clawdi.runtimeDesiredState.v1` is the normalized internal convergence shape
   consumed by `runtime init`.
@@ -282,7 +282,7 @@ Normalization maps hosted fields into the internal shape:
 | `providers.<id>.{baseUrl,apiMode,runtimeEnvName,apiKeySecretRef}` | Canonical Hosted provider transport and secret-reference fields |
 | `runtimes.<name>.services` | Runtime-owned auxiliary processes, such as a browser dashboard, managed without user command shims |
 | `bridge.surfaces` | Optional authenticated runtime surface listen/upstream mappings |
-| `providers` | Runtime-scoped AI provider projections and secret refs |
+| `providers` | Required runtime-scoped AI provider projections whose keys exactly match selected `provider_ids` |
 | `mcp`, `tools` | Runtime MCP/tool projection input |
 | `liveSync.{enabled,agents}` | Required explicit daemon sync configuration; Hosted does not infer it from agent metadata |
 | `egressProfiles` | Explicit local sidecar profiles |

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -265,7 +265,9 @@ Normalization maps hosted fields into the internal shape:
 | `deploymentId`, `environmentId`, `instanceId`, `generation` | Identity, cache keys, status, and idempotence |
 | `system.home`, `system.workspace` | Runtime HOME and workspace root |
 | `controlPlane.manifestUrl`, `controlPlane.cloudApiUrl` | Manifest datasource and API origin |
-| `clawdiCli.packageSpec` | System-managed CLI package selection |
+| `clawdiCli.source` | Required literal `npm:clawdi` for Hosted managed CLI updates |
+| `clawdiCli.packageSpec` | Required Cloud-owned managed CLI package selection |
+| `clawdiCli.registry` | Required literal `https://registry.npmjs.org`; Hosted does not use npm registry defaults or overrides |
 | `runtimes.<name>.enabled` | Run config and systemd unit state |
 | `runtimes.<name>.install` | Supported official installer input |
 | `runtimes.<name>.run` | Command, args, cwd, env, and PATH projection |

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -253,8 +253,11 @@ OpenClaw port directly.
 The CLI accepts two related shapes:
 
 - `clawdi.hosted-runtime.manifest.v1` is the hosted control-plane response
-  shape. It can include `system`, `controlPlane`, `clawdiCli`, `runtimes`,
-  `providers`, `liveSync`, `egressProfiles`, `mcp`, `tools`, and `recovery`.
+  shape served only from `/v1/runtime/manifest`. It requires explicit `runtime`
+  and `environmentId` fields and rejects unknown fields instead of accepting
+  compatibility payloads. It can include `system`, `controlPlane`, `clawdiCli`,
+  `runtimes`, `providers`, `liveSync`, `egressProfiles`, `mcp`, `tools`, and
+  `recovery`.
 - `clawdi.runtimeDesiredState.v1` is the normalized internal convergence shape
   consumed by `runtime init`.
 
@@ -264,9 +267,10 @@ Normalization maps hosted fields into the internal shape:
 | --- | --- |
 | `deploymentId`, `environmentId`, `instanceId`, `generation` | Identity, cache keys, status, and idempotence |
 | `system.home`, `system.workspace` | Runtime HOME and workspace root |
-| `controlPlane.manifestUrl`, `controlPlane.cloudApiUrl` | Manifest datasource and API origin |
+| `controlPlane.cloudApiUrl` | Required API origin; manifest datasource selection stays out of band |
+| `minimumCliVersion` | Required hosted CLI protocol floor |
 | `clawdiCli.source` | Required literal `npm:clawdi` for Hosted managed CLI updates |
-| `clawdiCli.packageSpec` | Required Cloud-owned managed CLI package selection |
+| `clawdiCli.packageSpec` | Required `clawdi@agent-v2`, exact `clawdi@<semver>`, or immutable managed bootstrap tgz |
 | `clawdiCli.registry` | Required literal `https://registry.npmjs.org`; Hosted does not use npm registry defaults or overrides |
 | `runtimes.<name>.enabled` | Run config and systemd unit state |
 | `runtimes.<name>.install` | Supported official installer input |

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -101,18 +101,20 @@ releases.
 3. For CLI releases, verify npm after the workflow succeeds:
 
    ```bash
-   npm view clawdi version
+   CLI_VERSION='<exact-version>'
+   test "$(npm view "clawdi@$CLI_VERSION" version)" = "$CLI_VERSION"
    npm view clawdi dist-tags
    ```
 
-   Done: `agent-v2-candidate` points to the exact version published from the
-   verified CLI artifact while `beta` and `latest` are unchanged.
-   The Hosted image repository has a separate release boundary. An operator
-   verifies the candidate tag and exact package publication, then explicitly
-   supplies the exact `clawdi@<semver>` package spec to the Hosted image workflow.
-   That workflow fails when the exact spec is missing and never resolves
-   `agent-v2-candidate` or any other npm dist-tag. It runs the image/CLI pairing
-   smoke before publishing the image and does not call back into this workflow.
+   Done: the exact version exists from the verified CLI artifact while `beta`
+   and `latest` are unchanged. The Hosted image repository has a separate
+   release boundary. An operator supplies the exact `clawdi@<semver>` package
+   spec to the Hosted image workflow. That workflow fails when the exact spec is
+   missing, verifies registry integrity, signatures, and provenance, and never
+   resolves `agent-v2-candidate` or any other npm dist-tag. It runs the image/CLI
+   pairing smoke before publishing the image and does not call back into this
+   workflow. The candidate tag is workflow-internal diagnostic metadata, not an
+   operator gate.
 
    Hosted rollout uses that same exact package spec in the Cloud manifest. The
    runtime never resolves an npm dist-tag.

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -73,12 +73,13 @@ releases.
 6. If the PR touches the CLI package and should publish, bump
    `packages/cli/package.json` using semver. If no npm publish is intended,
    leave the version unchanged.
-   For the managed `agent-v2` channel, the release workflow must build and pack
-   one immutable artifact, pass it through the reusable Hosted paired smoke,
-   and publish that exact tarball once to `agent-v2` with npm trusted-publisher
-   OIDC. For `0.12.10-beta.51`, there is no candidate tag or dist-tag promotion
-   step. Cross-repository rollout ownership and ordering live in the
-   [Hosted agent v2 release runbook](https://github.com/Clawdi-AI/clawdi-hosted/blob/main/docs/v2/ops/2026-07-12-agent-v2-cross-repo-release-runbook.md).
+   For the managed `agent-v2` channel, this repository's release workflow must
+   build, typecheck, run the full CLI suite, and pack one immutable tarball. It
+   installs that tarball, records and verifies its SHA-256, transfers the same
+   artifact to the protected npm job, verifies it again, and publishes it once
+   to `agent-v2` with npm trusted-publisher OIDC. There is no candidate tag or
+   dist-tag promotion step. The CLI workflow does not call workflows in the
+   Hosted repository or depend on Hosted repository settings.
 7. Decide whether `CHANGELOG.md` needs a curated entry. Add one for notable
    user-facing releases, especially when GitHub generated notes would be too
    noisy or too terse.
@@ -102,12 +103,12 @@ releases.
    npm view clawdi dist-tags
    ```
 
-   Done: `agent-v2` points directly to the paired-smoke-approved exact version
-   while `beta` and `latest` are unchanged. Before release, merge the focused
-   reusable-workflow PR, set the private Hosted repository Actions access to
-   `organization`, and land the final capability envelope on Hosted `main`.
-   The reusable workflow checks out its own exact Hosted source, so this order
-   makes the release gate exercise the image that will actually launch.
+   Done: `agent-v2` points directly to the exact version published from the
+   verified CLI artifact while `beta` and `latest` are unchanged. The Hosted
+   image repository has a separate release boundary: its own release resolves
+   the published CLI to an exact npm semver and runs the image/CLI pairing smoke
+   before publishing that image. Hosted image validation does not gate or call
+   back into the CLI publish workflow.
 
    Agent deployment v2 is not live. Keep creation and runtime-state
    reconciliation disabled until the Hosted image contract, CLI version

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -101,27 +101,17 @@ releases.
    ```
 
    Done: `agent-v2` points directly to the paired-smoke-approved exact version
-   while `beta` and `latest` are unchanged. Before merge/release, the focused
-   smoke-only Hosted reusable-workflow PR must be on Hosted `main`, and the
-   private Hosted repository Actions access must be set to `organization`; its
-   current `none` setting prevents the reusable workflow call. Hosted #780 is
-   not this prerequisite because its runtime behavior must deploy after Cloud
-   #387 owns the hosted manifest channel. Do not work around this with
-   long-lived credentials or duplicated private smoke code.
+   while `beta` and `latest` are unchanged. Before release, merge the focused
+   reusable-workflow PR, set the private Hosted repository Actions access to
+   `organization`, and land the final capability envelope on Hosted `main`.
+   The reusable workflow checks out its own exact Hosted source, so this order
+   makes the release gate exercise the image that will actually launch.
 
-   Safe rollout order: smoke-only Hosted workflow PR -> organization Actions
-   access -> merge this CLI PR and publish `.51` -> controlled short
-   maintenance window. During that window, pause agent-v2 creation and all
-   Hosted runtime-state writers/reconciliation, deploy Cloud #387, immediately
-   deploy Hosted #780, then force or reconcile affected prelaunch pods so they
-   receive the final bootstrap environment. Verify runtime-state writes,
-   hosted manifest fetch, and runtime services before resuming creation and
-   writers. Brief runtime unavailability is possible and expected: pre-#780
-   pods do not have `CLAWDI_RUNTIME_AUTH_ENV`, so pods that self-update to `.51`
-   after Cloud #387 starts serving `agent-v2` can fail closed. This is not a
-   rolling cross-service deployment. Cloud #387 removes or rejects admin
-   `clawdi_cli` while pre-#780 Hosted still sends it; do not add a temporary
-   accepted-but-ignored compatibility field.
+   Agent deployment v2 is not live. Keep creation and runtime-state
+   reconciliation disabled until the Hosted image contract, this CLI release,
+   and the Cloud manifest contract are all deployed. Validate one fresh
+   deployment end to end through `/v1/runtime/manifest` and SSE before enabling
+   v2. Do not add compatibility fields, aliases, or fallback package channels.
 
 4. For app/backend/web releases, run `Release Clawdi` manually with the
    deployed commit SHA, then verify the GitHub release exists and has

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -73,13 +73,10 @@ releases.
 6. If the PR touches the CLI package and should publish, bump
    `packages/cli/package.json` using semver. If no npm publish is intended,
    leave the version unchanged.
-   For the managed `agent-v2` channel, do not treat a successful npm upload as
-   approval. `publishConfig.tag` uploads to the non-production
-   `agent-v2-candidate` tag. Promote the exact tested version to `agent-v2` only
-   after the Hosted stable-envelope paired smoke passes. Until a workflow with
-   the required Hosted smoke and npm promotion credentials exists, automatic
-   promotion is a release blocker/follow-up; do not replace it with
-   cross-repository polling or long-lived token automation.
+   For the managed `agent-v2` channel, the release workflow must build and pack
+   one immutable artifact, pass it through the reusable Hosted paired smoke,
+   and publish that exact tarball once to `agent-v2` with npm trusted-publisher
+   OIDC. There is no candidate tag or dist-tag promotion step.
 7. Decide whether `CHANGELOG.md` needs a curated entry. Add one for notable
    user-facing releases, especially when GitHub generated notes would be too
    noisy or too terse.
@@ -103,18 +100,28 @@ releases.
    npm view clawdi dist-tags
    ```
 
-   Agent-v2 releases appear first under `agent-v2-candidate`. After the Hosted
-   stable-envelope paired smoke passes for that exact version, a maintainer
-   with npm package permission promotes it explicitly:
+   Done: `agent-v2` points directly to the paired-smoke-approved exact version
+   while `beta` and `latest` are unchanged. Before merge/release, the focused
+   smoke-only Hosted reusable-workflow PR must be on Hosted `main`, and the
+   private Hosted repository Actions access must be set to `organization`; its
+   current `none` setting prevents the reusable workflow call. Hosted #780 is
+   not this prerequisite because its runtime behavior must deploy after Cloud
+   #387 owns the hosted manifest channel. Do not work around this with
+   long-lived credentials or duplicated private smoke code.
 
-   ```bash
-   npm dist-tag add clawdi@<exact-version> agent-v2
-   npm view clawdi dist-tags
-   ```
-
-   Done: `agent-v2` points to the paired-smoke-approved exact version while
-   `beta` and `latest` are unchanged. Automated promotion remains blocked until
-   a reusable Hosted smoke and npm credential contract exists.
+   Safe rollout order: smoke-only Hosted workflow PR -> organization Actions
+   access -> merge this CLI PR and publish `.50` -> controlled short
+   maintenance window. During that window, pause agent-v2 creation and all
+   Hosted runtime-state writers/reconciliation, deploy Cloud #387, immediately
+   deploy Hosted #780, then force or reconcile affected prelaunch pods so they
+   receive the final bootstrap environment. Verify runtime-state writes,
+   hosted manifest fetch, and runtime services before resuming creation and
+   writers. Brief runtime unavailability is possible and expected: pre-#780
+   pods do not have `CLAWDI_RUNTIME_AUTH_ENV`, so pods that self-update to `.50`
+   after Cloud #387 starts serving `agent-v2` can fail closed. This is not a
+   rolling cross-service deployment. Cloud #387 removes or rejects admin
+   `clawdi_cli` while pre-#780 Hosted still sends it; do not add a temporary
+   accepted-but-ignored compatibility field.
 
 4. For app/backend/web releases, run `Release Clawdi` manually with the
    deployed commit SHA, then verify the GitHub release exists and has

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -77,7 +77,8 @@ releases.
    build, typecheck, run the full CLI suite, and pack one immutable tarball. It
    installs that tarball, records and verifies its SHA-256, transfers the same
    artifact to the protected npm job, verifies it again, and publishes it once
-   to `agent-v2-candidate` with npm trusted-publisher OIDC. The build job may use
+   to the package-selected npm tag with trusted-publisher OIDC. Current Agent v2
+   package metadata selects `agent-v2-candidate`. The build job may use
    the configured fast runner; the protected publish job must use GitHub-hosted
    `ubuntu-latest`, because npm trusted publishing does not support self-hosted
    or third-party GitHub Actions runners. The CLI workflow does not call

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -77,12 +77,13 @@ releases.
    build, typecheck, run the full CLI suite, and pack one immutable tarball. It
    installs that tarball, records and verifies its SHA-256, transfers the same
    artifact to the protected npm job, verifies it again, and publishes it once
-   to the package-selected npm tag with trusted-publisher OIDC. Current Agent v2
-   package metadata selects `agent-v2-candidate`. The build job may use
-   the configured fast runner; the protected publish job must use GitHub-hosted
-   `ubuntu-latest`, because npm trusted publishing does not support self-hosted
-   or third-party GitHub Actions runners. The CLI workflow does not call
-   workflows in the Hosted repository or depend on Hosted repository settings.
+   to `beta` for a prerelease or `latest` for a stable version with
+   trusted-publisher OIDC. Package-level tag overrides are rejected. The build
+   job may use the configured fast runner; the protected publish job must use
+   GitHub-hosted `ubuntu-latest`, because npm trusted publishing does not support
+   self-hosted or third-party GitHub Actions runners. The CLI workflow does not
+   call workflows in the Hosted repository or depend on Hosted repository
+   settings.
 7. Decide whether `CHANGELOG.md` needs a curated entry. Add one for notable
    user-facing releases, especially when GitHub generated notes would be too
    noisy or too terse.
@@ -107,15 +108,15 @@ releases.
    npm view clawdi dist-tags
    ```
 
-   Done: the exact version exists from the verified CLI artifact while `beta`
-   and `latest` are unchanged. The Hosted image repository has a separate
+   Done: the exact version exists from the verified CLI artifact and the
+   version-derived standard channel points to it: `beta` for a prerelease or
+   `latest` for a stable release. The Hosted image repository has a separate
    release boundary. An operator supplies the exact `clawdi@<semver>` package
    spec to the Hosted image workflow. That workflow fails when the exact spec is
    missing, verifies registry integrity, signatures, and provenance, and never
-   resolves `agent-v2-candidate` or any other npm dist-tag. It runs the image/CLI
-   pairing smoke before publishing the image and does not call back into this
-   workflow. The candidate tag is workflow-internal diagnostic metadata, not an
-   operator gate.
+   resolves an npm dist-tag. It runs the image/CLI pairing smoke before
+   publishing the image and does not call back into this workflow. The `beta`
+   tag is publication metadata, not an operator gate.
 
    Hosted rollout uses that same exact package spec in the Cloud manifest. The
    runtime never resolves an npm dist-tag.

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -76,7 +76,9 @@ releases.
    For the managed `agent-v2` channel, the release workflow must build and pack
    one immutable artifact, pass it through the reusable Hosted paired smoke,
    and publish that exact tarball once to `agent-v2` with npm trusted-publisher
-   OIDC. There is no candidate tag or dist-tag promotion step.
+   OIDC. For `0.12.10-beta.51`, there is no candidate tag or dist-tag promotion
+   step. Cross-repository rollout ownership and ordering live in the
+   [Hosted agent v2 release runbook](https://github.com/Clawdi-AI/clawdi-hosted/blob/main/docs/v2/ops/2026-07-12-agent-v2-cross-repo-release-runbook.md).
 7. Decide whether `CHANGELOG.md` needs a curated entry. Add one for notable
    user-facing releases, especially when GitHub generated notes would be too
    noisy or too terse.
@@ -108,10 +110,11 @@ releases.
    makes the release gate exercise the image that will actually launch.
 
    Agent deployment v2 is not live. Keep creation and runtime-state
-   reconciliation disabled until the Hosted image contract, this CLI release,
-   and the Cloud manifest contract are all deployed. Validate one fresh
-   deployment end to end through `/v1/runtime/manifest` and SSE before enabling
-   v2. Do not add compatibility fields, aliases, or fallback package channels.
+   reconciliation disabled until the Hosted image contract, CLI version
+   `0.12.10-beta.51`, and the Cloud manifest contract are all deployed. Validate
+   one fresh deployment end to end through `/v1/runtime/manifest` and SSE before
+   enabling v2. Do not add compatibility fields, aliases, or fallback package
+   channels.
 
 4. For app/backend/web releases, run `Release Clawdi` manually with the
    deployed commit SHA, then verify the GitHub release exists and has

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -110,14 +110,14 @@ releases.
    long-lived credentials or duplicated private smoke code.
 
    Safe rollout order: smoke-only Hosted workflow PR -> organization Actions
-   access -> merge this CLI PR and publish `.50` -> controlled short
+   access -> merge this CLI PR and publish `.51` -> controlled short
    maintenance window. During that window, pause agent-v2 creation and all
    Hosted runtime-state writers/reconciliation, deploy Cloud #387, immediately
    deploy Hosted #780, then force or reconcile affected prelaunch pods so they
    receive the final bootstrap environment. Verify runtime-state writes,
    hosted manifest fetch, and runtime services before resuming creation and
    writers. Brief runtime unavailability is possible and expected: pre-#780
-   pods do not have `CLAWDI_RUNTIME_AUTH_ENV`, so pods that self-update to `.50`
+   pods do not have `CLAWDI_RUNTIME_AUTH_ENV`, so pods that self-update to `.51`
    after Cloud #387 starts serving `agent-v2` can fail closed. This is not a
    rolling cross-service deployment. Cloud #387 removes or rejects admin
    `clawdi_cli` while pre-#780 Hosted still sends it; do not add a temporary

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -107,13 +107,15 @@ releases.
 
    Done: `agent-v2-candidate` points to the exact version published from the
    verified CLI artifact while `beta` and `latest` are unchanged.
-   The Hosted image repository has a separate release boundary: its own release
-   resolves that candidate to an exact npm semver and runs the image/CLI pairing
-   smoke before publishing the image. It does not call back into this workflow.
+   The Hosted image repository has a separate release boundary. An operator
+   verifies the candidate tag and exact package publication, then explicitly
+   supplies the exact `clawdi@<semver>` package spec to the Hosted image workflow.
+   That workflow fails when the exact spec is missing and never resolves
+   `agent-v2-candidate` or any other npm dist-tag. It runs the image/CLI pairing
+   smoke before publishing the image and does not call back into this workflow.
 
-   Hosted rollout uses the Cloud manifest's exact `clawdi@<semver>` package
-   selection. The runtime does not resolve a production npm dist-tag. Verify the
-   exact package version directly before rollout.
+   Hosted rollout uses that same exact package spec in the Cloud manifest. The
+   runtime never resolves an npm dist-tag.
 
    Agent deployment v2 is not live. Keep creation and runtime-state
    reconciliation disabled until the Hosted image contract, CLI version

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -73,13 +73,15 @@ releases.
 6. If the PR touches the CLI package and should publish, bump
    `packages/cli/package.json` using semver. If no npm publish is intended,
    leave the version unchanged.
-   For the managed `agent-v2` channel, this repository's release workflow must
+   For the managed agent-v2 release line, this repository's release workflow must
    build, typecheck, run the full CLI suite, and pack one immutable tarball. It
    installs that tarball, records and verifies its SHA-256, transfers the same
    artifact to the protected npm job, verifies it again, and publishes it once
-   to `agent-v2` with npm trusted-publisher OIDC. There is no candidate tag or
-   dist-tag promotion step. The CLI workflow does not call workflows in the
-   Hosted repository or depend on Hosted repository settings.
+   to `agent-v2-candidate` with npm trusted-publisher OIDC. The build job may use
+   the configured fast runner; the protected publish job must use GitHub-hosted
+   `ubuntu-latest`, because npm trusted publishing does not support self-hosted
+   or third-party GitHub Actions runners. The CLI workflow does not call
+   workflows in the Hosted repository or depend on Hosted repository settings.
 7. Decide whether `CHANGELOG.md` needs a curated entry. Add one for notable
    user-facing releases, especially when GitHub generated notes would be too
    noisy or too terse.
@@ -103,12 +105,15 @@ releases.
    npm view clawdi dist-tags
    ```
 
-   Done: `agent-v2` points directly to the exact version published from the
-   verified CLI artifact while `beta` and `latest` are unchanged. The Hosted
-   image repository has a separate release boundary: its own release resolves
-   the published CLI to an exact npm semver and runs the image/CLI pairing smoke
-   before publishing that image. Hosted image validation does not gate or call
-   back into the CLI publish workflow.
+   Done: `agent-v2-candidate` points to the exact version published from the
+   verified CLI artifact while `beta` and `latest` are unchanged.
+   The Hosted image repository has a separate release boundary: its own release
+   resolves that candidate to an exact npm semver and runs the image/CLI pairing
+   smoke before publishing the image. It does not call back into this workflow.
+
+   Hosted rollout uses the Cloud manifest's exact `clawdi@<semver>` package
+   selection. The runtime does not resolve a production npm dist-tag. Verify the
+   exact package version directly before rollout.
 
    Agent deployment v2 is not live. Keep creation and runtime-state
    reconciliation disabled until the Hosted image contract, CLI version

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,8 +19,7 @@
 		"node": ">=22.5"
 	},
 	"publishConfig": {
-		"access": "public",
-		"tag": "agent-v2-candidate"
+		"access": "public"
 	},
 	"scripts": {
 		"dev": "bun run src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,7 +19,8 @@
 		"node": ">=22.5"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"tag": "agent-v2-candidate"
 	},
 	"scripts": {
 		"dev": "bun run src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,7 +57,7 @@
 	],
 	"devDependencies": {
 		"@clack/prompts": "^1.7.0",
-		"@clawdi/shared": "0.1.0",
+		"@clawdi/shared": "workspace:*",
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"@types/bun": "^1.3.12",
 		"@types/node": "^22.20.0",
@@ -65,8 +65,8 @@
 		"commander": "^15.0.0",
 		"openapi-fetch": "^0.17.0",
 		"tar": "^7.5.19",
-		"typescript": "^7.0.2",
+		"typescript": "catalog:",
 		"yaml": "^2.9.0",
-		"zod": "^4.4.3"
+		"zod": "catalog:"
 	}
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.49",
+	"version": "0.12.10-beta.50",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",
@@ -19,8 +19,7 @@
 		"node": ">=22.5"
 	},
 	"publishConfig": {
-		"access": "public",
-		"tag": "agent-v2-candidate"
+		"access": "public"
 	},
 	"scripts": {
 		"dev": "bun run src/index.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,7 @@
 		"test": "bun test --isolate --max-concurrency=1",
 		"test:e2e": "bun test --isolate --max-concurrency=1 tests/e2e",
 		"test:watch": "bun test --watch",
-		"prepublishOnly": "bun run build"
+		"prepublishOnly": "bun run check:publish-manifest && bun run build"
 	},
 	"repository": {
 		"type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.50",
+	"version": "0.12.10-beta.51",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",
@@ -57,7 +57,7 @@
 	],
 	"devDependencies": {
 		"@clack/prompts": "^1.7.0",
-		"@clawdi/shared": "workspace:*",
+		"@clawdi/shared": "0.1.0",
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"@types/bun": "^1.3.12",
 		"@types/node": "^22.20.0",
@@ -65,8 +65,8 @@
 		"commander": "^15.0.0",
 		"openapi-fetch": "^0.17.0",
 		"tar": "^7.5.19",
-		"typescript": "catalog:",
+		"typescript": "^7.0.2",
 		"yaml": "^2.9.0",
-		"zod": "catalog:"
+		"zod": "^4.4.3"
 	}
 }

--- a/packages/cli/scripts/check-publish-manifest.mjs
+++ b/packages/cli/scripts/check-publish-manifest.mjs
@@ -5,14 +5,8 @@ const forbiddenProtocols = /^(catalog|workspace):/;
 const dependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"];
 
 const problems = [];
-const publishTag = packageJson.publishConfig?.tag;
-if (
-	typeof packageJson.version === "string" &&
-	!packageJson.version.includes("-") &&
-	typeof publishTag === "string" &&
-	publishTag.length > 0
-) {
-	problems.push("stable package versions must not declare publishConfig.tag");
+if (Object.hasOwn(packageJson.publishConfig ?? {}, "tag")) {
+	problems.push("published CLI package must not declare publishConfig.tag");
 }
 if (packageJson.dependencies && Object.keys(packageJson.dependencies).length > 0) {
 	problems.push("published bundled CLI package must not declare runtime dependencies");

--- a/packages/cli/scripts/check-publish-manifest.mjs
+++ b/packages/cli/scripts/check-publish-manifest.mjs
@@ -5,6 +5,15 @@ const forbiddenProtocols = /^(catalog|workspace):/;
 const dependencyFields = ["dependencies", "optionalDependencies", "peerDependencies"];
 
 const problems = [];
+const publishTag = packageJson.publishConfig?.tag;
+if (
+	typeof packageJson.version === "string" &&
+	!packageJson.version.includes("-") &&
+	typeof publishTag === "string" &&
+	publishTag.length > 0
+) {
+	problems.push("stable package versions must not declare publishConfig.tag");
+}
 if (packageJson.dependencies && Object.keys(packageJson.dependencies).length > 0) {
 	problems.push("published bundled CLI package must not declare runtime dependencies");
 }

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -21,7 +21,11 @@ import { getConfig } from "../lib/config";
 import { PRIVATE_DIR_MODE, writePrivateFileAtomic } from "../lib/private-file";
 import { isSemverLessThan } from "../lib/semver";
 import { getCliVersion } from "../lib/version";
-import { ensureRuntimeAuthTokenFile, runtimeAuthTokenFileLabel } from "../runtime/auth-token";
+import {
+	ensureRuntimeAuthTokenFile,
+	readRuntimeAuthToken,
+	runtimeAuthTokenFileLabel,
+} from "../runtime/auth-token";
 import { RUNTIME_BRIDGE_SURFACES_ENV, startRuntimeBridge } from "../runtime/bridge";
 import { applyRuntimeChannelsToManifestLoad } from "../runtime/channels";
 import {
@@ -70,6 +74,7 @@ import {
 	type TransparentEgressEnvConfig,
 } from "../runtime/transparent-egress";
 import { WHATSAPP_UPSTREAM_READY } from "../runtime/whatsapp-gate";
+import { consumeSse } from "../serve/sse-client";
 
 type ChannelAccount = components["schemas"]["ChannelAccountResponse"];
 type ChannelAccountCreate = components["schemas"]["ChannelAccountCreate"];
@@ -1170,6 +1175,9 @@ interface RuntimeWatchOptions {
 	selfHealMs?: number | string;
 	once?: boolean;
 	json?: boolean;
+	abort?: AbortSignal;
+	notifications?: boolean;
+	notificationConsumer?: typeof consumeSse;
 }
 
 interface RuntimeVerifyOptions {
@@ -1305,8 +1313,125 @@ function parsePositiveMs(
 	return parsed;
 }
 
-function sleep(ms: number): Promise<void> {
-	return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+interface RuntimeWatchWakeSignal {
+	signal: () => void;
+	wait: (ms: number, abort?: AbortSignal) => Promise<"notification" | "poll" | "aborted">;
+}
+
+function createRuntimeWatchWakeSignal(): RuntimeWatchWakeSignal {
+	let queued = false;
+	let wake: (() => void) | null = null;
+	return {
+		signal: () => {
+			queued = true;
+			wake?.();
+		},
+		wait: async (ms, abort) => {
+			if (abort?.aborted) return "aborted";
+			if (queued) {
+				queued = false;
+				return "notification";
+			}
+			return new Promise((resolveWait) => {
+				let settled = false;
+				const finish = (reason: "notification" | "poll" | "aborted") => {
+					if (settled) return;
+					settled = true;
+					clearTimeout(timer);
+					abort?.removeEventListener("abort", onAbort);
+					wake = null;
+					if (reason === "notification") queued = false;
+					resolveWait(reason);
+				};
+				const timer = setTimeout(() => finish("poll"), ms);
+				const onAbort = () => finish("aborted");
+				wake = () => finish("notification");
+				abort?.addEventListener("abort", onAbort, { once: true });
+			});
+		},
+	};
+}
+
+interface RuntimeWatchNotificationConfig {
+	apiUrl: string;
+	apiKey: string;
+	environmentId: string;
+}
+
+interface RuntimeWatchNotificationSubscription {
+	config: RuntimeWatchNotificationConfig;
+	abort: AbortController;
+	task: Promise<void>;
+}
+
+function sameRuntimeWatchNotificationConfig(
+	left: RuntimeWatchNotificationConfig,
+	right: RuntimeWatchNotificationConfig,
+): boolean {
+	return (
+		left.apiUrl === right.apiUrl &&
+		left.apiKey === right.apiKey &&
+		left.environmentId === right.environmentId
+	);
+}
+
+function readRuntimeWatchNotificationConfig(
+	paths: ReturnType<typeof getRuntimePaths>,
+): RuntimeWatchNotificationConfig | null {
+	const apiKey = readRuntimeAuthToken(paths);
+	if (!apiKey || !existsSync(paths.manifestLastGood)) return null;
+	try {
+		const parsed = runtimeDesiredStateSchema.safeParse(
+			JSON.parse(readFileSync(paths.manifestLastGood, "utf-8")),
+		);
+		if (!parsed.success) return null;
+		return {
+			apiUrl: parsed.data.controlPlane.apiUrl,
+			apiKey,
+			environmentId: parsed.data.environmentId,
+		};
+	} catch {
+		return null;
+	}
+}
+
+function ensureRuntimeWatchNotificationSubscription(
+	current: RuntimeWatchNotificationSubscription | null,
+	paths: ReturnType<typeof getRuntimePaths>,
+	wakeSignal: RuntimeWatchWakeSignal,
+	opts: RuntimeWatchOptions,
+): RuntimeWatchNotificationSubscription | null {
+	if (opts.once || opts.notifications === false) return current;
+	const config = readRuntimeWatchNotificationConfig(paths);
+	if (!config) {
+		current?.abort.abort();
+		return null;
+	}
+	if (current && sameRuntimeWatchNotificationConfig(current.config, config)) return current;
+	current?.abort.abort();
+	const abort = new AbortController();
+	const consumer = opts.notificationConsumer ?? consumeSse;
+	const task = consumer({
+		apiUrl: config.apiUrl,
+		apiKey: config.apiKey,
+		abort: abort.signal,
+		onEvent: (event) => {
+			if (
+				event.type === "runtime_manifest_changed" &&
+				event.environment_id === config.environmentId
+			) {
+				wakeSignal.signal();
+			}
+		},
+		// Runtime-watch keeps ETag polling alive after auth failure. A new
+		// manifest/token identity is the only condition that creates a new stream.
+		onAuthFailure: () => {},
+	});
+	void task.catch(() => {
+		// The shared SSE consumer already handles transient reconnects. An
+		// unexpected terminal failure must not take down the polling fallback.
+	});
+	return { config, abort, task };
 }
 
 function readFileIfExists(path: string): string | null {
@@ -2272,6 +2397,8 @@ export async function runtimeWatch(opts: RuntimeWatchOptions = {}) {
 	let cliInstallRetryPending = false;
 	let cliInstallBackoffMs = 0;
 	let nextCliInstallRetryAt = 0;
+	const wakeSignal = createRuntimeWatchWakeSignal();
+	let notificationSubscription: RuntimeWatchNotificationSubscription | null = null;
 
 	if (mode !== "hosted") {
 		const event = {
@@ -2304,45 +2431,64 @@ export async function runtimeWatch(opts: RuntimeWatchOptions = {}) {
 		return;
 	}
 
-	for (;;) {
-		const now = Date.now();
-		const cliInstallRetryDue = cliInstallRetryPending && now >= nextCliInstallRetryAt;
-		const deferCliInstall = cliInstallRetryPending && !cliInstallRetryDue;
-		// Full refreshes also re-resolve floating CLI channels when manifest ETags are unchanged.
-		const forceRefresh = now - lastFullFetchAt >= selfHealMs || cliInstallRetryDue;
-		const event = await runtimeWatchTick(paths, {
-			forceRefresh,
-			deferCliInstall,
-			deferCliInstallReason: deferCliInstall
-				? `CLI install retry is in backoff until ${new Date(nextCliInstallRetryAt).toISOString()}`
-				: undefined,
-		});
-		const cliUpdateStatus = runtimeWatchCliUpdateStatus(event);
-		if (cliUpdateStatus === "error") {
-			cliInstallRetryPending = true;
-			cliInstallBackoffMs = nextCliInstallBackoffMs(cliInstallBackoffMs);
-			nextCliInstallRetryAt = Date.now() + cliInstallBackoffMs;
-		} else if (
-			cliUpdateStatus === "installed" ||
-			cliUpdateStatus === "current" ||
-			cliUpdateStatus === "not_requested"
-		) {
-			cliInstallRetryPending = false;
-			cliInstallBackoffMs = 0;
-			nextCliInstallRetryAt = 0;
+	try {
+		notificationSubscription = ensureRuntimeWatchNotificationSubscription(
+			notificationSubscription,
+			paths,
+			wakeSignal,
+			opts,
+		);
+		for (;;) {
+			if (opts.abort?.aborted) return;
+			const now = Date.now();
+			const cliInstallRetryDue = cliInstallRetryPending && now >= nextCliInstallRetryAt;
+			const deferCliInstall = cliInstallRetryPending && !cliInstallRetryDue;
+			// Full refreshes also re-resolve floating CLI channels when manifest ETags are unchanged.
+			const forceRefresh = now - lastFullFetchAt >= selfHealMs || cliInstallRetryDue;
+			const event = await runtimeWatchTick(paths, {
+				forceRefresh,
+				deferCliInstall,
+				deferCliInstallReason: deferCliInstall
+					? `CLI install retry is in backoff until ${new Date(nextCliInstallRetryAt).toISOString()}`
+					: undefined,
+			});
+			const cliUpdateStatus = runtimeWatchCliUpdateStatus(event);
+			if (cliUpdateStatus === "error") {
+				cliInstallRetryPending = true;
+				cliInstallBackoffMs = nextCliInstallBackoffMs(cliInstallBackoffMs);
+				nextCliInstallRetryAt = Date.now() + cliInstallBackoffMs;
+			} else if (
+				cliUpdateStatus === "installed" ||
+				cliUpdateStatus === "current" ||
+				cliUpdateStatus === "not_requested"
+			) {
+				cliInstallRetryPending = false;
+				cliInstallBackoffMs = 0;
+				nextCliInstallRetryAt = 0;
+			}
+			if (event.status === "applied" || forceRefresh) lastFullFetchAt = Date.now();
+			writeRuntimeWatchStatus(event, paths);
+			emitRuntimeWatchEvent(event, opts.json);
+			notificationSubscription = ensureRuntimeWatchNotificationSubscription(
+				notificationSubscription,
+				paths,
+				wakeSignal,
+				opts,
+			);
+			if (opts.once) {
+				if (event.status === "error") process.exitCode = 1;
+				else process.exitCode = 0;
+				return;
+			}
+			if (event.selfReexec === true || opts.abort?.aborted) {
+				return;
+			}
+			const wakeReason = await wakeSignal.wait(intervalMs, opts.abort);
+			if (wakeReason === "aborted") return;
 		}
-		if (event.status === "applied" || forceRefresh) lastFullFetchAt = Date.now();
-		writeRuntimeWatchStatus(event, paths);
-		emitRuntimeWatchEvent(event, opts.json);
-		if (opts.once) {
-			if (event.status === "error") process.exitCode = 1;
-			else process.exitCode = 0;
-			return;
-		}
-		if (event.selfReexec === true) {
-			return;
-		}
-		await sleep(intervalMs);
+	} finally {
+		notificationSubscription?.abort.abort();
+		await notificationSubscription?.task.catch(() => {});
 	}
 }
 

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1362,6 +1362,7 @@ interface RuntimeWatchNotificationSubscription {
 	config: RuntimeWatchNotificationConfig;
 	abort: AbortController;
 	task: Promise<void>;
+	settled: boolean;
 }
 
 function sameRuntimeWatchNotificationConfig(
@@ -1407,11 +1408,19 @@ function ensureRuntimeWatchNotificationSubscription(
 		current?.abort.abort();
 		return null;
 	}
-	if (current && sameRuntimeWatchNotificationConfig(current.config, config)) return current;
+	if (current && !current.settled && sameRuntimeWatchNotificationConfig(current.config, config)) {
+		return current;
+	}
 	current?.abort.abort();
 	const abort = new AbortController();
 	const consumer = opts.notificationConsumer ?? consumeSse;
-	const task = consumer({
+	const subscription: RuntimeWatchNotificationSubscription = {
+		config,
+		abort,
+		task: Promise.resolve(),
+		settled: false,
+	};
+	subscription.task = consumer({
 		apiUrl: config.apiUrl,
 		apiKey: config.apiKey,
 		abort: abort.signal,
@@ -1423,15 +1432,17 @@ function ensureRuntimeWatchNotificationSubscription(
 				wakeSignal.signal();
 			}
 		},
-		// Runtime-watch keeps ETag polling alive after auth failure. A new
-		// manifest/token identity is the only condition that creates a new stream.
+		// Runtime-watch keeps ETag polling alive after auth failure. The settled
+		// subscription becomes eligible for replacement on the next watch pass.
 		onAuthFailure: () => {},
+	}).finally(() => {
+		subscription.settled = true;
 	});
-	void task.catch(() => {
+	void subscription.task.catch(() => {
 		// The shared SSE consumer already handles transient reconnects. An
 		// unexpected terminal failure must not take down the polling fallback.
 	});
-	return { config, abort, task };
+	return subscription;
 }
 
 function readFileIfExists(path: string): string | null {

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -2308,6 +2308,7 @@ export async function runtimeWatch(opts: RuntimeWatchOptions = {}) {
 		const now = Date.now();
 		const cliInstallRetryDue = cliInstallRetryPending && now >= nextCliInstallRetryAt;
 		const deferCliInstall = cliInstallRetryPending && !cliInstallRetryDue;
+		// Full refreshes also re-resolve floating CLI channels when manifest ETags are unchanged.
 		const forceRefresh = now - lastFullFetchAt >= selfHealMs || cliInstallRetryDue;
 		const event = await runtimeWatchTick(paths, {
 			forceRefresh,

--- a/packages/cli/src/lib/hermes-config-merge.ts
+++ b/packages/cli/src/lib/hermes-config-merge.ts
@@ -85,6 +85,15 @@ export function mergeHermesChannelConfig(
 	});
 }
 
+export function mergeHermesRuntimeLocale(configPath: string, timezone: string): void {
+	const document = readHermesConfig(configPath);
+	document.set("timezone", timezone);
+	writePrivateFileAtomic(configPath, String(document), {
+		mode: PRIVATE_FILE_MODE,
+		dirMode: PRIVATE_DIR_MODE,
+	});
+}
+
 export function removeHermesMcpServer(configPath: string, name: string): void {
 	if (!existsSync(configPath)) return;
 	const document = readHermesConfig(configPath);

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -446,6 +446,12 @@ function installCliPackage(
 		throw new Error(`npm install completed but clawdi bin is missing: ${activeTarget}`);
 	}
 	const version = smokeCliVersion(activeTarget);
+	const exactVersion = exactNpmPackageVersion(packageSpec);
+	if (exactVersion && version !== exactVersion) {
+		throw new Error(
+			`npm install ${installPlan.installPackageSpec} reported version ${version}, expected ${exactVersion}`,
+		);
+	}
 	verifyCliRuntime(activeTarget);
 	return { npmPrefix, activeTarget, version };
 }

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -14,7 +14,11 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { chmodBestEffort, writePrivateFileAtomic } from "../lib/private-file";
-import type { RuntimeManifest } from "./manifest-contract";
+import {
+	hostedCliPackageSpecSchema,
+	hostedFixtureCliPackageSpecSchema,
+	type RuntimeManifest,
+} from "./manifest-contract";
 import type { RuntimePaths } from "./paths";
 
 export interface RuntimeCliUpdateResult {
@@ -219,19 +223,7 @@ function cliRegistry(manifest: RuntimeManifest): string | null {
 }
 
 function validatePackageSpec(packageSpec: string): void {
-	if (
-		/^clawdi@[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$/.test(
-			packageSpec,
-		)
-	) {
-		return;
-	}
-	if (
-		/^\/usr\/local\/share\/clawdi\/bootstrap\/[^/]+\.tgz$/.test(packageSpec) &&
-		!packageSpec.includes("..")
-	) {
-		return;
-	}
+	if (hostedFixtureCliPackageSpecSchema.safeParse(packageSpec).success) return;
 	throw new Error(
 		`clawdi CLI packageSpec must be clawdi@<exact-semver> or a managed bootstrap tarball: ${packageSpec}`,
 	);
@@ -292,16 +284,8 @@ function recoverCurrentCliInstallFromActiveLink(
 }
 
 function exactNpmPackageVersion(packageSpec: string): string | null {
-	const match = /^clawdi@(.+)$/.exec(packageSpec);
-	if (!match) return null;
-	const specifier = match[1] ?? "";
-	return isExactNpmPackageVersion(specifier) ? specifier : null;
-}
-
-function isExactNpmPackageVersion(value: string): boolean {
-	return /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$/.test(
-		value,
-	);
+	if (!hostedCliPackageSpecSchema.safeParse(packageSpec).success) return null;
+	return packageSpec.slice("clawdi@".length);
 }
 
 function installCliPackage(

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -123,7 +123,7 @@ export function applyRuntimeCliDesiredState(
 			version: current.version ?? null,
 		});
 	}
-	const recovered = recoverCurrentCliInstallFromActiveLink(paths, packageSpec, registry);
+	const recovered = recoverCurrentCliInstallFromActiveLink(paths, packageSpec);
 	if (recovered) {
 		writeCliBootstrapStatus(paths, {
 			packageSpec,
@@ -260,19 +260,12 @@ function isCurrentCliInstall(
 function recoverCurrentCliInstallFromActiveLink(
 	paths: RuntimePaths,
 	packageSpec: string,
-	registry: string | null,
 ): { npmPrefix: string; activeTarget: string; version: string } | null {
 	const desiredVersion = exactNpmPackageVersion(packageSpec);
 	if (!desiredVersion) return null;
 	const npmPrefix = cliPackagePrefix(paths, desiredVersion);
-	const legacyNpmPrefix = cliPackagePrefixForLegacyHash(paths, packageSpec, registry);
 	const activeTarget = activeLinkTarget(paths.cliManagedBin);
-	if (
-		activeTarget !== join(npmPrefix, "bin", "clawdi") &&
-		activeTarget !== join(legacyNpmPrefix, "bin", "clawdi")
-	) {
-		return null;
-	}
+	if (activeTarget !== join(npmPrefix, "bin", "clawdi")) return null;
 	if (!isExecutable(activeTarget) || !isExecutable(paths.cliManagedBin)) return null;
 	const version = smokeCliVersion(activeTarget);
 	if (version !== desiredVersion) return null;
@@ -392,18 +385,6 @@ function cliPackagePrefix(paths: RuntimePaths, version: string): string {
 		throw new Error(`resolved clawdi CLI version contains unsafe path characters: ${version}`);
 	}
 	return join(paths.cliNpmPrefix, "packages", version);
-}
-
-function cliPackagePrefixForLegacyHash(
-	paths: RuntimePaths,
-	packageSpec: string,
-	registry: string | null,
-): string {
-	const hash = createHash("sha256")
-		.update(JSON.stringify({ packageSpec, registry }))
-		.digest("hex")
-		.slice(0, 16);
-	return join(paths.cliNpmPrefix, "packages", hash);
 }
 
 function prefixForActiveTarget(activeTarget: string): string {

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -80,7 +80,6 @@ export interface RuntimeCliRollbackResult {
 }
 
 const NPM_INSTALL_TIMEOUT_MS = 180_000;
-const NPM_VIEW_TIMEOUT_MS = 30_000;
 const VERSION_SMOKE_TIMEOUT_MS = 20_000;
 const RUNTIME_VERIFY_TIMEOUT_MS = 20_000;
 
@@ -220,17 +219,11 @@ function cliRegistry(manifest: RuntimeManifest): string | null {
 }
 
 function validatePackageSpec(packageSpec: string): void {
-	if (packageSpec === "clawdi") {
-		return;
-	}
 	if (
 		/^clawdi@[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$/.test(
 			packageSpec,
 		)
 	) {
-		return;
-	}
-	if (/^clawdi@[A-Za-z0-9._-]+$/.test(packageSpec)) {
 		return;
 	}
 	if (
@@ -240,7 +233,7 @@ function validatePackageSpec(packageSpec: string): void {
 		return;
 	}
 	throw new Error(
-		`clawdi CLI packageSpec must be clawdi, clawdi@<version-or-tag>, or a managed bootstrap tarball: ${packageSpec}`,
+		`clawdi CLI packageSpec must be clawdi@<exact-semver> or a managed bootstrap tarball: ${packageSpec}`,
 	);
 }
 
@@ -267,7 +260,8 @@ function isCurrentCliInstall(
 	if ((status.registry ?? null) !== registry) return false;
 	if (status.activePath !== paths.cliManagedBin) return false;
 	if (!status.activeTarget || !isExecutable(status.activeTarget)) return false;
-	if (!installedFloatingSpecVersionIsCurrent(paths, status, packageSpec, registry)) return false;
+	const exactVersion = exactNpmPackageVersion(packageSpec);
+	if (exactVersion && status.version !== exactVersion) return false;
 	return isExecutable(paths.cliManagedBin);
 }
 
@@ -276,7 +270,7 @@ function recoverCurrentCliInstallFromActiveLink(
 	packageSpec: string,
 	registry: string | null,
 ): { npmPrefix: string; activeTarget: string; version: string } | null {
-	const desiredVersion = desiredNpmPackageVersion(paths, packageSpec, registry);
+	const desiredVersion = exactNpmPackageVersion(packageSpec);
 	if (!desiredVersion) return null;
 	const npmPrefix = cliPackagePrefix(paths, desiredVersion);
 	const legacyNpmPrefix = cliPackagePrefixForLegacyHash(paths, packageSpec, registry);
@@ -289,46 +283,12 @@ function recoverCurrentCliInstallFromActiveLink(
 	}
 	if (!isExecutable(activeTarget) || !isExecutable(paths.cliManagedBin)) return null;
 	const version = smokeCliVersion(activeTarget);
-	if (!installedFloatingSpecVersionIsCurrent(paths, { version }, packageSpec, registry))
-		return null;
+	if (version !== desiredVersion) return null;
 	return {
 		npmPrefix: prefixForActiveTarget(activeTarget),
 		activeTarget,
 		version,
 	};
-}
-
-function installedFloatingSpecVersionIsCurrent(
-	paths: RuntimePaths,
-	status: Pick<RuntimeCliBootstrapStatus, "version">,
-	packageSpec: string,
-	registry: string | null,
-): boolean {
-	const exact = exactNpmPackageVersion(packageSpec);
-	if (exact) return status.version === exact;
-	if (!isFloatingNpmPackageSpec(packageSpec)) return true;
-	if (!status.version) return false;
-	const desiredVersion = desiredNpmPackageVersion(paths, packageSpec, registry);
-	return desiredVersion === null || status.version === desiredVersion;
-}
-
-function isFloatingNpmPackageSpec(packageSpec: string): boolean {
-	const match = /^clawdi@(.+)$/.exec(packageSpec);
-	if (!match) return false;
-	const specifier = match[1] ?? "";
-	if (!/^(agent-v2|alpha|beta|canary|next|rc)$/.test(specifier)) return false;
-	return !isExactNpmPackageVersion(specifier);
-}
-
-function desiredNpmPackageVersion(
-	paths: RuntimePaths,
-	packageSpec: string,
-	registry: string | null,
-): string | null {
-	const exact = exactNpmPackageVersion(packageSpec);
-	if (exact) return exact;
-	if (!isFloatingNpmPackageSpec(packageSpec)) return null;
-	return resolveNpmPackageVersion(paths, packageSpec, registry);
 }
 
 function exactNpmPackageVersion(packageSpec: string): string | null {
@@ -342,43 +302,6 @@ function isExactNpmPackageVersion(value: string): boolean {
 	return /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$/.test(
 		value,
 	);
-}
-
-function resolveNpmPackageVersion(
-	paths: RuntimePaths,
-	packageSpec: string,
-	registry: string | null,
-): string | null {
-	const result = spawnSync(
-		"npm",
-		[
-			"view",
-			packageSpec,
-			"version",
-			"--json",
-			"--cache",
-			paths.cliNpmCache,
-			...(registry ? ["--registry", registry] : []),
-		],
-		{
-			encoding: "utf8",
-			timeout: NPM_VIEW_TIMEOUT_MS,
-			env: {
-				...process.env,
-				NO_UPDATE_NOTIFIER: "1",
-				NPM_CONFIG_UPDATE_NOTIFIER: "false",
-			},
-		},
-	);
-	if (result.status !== 0) return null;
-	const output = result.stdout.trim();
-	if (!output) return null;
-	try {
-		const parsed = JSON.parse(output) as unknown;
-		return typeof parsed === "string" && parsed.trim() ? parsed.trim() : null;
-	} catch {
-		return output;
-	}
 }
 
 function installCliPackage(
@@ -461,7 +384,7 @@ function cliInstallPlan(
 	packageSpec: string,
 	registry: string | null,
 ): { installPackageSpec: string; npmPrefix: string; version: string } {
-	const version = desiredNpmPackageVersion(paths, packageSpec, registry);
+	const version = exactNpmPackageVersion(packageSpec);
 	if (version) {
 		return {
 			installPackageSpec: `clawdi@${version}`,

--- a/packages/cli/src/runtime/cli-update.ts
+++ b/packages/cli/src/runtime/cli-update.ts
@@ -305,7 +305,7 @@ function installedFloatingSpecVersionIsCurrent(
 	registry: string | null,
 ): boolean {
 	const exact = exactNpmPackageVersion(packageSpec);
-	if (exact) return !status.version || status.version === exact;
+	if (exact) return status.version === exact;
 	if (!isFloatingNpmPackageSpec(packageSpec)) return true;
 	if (!status.version) return false;
 	const desiredVersion = desiredNpmPackageVersion(paths, packageSpec, registry);

--- a/packages/cli/src/runtime/hosted-egress-profiles.ts
+++ b/packages/cli/src/runtime/hosted-egress-profiles.ts
@@ -4,10 +4,6 @@ type HostedEgressProfile = EgressProfileInputBundle["profiles"][number];
 
 interface HostedRuntimeManifestProjection {
 	egressProfiles?: unknown;
-	controlPlane?: {
-		cloudApiUrl?: string | null;
-		manifestUrl?: string | null;
-	} | null;
 	providers?: unknown;
 }
 

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -417,7 +417,7 @@ export const hostedRuntimeManifestSchema = z
 		egressEngine: egressEngineSchema.strict().optional(),
 		runtimes: z.record(runtimeNameSchema, hostedRuntimeEntrySchema),
 		bridge: hostedRuntimeBridgeSchema.optional(),
-		providers: z.record(z.string().min(1), hostedProviderSchema).optional(),
+		providers: z.record(z.string().min(1), hostedProviderSchema),
 		liveSync: hostedLiveSyncSchema,
 		egressProfiles: egressProfileInputBundleSchema.strict().optional(),
 		mcp: z.unknown().optional(),
@@ -453,6 +453,28 @@ export const hostedRuntimeManifestSchema = z
 				message: "selected runtime must be enabled",
 				path: ["runtimes", manifest.runtime, "enabled"],
 			});
+		}
+		const selectedRuntime = manifest.runtimes[manifest.runtime];
+		if (selectedRuntime) {
+			const providerIds = new Set(selectedRuntime.provider_ids);
+			for (const providerId of providerIds) {
+				if (!Object.hasOwn(manifest.providers, providerId)) {
+					ctx.addIssue({
+						code: "custom",
+						message: "runtime provider must have a matching provider projection",
+						path: ["providers", providerId],
+					});
+				}
+			}
+			for (const providerId of Object.keys(manifest.providers)) {
+				if (!providerIds.has(providerId)) {
+					ctx.addIssue({
+						code: "custom",
+						message: "provider projection must be selected by the runtime",
+						path: ["providers", providerId],
+					});
+				}
+			}
 		}
 		const surfaces = manifest.bridge?.surfaces ?? [];
 		if (manifest.runtime === "openclaw" && surfaces.length > 0) {

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -374,10 +374,10 @@ export const hostedRuntimeManifestSchema = z
 		locale: runtimeLocaleSchema,
 		system: z
 			.object({
-				user: z.string().min(1).optional(),
+				user: z.string().min(1),
 				home: z.string().min(1),
 				workspace: z.string().min(1),
-				persistentPaths: z.array(z.string().min(1)).optional(),
+				persistentPaths: z.array(z.string().min(1)),
 				openclawControlUiAllowedOrigins: z.array(urlOriginSchema).optional(),
 			})
 			.strict(),

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -81,11 +81,29 @@ const cliPayloadPolicySchema = z.object({
 	registry: z.string().min(1).optional(),
 });
 
+const HOSTED_BOOTSTRAP_PACKAGE_ROOT = "/usr/local/share/clawdi/bootstrap/";
+
+function isHostedCliPackageSpec(value: string): boolean {
+	if (value === "clawdi@agent-v2") return true;
+	const npmVersion = /^clawdi@(.+)$/.exec(value)?.[1];
+	if (npmVersion && isValidSemver(npmVersion)) return true;
+	if (!value.startsWith(HOSTED_BOOTSTRAP_PACKAGE_ROOT)) return false;
+	const basename = value.slice(HOSTED_BOOTSTRAP_PACKAGE_ROOT.length);
+	return !basename.includes("..") && /^[A-Za-z0-9][A-Za-z0-9._-]*\.tgz$/.test(basename);
+}
+
+const hostedCliPackageSpecSchema = z
+	.string()
+	.refine(
+		isHostedCliPackageSpec,
+		"must be clawdi@agent-v2, clawdi@<exact-semver>, or a managed bootstrap tarball",
+	);
+
 const hostedCliPayloadPolicySchema = z
 	.object({
 		// The image env seeds pre-manifest bootstrap only; Cloud owns every hosted update after that.
 		source: z.literal("npm:clawdi"),
-		packageSpec: z.string().min(1),
+		packageSpec: hostedCliPackageSpecSchema,
 		registry: z.literal("https://registry.npmjs.org"),
 	})
 	.strict();
@@ -100,11 +118,6 @@ export const egressEngineSchema = z.object({
 });
 
 export type EgressEnginePin = z.infer<typeof egressEngineSchema>;
-
-export const DEFAULT_CLAWDI_CLI_POLICY = {
-	source: "npm:clawdi",
-	packageSpec: "clawdi@latest",
-} satisfies z.infer<typeof cliPayloadPolicySchema>;
 
 const liveSyncAgentSchema = z.object({
 	agentType: runtimeNameSchema,
@@ -197,246 +210,253 @@ export const manifestSchema = z
 
 const hostedControlPlaneSchema = z
 	.object({
-		manifestUrl: z.string().url().optional(),
-		cloudApiUrl: z.string().url().optional(),
-		apiUrl: z.unknown().optional(),
+		cloudApiUrl: z.string().url(),
 	})
-	.superRefine((controlPlane, ctx) => {
-		if ("apiUrl" in controlPlane) {
-			addForbiddenFieldIssue(ctx, "apiUrl", "hosted runtime controlPlane must use cloudApiUrl");
+	.strict();
+
+const hostedRuntimeRunSettingsSchema = runtimeRunSettingsSchema.strict();
+
+const hostedRuntimeInstallSchema = z
+	.object({
+		source: z.literal("official"),
+		channel: z.string().min(1).optional(),
+		args: z.array(z.string()).optional(),
+	})
+	.strict();
+
+const hostedPrimaryModelSchema = z
+	.object({
+		provider_id: z.string().min(1).optional(),
+		providerId: z.string().min(1).optional(),
+		model: z.string().min(1),
+	})
+	.strict();
+
+const hostedRuntimeEntrySchema = z
+	.object({
+		enabled: z.boolean(),
+		install: hostedRuntimeInstallSchema.optional(),
+		run: hostedRuntimeRunSettingsSchema.optional(),
+		services: z.record(runtimeServiceNameSchema, hostedRuntimeRunSettingsSchema).default({}),
+		provider_ids: z.array(z.string().min(1)).optional(),
+		providerIds: z.array(z.string().min(1)).optional(),
+		primary_model: z.union([z.string().min(1), hostedPrimaryModelSchema]).optional(),
+		primaryModel: hostedPrimaryModelSchema.optional(),
+		paths: z
+			.object({
+				home: z.string().min(1).optional(),
+				workspace: z.string().min(1).optional(),
+			})
+			.strict()
+			.optional(),
+	})
+	.strict();
+
+const hostedProviderCapabilitiesSchema = z
+	.object({
+		chat: z.boolean().optional(),
+		responses: z.boolean().optional(),
+		tools: z.boolean().optional(),
+		vision: z.boolean().optional(),
+		embeddings: z.boolean().optional(),
+		image_generation: z.boolean().optional(),
+	})
+	.strict();
+
+const hostedProviderModelCostSchema = z
+	.object({
+		input: z.number().nonnegative(),
+		output: z.number().nonnegative(),
+		cache_read: z.number().nonnegative().optional(),
+		cache_write: z.number().nonnegative().optional(),
+	})
+	.strict();
+
+const hostedProviderModelSchema = z
+	.object({
+		id: z.string().min(1),
+		label: z.string().min(1).optional(),
+		alias: z.string().min(1).optional(),
+		api_mode: z.string().min(1).optional(),
+		input_modalities: z.array(z.string().min(1)).optional(),
+		supports_vision: z.boolean().optional(),
+		supports_tools: z.boolean().optional(),
+		supports_reasoning: z.boolean().optional(),
+		context_window: z.number().int().positive().optional(),
+		max_tokens: z.number().int().positive().optional(),
+		cost: hostedProviderModelCostSchema.optional(),
+		capabilities: hostedProviderCapabilitiesSchema.optional(),
+	})
+	.strict();
+
+const hostedProviderAuthSchema = z
+	.object({
+		type: z.string().min(1),
+		tool: z.string().min(1).optional(),
+		profile: z.string().min(1).optional(),
+		source: z.string().min(1).optional(),
+		ref: z.string().min(1).optional(),
+	})
+	.strict();
+
+const hostedProviderSchema = z
+	.object({
+		kind: z.string().min(1).optional(),
+		type: z.string().min(1).optional(),
+		baseUrl: z.string().url().optional(),
+		base_url: z.string().url().optional(),
+		model: z.string().min(1).optional(),
+		models: z.array(hostedProviderModelSchema).optional(),
+		apiMode: z.string().min(1).optional(),
+		api_mode: z.string().min(1).optional(),
+		managed_by: z.string().min(1).optional(),
+		runtimeEnvName: z.string().min(1).optional(),
+		runtime_env_name: z.string().min(1).optional(),
+		apiKeySecretRef: z.string().min(1).nullable().optional(),
+		api_key_secret_ref: z.string().min(1).nullable().optional(),
+		apiKeyRequired: z.boolean().optional(),
+		status: z.string().min(1).optional(),
+		error: z
+			.object({
+				code: z.string().min(1),
+				message: z.string().min(1).optional(),
+			})
+			.strict()
+			.optional(),
+		auth: hostedProviderAuthSchema.optional(),
+	})
+	.strict();
+
+const hostedRuntimeBridgeSchema = z
+	.object({
+		surfaces: z.array(runtimeBridgeSurfaceSchema.strict()).default([]),
+	})
+	.strict();
+
+const hostedLiveSyncSchema = z
+	.object({
+		enabled: z.boolean().optional(),
+		agents: z.array(liveSyncAgentSchema.strict()).default([]),
+	})
+	.strict();
+
+export const hostedRuntimeManifestSchema = z
+	.object({
+		schemaVersion: z.literal("clawdi.hosted-runtime.manifest.v1"),
+		runtime: hostedRuntimeChoiceSchema,
+		deploymentId: z.string().min(1),
+		environmentId: z.string().min(1),
+		instanceId: z.string().min(1),
+		generation: z.number().int().nonnegative(),
+		minimumCliVersion: semverSchema,
+		issuedAt: z.string().min(1),
+		expiresAt: z.string().min(1).optional(),
+		locale: runtimeLocaleSchema,
+		language: z.never().optional(),
+		timezone: z.never().optional(),
+		personality: z.never().optional(),
+		system: z
+			.object({
+				user: z.string().min(1).optional(),
+				home: z.string().min(1).optional(),
+				workspace: z.string().min(1).optional(),
+				persistentPaths: z.array(z.string().min(1)).optional(),
+			})
+			.strict()
+			.optional(),
+		controlPlane: hostedControlPlaneSchema,
+		clawdiCli: hostedCliPayloadPolicySchema,
+		egressEngine: egressEngineSchema.strict().optional(),
+		runtimes: z.record(runtimeNameSchema, hostedRuntimeEntrySchema),
+		bridge: hostedRuntimeBridgeSchema.optional(),
+		providers: z.record(z.string().min(1), hostedProviderSchema).optional(),
+		liveSync: hostedLiveSyncSchema.optional(),
+		egressProfiles: egressProfileInputBundleSchema.strict().optional(),
+		mcp: z.unknown().optional(),
+		tools: z.unknown().optional(),
+		recovery: z
+			.object({
+				cacheManifest: z.boolean().optional(),
+				allowOfflineBoot: z.boolean().optional(),
+			})
+			.strict()
+			.optional(),
+	})
+	.strict()
+	.superRefine((manifest, ctx) => {
+		const runtimeKeys = Object.keys(manifest.runtimes);
+		const unexpectedRuntimeKeys = runtimeKeys.filter((runtime) => runtime !== manifest.runtime);
+		if (!manifest.runtimes[manifest.runtime]) {
+			ctx.addIssue({
+				code: "custom",
+				message: `runtimes.${manifest.runtime} must be present for selected runtime`,
+				path: ["runtimes", manifest.runtime],
+			});
 		}
+		for (const key of unexpectedRuntimeKeys) {
+			ctx.addIssue({
+				code: "custom",
+				message: "hosted runtime manifests must declare exactly one selected runtime",
+				path: ["runtimes", key],
+			});
+		}
+		if (manifest.runtimes[manifest.runtime]?.enabled !== true) {
+			ctx.addIssue({
+				code: "custom",
+				message: "selected runtime must be enabled",
+				path: ["runtimes", manifest.runtime, "enabled"],
+			});
+		}
+		const surfaces = manifest.bridge?.surfaces ?? [];
+		if (manifest.runtime === "openclaw" && surfaces.length > 0) {
+			const surface = surfaces.at(0);
+			if (
+				surfaces.length !== 1 ||
+				surface?.name !== "openclaw" ||
+				surface?.kind !== "control-ui" ||
+				surface?.listenPort !== 28789 ||
+				surface?.upstreamHost !== "127.0.0.1" ||
+				surface?.upstreamPort !== 18789
+			) {
+				ctx.addIssue({
+					code: "custom",
+					message: "openclaw bridge surface must be openclaw control-ui 28789 -> 127.0.0.1:18789",
+					path: ["bridge", "surfaces"],
+				});
+			}
+		}
+		if (manifest.runtime === "hermes") {
+			if (surfaces.length !== 1) {
+				ctx.addIssue({
+					code: "custom",
+					message: "hermes must declare exactly one bridge surface",
+					path: ["bridge", "surfaces"],
+				});
+				return;
+			}
+			const surface = surfaces.at(0);
+			if (
+				surface?.name !== "hermes" ||
+				surface?.kind !== "control-ui" ||
+				surface?.listenPort !== 28793 ||
+				surface?.upstreamHost !== "127.0.0.1" ||
+				surface?.upstreamPort !== 9119
+			) {
+				ctx.addIssue({
+					code: "custom",
+					message: "hermes bridge surface must be hermes control-ui 28793 -> 127.0.0.1:9119",
+					path: ["bridge", "surfaces", 0],
+				});
+			}
+		}
+	});
+
+export const hostedRuntimeManifestResponseSchema = z
+	.object({
+		manifest: hostedRuntimeManifestSchema,
+		secretValues: z.record(z.string().min(1), z.string()).default({}),
 	})
-	.transform(({ apiUrl: _apiUrl, ...controlPlane }) => controlPlane);
-
-const hostedRuntimeInstallSchema = z.object({
-	source: z.literal("official"),
-	channel: z.string().min(1).optional(),
-	args: z.array(z.string()).optional(),
-});
-
-const hostedRuntimeEntrySchema = z.object({
-	enabled: z.boolean(),
-	install: hostedRuntimeInstallSchema.optional(),
-	run: runtimeRunSettingsSchema.optional(),
-	services: z.record(runtimeServiceNameSchema, runtimeRunSettingsSchema).default({}),
-	provider_ids: z.array(z.string().min(1)).optional(),
-	providerIds: z.array(z.string().min(1)).optional(),
-	primary_model: z
-		.union([
-			z.string().min(1),
-			z.object({
-				provider_id: z.string().min(1).optional(),
-				providerId: z.string().min(1).optional(),
-				model: z.string().min(1),
-			}),
-		])
-		.optional(),
-	primaryModel: z
-		.object({
-			provider_id: z.string().min(1).optional(),
-			providerId: z.string().min(1).optional(),
-			model: z.string().min(1),
-		})
-		.optional(),
-	paths: z
-		.object({
-			home: z.string().min(1).optional(),
-			workspace: z.string().min(1).optional(),
-		})
-		.optional(),
-});
-
-const hostedProviderCapabilitiesSchema = z.object({
-	chat: z.boolean().optional(),
-	responses: z.boolean().optional(),
-	tools: z.boolean().optional(),
-	vision: z.boolean().optional(),
-	embeddings: z.boolean().optional(),
-	image_generation: z.boolean().optional(),
-});
-
-const hostedProviderModelCostSchema = z.object({
-	input: z.number().nonnegative(),
-	output: z.number().nonnegative(),
-	cache_read: z.number().nonnegative().optional(),
-	cache_write: z.number().nonnegative().optional(),
-});
-
-const hostedProviderModelSchema = z.object({
-	id: z.string().min(1),
-	label: z.string().min(1).optional(),
-	alias: z.string().min(1).optional(),
-	api_mode: z.string().min(1).optional(),
-	input_modalities: z.array(z.string().min(1)).optional(),
-	supports_vision: z.boolean().optional(),
-	supports_tools: z.boolean().optional(),
-	supports_reasoning: z.boolean().optional(),
-	context_window: z.number().int().positive().optional(),
-	max_tokens: z.number().int().positive().optional(),
-	cost: hostedProviderModelCostSchema.optional(),
-	capabilities: hostedProviderCapabilitiesSchema.optional(),
-});
-
-const hostedProviderAuthSchema = z.object({
-	type: z.string().min(1),
-	tool: z.string().min(1).optional(),
-	profile: z.string().min(1).optional(),
-	source: z.string().min(1).optional(),
-	ref: z.string().min(1).optional(),
-});
-
-const hostedProviderSchema = z.object({
-	kind: z.string().min(1).optional(),
-	type: z.string().min(1).optional(),
-	baseUrl: z.string().url().optional(),
-	base_url: z.string().url().optional(),
-	model: z.string().min(1).optional(),
-	models: z.array(hostedProviderModelSchema).optional(),
-	apiMode: z.string().min(1).optional(),
-	api_mode: z.string().min(1).optional(),
-	managed_by: z.string().min(1).optional(),
-	runtimeEnvName: z.string().min(1).optional(),
-	runtime_env_name: z.string().min(1).optional(),
-	apiKeySecretRef: z.string().min(1).nullable().optional(),
-	api_key_secret_ref: z.string().min(1).nullable().optional(),
-	apiKeyRequired: z.boolean().optional(),
-	status: z.string().min(1).optional(),
-	error: z
-		.object({
-			code: z.string().min(1),
-			message: z.string().min(1).optional(),
-		})
-		.optional(),
-	auth: hostedProviderAuthSchema.optional(),
-});
-
-export const hostedRuntimeManifestSchema = z.preprocess(
-	(value) => {
-		if (typeof value !== "object" || value === null || Array.isArray(value)) return value;
-		const manifest = value as Record<string, unknown>;
-		if (manifest.runtime !== undefined) return value;
-		const runtimes = manifest.runtimes;
-		if (typeof runtimes !== "object" || runtimes === null || Array.isArray(runtimes)) return value;
-		const runtimeKeys = Object.keys(runtimes).filter(
-			(runtime) => hostedRuntimeChoiceSchema.safeParse(runtime).success,
-		);
-		if (runtimeKeys.length !== 1) return value;
-		return { ...manifest, runtime: runtimeKeys[0] };
-	},
-	z
-		.object({
-			schemaVersion: z.literal("clawdi.hosted-runtime.manifest.v1"),
-			runtime: hostedRuntimeChoiceSchema,
-			deploymentId: z.string().min(1),
-			environmentId: z.string().min(1).optional(),
-			appId: z.string().min(1).optional(),
-			instanceId: z.string().min(1),
-			generation: z.number().int().nonnegative(),
-			minimumCliVersion: semverSchema.optional(),
-			issuedAt: z.string().min(1),
-			expiresAt: z.string().min(1).optional(),
-			locale: runtimeLocaleSchema,
-			language: z.never().optional(),
-			timezone: z.never().optional(),
-			personality: z.never().optional(),
-			system: z
-				.object({
-					user: z.string().min(1).optional(),
-					home: z.string().min(1).optional(),
-					workspace: z.string().min(1).optional(),
-					persistentPaths: z.array(z.string().min(1)).optional(),
-				})
-				.optional(),
-			controlPlane: hostedControlPlaneSchema,
-			clawdiCli: hostedCliPayloadPolicySchema,
-			egressEngine: egressEngineSchema.optional(),
-			runtimes: z.record(runtimeNameSchema, hostedRuntimeEntrySchema),
-			bridge: runtimeBridgeSchema.optional(),
-			providers: z.record(z.string().min(1), hostedProviderSchema).optional(),
-			liveSync: liveSyncSchema.optional(),
-			egressProfiles: z.unknown().optional(),
-			mcp: z.unknown().optional(),
-			tools: z.unknown().optional(),
-			recovery: z
-				.object({
-					cacheManifest: z.boolean().optional(),
-					allowOfflineBoot: z.boolean().optional(),
-				})
-				.optional(),
-		})
-		.superRefine((manifest, ctx) => {
-			const runtimeKeys = Object.keys(manifest.runtimes);
-			const unexpectedRuntimeKeys = runtimeKeys.filter((runtime) => runtime !== manifest.runtime);
-			if (!manifest.runtimes[manifest.runtime]) {
-				ctx.addIssue({
-					code: "custom",
-					message: `runtimes.${manifest.runtime} must be present for selected runtime`,
-					path: ["runtimes", manifest.runtime],
-				});
-			}
-			for (const key of unexpectedRuntimeKeys) {
-				ctx.addIssue({
-					code: "custom",
-					message: "hosted runtime manifests must declare exactly one selected runtime",
-					path: ["runtimes", key],
-				});
-			}
-			if (manifest.runtimes[manifest.runtime]?.enabled !== true) {
-				ctx.addIssue({
-					code: "custom",
-					message: "selected runtime must be enabled",
-					path: ["runtimes", manifest.runtime, "enabled"],
-				});
-			}
-			const surfaces = manifest.bridge?.surfaces ?? [];
-			if (manifest.runtime === "openclaw" && surfaces.length > 0) {
-				const surface = surfaces.at(0);
-				if (
-					surfaces.length !== 1 ||
-					surface?.name !== "openclaw" ||
-					surface?.kind !== "control-ui" ||
-					surface?.listenPort !== 28789 ||
-					surface?.upstreamHost !== "127.0.0.1" ||
-					surface?.upstreamPort !== 18789
-				) {
-					ctx.addIssue({
-						code: "custom",
-						message: "openclaw bridge surface must be openclaw control-ui 28789 -> 127.0.0.1:18789",
-						path: ["bridge", "surfaces"],
-					});
-				}
-			}
-			if (manifest.runtime === "hermes") {
-				if (surfaces.length !== 1) {
-					ctx.addIssue({
-						code: "custom",
-						message: "hermes must declare exactly one bridge surface",
-						path: ["bridge", "surfaces"],
-					});
-					return;
-				}
-				const surface = surfaces.at(0);
-				if (
-					surface?.name !== "hermes" ||
-					surface?.kind !== "control-ui" ||
-					surface?.listenPort !== 28793 ||
-					surface?.upstreamHost !== "127.0.0.1" ||
-					surface?.upstreamPort !== 9119
-				) {
-					ctx.addIssue({
-						code: "custom",
-						message: "hermes bridge surface must be hermes control-ui 28793 -> 127.0.0.1:9119",
-						path: ["bridge", "surfaces", 0],
-					});
-				}
-			}
-		}),
-);
-
-export const hostedRuntimeManifestResponseSchema = z.object({
-	manifest: hostedRuntimeManifestSchema,
-	secretValues: z.record(z.string().min(1), z.string()).default({}),
-});
+	.strict();
 
 export type RuntimeManifest = z.output<typeof manifestSchema>;
 export type RuntimeInstall = z.infer<typeof installSchema>;

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -216,6 +216,15 @@ const hostedControlPlaneSchema = z
 
 const hostedRuntimeRunSettingsSchema = runtimeRunSettingsSchema.strict();
 
+const urlOriginSchema = z.string().refine((value) => {
+	try {
+		const url = new URL(value);
+		return (url.protocol === "http:" || url.protocol === "https:") && url.origin === value;
+	} catch {
+		return false;
+	}
+}, "must be an HTTP(S) URL origin");
+
 const hostedRuntimeInstallSchema = z
 	.object({
 		source: z.literal("official"),
@@ -226,8 +235,7 @@ const hostedRuntimeInstallSchema = z
 
 const hostedPrimaryModelSchema = z
 	.object({
-		provider_id: z.string().min(1).optional(),
-		providerId: z.string().min(1).optional(),
+		provider_id: z.string().min(1),
 		model: z.string().min(1),
 	})
 	.strict();
@@ -239,9 +247,7 @@ const hostedRuntimeEntrySchema = z
 		run: hostedRuntimeRunSettingsSchema.optional(),
 		services: z.record(runtimeServiceNameSchema, hostedRuntimeRunSettingsSchema).default({}),
 		provider_ids: z.array(z.string().min(1)).optional(),
-		providerIds: z.array(z.string().min(1)).optional(),
-		primary_model: z.union([z.string().min(1), hostedPrimaryModelSchema]).optional(),
-		primaryModel: hostedPrimaryModelSchema.optional(),
+		primary_model: hostedPrimaryModelSchema.optional(),
 		paths: z
 			.object({
 				home: z.string().min(1).optional(),
@@ -304,16 +310,12 @@ const hostedProviderSchema = z
 		kind: z.string().min(1).optional(),
 		type: z.string().min(1).optional(),
 		baseUrl: z.string().url().optional(),
-		base_url: z.string().url().optional(),
 		model: z.string().min(1).optional(),
 		models: z.array(hostedProviderModelSchema).optional(),
 		apiMode: z.string().min(1).optional(),
-		api_mode: z.string().min(1).optional(),
 		managed_by: z.string().min(1).optional(),
 		runtimeEnvName: z.string().min(1).optional(),
-		runtime_env_name: z.string().min(1).optional(),
 		apiKeySecretRef: z.string().min(1).nullable().optional(),
-		api_key_secret_ref: z.string().min(1).nullable().optional(),
 		apiKeyRequired: z.boolean().optional(),
 		status: z.string().min(1).optional(),
 		error: z
@@ -352,15 +354,13 @@ export const hostedRuntimeManifestSchema = z
 		issuedAt: z.string().min(1),
 		expiresAt: z.string().min(1).optional(),
 		locale: runtimeLocaleSchema,
-		language: z.never().optional(),
-		timezone: z.never().optional(),
-		personality: z.never().optional(),
 		system: z
 			.object({
 				user: z.string().min(1).optional(),
 				home: z.string().min(1).optional(),
 				workspace: z.string().min(1).optional(),
 				persistentPaths: z.array(z.string().min(1)).optional(),
+				openclawControlUiAllowedOrigins: z.array(urlOriginSchema).optional(),
 			})
 			.strict()
 			.optional(),

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -22,6 +22,34 @@ export const OFFICIAL_INSTALL_ARGS: Record<string, string[]> = {
 const hostedRuntimeChoiceSchema = z.enum(["openclaw", "hermes"]);
 const semverSchema = z.string().min(1).refine(isValidSemver, "must be a semver string");
 
+export const HOSTED_LOCALE_LANGUAGES = [
+	"en",
+	"zh-CN",
+	"zh-TW",
+	"ja",
+	"ko",
+	"es",
+	"fr",
+	"de",
+	"pt",
+] as const;
+
+function isValidIanaTimezone(value: string): boolean {
+	try {
+		new Intl.DateTimeFormat("en-US", { timeZone: value }).format();
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export const runtimeLocaleSchema = z
+	.object({
+		language: z.enum(HOSTED_LOCALE_LANGUAGES),
+		timezone: z.string().min(1).refine(isValidIanaTimezone, "must be a valid IANA timezone"),
+	})
+	.strict();
+
 const installSchema = z.object({
 	authority: z.literal("official"),
 	method: z.literal("official-installer"),
@@ -127,6 +155,7 @@ const runtimeDesiredStateShape = {
 	minimumCliVersion: semverSchema.optional(),
 	issuedAt: z.string().min(1),
 	expiresAt: z.string().min(1).optional(),
+	locale: runtimeLocaleSchema.optional(),
 	workspaceRoot: z.string().min(1).optional(),
 	runtime: hostedRuntimeChoiceSchema.optional(),
 	controlPlane: z.object({
@@ -306,6 +335,10 @@ export const hostedRuntimeManifestSchema = z.preprocess(
 			minimumCliVersion: semverSchema.optional(),
 			issuedAt: z.string().min(1),
 			expiresAt: z.string().min(1).optional(),
+			locale: runtimeLocaleSchema,
+			language: z.never().optional(),
+			timezone: z.never().optional(),
+			personality: z.never().optional(),
 			system: z
 				.object({
 					user: z.string().min(1).optional(),

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -353,12 +353,43 @@ const hostedRuntimeBridgeSchema = z
 	})
 	.strict();
 
-const hostedLiveSyncSchema = z
-	.object({
-		enabled: z.boolean().optional(),
-		agents: z.array(liveSyncAgentSchema.strict()).default([]),
+const hostedLiveSyncAgentSchema = liveSyncAgentSchema
+	.extend({
+		agentType: z.enum(["openclaw", "hermes", "codex"]),
+		environmentId: z
+			.string()
+			.min(1)
+			.max(200)
+			.refine((value) => value === value.trim(), "must not contain surrounding whitespace"),
 	})
 	.strict();
+
+const hostedLiveSyncSchema = z
+	.object({
+		enabled: z.boolean(),
+		agents: z.array(hostedLiveSyncAgentSchema),
+	})
+	.strict()
+	.superRefine((liveSync, ctx) => {
+		const identities = liveSync.agents.map(
+			(agent) => `${agent.agentType}\u0000${agent.environmentId}`,
+		);
+		if (new Set(identities).size !== identities.length) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["agents"],
+				message: "must not contain duplicate agent identities",
+			});
+		}
+		const hasAgents = liveSync.agents.length > 0;
+		if (liveSync.enabled !== hasAgents) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["enabled"],
+				message: "must match whether agents are configured",
+			});
+		}
+	});
 
 export const hostedRuntimeManifestSchema = z
 	.object({
@@ -387,17 +418,16 @@ export const hostedRuntimeManifestSchema = z
 		runtimes: z.record(runtimeNameSchema, hostedRuntimeEntrySchema),
 		bridge: hostedRuntimeBridgeSchema.optional(),
 		providers: z.record(z.string().min(1), hostedProviderSchema).optional(),
-		liveSync: hostedLiveSyncSchema.optional(),
+		liveSync: hostedLiveSyncSchema,
 		egressProfiles: egressProfileInputBundleSchema.strict().optional(),
 		mcp: z.unknown().optional(),
 		tools: z.unknown().optional(),
 		recovery: z
 			.object({
-				cacheManifest: z.boolean().optional(),
-				allowOfflineBoot: z.boolean().optional(),
+				cacheManifest: z.boolean(),
+				allowOfflineBoot: z.boolean(),
 			})
-			.strict()
-			.optional(),
+			.strict(),
 	})
 	.strict()
 	.superRefine((manifest, ctx) => {

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -240,23 +240,41 @@ const hostedPrimaryModelSchema = z
 	})
 	.strict();
 
+const hostedProviderIdsSchema = z
+	.array(z.string().min(1))
+	.min(1)
+	.refine((providerIds) => new Set(providerIds).size === providerIds.length, {
+		message: "must contain unique provider ids",
+	});
+
 const hostedRuntimeEntrySchema = z
 	.object({
 		enabled: z.boolean(),
 		install: hostedRuntimeInstallSchema.optional(),
 		run: hostedRuntimeRunSettingsSchema.optional(),
 		services: z.record(runtimeServiceNameSchema, hostedRuntimeRunSettingsSchema).default({}),
-		provider_ids: z.array(z.string().min(1)).optional(),
-		primary_model: hostedPrimaryModelSchema.optional(),
+		provider_ids: hostedProviderIdsSchema,
+		primary_model: hostedPrimaryModelSchema,
 		paths: z
 			.object({
-				home: z.string().min(1).optional(),
-				workspace: z.string().min(1).optional(),
+				home: z.string().min(1),
+				workspace: z.string().min(1),
 			})
-			.strict()
-			.optional(),
+			.strict(),
 	})
-	.strict();
+	.strict()
+	.superRefine((runtime, ctx) => {
+		if (
+			runtime.primary_model &&
+			!runtime.provider_ids.includes(runtime.primary_model.provider_id)
+		) {
+			ctx.addIssue({
+				code: "custom",
+				message: "primary model provider must be included in provider_ids",
+				path: ["primary_model", "provider_id"],
+			});
+		}
+	});
 
 const hostedProviderCapabilitiesSchema = z
 	.object({
@@ -357,13 +375,12 @@ export const hostedRuntimeManifestSchema = z
 		system: z
 			.object({
 				user: z.string().min(1).optional(),
-				home: z.string().min(1).optional(),
-				workspace: z.string().min(1).optional(),
+				home: z.string().min(1),
+				workspace: z.string().min(1),
 				persistentPaths: z.array(z.string().min(1)).optional(),
 				openclawControlUiAllowedOrigins: z.array(urlOriginSchema).optional(),
 			})
-			.strict()
-			.optional(),
+			.strict(),
 		controlPlane: hostedControlPlaneSchema,
 		clawdiCli: hostedCliPayloadPolicySchema,
 		egressEngine: egressEngineSchema.strict().optional(),

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -108,12 +108,12 @@ function isHostedFixtureCliPackageSpec(value: string): boolean {
 	return !basename.includes("..") && /^[A-Za-z0-9][A-Za-z0-9._-]*\.tgz$/.test(basename);
 }
 
-const hostedCliPackageSpecSchema = z
+export const hostedCliPackageSpecSchema = z
 	.string()
 	.max(200)
 	.refine(isHostedExactCliPackageSpec, "must be clawdi@<exact-semver>");
 
-const hostedFixtureCliPackageSpecSchema = z
+export const hostedFixtureCliPackageSpecSchema = z
 	.string()
 	.max(200)
 	.refine(

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -110,10 +110,12 @@ function isHostedFixtureCliPackageSpec(value: string): boolean {
 
 const hostedCliPackageSpecSchema = z
 	.string()
+	.max(200)
 	.refine(isHostedExactCliPackageSpec, "must be clawdi@<exact-semver>");
 
 const hostedFixtureCliPackageSpecSchema = z
 	.string()
+	.max(200)
 	.refine(
 		isHostedFixtureCliPackageSpec,
 		"must be clawdi@<exact-semver> or a managed bootstrap tarball",
@@ -359,7 +361,7 @@ const hostedProviderSchema = z
 		error: z
 			.object({
 				code: z.string().min(1),
-				message: z.string().min(1).optional(),
+				message: z.string().min(1),
 			})
 			.strict()
 			.optional(),

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -121,7 +121,7 @@ const hostedFixtureCliPackageSpecSchema = z
 		"must be clawdi@<exact-semver> or a managed bootstrap tarball",
 	);
 
-const hostedCliPayloadPolicySchema = z
+export const hostedCliPayloadPolicySchema = z
 	.object({
 		source: z.literal("npm:clawdi"),
 		packageSpec: hostedCliPackageSpecSchema,
@@ -129,7 +129,7 @@ const hostedCliPayloadPolicySchema = z
 	})
 	.strict();
 
-const hostedFixtureCliPayloadPolicySchema = hostedCliPayloadPolicySchema.safeExtend({
+export const hostedFixtureCliPayloadPolicySchema = hostedCliPayloadPolicySchema.safeExtend({
 	packageSpec: hostedFixtureCliPackageSpecSchema,
 });
 

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -83,10 +83,26 @@ const cliPayloadPolicySchema = z.object({
 
 const HOSTED_BOOTSTRAP_PACKAGE_ROOT = "/usr/local/share/clawdi/bootstrap/";
 
-function isHostedCliPackageSpec(value: string): boolean {
-	if (value === "clawdi@agent-v2") return true;
+function isHostedExactCliPackageSpec(value: string): boolean {
 	const npmVersion = /^clawdi@(.+)$/.exec(value)?.[1];
-	if (npmVersion && isValidSemver(npmVersion)) return true;
+	return npmVersion !== undefined && isHostedExactSemver(npmVersion);
+}
+
+function isHostedExactSemver(value: string): boolean {
+	const match =
+		/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/.exec(
+			value,
+		);
+	if (!match) return false;
+	const prerelease = match[4];
+	if (!prerelease) return true;
+	return prerelease
+		.split(".")
+		.every((identifier) => !/^\d+$/.test(identifier) || /^(0|[1-9]\d*)$/.test(identifier));
+}
+
+function isHostedFixtureCliPackageSpec(value: string): boolean {
+	if (isHostedExactCliPackageSpec(value)) return true;
 	if (!value.startsWith(HOSTED_BOOTSTRAP_PACKAGE_ROOT)) return false;
 	const basename = value.slice(HOSTED_BOOTSTRAP_PACKAGE_ROOT.length);
 	return !basename.includes("..") && /^[A-Za-z0-9][A-Za-z0-9._-]*\.tgz$/.test(basename);
@@ -94,19 +110,26 @@ function isHostedCliPackageSpec(value: string): boolean {
 
 const hostedCliPackageSpecSchema = z
 	.string()
+	.refine(isHostedExactCliPackageSpec, "must be clawdi@<exact-semver>");
+
+const hostedFixtureCliPackageSpecSchema = z
+	.string()
 	.refine(
-		isHostedCliPackageSpec,
-		"must be clawdi@agent-v2, clawdi@<exact-semver>, or a managed bootstrap tarball",
+		isHostedFixtureCliPackageSpec,
+		"must be clawdi@<exact-semver> or a managed bootstrap tarball",
 	);
 
 const hostedCliPayloadPolicySchema = z
 	.object({
-		// The image env seeds pre-manifest bootstrap only; Cloud owns every hosted update after that.
 		source: z.literal("npm:clawdi"),
 		packageSpec: hostedCliPackageSpecSchema,
 		registry: z.literal("https://registry.npmjs.org"),
 	})
 	.strict();
+
+const hostedFixtureCliPayloadPolicySchema = hostedCliPayloadPolicySchema.safeExtend({
+	packageSpec: hostedFixtureCliPackageSpecSchema,
+});
 
 const sha256Schema = z.string().regex(/^[a-fA-F0-9]{64}$/);
 
@@ -228,8 +251,6 @@ const urlOriginSchema = z.string().refine((value) => {
 const hostedRuntimeInstallSchema = z
 	.object({
 		source: z.literal("official"),
-		channel: z.string().min(1).optional(),
-		args: z.array(z.string()).optional(),
 	})
 	.strict();
 
@@ -250,7 +271,7 @@ const hostedProviderIdsSchema = z
 const hostedRuntimeEntrySchema = z
 	.object({
 		enabled: z.boolean(),
-		install: hostedRuntimeInstallSchema.optional(),
+		install: hostedRuntimeInstallSchema,
 		run: hostedRuntimeRunSettingsSchema.optional(),
 		services: z.record(runtimeServiceNameSchema, hostedRuntimeRunSettingsSchema).default({}),
 		provider_ids: hostedProviderIdsSchema,
@@ -325,17 +346,16 @@ const hostedProviderAuthSchema = z
 
 const hostedProviderSchema = z
 	.object({
-		kind: z.string().min(1).optional(),
+		kind: z.literal("openai-compatible"),
 		type: z.string().min(1).optional(),
 		baseUrl: z.string().url().optional(),
-		model: z.string().min(1).optional(),
 		models: z.array(hostedProviderModelSchema).optional(),
 		apiMode: z.string().min(1).optional(),
 		managed_by: z.string().min(1).optional(),
 		runtimeEnvName: z.string().min(1).optional(),
 		apiKeySecretRef: z.string().min(1).nullable().optional(),
 		apiKeyRequired: z.boolean().optional(),
-		status: z.string().min(1).optional(),
+		status: z.literal("error").optional(),
 		error: z
 			.object({
 				code: z.string().min(1),
@@ -345,7 +365,28 @@ const hostedProviderSchema = z
 			.optional(),
 		auth: hostedProviderAuthSchema.optional(),
 	})
-	.strict();
+	.strict()
+	.superRefine((provider, ctx) => {
+		const hasErrorStatus = provider.status === "error";
+		const hasError = provider.error !== undefined;
+		if (hasErrorStatus !== hasError) {
+			ctx.addIssue({
+				code: "custom",
+				message: "provider status:error and error must be supplied together",
+				path: hasErrorStatus ? ["error"] : ["status"],
+			});
+		}
+
+		const isProviderNotFound = hasErrorStatus && provider.error?.code === "provider_not_found";
+		const hasNormalProjection = provider.type !== undefined && provider.baseUrl !== undefined;
+		if (!isProviderNotFound && !hasNormalProjection) {
+			ctx.addIssue({
+				code: "custom",
+				message: "provider must include type and baseUrl unless it is a provider_not_found error",
+				path: [],
+			});
+		}
+	});
 
 const hostedRuntimeBridgeSchema = z
 	.object({
@@ -523,6 +564,17 @@ export const hostedRuntimeManifestSchema = z
 export const hostedRuntimeManifestResponseSchema = z
 	.object({
 		manifest: hostedRuntimeManifestSchema,
+		secretValues: z.record(z.string().min(1), z.string()).default({}),
+	})
+	.strict();
+
+const hostedRuntimeManifestFixtureSchema = hostedRuntimeManifestSchema.safeExtend({
+	clawdiCli: hostedFixtureCliPayloadPolicySchema,
+});
+
+export const hostedRuntimeManifestFixtureResponseSchema = z
+	.object({
+		manifest: hostedRuntimeManifestFixtureSchema,
 		secretValues: z.record(z.string().min(1), z.string()).default({}),
 	})
 	.strict();

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -53,6 +53,15 @@ const cliPayloadPolicySchema = z.object({
 	registry: z.string().min(1).optional(),
 });
 
+const hostedCliPayloadPolicySchema = z
+	.object({
+		// The image env seeds pre-manifest bootstrap only; Cloud owns every hosted update after that.
+		source: z.literal("npm:clawdi"),
+		packageSpec: z.string().min(1),
+		registry: z.literal("https://registry.npmjs.org"),
+	})
+	.strict();
+
 const sha256Schema = z.string().regex(/^[a-fA-F0-9]{64}$/);
 
 export const egressEngineSchema = z.object({
@@ -306,7 +315,7 @@ export const hostedRuntimeManifestSchema = z.preprocess(
 				})
 				.optional(),
 			controlPlane: hostedControlPlaneSchema,
-			clawdiCli: cliPayloadPolicySchema.optional(),
+			clawdiCli: hostedCliPayloadPolicySchema,
 			egressEngine: egressEngineSchema.optional(),
 			runtimes: z.record(runtimeNameSchema, hostedRuntimeEntrySchema),
 			bridge: runtimeBridgeSchema.optional(),

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -128,6 +128,76 @@ afterEach(() => {
 });
 
 describe("runtime manifest reconciliation invariants", () => {
+	test("rejects hosted manifests without an explicit CLI package policy", () => {
+		expect(() =>
+			normalizeManifestPayload({
+				manifest: {
+					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					runtime: "openclaw",
+					deploymentId: "hdep_missing_cli_policy",
+					environmentId: "env_missing_cli_policy",
+					instanceId: "hri_missing_cli_policy",
+					generation: 1,
+					issuedAt: "2026-07-11T00:00:00.000Z",
+					controlPlane: { cloudApiUrl: "https://cloud-api.example.test" },
+					runtimes: { openclaw: { enabled: true } },
+				},
+				secretValues: {},
+			}),
+		).toThrow(/clawdiCli/);
+	});
+
+	test.each([
+		{
+			name: "wrong source",
+			clawdiCli: {
+				source: "npm:other",
+				packageSpec: "clawdi@agent-v2",
+				registry: "https://registry.npmjs.org",
+			},
+		},
+		{
+			name: "missing registry",
+			clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@agent-v2" },
+		},
+		{
+			name: "non-official registry",
+			clawdiCli: {
+				source: "npm:clawdi",
+				packageSpec: "clawdi@agent-v2",
+				registry: "https://registry.example.test",
+			},
+		},
+		{
+			name: "dead managed flags",
+			clawdiCli: {
+				source: "npm:clawdi",
+				packageSpec: "clawdi@agent-v2",
+				registry: "https://registry.npmjs.org",
+				managedConfig: true,
+				userEditableConfig: false,
+			},
+		},
+	])("rejects hosted CLI policy with $name", ({ clawdiCli }) => {
+		expect(() =>
+			normalizeManifestPayload({
+				manifest: {
+					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					runtime: "openclaw",
+					deploymentId: "hdep_invalid_cli_policy",
+					environmentId: "env_invalid_cli_policy",
+					instanceId: "hri_invalid_cli_policy",
+					generation: 1,
+					issuedAt: "2026-07-11T00:00:00.000Z",
+					controlPlane: { cloudApiUrl: "https://cloud-api.example.test" },
+					clawdiCli,
+					runtimes: { openclaw: { enabled: true } },
+				},
+				secretValues: {},
+			}),
+		).toThrow();
+	});
+
 	test("normalizes hosted manifest responses into runtime desired state without embedding secrets", () => {
 		const hostedResponse = {
 			manifest: {
@@ -145,6 +215,11 @@ describe("runtime manifest reconciliation invariants", () => {
 				controlPlane: {
 					cloudApiUrl: "https://cloud-api.example.test",
 					manifestUrl: "https://cloud-api.example.test/v1/runtime/manifest",
+				},
+				clawdiCli: {
+					source: "npm:clawdi",
+					packageSpec: "clawdi@agent-v2",
+					registry: "https://registry.npmjs.org",
 				},
 				runtimes: {
 					openclaw: {
@@ -271,6 +346,11 @@ describe("runtime manifest reconciliation invariants", () => {
 			controlPlane: {
 				cloudApiUrl: "https://cloud-api.example.test",
 			},
+			clawdiCli: {
+				source: "npm:clawdi",
+				packageSpec: "clawdi@agent-v2",
+				registry: "https://registry.npmjs.org",
+			},
 			runtimes: {
 				openclaw: {
 					enabled: true,
@@ -294,6 +374,11 @@ describe("runtime manifest reconciliation invariants", () => {
 			issuedAt: "2026-07-01T00:00:00.000Z",
 			controlPlane: {
 				cloudApiUrl: "https://cloud-api.example.test",
+			},
+			clawdiCli: {
+				source: "npm:clawdi",
+				packageSpec: "clawdi@agent-v2",
+				registry: "https://registry.npmjs.org",
 			},
 			runtimes: {
 				openclaw: {
@@ -341,6 +426,11 @@ describe("runtime manifest reconciliation invariants", () => {
 				issuedAt: "2026-07-01T00:00:00.000Z",
 				controlPlane: {
 					cloudApiUrl: "https://cloud-api.example.test",
+				},
+				clawdiCli: {
+					source: "npm:clawdi",
+					packageSpec: "clawdi@agent-v2",
+					registry: "https://registry.npmjs.org",
 				},
 				runtimes: {
 					openclaw: {

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -19,6 +19,7 @@ import {
 	runtimeSidecarProgramRevision,
 } from "./manifest";
 import {
+	hostedRuntimeManifestFixtureResponseSchema,
 	hostedRuntimeManifestSchema,
 	manifestSchema,
 	OFFICIAL_INSTALL_ARGS,
@@ -456,7 +457,10 @@ describe("runtime manifest reconciliation invariants", () => {
 				kind: "openai-compatible",
 				type: "custom_openai_compatible",
 				baseUrl: "https://provider.example.test/v1",
-				error: { code: "provider_secret_unavailable" },
+				error: {
+					code: "provider_secret_unavailable",
+					message: "provider secret is unavailable",
+				},
 			},
 		],
 		[
@@ -464,7 +468,36 @@ describe("runtime manifest reconciliation invariants", () => {
 			{
 				kind: "openai-compatible",
 				status: "error",
+				error: {
+					code: "provider_secret_unavailable",
+					message: "provider secret is unavailable",
+				},
+			},
+		],
+		[
+			"provider_not_found without error message",
+			{
+				kind: "openai-compatible",
+				status: "error",
+				error: { code: "provider_not_found" },
+			},
+		],
+		[
+			"provider_secret_unavailable without error message",
+			{
+				kind: "openai-compatible",
+				type: "anthropic",
+				baseUrl: "https://api.anthropic.com",
+				status: "error",
 				error: { code: "provider_secret_unavailable" },
+			},
+		],
+		[
+			"empty error message",
+			{
+				kind: "openai-compatible",
+				status: "error",
+				error: { code: "provider_not_found", message: "" },
 			},
 		],
 		[
@@ -504,7 +537,10 @@ describe("runtime manifest reconciliation invariants", () => {
 				runtimeEnvName: "ANTHROPIC_API_KEY",
 				apiKeyRequired: true,
 				status: "error",
-				error: { code: "provider_secret_unavailable" },
+				error: {
+					code: "provider_secret_unavailable",
+					message: "provider secret is unavailable",
+				},
 			},
 		],
 		[
@@ -744,6 +780,31 @@ describe("runtime manifest reconciliation invariants", () => {
 		).toBe(true);
 	});
 
+	test("enforces the Cloud package spec length limit for remote and fixture Hosted schemas", () => {
+		const atLimit = `clawdi@1.2.3-${"a".repeat(187)}`;
+		const overLimit = `clawdi@1.2.3-${"a".repeat(188)}`;
+		expect(atLimit).toHaveLength(200);
+		expect(overLimit).toHaveLength(201);
+
+		for (const packageSpec of [atLimit, overLimit]) {
+			const manifest = hostedManifestFixture({
+				clawdiCli: {
+					source: "npm:clawdi",
+					packageSpec,
+					registry: "https://registry.npmjs.org",
+				},
+			});
+			const expected = packageSpec === atLimit;
+			expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(expected);
+			expect(
+				hostedRuntimeManifestFixtureResponseSchema.safeParse({
+					manifest,
+					secretValues: {},
+				}).success,
+			).toBe(expected);
+		}
+	});
+
 	test.each([
 		"clawdi@agent-v2",
 		"clawdi@latest",
@@ -941,7 +1002,7 @@ describe("runtime manifest reconciliation invariants", () => {
 					default: {
 						kind: "openai-compatible",
 						status: "error",
-						error: { code: "provider_not_found" },
+						error: { code: "provider_not_found", message: "provider is missing" },
 					},
 				},
 				liveSync: { enabled: false, agents: [] },
@@ -1064,7 +1125,7 @@ describe("runtime manifest reconciliation invariants", () => {
 					default: {
 						kind: "openai-compatible",
 						status: "error",
-						error: { code: "provider_not_found" },
+						error: { code: "provider_not_found", message: "provider is missing" },
 					},
 				},
 				liveSync: { enabled: false, agents: [] },

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -35,6 +35,8 @@ const originalEnv = { ...process.env };
 const tempRoots: string[] = [];
 const TEST_HOSTED_LOCALE = { language: "en" as const, timezone: "UTC" };
 const TEST_HOSTED_MINIMUM_CLI_VERSION = "0.12.10-beta.51";
+const TEST_HOSTED_HOME = "/home/clawdi";
+const TEST_HOSTED_WORKSPACE = "/home/clawdi/clawdi";
 
 function tempRuntimePaths(): RuntimePaths {
 	const root = mkdtempSync(join(tmpdir(), "clawdi-runtime-reconcile-test-"));
@@ -99,14 +101,38 @@ function hostedManifestFixture(overrides: Record<string, unknown> = {}): Record<
 		generation: 1,
 		issuedAt: "2026-07-11T00:00:00.000Z",
 		locale: TEST_HOSTED_LOCALE,
+		system: { home: TEST_HOSTED_HOME, workspace: TEST_HOSTED_WORKSPACE },
 		controlPlane: { cloudApiUrl: "https://cloud-api.example.test" },
 		clawdiCli: {
 			source: "npm:clawdi",
 			packageSpec: "clawdi@agent-v2",
 			registry: "https://registry.npmjs.org",
 		},
-		runtimes: { openclaw: { enabled: true } },
+		runtimes: {
+			openclaw: {
+				enabled: true,
+				provider_ids: ["default"],
+				primary_model: { provider_id: "default", model: "gpt-test" },
+				paths: { home: TEST_HOSTED_HOME, workspace: TEST_HOSTED_WORKSPACE },
+			},
+		},
 		...overrides,
+	};
+}
+
+function hostedRuntimeFixture(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	const paths =
+		typeof overrides.paths === "object" &&
+		overrides.paths !== null &&
+		!Array.isArray(overrides.paths)
+			? (overrides.paths as Record<string, unknown>)
+			: {};
+	return {
+		enabled: true,
+		provider_ids: ["default"],
+		primary_model: { provider_id: "default", model: "gpt-test" },
+		...overrides,
+		paths: { home: TEST_HOSTED_HOME, workspace: TEST_HOSTED_WORKSPACE, ...paths },
 	};
 }
 
@@ -183,28 +209,25 @@ describe("runtime manifest reconciliation invariants", () => {
 	});
 
 	test.each([
-		["providerIds", { enabled: true, providerIds: ["default"] }],
+		["providerIds", hostedRuntimeFixture({ providerIds: ["default"] })],
 		[
 			"primaryModel",
-			{
-				enabled: true,
+			hostedRuntimeFixture({
 				primaryModel: { provider_id: "default", model: "gpt-test" },
-			},
+			}),
 		],
 		[
 			"primary_model.providerId",
-			{
-				enabled: true,
+			hostedRuntimeFixture({
 				primary_model: { providerId: "default", model: "gpt-test" },
-			},
+			}),
 		],
-		["string primary_model", { enabled: true, primary_model: "gpt-test" }],
+		["string primary_model", hostedRuntimeFixture({ primary_model: "gpt-test" })],
 		[
 			"paths.stateDir",
-			{
-				enabled: true,
+			hostedRuntimeFixture({
 				paths: { home: "/home/clawdi", workspace: "/workspace", stateDir: "/state" },
-			},
+			}),
 		],
 	])("rejects noncanonical hosted runtime field %s", (_name, runtime) => {
 		expect(
@@ -218,11 +241,10 @@ describe("runtime manifest reconciliation invariants", () => {
 		const canonical = hostedRuntimeManifestSchema.parse(
 			hostedManifestFixture({
 				runtimes: {
-					openclaw: {
-						enabled: true,
+					openclaw: hostedRuntimeFixture({
 						provider_ids: ["default"],
 						primary_model: { provider_id: "default", model: "gpt-test" },
-					},
+					}),
 				},
 			}),
 		);
@@ -230,20 +252,50 @@ describe("runtime manifest reconciliation invariants", () => {
 			provider_ids: ["default"],
 			primary_model: { provider_id: "default", model: "gpt-test" },
 		});
+	});
 
-		const primaryOnly = hostedRuntimeManifestSchema.parse(
-			hostedManifestFixture({
-				runtimes: {
-					openclaw: {
-						enabled: true,
-						primary_model: { provider_id: "default", model: "gpt-test" },
-					},
-				},
-			}),
-		);
+	test.each([
+		["missing provider_ids", { provider_ids: undefined }],
+		["empty provider_ids", { provider_ids: [] }],
+		["duplicate provider_ids", { provider_ids: ["default", "default"] }],
+		["missing primary_model", { primary_model: undefined }],
+		[
+			"primary model provider outside provider_ids",
+			{
+				provider_ids: ["default"],
+				primary_model: { provider_id: "other", model: "gpt-test" },
+			},
+		],
+	])("rejects hosted runtime with %s", (_name, overrides) => {
+		const runtime = hostedRuntimeFixture(overrides);
 		expect(
-			hostedManifestToRuntimeManifest(primaryOnly).runtimes.openclaw.provider_ids,
-		).toBeUndefined();
+			hostedRuntimeManifestSchema.safeParse(
+				hostedManifestFixture({ runtimes: { openclaw: runtime } }),
+			).success,
+		).toBe(false);
+	});
+
+	test.each([
+		"system",
+		"system.home",
+		"system.workspace",
+		"runtime.paths",
+		"runtime.paths.home",
+		"runtime.paths.workspace",
+	])("rejects hosted manifests with missing %s", (field) => {
+		const manifest = structuredClone(hostedManifestFixture()) as Record<string, unknown>;
+		const system = manifest.system as Record<string, unknown>;
+		const runtimes = manifest.runtimes as Record<string, Record<string, unknown>>;
+		const runtime = runtimes.openclaw;
+		const paths = runtime.paths as Record<string, unknown>;
+		if (field === "system") delete manifest.system;
+		if (field === "system.home") delete system.home;
+		if (field === "system.workspace") delete system.workspace;
+		if (field === "runtime.paths") delete runtime.paths;
+		if (field === "runtime.paths.home") delete paths.home;
+		if (field === "runtime.paths.workspace") delete paths.workspace;
+
+		expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(false);
 	});
 
 	test.each([
@@ -268,7 +320,11 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(
 			hostedRuntimeManifestSchema.safeParse(
 				hostedManifestFixture({
-					system: { openclawControlUiAllowedOrigins: [origin] },
+					system: {
+						home: TEST_HOSTED_HOME,
+						workspace: TEST_HOSTED_WORKSPACE,
+						openclawControlUiAllowedOrigins: [origin],
+					},
 				}),
 			).success,
 		).toBe(false);
@@ -306,6 +362,8 @@ describe("runtime manifest reconciliation invariants", () => {
 				runtimes: {
 					openclaw: {
 						enabled: true,
+						provider_ids: ["default"],
+						primary_model: { provider_id: "default", model: "gpt-test" },
 						install: { source: "official" },
 						paths: { home: paths.userHome, workspace },
 					},
@@ -523,6 +581,8 @@ describe("runtime manifest reconciliation invariants", () => {
 				runtimes: {
 					openclaw: {
 						enabled: true,
+						provider_ids: ["default"],
+						primary_model: { provider_id: "default", model: "gpt-test" },
 						install: { source: "official", channel: "stable" },
 						run: {
 							command: "openclaw",
@@ -761,6 +821,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				generation: 1,
 				issuedAt: "2026-07-01T00:00:00.000Z",
 				locale: TEST_HOSTED_LOCALE,
+				system: { home: TEST_HOSTED_HOME, workspace: TEST_HOSTED_WORKSPACE },
 				controlPlane: {
 					cloudApiUrl: "https://cloud-api.example.test",
 				},
@@ -772,10 +833,16 @@ describe("runtime manifest reconciliation invariants", () => {
 				runtimes: {
 					openclaw: {
 						enabled: true,
+						provider_ids: ["default"],
+						primary_model: { provider_id: "default", model: "gpt-test" },
+						paths: { home: TEST_HOSTED_HOME, workspace: TEST_HOSTED_WORKSPACE },
 						run: { command: "openclaw", args: ["gateway", "run"] },
 					},
 					hermes: {
 						enabled: true,
+						provider_ids: ["default"],
+						primary_model: { provider_id: "default", model: "gpt-test" },
+						paths: { home: TEST_HOSTED_HOME, workspace: TEST_HOSTED_WORKSPACE },
 						run: { command: "hermes", args: ["gateway", "run"] },
 					},
 				},

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -20,6 +20,7 @@ import {
 } from "./manifest";
 import {
 	hostedRuntimeManifestSchema,
+	manifestSchema,
 	OFFICIAL_INSTALL_ARGS,
 	OFFICIAL_INSTALL_URLS,
 } from "./manifest-contract";
@@ -115,7 +116,7 @@ function hostedManifestFixture(overrides: Record<string, unknown> = {}): Record<
 		controlPlane: { cloudApiUrl: "https://cloud-api.example.test" },
 		clawdiCli: {
 			source: "npm:clawdi",
-			packageSpec: "clawdi@agent-v2",
+			packageSpec: "clawdi@0.12.10-beta.51",
 			registry: "https://registry.npmjs.org",
 		},
 		providers: {
@@ -130,6 +131,7 @@ function hostedManifestFixture(overrides: Record<string, unknown> = {}): Record<
 		runtimes: {
 			openclaw: {
 				enabled: true,
+				install: { source: "official" },
 				provider_ids: ["default"],
 				primary_model: { provider_id: "default", model: "gpt-test" },
 				paths: { home: TEST_HOSTED_HOME, workspace: TEST_HOSTED_WORKSPACE },
@@ -148,6 +150,7 @@ function hostedRuntimeFixture(overrides: Record<string, unknown> = {}): Record<s
 			: {};
 	return {
 		enabled: true,
+		install: { source: "official" },
 		provider_ids: ["default"],
 		primary_model: { provider_id: "default", model: "gpt-test" },
 		...overrides,
@@ -345,6 +348,49 @@ describe("runtime manifest reconciliation invariants", () => {
 	});
 
 	test.each([
+		["missing install", { install: undefined }],
+		["remote install channel", { install: { source: "official", channel: "stable" } }],
+		["remote install args", { install: { source: "official", args: [] } }],
+	])("rejects hosted runtime with %s", (_name, overrides) => {
+		const runtime = hostedRuntimeFixture(overrides);
+		expect(
+			hostedRuntimeManifestSchema.safeParse(
+				hostedManifestFixture({ runtimes: { openclaw: runtime } }),
+			).success,
+		).toBe(false);
+	});
+
+	test("preserves generic runtime install defaults and provider model projections", () => {
+		const parsed = manifestSchema.parse({
+			schemaVersion: "clawdi.runtimeDesiredState.v1",
+			deploymentId: "dep_generic",
+			environmentId: "env_generic",
+			instanceId: "iid_generic",
+			generation: 1,
+			issuedAt: "2026-07-12T00:00:00.000Z",
+			controlPlane: { apiUrl: "https://cloud-api.example.test" },
+			runtimes: {
+				custom: {
+					enabled: true,
+					updateChannel: "stable",
+					install: {
+						authority: "official",
+						method: "official-installer",
+						url: "https://runtime.example.test/install.sh",
+						home: "/home/runtime",
+					},
+				},
+			},
+			projection: { providers: { default: { model: "legacy-model" } } },
+			recovery: {},
+		});
+
+		expect(parsed.runtimes.custom.install?.args).toEqual([]);
+		expect(parsed.runtimes.custom.updateChannel).toBe("stable");
+		expect(parsed.projection?.providers?.default).toEqual({ model: "legacy-model" });
+	});
+
+	test.each([
 		"system",
 		"system.user",
 		"system.home",
@@ -382,6 +428,102 @@ describe("runtime manifest reconciliation invariants", () => {
 				hostedManifestFixture({ providers: { default: provider } }),
 			).success,
 		).toBe(false);
+	});
+
+	test.each([
+		["empty provider", {}],
+		[
+			"unsupported kind",
+			{
+				kind: "anthropic-compatible",
+				type: "anthropic",
+				baseUrl: "https://api.anthropic.com",
+			},
+		],
+		["kind only", { kind: "openai-compatible" }],
+		[
+			"error status without error",
+			{
+				kind: "openai-compatible",
+				type: "custom_openai_compatible",
+				baseUrl: "https://provider.example.test/v1",
+				status: "error",
+			},
+		],
+		[
+			"error without error status",
+			{
+				kind: "openai-compatible",
+				type: "custom_openai_compatible",
+				baseUrl: "https://provider.example.test/v1",
+				error: { code: "provider_secret_unavailable" },
+			},
+		],
+		[
+			"non-not-found error without normal projection",
+			{
+				kind: "openai-compatible",
+				status: "error",
+				error: { code: "provider_secret_unavailable" },
+			},
+		],
+		[
+			"singular model alias",
+			{
+				kind: "openai-compatible",
+				type: "custom_openai_compatible",
+				baseUrl: "https://provider.example.test/v1",
+				model: "gpt-test",
+			},
+		],
+	])("rejects hosted manifests with %s", (_name, provider) => {
+		expect(
+			hostedRuntimeManifestSchema.safeParse(
+				hostedManifestFixture({ providers: { default: provider } }),
+			).success,
+		).toBe(false);
+	});
+
+	test.each([
+		[
+			"provider_not_found projection",
+			{
+				kind: "openai-compatible",
+				status: "error",
+				error: { code: "provider_not_found", message: "provider is missing" },
+			},
+		],
+		[
+			"provider_secret_unavailable projection",
+			{
+				kind: "openai-compatible",
+				type: "anthropic",
+				baseUrl: "https://api.anthropic.com",
+				apiMode: "anthropic_messages",
+				models: [{ id: "claude-opus-4-6" }],
+				runtimeEnvName: "ANTHROPIC_API_KEY",
+				apiKeyRequired: true,
+				status: "error",
+				error: { code: "provider_secret_unavailable" },
+			},
+		],
+		[
+			"healthy provider projection",
+			{
+				kind: "openai-compatible",
+				type: "custom_openai_compatible",
+				baseUrl: "https://provider.example.test/v1",
+				apiMode: "openai_chat",
+				models: [{ id: "gpt-test" }],
+				apiKeySecretRef: "provider.default.apiKey",
+			},
+		],
+	])("accepts Cloud %s", (_name, provider) => {
+		expect(
+			hostedRuntimeManifestSchema.safeParse(
+				hostedManifestFixture({ providers: { default: provider } }),
+			).success,
+		).toBe(true);
 	});
 
 	test.each([
@@ -434,9 +576,9 @@ describe("runtime manifest reconciliation invariants", () => {
 				runtimes: {
 					openclaw: {
 						enabled: true,
+						install: { source: "official" },
 						provider_ids: ["default"],
 						primary_model: { provider_id: "default", model: "gpt-test" },
-						install: { source: "official" },
 						paths: { home: paths.userHome, workspace },
 					},
 				},
@@ -536,19 +678,19 @@ describe("runtime manifest reconciliation invariants", () => {
 			name: "wrong source",
 			clawdiCli: {
 				source: "npm:other",
-				packageSpec: "clawdi@agent-v2",
+				packageSpec: "clawdi@0.12.10-beta.51",
 				registry: "https://registry.npmjs.org",
 			},
 		},
 		{
 			name: "missing registry",
-			clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@agent-v2" },
+			clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@0.12.10-beta.51" },
 		},
 		{
 			name: "non-official registry",
 			clawdiCli: {
 				source: "npm:clawdi",
-				packageSpec: "clawdi@agent-v2",
+				packageSpec: "clawdi@0.12.10-beta.51",
 				registry: "https://registry.example.test",
 			},
 		},
@@ -556,7 +698,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			name: "dead managed flags",
 			clawdiCli: {
 				source: "npm:clawdi",
-				packageSpec: "clawdi@agent-v2",
+				packageSpec: "clawdi@0.12.10-beta.51",
 				registry: "https://registry.npmjs.org",
 				managedConfig: true,
 				userEditableConfig: false,
@@ -585,10 +727,10 @@ describe("runtime manifest reconciliation invariants", () => {
 	});
 
 	test.each([
-		"clawdi@agent-v2",
 		"clawdi@0.12.10-beta.51",
-		"/usr/local/share/clawdi/bootstrap/clawdi-0.12.10-beta.51.tgz",
-	])("accepts hosted CLI package spec %s", (packageSpec) => {
+		"clawdi@1.2.3-rc-1.2",
+		"clawdi@1.2.3",
+	])("accepts exact hosted CLI package spec %s", (packageSpec) => {
 		expect(
 			hostedRuntimeManifestSchema.safeParse(
 				hostedManifestFixture({
@@ -603,12 +745,20 @@ describe("runtime manifest reconciliation invariants", () => {
 	});
 
 	test.each([
+		"clawdi@agent-v2",
 		"clawdi@latest",
 		"clawdi@beta",
 		"clawdi",
 		"clawdi@candidate",
+		"clawdi@1.2.3+build.1",
+		"clawdi@1.2.3-beta..1",
+		"clawdi@1.2.3-beta.",
+		"clawdi@1.2.3-.beta",
+		"clawdi@1.2.3-01",
+		"clawdi@01.2.3",
 		"./clawdi.tgz",
 		"/tmp/clawdi.tgz",
+		"/usr/local/share/clawdi/bootstrap/clawdi-0.12.10-beta.51.tgz",
 		"/usr/local/share/clawdi/bootstrap/../clawdi.tgz",
 		"/usr/local/share/clawdi/bootstrap/nested/clawdi.tgz",
 		"/usr/local/share/clawdi/bootstrap/clawdi..tgz",
@@ -648,7 +798,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				},
 				clawdiCli: {
 					source: "npm:clawdi",
-					packageSpec: "clawdi@agent-v2",
+					packageSpec: "clawdi@0.12.10-beta.51",
 					registry: "https://registry.npmjs.org",
 				},
 				runtimes: {
@@ -656,7 +806,7 @@ describe("runtime manifest reconciliation invariants", () => {
 						enabled: true,
 						provider_ids: ["default"],
 						primary_model: { provider_id: "default", model: "gpt-test" },
-						install: { source: "official", channel: "stable" },
+						install: { source: "official" },
 						run: {
 							command: "openclaw",
 							args: [
@@ -684,7 +834,7 @@ describe("runtime manifest reconciliation invariants", () => {
 						kind: "openai-compatible",
 						type: "custom_openai_compatible",
 						baseUrl: "https://api.example.test/v1",
-						model: "gpt-test",
+						models: [{ id: "gpt-test" }],
 						apiMode: "openai_chat",
 						apiKeySecretRef: "secret://providers/default/api-key",
 					},
@@ -736,7 +886,7 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(normalized.manifest.runtime).toBe("openclaw");
 		expect(Object.keys(normalized.manifest.runtimes)).toEqual(["openclaw"]);
 		expect(normalized.manifest.runtimes.openclaw.enabled).toBe(true);
-		expect(normalized.manifest.runtimes.openclaw.updateChannel).toBe("stable");
+		expect(normalized.manifest.runtimes.openclaw.updateChannel).toBeUndefined();
 		expect(normalized.manifest.runtimes.openclaw.install?.url).toBe(OFFICIAL_INSTALL_URLS.openclaw);
 		expect(normalized.manifest.runtimes.openclaw.install?.args).toEqual(
 			OFFICIAL_INSTALL_ARGS.openclaw,
@@ -784,7 +934,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				},
 				clawdiCli: {
 					source: "npm:clawdi",
-					packageSpec: "clawdi@agent-v2",
+					packageSpec: "clawdi@0.12.10-beta.51",
 					registry: "https://registry.npmjs.org",
 				},
 				providers: {
@@ -797,7 +947,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				liveSync: { enabled: false, agents: [] },
 				recovery: { cacheManifest: true, allowOfflineBoot: true },
 				runtimes: {
-					openclaw: hostedRuntimeFixture({ install: { source: "official" } }),
+					openclaw: hostedRuntimeFixture(),
 				},
 			}).success,
 		).toBe(false);
@@ -868,7 +1018,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			},
 			clawdiCli: {
 				source: "npm:clawdi",
-				packageSpec: "clawdi@agent-v2",
+				packageSpec: "clawdi@0.12.10-beta.51",
 				registry: "https://registry.npmjs.org",
 			},
 			runtimes: {
@@ -907,7 +1057,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				},
 				clawdiCli: {
 					source: "npm:clawdi",
-					packageSpec: "clawdi@agent-v2",
+					packageSpec: "clawdi@0.12.10-beta.51",
 					registry: "https://registry.npmjs.org",
 				},
 				providers: {
@@ -922,6 +1072,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				runtimes: {
 					openclaw: {
 						enabled: true,
+						install: { source: "official" },
 						provider_ids: ["default"],
 						primary_model: { provider_id: "default", model: "gpt-test" },
 						paths: { home: TEST_HOSTED_HOME, workspace: TEST_HOSTED_WORKSPACE },
@@ -929,6 +1080,7 @@ describe("runtime manifest reconciliation invariants", () => {
 					},
 					hermes: {
 						enabled: true,
+						install: { source: "official" },
 						provider_ids: ["default"],
 						primary_model: { provider_id: "default", model: "gpt-test" },
 						paths: { home: TEST_HOSTED_HOME, workspace: TEST_HOSTED_WORKSPACE },

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -34,6 +34,7 @@ import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
 const originalEnv = { ...process.env };
 const tempRoots: string[] = [];
 const TEST_HOSTED_LOCALE = { language: "en" as const, timezone: "UTC" };
+const TEST_HOSTED_MINIMUM_CLI_VERSION = "0.12.10-beta.51";
 
 function tempRuntimePaths(): RuntimePaths {
 	const root = mkdtempSync(join(tmpdir(), "clawdi-runtime-reconcile-test-"));
@@ -90,6 +91,7 @@ function baseManifest(
 function hostedManifestFixture(overrides: Record<string, unknown> = {}): Record<string, unknown> {
 	return {
 		schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+		minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 		runtime: "openclaw",
 		deploymentId: "hdep_locale",
 		environmentId: "env_locale",
@@ -185,6 +187,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			normalizeManifestPayload({
 				manifest: {
 					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "openclaw",
 					deploymentId: "hdep_missing_cli_policy",
 					environmentId: "env_missing_cli_policy",
@@ -198,6 +201,55 @@ describe("runtime manifest reconciliation invariants", () => {
 				secretValues: {},
 			}),
 		).toThrow(/clawdiCli/);
+	});
+
+	test.each([
+		["missing environmentId", {}],
+		["appId fallback", { appId: "app_legacy_identity" }],
+	])("rejects hosted manifests with %s", (_name, identity) => {
+		const manifest = hostedManifestFixture(identity);
+		delete manifest.environmentId;
+		expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(false);
+	});
+
+	test("uses only the hosted environmentId as the runtime environment identity", () => {
+		const parsed = hostedRuntimeManifestSchema.parse(
+			hostedManifestFixture({
+				deploymentId: "hdep_distinct_identity",
+				environmentId: "env_canonical_identity",
+			}),
+		);
+
+		expect(hostedManifestToRuntimeManifest(parsed).environmentId).toBe("env_canonical_identity");
+	});
+
+	test("rejects hosted manifests without a minimum CLI protocol floor", () => {
+		const manifest = hostedManifestFixture();
+		delete manifest.minimumCliVersion;
+		expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(false);
+	});
+
+	test.each([
+		["missing cloudApiUrl", {}],
+		[
+			"manifestUrl",
+			{
+				cloudApiUrl: "https://cloud-api.example.test",
+				manifestUrl: "https://cloud-api.example.test/v1/runtime/manifest",
+			},
+		],
+		[
+			"apiUrl",
+			{
+				cloudApiUrl: "https://cloud-api.example.test",
+				apiUrl: "https://cloud-api.example.test",
+			},
+		],
+		["unknown key", { cloudApiUrl: "https://cloud-api.example.test", unknown: true }],
+	])("rejects hosted controlPlane with %s", (_name, controlPlane) => {
+		expect(
+			hostedRuntimeManifestSchema.safeParse(hostedManifestFixture({ controlPlane })).success,
+		).toBe(false);
 	});
 
 	test.each([
@@ -236,6 +288,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			normalizeManifestPayload({
 				manifest: {
 					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "openclaw",
 					deploymentId: "hdep_invalid_cli_policy",
 					environmentId: "env_invalid_cli_policy",
@@ -252,10 +305,53 @@ describe("runtime manifest reconciliation invariants", () => {
 		).toThrow();
 	});
 
+	test.each([
+		"clawdi@agent-v2",
+		"clawdi@0.12.10-beta.51",
+		"/usr/local/share/clawdi/bootstrap/clawdi-0.12.10-beta.51.tgz",
+	])("accepts hosted CLI package spec %s", (packageSpec) => {
+		expect(
+			hostedRuntimeManifestSchema.safeParse(
+				hostedManifestFixture({
+					clawdiCli: {
+						source: "npm:clawdi",
+						packageSpec,
+						registry: "https://registry.npmjs.org",
+					},
+				}),
+			).success,
+		).toBe(true);
+	});
+
+	test.each([
+		"clawdi@latest",
+		"clawdi@beta",
+		"clawdi",
+		"clawdi@candidate",
+		"./clawdi.tgz",
+		"/tmp/clawdi.tgz",
+		"/usr/local/share/clawdi/bootstrap/../clawdi.tgz",
+		"/usr/local/share/clawdi/bootstrap/nested/clawdi.tgz",
+		"/usr/local/share/clawdi/bootstrap/clawdi..tgz",
+	])("rejects hosted CLI package spec %s", (packageSpec) => {
+		expect(
+			hostedRuntimeManifestSchema.safeParse(
+				hostedManifestFixture({
+					clawdiCli: {
+						source: "npm:clawdi",
+						packageSpec,
+						registry: "https://registry.npmjs.org",
+					},
+				}),
+			).success,
+		).toBe(false);
+	});
+
 	test("normalizes hosted manifest responses into runtime desired state without embedding secrets", () => {
 		const hostedResponse = {
 			manifest: {
 				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 				runtime: "openclaw",
 				deploymentId: "hdep_normalize",
 				environmentId: "env_normalize",
@@ -269,7 +365,6 @@ describe("runtime manifest reconciliation invariants", () => {
 				},
 				controlPlane: {
 					cloudApiUrl: "https://cloud-api.example.test",
-					manifestUrl: "https://cloud-api.example.test/v1/runtime/manifest",
 				},
 				clawdiCli: {
 					source: "npm:clawdi",
@@ -390,38 +485,88 @@ describe("runtime manifest reconciliation invariants", () => {
 		});
 	});
 
-	test("infers the hosted runtime when the manifest has one runtime entry", () => {
-		const hostedManifest = hostedRuntimeManifestSchema.parse({
-			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
-			deploymentId: "hdep_infer_runtime",
-			environmentId: "env_infer_runtime",
-			instanceId: "hri_infer_runtime",
-			generation: 1,
-			issuedAt: "2026-07-07T00:00:00.000Z",
-			locale: TEST_HOSTED_LOCALE,
-			controlPlane: {
-				cloudApiUrl: "https://cloud-api.example.test",
-			},
-			clawdiCli: {
-				source: "npm:clawdi",
-				packageSpec: "clawdi@agent-v2",
-				registry: "https://registry.npmjs.org",
-			},
-			runtimes: {
-				openclaw: {
-					enabled: true,
-					install: { source: "official" },
+	test("rejects a missing explicit runtime even with one runtime entry", () => {
+		expect(
+			hostedRuntimeManifestSchema.safeParse({
+				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
+				deploymentId: "hdep_infer_runtime",
+				environmentId: "env_infer_runtime",
+				instanceId: "hri_infer_runtime",
+				generation: 1,
+				issuedAt: "2026-07-07T00:00:00.000Z",
+				locale: TEST_HOSTED_LOCALE,
+				controlPlane: {
+					cloudApiUrl: "https://cloud-api.example.test",
 				},
-			},
-		});
-
-		expect(hostedManifest.runtime).toBe("openclaw");
-		expect(hostedManifestToRuntimeManifest(hostedManifest).runtime).toBe("openclaw");
+				clawdiCli: {
+					source: "npm:clawdi",
+					packageSpec: "clawdi@agent-v2",
+					registry: "https://registry.npmjs.org",
+				},
+				runtimes: {
+					openclaw: {
+						enabled: true,
+						install: { source: "official" },
+					},
+				},
+			}).success,
+		).toBe(false);
 	});
 
-	test("strips unknown hosted manifest fields while preserving the known contract", () => {
+	test.each([
+		["top level", (manifest: Record<string, unknown>) => ({ ...manifest, unknown: true })],
+		[
+			"system",
+			(manifest: Record<string, unknown>) => ({
+				...manifest,
+				system: { home: "/home/clawdi", unknown: true },
+			}),
+		],
+		[
+			"control plane",
+			(manifest: Record<string, unknown>) => ({
+				...manifest,
+				controlPlane: {
+					...(manifest.controlPlane as Record<string, unknown>),
+					unknown: true,
+				},
+			}),
+		],
+		[
+			"runtime entry",
+			(manifest: Record<string, unknown>) => ({
+				...manifest,
+				runtimes: {
+					openclaw: {
+						...((manifest.runtimes as Record<string, unknown>).openclaw as Record<string, unknown>),
+						unknown: true,
+					},
+				},
+			}),
+		],
+		[
+			"runtime run settings",
+			(manifest: Record<string, unknown>) => ({
+				...manifest,
+				runtimes: {
+					openclaw: {
+						...((manifest.runtimes as Record<string, unknown>).openclaw as Record<string, unknown>),
+						run: {
+							command: "openclaw",
+							args: ["gateway", "run"],
+							env: {},
+							prependPath: [],
+							unknown: true,
+						},
+					},
+				},
+			}),
+		],
+	])("rejects unknown hosted manifest fields at the %s", (_name, addUnknownField) => {
 		const cleanManifest = {
 			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+			minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 			runtime: "openclaw",
 			deploymentId: "hdep_forward_compat",
 			environmentId: "env_forward_compat",
@@ -450,31 +595,16 @@ describe("runtime manifest reconciliation invariants", () => {
 			},
 		};
 
-		const parsed = hostedRuntimeManifestSchema.parse({
-			...cleanManifest,
-			futureTopLevelField: { deployApiCanShipFirst: true },
-			runtimes: {
-				openclaw: {
-					...cleanManifest.runtimes.openclaw,
-					futureRuntimeField: "ignored",
-					run: {
-						...cleanManifest.runtimes.openclaw.run,
-						futureRunField: "ignored",
-					},
-				},
-			},
-		});
-
-		expect(parsed).toEqual(hostedRuntimeManifestSchema.parse(cleanManifest));
-		expect(parsed).not.toHaveProperty("futureTopLevelField");
-		expect(parsed.runtimes.openclaw).not.toHaveProperty("futureRuntimeField");
-		expect(parsed.runtimes.openclaw.run).not.toHaveProperty("futureRunField");
+		expect(hostedRuntimeManifestSchema.safeParse(addUnknownField(cleanManifest)).success).toBe(
+			false,
+		);
 	});
 
 	test("rejects hosted manifests that still declare multiple execution runtimes", () => {
 		expect(() =>
 			hostedRuntimeManifestSchema.parse({
 				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 				runtime: "openclaw",
 				deploymentId: "hdep_multi",
 				environmentId: "env_multi",

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -182,6 +182,155 @@ describe("runtime manifest reconciliation invariants", () => {
 		).toBe(false);
 	});
 
+	test.each([
+		["providerIds", { enabled: true, providerIds: ["default"] }],
+		[
+			"primaryModel",
+			{
+				enabled: true,
+				primaryModel: { provider_id: "default", model: "gpt-test" },
+			},
+		],
+		[
+			"primary_model.providerId",
+			{
+				enabled: true,
+				primary_model: { providerId: "default", model: "gpt-test" },
+			},
+		],
+		["string primary_model", { enabled: true, primary_model: "gpt-test" }],
+		[
+			"paths.stateDir",
+			{
+				enabled: true,
+				paths: { home: "/home/clawdi", workspace: "/workspace", stateDir: "/state" },
+			},
+		],
+	])("rejects noncanonical hosted runtime field %s", (_name, runtime) => {
+		expect(
+			hostedRuntimeManifestSchema.safeParse(
+				hostedManifestFixture({ runtimes: { openclaw: runtime } }),
+			).success,
+		).toBe(false);
+	});
+
+	test("copies canonical runtime provider bindings without backfill", () => {
+		const canonical = hostedRuntimeManifestSchema.parse(
+			hostedManifestFixture({
+				runtimes: {
+					openclaw: {
+						enabled: true,
+						provider_ids: ["default"],
+						primary_model: { provider_id: "default", model: "gpt-test" },
+					},
+				},
+			}),
+		);
+		expect(hostedManifestToRuntimeManifest(canonical).runtimes.openclaw).toMatchObject({
+			provider_ids: ["default"],
+			primary_model: { provider_id: "default", model: "gpt-test" },
+		});
+
+		const primaryOnly = hostedRuntimeManifestSchema.parse(
+			hostedManifestFixture({
+				runtimes: {
+					openclaw: {
+						enabled: true,
+						primary_model: { provider_id: "default", model: "gpt-test" },
+					},
+				},
+			}),
+		);
+		expect(
+			hostedManifestToRuntimeManifest(primaryOnly).runtimes.openclaw.provider_ids,
+		).toBeUndefined();
+	});
+
+	test.each([
+		["base_url", { base_url: "https://provider.example.test/v1" }],
+		["api_mode", { api_mode: "openai_chat" }],
+		["runtime_env_name", { runtime_env_name: "OPENAI_API_KEY" }],
+		["api_key_secret_ref", { api_key_secret_ref: "provider.default.apiKey" }],
+	])("rejects noncanonical hosted provider field %s", (_name, provider) => {
+		expect(
+			hostedRuntimeManifestSchema.safeParse(
+				hostedManifestFixture({ providers: { default: provider } }),
+			).success,
+		).toBe(false);
+	});
+
+	test.each([
+		"not-an-origin",
+		"ftp://app-v2.example.test",
+		"https://app-v2.example.test/path",
+		"https://user@app-v2.example.test",
+	])("rejects invalid OpenClaw Control UI origin %s", (origin) => {
+		expect(
+			hostedRuntimeManifestSchema.safeParse(
+				hostedManifestFixture({
+					system: { openclawControlUiAllowedOrigins: [origin] },
+				}),
+			).success,
+		).toBe(false);
+	});
+
+	test("preserves canonical OpenClaw Control UI origins through gateway projection", () => {
+		const paths = tempRuntimePaths();
+		const workspace = join(paths.userHome, "clawdi");
+		const openclawBin = join(paths.userHome, ".openclaw", "bin", "openclaw");
+		const patchPath = join(paths.serviceStateRoot, "openclaw-gateway-patch.json");
+		const allowedOrigins = ["https://app-v2-18789.k3s.example.test"];
+		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "0";
+		mkdirSync(dirname(openclawBin), { recursive: true });
+		writeFileSync(
+			openclawBin,
+			[
+				"#!/bin/sh",
+				'if [ "$1 $2 $3" = "config patch --stdin" ]; then',
+				`  cat > '${patchPath}'`,
+				"  exit 0",
+				"fi",
+				"exit 0",
+				"",
+			].join("\n"),
+		);
+		chmodSync(openclawBin, 0o700);
+
+		const hosted = hostedRuntimeManifestSchema.parse(
+			hostedManifestFixture({
+				system: {
+					home: paths.userHome,
+					workspace,
+					openclawControlUiAllowedOrigins: allowedOrigins,
+				},
+				runtimes: {
+					openclaw: {
+						enabled: true,
+						install: { source: "official" },
+						paths: { home: paths.userHome, workspace },
+					},
+				},
+			}),
+		);
+		const normalized = hostedManifestToRuntimeManifest(hosted);
+		expect(normalized.projection?.system).toEqual(hosted.system);
+
+		const result = convergeRuntimeManifest(
+			manifestLoad(normalized, "inline-hosted-control-ui-origins"),
+			paths,
+		);
+
+		expect(result.installErrors).toEqual([]);
+		expect(JSON.parse(readFileSync(patchPath, "utf8"))).toMatchObject({
+			gateway: {
+				controlUi: {
+					allowedOrigins,
+					dangerouslyDisableDeviceAuth: true,
+				},
+			},
+		});
+	});
+
 	test("rejects hosted manifests without an explicit CLI package policy", () => {
 		expect(() =>
 			normalizeManifestPayload({

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -118,6 +118,13 @@ function hostedManifestFixture(overrides: Record<string, unknown> = {}): Record<
 			packageSpec: "clawdi@agent-v2",
 			registry: "https://registry.npmjs.org",
 		},
+		providers: {
+			default: {
+				kind: "openai-compatible",
+				status: "error",
+				error: { code: "provider_not_found", message: "fixture provider unavailable" },
+			},
+		},
 		liveSync: { enabled: false, agents: [] },
 		recovery: { cacheManifest: true, allowOfflineBoot: true },
 		runtimes: {
@@ -208,6 +215,22 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(hostedRuntimeManifestSchema.safeParse(hostedManifestFixture({ locale })).success).toBe(
 			false,
 		);
+	});
+
+	test.each([
+		["missing providers", undefined],
+		["missing selected provider", {}],
+		[
+			"unselected provider",
+			{
+				default: { kind: "openai-compatible" },
+				extra: { kind: "openai-compatible" },
+			},
+		],
+	])("rejects hosted manifests with %s", (_name, providers) => {
+		expect(
+			hostedRuntimeManifestSchema.safeParse(hostedManifestFixture({ providers })).success,
+		).toBe(false);
 	});
 
 	test.each([
@@ -764,6 +787,13 @@ describe("runtime manifest reconciliation invariants", () => {
 					packageSpec: "clawdi@agent-v2",
 					registry: "https://registry.npmjs.org",
 				},
+				providers: {
+					default: {
+						kind: "openai-compatible",
+						status: "error",
+						error: { code: "provider_not_found" },
+					},
+				},
 				liveSync: { enabled: false, agents: [] },
 				recovery: { cacheManifest: true, allowOfflineBoot: true },
 				runtimes: {
@@ -879,6 +909,13 @@ describe("runtime manifest reconciliation invariants", () => {
 					source: "npm:clawdi",
 					packageSpec: "clawdi@agent-v2",
 					registry: "https://registry.npmjs.org",
+				},
+				providers: {
+					default: {
+						kind: "openai-compatible",
+						status: "error",
+						error: { code: "provider_not_found" },
+					},
 				},
 				liveSync: { enabled: false, agents: [] },
 				recovery: { cacheManifest: true, allowOfflineBoot: true },

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -33,6 +33,7 @@ import { type RuntimeRunSettings, runtimeRunConfigPath } from "./run-config";
 
 const originalEnv = { ...process.env };
 const tempRoots: string[] = [];
+const TEST_HOSTED_LOCALE = { language: "en" as const, timezone: "UTC" };
 
 function tempRuntimePaths(): RuntimePaths {
 	const root = mkdtempSync(join(tmpdir(), "clawdi-runtime-reconcile-test-"));
@@ -86,6 +87,27 @@ function baseManifest(
 	};
 }
 
+function hostedManifestFixture(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+		runtime: "openclaw",
+		deploymentId: "hdep_locale",
+		environmentId: "env_locale",
+		instanceId: "hri_locale",
+		generation: 1,
+		issuedAt: "2026-07-11T00:00:00.000Z",
+		locale: TEST_HOSTED_LOCALE,
+		controlPlane: { cloudApiUrl: "https://cloud-api.example.test" },
+		clawdiCli: {
+			source: "npm:clawdi",
+			packageSpec: "clawdi@agent-v2",
+			registry: "https://registry.npmjs.org",
+		},
+		runtimes: { openclaw: { enabled: true } },
+		...overrides,
+	};
+}
+
 function writeFakeGatewayCli(input: {
 	path: string;
 	runtime: "openclaw" | "hermes";
@@ -128,6 +150,36 @@ afterEach(() => {
 });
 
 describe("runtime manifest reconciliation invariants", () => {
+	test("accepts and preserves the exact hosted locale contract", () => {
+		const parsed = hostedRuntimeManifestSchema.parse(
+			hostedManifestFixture({ locale: { language: "zh-CN", timezone: "Asia/Shanghai" } }),
+		);
+		expect(parsed.locale).toEqual({ language: "zh-CN", timezone: "Asia/Shanghai" });
+		expect(hostedManifestToRuntimeManifest(parsed).locale).toEqual(parsed.locale);
+	});
+
+	test.each([
+		["missing locale", undefined],
+		["unknown locale key", { language: "en", timezone: "UTC", personality: "warm" }],
+		["malformed language", { language: "zh-cn", timezone: "UTC" }],
+		["unsupported language", { language: "en-US", timezone: "UTC" }],
+		["invalid timezone", { language: "en", timezone: "Mars/Olympus" }],
+	])("rejects hosted manifests with %s", (_name, locale) => {
+		expect(hostedRuntimeManifestSchema.safeParse(hostedManifestFixture({ locale })).success).toBe(
+			false,
+		);
+	});
+
+	test.each([
+		["language", "en"],
+		["timezone", "UTC"],
+		["personality", "warm"],
+	])("rejects the top-level %s compatibility field", (field, value) => {
+		expect(
+			hostedRuntimeManifestSchema.safeParse(hostedManifestFixture({ [field]: value })).success,
+		).toBe(false);
+	});
+
 	test("rejects hosted manifests without an explicit CLI package policy", () => {
 		expect(() =>
 			normalizeManifestPayload({
@@ -139,6 +191,7 @@ describe("runtime manifest reconciliation invariants", () => {
 					instanceId: "hri_missing_cli_policy",
 					generation: 1,
 					issuedAt: "2026-07-11T00:00:00.000Z",
+					locale: TEST_HOSTED_LOCALE,
 					controlPlane: { cloudApiUrl: "https://cloud-api.example.test" },
 					runtimes: { openclaw: { enabled: true } },
 				},
@@ -189,6 +242,7 @@ describe("runtime manifest reconciliation invariants", () => {
 					instanceId: "hri_invalid_cli_policy",
 					generation: 1,
 					issuedAt: "2026-07-11T00:00:00.000Z",
+					locale: TEST_HOSTED_LOCALE,
 					controlPlane: { cloudApiUrl: "https://cloud-api.example.test" },
 					clawdiCli,
 					runtimes: { openclaw: { enabled: true } },
@@ -208,6 +262,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				instanceId: "hri_normalize",
 				generation: 7,
 				issuedAt: "2026-07-01T00:00:00.000Z",
+				locale: TEST_HOSTED_LOCALE,
 				system: {
 					home: "/home/clawdi-test",
 					workspace: "/workspace/clawdi",
@@ -343,6 +398,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			instanceId: "hri_infer_runtime",
 			generation: 1,
 			issuedAt: "2026-07-07T00:00:00.000Z",
+			locale: TEST_HOSTED_LOCALE,
 			controlPlane: {
 				cloudApiUrl: "https://cloud-api.example.test",
 			},
@@ -372,6 +428,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			instanceId: "hri_forward_compat",
 			generation: 1,
 			issuedAt: "2026-07-01T00:00:00.000Z",
+			locale: TEST_HOSTED_LOCALE,
 			controlPlane: {
 				cloudApiUrl: "https://cloud-api.example.test",
 			},
@@ -424,6 +481,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				instanceId: "hri_multi",
 				generation: 1,
 				issuedAt: "2026-07-01T00:00:00.000Z",
+				locale: TEST_HOSTED_LOCALE,
 				controlPlane: {
 					cloudApiUrl: "https://cloud-api.example.test",
 				},

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -38,6 +38,16 @@ const TEST_HOSTED_MINIMUM_CLI_VERSION = "0.12.10-beta.51";
 const TEST_HOSTED_HOME = "/home/clawdi";
 const TEST_HOSTED_WORKSPACE = "/home/clawdi/clawdi";
 
+function hostedSystemFixture(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		user: "clawdi",
+		home: TEST_HOSTED_HOME,
+		workspace: TEST_HOSTED_WORKSPACE,
+		persistentPaths: [TEST_HOSTED_HOME, TEST_HOSTED_WORKSPACE],
+		...overrides,
+	};
+}
+
 function tempRuntimePaths(): RuntimePaths {
 	const root = mkdtempSync(join(tmpdir(), "clawdi-runtime-reconcile-test-"));
 	tempRoots.push(root);
@@ -101,7 +111,7 @@ function hostedManifestFixture(overrides: Record<string, unknown> = {}): Record<
 		generation: 1,
 		issuedAt: "2026-07-11T00:00:00.000Z",
 		locale: TEST_HOSTED_LOCALE,
-		system: { home: TEST_HOSTED_HOME, workspace: TEST_HOSTED_WORKSPACE },
+		system: hostedSystemFixture(),
 		controlPlane: { cloudApiUrl: "https://cloud-api.example.test" },
 		clawdiCli: {
 			source: "npm:clawdi",
@@ -277,8 +287,10 @@ describe("runtime manifest reconciliation invariants", () => {
 
 	test.each([
 		"system",
+		"system.user",
 		"system.home",
 		"system.workspace",
+		"system.persistentPaths",
 		"runtime.paths",
 		"runtime.paths.home",
 		"runtime.paths.workspace",
@@ -289,8 +301,10 @@ describe("runtime manifest reconciliation invariants", () => {
 		const runtime = runtimes.openclaw;
 		const paths = runtime.paths as Record<string, unknown>;
 		if (field === "system") delete manifest.system;
+		if (field === "system.user") delete system.user;
 		if (field === "system.home") delete system.home;
 		if (field === "system.workspace") delete system.workspace;
+		if (field === "system.persistentPaths") delete system.persistentPaths;
 		if (field === "runtime.paths") delete runtime.paths;
 		if (field === "runtime.paths.home") delete paths.home;
 		if (field === "runtime.paths.workspace") delete paths.workspace;
@@ -320,11 +334,9 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(
 			hostedRuntimeManifestSchema.safeParse(
 				hostedManifestFixture({
-					system: {
-						home: TEST_HOSTED_HOME,
-						workspace: TEST_HOSTED_WORKSPACE,
+					system: hostedSystemFixture({
 						openclawControlUiAllowedOrigins: [origin],
-					},
+					}),
 				}),
 			).success,
 		).toBe(false);
@@ -354,11 +366,12 @@ describe("runtime manifest reconciliation invariants", () => {
 
 		const hosted = hostedRuntimeManifestSchema.parse(
 			hostedManifestFixture({
-				system: {
+				system: hostedSystemFixture({
 					home: paths.userHome,
 					workspace,
+					persistentPaths: [paths.userHome, workspace],
 					openclawControlUiAllowedOrigins: allowedOrigins,
-				},
+				}),
 				runtimes: {
 					openclaw: {
 						enabled: true,
@@ -566,10 +579,11 @@ describe("runtime manifest reconciliation invariants", () => {
 				generation: 7,
 				issuedAt: "2026-07-01T00:00:00.000Z",
 				locale: TEST_HOSTED_LOCALE,
-				system: {
+				system: hostedSystemFixture({
 					home: "/home/clawdi-test",
 					workspace: "/workspace/clawdi",
-				},
+					persistentPaths: ["/home/clawdi-test", "/workspace/clawdi"],
+				}),
 				controlPlane: {
 					cloudApiUrl: "https://cloud-api.example.test",
 				},
@@ -705,6 +719,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				generation: 1,
 				issuedAt: "2026-07-07T00:00:00.000Z",
 				locale: TEST_HOSTED_LOCALE,
+				system: hostedSystemFixture(),
 				controlPlane: {
 					cloudApiUrl: "https://cloud-api.example.test",
 				},
@@ -714,10 +729,7 @@ describe("runtime manifest reconciliation invariants", () => {
 					registry: "https://registry.npmjs.org",
 				},
 				runtimes: {
-					openclaw: {
-						enabled: true,
-						install: { source: "official" },
-					},
+					openclaw: hostedRuntimeFixture({ install: { source: "official" } }),
 				},
 			}).success,
 		).toBe(false);
@@ -729,7 +741,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			"system",
 			(manifest: Record<string, unknown>) => ({
 				...manifest,
-				system: { home: "/home/clawdi", unknown: true },
+				system: hostedSystemFixture({ unknown: true }),
 			}),
 		],
 		[
@@ -821,7 +833,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				generation: 1,
 				issuedAt: "2026-07-01T00:00:00.000Z",
 				locale: TEST_HOSTED_LOCALE,
-				system: { home: TEST_HOSTED_HOME, workspace: TEST_HOSTED_WORKSPACE },
+				system: hostedSystemFixture(),
 				controlPlane: {
 					cloudApiUrl: "https://cloud-api.example.test",
 				},

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -118,6 +118,8 @@ function hostedManifestFixture(overrides: Record<string, unknown> = {}): Record<
 			packageSpec: "clawdi@agent-v2",
 			registry: "https://registry.npmjs.org",
 		},
+		liveSync: { enabled: false, agents: [] },
+		recovery: { cacheManifest: true, allowOfflineBoot: true },
 		runtimes: {
 			openclaw: {
 				enabled: true,
@@ -204,6 +206,40 @@ describe("runtime manifest reconciliation invariants", () => {
 		["invalid timezone", { language: "en", timezone: "Mars/Olympus" }],
 	])("rejects hosted manifests with %s", (_name, locale) => {
 		expect(hostedRuntimeManifestSchema.safeParse(hostedManifestFixture({ locale })).success).toBe(
+			false,
+		);
+	});
+
+	test.each([
+		["enabled without agents", { enabled: true, agents: [] }],
+		[
+			"disabled with agents",
+			{ enabled: false, agents: [{ agentType: "openclaw", environmentId: "env-live" }] },
+		],
+		[
+			"duplicate agents",
+			{
+				enabled: true,
+				agents: [
+					{ agentType: "openclaw", environmentId: "env-live" },
+					{ agentType: "openclaw", environmentId: "env-live" },
+				],
+			},
+		],
+		[
+			"environment id with surrounding whitespace",
+			{ enabled: true, agents: [{ agentType: "openclaw", environmentId: " env-live " }] },
+		],
+		[
+			"unsupported agent type",
+			{ enabled: true, agents: [{ agentType: "custom-runtime", environmentId: "env-live" }] },
+		],
+		[
+			"overlong environment id",
+			{ enabled: true, agents: [{ agentType: "openclaw", environmentId: "e".repeat(201) }] },
+		],
+	])("rejects hosted live sync with %s", (_name, liveSync) => {
+		expect(hostedRuntimeManifestSchema.safeParse(hostedManifestFixture({ liveSync })).success).toBe(
 			false,
 		);
 	});
@@ -728,6 +764,8 @@ describe("runtime manifest reconciliation invariants", () => {
 					packageSpec: "clawdi@agent-v2",
 					registry: "https://registry.npmjs.org",
 				},
+				liveSync: { enabled: false, agents: [] },
+				recovery: { cacheManifest: true, allowOfflineBoot: true },
 				runtimes: {
 					openclaw: hostedRuntimeFixture({ install: { source: "official" } }),
 				},
@@ -842,6 +880,8 @@ describe("runtime manifest reconciliation invariants", () => {
 					packageSpec: "clawdi@agent-v2",
 					registry: "https://registry.npmjs.org",
 				},
+				liveSync: { enabled: false, agents: [] },
+				recovery: { cacheManifest: true, allowOfflineBoot: true },
 				runtimes: {
 					openclaw: {
 						enabled: true,

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -451,6 +451,64 @@ describe("runtime manifest services", () => {
 		}
 	});
 
+	test("applies locale config without a systemd user manager when systemd apply is disabled", () => {
+		const paths = tempRuntimePaths();
+		const logPath = join(paths.runRoot, "openclaw-config.log");
+		const openclawCommand = join(paths.userHome, ".openclaw", "bin", "openclaw");
+		process.env.CLAWDI_SYSTEMD_APPLY = "0";
+		mkdirSync(dirname(openclawCommand), { recursive: true });
+		writeFileSync(
+			openclawCommand,
+			`#!/usr/bin/env bash
+set -euo pipefail
+test "$*" = "config patch --stdin"
+cat > '${logPath}'
+`,
+		);
+		chmodSync(openclawCommand, 0o700);
+		const manifest: RuntimeManifest = {
+			schemaVersion: "clawdi.runtimeDesiredState.v1",
+			deploymentId: "hdep_locale_no_systemd",
+			environmentId: "env_locale_no_systemd",
+			instanceId: "hri_locale_no_systemd",
+			generation: 1,
+			issuedAt: "2026-07-01T00:00:00.000Z",
+			workspaceRoot: join(paths.userHome, "clawdi"),
+			controlPlane: { apiUrl: "https://cloud-api.example.test" },
+			locale: { language: "en", timezone: "UTC" },
+			runtimes: {
+				openclaw: {
+					enabled: true,
+					install: {
+						authority: "official",
+						method: "official-installer",
+						url: "https://openclaw.ai/install-cli.sh",
+						home: paths.userHome,
+						args: [],
+					},
+					run: runSettings(openclawCommand, ["gateway", "run"]),
+					services: {},
+				},
+			},
+			recovery: {},
+		};
+
+		const result = convergeRuntimeManifest(
+			{
+				manifest,
+				source: "fixture-file",
+				sourcePath: "inline-locale-no-systemd",
+				offline: false,
+			},
+			paths,
+		);
+
+		expect(result.installErrors).toEqual([]);
+		expect(JSON.parse(readFileSync(logPath, "utf8"))).toEqual({
+			agents: { defaults: { userTimezone: "UTC" } },
+		});
+	});
+
 	test("skips hosted drop-ins when official install fails without a base unit", () => {
 		const paths = tempRuntimePaths();
 		const logPath = join(paths.runRoot, "official-service-commands.log");

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -9,6 +9,7 @@ import {
 import { hostedManifestEgressProfiles } from "./hosted-egress-profiles";
 import {
 	type HostedRuntimeManifest,
+	hostedRuntimeManifestFixtureResponseSchema,
 	hostedRuntimeManifestResponseSchema,
 	manifestSchema,
 	OFFICIAL_INSTALL_ARGS,
@@ -235,6 +236,27 @@ export function normalizeManifestPayload(value: unknown): {
 	if (internal.success) return { manifest: internal.data };
 
 	const hostedResponse = hostedRuntimeManifestResponseSchema.safeParse(value);
+	if (hostedResponse.success) {
+		return {
+			manifest: hostedManifestToRuntimeManifest(hostedResponse.data.manifest),
+			secretValues: normalizeSecretValues(hostedResponse.data.secretValues),
+		};
+	}
+	if (looksLikeHostedManifestResponse(value)) {
+		throw hostedResponse.error;
+	}
+
+	throw internal.error;
+}
+
+function normalizeManifestFixturePayload(value: unknown): {
+	manifest: RuntimeManifest;
+	secretValues?: Record<string, string>;
+} {
+	const internal = manifestSchema.safeParse(value);
+	if (internal.success) return { manifest: internal.data };
+
+	const hostedResponse = hostedRuntimeManifestFixtureResponseSchema.safeParse(value);
 	if (hostedResponse.success) {
 		return {
 			manifest: hostedManifestToRuntimeManifest(hostedResponse.data.manifest),
@@ -571,17 +593,13 @@ export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): 
 		runtimes: {
 			[selectedRuntime]: {
 				enabled: runtime.enabled,
-				updateChannel: runtime.install?.channel,
-				install:
-					runtime.enabled && runtime.install && OFFICIAL_INSTALL_URLS[selectedRuntime]
-						? {
-								authority: "official" as const,
-								method: "official-installer" as const,
-								url: OFFICIAL_INSTALL_URLS[selectedRuntime],
-								home: runtime.paths.home,
-								args: runtime.install.args ?? OFFICIAL_INSTALL_ARGS[selectedRuntime],
-							}
-						: undefined,
+				install: {
+					authority: "official" as const,
+					method: "official-installer" as const,
+					url: OFFICIAL_INSTALL_URLS[selectedRuntime],
+					home: runtime.paths.home,
+					args: OFFICIAL_INSTALL_ARGS[selectedRuntime],
+				},
 				run: hostedRuntimeRunSettings(runtime.run, runtime.paths.workspace),
 				services: Object.fromEntries(
 					Object.entries(runtime.services ?? {}).map(([service, run]) => [
@@ -839,7 +857,7 @@ export async function loadRuntimeManifest(
 	}
 	let normalized: { manifest: RuntimeManifest; secretValues?: Record<string, string> };
 	try {
-		normalized = normalizeManifestPayload(raw);
+		normalized = normalizeManifestFixturePayload(raw);
 	} catch (error) {
 		return {
 			mode: "manifest-rejected",

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -8,7 +8,6 @@ import {
 } from "./auth-token";
 import { hostedManifestEgressProfiles } from "./hosted-egress-profiles";
 import {
-	DEFAULT_CLAWDI_CLI_POLICY,
 	type HostedRuntimeManifest,
 	hostedRuntimeManifestResponseSchema,
 	manifestSchema,
@@ -567,13 +566,7 @@ export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): 
 		controlPlane: {
 			apiUrl: hostedControlPlaneApiUrl(hosted),
 		},
-		clawdiCli: hosted.clawdiCli
-			? {
-					...DEFAULT_CLAWDI_CLI_POLICY,
-					...hosted.clawdiCli,
-					source: hosted.clawdiCli.source ?? DEFAULT_CLAWDI_CLI_POLICY.source,
-				}
-			: { ...DEFAULT_CLAWDI_CLI_POLICY },
+		clawdiCli: { ...hosted.clawdiCli },
 		egressEngine: hosted.egressEngine,
 		runtimes: {
 			[selectedRuntime]: {

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -561,6 +561,7 @@ export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): 
 		minimumCliVersion: hosted.minimumCliVersion,
 		issuedAt: hosted.issuedAt,
 		expiresAt: hosted.expiresAt,
+		locale: hosted.locale,
 		workspaceRoot,
 		runtime: selectedRuntime,
 		controlPlane: {

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -555,7 +555,7 @@ export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): 
 	return {
 		schemaVersion: RUNTIME_DESIRED_STATE_SCHEMA_VERSION,
 		deploymentId: hosted.deploymentId,
-		environmentId: hosted.environmentId || hosted.appId || hosted.deploymentId,
+		environmentId: hosted.environmentId,
 		instanceId: hosted.instanceId,
 		generation: hosted.generation,
 		minimumCliVersion: hosted.minimumCliVersion,
@@ -565,7 +565,7 @@ export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): 
 		workspaceRoot,
 		runtime: selectedRuntime,
 		controlPlane: {
-			apiUrl: hostedControlPlaneApiUrl(hosted),
+			apiUrl: hosted.controlPlane.cloudApiUrl,
 		},
 		clawdiCli: { ...hosted.clawdiCli },
 		egressEngine: hosted.egressEngine,
@@ -678,33 +678,6 @@ function hostedRuntimeServiceRunSettings(
 			prependPath: [],
 		}
 	);
-}
-
-function hostedControlPlaneApiUrl(hosted: HostedRuntimeManifest): string {
-	const explicit = hosted.controlPlane.cloudApiUrl;
-	if (explicit) return explicit;
-	const manifestUrl = hosted.controlPlane.manifestUrl;
-	if (!manifestUrl) return new URL(runtimeManifestUrlFromEnvOrSource()).origin;
-	try {
-		return new URL(manifestUrl).origin;
-	} catch {
-		return new URL(runtimeManifestUrlFromEnvOrSource()).origin;
-	}
-}
-
-function runtimeManifestUrlFromEnvOrSource(): string {
-	const explicit = process.env.CLAWDI_RUNTIME_MANIFEST_URL?.trim();
-	if (explicit) return explicit;
-	if (process.env.CLAWDI_RUNTIME_MODE?.trim().toLowerCase() === "hosted") {
-		throw new Error("missing CLAWDI_RUNTIME_MANIFEST_URL");
-	}
-	const sourcePath =
-		process.env.CLAWDI_RUNTIME_SOURCE_PATH?.trim() || "/etc/clawdi/runtime-source.json";
-	if (existsSync(sourcePath)) {
-		const parsed = runtimeSourceSchema.safeParse(readJsonFile(sourcePath));
-		if (parsed.success) return parsed.data.url;
-	}
-	return "https://runtime.invalid/manifest";
 }
 
 function loadExistingState(paths: RuntimePaths): ExistingManifestState {

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -614,36 +614,9 @@ function hostedRuntimeProviderBinding(runtime: HostedRuntimeManifest["runtimes"]
 	provider_ids?: string[];
 	primary_model?: { provider_id: string; model: string };
 } {
-	const providerIds = runtime.provider_ids ?? runtime.providerIds;
-	const primary = runtime.primary_model ?? runtime.primaryModel;
-	const primaryRecord =
-		typeof primary === "object" && primary !== null && !Array.isArray(primary)
-			? (primary as Record<string, unknown>)
-			: null;
-	const primaryProviderId =
-		typeof primaryRecord?.provider_id === "string"
-			? primaryRecord.provider_id
-			: typeof primaryRecord?.providerId === "string"
-				? primaryRecord.providerId
-				: undefined;
-	const primaryModel =
-		typeof primaryRecord?.model === "string"
-			? primaryRecord.model
-			: typeof primary === "string"
-				? primary
-				: undefined;
-	const normalizedProviderIds = providerIds?.filter((id) => id.trim().length > 0);
-	const fallbackProviderIds =
-		primaryProviderId && !normalizedProviderIds?.includes(primaryProviderId)
-			? [...(normalizedProviderIds ?? []), primaryProviderId]
-			: normalizedProviderIds;
 	return {
-		...(fallbackProviderIds && fallbackProviderIds.length > 0
-			? { provider_ids: fallbackProviderIds }
-			: {}),
-		...(primaryProviderId && primaryModel
-			? { primary_model: { provider_id: primaryProviderId, model: primaryModel } }
-			: {}),
+		...(runtime.provider_ids ? { provider_ids: runtime.provider_ids } : {}),
+		...(runtime.primary_model ? { primary_model: runtime.primary_model } : {}),
 	};
 }
 

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -596,7 +596,7 @@ export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): 
 		projection: {
 			sourceSchemaVersion: hosted.schemaVersion,
 			system: hosted.system,
-			providers: hosted.providers ?? {},
+			providers: hosted.providers,
 			...(hosted.mcp === undefined ? {} : { mcp: hosted.mcp }),
 			...(hosted.tools === undefined ? {} : { tools: hosted.tools }),
 		},

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -266,12 +266,11 @@ function normalizeRemoteManifestPayload(
 function normalizeManifestFixturePayload(
 	value: unknown,
 	paths: RuntimePaths,
-	explicitSimulation: boolean,
 ): {
 	manifest: RuntimeManifest;
 	secretValues?: Record<string, string>;
 } {
-	if (paths.mode === "hosted" && !explicitSimulation) {
+	if (paths.mode === "hosted") {
 		const hostedResponse = hostedRuntimeManifestFixtureResponseSchema.parse(value);
 		return {
 			manifest: hostedManifestToRuntimeManifest(hostedResponse.manifest),
@@ -907,7 +906,7 @@ export async function loadRuntimeManifest(
 	}
 	let normalized: { manifest: RuntimeManifest; secretValues?: Record<string, string> };
 	try {
-		normalized = normalizeManifestFixturePayload(raw, paths, opts.manifestPath !== undefined);
+		normalized = normalizeManifestFixturePayload(raw, paths);
 	} catch (error) {
 		return {
 			mode: "manifest-rejected",
@@ -933,13 +932,7 @@ export async function loadRuntimeManifest(
 		};
 	}
 
-	return validateLoadedManifest(
-		normalized,
-		paths,
-		"fixture-file",
-		manifestPath,
-		opts.manifestPath !== undefined ? "generic" : undefined,
-	);
+	return validateLoadedManifest(normalized, paths, "fixture-file", manifestPath);
 }
 
 function loadLastGoodManifest(paths: RuntimePaths): RuntimeManifestLoad | RuntimeManifestFailure {
@@ -1081,17 +1074,11 @@ function validateLoadedManifest(
 	paths: RuntimePaths,
 	source: RuntimeManifestLoad["source"],
 	sourcePath: string,
-	trustDomainOverride?: "generic" | "hosted" | "hosted-fixture",
 ): RuntimeManifestLoad | RuntimeManifestFailure {
 	const existing = loadExistingState(paths);
 	const manifest = normalized.manifest;
 	const trustDomain =
-		trustDomainOverride ??
-		(paths.mode === "hosted"
-			? source === "fixture-file"
-				? "hosted-fixture"
-				: "hosted"
-			: "generic");
+		paths.mode === "hosted" ? (source === "fixture-file" ? "hosted-fixture" : "hosted") : "generic";
 	const semanticErrors = validateManifestSemantics(manifest, paths, trustDomain);
 	if (existing.instanceId && existing.instanceId !== manifest.instanceId) {
 		semanticErrors.push(

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { isAbsolute, join } from "node:path";
+import { isAbsolute } from "node:path";
 import { z } from "zod";
 import {
 	ensureRuntimeAuthTokenFile,
@@ -548,8 +548,7 @@ function runtimeFetchFailureStage(error: unknown): "network" | "auth" {
 }
 
 export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): RuntimeManifest {
-	const home = hosted.system?.home || "/home/clawdi";
-	const workspaceRoot = hosted.system?.workspace || join(home, "clawdi");
+	const workspaceRoot = hosted.system.workspace;
 	const selectedRuntime = hosted.runtime;
 	const runtime = hosted.runtimes[selectedRuntime];
 	return {
@@ -578,16 +577,16 @@ export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): 
 						? {
 								authority: "official" as const,
 								method: "official-installer" as const,
-								url: OFFICIAL_INSTALL_URLS[selectedRuntime] ?? "",
-								home: runtime.paths?.home || home,
-								args: runtime.install?.args ?? OFFICIAL_INSTALL_ARGS[selectedRuntime] ?? [],
+								url: OFFICIAL_INSTALL_URLS[selectedRuntime],
+								home: runtime.paths.home,
+								args: runtime.install.args ?? OFFICIAL_INSTALL_ARGS[selectedRuntime],
 							}
 						: undefined,
-				run: hostedRuntimeRunSettings(runtime.run, runtime.paths?.workspace, workspaceRoot),
+				run: hostedRuntimeRunSettings(runtime.run, runtime.paths.workspace),
 				services: Object.fromEntries(
 					Object.entries(runtime.services ?? {}).map(([service, run]) => [
 						service,
-						hostedRuntimeServiceRunSettings(run, runtime.paths?.workspace, workspaceRoot),
+						hostedRuntimeServiceRunSettings(run, runtime.paths.workspace),
 					]),
 				),
 				...hostedRuntimeProviderBinding(runtime),
@@ -596,7 +595,7 @@ export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): 
 		bridge: hosted.bridge,
 		projection: {
 			sourceSchemaVersion: hosted.schemaVersion,
-			system: hosted.system ?? null,
+			system: hosted.system,
 			providers: hosted.providers ?? {},
 			...(hosted.mcp === undefined ? {} : { mcp: hosted.mcp }),
 			...(hosted.tools === undefined ? {} : { tools: hosted.tools }),
@@ -611,22 +610,20 @@ export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): 
 }
 
 function hostedRuntimeProviderBinding(runtime: HostedRuntimeManifest["runtimes"][string]): {
-	provider_ids?: string[];
-	primary_model?: { provider_id: string; model: string };
+	provider_ids: string[];
+	primary_model: { provider_id: string; model: string };
 } {
 	return {
-		...(runtime.provider_ids ? { provider_ids: runtime.provider_ids } : {}),
-		...(runtime.primary_model ? { primary_model: runtime.primary_model } : {}),
+		provider_ids: runtime.provider_ids,
+		primary_model: runtime.primary_model,
 	};
 }
 
 function hostedRuntimeRunSettings(
 	run: RuntimeRunSettings | undefined,
-	runtimeWorkspace: string | undefined,
-	workspaceRoot: string,
-): RuntimeRunSettings | undefined {
-	if (!run && !runtimeWorkspace) return undefined;
-	const cwd = run?.cwd ?? runtimeWorkspace ?? workspaceRoot;
+	runtimeWorkspace: string,
+): RuntimeRunSettings {
+	const cwd = run?.cwd ?? runtimeWorkspace;
 	const settings: RuntimeRunSettings = {
 		env: run?.env ?? {},
 		cwd,
@@ -640,17 +637,9 @@ function hostedRuntimeRunSettings(
 
 function hostedRuntimeServiceRunSettings(
 	run: RuntimeRunSettings,
-	runtimeWorkspace: string | undefined,
-	workspaceRoot: string,
+	runtimeWorkspace: string,
 ): RuntimeRunSettings {
-	return (
-		hostedRuntimeRunSettings(run, runtimeWorkspace, workspaceRoot) ?? {
-			args: [],
-			env: {},
-			cwd: runtimeWorkspace ?? workspaceRoot,
-			prependPath: [],
-		}
-	);
+	return hostedRuntimeRunSettings(run, runtimeWorkspace);
 }
 
 function loadExistingState(paths: RuntimePaths): ExistingManifestState {

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -9,6 +9,8 @@ import {
 import { hostedManifestEgressProfiles } from "./hosted-egress-profiles";
 import {
 	type HostedRuntimeManifest,
+	hostedCliPayloadPolicySchema,
+	hostedFixtureCliPayloadPolicySchema,
 	hostedRuntimeManifestFixtureResponseSchema,
 	hostedRuntimeManifestResponseSchema,
 	manifestSchema,
@@ -249,10 +251,33 @@ export function normalizeManifestPayload(value: unknown): {
 	throw internal.error;
 }
 
-function normalizeManifestFixturePayload(value: unknown): {
+function normalizeRemoteManifestPayload(
+	value: unknown,
+	paths: RuntimePaths,
+): { manifest: RuntimeManifest; secretValues?: Record<string, string> } {
+	if (paths.mode !== "hosted") return normalizeManifestPayload(value);
+	const hostedResponse = hostedRuntimeManifestResponseSchema.parse(value);
+	return {
+		manifest: hostedManifestToRuntimeManifest(hostedResponse.manifest),
+		secretValues: normalizeSecretValues(hostedResponse.secretValues),
+	};
+}
+
+function normalizeManifestFixturePayload(
+	value: unknown,
+	paths: RuntimePaths,
+	explicitSimulation: boolean,
+): {
 	manifest: RuntimeManifest;
 	secretValues?: Record<string, string>;
 } {
+	if (paths.mode === "hosted" && !explicitSimulation) {
+		const hostedResponse = hostedRuntimeManifestFixtureResponseSchema.parse(value);
+		return {
+			manifest: hostedManifestToRuntimeManifest(hostedResponse.manifest),
+			secretValues: normalizeSecretValues(hostedResponse.secretValues),
+		};
+	}
 	const internal = manifestSchema.safeParse(value);
 	if (internal.success) return { manifest: internal.data };
 
@@ -506,7 +531,7 @@ export async function loadRemoteRuntimeManifest(
 
 	let normalized: { manifest: RuntimeManifest; secretValues?: Record<string, string> };
 	try {
-		normalized = normalizeManifestPayload(fetched.raw);
+		normalized = normalizeRemoteManifestPayload(fetched.raw, paths);
 	} catch (error) {
 		return {
 			mode: "manifest-rejected",
@@ -682,13 +707,27 @@ function manifestExpiryError(manifest: RuntimeManifest): string | null {
 	return null;
 }
 
-function validateManifestSemantics(manifest: RuntimeManifest, paths: RuntimePaths): string[] {
+function validateManifestSemantics(
+	manifest: RuntimeManifest,
+	paths: RuntimePaths,
+	trustDomain: "generic" | "hosted" | "hosted-fixture" = "generic",
+): string[] {
 	const errors: string[] = [];
 	const expiryError = manifestExpiryError(manifest);
 	if (expiryError) errors.push(expiryError);
 	if (!isAbsolute(paths.userHome)) errors.push(`runtime HOME must be absolute: ${paths.userHome}`);
 	if (manifest.workspaceRoot && !isAbsolute(manifest.workspaceRoot)) {
 		errors.push(`runtime workspaceRoot must be absolute: ${manifest.workspaceRoot}`);
+	}
+	if (trustDomain !== "generic") {
+		const cliPolicySchema =
+			trustDomain === "hosted-fixture"
+				? hostedFixtureCliPayloadPolicySchema
+				: hostedCliPayloadPolicySchema;
+		const cliPolicy = cliPolicySchema.safeParse(manifest.clawdiCli);
+		if (!cliPolicy.success) {
+			errors.push(...zodErrors(cliPolicy.error).map((error) => `clawdiCli.${error}`));
+		}
 	}
 	if (manifest.runtime) {
 		const runtime = manifest.runtime;
@@ -785,6 +824,17 @@ export async function loadRuntimeManifest(
 	opts: { manifestPath?: string } = {},
 ): Promise<RuntimeManifestLoad | RuntimeManifestFailure> {
 	const manifestPath = opts.manifestPath ?? runtimeManifestFixturePath();
+	if (
+		manifestPath &&
+		opts.manifestPath === undefined &&
+		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS !== "1"
+	) {
+		return {
+			mode: "repair",
+			stage: "local",
+			errors: ["CLAWDI_RUNTIME_MANIFEST_PATH requires CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS=1"],
+		};
+	}
 	if (!manifestPath) {
 		let fetched: { url: string; raw: unknown; etag?: string };
 		try {
@@ -810,7 +860,7 @@ export async function loadRuntimeManifest(
 
 		let normalized: { manifest: RuntimeManifest; secretValues?: Record<string, string> };
 		try {
-			normalized = normalizeManifestPayload(fetched.raw);
+			normalized = normalizeRemoteManifestPayload(fetched.raw, paths);
 		} catch (error) {
 			return {
 				mode: "manifest-rejected",
@@ -857,7 +907,7 @@ export async function loadRuntimeManifest(
 	}
 	let normalized: { manifest: RuntimeManifest; secretValues?: Record<string, string> };
 	try {
-		normalized = normalizeManifestFixturePayload(raw);
+		normalized = normalizeManifestFixturePayload(raw, paths, opts.manifestPath !== undefined);
 	} catch (error) {
 		return {
 			mode: "manifest-rejected",
@@ -883,7 +933,13 @@ export async function loadRuntimeManifest(
 		};
 	}
 
-	return validateLoadedManifest(normalized, paths, "fixture-file", manifestPath);
+	return validateLoadedManifest(
+		normalized,
+		paths,
+		"fixture-file",
+		manifestPath,
+		opts.manifestPath !== undefined ? "generic" : undefined,
+	);
 }
 
 function loadLastGoodManifest(paths: RuntimePaths): RuntimeManifestLoad | RuntimeManifestFailure {
@@ -903,12 +959,13 @@ function loadLastGoodManifest(paths: RuntimePaths): RuntimeManifestLoad | Runtim
 				errors: ["cached manifest does not allow offline boot"],
 			};
 		}
-		const expiryError = manifestExpiryError(manifest);
-		if (expiryError) {
+		const trustDomain = paths.mode === "hosted" ? "hosted" : "generic";
+		const semanticErrors = validateManifestSemantics(manifest, paths, trustDomain);
+		if (semanticErrors.length > 0) {
 			return {
 				mode: "repair",
 				stage: "local",
-				errors: [`cached ${expiryError}`],
+				errors: semanticErrors.map((error) => `cached ${error}`),
 			};
 		}
 		const secretRefs = manifestSecretRefs(manifest);
@@ -1024,10 +1081,18 @@ function validateLoadedManifest(
 	paths: RuntimePaths,
 	source: RuntimeManifestLoad["source"],
 	sourcePath: string,
+	trustDomainOverride?: "generic" | "hosted" | "hosted-fixture",
 ): RuntimeManifestLoad | RuntimeManifestFailure {
 	const existing = loadExistingState(paths);
 	const manifest = normalized.manifest;
-	const semanticErrors = validateManifestSemantics(manifest, paths);
+	const trustDomain =
+		trustDomainOverride ??
+		(paths.mode === "hosted"
+			? source === "fixture-file"
+				? "hosted-fixture"
+				: "hosted"
+			: "generic");
+	const semanticErrors = validateManifestSemantics(manifest, paths, trustDomain);
 	if (existing.instanceId && existing.instanceId !== manifest.instanceId) {
 		semanticErrors.push(
 			`manifest instanceId ${manifest.instanceId} does not match last-good instanceId ${existing.instanceId}`,

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -603,8 +603,8 @@ export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): 
 		liveSync: hosted.liveSync,
 		egressProfiles: hostedManifestEgressProfiles(hosted),
 		recovery: {
-			cacheManifest: hosted.recovery?.cacheManifest ?? true,
-			allowOfflineBoot: hosted.recovery?.allowOfflineBoot ?? true,
+			cacheManifest: hosted.recovery.cacheManifest,
+			allowOfflineBoot: hosted.recovery.allowOfflineBoot,
 		},
 	};
 }

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -669,7 +669,7 @@ function providerHealthReasons(
 	if (!stringValue(provider.model) && !providerHasModels(provider)) {
 		reasons.push("model_missing");
 	}
-	const apiMode = stringValue(provider.apiMode) ?? stringValue(provider.api_mode);
+	const apiMode = stringValue(provider.apiMode);
 	if (baseUrl && isOpenAiCompatibleMode(apiMode)) {
 		try {
 			const parsed = new URL(baseUrl);
@@ -1373,7 +1373,7 @@ function hostedProviderModels(
 }
 
 function hostedProviderApiMode(input: Record<string, unknown>): AiProviderApiMode {
-	const raw = typeof input.apiMode === "string" ? input.apiMode : input.api_mode;
+	const raw = input.apiMode;
 	if (typeof raw === "string" && isAiProviderApiMode(raw)) {
 		return raw;
 	}
@@ -1600,12 +1600,7 @@ function hostedProviderRequiresApiKey(input: Record<string, unknown>): boolean {
 const HOSTED_PROVIDER_FORBIDDEN_AGENT_ENV_NAMES = new Set(["CLAWDI_MANAGED_OPENAI_API_KEY"]);
 
 function hostedProviderRuntimeEnvName(providerId: string, input: Record<string, unknown>): string {
-	const raw =
-		typeof input.runtimeEnvName === "string"
-			? input.runtimeEnvName
-			: typeof input.runtime_env_name === "string"
-				? input.runtime_env_name
-				: null;
+	const raw = typeof input.runtimeEnvName === "string" ? input.runtimeEnvName : null;
 	if (raw && isEnvKey(raw) && !HOSTED_PROVIDER_FORBIDDEN_AGENT_ENV_NAMES.has(raw)) return raw;
 	if (
 		HOSTED_PROVIDER_FORBIDDEN_AGENT_ENV_NAMES.has(raw ?? "") &&
@@ -2048,10 +2043,9 @@ function hostedCodexManagedProvider(manifest: RuntimeManifest): HostedCodexManag
 		const provider = recordValue(raw);
 		if (!provider) continue;
 		if (provider.managed_by === "user") continue;
-		const runtimeEnvName =
-			stringValue(provider.runtimeEnvName) ?? stringValue(provider.runtime_env_name);
+		const runtimeEnvName = stringValue(provider.runtimeEnvName);
 		if (!runtimeEnvName || !CODEX_MANAGED_PROVIDER_ENV_KEYS.has(runtimeEnvName)) continue;
-		const baseUrl = stringValue(provider.baseUrl) ?? stringValue(provider.base_url);
+		const baseUrl = stringValue(provider.baseUrl);
 		if (!baseUrl?.trim()) continue;
 		entries.push({
 			priority: hostedCodexManagedProviderPriority(providerId),
@@ -2060,9 +2054,8 @@ function hostedCodexManagedProvider(manifest: RuntimeManifest): HostedCodexManag
 				providerId,
 				baseUrl: baseUrl.trim(),
 				model: stringValue(provider.model),
-				apiMode: stringValue(provider.apiMode) ?? stringValue(provider.api_mode),
-				apiKeySecretRef:
-					stringValue(provider.apiKeySecretRef) ?? stringValue(provider.api_key_secret_ref),
+				apiMode: stringValue(provider.apiMode),
+				apiKeySecretRef: stringValue(provider.apiKeySecretRef),
 			},
 		});
 	}

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -38,6 +38,7 @@ import {
 	mergeHermesChannelConfig,
 	mergeHermesConfig,
 	mergeHermesMcpServer,
+	mergeHermesRuntimeLocale,
 	removeHermesMcpServer,
 } from "../lib/hermes-config-merge";
 import { writePrivateFileAtomic } from "../lib/private-file";
@@ -125,6 +126,7 @@ export interface RuntimeConvergenceResult {
 		manifestLastGood: string | null;
 		installInventory: string[];
 		projections: string[];
+		managedLocaleFiles: string[];
 		runConfigs: string[];
 		systemdSystemUnitRoot: string;
 		systemdSystemUnits: string[];
@@ -1147,6 +1149,7 @@ function projectionPayload(name: string, manifest: RuntimeManifest): unknown {
 		runtime: name,
 		generation: manifest.generation,
 		instanceId: manifest.instanceId,
+		locale: manifest.locale ?? null,
 		managedBy: "clawdi runtime init",
 		target:
 			name === "openclaw"
@@ -1156,6 +1159,80 @@ function projectionPayload(name: string, manifest: RuntimeManifest): unknown {
 					: "clawdi mcp",
 		projection: projection ?? null,
 	};
+}
+
+const MANAGED_LOCALE_BLOCK_START = "<!-- >>> clawdi managed locale >>>";
+const MANAGED_LOCALE_BLOCK_END = "<!-- <<< clawdi managed locale <<< -->";
+
+function managedLocaleBlock(manifest: RuntimeManifest): string | null {
+	if (!manifest.locale) return null;
+	return [
+		MANAGED_LOCALE_BLOCK_START,
+		"## Clawdi managed locale",
+		"",
+		`Use \`${manifest.locale.language}\` as the default response language unless the user explicitly requests another language.`,
+		`Interpret ambiguous dates and times in \`${manifest.locale.timezone}\` unless the user specifies another timezone.`,
+		MANAGED_LOCALE_BLOCK_END,
+	].join("\n");
+}
+
+function updateManagedLocaleFile(path: string, block: string | null): string | null {
+	const existing = existsSync(path) ? readFileSync(path, "utf-8") : "";
+	const start = existing.indexOf(MANAGED_LOCALE_BLOCK_START);
+	const end = existing.indexOf(MANAGED_LOCALE_BLOCK_END);
+	const hasStart = start !== -1;
+	const hasEnd = end !== -1;
+	if (hasStart !== hasEnd || (hasStart && end < start)) {
+		throw new Error(`managed locale block markers are malformed in ${path}`);
+	}
+	if (
+		hasStart &&
+		(existing.indexOf(MANAGED_LOCALE_BLOCK_START, start + MANAGED_LOCALE_BLOCK_START.length) !==
+			-1 ||
+			existing.indexOf(MANAGED_LOCALE_BLOCK_END, end + MANAGED_LOCALE_BLOCK_END.length) !== -1)
+	) {
+		throw new Error(`managed locale block markers are duplicated in ${path}`);
+	}
+
+	let next = existing;
+	if (hasStart && hasEnd) {
+		const suffixStart = end + MANAGED_LOCALE_BLOCK_END.length;
+		next = `${existing.slice(0, start)}${block ?? ""}${existing.slice(suffixStart)}`;
+	} else if (block) {
+		const separator = existing.length === 0 ? "" : existing.endsWith("\n") ? "\n" : "\n\n";
+		next = `${existing}${separator}${block}\n`;
+	}
+
+	if (next === existing) return block ? path : null;
+	if (!block && next.length === 0) {
+		rmSync(path, { force: true });
+		return null;
+	}
+	writePrivateFileAtomic(path, next, { mode: 0o600, dirMode: 0o700 });
+	makeRuntimeUserOwned(path);
+	return block ? path : null;
+}
+
+function applyHostedLocaleProjection(
+	runtime: string,
+	manifest: RuntimeManifest,
+	home: string,
+	workspaceRoot: string,
+): string | null {
+	if (!manifest.locale) return null;
+	const block = managedLocaleBlock(manifest);
+	if (runtime === "openclaw") {
+		return updateManagedLocaleFile(join(workspaceRoot, "SOUL.md"), block);
+	}
+	if (runtime === "hermes") {
+		const hermesHome = join(home, ".hermes");
+		makeRuntimeUserPrivateDir(hermesHome);
+		const configPath = join(hermesHome, "config.yaml");
+		mergeHermesRuntimeLocale(configPath, manifest.locale.timezone);
+		makeRuntimeUserOwned(configPath);
+		return updateManagedLocaleFile(join(hermesHome, "SOUL.md"), block);
+	}
+	return null;
 }
 
 export function hostedAiProviderCatalog(
@@ -2821,29 +2898,42 @@ function staleProviderIds(
 function openClawGatewayHostedPatch(manifest: RuntimeManifest): Record<string, unknown> | null {
 	const allowedOrigins = openClawControlUiAllowedOrigins(manifest);
 	const gatewayToken = process.env[OPENCLAW_GATEWAY_TOKEN_ENV]?.trim();
-	if (allowedOrigins.length === 0 && !gatewayToken) return null;
+	if (allowedOrigins.length === 0 && !gatewayToken && !manifest.locale) return null;
 	return {
-		gateway: {
-			...(gatewayToken
-				? {
-						auth: {
-							mode: "token",
-							token: gatewayToken,
+		...(manifest.locale
+			? {
+					agents: {
+						defaults: {
+							userTimezone: manifest.locale.timezone,
 						},
-					}
-				: {}),
-			...(allowedOrigins.length > 0
-				? {
-						controlUi: {
-							allowedOrigins,
-							// Clawdi's runtime bridge owns browser auth for hosted Control UI
-							// traffic, so OpenClaw's local device-auth prompt would be a second
-							// owner gate behind the already-authenticated edge.
-							dangerouslyDisableDeviceAuth: true,
-						},
-					}
-				: {}),
-		},
+					},
+				}
+			: {}),
+		...(gatewayToken || allowedOrigins.length > 0
+			? {
+					gateway: {
+						...(gatewayToken
+							? {
+									auth: {
+										mode: "token",
+										token: gatewayToken,
+									},
+								}
+							: {}),
+						...(allowedOrigins.length > 0
+							? {
+									controlUi: {
+										allowedOrigins,
+										// Clawdi's runtime bridge owns browser auth for hosted Control UI
+										// traffic, so OpenClaw's local device-auth prompt would be a second
+										// owner gate behind the already-authenticated edge.
+										dangerouslyDisableDeviceAuth: true,
+									},
+								}
+							: {}),
+					},
+				}
+			: {}),
 	};
 }
 
@@ -3770,6 +3860,7 @@ export function runtimeProgramRevision(
 		clawdiCli: manifest.clawdiCli ?? null,
 		controlPlane: manifest.controlPlane,
 		egressProfiles: manifest.egressProfiles ?? null,
+		locale: manifest.locale ?? null,
 		projection: manifest.projection ?? null,
 		providerProjectionRevision,
 		runtime: manifest.runtimes[runtime] ?? null,
@@ -3788,6 +3879,7 @@ function runtimeServiceProgramRevision(
 		runtime: runtime,
 		service,
 		settings: manifest.runtimes[runtime]?.services?.[service] ?? null,
+		timezone: manifest.locale?.timezone ?? null,
 	});
 }
 
@@ -4639,6 +4731,7 @@ function writeSystemdUnits(
 		const runtimeEnvironment = {
 			...commonEnvironment,
 			...program.env,
+			...(manifest.locale ? { TZ: manifest.locale.timezone } : {}),
 			CLAWDI_AUTH_TOKEN: "",
 			CLAWDI_RUNTIME_REV: runtimeSystemdProgramRevision(
 				manifest,
@@ -4732,6 +4825,7 @@ export function convergeRuntimeManifest(
 	const instanceSemaphores: string[] = [];
 	const installInventory: string[] = [];
 	const projections: string[] = [];
+	const managedLocaleFiles: string[] = [];
 	const runConfigs: string[] = [];
 	const runtimeSystemdUserPrograms: RuntimeSystemdUserProgram[] = [];
 	const installErrors: string[] = [];
@@ -4761,6 +4855,7 @@ export function convergeRuntimeManifest(
 		environmentId: manifest.environmentId,
 		instanceId: manifest.instanceId,
 		generation: manifest.generation,
+		locale: manifest.locale ?? null,
 		controlPlane: manifest.controlPlane,
 		egressEngine: manifest.egressEngine ?? null,
 		auth: {
@@ -4776,6 +4871,7 @@ export function convergeRuntimeManifest(
 		environmentId: manifest.environmentId,
 		instanceId: manifest.instanceId,
 		generation: manifest.generation,
+		locale: manifest.locale ?? null,
 		runtimes: Object.fromEntries(
 			Object.entries(manifest.runtimes).map(([name, runtime]) => [
 				name,
@@ -4794,6 +4890,7 @@ export function convergeRuntimeManifest(
 		environmentId: manifest.environmentId,
 		instanceId: manifest.instanceId,
 		generation: manifest.generation,
+		locale: manifest.locale ?? null,
 		controlPlane: manifest.controlPlane,
 		workspaceRoot,
 	});
@@ -4913,6 +5010,21 @@ export function convergeRuntimeManifest(
 		const projectionPath = join(paths.projectionRoot, `${name}.json`);
 		writeJsonFile(projectionPath, projectionPayload(name, manifest));
 		projections.push(projectionPath);
+		try {
+			const localeFile = applyHostedLocaleProjection(
+				name,
+				manifest,
+				projectionSystemHome(manifest) ?? paths.userHome,
+				workspaceRoot,
+			);
+			if (localeFile) managedLocaleFiles.push(localeFile);
+		} catch (error) {
+			installErrors.push(
+				`runtime ${name} locale projection failed: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
+		}
 		try {
 			const providerProjection = applyHostedAiProviderProjection(
 				name,
@@ -5091,6 +5203,7 @@ export function convergeRuntimeManifest(
 			manifestLastGood,
 			installInventory,
 			projections,
+			managedLocaleFiles,
 			runConfigs,
 			systemdSystemUnitRoot: paths.systemdSystemRoot,
 			systemdSystemUnits: systemdUnits.systemUnits,

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1164,19 +1164,18 @@ function projectionPayload(name: string, manifest: RuntimeManifest): unknown {
 const MANAGED_LOCALE_BLOCK_START = "<!-- >>> clawdi managed locale >>>";
 const MANAGED_LOCALE_BLOCK_END = "<!-- <<< clawdi managed locale <<< -->";
 
-function managedLocaleBlock(manifest: RuntimeManifest): string | null {
-	if (!manifest.locale) return null;
+function managedLocaleBlock(locale: NonNullable<RuntimeManifest["locale"]>): string {
 	return [
 		MANAGED_LOCALE_BLOCK_START,
 		"## Clawdi managed locale",
 		"",
-		`Use \`${manifest.locale.language}\` as the default response language unless the user explicitly requests another language.`,
-		`Interpret ambiguous dates and times in \`${manifest.locale.timezone}\` unless the user specifies another timezone.`,
+		`Use \`${locale.language}\` as the default response language unless the user explicitly requests another language.`,
+		`Interpret ambiguous dates and times in \`${locale.timezone}\` unless the user specifies another timezone.`,
 		MANAGED_LOCALE_BLOCK_END,
 	].join("\n");
 }
 
-function updateManagedLocaleFile(path: string, block: string | null): string | null {
+function updateManagedLocaleFile(path: string, block: string): string {
 	const existing = existsSync(path) ? readFileSync(path, "utf-8") : "";
 	const start = existing.indexOf(MANAGED_LOCALE_BLOCK_START);
 	const end = existing.indexOf(MANAGED_LOCALE_BLOCK_END);
@@ -1194,23 +1193,19 @@ function updateManagedLocaleFile(path: string, block: string | null): string | n
 		throw new Error(`managed locale block markers are duplicated in ${path}`);
 	}
 
-	let next = existing;
+	let next: string;
 	if (hasStart && hasEnd) {
 		const suffixStart = end + MANAGED_LOCALE_BLOCK_END.length;
-		next = `${existing.slice(0, start)}${block ?? ""}${existing.slice(suffixStart)}`;
-	} else if (block) {
+		next = `${existing.slice(0, start)}${block}${existing.slice(suffixStart)}`;
+	} else {
 		const separator = existing.length === 0 ? "" : existing.endsWith("\n") ? "\n" : "\n\n";
 		next = `${existing}${separator}${block}\n`;
 	}
 
-	if (next === existing) return block ? path : null;
-	if (!block && next.length === 0) {
-		rmSync(path, { force: true });
-		return null;
-	}
+	if (next === existing) return path;
 	writePrivateFileAtomic(path, next, { mode: 0o600, dirMode: 0o700 });
 	makeRuntimeUserOwned(path);
-	return block ? path : null;
+	return path;
 }
 
 function applyHostedLocaleProjection(
@@ -1219,8 +1214,9 @@ function applyHostedLocaleProjection(
 	home: string,
 	workspaceRoot: string,
 ): string | null {
-	if (!manifest.locale) return null;
-	const block = managedLocaleBlock(manifest);
+	const locale = manifest.locale;
+	if (!locale) return null;
+	const block = managedLocaleBlock(locale);
 	if (runtime === "openclaw") {
 		return updateManagedLocaleFile(join(workspaceRoot, "SOUL.md"), block);
 	}
@@ -1228,7 +1224,7 @@ function applyHostedLocaleProjection(
 		const hermesHome = join(home, ".hermes");
 		makeRuntimeUserPrivateDir(hermesHome);
 		const configPath = join(hermesHome, "config.yaml");
-		mergeHermesRuntimeLocale(configPath, manifest.locale.timezone);
+		mergeHermesRuntimeLocale(configPath, locale.timezone);
 		makeRuntimeUserOwned(configPath);
 		return updateManagedLocaleFile(join(hermesHome, "SOUL.md"), block);
 	}
@@ -4587,13 +4583,7 @@ function removeStaleSystemdEnvironmentFiles(paths: RuntimePaths, writtenUnits: s
 	}
 }
 
-function runtimeManifestUrlEnv(manifest: RuntimeManifest, sourcePath: string): string {
-	const controlPlane = manifest.controlPlane;
-	const manifestUrl =
-		"manifestUrl" in controlPlane && typeof controlPlane.manifestUrl === "string"
-			? controlPlane.manifestUrl.trim()
-			: "";
-	if (manifestUrl) return manifestUrl;
+function runtimeManifestUrlEnv(sourcePath: string): string {
 	if (/^https?:\/\//i.test(sourcePath)) return sourcePath;
 	return process.env.CLAWDI_RUNTIME_MANIFEST_URL?.trim() || "";
 }
@@ -4621,7 +4611,7 @@ function writeSystemdUnits(
 		CLAWDI_RUNTIME_USER: runtimeUser,
 		CLAWDI_SERVICE_STATE_DIR: paths.serviceStateRoot,
 		CLAWDI_RUN_DIR: paths.runRoot,
-		CLAWDI_RUNTIME_MANIFEST_URL: runtimeManifestUrlEnv(manifest, sourcePath),
+		CLAWDI_RUNTIME_MANIFEST_URL: runtimeManifestUrlEnv(sourcePath),
 		[RUNTIME_BRIDGE_TOKEN_ENV]: "",
 		[RUNTIME_BRIDGE_LISTEN_HOST_ENV]: process.env[RUNTIME_BRIDGE_LISTEN_HOST_ENV]?.trim() ?? "",
 		[RUNTIME_BRIDGE_SURFACES_ENV]: "",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1338,12 +1338,13 @@ function hostedProviderModels(
 	primaryModel: AgentPrimaryModel | null,
 ): NonNullable<AiProviderCatalog["providers"][number]["models"]> {
 	const providerApiMode = hostedProviderApiMode(input);
-	const legacyModel = stringValue(input.model);
+	// Hosted wire rejects singular model; this fallback serves generic provider projections only.
+	const singularModel = stringValue(input.model);
 	if (hostedProviderManagedBy(input) === "clawdi") {
 		if (primaryModel) {
 			return [{ id: primaryModel.model, api_mode: providerApiMode }];
 		}
-		return legacyModel ? [{ id: legacyModel, api_mode: providerApiMode }] : [];
+		return singularModel ? [{ id: singularModel, api_mode: providerApiMode }] : [];
 	}
 
 	const rawModels = Array.isArray(input.models) ? input.models : [];
@@ -1361,8 +1362,8 @@ function hostedProviderModels(
 			};
 		})
 		.filter((model): model is NonNullable<typeof model> => model !== null);
-	if (legacyModel && !models.some((model) => model.id === legacyModel)) {
-		models.unshift({ id: legacyModel, api_mode: providerApiMode });
+	if (singularModel && !models.some((model) => model.id === singularModel)) {
+		models.unshift({ id: singularModel, api_mode: providerApiMode });
 	}
 	if (primaryModel && !models.some((model) => model.id === primaryModel.model)) {
 		models.unshift({ id: primaryModel.model, api_mode: providerApiMode });

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -3394,6 +3394,13 @@ function ensureRuntimeUserManagerReady(runtimeUser: string): void {
 	}
 }
 
+// Only official service installers may invoke systemctl --user. Config,
+// projection, plugin, and installer commands need privilege drop but not a manager.
+function ensureConfiguredRuntimeUserManagerReady(): void {
+	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
+	if (runtimeUser) ensureRuntimeUserManagerReady(runtimeUser);
+}
+
 function spawnRuntimeUserCommand(
 	command: string,
 	args: string[],
@@ -3404,7 +3411,6 @@ function spawnRuntimeUserCommand(
 	const env = runtimeUserCommandEnv(home, options);
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
 	if (runningAsRoot() && runtimeUser && runtimeUser !== "root") {
-		ensureRuntimeUserManagerReady(runtimeUser);
 		if (commandExists("gosu")) {
 			return spawnSync("gosu", [runtimeUser, command, ...args], {
 				env: { ...env, USER: runtimeUser, LOGNAME: runtimeUser },
@@ -3437,7 +3443,6 @@ function runRuntimeUserCommand(
 	const env = runtimeUserCommandEnv(home, options);
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim();
 	if (runningAsRoot() && runtimeUser && runtimeUser !== "root") {
-		ensureRuntimeUserManagerReady(runtimeUser);
 		if (commandExists("gosu")) {
 			execFileSync("gosu", [runtimeUser, command, ...args], {
 				input: stdin,
@@ -4452,6 +4457,7 @@ function installOfficialRuntimeUserService(
 		return `official ${runtimeSystemdProgramName(program)} service installer command is unavailable: ${program.command}`;
 	}
 	try {
+		ensureConfiguredRuntimeUserManagerReady();
 		runRuntimeUserCommand(program.command, args, "", paths.userHome, program.cwd);
 		return null;
 	} catch (error) {
@@ -4473,6 +4479,7 @@ function uninstallOfficialRuntimeUserService(input: {
 		return `official ${input.unitName} uninstaller command is unavailable: ${command}`;
 	}
 	try {
+		ensureConfiguredRuntimeUserManagerReady();
 		runRuntimeUserCommand(
 			command,
 			descriptor.uninstallArgs,

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -224,7 +224,7 @@ function providerReasons(provider: JsonRecord, secretAvailable: boolean | null):
 	} else {
 		try {
 			const parsed = new URL(baseUrl);
-			const apiMode = stringValue(provider.apiMode) ?? stringValue(provider.api_mode);
+			const apiMode = stringValue(provider.apiMode);
 			if (isOpenAiCompatibleMode(apiMode) && (!parsed.pathname || parsed.pathname === "/")) {
 				reasons.push("base_url_path_missing");
 			}

--- a/packages/cli/src/serve/sse-client.test.ts
+++ b/packages/cli/src/serve/sse-client.test.ts
@@ -129,6 +129,21 @@ describe("parseRecord", () => {
 		});
 	});
 
+	it("parses runtime manifest change signals", () => {
+		const record =
+			'event: runtime_manifest_changed\ndata: {"type":"runtime_manifest_changed","environment_id":"env-runtime-1"}';
+		expect(parseRecord(record)).toEqual({
+			type: "runtime_manifest_changed",
+			environment_id: "env-runtime-1",
+		});
+	});
+
+	it("rejects malformed runtime manifest change signals", () => {
+		const record =
+			'event: runtime_manifest_changed\ndata: {"type":"runtime_manifest_changed","environment_id":""}';
+		expect(parseRecord(record)).toBeNull();
+	});
+
 	it("ignores leading colon-comment lines (heartbeats)", () => {
 		// `: ping` is the SSE heartbeat the server emits every 25s.
 		// Mixed with a real event in the same record, the comment
@@ -136,7 +151,7 @@ describe("parseRecord", () => {
 		const record =
 			': ping\nevent: skill_changed\ndata: {"type":"skill_changed","skill_key":"a","project_id":"00000000-0000-0000-0000-000000000001","skills_revision":1}';
 		const parsed = parseRecord(record);
-		expect(parsed?.skill_key).toBe("a");
+		expect(parsed).toEqual(expect.objectContaining({ skill_key: "a" }));
 	});
 
 	it("strips a single optional space after the field colon", () => {
@@ -146,7 +161,7 @@ describe("parseRecord", () => {
 		// every event's JSON and break the parse.
 		const record = `event:skill_changed\ndata:{"type":"skill_changed","skill_key":"x","project_id":"00000000-0000-0000-0000-000000000001","skills_revision":1}`;
 		const parsed = parseRecord(record);
-		expect(parsed?.skill_key).toBe("x");
+		expect(parsed).toEqual(expect.objectContaining({ skill_key: "x" }));
 	});
 
 	it("concatenates multi-line data fields with newline", () => {
@@ -157,7 +172,7 @@ describe("parseRecord", () => {
 		const record =
 			'event: skill_changed\ndata: {"type":"skill_changed",\ndata: "skill_key":"multi","project_id":"00000000-0000-0000-0000-000000000001","skills_revision":2}';
 		const parsed = parseRecord(record);
-		expect(parsed?.skill_key).toBe("multi");
+		expect(parsed).toEqual(expect.objectContaining({ skill_key: "multi" }));
 	});
 
 	it("returns null for a record with no data field", () => {

--- a/packages/cli/src/serve/sse-client.ts
+++ b/packages/cli/src/serve/sse-client.ts
@@ -1,5 +1,5 @@
 /**
- * Outbound SSE consumer for `GET /api/sync/events`.
+ * Outbound SSE consumer for `GET /v1/sync/events`.
  *
  * Why outbound, not webhook: pods don't open inbound HTTP
  * servers (k8s ingress, NAT, no public domain), but they can
@@ -37,7 +37,7 @@ import { log, toErrorMessage } from "./log";
  * skill with the same skill_key. The phase-1 design defers
  * server-side filtering to phase 2; daemon-side filtering is the
  * v1 mitigation. */
-export type ServerEvent =
+export type SkillServerEvent =
 	| {
 			type: "skill_changed";
 			skill_key: string;
@@ -58,6 +58,13 @@ export type ServerEvent =
 			project_id: string;
 			skills_revision: number;
 	  };
+
+export type RuntimeManifestChangedEvent = {
+	type: "runtime_manifest_changed";
+	environment_id: string;
+};
+
+export type ServerEvent = SkillServerEvent | RuntimeManifestChangedEvent;
 
 const STALE_MS = 60_000;
 const HEARTBEAT_HINT_MS = 25_000;
@@ -357,7 +364,11 @@ export function parseRecord(record: string): ServerEvent | null {
 	if (!eventType || !dataPayload) return null;
 
 	try {
-		const parsed = JSON.parse(dataPayload) as ServerEvent;
+		const parsed = parseServerEvent(JSON.parse(dataPayload) as unknown);
+		if (!parsed) {
+			log.warn("sse.event_invalid", { event_type: eventType });
+			return null;
+		}
 		if (parsed.type !== eventType) {
 			log.warn("sse.event_type_mismatch", { header: eventType, body_type: parsed.type });
 		}
@@ -366,6 +377,41 @@ export function parseRecord(record: string): ServerEvent | null {
 		log.warn("sse.parse_failed", { record, error: toErrorMessage(e) });
 		return null;
 	}
+}
+
+function parseServerEvent(value: unknown): ServerEvent | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+	const event = value as Record<string, unknown>;
+	if (event.type === "runtime_manifest_changed") {
+		return typeof event.environment_id === "string" && event.environment_id.length > 0
+			? { type: event.type, environment_id: event.environment_id }
+			: null;
+	}
+	if (event.type !== "skill_changed" && event.type !== "skill_deleted") return null;
+	if (
+		typeof event.skill_key !== "string" ||
+		event.skill_key.length === 0 ||
+		typeof event.project_id !== "string" ||
+		event.project_id.length === 0 ||
+		typeof event.skills_revision !== "number" ||
+		!Number.isInteger(event.skills_revision)
+	) {
+		return null;
+	}
+	return event.type === "skill_changed"
+		? {
+				type: event.type,
+				skill_key: event.skill_key,
+				project_id: event.project_id,
+				skills_revision: event.skills_revision,
+				...(typeof event.content_hash === "string" ? { content_hash: event.content_hash } : {}),
+			}
+		: {
+				type: event.type,
+				skill_key: event.skill_key,
+				project_id: event.project_id,
+				skills_revision: event.skills_revision,
+			};
 }
 
 function errorInfo(err: unknown): { reason: string; http_status?: number; request_id?: string } {

--- a/packages/cli/src/serve/sync-engine.test.ts
+++ b/packages/cli/src/serve/sync-engine.test.ts
@@ -12,6 +12,7 @@ import {
 	heartbeatDelayMs,
 	isAuthFailure,
 	isOversizedUploadError,
+	isSkillSyncServerEvent,
 	lastSyncErrorForSseReconnect,
 	projectRefreshDelayMs,
 	reconcileDelayMs,
@@ -19,6 +20,17 @@ import {
 	rememberPendingSkillUploadEcho,
 	resolveOwningSkillKey,
 } from "./sync-engine";
+
+describe("daemon SSE routing", () => {
+	it("ignores runtime manifest notifications without dispatching skill work", () => {
+		expect(
+			isSkillSyncServerEvent({
+				type: "runtime_manifest_changed",
+				environment_id: "env-runtime-1",
+			}),
+		).toBe(false);
+	});
+});
 
 describe("isAuthFailure", () => {
 	// Pull-side and push-side both rely on this classifier to decide

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -70,8 +70,17 @@ import { log, toErrorMessage } from "./log";
 import { getServeStateDir } from "./paths";
 import { type QueueItem, RetryQueue } from "./queue";
 import { watchSessions } from "./sessions-watcher";
-import { consumeSse, type ServerEvent, type SseReconnectInfo } from "./sse-client";
+import {
+	consumeSse,
+	type ServerEvent,
+	type SkillServerEvent,
+	type SseReconnectInfo,
+} from "./sse-client";
 import { watchSkills } from "./watcher";
+
+export function isSkillSyncServerEvent(event: ServerEvent): event is SkillServerEvent {
+	return event.type === "skill_changed" || event.type === "skill_deleted";
+}
 
 type SkillSummary = components["schemas"]["SkillSummaryResponse"];
 
@@ -560,6 +569,13 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 	// is defense-in-depth in case a future broker bug fans out
 	// without filtering.
 	const onServerEvent = async (event: ServerEvent) => {
+		if (!isSkillSyncServerEvent(event)) {
+			log.debug("engine.sse_event_ignored", {
+				type: event.type,
+				environment_id: event.environment_id,
+			});
+			return;
+		}
 		if (event.project_id !== defaultProjectId) {
 			log.debug("engine.sse_event_other_project", {
 				type: event.type,

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const workflow = readFileSync(
+	resolve(import.meta.dir, "../../../.github/workflows/cli-publish.yml"),
+	"utf8",
+);
+
+describe("CLI publish workflow contract", () => {
+	test("gates the protected OIDC publish on the reusable Hosted paired smoke", () => {
+		const build = workflow.indexOf("  build-immutable-artifact:");
+		const smoke = workflow.indexOf("  hosted-paired-smoke:");
+		const publish = workflow.indexOf("  publish-paired-artifact-with-oidc:");
+
+		expect(build).toBeGreaterThan(-1);
+		expect(smoke).toBeGreaterThan(build);
+		expect(publish).toBeGreaterThan(smoke);
+		expect(workflow).toContain(
+			"uses: Clawdi-AI/clawdi-hosted/.github/workflows/hosted-runtime-paired-smoke.yml@main",
+		);
+		expect(workflow).toContain("cli_artifact_name: clawdi-cli-release");
+		expect(workflow).toContain(
+			'echo "cli_tarball_filename=clawdi-$version.tgz" >> "$GITHUB_OUTPUT"',
+		);
+		expect(workflow).toContain(
+			`cli_tarball_filename: \${{ needs['build-immutable-artifact'].outputs.cli_tarball_filename }}`,
+		);
+		expect(workflow).toContain("needs: [build-immutable-artifact, hosted-paired-smoke]");
+		expect(workflow).toContain("environment: npm");
+		expect(workflow).toContain("id-token: write");
+	});
+
+	test("publishes the paired-smoked tarball exactly once to agent-v2", () => {
+		const publishCommands = workflow.match(/npm publish /g) ?? [];
+
+		expect(publishCommands).toHaveLength(1);
+		expect(workflow).toContain(
+			'npm publish "release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag agent-v2',
+		);
+		expect(workflow).toContain("CLI_ARTIFACT_NAME: clawdi-cli-release");
+		expect(workflow).toContain(
+			`CLI_TARBALL_FILENAME: \${{ needs['build-immutable-artifact'].outputs.cli_tarball_filename }}`,
+		);
+		expect(workflow).toContain('tarball="$CLI_TARBALL_FILENAME"');
+		expect(workflow).toContain(`name: \${{ env.CLI_ARTIFACT_NAME }}`);
+		expect(workflow.match(/npm pack /g) ?? []).toHaveLength(1);
+		expect(workflow.indexOf("npm pack ")).toBeLessThan(workflow.indexOf("  hosted-paired-smoke:"));
+		expect(workflow).not.toContain("agent-v2-candidate");
+		expect(workflow).not.toContain("npm dist-tag");
+		expect(workflow).not.toContain("NPM_TOKEN");
+	});
+
+	test("keeps ordinary pull request CI repo-local", () => {
+		expect(workflow).not.toContain("pull_request:");
+	});
+});

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -71,8 +71,10 @@ describe("CLI publish workflow contract", () => {
 			'npm publish "release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag "$NPM_TAG"',
 		);
 		expect(expectedNpmTag(cliPackage)).toBe("agent-v2-candidate");
+		expect(cliPackage.version).toContain("-");
 		expect(expectedNpmTag({ version: "1.2.3-beta.1" })).toBe("beta");
 		expect(expectedNpmTag({ version: "1.2.3" })).toBe("latest");
+		expect(workflow).toContain("node scripts/check-publish-manifest.mjs");
 		expect(workflow).toContain("p.version.includes('-') ? 'beta' : 'latest'");
 		expect(workflow).toContain("CLI_ARTIFACT_NAME: clawdi-cli-release");
 		expect(workflow).toContain(

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -18,6 +18,13 @@ const manifestContract = readFileSync(
 	resolve(import.meta.dir, "../src/runtime/manifest-contract.ts"),
 	"utf8",
 );
+const cliPackage = JSON.parse(
+	readFileSync(resolve(import.meta.dir, "../package.json"), "utf8"),
+) as { version: string; publishConfig?: { tag?: string } };
+
+function expectedNpmTag(pkg: { version: string; publishConfig?: { tag?: string } }): string {
+	return pkg.publishConfig?.tag || (pkg.version.includes("-") ? "beta" : "latest");
+}
 
 describe("CLI publish workflow contract", () => {
 	test("keeps the protected OIDC publish fully repository-local", () => {
@@ -53,9 +60,20 @@ describe("CLI publish workflow contract", () => {
 		const publishCommands = workflow.match(/npm publish /g) ?? [];
 
 		expect(publishCommands).toHaveLength(1);
+		expect(workflow).toContain('echo "npm_tag=$npm_tag" >> "$GITHUB_OUTPUT"');
 		expect(workflow).toContain(
-			'npm publish "release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag agent-v2-candidate',
+			"p.publishConfig?.tag || (p.version.includes('-') ? 'beta' : 'latest')",
 		);
+		expect(workflow).toContain(
+			`NPM_TAG: \${{ needs['build-immutable-artifact'].outputs.npm_tag }}`,
+		);
+		expect(workflow).toContain(
+			'npm publish "release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag "$NPM_TAG"',
+		);
+		expect(expectedNpmTag(cliPackage)).toBe("agent-v2-candidate");
+		expect(expectedNpmTag({ version: "1.2.3-beta.1" })).toBe("beta");
+		expect(expectedNpmTag({ version: "1.2.3" })).toBe("latest");
+		expect(workflow).toContain("p.version.includes('-') ? 'beta' : 'latest'");
 		expect(workflow).toContain("CLI_ARTIFACT_NAME: clawdi-cli-release");
 		expect(workflow).toContain(
 			`CLI_TARBALL_FILENAME: \${{ needs['build-immutable-artifact'].outputs.cli_tarball_filename }}`,

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -6,8 +6,8 @@ const workflow = readFileSync(
 	resolve(import.meta.dir, "../../../.github/workflows/cli-publish.yml"),
 	"utf8",
 );
-const managedRuntimeDoc = readFileSync(
-	resolve(import.meta.dir, "../../../docs/managed-runtime.md"),
+const releaseRunbookDoc = readFileSync(
+	resolve(import.meta.dir, "../../../docs/runbooks/release.md"),
 	"utf8",
 );
 const cliDevelopmentDoc = readFileSync(
@@ -82,12 +82,19 @@ describe("CLI publish workflow contract", () => {
 	});
 
 	test("keeps Hosted production semantics exact-version only", () => {
-		for (const surface of [workflow, managedRuntimeDoc, cliDevelopmentDoc, manifestContract]) {
+		for (const surface of [workflow, cliDevelopmentDoc, releaseRunbookDoc, manifestContract]) {
 			expect(surface).not.toMatch(/clawdi@agent-v2(?!-)/);
 		}
 		expect(workflow).toContain("npm install -g clawdi@$VERSION");
-		expect(managedRuntimeDoc).toContain("exact `clawdi@<semver>` without build metadata");
-		expect(managedRuntimeDoc).toContain("Remote fetches cannot use that fixture schema");
+		expect(cliDevelopmentDoc).toContain("supplies the exact `clawdi@<semver>` package spec");
+		expect(cliDevelopmentDoc).toContain("fails closed when the exact input is missing");
+		expect(releaseRunbookDoc).toContain("supplies the exact `clawdi@<semver>` package spec");
+		expect(releaseRunbookDoc).toContain("fails when the exact spec is missing");
+		for (const surface of [cliDevelopmentDoc, releaseRunbookDoc]) {
+			expect(surface).toMatch(/never\s+resolves\s+`agent-v2-candidate` or any other npm dist-tag/);
+			expect(surface).not.toContain("resolves that candidate");
+		}
+		expect(manifestContract).toContain("must be clawdi@<exact-semver>");
 		expect(workflow).not.toContain("npm view clawdi@agent-v2");
 	});
 });

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -14,16 +14,20 @@ const cliDevelopmentDoc = readFileSync(
 	resolve(import.meta.dir, "../../../docs/cli-development.md"),
 	"utf8",
 );
+const publishManifestChecker = readFileSync(
+	resolve(import.meta.dir, "../scripts/check-publish-manifest.mjs"),
+	"utf8",
+);
 const manifestContract = readFileSync(
 	resolve(import.meta.dir, "../src/runtime/manifest-contract.ts"),
 	"utf8",
 );
 const cliPackage = JSON.parse(
 	readFileSync(resolve(import.meta.dir, "../package.json"), "utf8"),
-) as { version: string; publishConfig?: { tag?: string } };
+) as { version: string; publishConfig?: { access?: string; tag?: unknown } };
 
-function expectedNpmTag(pkg: { version: string; publishConfig?: { tag?: string } }): string {
-	return pkg.publishConfig?.tag || (pkg.version.includes("-") ? "beta" : "latest");
+function expectedNpmTag(version: string): string {
+	return version.includes("-") ? "beta" : "latest";
 }
 
 describe("CLI publish workflow contract", () => {
@@ -61,21 +65,26 @@ describe("CLI publish workflow contract", () => {
 
 		expect(publishCommands).toHaveLength(1);
 		expect(workflow).toContain('echo "npm_tag=$npm_tag" >> "$GITHUB_OUTPUT"');
-		expect(workflow).toContain(
-			"p.publishConfig?.tag || (p.version.includes('-') ? 'beta' : 'latest')",
-		);
+		expect(workflow).toContain("p.version.includes('-') ? 'beta' : 'latest'");
+		expect(workflow).not.toContain("publishConfig");
 		expect(workflow).toContain(
 			`NPM_TAG: \${{ needs['build-immutable-artifact'].outputs.npm_tag }}`,
 		);
 		expect(workflow).toContain(
 			'npm publish "release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag "$NPM_TAG"',
 		);
-		expect(expectedNpmTag(cliPackage)).toBe("agent-v2-candidate");
 		expect(cliPackage.version).toContain("-");
-		expect(expectedNpmTag({ version: "1.2.3-beta.1" })).toBe("beta");
-		expect(expectedNpmTag({ version: "1.2.3" })).toBe("latest");
+		expect(expectedNpmTag(cliPackage.version)).toBe("beta");
+		expect(expectedNpmTag("1.2.3-beta.1")).toBe("beta");
+		expect(expectedNpmTag("1.2.3")).toBe("latest");
+		expect(cliPackage.publishConfig).toEqual({ access: "public" });
+		expect(publishManifestChecker).toContain(
+			'Object.hasOwn(packageJson.publishConfig ?? {}, "tag")',
+		);
+		expect(publishManifestChecker).toContain(
+			"published CLI package must not declare publishConfig.tag",
+		);
 		expect(workflow).toContain("node scripts/check-publish-manifest.mjs");
-		expect(workflow).toContain("p.version.includes('-') ? 'beta' : 'latest'");
 		expect(workflow).toContain("CLI_ARTIFACT_NAME: clawdi-cli-release");
 		expect(workflow).toContain(
 			`CLI_TARBALL_FILENAME: \${{ needs['build-immutable-artifact'].outputs.cli_tarball_filename }}`,
@@ -113,9 +122,7 @@ describe("CLI publish workflow contract", () => {
 		expect(releaseRunbookDoc).toMatch(/supplies the exact\s+`clawdi@<semver>`\s+package\s+spec/);
 		expect(releaseRunbookDoc).toMatch(/fails when the exact spec is\s+missing/);
 		for (const surface of [cliDevelopmentDoc, releaseRunbookDoc]) {
-			expect(surface).toMatch(
-				/never\s+resolves\s+`agent-v2-candidate`\s+or\s+any\s+other\s+npm\s+dist-tag/,
-			);
+			expect(surface).toMatch(/never\s+resolves\s+an\s+npm\s+dist-tag/);
 			expect(surface).not.toContain("resolves that candidate");
 		}
 		expect(manifestContract).toContain("must be clawdi@<exact-semver>");

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -6,20 +6,42 @@ const workflow = readFileSync(
 	resolve(import.meta.dir, "../../../.github/workflows/cli-publish.yml"),
 	"utf8",
 );
+const managedRuntimeDoc = readFileSync(
+	resolve(import.meta.dir, "../../../docs/managed-runtime.md"),
+	"utf8",
+);
+const cliDevelopmentDoc = readFileSync(
+	resolve(import.meta.dir, "../../../docs/cli-development.md"),
+	"utf8",
+);
+const manifestContract = readFileSync(
+	resolve(import.meta.dir, "../src/runtime/manifest-contract.ts"),
+	"utf8",
+);
 
 describe("CLI publish workflow contract", () => {
 	test("keeps the protected OIDC publish fully repository-local", () => {
 		const build = workflow.indexOf("  build-immutable-artifact:");
 		const publish = workflow.indexOf("  publish-immutable-artifact-with-oidc:");
+		const buildJob = workflow.slice(build, publish);
+		const publishJob = workflow.slice(publish);
 
 		expect(build).toBeGreaterThan(-1);
 		expect(publish).toBeGreaterThan(build);
+		expect(buildJob).toContain(
+			`runs-on: \${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}`,
+		);
+		expect(publishJob).toContain("runs-on: ubuntu-latest");
+		expect(publishJob).not.toContain("vars.CI_RUNNER");
 		expect(workflow).toContain(
 			'echo "cli_tarball_filename=clawdi-$version.tgz" >> "$GITHUB_OUTPUT"',
 		);
 		expect(workflow).toContain("needs: build-immutable-artifact");
 		expect(workflow).toContain("environment: npm");
 		expect(workflow).toContain("id-token: write");
+		expect(publishJob).toContain('node-version: "24"');
+		expect(publishJob).toContain("npm install --global npm@11.5.1");
+		expect(publishJob).toContain('test "$(npm --version)" = "11.5.1"');
 		expect(workflow).not.toContain("Clawdi-AI/clawdi-hosted");
 		expect(workflow).not.toContain("uses: Clawdi-AI/");
 		expect(workflow).not.toContain("repository_dispatch");
@@ -32,7 +54,7 @@ describe("CLI publish workflow contract", () => {
 
 		expect(publishCommands).toHaveLength(1);
 		expect(workflow).toContain(
-			'npm publish "release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag agent-v2',
+			'npm publish "release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag agent-v2-candidate',
 		);
 		expect(workflow).toContain("CLI_ARTIFACT_NAME: clawdi-cli-release");
 		expect(workflow).toContain(
@@ -47,8 +69,8 @@ describe("CLI publish workflow contract", () => {
 		expect(workflow).toContain("sha256sum --check clawdi-cli-linux-x64.tar.gz.sha256");
 		expect(workflow.match(/npm pack /g) ?? []).toHaveLength(1);
 		expect(workflow.indexOf("npm pack ")).toBeLessThan(workflow.indexOf("npm publish "));
-		expect(workflow).not.toContain("agent-v2-candidate");
-		expect(workflow).not.toContain("npm dist-tag");
+		expect(workflow).not.toMatch(/npm dist-tag (?:add|rm)/);
+		expect(workflow).not.toContain("npm stage publish");
 		expect(workflow).not.toContain("NPM_TOKEN");
 	});
 
@@ -57,5 +79,15 @@ describe("CLI publish workflow contract", () => {
 			workflow.indexOf('release create "$tag"'),
 		);
 		expect(workflow).not.toContain("pull_request:");
+	});
+
+	test("keeps Hosted production semantics exact-version only", () => {
+		for (const surface of [workflow, managedRuntimeDoc, cliDevelopmentDoc, manifestContract]) {
+			expect(surface).not.toMatch(/clawdi@agent-v2(?!-)/);
+		}
+		expect(workflow).toContain("npm install -g clawdi@$VERSION");
+		expect(managedRuntimeDoc).toContain("exact `clawdi@<semver>` without build metadata");
+		expect(managedRuntimeDoc).toContain("Remote fetches cannot use that fixture schema");
+		expect(workflow).not.toContain("npm view clawdi@agent-v2");
 	});
 });

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -86,12 +86,16 @@ describe("CLI publish workflow contract", () => {
 			expect(surface).not.toMatch(/clawdi@agent-v2(?!-)/);
 		}
 		expect(workflow).toContain("npm install -g clawdi@$VERSION");
-		expect(cliDevelopmentDoc).toContain("supplies the exact `clawdi@<semver>` package spec");
+		expect(cliDevelopmentDoc).toMatch(
+			/explicitly supplies the exact\s+`clawdi@<semver>` package spec/,
+		);
 		expect(cliDevelopmentDoc).toContain("fails closed when the exact input is missing");
-		expect(releaseRunbookDoc).toContain("supplies the exact `clawdi@<semver>` package spec");
-		expect(releaseRunbookDoc).toContain("fails when the exact spec is missing");
+		expect(releaseRunbookDoc).toMatch(/supplies the exact\s+`clawdi@<semver>`\s+package\s+spec/);
+		expect(releaseRunbookDoc).toMatch(/fails when the exact spec is\s+missing/);
 		for (const surface of [cliDevelopmentDoc, releaseRunbookDoc]) {
-			expect(surface).toMatch(/never\s+resolves\s+`agent-v2-candidate` or any other npm dist-tag/);
+			expect(surface).toMatch(
+				/never\s+resolves\s+`agent-v2-candidate`\s+or\s+any\s+other\s+npm\s+dist-tag/,
+			);
 			expect(surface).not.toContain("resolves that candidate");
 		}
 		expect(manifestContract).toContain("must be clawdi@<exact-semver>");

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -8,30 +8,26 @@ const workflow = readFileSync(
 );
 
 describe("CLI publish workflow contract", () => {
-	test("gates the protected OIDC publish on the reusable Hosted paired smoke", () => {
+	test("keeps the protected OIDC publish fully repository-local", () => {
 		const build = workflow.indexOf("  build-immutable-artifact:");
-		const smoke = workflow.indexOf("  hosted-paired-smoke:");
-		const publish = workflow.indexOf("  publish-paired-artifact-with-oidc:");
+		const publish = workflow.indexOf("  publish-immutable-artifact-with-oidc:");
 
 		expect(build).toBeGreaterThan(-1);
-		expect(smoke).toBeGreaterThan(build);
-		expect(publish).toBeGreaterThan(smoke);
-		expect(workflow).toContain(
-			"uses: Clawdi-AI/clawdi-hosted/.github/workflows/hosted-runtime-paired-smoke.yml@main",
-		);
-		expect(workflow).toContain("cli_artifact_name: clawdi-cli-release");
+		expect(publish).toBeGreaterThan(build);
 		expect(workflow).toContain(
 			'echo "cli_tarball_filename=clawdi-$version.tgz" >> "$GITHUB_OUTPUT"',
 		);
-		expect(workflow).toContain(
-			`cli_tarball_filename: \${{ needs['build-immutable-artifact'].outputs.cli_tarball_filename }}`,
-		);
-		expect(workflow).toContain("needs: [build-immutable-artifact, hosted-paired-smoke]");
+		expect(workflow).toContain("needs: build-immutable-artifact");
 		expect(workflow).toContain("environment: npm");
 		expect(workflow).toContain("id-token: write");
+		expect(workflow).not.toContain("Clawdi-AI/clawdi-hosted");
+		expect(workflow).not.toContain("uses: Clawdi-AI/");
+		expect(workflow).not.toContain("repository_dispatch");
+		expect(workflow).not.toContain("workflow_run");
+		expect(workflow).not.toContain("repository: Clawdi-AI/");
 	});
 
-	test("publishes the paired-smoked tarball exactly once to agent-v2", () => {
+	test("builds and publishes the same verified tarball exactly once", () => {
 		const publishCommands = workflow.match(/npm publish /g) ?? [];
 
 		expect(publishCommands).toHaveLength(1);
@@ -44,14 +40,22 @@ describe("CLI publish workflow contract", () => {
 		);
 		expect(workflow).toContain('tarball="$CLI_TARBALL_FILENAME"');
 		expect(workflow).toContain(`name: \${{ env.CLI_ARTIFACT_NAME }}`);
+		expect(workflow).toContain("run: bun run typecheck");
+		expect(workflow).toContain("run: bun test --isolate --max-concurrency=1");
+		expect(workflow).toContain('npm install "$tarball_path" --ignore-scripts --no-audit --no-fund');
+		expect(workflow).toContain('sha256sum --check "$tarball.sha256"');
+		expect(workflow).toContain("sha256sum --check clawdi-cli-linux-x64.tar.gz.sha256");
 		expect(workflow.match(/npm pack /g) ?? []).toHaveLength(1);
-		expect(workflow.indexOf("npm pack ")).toBeLessThan(workflow.indexOf("  hosted-paired-smoke:"));
+		expect(workflow.indexOf("npm pack ")).toBeLessThan(workflow.indexOf("npm publish "));
 		expect(workflow).not.toContain("agent-v2-candidate");
 		expect(workflow).not.toContain("npm dist-tag");
 		expect(workflow).not.toContain("NPM_TOKEN");
 	});
 
-	test("keeps ordinary pull request CI repo-local", () => {
+	test("creates the CLI release only after publishing", () => {
+		expect(workflow.indexOf("npm publish ")).toBeLessThan(
+			workflow.indexOf('release create "$tag"'),
+		);
 		expect(workflow).not.toContain("pull_request:");
 	});
 });

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -6058,6 +6058,78 @@ chmod +x "$prefix/bin/clawdi"
 		}
 	});
 
+	it("recovers an exact CLI install when matching bootstrap status has no version", () => {
+		const desiredVersion = "0.12.10-beta.49";
+		const desiredSpec = `clawdi@${desiredVersion}`;
+		const home = join(root, "home-exact-recovery", "clawdi");
+		const state = join(root, "state-exact-recovery");
+		const run = join(root, "run-exact-recovery");
+		const bin = join(root, "bin-exact-recovery");
+		const npmLog = join(root, "npm-exact-recovery.log");
+		const previousPath = process.env.PATH;
+		mkdirSync(bin, { recursive: true });
+		writeFileSync(
+			join(bin, "npm"),
+			`#!/usr/bin/env bash
+printf '%s\\n' "$*" >> '${npmLog}'
+exit 97
+`,
+		);
+		chmodSync(join(bin, "npm"), 0o700);
+		process.env.PATH = `${bin}:${previousPath ?? ""}`;
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(state, desiredSpec, desiredVersion, "https://registry.npmjs.org");
+		const paths = getRuntimePaths();
+		const exactPrefix = join(paths.cliNpmPrefix, "packages", desiredVersion);
+		const exactTarget = join(exactPrefix, "bin", "clawdi");
+		mkdirSync(dirname(exactTarget), { recursive: true });
+		writeFileSync(
+			exactTarget,
+			`#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+  echo "${desiredVersion}"
+  exit 0
+fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
+  exit 0
+fi
+exit 64
+`,
+		);
+		chmodSync(exactTarget, 0o700);
+		rmSync(paths.cliManagedBin, { force: true });
+		symlinkSync(exactTarget, paths.cliManagedBin);
+		const bootstrapStatus = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+		bootstrapStatus.npmPrefix = exactPrefix;
+		bootstrapStatus.activeTarget = exactTarget;
+		delete bootstrapStatus.version;
+		writeFileSync(paths.cliBootstrapStatus, JSON.stringify(bootstrapStatus));
+
+		try {
+			const desired = normalizeManifestPayload(hostedCliManifestResponse(home, desiredSpec));
+			const result = applyRuntimeCliDesiredState(desired.manifest, paths);
+
+			expect(result.status).toBe("current");
+			expect(result.packageSpec).toBe(desiredSpec);
+			expect(result.version).toBe(desiredVersion);
+			expect(result.npmPrefix).toBe(exactPrefix);
+			expect(result.activeTarget).toBe(exactTarget);
+			expect(readlinkSync(paths.cliManagedBin)).toBe(exactTarget);
+			expect(existsSync(npmLog)).toBe(false);
+			const repairedStatus = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+			expect(repairedStatus.version).toBe(desiredVersion);
+			expect(repairedStatus.npmPrefix).toBe(exactPrefix);
+			expect(repairedStatus.activeTarget).toBe(exactTarget);
+		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
+	});
+
 	it("reinstalls an exact CLI spec when matching bootstrap status has no version", () => {
 		const desiredVersion = "0.12.10-beta.49";
 		const desiredSpec = `clawdi@${desiredVersion}`;
@@ -6130,6 +6202,87 @@ chmod +x "$prefix/bin/clawdi"
 			expect(npmCalls.some((call) => call.includes(desiredSpec))).toBe(true);
 			const repairedStatus = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
 			expect(repairedStatus.version).toBe(desiredVersion);
+		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
+	});
+
+	it("rejects an exact CLI install that reports a different version without swapping active", () => {
+		const desiredVersion = "0.12.10-beta.49";
+		const actualVersion = "0.12.10-beta.48";
+		const desiredSpec = `clawdi@${desiredVersion}`;
+		const home = join(root, "home-exact-version-mismatch", "clawdi");
+		const state = join(root, "state-exact-version-mismatch");
+		const run = join(root, "run-exact-version-mismatch");
+		const bin = join(root, "bin-exact-version-mismatch");
+		const npmLog = join(root, "npm-exact-version-mismatch.log");
+		const previousPath = process.env.PATH;
+		mkdirSync(bin, { recursive: true });
+		writeFileSync(
+			join(bin, "npm"),
+			`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> '${npmLog}'
+if [ "\${1:-}" = "view" ]; then
+  echo "exact hosted CLI updates must not call npm view" >&2
+  exit 96
+fi
+prefix=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--prefix" ]; then
+    prefix="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+test -n "$prefix"
+install -d "$prefix/bin"
+cat > "$prefix/bin/clawdi" <<'SH'
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+  echo "${actualVersion}"
+  exit 0
+fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
+  exit 0
+fi
+exit 64
+SH
+chmod +x "$prefix/bin/clawdi"
+`,
+		);
+		chmodSync(join(bin, "npm"), 0o700);
+		process.env.PATH = `${bin}:${previousPath ?? ""}`;
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(
+			state,
+			"clawdi@0.12.10-beta.47",
+			"0.12.10-beta.47",
+			"https://registry.npmjs.org",
+		);
+		const paths = getRuntimePaths();
+		const oldTarget = readlinkSync(paths.cliManagedBin);
+		const oldStatus = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+
+		try {
+			const desired = normalizeManifestPayload(hostedCliManifestResponse(home, desiredSpec));
+			expect(() => applyRuntimeCliDesiredState(desired.manifest, paths)).toThrow(
+				`npm install ${desiredSpec} reported version ${actualVersion}, expected ${desiredVersion}`,
+			);
+
+			expect(readlinkSync(paths.cliManagedBin)).toBe(oldTarget);
+			expect(JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"))).toEqual(oldStatus);
+			const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
+			expect(npmCalls).toHaveLength(1);
+			expect(npmCalls[0].startsWith("install ")).toBe(true);
+			expect(npmCalls[0]).toContain(desiredSpec);
+			expect(npmCalls.some((call) => call.startsWith("view "))).toBe(false);
 		} finally {
 			if (previousPath === undefined) delete process.env.PATH;
 			else process.env.PATH = previousPath;

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -275,7 +275,22 @@ function hostedRuntimeWatchLocalePayload(
 	};
 }
 
-function hostedCliManifestResponse(home: string, packageSpec: string): unknown {
+function hostedCliManifestResponse(
+	home: string,
+	packageSpec: string,
+	opts: { providerSecretRef?: string } = {},
+): unknown {
+	const provider = opts.providerSecretRef
+		? {
+				kind: "openai-compatible",
+				type: "custom_openai_compatible",
+				baseUrl: "https://provider.test/v1",
+				models: [{ id: "gpt-5" }],
+				apiMode: "openai_responses",
+				managed_by: "clawdi",
+				apiKeySecretRef: opts.providerSecretRef,
+			}
+		: hostedRequiredState().providers.default;
 	return {
 		manifest: {
 			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
@@ -284,6 +299,7 @@ function hostedCliManifestResponse(home: string, packageSpec: string): unknown {
 			deploymentId: "dep_cli_package_spec",
 			environmentId: "env_cli_package_spec",
 			...hostedRequiredState(),
+			providers: { default: provider },
 			instanceId: "iid_cli_package_spec",
 			generation: 1,
 			issuedAt: "2026-07-12T00:00:00Z",
@@ -1424,6 +1440,28 @@ describe("runtime manifest datasource", () => {
 		expect("manifest" in loaded).toBe(true);
 		if (!("manifest" in loaded)) throw new Error("expected strict hosted fixture success");
 		expect(loaded.manifest.clawdiCli?.packageSpec).toBe(packageSpec);
+	});
+
+	it("rejects a strict hosted fixture with secret refs but no inline secret values", async () => {
+		const home = join(root, "home", "clawdi");
+		const manifestPath = join(root, "strict-hosted-missing-secret.json");
+		const packageSpec = "/usr/local/share/clawdi/bootstrap/clawdi-0.13.0-test.tgz";
+		process.env.HOME = home;
+		writeFileSync(
+			manifestPath,
+			JSON.stringify(
+				hostedCliManifestResponse(home, packageSpec, {
+					providerSecretRef: "provider.default.apiKey",
+				}),
+			),
+		);
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths({ mode: "hosted" }), {
+			manifestPath,
+		});
+		expect("errors" in loaded).toBe(true);
+		if (!("errors" in loaded)) throw new Error("expected missing fixture secret rejection");
+		expect(loaded.errors.join("\n")).toContain("fixture references secretValues");
 	});
 
 	for (const packageSpec of ["clawdi@latest", "clawdi"]) {
@@ -5938,157 +5976,6 @@ printf 'ActiveState=active\\nSubState=running\\n'
 			restore();
 			console.log = previousLog;
 			process.exitCode = previousExitCode;
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-		}
-	});
-
-	it("generic runtime CLI update resolves a floating npm tag through the managed npm cache", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const bin = join(root, "bin");
-		const npmLog = join(root, "npm.log");
-		const previousPath = process.env.PATH;
-		mkdirSync(bin, { recursive: true });
-		writeFileSync(
-			join(bin, "npm"),
-			`#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\\n' "$*" >> '${npmLog}'
-if [ "\${1:-}" = "view" ]; then
-	cache=""
-	while [ "$#" -gt 0 ]; do
-	  if [ "$1" = "--cache" ]; then
-	    cache="$2"
-	    shift 2
-	    continue
-	  fi
-	  shift
-	done
-	if [ -z "$cache" ]; then
-	  echo "missing --cache" >&2
-	  exit 65
-	fi
-	install -d "$cache"
-	touch "$cache/view-proof"
-  echo '"0.12.10-beta.49"'
-  exit 0
-fi
-prefix=""
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--prefix" ]; then
-    prefix="$2"
-    shift 2
-    continue
-  fi
-  shift
-done
-if [ -z "$prefix" ]; then
-  echo "missing --prefix" >&2
-  exit 64
-fi
-install -d "$prefix/bin"
-cat > "$prefix/bin/clawdi" <<'SH'
-#!/usr/bin/env bash
-if [ "\${1:-}" = "--version" ]; then
-  echo "0.12.10-beta.49"
-  exit 0
-fi
-if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
-  echo '{"status":"ok"}'
-  exit 0
-fi
-echo "fake clawdi"
-SH
-chmod +x "$prefix/bin/clawdi"
-`,
-		);
-		chmodSync(join(bin, "npm"), 0o700);
-		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		try {
-			const paths = getRuntimePaths();
-			seedCurrentCliInstall(
-				state,
-				"clawdi@agent-v2",
-				"0.12.10-beta.48",
-				"https://registry.npmjs.org",
-			);
-			const result = applyRuntimeCliDesiredState(genericCliDesiredState("clawdi@agent-v2"), paths);
-
-			expect(result.status).toBe("installed");
-			expect(result.version).toBe("0.12.10-beta.49");
-			expect(readlinkSync(paths.cliManagedBin)).toBe(result.activeTarget);
-			const status = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
-			expect(status.packageSpec).toBe("clawdi@agent-v2");
-			expect(status.version).toBe("0.12.10-beta.49");
-			const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
-			const npmViewCalls = npmCalls.filter((call) => call.startsWith("view "));
-			expect(npmViewCalls.length).toBeGreaterThan(0);
-			for (const call of npmViewCalls) {
-				expect(call).toContain(`--cache ${paths.cliNpmCache}`);
-			}
-			expect(npmCalls.some((call) => call.startsWith("install "))).toBe(true);
-			expect(existsSync(join(paths.cliNpmCache, "view-proof"))).toBe(true);
-			expect(existsSync(join(home, ".npm"))).toBe(false);
-		} finally {
-			if (previousPath === undefined) delete process.env.PATH;
-			else process.env.PATH = previousPath;
-		}
-	});
-
-	it("keeps a generic floating CLI install current without reinstalling", () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const bin = join(root, "bin");
-		const npmLog = join(root, "npm-current.log");
-		const previousPath = process.env.PATH;
-		mkdirSync(bin, { recursive: true });
-		writeFileSync(
-			join(bin, "npm"),
-			`#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\\n' "$*" >> '${npmLog}'
-if [ "\${1:-}" = "view" ]; then
-  echo '"0.12.10-beta.50"'
-  exit 0
-fi
-echo "unexpected npm install" >&2
-exit 97
-`,
-		);
-		chmodSync(join(bin, "npm"), 0o700);
-		process.env.PATH = `${bin}:${previousPath ?? ""}`;
-		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_SERVICE_STATE_DIR = state;
-		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(
-			state,
-			"clawdi@agent-v2",
-			"0.12.10-beta.50",
-			"https://registry.npmjs.org",
-		);
-
-		try {
-			const result = applyRuntimeCliDesiredState(
-				genericCliDesiredState("clawdi@agent-v2"),
-				getRuntimePaths(),
-			);
-
-			expect(result.status).toBe("current");
-			expect(result.packageSpec).toBe("clawdi@agent-v2");
-			expect(result.registry).toBe("https://registry.npmjs.org");
-			expect(result.version).toBe("0.12.10-beta.50");
-			const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
-			expect(npmCalls.some((call) => call.startsWith("view clawdi@agent-v2"))).toBe(true);
-			expect(npmCalls.some((call) => call.startsWith("install "))).toBe(false);
-		} finally {
 			if (previousPath === undefined) delete process.env.PATH;
 			else process.env.PATH = previousPath;
 		}

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -7231,7 +7231,14 @@ chmod +x "$prefix/bin/clawdi"
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
+		const bin = join(root, "bin");
+		const npmMarker = join(root, "npm-invoked");
+		const previousPath = process.env.PATH;
 		mkdirSync(home, { recursive: true });
+		mkdirSync(bin, { recursive: true });
+		writeFileSync(join(bin, "npm"), `#!/usr/bin/env sh\ntouch '${npmMarker}'\nexit 99\n`);
+		chmodSync(join(bin, "npm"), 0o700);
+		process.env.PATH = `${bin}:${previousPath ?? ""}`;
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
@@ -7251,6 +7258,11 @@ chmod +x "$prefix/bin/clawdi"
 		};
 
 		for (const packageSpec of [
+			"clawdi@01.2.3",
+			"clawdi@1.2.3-01",
+			"clawdi@1.2.3+build.1",
+			"clawdi",
+			"clawdi@latest",
 			"clawdi@npm:evil",
 			"clawdi@https://evil.test/clawdi.tgz",
 			"clawdi@github:evil/clawdi",
@@ -7263,6 +7275,7 @@ chmod +x "$prefix/bin/clawdi"
 				),
 			).toThrow(/packageSpec/);
 		}
+		expect(existsSync(npmMarker)).toBe(false);
 		expect(() =>
 			applyRuntimeCliDesiredState(
 				{
@@ -7276,6 +7289,9 @@ chmod +x "$prefix/bin/clawdi"
 				paths,
 			),
 		).toThrow(/registry/);
+		expect(existsSync(npmMarker)).toBe(false);
+		if (previousPath === undefined) delete process.env.PATH;
+		else process.env.PATH = previousPath;
 	});
 
 	it("rebuilds missing CLI bootstrap status without reinstalling the active package", () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -179,6 +179,13 @@ const TEST_HOSTED_LOCALE = {
 };
 const TEST_HOSTED_MINIMUM_CLI_VERSION = "0.12.10-beta.51";
 
+function hostedRequiredState() {
+	return {
+		liveSync: { enabled: false, agents: [] },
+		recovery: { cacheManifest: true, allowOfflineBoot: true },
+	};
+}
+
 function hostedSystemFixture(
 	home: string,
 	workspace = join(home, "clawdi"),
@@ -238,6 +245,7 @@ function hostedRuntimeWatchLocalePayload(
 			runtime: "openclaw",
 			deploymentId: "dep_watch_locale",
 			environmentId: "env_watch_locale",
+			...hostedRequiredState(),
 			instanceId: "iid_watch_locale",
 			generation,
 			issuedAt: "2026-07-11T00:00:00Z",
@@ -1106,6 +1114,7 @@ describe("runtime manifest datasource", () => {
 							runtime: "openclaw",
 							deploymentId: "dep_test",
 							environmentId: "env_test",
+							...hostedRequiredState(),
 							instanceId: "iid_remote",
 							generation: 3,
 							issuedAt: "2026-06-06T00:00:00Z",
@@ -1261,6 +1270,7 @@ chmod +x "$HOME/.local/bin/hermes"
 							runtime: "hermes",
 							deploymentId: "dep_runtime_bridge",
 							environmentId: "env_runtime_bridge",
+							...hostedRequiredState(),
 							instanceId: "iid_runtime_bridge",
 							generation: 4,
 							issuedAt: "2026-06-06T00:00:00Z",
@@ -1354,6 +1364,7 @@ chmod +x "$HOME/.local/bin/hermes"
 							runtime: "openclaw",
 							deploymentId: "dep_chat_provider",
 							environmentId: "env_chat_provider",
+							...hostedRequiredState(),
 							instanceId: "iid_chat_provider",
 							generation: 1,
 							issuedAt: "2026-06-22T00:00:00Z",
@@ -1451,6 +1462,7 @@ chmod +x "$HOME/.local/bin/hermes"
 							runtime: "openclaw",
 							deploymentId: "dep_codex_provider",
 							environmentId: "env_codex_provider",
+							...hostedRequiredState(),
 							instanceId: "iid_codex_provider",
 							generation: 1,
 							issuedAt: "2026-06-22T00:00:00Z",
@@ -2961,6 +2973,7 @@ exit 0
 					runtime: "openclaw",
 					deploymentId: "dep_hosted_provider_secret",
 					environmentId: "env_hosted_provider_secret",
+					...hostedRequiredState(),
 					instanceId: "iid_hosted_provider_secret",
 					generation: 5,
 					issuedAt: "2026-06-15T00:00:00Z",
@@ -3122,6 +3135,7 @@ exit 64
 					runtime: "openclaw",
 					deploymentId: "dep_bridge_token",
 					environmentId: "env_bridge_token",
+					...hostedRequiredState(),
 					instanceId: "iid_bridge_token",
 					generation: 1,
 					issuedAt: "2026-06-15T00:00:00Z",
@@ -3169,6 +3183,7 @@ exit 64
 					runtime: "openclaw",
 					deploymentId: "dep_bridge_token_explicit",
 					environmentId: "env_bridge_token_explicit",
+					...hostedRequiredState(),
 					instanceId: "iid_bridge_token_explicit",
 					generation: 1,
 					issuedAt: "2026-06-15T00:00:00Z",
@@ -3242,6 +3257,7 @@ exit 64
 							runtime: "hermes",
 							deploymentId: "dep_custom_auth",
 							environmentId: "env_custom_auth",
+							...hostedRequiredState(),
 							instanceId: "iid_custom_auth",
 							generation: 1,
 							issuedAt: "2026-06-06T00:00:00Z",
@@ -3304,6 +3320,7 @@ exit 64
 							runtime: "openclaw",
 							deploymentId: "dep_same_token",
 							environmentId: "env_same_token",
+							...hostedRequiredState(),
 							instanceId: "iid_same_token",
 							generation: 1,
 							issuedAt: "2026-06-06T00:00:00Z",
@@ -3337,6 +3354,7 @@ exit 64
 							runtime: "openclaw",
 							deploymentId: "dep_same_token",
 							environmentId: "env_same_token",
+							...hostedRequiredState(),
 							instanceId: "iid_same_token",
 							generation: 2,
 							issuedAt: "2026-06-06T00:01:00Z",
@@ -4255,6 +4273,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 								runtime: "openclaw",
 								deploymentId: "dep_watch",
 								environmentId: "env_watch",
+								...hostedRequiredState(),
 								instanceId: "iid_watch",
 								generation: 12,
 								issuedAt: "2026-06-06T00:00:00Z",
@@ -4399,6 +4418,7 @@ exit 42
 								runtime: "openclaw",
 								deploymentId: "dep_watch_systemd_failure",
 								environmentId: "env_watch_systemd_failure",
+								...hostedRequiredState(),
 								instanceId: "iid_watch_systemd_failure",
 								generation: 13,
 								issuedAt: "2026-06-06T00:00:00Z",
@@ -4477,6 +4497,7 @@ exit 42
 				runtime: "openclaw",
 				deploymentId: "dep_watch_secret",
 				environmentId: "env_watch_secret",
+				...hostedRequiredState(),
 				instanceId: "iid_watch_secret",
 				generation: 22,
 				issuedAt: "2026-06-06T00:00:00Z",
@@ -4758,6 +4779,7 @@ exit 64
 								runtime: "openclaw",
 								deploymentId: "dep_watch_recovery",
 								environmentId: "env_watch_recovery",
+								...hostedRequiredState(),
 								instanceId: "iid_watch_recovery",
 								generation: 18,
 								issuedAt: "2026-06-06T00:00:00Z",
@@ -5339,6 +5361,7 @@ chmod +x "$prefix/bin/clawdi"
 								runtime: "openclaw",
 								deploymentId: "dep_cli_update",
 								environmentId: "env_cli_update",
+								...hostedRequiredState(),
 								instanceId: "iid_cli_update",
 								generation: 13,
 								issuedAt: "2026-06-06T00:00:00Z",
@@ -5577,6 +5600,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 								runtime: "openclaw",
 								deploymentId: "dep_cli_mitm",
 								environmentId: "env_cli_mitm",
+								...hostedRequiredState(),
 								instanceId: "iid_cli_mitm",
 								generation: 2,
 								issuedAt: "2026-06-06T00:00:00Z",
@@ -5745,6 +5769,7 @@ chmod +x "$prefix/bin/clawdi"
 					runtime: "openclaw",
 					deploymentId: "dep_floating_cli_tag",
 					environmentId: "env_floating_cli_tag",
+					...hostedRequiredState(),
 					instanceId: "iid_floating_cli_tag",
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",
@@ -5824,6 +5849,7 @@ exit 97
 					runtime: "openclaw",
 					deploymentId: "dep_cli_bootstrap_current",
 					environmentId: "env_cli_bootstrap_current",
+					...hostedRequiredState(),
 					instanceId: "iid_cli_bootstrap_current",
 					generation: 1,
 					issuedAt: "2026-07-11T00:00:00Z",
@@ -5940,6 +5966,7 @@ chmod +x "$prefix/bin/clawdi"
 				runtime: "openclaw",
 				deploymentId: "dep_cli_self_heal",
 				environmentId: "env_cli_self_heal",
+				...hostedRequiredState(),
 				instanceId: "iid_cli_self_heal",
 				generation: 30,
 				issuedAt: "2026-07-11T00:00:00Z",
@@ -6145,6 +6172,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 								runtime: "openclaw",
 								deploymentId: "dep_cli_update_converge_failure",
 								environmentId: "env_cli_update_converge_failure",
+								...hostedRequiredState(),
 								instanceId: "iid_cli_update_converge_failure",
 								generation: 16,
 								issuedAt: "2026-06-06T00:00:00Z",
@@ -6301,6 +6329,7 @@ chmod +x "$prefix/bin/clawdi"
 			runtime: "openclaw",
 			deploymentId: "dep_cli_rollback",
 			environmentId: "env_cli_rollback",
+			...hostedRequiredState(),
 			instanceId: "iid_cli_rollback",
 			generation: 18,
 			issuedAt: "2026-06-06T00:00:00Z",
@@ -6448,6 +6477,7 @@ chmod +x "$prefix/bin/clawdi"
 								runtime: "openclaw",
 								deploymentId: "dep_cli_update_failure",
 								environmentId: "env_cli_update_failure",
+								...hostedRequiredState(),
 								instanceId: "iid_cli_update_failure",
 								generation: 17,
 								issuedAt: "2026-06-06T00:00:00Z",
@@ -6586,6 +6616,7 @@ chmod +x "$prefix/bin/clawdi"
 								runtime: "openclaw",
 								deploymentId: "dep_min_cli",
 								environmentId: "env_min_cli",
+								...hostedRequiredState(),
 								instanceId: "iid_min_cli",
 								generation: 19,
 								minimumCliVersion: "999.0.0",
@@ -7072,6 +7103,7 @@ exit 64
 								runtime: "openclaw",
 								deploymentId: "dep_init",
 								environmentId: "env_init",
+								...hostedRequiredState(),
 								instanceId: "iid_init",
 								generation: 7,
 								issuedAt: "2026-06-06T00:00:00Z",
@@ -8223,6 +8255,7 @@ exit 64
 							runtime: "hermes",
 							deploymentId: "dep_workspace",
 							environmentId: "env_workspace",
+							...hostedRequiredState(),
 							instanceId: "iid_workspace",
 							generation: 1,
 							issuedAt: "2026-06-06T00:00:00Z",
@@ -8351,6 +8384,7 @@ exit 64
 					runtime: "hermes",
 					deploymentId: "dep_legacy_api_url",
 					environmentId: "env_legacy_api_url",
+					...hostedRequiredState(),
 					instanceId: "iid_legacy_api_url",
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",
@@ -8379,6 +8413,29 @@ exit 64
 		expect(loaded.errors.join("\n")).toContain("apiUrl");
 	});
 
+	it.each([
+		"liveSync",
+		"recovery",
+	] as const)("rejects hosted manifests without required %s state", async (field) => {
+		const home = join(root, "home", "clawdi");
+		const manifestPath = join(root, `hosted-missing-${field}.json`);
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		const payload = hostedRuntimeWatchLocalePayload(home, 1) as {
+			manifest: Record<string, unknown>;
+		};
+		delete payload.manifest[field];
+		writeFileSync(manifestPath, JSON.stringify(payload));
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths(), { manifestPath });
+
+		expect("errors" in loaded).toBe(true);
+		if (!("errors" in loaded)) throw new Error("expected manifest load failure");
+		expect(loaded.mode).toBe("manifest-rejected");
+		expect(loaded.errors.join("\n")).toContain(`manifest.${field}`);
+	});
+
 	it("uses hosted runtime workspace paths even without explicit run settings", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -8399,6 +8456,7 @@ exit 64
 					runtime: "hermes",
 					deploymentId: "dep_runtime_workspace",
 					environmentId: "env_runtime_workspace",
+					...hostedRequiredState(),
 					instanceId: "iid_runtime_workspace",
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",
@@ -9405,6 +9463,7 @@ exit 64
 							runtime: "openclaw",
 							deploymentId: "dep_manifest_only",
 							environmentId: "env_manifest_only",
+							...hostedRequiredState(),
 							instanceId: "iid_manifest_only",
 							generation: 1,
 							issuedAt: "2026-06-06T00:00:00Z",
@@ -9460,6 +9519,7 @@ exit 64
 							runtime: "openclaw",
 							deploymentId: "dep_test",
 							environmentId: "env_test",
+							...hostedRequiredState(),
 							instanceId: "iid_remote",
 							generation: 4,
 							issuedAt: "2026-06-06T00:00:00Z",
@@ -9740,6 +9800,7 @@ exit 64
 							runtime: "openclaw",
 							deploymentId: "dep_sync",
 							environmentId: "env_sync",
+							...hostedRequiredState(),
 							instanceId: "iid_sync",
 							generation: 9,
 							issuedAt: "2026-06-06T00:00:00Z",
@@ -9845,6 +9906,7 @@ exit 64
 					runtime: "openclaw",
 					deploymentId: "dep_no_secret_ref",
 					environmentId: "env_no_secret_ref",
+					...hostedRequiredState(),
 					instanceId: "iid_no_secret_ref",
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",
@@ -9891,6 +9953,7 @@ exit 64
 					runtime: "hermes",
 					deploymentId: "dep_bad_mitm",
 					environmentId: "env_bad_mitm",
+					...hostedRequiredState(),
 					instanceId: "iid_bad_mitm",
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -920,14 +920,15 @@ describe("runtime manifest datasource", () => {
 		expect(loaded.errors[0]).toContain("missing CLAWDI_RUNTIME_MANIFEST_URL");
 	});
 
-	it("rejects noncanonical hosted manifest paths", async () => {
+	it("rejects the /api hosted manifest path even when it has a normal query", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		mkdirSync(home, { recursive: true });
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
-		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://cloud-api.example.test/api/runtime/manifest";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL =
+			"https://cloud-api.example.test/api/runtime/manifest?environment_id=env_runtime";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -294,16 +294,25 @@ type HostedRuntimeFixtureEntry = {
 	install?: { source: "official"; channel?: string; args?: string[] };
 	run?: HostedRunFixture;
 	services?: Record<string, HostedRunFixture>;
-	paths?: { home?: string; workspace?: string };
-	provider_ids?: string[];
-	primary_model?: unknown;
+	paths: { home: string; workspace: string };
+	provider_ids: string[];
+	primary_model: { provider_id: string; model: string };
 };
 
 function hostedOpenClawRuntime(
 	overrides: Partial<HostedRuntimeFixtureEntry> = {},
 ): HostedRuntimeFixtureEntry {
+	const home = process.env.HOME ?? "/home/clawdi";
+	const {
+		paths,
+		provider_ids = ["default"],
+		primary_model = { provider_id: provider_ids[0] ?? "default", model: "gpt-test" },
+		...entryOverrides
+	} = overrides;
 	return {
 		enabled: true,
+		provider_ids,
+		primary_model,
 		run: {
 			args: [
 				"gateway",
@@ -319,15 +328,29 @@ function hostedOpenClawRuntime(
 			prependPath: [],
 		},
 		services: {},
-		...overrides,
+		...entryOverrides,
+		paths: {
+			home,
+			workspace: join(home, "clawdi"),
+			...paths,
+		},
 	};
 }
 
 function hostedHermesRuntime(
 	overrides: Partial<HostedRuntimeFixtureEntry> = {},
 ): HostedRuntimeFixtureEntry {
+	const home = process.env.HOME ?? "/home/clawdi";
+	const {
+		paths,
+		provider_ids = ["default"],
+		primary_model = { provider_id: provider_ids[0] ?? "default", model: "gpt-test" },
+		...entryOverrides
+	} = overrides;
 	return {
 		enabled: true,
+		provider_ids,
+		primary_model,
 		run: {
 			args: ["gateway", "run", "--replace"],
 			env: {},
@@ -340,7 +363,12 @@ function hostedHermesRuntime(
 				prependPath: [],
 			},
 		},
-		...overrides,
+		...entryOverrides,
+		paths: {
+			home,
+			workspace: join(home, "clawdi"),
+			...paths,
+		},
 	};
 }
 
@@ -3084,7 +3112,7 @@ exit 64
 					generation: 1,
 					issuedAt: "2026-06-15T00:00:00Z",
 					locale: TEST_HOSTED_LOCALE,
-					system: { home },
+					system: { home, workspace: join(home, "clawdi") },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
@@ -3131,7 +3159,7 @@ exit 64
 					generation: 1,
 					issuedAt: "2026-06-15T00:00:00Z",
 					locale: TEST_HOSTED_LOCALE,
-					system: { home },
+					system: { home, workspace: join(home, "clawdi") },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
@@ -3140,7 +3168,13 @@ exit 64
 					},
 					runtimes: {
 						openclaw: hostedOpenClawRuntime(),
-						hermes: { enabled: false, install: { source: "official" }, paths: { home } },
+						hermes: {
+							enabled: false,
+							install: { source: "official" },
+							provider_ids: ["default"],
+							primary_model: { provider_id: "default", model: "gpt-test" },
+							paths: { home, workspace: join(home, "clawdi") },
+						},
 					},
 				},
 				secretValues: {},
@@ -3198,7 +3232,7 @@ exit 64
 							generation: 1,
 							issuedAt: "2026-06-06T00:00:00Z",
 							locale: TEST_HOSTED_LOCALE,
-							system: { home },
+							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 							clawdiCli: {
 								source: "npm:clawdi",
@@ -8151,7 +8185,7 @@ exit 64
 		expect(patchText).toContain('"plugins"');
 	});
 
-	it("uses hosted system workspace when converging run config and systemd units", async () => {
+	it("uses explicit hosted workspaces when converging run config and systemd units", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -8187,7 +8221,9 @@ exit 64
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
-								hermes: hostedHermesRuntime(),
+								hermes: hostedHermesRuntime({
+									paths: { home, workspace },
+								}),
 							},
 							bridge: { surfaces: [hostedHermesBridgeSurface()] },
 						},
@@ -8305,7 +8341,7 @@ exit 64
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",
 					locale: TEST_HOSTED_LOCALE,
-					system: { home },
+					system: { home, workspace: join(home, "clawdi") },
 					controlPlane: { apiUrl: "https://api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1396,19 +1396,34 @@ describe("runtime manifest datasource", () => {
 		expect(loaded.manifest.clawdiCli?.packageSpec).toBe(packageSpec);
 	});
 
-	it("rejects a generic internal fixture in hosted mode", async () => {
+	it("rejects an explicit generic internal fixture in hosted mode", async () => {
 		const home = join(root, "home", "clawdi");
 		const manifestPath = join(root, "generic-hosted-fixture.json");
 		process.env.HOME = home;
 		writeFileSync(manifestPath, JSON.stringify(genericCliDesiredState("clawdi@1.2.3")));
-		process.env.CLAWDI_RUNTIME_MANIFEST_PATH = manifestPath;
-		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
 
-		const loaded = await loadRuntimeManifest(getRuntimePaths({ mode: "hosted" }));
+		const loaded = await loadRuntimeManifest(getRuntimePaths({ mode: "hosted" }), {
+			manifestPath,
+		});
 		expect("errors" in loaded).toBe(true);
 		if (!("errors" in loaded)) throw new Error("expected hosted fixture rejection");
 		expect(loaded.mode).toBe("manifest-rejected");
 		expect(loaded.errors.join("\n")).toContain("manifest: Invalid input");
+	});
+
+	it("accepts an explicit strict hosted fixture in hosted mode", async () => {
+		const home = join(root, "home", "clawdi");
+		const manifestPath = join(root, "strict-hosted-fixture.json");
+		const packageSpec = "/usr/local/share/clawdi/bootstrap/clawdi-0.13.0-test.tgz";
+		process.env.HOME = home;
+		writeFileSync(manifestPath, JSON.stringify(hostedCliManifestResponse(home, packageSpec)));
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths({ mode: "hosted" }), {
+			manifestPath,
+		});
+		expect("manifest" in loaded).toBe(true);
+		if (!("manifest" in loaded)) throw new Error("expected strict hosted fixture success");
+		expect(loaded.manifest.clawdiCli?.packageSpec).toBe(packageSpec);
 	});
 
 	for (const packageSpec of ["clawdi@latest", "clawdi"]) {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -6058,6 +6058,84 @@ chmod +x "$prefix/bin/clawdi"
 		}
 	});
 
+	it("reinstalls an exact CLI spec when matching bootstrap status has no version", () => {
+		const desiredVersion = "0.12.10-beta.49";
+		const desiredSpec = `clawdi@${desiredVersion}`;
+		const home = join(root, "home-exact-missing-version", "clawdi");
+		const state = join(root, "state-exact-missing-version");
+		const run = join(root, "run-exact-missing-version");
+		const bin = join(root, "bin-exact-missing-version");
+		const npmLog = join(root, "npm-exact-missing-version.log");
+		const previousPath = process.env.PATH;
+		mkdirSync(bin, { recursive: true });
+		writeFileSync(
+			join(bin, "npm"),
+			`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> '${npmLog}'
+if [ "\${1:-}" = "view" ]; then
+  echo "exact hosted CLI updates must not call npm view" >&2
+  exit 96
+fi
+prefix=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--prefix" ]; then
+    prefix="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+test -n "$prefix"
+install -d "$prefix/bin"
+cat > "$prefix/bin/clawdi" <<'SH'
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+  echo "${desiredVersion}"
+  exit 0
+fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
+  exit 0
+fi
+exit 64
+SH
+chmod +x "$prefix/bin/clawdi"
+`,
+		);
+		chmodSync(join(bin, "npm"), 0o700);
+		process.env.PATH = `${bin}:${previousPath ?? ""}`;
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(state, desiredSpec, desiredVersion, "https://registry.npmjs.org");
+		const paths = getRuntimePaths();
+		const bootstrapStatus = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+		delete bootstrapStatus.version;
+		writeFileSync(paths.cliBootstrapStatus, JSON.stringify(bootstrapStatus));
+		expect(existsSync(paths.cliManagedBin)).toBe(true);
+
+		try {
+			const desired = normalizeManifestPayload(hostedCliManifestResponse(home, desiredSpec));
+			const result = applyRuntimeCliDesiredState(desired.manifest, paths);
+
+			expect(result.status).toBe("installed");
+			expect(result.packageSpec).toBe(desiredSpec);
+			expect(result.version).toBe(desiredVersion);
+			expect(result.activeTarget).not.toBe(bootstrapStatus.activeTarget);
+			const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
+			expect(npmCalls.some((call) => call.startsWith("view "))).toBe(false);
+			expect(npmCalls.some((call) => call.startsWith("install "))).toBe(true);
+			expect(npmCalls.some((call) => call.includes(desiredSpec))).toBe(true);
+			const repairedStatus = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+			expect(repairedStatus.version).toBe(desiredVersion);
+		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
+	});
+
 	it("runtime watch self-heal applies an exact hosted CLI version without npm view", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
 import {
 	chmodSync,
 	existsSync,
@@ -337,6 +338,15 @@ function genericCliDesiredState(packageSpec: string): RuntimeManifest {
 		},
 		runtimes: { openclaw: { enabled: true } },
 		recovery: {},
+	};
+}
+
+function cachedHostedCliDesiredState(home: string, packageSpec: string): RuntimeManifest {
+	return {
+		...genericCliDesiredState(packageSpec),
+		workspaceRoot: join(home, "clawdi"),
+		runtimes: { openclaw: { enabled: false } },
+		recovery: { cacheManifest: true, allowOfflineBoot: true },
 	};
 }
 
@@ -1130,6 +1140,65 @@ describe("runtime manifest datasource", () => {
 		});
 	});
 
+	it("reports degraded-offline apply and boot state after remote fetch failure", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		mkdirSync(join(state, "cache"), { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_AUTH_TOKEN = "auth-token";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
+		writeFileSync(
+			join(state, "cache", "manifest.last-good.json"),
+			JSON.stringify(cachedHostedCliDesiredState(home, "clawdi@0.13.0-test")),
+		);
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/runtime/manifest",
+				response: () => {
+					throw new Error("control plane unavailable");
+				},
+			},
+		]);
+
+		try {
+			const paths = getRuntimePaths();
+			const loaded = await loadRuntimeManifest(paths);
+			if (!("manifest" in loaded)) {
+				throw new Error(`expected last-good manifest: ${loaded.errors.join("; ")}`);
+			}
+			const convergence = convergeRuntimeManifest(loaded, paths, { cacheLastGood: false });
+			const boot = buildRuntimeBootStatus(
+				{
+					mode: convergence.mode,
+					status: "ok",
+					stage: "final",
+					bootId: "boot-degraded-offline",
+					runtimeMode: "hosted",
+					activeGeneration: convergence.manifest.generation,
+					instanceId: convergence.manifest.instanceId,
+					enabledRuntimes: convergence.enabledRuntimes,
+					errors: [],
+					exitCode: 0,
+					datasource: "RuntimeSource",
+					hostPolicy: { source: "builtin", exists: true, valid: true },
+				},
+				paths,
+			);
+
+			expect(loaded.source).toBe("last-good-cache");
+			expect(loaded.offline).toBe(true);
+			expect(convergence.mode).toBe("degraded-offline");
+			expect(boot.mode).toBe("degraded-offline");
+		} finally {
+			restore();
+		}
+	});
+
 	it("refuses last-good offline boot when cached secret values are missing", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -1464,7 +1533,12 @@ describe("runtime manifest datasource", () => {
 		expect(loaded.errors.join("\n")).toContain("fixture references secretValues");
 	});
 
-	for (const packageSpec of ["clawdi@latest", "clawdi"]) {
+	for (const packageSpec of [
+		"clawdi@latest",
+		"clawdi@agent-v2",
+		"clawdi@1.2.3+build.1",
+		"clawdi",
+	]) {
 		it(`rejects cached hosted state with ${packageSpec} and no hosted marker`, async () => {
 			const home = join(root, "home", "clawdi");
 			const state = join(root, "var", "lib", "clawdi");
@@ -1475,11 +1549,7 @@ describe("runtime manifest datasource", () => {
 			process.env.CLAWDI_RUN_DIR = join(root, "run", "clawdi");
 			writeFileSync(
 				join(state, "cache", "manifest.last-good.json"),
-				JSON.stringify({
-					...genericCliDesiredState(packageSpec),
-					workspaceRoot: join(home, "clawdi"),
-					recovery: { cacheManifest: true, allowOfflineBoot: true },
-				}),
+				JSON.stringify(cachedHostedCliDesiredState(home, packageSpec)),
 			);
 
 			const loaded = await loadRuntimeManifest(getRuntimePaths());
@@ -6125,9 +6195,10 @@ exit 64
 		}
 	});
 
-	it("reinstalls an exact CLI spec when matching bootstrap status has no version", () => {
+	it("reinstalls an exact CLI spec when the active link uses a legacy hash prefix", () => {
 		const desiredVersion = "0.12.10-beta.49";
 		const desiredSpec = `clawdi@${desiredVersion}`;
+		const registry = "https://registry.npmjs.org";
 		const home = join(root, "home-exact-missing-version", "clawdi");
 		const state = join(root, "state-exact-missing-version");
 		const run = join(root, "run-exact-missing-version");
@@ -6176,21 +6247,46 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
-		seedCurrentCliInstall(state, desiredSpec, desiredVersion, "https://registry.npmjs.org");
+		seedCurrentCliInstall(state, desiredSpec, desiredVersion, registry);
 		const paths = getRuntimePaths();
+		const legacyHash = createHash("sha256")
+			.update(JSON.stringify({ packageSpec: desiredSpec, registry }))
+			.digest("hex")
+			.slice(0, 16);
+		const legacyPrefix = join(paths.cliNpmPrefix, "packages", legacyHash);
+		const legacyTarget = join(legacyPrefix, "bin", "clawdi");
+		mkdirSync(dirname(legacyTarget), { recursive: true });
+		writeFileSync(
+			legacyTarget,
+			`#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+  echo "${desiredVersion}"
+  exit 0
+fi
+exit 64
+`,
+		);
+		chmodSync(legacyTarget, 0o700);
+		rmSync(paths.cliManagedBin, { force: true });
+		symlinkSync(legacyTarget, paths.cliManagedBin);
 		const bootstrapStatus = JSON.parse(readFileSync(paths.cliBootstrapStatus, "utf-8"));
+		bootstrapStatus.npmPrefix = legacyPrefix;
+		bootstrapStatus.activeTarget = legacyTarget;
 		delete bootstrapStatus.version;
 		writeFileSync(paths.cliBootstrapStatus, JSON.stringify(bootstrapStatus));
-		expect(existsSync(paths.cliManagedBin)).toBe(true);
 
 		try {
 			const desired = normalizeManifestPayload(hostedCliManifestResponse(home, desiredSpec));
 			const result = applyRuntimeCliDesiredState(desired.manifest, paths);
+			const canonicalPrefix = join(paths.cliNpmPrefix, "packages", desiredVersion);
+			const canonicalTarget = join(canonicalPrefix, "bin", "clawdi");
 
 			expect(result.status).toBe("installed");
 			expect(result.packageSpec).toBe(desiredSpec);
 			expect(result.version).toBe(desiredVersion);
-			expect(result.activeTarget).not.toBe(bootstrapStatus.activeTarget);
+			expect(result.npmPrefix).toBe(canonicalPrefix);
+			expect(result.activeTarget).toBe(canonicalTarget);
+			expect(readlinkSync(paths.cliManagedBin)).toBe(canonicalTarget);
 			const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
 			expect(npmCalls.some((call) => call.startsWith("view "))).toBe(false);
 			expect(npmCalls.some((call) => call.startsWith("install "))).toBe(true);

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -173,6 +173,98 @@ const TEST_EGRESS_ENGINE_PIN = {
 	sha256: "2e95286b618fa6fd33e5e62a78c2e5112571d85f42ec2bac29b97ee242bdb5c5",
 };
 
+const TEST_HOSTED_LOCALE = {
+	language: "en" as const,
+	timezone: "UTC",
+};
+
+function runtimeWatchLocaleManifest(
+	home: string,
+	generation: number,
+	language: "en" | "fr" = "en",
+	timezone = "UTC",
+): RuntimeManifest {
+	return {
+		schemaVersion: "clawdi.runtimeDesiredState.v1",
+		deploymentId: "dep_watch_locale",
+		environmentId: "env_watch_locale",
+		instanceId: "iid_watch_locale",
+		generation,
+		issuedAt: "2026-07-11T00:00:00Z",
+		locale: { language, timezone },
+		workspaceRoot: join(home, "clawdi"),
+		controlPlane: { apiUrl: "https://cloud-api.test" },
+		clawdiCli: {
+			source: "npm:clawdi",
+			packageSpec: "clawdi@agent-v2",
+			registry: "https://registry.npmjs.org",
+		},
+		runtimes: {
+			openclaw: {
+				enabled: true,
+				run: hostedOpenClawRuntime().run,
+				services: {},
+			},
+		},
+		recovery: { cacheManifest: true, allowOfflineBoot: true },
+	};
+}
+
+function hostedRuntimeWatchLocalePayload(
+	home: string,
+	generation: number,
+	language: "en" | "fr" = "fr",
+	timezone = "Europe/Paris",
+): unknown {
+	return {
+		manifest: {
+			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+			runtime: "openclaw",
+			deploymentId: "dep_watch_locale",
+			environmentId: "env_watch_locale",
+			instanceId: "iid_watch_locale",
+			generation,
+			issuedAt: "2026-07-11T00:00:00Z",
+			locale: { language, timezone },
+			system: { home, workspace: join(home, "clawdi") },
+			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+			clawdiCli: {
+				source: "npm:clawdi",
+				packageSpec: "clawdi@agent-v2",
+				registry: "https://registry.npmjs.org",
+			},
+			runtimes: { openclaw: hostedOpenClawRuntime() },
+		},
+		secretValues: {},
+	};
+}
+
+function seedRuntimeWatchLocaleBaseline(home: string, state: string, run: string): RuntimePaths {
+	mkdirSync(join(run, "secrets"), { recursive: true });
+	mkdirSync(home, { recursive: true });
+	process.env.HOME = home;
+	process.env.CLAWDI_RUNTIME_MODE = "hosted";
+	process.env.CLAWDI_SERVICE_STATE_DIR = state;
+	process.env.CLAWDI_RUN_DIR = run;
+	process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
+	seedCurrentCliInstall(state, "clawdi@agent-v2", "0.13.0-test", "https://registry.npmjs.org");
+	writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
+	const paths = getRuntimePaths();
+	convergeRuntimeManifest(
+		{
+			manifest: runtimeWatchLocaleManifest(home, 1),
+			source: "remote-datasource",
+			sourcePath: "https://runtime.test/v1/runtime/manifest",
+			offline: false,
+			secretValues: {},
+		},
+		paths,
+	);
+	writeFileSync(paths.manifestEtag, '"manifest-locale-1"\n');
+	writeFileSync(paths.channelsEtag, '"channels-locale-1"\n');
+	return paths;
+}
+
 function seedMitmproxyCache(paths = getRuntimePaths()): typeof TEST_EGRESS_ENGINE_PIN {
 	const binary = join(
 		paths.egressEngineMaintainedRoot,
@@ -972,6 +1064,7 @@ describe("runtime manifest datasource", () => {
 							instanceId: "iid_remote",
 							generation: 3,
 							issuedAt: "2026-06-06T00:00:00Z",
+							locale: TEST_HOSTED_LOCALE,
 							system: {
 								user: "clawdi",
 								home,
@@ -1127,6 +1220,7 @@ chmod +x "$HOME/.local/bin/hermes"
 							instanceId: "iid_runtime_bridge",
 							generation: 4,
 							issuedAt: "2026-06-06T00:00:00Z",
+							locale: TEST_HOSTED_LOCALE,
 							system: { home, workspace: join(home, "managed-workspace") },
 							controlPlane: {
 								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
@@ -1220,6 +1314,7 @@ chmod +x "$HOME/.local/bin/hermes"
 							instanceId: "iid_chat_provider",
 							generation: 1,
 							issuedAt: "2026-06-22T00:00:00Z",
+							locale: TEST_HOSTED_LOCALE,
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
 								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
@@ -1317,6 +1412,7 @@ chmod +x "$HOME/.local/bin/hermes"
 							instanceId: "iid_codex_provider",
 							generation: 1,
 							issuedAt: "2026-06-22T00:00:00Z",
+							locale: TEST_HOSTED_LOCALE,
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
 								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
@@ -1431,6 +1527,7 @@ chmod +x "$HOME/.local/bin/hermes"
 				instanceId: "iid_direct_provider",
 				generation: 1,
 				issuedAt: "2026-06-22T00:00:00Z",
+				locale: { language: "fr", timezone: "Europe/Paris" },
 				workspaceRoot: join(home, "clawdi"),
 				controlPlane: { apiUrl: "https://cloud-api.test" },
 				runtimes: {
@@ -1477,6 +1574,11 @@ chmod +x "$HOME/.local/bin/hermes"
 		]);
 		const patch = JSON.parse(readFileSync(openclawPatch, "utf-8"));
 		expect(JSON.parse(readFileSync(openclawOriginsPatch, "utf-8"))).toEqual({
+			agents: {
+				defaults: {
+					userTimezone: "Europe/Paris",
+				},
+			},
 			gateway: {
 				auth: {
 					mode: "token",
@@ -2820,6 +2922,7 @@ exit 0
 					instanceId: "iid_hosted_provider_secret",
 					generation: 5,
 					issuedAt: "2026-06-15T00:00:00Z",
+					locale: TEST_HOSTED_LOCALE,
 					system: { home, workspace: join(home, "clawdi") },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
@@ -2979,6 +3082,7 @@ exit 64
 					instanceId: "iid_bridge_token",
 					generation: 1,
 					issuedAt: "2026-06-15T00:00:00Z",
+					locale: TEST_HOSTED_LOCALE,
 					system: { home },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
@@ -3024,6 +3128,7 @@ exit 64
 					instanceId: "iid_bridge_token_explicit",
 					generation: 1,
 					issuedAt: "2026-06-15T00:00:00Z",
+					locale: TEST_HOSTED_LOCALE,
 					system: { home },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
@@ -3088,6 +3193,7 @@ exit 64
 							instanceId: "iid_custom_auth",
 							generation: 1,
 							issuedAt: "2026-06-06T00:00:00Z",
+							locale: TEST_HOSTED_LOCALE,
 							system: { home },
 							controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 							clawdiCli: {
@@ -3148,6 +3254,7 @@ exit 64
 							instanceId: "iid_same_token",
 							generation: 1,
 							issuedAt: "2026-06-06T00:00:00Z",
+							locale: TEST_HOSTED_LOCALE,
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
 								manifestUrl: "https://runtime.test/v1/runtime/manifest",
@@ -3180,6 +3287,7 @@ exit 64
 							instanceId: "iid_same_token",
 							generation: 2,
 							issuedAt: "2026-06-06T00:01:00Z",
+							locale: TEST_HOSTED_LOCALE,
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
 								manifestUrl: "https://runtime.test/v1/runtime/manifest",
@@ -3786,6 +3894,179 @@ exit 64
 		]);
 	});
 
+	it("runtime watch wakes on its own manifest SSE signal and restarts only the runtime unit", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const bin = join(root, "bin");
+		const systemctlLog = join(root, "systemctl-locale.log");
+		const abort = new AbortController();
+		const previousLog = console.log;
+		const logs: string[] = [];
+		mkdirSync(bin, { recursive: true });
+		writeFileSync(
+			join(bin, "systemctl"),
+			`#!/usr/bin/env bash
+printf '%s\\n' "$*" >> '${systemctlLog}'
+exit 0
+`,
+		);
+		chmodSync(join(bin, "systemctl"), 0o700);
+		process.env.CLAWDI_SYSTEMD_APPLY = "1";
+		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
+		process.env.CLAWDI_RUNTIME_USER = "root";
+		process.env.CLAWDI_RUNTIME_INSTALL_OFFICIAL_SERVICES = "0";
+		seedRuntimeWatchLocaleBaseline(home, state, run);
+		console.log = (value?: unknown) => logs.push(String(value));
+		let manifestCalls = 0;
+		let manifestRequestsBeforeOwnSignal = 0;
+		let resolveInitialManifestRequest: (() => void) | null = null;
+		const initialManifestRequest = new Promise<void>((resolveRequest) => {
+			resolveInitialManifestRequest = resolveRequest;
+		});
+		const { captured, restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/runtime/manifest",
+				response: () => {
+					manifestCalls += 1;
+					if (manifestCalls === 1) {
+						resolveInitialManifestRequest?.();
+						return new Response(null, {
+							status: 304,
+							headers: { etag: '"manifest-locale-1"' },
+						});
+					}
+					return new Response(JSON.stringify(hostedRuntimeWatchLocalePayload(home, 2)), {
+						status: 200,
+						headers: {
+							"content-type": "application/json",
+							etag: '"manifest-locale-2"',
+						},
+					});
+				},
+			},
+			{
+				method: "GET",
+				path: "/v1/channels",
+				response: (request) => {
+					if (request.headers["if-none-match"]) {
+						return new Response(null, {
+							status: 304,
+							headers: { etag: '"channels-locale-1"' },
+						});
+					}
+					setTimeout(() => abort.abort(), 0);
+					return jsonResponse([]);
+				},
+			},
+		]);
+
+		try {
+			await runtimeWatch({
+				intervalMs: 60_000,
+				selfHealMs: 300_000,
+				json: true,
+				abort: abort.signal,
+				notificationConsumer: async (options) => {
+					await options.onEvent({
+						type: "runtime_manifest_changed",
+						environment_id: "env_other",
+					});
+					await initialManifestRequest;
+					manifestRequestsBeforeOwnSignal = captured.filter(
+						(request) => request.path === "/v1/runtime/manifest",
+					).length;
+					await options.onEvent({
+						type: "runtime_manifest_changed",
+						environment_id: "env_watch_locale",
+					});
+					await new Promise<void>((resolveDone) => {
+						if (options.abort.aborted) return resolveDone();
+						options.abort.addEventListener("abort", () => resolveDone(), { once: true });
+					});
+				},
+			});
+
+			expect(manifestRequestsBeforeOwnSignal).toBe(1);
+			expect(manifestCalls).toBe(2);
+			const events = logs.map((line) => JSON.parse(line));
+			expect(events.map((event) => event.status)).toEqual(["not_modified", "applied"]);
+			expect(events[1].etag).toBe('"manifest-locale-2"');
+			expect(
+				captured.filter((request) => request.path === "/v1/runtime/manifest")[1].headers[
+					"if-none-match"
+				],
+			).toBe('"manifest-locale-1"');
+			const systemctlCalls = readFileSync(systemctlLog, "utf-8").trim().split("\n");
+			expect(systemctlCalls).toContain("--user restart openclaw-gateway.service");
+			expect(systemctlCalls.some((call) => call.includes("restart clawdi-runtime-watch"))).toBe(
+				false,
+			);
+			const observed = readHostedRuntimeObserved(getRuntimePaths());
+			expect(expectRecord(observed?.watch, "runtime watch observed status").generation).toBe(2);
+		} finally {
+			restore();
+			console.log = previousLog;
+		}
+	});
+
+	it("runtime watch keeps polling after SSE authentication failure", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const abort = new AbortController();
+		const previousLog = console.log;
+		const logs: string[] = [];
+		seedRuntimeWatchLocaleBaseline(home, state, run);
+		console.log = (value?: unknown) => logs.push(String(value));
+		let manifestCalls = 0;
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/runtime/manifest",
+				response: () => {
+					manifestCalls += 1;
+					if (manifestCalls === 1) return new Response(null, { status: 304 });
+					return new Response(JSON.stringify(hostedRuntimeWatchLocalePayload(home, 2)), {
+						status: 200,
+						headers: {
+							"content-type": "application/json",
+							etag: '"manifest-locale-2"',
+						},
+					});
+				},
+			},
+			{
+				method: "GET",
+				path: "/v1/channels",
+				response: (request) => {
+					if (request.headers["if-none-match"]) return new Response(null, { status: 304 });
+					setTimeout(() => abort.abort(), 0);
+					return jsonResponse([]);
+				},
+			},
+		]);
+
+		try {
+			await runtimeWatch({
+				intervalMs: 20,
+				selfHealMs: 300_000,
+				json: true,
+				abort: abort.signal,
+				notificationConsumer: async (options) => {
+					options.onAuthFailure?.();
+				},
+			});
+
+			expect(manifestCalls).toBe(2);
+			expect(logs.map((line) => JSON.parse(line).status)).toEqual(["not_modified", "applied"]);
+		} finally {
+			restore();
+			console.log = previousLog;
+		}
+	});
+
 	it("runtime watch applies remote changes, tracks systemd unit changes, and saves the new ETag", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -3841,6 +4122,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 								instanceId: "iid_watch",
 								generation: 12,
 								issuedAt: "2026-06-06T00:00:00Z",
+								locale: TEST_HOSTED_LOCALE,
 								system: { home, workspace: join(home, "clawdi") },
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
@@ -3983,6 +4265,7 @@ exit 42
 								instanceId: "iid_watch_systemd_failure",
 								generation: 13,
 								issuedAt: "2026-06-06T00:00:00Z",
+								locale: TEST_HOSTED_LOCALE,
 								system: { home, workspace: join(home, "clawdi") },
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
@@ -4059,6 +4342,7 @@ exit 42
 				instanceId: "iid_watch_secret",
 				generation: 22,
 				issuedAt: "2026-06-06T00:00:00Z",
+				locale: TEST_HOSTED_LOCALE,
 				system: { home, workspace: join(home, "clawdi") },
 				controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 				clawdiCli: {
@@ -4338,6 +4622,7 @@ exit 64
 								instanceId: "iid_watch_recovery",
 								generation: 18,
 								issuedAt: "2026-06-06T00:00:00Z",
+								locale: TEST_HOSTED_LOCALE,
 								system: { home, workspace: join(home, "clawdi") },
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
@@ -4917,6 +5202,7 @@ chmod +x "$prefix/bin/clawdi"
 								instanceId: "iid_cli_update",
 								generation: 13,
 								issuedAt: "2026-06-06T00:00:00Z",
+								locale: TEST_HOSTED_LOCALE,
 								system: { home, workspace: join(home, "clawdi") },
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
@@ -5153,6 +5439,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 								instanceId: "iid_cli_mitm",
 								generation: 2,
 								issuedAt: "2026-06-06T00:00:00Z",
+								locale: TEST_HOSTED_LOCALE,
 								system: { home, workspace: join(home, "clawdi") },
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								egressEngine: mitmproxy,
@@ -5319,6 +5606,7 @@ chmod +x "$prefix/bin/clawdi"
 					instanceId: "iid_floating_cli_tag",
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",
+					locale: TEST_HOSTED_LOCALE,
 					system: { home, workspace: join(home, "clawdi") },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
@@ -5396,6 +5684,7 @@ exit 97
 					instanceId: "iid_cli_bootstrap_current",
 					generation: 1,
 					issuedAt: "2026-07-11T00:00:00Z",
+					locale: TEST_HOSTED_LOCALE,
 					system: { home, workspace: join(home, "clawdi") },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
@@ -5510,6 +5799,7 @@ chmod +x "$prefix/bin/clawdi"
 				instanceId: "iid_cli_self_heal",
 				generation: 30,
 				issuedAt: "2026-07-11T00:00:00Z",
+				locale: TEST_HOSTED_LOCALE,
 				system: { home, workspace: join(home, "clawdi") },
 				controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 				clawdiCli: {
@@ -5561,7 +5851,12 @@ chmod +x "$prefix/bin/clawdi"
 
 		try {
 			await Promise.race([
-				runtimeWatch({ intervalMs: 20, selfHealMs: 10, json: true }),
+				runtimeWatch({
+					intervalMs: 20,
+					selfHealMs: 10,
+					json: true,
+					notifications: false,
+				}),
 				new Promise<never>(
 					(_, reject) =>
 						(timeoutId = setTimeout(
@@ -5708,6 +6003,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 								instanceId: "iid_cli_update_converge_failure",
 								generation: 16,
 								issuedAt: "2026-06-06T00:00:00Z",
+								locale: TEST_HOSTED_LOCALE,
 								system: { home, workspace: join(home, "clawdi") },
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
@@ -5763,7 +6059,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 			expect(event.status).toBe("error");
 			expect(event.cliUpdate.status).toBe("installed");
 			expect(event.selfReexec).toBe(true);
-			expect(event.errors[0]).toContain("runtime openclaw channel projection failed");
+			expect(event.errors[0]).toContain("runtime openclaw provider projection failed");
 			expect(event.errors[0]).toContain("projection boom");
 			expect(existsSync(join(state, "cache", "manifest.etag"))).toBe(false);
 		} finally {
@@ -5862,6 +6158,7 @@ chmod +x "$prefix/bin/clawdi"
 			instanceId: "iid_cli_rollback",
 			generation: 18,
 			issuedAt: "2026-06-06T00:00:00Z",
+			locale: TEST_HOSTED_LOCALE,
 			system: { home, workspace: join(home, "clawdi") },
 			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 			clawdiCli: {
@@ -6007,6 +6304,7 @@ chmod +x "$prefix/bin/clawdi"
 								instanceId: "iid_cli_update_failure",
 								generation: 17,
 								issuedAt: "2026-06-06T00:00:00Z",
+								locale: TEST_HOSTED_LOCALE,
 								system: { home, workspace: join(home, "clawdi") },
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
@@ -6145,6 +6443,7 @@ chmod +x "$prefix/bin/clawdi"
 								generation: 19,
 								minimumCliVersion: "999.0.0",
 								issuedAt: "2026-06-06T00:00:00Z",
+								locale: TEST_HOSTED_LOCALE,
 								system: { home, workspace: join(home, "clawdi") },
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
@@ -6628,6 +6927,7 @@ exit 64
 								instanceId: "iid_init",
 								generation: 7,
 								issuedAt: "2026-06-06T00:00:00Z",
+								locale: TEST_HOSTED_LOCALE,
 								system: { home, workspace: join(home, "clawdi") },
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
@@ -7776,6 +8076,7 @@ exit 64
 							instanceId: "iid_workspace",
 							generation: 1,
 							issuedAt: "2026-06-06T00:00:00Z",
+							locale: TEST_HOSTED_LOCALE,
 							system: { home, workspace },
 							controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 							clawdiCli: {
@@ -7899,6 +8200,7 @@ exit 64
 					instanceId: "iid_legacy_api_url",
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",
+					locale: TEST_HOSTED_LOCALE,
 					system: { home },
 					controlPlane: { apiUrl: "https://api.test" },
 					clawdiCli: {
@@ -7944,6 +8246,7 @@ exit 64
 					instanceId: "iid_runtime_workspace",
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",
+					locale: TEST_HOSTED_LOCALE,
 					system: { home, workspace: join(home, "system-workspace") },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
@@ -8650,6 +8953,125 @@ exit 64
 		expect(JSON.parse(readFileSync(cachePath, "utf-8")).generation).toBe(1);
 	});
 
+	it("updates the OpenClaw locale block without changing user-authored workspace content", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const workspace = join(home, "clawdi");
+		const soulPath = join(workspace, "SOUL.md");
+		const userPath = join(workspace, "USER.md");
+		mkdirSync(workspace, { recursive: true });
+		writeFileSync(soulPath, "User preface.\n\nUser epilogue.\n");
+		writeFileSync(userPath, "User profile stays untouched.\n");
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+
+		const manifestFor = (language: "en" | "fr", timezone: string): RuntimeManifest => ({
+			schemaVersion: "clawdi.runtimeDesiredState.v1",
+			deploymentId: "dep_locale_openclaw",
+			environmentId: "env_locale_openclaw",
+			instanceId: "iid_locale_openclaw",
+			generation: language === "en" ? 1 : 2,
+			issuedAt: "2026-07-11T00:00:00Z",
+			locale: { language, timezone },
+			workspaceRoot: workspace,
+			controlPlane: { apiUrl: "https://cloud-api.test" },
+			runtimes: {
+				openclaw: {
+					enabled: true,
+					run: { command: "/bin/true", args: [], env: {}, prependPath: [] },
+				},
+			},
+			recovery: {},
+		});
+		const paths = getRuntimePaths();
+		const converge = (manifest: RuntimeManifest) =>
+			convergeRuntimeManifest(
+				{
+					manifest,
+					source: "fixture-file",
+					sourcePath: "test://locale-openclaw",
+					offline: false,
+					secretValues: {},
+				},
+				paths,
+			);
+
+		converge(manifestFor("en", "UTC"));
+		const initialRevision = systemdEnvRevision(readSystemdEnvFile(paths, "openclaw-gateway"));
+		expect(readSystemdEnvFile(paths, "openclaw-gateway")).toContain('TZ="UTC"');
+
+		converge(manifestFor("fr", "Europe/Paris"));
+		const soul = readFileSync(soulPath, "utf-8");
+		expect(soul.startsWith("User preface.\n\nUser epilogue.\n")).toBe(true);
+		expect(soul.match(/clawdi managed locale/g)).toHaveLength(2);
+		expect(soul).toContain("`fr`");
+		expect(soul).toContain("`Europe/Paris`");
+		expect(readFileSync(userPath, "utf-8")).toBe("User profile stays untouched.\n");
+		const updatedEnv = readSystemdEnvFile(paths, "openclaw-gateway");
+		expect(updatedEnv).toContain('TZ="Europe/Paris"');
+		expect(systemdEnvRevision(updatedEnv)).not.toBe(initialRevision);
+		converge(manifestFor("fr", "Europe/Paris"));
+		expect(readFileSync(soulPath, "utf-8")).toBe(soul);
+		expect(systemdEnvRevision(readSystemdEnvFile(paths, "openclaw-gateway"))).toBe(
+			systemdEnvRevision(updatedEnv),
+		);
+	});
+
+	it("projects Hermes locale into its managed SOUL block and timezone config", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const hermesHome = join(home, ".hermes");
+		mkdirSync(hermesHome, { recursive: true });
+		writeFileSync(join(hermesHome, "SOUL.md"), "User Hermes identity.\n");
+		writeFileSync(join(hermesHome, "config.yaml"), "custom_setting: keep\n");
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+
+		const manifest: RuntimeManifest = {
+			schemaVersion: "clawdi.runtimeDesiredState.v1",
+			deploymentId: "dep_locale_hermes",
+			environmentId: "env_locale_hermes",
+			instanceId: "iid_locale_hermes",
+			generation: 1,
+			issuedAt: "2026-07-11T00:00:00Z",
+			locale: { language: "zh-TW", timezone: "Asia/Taipei" },
+			workspaceRoot: join(home, "clawdi"),
+			controlPlane: { apiUrl: "https://cloud-api.test" },
+			runtimes: {
+				hermes: {
+					enabled: true,
+					run: { command: "/bin/true", args: [], env: {}, prependPath: [] },
+				},
+			},
+			recovery: {},
+		};
+		const paths = getRuntimePaths();
+		convergeRuntimeManifest(
+			{
+				manifest,
+				source: "fixture-file",
+				sourcePath: "test://locale-hermes",
+				offline: false,
+				secretValues: {},
+			},
+			paths,
+		);
+
+		const soul = readFileSync(join(hermesHome, "SOUL.md"), "utf-8");
+		expect(soul.startsWith("User Hermes identity.\n")).toBe(true);
+		expect(soul).toContain("`zh-TW`");
+		const config = readHermesConfigYaml(home);
+		expect(config.custom_setting).toBe("keep");
+		expect(config.timezone).toBe("Asia/Taipei");
+		expect(readSystemdEnvFile(paths, "clawdi-hermes")).toContain('TZ="Asia/Taipei"');
+	});
+
 	it("runtime program revision changes for control-plane changes but not sibling runtimes", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -8828,6 +9250,7 @@ exit 64
 							instanceId: "iid_manifest_only",
 							generation: 1,
 							issuedAt: "2026-06-06T00:00:00Z",
+							locale: TEST_HOSTED_LOCALE,
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
 								manifestUrl: "https://runtime-source.test/v1/desired-state/",
@@ -8882,6 +9305,7 @@ exit 64
 							instanceId: "iid_remote",
 							generation: 4,
 							issuedAt: "2026-06-06T00:00:00Z",
+							locale: TEST_HOSTED_LOCALE,
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
 								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
@@ -9161,6 +9585,7 @@ exit 64
 							instanceId: "iid_sync",
 							generation: 9,
 							issuedAt: "2026-06-06T00:00:00Z",
+							locale: TEST_HOSTED_LOCALE,
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
 								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
@@ -9265,6 +9690,7 @@ exit 64
 					instanceId: "iid_no_secret_ref",
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",
+					locale: TEST_HOSTED_LOCALE,
 					system: { home, workspace: join(home, "clawdi") },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
@@ -9309,6 +9735,7 @@ exit 64
 					instanceId: "iid_bad_mitm",
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",
+					locale: TEST_HOSTED_LOCALE,
 					system: { home, workspace: join(home, "clawdi") },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1080,6 +1080,11 @@ describe("runtime manifest datasource", () => {
 				generation: 3,
 				issuedAt: "2026-06-06T00:00:00Z",
 				controlPlane: { apiUrl: "https://cloud-api.test" },
+				clawdiCli: {
+					source: "npm:clawdi",
+					packageSpec: "clawdi@0.13.0-test",
+					registry: "https://registry.npmjs.org",
+				},
 				runtimes: { openclaw: { enabled: false } },
 				projection: {
 					providers: {
@@ -1128,6 +1133,11 @@ describe("runtime manifest datasource", () => {
 				generation: 3,
 				issuedAt: "2026-06-06T00:00:00Z",
 				controlPlane: { apiUrl: "https://cloud-api.test" },
+				clawdiCli: {
+					source: "npm:clawdi",
+					packageSpec: "clawdi@0.13.0-test",
+					registry: "https://registry.npmjs.org",
+				},
 				runtimes: { openclaw: { enabled: false } },
 				projection: {
 					providers: {
@@ -1321,6 +1331,48 @@ describe("runtime manifest datasource", () => {
 		}
 	});
 
+	for (const packageSpec of ["clawdi@latest", "clawdi"]) {
+		it(`rejects ${packageSpec} from a remote hosted manifest`, async () => {
+			const home = join(root, "home", "clawdi");
+			const state = join(root, "var", "lib", "clawdi");
+			mkdirSync(home, { recursive: true });
+			process.env.HOME = home;
+			process.env.CLAWDI_RUNTIME_MODE = "hosted";
+			process.env.CLAWDI_SERVICE_STATE_DIR = state;
+			process.env.CLAWDI_RUN_DIR = join(root, "run", "clawdi");
+			process.env.CLAWDI_AUTH_TOKEN = "auth-token";
+			process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
+			const { restore } = mockFetch([
+				{
+					method: "GET",
+					path: "/v1/runtime/manifest",
+					response: () => jsonResponse(hostedCliManifestResponse(home, packageSpec)),
+				},
+			]);
+
+			try {
+				const loaded = await loadRuntimeManifest(getRuntimePaths());
+				expect("errors" in loaded).toBe(true);
+				if (!("errors" in loaded)) throw new Error("expected remote manifest rejection");
+				expect(loaded.errors.join("\n")).toContain("must be clawdi@<exact-semver>");
+			} finally {
+				restore();
+			}
+		});
+	}
+
+	it("rejects CLAWDI_RUNTIME_MANIFEST_PATH without the fixture test gate", async () => {
+		const manifestPath = join(root, "hosted-bootstrap-fixture.json");
+		process.env.CLAWDI_RUNTIME_MANIFEST_PATH = manifestPath;
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths({ mode: "hosted" }));
+		expect("errors" in loaded).toBe(true);
+		if (!("errors" in loaded)) throw new Error("expected fixture gate rejection");
+		expect(loaded.errors).toContain(
+			"CLAWDI_RUNTIME_MANIFEST_PATH requires CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS=1",
+		);
+	});
+
 	it("accepts a managed bootstrap tarball only from CLAWDI_RUNTIME_MANIFEST_PATH", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -1334,6 +1386,7 @@ describe("runtime manifest datasource", () => {
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_RUNTIME_MANIFEST_PATH = manifestPath;
+		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
 
 		const loaded = await loadRuntimeManifest(getRuntimePaths());
 		if (!("manifest" in loaded)) {
@@ -1342,6 +1395,46 @@ describe("runtime manifest datasource", () => {
 		expect(loaded.source).toBe("fixture-file");
 		expect(loaded.manifest.clawdiCli?.packageSpec).toBe(packageSpec);
 	});
+
+	it("rejects a generic internal fixture in hosted mode", async () => {
+		const home = join(root, "home", "clawdi");
+		const manifestPath = join(root, "generic-hosted-fixture.json");
+		process.env.HOME = home;
+		writeFileSync(manifestPath, JSON.stringify(genericCliDesiredState("clawdi@1.2.3")));
+		process.env.CLAWDI_RUNTIME_MANIFEST_PATH = manifestPath;
+		process.env.CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS = "1";
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths({ mode: "hosted" }));
+		expect("errors" in loaded).toBe(true);
+		if (!("errors" in loaded)) throw new Error("expected hosted fixture rejection");
+		expect(loaded.mode).toBe("manifest-rejected");
+		expect(loaded.errors.join("\n")).toContain("manifest: Invalid input");
+	});
+
+	for (const packageSpec of ["clawdi@latest", "clawdi"]) {
+		it(`rejects cached hosted state with ${packageSpec} and no hosted marker`, async () => {
+			const home = join(root, "home", "clawdi");
+			const state = join(root, "var", "lib", "clawdi");
+			mkdirSync(join(state, "cache"), { recursive: true });
+			process.env.HOME = home;
+			process.env.CLAWDI_RUNTIME_MODE = "hosted";
+			process.env.CLAWDI_SERVICE_STATE_DIR = state;
+			process.env.CLAWDI_RUN_DIR = join(root, "run", "clawdi");
+			writeFileSync(
+				join(state, "cache", "manifest.last-good.json"),
+				JSON.stringify({
+					...genericCliDesiredState(packageSpec),
+					workspaceRoot: join(home, "clawdi"),
+					recovery: { cacheManifest: true, allowOfflineBoot: true },
+				}),
+			);
+
+			const loaded = await loadRuntimeManifest(getRuntimePaths());
+			expect("errors" in loaded).toBe(true);
+			if (!("errors" in loaded)) throw new Error("expected cached manifest rejection");
+			expect(loaded.errors.join("\n")).toContain("must be clawdi@<exact-semver>");
+		});
+	}
 
 	it("recovers hosted bridge token from pid1 env for Hermes runtime bridge exposure", async () => {
 		const home = join(root, "home", "clawdi");
@@ -8716,7 +8809,7 @@ exit 64
 		writeFileSync(futureBin, "#!/bin/sh\nexit 0\n");
 		chmodSync(futureBin, 0o700);
 		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_MODE = "local";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		writeFileSync(
@@ -8941,7 +9034,7 @@ exit 64
 		chmodSync(openclawBin, 0o700);
 		chmodSync(hermesBin, 0o700);
 		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_MODE = "local";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_AUTH_TOKEN = "deploy-key-secret";
@@ -9762,7 +9855,7 @@ exit 64
 		const manifestPath = join(root, "runtime-reset.json");
 		mkdirSync(join(state, "cache"), { recursive: true });
 		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_MODE = "local";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		const paths = getRuntimePaths();
@@ -9801,7 +9894,7 @@ exit 64
 		const run = join(root, "run", "clawdi");
 		const manifestPath = join(root, "runtime-secretref.json");
 		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_MODE = "local";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		writeFileSync(
@@ -10040,7 +10133,7 @@ exit 64
 		mkdirSync(join(state, "config", "run"), { recursive: true });
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_MODE = "local";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		writeFileSync(join(state, "config", "egress", "profiles.json"), "{}\n");
@@ -10086,7 +10179,7 @@ exit 64
 		mkdirSync(home, { recursive: true });
 		mkdirSync(join(state, "cache"), { recursive: true });
 		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_MODE = "local";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		const previousManifest = {
@@ -10128,7 +10221,7 @@ exit 64
 		const manifestPath = join(root, "expired-manifest.json");
 		mkdirSync(home, { recursive: true });
 		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_MODE = "local";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		writeFileSync(
@@ -10421,7 +10514,7 @@ exit 64
 		const manifestPath = join(root, "manifest.json");
 		mkdirSync(home, { recursive: true });
 		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_MODE = "local";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_AUTH_TOKEN = "auth-token";
@@ -10467,7 +10560,7 @@ exit 64
 		const manifestPath = join(root, "manifest.json");
 		mkdirSync(home, { recursive: true });
 		process.env.HOME = home;
-		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_RUNTIME_MODE = "local";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
 		process.env.CLAWDI_RUN_DIR = run;
 		writeFileSync(

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -181,6 +181,13 @@ const TEST_HOSTED_MINIMUM_CLI_VERSION = "0.12.10-beta.51";
 
 function hostedRequiredState() {
 	return {
+		providers: {
+			default: {
+				kind: "openai-compatible",
+				status: "error",
+				error: { code: "provider_not_found", message: "fixture provider unavailable" },
+			},
+		},
 		liveSync: { enabled: false, agents: [] },
 		recovery: { cacheManifest: true, allowOfflineBoot: true },
 	};
@@ -1137,6 +1144,7 @@ describe("runtime manifest datasource", () => {
 								openclaw: hostedOpenClawRuntime({
 									install: { source: "official", channel: "stable" },
 									paths: { home },
+									provider_ids: ["default", "codex"],
 								}),
 							},
 							providers: {
@@ -4287,6 +4295,16 @@ printf 'ActiveState=active\\nSubState=running\\n'
 								},
 								runtimes: {
 									openclaw: hostedOpenClawRuntime(),
+								},
+								providers: {
+									default: {
+										kind: "openai-compatible",
+										type: "custom_openai_compatible",
+										baseUrl: "https://provider.test/v1",
+										model: "gpt-test",
+										apiMode: "openai_chat",
+										status: "ok",
+									},
 								},
 							},
 							secretValues: {},

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -127,6 +127,7 @@ function seedCurrentCliInstall(
 	state: string,
 	packageSpec = "clawdi@latest",
 	version = "0.13.0-test",
+	registry: string | null = null,
 ): void {
 	const active = join(state, "bin", "clawdi");
 	const target = join(state, "npm", "bin", "clawdi");
@@ -154,7 +155,7 @@ echo "seeded clawdi"
 			status: "installed",
 			source: "npm",
 			packageSpec,
-			registry: null,
+			registry,
 			npmPrefix: join(state, "npm"),
 			npmCache: join(state, "npm-cache"),
 			activePath: active,
@@ -983,8 +984,8 @@ describe("runtime manifest datasource", () => {
 							},
 							clawdiCli: {
 								source: "npm:clawdi",
-								managedConfig: true,
-								userEditableConfig: false,
+								packageSpec: "clawdi@agent-v2",
+								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
 								openclaw: hostedOpenClawRuntime({
@@ -1037,7 +1038,7 @@ describe("runtime manifest datasource", () => {
 			expect(loaded.manifest.environmentId).toBe("env_test");
 			expect(loaded.manifest.controlPlane.apiUrl).toBe("https://cloud-api.test");
 			expect(loaded.manifest.clawdiCli?.source).toBe("npm:clawdi");
-			expect(loaded.manifest.clawdiCli?.packageSpec).toBe("clawdi@latest");
+			expect(loaded.manifest.clawdiCli?.packageSpec).toBe("clawdi@agent-v2");
 			expect(loaded.manifest.projection?.mcp).toEqual({
 				enabled: true,
 				profile: "clawdi-default",
@@ -1131,6 +1132,11 @@ chmod +x "$HOME/.local/bin/hermes"
 								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
+							clawdiCli: {
+								source: "npm:clawdi",
+								packageSpec: "clawdi@agent-v2",
+								registry: "https://registry.npmjs.org",
+							},
 							runtimes: {
 								hermes: hostedHermesRuntime({
 									install: { source: "official", channel: "stable" },
@@ -1218,6 +1224,11 @@ chmod +x "$HOME/.local/bin/hermes"
 							controlPlane: {
 								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
+							},
+							clawdiCli: {
+								source: "npm:clawdi",
+								packageSpec: "clawdi@agent-v2",
+								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
 								openclaw: hostedOpenClawRuntime(),
@@ -1310,6 +1321,11 @@ chmod +x "$HOME/.local/bin/hermes"
 							controlPlane: {
 								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
+							},
+							clawdiCli: {
+								source: "npm:clawdi",
+								packageSpec: "clawdi@agent-v2",
+								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
 								openclaw: hostedOpenClawRuntime(),
@@ -2806,6 +2822,11 @@ exit 0
 					issuedAt: "2026-06-15T00:00:00Z",
 					system: { home, workspace: join(home, "clawdi") },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+					clawdiCli: {
+						source: "npm:clawdi",
+						packageSpec: "clawdi@agent-v2",
+						registry: "https://registry.npmjs.org",
+					},
 					runtimes: {
 						openclaw: hostedOpenClawRuntime(),
 					},
@@ -2960,6 +2981,11 @@ exit 64
 					issuedAt: "2026-06-15T00:00:00Z",
 					system: { home },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+					clawdiCli: {
+						source: "npm:clawdi",
+						packageSpec: "clawdi@agent-v2",
+						registry: "https://registry.npmjs.org",
+					},
 					runtimes: {
 						openclaw: hostedOpenClawRuntime(),
 					},
@@ -3000,6 +3026,11 @@ exit 64
 					issuedAt: "2026-06-15T00:00:00Z",
 					system: { home },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+					clawdiCli: {
+						source: "npm:clawdi",
+						packageSpec: "clawdi@agent-v2",
+						registry: "https://registry.npmjs.org",
+					},
 					runtimes: {
 						openclaw: hostedOpenClawRuntime(),
 						hermes: { enabled: false, install: { source: "official" }, paths: { home } },
@@ -3059,6 +3090,11 @@ exit 64
 							issuedAt: "2026-06-06T00:00:00Z",
 							system: { home },
 							controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+							clawdiCli: {
+								source: "npm:clawdi",
+								packageSpec: "clawdi@agent-v2",
+								registry: "https://registry.npmjs.org",
+							},
 							runtimes: { hermes: hostedHermesRuntime() },
 							bridge: { surfaces: [hostedHermesBridgeSurface()] },
 						},
@@ -3117,6 +3153,11 @@ exit 64
 								manifestUrl: "https://runtime.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
+							clawdiCli: {
+								source: "npm:clawdi",
+								packageSpec: "clawdi@agent-v2",
+								registry: "https://registry.npmjs.org",
+							},
 							runtimes: { openclaw: hostedOpenClawRuntime() },
 							liveSync: {
 								enabled: true,
@@ -3143,6 +3184,11 @@ exit 64
 							controlPlane: {
 								manifestUrl: "https://runtime.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
+							},
+							clawdiCli: {
+								source: "npm:clawdi",
+								packageSpec: "clawdi@agent-v2",
+								registry: "https://registry.npmjs.org",
 							},
 							runtimes: { openclaw: hostedOpenClawRuntime() },
 							liveSync: {
@@ -3769,7 +3815,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		seedCurrentCliInstall(state);
+		seedCurrentCliInstall(state, "clawdi@agent-v2", "0.13.0-test", "https://registry.npmjs.org");
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
@@ -3797,6 +3843,11 @@ printf 'ActiveState=active\\nSubState=running\\n'
 								issuedAt: "2026-06-06T00:00:00Z",
 								system: { home, workspace: join(home, "clawdi") },
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+								clawdiCli: {
+									source: "npm:clawdi",
+									packageSpec: "clawdi@agent-v2",
+									registry: "https://registry.npmjs.org",
+								},
 								runtimes: {
 									openclaw: hostedOpenClawRuntime(),
 								},
@@ -3906,7 +3957,7 @@ exit 42
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		seedCurrentCliInstall(state);
+		seedCurrentCliInstall(state, "clawdi@agent-v2", "0.13.0-test", "https://registry.npmjs.org");
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
@@ -3934,6 +3985,11 @@ exit 42
 								issuedAt: "2026-06-06T00:00:00Z",
 								system: { home, workspace: join(home, "clawdi") },
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+								clawdiCli: {
+									source: "npm:clawdi",
+									packageSpec: "clawdi@agent-v2",
+									registry: "https://registry.npmjs.org",
+								},
 								runtimes: {
 									openclaw: hostedOpenClawRuntime(),
 								},
@@ -4005,6 +4061,11 @@ exit 42
 				issuedAt: "2026-06-06T00:00:00Z",
 				system: { home, workspace: join(home, "clawdi") },
 				controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+				clawdiCli: {
+					source: "npm:clawdi",
+					packageSpec: "clawdi@agent-v2",
+					registry: "https://registry.npmjs.org",
+				},
 				runtimes: {
 					openclaw: hostedOpenClawRuntime({
 						install: { source: "official", channel: "stable" },
@@ -4092,7 +4153,7 @@ exit 64
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		seedCurrentCliInstall(state);
+		seedCurrentCliInstall(state, "clawdi@agent-v2", "0.13.0-test", "https://registry.npmjs.org");
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
@@ -4232,7 +4293,7 @@ exit 64
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
-		seedCurrentCliInstall(state);
+		seedCurrentCliInstall(state, "clawdi@agent-v2", "0.13.0-test", "https://registry.npmjs.org");
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
@@ -4279,6 +4340,11 @@ exit 64
 								issuedAt: "2026-06-06T00:00:00Z",
 								system: { home, workspace: join(home, "clawdi") },
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+								clawdiCli: {
+									source: "npm:clawdi",
+									packageSpec: "clawdi@agent-v2",
+									registry: "https://registry.npmjs.org",
+								},
 								runtimes: { openclaw: hostedOpenClawRuntime() },
 							},
 							secretValues: {},
@@ -4856,6 +4922,7 @@ chmod +x "$prefix/bin/clawdi"
 								clawdiCli: {
 									source: "npm:clawdi",
 									packageSpec: "clawdi@0.13.1-beta.0",
+									registry: "https://registry.npmjs.org",
 								},
 								runtimes: {
 									openclaw: hostedOpenClawRuntime(),
@@ -5092,6 +5159,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 								clawdiCli: {
 									source: "npm:clawdi",
 									packageSpec: "clawdi@0.13.2-beta.0",
+									registry: "https://registry.npmjs.org",
 								},
 								runtimes: {
 									openclaw: hostedOpenClawRuntime(),
@@ -5236,7 +5304,12 @@ chmod +x "$prefix/bin/clawdi"
 		process.env.CLAWDI_RUN_DIR = run;
 		try {
 			const paths = getRuntimePaths();
-			seedCurrentCliInstall(state, "clawdi@agent-v2", "0.12.10-beta.48");
+			seedCurrentCliInstall(
+				state,
+				"clawdi@agent-v2",
+				"0.12.10-beta.48",
+				"https://registry.npmjs.org",
+			);
 			const result = applyRuntimeCliDesiredState(
 				{
 					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
@@ -5248,7 +5321,11 @@ chmod +x "$prefix/bin/clawdi"
 					issuedAt: "2026-06-06T00:00:00Z",
 					system: { home, workspace: join(home, "clawdi") },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
-					clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@agent-v2" },
+					clawdiCli: {
+						source: "npm:clawdi",
+						packageSpec: "clawdi@agent-v2",
+						registry: "https://registry.npmjs.org",
+					},
 					runtimes: { openclaw: hostedOpenClawRuntime() },
 				},
 				paths,
@@ -5270,6 +5347,260 @@ chmod +x "$prefix/bin/clawdi"
 			expect(existsSync(join(paths.cliNpmCache, "view-proof"))).toBe(true);
 			expect(existsSync(join(home, ".npm"))).toBe(false);
 		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
+	});
+
+	it("keeps an official agent-v2 bootstrap install current without reinstalling", () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const bin = join(root, "bin");
+		const npmLog = join(root, "npm-current.log");
+		const previousPath = process.env.PATH;
+		mkdirSync(bin, { recursive: true });
+		writeFileSync(
+			join(bin, "npm"),
+			`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> '${npmLog}'
+if [ "\${1:-}" = "view" ]; then
+  echo '"0.12.10-beta.50"'
+  exit 0
+fi
+echo "unexpected npm install" >&2
+exit 97
+`,
+		);
+		chmodSync(join(bin, "npm"), 0o700);
+		process.env.PATH = `${bin}:${previousPath ?? ""}`;
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		seedCurrentCliInstall(
+			state,
+			"clawdi@agent-v2",
+			"0.12.10-beta.50",
+			"https://registry.npmjs.org",
+		);
+
+		try {
+			const result = applyRuntimeCliDesiredState(
+				{
+					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					runtime: "openclaw",
+					deploymentId: "dep_cli_bootstrap_current",
+					environmentId: "env_cli_bootstrap_current",
+					instanceId: "iid_cli_bootstrap_current",
+					generation: 1,
+					issuedAt: "2026-07-11T00:00:00Z",
+					system: { home, workspace: join(home, "clawdi") },
+					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+					clawdiCli: {
+						source: "npm:clawdi",
+						packageSpec: "clawdi@agent-v2",
+						registry: "https://registry.npmjs.org",
+					},
+					runtimes: { openclaw: hostedOpenClawRuntime() },
+				},
+				getRuntimePaths(),
+			);
+
+			expect(result.status).toBe("current");
+			expect(result.packageSpec).toBe("clawdi@agent-v2");
+			expect(result.registry).toBe("https://registry.npmjs.org");
+			expect(result.version).toBe("0.12.10-beta.50");
+			const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
+			expect(npmCalls.some((call) => call.startsWith("view clawdi@agent-v2"))).toBe(true);
+			expect(npmCalls.some((call) => call.startsWith("install "))).toBe(false);
+		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
+	});
+
+	it("runtime watch self-heal re-resolves agent-v2 when manifest ETags stay unchanged", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const sourcePath = join(root, "runtime-source.json");
+		const bin = join(root, "bin");
+		const npmLog = join(root, "npm-self-heal.log");
+		const previousExitCode = process.exitCode;
+		const previousLog = console.log;
+		const previousPath = process.env.PATH;
+		const logs: string[] = [];
+		mkdirSync(join(run, "secrets"), { recursive: true });
+		mkdirSync(bin, { recursive: true });
+		mkdirSync(home, { recursive: true });
+		writeFileSync(
+			join(bin, "npm"),
+			`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> '${npmLog}'
+if [ "\${1:-}" = "view" ]; then
+  echo '"0.12.10-beta.50"'
+  exit 0
+fi
+prefix=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--prefix" ]; then
+    prefix="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+test -n "$prefix"
+install -d "$prefix/bin"
+cat > "$prefix/bin/clawdi" <<'SH'
+#!/usr/bin/env bash
+if [ "\${1:-}" = "--version" ]; then
+  echo "0.12.10-beta.50"
+  exit 0
+fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
+  exit 0
+fi
+exit 64
+SH
+chmod +x "$prefix/bin/clawdi"
+`,
+		);
+		chmodSync(join(bin, "npm"), 0o700);
+		process.env.PATH = `${bin}:${previousPath ?? ""}`;
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
+		process.exitCode = undefined;
+		console.log = (value?: unknown) => {
+			logs.push(String(value));
+		};
+		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
+		writeFileSync(
+			sourcePath,
+			JSON.stringify({
+				schemaVersion: "clawdi.runtimeSource.v1",
+				type: "http",
+				url: "https://runtime.test/v1/runtime/manifest",
+				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
+			}),
+		);
+		const paths = getRuntimePaths();
+		seedCurrentCliInstall(
+			state,
+			"clawdi@agent-v2",
+			"0.12.10-beta.49",
+			"https://registry.npmjs.org",
+		);
+		mkdirSync(dirname(paths.manifestEtag), { recursive: true });
+		writeFileSync(paths.manifestEtag, '"manifest-self-heal"\n');
+		writeFileSync(paths.channelsEtag, '"channels-self-heal"\n');
+		const manifestPayload = {
+			manifest: {
+				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				runtime: "openclaw",
+				deploymentId: "dep_cli_self_heal",
+				environmentId: "env_cli_self_heal",
+				instanceId: "iid_cli_self_heal",
+				generation: 30,
+				issuedAt: "2026-07-11T00:00:00Z",
+				system: { home, workspace: join(home, "clawdi") },
+				controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+				clawdiCli: {
+					source: "npm:clawdi",
+					packageSpec: "clawdi@agent-v2",
+					registry: "https://registry.npmjs.org",
+				},
+				runtimes: { openclaw: hostedOpenClawRuntime() },
+			},
+			secretValues: {},
+		};
+		const { captured, restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/runtime/manifest",
+				response: (request) =>
+					request.headers["if-none-match"]
+						? new Response(null, {
+								status: 304,
+								headers: { etag: '"manifest-self-heal"' },
+							})
+						: new Response(JSON.stringify(manifestPayload), {
+								status: 200,
+								headers: {
+									"content-type": "application/json",
+									etag: '"manifest-self-heal"',
+								},
+							}),
+			},
+			{
+				method: "GET",
+				path: "/v1/channels",
+				response: (request) =>
+					request.headers["if-none-match"]
+						? new Response(null, {
+								status: 304,
+								headers: { etag: '"channels-self-heal"' },
+							})
+						: new Response(JSON.stringify([]), {
+								status: 200,
+								headers: {
+									"content-type": "application/json",
+									etag: '"channels-self-heal"',
+								},
+							}),
+			},
+		]);
+		let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+		try {
+			await Promise.race([
+				runtimeWatch({ intervalMs: 20, selfHealMs: 10, json: true }),
+				new Promise<never>(
+					(_, reject) =>
+						(timeoutId = setTimeout(
+							() => reject(new Error("runtime watch self-heal test timed out")),
+							2_000,
+						)),
+				),
+			]);
+
+			expect(process.exitCode ?? 0).toBe(0);
+			expect(captured).toHaveLength(4);
+			expect(captured.map((request) => request.path)).toEqual([
+				"/v1/runtime/manifest",
+				"/v1/channels",
+				"/v1/runtime/manifest",
+				"/v1/channels",
+			]);
+			expect(captured[0].headers["if-none-match"]).toBe('"manifest-self-heal"');
+			expect(captured[1].headers["if-none-match"]).toBe('"channels-self-heal"');
+			expect(captured[2].headers["if-none-match"]).toBeUndefined();
+			expect(captured[3].headers["if-none-match"]).toBeUndefined();
+			const events = logs.map((line) => JSON.parse(line));
+			expect(events.map((event) => event.status)).toEqual(["not_modified", "applied"]);
+			expect(events[1].cliUpdate).toEqual(
+				expect.objectContaining({
+					status: "installed",
+					packageSpec: "clawdi@agent-v2",
+					version: "0.12.10-beta.50",
+				}),
+			);
+			expect(events[1].selfReexec).toBe(true);
+			const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
+			expect(npmCalls.some((call) => call.startsWith("view clawdi@agent-v2"))).toBe(true);
+			expect(npmCalls.some((call) => call.startsWith("install "))).toBe(true);
+		} finally {
+			if (timeoutId !== undefined) clearTimeout(timeoutId);
+			restore();
+			console.log = previousLog;
+			process.exitCode = previousExitCode;
 			if (previousPath === undefined) delete process.env.PATH;
 			else process.env.PATH = previousPath;
 		}
@@ -5379,7 +5710,11 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 								issuedAt: "2026-06-06T00:00:00Z",
 								system: { home, workspace: join(home, "clawdi") },
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
-								clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@0.13.3-beta.0" },
+								clawdiCli: {
+									source: "npm:clawdi",
+									packageSpec: "clawdi@0.13.3-beta.0",
+									registry: "https://registry.npmjs.org",
+								},
 								runtimes: {
 									openclaw: hostedOpenClawRuntime({
 										install: { source: "official", channel: "stable" },
@@ -5529,7 +5864,11 @@ chmod +x "$prefix/bin/clawdi"
 			issuedAt: "2026-06-06T00:00:00Z",
 			system: { home, workspace: join(home, "clawdi") },
 			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
-			clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@beta" },
+			clawdiCli: {
+				source: "npm:clawdi",
+				packageSpec: "clawdi@beta",
+				registry: "https://registry.npmjs.org",
+			},
 			runtimes: {
 				openclaw: hostedOpenClawRuntime({
 					install: { source: "official", channel: "stable" },
@@ -5594,7 +5933,11 @@ chmod +x "$prefix/bin/clawdi"
 						generation: 18,
 						issuedAt: "2026-06-06T00:00:00Z",
 						controlPlane: { apiUrl: "https://cloud-api.test" },
-						clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@beta" },
+						clawdiCli: {
+							source: "npm:clawdi",
+							packageSpec: "clawdi@beta",
+							registry: "https://registry.npmjs.org",
+						},
 						runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
 						recovery: {},
 					},
@@ -5666,7 +6009,11 @@ chmod +x "$prefix/bin/clawdi"
 								issuedAt: "2026-06-06T00:00:00Z",
 								system: { home, workspace: join(home, "clawdi") },
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
-								clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@0.13.4-beta.0" },
+								clawdiCli: {
+									source: "npm:clawdi",
+									packageSpec: "clawdi@0.13.4-beta.0",
+									registry: "https://registry.npmjs.org",
+								},
 								runtimes: {
 									openclaw: hostedOpenClawRuntime(),
 								},
@@ -5803,6 +6150,7 @@ chmod +x "$prefix/bin/clawdi"
 								clawdiCli: {
 									source: "npm:clawdi",
 									packageSpec: "clawdi@0.13.10-beta.0",
+									registry: "https://registry.npmjs.org",
 								},
 								runtimes: { openclaw: hostedOpenClawRuntime() },
 							},
@@ -6264,7 +6612,7 @@ exit 64
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		seedCurrentCliInstall(state);
+		seedCurrentCliInstall(state, "clawdi@agent-v2", "0.13.0-test", "https://registry.npmjs.org");
 		const { captured, restore } = mockFetch([
 			{
 				method: "GET",
@@ -6282,6 +6630,11 @@ exit 64
 								issuedAt: "2026-06-06T00:00:00Z",
 								system: { home, workspace: join(home, "clawdi") },
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+								clawdiCli: {
+									source: "npm:clawdi",
+									packageSpec: "clawdi@agent-v2",
+									registry: "https://registry.npmjs.org",
+								},
 								runtimes: {
 									openclaw: hostedOpenClawRuntime({
 										install: { source: "official", args: [] },
@@ -7425,6 +7778,11 @@ exit 64
 							issuedAt: "2026-06-06T00:00:00Z",
 							system: { home, workspace },
 							controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+							clawdiCli: {
+								source: "npm:clawdi",
+								packageSpec: "clawdi@agent-v2",
+								registry: "https://registry.npmjs.org",
+							},
 							runtimes: {
 								hermes: hostedHermesRuntime(),
 							},
@@ -7543,6 +7901,11 @@ exit 64
 					issuedAt: "2026-06-06T00:00:00Z",
 					system: { home },
 					controlPlane: { apiUrl: "https://api.test" },
+					clawdiCli: {
+						source: "npm:clawdi",
+						packageSpec: "clawdi@agent-v2",
+						registry: "https://registry.npmjs.org",
+					},
 					runtimes: {
 						hermes: hostedHermesRuntime(),
 					},
@@ -7583,6 +7946,11 @@ exit 64
 					issuedAt: "2026-06-06T00:00:00Z",
 					system: { home, workspace: join(home, "system-workspace") },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+					clawdiCli: {
+						source: "npm:clawdi",
+						packageSpec: "clawdi@agent-v2",
+						registry: "https://registry.npmjs.org",
+					},
 					runtimes: {
 						hermes: hostedHermesRuntime({
 							paths: { workspace: runtimeWorkspace },
@@ -8464,6 +8832,11 @@ exit 64
 							controlPlane: {
 								manifestUrl: "https://runtime-source.test/v1/desired-state/",
 							},
+							clawdiCli: {
+								source: "npm:clawdi",
+								packageSpec: "clawdi@agent-v2",
+								registry: "https://registry.npmjs.org",
+							},
 							runtimes: {
 								openclaw: hostedOpenClawRuntime(),
 							},
@@ -8515,6 +8888,11 @@ exit 64
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							egressEngine: mitmproxy,
+							clawdiCli: {
+								source: "npm:clawdi",
+								packageSpec: "clawdi@agent-v2",
+								registry: "https://registry.npmjs.org",
+							},
 							runtimes: {
 								openclaw: hostedOpenClawRuntime(),
 							},
@@ -8788,6 +9166,11 @@ exit 64
 								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
+							clawdiCli: {
+								source: "npm:clawdi",
+								packageSpec: "clawdi@agent-v2",
+								registry: "https://registry.npmjs.org",
+							},
 							runtimes: {
 								openclaw: hostedOpenClawRuntime(),
 							},
@@ -8884,6 +9267,11 @@ exit 64
 					issuedAt: "2026-06-06T00:00:00Z",
 					system: { home, workspace: join(home, "clawdi") },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+					clawdiCli: {
+						source: "npm:clawdi",
+						packageSpec: "clawdi@agent-v2",
+						registry: "https://registry.npmjs.org",
+					},
 					runtimes: {
 						openclaw: hostedOpenClawRuntime(),
 					},
@@ -8923,6 +9311,11 @@ exit 64
 					issuedAt: "2026-06-06T00:00:00Z",
 					system: { home, workspace: join(home, "clawdi") },
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+					clawdiCli: {
+						source: "npm:clawdi",
+						packageSpec: "clawdi@agent-v2",
+						registry: "https://registry.npmjs.org",
+					},
 					runtimes: {
 						hermes: hostedHermesRuntime(),
 					},

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -125,7 +125,7 @@ afterAll(() => {
 
 function seedCurrentCliInstall(
 	state: string,
-	packageSpec = "clawdi@latest",
+	packageSpec: string,
 	version = "0.13.0-test",
 	registry: string | null = null,
 ): void {
@@ -177,6 +177,7 @@ const TEST_HOSTED_LOCALE = {
 	language: "en" as const,
 	timezone: "UTC",
 };
+const TEST_HOSTED_MINIMUM_CLI_VERSION = "0.12.10-beta.51";
 
 function runtimeWatchLocaleManifest(
 	home: string,
@@ -219,6 +220,7 @@ function hostedRuntimeWatchLocalePayload(
 	return {
 		manifest: {
 			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+			minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 			runtime: "openclaw",
 			deploymentId: "dep_watch_locale",
 			environmentId: "env_watch_locale",
@@ -1058,10 +1060,10 @@ describe("runtime manifest datasource", () => {
 					jsonResponse({
 						manifest: {
 							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "openclaw",
 							deploymentId: "dep_test",
 							environmentId: "env_test",
-							appId: "app_test",
 							instanceId: "iid_remote",
 							generation: 3,
 							issuedAt: "2026-06-06T00:00:00Z",
@@ -1073,7 +1075,6 @@ describe("runtime manifest datasource", () => {
 								persistentPaths: [home],
 							},
 							controlPlane: {
-								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							clawdiCli: {
@@ -1214,17 +1215,16 @@ chmod +x "$HOME/.local/bin/hermes"
 					jsonResponse({
 						manifest: {
 							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "hermes",
 							deploymentId: "dep_runtime_bridge",
 							environmentId: "env_runtime_bridge",
-							appId: "app_runtime_bridge",
 							instanceId: "iid_runtime_bridge",
 							generation: 4,
 							issuedAt: "2026-06-06T00:00:00Z",
 							locale: TEST_HOSTED_LOCALE,
 							system: { home, workspace: join(home, "managed-workspace") },
 							controlPlane: {
-								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							clawdiCli: {
@@ -1308,17 +1308,16 @@ chmod +x "$HOME/.local/bin/hermes"
 					jsonResponse({
 						manifest: {
 							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "openclaw",
 							deploymentId: "dep_chat_provider",
 							environmentId: "env_chat_provider",
-							appId: "app_chat_provider",
 							instanceId: "iid_chat_provider",
 							generation: 1,
 							issuedAt: "2026-06-22T00:00:00Z",
 							locale: TEST_HOSTED_LOCALE,
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
-								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							clawdiCli: {
@@ -1406,17 +1405,16 @@ chmod +x "$HOME/.local/bin/hermes"
 					jsonResponse({
 						manifest: {
 							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "openclaw",
 							deploymentId: "dep_codex_provider",
 							environmentId: "env_codex_provider",
-							appId: "app_codex_provider",
 							instanceId: "iid_codex_provider",
 							generation: 1,
 							issuedAt: "2026-06-22T00:00:00Z",
 							locale: TEST_HOSTED_LOCALE,
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
-								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							clawdiCli: {
@@ -2917,6 +2915,7 @@ exit 0
 			JSON.stringify({
 				manifest: {
 					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "openclaw",
 					deploymentId: "dep_hosted_provider_secret",
 					environmentId: "env_hosted_provider_secret",
@@ -3077,6 +3076,7 @@ exit 64
 			JSON.stringify({
 				manifest: {
 					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "openclaw",
 					deploymentId: "dep_bridge_token",
 					environmentId: "env_bridge_token",
@@ -3123,6 +3123,7 @@ exit 64
 			JSON.stringify({
 				manifest: {
 					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "openclaw",
 					deploymentId: "dep_bridge_token_explicit",
 					environmentId: "env_bridge_token_explicit",
@@ -3189,8 +3190,10 @@ exit 64
 					jsonResponse({
 						manifest: {
 							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "hermes",
 							deploymentId: "dep_custom_auth",
+							environmentId: "env_custom_auth",
 							instanceId: "iid_custom_auth",
 							generation: 1,
 							issuedAt: "2026-06-06T00:00:00Z",
@@ -3249,6 +3252,7 @@ exit 64
 					jsonResponse({
 						manifest: {
 							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "openclaw",
 							deploymentId: "dep_same_token",
 							environmentId: "env_same_token",
@@ -3258,7 +3262,6 @@ exit 64
 							locale: TEST_HOSTED_LOCALE,
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
-								manifestUrl: "https://runtime.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							clawdiCli: {
@@ -3282,6 +3285,7 @@ exit 64
 					jsonResponse({
 						manifest: {
 							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "openclaw",
 							deploymentId: "dep_same_token",
 							environmentId: "env_same_token",
@@ -3291,7 +3295,6 @@ exit 64
 							locale: TEST_HOSTED_LOCALE,
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
-								manifestUrl: "https://runtime.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							clawdiCli: {
@@ -4068,6 +4071,89 @@ exit 0
 		}
 	});
 
+	it.each([
+		"authentication failure",
+		"task completion",
+	])("runtime watch re-subscribes after SSE %s with unchanged connection identity", async (completionMode) => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const abort = new AbortController();
+		const previousLog = console.log;
+		const logs: string[] = [];
+		seedRuntimeWatchLocaleBaseline(home, state, run);
+		console.log = (value?: unknown) => logs.push(String(value));
+		let manifestCalls = 0;
+		let subscriptionCalls = 0;
+		let resolveInitialManifestRequest: (() => void) | null = null;
+		const initialManifestRequest = new Promise<void>((resolveRequest) => {
+			resolveInitialManifestRequest = resolveRequest;
+		});
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/runtime/manifest",
+				response: () => {
+					manifestCalls += 1;
+					if (manifestCalls === 1) {
+						resolveInitialManifestRequest?.();
+						return new Response(null, { status: 304 });
+					}
+					return new Response(JSON.stringify(hostedRuntimeWatchLocalePayload(home, 2)), {
+						status: 200,
+						headers: {
+							"content-type": "application/json",
+							etag: '"manifest-locale-2"',
+						},
+					});
+				},
+			},
+			{
+				method: "GET",
+				path: "/v1/channels",
+				response: (request) => {
+					if (request.headers["if-none-match"]) return new Response(null, { status: 304 });
+					setTimeout(() => abort.abort(), 0);
+					return jsonResponse([]);
+				},
+			},
+		]);
+		const timeout = setTimeout(() => abort.abort(), 500);
+
+		try {
+			await runtimeWatch({
+				intervalMs: 60_000,
+				selfHealMs: 300_000,
+				json: true,
+				abort: abort.signal,
+				notificationConsumer: async (options) => {
+					subscriptionCalls += 1;
+					if (subscriptionCalls === 1) {
+						if (completionMode === "authentication failure") options.onAuthFailure?.();
+						return;
+					}
+					await initialManifestRequest;
+					await options.onEvent({
+						type: "runtime_manifest_changed",
+						environment_id: "env_watch_locale",
+					});
+					await new Promise<void>((resolveDone) => {
+						if (options.abort.aborted) return resolveDone();
+						options.abort.addEventListener("abort", () => resolveDone(), { once: true });
+					});
+				},
+			});
+
+			expect(subscriptionCalls).toBe(2);
+			expect(manifestCalls).toBe(2);
+			expect(logs.map((line) => JSON.parse(line).status)).toEqual(["not_modified", "applied"]);
+		} finally {
+			clearTimeout(timeout);
+			restore();
+			console.log = previousLog;
+		}
+	});
+
 	it("runtime watch applies remote changes, tracks systemd unit changes, and saves the new ETag", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -4117,6 +4203,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 						JSON.stringify({
 							manifest: {
 								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 								runtime: "openclaw",
 								deploymentId: "dep_watch",
 								environmentId: "env_watch",
@@ -4260,6 +4347,7 @@ exit 42
 						JSON.stringify({
 							manifest: {
 								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 								runtime: "openclaw",
 								deploymentId: "dep_watch_systemd_failure",
 								environmentId: "env_watch_systemd_failure",
@@ -4337,6 +4425,7 @@ exit 42
 		const hostedPayload = {
 			manifest: {
 				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 				runtime: "openclaw",
 				deploymentId: "dep_watch_secret",
 				environmentId: "env_watch_secret",
@@ -4617,6 +4706,7 @@ exit 64
 						JSON.stringify({
 							manifest: {
 								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 								runtime: "openclaw",
 								deploymentId: "dep_watch_recovery",
 								environmentId: "env_watch_recovery",
@@ -5197,6 +5287,7 @@ chmod +x "$prefix/bin/clawdi"
 						JSON.stringify({
 							manifest: {
 								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 								runtime: "openclaw",
 								deploymentId: "dep_cli_update",
 								environmentId: "env_cli_update",
@@ -5434,6 +5525,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 						JSON.stringify({
 							manifest: {
 								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 								runtime: "openclaw",
 								deploymentId: "dep_cli_mitm",
 								environmentId: "env_cli_mitm",
@@ -5601,6 +5693,7 @@ chmod +x "$prefix/bin/clawdi"
 			const result = applyRuntimeCliDesiredState(
 				{
 					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "openclaw",
 					deploymentId: "dep_floating_cli_tag",
 					environmentId: "env_floating_cli_tag",
@@ -5679,6 +5772,7 @@ exit 97
 			const result = applyRuntimeCliDesiredState(
 				{
 					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "openclaw",
 					deploymentId: "dep_cli_bootstrap_current",
 					environmentId: "env_cli_bootstrap_current",
@@ -5794,6 +5888,7 @@ chmod +x "$prefix/bin/clawdi"
 		const manifestPayload = {
 			manifest: {
 				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 				runtime: "openclaw",
 				deploymentId: "dep_cli_self_heal",
 				environmentId: "env_cli_self_heal",
@@ -5998,6 +6093,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 						JSON.stringify({
 							manifest: {
 								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 								runtime: "openclaw",
 								deploymentId: "dep_cli_update_converge_failure",
 								environmentId: "env_cli_update_converge_failure",
@@ -6146,13 +6242,14 @@ chmod +x "$prefix/bin/clawdi"
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
-		seedCurrentCliInstall(state, "clawdi@beta", "0.13.4-beta.0");
+		seedCurrentCliInstall(state, "clawdi@0.13.4-beta.0", "0.13.4-beta.0");
 		const paths = getRuntimePaths();
 		const oldTarget = readlinkSync(paths.cliManagedBin);
 		mkdirSync(dirname(paths.manifestEtag), { recursive: true });
 		writeFileSync(paths.manifestEtag, '"etag-cli-rollback"\n');
 		const manifest = {
 			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+			minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 			runtime: "openclaw",
 			deploymentId: "dep_cli_rollback",
 			environmentId: "env_cli_rollback",
@@ -6164,7 +6261,7 @@ chmod +x "$prefix/bin/clawdi"
 			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 			clawdiCli: {
 				source: "npm:clawdi",
-				packageSpec: "clawdi@beta",
+				packageSpec: "clawdi@0.13.5-beta.0",
 				registry: "https://registry.npmjs.org",
 			},
 			runtimes: {
@@ -6216,7 +6313,7 @@ chmod +x "$prefix/bin/clawdi"
 			expect(upgradeState.pendingUpgrade).toBeNull();
 			expect(upgradeState.badVersions).toContainEqual(
 				expect.objectContaining({
-					packageSpec: "clawdi@beta",
+					packageSpec: "clawdi@0.13.5-beta.0",
 					version: "0.13.5-beta.0",
 				}),
 			);
@@ -6233,7 +6330,7 @@ chmod +x "$prefix/bin/clawdi"
 						controlPlane: { apiUrl: "https://cloud-api.test" },
 						clawdiCli: {
 							source: "npm:clawdi",
-							packageSpec: "clawdi@beta",
+							packageSpec: "clawdi@0.13.5-beta.0",
 							registry: "https://registry.npmjs.org",
 						},
 						runtimes: { openclaw: { enabled: false }, hermes: { enabled: false } },
@@ -6299,6 +6396,7 @@ chmod +x "$prefix/bin/clawdi"
 						JSON.stringify({
 							manifest: {
 								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 								runtime: "openclaw",
 								deploymentId: "dep_cli_update_failure",
 								environmentId: "env_cli_update_failure",
@@ -6922,6 +7020,7 @@ exit 64
 						JSON.stringify({
 							manifest: {
 								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 								runtime: "openclaw",
 								deploymentId: "dep_init",
 								environmentId: "env_init",
@@ -8072,8 +8171,10 @@ exit 64
 					jsonResponse({
 						manifest: {
 							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "hermes",
 							deploymentId: "dep_workspace",
+							environmentId: "env_workspace",
 							instanceId: "iid_workspace",
 							generation: 1,
 							issuedAt: "2026-06-06T00:00:00Z",
@@ -8196,8 +8297,10 @@ exit 64
 			JSON.stringify({
 				manifest: {
 					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "hermes",
 					deploymentId: "dep_legacy_api_url",
+					environmentId: "env_legacy_api_url",
 					instanceId: "iid_legacy_api_url",
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",
@@ -8223,7 +8326,7 @@ exit 64
 		expect("errors" in loaded).toBe(true);
 		if (!("errors" in loaded)) throw new Error("expected manifest load failure");
 		expect(loaded.mode).toBe("manifest-rejected");
-		expect(loaded.errors.join("\n")).toContain("hosted runtime controlPlane must use cloudApiUrl");
+		expect(loaded.errors.join("\n")).toContain("apiUrl");
 	});
 
 	it("uses hosted runtime workspace paths even without explicit run settings", async () => {
@@ -8242,8 +8345,10 @@ exit 64
 			JSON.stringify({
 				manifest: {
 					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "hermes",
 					deploymentId: "dep_runtime_workspace",
+					environmentId: "env_runtime_workspace",
 					instanceId: "iid_runtime_workspace",
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",
@@ -9227,7 +9332,7 @@ exit 64
 		expect(loaded.errors[0]).toContain("fixture references secretValues");
 	});
 
-	it("derives a safe API origin when manifests only include a source URL", async () => {
+	it("rejects hosted manifests without cloudApiUrl instead of deriving it from the source URL", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -9246,16 +9351,16 @@ exit 64
 					jsonResponse({
 						manifest: {
 							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "openclaw",
 							deploymentId: "dep_manifest_only",
+							environmentId: "env_manifest_only",
 							instanceId: "iid_manifest_only",
 							generation: 1,
 							issuedAt: "2026-06-06T00:00:00Z",
 							locale: TEST_HOSTED_LOCALE,
 							system: { home, workspace: join(home, "clawdi") },
-							controlPlane: {
-								manifestUrl: "https://runtime-source.test/v1/desired-state/",
-							},
+							controlPlane: {},
 							clawdiCli: {
 								source: "npm:clawdi",
 								packageSpec: "clawdi@agent-v2",
@@ -9272,9 +9377,10 @@ exit 64
 
 		try {
 			const loaded = await loadRuntimeManifest(getRuntimePaths());
-			expect("manifest" in loaded).toBe(true);
-			if (!("manifest" in loaded)) throw new Error("expected manifest load success");
-			expect(loaded.manifest.controlPlane.apiUrl).toBe("https://runtime-source.test");
+			expect("errors" in loaded).toBe(true);
+			if (!("errors" in loaded)) throw new Error("expected manifest load failure");
+			expect(loaded.mode).toBe("manifest-rejected");
+			expect(loaded.errors.join("\n")).toContain("cloudApiUrl");
 		} finally {
 			restore();
 		}
@@ -9300,16 +9406,16 @@ exit 64
 					jsonResponse({
 						manifest: {
 							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "openclaw",
 							deploymentId: "dep_test",
-							appId: "app_test",
+							environmentId: "env_test",
 							instanceId: "iid_remote",
 							generation: 4,
 							issuedAt: "2026-06-06T00:00:00Z",
 							locale: TEST_HOSTED_LOCALE,
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
-								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							egressEngine: mitmproxy,
@@ -9580,16 +9686,16 @@ exit 64
 					jsonResponse({
 						manifest: {
 							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "openclaw",
 							deploymentId: "dep_sync",
-							appId: "app_sync",
+							environmentId: "env_sync",
 							instanceId: "iid_sync",
 							generation: 9,
 							issuedAt: "2026-06-06T00:00:00Z",
 							locale: TEST_HOSTED_LOCALE,
 							system: { home, workspace: join(home, "clawdi") },
 							controlPlane: {
-								manifestUrl: "https://runtime-source.test/v1/runtime/manifest",
 								cloudApiUrl: "https://cloud-api.test",
 							},
 							clawdiCli: {
@@ -9685,9 +9791,10 @@ exit 64
 			JSON.stringify({
 				manifest: {
 					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "openclaw",
 					deploymentId: "dep_no_secret_ref",
-					appId: "app_no_secret_ref",
+					environmentId: "env_no_secret_ref",
 					instanceId: "iid_no_secret_ref",
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",
@@ -9730,9 +9837,10 @@ exit 64
 			JSON.stringify({
 				manifest: {
 					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "hermes",
 					deploymentId: "dep_bad_mitm",
-					appId: "app_bad_mitm",
+					environmentId: "env_bad_mitm",
 					instanceId: "iid_bad_mitm",
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -179,6 +179,20 @@ const TEST_HOSTED_LOCALE = {
 };
 const TEST_HOSTED_MINIMUM_CLI_VERSION = "0.12.10-beta.51";
 
+function hostedSystemFixture(
+	home: string,
+	workspace = join(home, "clawdi"),
+	overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+	return {
+		user: "clawdi",
+		home,
+		workspace,
+		persistentPaths: [home, workspace],
+		...overrides,
+	};
+}
+
 function runtimeWatchLocaleManifest(
 	home: string,
 	generation: number,
@@ -228,7 +242,7 @@ function hostedRuntimeWatchLocalePayload(
 			generation,
 			issuedAt: "2026-07-11T00:00:00Z",
 			locale: { language, timezone },
-			system: { home, workspace: join(home, "clawdi") },
+			system: hostedSystemFixture(home),
 			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 			clawdiCli: {
 				source: "npm:clawdi",
@@ -1251,7 +1265,7 @@ chmod +x "$HOME/.local/bin/hermes"
 							generation: 4,
 							issuedAt: "2026-06-06T00:00:00Z",
 							locale: TEST_HOSTED_LOCALE,
-							system: { home, workspace: join(home, "managed-workspace") },
+							system: hostedSystemFixture(home, join(home, "managed-workspace")),
 							controlPlane: {
 								cloudApiUrl: "https://cloud-api.test",
 							},
@@ -1344,7 +1358,7 @@ chmod +x "$HOME/.local/bin/hermes"
 							generation: 1,
 							issuedAt: "2026-06-22T00:00:00Z",
 							locale: TEST_HOSTED_LOCALE,
-							system: { home, workspace: join(home, "clawdi") },
+							system: hostedSystemFixture(home),
 							controlPlane: {
 								cloudApiUrl: "https://cloud-api.test",
 							},
@@ -1441,7 +1455,7 @@ chmod +x "$HOME/.local/bin/hermes"
 							generation: 1,
 							issuedAt: "2026-06-22T00:00:00Z",
 							locale: TEST_HOSTED_LOCALE,
-							system: { home, workspace: join(home, "clawdi") },
+							system: hostedSystemFixture(home),
 							controlPlane: {
 								cloudApiUrl: "https://cloud-api.test",
 							},
@@ -2951,7 +2965,7 @@ exit 0
 					generation: 5,
 					issuedAt: "2026-06-15T00:00:00Z",
 					locale: TEST_HOSTED_LOCALE,
-					system: { home, workspace: join(home, "clawdi") },
+					system: hostedSystemFixture(home),
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
@@ -3112,7 +3126,7 @@ exit 64
 					generation: 1,
 					issuedAt: "2026-06-15T00:00:00Z",
 					locale: TEST_HOSTED_LOCALE,
-					system: { home, workspace: join(home, "clawdi") },
+					system: hostedSystemFixture(home),
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
@@ -3159,7 +3173,7 @@ exit 64
 					generation: 1,
 					issuedAt: "2026-06-15T00:00:00Z",
 					locale: TEST_HOSTED_LOCALE,
-					system: { home, workspace: join(home, "clawdi") },
+					system: hostedSystemFixture(home),
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
@@ -3232,7 +3246,7 @@ exit 64
 							generation: 1,
 							issuedAt: "2026-06-06T00:00:00Z",
 							locale: TEST_HOSTED_LOCALE,
-							system: { home, workspace: join(home, "clawdi") },
+							system: hostedSystemFixture(home),
 							controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 							clawdiCli: {
 								source: "npm:clawdi",
@@ -3294,7 +3308,7 @@ exit 64
 							generation: 1,
 							issuedAt: "2026-06-06T00:00:00Z",
 							locale: TEST_HOSTED_LOCALE,
-							system: { home, workspace: join(home, "clawdi") },
+							system: hostedSystemFixture(home),
 							controlPlane: {
 								cloudApiUrl: "https://cloud-api.test",
 							},
@@ -3327,7 +3341,7 @@ exit 64
 							generation: 2,
 							issuedAt: "2026-06-06T00:01:00Z",
 							locale: TEST_HOSTED_LOCALE,
-							system: { home, workspace: join(home, "clawdi") },
+							system: hostedSystemFixture(home),
 							controlPlane: {
 								cloudApiUrl: "https://cloud-api.test",
 							},
@@ -4245,7 +4259,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 								generation: 12,
 								issuedAt: "2026-06-06T00:00:00Z",
 								locale: TEST_HOSTED_LOCALE,
-								system: { home, workspace: join(home, "clawdi") },
+								system: hostedSystemFixture(home),
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
@@ -4389,7 +4403,7 @@ exit 42
 								generation: 13,
 								issuedAt: "2026-06-06T00:00:00Z",
 								locale: TEST_HOSTED_LOCALE,
-								system: { home, workspace: join(home, "clawdi") },
+								system: hostedSystemFixture(home),
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
@@ -4467,7 +4481,7 @@ exit 42
 				generation: 22,
 				issuedAt: "2026-06-06T00:00:00Z",
 				locale: TEST_HOSTED_LOCALE,
-				system: { home, workspace: join(home, "clawdi") },
+				system: hostedSystemFixture(home),
 				controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 				clawdiCli: {
 					source: "npm:clawdi",
@@ -4748,7 +4762,7 @@ exit 64
 								generation: 18,
 								issuedAt: "2026-06-06T00:00:00Z",
 								locale: TEST_HOSTED_LOCALE,
-								system: { home, workspace: join(home, "clawdi") },
+								system: hostedSystemFixture(home),
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
@@ -5329,7 +5343,7 @@ chmod +x "$prefix/bin/clawdi"
 								generation: 13,
 								issuedAt: "2026-06-06T00:00:00Z",
 								locale: TEST_HOSTED_LOCALE,
-								system: { home, workspace: join(home, "clawdi") },
+								system: hostedSystemFixture(home),
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
@@ -5567,7 +5581,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 								generation: 2,
 								issuedAt: "2026-06-06T00:00:00Z",
 								locale: TEST_HOSTED_LOCALE,
-								system: { home, workspace: join(home, "clawdi") },
+								system: hostedSystemFixture(home),
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								egressEngine: mitmproxy,
 								clawdiCli: {
@@ -5735,7 +5749,7 @@ chmod +x "$prefix/bin/clawdi"
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",
 					locale: TEST_HOSTED_LOCALE,
-					system: { home, workspace: join(home, "clawdi") },
+					system: hostedSystemFixture(home),
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
@@ -5814,7 +5828,7 @@ exit 97
 					generation: 1,
 					issuedAt: "2026-07-11T00:00:00Z",
 					locale: TEST_HOSTED_LOCALE,
-					system: { home, workspace: join(home, "clawdi") },
+					system: hostedSystemFixture(home),
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
@@ -5930,7 +5944,7 @@ chmod +x "$prefix/bin/clawdi"
 				generation: 30,
 				issuedAt: "2026-07-11T00:00:00Z",
 				locale: TEST_HOSTED_LOCALE,
-				system: { home, workspace: join(home, "clawdi") },
+				system: hostedSystemFixture(home),
 				controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 				clawdiCli: {
 					source: "npm:clawdi",
@@ -6135,7 +6149,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 								generation: 16,
 								issuedAt: "2026-06-06T00:00:00Z",
 								locale: TEST_HOSTED_LOCALE,
-								system: { home, workspace: join(home, "clawdi") },
+								system: hostedSystemFixture(home),
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
@@ -6291,7 +6305,7 @@ chmod +x "$prefix/bin/clawdi"
 			generation: 18,
 			issuedAt: "2026-06-06T00:00:00Z",
 			locale: TEST_HOSTED_LOCALE,
-			system: { home, workspace: join(home, "clawdi") },
+			system: hostedSystemFixture(home),
 			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 			clawdiCli: {
 				source: "npm:clawdi",
@@ -6438,7 +6452,7 @@ chmod +x "$prefix/bin/clawdi"
 								generation: 17,
 								issuedAt: "2026-06-06T00:00:00Z",
 								locale: TEST_HOSTED_LOCALE,
-								system: { home, workspace: join(home, "clawdi") },
+								system: hostedSystemFixture(home),
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
@@ -6577,7 +6591,7 @@ chmod +x "$prefix/bin/clawdi"
 								minimumCliVersion: "999.0.0",
 								issuedAt: "2026-06-06T00:00:00Z",
 								locale: TEST_HOSTED_LOCALE,
-								system: { home, workspace: join(home, "clawdi") },
+								system: hostedSystemFixture(home),
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
@@ -7062,7 +7076,7 @@ exit 64
 								generation: 7,
 								issuedAt: "2026-06-06T00:00:00Z",
 								locale: TEST_HOSTED_LOCALE,
-								system: { home, workspace: join(home, "clawdi") },
+								system: hostedSystemFixture(home),
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
@@ -8213,7 +8227,7 @@ exit 64
 							generation: 1,
 							issuedAt: "2026-06-06T00:00:00Z",
 							locale: TEST_HOSTED_LOCALE,
-							system: { home, workspace },
+							system: hostedSystemFixture(home, workspace),
 							controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 							clawdiCli: {
 								source: "npm:clawdi",
@@ -8341,7 +8355,7 @@ exit 64
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",
 					locale: TEST_HOSTED_LOCALE,
-					system: { home, workspace: join(home, "clawdi") },
+					system: hostedSystemFixture(home),
 					controlPlane: { apiUrl: "https://api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
@@ -8389,7 +8403,7 @@ exit 64
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",
 					locale: TEST_HOSTED_LOCALE,
-					system: { home, workspace: join(home, "system-workspace") },
+					system: hostedSystemFixture(home, join(home, "system-workspace")),
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
@@ -9395,7 +9409,7 @@ exit 64
 							generation: 1,
 							issuedAt: "2026-06-06T00:00:00Z",
 							locale: TEST_HOSTED_LOCALE,
-							system: { home, workspace: join(home, "clawdi") },
+							system: hostedSystemFixture(home),
 							controlPlane: {},
 							clawdiCli: {
 								source: "npm:clawdi",
@@ -9450,7 +9464,7 @@ exit 64
 							generation: 4,
 							issuedAt: "2026-06-06T00:00:00Z",
 							locale: TEST_HOSTED_LOCALE,
-							system: { home, workspace: join(home, "clawdi") },
+							system: hostedSystemFixture(home),
 							controlPlane: {
 								cloudApiUrl: "https://cloud-api.test",
 							},
@@ -9730,7 +9744,7 @@ exit 64
 							generation: 9,
 							issuedAt: "2026-06-06T00:00:00Z",
 							locale: TEST_HOSTED_LOCALE,
-							system: { home, workspace: join(home, "clawdi") },
+							system: hostedSystemFixture(home),
 							controlPlane: {
 								cloudApiUrl: "https://cloud-api.test",
 							},
@@ -9835,7 +9849,7 @@ exit 64
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",
 					locale: TEST_HOSTED_LOCALE,
-					system: { home, workspace: join(home, "clawdi") },
+					system: hostedSystemFixture(home),
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
@@ -9881,7 +9895,7 @@ exit 64
 					generation: 1,
 					issuedAt: "2026-06-06T00:00:00Z",
 					locale: TEST_HOSTED_LOCALE,
-					system: { home, workspace: join(home, "clawdi") },
+					system: hostedSystemFixture(home),
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -38,6 +38,7 @@ import {
 import {
 	loadRemoteRuntimeChannels,
 	loadRemoteRuntimeManifest,
+	normalizeManifestPayload,
 	type RuntimeChannelsLoad,
 	type RuntimeManifestLoad,
 } from "../src/runtime/manifest-source";
@@ -225,7 +226,7 @@ function runtimeWatchLocaleManifest(
 		controlPlane: { apiUrl: "https://cloud-api.test" },
 		clawdiCli: {
 			source: "npm:clawdi",
-			packageSpec: "clawdi@agent-v2",
+			packageSpec: "clawdi@0.13.0-test",
 			registry: "https://registry.npmjs.org",
 		},
 		runtimes: {
@@ -261,24 +262,84 @@ function hostedRuntimeWatchLocalePayload(
 			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 			clawdiCli: {
 				source: "npm:clawdi",
-				packageSpec: "clawdi@agent-v2",
+				packageSpec: "clawdi@0.13.0-test",
 				registry: "https://registry.npmjs.org",
 			},
-			runtimes: { openclaw: hostedOpenClawRuntime() },
+			runtimes: {
+				openclaw: hostedOpenClawRuntime({
+					paths: { home, workspace: join(home, "clawdi") },
+				}),
+			},
 		},
 		secretValues: {},
 	};
 }
 
+function hostedCliManifestResponse(home: string, packageSpec: string): unknown {
+	return {
+		manifest: {
+			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+			minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
+			runtime: "openclaw",
+			deploymentId: "dep_cli_package_spec",
+			environmentId: "env_cli_package_spec",
+			...hostedRequiredState(),
+			instanceId: "iid_cli_package_spec",
+			generation: 1,
+			issuedAt: "2026-07-12T00:00:00Z",
+			locale: TEST_HOSTED_LOCALE,
+			system: hostedSystemFixture(home),
+			controlPlane: { cloudApiUrl: "https://cloud-api.test" },
+			clawdiCli: {
+				source: "npm:clawdi",
+				packageSpec,
+				registry: "https://registry.npmjs.org",
+			},
+			runtimes: {
+				openclaw: hostedOpenClawRuntime({
+					paths: { home, workspace: join(home, "clawdi") },
+				}),
+			},
+		},
+		secretValues: {},
+	};
+}
+
+function genericCliDesiredState(packageSpec: string): RuntimeManifest {
+	return {
+		schemaVersion: "clawdi.runtimeDesiredState.v1",
+		deploymentId: "dep_generic_cli_update",
+		environmentId: "env_generic_cli_update",
+		instanceId: "iid_generic_cli_update",
+		generation: 1,
+		issuedAt: "2026-07-12T00:00:00Z",
+		controlPlane: { apiUrl: "https://cloud-api.test" },
+		clawdiCli: {
+			source: "npm:clawdi",
+			packageSpec,
+			registry: "https://registry.npmjs.org",
+		},
+		runtimes: { openclaw: { enabled: true } },
+		recovery: {},
+	};
+}
+
+function seedOpenClawBinary(home: string): void {
+	const openclawBin = join(home, ".openclaw", "bin", "openclaw");
+	mkdirSync(dirname(openclawBin), { recursive: true });
+	writeFileSync(openclawBin, "#!/bin/sh\nexit 0\n");
+	chmodSync(openclawBin, 0o700);
+}
+
 function seedRuntimeWatchLocaleBaseline(home: string, state: string, run: string): RuntimePaths {
 	mkdirSync(join(run, "secrets"), { recursive: true });
-	mkdirSync(home, { recursive: true });
+	seedOpenClawBinary(home);
 	process.env.HOME = home;
 	process.env.CLAWDI_RUNTIME_MODE = "hosted";
 	process.env.CLAWDI_SERVICE_STATE_DIR = state;
 	process.env.CLAWDI_RUN_DIR = run;
 	process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
-	seedCurrentCliInstall(state, "clawdi@agent-v2", "0.13.0-test", "https://registry.npmjs.org");
+	seedCurrentCliInstall(state, "clawdi@0.13.0-test", "0.13.0-test", "https://registry.npmjs.org");
 	writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 	const paths = getRuntimePaths();
 	convergeRuntimeManifest(
@@ -320,7 +381,7 @@ type HostedRunFixture = {
 
 type HostedRuntimeFixtureEntry = {
 	enabled: boolean;
-	install?: { source: "official"; channel?: string; args?: string[] };
+	install: { source: "official" };
 	run?: HostedRunFixture;
 	services?: Record<string, HostedRunFixture>;
 	paths: { home: string; workspace: string };
@@ -340,6 +401,7 @@ function hostedOpenClawRuntime(
 	} = overrides;
 	return {
 		enabled: true,
+		install: { source: "official" },
 		provider_ids,
 		primary_model,
 		run: {
@@ -378,6 +440,7 @@ function hostedHermesRuntime(
 	} = overrides;
 	return {
 		enabled: true,
+		install: { source: "official" },
 		provider_ids,
 		primary_model,
 		run: {
@@ -1137,12 +1200,11 @@ describe("runtime manifest datasource", () => {
 							},
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@agent-v2",
+								packageSpec: "clawdi@0.13.0-test",
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
 								openclaw: hostedOpenClawRuntime({
-									install: { source: "official", channel: "stable" },
 									paths: { home },
 									provider_ids: ["default", "codex"],
 								}),
@@ -1150,8 +1212,9 @@ describe("runtime manifest datasource", () => {
 							providers: {
 								default: {
 									kind: "openai-compatible",
+									type: "custom_openai_compatible",
 									baseUrl: "https://sub2api.test/v1",
-									model: "gpt-5.5",
+									models: [{ id: "gpt-5.5" }],
 									apiMode: "openai_chat",
 									managed_by: "clawdi",
 									apiKeySecretRef: "provider.default.apiKey",
@@ -1160,7 +1223,7 @@ describe("runtime manifest datasource", () => {
 									kind: "openai-compatible",
 									type: "openai",
 									baseUrl: "https://api.openai.com/v1",
-									model: "gpt-5.5",
+									models: [{ id: "gpt-5.5" }],
 									apiMode: "openai_responses",
 									auth: {
 										type: "agent_profile",
@@ -1192,7 +1255,7 @@ describe("runtime manifest datasource", () => {
 			expect(loaded.manifest.environmentId).toBe("env_test");
 			expect(loaded.manifest.controlPlane.apiUrl).toBe("https://cloud-api.test");
 			expect(loaded.manifest.clawdiCli?.source).toBe("npm:clawdi");
-			expect(loaded.manifest.clawdiCli?.packageSpec).toBe("clawdi@agent-v2");
+			expect(loaded.manifest.clawdiCli?.packageSpec).toBe("clawdi@0.13.0-test");
 			expect(loaded.manifest.projection?.mcp).toEqual({
 				enabled: true,
 				profile: "clawdi-default",
@@ -1224,6 +1287,60 @@ describe("runtime manifest datasource", () => {
 		} finally {
 			restore();
 		}
+	});
+
+	it("rejects a managed bootstrap tarball from a remote hosted manifest", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		mkdirSync(home, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_AUTH_TOKEN = "auth-token";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
+		const packageSpec = "/usr/local/share/clawdi/bootstrap/clawdi-0.13.0-test.tgz";
+		const { restore } = mockFetch([
+			{
+				method: "GET",
+				path: "/v1/runtime/manifest",
+				response: () => jsonResponse(hostedCliManifestResponse(home, packageSpec)),
+			},
+		]);
+
+		try {
+			const loaded = await loadRuntimeManifest(getRuntimePaths());
+			expect("errors" in loaded).toBe(true);
+			if (!("errors" in loaded)) throw new Error("expected remote manifest rejection");
+			expect(loaded.mode).toBe("manifest-rejected");
+			expect(loaded.stage).toBe("network");
+			expect(loaded.errors.join("\n")).toContain("must be clawdi@<exact-semver>");
+		} finally {
+			restore();
+		}
+	});
+
+	it("accepts a managed bootstrap tarball only from CLAWDI_RUNTIME_MANIFEST_PATH", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const manifestPath = join(root, "hosted-bootstrap-fixture.json");
+		const packageSpec = "/usr/local/share/clawdi/bootstrap/clawdi-0.13.0-test.tgz";
+		mkdirSync(home, { recursive: true });
+		writeFileSync(manifestPath, JSON.stringify(hostedCliManifestResponse(home, packageSpec)));
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_RUNTIME_MANIFEST_PATH = manifestPath;
+
+		const loaded = await loadRuntimeManifest(getRuntimePaths());
+		if (!("manifest" in loaded)) {
+			throw new Error(`expected fixture manifest load: ${loaded.errors.join("; ")}`);
+		}
+		expect(loaded.source).toBe("fixture-file");
+		expect(loaded.manifest.clawdiCli?.packageSpec).toBe(packageSpec);
 	});
 
 	it("recovers hosted bridge token from pid1 env for Hermes runtime bridge exposure", async () => {
@@ -1289,12 +1406,11 @@ chmod +x "$HOME/.local/bin/hermes"
 							},
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@agent-v2",
+								packageSpec: "clawdi@0.13.0-test",
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
 								hermes: hostedHermesRuntime({
-									install: { source: "official", channel: "stable" },
 									paths: { home },
 								}),
 							},
@@ -1304,8 +1420,9 @@ chmod +x "$HOME/.local/bin/hermes"
 							providers: {
 								default: {
 									kind: "openai-compatible",
+									type: "custom_openai_compatible",
 									baseUrl: "https://ai-gateway.test/v1",
-									model: "gpt-5.5",
+									models: [{ id: "gpt-5.5" }],
 									apiMode: "openai_chat",
 									managed_by: "clawdi",
 									runtimeEnvName: "CLAWDI_MANAGED_OPENAI_API_KEY",
@@ -1383,7 +1500,7 @@ chmod +x "$HOME/.local/bin/hermes"
 							},
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@agent-v2",
+								packageSpec: "clawdi@0.13.0-test",
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
@@ -1392,8 +1509,9 @@ chmod +x "$HOME/.local/bin/hermes"
 							providers: {
 								default: {
 									kind: "openai-compatible",
+									type: "custom_openai_compatible",
 									baseUrl: "https://ai-gateway.example.test/v1",
-									model: "gpt-5.4-mini",
+									models: [{ id: "gpt-5.4-mini" }],
 									apiMode: "openai_chat",
 									managed_by: "clawdi",
 									runtimeEnvName: "CLAWDI_MANAGED_OPENAI_API_KEY",
@@ -1414,7 +1532,7 @@ chmod +x "$HOME/.local/bin/hermes"
 			if (!("manifest" in loaded)) throw new Error("expected manifest load success");
 			expect(loaded.manifest.projection?.providers.default).toMatchObject({
 				baseUrl: "https://ai-gateway.example.test/v1",
-				model: "gpt-5.4-mini",
+				models: [{ id: "gpt-5.4-mini" }],
 				apiMode: "openai_chat",
 				runtimeEnvName: "CLAWDI_MANAGED_OPENAI_API_KEY",
 			});
@@ -1481,7 +1599,7 @@ chmod +x "$HOME/.local/bin/hermes"
 							},
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@agent-v2",
+								packageSpec: "clawdi@0.13.0-test",
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
@@ -1490,8 +1608,9 @@ chmod +x "$HOME/.local/bin/hermes"
 							providers: {
 								default: {
 									kind: "openai-compatible",
+									type: "custom_openai_compatible",
 									baseUrl: "https://ai-gateway.example.test/v1",
-									model: "gpt-5.4-mini",
+									models: [{ id: "gpt-5.4-mini" }],
 									apiMode: "openai_responses",
 									managed_by: "clawdi",
 									runtimeEnvName: "CLAWDI_MANAGED_OPENAI_API_KEY",
@@ -2990,27 +3109,34 @@ exit 0
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
-						packageSpec: "clawdi@agent-v2",
+						packageSpec: "clawdi@0.13.0-test",
 						registry: "https://registry.npmjs.org",
 					},
 					runtimes: {
-						openclaw: hostedOpenClawRuntime(),
+						openclaw: hostedOpenClawRuntime({
+							provider_ids: ["clawdi-managed-v2"],
+							primary_model: {
+								provider_id: "clawdi-managed-v2",
+								model: "gpt-5.5",
+							},
+						}),
 					},
 					providers: {
-						default: {
+						"clawdi-managed-v2": {
 							kind: "openai-compatible",
+							type: "custom_openai_compatible",
 							baseUrl: "https://ai-gateway.example.test/v1",
-							model: "gpt-5.5",
-							apiMode: "openai_responses",
+							models: [{ id: "gpt-5.5" }],
+							apiMode: "openai_chat",
 							managed_by: "clawdi",
 							runtimeEnvName: "CLAWDI_MANAGED_OPENAI_API_KEY",
-							apiKeySecretRef: "provider.default.apiKey",
+							apiKeySecretRef: "provider.clawdi-managed-v2.apiKey",
 						},
 					},
 					recovery: { cacheManifest: true, allowOfflineBoot: true },
 				},
 				secretValues: {
-					"provider.default.apiKey": "sk-runtime-provider",
+					"provider.clawdi-managed-v2.apiKey": "sk-runtime-provider",
 				},
 			}),
 		);
@@ -3037,13 +3163,13 @@ exit 0
 		const paths = getRuntimePaths();
 		expectEgressProfileBundleUsesSecretRef(
 			convergence.outputs.egressProfileBundle,
-			"secret://provider.default.apiKey",
+			"secret://provider.clawdi-managed-v2.apiKey",
 			"sk-runtime-provider",
 		);
 		expectMitmSecretFileIsSidecarOnly(
 			paths,
 			convergence.outputs.egressSecretFile,
-			"secret://provider.default.apiKey",
+			"secret://provider.clawdi-managed-v2.apiKey",
 			"sk-runtime-provider",
 		);
 		expect(existsSync(join(run, "secrets", "runtimes", "openclaw.json"))).toBe(false);
@@ -3152,7 +3278,7 @@ exit 64
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
-						packageSpec: "clawdi@agent-v2",
+						packageSpec: "clawdi@0.13.0-test",
 						registry: "https://registry.npmjs.org",
 					},
 					runtimes: {
@@ -3200,7 +3326,7 @@ exit 64
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
-						packageSpec: "clawdi@agent-v2",
+						packageSpec: "clawdi@0.13.0-test",
 						registry: "https://registry.npmjs.org",
 					},
 					runtimes: {
@@ -3274,7 +3400,7 @@ exit 64
 							controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@agent-v2",
+								packageSpec: "clawdi@0.13.0-test",
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: { hermes: hostedHermesRuntime() },
@@ -3300,7 +3426,10 @@ exit 64
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const wrongSourcePath = join(root, "wrong-runtime-source.json");
-		mkdirSync(home, { recursive: true });
+		const openclawBin = join(home, ".openclaw", "bin", "openclaw");
+		mkdirSync(dirname(openclawBin), { recursive: true });
+		writeFileSync(openclawBin, "#!/usr/bin/env bash\nexit 0\n");
+		chmodSync(openclawBin, 0o700);
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
@@ -3339,7 +3468,7 @@ exit 64
 							},
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@agent-v2",
+								packageSpec: "clawdi@0.13.0-test",
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: { openclaw: hostedOpenClawRuntime() },
@@ -3373,7 +3502,7 @@ exit 64
 							},
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@agent-v2",
+								packageSpec: "clawdi@0.13.0-test",
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: { openclaw: hostedOpenClawRuntime() },
@@ -4239,7 +4368,7 @@ exit 0
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
-		mkdirSync(home, { recursive: true });
+		seedOpenClawBinary(home);
 		writeFileSync(
 			join(bin, "systemctl"),
 			`#!/usr/bin/env bash
@@ -4257,7 +4386,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		seedCurrentCliInstall(state, "clawdi@agent-v2", "0.13.0-test", "https://registry.npmjs.org");
+		seedCurrentCliInstall(state, "clawdi@0.13.0-test", "0.13.0-test", "https://registry.npmjs.org");
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
@@ -4290,7 +4419,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
-									packageSpec: "clawdi@agent-v2",
+									packageSpec: "clawdi@0.13.0-test",
 									registry: "https://registry.npmjs.org",
 								},
 								runtimes: {
@@ -4301,13 +4430,14 @@ printf 'ActiveState=active\\nSubState=running\\n'
 										kind: "openai-compatible",
 										type: "custom_openai_compatible",
 										baseUrl: "https://provider.test/v1",
-										model: "gpt-test",
+										models: [{ id: "gpt-test" }],
 										apiMode: "openai_chat",
-										status: "ok",
+										apiKeySecretRef: "provider.default.apiKey",
+										apiKeyRequired: true,
 									},
 								},
 							},
-							secretValues: {},
+							secretValues: { "provider.default.apiKey": "sk-provider-watch" },
 						}),
 						{
 							status: 200,
@@ -4392,7 +4522,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
-		mkdirSync(home, { recursive: true });
+		seedOpenClawBinary(home);
 		writeFileSync(
 			join(bin, "systemctl"),
 			`#!/usr/bin/env bash
@@ -4412,7 +4542,7 @@ exit 42
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		seedCurrentCliInstall(state, "clawdi@agent-v2", "0.13.0-test", "https://registry.npmjs.org");
+		seedCurrentCliInstall(state, "clawdi@0.13.0-test", "0.13.0-test", "https://registry.npmjs.org");
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
@@ -4445,7 +4575,7 @@ exit 42
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
-									packageSpec: "clawdi@agent-v2",
+									packageSpec: "clawdi@0.13.0-test",
 									registry: "https://registry.npmjs.org",
 								},
 								runtimes: {
@@ -4524,12 +4654,11 @@ exit 42
 				controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 				clawdiCli: {
 					source: "npm:clawdi",
-					packageSpec: "clawdi@agent-v2",
+					packageSpec: "clawdi@0.13.0-test",
 					registry: "https://registry.npmjs.org",
 				},
 				runtimes: {
 					openclaw: hostedOpenClawRuntime({
-						install: { source: "official", channel: "stable" },
 						paths: { home },
 						provider_ids: ["clawdi-managed-v2"],
 						primary_model: {
@@ -4541,8 +4670,9 @@ exit 42
 				providers: {
 					"clawdi-managed-v2": {
 						kind: "openai-compatible",
+						type: "custom_openai_compatible",
 						baseUrl: "https://sub2api.test/v1",
-						model: "gpt-5.5",
+						models: [{ id: "gpt-5.5" }],
 						apiMode: "openai_chat",
 						managed_by: "clawdi",
 						runtimeEnvName: "CLAWDI_MANAGED_OPENAI_API_KEY",
@@ -4614,7 +4744,7 @@ exit 64
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		seedCurrentCliInstall(state, "clawdi@agent-v2", "0.13.0-test", "https://registry.npmjs.org");
+		seedCurrentCliInstall(state, "clawdi@0.13.0-test", "0.13.0-test", "https://registry.npmjs.org");
 		writeFileSync(join(run, "secrets", "auth-token"), "file-runtime-token\n");
 		writeFileSync(
 			sourcePath,
@@ -4738,7 +4868,7 @@ exit 64
 		const previousLog = console.log;
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
-		mkdirSync(home, { recursive: true });
+		seedOpenClawBinary(home);
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
@@ -4754,7 +4884,7 @@ exit 64
 				auth: { type: "bearer-env", env: "CLAWDI_AUTH_TOKEN" },
 			}),
 		);
-		seedCurrentCliInstall(state, "clawdi@agent-v2", "0.13.0-test", "https://registry.npmjs.org");
+		seedCurrentCliInstall(state, "clawdi@0.13.0-test", "0.13.0-test", "https://registry.npmjs.org");
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
@@ -4806,7 +4936,7 @@ exit 64
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
-									packageSpec: "clawdi@agent-v2",
+									packageSpec: "clawdi@0.13.0-test",
 									registry: "https://registry.npmjs.org",
 								},
 								runtimes: { openclaw: hostedOpenClawRuntime() },
@@ -5310,7 +5440,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
-		mkdirSync(home, { recursive: true });
+		seedOpenClawBinary(home);
 		writeFileSync(
 			join(bin, "npm"),
 			`#!/usr/bin/env bash
@@ -5473,7 +5603,7 @@ chmod +x "$prefix/bin/clawdi"
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
-		mkdirSync(home, { recursive: true });
+		seedOpenClawBinary(home);
 		writeFileSync(
 			join(bin, "npm"),
 			`#!/usr/bin/env bash
@@ -5566,10 +5696,10 @@ printf 'ActiveState=active\\nSubState=running\\n'
 						providers: {
 							default: {
 								kind: "openai-compatible",
+								type: "custom_openai_compatible",
 								baseUrl: "https://ai-gateway.example.test/v1",
-								model: "gpt-5.5",
+								models: [{ id: "gpt-5.5" }],
 								apiMode: "openai_responses",
-								managed_by: "clawdi",
 								runtimeEnvName: "CLAWDI_MANAGED_OPENAI_API_KEY",
 								apiKeySecretRef: "provider.default.apiKey",
 							},
@@ -5637,10 +5767,10 @@ printf 'ActiveState=active\\nSubState=running\\n'
 								providers: {
 									default: {
 										kind: "openai-compatible",
+										type: "custom_openai_compatible",
 										baseUrl: "https://ai-gateway.example.test/v1",
-										model: "gpt-5.5",
+										models: [{ id: "gpt-5.5" }],
 										apiMode: "openai_responses",
-										managed_by: "clawdi",
 										runtimeEnvName: "CLAWDI_MANAGED_OPENAI_API_KEY",
 										apiKeySecretRef: "provider.default.apiKey",
 									},
@@ -5705,7 +5835,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		}
 	});
 
-	it("runtime CLI update resolves the floating agent-v2 npm tag through the managed npm cache", () => {
+	it("generic runtime CLI update resolves a floating npm tag through the managed npm cache", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -5780,29 +5910,7 @@ chmod +x "$prefix/bin/clawdi"
 				"0.12.10-beta.48",
 				"https://registry.npmjs.org",
 			);
-			const result = applyRuntimeCliDesiredState(
-				{
-					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
-					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
-					runtime: "openclaw",
-					deploymentId: "dep_floating_cli_tag",
-					environmentId: "env_floating_cli_tag",
-					...hostedRequiredState(),
-					instanceId: "iid_floating_cli_tag",
-					generation: 1,
-					issuedAt: "2026-06-06T00:00:00Z",
-					locale: TEST_HOSTED_LOCALE,
-					system: hostedSystemFixture(home),
-					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
-					clawdiCli: {
-						source: "npm:clawdi",
-						packageSpec: "clawdi@agent-v2",
-						registry: "https://registry.npmjs.org",
-					},
-					runtimes: { openclaw: hostedOpenClawRuntime() },
-				},
-				paths,
-			);
+			const result = applyRuntimeCliDesiredState(genericCliDesiredState("clawdi@agent-v2"), paths);
 
 			expect(result.status).toBe("installed");
 			expect(result.version).toBe("0.12.10-beta.49");
@@ -5825,7 +5933,7 @@ chmod +x "$prefix/bin/clawdi"
 		}
 	});
 
-	it("keeps an official agent-v2 bootstrap install current without reinstalling", () => {
+	it("keeps a generic floating CLI install current without reinstalling", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -5861,26 +5969,7 @@ exit 97
 
 		try {
 			const result = applyRuntimeCliDesiredState(
-				{
-					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
-					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
-					runtime: "openclaw",
-					deploymentId: "dep_cli_bootstrap_current",
-					environmentId: "env_cli_bootstrap_current",
-					...hostedRequiredState(),
-					instanceId: "iid_cli_bootstrap_current",
-					generation: 1,
-					issuedAt: "2026-07-11T00:00:00Z",
-					locale: TEST_HOSTED_LOCALE,
-					system: hostedSystemFixture(home),
-					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
-					clawdiCli: {
-						source: "npm:clawdi",
-						packageSpec: "clawdi@agent-v2",
-						registry: "https://registry.npmjs.org",
-					},
-					runtimes: { openclaw: hostedOpenClawRuntime() },
-				},
+				genericCliDesiredState("clawdi@agent-v2"),
 				getRuntimePaths(),
 			);
 
@@ -5897,28 +5986,25 @@ exit 97
 		}
 	});
 
-	it("runtime watch self-heal re-resolves agent-v2 when manifest ETags stay unchanged", async () => {
-		const home = join(root, "home", "clawdi");
-		const state = join(root, "var", "lib", "clawdi");
-		const run = join(root, "run", "clawdi");
-		const sourcePath = join(root, "runtime-source.json");
-		const bin = join(root, "bin");
-		const npmLog = join(root, "npm-self-heal.log");
-		const previousExitCode = process.exitCode;
-		const previousLog = console.log;
+	it.each([
+		["upgrades", "0.12.10-beta.48", "0.12.10-beta.49"],
+		["downgrades", "0.12.10-beta.50", "0.12.10-beta.49"],
+	])("hosted exact CLI desired state %s without npm view", (_name, currentVersion, desiredVersion) => {
+		const home = join(root, `home-${currentVersion}`, "clawdi");
+		const state = join(root, `state-${currentVersion}`);
+		const run = join(root, `run-${currentVersion}`);
+		const bin = join(root, `bin-${currentVersion}`);
+		const npmLog = join(root, `npm-exact-${currentVersion}.log`);
 		const previousPath = process.env.PATH;
-		const logs: string[] = [];
-		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
-		mkdirSync(home, { recursive: true });
 		writeFileSync(
 			join(bin, "npm"),
 			`#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\\n' "$*" >> '${npmLog}'
 if [ "\${1:-}" = "view" ]; then
-  echo '"0.12.10-beta.50"'
-  exit 0
+  echo "exact hosted CLI updates must not call npm view" >&2
+  exit 96
 fi
 prefix=""
 while [ "$#" -gt 0 ]; do
@@ -5934,7 +6020,82 @@ install -d "$prefix/bin"
 cat > "$prefix/bin/clawdi" <<'SH'
 #!/usr/bin/env bash
 if [ "\${1:-}" = "--version" ]; then
-  echo "0.12.10-beta.50"
+  echo "${desiredVersion}"
+  exit 0
+fi
+if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
+  echo '{"status":"ok"}'
+  exit 0
+fi
+exit 64
+SH
+chmod +x "$prefix/bin/clawdi"
+`,
+		);
+		chmodSync(join(bin, "npm"), 0o700);
+		process.env.PATH = `${bin}:${previousPath ?? ""}`;
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		const currentSpec = `clawdi@${currentVersion}`;
+		const desiredSpec = `clawdi@${desiredVersion}`;
+		seedCurrentCliInstall(state, currentSpec, currentVersion, "https://registry.npmjs.org");
+
+		try {
+			const desired = normalizeManifestPayload(hostedCliManifestResponse(home, desiredSpec));
+			const result = applyRuntimeCliDesiredState(desired.manifest, getRuntimePaths());
+
+			expect(result.status).toBe("installed");
+			expect(result.packageSpec).toBe(desiredSpec);
+			expect(result.version).toBe(desiredVersion);
+			const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
+			expect(npmCalls.some((call) => call.startsWith("view "))).toBe(false);
+			expect(npmCalls.some((call) => call.includes(desiredSpec))).toBe(true);
+		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+		}
+	});
+
+	it("runtime watch self-heal applies an exact hosted CLI version without npm view", async () => {
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const sourcePath = join(root, "runtime-source.json");
+		const bin = join(root, "bin");
+		const npmLog = join(root, "npm-self-heal.log");
+		const previousExitCode = process.exitCode;
+		const previousLog = console.log;
+		const previousPath = process.env.PATH;
+		const logs: string[] = [];
+		mkdirSync(join(run, "secrets"), { recursive: true });
+		mkdirSync(bin, { recursive: true });
+		seedOpenClawBinary(home);
+		writeFileSync(
+			join(bin, "npm"),
+			`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> '${npmLog}'
+	if [ "\${1:-}" = "view" ]; then
+	  echo "exact hosted CLI updates must not call npm view" >&2
+	  exit 96
+fi
+prefix=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--prefix" ]; then
+    prefix="$2"
+    shift 2
+    continue
+  fi
+  shift
+done
+test -n "$prefix"
+install -d "$prefix/bin"
+cat > "$prefix/bin/clawdi" <<'SH'
+#!/usr/bin/env bash
+	if [ "\${1:-}" = "--version" ]; then
+	  echo "0.13.0-test"
   exit 0
 fi
 if [ "\${1:-} \${2:-} \${3:-}" = "runtime verify --json" ]; then
@@ -5970,7 +6131,7 @@ chmod +x "$prefix/bin/clawdi"
 		const paths = getRuntimePaths();
 		seedCurrentCliInstall(
 			state,
-			"clawdi@agent-v2",
+			"clawdi@0.12.10-beta.49",
 			"0.12.10-beta.49",
 			"https://registry.npmjs.org",
 		);
@@ -5993,7 +6154,7 @@ chmod +x "$prefix/bin/clawdi"
 				controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 				clawdiCli: {
 					source: "npm:clawdi",
-					packageSpec: "clawdi@agent-v2",
+					packageSpec: "clawdi@0.13.0-test",
 					registry: "https://registry.npmjs.org",
 				},
 				runtimes: { openclaw: hostedOpenClawRuntime() },
@@ -6072,13 +6233,13 @@ chmod +x "$prefix/bin/clawdi"
 			expect(events[1].cliUpdate).toEqual(
 				expect.objectContaining({
 					status: "installed",
-					packageSpec: "clawdi@agent-v2",
-					version: "0.12.10-beta.50",
+					packageSpec: "clawdi@0.13.0-test",
+					version: "0.13.0-test",
 				}),
 			);
 			expect(events[1].selfReexec).toBe(true);
 			const npmCalls = readFileSync(npmLog, "utf-8").trim().split("\n");
-			expect(npmCalls.some((call) => call.startsWith("view clawdi@agent-v2"))).toBe(true);
+			expect(npmCalls.some((call) => call.startsWith("view "))).toBe(false);
 			expect(npmCalls.some((call) => call.startsWith("install "))).toBe(true);
 		} finally {
 			if (timeoutId !== undefined) clearTimeout(timeoutId);
@@ -6204,7 +6365,6 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 								},
 								runtimes: {
 									openclaw: hostedOpenClawRuntime({
-										install: { source: "official", channel: "stable" },
 										paths: { home },
 									}),
 								},
@@ -6361,7 +6521,6 @@ chmod +x "$prefix/bin/clawdi"
 			},
 			runtimes: {
 				openclaw: hostedOpenClawRuntime({
-					install: { source: "official", channel: "stable" },
 					paths: { home },
 				}),
 			},
@@ -6459,7 +6618,7 @@ chmod +x "$prefix/bin/clawdi"
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
-		mkdirSync(home, { recursive: true });
+		seedOpenClawBinary(home);
 		writeFileSync(join(bin, "npm"), "#!/usr/bin/env bash\necho npm down >&2\nexit 42\n");
 		chmodSync(join(bin, "npm"), 0o700);
 		process.env.PATH = `${bin}:${previousPath ?? ""}`;
@@ -7107,7 +7266,7 @@ exit 64
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
 		};
-		seedCurrentCliInstall(state, "clawdi@agent-v2", "0.13.0-test", "https://registry.npmjs.org");
+		seedCurrentCliInstall(state, "clawdi@0.13.0-test", "0.13.0-test", "https://registry.npmjs.org");
 		const { captured, restore } = mockFetch([
 			{
 				method: "GET",
@@ -7130,13 +7289,11 @@ exit 64
 								controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 								clawdiCli: {
 									source: "npm:clawdi",
-									packageSpec: "clawdi@agent-v2",
+									packageSpec: "clawdi@0.13.0-test",
 									registry: "https://registry.npmjs.org",
 								},
 								runtimes: {
-									openclaw: hostedOpenClawRuntime({
-										install: { source: "official", args: [] },
-									}),
+									openclaw: hostedOpenClawRuntime(),
 								},
 							},
 							secretValues: {},
@@ -8254,7 +8411,7 @@ exit 64
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const workspace = join(home, "custom-workspace");
-		mkdirSync(home, { recursive: true });
+		writeHermesVersionBinary(home, "0.18.0");
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
@@ -8282,7 +8439,7 @@ exit 64
 							controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@agent-v2",
+								packageSpec: "clawdi@0.13.0-test",
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
@@ -8411,7 +8568,7 @@ exit 64
 					controlPlane: { apiUrl: "https://api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
-						packageSpec: "clawdi@agent-v2",
+						packageSpec: "clawdi@0.13.0-test",
 						registry: "https://registry.npmjs.org",
 					},
 					runtimes: {
@@ -8460,7 +8617,7 @@ exit 64
 		const run = join(root, "run", "clawdi");
 		const runtimeWorkspace = join(home, "hermes-workspace");
 		const manifestPath = join(root, "runtime-workspace.json");
-		mkdirSync(home, { recursive: true });
+		writeHermesVersionBinary(home, "0.18.0");
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
@@ -8483,7 +8640,7 @@ exit 64
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
-						packageSpec: "clawdi@agent-v2",
+						packageSpec: "clawdi@0.13.0-test",
 						registry: "https://registry.npmjs.org",
 					},
 					runtimes: {
@@ -9490,7 +9647,7 @@ exit 64
 							controlPlane: {},
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@agent-v2",
+								packageSpec: "clawdi@0.13.0-test",
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
@@ -9517,7 +9674,7 @@ exit 64
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
-		mkdirSync(home, { recursive: true });
+		seedOpenClawBinary(home);
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
@@ -9549,24 +9706,33 @@ exit 64
 							egressEngine: mitmproxy,
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@agent-v2",
+								packageSpec: "clawdi@0.13.0-test",
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
-								openclaw: hostedOpenClawRuntime(),
+								openclaw: hostedOpenClawRuntime({
+									provider_ids: ["clawdi-managed-v2"],
+									primary_model: {
+										provider_id: "clawdi-managed-v2",
+										model: "gpt-test",
+									},
+								}),
 							},
 							providers: {
-								default: {
+								"clawdi-managed-v2": {
 									kind: "openai-compatible",
+									type: "custom_openai_compatible",
 									baseUrl: "https://sub2api.test/v1",
+									models: [{ id: "gpt-test" }],
 									apiMode: "openai_chat",
 									managed_by: "clawdi",
-									apiKeySecretRef: "provider.default.apiKey",
+									runtimeEnvName: "CLAWDI_MANAGED_OPENAI_API_KEY",
+									apiKeySecretRef: "provider.clawdi-managed-v2.apiKey",
 								},
 							},
 						},
 						secretValues: {
-							"provider.default.apiKey": "sk-runtime",
+							"provider.clawdi-managed-v2.apiKey": "sk-runtime",
 						},
 					}),
 			},
@@ -9579,16 +9745,17 @@ exit 64
 			const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
 
 			expect(convergence.mode).toBe("normal");
+			expect(convergence.installErrors).toEqual([]);
 			const paths = getRuntimePaths();
 			expectEgressProfileBundleUsesSecretRef(
 				convergence.outputs.egressProfileBundle,
-				"secret://provider.default.apiKey",
+				"secret://provider.clawdi-managed-v2.apiKey",
 				"sk-runtime",
 			);
 			expectMitmSecretFileIsSidecarOnly(
 				paths,
 				convergence.outputs.egressSecretFile,
-				"secret://provider.default.apiKey",
+				"secret://provider.clawdi-managed-v2.apiKey",
 				"sk-runtime",
 			);
 			expectExistingFileNotToContain(join(run, "secrets", "runtime-secrets.json"), "sk-runtime");
@@ -9615,15 +9782,16 @@ exit 64
 			const providerHealth = JSON.parse(
 				readFileSync(join(state, "status", "provider-health.json"), "utf-8"),
 			);
-			expect(providerHealth.providers.default).toEqual({
-				status: "error",
+			expect(providerHealth.providers["clawdi-managed-v2"]).toEqual({
+				status: "ok",
 				configured: true,
 				kind: "openai-compatible",
 				baseUrl: "https://sub2api.test/v1",
 				model: null,
-				apiKeySecretRef: "provider.default.apiKey",
+				models: [{ id: "gpt-test" }],
+				apiKeySecretRef: "provider.clawdi-managed-v2.apiKey",
 				secretAvailable: true,
-				reasons: ["model_missing"],
+				reasons: [],
 			});
 			expect(JSON.stringify(providerHealth)).not.toContain("sk-runtime");
 		} finally {
@@ -9799,7 +9967,7 @@ exit 64
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
-		mkdirSync(home, { recursive: true });
+		seedOpenClawBinary(home);
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
@@ -9829,7 +9997,7 @@ exit 64
 							},
 							clawdiCli: {
 								source: "npm:clawdi",
-								packageSpec: "clawdi@agent-v2",
+								packageSpec: "clawdi@0.13.0-test",
 								registry: "https://registry.npmjs.org",
 							},
 							runtimes: {
@@ -9933,14 +10101,18 @@ exit 64
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
-						packageSpec: "clawdi@agent-v2",
+						packageSpec: "clawdi@0.13.0-test",
 						registry: "https://registry.npmjs.org",
 					},
 					runtimes: {
 						openclaw: hostedOpenClawRuntime(),
 					},
 					providers: {
-						default: { kind: "openai-compatible", baseUrl: "https://sub2api.test/v1" },
+						default: {
+							kind: "openai-compatible",
+							type: "custom_openai_compatible",
+							baseUrl: "https://sub2api.test/v1",
+						},
 					},
 				},
 				secretValues: {},
@@ -9980,7 +10152,7 @@ exit 64
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
-						packageSpec: "clawdi@agent-v2",
+						packageSpec: "clawdi@0.13.0-test",
 						registry: "https://registry.npmjs.org",
 					},
 					runtimes: {

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -215,551 +215,136 @@ describe("CLI smoke — src entry", () => {
 		}
 	});
 
-	it("runtime init performs first-install convergence from a fixture manifest", async () => {
+	it("runtime init rejects a generic manifest-file fixture in hosted mode", async () => {
 		const { tmpdir } = await import("node:os");
-		const {
-			chmodSync,
-			existsSync,
-			mkdirSync,
-			readFileSync,
-			rmSync,
-			statSync,
-			symlinkSync,
-			writeFileSync,
-		} = await import("node:fs");
-		const root = join(tmpdir(), `clawdi-smoke-runtime-full-${Date.now()}`);
+		const { mkdirSync, rmSync, writeFileSync } = await import("node:fs");
+		const root = join(tmpdir(), `clawdi-smoke-runtime-generic-reject-${Date.now()}`);
 		const home = join(root, "home", "clawdi");
-		const policyPath = join(root, "etc", "clawdi", "host-policy.json");
-		const manifestPath = join(root, "runtime-manifest.json");
-		const staleManifestPath = join(root, "runtime-manifest-stale.json");
-		const serviceStateRoot = join(root, "var", "lib", "clawdi");
-		const runRoot = join(root, "run", "clawdi");
-		const openclawInstaller = join(root, "fixtures", "openclaw-install.sh");
-		const hermesInstaller = join(root, "fixtures", "hermes-install.sh");
-		mkdirSync(dirname(policyPath), { recursive: true });
-		mkdirSync(dirname(openclawInstaller), { recursive: true });
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const manifestPath = join(root, "generic-manifest.json");
 		mkdirSync(home, { recursive: true });
 		writeFileSync(
-			policyPath,
+			manifestPath,
 			JSON.stringify({
-				schemaVersion: "clawdi.hostPolicy.v1",
-				mode: "hosted-runtime",
-				cliUpdateMode: "system-managed-npm",
-				deniedCommands: ["setup", "teardown", "update"],
+				schemaVersion: "clawdi.runtimeDesiredState.v1",
+				deploymentId: "dep_generic_reject",
+				environmentId: "env_generic_reject",
+				instanceId: "iid_generic_reject",
+				generation: 1,
+				issuedAt: "2026-07-12T00:00:00Z",
+				controlPlane: { apiUrl: "https://cloud-api.test" },
+				runtimes: { openclaw: { enabled: false } },
+				recovery: {},
 			}),
 		);
+
+		try {
+			const result = await runCli(
+				["runtime", "init", "--non-interactive", "--json", "--manifest-file", manifestPath],
+				{
+					HOME: home,
+					CLAWDI_RUNTIME_MODE: "hosted",
+					CLAWDI_SERVICE_STATE_DIR: state,
+					CLAWDI_RUN_DIR: run,
+				},
+			);
+			expect(result.code).toBe(22);
+			expect(JSON.parse(result.stdout).mode).toBe("manifest-rejected");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("runtime init converges a strict hosted manifest-file fixture", async () => {
+		const { tmpdir } = await import("node:os");
+		const { chmodSync, existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } = await import(
+			"node:fs"
+		);
+		const root = join(tmpdir(), `clawdi-smoke-runtime-strict-${Date.now()}`);
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		const manifestPath = join(root, "strict-hosted-manifest.json");
+		const installer = join(root, "install-openclaw.sh");
+		const managedCli = join(state, "bin", "clawdi");
+		const managedCliTarget = join(state, "npm", "bin", "clawdi");
+		mkdirSync(home, { recursive: true });
+		mkdirSync(dirname(installer), { recursive: true });
+		mkdirSync(dirname(managedCli), { recursive: true });
+		mkdirSync(dirname(managedCliTarget), { recursive: true });
+		mkdirSync(join(state, "status"), { recursive: true });
 		writeFileSync(
-			openclawInstaller,
-			`#!/usr/bin/env bash
-set -euo pipefail
-install -d "$HOME/.openclaw/bin" "$HOME/.openclaw/install-proof"
-printf '%s\\n' "\${NPM_CONFIG_PREFIX:-}" > "$HOME/.openclaw/install-proof/npm-config-prefix"
-printf '%s\\n' "\${NPM_CONFIG_CACHE:-}" > "$HOME/.openclaw/install-proof/npm-config-cache"
-printf '%s\\n' "\${NODE_EXTRA_CA_CERTS:-}" > "$HOME/.openclaw/install-proof/node-extra-ca-certs"
-printf '%s\\n' "\${NPM_CONFIG_CAFILE:-}" > "$HOME/.openclaw/install-proof/npm-config-cafile"
-cat > "$HOME/.openclaw/bin/openclaw" <<'SH'
-#!/usr/bin/env bash
-echo "openclaw fixture"
-SH
+			installer,
+			`#!/usr/bin/env sh
+set -eu
+mkdir -p "$HOME/.openclaw/bin"
+printf '#!/usr/bin/env sh\nexit 0\n' > "$HOME/.openclaw/bin/openclaw"
 chmod +x "$HOME/.openclaw/bin/openclaw"
 `,
 		);
-		chmodSync(openclawInstaller, 0o700);
+		chmodSync(installer, 0o700);
+		writeFileSync(managedCliTarget, "#!/usr/bin/env sh\nexit 0\n");
+		chmodSync(managedCliTarget, 0o700);
+		symlinkSync(managedCliTarget, managedCli);
 		writeFileSync(
-			hermesInstaller,
-			`#!/usr/bin/env bash
-set -euo pipefail
-install -d "$HOME/.local/bin" "$HOME/.hermes/hermes-agent" "$HOME/.hermes/install-proof"
-printf '%s\\n' "\${NPM_CONFIG_PREFIX:-}" > "$HOME/.hermes/install-proof/npm-config-prefix"
-printf '%s\\n' "\${NPM_CONFIG_CACHE:-}" > "$HOME/.hermes/install-proof/npm-config-cache"
-printf '%s\\n' "\${NODE_EXTRA_CA_CERTS:-}" > "$HOME/.hermes/install-proof/node-extra-ca-certs"
-printf '%s\\n' "\${NPM_CONFIG_CAFILE:-}" > "$HOME/.hermes/install-proof/npm-config-cafile"
-printf '%s\\n' "\${HERMES_HOME:-}" > "$HOME/.hermes/install-proof/hermes-home"
-printf '%s\\n' "\${UV_PYTHON_INSTALL_DIR:-}" > "$HOME/.hermes/install-proof/uv-python-install-dir"
-printf '%s\\n' "\${UV_PYTHON_BIN_DIR:-}" > "$HOME/.hermes/install-proof/uv-python-bin-dir"
-printf '%s\\n' "\${UV_MANAGED_PYTHON:-}" > "$HOME/.hermes/install-proof/uv-managed-python"
-printf '%s\\n' "\${UV_NO_MANAGED_PYTHON:-}" > "$HOME/.hermes/install-proof/uv-no-managed-python"
-printf '%s\\n' "\${UV_PYTHON_DOWNLOADS:-}" > "$HOME/.hermes/install-proof/uv-python-downloads"
-cat > "$HOME/.local/bin/hermes" <<'SH'
-#!/usr/bin/env bash
-echo "hermes fixture"
-SH
-chmod +x "$HOME/.local/bin/hermes"
-`,
+			join(state, "status", "cli-bootstrap.json"),
+			JSON.stringify({
+				schemaVersion: "clawdi.cliNpmBootstrapStatus.v1",
+				status: "installed",
+				source: "npm",
+				packageSpec: "clawdi@0.12.10-beta.51",
+				registry: "https://registry.npmjs.org",
+				activePath: managedCli,
+				activeTarget: managedCliTarget,
+				version: "0.12.10-beta.51",
+			}),
 		);
-		chmodSync(hermesInstaller, 0o700);
-		const mitmproxy = {
-			type: "mitmproxy" as const,
-			version: "12.2.3",
-			url: "https://downloads.mitmproxy.org/12.2.3/mitmproxy-12.2.3-linux-x86_64.tar.gz",
-			sha256: "2e95286b618fa6fd33e5e62a78c2e5112571d85f42ec2bac29b97ee242bdb5c5",
-		};
-		const mitmdump = join(
-			serviceStateRoot,
-			"maintained",
-			"mitmproxy",
-			mitmproxy.version,
-			mitmproxy.sha256,
-			"mitmdump",
-		);
-		mkdirSync(dirname(mitmdump), { recursive: true });
-		writeFileSync(mitmdump, "#!/usr/bin/env sh\necho fake mitmdump\n");
-		chmodSync(mitmdump, 0o755);
-
-		const manifest = {
-			schemaVersion: "clawdi.runtimeDesiredState.v1",
-			deploymentId: "dep_test",
-			environmentId: "env_test",
-			instanceId: "iid_test",
-			generation: 7,
-			issuedAt: "2026-06-03T00:00:00Z",
-			controlPlane: { apiUrl: "https://cloud-api.example.test" },
-			clawdiCli: { version: "0.10.1", channel: "stable", source: "npm:clawdi@stable" },
-			egressEngine: mitmproxy,
-			runtimes: {
-				openclaw: {
-					enabled: true,
-					updateChannel: "stable",
-					install: {
-						authority: "official",
-						method: "official-installer",
-						url: "https://openclaw.ai/install-cli.sh",
+		writeFileSync(
+			manifestPath,
+			JSON.stringify({
+				manifest: {
+					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					minimumCliVersion: "0.12.10-beta.51",
+					runtime: "openclaw",
+					deploymentId: "dep_strict_smoke",
+					environmentId: "env_strict_smoke",
+					instanceId: "iid_strict_smoke",
+					generation: 1,
+					issuedAt: "2026-07-12T00:00:00Z",
+					locale: { language: "en", timezone: "UTC" },
+					system: {
+						user: "clawdi",
 						home,
-						args: ["--json", "--version", "stable", "--no-onboard"],
+						workspace: join(home, "clawdi"),
+						persistentPaths: [home],
 					},
-				},
-				hermes: {
-					enabled: true,
-					updateChannel: "main",
-					install: {
-						authority: "official",
-						method: "official-installer",
-						url: "https://hermes-agent.nousresearch.com/install.sh",
-						home,
-						args: ["--branch", "main", "--skip-setup", "--non-interactive"],
-					},
-					run: {
-						env: {
-							DISCORD_API_BASE_URL: "http://127.0.0.1:4500/discord",
-						},
-						args: ["gateway", "run"],
-					},
-				},
-			},
-			egressProfiles: {
-				profiles: [
-					{
-						id: "codex-openai-responses",
-						kind: "provider",
-						match: {
-							scheme: "https",
-							host: "api.openai.com",
-							pathPrefix: "/v1/",
-							headers: {
-								authorization: {
-									type: "equals",
-									value: "clawdi-egress-placeholder",
-									prefix: "Bearer ",
-								},
-							},
-						},
-						rewrite: {
-							upstreamBaseUrl: "http://127.0.0.1:18890/provider/openai/responses",
-							preservePath: false,
-							setHeaders: {
-								authorization: "Bearer smoke-provider-key",
-							},
-						},
-						logging: { redactHeaders: ["authorization"] },
-						owner: "provider-projection",
-					},
-				],
-			},
-			projection: {
-				aiProviders: {
-					default: "openai-main/gpt-5.2",
-				},
-				mcp: { command: "clawdi mcp" },
-			},
-			liveSync: {
-				enabled: true,
-				agents: [{ agentType: "codex", environmentId: "env-codex" }],
-			},
-			recovery: { cacheManifest: true, allowOfflineBoot: true },
-		};
-		writeFileSync(manifestPath, JSON.stringify(manifest));
-
-		const env = {
-			HOME: home,
-			CLAWDI_RUNTIME_MODE: "hosted",
-			CLAWDI_HOST_POLICY_PATH: policyPath,
-			CLAWDI_SERVICE_STATE_DIR: serviceStateRoot,
-			CLAWDI_RUN_DIR: runRoot,
-			CLAWDI_AUTH_TOKEN: undefined,
-			CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS: "1",
-			CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER: openclawInstaller,
-			CLAWDI_RUNTIME_TEST_HERMES_INSTALLER: hermesInstaller,
-			CLAWDI_RUNTIME_MANIFEST_PATH: undefined,
-			NPM_CONFIG_PREFIX: "/var/lib/clawdi/npm",
-			NPM_CONFIG_CACHE: "/var/lib/clawdi/npm-cache",
-			HERMES_HOME: undefined,
-			OPENCLAW_STATE_DIR: undefined,
-		};
-
-		try {
-			const first = await runCli(
-				["runtime", "init", "--non-interactive", "--json", "--manifest-file", manifestPath],
-				env,
-			);
-			expect(first.code).toBe(0);
-			const parsed = JSON.parse(first.stdout);
-			expect(parsed.mode).toBe("normal");
-			expect(parsed.status).toBe("ok");
-			expect(parsed.stage).toBe("final");
-			expect(parsed.activeGeneration).toBe(7);
-			expect(parsed.enabledRuntimes).toEqual(["hermes", "openclaw"]);
-			expect(parsed.manifestSource.type).toBe("fixture-file");
-			expect(parsed.paths.workspaceRoot).toBe(join(home, "clawdi"));
-			expect(parsed.convergence.egressProfileBundle).toBe(
-				join(serviceStateRoot, "config", "egress", "profiles.json"),
-			);
-			expect(parsed.convergence.daemonAuthTokenFile).toBeNull();
-			expect(parsed.convergence.systemdSystemUnits).toEqual([
-				join(runRoot, "systemd", "system", "clawdi-runtime-sidecar.service"),
-			]);
-
-			for (const outputPath of [
-				join(serviceStateRoot, "config", "clawdi.json"),
-				join(serviceStateRoot, "sync", "runtimes.json"),
-				join(serviceStateRoot, "cache", "manifest.last-good.json"),
-				join(runRoot, "instance-data.json"),
-				join(runRoot, "instance-data-sensitive.json"),
-				join(serviceStateRoot, "install-inventory", "openclaw.json"),
-				join(serviceStateRoot, "install-inventory", "hermes.json"),
-				join(serviceStateRoot, "config", "projections", "openclaw.json"),
-				join(serviceStateRoot, "config", "projections", "hermes.json"),
-				join(serviceStateRoot, "config", "run", "openclaw.json"),
-				join(serviceStateRoot, "config", "run", "hermes.json"),
-				join(
-					home,
-					".config",
-					"systemd",
-					"user",
-					"openclaw-gateway.service.d",
-					"10-clawdi-hosted.conf",
-				),
-				join(
-					home,
-					".config",
-					"systemd",
-					"user",
-					"hermes-gateway.service.d",
-					"10-clawdi-hosted.conf",
-				),
-				join(runRoot, "systemd", "env", "openclaw-gateway.service.env"),
-				join(runRoot, "systemd", "env", "hermes-gateway.service.env"),
-				join(runRoot, "systemd", "env", "clawdi-runtime-sidecar.service.env"),
-				join(runRoot, "systemd", "system", "clawdi-runtime-sidecar.service"),
-				join(runRoot, "egress", "transparent-egress.env"),
-				join(runRoot, "egress", "clawdi_egress_addon.py"),
-				join(serviceStateRoot, "config", "egress", "profiles.json"),
-				join(serviceStateRoot, "instances", "iid_test", "boot-finished"),
-				join(home, "clawdi"),
-				join(home, ".openclaw", "bin", "openclaw"),
-				join(home, ".local", "bin", "hermes"),
-			]) {
-				if (!existsSync(outputPath)) {
-					throw new Error(`expected runtime init output to exist: ${outputPath}`);
-				}
-			}
-			for (const staleShimPath of [
-				join(serviceStateRoot, "bin", ".clawdi-runtime-command-shim"),
-				join(serviceStateRoot, "bin", "openclaw"),
-				join(serviceStateRoot, "bin", "hermes"),
-				join(serviceStateRoot, "bin", "codex"),
-				join(serviceStateRoot, "config", "runtime-command-shims.json"),
-				join(serviceStateRoot, "supervisor", "supervisord.conf"),
-				join(runRoot, "supervisor", "supervisord.conf"),
-				join(runRoot, "launch", "openclaw.sh"),
-				join(runRoot, "launch", "openclaw.env"),
-				join(runRoot, "launch", "hermes.sh"),
-				join(runRoot, "launch", "hermes.env"),
-			]) {
-				expect(existsSync(staleShimPath)).toBe(false);
-			}
-			expect(statSync(join(serviceStateRoot, "cache", "boot-status.json")).mode & 0o777).toBe(
-				0o644,
-			);
-			expect(statSync(join(serviceStateRoot, "boot", "status.json")).mode & 0o777).toBe(0o644);
-			expect(statSync(join(serviceStateRoot, "boot", "result.json")).mode & 0o777).toBe(0o644);
-			expect(statSync(join(runRoot, "instance-data-sensitive.json")).mode & 0o777).toBe(0o600);
-			expect(
-				JSON.parse(readFileSync(join(runRoot, "instance-data-sensitive.json"), "utf-8"))
-					.tokenSource,
-			).toBe("fixture-file");
-			expect(
-				readFileSync(join(home, ".openclaw", "install-proof", "npm-config-prefix"), "utf-8"),
-			).toBe("\n");
-			expect(
-				readFileSync(join(home, ".openclaw", "install-proof", "npm-config-cache"), "utf-8"),
-			).toBe("\n");
-			expect(
-				readFileSync(join(home, ".openclaw", "install-proof", "node-extra-ca-certs"), "utf-8"),
-			).toBe("/etc/ssl/certs/ca-certificates.crt\n");
-			expect(
-				readFileSync(join(home, ".openclaw", "install-proof", "npm-config-cafile"), "utf-8"),
-			).toBe("/etc/ssl/certs/ca-certificates.crt\n");
-			expect(
-				readFileSync(join(home, ".hermes", "install-proof", "npm-config-prefix"), "utf-8"),
-			).toBe("\n");
-			expect(
-				readFileSync(join(home, ".hermes", "install-proof", "npm-config-cache"), "utf-8"),
-			).toBe("\n");
-			expect(
-				readFileSync(join(home, ".hermes", "install-proof", "node-extra-ca-certs"), "utf-8"),
-			).toBe("/etc/ssl/certs/ca-certificates.crt\n");
-			expect(
-				readFileSync(join(home, ".hermes", "install-proof", "npm-config-cafile"), "utf-8"),
-			).toBe("/etc/ssl/certs/ca-certificates.crt\n");
-			expect(readFileSync(join(home, ".hermes", "install-proof", "hermes-home"), "utf-8")).toBe(
-				`${join(home, ".hermes")}\n`,
-			);
-			expect(
-				readFileSync(join(home, ".hermes", "install-proof", "uv-python-install-dir"), "utf-8"),
-			).toBe(`${join(home, ".hermes", "uv", "python")}\n`);
-			expect(
-				readFileSync(join(home, ".hermes", "install-proof", "uv-python-bin-dir"), "utf-8"),
-			).toBe(`${join(home, ".hermes", "uv", "bin")}\n`);
-			expect(
-				readFileSync(join(home, ".hermes", "install-proof", "uv-managed-python"), "utf-8"),
-			).toBe("1\n");
-			expect(
-				readFileSync(join(home, ".hermes", "install-proof", "uv-no-managed-python"), "utf-8"),
-			).toBe("\n");
-			expect(
-				readFileSync(join(home, ".hermes", "install-proof", "uv-python-downloads"), "utf-8"),
-			).toBe("\n");
-
-			const managed = JSON.parse(
-				readFileSync(join(serviceStateRoot, "config", "clawdi.json"), "utf-8"),
-			);
-			expect(managed.generation).toBe(7);
-			expect(JSON.stringify(managed)).not.toContain("auth-test-token");
-			const hermesUnit = readFileSync(
-				join(
-					home,
-					".config",
-					"systemd",
-					"user",
-					"hermes-gateway.service.d",
-					"10-clawdi-hosted.conf",
-				),
-				"utf-8",
-			);
-			const openclawUnit = readFileSync(
-				join(
-					home,
-					".config",
-					"systemd",
-					"user",
-					"openclaw-gateway.service.d",
-					"10-clawdi-hosted.conf",
-				),
-				"utf-8",
-			);
-			const sidecarUnit = readFileSync(
-				join(runRoot, "systemd", "system", "clawdi-runtime-sidecar.service"),
-				"utf-8",
-			);
-			const openclawEnv = readFileSync(
-				join(runRoot, "systemd", "env", "openclaw-gateway.service.env"),
-				"utf-8",
-			);
-			expect(hermesUnit).toContain(
-				`ExecStart="${join(home, ".local", "bin", "hermes")}" "gateway" "run"`,
-			);
-			expect(openclawUnit).toContain(
-				`ExecStart="${join(home, ".openclaw", "bin", "openclaw")}" "gateway" "run"`,
-			);
-			expect(sidecarUnit).toContain('ExecStart="clawdi" "runtime" "sidecar"');
-			expect(existsSync(join(runRoot, "systemd", "system", "clawdi-runtime-sidecar.service"))).toBe(
-				true,
-			);
-			expect(hermesUnit).not.toContain("clawdi run -- hermes");
-			expect(openclawUnit).not.toContain("clawdi run -- openclaw");
-			expect(openclawEnv).toContain('CLAWDI_RUNTIME_REV="');
-			expect(openclawEnv).toContain('OPENCLAW_SYSTEMD_UNIT="openclaw-gateway.service"');
-			expect(openclawUnit).not.toContain("auth-test-token");
-			expect(openclawEnv).not.toContain("auth-test-token");
-			const inventory = JSON.parse(
-				readFileSync(join(serviceStateRoot, "install-inventory", "openclaw.json"), "utf-8"),
-			);
-			expect(inventory.install.url).toBe("https://openclaw.ai/install-cli.sh");
-			expect(inventory.install.args).not.toContain("--dir");
-			expect(inventory.install.args).not.toContain("--prefix");
-			expect(inventory.status).toBe("installed");
-			expect(inventory.commandPath).toBe(join(home, ".openclaw", "bin", "openclaw"));
-			expect(typeof inventory.installStartedAt).toBe("string");
-			expect(typeof inventory.installFinishedAt).toBe("string");
-			expect(typeof inventory.installDurationMs).toBe("number");
-			expect(inventory.installDurationMs).toBeGreaterThanOrEqual(0);
-			const openclawRunConfig = JSON.parse(
-				readFileSync(join(serviceStateRoot, "config", "run", "openclaw.json"), "utf-8"),
-			);
-			expect(openclawRunConfig.schemaVersion).toBe("clawdi.runtimeRunConfig.v1");
-			expect(openclawRunConfig.commandPath).toBe(join(home, ".openclaw", "bin", "openclaw"));
-			expect(openclawRunConfig.defaultArgs).toEqual([
-				"gateway",
-				"run",
-				"--allow-unconfigured",
-				"--bind",
-				"loopback",
-				"--force",
-			]);
-			expect(openclawRunConfig.env.CLAWDI_EGRESS_SECRET_FILE).toBeUndefined();
-			const hermesRunConfig = JSON.parse(
-				readFileSync(join(serviceStateRoot, "config", "run", "hermes.json"), "utf-8"),
-			);
-			expect(hermesRunConfig.schemaVersion).toBe("clawdi.runtimeRunConfig.v1");
-			expect(hermesRunConfig.commandPath).toBe(join(home, ".local", "bin", "hermes"));
-			expect(hermesRunConfig.defaultArgs).toEqual(["gateway", "run"]);
-			expect(hermesRunConfig.env.DISCORD_API_BASE_URL).toBe("http://127.0.0.1:4500/discord");
-			expect(hermesRunConfig.env.CLAWDI_EGRESS_SECRET_FILE).toBeUndefined();
-			expect(hermesRunConfig.egressProfileBundlePath).toBe(
-				join(serviceStateRoot, "config", "egress", "profiles.json"),
-			);
-			const egressProfiles = JSON.parse(
-				readFileSync(join(serviceStateRoot, "config", "egress", "profiles.json"), "utf-8"),
-			);
-			expect(egressProfiles.schemaVersion).toBe("clawdi.egressProfiles.v1");
-			expect(egressProfiles.profiles[0].id).toBe("codex-openai-responses");
-			expect(JSON.stringify(egressProfiles)).toContain("smoke-provider-key");
-			expect(JSON.stringify(egressProfiles)).not.toContain("auth-test-token");
-			const lastGoodPath = join(serviceStateRoot, "cache", "manifest.last-good.json");
-			const cachedLastGood = JSON.parse(readFileSync(lastGoodPath, "utf-8"));
-			writeFileSync(
-				lastGoodPath,
-				JSON.stringify({
-					...cachedLastGood,
+					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
 						packageSpec: "clawdi@0.12.10-beta.51",
 						registry: "https://registry.npmjs.org",
 					},
-				}),
-			);
-			const managedCli = join(serviceStateRoot, "bin", "clawdi");
-			const managedCliTarget = join(serviceStateRoot, "npm", "bin", "clawdi");
-			mkdirSync(dirname(managedCli), { recursive: true });
-			mkdirSync(dirname(managedCliTarget), { recursive: true });
-			mkdirSync(join(serviceStateRoot, "status"), { recursive: true });
-			writeFileSync(managedCliTarget, "#!/usr/bin/env sh\nexit 0\n");
-			chmodSync(managedCliTarget, 0o700);
-			symlinkSync(managedCliTarget, managedCli);
-			writeFileSync(
-				join(serviceStateRoot, "status", "cli-bootstrap.json"),
-				JSON.stringify({
-					schemaVersion: "clawdi.cliNpmBootstrapStatus.v1",
-					status: "installed",
-					source: "npm",
-					packageSpec: "clawdi@0.12.10-beta.51",
-					registry: "https://registry.npmjs.org",
-					activePath: managedCli,
-					activeTarget: managedCliTarget,
-					version: "0.12.10-beta.51",
-				}),
-			);
-
-			const offline = await runCli(["runtime", "init", "--non-interactive", "--json"], env);
-			expect(offline.code).toBe(0);
-			const offlineParsed = JSON.parse(offline.stdout);
-			expect(offlineParsed.mode).toBe("degraded-offline");
-			expect(offlineParsed.status).toBe("ok");
-
-			writeFileSync(staleManifestPath, JSON.stringify({ ...manifest, generation: 6 }));
-			const stale = await runCli(
-				["runtime", "init", "--non-interactive", "--json", "--manifest-file", staleManifestPath],
-				env,
-			);
-			expect(stale.code).toBe(0);
-			const staleParsed = JSON.parse(stale.stdout);
-			expect(staleParsed.mode).toBe("normal");
-			expect(staleParsed.activeGeneration).toBe(6);
-			const lastGood = JSON.parse(
-				readFileSync(join(serviceStateRoot, "cache", "manifest.last-good.json"), "utf-8"),
-			);
-			expect(lastGood.generation).toBe(6);
-		} finally {
-			rmSync(root, { recursive: true, force: true });
-		}
-	});
-
-	it("runtime init rejects fixture secretRefs without inline secretValues", async () => {
-		const { tmpdir } = await import("node:os");
-		const { mkdirSync, rmSync, writeFileSync } = await import("node:fs");
-		const root = join(tmpdir(), `clawdi-smoke-runtime-secretref-${Date.now()}`);
-		const home = join(root, "home", "clawdi");
-		const policyPath = join(root, "etc", "clawdi", "host-policy.json");
-		const manifestPath = join(root, "runtime-manifest.json");
-		const serviceStateRoot = join(root, "var", "lib", "clawdi");
-		const runRoot = join(root, "run", "clawdi");
-		mkdirSync(home, { recursive: true });
-		mkdirSync(dirname(policyPath), { recursive: true });
-		writeFileSync(
-			policyPath,
-			JSON.stringify({
-				schemaVersion: "clawdi.hostPolicy.v1",
-				mode: "hosted-runtime",
-				cliUpdateMode: "system-managed-npm",
-				deniedCommands: ["setup", "teardown", "update"],
-			}),
-		);
-		writeFileSync(
-			manifestPath,
-			JSON.stringify({
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_secretref_reject",
-				environmentId: "env_secretref_reject",
-				instanceId: "iid_secretref_reject",
-				generation: 1,
-				issuedAt: "2026-06-04T00:00:00Z",
-				controlPlane: { apiUrl: "https://cloud-api.example.test" },
-				runtimes: {
-					openclaw: { enabled: false },
-					hermes: { enabled: false },
-				},
-				egressProfiles: {
-					profiles: [
-						{
-							id: "codex-openai-responses",
-							kind: "provider",
-							match: {
-								scheme: "https",
-								host: "api.openai.com",
-								pathPrefix: "/v1/",
-								headers: {
-									authorization: {
-										type: "equals",
-										value: "clawdi-egress-placeholder",
-										prefix: "Bearer ",
-									},
-								},
-							},
-							rewrite: {
-								upstreamBaseUrl: "https://sub2api.test/v1/responses",
-								preservePath: false,
-								setHeaders: {
-									authorization: {
-										type: "secretRef",
-										secretRef: "secret://provider.default.apiKey",
-										prefix: "Bearer ",
-									},
-								},
-							},
+					runtimes: {
+						openclaw: {
+							enabled: true,
+							install: { source: "official" },
+							provider_ids: ["default"],
+							primary_model: { provider_id: "default", model: "gpt-5" },
+							paths: { home, workspace: join(home, "clawdi") },
 						},
-					],
+					},
+					providers: {
+						default: {
+							kind: "openai-compatible",
+							status: "error",
+							error: { code: "provider_not_found", message: "fixture provider unavailable" },
+						},
+					},
+					liveSync: { enabled: false, agents: [] },
+					recovery: { cacheManifest: true, allowOfflineBoot: true },
 				},
-				recovery: { cacheManifest: true, allowOfflineBoot: true },
+				secretValues: {},
 			}),
 		);
 
@@ -769,136 +354,20 @@ chmod +x "$HOME/.local/bin/hermes"
 				{
 					HOME: home,
 					CLAWDI_RUNTIME_MODE: "hosted",
-					CLAWDI_HOST_POLICY_PATH: policyPath,
-					CLAWDI_SERVICE_STATE_DIR: serviceStateRoot,
-					CLAWDI_RUN_DIR: runRoot,
-					CLAWDI_RUNTIME_MANIFEST_PATH: undefined,
-				},
-			);
-			expect(result.code).toBe(22);
-			const parsed = JSON.parse(result.stdout);
-			expect(parsed.mode).toBe("manifest-rejected");
-			expect(parsed.errors[0]).toContain("fixture references secretValues");
-		} finally {
-			rmSync(root, { recursive: true, force: true });
-		}
-	});
-
-	it("runtime init installs only selected runtimes", async () => {
-		const { tmpdir } = await import("node:os");
-		const { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } = await import(
-			"node:fs"
-		);
-		const root = join(tmpdir(), `clawdi-smoke-runtime-selection-${Date.now()}`);
-		const home = join(root, "home", "clawdi");
-		const policyPath = join(root, "etc", "clawdi", "host-policy.json");
-		const manifestPath = join(root, "runtime-manifest.json");
-		const serviceStateRoot = join(root, "var", "lib", "clawdi");
-		const runRoot = join(root, "run", "clawdi");
-		const openclawInstaller = join(root, "fixtures", "openclaw-install.sh");
-		mkdirSync(dirname(policyPath), { recursive: true });
-		mkdirSync(dirname(openclawInstaller), { recursive: true });
-		mkdirSync(home, { recursive: true });
-		writeFileSync(
-			policyPath,
-			JSON.stringify({
-				schemaVersion: "clawdi.hostPolicy.v1",
-				mode: "hosted-runtime",
-				cliUpdateMode: "system-managed-npm",
-				deniedCommands: ["setup", "teardown", "update"],
-			}),
-		);
-		writeFileSync(
-			openclawInstaller,
-			`#!/usr/bin/env bash
-set -euo pipefail
-install -d "$HOME/.openclaw/bin"
-cat > "$HOME/.openclaw/bin/openclaw" <<'SH'
-#!/usr/bin/env bash
-echo "openclaw fixture"
-SH
-chmod +x "$HOME/.openclaw/bin/openclaw"
-`,
-		);
-		chmodSync(openclawInstaller, 0o700);
-
-		writeFileSync(
-			manifestPath,
-			JSON.stringify({
-				schemaVersion: "clawdi.runtimeDesiredState.v1",
-				deploymentId: "dep_selection",
-				environmentId: "env_selection",
-				instanceId: "iid_selection",
-				generation: 1,
-				issuedAt: "2026-06-04T00:00:00Z",
-				controlPlane: { apiUrl: "https://cloud-api.example.test" },
-				runtimes: {
-					openclaw: {
-						enabled: true,
-						updateChannel: "stable",
-						install: {
-							authority: "official",
-							method: "official-installer",
-							url: "https://openclaw.ai/install-cli.sh",
-							home,
-							args: ["--json", "--no-onboard"],
-						},
-					},
-					hermes: {
-						enabled: false,
-					},
-				},
-				recovery: { cacheManifest: true, allowOfflineBoot: true },
-			}),
-		);
-
-		try {
-			const result = await runCli(
-				["runtime", "init", "--non-interactive", "--json", "--manifest-file", manifestPath],
-				{
-					HOME: home,
-					CLAWDI_RUNTIME_MODE: "hosted",
-					CLAWDI_HOST_POLICY_PATH: policyPath,
-					CLAWDI_SERVICE_STATE_DIR: serviceStateRoot,
-					CLAWDI_RUN_DIR: runRoot,
-					CLAWDI_AUTH_TOKEN: "auth-selection-token",
+					CLAWDI_SERVICE_STATE_DIR: state,
+					CLAWDI_RUN_DIR: run,
 					CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS: "1",
-					CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER: openclawInstaller,
-					CLAWDI_RUNTIME_TEST_HERMES_INSTALLER: undefined,
-					CLAWDI_RUNTIME_MANIFEST_PATH: undefined,
-					HERMES_HOME: undefined,
-					OPENCLAW_STATE_DIR: undefined,
+					CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER: installer,
 				},
 			);
 			expect(result.code).toBe(0);
 			const parsed = JSON.parse(result.stdout);
+			expect(parsed.status).toBe("ok");
+			expect(parsed.stage).toBe("final");
 			expect(parsed.enabledRuntimes).toEqual(["openclaw"]);
+			expect(parsed.manifestSource.type).toBe("fixture-file");
 			expect(existsSync(join(home, ".openclaw", "bin", "openclaw"))).toBe(true);
-			expect(existsSync(join(home, ".local", "bin", "hermes"))).toBe(false);
-			expect(existsSync(join(serviceStateRoot, "bin", "openclaw"))).toBe(false);
-			expect(existsSync(join(serviceStateRoot, "bin", "hermes"))).toBe(false);
-			expect(existsSync(join(serviceStateRoot, "bin", "codex"))).toBe(false);
-			expect(existsSync(join(serviceStateRoot, "bin", ".clawdi-runtime-command-shim"))).toBe(false);
-			expect(existsSync(join(serviceStateRoot, "config", "runtime-command-shims.json"))).toBe(
-				false,
-			);
-			expect(existsSync(join(runRoot, "launch", "openclaw.sh"))).toBe(false);
-			expect(existsSync(join(runRoot, "launch", "openclaw.env"))).toBe(false);
-			expect(existsSync(join(runRoot, "launch", "hermes.sh"))).toBe(false);
-			expect(existsSync(join(runRoot, "launch", "hermes.env"))).toBe(false);
-
-			const openclawInventory = JSON.parse(
-				readFileSync(join(serviceStateRoot, "install-inventory", "openclaw.json"), "utf-8"),
-			);
-			const hermesInventory = JSON.parse(
-				readFileSync(join(serviceStateRoot, "install-inventory", "hermes.json"), "utf-8"),
-			);
-			expect(openclawInventory.status).toBe("installed");
-			expect(hermesInventory.status).toBe("disabled");
-			const hermesRunConfig = JSON.parse(
-				readFileSync(join(serviceStateRoot, "config", "run", "hermes.json"), "utf-8"),
-			);
-			expect(hermesRunConfig.enabled).toBe(false);
+			expect(existsSync(join(state, "cache", "manifest.last-good.json"))).toBe(true);
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -217,8 +217,16 @@ describe("CLI smoke — src entry", () => {
 
 	it("runtime init performs first-install convergence from a fixture manifest", async () => {
 		const { tmpdir } = await import("node:os");
-		const { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } =
-			await import("node:fs");
+		const {
+			chmodSync,
+			existsSync,
+			mkdirSync,
+			readFileSync,
+			rmSync,
+			statSync,
+			symlinkSync,
+			writeFileSync,
+		} = await import("node:fs");
 		const root = join(tmpdir(), `clawdi-smoke-runtime-full-${Date.now()}`);
 		const home = join(root, "home", "clawdi");
 		const policyPath = join(root, "etc", "clawdi", "host-policy.json");
@@ -627,6 +635,40 @@ chmod +x "$HOME/.local/bin/hermes"
 			expect(egressProfiles.profiles[0].id).toBe("codex-openai-responses");
 			expect(JSON.stringify(egressProfiles)).toContain("smoke-provider-key");
 			expect(JSON.stringify(egressProfiles)).not.toContain("auth-test-token");
+			const lastGoodPath = join(serviceStateRoot, "cache", "manifest.last-good.json");
+			const cachedLastGood = JSON.parse(readFileSync(lastGoodPath, "utf-8"));
+			writeFileSync(
+				lastGoodPath,
+				JSON.stringify({
+					...cachedLastGood,
+					clawdiCli: {
+						source: "npm:clawdi",
+						packageSpec: "clawdi@0.12.10-beta.51",
+						registry: "https://registry.npmjs.org",
+					},
+				}),
+			);
+			const managedCli = join(serviceStateRoot, "bin", "clawdi");
+			const managedCliTarget = join(serviceStateRoot, "npm", "bin", "clawdi");
+			mkdirSync(dirname(managedCli), { recursive: true });
+			mkdirSync(dirname(managedCliTarget), { recursive: true });
+			mkdirSync(join(serviceStateRoot, "status"), { recursive: true });
+			writeFileSync(managedCliTarget, "#!/usr/bin/env sh\nexit 0\n");
+			chmodSync(managedCliTarget, 0o700);
+			symlinkSync(managedCliTarget, managedCli);
+			writeFileSync(
+				join(serviceStateRoot, "status", "cli-bootstrap.json"),
+				JSON.stringify({
+					schemaVersion: "clawdi.cliNpmBootstrapStatus.v1",
+					status: "installed",
+					source: "npm",
+					packageSpec: "clawdi@0.12.10-beta.51",
+					registry: "https://registry.npmjs.org",
+					activePath: managedCli,
+					activeTarget: managedCliTarget,
+					version: "0.12.10-beta.51",
+				}),
+			);
 
 			const offline = await runCli(["runtime", "init", "--non-interactive", "--json"], env);
 			expect(offline.code).toBe(0);


### PR DESCRIPTION
## Why

Agent deployment v2 needs one fail-closed Hosted wire contract across Cloud, the bootstrap shim, and the CLI. Hosted desired state must select an immutable exact CLI version and must not downgrade into the generic manifest contract.

CLI publication remains repository-local and uses the standard npm channels: prereleases publish to `beta`, stable versions publish to `latest`. These tags are publication metadata only. Hosted runtime authority is always an exact `clawdi@<semver>`.

## What changed

- Enforces strict Hosted schemas for remote responses, fixtures, and last-good cache state.
- Requires exact npm specs for Hosted remote/cache inputs; controlled image-local tgz fixtures remain test-only.
- Makes trust-domain selection explicit from Hosted mode rather than manifest markers.
- Removes floating-tag and `npm view` convergence from the Hosted runtime CLI updater.
- Preserves exact upgrade/downgrade, canonical active-link recovery, bad-version quarantine, and fail-before-swap version verification.
- Rejects legacy hash-prefix recovery and covers `degraded-offline` apply/boot behavior.
- Publishes prereleases to `beta` and stable versions to `latest`; package-level `publishConfig.tag` overrides are forbidden.
- Keeps one immutable artifact between build, verification, and the GitHub-hosted OIDC publish job.
- Keeps Agent v2 production-disabled.

## Trust Boundaries

- **Hosted remote:** strict Hosted response schema and exact registry spec only.
- **Hosted fixture:** strict Hosted fixture envelope; local tgz requires the explicit test-installer gate.
- **Hosted cache:** strict Hosted semantics are revalidated before offline boot.
- **Generic/non-Hosted:** remains separate from the Hosted trust domain.
- **npm publication:** version-derived standard channel only.
- **Production runtime:** exact package versions only; no dist-tag resolution.

## Verification

- Full isolated CLI suite: `927 passed, 0 failed`.
- Focused runtime and publish-workflow contract tests passed.
- TypeScript typecheck and Biome passed.
- Manifest checker rejects any package-level tag override.
- `npm pack --dry-run --ignore-scripts` passed with no published tag override.
- `git diff --check` and pre-commit hooks passed.
- #387/#388 changed-file overlap is empty and `git merge-tree --write-tree` succeeds.

Final head: `4526d624f798bc2490c9c7f9c4894d099c1355e5`.

No merge, npm publish, deploy, repository-setting change, production operation, or tenant-data operation was performed. Agent v2 remains production-disabled.
