### PR TITLE
ci: guard deploy client against hosted contract drift

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -6,6 +6,10 @@ on:
       - "apps/web/**"
       - "packages/shared/**"
       - "packages/cli/**"
+      - "scripts/filter-deploy-openapi.py"
+      - "scripts/openapi-typescript.sh"
+      - "scripts/generate-deploy-api.sh"
+      - "scripts/check-deploy-generated-api.sh"
       - "package.json"
       - "bun.lock"
       - "turbo.json"
@@ -19,6 +23,10 @@ on:
       - "apps/web/**"
       - "packages/shared/**"
       - "packages/cli/**"
+      - "scripts/filter-deploy-openapi.py"
+      - "scripts/openapi-typescript.sh"
+      - "scripts/generate-deploy-api.sh"
+      - "scripts/check-deploy-generated-api.sh"
       - "package.json"
       - "bun.lock"
       - "turbo.json"
@@ -26,6 +34,8 @@ on:
       - "biome.json"
       - ".github/actions/setup-bun-ci/**"
       - ".github/workflows/client-ci.yml"
+  schedule:
+    - cron: "17 6 * * *"
 
 permissions:
   contents: read
@@ -41,12 +51,14 @@ env:
 
 jobs:
   changes:
+    if: github.event_name != 'schedule'
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     outputs:
       web: ${{ steps.filter.outputs.web }}
       cli: ${{ steps.filter.outputs.cli }}
       shared: ${{ steps.filter.outputs.shared }}
       infra: ${{ steps.filter.outputs.infra }}
+      deploy_contract: ${{ steps.filter.outputs.deploy_contract }}
     steps:
       - uses: actions/checkout@v6
       - id: filter
@@ -67,15 +79,25 @@ jobs:
               - "biome.json"
               - ".github/actions/setup-bun-ci/**"
               - ".github/workflows/client-ci.yml"
+            deploy_contract:
+              - "packages/shared/src/api/deploy.generated.ts"
+              - "scripts/filter-deploy-openapi.py"
+              - "scripts/openapi-typescript.sh"
+              - "scripts/generate-deploy-api.sh"
+              - "scripts/check-deploy-generated-api.sh"
+              - "apps/web/package.json"
+              - ".github/workflows/client-ci.yml"
 
   # Lint + format check across the whole JS/TS tree in one fast job.
   lint:
     needs: changes
     if: >-
-      needs.changes.outputs.web == 'true' ||
-      needs.changes.outputs.cli == 'true' ||
-      needs.changes.outputs.shared == 'true' ||
-      needs.changes.outputs.infra == 'true'
+      github.event_name != 'schedule' && (
+        needs.changes.outputs.web == 'true' ||
+        needs.changes.outputs.cli == 'true' ||
+        needs.changes.outputs.shared == 'true' ||
+        needs.changes.outputs.infra == 'true'
+      )
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 10
     steps:
@@ -89,10 +111,12 @@ jobs:
   typecheck:
     needs: changes
     if: >-
-      needs.changes.outputs.web == 'true' ||
-      needs.changes.outputs.cli == 'true' ||
-      needs.changes.outputs.shared == 'true' ||
-      needs.changes.outputs.infra == 'true'
+      github.event_name != 'schedule' && (
+        needs.changes.outputs.web == 'true' ||
+        needs.changes.outputs.cli == 'true' ||
+        needs.changes.outputs.shared == 'true' ||
+        needs.changes.outputs.infra == 'true'
+      )
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     strategy:
@@ -148,9 +172,11 @@ jobs:
   cli-test:
     needs: changes
     if: >-
-      needs.changes.outputs.cli == 'true' ||
-      needs.changes.outputs.shared == 'true' ||
-      needs.changes.outputs.infra == 'true'
+      github.event_name != 'schedule' && (
+        needs.changes.outputs.cli == 'true' ||
+        needs.changes.outputs.shared == 'true' ||
+        needs.changes.outputs.infra == 'true'
+      )
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 10
     steps:
@@ -175,9 +201,11 @@ jobs:
   build:
     needs: [changes, typecheck]
     if: >-
-      needs.changes.outputs.web == 'true' ||
-      needs.changes.outputs.shared == 'true' ||
-      needs.changes.outputs.infra == 'true'
+      github.event_name != 'schedule' && (
+        needs.changes.outputs.web == 'true' ||
+        needs.changes.outputs.shared == 'true' ||
+        needs.changes.outputs.infra == 'true'
+      )
     runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
     timeout-minutes: 15
     steps:
