### PR TITLE
fix(web): migrate hosted deploy client and v2 flow to the live hosted contract

### DIFF
--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -9,6 +9,7 @@ import type {
 	RebindAgentAiProviderRequest,
 	SetAgentEnabledRequest,
 } from "@/hosted/billing/contracts";
+import { normalizeHostedLanguage } from "@/hosted/billing/deploy/language-timezone-controls";
 import { BillingApiError, normalizeBillingError, toastBillingError } from "@/hosted/billing/errors";
 import { billingKeys, useHostedDeployments } from "@/hosted/billing/hooks";
 import { deploymentRuntime, runtimeEnvironmentId } from "@/hosted/runtimes";
@@ -104,8 +105,8 @@ export function useSetAgentLanguageTimezone() {
 		}) => {
 			const body: SetAgentEnabledRequest = {
 				enabled: true,
-				language: vars.language || null,
-				timezone: vars.timezone || null,
+				language: normalizeHostedLanguage(vars.language),
+				timezone: vars.timezone.trim() || null,
 			};
 			return client.setAgentLanguageTimezone(vars.id, vars.agentType, body);
 		},

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -135,6 +135,7 @@ import { type HostedRuntime, runtimeConsoleUrl, runtimeDisplayName } from "@/hos
 import { hostedRuntimeStatusView } from "@/hosted/use-hosted-agent-tiles";
 import { useAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import { AuthBadge, ProviderTypeChip } from "@/hosted/v2/ai-providers/ai-providers-ui";
+import { authCardLabel } from "@/hosted/v2/ai-providers/auth-card-label";
 import {
 	dedupeProviderIds,
 	firstModelForProvider,
@@ -178,6 +179,7 @@ import { sessionListQueryOptions } from "@/lib/session-queries";
 import { cn } from "@/lib/utils";
 
 type Runtime = HostedRuntime;
+type AiBindingMode = "unmanaged" | "configured";
 type DeploymentStatus = ReturnType<typeof parseDeploymentStatus>;
 type TermChangeConfirmation = {
 	clientSecret: string;
@@ -1218,35 +1220,50 @@ function AiProviderTab({
 	);
 	// Selected-runtime binding: the deployment owns one runtime in the v2 model.
 	const binding = ci?.ai_provider_bindings?.[runtime];
-	const legacyProviderRef = binding?.provider_id ?? ci?.ai_provider_id ?? null;
+	const currentAuthKind = binding?.auth_kind ?? ci?.ai_provider_auth_kind ?? "managed";
+	const initialMode: AiBindingMode = currentAuthKind === "unmanaged" ? "unmanaged" : "configured";
+	const legacyProviderRef =
+		currentAuthKind === "unmanaged" ? null : (binding?.provider_id ?? ci?.ai_provider_id ?? null);
 	const rawProviderRefs =
-		binding?.provider_ids && binding.provider_ids.length > 0
-			? binding.provider_ids
-			: legacyProviderRef
-				? [legacyProviderRef]
-				: [MANAGED_PROVIDER_ID];
+		currentAuthKind === "unmanaged"
+			? []
+			: binding?.provider_ids && binding.provider_ids.length > 0
+				? binding.provider_ids
+				: legacyProviderRef
+					? [legacyProviderRef]
+					: [MANAGED_PROVIDER_ID];
 	const primaryProviderRef =
-		primaryModelProviderId(binding?.primary_model) ??
-		legacyProviderRef ??
-		rawProviderRefs[0] ??
-		MANAGED_PROVIDER_ID;
+		currentAuthKind === "unmanaged"
+			? MANAGED_PROVIDER_ID
+			: (primaryModelProviderId(binding?.primary_model) ??
+				legacyProviderRef ??
+				rawProviderRefs[0] ??
+				MANAGED_PROVIDER_ID);
 	const initialPrimaryChoice =
-		agentChoiceFromProviderRef(primaryProviderRef, list) ??
-		(isManagedProviderId(primaryProviderRef)
+		currentAuthKind === "unmanaged"
 			? MANAGED_AI_CHOICE
-			: unresolvedProviderChoice(primaryProviderRef));
-	const initialProviderChoices = normalizeSelectedProviderIds(
-		rawProviderRefs
-			.map((providerRef) => agentChoiceFromProviderRef(providerRef, list))
-			.filter((choice): choice is string => Boolean(choice)),
-		initialPrimaryChoice,
-	);
+			: (agentChoiceFromProviderRef(primaryProviderRef, list) ??
+				(isManagedProviderId(primaryProviderRef)
+					? MANAGED_AI_CHOICE
+					: unresolvedProviderChoice(primaryProviderRef)));
+	const initialProviderChoices =
+		currentAuthKind === "unmanaged"
+			? []
+			: normalizeSelectedProviderIds(
+					rawProviderRefs
+						.map((providerRef) => agentChoiceFromProviderRef(providerRef, list))
+						.filter((choice): choice is string => Boolean(choice)),
+					initialPrimaryChoice,
+				);
 	const currentModel =
-		primaryModelValue(binding?.primary_model) ||
-		primaryModelValue(ci?.primary_model) ||
-		firstModelForProvider(initialPrimaryChoice, list);
+		currentAuthKind === "unmanaged"
+			? ""
+			: primaryModelValue(binding?.primary_model) ||
+				primaryModelValue(ci?.primary_model) ||
+				firstModelForProvider(initialPrimaryChoice, list);
 
 	const [selectedProviders, setSelectedProviders] = useState<string[]>(initialProviderChoices);
+	const [bindingMode, setBindingMode] = useState<AiBindingMode>(initialMode);
 	const [primaryProviderChoice, setPrimaryProviderChoice] = useState(initialPrimaryChoice);
 	const [primaryModel, setPrimaryModel] = useState<string>(
 		currentModel || MANAGED_PRIMARY_MODEL_FALLBACK,
@@ -1259,6 +1276,7 @@ function AiProviderTab({
 	// the new truth. This is React's "adjust state during render" idiom, which
 	// replaces an effect that re-ran on every keystroke.
 	const bindingIdentity = JSON.stringify([
+		initialMode,
 		initialProviderChoices,
 		initialPrimaryChoice,
 		currentModel,
@@ -1266,6 +1284,7 @@ function AiProviderTab({
 	const [syncedIdentity, setSyncedIdentity] = useState(bindingIdentity);
 	if (bindingIdentity !== syncedIdentity) {
 		setSyncedIdentity(bindingIdentity);
+		setBindingMode(initialMode);
 		setSelectedProviders(initialProviderChoices);
 		setPrimaryProviderChoice(initialPrimaryChoice);
 		setPrimaryModel(currentModel || MANAGED_PRIMARY_MODEL_FALLBACK);
@@ -1276,11 +1295,14 @@ function AiProviderTab({
 	);
 	const initialSelectedIdentity = JSON.stringify(initialProviderChoices);
 	const dirty =
-		selectedIdentity !== initialSelectedIdentity ||
-		primaryProviderChoice !== initialPrimaryChoice ||
-		primaryModel !== (currentModel || MANAGED_PRIMARY_MODEL_FALLBACK);
+		bindingMode !== initialMode ||
+		(bindingMode === "configured" &&
+			(selectedIdentity !== initialSelectedIdentity ||
+				primaryProviderChoice !== initialPrimaryChoice ||
+				primaryModel !== (currentModel || MANAGED_PRIMARY_MODEL_FALLBACK)));
 
 	function setPrimaryProvider(choice: string) {
+		setBindingMode("configured");
 		const previousCatalog = modelIdsForProvider(primaryProviderChoice, list);
 		const nextCatalog = modelIdsForProvider(choice, list);
 		const fallback = firstModelForProvider(choice, list);
@@ -1301,6 +1323,7 @@ function AiProviderTab({
 	}
 
 	function toggleProvider(choice: string) {
+		setBindingMode("configured");
 		const selected = selectedProviders.includes(choice);
 		let next =
 			choice === MANAGED_AI_CHOICE && selectedProviders.some(isUnresolvedProviderChoice)
@@ -1321,6 +1344,19 @@ function AiProviderTab({
 	}
 
 	function apply() {
+		if (bindingMode === "unmanaged") {
+			const body: RebindAgentAiProviderRequest = { ai_provider_auth_kind: "unmanaged" };
+			setProvider.mutate(
+				{ id: deployment.id, agentType: runtime, body },
+				{
+					onSuccess: () =>
+						toast.success("Provider updated", {
+							description: "This runtime now expects provider setup inside the agent.",
+						}),
+				},
+			);
+			return;
+		}
 		const selectedChoices = normalizeSelectedProviderIds(selectedProviders, primaryProviderChoice);
 		const providerRefs = selectedChoices
 			.map((choice) => agentProviderRefFromChoice(choice, customProviders))
@@ -1388,14 +1424,29 @@ function AiProviderTab({
 			<div className="flex flex-col gap-2">
 				<button
 					type="button"
+					onClick={() => setBindingMode("unmanaged")}
+					className={selectableCard(bindingMode === "unmanaged")}
+				>
+					<div className="flex items-center justify-between gap-2">
+						<span className="text-sm font-medium">{authCardLabel("unmanaged")}</span>
+						{bindingMode === "unmanaged" ? <Badge variant="secondary">Current</Badge> : null}
+					</div>
+					<p className="mt-0.5 text-sm text-muted-foreground">
+						Remove the hosted provider binding and configure model access inside the runtime.
+					</p>
+				</button>
+				<button
+					type="button"
 					onClick={() => toggleProvider(MANAGED_AI_CHOICE)}
-					className={selectableCard(selectedProviders.includes(MANAGED_AI_CHOICE))}
+					className={selectableCard(
+						bindingMode === "configured" && selectedProviders.includes(MANAGED_AI_CHOICE),
+					)}
 				>
 					<div className="flex items-center justify-between gap-2">
 						<span className="text-sm font-medium">Managed by Clawdi</span>
-						{primaryProviderChoice === MANAGED_AI_CHOICE ? (
+						{bindingMode === "configured" && primaryProviderChoice === MANAGED_AI_CHOICE ? (
 							<Badge variant="secondary">Primary</Badge>
-						) : selectedProviders.includes(MANAGED_AI_CHOICE) ? (
+						) : bindingMode === "configured" && selectedProviders.includes(MANAGED_AI_CHOICE) ? (
 							<Badge variant="outline">Bound</Badge>
 						) : null}
 					</div>
@@ -1412,20 +1463,23 @@ function AiProviderTab({
 						title="Couldn't load providers"
 					/>
 				) : null}
-				{selectedProviders.filter(isUnresolvedProviderChoice).map((choice) => (
-					<button key={choice} type="button" disabled className={selectableCard(true)}>
-						<div className="flex items-center justify-between gap-2">
-							<span className="text-sm font-medium">Provider unavailable</span>
-							<Badge variant="secondary">In use</Badge>
-						</div>
-						<p className="mt-0.5 text-sm text-muted-foreground">
-							This runtime is bound to {unresolvedProviderRef(choice)}, but that provider could not
-							be loaded. Choose Managed by Clawdi to replace it.
-						</p>
-					</button>
-				))}
+				{bindingMode === "configured"
+					? selectedProviders.filter(isUnresolvedProviderChoice).map((choice) => (
+							<button key={choice} type="button" disabled className={selectableCard(true)}>
+								<div className="flex items-center justify-between gap-2">
+									<span className="text-sm font-medium">Provider unavailable</span>
+									<Badge variant="secondary">In use</Badge>
+								</div>
+								<p className="mt-0.5 text-sm text-muted-foreground">
+									This runtime is bound to {unresolvedProviderRef(choice)}, but that provider could
+									not be loaded. Choose Managed by Clawdi to replace it.
+								</p>
+							</button>
+						))
+					: null}
 				{customProviders.map((p) => {
-					const selected = selectedProviders.includes(p.provider_id);
+					const selected =
+						bindingMode === "configured" && selectedProviders.includes(p.provider_id);
 					return (
 						<button
 							key={p.provider_id}
@@ -1443,7 +1497,7 @@ function AiProviderTab({
 									{providerCatalogDescription(p)}
 								</span>
 							</span>
-							{primaryProviderChoice === p.provider_id ? (
+							{bindingMode === "configured" && primaryProviderChoice === p.provider_id ? (
 								<Badge variant="secondary">Primary</Badge>
 							) : selected ? (
 								<Badge variant="outline">Bound</Badge>
@@ -1463,18 +1517,25 @@ function AiProviderTab({
 				</Button>
 			</div>
 
-			<AgentPrimaryModelPicker
-				providers={list}
-				customProviders={customProviders}
-				selectedProviderChoices={normalizeSelectedProviderIds(
-					selectedProviders,
-					primaryProviderChoice,
-				)}
-				primaryProviderChoice={primaryProviderChoice}
-				primaryModel={primaryModel}
-				onPrimaryProviderChange={setPrimaryProvider}
-				onPrimaryModelChange={setPrimaryModel}
-			/>
+			{bindingMode === "unmanaged" ? (
+				<p className="text-sm text-muted-foreground">
+					This runtime now carries no hosted provider binding. Configure models inside the agent
+					after it starts.
+				</p>
+			) : (
+				<AgentPrimaryModelPicker
+					providers={list}
+					customProviders={customProviders}
+					selectedProviderChoices={normalizeSelectedProviderIds(
+						selectedProviders,
+						primaryProviderChoice,
+					)}
+					primaryProviderChoice={primaryProviderChoice}
+					primaryModel={primaryModel}
+					onPrimaryProviderChange={setPrimaryProvider}
+					onPrimaryModelChange={setPrimaryModel}
+				/>
+			)}
 
 			<div className="flex items-center gap-2">
 				<Button
@@ -1482,9 +1543,11 @@ function AiProviderTab({
 					disabled={
 						!dirty ||
 						setProvider.isPending ||
-						(providers.isLoading &&
+						(bindingMode === "configured" &&
+							providers.isLoading &&
 							selectedProviders.some((choice) => choice !== MANAGED_AI_CHOICE)) ||
-						(!!providers.error &&
+						(bindingMode === "configured" &&
+							!!providers.error &&
 							selectedProviders.some(
 								(choice) => choice !== MANAGED_AI_CHOICE && !isUnresolvedProviderChoice(choice),
 							))

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -131,8 +131,8 @@ export function useBillingClient() {
 				unwrapDeploy(await api.POST("/v2/subscription/resume", { body })),
 			getUsage: async () => unwrapDeploy(await api.GET("/v2/usage")),
 
-			getMe: async () => unwrapDeploy(await api.GET("/me")),
-			getLegacyAgentEnvironments: async () => unwrapDeploy(await api.GET("/agent-environments")),
+			getMe: async () => unwrapDeploy(await api.GET("/v1/me")),
+			getLegacyAgentEnvironments: async () => unwrapDeploy(await api.GET("/v1/agent-environments")),
 
 			listDeployments: async () => unwrapDeploy(await api.GET("/v2/deployments")),
 			createDeployment: async (body: DeployRequest, idempotencyKey: string) =>

--- a/apps/web/src/hosted/billing/components/stripe-checkout.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/stripe-checkout.logic.test.ts
@@ -40,7 +40,11 @@ describe("stripe checkout logic", () => {
 			plan_slug: "compute_performance",
 			billing_term_months: 12,
 			ui_mode: CHECKOUT_ELEMENTS_UI_MODE,
-			deploy_config: { compute_plan_slug: "compute_performance" },
+			deploy_config: {
+				compute_plan_slug: "compute_performance",
+				runtime: "hermes",
+				ai_provider_auth_kind: "unmanaged",
+			},
 		};
 
 		expect(buildHostedCheckoutFallbackRequest(request)).toEqual({

--- a/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
@@ -18,13 +18,11 @@ describe("buildHostedDeployRequest", () => {
 		expect("personality" in request).toBe(false);
 		expect(request).toMatchObject({
 			compute_plan_slug: "compute_performance",
-			channel: null,
 			runtime: "openclaw",
 			language: "en",
 			timezone: "America/Los_Angeles",
 			ai_provider_auth_kind: "managed",
 			config: {
-				channel: null,
 				runtime: "openclaw",
 				language: "en",
 				timezone: "America/Los_Angeles",
@@ -71,5 +69,30 @@ describe("buildHostedDeployRequest", () => {
 		});
 		expect("provider_ids" in (request.config ?? {})).toBe(false);
 		expect("ai_provider_id" in (request.config ?? {})).toBe(false);
+	});
+
+	test("serializes explicit unmanaged deploys without provider material", () => {
+		const request = buildHostedDeployRequest({
+			computePlanSlug: "compute_free",
+			runtime: "hermes",
+			persona: {
+				language: "",
+				timezone: "",
+			},
+			aiFields: { ai_provider_auth_kind: "unmanaged" },
+		});
+
+		expect(request).toEqual({
+			compute_plan_slug: "compute_free",
+			runtime: "hermes",
+			language: null,
+			timezone: null,
+			ai_provider_auth_kind: "unmanaged",
+			config: {
+				runtime: "hermes",
+				language: null,
+				timezone: null,
+			},
+		});
 	});
 });

--- a/apps/web/src/hosted/billing/deploy/deploy-request.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-request.ts
@@ -1,4 +1,5 @@
 import type { DeployRequest, HostedConfigRequest } from "@/hosted/billing/contracts";
+import { normalizeHostedLanguage } from "@/hosted/billing/deploy/language-timezone-controls";
 import type { HostedRuntime } from "@/hosted/runtimes";
 
 type DeployPersona = {
@@ -7,6 +8,7 @@ type DeployPersona = {
 };
 
 type ComputePlanSlug = DeployRequest["compute_plan_slug"];
+export type DeployAiFields = Pick<DeployRequest, "ai_provider_auth_kind"> & Partial<DeployRequest>;
 
 export function buildHostedDeployRequest({
 	computePlanSlug,
@@ -17,23 +19,25 @@ export function buildHostedDeployRequest({
 	computePlanSlug: ComputePlanSlug;
 	runtime: HostedRuntime;
 	persona: DeployPersona;
-	aiFields: Partial<DeployRequest>;
+	aiFields: DeployAiFields;
 }): DeployRequest {
+	const language = normalizeHostedLanguage(persona.language);
+	const timezone = persona.timezone.trim() || null;
+	const { ai_provider_auth_kind, ...restAiFields } = aiFields;
 	const personaFields = {
-		language: persona.language || null,
-		timezone: persona.timezone || null,
+		language,
+		timezone,
 	};
 	const config: HostedConfigRequest = {
-		channel: null,
 		runtime,
 		...personaFields,
 	};
 	return {
 		compute_plan_slug: computePlanSlug,
-		channel: null,
 		runtime,
 		config,
 		...personaFields,
-		...aiFields,
+		ai_provider_auth_kind,
+		...restAiFields,
 	};
 }

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -2,7 +2,16 @@
 
 import { isFirstPartyManagedAiProvider } from "@clawdi/shared";
 import { useLocation, useRouter } from "@tanstack/react-router";
-import { CalendarClock, Cpu, Plus, RefreshCw, Rocket, Sparkles, Zap } from "lucide-react";
+import {
+	CalendarClock,
+	Cpu,
+	Plus,
+	RefreshCw,
+	Rocket,
+	Settings2,
+	Sparkles,
+	Zap,
+} from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { type ApiErrorNormalizer, ApiErrorPanel } from "@/components/api-error-panel";
@@ -45,7 +54,10 @@ import type {
 	Plan,
 } from "@/hosted/billing/contracts";
 import { usesActiveFreeComputeSlot } from "@/hosted/billing/deploy/deploy-model";
-import { buildHostedDeployRequest } from "@/hosted/billing/deploy/deploy-request";
+import {
+	buildHostedDeployRequest,
+	type DeployAiFields,
+} from "@/hosted/billing/deploy/deploy-request";
 import {
 	browserTimezone,
 	LANGUAGE_OPTIONS,
@@ -84,6 +96,7 @@ import { type HostedRuntime, runtimeBlurb, runtimeDisplayName } from "@/hosted/r
 import { AddProviderDialog } from "@/hosted/v2/ai-providers/add-provider-dialog";
 import { useAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import { AuthBadge, ProviderTypeChip } from "@/hosted/v2/ai-providers/ai-providers-ui";
+import { authCardLabel } from "@/hosted/v2/ai-providers/auth-card-label";
 import {
 	dedupeProviderIds,
 	firstModelForProvider,
@@ -109,6 +122,7 @@ import { isApiAuthError, normalizeApiError } from "@/lib/api-errors";
 import { cn } from "@/lib/utils";
 
 type Compute = "free" | "performance";
+type AiAccessMode = "unmanaged" | "configured";
 type ComputePlanSlug = DeployRequest["compute_plan_slug"];
 type NativeDeployCheckout = {
 	clientSecret: string;
@@ -311,7 +325,8 @@ export function DeployWizard() {
 		null,
 	);
 
-	const [runtime, setRuntime] = useState<HostedRuntime>("hermes");
+	const [runtime, setRuntime] = useState<HostedRuntime | null>(null);
+	const [aiAccessMode, setAiAccessMode] = useState<AiAccessMode>("unmanaged");
 	const [aiProviderChoices, setAiProviderChoices] = useState<string[]>([MANAGED_AI_CHOICE]);
 	const [primaryProviderChoice, setPrimaryProviderChoice] = useState(MANAGED_AI_CHOICE);
 	const [primaryModel, setPrimaryModel] = useState(MANAGED_PRIMARY_MODEL_FALLBACK);
@@ -359,13 +374,14 @@ export function DeployWizard() {
 			? !!perfPlan && !!perfOfferSelection
 			: !!freePlan && !freeSlotUnavailable;
 	const planReady = !plans.isLoading && computePlanReady;
-	const canSubmit = planReady && !submitting;
+	const canSubmit = planReady && runtime !== null && !submitting;
 
 	function selectCreatedProvider(providerId: string) {
 		createdProviderGuardRef.current = {
 			providerId,
 			dataUpdatedAt: aiProviders.dataUpdatedAt,
 		};
+		setAiAccessMode("configured");
 		setAiProviderChoices([providerId]);
 		setPrimaryProvider(providerId);
 	}
@@ -472,6 +488,7 @@ export function DeployWizard() {
 	}
 
 	function setPrimaryProvider(choice: string) {
+		setAiAccessMode("configured");
 		const providers = aiProviders.data?.providers ?? [];
 		const previousCatalog = modelIdsForProvider(primaryProviderChoice, providers);
 		const nextCatalog = modelIdsForProvider(choice, providers);
@@ -493,6 +510,7 @@ export function DeployWizard() {
 	}
 
 	function toggleAiProviderChoice(choice: string) {
+		setAiAccessMode("configured");
 		const selected = aiProviderChoices.includes(choice);
 		let next = selected
 			? aiProviderChoices.filter((item) => item !== choice)
@@ -509,7 +527,10 @@ export function DeployWizard() {
 		}
 	}
 
-	function aiDeployFields(): Partial<DeployRequest> | null {
+	function aiDeployFields(): DeployAiFields | null {
+		if (aiAccessMode === "unmanaged") {
+			return { ai_provider_auth_kind: "unmanaged" };
+		}
 		const selectedChoices = normalizeSelectedProviderIds(aiProviderChoices, primaryProviderChoice);
 		const providerRefs = selectedChoices
 			.map((choice) => providerRefFromChoice(choice, providerList))
@@ -536,7 +557,7 @@ export function DeployWizard() {
 			.filter((choice) => choice !== MANAGED_AI_CHOICE)
 			.map((choice) => providerList.find((provider) => provider.provider_id === choice))
 			.filter((provider): provider is AiProvider => Boolean(provider));
-		const body: Partial<DeployRequest> = {
+		const body: DeployAiFields = {
 			ai_provider_id: primaryProvider ? aiProviderRuntimeId(primaryProvider) : null,
 			ai_provider_auth_kind: primaryKind,
 			provider_ids: providerRefs,
@@ -561,7 +582,10 @@ export function DeployWizard() {
 		return body;
 	}
 
-	function buildDeployRequest(aiFields: Partial<DeployRequest>): DeployRequest {
+	function buildDeployRequest(aiFields: DeployAiFields): DeployRequest {
+		if (!runtime) {
+			throw new Error("Choose a runtime before deploying.");
+		}
 		const computePlanSlug: ComputePlanSlug =
 			compute === "performance" ? COMPUTE_PERFORMANCE_SLUG : COMPUTE_FREE_SLUG;
 		return buildHostedDeployRequest({
@@ -632,6 +656,12 @@ export function DeployWizard() {
 		if (!canSubmit) return;
 		setSubmitting(true);
 		try {
+			if (!runtime) {
+				toast.error("Choose a runtime", {
+					description: "Select OpenClaw or Hermes before deploying.",
+				});
+				return;
+			}
 			const aiFields = aiDeployFields();
 			if (!aiFields) return;
 			const deployConfig = buildDeployRequest(aiFields);
@@ -697,14 +727,17 @@ export function DeployWizard() {
 	}
 
 	const deployLabel = compute === "performance" ? "Continue to checkout" : "Deploy agent";
-	const selectedProviderCount = normalizeSelectedProviderIds(
-		aiProviderChoices,
-		primaryProviderChoice,
-	).length;
-	const aiSummary = `${providerChoiceLabel(primaryProviderChoice, providerList)}${
-		selectedProviderCount > 1 ? ` +${selectedProviderCount - 1}` : ""
-	}`;
-	const runtimeSummary = runtimeDisplayName(runtime);
+	const selectedProviderCount =
+		aiAccessMode === "configured"
+			? normalizeSelectedProviderIds(aiProviderChoices, primaryProviderChoice).length
+			: 0;
+	const aiSummary =
+		aiAccessMode === "unmanaged"
+			? authCardLabel("unmanaged")
+			: `${providerChoiceLabel(primaryProviderChoice, providerList)}${
+					selectedProviderCount > 1 ? ` +${selectedProviderCount - 1}` : ""
+				}`;
+	const runtimeSummary = runtime ? runtimeDisplayName(runtime) : null;
 	const summaryLine = [
 		`${compute === "performance" ? "Performance" : "Free"} compute`,
 		aiSummary,
@@ -773,6 +806,11 @@ export function DeployWizard() {
 							description={runtimeBlurb("openclaw")}
 						/>
 					</div>
+					{runtime ? null : (
+						<p className="text-xs text-muted-foreground">
+							Choose a runtime before you deploy. The hosted API no longer applies a default.
+						</p>
+					)}
 				</SettingsSection>
 
 				<SettingsSection
@@ -781,7 +819,25 @@ export function DeployWizard() {
 				>
 					<div className={TWO_TILE_GRID_CLASS}>
 						<EntityChoiceCard
-							selected={aiProviderChoices.includes(MANAGED_AI_CHOICE)}
+							selected={aiAccessMode === "unmanaged"}
+							onClick={() => setAiAccessMode("unmanaged")}
+							icon={
+								<IconChip tint="bg-muted text-muted-foreground">
+									<Settings2 />
+								</IconChip>
+							}
+							title={authCardLabel("unmanaged")}
+							description="Deploy first, then configure model access inside the runtime."
+							badge={
+								<Badge variant={aiAccessMode === "unmanaged" ? "secondary" : "outline"}>
+									{aiAccessMode === "unmanaged" ? "Default" : "Optional"}
+								</Badge>
+							}
+						/>
+						<EntityChoiceCard
+							selected={
+								aiAccessMode === "configured" && aiProviderChoices.includes(MANAGED_AI_CHOICE)
+							}
 							onClick={() => toggleAiProviderChoice(MANAGED_AI_CHOICE)}
 							icon={
 								<IconChip tint="bg-primary/10 text-primary">
@@ -792,7 +848,9 @@ export function DeployWizard() {
 							description="AI Credits from your wallet."
 							badge={
 								<Badge variant="secondary">
-									{primaryProviderChoice === MANAGED_AI_CHOICE ? "Primary" : "Managed"}
+									{aiAccessMode === "configured" && primaryProviderChoice === MANAGED_AI_CHOICE
+										? "Primary"
+										: "Managed"}
 								</Badge>
 							}
 						/>
@@ -811,7 +869,9 @@ export function DeployWizard() {
 						{providerList.map((provider) => (
 							<EntityChoiceCard
 								key={provider.provider_id}
-								selected={aiProviderChoices.includes(provider.provider_id)}
+								selected={
+									aiAccessMode === "configured" && aiProviderChoices.includes(provider.provider_id)
+								}
 								onClick={() => toggleAiProviderChoice(provider.provider_id)}
 								icon={<ProviderTypeChip type={provider.type} />}
 								title={provider.label ?? provider.provider_id}
@@ -831,18 +891,25 @@ export function DeployWizard() {
 							onClick={() => setAddProviderOpen(true)}
 						/>
 					</div>
-					<PrimaryModelPicker
-						providers={aiProviders.data?.providers ?? []}
-						customProviders={providerList}
-						selectedProviderChoices={normalizeSelectedProviderIds(
-							aiProviderChoices,
-							primaryProviderChoice,
-						)}
-						primaryProviderChoice={primaryProviderChoice}
-						primaryModel={primaryModel}
-						onPrimaryProviderChange={setPrimaryProvider}
-						onPrimaryModelChange={setPrimaryModel}
-					/>
+					{aiAccessMode === "unmanaged" ? (
+						<p className="mt-4 text-sm text-muted-foreground">
+							This deploy sends no hosted provider binding. Configure models inside the agent after
+							provisioning.
+						</p>
+					) : (
+						<PrimaryModelPicker
+							providers={aiProviders.data?.providers ?? []}
+							customProviders={providerList}
+							selectedProviderChoices={normalizeSelectedProviderIds(
+								aiProviderChoices,
+								primaryProviderChoice,
+							)}
+							primaryProviderChoice={primaryProviderChoice}
+							primaryModel={primaryModel}
+							onPrimaryProviderChange={setPrimaryProvider}
+							onPrimaryModelChange={setPrimaryModel}
+						/>
+					)}
 				</SettingsSection>
 
 				<SettingsSection

--- a/apps/web/src/hosted/billing/deploy/language-timezone-controls.tsx
+++ b/apps/web/src/hosted/billing/deploy/language-timezone-controls.tsx
@@ -27,10 +27,21 @@ export const LANGUAGE_OPTIONS = [
 	{ code: "pt", label: "Português" },
 ] as const;
 
+export type HostedLanguage = (typeof LANGUAGE_OPTIONS)[number]["code"];
+
+const HOSTED_LANGUAGE_CODES = new Set<HostedLanguage>(
+	LANGUAGE_OPTIONS.map((option) => option.code),
+);
+
 export const LANGUAGE_SELECT_ITEMS = [
 	{ value: "default", label: "Default" },
 	...LANGUAGE_OPTIONS.map((option) => ({ value: option.code, label: option.label })),
 ] as const;
+
+export function normalizeHostedLanguage(value: string | null | undefined): HostedLanguage | null {
+	if (!value) return null;
+	return HOSTED_LANGUAGE_CODES.has(value as HostedLanguage) ? (value as HostedLanguage) : null;
+}
 
 // Static IANA timezone list keeps SSR and client markup deterministic.
 const TIMEZONE_OPTIONS = `

--- a/apps/web/src/hosted/billing/deployment-links.test.ts
+++ b/apps/web/src/hosted/billing/deployment-links.test.ts
@@ -22,7 +22,6 @@ function deployment(envs: Record<string, string> | null): HostedDeployment {
 					whatsapp_mux_enabled: false,
 					imessage_mux_enabled: false,
 					kobb_available: false,
-					channel: null,
 					primary_model: null,
 					ai_provider_id: null,
 					ai_provider_auth_kind: "managed",

--- a/apps/web/src/hosted/runtimes.test.ts
+++ b/apps/web/src/hosted/runtimes.test.ts
@@ -30,7 +30,6 @@ function configInfo(
 		whatsapp_mux_enabled: false,
 		imessage_mux_enabled: false,
 		kobb_available: false,
-		channel: null,
 		primary_model: null,
 		ai_provider_id: null,
 		ai_provider_auth_kind: "managed",

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -99,7 +99,6 @@ function deployment(
 			whatsapp_mux_enabled: false,
 			imessage_mux_enabled: false,
 			kobb_available: false,
-			channel: null,
 			primary_model: null,
 			ai_provider_id: null,
 			ai_provider_auth_kind: "managed",

--- a/apps/web/src/hosted/v2/ai-providers/auth-card-label.ts
+++ b/apps/web/src/hosted/v2/ai-providers/auth-card-label.ts
@@ -1,0 +1,14 @@
+import type { AiProviderAuthKind } from "@/hosted/billing/contracts";
+
+export function authCardLabel(authKind: AiProviderAuthKind): string {
+	switch (authKind) {
+		case "unmanaged":
+			return "Configure inside agent";
+		case "api_key":
+			return "Use your own API key";
+		case "codex_oauth":
+			return "Use your OpenAI account";
+		default:
+			return "Managed by Clawdi";
+	}
+}

--- a/apps/web/src/lib/hosted-product-access.ts
+++ b/apps/web/src/lib/hosted-product-access.ts
@@ -20,7 +20,7 @@ async function fetchHostedProductAccessProfile(
 ): Promise<HostedProductAccessProfile> {
 	const token = await getToken();
 	const api = createClient<DeployPaths>({ baseUrl: hostedApiBaseUrl(DEPLOY_API_URL) });
-	const result = await api.GET("/me", {
+	const result = await api.GET("/v1/me", {
 		headers: token ? { Authorization: `Bearer ${token}` } : undefined,
 	});
 	if (!result.response.ok) {

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -4,7 +4,7 @@
  */
 
 export interface paths {
-    "/agent-environments": {
+    "/v1/agent-environments": {
         parameters: {
             query?: never;
             header?: never;
@@ -12,7 +12,7 @@ export interface paths {
             cookie?: never;
         };
         /** List V1 Agent Environments */
-        get: operations["list_v1_agent_environments_agent_environments_get"];
+        get: operations["list_v1_agent_environments_v1_agent_environments_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -21,7 +21,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/me": {
+    "/v1/me": {
         parameters: {
             query?: never;
             header?: never;
@@ -29,7 +29,7 @@ export interface paths {
             cookie?: never;
         };
         /** Me */
-        get: operations["me_me_get"];
+        get: operations["me_v1_me_get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -474,18 +474,18 @@ export interface components {
         /** V2AiProviderBindingInfo */
         V2AiProviderBindingInfo: {
             /** Provider Id */
-            provider_id: string;
+            provider_id?: string | null;
             /** Provider Ids */
             provider_ids?: string[];
             /**
              * Auth Kind
              * @enum {string}
              */
-            auth_kind: "managed" | "api_key" | "codex_oauth";
-            primary_model?: components["schemas"]["V2AiProviderPrimaryModelRef-Output"] | null;
+            auth_kind: "unmanaged" | "managed" | "api_key" | "codex_oauth";
+            primary_model?: components["schemas"]["V2AiProviderPrimaryModelRef"] | null;
         };
         /** V2AiProviderPrimaryModelRef */
-        "V2AiProviderPrimaryModelRef-Output": {
+        V2AiProviderPrimaryModelRef: {
             /** Provider Id */
             provider_id: string;
             /** Model */
@@ -655,6 +655,16 @@ export interface components {
             /** Upgrade Status */
             upgrade_status?: string | null;
         };
+        /** V2DeploymentRuntimeUiRedemptionResponse */
+        V2DeploymentRuntimeUiRedemptionResponse: {
+            /** Url */
+            url: string;
+            /**
+             * Expires At
+             * Format: date-time
+             */
+            expires_at: string;
+        };
         /** V2DeploymentTerminalSessionResponse */
         V2DeploymentTerminalSessionResponse: {
             /**
@@ -665,16 +675,6 @@ export interface components {
             deployment_id: string;
             /** Websocket Url */
             websocket_url: string;
-            /**
-             * Expires At
-             * Format: date-time
-             */
-            expires_at: string;
-        };
-        /** V2DeploymentRuntimeUiRedemptionResponse */
-        V2DeploymentRuntimeUiRedemptionResponse: {
-            /** Url */
-            url: string;
             /**
              * Expires At
              * Format: date-time
@@ -721,7 +721,7 @@ export interface components {
         /** V2HostedConfigRequest */
         V2HostedConfigRequest: {
             /** Primary Model */
-            primary_model?: string | components["schemas"]["app__v2__hosted__schemas__V2AiProviderPrimaryModelRef"] | null;
+            primary_model?: string | components["schemas"]["V2AiProviderPrimaryModelRef"] | null;
             /** Channel */
             channel?: string | null;
             /** Telegram Bot Token */
@@ -738,20 +738,14 @@ export interface components {
             slack_app_token?: string | null;
             /** Assistant Name */
             assistant_name?: string | null;
-            /** Personality */
-            personality?: string | null;
             /** Language */
-            language?: string | null;
+            language?: ("en" | "es" | "fr" | "de" | "ja" | "ko" | "pt" | "zh-CN" | "zh-TW") | null;
             /** Timezone */
             timezone?: string | null;
             /** Public Ports */
             public_ports?: number[] | null;
-            /**
-             * Runtime
-             * @default openclaw
-             * @enum {string}
-             */
-            runtime: "openclaw" | "hermes";
+            /** Runtime */
+            runtime?: ("openclaw" | "hermes") | null;
         };
         /** V2HostedDeployRequest */
         V2HostedDeployRequest: {
@@ -761,7 +755,7 @@ export interface components {
              */
             compute_plan_slug: "compute_free" | "compute_performance";
             /** Primary Model */
-            primary_model?: string | components["schemas"]["app__v2__hosted__schemas__V2AiProviderPrimaryModelRef"] | null;
+            primary_model?: string | components["schemas"]["V2AiProviderPrimaryModelRef"] | null;
             /** Channel */
             channel?: string | null;
             /** Telegram Bot Token */
@@ -780,24 +774,28 @@ export interface components {
             model?: string | null;
             /** Assistant Name */
             assistant_name?: string | null;
-            /** Personality */
-            personality?: string | null;
             /** Language */
-            language?: string | null;
+            language?: ("en" | "es" | "fr" | "de" | "ja" | "ko" | "pt" | "zh-CN" | "zh-TW") | null;
             /** Timezone */
             timezone?: string | null;
             /** Public Ports */
             public_ports?: number[] | null;
-            /** Runtime */
-            runtime?: ("openclaw" | "hermes") | null;
+            /**
+             * Runtime
+             * @enum {string}
+             */
+            runtime: "openclaw" | "hermes";
             /** Deploy Request Id */
             deploy_request_id?: string | null;
             /** Ai Provider Id */
             ai_provider_id?: string | null;
             /** Provider Ids */
             provider_ids?: string[];
-            /** Ai Provider Auth Kind */
-            ai_provider_auth_kind?: ("managed" | "api_key" | "codex_oauth") | null;
+            /**
+             * Ai Provider Auth Kind
+             * @enum {string}
+             */
+            ai_provider_auth_kind: "unmanaged" | "managed" | "api_key" | "codex_oauth";
             /** Ai Provider Bootstrap */
             ai_provider_bootstrap?: {
                 [key: string]: unknown;
@@ -841,24 +839,19 @@ export interface components {
              * @default false
              */
             kobb_available: boolean;
-            /** Channel */
-            channel?: string | null;
             /** Primary Model */
             primary_model?: string | null;
             /** Ai Provider Id */
             ai_provider_id?: string | null;
             /**
              * Ai Provider Auth Kind
-             * @default managed
              * @enum {string}
              */
-            ai_provider_auth_kind: "managed" | "api_key" | "codex_oauth";
+            ai_provider_auth_kind: "unmanaged" | "managed" | "api_key" | "codex_oauth";
             /** Ai Provider Bindings */
             ai_provider_bindings?: {
                 [key: string]: components["schemas"]["V2AiProviderBindingInfo"];
             };
-            /** Telegram Allowed Usernames */
-            telegram_allowed_usernames?: string[] | null;
             /** Telegram Bot Username */
             telegram_bot_username?: string | null;
             /** Telegram Entry Url */
@@ -871,7 +864,6 @@ export interface components {
             public_ports?: number[];
             /**
              * Runtime
-             * @default openclaw
              * @enum {string}
              */
             runtime: "openclaw" | "hermes";
@@ -933,10 +925,6 @@ export interface components {
              * @default false
              */
             upgrade_available: boolean;
-            /** Agent Version */
-            agent_version?: string | null;
-            /** App Image */
-            app_image?: string | null;
         };
         /** V2HostedUsageDay */
         V2HostedUsageDay: {
@@ -1024,7 +1012,7 @@ export interface components {
         /** V2RebindAgentAiProviderRequest */
         V2RebindAgentAiProviderRequest: {
             /** Primary Model */
-            primary_model?: string | components["schemas"]["app__v2__api_schemas__V2AiProviderPrimaryModelRef"] | null;
+            primary_model?: string | components["schemas"]["V2AiProviderPrimaryModelRef"] | null;
             /** Ai Provider Id */
             ai_provider_id?: string | null;
             /** Provider Ids */
@@ -1033,7 +1021,7 @@ export interface components {
              * Ai Provider Auth Kind
              * @enum {string}
              */
-            ai_provider_auth_kind: "managed" | "api_key" | "codex_oauth";
+            ai_provider_auth_kind: "unmanaged" | "managed" | "api_key" | "codex_oauth";
             /** Ai Provider Bootstrap */
             ai_provider_bootstrap?: {
                 [key: string]: unknown;
@@ -1043,10 +1031,8 @@ export interface components {
         V2SetAgentEnabledRequest: {
             /** Enabled */
             enabled: boolean;
-            /** Personality */
-            personality?: string | null;
             /** Language */
-            language?: string | null;
+            language?: ("en" | "es" | "fr" | "de" | "ja" | "ko" | "pt" | "zh-CN" | "zh-TW") | null;
             /** Timezone */
             timezone?: string | null;
         };
@@ -1165,20 +1151,6 @@ export interface components {
             /** Context */
             ctx?: Record<string, never>;
         };
-        /** V2AiProviderPrimaryModelRef */
-        app__v2__api_schemas__V2AiProviderPrimaryModelRef: {
-            /** Provider Id */
-            provider_id: string;
-            /** Model */
-            model: string;
-        };
-        /** V2AiProviderPrimaryModelRef */
-        app__v2__hosted__schemas__V2AiProviderPrimaryModelRef: {
-            /** Provider Id */
-            provider_id: string;
-            /** Model */
-            model: string;
-        };
     };
     responses: never;
     parameters: never;
@@ -1188,7 +1160,7 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    list_v1_agent_environments_agent_environments_get: {
+    list_v1_agent_environments_v1_agent_environments_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -1208,7 +1180,7 @@ export interface operations {
             };
         };
     };
-    me_me_get: {
+    me_v1_me_get: {
         parameters: {
             query?: never;
             header?: never;
@@ -1450,37 +1422,6 @@ export interface operations {
             };
         };
     };
-    create_v2_deployment_runtime_ui_redemption_v2_deployments__deployment_id__runtime_ui_redemption_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                deployment_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["V2DeploymentRuntimeUiRedemptionResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     create_v2_deployment_terminal_session_v2_deployments__deployment_id__terminal_post: {
         parameters: {
             query?: never;
@@ -1499,6 +1440,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["V2DeploymentTerminalSessionResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_v2_deployment_runtime_ui_redemption_v2_deployments__deployment_id__runtime_ui_redemption_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                deployment_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["V2DeploymentRuntimeUiRedemptionResponse"];
                 };
             };
             /** @description Validation Error */

--- a/scripts/filter-deploy-openapi.py
+++ b/scripts/filter-deploy-openapi.py
@@ -37,8 +37,8 @@ from typing import Any
 # Endpoints the OSS dashboard actually calls. Adding a new operation here is the
 # SINGLE knob for widening the schema surface.
 KEEP_OPERATIONS_BY_PATH: dict[str, set[str]] = {
-    "/agent-environments": {"get"},
-    "/me": {"get"},
+    "/v1/agent-environments": {"get"},
+    "/v1/me": {"get"},
     "/v2/deployments": {"get", "post"},
     "/v2/deployments/{deployment_id}": {"get", "delete", "patch"},
     "/v2/deployments/{deployment_id}/agents/{agent_type}": {"patch"},


### PR DESCRIPTION
## Summary
- include the first-half branch work: regenerated `packages/shared/src/api/deploy.generated.ts` from the live hosted OpenAPI, moved the hosted allowlist to `/v1/me` + `/v1/agent-environments`, and migrated the remaining bare-path callers
- migrate the Cloud dashboard hosted v2 deploy/billing flow to the live hosted contract by requiring an explicit runtime choice, defaulting deploy/rebind flows to explicit `unmanaged`, and removing stale provider payload from unmanaged requests
- update hosted deploy and agent-detail rendering for `auth_kind: unmanaged` / nullable `provider_id`, tighten hosted language request shaping, and refresh web tests for the new response and request contract

## Verification
- `bun run typecheck`
- `bun test apps/web/src/hosted/billing/deploy/deploy-request.test.ts apps/web/src/hosted/billing/components/stripe-checkout.logic.test.ts apps/web/src/hosted/billing/deployment-links.test.ts apps/web/src/hosted/runtimes.test.ts apps/web/src/hosted/use-hosted-agent-tiles.test.ts`
- `bun run check`

## Notes
- skipped local `scripts/test.sh js` per urgency; PR CI will run the full suite
