### PR TITLE
feat(web): add funded Basic compute flow

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -296,6 +296,30 @@ test("free-funded Basic uses annual compute_basic checkout when the included slo
 	expect(errors, `paid Basic checkout: ${errors.join(" | ")}`).toEqual([]);
 });
 
+test("compute plans keep signup credits without advertising subscription credit grants", async ({
+	page,
+}) => {
+	const errors = collectBrowserErrors(page);
+	await stubHostedApi(page, {
+		deployments: [paidBasicDeployment],
+		plans: [
+			{ ...basicPlan, subscription_grant_credits: 500 },
+			{ ...performancePlan, subscription_grant_credits: 1_000 },
+		],
+	});
+	await page.goto("/channels?settings=billing-plan");
+
+	const settingsDialog = page.getByTestId("settings-dialog");
+	await expect(settingsDialog).toBeVisible();
+	await expect(
+		settingsDialog.getByText("$5.00 in AI Credits on signup", { exact: true }),
+	).toBeVisible();
+	await expect(settingsDialog).not.toContainText("AI Credits per subscription");
+	await expect(settingsDialog).not.toContainText("AI Credits added to Wallet");
+	await expect(settingsDialog).not.toContainText("credits do not expire");
+	expect(errors, `compute plan comparison: ${errors.join(" | ")}`).toEqual([]);
+});
+
 test("command palette opens with Ctrl+K", async ({ page }) => {
 	const errors = collectBrowserErrors(page);
 	await stubHostedApi(page);

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -271,9 +271,10 @@ async function gotoHostedAgentSettings(
 	page: Page,
 	deploymentId: string,
 	tier: "Basic" | "Performance",
+	search = "",
 ) {
 	for (let attempt = 0; attempt < 2; attempt += 1) {
-		await page.goto(`/agents/${deploymentId}/settings`);
+		await page.goto(`/agents/${deploymentId}/settings${search}`);
 		try {
 			await expect(page.getByText(`${tier} compute`, { exact: true })).toBeVisible();
 			return;
@@ -403,6 +404,26 @@ test("included Basic starts annual Performance checkout without direct tier swit
 	expect(errors, `included Basic upgrade: ${errors.join(" | ")}`).toEqual([]);
 });
 
+test("included Basic checkout abandonment preserves the current plan", async ({ page }) => {
+	const checkoutRequests: string[] = [];
+	await stubHostedApi(page, {
+		checkoutRequests,
+		deployments: [includedBasicDeployment],
+		plans: [basicPlan, performancePlan],
+	});
+	await gotoHostedAgentSettings(page, "hdep_included", "Basic", "?checkout=cancel");
+	const errors = collectBrowserErrors(page);
+
+	await expect(page.getByText("Checkout canceled", { exact: true })).toBeVisible();
+	await expect(
+		page.getByText("You were not charged. Your compute plan is unchanged.", { exact: true }),
+	).toBeVisible();
+	await expect(page.getByRole("button", { name: "Upgrade to Performance" })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Cancel subscription" })).toHaveCount(0);
+	expect(checkoutRequests).toEqual([]);
+	expect(errors, `included Basic checkout abandonment: ${errors.join(" | ")}`).toEqual([]);
+});
+
 test("paid Basic cancellation stays conditional with the included slot vacant or occupied", async ({
 	page,
 }) => {
@@ -498,23 +519,23 @@ test("occupied included Basic start surfaces the backend slot entitlement error"
 	]);
 });
 
-test("checkout abandonment leaves the Basic wizard unchanged and creates no deployment", async ({
-	page,
-}) => {
+test("paid Basic checkout abandonment preserves the checkout-ready wizard", async ({ page }) => {
 	const errors = collectBrowserErrors(page);
 	const checkoutRequests: string[] = [];
 	const createRequests: string[] = [];
 	await stubHostedApi(page, {
 		checkoutRequests,
 		createRequests,
-		deployments: [],
+		deployments: [includedBasicDeployment],
 		plans: [basicPlan, performancePlan],
 	});
 	await page.goto("/deploy?checkout=cancel");
 
 	await expect(page.getByText("Checkout canceled", { exact: true })).toBeVisible();
 	await expect(page.getByText("You were not charged. Your agent was not deployed.")).toBeVisible();
-	await expect(page.getByText("First slot free", { exact: true })).toBeVisible();
+	await expect(page.getByText("$9/mo additional", { exact: true })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Continue to checkout" })).toBeVisible();
+	await expect(page.getByText("First slot free", { exact: true })).toHaveCount(0);
 	expect(checkoutRequests).toEqual([]);
 	expect(createRequests).toEqual([]);
 	expect(errors, `checkout abandonment: ${errors.join(" | ")}`).toEqual([]);

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -15,24 +15,145 @@ const emptyPage = { items: [], total: 0, page: 1, page_size: 25 };
 const CLOUD_API = "http://127.0.0.1:8000";
 const DEPLOY_API = "http://127.0.0.1:8001";
 
+const basicPlan = {
+	slug: "compute_basic",
+	name: "Basic",
+	price_cents: 900,
+	points_per_usd: 100,
+	signup_grant_credits: 500,
+	subscription_grant_credits: 0,
+	vcpu: 1,
+	ram_gb: 2,
+	disk_size: 20,
+	offers: [
+		{
+			billing_term_months: 1,
+			price_cents: 900,
+			effective_monthly_price_cents: 900,
+			discount_percent: 0,
+		},
+		{
+			billing_term_months: 12,
+			price_cents: 9_000,
+			effective_monthly_price_cents: 750,
+			discount_percent: 17,
+		},
+	],
+};
+
+const performancePlan = {
+	slug: "compute_performance",
+	name: "Performance",
+	price_cents: 1_900,
+	points_per_usd: 100,
+	signup_grant_credits: 500,
+	subscription_grant_credits: 500,
+	vcpu: 4,
+	ram_gb: 8,
+	disk_size: 80,
+	offers: [
+		{
+			billing_term_months: 1,
+			price_cents: 1_900,
+			effective_monthly_price_cents: 1_900,
+			discount_percent: 0,
+		},
+		{
+			billing_term_months: 12,
+			price_cents: 19_000,
+			effective_monthly_price_cents: 1_583,
+			discount_percent: 17,
+		},
+	],
+};
+
+const includedBasicDeployment = {
+	id: "hdep_included",
+	user_id: "usr_browser",
+	name: "Included Basic",
+	app_id: "v2-browser",
+	status: "running",
+	created_at: "2026-07-15T00:00:00Z",
+	upgrade_available: true,
+	compute_subscription: null,
+	config_info: {
+		compute_plan_slug: "compute_basic",
+		mux_enabled: false,
+		telegram_mux_enabled: false,
+		discord_mux_enabled: false,
+		whatsapp_mux_enabled: false,
+		imessage_mux_enabled: false,
+		kobb_available: false,
+		ai_provider_auth_kind: "managed",
+		runtime: "hermes",
+		clawdi_cloud_environments: {},
+		ai_provider_bindings: {},
+		public_ports: [],
+	},
+};
+
+const paidBasicDeployment = {
+	...includedBasicDeployment,
+	id: "hdep_paid",
+	name: "Paid Basic",
+	compute_subscription: {
+		status: "active",
+		payment_state: "ok",
+		billing_term_months: 12,
+		price_cents: 9_000,
+		currency: "usd",
+		cancel_at_period_end: false,
+	},
+};
+
+type HostedApiStubOptions = {
+	checkoutRequests?: string[];
+	createRequests?: string[];
+	deployments?: readonly unknown[];
+	plans?: readonly unknown[];
+};
+
 async function fulfillJson(route: Route, body: unknown) {
 	await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
 }
 
-async function stubHostedApi(page: Page) {
+async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
+	const deployments = options.deployments ?? [];
+	const plans = options.plans ?? [];
 	// Deploy API (/me, /v2/*).
 	await page.route(`${DEPLOY_API}/**`, (r) => {
 		const p = new URL(r.request().url()).pathname;
-		if (p === "/me") return fulfillJson(r, me);
-		if (p === "/v2/subscription/plans") return fulfillJson(r, []);
-		if (p === "/v2/deployments") return fulfillJson(r, []);
+		if (p === "/me" || p === "/v1/me") return fulfillJson(r, me);
+		if (p === "/v2/subscription/plans") return fulfillJson(r, plans);
+		if (p === "/v2/deployments" && r.request().method() === "GET") {
+			return fulfillJson(r, deployments);
+		}
+		if (p === "/v2/deployments" && r.request().method() === "POST") {
+			options.createRequests?.push(r.request().postData() ?? "");
+			return fulfillJson(r, {
+				...includedBasicDeployment,
+				id: "hdep_created",
+				name: "Created Basic",
+				status: "starting",
+			});
+		}
+		if (p === "/v2/subscription/checkout" && r.request().method() === "POST") {
+			options.checkoutRequests?.push(r.request().postData() ?? "");
+			return fulfillJson(r, {
+				flow_type: "checkout_session",
+				action_url: null,
+				checkout_url: "http://127.0.0.1:3100/deploy?mockCheckout=browser",
+				client_secret: null,
+			});
+		}
 		return fulfillJson(r, {});
 	});
 	// Cloud API (/v1/*).
 	await page.route(`${CLOUD_API}/**`, (r) => {
 		const p = new URL(r.request().url()).pathname;
+		if (p === "/v1/me") return fulfillJson(r, me);
 		if (p === "/v1/agents") return fulfillJson(r, []);
-		if (p === "/v1/ai-providers") return fulfillJson(r, []);
+		if (p === "/v1/ai-providers") return fulfillJson(r, { providers: [] });
 		if (p === "/v1/channels") return fulfillJson(r, []);
 		if (p === "/v1/channels/bot-pool") return fulfillJson(r, { providers: {} });
 		if (p === "/v1/channels/health") return fulfillJson(r, { items: [] });
@@ -41,6 +162,28 @@ async function stubHostedApi(page: Page) {
 		if (p === "/v1/auth/keys") return fulfillJson(r, []);
 		return fulfillJson(r, {});
 	});
+}
+
+async function expectNoQuarterlyCopy(page: Page) {
+	await expect(page.getByText("Quarterly", { exact: true })).toHaveCount(0);
+	await expect(page.getByText(/\/qtr/)).toHaveCount(0);
+}
+
+async function capturePricingScreenshot(page: Page, path: string) {
+	await page.addStyleTag({
+		content: `
+			* { animation: none !important; transition: none !important; }
+			::view-transition-old(root), ::view-transition-new(root) {
+				animation: none !important;
+			}
+		`,
+	});
+	const basicCard = page.getByRole("button", { name: /^Basic/ });
+	await basicCard.evaluate((element) => {
+		element.scrollIntoView({ block: "center", inline: "nearest" });
+	});
+	await page.waitForTimeout(1_000);
+	await basicCard.locator("xpath=ancestor::section[1]").screenshot({ path });
 }
 
 function collectBrowserErrors(page: Page): string[] {
@@ -78,6 +221,77 @@ test("deploy wizard Select opens without browser errors", async ({ page }) => {
 	await page.getByRole("option").first().click();
 	await page.waitForTimeout(150);
 	expect(errors, `language select: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("paid-funded Basic leaves the included slot available for direct compute_basic deploy", async ({
+	page,
+}) => {
+	const errors = collectBrowserErrors(page);
+	const createRequests: string[] = [];
+	await page.setViewportSize({ width: 1_440, height: 1_100 });
+	await page.emulateMedia({ reducedMotion: "reduce" });
+	await stubHostedApi(page, {
+		createRequests,
+		deployments: [paidBasicDeployment],
+		plans: [basicPlan, performancePlan],
+	});
+	await page.goto("/deploy");
+	await page.waitForLoadState("networkidle");
+
+	await expect(page.getByText("First slot free", { exact: true })).toBeVisible();
+	await expect(
+		page.getByText(/First active agent free · then \$9\/mo per additional agent/),
+	).toBeVisible();
+	await expectNoQuarterlyCopy(page);
+	await capturePricingScreenshot(page, "/tmp/basic-paid-funded-slot-available-final.png");
+
+	await page.getByRole("button", { name: "Deploy agent" }).click();
+	await expect.poll(() => createRequests.length).toBe(1);
+	expect(JSON.parse(createRequests[0] ?? "{}")).toMatchObject({
+		compute_plan_slug: "compute_basic",
+	});
+	expect(errors, `direct Basic deploy: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("free-funded Basic uses annual compute_basic checkout when the included slot is occupied", async ({
+	page,
+}) => {
+	const errors = collectBrowserErrors(page);
+	const checkoutRequests: string[] = [];
+	await page.setViewportSize({ width: 1_440, height: 1_100 });
+	await page.emulateMedia({ reducedMotion: "reduce" });
+	await stubHostedApi(page, {
+		checkoutRequests,
+		deployments: [includedBasicDeployment],
+		plans: [basicPlan, performancePlan],
+	});
+	await page.goto("/deploy");
+	await page.waitForLoadState("networkidle");
+
+	await expect(page.getByText("$9/mo additional", { exact: true })).toBeVisible();
+	await expect(page.getByText("Monthly", { exact: true })).toBeVisible();
+	const annualTerm = page.getByRole("button", { name: /Annual/ });
+	await expect(annualTerm).toBeVisible();
+	await expectNoQuarterlyCopy(page);
+	await annualTerm.click();
+	await expect(
+		page.getByText(
+			/First active agent free · then \$7.5\/mo, billed \$90\/yr per additional agent/,
+		),
+	).toBeVisible();
+	await expect(
+		page.getByText(/additional Basic agent at \$7.5\/mo, billed \$90\/yr/),
+	).toBeVisible();
+	await capturePricingScreenshot(page, "/tmp/basic-free-funded-slot-occupied-final.png");
+
+	await page.getByRole("button", { name: "Continue to checkout" }).click();
+	await expect.poll(() => checkoutRequests.length).toBe(1);
+	expect(JSON.parse(checkoutRequests[0] ?? "{}")).toMatchObject({
+		plan_slug: "compute_basic",
+		billing_term_months: 12,
+		deploy_config: { compute_plan_slug: "compute_basic" },
+	});
+	expect(errors, `paid Basic checkout: ${errors.join(" | ")}`).toEqual([]);
 });
 
 test("command palette opens with Ctrl+K", async ({ page }) => {

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -108,15 +108,35 @@ const paidBasicDeployment = {
 	},
 };
 
+const performanceDeployment = {
+	...paidBasicDeployment,
+	id: "hdep_performance",
+	name: "Performance agent",
+	config_info: {
+		...paidBasicDeployment.config_info,
+		compute_plan_slug: "compute_performance",
+	},
+};
+
+const stoppedIncludedBasicDeployment = {
+	...includedBasicDeployment,
+	id: "hdep_stopped",
+	name: "Stopped Basic",
+	status: "stopped",
+};
+
 type HostedApiStubOptions = {
+	cancelRequests?: string[];
 	checkoutRequests?: string[];
 	createRequests?: string[];
 	deployments?: readonly unknown[];
 	plans?: readonly unknown[];
+	startError?: { status: number; detail: string };
+	startRequests?: string[];
 };
 
-async function fulfillJson(route: Route, body: unknown) {
-	await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
+async function fulfillJson(route: Route, body: unknown, status = 200) {
+	await route.fulfill({ status, contentType: "application/json", body: JSON.stringify(body) });
 }
 
 async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
@@ -148,6 +168,23 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 				client_secret: null,
 			});
 		}
+		if (p === "/v2/subscription/cancel" && r.request().method() === "POST") {
+			options.cancelRequests?.push(r.request().postData() ?? "");
+			return fulfillJson(r, {
+				status: "active",
+				billing_term_months: 12,
+				cancel_at_period_end: true,
+				current_period_end: "2026-08-15T00:00:00Z",
+				cancel_at: "2026-08-15T00:00:00Z",
+			});
+		}
+		if (p.endsWith("/start") && r.request().method() === "POST") {
+			options.startRequests?.push(r.request().postData() ?? "");
+			if (options.startError) {
+				return fulfillJson(r, { detail: options.startError.detail }, options.startError.status);
+			}
+			return fulfillJson(r, { status: "starting" });
+		}
 		return fulfillJson(r, {});
 	});
 	// Cloud API (/v1/*).
@@ -155,6 +192,30 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		const p = new URL(r.request().url()).pathname;
 		if (p === "/v1/me") return fulfillJson(r, me);
 		if (p === "/v1/agents") return fulfillJson(r, []);
+		if (p.startsWith("/v1/agents/") && r.request().method() === "GET") {
+			const id = decodeURIComponent(p.slice("/v1/agents/".length));
+			return fulfillJson(r, {
+				id,
+				name: id,
+				default_name: "Hosted agent",
+				machine_name: "hosted.local",
+				display_name: null,
+				avatar_url: null,
+				sort_order: 0,
+				agent_type: "hermes",
+				agent_version: "1.0.0",
+				os: "linux",
+				last_seen_at: "2026-07-15T00:00:00Z",
+				last_sync_at: "2026-07-15T00:00:00Z",
+				last_sync_error: null,
+				last_revision_seen: 1,
+				queue_depth_high_water: 0,
+				dropped_count: 0,
+				sync_enabled: true,
+				explicit_identity: true,
+				default_project_id: "project-hosted",
+			});
+		}
 		if (p === "/v1/ai-providers") return fulfillJson(r, { providers: [] });
 		if (p === "/v1/channels") return fulfillJson(r, []);
 		if (p === "/v1/channels/bot-pool") return fulfillJson(r, { providers: {} });
@@ -204,6 +265,22 @@ async function expectNonZeroBox(locator: ReturnType<Page["locator"]>, label: str
 	expect(box, `${label} should render a layout box`).not.toBeNull();
 	expect(box?.width, `${label} width`).toBeGreaterThan(0);
 	expect(box?.height, `${label} height`).toBeGreaterThan(0);
+}
+
+async function gotoHostedAgentSettings(
+	page: Page,
+	deploymentId: string,
+	tier: "Basic" | "Performance",
+) {
+	for (let attempt = 0; attempt < 2; attempt += 1) {
+		await page.goto(`/agents/${deploymentId}/settings`);
+		try {
+			await expect(page.getByText(`${tier} compute`, { exact: true })).toBeVisible();
+			return;
+		} catch (error) {
+			if (attempt === 1) throw error;
+		}
+	}
 }
 
 test("deploy wizard Select opens without browser errors", async ({ page }) => {
@@ -294,6 +371,153 @@ test("free-funded Basic uses annual compute_basic checkout when the included slo
 		deploy_config: { compute_plan_slug: "compute_basic" },
 	});
 	expect(errors, `paid Basic checkout: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("included Basic starts annual Performance checkout without direct tier switching", async ({
+	page,
+}) => {
+	const checkoutRequests: string[] = [];
+	await stubHostedApi(page, {
+		checkoutRequests,
+		deployments: [includedBasicDeployment],
+		plans: [basicPlan, performancePlan],
+	});
+	await gotoHostedAgentSettings(page, "hdep_included", "Basic");
+	const errors = collectBrowserErrors(page);
+
+	await expect(page.getByRole("button", { name: "Upgrade to Performance" })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Change billing term" })).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Cancel subscription" })).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Restart", exact: true })).toBeEnabled();
+	await expect(page.getByRole("button", { name: "Stop", exact: true })).toBeEnabled();
+	await expect(page.getByRole("button", { name: "Start", exact: true })).toHaveCount(0);
+
+	await page.getByRole("button", { name: /Annual/ }).click();
+	await page.getByRole("button", { name: "Upgrade to Performance" }).click();
+	await expect.poll(() => checkoutRequests.length).toBe(1);
+	expect(JSON.parse(checkoutRequests[0] ?? "{}")).toMatchObject({
+		plan_slug: "compute_performance",
+		billing_term_months: 12,
+		upgrade_deployment_id: "hdep_included",
+	});
+	expect(errors, `included Basic upgrade: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("paid Basic cancellation stays conditional with the included slot vacant or occupied", async ({
+	page,
+}) => {
+	const cancelRequests: string[] = [];
+	const deployments: unknown[] = [paidBasicDeployment];
+	await stubHostedApi(page, {
+		cancelRequests,
+		deployments,
+		plans: [basicPlan, performancePlan],
+	});
+	await gotoHostedAgentSettings(page, "hdep_paid", "Basic");
+	const errors = collectBrowserErrors(page);
+
+	for (const [index, label] of ["vacant", "occupied"].entries()) {
+		if (label === "occupied") deployments.push(includedBasicDeployment);
+		if (index > 0) await gotoHostedAgentSettings(page, "hdep_paid", "Basic");
+
+		await expect(page.getByRole("button", { name: "Change billing term" })).toBeVisible();
+		await expect(page.getByRole("button", { name: "Cancel subscription" })).toBeVisible();
+		await expect(page.getByRole("button", { name: "Upgrade to Performance" })).toHaveCount(0);
+
+		await page.getByRole("button", { name: "Cancel subscription" }).click();
+		const cancelDialog = page.getByRole("alertdialog");
+		await expect(
+			cancelDialog.getByText("Cancel Basic subscription?", { exact: true }),
+		).toBeVisible();
+		await expect(
+			cancelDialog.getByText(
+				/falls back to included Basic funding if available; otherwise, it stops/,
+			),
+		).toBeVisible();
+		await cancelDialog.getByRole("button", { name: "Cancel at period end" }).click();
+
+		await expect.poll(() => cancelRequests.length, { message: label }).toBe(index + 1);
+		expect(JSON.parse(cancelRequests[index] ?? "{}")).toMatchObject({
+			deployment_id: "hdep_paid",
+		});
+		await expect(
+			page.getByText("Subscription cancellation scheduled", { exact: true }),
+		).toBeVisible();
+		await expect(page.getByRole("button", { name: "Resume subscription" })).toBeVisible();
+	}
+	expect(errors, `paid Basic cancellation: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("paid Performance exposes subscription actions without a direct Basic switch", async ({
+	page,
+}) => {
+	await stubHostedApi(page, {
+		deployments: [performanceDeployment],
+		plans: [basicPlan, performancePlan],
+	});
+	await gotoHostedAgentSettings(page, "hdep_performance", "Performance");
+	const errors = collectBrowserErrors(page);
+
+	await expect(page.getByRole("button", { name: "Change billing term" })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Cancel subscription" })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Upgrade to Performance" })).toHaveCount(0);
+	await expect(page.getByRole("button", { name: /switch|downgrade/i })).toHaveCount(0);
+	expect(errors, `paid Performance actions: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("occupied included Basic start surfaces the backend slot entitlement error", async ({
+	page,
+}) => {
+	const startRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments: [stoppedIncludedBasicDeployment, includedBasicDeployment],
+		plans: [basicPlan, performancePlan],
+		startError: {
+			status: 403,
+			detail: "The Compute Basic free slot allows only one active deployment.",
+		},
+		startRequests,
+	});
+	await gotoHostedAgentSettings(page, "hdep_stopped", "Basic");
+	const errors = collectBrowserErrors(page);
+
+	await expect(page.getByRole("button", { name: "Start", exact: true })).toBeEnabled();
+	await expect(page.getByRole("button", { name: "Restart", exact: true })).toBeDisabled();
+	await expect(page.getByRole("button", { name: "Stop", exact: true })).toHaveCount(0);
+	await page.getByRole("button", { name: "Start", exact: true }).click();
+
+	await expect.poll(() => startRequests.length).toBe(1);
+	await expect(page.getByText("Couldn't update lifecycle", { exact: true })).toBeVisible();
+	await expect(
+		page.getByText("The Compute Basic free slot allows only one active deployment.", {
+			exact: true,
+		}),
+	).toBeVisible();
+	expect(errors, `included Basic start entitlement: ${errors.join(" | ")}`).toEqual([
+		expect.stringMatching(/status of 403 \(Forbidden\)/),
+	]);
+});
+
+test("checkout abandonment leaves the Basic wizard unchanged and creates no deployment", async ({
+	page,
+}) => {
+	const errors = collectBrowserErrors(page);
+	const checkoutRequests: string[] = [];
+	const createRequests: string[] = [];
+	await stubHostedApi(page, {
+		checkoutRequests,
+		createRequests,
+		deployments: [],
+		plans: [basicPlan, performancePlan],
+	});
+	await page.goto("/deploy?checkout=cancel");
+
+	await expect(page.getByText("Checkout canceled", { exact: true })).toBeVisible();
+	await expect(page.getByText("You were not charged. Your agent was not deployed.")).toBeVisible();
+	await expect(page.getByText("First slot free", { exact: true })).toBeVisible();
+	expect(checkoutRequests).toEqual([]);
+	expect(createRequests).toEqual([]);
+	expect(errors, `checkout abandonment: ${errors.join(" | ")}`).toEqual([]);
 });
 
 test("compute plans keep signup credits without advertising subscription credit grants", async ({

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -17,14 +17,15 @@ const DEPLOY_API = "http://127.0.0.1:8001";
 
 const basicPlan = {
 	slug: "compute_basic",
-	name: "Basic",
+	name: "Compute Basic",
 	price_cents: 900,
 	points_per_usd: 100,
 	signup_grant_credits: 500,
 	subscription_grant_credits: 0,
-	vcpu: 1,
-	ram_gb: 2,
+	vcpu: 2,
+	ram_gb: 4,
 	disk_size: 20,
+	instance_type: null,
 	offers: [
 		{
 			billing_term_months: 1,
@@ -34,23 +35,24 @@ const basicPlan = {
 		},
 		{
 			billing_term_months: 12,
-			price_cents: 9_000,
-			effective_monthly_price_cents: 750,
-			discount_percent: 17,
+			price_cents: 8_640,
+			effective_monthly_price_cents: 720,
+			discount_percent: 20,
 		},
 	],
 };
 
 const performancePlan = {
 	slug: "compute_performance",
-	name: "Performance",
+	name: "Compute Performance",
 	price_cents: 1_900,
 	points_per_usd: 100,
 	signup_grant_credits: 500,
 	subscription_grant_credits: 500,
 	vcpu: 4,
 	ram_gb: 8,
-	disk_size: 80,
+	disk_size: 40,
+	instance_type: "tdx.large",
 	offers: [
 		{
 			billing_term_months: 1,
@@ -60,9 +62,9 @@ const performancePlan = {
 		},
 		{
 			billing_term_months: 12,
-			price_cents: 19_000,
-			effective_monthly_price_cents: 1_583,
-			discount_percent: 17,
+			price_cents: 18_000,
+			effective_monthly_price_cents: 1_500,
+			discount_percent: 21,
 		},
 	],
 };
@@ -100,7 +102,7 @@ const paidBasicDeployment = {
 		status: "active",
 		payment_state: "ok",
 		billing_term_months: 12,
-		price_cents: 9_000,
+		price_cents: 8_640,
 		currency: "usd",
 		cancel_at_period_end: false,
 	},
@@ -233,14 +235,14 @@ test("paid-funded Basic leaves the included slot available for direct compute_ba
 	await stubHostedApi(page, {
 		createRequests,
 		deployments: [paidBasicDeployment],
-		plans: [basicPlan, performancePlan],
+		plans: [{ ...basicPlan, offers: [] }, performancePlan],
 	});
 	await page.goto("/deploy");
 	await page.waitForLoadState("networkidle");
 
 	await expect(page.getByText("First slot free", { exact: true })).toBeVisible();
 	await expect(
-		page.getByText(/First active agent free · then \$9\/mo per additional agent/),
+		page.getByText(/First active agent free · paid additional agents unavailable/),
 	).toBeVisible();
 	await expectNoQuarterlyCopy(page);
 	await capturePricingScreenshot(page, "/tmp/basic-paid-funded-slot-available-final.png");
@@ -276,11 +278,11 @@ test("free-funded Basic uses annual compute_basic checkout when the included slo
 	await annualTerm.click();
 	await expect(
 		page.getByText(
-			/First active agent free · then \$7.5\/mo, billed \$90\/yr per additional agent/,
+			/First active agent free · then \$7.2\/mo, billed \$86.4\/yr per additional agent/,
 		),
 	).toBeVisible();
 	await expect(
-		page.getByText(/additional Basic agent at \$7.5\/mo, billed \$90\/yr/),
+		page.getByText(/additional Basic agent at \$7.2\/mo, billed \$86.4\/yr/),
 	).toBeVisible();
 	await capturePricingScreenshot(page, "/tmp/basic-free-funded-slot-occupied-final.png");
 

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -108,9 +108,14 @@ import {
 	newIdempotencyKey,
 } from "@/hosted/billing/idempotency";
 import {
+	COMPUTE_BASIC_SLUG,
+	COMPUTE_PERFORMANCE_SLUG,
+	computeFundingMode,
+	computeTierLabel,
 	isComputeSubscriptionCancelable,
 	isComputeSubscriptionTermChangeable,
 	planOffers,
+	resolveBasicPlan,
 	resolvePerformancePlan,
 	selectOfferForTerm,
 } from "@/hosted/billing/subscription/subscription-utils";
@@ -372,7 +377,7 @@ export function HostedAgentDetail({
 		section: activeTab,
 	});
 
-	const isPerformance = ci?.compute_plan_slug === "compute_performance";
+	const isPerformance = ci?.compute_plan_slug === COMPUTE_PERFORMANCE_SLUG;
 	const consoleUrl = runtimeConsoleUrl(deployment, runtime);
 	const searchStr = useLocation({ select: (location) => location.searchStr });
 	const scopedSessionLink = (sessionId: string) => ({
@@ -486,7 +491,6 @@ export function HostedAgentDetail({
 						<HostedAgentSettingsTab
 							environmentId={environmentId}
 							deployment={deployment}
-							isPerformance={isPerformance}
 							runtime={runtime}
 						/>
 					) : null}
@@ -728,7 +732,7 @@ function OverviewTab({
 					label="Status"
 					value={<RuntimeStatusValue deployment={deployment} agent={agent} />}
 				/>
-				<StatCard label="Compute" value={isPerformance ? "Performance" : "Free"} />
+				<StatCard label="Compute" value={isPerformance ? "Performance" : "Basic"} />
 				<StatCard label="Model" value={model} />
 				<StatCard
 					label="Resources"
@@ -1957,19 +1961,17 @@ function LinkedChannelRow({
 function HostedAgentSettingsTab({
 	environmentId,
 	deployment,
-	isPerformance,
 	runtime,
 }: {
 	environmentId: string;
 	deployment: HostedDeployment;
-	isPerformance: boolean;
 	runtime: Runtime;
 }) {
 	return (
 		<div className="flex flex-col gap-10">
 			<AgentSettingsPanel environmentId={environmentId} />
 			<LanguageTimezoneSettingsSection deployment={deployment} runtime={runtime} />
-			<ComputeSettingsSections deployment={deployment} isPerformance={isPerformance} />
+			<ComputeSettingsSections deployment={deployment} />
 		</div>
 	);
 }
@@ -2095,13 +2097,7 @@ function LanguageTimezoneSettingsSection({
 	);
 }
 
-function ComputeSettingsSections({
-	deployment,
-	isPerformance,
-}: {
-	deployment: HostedDeployment;
-	isPerformance: boolean;
-}) {
+function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment }) {
 	const router = useRouter();
 	const searchStr = useLocation({ select: (location) => location.searchStr });
 	const lifecycle = useDeploymentLifecycle();
@@ -2121,11 +2117,17 @@ function ComputeSettingsSections({
 	const canRestart = canRestartDeployment(deploymentStatus);
 	const primaryLifecycleAction: "stop" | "start" = canStop ? "stop" : "start";
 	const canRunPrimaryLifecycleAction = canStop || canStart;
+	const computePlanSlug = deployment.config_info?.compute_plan_slug;
 	const currentSubscription = deployment.compute_subscription;
+	const fundingMode = computeFundingMode(computePlanSlug, currentSubscription);
+	const isIncludedBasic = fundingMode === "included_basic";
+	const isPaidCompute = fundingMode === "subscription";
+	const tierLabel = computeTierLabel(computePlanSlug);
 	const currentBillingTerm = currentSubscription?.billing_term_months ?? 1;
 	const [term, setTerm] = useState(currentBillingTerm);
 	const [termChangeConfirmation, setTermChangeConfirmation] =
 		useState<TermChangeConfirmation | null>(null);
+	const basicPlan = useMemo(() => resolveBasicPlan(plans.data), [plans.data]);
 	const perfPlan = useMemo(() => resolvePerformancePlan(plans.data), [plans.data]);
 	const perfOffers = useMemo(() => (perfPlan ? planOffers(perfPlan) : []), [perfPlan]);
 	const perfOfferSelection = useMemo(
@@ -2133,10 +2135,22 @@ function ComputeSettingsSections({
 		[perfPlan, term],
 	);
 	const perfOffer = perfOfferSelection?.offer ?? null;
-	const selectedBillingTerm = perfOfferSelection?.billingTermMonths ?? term;
+	const currentPaidPlan =
+		computePlanSlug === COMPUTE_BASIC_SLUG
+			? basicPlan
+			: computePlanSlug === COMPUTE_PERFORMANCE_SLUG
+				? perfPlan
+				: undefined;
+	const billingPlan = isIncludedBasic ? perfPlan : currentPaidPlan;
+	const billingOffers = useMemo(() => (billingPlan ? planOffers(billingPlan) : []), [billingPlan]);
+	const billingOfferSelection = useMemo(
+		() => (billingPlan ? selectOfferForTerm(billingPlan, term) : null),
+		[billingPlan, term],
+	);
+	const selectedBillingTerm = billingOfferSelection?.billingTermMonths ?? term;
 	const currentOfferSelection = useMemo(
-		() => (perfPlan ? selectOfferForTerm(perfPlan, currentBillingTerm) : null),
-		[perfPlan, currentBillingTerm],
+		() => (currentPaidPlan ? selectOfferForTerm(currentPaidPlan, currentBillingTerm) : null),
+		[currentPaidPlan, currentBillingTerm],
 	);
 	const currentOffer =
 		currentOfferSelection?.billingTermMonths === currentBillingTerm
@@ -2152,27 +2166,30 @@ function ComputeSettingsSections({
 	const subscriptionCancelPending = !!currentSubscription?.cancel_at_period_end;
 	const subscriptionCancelable = isComputeSubscriptionCancelable(currentSubscription);
 	const canChangeBillingTerm =
-		isPerformance &&
-		!!perfPlan &&
-		!!perfOfferSelection &&
+		isPaidCompute &&
+		!!currentPaidPlan &&
+		!!billingOfferSelection &&
 		!!currentSubscription &&
 		isComputeSubscriptionTermChangeable(currentSubscription) &&
 		!subscriptionCancelPending &&
 		selectedBillingTerm !== currentBillingTerm;
-	const canUpgrade = !isPerformance && deployment.upgrade_available;
+	const canUpgrade = isIncludedBasic && deployment.upgrade_available;
 	const upgradeUnavailableMessage = plans.isLoading
 		? "Checking Performance availability..."
 		: !perfPlan
 			? "Performance compute is unavailable right now."
 			: isRunningStatus(deploymentStatus) || deploymentStatus.kind === "stopped"
-				? "An upgrade may already be pending for this Free agent."
-				: "Upgrade is available once this Free agent is running or stopped.";
+				? "An upgrade may already be pending for this Basic agent."
+				: "Upgrade is available once this Basic agent is running or stopped.";
 	useEffect(() => {
-		if (!perfOffers.length || perfOffers.some((offer) => offer.billing_term_months === term)) {
+		if (
+			!billingOffers.length ||
+			billingOffers.some((offer) => offer.billing_term_months === term)
+		) {
 			return;
 		}
-		setTerm(perfOffers[0]?.billing_term_months ?? 1);
-	}, [perfOffers, term]);
+		setTerm(billingOffers[0]?.billing_term_months ?? 1);
+	}, [billingOffers, term]);
 	useEffect(() => {
 		setTerm(currentBillingTerm);
 	}, [deployment.id, currentBillingTerm]);
@@ -2283,21 +2300,23 @@ function ComputeSettingsSections({
 		);
 	}
 
-	async function cancelPerformanceSubscription() {
+	async function cancelComputeSubscription() {
 		if (!subscriptionCancelable || subscriptionCancelPending) return;
 		try {
 			const res = await cancelSubscription.mutateAsync({ deployment_id: deployment.id });
 			toast.success("Subscription cancellation scheduled", {
 				description: res.current_period_end
-					? `Performance stays active until ${formatShortDate(res.current_period_end)}.`
-					: (res.message ?? undefined),
+					? `Cancellation takes effect ${formatShortDate(
+							res.current_period_end,
+						)}. The deployment then falls back to included Basic funding if available; otherwise, it stops.`
+					: "The deployment falls back to included Basic funding if available when cancellation takes effect; otherwise, it stops.",
 			});
 		} catch (error) {
 			toast.error("Couldn’t cancel subscription", { description: normalizeBillingError(error) });
 		}
 	}
 
-	async function resumePerformanceSubscription() {
+	async function resumeComputeSubscription() {
 		if (!subscriptionCancelable || !subscriptionCancelPending) return;
 		try {
 			await resumeSubscription.mutateAsync({ deployment_id: deployment.id });
@@ -2349,16 +2368,21 @@ function ComputeSettingsSections({
 				<div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
 					<div className="min-w-0 flex-1">
 						<div className="flex flex-wrap items-center gap-1.5 text-sm font-medium">
-							{isPerformance ? <Zap className="size-4" /> : <Cpu className="size-4" />}
-							<span>{isPerformance ? "Performance compute" : "Free compute"}</span>
+							{tierLabel === "Performance" ? (
+								<Zap className="size-4" />
+							) : (
+								<Cpu className="size-4" />
+							)}
+							<span>{tierLabel} compute</span>
 							<Badge variant="outline" className="font-normal text-muted-foreground">
 								Current
 							</Badge>
 						</div>
 						<p className="mt-1 text-xs text-muted-foreground">
-							Free uses one active slot per user. Performance uses one subscription per deployment.
+							Basic includes one free active slot per user. Paid Basic and Performance each use one
+							subscription per deployment.
 						</p>
-						{isPerformance && currentSubscription ? (
+						{isPaidCompute && currentSubscription ? (
 							<p className="mt-2 text-xs text-muted-foreground">
 								{billingTermLabel(currentBillingTerm)}
 								{currentPriceCents !== null ? (
@@ -2374,7 +2398,7 @@ function ComputeSettingsSections({
 						) : null}
 					</div>
 					<div className="flex w-full flex-col gap-2 lg:w-auto lg:min-w-64 lg:items-end">
-						{!isPerformance && perfPlan ? (
+						{isIncludedBasic && perfPlan ? (
 							<div className="text-xs text-muted-foreground sm:text-right">
 								<span className="font-medium text-foreground">
 									{perfOffer
@@ -2391,7 +2415,7 @@ function ComputeSettingsSections({
 								) : null}
 							</div>
 						) : null}
-						{!isPerformance ? (
+						{isIncludedBasic ? (
 							<div className="flex w-full flex-col gap-2 lg:w-64">
 								<TermSwitcher offers={perfOffers} value={selectedBillingTerm} onChange={setTerm} />
 								<Button
@@ -2416,9 +2440,13 @@ function ComputeSettingsSections({
 									<p className="text-xs text-muted-foreground">{upgradeUnavailableMessage}</p>
 								)}
 							</div>
-						) : (
+						) : isPaidCompute ? (
 							<div className="flex w-full flex-col gap-2 lg:w-72">
-								<TermSwitcher offers={perfOffers} value={selectedBillingTerm} onChange={setTerm} />
+								<TermSwitcher
+									offers={billingOffers}
+									value={selectedBillingTerm}
+									onChange={setTerm}
+								/>
 								<Button
 									type="button"
 									variant="outline"
@@ -2439,9 +2467,7 @@ function ComputeSettingsSections({
 										variant="outline"
 										size="sm"
 										disabled={resumeSubscription.isPending || !subscriptionCancelable}
-										onClick={() =>
-											void runAction(resumePerformanceSubscription).catch(() => undefined)
-										}
+										onClick={() => void runAction(resumeComputeSubscription).catch(() => undefined)}
 									>
 										{resumeSubscription.isPending ? (
 											<Spinner className="size-3.5" />
@@ -2452,16 +2478,16 @@ function ComputeSettingsSections({
 									</Button>
 								) : (
 									<ConfirmAction
-										title="Cancel Performance?"
+										title={`Cancel ${tierLabel} subscription?`}
 										description={
 											<p>
-												This deployment stays on Performance until {subscriptionPeriodLabel}, then
-												moves back to Free compute.
+												Cancellation takes effect {subscriptionPeriodLabel}. The deployment then
+												falls back to included Basic funding if available; otherwise, it stops.
 											</p>
 										}
 										confirmLabel="Cancel at period end"
 										destructive
-										onConfirm={() => runAction(cancelPerformanceSubscription)}
+										onConfirm={() => runAction(cancelComputeSubscription)}
 									>
 										<Button
 											type="button"
@@ -2484,7 +2510,7 @@ function ComputeSettingsSections({
 									</p>
 								) : null}
 							</div>
-						)}
+						) : null}
 					</div>
 				</div>
 			</SettingsSection>

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -112,11 +112,13 @@ import {
 	COMPUTE_PERFORMANCE_SLUG,
 	computeFundingMode,
 	computeTierLabel,
+	explicitPlanOffers,
 	isComputeSubscriptionCancelable,
 	isComputeSubscriptionTermChangeable,
 	planOffers,
 	resolveBasicPlan,
 	resolvePerformancePlan,
+	selectExplicitOfferForTerm,
 	selectOfferForTerm,
 } from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
@@ -2142,15 +2144,34 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 				? perfPlan
 				: undefined;
 	const billingPlan = isIncludedBasic ? perfPlan : currentPaidPlan;
-	const billingOffers = useMemo(() => (billingPlan ? planOffers(billingPlan) : []), [billingPlan]);
+	const billingUsesExplicitBasicOffers = !isIncludedBasic && computePlanSlug === COMPUTE_BASIC_SLUG;
+	const billingOffers = useMemo(
+		() =>
+			billingPlan
+				? billingUsesExplicitBasicOffers
+					? explicitPlanOffers(billingPlan)
+					: planOffers(billingPlan)
+				: [],
+		[billingPlan, billingUsesExplicitBasicOffers],
+	);
 	const billingOfferSelection = useMemo(
-		() => (billingPlan ? selectOfferForTerm(billingPlan, term) : null),
-		[billingPlan, term],
+		() =>
+			billingPlan
+				? billingUsesExplicitBasicOffers
+					? selectExplicitOfferForTerm(billingPlan, term)
+					: selectOfferForTerm(billingPlan, term)
+				: null,
+		[billingPlan, billingUsesExplicitBasicOffers, term],
 	);
 	const selectedBillingTerm = billingOfferSelection?.billingTermMonths ?? term;
 	const currentOfferSelection = useMemo(
-		() => (currentPaidPlan ? selectOfferForTerm(currentPaidPlan, currentBillingTerm) : null),
-		[currentPaidPlan, currentBillingTerm],
+		() =>
+			currentPaidPlan
+				? computePlanSlug === COMPUTE_BASIC_SLUG
+					? selectExplicitOfferForTerm(currentPaidPlan, currentBillingTerm)
+					: selectOfferForTerm(currentPaidPlan, currentBillingTerm)
+				: null,
+		[computePlanSlug, currentPaidPlan, currentBillingTerm],
 	);
 	const currentOffer =
 		currentOfferSelection?.billingTermMonths === currentBillingTerm
@@ -2233,7 +2254,7 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 		}
 		try {
 			const body: CheckoutRequest = {
-				plan_slug: perfPlan.slug,
+				plan_slug: COMPUTE_PERFORMANCE_SLUG,
 				billing_term_months: perfOfferSelection.billingTermMonths,
 				ui_mode: "hosted",
 				upgrade_deployment_id: deployment.id,

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -5,11 +5,13 @@ import createClient from "openapi-fetch";
 import { useMemo } from "react";
 import { hostedApiBaseUrl } from "@/hosted/billing/billing-url";
 import type {
+	BillingDeployPaths,
 	CheckoutRequest,
 	ComputeFixPaymentRequest,
 	ComputeSubscriptionCancelRequest,
 	ComputeSubscriptionResumeRequest,
 	DeployRequest,
+	HostedDeployment,
 	PortalRequest,
 	RuntimeAgentType,
 	SetAgentEnabledRequest,
@@ -80,7 +82,10 @@ function runtimeAgentType(agentType: string): RuntimeAgentType {
 export function useBillingClient() {
 	const { getToken } = useAuthToken();
 	return useMemo(() => {
-		const api = createClient<DeployPaths>({ baseUrl: ROOT_BASE_URL, fetch: fetchWithTimeout });
+		const api = createClient<BillingDeployPaths>({
+			baseUrl: ROOT_BASE_URL,
+			fetch: fetchWithTimeout,
+		});
 		api.use({
 			async onRequest({ request }) {
 				const token = await getToken();
@@ -134,7 +139,8 @@ export function useBillingClient() {
 			getMe: async () => unwrapDeploy(await api.GET("/v1/me")),
 			getLegacyAgentEnvironments: async () => unwrapDeploy(await api.GET("/v1/agent-environments")),
 
-			listDeployments: async () => unwrapDeploy(await api.GET("/v2/deployments")),
+			listDeployments: async (): Promise<HostedDeployment[]> =>
+				unwrapDeploy(await api.GET("/v2/deployments")),
 			createDeployment: async (body: DeployRequest, idempotencyKey: string) =>
 				unwrapDeploy(
 					await api.POST("/v2/deployments", {

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -5,7 +5,6 @@ import createClient from "openapi-fetch";
 import { useMemo } from "react";
 import { hostedApiBaseUrl } from "@/hosted/billing/billing-url";
 import type {
-	BillingDeployPaths,
 	CheckoutRequest,
 	ComputeFixPaymentRequest,
 	ComputeSubscriptionCancelRequest,
@@ -82,7 +81,7 @@ function runtimeAgentType(agentType: string): RuntimeAgentType {
 export function useBillingClient() {
 	const { getToken } = useAuthToken();
 	return useMemo(() => {
-		const api = createClient<BillingDeployPaths>({
+		const api = createClient<DeployPaths>({
 			baseUrl: ROOT_BASE_URL,
 			fetch: fetchWithTimeout,
 		});

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
@@ -1,11 +1,27 @@
 import { describe, expect, test } from "bun:test";
-import type { HostedDeployment } from "@/hosted/billing/contracts";
+import type { ComputePlanSlug, HostedDeployment } from "@/hosted/billing/contracts";
 import { computeDunningState, computeDunningTileStatus } from "./compute-dunning.logic";
 
 function deployment(
 	computeSubscription: HostedDeployment["compute_subscription"],
-): Pick<HostedDeployment, "compute_subscription"> {
-	return { compute_subscription: computeSubscription };
+	computePlanSlug?: ComputePlanSlug,
+): Pick<HostedDeployment, "compute_subscription" | "config_info"> {
+	return {
+		compute_subscription: computeSubscription,
+		config_info: computePlanSlug
+			? {
+					compute_plan_slug: computePlanSlug,
+					mux_enabled: false,
+					telegram_mux_enabled: false,
+					discord_mux_enabled: false,
+					whatsapp_mux_enabled: false,
+					imessage_mux_enabled: false,
+					kobb_available: false,
+					ai_provider_auth_kind: "managed",
+					runtime: "hermes",
+				}
+			: null,
+	};
 }
 
 function subscription(
@@ -49,6 +65,18 @@ describe("computeDunningState", () => {
 		expect(state?.ctaTarget).toBe("invoice");
 		expect(state?.invoiceUrl).toBe("https://invoice.stripe.test/action");
 		expect(state?.tileLabel).toBe("Payment action required");
+	});
+
+	test("uses Basic naming for paid Basic payment remediation", () => {
+		const state = computeDunningState(
+			deployment(
+				subscription({ status: "past_due", payment_state: "requires_action" }),
+				"compute_basic",
+			),
+		);
+
+		expect(state?.description).toContain("keep Basic compute active");
+		expect(state?.tileTitle).toContain("keep Basic compute active");
 	});
 
 	test("uses portal remediation for retryable past-due subscriptions", () => {

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
@@ -1,6 +1,8 @@
 import type { HostedDeployment } from "@/hosted/billing/contracts";
+import { computeTierLabel } from "@/hosted/billing/subscription/subscription-utils";
 
 type ComputeSubscription = NonNullable<HostedDeployment["compute_subscription"]>;
+type DunningDeployment = Pick<HostedDeployment, "compute_subscription" | "config_info">;
 export type ComputePaymentState = ComputeSubscription["payment_state"];
 
 export type ComputeDunningState = {
@@ -16,17 +18,16 @@ export type ComputeDunningState = {
 	tileTextClass: string;
 };
 
-function subscriptionForDunning(
-	deployment: Pick<HostedDeployment, "compute_subscription">,
-): ComputeSubscription | null {
+function subscriptionForDunning(deployment: DunningDeployment): ComputeSubscription | null {
 	return deployment.compute_subscription ?? null;
 }
 
-export function computeDunningState(
-	deployment: Pick<HostedDeployment, "compute_subscription">,
-): ComputeDunningState | null {
+export function computeDunningState(deployment: DunningDeployment): ComputeDunningState | null {
 	const subscription = subscriptionForDunning(deployment);
 	if (!subscription || subscription.payment_state === "ok") return null;
+	const computeName = deployment.config_info
+		? `${computeTierLabel(deployment.config_info.compute_plan_slug)} compute`
+		: "paid compute";
 
 	const invoiceUrl = subscription.latest_failed_invoice_hosted_url ?? null;
 	const nextPaymentAttemptAt = subscription.next_payment_attempt_at ?? null;
@@ -36,14 +37,13 @@ export function computeDunningState(
 		return {
 			paymentState: "requires_action",
 			title: "Payment authentication required",
-			description:
-				"Stripe needs bank authentication for the latest renewal invoice. Complete the payment to keep Performance compute active.",
+			description: `Stripe needs bank authentication for the latest renewal invoice. Complete the payment to keep ${computeName} active.`,
 			ctaTarget: invoiceUrl ? "invoice" : "portal",
 			invoiceUrl,
 			nextPaymentAttemptAt,
 			serviceRiskAt,
 			tileLabel: "Payment action required",
-			tileTitle: "Complete payment authentication to keep Performance compute active.",
+			tileTitle: `Complete payment authentication to keep ${computeName} active.`,
 			tileTextClass: "text-warning-muted-foreground",
 		};
 	}
@@ -67,20 +67,19 @@ export function computeDunningState(
 	return {
 		paymentState: "unpaid",
 		title: "Payment retries ended",
-		description:
-			"Stripe could not collect payment and Performance entitlement was removed. Update your payment method before restoring this subscription.",
+		description: `Stripe could not collect payment and ${computeName} entitlement was removed. Update your payment method before restoring this subscription.`,
 		ctaTarget: "portal",
 		invoiceUrl,
 		nextPaymentAttemptAt,
 		serviceRiskAt,
 		tileLabel: "Payment unpaid",
-		tileTitle: "Performance entitlement was removed after payment retries ended.",
+		tileTitle: `${computeName} entitlement was removed after payment retries ended.`,
 		tileTextClass: "text-destructive",
 	};
 }
 
 export function computeDunningTileStatus(
-	deployment: Pick<HostedDeployment, "compute_subscription">,
+	deployment: DunningDeployment,
 ): { label: string; title: string; textClass: string } | null {
 	const state = computeDunningState(deployment);
 	if (!state) return null;

--- a/apps/web/src/hosted/billing/components/stripe-checkout.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/stripe-checkout.logic.test.ts
@@ -37,11 +37,11 @@ describe("stripe checkout logic", () => {
 
 	test("builds an explicit hosted fallback request", () => {
 		const request: CheckoutRequest = {
-			plan_slug: "compute_performance",
+			plan_slug: "compute_basic",
 			billing_term_months: 12,
 			ui_mode: CHECKOUT_ELEMENTS_UI_MODE,
 			deploy_config: {
-				compute_plan_slug: "compute_performance",
+				compute_plan_slug: "compute_basic",
 				runtime: "hermes",
 				ai_provider_auth_kind: "unmanaged",
 			},
@@ -51,6 +51,9 @@ describe("stripe checkout logic", () => {
 			...request,
 			ui_mode: "hosted",
 		});
+		expect(buildHostedCheckoutFallbackRequest(request).deploy_config?.compute_plan_slug).toBe(
+			"compute_basic",
+		);
 	});
 
 	test("finds a deployment created after checkout completes", () => {

--- a/apps/web/src/hosted/billing/contracts.ts
+++ b/apps/web/src/hosted/billing/contracts.ts
@@ -2,83 +2,16 @@ import type { DeployComponents, DeployPaths } from "@clawdi/shared/api";
 
 type Schemas = DeployComponents["schemas"];
 
-type GeneratedCheckoutRequest = Schemas["V2ComputeCheckoutRequest"];
-type GeneratedDeploymentDetailsInfo = Schemas["V2HostedDeploymentDetailsInfo"];
-type GeneratedDeployRequest = Schemas["V2HostedDeployRequest"];
-type GeneratedHostedDeployment = Schemas["V2HostedDeploymentResponse"];
-
 export const COMPUTE_BASIC_SLUG = "compute_basic" as const;
 export const COMPUTE_PERFORMANCE_SLUG = "compute_performance" as const;
-
-/**
- * Temporary frontend extension until the hosted backend OpenAPI is regenerated.
- * The committed schema still exposes the retired low-tier slug and omits
- * compute_basic from both deploy request and deployment detail enums. Keep the
- * mismatch isolated here rather than hand-editing deploy.generated.ts.
- */
-export type ComputePlanSlug =
-	| Exclude<GeneratedDeployRequest["compute_plan_slug"], "compute_free">
-	| typeof COMPUTE_BASIC_SLUG;
-export type DeployRequest<TPlanSlug extends ComputePlanSlug = ComputePlanSlug> = Omit<
-	GeneratedDeployRequest,
-	"compute_plan_slug"
-> & {
-	compute_plan_slug: TPlanSlug;
-};
-export type CheckoutRequest = Omit<GeneratedCheckoutRequest, "deploy_config"> & {
-	deploy_config?: DeployRequest | null;
-};
-export type DeploymentDetailsInfo = Omit<GeneratedDeploymentDetailsInfo, "compute_plan_slug"> & {
-	compute_plan_slug: ComputePlanSlug;
-};
-export type HostedDeployment = Omit<GeneratedHostedDeployment, "config_info"> & {
-	config_info?: DeploymentDetailsInfo | null;
-};
-
-type GeneratedCheckoutPath = DeployPaths["/v2/subscription/checkout"];
-type GeneratedCheckoutOperation = GeneratedCheckoutPath["post"];
-type GeneratedDeploymentsPath = DeployPaths["/v2/deployments"];
-type GeneratedCreateDeploymentOperation = GeneratedDeploymentsPath["post"];
-type GeneratedCreateDeploymentResponses = GeneratedCreateDeploymentOperation["responses"];
-type GeneratedCreateDeploymentSuccess = GeneratedCreateDeploymentResponses[200];
-type GeneratedListDeploymentsOperation = GeneratedDeploymentsPath["get"];
-type GeneratedListDeploymentsResponses = GeneratedListDeploymentsOperation["responses"];
-type GeneratedListDeploymentsSuccess = GeneratedListDeploymentsResponses[200];
-
-/** Remove after deploy.generated.ts includes compute_basic. */
-export type BillingDeployPaths = Omit<
-	DeployPaths,
-	"/v2/deployments" | "/v2/subscription/checkout"
-> & {
-	"/v2/deployments": Omit<GeneratedDeploymentsPath, "get" | "post"> & {
-		get: Omit<GeneratedListDeploymentsOperation, "responses"> & {
-			responses: Omit<GeneratedListDeploymentsResponses, 200> & {
-				200: Omit<GeneratedListDeploymentsSuccess, "content"> & {
-					content: { "application/json": HostedDeployment[] };
-				};
-			};
-		};
-		post: Omit<GeneratedCreateDeploymentOperation, "requestBody" | "responses"> & {
-			requestBody: { content: { "application/json": DeployRequest } };
-			responses: Omit<GeneratedCreateDeploymentResponses, 200> & {
-				200: Omit<GeneratedCreateDeploymentSuccess, "content"> & {
-					content: { "application/json": HostedDeployment };
-				};
-			};
-		};
-	};
-	"/v2/subscription/checkout": Omit<GeneratedCheckoutPath, "post"> & {
-		post: Omit<GeneratedCheckoutOperation, "requestBody"> & {
-			requestBody: { content: { "application/json": CheckoutRequest } };
-		};
-	};
-};
 
 export type AiProviderAuthKind = NonNullable<
 	Schemas["V2HostedDeployRequest"]["ai_provider_auth_kind"]
 >;
 export type BillingOffer = Schemas["V2BillingOfferResponse"];
+export type CheckoutRequest = Schemas["V2ComputeCheckoutRequest"];
 export type CheckoutResult = Schemas["V2CheckoutResponse"];
+export type ComputePlanSlug = Schemas["V2HostedDeployRequest"]["compute_plan_slug"];
 export type ComputeSubscriptionActionResult = Schemas["V2ComputeSubscriptionActionResponse"];
 export type ComputeSubscriptionCancelRequest = Schemas["V2ComputeSubscriptionCancelRequest"];
 export type ComputeFixPaymentRequest = Schemas["V2ComputeFixPaymentRequest"];
@@ -86,6 +19,9 @@ export type ComputeInvoice = Schemas["V2ComputeInvoiceInfo"];
 export type ComputeInvoicesPage = Schemas["V2ComputeInvoicesResponse"];
 export type ComputeSubscriptionResumeRequest = Schemas["V2ComputeSubscriptionResumeRequest"];
 export type DeleteDeploymentResult = Schemas["V2DeploymentDeleteResponse"];
+export type DeployRequest = Schemas["V2HostedDeployRequest"];
+export type DeploymentDetailsInfo = Schemas["V2HostedDeploymentDetailsInfo"];
+export type HostedDeployment = Schemas["V2HostedDeploymentResponse"];
 export type RuntimeUiRedemption = Schemas["V2DeploymentRuntimeUiRedemptionResponse"];
 export type HostedUser = Schemas["V1UserResponse"];
 export type HostedConfigRequest = Schemas["V2HostedConfigRequest"];

--- a/apps/web/src/hosted/billing/contracts.ts
+++ b/apps/web/src/hosted/billing/contracts.ts
@@ -2,11 +2,82 @@ import type { DeployComponents, DeployPaths } from "@clawdi/shared/api";
 
 type Schemas = DeployComponents["schemas"];
 
+type GeneratedCheckoutRequest = Schemas["V2ComputeCheckoutRequest"];
+type GeneratedDeploymentDetailsInfo = Schemas["V2HostedDeploymentDetailsInfo"];
+type GeneratedDeployRequest = Schemas["V2HostedDeployRequest"];
+type GeneratedHostedDeployment = Schemas["V2HostedDeploymentResponse"];
+
+export const COMPUTE_BASIC_SLUG = "compute_basic" as const;
+export const COMPUTE_PERFORMANCE_SLUG = "compute_performance" as const;
+
+/**
+ * Temporary frontend extension until the hosted backend OpenAPI is regenerated.
+ * The committed schema still exposes the retired low-tier slug and omits
+ * compute_basic from both deploy request and deployment detail enums. Keep the
+ * mismatch isolated here rather than hand-editing deploy.generated.ts.
+ */
+export type ComputePlanSlug =
+	| Exclude<GeneratedDeployRequest["compute_plan_slug"], "compute_free">
+	| typeof COMPUTE_BASIC_SLUG;
+export type DeployRequest<TPlanSlug extends ComputePlanSlug = ComputePlanSlug> = Omit<
+	GeneratedDeployRequest,
+	"compute_plan_slug"
+> & {
+	compute_plan_slug: TPlanSlug;
+};
+export type CheckoutRequest = Omit<GeneratedCheckoutRequest, "deploy_config"> & {
+	deploy_config?: DeployRequest | null;
+};
+export type DeploymentDetailsInfo = Omit<GeneratedDeploymentDetailsInfo, "compute_plan_slug"> & {
+	compute_plan_slug: ComputePlanSlug;
+};
+export type HostedDeployment = Omit<GeneratedHostedDeployment, "config_info"> & {
+	config_info?: DeploymentDetailsInfo | null;
+};
+
+type GeneratedCheckoutPath = DeployPaths["/v2/subscription/checkout"];
+type GeneratedCheckoutOperation = GeneratedCheckoutPath["post"];
+type GeneratedDeploymentsPath = DeployPaths["/v2/deployments"];
+type GeneratedCreateDeploymentOperation = GeneratedDeploymentsPath["post"];
+type GeneratedCreateDeploymentResponses = GeneratedCreateDeploymentOperation["responses"];
+type GeneratedCreateDeploymentSuccess = GeneratedCreateDeploymentResponses[200];
+type GeneratedListDeploymentsOperation = GeneratedDeploymentsPath["get"];
+type GeneratedListDeploymentsResponses = GeneratedListDeploymentsOperation["responses"];
+type GeneratedListDeploymentsSuccess = GeneratedListDeploymentsResponses[200];
+
+/** Remove after deploy.generated.ts includes compute_basic. */
+export type BillingDeployPaths = Omit<
+	DeployPaths,
+	"/v2/deployments" | "/v2/subscription/checkout"
+> & {
+	"/v2/deployments": Omit<GeneratedDeploymentsPath, "get" | "post"> & {
+		get: Omit<GeneratedListDeploymentsOperation, "responses"> & {
+			responses: Omit<GeneratedListDeploymentsResponses, 200> & {
+				200: Omit<GeneratedListDeploymentsSuccess, "content"> & {
+					content: { "application/json": HostedDeployment[] };
+				};
+			};
+		};
+		post: Omit<GeneratedCreateDeploymentOperation, "requestBody" | "responses"> & {
+			requestBody: { content: { "application/json": DeployRequest } };
+			responses: Omit<GeneratedCreateDeploymentResponses, 200> & {
+				200: Omit<GeneratedCreateDeploymentSuccess, "content"> & {
+					content: { "application/json": HostedDeployment };
+				};
+			};
+		};
+	};
+	"/v2/subscription/checkout": Omit<GeneratedCheckoutPath, "post"> & {
+		post: Omit<GeneratedCheckoutOperation, "requestBody"> & {
+			requestBody: { content: { "application/json": CheckoutRequest } };
+		};
+	};
+};
+
 export type AiProviderAuthKind = NonNullable<
 	Schemas["V2HostedDeployRequest"]["ai_provider_auth_kind"]
 >;
 export type BillingOffer = Schemas["V2BillingOfferResponse"];
-export type CheckoutRequest = Schemas["V2ComputeCheckoutRequest"];
 export type CheckoutResult = Schemas["V2CheckoutResponse"];
 export type ComputeSubscriptionActionResult = Schemas["V2ComputeSubscriptionActionResponse"];
 export type ComputeSubscriptionCancelRequest = Schemas["V2ComputeSubscriptionCancelRequest"];
@@ -14,10 +85,7 @@ export type ComputeFixPaymentRequest = Schemas["V2ComputeFixPaymentRequest"];
 export type ComputeInvoice = Schemas["V2ComputeInvoiceInfo"];
 export type ComputeInvoicesPage = Schemas["V2ComputeInvoicesResponse"];
 export type ComputeSubscriptionResumeRequest = Schemas["V2ComputeSubscriptionResumeRequest"];
-export type DeployRequest = Schemas["V2HostedDeployRequest"];
 export type DeleteDeploymentResult = Schemas["V2DeploymentDeleteResponse"];
-export type DeploymentDetailsInfo = Schemas["V2HostedDeploymentDetailsInfo"];
-export type HostedDeployment = Schemas["V2HostedDeploymentResponse"];
 export type RuntimeUiRedemption = Schemas["V2DeploymentRuntimeUiRedemptionResponse"];
 export type HostedUser = Schemas["V1UserResponse"];
 export type HostedConfigRequest = Schemas["V2HostedConfigRequest"];

--- a/apps/web/src/hosted/billing/deploy/deploy-model.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-model.test.ts
@@ -1,11 +1,30 @@
 import { describe, expect, test } from "bun:test";
-import type { HostedDeployment } from "@/hosted/billing/contracts";
-import { usesActiveFreeComputeSlot } from "@/hosted/billing/deploy/deploy-model";
+import type { ComputePlanSlug, HostedDeployment, Plan } from "@/hosted/billing/contracts";
+import {
+	resolveBasicDeploySelection,
+	usesActiveIncludedBasicSlot,
+} from "@/hosted/billing/deploy/deploy-model";
 
-function deployment(
-	status: string,
-	computePlanSlug: "compute_free" | "compute_performance",
-): HostedDeployment {
+function subscription(): NonNullable<HostedDeployment["compute_subscription"]> {
+	return {
+		status: "active",
+		payment_state: "ok",
+		billing_term_months: 1,
+		price_cents: 900,
+		currency: "usd",
+		cancel_at_period_end: false,
+	};
+}
+
+function deployment({
+	status,
+	computePlanSlug = "compute_basic",
+	computeSubscription,
+}: {
+	status: string;
+	computePlanSlug?: ComputePlanSlug;
+	computeSubscription?: HostedDeployment["compute_subscription"];
+}): HostedDeployment {
 	return {
 		id: `hdep_${status}_${computePlanSlug}`,
 		user_id: "usr_test",
@@ -14,6 +33,7 @@ function deployment(
 		status,
 		created_at: "2026-06-24T00:00:00Z",
 		upgrade_available: false,
+		compute_subscription: computeSubscription,
 		config_info: {
 			compute_plan_slug: computePlanSlug,
 			mux_enabled: false,
@@ -31,29 +51,105 @@ function deployment(
 	};
 }
 
-describe("usesActiveFreeComputeSlot", () => {
-	test("treats non-stopped Free deployments as occupying the user Free slot", () => {
-		expect(usesActiveFreeComputeSlot([deployment("running", "compute_free")])).toBe(true);
-		expect(usesActiveFreeComputeSlot([deployment("starting", "compute_free")])).toBe(true);
-		expect(usesActiveFreeComputeSlot([deployment("failed", "compute_free")])).toBe(true);
-		expect(usesActiveFreeComputeSlot([deployment("deleting", "compute_free")])).toBe(true);
+function plan(priceCents: number): Plan {
+	return {
+		slug: "compute_basic",
+		name: "Basic",
+		price_cents: priceCents,
+		points_per_usd: 100,
+		signup_grant_credits: 0,
+		subscription_grant_credits: 0,
+		vcpu: 1,
+		ram_gb: 2,
+		disk_size: 20,
+		offers: [
+			{
+				billing_term_months: 1,
+				price_cents: priceCents,
+				effective_monthly_price_cents: priceCents,
+				discount_percent: 0,
+			},
+		],
+	};
+}
+
+describe("usesActiveIncludedBasicSlot", () => {
+	test("counts active free-funded Basic deployments", () => {
+		expect(usesActiveIncludedBasicSlot([deployment({ status: "running" })])).toBe(true);
+		expect(usesActiveIncludedBasicSlot([deployment({ status: "starting" })])).toBe(true);
+		expect(usesActiveIncludedBasicSlot([deployment({ status: "failed" })])).toBe(true);
+		expect(usesActiveIncludedBasicSlot([deployment({ status: "deleting" })])).toBe(true);
 	});
 
-	test("does not count stopped or deleted Free deployments or Performance deployments", () => {
-		expect(usesActiveFreeComputeSlot([deployment("stopped", "compute_free")])).toBe(false);
-		expect(usesActiveFreeComputeSlot([deployment("deleted", "compute_free")])).toBe(false);
-		expect(usesActiveFreeComputeSlot([deployment("running", "compute_performance")])).toBe(false);
+	test("ignores inactive, paid-funded Basic, and Performance deployments", () => {
+		expect(usesActiveIncludedBasicSlot([deployment({ status: "stopped" })])).toBe(false);
+		expect(usesActiveIncludedBasicSlot([deployment({ status: "deleted" })])).toBe(false);
+		expect(
+			usesActiveIncludedBasicSlot([
+				deployment({ status: "running", computeSubscription: subscription() }),
+			]),
+		).toBe(false);
+		expect(
+			usesActiveIncludedBasicSlot([
+				deployment({ status: "running", computePlanSlug: "compute_performance" }),
+			]),
+		).toBe(false);
+	});
+});
+
+describe("resolveBasicDeploySelection", () => {
+	const basic = plan(900);
+
+	test("deploys compute_basic directly while included funding is available", () => {
+		expect(
+			resolveBasicDeploySelection({
+				includedSlotUsed: false,
+				basicPlan: basic,
+				billingTermMonths: 1,
+			}),
+		).toEqual({ mode: "direct", computePlanSlug: "compute_basic", plan: basic });
+	});
+
+	test("starts compute_basic checkout with the API offer after included funding is used", () => {
+		const selection = resolveBasicDeploySelection({
+			includedSlotUsed: true,
+			basicPlan: basic,
+			billingTermMonths: 1,
+		});
+
+		expect(selection).toMatchObject({
+			mode: "checkout",
+			computePlanSlug: "compute_basic",
+			billingTermMonths: 1,
+			plan: basic,
+			offer: { price_cents: 900 },
+		});
+	});
+
+	test("requires the canonical Basic plan for either funding path", () => {
+		expect(
+			resolveBasicDeploySelection({
+				includedSlotUsed: false,
+				basicPlan: undefined,
+				billingTermMonths: 1,
+			}),
+		).toEqual({ mode: "unavailable" });
+		expect(
+			resolveBasicDeploySelection({
+				includedSlotUsed: true,
+				basicPlan: undefined,
+				billingTermMonths: 1,
+			}),
+		).toEqual({ mode: "unavailable" });
 	});
 });
 
 /**
- * The compute-slot contract. Every row must match the deploy-API's
- * `slot_occupancy.py::v2_hosted_deployment_occupies_compute_slot` exactly —
- * a divergence here is what locked a production user out of deploying
- * (a `failed` row with no k8s resources held the free slot forever, while
- * the agents view sourced from cloud-api envs never showed it).
+ * The active-state half of the funding-slot contract. Every row must match the
+ * deploy API occupancy predicate; subscription-backed Basic is excluded before
+ * this predicate runs because it does not consume included funding.
  */
-describe("usesActiveFreeComputeSlot agrees with the backend predicate", () => {
+describe("usesActiveIncludedBasicSlot agrees with the backend occupancy predicate", () => {
 	const cases: Array<{ status: string; failureReason: string | null; occupies: boolean }> = [
 		{ status: "running", failureReason: null, occupies: true },
 		{ status: "starting", failureReason: null, occupies: true },
@@ -61,7 +157,6 @@ describe("usesActiveFreeComputeSlot agrees with the backend predicate", () => {
 		{ status: "deleting", failureReason: null, occupies: true },
 		{ status: "stopped", failureReason: null, occupies: false },
 		{ status: "deleted", failureReason: null, occupies: false },
-		// failed: only released when the reason proves the infra is gone.
 		{ status: "failed", failureReason: "backend_status=not_found", occupies: false },
 		{
 			status: "failed",
@@ -71,19 +166,21 @@ describe("usesActiveFreeComputeSlot agrees with the backend predicate", () => {
 		{ status: "failed", failureReason: "creation_interrupted", occupies: false },
 		{ status: "failed", failureReason: "startup_probe_failing; restart_count=2", occupies: true },
 		{ status: "failed", failureReason: null, occupies: true },
-		// unknown future statuses are treated as occupying (fail closed).
 		{ status: "some_future_state", failureReason: null, occupies: true },
 	];
 
 	for (const { status, failureReason, occupies } of cases) {
-		test(`${status} / ${failureReason ?? "no reason"} → ${occupies ? "occupies" : "free"}`, () => {
-			const d = { ...deployment(status, "compute_free"), failure_reason: failureReason };
-			expect(usesActiveFreeComputeSlot([d])).toBe(occupies);
+		test(`${status} / ${failureReason ?? "no reason"} → ${occupies ? "occupies" : "available"}`, () => {
+			const candidate = { ...deployment({ status }), failure_reason: failureReason };
+			expect(usesActiveIncludedBasicSlot([candidate])).toBe(occupies);
 		});
 	}
 
-	test("ignores non-free plans entirely", () => {
-		const d = { ...deployment("running", "compute_performance"), failure_reason: null };
-		expect(usesActiveFreeComputeSlot([d])).toBe(false);
+	test("excludes subscription-backed Basic before applying occupancy", () => {
+		const candidate = {
+			...deployment({ status: "running", computeSubscription: subscription() }),
+			failure_reason: null,
+		};
+		expect(usesActiveIncludedBasicSlot([candidate])).toBe(false);
 	});
 });

--- a/apps/web/src/hosted/billing/deploy/deploy-model.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-model.test.ts
@@ -59,8 +59,8 @@ function plan(priceCents: number): Plan {
 		points_per_usd: 100,
 		signup_grant_credits: 0,
 		subscription_grant_credits: 0,
-		vcpu: 1,
-		ram_gb: 2,
+		vcpu: 2,
+		ram_gb: 4,
 		disk_size: 20,
 		offers: [
 			{
@@ -133,14 +133,37 @@ describe("resolveBasicDeploySelection", () => {
 				basicPlan: undefined,
 				billingTermMonths: 1,
 			}),
-		).toEqual({ mode: "unavailable" });
+		).toEqual({ mode: "unavailable", reason: "plan_missing" });
 		expect(
 			resolveBasicDeploySelection({
 				includedSlotUsed: true,
 				basicPlan: undefined,
 				billingTermMonths: 1,
 			}),
-		).toEqual({ mode: "unavailable" });
+		).toEqual({ mode: "unavailable", reason: "plan_missing" });
+	});
+
+	test("requires a real API offer only when the included slot is occupied", () => {
+		const basicWithoutOffers = { ...basic, offers: [] };
+
+		expect(
+			resolveBasicDeploySelection({
+				includedSlotUsed: false,
+				basicPlan: basicWithoutOffers,
+				billingTermMonths: 1,
+			}),
+		).toEqual({
+			mode: "direct",
+			computePlanSlug: "compute_basic",
+			plan: basicWithoutOffers,
+		});
+		expect(
+			resolveBasicDeploySelection({
+				includedSlotUsed: true,
+				basicPlan: basicWithoutOffers,
+				billingTermMonths: 1,
+			}),
+		).toEqual({ mode: "unavailable", reason: "offers_missing" });
 	});
 });
 

--- a/apps/web/src/hosted/billing/deploy/deploy-model.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-model.ts
@@ -1,9 +1,62 @@
-import type { HostedDeployment } from "@/hosted/billing/contracts";
+import type { HostedDeployment, Plan } from "@/hosted/billing/contracts";
+import {
+	COMPUTE_BASIC_SLUG,
+	computeFundingMode,
+	selectOfferForTerm,
+} from "@/hosted/billing/subscription/subscription-utils";
 import { occupiesComputeSlot } from "@/hosted/deployment-status";
 
-export function usesActiveFreeComputeSlot(deployments: HostedDeployment[] | undefined): boolean {
+export type BasicDeploySelection =
+	| {
+			mode: "direct";
+			computePlanSlug: typeof COMPUTE_BASIC_SLUG;
+			plan: Plan;
+	  }
+	| {
+			mode: "checkout";
+			billingTermMonths: number;
+			computePlanSlug: typeof COMPUTE_BASIC_SLUG;
+			offer: ReturnType<typeof selectOfferForTerm>["offer"];
+			plan: Plan;
+	  }
+	| {
+			mode: "unavailable";
+	  };
+
+export function usesActiveIncludedBasicSlot(deployments: HostedDeployment[] | undefined): boolean {
 	return (deployments ?? []).some((deployment) => {
-		if (deployment.config_info?.compute_plan_slug !== "compute_free") return false;
+		if (
+			computeFundingMode(
+				deployment.config_info?.compute_plan_slug,
+				deployment.compute_subscription,
+			) !== "included_basic"
+		) {
+			return false;
+		}
 		return occupiesComputeSlot(deployment);
 	});
+}
+
+export function resolveBasicDeploySelection({
+	includedSlotUsed,
+	basicPlan,
+	billingTermMonths,
+}: {
+	includedSlotUsed: boolean;
+	basicPlan: Plan | undefined;
+	billingTermMonths: number;
+}): BasicDeploySelection {
+	if (!basicPlan) return { mode: "unavailable" };
+	if (!includedSlotUsed) {
+		return { mode: "direct", computePlanSlug: COMPUTE_BASIC_SLUG, plan: basicPlan };
+	}
+
+	const selection = selectOfferForTerm(basicPlan, billingTermMonths);
+	return {
+		mode: "checkout",
+		billingTermMonths: selection.billingTermMonths,
+		computePlanSlug: COMPUTE_BASIC_SLUG,
+		offer: selection.offer,
+		plan: basicPlan,
+	};
 }

--- a/apps/web/src/hosted/billing/deploy/deploy-model.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-model.ts
@@ -1,8 +1,8 @@
-import type { HostedDeployment, Plan } from "@/hosted/billing/contracts";
+import type { BillingOffer, HostedDeployment, Plan } from "@/hosted/billing/contracts";
 import {
 	COMPUTE_BASIC_SLUG,
 	computeFundingMode,
-	selectOfferForTerm,
+	selectExplicitOfferForTerm,
 } from "@/hosted/billing/subscription/subscription-utils";
 import { occupiesComputeSlot } from "@/hosted/deployment-status";
 
@@ -16,11 +16,12 @@ export type BasicDeploySelection =
 			mode: "checkout";
 			billingTermMonths: number;
 			computePlanSlug: typeof COMPUTE_BASIC_SLUG;
-			offer: ReturnType<typeof selectOfferForTerm>["offer"];
+			offer: BillingOffer;
 			plan: Plan;
 	  }
 	| {
 			mode: "unavailable";
+			reason: "plan_missing" | "offers_missing";
 	  };
 
 export function usesActiveIncludedBasicSlot(deployments: HostedDeployment[] | undefined): boolean {
@@ -46,12 +47,13 @@ export function resolveBasicDeploySelection({
 	basicPlan: Plan | undefined;
 	billingTermMonths: number;
 }): BasicDeploySelection {
-	if (!basicPlan) return { mode: "unavailable" };
+	if (!basicPlan) return { mode: "unavailable", reason: "plan_missing" };
 	if (!includedSlotUsed) {
 		return { mode: "direct", computePlanSlug: COMPUTE_BASIC_SLUG, plan: basicPlan };
 	}
 
-	const selection = selectOfferForTerm(basicPlan, billingTermMonths);
+	const selection = selectExplicitOfferForTerm(basicPlan, billingTermMonths);
+	if (!selection) return { mode: "unavailable", reason: "offers_missing" };
 	return {
 		mode: "checkout",
 		billingTermMonths: selection.billingTermMonths,

--- a/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
@@ -8,7 +8,7 @@ import { buildHostedDeployRequest } from "@/hosted/billing/deploy/deploy-request
 describe("buildHostedDeployRequest", () => {
 	test("serializes the default wizard state with explicit hermes and managed AI", () => {
 		const request = buildHostedDeployRequest({
-			computePlanSlug: "compute_free",
+			computePlanSlug: "compute_basic",
 			runtime: DEFAULT_DEPLOY_RUNTIME,
 			persona: {
 				language: "",
@@ -18,7 +18,7 @@ describe("buildHostedDeployRequest", () => {
 		});
 
 		expect(request).toEqual({
-			compute_plan_slug: "compute_free",
+			compute_plan_slug: "compute_basic",
 			runtime: "hermes",
 			language: null,
 			timezone: null,
@@ -77,6 +77,30 @@ describe("buildHostedDeployRequest", () => {
 		expect("slack_bot_token" in (request.config ?? {})).toBe(false);
 	});
 
+	test("serializes paid Basic deploy config for checkout auto-deploy", () => {
+		const request = buildHostedDeployRequest({
+			computePlanSlug: "compute_basic",
+			runtime: "hermes",
+			persona: {
+				language: "en",
+				timezone: "Etc/UTC",
+			},
+			aiFields: { ai_provider_auth_kind: "managed" },
+		});
+
+		expect(request).toMatchObject({
+			compute_plan_slug: "compute_basic",
+			runtime: "hermes",
+			language: "en",
+			timezone: "Etc/UTC",
+			config: {
+				runtime: "hermes",
+				language: "en",
+				timezone: "Etc/UTC",
+			},
+		});
+	});
+
 	test("serializes backend provider pool contract at the deploy body boundary", () => {
 		const request = buildHostedDeployRequest({
 			computePlanSlug: "compute_performance",
@@ -112,7 +136,7 @@ describe("buildHostedDeployRequest", () => {
 
 	test("serializes explicit unmanaged deploys without provider material", () => {
 		const request = buildHostedDeployRequest({
-			computePlanSlug: "compute_free",
+			computePlanSlug: "compute_basic",
 			runtime: "hermes",
 			persona: {
 				language: "",
@@ -122,7 +146,7 @@ describe("buildHostedDeployRequest", () => {
 		});
 
 		expect(request).toEqual({
-			compute_plan_slug: "compute_free",
+			compute_plan_slug: "compute_basic",
 			runtime: "hermes",
 			language: null,
 			timezone: null,

--- a/apps/web/src/hosted/billing/deploy/deploy-request.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-request.ts
@@ -1,4 +1,8 @@
-import type { DeployRequest, HostedConfigRequest } from "@/hosted/billing/contracts";
+import type {
+	ComputePlanSlug,
+	DeployRequest,
+	HostedConfigRequest,
+} from "@/hosted/billing/contracts";
 import { normalizeHostedLanguage } from "@/hosted/billing/deploy/language-timezone-controls";
 import type { HostedRuntime } from "@/hosted/runtimes";
 
@@ -7,20 +11,25 @@ type DeployPersona = {
 	timezone: string;
 };
 
-type ComputePlanSlug = DeployRequest["compute_plan_slug"];
-export type DeployAiFields = Pick<DeployRequest, "ai_provider_auth_kind"> & Partial<DeployRequest>;
+export type DeployAiFields = Pick<DeployRequest, "ai_provider_auth_kind"> &
+	Partial<
+		Pick<
+			DeployRequest,
+			"ai_provider_bootstrap" | "ai_provider_id" | "primary_model" | "provider_ids"
+		>
+	>;
 
-export function buildHostedDeployRequest({
+export function buildHostedDeployRequest<TPlanSlug extends ComputePlanSlug>({
 	computePlanSlug,
 	runtime,
 	persona,
 	aiFields,
 }: {
-	computePlanSlug: ComputePlanSlug;
+	computePlanSlug: TPlanSlug;
 	runtime: HostedRuntime;
 	persona: DeployPersona;
 	aiFields: DeployAiFields;
-}): DeployRequest {
+}): DeployRequest<TPlanSlug> {
 	const language = normalizeHostedLanguage(persona.language);
 	const timezone = persona.timezone.trim() || null;
 	const { ai_provider_auth_kind, ...restAiFields } = aiFields;

--- a/apps/web/src/hosted/billing/deploy/deploy-request.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-request.ts
@@ -19,17 +19,17 @@ export type DeployAiFields = Pick<DeployRequest, "ai_provider_auth_kind"> &
 		>
 	>;
 
-export function buildHostedDeployRequest<TPlanSlug extends ComputePlanSlug>({
+export function buildHostedDeployRequest({
 	computePlanSlug,
 	runtime,
 	persona,
 	aiFields,
 }: {
-	computePlanSlug: TPlanSlug;
+	computePlanSlug: ComputePlanSlug;
 	runtime: HostedRuntime;
 	persona: DeployPersona;
 	aiFields: DeployAiFields;
-}): DeployRequest<TPlanSlug> {
+}): DeployRequest {
 	const language = normalizeHostedLanguage(persona.language);
 	const timezone = persona.timezone.trim() || null;
 	const { ai_provider_auth_kind, ...restAiFields } = aiFields;

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -50,6 +50,7 @@ import { TermSwitcher } from "@/hosted/billing/components/term-switcher";
 import type {
 	BillingOffer,
 	CheckoutRequest,
+	ComputePlanSlug,
 	DeployRequest,
 	Plan,
 } from "@/hosted/billing/contracts";
@@ -61,7 +62,10 @@ import {
 	DEFAULT_DEPLOY_RUNTIME,
 	type DeployWizardAiAccessMode,
 } from "@/hosted/billing/deploy/deploy-defaults";
-import { usesActiveFreeComputeSlot } from "@/hosted/billing/deploy/deploy-model";
+import {
+	resolveBasicDeploySelection,
+	usesActiveIncludedBasicSlot,
+} from "@/hosted/billing/deploy/deploy-model";
 import {
 	buildHostedDeployRequest,
 	type DeployAiFields,
@@ -93,10 +97,10 @@ import {
 	newIdempotencyKey,
 } from "@/hosted/billing/idempotency";
 import {
-	COMPUTE_FREE_SLUG,
+	COMPUTE_BASIC_SLUG,
 	COMPUTE_PERFORMANCE_SLUG,
 	planOffers,
-	resolveFreePlan,
+	resolveBasicPlan,
 	resolvePerformancePlan,
 	selectOfferForTerm,
 } from "@/hosted/billing/subscription/subscription-utils";
@@ -130,14 +134,14 @@ import { agentSectionHref } from "@/lib/agent-routes";
 import { isApiAuthError, normalizeApiError } from "@/lib/api-errors";
 import { cn } from "@/lib/utils";
 
-type Compute = "free" | "performance";
+type Compute = "basic" | "performance";
 type AiAccessMode = DeployWizardAiAccessMode;
-type ComputePlanSlug = DeployRequest["compute_plan_slug"];
 type NativeDeployCheckout = {
 	clientSecret: string;
 	previousDeploymentIds: string[];
 	request: CheckoutRequest;
 	summary: StripeCheckoutSummary;
+	tierLabel: "Basic" | "Performance";
 };
 const DEPLOY_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
 const THREE_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2 lg:grid-cols-3";
@@ -181,25 +185,38 @@ function AddTile({
 	);
 }
 
-function performanceCheckoutSummary({
+function computeCheckoutSummary({
 	offer,
 	plan,
 	termMonths,
+	tierLabel,
 }: {
 	offer: BillingOffer;
 	plan: Plan;
 	termMonths: number;
+	tierLabel: "Basic" | "Performance";
 }): StripeCheckoutSummary {
 	const effectiveMonthly = formatCentsCompact(offer.effective_monthly_price_cents);
+	const agentLabel =
+		tierLabel === "Basic" ? "additional hosted Basic agent" : "hosted Performance agent";
 	return {
 		detail:
 			termMonths === 1
-				? "Per hosted Performance agent, billed monthly."
-				: `${effectiveMonthly}/mo effective per hosted Performance agent.`,
+				? `Per ${agentLabel}, billed monthly.`
+				: `${effectiveMonthly}/mo effective per ${agentLabel}.`,
 		planName: plan.name,
 		priceLabel: formatCentsCompact(offer.price_cents),
 		termLabel: billingTermLabel(termMonths),
 	};
+}
+
+function recurringOfferLabel(offer: BillingOffer): string {
+	const monthly = `${formatCentsCompact(offer.effective_monthly_price_cents)}/mo`;
+	return offer.billing_term_months === 1
+		? monthly
+		: `${monthly}, billed ${formatCentsCompact(offer.price_cents)}${billingTermSuffix(
+				offer.billing_term_months,
+			)}`;
 }
 
 function ChannelInfoTile({ channel }: { channel: ChannelAccount }) {
@@ -222,10 +239,11 @@ function ChannelInfoTile({ channel }: { channel: ChannelAccount }) {
 
 interface ComputeStatusInput {
 	compute: Compute;
-	freeSlotPending: boolean;
-	freeSlotUsed: boolean;
+	includedSlotPending: boolean;
+	includedSlotUsed: boolean;
 	deploymentsError: unknown;
-	freePlan: Plan | undefined;
+	basicSelection: ReturnType<typeof resolveBasicDeploySelection>;
+	basicOffer: BillingOffer | null;
 	perfOffer: BillingOffer | null;
 }
 
@@ -264,40 +282,45 @@ function DeploySectionSkeleton({ columns = 2 }: { columns?: 2 | 3 }) {
 
 function computeStatusLine({
 	compute,
-	freeSlotPending,
-	freeSlotUsed,
+	includedSlotPending,
+	includedSlotUsed,
 	deploymentsError,
-	freePlan,
+	basicSelection,
+	basicOffer,
 	perfOffer,
 }: ComputeStatusInput): { message: string; tone: "destructive" | "muted" } | null {
-	if (compute === "free") {
+	if (compute === "basic") {
 		if (deploymentsError) {
 			return {
 				tone: "destructive",
-				message: "Couldn’t verify your Free slot. Retry this page before deploying Free.",
+				message: "Couldn’t verify your included Basic slot. Retry this page before deploying.",
 			};
 		}
-		if (!freePlan) {
+		if (basicSelection.mode === "unavailable") {
 			return {
 				tone: "destructive",
 				message:
-					"Free compute isn’t available from the billing service. Retry plans before deploying.",
+					"The Basic plan isn’t available from the billing service. Retry plans before deploying.",
 			};
 		}
-		if (freeSlotUsed) {
+		if (includedSlotPending) {
 			return {
 				tone: "muted",
-				message:
-					"You already have an active Free agent. Stop or delete it to reuse Free, or deploy a Performance agent.",
+				message: "Checking whether your included Basic slot is available before deployment.",
 			};
 		}
-		if (freeSlotPending) {
+		if (includedSlotUsed && basicOffer) {
 			return {
 				tone: "muted",
-				message: "Checking whether your Free slot is available before deployment.",
+				message: `Your included Basic slot is in use. Checkout opens here for an additional Basic agent at ${recurringOfferLabel(
+					basicOffer,
+				)}.`,
 			};
 		}
-		return null;
+		return {
+			tone: "muted",
+			message: "Your first active Basic agent is free. This deployment won’t open checkout.",
+		};
 	}
 
 	if (perfOffer && perfOffer.billing_term_months !== 1) {
@@ -343,7 +366,7 @@ export function DeployWizard() {
 		DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE,
 	);
 	const [primaryModel, setPrimaryModel] = useState(DEFAULT_DEPLOY_PRIMARY_MODEL);
-	const [compute, setCompute] = useState<Compute>("free");
+	const [compute, setCompute] = useState<Compute>("basic");
 	const [language, setLanguage] = useState("");
 	const [timezone, setTimezone] = useState("");
 	const [addProviderOpen, setAddProviderOpen] = useState(false);
@@ -363,18 +386,35 @@ export function DeployWizard() {
 		return all;
 	}, [timezone]);
 
-	const freePlan = resolveFreePlan(plans.data);
+	const basicPlan = resolveBasicPlan(plans.data);
 	const perfPlan = resolvePerformancePlan(plans.data);
-	const freeSlotUsed = usesActiveFreeComputeSlot(deployments.data);
-	const freeSlotPending = deployments.isLoading;
-	const freeSlotUnavailable = freeSlotUsed || freeSlotPending || !!deployments.error;
+	const includedSlotUsed = usesActiveIncludedBasicSlot(deployments.data);
+	const includedSlotPending = deployments.isLoading;
+	const basicOfferSelection = useMemo(
+		() => (basicPlan ? selectOfferForTerm(basicPlan, term) : null),
+		[basicPlan, term],
+	);
+	const basicSelection = useMemo(
+		() =>
+			resolveBasicDeploySelection({
+				includedSlotUsed,
+				basicPlan,
+				billingTermMonths: term,
+			}),
+		[basicPlan, includedSlotUsed, term],
+	);
 	const perfOfferSelection = useMemo(
 		() => (perfPlan ? selectOfferForTerm(perfPlan, term) : null),
 		[perfPlan, term],
 	);
 	const perfOffer = perfOfferSelection?.offer ?? null;
+	const basicOffer = basicOfferSelection?.offer ?? null;
+	const basicBillingTermMonths = basicOfferSelection?.billingTermMonths ?? term;
 	const perfBillingTermMonths = perfOfferSelection?.billingTermMonths ?? term;
+	const basicOffers = basicPlan ? planOffers(basicPlan) : [];
 	const perfOffers = perfPlan ? planOffers(perfPlan) : [];
+	const basicUnavailable =
+		includedSlotPending || !!deployments.error || basicSelection.mode === "unavailable";
 
 	const providerList = useMemo(
 		() =>
@@ -385,9 +425,7 @@ export function DeployWizard() {
 	);
 	const channelList = channels.data ?? [];
 	const computePlanReady =
-		compute === "performance"
-			? !!perfPlan && !!perfOfferSelection
-			: !!freePlan && !freeSlotUnavailable;
+		compute === "performance" ? !!perfPlan && !!perfOfferSelection : !basicUnavailable;
 	const planReady = !plans.isLoading && computePlanReady;
 	const canSubmit = planReady && !submitting;
 
@@ -428,19 +466,21 @@ export function DeployWizard() {
 
 	useEffect(() => {
 		if (compute !== "performance" || !plans.isSuccess || perfPlan) return;
-		setCompute("free");
+		setCompute("basic");
 	}, [compute, plans.isSuccess, perfPlan]);
 
 	useEffect(() => {
-		if (
-			compute !== "performance" ||
-			!perfOfferSelection ||
-			term === perfOfferSelection.billingTermMonths
-		) {
+		const selectedOffer =
+			compute === "performance"
+				? perfOfferSelection
+				: includedSlotUsed
+					? basicOfferSelection
+					: null;
+		if (!selectedOffer || term === selectedOffer.billingTermMonths) {
 			return;
 		}
-		setTerm(perfOfferSelection.billingTermMonths);
-	}, [compute, perfOfferSelection, term]);
+		setTerm(selectedOffer.billingTermMonths);
+	}, [basicOfferSelection, compute, includedSlotUsed, perfOfferSelection, term]);
 
 	// Don't let the selection silently degrade to managed: if the chosen
 	// provider vanishes from a SUCCESSFULLY-loaded list (deleted elsewhere),
@@ -488,11 +528,6 @@ export function DeployWizard() {
 		);
 		if (fallback) setPrimaryModel(fallback);
 	}, [aiProviders.data?.providers, primaryModel, primaryProviderChoice]);
-
-	useEffect(() => {
-		if (compute !== "free" || !freeSlotUsed || !perfPlan) return;
-		setCompute("performance");
-	}, [compute, freeSlotUsed, perfPlan]);
 
 	function setComputeTier(next: Compute) {
 		setCompute(next);
@@ -597,9 +632,10 @@ export function DeployWizard() {
 		return body;
 	}
 
-	function buildDeployRequest(aiFields: DeployAiFields): DeployRequest {
-		const computePlanSlug: ComputePlanSlug =
-			compute === "performance" ? COMPUTE_PERFORMANCE_SLUG : COMPUTE_FREE_SLUG;
+	function buildDeployRequest<TPlanSlug extends ComputePlanSlug>(
+		aiFields: DeployAiFields,
+		computePlanSlug: TPlanSlug,
+	): DeployRequest<TPlanSlug> {
 		return buildHostedDeployRequest({
 			computePlanSlug,
 			runtime,
@@ -635,22 +671,24 @@ export function DeployWizard() {
 		throw new Error("No checkout URL was returned.");
 	}
 
-	async function handleCheckoutComplete(previousDeploymentIds: readonly string[]) {
+	async function handleCheckoutComplete(
+		previousDeploymentIds: readonly string[],
+		tierLabel: "Basic" | "Performance",
+	) {
 		setCheckoutSession(null);
 		let refreshedDeployments: Awaited<ReturnType<typeof refreshCheckoutReturn>>;
 		try {
 			refreshedDeployments = await refreshCheckoutReturn();
 		} catch {
 			toast.success("Checkout complete", {
-				description:
-					"Your Performance deployment is provisioning. We’ll refresh it on the next load.",
+				description: `Your ${tierLabel} deployment is provisioning. We’ll refresh it on the next load.`,
 			});
 			return;
 		}
 		const deploymentId = findNewDeploymentId(previousDeploymentIds, refreshedDeployments);
 		if (deploymentId) {
 			toast.success("Checkout complete", {
-				description: "Your Performance deployment is provisioning now.",
+				description: `Your ${tierLabel} deployment is provisioning now.`,
 			});
 			void router.navigate({
 				href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"),
@@ -659,8 +697,7 @@ export function DeployWizard() {
 			return;
 		}
 		toast.success("Checkout complete", {
-			description:
-				"Your Performance deployment is provisioning. Check your agents list in a moment.",
+			description: `Your ${tierLabel} deployment is provisioning. Check your agents list in a moment.`,
 		});
 	}
 
@@ -670,12 +707,30 @@ export function DeployWizard() {
 		try {
 			const aiFields = aiDeployFields();
 			if (!aiFields) return;
-			const deployConfig = buildDeployRequest(aiFields);
+			const paidSelection =
+				compute === "performance" && perfPlan && perfOfferSelection
+					? {
+							billingTermMonths: perfOfferSelection.billingTermMonths,
+							computePlanSlug: COMPUTE_PERFORMANCE_SLUG,
+							offer: perfOfferSelection.offer,
+							plan: perfPlan,
+							tierLabel: "Performance" as const,
+						}
+					: compute === "basic" && basicSelection.mode === "checkout"
+						? {
+								billingTermMonths: basicSelection.billingTermMonths,
+								computePlanSlug: COMPUTE_BASIC_SLUG,
+								offer: basicSelection.offer,
+								plan: basicSelection.plan,
+								tierLabel: "Basic" as const,
+							}
+						: null;
 
-			if (compute === "performance" && perfPlan && perfOfferSelection) {
+			if (paidSelection) {
+				const deployConfig = buildDeployRequest(aiFields, paidSelection.computePlanSlug);
 				const body: CheckoutRequest = {
-					plan_slug: perfPlan.slug,
-					billing_term_months: perfOfferSelection.billingTermMonths,
+					plan_slug: paidSelection.plan.slug,
+					billing_term_months: paidSelection.billingTermMonths,
 					ui_mode: CHECKOUT_ELEMENTS_UI_MODE,
 					deploy_config: deployConfig,
 				};
@@ -694,11 +749,13 @@ export function DeployWizard() {
 						clientSecret: result.client_secret,
 						previousDeploymentIds: (deployments.data ?? []).map((deployment) => deployment.id),
 						request: body,
-						summary: performanceCheckoutSummary({
-							offer: perfOfferSelection.offer,
-							plan: perfPlan,
-							termMonths: perfOfferSelection.billingTermMonths,
+						summary: computeCheckoutSummary({
+							offer: paidSelection.offer,
+							plan: paidSelection.plan,
+							termMonths: paidSelection.billingTermMonths,
+							tierLabel: paidSelection.tierLabel,
 						}),
+						tierLabel: paidSelection.tierLabel,
 					});
 					return;
 				}
@@ -708,6 +765,8 @@ export function DeployWizard() {
 				});
 				return;
 			}
+			if (compute !== "basic" || basicSelection.mode !== "direct") return;
+			const deployConfig = buildDeployRequest(aiFields, COMPUTE_BASIC_SLUG);
 
 			deployAttemptRef.current = idempotencyAttemptFor(
 				deployAttemptRef.current,
@@ -732,7 +791,10 @@ export function DeployWizard() {
 		}
 	}
 
-	const deployLabel = compute === "performance" ? "Continue to checkout" : "Deploy agent";
+	const deployLabel =
+		compute === "performance" || (compute === "basic" && basicSelection.mode === "checkout")
+			? "Continue to checkout"
+			: "Deploy agent";
 	const selectedProviderCount =
 		aiAccessMode === "configured"
 			? normalizeSelectedProviderIds(aiProviderChoices, primaryProviderChoice).length
@@ -745,7 +807,7 @@ export function DeployWizard() {
 				}`;
 	const runtimeSummary = runtimeDisplayName(runtime);
 	const summaryLine = [
-		`${compute === "performance" ? "Performance" : "Free"} compute`,
+		`${compute === "performance" ? "Performance" : "Basic"} compute`,
 		aiSummary,
 		runtimeSummary,
 		LANGUAGE_OPTIONS.find((l) => l.code === language)?.label ?? null,
@@ -949,32 +1011,36 @@ export function DeployWizard() {
 
 				<SettingsSection
 					title="Compute"
-					description="Free gives one active hosted deployment. Performance is billed per deployment with higher resources."
+					description="Basic includes the first active deployment. Additional Basic and Performance agents are billed per deployment."
 				>
 					<div className="flex flex-col gap-3">
 						<div className="grid gap-2 sm:grid-cols-2">
 							<EntityChoiceCard
-								selected={compute === "free"}
-								onClick={!freeSlotUnavailable ? () => setComputeTier("free") : undefined}
+								selected={compute === "basic"}
+								onClick={!basicUnavailable ? () => setComputeTier("basic") : undefined}
 								icon={
 									<IconChip tint="bg-identity-3-bg text-identity-3-fg">
 										<Cpu />
 									</IconChip>
 								}
-								title="Free"
+								title="Basic"
 								description={
-									freeSlotUsed
-										? "Free slot already in use"
-										: freeSlotPending
-											? "Checking Free slot…"
-											: deployments.error
-												? "Free slot check unavailable"
-												: freePlan
-													? `${freePlan.vcpu} vCPU / ${freePlan.ram_gb} GB burst · one active deployment`
-													: "$0 · one active deployment"
+									basicOffer
+										? `First active agent free · then ${recurringOfferLabel(basicOffer)} per additional agent`
+										: "First active agent free · paid additional agents unavailable"
 								}
-								badge={<Badge variant="secondary">$0</Badge>}
-								disabled={freeSlotUnavailable}
+								badge={
+									<Badge variant={includedSlotUsed ? "default" : "secondary"}>
+										{includedSlotPending
+											? "Checking slot"
+											: deployments.error
+												? "Slot unavailable"
+												: includedSlotUsed && basicOffer
+													? `${formatCentsCompact(basicOffer.effective_monthly_price_cents)}/mo additional`
+													: "First slot free"}
+									</Badge>
+								}
+								disabled={basicUnavailable}
 							/>
 							<EntityChoiceCard
 								selected={compute === "performance"}
@@ -1002,22 +1068,26 @@ export function DeployWizard() {
 								disabled={!perfPlan}
 							/>
 						</div>
-						{compute === "performance" && perfOffers.length > 1 ? (
+						{(compute === "performance" ? perfOffers : includedSlotUsed ? basicOffers : []).length >
+						1 ? (
 							<div className="flex flex-col gap-1.5 sm:max-w-xs">
 								<span className="text-xs text-muted-foreground">Billing term</span>
 								<TermSwitcher
-									offers={perfOffers}
-									value={perfBillingTermMonths}
+									offers={
+										compute === "performance" ? perfOffers : includedSlotUsed ? basicOffers : []
+									}
+									value={compute === "performance" ? perfBillingTermMonths : basicBillingTermMonths}
 									onChange={setTerm}
 								/>
 							</div>
 						) : null}
 						<ComputeStatusLine
 							compute={compute}
-							freeSlotPending={freeSlotPending}
-							freeSlotUsed={freeSlotUsed}
+							includedSlotPending={includedSlotPending}
+							includedSlotUsed={includedSlotUsed}
 							deploymentsError={deployments.error}
-							freePlan={freePlan}
+							basicSelection={basicSelection}
+							basicOffer={basicOffer}
 							perfOffer={perfOffer}
 						/>
 					</div>
@@ -1103,10 +1173,15 @@ export function DeployWizard() {
 					if (!next) setCheckoutSession(null);
 				}}
 				clientSecret={checkoutSession?.clientSecret ?? null}
-				title="Complete Performance checkout"
+				title={`Complete ${checkoutSession?.tierLabel ?? "compute"} checkout`}
 				description="Enter payment details without leaving this page. Redirect-based payment methods return here after confirmation."
 				summary={checkoutSession?.summary ?? null}
-				onComplete={() => void handleCheckoutComplete(checkoutSession?.previousDeploymentIds ?? [])}
+				onComplete={() =>
+					void handleCheckoutComplete(
+						checkoutSession?.previousDeploymentIds ?? [],
+						checkoutSession?.tierLabel ?? "Basic",
+					)
+				}
 				onFallback={() =>
 					checkoutSession
 						? fallbackToHostedCheckout(checkoutSession.request)

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -99,9 +99,11 @@ import {
 import {
 	COMPUTE_BASIC_SLUG,
 	COMPUTE_PERFORMANCE_SLUG,
+	explicitPlanOffers,
 	planOffers,
 	resolveBasicPlan,
 	resolvePerformancePlan,
+	selectExplicitOfferForTerm,
 	selectOfferForTerm,
 } from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
@@ -300,7 +302,9 @@ function computeStatusLine({
 			return {
 				tone: "destructive",
 				message:
-					"The Basic plan isn’t available from the billing service. Retry plans before deploying.",
+					basicSelection.reason === "offers_missing"
+						? "Paid Basic checkout isn’t available from the billing service. Retry plans or choose Performance."
+						: "The Basic plan isn’t available from the billing service. Retry plans before deploying.",
 			};
 		}
 		if (includedSlotPending) {
@@ -391,7 +395,7 @@ export function DeployWizard() {
 	const includedSlotUsed = usesActiveIncludedBasicSlot(deployments.data);
 	const includedSlotPending = deployments.isLoading;
 	const basicOfferSelection = useMemo(
-		() => (basicPlan ? selectOfferForTerm(basicPlan, term) : null),
+		() => (basicPlan ? selectExplicitOfferForTerm(basicPlan, term) : null),
 		[basicPlan, term],
 	);
 	const basicSelection = useMemo(
@@ -411,7 +415,7 @@ export function DeployWizard() {
 	const basicOffer = basicOfferSelection?.offer ?? null;
 	const basicBillingTermMonths = basicOfferSelection?.billingTermMonths ?? term;
 	const perfBillingTermMonths = perfOfferSelection?.billingTermMonths ?? term;
-	const basicOffers = basicPlan ? planOffers(basicPlan) : [];
+	const basicOffers = basicPlan ? explicitPlanOffers(basicPlan) : [];
 	const perfOffers = perfPlan ? planOffers(perfPlan) : [];
 	const basicUnavailable =
 		includedSlotPending || !!deployments.error || basicSelection.mode === "unavailable";
@@ -632,10 +636,10 @@ export function DeployWizard() {
 		return body;
 	}
 
-	function buildDeployRequest<TPlanSlug extends ComputePlanSlug>(
+	function buildDeployRequest(
 		aiFields: DeployAiFields,
-		computePlanSlug: TPlanSlug,
-	): DeployRequest<TPlanSlug> {
+		computePlanSlug: ComputePlanSlug,
+	): DeployRequest {
 		return buildHostedDeployRequest({
 			computePlanSlug,
 			runtime,
@@ -729,7 +733,7 @@ export function DeployWizard() {
 			if (paidSelection) {
 				const deployConfig = buildDeployRequest(aiFields, paidSelection.computePlanSlug);
 				const body: CheckoutRequest = {
-					plan_slug: paidSelection.plan.slug,
+					plan_slug: paidSelection.computePlanSlug,
 					billing_term_months: paidSelection.billingTermMonths,
 					ui_mode: CHECKOUT_ELEMENTS_UI_MODE,
 					deploy_config: deployConfig,
@@ -1035,8 +1039,10 @@ export function DeployWizard() {
 											? "Checking slot"
 											: deployments.error
 												? "Slot unavailable"
-												: includedSlotUsed && basicOffer
-													? `${formatCentsCompact(basicOffer.effective_monthly_price_cents)}/mo additional`
+												: includedSlotUsed
+													? basicOffer
+														? `${formatCentsCompact(basicOffer.effective_monthly_price_cents)}/mo additional`
+														: "Additional unavailable"
 													: "First slot free"}
 									</Badge>
 								}

--- a/apps/web/src/hosted/billing/deployment-links.test.ts
+++ b/apps/web/src/hosted/billing/deployment-links.test.ts
@@ -15,7 +15,7 @@ function deployment(envs: Record<string, string> | null): HostedDeployment {
 		hermes_control_ui_url: null,
 		config_info: envs
 			? {
-					compute_plan_slug: "compute_free",
+					compute_plan_slug: "compute_basic",
 					mux_enabled: true,
 					telegram_mux_enabled: false,
 					discord_mux_enabled: false,

--- a/apps/web/src/hosted/billing/subscription/invoices-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/invoices-section.tsx
@@ -70,7 +70,7 @@ export function InvoicesSection() {
 						Invoices
 					</h2>
 					<p className="text-sm text-muted-foreground">
-						Recent Performance compute invoices from Stripe.
+						Recent Basic and Performance compute invoices from Stripe.
 					</p>
 				</div>
 			</div>
@@ -98,7 +98,7 @@ export function InvoicesSection() {
 					variant="inset"
 					icon={Receipt}
 					title="No invoices yet"
-					description="Performance compute invoices will appear here after Stripe creates them."
+					description="Paid compute invoices will appear here after Stripe creates them."
 				/>
 			) : (
 				<>

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -19,9 +19,11 @@ import type { Plan } from "@/hosted/billing/contracts";
 import { billingTermSuffix, creditsToUsd, formatCentsCompact } from "@/hosted/billing/format";
 import { usePlans } from "@/hosted/billing/hooks";
 import {
+	explicitPlanOffers,
 	planOffers,
 	resolveBasicPlan,
 	resolvePerformancePlan,
+	selectExplicitOfferForTerm,
 	selectOfferForTerm,
 } from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
@@ -78,7 +80,7 @@ export function PlanComparison({
 	const performanceOffer = performanceOfferSelection?.offer ?? null;
 	const performanceBillingTermMonths = performanceOfferSelection?.billingTermMonths ?? term;
 	const basicOfferSelection = useMemo(
-		() => (basic ? selectOfferForTerm(basic, term) : null),
+		() => (basic ? selectExplicitOfferForTerm(basic, term) : null),
 		[basic, term],
 	);
 	const basicOffer = basicOfferSelection?.offer ?? null;
@@ -99,7 +101,7 @@ export function PlanComparison({
 	);
 	const subscriptionGrantCredits = Math.max(0, performance?.subscription_grant_credits ?? 0);
 	const basicSubscriptionGrantCredits = Math.max(0, basic?.subscription_grant_credits ?? 0);
-	const basicOffers = basic ? planOffers(basic) : [];
+	const basicOffers = basic ? explicitPlanOffers(basic) : [];
 	const basicResources = basic;
 	const performanceOffers = performance ? planOffers(performance) : [];
 	const annualOffer = performanceOffers.find((o) => o.billing_term_months === 12);

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -20,16 +20,16 @@ import { billingTermSuffix, creditsToUsd, formatCentsCompact } from "@/hosted/bi
 import { usePlans } from "@/hosted/billing/hooks";
 import {
 	planOffers,
-	resolveFreePlan,
+	resolveBasicPlan,
 	resolvePerformancePlan,
 	selectOfferForTerm,
 } from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { settingsQueryHref } from "@/lib/settings-routes";
 
-function partitionPlans(plans: Plan[]): { free?: Plan; performance?: Plan } {
+function partitionPlans(plans: Plan[]): { basic?: Plan; performance?: Plan } {
 	return {
-		free: resolveFreePlan(plans),
+		basic: resolveBasicPlan(plans),
 		performance: resolvePerformancePlan(plans),
 	};
 }
@@ -44,7 +44,7 @@ function FeatureRow({ children }: { children: React.ReactNode }) {
 }
 
 /**
- * The Free / Performance / AI Credits comparison, folded into the Plan tab's
+ * The Basic / Performance / AI Credits comparison, folded into the Plan tab's
  * deploy flow (its own Pricing tab was redundant in Settings — Linear/Vercel
  * keep Plan + Usage). Self-contained; safe to drop below the current-plan card.
  */
@@ -66,7 +66,7 @@ export function PlanComparison({
 	const term = termProp ?? internalTerm;
 	const setTerm = onTermChange ?? setInternalTerm;
 
-	const { free, performance } = useMemo(
+	const { basic, performance } = useMemo(
 		() => partitionPlans(plansQuery.data ?? []),
 		[plansQuery.data],
 	);
@@ -77,6 +77,12 @@ export function PlanComparison({
 	);
 	const performanceOffer = performanceOfferSelection?.offer ?? null;
 	const performanceBillingTermMonths = performanceOfferSelection?.billingTermMonths ?? term;
+	const basicOfferSelection = useMemo(
+		() => (basic ? selectOfferForTerm(basic, term) : null),
+		[basic, term],
+	);
+	const basicOffer = basicOfferSelection?.offer ?? null;
+	const basicBillingTermMonths = basicOfferSelection?.billingTermMonths ?? term;
 
 	async function startPerformanceCheckout() {
 		if (!performance) return;
@@ -85,13 +91,16 @@ export function PlanComparison({
 
 	if (!plansQuery.data) return null;
 
-	const pointsPerUsd = performance?.points_per_usd ?? free?.points_per_usd ?? 1000;
+	const pointsPerUsd = performance?.points_per_usd ?? basic?.points_per_usd ?? 1000;
 	const creditsPerDollar = pointsPerUsd.toLocaleString();
 	const signupGrantCredits = Math.max(
 		0,
-		free?.signup_grant_credits ?? performance?.signup_grant_credits ?? 0,
+		basic?.signup_grant_credits ?? performance?.signup_grant_credits ?? 0,
 	);
 	const subscriptionGrantCredits = Math.max(0, performance?.subscription_grant_credits ?? 0);
+	const basicSubscriptionGrantCredits = Math.max(0, basic?.subscription_grant_credits ?? 0);
+	const basicOffers = basic ? planOffers(basic) : [];
+	const basicResources = basic;
 	const performanceOffers = performance ? planOffers(performance) : [];
 	const annualOffer = performanceOffers.find((o) => o.billing_term_months === 12);
 
@@ -100,35 +109,66 @@ export function PlanComparison({
 			<div>
 				<h3 className="text-base font-semibold">Compare compute options</h3>
 				<p className="text-sm text-muted-foreground">
-					Free is one user-level slot. Performance is billed per hosted agent.
+					Basic includes the first active agent. Additional Basic and Performance agents are billed
+					separately.
 				</p>
 			</div>
 			<div className="grid items-start gap-4 lg:grid-cols-3">
-				{/* Free */}
+				{/* Basic */}
 				<Card className="flex flex-col">
 					<CardHeader>
 						<div className="flex items-center justify-between">
 							<CardTitle className="flex items-center gap-2">
-								<Cpu className="size-5 text-muted-foreground" aria-hidden /> Free
+								<Cpu className="size-5 text-muted-foreground" aria-hidden /> Basic
 							</CardTitle>
 						</div>
-						<div className="mt-2 flex items-baseline gap-1">
-							<span className="text-3xl font-semibold tracking-tight tabular-nums">$0</span>
-							<span className="text-sm text-muted-foreground">/mo</span>
+						<div className="mt-2 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+							<span className="text-2xl font-semibold tracking-tight">First agent free</span>
+							<span className="text-sm text-muted-foreground">
+								{basicOffer
+									? `then ${formatCentsCompact(basicOffer.effective_monthly_price_cents)}/mo`
+									: "additional pricing unavailable"}
+							</span>
 						</div>
 						<CardDescription className="mt-2">
-							An always-on agent. Pair it with your own AI key to run end-to-end at no cost.
+							One active Basic agent is included. Each additional Basic agent uses its own
+							subscription.
 						</CardDescription>
+						{basicOffer && basicOffer.billing_term_months !== 1 ? (
+							<p className="text-xs text-muted-foreground">
+								Additional agents billed {formatCentsCompact(basicOffer.price_cents)}
+								{billingTermSuffix(basicOffer.billing_term_months)}
+							</p>
+						) : null}
+						{basicOffers.length > 1 ? (
+							<div className="mt-3">
+								<TermSwitcher
+									offers={basicOffers}
+									value={basicBillingTermMonths}
+									onChange={setTerm}
+								/>
+							</div>
+						) : null}
 					</CardHeader>
 					<CardContent className="flex-1">
 						<ul className="space-y-2">
 							<FeatureRow>Always-on hosted runtime + TEE</FeatureRow>
 							<FeatureRow>
-								Burstable compute{free ? ` (${free.vcpu} vCPU / ${free.ram_gb} GB burst)` : ""}
+								Burstable compute
+								{basicResources
+									? ` (${basicResources.vcpu} vCPU / ${basicResources.ram_gb} GB burst)`
+									: ""}
 							</FeatureRow>
-							<FeatureRow>One active Free agent per user</FeatureRow>
+							<FeatureRow>One free active Basic agent per user</FeatureRow>
+							<FeatureRow>Paid additional Basic agents</FeatureRow>
 							<FeatureRow>Single agent engine (OpenClaw or Hermes)</FeatureRow>
-							<FeatureRow>$0 with BYOK — bring your own provider key</FeatureRow>
+							<FeatureRow>BYOK avoids managed-AI usage charges</FeatureRow>
+							{basicSubscriptionGrantCredits > 0 ? (
+								<FeatureRow>
+									{creditsToUsd(basicSubscriptionGrantCredits, pointsPerUsd)} in AI Credits per
+									subscription
+								</FeatureRow>
+							) : null}
 							{signupGrantCredits > 0 ? (
 								<FeatureRow>
 									{creditsToUsd(signupGrantCredits, pointsPerUsd)} in AI Credits on signup
@@ -142,7 +182,7 @@ export function PlanComparison({
 							variant="outline"
 							onClick={() => void router.navigate({ href: "/deploy" })}
 						>
-							<Rocket /> Deploy Free agent
+							<Rocket /> Deploy Basic agent
 						</Button>
 					</CardFooter>
 				</Card>
@@ -190,7 +230,7 @@ export function PlanComparison({
 					</CardHeader>
 					<CardContent className="flex-1">
 						<ul className="space-y-2">
-							<FeatureRow>Everything in Free, plus:</FeatureRow>
+							<FeatureRow>Everything in Basic, plus:</FeatureRow>
 							<FeatureRow>
 								Higher burst
 								{performance ? ` (${performance.vcpu} vCPU / ${performance.ram_gb} GB)` : ""}
@@ -240,13 +280,13 @@ export function PlanComparison({
 							<FeatureRow>Top up any amount, $10–$2,000</FeatureRow>
 							<FeatureRow>Optional auto-reload so agents never stall</FeatureRow>
 							<FeatureRow>
-								<span className="font-medium">Free with BYOK</span> — your own key bypasses managed
-								AI
+								<span className="font-medium">No managed-AI charge with BYOK</span> — your own key
+								bypasses managed AI
 							</FeatureRow>
 						</ul>
 						<Separator className="my-4" />
 						<p className="text-xs text-muted-foreground">
-							Works with both Free and Performance compute. Manage balance and auto-reload from the
+							Works with both Basic and Performance compute. Manage balance and auto-reload from the
 							Wallet.
 						</p>
 					</CardContent>

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -99,8 +99,6 @@ export function PlanComparison({
 		0,
 		basic?.signup_grant_credits ?? performance?.signup_grant_credits ?? 0,
 	);
-	const subscriptionGrantCredits = Math.max(0, performance?.subscription_grant_credits ?? 0);
-	const basicSubscriptionGrantCredits = Math.max(0, basic?.subscription_grant_credits ?? 0);
 	const basicOffers = basic ? explicitPlanOffers(basic) : [];
 	const basicResources = basic;
 	const performanceOffers = performance ? planOffers(performance) : [];
@@ -165,12 +163,6 @@ export function PlanComparison({
 							<FeatureRow>Paid additional Basic agents</FeatureRow>
 							<FeatureRow>Single agent engine (OpenClaw or Hermes)</FeatureRow>
 							<FeatureRow>BYOK avoids managed-AI usage charges</FeatureRow>
-							{basicSubscriptionGrantCredits > 0 ? (
-								<FeatureRow>
-									{creditsToUsd(basicSubscriptionGrantCredits, pointsPerUsd)} in AI Credits per
-									subscription
-								</FeatureRow>
-							) : null}
 							{signupGrantCredits > 0 ? (
 								<FeatureRow>
 									{creditsToUsd(signupGrantCredits, pointsPerUsd)} in AI Credits on signup
@@ -242,12 +234,6 @@ export function PlanComparison({
 							<FeatureRow>
 								Larger disk{performance ? ` (${performance.disk_size} GB)` : ""}
 							</FeatureRow>
-							{subscriptionGrantCredits > 0 ? (
-								<FeatureRow>
-									{creditsToUsd(subscriptionGrantCredits, pointsPerUsd)} in AI Credits added to
-									Wallet; credits do not expire
-								</FeatureRow>
-							) : null}
 						</ul>
 					</CardContent>
 					<CardFooter>

--- a/apps/web/src/hosted/billing/subscription/subscription-page.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-page.tsx
@@ -81,8 +81,8 @@ export function SubscriptionPage() {
 				<CardHeader>
 					<CardTitle>Compute is managed per agent</CardTitle>
 					<CardDescription>
-						Free gives one active hosted-agent slot. Performance creates a separate subscription for
-						each hosted agent.
+						Basic includes one free active hosted-agent slot. Additional Basic and Performance
+						agents each use a separate subscription.
 					</CardDescription>
 				</CardHeader>
 				<CardContent className="space-y-4">

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import type { BillingOffer, Plan } from "@/hosted/billing/contracts";
+import type { BillingOffer, HostedDeployment, Plan } from "@/hosted/billing/contracts";
 import {
-	COMPUTE_FREE_SLUG,
+	COMPUTE_BASIC_SLUG,
 	COMPUTE_PERFORMANCE_SLUG,
+	computeFundingMode,
+	computeTierLabel,
+	isBasicCompute,
 	isComputeSubscriptionCancelable,
 	isComputeSubscriptionTermChangeable,
-	resolveFreePlan,
+	resolveBasicPlan,
 	resolvePerformancePlan,
 	selectOfferForTerm,
 } from "@/hosted/billing/subscription/subscription-utils";
@@ -35,6 +38,17 @@ function plan(overrides: Partial<Plan> & Pick<Plan, "slug" | "price_cents">): Pl
 	};
 }
 
+function subscription(): NonNullable<HostedDeployment["compute_subscription"]> {
+	return {
+		status: "active",
+		payment_state: "ok",
+		billing_term_months: 1,
+		price_cents: 900,
+		currency: "usd",
+		cancel_at_period_end: false,
+	};
+}
+
 describe("compute plan resolvers", () => {
 	test("resolvePerformancePlan prefers the canonical slug before price fallback", () => {
 		const priceFallback = plan({ slug: "legacy_paid", price_cents: 1900 });
@@ -44,17 +58,48 @@ describe("compute plan resolvers", () => {
 	});
 
 	test("resolvePerformancePlan falls back to the first paid plan when the slug is absent", () => {
-		const free = plan({ slug: COMPUTE_FREE_SLUG, price_cents: 0 });
+		const basic = plan({ slug: COMPUTE_BASIC_SLUG, price_cents: 900 });
 		const paid = plan({ slug: "paid", price_cents: 1900 });
 
-		expect(resolvePerformancePlan([free, paid])).toBe(paid);
+		expect(resolvePerformancePlan([basic, paid])).toBe(paid);
 	});
 
-	test("resolveFreePlan prefers the canonical slug before price fallback", () => {
-		const priceFallback = plan({ slug: "legacy_free", price_cents: 0 });
-		const canonical = plan({ slug: COMPUTE_FREE_SLUG, price_cents: 500 });
+	test("resolvePerformancePlan never treats compute_basic as the positive-price fallback", () => {
+		const basic = plan({ slug: COMPUTE_BASIC_SLUG, price_cents: 900 });
 
-		expect(resolveFreePlan([priceFallback, canonical])).toBe(canonical);
+		expect(resolvePerformancePlan([basic])).toBeUndefined();
+	});
+
+	test("resolveBasicPlan only resolves the canonical Basic plan", () => {
+		const otherPaid = plan({ slug: "legacy_paid", price_cents: 900 });
+		const basic = plan({ slug: COMPUTE_BASIC_SLUG, price_cents: 1_100 });
+
+		expect(resolveBasicPlan([otherPaid, basic])).toBe(basic);
+		expect(resolveBasicPlan([otherPaid])).toBeUndefined();
+	});
+});
+
+describe("compute tier naming", () => {
+	test("presents the low tier as Basic", () => {
+		expect(computeTierLabel(COMPUTE_BASIC_SLUG)).toBe("Basic");
+		expect(computeTierLabel(COMPUTE_PERFORMANCE_SLUG)).toBe("Performance");
+	});
+
+	test("recognizes the Basic slug without inferring its funding source", () => {
+		expect(isBasicCompute(COMPUTE_BASIC_SLUG)).toBe(true);
+		expect(isBasicCompute(COMPUTE_PERFORMANCE_SLUG)).toBe(false);
+	});
+});
+
+describe("compute funding", () => {
+	test("derives included and paid Basic from subscription presence", () => {
+		expect(computeFundingMode(COMPUTE_BASIC_SLUG, null)).toBe("included_basic");
+		expect(computeFundingMode(COMPUTE_BASIC_SLUG, subscription())).toBe("subscription");
+	});
+
+	test("does not infer included funding for Performance without subscription state", () => {
+		expect(computeFundingMode(COMPUTE_PERFORMANCE_SLUG, subscription())).toBe("subscription");
+		expect(computeFundingMode(COMPUTE_PERFORMANCE_SLUG, null)).toBe("unknown");
 	});
 });
 

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -10,6 +10,7 @@ import {
 	isComputeSubscriptionTermChangeable,
 	resolveBasicPlan,
 	resolvePerformancePlan,
+	selectExplicitOfferForTerm,
 	selectOfferForTerm,
 } from "@/hosted/billing/subscription/subscription-utils";
 
@@ -50,18 +51,18 @@ function subscription(): NonNullable<HostedDeployment["compute_subscription"]> {
 }
 
 describe("compute plan resolvers", () => {
-	test("resolvePerformancePlan prefers the canonical slug before price fallback", () => {
-		const priceFallback = plan({ slug: "legacy_paid", price_cents: 1900 });
+	test("resolvePerformancePlan selects only the canonical slug", () => {
+		const otherPaid = plan({ slug: "legacy_paid", price_cents: 1900 });
 		const canonical = plan({ slug: COMPUTE_PERFORMANCE_SLUG, price_cents: 0 });
 
-		expect(resolvePerformancePlan([priceFallback, canonical])).toBe(canonical);
+		expect(resolvePerformancePlan([otherPaid, canonical])).toBe(canonical);
 	});
 
-	test("resolvePerformancePlan falls back to the first paid plan when the slug is absent", () => {
+	test("resolvePerformancePlan does not infer Performance from a positive price", () => {
 		const basic = plan({ slug: COMPUTE_BASIC_SLUG, price_cents: 900 });
 		const paid = plan({ slug: "paid", price_cents: 1900 });
 
-		expect(resolvePerformancePlan([basic, paid])).toBe(paid);
+		expect(resolvePerformancePlan([basic, paid])).toBeUndefined();
 	});
 
 	test("resolvePerformancePlan never treats compute_basic as the positive-price fallback", () => {
@@ -153,6 +154,31 @@ describe("selectOfferForTerm", () => {
 			},
 			billingTermMonths: 1,
 		});
+	});
+});
+
+describe("selectExplicitOfferForTerm", () => {
+	test("selects only offers advertised by the plans API", () => {
+		const annual = offer(12, 8_640);
+		const selected = selectExplicitOfferForTerm(
+			plan({
+				slug: COMPUTE_BASIC_SLUG,
+				price_cents: 900,
+				offers: [offer(1, 900), annual],
+			}),
+			12,
+		);
+
+		expect(selected).toEqual({ offer: annual, billingTermMonths: 12 });
+	});
+
+	test("returns null instead of synthesizing a purchasable offer", () => {
+		expect(
+			selectExplicitOfferForTerm(
+				plan({ slug: COMPUTE_BASIC_SLUG, price_cents: 900, offers: [] }),
+				1,
+			),
+		).toBeNull();
 	});
 });
 

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -40,10 +40,7 @@ export function resolveBasicPlan(plans: Plan[] | undefined): Plan | undefined {
 }
 
 export function resolvePerformancePlan(plans: Plan[] | undefined): Plan | undefined {
-	return (
-		plans?.find((plan) => plan.slug === COMPUTE_PERFORMANCE_SLUG) ??
-		plans?.find((plan) => plan.slug !== COMPUTE_BASIC_SLUG && plan.price_cents > 0)
-	);
+	return plans?.find((plan) => plan.slug === COMPUTE_PERFORMANCE_SLUG);
 }
 
 export function isBasicCompute(planSlug: string | null | undefined): boolean {
@@ -82,6 +79,17 @@ export function planOffers(plan: Plan): BillingOffer[] {
 					discount_percent: 0,
 				},
 			];
+}
+
+/** Offers explicitly advertised by the plans API; an empty list is not purchasable. */
+export function explicitPlanOffers(plan: Plan): BillingOffer[] {
+	return plan.offers ?? [];
+}
+
+export function selectExplicitOfferForTerm(plan: Plan, term: number): ResolvedBillingOffer | null {
+	const offers = explicitPlanOffers(plan);
+	const offer = offers.find((candidate) => candidate.billing_term_months === term) ?? offers[0];
+	return offer ? { offer, billingTermMonths: offer.billing_term_months } : null;
 }
 
 export function selectOfferForTerm(plan: Plan, term: number): ResolvedBillingOffer {

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -1,7 +1,13 @@
-import type { BillingOffer, Plan } from "@/hosted/billing/contracts";
+import {
+	type BillingOffer,
+	COMPUTE_BASIC_SLUG,
+	COMPUTE_PERFORMANCE_SLUG,
+	type ComputePlanSlug,
+	type HostedDeployment,
+	type Plan,
+} from "@/hosted/billing/contracts";
 
-export const COMPUTE_FREE_SLUG = "compute_free";
-export const COMPUTE_PERFORMANCE_SLUG = "compute_performance";
+export { COMPUTE_BASIC_SLUG, COMPUTE_PERFORMANCE_SLUG };
 export const COMPUTE_SUBSCRIPTION_CANCELABLE_STATUSES = new Set(["trialing", "active", "past_due"]);
 export const COMPUTE_SUBSCRIPTION_TERM_CHANGEABLE_STATUSES = new Set(["trialing", "active"]);
 
@@ -29,18 +35,36 @@ export function isComputeSubscriptionTermChangeable(
 	return COMPUTE_SUBSCRIPTION_TERM_CHANGEABLE_STATUSES.has(subscription?.status ?? "");
 }
 
-export function resolveFreePlan(plans: Plan[] | undefined): Plan | undefined {
-	return (
-		plans?.find((plan) => plan.slug === COMPUTE_FREE_SLUG) ??
-		plans?.find((plan) => plan.price_cents === 0)
-	);
+export function resolveBasicPlan(plans: Plan[] | undefined): Plan | undefined {
+	return plans?.find((plan) => plan.slug === COMPUTE_BASIC_SLUG);
 }
 
 export function resolvePerformancePlan(plans: Plan[] | undefined): Plan | undefined {
 	return (
 		plans?.find((plan) => plan.slug === COMPUTE_PERFORMANCE_SLUG) ??
-		plans?.find((plan) => plan.price_cents > 0)
+		plans?.find((plan) => plan.slug !== COMPUTE_BASIC_SLUG && plan.price_cents > 0)
 	);
+}
+
+export function isBasicCompute(planSlug: string | null | undefined): boolean {
+	return planSlug === COMPUTE_BASIC_SLUG;
+}
+
+export type ComputeFundingMode = "included_basic" | "subscription" | "unknown";
+
+export function computeFundingMode(
+	planSlug: string | null | undefined,
+	computeSubscription: HostedDeployment["compute_subscription"] | null | undefined,
+): ComputeFundingMode {
+	if (computeSubscription) return "subscription";
+	if (isBasicCompute(planSlug)) return "included_basic";
+	return "unknown";
+}
+
+export function computeTierLabel(
+	planSlug: ComputePlanSlug | null | undefined,
+): "Basic" | "Performance" {
+	return planSlug === COMPUTE_PERFORMANCE_SLUG ? "Performance" : "Basic";
 }
 
 /**

--- a/apps/web/src/hosted/billing/subscription/welcome-credits-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/welcome-credits-card.tsx
@@ -81,12 +81,12 @@ export function WelcomeCreditsCard() {
 						</p>
 						<p className="text-sm text-muted-foreground">
 							{grantApplied
-								? "Your Free compute slot is ready. Deploy your first agent — managed AI is on us to start."
+								? "Your free Basic compute slot is ready. Deploy your first agent — managed AI is on us to start."
 								: grantPending
 									? grantCredits
 										? `Your ${grantCredits} in AI Credits is on the way. You can deploy now; it’ll be ready in a moment.`
 										: "Your welcome credits are on the way. You can deploy now; they’ll be ready in a moment."
-									: "Your Free compute slot is ready at $0. Deploy your first agent to get going."}
+									: "Your free Basic compute slot is ready. Deploy your first agent to get going."}
 						</p>
 					</div>
 				</div>

--- a/apps/web/src/hosted/billing/wallet/ledger-table.tsx
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.tsx
@@ -37,7 +37,7 @@ const OPERATION_LABELS: Record<string, string> = {
 	invoice: "Top-up",
 	x402: "On-chain top-up",
 	grant_signup: "Signup grant",
-	grant_subscription: "Performance grant",
+	grant_subscription: "Credit grant",
 	grant_redemption: "Redeemed credits",
 	grant_referral: "Referral grant",
 	admin_adjust: "Adjustment",

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -120,9 +120,9 @@ function failureReasonIndicatesNoBackingInfra(failureReason: string | null | und
 }
 
 /**
- * Mirrors the deploy-API Free-slot product predicate in `slot_occupancy.py`.
+ * Mirrors the deploy-API included-Basic-slot product predicate in `slot_occupancy.py`.
  * This is not the cluster tenant/disk reservation rule; stopped deployments
- * release a user's Free slot while their PVC may still reserve cluster space.
+ * release a user's included Basic slot while their PVC may still reserve cluster space.
  */
 export function occupiesComputeSlot(deployment: {
 	status: string | null | undefined;

--- a/apps/web/src/hosted/runtimes.test.ts
+++ b/apps/web/src/hosted/runtimes.test.ts
@@ -23,7 +23,7 @@ function configInfo(
 	overrides: Partial<NonNullable<HostedDeployment["config_info"]>>,
 ): NonNullable<HostedDeployment["config_info"]> {
 	return {
-		compute_plan_slug: "compute_free",
+		compute_plan_slug: "compute_basic",
 		mux_enabled: true,
 		telegram_mux_enabled: false,
 		discord_mux_enabled: false,

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -92,7 +92,7 @@ function deployment(
 		openclaw_control_ui_url: null,
 		hermes_control_ui_url: null,
 		config_info: {
-			compute_plan_slug: "compute_free",
+			compute_plan_slug: "compute_basic",
 			mux_enabled: true,
 			telegram_mux_enabled: false,
 			discord_mux_enabled: false,
@@ -180,7 +180,7 @@ describe("deploymentToTiles", () => {
 
 		expect(tile?.secondaryStatus).toEqual({
 			label: "Payment action required",
-			title: "Complete payment authentication to keep Performance compute active.",
+			title: "Complete payment authentication to keep Basic compute active.",
 			textClass: "text-warning-muted-foreground",
 		});
 	});

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -521,8 +521,11 @@ export interface components {
         };
         /** V2ComputeCheckoutRequest */
         V2ComputeCheckoutRequest: {
-            /** Plan Slug */
-            plan_slug: string;
+            /**
+             * Plan Slug
+             * @enum {string}
+             */
+            plan_slug: "compute_basic" | "compute_performance";
             /**
              * Billing Term Months
              * @default 1
@@ -753,7 +756,7 @@ export interface components {
              * Compute Plan Slug
              * @enum {string}
              */
-            compute_plan_slug: "compute_free" | "compute_performance";
+            compute_plan_slug: "compute_basic" | "compute_performance";
             /** Primary Model */
             primary_model?: string | components["schemas"]["V2AiProviderPrimaryModelRef"] | null;
             /** Channel */
@@ -808,7 +811,7 @@ export interface components {
              * Compute Plan Slug
              * @enum {string}
              */
-            compute_plan_slug: "compute_free" | "compute_performance";
+            compute_plan_slug: "compute_basic" | "compute_performance";
             /**
              * Mux Enabled
              * @default false
@@ -1223,7 +1226,9 @@ export interface operations {
     create_v2_deployment_v2_deployments_post: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                "Idempotency-Key"?: string | null;
+            };
             path?: never;
             cookie?: never;
         };


### PR DESCRIPTION
## Why

The web UI must present one Basic compute tier while making funding explicit before deployment: the first active Basic agent is included, and every additional Basic agent requires its own Stripe subscription instead of being blocked.

The UI must also stop promising recurring AI credits with Performance now that compute-subscription wallet grants are retired.

## Product decisions

1. Compute and managed-AI usage share one prepaid wallet balance with no buckets; promo and signup credits are fungible.
2. No compute subscription, including Performance, receives a recurring wallet credit grant. Historical grants remain visible and there is no clawback.
3. Wallet-funded compute is a separate next epic, not part of this PR. Its contract is refresh-before-debit, a 72-hour grace period after failed renewal, and coverage-aware auto-reload.

## What changed

- replace the Free/Performance picker with Basic/Performance and remove Free as a tier name across hosted surfaces
- detect included-slot use only from active `compute_basic` deployments without `compute_subscription`; paid Basic does not consume the included slot
- send direct `compute_basic` deploys while the included slot is available
- start `compute_basic` monthly/annual checkout, including nested deploy config and the auto-deploy return flow, when the slot is occupied
- require a Basic offer explicitly advertised by the plans API before paid checkout; `offers=[]` keeps the included direct path usable but never creates a synthetic purchasable price
- show the free-vs-paid outcome, real API price, and cadence before the deploy action
- render included-funded and paid-funded Basic correctly on agent detail, cancellation, dunning, invoice, signup-credit, and comparison surfaces
- preserve paid Basic term/payment/cancel/resume controls and show Performance upgrade only for included-funded Basic
- remove Performance recurring-credit claims while retaining the signup `WelcomeCreditsCard`
- regenerate `deploy.generated.ts` from the companion backend OpenAPI; no handwritten generated-file widening remains
- keep paid Basic ↔ Performance direct switching out of the current UI; the backend still accepts Stripe price-change webhooks

## Transition coverage

| Transition | Verification |
| --- | --- |
| paid Basic leaves included slot available | E2E `paid-funded Basic leaves the included slot available for direct compute_basic deploy` |
| included Basic slot occupied → paid Basic | E2E `free-funded Basic uses annual compute_basic checkout when the included slot is occupied` |
| included Basic → Performance checkout | E2E `included Basic starts annual Performance checkout without direct tier switching` |
| paid Basic cancel, included slot vacant vs occupied | E2E `paid Basic cancellation stays conditional with the included slot vacant or occupied` |
| paid Performance actions without direct Basic switch | E2E `paid Performance exposes subscription actions without a direct Basic switch` |
| stop/start entitlement failure | E2E `occupied included Basic start surfaces the backend slot entitlement error` |
| included and paid checkout abandonment | E2E `included Basic checkout abandonment preserves the current plan`; `paid Basic checkout abandonment preserves the checkout-ready wizard` |
| no recurring compute grant copy; signup credit remains | E2E `compute plans keep signup credits without advertising subscription credit grants` |

Unit coverage also exercises Basic selection/funding, deploy request serialization, dunning, checkout fallback, and subscription offer resolution.

## Stripe and backend dependency

Backend companion: https://github.com/Clawdi-AI/clawdi-hosted/pull/860

Provisioned Basic prices:

- test monthly: `price_1TtPH8Ll4MZsiow19w0k0cmy`
- test annual: `price_1TtPH8Ll4MZsiow1WfCT2Efp`
- live monthly: `price_1TtPHlLl4MZsiow1UaVdDhRv`
- live annual: `price_1TtPHlLl4MZsiow1BSNlsxDj`

The live IDs are already recorded in the operator ops env file. The backend adds:

- `STRIPE_PRICE_ID_COMPUTE_BASIC`
- `STRIPE_PRICE_ID_COMPUTE_BASIC_ANNUAL`

**Do not merge or deploy either PR until both live IDs are installed in the production backend service environment and billing readiness resolves all Basic/Performance monthly and annual offers.**

The backend migration and compatible backend must ship atomically after old create/start/auto-deploy writers are drained or fenced; old code against renamed rows can grant unlimited included slots. Deploy this frontend only after that backend window completes.

Until backend #860 is live, the `deploy-contract-drift` check is expected to fail because the deployed OpenAPI still emits `compute_free`. Regenerate/re-run against the live backend after the atomic backend rollout; this frontend should not merge before that contract check passes.

## Verification

- `bunx biome check apps/web/src apps/web/e2e/hosted-smoke.pw.ts` — 380 files checked
- `bun run --cwd apps/web typecheck` — passed
- `bun run --cwd apps/web test` — 413 passed, 0 failed, 875 assertions
- `bun run --cwd apps/web build:oss` — passed
- `bun run --cwd apps/web e2e:hosted` — 12 Chromium tests passed
