### PR TITLE
fix(web): unify sidebar and dashboard agent lists

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -44,7 +44,7 @@ import {
 } from "lucide-react";
 import { useQueryState } from "nuqs";
 import { parseAsStringLiteral } from "nuqs/server";
-import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useCommandPalette } from "@/components/command-palette";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
@@ -54,10 +54,14 @@ import {
 	agentSourceKindLabel,
 	agentTextLabel,
 	agentTypeLabel,
-	compareAgentEnvironments,
 	displayMachineName,
 	LegacyAgentBadge,
 } from "@/components/dashboard/agent-label";
+import {
+	type AgentTile,
+	compareAgentTiles,
+	selfManagedAgentTiles,
+} from "@/components/dashboard/agents-card";
 import { DaemonStatusBadge } from "@/components/dashboard/daemon-status";
 import { NewAgentButton } from "@/components/dashboard/new-agent-button";
 import { IconChip } from "@/components/icon-chip";
@@ -129,6 +133,13 @@ const HostedFocusRuntimeStatusBadge = IS_HOSTED_BUILD
 	? lazy(() =>
 			import("@/hosted/use-hosted-agent-tiles").then((m) => ({
 				default: m.HostedFocusRuntimeStatusBadge,
+			})),
+		)
+	: null;
+const HostedUnifiedAgentListSensor = IS_HOSTED_BUILD
+	? lazy(() =>
+			import("@/hosted/use-unified-agent-list").then((m) => ({
+				default: m.HostedUnifiedAgentListSensor,
 			})),
 		)
 	: null;
@@ -274,12 +285,18 @@ function reorderEnvironmentsForCache(
 	return reordered.map((env, index) => ({ ...env, sort_order: index }));
 }
 
