### PR TITLE
release(cli): publish Agent v2 beta.52 artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.12.10-beta.52
+
+Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.52
+
+Package: `clawdi@0.12.10-beta.52`
+
+### Changed
+
+- Finalized the immutable Agent v2 CLI bundle with a single applied-state
+  authority and fail-closed hosted runtime convergence.
+
 ## Clawdi CLI v0.12.10-beta.51
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.51

--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.51",
+      "version": "0.12.10-beta.52",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.51",
+	"version": "0.12.10-beta.52",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## Summary

- bump the final Agent v2 CLI artifact identity to `0.12.10-beta.52`
- keep the already-published immutable `0.12.10-beta.51` release history unchanged
- add the release changelog entry and lockfile metadata

## Why

Cloud PR #398 finalized the runtime bundle and applied-authority implementation after `beta.51` had already been published from commit `1447f536`. npm versions are immutable, so the final CLI requires a new exact prerelease.

This PR intentionally does not change the Cloud minimum CLI floor or Hosted desired package spec. Those activation changes follow only after npm confirms the `beta.52` artifact exists.

## Rollout

Merge -> repository-local OIDC publish -> verify exact npm version, integrity, provenance, and GitHub release. No production cohort activation is included.