### PR TITLE
fix(web): make hosted deployment status authoritative

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -140,6 +140,21 @@ const failedMissingProjectionDeployment = {
 	},
 };
 
+const retainedProjectionEnvironmentId = "66666666-6666-4666-8666-666666666666";
+const retainedProjectionFailureReason =
+	"startup_probe_failing; restart_count=4; runtime daemon exited and is no longer reachable";
+const failedRetainedProjectionDeployment = {
+	...includedBasicDeployment,
+	id: "hdep_failed_retained_projection",
+	name: "Failed retained projection agent",
+	status: "failed",
+	failure_reason: retainedProjectionFailureReason,
+	config_info: {
+		...includedBasicDeployment.config_info,
+		clawdi_cloud_environments: { hermes: retainedProjectionEnvironmentId },
+	},
+};
+
 const interruptedIdentitylessDeployment = {
 	...includedBasicDeployment,
 	id: "hdep_creation_interrupted",
@@ -268,6 +283,7 @@ type HostedApiStubOptions = {
 	billingHistoryResponses?: unknown[];
 	cancelRequests?: string[];
 	checkoutRequests?: string[];
+	cloudAgentOverrides?: Record<string, unknown>;
 	cloudAgentNotFoundIds?: readonly string[];
 	createRequests?: string[];
 	deleteRequests?: string[];
@@ -556,6 +572,7 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 				sync_enabled: true,
 				explicit_identity: true,
 				default_project_id: "project-hosted",
+				...options.cloudAgentOverrides,
 			});
 		}
 		if (p === "/v1/ai-providers") return fulfillJson(r, { providers: [] });
