### PR TITLE
fix(cli): cache content-hashed runtime UI assets

### DIFF
--- a/packages/cli/src/runtime/bridge.ts
+++ b/packages/cli/src/runtime/bridge.ts
@@ -81,6 +81,9 @@ const HEALTH_CONNECT_TIMEOUT_MS = 1_000;
 const MAX_HEADER_BYTES = 64 * 1024;
 const BRIDGE_PUBLIC_PREFIX_SCRIPT_PATH = "/__clawdi_runtime_bridge_prefix.js";
 const RUNTIME_UI_REDEMPTION_SUBJECT = "v2_hosted_runtime_ui";
+const IMMUTABLE_ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable";
+const CONTENT_HASHED_ASSET_PATH =
+	/^\/(?:assets|static)\/(?:[^/]+\/)*[^/]*-[A-Za-z0-9_-]{8,}\.(?:js|css|woff2|woff|ttf|svg|png|ico|map)$/;
 const BRIDGE_PUBLIC_PREFIX_SCRIPT = String.raw`
 (() => {
 	const script = document.currentScript;
@@ -472,7 +475,15 @@ function proxyRawRequest(
 		connected = true;
 		clearTimeout(timer);
 		if (!isUpgrade) {
-			pipeUpstreamHttpResponse(upstreamSocket, clientSocket, frameAncestors, publicPrefix);
+			const upstreamPath = requestUrl(proxyPath(parsed.requestTarget))?.pathname ?? "/";
+			pipeUpstreamHttpResponse(
+				upstreamSocket,
+				clientSocket,
+				frameAncestors,
+				publicPrefix,
+				parsed.method,
+				upstreamPath,
+			);
 		}
 		upstreamSocket.write(buildProxyRequestHead(parsed, surface));
 		if (remaining.length > 0) upstreamSocket.write(remaining);
@@ -498,6 +509,8 @@ function pipeUpstreamHttpResponse(
 	clientSocket: Socket,
 	frameAncestors: string,
 	publicPrefix: string,
+	requestMethod: string,
+	requestPath: string,
 ): void {
 	let buffer = Buffer.alloc(0);
 	let handled = false;
@@ -522,7 +535,13 @@ function pipeUpstreamHttpResponse(
 			upstreamSocket.on("data", (nextChunk) => chunks.push(nextChunk));
 			upstreamSocket.once("end", () => {
 				const body = rewriteHtmlBody(Buffer.concat(chunks));
-				const head = rewriteResponseHeadForFrameEmbedding(rawHead, frameAncestors, body.length);
+				const head = rewriteResponseHeadForFrameEmbedding(
+					rawHead,
+					frameAncestors,
+					requestMethod,
+					requestPath,
+					body.length,
+				);
 				clientSocket.end(Buffer.concat([Buffer.from(`${head}\r\n\r\n`, "latin1"), body]));
 			});
 			upstreamSocket.once("close", () => {
@@ -530,7 +549,12 @@ function pipeUpstreamHttpResponse(
 			});
 			return;
 		}
-		const head = rewriteResponseHeadForFrameEmbedding(rawHead, frameAncestors);
+		const head = rewriteResponseHeadForFrameEmbedding(
+			rawHead,
+			frameAncestors,
+			requestMethod,
+			requestPath,
+		);
 		clientSocket.write(Buffer.from(`${head}\r\n\r\n`, "latin1"));
 		if (remaining.length > 0) clientSocket.write(remaining);
 		upstreamSocket.pipe(clientSocket);
@@ -595,6 +619,8 @@ function publicPathPrefix(headers: Map<string, string[]>): string {
 function rewriteResponseHeadForFrameEmbedding(
 	rawHead: string,
 	frameAncestors: string,
+	requestMethod: string,
+	requestPath: string,
 	contentLength?: number,
 ): string {
 	const lines = rawHead.split("\r\n");
@@ -602,6 +628,7 @@ function rewriteResponseHeadForFrameEmbedding(
 	if (!statusLine) return rawHead;
 	const output = [statusLine];
 	const cspValues: string[] = [];
+	let hasCacheControl = false;
 	for (const line of lines) {
 		const index = line.indexOf(":");
 		if (index <= 0) {
@@ -611,6 +638,7 @@ function rewriteResponseHeadForFrameEmbedding(
 		const name = line.slice(0, index);
 		const value = line.slice(index + 1).trimStart();
 		const lowerName = name.toLowerCase();
+		if (lowerName === "cache-control") hasCacheControl = true;
 		if (lowerName === "x-frame-options") continue;
 		if (lowerName === "content-security-policy") {
 			const sanitized = removeCspDirective(value, "frame-ancestors");
@@ -619,6 +647,14 @@ function rewriteResponseHeadForFrameEmbedding(
 		}
 		if (contentLength !== undefined && lowerName === "content-length") continue;
 		output.push(line);
+	}
+	if (
+		requestMethod === "GET" &&
+		/^HTTP\/\d\.\d 200(?: |$)/.test(statusLine) &&
+		CONTENT_HASHED_ASSET_PATH.test(requestPath) &&
+		!hasCacheControl
+	) {
+		output.push(`Cache-Control: ${IMMUTABLE_ASSET_CACHE_CONTROL}`);
 	}
 	for (const value of cspValues) {
 		output.push(`Content-Security-Policy: ${value}`);

--- a/packages/cli/tests/runtime-bridge.test.ts
+++ b/packages/cli/tests/runtime-bridge.test.ts
@@ -327,6 +327,93 @@ describe("runtime bridge", () => {
 		}
 	});
 
+	it("adds immutable caching only to successful GETs for content-hashed assets", async () => {
+		const upstream = createServer((req, res) => {
+			const url = new URL(req.url ?? "/", "http://runtime.local");
+			const headers: Record<string, string> = {
+				"Content-Type": url.pathname.endsWith(".html")
+					? "text/html; charset=utf-8"
+					: "application/octet-stream",
+			};
+			if (url.searchParams.has("upstream-cache")) {
+				headers["Cache-Control"] = "private, max-age=60";
+			}
+			res.writeHead(url.searchParams.has("missing") ? 404 : 200, headers);
+			res.end("asset");
+		});
+		await listen(upstream, "127.0.0.1", 0);
+		const bridge = await startRuntimeBridge({
+			token: "asset-token",
+			surfaces: [
+				{
+					...HERMES_SURFACE,
+					listenHost: "127.0.0.1",
+					listenPort: 0,
+					upstreamPort: serverPort(upstream),
+				},
+			],
+		});
+		const bridgePort = bridge.surfaces[0]?.listenPort;
+		if (bridgePort === undefined) throw new Error("bridge did not expose a port");
+		const immutable = "public, max-age=31536000, immutable";
+		const cases = [
+			{
+				name: "hashed JavaScript",
+				path: "/assets/index-AbCd1234.js",
+				expected: immutable,
+			},
+			{
+				name: "hashed CSS behind a public path prefix",
+				path: "/assets/theme-A_b-1234.css?theme=dark",
+				headers: { "X-Forwarded-Prefix": "/v2-hermes-9119" },
+				expected: immutable,
+			},
+			{ name: "HTML", path: "/assets/index-AbCd1234.html", expected: null },
+			{ name: "API path", path: "/api/assets/index-AbCd1234.js", expected: null },
+			{
+				name: "upstream cache policy",
+				path: "/assets/index-AbCd1234.js?upstream-cache=1",
+				expected: "private, max-age=60",
+			},
+			{
+				name: "non-200 response",
+				path: "/assets/missing-AbCd1234.js?missing=1",
+				status: 404,
+				expected: null,
+			},
+			{
+				name: "non-GET request",
+				path: "/assets/index-AbCd1234.js",
+				method: "POST",
+				expected: null,
+			},
+			{ name: "unhashed filename", path: "/assets/index.js", expected: null },
+		] as const;
+
+		try {
+			for (const testCase of cases) {
+				const response = await bridgeHttpRequest({
+					port: bridgePort,
+					path: testCase.path,
+					method: "method" in testCase ? testCase.method : "GET",
+					headers: {
+						...("headers" in testCase ? testCase.headers : {}),
+					},
+					cookie: `${RUNTIME_BRIDGE_COOKIE}=asset-token`,
+				});
+				expect(response.statusCode, testCase.name).toBe(
+					"status" in testCase ? testCase.status : 200,
+				);
+				expect(response.headers.get("cache-control") ?? null, testCase.name).toBe(
+					testCase.expected,
+				);
+			}
+		} finally {
+			await bridge.close();
+			await close(upstream);
+		}
+	});
+
 	it("leaves wildcard-subdomain HTML bodies unchanged when no public path prefix is present", async () => {
 		const html =
 			'<html><head><link rel="stylesheet" href="/style.css"></head><body><script src="/app.js"></script></body></html>';
@@ -860,6 +947,49 @@ describe("runtime bridge", () => {
 		}
 	});
 });
+
+function bridgeHttpRequest(input: {
+	port: number;
+	path: string;
+	method: string;
+	cookie: string;
+	headers?: Record<string, string>;
+}): Promise<{ statusCode: number; headers: Map<string, string> }> {
+	return new Promise((resolve, reject) => {
+		const socket = connect(input.port, "127.0.0.1");
+		let buffer = "";
+		socket.once("error", reject);
+		socket.on("data", (chunk) => {
+			buffer += chunk.toString("latin1");
+			if (!buffer.includes("\r\n\r\n")) return;
+			socket.destroy();
+			const [head] = buffer.split("\r\n\r\n");
+			const lines = (head ?? "").split("\r\n");
+			const statusCode = Number.parseInt(lines.shift()?.split(" ")[1] ?? "0", 10);
+			const headers = new Map<string, string>();
+			for (const line of lines) {
+				const separator = line.indexOf(":");
+				if (separator <= 0) continue;
+				headers.set(line.slice(0, separator).toLowerCase(), line.slice(separator + 1).trim());
+			}
+			resolve({ statusCode, headers });
+		});
+		socket.once("connect", () => {
+			socket.write(
+				[
+					`${input.method} ${input.path} HTTP/1.1`,
+					`Host: 127.0.0.1:${input.port}`,
+					"Connection: close",
+					`Cookie: ${input.cookie}`,
+					...(input.method === "GET" ? [] : ["Content-Length: 0"]),
+					...Object.entries(input.headers ?? {}).map(([name, value]) => `${name}: ${value}`),
+					"",
+					"",
+				].join("\r\n"),
+			);
+		});
+	});
+}
 
 function websocketRequest(input: {
 	port: number;


### PR DESCRIPTION
## Summary

- inject `Cache-Control: public, max-age=31536000, immutable` for successful GET responses to conservatively matched content-hashed runtime UI assets
- preserve upstream Cache-Control decisions and leave HTML, API paths, errors, redirects, non-GET requests, and unhashed files unchanged
- match the upstream-facing pathname, including iframe requests routed with `x-forwarded-prefix`

## Testing

- `bun run --cwd packages/cli typecheck`
- `bun run --cwd packages/cli test` (986 passed)
- `bun test --isolate --max-concurrency=1 tests/runtime-bridge.test.ts` (18 passed)
- `bunx biome check packages/cli/src/runtime/bridge.ts packages/cli/tests/runtime-bridge.test.ts`

## Rollout

This ships via the next CLI beta publish plus exact promotion; no image rebuild is required. This PR does not perform the release, publish anything, or operate against a live environment.