### PR TITLE
fix(web): restore v2 deploy wizard defaults

### DIFF
--- a/apps/web/src/hosted/billing/deploy/browser-language.test.ts
+++ b/apps/web/src/hosted/billing/deploy/browser-language.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { browserLanguage } from "@/hosted/billing/deploy/language-timezone-controls";
+
+const original = globalThis.navigator;
+
+function setLanguages(languages: string[]): void {
+	Object.defineProperty(globalThis, "navigator", {
+		value: { languages, language: languages[0] },
+		configurable: true,
+	});
+}
+
+afterEach(() => {
+	Object.defineProperty(globalThis, "navigator", { value: original, configurable: true });
+});
+
+describe("browserLanguage", () => {
+	it("matches an exact supported code", () => {
+		setLanguages(["zh-TW"]);
+		expect(browserLanguage()).toBe("zh-TW");
+	});
+
+	it("maps a region variant onto its base language", () => {
+		setLanguages(["en-US"]);
+		expect(browserLanguage()).toBe("en");
+	});
+
+	it("falls through preferred list to the first supported entry", () => {
+		setLanguages(["xx-YY", "fr-FR"]);
+		expect(browserLanguage()).toBe("fr");
+	});
+
+	it("returns unset when nothing is supported", () => {
+		setLanguages(["xx-YY"]);
+		expect(browserLanguage()).toBe("");
+	});
+});

