### PR TITLE
fix(web): keep hosted deployments manageable without agent projection

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -125,6 +125,29 @@ const stoppedIncludedBasicDeployment = {
 	status: "stopped",
 };
 
+const missingProjectionEnvironmentId = "55555555-5555-4555-8555-555555555555";
+const missingProjectionFailureReason =
+	"startup_probe_failing; restart_count=2; container failed readiness probe after the runtime bridge exhausted every startup attempt";
+const failedMissingProjectionDeployment = {
+	...includedBasicDeployment,
+	id: "hdep_failed_projection",
+	name: "Failed projection agent",
+	status: "failed",
+	failure_reason: missingProjectionFailureReason,
+	config_info: {
+		...includedBasicDeployment.config_info,
+		clawdi_cloud_environments: { hermes: missingProjectionEnvironmentId },
+	},
+};
+
+const interruptedIdentitylessDeployment = {
+	...includedBasicDeployment,
+	id: "hdep_creation_interrupted",
+	name: "Interrupted deployment",
+	status: "failed",
+	failure_reason: "creation_interrupted",
+};
+
 const walletState = {
 	balance_credits: 25_000,
 	overdraft_credits: 0,
@@ -245,7 +268,9 @@ type HostedApiStubOptions = {
 	billingHistoryResponses?: unknown[];
 	cancelRequests?: string[];
 	checkoutRequests?: string[];
+	cloudAgentNotFoundIds?: readonly string[];
 	createRequests?: string[];
+	deleteRequests?: string[];
 	deployRequestStatusRequests?: string[];
 	deployRequestStatusResponses?: StubResponse[];
 	deployments?: readonly unknown[];
@@ -255,6 +280,7 @@ type HostedApiStubOptions = {
 	ledgerResponses?: unknown[];
 	plans?: readonly unknown[];
 	retryRequests?: string[];
+	restartRequests?: string[];
 	walletRetryResponses?: StubResponse[];
 	startError?: { status: number; detail: string };
 	startRequests?: string[];
@@ -483,12 +509,20 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 				cancel_at: "2026-08-15T00:00:00Z",
 			});
 		}
+		if (p.endsWith("/restart") && r.request().method() === "POST") {
+			options.restartRequests?.push(p);
+			return fulfillJson(r, { status: "starting" });
+		}
 		if (p.endsWith("/start") && r.request().method() === "POST") {
 			options.startRequests?.push(r.request().postData() ?? "");
 			if (options.startError) {
 				return fulfillJson(r, { detail: options.startError.detail }, options.startError.status);
 			}
 			return fulfillJson(r, { status: "starting" });
+		}
+		if (p.startsWith("/v2/deployments/") && r.request().method() === "DELETE") {
+			options.deleteRequests?.push(p);
+			return fulfillJson(r, { status: "deleted", cvm_deleted: true });
 		}
 		return fulfillJson(r, {});
 	});
