### PR TITLE
feat(admin): M1/A0.2 — principal-aware user provisioning

### DIFF
--- a/backend/alembic/versions/a26c40c6965e_principal_aware_users.py
+++ b/backend/alembic/versions/a26c40c6965e_principal_aware_users.py
@@ -1,0 +1,73 @@
+"""Add principal-aware users.
+
+Revision ID: a26c40c6965e
+Revises: d8f2a1c4b6e9
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a26c40c6965e"
+down_revision: str | Sequence[str] | None = "d8f2a1c4b6e9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "principal_kind",
+            sa.String(length=32),
+            server_default="clerk",
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "users",
+        sa.Column("partner_tenant_ref", sa.String(length=255), nullable=True),
+    )
+    op.alter_column(
+        "users",
+        "clerk_id",
+        existing_type=sa.String(length=200),
+        nullable=True,
+    )
+    op.create_unique_constraint(
+        "uq_users_partner_tenant_ref",
+        "users",
+        ["partner_tenant_ref"],
+    )
+    op.create_check_constraint(
+        "ck_users_principal_identity",
+        "users",
+        "(principal_kind = 'clerk' AND clerk_id IS NOT NULL "
+        "AND partner_tenant_ref IS NULL) OR "
+        "(principal_kind = 'partner_tenant' AND clerk_id IS NULL "
+        "AND partner_tenant_ref IS NOT NULL)",
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    tenant_user_count = bind.execute(
+        sa.text("SELECT count(*) FROM users WHERE clerk_id IS NULL")
+    ).scalar_one()
+    if tenant_user_count:
+        raise RuntimeError(
+            "cannot downgrade principal-aware users while partner tenant users exist"
+        )
+
+    op.drop_constraint("ck_users_principal_identity", "users", type_="check")
+    op.drop_constraint("uq_users_partner_tenant_ref", "users", type_="unique")
+    op.alter_column(
+        "users",
+        "clerk_id",
+        existing_type=sa.String(length=200),
+        nullable=False,
+    )
+    op.drop_column("users", "partner_tenant_ref")
+    op.drop_column("users", "principal_kind")

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -19,7 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.core.database import get_session
 from app.models.api_key import ApiKey
-from app.models.user import User
+from app.models.user import PRINCIPAL_KIND_CLERK, User
 from app.services.user_provisioning import lazy_create_user_with_personal_project
 
 bearer_scheme = HTTPBearer()
@@ -58,7 +58,9 @@ class _CachedApiKeyAuth:
     environment_id: UUID | None
     managed: bool
     expires_at: datetime | None
-    user_clerk_id: str
+    user_clerk_id: str | None
+    user_principal_kind: str
+    user_partner_tenant_ref: str | None
     user_email: str | None
     user_name: str | None
     user_avatar_url: str | None
@@ -69,6 +71,8 @@ class _CachedApiKeyAuth:
         user = User(
             id=self.user_id,
             clerk_id=self.user_clerk_id,
+            principal_kind=self.user_principal_kind,
+            partner_tenant_ref=self.user_partner_tenant_ref,
             email=self.user_email,
             name=self.user_name,
             avatar_url=self.user_avatar_url,
@@ -138,6 +142,8 @@ def _cache_api_key_auth(
             managed=api_key.managed,
             expires_at=api_key.expires_at,
             user_clerk_id=user.clerk_id,
+            user_principal_kind=user.principal_kind,
+            user_partner_tenant_ref=user.partner_tenant_ref,
             user_email=user.email,
             user_name=user.name,
             user_avatar_url=user.avatar_url,
@@ -242,7 +248,12 @@ async def _auth_via_dev_bypass(token: str, db: AsyncSession) -> AuthContext | No
         )
 
     clerk_id = settings.dev_auth_clerk_id
-    result = await db.execute(select(User).where(User.clerk_id == clerk_id))
+    result = await db.execute(
+        select(User).where(
+            User.principal_kind == PRINCIPAL_KIND_CLERK,
+            User.clerk_id == clerk_id,
+        )
+    )
     user = result.scalar_one_or_none()
     if user is None:
         user = await lazy_create_user_with_personal_project(
@@ -335,7 +346,12 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
     if not clerk_id:
         return None
 
-    result = await db.execute(select(User).where(User.clerk_id == clerk_id))
+    result = await db.execute(
+        select(User).where(
+            User.principal_kind == PRINCIPAL_KIND_CLERK,
+            User.clerk_id == clerk_id,
+        )
+    )
     user = result.scalar_one_or_none()
 
     email = payload.get("email") or payload.get("email_address")
@@ -372,7 +388,12 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
             # row (which now carries the winner's values) instead of
             # 500-ing the user out of their session.
             await db.rollback()
-            result = await db.execute(select(User).where(User.clerk_id == clerk_id))
+            result = await db.execute(
+                select(User).where(
+                    User.principal_kind == PRINCIPAL_KIND_CLERK,
+                    User.clerk_id == clerk_id,
+                )
+            )
             user = result.scalar_one()
 
     # Sub miss + snapshot-rebind opted in: try to attach to an existing
@@ -400,7 +421,13 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
         # whoever signs in first would otherwise get to choose which
         # row they take over.
         result = await db.execute(
-            select(User).where(User.email == email).order_by(User.created_at).limit(2)
+            select(User)
+            .where(
+                User.principal_kind == PRINCIPAL_KIND_CLERK,
+                User.email == email,
+            )
+            .order_by(User.created_at)
+            .limit(2)
         )
         candidates = list(result.scalars())
         if len(candidates) > 1:
@@ -434,7 +461,12 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
                 await db.refresh(user)
             except IntegrityError:
                 await db.rollback()
-                result = await db.execute(select(User).where(User.clerk_id == clerk_id))
+                result = await db.execute(
+                    select(User).where(
+                        User.principal_kind == PRINCIPAL_KIND_CLERK,
+                        User.clerk_id == clerk_id,
+                    )
+                )
                 user = result.scalar_one_or_none()
                 if user is None:
                     # Both writers somehow lost the row — extremely

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,17 +1,40 @@
 import uuid
 
-from sqlalchemy import Integer, String
+from sqlalchemy import CheckConstraint, Integer, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base, TimestampMixin
 
+PRINCIPAL_KIND_CLERK = "clerk"
+PRINCIPAL_KIND_PARTNER_TENANT = "partner_tenant"
+
 
 class User(Base, TimestampMixin):
     __tablename__ = "users"
+    __table_args__ = (
+        UniqueConstraint(
+            "partner_tenant_ref",
+            name="uq_users_partner_tenant_ref",
+        ),
+        CheckConstraint(
+            "(principal_kind = 'clerk' AND clerk_id IS NOT NULL "
+            "AND partner_tenant_ref IS NULL) OR "
+            "(principal_kind = 'partner_tenant' AND clerk_id IS NULL "
+            "AND partner_tenant_ref IS NOT NULL)",
+            name="ck_users_principal_identity",
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    clerk_id: Mapped[str] = mapped_column(String(200), unique=True, nullable=False)
+    clerk_id: Mapped[str | None] = mapped_column(String(200), unique=True)
+    principal_kind: Mapped[str] = mapped_column(
+        String(32),
+        default=PRINCIPAL_KIND_CLERK,
+        server_default=PRINCIPAL_KIND_CLERK,
+        nullable=False,
+    )
+    partner_tenant_ref: Mapped[str | None] = mapped_column(String(255))
     email: Mapped[str | None] = mapped_column(String(320))
     name: Mapped[str | None] = mapped_column(String(200))
     # Profile picture URL captured from the Clerk JWT `picture` claim

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -44,7 +44,11 @@ from app.models.channel import (
 )
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.session import AgentEnvironment
-from app.models.user import User
+from app.models.user import (
+    PRINCIPAL_KIND_CLERK,
+    PRINCIPAL_KIND_PARTNER_TENANT,
+    User,
+)
 from app.schemas.admin import (
     AdminAgentCreate,
     AdminApiKeyCreate,
@@ -57,6 +61,7 @@ from app.schemas.admin import (
     AdminEnvironmentCreate,
     AdminManagedAiProviderResponse,
     AdminManagedAiProviderUpsert,
+    AdminPrincipalSelector,
     AdminRuntimeStateResponse,
     AdminRuntimeStateUpsert,
 )
@@ -92,7 +97,10 @@ from app.services.sync_events import (
     queue_provider_runtime_manifest_changed,
     queue_runtime_manifest_changed,
 )
-from app.services.user_provisioning import lazy_create_user_with_personal_project
+from app.services.user_provisioning import (
+    lazy_create_partner_user_with_personal_project,
+    lazy_create_user_with_personal_project,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -127,7 +135,14 @@ async def _resolve_or_create_user(db: AsyncSession, clerk_id: str) -> User:
     an operational anomaly worth a loud failure rather than a
     user-flow retry.
     """