--- a/apps/web/src/hosted/billing/deploy/deploy-defaults.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-defaults.test.ts
@@ -11,8 +11,8 @@ import {
 import { MANAGED_AI_CHOICE, MANAGED_PROVIDER_ID } from "@/hosted/v2/ai-providers/model-binding";
 
 describe("deploy wizard defaults", () => {
-	test("default to the historical openclaw runtime and managed AI mode", () => {
-		expect(DEFAULT_DEPLOY_RUNTIME).toBe("openclaw");
+	test("default to the hermes runtime and managed AI mode", () => {
+		expect(DEFAULT_DEPLOY_RUNTIME).toBe("hermes");
 		expect(DEFAULT_DEPLOY_AI_ACCESS_MODE).toBe("configured");
 		expect(DEFAULT_DEPLOY_AI_PROVIDER_CHOICES).toEqual([MANAGED_AI_CHOICE]);
 		expect(DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE).toBe(MANAGED_AI_CHOICE);

--- a/apps/web/src/hosted/billing/deploy/deploy-defaults.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-defaults.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import {
+	DEFAULT_DEPLOY_AI_ACCESS_MODE,
+	DEFAULT_DEPLOY_AI_PROVIDER_CHOICES,
+	DEFAULT_DEPLOY_PRIMARY_MODEL,
+	DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE,
+	DEFAULT_DEPLOY_RUNTIME,
+	defaultManagedDeployAiFields,
+	defaultManagedPrimaryModel,
+} from "@/hosted/billing/deploy/deploy-defaults";
+import { MANAGED_AI_CHOICE, MANAGED_PROVIDER_ID } from "@/hosted/v2/ai-providers/model-binding";
+
+describe("deploy wizard defaults", () => {
+	test("default to the historical openclaw runtime and managed AI mode", () => {
+		expect(DEFAULT_DEPLOY_RUNTIME).toBe("openclaw");
+		expect(DEFAULT_DEPLOY_AI_ACCESS_MODE).toBe("configured");
+		expect(DEFAULT_DEPLOY_AI_PROVIDER_CHOICES).toEqual([MANAGED_AI_CHOICE]);
+		expect(DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE).toBe(MANAGED_AI_CHOICE);
+		expect(DEFAULT_DEPLOY_PRIMARY_MODEL).toBe("gpt-5.5");
+	});
+
+	test("build the explicit managed deploy fields used by the default wizard state", () => {
+		expect(defaultManagedPrimaryModel()).toEqual({
+			provider_id: MANAGED_PROVIDER_ID,
+			model: DEFAULT_DEPLOY_PRIMARY_MODEL,
+		});
+		expect(defaultManagedDeployAiFields()).toEqual({
+			ai_provider_id: null,
+			ai_provider_auth_kind: "managed",
+			provider_ids: [MANAGED_PROVIDER_ID],
+			primary_model: {
+				provider_id: MANAGED_PROVIDER_ID,
+				model: DEFAULT_DEPLOY_PRIMARY_MODEL,
+			},
+		});
+	});
+});

--- a/apps/web/src/hosted/billing/deploy/deploy-defaults.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-defaults.ts
@@ -1,0 +1,32 @@
+import type { DeployAiFields } from "@/hosted/billing/deploy/deploy-request";
+import { DEFAULT_HOSTED_RUNTIME, type HostedRuntime } from "@/hosted/runtimes";
+import {
+	MANAGED_AI_CHOICE,
+	MANAGED_PRIMARY_MODEL_FALLBACK,
+	MANAGED_PROVIDER_ID,
+	type PrimaryModelRef,
+} from "@/hosted/v2/ai-providers/model-binding";
+
+export type DeployWizardAiAccessMode = "unmanaged" | "configured";
+
+export const DEFAULT_DEPLOY_RUNTIME: HostedRuntime = DEFAULT_HOSTED_RUNTIME;
+export const DEFAULT_DEPLOY_AI_ACCESS_MODE: DeployWizardAiAccessMode = "configured";
+export const DEFAULT_DEPLOY_AI_PROVIDER_CHOICES = [MANAGED_AI_CHOICE] as const;
+export const DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE = MANAGED_AI_CHOICE;
+export const DEFAULT_DEPLOY_PRIMARY_MODEL = MANAGED_PRIMARY_MODEL_FALLBACK;
+
+export function defaultManagedPrimaryModel(): PrimaryModelRef {
+	return {
+		provider_id: MANAGED_PROVIDER_ID,
+		model: DEFAULT_DEPLOY_PRIMARY_MODEL,
+	};
+}
+
+export function defaultManagedDeployAiFields(): DeployAiFields {
+	return {
+		ai_provider_id: null,
+		ai_provider_auth_kind: "managed",
+		provider_ids: [MANAGED_PROVIDER_ID],
+		primary_model: defaultManagedPrimaryModel(),
+	};
+}

--- a/apps/web/src/hosted/billing/deploy/deploy-defaults.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-defaults.ts
@@ -1,5 +1,5 @@
 import type { DeployAiFields } from "@/hosted/billing/deploy/deploy-request";
-import { DEFAULT_HOSTED_RUNTIME, type HostedRuntime } from "@/hosted/runtimes";
+import type { HostedRuntime } from "@/hosted/runtimes";
 import {
 	MANAGED_AI_CHOICE,
 	MANAGED_PRIMARY_MODEL_FALLBACK,
@@ -9,7 +9,9 @@ import {
 
 export type DeployWizardAiAccessMode = "unmanaged" | "configured";
 
-export const DEFAULT_DEPLOY_RUNTIME: HostedRuntime = DEFAULT_HOSTED_RUNTIME;
+// Deploy-form pre-selection. Independent from the config-interpretation
+// fallback in runtimes.ts (which stays openclaw for existing deployment records).
+export const DEFAULT_DEPLOY_RUNTIME: HostedRuntime = "hermes";
 export const DEFAULT_DEPLOY_AI_ACCESS_MODE: DeployWizardAiAccessMode = "configured";
 export const DEFAULT_DEPLOY_AI_PROVIDER_CHOICES = [MANAGED_AI_CHOICE] as const;
 export const DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE = MANAGED_AI_CHOICE;

--- a/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
@@ -6,7 +6,7 @@ import {
 import { buildHostedDeployRequest } from "@/hosted/billing/deploy/deploy-request";
 
 describe("buildHostedDeployRequest", () => {
-	test("serializes the default wizard state with explicit openclaw and managed AI", () => {
+	test("serializes the default wizard state with explicit hermes and managed AI", () => {
 		const request = buildHostedDeployRequest({
 			computePlanSlug: "compute_free",
 			runtime: DEFAULT_DEPLOY_RUNTIME,
@@ -19,7 +19,7 @@ describe("buildHostedDeployRequest", () => {
 
 		expect(request).toEqual({
 			compute_plan_slug: "compute_free",
-			runtime: "openclaw",
+			runtime: "hermes",
 			language: null,
 			timezone: null,
 			ai_provider_id: null,
@@ -30,7 +30,7 @@ describe("buildHostedDeployRequest", () => {
 				model: "gpt-5.5",
 			},
 			config: {
-				runtime: "openclaw",
+				runtime: "hermes",
 				language: null,
 				timezone: null,
 			},

--- a/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
@@ -1,7 +1,46 @@
 import { describe, expect, test } from "bun:test";
+import {
+	DEFAULT_DEPLOY_RUNTIME,
+	defaultManagedDeployAiFields,
+} from "@/hosted/billing/deploy/deploy-defaults";
 import { buildHostedDeployRequest } from "@/hosted/billing/deploy/deploy-request";
 
 describe("buildHostedDeployRequest", () => {
+	test("serializes the default wizard state with explicit openclaw and managed AI", () => {
+		const request = buildHostedDeployRequest({
+			computePlanSlug: "compute_free",
+			runtime: DEFAULT_DEPLOY_RUNTIME,
+			persona: {
+				language: "",
+				timezone: "",
+			},
+			aiFields: defaultManagedDeployAiFields(),
+		});
+
+		expect(request).toEqual({
+			compute_plan_slug: "compute_free",
+			runtime: "openclaw",
+			language: null,
+			timezone: null,
+			ai_provider_id: null,
+			ai_provider_auth_kind: "managed",
+			provider_ids: ["clawdi-managed-v2"],
+			primary_model: {
+				provider_id: "clawdi-managed-v2",
+				model: "gpt-5.5",
+			},
+			config: {
+				runtime: "openclaw",
+				language: null,
+				timezone: null,
+			},
+		});
+		expect("assistant_name" in request).toBe(false);
+		expect("assistant_name" in (request.config ?? {})).toBe(false);
+		expect("personality" in request).toBe(false);
+		expect("personality" in (request.config ?? {})).toBe(false);
+	});
+
 	test("serializes v2 hosted deploys without legacy deploy profile", () => {
 		const request = buildHostedDeployRequest({
 			computePlanSlug: "compute_performance",

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -53,6 +53,14 @@ import type {
 	DeployRequest,
 	Plan,
 } from "@/hosted/billing/contracts";
+import {
+	DEFAULT_DEPLOY_AI_ACCESS_MODE,
+	DEFAULT_DEPLOY_AI_PROVIDER_CHOICES,
+	DEFAULT_DEPLOY_PRIMARY_MODEL,
+	DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE,
+	DEFAULT_DEPLOY_RUNTIME,
+	type DeployWizardAiAccessMode,
+} from "@/hosted/billing/deploy/deploy-defaults";
 import { usesActiveFreeComputeSlot } from "@/hosted/billing/deploy/deploy-model";
 import {
 	buildHostedDeployRequest,
@@ -92,7 +100,7 @@ import {
 	selectOfferForTerm,
 } from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
-import { type HostedRuntime, runtimeBlurb, runtimeDisplayName } from "@/hosted/runtimes";
+import { runtimeBlurb, runtimeDisplayName } from "@/hosted/runtimes";
 import { AddProviderDialog } from "@/hosted/v2/ai-providers/add-provider-dialog";
 import { useAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import { AuthBadge, ProviderTypeChip } from "@/hosted/v2/ai-providers/ai-providers-ui";
@@ -122,7 +130,7 @@ import { isApiAuthError, normalizeApiError } from "@/lib/api-errors";
 import { cn } from "@/lib/utils";
 
 type Compute = "free" | "performance";
-type AiAccessMode = "unmanaged" | "configured";
+type AiAccessMode = DeployWizardAiAccessMode;
 type ComputePlanSlug = DeployRequest["compute_plan_slug"];
 type NativeDeployCheckout = {
 	clientSecret: string;
@@ -325,11 +333,15 @@ export function DeployWizard() {
 		null,
 	);
 
-	const [runtime, setRuntime] = useState<HostedRuntime | null>(null);
-	const [aiAccessMode, setAiAccessMode] = useState<AiAccessMode>("unmanaged");
-	const [aiProviderChoices, setAiProviderChoices] = useState<string[]>([MANAGED_AI_CHOICE]);
-	const [primaryProviderChoice, setPrimaryProviderChoice] = useState(MANAGED_AI_CHOICE);
-	const [primaryModel, setPrimaryModel] = useState(MANAGED_PRIMARY_MODEL_FALLBACK);
+	const [runtime, setRuntime] = useState(DEFAULT_DEPLOY_RUNTIME);
+	const [aiAccessMode, setAiAccessMode] = useState<AiAccessMode>(DEFAULT_DEPLOY_AI_ACCESS_MODE);
+	const [aiProviderChoices, setAiProviderChoices] = useState<string[]>([
+		...DEFAULT_DEPLOY_AI_PROVIDER_CHOICES,
+	]);
+	const [primaryProviderChoice, setPrimaryProviderChoice] = useState(
+		DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE,
+	);
+	const [primaryModel, setPrimaryModel] = useState(DEFAULT_DEPLOY_PRIMARY_MODEL);
 	const [compute, setCompute] = useState<Compute>("free");
 	const [language, setLanguage] = useState("");
 	const [timezone, setTimezone] = useState("");
@@ -374,7 +386,7 @@ export function DeployWizard() {
 			? !!perfPlan && !!perfOfferSelection
 			: !!freePlan && !freeSlotUnavailable;
 	const planReady = !plans.isLoading && computePlanReady;
-	const canSubmit = planReady && runtime !== null && !submitting;
+	const canSubmit = planReady && !submitting;
 
 	function selectCreatedProvider(providerId: string) {
 		createdProviderGuardRef.current = {
@@ -583,9 +595,6 @@ export function DeployWizard() {
 	}
 
 	function buildDeployRequest(aiFields: DeployAiFields): DeployRequest {
-		if (!runtime) {
-			throw new Error("Choose a runtime before deploying.");
-		}
 		const computePlanSlug: ComputePlanSlug =
 			compute === "performance" ? COMPUTE_PERFORMANCE_SLUG : COMPUTE_FREE_SLUG;
 		return buildHostedDeployRequest({
@@ -656,12 +665,6 @@ export function DeployWizard() {
 		if (!canSubmit) return;
 		setSubmitting(true);
 		try {
-			if (!runtime) {
-				toast.error("Choose a runtime", {
-					description: "Select OpenClaw or Hermes before deploying.",
-				});
-				return;
-			}
 			const aiFields = aiDeployFields();
 			if (!aiFields) return;
 			const deployConfig = buildDeployRequest(aiFields);
@@ -737,7 +740,7 @@ export function DeployWizard() {
 			: `${providerChoiceLabel(primaryProviderChoice, providerList)}${
 					selectedProviderCount > 1 ? ` +${selectedProviderCount - 1}` : ""
 				}`;
-	const runtimeSummary = runtime ? runtimeDisplayName(runtime) : null;
+	const runtimeSummary = runtimeDisplayName(runtime);
 	const summaryLine = [
 		`${compute === "performance" ? "Performance" : "Free"} compute`,
 		aiSummary,
@@ -806,11 +809,6 @@ export function DeployWizard() {
 							description={runtimeBlurb("openclaw")}
 						/>
 					</div>
-					{runtime ? null : (
-						<p className="text-xs text-muted-foreground">
-							Choose a runtime before you deploy. The hosted API no longer applies a default.
-						</p>
-					)}
 				</SettingsSection>
 
 				<SettingsSection
@@ -830,7 +828,7 @@ export function DeployWizard() {
 							description="Deploy first, then configure model access inside the runtime."
 							badge={
 								<Badge variant={aiAccessMode === "unmanaged" ? "secondary" : "outline"}>
-									{aiAccessMode === "unmanaged" ? "Default" : "Optional"}
+									{aiAccessMode === "unmanaged" ? "Selected" : "Optional"}
 								</Badge>
 							}
 						/>
@@ -849,7 +847,7 @@ export function DeployWizard() {
 							badge={
 								<Badge variant="secondary">
 									{aiAccessMode === "configured" && primaryProviderChoice === MANAGED_AI_CHOICE
-										? "Primary"
+										? "Default"
 										: "Managed"}
 								</Badge>
 							}

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -67,6 +67,7 @@ import {
 	type DeployAiFields,
 } from "@/hosted/billing/deploy/deploy-request";
 import {
+	browserLanguage,
 	browserTimezone,
 	LANGUAGE_OPTIONS,
 	LANGUAGE_SELECT_ITEMS,
@@ -350,9 +351,11 @@ export function DeployWizard() {
 	const [term, setTerm] = useState(1);
 	const [submitting, setSubmitting] = useState(false);
 
-	// Default the timezone to the browser's after mount (avoids an SSR mismatch).
+	// Default language + timezone to the browser's after mount (avoids an SSR
+	// mismatch). Both stay explicitly unsettable back to the runtime default.
 	useEffect(() => {
 		setTimezone((tz) => tz || browserTimezone());
+		setLanguage((lang) => lang || browserLanguage());
 	}, []);
 	const tzOptions = useMemo(() => {
 		const all = supportedTimezones();
@@ -791,15 +794,6 @@ export function DeployWizard() {
 				>
 					<div className={RUNTIME_TILE_GRID_CLASS}>
 						<EntityChoiceCard
-							selected={runtime === "hermes"}
-							onClick={() => setRuntime("hermes")}
-							icon={
-								<EntityIcon kind="framework" id="hermes" label={runtimeDisplayName("hermes")} />
-							}
-							title={runtimeDisplayName("hermes")}
-							description={runtimeBlurb("hermes")}
-						/>
-						<EntityChoiceCard
 							selected={runtime === "openclaw"}
 							onClick={() => setRuntime("openclaw")}
 							icon={
@@ -807,6 +801,15 @@ export function DeployWizard() {
 							}
 							title={runtimeDisplayName("openclaw")}
 							description={runtimeBlurb("openclaw")}
+						/>
+						<EntityChoiceCard
+							selected={runtime === "hermes"}
+							onClick={() => setRuntime("hermes")}
+							icon={
+								<EntityIcon kind="framework" id="hermes" label={runtimeDisplayName("hermes")} />
+							}
+							title={runtimeDisplayName("hermes")}
+							description={runtimeBlurb("hermes")}
 						/>
 					</div>
 				</SettingsSection>

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -794,15 +794,6 @@ export function DeployWizard() {
 				>
 					<div className={RUNTIME_TILE_GRID_CLASS}>
 						<EntityChoiceCard
-							selected={runtime === "openclaw"}
-							onClick={() => setRuntime("openclaw")}
-							icon={
-								<EntityIcon kind="framework" id="openclaw" label={runtimeDisplayName("openclaw")} />
-							}
-							title={runtimeDisplayName("openclaw")}
-							description={runtimeBlurb("openclaw")}
-						/>
-						<EntityChoiceCard
 							selected={runtime === "hermes"}
 							onClick={() => setRuntime("hermes")}
 							icon={
@@ -810,6 +801,15 @@ export function DeployWizard() {
 							}
 							title={runtimeDisplayName("hermes")}
 							description={runtimeBlurb("hermes")}
+						/>
+						<EntityChoiceCard
+							selected={runtime === "openclaw"}
+							onClick={() => setRuntime("openclaw")}
+							icon={
+								<EntityIcon kind="framework" id="openclaw" label={runtimeDisplayName("openclaw")} />
+							}
+							title={runtimeDisplayName("openclaw")}
+							description={runtimeBlurb("openclaw")}
 						/>
 					</div>
 				</SettingsSection>

--- a/apps/web/src/hosted/billing/deploy/language-timezone-controls.tsx
+++ b/apps/web/src/hosted/billing/deploy/language-timezone-controls.tsx
@@ -43,6 +43,32 @@ export function normalizeHostedLanguage(value: string | null | undefined): Hoste
 	return HOSTED_LANGUAGE_CODES.has(value as HostedLanguage) ? (value as HostedLanguage) : null;
 }
 
+/**
+ * Best-effort map of the browser's preferred languages onto a supported hosted
+ * language. Returns "" when none match, so the caller falls back to the
+ * unset/"Default" choice. Client-only (reads navigator); call after mount.
+ */
+export function browserLanguage(): HostedLanguage | "" {
+	try {
+		const preferred =
+			typeof navigator !== "undefined"
+				? (navigator.languages?.length ? navigator.languages : [navigator.language]).filter(Boolean)
+				: [];
+		for (const raw of preferred) {
+			const exact = normalizeHostedLanguage(raw);
+			if (exact) return exact;
+			const base = raw.toLowerCase().split("-")[0];
+			const byBase = LANGUAGE_OPTIONS.find(
+				(option) => option.code.toLowerCase().split("-")[0] === base,
+			);
+			if (byBase) return byBase.code;
+		}
+	} catch {
+		// Ignore: fall through to the unset default.
+	}
+	return "";
+}
+
 // Static IANA timezone list keeps SSR and client markup deterministic.
 const TIMEZONE_OPTIONS = `
 Africa/Abidjan

--- a/apps/web/src/hosted/runtimes.ts
+++ b/apps/web/src/hosted/runtimes.ts
@@ -2,6 +2,7 @@ import type { DeploymentDetailsInfo, HostedDeployment } from "@/hosted/billing/c
 
 export const HOSTED_RUNTIMES = ["openclaw", "hermes"] as const;
 export type HostedRuntime = (typeof HOSTED_RUNTIMES)[number];
+export const DEFAULT_HOSTED_RUNTIME: HostedRuntime = "openclaw";
 
 const RUNTIME_ORDER = new Map<HostedRuntime, number>(
 	HOSTED_RUNTIMES.map((runtime, index) => [runtime, index]),
@@ -42,7 +43,7 @@ export function sortHostedRuntimes(values: Iterable<string>): HostedRuntime[] {
 
 export function configRuntime(configInfo: DeploymentDetailsInfo | null | undefined): HostedRuntime {
 	const runtime = configInfo?.runtime;
-	return runtime && isHostedRuntime(runtime) ? runtime : "openclaw";
+	return runtime && isHostedRuntime(runtime) ? runtime : DEFAULT_HOSTED_RUNTIME;
 }
 
 export function deploymentRuntime(deployment: HostedDeployment): HostedRuntime {


### PR DESCRIPTION
## Summary
Restores sensible defaults in the Cloud dashboard v2 deploy wizard without changing the hosted API contract or backend.

Vercel deploys the dashboard on merge, so this PR keeps the change scoped to `apps/web` only.

## Owner Feedback Mapping
1. Runtime default
- Restored the wizard's default runtime to `openclaw`, using a shared hosted runtime default constant.
- The runtime selector still allows switching to Hermes.
- Removed the null-runtime submit gating and obsolete runtime-default warning copy, while still sending `runtime` explicitly on the request body.

2. AI provider default
- Restored the wizard's default AI mode to the managed/configured path.
- The form now opens with `Managed by Clawdi` selected, and the default request shape stays on the explicit managed wire contract (`ai_provider_auth_kind: "managed"` with managed provider + primary model).
- Unmanaged and BYOK/OAuth provider choices remain selectable.

3. Personalize / unset name
- I confirmed the current v2 deploy wizard does not expose any assistant-name or personality field in this flow.
- I did not invent new UI for that.
- The request-builder test continues to assert that the unset path is valid by omitting `assistant_name` and `personality` entirely.

4. Jargon / obsolete messaging
- Removed the runtime warning text that referenced the hosted API no longer applying a default.
- Removed the now-unreachable `Choose a runtime` toast path.
- Updated the AI choice badges so unmanaged no longer claims to be the default; managed now carries the default badge state.

## Verification
- `bun test apps/web/src/hosted/billing/deploy/deploy-request.test.ts apps/web/src/hosted/billing/deploy/deploy-defaults.test.ts apps/web/src/hosted/billing/deploy/deploy-model.test.ts`
- `bun run --cwd apps/web typecheck`
- `bun run typecheck`
- `bun run check`
- Local UI check via one-off Playwright script against `bun run dev` with stubbed APIs:
  - `/deploy` rendered with `OpenClaw` pre-selected.
  - `Managed by Clawdi` rendered selected by default.
  - The Personalize language control rendered with `Default` selected.