@@ -499,6 +533,9 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		if (p === "/v1/agents") return fulfillJson(r, []);
 		if (p.startsWith("/v1/agents/") && r.request().method() === "GET") {
 			const id = decodeURIComponent(p.slice("/v1/agents/".length));
+			if (options.cloudAgentNotFoundIds?.includes(id)) {
+				return fulfillJson(r, { detail: "Agent not found" }, 404);
+			}
 			return fulfillJson(r, {
 				id,
 				name: id,
@@ -624,6 +661,67 @@ test("deploy wizard Select opens without browser errors", async ({ page }) => {
 	await page.getByRole("option").first().click();
 	await page.waitForTimeout(150);
 	expect(errors, `language select: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("env-keyed agent route keeps failed deployment recovery available without its projection", async ({
+	page,
+}) => {
+	const restartRequests: string[] = [];
+	const deleteRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments: [failedMissingProjectionDeployment],
+		plans: [basicPlan, performancePlan],
+		cloudAgentNotFoundIds: [missingProjectionEnvironmentId],
+		restartRequests,
+		deleteRequests,
+	});
+
+	await page.goto(`/agents/${missingProjectionEnvironmentId}?source=on-clawdi`);
+	const main = page.locator("main");
+	await expect(main.getByText("Agent sync record unavailable", { exact: true })).toBeVisible();
+	await expect(main.getByText(missingProjectionFailureReason, { exact: true })).toBeVisible();
+	await expect(main.getByText("Failed", { exact: true })).toBeVisible();
+	await expect(main.getByText("Basic", { exact: true })).toBeVisible();
+	await expect(main.getByText("Jul 15, 2026", { exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Retry startup", exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Delete", exact: true })).toBeVisible();
+	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toHaveCount(0);
+	await expect(page.getByRole("link", { name: "Runtime UI", exact: true })).toHaveCount(0);
+	await expect(page.getByRole("link", { name: "Sessions", exact: true })).toHaveCount(0);
+
+	await main.getByRole("button", { name: "Retry startup", exact: true }).click();
+	await page
+		.getByRole("alertdialog")
+		.getByRole("button", { name: "Retry startup", exact: true })
+		.click();
+	await expect
+		.poll(() => restartRequests)
+		.toEqual(["/v2/deployments/hdep_failed_projection/restart"]);
+
+	await main.getByRole("button", { name: "Delete", exact: true }).click();
+	await page
+		.getByRole("alertdialog")
+		.getByRole("button", { name: "Delete compute", exact: true })
+		.click();
+	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_failed_projection"]);
+});
+
+test("identity-less interrupted deployment tile exposes delete", async ({ page }) => {
+	const deleteRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments: [interruptedIdentitylessDeployment],
+		deleteRequests,
+	});
+
+	await page.goto("/agents");
+	const deleteAction = page.getByRole("button", { name: "Delete Interrupted deployment" });
+	await expect(deleteAction).toBeVisible();
+	await deleteAction.click();
+	await page
+		.getByRole("alertdialog")
+		.getByRole("button", { name: "Delete deployment", exact: true })
+		.click();
+	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_creation_interrupted"]);
 });
 
 test("paid-funded Basic leaves the included slot available for direct compute_basic deploy", async ({

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -229,6 +229,10 @@ const HOSTED_AGENT_SECTIONS: {
 	},
 ];
 
+const HOSTED_AGENT_FALLBACK_SECTIONS = HOSTED_AGENT_SECTIONS.filter(
+	(section) => section.id === "overview",
+);
+
 const AGENT_SECTION_TINTS = {
 	overview: RESOURCE_TINT_CLASSES.overview,
 	sessions: RESOURCE_TINT_CLASSES.sessions,
@@ -297,6 +301,11 @@ function agentTileChromeKind(tile: AgentTile): AgentChromeKind {
 	if (tile.source === "on-clawdi") return "cloud";
 	if (tile.source === "legacy-hosted") return "legacy";
 	return "connected";
+}
+
+function agentTileRouteId(tile: AgentTile): string | null {
+	if (tile.env) return tile.env.id;
+	return tile.href ? (parseAgentPathname(tile.href)?.agentId ?? null) : null;
 }
 
 function sameOrder(a: string[], b: string[]): boolean {
@@ -564,7 +573,7 @@ function AgentFocusHostedFallbackSections({
 	return (
 		<AgentSectionList
 			agentId={agentId}
-			sections={HOSTED_AGENT_SECTIONS}
+			sections={HOSTED_AGENT_FALLBACK_SECTIONS}
 			activeSection={activeSection}
 			onNavigate={onNavigate}
 		/>
@@ -1129,7 +1138,7 @@ function FocusRailContent({
 								<SortableAgentRailItem
 									key={agent.id}
 									agent={agent}
-									active={activeAgentId === agent.env?.id}
+									active={activeAgentId === agentTileRouteId(agent)}
 									onNavigate={onRailAgentNavigate}
 									onClickCapture={onRailAgentClickCapture}
 									onPointerDownCapture={recordRailPointerStart}

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -3,7 +3,7 @@
 import type { components } from "@clawdi/shared/api";
 import { Link } from "@tanstack/react-router";
 import { ArrowUpRight } from "lucide-react";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { type ApiErrorNormalizer, ApiErrorPanel } from "@/components/api-error-panel";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import {
@@ -87,14 +87,14 @@ export interface AgentTile {
 	statusLabel: string;
 	/** Used to compute the "N active now" count in the card description. */
 	lastSeenAt?: string | null;
-	/** Primary click target. Points at the in-app env detail
-	 * page (`/agents/{env_id}`) when an env is available — for both
-	 * self-managed and hosted tiles with a registered env, so the
-	 * sessions/skills/memory experience stays unified. Hosted tiles without a
-	 * registered env are non-navigable instead of putting a deployment id in an
-	 * agent route. `external` reflects whichever applies. */
+	/** Primary click target. Points at the in-app env detail page
+	 * (`/agents/{env_id}`). Hosted tiles derive this identity from deployment
+	 * config even while the cloud-api projection is absent. A hosted deployment
+	 * with no minted env id remains non-navigable. */
 	href: string | null;
 	external?: boolean;
+	/** Optional card-level action supplied by the owning integration. */
+	action?: ReactNode;
 	/** Optional hosted remediation target retained for surfaces that open
 	 * status dialogs. Tiles render daemon status as a non-interactive dot. */
 	manageHref?: string;
@@ -303,7 +303,7 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 				}
 				meta={meta.length > 0 ? meta : undefined}
 				titleAdornment={sourcePill}
-				className="min-w-0 flex-1"
+				className={cn("min-w-0 flex-1", tile.action && "pr-8")}
 			/>
 			{onClawdi && tile.secondaryStatus ? (
 				<div
@@ -322,6 +322,7 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 					className="pointer-events-none absolute right-3 top-3.5 size-3.5 text-muted-foreground"
 				/>
 			) : null}
+			{tile.action ? <div className="absolute top-2 right-2">{tile.action}</div> : null}
 		</div>
 	);
 	const linkClassName = cn(

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -32,6 +32,7 @@ import { useSetAgentBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { AgentSourceBadge, agentDisplayName } from "@/components/dashboard/agent-label";
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
 import { AgentSkillsTab } from "@/components/dashboard/agent-skills-tab";
+import { ConnectedAgentDetailSkeleton } from "@/components/dashboard/connected-agent-detail";
 import type { DetailSectionMeta } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
 import { PageHeader } from "@/components/page-header";
@@ -61,7 +62,6 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { deploymentDisplayName, isCloudEnvId } from "@/hosted/agent-identity";
 import {
 	useCreateRuntimeUiRedemption,
@@ -155,10 +155,7 @@ import {
 } from "@/hosted/billing/wallet/stripe-payment-form";
 import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
 import { topUpAmountCentsForCreditShortfall } from "@/hosted/billing/wallet/top-up-dialog.logic";
-import {
-	compactDeploymentFailureReason,
-	deploymentFailureReason,
-} from "@/hosted/deployment-failure";
+import { deploymentFailureReason } from "@/hosted/deployment-failure";
 import {
 	canRestart as canRestartDeployment,
 	canStart as canStartDeployment,
@@ -209,6 +206,7 @@ import {
 	HOSTED_AGENT_SECTION_IDS,
 } from "@/lib/agent-routes";
 import { toastApiError, unwrap, useApi } from "@/lib/api";
+import { isApiNotFoundError } from "@/lib/api-errors";
 import type { SessionListItem } from "@/lib/api-schemas";
 import { formatModelLabel, formatShortDate } from "@/lib/format";
 import { sessionListQueryOptions } from "@/lib/session-queries";
@@ -308,7 +306,13 @@ function provisioningTitle(status: DeploymentStatus): string {
 	return status.kind === "starting" ? "Starting your agent..." : "Setting up your agent...";
 }
 
-function RestartComputeAction({ deployment }: { deployment: HostedDeployment }) {
+function RestartComputeAction({
+	deployment,
+	label = "Restart compute",
+}: {
+	deployment: HostedDeployment;
+	label?: string;
+}) {
 	const lifecycle = useDeploymentLifecycle();
 	const runAction = useActionLock();
 	const status = parseDeploymentStatus(deployment.status);
@@ -317,7 +321,7 @@ function RestartComputeAction({ deployment }: { deployment: HostedDeployment }) 
 		<ConfirmAction
 			title="Restart compute?"
 			description={<p>This restarts this hosted agent.</p>}
-			confirmLabel="Restart compute"
+			confirmLabel={label}
 			onConfirm={() =>
 				runAction(async () => {
 					await lifecycle.mutateAsync({ id: deployment.id, action: "restart" });
@@ -330,7 +334,32 @@ function RestartComputeAction({ deployment }: { deployment: HostedDeployment }) 
 				) : (
 					<RefreshCw className="size-3.5" />
 				)}
-				Restart compute
+				{label}
+			</Button>
+		</ConfirmAction>
+	);
+}
+
+function DeleteComputeAction({ deployment }: { deployment: HostedDeployment }) {
+	const router = useRouter();
+	const deleteDeployment = useDeleteDeployment();
+	const runAction = useActionLock();
+	return (
+		<ConfirmAction
+			title={`Delete ${deploymentDisplayName(deployment.name)}?`}
+			description={<p>The hosted agent is torn down. This can’t be undone.</p>}
+			confirmLabel="Delete compute"
+			destructive
+			onConfirm={() =>
+				runAction(async () => {
+					await deleteDeployment.mutateAsync(deployment.id);
+					await router.navigate({ href: "/" });
+				})
+			}
+		>
+			<Button type="button" variant="destructive" size="sm" disabled={deleteDeployment.isPending}>
+				{deleteDeployment.isPending ? <Spinner /> : <Trash2 />}
+				Delete
 			</Button>
 		</ConfirmAction>
 	);
@@ -398,6 +427,7 @@ export function HostedAgentDetail({
 		enabled: isCloudEnvId(environmentId),
 	});
 	const agent = agentQuery.data;
+	const agentProjectionMissing = isApiNotFoundError(agentQuery.error);
 	const name = agent ? agentDisplayName(agent) : deploymentDisplayName(deployment.name);
 	const runtimeLabel = runtimeDisplayName(runtime);
 	const agentTitle = name === runtimeLabel ? name : `${name} · ${runtimeLabel}`;
@@ -426,8 +456,22 @@ export function HostedAgentDetail({
 
 	const sessions = useQuery({
 		...sessionListQueryOptions(api, { environment_id: environmentId, page_size: 20 }),
-		enabled: isCloudEnvId(environmentId),
+		enabled: Boolean(agent),
 	});
+
+	if (agentQuery.isLoading && isCloudEnvId(environmentId)) {
+		return <ConnectedAgentDetailSkeleton hosted />;
+	}
+
+	if (agentProjectionMissing) {
+		return (
+			<MissingAgentProjectionDetail
+				deployment={deployment}
+				runtime={runtime}
+				environmentId={environmentId}
+			/>
+		);
+	}
 
 	const activeNavItem = HOSTED_AGENT_NAV_META[activeTab];
 	const activeTabLabel = agentSectionLabel(activeTab);
@@ -660,20 +704,16 @@ function OverviewProvisioningPanel({ status }: { status: DeploymentStatus }) {
 }
 
 function DeploymentFailureReasonText({ reason }: { reason: string }) {
-	const preview = compactDeploymentFailureReason(reason);
-	return (
-		<Tooltip>
-			<TooltipTrigger
-				render={<span className="mt-2 block max-w-full truncate font-mono text-xs" />}
-			>
-				{preview}
-			</TooltipTrigger>
-			<TooltipContent className="max-w-sm whitespace-normal break-words">{reason}</TooltipContent>
-		</Tooltip>
-	);
+	return <p className="mt-2 whitespace-pre-wrap break-words font-mono text-xs">{reason}</p>;
 }
 
-function OverviewFailedPanel({ deployment }: { deployment: HostedDeployment }) {
+function OverviewFailedPanel({
+	deployment,
+	restartLabel = "Restart compute",
+}: {
+	deployment: HostedDeployment;
+	restartLabel?: string;
+}) {
 	const status = parseDeploymentStatus(deployment.status);
 	const failureReason = deploymentFailureReason(deployment);
 	if (failureReason) {
@@ -689,7 +729,7 @@ function OverviewFailedPanel({ deployment }: { deployment: HostedDeployment }) {
 						<DeploymentFailureReasonText reason={failureReason} />
 					</div>
 					<div className="shrink-0">
-						<RestartComputeAction deployment={deployment} />
+						<RestartComputeAction deployment={deployment} label={restartLabel} />
 					</div>
 				</AlertDescription>
 			</Alert>
@@ -710,9 +750,70 @@ function OverviewFailedPanel({ deployment }: { deployment: HostedDeployment }) {
 					</div>
 				</div>
 				<div className="shrink-0">
-					<RestartComputeAction deployment={deployment} />
+					<RestartComputeAction deployment={deployment} label={restartLabel} />
 				</div>
 			</div>
+		</div>
+	);
+}
+
+function MissingAgentProjectionDetail({
+	deployment,
+	runtime,
+	environmentId,
+}: {
+	deployment: HostedDeployment;
+	runtime: Runtime;
+	environmentId: string;
+}) {
+	const status = parseDeploymentStatus(deployment.status);
+	const canRestart = canRestartDeployment(status);
+	const canStart = canStartDeployment(status);
+	const failed = status.kind === "failed";
+	return (
+		<div
+			data-hosted="true"
+			className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6")}
+		>
+			<section className="flex flex-col gap-5">
+				<PageHeader
+					title="Overview"
+					description="Deployment status and recovery controls."
+					icon={<Info className="size-4 text-muted-foreground" />}
+					status={<AgentSourceBadge source="hosted" compact />}
+				/>
+				<Alert data-hosted="true">
+					<AlertCircle />
+					<AlertTitle>Agent sync record unavailable</AlertTitle>
+					<AlertDescription>
+						The hosted deployment still claims agent {environmentId}, but its synced agent record is
+						missing. Runtime UI, terminal, sessions, and other agent data will become available
+						after the agent reconnects.
+					</AlertDescription>
+				</Alert>
+				{failed ? (
+					<OverviewFailedPanel deployment={deployment} restartLabel="Retry startup" />
+				) : null}
+				<div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+					<StatCard label="Status" value={deploymentStatusLabel(status)} />
+					<StatCard
+						label="Compute plan"
+						value={computeTierLabel(deployment.config_info?.compute_plan_slug)}
+					/>
+					<StatCard label="Created" value={formatShortDate(deployment.created_at)} />
+					<StatCard label="Runtime" value={runtimeDisplayName(runtime)} />
+				</div>
+				<SettingsSection
+					title="Deployment actions"
+					description="Manage compute while synced agent data is unavailable."
+				>
+					<div className="flex flex-wrap gap-2.5">
+						{canRestart && !failed ? <RestartComputeAction deployment={deployment} /> : null}
+						{canStart && !failed ? <StartComputeAction deployment={deployment} /> : null}
+						<DeleteComputeAction deployment={deployment} />
+					</div>
+				</SettingsSection>
+			</section>
 		</div>
 	);
 }

--- a/apps/web/src/hosted/hosted-deployment-tile-action.tsx
+++ b/apps/web/src/hosted/hosted-deployment-tile-action.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { MoreHorizontal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ConfirmAction } from "@/components/ui/confirm-action";
+import { Spinner } from "@/components/ui/spinner";
+import { deploymentDisplayName } from "@/hosted/agent-identity";
+import { useDeleteDeployment } from "@/hosted/agents/deployment-hooks";
+import type { HostedDeployment } from "@/hosted/billing/contracts";
+import { useActionLock } from "@/hosted/billing/use-action-lock";
+
+export function HostedDeploymentTileDeleteAction({ deployment }: { deployment: HostedDeployment }) {
+	const deleteDeployment = useDeleteDeployment();
+	const runAction = useActionLock();
+	const name = deploymentDisplayName(deployment.name);
+
+	return (
+		<div data-hosted="true">
+			<ConfirmAction
+				title={`Delete ${name}?`}
+				description={<p>The hosted deployment is torn down. This can’t be undone.</p>}
+				confirmLabel="Delete deployment"
+				destructive
+				onConfirm={() =>
+					runAction(async () => {
+						await deleteDeployment.mutateAsync(deployment.id);
+					})
+				}
+			>
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon-sm"
+					className="text-muted-foreground"
+					disabled={deleteDeployment.isPending}
+					aria-label={`Delete ${name}`}
+					title={`Delete ${name}`}
+				>
+					{deleteDeployment.isPending ? <Spinner /> : <MoreHorizontal />}
+				</Button>
+			</ConfirmAction>
+		</div>
+	);
+}

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -194,13 +194,43 @@ describe("deploymentToTiles", () => {
 		});
 	});
 
-	test("keeps an unmatched deployment non-navigable instead of emitting an agent route", () => {
+	test("links by deployment env identity when the cloud-api projection is missing", () => {
 		const failureReason = "startup_probe_failing; restart_count=2";
+		const environmentId = "55555555-5555-4555-8555-555555555555";
 		const [tile] = hostedDeploymentToTiles(
 			deployment(
 				{
 					status: "failed",
 					failure_reason: failureReason,
+				},
+				{
+					clawdi_cloud_environments: { openclaw: environmentId },
+				},
+			),
+		);
+
+		expect(tile).toMatchObject({
+			id: "dep_123",
+			source: "on-clawdi",
+			href: `/agents/${environmentId}?source=on-clawdi`,
+			env: null,
+			secondaryStatus: {
+				label: "Failure: startup_probe_failing; restart_count=2",
+				title: failureReason,
+				textClass: "text-destructive-muted-foreground font-medium",
+			},
+		});
+		expect(tile?.manageHref).toBeUndefined();
+		expect(tile?.action).toBeUndefined();
+		expect(JSON.stringify(tile)).not.toContain("/agents/dep_123");
+	});
+
+	test("keeps a deployment without an env identity non-navigable but exposes delete", () => {
+		const [tile] = hostedDeploymentToTiles(
+			deployment(
+				{
+					status: "failed",
+					failure_reason: "creation_interrupted",
 				},
 				{
 					clawdi_cloud_environments: {},
@@ -210,16 +240,14 @@ describe("deploymentToTiles", () => {
 
 		expect(tile).toMatchObject({
 			id: "dep_123",
-			source: "on-clawdi",
 			href: null,
 			env: null,
 			secondaryStatus: {
-				label: "Failure: startup_probe_failing; restart_count=2",
-				title: failureReason,
-				textClass: "text-destructive-muted-foreground font-medium",
+				label: "Failure: creation_interrupted",
+				title: "creation_interrupted",
 			},
 		});
-		expect(tile?.manageHref).toBeUndefined();
+		expect(tile?.action).toBeDefined();
 		expect(JSON.stringify(tile)).not.toContain("/agents/dep_123");
 	});
 });

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -30,6 +30,7 @@ import {
 	parseDeploymentStatus,
 	shouldPollDeployments,
 } from "@/hosted/deployment-status";
+import { HostedDeploymentTileDeleteAction } from "@/hosted/hosted-deployment-tile-action";
 import { deploymentRuntime, runtimeDisplayName, runtimeEnvironmentId } from "@/hosted/runtimes";
 import { normalizeAgentEnvId } from "@/lib/agent-ownership";
 import { agentSectionHref } from "@/lib/agent-routes";
@@ -225,19 +226,18 @@ export function useHostedAgentTiles({
 
 /**
  * One deployment renders as one hosted agent tile. The selected runtime decides
- * which cloud-api environment is joined for daemon sync state and detail links.
+ * which config env id owns the detail route. A matching cloud-api environment
+ * only decorates the tile with daemon sync state and presentation metadata.
  */
 export function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>): AgentTile[] {
 	const runtime = deploymentRuntime(d);
 	const slug = deploymentDisplayName(d.name);
 	// Hosted deployments don't use last_seen_at; status is the freshness signal
-	// Hosted env join: the selected hosted runtime registers one cloud-api env
-	// via the admin endpoint. Without that env there is no resolvable agent route.
+	// The deployment config owns the stable agent identity. The cloud-api env
+	// join only decorates the tile and may legitimately lag or be missing.
 	const envId = runtimeEnvironmentId(d.config_info, runtime);
 	const matchedEnv = envId ? envById.get(envId.toLowerCase()) : undefined;
-	const detailHref = matchedEnv
-		? agentSectionHref(matchedEnv.id, "overview", "source=on-clawdi")
-		: null;
+	const detailHref = envId ? agentSectionHref(envId, "overview", "source=on-clawdi") : null;
 	const settingsHref = matchedEnv
 		? agentSectionHref(matchedEnv.id, "settings", "source=on-clawdi")
 		: undefined;
@@ -260,6 +260,9 @@ export function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>
 			lastSeenAt: matchedEnv?.last_seen_at ?? null,
 			href: detailHref,
 			external: false,
+			action: envId
+				? undefined
+				: createElement(HostedDeploymentTileDeleteAction, { deployment: d }),
 			manageHref: settingsHref,
 			active: runtimeStatus.active,
 			statusDot: {


### PR DESCRIPTION
## Why

PR #419 correctly stopped emitting `/agents/<deployment-id>` links when a hosted deployment did not join to a `/v1/agents` record. That removed the broken identity scheme, but it also made deployments with a lagging, lost, or damaged projection impossible to open precisely when users needed the failure reason and recovery controls.

A hosted deployment's stable agent identity already lives in `deployment.config_info.clawdi_cloud_environments[runtime]`. The `/v1/agents` record is a projection of that identity, so projection availability must not decide whether the deployment is navigable.

## Navigation before and after

| Deployment config identity | `/v1/agents` projection | Before | After |
|---|---|---|---|
| Present | Present | `/agents/<env-id>?source=on-clawdi` | Unchanged: the full env-backed view |
| Present | Missing, running/stopped | Non-navigable tile | The same env-keyed route with deployment status, metadata, recovery controls, and a clear sync-record message |
| Present | Missing, failed | Non-navigable tile | The same env-keyed route with the full failure reason plus retry and delete |
| Missing | Missing / not joinable | Non-navigable dead end | Status-only tile with a confirmed delete action |

## What changed

- Derive hosted tile detail links from `runtimeEnvironmentId(deployment.config_info, runtime)`, regardless of whether the cloud projection join succeeds. The join remains decoration for display name, avatar, ordering, and daemon sync state.
- Reuse the existing `/agents/<env-id>` route and `HostedAgentDetail`. A 404 from the agent projection now renders a deployment-centric recovery view instead of mounting env-dependent content.
- Show deployment status, compute plan, creation date, runtime, the full untruncated failure reason, and the existing restart/delete mutations in that recovery view.
- Hide terminal, Runtime UI, sessions, and other env-dependent navigation while the projection is missing.
- Add a confirmed kebab delete affordance to the only non-navigable case: a deployment whose config has no env identity yet.

There is no new route, identity scheme, API call, backend change, or generated client change.

## Create-flow audit

The production hosted control-plane implementation is outside this OSS repository, so its exact listability ordering cannot be verified here. The repository's local mock in `backend/scripts/mock_deploy_api.py` populates `config["clawdi_cloud_environments"]`, constructs the deployment, and only then inserts it into `DEPLOYMENTS`, so mock deployments have an env identity before they are first listable.

The generated frontend contract still allows `config_info` or the mapping to be absent. The identity-less status tile and delete action therefore remain as a defensive path for very early or interrupted creation states.

## Verification

- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web lint`
- `bun run --cwd apps/web test` — 459 passed
- `bun run check`
- `bun run --cwd apps/web e2e:hosted` — 32 passed
- `bun run --cwd apps/web build:oss`
- `VITE_CLERK_PUBLISHABLE_KEY=pk_test_dummy VITE_CLAWDI_API_URL=http://localhost:8000 CLERK_SECRET_KEY=sk_test_dummy bunx turbo build --filter=web`
