### PR TITLE
ci: run workflows on self-hosted runners

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     outputs:
       any: ${{ steps.filter.outputs.any }}
       test: ${{ steps.filter.outputs.test }}
@@ -83,7 +83,7 @@ jobs:
   lint-and-typecheck:
     needs: changes
     if: needs.changes.outputs.any == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 10
     defaults:
       run:
@@ -124,7 +124,7 @@ jobs:
   test:
     needs: changes
     if: needs.changes.outputs.test == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 20
     defaults:
       run:

--- a/.github/workflows/clawdi-image-release.yml
+++ b/.github/workflows/clawdi-image-release.yml
@@ -63,7 +63,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_branch == 'main')
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 30
     outputs:
       image_tag: ${{ steps.rev.outputs.sha }}
@@ -240,7 +240,7 @@ jobs:
   deploy:
     needs: build
     if: needs.build.outputs.build_required == 'true' && needs.build.outputs.should_deploy == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -289,7 +289,7 @@ jobs:
   audit:
     needs: build
     if: needs.build.outputs.build_required != 'true' && needs.build.outputs.should_deploy == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/clawdi-release.yml
+++ b/.github/workflows/clawdi-release.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/clean-test-runner-ci.yml
+++ b/.github/workflows/clean-test-runner-ci.yml
@@ -29,7 +29,7 @@ concurrency:
 
 jobs:
   docker-runner:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 30
     env:
       CLAWDI_TEST_COMPOSE_PROJECT_NAME: clawdi-test-ci-${{ github.run_id }}

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     # `environment: npm` gates the job behind the repo's `npm` environment
     # secrets/rules. Combined with `id-token: write` this enables npm
     # trusted-publisher OIDC so no NPM_TOKEN secret is needed.

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     outputs:
       web: ${{ steps.filter.outputs.web }}
       cli: ${{ steps.filter.outputs.cli }}
@@ -76,7 +76,7 @@ jobs:
       needs.changes.outputs.cli == 'true' ||
       needs.changes.outputs.shared == 'true' ||
       needs.changes.outputs.infra == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -93,7 +93,7 @@ jobs:
       needs.changes.outputs.cli == 'true' ||
       needs.changes.outputs.shared == 'true' ||
       needs.changes.outputs.infra == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -151,7 +151,7 @@ jobs:
       needs.changes.outputs.cli == 'true' ||
       needs.changes.outputs.shared == 'true' ||
       needs.changes.outputs.infra == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -178,7 +178,7 @@ jobs:
       needs.changes.outputs.web == 'true' ||
       needs.changes.outputs.shared == 'true' ||
       needs.changes.outputs.infra == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- route every GitHub Actions job through `CI_RUNNER`
- default to `blacksmith-16vcpu-ubuntu-2404`
- leave triggers, permissions, secrets, and commands unchanged

## Repository settings
- `CI_RUNNER=blacksmith-16vcpu-ubuntu-2404`
- default `GITHUB_TOKEN` permission: read
- all external contributors require workflow approval

## Verification
- actionlint passed with existing shellcheck findings excluded
- diff contains only `runs-on` changes