-function reorderEnvironmentsByIndex(
-	current: SidebarEnvironment[],
-	from: number,
-	to: number,
-): SidebarEnvironment[] {
-	return arrayMove(current, from, to).map((env, index) => ({ ...env, sort_order: index }));
+function reorderAgentTilesByIndex(current: AgentTile[], from: number, to: number): AgentTile[] {
+	return arrayMove(current, from, to).map((tile, index) => ({
+		...tile,
+		sortOrder: index,
+		env: tile.env ? { ...tile.env, sort_order: index } : tile.env,
+	}));
+}
+
+function agentTileChromeKind(tile: AgentTile): AgentChromeKind {
+	if (tile.source === "on-clawdi") return "cloud";
+	if (tile.source === "legacy-hosted") return "legacy";
+	return "connected";
 }
 
 function sameOrder(a: string[], b: string[]): boolean {
@@ -712,7 +729,7 @@ function RailFocusButton({
 	showTooltip = true,
 	children,
 }: {
-	href: string;
+	href: string | null;
 	label: string;
 	caption?: string;
 	active: boolean;
@@ -726,21 +743,24 @@ function RailFocusButton({
 	children: React.ReactNode;
 }) {
 	const hasCaption = Boolean(caption);
+	const focusTarget = href ? (
+		<Link
+			to={href}
+			draggable={false}
+			onClickCapture={onClickCapture}
+			onClick={onNavigate}
+			onPointerDownCapture={onPointerDownCapture}
+			onPointerDown={onPointerDown}
+			onTouchStartCapture={onTouchStartCapture}
+			onTouchStart={onTouchStart}
+			className="cursor-default"
+		/>
+	) : (
+		<div aria-disabled="true" className="cursor-default" />
+	);
 	const button = (
 		<SidebarMenuButton
-			render={
-				<Link
-					to={href}
-					draggable={false}
-					onClickCapture={onClickCapture}
-					onClick={onNavigate}
-					onPointerDownCapture={onPointerDownCapture}
-					onPointerDown={onPointerDown}
-					onTouchStartCapture={onTouchStartCapture}
-					onTouchStart={onTouchStart}
-					className="cursor-default"
-				/>
-			}
+			render={focusTarget}
 			size="lg"
 			isActive={active}
 			aria-label={label}
@@ -806,7 +826,7 @@ function SortableAgentRailItem({
 	onTouchStartCapture,
 	showTooltip,
 }: {
-	agent: SidebarEnvironment;
+	agent: AgentTile;
 	active: boolean;
 	onNavigate: React.MouseEventHandler<HTMLAnchorElement>;
 	onClickCapture: React.MouseEventHandler<HTMLAnchorElement>;
@@ -816,14 +836,25 @@ function SortableAgentRailItem({
 }) {
 	const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({
 		id: agent.id,
+		disabled: !agent.env,
 	});
-	const kind = useAgentChromeKind(agent);
-	const label =
+	const kind = agentTileChromeKind(agent);
+	const identity = agent.env ?? {
+		id: agent.id,
+		name: agent.name,
+		machine_name: agent.name,
+		agent_type: agent.agentType,
+	};
+	const identityLabel =
 		kind === "legacy"
-			? `Legacy · ${agentTextLabel(agent, { includeSource: false, ownershipKind: kind })}`
-			: agentTextLabel(agent, { includeSource: kind === "cloud", ownershipKind: kind });
-	const caption = displayMachineName(agentDisplayName(agent));
-	const href = agentSectionHref(agent.id);
+			? `Legacy · ${agentTextLabel(identity, { includeSource: false, ownershipKind: kind })}`
+			: agentTextLabel(identity, { includeSource: kind === "cloud", ownershipKind: kind });
+	const statusLabel =
+		kind === "cloud"
+			? [agent.statusLabel, agent.secondaryStatus?.label].filter(Boolean).join(" · ")
+			: null;
+	const label = statusLabel ? `${identityLabel} · ${statusLabel}` : identityLabel;
+	const caption = displayMachineName(agent.name);
 	const style: React.CSSProperties = {
 		transform: CSS.Transform.toString(transform),
 		transition: isDragging ? undefined : transition,
@@ -845,7 +876,7 @@ function SortableAgentRailItem({
 			)}
 		>
 			<RailFocusButton
-				href={href}
+				href={agent.href}
 				label={label}
 				caption={caption}
 				active={active}
@@ -858,7 +889,7 @@ function SortableAgentRailItem({
 				showTooltip={showTooltip}
 			>
 				<span className="relative inline-flex rounded-md">
-					<AgentIcon agent={agent.agent_type} size="rail" avatarUrl={agent.avatar_url} />
+					<AgentIcon agent={agent.agentType} size="rail" avatarUrl={agent.avatarUrl} />
 					{kind === "cloud" ? (
 						<span
 							title="Clawdi Cloud agent"
@@ -886,7 +917,7 @@ function FocusRailContent({
 	onNavigate,
 	showTooltips = true,
 }: {
-	agents: SidebarEnvironment[];
+	agents: AgentTile[];
 	activeAgentId: string | null;
 	onNavigate?: () => void;
 	showTooltips?: boolean;
@@ -896,12 +927,12 @@ function FocusRailContent({
 	const draggingRailItem = useRef(false);
 	const railPointerStart = useRef<{ x: number; y: number } | null>(null);
 	const suppressCurrentRailPointerClick = useRef(false);
-	const [railAgents, setRailAgents] = useState<SidebarEnvironment[]>(() =>
-		[...agents].sort(compareAgentEnvironments),
+	const [railAgents, setRailAgents] = useState<AgentTile[]>(() =>
+		[...agents].sort(compareAgentTiles),
 	);
 	const railAgentsRef = useRef(railAgents);
-	const dragStartRailAgents = useRef<SidebarEnvironment[] | null>(null);
-	const setRailAgentsOrder = (next: SidebarEnvironment[]) => {
+	const dragStartRailAgents = useRef<AgentTile[] | null>(null);
+	const setRailAgentsOrder = (next: AgentTile[]) => {
 		railAgentsRef.current = next;
 		setRailAgents(next);
 	};
@@ -911,32 +942,35 @@ function FocusRailContent({
 	);
 	useEffect(() => {
 		if (!draggingRailItem.current) {
-			setRailAgentsOrder([...agents].sort(compareAgentEnvironments));
+			setRailAgentsOrder([...agents].sort(compareAgentTiles));
 		}
 	}, [agents]);
 	const orderedAgents = railAgents;
 	const orderedAgentIds = orderedAgents.map((agent) => agent.id);
 	const reorderAgents = useMutation({
-		mutationFn: async (environmentIds: string[]) =>
-			unwrap(await api.PATCH("/v1/agents/order", { body: { agent_ids: environmentIds } })),
-		onMutate: async (environmentIds) => {
+		mutationFn: async ({
+			environmentIds,
+		}: {
+			environmentIds: string[];
+			previousRail: AgentTile[];
+		}) => unwrap(await api.PATCH("/v1/agents/order", { body: { agent_ids: environmentIds } })),
+		onMutate: async ({ environmentIds, previousRail }) => {
 			await queryClient.cancelQueries({ queryKey: ["agents"] });
 			const previous = queryClient.getQueryData<SidebarEnvironment[]>(["agents"]);
 			queryClient.setQueryData<SidebarEnvironment[]>(["agents"], (current) =>
 				current ? reorderEnvironmentsForCache(current, environmentIds) : current,
 			);
-			return { previous };
+			return { previous, previousRail };
 		},
-		onError: (error, _environmentIds, context) => {
+		onError: (error, _variables, context) => {
 			if (context?.previous) {
 				queryClient.setQueryData(["agents"], context.previous);
-				setRailAgentsOrder([...context.previous].sort(compareAgentEnvironments));
 			}
+			if (context?.previousRail) setRailAgentsOrder(context.previousRail);
 			toast.error("Couldn't reorder agents", { description: errorMessage(error) });
 		},
 		onSuccess: (data) => {
 			queryClient.setQueryData(["agents"], data);
-			setRailAgentsOrder([...data].sort(compareAgentEnvironments));
 		},
 	});
 	const onDragEnd = (event: DragEndEvent) => {
@@ -955,13 +989,16 @@ function FocusRailContent({
 			const from = finalIds.indexOf(String(active.id));
 			const to = finalIds.indexOf(String(over.id));
 			if (from >= 0 && to >= 0) {
-				finalAgents = reorderEnvironmentsByIndex(finalAgents, from, to);
+				finalAgents = reorderAgentTilesByIndex(finalAgents, from, to);
 				setRailAgentsOrder(finalAgents);
 				finalIds = finalAgents.map((agent) => agent.id);
 			}
 		}
 		if (sameOrder(initialIds, finalIds)) return;
-		reorderAgents.mutate(finalIds);
+		reorderAgents.mutate({
+			environmentIds: finalAgents.flatMap((agent) => (agent.env ? [agent.env.id] : [])),
+			previousRail: initialAgents ?? orderedAgents,
+		});
 	};
 	const onDragOver = (event: DragOverEvent) => {
 		const { active, over } = event;
@@ -972,7 +1009,7 @@ function FocusRailContent({
 		const from = current.findIndex((agent) => agent.id === activeId);
 		const to = current.findIndex((agent) => agent.id === overId);
 		if (from < 0 || to < 0 || from === to) return;
-		setRailAgentsOrder(reorderEnvironmentsByIndex(current, from, to));
+		setRailAgentsOrder(reorderAgentTilesByIndex(current, from, to));
 	};
 	const beginRailDragGesture = () => {
 		draggingRailItem.current = true;
@@ -1080,7 +1117,7 @@ function FocusRailContent({
 							if (dragStartRailAgents.current) {
 								setRailAgentsOrder(dragStartRailAgents.current);
 							} else {
-								setRailAgentsOrder([...agents].sort(compareAgentEnvironments));
+								setRailAgentsOrder([...agents].sort(compareAgentTiles));
 							}
 							dragStartRailAgents.current = null;
 						}}
@@ -1092,7 +1129,7 @@ function FocusRailContent({
 								<SortableAgentRailItem
 									key={agent.id}
 									agent={agent}
-									active={activeAgentId === agent.id}
+									active={activeAgentId === agent.env?.id}
 									onNavigate={onRailAgentNavigate}
 									onClickCapture={onRailAgentClickCapture}
 									onPointerDownCapture={recordRailPointerStart}
@@ -1263,7 +1300,7 @@ function RailSidebar({
 	agents,
 	activeAgentId,
 }: {
-	agents: SidebarEnvironment[];
+	agents: AgentTile[];
 	activeAgentId: string | null;
 }) {
 	return (
@@ -1554,6 +1591,7 @@ export function AppSidebar({
 	const api = useApi();
 	const hostedAccess = useHostedProductAccess();
 	const [mounted, setMounted] = useState(false);
+	const [hostedAgentTiles, setHostedAgentTiles] = useState<AgentTile[] | null>(null);
 	useEffect(() => {
 		setMounted(true);
 	}, []);
@@ -1566,9 +1604,17 @@ export function AppSidebar({
 		refetchInterval: activeAgentId ? 10_000 : false,
 	});
 	const hydratedEnvironments = mounted ? environments : undefined;
-	const agentsLoaded = hydratedEnvironments !== undefined;
-	const agents = hydratedEnvironments ?? [];
-	const activeAgent = activeAgentId ? agents.find((env) => env.id === activeAgentId) : null;
+	const selfManagedTiles = useMemo(
+		() => selfManagedAgentTiles(hydratedEnvironments),
+		[hydratedEnvironments],
+	);
+	const unifiedAgentListEnabled = mounted && Boolean(HostedUnifiedAgentListSensor);
+	const agentsLoaded =
+		hydratedEnvironments !== undefined && (!unifiedAgentListEnabled || hostedAgentTiles !== null);
+	const agents = unifiedAgentListEnabled ? (hostedAgentTiles ?? []) : selfManagedTiles;
+	const activeAgent = activeAgentId
+		? (hydratedEnvironments?.find((env) => env.id === activeAgentId) ?? null)
+		: null;
 	const activeSection = agentRoute?.section ?? "overview";
 	const [settingsSection, setSettingsSection] = useQueryState(
 		SETTINGS_QUERY_KEY,
@@ -1601,6 +1647,16 @@ export function AppSidebar({
 
 	return (
 		<>
+			{unifiedAgentListEnabled && HostedUnifiedAgentListSensor ? (
+				<Suspense fallback={null}>
+					<HostedUnifiedAgentListSensor
+						cloudEnvs={hydratedEnvironments ?? []}
+						showCloudDeployments
+						showLegacyAgents={hostedAccess.canUseLegacyHostedDashboard}
+						onChange={setHostedAgentTiles}
+					/>
+				</Suspense>
+			) : null}
 			{!isMobile ? <RailSidebar agents={agents} activeAgentId={activeAgentId} /> : null}
 			<Sidebar
 				collapsible="offcanvas"

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -87,13 +87,13 @@ export interface AgentTile {
 	statusLabel: string;
 	/** Used to compute the "N active now" count in the card description. */
 	lastSeenAt?: string | null;
-	/** Primary click target. Always points at the in-app env detail
+	/** Primary click target. Points at the in-app env detail
 	 * page (`/agents/{env_id}`) when an env is available — for both
 	 * self-managed and hosted tiles with a registered env, so the
-	 * sessions/skills/memory experience stays unified. Uses the in-app
-	 * deployment-id route for hosted tiles whose cloud-api env has not
-	 * been registered yet. `external` reflects whichever applies. */
-	href: string;
+	 * sessions/skills/memory experience stays unified. Hosted tiles without a
+	 * registered env are non-navigable instead of putting a deployment id in an
+	 * agent route. `external` reflects whichever applies. */
+	href: string | null;
 	external?: boolean;
 	/** Optional hosted remediation target retained for surfaces that open
 	 * status dialogs. Tiles render daemon status as a non-interactive dot. */
@@ -331,6 +331,14 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 	const linkStatus = [statusDot.label, tile.secondaryStatus?.label].filter(Boolean).join(", ");
 	const linkLabel = `Open ${tile.name}. Status: ${linkStatus}`;
 
+	if (!tile.href) {
+		return (
+			<div className="block h-full rounded-lg text-inherit" title={`Status: ${linkStatus}`}>
+				{card}
+			</div>
+		);
+	}
+
 	if (tile.external) {
 		return (
 			<a
@@ -366,7 +374,7 @@ function agentTileActivityLabel(tile: AgentTile): string | null {
 	return null;
 }
 
-function compareAgentTiles(a: AgentTile, b: AgentTile): number {
+export function compareAgentTiles(a: AgentTile, b: AgentTile): number {
 	if (a.env && b.env) return compareAgentEnvironments(a.env, b.env);
 	const aOrder = a.sortOrder ?? Number.MAX_SAFE_INTEGER;
 	const bOrder = b.sortOrder ?? Number.MAX_SAFE_INTEGER;

--- a/apps/web/src/hosted/hosted-agents-section.tsx
+++ b/apps/web/src/hosted/hosted-agents-section.tsx
@@ -5,25 +5,20 @@ import { ApiErrorPanel } from "@/components/api-error-panel";
 import { AgentSourceBadge } from "@/components/dashboard/agent-label";
 import {
 	AgentsCard,
-	type AgentTile,
 	AgentTileGrid,
 	HostedUnavailableBanner,
 } from "@/components/dashboard/agents-card";
 import { OnboardingCard } from "@/components/dashboard/onboarding-card";
 import { SectionLabel } from "@/components/section-label";
-import { useLegacyEnvIds } from "@/hosted/agents/ownership-sensor";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
-import {
-	connectedAgentTilesForHostedView,
-	useHostedAgentTiles,
-} from "@/hosted/use-hosted-agent-tiles";
+import { useUnifiedAgentList } from "@/hosted/use-unified-agent-list";
 
 type Env = components["schemas"]["AgentResponse"];
 
 /**
  * Hosted-only branch of the dashboard's agent panel.
  *
- * Wraps `useHostedAgentTiles` (cross-origin to the deploy API) and the
+ * Wraps `useUnifiedAgentList` (cross-origin to the deploy API) and the
  * AgentsCard / OnboardingCard render decision into one component so the
  * entire hosted code path — including the cross-origin client and the
  * empty-state coupling between hosted and self-managed counts — can be
@@ -44,7 +39,6 @@ type Env = components["schemas"]["AgentResponse"];
  * inherits no extra spacing.
  */
 export function HostedAgentsSection({
-	selfManagedTiles,
 	envsLoading,
 	selfManagedError,
 	onRetrySelfManaged,
@@ -53,7 +47,6 @@ export function HostedAgentsSection({
 	showCloudDeployments = true,
 	showLegacyAgents = false,
 }: {
-	selfManagedTiles: AgentTile[];
 	envsLoading: boolean;
 	selfManagedError?: unknown;
 	onRetrySelfManaged?: () => void;
@@ -70,34 +63,25 @@ export function HostedAgentsSection({
 	showCloudDeployments?: boolean;
 	showLegacyAgents?: boolean;
 }) {
-	const hosted = useHostedAgentTiles({
+	const unified = useUnifiedAgentList({
 		cloudEnvs,
-		includeDeployments: showCloudDeployments,
-	});
-	const legacyEnvIds = useLegacyEnvIds();
-	const legacyOwnershipLoading = showLegacyAgents && legacyEnvIds === null;
-	const hostedDeploymentsLoading = showCloudDeployments && hosted.isLoading;
-	const connectedTiles = connectedAgentTilesForHostedView({
-		selfManagedTiles,
-		claimedEnvIds: hosted.claimedEnvIds,
-		legacyEnvIds,
-		cloudEnvs,
+		showCloudDeployments,
 		showLegacyAgents,
 	});
-	const agentTiles: AgentTile[] = [...hosted.tiles, ...connectedTiles];
+	const connectedTiles = unified.connectedTiles;
+	const agentTiles = unified.tiles;
 	// Empty state must consider BOTH sources of agents. Hidden behind
-	// `!hosted.error` so a transient hosted-fetch failure surfaces in
+	// `!unified.error` so a transient hosted-fetch failure surfaces in
 	// AgentsCard's error banner instead of dropping silently into the
 	// onboarding hero.
 	const isEmptyState =
 		!envsLoading &&
 		!selfManagedError &&
 		selfManagedCount === 0 &&
-		hosted.tiles.length === 0 &&
+		unified.hostedTiles.length === 0 &&
 		connectedTiles.length === 0 &&
-		!hostedDeploymentsLoading &&
-		!legacyOwnershipLoading &&
-		!hosted.error;
+		!unified.isLoading &&
+		!unified.error;
 	return (
 		<div data-hosted="true">
 			{isEmptyState ? (
@@ -109,10 +93,10 @@ export function HostedAgentsSection({
 					error={selfManagedError}
 					onRetry={onRetrySelfManaged}
 					hostedStatus={{
-						isLoading: hostedDeploymentsLoading || legacyOwnershipLoading,
-						error: hosted.error,
+						isLoading: unified.isLoading,
+						error: unified.error,
 						onRetry: () => {
-							void hosted.refetch();
+							void unified.refetch();
 						},
 						normalizer: billingErrorNormalizer,
 					}}
@@ -132,13 +116,11 @@ export function HostedAgentsSection({
  * secondary CTA.
  */
 export function HostedSecondaryCTA({
-	selfManagedCount,
 	envsLoading,
 	cloudEnvs,
 	showCloudDeployments = true,
 	showLegacyAgents = false,
 }: {
-	selfManagedCount: number;
 	envsLoading: boolean;
 	cloudEnvs: Env[];
 	showCloudDeployments?: boolean;
@@ -147,26 +129,16 @@ export function HostedSecondaryCTA({
 	// Reuses the same hosted deployments TanStack Query cache
 	// as `HostedAgentsSection` so passing cloudEnvs here is just
 	// re-running the join, not re-fetching.
-	const hosted = useHostedAgentTiles({
+	const unified = useUnifiedAgentList({
 		cloudEnvs,
-		includeDeployments: showCloudDeployments,
-	});
-	const legacyEnvIds = useLegacyEnvIds();
-	const legacyOwnershipLoading = showLegacyAgents && legacyEnvIds === null;
-	const hostedDeploymentsLoading = showCloudDeployments && hosted.isLoading;
-	const legacyConnectedTiles = connectedAgentTilesForHostedView({
-		selfManagedTiles: [],
-		claimedEnvIds: hosted.claimedEnvIds,
-		legacyEnvIds,
-		cloudEnvs,
+		showCloudDeployments,
 		showLegacyAgents,
 	});
-	const hasAnyAgent =
-		selfManagedCount > 0 || hosted.tiles.length > 0 || legacyConnectedTiles.length > 0;
+	const hasAnyAgent = unified.tiles.length > 0;
 	if (hasAnyAgent) return <OnboardingCard variant="additional-agent" />;
 	// Loading: don't flash an empty slot then pop in. Wait for pending
 	// sources only when none has already proven there is an agent.
-	if (envsLoading || hostedDeploymentsLoading || legacyOwnershipLoading) return null;
+	if (envsLoading || unified.isLoading) return null;
 	return null;
 }
 
@@ -175,7 +147,6 @@ export function HostedSecondaryCTA({
  * each; self-managed and legacy hosted agents get their own section.
  */
 export function HostedAgentsByCompute({
-	selfManagedTiles,
 	envsLoading,
 	selfManagedError,
 	onRetrySelfManaged,
@@ -184,7 +155,6 @@ export function HostedAgentsByCompute({
 	showCloudDeployments = true,
 	showLegacyAgents = false,
 }: {
-	selfManagedTiles: AgentTile[];
 	envsLoading: boolean;
 	selfManagedError?: unknown;
 	onRetrySelfManaged?: () => void;
@@ -193,21 +163,13 @@ export function HostedAgentsByCompute({
 	showCloudDeployments?: boolean;
 	showLegacyAgents?: boolean;
 }) {
-	const hosted = useHostedAgentTiles({
+	const unified = useUnifiedAgentList({
 		cloudEnvs,
-		includeDeployments: showCloudDeployments,
-	});
-	const legacyEnvIds = useLegacyEnvIds();
-	const legacyOwnershipLoading = showLegacyAgents && legacyEnvIds === null;
-	const hostedDeploymentsLoading = showCloudDeployments && hosted.isLoading;
-	const hostedTiles = hosted.tiles;
-	const connectedTiles = connectedAgentTilesForHostedView({
-		selfManagedTiles,
-		claimedEnvIds: hosted.claimedEnvIds,
-		legacyEnvIds,
-		cloudEnvs,
+		showCloudDeployments,
 		showLegacyAgents,
 	});
+	const hostedTiles = unified.hostedTiles;
+	const connectedTiles = unified.connectedTiles;
 
 	const isEmptyState =
 		!envsLoading &&
@@ -215,9 +177,8 @@ export function HostedAgentsByCompute({
 		selfManagedCount === 0 &&
 		hostedTiles.length === 0 &&
 		connectedTiles.length === 0 &&
-		!hostedDeploymentsLoading &&
-		!legacyOwnershipLoading &&
-		!hosted.error;
+		!unified.isLoading &&
+		!unified.error;
 	if (isEmptyState) {
 		return (
 			<div data-hosted="true">
@@ -227,7 +188,7 @@ export function HostedAgentsByCompute({
 	}
 
 	if (
-		(envsLoading || hostedDeploymentsLoading || legacyOwnershipLoading) &&
+		(envsLoading || unified.isLoading) &&
 		hostedTiles.length === 0 &&
 		connectedTiles.length === 0
 	) {
@@ -270,11 +231,11 @@ export function HostedAgentsByCompute({
 				</section>
 			) : null}
 
-			{hosted.error ? (
+			{unified.error ? (
 				<HostedUnavailableBanner
-					error={hosted.error}
+					error={unified.error}
 					onRetry={() => {
-						void hosted.refetch();
+						void unified.refetch();
 					}}
 					normalizer={billingErrorNormalizer}
 				/>

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -1,20 +1,16 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import type { components } from "@clawdi/shared/api";
-import type { AgentTile } from "@/components/dashboard/agents-card";
 import type { HostedDeployment } from "@/hosted/billing/contracts";
 
 type HostedAgentTileStatus = typeof import("@/hosted/use-hosted-agent-tiles").hostedAgentTileStatus;
 type DeploymentToTiles = typeof import("@/hosted/use-hosted-agent-tiles").deploymentToTiles;
 type HostedRuntimeStatusView =
 	typeof import("@/hosted/use-hosted-agent-tiles").hostedRuntimeStatusView;
-type UnifiedHostedAgentTiles =
-	typeof import("@/hosted/use-hosted-agent-tiles").unifiedHostedAgentTiles;
 type Env = components["schemas"]["AgentResponse"];
 
 let getTileStatus: HostedAgentTileStatus | null = null;
 let getDeploymentToTiles: DeploymentToTiles | null = null;
 let getRuntimeStatusView: HostedRuntimeStatusView | null = null;
-let getUnifiedHostedAgentTiles: UnifiedHostedAgentTiles | null = null;
 
 beforeAll(async () => {
 	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
@@ -24,7 +20,6 @@ beforeAll(async () => {
 	getTileStatus = module.hostedAgentTileStatus;
 	getDeploymentToTiles = module.deploymentToTiles;
 	getRuntimeStatusView = module.hostedRuntimeStatusView;
-	getUnifiedHostedAgentTiles = module.unifiedHostedAgentTiles;
 });
 
 function hostedAgentTileStatus(rawStatus: string) {
@@ -47,11 +42,6 @@ function hostedDeploymentToTiles(deployment: HostedDeployment, envs: Env[] = [])
 		deployment,
 		new Map(envs.map((item) => [item.id.toLowerCase(), item])),
 	);
-}
-
-function unifiedHostedAgentTiles(args: Parameters<UnifiedHostedAgentTiles>[0]) {
-	if (!getUnifiedHostedAgentTiles) throw new Error("unifiedHostedAgentTiles was not loaded");
-	return getUnifiedHostedAgentTiles(args);
 }
 
 function env(overrides: Partial<Env> = {}): Env {
@@ -116,20 +106,6 @@ function deployment(
 	};
 }
 
-function agentTile(overrides: Partial<AgentTile> = {}): AgentTile {
-	return {
-		id: "11111111-1111-4111-8111-111111111111",
-		source: "self-managed",
-		name: "connected-agent",
-		agentType: "openclaw",
-		statusLabel: "Never seen",
-		href: "/agents/11111111-1111-4111-8111-111111111111",
-		active: false,
-		env: null,
-		...overrides,
-	};
-}
-
 describe("deploymentToTiles", () => {
 	test("renders only the selected runtime even when stale environment mappings remain", () => {
 		const openclawEnv = env({
@@ -156,6 +132,8 @@ describe("deploymentToTiles", () => {
 
 		expect(tiles.map((tile) => tile.agentType)).toEqual(["openclaw"]);
 		expect(tiles.map((tile) => tile.id)).toEqual(["dep_123"]);
+		expect(tiles[0]?.href).toBe(`/agents/${openclawEnv.id}?source=on-clawdi`);
+		expect(tiles[0]?.manageHref).toBe(`/agents/${openclawEnv.id}/settings?source=on-clawdi`);
 	});
 
 	test("projects dunning state as the hosted tile secondary status", () => {
@@ -216,7 +194,7 @@ describe("deploymentToTiles", () => {
 		});
 	});
 
-	test("routes a failed never-provisioned deployment by deployment id so delete stays reachable", () => {
+	test("keeps an unmatched deployment non-navigable instead of emitting an agent route", () => {
 		const failureReason = "startup_probe_failing; restart_count=2";
 		const [tile] = hostedDeploymentToTiles(
 			deployment(
@@ -233,8 +211,7 @@ describe("deploymentToTiles", () => {
 		expect(tile).toMatchObject({
 			id: "dep_123",
 			source: "on-clawdi",
-			href: "/agents/dep_123",
-			manageHref: "/agents/dep_123/settings",
+			href: null,
 			env: null,
 			secondaryStatus: {
 				label: "Failure: startup_probe_failing; restart_count=2",
@@ -242,47 +219,8 @@ describe("deploymentToTiles", () => {
 				textClass: "text-destructive-muted-foreground font-medium",
 			},
 		});
-	});
-});
-
-describe("unifiedHostedAgentTiles", () => {
-	test("keeps hosted tiles visible while legacy ownership is unresolved", () => {
-		const claimedEnv = "33333333-3333-4333-8333-333333333333";
-		const hostedTile = agentTile({
-			id: "dep_failed",
-			source: "on-clawdi",
-			name: "OpenClaw",
-			href: "/agents/dep_failed",
-			manageHref: "/agents/dep_failed/settings",
-			statusLabel: "Failed",
-			secondaryStatus: {
-				label: "Failure: startup_probe_failing",
-				title: "startup_probe_failing",
-				textClass: "text-destructive-muted-foreground font-medium",
-			},
-		});
-		const claimedSelfManaged = agentTile({
-			id: claimedEnv,
-			name: "cloud-env",
-			href: `/agents/${claimedEnv}`,
-		});
-		const connected = agentTile({
-			id: "44444444-4444-4444-8444-444444444444",
-			name: "connected-agent",
-			href: "/agents/44444444-4444-4444-8444-444444444444",
-		});
-
-		const tiles = unifiedHostedAgentTiles({
-			selfManagedTiles: [claimedSelfManaged, connected],
-			hostedTiles: [hostedTile],
-			claimedEnvIds: new Set([claimedEnv.toLowerCase()]),
-			legacyEnvIds: null,
-			cloudEnvs: [],
-			showLegacyAgents: true,
-		});
-
-		expect(tiles.map((tile) => tile.id)).toEqual(["dep_failed", connected.id]);
-		expect(tiles[0]?.secondaryStatus?.label).toBe("Failure: startup_probe_failing");
+		expect(tile?.manageHref).toBeUndefined();
+		expect(JSON.stringify(tile)).not.toContain("/agents/dep_123");
 	});
 });
 

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -2,14 +2,9 @@
 
 import type { components } from "@clawdi/shared/api";
 import { useQuery } from "@tanstack/react-query";
-import { createElement, type ReactNode, useMemo } from "react";
+import { createElement, useMemo } from "react";
 import { agentDisplayName } from "@/components/dashboard/agent-label";
-import {
-	type AgentFleetSummary,
-	type AgentTile,
-	fleetSummaryFromTiles,
-	isAgentActive,
-} from "@/components/dashboard/agents-card";
+import { type AgentTile, isAgentActive } from "@/components/dashboard/agents-card";
 import {
 	DaemonStatusBadge,
 	type DaemonStatusVisual,
@@ -35,15 +30,12 @@ import {
 	parseDeploymentStatus,
 	shouldPollDeployments,
 } from "@/hosted/deployment-status";
-import { legacyConnectedAgentTiles } from "@/hosted/legacy-agent-tiles";
 import { deploymentRuntime, runtimeDisplayName, runtimeEnvironmentId } from "@/hosted/runtimes";
-import { normalizeAgentEnvId, useAgentOwnership } from "@/lib/agent-ownership";
+import { normalizeAgentEnvId } from "@/lib/agent-ownership";
 import { agentSectionHref } from "@/lib/agent-routes";
 
 type Env = components["schemas"]["AgentResponse"];
 type DeploymentStatusInput = Pick<HostedDeployment, "status" | "failure_reason">;
-
-const EMPTY_ENV_IDS: ReadonlySet<string> = new Set();
 
 const COMPUTE_DOT_TONE: Record<DeploymentStatusTone, string> = {
 	success: "bg-success ring-2 ring-success/20",
@@ -240,15 +232,15 @@ export function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>
 	const slug = deploymentDisplayName(d.name);
 	// Hosted deployments don't use last_seen_at; status is the freshness signal
 	// Hosted env join: the selected hosted runtime registers one cloud-api env
-	// via the admin endpoint. If it is not minted yet, route by deployment id.
+	// via the admin endpoint. Without that env there is no resolvable agent route.
 	const envId = runtimeEnvironmentId(d.config_info, runtime);
 	const matchedEnv = envId ? envById.get(envId.toLowerCase()) : undefined;
 	const detailHref = matchedEnv
 		? agentSectionHref(matchedEnv.id, "overview", "source=on-clawdi")
-		: agentSectionHref(d.id);
+		: null;
 	const settingsHref = matchedEnv
 		? agentSectionHref(matchedEnv.id, "settings", "source=on-clawdi")
-		: agentSectionHref(d.id, "settings");
+		: undefined;
 	const name = matchedEnv ? agentDisplayName(matchedEnv) : runtimeDisplayName(runtime);
 	const contextLabel = slug !== name ? slug : null;
 	const runtimeStatus = hostedRuntimeStatusView(d, matchedEnv ?? null);
@@ -300,107 +292,6 @@ export function hostedAgentTileStatus(rawStatus: string): { label: string; activ
 		label: deploymentStatusLabel(status),
 		active: isRunningStatus(status),
 	};
-}
-
-export function unifiedHostedAgentTiles({
-	selfManagedTiles,
-	hostedTiles,
-	claimedEnvIds,
-	legacyEnvIds,
-	cloudEnvs,
-	showLegacyAgents,
-}: {
-	selfManagedTiles: AgentTile[];
-	hostedTiles: AgentTile[];
-	claimedEnvIds: ReadonlySet<string>;
-	legacyEnvIds: ReadonlySet<string> | null;
-	cloudEnvs: Env[];
-	showLegacyAgents: boolean;
-}): AgentTile[] {
-	return [
-		...hostedTiles,
-		...connectedAgentTilesForHostedView({
-			selfManagedTiles,
-			claimedEnvIds,
-			legacyEnvIds,
-			cloudEnvs,
-			showLegacyAgents,
-		}),
-	];
-}
-
-export function connectedAgentTilesForHostedView({
-	selfManagedTiles,
-	claimedEnvIds,
-	legacyEnvIds,
-	cloudEnvs,
-	showLegacyAgents,
-}: {
-	selfManagedTiles: AgentTile[];
-	claimedEnvIds: ReadonlySet<string>;
-	legacyEnvIds: ReadonlySet<string> | null;
-	cloudEnvs: Env[];
-	showLegacyAgents: boolean;
-}): AgentTile[] {
-	const legacyConnectedTiles = showLegacyAgents
-		? legacyEnvIds
-			? legacyConnectedAgentTiles(cloudEnvs, legacyEnvIds, claimedEnvIds)
-			: []
-		: [];
-	const dedupedSelfManaged = selfManagedTiles.filter(
-		(tile) =>
-			!isOwnedEnvId(tile.id, claimedEnvIds, showLegacyAgents ? legacyEnvIds : EMPTY_ENV_IDS),
-	);
-	return [...legacyConnectedTiles, ...dedupedSelfManaged];
-}
-
-function isOwnedEnvId(
-	id: string,
-	claimedEnvIds: ReadonlySet<string>,
-	legacyEnvIds: ReadonlySet<string> | null,
-): boolean {
-	const envId = normalizeAgentEnvId(id);
-	return Boolean(envId && (claimedEnvIds.has(envId) || legacyEnvIds?.has(envId)));
-}
-
-export function HostedFleetSummary({
-	selfManagedTiles,
-	cloudEnvs,
-	showCloudDeployments = true,
-	showLegacyAgents = false,
-	children,
-}: {
-	selfManagedTiles: AgentTile[];
-	cloudEnvs: Env[];
-	showCloudDeployments?: boolean;
-	showLegacyAgents?: boolean;
-	children: (summary: AgentFleetSummary) => ReactNode;
-}) {
-	const hosted = useHostedAgentTiles({
-		cloudEnvs,
-		includeDeployments: showCloudDeployments,
-	});
-	const ownership = useAgentOwnership();
-	const legacyEnvIds = showLegacyAgents ? (ownership?.legacyEnvIds ?? null) : EMPTY_ENV_IDS;
-	const tiles = useMemo(() => {
-		return unifiedHostedAgentTiles({
-			selfManagedTiles,
-			hostedTiles: hosted.tiles,
-			claimedEnvIds: hosted.claimedEnvIds,
-			legacyEnvIds,
-			cloudEnvs,
-			showLegacyAgents,
-		});
-	}, [
-		cloudEnvs,
-		hosted.claimedEnvIds,
-		hosted.tiles,
-		legacyEnvIds,
-		selfManagedTiles,
-		showLegacyAgents,
-	]);
-	const summary = useMemo(() => fleetSummaryFromTiles(tiles), [tiles]);
-	return children(summary);
 }
 
 export function HostedFocusRuntimeStatusBadge({

--- a/apps/web/src/hosted/use-unified-agent-list.test.ts
+++ b/apps/web/src/hosted/use-unified-agent-list.test.ts
@@ -1,0 +1,119 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { components } from "@clawdi/shared/api";
+import type { AgentTile } from "@/components/dashboard/agents-card";
+
+type Env = components["schemas"]["AgentResponse"];
+type SelectUnifiedAgentList =
+	typeof import("@/hosted/use-unified-agent-list").selectUnifiedAgentList;
+
+let getUnifiedAgentList: SelectUnifiedAgentList | null = null;
+
+beforeAll(async () => {
+	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
+	process.env.VITE_CLAWDI_DEPLOY_API_URL = "http://localhost:50021";
+	process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
+	const module = await import("@/hosted/use-unified-agent-list");
+	getUnifiedAgentList = module.selectUnifiedAgentList;
+});
+
+function selectUnifiedAgentList(args: Parameters<SelectUnifiedAgentList>[0]) {
+	if (!getUnifiedAgentList) throw new Error("selectUnifiedAgentList was not loaded");
+	return getUnifiedAgentList(args);
+}
+
+function env(id: string, name: string): Env {
+	return {
+		id,
+		name,
+		default_name: name,
+		machine_name: name,
+		agent_type: "openclaw",
+		agent_version: null,
+		os: "linux",
+		last_seen_at: null,
+		last_sync_at: null,
+		last_sync_error: null,
+		last_revision_seen: null,
+		sort_order: 0,
+		queue_depth_high_water: 0,
+		dropped_count: 0,
+		sync_enabled: true,
+		explicit_identity: false,
+		default_project_id: "22222222-2222-4222-8222-222222222222",
+	};
+}
+
+describe("selectUnifiedAgentList", () => {
+	test("joins hosted, legacy, and self-managed membership without duplicates", () => {
+		const claimed = env("11111111-1111-4111-8111-111111111111", "claimed-cloud-env");
+		const legacy = env("22222222-2222-4222-8222-222222222222", "legacy-env");
+		const connected = env("33333333-3333-4333-8333-333333333333", "connected-env");
+		const hostedTile: AgentTile = {
+			id: "dep_failed",
+			source: "on-clawdi",
+			name: "OpenClaw",
+			agentType: "openclaw",
+			statusLabel: "Failed",
+			href: null,
+			active: false,
+			env: null,
+		};
+
+		const selection = selectUnifiedAgentList({
+			cloudEnvs: [claimed, legacy, connected],
+			hostedTiles: [hostedTile],
+			claimedEnvIds: new Set([claimed.id.toLowerCase()]),
+			legacyEnvIds: new Set([legacy.id.toLowerCase()]),
+			showLegacyAgents: true,
+		});
+
+		expect(selection.tiles.map((tile) => [tile.id, tile.source])).toEqual([
+			["dep_failed", "on-clawdi"],
+			[legacy.id, "legacy-hosted"],
+			[connected.id, "self-managed"],
+		]);
+		expect(selection.tiles[0]?.statusLabel).toBe("Failed");
+		expect(selection.tiles.some((tile) => tile.id === claimed.id)).toBe(false);
+	});
+
+	test("keeps hosted membership while legacy ownership is unresolved", () => {
+		const claimed = env("11111111-1111-4111-8111-111111111111", "claimed-cloud-env");
+		const connected = env("33333333-3333-4333-8333-333333333333", "connected-env");
+		const hostedTile: AgentTile = {
+			id: "dep_starting",
+			source: "on-clawdi",
+			name: "OpenClaw",
+			agentType: "openclaw",
+			statusLabel: "Starting",
+			href: null,
+			active: false,
+			env: null,
+		};
+
+		const selection = selectUnifiedAgentList({
+			cloudEnvs: [claimed, connected],
+			hostedTiles: [hostedTile],
+			claimedEnvIds: new Set([claimed.id.toLowerCase()]),
+			legacyEnvIds: null,
+			showLegacyAgents: true,
+		});
+
+		expect(selection.tiles.map((tile) => tile.id)).toEqual(["dep_starting", connected.id]);
+	});
+});
+
+describe("unified list consumers", () => {
+	test("sidebar and homepage use the shared unified list hook", () => {
+		const srcDir = resolve(import.meta.dir, "..");
+		const sidebar = readFileSync(resolve(srcDir, "components/app-sidebar.tsx"), "utf8");
+		const homepage = readFileSync(resolve(srcDir, "hosted/hosted-agents-section.tsx"), "utf8");
+
+		expect(sidebar).toContain('import("@/hosted/use-unified-agent-list")');
+		expect(sidebar).toContain("hostedAgentTiles ?? []");
+		expect(homepage).toContain("useUnifiedAgentList({");
+		expect(homepage).not.toContain("connectedAgentTilesForHostedView");
+		expect(homepage).not.toContain("useHostedAgentTiles({");
+	});
+});

--- a/apps/web/src/hosted/use-unified-agent-list.ts
+++ b/apps/web/src/hosted/use-unified-agent-list.ts
@@ -1,0 +1,152 @@
+"use client";
+
+import type { components } from "@clawdi/shared/api";
+import { type ReactNode, useEffect, useMemo } from "react";
+import {
+	type AgentFleetSummary,
+	type AgentTile,
+	fleetSummaryFromTiles,
+	selfManagedAgentTiles,
+} from "@/components/dashboard/agents-card";
+import { useLegacyEnvIds } from "@/hosted/agents/ownership-sensor";
+import { legacyConnectedAgentTiles } from "@/hosted/legacy-agent-tiles";
+import { useHostedAgentTiles } from "@/hosted/use-hosted-agent-tiles";
+import { normalizeAgentEnvId } from "@/lib/agent-ownership";
+
+type Env = components["schemas"]["AgentResponse"];
+
+const EMPTY_ENV_IDS: ReadonlySet<string> = new Set();
+
+export interface UnifiedAgentListSelection {
+	tiles: AgentTile[];
+	hostedTiles: AgentTile[];
+	connectedTiles: AgentTile[];
+}
+
+/**
+ * Canonical membership selector for every hosted dashboard agent list.
+ *
+ * A Cloud deployment owns its configured environment even while that
+ * environment is absent from the Cloud API response. Legacy environments are
+ * bridged once, and every remaining environment is rendered as self-managed.
+ */
+export function selectUnifiedAgentList({
+	cloudEnvs,
+	hostedTiles,
+	claimedEnvIds,
+	legacyEnvIds,
+	showLegacyAgents,
+}: {
+	cloudEnvs: Env[];
+	hostedTiles: AgentTile[];
+	claimedEnvIds: ReadonlySet<string>;
+	legacyEnvIds: ReadonlySet<string> | null;
+	showLegacyAgents: boolean;
+}): UnifiedAgentListSelection {
+	const legacyConnectedTiles =
+		showLegacyAgents && legacyEnvIds
+			? legacyConnectedAgentTiles(cloudEnvs, legacyEnvIds, claimedEnvIds)
+			: [];
+	const dedupedSelfManaged = selfManagedAgentTiles(cloudEnvs).filter(
+		(tile) =>
+			!isOwnedEnvId(tile.id, claimedEnvIds, showLegacyAgents ? legacyEnvIds : EMPTY_ENV_IDS),
+	);
+	const connectedTiles = [...legacyConnectedTiles, ...dedupedSelfManaged];
+	return {
+		tiles: [...hostedTiles, ...connectedTiles],
+		hostedTiles,
+		connectedTiles,
+	};
+}
+
+function isOwnedEnvId(
+	id: string,
+	claimedEnvIds: ReadonlySet<string>,
+	legacyEnvIds: ReadonlySet<string> | null,
+): boolean {
+	const envId = normalizeAgentEnvId(id);
+	return Boolean(envId && (claimedEnvIds.has(envId) || legacyEnvIds?.has(envId)));
+}
+
+export function useUnifiedAgentList({
+	cloudEnvs,
+	showCloudDeployments = true,
+	showLegacyAgents = false,
+}: {
+	cloudEnvs: Env[];
+	showCloudDeployments?: boolean;
+	showLegacyAgents?: boolean;
+}) {
+	const hosted = useHostedAgentTiles({
+		cloudEnvs,
+		includeDeployments: showCloudDeployments,
+	});
+	const resolvedLegacyEnvIds = useLegacyEnvIds();
+	const legacyEnvIds = showLegacyAgents ? resolvedLegacyEnvIds : EMPTY_ENV_IDS;
+	const selection = useMemo(
+		() =>
+			selectUnifiedAgentList({
+				cloudEnvs,
+				hostedTiles: hosted.tiles,
+				claimedEnvIds: hosted.claimedEnvIds,
+				legacyEnvIds,
+				showLegacyAgents,
+			}),
+		[cloudEnvs, hosted.claimedEnvIds, hosted.tiles, legacyEnvIds, showLegacyAgents],
+	);
+
+	return {
+		...selection,
+		hasExistingDeployments: hosted.hasExistingDeployments,
+		isLoading:
+			(showCloudDeployments && hosted.isLoading) ||
+			(showLegacyAgents && resolvedLegacyEnvIds === null),
+		error: hosted.error,
+		refetch: hosted.refetch,
+	};
+}
+
+export function HostedUnifiedAgentListSensor({
+	cloudEnvs,
+	showCloudDeployments = true,
+	showLegacyAgents = false,
+	onChange,
+}: {
+	cloudEnvs: Env[];
+	showCloudDeployments?: boolean;
+	showLegacyAgents?: boolean;
+	onChange: (tiles: AgentTile[] | null) => void;
+}) {
+	const unified = useUnifiedAgentList({
+		cloudEnvs,
+		showCloudDeployments,
+		showLegacyAgents,
+	});
+
+	useEffect(() => {
+		onChange(unified.tiles);
+	}, [onChange, unified.tiles]);
+	useEffect(() => () => onChange(null), [onChange]);
+
+	return null;
+}
+
+export function HostedFleetSummary({
+	cloudEnvs,
+	showCloudDeployments = true,
+	showLegacyAgents = false,
+	children,
+}: {
+	cloudEnvs: Env[];
+	showCloudDeployments?: boolean;
+	showLegacyAgents?: boolean;
+	children: (summary: AgentFleetSummary) => ReactNode;
+}) {
+	const unified = useUnifiedAgentList({
+		cloudEnvs,
+		showCloudDeployments,
+		showLegacyAgents,
+	});
+	const summary = useMemo(() => fleetSummaryFromTiles(unified.tiles), [unified.tiles]);
+	return children(summary);
+}

--- a/apps/web/src/pages/dashboard/agents/page.tsx
+++ b/apps/web/src/pages/dashboard/agents/page.tsx
@@ -60,7 +60,6 @@ export default function AgentsIndexPage() {
 			) : hostedSectionEnabled && HostedAgentsByCompute ? (
 				<Suspense fallback={<AgentsCard agents={selfManagedTiles} isLoading />}>
 					<HostedAgentsByCompute
-						selfManagedTiles={selfManagedTiles}
 						envsLoading={envsLoading}
 						selfManagedError={envsError}
 						onRetrySelfManaged={() => {

--- a/apps/web/src/pages/dashboard/page.tsx
+++ b/apps/web/src/pages/dashboard/page.tsx
@@ -73,7 +73,7 @@ const HostedSecondaryCTA = IS_HOSTED_BUILD
 	: null;
 const HostedFleetSummary = IS_HOSTED_BUILD
 	? lazy(() =>
-			import("@/hosted/use-hosted-agent-tiles").then((m) => ({
+			import("@/hosted/use-unified-agent-list").then((m) => ({
 				default: m.HostedFleetSummary,
 			})),
 		)
@@ -181,7 +181,6 @@ export default function DashboardPage() {
 			) : hostedSectionEnabled && HostedFleetSummary ? (
 				<Suspense fallback={greeting}>
 					<HostedFleetSummary
-						selfManagedTiles={selfManagedTiles}
 						cloudEnvs={environments ?? []}
 						showCloudDeployments={cloudDeploymentManagementEnabled}
 						showLegacyAgents={legacyHostedAgentsEnabled}
@@ -210,7 +209,6 @@ export default function DashboardPage() {
 					) : hostedSectionEnabled && HostedAgentsSection ? (
 						<Suspense fallback={<AgentsCard agents={selfManagedTiles} isLoading />}>
 							<HostedAgentsSection
-								selfManagedTiles={selfManagedTiles}
 								envsLoading={envsLoading}
 								selfManagedError={envsError}
 								onRetrySelfManaged={() => {
@@ -309,7 +307,6 @@ export default function DashboardPage() {
 					{hostedAccessLoading ? null : hostedSectionEnabled && HostedSecondaryCTA ? (
 						<Suspense fallback={null}>
 							<HostedSecondaryCTA
-								selfManagedCount={selfManagedCount}
 								envsLoading={envsLoading}
 								cloudEnvs={environments ?? []}
 								showCloudDeployments={cloudDeploymentManagementEnabled}


### PR DESCRIPTION
## Before

- The sidebar rendered the raw Cloud API /v1/agents response, while the homepage and Agents page separately joined hosted deployments, removed deployment-claimed environment ids, and bridged legacy agents. The surfaces could therefore show different membership and hosted status.
- A hosted deployment tile without a matched Cloud API environment generated /agents/<deployment-id> and /agents/<deployment-id>/settings links, placing a deployment id into an agent route.

## After

- A single useUnifiedAgentList hook and selectUnifiedAgentList selector now own hosted, legacy, and self-managed membership and deduplication. The homepage cards, Agents page, fleet summary, secondary CTA, and compact sidebar rail all consume that canonical selection.
- Hosted status remains projected once by deploymentToTiles and is carried into both card and compact sidebar representations.
- Matched deployments still navigate to the canonical environment-backed agent overview/settings routes. Unmatched deployments remain visible with their deployment status but are non-navigable, so no tile emits an agent route containing a deployment id.
- Sidebar reordering still optimistically updates the existing ["agents"] cache and sends only real environment ids to /v1/agents/order.

## Not changed

- No backend, CLI, shared schema/client, API contract, or generated type changes.
- No change to the ["agents"] query shape, /v1/agents fetch, /v1/agents/order endpoint, or existing mutation rollback behavior.
- No change to existing homepage card layouts, sidebar compact visual treatment, onboarding decisions, polling cadence, hosted access gates, or OSS hosted-code boundary beyond sourcing list membership from the shared hook.

## Verification

- bun run --cwd apps/web typecheck
- bun run --cwd apps/web lint
- bun run --cwd apps/web test (448 passed)
- bun run check
- bun run --cwd apps/web build:oss
- VITE_CLERK_PUBLISHABLE_KEY=pk_test_dummy VITE_CLAWDI_API_URL=http://localhost:8000 CLERK_SECRET_KEY=sk_test_dummy bunx turbo build --filter=web