### PR TITLE
Agent v2: runtime-only unmanaged provider mode + Hosted Codex tool plane (beta.53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.12.10-beta.53
+
+Package: `clawdi@0.12.10-beta.53`
+
+### Changed
+
+- Added explicit unmanaged provider convergence for runtime-only OpenClaw and
+  Hermes deployments, including exact empty-provider health and safe removal of
+  only Clawdi-owned runtime projections.
+- Decoupled the fixed Hosted Codex terminal tool from runtime provider choice.
+  The CLI now maintains its single default config and process-scoped managed
+  egress shim without leaking provider material into unmanaged runtime units.
+  Hosted Codex is installed and verified at the audited exact
+  `@openai/codex@0.142.4` version.
+- Restricted managed provider egress credential replacement to requests carrying
+  the exact Clawdi placeholder marker, so user bearer tokens and unauthenticated
+  requests to the same host remain untouched.
+
 ## Clawdi CLI v0.12.10-beta.52
 
 Release: https://github.com/Clawdi-AI/clawdi/releases/tag/clawdi-cli-v0.12.10-beta.52

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -1080,7 +1080,11 @@ def _runtime_state_values(body: AdminRuntimeStateUpsert) -> dict[str, Any]:
         "recovery": body.recovery.model_dump(mode="json"),
         "egress_profiles": optional_wire_value("egress_profiles"),
         "mcp": body.mcp,
-        "tools": body.tools,
+        "tools": (
+            body.tools.model_dump(exclude_none=True, exclude_unset=True, mode="json")
+            if body.tools is not None
+            else None
+        ),
     }
 
 

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -919,7 +919,7 @@ def _assign_runtime_state(
     state.recovery = body.recovery.model_dump(mode="json")
     state.egress_profiles = _optional_runtime_model(body.egress_profiles)
     state.mcp = body.mcp
-    state.tools = body.tools
+    state.tools = body.tools.model_dump(exclude_none=True, exclude_unset=True, mode="json")
 
 
 def _optional_runtime_model(value: BaseModel | None) -> dict[str, Any] | None:
@@ -965,6 +965,8 @@ def _runtime_state_changed_fields(
             body_value = _optional_runtime_model(getattr(body, field))
         elif field in {"live_sync", "recovery"}:
             body_value = getattr(body, field).model_dump(mode="json")
+        elif field == "tools":
+            body_value = body.tools.model_dump(exclude_none=True, exclude_unset=True, mode="json")
         else:
             body_value = getattr(body, field)
         if getattr(state, field) != body_value:

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -36,7 +36,7 @@ from app.models.session_permission import (
     SessionPermission,
 )
 from app.schemas.common import Paginated
-from app.schemas.runtime import HostedRuntimeDesiredState
+from app.schemas.runtime import validate_hosted_runtime_desired_state
 from app.schemas.runtime_observed import (
     HostedRuntimeObserved,
     HostedRuntimeObservedProviderPayload,
@@ -1004,7 +1004,7 @@ def _runtime_observed_desired(
     *,
     source_revision: str | None = None,
 ) -> RuntimeObservedDesiredResponse:
-    provider_ids, primary_provider_id = _runtime_desired_provider_binding(state.runtimes)
+    _, provider_ids, primary_provider_id = _runtime_desired_provider_binding(state.runtimes)
     return RuntimeObservedDesiredResponse(
         deployment_id=state.deployment_id,
         instance_id=state.instance_id,
@@ -1092,16 +1092,19 @@ def _runtime_observed_health(
         elif diagnostics.active_cli_version != desired_cli_version:
             reasons.append("active_cli_version_mismatch")
 
-        desired_provider_ids, _ = _runtime_desired_provider_binding(state.runtimes)
-        applied_provider_ids = (
-            diagnostics.applied.applied_provider_ids if diagnostics.applied else []
-        )
-        missing_provider_ids = sorted(set(desired_provider_ids) - set(applied_provider_ids))
-        extra_provider_ids = sorted(set(applied_provider_ids) - set(desired_provider_ids))
-        if missing_provider_ids:
-            reasons.append("applied_provider_ids_missing_desired")
-        if extra_provider_ids:
-            reasons.append("applied_provider_ids_extra")
+        provider_mode, desired_provider_ids, _ = _runtime_desired_provider_binding(state.runtimes)
+        if provider_mode is None:
+            reasons.append("desired_provider_contract_invalid")
+        else:
+            applied_provider_ids = (
+                diagnostics.applied.applied_provider_ids if diagnostics.applied else []
+            )
+            missing_provider_ids = sorted(set(desired_provider_ids) - set(applied_provider_ids))
+            extra_provider_ids = sorted(set(applied_provider_ids) - set(desired_provider_ids))
+            if missing_provider_ids:
+                reasons.append("applied_provider_ids_missing_desired")
+            if extra_provider_ids:
+                reasons.append("applied_provider_ids_extra")
 
     supervisor_status = (
         diagnostics.supervisor.status if diagnostics and diagnostics.supervisor else None
@@ -1150,7 +1153,7 @@ def _runtime_observed_provider_health(
     if state is None or diagnostics is None:
         return []
 
-    provider_ids, primary_provider_id = _runtime_desired_provider_binding(state.runtimes)
+    _, provider_ids, primary_provider_id = _runtime_desired_provider_binding(state.runtimes)
     provider_health: list[RuntimeObservedProviderHealthResponse] = []
     observed_providers = diagnostics.providers or {}
     for provider_key in sorted(set(provider_ids) | set(observed_providers)):
@@ -1190,17 +1193,19 @@ def _clawdi_cli_version(package_spec: str) -> str | None:
 
 def _runtime_desired_provider_binding(
     runtimes: dict | None,
-) -> tuple[list[str], str | None]:
+) -> tuple[str | None, list[str], str | None]:
     if not isinstance(runtimes, dict) or len(runtimes) != 1:
-        return [], None
+        return None, [], None
     runtime_name, raw_runtime = next(iter(runtimes.items()))
     if runtime_name not in {"hermes", "openclaw"}:
-        return [], None
+        return None, [], None
     try:
-        runtime = HostedRuntimeDesiredState.model_validate(raw_runtime)
+        runtime = validate_hosted_runtime_desired_state(raw_runtime)
     except ValidationError:
-        return [], None
-    return runtime.provider_ids, runtime.primary_model.provider_id
+        return None, [], None
+    primary_model = getattr(runtime, "primary_model", None)
+    primary_provider_id = primary_model.provider_id if primary_model is not None else None
+    return runtime.providerMode, runtime.provider_ids, primary_provider_id
 
 
 def _runtime_observed_provider_status(

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -32,6 +32,7 @@ from app.schemas.runtime import (
     HostedRuntimeLocale,
     HostedRuntimeRecovery,
     HostedRuntimeSystem,
+    HostedRuntimeTools,
     validate_clawdi_cli_package_spec,
     validate_hosted_runtime_bridge,
     validate_no_plaintext_tool_secrets,
@@ -145,7 +146,7 @@ class AdminRuntimeStateUpsert(BaseModel):
     recovery: HostedRuntimeRecovery
     egress_profiles: HostedEgressProfiles | None = None
     mcp: dict[str, Any] | None = None
-    tools: dict[str, Any] | None = None
+    tools: HostedRuntimeTools
 
     @field_validator("cli_package_spec")
     @classmethod
@@ -175,7 +176,7 @@ class AdminRuntimeStateUpsert(BaseModel):
         validate_hosted_runtime_bridge(runtime, self.bridge)
         return self
 
-    @field_validator("mcp", "tools")
+    @field_validator("mcp")
     @classmethod
     def _validate_tool_desired_state(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
         if value is not None:

--- a/backend/app/schemas/platform.py
+++ b/backend/app/schemas/platform.py
@@ -15,6 +15,7 @@ from app.schemas.runtime import (
     HostedRuntimeLocale,
     HostedRuntimeRecovery,
     HostedRuntimeSystem,
+    HostedRuntimeTools,
     validate_clawdi_cli_package_spec,
     validate_hosted_runtime_bridge,
     validate_no_plaintext_tool_secrets,
@@ -95,7 +96,7 @@ class PlatformRuntimeStateUpsert(PlatformMutationBody):
     recovery: HostedRuntimeRecovery
     egress_profiles: HostedEgressProfiles | None = None
     mcp: dict[str, Any] | None = None
-    tools: dict[str, Any] | None = None
+    tools: HostedRuntimeTools
 
     @field_validator("cli_package_spec")
     @classmethod
@@ -125,7 +126,7 @@ class PlatformRuntimeStateUpsert(PlatformMutationBody):
         validate_hosted_runtime_bridge(runtime, self.bridge)
         return self
 
-    @field_validator("mcp", "tools")
+    @field_validator("mcp")
     @classmethod
     def _validate_tool_desired_state(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
         if value is not None:

--- a/backend/app/schemas/runtime.py
+++ b/backend/app/schemas/runtime.py
@@ -3,7 +3,7 @@ from typing import Annotated, Literal
 from urllib.parse import urlsplit
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, field_validator, model_validator
 
 HostedRuntimeLanguage = Literal[
     "en",
@@ -31,7 +31,7 @@ _EXACT_SEMVER_PATTERN = re.compile(
     rf"({_SEMVER_CORE_IDENTIFIER})(?:-({_SEMVER_PRERELEASE_IDENTIFIER}"
     rf"(?:\.{_SEMVER_PRERELEASE_IDENTIFIER})*))?$"
 )
-_AGENT_V2_MANIFEST_MINIMUM_CLI_VERSION = "0.12.10-beta.51"
+_AGENT_V2_MANIFEST_MINIMUM_CLI_VERSION = "0.12.10-beta.53"
 _FORBIDDEN_TOOL_SECRET_KEYS = {
     "apikey",
     "api_key",
@@ -45,6 +45,8 @@ _FORBIDDEN_TOOL_SECRET_KEYS = {
     "secretvalues",
     "token",
 }
+_UNMANAGED_PROVIDER_ENV_NAMES = {"CLAWDI_MANAGED_OPENAI_API_KEY", "OPENAI_API_KEY"}
+_MANAGED_EGRESS_PLACEHOLDER_VALUE = "clawdi-egress-placeholder"
 
 
 def validate_no_plaintext_tool_secrets(value: object, path: str = "") -> None:
@@ -535,30 +537,53 @@ class HostedRuntimePrimaryModel(BaseModel):
         return value
 
 
-class HostedRuntimeDesiredState(BaseModel):
+class HostedCodexTool(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     enabled: Literal[True]
-    provider_ids: list[str] = Field(min_length=1)
+    provider_id: str = Field(min_length=1, max_length=80)
     primary_model: HostedRuntimePrimaryModel
+
+    @model_validator(mode="after")
+    def _validate_primary_model_provider(self) -> "HostedCodexTool":
+        if self.primary_model.provider_id != self.provider_id:
+            raise ValueError("Codex tool primary_model.provider_id must match provider_id")
+        return self
+
+
+class HostedCodexProviderProjection(BaseModel):
+    """Typed Cloud-owned provider projection for the fixed Hosted Codex tool."""
+
+    model_config = ConfigDict(extra="allow")
+
+    kind: Literal["openai-compatible"]
+    baseUrl: str = Field(min_length=1, max_length=1000)
+    apiMode: Literal["openai_responses"]
+    managed_by: Literal["clawdi"]
+    runtimeEnvName: Literal["OPENAI_API_KEY"]
+    apiKeySecretRef: Literal["tool.codex.apiKey"]
+
+
+class HostedRuntimeTools(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    codex: HostedCodexTool
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_no_plaintext_secrets(cls, value: object) -> object:
+        validate_no_plaintext_tool_secrets(value)
+        return value
+
+
+class _HostedRuntimeDesiredStateBase(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: Literal[True]
     install: HostedRuntimeInstall
     run: HostedRuntimeRunSettings | None = None
     services: dict[str, HostedRuntimeRunSettings] | None = None
     paths: HostedRuntimePaths
-
-    @field_validator("provider_ids")
-    @classmethod
-    def _validate_provider_ids(cls, value: list[str]) -> list[str]:
-        if any(
-            not provider_id or provider_id != provider_id.strip() or len(provider_id) > 80
-            for provider_id in value
-        ):
-            raise ValueError(
-                "provider_ids must contain canonical non-empty strings up to 80 characters"
-            )
-        if len(set(value)) != len(value):
-            raise ValueError("provider_ids must not contain duplicates")
-        return value
 
     @field_validator("services")
     @classmethod
@@ -575,11 +600,78 @@ class HostedRuntimeDesiredState(BaseModel):
             raise ValueError("runtime service names must be canonical")
         return value
 
+
+def _validate_runtime_provider_ids(value: list[str]) -> list[str]:
+    if any(
+        not provider_id or provider_id != provider_id.strip() or len(provider_id) > 80
+        for provider_id in value
+    ):
+        raise ValueError(
+            "provider_ids must contain canonical non-empty strings up to 80 characters"
+        )
+    if len(set(value)) != len(value):
+        raise ValueError("provider_ids must not contain duplicates")
+    return value
+
+
+class HostedRuntimeConfiguredDesiredState(_HostedRuntimeDesiredStateBase):
+    providerMode: Literal["configured"]
+    provider_ids: list[str] = Field(min_length=1)
+    primary_model: HostedRuntimePrimaryModel
+
+    @field_validator("provider_ids")
+    @classmethod
+    def _validate_provider_ids(cls, value: list[str]) -> list[str]:
+        return _validate_runtime_provider_ids(value)
+
     @model_validator(mode="after")
-    def _validate_primary_model_provider(self) -> "HostedRuntimeDesiredState":
+    def _validate_primary_model_provider(self) -> "HostedRuntimeConfiguredDesiredState":
         if self.primary_model.provider_id not in self.provider_ids:
             raise ValueError("primary_model.provider_id must be present in provider_ids")
         return self
+
+
+class HostedRuntimeUnmanagedDesiredState(_HostedRuntimeDesiredStateBase):
+    providerMode: Literal["unmanaged"]
+    provider_ids: list[str] = Field(max_length=0)
+
+    @model_validator(mode="after")
+    def _validate_no_runtime_provider_inputs(self) -> "HostedRuntimeUnmanagedDesiredState":
+        settings = [("run", self.run)]
+        settings.extend(
+            (f"services.{name}", service) for name, service in (self.services or {}).items()
+        )
+        for location, run_settings in settings:
+            if run_settings is None:
+                continue
+            env = run_settings.env or {}
+            secret_env = run_settings.secretEnv or {}
+            forbidden_names = sorted(
+                _UNMANAGED_PROVIDER_ENV_NAMES.intersection({*env, *secret_env})
+            )
+            if forbidden_names:
+                raise ValueError(
+                    f"unmanaged {location} must not include provider env: "
+                    f"{', '.join(forbidden_names)}"
+                )
+            if any(value == _MANAGED_EGRESS_PLACEHOLDER_VALUE for value in env.values()):
+                raise ValueError(f"unmanaged {location} must not include provider placeholder env")
+            for secret_ref in (*env.values(), *secret_env.values()):
+                normalized = secret_ref.removeprefix("secret://")
+                if normalized.startswith("provider."):
+                    raise ValueError(f"unmanaged {location} must not include provider secret refs")
+        return self
+
+
+HostedRuntimeDesiredState = Annotated[
+    HostedRuntimeConfiguredDesiredState | HostedRuntimeUnmanagedDesiredState,
+    Field(discriminator="providerMode"),
+]
+_HOSTED_RUNTIME_DESIRED_STATE_ADAPTER = TypeAdapter(HostedRuntimeDesiredState)
+
+
+def validate_hosted_runtime_desired_state(value: object) -> HostedRuntimeDesiredState:
+    return _HOSTED_RUNTIME_DESIRED_STATE_ADAPTER.validate_python(value)
 
 
 class HostedRuntimeLocale(BaseModel):

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -26,17 +26,19 @@ from app.models.session import AgentEnvironment
 from app.schemas.ai_provider import AiProviderModel
 from app.schemas.runtime import (
     _AGENT_V2_MANIFEST_MINIMUM_CLI_VERSION,
+    HostedCodexProviderProjection,
     HostedEgressEngine,
     HostedEgressProfiles,
     HostedRuntimeBridge,
-    HostedRuntimeDesiredState,
     HostedRuntimeLiveSync,
     HostedRuntimeLocale,
     HostedRuntimeName,
     HostedRuntimeRecovery,
     HostedRuntimeSystem,
+    HostedRuntimeTools,
     validate_clawdi_cli_package_spec,
     validate_hosted_runtime_bridge,
+    validate_hosted_runtime_desired_state,
 )
 from app.services.managed_ai_provider import (
     MANAGED_AI_PROVIDER_IDS,
@@ -48,6 +50,9 @@ RUNTIME_BUNDLE_V2_MEDIA_TYPE = "application/vnd.clawdi.runtime-bundle.v2+json"
 RUNTIME_BUNDLE_V2_SCHEMA_VERSION = "clawdi.hosted-runtime.bundle.v2"
 _SUPPORTED_RUNTIMES = {"hermes", "openclaw"}
 _MANAGED_PROVIDER_RUNTIME_ENV = "OPENAI_API_KEY"
+_CODEX_TOOL_SECRET_REF = "tool.codex.apiKey"
+_CODEX_TOOL_API_MODE = "openai_responses"
+_CODEX_PROVIDER_SOURCE_API_MODES = {"openai_chat", "openai_responses"}
 
 
 class RuntimeSourceError(ValueError):
@@ -214,6 +219,10 @@ def render_runtime_source(
     except ValidationError as exc:
         raise RuntimeSourceError("Hosted runtime egress state is invalid") from exc
     try:
+        tools = HostedRuntimeTools.model_validate(state.tools)
+    except ValidationError as exc:
+        raise RuntimeSourceError("Hosted runtime tools state is invalid") from exc
+    try:
         cli_package_spec = validate_clawdi_cli_package_spec(state.cli_package_spec)
     except ValueError as exc:
         raise RuntimeSourceError(
@@ -231,14 +240,44 @@ def render_runtime_source(
     secrets: dict[str, str] = {}
     secret_sources: dict[str, dict[str, str]] = {}
     secret_materials: list[RuntimeSecretMaterial] = []
-    for provider_id in tuple(runtime["provider_ids"]):
+    codex_tool = tools.codex
+    provider_ids = set(runtime["provider_ids"])
+    provider_ids.add(codex_tool.provider_id)
+    provider_material: dict[str, dict[str, Any]] = {}
+    for provider_id in sorted(provider_ids):
         provider = batch.providers.get((user_id, provider_id))
         if provider is None:
-            providers[provider_id] = _unhealthy_provider(provider_id, runtime_name)
+            if provider_id == codex_tool.provider_id:
+                raise RuntimeSourceError("Hosted Codex tool provider is missing or archived")
+            consumer = runtime_name if provider_id in runtime["provider_ids"] else "codex tool"
+            provider_material[provider_id] = _unhealthy_provider(provider_id, consumer)
             continue
         payload = _selected_auth_payload(batch, provider)
-        secret_ref = _provider_secret_ref(provider_id) if payload is not None else None
-        providers[provider_id] = _provider_entry(provider, secret_ref=secret_ref)
+        if provider_id == codex_tool.provider_id and (
+            provider.managed_by != "clawdi"
+            or payload is None
+            or payload.kind != "api_key"
+            or payload.source != "managed"
+        ):
+            raise RuntimeSourceError(
+                "Hosted Codex tool provider must use a Clawdi-managed provider auth payload"
+            )
+        secret_ref = (
+            _CODEX_TOOL_SECRET_REF
+            if payload is not None and provider_id == codex_tool.provider_id
+            else _provider_secret_ref(provider_id)
+            if payload is not None
+            else None
+        )
+        provider_entry = _provider_entry(provider, secret_ref=secret_ref)
+        if provider_id == codex_tool.provider_id and (
+            provider_entry.get("apiMode") not in _CODEX_PROVIDER_SOURCE_API_MODES
+            or provider_entry.get("runtimeEnvName") != _MANAGED_PROVIDER_RUNTIME_ENV
+        ):
+            raise RuntimeSourceError(
+                "Hosted Codex tool provider must use a supported managed OpenAI projection"
+            )
+        provider_material[provider_id] = provider_entry
         if payload is not None and secret_ref is not None:
             _add_secret_source(
                 secret_sources,
@@ -248,7 +287,11 @@ def render_runtime_source(
                     payload.encrypted_payload,
                     payload.nonce,
                     vault_key_identity,
-                    "provider-api-key",
+                    (
+                        "tool-codex-api-key"
+                        if provider_id == codex_tool.provider_id
+                        else "provider-api-key"
+                    ),
                 ),
             )
             secret_materials.append(
@@ -259,6 +302,32 @@ def render_runtime_source(
                     error_message="Hosted runtime provider secret source is invalid",
                 )
             )
+
+    providers = {
+        provider_id: provider_material[provider_id] for provider_id in runtime["provider_ids"]
+    }
+    tool_projection = tools.model_dump(
+        exclude={"codex"},
+        exclude_none=True,
+        exclude_unset=True,
+        mode="json",
+    )
+    codex_provider_input = {
+        **provider_material[codex_tool.provider_id],
+        "apiMode": _CODEX_TOOL_API_MODE,
+    }
+    try:
+        codex_provider = HostedCodexProviderProjection.model_validate(
+            codex_provider_input
+        ).model_dump(exclude_none=True, mode="json")
+    except ValidationError as exc:
+        raise RuntimeSourceError("Hosted Codex tool provider projection is invalid") from exc
+    terminal_tooling = {
+        "codex": {
+            **codex_tool.model_dump(mode="json"),
+            "provider": codex_provider,
+        }
+    }
 
     manifest: dict[str, Any] = {
         "schemaVersion": "clawdi.hosted-runtime.manifest.v1",
@@ -294,8 +363,9 @@ def render_runtime_source(
         )
     if state.mcp:
         manifest["mcp"] = state.mcp
-    if state.tools:
-        manifest["tools"] = state.tools
+    if tool_projection:
+        manifest["tools"] = tool_projection
+    manifest["terminalTooling"] = terminal_tooling
 
     bindings: list[dict[str, str]] = []
     channel_rows = batch.channels.get(environment_id, ())
@@ -374,7 +444,7 @@ def _runtime(value: dict | None) -> tuple[HostedRuntimeName, dict[str, Any]]:
     if name not in _SUPPORTED_RUNTIMES:
         raise RuntimeSourceError(f"unsupported enabled runtime: {name}")
     try:
-        desired = HostedRuntimeDesiredState.model_validate(raw)
+        desired = validate_hosted_runtime_desired_state(raw)
     except ValidationError as exc:
         raise RuntimeSourceError(f"hosted runtime state for {name} is invalid") from exc
     runtime_name: HostedRuntimeName = "hermes" if name == "hermes" else "openclaw"
@@ -443,13 +513,13 @@ def _provider_entry(provider: AiProvider, *, secret_ref: str | None) -> dict[str
     return result
 
 
-def _unhealthy_provider(provider_id: str, runtime_name: str) -> dict[str, Any]:
+def _unhealthy_provider(provider_id: str, consumer: str) -> dict[str, Any]:
     return {
         "kind": "openai-compatible",
         "status": "error",
         "error": {
             "code": "provider_not_found",
-            "message": f"provider required by {runtime_name} is missing or archived",
+            "message": f"provider required by {consumer} is missing or archived",
         },
     }
 

--- a/backend/app/services/sync_events.py
+++ b/backend/app/services/sync_events.py
@@ -77,7 +77,7 @@ from app.models.hosted_runtime import HostedRuntimeState
 from app.models.project_membership import ProjectMembership
 from app.models.session import AgentEnvironment
 from app.models.user import User
-from app.schemas.runtime import HostedRuntimeDesiredState
+from app.schemas.runtime import HostedRuntimeTools, validate_hosted_runtime_desired_state
 
 log = logging.getLogger(__name__)
 
@@ -332,10 +332,16 @@ def _runtime_state_may_use_provider(state: HostedRuntimeState, provider_id: str)
     if runtime_name not in {"hermes", "openclaw"}:
         return False
     try:
-        runtime = HostedRuntimeDesiredState.model_validate(raw_runtime)
+        runtime = validate_hosted_runtime_desired_state(raw_runtime)
     except ValidationError:
         return False
-    return provider_id in runtime.provider_ids
+    if provider_id in runtime.provider_ids:
+        return True
+    try:
+        tools = HostedRuntimeTools.model_validate(state.tools)
+    except ValidationError:
+        return False
+    return provider_id == tools.codex.provider_id
 
 
 async def bump_skills_revision(

--- a/backend/scripts/seed_dashboard_dev.py
+++ b/backend/scripts/seed_dashboard_dev.py
@@ -34,7 +34,7 @@ from sqlalchemy.ext.asyncio import (  # noqa: E402
 
 from app.core.config import settings  # noqa: E402
 from app.models.agent_project_binding import AgentProjectBinding  # noqa: E402
-from app.models.ai_provider import AiProvider  # noqa: E402
+from app.models.ai_provider import AiProvider, AiProviderAuthPayload  # noqa: E402
 from app.models.channel import (  # noqa: E402
     BINDING_STATUS_ACTIVE,
     BOT_AGENT_LINK_STATUS_ACTIVE,
@@ -72,7 +72,8 @@ DEV_V2_APP_ID = "app_dev_sidebar"
 DEV_V2_HOSTED_MACHINE_ID = "dev-hosted-sidebar"
 DEV_V2_HOSTED_MACHINE_NAME = "Dev Hosted Compute"
 DEV_V2_PROVIDER_ID = "openrouter-dev"
-DEV_V2_CLI_PACKAGE_SPEC = "clawdi@0.12.10-beta.51"
+DEV_V2_CODEX_PROVIDER_ID = "clawdi-managed-v2"
+DEV_V2_CLI_PACKAGE_SPEC = "clawdi@0.12.10-beta.53"
 _STABLE_UUID_NAMESPACE = uuid.UUID("6a9575fd-7eb5-464a-89e7-e13f090f8de6")
 
 
@@ -253,6 +254,7 @@ async def _create_hosted_runtime_graph(
                 runtimes={
                     runtime: {
                         "enabled": True,
+                        "providerMode": "configured",
                         "provider_ids": [DEV_V2_PROVIDER_ID],
                         "primary_model": {
                             "provider_id": DEV_V2_PROVIDER_ID,
@@ -300,7 +302,18 @@ async def _create_hosted_runtime_graph(
                 recovery={"cacheManifest": True, "allowOfflineBoot": True},
                 egress_profiles={},
                 mcp={"enabled": True},
-                tools={"channels": True, "aiProviders": True},
+                tools={
+                    "codex": {
+                        "enabled": True,
+                        "provider_id": DEV_V2_CODEX_PROVIDER_ID,
+                        "primary_model": {
+                            "provider_id": DEV_V2_CODEX_PROVIDER_ID,
+                            "model": "gpt-5.5",
+                        },
+                    },
+                    "channels": True,
+                    "aiProviders": True,
+                },
             ),
         ]
     )
@@ -422,6 +435,35 @@ def _seed_ai_provider(user: User) -> AiProvider:
         managed_by="user",
         runtime_env_name="OPENROUTER_API_KEY",
     )
+
+
+def _seed_codex_provider_graph(
+    user: User,
+) -> tuple[AiProvider, AiProviderAuthPayload]:
+    ciphertext, nonce = encrypt("dev-hosted-codex-platform-credential")
+    provider = AiProvider(
+        owner_user_id=user.id,
+        provider_id=DEV_V2_CODEX_PROVIDER_ID,
+        type="custom_openai_compatible",
+        label="Clawdi Managed Codex",
+        base_url="https://ai-gateway.invalid/v1",
+        api_mode="openai_chat",
+        models=[{"id": "gpt-5.5"}],
+        auth_type="api_key",
+        auth_metadata={"source": "managed"},
+        managed_by="clawdi",
+        runtime_env_name="CLAWDI_MANAGED_OPENAI_API_KEY",
+    )
+    payload = AiProviderAuthPayload(
+        owner_user_id=user.id,
+        provider_id=DEV_V2_CODEX_PROVIDER_ID,
+        auth_profile="default",
+        kind="api_key",
+        source="managed",
+        encrypted_payload=ciphertext,
+        nonce=nonce,
+    )
+    return provider, payload
 
 
 def _seed_channel_graph(
@@ -644,7 +686,8 @@ async def seed(clerk_id: str, agent_type: str) -> None:
         except (RuntimeError, ValueError) as exc:
             print(f"skipped vault items: {exc}", file=sys.stderr)
 
-        db.add(_seed_ai_provider(user))
+        codex_provider, codex_payload = _seed_codex_provider_graph(user)
+        db.add_all([_seed_ai_provider(user), codex_provider, codex_payload])
         channel_account, channel_link, channel_binding, channel_message = _seed_channel_graph(
             user=user,
             agent=hosted_openclaw_env,

--- a/backend/tests/hosted_runtime_fixtures.py
+++ b/backend/tests/hosted_runtime_fixtures.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.ai_provider import AiProvider, AiProviderAuthPayload
+from app.models.hosted_runtime import HostedRuntimeState
+from app.models.user import User
+from app.services.vault_crypto import encrypt
+
+CANONICAL_CODEX_TOOL_PROVIDER_ID = "clawdi-managed-v2"
+CANONICAL_CODEX_TOOL_SECRET = "sk-codex-tool"
+CANONICAL_CODEX_TOOLS = {
+    "codex": {
+        "enabled": True,
+        "provider_id": CANONICAL_CODEX_TOOL_PROVIDER_ID,
+        "primary_model": {
+            "provider_id": CANONICAL_CODEX_TOOL_PROVIDER_ID,
+            "model": "gpt-5.5",
+        },
+    }
+}
+
+
+def canonical_codex_tool_provider_graph(
+    user: User,
+    *,
+    api_key: str = CANONICAL_CODEX_TOOL_SECRET,
+) -> tuple[AiProvider, AiProviderAuthPayload]:
+    ciphertext, nonce = encrypt(api_key)
+    provider = AiProvider(
+        owner_user_id=user.id,
+        provider_id=CANONICAL_CODEX_TOOL_PROVIDER_ID,
+        type="custom_openai_compatible",
+        label="Clawdi Managed",
+        base_url="https://sub2api.test/v1",
+        models=[{"id": "gpt-5.5"}],
+        api_mode="openai_chat",
+        auth_type="api_key",
+        auth_metadata={"source": "managed"},
+        managed_by="clawdi",
+        runtime_env_name="CLAWDI_MANAGED_OPENAI_API_KEY",
+    )
+    payload = AiProviderAuthPayload(
+        owner_user_id=user.id,
+        provider_id=provider.provider_id,
+        auth_profile="default",
+        kind="api_key",
+        source="managed",
+        encrypted_payload=ciphertext,
+        nonce=nonce,
+    )
+    return provider, payload
+
+
+async def ensure_canonical_codex_tool_provider(
+    db: AsyncSession,
+    user: User,
+) -> AiProvider:
+    provider = await db.scalar(
+        select(AiProvider).where(
+            AiProvider.owner_user_id == user.id,
+            AiProvider.provider_id == CANONICAL_CODEX_TOOL_PROVIDER_ID,
+        )
+    )
+    if provider is None:
+        provider, payload = canonical_codex_tool_provider_graph(user)
+        db.add_all([provider, payload])
+        await db.flush()
+    return provider
+
+
+def canonical_hosted_runtime_state(**values: Any) -> HostedRuntimeState:
+    values.setdefault("tools", CANONICAL_CODEX_TOOLS)
+    return HostedRuntimeState(**values)

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -1241,7 +1241,7 @@ async def test_admin_agents_alias_registers_with_agent_id_and_runtime_state(
             "deployment_id": "dep-admin-agent-alias",
             "instance_id": "iid-admin-agent-alias",
             "generation": 7,
-            "cli_package_spec": "clawdi@0.12.10-beta.51",
+            "cli_package_spec": "clawdi@0.12.10-beta.53",
             "locale": {"language": "en", "timezone": "America/Los_Angeles"},
             "system": {
                 "user": "clawdi",
@@ -1251,9 +1251,20 @@ async def test_admin_agents_alias_registers_with_agent_id_and_runtime_state(
             },
             "live_sync": {"enabled": False, "agents": []},
             "recovery": {"cacheManifest": True, "allowOfflineBoot": True},
+            "tools": {
+                "codex": {
+                    "enabled": True,
+                    "provider_id": "clawdi-managed",
+                    "primary_model": {
+                        "provider_id": "clawdi-managed",
+                        "model": "gpt-5.5",
+                    },
+                }
+            },
             "runtimes": {
                 "openclaw": {
                     "enabled": True,
+                    "providerMode": "configured",
                     "provider_ids": ["clawdi-managed"],
                     "primary_model": {
                         "provider_id": "clawdi-managed",

--- a/backend/tests/test_agent_endpoints.py
+++ b/backend/tests/test_agent_endpoints.py
@@ -14,7 +14,7 @@ from app.services.runtime_source import expected_runtime_bundle_v2_etag
 
 _DEPRECATED_HOSTED_FIELDS = {"hosted_managed", "hosted_deployment_id"}
 _TEST_LOCALE = {"language": "en", "timezone": "UTC"}
-_TEST_CLI_PACKAGE_SPEC = "clawdi@0.12.10-beta.51"
+_TEST_CLI_PACKAGE_SPEC = "clawdi@0.12.10-beta.53"
 _TEST_SYSTEM = {
     "user": "clawdi",
     "home": "/home/clawdi",
@@ -108,6 +108,7 @@ async def test_agent_and_environment_routes_share_non_deprecated_payloads(
             runtimes={
                 "openclaw": {
                     "enabled": True,
+                    "providerMode": "configured",
                     "provider_ids": ["clawdi-managed"],
                     "primary_model": {
                         "provider_id": "clawdi-managed",
@@ -129,7 +130,7 @@ async def test_agent_and_environment_routes_share_non_deprecated_payloads(
         "reportedAt": datetime.now(UTC).isoformat(),
         "runtimeMode": "hosted",
         "status": "ok",
-        "activeCliVersion": "0.12.10-beta.51",
+        "activeCliVersion": "0.12.10-beta.53",
         "applied": {
             "etag": expected_runtime_bundle_v2_etag(source_revision),
             "sourceRevision": source_revision,

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -305,7 +305,7 @@ async def test_provider_and_secret_mutations_invalidate_only_bound_runtime(
                 deployment_id=f"dep-{provider_id}",
                 instance_id=f"hri-{provider_id}",
                 generation=1,
-                cli_package_spec="clawdi@0.12.10-beta.51",
+                cli_package_spec="clawdi@0.12.10-beta.53",
                 locale={"language": "en", "timezone": "UTC"},
                 system=_TEST_SYSTEM,
                 live_sync={"enabled": False, "agents": []},
@@ -313,6 +313,7 @@ async def test_provider_and_secret_mutations_invalidate_only_bound_runtime(
                 runtimes={
                     "openclaw": {
                         "enabled": True,
+                        "providerMode": "configured",
                         "provider_ids": [provider_id],
                         "primary_model": {"provider_id": provider_id, "model": "test-model"},
                         "install": {"source": "official"},

--- a/backend/tests/test_platform_endpoints.py
+++ b/backend/tests/test_platform_endpoints.py
@@ -25,7 +25,7 @@ from tests.conftest import create_env_with_project
 
 _ADMIN_KEY = "test-platform-admin-secret"
 _ADMIN_AUTH = {"X-Admin-Key": _ADMIN_KEY}
-_TEST_CLI_PACKAGE_SPEC = "clawdi@0.12.10-beta.51"
+_TEST_CLI_PACKAGE_SPEC = "clawdi@0.12.10-beta.53"
 _TEST_LOCALE = {"language": "en", "timezone": "America/Los_Angeles"}
 _TEST_SYSTEM = {
     "user": "clawdi",
@@ -36,6 +36,16 @@ _TEST_SYSTEM = {
 _TEST_RUNTIME_PATHS = {
     "home": "/home/clawdi",
     "workspace": "/home/clawdi/clawdi",
+}
+_TEST_TOOLS = {
+    "codex": {
+        "enabled": True,
+        "provider_id": "clawdi-managed-v2",
+        "primary_model": {
+            "provider_id": "clawdi-managed-v2",
+            "model": "gpt-5.5",
+        },
+    }
 }
 
 
@@ -93,6 +103,7 @@ def _runtime_payload(agent_id: uuid.UUID) -> dict[str, object]:
         "runtimes": {
             "openclaw": {
                 "enabled": True,
+                "providerMode": "configured",
                 "provider_ids": ["clawdi-managed-v2"],
                 "primary_model": {
                     "provider_id": "clawdi-managed-v2",
@@ -114,6 +125,7 @@ def _runtime_payload(agent_id: uuid.UUID) -> dict[str, object]:
             ],
         },
         "recovery": {"cacheManifest": True, "allowOfflineBoot": True},
+        "tools": _TEST_TOOLS,
     }
 
 
@@ -291,6 +303,9 @@ async def test_platform_clerk_owner_full_lifecycle_and_audit(
     )
     assert runtime.status_code == 200, runtime.text
     assert runtime.json()["environment_id"] == str(agent_id)
+    runtime_state = await db_session.get(HostedRuntimeState, agent_id)
+    assert runtime_state is not None
+    assert runtime_state.tools == _TEST_TOOLS
 
     minted = await platform_client.post(
         "/v1/platform/auth/keys",
@@ -370,6 +385,102 @@ async def test_platform_clerk_owner_full_lifecycle_and_audit(
         assert event.details["workload_sub"] is None
         assert event.details["credential_id"] is None
         assert event.details["token_jti"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tools",
+    [
+        None,
+        {},
+        {"codex": {"enabled": True}},
+        {
+            "codex": {
+                "enabled": True,
+                "provider_id": "managed",
+                "primary_model": {"provider_id": "other", "model": "gpt-5.5"},
+            }
+        },
+    ],
+)
+async def test_platform_runtime_state_requires_typed_codex_tool(
+    platform_client,
+    seed_user,
+    tools,
+):
+    owner = _clerk_owner(seed_user)
+    agent_id = uuid.uuid4()
+    created = await _create_platform_agent(
+        platform_client,
+        owner,
+        agent_id,
+        key=f"typed-codex-agent-{uuid.uuid4()}",
+    )
+    assert created.status_code == 200, created.text
+    body = _runtime_body(owner, agent_id)
+    if tools is None:
+        body.pop("tools")
+    else:
+        body["tools"] = tools
+
+    response = await platform_client.put(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_headers(f"typed-codex-runtime-{uuid.uuid4()}"),
+        json=body,
+    )
+
+    assert response.status_code == 422, response.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("runtime_name", ["openclaw", "hermes"])
+async def test_platform_runtime_only_state_is_explicitly_unmanaged(
+    platform_client,
+    db_session,
+    seed_user,
+    runtime_name,
+):
+    owner = _clerk_owner(seed_user)
+    agent_id = uuid.uuid4()
+    created = await _create_platform_agent(
+        platform_client,
+        owner,
+        agent_id,
+        key=f"runtime-only-agent-{runtime_name}-{uuid.uuid4()}",
+    )
+    assert created.status_code == 200, created.text
+    body = _runtime_body(owner, agent_id)
+    configured_runtime = next(iter(body["runtimes"].values()))
+    runtime = {key: value for key, value in configured_runtime.items() if key != "primary_model"}
+    runtime.update({"providerMode": "unmanaged", "provider_ids": []})
+    body["runtimes"] = {runtime_name: runtime}
+    if runtime_name == "hermes":
+        body["bridge"] = {
+            "surfaces": [
+                {
+                    "name": "hermes",
+                    "kind": "control-ui",
+                    "listenPort": 28793,
+                    "upstreamHost": "127.0.0.1",
+                    "upstreamPort": 9119,
+                }
+            ]
+        }
+
+    response = await platform_client.put(
+        f"/v1/platform/agents/{agent_id}/runtime-state",
+        headers=_headers(f"runtime-only-state-{runtime_name}-{uuid.uuid4()}"),
+        json=body,
+    )
+
+    assert response.status_code == 200, response.text
+    state = await db_session.get(HostedRuntimeState, agent_id)
+    assert state is not None
+    persisted_runtime = state.runtimes[runtime_name]
+    assert persisted_runtime["providerMode"] == "unmanaged"
+    assert persisted_runtime["provider_ids"] == []
+    assert "primary_model" not in persisted_runtime
+    assert state.tools == _TEST_TOOLS
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -29,6 +29,7 @@ from app.models.hosted_runtime import HostedRuntimeConfigObservation, HostedRunt
 from app.models.session import AgentEnvironment
 from app.models.user import User
 from app.routes.admin import _admin_upsert_runtime_state
+from app.routes.sessions import _runtime_observed_health
 from app.schemas.admin import AdminRuntimeStateUpsert
 from app.schemas.runtime import (
     HostedEgressEngine,
@@ -43,8 +44,21 @@ from app.services.runtime_source import (
     runtime_manifest_issued_at,
 )
 from app.services.vault_crypto import encrypt
-from scripts.seed_dashboard_dev import _create_hosted_runtime_graph, _seed_ai_provider
+from scripts.seed_dashboard_dev import (
+    _create_hosted_runtime_graph,
+    _seed_ai_provider,
+    _seed_codex_provider_graph,
+)
 from tests.conftest import create_env_with_project
+from tests.hosted_runtime_fixtures import (
+    CANONICAL_CODEX_TOOLS as TEST_CODEX_TOOLS,
+)
+from tests.hosted_runtime_fixtures import (
+    canonical_codex_tool_provider_graph as _managed_codex_provider_graph,
+)
+from tests.hosted_runtime_fixtures import (
+    canonical_hosted_runtime_state,
+)
 
 _ADMIN_KEY = "runtime-state-admin-secret"
 _AUTH = {"X-Admin-Key": _ADMIN_KEY}
@@ -125,8 +139,8 @@ TEST_HERMES_BRIDGE = {
         }
     ]
 }
-OPTIONAL_RUNTIME_STATE_FIELDS = ("egress_engine", "egress_profiles", "mcp", "tools")
-TEST_CLI_PACKAGE_SPEC = "clawdi@0.12.10-beta.51"
+OPTIONAL_RUNTIME_STATE_FIELDS = ("egress_engine", "egress_profiles", "mcp")
+TEST_CLI_PACKAGE_SPEC = "clawdi@0.12.10-beta.53"
 
 
 async def _create_bundle_runtime(admin_client, db_session, seed_user):
@@ -137,20 +151,11 @@ async def _create_bundle_runtime(admin_client, db_session, seed_user):
         machine_name="Bundle runtime",
         agent_type="openclaw",
     )
-    provider = _seed_ai_provider(seed_user)
-    provider.provider_id = f"bundle-provider-{uuid4().hex[:8]}"
-    provider.label = "Bundle provider"
-    provider.auth_metadata = {"source": "managed"}
-    ciphertext, nonce = encrypt("sk-bundle-provider")
-    payload = AiProviderAuthPayload(
-        owner_user_id=seed_user.id,
-        provider_id=provider.provider_id,
-        auth_profile="default",
-        kind="api_key",
-        source="managed",
-        encrypted_payload=ciphertext,
-        nonce=nonce,
+    provider, payload = _managed_codex_provider_graph(
+        seed_user,
+        api_key="sk-bundle-provider",
     )
+    provider.label = "Bundle provider"
     account = ChannelAccount(
         user_id=seed_user.id,
         provider="telegram",
@@ -212,6 +217,17 @@ async def admin_client(db_session) -> AsyncIterator[httpx.AsyncClient]:
 
 
 async def _runtime_client(db_session, seed_user, api_key: ApiKey | None):
+    provider = await db_session.scalar(
+        select(AiProvider).where(
+            AiProvider.owner_user_id == seed_user.id,
+            AiProvider.provider_id == "clawdi-managed-v2",
+        )
+    )
+    if provider is None:
+        provider, payload = _managed_codex_provider_graph(seed_user)
+        db_session.add_all([provider, payload])
+        await db_session.flush()
+
     async def _override_get_session():
         yield db_session
 
@@ -284,21 +300,30 @@ async def _concurrent_initial_runtime_state_responses(
 def _runtime_state(
     runtime_name: str = "openclaw",
     *,
+    provider_mode: str = "configured",
     provider_ids: list[str] | None = None,
     primary_model: dict | None = None,
     **overrides,
 ) -> dict:
-    selected_provider_ids = provider_ids or ["clawdi-managed-v2"]
+    selected_provider_ids = (
+        ([] if provider_mode == "unmanaged" else ["clawdi-managed-v2"])
+        if provider_ids is None
+        else provider_ids
+    )
     runtime = {
         "enabled": True,
+        "providerMode": provider_mode,
         "provider_ids": selected_provider_ids,
-        "primary_model": primary_model
-        or {"provider_id": selected_provider_ids[0], "model": "gpt-5.5"},
         "install": {"source": "official"},
         "run": {"args": ["gateway", "run"]},
         "services": {},
         "paths": TEST_RUNTIME_PATHS,
     }
+    if provider_mode == "configured" or primary_model is not None:
+        runtime["primary_model"] = primary_model or {
+            "provider_id": selected_provider_ids[0],
+            "model": "gpt-5.5",
+        }
     runtime.update(overrides)
     return {runtime_name: runtime}
 
@@ -314,9 +339,184 @@ def _runtime_state_body(environment_id: str, **overrides) -> dict:
         "runtimes": _runtime_state(),
         "live_sync": _live_sync(environment_id),
         "recovery": {"cacheManifest": True, "allowOfflineBoot": True},
+        "tools": TEST_CODEX_TOOLS,
     }
     body.update(overrides)
     return body
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("runtime_name", ["openclaw", "hermes"])
+async def test_runtime_only_bundle_is_explicitly_unmanaged(
+    admin_client,
+    db_session,
+    seed_user,
+    runtime_name,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"runtime-only-{runtime_name}-{uuid4().hex[:8]}",
+        machine_name=f"Runtime only {runtime_name}",
+        agent_type=runtime_name,
+    )
+    codex_provider, codex_payload = _managed_codex_provider_graph(seed_user)
+    db_session.add_all([codex_provider, codex_payload])
+    await db_session.commit()
+    await _write_runtime_state(
+        admin_client,
+        str(env.id),
+        runtimes=_runtime_state(runtime_name, provider_mode="unmanaged"),
+        bridge=TEST_HERMES_BRIDGE if runtime_name == "hermes" else None,
+        live_sync=_live_sync(str(env.id), runtime_name),
+    )
+
+    api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="runtime-only")
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        response = await client.get("/v1/runtime/manifest")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200, response.text
+    bundle = response.json()
+    runtime = bundle["manifest"]["runtimes"][runtime_name]
+    assert runtime["providerMode"] == "unmanaged"
+    assert runtime["provider_ids"] == []
+    assert "primary_model" not in runtime
+    assert bundle["manifest"]["providers"] == {}
+    assert bundle["manifest"]["terminalTooling"]["codex"]["provider_id"] == ("clawdi-managed-v2")
+    assert bundle["channelBindings"] == []
+    assert bundle["secretValues"] == {"tool.codex.apiKey": "sk-codex-tool"}
+
+
+@pytest.mark.parametrize(
+    "runtime",
+    [
+        {**next(iter(_runtime_state().values())), "providerMode": "unmanaged"},
+        {
+            **next(iter(_runtime_state(provider_mode="unmanaged").values())),
+            "provider_ids": ["managed"],
+        },
+        {
+            **next(iter(_runtime_state(provider_mode="unmanaged").values())),
+            "primary_model": {"provider_id": "managed", "model": "gpt-5.5"},
+        },
+        {
+            **next(iter(_runtime_state(provider_mode="unmanaged").values())),
+            "primary_model": None,
+        },
+        {
+            **next(iter(_runtime_state(provider_mode="unmanaged").values())),
+            "run": {"env": {"OPENAI_API_KEY": "clawdi-egress-placeholder"}},
+        },
+        {
+            **next(iter(_runtime_state(provider_mode="unmanaged").values())),
+            "run": {"secretEnv": {"OPENAI_API_KEY": "provider.clawdi-managed-v2.apiKey"}},
+        },
+        {
+            **next(iter(_runtime_state(provider_mode="unmanaged").values())),
+            "services": {"helper": {"secretEnv": {"TOKEN": "secret://provider.runtime.apiKey"}}},
+        },
+        {
+            **next(iter(_runtime_state().values())),
+            "provider_ids": [],
+        },
+        {
+            key: value
+            for key, value in next(iter(_runtime_state().values())).items()
+            if key != "providerMode"
+        },
+    ],
+)
+def test_runtime_provider_mode_rejects_mixed_contracts(runtime):
+    with pytest.raises(ValidationError):
+        AdminRuntimeStateUpsert.model_validate(
+            _runtime_state_body(str(uuid4()), runtimes={"openclaw": runtime})
+        )
+
+
+def test_unmanaged_runtime_allows_explicit_user_vault_backed_service_secret_ref():
+    runtime = {
+        **next(iter(_runtime_state(provider_mode="unmanaged").values())),
+        "services": {"helper": {"secretEnv": {"TOKEN": "clawdi://default/key"}}},
+    }
+
+    state = AdminRuntimeStateUpsert.model_validate(
+        _runtime_state_body(str(uuid4()), runtimes={"openclaw": runtime})
+    )
+
+    assert state.runtimes["openclaw"].services["helper"].secretEnv == {
+        "TOKEN": "clawdi://default/key"
+    }
+
+
+def test_unmanaged_health_requires_exact_empty_applied_provider_set():
+    now = datetime.now(UTC)
+    source_revision = "d" * 64
+    etag = expected_runtime_bundle_v2_etag(source_revision)
+    state = SimpleNamespace(
+        deployment_id="dep-unmanaged-health",
+        instance_id="hri-unmanaged-health",
+        generation=3,
+        cli_package_spec=TEST_CLI_PACKAGE_SPEC,
+        runtimes=_runtime_state(provider_mode="unmanaged"),
+    )
+    env = SimpleNamespace(last_sync_error=None, last_sync_at=now)
+
+    def observation(applied_provider_ids):
+        return SimpleNamespace(
+            observed_at=now,
+            observed_config_generation=3,
+            observed_manifest_etag=etag,
+            observed_source_revision=source_revision,
+            diagnostics={
+                "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
+                "reportedAt": now.isoformat(),
+                "runtimeMode": "hosted",
+                "status": "ok",
+                "activeCliVersion": TEST_CLI_PACKAGE_SPEC.split("@", 1)[1],
+                "applied": {
+                    "etag": etag,
+                    "sourceRevision": source_revision,
+                    "generation": 3,
+                    "instanceId": "hri-unmanaged-health",
+                    "appliedProviderIds": applied_provider_ids,
+                },
+                "boot": None,
+                "cli": None,
+            },
+        )
+
+    exact = _runtime_observed_health(
+        env,
+        state,
+        observation([]),
+        desired_source_revision=source_revision,
+        desired_cli_package_spec=TEST_CLI_PACKAGE_SPEC,
+    )
+    stale = _runtime_observed_health(
+        env,
+        state,
+        observation(["stale-managed"]),
+        desired_source_revision=source_revision,
+        desired_cli_package_spec=TEST_CLI_PACKAGE_SPEC,
+    )
+    malformed_runtime = dict(next(iter(state.runtimes.values())))
+    malformed_runtime.pop("providerMode")
+    state.runtimes = {"openclaw": malformed_runtime}
+    malformed = _runtime_observed_health(
+        env,
+        state,
+        observation([]),
+        desired_source_revision=source_revision,
+        desired_cli_package_spec=TEST_CLI_PACKAGE_SPEC,
+    )
+
+    assert exact.status == "ok"
+    assert exact.reasons == []
+    assert stale.status == "unknown"
+    assert "applied_provider_ids_extra" in stale.reasons
+    assert malformed.status == "unknown"
+    assert "desired_provider_contract_invalid" in malformed.reasons
 
 
 async def _write_runtime_state(admin_client: httpx.AsyncClient, environment_id: str, **overrides):
@@ -348,7 +548,8 @@ async def _runtime_state_audit_count(db: AsyncSession, environment_id) -> int:
 @pytest.mark.parametrize(
     ("cli_package_spec", "accepted"),
     [
-        ("clawdi@0.12.10-beta.51", True),
+        ("clawdi@0.12.10-beta.52", False),
+        ("clawdi@0.12.10-beta.53", True),
         ("clawdi@1.2.3-rc-1.2", True),
         ("clawdi@1.2.3-beta..1", False),
         ("clawdi@1.2.3-beta.", False),
@@ -404,7 +605,8 @@ async def test_dashboard_dev_seed_runtime_state_validates_and_serves_manifest(
         now=datetime.now(UTC),
         sort_order=1,
     )
-    db_session.add(_seed_ai_provider(seed_user))
+    codex_provider, codex_payload = _seed_codex_provider_graph(seed_user)
+    db_session.add_all([_seed_ai_provider(seed_user), codex_provider, codex_payload])
     await db_session.commit()
 
     state = await db_session.get(HostedRuntimeState, env.id)
@@ -554,8 +756,7 @@ async def test_admin_runtime_state_rejects_invalid_or_below_floor_cli_package_sp
 @pytest.mark.parametrize(
     "cli_package_spec",
     [
-        "clawdi@0.12.10-beta.51",
-        "clawdi@0.12.10-beta.52",
+        "clawdi@0.12.10-beta.53",
         "clawdi@0.12.10-rc.1",
         "clawdi@0.12.10",
         "clawdi@0.12.11-beta.0",
@@ -641,7 +842,7 @@ async def test_admin_upsert_runtime_state_and_manifest_omit_channels(
     payload = response.json()
     manifest = payload["manifest"]
     assert manifest["schemaVersion"] == "clawdi.hosted-runtime.manifest.v1"
-    assert manifest["minimumCliVersion"] == "0.12.10-beta.51"
+    assert manifest["minimumCliVersion"] == "0.12.10-beta.53"
     assert manifest["runtime"] == "openclaw"
     assert set(manifest["runtimes"]) == {"openclaw"}
     assert manifest["locale"] == TEST_LOCALE
@@ -666,7 +867,7 @@ async def test_admin_upsert_runtime_state_and_manifest_omit_channels(
     ]
     assert "appId" not in manifest
     assert "channels" not in manifest
-    assert payload["secretValues"] == {}
+    assert payload["secretValues"] == {"tool.codex.apiKey": "sk-codex-tool"}
     assert etag == expected_runtime_bundle_v2_etag(payload["sourceRevision"])
 
     async with await _runtime_client(db_session, seed_user, api_key) as client:
@@ -785,7 +986,7 @@ async def test_stale_runtime_state_generation_returns_current_generation_without
             json={
                 **body,
                 "generation": 6,
-                "cli_package_spec": "clawdi@0.12.10-beta.52",
+                "cli_package_spec": "clawdi@0.12.10-beta.53",
             },
         )
 
@@ -824,7 +1025,7 @@ async def test_equal_generation_material_conflict_returns_current_generation_wit
         response = await admin_client.put(
             f"/v1/admin/environments/{environment_id}/runtime-state",
             headers=_AUTH,
-            json={**body, "cli_package_spec": "clawdi@0.12.10-beta.52"},
+            json={**body, "cli_package_spec": "clawdi@0.12.10-beta.54"},
         )
 
         assert response.status_code == 409, response.text
@@ -862,8 +1063,8 @@ async def test_concurrent_same_generation_runtime_state_updates_allow_one_winner
     sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
     try:
         candidate_specs = (
-            "clawdi@0.12.10-beta.52",
             "clawdi@0.12.10-beta.53",
+            "clawdi@0.12.10-beta.54",
         )
         candidate_bodies = [
             AdminRuntimeStateUpsert.model_validate(
@@ -967,8 +1168,8 @@ async def test_concurrent_initial_conflicting_runtime_state_upserts_return_gener
     )
     body = _runtime_state_body(str(env.id))
     candidate_specs = (
-        "clawdi@0.12.10-beta.52",
         "clawdi@0.12.10-beta.53",
+        "clawdi@0.12.10-beta.54",
     )
     audit_count = await _runtime_state_audit_count(db_session, env.id)
     queue = sync_events.subscribe(seed_user.id, frozenset(), environment_id=env.id)
@@ -1036,7 +1237,7 @@ async def test_cli_package_spec_change_updates_etag_audit_and_invalidation(
 
     queue = sync_events.subscribe(seed_user.id, frozenset(), environment_id=env.id)
     try:
-        updated_spec = "clawdi@0.12.10-beta.52"
+        updated_spec = "clawdi@0.12.10-beta.54"
         updated = await admin_client.put(
             f"/v1/admin/environments/{env.id}/runtime-state",
             headers=_AUTH,
@@ -1174,7 +1375,7 @@ async def test_agent_v2_manifest_cli_package_and_protocol_are_cloud_owned(
         "packageSpec": TEST_CLI_PACKAGE_SPEC,
         "registry": "https://registry.npmjs.org",
     }
-    assert response.json()["manifest"]["minimumCliVersion"] == "0.12.10-beta.51"
+    assert response.json()["manifest"]["minimumCliVersion"] == "0.12.10-beta.53"
 
 
 @pytest.mark.asyncio
@@ -1201,7 +1402,7 @@ async def test_admin_runtime_state_rejects_manifest_protocol_metadata(
             "locale": TEST_LOCALE,
             "system": TEST_SYSTEM,
             "runtimes": _runtime_state(),
-            "minimumCliVersion": "0.12.10-beta.51",
+            "minimumCliVersion": "0.12.10-beta.53",
         },
     )
 
@@ -1495,7 +1696,7 @@ async def test_runtime_manifest_rejects_invalid_stored_live_sync_or_recovery(
     if live_sync.get("agents"):
         live_sync["agents"][0]["environmentId"] = str(env.id)
     db_session.add(
-        HostedRuntimeState(
+        canonical_hosted_runtime_state(
             environment_id=env.id,
             deployment_id=f"dep_{uuid4().hex}",
             instance_id=f"hri_{uuid4().hex}",
@@ -1531,7 +1732,7 @@ async def test_runtime_manifest_rejects_invalid_stored_locale(
         agent_type="openclaw",
     )
     db_session.add(
-        HostedRuntimeState(
+        canonical_hosted_runtime_state(
             environment_id=env.id,
             deployment_id="dep-invalid-locale",
             instance_id="hri-invalid-locale",
@@ -1588,7 +1789,7 @@ async def test_runtime_manifest_rejects_malformed_stored_contract(
         agent_type="openclaw",
     )
     db_session.add(
-        HostedRuntimeState(
+        canonical_hosted_runtime_state(
             environment_id=env.id,
             deployment_id=f"dep_{uuid4().hex}",
             instance_id=f"hri_{uuid4().hex}",
@@ -1693,7 +1894,7 @@ async def test_runtime_manifest_rejects_invalid_stored_egress_state(
         "recovery": {"cacheManifest": True, "allowOfflineBoot": True},
         field: value,
     }
-    db_session.add(HostedRuntimeState(**state_values))
+    db_session.add(canonical_hosted_runtime_state(**state_values))
     await db_session.commit()
 
     api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
@@ -1740,7 +1941,7 @@ async def test_runtime_manifest_rejects_stored_runtime_bridge_mismatch(
         agent_type=runtime,
     )
     db_session.add(
-        HostedRuntimeState(
+        canonical_hosted_runtime_state(
             environment_id=env.id,
             deployment_id=f"dep_{uuid4().hex}",
             instance_id=f"hri_{uuid4().hex}",
@@ -1795,7 +1996,7 @@ async def test_runtime_manifest_rejects_invalid_stored_bridge(
         agent_type="openclaw",
     )
     db_session.add(
-        HostedRuntimeState(
+        canonical_hosted_runtime_state(
             environment_id=env.id,
             deployment_id=f"dep_{uuid4().hex}",
             instance_id=f"hri_{uuid4().hex}",
@@ -2190,7 +2391,7 @@ async def test_runtime_manifest_rejects_invalid_or_below_floor_stored_cli_packag
         agent_type="openclaw",
     )
     db_session.add(
-        HostedRuntimeState(
+        canonical_hosted_runtime_state(
             environment_id=env.id,
             deployment_id=f"dep_{uuid4().hex}",
             instance_id=f"hri_{uuid4().hex}",
@@ -2507,7 +2708,7 @@ async def test_admin_runtime_state_clears_optional_state(
         egress_engine=TEST_EGRESS_ENGINE_PIN,
         egress_profiles=TEST_EGRESS_PROFILES,
         mcp={"enabled": True},
-        tools={"catalog": "clawdi-default"},
+        tools={**TEST_CODEX_TOOLS, "catalog": "clawdi-default"},
     )
     update = _clear_optional_runtime_state({**initial, "generation": 8}, clear_mode)
     response = await admin_client.put(
@@ -2523,7 +2724,7 @@ async def test_admin_runtime_state_clears_optional_state(
     assert state.egress_engine is None
     assert state.egress_profiles is None
     assert state.mcp is None
-    assert state.tools is None
+    assert state.tools == {**TEST_CODEX_TOOLS, "catalog": "clawdi-default"}
 
 
 @pytest.mark.asyncio
@@ -2547,7 +2748,7 @@ async def test_equal_generation_optional_state_clear_is_material_conflict(
         egress_engine=TEST_EGRESS_ENGINE_PIN,
         egress_profiles=TEST_EGRESS_PROFILES,
         mcp={"enabled": True},
-        tools={"catalog": "clawdi-default"},
+        tools={**TEST_CODEX_TOOLS, "catalog": "clawdi-default"},
     )
     environment_id = env.id
     candidate = _clear_optional_runtime_state(initial, clear_mode)
@@ -2566,7 +2767,7 @@ async def test_equal_generation_optional_state_clear_is_material_conflict(
     assert state.egress_engine == TEST_EGRESS_ENGINE_PIN
     assert state.egress_profiles == TEST_EGRESS_PROFILES
     assert state.mcp == {"enabled": True}
-    assert state.tools == {"catalog": "clawdi-default"}
+    assert state.tools == {**TEST_CODEX_TOOLS, "catalog": "clawdi-default"}
 
 
 def test_control_plane_audit_sanitizes_auth_cookie_and_credential_keys():
@@ -2608,7 +2809,11 @@ async def test_runtime_manifest_projects_mcp_and_tools_desired_state(
         admin_client,
         str(env.id),
         mcp={"enabled": True, "profile": "clawdi-default"},
-        tools={"catalog": "clawdi-default", "enabled": ["memory", "connectors"]},
+        tools={
+            **TEST_CODEX_TOOLS,
+            "catalog": "clawdi-default",
+            "enabled": ["memory", "connectors"],
+        },
     )
 
     api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
@@ -2623,6 +2828,7 @@ async def test_runtime_manifest_projects_mcp_and_tools_desired_state(
         "catalog": "clawdi-default",
         "enabled": ["memory", "connectors"],
     }
+    assert manifest["terminalTooling"]["codex"]["provider_id"] == "clawdi-managed-v2"
     assert "channels" not in manifest
 
 
@@ -2735,6 +2941,7 @@ async def test_runtime_manifest_projects_selected_runtime_provider_pool(
     assert payload["secretValues"] == {
         "provider.anthropic-managed.apiKey": "sk-hermes-provider",
         "provider.openai-managed.apiKey": "sk-openclaw-provider",
+        "tool.codex.apiKey": "sk-codex-tool",
     }
 
 
@@ -2848,6 +3055,7 @@ async def test_runtime_manifest_preserves_non_openai_provider_protocols(
     assert payload["secretValues"] == {
         "provider.gemini-byok.apiKey": "sk-gemini-provider",
         "provider.anthropic-byok.apiKey": "sk-anthropic-provider",
+        "tool.codex.apiKey": "sk-codex-tool",
     }
 
 
@@ -2919,7 +3127,7 @@ async def test_runtime_manifest_marks_key_required_provider_unhealthy_without_se
         "provider_id": "missing-key-provider",
         "model": "claude-opus-4-6",
     }
-    assert body["secretValues"] == {}
+    assert body["secretValues"] == {"tool.codex.apiKey": "sk-codex-tool"}
 
 
 @pytest.mark.asyncio
@@ -2977,7 +3185,7 @@ async def test_runtime_manifest_does_not_select_secret_without_managed_source(
     provider = response.json()["manifest"]["providers"]["missing-source-provider"]
     assert provider["status"] == "error"
     assert provider["error"]["code"] == "provider_secret_unavailable"
-    assert response.json()["secretValues"] == {}
+    assert response.json()["secretValues"] == {"tool.codex.apiKey": "sk-codex-tool"}
 
 
 @pytest.mark.asyncio
@@ -3061,7 +3269,7 @@ async def test_runtime_manifest_marks_explicit_archived_provider_binding_unhealt
         "provider_id": "deleted-custom-provider",
         "model": "gpt-5.5",
     }
-    assert payload["secretValues"] == {}
+    assert payload["secretValues"] == {"tool.codex.apiKey": "sk-managed-provider"}
 
 
 @pytest.mark.asyncio
@@ -3697,7 +3905,7 @@ async def test_runtime_manifest_rejects_state_without_exactly_one_enabled_runtim
         agent_type="openclaw",
     )
     db_session.add(
-        HostedRuntimeState(
+        canonical_hosted_runtime_state(
             environment_id=env.id,
             deployment_id=f"dep_{uuid4().hex}",
             instance_id=f"hri_{uuid4().hex}",
@@ -3736,7 +3944,7 @@ async def test_runtime_manifest_rejects_unknown_enabled_runtime_state(
         agent_type="openclaw",
     )
     db_session.add(
-        HostedRuntimeState(
+        canonical_hosted_runtime_state(
             environment_id=env.id,
             deployment_id=f"dep_{uuid4().hex}",
             instance_id=f"hri_{uuid4().hex}",
@@ -3751,7 +3959,7 @@ async def test_runtime_manifest_rejects_unknown_enabled_runtime_state(
             recovery={"cacheManifest": True, "allowOfflineBoot": True},
             egress_profiles=None,
             mcp=None,
-            tools=None,
+            tools=TEST_CODEX_TOOLS,
         )
     )
     await db_session.commit()
@@ -3778,7 +3986,7 @@ async def test_runtime_manifest_rejects_codex_selected_runtime_state(
         agent_type="codex",
     )
     db_session.add(
-        HostedRuntimeState(
+        canonical_hosted_runtime_state(
             environment_id=env.id,
             deployment_id=f"dep_{uuid4().hex}",
             instance_id=f"hri_{uuid4().hex}",
@@ -4026,14 +4234,14 @@ async def test_runtime_manifest_projects_provider_secret_values_for_managed_acco
         "managed_by": "clawdi",
         "models": managed_models,
         "runtimeEnvName": "OPENAI_API_KEY",
-        "apiKeySecretRef": "provider.clawdi-managed-v2.apiKey",
+        "apiKeySecretRef": "tool.codex.apiKey",
     }
     assert payload["manifest"]["runtimes"]["openclaw"]["provider_ids"] == ["clawdi-managed-v2"]
     assert payload["manifest"]["runtimes"]["openclaw"]["primary_model"] == {
         "provider_id": "clawdi-managed-v2",
         "model": "gpt-5.5",
     }
-    assert payload["secretValues"] == {"provider.clawdi-managed-v2.apiKey": "sk-test-provider"}
+    assert payload["secretValues"] == {"tool.codex.apiKey": "sk-test-provider"}
     etag = response.headers["etag"]
 
     provider.label = "Presentation-only label"
@@ -4084,9 +4292,7 @@ async def test_runtime_manifest_projects_provider_secret_values_for_managed_acco
         rotated.json()["sourceRevision"]
     )
     assert rotated.json()["manifest"]["issuedAt"] == issued_at
-    assert rotated.json()["secretValues"] == {
-        "provider.clawdi-managed-v2.apiKey": "sk-rotated-provider"
-    }
+    assert rotated.json()["secretValues"] == {"tool.codex.apiKey": "sk-rotated-provider"}
 
 
 @pytest.mark.asyncio
@@ -4155,7 +4361,10 @@ async def test_runtime_manifest_selects_managed_provider_secret_by_auth_profile(
 
     assert response.status_code == 200, response.text
     expected_secret = "sk-default-profile" if active_profile == "default" else "sk-work-profile"
-    assert response.json()["secretValues"] == {f"provider.{provider_id}.apiKey": expected_secret}
+    assert response.json()["secretValues"] == {
+        f"provider.{provider_id}.apiKey": expected_secret,
+        "tool.codex.apiKey": "sk-codex-tool",
+    }
 
 
 @pytest.mark.asyncio
@@ -4261,18 +4470,22 @@ async def test_runtime_manifest_rejects_invalid_stored_provider_model_metadata(
     db_session.add(
         AiProvider(
             owner_user_id=seed_user.id,
-            provider_id="clawdi-managed-v2",
+            provider_id="invalid-runtime-provider",
             type="custom_openai_compatible",
             base_url="https://sub2api.test/v1",
             models=stored_models,
             api_mode="openai_chat",
             auth_type="none",
-            managed_by="clawdi",
-            runtime_env_name="CLAWDI_MANAGED_OPENAI_API_KEY",
+            managed_by="user",
+            runtime_env_name="INVALID_RUNTIME_PROVIDER_API_KEY",
         )
     )
     await db_session.commit()
-    await _write_runtime_state(admin_client, str(env.id))
+    await _write_runtime_state(
+        admin_client,
+        str(env.id),
+        runtimes=_runtime_state(provider_ids=["invalid-runtime-provider"]),
+    )
 
     api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
     async with await _runtime_client(db_session, seed_user, api_key) as client:
@@ -4356,7 +4569,10 @@ async def test_runtime_manifest_projects_legacy_managed_provider_as_responses(
         "provider_id": "clawdi-managed",
         "model": "openai-codex/gpt-5.5",
     }
-    assert payload["secretValues"] == {"provider.clawdi-managed.apiKey": "sk-test-legacy-provider"}
+    assert payload["secretValues"] == {
+        "provider.clawdi-managed.apiKey": "sk-test-legacy-provider",
+        "tool.codex.apiKey": "sk-codex-tool",
+    }
 
 
 @pytest.mark.asyncio
@@ -4495,7 +4711,7 @@ async def test_runtime_manifest_projects_codex_agent_profile_auth(
         "provider_id": "openai-codex",
         "model": "gpt-5.5",
     }
-    assert response.json()["secretValues"] == {}
+    assert response.json()["secretValues"] == {"tool.codex.apiKey": "sk-codex-tool"}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -11,6 +11,7 @@ from app.models.ai_provider import AiProvider, AiProviderAuthPayload
 from app.models.channel import ChannelAccount, ChannelBotAgentLink
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.session import AgentEnvironment
+from app.schemas.runtime import HostedCodexProviderProjection
 from app.services.runtime_source import (
     RuntimeSourceBatch,
     RuntimeSourceError,
@@ -48,7 +49,7 @@ def _batch(
         deployment_id="dep_test",
         instance_id="hri_test",
         generation=7,
-        cli_package_spec="clawdi@0.12.10-beta.51",
+        cli_package_spec="clawdi@0.12.10-beta.53",
         locale={"language": "en", "timezone": "UTC"},
         system={
             "user": "clawdi",
@@ -59,6 +60,7 @@ def _batch(
         runtimes={
             "openclaw": {
                 "enabled": True,
+                "providerMode": "configured",
                 "provider_ids": ["managed"],
                 "primary_model": {"provider_id": "managed", "model": "gpt-test"},
                 "install": {"source": "official"},
@@ -75,6 +77,13 @@ def _batch(
             "agents": [{"agentType": "openclaw", "environmentId": str(ENV_ID)}],
         },
         recovery={"cacheManifest": True, "allowOfflineBoot": True},
+        tools={
+            "codex": {
+                "enabled": True,
+                "provider_id": "managed",
+                "primary_model": {"provider_id": "managed", "model": "gpt-test"},
+            }
+        },
     )
     state.created_at = now
     provider = AiProvider(
@@ -84,7 +93,7 @@ def _batch(
         type="openai",
         label=provider_label,
         base_url="https://provider.test/v1",
-        api_mode="responses",
+        api_mode="openai_chat",
         auth_type="api_key",
         auth_metadata={"source": "managed", "profile": "default"},
         managed_by="clawdi",
@@ -215,6 +224,100 @@ def test_runtime_source_revision_uses_only_projected_descriptor_and_secret_sourc
     ]
 
 
+def test_unmanaged_runtime_tool_secret_uses_auth_payload_without_user_vault_refs(
+    monkeypatch,
+) -> None:
+    from app.services import runtime_source
+
+    batch = _batch()
+    state = batch.rows[ENV_ID].state
+    assert state is not None
+    runtime = dict(state.runtimes["openclaw"])
+    runtime["providerMode"] = "unmanaged"
+    runtime["provider_ids"] = []
+    runtime.pop("primary_model")
+    state.runtimes = {"openclaw": runtime}
+    batch.channels.clear()
+    decrypt_calls: list[tuple[bytes, bytes]] = []
+
+    def record_decrypt(ciphertext: bytes, nonce: bytes) -> str:
+        decrypt_calls.append((ciphertext, nonce))
+        return "sk-codex-tool"
+
+    monkeypatch.setattr(runtime_source, "decrypt", record_decrypt)
+    source = render_runtime_source(
+        batch,
+        environment_id=ENV_ID,
+        public_api_url="https://cloud.test/",
+        vault_key_identity="platform-key-generation-1",
+        decrypt_secrets=True,
+    )
+    bundle = render_runtime_bundle(source)
+
+    assert source.manifest["providers"] == {}
+    assert source.manifest["runtimes"]["openclaw"]["providerMode"] == "unmanaged"
+    assert source.manifest["terminalTooling"]["codex"]["provider_id"] == "managed"
+    assert source.manifest["terminalTooling"]["codex"]["provider"]["apiMode"] == (
+        "openai_responses"
+    )
+    assert source.secret_values == {"tool.codex.apiKey": "sk-codex-tool"}
+    assert decrypt_calls == [(b"provider-ciphertext", b"provider-nonce")]
+    assert "clawdi://" not in json.dumps(bundle)
+
+
+def test_codex_tool_projection_pydantic_contract_rejects_openai_chat() -> None:
+    with pytest.raises(ValueError):
+        HostedCodexProviderProjection.model_validate(
+            {
+                "kind": "openai-compatible",
+                "baseUrl": "https://provider.test/v1",
+                "apiMode": "openai_chat",
+                "managed_by": "clawdi",
+                "runtimeEnvName": "OPENAI_API_KEY",
+                "apiKeySecretRef": "tool.codex.apiKey",
+            }
+        )
+
+
+def test_shared_managed_provider_material_has_distinct_codex_wire_mode() -> None:
+    source = _render(_batch())
+
+    assert source.manifest["providers"]["managed"]["apiMode"] == "openai_chat"
+    assert source.manifest["terminalTooling"]["codex"]["provider"]["apiMode"] == (
+        "openai_responses"
+    )
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        "missing_provider",
+        "user_owned",
+        "missing_payload",
+        "payload_kind",
+        "payload_source",
+        "api_mode",
+    ],
+)
+def test_codex_tool_provider_fails_closed_without_platform_credential(failure: str) -> None:
+    batch = _batch()
+    if failure == "missing_provider":
+        batch.providers.clear()
+    elif failure == "user_owned":
+        batch.providers[(USER_ID, "managed")].managed_by = "user"
+    elif failure == "missing_payload":
+        batch.auth_payloads.clear()
+    elif failure == "payload_kind":
+        batch.auth_payloads[(USER_ID, "managed", "default")].kind = "oauth_profile"
+    elif failure == "payload_source":
+        batch.auth_payloads[(USER_ID, "managed", "default")].source = "vault"
+    else:
+        batch.providers[(USER_ID, "managed")].api_mode = "anthropic_messages"
+
+    with pytest.raises(RuntimeSourceError, match="Hosted Codex tool provider"):
+        _render(batch)
+
+
 def test_runtime_source_preserves_distinct_valid_provider_ids(monkeypatch) -> None:
     from app.services import runtime_source
 
@@ -241,7 +344,7 @@ def test_runtime_source_preserves_distinct_valid_provider_ids(monkeypatch) -> No
         vault_key_identity="vault-key-generation-1",
         decrypt_secrets=True,
     )
-    assert source.secret_values["provider.managed.apiKey"] == "provider-ciphertext"
+    assert source.secret_values["tool.codex.apiKey"] == "provider-ciphertext"
     assert source.secret_values["provider.managed-.apiKey"] == "provider-two-ciphertext"
     assert len(decrypt_calls) == 3
 
@@ -263,6 +366,11 @@ def test_runtime_source_rejects_duplicate_normalized_provider_ref_before_decrypt
         runtime_source,
         "_provider_secret_ref",
         lambda value: f"provider.{value.rstrip('-')}.apiKey",
+    )
+    monkeypatch.setattr(
+        runtime_source,
+        "_CODEX_TOOL_SECRET_REF",
+        "provider.managed.apiKey",
     )
     decrypt_calls: list[tuple[bytes, bytes]] = []
 

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -257,7 +257,7 @@ async def test_environments_mark_only_agents_with_hosted_runtime_state(
             deployment_id="hdep_test",
             instance_id="instance-test",
             generation=1,
-            cli_package_spec="clawdi@0.12.10-beta.51",
+            cli_package_spec="clawdi@0.12.10-beta.53",
             locale={"language": "en", "timezone": "UTC"},
             system=_TEST_SYSTEM,
             live_sync={"enabled": False, "agents": []},
@@ -265,6 +265,7 @@ async def test_environments_mark_only_agents_with_hosted_runtime_state(
             runtimes={
                 "openclaw": {
                     "enabled": True,
+                    "providerMode": "configured",
                     "provider_ids": ["clawdi-managed"],
                     "primary_model": {
                         "provider_id": "clawdi-managed",

--- a/backend/tests/test_sync_events.py
+++ b/backend/tests/test_sync_events.py
@@ -26,6 +26,7 @@ import pytest
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.hosted_runtime import HostedRuntimeState
 from app.models.user import User
 from app.services import sync_events
 
@@ -252,6 +253,31 @@ async def test_runtime_manifest_event_delivers_after_commit_not_rollback(
         assert queue.empty()
     finally:
         sync_events.unsubscribe(user_id, queue)
+
+
+def test_runtime_provider_usage_includes_independent_codex_tool_ref() -> None:
+    state = HostedRuntimeState(
+        runtimes={
+            "openclaw": {
+                "enabled": True,
+                "providerMode": "unmanaged",
+                "provider_ids": [],
+                "install": {"source": "official"},
+                "services": {},
+                "paths": {"home": "/home/clawdi", "workspace": "/home/clawdi/clawdi"},
+            }
+        },
+        tools={
+            "codex": {
+                "enabled": True,
+                "provider_id": "codex-managed",
+                "primary_model": {"provider_id": "codex-managed", "model": "gpt-5.5"},
+            }
+        },
+    )
+
+    assert sync_events._runtime_state_may_use_provider(state, "codex-managed") is True
+    assert sync_events._runtime_state_may_use_provider(state, "unrelated") is False
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -30,11 +30,16 @@ from app.core.auth import AuthContext, get_auth
 from app.core.database import get_session
 from app.main import app
 from app.models.api_key import ApiKey
-from app.models.hosted_runtime import HostedRuntimeConfigObservation, HostedRuntimeState
+from app.models.hosted_runtime import HostedRuntimeConfigObservation
 from app.services.runtime_source import expected_runtime_bundle_v2_etag
+from tests.hosted_runtime_fixtures import (
+    CANONICAL_CODEX_TOOLS,
+    canonical_hosted_runtime_state,
+    ensure_canonical_codex_tool_provider,
+)
 
 _TEST_LOCALE = {"language": "en", "timezone": "UTC"}
-_TEST_CLI_PACKAGE_SPEC = "clawdi@0.12.10-beta.51"
+_TEST_CLI_PACKAGE_SPEC = "clawdi@0.12.10-beta.53"
 _TEST_SYSTEM = {
     "user": "clawdi",
     "home": "/home/clawdi",
@@ -43,10 +48,19 @@ _TEST_SYSTEM = {
 }
 
 
+@pytest_asyncio.fixture(autouse=True)
+async def _canonical_codex_tool_graph(
+    db_session: AsyncSession,
+    seed_user,
+) -> None:
+    await ensure_canonical_codex_tool_provider(db_session, seed_user)
+
+
 def _test_runtimes(provider_id: str = "clawdi-managed") -> dict:
     return {
         "openclaw": {
             "enabled": True,
+            "providerMode": "configured",
             "provider_ids": [provider_id],
             "primary_model": {"provider_id": provider_id, "model": "gpt-5.5"},
             "install": {"source": "official"},
@@ -60,7 +74,7 @@ def _runtime_observed(
     source_revision: str = "a" * 64,
     reported_at: str | None = None,
     status: str = "ok",
-    active_cli_version: str | None = "0.12.10-beta.51",
+    active_cli_version: str | None = "0.12.10-beta.53",
     applied: bool = True,
     manifest_etag: str | None = None,
     applied_generation: int = 4,
@@ -467,7 +481,7 @@ async def test_bound_key_heartbeat_updates_hosted_runtime_config_observation(
     env_bound_cli_client, db_session: AsyncSession
 ):
     client, bound_id, _other_id = env_bound_cli_client
-    state = HostedRuntimeState(
+    state = canonical_hosted_runtime_state(
         environment_id=uuid.UUID(bound_id),
         deployment_id="dep-observed",
         instance_id="iid-observed",
@@ -517,7 +531,7 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
     db_session: AsyncSession,
 ):
     env_id = await _create_env(client)
-    state = HostedRuntimeState(
+    state = canonical_hosted_runtime_state(
         environment_id=uuid.UUID(env_id),
         deployment_id="dep-observed-api",
         instance_id="iid-observed-api",
@@ -529,7 +543,7 @@ async def test_runtime_observed_endpoint_returns_desired_observed_health(
         recovery={"cacheManifest": True, "allowOfflineBoot": True},
         runtimes=_test_runtimes(),
         mcp={"enabled": True},
-        tools={"catalog": "clawdi-default"},
+        tools={**CANONICAL_CODEX_TOOLS, "catalog": "clawdi-default"},
     )
     db_session.add(state)
     await db_session.commit()
@@ -591,7 +605,7 @@ async def test_v2_applied_authority_persists_and_drives_health(
 ):
     env_id = await _create_env(client)
     db_session.add(
-        HostedRuntimeState(
+        canonical_hosted_runtime_state(
             environment_id=uuid.UUID(env_id),
             deployment_id="dep-observed-v2",
             instance_id="iid-observed-v2",
@@ -618,7 +632,7 @@ async def test_v2_applied_authority_persists_and_drives_health(
     assert observation.observed_config_generation == 4
     assert observation.observed_manifest_etag == expected_runtime_bundle_v2_etag(source_revision)
     assert observation.observed_source_revision == source_revision
-    assert observation.diagnostics["activeCliVersion"] == "0.12.10-beta.51"
+    assert observation.diagnostics["activeCliVersion"] == "0.12.10-beta.53"
     healthy = (await client.get(f"/v1/environments/{env_id}/runtime-observed")).json()
     assert healthy["health"] == {
         "status": "ok",
@@ -688,7 +702,7 @@ async def test_v2_health_requires_expected_etag_and_exact_source_provider_set(
 ):
     env_id = await _create_env(client)
     db_session.add(
-        HostedRuntimeState(
+        canonical_hosted_runtime_state(
             environment_id=uuid.UUID(env_id),
             deployment_id="dep-observed-v2-equality",
             instance_id="iid-observed-v2-equality",
@@ -730,7 +744,7 @@ async def test_runtime_observed_health_uses_typed_config_generation(
 ):
     env_id = await _create_env(client)
     db_session.add(
-        HostedRuntimeState(
+        canonical_hosted_runtime_state(
             environment_id=uuid.UUID(env_id),
             deployment_id="dep-config-convergence",
             instance_id="iid-config-convergence",
@@ -785,7 +799,7 @@ async def test_sync_heartbeat_repairs_non_object_diagnostics(
 ):
     env_id = await _create_env(client)
     db_session.add(
-        HostedRuntimeState(
+        canonical_hosted_runtime_state(
             environment_id=uuid.UUID(env_id),
             deployment_id="dep-legacy-json-value",
             instance_id="iid-legacy-json-value",
@@ -832,7 +846,7 @@ async def test_config_generation_and_manifest_etag_are_stored_independently(
     db_session: AsyncSession,
 ):
     env_id = await _create_env(client)
-    state = HostedRuntimeState(
+    state = canonical_hosted_runtime_state(
         environment_id=uuid.UUID(env_id),
         deployment_id="dep-config-etag-independent",
         instance_id="iid-config-etag-independent",
@@ -885,7 +899,7 @@ async def test_runtime_observed_endpoint_safely_degrades_invalid_stored_diagnost
 ):
     env_id = await _create_env(client)
     db_session.add(
-        HostedRuntimeState(
+        canonical_hosted_runtime_state(
             environment_id=uuid.UUID(env_id),
             deployment_id="dep-legacy-diagnostics",
             instance_id="iid-legacy-diagnostics",
@@ -948,7 +962,7 @@ async def test_sync_heartbeat_ignores_reported_at_only_observed_changes(
     db_session: AsyncSession,
 ):
     env_id = await _create_env(client)
-    state = HostedRuntimeState(
+    state = canonical_hosted_runtime_state(
         environment_id=uuid.UUID(env_id),
         deployment_id="dep-observed-dedupe",
         instance_id="iid-observed-dedupe",
@@ -995,7 +1009,7 @@ async def test_runtime_observed_endpoint_surfaces_supervisor_errors(
     db_session: AsyncSession,
 ):
     env_id = await _create_env(client)
-    state = HostedRuntimeState(
+    state = canonical_hosted_runtime_state(
         environment_id=uuid.UUID(env_id),
         deployment_id="dep-supervisor-error",
         instance_id="iid-supervisor-error",
@@ -1045,7 +1059,7 @@ async def test_runtime_observed_endpoint_surfaces_provider_errors(
     db_session: AsyncSession,
 ):
     env_id = await _create_env(client)
-    state = HostedRuntimeState(
+    state = canonical_hosted_runtime_state(
         environment_id=uuid.UUID(env_id),
         deployment_id="dep-provider-error",
         instance_id="iid-provider-error",
@@ -1140,7 +1154,7 @@ async def test_runtime_observed_summary_has_bounded_queries_without_secret_decry
     missing_state_env_id = await _create_env(client)
     db_session.add_all(
         [
-            HostedRuntimeState(
+            canonical_hosted_runtime_state(
                 environment_id=uuid.UUID(ok_env_id),
                 deployment_id="dep-summary-ok",
                 instance_id="iid-summary-ok",
@@ -1152,7 +1166,7 @@ async def test_runtime_observed_summary_has_bounded_queries_without_secret_decry
                 recovery={"cacheManifest": True, "allowOfflineBoot": True},
                 runtimes=_test_runtimes(),
             ),
-            HostedRuntimeState(
+            canonical_hosted_runtime_state(
                 environment_id=uuid.UUID(error_env_id),
                 deployment_id="dep-summary-error",
                 instance_id="iid-summary-error",
@@ -1232,7 +1246,7 @@ async def test_sync_heartbeat_rejects_malformed_observed_scalar(
 ):
     env_id = await _create_env(client)
     db_session.add(
-        HostedRuntimeState(
+        canonical_hosted_runtime_state(
             environment_id=uuid.UUID(env_id),
             deployment_id="dep-observed-strict",
             instance_id="iid-observed-strict",
@@ -1265,7 +1279,7 @@ async def test_sync_heartbeat_bounds_oversized_observed_payload(
 ):
     env_id = await _create_env(client)
     db_session.add(
-        HostedRuntimeState(
+        canonical_hosted_runtime_state(
             environment_id=uuid.UUID(env_id),
             deployment_id="dep-observed-bounded",
             instance_id="iid-observed-bounded",

--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.52",
+      "version": "0.12.10-beta.53",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
+++ b/docs/adr/0002-runtime-image-is-a-stable-capability-envelope.md
@@ -23,6 +23,11 @@ The runtime image supplies stable operating-system capabilities. The Clawdi CLI
 owns runtime-local module paths, generated configuration, permissions,
 privilege dropping, and lifecycle behavior.
 
+Provider ownership modes, terminal Codex provider selection, secret references,
+egress profiles, and generated Codex configuration or command shims are desired-state
+business logic. They are materialized by Cloud and reconciled by the CLI; none
+of them may be baked into the stable runtime image or its entrypoints.
+
 Hosted mode is an explicit CLI contract selected by
 `CLAWDI_RUNTIME_MODE=hosted`; it is not inferred from image files. The hosted
 command policy is built into the CLI. Deployment must provide
@@ -61,7 +66,7 @@ For transparent egress:
 ## Cloud Hosted Authority
 
 The Hosted rollout writer selects an exact CLI package spec. Cloud validates
-and persists it, enforces the Cloud-owned `0.12.10-beta.51` minimum, fixes the
+and persists it, enforces the Cloud-owned `0.12.10-beta.53` minimum, fixes the
 package source and official registry, and owns the public manifest projection.
 Remote Hosted state cannot provide a floating package, installer URL, installer
 args, source, or registry. Bootstrap tgz input is fixture-only, while generic

--- a/docs/adr/0003-runtime-bundle-media-type-is-the-render-contract.md
+++ b/docs/adr/0003-runtime-bundle-media-type-is-the-render-contract.md
@@ -31,6 +31,14 @@ payloads, and active Telegram/Discord links with set-based queries inside one
 `REPEATABLE READ READ ONLY` snapshot. The endpoint and runtime health summary
 use the same pure materializer. Summary rendering does not decrypt secrets.
 
+The runtime provider plane has an explicit `configured | unmanaged`
+discriminator. Runtime `providers` remains an exact projection of runtime
+`provider_ids`; unmanaged renders both as empty and omits the runtime primary
+model. Hosted Codex is a distinct typed `terminalTooling.codex` projection. Its
+provider material is resolved from the same snapshot and deduplicated with a
+shared configured runtime provider, but it is excluded from runtime provider
+identity, observations, and health. Terminal Codex does not imply MCP.
+
 `sourceRevision` hashes the effective public descriptor plus secret-reference
 keyed encrypted-source identities. Because the v2 media-type renderer is
 immutable, its strong HTTP ETag is derived as `"sha256:<sourceRevision>"`.

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -293,14 +293,16 @@ Normalization maps hosted fields into the internal shape:
 | `runtimes.<name>.enabled` | Run config and systemd unit state |
 | `runtimes.<name>.install` | Required strict `{source: "official"}` selector; CLI owns installer URL and args |
 | `runtimes.<name>.run` | Command, args, cwd, env, and PATH projection |
-| `runtimes.<name>.provider_ids` | Required non-empty unique runtime provider selection |
-| `runtimes.<name>.primary_model.{provider_id,model}` | Required primary model whose provider belongs to `provider_ids` |
+| `runtimes.<name>.providerMode` | Required runtime-provider ownership discriminator: `configured` or `unmanaged` |
+| `runtimes.<name>.provider_ids` | Configured mode requires a non-empty unique selection; unmanaged mode requires an exact empty list |
+| `runtimes.<name>.primary_model.{provider_id,model}` | Required only in configured mode and its provider must belong to `provider_ids`; absent in unmanaged mode |
 | `runtimes.<name>.paths.{home,workspace}` | Required canonical runtime paths; missing values and legacy `stateDir` are rejected |
 | `providers.<id>` | Canonical Hosted provider projection: `kind` is exactly `openai-compatible`; normal entries also require `type` and `baseUrl`, while `provider_not_found` is the only reduced error entry |
 | `runtimes.<name>.services` | Runtime-owned auxiliary processes, such as a browser dashboard, managed without user command shims |
 | `bridge.surfaces` | Optional authenticated runtime surface listen/upstream mappings |
-| `providers` | Required runtime-scoped AI provider projections whose keys exactly match selected `provider_ids` |
-| `mcp`, `tools` | Runtime MCP/tool projection input |
+| `providers` | Required runtime-scoped AI provider projections whose keys exactly match selected `provider_ids`; `{}` in unmanaged mode |
+| `terminalTooling.codex` | Required typed Hosted terminal-tool projection with one Clawdi-managed provider metadata and secret reference, independent of runtime providers |
+| `mcp`, `tools` | Existing runtime MCP/tool projection input; unrelated tool fields remain pass-through and do not include terminal Codex |
 | `liveSync.{enabled,agents}` | Required explicit daemon sync configuration; Hosted does not infer it from agent metadata |
 | `egressProfiles` | Explicit local sidecar profiles |
 | `recovery.{cacheManifest,allowOfflineBoot}` | Required explicit manifest cache and offline-boot behavior |
@@ -319,12 +321,55 @@ healthy entries retain the normal `kind`, `type`, and `baseUrl` projection.
 This strict typing claim applies only to the Hosted fields modeled in this
 release. `egressEngine` and `egressProfiles` use closed schemas matching the
 Hosted CLI wire and are validated at admin write and manifest read boundaries.
-Invalid stored egress JSON fails closed with `409`. `mcp` and `tools` remain
-explicit pass-through projections; this work does not broaden, alias, remove,
-or remodel those surfaces. The normalized generic
+Invalid stored egress JSON fails closed with `409`. `terminalTooling.codex` is
+the one typed terminal-tool subset in this release. It does not declare MCP and
+does not participate in runtime `provider_ids`, runtime primary-model selection,
+source-level applied provider IDs, or runtime provider health. `mcp` and
+unrelated `tools` fields retain their existing pass-through behavior. `mcp` and
+`tools` remain explicit pass-through projections. The normalized generic
 `clawdi.runtimeDesiredState.v1` shape also retains optional install metadata,
 default install args, and arbitrary provider projection data such as singular
 `model` for non-Hosted inputs.
+
+### Runtime Provider Ownership And Terminal Codex
+
+Agent v2 requires exactly one selected OpenClaw or Hermes runtime. Provider
+intent is also explicit: `configured` means Clawdi owns the selected runtime
+provider projection, while `unmanaged` means Clawdi projects no runtime provider
+metadata, secret reference, environment variable, or primary model. Empty
+provider state never implies a mode. Runtime-only deployments therefore render
+`providerMode: "unmanaged"`, `provider_ids: []`, no `primary_model`, and
+`providers: {}`. Health is exact only when the source-level applied provider set
+is also empty.
+
+Hosted Codex is a separate terminal tool plane. Its fixed provider reference is
+materialized under `terminalTooling.codex` from the same repeatable-read batch as
+runtime providers. When both consumers use the same provider, Cloud resolves
+and decrypts that provider auth payload once. The CLI uses the terminal-tool
+reference to own exactly one Hosted Codex default configuration at
+`$CODEX_HOME/config.toml` (default `~/.codex/config.toml`) and a managed command
+shim. The shim exports the process-scoped egress placeholder and executes the
+real Codex with the original arguments; it never adds `--profile`. Managed,
+BYOK, Codex OAuth, and unmanaged runtime-provider modes all receive the same
+terminal Codex default. Unmanaged OpenClaw or Hermes units receive no provider
+environment.
+
+This mode controls default configuration ownership, not pod-wide network
+isolation. Egress matching is domain based, so another pod process could call a
+tool-plane gateway deliberately; the credential remains deployment-scoped and
+charges that deployment user's wallet.
+
+Platform provider and tool credentials are stored as encrypted provider auth
+payloads and projected through bundle secret references. They are not user
+Vault items, do not use `clawdi://` references, and do not depend on Vault
+attach, share, delete, or resolve operations. User Vault participation remains
+explicit through the existing user-facing provider and `clawdi run` flows. The
+unmanaged provider discriminator does not reject an independently, explicitly
+selected user Vault-backed run or service secret reference; it only prevents
+provider-plane material from being inferred or projected into the runtime.
+The backend's existing low-level encryption helper and key reuse is legacy
+infrastructure; it is not a runtime Vault contract and this release does not
+change its ciphertext format or key.
 
 Remote Hosted CLI policy is exact-version only. Values such as npm dist-tags,
 bare package names, build-metadata versions such as `clawdi@1.2.3+build.1`, and
@@ -685,7 +730,7 @@ The exact-only Hosted package, fixture-only bootstrap tgz, strict
 provider/install fields, and preserved generic desired-state behavior described
 above are the CLI boundary. The Hosted rollout writer selects
 `cli_package_spec`; Cloud validates and persists it, requires the exact version
-to be at least the Cloud-owned `0.12.10-beta.51` protocol floor, and owns the
+to be at least the Cloud-owned `0.12.10-beta.53` protocol floor, and owns the
 public manifest projection. Cloud fixes `clawdiCli.source` to `npm:clawdi` and
 `clawdiCli.registry` to `https://registry.npmjs.org`. Stored package state is
 revalidated on every read and fails closed with `409` when invalid or below the

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -144,7 +144,7 @@ releases.
 
    Agent deployment v2 is not live. Keep creation and runtime-state
    reconciliation disabled until the Hosted image contract, CLI version
-   `0.12.10-beta.51`, and the Cloud manifest contract are all deployed. Validate
+   `0.12.10-beta.53`, and the Cloud manifest contract are all deployed. Validate
    one fresh deployment end to end through `/v1/runtime/manifest` and SSE before
    enabling v2. Do not add compatibility fields, aliases, or fallback package
    channels.

--- a/docs/runbooks/release.md
+++ b/docs/runbooks/release.md
@@ -121,6 +121,27 @@ releases.
    Hosted rollout uses that same exact package spec in the Cloud manifest. The
    runtime never resolves an npm dist-tag.
 
+   Hosted Codex is a CLI-owned tool-plane dependency pinned by the immutable
+   Clawdi CLI release. For `0.12.10-beta.53`, verify the audited exact package
+   and executable before activating Hosted:
+
+   ```bash
+   test "$(npm view @openai/codex@0.142.4 version)" = "0.142.4"
+   npx --yes @openai/codex@0.142.4 --version | grep -F '0.142.4'
+   ```
+
+   A Hosted Codex version change therefore requires a new exact Clawdi CLI
+   release and the same registry/pairing smoke gate; it is not an image,
+   manifest, environment override, or npm dist-tag setting.
+
+   Managed provider egress rewrites require the public
+   `Bearer clawdi-egress-placeholder` authorization value as an explicit intent
+   marker. Requests with a user token or no authorization header are not
+   rewritten, which prevents accidental BYOK or unmanaged credential
+   replacement. This is not process or security isolation: any pod process that
+   deliberately sends the public marker can opt in, and resulting usage is
+   charged to that deployment user's wallet.
+
    Agent deployment v2 is not live. Keep creation and runtime-state
    reconciliation disabled until the Hosted image contract, CLI version
    `0.12.10-beta.51`, and the Cloud manifest contract are all deployed. Validate

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.52",
+	"version": "0.12.10-beta.53",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/runtime/hosted-egress-profiles.ts
+++ b/packages/cli/src/runtime/hosted-egress-profiles.ts
@@ -1,3 +1,4 @@
+import { MANAGED_EGRESS_PLACEHOLDER_VALUE } from "./egress-env";
 import { type EgressProfileInputBundle, egressProfileInputBundleSchema } from "./egress-profiles";
 
 type HostedEgressProfile = EgressProfileInputBundle["profiles"][number];
@@ -5,6 +6,7 @@ type HostedEgressProfile = EgressProfileInputBundle["profiles"][number];
 interface HostedRuntimeManifestProjection {
 	egressProfiles?: unknown;
 	providers?: unknown;
+	terminalTooling?: unknown;
 }
 
 interface HostedProviderProjection {
@@ -126,15 +128,28 @@ export function managedProviderEgressProfiles(
 ): HostedEgressProfile[] {
 	const profiles: HostedEgressProfile[] = [];
 	const seenMatches = new Set<string>();
-	for (const [providerId, provider] of providerProjectionEntries(hosted.providers)) {
+	for (const [providerId, provider] of managedProviderProjectionEntries(hosted)) {
 		const profile = managedProviderEgressProfileForProvider(providerId, provider);
 		if (!profile) continue;
-		const matchKey = `${profile.match.scheme}:${profile.match.host}`;
+		const secretRef = normalizeSecretRef(provider.apiKeySecretRef);
+		const matchKey = `${profile.match.scheme}:${profile.match.host}:${secretRef ?? ""}`;
 		if (seenMatches.has(matchKey)) continue;
 		seenMatches.add(matchKey);
 		profiles.push(profile);
 	}
 	return profiles;
+}
+
+function managedProviderProjectionEntries(
+	hosted: HostedRuntimeManifestProjection,
+): Array<[string, HostedProviderProjection]> {
+	const entries = providerProjectionEntries(hosted.providers);
+	const terminalTooling = recordValue(hosted.terminalTooling);
+	const codex = recordValue(terminalTooling?.codex);
+	const provider = providerProjectionValue(codex?.provider);
+	const providerId = cleanString(typeof codex?.provider_id === "string" ? codex.provider_id : null);
+	if (providerId && provider) entries.push([providerId, provider]);
+	return entries;
 }
 
 function managedProviderEgressProfileForProvider(
@@ -164,7 +179,13 @@ function managedProviderEgressProfileForProvider(
 		match: {
 			scheme: parsed.protocol.replace(/:$/, "") as "http" | "https" | "ws" | "wss",
 			host: parsed.host.toLowerCase(),
-			headers: {},
+			headers: {
+				authorization: {
+					type: "equals",
+					value: MANAGED_EGRESS_PLACEHOLDER_VALUE,
+					prefix: "Bearer ",
+				},
+			},
 			query: {},
 		},
 		rewrite: {
@@ -212,9 +233,31 @@ function providerProjectionEntries(value: unknown): Array<[string, HostedProvide
 		});
 }
 
+function providerProjectionValue(value: unknown): HostedProviderProjection | null {
+	const provider = recordValue(value);
+	if (!provider) return null;
+	return {
+		baseUrl: nullableString(provider.baseUrl),
+		apiMode: nullableString(provider.apiMode),
+		apiKeySecretRef: nullableString(provider.apiKeySecretRef),
+		managed_by: nullableString(provider.managed_by),
+		status: nullableString(provider.status),
+	};
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
 function cleanString(value: string | null | undefined): string | null {
 	const trimmed = value?.trim();
 	return trimmed || null;
+}
+
+function nullableString(value: unknown): string | null | undefined {
+	return value === null || typeof value === "string" ? value : undefined;
 }
 
 function cleanBaseUrl(value: string | null | undefined): string | null {

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -6,6 +6,7 @@ import {
 	runtimeRunSettingsSchema,
 	runtimeServiceNameSchema,
 } from "./run-config";
+import { canonicalSecretRefName } from "./secret-values";
 
 export const RUNTIME_DESIRED_STATE_SCHEMA_VERSION = "clawdi.runtimeDesiredState.v1";
 
@@ -60,6 +61,7 @@ const installSchema = z.object({
 
 const runtimeSchema = z.object({
 	enabled: z.boolean(),
+	providerMode: z.enum(["configured", "unmanaged"]).optional(),
 	updateChannel: z.string().min(1).optional(),
 	install: installSchema.optional(),
 	run: runtimeRunSettingsSchema.optional(),
@@ -183,6 +185,7 @@ const runtimeProjectionSchema = z.object({
 	aiProviders: z.record(z.string().min(1), z.unknown()).optional(),
 	mcp: z.unknown().optional(),
 	tools: z.unknown().optional(),
+	terminalTooling: z.unknown().optional(),
 });
 
 const runtimeDesiredStateShape = {
@@ -240,6 +243,50 @@ const hostedControlPlaneSchema = z
 	.strict();
 
 const hostedRuntimeRunSettingsSchema = runtimeRunSettingsSchema.strict();
+type HostedRuntimeRunSettings = z.infer<typeof hostedRuntimeRunSettingsSchema>;
+
+function validateUnmanagedRunSettings(
+	location: string,
+	settings: HostedRuntimeRunSettings | undefined,
+	ctx: z.RefinementCtx,
+): void {
+	if (!settings) return;
+	const env = settings.env ?? {};
+	const secretEnv = settings.secretEnv ?? {};
+	for (const envName of ["CLAWDI_MANAGED_OPENAI_API_KEY", "OPENAI_API_KEY"]) {
+		if (envName in env || envName in secretEnv) {
+			ctx.addIssue({
+				code: "custom",
+				message: `unmanaged ${location} must not include provider env`,
+				path: [location, envName in env ? "env" : "secretEnv", envName],
+			});
+		}
+	}
+	for (const [envName, value] of Object.entries(env)) {
+		if (value === "clawdi-egress-placeholder") {
+			ctx.addIssue({
+				code: "custom",
+				message: `unmanaged ${location} must not include provider placeholder env`,
+				path: [location, "env", envName],
+			});
+		}
+	}
+	for (const [source, values] of [
+		["env", env],
+		["secretEnv", secretEnv],
+	] as const) {
+		for (const [envName, value] of Object.entries(values)) {
+			const secretRef = canonicalSecretRefName(value);
+			if (secretRef?.startsWith("provider.")) {
+				ctx.addIssue({
+					code: "custom",
+					message: `unmanaged ${location} must not include provider secret refs`,
+					path: [location, source, envName],
+				});
+			}
+		}
+	}
+}
 
 const urlOriginSchema = z.string().refine((value) => {
 	try {
@@ -270,20 +317,25 @@ const hostedProviderIdsSchema = z
 		message: "must contain unique provider ids",
 	});
 
-const hostedRuntimeEntrySchema = z
+const hostedRuntimeEntryBaseShape = {
+	enabled: z.boolean(),
+	install: hostedRuntimeInstallSchema,
+	run: hostedRuntimeRunSettingsSchema.optional(),
+	services: z.record(runtimeServiceNameSchema, hostedRuntimeRunSettingsSchema).default({}),
+	paths: z
+		.object({
+			home: z.string().min(1),
+			workspace: z.string().min(1),
+		})
+		.strict(),
+};
+
+const hostedConfiguredRuntimeEntrySchema = z
 	.object({
-		enabled: z.boolean(),
-		install: hostedRuntimeInstallSchema,
-		run: hostedRuntimeRunSettingsSchema.optional(),
-		services: z.record(runtimeServiceNameSchema, hostedRuntimeRunSettingsSchema).default({}),
+		...hostedRuntimeEntryBaseShape,
+		providerMode: z.literal("configured"),
 		provider_ids: hostedProviderIdsSchema,
 		primary_model: hostedPrimaryModelSchema,
-		paths: z
-			.object({
-				home: z.string().min(1),
-				workspace: z.string().min(1),
-			})
-			.strict(),
 	})
 	.strict()
 	.superRefine((runtime, ctx) => {
@@ -298,6 +350,25 @@ const hostedRuntimeEntrySchema = z
 			});
 		}
 	});
+
+const hostedUnmanagedRuntimeEntrySchema = z
+	.object({
+		...hostedRuntimeEntryBaseShape,
+		providerMode: z.literal("unmanaged"),
+		provider_ids: z.array(z.string()).length(0),
+	})
+	.strict()
+	.superRefine((runtime, ctx) => {
+		validateUnmanagedRunSettings("run", runtime.run, ctx);
+		for (const [name, service] of Object.entries(runtime.services)) {
+			validateUnmanagedRunSettings(`services.${name}`, service, ctx);
+		}
+	});
+
+const hostedRuntimeEntrySchema = z.discriminatedUnion("providerMode", [
+	hostedConfiguredRuntimeEntrySchema,
+	hostedUnmanagedRuntimeEntrySchema,
+]);
 
 const hostedProviderCapabilitiesSchema = z
 	.object({
@@ -388,7 +459,51 @@ const hostedProviderSchema = z
 				path: [],
 			});
 		}
+		if (provider.managed_by === "clawdi" && provider.runtimeEnvName !== "OPENAI_API_KEY") {
+			ctx.addIssue({
+				code: "custom",
+				message: "Clawdi-managed runtime providers require OPENAI_API_KEY",
+				path: ["runtimeEnvName"],
+			});
+		}
 	});
+
+const hostedCodexToolSchema = z
+	.object({
+		enabled: z.literal(true),
+		provider_id: z.string().min(1),
+		primary_model: hostedPrimaryModelSchema,
+		provider: hostedProviderSchema,
+	})
+	.strict()
+	.superRefine((tool, ctx) => {
+		if (tool.primary_model.provider_id !== tool.provider_id) {
+			ctx.addIssue({
+				code: "custom",
+				message: "Codex tool primary model provider must match provider_id",
+				path: ["primary_model", "provider_id"],
+			});
+		}
+		if (
+			tool.provider.managed_by !== "clawdi" ||
+			tool.provider.apiMode !== "openai_responses" ||
+			canonicalSecretRefName(tool.provider.apiKeySecretRef) !== "tool.codex.apiKey" ||
+			tool.provider.runtimeEnvName !== "OPENAI_API_KEY" ||
+			tool.provider.status === "error"
+		) {
+			ctx.addIssue({
+				code: "custom",
+				message: "Codex tool requires a healthy Clawdi-managed provider secret reference",
+				path: ["provider"],
+			});
+		}
+	});
+
+const hostedTerminalToolingSchema = z
+	.object({
+		codex: hostedCodexToolSchema,
+	})
+	.strict();
 
 const hostedRuntimeBridgeSchema = z
 	.object({
@@ -465,6 +580,7 @@ export const hostedRuntimeManifestSchema = z
 		egressProfiles: egressProfileInputBundleSchema.strict().optional(),
 		mcp: z.unknown().optional(),
 		tools: z.unknown().optional(),
+		terminalTooling: hostedTerminalToolingSchema,
 		recovery: z
 			.object({
 				cacheManifest: z.boolean(),
@@ -568,7 +684,23 @@ export const hostedRuntimeManifestResponseSchema = z
 		manifest: hostedRuntimeManifestSchema,
 		secretValues: z.record(z.string().min(1), z.string()).default({}),
 	})
-	.strict();
+	.strict()
+	.superRefine((response, ctx) => {
+		const runtime = response.manifest.runtimes[response.manifest.runtime];
+		if (runtime?.providerMode !== "unmanaged") return;
+		const codexSecretRef = canonicalSecretRefName(
+			response.manifest.terminalTooling?.codex.provider.apiKeySecretRef,
+		);
+		for (const rawSecretRef of Object.keys(response.secretValues)) {
+			const secretRef = canonicalSecretRefName(rawSecretRef);
+			if (!secretRef?.startsWith("provider.") || secretRef === codexSecretRef) continue;
+			ctx.addIssue({
+				code: "custom",
+				message: "unmanaged provider mode must not include provider secret values",
+				path: ["secretValues", rawSecretRef],
+			});
+		}
+	});
 
 const hostedRuntimeManifestFixtureSchema = hostedRuntimeManifestSchema.safeExtend({
 	clawdiCli: hostedFixtureCliPayloadPolicySchema,

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -23,6 +23,7 @@ import {
 } from "./manifest";
 import {
 	hostedRuntimeManifestFixtureResponseSchema,
+	hostedRuntimeManifestResponseSchema,
 	hostedRuntimeManifestSchema,
 	manifestSchema,
 	OFFICIAL_INSTALL_ARGS,
@@ -40,9 +41,25 @@ import { GENERATED_RUNTIME_SYSTEMD_FILE_HEADER } from "./systemd-user";
 const originalEnv = { ...process.env };
 const tempRoots: string[] = [];
 const TEST_HOSTED_LOCALE = { language: "en" as const, timezone: "UTC" };
-const TEST_HOSTED_MINIMUM_CLI_VERSION = "0.12.10-beta.51";
+const TEST_HOSTED_MINIMUM_CLI_VERSION = "0.12.10-beta.53";
 const TEST_HOSTED_HOME = "/home/clawdi";
 const TEST_HOSTED_WORKSPACE = "/home/clawdi/clawdi";
+const TEST_HOSTED_CODEX_TOOLING = {
+	codex: {
+		enabled: true,
+		provider_id: "codex-managed",
+		primary_model: { provider_id: "codex-managed", model: "gpt-test" },
+		provider: {
+			kind: "openai-compatible",
+			type: "openai",
+			baseUrl: "https://provider.test/v1",
+			apiMode: "openai_responses",
+			managed_by: "clawdi",
+			runtimeEnvName: "OPENAI_API_KEY",
+			apiKeySecretRef: "tool.codex.apiKey",
+		},
+	},
+};
 
 function hostedSystemFixture(overrides: Record<string, unknown> = {}): Record<string, unknown> {
 	return {
@@ -121,7 +138,7 @@ function hostedManifestFixture(overrides: Record<string, unknown> = {}): Record<
 		controlPlane: { cloudApiUrl: "https://cloud-api.example.test" },
 		clawdiCli: {
 			source: "npm:clawdi",
-			packageSpec: "clawdi@0.12.10-beta.51",
+			packageSpec: "clawdi@0.12.10-beta.53",
 			registry: "https://registry.npmjs.org",
 		},
 		providers: {
@@ -131,12 +148,14 @@ function hostedManifestFixture(overrides: Record<string, unknown> = {}): Record<
 				error: { code: "provider_not_found", message: "fixture provider unavailable" },
 			},
 		},
+		terminalTooling: structuredClone(TEST_HOSTED_CODEX_TOOLING),
 		liveSync: { enabled: false, agents: [] },
 		recovery: { cacheManifest: true, allowOfflineBoot: true },
 		runtimes: {
 			openclaw: {
 				enabled: true,
 				install: { source: "official" },
+				providerMode: "configured",
 				provider_ids: ["default"],
 				primary_model: { provider_id: "default", model: "gpt-test" },
 				paths: { home: TEST_HOSTED_HOME, workspace: TEST_HOSTED_WORKSPACE },
@@ -156,6 +175,7 @@ function hostedRuntimeFixture(overrides: Record<string, unknown> = {}): Record<s
 	return {
 		enabled: true,
 		install: { source: "official" },
+		providerMode: "configured",
 		provider_ids: ["default"],
 		primary_model: { provider_id: "default", model: "gpt-test" },
 		...overrides,
@@ -329,6 +349,178 @@ describe("runtime manifest reconciliation invariants", () => {
 			provider_ids: ["default"],
 			primary_model: { provider_id: "default", model: "gpt-test" },
 		});
+	});
+
+	test("accepts explicit unmanaged provider mode without provider state", () => {
+		const runtime = hostedRuntimeFixture({
+			providerMode: "unmanaged",
+			provider_ids: [],
+		});
+		delete runtime.primary_model;
+		const parsed = hostedRuntimeManifestSchema.parse(
+			hostedManifestFixture({
+				providers: {},
+				runtimes: { openclaw: runtime },
+			}),
+		);
+		const normalized = hostedManifestToRuntimeManifest(parsed);
+		expect(normalized.runtimes.openclaw).toMatchObject({
+			providerMode: "unmanaged",
+			provider_ids: [],
+		});
+		expect(normalized.runtimes.openclaw.primary_model).toBeUndefined();
+		expect(normalized.projection?.providers).toEqual({});
+	});
+
+	test.each([
+		[
+			"unmanaged provider ids",
+			hostedRuntimeFixture({ providerMode: "unmanaged", provider_ids: ["default"] }),
+		],
+		[
+			"unmanaged primary model",
+			hostedRuntimeFixture({ providerMode: "unmanaged", provider_ids: [] }),
+		],
+		[
+			"configured empty provider ids",
+			hostedRuntimeFixture({ providerMode: "configured", provider_ids: [] }),
+		],
+		[
+			"missing provider mode",
+			(() => {
+				const runtime = hostedRuntimeFixture();
+				delete runtime.providerMode;
+				return runtime;
+			})(),
+		],
+	])("rejects mixed provider contract: %s", (_name, runtime) => {
+		expect(
+			hostedRuntimeManifestSchema.safeParse(
+				hostedManifestFixture({ runtimes: { openclaw: runtime } }),
+			).success,
+		).toBe(false);
+	});
+
+	test.each([
+		["run provider env", { run: { env: { OPENAI_API_KEY: "configured" } } }],
+		["run placeholder", { run: { env: { TOKEN: "clawdi-egress-placeholder" } } }],
+		[
+			"run provider secret ref",
+			{ run: { secretEnv: { OPENAI_API_KEY: "provider.clawdi-managed-v2.apiKey" } } },
+		],
+		[
+			"service provider secret ref",
+			{ services: { helper: { secretEnv: { TOKEN: "secret://provider.runtime.apiKey" } } } },
+		],
+	])("rejects unmanaged runtime %s", (_name, overrides) => {
+		const runtime = hostedRuntimeFixture({
+			providerMode: "unmanaged",
+			provider_ids: [],
+			primary_model: undefined,
+			...overrides,
+		});
+		expect(
+			hostedRuntimeManifestSchema.safeParse(
+				hostedManifestFixture({ providers: {}, runtimes: { openclaw: runtime } }),
+			).success,
+		).toBe(false);
+	});
+
+	test("allows an explicit user Vault-backed service secret ref in unmanaged mode", () => {
+		const runtime = hostedRuntimeFixture({
+			providerMode: "unmanaged",
+			provider_ids: [],
+			services: { helper: { secretEnv: { TOKEN: "clawdi://default/key" } } },
+		});
+		delete runtime.primary_model;
+
+		expect(
+			hostedRuntimeManifestSchema.safeParse(
+				hostedManifestFixture({ providers: {}, runtimes: { openclaw: runtime } }),
+			).success,
+		).toBe(true);
+	});
+
+	test("rejects terminal Codex without its fixed process env contract", () => {
+		const terminalTooling = structuredClone(TEST_HOSTED_CODEX_TOOLING);
+		terminalTooling.codex.provider.runtimeEnvName = "CLAWDI_MANAGED_OPENAI_API_KEY";
+		const manifest = hostedManifestFixture({ terminalTooling });
+		expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(false);
+	});
+
+	test("rejects the legacy managed runtime env-name rewrite contract", () => {
+		const provider = {
+			...TEST_HOSTED_CODEX_TOOLING.codex.provider,
+			runtimeEnvName: "CLAWDI_MANAGED_OPENAI_API_KEY",
+			apiKeySecretRef: "provider.default.apiKey",
+		};
+		const manifest = hostedManifestFixture({ providers: { default: provider } });
+
+		expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(false);
+	});
+
+	test("rejects terminal Codex with a runtime-provider secret ref", () => {
+		const terminalTooling = structuredClone(TEST_HOSTED_CODEX_TOOLING);
+		terminalTooling.codex.provider.apiKeySecretRef = "provider.codex-managed.apiKey";
+		const manifest = hostedManifestFixture({ terminalTooling });
+		expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(false);
+	});
+
+	test.each([
+		"openai_chat",
+		"anthropic_messages",
+		"google_generate_content",
+	])("rejects terminal Codex without the fixed responses API mode (%s)", (apiMode) => {
+		const terminalTooling = structuredClone(TEST_HOSTED_CODEX_TOOLING);
+		terminalTooling.codex.provider.apiMode = apiMode;
+		const manifest = hostedManifestFixture({ terminalTooling });
+		expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(false);
+	});
+
+	test("rejects terminal Codex without an API mode", () => {
+		const { apiMode: _apiMode, ...provider } = TEST_HOSTED_CODEX_TOOLING.codex.provider;
+		const terminalTooling = {
+			codex: { ...TEST_HOSTED_CODEX_TOOLING.codex, provider },
+		};
+		const manifest = hostedManifestFixture({ terminalTooling });
+		expect(hostedRuntimeManifestSchema.safeParse(manifest).success).toBe(false);
+	});
+
+	test.each([
+		"provider.stale.apiKey",
+		"secret://provider.stale.apiKey",
+	])("rejects provider secret value %s in unmanaged mode", (secretRef) => {
+		const runtime = hostedRuntimeFixture({
+			providerMode: "unmanaged",
+			provider_ids: [],
+		});
+		delete runtime.primary_model;
+		const manifest = hostedManifestFixture({
+			providers: {},
+			runtimes: { openclaw: runtime },
+		});
+		expect(
+			hostedRuntimeManifestResponseSchema.safeParse({
+				manifest,
+				secretValues: { [secretRef]: "secret" },
+			}).success,
+		).toBe(false);
+	});
+
+	test("accepts either Codex tool secret-ref alias in unmanaged mode", () => {
+		const runtime = hostedRuntimeFixture({ providerMode: "unmanaged", provider_ids: [] });
+		delete runtime.primary_model;
+		const manifest = hostedManifestFixture({ providers: {}, runtimes: { openclaw: runtime } });
+		const codexRef = TEST_HOSTED_CODEX_TOOLING.codex.provider.apiKeySecretRef;
+		expect(codexRef).toBeDefined();
+		for (const secretRef of [codexRef, `secret://${codexRef}`]) {
+			expect(
+				hostedRuntimeManifestResponseSchema.safeParse({
+					manifest,
+					secretValues: { [secretRef]: "secret" },
+				}).success,
+			).toBe(true);
+		}
 	});
 
 	test.each([
@@ -617,6 +809,7 @@ describe("runtime manifest reconciliation invariants", () => {
 					openclaw: {
 						enabled: true,
 						install: { source: "official" },
+						providerMode: "configured",
 						provider_ids: ["default"],
 						primary_model: { provider_id: "default", model: "gpt-test" },
 						paths: { home: paths.userHome, workspace },
@@ -718,19 +911,19 @@ describe("runtime manifest reconciliation invariants", () => {
 			name: "wrong source",
 			clawdiCli: {
 				source: "npm:other",
-				packageSpec: "clawdi@0.12.10-beta.51",
+				packageSpec: "clawdi@0.12.10-beta.53",
 				registry: "https://registry.npmjs.org",
 			},
 		},
 		{
 			name: "missing registry",
-			clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@0.12.10-beta.51" },
+			clawdiCli: { source: "npm:clawdi", packageSpec: "clawdi@0.12.10-beta.53" },
 		},
 		{
 			name: "non-official registry",
 			clawdiCli: {
 				source: "npm:clawdi",
-				packageSpec: "clawdi@0.12.10-beta.51",
+				packageSpec: "clawdi@0.12.10-beta.53",
 				registry: "https://registry.example.test",
 			},
 		},
@@ -738,7 +931,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			name: "dead managed flags",
 			clawdiCli: {
 				source: "npm:clawdi",
-				packageSpec: "clawdi@0.12.10-beta.51",
+				packageSpec: "clawdi@0.12.10-beta.53",
 				registry: "https://registry.npmjs.org",
 				managedConfig: true,
 				userEditableConfig: false,
@@ -767,7 +960,7 @@ describe("runtime manifest reconciliation invariants", () => {
 	});
 
 	test.each([
-		"clawdi@0.12.10-beta.51",
+		"clawdi@0.12.10-beta.53",
 		"clawdi@1.2.3-rc-1.2",
 		"clawdi@1.2.3",
 	])("accepts exact hosted CLI package spec %s", (packageSpec) => {
@@ -823,7 +1016,7 @@ describe("runtime manifest reconciliation invariants", () => {
 		"clawdi@01.2.3",
 		"./clawdi.tgz",
 		"/tmp/clawdi.tgz",
-		"/usr/local/share/clawdi/bootstrap/clawdi-0.12.10-beta.51.tgz",
+		"/usr/local/share/clawdi/bootstrap/clawdi-0.12.10-beta.53.tgz",
 		"/usr/local/share/clawdi/bootstrap/../clawdi.tgz",
 		"/usr/local/share/clawdi/bootstrap/nested/clawdi.tgz",
 		"/usr/local/share/clawdi/bootstrap/clawdi..tgz",
@@ -863,12 +1056,13 @@ describe("runtime manifest reconciliation invariants", () => {
 				},
 				clawdiCli: {
 					source: "npm:clawdi",
-					packageSpec: "clawdi@0.12.10-beta.51",
+					packageSpec: "clawdi@0.12.10-beta.53",
 					registry: "https://registry.npmjs.org",
 				},
 				runtimes: {
 					openclaw: {
 						enabled: true,
+						providerMode: "configured",
 						provider_ids: ["default"],
 						primary_model: { provider_id: "default", model: "gpt-test" },
 						install: { source: "official" },
@@ -904,6 +1098,7 @@ describe("runtime manifest reconciliation invariants", () => {
 						apiKeySecretRef: "secret://providers/default/api-key",
 					},
 				},
+				terminalTooling: TEST_HOSTED_CODEX_TOOLING,
 				liveSync: {
 					enabled: true,
 					agents: [{ agentType: "openclaw", environmentId: "env_normalize" }],
@@ -999,7 +1194,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				},
 				clawdiCli: {
 					source: "npm:clawdi",
-					packageSpec: "clawdi@0.12.10-beta.51",
+					packageSpec: "clawdi@0.12.10-beta.53",
 					registry: "https://registry.npmjs.org",
 				},
 				providers: {
@@ -1009,6 +1204,7 @@ describe("runtime manifest reconciliation invariants", () => {
 						error: { code: "provider_not_found", message: "provider is missing" },
 					},
 				},
+				terminalTooling: TEST_HOSTED_CODEX_TOOLING,
 				liveSync: { enabled: false, agents: [] },
 				recovery: { cacheManifest: true, allowOfflineBoot: true },
 				runtimes: {
@@ -1083,7 +1279,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			},
 			clawdiCli: {
 				source: "npm:clawdi",
-				packageSpec: "clawdi@0.12.10-beta.51",
+				packageSpec: "clawdi@0.12.10-beta.53",
 				registry: "https://registry.npmjs.org",
 			},
 			runtimes: {
@@ -1122,7 +1318,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				},
 				clawdiCli: {
 					source: "npm:clawdi",
-					packageSpec: "clawdi@0.12.10-beta.51",
+					packageSpec: "clawdi@0.12.10-beta.53",
 					registry: "https://registry.npmjs.org",
 				},
 				providers: {
@@ -1132,12 +1328,14 @@ describe("runtime manifest reconciliation invariants", () => {
 						error: { code: "provider_not_found", message: "provider is missing" },
 					},
 				},
+				terminalTooling: TEST_HOSTED_CODEX_TOOLING,
 				liveSync: { enabled: false, agents: [] },
 				recovery: { cacheManifest: true, allowOfflineBoot: true },
 				runtimes: {
 					openclaw: {
 						enabled: true,
 						install: { source: "official" },
+						providerMode: "configured",
 						provider_ids: ["default"],
 						primary_model: { provider_id: "default", model: "gpt-test" },
 						paths: { home: TEST_HOSTED_HOME, workspace: TEST_HOSTED_WORKSPACE },
@@ -1146,6 +1344,7 @@ describe("runtime manifest reconciliation invariants", () => {
 					hermes: {
 						enabled: true,
 						install: { source: "official" },
+						providerMode: "configured",
 						provider_ids: ["default"],
 						primary_model: { provider_id: "default", model: "gpt-test" },
 						paths: { home: TEST_HOSTED_HOME, workspace: TEST_HOSTED_WORKSPACE },
@@ -1240,6 +1439,8 @@ describe("runtime manifest reconciliation invariants", () => {
 				openclaw: {
 					enabled: true,
 					run: runSettings("openclaw", ["gateway", "run"]),
+					provider_ids: ["default"],
+					primary_model: { provider_id: "default", model: "gpt-test" },
 					services: {},
 				},
 			},
@@ -1295,6 +1496,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				openclaw: {
 					enabled: true,
 					run: runSettings("openclaw", ["gateway", "run"]),
+					provider_ids: ["default"],
 					primary_model: { provider_id: "default", model: "gpt-live" },
 					services: {},
 				},
@@ -1322,6 +1524,71 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(projection?.catalog.providers[0]?.models).toEqual([
 			{ id: "gpt-live", api_mode: "openai_chat" },
 		]);
+	});
+
+	test.each([
+		"openclaw",
+		"default",
+	])("does not infer strict hosted provider bindings from the %s provider key", (providerKey) => {
+		const paths = tempRuntimePaths();
+		const manifest = baseManifest(
+			paths,
+			{
+				openclaw: {
+					enabled: true,
+					run: runSettings("openclaw", ["gateway", "run"]),
+					provider_ids: ["default"],
+					services: {},
+				},
+			},
+			{
+				projection: {
+					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					providers: {
+						[providerKey]: {
+							type: "custom_openai_compatible",
+							baseUrl: "https://api.example.test/v1",
+							model: "gpt-inferred",
+							models: [{ id: "gpt-inferred" }],
+							apiMode: "openai_chat",
+						},
+					},
+				},
+			},
+		);
+
+		expect(hostedAiProviderCatalog(manifest, "openclaw")).toBeNull();
+	});
+
+	test("does not infer a strict hosted primary model from the first provider", () => {
+		const paths = tempRuntimePaths();
+		const manifest = baseManifest(
+			paths,
+			{
+				openclaw: {
+					enabled: true,
+					run: runSettings("openclaw", ["gateway", "run"]),
+					provider_ids: ["default"],
+					services: {},
+				},
+			},
+			{
+				projection: {
+					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					providers: {
+						default: {
+							type: "custom_openai_compatible",
+							baseUrl: "https://api.example.test/v1",
+							model: "gpt-inferred",
+							models: [{ id: "gpt-inferred" }],
+							apiMode: "openai_chat",
+						},
+					},
+				},
+			},
+		);
+
+		expect(hostedAiProviderCatalog(manifest, "openclaw")).toBeNull();
 	});
 
 	test("preserves hosted provider model alias and cost metadata", () => {
@@ -1389,6 +1656,7 @@ describe("runtime manifest reconciliation invariants", () => {
 				openclaw: {
 					enabled: true,
 					run: runSettings("openclaw", ["gateway", "run"]),
+					provider_ids: ["default"],
 					services: {},
 				},
 			},

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -14,6 +14,7 @@ import {
 	hostedFixtureCliPayloadPolicySchema,
 	hostedRuntimeManifestFixtureResponseSchema,
 	hostedRuntimeManifestResponseSchema,
+	hostedRuntimeManifestSchema,
 	manifestSchema,
 	OFFICIAL_INSTALL_ARGS,
 	OFFICIAL_INSTALL_URLS,
@@ -22,7 +23,7 @@ import {
 } from "./manifest-contract";
 import type { RuntimePaths } from "./paths";
 import { isSupportedRuntimeName, type RuntimeRunSettings } from "./run-config";
-import { envSecretRefName, normalizeSecretValues } from "./secret-values";
+import { canonicalSecretRefName, envSecretRefName, normalizeSecretValues } from "./secret-values";
 
 export interface RuntimeManifestLoad {
 	manifest: RuntimeManifest;
@@ -60,11 +61,27 @@ const hostedRuntimeBundleV2Schema = z
 	.object({
 		schemaVersion: z.literal("clawdi.hosted-runtime.bundle.v2"),
 		sourceRevision: z.string().regex(/^[a-f0-9]{64}$/),
-		manifest: hostedRuntimeManifestResponseSchema.shape.manifest,
+		manifest: hostedRuntimeManifestSchema,
 		channelBindings: z.array(runtimeBundleChannelBindingSchema),
 		secretValues: z.record(z.string(), z.string()),
 	})
-	.strict();
+	.strict()
+	.superRefine((bundle, ctx) => {
+		const runtime = bundle.manifest.runtimes[bundle.manifest.runtime];
+		if (runtime?.providerMode !== "unmanaged") return;
+		const codexSecretRef = canonicalSecretRefName(
+			bundle.manifest.terminalTooling?.codex.provider.apiKeySecretRef,
+		);
+		for (const rawSecretRef of Object.keys(bundle.secretValues)) {
+			const secretRef = canonicalSecretRefName(rawSecretRef);
+			if (!secretRef?.startsWith("provider.") || secretRef === codexSecretRef) continue;
+			ctx.addIssue({
+				code: "custom",
+				message: "unmanaged provider mode must not include provider secret values",
+				path: ["secretValues", rawSecretRef],
+			});
+		}
+	});
 
 export function normalizeHostedRuntimeBundleV2(value: unknown): RuntimeManifestLoad {
 	const bundle = hostedRuntimeBundleV2Schema.parse(value);
@@ -474,6 +491,7 @@ export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): 
 		runtimes: {
 			[selectedRuntime]: {
 				enabled: runtime.enabled,
+				providerMode: runtime.providerMode,
 				install: {
 					authority: "official" as const,
 					method: "official-installer" as const,
@@ -498,6 +516,7 @@ export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): 
 			providers: hosted.providers,
 			...(hosted.mcp === undefined ? {} : { mcp: hosted.mcp }),
 			...(hosted.tools === undefined ? {} : { tools: hosted.tools }),
+			...(hosted.terminalTooling === undefined ? {} : { terminalTooling: hosted.terminalTooling }),
 		},
 		liveSync: hosted.liveSync,
 		egressProfiles: hostedManifestEgressProfiles(hosted),
@@ -508,14 +527,13 @@ export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): 
 	};
 }
 
-function hostedRuntimeProviderBinding(runtime: HostedRuntimeManifest["runtimes"][string]): {
-	provider_ids: string[];
-	primary_model: { provider_id: string; model: string };
-} {
-	return {
-		provider_ids: runtime.provider_ids,
-		primary_model: runtime.primary_model,
-	};
+function hostedRuntimeProviderBinding(
+	runtime: HostedRuntimeManifest["runtimes"][string],
+):
+	| { provider_ids: string[]; primary_model: { provider_id: string; model: string } }
+	| { provider_ids: [] } {
+	if (runtime.providerMode === "unmanaged") return { provider_ids: [] };
+	return { provider_ids: runtime.provider_ids, primary_model: runtime.primary_model };
 }
 
 function hostedRuntimeRunSettings(

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1356,7 +1356,7 @@ export function hostedAiProviderCatalog(
 	if (!providers || Object.keys(providers).length === 0) return null;
 	const rawEntries = hostedProviderEntries(providers, runtimeName, manifest);
 	const primaryModel =
-		options.primaryModelOverride ?? hostedRuntimePrimaryModel(manifest, runtimeName, rawEntries);
+		options.primaryModelOverride ?? hostedRuntimePrimaryModel(manifest, runtimeName);
 	if (!primaryModel) return null;
 	const entries = rawEntries
 		.map(([id, raw]) => {
@@ -1413,40 +1413,18 @@ function hostedProviderEntries(
 	if (!runtimeName) {
 		return Object.entries(providers).sort(([left], [right]) => left.localeCompare(right));
 	}
-	const runtime = manifest?.runtimes?.[runtimeName];
-	if (runtime) {
-		const providerIds = runtime.provider_ids?.filter((id) => Object.hasOwn(providers, id));
-		if (providerIds && providerIds.length > 0) {
-			return providerIds.map((providerId) => [providerId, providers[providerId]]);
-		}
-	}
-	if (Object.hasOwn(providers, runtimeName)) {
-		return [[runtimeName, providers[runtimeName]]];
-	}
-	if (Object.hasOwn(providers, "default")) {
-		return [["default", providers.default]];
-	}
-	return [];
+	const providerIds = manifest?.runtimes?.[runtimeName]?.provider_ids ?? [];
+	return providerIds
+		.filter((providerId) => Object.hasOwn(providers, providerId))
+		.map((providerId) => [providerId, providers[providerId]]);
 }
 
 function hostedRuntimePrimaryModel(
 	manifest: RuntimeManifest,
 	runtimeName: string | undefined,
-	rawEntries: Array<[string, unknown]>,
 ): AgentPrimaryModel | null {
 	const runtime = runtimeName ? manifest.runtimes[runtimeName] : undefined;
-	const primary = runtime?.primary_model;
-	if (primary) return primary;
-	for (const [providerId, raw] of rawEntries) {
-		const provider = recordValue(raw);
-		const model = provider ? stringValue(provider.model) : null;
-		if (model) return { provider_id: providerId, model };
-	}
-	const firstProvider = rawEntries[0];
-	if (!firstProvider) return null;
-	const provider = recordValue(firstProvider[1]);
-	const model = hostedProviderModels(provider ?? {}, null)[0]?.id;
-	return model ? { provider_id: firstProvider[0], model } : null;
+	return runtime?.primary_model ?? null;
 }
 
 function hostedProviderModels(
@@ -1513,8 +1491,8 @@ function managedGatewayPrimaryModelTarget(
 	if (!providers) return null;
 	const rawEntries = hostedProviderEntries(providers, runtimeName, manifest);
 	if (rawEntries.length === 0) return null;
-	const currentPrimary = hostedRuntimePrimaryModel(manifest, runtimeName, rawEntries);
-	const selectedProviderId = currentPrimary?.provider_id ?? rawEntries[0]?.[0] ?? null;
+	const currentPrimary = hostedRuntimePrimaryModel(manifest, runtimeName);
+	const selectedProviderId = currentPrimary?.provider_id ?? null;
 	if (!selectedProviderId) return null;
 	const selectedProvider = rawEntries.find(
 		([providerId]) => providerId === selectedProviderId,
@@ -1714,17 +1692,9 @@ function hostedProviderRequiresApiKey(input: Record<string, unknown>): boolean {
 	return type === "api_key" || type === "secret_ref";
 }
 
-const HOSTED_PROVIDER_FORBIDDEN_AGENT_ENV_NAMES = new Set(["CLAWDI_MANAGED_OPENAI_API_KEY"]);
-
 function hostedProviderRuntimeEnvName(providerId: string, input: Record<string, unknown>): string {
 	const raw = typeof input.runtimeEnvName === "string" ? input.runtimeEnvName : null;
-	if (raw && isEnvKey(raw) && !HOSTED_PROVIDER_FORBIDDEN_AGENT_ENV_NAMES.has(raw)) return raw;
-	if (
-		HOSTED_PROVIDER_FORBIDDEN_AGENT_ENV_NAMES.has(raw ?? "") &&
-		isOpenAiCompatibleMode(hostedProviderApiMode(input))
-	) {
-		return "OPENAI_API_KEY";
-	}
+	if (raw && isEnvKey(raw)) return raw;
 	return `CLAWDI_PROVIDER_${providerId.toUpperCase().replace(/[^A-Z0-9]/g, "_")}_API_KEY`;
 }
 
@@ -1983,9 +1953,10 @@ interface HostedAiProviderProjectionResult {
 }
 
 const CODEX_MANAGED_PROVIDER_ID = "clawdi-managed";
-const CODEX_MANAGED_PROVIDER_STATE_FILE = "clawdi-managed-provider.json";
+const CODEX_MANAGED_PROVIDER_CONFIG_FILE = "config.toml";
 const CODEX_MANAGED_ENV_KEY = "OPENAI_API_KEY";
-const CODEX_NPM_PACKAGE_SPEC = "@openai/codex@latest";
+const CODEX_NPM_PACKAGE_VERSION = "0.142.4";
+const CODEX_NPM_PACKAGE_SPEC = `@openai/codex@${CODEX_NPM_PACKAGE_VERSION}`;
 
 interface HostedCodexManagedProvider {
 	providerId: string;
@@ -2098,7 +2069,14 @@ function applyHostedAiProviderProjection(
 			primaryModelOverride: managedPrimaryModelOverrides[name],
 		}),
 	);
+	assertHostedProviderProjectionMode(name, manifest, projectionInput);
 	const home = projectionSystemHome(manifest) ?? process.env.HOME ?? "";
+	if (manifest.runtimes[name]?.providerMode === "configured" && !projectionInput) {
+		if (name === "openclaw") {
+			applyOpenClawGatewayHostedProjection(observation.commandPath, manifest, home, workspaceRoot);
+		}
+		return { path: null, revision: null, providerIds: [...previousProviderIds] };
+	}
 	if (name === "hermes") {
 		return applyHostedHermesAiProviderProjection(
 			observation,
@@ -2148,71 +2126,62 @@ function applyHostedCodexManagedProviderProjection(
 
 	const codexHome = hostedCodexHome(home);
 	makeRuntimeUserPrivateDir(codexHome);
-	const configPath = join(codexHome, "config.toml");
-	const statePath = join(codexHome, CODEX_MANAGED_PROVIDER_STATE_FILE);
+	const configPath = join(codexHome, CODEX_MANAGED_PROVIDER_CONFIG_FILE);
 	const configContent = hostedCodexManagedConfigToml(provider);
-	const statePayload = hostedCodexManagedProviderState(provider);
 	writePrivateFileAtomic(configPath, configContent, { mode: 0o600, dirMode: 0o700 });
-	writePrivateFileAtomic(statePath, `${JSON.stringify(statePayload, null, 2)}\n`, {
-		mode: 0o600,
-		dirMode: 0o700,
-	});
 	makeRuntimeUserOwned(configPath);
-	makeRuntimeUserOwned(statePath);
 	makeRuntimeUserPrivateDir(codexHome);
 
 	return {
 		path: configPath,
 		providerIds: [CODEX_MANAGED_PROVIDER_ID],
 		revision: revisionHash({
-			codexManagedProviderProjection: "config.toml",
+			codexManagedProviderProjection: CODEX_MANAGED_PROVIDER_CONFIG_FILE,
 			configContent,
 			codexCli,
-			statePayload,
 		}),
 	};
 }
 
-function hostedCodexManagedProvider(manifest: RuntimeManifest): HostedCodexManagedProvider | null {
-	const providers = recordValue(manifest.projection?.providers);
-	if (!providers) return null;
-	const entries: Array<{
-		priority: number;
-		providerId: string;
-		provider: HostedCodexManagedProvider;
-	}> = [];
-	for (const [providerId, raw] of Object.entries(providers)) {
-		const provider = recordValue(raw);
-		if (!provider) continue;
-		if (provider.managed_by === "user") continue;
-		const runtimeEnvName = stringValue(provider.runtimeEnvName);
-		if (runtimeEnvName !== CODEX_MANAGED_ENV_KEY) continue;
-		const baseUrl = stringValue(provider.baseUrl);
-		if (!baseUrl?.trim()) continue;
-		entries.push({
-			priority: hostedCodexManagedProviderPriority(providerId),
-			providerId,
-			provider: {
-				providerId,
-				baseUrl: baseUrl.trim(),
-				model: stringValue(provider.model),
-				apiMode: stringValue(provider.apiMode),
-				apiKeySecretRef: stringValue(provider.apiKeySecretRef),
-			},
-		});
+function assertHostedProviderProjectionMode(
+	runtimeName: string,
+	manifest: RuntimeManifest,
+	projectionInput: HostedAiProviderProjectionInput | null,
+): void {
+	const providerMode = manifest.runtimes[runtimeName]?.providerMode;
+	if (providerMode === "unmanaged" && projectionInput) {
+		throw new Error(`runtime ${runtimeName} unmanaged provider mode has a provider projection`);
 	}
-	if (entries.length === 0) return null;
-	entries.sort(
-		(left, right) =>
-			left.priority - right.priority || left.providerId.localeCompare(right.providerId),
-	);
-	return entries[0]?.provider ?? null;
 }
 
-function hostedCodexManagedProviderPriority(providerId: string): number {
-	if (providerId === "openclaw") return 0;
-	if (providerId === "hermes") return 1;
-	return 2;
+function hostedCodexManagedProvider(manifest: RuntimeManifest): HostedCodexManagedProvider | null {
+	const terminalTooling = recordValue(manifest.projection?.terminalTooling);
+	const codex = recordValue(terminalTooling?.codex);
+	const provider = recordValue(codex?.provider);
+	const primaryModel = recordValue(codex?.primary_model);
+	const providerId = stringValue(codex?.provider_id);
+	const baseUrl = stringValue(provider?.baseUrl);
+	const apiMode = stringValue(provider?.apiMode);
+	if (
+		codex?.enabled !== true ||
+		!provider ||
+		provider.managed_by !== "clawdi" ||
+		apiMode !== "openai_responses" ||
+		stringValue(provider.runtimeEnvName) !== CODEX_MANAGED_ENV_KEY ||
+		normalizeSecretRef(stringValue(provider.apiKeySecretRef)) !== "secret://tool.codex.apiKey" ||
+		!providerId ||
+		stringValue(primaryModel?.provider_id) !== providerId ||
+		!baseUrl
+	) {
+		return null;
+	}
+	return {
+		providerId,
+		baseUrl,
+		model: stringValue(primaryModel?.model),
+		apiMode,
+		apiKeySecretRef: stringValue(provider.apiKeySecretRef),
+	};
 }
 
 function hostedCodexHome(home: string): string {
@@ -2240,31 +2209,21 @@ function hostedCodexManagedConfigToml(provider: HostedCodexManagedProvider): str
 	return lines.join("\n");
 }
 
-function hostedCodexManagedProviderState(
-	provider: HostedCodexManagedProvider,
-): Record<string, unknown> {
-	return {
-		schemaVersion: "clawdi.hostedCodexManagedProvider.v1",
-		managedBy: "clawdi hosted runtime",
-		provider: {
-			baseUrl: provider.baseUrl,
-			model: provider.model,
-			apiMode: provider.apiMode,
-			runtimeEnvName: CODEX_MANAGED_ENV_KEY,
-			apiKeySecretRef: provider.apiKeySecretRef,
-		},
-	};
-}
-
 function ensureHostedCodexCli(paths: RuntimePaths): Record<string, string> | null {
 	if (process.env.CLAWDI_CODEX_INSTALL_DISABLED === "1") return null;
-	const packageSpec = hostedCodexPackageSpec();
 	const npmPrefix = join(paths.serviceStateRoot, "codex", "npm");
 	const npmCache = join(paths.serviceStateRoot, "codex", "npm-cache");
 	const realBin = join(npmPrefix, "bin", "codex");
 	const commandPath = join(runtimeManagedBinDir(paths), "codex");
-	if (!executableExists(realBin)) {
-		installHostedCodexCli(packageSpec, npmPrefix, npmCache);
+	let installedVersion = hostedCodexInstalledVersion(npmPrefix);
+	if (installedVersion !== CODEX_NPM_PACKAGE_VERSION || !executableExists(realBin)) {
+		installHostedCodexCli(CODEX_NPM_PACKAGE_SPEC, npmPrefix, npmCache);
+		installedVersion = hostedCodexInstalledVersion(npmPrefix);
+	}
+	if (installedVersion !== CODEX_NPM_PACKAGE_VERSION) {
+		throw new Error(
+			`Codex npm install produced version ${installedVersion ?? "unknown"}; expected ${CODEX_NPM_PACKAGE_VERSION}`,
+		);
 	}
 	if (!executableExists(realBin)) {
 		throw new Error(`Codex npm install did not create ${realBin}`);
@@ -2274,17 +2233,28 @@ function ensureHostedCodexCli(paths: RuntimePaths): Record<string, string> | nul
 		commandPath,
 		npmCache,
 		npmPrefix,
-		packageSpec,
+		packageSpec: CODEX_NPM_PACKAGE_SPEC,
+		packageVersion: installedVersion,
 		realBin,
 	};
 }
 
-function hostedCodexPackageSpec(): string {
-	const packageSpec = process.env.CLAWDI_CODEX_PACKAGE_SPEC?.trim() || CODEX_NPM_PACKAGE_SPEC;
-	if (packageSpec === "@openai/codex" || packageSpec.startsWith("@openai/codex@")) {
-		return packageSpec;
+function hostedCodexInstalledVersion(npmPrefix: string): string | null {
+	const packageJsonPath = join(
+		npmPrefix,
+		"lib",
+		"node_modules",
+		"@openai",
+		"codex",
+		"package.json",
+	);
+	try {
+		const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as unknown;
+		if (!parsed || typeof parsed !== "object" || !("version" in parsed)) return null;
+		return typeof parsed.version === "string" ? parsed.version : null;
+	} catch {
+		return null;
 	}
-	throw new Error("CLAWDI_CODEX_PACKAGE_SPEC must be @openai/codex or @openai/codex@...");
 }
 
 function installHostedCodexCli(packageSpec: string, npmPrefix: string, npmCache: string): void {
@@ -2337,10 +2307,19 @@ function installHostedCodexCli(packageSpec: string, npmPrefix: string, npmCache:
 function writeHostedCodexCommandShim(commandPath: string, realBin: string): void {
 	const binDir = dirname(commandPath);
 	makeRootReadableDir(binDir);
-	writePrivateFileAtomic(commandPath, `#!/usr/bin/env sh\nexec ${shellQuote(realBin)} "$@"\n`, {
-		mode: 0o755,
-		dirMode: 0o755,
-	});
+	writePrivateFileAtomic(
+		commandPath,
+		[
+			"#!/usr/bin/env sh",
+			`export ${CODEX_MANAGED_ENV_KEY}=${shellQuote(MANAGED_EGRESS_PLACEHOLDER_VALUE)}`,
+			`exec ${shellQuote(realBin)} "$@"`,
+			"",
+		].join("\n"),
+		{
+			mode: 0o755,
+			dirMode: 0o755,
+		},
+	);
 	makeRootOwned(commandPath);
 }
 
@@ -2357,7 +2336,7 @@ function applyHostedHermesAiProviderProjection(
 ): HostedAiProviderProjectionResult {
 	const configPath = join(home, ".hermes", "config.yaml");
 	if (!projectionInput) {
-		removeHermesModelProviderPlugin(home);
+		if (previousProviderIds.length > 0) removeHermesModelProviderPlugin(home);
 		const deletedProviderIds = existingHermesProviderIds(
 			configPath,
 			staleProviderIds(new Set(previousProviderIds), new Set()),
@@ -5129,8 +5108,7 @@ export function runtimeLiveSnapshotPaths(
 		join(home, ".hermes", "config.yaml"),
 		join(home, ".hermes", "SOUL.md"),
 		hermesModelProviderPluginDir(home),
-		join(hostedCodexHome(home), "config.toml"),
-		join(hostedCodexHome(home), CODEX_MANAGED_PROVIDER_STATE_FILE),
+		join(hostedCodexHome(home), CODEX_MANAGED_PROVIDER_CONFIG_FILE),
 	]);
 	for (const agent of MANAGED_LIVE_SYNC_AGENTS) {
 		result.add(join(paths.localEnvironments, `${agent}.json`));
@@ -5329,7 +5307,6 @@ function validateRuntimeProjectionPlan(input: {
 	const codexProvider = hostedCodexManagedProvider(manifest);
 	if (codexProvider) {
 		hostedCodexManagedConfigToml(codexProvider);
-		hostedCodexManagedProviderState(codexProvider);
 	}
 
 	for (const [name, runtime] of Object.entries(manifest.runtimes).sort(([a], [b]) =>
@@ -5363,6 +5340,9 @@ function validateRuntimeProjectionPlan(input: {
 				primaryModelOverride: managedPrimaryModelOverrides?.[name],
 			}),
 		);
+		assertHostedProviderProjectionMode(name, manifest, projectionInput);
+		const configuredProjectionUnavailable =
+			manifest.runtimes[name]?.providerMode === "configured" && !projectionInput;
 		const projectionRequiresInstalledModelProbe =
 			projectionInput?.catalog.providers.some((provider) => provider.managed_by === "clawdi") &&
 			managedPrimaryModelOverrides === undefined;
@@ -5382,7 +5362,7 @@ function validateRuntimeProjectionPlan(input: {
 						openClawProviderIdsFromPatch(file.content),
 					),
 				);
-			} else {
+			} else if (!configuredProjectionUnavailable) {
 				JSON.stringify(openClawProviderDeletePatch(previousProjectedProviderIds.openclaw ?? []));
 			}
 			JSON.stringify(openClawGatewayHostedPatch(manifest));
@@ -5402,7 +5382,10 @@ function validateRuntimeProjectionPlan(input: {
 					projectionInput.primaryModel,
 				);
 				hermesConfig = renderHermesConfig(hermesConfig, yamlFile.content);
-			} else if ((previousProjectedProviderIds.hermes ?? []).length > 0) {
+			} else if (
+				!configuredProjectionUnavailable &&
+				(previousProjectedProviderIds.hermes ?? []).length > 0
+			) {
 				hermesConfig = renderHermesConfig(
 					hermesConfig,
 					hermesProviderDeletePatch(previousProjectedProviderIds.hermes ?? []),
@@ -5550,7 +5533,10 @@ export function convergeRuntimeManifest(
 	// generation-owned live configuration and is created only after Plan succeeds.
 	mkdirSync(paths.runRoot, { recursive: true });
 	let codexCli: Record<string, string> | null = null;
-	if (hostedCodexManagedProvider(manifest)) {
+	if (
+		hostedCodexManagedProvider(manifest) ||
+		manifest.projection?.sourceSchemaVersion === "clawdi.hosted-runtime.manifest.v1"
+	) {
 		try {
 			codexCli = ensureHostedCodexCli(paths);
 		} catch (error) {
@@ -5943,8 +5929,12 @@ export function convergeRuntimeManifest(
 		}
 
 		const mcpProjection = join(paths.projectionRoot, "clawdi-mcp.json");
-		writeJsonFile(mcpProjection, projectionPayload("clawdi-mcp", manifest));
-		projections.push(mcpProjection);
+		if (hostedMcpProjectionDeclared(manifest)) {
+			writeJsonFile(mcpProjection, projectionPayload("clawdi-mcp", manifest));
+			projections.push(mcpProjection);
+		} else {
+			rmSync(mcpProjection, { force: true });
+		}
 		const systemdUnits = writeSystemdUnits(
 			runtimeSystemdUserPrograms,
 			egressSystemdProgram,

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -32,7 +32,7 @@ describe("hosted runtime bundle v2", () => {
 		const projected = applyRuntimeBundleChannelsToManifestLoad(load);
 
 		expect(projected.sourceRevision).toBe(
-			"770c65d7b9903e89f31d6ba4417bf70cf2c755366d8e44fb4e20a3c4bad9d6a4",
+			"40a7584d7613031f489606ff215523af06f681df4011cfc9ed718beefd09c848",
 		);
 		expect(projected.secretValues).toMatchObject(
 			(raw as { secretValues: Record<string, string> }).secretValues,
@@ -146,7 +146,7 @@ describe("hosted runtime bundle v2", () => {
 		if (!("manifest" in loaded)) throw new Error(JSON.stringify(loaded));
 		expect(loaded.etag).toBe('"bundle-golden"');
 		expect(loaded.sourceRevision).toBe(
-			"770c65d7b9903e89f31d6ba4417bf70cf2c755366d8e44fb4e20a3c4bad9d6a4",
+			"40a7584d7613031f489606ff215523af06f681df4011cfc9ed718beefd09c848",
 		);
 		expect(loaded.channelBindings).toHaveLength(1);
 	});

--- a/packages/cli/src/runtime/secret-values.ts
+++ b/packages/cli/src/runtime/secret-values.ts
@@ -27,6 +27,11 @@ export function normalizeSecretValues(
 	return normalized;
 }
 
+export function canonicalSecretRefName(ref: string | null | undefined): string | null {
+	const normalized = normalizeSecretRef(ref ?? undefined);
+	return normalized?.slice("secret://".length) ?? null;
+}
+
 export function runtimeSecretValue(secrets: Record<string, unknown>, ref: string): string | null {
 	const envName = envSecretRefName(ref);
 	if (envName) {

--- a/packages/cli/tests/egress_addon/clawdi_egress_addon_test.py
+++ b/packages/cli/tests/egress_addon/clawdi_egress_addon_test.py
@@ -183,34 +183,45 @@ class AddonProfileInterpreterTest(unittest.TestCase):
         self.assertEqual(flow.request.host, "shared.test")
         self.assertEqual(flow.request.path, "/managed/messages")
 
-    def test_provider_profile_overwrites_authorization_without_host_rewrite(self):
+    def managed_provider_profile(self):
+        return {
+            "id": "provider",
+            "enabled": True,
+            "kind": "provider",
+            "match": {
+                "scheme": "https",
+                "host": "gateway.test",
+                "headers": {
+                    "authorization": {
+                        "type": "equals",
+                        "value": "clawdi-egress-placeholder",
+                        "prefix": "Bearer ",
+                    }
+                },
+            },
+            "rewrite": {
+                "setHeaders": {
+                    "authorization": {
+                        "type": "secretRef",
+                        "secretRef": "secret://provider-key",
+                        "prefix": "Bearer ",
+                    }
+                },
+            },
+            "logging": {"redactHeaders": ["authorization"], "redactUrlPatterns": []},
+            "priority": 10,
+        }
+
+    def test_provider_profile_rewrites_only_the_managed_placeholder(self):
         egress = self.load(
-            [
-                {
-                    "id": "provider",
-                    "enabled": True,
-                    "kind": "provider",
-                    "match": {"scheme": "https", "host": "gateway.test"},
-                    "rewrite": {
-                        "setHeaders": {
-                            "authorization": {
-                                "type": "secretRef",
-                                "secretRef": "secret://provider-key",
-                                "prefix": "Bearer ",
-                            }
-                        },
-                    },
-                    "logging": {"redactHeaders": ["authorization"], "redactUrlPatterns": []},
-                    "priority": 10,
-                }
-            ],
+            [self.managed_provider_profile()],
             {"secret://provider-key": "real-key"},
         )
 
         flow = Flow(
             host="gateway.test",
             path="/v1/responses",
-            headers={"Authorization": "Bearer dummy"},
+            headers={"Authorization": "Bearer clawdi-egress-placeholder"},
         )
         decision = egress.apply_to_flow(flow)
 
@@ -219,6 +230,36 @@ class AddonProfileInterpreterTest(unittest.TestCase):
         self.assertEqual(flow.request.path, "/v1/responses")
         self.assertEqual(flow.request.headers["Authorization"], "Bearer real-key")
 
+    def test_provider_profile_does_not_rewrite_a_user_bearer_token(self):
+        egress = self.load(
+            [self.managed_provider_profile()],
+            {"secret://provider-key": "real-key"},
+        )
+        flow = Flow(
+            host="gateway.test",
+            path="/v1/responses",
+            headers={"Authorization": "Bearer sk-user-real-token"},
+        )
+
+        decision = egress.apply_to_flow(flow)
+
+        self.assertEqual(decision.action, "allow")
+        self.assertEqual(flow.request.host, "gateway.test")
+        self.assertEqual(flow.request.headers["Authorization"], "Bearer sk-user-real-token")
+
+    def test_provider_profile_does_not_inject_a_missing_authorization_header(self):
+        egress = self.load(
+            [self.managed_provider_profile()],
+            {"secret://provider-key": "real-key"},
+        )
+        flow = Flow(host="gateway.test", path="/v1/responses")
+
+        decision = egress.apply_to_flow(flow)
+
+        self.assertEqual(decision.action, "allow")
+        self.assertEqual(flow.request.host, "gateway.test")
+        self.assertNotIn("authorization", flow.request.headers)
+
     def test_provider_profile_restores_transparent_authority_before_forwarding(self):
         egress = self.load(
             [
@@ -226,7 +267,17 @@ class AddonProfileInterpreterTest(unittest.TestCase):
                     "id": "provider",
                     "enabled": True,
                     "kind": "provider",
-                    "match": {"scheme": "https", "host": "gateway.test"},
+                    "match": {
+                        "scheme": "https",
+                        "host": "gateway.test",
+                        "headers": {
+                            "authorization": {
+                                "type": "equals",
+                                "value": "clawdi-egress-placeholder",
+                                "prefix": "Bearer ",
+                            }
+                        },
+                    },
                     "rewrite": {
                         "setHeaders": {
                             "authorization": {
@@ -247,7 +298,10 @@ class AddonProfileInterpreterTest(unittest.TestCase):
             host="203.0.113.10",
             pretty_host="gateway.test",
             path="/v1/chat/completions",
-            headers={"Host": "203.0.113.10", "Authorization": "Bearer dummy"},
+            headers={
+                "Host": "203.0.113.10",
+                "Authorization": "Bearer clawdi-egress-placeholder",
+            },
         )
         decision = egress.apply_to_flow(flow)
 
@@ -263,7 +317,17 @@ class AddonProfileInterpreterTest(unittest.TestCase):
                     "id": "provider",
                     "enabled": True,
                     "kind": "provider",
-                    "match": {"scheme": "https", "host": "gateway.test"},
+                    "match": {
+                        "scheme": "https",
+                        "host": "gateway.test",
+                        "headers": {
+                            "authorization": {
+                                "type": "equals",
+                                "value": "clawdi-egress-placeholder",
+                                "prefix": "Bearer ",
+                            }
+                        },
+                    },
                     "rewrite": {
                         "setHeaders": {
                             "authorization": {
@@ -283,7 +347,10 @@ class AddonProfileInterpreterTest(unittest.TestCase):
             host="203.0.113.10",
             pretty_host="gateway.test",
             path="/v1/chat/completions",
-            headers={"Host": "203.0.113.10", "Authorization": "Bearer dummy"},
+            headers={
+                "Host": "203.0.113.10",
+                "Authorization": "Bearer clawdi-egress-placeholder",
+            },
         )
 
         egress.requestheaders(flow)

--- a/packages/cli/tests/runtime-egress-profiles.test.ts
+++ b/packages/cli/tests/runtime-egress-profiles.test.ts
@@ -150,7 +150,13 @@ describe("runtime egress profile schema", () => {
 				match: {
 					scheme: "https",
 					host: "ai-gateway.example.test",
-					headers: {},
+					headers: {
+						authorization: {
+							type: "equals",
+							value: "clawdi-egress-placeholder",
+							prefix: "Bearer ",
+						},
+					},
 					query: {},
 				},
 				rewrite: {
@@ -280,6 +286,69 @@ describe("runtime egress profile schema", () => {
 			"hermes-provider.example.test",
 			"openclaw-provider.example.test",
 		]);
+	});
+
+	it("builds the Codex tool provider profile without runtime providers", () => {
+		const bundle = hostedManifestEgressProfiles({
+			providers: {},
+			terminalTooling: {
+				codex: {
+					enabled: true,
+					provider_id: "codex-managed",
+					provider: {
+						baseUrl: "https://ai-gateway.example.test/v1",
+						apiMode: "openai_responses",
+						managed_by: "clawdi",
+						apiKeySecretRef: "tool.codex.apiKey",
+					},
+				},
+			},
+		});
+
+		expect(providerProfiles(bundle.profiles)).toHaveLength(1);
+		expect(providerProfiles(bundle.profiles)[0]).toMatchObject({
+			id: "managed-provider-codex-managed",
+			match: {
+				scheme: "https",
+				host: "ai-gateway.example.test",
+				headers: {
+					authorization: {
+						type: "equals",
+						value: "clawdi-egress-placeholder",
+						prefix: "Bearer ",
+					},
+				},
+			},
+			rewrite: {
+				setHeaders: {
+					authorization: {
+						secretRef: "secret://tool.codex.apiKey",
+					},
+				},
+			},
+		});
+	});
+
+	it("dedupes a shared managed runtime and Codex provider host and ref", () => {
+		const sharedProvider = {
+			baseUrl: "https://ai-gateway.example.test/v1",
+			apiMode: "openai_responses",
+			managed_by: "clawdi",
+			apiKeySecretRef: "tool.codex.apiKey",
+		};
+		const bundle = hostedManifestEgressProfiles({
+			providers: { shared: sharedProvider },
+			terminalTooling: {
+				codex: {
+					enabled: true,
+					provider_id: "shared",
+					provider: sharedProvider,
+				},
+			},
+		});
+
+		expect(providerProfiles(bundle.profiles)).toHaveLength(1);
+		expect(providerProfiles(bundle.profiles)[0]?.id).toBe("managed-provider-shared");
 	});
 
 	it("does not derive provider egress profiles without a managed provider secret ref", () => {

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
 	chmodSync,
@@ -38,6 +39,7 @@ import {
 	evaluateHostPolicyForCommand,
 	readHostPolicy,
 } from "../src/runtime/host-policy";
+import { hostedManifestEgressProfiles } from "../src/runtime/hosted-egress-profiles";
 import {
 	convergeRuntimeManifest,
 	loadRuntimeManifest,
@@ -86,7 +88,6 @@ const ENV_KEYS = [
 	"CODEX_HOME",
 	"CLAWDI_CODEX_INSTALL_DISABLED",
 	"CLAWDI_CODEX_INSTALL_TIMEOUT",
-	"CLAWDI_CODEX_PACKAGE_SPEC",
 	"CUSTOM_RUNTIME_TOKEN",
 	"CLAWDI_RUNTIME_MANIFEST_TIMEOUT_MS",
 	"CLAWDI_API_URL",
@@ -189,7 +190,28 @@ const TEST_HOSTED_LOCALE = {
 	language: "en" as const,
 	timezone: "UTC",
 };
-const TEST_HOSTED_MINIMUM_CLI_VERSION = "0.12.10-beta.51";
+const TEST_HOSTED_MINIMUM_CLI_VERSION = "0.12.10-beta.53";
+const TEST_HOSTED_CODEX_SECRET_REF = "tool.codex.apiKey";
+const TEST_HOSTED_CODEX_SECRET_VALUES = {
+	[TEST_HOSTED_CODEX_SECRET_REF]: "sk-codex-tool",
+};
+const TEST_HOSTED_CODEX_TERMINAL_TOOLING = {
+	codex: {
+		enabled: true,
+		provider_id: "clawdi-managed-v2",
+		primary_model: { provider_id: "clawdi-managed-v2", model: "gpt-5.5" },
+		provider: {
+			kind: "openai-compatible",
+			type: "openai",
+			baseUrl: "https://sub2api.test/v1",
+			models: [{ id: "gpt-5.5" }],
+			apiMode: "openai_responses",
+			managed_by: "clawdi",
+			runtimeEnvName: "OPENAI_API_KEY",
+			apiKeySecretRef: TEST_HOSTED_CODEX_SECRET_REF,
+		},
+	},
+};
 
 function hostedRequiredState() {
 	return {
@@ -200,6 +222,7 @@ function hostedRequiredState() {
 				error: { code: "provider_not_found", message: "fixture provider unavailable" },
 			},
 		},
+		terminalTooling: TEST_HOSTED_CODEX_TERMINAL_TOOLING,
 		liveSync: { enabled: false, agents: [] },
 		recovery: { cacheManifest: true, allowOfflineBoot: true },
 	};
@@ -262,7 +285,10 @@ function hostedRuntimeBundleResponse(
 	options: { etag?: string; sourceRevision?: string } = {},
 ): Response {
 	const channelBindings = payload.channelBindings ?? [];
-	const secretValues = payload.secretValues ?? {};
+	const secretValues = {
+		...TEST_HOSTED_CODEX_SECRET_VALUES,
+		...(payload.secretValues ?? {}),
+	};
 	const sourceRevision =
 		options.sourceRevision ??
 		runtimeContentSha256({
@@ -326,7 +352,7 @@ function hostedRuntimeWatchLocalePayload(
 				}),
 			},
 		},
-		secretValues: {},
+		secretValues: TEST_HOSTED_CODEX_SECRET_VALUES,
 	};
 }
 
@@ -343,6 +369,7 @@ function hostedCliManifestResponse(
 				models: [{ id: "gpt-5" }],
 				apiMode: "openai_responses",
 				managed_by: "clawdi",
+				runtimeEnvName: "OPENAI_API_KEY",
 				apiKeySecretRef: opts.providerSecretRef,
 			}
 		: hostedRequiredState().providers.default;
@@ -372,7 +399,7 @@ function hostedCliManifestResponse(
 				}),
 			},
 		},
-		secretValues: {},
+		secretValues: TEST_HOSTED_CODEX_SECRET_VALUES,
 	};
 }
 
@@ -409,6 +436,51 @@ function seedOpenClawBinary(home: string): void {
 	mkdirSync(dirname(openclawBin), { recursive: true });
 	writeFileSync(openclawBin, "#!/bin/sh\nexit 0\n");
 	chmodSync(openclawBin, 0o700);
+}
+
+function seedHostedCodexPackage(
+	serviceStateRoot: string,
+	version: string,
+	options: { executable?: boolean; validPackageJson?: boolean } = {},
+): { packageJson: string; realBin: string } {
+	const npmPrefix = join(serviceStateRoot, "codex", "npm");
+	const packageJson = join(npmPrefix, "lib", "node_modules", "@openai", "codex", "package.json");
+	const realBin = join(npmPrefix, "bin", "codex");
+	mkdirSync(dirname(packageJson), { recursive: true });
+	mkdirSync(dirname(realBin), { recursive: true });
+	writeFileSync(
+		packageJson,
+		options.validPackageJson === false ? "not-json\n" : JSON.stringify({ version }),
+	);
+	writeFileSync(realBin, "#!/bin/sh\nexit 0\n");
+	chmodSync(realBin, options.executable === false ? 0o600 : 0o755);
+	return { packageJson, realBin };
+}
+
+function writeHostedCodexNpmInstaller(
+	binDir: string,
+	markerPath: string,
+	installedVersion: string,
+): void {
+	mkdirSync(binDir, { recursive: true });
+	writeFileSync(
+		join(binDir, "npm"),
+		[
+			"#!/usr/bin/env bash",
+			"set -euo pipefail",
+			`printf 'install\\n' >> '${markerPath}'`,
+			"prefix=''",
+			'while [ "$#" -gt 0 ]; do',
+			'  if [ "$1" = "--prefix" ]; then prefix="$2"; shift 2; else shift; fi',
+			"done",
+			'mkdir -p "$prefix/bin" "$prefix/lib/node_modules/@openai/codex"',
+			`printf '%s\\n' '{"version":"${installedVersion}"}' > "$prefix/lib/node_modules/@openai/codex/package.json"`,
+			"printf '#!/bin/sh\\nexit 0\\n' > \"$prefix/bin/codex\"",
+			'chmod 755 "$prefix/bin/codex"',
+			"",
+		].join("\n"),
+	);
+	chmodSync(join(binDir, "npm"), 0o755);
 }
 
 function seedRuntimeWatchLocaleBaseline(home: string, state: string, run: string): RuntimePaths {
@@ -460,6 +532,7 @@ type HostedRunFixture = {
 
 type HostedRuntimeFixtureEntry = {
 	enabled: boolean;
+	providerMode: "configured" | "unmanaged";
 	install: { source: "official" };
 	run?: HostedRunFixture;
 	services?: Record<string, HostedRunFixture>;
@@ -481,6 +554,7 @@ function hostedOpenClawRuntime(
 	return {
 		enabled: true,
 		install: { source: "official" },
+		providerMode: "configured",
 		provider_ids,
 		primary_model,
 		run: {
@@ -520,6 +594,7 @@ function hostedHermesRuntime(
 	return {
 		enabled: true,
 		install: { source: "official" },
+		providerMode: "configured",
 		provider_ids,
 		primary_model,
 		run: {
@@ -602,8 +677,11 @@ function expectProviderEgressProfileUsesSecretRef(
 	const providerProfiles = (profiles as Array<Record<string, unknown>>).filter(
 		(profile) => profile.kind === "provider" && profile.owner === "provider-projection",
 	);
-	expect(providerProfiles).toHaveLength(1);
-	const providerProfileText = JSON.stringify(providerProfiles[0]);
+	const matchingProfiles = providerProfiles.filter((profile) =>
+		JSON.stringify(profile).includes(`"secretRef":"${secretRef}"`),
+	);
+	expect(matchingProfiles.length).toBeGreaterThan(0);
+	const providerProfileText = JSON.stringify(matchingProfiles[0]);
 	expect(providerProfileText).toContain(`"secretRef":"${secretRef}"`);
 	expect(providerProfileText).toContain('"type":"secretRef"');
 	expect(providerProfileText).not.toContain(plaintextSecret);
@@ -714,6 +792,9 @@ function hostedHermesProviderLoad(home: string): RuntimeManifestLoad {
 			runtimes: {
 				hermes: {
 					enabled: true,
+					providerMode: "configured",
+					provider_ids: ["hermes"],
+					primary_model: { provider_id: "hermes", model: "kimi/kimi-for-coding" },
 					install: {
 						authority: "official",
 						method: "official-installer",
@@ -768,6 +849,7 @@ function hostedProviderSwitchProvider(
 	const envPrefix = providerId.toUpperCase().replace(/[^A-Z0-9]/g, "_");
 	return {
 		kind: "openai-compatible",
+		type: "custom_openai_compatible",
 		baseUrl: `https://${providerId}.provider.example.test/v1`,
 		model: hostedProviderSwitchModel(providerId),
 		models: [
@@ -794,16 +876,35 @@ function hostedProviderSwitchLoad(
 	selectedProviderId: string,
 	generation: number,
 ): RuntimeManifestLoad {
+	const codexProvider = {
+		...hostedProviderSwitchProvider("clawdi-managed", "clawdi"),
+		type: "openai",
+		apiKeySecretRef: TEST_HOSTED_CODEX_SECRET_REF,
+	};
+	const terminalTooling = {
+		codex: {
+			enabled: true,
+			provider_id: "clawdi-managed",
+			primary_model: {
+				provider_id: "clawdi-managed",
+				model: hostedProviderSwitchModel("clawdi-managed"),
+			},
+			provider: codexProvider,
+		},
+	};
 	return {
 		source: "remote-datasource",
 		sourcePath: "https://runtime-source.test/desired-state",
 		offline: false,
-		secretValues: Object.fromEntries(
-			Object.keys(HOSTED_PROVIDER_SWITCH_PROVIDERS).map((providerId) => [
-				`provider.${providerId}.apiKey`,
-				`sk-${providerId}`,
-			]),
-		),
+		secretValues: {
+			...Object.fromEntries(
+				Object.keys(HOSTED_PROVIDER_SWITCH_PROVIDERS).map((providerId) => [
+					`provider.${providerId}.apiKey`,
+					`sk-${providerId}`,
+				]),
+			),
+			...TEST_HOSTED_CODEX_SECRET_VALUES,
+		},
 		manifest: {
 			schemaVersion: "clawdi.runtimeDesiredState.v1",
 			deploymentId: "dep_provider_switch",
@@ -851,8 +952,109 @@ function hostedProviderSwitchLoad(
 				sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
 				system: { home, workspace: join(home, "clawdi") },
 				providers: HOSTED_PROVIDER_SWITCH_PROVIDERS,
+				terminalTooling,
 			},
 			egressProfiles: { profiles: [] },
+			recovery: { cacheManifest: true, allowOfflineBoot: true },
+		},
+	};
+}
+
+function hostedSingleProviderModeLoad(
+	home: string,
+	runtimeName: "openclaw" | "hermes",
+	providerMode: "configured" | "unmanaged",
+	generation: number,
+): RuntimeManifestLoad {
+	const configuredRuntime =
+		runtimeName === "openclaw"
+			? hostedOpenClawRuntime({
+					providerMode: "configured",
+					provider_ids: ["clawdi-managed"],
+					primary_model: { provider_id: "clawdi-managed", model: "gpt-5.5" },
+				})
+			: hostedHermesRuntime({
+					providerMode: "configured",
+					provider_ids: ["clawdi-managed"],
+					primary_model: { provider_id: "clawdi-managed", model: "gpt-5.5" },
+				});
+	const { primary_model: _primaryModel, ...runtimeWithoutPrimaryModel } = configuredRuntime;
+	const runtime =
+		providerMode === "configured"
+			? configuredRuntime
+			: { ...runtimeWithoutPrimaryModel, providerMode: "unmanaged" as const, provider_ids: [] };
+	const install =
+		runtimeName === "openclaw"
+			? {
+					authority: "official" as const,
+					method: "official-installer" as const,
+					url: "https://openclaw.ai/install-cli.sh",
+					home,
+					args: ["--json", "--no-onboard"],
+				}
+			: {
+					authority: "official" as const,
+					method: "official-installer" as const,
+					url: "https://hermes-agent.nousresearch.com/install.sh",
+					home,
+					args: ["--skip-setup", "--skip-browser", "--non-interactive"],
+				};
+	const providers =
+		providerMode === "configured"
+			? {
+					"clawdi-managed": {
+						kind: "openai-compatible",
+						baseUrl: "https://managed.provider.example.test/v1",
+						model: "gpt-5.5",
+						models: [{ id: "gpt-5.5" }],
+						apiMode: "openai_responses",
+						managed_by: "clawdi",
+						runtimeEnvName: "OPENAI_API_KEY",
+						apiKeySecretRef: "provider.clawdi-managed.apiKey",
+					},
+				}
+			: {};
+	const codexProvider = {
+		...hostedProviderSwitchProvider("clawdi-managed", "clawdi"),
+		type: "openai",
+		apiKeySecretRef: TEST_HOSTED_CODEX_SECRET_REF,
+	};
+	const terminalTooling = {
+		codex: {
+			enabled: true,
+			provider_id: "clawdi-managed",
+			primary_model: { provider_id: "clawdi-managed", model: "gpt-5.5" },
+			provider: codexProvider,
+		},
+	};
+	return {
+		source: "remote-datasource",
+		sourcePath: "https://runtime-source.test/desired-state",
+		offline: false,
+		secretValues: {
+			...(providerMode === "configured"
+				? { "provider.clawdi-managed.apiKey": "sk-managed-provider" }
+				: {}),
+			...TEST_HOSTED_CODEX_SECRET_VALUES,
+		},
+		manifest: {
+			schemaVersion: "clawdi.runtimeDesiredState.v1",
+			deploymentId: "dep_provider_mode",
+			environmentId: "env_provider_mode",
+			instanceId: "iid_provider_mode",
+			generation,
+			issuedAt: "2026-07-14T00:00:00Z",
+			workspaceRoot: join(home, "clawdi"),
+			runtime: runtimeName,
+			controlPlane: { apiUrl: "https://cloud-api.test" },
+			runtimes: { [runtimeName]: { ...runtime, install } },
+			projection: {
+				sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				system: { home, workspace: join(home, "clawdi") },
+				providers,
+				terminalTooling,
+			},
+			egressProfiles: hostedManifestEgressProfiles({ providers, terminalTooling }),
 			recovery: { cacheManifest: true, allowOfflineBoot: true },
 		},
 	};
@@ -1424,7 +1626,7 @@ describe("runtime manifest datasource", () => {
 							runtimes: {
 								openclaw: hostedOpenClawRuntime({
 									paths: { home },
-									provider_ids: ["default", "codex"],
+									provider_ids: ["default"],
 								}),
 							},
 							providers: {
@@ -1435,21 +1637,11 @@ describe("runtime manifest datasource", () => {
 									models: [{ id: "gpt-5.5" }],
 									apiMode: "openai_chat",
 									managed_by: "clawdi",
+									runtimeEnvName: "OPENAI_API_KEY",
 									apiKeySecretRef: "provider.default.apiKey",
 								},
-								codex: {
-									kind: "openai-compatible",
-									type: "openai",
-									baseUrl: "https://api.openai.com/v1",
-									models: [{ id: "gpt-5.5" }],
-									apiMode: "openai_responses",
-									auth: {
-										type: "agent_profile",
-										tool: "codex",
-										profile: "default",
-									},
-								},
 							},
+							terminalTooling: TEST_HOSTED_CODEX_TERMINAL_TOOLING,
 							mcp: { enabled: true, profile: "clawdi-default" },
 							tools: { catalog: "clawdi-default" },
 						},
@@ -1479,14 +1671,9 @@ describe("runtime manifest datasource", () => {
 				profile: "clawdi-default",
 			});
 			expect(loaded.manifest.projection?.tools).toEqual({ catalog: "clawdi-default" });
-			expect(loaded.manifest.projection?.providers.codex).toMatchObject({
-				type: "openai",
-				auth: {
-					type: "agent_profile",
-					tool: "codex",
-					profile: "default",
-				},
-			});
+			expect(loaded.manifest.projection?.terminalTooling).toEqual(
+				TEST_HOSTED_CODEX_TERMINAL_TOOLING,
+			);
 			expect(loaded.manifest.runtimes.openclaw.install?.url).toBe(
 				"https://openclaw.ai/install-cli.sh",
 			);
@@ -1499,6 +1686,8 @@ describe("runtime manifest datasource", () => {
 			);
 			expect(JSON.stringify(loaded.manifest.egressProfiles)).not.toContain("sk-runtime");
 			expect(loaded.secretValues).toEqual({
+				[TEST_HOSTED_CODEX_SECRET_REF]: "sk-codex-tool",
+				[`secret://${TEST_HOSTED_CODEX_SECRET_REF}`]: "sk-codex-tool",
 				"provider.default.apiKey": "sk-runtime",
 				"secret://provider.default.apiKey": "sk-runtime",
 			});
@@ -2053,6 +2242,8 @@ chmod +x "$HOME/.local/bin/hermes"
 				runtimes: {
 					openclaw: {
 						enabled: true,
+						provider_ids: ["default"],
+						primary_model: { provider_id: "default", model: "gpt-5.4-mini" },
 						install: {
 							authority: "official",
 							method: "official-installer",
@@ -2156,11 +2347,9 @@ chmod +x "$HOME/.local/bin/hermes"
 		const run = join(root, "run", "clawdi");
 		const codexHome = join(home, ".codex");
 		mkdirSync(codexHome, { recursive: true });
-		writeFileSync(join(codexHome, "config.toml"), "stale image config\n");
-		writeFileSync(join(codexHome, "clawdi-managed-provider.json"), '{"stale":true}\n');
+		writeFileSync(join(codexHome, "config.toml"), '# stale Hosted config\nmodel = "stale"\n');
 		chmodSync(codexHome, 0o755);
 		chmodSync(join(codexHome, "config.toml"), 0o644);
-		chmodSync(join(codexHome, "clawdi-managed-provider.json"), 0o644);
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
@@ -2187,24 +2376,21 @@ chmod +x "$HOME/.local/bin/hermes"
 					projection: {
 						sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
 						system: { home },
-						providers: {
-							hermes: {
-								kind: "openai-compatible",
-								baseUrl: "https://hermes-provider.example.test/v1",
-								model: "kimi/kimi-for-coding",
-								apiMode: "openai_chat",
-								managed_by: "clawdi",
-								runtimeEnvName: "OPENAI_API_KEY",
-								apiKeySecretRef: "provider.hermes.apiKey",
-							},
-							openclaw: {
-								kind: "openai-compatible",
-								baseUrl: "https://openclaw-provider.example.test/v1",
-								model: "gpt-5.5",
-								apiMode: "openai_responses",
-								managed_by: "clawdi",
-								runtimeEnvName: "OPENAI_API_KEY",
-								apiKeySecretRef: "provider.openclaw.apiKey",
+						providers: {},
+						terminalTooling: {
+							codex: {
+								enabled: true,
+								provider_id: "codex-managed",
+								primary_model: { provider_id: "codex-managed", model: "gpt-5.5" },
+								provider: {
+									kind: "openai-compatible",
+									type: "openai",
+									baseUrl: "https://codex-provider.example.test/v1",
+									apiMode: "openai_responses",
+									managed_by: "clawdi",
+									runtimeEnvName: "OPENAI_API_KEY",
+									apiKeySecretRef: "tool.codex.apiKey",
+								},
 							},
 						},
 					},
@@ -2227,25 +2413,12 @@ chmod +x "$HOME/.local/bin/hermes"
 				"",
 				"[model_providers.clawdi-managed]",
 				'name = "Clawdi Managed OpenAI"',
-				'base_url = "https://openclaw-provider.example.test/v1"',
+				'base_url = "https://codex-provider.example.test/v1"',
 				'wire_api = "responses"',
 				'env_key = "OPENAI_API_KEY"',
 				"",
 			].join("\n"),
 		);
-		const statePath = join(codexHome, "clawdi-managed-provider.json");
-		expect(statSync(statePath).mode & 0o777).toBe(0o600);
-		expect(JSON.parse(readFileSync(statePath, "utf-8"))).toEqual({
-			schemaVersion: "clawdi.hostedCodexManagedProvider.v1",
-			managedBy: "clawdi hosted runtime",
-			provider: {
-				baseUrl: "https://openclaw-provider.example.test/v1",
-				model: "gpt-5.5",
-				apiMode: "openai_responses",
-				runtimeEnvName: "OPENAI_API_KEY",
-				apiKeySecretRef: "provider.openclaw.apiKey",
-			},
-		});
 	});
 
 	it("installs the Codex runtime add-on through npm when managed config is projected", () => {
@@ -2254,8 +2427,12 @@ chmod +x "$HOME/.local/bin/hermes"
 		const run = join(root, "run", "clawdi");
 		const binDir = join(root, "fake-bin");
 		const npmArgsPath = join(root, "npm-args.txt");
+		const userCodexConfig = join(home, ".codex", "config.toml");
+		const userConfigBytes = Buffer.from('# user config\nmodel = "user-model"\n');
 		const previousPath = process.env.PATH;
 		mkdirSync(binDir, { recursive: true });
+		mkdirSync(dirname(userCodexConfig), { recursive: true });
+		writeFileSync(userCodexConfig, userConfigBytes);
 		writeFileSync(
 			join(binDir, "npm"),
 			[
@@ -2274,10 +2451,12 @@ chmod +x "$HOME/.local/bin/hermes"
 				"      ;;",
 				"  esac",
 				"done",
-				'mkdir -p "$prefix/bin"',
+				'mkdir -p "$prefix/bin" "$prefix/lib/node_modules/@openai/codex"',
+				`printf '%s\\n' '{"version":"0.142.4"}' > "$prefix/lib/node_modules/@openai/codex/package.json"`,
 				"cat > \"$prefix/bin/codex\" <<'SH'",
 				"#!/usr/bin/env sh",
-				"echo fake codex",
+				"printf 'env=<%s>\\n' \"$" + '{OPENAI_API_KEY-unset}"',
+				'for arg in "$@"; do printf \'arg=<%s>\\n\' "$arg"; done',
 				"SH",
 				'chmod 755 "$prefix/bin/codex"',
 				"",
@@ -2285,7 +2464,6 @@ chmod +x "$HOME/.local/bin/hermes"
 		);
 		chmodSync(join(binDir, "npm"), 0o755);
 		delete process.env.CLAWDI_CODEX_INSTALL_DISABLED;
-		process.env.CLAWDI_CODEX_PACKAGE_SPEC = "@openai/codex@latest";
 		process.env.HOME = home;
 		process.env.CLAWDI_RUNTIME_MODE = "hosted";
 		process.env.CLAWDI_SERVICE_STATE_DIR = state;
@@ -2312,15 +2490,20 @@ chmod +x "$HOME/.local/bin/hermes"
 						},
 						projection: {
 							system: { home },
-							providers: {
-								default: {
-									kind: "openai-compatible",
-									baseUrl: "https://managed-provider.example.test/v1",
-									model: "gpt-5.5",
-									apiMode: "openai_responses",
-									managed_by: "clawdi",
-									runtimeEnvName: "OPENAI_API_KEY",
-									apiKeySecretRef: "provider.default.apiKey",
+							providers: {},
+							terminalTooling: {
+								codex: {
+									enabled: true,
+									provider_id: "codex-managed",
+									primary_model: { provider_id: "codex-managed", model: "gpt-5.5" },
+									provider: {
+										kind: "openai-compatible",
+										baseUrl: "https://managed-provider.example.test/v1",
+										apiMode: "openai_responses",
+										managed_by: "clawdi",
+										runtimeEnvName: "OPENAI_API_KEY",
+										apiKeySecretRef: "tool.codex.apiKey",
+									},
 								},
 							},
 						},
@@ -2339,13 +2522,164 @@ chmod +x "$HOME/.local/bin/hermes"
 		}
 
 		const npmArgs = readFileSync(npmArgsPath, "utf-8");
-		expect(npmArgs).toContain("@openai/codex@latest");
+		expect(npmArgs).toContain("@openai/codex@0.142.4");
 		expect(npmArgs).toContain(`${join(state, "codex", "npm")}\n`);
 		const realBin = join(state, "codex", "npm", "bin", "codex");
 		const commandShim = join(state, "bin", "codex");
 		expect(statSync(realBin).mode & 0o777).toBe(0o755);
 		expect(statSync(commandShim).mode & 0o777).toBe(0o755);
-		expect(readFileSync(commandShim, "utf-8")).toBe(`#!/usr/bin/env sh\nexec '${realBin}' "$@"\n`);
+		expect(readFileSync(commandShim, "utf8")).not.toContain("--profile");
+		expect(readFileSync(userCodexConfig, "utf8")).toContain('model_provider = "clawdi-managed"');
+
+		const runShim = (args: string[]) => {
+			const result = spawnSync(commandShim, args, {
+				encoding: "utf8",
+				env: { ...process.env, OPENAI_API_KEY: "user-existing-key" },
+			});
+			expect(result.status).toBe(0);
+			return result.stdout.trimEnd().split("\n");
+		};
+		expect(runShim(["exec", "quoted arg", ""])).toEqual([
+			"env=<clawdi-egress-placeholder>",
+			"arg=<exec>",
+			"arg=<quoted arg>",
+			"arg=<>",
+		]);
+		for (const args of [
+			["resume", "session id", "--flag=value"],
+			["exec", "", "'quoted'", '"double quoted"'],
+		]) {
+			expect(runShim(args)).toEqual([
+				"env=<clawdi-egress-placeholder>",
+				...args.map((arg) => `arg=<${arg}>`),
+			]);
+		}
+	});
+
+	it("does not reinstall the exact executable Hosted Codex package", () => {
+		const home = join(root, "codex-exact", "home", "clawdi");
+		const state = join(root, "codex-exact", "var", "lib", "clawdi");
+		const run = join(root, "codex-exact", "run", "clawdi");
+		const binDir = join(root, "codex-exact", "fake-bin");
+		const installMarker = join(root, "codex-exact", "npm-install.txt");
+		const previousPath = process.env.PATH;
+		seedOpenClawBinary(home);
+		seedHostedCodexPackage(state, "0.142.4");
+		writeHostedCodexNpmInstaller(binDir, installMarker, "0.142.4");
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_SYSTEMD_APPLY = "0";
+		process.env.PATH = [binDir, previousPath].filter(Boolean).join(":");
+		delete process.env.CLAWDI_CODEX_INSTALL_DISABLED;
+
+		try {
+			const convergence = convergeRuntimeManifest(
+				hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 1),
+				getRuntimePaths(),
+			);
+			expect(convergence.installErrors).toEqual([]);
+		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+			process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
+		}
+
+		expect(existsSync(installMarker)).toBe(false);
+		expect(readFileSync(join(home, ".codex", "config.toml"), "utf8")).toContain(
+			'model_provider = "clawdi-managed"',
+		);
+		expect(readFileSync(join(state, "bin", "codex"), "utf8")).not.toContain("--profile");
+	});
+
+	it("reinstalls missing, damaged, or old Hosted Codex packages to the exact version", () => {
+		const previousPath = process.env.PATH;
+		const cases = [
+			{ name: "missing" },
+			{ name: "old", version: "0.142.3" },
+			{ name: "damaged", version: "0.142.4", validPackageJson: false },
+			{ name: "non-executable", version: "0.142.4", executable: false },
+		] as const;
+
+		try {
+			for (const packageCase of cases) {
+				const caseRoot = join(root, `codex-${packageCase.name}`);
+				const home = join(caseRoot, "home", "clawdi");
+				const state = join(caseRoot, "var", "lib", "clawdi");
+				const run = join(caseRoot, "run", "clawdi");
+				const binDir = join(caseRoot, "fake-bin");
+				const installMarker = join(caseRoot, "npm-install.txt");
+				seedOpenClawBinary(home);
+				if ("version" in packageCase) {
+					seedHostedCodexPackage(state, packageCase.version, {
+						executable: "executable" in packageCase ? packageCase.executable : undefined,
+						validPackageJson:
+							"validPackageJson" in packageCase ? packageCase.validPackageJson : undefined,
+					});
+				}
+				writeHostedCodexNpmInstaller(binDir, installMarker, "0.142.4");
+				process.env.HOME = home;
+				process.env.CLAWDI_RUNTIME_MODE = "hosted";
+				process.env.CLAWDI_SERVICE_STATE_DIR = state;
+				process.env.CLAWDI_RUN_DIR = run;
+				process.env.CLAWDI_SYSTEMD_APPLY = "0";
+				process.env.PATH = [binDir, previousPath].filter(Boolean).join(":");
+				delete process.env.CLAWDI_CODEX_INSTALL_DISABLED;
+
+				const convergence = convergeRuntimeManifest(
+					hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 1),
+					getRuntimePaths(),
+				);
+				expect(convergence.installErrors).toEqual([]);
+				expect(readFileSync(installMarker, "utf8")).toBe("install\n");
+				expect(
+					JSON.parse(
+						readFileSync(
+							join(state, "codex/npm/lib/node_modules/@openai/codex/package.json"),
+							"utf8",
+						),
+					).version,
+				).toBe("0.142.4");
+			}
+		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+			process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
+		}
+	});
+
+	it("fails closed when npm installs the wrong Hosted Codex version", () => {
+		const home = join(root, "codex-wrong-version", "home", "clawdi");
+		const state = join(root, "codex-wrong-version", "var", "lib", "clawdi");
+		const run = join(root, "codex-wrong-version", "run", "clawdi");
+		const binDir = join(root, "codex-wrong-version", "fake-bin");
+		const installMarker = join(root, "codex-wrong-version", "npm-install.txt");
+		const previousPath = process.env.PATH;
+		seedOpenClawBinary(home);
+		writeHostedCodexNpmInstaller(binDir, installMarker, "0.142.3");
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		process.env.CLAWDI_SYSTEMD_APPLY = "0";
+		process.env.PATH = [binDir, previousPath].filter(Boolean).join(":");
+		delete process.env.CLAWDI_CODEX_INSTALL_DISABLED;
+
+		try {
+			const convergence = convergeRuntimeManifest(
+				hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 1),
+				getRuntimePaths(),
+			);
+			expect(convergence.installErrors.join("\n")).toContain(
+				"Codex npm install produced version 0.142.3; expected 0.142.4",
+			);
+			expect(existsSync(join(home, ".codex", "config.toml"))).toBe(false);
+		} finally {
+			if (previousPath === undefined) delete process.env.PATH;
+			else process.env.PATH = previousPath;
+			process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
+		}
 	});
 
 	it("does not mutate live config when the Codex runtime add-on install fails", () => {
@@ -2366,7 +2700,6 @@ chmod +x "$HOME/.local/bin/hermes"
 		process.env.CLAWDI_SYSTEMD_APPLY = "0";
 		process.env.PATH = [binDir, previousPath].filter(Boolean).join(":");
 		delete process.env.CLAWDI_CODEX_INSTALL_DISABLED;
-		process.env.CLAWDI_CODEX_PACKAGE_SPEC = "@openai/codex@latest";
 		const paths = getRuntimePaths();
 		const liveFiles = [
 			paths.managedConfig,
@@ -2400,7 +2733,7 @@ chmod +x "$HOME/.local/bin/hermes"
 		}
 	});
 
-	it("does not write Codex managed provider config for user-owned providers", () => {
+	it("keeps the Codex tool profile configured when runtime providers are user-owned", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -2439,6 +2772,7 @@ chmod +x "$HOME/.local/bin/hermes"
 								apiKeySecretRef: "provider.byok.apiKey",
 							},
 						},
+						terminalTooling: TEST_HOSTED_CODEX_TERMINAL_TOOLING,
 					},
 					egressProfiles: { profiles: [] },
 					recovery: { cacheManifest: true, allowOfflineBoot: true },
@@ -2448,8 +2782,9 @@ chmod +x "$HOME/.local/bin/hermes"
 		);
 
 		expect(convergence.installErrors).toEqual([]);
-		expect(existsSync(join(home, ".codex", "config.toml"))).toBe(false);
-		expect(existsSync(join(home, ".codex", "clawdi-managed-provider.json"))).toBe(false);
+		expect(readFileSync(join(home, ".codex", "config.toml"), "utf8")).toContain(
+			'model_provider = "clawdi-managed"',
+		);
 	});
 
 	it("preserves Clawdi-managed provider ownership when projecting hosted providers", () => {
@@ -2644,6 +2979,184 @@ exit 0
 		}
 	});
 
+	it.each([
+		"openclaw",
+		"hermes",
+	] as const)("converges %s in unmanaged mode without touching user provider config", (runtimeName) => {
+		const home = join(root, runtimeName, "home", "clawdi");
+		const state = join(root, runtimeName, "var", "lib", "clawdi");
+		const run = join(root, runtimeName, "run", "clawdi");
+		const workspace = join(home, "clawdi");
+		mkdirSync(workspace, { recursive: true });
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+
+		let userConfigPath: string;
+		let userConfig: string;
+		if (runtimeName === "openclaw") {
+			seedOpenClawBinary(home);
+			userConfigPath = join(home, ".openclaw", "openclaw.json");
+			userConfig =
+				'{"models":{"providers":{"user-local":{"baseUrl":"http://localhost:11434/v1"}}}}\n';
+			writeFileSync(userConfigPath, userConfig);
+		} else {
+			writeHermesVersionBinary(home, "0.18.0");
+			userConfigPath = join(home, ".hermes", "config.yaml");
+			userConfig = 'providers:\n  user-local:\n    api: "http://localhost:11434/v1"\n';
+			mkdirSync(dirname(userConfigPath), { recursive: true });
+			writeFileSync(userConfigPath, userConfig);
+		}
+		const userCodexConfig = join(home, ".codex", "config.toml");
+		mkdirSync(dirname(userCodexConfig), { recursive: true });
+		writeFileSync(userCodexConfig, "# preserve me byte-for-byte\n");
+
+		const paths = getRuntimePaths();
+		const load = hostedSingleProviderModeLoad(home, runtimeName, "unmanaged", 1);
+		const convergence = convergeRuntimeManifest(load, paths);
+		writeTestRuntimeAppliedState(paths, load, convergence);
+
+		expect(convergence.installErrors).toEqual([]);
+		expect(convergence.projectedProviderIds[runtimeName]).toEqual([]);
+		expect(convergence.projectedProviderIds.codex).toEqual(["clawdi-managed"]);
+		expect(readFileSync(userConfigPath, "utf-8")).toBe(userConfig);
+		expect(readFileSync(userCodexConfig, "utf-8")).toContain('model_provider = "clawdi-managed"');
+		const runConfig = JSON.parse(
+			readFileSync(join(state, "config", "run", `${runtimeName}.json`), "utf-8"),
+		);
+		expect(runConfig.secretEnv).toEqual({});
+		expect(JSON.stringify(runConfig)).not.toContain("OPENAI_API_KEY");
+		expect(JSON.stringify(runConfig)).not.toContain("clawdi-egress-placeholder");
+		expect(existsSync(join(run, "secrets", "runtime-secrets.json"))).toBe(false);
+		expect(existsSync(join(paths.runtimeSecretFileRoot, `${runtimeName}.json`))).toBe(false);
+		const runtimeUnit = runtimeName === "openclaw" ? "openclaw-gateway" : "hermes-gateway";
+		const runtimeUnitEnv = readSystemdEnvFile(paths, runtimeUnit);
+		for (const forbidden of [
+			"OPENAI_API_KEY",
+			"CLAWDI_MANAGED_OPENAI_API_KEY",
+			"clawdi-egress-placeholder",
+			"provider.clawdi-managed",
+			"egress-secrets.json",
+		]) {
+			expect(runtimeUnitEnv).not.toContain(forbidden);
+		}
+		const egressSecrets = readFileSync(join(run, "secrets", "egress-secrets.json"), "utf-8");
+		expect(egressSecrets).toContain("secret://tool.codex.apiKey");
+		expect(egressSecrets).toContain("sk-codex-tool");
+		expect(existsSync(join(state, "config", "projections", "clawdi-mcp.json"))).toBe(false);
+		const applied = JSON.parse(readFileSync(paths.appliedState, "utf-8"));
+		expect(applied.providerIds).toEqual([]);
+		expect(applied.projectedProviderIds[runtimeName]).toEqual([]);
+		expect(applied.projectedProviderIds.codex).toEqual(["clawdi-managed"]);
+	});
+
+	it("removes only the runtime provider projection on configured to unmanaged", () => {
+		const home = join(root, "owned-cleanup", "home", "clawdi");
+		const state = join(root, "owned-cleanup", "var", "lib", "clawdi");
+		const run = join(root, "owned-cleanup", "run", "clawdi");
+		mkdirSync(join(home, "clawdi"), { recursive: true });
+		seedOpenClawBinary(home);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		const userCodexConfig = join(home, ".codex", "config.toml");
+		mkdirSync(dirname(userCodexConfig), { recursive: true });
+		writeFileSync(userCodexConfig, '# user-owned bytes\nmodel = "user-model"\n');
+		const paths = getRuntimePaths();
+		const configuredLoad = hostedSingleProviderModeLoad(home, "openclaw", "configured", 1);
+		const configured = convergeRuntimeManifest(configuredLoad, paths);
+		expect(configured.installErrors).toEqual([]);
+		writeTestRuntimeAppliedState(paths, configuredLoad, configured);
+		const codexConfig = join(home, ".codex", "config.toml");
+		expect(readFileSync(codexConfig, "utf-8")).toContain('env_key = "OPENAI_API_KEY"');
+		const expectedCodexConfig = readFileSync(codexConfig, "utf-8");
+
+		const unmanaged = convergeRuntimeManifest(
+			hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 2),
+			paths,
+		);
+
+		expect(unmanaged.installErrors).toEqual([]);
+		expect(unmanaged.projectedProviderIds).toMatchObject({
+			codex: ["clawdi-managed"],
+			openclaw: [],
+		});
+		expect(readFileSync(codexConfig, "utf-8")).toBe(expectedCodexConfig);
+		const runConfig = JSON.parse(
+			readFileSync(join(state, "config", "run", "openclaw.json"), "utf-8"),
+		);
+		expect(runConfig.secretEnv).toEqual({});
+		expect(JSON.stringify(runConfig)).not.toContain("OPENAI_API_KEY");
+		expect(existsSync(join(run, "secrets", "runtime-secrets.json"))).toBe(false);
+		expect(readFileSync(join(run, "secrets", "egress-secrets.json"), "utf-8")).toContain(
+			"sk-codex-tool",
+		);
+	});
+
+	it("removes a BYOK runtime secret file without removing Codex tooling", () => {
+		const home = join(root, "byok-cleanup", "home", "clawdi");
+		const state = join(root, "byok-cleanup", "var", "lib", "clawdi");
+		const run = join(root, "byok-cleanup", "run", "clawdi");
+		mkdirSync(join(home, "clawdi"), { recursive: true });
+		seedOpenClawBinary(home);
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		const paths = getRuntimePaths();
+		const configuredLoad = hostedSingleProviderModeLoad(home, "openclaw", "configured", 1);
+		const byokProviders = {
+			"user-byok": {
+				kind: "openai-compatible",
+				baseUrl: "https://byok.provider.example.test/v1",
+				model: "user-model",
+				models: [{ id: "user-model" }],
+				apiMode: "openai_responses",
+				managed_by: "user",
+				runtimeEnvName: "OPENAI_API_KEY",
+				apiKeySecretRef: "provider.user-byok.apiKey",
+			},
+		};
+		const terminalTooling = configuredLoad.manifest.projection?.terminalTooling;
+		configuredLoad.manifest = {
+			...configuredLoad.manifest,
+			runtimes: {
+				openclaw: {
+					...configuredLoad.manifest.runtimes.openclaw,
+					provider_ids: ["user-byok"],
+					primary_model: { provider_id: "user-byok", model: "user-model" },
+				},
+			},
+			projection: {
+				...configuredLoad.manifest.projection,
+				providers: byokProviders,
+			},
+			egressProfiles: hostedManifestEgressProfiles({ providers: byokProviders, terminalTooling }),
+		};
+		configuredLoad.secretValues = {
+			...configuredLoad.secretValues,
+			"provider.user-byok.apiKey": "sk-user-byok",
+		};
+		const configured = convergeRuntimeManifest(configuredLoad, paths);
+		expect(configured.installErrors).toEqual([]);
+		writeTestRuntimeAppliedState(paths, configuredLoad, configured);
+		const runtimeSecretFile = join(paths.runtimeSecretFileRoot, "openclaw.json");
+		expect(readFileSync(runtimeSecretFile, "utf-8")).toContain("sk-user-byok");
+
+		const unmanagedLoad = hostedSingleProviderModeLoad(home, "openclaw", "unmanaged", 2);
+		const unmanaged = convergeRuntimeManifest(unmanagedLoad, paths);
+
+		expect(unmanaged.installErrors).toEqual([]);
+		expect(existsSync(runtimeSecretFile)).toBe(false);
+		expect(readSystemdEnvFile(paths, "openclaw-gateway")).not.toContain("OPENAI_API_KEY");
+		expect(readFileSync(join(run, "secrets", "egress-secrets.json"), "utf-8")).toContain(
+			"sk-codex-tool",
+		);
+		expect(existsSync(join(home, ".codex", "config.toml"))).toBe(true);
+	});
+
 	it("does not delete unknown provider projections when applied state is missing", () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
@@ -2763,6 +3276,8 @@ exit 0
 				runtimes: {
 					openclaw: {
 						enabled: true,
+						provider_ids: ["default"],
+						primary_model: { provider_id: "default", model: "gpt-5.4-mini" },
 						install: {
 							authority: "official",
 							method: "official-installer",
@@ -2867,6 +3382,8 @@ exit 0
 				runtimes: {
 					openclaw: {
 						enabled: true,
+						provider_ids: ["openclaw"],
+						primary_model: { provider_id: "openclaw", model: "gpt-5.5" },
 						install: {
 							authority: "official",
 							method: "official-installer",
@@ -2877,6 +3394,11 @@ exit 0
 					},
 					hermes: {
 						enabled: true,
+						provider_ids: ["hermes"],
+						primary_model: {
+							provider_id: "hermes",
+							model: "kimi/kimi-for-coding",
+						},
 						install: {
 							authority: "official",
 							method: "official-installer",
@@ -3151,6 +3673,14 @@ exit 0
 			...withProvider,
 			manifest: {
 				...withProvider.manifest,
+				runtimes: {
+					hermes: {
+						...withProvider.manifest.runtimes.hermes,
+						providerMode: "unmanaged",
+						provider_ids: [],
+						primary_model: undefined,
+					},
+				},
 				projection: {
 					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
 					system: { home },
@@ -3159,7 +3689,8 @@ exit 0
 		};
 		const paths = getRuntimePaths();
 
-		convergeRuntimeManifest(withProvider, paths);
+		const first = convergeRuntimeManifest(withProvider, paths);
+		writeTestRuntimeAppliedState(paths, withProvider, first);
 		const firstRevision = systemdEnvRevision(readSystemdEnvFile(paths, "clawdi-hermes"));
 		expect(existsSync(hermesModelProviderPluginDir(home))).toBe(true);
 
@@ -3307,6 +3838,8 @@ exit 0
 				runtimes: {
 					openclaw: {
 						enabled: true,
+						provider_ids: ["openclaw"],
+						primary_model: { provider_id: "openclaw", model: "gpt-5.5" },
 						install: {
 							authority: "official",
 							method: "official-installer",
@@ -3487,6 +4020,11 @@ exit 0
 					runtimes: {
 						openclaw: {
 							enabled: true,
+							provider_ids: ["openclaw"],
+							primary_model: {
+								provider_id: "openclaw",
+								model: providerCase.model,
+							},
 							install: {
 								authority: "official",
 								method: "official-installer",
@@ -3577,13 +4115,13 @@ exit 0
 							apiMode: "openai_chat",
 							managed_by: "clawdi",
 							runtimeEnvName: "OPENAI_API_KEY",
-							apiKeySecretRef: "provider.clawdi-managed-v2.apiKey",
+							apiKeySecretRef: "tool.codex.apiKey",
 						},
 					},
 					recovery: { cacheManifest: true, allowOfflineBoot: true },
 				},
 				secretValues: {
-					"provider.clawdi-managed-v2.apiKey": "sk-runtime-provider",
+					"tool.codex.apiKey": "sk-runtime-provider",
 				},
 			}),
 		);
@@ -3610,13 +4148,13 @@ exit 0
 		const paths = getRuntimePaths();
 		expectEgressProfileBundleUsesSecretRef(
 			convergence.outputs.egressProfileBundle,
-			"secret://provider.clawdi-managed-v2.apiKey",
+			"secret://tool.codex.apiKey",
 			"sk-runtime-provider",
 		);
 		expectMitmSecretFileIsSidecarOnly(
 			paths,
 			convergence.outputs.egressSecretFile,
-			"secret://provider.clawdi-managed-v2.apiKey",
+			"secret://tool.codex.apiKey",
 			"sk-runtime-provider",
 		);
 		expect(existsSync(join(run, "secrets", "runtimes", "openclaw.json"))).toBe(false);
@@ -3732,7 +4270,7 @@ exit 64
 						openclaw: hostedOpenClawRuntime(),
 					},
 				},
-				secretValues: {},
+				secretValues: TEST_HOSTED_CODEX_SECRET_VALUES,
 			}),
 		);
 
@@ -3781,6 +4319,7 @@ exit 64
 						hermes: {
 							enabled: false,
 							install: { source: "official" },
+							providerMode: "configured",
 							provider_ids: ["default"],
 							primary_model: { provider_id: "default", model: "gpt-test" },
 							paths: { home, workspace: join(home, "clawdi") },
@@ -3853,7 +4392,7 @@ exit 64
 							runtimes: { hermes: hostedHermesRuntime() },
 							bridge: { surfaces: [hostedHermesBridgeSurface()] },
 						},
-						secretValues: {},
+						secretValues: TEST_HOSTED_CODEX_SECRET_VALUES,
 					}),
 			},
 		]);
@@ -6089,7 +6628,11 @@ printf 'ActiveState=active\\nSubState=running\\n'
 					controlPlane: { apiUrl: "https://cloud-api.test" },
 					egressEngine: mitmproxy,
 					runtimes: {
-						openclaw: { enabled: true },
+						openclaw: {
+							enabled: true,
+							provider_ids: ["default"],
+							primary_model: { provider_id: "default", model: "gpt-5.5" },
+						},
 					},
 					projection: {
 						providers: {
@@ -9068,7 +9611,7 @@ exit 64
 							},
 							bridge: { surfaces: [hostedHermesBridgeSurface()] },
 						},
-						secretValues: {},
+						secretValues: TEST_HOSTED_CODEX_SECRET_VALUES,
 					}),
 			},
 		]);
@@ -9269,7 +9812,7 @@ exit 64
 					},
 					bridge: { surfaces: [hostedHermesBridgeSurface()] },
 				},
-				secretValues: {},
+				secretValues: TEST_HOSTED_CODEX_SECRET_VALUES,
 			}),
 		);
 
@@ -9481,7 +10024,11 @@ exit 64
 					issuedAt: "2026-06-15T00:00:00Z",
 					controlPlane: { apiUrl: "https://cloud-api.test" },
 					runtimes: {
-						openclaw: { enabled: true },
+						openclaw: {
+							enabled: true,
+							provider_ids: ["default"],
+							primary_model: { provider_id: "default", model: "gpt-5.5" },
+						},
 						hermes: { enabled: false },
 					},
 					recovery: {},
@@ -9606,7 +10153,11 @@ exit 64
 					controlPlane: { apiUrl: "https://cloud-api.test" },
 					egressEngine: mitmproxy,
 					runtimes: {
-						openclaw: { enabled: true },
+						openclaw: {
+							enabled: true,
+							provider_ids: ["default"],
+							primary_model: { provider_id: "default", model: "gpt-5.5" },
+						},
 						hermes: { enabled: false },
 					},
 					bridge: {
@@ -9750,7 +10301,11 @@ exit 64
 					issuedAt: "2026-06-26T00:00:00Z",
 					controlPlane: { apiUrl: "https://cloud-api.test" },
 					runtimes: {
-						openclaw: { enabled: true },
+						openclaw: {
+							enabled: true,
+							provider_ids: ["default"],
+							primary_model: { provider_id: "default", model: "gpt-5.5" },
+						},
 					},
 					projection: {
 						providers: {
@@ -10402,12 +10957,12 @@ exit 64
 									apiMode: "openai_chat",
 									managed_by: "clawdi",
 									runtimeEnvName: "OPENAI_API_KEY",
-									apiKeySecretRef: "provider.clawdi-managed-v2.apiKey",
+									apiKeySecretRef: "tool.codex.apiKey",
 								},
 							},
 						},
 						secretValues: {
-							"provider.clawdi-managed-v2.apiKey": "sk-runtime",
+							"tool.codex.apiKey": "sk-runtime",
 						},
 					}),
 			},
@@ -10424,13 +10979,13 @@ exit 64
 			const paths = getRuntimePaths();
 			expectEgressProfileBundleUsesSecretRef(
 				convergence.outputs.egressProfileBundle,
-				"secret://provider.clawdi-managed-v2.apiKey",
+				"secret://tool.codex.apiKey",
 				"sk-runtime",
 			);
 			expectMitmSecretFileIsSidecarOnly(
 				paths,
 				convergence.outputs.egressSecretFile,
-				"secret://provider.clawdi-managed-v2.apiKey",
+				"secret://tool.codex.apiKey",
 				"sk-runtime",
 			);
 			expectExistingFileNotToContain(join(run, "secrets", "runtime-secrets.json"), "sk-runtime");
@@ -10464,7 +11019,7 @@ exit 64
 				baseUrl: "https://sub2api.test/v1",
 				model: null,
 				models: [{ id: "gpt-test" }],
-				apiKeySecretRef: "provider.clawdi-managed-v2.apiKey",
+				apiKeySecretRef: "tool.codex.apiKey",
 				secretAvailable: true,
 				reasons: [],
 			});
@@ -10752,7 +11307,7 @@ exit 64
 		}
 	});
 
-	it("does not generate Codex egress profiles without a managed provider secret ref", async () => {
+	it("skips a runtime provider egress profile without disturbing the Codex tool profile", async () => {
 		const home = join(root, "home", "clawdi");
 		const manifestPath = join(root, "hosted-no-provider-secret.json");
 		mkdirSync(home, { recursive: true });
@@ -10790,7 +11345,7 @@ exit 64
 						},
 					},
 				},
-				secretValues: {},
+				secretValues: TEST_HOSTED_CODEX_SECRET_VALUES,
 			}),
 		);
 
@@ -10799,8 +11354,10 @@ exit 64
 		expect("manifest" in loaded).toBe(true);
 		if (!("manifest" in loaded)) throw new Error("expected manifest load success");
 		const profiles = loaded.manifest.egressProfiles?.profiles ?? [];
-		expect(profiles.every((profile) => profile.owner === "runtime-installer")).toBe(true);
-		expect(profiles.some((profile) => profile.kind === "provider")).toBe(false);
+		const providerProfiles = profiles.filter((profile) => profile.kind === "provider");
+		expect(providerProfiles).toHaveLength(1);
+		expect(JSON.stringify(providerProfiles[0])).toContain(TEST_HOSTED_CODEX_SECRET_REF);
+		expect(JSON.stringify(providerProfiles[0])).not.toContain("provider.default.apiKey");
 	});
 
 	it("rejects invalid explicit hosted egress profiles instead of falling back", async () => {

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -293,11 +293,11 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 				schemaVersion: "clawdi.cliNpmBootstrapStatus.v1",
 				status: "installed",
 				source: "npm",
-				packageSpec: "clawdi@0.12.10-beta.51",
+				packageSpec: "clawdi@0.12.10-beta.53",
 				registry: "https://registry.npmjs.org",
 				activePath: managedCli,
 				activeTarget: managedCliTarget,
-				version: "0.12.10-beta.51",
+				version: "0.12.10-beta.53",
 			}),
 		);
 		writeFileSync(
@@ -305,7 +305,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 			JSON.stringify({
 				manifest: {
 					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
-					minimumCliVersion: "0.12.10-beta.51",
+					minimumCliVersion: "0.12.10-beta.53",
 					runtime: "openclaw",
 					deploymentId: "dep_strict_smoke",
 					environmentId: "env_strict_smoke",
@@ -322,29 +322,39 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 					controlPlane: { cloudApiUrl: "https://cloud-api.test" },
 					clawdiCli: {
 						source: "npm:clawdi",
-						packageSpec: "clawdi@0.12.10-beta.51",
+						packageSpec: "clawdi@0.12.10-beta.53",
 						registry: "https://registry.npmjs.org",
 					},
 					runtimes: {
 						openclaw: {
 							enabled: true,
 							install: { source: "official" },
-							provider_ids: ["default"],
-							primary_model: { provider_id: "default", model: "gpt-5" },
+							providerMode: "unmanaged",
+							provider_ids: [],
 							paths: { home, workspace: join(home, "clawdi") },
 						},
 					},
-					providers: {
-						default: {
-							kind: "openai-compatible",
-							status: "error",
-							error: { code: "provider_not_found", message: "fixture provider unavailable" },
+					providers: {},
+					terminalTooling: {
+						codex: {
+							enabled: true,
+							provider_id: "codex-managed",
+							primary_model: { provider_id: "codex-managed", model: "gpt-test" },
+							provider: {
+								kind: "openai-compatible",
+								type: "openai",
+								baseUrl: "https://provider.test/v1",
+								apiMode: "openai_responses",
+								managed_by: "clawdi",
+								runtimeEnvName: "OPENAI_API_KEY",
+								apiKeySecretRef: "tool.codex.apiKey",
+							},
 						},
 					},
 					liveSync: { enabled: false, agents: [] },
 					recovery: { cacheManifest: true, allowOfflineBoot: true },
 				},
-				secretValues: {},
+				secretValues: { "tool.codex.apiKey": "sk-codex-tool" },
 			}),
 		);
 
@@ -358,6 +368,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 					CLAWDI_RUN_DIR: run,
 					CLAWDI_RUNTIME_ALLOW_TEST_INSTALLERS: "1",
 					CLAWDI_RUNTIME_TEST_OPENCLAW_INSTALLER: installer,
+					CLAWDI_CODEX_INSTALL_DISABLED: "1",
 				},
 			);
 			expect(result.code).toBe(0);

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -4215,6 +4215,17 @@ export interface components {
              */
             status: "ok";
         };
+        /** HostedCodexTool */
+        HostedCodexTool: {
+            /**
+             * Enabled
+             * @constant
+             */
+            enabled: true;
+            /** Provider Id */
+            provider_id: string;
+            primary_model: components["schemas"]["HostedRuntimePrimaryModel"];
+        };
         /** HostedEgressEngine */
         HostedEgressEngine: {
             /**
@@ -4410,16 +4421,13 @@ export interface components {
             /** Upstreamport */
             upstreamPort: number;
         };
-        /** HostedRuntimeDesiredState */
-        HostedRuntimeDesiredState: {
+        /** HostedRuntimeConfiguredDesiredState */
+        HostedRuntimeConfiguredDesiredState: {
             /**
              * Enabled
              * @constant
              */
             enabled: true;
-            /** Provider Ids */
-            provider_ids: string[];
-            primary_model: components["schemas"]["HostedRuntimePrimaryModel"];
             install: components["schemas"]["HostedRuntimeInstall"];
             run?: components["schemas"]["HostedRuntimeRunSettings"] | null;
             /** Services */
@@ -4427,6 +4435,14 @@ export interface components {
                 [key: string]: components["schemas"]["HostedRuntimeRunSettings"];
             } | null;
             paths: components["schemas"]["HostedRuntimePaths"];
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            providerMode: "configured";
+            /** Provider Ids */
+            provider_ids: string[];
+            primary_model: components["schemas"]["HostedRuntimePrimaryModel"];
         };
         /** HostedRuntimeInstall */
         HostedRuntimeInstall: {
@@ -4668,6 +4684,34 @@ export interface components {
             persistentPaths: string[];
             /** Openclawcontroluiallowedorigins */
             openclawControlUiAllowedOrigins?: string[] | null;
+        };
+        /** HostedRuntimeTools */
+        HostedRuntimeTools: {
+            codex: components["schemas"]["HostedCodexTool"];
+        } & {
+            [key: string]: unknown;
+        };
+        /** HostedRuntimeUnmanagedDesiredState */
+        HostedRuntimeUnmanagedDesiredState: {
+            /**
+             * Enabled
+             * @constant
+             */
+            enabled: true;
+            install: components["schemas"]["HostedRuntimeInstall"];
+            run?: components["schemas"]["HostedRuntimeRunSettings"] | null;
+            /** Services */
+            services?: {
+                [key: string]: components["schemas"]["HostedRuntimeRunSettings"];
+            } | null;
+            paths: components["schemas"]["HostedRuntimePaths"];
+            /**
+             * @description discriminator enum property added by openapi-typescript
+             * @enum {string}
+             */
+            providerMode: "unmanaged";
+            /** Provider Ids */
+            provider_ids: string[];
         };
         /**
          * InvitationAcceptResponse
@@ -4964,7 +5008,7 @@ export interface components {
             egress_engine?: components["schemas"]["HostedEgressEngine"] | null;
             /** Runtimes */
             runtimes: {
-                [key: string]: components["schemas"]["HostedRuntimeDesiredState"];
+                [key: string]: components["schemas"]["HostedRuntimeConfiguredDesiredState"] | components["schemas"]["HostedRuntimeUnmanagedDesiredState"];
             };
             bridge?: components["schemas"]["HostedRuntimeBridge"] | null;
             live_sync: components["schemas"]["HostedRuntimeLiveSync"];
@@ -4974,10 +5018,7 @@ export interface components {
             mcp?: {
                 [key: string]: unknown;
             } | null;
-            /** Tools */
-            tools?: {
-                [key: string]: unknown;
-            } | null;
+            tools: components["schemas"]["HostedRuntimeTools"];
         };
         /** ProjectCreate */
         ProjectCreate: {

--- a/test-fixtures/runtime-bundle-v2.golden.json
+++ b/test-fixtures/runtime-bundle-v2.golden.json
@@ -9,7 +9,7 @@
 	],
 	"manifest": {
 		"clawdiCli": {
-			"packageSpec": "clawdi@0.12.10-beta.51",
+			"packageSpec": "clawdi@0.12.10-beta.53",
 			"registry": "https://registry.npmjs.org",
 			"source": "npm:clawdi"
 		},
@@ -29,11 +29,11 @@
 			"enabled": true
 		},
 		"locale": { "language": "en", "timezone": "UTC" },
-		"minimumCliVersion": "0.12.10-beta.51",
+		"minimumCliVersion": "0.12.10-beta.53",
 		"providers": {
 			"managed": {
-				"apiKeySecretRef": "provider.managed.apiKey",
-				"apiMode": "responses",
+				"apiKeySecretRef": "tool.codex.apiKey",
+				"apiMode": "openai_chat",
 				"baseUrl": "https://provider.test/v1",
 				"kind": "openai-compatible",
 				"managed_by": "clawdi",
@@ -47,6 +47,7 @@
 			"openclaw": {
 				"enabled": true,
 				"install": { "source": "official" },
+				"providerMode": "configured",
 				"paths": {
 					"home": "/home/clawdi",
 					"workspace": "/home/clawdi/clawdi"
@@ -63,13 +64,29 @@
 			"persistentPaths": ["/home/clawdi"],
 			"user": "clawdi",
 			"workspace": "/home/clawdi/clawdi"
+		},
+		"terminalTooling": {
+			"codex": {
+				"enabled": true,
+				"primary_model": { "model": "gpt-test", "provider_id": "managed" },
+				"provider": {
+					"apiKeySecretRef": "tool.codex.apiKey",
+					"apiMode": "openai_responses",
+					"baseUrl": "https://provider.test/v1",
+					"kind": "openai-compatible",
+					"managed_by": "clawdi",
+					"runtimeEnvName": "OPENAI_API_KEY",
+					"type": "openai"
+				},
+				"provider_id": "managed"
+			}
 		}
 	},
 	"schemaVersion": "clawdi.hosted-runtime.bundle.v2",
 	"secretValues": {
-		"provider.managed.apiKey": "sk-provider-golden",
+		"tool.codex.apiKey": "sk-provider-golden",
 		"secret://channels/telegram/clawdi_50000000000000000000000000000005/agent-token": "123456789:telegram-agent-golden",
 		"secret://channels/telegram/clawdi_50000000000000000000000000000005/placeholder-token": "999999999:9ded1453047ec0a48ec3b735075f7448"
 	},
-	"sourceRevision": "770c65d7b9903e89f31d6ba4417bf70cf2c755366d8e44fb4e20a3c4bad9d6a4"
+	"sourceRevision": "40a7584d7613031f489606ff215523af06f681df4011cfc9ed718beefd09c848"
 }


### PR DESCRIPTION
# Agent v2: runtime-only unmanaged provider mode + Hosted Codex tool plane (beta.53)

## What

Two commits with a strict release boundary:

1. `release(cli): prepare beta.53 unmanaged runtime artifact` — the immutable CLI artifact (`clawdi@0.12.10-beta.53`). CLI-only changes; must be published to npm **before** the second commit is deployed.
2. `feat(runtime): activate unmanaged provider authority` — Cloud backend contract activation. Raises the Agent v2 manifest minimum CLI version to `0.12.10-beta.53`.

## Changes

### Runtime provider contract
- `HostedRuntimeDesiredState` becomes a discriminated union on `providerMode`: `configured` (non-empty `provider_ids` + `primary_model`) or `unmanaged` (empty `provider_ids`, no primary model). Missing/mixed contracts fail validation — no fallback.
- Unmanaged runtime units must contain no `OPENAI_API_KEY` / `CLAWDI_MANAGED_OPENAI_API_KEY` env, no `clawdi-egress-placeholder` value, and no `provider.*` secret ref. Enforced in both the backend schema and the CLI zod contract, plus bundle/response-level checks on `secretValues`.
- Removed all legacy inference paths: no provider binding from `default`/runtime-named provider keys, no primary-model inference from the first provider, no `CLAWDI_MANAGED_OPENAI_API_KEY` → `OPENAI_API_KEY` env rewrite.

### Hosted Codex terminal tool (separate from runtime providers)
- `tools.codex` is a typed, required Cloud contract; the manifest projects it under `terminalTooling` with a Clawdi-managed `openai_responses` provider pinned to secret ref `tool.codex.apiKey`.
- The CLI writes a single Clawdi-owned default `$CODEX_HOME/config.toml` (no named profile, no `--profile`, no API key on disk) and installs the audited exact `@openai/codex@0.142.4`, verifying installed identity from the npm `package.json` and failing closed on mismatch. The `CLAWDI_CODEX_PACKAGE_SPEC` override is removed.
- Codex never enters runtime provider IDs, primary model, provider health, or applied-provider observations.

### Managed egress credential rewrite
- Provider egress profiles now match only requests carrying `Authorization: Bearer clawdi-egress-placeholder` on the managed gateway host. Real BYOK bearer tokens and requests without an Authorization header pass through unchanged. Profile dedupe keys on host + secret ref.

### v1 unchanged
- `clawdi ai-provider apply` named-profile path, `AGENT_TARGET_CONTRACTS`, and `CODEX_PROFILE_NAME` are untouched.

## Verification (local, isolated Docker)
- CLI suite: 923+ pass (bun, isolated); egress addon unittest 13/13.
- Backend: 1214 passed, 1 pre-existing unrelated flake (`test_project_isolation.py::test_unbound_cli_key_can_pin_any_project`) that passes in isolation; file untouched by this branch.
- typecheck, Biome, Ruff (lint + format), publish-manifest check, generated OpenAPI client consistency: all green.

## Release order (do not merge/publish out of order)
1. Publish commit A artifact `clawdi@0.12.10-beta.53` to npm; prove with `npm view clawdi@0.12.10-beta.53 version`.
2. Only then deploy commit B (Cloud activation).
3. Then Hosted activation (companion PR in `clawdi-hosted`).

v2 is unpublished: no compatibility migrations or legacy fallback paths were added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