@@ -704,6 +721,53 @@ test("env-keyed agent route keeps failed deployment recovery available without i
 		.getByRole("button", { name: "Delete compute", exact: true })
 		.click();
 	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_failed_projection"]);
+});
+
+test("failed deployment with a retained projection renders recovery without live agent sections", async ({
+	page,
+}) => {
+	const restartRequests: string[] = [];
+	const deleteRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments: [failedRetainedProjectionDeployment],
+		plans: [basicPlan, performancePlan],
+		cloudAgentOverrides: {
+			last_seen_at: new Date().toISOString(),
+			last_sync_error: "daemon unreachable: connection refused",
+		},
+		restartRequests,
+		deleteRequests,
+	});
+
+	await page.goto(`/agents/${retainedProjectionEnvironmentId}?source=on-clawdi`);
+	const main = page.locator("main");
+	await expect(main.getByText(retainedProjectionFailureReason, { exact: true })).toBeVisible();
+	await expect(main.getByText("Failed", { exact: true })).toBeVisible();
+	await expect(main.getByText("Basic", { exact: true })).toBeVisible();
+	await expect(main.getByText("Jul 15, 2026", { exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Retry startup", exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Delete", exact: true })).toBeVisible();
+	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toHaveCount(0);
+	await expect(page.getByRole("link", { name: "Runtime UI", exact: true })).toHaveCount(0);
+	await expect(page.getByRole("link", { name: "Sessions", exact: true })).toHaveCount(0);
+
+	await main.getByRole("button", { name: "Retry startup", exact: true }).click();
+	await page
+		.getByRole("alertdialog")
+		.getByRole("button", { name: "Retry startup", exact: true })
+		.click();
+	await expect
+		.poll(() => restartRequests)
+		.toEqual(["/v2/deployments/hdep_failed_retained_projection/restart"]);
+
+	await main.getByRole("button", { name: "Delete", exact: true }).click();
+	await page
+		.getByRole("alertdialog")
+		.getByRole("button", { name: "Delete compute", exact: true })
+		.click();
+	await expect
+		.poll(() => deleteRequests)
+		.toEqual(["/v2/deployments/hdep_failed_retained_projection"]);
 });
 
 test("identity-less interrupted deployment tile exposes delete", async ({ page }) => {

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -416,6 +416,9 @@ export function HostedAgentDetail({
 	const api = useApi();
 	const router = useRouter();
 	const ci = deployment.config_info;
+	const deploymentStatus = parseDeploymentStatus(deployment.status);
+	const deploymentRunning = isRunningStatus(deploymentStatus);
+	const cloudEnvironmentId = isCloudEnvId(environmentId);
 	const agentQuery = useQuery({
 		queryKey: ["agents", environmentId],
 		queryFn: async () =>
@@ -424,10 +427,10 @@ export function HostedAgentDetail({
 					params: { path: { agent_id: environmentId } },
 				}),
 			),
-		enabled: isCloudEnvId(environmentId),
+		enabled: cloudEnvironmentId,
 	});
 	const agent = agentQuery.data;
-	const agentProjectionMissing = isApiNotFoundError(agentQuery.error);
+	const agentProjectionMissing = cloudEnvironmentId && isApiNotFoundError(agentQuery.error);
 	const name = agent ? agentDisplayName(agent) : deploymentDisplayName(deployment.name);
 	const runtimeLabel = runtimeDisplayName(runtime);
 	const agentTitle = name === runtimeLabel ? name : `${name} · ${runtimeLabel}`;
@@ -456,19 +459,21 @@ export function HostedAgentDetail({
 
 	const sessions = useQuery({
 		...sessionListQueryOptions(api, { environment_id: environmentId, page_size: 20 }),
-		enabled: Boolean(agent),
+		enabled: deploymentRunning && Boolean(agent),
 	});
 
-	if (agentQuery.isLoading && isCloudEnvId(environmentId)) {
+	if (agentQuery.isLoading && deploymentRunning && cloudEnvironmentId) {
 		return <ConnectedAgentDetailSkeleton hosted />;
 	}
 
-	if (agentProjectionMissing) {
+	if (!deploymentRunning || agentProjectionMissing) {
 		return (
-			<MissingAgentProjectionDetail
+			<DeploymentCentricDetail
 				deployment={deployment}
 				runtime={runtime}
 				environmentId={environmentId}
+				agentProjectionMissing={agentProjectionMissing}
+				section={activeTab}
 			/>
 		);
 	}
@@ -757,19 +762,45 @@ function OverviewFailedPanel({
 	);
 }
 
-function MissingAgentProjectionDetail({
+function DeploymentCentricDetail({
 	deployment,
 	runtime,
 	environmentId,
+	agentProjectionMissing,
+	section,
 }: {
 	deployment: HostedDeployment;
 	runtime: Runtime;
 	environmentId: string;
+	agentProjectionMissing: boolean;
+	section: HostedAgentTab;
 }) {
 	const status = parseDeploymentStatus(deployment.status);
 	const canRestart = canRestartDeployment(status);
 	const canStart = canStartDeployment(status);
 	const failed = status.kind === "failed";
+	const stoppedComputeSettings = status.kind === "stopped" && section === "settings";
+
+	if (stoppedComputeSettings) {
+		return (
+			<div
+				data-hosted="true"
+				className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6")}
+			>
+				<section className="flex flex-col gap-4">
+					<PageHeader
+						title="Settings"
+						description="Compute plan, billing, and lifecycle controls."
+						icon={<Settings className="size-4 text-muted-foreground" />}
+						status={<AgentSourceBadge source="hosted" compact />}
+					/>
+					<ComputeDunningBanner deployment={deployment} />
+					<ComputeSettingsSections deployment={deployment} />
+				</section>
+			</div>
+		);
+	}
+
 	return (
 		<div
 			data-hosted="true"
@@ -782,15 +813,28 @@ function MissingAgentProjectionDetail({
 					icon={<Info className="size-4 text-muted-foreground" />}
 					status={<AgentSourceBadge source="hosted" compact />}
 				/>
-				<Alert data-hosted="true">
-					<AlertCircle />
-					<AlertTitle>Agent sync record unavailable</AlertTitle>
-					<AlertDescription>
-						The hosted deployment still claims agent {environmentId}, but its synced agent record is
-						missing. Runtime UI, terminal, sessions, and other agent data will become available
-						after the agent reconnects.
-					</AlertDescription>
-				</Alert>
+				{agentProjectionMissing ? (
+					<Alert data-hosted="true">
+						<AlertCircle />
+						<AlertTitle>Agent sync record unavailable</AlertTitle>
+						<AlertDescription>
+							The hosted deployment still claims agent {environmentId}, but its synced agent record
+							is missing. Runtime UI, terminal, sessions, and other agent data will become available
+							after the agent reconnects.
+						</AlertDescription>
+					</Alert>
+				) : status.kind === "stopped" ? (
+					<Alert data-hosted="true">
+						<AlertCircle />
+						<AlertTitle>Hosted compute is stopped</AlertTitle>
+						<AlertDescription>
+							The agent record is retained, but Runtime UI, terminal, sessions, and daemon status
+							are unavailable until compute starts again.
+						</AlertDescription>
+					</Alert>
+				) : isProvisioningStatus(status) ? (
+					<OverviewProvisioningPanel status={status} />
+				) : null}
 				{failed ? (
 					<OverviewFailedPanel deployment={deployment} restartLabel="Retry startup" />
 				) : null}
@@ -805,7 +849,11 @@ function MissingAgentProjectionDetail({
 				</div>
 				<SettingsSection
 					title="Deployment actions"
-					description="Manage compute while synced agent data is unavailable."
+					description={
+						agentProjectionMissing
+							? "Manage compute while synced agent data is unavailable."
+							: "Manage this hosted deployment while live agent tools are unavailable."
+					}
 				>
 					<div className="flex flex-wrap gap-2.5">
 						{canRestart && !failed ? <RestartComputeAction deployment={deployment} /> : null}

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -300,14 +300,21 @@ describe("hostedRuntimeStatusView", () => {
 		expect(view.secondary).toBeNull();
 	});
 
-	test("counts a hosted runtime active when its joined environment is fresh", () => {
+	test("keeps a failed deployment inactive when its joined environment is fresh", () => {
+		const view = hostedRuntimeStatusView("failed", env({ last_seen_at: new Date().toISOString() }));
+
+		expect(view.primary.label).toBe("Failed");
+		expect(view.active).toBe(false);
+	});
+
+	test("keeps a stopped deployment inactive when its joined environment is fresh", () => {
 		const view = hostedRuntimeStatusView(
 			"stopped",
 			env({ last_seen_at: new Date().toISOString() }),
 		);
 
 		expect(view.primary.label).toBe("Stopped");
-		expect(view.active).toBe(true);
+		expect(view.active).toBe(false);
 		expect(view.secondary).toBeNull();
 	});
 

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -4,7 +4,7 @@ import type { components } from "@clawdi/shared/api";
 import { useQuery } from "@tanstack/react-query";
 import { createElement, useMemo } from "react";
 import { agentDisplayName } from "@/components/dashboard/agent-label";
-import { type AgentTile, isAgentActive } from "@/components/dashboard/agents-card";
+import type { AgentTile } from "@/components/dashboard/agents-card";
 import {
 	DaemonStatusBadge,
 	type DaemonStatusVisual,
@@ -81,7 +81,6 @@ export function hostedRuntimeStatusView(
 	const sync = env === undefined ? null : daemonStatusVisual(env, "on-clawdi");
 	const computeIsRunning = isRunningStatus(compute);
 	const failureReason = compute.kind === "failed" ? deploymentFailureReason(deployment) : null;
-	const envIsFresh = isAgentActive(env?.last_seen_at);
 	let secondary: HostedRuntimeStatusView["secondary"] = null;
 	if (failureReason) {
 		secondary = {
@@ -108,7 +107,7 @@ export function hostedRuntimeStatusView(
 			textClass: COMPUTE_TEXT_TONE[computeTone],
 		},
 		secondary,
-		active: computeIsRunning || envIsFresh,
+		active: computeIsRunning,
 	};
 }
 


### PR DESCRIPTION
## Why

Owner re-testing after #421 found two symptoms of the same rendering hierarchy bug:

- a fresh cloud agent projection could mark a failed or stopped hosted deployment active;
- a failed deployment with a retained agent projection mounted the normal live-agent detail, even though its daemon no longer existed.

The design rule in this PR is: **deployment status is authoritative; cloud projection data is additive**. Projection freshness or presence can add sync context, but it cannot override the deployment status verdict or select a live view.

## Before / after rendering matrix

| Deployment status | Cloud projection | Before | After |
|---|---|---|---|
| Running | Present | Live-agent view; active tile | Unchanged: live-agent view; active tile; projection adds sync context |
| Running | Missing after a claimed env id | Deployment-centric sync-missing recovery from #421 | Unchanged: deployment-centric sync-missing recovery; status still owns the primary verdict |
| Failed | Present | Incorrect live-agent view; a fresh `last_seen_at` could also mark the tile active | Deployment-centric failure view with full reason, Retry, Delete, plan, and creation metadata; inactive tile |
| Failed | Missing | Deployment-centric failure recovery with the sync-record alert | Same recovery view; projection absence only adds the sync-record alert; inactive tile |
| Stopped | Present | Normal agent detail despite no live daemon; a fresh projection could mark the tile active | Deployment-centric stopped overview with Start/Delete and metadata; inactive tile |
| Stopped | Missing | Deployment-centric sync-missing recovery | Deployment-centric stopped recovery; projection absence only adds the sync-record alert; inactive tile |

A running post-deploy route that has not minted a cloud env identity yet keeps its existing deployment-id management path; that is distinct from a claimed env id returning projection 404.

## What changed

- Derive hosted tile `active` solely from the normalized deployment status. The joined environment still powers the secondary sync badge while compute is running.
- Select the deployment-centric detail whenever compute is not running, regardless of whether the cloud agent record still exists.
- Gate recent sessions and all live-agent tab rendering behind running deployment status.
- Keep projection lookup non-blocking and additive so a real 404 can still add the existing "Agent sync record unavailable" alert.
- Treat stopped as recoverable rather than failed: show Start/Delete on the deployment overview, hide live-agent surfaces, and retain the existing compute-only Settings path for billing and lifecycle management.

## Regression tests

Both bugs were reproduced before the implementation changed:

- the new selector test failed on current main with `Expected: false`, `Received: true` for failed + fresh projection;
- the new hosted Playwright test rendered the old Recent sessions/live-agent view and could not find deployment creation metadata or recovery controls for failed + retained projection.

The browser regression now also verifies the full failure reason, hidden Terminal/Runtime UI/Sessions links, and working Retry/Delete requests.

## Verification

- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web lint`
- `bunx biome check apps/web/e2e/hosted-smoke.pw.ts`
- `bun run --cwd apps/web test` — 460 passed
- `bun run --cwd apps/web e2e:hosted` — 33 passed
- `bun run --cwd apps/web build:oss`
- hosted `bun run --cwd apps/web build` with `VITE_CLAWDI_HOSTED=true` and dummy build credentials
