### PR TITLE
fix(cli): tolerate user daemon-reload failure during official service install

### DIFF
--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -4632,14 +4632,20 @@ function resetFailedRuntimeUserService(name: string, paths: RuntimePaths, cwd: s
 }
 
 function reloadRuntimeUserManager(paths: RuntimePaths, cwd: string): void {
-	ensureConfiguredRuntimeUserManagerReady();
-	runRuntimeUserCommand(
-		process.env.CLAWDI_SYSTEMCTL_PATH?.trim() || "systemctl",
-		["--user", "daemon-reload"],
-		"",
-		paths.userHome,
-		cwd,
-	);
+	try {
+		ensureConfiguredRuntimeUserManagerReady();
+		runRuntimeUserCommand(
+			process.env.CLAWDI_SYSTEMCTL_PATH?.trim() || "systemctl",
+			["--user", "daemon-reload"],
+			"",
+			paths.userHome,
+			cwd,
+		);
+	} catch {
+		// Best-effort: environments without a reachable user manager (unit tests,
+		// non-hosted hosts) must not fail convergence, and official installers
+		// perform their own daemon-reload after writing the base unit.
+	}
 }
 
 function uninstallOfficialRuntimeUserService(input: {


### PR DESCRIPTION
## Summary
#416 (heal stale hosted runtime drop-ins) added a `systemctl --user daemon-reload` before the official gateway installer runs. That call threw in environments without a reachable systemd user bus — which is exactly what CI runners provide — so `cli-test` failed on main (`runtime manifest datasource > applies OpenClaw hosted config after the official gateway installer`, `runtime manifest reconciliation invariants > advances last-good manifest only after a clean converge`) with `Failed to connect to bus: No medium found`, and any non-hosted converge would abort the same way.

## Fix
Wrap `reloadRuntimeUserManager` in the same best-effort pattern as `resetFailedRuntimeUserService`. Rationale: in production the hosted bootstrap guarantees the user manager exists before `runtime init`, so the reload still takes effect there; official installers additionally perform their own daemon-reload after writing the base unit, so a skipped reload never leaves the installer acting on stale unit definitions.

## Validation
- Reproduced both CI failures locally with `env -u DBUS_SESSION_BUS_ADDRESS -u XDG_RUNTIME_DIR`; both pass with the fix.
- Full `packages/cli` suite in the same environment: 987 pass / 0 fail. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)