-    target = (await db.execute(select(User).where(User.clerk_id == clerk_id))).scalar_one_or_none()
+    target = (
+        await db.execute(
+            select(User).where(
+                User.principal_kind == PRINCIPAL_KIND_CLERK,
+                User.clerk_id == clerk_id,
+            )
+        )
+    ).scalar_one_or_none()
     if target is not None:
         return target
 
@@ -142,6 +157,32 @@ async def _resolve_or_create_user(db: AsyncSession, clerk_id: str) -> User:
     return user
 
 
+async def _resolve_or_create_principal_user(
+    db: AsyncSession,
+    principal: AdminPrincipalSelector,
+) -> User:
+    if principal.principal_kind == PRINCIPAL_KIND_CLERK:
+        if principal.target_clerk_id is None:
+            raise RuntimeError("validated Clerk principal is missing target_clerk_id")
+        return await _resolve_or_create_user(db, principal.target_clerk_id)
+
+    if principal.principal_kind != PRINCIPAL_KIND_PARTNER_TENANT:
+        raise RuntimeError("validated admin principal has an unsupported kind")
+    if principal.partner_tenant_ref is None:
+        raise RuntimeError("validated PartnerTenant principal is missing partner_tenant_ref")
+    user = await lazy_create_partner_user_with_personal_project(
+        db,
+        partner_tenant_ref=principal.partner_tenant_ref,
+        race_loser_status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+    )
+    logger.info(
+        "admin_lazy_create_partner_user partner_tenant_ref=%s user_id=%s",
+        principal.partner_tenant_ref,
+        user.id,
+    )
+    return user
+
+
 async def _assert_admin_target_owns_environment(
     db: AsyncSession,
     *,
@@ -152,7 +193,12 @@ async def _assert_admin_target_owns_environment(
         return env.user_id
 
     target = (
-        await db.execute(select(User).where(User.clerk_id == target_clerk_id))
+        await db.execute(
+            select(User).where(
+                User.principal_kind == PRINCIPAL_KIND_CLERK,
+                User.clerk_id == target_clerk_id,
+            )
+        )
     ).scalar_one_or_none()
     if target is None or env.user_id != target.id:
         logger.warning(
@@ -174,18 +220,16 @@ async def admin_mint_api_key(
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> ApiKeyCreated:
-    """Mint an api_key on behalf of a user identified by Clerk id.
+    """Mint an api_key for an explicit Clerk or PartnerTenant principal.
 
     Used by upstream-SaaS batch tooling: each legacy deployment that
     didn't have live sync wired up needs a fresh api_key bound to a
     fresh env, but the migration script has no per-user Clerk JWT.
 
-    User row is lazy-created if absent — handles the common entry
-    path of a user whose first interaction with cloud-api is via
-    SaaS-side admin calls. See `_resolve_or_create_user` for the
-    safety model.
+    User row is lazy-created if absent. Clerk and PartnerTenant identities use
+    separate unique references and cannot be converted into one another.
     """
-    target = await _resolve_or_create_user(db, body.target_clerk_id)
+    target = await _resolve_or_create_principal_user(db, body)
 
     env_uuid: UUID | None = None
     if body.environment_id:
@@ -218,16 +262,22 @@ async def admin_mint_api_key(
         # can grep cloud-api logs directly without correlating with
         # the SaaS side.
         logger.warning(
-            "admin_mint_rejected reason=cross_tenant_env target_clerk_id=%s env=%s",
+            "admin_mint_rejected reason=cross_tenant_env principal_kind=%s "
+            "target_clerk_id=%s partner_tenant_ref=%s env=%s",
+            body.principal_kind,
             body.target_clerk_id,
+            body.partner_tenant_ref,
             env_uuid,
         )
         raise HTTPException(status.HTTP_403_FORBIDDEN, str(e)) from e
 
     api_key = minted.api_key
     logger.info(
-        "admin_api_key_minted target_clerk_id=%s key_id=%s environment_id=%s managed=%s",
+        "admin_api_key_minted principal_kind=%s target_clerk_id=%s "
+        "partner_tenant_ref=%s key_id=%s environment_id=%s managed=%s",
+        body.principal_kind,
         body.target_clerk_id,
+        body.partner_tenant_ref,
         api_key.id,
         api_key.environment_id,
         api_key.managed,
@@ -247,6 +297,8 @@ async def admin_mint_api_key(
             "managed": api_key.managed,
             "has_environment_binding": api_key.environment_id is not None,
             "scope_count": None if api_key.scopes is None else len(api_key.scopes),
+            "principal_kind": target.principal_kind,
+            "partner_tenant_ref": target.partner_tenant_ref,
         },
     )
     await db.commit()
@@ -609,7 +661,7 @@ async def _admin_register_environment(
     body: AdminEnvironmentCreate,
     db: AsyncSession,
 ) -> EnvironmentCreatedResponse:
-    target = await _resolve_or_create_user(db, body.target_clerk_id)
+    target = await _resolve_or_create_principal_user(db, body)
     try:
         registered = await register_agent_environment(
             db,
@@ -637,8 +689,11 @@ async def _admin_register_environment(
         ) from None
 
     logger.info(
-        "admin_environment_registered target_clerk_id=%s env_id=%s machine_id=%s explicit_id=%s",
+        "admin_environment_registered principal_kind=%s target_clerk_id=%s "
+        "partner_tenant_ref=%s env_id=%s machine_id=%s explicit_id=%s",
+        body.principal_kind,
         body.target_clerk_id,
+        body.partner_tenant_ref,
         env.id,
         body.machine_id,
         body.environment_id is not None,
@@ -655,6 +710,8 @@ async def admin_register_agent(
     return await _admin_register_environment(
         AdminEnvironmentCreate(
             target_clerk_id=body.target_clerk_id,
+            principal_kind=body.principal_kind,
+            partner_tenant_ref=body.partner_tenant_ref,
             environment_id=body.agent_id,
             machine_id=body.machine_id,
             machine_name=body.machine_name,

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -5,11 +5,22 @@ and are used by SaaS batch tooling + ops-side scripts. Kept in a
 separate file so they don't pollute user-facing schemas.
 """
 
+from __future__ import annotations
+
+import re
 from datetime import datetime
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator, model_validator
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    field_validator,
+    model_validator,
+)
 
 from app.schemas.ai_provider import AiProviderModel
 from app.schemas.runtime import (
@@ -28,10 +39,56 @@ from app.schemas.runtime import (
 AdminChannelProvider = Literal["telegram", "discord", "whatsapp", "imessage"]
 AdminChannelVisibility = Literal["private", "public"]
 AdminChannelStatus = Literal["active", "disabled"]
+AdminPrincipalKind = Literal["clerk", "partner_tenant"]
 _SUPPORTED_HOSTED_RUNTIMES = {"hermes", "openclaw"}
+_ADMIN_CLERK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_PARTNER_TENANT_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
 
 
-class AdminEnvironmentCreate(BaseModel):
+def _validate_admin_clerk_id(value: str) -> str:
+    if value != value.strip() or not _ADMIN_CLERK_ID_RE.fullmatch(value):
+        raise ValueError("target_clerk_id must be a stable Clerk identifier")
+    return value
+
+
+def _validate_partner_tenant_ref(value: str) -> str:
+    if value != value.strip() or not _PARTNER_TENANT_REF_RE.fullmatch(value):
+        raise ValueError("partner_tenant_ref must be a stable PartnerTenant reference")
+    return value
+
+
+AdminClerkId = Annotated[
+    str,
+    Field(min_length=1, max_length=200),
+    AfterValidator(_validate_admin_clerk_id),
+]
+AdminPartnerTenantRef = Annotated[
+    str,
+    Field(min_length=1, max_length=255),
+    AfterValidator(_validate_partner_tenant_ref),
+]
+
+
+class AdminPrincipalSelector(BaseModel):
+    target_clerk_id: AdminClerkId | None = None
+    principal_kind: AdminPrincipalKind = "clerk"
+    partner_tenant_ref: AdminPartnerTenantRef | None = None
+
+    @model_validator(mode="after")
+    def _validate_principal_reference(self) -> AdminPrincipalSelector:
+        if self.principal_kind == "clerk":
+            if self.target_clerk_id is None or self.partner_tenant_ref is not None:
+                raise ValueError(
+                    "clerk principal requires target_clerk_id and forbids partner_tenant_ref"
+                )
+        elif self.target_clerk_id is not None or self.partner_tenant_ref is None:
+            raise ValueError(
+                "partner_tenant principal requires partner_tenant_ref and forbids target_clerk_id"
+            )
+        return self
+
+
+class AdminEnvironmentCreate(AdminPrincipalSelector):
     """Body for `POST /v1/admin/environments`. Mirrors the
     user-facing EnvironmentCreate but takes target_clerk_id
     instead of relying on auth context to resolve the user.
@@ -43,7 +100,6 @@ class AdminEnvironmentCreate(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    target_clerk_id: str
     environment_id: UUID | None = None
     machine_id: str
     machine_name: str
@@ -52,7 +108,7 @@ class AdminEnvironmentCreate(BaseModel):
     os_name: str = "linux"
 
 
-class AdminAgentCreate(BaseModel):
+class AdminAgentCreate(AdminPrincipalSelector):
     """Body for `POST /v1/admin/agents`.
 
     Agent-first alias of `AdminEnvironmentCreate`; `agent_id` maps to the
@@ -61,7 +117,6 @@ class AdminAgentCreate(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    target_clerk_id: str
     agent_id: UUID | None = None
     machine_id: str
     machine_name: str
@@ -70,12 +125,11 @@ class AdminAgentCreate(BaseModel):
     os_name: str = "linux"
 
 
-class AdminApiKeyCreate(BaseModel):
+class AdminApiKeyCreate(AdminPrincipalSelector):
     """Body for `POST /v1/admin/auth/keys` — mint an api_key on
-    behalf of a user identified by Clerk id. The route resolves
-    `target_clerk_id` to the internal `User.id` and then calls the
-    existing `mint_api_key` service, preserving the env-ownership
-    invariant the service enforces.
+    behalf of an explicit Clerk or PartnerTenant principal. The route resolves
+    the principal to the internal `User.id` and then calls the existing
+    `mint_api_key` service, preserving its env-ownership invariant.
 
     `environment_id` is optional — if set, the minted key is bound
     to that env (deploy-key semantics). If null, the key is unbound.
@@ -87,7 +141,6 @@ class AdminApiKeyCreate(BaseModel):
     everything.
     """
 
-    target_clerk_id: str
     label: str
     environment_id: str | None = None
     scopes: list[str] | None = None
@@ -179,7 +232,7 @@ class AdminManagedAiProviderUpsert(BaseModel):
 
 class AdminManagedAiProviderResponse(BaseModel):
     owner_user_id: UUID
-    owner_clerk_id: str
+    owner_clerk_id: str | None
     provider_id: str
     api_mode: str
     runtime_env_name: str
@@ -253,7 +306,7 @@ class AdminChannelUpdate(BaseModel):
 class AdminChannelResponse(BaseModel):
     id: UUID
     owner_user_id: UUID
-    owner_clerk_id: str
+    owner_clerk_id: str | None
     provider: str
     name: str
     status: str

--- a/backend/app/services/user_provisioning.py
+++ b/backend/app/services/user_provisioning.py
@@ -1,6 +1,6 @@
 """Shared lazy-create flow for `users` + their Personal project.
 
-Two callers hit this code path:
+Clerk callers hit this code path:
 1. `_auth_via_clerk_jwt` (auth.py) — first login from cloud.clawdi.ai
    directly. Has email/name from the JWT, commits at the end.
 2. `_resolve_or_create_user` (admin.py) — first interaction is via
@@ -16,6 +16,9 @@ The race semantics and project invariant MUST stay identical across
 callers — downstream resolvers assume every user has a Personal
 project. Centralizing here means there's one place to maintain that
 contract.
+
+PartnerTenant provisioning uses a separate stable reference and never creates
+or accepts a synthetic Clerk id.
 """
 
 import logging
@@ -26,7 +29,11 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.project import PROJECT_KIND_PERSONAL, Project
-from app.models.user import User
+from app.models.user import (
+    PRINCIPAL_KIND_CLERK,
+    PRINCIPAL_KIND_PARTNER_TENANT,
+    User,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +80,14 @@ async def lazy_create_user_with_personal_project(
         HTTPException 500 — Personal project insert failed. Bizarre
         states only (partial unique index, mid-flush connection drop).
     """
-    new_user = User(clerk_id=clerk_id, email=email, name=name, avatar_url=avatar_url)
+    new_user = User(
+        clerk_id=clerk_id,
+        principal_kind=PRINCIPAL_KIND_CLERK,
+        partner_tenant_ref=None,
+        email=email,
+        name=name,
+        avatar_url=avatar_url,
+    )
     db.add(new_user)
 
     # User flush: the ONLY racy point. `users.clerk_id` is unique, so
@@ -94,12 +108,68 @@ async def lazy_create_user_with_personal_project(
             ) from None
         return target
 
-    # Personal project insert. Cannot race on `user_id` (just generated)
-    # so a partial-unique kind=personal index is the only realistic
-    # failure mode. Wrap in try/except so a SQLAlchemy traceback
-    # doesn't leak to the client as a raw 500.
+    await _create_personal_project(
+        db,
+        user=new_user,
+        identity_log=f"clerk_id={clerk_id}",
+    )
+    return new_user
+
+
+async def lazy_create_partner_user_with_personal_project(
+    db: AsyncSession,
+    *,
+    partner_tenant_ref: str,
+    race_loser_status: int,
+) -> User:
+    """Insert a PartnerTenant-owned User row + Personal project, race-safe."""
+    new_user = User(
+        clerk_id=None,
+        principal_kind=PRINCIPAL_KIND_PARTNER_TENANT,
+        partner_tenant_ref=partner_tenant_ref,
+        email=None,
+        name=None,
+        avatar_url=None,
+    )
+    db.add(new_user)
+
+    try:
+        await db.flush()
+    except IntegrityError:
+        await db.rollback()
+        target = (
+            await db.execute(
+                select(User).where(
+                    User.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT,
+                    User.partner_tenant_ref == partner_tenant_ref,
+                )
+            )
+        ).scalar_one_or_none()
+        if target is None:
+            raise HTTPException(
+                race_loser_status,
+                "could not create or load partner tenant user",
+            ) from None
+        return target
+
+    await _create_personal_project(
+        db,
+        user=new_user,
+        identity_log=f"partner_tenant_ref={partner_tenant_ref}",
+    )
+    return new_user
+
+
+async def _create_personal_project(
+    db: AsyncSession,
+    *,
+    user: User,
+    identity_log: str,
+) -> None:
+    # Cannot race on `user_id` (just generated), so a partial-unique
+    # kind=personal index is the only realistic failure mode.
     personal = Project(
-        user_id=new_user.id,
+        user_id=user.id,
         name="Personal",
         slug="personal",
         kind=PROJECT_KIND_PERSONAL,
@@ -109,13 +179,12 @@ async def lazy_create_user_with_personal_project(
         await db.flush()
     except Exception:
         logger.exception(
-            "personal_project_create_failed clerk_id=%s user_id=%s",
-            clerk_id,
-            new_user.id,
+            "personal_project_create_failed %s user_id=%s",
+            identity_log,
+            user.id,
         )
         await db.rollback()
         raise HTTPException(
             status.HTTP_500_INTERNAL_SERVER_ERROR,
             "internal server error",
         ) from None
-    return new_user

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -74,6 +74,52 @@ async def test_admin_mint_rejects_wrong_key(admin_client, seed_user):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "target_clerk_id",
+    ["", " user_123", "user 123", "partner:phala:team_123", "x" * 201],
+)
+async def test_admin_mint_rejects_invalid_target_clerk_id(admin_client, target_clerk_id):
+    response = await admin_client.post(
+        "/v1/admin/auth/keys",
+        headers=_AUTH,
+        json={"target_clerk_id": target_clerk_id, "label": "invalid-target"},
+    )
+
+    assert response.status_code == 422, response.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "principal",
+    [
+        {},
+        {"principal_kind": "partner_tenant"},
+        {
+            "principal_kind": "partner_tenant",
+            "partner_tenant_ref": "phala cloud team 123",
+        },
+        {
+            "principal_kind": "partner_tenant",
+            "partner_tenant_ref": "phala_cloud:team_123",
+            "target_clerk_id": "user_123",
+        },
+        {
+            "target_clerk_id": "user_123",
+            "partner_tenant_ref": "phala_cloud:team_123",
+        },
+    ],
+)
+async def test_admin_mint_rejects_ambiguous_principal(admin_client, principal):
+    response = await admin_client.post(
+        "/v1/admin/auth/keys",
+        headers=_AUTH,
+        json={**principal, "label": "invalid-principal"},
+    )
+
+    assert response.status_code == 422, response.text
+
+
+@pytest.mark.asyncio
 async def test_admin_endpoints_disabled_when_unset(db_session, seed_user):
     """If `settings.admin_api_key` is empty, endpoints return 503
     regardless of header. Default OSS posture: admin endpoints are
@@ -247,6 +293,87 @@ async def test_admin_mint_api_key_writes_control_plane_audit(admin_client, db_se
 
 
 @pytest.mark.asyncio
+async def test_admin_partner_principal_provisions_user_key_and_agent(admin_client, db_session):
+    import uuid
+
+    from sqlalchemy import select
+
+    from app.core.auth import _auth_via_api_key
+    from app.models.audit import ControlPlaneAuditEvent
+    from app.models.project import PROJECT_KIND_PERSONAL, Project
+    from app.models.session import AgentEnvironment
+    from app.models.user import PRINCIPAL_KIND_PARTNER_TENANT, User
+
+    partner_tenant_ref = f"ptn_{uuid.uuid4().hex[:12]}"
+    principal = {
+        "principal_kind": PRINCIPAL_KIND_PARTNER_TENANT,
+        "partner_tenant_ref": partner_tenant_ref,
+    }
+
+    minted = await admin_client.post(
+        "/v1/admin/auth/keys",
+        headers=_AUTH,
+        json={**principal, "label": "partner-runtime"},
+    )
+    assert minted.status_code == 200, minted.text
+    raw_key = minted.json()["raw_key"]
+
+    user = (
+        await db_session.execute(select(User).where(User.partner_tenant_ref == partner_tenant_ref))
+    ).scalar_one()
+    assert user.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT
+    assert user.clerk_id is None
+    personal = (
+        await db_session.execute(
+            select(Project).where(
+                Project.user_id == user.id,
+                Project.kind == PROJECT_KIND_PERSONAL,
+            )
+        )
+    ).scalar_one()
+    assert personal.slug == "personal"
+
+    uncached = await _auth_via_api_key(raw_key, db_session)
+    cached = await _auth_via_api_key(raw_key, db_session)
+    assert uncached is not None
+    assert cached is not None
+    assert cached.user.clerk_id is None
+    assert cached.user.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT
+    assert cached.user.partner_tenant_ref == partner_tenant_ref
+
+    agent_id = uuid.uuid4()
+    registered = await admin_client.post(
+        "/v1/admin/agents",
+        headers=_AUTH,
+        json={
+            **principal,
+            "agent_id": str(agent_id),
+            "machine_id": f"partner-agent-{uuid.uuid4().hex[:8]}",
+            "machine_name": "Partner Agent",
+            "agent_type": "openclaw",
+        },
+    )
+    assert registered.status_code == 200, registered.text
+    environment = await db_session.get(AgentEnvironment, agent_id)
+    assert environment is not None
+    assert environment.user_id == user.id
+
+    audit = (
+        await db_session.execute(
+            select(ControlPlaneAuditEvent).where(
+                ControlPlaneAuditEvent.action == "api_key.mint",
+                ControlPlaneAuditEvent.target_user_id == user.id,
+            )
+        )
+    ).scalar_one()
+    assert audit.details["principal_kind"] == PRINCIPAL_KIND_PARTNER_TENANT
+    assert audit.details["partner_tenant_ref"] == partner_tenant_ref
+
+    await db_session.delete(user)
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
 async def test_admin_mint_lazy_creates_user(admin_client, db_session):
     """First-time deploy path: a user who's never visited cloud-api
     directly (no row yet) clicks Deploy on the upstream SaaS
@@ -289,6 +416,8 @@ async def test_admin_mint_lazy_creates_user(admin_client, db_session):
     user = (
         await db_session.execute(select(User).where(User.clerk_id == novel_clerk_id))
     ).scalar_one()
+    assert user.principal_kind == "clerk"
+    assert user.partner_tenant_ref is None
     assert user.email is None
     assert user.name is None
 

--- a/backend/tests/test_agent_v2_runtime_contract_migration.py
+++ b/backend/tests/test_agent_v2_runtime_contract_migration.py
@@ -14,6 +14,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 REVISION = "d8f2a1c4b6e9"
+HEAD_REVISION = "a26c40c6965e"
+HEAD_DOWN_REVISION = REVISION
 MIGRATION_FILENAME = f"{REVISION}_finalize_agent_v2_runtime_contract.py"
 
 
@@ -35,7 +37,8 @@ def test_agent_v2_runtime_contract_migration_is_single_head() -> None:
     config.set_main_option("script_location", str(backend_dir / "alembic"))
     scripts = ScriptDirectory.from_config(config)
 
-    assert scripts.get_heads() == [REVISION]
+    assert scripts.get_heads() == [HEAD_REVISION]
+    assert scripts.get_revision(HEAD_REVISION).down_revision == HEAD_DOWN_REVISION
     assert scripts.get_revision(REVISION).down_revision == "c4e8f1a2b3d5"
 
 

--- a/backend/tests/test_auth_email_rebind.py
+++ b/backend/tests/test_auth_email_rebind.py
@@ -166,6 +166,44 @@ async def test_rebind_with_no_email_match_creates_fresh_user(db_session, signing
     await db_session.commit()
 
 
+@pytest.mark.asyncio
+async def test_rebind_excludes_partner_tenant_user(db_session, signing_key, monkeypatch):
+    from app.models.user import PRINCIPAL_KIND_PARTNER_TENANT, User
+    from app.services.user_provisioning import lazy_create_partner_user_with_personal_project
+
+    monkeypatch.setattr(settings, "enable_snapshot_email_rebind", True)
+    email = f"partner_{uuid.uuid4().hex[:8]}@example.test"
+    partner_tenant_ref = f"phala_cloud:team_{uuid.uuid4().hex[:12]}"
+    partner_user = await lazy_create_partner_user_with_personal_project(
+        db_session,
+        partner_tenant_ref=partner_tenant_ref,
+        race_loser_status=500,
+    )
+    partner_user.email = email
+    await db_session.commit()
+    partner_user_id = partner_user.id
+
+    token = _sign(
+        signing_key,
+        sub=f"new_{uuid.uuid4().hex[:8]}",
+        email=email,
+    )
+    ctx = await _auth_via_clerk_jwt(token, db_session)
+
+    assert ctx is not None
+    assert ctx.user.id != partner_user_id
+    assert ctx.user.principal_kind == "clerk"
+    persisted_partner = await db_session.get(User, partner_user_id)
+    assert persisted_partner is not None
+    assert persisted_partner.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT
+    assert persisted_partner.clerk_id is None
+    assert persisted_partner.partner_tenant_ref == partner_tenant_ref
+
+    await db_session.delete(ctx.user)
+    await db_session.delete(persisted_partner)
+    await db_session.commit()
+
+
 # ---------------------------------------------------------------------------
 # Rebind enabled — fail-closed paths
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_principal_user_migration.py
+++ b/backend/tests/test_principal_user_migration.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.engine import URL, make_url
+from sqlalchemy.exc import IntegrityError
+
+BASE_REVISION = "d8f2a1c4b6e9"
+PRINCIPAL_REVISION = "a26c40c6965e"
+BACKEND_DIR = Path(__file__).parents[1]
+
+
+def _sync_url(url: URL, *, database: str) -> URL:
+    return url.set(drivername="postgresql+psycopg2", database=database)
+
+
+def _url_text(url: URL) -> str:
+    return url.render_as_string(hide_password=False)
+
+
+def _run_alembic(database_url: URL, *args: str) -> None:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = _url_text(database_url)
+    subprocess.run(
+        [str(Path(sys.executable).with_name("alembic")), *args],
+        cwd=BACKEND_DIR,
+        env=env,
+        check=True,
+    )
+
+
+def test_principal_user_migration_apply_and_rollback():
+    source_url = make_url(os.environ["DATABASE_URL"])
+    database_name = f"clawdi_principal_migration_{uuid.uuid4().hex}"
+    admin_engine = create_engine(
+        _sync_url(source_url, database="postgres"),
+        isolation_level="AUTOCOMMIT",
+    )
+    database_url = source_url.set(database=database_name)
+    sync_database_url = _sync_url(source_url, database=database_name)
+    tenant_user_id = uuid.uuid4()
+    clerk_user_id = uuid.uuid4()
+
+    with admin_engine.connect() as connection:
+        connection.execute(text(f'CREATE DATABASE "{database_name}"'))
+
+    database_engine = create_engine(sync_database_url)
+    try:
+        _run_alembic(database_url, "upgrade", BASE_REVISION)
+
+        with database_engine.begin() as connection:
+            connection.execute(
+                text(
+                    "INSERT INTO users (id, clerk_id, email, name, skills_revision) "
+                    "VALUES (:id, :clerk_id, NULL, NULL, 0)"
+                ),
+                {"id": clerk_user_id, "clerk_id": "user_existing_tenant_zero"},
+            )
+
+        _run_alembic(database_url, "upgrade", PRINCIPAL_REVISION)
+
+        inspector = inspect(database_engine)
+        columns = {column["name"]: column for column in inspector.get_columns("users")}
+        checks = {constraint["name"] for constraint in inspector.get_check_constraints("users")}
+        assert columns["clerk_id"]["nullable"] is True
+        assert columns["principal_kind"]["nullable"] is False
+        assert "partner_tenant_ref" in columns
+        assert "ck_users_principal_identity" in checks
+
+        with database_engine.begin() as connection:
+            existing = connection.execute(
+                text("SELECT principal_kind, partner_tenant_ref FROM users WHERE id = :id"),
+                {"id": clerk_user_id},
+            ).one()
+            assert existing == ("clerk", None)
+            connection.execute(
+                text(
+                    "INSERT INTO users "
+                    "(id, clerk_id, principal_kind, partner_tenant_ref, email, name, "
+                    "skills_revision) VALUES "
+                    "(:id, NULL, 'partner_tenant', :partner_tenant_ref, NULL, NULL, 0)"
+                ),
+                {
+                    "id": tenant_user_id,
+                    "partner_tenant_ref": "ptn_migration",
+                },
+            )
+
+        with pytest.raises(IntegrityError):
+            with database_engine.begin() as connection:
+                connection.execute(
+                    text(
+                        "INSERT INTO users "
+                        "(id, clerk_id, principal_kind, partner_tenant_ref, email, name, "
+                        "skills_revision) VALUES "
+                        "(:id, :clerk_id, 'partner_tenant', :partner_tenant_ref, "
+                        "NULL, NULL, 0)"
+                    ),
+                    {
+                        "id": uuid.uuid4(),
+                        "clerk_id": "user_illegal_double_identity",
+                        "partner_tenant_ref": "ptn_illegal",
+                    },
+                )
+
+        with database_engine.begin() as connection:
+            connection.execute(
+                text("DELETE FROM users WHERE id = :id"),
+                {"id": tenant_user_id},
+            )
+
+        _run_alembic(database_url, "downgrade", BASE_REVISION)
+
+        inspector = inspect(database_engine)
+        columns = {column["name"]: column for column in inspector.get_columns("users")}
+        assert columns["clerk_id"]["nullable"] is False
+        assert "principal_kind" not in columns
+        assert "partner_tenant_ref" not in columns
+        with database_engine.connect() as connection:
+            clerk_id = connection.execute(
+                text("SELECT clerk_id FROM users WHERE id = :id"),
+                {"id": clerk_user_id},
+            ).scalar_one()
+        assert clerk_id == "user_existing_tenant_zero"
+    finally:
+        database_engine.dispose()
+        with admin_engine.connect() as connection:
+            connection.execute(text(f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE)'))
+        admin_engine.dispose()

--- a/backend/tests/test_principal_users.py
+++ b/backend/tests/test_principal_users.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models.user import (
+    PRINCIPAL_KIND_CLERK,
+    PRINCIPAL_KIND_PARTNER_TENANT,
+    User,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "identity",
+    [
+        {
+            "clerk_id": None,
+            "principal_kind": PRINCIPAL_KIND_CLERK,
+            "partner_tenant_ref": None,
+        },
+        {
+            "clerk_id": "user_invalid_partner",
+            "principal_kind": PRINCIPAL_KIND_PARTNER_TENANT,
+            "partner_tenant_ref": "phala_cloud:team_invalid_partner",
+        },
+        {
+            "clerk_id": None,
+            "principal_kind": PRINCIPAL_KIND_PARTNER_TENANT,
+            "partner_tenant_ref": None,
+        },
+        {
+            "clerk_id": "user_invalid_double",
+            "principal_kind": PRINCIPAL_KIND_CLERK,
+            "partner_tenant_ref": "phala_cloud:team_invalid_double",
+        },
+        {
+            "clerk_id": "user_invalid_kind",
+            "principal_kind": "unknown",
+            "partner_tenant_ref": None,
+        },
+    ],
+)
+async def test_database_rejects_invalid_principal_identity_combinations(
+    db_session,
+    identity,
+):
+    user = User(
+        id=uuid.uuid4(),
+        email=None,
+        name=None,
+        **identity,
+    )
+    db_session.add(user)
+
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()


### PR DESCRIPTION
M1 第二块（叠在 A0.1a 上）：`clerk_id` 可空 + `principal_kind`/`partner_tenant_ref` + DB CHECK 互斥不变量；tenant 用户结构性不可 JWT 登录/不可 email rebind；坏 target_clerk_id 拒绝。migration `a26c40c6965e` 双向验证。

- 测试：925 passed
- ⚠️ stacked PR：base 是 a0-1a-owner-audit，父 PR 合并后自动重定向 main

🤖 Generated with [Claude Code](https://claude.com/claude-code)