@@ -191,3 +219,36 @@ jobs:
           VITE_CLAWDI_API_URL: http://localhost:8000
           CLERK_SECRET_KEY: sk_test_dummy
         run: bunx turbo build --filter=web
+
+  deploy-contract-drift:
+    needs: changes
+    if: >-
+      github.event_name != 'schedule' &&
+      needs.changes.outputs.deploy_contract == 'true'
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-bun-ci
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - name: Hosted deploy contract matches live spec
+        env:
+          DEPLOY_OPENAPI_SOURCE: https://api.clawdi.ai/openapi.json
+          DEPLOY_CONTRACT_FETCH_MODE: warn
+        run: scripts/check-deploy-generated-api.sh
+
+  deploy-contract-drift-daily:
+    if: github.event_name == 'schedule'
+    runs-on: ${{ vars.CI_RUNNER || 'blacksmith-16vcpu-ubuntu-2404' }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-bun-ci
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - name: Hosted deploy contract matches live spec (strict)
+        env:
+          DEPLOY_OPENAPI_SOURCE: https://api.clawdi.ai/openapi.json
+          DEPLOY_CONTRACT_FETCH_MODE: strict
+        run: scripts/check-deploy-generated-api.sh

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,8 @@
 		"e2e": "playwright test",
 		"e2e:hosted": "playwright test --config=playwright.hosted.config.ts",
 		"generate-api": "../../scripts/openapi-typescript.sh http://localhost:8000/openapi.json -o ../../packages/shared/src/api/api.generated.ts",
-		"generate-deploy-api": "curl -sf http://localhost:50021/openapi.json | python3 ../../scripts/filter-deploy-openapi.py | ../../scripts/openapi-typescript.sh /dev/stdin -o ../../packages/shared/src/api/deploy.generated.ts"
+		"generate-deploy-api": "../../scripts/generate-deploy-api.sh",
+		"generate-deploy-api:live": "DEPLOY_OPENAPI_SOURCE=https://api.clawdi.ai/openapi.json ../../scripts/generate-deploy-api.sh"
 	},
 	"dependencies": {
 		"@base-ui/react": "^1.6.0",

--- a/packages/shared/src/api/deploy.ts
+++ b/packages/shared/src/api/deploy.ts
@@ -4,7 +4,11 @@
  *
  *     bun --cwd apps/web run generate-deploy-api
  *
- * (requires the hosted deploy API running on :50021).
+ * The default source is the local hosted API on `:50021`. To regenerate
+ * against the live hosted contract that CI checks, run:
+ *
+ *     DEPLOY_OPENAPI_SOURCE=https://api.clawdi.ai/openapi.json \
+ *       bun --cwd apps/web run generate-deploy-api
  *
  * The generated file is intentionally a FILTERED subset of the hosted
  * deploy API OpenAPI surface — `scripts/filter-deploy-openapi.py` keeps only the

--- a/scripts/check-deploy-generated-api.sh
+++ b/scripts/check-deploy-generated-api.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+
+spec_source="${DEPLOY_OPENAPI_SOURCE:-https://api.clawdi.ai/openapi.json}"
+fetch_mode="${DEPLOY_CONTRACT_FETCH_MODE:-warn}"
+committed_path="$repo_root/packages/shared/src/api/deploy.generated.ts"
+
+case "$fetch_mode" in
+	warn|strict) ;;
+	*)
+		echo "Unsupported DEPLOY_CONTRACT_FETCH_MODE: $fetch_mode" >&2
+		exit 2
+		;;
+esac
+
+warn() {
+	local message="$1"
+	if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+		printf '::warning title=Hosted deploy contract check skipped::%s\n' "$message"
+	fi
+	echo "$message" >&2
+}
+
+tempdir="$(mktemp -d "${TMPDIR:-/tmp}/clawdi-deploy-openapi.XXXXXX")"
+trap "rm -rf -- '$tempdir'" EXIT
+
+raw_spec="$tempdir/openapi.json"
+expected_path="$tempdir/deploy.generated.ts"
+
+case "$spec_source" in
+	http://*|https://*)
+		if ! curl \
+			--fail \
+			--silent \
+			--show-error \
+			--location \
+			--connect-timeout "${DEPLOY_OPENAPI_CONNECT_TIMEOUT:-5}" \
+			--max-time "${DEPLOY_OPENAPI_MAX_TIME:-20}" \
+			--retry "${DEPLOY_OPENAPI_RETRY:-2}" \
+			--retry-delay "${DEPLOY_OPENAPI_RETRY_DELAY:-1}" \
+			--retry-all-errors \
+			"$spec_source" \
+			>"$raw_spec"; then
+			message="Unable to fetch hosted OpenAPI from $spec_source."
+			if [[ "$fetch_mode" == "warn" ]]; then
+				warn "$message Skipping drift check for this run."
+				exit 0
+			fi
+			echo "$message" >&2
+			exit 1
+		fi
+		;;
+	*)
+		cat "$spec_source" >"$raw_spec"
+		;;
+esac
+
+"$script_dir/generate-deploy-api.sh" "$raw_spec" "$expected_path"
+
+if cmp -s "$committed_path" "$expected_path"; then
+	exit 0
+fi
+
+diff -u "$committed_path" "$expected_path" || true
+echo \
+	"packages/shared/src/api/deploy.generated.ts is stale. Regenerate with \`DEPLOY_OPENAPI_SOURCE=$spec_source bun --cwd apps/web run generate-deploy-api\` and commit the result." \
+	>&2
+exit 1

