### PR TITLE
fix(web): align wallet billing UI with simplified lifecycle

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -250,6 +250,7 @@ type HostedApiStubOptions = {
 	deployRequestStatusResponses?: StubResponse[];
 	deployments?: readonly unknown[];
 	fixPaymentRequests?: string[];
+	ledgerResponseForRequest?: (limit: number) => unknown;
 	ledgerRequests?: string[];
 	ledgerResponses?: unknown[];
 	plans?: readonly unknown[];
@@ -294,7 +295,12 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		}
 		if (p === "/v2/wallet/ledger" && r.request().method() === "GET") {
 			options.ledgerRequests?.push(r.request().url());
-			return fulfillJson(r, options.ledgerResponses?.shift() ?? { items: [], has_more: false });
+			const limit = Number(new URL(r.request().url()).searchParams.get("limit"));
+			return fulfillJson(
+				r,
+				options.ledgerResponseForRequest?.(limit) ??
+					options.ledgerResponses?.shift() ?? { items: [], has_more: false },
+			);
 		}
 		if (p === "/v2/deployments" && r.request().method() === "GET") {
 			return fulfillJson(r, deployments);
@@ -584,6 +590,21 @@ async function gotoHostedAgentSettings(
 			if (attempt === 1) throw error;
 		}
 	}
