### PR TITLE
M3: cloud-api workload OAuth issuer (replaces shared root key)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -42,6 +42,14 @@ CORS_ORIGINS=["http://localhost:3000"]
 # on the SaaS backend side. Constant-time HMAC comparison.
 ADMIN_API_KEY=
 
+# Transitional auth for the six `/v1/platform/*` mutation routes. Disable only
+# after every non-v1 cohort uses workload OAuth; this does not affect `/v1/admin/*`.
+PLATFORM_LEGACY_ADMIN_AUTH_ENABLED=true
+# Independent cloud-api workload authorization-server issuer and exact client
+# assertion audience. Leave the endpoint empty to derive it from PUBLIC_API_URL.
+PLATFORM_WORKLOAD_ISSUER=clawdi-cloud-platform
+PLATFORM_WORKLOAD_TOKEN_ENDPOINT=
+
 # Externally reachable URLs the backend embeds in payloads it hands out.
 # PUBLIC_API_URL: this backend's own URL (used for MCP client config etc.).
 # WEB_ORIGIN:     the dashboard URL — the CLI device-flow `verification_uri`

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -14,6 +14,7 @@ from app.models import (  # noqa: F401 - register models
     hosted_runtime,
     memory,
     platform_idempotency,
+    platform_workload_auth,
     project,
     project_invitation,
     project_membership,

--- a/backend/alembic/versions/c7e4a9b2d6f1_platform_workload_oauth.py
+++ b/backend/alembic/versions/c7e4a9b2d6f1_platform_workload_oauth.py
@@ -1,0 +1,188 @@
+"""Add platform workload OAuth authorization-server state.
+
+Revision ID: c7e4a9b2d6f1
+Revises: f3a1c7d9e2b4
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "c7e4a9b2d6f1"
+down_revision: str | Sequence[str] | None = "f1a7c3d9e2b4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_APPROVED_SCOPES_SQL = (
+    "ARRAY["
+    + ",".join(
+        f"'{scope}'"
+        for scope in (
+            "platform:agents:create",
+            "platform:agents:delete",
+            "platform:runtime-state:write",
+            "platform:keys:mint",
+            "platform:keys:revoke",
+        )
+    )
+    + "]::varchar[]"
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "platform_workload_clients",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("client_id", sa.String(length=200), nullable=False),
+        sa.Column("assertion_kid", sa.String(length=200), nullable=False),
+        sa.Column("assertion_algorithm", sa.String(length=16), nullable=False),
+        sa.Column("public_jwk", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("status", sa.String(length=32), server_default="active", nullable=False),
+        sa.Column("allowed_scopes", postgresql.ARRAY(sa.String(length=64)), nullable=False),
+        sa.Column("token_version", sa.Integer(), server_default="1", nullable=False),
+        sa.Column("revoked_before", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.CheckConstraint(
+            "status IN ('active', 'disabled', 'revoked')",
+            name="ck_platform_workload_clients_status",
+        ),
+        sa.CheckConstraint(
+            "token_version >= 1",
+            name="ck_platform_workload_clients_token_version",
+        ),
+        sa.CheckConstraint(
+            "jsonb_typeof(public_jwk) = 'object'",
+            name="ck_platform_workload_clients_public_jwk_object",
+        ),
+        sa.CheckConstraint(
+            "NOT (public_jwk ?| ARRAY['d','p','q','dp','dq','qi','oth','k']::text[])",
+            name="ck_platform_workload_clients_public_jwk_only",
+        ),
+        sa.CheckConstraint(
+            "public_jwk ?& ARRAY['kid','alg','kty']::text[] "
+            "AND public_jwk ->> 'kid' = assertion_kid "
+            "AND public_jwk ->> 'alg' = assertion_algorithm",
+            name="ck_platform_workload_clients_public_jwk_identity",
+        ),
+        sa.CheckConstraint(
+            "(assertion_algorithm = 'RS256' AND public_jwk ->> 'kty' = 'RSA') "
+            "OR (assertion_algorithm = 'ES256' AND public_jwk ->> 'kty' = 'EC')",
+            name="ck_platform_workload_clients_public_jwk_key_type",
+        ),
+        sa.CheckConstraint(
+            "assertion_algorithm IN ('RS256', 'ES256')",
+            name="ck_platform_workload_clients_assertion_algorithm",
+        ),
+        sa.CheckConstraint(
+            f"cardinality(allowed_scopes) > 0 AND allowed_scopes <@ {_APPROVED_SCOPES_SQL}",
+            name="ck_platform_workload_clients_allowed_scopes",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("client_id", name="uq_platform_workload_clients_client_id"),
+    )
+    op.create_index(
+        "ix_platform_workload_clients_status",
+        "platform_workload_clients",
+        ["status"],
+    )
+
+    op.create_table(
+        "platform_workload_signing_keys",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("kid", sa.String(length=200), nullable=False),
+        sa.Column("algorithm", sa.String(length=16), nullable=False),
+        sa.Column("private_key_ref", sa.String(length=500), nullable=False),
+        sa.Column("status", sa.String(length=32), server_default="active", nullable=False),
+        sa.Column("not_before", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.CheckConstraint(
+            "status IN ('active', 'retired', 'revoked')",
+            name="ck_platform_workload_signing_keys_status",
+        ),
+        sa.CheckConstraint(
+            "algorithm IN ('RS256', 'ES256')",
+            name="ck_platform_workload_signing_keys_algorithm",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("kid", name="uq_platform_workload_signing_keys_kid"),
+        sa.UniqueConstraint(
+            "private_key_ref",
+            name="uq_platform_workload_signing_keys_private_key_ref",
+        ),
+    )
+    op.create_index(
+        "ix_platform_workload_signing_keys_status",
+        "platform_workload_signing_keys",
+        ["status"],
+    )
+
+    op.create_table(
+        "platform_workload_assertion_replays",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("client_id", sa.String(length=200), nullable=False),
+        sa.Column("jti", sa.String(length=200), nullable=False),
+        sa.Column("assertion_expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.ForeignKeyConstraint(
+            ["client_id"],
+            ["platform_workload_clients.client_id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "client_id",
+            "jti",
+            name="uq_platform_workload_assertion_replays_client_jti",
+        ),
+    )
+    op.create_index(
+        "ix_platform_workload_assertion_replays_client_id",
+        "platform_workload_assertion_replays",
+        ["client_id"],
+    )
+    op.create_index(
+        "ix_platform_workload_assertion_replays_assertion_expires_at",
+        "platform_workload_assertion_replays",
+        ["assertion_expires_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_platform_workload_assertion_replays_assertion_expires_at",
+        table_name="platform_workload_assertion_replays",
+    )
+    op.drop_index(
+        "ix_platform_workload_assertion_replays_client_id",
+        table_name="platform_workload_assertion_replays",
+    )
+    op.drop_table("platform_workload_assertion_replays")
+    op.drop_index(
+        "ix_platform_workload_signing_keys_status",
+        table_name="platform_workload_signing_keys",
+    )
+    op.drop_table("platform_workload_signing_keys")
+    op.drop_index(
+        "ix_platform_workload_clients_status",
+        table_name="platform_workload_clients",
+    )
+    op.drop_table("platform_workload_clients")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -148,6 +148,14 @@ class Settings(BaseSettings):
     # comparison.
     admin_api_key: str = ""
 
+    # Legacy shared-root auth remains available only for the six canonical
+    # /v1/platform mutations while cohorts move to workload OAuth.
+    platform_legacy_admin_auth_enabled: bool = True
+    # This authorization server is independent from tenant -> Hosted OAuth.
+    platform_workload_issuer: str = "clawdi-cloud-platform"
+    # Exact RFC 7523 assertion audience. Empty derives from PUBLIC_API_URL.
+    platform_workload_token_endpoint: str = ""
+
     composio_api_key: str = ""
     composio_api_base_url: str = "https://backend.composio.dev"
 

--- a/backend/app/models/platform_workload_auth.py
+++ b/backend/app/models/platform_workload_auth.py
@@ -1,0 +1,132 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+PLATFORM_WORKLOAD_CLIENT_ACTIVE = "active"
+PLATFORM_WORKLOAD_CLIENT_DISABLED = "disabled"
+PLATFORM_WORKLOAD_CLIENT_REVOKED = "revoked"
+
+PLATFORM_WORKLOAD_SIGNING_KEY_ACTIVE = "active"
+PLATFORM_WORKLOAD_SIGNING_KEY_RETIRED = "retired"
+PLATFORM_WORKLOAD_SIGNING_KEY_REVOKED = "revoked"
+
+
+class PlatformWorkloadClient(Base, TimestampMixin):
+    __tablename__ = "platform_workload_clients"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('active', 'disabled', 'revoked')",
+            name="ck_platform_workload_clients_status",
+        ),
+        CheckConstraint(
+            "token_version >= 1",
+            name="ck_platform_workload_clients_token_version",
+        ),
+        CheckConstraint(
+            "jsonb_typeof(public_jwk) = 'object'",
+            name="ck_platform_workload_clients_public_jwk_object",
+        ),
+        CheckConstraint(
+            "NOT (public_jwk ?| ARRAY['d','p','q','dp','dq','qi','oth','k']::text[])",
+            name="ck_platform_workload_clients_public_jwk_only",
+        ),
+        CheckConstraint(
+            "public_jwk ?& ARRAY['kid','alg','kty']::text[] "
+            "AND public_jwk ->> 'kid' = assertion_kid "
+            "AND public_jwk ->> 'alg' = assertion_algorithm",
+            name="ck_platform_workload_clients_public_jwk_identity",
+        ),
+        CheckConstraint(
+            "(assertion_algorithm = 'RS256' AND public_jwk ->> 'kty' = 'RSA') "
+            "OR (assertion_algorithm = 'ES256' AND public_jwk ->> 'kty' = 'EC')",
+            name="ck_platform_workload_clients_public_jwk_key_type",
+        ),
+        CheckConstraint(
+            "assertion_algorithm IN ('RS256', 'ES256')",
+            name="ck_platform_workload_clients_assertion_algorithm",
+        ),
+        CheckConstraint(
+            "cardinality(allowed_scopes) > 0 AND allowed_scopes <@ "
+            "ARRAY['platform:agents:create','platform:agents:delete',"
+            "'platform:runtime-state:write','platform:keys:mint',"
+            "'platform:keys:revoke']::varchar[]",
+            name="ck_platform_workload_clients_allowed_scopes",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    client_id: Mapped[str] = mapped_column(String(200), unique=True, nullable=False)
+    assertion_kid: Mapped[str] = mapped_column(String(200), nullable=False)
+    assertion_algorithm: Mapped[str] = mapped_column(String(16), nullable=False)
+    public_jwk: Mapped[dict] = mapped_column(JSONB(none_as_null=True), nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(32),
+        default=PLATFORM_WORKLOAD_CLIENT_ACTIVE,
+        server_default=PLATFORM_WORKLOAD_CLIENT_ACTIVE,
+        nullable=False,
+        index=True,
+    )
+    allowed_scopes: Mapped[list[str]] = mapped_column(ARRAY(String(64)), nullable=False)
+    token_version: Mapped[int] = mapped_column(
+        Integer,
+        default=1,
+        server_default="1",
+        nullable=False,
+    )
+    revoked_before: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class PlatformWorkloadAssertionReplay(Base, TimestampMixin):
+    __tablename__ = "platform_workload_assertion_replays"
+    __table_args__ = (
+        UniqueConstraint(
+            "client_id",
+            "jti",
+            name="uq_platform_workload_assertion_replays_client_jti",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    client_id: Mapped[str] = mapped_column(
+        String(200),
+        ForeignKey("platform_workload_clients.client_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    jti: Mapped[str] = mapped_column(String(200), nullable=False)
+    assertion_expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
+
+
+class PlatformWorkloadSigningKey(Base, TimestampMixin):
+    __tablename__ = "platform_workload_signing_keys"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('active', 'retired', 'revoked')",
+            name="ck_platform_workload_signing_keys_status",
+        ),
+        CheckConstraint(
+            "algorithm IN ('RS256', 'ES256')",
+            name="ck_platform_workload_signing_keys_algorithm",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    kid: Mapped[str] = mapped_column(String(200), unique=True, nullable=False)
+    algorithm: Mapped[str] = mapped_column(String(16), nullable=False)
+    private_key_ref: Mapped[str] = mapped_column(String(500), unique=True, nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(32),
+        default=PLATFORM_WORKLOAD_SIGNING_KEY_ACTIVE,
+        server_default=PLATFORM_WORKLOAD_SIGNING_KEY_ACTIVE,
+        nullable=False,
+        index=True,
+    )
+    not_before: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.auth import invalidate_api_key_auth_cache, require_admin_api_key
+from app.core.auth import invalidate_api_key_auth_cache
 from app.core.database import get_session
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeState
@@ -29,6 +29,7 @@ from app.schemas.platform import (
     PlatformRuntimeStateResponse,
     PlatformRuntimeStateUpsert,
 )
+from app.schemas.platform_oauth import PlatformOAuthErrorResponse, PlatformOAuthTokenResponse
 from app.schemas.session import EnvironmentCreatedResponse
 from app.services.agent_environments import (
     AgentEnvironmentIdConflict,
@@ -43,6 +44,14 @@ from app.services.platform_contract import (
     read_platform_replay,
     store_platform_response,
 )
+from app.services.platform_workload_auth import (
+    PlatformMutationAuth,
+    PlatformOAuthProtocolError,
+    PlatformWorkloadKeyResolver,
+    get_platform_workload_key_resolver,
+    issue_platform_workload_token,
+    require_platform_mutation_auth,
+)
 from app.services.sync_events import (
     queue_environment_runtime_manifest_changed,
     queue_runtime_manifest_changed,
@@ -55,6 +64,112 @@ IdempotencyKey = Annotated[
     Header(alias="Idempotency-Key", min_length=1, max_length=200),
 ]
 
+_OAUTH_NO_STORE_HEADERS = {
+    "Cache-Control": "no-store",
+    "Pragma": "no-cache",
+}
+_OAUTH_TOKEN_REQUEST_SCHEMA = {
+    "requestBody": {
+        "required": True,
+        "content": {
+            "application/x-www-form-urlencoded": {
+                "schema": {
+                    "type": "object",
+                    "required": [
+                        "grant_type",
+                        "client_id",
+                        "scope",
+                        "client_assertion_type",
+                        "client_assertion",
+                    ],
+                    "properties": {
+                        "grant_type": {"type": "string"},
+                        "client_id": {"type": "string"},
+                        "scope": {"type": "string"},
+                        "client_assertion_type": {"type": "string"},
+                        "client_assertion": {"type": "string"},
+                    },
+                }
+            }
+        },
+    }
+}
+
+
+def _oauth_error_response(exc: PlatformOAuthProtocolError) -> JSONResponse:
+    headers = dict(_OAUTH_NO_STORE_HEADERS)
+    body = PlatformOAuthErrorResponse(
+        error=exc.error,
+        error_description=exc.description,
+    )
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=body.model_dump(),
+        headers=headers,
+    )
+
+
+def _oauth_form_value(form: Any, name: str) -> str:
+    values = form.getlist(name)
+    if len(values) != 1 or not isinstance(values[0], str) or not values[0]:
+        raise PlatformOAuthProtocolError(
+            error="invalid_request",
+            description=f"{name} must be provided exactly once",
+        )
+    return values[0]
+
+
+@router.post(
+    "/oauth/token",
+    response_model=PlatformOAuthTokenResponse,
+    responses={
+        400: {"model": PlatformOAuthErrorResponse},
+        401: {"model": PlatformOAuthErrorResponse},
+        503: {"model": PlatformOAuthErrorResponse},
+    },
+    openapi_extra=_OAUTH_TOKEN_REQUEST_SCHEMA,
+)
+async def platform_workload_oauth_token(
+    request: Request,
+    db: AsyncSession = Depends(get_session),
+    resolver: PlatformWorkloadKeyResolver = Depends(get_platform_workload_key_resolver),
+) -> PlatformOAuthTokenResponse | Response:
+    if request.headers.getlist("authorization") or request.headers.getlist("x-admin-key"):
+        return _oauth_error_response(
+            PlatformOAuthProtocolError(
+                error="invalid_request",
+                description="client authentication must use client_assertion form fields only",
+            )
+        )
+    if request.headers.get("content-type", "").split(";", 1)[0].strip().lower() != (
+        "application/x-www-form-urlencoded"
+    ):
+        return _oauth_error_response(
+            PlatformOAuthProtocolError(
+                error="invalid_request",
+                description="content type must be application/x-www-form-urlencoded",
+            )
+        )
+    try:
+        form = await request.form()
+        issued = await issue_platform_workload_token(
+            db,
+            resolver,
+            grant_type=_oauth_form_value(form, "grant_type"),
+            client_id=_oauth_form_value(form, "client_id"),
+            scope=_oauth_form_value(form, "scope"),
+            client_assertion_type=_oauth_form_value(form, "client_assertion_type"),
+            client_assertion=_oauth_form_value(form, "client_assertion"),
+        )
+    except PlatformOAuthProtocolError as exc:
+        return _oauth_error_response(exc)
+    response = PlatformOAuthTokenResponse(
+        access_token=issued.access_token,
+        expires_in=issued.expires_in,
+        scope=issued.scope,
+    )
+    return JSONResponse(content=response.model_dump(), headers=_OAUTH_NO_STORE_HEADERS)
+
 
 def _audit_details(
     *,
@@ -65,12 +180,15 @@ def _audit_details(
     result: str,
     request_id: str,
     idempotency_key: str,
+    workload_sub: str | None,
+    credential_id: str | None,
+    token_jti: str | None,
     details: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     return {
-        "workload_sub": None,
-        "credential_id": None,
-        "token_jti": None,
+        "workload_sub": workload_sub,
+        "credential_id": credential_id,
+        "token_jti": token_jti,
         "owner": owner.model_dump(mode="json"),
         "resource": {"type": resource_type, "id": resource_id},
         "action": action,
@@ -95,6 +213,7 @@ def _record_platform_audit(
     environment_id: UUID | None = None,
     details: dict[str, Any] | None = None,
 ) -> None:
+    auth = getattr(request.state, "platform_mutation_auth", None)
     record_control_plane_audit(
         db,
         actor_type="platform",
@@ -112,6 +231,13 @@ def _record_platform_audit(
             result=result,
             request_id=str(request.state.request_id),
             idempotency_key=idempotency_key,
+            workload_sub=auth.client_id if auth is not None else None,
+            credential_id=(
+                str(auth.credential_id)
+                if auth is not None and auth.credential_id is not None
+                else None
+            ),
+            token_jti=auth.token_jti if auth is not None else None,
             details=details,
         ),
     )
@@ -373,7 +499,7 @@ async def platform_create_agent(
     body: PlatformAgentCreate,
     request: Request,
     idempotency_key: IdempotencyKey,
-    _: None = Depends(require_admin_api_key),
+    _auth: PlatformMutationAuth = Depends(require_platform_mutation_auth("platform:agents:create")),
     db: AsyncSession = Depends(get_session),
 ) -> EnvironmentCreatedResponse | Response:
     action = "agent_environment.create"
@@ -465,7 +591,7 @@ async def platform_delete_agent(
     body: PlatformMutationBody,
     request: Request,
     idempotency_key: IdempotencyKey,
-    _: None = Depends(require_admin_api_key),
+    _auth: PlatformMutationAuth = Depends(require_platform_mutation_auth("platform:agents:delete")),
     db: AsyncSession = Depends(get_session),
 ) -> Response:
     action = "agent_environment.delete"
@@ -536,7 +662,9 @@ async def platform_upsert_runtime_state(
     body: PlatformRuntimeStateUpsert,
     request: Request,
     idempotency_key: IdempotencyKey,
-    _: None = Depends(require_admin_api_key),
+    _auth: PlatformMutationAuth = Depends(
+        require_platform_mutation_auth("platform:runtime-state:write")
+    ),
     db: AsyncSession = Depends(get_session),
 ) -> PlatformRuntimeStateResponse | Response:
     action = "hosted_runtime_state.upsert"
@@ -674,7 +802,9 @@ async def platform_delete_runtime_state(
     body: PlatformMutationBody,
     request: Request,
     idempotency_key: IdempotencyKey,
-    _: None = Depends(require_admin_api_key),
+    _auth: PlatformMutationAuth = Depends(
+        require_platform_mutation_auth("platform:runtime-state:write")
+    ),
     db: AsyncSession = Depends(get_session),
 ) -> Response:
     action = "hosted_runtime_state.delete"
@@ -752,7 +882,7 @@ async def platform_mint_api_key(
     body: PlatformApiKeyCreate,
     request: Request,
     idempotency_key: IdempotencyKey,
-    _: None = Depends(require_admin_api_key),
+    _auth: PlatformMutationAuth = Depends(require_platform_mutation_auth("platform:keys:mint")),
     db: AsyncSession = Depends(get_session),
 ) -> ApiKeyCreated | Response:
     action = "api_key.mint"
@@ -838,7 +968,7 @@ async def platform_revoke_api_key(
     body: PlatformMutationBody,
     request: Request,
     idempotency_key: IdempotencyKey,
-    _: None = Depends(require_admin_api_key),
+    _auth: PlatformMutationAuth = Depends(require_platform_mutation_auth("platform:keys:revoke")),
     db: AsyncSession = Depends(get_session),
 ) -> ApiKeyRevokeResponse | Response:
     action = "api_key.revoke"

--- a/backend/app/schemas/platform_oauth.py
+++ b/backend/app/schemas/platform_oauth.py
@@ -1,0 +1,15 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class PlatformOAuthTokenResponse(BaseModel):
+    access_token: str
+    token_type: Literal["Bearer"] = "Bearer"
+    expires_in: int
+    scope: str
+
+
+class PlatformOAuthErrorResponse(BaseModel):
+    error: str
+    error_description: str

--- a/backend/app/services/platform_workload_auth.py
+++ b/backend/app/services/platform_workload_auth.py
@@ -1,0 +1,753 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Annotated, Any, Literal, Protocol
+from urllib.parse import urlsplit
+
+import jwt
+from fastapi import Depends, Header, HTTPException, Request, status
+from sqlalchemy import or_, select
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import require_admin_api_key
+from app.core.config import settings
+from app.core.database import get_session
+from app.models.platform_workload_auth import (
+    PLATFORM_WORKLOAD_CLIENT_ACTIVE,
+    PLATFORM_WORKLOAD_SIGNING_KEY_ACTIVE,
+    PLATFORM_WORKLOAD_SIGNING_KEY_RETIRED,
+    PlatformWorkloadAssertionReplay,
+    PlatformWorkloadClient,
+    PlatformWorkloadSigningKey,
+)
+
+PLATFORM_WORKLOAD_ACCESS_TOKEN_AUDIENCE = "clawdi-cloud-platform-admin"
+PLATFORM_WORKLOAD_ACCESS_TOKEN_TTL_SECONDS = 300
+PLATFORM_WORKLOAD_ASSERTION_MAX_TTL_SECONDS = 300
+PLATFORM_WORKLOAD_CLOCK_SKEW_SECONDS = 60
+PLATFORM_WORKLOAD_CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+PLATFORM_WORKLOAD_ALLOWED_ALGORITHMS = frozenset({"RS256", "ES256"})
+PLATFORM_WORKLOAD_SCOPES = (
+    "platform:agents:create",
+    "platform:agents:delete",
+    "platform:runtime-state:write",
+    "platform:keys:mint",
+    "platform:keys:revoke",
+)
+
+_PRIVATE_JWK_FIELDS = frozenset({"d", "p", "q", "dp", "dq", "qi", "oth", "k"})
+_MAX_JWT_LENGTH = 16_384
+
+
+class PlatformWorkloadKeyUnavailable(RuntimeError):
+    pass
+
+
+class PlatformWorkloadConfigurationUnavailable(RuntimeError):
+    pass
+
+
+class PlatformWorkloadKeyResolver(Protocol):
+    async def sign_jwt(
+        self,
+        *,
+        private_key_ref: str,
+        payload: dict[str, Any],
+        algorithm: str,
+        headers: dict[str, Any],
+    ) -> str: ...
+
+    async def resolve_verification_key(
+        self,
+        *,
+        private_key_ref: str,
+        algorithm: str,
+    ) -> Any: ...
+
+
+class UnconfiguredPlatformWorkloadKeyResolver:
+    async def sign_jwt(
+        self,
+        *,
+        private_key_ref: str,
+        payload: dict[str, Any],
+        algorithm: str,
+        headers: dict[str, Any],
+    ) -> str:
+        raise PlatformWorkloadKeyUnavailable("platform workload signing resolver is unavailable")
+
+    async def resolve_verification_key(
+        self,
+        *,
+        private_key_ref: str,
+        algorithm: str,
+    ) -> Any:
+        raise PlatformWorkloadKeyUnavailable("platform workload signing resolver is unavailable")
+
+
+class InMemoryPlatformWorkloadKeyResolver:
+    """Local/test resolver that never persists private key material in the database."""
+
+    def __init__(self, keys: dict[str, Any]):
+        self._keys = dict(keys)
+
+    def _private_key(self, private_key_ref: str) -> Any:
+        try:
+            return self._keys[private_key_ref]
+        except KeyError as exc:
+            raise PlatformWorkloadKeyUnavailable(
+                f"unknown platform workload private key ref: {private_key_ref}"
+            ) from exc
+
+    async def sign_jwt(
+        self,
+        *,
+        private_key_ref: str,
+        payload: dict[str, Any],
+        algorithm: str,
+        headers: dict[str, Any],
+    ) -> str:
+        try:
+            return jwt.encode(
+                payload,
+                self._private_key(private_key_ref),
+                algorithm=algorithm,
+                headers=headers,
+            )
+        except (TypeError, ValueError, jwt.PyJWTError) as exc:
+            raise PlatformWorkloadKeyUnavailable(
+                f"platform workload signing failed for ref: {private_key_ref}"
+            ) from exc
+
+    async def resolve_verification_key(
+        self,
+        *,
+        private_key_ref: str,
+        algorithm: str,
+    ) -> Any:
+        private_key = self._private_key(private_key_ref)
+        public_key = getattr(private_key, "public_key", None)
+        return public_key() if callable(public_key) else private_key
+
+
+_unconfigured_key_resolver = UnconfiguredPlatformWorkloadKeyResolver()
+
+
+def get_platform_workload_key_resolver() -> PlatformWorkloadKeyResolver:
+    # TODO(A0.7d0): Real KMS/secret-manager signing and public-key resolution is
+    # an M3 launch prerequisite. The OSS default must remain fail-closed until it is wired.
+    return _unconfigured_key_resolver
+
+
+def canonical_platform_workload_token_endpoint() -> str:
+    configured = settings.platform_workload_token_endpoint.strip()
+    endpoint = configured or f"{settings.public_api_url.rstrip('/')}/v1/platform/oauth/token"
+    parsed = urlsplit(endpoint)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise PlatformWorkloadConfigurationUnavailable(
+            "platform workload token endpoint must be an absolute HTTP(S) URL"
+        )
+    return endpoint
+
+
+def platform_workload_issuer() -> str:
+    issuer = settings.platform_workload_issuer.strip()
+    if not issuer:
+        raise PlatformWorkloadConfigurationUnavailable(
+            "platform workload issuer must be configured"
+        )
+    return issuer
+
+
+@dataclass(frozen=True)
+class PlatformOAuthProtocolError(Exception):
+    error: str
+    description: str
+    status_code: int = status.HTTP_400_BAD_REQUEST
+
+
+@dataclass(frozen=True)
+class IssuedPlatformWorkloadToken:
+    access_token: str
+    expires_in: int
+    scope: str
+
+
+@dataclass(frozen=True)
+class PlatformMutationAuth:
+    kind: Literal["admin", "workload"]
+    client_id: str | None = None
+    credential_id: uuid.UUID | None = None
+    token_jti: str | None = None
+    scopes: tuple[str, ...] = ()
+
+
+class PlatformWorkloadAccessError(Exception):
+    def __init__(self, status_code: int, detail: str):
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+def _invalid_client(
+    description: str = "client authentication failed",
+) -> PlatformOAuthProtocolError:
+    return PlatformOAuthProtocolError(
+        error="invalid_client",
+        description=description,
+        status_code=status.HTTP_401_UNAUTHORIZED,
+    )
+
+
+def _temporarily_unavailable() -> PlatformOAuthProtocolError:
+    return PlatformOAuthProtocolError(
+        error="temporarily_unavailable",
+        description="authorization server storage or signing service is unavailable",
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+    )
+
+
+def _numeric_date(payload: dict[str, Any], claim: str) -> int:
+    value = payload.get(claim)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise _invalid_client()
+    return int(value)
+
+
+def _validate_time_window(
+    payload: dict[str, Any],
+    *,
+    now: datetime,
+    max_ttl_seconds: int,
+    clock_skew_seconds: int,
+    require_nbf: bool,
+) -> tuple[int, int]:
+    iat = _numeric_date(payload, "iat")
+    exp = _numeric_date(payload, "exp")
+    now_seconds = int(now.timestamp())
+    if exp <= iat or exp - iat > max_ttl_seconds:
+        raise _invalid_client()
+    if iat > now_seconds + clock_skew_seconds:
+        raise _invalid_client()
+    if exp <= now_seconds - clock_skew_seconds:
+        raise _invalid_client()
+    if require_nbf or "nbf" in payload:
+        nbf = _numeric_date(payload, "nbf")
+        if nbf > now_seconds + clock_skew_seconds:
+            raise _invalid_client()
+        if nbf > exp:
+            raise _invalid_client()
+    return iat, exp
+
+
+def _parse_scope(value: str) -> tuple[str, ...]:
+    scopes = tuple(value.split())
+    if not scopes or len(scopes) != len(set(scopes)):
+        raise PlatformOAuthProtocolError("invalid_scope", "scope must be non-empty and unique")
+    if not set(scopes) <= set(PLATFORM_WORKLOAD_SCOPES):
+        raise PlatformOAuthProtocolError("invalid_scope", "requested scope is not approved")
+    return tuple(scope for scope in PLATFORM_WORKLOAD_SCOPES if scope in scopes)
+
+
+def _validated_client_scopes(client: PlatformWorkloadClient) -> frozenset[str]:
+    scopes = client.allowed_scopes or []
+    if not scopes or len(scopes) != len(set(scopes)):
+        raise _temporarily_unavailable()
+    if not set(scopes) <= set(PLATFORM_WORKLOAD_SCOPES):
+        raise _temporarily_unavailable()
+    return frozenset(scopes)
+
+
+def _unverified_jwt(token: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not token or len(token) > _MAX_JWT_LENGTH or token.count(".") != 2:
+        raise _invalid_client()
+    try:
+        header = jwt.get_unverified_header(token)
+        payload = jwt.decode(
+            token,
+            options={"verify_signature": False, "verify_aud": False},
+        )
+    except jwt.PyJWTError as exc:
+        raise _invalid_client() from exc
+    if not isinstance(header, dict) or not isinstance(payload, dict):
+        raise _invalid_client()
+    return header, payload
+
+
+def _assertion_verification_key(
+    client: PlatformWorkloadClient,
+    header: dict[str, Any],
+) -> Any:
+    algorithm = header.get("alg")
+    kid = header.get("kid")
+    if algorithm not in PLATFORM_WORKLOAD_ALLOWED_ALGORITHMS:
+        raise _invalid_client()
+    if algorithm != client.assertion_algorithm or kid != client.assertion_kid:
+        raise _invalid_client()
+    if header.get("crit"):
+        raise _invalid_client()
+
+    jwk = client.public_jwk
+    if not isinstance(jwk, dict) or _PRIVATE_JWK_FIELDS.intersection(jwk):
+        raise _invalid_client()
+    if jwk.get("kid") != client.assertion_kid or jwk.get("alg") != algorithm:
+        raise _invalid_client()
+    if jwk.get("use") not in (None, "sig"):
+        raise _invalid_client()
+    key_ops = jwk.get("key_ops")
+    if key_ops is not None and (
+        not isinstance(key_ops, list) or "verify" not in key_ops or "sign" in key_ops
+    ):
+        raise _invalid_client()
+    try:
+        return jwt.PyJWK.from_dict(jwk, algorithm=algorithm).key
+    except jwt.PyJWTError as exc:
+        raise _invalid_client() from exc
+
+
+async def load_platform_workload_client(
+    db: AsyncSession,
+    client_id: str,
+) -> PlatformWorkloadClient | None:
+    return (
+        await db.execute(
+            select(PlatformWorkloadClient).where(PlatformWorkloadClient.client_id == client_id)
+        )
+    ).scalar_one_or_none()
+
+
+async def load_platform_workload_signing_key_for_issue(
+    db: AsyncSession,
+    *,
+    now: datetime,
+    token_expires_at: datetime,
+) -> PlatformWorkloadSigningKey | None:
+    return (
+        await db.execute(
+            select(PlatformWorkloadSigningKey)
+            .where(
+                PlatformWorkloadSigningKey.status == PLATFORM_WORKLOAD_SIGNING_KEY_ACTIVE,
+                PlatformWorkloadSigningKey.not_before <= now,
+                or_(
+                    PlatformWorkloadSigningKey.expires_at.is_(None),
+                    PlatformWorkloadSigningKey.expires_at >= token_expires_at,
+                ),
+            )
+            .order_by(
+                PlatformWorkloadSigningKey.not_before.desc(),
+                PlatformWorkloadSigningKey.created_at.desc(),
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+
+async def load_platform_workload_signing_key(
+    db: AsyncSession,
+    kid: str,
+) -> PlatformWorkloadSigningKey | None:
+    return (
+        await db.execute(
+            select(PlatformWorkloadSigningKey).where(PlatformWorkloadSigningKey.kid == kid)
+        )
+    ).scalar_one_or_none()
+
+
+async def store_platform_workload_assertion_replay(
+    db: AsyncSession,
+    *,
+    client_id: str,
+    jti: str,
+    assertion_expires_at: datetime,
+) -> bool:
+    statement = (
+        postgresql_insert(PlatformWorkloadAssertionReplay)
+        .values(
+            id=uuid.uuid4(),
+            client_id=client_id,
+            jti=jti,
+            assertion_expires_at=assertion_expires_at,
+        )
+        .on_conflict_do_nothing(constraint="uq_platform_workload_assertion_replays_client_jti")
+        .returning(PlatformWorkloadAssertionReplay.id)
+    )
+    return (await db.execute(statement)).scalar_one_or_none() is not None
+
+
+async def _safe_rollback(db: AsyncSession) -> None:
+    try:
+        await db.rollback()
+    except SQLAlchemyError:
+        pass
+
+
+async def issue_platform_workload_token(
+    db: AsyncSession,
+    resolver: PlatformWorkloadKeyResolver,
+    *,
+    grant_type: str,
+    client_id: str,
+    scope: str,
+    client_assertion_type: str,
+    client_assertion: str,
+    now: datetime | None = None,
+) -> IssuedPlatformWorkloadToken:
+    if grant_type != "client_credentials":
+        raise PlatformOAuthProtocolError(
+            "unsupported_grant_type",
+            "grant_type must be client_credentials",
+        )
+    if client_assertion_type != PLATFORM_WORKLOAD_CLIENT_ASSERTION_TYPE:
+        raise PlatformOAuthProtocolError(
+            "invalid_request",
+            "client_assertion_type must identify a JWT bearer assertion",
+        )
+    if not client_id or len(client_id) > 200:
+        raise _invalid_client()
+
+    current_time = now or datetime.now(UTC)
+    requested_scopes = _parse_scope(scope)
+    header, unverified_payload = _unverified_jwt(client_assertion)
+    if unverified_payload.get("iss") != client_id or unverified_payload.get("sub") != client_id:
+        raise _invalid_client()
+
+    try:
+        client = await load_platform_workload_client(db, client_id)
+        if client is None or client.status != PLATFORM_WORKLOAD_CLIENT_ACTIVE:
+            raise _invalid_client()
+
+        verification_key = _assertion_verification_key(client, header)
+        assertion_audience = canonical_platform_workload_token_endpoint()
+        try:
+            assertion_payload = jwt.decode(
+                client_assertion,
+                verification_key,
+                algorithms=[client.assertion_algorithm],
+                audience=assertion_audience,
+                issuer=client_id,
+                subject=client_id,
+                leeway=PLATFORM_WORKLOAD_CLOCK_SKEW_SECONDS,
+                options={"require": ["iss", "sub", "aud", "iat", "exp", "jti"]},
+            )
+        except jwt.PyJWTError as exc:
+            raise _invalid_client() from exc
+
+        if assertion_payload.get("aud") != assertion_audience:
+            raise _invalid_client()
+        iat, assertion_exp = _validate_time_window(
+            assertion_payload,
+            now=current_time,
+            max_ttl_seconds=PLATFORM_WORKLOAD_ASSERTION_MAX_TTL_SECONDS,
+            clock_skew_seconds=PLATFORM_WORKLOAD_CLOCK_SKEW_SECONDS,
+            require_nbf=False,
+        )
+        jti = assertion_payload.get("jti")
+        if not isinstance(jti, str) or not jti or len(jti) > 200:
+            raise _invalid_client()
+        if client.revoked_before is not None and iat <= int(client.revoked_before.timestamp()):
+            raise _invalid_client()
+        allowed_scopes = _validated_client_scopes(client)
+        if not set(requested_scopes) <= allowed_scopes:
+            raise PlatformOAuthProtocolError(
+                "invalid_scope",
+                "requested scope exceeds the client's grant",
+            )
+
+        token_iat = int(current_time.timestamp())
+        token_exp = token_iat + PLATFORM_WORKLOAD_ACCESS_TOKEN_TTL_SECONDS
+        token_expires_at = datetime.fromtimestamp(token_exp, tz=UTC)
+        signing_key = await load_platform_workload_signing_key_for_issue(
+            db,
+            now=current_time,
+            token_expires_at=token_expires_at,
+        )
+        if signing_key is None or signing_key.algorithm not in PLATFORM_WORKLOAD_ALLOWED_ALGORITHMS:
+            raise _temporarily_unavailable()
+
+        token_jti = str(uuid.uuid4())
+        scope_value = " ".join(requested_scopes)
+        access_token = await resolver.sign_jwt(
+            private_key_ref=signing_key.private_key_ref,
+            payload={
+                "iss": platform_workload_issuer(),
+                "sub": client.client_id,
+                "aud": PLATFORM_WORKLOAD_ACCESS_TOKEN_AUDIENCE,
+                "iat": token_iat,
+                "nbf": token_iat,
+                "exp": token_exp,
+                "jti": token_jti,
+                "client_id": client.client_id,
+                "credential_id": str(client.id),
+                "token_version": client.token_version,
+                "scope": scope_value,
+            },
+            algorithm=signing_key.algorithm,
+            headers={"kid": signing_key.kid, "typ": "at+jwt"},
+        )
+
+        inserted = await store_platform_workload_assertion_replay(
+            db,
+            client_id=client.client_id,
+            jti=jti,
+            assertion_expires_at=datetime.fromtimestamp(assertion_exp, tz=UTC),
+        )
+        if not inserted:
+            await db.commit()
+            raise _invalid_client("client assertion has already been used")
+        await db.commit()
+        return IssuedPlatformWorkloadToken(
+            access_token=access_token,
+            expires_in=PLATFORM_WORKLOAD_ACCESS_TOKEN_TTL_SECONDS,
+            scope=scope_value,
+        )
+    except PlatformOAuthProtocolError:
+        raise
+    except (
+        PlatformWorkloadConfigurationUnavailable,
+        PlatformWorkloadKeyUnavailable,
+        SQLAlchemyError,
+    ):
+        await _safe_rollback(db)
+        raise _temporarily_unavailable() from None
+
+
+def _invalid_access_token() -> PlatformWorkloadAccessError:
+    return PlatformWorkloadAccessError(
+        status.HTTP_401_UNAUTHORIZED,
+        "invalid workload access token",
+    )
+
+
+async def authenticate_platform_workload_access_token(
+    db: AsyncSession,
+    resolver: PlatformWorkloadKeyResolver,
+    token: str,
+    *,
+    required_scope: str,
+    now: datetime | None = None,
+) -> PlatformMutationAuth:
+    current_time = now or datetime.now(UTC)
+    try:
+        header, unverified_payload = _unverified_jwt(token)
+    except PlatformOAuthProtocolError as exc:
+        raise _invalid_access_token() from exc
+
+    client_id = unverified_payload.get("sub")
+    kid = header.get("kid")
+    algorithm = header.get("alg")
+    if (
+        not isinstance(client_id, str)
+        or not client_id
+        or len(client_id) > 200
+        or not isinstance(kid, str)
+        or not kid
+        or len(kid) > 200
+        or algorithm not in PLATFORM_WORKLOAD_ALLOWED_ALGORITHMS
+        or header.get("typ") != "at+jwt"
+        or header.get("crit")
+    ):
+        raise _invalid_access_token()
+
+    try:
+        client = await load_platform_workload_client(db, client_id)
+        signing_key = await load_platform_workload_signing_key(db, kid)
+        if client is None or signing_key is None:
+            raise _invalid_access_token()
+        if client.status != PLATFORM_WORKLOAD_CLIENT_ACTIVE:
+            raise _invalid_access_token()
+        if signing_key.status not in {
+            PLATFORM_WORKLOAD_SIGNING_KEY_ACTIVE,
+            PLATFORM_WORKLOAD_SIGNING_KEY_RETIRED,
+        }:
+            raise _invalid_access_token()
+        if signing_key.algorithm != algorithm:
+            raise _invalid_access_token()
+
+        verification_key = await resolver.resolve_verification_key(
+            private_key_ref=signing_key.private_key_ref,
+            algorithm=signing_key.algorithm,
+        )
+        issuer = platform_workload_issuer()
+        try:
+            payload = jwt.decode(
+                token,
+                verification_key,
+                algorithms=[signing_key.algorithm],
+                audience=PLATFORM_WORKLOAD_ACCESS_TOKEN_AUDIENCE,
+                issuer=issuer,
+                subject=client.client_id,
+                leeway=0,
+                options={
+                    "require": [
+                        "iss",
+                        "sub",
+                        "aud",
+                        "iat",
+                        "nbf",
+                        "exp",
+                        "jti",
+                        "client_id",
+                        "credential_id",
+                        "token_version",
+                        "scope",
+                    ]
+                },
+            )
+        except jwt.PyJWTError as exc:
+            raise _invalid_access_token() from exc
+
+        if payload.get("aud") != PLATFORM_WORKLOAD_ACCESS_TOKEN_AUDIENCE:
+            raise _invalid_access_token()
+        if payload.get("client_id") != client.client_id:
+            raise _invalid_access_token()
+        if payload.get("credential_id") != str(client.id):
+            raise _invalid_access_token()
+        token_version = payload.get("token_version")
+        if type(token_version) is not int or token_version != client.token_version:
+            raise _invalid_access_token()
+
+        try:
+            iat, token_exp = _validate_time_window(
+                payload,
+                now=current_time,
+                max_ttl_seconds=PLATFORM_WORKLOAD_ACCESS_TOKEN_TTL_SECONDS,
+                clock_skew_seconds=0,
+                require_nbf=True,
+            )
+        except PlatformOAuthProtocolError as exc:
+            raise _invalid_access_token() from exc
+        if client.revoked_before is not None and iat <= int(client.revoked_before.timestamp()):
+            raise _invalid_access_token()
+        if iat < int(signing_key.not_before.timestamp()):
+            raise _invalid_access_token()
+        if signing_key.expires_at is not None:
+            signing_key_expires_at = int(signing_key.expires_at.timestamp())
+            if iat >= signing_key_expires_at or token_exp > signing_key_expires_at:
+                raise _invalid_access_token()
+
+        token_scope = payload.get("scope")
+        if not isinstance(token_scope, str):
+            raise _invalid_access_token()
+        try:
+            scopes = _parse_scope(token_scope)
+        except PlatformOAuthProtocolError as exc:
+            raise _invalid_access_token() from exc
+        try:
+            allowed_scopes = _validated_client_scopes(client)
+        except PlatformOAuthProtocolError as exc:
+            raise PlatformWorkloadAccessError(
+                status.HTTP_503_SERVICE_UNAVAILABLE,
+                "workload auth client grant is unavailable",
+            ) from exc
+        if not set(scopes) <= allowed_scopes or required_scope not in scopes:
+            raise PlatformWorkloadAccessError(
+                status.HTTP_403_FORBIDDEN,
+                "workload access token lacks required scope",
+            )
+        token_jti = payload.get("jti")
+        if not isinstance(token_jti, str) or not token_jti or len(token_jti) > 200:
+            raise _invalid_access_token()
+        return PlatformMutationAuth(
+            kind="workload",
+            client_id=client.client_id,
+            credential_id=client.id,
+            token_jti=token_jti,
+            scopes=scopes,
+        )
+    except PlatformWorkloadAccessError:
+        raise
+    except (
+        PlatformWorkloadConfigurationUnavailable,
+        PlatformWorkloadKeyUnavailable,
+        SQLAlchemyError,
+    ):
+        await _safe_rollback(db)
+        raise PlatformWorkloadAccessError(
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            "workload auth storage or signing service is unavailable",
+        ) from None
+
+
+def _credential_values(request: Request, name: str) -> list[str]:
+    return request.headers.getlist(name)
+
+
+def require_platform_mutation_auth(required_scope: str):
+    if required_scope not in PLATFORM_WORKLOAD_SCOPES:
+        raise ValueError(f"unsupported platform workload scope: {required_scope}")
+
+    async def dependency(
+        request: Request,
+        x_admin_key: Annotated[str | None, Header(alias="X-Admin-Key")] = None,
+        authorization: Annotated[str | None, Header(alias="Authorization")] = None,
+        db: AsyncSession = Depends(get_session),
+        resolver: PlatformWorkloadKeyResolver = Depends(get_platform_workload_key_resolver),
+    ) -> PlatformMutationAuth:
+        admin_values = _credential_values(request, "x-admin-key")
+        authorization_values = _credential_values(request, "authorization")
+        if len(admin_values) > 1 or len(authorization_values) > 1:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, "multiple credentials are not allowed")
+        if admin_values and authorization_values:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, "ambiguous platform credentials")
+
+        if authorization_values:
+            raw_authorization = authorization_values[0].strip()
+            if "," in raw_authorization:
+                raise HTTPException(
+                    status.HTTP_400_BAD_REQUEST,
+                    "multiple credentials are not allowed",
+                )
+            scheme, separator, token = raw_authorization.partition(" ")
+            if separator != " " or scheme.lower() != "bearer" or not token.strip():
+                raise HTTPException(
+                    status.HTTP_401_UNAUTHORIZED,
+                    "invalid workload authorization",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+            try:
+                auth = await authenticate_platform_workload_access_token(
+                    db,
+                    resolver,
+                    token.strip(),
+                    required_scope=required_scope,
+                )
+            except PlatformWorkloadAccessError as exc:
+                headers = (
+                    {"WWW-Authenticate": 'Bearer error="invalid_token"'}
+                    if exc.status_code == status.HTTP_401_UNAUTHORIZED
+                    else None
+                )
+                raise HTTPException(exc.status_code, exc.detail, headers=headers) from exc
+            request.state.platform_mutation_auth = auth
+            return auth
+
+        if admin_values:
+            if "," in admin_values[0]:
+                raise HTTPException(
+                    status.HTTP_400_BAD_REQUEST,
+                    "multiple credentials are not allowed",
+                )
+            if not settings.platform_legacy_admin_auth_enabled:
+                raise HTTPException(
+                    status.HTTP_401_UNAUTHORIZED,
+                    "legacy platform admin auth is disabled",
+                )
+            await require_admin_api_key(x_admin_key=admin_values[0])
+            auth = PlatformMutationAuth(kind="admin")
+            request.state.platform_mutation_auth = auth
+            return auth
+
+        if settings.platform_legacy_admin_auth_enabled:
+            await require_admin_api_key(x_admin_key=x_admin_key)
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "platform credentials are required")
+
+    return dependency

--- a/backend/tests/test_agent_v2_runtime_contract_migration.py
+++ b/backend/tests/test_agent_v2_runtime_contract_migration.py
@@ -14,8 +14,9 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 REVISION = "d8f2a1c4b6e9"
-HEAD_REVISION = "f1a7c3d9e2b4"
-HEAD_DOWN_REVISION = "f3a1c7d9e2b4"
+HEAD_REVISION = "c7e4a9b2d6f1"
+HEAD_DOWN_REVISION = "f1a7c3d9e2b4"
+CONFIG_OBSERVATION_REVISION = "f3a1c7d9e2b4"
 MIGRATION_FILENAME = f"{REVISION}_finalize_agent_v2_runtime_contract.py"
 
 
@@ -39,7 +40,8 @@ def test_agent_v2_runtime_contract_migration_precedes_config_observation_migrati
 
     assert scripts.get_heads() == [HEAD_REVISION]
     assert scripts.get_revision(HEAD_REVISION).down_revision == HEAD_DOWN_REVISION
-    assert scripts.get_revision(HEAD_DOWN_REVISION).down_revision == "a26c40c6965e"
+    assert scripts.get_revision(HEAD_DOWN_REVISION).down_revision == CONFIG_OBSERVATION_REVISION
+    assert scripts.get_revision(CONFIG_OBSERVATION_REVISION).down_revision == "a26c40c6965e"
     assert scripts.get_revision("a26c40c6965e").down_revision == REVISION
     assert scripts.get_revision(REVISION).down_revision == "c4e8f1a2b3d5"
 

--- a/backend/tests/test_hosted_runtime_config_observation_migration.py
+++ b/backend/tests/test_hosted_runtime_config_observation_migration.py
@@ -13,6 +13,7 @@ from sqlalchemy import create_engine, inspect
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 REVISION = "f1a7c3d9e2b4"
+HEAD_REVISION = "c7e4a9b2d6f1"
 MIGRATION_FILENAME = f"{REVISION}_finalize_unlaunched_agent_v2_schema.py"
 
 
@@ -55,7 +56,8 @@ def test_agent_v2_final_schema_migration_is_single_head() -> None:
     config.set_main_option("script_location", str(backend_dir / "alembic"))
     scripts = ScriptDirectory.from_config(config)
 
-    assert scripts.get_heads() == [REVISION]
+    assert scripts.get_heads() == [HEAD_REVISION]
+    assert scripts.get_revision(HEAD_REVISION).down_revision == REVISION
     assert scripts.get_revision(REVISION).down_revision == "f3a1c7d9e2b4"
 
 

--- a/backend/tests/test_platform_endpoints.py
+++ b/backend/tests/test_platform_endpoints.py
@@ -811,6 +811,7 @@ async def test_platform_routes_are_canonical_and_exposed_in_openapi(platform_cli
         "/v1/platform/agents/{agent_id}/runtime-state",
         "/v1/platform/auth/keys",
         "/v1/platform/auth/keys/{key_id}",
+        "/v1/platform/oauth/token",
     }
     assert all(not path.startswith("/api/platform") for path in paths)
     assert set(paths["/v1/platform/agents/{agent_id}/runtime-state"]) == {"put", "delete"}

--- a/backend/tests/test_platform_workload_oauth.py
+++ b/backend/tests/test_platform_workload_oauth.py
@@ -1,0 +1,911 @@
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import httpx
+import jwt
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives.asymmetric import rsa
+from httpx import ASGITransport
+from sqlalchemy import delete, func, select
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.core.config import settings
+from app.core.database import get_session
+from app.main import app
+from app.models.api_key import ApiKey
+from app.models.audit import ControlPlaneAuditEvent
+from app.models.platform_workload_auth import (
+    PLATFORM_WORKLOAD_CLIENT_ACTIVE,
+    PLATFORM_WORKLOAD_CLIENT_DISABLED,
+    PlatformWorkloadAssertionReplay,
+    PlatformWorkloadClient,
+    PlatformWorkloadSigningKey,
+)
+from app.models.session import AgentEnvironment
+from app.models.user import User
+from app.schemas.platform import PLATFORM_RUNTIME_KEY_SCOPES
+from app.services import platform_workload_auth
+from app.services.platform_workload_auth import (
+    PLATFORM_WORKLOAD_ACCESS_TOKEN_AUDIENCE,
+    PLATFORM_WORKLOAD_ACCESS_TOKEN_TTL_SECONDS,
+    PLATFORM_WORKLOAD_CLIENT_ASSERTION_TYPE,
+    PLATFORM_WORKLOAD_SCOPES,
+    InMemoryPlatformWorkloadKeyResolver,
+    PlatformWorkloadAccessError,
+    PlatformWorkloadKeyUnavailable,
+    authenticate_platform_workload_access_token,
+    canonical_platform_workload_token_endpoint,
+    get_platform_workload_key_resolver,
+)
+
+_ADMIN_KEY = "test-platform-admin-secret"
+_TEST_CLI_PACKAGE_SPEC = "clawdi@0.12.10-beta.51"
+
+
+@dataclass
+class WorkloadHarness:
+    client: httpx.AsyncClient
+    credential: PlatformWorkloadClient
+    client_id: str
+    client_kid: str
+    client_private_key: Any
+    signing_private_key: Any
+    signing_key: PlatformWorkloadSigningKey
+    resolver: InMemoryPlatformWorkloadKeyResolver
+
+
+def _public_jwk(private_key: Any, *, kid: str) -> dict[str, Any]:
+    jwk = json.loads(jwt.algorithms.RSAAlgorithm.to_jwk(private_key.public_key()))
+    jwk.update({"kid": kid, "alg": "RS256", "use": "sig", "key_ops": ["verify"]})
+    return jwk
+
+
+@pytest_asyncio.fixture
+async def workload_harness(db_session, seed_user) -> AsyncIterator[WorkloadHarness]:
+    client_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    signing_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    client_id = f"hosted-workload-{uuid.uuid4().hex}"
+    client_kid = f"client-{uuid.uuid4().hex}"
+    signing_kid = f"issuer-{uuid.uuid4().hex}"
+    private_key_ref = f"memory://{signing_kid}"
+    now = datetime.now(UTC)
+    credential = PlatformWorkloadClient(
+        client_id=client_id,
+        assertion_kid=client_kid,
+        assertion_algorithm="RS256",
+        public_jwk=_public_jwk(client_private_key, kid=client_kid),
+        status=PLATFORM_WORKLOAD_CLIENT_ACTIVE,
+        allowed_scopes=list(PLATFORM_WORKLOAD_SCOPES),
+        token_version=1,
+    )
+    signing_key = PlatformWorkloadSigningKey(
+        kid=signing_kid,
+        algorithm="RS256",
+        private_key_ref=private_key_ref,
+        status="active",
+        not_before=now - timedelta(minutes=1),
+        expires_at=now + timedelta(hours=1),
+    )
+    db_session.add_all([credential, signing_key])
+    await db_session.commit()
+    await db_session.refresh(credential)
+    await db_session.refresh(signing_key)
+
+    resolver = InMemoryPlatformWorkloadKeyResolver({private_key_ref: signing_private_key})
+
+    async def _override_get_session():
+        yield db_session
+
+    def _override_resolver():
+        return resolver
+
+    original_admin_key = settings.admin_api_key
+    original_legacy_flag = settings.platform_legacy_admin_auth_enabled
+    original_public_api_url = settings.public_api_url
+    original_token_endpoint = settings.platform_workload_token_endpoint
+    original_issuer = settings.platform_workload_issuer
+    settings.admin_api_key = _ADMIN_KEY
+    settings.platform_legacy_admin_auth_enabled = True
+    settings.public_api_url = "http://test"
+    settings.platform_workload_token_endpoint = ""
+    settings.platform_workload_issuer = "clawdi-cloud-platform-test"
+    app.dependency_overrides[get_session] = _override_get_session
+    app.dependency_overrides[get_platform_workload_key_resolver] = _override_resolver
+    try:
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            yield WorkloadHarness(
+                client=client,
+                credential=credential,
+                client_id=client_id,
+                client_kid=client_kid,
+                client_private_key=client_private_key,
+                signing_private_key=signing_private_key,
+                signing_key=signing_key,
+                resolver=resolver,
+            )
+    finally:
+        app.dependency_overrides.clear()
+        settings.admin_api_key = original_admin_key
+        settings.platform_legacy_admin_auth_enabled = original_legacy_flag
+        settings.public_api_url = original_public_api_url
+        settings.platform_workload_token_endpoint = original_token_endpoint
+        settings.platform_workload_issuer = original_issuer
+        await db_session.execute(
+            delete(PlatformWorkloadAssertionReplay).where(
+                PlatformWorkloadAssertionReplay.client_id == client_id
+            )
+        )
+        await db_session.execute(
+            delete(PlatformWorkloadClient).where(PlatformWorkloadClient.client_id == client_id)
+        )
+        await db_session.execute(
+            delete(PlatformWorkloadSigningKey).where(PlatformWorkloadSigningKey.kid == signing_kid)
+        )
+        await db_session.commit()
+
+
+def _assertion(
+    harness: WorkloadHarness,
+    *,
+    payload_updates: dict[str, Any] | None = None,
+    remove_claims: tuple[str, ...] = (),
+    kid: str | None = None,
+    algorithm: str = "RS256",
+    signing_key: Any | None = None,
+    jti: str | None = None,
+) -> str:
+    now = int(datetime.now(UTC).timestamp())
+    payload: dict[str, Any] = {
+        "iss": harness.client_id,
+        "sub": harness.client_id,
+        "aud": canonical_platform_workload_token_endpoint(),
+        "iat": now,
+        "exp": now + 120,
+        "jti": jti or str(uuid.uuid4()),
+    }
+    payload.update(payload_updates or {})
+    for claim in remove_claims:
+        payload.pop(claim, None)
+    key = signing_key or harness.client_private_key
+    return jwt.encode(
+        payload,
+        key,
+        algorithm=algorithm,
+        headers={"kid": kid or harness.client_kid, "typ": "JWT"},
+    )
+
+
+async def _token_response(
+    harness: WorkloadHarness,
+    *,
+    scope: str,
+    assertion: str | None = None,
+    client_id: str | None = None,
+    grant_type: str = "client_credentials",
+    assertion_type: str = PLATFORM_WORKLOAD_CLIENT_ASSERTION_TYPE,
+) -> httpx.Response:
+    return await harness.client.post(
+        "/v1/platform/oauth/token",
+        data={
+            "grant_type": grant_type,
+            "client_id": client_id or harness.client_id,
+            "scope": scope,
+            "client_assertion_type": assertion_type,
+            "client_assertion": assertion or _assertion(harness),
+        },
+    )
+
+
+async def _access_token(harness: WorkloadHarness, scope: str) -> str:
+    response = await _token_response(harness, scope=scope)
+    assert response.status_code == 200, response.text
+    return response.json()["access_token"]
+
+
+def _workload_headers(token: str, idempotency_key: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Idempotency-Key": idempotency_key,
+    }
+
+
+def _owner(user: User) -> dict[str, str]:
+    assert user.clerk_id is not None
+    return {"kind": "clerk", "ref": user.clerk_id}
+
+
+def _agent_body(owner: dict[str, str], agent_id: uuid.UUID) -> dict[str, Any]:
+    return {
+        "owner": owner,
+        "agent_id": str(agent_id),
+        "machine_id": f"machine-{agent_id.hex[:8]}",
+        "machine_name": "workload-platform-agent",
+        "agent_type": "openclaw",
+        "agent_version": "1.0.0",
+        "os_name": "linux",
+    }
+
+
+def _runtime_body(owner: dict[str, str], agent_id: uuid.UUID) -> dict[str, Any]:
+    return {
+        "owner": owner,
+        "deployment_id": "deployment-workload",
+        "instance_id": "instance-workload",
+        "generation": 1,
+        "cli_package_spec": _TEST_CLI_PACKAGE_SPEC,
+        "locale": {"language": "en", "timezone": "UTC"},
+        "system": {
+            "user": "clawdi",
+            "home": "/home/clawdi",
+            "workspace": "/home/clawdi/clawdi",
+            "persistentPaths": ["/home/clawdi"],
+        },
+        "runtimes": {
+            "openclaw": {
+                "enabled": True,
+                "provider_ids": ["clawdi-managed-v2"],
+                "primary_model": {
+                    "provider_id": "clawdi-managed-v2",
+                    "model": "gpt-5.5",
+                },
+                "install": {"source": "official"},
+                "run": {"args": ["gateway", "run"]},
+                "services": {},
+                "paths": {
+                    "home": "/home/clawdi",
+                    "workspace": "/home/clawdi/clawdi",
+                },
+            }
+        },
+        "live_sync": {
+            "enabled": True,
+            "agents": [
+                {
+                    "agentType": "openclaw",
+                    "environmentId": str(agent_id),
+                }
+            ],
+        },
+        "recovery": {"cacheManifest": True, "allowOfflineBoot": True},
+    }
+
+
+@pytest.mark.asyncio
+async def test_oauth_issues_at_jwt_with_fixed_contract_and_short_ttl(
+    workload_harness,
+    db_session,
+):
+    assertion_jti = str(uuid.uuid4())
+    response = await _token_response(
+        workload_harness,
+        scope="platform:agents:create platform:keys:mint",
+        assertion=_assertion(workload_harness, jti=assertion_jti),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.headers["cache-control"] == "no-store"
+    assert response.headers["pragma"] == "no-cache"
+    body = response.json()
+    assert body["token_type"] == "Bearer"
+    assert body["expires_in"] == PLATFORM_WORKLOAD_ACCESS_TOKEN_TTL_SECONDS
+    assert body["scope"] == "platform:agents:create platform:keys:mint"
+
+    header = jwt.get_unverified_header(body["access_token"])
+    assert header == {
+        "alg": "RS256",
+        "kid": workload_harness.signing_key.kid,
+        "typ": "at+jwt",
+    }
+    claims = jwt.decode(
+        body["access_token"],
+        workload_harness.signing_private_key.public_key(),
+        algorithms=["RS256"],
+        audience=PLATFORM_WORKLOAD_ACCESS_TOKEN_AUDIENCE,
+        issuer=settings.platform_workload_issuer,
+    )
+    assert claims["sub"] == workload_harness.credential.client_id
+    assert claims["client_id"] == workload_harness.credential.client_id
+    assert claims["credential_id"] == str(workload_harness.credential.id)
+    assert claims["token_version"] == 1
+    assert claims["scope"] == body["scope"]
+    assert claims["exp"] - claims["iat"] == PLATFORM_WORKLOAD_ACCESS_TOKEN_TTL_SECONDS
+    assert claims["nbf"] == claims["iat"]
+    replay_count = await db_session.scalar(
+        select(func.count())
+        .select_from(PlatformWorkloadAssertionReplay)
+        .where(
+            PlatformWorkloadAssertionReplay.client_id == workload_harness.credential.client_id,
+            PlatformWorkloadAssertionReplay.jti == assertion_jti,
+        )
+    )
+    assert replay_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("case", "expected_error"),
+    [
+        ("grant_type", "unsupported_grant_type"),
+        ("assertion_type", "invalid_request"),
+        ("client_id", "invalid_client"),
+        ("kid", "invalid_client"),
+        ("algorithm", "invalid_client"),
+        ("signature", "invalid_client"),
+        ("issuer", "invalid_client"),
+        ("subject", "invalid_client"),
+        ("audience", "invalid_client"),
+        ("missing_issuer", "invalid_client"),
+        ("missing_subject", "invalid_client"),
+        ("missing_audience", "invalid_client"),
+        ("missing_iat", "invalid_client"),
+        ("missing_exp", "invalid_client"),
+        ("future_iat", "invalid_client"),
+        ("future_nbf", "invalid_client"),
+        ("expired", "invalid_client"),
+        ("long_lived", "invalid_client"),
+        ("empty_jti", "invalid_client"),
+        ("missing_jti", "invalid_client"),
+    ],
+)
+async def test_oauth_rejects_invalid_protocol_and_assertion_branches(
+    workload_harness,
+    case,
+    expected_error,
+):
+    now = int(datetime.now(UTC).timestamp())
+    kwargs: dict[str, Any] = {"scope": "platform:agents:create"}
+    if case == "grant_type":
+        kwargs["grant_type"] = "authorization_code"
+    elif case == "assertion_type":
+        kwargs["assertion_type"] = "urn:example:wrong"
+    elif case == "client_id":
+        kwargs["client_id"] = f"wrong-{uuid.uuid4().hex}"
+    elif case == "kid":
+        kwargs["assertion"] = _assertion(workload_harness, kid="wrong-kid")
+    elif case == "algorithm":
+        kwargs["assertion"] = _assertion(
+            workload_harness,
+            algorithm="HS256",
+            signing_key="not-a-public-key-not-a-public-key",
+        )
+    elif case == "signature":
+        kwargs["assertion"] = _assertion(
+            workload_harness,
+            signing_key=rsa.generate_private_key(public_exponent=65537, key_size=2048),
+        )
+    elif case == "issuer":
+        kwargs["assertion"] = _assertion(workload_harness, payload_updates={"iss": "wrong"})
+    elif case == "subject":
+        kwargs["assertion"] = _assertion(workload_harness, payload_updates={"sub": "wrong"})
+    elif case == "audience":
+        kwargs["assertion"] = _assertion(
+            workload_harness,
+            payload_updates={"aud": "https://wrong.example/token"},
+        )
+    elif case == "missing_issuer":
+        kwargs["assertion"] = _assertion(workload_harness, remove_claims=("iss",))
+    elif case == "missing_subject":
+        kwargs["assertion"] = _assertion(workload_harness, remove_claims=("sub",))
+    elif case == "missing_audience":
+        kwargs["assertion"] = _assertion(workload_harness, remove_claims=("aud",))
+    elif case == "missing_iat":
+        kwargs["assertion"] = _assertion(workload_harness, remove_claims=("iat",))
+    elif case == "missing_exp":
+        kwargs["assertion"] = _assertion(workload_harness, remove_claims=("exp",))
+    elif case == "future_iat":
+        kwargs["assertion"] = _assertion(
+            workload_harness,
+            payload_updates={"iat": now + 120, "exp": now + 240},
+        )
+    elif case == "future_nbf":
+        kwargs["assertion"] = _assertion(
+            workload_harness,
+            payload_updates={"nbf": now + 120},
+        )
+    elif case == "expired":
+        kwargs["assertion"] = _assertion(
+            workload_harness,
+            payload_updates={"iat": now - 240, "exp": now - 120},
+        )
+    elif case == "long_lived":
+        kwargs["assertion"] = _assertion(
+            workload_harness,
+            payload_updates={"iat": now, "exp": now + 301},
+        )
+    elif case == "empty_jti":
+        kwargs["assertion"] = _assertion(workload_harness, payload_updates={"jti": ""})
+    elif case == "missing_jti":
+        kwargs["assertion"] = _assertion(workload_harness, remove_claims=("jti",))
+
+    response = await _token_response(workload_harness, **kwargs)
+
+    assert response.status_code in {400, 401}, response.text
+    assert response.json()["error"] == expected_error
+    assert response.headers["cache-control"] == "no-store"
+
+
+@pytest.mark.asyncio
+async def test_oauth_rejects_replay_and_scope_escalation(workload_harness):
+    workload_harness.credential.allowed_scopes = ["platform:agents:create"]
+    assertion = _assertion(workload_harness)
+    first = await _token_response(
+        workload_harness,
+        scope="platform:agents:create",
+        assertion=assertion,
+    )
+    replay = await _token_response(
+        workload_harness,
+        scope="platform:agents:create",
+        assertion=assertion,
+    )
+    escalated = await _token_response(
+        workload_harness,
+        scope="platform:agents:create platform:agents:delete",
+    )
+    unapproved = await _token_response(workload_harness, scope="platform:root")
+
+    assert first.status_code == 200, first.text
+    assert replay.status_code == 401, replay.text
+    assert replay.json()["error"] == "invalid_client"
+    assert escalated.status_code == 400, escalated.text
+    assert escalated.json()["error"] == "invalid_scope"
+    assert unapproved.status_code == 400, unapproved.text
+    assert unapproved.json()["error"] == "invalid_scope"
+
+
+@pytest.mark.asyncio
+async def test_oauth_enforces_client_status_and_revoked_before(
+    workload_harness,
+    db_session,
+):
+    workload_harness.credential.status = PLATFORM_WORKLOAD_CLIENT_DISABLED
+    await db_session.commit()
+    disabled = await _token_response(workload_harness, scope="platform:agents:create")
+    assert disabled.status_code == 401, disabled.text
+
+    workload_harness.credential.status = PLATFORM_WORKLOAD_CLIENT_ACTIVE
+    workload_harness.credential.revoked_before = datetime.now(UTC)
+    await db_session.commit()
+    now = int(datetime.now(UTC).timestamp())
+    revoked = await _token_response(
+        workload_harness,
+        scope="platform:agents:create",
+        assertion=_assertion(
+            workload_harness,
+            payload_updates={"iat": now - 1, "exp": now + 60},
+        ),
+    )
+    assert revoked.status_code == 401, revoked.text
+    assert revoked.json()["error"] == "invalid_client"
+
+
+@pytest.mark.asyncio
+async def test_oauth_storage_failures_are_503(
+    workload_harness,
+    monkeypatch,
+):
+    async def unavailable_client(*args, **kwargs):
+        raise SQLAlchemyError("client storage unavailable")
+
+    monkeypatch.setattr(
+        platform_workload_auth,
+        "load_platform_workload_client",
+        unavailable_client,
+    )
+    client_failure = await _token_response(workload_harness, scope="platform:agents:create")
+    assert client_failure.status_code == 503, client_failure.text
+    assert client_failure.json()["error"] == "temporarily_unavailable"
+
+    monkeypatch.undo()
+
+    async def unavailable_replay(*args, **kwargs):
+        raise SQLAlchemyError("replay storage unavailable")
+
+    monkeypatch.setattr(
+        platform_workload_auth,
+        "store_platform_workload_assertion_replay",
+        unavailable_replay,
+    )
+    replay_failure = await _token_response(workload_harness, scope="platform:agents:create")
+    assert replay_failure.status_code == 503, replay_failure.text
+    assert replay_failure.json()["error"] == "temporarily_unavailable"
+
+    monkeypatch.undo()
+
+    async def unavailable_signing_key(*args, **kwargs):
+        raise SQLAlchemyError("issuer key storage unavailable")
+
+    monkeypatch.setattr(
+        platform_workload_auth,
+        "load_platform_workload_signing_key_for_issue",
+        unavailable_signing_key,
+    )
+    signing_key_failure = await _token_response(
+        workload_harness,
+        scope="platform:agents:create",
+    )
+    assert signing_key_failure.status_code == 503, signing_key_failure.text
+    assert signing_key_failure.json()["error"] == "temporarily_unavailable"
+
+    monkeypatch.undo()
+
+    async def unavailable_signer(**kwargs):
+        raise PlatformWorkloadKeyUnavailable("signer unavailable")
+
+    monkeypatch.setattr(workload_harness.resolver, "sign_jwt", unavailable_signer)
+    signer_failure = await _token_response(workload_harness, scope="platform:agents:create")
+    assert signer_failure.status_code == 503, signer_failure.text
+    assert signer_failure.json()["error"] == "temporarily_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_workload_tokens_cover_exact_six_route_scope_mapping(
+    workload_harness,
+    seed_user,
+    db_session,
+):
+    owner = _owner(seed_user)
+    agent_id = uuid.uuid4()
+
+    create_token = await _access_token(workload_harness, "platform:agents:create")
+    created = await workload_harness.client.post(
+        "/v1/platform/agents",
+        headers=_workload_headers(create_token, "workload-create"),
+        json=_agent_body(owner, agent_id),
+    )
+    assert created.status_code == 200, created.text
+
+    runtime_token = await _access_token(workload_harness, "platform:runtime-state:write")
+    runtime = await workload_harness.client.put(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_workload_headers(runtime_token, "workload-runtime-put"),
+        json=_runtime_body(owner, agent_id),
+    )
+    assert runtime.status_code == 200, runtime.text
+
+    mint_token = await _access_token(workload_harness, "platform:keys:mint")
+    minted = await workload_harness.client.post(
+        "/v1/platform/auth/keys",
+        headers=_workload_headers(mint_token, "workload-key-mint"),
+        json={
+            "owner": owner,
+            "label": "workload-managed",
+            "environment_id": str(agent_id),
+            "scopes": list(PLATFORM_RUNTIME_KEY_SCOPES),
+        },
+    )
+    assert minted.status_code == 200, minted.text
+    key_id = minted.json()["id"]
+
+    revoke_token = await _access_token(workload_harness, "platform:keys:revoke")
+    revoked = await workload_harness.client.request(
+        "DELETE",
+        f"/v1/platform/auth/keys/{key_id}",
+        headers=_workload_headers(revoke_token, "workload-key-revoke"),
+        json={"owner": owner},
+    )
+    assert revoked.status_code == 200, revoked.text
+    revoked_key = await db_session.get(ApiKey, uuid.UUID(key_id))
+    assert revoked_key is not None and revoked_key.revoked_at is not None
+
+    deleted_runtime = await workload_harness.client.request(
+        "DELETE",
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_workload_headers(runtime_token, "workload-runtime-delete"),
+        json={"owner": owner},
+    )
+    assert deleted_runtime.status_code == 204, deleted_runtime.text
+
+    delete_token = await _access_token(workload_harness, "platform:agents:delete")
+    deleted_agent = await workload_harness.client.request(
+        "DELETE",
+        f"/v1/platform/agents/{agent_id}",
+        headers=_workload_headers(delete_token, "workload-agent-delete"),
+        json={"owner": owner},
+    )
+    assert deleted_agent.status_code == 204, deleted_agent.text
+
+    events = (
+        await db_session.execute(
+            select(ControlPlaneAuditEvent).where(
+                ControlPlaneAuditEvent.source == "api.platform",
+                ControlPlaneAuditEvent.details["workload_sub"].astext
+                == workload_harness.credential.client_id,
+            )
+        )
+    ).scalars()
+    event_list = list(events)
+    assert len(event_list) == 6
+    assert all(
+        event.details["credential_id"] == "[REDACTED]"
+        and event.details["token_jti"] == "[REDACTED]"
+        for event in event_list
+    )
+    assert await db_session.get(AgentEnvironment, agent_id) is None
+
+
+@pytest.mark.asyncio
+async def test_workload_owner_is_still_mandatory_and_mismatch_is_forbidden(
+    workload_harness,
+    seed_user,
+    db_session,
+):
+    token = await _access_token(workload_harness, "platform:agents:create")
+    missing_owner = await workload_harness.client.post(
+        "/v1/platform/agents",
+        headers=_workload_headers(token, "workload-missing-owner"),
+        json={
+            "agent_id": str(uuid.uuid4()),
+            "machine_id": "missing-owner",
+            "machine_name": "missing-owner",
+            "agent_type": "openclaw",
+        },
+    )
+    assert missing_owner.status_code == 422, missing_owner.text
+    assert any(error["loc"][-1] == "owner" for error in missing_owner.json()["detail"])
+
+    agent_id = uuid.uuid4()
+    admin_created = await workload_harness.client.post(
+        "/v1/platform/agents",
+        headers={"X-Admin-Key": _ADMIN_KEY, "Idempotency-Key": "admin-owner-create"},
+        json=_agent_body(_owner(seed_user), agent_id),
+    )
+    assert admin_created.status_code == 200, admin_created.text
+    other_user = User(
+        clerk_id=f"other_{uuid.uuid4().hex}",
+        email="other-workload@example.test",
+        name="Other Workload Owner",
+    )
+    db_session.add(other_user)
+    await db_session.commit()
+
+    delete_token = await _access_token(workload_harness, "platform:agents:delete")
+    mismatch = await workload_harness.client.request(
+        "DELETE",
+        f"/v1/platform/agents/{agent_id}",
+        headers=_workload_headers(delete_token, "workload-owner-mismatch"),
+        json={"owner": _owner(other_user)},
+    )
+    assert mismatch.status_code == 403, mismatch.text
+    assert await db_session.get(AgentEnvironment, agent_id) is not None
+
+    await db_session.execute(delete(AgentEnvironment).where(AgentEnvironment.id == agent_id))
+    await db_session.delete(other_user)
+    await db_session.commit()
+
+
+@pytest.mark.asyncio
+async def test_workload_resource_auth_enforces_scope_status_version_and_revocation(
+    workload_harness,
+    seed_user,
+    db_session,
+):
+    owner = _owner(seed_user)
+    token = await _access_token(workload_harness, "platform:agents:create")
+
+    wrong_scope = await workload_harness.client.request(
+        "DELETE",
+        f"/v1/platform/agents/{uuid.uuid4()}",
+        headers=_workload_headers(token, "workload-wrong-scope"),
+        json={"owner": owner},
+    )
+    assert wrong_scope.status_code == 403, wrong_scope.text
+
+    workload_harness.credential.status = PLATFORM_WORKLOAD_CLIENT_DISABLED
+    await db_session.commit()
+    disabled = await workload_harness.client.post(
+        "/v1/platform/agents",
+        headers=_workload_headers(token, "workload-disabled"),
+        json=_agent_body(owner, uuid.uuid4()),
+    )
+    assert disabled.status_code == 401, disabled.text
+
+    workload_harness.credential.status = PLATFORM_WORKLOAD_CLIENT_ACTIVE
+    workload_harness.credential.token_version += 1
+    await db_session.commit()
+    old_version = await workload_harness.client.post(
+        "/v1/platform/agents",
+        headers=_workload_headers(token, "workload-old-version"),
+        json=_agent_body(owner, uuid.uuid4()),
+    )
+    assert old_version.status_code == 401, old_version.text
+
+    workload_harness.credential.token_version -= 1
+    workload_harness.credential.revoked_before = datetime.now(UTC)
+    await db_session.commit()
+    revoked_before = await workload_harness.client.post(
+        "/v1/platform/agents",
+        headers=_workload_headers(token, "workload-revoked-before"),
+        json=_agent_body(owner, uuid.uuid4()),
+    )
+    assert revoked_before.status_code == 401, revoked_before.text
+
+    workload_harness.credential.revoked_before = None
+    workload_harness.signing_key.status = "revoked"
+    await db_session.commit()
+    revoked_signing_key = await workload_harness.client.post(
+        "/v1/platform/agents",
+        headers=_workload_headers(token, "workload-revoked-signing-key"),
+        json=_agent_body(owner, uuid.uuid4()),
+    )
+    assert revoked_signing_key.status_code == 401, revoked_signing_key.text
+
+
+@pytest.mark.asyncio
+async def test_workload_access_token_expires_at_exactly_five_minutes(
+    workload_harness,
+    db_session,
+):
+    token = await _access_token(workload_harness, "platform:agents:create")
+    claims = jwt.decode(token, options={"verify_signature": False, "verify_aud": False})
+
+    with pytest.raises(PlatformWorkloadAccessError) as exc_info:
+        await authenticate_platform_workload_access_token(
+            db_session,
+            workload_harness.resolver,
+            token,
+            required_scope="platform:agents:create",
+            now=datetime.fromtimestamp(claims["exp"], tz=UTC),
+        )
+
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_workload_resource_storage_failure_is_503_without_admin_fallback(
+    workload_harness,
+    seed_user,
+    monkeypatch,
+):
+    token = await _access_token(workload_harness, "platform:agents:create")
+    owner = _owner(seed_user)
+
+    async def unavailable_client(*args, **kwargs):
+        raise SQLAlchemyError("status storage unavailable")
+
+    monkeypatch.setattr(
+        platform_workload_auth,
+        "load_platform_workload_client",
+        unavailable_client,
+    )
+    response = await workload_harness.client.post(
+        "/v1/platform/agents",
+        headers=_workload_headers(token, "workload-status-unavailable"),
+        json=_agent_body(owner, uuid.uuid4()),
+    )
+    assert response.status_code == 503, response.text
+
+    monkeypatch.undo()
+
+    async def unavailable_signing_key(*args, **kwargs):
+        raise SQLAlchemyError("issuer key status storage unavailable")
+
+    monkeypatch.setattr(
+        platform_workload_auth,
+        "load_platform_workload_signing_key",
+        unavailable_signing_key,
+    )
+    signing_key_failure = await workload_harness.client.post(
+        "/v1/platform/agents",
+        headers=_workload_headers(token, "workload-signing-key-unavailable"),
+        json=_agent_body(owner, uuid.uuid4()),
+    )
+    assert signing_key_failure.status_code == 503, signing_key_failure.text
+
+    monkeypatch.undo()
+
+    async def unavailable_verifier(**kwargs):
+        raise PlatformWorkloadKeyUnavailable("verification key unavailable")
+
+    monkeypatch.setattr(
+        workload_harness.resolver,
+        "resolve_verification_key",
+        unavailable_verifier,
+    )
+    verifier_failure = await workload_harness.client.post(
+        "/v1/platform/agents",
+        headers=_workload_headers(token, "workload-verifier-unavailable"),
+        json=_agent_body(owner, uuid.uuid4()),
+    )
+    assert verifier_failure.status_code == 503, verifier_failure.text
+
+
+@pytest.mark.asyncio
+async def test_platform_credential_selection_legacy_flag_ambiguity_and_no_fallback(
+    workload_harness,
+    seed_user,
+):
+    owner = _owner(seed_user)
+    admin_success = await workload_harness.client.post(
+        "/v1/platform/agents",
+        headers={"X-Admin-Key": _ADMIN_KEY, "Idempotency-Key": "legacy-admin-enabled"},
+        json=_agent_body(owner, uuid.uuid4()),
+    )
+    assert admin_success.status_code == 200, admin_success.text
+
+    settings.platform_legacy_admin_auth_enabled = False
+    disabled = await workload_harness.client.post(
+        "/v1/platform/agents",
+        headers={"X-Admin-Key": _ADMIN_KEY, "Idempotency-Key": "legacy-admin-disabled"},
+        json=_agent_body(owner, uuid.uuid4()),
+    )
+    assert disabled.status_code == 401, disabled.text
+    settings.platform_legacy_admin_auth_enabled = True
+
+    token = await _access_token(workload_harness, "platform:agents:create")
+    ambiguous = await workload_harness.client.post(
+        "/v1/platform/agents",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "X-Admin-Key": _ADMIN_KEY,
+            "Idempotency-Key": "ambiguous-credentials",
+        },
+        json=_agent_body(owner, uuid.uuid4()),
+    )
+    assert ambiguous.status_code == 400, ambiguous.text
+
+    invalid_bearer = await workload_harness.client.post(
+        "/v1/platform/agents",
+        headers={
+            "Authorization": f"Bearer {_ADMIN_KEY}",
+            "Idempotency-Key": "bearer-no-root-fallback",
+        },
+        json=_agent_body(owner, uuid.uuid4()),
+    )
+    assert invalid_bearer.status_code == 401, invalid_bearer.text
+
+    workload_in_admin_header = await workload_harness.client.post(
+        "/v1/platform/agents",
+        headers={
+            "X-Admin-Key": token,
+            "Idempotency-Key": "admin-no-workload-fallback",
+        },
+        json=_agent_body(owner, uuid.uuid4()),
+    )
+    assert workload_in_admin_header.status_code == 401, workload_in_admin_header.text
+
+    repeated = await workload_harness.client.post(
+        "/v1/platform/agents",
+        headers=[
+            ("Authorization", f"Bearer {token}"),
+            ("Authorization", f"Bearer {token}"),
+            ("Idempotency-Key", "repeated-credentials"),
+        ],
+        json=_agent_body(owner, uuid.uuid4()),
+    )
+    assert repeated.status_code == 400, repeated.text
+
+
+@pytest.mark.asyncio
+async def test_oauth_rejects_admin_or_authorization_header_auth(workload_harness):
+    form = {
+        "grant_type": "client_credentials",
+        "client_id": workload_harness.credential.client_id,
+        "scope": "platform:agents:create",
+        "client_assertion_type": PLATFORM_WORKLOAD_CLIENT_ASSERTION_TYPE,
+        "client_assertion": _assertion(workload_harness),
+    }
+    with_admin = await workload_harness.client.post(
+        "/v1/platform/oauth/token",
+        headers={"X-Admin-Key": _ADMIN_KEY},
+        data=form,
+    )
+    with_bearer = await workload_harness.client.post(
+        "/v1/platform/oauth/token",
+        headers={"Authorization": "Bearer unrelated"},
+        data=form,
+    )
+    assert with_admin.status_code == 400, with_admin.text
+    assert with_bearer.status_code == 400, with_bearer.text
+    assert with_admin.json()["error"] == "invalid_request"
+    assert with_bearer.json()["error"] == "invalid_request"

--- a/backend/tests/test_platform_workload_oauth_migration.py
+++ b/backend/tests/test_platform_workload_oauth_migration.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import importlib.util
+import uuid
+from pathlib import Path
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import inspect, text
+
+MIGRATION_FILENAME = "c7e4a9b2d6f1_platform_workload_oauth.py"
+
+
+def _load_migration():
+    migration_path = Path(__file__).parents[1] / "alembic" / "versions" / MIGRATION_FILENAME
+    spec = importlib.util.spec_from_file_location(
+        "platform_workload_oauth_migration",
+        migration_path,
+    )
+    assert spec is not None and spec.loader is not None
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    return migration
+
+
+async def test_platform_workload_oauth_migration_upgrades_and_downgrades(engine):
+    schema = f"platform_workload_oauth_{uuid.uuid4().hex}"
+    migration = _load_migration()
+
+    async with engine.begin() as connection:
+        await connection.execute(text(f'CREATE SCHEMA "{schema}"'))
+
+        def run(sync_connection):
+            try:
+                sync_connection.execute(text(f'SET search_path TO "{schema}"'))
+                migration.op = Operations(MigrationContext.configure(sync_connection))
+                migration.upgrade()
+
+                inspector = inspect(sync_connection)
+                assert set(inspector.get_table_names()) == {
+                    "platform_workload_assertion_replays",
+                    "platform_workload_clients",
+                    "platform_workload_signing_keys",
+                }
+                client_checks = {
+                    check["name"]
+                    for check in inspector.get_check_constraints("platform_workload_clients")
+                }
+                assert "ck_platform_workload_clients_allowed_scopes" in client_checks
+                assert "ck_platform_workload_clients_public_jwk_only" in client_checks
+                assert "ck_platform_workload_clients_public_jwk_identity" in client_checks
+                assert "ck_platform_workload_clients_public_jwk_key_type" in client_checks
+                replay_uniques = {
+                    unique["name"]
+                    for unique in inspector.get_unique_constraints(
+                        "platform_workload_assertion_replays"
+                    )
+                }
+                assert "uq_platform_workload_assertion_replays_client_jti" in replay_uniques
+                signing_columns = {
+                    column["name"]
+                    for column in inspector.get_columns("platform_workload_signing_keys")
+                }
+                assert "private_key_ref" in signing_columns
+                assert "private_key" not in signing_columns
+
+                migration.downgrade()
+                assert inspect(sync_connection).get_table_names() == []
+
+                migration.upgrade()
+                assert set(inspect(sync_connection).get_table_names()) == {
+                    "platform_workload_assertion_replays",
+                    "platform_workload_clients",
+                    "platform_workload_signing_keys",
+                }
+                migration.downgrade()
+                assert inspect(sync_connection).get_table_names() == []
+            finally:
+                sync_connection.execute(text("SET search_path TO public"))
+
+        try:
+            await connection.run_sync(run)
+        finally:
+            await connection.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -1725,6 +1725,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/platform/oauth/token": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Platform Workload Oauth Token */
+        post: operations["platform_workload_oauth_token_v1_platform_oauth_token_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/platform/agents": {
         parameters: {
             query?: never;
@@ -4923,6 +4940,28 @@ export interface components {
         /** PlatformMutationBody */
         PlatformMutationBody: {
             owner: components["schemas"]["PlatformOwner"];
+        };
+        /** PlatformOAuthErrorResponse */
+        PlatformOAuthErrorResponse: {
+            /** Error */
+            error: string;
+            /** Error Description */
+            error_description: string;
+        };
+        /** PlatformOAuthTokenResponse */
+        PlatformOAuthTokenResponse: {
+            /** Access Token */
+            access_token: string;
+            /**
+             * Token Type
+             * @default Bearer
+             * @constant
+             */
+            token_type: "Bearer";
+            /** Expires In */
+            expires_in: number;
+            /** Scope */
+            scope: string;
         };
         /** PlatformOwner */
         PlatformOwner: {
@@ -9655,12 +9694,70 @@ export interface operations {
             };
         };
     };
+    platform_workload_oauth_token_v1_platform_oauth_token_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/x-www-form-urlencoded": {
+                    grant_type: string;
+                    client_id: string;
+                    scope: string;
+                    client_assertion_type: string;
+                    client_assertion: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformOAuthTokenResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformOAuthErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformOAuthErrorResponse"];
+                };
+            };
+            /** @description Service Unavailable */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlatformOAuthErrorResponse"];
+                };
+            };
+        };
+    };
     platform_create_agent_v1_platform_agents_post: {
         parameters: {
             query?: never;
             header: {
                 "Idempotency-Key": string;
                 "X-Admin-Key"?: string | null;
+                Authorization?: string | null;
             };
             path?: never;
             cookie?: never;
@@ -9697,6 +9794,7 @@ export interface operations {
             header: {
                 "Idempotency-Key": string;
                 "X-Admin-Key"?: string | null;
+                Authorization?: string | null;
             };
             path: {
                 agent_id: string;
@@ -9733,6 +9831,7 @@ export interface operations {
             header: {
                 "Idempotency-Key": string;
                 "X-Admin-Key"?: string | null;
+                Authorization?: string | null;
             };
             path: {
                 agent_id: string;
@@ -9771,6 +9870,7 @@ export interface operations {
             header: {
                 "Idempotency-Key": string;
                 "X-Admin-Key"?: string | null;
+                Authorization?: string | null;
             };
             path: {
                 agent_id: string;
@@ -9807,6 +9907,7 @@ export interface operations {
             header: {
                 "Idempotency-Key": string;
                 "X-Admin-Key"?: string | null;
+                Authorization?: string | null;
             };
             path?: never;
             cookie?: never;
@@ -9843,6 +9944,7 @@ export interface operations {
             header: {
                 "Idempotency-Key": string;
                 "X-Admin-Key"?: string | null;
+                Authorization?: string | null;
             };
             path: {
                 key_id: string;


### PR DESCRIPTION
**一句话**：cloud-api 长出自己的 workload token 签发端点——hosted 用私钥换 5 分钟、最小权限的 token 调 `/v1/platform/*`，取代那把全局 root 钥匙。

**保证**（都验过）：
- legacy `/v1/admin/*` 与 v1 面零改动
- Bearer 与 X-Admin-Key 严格互斥，**认证失败绝不回退 root key**（评审当初点名的头号安全债）
- 私钥只存引用（KMS resolver 是上线前置，代码里有显式 TODO）；防重放、scope 越权、存储故障 503 全测试覆盖
- 全部成熟库（PyJWT/cryptography），零新增依赖；migration 单头，双向验证
- 测试 1218 绿

**你需要决定的**：合不合。与 hosted 侧 M3 PR 配套（cloud 先合先部署，hosted 的 cohort 才能切）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)