--- a/scripts/filter-deploy-openapi.py
+++ b/scripts/filter-deploy-openapi.py
@@ -15,16 +15,25 @@ only the surface we actually consume so:
   * adding a new endpoint requires editing the allowlist below (a
     deliberate audit point) instead of silently widening the bundle.
 
-Usage (wired up via `apps/web/package.json`):
+Usage:
 
-    curl -s http://localhost:50021/openapi.json \
-      | python3 scripts/filter-deploy-openapi.py \
-      | scripts/openapi-typescript.sh /dev/stdin \
-          -o packages/shared/src/api/deploy.generated.ts
+Local development (the default behind `bun --cwd apps/web run generate-deploy-api`):
+
+    DEPLOY_OPENAPI_SOURCE=http://localhost:50021/openapi.json \
+      bun --cwd apps/web run generate-deploy-api
+
+Regenerating against the live hosted contract that CI checks:
+
+    DEPLOY_OPENAPI_SOURCE=https://api.clawdi.ai/openapi.json \
+      bun --cwd apps/web run generate-deploy-api
 
 To consume a new endpoint, add its path + HTTP method to
 `KEEP_OPERATIONS_BY_PATH` and rerun the generate command. Schema closure is
 auto-discovered via `$ref` walks, so referenced types come along for free.
+
+Do not use clawdi-hosted's checked-in `backend/openapi.json` as a generation
+source. It can lag the live hosted contract, which would hide exactly the drift
+this guard is meant to catch.
 """
 
 from __future__ import annotations

--- a/scripts/generate-deploy-api.sh
+++ b/scripts/generate-deploy-api.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+
+spec_source="${1:-${DEPLOY_OPENAPI_SOURCE:-http://localhost:50021/openapi.json}}"
+output_path="${2:-$repo_root/packages/shared/src/api/deploy.generated.ts}"
+
+read_spec() {
+	case "$spec_source" in
+		http://*|https://*)
+			curl --fail --silent --show-error --location "$spec_source"
+			;;
+		*)
+			cat "$spec_source"
+			;;
+	esac
+}
+
+read_spec \
+	| python3 "$script_dir/filter-deploy-openapi.py" \
+	| "$script_dir/openapi-typescript.sh" /dev/stdin -o "$output_path"


### PR DESCRIPTION
## Summary
- add repo-local deploy-contract generation and drift-check scripts so CI can fetch the live hosted OpenAPI, filter it, regenerate `packages/shared/src/api/deploy.generated.ts`, and diff against the committed file
- wire `client-ci` to run the drift guard on relevant PR/push changes with fetch-failure warnings, plus a daily scheduled strict run that fails on fetch or contract drift
- update the filter/doc comments and web package scripts to document the CI live-spec source while keeping `http://localhost:50021/openapi.json` as the local default

## Verification
- `bash -n scripts/generate-deploy-api.sh scripts/check-deploy-generated-api.sh && python3 -m py_compile scripts/filter-deploy-openapi.py`
- `python3 - <<'PY' ... yaml.safe_load('.github/workflows/client-ci.yml') ... PY`
- `DEPLOY_OPENAPI_SOURCE=https://api.clawdi.ai/openapi.json DEPLOY_CONTRACT_FETCH_MODE=strict scripts/check-deploy-generated-api.sh`
  - passed; no regeneration was needed, so the committed `packages/shared/src/api/deploy.generated.ts` already matches the live hosted contract today
- simulated drift by appending a scratch `// drift simulation` line to `packages/shared/src/api/deploy.generated.ts`, rerunning the strict check, and restoring the file
  - failed as expected with a unified diff and `simulated_exit=1`
