### PR TITLE
fix(cli): publish local release tarball

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -163,7 +163,7 @@ jobs:
         env:
           CLI_TARBALL_FILENAME: ${{ needs['build-immutable-artifact'].outputs.cli_tarball_filename }}
           NPM_TAG: ${{ needs['build-immutable-artifact'].outputs.npm_tag }}
-        run: npm publish "release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag "$NPM_TAG"
+        run: npm publish "./release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag "$NPM_TAG"
 
       - name: Create GitHub release
         env:

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -71,7 +71,7 @@ describe("CLI publish workflow contract", () => {
 			`NPM_TAG: \${{ needs['build-immutable-artifact'].outputs.npm_tag }}`,
 		);
 		expect(workflow).toContain(
-			'npm publish "release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag "$NPM_TAG"',
+			'npm publish "./release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag "$NPM_TAG"',
 		);
 		expect(cliPackage.version).toContain("-");
 		expect(expectedNpmTag(cliPackage.version)).toBe("beta");


### PR DESCRIPTION
## Summary
- make the OIDC publish step pass an explicit local tarball path
- update the workflow contract assertion

## Verification
- `bun test packages/cli/tests/cli-publish-workflow.test.ts`
- `git diff --check`

The previous run interpreted `release/<tarball>.tgz` as a GitHub package shorthand and failed before npm trusted publishing.