+}
+
+async function gotoHostedSettingsDialog(page: Page, section: string) {
+	for (let attempt = 0; attempt < 2; attempt += 1) {
+		await page.goto(`/channels?settings=${section}`);
+		const dialog = page.getByTestId("settings-dialog");
+		try {
+			await expect(dialog).toBeVisible();
+			await page.waitForLoadState("networkidle");
+			return dialog;
+		} catch (error) {
+			if (attempt === 1) throw error;
+		}
+	}
+	throw new Error("Settings dialog did not open.");
 }
 
 test("deploy wizard Select opens without browser errors", async ({ page }) => {
@@ -925,7 +946,10 @@ test("wallet deploy rotates its request key after an explicit reuse conflict", a
 
 	await submit.click();
 	await expect.poll(() => walletActivateRequests.length).toBe(1);
-	await expect(page.getByText("Start a fresh wallet attempt", { exact: true })).toBeVisible();
+	const freshAttemptToast = page.getByText("Start a fresh wallet attempt", { exact: true });
+	await expect(freshAttemptToast).toBeVisible();
+	await page.mouse.move(0, 0);
+	await expect(freshAttemptToast).toHaveCount(0);
 	await submit.click();
 	await expect.poll(() => walletActivateRequests.length).toBe(2);
 
@@ -1526,7 +1550,6 @@ test("mixed billing history paginates wallet charges and Stripe invoices", async
 });
 
 test("Wallet activity caps show-more requests at the ledger API limit", async ({ page }) => {
-	const errors = collectBrowserErrors(page);
 	const ledgerRequests: string[] = [];
 	const computeCharge = {
 		id: "ledger-compute-charge",
@@ -1538,26 +1561,26 @@ test("Wallet activity caps show-more requests at the ledger API limit", async ({
 	};
 	await stubHostedApi(page, {
 		ledgerRequests,
-		ledgerResponses: [
-			{ items: [computeCharge], has_more: true },
-			{
-				items: [
-					computeCharge,
-					{
-						...computeCharge,
-						id: "ledger-compute-credit",
-						operation: "compute_credit",
-						request_id: "compute-reversal-42",
-						credits_amount: 9_000,
+		ledgerResponseForRequest: (limit) =>
+			limit === 50
+				? { items: [computeCharge], has_more: true }
+				: {
+						items: [
+							computeCharge,
+							{
+								...computeCharge,
+								id: "ledger-compute-credit",
+								operation: "compute_credit",
+								request_id: "compute-reversal-42",
+								credits_amount: 9_000,
+							},
+						],
+						has_more: true,
 					},
-				],
-				has_more: true,
-			},
-		],
 		plans: [basicPlan, performancePlan],
 	});
-	await page.goto("/channels?settings=billing-wallet");
-	const settingsDialog = page.getByTestId("settings-dialog");
+	const settingsDialog = await gotoHostedSettingsDialog(page, "billing-wallet");
+	const errors = collectBrowserErrors(page);
 	const ledgerTable = settingsDialog.getByRole("table");
 
 	await expect(ledgerTable.getByText("Compute charge", { exact: true })).toBeVisible();
@@ -1570,7 +1593,7 @@ test("Wallet activity caps show-more requests at the ledger API limit", async ({
 	);
 
 	const limits = ledgerRequests.map((url) => Number(new URL(url).searchParams.get("limit")));
-	expect(limits).toEqual([50, 100]);
+	expect([...new Set(limits)]).toEqual([50, 100]);
 	expect(limits.every((limit) => limit <= 100)).toBe(true);
 	expect(errors, `wallet ledger cap: ${errors.join(" | ")}`).toEqual([]);
 });

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -127,6 +127,7 @@ const stoppedIncludedBasicDeployment = {
 
 const walletState = {
 	balance_credits: 25_000,
+	overdraft_credits: 0,
 	balance_snapshot_at: "2026-07-15T00:00:00Z",
 	payment_mode: "card",
 	x402_enabled: false,
@@ -207,6 +208,21 @@ const walletFallbackDeployment = {
 	},
 };
 
+const stripeFallbackDeployment = {
+	...includedBasicDeployment,
+	id: "hdep_stripe_fallback",
+	name: "Stripe fallback agent",
+	upgrade_available: true,
+	last_funding_event: {
+		type: "compute_subscription_fallback",
+		funding_source: "stripe",
+		reason: "payment_failure",
+		occurred_at: "2026-07-14T00:00:00Z",
+		prior_plan_slug: "compute_performance",
+		subscription_id: 84,
+	},
+};
+
 type StubResponse = { body: unknown; status: number };
 
 type HostedApiStubOptions = {
@@ -218,12 +234,17 @@ type HostedApiStubOptions = {
 	deployRequestStatusRequests?: string[];
 	deployRequestStatusResponses?: StubResponse[];
 	deployments?: readonly unknown[];
+	fixPaymentRequests?: string[];
+	ledgerRequests?: string[];
+	ledgerResponses?: unknown[];
 	plans?: readonly unknown[];
 	retryRequests?: string[];
 	walletRetryResponses?: StubResponse[];
 	startError?: { status: number; detail: string };
 	startRequests?: string[];
+	topUpIdempotencyKeys?: string[];
 	topUpRequests?: string[];
+	topUpResponses?: StubResponse[];
 	walletActivateRequests?: string[];
 	walletActivateResponses?: StubResponse[];
 	walletQuoteRequests?: string[];
@@ -257,7 +278,8 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			return fulfillJson(r, walletState);
 		}
 		if (p === "/v2/wallet/ledger" && r.request().method() === "GET") {
-			return fulfillJson(r, { items: [] });
+			options.ledgerRequests?.push(r.request().url());
+			return fulfillJson(r, options.ledgerResponses?.shift() ?? { items: [], has_more: false });
 		}
 		if (p === "/v2/deployments" && r.request().method() === "GET") {
 			return fulfillJson(r, deployments);
@@ -356,15 +378,11 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 					subscription_id: 73,
 					current_plan_slug: "compute_basic",
 					target_plan_slug: "compute_performance",
-					change_kind: "upgrade",
 					status: "quoted",
-					effective_at: "2026-07-15T00:00:00Z",
-					period_start: "2026-07-01T00:00:00Z",
-					period_end: "2026-08-01T00:00:00Z",
-					prorated_delta_cents: 600,
-					prorated_delta_credits: "6000",
+					effective_at: "2026-08-15T00:00:00Z",
+					amount_cents: 1900,
+					amount_credits: "19000",
 					points_per_usd: 1000,
-					charge_ledger_id: null,
 					pending_plan_slug: null,
 				},
 			};
@@ -378,16 +396,12 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 					subscription_id: 73,
 					current_plan_slug: "compute_basic",
 					target_plan_slug: "compute_performance",
-					change_kind: "upgrade",
-					status: "active",
-					effective_at: "2026-07-15T00:00:00Z",
-					period_start: "2026-07-01T00:00:00Z",
-					period_end: "2026-08-01T00:00:00Z",
-					prorated_delta_cents: 600,
-					prorated_delta_credits: "6000",
+					status: "scheduled",
+					effective_at: "2026-08-15T00:00:00Z",
+					amount_cents: 1900,
+					amount_credits: "19000",
 					points_per_usd: 1000,
-					charge_ledger_id: "ledger_plan_change",
-					pending_plan_slug: null,
+					pending_plan_slug: "compute_performance",
 				},
 			};
 			if (response.status < 400) options.onWalletPlanChangeSuccess?.();
@@ -410,13 +424,22 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		}
 		if (p === "/v2/wallet/topup" && r.request().method() === "POST") {
 			options.topUpRequests?.push(r.request().postData() ?? "");
-			return fulfillJson(r, {
-				status: "succeeded",
-				flow_type: "mock",
-				payment_intent_id: null,
-				client_secret: null,
-				credits_added: 25_000,
-			});
+			options.topUpIdempotencyKeys?.push(r.request().headers()["idempotency-key"] ?? "");
+			const response = options.topUpResponses?.shift() ?? {
+				status: 200,
+				body: {
+					status: "succeeded",
+					flow_type: "mock",
+					payment_intent_id: null,
+					client_secret: null,
+					credits_added: 25_000,
+				},
+			};
+			return fulfillJson(r, response.body, response.status);
+		}
+		if (p === "/v2/subscription/fix-payment" && r.request().method() === "POST") {
+			options.fixPaymentRequests?.push(r.request().postData() ?? "");
+			return fulfillJson(r, { message: "Payment recovery started." });
 		}
 		if (p === "/v2/subscription/billing-history" && r.request().method() === "GET") {
 			options.billingHistoryRequests?.push(r.request().url());
@@ -860,6 +883,51 @@ test("wallet-funded Basic quotes, debits Wallet, and deploys without checkout", 
 	expect(errors, `wallet deploy happy path: ${errors.join(" | ")}`).toEqual([]);
 });
 
+test("wallet deploy rotates its request key after an explicit reuse conflict", async ({ page }) => {
+	const errors = collectBrowserErrors(page);
+	const deployments: unknown[] = [includedBasicDeployment];
+	const walletActivateRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments,
+		plans: [basicPlan, performancePlan],
+		walletActivateRequests,
+		walletActivateResponses: [
+			{
+				status: 409,
+				body: {
+					detail: {
+						code: "idempotency_key_reused",
+						message: "The deploy request key belongs to another payload.",
+					},
+				},
+			},
+		],
+		onWalletActivateSuccess: () => deployments.push(walletBasicDeployment),
+	});
+	await page.goto("/deploy");
+	await page.getByRole("button", { name: /Wallet balance/ }).click();
+	const submit = page.getByRole("button", { name: "Pay $9.00 from wallet & deploy" });
+
+	await submit.click();
+	await expect.poll(() => walletActivateRequests.length).toBe(1);
+	await expect(page.getByText("Start a fresh wallet attempt", { exact: true })).toBeVisible();
+	await submit.click();
+	await expect.poll(() => walletActivateRequests.length).toBe(2);
+
+	const requestKeys = walletActivateRequests.map((body) => {
+		const request = JSON.parse(body);
+		return request.deploy_config.deploy_request_id as string;
+	});
+	expect(requestKeys[0]).toMatch(/^wallet-compute-deploy-/);
+	expect(requestKeys[1]).toMatch(/^wallet-compute-deploy-/);
+	expect(requestKeys[1]).not.toBe(requestKeys[0]);
+	await expect(page).toHaveURL(/\/agents\/hdep_wallet(?:\?|\/)/);
+	expect(
+		errors.filter((error) => !error.includes("status of 409")),
+		`wallet deploy key rotation: ${errors.join(" | ")}`,
+	).toEqual([]);
+});
+
 test("wallet deploy resolves an asynchronous autodeploy by stable request ID", async ({ page }) => {
 	const errors = collectBrowserErrors(page);
 	const deployments: unknown[] = [includedBasicDeployment];
@@ -996,6 +1064,42 @@ test("insufficient wallet deploy keeps the wizard, opens top-up, and re-quotes",
 	).toEqual([]);
 });
 
+test("wallet deploy refund debt prefills debt plus the blocked compute charge", async ({
+	page,
+}) => {
+	const errors = collectBrowserErrors(page);
+	await stubHostedApi(page, {
+		deployments: [includedBasicDeployment],
+		plans: [basicPlan, performancePlan],
+		walletActivateResponses: [
+			{
+				status: 409,
+				body: {
+					detail: {
+						code: "open_refund_debt",
+						outstanding_debt_credits: "2500.5",
+					},
+				},
+			},
+		],
+	});
+	await page.goto("/deploy");
+	await page.getByRole("button", { name: /Wallet balance/ }).click();
+	await page.getByRole("button", { name: "Pay $9.00 from wallet & deploy" }).click();
+
+	const topUpDialog = page.getByRole("dialog");
+	await expect(topUpDialog.getByText("Top up AI Credits", { exact: true })).toBeVisible();
+	await expect(topUpDialog.getByText("Refund debt is repaid first", { exact: true })).toBeVisible();
+	await expect(topUpDialog).toContainText(
+		"The remaining funds cover the 9,000 credits blocked compute charge.",
+	);
+	await expect(page.getByLabel("Amount (USD)")).toHaveValue("12");
+	expect(
+		errors.filter((error) => !error.includes("status of 409")),
+		`wallet deploy refund debt: ${errors.join(" | ")}`,
+	).toEqual([]);
+});
+
 test("wallet dunning shows grace recovery without Stripe portal actions", async ({ page }) => {
 	const errors = collectBrowserErrors(page);
 	const deployments: unknown[] = [walletPastDueDeployment];
@@ -1092,12 +1196,12 @@ test("wallet fallback explains the failed Performance payment and offers re-acti
 }) => {
 	const errors = collectBrowserErrors(page);
 	const deployments: unknown[] = [walletFallbackDeployment];
-	const retryRequests: string[] = [];
+	const walletActivateRequests: string[] = [];
 	await stubHostedApi(page, {
 		deployments,
 		plans: [basicPlan, performancePlan],
-		retryRequests,
-		onWalletRetrySuccess: () =>
+		walletActivateRequests,
+		onWalletActivateSuccess: () =>
 			deployments.splice(0, 1, {
 				...performanceDeployment,
 				id: "hdep_wallet_fallback",
@@ -1117,18 +1221,42 @@ test("wallet fallback explains the failed Performance payment and offers re-acti
 		"This agent fell back from Performance compute because payment failed on Jul 18, 2026.",
 	);
 	await expect(alert).toContainText("This agent is now using included Basic.");
-	await expect(page.getByRole("button", { name: "Retry payment" })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Reactivate Performance" })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Retry payment" })).toHaveCount(0);
 	await expect(page.getByRole("button", { name: "Upgrade to Performance" })).toHaveCount(0);
 	await expect(page.getByText("Wallet fallback", { exact: true })).toBeVisible();
-	await page.getByRole("button", { name: "Retry payment" }).click();
-	await expect.poll(() => retryRequests.length).toBe(1);
-	expect(JSON.parse(retryRequests[0] ?? "{}")).toEqual({ subscription_id: 42 });
+	await page.getByRole("button", { name: "Reactivate Performance" }).click();
+	await expect.poll(() => walletActivateRequests.length).toBe(1);
+	expect(JSON.parse(walletActivateRequests[0] ?? "{}")).toEqual({
+		plan_slug: "compute_performance",
+		billing_term_months: 1,
+		upgrade_deployment_id: "hdep_wallet_fallback",
+	});
 	await expect(page.getByText("Wallet compute funding ended", { exact: true })).toHaveCount(0);
 	await expect(page.getByText("Performance compute", { exact: true })).toBeVisible();
 	expect(errors, `wallet fallback: ${errors.join(" | ")}`).toEqual([]);
 });
 
-test("wallet-funded plan upgrade quotes the prorated debit before resizing", async ({ page }) => {
+test("detached Stripe recovery omits the deployment id from fix-payment", async ({ page }) => {
+	const errors = collectBrowserErrors(page);
+	const fixPaymentRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments: [stripeFallbackDeployment],
+		fixPaymentRequests,
+		plans: [basicPlan, performancePlan],
+	});
+	await gotoHostedAgentSettings(page, "hdep_stripe_fallback", "Basic");
+
+	await expect(page.getByText("Compute funding ended", { exact: true })).toBeVisible();
+	await page.getByRole("button", { name: "Fix payment" }).click();
+	await expect.poll(() => fixPaymentRequests.length).toBe(1);
+	expect(JSON.parse(fixPaymentRequests[0] ?? "null")).toEqual({});
+	expect(errors, `detached Stripe recovery: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("wallet-funded plan upgrade renders and submits a scheduled renewal change", async ({
+	page,
+}) => {
 	const errors = collectBrowserErrors(page);
 	const walletPlanQuoteRequests: string[] = [];
 	const walletPlanChangeRequests: string[] = [];
@@ -1142,11 +1270,15 @@ test("wallet-funded plan upgrade quotes the prorated debit before resizing", asy
 
 	await expect(page.getByText("Wallet", { exact: true })).toBeVisible();
 	await expect(page.getByRole("button", { name: "Change billing term" })).toHaveCount(0);
-	await page.getByRole("button", { name: "Upgrade with Wallet" }).click();
+	await page.getByRole("button", { name: "Schedule Performance upgrade" }).click();
 	await expect.poll(() => walletPlanQuoteRequests.length).toBe(1);
-	await expect(page.getByText("Due now", { exact: true })).toBeVisible();
-	await expect(page.getByText("$6.00", { exact: true })).toBeVisible();
-	await page.getByRole("button", { name: "Pay $6.00 & upgrade" }).click();
+	await expect(
+		page.getByText("Changes at next renewal on Aug 15, 2026 · then $19.00/mo.", {
+			exact: true,
+		}),
+	).toBeVisible();
+	await expect(page.getByText("Due now", { exact: true })).toHaveCount(0);
+	await page.getByRole("button", { name: "Schedule plan change" }).click();
 	await expect.poll(() => walletPlanChangeRequests.length).toBe(1);
 	expect(JSON.parse(walletPlanQuoteRequests[0] ?? "{}")).toEqual({
 		subscription_id: 73,
@@ -1156,113 +1288,24 @@ test("wallet-funded plan upgrade quotes the prorated debit before resizing", asy
 		subscription_id: 73,
 		target_plan_slug: "compute_performance",
 	});
+	await expect(page.getByText("Plan change scheduled", { exact: true })).toBeVisible();
 	expect(errors, `wallet plan upgrade: ${errors.join(" | ")}`).toEqual([]);
 });
 
-test("wallet plan upgrade retries a paid resize without quoting or charging again", async ({
-	page,
-}) => {
+test("wallet plan quote refund debt opens an actionable prefilled top-up", async ({ page }) => {
 	const errors = collectBrowserErrors(page);
 	const walletPlanQuoteRequests: string[] = [];
-	const walletPlanChangeRequests: string[] = [];
 	await stubHostedApi(page, {
 		deployments: [walletPlanDeployment],
 		plans: [basicPlan, performancePlan],
-		walletPlanChangeRequests,
-		walletPlanQuoteRequests,
-		walletPlanChangeResponses: [
-			{
-				status: 502,
-				body: {
-					detail: {
-						code: "resize_failed_retryable",
-						failure_code: "deployment_resize_failed",
-						retryable: true,
-					},
-				},
-			},
-			{
-				status: 200,
-				body: {
-					subscription_id: 73,
-					current_plan_slug: "compute_performance",
-					target_plan_slug: "compute_performance",
-					change_kind: "upgrade",
-					status: "active",
-					effective_at: "2026-07-15T00:00:00Z",
-					period_start: "2026-07-01T00:00:00Z",
-					period_end: "2026-08-01T00:00:00Z",
-					prorated_delta_cents: 600,
-					prorated_delta_credits: "6000",
-					points_per_usd: 1000,
-					charge_ledger_id: "ledger_plan_change",
-					pending_plan_slug: null,
-				},
-			},
-		],
-	});
-	await gotoHostedAgentSettings(page, "hdep_wallet_plan", "Basic");
-
-	await page.getByRole("button", { name: "Upgrade with Wallet" }).click();
-	await page.getByRole("button", { name: "Pay $6.00 & upgrade" }).click();
-	await expect(
-		page.getByRole("dialog").getByRole("heading", { name: "Charge applied, resize pending" }),
-	).toBeVisible();
-	await expect(page.getByText(/Wallet debit is already recorded/)).toBeVisible();
-	await expect(page.getByRole("button", { name: "Retry resize" })).toBeVisible();
-	await expect(page.getByText("Top up AI Credits", { exact: true })).toHaveCount(0);
-	await page.getByRole("button", { name: "Retry resize" }).click();
-	await expect.poll(() => walletPlanChangeRequests.length).toBe(2);
-	expect(walletPlanQuoteRequests).toHaveLength(1);
-	expect(walletPlanChangeRequests.map((body) => JSON.parse(body))).toEqual([
-		{ subscription_id: 73, target_plan_slug: "compute_performance" },
-		{ subscription_id: 73, target_plan_slug: "compute_performance" },
-	]);
-	await expect(page.getByText("Compute upgraded", { exact: true })).toBeVisible();
-	await expect(page.getByRole("button", { name: "Retry resize" })).toHaveCount(0);
-	expect(
-		errors.filter((error) => !error.includes("status of 502")),
-		`wallet resize retry: ${errors.join(" | ")}`,
-	).toEqual([]);
-});
-
-test("wallet plan change distinguishes quote conflicts from debit shortfalls", async ({ page }) => {
-	const errors = collectBrowserErrors(page);
-	const walletPlanChangeRequests: string[] = [];
-	const walletPlanQuoteRequests: string[] = [];
-	const upgradeQuote = {
-		subscription_id: 73,
-		current_plan_slug: "compute_basic",
-		target_plan_slug: "compute_performance",
-		change_kind: "upgrade",
-		status: "quoted",
-		effective_at: "2026-07-15T00:00:00Z",
-		period_start: "2026-07-01T00:00:00Z",
-		period_end: "2026-08-01T00:00:00Z",
-		prorated_delta_cents: 600,
-		prorated_delta_credits: "6000",
-		points_per_usd: 1000,
-		charge_ledger_id: null,
-		pending_plan_slug: null,
-	};
-	await stubHostedApi(page, {
-		deployments: [walletPlanDeployment],
-		plans: [basicPlan, performancePlan],
-		walletPlanChangeRequests,
 		walletPlanQuoteRequests,
 		walletPlanQuoteResponses: [
-			{ status: 409, body: { detail: { code: "open_refund_debt" } } },
-			{ status: 200, body: upgradeQuote },
-		],
-		walletPlanChangeResponses: [
 			{
-				status: 402,
+				status: 409,
 				body: {
 					detail: {
-						code: "insufficient_wallet_balance",
-						required_credits: "6000",
-						available_credits: "3500",
-						shortfall_credits: "2500",
+						code: "open_refund_debt",
+						outstanding_debt_credits: "2500.5",
 					},
 				},
 			},
@@ -1270,21 +1313,15 @@ test("wallet plan change distinguishes quote conflicts from debit shortfalls", a
 	});
 	await gotoHostedAgentSettings(page, "hdep_wallet_plan", "Basic");
 
-	await page.getByRole("button", { name: "Upgrade with Wallet" }).click();
-	await expect(page.getByText("Wallet plan change conflict", { exact: true })).toBeVisible();
-	await page.getByRole("button", { name: "Upgrade with Wallet" }).click();
-	await expect(page.getByRole("button", { name: "Pay $6.00 & upgrade" })).toBeVisible();
-	await page.getByRole("button", { name: "Pay $6.00 & upgrade" }).click();
+	await page.getByRole("button", { name: "Schedule Performance upgrade" }).click();
 	await expect(
 		page.getByRole("dialog").getByText("Top up AI Credits", { exact: true }),
 	).toBeVisible();
-	await expect(
-		page.getByText("Top up 2,500 credits, then confirm again.", { exact: true }),
-	).toBeVisible();
-	expect(walletPlanQuoteRequests).toHaveLength(2);
-	expect(walletPlanChangeRequests).toHaveLength(1);
+	await expect(page.getByText("Refund debt is repaid first", { exact: true })).toBeVisible();
+	await expect(page.getByLabel("Amount (USD)")).toHaveValue("10");
+	expect(walletPlanQuoteRequests).toHaveLength(1);
 	expect(
-		errors.filter((error) => !error.includes("status of 402") && !error.includes("status of 409")),
+		errors.filter((error) => !error.includes("status of 409")),
 		`wallet plan errors: ${errors.join(" | ")}`,
 	).toEqual([]);
 });
@@ -1312,17 +1349,17 @@ test("wallet-funded pending downgrade can be canceled and refreshes the deployme
 
 	await expect(page.getByText(/Basic scheduled for/)).toBeVisible();
 	await expect(page.getByRole("button", { name: "Schedule Basic downgrade" })).toBeDisabled();
-	await page.getByRole("button", { name: "Cancel scheduled downgrade" }).click();
-	await expect(page.getByText("Cancel scheduled downgrade?", { exact: true })).toBeVisible();
+	await page.getByRole("button", { name: "Cancel scheduled plan change" }).click();
+	await expect(page.getByText("Cancel scheduled plan change?", { exact: true })).toBeVisible();
 	await page
 		.getByRole("alertdialog")
-		.getByRole("button", { name: "Cancel scheduled downgrade" })
+		.getByRole("button", { name: "Cancel scheduled plan change" })
 		.click();
 	await expect.poll(() => walletPlanCancelRequests.length).toBe(1);
 	expect(JSON.parse(walletPlanCancelRequests[0] ?? "{}")).toEqual({ subscription_id: 74 });
 	await expect(page.getByText(/Basic scheduled for/)).toHaveCount(0);
 	await expect(page.getByRole("button", { name: "Schedule Basic downgrade" })).toBeEnabled();
-	await expect(page.getByText("Scheduled downgrade canceled", { exact: true })).toBeVisible();
+	await expect(page.getByText("Scheduled plan change canceled", { exact: true })).toBeVisible();
 	expect(errors, `wallet pending downgrade: ${errors.join(" | ")}`).toEqual([]);
 });
 
@@ -1348,10 +1385,10 @@ test("wallet pending downgrade cancel reconciles an already-cleared conflict", a
 	});
 	await gotoHostedAgentSettings(page, "hdep_wallet_pending", "Performance");
 
-	await page.getByRole("button", { name: "Cancel scheduled downgrade" }).click();
+	await page.getByRole("button", { name: "Cancel scheduled plan change" }).click();
 	await page
 		.getByRole("alertdialog")
-		.getByRole("button", { name: "Cancel scheduled downgrade" })
+		.getByRole("button", { name: "Cancel scheduled plan change" })
 		.click();
 	await expect(page.getByText("Scheduled change already cleared", { exact: true })).toBeVisible();
 	expect(walletPlanCancelRequests).toHaveLength(1);
@@ -1430,6 +1467,97 @@ test("mixed billing history paginates wallet charges and Stripe invoices", async
 	await expect(billingTable.getByText("Refunded", { exact: true })).toBeVisible();
 	await settingsDialog.screenshot({ path: "/tmp/mixed-billing-history.png" });
 	expect(errors, `mixed billing history: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("Wallet activity caps show-more requests at the ledger API limit", async ({ page }) => {
+	const errors = collectBrowserErrors(page);
+	const ledgerRequests: string[] = [];
+	const computeCharge = {
+		id: "ledger-compute-charge",
+		operation: "compute_charge",
+		request_id: "compute-renewal-42",
+		credits_amount: -9_000,
+		status: "applied",
+		created_at: "2026-07-15T00:00:00Z",
+	};
+	await stubHostedApi(page, {
+		ledgerRequests,
+		ledgerResponses: [
+			{ items: [computeCharge], has_more: true },
+			{
+				items: [
+					computeCharge,
+					{
+						...computeCharge,
+						id: "ledger-compute-credit",
+						operation: "compute_credit",
+						request_id: "compute-reversal-42",
+						credits_amount: 9_000,
+					},
+				],
+				has_more: true,
+			},
+		],
+		plans: [basicPlan, performancePlan],
+	});
+	await page.goto("/channels?settings=billing-wallet");
+	const settingsDialog = page.getByTestId("settings-dialog");
+	const ledgerTable = settingsDialog.getByRole("table");
+
+	await expect(ledgerTable.getByText("Compute charge", { exact: true })).toBeVisible();
+	await settingsDialog.getByRole("button", { name: "Show more" }).click();
+	await expect.poll(() => ledgerRequests.length).toBe(2);
+	await expect(ledgerTable.getByText("Compute reversal", { exact: true })).toBeVisible();
+	await expect(settingsDialog.getByRole("button", { name: "Show more" })).toHaveCount(0);
+	await expect(settingsDialog).toContainText(
+		"Showing your most recent activity. Older entries are archived.",
+	);
+
+	const limits = ledgerRequests.map((url) => Number(new URL(url).searchParams.get("limit")));
+	expect(limits).toEqual([50, 100]);
+	expect(limits.every((limit) => limit <= 100)).toBe(true);
+	expect(errors, `wallet ledger cap: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("top-up rotates its idempotency key after an explicit reuse conflict", async ({ page }) => {
+	const errors = collectBrowserErrors(page);
+	const topUpIdempotencyKeys: string[] = [];
+	await stubHostedApi(page, {
+		plans: [basicPlan, performancePlan],
+		topUpIdempotencyKeys,
+		topUpResponses: [
+			{
+				status: 409,
+				body: {
+					detail: {
+						code: "idempotency_key_reused",
+						message: "The top-up key belongs to another amount.",
+					},
+				},
+			},
+		],
+	});
+	await page.goto("/channels?settings=billing-wallet");
+	const settingsDialog = page.getByTestId("settings-dialog");
+	await settingsDialog.getByRole("button", { name: "Top up" }).click();
+	const topUpDialog = page.getByRole("dialog").filter({ hasText: "Top up AI Credits" });
+	const submit = topUpDialog.getByRole("button", { name: "Continue" });
+
+	await submit.click();
+	await expect.poll(() => topUpIdempotencyKeys.length).toBe(1);
+	await expect(page.getByText("Start a fresh top-up", { exact: true })).toBeVisible();
+	await expect(topUpDialog).toBeVisible();
+	await submit.click();
+	await expect.poll(() => topUpIdempotencyKeys.length).toBe(2);
+
+	expect(topUpIdempotencyKeys[0]).toMatch(/^topup-/);
+	expect(topUpIdempotencyKeys[1]).toMatch(/^topup-/);
+	expect(topUpIdempotencyKeys[1]).not.toBe(topUpIdempotencyKeys[0]);
+	await expect(topUpDialog).toHaveCount(0);
+	expect(
+		errors.filter((error) => !error.includes("status of 409")),
+		`top-up key rotation: ${errors.join(" | ")}`,
+	).toEqual([]);
 });
 
 test("Wallet summarizes compute commitment, coverage, renewal, and deployment link", async ({

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -171,6 +171,21 @@ const walletPastDueDeployment = {
 	},
 };
 
+const walletUnpaidDeployment = {
+	...walletBasicDeployment,
+	id: "hdep_wallet_unpaid",
+	name: "Wallet unpaid agent",
+	compute_subscription: {
+		...walletBasicDeployment.compute_subscription,
+		subscription_id: 44,
+		status: "unpaid",
+		payment_state: "unpaid",
+		pending_plan_slug: "compute_performance",
+		last_collection_failure_code: "insufficient_balance",
+		recovery_action: "top_up",
+	},
+};
+
 const walletPlanDeployment = {
 	...walletBasicDeployment,
 	id: "hdep_wallet_plan",
@@ -1135,9 +1150,7 @@ test("wallet dunning shows grace recovery without Stripe portal actions", async 
 	expect(errors, `wallet dunning: ${errors.join(" | ")}`).toEqual([]);
 });
 
-test("wallet retry distinguishes insufficient balance from a collection conflict", async ({
-	page,
-}) => {
+test("wallet retry opens top-up for balance shortfalls and refund debt", async ({ page }) => {
 	const errors = collectBrowserErrors(page);
 	const retryRequests: string[] = [];
 	const topUpRequests: string[] = [];
@@ -1160,7 +1173,12 @@ test("wallet retry distinguishes insufficient balance from a collection conflict
 			},
 			{
 				status: 409,
-				body: { detail: "Wallet compute collection is already in progress." },
+				body: {
+					detail: {
+						code: "open_refund_debt",
+						outstanding_debt_credits: "2500.5",
+					},
+				},
 			},
 		],
 	});
@@ -1179,16 +1197,54 @@ test("wallet retry distinguishes insufficient balance from a collection conflict
 	).toHaveCount(0);
 	await page.getByRole("button", { name: "Retry payment" }).click();
 	await expect(
-		page.getByText(
-			"Another billing action is in progress, or this payment no longer needs recovery. Refresh and try again.",
-			{ exact: true },
-		),
+		page.getByRole("dialog").getByText("Refund debt is repaid first", { exact: true }),
 	).toBeVisible();
+	await expect(page.getByLabel("Amount (USD)")).toHaveValue("12");
+	await expect(page.getByText("Top up to clear refund debt", { exact: true })).toBeVisible();
 	expect(retryRequests).toHaveLength(2);
 	expect(
 		errors.filter((error) => !error.includes("status of 402") && !error.includes("status of 409")),
 		`wallet retry errors: ${errors.join(" | ")}`,
 	).toEqual([]);
+});
+
+test("wallet unpaid subscription reactivates the plan due after terminal dunning", async ({
+	page,
+}) => {
+	const errors = collectBrowserErrors(page);
+	const deployments: unknown[] = [walletUnpaidDeployment];
+	const walletActivateRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments,
+		plans: [basicPlan, performancePlan],
+		walletActivateRequests,
+		onWalletActivateSuccess: () =>
+			deployments.splice(0, 1, {
+				...performanceDeployment,
+				id: "hdep_wallet_unpaid",
+				name: "Wallet unpaid agent",
+				compute_subscription: {
+					...walletBasicDeployment.compute_subscription,
+					subscription_id: 45,
+					price_cents: 1_900,
+				},
+			}),
+	});
+	await gotoHostedAgentSettings(page, "hdep_wallet_unpaid", "Basic");
+
+	const alert = page.getByRole("alert").filter({ hasText: "Wallet compute funding ended" });
+	await expect(alert).toContainText("Reactivate Performance compute to start a new subscription.");
+	await expect(page.getByRole("button", { name: "Reactivate Performance" })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Retry payment" })).toHaveCount(0);
+	await page.getByRole("button", { name: "Reactivate Performance" }).click();
+	await expect.poll(() => walletActivateRequests.length).toBe(1);
+	expect(JSON.parse(walletActivateRequests[0] ?? "{}")).toEqual({
+		plan_slug: "compute_performance",
+		billing_term_months: 1,
+		upgrade_deployment_id: "hdep_wallet_unpaid",
+	});
+	await expect(page.getByText("Wallet compute funding ended", { exact: true })).toHaveCount(0);
+	expect(errors, `wallet unpaid recovery: ${errors.join(" | ")}`).toEqual([]);
 });
 
 test("wallet fallback explains the failed Performance payment and offers re-activation", async ({

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -128,11 +128,13 @@ import {
 	computeFundingMode,
 	computeFundingSource,
 	computeSubscriptionId,
+	computeSubscriptionLifecycle,
 	computeTierLabel,
 	explicitPlanOffers,
 	isComputeSubscriptionCancelable,
 	isComputeSubscriptionTermChangeable,
 	pendingComputePlanSlug,
+	pendingPlanScheduleCopy,
 	planOffers,
 	resolveBasicPlan,
 	resolvePerformancePlan,
@@ -152,6 +154,7 @@ import {
 	StripePaymentForm,
 } from "@/hosted/billing/wallet/stripe-payment-form";
 import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
+import { topUpAmountCentsForCreditShortfall } from "@/hosted/billing/wallet/top-up-dialog.logic";
 import {
 	compactDeploymentFailureReason,
 	deploymentFailureReason,
@@ -2231,6 +2234,17 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 		currentSubscription?.cancel_at ?? currentSubscription?.current_period_end ?? null;
 	const subscriptionPeriodLabel = formatShortDate(subscriptionEndsAt);
 	const subscriptionCancelPending = !!currentSubscription?.cancel_at_period_end;
+	const subscriptionLifecycle = currentSubscription
+		? computeSubscriptionLifecycle(currentSubscription)
+		: null;
+	const subscriptionLifecycleDateLabel = formatShortDate(subscriptionLifecycle?.dateAt);
+	const pendingPlanCopy = pendingPlanSlug
+		? pendingPlanScheduleCopy(
+				pendingPlanSlug,
+				currentSubscription?.current_period_end,
+				subscriptionPeriodLabel,
+			)
+		: null;
 	const subscriptionCancelable = isComputeSubscriptionCancelable(currentSubscription);
 	const canChangeBillingTerm =
 		isStripeFunded &&
@@ -2393,12 +2407,16 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 			setWalletPlanQuote(quote);
 		} catch (error) {
 			const failure = walletPlanChangeFailure(error);
+			setWalletPlanFailure(failure.kind === "refund_debt" ? failure : null);
+			if (failure.kind === "refund_debt") setWalletTopUpOpen(true);
 			toast.error(
-				failure.kind === "conflict"
-					? "Wallet plan change conflict"
-					: failure.kind === "retryable"
-						? "Wallet quote temporarily unavailable"
-						: "Couldn’t quote wallet plan change",
+				failure.kind === "refund_debt"
+					? "Top up to clear refund debt"
+					: failure.kind === "conflict"
+						? "Wallet plan change conflict"
+						: failure.kind === "retryable"
+							? "Wallet quote temporarily unavailable"
+							: "Couldn’t quote wallet plan change",
 				{ description: normalizeBillingError(error) },
 			);
 		}
@@ -2420,38 +2438,24 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 			});
 			setWalletPlanFailure(null);
 			setWalletPlanQuote(null);
-			toast.success(result.change_kind === "upgrade" ? "Compute upgraded" : "Downgrade scheduled", {
-				description:
-					result.change_kind === "upgrade"
-						? "The wallet charge was applied and the deployment is resizing."
-						: `The ${computeTierLabel(COMPUTE_BASIC_SLUG)} plan begins ${formatShortDate(result.effective_at)}.`,
+			toast.success("Plan change scheduled", {
+				description: `${computeTierLabel(targetPlanSlug)} compute begins ${formatShortDate(
+					result.effective_at,
+				)} at ${formatCents(result.amount_cents)}/mo.`,
 			});
 		} catch (error) {
 			const failure = walletPlanChangeFailure(error);
-			if (failure.kind === "insufficient") setWalletTopUpOpen(true);
-			if (failure.kind === "resize_pending") {
-				setWalletPlanFailure(failure);
-			} else if (walletPlanFailure?.kind !== "resize_pending") {
-				setWalletPlanFailure(null);
-			}
+			setWalletPlanFailure(failure.kind === "refund_debt" ? failure : null);
+			if (failure.kind === "refund_debt") setWalletTopUpOpen(true);
 			toast.error(
-				failure.kind === "insufficient"
-					? "Wallet balance too low"
+				failure.kind === "refund_debt"
+					? "Top up to clear refund debt"
 					: failure.kind === "conflict"
 						? "Wallet plan change conflict"
-						: failure.kind === "resize_pending"
-							? "Charge applied, resize pending"
-							: failure.kind === "retryable"
-								? "Plan change needs a retry"
-								: "Couldn’t change wallet compute plan",
-				{
-					description:
-						failure.kind === "insufficient" && failure.shortfallCredits !== null
-							? `Top up ${failure.shortfallCredits.toLocaleString()} credits, then confirm again.`
-							: failure.kind === "resize_pending"
-								? "The Wallet charge is recorded. Retry the resize without paying again."
-								: normalizeBillingError(error),
-				},
+						: failure.kind === "retryable"
+							? "Plan change needs a retry"
+							: "Couldn’t change wallet compute plan",
+				{ description: normalizeBillingError(error) },
 			);
 		}
 	}
@@ -2462,7 +2466,7 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 			await cancelPendingWalletPlan.mutateAsync({
 				subscription_id: walletSubscriptionId,
 			});
-			toast.success("Scheduled downgrade canceled", {
+			toast.success("Scheduled plan change canceled", {
 				description: `${tierLabel} compute remains active.`,
 			});
 		} catch (error) {
@@ -2530,8 +2534,6 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 		await router.navigate({ href: "/" });
 	}
 
-	const walletResizePending = walletPlanFailure?.kind === "resize_pending";
-
 	return (
 		<div className="flex flex-col gap-9">
 			<Dialog
@@ -2571,22 +2573,14 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 			>
 				<DialogContent className="sm:max-w-md" data-hosted="true">
 					<DialogHeader>
-						<DialogTitle>
-							{walletResizePending
-								? "Charge applied, resize pending"
-								: `Confirm wallet-funded ${walletPlanQuote?.change_kind ?? "plan"} change`}
-						</DialogTitle>
+						<DialogTitle>Confirm wallet-funded plan change</DialogTitle>
 						<DialogDescription>
-							{walletResizePending
-								? "The Wallet debit is already recorded. Retry only completes the compute resize and does not charge again."
-								: walletPlanQuote
-									? walletPlanChangeSummary(walletPlanQuote)
-									: "Review the change."}
+							{walletPlanQuote ? walletPlanChangeSummary(walletPlanQuote) : "Review the change."}
 						</DialogDescription>
 					</DialogHeader>
 					{walletPlanQuote ? (
 						<div className="flex flex-col gap-4">
-							<div className="grid gap-3 rounded-lg border p-3 text-sm sm:grid-cols-2">
+							<div className="grid gap-3 rounded-lg border p-3 text-sm sm:grid-cols-3">
 								<div>
 									<div className="text-xs text-muted-foreground">New plan</div>
 									<div className="font-medium">
@@ -2598,13 +2592,13 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 									</div>
 								</div>
 								<div>
-									<div className="text-xs text-muted-foreground">
-										{walletPlanQuote.change_kind === "upgrade" ? "Due now" : "Effective"}
-									</div>
+									<div className="text-xs text-muted-foreground">Next renewal</div>
+									<div className="font-medium">{formatShortDate(walletPlanQuote.effective_at)}</div>
+								</div>
+								<div>
+									<div className="text-xs text-muted-foreground">Then</div>
 									<div className="font-medium tabular-nums">
-										{walletPlanQuote.change_kind === "upgrade"
-											? formatCents(walletPlanQuote.prorated_delta_cents)
-											: formatShortDate(walletPlanQuote.effective_at)}
+										{formatCents(walletPlanQuote.amount_cents)}/mo
 									</div>
 								</div>
 							</div>
@@ -2623,18 +2617,8 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 									onClick={() => void confirmWalletComputePlanChange()}
 									disabled={changeWalletPlan.isPending}
 								>
-									{changeWalletPlan.isPending ? (
-										<Spinner />
-									) : walletResizePending ? (
-										<RefreshCw />
-									) : (
-										<WalletCards />
-									)}
-									{walletResizePending
-										? "Retry resize"
-										: walletPlanQuote.change_kind === "upgrade"
-											? `Pay ${formatCents(walletPlanQuote.prorated_delta_cents)} & upgrade`
-											: "Schedule downgrade"}
+									{changeWalletPlan.isPending ? <Spinner /> : <WalletCards />}
+									Schedule plan change
 								</Button>
 							</div>
 						</div>
@@ -2647,6 +2631,11 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 					onOpenChange={setWalletTopUpOpen}
 					wallet={wallet.data}
 					onComplete={handleWalletPlanTopup}
+					initialAmountCents={topUpAmountCentsForCreditShortfall(
+						walletPlanFailure?.debtCredits ?? null,
+						wallet.data.points_per_usd,
+					)}
+					refundDebtCredits={walletPlanFailure?.debtCredits}
 				/>
 			) : null}
 
@@ -2661,7 +2650,9 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 							)}
 							<span>{tierLabel} compute</span>
 							<Badge variant="outline" className="font-normal text-muted-foreground">
-								Current
+								{isPaidCompute && subscriptionLifecycle
+									? subscriptionLifecycle.badgeLabel
+									: "Current"}
 							</Badge>
 							{isPaidCompute ? (
 								<Badge variant="outline" className="font-normal text-muted-foreground">
@@ -2688,13 +2679,15 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 											{billingTermSuffix(currentBillingTerm)}
 										</>
 									) : null}
-									{" · "}
-									{subscriptionCancelPending ? "Ends" : "Renews"} {subscriptionPeriodLabel}
+									{subscriptionLifecycle?.dateVerb && subscriptionLifecycle.dateAt ? (
+										<>
+											{" · "}
+											{subscriptionLifecycle.dateVerb} {subscriptionLifecycleDateLabel}
+										</>
+									) : null}
 								</p>
-								{pendingPlanSlug ? (
-									<p className="font-medium text-warning-muted-foreground">
-										{computeTierLabel(pendingPlanSlug)} scheduled for {subscriptionPeriodLabel}.
-									</p>
+								{pendingPlanCopy ? (
+									<p className="font-medium text-warning-muted-foreground">{pendingPlanCopy}</p>
 								) : null}
 							</div>
 						) : null}
@@ -2767,7 +2760,7 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 								>
 									{quoteWalletPlanChange.isPending ? <Spinner /> : <WalletCards />}
 									{computePlanSlug === COMPUTE_BASIC_SLUG
-										? "Upgrade with Wallet"
+										? "Schedule Performance upgrade"
 										: "Schedule Basic downgrade"}
 								</Button>
 								{!walletSubscriptionId ? (
@@ -2776,11 +2769,11 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 									</p>
 								) : pendingPlanSlug ? (
 									<ConfirmAction
-										title="Cancel scheduled downgrade?"
+										title="Cancel scheduled plan change?"
 										description={
 											<p>{tierLabel} compute will remain active and renew at its current price.</p>
 										}
-										confirmLabel="Cancel scheduled downgrade"
+										confirmLabel="Cancel scheduled plan change"
 										onConfirm={() => runAction(cancelPendingWalletComputePlanChange)}
 									>
 										<Button
@@ -2790,7 +2783,7 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 											disabled={cancelPendingWalletPlan.isPending}
 										>
 											{cancelPendingWalletPlan.isPending ? <Spinner /> : <Link2Off />}
-											Cancel scheduled downgrade
+											Cancel scheduled plan change
 										</Button>
 									</ConfirmAction>
 								) : null}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -2477,7 +2477,7 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 				});
 				return;
 			}
-			toast.error("Couldn’t cancel scheduled downgrade", {
+			toast.error("Couldn’t cancel scheduled plan change", {
 				description: normalizeBillingError(error),
 			});
 			throw error;

--- a/apps/web/src/hosted/billing/components/compute-dunning-banner.tsx
+++ b/apps/web/src/hosted/billing/components/compute-dunning-banner.tsx
@@ -126,6 +126,10 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 				description: "Paid compute is active again.",
 			});
 		} catch (error) {
+			const debtCredits =
+				error instanceof BillingApiError && error.status === 409
+					? walletRefundDebtCredits(error)
+					: null;
 			if (error instanceof BillingApiError && error.status === 402) {
 				const detail = walletComputeErrorDetail(error);
 				const shortfall =
@@ -135,20 +139,22 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 				setTopUpCredits(Number.isFinite(shortfall) ? shortfall : null);
 				setRefundDebtCredits(null);
 				setTopUpOpen(true);
-			} else if (error instanceof BillingApiError && error.status === 409) {
-				const debtCredits = walletRefundDebtCredits(error);
-				if (debtCredits !== null) {
-					setRefundDebtCredits(debtCredits);
-					setTopUpCredits(debtCredits + blockedChargeCredits);
-					setTopUpOpen(true);
-				}
+			} else if (debtCredits !== null) {
+				setRefundDebtCredits(debtCredits);
+				setTopUpCredits(debtCredits + blockedChargeCredits);
+				setTopUpOpen(true);
 			}
-			toast.error("Couldn’t retry wallet payment", {
-				description:
-					error instanceof BillingApiError && error.status === 409
-						? "Another billing action is in progress, or this payment no longer needs recovery. Refresh and try again."
-						: normalizeBillingError(error),
-			});
+			toast.error(
+				debtCredits !== null ? "Top up to clear refund debt" : "Couldn’t retry wallet payment",
+				{
+					description:
+						debtCredits !== null
+							? "New Wallet funds repay refund debt before the blocked compute charge."
+							: error instanceof BillingApiError && error.status === 409
+								? "Another billing action is in progress, or this payment no longer needs recovery. Refresh and try again."
+								: normalizeBillingError(error),
+				},
+			);
 		}
 	}
 

--- a/apps/web/src/hosted/billing/components/compute-dunning-banner.tsx
+++ b/apps/web/src/hosted/billing/components/compute-dunning-banner.tsx
@@ -16,14 +16,24 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import type { HostedDeployment } from "@/hosted/billing/contracts";
+import { walletActivationFailure } from "@/hosted/billing/deploy/deploy-wallet.logic";
 import {
 	BillingApiError,
 	normalizeBillingError,
 	walletComputeErrorDetail,
+	walletRefundDebtCredits,
 } from "@/hosted/billing/errors";
-import { useFixPayment, useRetryWalletCompute, useWallet } from "@/hosted/billing/hooks";
+import {
+	useActivateWalletCompute,
+	useFixPayment,
+	useRetryWalletCompute,
+	useWallet,
+	useWalletComputeQuote,
+} from "@/hosted/billing/hooks";
+import { computeTierLabel } from "@/hosted/billing/subscription/subscription-utils";
 import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
 import { topUpAmountCentsForCreditShortfall } from "@/hosted/billing/wallet/top-up-dialog.logic";
+import { decimalCredits } from "@/hosted/billing/wallet/wallet-compute.logic";
 import { formatShortDate } from "@/lib/format";
 import { settingsQueryHref } from "@/lib/settings-routes";
 import {
@@ -31,19 +41,29 @@ import {
 	computeDunningState,
 	dunningDeadlineCountdown,
 	fallbackReasonSentence,
+	fixPaymentRequestForDunning,
 } from "./compute-dunning.logic";
 
 export function ComputeDunningBanner({ deployment }: { deployment: HostedDeployment }) {
 	const state = computeDunningState(deployment);
 	const fixPayment = useFixPayment();
 	const retryWallet = useRetryWalletCompute();
-	const wallet = useWallet({ enabled: state?.ctaTarget === "wallet" });
+	const activateWallet = useActivateWalletCompute();
+	const walletRecovery =
+		state?.ctaTarget === "wallet_retry" || state?.ctaTarget === "wallet_reactivate";
+	const wallet = useWallet({ enabled: walletRecovery });
+	const reactivationQuote = useWalletComputeQuote(
+		state?.ctaTarget === "wallet_reactivate" && state.recoveryPlanSlug
+			? { plan_slug: state.recoveryPlanSlug, billing_term_months: 1 }
+			: null,
+	);
 	const [topUpOpen, setTopUpOpen] = useState(false);
-	const [retryShortfallCredits, setRetryShortfallCredits] = useState<number | null>(null);
+	const [topUpCredits, setTopUpCredits] = useState<number | null>(null);
+	const [refundDebtCredits, setRefundDebtCredits] = useState<number | null>(null);
 	const [now, setNow] = useState(() => Date.now());
 
 	useEffect(() => {
-		if (!state?.serviceRiskAt || state.ctaTarget !== "wallet") return;
+		if (!state?.serviceRiskAt || state.ctaTarget !== "wallet_retry") return;
 		const interval = window.setInterval(() => setNow(Date.now()), 60_000);
 		return () => window.clearInterval(interval);
 	}, [state?.ctaTarget, state?.serviceRiskAt]);
@@ -51,7 +71,7 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 	if (!state) return null;
 
 	const countdown =
-		state.ctaTarget === "wallet" ? dunningDeadlineCountdown(state.serviceRiskAt, now) : null;
+		state.ctaTarget === "wallet_retry" ? dunningDeadlineCountdown(state.serviceRiskAt, now) : null;
 	const riskLabel = countdown
 		? `Grace deadline: ${formatShortDate(state.serviceRiskAt)} (${countdown}).`
 		: state.nextPaymentAttemptAt
@@ -82,7 +102,7 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 			return;
 		}
 		try {
-			const res = await fixPayment.mutateAsync({ deployment_id: deployment.id });
+			const res = await fixPayment.mutateAsync(fixPaymentRequestForDunning(state, deployment.id));
 			const url = res.url || res.portal_url;
 			if (url) {
 				window.location.href = url;
@@ -112,8 +132,16 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 					detail && typeof detail !== "string" && "shortfall_credits" in detail
 						? Number(detail.shortfall_credits)
 						: Number.NaN;
-				setRetryShortfallCredits(Number.isFinite(shortfall) ? shortfall : null);
+				setTopUpCredits(Number.isFinite(shortfall) ? shortfall : null);
+				setRefundDebtCredits(null);
 				setTopUpOpen(true);
+			} else if (error instanceof BillingApiError && error.status === 409) {
+				const debtCredits = walletRefundDebtCredits(error);
+				if (debtCredits !== null) {
+					setRefundDebtCredits(debtCredits);
+					setTopUpCredits(debtCredits + blockedChargeCredits);
+					setTopUpOpen(true);
+				}
 			}
 			toast.error("Couldn’t retry wallet payment", {
 				description:
@@ -124,10 +152,42 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 		}
 	}
 
+	async function handleWalletReactivate() {
+		if (!state?.recoveryPlanSlug) return;
+		try {
+			await activateWallet.mutateAsync({
+				plan_slug: state.recoveryPlanSlug,
+				billing_term_months: 1,
+				upgrade_deployment_id: deployment.id,
+			});
+			toast.success(`${computeTierLabel(state.recoveryPlanSlug)} compute reactivated`, {
+				description: "A new wallet-funded subscription is active.",
+			});
+		} catch (error) {
+			const failure = walletActivationFailure(error, blockedChargeCredits);
+			if (failure.kind === "insufficient" || failure.kind === "refund_debt") {
+				setTopUpCredits(failure.topUpCredits);
+				setRefundDebtCredits(failure.debtCredits);
+				setTopUpOpen(true);
+			}
+			toast.error("Couldn’t reactivate wallet compute", {
+				description: failure.description,
+			});
+		}
+	}
+
 	function openManualTopUp() {
-		setRetryShortfallCredits(null);
+		setTopUpCredits(null);
+		setRefundDebtCredits(null);
 		setTopUpOpen(true);
 	}
+
+	const blockedChargeCredits =
+		state.ctaTarget === "wallet_reactivate"
+			? decimalCredits(reactivationQuote.data?.first_charge_credits)
+			: state.ctaTarget === "wallet_retry" && wallet.data
+				? ((deployment.compute_subscription?.price_cents ?? 0) / 100) * wallet.data.points_per_usd
+				: 0;
 
 	const BannerIcon = state.tone === "neutral" ? Info : TriangleAlert;
 
@@ -148,7 +208,7 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 				<AlertTitle>{state.title}</AlertTitle>
 				<AlertDescription className="flex flex-col items-start gap-3">
 					<span>{bannerDescription}</span>
-					{state.ctaTarget === "wallet" ? (
+					{state.ctaTarget === "wallet_retry" ? (
 						<div className="flex flex-col items-start gap-2">
 							<div className="flex flex-wrap gap-2">
 								<Button
@@ -174,6 +234,22 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 									Retry becomes available after wallet billing details finish syncing.
 								</span>
 							)}
+						</div>
+					) : state.ctaTarget === "wallet_reactivate" ? (
+						<div className="flex flex-wrap gap-2">
+							<Button
+								size="sm"
+								variant={destructive ? "destructive" : "default"}
+								onClick={() => void handleWalletReactivate()}
+								disabled={activateWallet.isPending || !state.recoveryPlanSlug}
+							>
+								{activateWallet.isPending ? <Spinner /> : <RefreshCw data-icon="inline-start" />}
+								Reactivate{" "}
+								{state.recoveryPlanSlug ? computeTierLabel(state.recoveryPlanSlug) : "compute"}
+							</Button>
+							<Button size="sm" variant="outline" onClick={openManualTopUp} disabled={!wallet.data}>
+								<WalletCards data-icon="inline-start" /> Top up first
+							</Button>
 						</div>
 					) : state.ctaTarget === "billing_history" ? (
 						<Button
@@ -218,9 +294,11 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 					onOpenChange={setTopUpOpen}
 					wallet={wallet.data}
 					initialAmountCents={topUpAmountCentsForCreditShortfall(
-						retryShortfallCredits,
+						topUpCredits,
 						wallet.data.points_per_usd,
 					)}
+					refundDebtCredits={refundDebtCredits}
+					blockedChargeCredits={blockedChargeCredits}
 				/>
 			) : null}
 		</>

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.test.ts
@@ -6,6 +6,7 @@ import {
 	computeDunningTileStatus,
 	dunningDeadlineCountdown,
 	fallbackReasonSentence,
+	fixPaymentRequestForDunning,
 } from "./compute-dunning.logic";
 
 function deployment(
@@ -82,7 +83,7 @@ describe("computeDunningState", () => {
 		expect(state).toMatchObject({
 			fundingSource: "wallet",
 			recoveryAction: "top_up",
-			ctaTarget: "wallet",
+			ctaTarget: "wallet_retry",
 			serviceRiskAt: "2026-07-18T12:00:00Z",
 			failureCode: "insufficient_balance",
 		});
@@ -99,11 +100,13 @@ describe("computeDunningState", () => {
 					payment_state: "unpaid",
 					recovery_action: "top_up",
 				}),
+				"compute_basic",
 			),
 		);
 		expect(state?.description).toContain("fell back to included Basic");
 		expect(state?.description).toContain("otherwise it stopped");
-		expect(state?.ctaTarget).toBe("wallet");
+		expect(state?.ctaTarget).toBe("wallet_reactivate");
+		expect(state?.recoveryPlanSlug).toBe("compute_basic");
 	});
 
 	test("renders the persisted wallet fallback trace after the subscription detaches", () => {
@@ -121,7 +124,7 @@ describe("computeDunningState", () => {
 		expect(running).toMatchObject({
 			paymentState: "unpaid",
 			fundingSource: "wallet",
-			ctaTarget: "wallet",
+			ctaTarget: "wallet_reactivate",
 			subscriptionId: 42,
 			fallbackOccurredAt: "2026-07-18T12:00:00Z",
 			fallbackPlanLabel: "Performance compute",
@@ -159,7 +162,7 @@ describe("computeDunningState", () => {
 			{
 				fallbackReason: "payment_failure" as const,
 				tone: "destructive",
-				ctaTarget: "wallet",
+				ctaTarget: "wallet_reactivate",
 				title: "Wallet compute funding ended",
 			},
 			{
@@ -250,6 +253,47 @@ describe("computeDunningState", () => {
 
 		expect(state?.description).toContain("keep Basic compute active");
 		expect(state?.tileTitle).toContain("keep Basic compute active");
+	});
+
+	test("names the pending plan that the wallet retry will actually charge", () => {
+		const state = computeDunningState(
+			deployment(
+				subscription({
+					status: "past_due",
+					funding_source: "wallet",
+					payment_state: "past_due",
+					recovery_action: "top_up",
+					pending_plan_slug: "compute_basic",
+				}),
+				"compute_performance",
+			),
+		);
+		expect(state?.description).toContain("Basic compute debit");
+		expect(state?.recoveryPlanSlug).toBe("compute_basic");
+	});
+
+	test("omits the detached deployment id for Stripe fallback recovery", () => {
+		const state = computeDunningState(
+			deployment(null, "compute_basic", {
+				last_funding_event: {
+					type: "compute_subscription_fallback",
+					funding_source: "stripe",
+					reason: "payment_failure",
+					occurred_at: "2026-07-18T12:00:00Z",
+					prior_plan_slug: "compute_performance",
+					subscription_id: 42,
+				},
+			}),
+		);
+		expect(state).not.toBeNull();
+		if (!state) return;
+		expect(fixPaymentRequestForDunning(state, "hdep_detached")).toEqual({});
+		expect(
+			fixPaymentRequestForDunning(
+				{ fundingSource: "stripe", fallbackOccurredAt: null },
+				"hdep_bound",
+			),
+		).toEqual({ deployment_id: "hdep_bound" });
 	});
 
 	test("uses portal remediation for retryable past-due subscriptions", () => {

--- a/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
+++ b/apps/web/src/hosted/billing/components/compute-dunning.logic.ts
@@ -1,7 +1,13 @@
-import type { HostedDeployment, HostedFundingEvent } from "@/hosted/billing/contracts";
+import type {
+	ComputeFixPaymentRequest,
+	ComputePlanSlug,
+	HostedDeployment,
+	HostedFundingEvent,
+} from "@/hosted/billing/contracts";
 import {
 	computeSubscriptionId,
 	computeTierLabel,
+	pendingComputePlanSlug,
 } from "@/hosted/billing/subscription/subscription-utils";
 
 type ComputeSubscription = NonNullable<HostedDeployment["compute_subscription"]>;
@@ -18,7 +24,14 @@ export type ComputeDunningState = {
 	tone: "neutral" | "warning" | "destructive";
 	title: string;
 	description: string;
-	ctaTarget: "invoice" | "portal" | "wallet" | "billing_history" | "support" | "none";
+	ctaTarget:
+		| "invoice"
+		| "portal"
+		| "wallet_retry"
+		| "wallet_reactivate"
+		| "billing_history"
+		| "support"
+		| "none";
 	invoiceUrl: string | null;
 	subscriptionId: number | null;
 	nextPaymentAttemptAt: string | null;
@@ -27,6 +40,7 @@ export type ComputeDunningState = {
 	fallbackOccurredAt: string | null;
 	fallbackPlanLabel: string | null;
 	fallbackReason: HostedFundingEvent["reason"] | null;
+	recoveryPlanSlug: ComputePlanSlug | null;
 	tileLabel: string;
 	tileTitle: string;
 	tileTextClass: string;
@@ -70,8 +84,19 @@ export function dunningDeadlineCountdown(deadline: string | null, now = Date.now
 
 export function collectionFailureMessage(code: string | null): string | null {
 	if (code === "insufficient_balance") return "The wallet balance was too low.";
-	if (code === "open_refund_debt") return "A wallet refund is still settling.";
+	if (code === "open_refund_debt") {
+		return "New Wallet funds repay refund debt before compute charges.";
+	}
 	return null;
+}
+
+export function fixPaymentRequestForDunning(
+	state: Pick<ComputeDunningState, "fallbackOccurredAt" | "fundingSource">,
+	deploymentId: string,
+): ComputeFixPaymentRequest {
+	return state.fundingSource === "stripe" && state.fallbackOccurredAt
+		? {}
+		: { deployment_id: deploymentId };
 }
 
 export function computeDunningState(deployment: DunningDeployment): ComputeDunningState | null {
@@ -88,13 +113,19 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 					? "Basic compute"
 					: "paid compute";
 		const stopped = deployment.status.toLowerCase() === "stopped";
+		const recoveryPlanSlug: ComputePlanSlug | null =
+			fallback.prior_plan_slug === "compute_performance"
+				? "compute_performance"
+				: fallback.prior_plan_slug === "compute_basic"
+					? "compute_basic"
+					: null;
 		const fallbackPresentation = (() => {
 			switch (fallback.reason) {
 				case "payment_failure":
 					return {
 						tone: "destructive" as const,
 						title: walletRecovery ? "Wallet compute funding ended" : "Compute funding ended",
-						ctaTarget: walletRecovery ? ("wallet" as const) : ("portal" as const),
+						ctaTarget: walletRecovery ? ("wallet_reactivate" as const) : ("portal" as const),
 						tileLabel: walletRecovery ? "Wallet funding ended" : "Compute funding ended",
 						tileTextClass: "text-destructive",
 					};
@@ -152,14 +183,17 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 			fallbackOccurredAt: fallback.occurred_at,
 			fallbackPlanLabel,
 			fallbackReason: fallback.reason,
+			recoveryPlanSlug,
 			tileTitle: stopped
 				? `${fallbackPlanLabel} stopped after its funding ended.`
 				: `${fallbackPlanLabel} fell back to included Basic after its funding ended.`,
 		};
 	}
 	if (subscription.payment_state === "ok") return null;
-	const computeName = deployment.config_info
-		? `${computeTierLabel(deployment.config_info.compute_plan_slug)} compute`
+	const recoveryPlanSlug =
+		pendingComputePlanSlug(subscription) ?? deployment.config_info?.compute_plan_slug ?? null;
+	const computeName = recoveryPlanSlug
+		? `${computeTierLabel(recoveryPlanSlug)} compute`
 		: "paid compute";
 	const fundingSource = subscription.funding_source ?? "stripe";
 	const recoveryAction =
@@ -182,6 +216,7 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 		fallbackOccurredAt: null,
 		fallbackPlanLabel: null,
 		fallbackReason: null,
+		recoveryPlanSlug,
 	};
 
 	if (walletRecovery && subscription.payment_state === "past_due") {
@@ -191,7 +226,7 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 			tone: "warning",
 			title: "Wallet payment failed",
 			description: `The latest ${computeName} debit failed. Your resources stay available during the 72-hour grace period; top up, then retry the payment.`,
-			ctaTarget: "wallet",
+			ctaTarget: "wallet_retry",
 			tileLabel: "Wallet payment past due",
 			tileTitle: "Top up and retry before the compute grace period ends.",
 			tileTextClass: "text-warning-muted-foreground",
@@ -204,8 +239,8 @@ export function computeDunningState(deployment: DunningDeployment): ComputeDunni
 			paymentState: "unpaid",
 			tone: "destructive",
 			title: "Wallet compute funding ended",
-			description: `The grace period ended. The deployment fell back to included Basic when a slot was available; otherwise it stopped. Top up and retry to re-activate paid ${computeName}.`,
-			ctaTarget: "wallet",
+			description: `The grace period ended. The deployment fell back to included Basic when a slot was available; otherwise it stopped. Reactivate ${computeName} to start a new subscription.`,
+			ctaTarget: "wallet_reactivate",
 			tileLabel: "Wallet funding ended",
 			tileTitle: "Paid compute fell back to included Basic or stopped after the grace period.",
 			tileTextClass: "text-destructive",

--- a/apps/web/src/hosted/billing/components/low-balance-banner.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/low-balance-banner.logic.test.ts
@@ -5,6 +5,7 @@ import { lowBalanceBannerState } from "./low-balance-banner.logic";
 function wallet(over: Partial<WalletState> = {}): WalletState {
 	return {
 		balance_credits: 50_000,
+		overdraft_credits: 0,
 		balance_snapshot_at: null,
 		payment_mode: "card",
 		x402_enabled: true,

--- a/apps/web/src/hosted/billing/deploy/deploy-wallet.logic.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wallet.logic.test.ts
@@ -21,13 +21,30 @@ describe("walletActivationFailure", () => {
 			kind: "insufficient",
 			code: "insufficient_wallet_balance",
 			shortfallCredits: 14_000.5,
+			topUpCredits: 14_000.5,
+		});
+	});
+
+	test("prefills enough to repay refund debt before the blocked charge", () => {
+		const failure = walletActivationFailure(
+			new BillingApiError(409, "refund debt", {
+				detail: { code: "open_refund_debt", outstanding_debt_credits: "2500.5" },
+			}),
+			9_000,
+		);
+		expect(failure).toMatchObject({
+			kind: "refund_debt",
+			debtCredits: 2_500.5,
+			topUpCredits: 11_500.5,
 		});
 	});
 
 	test("separates conflicts from retryable ambiguous failures", () => {
 		expect(
 			walletActivationFailure(
-				new BillingApiError(409, "conflict", { detail: { code: "open_refund_debt" } }),
+				new BillingApiError(409, "conflict", {
+					detail: { code: "deploy_request_funding_conflict" },
+				}),
 			).kind,
 		).toBe("conflict");
 		expect(

--- a/apps/web/src/hosted/billing/deploy/deploy-wallet.logic.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wallet.logic.ts
@@ -7,19 +7,25 @@ import {
 	isNetworkError,
 	isRetryableError,
 	walletComputeErrorDetail,
+	walletRefundDebtCredits,
 } from "@/hosted/billing/errors";
 import { decimalCredits } from "@/hosted/billing/wallet/wallet-compute.logic";
 
 export type DeployPaymentMethod = "card" | "wallet";
 
 export type WalletActivationFailure = {
-	kind: "insufficient" | "conflict" | "retryable" | "other";
+	kind: "insufficient" | "refund_debt" | "conflict" | "retryable" | "other";
 	code: string | null;
 	shortfallCredits: number | null;
+	debtCredits: number | null;
+	topUpCredits: number | null;
 	description: string;
 };
 
-export function walletActivationFailure(error: unknown): WalletActivationFailure {
+export function walletActivationFailure(
+	error: unknown,
+	blockedChargeCredits = 0,
+): WalletActivationFailure {
 	const detail = walletComputeErrorDetail(error);
 	const code = typeof detail === "string" ? null : (detail?.code ?? null);
 	if (error instanceof BillingApiError && error.status === 402) {
@@ -31,18 +37,32 @@ export function walletActivationFailure(error: unknown): WalletActivationFailure
 			kind: "insufficient",
 			code,
 			shortfallCredits: shortfall === null ? null : decimalCredits(shortfall),
+			debtCredits: null,
+			topUpCredits: shortfall === null ? null : decimalCredits(shortfall),
 			description: "Your wallet does not have enough credits for the first compute charge.",
 		};
 	}
 	if (error instanceof BillingApiError && error.status === 409) {
+		const debtCredits = walletRefundDebtCredits(error);
+		if (debtCredits !== null) {
+			return {
+				kind: "refund_debt",
+				code,
+				shortfallCredits: null,
+				debtCredits,
+				topUpCredits: debtCredits + Math.max(0, blockedChargeCredits),
+				description:
+					"Top up to repay the outstanding refund debt first, then cover the compute charge.",
+			};
+		}
 		return {
 			kind: "conflict",
 			code,
 			shortfallCredits: null,
+			debtCredits: null,
+			topUpCredits: null,
 			description:
-				code === "open_refund_debt"
-					? "A wallet refund is still settling. Wait for it to finish before funding compute."
-					: "Another billing action owns this deploy request. Refresh the quote before trying again.",
+				"Another billing action owns this deploy request. Refresh the quote before trying again.",
 		};
 	}
 	const retryablePayload = detail !== null && typeof detail !== "string" && "retryable" in detail;
@@ -54,6 +74,8 @@ export function walletActivationFailure(error: unknown): WalletActivationFailure
 			kind: "retryable",
 			code,
 			shortfallCredits: null,
+			debtCredits: null,
+			topUpCredits: null,
 			description:
 				"The wallet charge result is temporarily unclear. Retry with the same deploy request; you will not be charged twice.",
 		};
@@ -62,6 +84,8 @@ export function walletActivationFailure(error: unknown): WalletActivationFailure
 		kind: "other",
 		code,
 		shortfallCredits: null,
+		debtCredits: null,
+		topUpCredits: null,
 		description: "Wallet funding could not be completed. Check the details and try again.",
 	};
 }
@@ -105,13 +129,15 @@ export async function resolveWalletDeploymentId(
 	if (activation.deployment_id) {
 		return { kind: "resolved", deploymentId: activation.deployment_id };
 	}
+	const deployRequestId = activation.deploy_request_id;
+	if (!deployRequestId) return { kind: "pending" };
 	const maxAttempts = Math.max(1, options.maxAttempts ?? 5);
 	const delay = options.delay ?? wait;
 
 	for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
 		try {
-			const status = await lookup(activation.deploy_request_id);
-			if (status.deploy_request_id !== activation.deploy_request_id) {
+			const status = await lookup(deployRequestId);
+			if (status.deploy_request_id !== deployRequestId) {
 				throw new Error("Deployment request lookup returned a mismatched request ID.");
 			}
 			if (status.deployment_id) {

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -91,7 +91,11 @@ import {
 	supportedTimezones,
 	TimezoneCombobox,
 } from "@/hosted/billing/deploy/language-timezone-controls";
-import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
+import {
+	billingErrorNormalizer,
+	isIdempotencyKeyReusedError,
+	normalizeBillingError,
+} from "@/hosted/billing/errors";
 import {
 	billingTermLabel,
 	billingTermSuffix,
@@ -131,6 +135,7 @@ import {
 } from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
+import { topUpAmountCentsForCreditShortfall } from "@/hosted/billing/wallet/top-up-dialog.logic";
 import { decimalCredits } from "@/hosted/billing/wallet/wallet-compute.logic";
 import { runtimeBlurb, runtimeDisplayName } from "@/hosted/runtimes";
 import { AddProviderDialog } from "@/hosted/v2/ai-providers/add-provider-dialog";
@@ -747,16 +752,25 @@ export function DeployWizard() {
 
 	async function fallbackToHostedCheckout(request: CheckoutRequest) {
 		const hostedBody = buildHostedCheckoutFallbackRequest(request);
+		const fingerprint = idempotencyFingerprint(hostedBody);
 		checkoutAttemptRef.current = idempotencyAttemptFor(
 			checkoutAttemptRef.current,
 			"subscription-checkout-hosted-fallback",
-			idempotencyFingerprint(hostedBody),
+			fingerprint,
 			newIdempotencyKey,
 		);
-		const result = await checkout.mutateAsync({
-			body: hostedBody,
-			idempotencyKey: checkoutAttemptRef.current.key,
-		});
+		const result = await checkout
+			.mutateAsync({
+				body: hostedBody,
+				idempotencyKey: checkoutAttemptRef.current.key,
+			})
+			.catch((error: unknown) => {
+				if (isIdempotencyKeyReusedError(error)) {
+					forgetIdempotencyAttempt("subscription-checkout-hosted-fallback", fingerprint);
+					checkoutAttemptRef.current = null;
+				}
+				throw error;
+			});
 		if (redirectTo(checkoutRedirectUrl(result))) return;
 		throw new Error("No checkout URL was returned.");
 	}
@@ -829,15 +843,28 @@ export function DeployWizard() {
 							},
 						});
 					} catch (error) {
-						const failure = walletActivationFailure(error);
+						if (isIdempotencyKeyReusedError(error)) {
+							forgetIdempotencyAttempt("wallet-compute-deploy", fingerprint);
+							walletDeployAttemptRef.current = null;
+						}
+						const failure = walletActivationFailure(
+							error,
+							decimalCredits(walletQuote.data?.first_charge_credits),
+						);
 						setWalletFailure(failure);
-						if (failure.kind === "insufficient") setTopUpOpen(true);
+						if (failure.kind === "insufficient" || failure.kind === "refund_debt") {
+							setTopUpOpen(true);
+						}
 						toast.error(
 							failure.kind === "insufficient"
 								? "Wallet balance too low"
-								: failure.kind === "conflict"
-									? "Wallet funding conflict"
-									: "Couldn’t fund compute from Wallet",
+								: failure.kind === "refund_debt"
+									? "Top up to clear refund debt"
+									: failure.kind === "conflict"
+										? isIdempotencyKeyReusedError(error)
+											? "Start a fresh wallet attempt"
+											: "Wallet funding conflict"
+										: "Couldn’t fund compute from Wallet",
 							{ description: failure.description },
 						);
 						return;
@@ -882,16 +909,25 @@ export function DeployWizard() {
 					ui_mode: CHECKOUT_ELEMENTS_UI_MODE,
 					deploy_config: deployConfig,
 				};
+				const checkoutFingerprint = idempotencyFingerprint(body);
 				checkoutAttemptRef.current = idempotencyAttemptFor(
 					checkoutAttemptRef.current,
 					"subscription-checkout",
-					idempotencyFingerprint(body),
+					checkoutFingerprint,
 					newIdempotencyKey,
 				);
-				const result = await checkout.mutateAsync({
-					body,
-					idempotencyKey: checkoutAttemptRef.current.key,
-				});
+				const result = await checkout
+					.mutateAsync({
+						body,
+						idempotencyKey: checkoutAttemptRef.current.key,
+					})
+					.catch((error: unknown) => {
+						if (isIdempotencyKeyReusedError(error)) {
+							forgetIdempotencyAttempt("subscription-checkout", checkoutFingerprint);
+							checkoutAttemptRef.current = null;
+						}
+						throw error;
+					});
 				if (hasCheckoutClientSecret(result)) {
 					setCheckoutSession({
 						clientSecret: result.client_secret,
@@ -915,17 +951,26 @@ export function DeployWizard() {
 			}
 			if (compute !== "basic" || basicSelection.mode !== "direct") return;
 			const deployConfig = buildDeployRequest(aiFields, COMPUTE_BASIC_SLUG);
+			const deployFingerprint = idempotencyFingerprint(deployConfig);
 
 			deployAttemptRef.current = idempotencyAttemptFor(
 				deployAttemptRef.current,
 				"deploy",
-				idempotencyFingerprint(deployConfig),
+				deployFingerprint,
 				newIdempotencyKey,
 			);
-			const deployment = await createDeployment.mutateAsync({
-				body: deployConfig,
-				idempotencyKey: deployAttemptRef.current.key,
-			});
+			const deployment = await createDeployment
+				.mutateAsync({
+					body: deployConfig,
+					idempotencyKey: deployAttemptRef.current.key,
+				})
+				.catch((error: unknown) => {
+					if (isIdempotencyKeyReusedError(error)) {
+						forgetIdempotencyAttempt("deploy", deployFingerprint);
+						deployAttemptRef.current = null;
+					}
+					throw error;
+				});
 			toast.success("Deploying your agent", {
 				description: "It’ll appear in your agents in a moment.",
 			});
@@ -1338,7 +1383,8 @@ export function DeployWizard() {
 											</div>
 											{walletQuote.data.warnings?.includes("open_refund_debt") ? (
 												<p className="text-xs text-destructive">
-													A wallet refund is still settling, so this charge may be blocked.
+													Wallet funds repay refund debt before compute charges. Top up enough to
+													cover both before deploying.
 												</p>
 											) : walletQuote.data.warnings?.includes("low_coverage") ? (
 												<p className="text-xs text-warning-muted-foreground">
@@ -1351,15 +1397,21 @@ export function DeployWizard() {
 
 								{walletFailure ? (
 									<Alert
-										variant={walletFailure.kind === "insufficient" ? "default" : "destructive"}
+										variant={
+											walletFailure.kind === "insufficient" || walletFailure.kind === "refund_debt"
+												? "default"
+												: "destructive"
+										}
 									>
 										<TriangleAlert />
 										<AlertTitle>
 											{walletFailure.kind === "insufficient"
 												? "Top up to deploy"
-												: walletFailure.kind === "retryable"
-													? "Wallet response needs a retry"
-													: "Wallet payment didn’t complete"}
+												: walletFailure.kind === "refund_debt"
+													? "Clear refund debt to deploy"
+													: walletFailure.kind === "retryable"
+														? "Wallet response needs a retry"
+														: "Wallet payment didn’t complete"}
 										</AlertTitle>
 										<AlertDescription className="flex flex-col items-start gap-3">
 											<span>
@@ -1368,7 +1420,8 @@ export function DeployWizard() {
 													? ` Shortfall: ${creditsToUsd(walletFailure.shortfallCredits, walletQuote.data.points_per_usd)}.`
 													: ""}
 											</span>
-											{walletFailure.kind === "insufficient" ? (
+											{walletFailure.kind === "insufficient" ||
+											walletFailure.kind === "refund_debt" ? (
 												<Button
 													size="sm"
 													onClick={() => setTopUpOpen(true)}
@@ -1505,6 +1558,16 @@ export function DeployWizard() {
 					onOpenChange={setTopUpOpen}
 					wallet={wallet.data}
 					onComplete={handleWalletTopupComplete}
+					initialAmountCents={topUpAmountCentsForCreditShortfall(
+						walletFailure?.topUpCredits ?? null,
+						wallet.data.points_per_usd,
+					)}
+					refundDebtCredits={walletFailure?.debtCredits}
+					blockedChargeCredits={
+						walletFailure?.kind === "refund_debt"
+							? decimalCredits(walletQuote.data?.first_charge_credits)
+							: null
+					}
 				/>
 			) : null}
 		</div>

--- a/apps/web/src/hosted/billing/errors.test.ts
+++ b/apps/web/src/hosted/billing/errors.test.ts
@@ -129,7 +129,7 @@ describe("normalizeBillingError", () => {
 		const unknown = new BillingApiError(409, '{"detail":{"code":"bridge_internal_17"}}', {
 			detail: { code: "bridge_internal_17" },
 		});
-		expect(normalizeBillingError(known)).toContain("refund is still settling");
+		expect(normalizeBillingError(known)).toContain("repay refund debt");
 		expect(normalizeBillingError(unknown)).toBe(
 			"The billing request could not be completed. Refresh and try again.",
 		);
@@ -141,7 +141,7 @@ describe("normalizeBillingError", () => {
 });
 
 describe("walletComputeErrorDetail", () => {
-	test("accepts the retry shortfall and resize-pending generated error variants", () => {
+	test("accepts shortfall and refund-debt generated error variants", () => {
 		const insufficient = walletComputeErrorDetail(
 			new BillingApiError(402, "insufficient", {
 				detail: {
@@ -154,15 +154,17 @@ describe("walletComputeErrorDetail", () => {
 		);
 		expect(insufficient).toMatchObject({ code: "insufficient_balance" });
 
-		const resize = walletComputeErrorDetail(
-			new BillingApiError(502, "resize", {
+		const debt = walletComputeErrorDetail(
+			new BillingApiError(409, "refund debt", {
 				detail: {
-					code: "resize_failed_retryable",
-					failure_code: "deployment_resize_failed",
-					retryable: true,
+					code: "open_refund_debt",
+					outstanding_debt_credits: "2500.5",
 				},
 			}),
 		);
-		expect(resize).toMatchObject({ code: "resize_failed_retryable" });
+		expect(debt).toMatchObject({
+			code: "open_refund_debt",
+			outstanding_debt_credits: "2500.5",
+		});
 	});
 });

--- a/apps/web/src/hosted/billing/errors.ts
+++ b/apps/web/src/hosted/billing/errors.ts
@@ -86,8 +86,7 @@ function isWalletComputeUpstreamDetail(
 	return (
 		(value.code === "wallet_balance_refresh_failed" ||
 			value.code === "wallet_compute_charge_failed" ||
-			value.code === "wallet_compute_upstream_failed" ||
-			value.code === "resize_failed_retryable") &&
+			value.code === "wallet_compute_upstream_failed") &&
 		value.retryable === true &&
 		(value.failure_code === undefined ||
 			value.failure_code === null ||
@@ -98,10 +97,12 @@ function isWalletComputeUpstreamDetail(
 function isWalletComputeConflictDetail(
 	value: Record<string, unknown>,
 ): value is Exclude<WalletComputeConflictError["detail"], string> {
+	if (value.code === "open_refund_debt") {
+		return typeof value.outstanding_debt_credits === "string";
+	}
 	return (
 		value.code === "deploy_request_funding_conflict" ||
 		value.code === "idempotency_key_reused" ||
-		value.code === "open_refund_debt" ||
 		(typeof value.code === "string" && value.retryable === true)
 	);
 }
@@ -114,6 +115,24 @@ export function walletComputeErrorDetail(error: unknown): WalletComputeErrorDeta
 	if (isWalletComputeUpstreamDetail(detail)) return detail;
 	if (isWalletComputeConflictDetail(detail)) return detail;
 	return null;
+}
+
+export function isIdempotencyKeyReusedError(error: unknown): boolean {
+	return billingErrorDetail(error)?.code === "idempotency_key_reused";
+}
+
+export function walletRefundDebtCredits(error: unknown): number | null {
+	const detail = walletComputeErrorDetail(error);
+	if (
+		!detail ||
+		typeof detail === "string" ||
+		detail.code !== "open_refund_debt" ||
+		!("outstanding_debt_credits" in detail)
+	) {
+		return null;
+	}
+	const credits = Number(detail.outstanding_debt_credits);
+	return Number.isFinite(credits) && credits > 0 ? credits : null;
 }
 
 /**
@@ -219,13 +238,13 @@ export function normalizeBillingError(error: unknown): string {
 	if (error instanceof BillingApiError) {
 		const code = billingErrorDetail(error)?.code;
 		if (code === "open_refund_debt") {
-			return "A wallet refund is still settling. Try again after it completes.";
+			return "Top up your Wallet to continue. New funds repay refund debt before compute charges.";
 		}
 		if (code === "deploy_request_funding_conflict") {
 			return "This deploy request is already linked to a different payment flow.";
 		}
 		if (code === "idempotency_key_reused") {
-			return "This payment request conflicts with an earlier attempt. Refresh and try again.";
+			return "This attempt conflicts with an earlier request. Review the details and submit again for a fresh attempt.";
 		}
 		if (typeof code === "string") {
 			return "The billing request could not be completed. Refresh and try again.";

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -8,6 +8,7 @@ import {
 	checkoutReturnWasCanceled,
 	refreshCheckoutReturnQueries,
 	shouldPollWalletDunningFor,
+	walletDunningRefetchIntervalFor,
 } from "@/hosted/billing/hooks";
 
 function deployment(
@@ -181,6 +182,22 @@ describe("shouldPollWalletDunningFor", () => {
 			active.compute_subscription.current_period_end = "2026-08-16T00:00:00Z";
 		}
 		expect(shouldPollWalletDunningFor([active], active.id, now)).toBe(false);
+		expect(walletDunningRefetchIntervalFor([active], active.id, now)).toBe(2_000_000_000);
+	});
+
+	test("schedules a wake-up before a future collection boundary", () => {
+		const active = deployment({
+			status: "active",
+			funding_source: "wallet",
+			payment_state: "ok",
+			billing_term_months: 1,
+			price_cents: 900,
+			currency: "usd",
+			cancel_at_period_end: false,
+			current_period_end: "2026-07-16T00:10:00Z",
+		});
+		active.id = "hdep_active";
+		expect(walletDunningRefetchIntervalFor([active], active.id, now)).toBe(540_000);
 	});
 
 	test("does not poll terminal wallet states", () => {

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -145,6 +145,8 @@ describe("refreshCheckoutReturnQueries", () => {
 });
 
 describe("shouldPollWalletDunningFor", () => {
+	const now = Date.parse("2026-07-16T00:00:00Z");
+
 	test("polls only the visible wallet grace deployment", () => {
 		const due = deployment({
 			status: "past_due",
@@ -157,8 +159,44 @@ describe("shouldPollWalletDunningFor", () => {
 			cancel_at_period_end: false,
 		});
 		due.id = "hdep_due";
-		expect(shouldPollWalletDunningFor([due], "hdep_due")).toBe(true);
-		expect(shouldPollWalletDunningFor([due], "hdep_other")).toBe(false);
+		expect(shouldPollWalletDunningFor([due], "hdep_due", now)).toBe(true);
+		expect(shouldPollWalletDunningFor([due], "hdep_other", now)).toBe(false);
+	});
+
+	test("starts before an active wallet collection boundary and stops after settlement", () => {
+		const active = deployment({
+			status: "active",
+			funding_source: "wallet",
+			payment_state: "ok",
+			billing_term_months: 1,
+			price_cents: 900,
+			currency: "usd",
+			cancel_at_period_end: false,
+			current_period_end: "2026-07-16T00:00:30Z",
+		});
+		active.id = "hdep_active";
+		expect(shouldPollWalletDunningFor([active], active.id, now)).toBe(true);
+
+		if (active.compute_subscription) {
+			active.compute_subscription.current_period_end = "2026-08-16T00:00:00Z";
+		}
+		expect(shouldPollWalletDunningFor([active], active.id, now)).toBe(false);
+	});
+
+	test("does not poll terminal wallet states", () => {
+		const unpaid = deployment({
+			status: "unpaid",
+			funding_source: "wallet",
+			payment_state: "unpaid",
+			recovery_action: "top_up",
+			billing_term_months: 1,
+			price_cents: 900,
+			currency: "usd",
+			cancel_at_period_end: false,
+			current_period_end: "2026-07-16T00:00:00Z",
+		});
+		unpaid.id = "hdep_unpaid";
+		expect(shouldPollWalletDunningFor([unpaid], unpaid.id, now)).toBe(false);
 	});
 });
 

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -415,6 +415,7 @@ export function useUsage() {
 export function shouldPollWalletDunningFor(
 	deployments: readonly HostedDeployment[] | undefined,
 	targetId: string | null | undefined,
+	now = Date.now(),
 ): boolean {
 	const target = targetId?.toLowerCase();
 	if (!target) return false;
@@ -426,11 +427,21 @@ export function shouldPollWalletDunningFor(
 			);
 		if (!matchesTarget) return false;
 		const subscription = deployment.compute_subscription;
-		if (subscription?.payment_state !== "past_due") return false;
-		return (
-			subscription.recovery_action === "top_up" ||
-			(!subscription.recovery_action && subscription.funding_source === "wallet")
-		);
+		const walletFunded =
+			subscription?.funding_source === "wallet" || subscription?.recovery_action === "top_up";
+		if (!subscription || !walletFunded) return false;
+		if (subscription.payment_state === "past_due") return true;
+		if (subscription.payment_state !== "ok") return false;
+		const status = subscription.status.toLowerCase();
+		if (status !== "active" && status !== "trialing") return false;
+		const collectionBoundary =
+			subscription.next_collection_attempt_at ?? subscription.current_period_end ?? null;
+		if (!collectionBoundary) return false;
+		const boundaryMs = Date.parse(collectionBoundary);
+		if (!Number.isFinite(boundaryMs)) return false;
+		// Start shortly before the collection boundary. A successful collection
+		// advances the projected period, while past_due keeps polling through grace.
+		return boundaryMs - now <= 60_000;
 	});
 }
 

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -412,37 +412,55 @@ export function useUsage() {
 
 // ── Deployments ────────────────────────────────────────────────────────────────
 
+const WALLET_DUNNING_POLL_INTERVAL_MS = 30_000;
+const WALLET_DUNNING_LEAD_TIME_MS = 60_000;
+const WALLET_DUNNING_MAX_WAKE_INTERVAL_MS = 2_000_000_000;
+
+export function walletDunningRefetchIntervalFor(
+	deployments: readonly HostedDeployment[] | undefined,
+	targetId: string | null | undefined,
+	now = Date.now(),
+): number | false {
+	const target = targetId?.toLowerCase();
+	if (!target) return false;
+	const deployment = (deployments ?? []).find((candidate) => {
+		const matchesTarget =
+			candidate.id.toLowerCase() === target ||
+			Object.values(candidate.config_info?.clawdi_cloud_environments ?? {}).some(
+				(environmentId) => environmentId?.toLowerCase() === target,
+			);
+		return matchesTarget;
+	});
+	const subscription = deployment?.compute_subscription;
+	const walletFunded =
+		subscription?.funding_source === "wallet" || subscription?.recovery_action === "top_up";
+	if (!subscription || !walletFunded) return false;
+	if (subscription.payment_state === "past_due") return WALLET_DUNNING_POLL_INTERVAL_MS;
+	if (subscription.payment_state !== "ok") return false;
+	const status = subscription.status.toLowerCase();
+	if (status !== "active" && status !== "trialing") return false;
+	const collectionBoundary =
+		subscription.next_collection_attempt_at ?? subscription.current_period_end ?? null;
+	if (!collectionBoundary) return false;
+	const boundaryMs = Date.parse(collectionBoundary);
+	if (!Number.isFinite(boundaryMs)) return false;
+	const untilPollingWindow = boundaryMs - now - WALLET_DUNNING_LEAD_TIME_MS;
+	if (untilPollingWindow <= 0) return WALLET_DUNNING_POLL_INTERVAL_MS;
+	// Wake the query up before the cached boundary even when the page opened
+	// earlier in the billing period. Cap long timers below the browser's signed
+	// 32-bit timeout limit; ordinary query invalidations still reconcile a
+	// changed backend boundary sooner.
+	return Math.min(untilPollingWindow, WALLET_DUNNING_MAX_WAKE_INTERVAL_MS);
+}
+
 export function shouldPollWalletDunningFor(
 	deployments: readonly HostedDeployment[] | undefined,
 	targetId: string | null | undefined,
 	now = Date.now(),
 ): boolean {
-	const target = targetId?.toLowerCase();
-	if (!target) return false;
-	return (deployments ?? []).some((deployment) => {
-		const matchesTarget =
-			deployment.id.toLowerCase() === target ||
-			Object.values(deployment.config_info?.clawdi_cloud_environments ?? {}).some(
-				(environmentId) => environmentId?.toLowerCase() === target,
-			);
-		if (!matchesTarget) return false;
-		const subscription = deployment.compute_subscription;
-		const walletFunded =
-			subscription?.funding_source === "wallet" || subscription?.recovery_action === "top_up";
-		if (!subscription || !walletFunded) return false;
-		if (subscription.payment_state === "past_due") return true;
-		if (subscription.payment_state !== "ok") return false;
-		const status = subscription.status.toLowerCase();
-		if (status !== "active" && status !== "trialing") return false;
-		const collectionBoundary =
-			subscription.next_collection_attempt_at ?? subscription.current_period_end ?? null;
-		if (!collectionBoundary) return false;
-		const boundaryMs = Date.parse(collectionBoundary);
-		if (!Number.isFinite(boundaryMs)) return false;
-		// Start shortly before the collection boundary. A successful collection
-		// advances the projected period, while past_due keeps polling through grace.
-		return boundaryMs - now <= 60_000;
-	});
+	return (
+		walletDunningRefetchIntervalFor(deployments, targetId, now) === WALLET_DUNNING_POLL_INTERVAL_MS
+	);
 }
 
 export function useHostedDeployments({
@@ -459,10 +477,7 @@ export function useHostedDeployments({
 		queryFn: () => client.listDeployments(),
 		refetchInterval: (q) => {
 			if (shouldPollDeployments(q.state.data)) return 10_000;
-			if (shouldPollWalletDunningFor(q.state.data, pollWalletDunningFor)) {
-				return 30_000;
-			}
-			return false;
+			return walletDunningRefetchIntervalFor(q.state.data, pollWalletDunningFor);
 		},
 	});
 }

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -6,11 +6,14 @@ import {
 	computeFundingMode,
 	computeFundingSource,
 	computeSubscriptionId,
+	computeSubscriptionLifecycle,
 	computeTierLabel,
 	isBasicCompute,
 	isComputeSubscriptionCancelable,
+	isComputeSubscriptionRenewing,
 	isComputeSubscriptionTermChangeable,
 	pendingComputePlanSlug,
+	pendingPlanScheduleCopy,
 	resolveBasicPlan,
 	resolvePerformancePlan,
 	selectExplicitOfferForTerm,
@@ -223,5 +226,57 @@ describe("compute subscription action status gates", () => {
 		expect(isComputeSubscriptionTermChangeable({ status: "past_due" })).toBe(false);
 		expect(isComputeSubscriptionTermChangeable({ status: "unpaid" })).toBe(false);
 		expect(isComputeSubscriptionTermChangeable(undefined)).toBe(false);
+	});
+});
+
+describe("compute subscription lifecycle presentation", () => {
+	test("only renewing states present as renewing", () => {
+		for (const status of ["active", "trialing", "past_due"]) {
+			expect(isComputeSubscriptionRenewing({ ...subscription(), status }), status).toBe(true);
+		}
+		for (const status of ["unpaid", "paused", "incomplete", "canceled", "expired"]) {
+			expect(isComputeSubscriptionRenewing({ ...subscription(), status }), status).toBe(false);
+		}
+		expect(isComputeSubscriptionRenewing({ ...subscription(), cancel_at_period_end: true })).toBe(
+			false,
+		);
+	});
+
+	test("labels terminal and non-entitled states honestly", () => {
+		expect(computeSubscriptionLifecycle({ ...subscription(), status: "paused" })).toMatchObject({
+			badgeLabel: "Paused",
+			renews: false,
+		});
+		expect(computeSubscriptionLifecycle({ ...subscription(), status: "incomplete" })).toMatchObject(
+			{ badgeLabel: "Setup incomplete", renews: false },
+		);
+		expect(computeSubscriptionLifecycle({ ...subscription(), status: "canceled" })).toMatchObject({
+			badgeLabel: "Canceled",
+			dateVerb: "Canceled",
+			renews: false,
+		});
+		expect(computeSubscriptionLifecycle({ ...subscription(), status: "expired" })).toMatchObject({
+			badgeLabel: "Expired",
+			renews: false,
+		});
+	});
+
+	test("does not claim an overdue pending plan boundary is still scheduled", () => {
+		expect(
+			pendingPlanScheduleCopy(
+				"compute_basic",
+				"2026-07-01T00:00:00Z",
+				"Jul 1, 2026",
+				Date.parse("2026-07-02T00:00:00Z"),
+			),
+		).toBe("Basic plan change is awaiting renewal processing.");
+		expect(
+			pendingPlanScheduleCopy(
+				"compute_basic",
+				"2026-08-01T00:00:00Z",
+				"Aug 1, 2026",
+				Date.parse("2026-07-02T00:00:00Z"),
+			),
+		).toBe("Basic scheduled for Aug 1, 2026.");
 	});
 });

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -93,6 +93,99 @@ export function pendingComputePlanSlug(
 		: null;
 }
 
+const COMPUTE_RENEWING_STATUSES = new Set(["trialing", "active", "past_due"]);
+
+export function isComputeSubscriptionRenewing(
+	subscription: HostedDeployment["compute_subscription"] | null | undefined,
+): boolean {
+	if (!subscription || subscription.cancel_at_period_end) return false;
+	return (
+		COMPUTE_RENEWING_STATUSES.has(subscription.status.toLowerCase()) &&
+		subscription.payment_state !== "unpaid"
+	);
+}
+
+export type ComputeSubscriptionLifecycle = {
+	badgeLabel: string;
+	dateAt: string | null;
+	dateVerb: string | null;
+	renews: boolean;
+};
+
+export function computeSubscriptionLifecycle(
+	subscription: NonNullable<HostedDeployment["compute_subscription"]>,
+): ComputeSubscriptionLifecycle {
+	const status = subscription.status.toLowerCase();
+	const canceledAt = subscription.canceled_at ?? subscription.current_period_end ?? null;
+	if (subscription.cancel_at_period_end && COMPUTE_RENEWING_STATUSES.has(status)) {
+		return {
+			badgeLabel: "Canceling",
+			dateAt: subscription.cancel_at ?? subscription.current_period_end ?? null,
+			dateVerb: "Ends",
+			renews: false,
+		};
+	}
+	if (status === "active") {
+		return {
+			badgeLabel: "Current",
+			dateAt: subscription.current_period_end ?? null,
+			dateVerb: "Renews",
+			renews: true,
+		};
+	}
+	if (status === "trialing") {
+		return {
+			badgeLabel: "Trial",
+			dateAt: subscription.current_period_end ?? null,
+			dateVerb: "Renews",
+			renews: true,
+		};
+	}
+	if (status === "past_due") {
+		return {
+			badgeLabel: "Payment past due",
+			dateAt: subscription.dunning_deadline_at ?? null,
+			dateVerb: subscription.dunning_deadline_at ? "Grace ends" : null,
+			renews: true,
+		};
+	}
+	if (status === "unpaid") {
+		return { badgeLabel: "Unpaid", dateAt: canceledAt, dateVerb: "Ended", renews: false };
+	}
+	if (status === "paused") {
+		return { badgeLabel: "Paused", dateAt: null, dateVerb: null, renews: false };
+	}
+	if (status === "incomplete") {
+		return { badgeLabel: "Setup incomplete", dateAt: null, dateVerb: null, renews: false };
+	}
+	if (status === "canceled") {
+		return { badgeLabel: "Canceled", dateAt: canceledAt, dateVerb: "Canceled", renews: false };
+	}
+	if (status === "expired" || status === "incomplete_expired") {
+		return { badgeLabel: "Expired", dateAt: canceledAt, dateVerb: "Expired", renews: false };
+	}
+	return {
+		badgeLabel: status.replace(/_/g, " ").replace(/\b\w/g, (character) => character.toUpperCase()),
+		dateAt: null,
+		dateVerb: null,
+		renews: false,
+	};
+}
+
+export function pendingPlanScheduleCopy(
+	planSlug: ComputePlanSlug,
+	effectiveAt: string | null | undefined,
+	dateLabel: string,
+	now = Date.now(),
+): string {
+	const planLabel = computeTierLabel(planSlug);
+	const effectiveMs = effectiveAt ? Date.parse(effectiveAt) : Number.NaN;
+	if (Number.isFinite(effectiveMs) && effectiveMs > now) {
+		return `${planLabel} scheduled for ${dateLabel}.`;
+	}
+	return `${planLabel} plan change is awaiting renewal processing.`;
+}
+
 export function computeTierLabel(
 	planSlug: ComputePlanSlug | null | undefined,
 ): "Basic" | "Performance" {

--- a/apps/web/src/hosted/billing/subscription/wallet-plan-change.logic.test.ts
+++ b/apps/web/src/hosted/billing/subscription/wallet-plan-change.logic.test.ts
@@ -18,51 +18,39 @@ describe("wallet plan change logic", () => {
 			subscription_id: 1,
 			current_plan_slug: "compute_basic",
 			target_plan_slug: "legacy_plan",
-			change_kind: "upgrade" as const,
 			status: "quoted",
-			effective_at: "2026-07-15T00:00:00Z",
-			period_start: "2026-07-01T00:00:00Z",
-			period_end: "2026-08-01T00:00:00Z",
-			prorated_delta_cents: 700,
-			prorated_delta_credits: "7000",
+			effective_at: "2026-08-01T00:00:00Z",
+			amount_cents: 1_900,
+			amount_credits: "19000",
 			points_per_usd: 1000,
 		};
 		expect(walletPlanResultTarget(quote)).toBeNull();
 	});
 
-	test("describes immediate upgrades and scheduled downgrades", () => {
+	test("describes both directions as next-renewal changes", () => {
 		const base = {
 			subscription_id: 1,
 			current_plan_slug: "compute_basic",
 			target_plan_slug: "compute_performance",
 			status: "quoted",
-			effective_at: "2026-07-15T00:00:00Z",
-			period_start: "2026-07-01T00:00:00Z",
-			period_end: "2026-08-01T00:00:00Z",
-			prorated_delta_cents: 700,
-			prorated_delta_credits: "7000",
+			effective_at: "2026-08-01T00:00:00Z",
+			amount_cents: 1_900,
+			amount_credits: "19000",
 			points_per_usd: 1000,
 		};
-		expect(walletPlanChangeSummary({ ...base, change_kind: "upgrade" })).toContain(
-			"resizes immediately",
-		);
-		expect(walletPlanChangeSummary({ ...base, change_kind: "downgrade" })).toContain(
-			"next renewal",
+		expect(walletPlanChangeSummary(base)).toBe(
+			"Changes at next renewal on Aug 1, 2026 · then $19.00/mo.",
 		);
 	});
 
-	test("classifies a plan-change shortfall", () => {
-		const failure = walletPlanChangeFailure(
-			new BillingApiError(402, "insufficient", {
-				detail: {
-					code: "insufficient_wallet_balance",
-					required_credits: "7000.0",
-					available_credits: "4499.5",
-					shortfall_credits: "2500.5",
-				},
-			}),
-		);
-		expect(failure).toEqual({ kind: "insufficient", shortfallCredits: 2500.5 });
+	test("extracts actionable refund debt from a plan-change conflict", () => {
+		expect(
+			walletPlanChangeFailure(
+				new BillingApiError(409, "refund debt", {
+					detail: { code: "open_refund_debt", outstanding_debt_credits: "2500.5" },
+				}),
+			),
+		).toEqual({ kind: "refund_debt", debtCredits: 2500.5 });
 	});
 
 	test("keeps typed upstream failures retryable", () => {
@@ -76,20 +64,6 @@ describe("wallet plan change logic", () => {
 					},
 				}),
 			),
-		).toEqual({ kind: "retryable", shortfallCredits: null });
-	});
-
-	test("distinguishes a charged upgrade awaiting resize", () => {
-		expect(
-			walletPlanChangeFailure(
-				new BillingApiError(502, "resize", {
-					detail: {
-						code: "resize_failed_retryable",
-						failure_code: "deployment_resize_failed",
-						retryable: true,
-					},
-				}),
-			),
-		).toEqual({ kind: "resize_pending", shortfallCredits: null });
+		).toEqual({ kind: "retryable", debtCredits: null });
 	});
 });

--- a/apps/web/src/hosted/billing/subscription/wallet-plan-change.logic.ts
+++ b/apps/web/src/hosted/billing/subscription/wallet-plan-change.logic.ts
@@ -1,11 +1,12 @@
 import type { ComputePlanSlug, WalletComputePlanChangeResult } from "@/hosted/billing/contracts";
-import { BillingApiError, isNetworkError, walletComputeErrorDetail } from "@/hosted/billing/errors";
-import { decimalCredits } from "@/hosted/billing/wallet/wallet-compute.logic";
+import { BillingApiError, isNetworkError, walletRefundDebtCredits } from "@/hosted/billing/errors";
+import { formatCents } from "@/hosted/billing/format";
+import { formatShortDate } from "@/lib/format";
 import { COMPUTE_BASIC_SLUG, COMPUTE_PERFORMANCE_SLUG } from "./subscription-utils";
 
 export type WalletPlanChangeFailure = {
-	kind: "insufficient" | "conflict" | "resize_pending" | "retryable" | "other";
-	shortfallCredits: number | null;
+	kind: "refund_debt" | "conflict" | "retryable" | "other";
+	debtCredits: number | null;
 };
 
 export function walletPlanTarget(
@@ -25,45 +26,18 @@ export function walletPlanResultTarget(
 }
 
 export function walletPlanChangeFailure(error: unknown): WalletPlanChangeFailure {
-	const detail = walletComputeErrorDetail(error);
-	if (error instanceof BillingApiError && error.status === 402) {
-		const value =
-			detail && typeof detail !== "string" && "shortfall_credits" in detail
-				? detail.shortfall_credits
-				: null;
-		return {
-			kind: "insufficient",
-			shortfallCredits: typeof value === "string" ? decimalCredits(value) : null,
-		};
-	}
 	if (error instanceof BillingApiError && error.status === 409) {
-		return { kind: "conflict", shortfallCredits: null };
+		const debtCredits = walletRefundDebtCredits(error);
+		return debtCredits === null
+			? { kind: "conflict", debtCredits: null }
+			: { kind: "refund_debt", debtCredits };
 	}
-	if (
-		error instanceof BillingApiError &&
-		error.status === 502 &&
-		detail !== null &&
-		typeof detail !== "string" &&
-		"code" in detail &&
-		detail.code === "resize_failed_retryable"
-	) {
-		return { kind: "resize_pending", shortfallCredits: null };
+	if (isNetworkError(error) || (error instanceof BillingApiError && error.status >= 500)) {
+		return { kind: "retryable", debtCredits: null };
 	}
-	if (
-		isNetworkError(error) ||
-		(error instanceof BillingApiError &&
-			error.status >= 500 &&
-			detail !== null &&
-			typeof detail !== "string" &&
-			"retryable" in detail)
-	) {
-		return { kind: "retryable", shortfallCredits: null };
-	}
-	return { kind: "other", shortfallCredits: null };
+	return { kind: "other", debtCredits: null };
 }
 
 export function walletPlanChangeSummary(quote: WalletComputePlanChangeResult): string {
-	return quote.change_kind === "upgrade"
-		? "The prorated difference is charged from Wallet now, then compute resizes immediately."
-		: "The current plan stays active until the next renewal, when the lower monthly charge begins.";
+	return `Changes at next renewal on ${formatShortDate(quote.effective_at)} · then ${formatCents(quote.amount_cents)}/mo.`;
 }

--- a/apps/web/src/hosted/billing/wallet/ledger-table.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.logic.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { WalletLedgerEntry } from "@/hosted/billing/contracts";
-import { filteredLedgerEntries, ledgerEmptyStateCopy } from "./ledger-table.logic";
+import {
+	filteredLedgerEntries,
+	ledgerEmptyStateCopy,
+	ledgerOperationGroup,
+} from "./ledger-table.logic";
 
 function entry(overrides: Partial<WalletLedgerEntry> = {}): WalletLedgerEntry {
 	return {
@@ -21,6 +25,17 @@ describe("filteredLedgerEntries", () => {
 		const filtered = filteredLedgerEntries([entry({ operation: "topup" })], "refund");
 
 		expect(filtered).toEqual([]);
+	});
+
+	test("groups compute charges and reversals under Compute", () => {
+		expect(ledgerOperationGroup("compute_charge")).toBe("compute");
+		expect(ledgerOperationGroup("compute_credit")).toBe("compute");
+		expect(
+			filteredLedgerEntries(
+				[entry({ operation: "compute_charge" }), entry({ id: "entry_2", operation: "topup" })],
+				"compute",
+			).map((item) => item.operation),
+		).toEqual(["compute_charge"]);
 	});
 });
 

--- a/apps/web/src/hosted/billing/wallet/ledger-table.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.logic.ts
@@ -1,8 +1,15 @@
 import type { WalletLedgerEntry } from "@/hosted/billing/contracts";
 
-export type LedgerFilter = "all" | "topup" | "grant" | "usage" | "refund";
+export type LedgerFilter = "all" | "topup" | "grant" | "usage" | "compute" | "refund";
 
-const LEDGER_FILTERS: readonly LedgerFilter[] = ["all", "topup", "grant", "usage", "refund"];
+const LEDGER_FILTERS: readonly LedgerFilter[] = [
+	"all",
+	"topup",
+	"grant",
+	"usage",
+	"compute",
+	"refund",
+];
 
 export interface LedgerEmptyStateCopyInput {
 	entriesCount: number;
@@ -23,6 +30,7 @@ export function ledgerOperationGroup(op: string): LedgerFilter {
 	if (op === "topup" || op === "invoice" || op === "x402") return "topup";
 	if (op.startsWith("grant_")) return "grant";
 	if (op === "proxy") return "usage";
+	if (op === "compute_charge" || op === "compute_credit") return "compute";
 	if (op === "refund") return "refund";
 	return "all";
 }

--- a/apps/web/src/hosted/billing/wallet/ledger-table.tsx
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.tsx
@@ -42,6 +42,8 @@ const OPERATION_LABELS: Record<string, string> = {
 	grant_referral: "Referral grant",
 	admin_adjust: "Adjustment",
 	proxy: "Usage",
+	compute_charge: "Compute charge",
+	compute_credit: "Compute reversal",
 	refund: "Refund",
 };
 
@@ -55,6 +57,7 @@ const LEDGER_FILTER_ITEMS = [
 	{ value: "topup", label: "Top-ups" },
 	{ value: "grant", label: "Grants" },
 	{ value: "usage", label: "Usage" },
+	{ value: "compute", label: "Compute" },
 	{ value: "refund", label: "Refunds" },
 ] as const;
 

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
+import { Info } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -15,7 +17,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import type { WalletState } from "@/hosted/billing/contracts";
-import { normalizeBillingError } from "@/hosted/billing/errors";
+import { isIdempotencyKeyReusedError, normalizeBillingError } from "@/hosted/billing/errors";
 import { formatCents, formatCredits } from "@/hosted/billing/format";
 import { useTopUp } from "@/hosted/billing/hooks";
 import { newIdempotencyKey } from "@/hosted/billing/idempotency";
@@ -41,12 +43,16 @@ export function TopUpDialog({
 	wallet,
 	onComplete,
 	initialAmountCents,
+	refundDebtCredits,
+	blockedChargeCredits,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	wallet: WalletState;
 	onComplete?: (status: "succeeded" | "processing") => void;
 	initialAmountCents?: number | null;
+	refundDebtCredits?: number | null;
+	blockedChargeCredits?: number | null;
 }) {
 	const topUp = useTopUp();
 	const qc = useQueryClient();
@@ -115,7 +121,11 @@ export function TopUpDialog({
 				},
 			});
 		} catch (e) {
-			toast.error("Couldn’t start top-up", { description: normalizeBillingError(e) });
+			const reused = isIdempotencyKeyReusedError(e);
+			if (reused) topupKeyRef.current = null;
+			toast.error(reused ? "Start a fresh top-up" : "Couldn’t start top-up", {
+				description: normalizeBillingError(e),
+			});
 		}
 	}
 
@@ -148,6 +158,18 @@ export function TopUpDialog({
 
 				{step === "amount" ? (
 					<div className="space-y-4">
+						{refundDebtCredits && refundDebtCredits > 0 ? (
+							<Alert>
+								<Info />
+								<AlertTitle>Refund debt is repaid first</AlertTitle>
+								<AlertDescription>
+									This top-up first repays {formatCredits(refundDebtCredits)} of refund debt.
+									{blockedChargeCredits && blockedChargeCredits > 0
+										? ` The remaining funds cover the ${formatCredits(blockedChargeCredits)} blocked compute charge.`
+										: " Remaining funds become available in your Wallet."}
+								</AlertDescription>
+							</Alert>
+						) : null}
 						<div className="flex flex-wrap gap-2">
 							{TOPUP_PRESETS_CENTS.map((preset) => (
 								<Button

--- a/apps/web/src/hosted/billing/wallet/wallet-compute.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-compute.logic.test.ts
@@ -4,6 +4,7 @@ import { decimalCredits, walletComputeCoverage } from "./wallet-compute.logic";
 
 const wallet: WalletState = {
 	balance_credits: 2_800,
+	overdraft_credits: 0,
 	balance_snapshot_at: null,
 	payment_mode: "card",
 	x402_enabled: false,
@@ -118,6 +119,16 @@ describe("walletComputeCoverage", () => {
 			pendingPlanLabel: "Basic",
 			priceCents: 900,
 		});
+	});
+
+	test("keeps non-renewing lifecycle states visible without counting commitment", () => {
+		for (const status of ["unpaid", "paused", "incomplete", "canceled", "expired"]) {
+			const terminal = deployment(status, "compute_basic", 900, "2026-08-15T00:00:00Z");
+			if (terminal.compute_subscription) terminal.compute_subscription.status = status;
+			const result = walletComputeCoverage(wallet, [terminal]);
+			expect(result.deployments[0]?.renews, status).toBe(false);
+			expect(result.totalMonthlyCents, status).toBe(0);
+		}
 	});
 });
 

--- a/apps/web/src/hosted/billing/wallet/wallet-compute.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-compute.logic.ts
@@ -2,6 +2,7 @@ import type { HostedDeployment, Plan, WalletState } from "@/hosted/billing/contr
 import {
 	COMPUTE_BASIC_SLUG,
 	computeTierLabel,
+	isComputeSubscriptionRenewing,
 	pendingComputePlanSlug,
 	resolveBasicPlan,
 	resolvePerformancePlan,
@@ -53,7 +54,7 @@ export function walletComputeCoverage(
 			planLabel: computeTierLabel(deployment.config_info?.compute_plan_slug),
 			pendingPlanLabel: pendingPlanSlug ? computeTierLabel(pendingPlanSlug) : null,
 			priceCents: Math.max(0, pendingPlan?.price_cents ?? subscription.price_cents ?? 0),
-			renews: !subscription.cancel_at_period_end && subscription.status !== "canceled",
+			renews: isComputeSubscriptionRenewing(subscription),
 			nextRenewalAt: subscription.current_period_end ?? null,
 			status: subscription.payment_state,
 		});

--- a/apps/web/src/hosted/billing/wallet/wallet-constants.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-constants.ts
@@ -23,7 +23,7 @@ export const LOW_BALANCE_USD = 2;
 // with thousands of entries can never render thousands of rows. "Show more"
 // steps up by a page until the cap, then the table states it's capped.
 export const LEDGER_PAGE_SIZE = 50;
-export const LEDGER_MAX_ROWS = 500;
+export const LEDGER_MAX_ROWS = 100;
 
 export function isLowBalance(balanceCredits: number, pointsPerUsd: number): boolean {
 	if (!pointsPerUsd) return false;

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -181,8 +181,8 @@ export function WalletPage() {
 					entries={ledger.data?.items ?? []}
 					pointsPerUsd={w.points_per_usd}
 					isLoading={ledger.isLoading}
-					hasMore={(ledger.data?.items.length ?? 0) >= ledgerLimit && ledgerLimit < LEDGER_MAX_ROWS}
-					atCap={(ledger.data?.items.length ?? 0) >= LEDGER_MAX_ROWS}
+					hasMore={ledger.data?.has_more ?? false}
+					atCap={ledgerLimit >= LEDGER_MAX_ROWS && (ledger.data?.has_more ?? false)}
 					isFetchingMore={ledger.isFetching}
 					onShowMore={() => setLedgerLimit((n) => Math.min(n + LEDGER_PAGE_SIZE, LEDGER_MAX_ROWS))}
 				/>

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -1357,7 +1357,9 @@ export interface components {
              * @constant
              */
             billing_term_months: 1;
-            deploy_config: components["schemas"]["V2HostedDeployRequest"];
+            deploy_config?: components["schemas"]["V2HostedDeployRequest"] | null;
+            /** Upgrade Deployment Id */
+            upgrade_deployment_id?: string | null;
         };
         /** V2WalletComputeActivateResponse */
         V2WalletComputeActivateResponse: {
@@ -1372,7 +1374,7 @@ export interface components {
              */
             funding_source: "wallet";
             /** Deploy Request Id */
-            deploy_request_id: string;
+            deploy_request_id?: string | null;
             /** Deployment Id */
             deployment_id?: string | null;
             /** Charge Ledger Id */
@@ -1419,12 +1421,12 @@ export interface components {
              * Code
              * @enum {string}
              */
-            code: "deploy_request_funding_conflict" | "idempotency_key_reused" | "open_refund_debt";
+            code: "deploy_request_funding_conflict" | "idempotency_key_reused";
         };
         /** V2WalletComputeConflictErrorResponse */
         V2WalletComputeConflictErrorResponse: {
             /** Detail */
-            detail: components["schemas"]["V2WalletComputeConflictCodeDetail"] | components["schemas"]["V2WalletComputeRetryErrorDetail"] | string;
+            detail: components["schemas"]["V2WalletComputeConflictCodeDetail"] | components["schemas"]["V2WalletComputeOpenRefundDebtDetail"] | components["schemas"]["V2WalletComputeRetryErrorDetail"] | string;
         };
         /** V2WalletComputeInsufficientErrorDetail */
         V2WalletComputeInsufficientErrorDetail: {
@@ -1444,6 +1446,16 @@ export interface components {
         V2WalletComputeInsufficientErrorResponse: {
             detail: components["schemas"]["V2WalletComputeInsufficientErrorDetail"];
         };
+        /** V2WalletComputeOpenRefundDebtDetail */
+        V2WalletComputeOpenRefundDebtDetail: {
+            /**
+             * Code
+             * @constant
+             */
+            code: "open_refund_debt";
+            /** Outstanding Debt Credits */
+            outstanding_debt_credits: string;
+        };
         /** V2WalletComputePlanChangeRequest */
         V2WalletComputePlanChangeRequest: {
             /** Subscription Id */
@@ -1462,11 +1474,6 @@ export interface components {
             current_plan_slug: string;
             /** Target Plan Slug */
             target_plan_slug: string;
-            /**
-             * Change Kind
-             * @enum {string}
-             */
-            change_kind: "upgrade" | "downgrade";
             /** Status */
             status: string;
             /**
@@ -1474,24 +1481,12 @@ export interface components {
              * Format: date-time
              */
             effective_at: string;
-            /**
-             * Period Start
-             * Format: date-time
-             */
-            period_start: string;
-            /**
-             * Period End
-             * Format: date-time
-             */
-            period_end: string;
-            /** Prorated Delta Cents */
-            prorated_delta_cents: number;
-            /** Prorated Delta Credits */
-            prorated_delta_credits: string;
+            /** Amount Cents */
+            amount_cents: number;
+            /** Amount Credits */
+            amount_credits: string;
             /** Points Per Usd */
             points_per_usd: number;
-            /** Charge Ledger Id */
-            charge_ledger_id?: string | null;
             /** Pending Plan Slug */
             pending_plan_slug?: string | null;
         };
@@ -1587,7 +1582,7 @@ export interface components {
              * Code
              * @enum {string}
              */
-            code: "wallet_balance_refresh_failed" | "wallet_compute_charge_failed" | "wallet_compute_upstream_failed" | "resize_failed_retryable";
+            code: "wallet_balance_refresh_failed" | "wallet_compute_charge_failed" | "wallet_compute_upstream_failed";
             /** Failure Code */
             failure_code?: string | null;
             /**
@@ -1623,11 +1618,15 @@ export interface components {
         V2WalletLedgerResponse: {
             /** Items */
             items: components["schemas"]["V2WalletLedgerItemResponse"][];
+            /** Has More */
+            has_more: boolean;
         };
         /** V2WalletResponse */
         V2WalletResponse: {
             /** Balance Credits */
             balance_credits: number;
+            /** Overdraft Credits */
+            overdraft_credits: number;
             /** Balance Snapshot At */
             balance_snapshot_at?: string | null;
             /**
@@ -2514,15 +2513,6 @@ export interface operations {
                     "application/json": components["schemas"]["V2WalletComputePlanChangeResponse"];
                 };
             };
-            /** @description The wallet balance cannot cover the plan change. */
-            402: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["V2WalletComputeInsufficientErrorResponse"];
-                };
-            };
             /** @description The plan change conflicts with current billing state. */
             409: {
                 headers: {
@@ -2539,15 +2529,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-            /** @description The wallet charge or deployment resize is retryable. */
-            502: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["V2WalletComputeUpstreamErrorResponse"];
                 };
             };
         };


### PR DESCRIPTION
## Summary

Align the hosted wallet billing UI with the simplified backend lifecycle shipped in Clawdi-AI/clawdi-hosted#877, #878, and #879.

- regenerate the filtered deploy API contract from the merged hosted OpenAPI
- present wallet plan changes as next-renewal schedules and remove immediate debit/resize recovery UI
- make past-due wallet recovery retry-only while unpaid/detached terminal recovery creates a new subscription for the projected plan
- omit `deployment_id` for detached Stripe fix-payment recovery
- turn refund-debt conflicts into prefilled top-ups that cover debt plus a blocked compute charge when known
- rotate idempotency keys only for explicit reuse conflicts while preserving ambiguous retry keys
- show honest subscription lifecycle labels, exclude non-renewing commitments, and name pending plans in dunning copy
- wake deployment projection polling before collection boundaries, then poll through wallet grace only
- honor the ledger `has_more` contract with a 100-row cap and label/filter compute ledger entries

## Verification

- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web test` — 456 passed
- `bunx biome check apps/web/src apps/web/e2e/hosted-smoke.pw.ts`
- `bun run --cwd apps/web build:oss`
- `bun run --cwd apps/web e2e:hosted` — 30 passed
- `DEPLOY_CONTRACT_FETCH_MODE=strict DEPLOY_OPENAPI_SOURCE=https://api.clawdi.ai/openapi.json scripts/check-deploy-generated-api.sh`
