### PR TITLE
feat(admin): M1/A0.1a — optional owner assertion + control-plane audit

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -142,6 +142,32 @@ async def _resolve_or_create_user(db: AsyncSession, clerk_id: str) -> User:
     return user
 
 
+async def _assert_admin_target_owns_environment(
+    db: AsyncSession,
+    *,
+    env: AgentEnvironment,
+    target_clerk_id: str | None,
+) -> UUID:
+    if target_clerk_id is None:
+        return env.user_id
+
+    target = (
+        await db.execute(select(User).where(User.clerk_id == target_clerk_id))
+    ).scalar_one_or_none()
+    if target is None or env.user_id != target.id:
+        logger.warning(
+            "admin_environment_owner_rejected target_clerk_id=%s env_id=%s owner_user_id=%s",
+            target_clerk_id,
+            env.id,
+            env.user_id,
+        )
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            "Agent environment is not owned by target user",
+        )
+    return target.id
+
+
 @router.post("/auth/keys", response_model=ApiKeyCreated)
 async def admin_mint_api_key(
     body: AdminApiKeyCreate,
@@ -206,6 +232,24 @@ async def admin_mint_api_key(
         api_key.environment_id,
         api_key.managed,
     )
+    record_control_plane_audit(
+        db,
+        actor_type="admin",
+        action="api_key.mint",
+        resource_type="api_key",
+        resource_id=str(api_key.id),
+        environment_id=api_key.environment_id,
+        target_user_id=target.id,
+        source="api.admin",
+        details={
+            "label": api_key.label,
+            "key_prefix": api_key.key_prefix,
+            "managed": api_key.managed,
+            "has_environment_binding": api_key.environment_id is not None,
+            "scope_count": None if api_key.scopes is None else len(api_key.scopes),
+        },
+    )
+    await db.commit()
     return ApiKeyCreated(
         id=str(api_key.id),
         label=api_key.label,
@@ -239,6 +283,22 @@ async def admin_revoke_api_key(
         return ApiKeyRevokeResponse(status="revoked")
 
     api_key.revoked_at = datetime.now(UTC)
+    record_control_plane_audit(
+        db,
+        actor_type="admin",
+        action="api_key.revoke",
+        resource_type="api_key",
+        resource_id=str(api_key.id),
+        environment_id=api_key.environment_id,
+        target_user_id=api_key.user_id,
+        source="api.admin",
+        details={
+            "label": api_key.label,
+            "key_prefix": api_key.key_prefix,
+            "managed": api_key.managed,
+            "has_environment_binding": api_key.environment_id is not None,
+        },
+    )
     await db.commit()
     invalidate_api_key_auth_cache(api_key.id)
     logger.info(
@@ -635,6 +695,7 @@ async def admin_register_environment(
 
 async def _admin_delete_environment(
     environment_id: UUID,
+    target_clerk_id: str | None,
     db: AsyncSession,
 ) -> None:
     env = (
@@ -642,19 +703,44 @@ async def _admin_delete_environment(
     ).scalar_one_or_none()
     if env is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
+    target_user_id = await _assert_admin_target_owns_environment(
+        db,
+        env=env,
+        target_clerk_id=target_clerk_id,
+    )
+    record_control_plane_audit(
+        db,
+        actor_type="admin",
+        action="agent_environment.delete",
+        resource_type="agent_environment",
+        resource_id=str(env.id),
+        environment_id=env.id,
+        target_user_id=target_user_id,
+        source="api.admin",
+        details={
+            "agent_type": env.agent_type,
+            "machine_id": env.machine_id,
+            "explicit_identity": env.registration_key is None,
+        },
+    )
     await queue_environment_runtime_manifest_changed(db, env.user_id, environment_id)
     await db.delete(env)
     await db.commit()
-    logger.info("admin_environment_deleted env_id=%s", environment_id)
+    logger.info(
+        "admin_environment_deleted target_clerk_id=%s env_id=%s",
+        target_clerk_id,
+        environment_id,
+    )
 
 
 @router.delete("/agents/{agent_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def admin_delete_agent(
     agent_id: UUID,
+    target_clerk_id: str | None = None,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> None:
-    await _admin_delete_environment(agent_id, db)
+    await _admin_delete_environment(agent_id, target_clerk_id, db)
 
 
 @router.delete(
@@ -664,6 +750,7 @@ async def admin_delete_agent(
 )
 async def admin_delete_environment(
     environment_id: UUID,
+    target_clerk_id: str | None = None,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> None:
@@ -673,7 +760,7 @@ async def admin_delete_environment(
     user-facing `/v1/environments/{id}` semantics. Unlike the dashboard route,
     first-party cleanup may delete explicit-identity rows.
     """
-    await _admin_delete_environment(environment_id, db)
+    await _admin_delete_environment(environment_id, target_clerk_id, db)
 
 
 async def _next_environment_sort_order(db: AsyncSession, user_id: UUID) -> int:
@@ -699,6 +786,11 @@ async def _admin_upsert_runtime_state(
     ).scalar_one_or_none()
     if env is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent environment not found")
+    target_user_id = await _assert_admin_target_owns_environment(
+        db,
+        env=env,
+        target_clerk_id=body.target_clerk_id,
+    )
 
     # Lock the parent before the optional child row so concurrent first creates
     # serialize even when there is no HostedRuntimeState row to lock yet.
@@ -788,7 +880,7 @@ async def _admin_upsert_runtime_state(
         resource_type="hosted_runtime_state",
         resource_id=str(environment_id),
         environment_id=environment_id,
-        target_user_id=env.user_id,
+        target_user_id=target_user_id,
         source="api.admin",
         details={
             "deployment_id": body.deployment_id,
@@ -809,7 +901,9 @@ async def _admin_upsert_runtime_state(
         queue_runtime_manifest_changed(db, env.user_id, environment_id)
     await db.commit()
     logger.info(
-        "admin_runtime_state_upserted environment_id=%s deployment_id=%s generation=%s",
+        "admin_runtime_state_upserted target_clerk_id=%s environment_id=%s "
+        "deployment_id=%s generation=%s",
+        body.target_clerk_id,
         environment_id,
         body.deployment_id,
         body.generation,
@@ -851,6 +945,7 @@ async def admin_upsert_runtime_state(
 
 async def _admin_delete_runtime_state(
     environment_id: UUID,
+    target_clerk_id: str | None,
     db: AsyncSession,
 ) -> None:
     env = (
@@ -858,6 +953,11 @@ async def _admin_delete_runtime_state(
     ).scalar_one_or_none()
     if env is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent environment not found")
+    target_user_id = await _assert_admin_target_owns_environment(
+        db,
+        env=env,
+        target_clerk_id=target_clerk_id,
+    )
 
     state = (
         await db.execute(
@@ -890,13 +990,14 @@ async def _admin_delete_runtime_state(
         resource_type="hosted_runtime_state",
         resource_id=str(environment_id),
         environment_id=environment_id,
-        target_user_id=env.user_id,
+        target_user_id=target_user_id,
         source="api.admin",
         details=details,
     )
     await db.commit()
     logger.info(
-        "admin_runtime_state_deleted environment_id=%s existed=%s",
+        "admin_runtime_state_deleted target_clerk_id=%s environment_id=%s existed=%s",
+        target_clerk_id,
         environment_id,
         state is not None,
     )
@@ -908,10 +1009,11 @@ async def _admin_delete_runtime_state(
 )
 async def admin_delete_agent_runtime_state(
     agent_id: UUID,
+    target_clerk_id: str | None = None,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> None:
-    await _admin_delete_runtime_state(agent_id, db)
+    await _admin_delete_runtime_state(agent_id, target_clerk_id, db)
 
 
 @router.delete(
@@ -921,10 +1023,11 @@ async def admin_delete_agent_runtime_state(
 )
 async def admin_delete_runtime_state(
     environment_id: UUID,
+    target_clerk_id: str | None = None,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> None:
-    await _admin_delete_runtime_state(environment_id, db)
+    await _admin_delete_runtime_state(environment_id, target_clerk_id, db)
 
 
 async def _admin_get_channel_row(

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -103,6 +103,7 @@ class AdminRuntimeStateUpsert(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    target_clerk_id: str | None = None
     deployment_id: str = Field(min_length=1, max_length=200)
     app_id: str | None = Field(default=None, min_length=1, max_length=200)
     instance_id: str = Field(min_length=1, max_length=200)

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -210,6 +210,43 @@ async def test_admin_mint_accepts_arbitrary_scopes(admin_client, db_session, see
 
 
 @pytest.mark.asyncio
+async def test_admin_mint_api_key_writes_control_plane_audit(admin_client, db_session, seed_user):
+    from sqlalchemy import select
+
+    from app.models.audit import ControlPlaneAuditEvent
+
+    response = await admin_client.post(
+        "/v1/admin/auth/keys",
+        headers=_AUTH,
+        json={
+            "target_clerk_id": seed_user.clerk_id,
+            "label": "audit-mint",
+            "managed": True,
+        },
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    event = (
+        await db_session.execute(
+            select(ControlPlaneAuditEvent).where(
+                ControlPlaneAuditEvent.action == "api_key.mint",
+                ControlPlaneAuditEvent.resource_id == body["id"],
+            )
+        )
+    ).scalar_one()
+    assert event.actor_type == "admin"
+    assert event.resource_type == "api_key"
+    assert event.target_user_id == seed_user.id
+    assert event.source == "api.admin"
+    assert event.details["label"] == "audit-mint"
+    assert event.details["key_prefix"] == body["key_prefix"]
+    assert event.details["managed"] is True
+    assert event.details["has_environment_binding"] is False
+    assert body["raw_key"] not in str(event.details)
+
+
+@pytest.mark.asyncio
 async def test_admin_mint_lazy_creates_user(admin_client, db_session):
     """First-time deploy path: a user who's never visited cloud-api
     directly (no row yet) clicks Deploy on the upstream SaaS
@@ -439,6 +476,43 @@ async def test_admin_revoke_happy_path(admin_client, db_session, seed_user):
     db_session.expire_all()
     row = (await db_session.execute(select(ApiKey).where(ApiKey.id == key_id))).scalar_one()
     assert row.revoked_at is not None
+
+
+@pytest.mark.asyncio
+async def test_admin_revoke_api_key_writes_control_plane_audit(admin_client, db_session, seed_user):
+    from sqlalchemy import select
+
+    from app.models.audit import ControlPlaneAuditEvent
+
+    minted_response = await admin_client.post(
+        "/v1/admin/auth/keys",
+        headers=_AUTH,
+        json={"target_clerk_id": seed_user.clerk_id, "label": "audit-revoke"},
+    )
+    assert minted_response.status_code == 200, minted_response.text
+    minted = minted_response.json()
+
+    response = await admin_client.delete(
+        f"/v1/admin/auth/keys/{minted['id']}",
+        headers=_AUTH,
+    )
+    assert response.status_code == 200, response.text
+
+    event = (
+        await db_session.execute(
+            select(ControlPlaneAuditEvent).where(
+                ControlPlaneAuditEvent.action == "api_key.revoke",
+                ControlPlaneAuditEvent.resource_id == minted["id"],
+            )
+        )
+    ).scalar_one()
+    assert event.actor_type == "admin"
+    assert event.resource_type == "api_key"
+    assert event.target_user_id == seed_user.id
+    assert event.source == "api.admin"
+    assert event.details["label"] == "audit-revoke"
+    assert event.details["key_prefix"] == minted["key_prefix"]
+    assert minted["raw_key"] not in str(event.details)
 
 
 @pytest.mark.asyncio
@@ -1321,6 +1395,7 @@ async def test_admin_delete_env_removes_environment_and_orphans_sessions(
 
     from sqlalchemy import select
 
+    from app.models.audit import ControlPlaneAuditEvent
     from app.models.session import AgentEnvironment, Session
 
     created = await admin_client.post(
@@ -1356,12 +1431,97 @@ async def test_admin_delete_env_removes_environment_and_orphans_sessions(
     assert env is None
     await db_session.refresh(session_row)
     assert session_row.environment_id is None
+    event = (
+        await db_session.execute(
+            select(ControlPlaneAuditEvent).where(
+                ControlPlaneAuditEvent.action == "agent_environment.delete",
+                ControlPlaneAuditEvent.resource_id == str(env_id),
+            )
+        )
+    ).scalar_one()
+    assert event.actor_type == "admin"
+    assert event.resource_type == "agent_environment"
+    assert event.target_user_id == seed_user.id
+    assert event.source == "api.admin"
+    assert event.details["agent_type"] == "codex"
+    assert event.details["machine_id"] == "delete-machine-1"
 
     deleted_again = await admin_client.delete(
         f"/api/admin/environments/{env_id}",
         headers=_AUTH,
     )
     assert deleted_again.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path_template",
+    ["/v1/admin/agents/{env_id}", "/v1/admin/environments/{env_id}"],
+)
+async def test_admin_delete_environment_accepts_matching_optional_owner(
+    admin_client, db_session, seed_user, path_template
+):
+    import uuid as _uuid
+
+    from app.models.session import AgentEnvironment
+    from tests.conftest import create_env_with_project
+
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"delete-owner-match-{_uuid.uuid4().hex[:8]}",
+        machine_name="delete-owner-match-pod",
+        agent_type="codex",
+    )
+
+    response = await admin_client.delete(
+        path_template.format(env_id=env.id),
+        headers=_AUTH,
+        params={"target_clerk_id": seed_user.clerk_id},
+    )
+
+    assert response.status_code == 204, response.text
+    assert await db_session.get(AgentEnvironment, env.id) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path_template",
+    ["/v1/admin/agents/{env_id}", "/v1/admin/environments/{env_id}"],
+)
+async def test_admin_delete_environment_rejects_mismatched_optional_owner(
+    admin_client, db_session, seed_user, path_template
+):
+    import uuid as _uuid
+
+    from app.models.session import AgentEnvironment
+    from app.models.user import User
+    from tests.conftest import create_env_with_project
+
+    other = User(
+        clerk_id=f"other_delete_{_uuid.uuid4().hex[:8]}",
+        email="other-delete@x.dev",
+        name="Other Delete",
+    )
+    db_session.add(other)
+    await db_session.commit()
+    await db_session.refresh(other)
+    env = await create_env_with_project(
+        db_session,
+        user_id=other.id,
+        machine_id=f"delete-owner-mismatch-{_uuid.uuid4().hex[:8]}",
+        machine_name="delete-owner-mismatch-pod",
+        agent_type="codex",
+    )
+
+    response = await admin_client.delete(
+        path_template.format(env_id=env.id),
+        headers=_AUTH,
+        params={"target_clerk_id": seed_user.clerk_id},
+    )
+
+    assert response.status_code == 403, response.text
+    assert await db_session.get(AgentEnvironment, env.id) is not None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -2118,6 +2118,97 @@ async def test_admin_delete_runtime_state_requires_admin_key(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("resource_name", ["agents", "environments"])
+async def test_admin_runtime_state_accepts_matching_optional_owner(
+    admin_client,
+    db_session,
+    seed_user,
+    resource_name,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"runtime-owner-match-{uuid4().hex[:8]}",
+        machine_name="Runtime Owner Match",
+        agent_type="openclaw",
+    )
+    body = _runtime_state_body(
+        str(env.id),
+        target_clerk_id=seed_user.clerk_id,
+    )
+
+    upserted = await admin_client.put(
+        f"/v1/admin/{resource_name}/{env.id}/runtime-state",
+        headers=_AUTH,
+        json=body,
+    )
+    assert upserted.status_code == 200, upserted.text
+    state = await db_session.get(HostedRuntimeState, env.id)
+    assert state is not None
+    assert state.deployment_id == body["deployment_id"]
+
+    deleted = await admin_client.delete(
+        f"/v1/admin/{resource_name}/{env.id}/runtime-state",
+        headers=_AUTH,
+        params={"target_clerk_id": seed_user.clerk_id},
+    )
+    assert deleted.status_code == 204, deleted.text
+    assert await db_session.get(HostedRuntimeState, env.id) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resource_name", ["agents", "environments"])
+async def test_admin_runtime_state_rejects_mismatched_optional_owner_without_mutating(
+    admin_client,
+    db_session,
+    seed_user,
+    resource_name,
+):
+    other_user = User(
+        clerk_id=f"runtime_owner_{uuid4().hex[:12]}",
+        email=f"runtime-owner-{uuid4().hex[:8]}@clawdi.local",
+        name="Runtime Owner",
+    )
+    db_session.add(other_user)
+    await db_session.commit()
+    await db_session.refresh(other_user)
+    upsert_env = await create_env_with_project(
+        db_session,
+        user_id=other_user.id,
+        machine_id=f"runtime-upsert-owner-{uuid4().hex[:8]}",
+        machine_name="Runtime Upsert Owner",
+        agent_type="openclaw",
+    )
+    delete_env = await create_env_with_project(
+        db_session,
+        user_id=other_user.id,
+        machine_id=f"runtime-delete-owner-{uuid4().hex[:8]}",
+        machine_name="Runtime Delete Owner",
+        agent_type="openclaw",
+    )
+    await _write_runtime_state(admin_client, str(delete_env.id))
+
+    upsert_response = await admin_client.put(
+        f"/v1/admin/{resource_name}/{upsert_env.id}/runtime-state",
+        headers=_AUTH,
+        json=_runtime_state_body(
+            str(upsert_env.id),
+            target_clerk_id=seed_user.clerk_id,
+        ),
+    )
+    assert upsert_response.status_code == 403, upsert_response.text
+    assert await db_session.get(HostedRuntimeState, upsert_env.id) is None
+
+    delete_response = await admin_client.delete(
+        f"/v1/admin/{resource_name}/{delete_env.id}/runtime-state",
+        headers=_AUTH,
+        params={"target_clerk_id": seed_user.clerk_id},
+    )
+    assert delete_response.status_code == 403, delete_response.text
+    assert await db_session.get(HostedRuntimeState, delete_env.id) is not None
+
+
+@pytest.mark.asyncio
 async def test_runtime_manifest_generation_advance_changes_etag_and_returns_generation(
     admin_client,
     db_session,


### PR DESCRIPTION
M1 第一块：legacy admin 面加可选 owner 校验（提供且不匹配→403，缺失→旧行为不变）+ key mint/revoke/环境删除写 durable audit。v1 合同零收紧（不传 owner 的老调用原样保留作回归证据）。

- 测试：`scripts/test.sh backend` 907 passed
- 评审依据：docs(clawdi-hosted) 2026-07-10-design-review-amendments B2/B3
- ⚠️ 栈底 PR：后续 A0.2、A0.1c 依次叠在本 PR 上，请按顺序合并

🤖 Generated with [Claude Code](https://claude.com/claude-code)