### PR TITLE
ci: drop node_modules cache from setup-bun-ci

### DIFF
--- a/.github/actions/setup-bun-ci/action.yml
+++ b/.github/actions/setup-bun-ci/action.yml
@@ -1,7 +1,7 @@
 # Reusable composite action: set up Bun + install workspace dependencies
 # with a shared cache. Used by JS-dependent CI jobs so caching is consistent.
 name: Setup Bun CI
-description: Install Bun and run `bun install --frozen-lockfile` with lockfile-scoped cache
+description: Install Bun and run `bun install --frozen-lockfile` with Bun download cache
 
 inputs:
   node-version:
@@ -33,12 +33,6 @@ runs:
         key: bun-cache-${{ runner.os }}-${{ runner.arch }}-${{ inputs.bun-version }}-${{ hashFiles('bun.lock') }}
         restore-keys: |
           bun-cache-${{ runner.os }}-${{ runner.arch }}-${{ inputs.bun-version }}-
-
-    - name: Cache workspace install
-      uses: actions/cache@v5
-      with:
-        path: node_modules
-        key: bun-node-modules-v3-${{ runner.os }}-${{ runner.arch }}-${{ inputs.node-version }}-${{ inputs.bun-version }}-${{ hashFiles('bun.lock') }}
 
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
## Summary
- remove the `node_modules` cache from `.github/actions/setup-bun-ci`
- keep the Bun download cache (`~/.bun/install/cache`) and its existing `restore-keys`
- rely on a fresh `bun install --frozen-lockfile` in each job instead of re-uploading `node_modules`

## Why
The composite action was caching `node_modules` with a lockfile-only key. Any `bun.lock` change caused parallel JS jobs to miss and each upload a large workspace tree in `Post Run ./.github/actions/setup-bun-ci`.

## Measurements
Clean baseline for apples-to-apples comparison:
- `Client CI` on `main@969b06cc`: run `29338744116`
- `Backend CI` on `main@969b06cc`: run `29338743862`

PR runs:
- `Client CI`: run `29343098907`
  - attempt 1 hit an unrelated `cli-test` hang in `Test CLI`; I cancelled it after confirming cache-save stayed at `1s`
  - attempt 2 reran only `cli-test`, which completed normally
- `Backend CI`: run `29343098892`

### Client CI per-job delta
| Job | Baseline total | PR total | Delta | Baseline post-cache | PR post-cache |
| --- | ---: | ---: | ---: | ---: | ---: |
| `typecheck (web)` | 314s | 81s | -233s | 238s | 1s |
| `typecheck (cli)` | 256s | 91s | -165s | 170s | 1s |
| `typecheck (shared)` | 96s | 88s | -8s | 1s | 1s |
| `cli-test` | 281s | 94s | -187s | 170s | 1s |
| `lint` | 101s | 211s | +110s | 1s | 1s |
| `build` | 90s | 82s | -8s | 1s | 0s |

Notes:
- The large wins are exactly where `node_modules` upload dominated before.
- `lint` was slower on this PR run due to a slow `setup-bun-ci` attempt on that runner, but its cache-save tail still dropped to `1s`.
- Critical path to `build` success dropped from `10m58s` on baseline main to `5m17s` on the PR run.

### Backend CI
| Job | Baseline total | PR total | Delta | Baseline post-cache | PR post-cache |
| --- | ---: | ---: | ---: | ---: | ---: |
| `lint-and-typecheck` | 97s | 106s | +9s | 1s | 1s |

### Install timing with warm Bun download cache
Local:
- `rm -rf node_modules && /usr/bin/time -p bun install --frozen-lockfile` -> `real 0.50`

GitHub Actions (`cli-test` rerun logs in run `29343098907`, attempt 2):
- Bun download cache restore hit: `876 MB` archive restored successfully
- `bun install --frozen-lockfile`: `2026-07-14T15:08:35.411Z` -> `2026-07-14T15:08:36.457Z` (`~1.0s`)

## Verification
- local: `rm -rf node_modules && /usr/bin/time -p bun install --frozen-lockfile`
- GitHub Actions: `Client CI #29343098907`, `Backend CI #29343098892`
