### PR TITLE
M1: cloud-api 多租户安全地基（owner 校验 + 租户身份 + 平台管理面）

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -13,6 +13,7 @@ from app.models import (  # noqa: F401 - register models
     device_authorization,
     hosted_runtime,
     memory,
+    platform_idempotency,
     project,
     project_invitation,
     project_membership,

--- a/backend/alembic/versions/a26c40c6965e_principal_aware_users.py
+++ b/backend/alembic/versions/a26c40c6965e_principal_aware_users.py
@@ -1,0 +1,73 @@
+"""Add principal-aware users.
+
+Revision ID: a26c40c6965e
+Revises: d8f2a1c4b6e9
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a26c40c6965e"
+down_revision: str | Sequence[str] | None = "d8f2a1c4b6e9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "principal_kind",
+            sa.String(length=32),
+            server_default="clerk",
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "users",
+        sa.Column("partner_tenant_ref", sa.String(length=255), nullable=True),
+    )
+    op.alter_column(
+        "users",
+        "clerk_id",
+        existing_type=sa.String(length=200),
+        nullable=True,
+    )
+    op.create_unique_constraint(
+        "uq_users_partner_tenant_ref",
+        "users",
+        ["partner_tenant_ref"],
+    )
+    op.create_check_constraint(
+        "ck_users_principal_identity",
+        "users",
+        "(principal_kind = 'clerk' AND clerk_id IS NOT NULL "
+        "AND partner_tenant_ref IS NULL) OR "
+        "(principal_kind = 'partner_tenant' AND clerk_id IS NULL "
+        "AND partner_tenant_ref IS NOT NULL)",
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    tenant_user_count = bind.execute(
+        sa.text("SELECT count(*) FROM users WHERE clerk_id IS NULL")
+    ).scalar_one()
+    if tenant_user_count:
+        raise RuntimeError(
+            "cannot downgrade principal-aware users while partner tenant users exist"
+        )
+
+    op.drop_constraint("ck_users_principal_identity", "users", type_="check")
+    op.drop_constraint("uq_users_partner_tenant_ref", "users", type_="unique")
+    op.alter_column(
+        "users",
+        "clerk_id",
+        existing_type=sa.String(length=200),
+        nullable=False,
+    )
+    op.drop_column("users", "partner_tenant_ref")
+    op.drop_column("users", "principal_kind")

--- a/backend/alembic/versions/f3a1c7d9e2b4_platform_mutation_idempotency.py
+++ b/backend/alembic/versions/f3a1c7d9e2b4_platform_mutation_idempotency.py
@@ -1,0 +1,55 @@
+"""Add durable platform mutation idempotency.
+
+Revision ID: f3a1c7d9e2b4
+Revises: a26c40c6965e
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "f3a1c7d9e2b4"
+down_revision: str | Sequence[str] | None = "a26c40c6965e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "platform_mutation_idempotency",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("operation", sa.String(length=100), nullable=False),
+        sa.Column("idempotency_key", sa.String(length=200), nullable=False),
+        sa.Column("request_hash", sa.String(length=64), nullable=False),
+        sa.Column("owner_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("resource_type", sa.String(length=80), nullable=False),
+        sa.Column("resource_id", sa.String(length=200), nullable=True),
+        sa.Column("response_status", sa.Integer(), nullable=False),
+        sa.Column("encrypted_response", sa.LargeBinary(), nullable=False),
+        sa.Column("response_nonce", sa.LargeBinary(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["owner_user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "operation",
+            "idempotency_key",
+            name="uq_platform_mutation_idempotency_operation_key",
+        ),
+    )
+    op.create_index(
+        "ix_platform_mutation_idempotency_owner_user_id",
+        "platform_mutation_idempotency",
+        ["owner_user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_platform_mutation_idempotency_owner_user_id",
+        table_name="platform_mutation_idempotency",
+    )
+    op.drop_table("platform_mutation_idempotency")

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -19,7 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.core.database import get_session
 from app.models.api_key import ApiKey
-from app.models.user import User
+from app.models.user import PRINCIPAL_KIND_CLERK, User
 from app.services.user_provisioning import lazy_create_user_with_personal_project
 
 bearer_scheme = HTTPBearer()
@@ -58,7 +58,9 @@ class _CachedApiKeyAuth:
     environment_id: UUID | None
     managed: bool
     expires_at: datetime | None
-    user_clerk_id: str
+    user_clerk_id: str | None
+    user_principal_kind: str
+    user_partner_tenant_ref: str | None
     user_email: str | None
     user_name: str | None
     user_avatar_url: str | None
@@ -69,6 +71,8 @@ class _CachedApiKeyAuth:
         user = User(
             id=self.user_id,
             clerk_id=self.user_clerk_id,
+            principal_kind=self.user_principal_kind,
+            partner_tenant_ref=self.user_partner_tenant_ref,
             email=self.user_email,
             name=self.user_name,
             avatar_url=self.user_avatar_url,
@@ -138,6 +142,8 @@ def _cache_api_key_auth(
             managed=api_key.managed,
             expires_at=api_key.expires_at,
             user_clerk_id=user.clerk_id,
+            user_principal_kind=user.principal_kind,
+            user_partner_tenant_ref=user.partner_tenant_ref,
             user_email=user.email,
             user_name=user.name,
             user_avatar_url=user.avatar_url,
@@ -242,7 +248,12 @@ async def _auth_via_dev_bypass(token: str, db: AsyncSession) -> AuthContext | No
         )
 
     clerk_id = settings.dev_auth_clerk_id
-    result = await db.execute(select(User).where(User.clerk_id == clerk_id))
+    result = await db.execute(
+        select(User).where(
+            User.principal_kind == PRINCIPAL_KIND_CLERK,
+            User.clerk_id == clerk_id,
+        )
+    )
     user = result.scalar_one_or_none()
     if user is None:
         user = await lazy_create_user_with_personal_project(
@@ -335,7 +346,12 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
     if not clerk_id:
         return None
 
-    result = await db.execute(select(User).where(User.clerk_id == clerk_id))
+    result = await db.execute(
+        select(User).where(
+            User.principal_kind == PRINCIPAL_KIND_CLERK,
+            User.clerk_id == clerk_id,
+        )
+    )
     user = result.scalar_one_or_none()
 
     email = payload.get("email") or payload.get("email_address")
@@ -372,7 +388,12 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
             # row (which now carries the winner's values) instead of
             # 500-ing the user out of their session.
             await db.rollback()
-            result = await db.execute(select(User).where(User.clerk_id == clerk_id))
+            result = await db.execute(
+                select(User).where(
+                    User.principal_kind == PRINCIPAL_KIND_CLERK,
+                    User.clerk_id == clerk_id,
+                )
+            )
             user = result.scalar_one()
 
     # Sub miss + snapshot-rebind opted in: try to attach to an existing
@@ -400,7 +421,13 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
         # whoever signs in first would otherwise get to choose which
         # row they take over.
         result = await db.execute(
-            select(User).where(User.email == email).order_by(User.created_at).limit(2)
+            select(User)
+            .where(
+                User.principal_kind == PRINCIPAL_KIND_CLERK,
+                User.email == email,
+            )
+            .order_by(User.created_at)
+            .limit(2)
         )
         candidates = list(result.scalars())
         if len(candidates) > 1:
@@ -434,7 +461,12 @@ async def _auth_via_clerk_jwt(token: str, db: AsyncSession) -> AuthContext | Non
                 await db.refresh(user)
             except IntegrityError:
                 await db.rollback()
-                result = await db.execute(select(User).where(User.clerk_id == clerk_id))
+                result = await db.execute(
+                    select(User).where(
+                        User.principal_kind == PRINCIPAL_KIND_CLERK,
+                        User.clerk_id == clerk_id,
+                    )
+                )
                 user = result.scalar_one_or_none()
                 if user is None:
                     # Both writers somehow lost the row — extremely

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -38,6 +38,7 @@ from app.routes.mcp_bridge import router as mcp_bridge_router
 from app.routes.me import router as me_router
 from app.routes.memories import router as memories_router
 from app.routes.metrics import router as metrics_router
+from app.routes.platform import router as platform_router
 from app.routes.projects import router as projects_router
 from app.routes.public_sessions import router as public_sessions_router
 from app.routes.runtime import router as runtime_router
@@ -246,7 +247,7 @@ async def request_validation_exception_handler(
 # API routers are mounted canonically under /v1 (the only
 # form in the OpenAPI schema — we serve on a dedicated API domain, so
 # versioning sits at the root). Older APIs also retain the legacy /api alias;
-# the unlaunched runtime manifest contract is canonical-only.
+# unlaunched runtime and platform contracts are canonical-only.
 #
 # Note for public_sessions_router: share routes live at
 # /v1/public/sessions/{id}/..., auth is optional (signed-in owners +
@@ -270,6 +271,7 @@ _VERSIONED_ROUTERS = (
     memories_router,
     settings_router,
     capabilities_router,
+    platform_router,
     vault_router,
     connectors_router,
     mcp_bridge_router,
@@ -281,7 +283,7 @@ _VERSIONED_ROUTERS = (
 )
 for _router in _VERSIONED_ROUTERS:
     app.include_router(_router, prefix="/v1")
-    if _router is not runtime_router:
+    if _router not in (runtime_router, platform_router):
         app.include_router(_router, prefix="/api", include_in_schema=False)
 # Scope skill reads predate the Scope -> Project migration and only
 # exist for old binaries; legacy /api alias only.

--- a/backend/app/models/platform_idempotency.py
+++ b/backend/app/models/platform_idempotency.py
@@ -1,0 +1,33 @@
+import uuid
+
+from sqlalchemy import ForeignKey, Integer, LargeBinary, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class PlatformMutationIdempotency(Base, TimestampMixin):
+    __tablename__ = "platform_mutation_idempotency"
+    __table_args__ = (
+        UniqueConstraint(
+            "operation",
+            "idempotency_key",
+            name="uq_platform_mutation_idempotency_operation_key",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    operation: Mapped[str] = mapped_column(String(100), nullable=False)
+    idempotency_key: Mapped[str] = mapped_column(String(200), nullable=False)
+    request_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    owner_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        index=True,
+    )
+    resource_type: Mapped[str] = mapped_column(String(80), nullable=False)
+    resource_id: Mapped[str | None] = mapped_column(String(200))
+    response_status: Mapped[int] = mapped_column(Integer, nullable=False)
+    encrypted_response: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    response_nonce: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,17 +1,40 @@
 import uuid
 
-from sqlalchemy import Integer, String
+from sqlalchemy import CheckConstraint, Integer, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base, TimestampMixin
 
+PRINCIPAL_KIND_CLERK = "clerk"
+PRINCIPAL_KIND_PARTNER_TENANT = "partner_tenant"
+
 
 class User(Base, TimestampMixin):
     __tablename__ = "users"
+    __table_args__ = (
+        UniqueConstraint(
+            "partner_tenant_ref",
+            name="uq_users_partner_tenant_ref",
+        ),
+        CheckConstraint(
+            "(principal_kind = 'clerk' AND clerk_id IS NOT NULL "
+            "AND partner_tenant_ref IS NULL) OR "
+            "(principal_kind = 'partner_tenant' AND clerk_id IS NULL "
+            "AND partner_tenant_ref IS NOT NULL)",
+            name="ck_users_principal_identity",
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    clerk_id: Mapped[str] = mapped_column(String(200), unique=True, nullable=False)
+    clerk_id: Mapped[str | None] = mapped_column(String(200), unique=True)
+    principal_kind: Mapped[str] = mapped_column(
+        String(32),
+        default=PRINCIPAL_KIND_CLERK,
+        server_default=PRINCIPAL_KIND_CLERK,
+        nullable=False,
+    )
+    partner_tenant_ref: Mapped[str | None] = mapped_column(String(255))
     email: Mapped[str | None] = mapped_column(String(320))
     name: Mapped[str | None] = mapped_column(String(200))
     # Profile picture URL captured from the Clerk JWT `picture` claim

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -142,6 +142,32 @@ async def _resolve_or_create_user(db: AsyncSession, clerk_id: str) -> User:
     return user
 
 
+async def _assert_admin_target_owns_environment(
+    db: AsyncSession,
+    *,
+    env: AgentEnvironment,
+    target_clerk_id: str | None,
+) -> UUID:
+    if target_clerk_id is None:
+        return env.user_id
+
+    target = (
+        await db.execute(select(User).where(User.clerk_id == target_clerk_id))
+    ).scalar_one_or_none()
+    if target is None or env.user_id != target.id:
+        logger.warning(
+            "admin_environment_owner_rejected target_clerk_id=%s env_id=%s owner_user_id=%s",
+            target_clerk_id,
+            env.id,
+            env.user_id,
+        )
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            "Agent environment is not owned by target user",
+        )
+    return target.id
+
+
 @router.post("/auth/keys", response_model=ApiKeyCreated)
 async def admin_mint_api_key(
     body: AdminApiKeyCreate,
@@ -206,6 +232,24 @@ async def admin_mint_api_key(
         api_key.environment_id,
         api_key.managed,
     )
+    record_control_plane_audit(
+        db,
+        actor_type="admin",
+        action="api_key.mint",
+        resource_type="api_key",
+        resource_id=str(api_key.id),
+        environment_id=api_key.environment_id,
+        target_user_id=target.id,
+        source="api.admin",
+        details={
+            "label": api_key.label,
+            "key_prefix": api_key.key_prefix,
+            "managed": api_key.managed,
+            "has_environment_binding": api_key.environment_id is not None,
+            "scope_count": None if api_key.scopes is None else len(api_key.scopes),
+        },
+    )
+    await db.commit()
     return ApiKeyCreated(
         id=str(api_key.id),
         label=api_key.label,
@@ -239,6 +283,22 @@ async def admin_revoke_api_key(
         return ApiKeyRevokeResponse(status="revoked")
 
     api_key.revoked_at = datetime.now(UTC)
+    record_control_plane_audit(
+        db,
+        actor_type="admin",
+        action="api_key.revoke",
+        resource_type="api_key",
+        resource_id=str(api_key.id),
+        environment_id=api_key.environment_id,
+        target_user_id=api_key.user_id,
+        source="api.admin",
+        details={
+            "label": api_key.label,
+            "key_prefix": api_key.key_prefix,
+            "managed": api_key.managed,
+            "has_environment_binding": api_key.environment_id is not None,
+        },
+    )
     await db.commit()
     invalidate_api_key_auth_cache(api_key.id)
     logger.info(
@@ -635,6 +695,7 @@ async def admin_register_environment(
 
 async def _admin_delete_environment(
     environment_id: UUID,
+    target_clerk_id: str | None,
     db: AsyncSession,
 ) -> None:
     env = (
@@ -642,19 +703,44 @@ async def _admin_delete_environment(
     ).scalar_one_or_none()
     if env is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent not found")
+    target_user_id = await _assert_admin_target_owns_environment(
+        db,
+        env=env,
+        target_clerk_id=target_clerk_id,
+    )
+    record_control_plane_audit(
+        db,
+        actor_type="admin",
+        action="agent_environment.delete",
+        resource_type="agent_environment",
+        resource_id=str(env.id),
+        environment_id=env.id,
+        target_user_id=target_user_id,
+        source="api.admin",
+        details={
+            "agent_type": env.agent_type,
+            "machine_id": env.machine_id,
+            "explicit_identity": env.registration_key is None,
+        },
+    )
     await queue_environment_runtime_manifest_changed(db, env.user_id, environment_id)
     await db.delete(env)
     await db.commit()
-    logger.info("admin_environment_deleted env_id=%s", environment_id)
+    logger.info(
+        "admin_environment_deleted target_clerk_id=%s env_id=%s",
+        target_clerk_id,
+        environment_id,
+    )
 
 
 @router.delete("/agents/{agent_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def admin_delete_agent(
     agent_id: UUID,
+    target_clerk_id: str | None = None,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> None:
-    await _admin_delete_environment(agent_id, db)
+    await _admin_delete_environment(agent_id, target_clerk_id, db)
 
 
 @router.delete(
@@ -664,6 +750,7 @@ async def admin_delete_agent(
 )
 async def admin_delete_environment(
     environment_id: UUID,
+    target_clerk_id: str | None = None,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> None:
@@ -673,7 +760,7 @@ async def admin_delete_environment(
     user-facing `/v1/environments/{id}` semantics. Unlike the dashboard route,
     first-party cleanup may delete explicit-identity rows.
     """
-    await _admin_delete_environment(environment_id, db)
+    await _admin_delete_environment(environment_id, target_clerk_id, db)
 
 
 async def _next_environment_sort_order(db: AsyncSession, user_id: UUID) -> int:
@@ -699,6 +786,11 @@ async def _admin_upsert_runtime_state(
     ).scalar_one_or_none()
     if env is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent environment not found")
+    target_user_id = await _assert_admin_target_owns_environment(
+        db,
+        env=env,
+        target_clerk_id=body.target_clerk_id,
+    )
 
     # Lock the parent before the optional child row so concurrent first creates
     # serialize even when there is no HostedRuntimeState row to lock yet.
@@ -788,7 +880,7 @@ async def _admin_upsert_runtime_state(
         resource_type="hosted_runtime_state",
         resource_id=str(environment_id),
         environment_id=environment_id,
-        target_user_id=env.user_id,
+        target_user_id=target_user_id,
         source="api.admin",
         details={
             "deployment_id": body.deployment_id,
@@ -809,7 +901,9 @@ async def _admin_upsert_runtime_state(
         queue_runtime_manifest_changed(db, env.user_id, environment_id)
     await db.commit()
     logger.info(
-        "admin_runtime_state_upserted environment_id=%s deployment_id=%s generation=%s",
+        "admin_runtime_state_upserted target_clerk_id=%s environment_id=%s "
+        "deployment_id=%s generation=%s",
+        body.target_clerk_id,
         environment_id,
         body.deployment_id,
         body.generation,
@@ -851,6 +945,7 @@ async def admin_upsert_runtime_state(
 
 async def _admin_delete_runtime_state(
     environment_id: UUID,
+    target_clerk_id: str | None,
     db: AsyncSession,
 ) -> None:
     env = (
@@ -858,6 +953,11 @@ async def _admin_delete_runtime_state(
     ).scalar_one_or_none()
     if env is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Agent environment not found")
+    target_user_id = await _assert_admin_target_owns_environment(
+        db,
+        env=env,
+        target_clerk_id=target_clerk_id,
+    )
 
     state = (
         await db.execute(
@@ -890,13 +990,14 @@ async def _admin_delete_runtime_state(
         resource_type="hosted_runtime_state",
         resource_id=str(environment_id),
         environment_id=environment_id,
-        target_user_id=env.user_id,
+        target_user_id=target_user_id,
         source="api.admin",
         details=details,
     )
     await db.commit()
     logger.info(
-        "admin_runtime_state_deleted environment_id=%s existed=%s",
+        "admin_runtime_state_deleted target_clerk_id=%s environment_id=%s existed=%s",
+        target_clerk_id,
         environment_id,
         state is not None,
     )
@@ -908,10 +1009,11 @@ async def _admin_delete_runtime_state(
 )
 async def admin_delete_agent_runtime_state(
     agent_id: UUID,
+    target_clerk_id: str | None = None,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> None:
-    await _admin_delete_runtime_state(agent_id, db)
+    await _admin_delete_runtime_state(agent_id, target_clerk_id, db)
 
 
 @router.delete(
@@ -921,10 +1023,11 @@ async def admin_delete_agent_runtime_state(
 )
 async def admin_delete_runtime_state(
     environment_id: UUID,
+    target_clerk_id: str | None = None,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> None:
-    await _admin_delete_runtime_state(environment_id, db)
+    await _admin_delete_runtime_state(environment_id, target_clerk_id, db)
 
 
 async def _admin_get_channel_row(

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -44,7 +44,7 @@ from app.models.channel import (
 )
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.session import AgentEnvironment
-from app.models.user import User
+from app.models.user import PRINCIPAL_KIND_CLERK, User
 from app.schemas.admin import (
     AdminAgentCreate,
     AdminApiKeyCreate,
@@ -127,7 +127,14 @@ async def _resolve_or_create_user(db: AsyncSession, clerk_id: str) -> User:
     an operational anomaly worth a loud failure rather than a
     user-flow retry.
     """
-    target = (await db.execute(select(User).where(User.clerk_id == clerk_id))).scalar_one_or_none()
+    target = (
+        await db.execute(
+            select(User).where(
+                User.principal_kind == PRINCIPAL_KIND_CLERK,
+                User.clerk_id == clerk_id,
+            )
+        )
+    ).scalar_one_or_none()
     if target is not None:
         return target
 
@@ -152,7 +159,12 @@ async def _assert_admin_target_owns_environment(
         return env.user_id
 
     target = (
-        await db.execute(select(User).where(User.clerk_id == target_clerk_id))
+        await db.execute(
+            select(User).where(
+                User.principal_kind == PRINCIPAL_KIND_CLERK,
+                User.clerk_id == target_clerk_id,
+            )
+        )
     ).scalar_one_or_none()
     if target is None or env.user_id != target.id:
         logger.warning(

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -1,0 +1,974 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Annotated, Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import invalidate_api_key_auth_cache, require_admin_api_key
+from app.core.database import get_session
+from app.models.api_key import ApiKey
+from app.models.hosted_runtime import HostedRuntimeState
+from app.models.session import AgentEnvironment
+from app.models.user import (
+    PRINCIPAL_KIND_CLERK,
+    PRINCIPAL_KIND_PARTNER_TENANT,
+    User,
+)
+from app.schemas.api_key import ApiKeyCreated, ApiKeyRevokeResponse
+from app.schemas.platform import (
+    PlatformAgentCreate,
+    PlatformApiKeyCreate,
+    PlatformMutationBody,
+    PlatformOwner,
+    PlatformRuntimeStateResponse,
+    PlatformRuntimeStateUpsert,
+)
+from app.schemas.session import EnvironmentCreatedResponse
+from app.services.agent_environments import (
+    AgentEnvironmentIdConflict,
+    register_agent_environment,
+)
+from app.services.api_key import mint_api_key
+from app.services.audit import record_control_plane_audit
+from app.services.platform_contract import (
+    PlatformReplay,
+    lock_platform_idempotency,
+    platform_request_hash,
+    read_platform_replay,
+    store_platform_response,
+)
+from app.services.sync_events import (
+    queue_environment_runtime_manifest_changed,
+    queue_runtime_manifest_changed,
+)
+
+router = APIRouter(prefix="/platform", tags=["platform"])
+
+IdempotencyKey = Annotated[
+    str,
+    Header(alias="Idempotency-Key", min_length=1, max_length=200),
+]
+
+
+def _audit_details(
+    *,
+    owner: PlatformOwner,
+    resource_type: str,
+    resource_id: str | None,
+    action: str,
+    result: str,
+    request_id: str,
+    idempotency_key: str,
+    details: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "workload_sub": None,
+        "credential_id": None,
+        "token_jti": None,
+        "owner": owner.model_dump(mode="json"),
+        "resource": {"type": resource_type, "id": resource_id},
+        "action": action,
+        "result": result,
+        "request_id": request_id,
+        "idempotency_key": idempotency_key,
+        **(details or {}),
+    }
+
+
+def _record_platform_audit(
+    db: AsyncSession,
+    *,
+    owner: PlatformOwner,
+    owner_user_id: UUID | None,
+    resource_type: str,
+    resource_id: str | None,
+    action: str,
+    result: str,
+    request: Request,
+    idempotency_key: str,
+    environment_id: UUID | None = None,
+    details: dict[str, Any] | None = None,
+) -> None:
+    record_control_plane_audit(
+        db,
+        actor_type="platform",
+        action=action,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        environment_id=environment_id,
+        target_user_id=owner_user_id,
+        source="api.platform",
+        details=_audit_details(
+            owner=owner,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            action=action,
+            result=result,
+            request_id=str(request.state.request_id),
+            idempotency_key=idempotency_key,
+            details=details,
+        ),
+    )
+
+
+async def _reject(
+    db: AsyncSession,
+    *,
+    status_code: int,
+    detail: str | dict[str, Any],
+    result: str,
+    owner: PlatformOwner,
+    owner_user_id: UUID | None,
+    resource_type: str,
+    resource_id: str | None,
+    action: str,
+    request: Request,
+    idempotency_key: str,
+    environment_id: UUID | None = None,
+) -> None:
+    _record_platform_audit(
+        db,
+        owner=owner,
+        owner_user_id=owner_user_id,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        action=action,
+        result=result,
+        request=request,
+        idempotency_key=idempotency_key,
+        environment_id=environment_id,
+    )
+    await db.commit()
+    raise HTTPException(status_code, detail)
+
+
+async def _resolve_owner(
+    db: AsyncSession,
+    *,
+    owner: PlatformOwner,
+    resource_type: str,
+    resource_id: str | None,
+    action: str,
+    request: Request,
+    idempotency_key: str,
+) -> User:
+    if owner.kind == PRINCIPAL_KIND_CLERK:
+        filters = (
+            User.principal_kind == PRINCIPAL_KIND_CLERK,
+            User.clerk_id == owner.ref,
+        )
+    else:
+        filters = (
+            User.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT,
+            User.partner_tenant_ref == owner.ref,
+            User.clerk_id.is_(None),
+        )
+    user = (await db.execute(select(User).where(*filters))).scalar_one_or_none()
+    if user is None:
+        await _reject(
+            db,
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Owner not found",
+            result="owner_not_found",
+            owner=owner,
+            owner_user_id=None,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            action=action,
+            request=request,
+            idempotency_key=idempotency_key,
+        )
+        raise AssertionError("unreachable")
+    return user
+
+
+async def _begin_mutation(
+    db: AsyncSession,
+    *,
+    operation: str,
+    idempotency_key: str,
+    request_payload: dict[str, Any],
+    owner: PlatformOwner,
+    owner_user_id: UUID,
+    resource_type: str,
+    resource_id: str | None,
+    action: str,
+    request: Request,
+) -> tuple[str, PlatformReplay | None]:
+    request_hash = platform_request_hash(request_payload)
+    existing = await lock_platform_idempotency(
+        db,
+        operation=operation,
+        idempotency_key=idempotency_key,
+    )
+    if existing is None:
+        return request_hash, None
+    if existing.request_hash != request_hash or existing.owner_user_id != owner_user_id:
+        await _reject(
+            db,
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Idempotency-Key was already used with a different request",
+            result="idempotency_conflict",
+            owner=owner,
+            owner_user_id=owner_user_id,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            action=action,
+            request=request,
+            idempotency_key=idempotency_key,
+        )
+        raise AssertionError("unreachable")
+    return request_hash, read_platform_replay(existing)
+
+
+def _replay_response(replay: PlatformReplay) -> Response:
+    if replay.status_code == status.HTTP_204_NO_CONTENT:
+        return Response(status_code=replay.status_code)
+    return JSONResponse(status_code=replay.status_code, content=replay.body)
+
+
+async def _complete_mutation(
+    db: AsyncSession,
+    *,
+    operation: str,
+    idempotency_key: str,
+    request_hash: str,
+    owner: PlatformOwner,
+    owner_user_id: UUID,
+    resource_type: str,
+    resource_id: str | None,
+    action: str,
+    request: Request,
+    response_status: int,
+    response_body: BaseModel | dict[str, Any] | None,
+    environment_id: UUID | None = None,
+    audit_details: dict[str, Any] | None = None,
+) -> None:
+    if isinstance(response_body, BaseModel):
+        stored_body = response_body.model_dump(mode="json")
+    else:
+        stored_body = response_body or {}
+    _record_platform_audit(
+        db,
+        owner=owner,
+        owner_user_id=owner_user_id,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        action=action,
+        result="success",
+        request=request,
+        idempotency_key=idempotency_key,
+        environment_id=environment_id,
+        details=audit_details,
+    )
+    store_platform_response(
+        db,
+        operation=operation,
+        idempotency_key=idempotency_key,
+        request_hash=request_hash,
+        owner_user_id=owner_user_id,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        response_status=response_status,
+        response_body=stored_body,
+    )
+    await db.commit()
+
+
+async def _load_owned_agent(
+    db: AsyncSession,
+    *,
+    agent_id: UUID,
+    owner: PlatformOwner,
+    owner_user_id: UUID,
+    action: str,
+    request: Request,
+    idempotency_key: str,
+) -> AgentEnvironment:
+    agent = (
+        await db.execute(
+            select(AgentEnvironment)
+            .where(
+                AgentEnvironment.id == agent_id,
+                AgentEnvironment.user_id == owner_user_id,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if agent is not None:
+        return agent
+    exists = await db.scalar(select(AgentEnvironment.id).where(AgentEnvironment.id == agent_id))
+    await _reject(
+        db,
+        status_code=status.HTTP_403_FORBIDDEN if exists is not None else status.HTTP_404_NOT_FOUND,
+        detail="Agent is not owned by requested owner" if exists is not None else "Agent not found",
+        result="owner_mismatch" if exists is not None else "resource_not_found",
+        owner=owner,
+        owner_user_id=owner_user_id,
+        resource_type="agent_environment",
+        resource_id=str(agent_id),
+        action=action,
+        request=request,
+        idempotency_key=idempotency_key,
+        environment_id=agent_id if exists is not None else None,
+    )
+    raise AssertionError("unreachable")
+
+
+async def _load_owned_key(
+    db: AsyncSession,
+    *,
+    key_id: UUID,
+    owner: PlatformOwner,
+    owner_user_id: UUID,
+    action: str,
+    request: Request,
+    idempotency_key: str,
+) -> ApiKey:
+    api_key = (
+        await db.execute(
+            select(ApiKey)
+            .where(ApiKey.id == key_id, ApiKey.user_id == owner_user_id)
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if api_key is not None:
+        return api_key
+    exists = await db.scalar(select(ApiKey.id).where(ApiKey.id == key_id))
+    await _reject(
+        db,
+        status_code=status.HTTP_403_FORBIDDEN if exists is not None else status.HTTP_404_NOT_FOUND,
+        detail="API key is not owned by requested owner"
+        if exists is not None
+        else "API key not found",
+        result="owner_mismatch" if exists is not None else "resource_not_found",
+        owner=owner,
+        owner_user_id=owner_user_id,
+        resource_type="api_key",
+        resource_id=str(key_id),
+        action=action,
+        request=request,
+        idempotency_key=idempotency_key,
+    )
+    raise AssertionError("unreachable")
+
+
+async def _next_agent_sort_order(db: AsyncSession, user_id: UUID) -> int:
+    value = await db.scalar(
+        select(func.coalesce(func.max(AgentEnvironment.sort_order), -1) + 1).where(
+            AgentEnvironment.user_id == user_id
+        )
+    )
+    return int(value or 0)
+
+
+@router.post("/agents", response_model=EnvironmentCreatedResponse)
+async def platform_create_agent(
+    body: PlatformAgentCreate,
+    request: Request,
+    idempotency_key: IdempotencyKey,
+    _: None = Depends(require_admin_api_key),
+    db: AsyncSession = Depends(get_session),
+) -> EnvironmentCreatedResponse | Response:
+    action = "agent_environment.create"
+    owner = await _resolve_owner(
+        db,
+        owner=body.owner,
+        resource_type="agent_environment",
+        resource_id=str(body.agent_id),
+        action=action,
+        request=request,
+        idempotency_key=idempotency_key,
+    )
+    request_hash, replay = await _begin_mutation(
+        db,
+        operation="agents.create",
+        idempotency_key=idempotency_key,
+        request_payload=body.model_dump(mode="json"),
+        owner=body.owner,
+        owner_user_id=owner.id,
+        resource_type="agent_environment",
+        resource_id=str(body.agent_id),
+        action=action,
+        request=request,
+    )
+    if replay is not None:
+        return _replay_response(replay)
+    try:
+        registered = await register_agent_environment(
+            db,
+            user_id=owner.id,
+            machine_id=body.machine_id,
+            machine_name=body.machine_name,
+            agent_type=body.agent_type,
+            agent_version=body.agent_version,
+            os_name=body.os_name,
+            sort_order=await _next_agent_sort_order(db, owner.id),
+            environment_id=body.agent_id,
+            registration_key=None,
+            commit=False,
+        )
+    except AgentEnvironmentIdConflict:
+        exists = await db.scalar(
+            select(AgentEnvironment.id).where(AgentEnvironment.id == body.agent_id)
+        )
+        await _reject(
+            db,
+            status_code=status.HTTP_403_FORBIDDEN
+            if exists is not None
+            else status.HTTP_409_CONFLICT,
+            detail=(
+                "Agent is not owned by requested owner"
+                if exists is not None
+                else "Agent could not be registered"
+            ),
+            result="owner_mismatch" if exists is not None else "resource_conflict",
+            owner=body.owner,
+            owner_user_id=owner.id,
+            resource_type="agent_environment",
+            resource_id=str(body.agent_id),
+            action=action,
+            request=request,
+            idempotency_key=idempotency_key,
+            environment_id=body.agent_id if exists is not None else None,
+        )
+        raise AssertionError("unreachable")
+    response = EnvironmentCreatedResponse(id=str(registered.env.id))
+    await _complete_mutation(
+        db,
+        operation="agents.create",
+        idempotency_key=idempotency_key,
+        request_hash=request_hash,
+        owner=body.owner,
+        owner_user_id=owner.id,
+        resource_type="agent_environment",
+        resource_id=str(registered.env.id),
+        action=action,
+        request=request,
+        response_status=status.HTTP_200_OK,
+        response_body=response,
+        environment_id=registered.env.id,
+        audit_details={"created": registered.created},
+    )
+    return response
+
+
+@router.delete("/agents/{agent_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def platform_delete_agent(
+    agent_id: UUID,
+    body: PlatformMutationBody,
+    request: Request,
+    idempotency_key: IdempotencyKey,
+    _: None = Depends(require_admin_api_key),
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    action = "agent_environment.delete"
+    owner = await _resolve_owner(
+        db,
+        owner=body.owner,
+        resource_type="agent_environment",
+        resource_id=str(agent_id),
+        action=action,
+        request=request,
+        idempotency_key=idempotency_key,
+    )
+    request_hash, replay = await _begin_mutation(
+        db,
+        operation="agents.delete",
+        idempotency_key=idempotency_key,
+        request_payload={"agent_id": str(agent_id), **body.model_dump(mode="json")},
+        owner=body.owner,
+        owner_user_id=owner.id,
+        resource_type="agent_environment",
+        resource_id=str(agent_id),
+        action=action,
+        request=request,
+    )
+    if replay is not None:
+        return _replay_response(replay)
+    agent = await _load_owned_agent(
+        db,
+        agent_id=agent_id,
+        owner=body.owner,
+        owner_user_id=owner.id,
+        action=action,
+        request=request,
+        idempotency_key=idempotency_key,
+    )
+    audit_details = {
+        "agent_type": agent.agent_type,
+        "machine_id": agent.machine_id,
+        "explicit_identity": agent.registration_key is None,
+    }
+    await queue_environment_runtime_manifest_changed(db, owner.id, agent_id)
+    await db.delete(agent)
+    await _complete_mutation(
+        db,
+        operation="agents.delete",
+        idempotency_key=idempotency_key,
+        request_hash=request_hash,
+        owner=body.owner,
+        owner_user_id=owner.id,
+        resource_type="agent_environment",
+        resource_id=str(agent_id),
+        action=action,
+        request=request,
+        response_status=status.HTTP_204_NO_CONTENT,
+        response_body=None,
+        environment_id=agent_id,
+        audit_details=audit_details,
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.put(
+    "/agents/{agent_id}/runtime-state",
+    response_model=PlatformRuntimeStateResponse,
+)
+async def platform_upsert_runtime_state(
+    agent_id: UUID,
+    body: PlatformRuntimeStateUpsert,
+    request: Request,
+    idempotency_key: IdempotencyKey,
+    _: None = Depends(require_admin_api_key),
+    db: AsyncSession = Depends(get_session),
+) -> PlatformRuntimeStateResponse | Response:
+    action = "hosted_runtime_state.upsert"
+    owner = await _resolve_owner(
+        db,
+        owner=body.owner,
+        resource_type="hosted_runtime_state",
+        resource_id=str(agent_id),
+        action=action,
+        request=request,
+        idempotency_key=idempotency_key,
+    )
+    request_hash, replay = await _begin_mutation(
+        db,
+        operation="runtime_state.upsert",
+        idempotency_key=idempotency_key,
+        request_payload={"agent_id": str(agent_id), **body.model_dump(mode="json")},
+        owner=body.owner,
+        owner_user_id=owner.id,
+        resource_type="hosted_runtime_state",
+        resource_id=str(agent_id),
+        action=action,
+        request=request,
+    )
+    if replay is not None:
+        return _replay_response(replay)
+    agent = await _load_owned_agent(
+        db,
+        agent_id=agent_id,
+        owner=body.owner,
+        owner_user_id=owner.id,
+        action=action,
+        request=request,
+        idempotency_key=idempotency_key,
+    )
+    runtime_state = (
+        await db.execute(
+            select(HostedRuntimeState)
+            .join(
+                AgentEnvironment,
+                AgentEnvironment.id == HostedRuntimeState.environment_id,
+            )
+            .where(
+                HostedRuntimeState.environment_id == agent_id,
+                AgentEnvironment.user_id == owner.id,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    previous_generation = runtime_state.generation if runtime_state is not None else None
+    changed_fields = _runtime_state_changed_fields(runtime_state, body)
+    if runtime_state is not None and body.generation <= runtime_state.generation:
+        current_generation = runtime_state.generation
+        if body.generation < current_generation:
+            await _reject(
+                db,
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "code": "stale_generation",
+                    "current_generation": current_generation,
+                },
+                result="stale_generation",
+                owner=body.owner,
+                owner_user_id=owner.id,
+                resource_type="hosted_runtime_state",
+                resource_id=str(agent_id),
+                action=action,
+                request=request,
+                idempotency_key=idempotency_key,
+                environment_id=agent_id,
+            )
+            raise AssertionError("unreachable")
+        material_changes = [field for field in changed_fields if field != "generation"]
+        if material_changes:
+            await _reject(
+                db,
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "code": "generation_conflict",
+                    "current_generation": current_generation,
+                },
+                result="generation_conflict",
+                owner=body.owner,
+                owner_user_id=owner.id,
+                resource_type="hosted_runtime_state",
+                resource_id=str(agent_id),
+                action=action,
+                request=request,
+                idempotency_key=idempotency_key,
+                environment_id=agent_id,
+            )
+            raise AssertionError("unreachable")
+    if runtime_state is None:
+        runtime_state = HostedRuntimeState(environment_id=agent_id)
+        db.add(runtime_state)
+    _assign_runtime_state(runtime_state, body)
+    if changed_fields:
+        queue_runtime_manifest_changed(db, agent.user_id, agent_id)
+    response = PlatformRuntimeStateResponse(
+        environment_id=agent_id,
+        deployment_id=body.deployment_id,
+        instance_id=body.instance_id,
+        generation=body.generation,
+    )
+    await _complete_mutation(
+        db,
+        operation="runtime_state.upsert",
+        idempotency_key=idempotency_key,
+        request_hash=request_hash,
+        owner=body.owner,
+        owner_user_id=owner.id,
+        resource_type="hosted_runtime_state",
+        resource_id=str(agent_id),
+        action=action,
+        request=request,
+        response_status=status.HTTP_200_OK,
+        response_body=response,
+        environment_id=agent_id,
+        audit_details={
+            "deployment_id": body.deployment_id,
+            "generation": body.generation,
+            "previous_generation": previous_generation,
+            "changed_fields": changed_fields,
+        },
+    )
+    return response
+
+
+@router.delete(
+    "/agents/{agent_id}/runtime-state",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def platform_delete_runtime_state(
+    agent_id: UUID,
+    body: PlatformMutationBody,
+    request: Request,
+    idempotency_key: IdempotencyKey,
+    _: None = Depends(require_admin_api_key),
+    db: AsyncSession = Depends(get_session),
+) -> Response:
+    action = "hosted_runtime_state.delete"
+    owner = await _resolve_owner(
+        db,
+        owner=body.owner,
+        resource_type="hosted_runtime_state",
+        resource_id=str(agent_id),
+        action=action,
+        request=request,
+        idempotency_key=idempotency_key,
+    )
+    request_hash, replay = await _begin_mutation(
+        db,
+        operation="runtime_state.delete",
+        idempotency_key=idempotency_key,
+        request_payload={"agent_id": str(agent_id), **body.model_dump(mode="json")},
+        owner=body.owner,
+        owner_user_id=owner.id,
+        resource_type="hosted_runtime_state",
+        resource_id=str(agent_id),
+        action=action,
+        request=request,
+    )
+    if replay is not None:
+        return _replay_response(replay)
+    agent = await _load_owned_agent(
+        db,
+        agent_id=agent_id,
+        owner=body.owner,
+        owner_user_id=owner.id,
+        action=action,
+        request=request,
+        idempotency_key=idempotency_key,
+    )
+    runtime_state = (
+        await db.execute(
+            select(HostedRuntimeState)
+            .join(
+                AgentEnvironment,
+                AgentEnvironment.id == HostedRuntimeState.environment_id,
+            )
+            .where(
+                HostedRuntimeState.environment_id == agent_id,
+                AgentEnvironment.user_id == owner.id,
+            )
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    existed = runtime_state is not None
+    if runtime_state is not None:
+        await db.delete(runtime_state)
+        queue_runtime_manifest_changed(db, agent.user_id, agent_id)
+    await _complete_mutation(
+        db,
+        operation="runtime_state.delete",
+        idempotency_key=idempotency_key,
+        request_hash=request_hash,
+        owner=body.owner,
+        owner_user_id=owner.id,
+        resource_type="hosted_runtime_state",
+        resource_id=str(agent_id),
+        action=action,
+        request=request,
+        response_status=status.HTTP_204_NO_CONTENT,
+        response_body=None,
+        environment_id=agent_id,
+        audit_details={"existed": existed},
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/auth/keys", response_model=ApiKeyCreated)
+async def platform_mint_api_key(
+    body: PlatformApiKeyCreate,
+    request: Request,
+    idempotency_key: IdempotencyKey,
+    _: None = Depends(require_admin_api_key),
+    db: AsyncSession = Depends(get_session),
+) -> ApiKeyCreated | Response:
+    action = "api_key.mint"
+    owner = await _resolve_owner(
+        db,
+        owner=body.owner,
+        resource_type="api_key",
+        resource_id=None,
+        action=action,
+        request=request,
+        idempotency_key=idempotency_key,
+    )
+    request_hash, replay = await _begin_mutation(
+        db,
+        operation="keys.mint",
+        idempotency_key=idempotency_key,
+        request_payload=body.model_dump(mode="json"),
+        owner=body.owner,
+        owner_user_id=owner.id,
+        resource_type="api_key",
+        resource_id=None,
+        action=action,
+        request=request,
+    )
+    if replay is not None:
+        return _replay_response(replay)
+    await _load_owned_agent(
+        db,
+        agent_id=body.environment_id,
+        owner=body.owner,
+        owner_user_id=owner.id,
+        action=action,
+        request=request,
+        idempotency_key=idempotency_key,
+    )
+    minted = await mint_api_key(
+        db,
+        user_id=owner.id,
+        label=body.label,
+        scopes=body.scopes,
+        environment_id=body.environment_id,
+        managed=True,
+        commit=False,
+    )
+    api_key = minted.api_key
+    response = ApiKeyCreated(
+        id=str(api_key.id),
+        label=api_key.label,
+        key_prefix=api_key.key_prefix,
+        created_at=api_key.created_at,
+        last_used_at=api_key.last_used_at,
+        expires_at=api_key.expires_at,
+        revoked_at=api_key.revoked_at,
+        raw_key=minted.raw_key,
+    )
+    await _complete_mutation(
+        db,
+        operation="keys.mint",
+        idempotency_key=idempotency_key,
+        request_hash=request_hash,
+        owner=body.owner,
+        owner_user_id=owner.id,
+        resource_type="api_key",
+        resource_id=str(api_key.id),
+        action=action,
+        request=request,
+        response_status=status.HTTP_200_OK,
+        response_body=response,
+        environment_id=body.environment_id,
+        audit_details={
+            "label": api_key.label,
+            "key_prefix": api_key.key_prefix,
+            "managed": api_key.managed,
+            "scopes": api_key.scopes,
+        },
+    )
+    return response
+
+
+@router.delete("/auth/keys/{key_id}", response_model=ApiKeyRevokeResponse)
+async def platform_revoke_api_key(
+    key_id: UUID,
+    body: PlatformMutationBody,
+    request: Request,
+    idempotency_key: IdempotencyKey,
+    _: None = Depends(require_admin_api_key),
+    db: AsyncSession = Depends(get_session),
+) -> ApiKeyRevokeResponse | Response:
+    action = "api_key.revoke"
+    owner = await _resolve_owner(
+        db,
+        owner=body.owner,
+        resource_type="api_key",
+        resource_id=str(key_id),
+        action=action,
+        request=request,
+        idempotency_key=idempotency_key,
+    )
+    request_hash, replay = await _begin_mutation(
+        db,
+        operation="keys.revoke",
+        idempotency_key=idempotency_key,
+        request_payload={"key_id": str(key_id), **body.model_dump(mode="json")},
+        owner=body.owner,
+        owner_user_id=owner.id,
+        resource_type="api_key",
+        resource_id=str(key_id),
+        action=action,
+        request=request,
+    )
+    if replay is not None:
+        return _replay_response(replay)
+    api_key = await _load_owned_key(
+        db,
+        key_id=key_id,
+        owner=body.owner,
+        owner_user_id=owner.id,
+        action=action,
+        request=request,
+        idempotency_key=idempotency_key,
+    )
+    already_revoked = api_key.revoked_at is not None
+    if not already_revoked:
+        api_key.revoked_at = datetime.now(UTC)
+    response = ApiKeyRevokeResponse(status="revoked")
+    await _complete_mutation(
+        db,
+        operation="keys.revoke",
+        idempotency_key=idempotency_key,
+        request_hash=request_hash,
+        owner=body.owner,
+        owner_user_id=owner.id,
+        resource_type="api_key",
+        resource_id=str(key_id),
+        action=action,
+        request=request,
+        response_status=status.HTTP_200_OK,
+        response_body=response,
+        environment_id=api_key.environment_id,
+        audit_details={"already_revoked": already_revoked},
+    )
+    if not already_revoked:
+        invalidate_api_key_auth_cache(api_key.id)
+    return response
+
+
+def _assign_runtime_state(
+    state: HostedRuntimeState,
+    body: PlatformRuntimeStateUpsert,
+) -> None:
+    state.deployment_id = body.deployment_id
+    state.app_id = body.app_id
+    state.instance_id = body.instance_id
+    state.generation = body.generation
+    state.cli_package_spec = body.cli_package_spec
+    state.locale = body.locale.model_dump()
+    state.system = body.system.model_dump(exclude_none=True, mode="json")
+    state.egress_engine = _optional_runtime_model(body.egress_engine)
+    state.runtimes = {
+        name: runtime.model_dump(exclude_none=True, mode="json")
+        for name, runtime in body.runtimes.items()
+    }
+    state.bridge = _optional_runtime_model(body.bridge)
+    state.live_sync = body.live_sync.model_dump(mode="json")
+    state.recovery = body.recovery.model_dump(mode="json")
+    state.egress_profiles = _optional_runtime_model(body.egress_profiles)
+    state.mcp = body.mcp
+    state.tools = body.tools
+
+
+def _optional_runtime_model(value: BaseModel | None) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    return value.model_dump(exclude_none=True, exclude_unset=True, mode="json")
+
+
+def _runtime_state_changed_fields(
+    state: HostedRuntimeState | None,
+    body: PlatformRuntimeStateUpsert,
+) -> list[str]:
+    fields = [
+        "deployment_id",
+        "app_id",
+        "instance_id",
+        "generation",
+        "cli_package_spec",
+        "locale",
+        "system",
+        "egress_engine",
+        "runtimes",
+        "bridge",
+        "live_sync",
+        "recovery",
+        "egress_profiles",
+        "mcp",
+        "tools",
+    ]
+    if state is None:
+        return fields
+    changed: list[str] = []
+    for field in fields:
+        if field == "locale":
+            body_value = body.locale.model_dump()
+        elif field == "system":
+            body_value = body.system.model_dump(exclude_none=True, mode="json")
+        elif field == "runtimes":
+            body_value = {
+                name: runtime.model_dump(exclude_none=True, mode="json")
+                for name, runtime in body.runtimes.items()
+            }
+        elif field in {"bridge", "egress_engine", "egress_profiles"}:
+            body_value = _optional_runtime_model(getattr(body, field))
+        elif field in {"live_sync", "recovery"}:
+            body_value = getattr(body, field).model_dump(mode="json")
+        else:
+            body_value = getattr(body, field)
+        if getattr(state, field) != body_value:
+            changed.append(field)
+    return changed

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -5,11 +5,22 @@ and are used by SaaS batch tooling + ops-side scripts. Kept in a
 separate file so they don't pollute user-facing schemas.
 """
 
+from __future__ import annotations
+
+import re
 from datetime import datetime
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator, model_validator
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    field_validator,
+    model_validator,
+)
 
 from app.schemas.ai_provider import AiProviderModel
 from app.schemas.runtime import (
@@ -29,6 +40,20 @@ AdminChannelProvider = Literal["telegram", "discord", "whatsapp", "imessage"]
 AdminChannelVisibility = Literal["private", "public"]
 AdminChannelStatus = Literal["active", "disabled"]
 _SUPPORTED_HOSTED_RUNTIMES = {"hermes", "openclaw"}
+_ADMIN_CLERK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def _validate_admin_clerk_id(value: str) -> str:
+    if value != value.strip() or not _ADMIN_CLERK_ID_RE.fullmatch(value):
+        raise ValueError("target_clerk_id must be a stable Clerk identifier")
+    return value
+
+
+AdminClerkId = Annotated[
+    str,
+    Field(min_length=1, max_length=200),
+    AfterValidator(_validate_admin_clerk_id),
+]
 
 
 class AdminEnvironmentCreate(BaseModel):
@@ -43,7 +68,7 @@ class AdminEnvironmentCreate(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    target_clerk_id: str
+    target_clerk_id: AdminClerkId
     environment_id: UUID | None = None
     machine_id: str
     machine_name: str
@@ -61,7 +86,7 @@ class AdminAgentCreate(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    target_clerk_id: str
+    target_clerk_id: AdminClerkId
     agent_id: UUID | None = None
     machine_id: str
     machine_name: str
@@ -74,8 +99,8 @@ class AdminApiKeyCreate(BaseModel):
     """Body for `POST /v1/admin/auth/keys` — mint an api_key on
     behalf of a user identified by Clerk id. The route resolves
     `target_clerk_id` to the internal `User.id` and then calls the
-    existing `mint_api_key` service, preserving the env-ownership
-    invariant the service enforces.
+    existing `mint_api_key` service, preserving its env-ownership
+    invariant.
 
     `environment_id` is optional — if set, the minted key is bound
     to that env (deploy-key semantics). If null, the key is unbound.
@@ -87,7 +112,9 @@ class AdminApiKeyCreate(BaseModel):
     everything.
     """
 
-    target_clerk_id: str
+    model_config = ConfigDict(extra="forbid")
+
+    target_clerk_id: AdminClerkId
     label: str
     environment_id: str | None = None
     scopes: list[str] | None = None
@@ -143,7 +170,7 @@ class AdminRuntimeStateUpsert(BaseModel):
         return value
 
     @model_validator(mode="after")
-    def _validate_runtime_bridge(self) -> "AdminRuntimeStateUpsert":
+    def _validate_runtime_bridge(self) -> AdminRuntimeStateUpsert:
         runtime = next(iter(self.runtimes))
         validate_hosted_runtime_bridge(runtime, self.bridge)
         return self
@@ -179,7 +206,7 @@ class AdminManagedAiProviderUpsert(BaseModel):
 
 class AdminManagedAiProviderResponse(BaseModel):
     owner_user_id: UUID
-    owner_clerk_id: str
+    owner_clerk_id: str | None
     provider_id: str
     api_mode: str
     runtime_env_name: str
@@ -253,7 +280,7 @@ class AdminChannelUpdate(BaseModel):
 class AdminChannelResponse(BaseModel):
     id: UUID
     owner_user_id: UUID
-    owner_clerk_id: str
+    owner_clerk_id: str | None
     provider: str
     name: str
     status: str

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -103,6 +103,7 @@ class AdminRuntimeStateUpsert(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    target_clerk_id: str | None = None
     deployment_id: str = Field(min_length=1, max_length=200)
     app_id: str | None = Field(default=None, min_length=1, max_length=200)
     instance_id: str = Field(min_length=1, max_length=200)

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -34,6 +34,7 @@ from app.schemas.runtime import (
     HostedRuntimeSystem,
     validate_clawdi_cli_package_spec,
     validate_hosted_runtime_bridge,
+    validate_no_plaintext_tool_secrets,
 )
 
 AdminChannelProvider = Literal["telegram", "discord", "whatsapp", "imessage"]
@@ -179,7 +180,7 @@ class AdminRuntimeStateUpsert(BaseModel):
     @classmethod
     def _validate_tool_desired_state(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
         if value is not None:
-            _reject_plaintext_tool_secret(value)
+            validate_no_plaintext_tool_secrets(value)
         return value
 
 
@@ -314,33 +315,3 @@ def _clean_channel_secret_values(value: dict[str, str] | None) -> dict[str, str]
             raise ValueError("secret values cannot be blank")
         cleaned[name] = secret
     return cleaned
-
-
-_FORBIDDEN_TOOL_SECRET_KEYS = {
-    "apikey",
-    "api_key",
-    "authorization",
-    "bearer",
-    "header",
-    "headers",
-    "password",
-    "secret",
-    "secrets",
-    "secretvalues",
-    "token",
-}
-
-
-def _reject_plaintext_tool_secret(value: Any, path: str = "") -> None:
-    if isinstance(value, dict):
-        for key, child in value.items():
-            normalized = str(key).replace("-", "_").lower()
-            if normalized in _FORBIDDEN_TOOL_SECRET_KEYS:
-                location = f" at {path}.{key}" if path else f" at {key}"
-                raise ValueError(
-                    f"mcp/tools desired state must not contain plaintext secrets{location}"
-                )
-            _reject_plaintext_tool_secret(child, f"{path}.{key}" if path else str(key))
-    elif isinstance(value, list):
-        for index, child in enumerate(value):
-            _reject_plaintext_tool_secret(child, f"{path}[{index}]")

--- a/backend/app/schemas/platform.py
+++ b/backend/app/schemas/platform.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from app.schemas.runtime import (
+    HostedEgressEngine,
+    HostedEgressProfiles,
+    HostedRuntimeBridge,
+    HostedRuntimeDesiredState,
+    HostedRuntimeLiveSync,
+    HostedRuntimeLocale,
+    HostedRuntimeRecovery,
+    HostedRuntimeSystem,
+    validate_clawdi_cli_package_spec,
+    validate_hosted_runtime_bridge,
+    validate_no_plaintext_tool_secrets,
+)
+
+PlatformOwnerKind = Literal["clerk", "partner_tenant"]
+PLATFORM_RUNTIME_KEY_SCOPES = (
+    "sessions:write",
+    "skills:read",
+    "skills:write",
+)
+
+_CLERK_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_PARTNER_TENANT_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
+_SUPPORTED_HOSTED_RUNTIMES = {"hermes", "openclaw"}
+
+
+class PlatformOwner(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: PlatformOwnerKind
+    ref: str = Field(min_length=1, max_length=255)
+
+    @model_validator(mode="after")
+    def _validate_ref(self) -> PlatformOwner:
+        pattern = _CLERK_REF_RE if self.kind == "clerk" else _PARTNER_TENANT_REF_RE
+        if pattern.fullmatch(self.ref) is None:
+            raise ValueError(f"invalid {self.kind} owner ref")
+        if self.kind == "clerk" and len(self.ref) > 200:
+            raise ValueError("clerk owner ref must be at most 200 characters")
+        return self
+
+
+class PlatformMutationBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    owner: PlatformOwner
+
+
+class PlatformAgentCreate(PlatformMutationBody):
+    agent_id: UUID
+    machine_id: str = Field(min_length=1, max_length=200)
+    machine_name: str = Field(min_length=1, max_length=200)
+    agent_type: str = Field(min_length=1, max_length=50)
+    agent_version: str | None = Field(default=None, max_length=50)
+    os_name: str = Field(default="linux", min_length=1, max_length=50)
+
+
+class PlatformApiKeyCreate(PlatformMutationBody):
+    label: str = Field(min_length=1, max_length=200)
+    environment_id: UUID
+    scopes: list[str] = Field(default_factory=lambda: list(PLATFORM_RUNTIME_KEY_SCOPES))
+
+    @field_validator("scopes")
+    @classmethod
+    def _validate_scopes(cls, value: list[str]) -> list[str]:
+        if not value:
+            raise ValueError("scopes cannot be empty")
+        if len(value) != len(set(value)):
+            raise ValueError("scopes cannot contain duplicates")
+        unknown = sorted(set(value) - set(PLATFORM_RUNTIME_KEY_SCOPES))
+        if unknown:
+            raise ValueError(f"scopes exceed platform runtime ceiling: {', '.join(unknown)}")
+        return [scope for scope in PLATFORM_RUNTIME_KEY_SCOPES if scope in value]
+
+
+class PlatformRuntimeStateUpsert(PlatformMutationBody):
+    deployment_id: str = Field(min_length=1, max_length=200)
+    app_id: str | None = Field(default=None, min_length=1, max_length=200)
+    instance_id: str = Field(min_length=1, max_length=200)
+    generation: int = Field(ge=0)
+    cli_package_spec: str = Field(min_length=1, max_length=200)
+    locale: HostedRuntimeLocale
+    system: HostedRuntimeSystem
+    egress_engine: HostedEgressEngine | None = None
+    runtimes: dict[str, HostedRuntimeDesiredState]
+    bridge: HostedRuntimeBridge | None = None
+    live_sync: HostedRuntimeLiveSync
+    recovery: HostedRuntimeRecovery
+    egress_profiles: HostedEgressProfiles | None = None
+    mcp: dict[str, Any] | None = None
+    tools: dict[str, Any] | None = None
+
+    @field_validator("cli_package_spec")
+    @classmethod
+    def _validate_cli_package_spec(cls, value: str) -> str:
+        return validate_clawdi_cli_package_spec(value)
+
+    @field_validator("runtimes")
+    @classmethod
+    def _validate_runtimes(
+        cls,
+        value: dict[str, HostedRuntimeDesiredState],
+    ) -> dict[str, HostedRuntimeDesiredState]:
+        if not value:
+            raise ValueError("runtimes cannot be empty")
+        if "channels" in value:
+            raise ValueError("channels are not runtime desired state")
+        unknown = sorted(set(value) - _SUPPORTED_HOSTED_RUNTIMES)
+        if unknown:
+            raise ValueError(f"unsupported runtime desired state: {', '.join(unknown)}")
+        if len(value) != 1:
+            raise ValueError("runtimes must contain exactly one enabled runtime")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_runtime_bridge(self) -> PlatformRuntimeStateUpsert:
+        runtime = next(iter(self.runtimes))
+        validate_hosted_runtime_bridge(runtime, self.bridge)
+        return self
+
+    @field_validator("mcp", "tools")
+    @classmethod
+    def _validate_tool_desired_state(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
+        if value is not None:
+            validate_no_plaintext_tool_secrets(value)
+        return value
+
+
+class PlatformRuntimeStateResponse(BaseModel):
+    environment_id: UUID
+    deployment_id: str
+    instance_id: str
+    generation: int

--- a/backend/app/schemas/runtime.py
+++ b/backend/app/schemas/runtime.py
@@ -32,6 +32,37 @@ _EXACT_SEMVER_PATTERN = re.compile(
     rf"(?:\.{_SEMVER_PRERELEASE_IDENTIFIER})*))?$"
 )
 _AGENT_V2_MANIFEST_MINIMUM_CLI_VERSION = "0.12.10-beta.51"
+_FORBIDDEN_TOOL_SECRET_KEYS = {
+    "apikey",
+    "api_key",
+    "authorization",
+    "bearer",
+    "header",
+    "headers",
+    "password",
+    "secret",
+    "secrets",
+    "secretvalues",
+    "token",
+}
+
+
+def validate_no_plaintext_tool_secrets(value: object, path: str = "") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            normalized = str(key).replace("-", "_").lower()
+            if normalized in _FORBIDDEN_TOOL_SECRET_KEYS:
+                location = f" at {path}.{key}" if path else f" at {key}"
+                raise ValueError(
+                    f"mcp/tools desired state must not contain plaintext secrets{location}"
+                )
+            validate_no_plaintext_tool_secrets(
+                child,
+                f"{path}.{key}" if path else str(key),
+            )
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            validate_no_plaintext_tool_secrets(child, f"{path}[{index}]")
 
 
 def _parse_exact_semver(value: str) -> tuple[int, int, int, tuple[str, ...]] | None:

--- a/backend/app/services/agent_environments.py
+++ b/backend/app/services/agent_environments.py
@@ -56,6 +56,7 @@ async def register_agent_environment(
     sort_order: int,
     environment_id: UUID | None = None,
     registration_key: str | None = None,
+    commit: bool = True,
 ) -> AgentEnvironmentRegistration:
     """Create or refresh an agent row.
 
@@ -74,15 +75,14 @@ async def register_agent_environment(
         existing = (
             await db.execute(
                 select(AgentEnvironment)
-                .where(AgentEnvironment.id == environment_id)
+                .where(
+                    AgentEnvironment.id == environment_id,
+                    AgentEnvironment.user_id == user_id,
+                )
                 .with_for_update()
             )
         ).scalar_one_or_none()
         if existing is not None:
-            if existing.user_id != user_id:
-                raise AgentEnvironmentIdConflict(
-                    f"environment {environment_id} is owned by another user"
-                )
             await _refresh_agent_environment(
                 db,
                 existing,
@@ -94,8 +94,18 @@ async def register_agent_environment(
                 os_name=os_name,
                 registration_key=registration_key,
             )
-            await db.commit()
+            if commit:
+                await db.commit()
+            else:
+                await db.flush()
             return AgentEnvironmentRegistration(env=existing, created=False)
+        owner_exists = await db.scalar(
+            select(AgentEnvironment.id).where(AgentEnvironment.id == environment_id)
+        )
+        if owner_exists is not None:
+            raise AgentEnvironmentIdConflict(
+                f"environment {environment_id} is owned by another user"
+            )
     elif registration_key is not None:
         existing = (
             await db.execute(
@@ -119,7 +129,10 @@ async def register_agent_environment(
                 os_name=os_name,
                 registration_key=registration_key,
             )
-            await db.commit()
+            if commit:
+                await db.commit()
+            else:
+                await db.flush()
             return AgentEnvironmentRegistration(env=existing, created=False)
 
     assigned_default_name = None
@@ -153,7 +166,10 @@ async def register_agent_environment(
         db.add(env)
         await db.flush()
         project.origin_environment_id = env.id
-        await db.commit()
+        if commit:
+            await db.commit()
+        else:
+            await db.flush()
         await db.refresh(env)
         return AgentEnvironmentRegistration(env=env, created=True)
     except IntegrityError:
@@ -161,17 +177,23 @@ async def register_agent_environment(
         if environment_id is not None:
             winner = (
                 await db.execute(
-                    select(AgentEnvironment).where(AgentEnvironment.id == environment_id)
+                    select(AgentEnvironment).where(
+                        AgentEnvironment.id == environment_id,
+                        AgentEnvironment.user_id == user_id,
+                    )
                 )
             ).scalar_one_or_none()
             if winner is None:
+                owner_exists = await db.scalar(
+                    select(AgentEnvironment.id).where(AgentEnvironment.id == environment_id)
+                )
+                if owner_exists is not None:
+                    raise AgentEnvironmentIdConflict(
+                        f"environment {environment_id} is owned by another user"
+                    ) from None
                 raise AgentEnvironmentIdConflict(
                     f"environment {environment_id} could not be registered"
                 ) from None
-            if winner.user_id != user_id:
-                raise AgentEnvironmentIdConflict(
-                    f"environment {environment_id} is owned by another user"
-                )
             await _refresh_agent_environment(
                 db,
                 winner,
@@ -183,7 +205,10 @@ async def register_agent_environment(
                 os_name=os_name,
                 registration_key=registration_key,
             )
-            await db.commit()
+            if commit:
+                await db.commit()
+            else:
+                await db.flush()
             return AgentEnvironmentRegistration(env=winner, created=False)
         if registration_key is None:
             raise

--- a/backend/app/services/api_key.py
+++ b/backend/app/services/api_key.py
@@ -53,6 +53,7 @@ async def mint_api_key(
     scopes: list[str] | None = None,
     environment_id: UUID | None = None,
     managed: bool = False,
+    commit: bool = True,
 ) -> MintedKey:
     """Create a new ApiKey row.
 
@@ -98,6 +99,9 @@ async def mint_api_key(
         managed=managed,
     )
     db.add(api_key)
-    await db.commit()
+    if commit:
+        await db.commit()
+    else:
+        await db.flush()
     await db.refresh(api_key)
     return MintedKey(api_key=api_key, raw_key=raw)

--- a/backend/app/services/platform_contract.py
+++ b/backend/app/services/platform_contract.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+from fastapi.encoders import jsonable_encoder
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.platform_idempotency import PlatformMutationIdempotency
+from app.services.vault_crypto import decrypt, encrypt
+
+
+@dataclass(frozen=True)
+class PlatformReplay:
+    status_code: int
+    body: dict[str, Any]
+
+
+def platform_request_hash(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        jsonable_encoder(payload),
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+async def lock_platform_idempotency(
+    db: AsyncSession,
+    *,
+    operation: str,
+    idempotency_key: str,
+) -> PlatformMutationIdempotency | None:
+    lock_name = f"platform-idempotency:{operation}:{idempotency_key}"
+    await db.execute(select(func.pg_advisory_xact_lock(func.hashtextextended(lock_name, 0))))
+    return (
+        await db.execute(
+            select(PlatformMutationIdempotency).where(
+                PlatformMutationIdempotency.operation == operation,
+                PlatformMutationIdempotency.idempotency_key == idempotency_key,
+            )
+        )
+    ).scalar_one_or_none()
+
+
+def read_platform_replay(row: PlatformMutationIdempotency) -> PlatformReplay:
+    body = json.loads(decrypt(row.encrypted_response, row.response_nonce))
+    if not isinstance(body, dict):
+        raise ValueError("stored platform idempotency response is not an object")
+    return PlatformReplay(status_code=row.response_status, body=body)
+
+
+def store_platform_response(
+    db: AsyncSession,
+    *,
+    operation: str,
+    idempotency_key: str,
+    request_hash: str,
+    owner_user_id: UUID,
+    resource_type: str,
+    resource_id: str | None,
+    response_status: int,
+    response_body: dict[str, Any],
+) -> PlatformMutationIdempotency:
+    serialized = json.dumps(
+        jsonable_encoder(response_body),
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    ciphertext, nonce = encrypt(serialized)
+    row = PlatformMutationIdempotency(
+        operation=operation,
+        idempotency_key=idempotency_key,
+        request_hash=request_hash,
+        owner_user_id=owner_user_id,
+        resource_type=resource_type,
+        resource_id=resource_id,
+        response_status=response_status,
+        encrypted_response=ciphertext,
+        response_nonce=nonce,
+    )
+    db.add(row)
+    return row

--- a/backend/app/services/user_provisioning.py
+++ b/backend/app/services/user_provisioning.py
@@ -1,6 +1,6 @@
 """Shared lazy-create flow for `users` + their Personal project.
 
-Two callers hit this code path:
+Clerk callers hit this code path:
 1. `_auth_via_clerk_jwt` (auth.py) — first login from cloud.clawdi.ai
    directly. Has email/name from the JWT, commits at the end.
 2. `_resolve_or_create_user` (admin.py) — first interaction is via
@@ -16,6 +16,9 @@ The race semantics and project invariant MUST stay identical across
 callers — downstream resolvers assume every user has a Personal
 project. Centralizing here means there's one place to maintain that
 contract.
+
+PartnerTenant provisioning uses a separate stable reference and never creates
+or accepts a synthetic Clerk id.
 """
 
 import logging
@@ -26,7 +29,11 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.project import PROJECT_KIND_PERSONAL, Project
-from app.models.user import User
+from app.models.user import (
+    PRINCIPAL_KIND_CLERK,
+    PRINCIPAL_KIND_PARTNER_TENANT,
+    User,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +80,14 @@ async def lazy_create_user_with_personal_project(
         HTTPException 500 — Personal project insert failed. Bizarre
         states only (partial unique index, mid-flush connection drop).
     """
-    new_user = User(clerk_id=clerk_id, email=email, name=name, avatar_url=avatar_url)
+    new_user = User(
+        clerk_id=clerk_id,
+        principal_kind=PRINCIPAL_KIND_CLERK,
+        partner_tenant_ref=None,
+        email=email,
+        name=name,
+        avatar_url=avatar_url,
+    )
     db.add(new_user)
 
     # User flush: the ONLY racy point. `users.clerk_id` is unique, so
@@ -94,12 +108,68 @@ async def lazy_create_user_with_personal_project(
             ) from None
         return target
 
-    # Personal project insert. Cannot race on `user_id` (just generated)
-    # so a partial-unique kind=personal index is the only realistic
-    # failure mode. Wrap in try/except so a SQLAlchemy traceback
-    # doesn't leak to the client as a raw 500.
+    await _create_personal_project(
+        db,
+        user=new_user,
+        identity_log=f"clerk_id={clerk_id}",
+    )
+    return new_user
+
+
+async def lazy_create_partner_user_with_personal_project(
+    db: AsyncSession,
+    *,
+    partner_tenant_ref: str,
+    race_loser_status: int,
+) -> User:
+    """Insert a PartnerTenant-owned User row + Personal project, race-safe."""
+    new_user = User(
+        clerk_id=None,
+        principal_kind=PRINCIPAL_KIND_PARTNER_TENANT,
+        partner_tenant_ref=partner_tenant_ref,
+        email=None,
+        name=None,
+        avatar_url=None,
+    )
+    db.add(new_user)
+
+    try:
+        await db.flush()
+    except IntegrityError:
+        await db.rollback()
+        target = (
+            await db.execute(
+                select(User).where(
+                    User.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT,
+                    User.partner_tenant_ref == partner_tenant_ref,
+                )
+            )
+        ).scalar_one_or_none()
+        if target is None:
+            raise HTTPException(
+                race_loser_status,
+                "could not create or load partner tenant user",
+            ) from None
+        return target
+
+    await _create_personal_project(
+        db,
+        user=new_user,
+        identity_log=f"partner_tenant_ref={partner_tenant_ref}",
+    )
+    return new_user
+
+
+async def _create_personal_project(
+    db: AsyncSession,
+    *,
+    user: User,
+    identity_log: str,
+) -> None:
+    # Cannot race on `user_id` (just generated), so a partial-unique
+    # kind=personal index is the only realistic failure mode.
     personal = Project(
-        user_id=new_user.id,
+        user_id=user.id,
         name="Personal",
         slug="personal",
         kind=PROJECT_KIND_PERSONAL,
@@ -109,13 +179,12 @@ async def lazy_create_user_with_personal_project(
         await db.flush()
     except Exception:
         logger.exception(
-            "personal_project_create_failed clerk_id=%s user_id=%s",
-            clerk_id,
-            new_user.id,
+            "personal_project_create_failed %s user_id=%s",
+            identity_log,
+            user.id,
         )
         await db.rollback()
         raise HTTPException(
             status.HTTP_500_INTERNAL_SERVER_ERROR,
             "internal server error",
         ) from None
-    return new_user

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -74,6 +74,63 @@ async def test_admin_mint_rejects_wrong_key(admin_client, seed_user):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "target_clerk_id",
+    ["", " user_123", "user 123", "partner:phala:team_123", "x" * 201],
+)
+async def test_admin_mint_rejects_invalid_target_clerk_id(admin_client, target_clerk_id):
+    response = await admin_client.post(
+        "/v1/admin/auth/keys",
+        headers=_AUTH,
+        json={"target_clerk_id": target_clerk_id, "label": "invalid-target"},
+    )
+
+    assert response.status_code == 422, response.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        ("/v1/admin/auth/keys", {"label": "partner-runtime"}),
+        (
+            "/v1/admin/agents",
+            {
+                "agent_id": "de9e247b-1c60-4f8a-ad7b-537b16b247a8",
+                "machine_id": "partner-agent",
+                "machine_name": "Partner Agent",
+                "agent_type": "openclaw",
+            },
+        ),
+    ],
+)
+async def test_legacy_admin_rejects_partner_principal_fields(
+    admin_client,
+    seed_user,
+    path,
+    payload,
+):
+    response = await admin_client.post(
+        path,
+        headers=_AUTH,
+        json={
+            "target_clerk_id": seed_user.clerk_id,
+            "principal_kind": "partner_tenant",
+            "partner_tenant_ref": "phala_cloud:team_123",
+            **payload,
+        },
+    )
+
+    assert response.status_code == 422, response.text
+    extra_fields = {
+        error["loc"][-1]
+        for error in response.json()["detail"]
+        if error["type"] == "extra_forbidden"
+    }
+    assert extra_fields == {"principal_kind", "partner_tenant_ref"}
+
+
+@pytest.mark.asyncio
 async def test_admin_endpoints_disabled_when_unset(db_session, seed_user):
     """If `settings.admin_api_key` is empty, endpoints return 503
     regardless of header. Default OSS posture: admin endpoints are
@@ -289,6 +346,8 @@ async def test_admin_mint_lazy_creates_user(admin_client, db_session):
     user = (
         await db_session.execute(select(User).where(User.clerk_id == novel_clerk_id))
     ).scalar_one()
+    assert user.principal_kind == "clerk"
+    assert user.partner_tenant_ref is None
     assert user.email is None
     assert user.name is None
 

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -210,6 +210,43 @@ async def test_admin_mint_accepts_arbitrary_scopes(admin_client, db_session, see
 
 
 @pytest.mark.asyncio
+async def test_admin_mint_api_key_writes_control_plane_audit(admin_client, db_session, seed_user):
+    from sqlalchemy import select
+
+    from app.models.audit import ControlPlaneAuditEvent
+
+    response = await admin_client.post(
+        "/v1/admin/auth/keys",
+        headers=_AUTH,
+        json={
+            "target_clerk_id": seed_user.clerk_id,
+            "label": "audit-mint",
+            "managed": True,
+        },
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    event = (
+        await db_session.execute(
+            select(ControlPlaneAuditEvent).where(
+                ControlPlaneAuditEvent.action == "api_key.mint",
+                ControlPlaneAuditEvent.resource_id == body["id"],
+            )
+        )
+    ).scalar_one()
+    assert event.actor_type == "admin"
+    assert event.resource_type == "api_key"
+    assert event.target_user_id == seed_user.id
+    assert event.source == "api.admin"
+    assert event.details["label"] == "audit-mint"
+    assert event.details["key_prefix"] == body["key_prefix"]
+    assert event.details["managed"] is True
+    assert event.details["has_environment_binding"] is False
+    assert body["raw_key"] not in str(event.details)
+
+
+@pytest.mark.asyncio
 async def test_admin_mint_lazy_creates_user(admin_client, db_session):
     """First-time deploy path: a user who's never visited cloud-api
     directly (no row yet) clicks Deploy on the upstream SaaS
@@ -439,6 +476,43 @@ async def test_admin_revoke_happy_path(admin_client, db_session, seed_user):
     db_session.expire_all()
     row = (await db_session.execute(select(ApiKey).where(ApiKey.id == key_id))).scalar_one()
     assert row.revoked_at is not None
+
+
+@pytest.mark.asyncio
+async def test_admin_revoke_api_key_writes_control_plane_audit(admin_client, db_session, seed_user):
+    from sqlalchemy import select
+
+    from app.models.audit import ControlPlaneAuditEvent
+
+    minted_response = await admin_client.post(
+        "/v1/admin/auth/keys",
+        headers=_AUTH,
+        json={"target_clerk_id": seed_user.clerk_id, "label": "audit-revoke"},
+    )
+    assert minted_response.status_code == 200, minted_response.text
+    minted = minted_response.json()
+
+    response = await admin_client.delete(
+        f"/v1/admin/auth/keys/{minted['id']}",
+        headers=_AUTH,
+    )
+    assert response.status_code == 200, response.text
+
+    event = (
+        await db_session.execute(
+            select(ControlPlaneAuditEvent).where(
+                ControlPlaneAuditEvent.action == "api_key.revoke",
+                ControlPlaneAuditEvent.resource_id == minted["id"],
+            )
+        )
+    ).scalar_one()
+    assert event.actor_type == "admin"
+    assert event.resource_type == "api_key"
+    assert event.target_user_id == seed_user.id
+    assert event.source == "api.admin"
+    assert event.details["label"] == "audit-revoke"
+    assert event.details["key_prefix"] == minted["key_prefix"]
+    assert minted["raw_key"] not in str(event.details)
 
 
 @pytest.mark.asyncio
@@ -1321,6 +1395,7 @@ async def test_admin_delete_env_removes_environment_and_orphans_sessions(
 
     from sqlalchemy import select
 
+    from app.models.audit import ControlPlaneAuditEvent
     from app.models.session import AgentEnvironment, Session
 
     created = await admin_client.post(
@@ -1356,12 +1431,97 @@ async def test_admin_delete_env_removes_environment_and_orphans_sessions(
     assert env is None
     await db_session.refresh(session_row)
     assert session_row.environment_id is None
+    event = (
+        await db_session.execute(
+            select(ControlPlaneAuditEvent).where(
+                ControlPlaneAuditEvent.action == "agent_environment.delete",
+                ControlPlaneAuditEvent.resource_id == str(env_id),
+            )
+        )
+    ).scalar_one()
+    assert event.actor_type == "admin"
+    assert event.resource_type == "agent_environment"
+    assert event.target_user_id == seed_user.id
+    assert event.source == "api.admin"
+    assert event.details["agent_type"] == "codex"
+    assert event.details["machine_id"] == "delete-machine-1"
 
     deleted_again = await admin_client.delete(
         f"/api/admin/environments/{env_id}",
         headers=_AUTH,
     )
     assert deleted_again.status_code == 404
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path_template",
+    ["/v1/admin/agents/{env_id}", "/v1/admin/environments/{env_id}"],
+)
+async def test_admin_delete_environment_accepts_matching_optional_owner(
+    admin_client, db_session, seed_user, path_template
+):
+    import uuid as _uuid
+
+    from app.models.session import AgentEnvironment
+    from tests.conftest import create_env_with_project
+
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"delete-owner-match-{_uuid.uuid4().hex[:8]}",
+        machine_name="delete-owner-match-pod",
+        agent_type="codex",
+    )
+
+    response = await admin_client.delete(
+        path_template.format(env_id=env.id),
+        headers=_AUTH,
+        params={"target_clerk_id": seed_user.clerk_id},
+    )
+
+    assert response.status_code == 204, response.text
+    assert await db_session.get(AgentEnvironment, env.id) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path_template",
+    ["/v1/admin/agents/{env_id}", "/v1/admin/environments/{env_id}"],
+)
+async def test_admin_delete_environment_rejects_mismatched_optional_owner(
+    admin_client, db_session, seed_user, path_template
+):
+    import uuid as _uuid
+
+    from app.models.session import AgentEnvironment
+    from app.models.user import User
+    from tests.conftest import create_env_with_project
+
+    other = User(
+        clerk_id=f"other_delete_{_uuid.uuid4().hex[:8]}",
+        email="other-delete@x.dev",
+        name="Other Delete",
+    )
+    db_session.add(other)
+    await db_session.commit()
+    await db_session.refresh(other)
+    env = await create_env_with_project(
+        db_session,
+        user_id=other.id,
+        machine_id=f"delete-owner-mismatch-{_uuid.uuid4().hex[:8]}",
+        machine_name="delete-owner-mismatch-pod",
+        agent_type="codex",
+    )
+
+    response = await admin_client.delete(
+        path_template.format(env_id=env.id),
+        headers=_AUTH,
+        params={"target_clerk_id": seed_user.clerk_id},
+    )
+
+    assert response.status_code == 403, response.text
+    assert await db_session.get(AgentEnvironment, env.id) is not None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_agent_v2_runtime_contract_migration.py
+++ b/backend/tests/test_agent_v2_runtime_contract_migration.py
@@ -14,8 +14,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 REVISION = "d8f2a1c4b6e9"
-HEAD_REVISION = "a26c40c6965e"
-HEAD_DOWN_REVISION = REVISION
+HEAD_REVISION = "f3a1c7d9e2b4"
+HEAD_DOWN_REVISION = "a26c40c6965e"
 MIGRATION_FILENAME = f"{REVISION}_finalize_agent_v2_runtime_contract.py"
 
 

--- a/backend/tests/test_agent_v2_runtime_contract_migration.py
+++ b/backend/tests/test_agent_v2_runtime_contract_migration.py
@@ -14,6 +14,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 REVISION = "d8f2a1c4b6e9"
+HEAD_REVISION = "a26c40c6965e"
+HEAD_DOWN_REVISION = REVISION
 MIGRATION_FILENAME = f"{REVISION}_finalize_agent_v2_runtime_contract.py"
 
 
@@ -35,7 +37,8 @@ def test_agent_v2_runtime_contract_migration_is_single_head() -> None:
     config.set_main_option("script_location", str(backend_dir / "alembic"))
     scripts = ScriptDirectory.from_config(config)
 
-    assert scripts.get_heads() == [REVISION]
+    assert scripts.get_heads() == [HEAD_REVISION]
+    assert scripts.get_revision(HEAD_REVISION).down_revision == HEAD_DOWN_REVISION
     assert scripts.get_revision(REVISION).down_revision == "c4e8f1a2b3d5"
 
 

--- a/backend/tests/test_api_version_alias.py
+++ b/backend/tests/test_api_version_alias.py
@@ -1,9 +1,9 @@
 """Canonical /v1 routing and the legacy /api alias.
 
-Every route is mounted canonically under /v1 and aliased under /api for
-clients built before the versioned-prefix migration. The alias must keep
-serving until old clients rotate; the OpenAPI schema (which the web/CLI
-typed-client codegen consumes) must only advertise /v1.
+Legacy routes are mounted canonically under /v1 and aliased under /api for
+clients built before the versioned-prefix migration. New contracts are
+canonical-only. The OpenAPI schema (which the web/CLI typed-client codegen
+consumes) must only advertise /v1.
 """
 
 import httpx
@@ -22,10 +22,14 @@ def _routes_by_path() -> dict[str, set[str]]:
     return routes
 
 
-def test_every_v1_route_has_api_legacy_alias():
+def test_every_legacy_v1_route_has_api_alias():
     routes = _routes_by_path()
     v1_paths = [
-        path for path in routes if path.startswith("/v1/") and path != "/v1/runtime/manifest"
+        path
+        for path in routes
+        if path.startswith("/v1/")
+        and path != "/v1/runtime/manifest"
+        and not path.startswith("/v1/platform/")
     ]
     assert v1_paths, "expected /v1 routes to be mounted"
     missing = [

--- a/backend/tests/test_auth_email_rebind.py
+++ b/backend/tests/test_auth_email_rebind.py
@@ -166,6 +166,44 @@ async def test_rebind_with_no_email_match_creates_fresh_user(db_session, signing
     await db_session.commit()
 
 
+@pytest.mark.asyncio
+async def test_rebind_excludes_partner_tenant_user(db_session, signing_key, monkeypatch):
+    from app.models.user import PRINCIPAL_KIND_PARTNER_TENANT, User
+    from app.services.user_provisioning import lazy_create_partner_user_with_personal_project
+
+    monkeypatch.setattr(settings, "enable_snapshot_email_rebind", True)
+    email = f"partner_{uuid.uuid4().hex[:8]}@example.test"
+    partner_tenant_ref = f"phala_cloud:team_{uuid.uuid4().hex[:12]}"
+    partner_user = await lazy_create_partner_user_with_personal_project(
+        db_session,
+        partner_tenant_ref=partner_tenant_ref,
+        race_loser_status=500,
+    )
+    partner_user.email = email
+    await db_session.commit()
+    partner_user_id = partner_user.id
+
+    token = _sign(
+        signing_key,
+        sub=f"new_{uuid.uuid4().hex[:8]}",
+        email=email,
+    )
+    ctx = await _auth_via_clerk_jwt(token, db_session)
+
+    assert ctx is not None
+    assert ctx.user.id != partner_user_id
+    assert ctx.user.principal_kind == "clerk"
+    persisted_partner = await db_session.get(User, partner_user_id)
+    assert persisted_partner is not None
+    assert persisted_partner.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT
+    assert persisted_partner.clerk_id is None
+    assert persisted_partner.partner_tenant_ref == partner_tenant_ref
+
+    await db_session.delete(ctx.user)
+    await db_session.delete(persisted_partner)
+    await db_session.commit()
+
+
 # ---------------------------------------------------------------------------
 # Rebind enabled — fail-closed paths
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_platform_endpoints.py
+++ b/backend/tests/test_platform_endpoints.py
@@ -1,0 +1,828 @@
+from __future__ import annotations
+
+import hashlib
+import uuid
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport
+from sqlalchemy import func, select
+
+from app.core.config import settings
+from app.core.database import get_session
+from app.main import app
+from app.models.api_key import ApiKey
+from app.models.audit import ControlPlaneAuditEvent
+from app.models.hosted_runtime import HostedRuntimeState
+from app.models.platform_idempotency import PlatformMutationIdempotency
+from app.models.session import AgentEnvironment
+from app.models.user import PRINCIPAL_KIND_PARTNER_TENANT, User
+from app.schemas.platform import PLATFORM_RUNTIME_KEY_SCOPES
+from app.services.user_provisioning import lazy_create_partner_user_with_personal_project
+from tests.conftest import create_env_with_project
+
+_ADMIN_KEY = "test-platform-admin-secret"
+_ADMIN_AUTH = {"X-Admin-Key": _ADMIN_KEY}
+_TEST_CLI_PACKAGE_SPEC = "clawdi@0.12.10-beta.51"
+_TEST_LOCALE = {"language": "en", "timezone": "America/Los_Angeles"}
+_TEST_SYSTEM = {
+    "user": "clawdi",
+    "home": "/home/clawdi",
+    "workspace": "/home/clawdi/clawdi",
+    "persistentPaths": ["/home/clawdi"],
+}
+_TEST_RUNTIME_PATHS = {
+    "home": "/home/clawdi",
+    "workspace": "/home/clawdi/clawdi",
+}
+
+
+@pytest_asyncio.fixture
+async def platform_client(db_session, seed_user) -> AsyncIterator[httpx.AsyncClient]:
+    async def _override_get_session():
+        yield db_session
+
+    original_admin_key = settings.admin_api_key
+    settings.admin_api_key = _ADMIN_KEY
+    app.dependency_overrides[get_session] = _override_get_session
+    try:
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            yield client
+    finally:
+        app.dependency_overrides.clear()
+        settings.admin_api_key = original_admin_key
+
+
+def _headers(key: str, *, request_id: str | None = None) -> dict[str, str]:
+    headers = {**_ADMIN_AUTH, "Idempotency-Key": key}
+    if request_id is not None:
+        headers["X-Request-ID"] = request_id
+    return headers
+
+
+def _clerk_owner(user: User) -> dict[str, str]:
+    assert user.clerk_id is not None
+    return {"kind": "clerk", "ref": user.clerk_id}
+
+
+def _agent_body(owner: dict[str, str], agent_id: uuid.UUID) -> dict[str, object]:
+    return {
+        "owner": owner,
+        "agent_id": str(agent_id),
+        "machine_id": f"machine-{agent_id.hex[:8]}",
+        "machine_name": "platform-agent",
+        "agent_type": "openclaw",
+        "agent_version": "1.0.0",
+        "os_name": "linux",
+    }
+
+
+def _runtime_payload(agent_id: uuid.UUID) -> dict[str, object]:
+    return {
+        "deployment_id": "deployment-1",
+        "app_id": "app-1",
+        "instance_id": "instance-1",
+        "generation": 1,
+        "cli_package_spec": _TEST_CLI_PACKAGE_SPEC,
+        "locale": _TEST_LOCALE,
+        "system": _TEST_SYSTEM,
+        "runtimes": {
+            "openclaw": {
+                "enabled": True,
+                "provider_ids": ["clawdi-managed-v2"],
+                "primary_model": {
+                    "provider_id": "clawdi-managed-v2",
+                    "model": "gpt-5.5",
+                },
+                "install": {"source": "official"},
+                "run": {"args": ["gateway", "run"]},
+                "services": {},
+                "paths": _TEST_RUNTIME_PATHS,
+            }
+        },
+        "live_sync": {
+            "enabled": True,
+            "agents": [
+                {
+                    "agentType": "openclaw",
+                    "environmentId": str(agent_id),
+                }
+            ],
+        },
+        "recovery": {"cacheManifest": True, "allowOfflineBoot": True},
+    }
+
+
+def _runtime_body(owner: dict[str, str], agent_id: uuid.UUID) -> dict[str, object]:
+    return {"owner": owner, **_runtime_payload(agent_id)}
+
+
+async def _create_platform_agent(
+    client: httpx.AsyncClient,
+    owner: dict[str, str],
+    agent_id: uuid.UUID,
+    *,
+    key: str,
+) -> httpx.Response:
+    return await client.post(
+        "/v1/platform/agents",
+        headers=_headers(key),
+        json=_agent_body(owner, agent_id),
+    )
+
+
+@pytest.mark.asyncio
+async def test_platform_routes_require_admin_key(platform_client, seed_user):
+    response = await platform_client.post(
+        "/v1/platform/agents",
+        headers={"Idempotency-Key": "no-admin-key"},
+        json=_agent_body(_clerk_owner(seed_user), uuid.uuid4()),
+    )
+
+    assert response.status_code == 401, response.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "path", "body"),
+    [
+        (
+            "POST",
+            "/v1/platform/agents",
+            {
+                "agent_id": str(uuid.uuid4()),
+                "machine_id": "missing-owner",
+                "machine_name": "missing-owner",
+                "agent_type": "openclaw",
+            },
+        ),
+        ("DELETE", f"/v1/platform/agents/{uuid.uuid4()}", {}),
+        (
+            "PUT",
+            f"/v1/platform/agents/{uuid.uuid4()}/runtime-state",
+            _runtime_payload(uuid.uuid4()),
+        ),
+        ("DELETE", f"/v1/platform/agents/{uuid.uuid4()}/runtime-state", {}),
+        (
+            "POST",
+            "/v1/platform/auth/keys",
+            {
+                "label": "missing-owner",
+                "environment_id": str(uuid.uuid4()),
+                "scopes": list(PLATFORM_RUNTIME_KEY_SCOPES),
+            },
+        ),
+        ("DELETE", f"/v1/platform/auth/keys/{uuid.uuid4()}", {}),
+    ],
+)
+async def test_platform_mutations_require_owner(platform_client, method, path, body):
+    response = await platform_client.request(
+        method,
+        path,
+        headers=_headers(f"missing-owner-{uuid.uuid4()}"),
+        json=body,
+    )
+
+    assert response.status_code == 422, response.text
+    assert any(error["loc"][-1] == "owner" for error in response.json()["detail"])
+
+
+@pytest.mark.asyncio
+async def test_platform_mutations_require_idempotency_key(platform_client, seed_user):
+    response = await platform_client.post(
+        "/v1/platform/agents",
+        headers=_ADMIN_AUTH,
+        json=_agent_body(_clerk_owner(seed_user), uuid.uuid4()),
+    )
+
+    assert response.status_code == 422, response.text
+    assert any(error["loc"][-1] == "Idempotency-Key" for error in response.json()["detail"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "path", "body"),
+    [
+        (
+            "POST",
+            "/v1/platform/agents",
+            {
+                "agent_id": str(uuid.uuid4()),
+                "machine_id": "unknown-owner",
+                "machine_name": "unknown-owner",
+                "agent_type": "openclaw",
+            },
+        ),
+        ("DELETE", f"/v1/platform/agents/{uuid.uuid4()}", {}),
+        (
+            "PUT",
+            f"/v1/platform/agents/{uuid.uuid4()}/runtime-state",
+            _runtime_payload(uuid.uuid4()),
+        ),
+        ("DELETE", f"/v1/platform/agents/{uuid.uuid4()}/runtime-state", {}),
+        (
+            "POST",
+            "/v1/platform/auth/keys",
+            {
+                "label": "unknown-owner",
+                "environment_id": str(uuid.uuid4()),
+                "scopes": list(PLATFORM_RUNTIME_KEY_SCOPES),
+            },
+        ),
+        ("DELETE", f"/v1/platform/auth/keys/{uuid.uuid4()}", {}),
+    ],
+)
+async def test_platform_mutations_reject_unknown_owner(
+    platform_client,
+    db_session,
+    method,
+    path,
+    body,
+):
+    owner = {"kind": "partner_tenant", "ref": f"missing:{uuid.uuid4().hex}"}
+    idempotency_key = f"unknown-owner-{uuid.uuid4()}"
+    response = await platform_client.request(
+        method,
+        path,
+        headers=_headers(idempotency_key),
+        json={"owner": owner, **body},
+    )
+
+    assert response.status_code == 404, response.text
+    event = (
+        await db_session.execute(
+            select(ControlPlaneAuditEvent).where(
+                ControlPlaneAuditEvent.source == "api.platform",
+                ControlPlaneAuditEvent.details["idempotency_key"].astext == idempotency_key,
+            )
+        )
+    ).scalar_one()
+    assert event.target_user_id is None
+    assert event.details["owner"] == owner
+    assert event.details["result"] == "owner_not_found"
+
+
+@pytest.mark.asyncio
+async def test_platform_clerk_owner_full_lifecycle_and_audit(
+    platform_client,
+    db_session,
+    seed_user,
+):
+    owner = _clerk_owner(seed_user)
+    agent_id = uuid.uuid4()
+    request_id = f"req-{uuid.uuid4().hex}"
+
+    created = await platform_client.post(
+        "/v1/platform/agents",
+        headers=_headers("lifecycle-agent-create", request_id=request_id),
+        json=_agent_body(owner, agent_id),
+    )
+    assert created.status_code == 200, created.text
+    assert created.json() == {"id": str(agent_id)}
+
+    runtime = await platform_client.put(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_headers("lifecycle-runtime-upsert", request_id=request_id),
+        json=_runtime_body(owner, agent_id),
+    )
+    assert runtime.status_code == 200, runtime.text
+    assert runtime.json()["environment_id"] == str(agent_id)
+
+    minted = await platform_client.post(
+        "/v1/platform/auth/keys",
+        headers=_headers("lifecycle-key-mint", request_id=request_id),
+        json={
+            "owner": owner,
+            "label": "platform-runtime",
+            "environment_id": str(agent_id),
+        },
+    )
+    assert minted.status_code == 200, minted.text
+    key_id = uuid.UUID(minted.json()["id"])
+    api_key = await db_session.get(ApiKey, key_id)
+    assert api_key is not None
+    assert api_key.user_id == seed_user.id
+    assert api_key.environment_id == agent_id
+    assert api_key.scopes == list(PLATFORM_RUNTIME_KEY_SCOPES)
+    assert api_key.managed is True
+
+    revoked = await platform_client.request(
+        "DELETE",
+        f"/v1/platform/auth/keys/{key_id}",
+        headers=_headers("lifecycle-key-revoke", request_id=request_id),
+        json={"owner": owner},
+    )
+    assert revoked.status_code == 200, revoked.text
+    assert revoked.json() == {"status": "revoked"}
+    await db_session.refresh(api_key)
+    assert api_key.revoked_at is not None
+
+    deleted_runtime = await platform_client.request(
+        "DELETE",
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_headers("lifecycle-runtime-delete", request_id=request_id),
+        json={"owner": owner},
+    )
+    assert deleted_runtime.status_code == 204, deleted_runtime.text
+    assert await db_session.get(HostedRuntimeState, agent_id) is None
+
+    deleted_agent = await platform_client.request(
+        "DELETE",
+        f"/v1/platform/agents/{agent_id}",
+        headers=_headers("lifecycle-agent-delete", request_id=request_id),
+        json={"owner": owner},
+    )
+    assert deleted_agent.status_code == 204, deleted_agent.text
+    assert await db_session.get(AgentEnvironment, agent_id) is None
+
+    events = (
+        (
+            await db_session.execute(
+                select(ControlPlaneAuditEvent)
+                .where(
+                    ControlPlaneAuditEvent.source == "api.platform",
+                    ControlPlaneAuditEvent.target_user_id == seed_user.id,
+                    ControlPlaneAuditEvent.details["request_id"].astext == request_id,
+                )
+                .order_by(ControlPlaneAuditEvent.created_at)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [event.action for event in events] == [
+        "agent_environment.create",
+        "hosted_runtime_state.upsert",
+        "api_key.mint",
+        "api_key.revoke",
+        "hosted_runtime_state.delete",
+        "agent_environment.delete",
+    ]
+    for event in events:
+        assert event.actor_type == "platform"
+        assert event.details["owner"] == owner
+        assert event.details["result"] == "success"
+        assert event.details["request_id"] == request_id
+        assert event.details["workload_sub"] is None
+        assert event.details["credential_id"] is None
+        assert event.details["token_jti"] is None
+
+
+@pytest.mark.asyncio
+async def test_platform_runtime_state_enforces_generation_contract(
+    platform_client,
+    db_session,
+    seed_user,
+):
+    owner = _clerk_owner(seed_user)
+    agent_id = uuid.uuid4()
+    created = await _create_platform_agent(
+        platform_client,
+        owner,
+        agent_id,
+        key="generation-agent-create",
+    )
+    assert created.status_code == 200, created.text
+
+    initial_body = {**_runtime_body(owner, agent_id), "generation": 2}
+    initial = await platform_client.put(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_headers("generation-initial"),
+        json=initial_body,
+    )
+    assert initial.status_code == 200, initial.text
+
+    stale = await platform_client.put(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_headers("generation-stale"),
+        json={**initial_body, "generation": 1},
+    )
+    assert stale.status_code == 409, stale.text
+    assert stale.json() == {"detail": {"code": "stale_generation", "current_generation": 2}}
+
+    conflict = await platform_client.put(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_headers("generation-conflict"),
+        json={**initial_body, "app_id": "app-2"},
+    )
+    assert conflict.status_code == 409, conflict.text
+    assert conflict.json() == {"detail": {"code": "generation_conflict", "current_generation": 2}}
+
+    state = await db_session.get(HostedRuntimeState, agent_id)
+    assert state is not None
+    assert state.generation == 2
+    assert state.app_id == "app-1"
+
+
+@pytest.mark.asyncio
+async def test_platform_partner_tenant_resolves_null_clerk_principal(
+    platform_client,
+    db_session,
+):
+    partner_ref = f"phala:{uuid.uuid4().hex}"
+    partner_user = await lazy_create_partner_user_with_personal_project(
+        db_session,
+        partner_tenant_ref=partner_ref,
+        race_loser_status=500,
+    )
+    await db_session.commit()
+    owner = {"kind": "partner_tenant", "ref": partner_ref}
+    agent_id = uuid.uuid4()
+    try:
+        created = await _create_platform_agent(
+            platform_client,
+            owner,
+            agent_id,
+            key="partner-agent-create",
+        )
+        assert created.status_code == 200, created.text
+
+        minted = await platform_client.post(
+            "/v1/platform/auth/keys",
+            headers=_headers("partner-key-mint"),
+            json={
+                "owner": owner,
+                "label": "partner-runtime",
+                "environment_id": str(agent_id),
+                "scopes": ["sessions:write", "skills:read"],
+            },
+        )
+        assert minted.status_code == 200, minted.text
+        await db_session.refresh(partner_user)
+        assert partner_user.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT
+        assert partner_user.clerk_id is None
+        api_key = await db_session.get(ApiKey, uuid.UUID(minted.json()["id"]))
+        assert api_key is not None
+        assert api_key.user_id == partner_user.id
+        assert api_key.scopes == ["sessions:write", "skills:read"]
+    finally:
+        await db_session.delete(partner_user)
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_platform_existing_resources_reject_owner_mismatch(
+    platform_client,
+    db_session,
+    seed_user,
+):
+    other = User(
+        clerk_id=f"platform_other_{uuid.uuid4().hex}",
+        email="platform-other@example.test",
+        name="Platform Other",
+    )
+    db_session.add(other)
+    await db_session.commit()
+    await db_session.refresh(other)
+    other_agent = await create_env_with_project(
+        db_session,
+        user_id=other.id,
+        machine_id=f"other-{uuid.uuid4().hex}",
+        machine_name="other-agent",
+        agent_type="openclaw",
+        os="linux",
+    )
+    raw_key = f"clawdi_{uuid.uuid4().hex}"
+    other_key = ApiKey(
+        user_id=other.id,
+        key_hash=hashlib.sha256(raw_key.encode()).hexdigest(),
+        key_prefix=raw_key[:16],
+        label="other-key",
+        environment_id=other_agent.id,
+        scopes=list(PLATFORM_RUNTIME_KEY_SCOPES),
+        managed=True,
+    )
+    db_session.add(other_key)
+    await db_session.commit()
+    await db_session.refresh(other_key)
+    owner = _clerk_owner(seed_user)
+    try:
+        calls = [
+            (
+                "POST",
+                "/v1/platform/agents",
+                _agent_body(owner, other_agent.id),
+            ),
+            (
+                "DELETE",
+                f"/v1/platform/agents/{other_agent.id}",
+                {"owner": owner},
+            ),
+            (
+                "PUT",
+                f"/v1/platform/agents/{other_agent.id}/runtime-state",
+                _runtime_body(owner, other_agent.id),
+            ),
+            (
+                "DELETE",
+                f"/v1/platform/agents/{other_agent.id}/runtime-state",
+                {"owner": owner},
+            ),
+            (
+                "POST",
+                "/v1/platform/auth/keys",
+                {
+                    "owner": owner,
+                    "label": "cross-owner",
+                    "environment_id": str(other_agent.id),
+                    "scopes": list(PLATFORM_RUNTIME_KEY_SCOPES),
+                },
+            ),
+            (
+                "DELETE",
+                f"/v1/platform/auth/keys/{other_key.id}",
+                {"owner": owner},
+            ),
+        ]
+        for index, (method, path, body) in enumerate(calls):
+            response = await platform_client.request(
+                method,
+                path,
+                headers=_headers(f"owner-mismatch-{index}"),
+                json=body,
+            )
+            assert response.status_code == 403, (method, path, response.text)
+
+        await db_session.refresh(other_agent)
+        await db_session.refresh(other_key)
+        assert other_agent.user_id == other.id
+        assert other_key.revoked_at is None
+        assert await db_session.get(HostedRuntimeState, other_agent.id) is None
+    finally:
+        await db_session.delete(other)
+        await db_session.commit()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "key_payload",
+    [
+        {"label": "missing-environment"},
+        {"label": "null-scopes", "scopes": None},
+        {"label": "empty-scopes", "scopes": []},
+        {"label": "excess-scope", "scopes": ["sessions:write", "vault:resolve"]},
+    ],
+)
+async def test_platform_key_mint_enforces_environment_and_scope_ceiling(
+    platform_client,
+    db_session,
+    seed_user,
+    key_payload,
+):
+    agent_id = uuid.uuid4()
+    created = await _create_platform_agent(
+        platform_client,
+        _clerk_owner(seed_user),
+        agent_id,
+        key=f"scope-agent-{uuid.uuid4()}",
+    )
+    assert created.status_code == 200, created.text
+    payload = {
+        "owner": _clerk_owner(seed_user),
+        "environment_id": str(agent_id),
+        **key_payload,
+    }
+    if "environment_id" not in key_payload and key_payload["label"] == "missing-environment":
+        payload.pop("environment_id")
+
+    response = await platform_client.post(
+        "/v1/platform/auth/keys",
+        headers=_headers(f"scope-rejected-{uuid.uuid4()}"),
+        json=payload,
+    )
+
+    assert response.status_code == 422, response.text
+    key_count = await db_session.scalar(
+        select(func.count()).select_from(ApiKey).where(ApiKey.environment_id == agent_id)
+    )
+    assert key_count == 0
+
+
+@pytest.mark.asyncio
+async def test_platform_idempotency_replays_every_mutation_without_second_side_effect(
+    platform_client,
+    db_session,
+    seed_user,
+):
+    owner = _clerk_owner(seed_user)
+    agent_id = uuid.uuid4()
+    agent_body = _agent_body(owner, agent_id)
+    create_headers = _headers("idem-agent-create")
+    created_once = await platform_client.post(
+        "/v1/platform/agents",
+        headers=create_headers,
+        json=agent_body,
+    )
+    created_twice = await platform_client.post(
+        "/v1/platform/agents",
+        headers=create_headers,
+        json=agent_body,
+    )
+    assert created_once.status_code == created_twice.status_code == 200
+    assert created_once.json() == created_twice.json()
+
+    runtime_body = _runtime_body(owner, agent_id)
+    runtime_headers = _headers("idem-runtime-upsert")
+    runtime_once = await platform_client.put(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=runtime_headers,
+        json=runtime_body,
+    )
+    runtime_twice = await platform_client.put(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=runtime_headers,
+        json=runtime_body,
+    )
+    assert runtime_once.status_code == runtime_twice.status_code == 200
+    assert runtime_once.json() == runtime_twice.json()
+
+    mint_body = {
+        "owner": owner,
+        "label": "idempotent-key",
+        "environment_id": str(agent_id),
+        "scopes": list(PLATFORM_RUNTIME_KEY_SCOPES),
+    }
+    mint_headers = _headers("idem-key-mint")
+    minted_once = await platform_client.post(
+        "/v1/platform/auth/keys",
+        headers=mint_headers,
+        json=mint_body,
+    )
+    minted_twice = await platform_client.post(
+        "/v1/platform/auth/keys",
+        headers=mint_headers,
+        json=mint_body,
+    )
+    assert minted_once.status_code == minted_twice.status_code == 200
+    assert minted_once.json() == minted_twice.json()
+    key_id = minted_once.json()["id"]
+
+    revoke_headers = _headers("idem-key-revoke")
+    revoked_once = await platform_client.request(
+        "DELETE",
+        f"/v1/platform/auth/keys/{key_id}",
+        headers=revoke_headers,
+        json={"owner": owner},
+    )
+    revoked_twice = await platform_client.request(
+        "DELETE",
+        f"/v1/platform/auth/keys/{key_id}",
+        headers=revoke_headers,
+        json={"owner": owner},
+    )
+    assert revoked_once.status_code == revoked_twice.status_code == 200
+    assert revoked_once.json() == revoked_twice.json()
+
+    runtime_delete_headers = _headers("idem-runtime-delete")
+    deleted_runtime_once = await platform_client.request(
+        "DELETE",
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=runtime_delete_headers,
+        json={"owner": owner},
+    )
+    deleted_runtime_twice = await platform_client.request(
+        "DELETE",
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=runtime_delete_headers,
+        json={"owner": owner},
+    )
+    assert deleted_runtime_once.status_code == deleted_runtime_twice.status_code == 204
+
+    agent_delete_headers = _headers("idem-agent-delete")
+    deleted_agent_once = await platform_client.request(
+        "DELETE",
+        f"/v1/platform/agents/{agent_id}",
+        headers=agent_delete_headers,
+        json={"owner": owner},
+    )
+    deleted_agent_twice = await platform_client.request(
+        "DELETE",
+        f"/v1/platform/agents/{agent_id}",
+        headers=agent_delete_headers,
+        json={"owner": owner},
+    )
+    assert deleted_agent_once.status_code == deleted_agent_twice.status_code == 204
+
+    assert (
+        await db_session.scalar(
+            select(func.count()).select_from(ApiKey).where(ApiKey.id == uuid.UUID(key_id))
+        )
+        == 0
+    )
+    idempotency_count = await db_session.scalar(
+        select(func.count())
+        .select_from(PlatformMutationIdempotency)
+        .where(
+            PlatformMutationIdempotency.idempotency_key.in_(
+                [
+                    "idem-agent-create",
+                    "idem-runtime-upsert",
+                    "idem-key-mint",
+                    "idem-key-revoke",
+                    "idem-runtime-delete",
+                    "idem-agent-delete",
+                ]
+            )
+        )
+    )
+    assert idempotency_count == 6
+    audit_counts = dict(
+        (
+            await db_session.execute(
+                select(ControlPlaneAuditEvent.action, func.count())
+                .where(
+                    ControlPlaneAuditEvent.source == "api.platform",
+                    ControlPlaneAuditEvent.details["idempotency_key"].astext.in_(
+                        [
+                            "idem-agent-create",
+                            "idem-runtime-upsert",
+                            "idem-key-mint",
+                            "idem-key-revoke",
+                            "idem-runtime-delete",
+                            "idem-agent-delete",
+                        ]
+                    ),
+                )
+                .group_by(ControlPlaneAuditEvent.action)
+            )
+        ).all()
+    )
+    assert audit_counts == {
+        "agent_environment.create": 1,
+        "agent_environment.delete": 1,
+        "api_key.mint": 1,
+        "api_key.revoke": 1,
+        "hosted_runtime_state.delete": 1,
+        "hosted_runtime_state.upsert": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_platform_idempotency_key_reuse_with_changed_request_is_409(
+    platform_client,
+    db_session,
+    seed_user,
+):
+    owner = _clerk_owner(seed_user)
+    agent_id = uuid.uuid4()
+    body = _agent_body(owner, agent_id)
+    headers = _headers("idem-conflict")
+    first = await platform_client.post(
+        "/v1/platform/agents",
+        headers=headers,
+        json=body,
+    )
+    assert first.status_code == 200, first.text
+    changed = {**body, "machine_name": "changed-machine-name"}
+
+    second = await platform_client.post(
+        "/v1/platform/agents",
+        headers=headers,
+        json=changed,
+    )
+
+    assert second.status_code == 409, second.text
+    agent = await db_session.get(AgentEnvironment, agent_id)
+    assert agent is not None
+    assert agent.machine_name == "platform-agent"
+    results = (
+        await db_session.execute(
+            select(ControlPlaneAuditEvent.details["result"].astext).where(
+                ControlPlaneAuditEvent.source == "api.platform",
+                ControlPlaneAuditEvent.details["idempotency_key"].astext == "idem-conflict",
+            )
+        )
+    ).scalars()
+    assert sorted(results) == ["idempotency_conflict", "success"]
+
+
+@pytest.mark.asyncio
+async def test_platform_routes_are_canonical_and_exposed_in_openapi(platform_client):
+    response = await platform_client.get("/openapi.json")
+    assert response.status_code == 200, response.text
+    paths = response.json()["paths"]
+    assert set(path for path in paths if path.startswith("/v1/platform")) == {
+        "/v1/platform/agents",
+        "/v1/platform/agents/{agent_id}",
+        "/v1/platform/agents/{agent_id}/runtime-state",
+        "/v1/platform/auth/keys",
+        "/v1/platform/auth/keys/{key_id}",
+    }
+    assert all(not path.startswith("/api/platform") for path in paths)
+    assert set(paths["/v1/platform/agents/{agent_id}/runtime-state"]) == {"put", "delete"}
+
+    missing_alias = await platform_client.post(
+        "/api/platform/agents",
+        headers={"Idempotency-Key": "missing-alias-check"},
+        json=_agent_body(
+            {"kind": "clerk", "ref": "missing_alias_owner"},
+            uuid.uuid4(),
+        ),
+    )
+    assert missing_alias.status_code == 404
+    assert missing_alias.json() == {"detail": "Not Found"}

--- a/backend/tests/test_principal_user_migration.py
+++ b/backend/tests/test_principal_user_migration.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.engine import URL, make_url
+from sqlalchemy.exc import IntegrityError
+
+BASE_REVISION = "d8f2a1c4b6e9"
+PRINCIPAL_REVISION = "a26c40c6965e"
+BACKEND_DIR = Path(__file__).parents[1]
+
+
+def _sync_url(url: URL, *, database: str) -> URL:
+    return url.set(drivername="postgresql+psycopg2", database=database)
+
+
+def _url_text(url: URL) -> str:
+    return url.render_as_string(hide_password=False)
+
+
+def _run_alembic(database_url: URL, *args: str) -> None:
+    env = os.environ.copy()
+    env["DATABASE_URL"] = _url_text(database_url)
+    subprocess.run(
+        [str(Path(sys.executable).with_name("alembic")), *args],
+        cwd=BACKEND_DIR,
+        env=env,
+        check=True,
+    )
+
+
+def test_principal_user_migration_apply_and_rollback():
+    source_url = make_url(os.environ["DATABASE_URL"])
+    database_name = f"clawdi_principal_migration_{uuid.uuid4().hex}"
+    admin_engine = create_engine(
+        _sync_url(source_url, database="postgres"),
+        isolation_level="AUTOCOMMIT",
+    )
+    database_url = source_url.set(database=database_name)
+    sync_database_url = _sync_url(source_url, database=database_name)
+    tenant_user_id = uuid.uuid4()
+    clerk_user_id = uuid.uuid4()
+
+    with admin_engine.connect() as connection:
+        connection.execute(text(f'CREATE DATABASE "{database_name}"'))
+
+    database_engine = create_engine(sync_database_url)
+    try:
+        _run_alembic(database_url, "upgrade", BASE_REVISION)
+
+        with database_engine.begin() as connection:
+            connection.execute(
+                text(
+                    "INSERT INTO users (id, clerk_id, email, name, skills_revision) "
+                    "VALUES (:id, :clerk_id, NULL, NULL, 0)"
+                ),
+                {"id": clerk_user_id, "clerk_id": "user_existing_tenant_zero"},
+            )
+
+        _run_alembic(database_url, "upgrade", PRINCIPAL_REVISION)
+
+        inspector = inspect(database_engine)
+        columns = {column["name"]: column for column in inspector.get_columns("users")}
+        checks = {constraint["name"] for constraint in inspector.get_check_constraints("users")}
+        assert columns["clerk_id"]["nullable"] is True
+        assert columns["principal_kind"]["nullable"] is False
+        assert "partner_tenant_ref" in columns
+        assert "ck_users_principal_identity" in checks
+
+        with database_engine.begin() as connection:
+            existing = connection.execute(
+                text("SELECT principal_kind, partner_tenant_ref FROM users WHERE id = :id"),
+                {"id": clerk_user_id},
+            ).one()
+            assert existing == ("clerk", None)
+            connection.execute(
+                text(
+                    "INSERT INTO users "
+                    "(id, clerk_id, principal_kind, partner_tenant_ref, email, name, "
+                    "skills_revision) VALUES "
+                    "(:id, NULL, 'partner_tenant', :partner_tenant_ref, NULL, NULL, 0)"
+                ),
+                {
+                    "id": tenant_user_id,
+                    "partner_tenant_ref": "ptn_migration",
+                },
+            )
+
+        with pytest.raises(IntegrityError):
+            with database_engine.begin() as connection:
+                connection.execute(
+                    text(
+                        "INSERT INTO users "
+                        "(id, clerk_id, principal_kind, partner_tenant_ref, email, name, "
+                        "skills_revision) VALUES "
+                        "(:id, :clerk_id, 'partner_tenant', :partner_tenant_ref, "
+                        "NULL, NULL, 0)"
+                    ),
+                    {
+                        "id": uuid.uuid4(),
+                        "clerk_id": "user_illegal_double_identity",
+                        "partner_tenant_ref": "ptn_illegal",
+                    },
+                )
+
+        with database_engine.begin() as connection:
+            connection.execute(
+                text("DELETE FROM users WHERE id = :id"),
+                {"id": tenant_user_id},
+            )
+
+        _run_alembic(database_url, "downgrade", BASE_REVISION)
+
+        inspector = inspect(database_engine)
+        columns = {column["name"]: column for column in inspector.get_columns("users")}
+        assert columns["clerk_id"]["nullable"] is False
+        assert "principal_kind" not in columns
+        assert "partner_tenant_ref" not in columns
+        with database_engine.connect() as connection:
+            clerk_id = connection.execute(
+                text("SELECT clerk_id FROM users WHERE id = :id"),
+                {"id": clerk_user_id},
+            ).scalar_one()
+        assert clerk_id == "user_existing_tenant_zero"
+    finally:
+        database_engine.dispose()
+        with admin_engine.connect() as connection:
+            connection.execute(text(f'DROP DATABASE IF EXISTS "{database_name}" WITH (FORCE)'))
+        admin_engine.dispose()

--- a/backend/tests/test_principal_users.py
+++ b/backend/tests/test_principal_users.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models.user import (
+    PRINCIPAL_KIND_CLERK,
+    PRINCIPAL_KIND_PARTNER_TENANT,
+    User,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "identity",
+    [
+        {
+            "clerk_id": None,
+            "principal_kind": PRINCIPAL_KIND_CLERK,
+            "partner_tenant_ref": None,
+        },
+        {
+            "clerk_id": "user_invalid_partner",
+            "principal_kind": PRINCIPAL_KIND_PARTNER_TENANT,
+            "partner_tenant_ref": "phala_cloud:team_invalid_partner",
+        },
+        {
+            "clerk_id": None,
+            "principal_kind": PRINCIPAL_KIND_PARTNER_TENANT,
+            "partner_tenant_ref": None,
+        },
+        {
+            "clerk_id": "user_invalid_double",
+            "principal_kind": PRINCIPAL_KIND_CLERK,
+            "partner_tenant_ref": "phala_cloud:team_invalid_double",
+        },
+        {
+            "clerk_id": "user_invalid_kind",
+            "principal_kind": "unknown",
+            "partner_tenant_ref": None,
+        },
+    ],
+)
+async def test_database_rejects_invalid_principal_identity_combinations(
+    db_session,
+    identity,
+):
+    user = User(
+        id=uuid.uuid4(),
+        email=None,
+        name=None,
+        **identity,
+    )
+    db_session.add(user)
+
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -2118,6 +2118,97 @@ async def test_admin_delete_runtime_state_requires_admin_key(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("resource_name", ["agents", "environments"])
+async def test_admin_runtime_state_accepts_matching_optional_owner(
+    admin_client,
+    db_session,
+    seed_user,
+    resource_name,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"runtime-owner-match-{uuid4().hex[:8]}",
+        machine_name="Runtime Owner Match",
+        agent_type="openclaw",
+    )
+    body = _runtime_state_body(
+        str(env.id),
+        target_clerk_id=seed_user.clerk_id,
+    )
+
+    upserted = await admin_client.put(
+        f"/v1/admin/{resource_name}/{env.id}/runtime-state",
+        headers=_AUTH,
+        json=body,
+    )
+    assert upserted.status_code == 200, upserted.text
+    state = await db_session.get(HostedRuntimeState, env.id)
+    assert state is not None
+    assert state.deployment_id == body["deployment_id"]
+
+    deleted = await admin_client.delete(
+        f"/v1/admin/{resource_name}/{env.id}/runtime-state",
+        headers=_AUTH,
+        params={"target_clerk_id": seed_user.clerk_id},
+    )
+    assert deleted.status_code == 204, deleted.text
+    assert await db_session.get(HostedRuntimeState, env.id) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resource_name", ["agents", "environments"])
+async def test_admin_runtime_state_rejects_mismatched_optional_owner_without_mutating(
+    admin_client,
+    db_session,
+    seed_user,
+    resource_name,
+):
+    other_user = User(
+        clerk_id=f"runtime_owner_{uuid4().hex[:12]}",
+        email=f"runtime-owner-{uuid4().hex[:8]}@clawdi.local",
+        name="Runtime Owner",
+    )
+    db_session.add(other_user)
+    await db_session.commit()
+    await db_session.refresh(other_user)
+    upsert_env = await create_env_with_project(
+        db_session,
+        user_id=other_user.id,
+        machine_id=f"runtime-upsert-owner-{uuid4().hex[:8]}",
+        machine_name="Runtime Upsert Owner",
+        agent_type="openclaw",
+    )
+    delete_env = await create_env_with_project(
+        db_session,
+        user_id=other_user.id,
+        machine_id=f"runtime-delete-owner-{uuid4().hex[:8]}",
+        machine_name="Runtime Delete Owner",
+        agent_type="openclaw",
+    )
+    await _write_runtime_state(admin_client, str(delete_env.id))
+
+    upsert_response = await admin_client.put(
+        f"/v1/admin/{resource_name}/{upsert_env.id}/runtime-state",
+        headers=_AUTH,
+        json=_runtime_state_body(
+            str(upsert_env.id),
+            target_clerk_id=seed_user.clerk_id,
+        ),
+    )
+    assert upsert_response.status_code == 403, upsert_response.text
+    assert await db_session.get(HostedRuntimeState, upsert_env.id) is None
+
+    delete_response = await admin_client.delete(
+        f"/v1/admin/{resource_name}/{delete_env.id}/runtime-state",
+        headers=_AUTH,
+        params={"target_clerk_id": seed_user.clerk_id},
+    )
+    assert delete_response.status_code == 403, delete_response.text
+    assert await db_session.get(HostedRuntimeState, delete_env.id) is not None
+
+
+@pytest.mark.asyncio
 async def test_runtime_manifest_generation_advance_changes_etag_and_returns_generation(
     admin_client,
     db_session,

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1725,6 +1725,92 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/platform/agents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Platform Create Agent */
+        post: operations["platform_create_agent_v1_platform_agents_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/platform/agents/{agent_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Platform Delete Agent */
+        delete: operations["platform_delete_agent_v1_platform_agents__agent_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/platform/agents/{agent_id}/runtime-state": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Platform Upsert Runtime State */
+        put: operations["platform_upsert_runtime_state_v1_platform_agents__agent_id__runtime_state_put"];
+        post?: never;
+        /** Platform Delete Runtime State */
+        delete: operations["platform_delete_runtime_state_v1_platform_agents__agent_id__runtime_state_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/platform/auth/keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Platform Mint Api Key */
+        post: operations["platform_mint_api_key_v1_platform_auth_keys_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/platform/auth/keys/{key_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Platform Revoke Api Key */
+        delete: operations["platform_revoke_api_key_v1_platform_auth_keys__key_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/vault": {
         parameters: {
             query?: never;
@@ -4033,6 +4119,307 @@ export interface components {
              */
             status: "ok";
         };
+        /** HostedEgressEngine */
+        HostedEgressEngine: {
+            /**
+             * Type
+             * @constant
+             */
+            type: "mitmproxy";
+            /** Version */
+            version: string;
+            /** Url */
+            url: string;
+            /** Sha256 */
+            sha256: string;
+        };
+        /** HostedEgressHeaderEqualsMatcher */
+        HostedEgressHeaderEqualsMatcher: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "equals";
+            /** Value */
+            value: string;
+            /** Prefix */
+            prefix?: string | null;
+        };
+        /** HostedEgressHeaderExistsMatcher */
+        HostedEgressHeaderExistsMatcher: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "exists";
+        };
+        /** HostedEgressHeaderSecretRefEqualsMatcher */
+        HostedEgressHeaderSecretRefEqualsMatcher: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "secretRefEquals";
+            /** Secretref */
+            secretRef: string;
+            /** Prefix */
+            prefix?: string | null;
+        };
+        /** HostedEgressHeaderSecretRefSetter */
+        HostedEgressHeaderSecretRefSetter: {
+            /**
+             * Type
+             * @constant
+             */
+            type: "secretRef";
+            /** Secretref */
+            secretRef: string;
+            /** Prefix */
+            prefix?: string | null;
+        };
+        /** HostedEgressPathEqualsMatcher */
+        HostedEgressPathEqualsMatcher: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "equals";
+            /** Value */
+            value: string;
+        };
+        /** HostedEgressPathPrefixMatcher */
+        HostedEgressPathPrefixMatcher: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "prefix";
+            /** Value */
+            value: string;
+        };
+        /** HostedEgressPathReplace */
+        HostedEgressPathReplace: {
+            /**
+             * Type
+             * @constant
+             */
+            type: "secretRefPrefix";
+            /** Secretref */
+            secretRef: string;
+            /** Replacementsecretref */
+            replacementSecretRef: string;
+            /** Prefix */
+            prefix?: string | null;
+            /** Suffix */
+            suffix?: string | null;
+        };
+        /** HostedEgressPathSecretRefMatcher */
+        HostedEgressPathSecretRefMatcher: {
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            type: "secretRefEquals" | "secretRefPrefix";
+            /** Secretref */
+            secretRef: string;
+            /** Prefix */
+            prefix?: string | null;
+            /** Suffix */
+            suffix?: string | null;
+        };
+        /** HostedEgressProfile */
+        HostedEgressProfile: {
+            /** Id */
+            id: string;
+            /** Enabled */
+            enabled?: boolean | null;
+            /**
+             * Kind
+             * @enum {string}
+             */
+            kind: "http" | "websocket" | "provider" | "passthrough" | "deny";
+            match: components["schemas"]["HostedEgressProfileMatch"];
+            rewrite?: components["schemas"]["HostedEgressProfileRewrite"] | null;
+            logging?: components["schemas"]["HostedEgressProfileLogging"] | null;
+            /** Priority */
+            priority?: number | null;
+            /** Owner */
+            owner?: string | null;
+            /** Description */
+            description?: string | null;
+        };
+        /** HostedEgressProfileLogging */
+        HostedEgressProfileLogging: {
+            /** Redactheaders */
+            redactHeaders?: string[] | null;
+            /** Redacturlpatterns */
+            redactUrlPatterns?: string[] | null;
+        };
+        /** HostedEgressProfileMatch */
+        HostedEgressProfileMatch: {
+            /** Scheme */
+            scheme?: ("http" | "https" | "ws" | "wss") | null;
+            /** Host */
+            host: string;
+            /** Pathprefix */
+            pathPrefix?: string | null;
+            /** Path */
+            path?: (components["schemas"]["HostedEgressPathEqualsMatcher"] | components["schemas"]["HostedEgressPathPrefixMatcher"] | components["schemas"]["HostedEgressPathSecretRefMatcher"]) | null;
+            /** Headers */
+            headers?: {
+                [key: string]: components["schemas"]["HostedEgressHeaderExistsMatcher"] | components["schemas"]["HostedEgressHeaderEqualsMatcher"] | components["schemas"]["HostedEgressHeaderSecretRefEqualsMatcher"];
+            } | null;
+            /** Query */
+            query?: {
+                [key: string]: components["schemas"]["HostedEgressHeaderExistsMatcher"] | components["schemas"]["HostedEgressHeaderEqualsMatcher"] | components["schemas"]["HostedEgressHeaderSecretRefEqualsMatcher"];
+            } | null;
+        };
+        /** HostedEgressProfileRewrite */
+        HostedEgressProfileRewrite: {
+            /** Upstreambaseurl */
+            upstreamBaseUrl?: string | null;
+            /** Preservepath */
+            preservePath?: boolean | null;
+            pathReplace?: components["schemas"]["HostedEgressPathReplace"] | null;
+            /** Setheaders */
+            setHeaders?: {
+                [key: string]: string | components["schemas"]["HostedEgressHeaderSecretRefSetter"];
+            } | null;
+        };
+        /** HostedEgressProfiles */
+        HostedEgressProfiles: {
+            /** Profiles */
+            profiles?: components["schemas"]["HostedEgressProfile"][] | null;
+        };
+        /** HostedRuntimeBridge */
+        HostedRuntimeBridge: {
+            /** Surfaces */
+            surfaces: components["schemas"]["HostedRuntimeBridgeSurface"][];
+        };
+        /** HostedRuntimeBridgeSurface */
+        HostedRuntimeBridgeSurface: {
+            /** Name */
+            name: string;
+            /**
+             * Kind
+             * @constant
+             */
+            kind: "control-ui";
+            /** Listenhost */
+            listenHost?: string | null;
+            /** Listenport */
+            listenPort: number;
+            /** Upstreamhost */
+            upstreamHost?: string | null;
+            /** Upstreamport */
+            upstreamPort: number;
+        };
+        /** HostedRuntimeDesiredState */
+        HostedRuntimeDesiredState: {
+            /**
+             * Enabled
+             * @constant
+             */
+            enabled: true;
+            /** Provider Ids */
+            provider_ids: string[];
+            primary_model: components["schemas"]["HostedRuntimePrimaryModel"];
+            install: components["schemas"]["HostedRuntimeInstall"];
+            run?: components["schemas"]["HostedRuntimeRunSettings"] | null;
+            /** Services */
+            services?: {
+                [key: string]: components["schemas"]["HostedRuntimeRunSettings"];
+            } | null;
+            paths: components["schemas"]["HostedRuntimePaths"];
+        };
+        /** HostedRuntimeInstall */
+        HostedRuntimeInstall: {
+            /**
+             * Source
+             * @constant
+             */
+            source: "official";
+        };
+        /** HostedRuntimeLiveSync */
+        HostedRuntimeLiveSync: {
+            /** Enabled */
+            enabled: boolean;
+            /** Agents */
+            agents: components["schemas"]["HostedRuntimeLiveSyncAgent"][];
+        };
+        /** HostedRuntimeLiveSyncAgent */
+        HostedRuntimeLiveSyncAgent: {
+            /**
+             * Agenttype
+             * @enum {string}
+             */
+            agentType: "openclaw" | "hermes" | "codex";
+            /** Environmentid */
+            environmentId: string;
+        };
+        /** HostedRuntimeLocale */
+        HostedRuntimeLocale: {
+            /**
+             * Language
+             * @enum {string}
+             */
+            language: "en" | "zh-CN" | "zh-TW" | "ja" | "ko" | "es" | "fr" | "de" | "pt";
+            /** Timezone */
+            timezone: string;
+        };
+        /** HostedRuntimePaths */
+        HostedRuntimePaths: {
+            /** Home */
+            home: string;
+            /** Workspace */
+            workspace: string;
+        };
+        /** HostedRuntimePrimaryModel */
+        HostedRuntimePrimaryModel: {
+            /** Provider Id */
+            provider_id: string;
+            /** Model */
+            model: string;
+        };
+        /** HostedRuntimeRecovery */
+        HostedRuntimeRecovery: {
+            /** Cachemanifest */
+            cacheManifest: boolean;
+            /** Allowofflineboot */
+            allowOfflineBoot: boolean;
+        };
+        /** HostedRuntimeRunSettings */
+        HostedRuntimeRunSettings: {
+            /** Command */
+            command?: string | null;
+            /** Args */
+            args?: string[] | null;
+            /** Env */
+            env?: {
+                [key: string]: string;
+            } | null;
+            /** Secretenv */
+            secretEnv?: {
+                [key: string]: string;
+            } | null;
+            /** Cwd */
+            cwd?: string | null;
+            /** Prependpath */
+            prependPath?: string[] | null;
+        };
+        /** HostedRuntimeSystem */
+        HostedRuntimeSystem: {
+            /** User */
+            user: string;
+            /** Home */
+            home: string;
+            /** Workspace */
+            workspace: string;
+            /** Persistentpaths */
+            persistentPaths: string[];
+            /** Openclawcontroluiallowedorigins */
+            openclawControlUiAllowedOrigins?: string[] | null;
+        };
         /**
          * InvitationAcceptResponse
          * @description Returned after a directed project invitation is accepted.
@@ -4247,6 +4634,102 @@ export interface components {
             page: number;
             /** Page Size */
             page_size: number;
+        };
+        /** PlatformAgentCreate */
+        PlatformAgentCreate: {
+            owner: components["schemas"]["PlatformOwner"];
+            /**
+             * Agent Id
+             * Format: uuid
+             */
+            agent_id: string;
+            /** Machine Id */
+            machine_id: string;
+            /** Machine Name */
+            machine_name: string;
+            /** Agent Type */
+            agent_type: string;
+            /** Agent Version */
+            agent_version?: string | null;
+            /**
+             * Os Name
+             * @default linux
+             */
+            os_name: string;
+        };
+        /** PlatformApiKeyCreate */
+        PlatformApiKeyCreate: {
+            owner: components["schemas"]["PlatformOwner"];
+            /** Label */
+            label: string;
+            /**
+             * Environment Id
+             * Format: uuid
+             */
+            environment_id: string;
+            /** Scopes */
+            scopes?: string[];
+        };
+        /** PlatformMutationBody */
+        PlatformMutationBody: {
+            owner: components["schemas"]["PlatformOwner"];
+        };
+        /** PlatformOwner */
+        PlatformOwner: {
+            /**
+             * Kind
+             * @enum {string}
+             */
+            kind: "clerk" | "partner_tenant";
+            /** Ref */
+            ref: string;
+        };
+        /** PlatformRuntimeStateResponse */
+        PlatformRuntimeStateResponse: {
+            /**
+             * Environment Id
+             * Format: uuid
+             */
+            environment_id: string;
+            /** Deployment Id */
+            deployment_id: string;
+            /** Instance Id */
+            instance_id: string;
+            /** Generation */
+            generation: number;
+        };
+        /** PlatformRuntimeStateUpsert */
+        PlatformRuntimeStateUpsert: {
+            owner: components["schemas"]["PlatformOwner"];
+            /** Deployment Id */
+            deployment_id: string;
+            /** App Id */
+            app_id?: string | null;
+            /** Instance Id */
+            instance_id: string;
+            /** Generation */
+            generation: number;
+            /** Cli Package Spec */
+            cli_package_spec: string;
+            locale: components["schemas"]["HostedRuntimeLocale"];
+            system: components["schemas"]["HostedRuntimeSystem"];
+            egress_engine?: components["schemas"]["HostedEgressEngine"] | null;
+            /** Runtimes */
+            runtimes: {
+                [key: string]: components["schemas"]["HostedRuntimeDesiredState"];
+            };
+            bridge?: components["schemas"]["HostedRuntimeBridge"] | null;
+            live_sync: components["schemas"]["HostedRuntimeLiveSync"];
+            recovery: components["schemas"]["HostedRuntimeRecovery"];
+            egress_profiles?: components["schemas"]["HostedEgressProfiles"] | null;
+            /** Mcp */
+            mcp?: {
+                [key: string]: unknown;
+            } | null;
+            /** Tools */
+            tools?: {
+                [key: string]: unknown;
+            } | null;
         };
         /** ProjectCreate */
         ProjectCreate: {
@@ -8903,6 +9386,226 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CapabilitiesResponse"];
+                };
+            };
+        };
+    };
+    platform_create_agent_v1_platform_agents_post: {
+        parameters: {
+            query?: never;
+            header: {
+                "Idempotency-Key": string;
+                "X-Admin-Key"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PlatformAgentCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EnvironmentCreatedResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    platform_delete_agent_v1_platform_agents__agent_id__delete: {
+        parameters: {
+            query?: never;
+            header: {
+                "Idempotency-Key": string;
+                "X-Admin-Key"?: string | null;
+            };
+            path: {
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PlatformMutationBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    platform_upsert_runtime_state_v1_platform_agents__agent_id__runtime_state_put: {
+        parameters: {
+            query?: never;
+            header: {
+                "Idempotency-Key": string;
+                "X-Admin-Key"?: string | null;
+            };
+            path: {
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PlatformRuntimeStateUpsert"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformRuntimeStateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    platform_delete_runtime_state_v1_platform_agents__agent_id__runtime_state_delete: {
+        parameters: {
+            query?: never;
+            header: {
+                "Idempotency-Key": string;
+                "X-Admin-Key"?: string | null;
+            };
+            path: {
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PlatformMutationBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    platform_mint_api_key_v1_platform_auth_keys_post: {
+        parameters: {
+            query?: never;
+            header: {
+                "Idempotency-Key": string;
+                "X-Admin-Key"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PlatformApiKeyCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiKeyCreated"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    platform_revoke_api_key_v1_platform_auth_keys__key_id__delete: {
+        parameters: {
+            query?: never;
+            header: {
+                "Idempotency-Key": string;
+                "X-Admin-Key"?: string | null;
+            };
+            path: {
+                key_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PlatformMutationBody"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiKeyRevokeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
**一句话**：cloud-api 从"一把万能钥匙"升级为"每个资源认主人"——为白标/多租户打地基。3 个 commit 各是一块砖，可逐 commit 看。

**保证**（每条我都验过）：
- v1 老用户/CLI/runtime 协议：零改动，不传 owner 的老调用行为逐字节不变（有专门回归测试钉死）
- 新的强制规则只在**新建的** `/v1/platform/*` 路由上；老 admin 接口冻结
- migration 纯加法，双向验证过；全量测试 1131 绿

**你需要决定的**：合不合、什么时候合。合并后自动部署但一切新面都锁着（无任何凭证存在），生产行为零变化。建议低峰时段合（migration 给 users 表加约束有秒级锁写）。

**合并顺序**：本 PR 先于 hosted 的 #798（sender 开关依赖本 PR 的接收端上线）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)