### PR TITLE
fix(web): disambiguate shared deployment environments

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -155,6 +155,46 @@ const failedRetainedProjectionDeployment = {
 	},
 };
 
+const sharedLegacyEnvironmentId = "77777777-7777-4777-8777-777777777777";
+const newerSharedEnvironmentDeployment = {
+	...includedBasicDeployment,
+	id: "hdep_shared_newer",
+	name: "Newer twin",
+	created_at: "2026-07-15T00:00:00Z",
+	config_info: {
+		...includedBasicDeployment.config_info,
+		clawdi_cloud_environments: { hermes: sharedLegacyEnvironmentId },
+	},
+};
+const olderSharedEnvironmentDeployment = {
+	...newerSharedEnvironmentDeployment,
+	id: "hdep_shared_older",
+	name: "Older twin",
+	status: "stopped",
+	created_at: "2026-07-14T00:00:00Z",
+};
+const sharedLegacyCloudAgent = {
+	id: sharedLegacyEnvironmentId,
+	name: "shared-legacy-agent",
+	default_name: "shared-legacy-agent",
+	machine_name: "shared-legacy-agent",
+	display_name: null,
+	avatar_url: null,
+	sort_order: 0,
+	agent_type: "hermes",
+	agent_version: "1.0.0",
+	os: "linux",
+	last_seen_at: "2026-07-15T00:00:00Z",
+	last_sync_at: "2026-07-15T00:00:00Z",
+	last_sync_error: null,
+	last_revision_seen: 1,
+	queue_depth_high_water: 0,
+	dropped_count: 0,
+	sync_enabled: true,
+	explicit_identity: true,
+	default_project_id: "project-hosted",
+};
+
 const interruptedIdentitylessDeployment = {
 	...includedBasicDeployment,
 	id: "hdep_creation_interrupted",
@@ -284,6 +324,7 @@ type HostedApiStubOptions = {
 	cancelRequests?: string[];
 	checkoutRequests?: string[];
 	cloudAgentOverrides?: Record<string, unknown>;
+	cloudAgents?: readonly unknown[];
 	cloudAgentNotFoundIds?: readonly string[];
 	createRequests?: string[];
 	deleteRequests?: string[];
@@ -546,7 +587,7 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 	await page.route(`${CLOUD_API}/**`, (r) => {
 		const p = new URL(r.request().url()).pathname;
 		if (p === "/v1/me") return fulfillJson(r, me);
-		if (p === "/v1/agents") return fulfillJson(r, []);
+		if (p === "/v1/agents") return fulfillJson(r, options.cloudAgents ?? []);
 		if (p.startsWith("/v1/agents/") && r.request().method() === "GET") {
 			const id = decodeURIComponent(p.slice("/v1/agents/".length));
 			if (options.cloudAgentNotFoundIds?.includes(id)) {
@@ -768,6 +809,64 @@ test("failed deployment with a retained projection renders recovery without live
 	await expect
 		.poll(() => deleteRequests)
 		.toEqual(["/v2/deployments/hdep_failed_retained_projection"]);
+});
+
+test("shared legacy environment routes an older tile's actions to its deployment", async ({
+	page,
+}) => {
+	const deleteRequests: string[] = [];
+	await stubHostedApi(page, {
+		// The deploy API returns newest first.
+		deployments: [newerSharedEnvironmentDeployment, olderSharedEnvironmentDeployment],
+		plans: [basicPlan, performancePlan],
+		cloudAgents: [sharedLegacyCloudAgent],
+		deleteRequests,
+	});
+
+	await page.goto("/agents");
+	const agents = page.locator("main");
+	const newerTile = agents.getByRole("link").filter({ hasText: "Newer twin" });
+	const olderTile = agents.getByRole("link").filter({ hasText: "Older twin" });
+	await expect(newerTile).toBeVisible();
+	await expect(olderTile).toBeVisible();
+	await olderTile.click();
+	await page.getByRole("link", { name: "Settings", exact: true }).click();
+	await expect(page).toHaveURL(
+		new RegExp(`/agents/${sharedLegacyEnvironmentId}/settings\\?.*d=hdep_shared_older`),
+	);
+
+	const main = page.locator("main");
+	await main.getByRole("button", { name: "Delete", exact: true }).click();
+	await page
+		.getByRole("alertdialog")
+		.getByRole("button", { name: "Delete compute", exact: true })
+		.click();
+
+	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_shared_older"]);
+});
+
+test("shared legacy environment direct route asks the user to choose a deployment", async ({
+	page,
+}) => {
+	await stubHostedApi(page, {
+		deployments: [newerSharedEnvironmentDeployment, olderSharedEnvironmentDeployment],
+	});
+
+	await page.goto(`/agents/${sharedLegacyEnvironmentId}?source=on-clawdi`);
+	const main = page.locator("main");
+	await expect(main.getByRole("heading", { name: "Choose a deployment" })).toBeVisible();
+	const newerChoice = main.getByRole("link", { name: "Open Newer twin" });
+	const olderChoice = main.getByRole("link", { name: "Open Older twin" });
+	await expect(newerChoice).toContainText("Running");
+	await expect(newerChoice).toContainText("Created Jul 15, 2026");
+	await expect(olderChoice).toContainText("Stopped");
+	await expect(olderChoice).toContainText("Created Jul 14, 2026");
+	await expect(main.getByRole("button", { name: "Delete", exact: true })).toHaveCount(0);
+	await olderChoice.click();
+	await expect(page).toHaveURL(
+		new RegExp(`/agents/${sharedLegacyEnvironmentId}\\?.*d=hdep_shared_older`),
+	);
+	await expect(main.getByRole("heading", { name: "Overview" })).toBeVisible();
 });
 
 test("identity-less interrupted deployment tile exposes delete", async ({ page }) => {

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -99,6 +99,7 @@ import {
 } from "@/lib/agent-ownership";
 import {
 	type AgentSectionId,
+	agentDeploymentRouteQuery,
 	agentSectionHref,
 	agentSectionLabel,
 	parseAgentPathname,
@@ -479,6 +480,8 @@ function AgentSectionList({
 	extraPrimaryItems?: SidebarNavItem[];
 	onNavigate?: () => void;
 }) {
+	const searchStr = useLocation({ select: (location) => location.searchStr });
+	const routeQuery = agentDeploymentRouteQuery(searchStr);
 	const normalizedActiveSection = sections.some((section) => section.id === activeSection)
 		? activeSection
 		: "overview";
@@ -495,7 +498,7 @@ function AgentSectionList({
 			return {
 				id: section.id,
 				label: agentSectionLabel(section.id),
-				href: agentSectionHref(agentId, section.id),
+				href: agentSectionHref(agentId, section.id, routeQuery),
 				icon: Icon,
 				tint: AGENT_SECTION_TINTS[section.id],
 				tooltip: section.tooltip,
@@ -509,7 +512,7 @@ function AgentSectionList({
 		return {
 			id: section.id,
 			label: agentSectionLabel(section.id),
-			href: agentSectionHref(agentId, section.id),
+			href: agentSectionHref(agentId, section.id, routeQuery),
 			icon: Icon,
 			tint: AGENT_SECTION_TINTS[section.id],
 			tooltip: section.tooltip,
@@ -589,10 +592,12 @@ function AgentFocusLoadingSections({
 	activeSection: AgentSectionId;
 	onNavigate?: () => void;
 }) {
+	const searchStr = useLocation({ select: (location) => location.searchStr });
+	const routeQuery = agentDeploymentRouteQuery(searchStr);
 	const overviewItem: SidebarNavItem = {
 		id: "overview",
 		label: "Overview",
-		href: agentSectionHref(agentId),
+		href: agentSectionHref(agentId, "overview", routeQuery),
 		icon: LayoutDashboard,
 		tint: RESOURCE_TINT_CLASSES.overview,
 		tooltip: "Agent overview",
@@ -1199,6 +1204,8 @@ function FocusHeader({
 	activeAgentId: string | null;
 	showCloudFeatures: boolean;
 }) {
+	const searchStr = useLocation({ select: (location) => location.searchStr });
+	const routeQuery = agentDeploymentRouteQuery(searchStr);
 	const kind = useAgentChromeKind(activeAgent);
 	if (!activeAgent && !activeAgentId) {
 		return (
@@ -1230,7 +1237,7 @@ function FocusHeader({
 	const title = [name, meta.detailLabel, meta.activityLabel].filter(Boolean).join(" · ");
 	const manageHref =
 		kind === "cloud"
-			? agentSectionHref(activeAgent.id, "settings")
+			? agentSectionHref(activeAgent.id, "settings", routeQuery)
 			: kind === "legacy"
 				? (legacyHostedDashboardUrl() ?? undefined)
 				: undefined;

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -273,6 +273,7 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 		agent_type: tile.agentType,
 	});
 	const meta: string[] = [];
+	if (tile.contextLabel) meta.push(tile.contextLabel);
 	if (identity.secondaryLabel) meta.push(identity.secondaryLabel);
 	if (onClawdi) meta.push(tile.statusLabel);
 	const activityLabel = agentTileActivityLabel(tile);
@@ -330,7 +331,8 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 		ENTITY_CARD_BUTTON_FOCUS_CLASS,
 	);
 	const linkStatus = [statusDot.label, tile.secondaryStatus?.label].filter(Boolean).join(", ");
-	const linkLabel = `Open ${tile.name}. Status: ${linkStatus}`;
+	const linkIdentity = tile.contextLabel ? `${tile.name} (${tile.contextLabel})` : tile.name;
+	const linkLabel = `Open ${linkIdentity}. Status: ${linkStatus}`;
 
 	if (!tile.href) {
 		return (

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -1,22 +1,38 @@
 "use client";
 
-import { useLocation } from "@tanstack/react-router";
-import { RefreshCw } from "lucide-react";
+import { Link, useLocation } from "@tanstack/react-router";
+import { ChevronRight, RefreshCw } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
+import { AgentIcon } from "@/components/dashboard/agent-icon";
 import {
 	ConnectedAgentDetail,
 	ConnectedAgentDetailSkeleton,
 } from "@/components/dashboard/connected-agent-detail";
 import { EmptyState } from "@/components/empty-state";
+import {
+	ENTITY_CARD_BASE,
+	ENTITY_CARD_BUTTON_FOCUS_CLASS,
+	EntityHeader,
+} from "@/components/entity-card";
+import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { Button } from "@/components/ui/button";
-import { isCloudEnvId } from "@/hosted/agent-identity";
-import { useAgentDeployment } from "@/hosted/agents/deployment-hooks";
+import { deploymentDisplayName, isCloudEnvId } from "@/hosted/agent-identity";
+import { type AgentDeploymentMatch, useAgentDeployment } from "@/hosted/agents/deployment-hooks";
 import { HostedAgentDetail } from "@/hosted/agents/hosted-agent-detail";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
+import { deploymentStatusLabel, parseDeploymentStatus } from "@/hosted/deployment-status";
 import { defaultDeploymentRuntime, isHostedRuntime } from "@/hosted/runtimes";
-import type { AgentSectionId } from "@/lib/agent-routes";
+import {
+	AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY,
+	type AgentSectionId,
+	agentDeploymentRouteQuery,
+	agentDeploymentSelector,
+	agentSectionHref,
+} from "@/lib/agent-routes";
+import { formatShortDate } from "@/lib/format";
+import { cn } from "@/lib/utils";
 
 const UNRESOLVED_HOSTED_AGENT_REFETCH_INTERVAL_MS = 5_000;
 const UNRESOLVED_HOSTED_AGENT_MAX_REFETCH_ATTEMPTS = 24;
@@ -37,19 +53,23 @@ export function AgentHome({
 }) {
 	const searchStr = useLocation({ select: (location) => location.searchStr });
 	const searchParams = new URLSearchParams(searchStr);
+	const deploymentSelector = agentDeploymentSelector(searchParams);
 	const {
 		deployment,
 		environmentId: resolvedEnvId,
 		matchedRuntime,
+		ambiguousMatches,
 		isLoading,
 		isFetching,
 		error,
 		refetch,
-	} = useAgentDeployment(environmentId);
+	} = useAgentDeployment(environmentId, deploymentSelector);
 	const isCloudEnvironmentId = isCloudEnvId(environmentId);
 	const requestedFromCloudRedirect = searchParams.get("source") === "on-clawdi";
-	const requestedHostedAgent = requestedFromCloudRedirect || !isCloudEnvironmentId;
-	const unresolvedHostedAgent = requestedHostedAgent && !deployment && !error && !isLoading;
+	const requestedHostedAgent =
+		requestedFromCloudRedirect || Boolean(deploymentSelector) || !isCloudEnvironmentId;
+	const unresolvedHostedAgent =
+		requestedHostedAgent && !deployment && ambiguousMatches.length === 0 && !error && !isLoading;
 	const shouldAutoRefetchUnresolvedHostedAgent =
 		unresolvedHostedAgent && (requestedFromCloudRedirect || isCloudEnvironmentId);
 	const isFetchingRef = useRef(isFetching);
@@ -107,6 +127,17 @@ export function AgentHome({
 		);
 	}
 
+	if (ambiguousMatches.length > 0) {
+		return (
+			<DeploymentChooser
+				environmentId={environmentId}
+				section={section}
+				searchStr={searchStr}
+				matches={ambiguousMatches}
+			/>
+		);
+	}
+
 	if (deployment) {
 		// Scope the detail to a single runtime. Prefer the env's matched runtime;
 		// fall back to the deployment default when the route used a deployment id.
@@ -144,4 +175,62 @@ export function AgentHome({
 	}
 
 	return <ConnectedAgentDetail environmentId={environmentId} section={section} />;
+}
+
+function DeploymentChooser({
+	environmentId,
+	section,
+	searchStr,
+	matches,
+}: {
+	environmentId: string;
+	section: AgentSectionId;
+	searchStr: string;
+	matches: readonly AgentDeploymentMatch[];
+}) {
+	return (
+		<div
+			data-hosted="true"
+			className={`${CENTERED_PAGE_WIDTH_CLASS.page} flex flex-col gap-4 px-4 py-2 lg:px-6`}
+		>
+			<PageHeader
+				title="Choose a deployment"
+				description="Multiple legacy deployments share this agent identity. Choose the deployment you want to manage."
+			/>
+			<div className="grid max-w-2xl gap-2">
+				{matches.map((match) => {
+					const { deployment } = match;
+					const name = deploymentDisplayName(deployment.name);
+					const query = {
+						...agentDeploymentRouteQuery(searchStr),
+						[AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY]: deployment.id,
+					};
+					return (
+						<Link
+							key={deployment.id}
+							to={agentSectionHref(environmentId, section, query)}
+							aria-label={`Open ${name}`}
+							className={cn(
+								ENTITY_CARD_BASE,
+								ENTITY_CARD_BUTTON_FOCUS_CLASS,
+								"block transition-colors hover:bg-muted/50",
+							)}
+						>
+							<EntityHeader
+								icon={<AgentIcon agent={match.runtime} size="lg" />}
+								title={name}
+								meta={[
+									deploymentStatusLabel(parseDeploymentStatus(deployment.status)),
+									`Created ${formatShortDate(deployment.created_at)}`,
+								]}
+								titleAdornment={
+									<ChevronRight className="size-4 text-muted-foreground/60" aria-hidden />
+								}
+							/>
+						</Link>
+					);
+				})}
+			</div>
+		</div>
+	);
 }

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { deleteDeploymentToastDecision } from "@/hosted/agents/delete-deployment-toast.logic";
 import { useBillingClient } from "@/hosted/billing/billing-client";
 import type {
+	HostedDeployment,
 	RebindAgentAiProviderRequest,
 	SetAgentEnabledRequest,
 } from "@/hosted/billing/contracts";
@@ -53,23 +54,16 @@ function toastAgentLanguageTimezoneError(error: unknown) {
 /**
  * Resolve the hosted deployment that backs a cloud-api environment, joined via
  * `config_info.clawdi_cloud_environments[runtime] === environmentId` (same join
- * the agent tiles use). Returns null for self-managed (CLI) agents.
+ * the agent tiles use). Duplicate joins remain unresolved until an explicit
+ * deployment selector is present.
  */
-export function useAgentDeployment(environmentId: string) {
-	const query = useHostedDeployments({ pollWalletDunningFor: environmentId });
-	const match = useMemo(() => {
-		const target = environmentId.toLowerCase();
-		for (const d of query.data ?? []) {
-			// Direct deployment-id match: the post-deploy redirect lands on
-			// `/agents/<deployment.id>` because cloud-api env ids aren't minted
-			// until provisioning finishes — resolve by id, not just the env join.
-			if (d.id.toLowerCase() === target) return { deployment: d, runtime: null };
-			const envs = d.config_info?.clawdi_cloud_environments ?? {};
-			const runtime = Object.entries(envs).find(([, v]) => (v ?? "").toLowerCase() === target);
-			if (runtime) return { deployment: d, runtime: runtime[0] };
-		}
-		return null;
-	}, [query.data, environmentId]);
+export function useAgentDeployment(environmentId: string, deploymentSelector?: string | null) {
+	const query = useHostedDeployments({ pollWalletDunningFor: deploymentSelector ?? environmentId });
+	const resolution = useMemo(
+		() => resolveAgentDeployment(query.data ?? [], environmentId, deploymentSelector),
+		[query.data, environmentId, deploymentSelector],
+	);
+	const match = resolution.match;
 
 	// The env id to drive per-env queries (sessions, channel links). For an
 	// env-id route it's the route param itself; for a deployment-id route
@@ -85,12 +79,56 @@ export function useAgentDeployment(environmentId: string) {
 	return {
 		deployment: match?.deployment ?? null,
 		matchedRuntime: match?.runtime ?? null,
+		ambiguousMatches: resolution.ambiguousMatches,
 		environmentId: resolvedEnvId,
 		isLoading: query.isLoading,
 		isFetching: query.isFetching,
 		error: query.error,
 		refetch: query.refetch,
 	};
+}
+
+export type AgentDeploymentMatch = {
+	deployment: HostedDeployment;
+	runtime: string | null;
+};
+
+export type AgentDeploymentResolution = {
+	match: AgentDeploymentMatch | null;
+	ambiguousMatches: AgentDeploymentMatch[];
+};
+
+export function resolveAgentDeployment(
+	deployments: readonly HostedDeployment[],
+	environmentId: string,
+	deploymentSelector?: string | null,
+): AgentDeploymentResolution {
+	const target = environmentId.toLowerCase();
+	// Direct deployment-id match: the post-deploy redirect lands on
+	// `/agents/<deployment.id>` because cloud-api env ids aren't minted until
+	// provisioning finishes — resolve by id, not just the env join.
+	const direct = deployments.find((deployment) => deployment.id.toLowerCase() === target);
+	if (direct) {
+		return { match: { deployment: direct, runtime: null }, ambiguousMatches: [] };
+	}
+
+	const matches: AgentDeploymentMatch[] = [];
+	for (const deployment of deployments) {
+		const envs = deployment.config_info?.clawdi_cloud_environments ?? {};
+		const runtime = Object.entries(envs).find(
+			([, value]) => (value ?? "").toLowerCase() === target,
+		);
+		if (runtime) matches.push({ deployment, runtime: runtime[0] });
+	}
+
+	if (deploymentSelector) {
+		const selector = deploymentSelector.toLowerCase();
+		const selected = matches.find((item) => item.deployment.id.toLowerCase() === selector);
+		if (selected) return { match: selected, ambiguousMatches: [] };
+	}
+
+	if (matches.length === 1) return { match: matches[0], ambiguousMatches: [] };
+	return { match: null, ambiguousMatches: matches };
 }
 
 export function useSetAgentLanguageTimezone() {

--- a/apps/web/src/hosted/billing/deployment-links.test.ts
+++ b/apps/web/src/hosted/billing/deployment-links.test.ts
@@ -41,14 +41,14 @@ function deployment(envs: Record<string, string> | null): HostedDeployment {
 describe("hostedEnvironmentHref", () => {
 	test("links to the minted cloud environment when available", () => {
 		expect(hostedEnvironmentHref(deployment({ openclaw: "env 1" }))).toBe(
-			"/agents/env%201?source=on-clawdi",
+			"/agents/env%201?source=on-clawdi&d=dep_123",
 		);
 	});
 
 	test("ignores stale Codex mappings when execution runtime environments exist", () => {
 		expect(
 			hostedEnvironmentHref(deployment({ openclaw: "env openclaw", codex: "env codex" })),
-		).toBe("/agents/env%20openclaw?source=on-clawdi");
+		).toBe("/agents/env%20openclaw?source=on-clawdi&d=dep_123");
 	});
 
 	test("does not treat the deployment id as an agent environment id", () => {

--- a/apps/web/src/hosted/billing/deployment-links.ts
+++ b/apps/web/src/hosted/billing/deployment-links.ts
@@ -1,10 +1,15 @@
 import type { HostedDeployment } from "@/hosted/billing/contracts";
 import { deploymentRuntimes, runtimeEnvironmentId } from "@/hosted/runtimes";
-import { agentSectionHref } from "@/lib/agent-routes";
+import { AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY, agentSectionHref } from "@/lib/agent-routes";
 
 export function hostedEnvironmentHref(deployment: HostedDeployment): string | null {
 	const envId = deploymentRuntimes(deployment)
 		.map((runtime) => runtimeEnvironmentId(deployment.config_info, runtime))
 		.find((value): value is string => Boolean(value));
-	return envId ? agentSectionHref(envId, "overview", "source=on-clawdi") : null;
+	return envId
+		? agentSectionHref(envId, "overview", {
+				source: "on-clawdi",
+				[AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY]: deployment.id,
+			})
+		: null;
 }

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -6,11 +6,14 @@ type HostedAgentTileStatus = typeof import("@/hosted/use-hosted-agent-tiles").ho
 type DeploymentToTiles = typeof import("@/hosted/use-hosted-agent-tiles").deploymentToTiles;
 type HostedRuntimeStatusView =
 	typeof import("@/hosted/use-hosted-agent-tiles").hostedRuntimeStatusView;
+type ResolveAgentDeployment =
+	typeof import("@/hosted/agents/deployment-hooks").resolveAgentDeployment;
 type Env = components["schemas"]["AgentResponse"];
 
 let getTileStatus: HostedAgentTileStatus | null = null;
 let getDeploymentToTiles: DeploymentToTiles | null = null;
 let getRuntimeStatusView: HostedRuntimeStatusView | null = null;
+let getAgentDeploymentResolution: ResolveAgentDeployment | null = null;
 
 beforeAll(async () => {
 	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
@@ -20,6 +23,8 @@ beforeAll(async () => {
 	getTileStatus = module.hostedAgentTileStatus;
 	getDeploymentToTiles = module.deploymentToTiles;
 	getRuntimeStatusView = module.hostedRuntimeStatusView;
+	const deploymentHooks = await import("@/hosted/agents/deployment-hooks");
+	getAgentDeploymentResolution = deploymentHooks.resolveAgentDeployment;
 });
 
 function hostedAgentTileStatus(rawStatus: string) {
@@ -42,6 +47,15 @@ function hostedDeploymentToTiles(deployment: HostedDeployment, envs: Env[] = [])
 		deployment,
 		new Map(envs.map((item) => [item.id.toLowerCase(), item])),
 	);
+}
+
+function resolveAgentDeployment(
+	deployments: readonly HostedDeployment[],
+	environmentId: string,
+	deploymentSelector?: string,
+) {
+	if (!getAgentDeploymentResolution) throw new Error("resolveAgentDeployment was not loaded");
+	return getAgentDeploymentResolution(deployments, environmentId, deploymentSelector);
 }
 
 function env(overrides: Partial<Env> = {}): Env {
@@ -132,8 +146,10 @@ describe("deploymentToTiles", () => {
 
 		expect(tiles.map((tile) => tile.agentType)).toEqual(["openclaw"]);
 		expect(tiles.map((tile) => tile.id)).toEqual(["dep_123"]);
-		expect(tiles[0]?.href).toBe(`/agents/${openclawEnv.id}?source=on-clawdi`);
-		expect(tiles[0]?.manageHref).toBe(`/agents/${openclawEnv.id}/settings?source=on-clawdi`);
+		expect(tiles[0]?.href).toBe(`/agents/${openclawEnv.id}?source=on-clawdi&d=dep_123`);
+		expect(tiles[0]?.manageHref).toBe(
+			`/agents/${openclawEnv.id}/settings?source=on-clawdi&d=dep_123`,
+		);
 	});
 
 	test("projects dunning state as the hosted tile secondary status", () => {
@@ -212,7 +228,7 @@ describe("deploymentToTiles", () => {
 		expect(tile).toMatchObject({
 			id: "dep_123",
 			source: "on-clawdi",
-			href: `/agents/${environmentId}?source=on-clawdi`,
+			href: `/agents/${environmentId}?source=on-clawdi&d=dep_123`,
 			env: null,
 			secondaryStatus: {
 				label: "Failure: startup_probe_failing; restart_count=2",
@@ -249,6 +265,44 @@ describe("deploymentToTiles", () => {
 		});
 		expect(tile?.action).toBeDefined();
 		expect(JSON.stringify(tile)).not.toContain("/agents/dep_123");
+	});
+});
+
+describe("resolveAgentDeployment", () => {
+	const sharedEnvironmentId = "66666666-6666-4666-8666-666666666666";
+	const newer = deployment(
+		{ id: "dep_newer", name: "Newer twin", created_at: "2026-07-15T00:00:00Z" },
+		{ clawdi_cloud_environments: { openclaw: sharedEnvironmentId } },
+	);
+	const older = deployment(
+		{ id: "dep_older", name: "Older twin", created_at: "2026-07-14T00:00:00Z" },
+		{ clawdi_cloud_environments: { openclaw: sharedEnvironmentId } },
+	);
+
+	test("keeps the common unambiguous environment join behavior", () => {
+		const resolution = resolveAgentDeployment([newer], sharedEnvironmentId);
+
+		expect(resolution.match?.deployment.id).toBe("dep_newer");
+		expect(resolution.match?.runtime).toBe("openclaw");
+		expect(resolution.ambiguousMatches).toEqual([]);
+	});
+
+	test("detects every deployment sharing an environment instead of picking newest", () => {
+		const resolution = resolveAgentDeployment([newer, older], sharedEnvironmentId);
+
+		expect(resolution.match).toBeNull();
+		expect(resolution.ambiguousMatches.map((match) => match.deployment.id)).toEqual([
+			"dep_newer",
+			"dep_older",
+		]);
+	});
+
+	test("prefers an explicit deployment selector within the environment matches", () => {
+		const resolution = resolveAgentDeployment([newer, older], sharedEnvironmentId, "dep_older");
+
+		expect(resolution.match?.deployment.id).toBe("dep_older");
+		expect(resolution.match?.runtime).toBe("openclaw");
+		expect(resolution.ambiguousMatches).toEqual([]);
 	});
 });
 

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -33,7 +33,7 @@ import {
 import { HostedDeploymentTileDeleteAction } from "@/hosted/hosted-deployment-tile-action";
 import { deploymentRuntime, runtimeDisplayName, runtimeEnvironmentId } from "@/hosted/runtimes";
 import { normalizeAgentEnvId } from "@/lib/agent-ownership";
-import { agentSectionHref } from "@/lib/agent-routes";
+import { AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY, agentSectionHref } from "@/lib/agent-routes";
 
 type Env = components["schemas"]["AgentResponse"];
 type DeploymentStatusInput = Pick<HostedDeployment, "status" | "failure_reason">;
@@ -236,9 +236,13 @@ export function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>
 	// join only decorates the tile and may legitimately lag or be missing.
 	const envId = runtimeEnvironmentId(d.config_info, runtime);
 	const matchedEnv = envId ? envById.get(envId.toLowerCase()) : undefined;
-	const detailHref = envId ? agentSectionHref(envId, "overview", "source=on-clawdi") : null;
+	const routeQuery = {
+		source: "on-clawdi",
+		[AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY]: d.id,
+	};
+	const detailHref = envId ? agentSectionHref(envId, "overview", routeQuery) : null;
 	const settingsHref = matchedEnv
-		? agentSectionHref(matchedEnv.id, "settings", "source=on-clawdi")
+		? agentSectionHref(matchedEnv.id, "settings", routeQuery)
 		: undefined;
 	const name = matchedEnv ? agentDisplayName(matchedEnv) : runtimeDisplayName(runtime);
 	const contextLabel = slug !== name ? slug : null;

--- a/apps/web/src/lib/agent-routes.test.ts
+++ b/apps/web/src/lib/agent-routes.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
+	agentDeploymentRouteQuery,
+	agentDeploymentSelector,
 	agentRouteQueryString,
 	agentSectionHref,
 	agentSectionLabel,
@@ -42,6 +44,19 @@ describe("agent routes", () => {
 				empty: undefined,
 			}),
 		).toBe("/agents/agent%201/sessions?tag=a&tag=b");
+	});
+
+	it("preserves only deployment identity while navigating agent sections", () => {
+		const query = "source=on-clawdi&d=dep_older&checkout=success";
+
+		expect(agentDeploymentSelector(query)).toBe("dep_older");
+		expect(agentDeploymentRouteQuery(query)).toEqual({
+			source: "on-clawdi",
+			d: "dep_older",
+		});
+		expect(agentSectionHref("agent 1", "settings", agentDeploymentRouteQuery(query))).toBe(
+			"/agents/agent%201/settings?source=on-clawdi&d=dep_older",
+		);
 	});
 
 	it("parses only canonical section segments", () => {

--- a/apps/web/src/lib/agent-routes.ts
+++ b/apps/web/src/lib/agent-routes.ts
@@ -12,6 +12,8 @@ export type AgentSectionId =
 export type RouteSearchParamsRecord = Record<string, string | string[] | undefined>;
 export type AgentRouteQuery = string | URLSearchParams | RouteSearchParamsRecord | null | undefined;
 
+export const AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY = "d";
+
 export const CONNECTED_AGENT_SECTION_IDS = [
 	"overview",
 	"sessions",
@@ -123,6 +125,23 @@ function agentRouteSearchParams(query?: AgentRouteQuery): URLSearchParams {
 
 export function hasAgentTabQuery(query?: AgentRouteQuery): boolean {
 	return agentRouteSearchParams(query).has("tab");
+}
+
+export function agentDeploymentSelector(query?: AgentRouteQuery): string | null {
+	const selector = agentRouteSearchParams(query).get(AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY)?.trim();
+	return selector || null;
+}
+
+export function agentDeploymentRouteQuery(
+	query?: AgentRouteQuery,
+): RouteSearchParamsRecord | undefined {
+	const params = agentRouteSearchParams(query);
+	const selector = agentDeploymentSelector(params);
+	if (!selector) return undefined;
+	return {
+		source: params.get("source") || undefined,
+		[AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY]: selector,
+	};
 }
 
 export function agentRouteQueryString(query?: AgentRouteQuery): string {


### PR DESCRIPTION
## Summary

- carry deployment identity through canonical environment routes and preserve it across hosted agent navigation
- detect legacy deployments sharing an environment, honor an explicit deployment selector, and render a chooser for ambiguous direct URLs
- render deployment context labels on hosted cards so shared-environment twins remain distinguishable
- keep all detail actions keyed by the resolved deployment object ID

## Test-first regression

The older-tile Playwright regression initially failed with:

    Expected: /v2/deployments/hdep_shared_older
    Received: /v2/deployments/hdep_shared_newer

The final coverage verifies selector-based resolution, safe DELETE targeting, and the ambiguous direct-URL chooser.

## Verification

- bun run --cwd apps/web typecheck
- bun run --cwd apps/web test (464 passed)
- bun run --cwd apps/web lint
- bunx biome check apps/web/src
- bun run --cwd apps/web build:oss
- VITE_CLAWDI_HOSTED=true VITE_CLERK_PUBLISHABLE_KEY=pk_test_dummy bun run --cwd apps/web build
- bun run --cwd apps/web e2e:hosted (35 passed)