### PR TITLE
release(cli): prepare 0.12.10-beta.54 artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ database migration, CI, and implementation details.
   `clawdi-v...` CalVer tag format.
 - CLI/npm releases use `clawdi-cli-vX.Y.Z`.
 
+## Clawdi CLI v0.12.10-beta.54
+
+Package: `clawdi@0.12.10-beta.54`
+
+### Fixed
+
+- Fixed a hosted runtime reboot deadlock: persistently enabled runtime user
+  units referenced a convergence-generated environment file that only exists
+  after boot-time convergence, tripping the systemd start limit and blocking
+  the official installer's restart. Units now declare the dependency with
+  `ConditionPathExists`, convergence clears failed unit state, and the
+  converged drop-in and environment file are written before the official
+  installer runs, so deployments created by earlier CLI versions self-heal on
+  their next restart without manual intervention.
+- Hosted convergence no longer fails on hosts without a reachable systemd user
+  bus when reloading the user manager before official service installs.
+- Vault reads and writes now use a stable identity across operations.
+- Runtime bridge assets are cached by content hash for reliable serving.
+
 ## Clawdi CLI v0.12.10-beta.53
 
 Package: `clawdi@0.12.10-beta.53`

--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.53",
+      "version": "0.12.10-beta.54",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.53",
+	"version": "0.12.10-beta.54",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## Summary
Prepare the `clawdi@0.12.10-beta.54` CLI prerelease. Content since `beta.53`:

- #415 / #416 / #417 — hosted runtime reboot deadlock chain: `ConditionPathExists` gating for persistent user units, `reset-failed` self-heal, converged drop-in + env written before the official installer runs (heals stale state from earlier CLI versions), and best-effort user daemon-reload.
- #410 — cache hashed runtime bridge assets.
- #406 — stable vault identity across reads and writes.

## Release-owner compatibility judgment (per cross-repo runbook)
This CLI depends only on capabilities already present in the current pinned hosted runtime image; baked-content inputs (`infra/v2/hosted-runtime/image/{Dockerfile,bin,config,systemd}`) are unchanged since the pinned digest's revision. The CLI-only validate-only pairing path applies; no new substrate is required.

Merging to main triggers `cli-publish.yml` to publish the exact version with the `beta` dist-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)