### PR TITLE
fix(web): harden v2 billing interactions

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -316,9 +316,21 @@ const stripeFallbackDeployment = {
 	},
 };
 
-type StubResponse = { body: unknown; status: number };
+type StubResponse = { body: unknown; status: number; delayMs?: number };
+
+function isStubResponse(value: unknown): value is StubResponse {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"body" in value &&
+		"status" in value &&
+		typeof value.status === "number"
+	);
+}
 
 type HostedApiStubOptions = {
+	autoReloadRequests?: string[];
+	autoReloadResponses?: StubResponse[];
 	billingHistoryRequests?: string[];
 	billingHistoryResponses?: unknown[];
 	cancelRequests?: string[];
@@ -354,6 +366,7 @@ type HostedApiStubOptions = {
 	walletPlanCancelResponses?: StubResponse[];
 	walletPlanQuoteRequests?: string[];
 	walletPlanQuoteResponses?: StubResponse[];
+	walletState?: typeof walletState;
 	onWalletActivateSuccess?: () => void;
 	onWalletPlanChangeSuccess?: () => void;
 	onWalletPlanCancelSuccess?: () => void;
@@ -368,22 +381,38 @@ async function fulfillJson(route: Route, body: unknown, status = 200) {
 async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 	const deployments = options.deployments ?? [];
 	const plans = options.plans ?? [];
+	let currentWallet = options.walletState ?? walletState;
 	// Deploy API (/me, /v2/*).
-	await page.route(`${DEPLOY_API}/**`, (r) => {
+	await page.route(`${DEPLOY_API}/**`, async (r) => {
 		const p = new URL(r.request().url()).pathname;
 		if (p === "/me" || p === "/v1/me") return fulfillJson(r, me);
 		if (p === "/v2/subscription/plans") return fulfillJson(r, plans);
 		if (p === "/v2/wallet" && r.request().method() === "GET") {
-			return fulfillJson(r, walletState);
+			return fulfillJson(r, currentWallet);
+		}
+		if (p === "/v2/wallet/auto-reload" && r.request().method() === "PUT") {
+			const requestBody = r.request().postData() ?? "";
+			options.autoReloadRequests?.push(requestBody);
+			const response = options.autoReloadResponses?.shift();
+			if (response?.delayMs) {
+				await new Promise((resolve) => setTimeout(resolve, response.delayMs));
+			}
+			if (response) {
+				if (response.status < 400) currentWallet = response.body as typeof walletState;
+				return fulfillJson(r, response.body, response.status);
+			}
+			const request = JSON.parse(requestBody) as Partial<typeof walletState>;
+			currentWallet = { ...currentWallet, ...request };
+			return fulfillJson(r, currentWallet);
 		}
 		if (p === "/v2/wallet/ledger" && r.request().method() === "GET") {
 			options.ledgerRequests?.push(r.request().url());
 			const limit = Number(new URL(r.request().url()).searchParams.get("limit"));
-			return fulfillJson(
-				r,
-				options.ledgerResponseForRequest?.(limit) ??
-					options.ledgerResponses?.shift() ?? { items: [], has_more: false },
-			);
+			const response = options.ledgerResponseForRequest?.(limit) ??
+				options.ledgerResponses?.shift() ?? { items: [], has_more: false };
+			return isStubResponse(response)
+				? fulfillJson(r, response.body, response.status)
+				: fulfillJson(r, response);
 		}
 		if (p === "/v2/deployments" && r.request().method() === "GET") {
 			return fulfillJson(r, deployments);
@@ -539,6 +568,9 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 					credits_added: 25_000,
 				},
 			};
+			if (response.delayMs) {
+				await new Promise((resolve) => setTimeout(resolve, response.delayMs));
+			}
 			return fulfillJson(r, response.body, response.status);
 		}
 		if (p === "/v2/subscription/fix-payment" && r.request().method() === "POST") {
@@ -547,14 +579,14 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		}
 		if (p === "/v2/subscription/billing-history" && r.request().method() === "GET") {
 			options.billingHistoryRequests?.push(r.request().url());
-			return fulfillJson(
-				r,
-				options.billingHistoryResponses?.shift() ?? {
-					data: [],
-					has_more: false,
-					next_cursor: null,
-				},
-			);
+			const response = options.billingHistoryResponses?.shift() ?? {
+				data: [],
+				has_more: false,
+				next_cursor: null,
+			};
+			return isStubResponse(response)
+				? fulfillJson(r, response.body, response.status)
+				: fulfillJson(r, response);
 		}
 		if (p === "/v2/subscription/cancel" && r.request().method() === "POST") {
 			options.cancelRequests?.push(r.request().postData() ?? "");
@@ -1776,6 +1808,10 @@ test("mixed billing history paginates wallet charges and Stripe invoices", async
 				next_cursor: "cursor_2",
 			},
 			{
+				status: 400,
+				body: { detail: "billing_history_backend_unavailable" },
+			},
+			{
 				data: [
 					{
 						id: "wallet:2",
@@ -1802,16 +1838,26 @@ test("mixed billing history paginates wallet charges and Stripe invoices", async
 	await expect(billingTable.locator('a[href="https://invoice.stripe.test/in_1"]')).toBeVisible();
 	await settingsDialog.getByRole("button", { name: "Load more" }).click();
 	await expect.poll(() => billingHistoryRequests.length).toBe(2);
+	await expect(
+		settingsDialog.getByText("Couldn’t load more billing history", { exact: true }),
+	).toBeVisible();
+	await expect(billingTable.getByText("Applied", { exact: true })).toBeVisible();
+	await settingsDialog.getByRole("button", { name: "Retry" }).click();
+	await expect.poll(() => billingHistoryRequests.length).toBe(3);
 	expect(new URL(billingHistoryRequests[1] ?? "http://invalid").searchParams.get("cursor")).toBe(
 		"cursor_2",
 	);
 	await expect(billingTable.getByText("Refunded", { exact: true })).toBeVisible();
 	await settingsDialog.screenshot({ path: "/tmp/mixed-billing-history.png" });
-	expect(errors, `mixed billing history: ${errors.join(" | ")}`).toEqual([]);
+	expect(
+		errors.filter((error) => !error.includes("status of 400")),
+		`mixed billing history: ${errors.join(" | ")}`,
+	).toEqual([]);
 });
 
 test("Wallet activity caps show-more requests at the ledger API limit", async ({ page }) => {
 	const ledgerRequests: string[] = [];
+	let expandedAttempts = 0;
 	const computeCharge = {
 		id: "ledger-compute-charge",
 		operation: "compute_charge",
@@ -1822,9 +1868,11 @@ test("Wallet activity caps show-more requests at the ledger API limit", async ({
 	};
 	await stubHostedApi(page, {
 		ledgerRequests,
-		ledgerResponseForRequest: (limit) =>
-			limit === 50
-				? { items: [computeCharge], has_more: true }
+		ledgerResponseForRequest: (limit) => {
+			if (limit === 50) return { items: [computeCharge], has_more: true };
+			expandedAttempts += 1;
+			return expandedAttempts === 1
+				? { status: 400, body: { detail: "ledger_backend_unavailable" } }
 				: {
 						items: [
 							computeCharge,
@@ -1837,7 +1885,8 @@ test("Wallet activity caps show-more requests at the ledger API limit", async ({
 							},
 						],
 						has_more: true,
-					},
+					};
+		},
 		plans: [basicPlan, performancePlan],
 	});
 	const settingsDialog = await gotoHostedSettingsDialog(page, "billing-wallet");
@@ -1847,6 +1896,12 @@ test("Wallet activity caps show-more requests at the ledger API limit", async ({
 	await expect(ledgerTable.getByText("Compute charge", { exact: true })).toBeVisible();
 	await settingsDialog.getByRole("button", { name: "Show more" }).click();
 	await expect.poll(() => ledgerRequests.length).toBe(2);
+	await expect(
+		settingsDialog.getByText("Couldn’t load more activity", { exact: true }),
+	).toBeVisible();
+	await expect(ledgerTable.getByText("Compute charge", { exact: true })).toBeVisible();
+	await settingsDialog.getByRole("button", { name: "Retry" }).click();
+	await expect.poll(() => ledgerRequests.length).toBe(3);
 	await expect(ledgerTable.getByText("Compute reversal", { exact: true })).toBeVisible();
 	await expect(settingsDialog.getByRole("button", { name: "Show more" })).toHaveCount(0);
 	await expect(settingsDialog).toContainText(
@@ -1856,7 +1911,154 @@ test("Wallet activity caps show-more requests at the ledger API limit", async ({
 	const limits = ledgerRequests.map((url) => Number(new URL(url).searchParams.get("limit")));
 	expect([...new Set(limits)]).toEqual([50, 100]);
 	expect(limits.every((limit) => limit <= 100)).toBe(true);
-	expect(errors, `wallet ledger cap: ${errors.join(" | ")}`).toEqual([]);
+	expect(
+		errors.filter((error) => !error.includes("status of 400")),
+		`wallet ledger cap: ${errors.join(" | ")}`,
+	).toEqual([]);
+});
+
+test("auto-reload batches toggle and fields into one explicit save", async ({ page }) => {
+	const errors = collectBrowserErrors(page);
+	const autoReloadRequests: string[] = [];
+	const savedWallet = {
+		...walletState,
+		auto_reload_enabled: true,
+		auto_reload_threshold_credits: 7_500,
+		auto_reload_amount_cents: 3_000,
+		auto_reload_monthly_cap_cents: 12_500,
+	};
+	await stubHostedApi(page, {
+		autoReloadRequests,
+		autoReloadResponses: [
+			{
+				status: 400,
+				body: { detail: "Auto reload requires a default payment method" },
+				delayMs: 250,
+			},
+			{ status: 200, body: savedWallet },
+		],
+		plans: [basicPlan, performancePlan],
+	});
+	const settingsDialog = await gotoHostedSettingsDialog(page, "billing-wallet");
+	const card = settingsDialog.locator('[data-slot="card"]').filter({ hasText: "Auto-reload" });
+	const enabled = card.getByRole("switch", { name: "Enabled" });
+	const threshold = card.getByLabel("When balance is below (USD)");
+	const amount = card.getByLabel("Amount to add (USD)");
+	const cap = card.getByLabel("Monthly cap (USD)");
+	const save = card.getByRole("button", { name: "Save changes" });
+	const cancel = card.getByRole("button", { name: "Cancel changes" });
+
+	await expect(card.getByText("All changes saved", { exact: true })).toBeVisible();
+	await expect(save).toBeDisabled();
+	await expect(cancel).toBeDisabled();
+
+	await enabled.click();
+	await threshold.fill("7.50");
+	await amount.fill("30");
+	await cap.fill("125");
+	await expect(card.getByText("Unsaved changes", { exact: true })).toBeVisible();
+	expect(autoReloadRequests).toEqual([]);
+
+	await cancel.click();
+	await expect(enabled).not.toBeChecked();
+	await expect(threshold).toHaveValue("5");
+	await expect(amount).toHaveValue("25");
+	await expect(cap).toHaveValue("100");
+	await expect(save).toBeDisabled();
+	expect(autoReloadRequests).toEqual([]);
+
+	await enabled.click();
+	await threshold.fill("7.50");
+	await amount.fill("30");
+	await cap.fill("125");
+	await settingsDialog.getByRole("button", { name: /^Compute/ }).click();
+	const discardDialog = page.getByRole("alertdialog");
+	await expect(discardDialog.getByText("Discard unsaved changes?", { exact: true })).toBeVisible();
+	await discardDialog.getByRole("button", { name: "Keep editing" }).click();
+	await expect(card).toBeVisible();
+
+	await card.screenshot({ path: "/tmp/auto-reload-dirty.png" });
+	await save.evaluate((button: HTMLButtonElement) => {
+		button.click();
+		button.click();
+	});
+	await expect(card.getByRole("button", { name: "Saving…" })).toBeDisabled();
+	await expect.poll(() => autoReloadRequests.length).toBe(1);
+	await expect(
+		card.getByText("Add a card before enabling auto-reload", { exact: true }),
+	).toBeVisible();
+	await expect(card.getByRole("button", { name: "Add a card" })).toBeVisible();
+	await expect(card.getByText("Unsaved changes", { exact: true })).toBeVisible();
+	await card.screenshot({ path: "/tmp/auto-reload-error.png" });
+
+	await save.click();
+	await expect.poll(() => autoReloadRequests.length).toBe(2);
+	await expect(card.getByText("All changes saved", { exact: true })).toBeVisible();
+	await expect(enabled).toBeChecked();
+	await expect(save).toBeDisabled();
+	await card.screenshot({ path: "/tmp/auto-reload-saved.png" });
+
+	for (const raw of autoReloadRequests) {
+		expect(JSON.parse(raw)).toEqual({
+			auto_reload_enabled: true,
+			auto_reload_threshold_credits: 7_500,
+			auto_reload_amount_cents: 3_000,
+			auto_reload_monthly_cap_cents: 12_500,
+		});
+	}
+	expect(
+		errors.filter((error) => !error.includes("status of 400")),
+		`auto-reload save: ${errors.join(" | ")}`,
+	).toEqual([]);
+});
+
+test("top-up validates the amount and blocks duplicate submission or close in flight", async ({
+	page,
+}) => {
+	const errors = collectBrowserErrors(page);
+	const topUpRequests: string[] = [];
+	await stubHostedApi(page, {
+		topUpRequests,
+		topUpResponses: [
+			{
+				status: 200,
+				delayMs: 250,
+				body: {
+					status: "succeeded",
+					flow_type: "mock",
+					payment_intent_id: null,
+					client_secret: null,
+					credits_added: 40_000,
+				},
+			},
+		],
+		plans: [basicPlan, performancePlan],
+	});
+	const settingsDialog = await gotoHostedSettingsDialog(page, "billing-wallet");
+	await settingsDialog.getByRole("button", { name: "Top up" }).click();
+	const topUpDialog = page.getByRole("dialog").filter({ hasText: "Top up AI Credits" });
+	const amount = topUpDialog.getByLabel("Amount (USD)");
+
+	await amount.fill("25.50");
+	await amount.blur();
+	await expect(
+		topUpDialog.getByText("Enter a whole-dollar amount from $10.00 to $2,000.00.", {
+			exact: true,
+		}),
+	).toBeVisible();
+	await amount.fill("40");
+	const submit = topUpDialog.getByRole("button", { name: "Continue with $40.00" });
+	await submit.evaluate((button: HTMLButtonElement) => {
+		button.click();
+		button.click();
+	});
+	await expect(topUpDialog.getByRole("button", { name: "Starting…" })).toBeDisabled();
+	await page.keyboard.press("Escape");
+	await expect(topUpDialog).toBeVisible();
+	await expect.poll(() => topUpRequests.length).toBe(1);
+	await expect(topUpDialog).toHaveCount(0);
+	expect(JSON.parse(topUpRequests[0] ?? "{}")).toEqual({ amount_cents: 4_000 });
+	expect(errors, `top-up interaction: ${errors.join(" | ")}`).toEqual([]);
 });
 
 test("top-up rotates its idempotency key after an explicit reuse conflict", async ({ page }) => {
@@ -1914,7 +2116,7 @@ test("Wallet summarizes compute commitment, coverage, renewal, and deployment li
 	await expect(settingsDialog.getByText("Monthly commitment", { exact: true })).toBeVisible();
 	await expect(settingsDialog.getByText("$9.00", { exact: true })).toBeVisible();
 	await expect(settingsDialog.getByText("Wallet Basic", { exact: true })).toBeVisible();
-	await expect(settingsDialog.getByText(/\$9 on Aug 15, 2026/)).toBeVisible();
+	await expect(settingsDialog.getByText(/\$9\.00 on Aug 15, 2026/)).toBeVisible();
 	const manage = settingsDialog.locator('a[href^="/agents/hdep_wallet/settings"]');
 	await expect(manage).toBeVisible();
 	await settingsDialog.screenshot({ path: "/tmp/wallet-compute-coverage.png" });

--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -9,12 +9,33 @@ import {
 	User,
 	WalletCards,
 } from "lucide-react";
-import { lazy, Suspense, useEffect, useRef, useState } from "react";
+import {
+	lazy,
+	type MouseEvent as ReactMouseEvent,
+	Suspense,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+import { type ApiErrorNormalizer, ApiErrorPanel } from "@/components/api-error-panel";
 import { HostedRouteSkeleton } from "@/components/hosted-route-skeleton";
 import { IconChip } from "@/components/icon-chip";
 import { ApiKeysPanel } from "@/components/settings/api-keys-panel";
 import { GeneralPanel } from "@/components/settings/general-panel";
 import { ProfilePanel } from "@/components/settings/profile-panel";
+import { type SettingsEditState, SettingsEditStateContext } from "@/components/settings-edit-state";
+import { SettingsPanelErrorBoundary } from "@/components/settings-panel-error-boundary";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -32,6 +53,11 @@ import {
 import { cn } from "@/lib/utils";
 
 const IS_HOSTED_BUILD = import.meta.env.VITE_CLAWDI_HOSTED === "true";
+
+const HOSTED_ACCESS_ERROR_NORMALIZER: ApiErrorNormalizer = {
+	isAuthError: () => false,
+	normalizeError: () => "Check your connection, then retry the billing access check.",
+};
 
 const WalletPage = IS_HOSTED_BUILD
 	? lazy(() =>
@@ -58,6 +84,11 @@ type SettingsNavItem = {
 	icon: LucideIcon;
 	cloudOnly?: boolean;
 };
+
+type PendingSettingsIntent =
+	| { kind: "close" }
+	| { kind: "section"; section: SettingsSectionId }
+	| { kind: "navigate"; href: string };
 
 const SETTINGS_NAV: SettingsNavItem[] = [
 	{
@@ -95,7 +126,7 @@ const SETTINGS_NAV: SettingsNavItem[] = [
 	{
 		id: "billing-usage",
 		label: "Usage",
-		description: "AI Credit consumption",
+		description: "AI Credits usage",
 		icon: BarChart3,
 		cloudOnly: true,
 	},
@@ -113,16 +144,42 @@ export function SettingsDialog({
 	onOpenChange: (open: boolean) => void;
 }) {
 	const activeButtonRef = useRef<HTMLButtonElement | null>(null);
+	const bypassUnloadRef = useRef(false);
 	const hostedAccess = useHostedProductAccess();
 	const [mounted, setMounted] = useState(false);
+	const [editStates, setEditStates] = useState<Map<symbol, SettingsEditState>>(() => new Map());
+	const [pendingIntent, setPendingIntent] = useState<PendingSettingsIntent | null>(null);
+	const registerEditState = useCallback((token: symbol, state: SettingsEditState | null) => {
+		setEditStates((current) => {
+			const next = new Map(current);
+			if (state && (state.dirty || state.busy)) next.set(token, state);
+			else next.delete(token);
+			return next;
+		});
+	}, []);
+	const hasUnsavedChanges = [...editStates.values()].some((state) => state.dirty);
+	const hasPendingSave = [...editStates.values()].some((state) => state.busy);
 	useEffect(() => {
 		setMounted(true);
 	}, []);
-	const showBilling = mounted && IS_HOSTED_BUILD && hostedAccess.canCreateCloudAgents;
+	const requestedBillingSection = section.startsWith("billing-");
+	const showBilling =
+		IS_HOSTED_BUILD &&
+		(hostedAccess.canCreateCloudAgents ||
+			(requestedBillingSection &&
+				(!mounted || hostedAccess.isLoading || Boolean(hostedAccess.error))));
 	const items = SETTINGS_NAV.filter((item) => !item.cloudOnly || showBilling);
 	const activeSection = items.some((item) => item.id === section)
 		? section
 		: DEFAULT_SETTINGS_SECTION;
+	const billingAccessPending =
+		requestedBillingSection && IS_HOSTED_BUILD && (!mounted || hostedAccess.isLoading);
+	const billingAccessError =
+		requestedBillingSection &&
+		IS_HOSTED_BUILD &&
+		mounted &&
+		Boolean(hostedAccess.error) &&
+		!hostedAccess.canCreateCloudAgents;
 
 	useEffect(() => {
 		if (!open) return;
@@ -132,80 +189,190 @@ export function SettingsDialog({
 		return () => window.cancelAnimationFrame(frame);
 	}, [open, activeSection]);
 
+	useEffect(() => {
+		if (!hasUnsavedChanges && !hasPendingSave) return;
+		const warnBeforeUnload = (event: BeforeUnloadEvent) => {
+			if (bypassUnloadRef.current) return;
+			event.preventDefault();
+			event.returnValue = "";
+		};
+		window.addEventListener("beforeunload", warnBeforeUnload);
+		return () => window.removeEventListener("beforeunload", warnBeforeUnload);
+	}, [hasPendingSave, hasUnsavedChanges]);
+
+	function requestClose(nextOpen: boolean) {
+		if (nextOpen) {
+			onOpenChange(true);
+			return;
+		}
+		if (hasPendingSave) return;
+		if (hasUnsavedChanges) {
+			setPendingIntent({ kind: "close" });
+			return;
+		}
+		onOpenChange(false);
+	}
+
+	function requestSectionChange(nextSection: SettingsSectionId) {
+		if (nextSection === activeSection || hasPendingSave) return;
+		if (hasUnsavedChanges) {
+			setPendingIntent({ kind: "section", section: nextSection });
+			return;
+		}
+		onSectionChange(nextSection);
+	}
+
+	function interceptNavigation(event: ReactMouseEvent<HTMLElement>) {
+		if ((!hasUnsavedChanges && !hasPendingSave) || event.defaultPrevented) return;
+		if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)
+			return;
+		if (!(event.target instanceof Element)) return;
+		const anchor = event.target.closest("a[href]");
+		if (!(anchor instanceof HTMLAnchorElement)) return;
+		if (anchor.target === "_blank" || anchor.hasAttribute("download")) return;
+		const destination = new URL(anchor.href, window.location.href);
+		const current = new URL(window.location.href);
+		if (
+			destination.origin === current.origin &&
+			destination.pathname === current.pathname &&
+			destination.search === current.search
+		) {
+			return;
+		}
+
+		event.preventDefault();
+		if (!hasPendingSave) setPendingIntent({ kind: "navigate", href: destination.href });
+	}
+
+	function discardChanges() {
+		const intent = pendingIntent;
+		if (!intent) return;
+		setPendingIntent(null);
+		if (intent.kind === "close") {
+			onOpenChange(false);
+			return;
+		}
+		if (intent.kind === "section") {
+			onSectionChange(intent.section);
+			return;
+		}
+		bypassUnloadRef.current = true;
+		window.location.assign(intent.href);
+	}
+
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent
-				data-testid="settings-dialog"
-				initialFocus={activeButtonRef}
-				className="h-[min(820px,calc(100dvh-2rem))] w-[calc(100vw-2rem)] max-w-6xl gap-0 overflow-hidden p-0 sm:max-w-6xl"
-			>
-				<DialogHeader className="sr-only">
-					<DialogTitle>Settings</DialogTitle>
-					<DialogDescription>Account, billing, and application settings.</DialogDescription>
-				</DialogHeader>
+		<SettingsEditStateContext.Provider value={registerEditState}>
+			<Dialog open={open} onOpenChange={requestClose}>
+				<DialogContent
+					data-testid="settings-dialog"
+					initialFocus={activeButtonRef}
+					onClickCapture={interceptNavigation}
+					showCloseButton={!hasPendingSave}
+					className="h-[min(820px,calc(100dvh-2rem))] w-[calc(100vw-2rem)] max-w-6xl gap-0 overflow-hidden p-0 sm:max-w-6xl"
+				>
+					<DialogHeader className="sr-only">
+						<DialogTitle>Settings</DialogTitle>
+						<DialogDescription>Account, billing, and application settings.</DialogDescription>
+					</DialogHeader>
 
-				<div className="grid h-full min-h-0 grid-rows-[auto_1fr] md:grid-cols-[15rem_minmax(0,1fr)] md:grid-rows-1">
-					<aside className="flex min-w-0 flex-col border-b bg-muted/30 md:border-r md:border-b-0">
-						<div className="flex h-14 shrink-0 items-center px-4 md:h-16">
-							<div className="min-w-0">
-								<div className="truncate text-sm font-semibold">Settings</div>
-								<div className="truncate text-xs text-muted-foreground">Clawdi preferences</div>
+					<div className="grid h-full min-h-0 grid-rows-[auto_1fr] md:grid-cols-[15rem_minmax(0,1fr)] md:grid-rows-1">
+						<aside className="flex min-w-0 flex-col border-b bg-muted/30 md:border-r md:border-b-0">
+							<div className="flex h-14 shrink-0 items-center px-4 md:h-16">
+								<div className="min-w-0">
+									<div className="truncate text-sm font-semibold">Settings</div>
+									<div className="truncate text-xs text-muted-foreground">Clawdi preferences</div>
+								</div>
 							</div>
-						</div>
-						<div className="relative min-w-0 md:min-h-0 md:flex-1">
-							<nav
-								aria-label="Settings sections"
-								className="flex gap-1 overflow-x-auto px-3 pb-3 [scrollbar-width:thin] md:min-h-0 md:flex-1 md:flex-col md:overflow-y-auto md:px-3 md:pb-3"
-							>
-								{items.map((item) => {
-									const Icon = item.icon;
-									const active = activeSection === item.id;
-									return (
-										<Button
-											key={item.id}
-											ref={active ? activeButtonRef : undefined}
-											type="button"
-											variant="ghost"
-											aria-current={active ? "page" : undefined}
-											data-active={active}
-											onClick={() => onSectionChange(item.id)}
-											className={cn(
-												"h-auto min-w-28 shrink-0 justify-start gap-2 rounded-md px-2.5 py-2 text-left text-sm text-muted-foreground hover:bg-background/70 hover:text-foreground md:min-w-0 md:gap-3 md:px-3",
-												"data-[active=true]:bg-background data-[active=true]:text-foreground data-[active=true]:shadow-xs",
-											)}
-										>
-											<IconChip
-												size="sm"
-												tint={
-													active
-														? "bg-primary text-primary-foreground"
-														: "bg-background text-foreground"
-												}
+							<div className="relative min-w-0 md:min-h-0 md:flex-1">
+								<nav
+									aria-label="Settings sections"
+									className="flex gap-1 overflow-x-auto px-3 pb-3 [scrollbar-width:thin] md:min-h-0 md:flex-1 md:flex-col md:overflow-y-auto md:px-3 md:pb-3"
+								>
+									{items.map((item) => {
+										const Icon = item.icon;
+										const active = activeSection === item.id;
+										return (
+											<Button
+												key={item.id}
+												ref={active ? activeButtonRef : undefined}
+												type="button"
+												variant="ghost"
+												aria-current={active ? "page" : undefined}
+												data-active={active}
+												onClick={() => requestSectionChange(item.id)}
+												className={cn(
+													"h-auto min-w-28 shrink-0 justify-start gap-2 rounded-md px-2.5 py-2 text-left text-sm text-muted-foreground hover:bg-background/70 hover:text-foreground md:min-w-0 md:gap-3 md:px-3",
+													"data-[active=true]:bg-background data-[active=true]:text-foreground data-[active=true]:shadow-xs",
+												)}
 											>
-												<Icon />
-											</IconChip>
-											<span className="grid min-w-0 flex-1 leading-tight">
-												<span className="truncate font-medium">{item.label}</span>
-												<span className="hidden truncate text-xs text-muted-foreground md:block">
-													{item.description}
+												<IconChip
+													size="sm"
+													tint={
+														active
+															? "bg-primary text-primary-foreground"
+															: "bg-background text-foreground"
+													}
+												>
+													<Icon />
+												</IconChip>
+												<span className="grid min-w-0 flex-1 leading-tight">
+													<span className="truncate font-medium">{item.label}</span>
+													<span className="hidden truncate text-xs text-muted-foreground md:block">
+														{item.description}
+													</span>
 												</span>
-											</span>
-										</Button>
-									);
-								})}
-							</nav>
-							<div className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-linear-to-l from-muted/30 to-transparent md:hidden" />
-						</div>
-					</aside>
+											</Button>
+										);
+									})}
+								</nav>
+								<div className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-linear-to-l from-muted/30 to-transparent md:hidden" />
+							</div>
+						</aside>
 
-					<section className="min-h-0 overflow-y-auto py-6 md:py-8">
-						<div className="mx-auto w-full max-w-5xl">
-							<SettingsPanel section={activeSection} />
-						</div>
-					</section>
-				</div>
-			</DialogContent>
-		</Dialog>
+						<section className="min-h-0 overflow-y-auto py-6 md:py-8">
+							<div className="mx-auto w-full max-w-5xl">
+								{billingAccessPending ? (
+									<HostedRouteSkeleton />
+								) : billingAccessError ? (
+									<ApiErrorPanel
+										error={hostedAccess.error}
+										normalizer={HOSTED_ACCESS_ERROR_NORMALIZER}
+										onRetry={() => void hostedAccess.refetch()}
+										title="Couldn’t verify billing access"
+									/>
+								) : (
+									<SettingsPanelErrorBoundary key={activeSection}>
+										<SettingsPanel section={activeSection} />
+									</SettingsPanelErrorBoundary>
+								)}
+							</div>
+						</section>
+					</div>
+				</DialogContent>
+			</Dialog>
+
+			<AlertDialog
+				open={pendingIntent !== null}
+				onOpenChange={(nextOpen) => {
+					if (!nextOpen) setPendingIntent(null);
+				}}
+			>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Discard unsaved changes?</AlertDialogTitle>
+						<AlertDialogDescription>
+							Your auto-reload settings will return to the last values saved on the server.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Keep editing</AlertDialogCancel>
+						<AlertDialogAction variant="destructive" onClick={discardChanges}>
+							Discard changes
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</SettingsEditStateContext.Provider>
 	);
 }
 

--- a/apps/web/src/components/settings-edit-state.tsx
+++ b/apps/web/src/components/settings-edit-state.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { createContext, useContext, useEffect, useRef } from "react";
+
+export interface SettingsEditState {
+	dirty: boolean;
+	busy: boolean;
+}
+
+export type RegisterSettingsEditState = (token: symbol, state: SettingsEditState | null) => void;
+
+export const SettingsEditStateContext = createContext<RegisterSettingsEditState | null>(null);
+
+export function useSettingsEditState(state: SettingsEditState): void {
+	const register = useContext(SettingsEditStateContext);
+	const tokenRef = useRef<symbol | null>(null);
+	if (tokenRef.current === null) tokenRef.current = Symbol("settings-edit-state");
+	const token = tokenRef.current;
+
+	useEffect(() => {
+		if (!register) return;
+		register(token, state);
+		return () => register(token, null);
+	}, [register, state.busy, state.dirty, token]);
+}

--- a/apps/web/src/components/settings-panel-error-boundary.tsx
+++ b/apps/web/src/components/settings-panel-error-boundary.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { AlertCircle, RefreshCw } from "lucide-react";
+import { Component, type ReactNode } from "react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+
+export class SettingsPanelErrorBoundary extends Component<
+	{ children: ReactNode },
+	{ failed: boolean }
+> {
+	state = { failed: false };
+
+	static getDerivedStateFromError() {
+		return { failed: true };
+	}
+
+	render() {
+		if (!this.state.failed) return this.props.children;
+
+		return (
+			<Alert variant="destructive">
+				<AlertCircle aria-hidden />
+				<AlertTitle>Couldn’t load this settings section</AlertTitle>
+				<AlertDescription className="flex flex-col items-start gap-3">
+					<span>The settings code didn’t finish loading. Reload the page to try again.</span>
+					<Button
+						type="button"
+						size="sm"
+						variant="outline"
+						onClick={() => window.location.reload()}
+					>
+						<RefreshCw data-icon="inline-start" /> Reload settings
+					</Button>
+				</AlertDescription>
+			</Alert>
+		);
+	}
+}

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -93,6 +93,7 @@ import {
 import {
 	BillingApiError,
 	billingErrorNormalizer,
+	isIdempotencyKeyReusedError,
 	normalizeBillingError,
 } from "@/hosted/billing/errors";
 import {
@@ -100,6 +101,7 @@ import {
 	billingTermSuffix,
 	formatCents,
 	formatCentsCompact,
+	formatUsd,
 } from "@/hosted/billing/format";
 import {
 	checkoutReturnDeploymentId,
@@ -117,6 +119,7 @@ import {
 	useWallet,
 } from "@/hosted/billing/hooks";
 import {
+	forgetIdempotencyAttempt,
 	type IdempotencyAttempt,
 	idempotencyAttemptFor,
 	idempotencyFingerprint,
@@ -153,6 +156,7 @@ import {
 	type PaymentOutcome,
 	StripePaymentForm,
 } from "@/hosted/billing/wallet/stripe-payment-form";
+import { buildSubscriptionPaymentReturnUrl } from "@/hosted/billing/wallet/stripe-payment-form.logic";
 import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
 import { topUpAmountCentsForCreditShortfall } from "@/hosted/billing/wallet/top-up-dialog.logic";
 import { deploymentFailureReason } from "@/hosted/deployment-failure";
@@ -218,6 +222,8 @@ type DeploymentStatus = ReturnType<typeof parseDeploymentStatus>;
 type TermChangeConfirmation = {
 	clientSecret: string;
 	billingTermMonths: number;
+	amountDueUsd: number | null;
+	effectiveAt: string | null;
 };
 type HostedAgentTab =
 	| "overview"
@@ -303,7 +309,7 @@ function isProvisioningStatus(status: DeploymentStatus): boolean {
 }
 
 function provisioningTitle(status: DeploymentStatus): string {
-	return status.kind === "starting" ? "Starting your agent..." : "Setting up your agent...";
+	return status.kind === "starting" ? "Starting your agent…" : "Setting up your agent…";
 }
 
 function RestartComputeAction({
@@ -2269,7 +2275,7 @@ function LanguageTimezoneSettingsSection({
 						Reset
 					</Button>
 					{setLanguageTimezone.isPending ? (
-						<span className="text-xs text-muted-foreground">Updating runtime settings...</span>
+						<span className="text-xs text-muted-foreground">Updating runtime settings…</span>
 					) : null}
 				</div>
 			</div>
@@ -2322,6 +2328,7 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 	const [term, setTerm] = useState(currentBillingTerm);
 	const [termChangeConfirmation, setTermChangeConfirmation] =
 		useState<TermChangeConfirmation | null>(null);
+	const [termChangeSubmitting, setTermChangeSubmitting] = useState(false);
 	const [walletPlanQuote, setWalletPlanQuote] = useState<WalletComputePlanChangeResult | null>(
 		null,
 	);
@@ -2405,7 +2412,7 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 		selectedBillingTerm !== currentBillingTerm;
 	const canUpgrade = isIncludedBasic && deployment.upgrade_available;
 	const upgradeUnavailableMessage = plans.isLoading
-		? "Checking Performance availability..."
+		? "Checking Performance availability…"
 		: !perfPlan
 			? "Performance compute is unavailable right now."
 			: isRunningStatus(deploymentStatus) || deploymentStatus.kind === "stopped"
@@ -2429,6 +2436,9 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 		checkoutReturnRef.current = marker;
 		void refreshCheckoutReturn().then(() => {
 			if (checkoutReturnWasCanceled(searchStr)) {
+				const attempt = checkoutAttemptRef.current;
+				if (attempt) forgetIdempotencyAttempt("subscription-upgrade", attempt.fingerprint);
+				checkoutAttemptRef.current = null;
 				toast.message("Checkout canceled", {
 					description: "You were not charged. Your compute plan is unchanged.",
 				});
@@ -2485,6 +2495,10 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 				description: "No checkout URL was returned. Please try again.",
 			});
 		} catch (error) {
+			if (isIdempotencyKeyReusedError(error) && checkoutAttemptRef.current) {
+				forgetIdempotencyAttempt("subscription-upgrade", checkoutAttemptRef.current.fingerprint);
+				checkoutAttemptRef.current = null;
+			}
 			toast.error("Couldn’t start upgrade", { description: normalizeBillingError(error) });
 		}
 	}
@@ -2501,6 +2515,8 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 				setTermChangeConfirmation({
 					clientSecret: res.payment_intent_client_secret,
 					billingTermMonths: selectedBillingTerm,
+					amountDueUsd: res.amount_due_usd ?? null,
+					effectiveAt: res.effective_at ?? null,
 				});
 				return;
 			}
@@ -2509,23 +2525,30 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 				return;
 			}
 			toast.message("Subscription update unavailable", {
-				description: res.message ?? "Please try again in a moment.",
+				description: "Refresh this agent and try again in a moment.",
 			});
 		} catch (error) {
 			toast.error("Couldn’t change billing term", { description: normalizeBillingError(error) });
 		}
 	}
 
-	function completeBillingTermConfirmation(status: PaymentOutcome) {
+	async function completeBillingTermConfirmation(status: PaymentOutcome) {
 		setTermChangeConfirmation(null);
-		void refreshCheckoutReturn().catch(() => undefined);
+		setTermChangeSubmitting(false);
+		const refreshed = await refreshCheckoutReturn();
+		if (!refreshed) {
+			toast.warning("Payment received; details need a refresh", {
+				description: "Reload this agent to confirm the updated billing term.",
+			});
+			return;
+		}
 		toast.success(
-			status === "succeeded" ? "Billing term update confirmed" : "Billing term update processing",
+			status === "succeeded" ? "Billing term updated" : "Billing term update processing",
 			{
 				description:
 					status === "succeeded"
-						? "We refreshed your compute subscription details."
-						: "We will refresh your compute subscription details once the payment settles.",
+						? "The refreshed subscription now shows the confirmed term."
+						: "The subscription will update after the payment settles.",
 			},
 		);
 	}
@@ -2661,6 +2684,7 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 			});
 		} catch (error) {
 			toast.error("Couldn’t cancel subscription", { description: normalizeBillingError(error) });
+			throw error;
 		}
 	}
 
@@ -2688,25 +2712,45 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 			<Dialog
 				open={termChangeConfirmation !== null}
 				onOpenChange={(open) => {
-					if (!open) setTermChangeConfirmation(null);
+					if (!open && !termChangeSubmitting) setTermChangeConfirmation(null);
 				}}
 			>
-				<DialogContent className="sm:max-w-md" data-hosted="true">
+				<DialogContent
+					className="sm:max-w-md"
+					data-hosted="true"
+					showCloseButton={!termChangeSubmitting}
+				>
 					<DialogHeader>
 						<DialogTitle>Confirm billing term change</DialogTitle>
 						<DialogDescription>
-							Complete your bank confirmation to switch this compute to{" "}
-							{billingTermLabel(
-								termChangeConfirmation?.billingTermMonths ?? selectedBillingTerm,
-							).toLowerCase()}
-							.
+							{termChangeConfirmation
+								? `${billingTermLabel(termChangeConfirmation.billingTermMonths)} billing${
+										termChangeConfirmation.effectiveAt
+											? ` takes effect ${formatShortDate(termChangeConfirmation.effectiveAt)}`
+											: " takes effect after confirmation"
+									}.`
+								: "Review the billing term change."}
 						</DialogDescription>
 					</DialogHeader>
 					{termChangeConfirmation ? (
 						<StripePaymentForm
 							clientSecret={termChangeConfirmation.clientSecret}
-							onComplete={completeBillingTermConfirmation}
+							onComplete={(status) => void completeBillingTermConfirmation(status)}
 							onCancel={() => setTermChangeConfirmation(null)}
+							returnUrl={(currentHref) =>
+								buildSubscriptionPaymentReturnUrl(currentHref, deployment.id)
+							}
+							summary={
+								termChangeConfirmation.amountDueUsd !== null
+									? `Charge due now: ${formatUsd(termChangeConfirmation.amountDueUsd)}`
+									: "No immediate charge was quoted."
+							}
+							submitLabel={
+								termChangeConfirmation.amountDueUsd !== null
+									? `Pay ${formatUsd(termChangeConfirmation.amountDueUsd)} & update term`
+									: "Confirm term change"
+							}
+							onSubmittingChange={setTermChangeSubmitting}
 						/>
 					) : null}
 				</DialogContent>
@@ -2720,7 +2764,11 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 					}
 				}}
 			>
-				<DialogContent className="sm:max-w-md" data-hosted="true">
+				<DialogContent
+					className="sm:max-w-md"
+					data-hosted="true"
+					showCloseButton={!changeWalletPlan.isPending}
+				>
 					<DialogHeader>
 						<DialogTitle>Confirm wallet-funded plan change</DialogTitle>
 						<DialogDescription>
@@ -2763,7 +2811,9 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 									Back
 								</Button>
 								<Button
-									onClick={() => void confirmWalletComputePlanChange()}
+									onClick={() =>
+										void runAction(confirmWalletComputePlanChange).catch(() => undefined)
+									}
 									disabled={changeWalletPlan.isPending}
 								>
 									{changeWalletPlan.isPending ? <Spinner /> : <WalletCards />}
@@ -2859,7 +2909,16 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 								) : null}
 							</div>
 						) : null}
-						{isWalletPaymentFailureFallback ? (
+						{isIncludedBasic && plans.error ? (
+							<div className="w-full lg:w-72">
+								<ApiErrorPanel
+									normalizer={billingErrorNormalizer}
+									error={plans.error}
+									onRetry={() => void plans.refetch()}
+									title="Couldn’t check Performance availability"
+								/>
+							</div>
+						) : isWalletPaymentFailureFallback ? (
 							<div className="flex w-full flex-col gap-2 text-xs text-muted-foreground lg:w-72">
 								<p>
 									Use the Wallet recovery banner above to top up and retry the previous paid compute

--- a/apps/web/src/hosted/billing/components/compute-dunning-banner.tsx
+++ b/apps/web/src/hosted/billing/components/compute-dunning-banner.tsx
@@ -31,6 +31,7 @@ import {
 	useWalletComputeQuote,
 } from "@/hosted/billing/hooks";
 import { computeTierLabel } from "@/hosted/billing/subscription/subscription-utils";
+import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
 import { topUpAmountCentsForCreditShortfall } from "@/hosted/billing/wallet/top-up-dialog.logic";
 import { decimalCredits } from "@/hosted/billing/wallet/wallet-compute.logic";
@@ -49,6 +50,7 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 	const fixPayment = useFixPayment();
 	const retryWallet = useRetryWalletCompute();
 	const activateWallet = useActivateWalletCompute();
+	const runAction = useActionLock();
 	const walletRecovery =
 		state?.ctaTarget === "wallet_retry" || state?.ctaTarget === "wallet_reactivate";
 	const wallet = useWallet({ enabled: walletRecovery });
@@ -109,7 +111,7 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 				return;
 			}
 			toast.message("Payment update unavailable", {
-				description: res.message ?? "Please try again in a moment.",
+				description: "Refresh this page and try again in a moment.",
 			});
 		} catch (error) {
 			toast.error("Couldn’t open payment settings", {
@@ -210,7 +212,7 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 							: "border-info-muted bg-info-muted text-info-muted-foreground"
 				}
 			>
-				<BannerIcon />
+				<BannerIcon aria-hidden />
 				<AlertTitle>{state.title}</AlertTitle>
 				<AlertDescription className="flex flex-col items-start gap-3">
 					<span>{bannerDescription}</span>
@@ -228,7 +230,7 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 								<Button
 									size="sm"
 									variant="outline"
-									onClick={() => void handleWalletRetry()}
+									onClick={() => void runAction(handleWalletRetry)}
 									disabled={retryWallet.isPending || !state.subscriptionId}
 								>
 									{retryWallet.isPending ? <Spinner /> : <RefreshCw data-icon="inline-start" />}
@@ -246,7 +248,7 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 							<Button
 								size="sm"
 								variant={destructive ? "destructive" : "default"}
-								onClick={() => void handleWalletReactivate()}
+								onClick={() => void runAction(handleWalletReactivate)}
 								disabled={activateWallet.isPending || !state.recoveryPlanSlug}
 							>
 								{activateWallet.isPending ? <Spinner /> : <RefreshCw data-icon="inline-start" />}
@@ -279,8 +281,8 @@ export function ComputeDunningBanner({ deployment }: { deployment: HostedDeploym
 						<Button
 							size="sm"
 							variant={destructive ? "destructive" : "default"}
-							onClick={() => void handleFixPayment()}
-							disabled={fixPayment.isPending && state.ctaTarget === "portal"}
+							onClick={() => void runAction(handleFixPayment)}
+							disabled={fixPayment.isPending}
 						>
 							{fixPayment.isPending && state.ctaTarget === "portal" ? (
 								<Spinner />

--- a/apps/web/src/hosted/billing/components/stripe-checkout-dialog.tsx
+++ b/apps/web/src/hosted/billing/components/stripe-checkout-dialog.tsx
@@ -157,14 +157,23 @@ function CheckoutSummaryPanel({ summary }: { summary: StripeCheckoutSummary | nu
 function CheckoutElementForm({
 	onComplete,
 	onLoadError,
+	onSubmittingChange,
 }: {
 	onComplete: () => void;
 	onLoadError: (message: string) => void;
+	onSubmittingChange: (submitting: boolean) => void;
 }) {
 	const checkoutState = useCheckoutElements();
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const submittingRef = useRef(false);
 	const loadErrorMessage = checkoutState.type === "error" ? checkoutState.error.message : null;
+
+	function finishSubmitting() {
+		submittingRef.current = false;
+		setSubmitting(false);
+		onSubmittingChange(false);
+	}
 
 	useEffect(() => {
 		if (loadErrorMessage) onLoadError(loadErrorMessage);
@@ -177,7 +186,7 @@ function CheckoutElementForm({
 				className="flex min-h-36 items-center gap-2 py-6 text-sm text-muted-foreground"
 			>
 				<Spinner />
-				<span>Loading secure payment form...</span>
+				<span>Loading secure payment form…</span>
 			</div>
 		);
 	}
@@ -196,14 +205,16 @@ function CheckoutElementForm({
 	const { checkout } = checkoutState;
 
 	async function confirmCheckout() {
-		if (submitting || !checkout.canConfirm) return;
+		if (submittingRef.current || !checkout.canConfirm) return;
+		submittingRef.current = true;
 		setSubmitting(true);
+		onSubmittingChange(true);
 		setError(null);
 		try {
 			const result = await checkout.confirm({ redirect: "if_required" });
 			if (result.type === "error") {
 				setError(result.error.message || "We could not confirm this payment. Please try again.");
-				setSubmitting(false);
+				finishSubmitting();
 				return;
 			}
 			if (result.session.status.type === "complete") {
@@ -211,10 +222,10 @@ function CheckoutElementForm({
 				return;
 			}
 			setError("Stripe needs another step before this checkout can finish.");
-			setSubmitting(false);
+			finishSubmitting();
 		} catch {
 			setError("We could not reach Stripe. Check your connection and try again.");
-			setSubmitting(false);
+			finishSubmitting();
 		}
 	}
 
@@ -233,10 +244,14 @@ function CheckoutElementForm({
 				</Alert>
 			) : null}
 			<div className="flex justify-end">
-				<Button onClick={confirmCheckout} disabled={submitting || !checkout.canConfirm}>
+				<Button
+					type="button"
+					onClick={confirmCheckout}
+					disabled={submitting || !checkout.canConfirm}
+				>
 					{submitting ? (
 						<>
-							<Spinner data-icon="inline-start" /> Processing...
+							<Spinner data-icon="inline-start" /> Processing…
 						</>
 					) : (
 						"Subscribe"
@@ -262,6 +277,7 @@ export function StripeCheckoutDialog({
 	const [state, setState] = useState<DialogState>("loading");
 	const [message, setMessage] = useState<string | null>(null);
 	const [attempt, setAttempt] = useState(0);
+	const [checkoutSubmitting, setCheckoutSubmitting] = useState(false);
 	const appearance = useCheckoutAppearance(open);
 	const onCompleteRef = useRef(onComplete);
 	const onFallbackRef = useRef(onFallback);
@@ -302,6 +318,7 @@ export function StripeCheckoutDialog({
 		if (!open || !clientSecret) return;
 		let cancelled = false;
 		fallbackStartedRef.current = false;
+		setCheckoutSubmitting(false);
 		setStripe(null);
 		setMessage(null);
 		setState("loading");
@@ -351,12 +368,17 @@ export function StripeCheckoutDialog({
 		};
 	}, [appearance, clientSecret]);
 
+	function requestOpenChange(nextOpen: boolean) {
+		if (!nextOpen && (checkoutSubmitting || state === "redirecting")) return;
+		onOpenChange(nextOpen);
+	}
+
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
+		<Dialog open={open} onOpenChange={requestOpenChange}>
 			<DialogContent
 				className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-lg"
 				data-hosted="true"
-				showCloseButton={state !== "redirecting"}
+				showCloseButton={state !== "redirecting" && !checkoutSubmitting}
 			>
 				<DialogHeader>
 					<DialogTitle>{title}</DialogTitle>
@@ -373,6 +395,7 @@ export function StripeCheckoutDialog({
 						<CheckoutElementForm
 							onComplete={completeCheckout}
 							onLoadError={handleProviderLoadError}
+							onSubmittingChange={setCheckoutSubmitting}
 						/>
 					</CheckoutElementsProvider>
 				) : state === "error" ? (
@@ -394,7 +417,7 @@ export function StripeCheckoutDialog({
 								<Button
 									size="sm"
 									onClick={() => {
-										void startHostedFallback("Opening Stripe checkout...");
+										void startHostedFallback("Opening Stripe checkout…");
 									}}
 								>
 									Continue in Stripe
@@ -408,7 +431,7 @@ export function StripeCheckoutDialog({
 						className="flex min-h-36 items-center gap-2 py-6 text-sm text-muted-foreground"
 					>
 						<Spinner />
-						<span>{message ?? "Loading secure checkout..."}</span>
+						<span>{message ?? "Loading secure checkout…"}</span>
 					</div>
 				)}
 			</DialogContent>

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -164,6 +164,7 @@ import type { ChannelAccount } from "@/hosted/v2/channels/channel-types";
 import { useChannels } from "@/hosted/v2/channels/channels-hooks";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { isApiAuthError, normalizeApiError } from "@/lib/api-errors";
+import { formatShortDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
 type Compute = "basic" | "performance";
@@ -1359,7 +1360,7 @@ export function DeployWizard() {
 												<div>
 													<div className="text-xs text-muted-foreground">Renews</div>
 													<div className="font-medium">
-														{new Date(walletQuote.data.period_end).toLocaleDateString()}
+														{formatShortDate(walletQuote.data.period_end)}
 													</div>
 												</div>
 												<div>

--- a/apps/web/src/hosted/billing/errors.test.ts
+++ b/apps/web/src/hosted/billing/errors.test.ts
@@ -113,9 +113,12 @@ describe("normalizeBillingError", () => {
 		expect(normalizeBillingError(e)).toMatch(/balance is too low/i);
 	});
 
-	test("snake_case codes become readable, real sentences pass through", () => {
+	test("snake_case codes stay internal while real sentences pass through", () => {
 		expect(normalizeBillingError(new BillingApiError(400, "payment_method_required"))).toBe(
-			"Payment Method Required",
+			"Add a payment method and try again.",
+		);
+		expect(normalizeBillingError(new BillingApiError(400, "bridge_internal_17"))).not.toContain(
+			"bridge_internal_17",
 		);
 		expect(
 			normalizeBillingError(new BillingApiError(400, "That code has already been used.")),

--- a/apps/web/src/hosted/billing/errors.ts
+++ b/apps/web/src/hosted/billing/errors.ts
@@ -249,9 +249,12 @@ export function normalizeBillingError(error: unknown): string {
 		if (typeof code === "string") {
 			return "The billing request could not be completed. Refresh and try again.";
 		}
-		// Snake_case error codes → readable text; pass through real sentences.
+		// A bare snake_case token is an internal error code, not product copy.
 		if (/^[a-z0-9_]+$/.test(error.detail)) {
-			return error.detail.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+			if (error.detail === "payment_method_required") {
+				return "Add a payment method and try again.";
+			}
+			return "The billing request could not be completed. Review the details and try again.";
 		}
 		return error.detail;
 	}

--- a/apps/web/src/hosted/billing/subscription/billing-history-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/billing-history-section.tsx
@@ -23,10 +23,17 @@ import { computeTierLabel } from "@/hosted/billing/subscription/subscription-uti
 import { formatShortDate } from "@/lib/format";
 
 function statusLabel(status: string): string {
-	return status
-		.split("_")
-		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-		.join(" ");
+	const known: Record<string, string> = {
+		applied: "Applied",
+		paid: "Paid",
+		refunded: "Refunded",
+		waived: "Waived",
+		void: "Void",
+		open: "Open",
+		draft: "Draft",
+		uncollectible: "Uncollectible",
+	};
+	return known[status] ?? "Unknown";
 }
 
 function statusTone(
@@ -50,10 +57,7 @@ function planLabel(planSlug: string): string {
 	if (planSlug === "compute_basic" || planSlug === "compute_performance") {
 		return computeTierLabel(planSlug);
 	}
-	return planSlug
-		.split("_")
-		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-		.join(" ");
+	return "Compute";
 }
 
 function InvoiceLink({ row }: { row: ComputeBillingHistoryItem }) {
@@ -65,7 +69,7 @@ function InvoiceLink({ row }: { row: ComputeBillingHistoryItem }) {
 			variant="outline"
 			size="sm"
 		>
-			Invoice <ExternalLink data-icon="inline-end" />
+			View invoice <ExternalLink data-icon="inline-end" />
 		</Button>
 	);
 }
@@ -175,7 +179,7 @@ export function BillingHistorySection() {
 							</TableBody>
 						</Table>
 					</div>
-					{history.hasNextPage ? (
+					{history.hasNextPage && !history.isFetchNextPageError ? (
 						<div className="flex justify-center">
 							<Button
 								variant="outline"
@@ -185,6 +189,14 @@ export function BillingHistorySection() {
 								{history.isFetchingNextPage ? "Loading…" : "Load more"}
 							</Button>
 						</div>
+					) : null}
+					{history.isFetchNextPageError ? (
+						<ApiErrorPanel
+							normalizer={billingErrorNormalizer}
+							error={history.error}
+							onRetry={() => void history.fetchNextPage()}
+							title="Couldn’t load more billing history"
+						/>
 					) : null}
 				</>
 			)}

--- a/apps/web/src/hosted/billing/subscription/invoices-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/invoices-section.tsx
@@ -33,7 +33,8 @@ function invoiceStatusTone(
 ): "success" | "warning" | "destructive" | "neutral" {
 	if (status === "paid") return "success";
 	if (status === "open" || status === "draft") return "warning";
-	if (status === "uncollectible" || status === "void") return "destructive";
+	if (status === "uncollectible") return "destructive";
+	if (status === "void") return "neutral";
 	return "neutral";
 }
 
@@ -48,7 +49,7 @@ function InvoiceLink({ invoice }: { invoice: ComputeInvoice }) {
 			variant="outline"
 			size="sm"
 		>
-			Open
+			View invoice
 			<ExternalLink data-icon="inline-end" />
 		</Button>
 	);

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useLocation, useRouter } from "@tanstack/react-router";
+import { Link, useLocation } from "@tanstack/react-router";
 import { Check, Coins, Cpu, Rocket, Sparkles, Zap } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
@@ -26,7 +26,6 @@ import {
 	selectExplicitOfferForTerm,
 	selectOfferForTerm,
 } from "@/hosted/billing/subscription/subscription-utils";
-import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { settingsQueryHref } from "@/lib/settings-routes";
 
 function partitionPlans(plans: Plan[]): { basic?: Plan; performance?: Plan } {
@@ -59,11 +58,9 @@ export function PlanComparison({
 	term?: number;
 	onTermChange?: (term: number) => void;
 } = {}) {
-	const router = useRouter();
 	const searchStr = useLocation({ select: (location) => location.searchStr });
 	const searchParams = new URLSearchParams(searchStr);
 	const plansQuery = usePlans();
-	const runAction = useActionLock();
 	const [internalTerm, setInternalTerm] = useState(1);
 	const term = termProp ?? internalTerm;
 	const setTerm = onTermChange ?? setInternalTerm;
@@ -85,11 +82,6 @@ export function PlanComparison({
 	);
 	const basicOffer = basicOfferSelection?.offer ?? null;
 	const basicBillingTermMonths = basicOfferSelection?.billingTermMonths ?? term;
-
-	async function startPerformanceCheckout() {
-		if (!performance) return;
-		void router.navigate({ href: "/deploy" });
-	}
 
 	if (!plansQuery.data) return null;
 
@@ -172,9 +164,10 @@ export function PlanComparison({
 					</CardContent>
 					<CardFooter>
 						<Button
+							render={<Link to="/deploy" />}
+							nativeButton={false}
 							className="w-full"
 							variant="outline"
-							onClick={() => void router.navigate({ href: "/deploy" })}
 						>
 							<Rocket /> Deploy Basic agent
 						</Button>
@@ -238,8 +231,9 @@ export function PlanComparison({
 					</CardContent>
 					<CardFooter>
 						<Button
+							render={<Link to="/deploy" />}
+							nativeButton={false}
 							className="w-full"
-							onClick={() => runAction(startPerformanceCheckout)}
 							disabled={!performance}
 						>
 							Deploy Performance agent
@@ -280,11 +274,10 @@ export function PlanComparison({
 					</CardContent>
 					<CardFooter>
 						<Button
+							render={<Link to={settingsQueryHref("billing-wallet", searchParams)} />}
+							nativeButton={false}
 							className="w-full"
 							variant="outline"
-							onClick={() =>
-								void router.navigate({ href: settingsQueryHref("billing-wallet", searchParams) })
-							}
 						>
 							<Sparkles /> Open Wallet
 						</Button>

--- a/apps/web/src/hosted/billing/subscription/subscription-page.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import { CreditCard, Rocket } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -27,7 +27,6 @@ const SUBSCRIPTION_PAGE_CLASS = cn(
 );
 
 export function SubscriptionPage() {
-	const router = useRouter();
 	const plans = usePlans();
 	const portal = usePortal();
 	const runAction = useActionLock();
@@ -41,7 +40,7 @@ export function SubscriptionPage() {
 				return;
 			}
 			toast.message("Billing portal unavailable", {
-				description: res.message ?? "Please try again in a moment.",
+				description: "Refresh this page and try again in a moment.",
 			});
 		} catch (e) {
 			toast.error("Couldn’t open billing", { description: normalizeBillingError(e) });
@@ -91,7 +90,7 @@ export function SubscriptionPage() {
 						balance and managed-AI usage stay account-wide.
 					</p>
 					<div className="flex flex-wrap gap-2">
-						<Button onClick={() => void router.navigate({ href: "/deploy" })}>
+						<Button render={<Link to="/deploy" />} nativeButton={false}>
 							<Rocket /> Deploy hosted agent
 						</Button>
 						<Button

--- a/apps/web/src/hosted/billing/subscription/welcome-credits-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/welcome-credits-card.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useRouter } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import { Gift, PartyPopper, Rocket } from "lucide-react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import type { Plan } from "@/hosted/billing/contracts";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
@@ -17,14 +18,13 @@ import { useHostedDeployments, usePlans, useWallet, useWalletLedger } from "@/ho
  * Renders for a new wallet user who hasn't deployed yet: it
  * confirms the AI Credits grant landed (reading the `grant_signup` ledger row)
  * and points them at the deploy wizard. Returns null once the user has an
- * agent or when the v2 billing reads are unavailable.
+ * agent. Read failures render a retry action instead of hiding onboarding.
  */
 function signupGrantCredits(plans: Plan[] | undefined): number {
 	return Math.max(0, ...(plans ?? []).map((plan) => plan.signup_grant_credits ?? 0));
 }
 
 export function WelcomeCreditsCard() {
-	const router = useRouter();
 	const wallet = useWallet();
 	const ledger = useWalletLedger(50);
 	const deployments = useHostedDeployments();
@@ -32,7 +32,19 @@ export function WelcomeCreditsCard() {
 
 	// Past onboarding — they already have at least one agent.
 	if ((deployments.data?.length ?? 0) > 0) return null;
-	if (ledger.isLoading || wallet.isLoading || deployments.isLoading) return null;
+	if (ledger.isLoading || wallet.isLoading || deployments.isLoading) {
+		return (
+			<Card data-hosted="true" aria-label="Loading welcome credits">
+				<CardContent className="flex items-center justify-between gap-4">
+					<div className="flex flex-1 flex-col gap-2">
+						<Skeleton className="h-5 w-56 max-w-full" />
+						<Skeleton className="h-4 w-96 max-w-full" />
+					</div>
+					<Skeleton className="h-9 w-32" />
+				</CardContent>
+			</Card>
+		);
+	}
 	const loadError = wallet.error ?? ledger.error ?? deployments.error;
 	if (loadError) {
 		return (
@@ -92,7 +104,7 @@ export function WelcomeCreditsCard() {
 				</div>
 				<div className="flex items-center gap-2">
 					{grantPending ? <Spinner className="size-4 text-muted-foreground" /> : null}
-					<Button onClick={() => void router.navigate({ href: "/deploy" })}>
+					<Button render={<Link to="/deploy" />} nativeButton={false}>
 						<Rocket /> Deploy an agent
 					</Button>
 				</div>

--- a/apps/web/src/hosted/billing/usage/usage-page.tsx
+++ b/apps/web/src/hosted/billing/usage/usage-page.tsx
@@ -13,7 +13,7 @@ import { useUsage } from "@/hosted/billing/hooks";
 import { formatShortDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
-const DESCRIPTION = "AI Credit consumption for the current reporting window across your agents.";
+const DESCRIPTION = "AI Credits usage for the current reporting window across your agents.";
 const USAGE_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6");
 
 export function UsagePage() {
@@ -48,7 +48,7 @@ export function UsagePage() {
 	const windowLabel = `${formatShortDate(u.period_start)} – ${formatShortDate(u.period_end)}`;
 	const dailyChartLabel =
 		hasDailyBreakdown && firstDailyPoint && lastDailyPoint
-			? `Daily AI Credit usage returned for ${formatShortDate(firstDailyPoint.date)} to ${formatShortDate(lastDailyPoint.date)} within the ${windowLabel} reporting window.`
+			? `Daily AI Credits usage returned for ${formatShortDate(firstDailyPoint.date)} to ${formatShortDate(lastDailyPoint.date)} within the ${windowLabel} reporting window.`
 			: undefined;
 	const maxDay = Math.max(1, ...u.by_day.map((d) => d.credits));
 	const maxModel = Math.max(1, ...u.by_model.map((m) => m.credits));
@@ -105,15 +105,15 @@ export function UsagePage() {
 								{u.by_day.map((d) => (
 									<div
 										key={d.date}
-										title={`${d.date}: ${formatCredits(d.credits)} credits`}
+										title={`${formatShortDate(d.date)}: ${formatCredits(d.credits)}`}
 										className="flex-1 rounded-t bg-primary/70 transition-colors hover:bg-primary"
 										style={{ height: `${Math.max(2, (d.credits / maxDay) * 100)}%` }}
 									/>
 								))}
 							</div>
 							<div className="mt-1.5 flex justify-between text-2xs text-muted-foreground">
-								<span>{firstDailyPoint?.date.slice(5)}</span>
-								<span>{lastDailyPoint?.date.slice(5)}</span>
+								<span>{formatShortDate(firstDailyPoint?.date, { includeYear: false })}</span>
+								<span>{formatShortDate(lastDailyPoint?.date, { includeYear: false })}</span>
 							</div>
 							<table className="sr-only">
 								<caption>Daily consumption by day in the reporting window</caption>
@@ -148,25 +148,33 @@ export function UsagePage() {
 				<CardHeader>
 					<CardTitle className="text-base">By model</CardTitle>
 				</CardHeader>
-				<CardContent className="space-y-4">
-					{u.by_model.map((m) => (
-						<div key={`${m.provider ?? "managed"}:${m.model}`} className="space-y-1">
-							<div className="flex items-baseline justify-between gap-2 text-sm">
-								<span className="truncate font-medium">{m.model}</span>
-								<span className="shrink-0 tabular-nums">{formatCredits(m.credits)}</span>
+				<CardContent className="flex flex-col gap-4">
+					{u.by_model.length === 0 ? (
+						<EmptyState
+							variant="inset"
+							description="No model breakdown available"
+							className="py-4 md:p-4"
+						/>
+					) : (
+						u.by_model.map((m) => (
+							<div key={`${m.provider ?? "managed"}:${m.model}`} className="space-y-1">
+								<div className="flex items-baseline justify-between gap-2 text-sm">
+									<span className="truncate font-medium">{m.model}</span>
+									<span className="shrink-0 tabular-nums">{formatCredits(m.credits)}</span>
+								</div>
+								<div className="h-2 overflow-hidden rounded-full bg-muted">
+									<div
+										className="h-2 rounded-full bg-primary"
+										style={{ width: `${(m.credits / maxModel) * 100}%` }}
+									/>
+								</div>
+								<div className="text-xs text-muted-foreground">
+									{m.provider ? `${m.provider} · ` : ""}
+									{m.requests.toLocaleString()} requests
+								</div>
 							</div>
-							<div className="h-2 overflow-hidden rounded-full bg-muted">
-								<div
-									className="h-2 rounded-full bg-primary"
-									style={{ width: `${(m.credits / maxModel) * 100}%` }}
-								/>
-							</div>
-							<div className="text-xs text-muted-foreground">
-								{m.provider ? `${m.provider} · ` : ""}
-								{m.requests.toLocaleString()} requests
-							</div>
-						</div>
-					))}
+						))
+					)}
 				</CardContent>
 			</Card>
 		</div>

--- a/apps/web/src/hosted/billing/wallet/auto-reload-action.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-action.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import type { WalletState } from "@/hosted/billing/contracts";
+import { formatCents } from "@/hosted/billing/format";
 import { billingKeys } from "@/hosted/billing/hooks";
 import {
 	type PaymentOutcome,
@@ -41,6 +42,7 @@ export function AutoReloadActionConfirm({
 	const clientSecret = action.client_secret;
 	const variant = declined ? "destructive" : "default";
 	const title = declined ? "Last auto-reload was declined" : "Confirm your last auto-reload";
+	const charge = formatCents(wallet.auto_reload_amount_cents);
 
 	function onComplete(status: PaymentOutcome) {
 		// The wallet snapshot resolves `auto_reload_action` once the PaymentIntent
@@ -69,7 +71,7 @@ export function AutoReloadActionConfirm({
 							: "Your bank is still confirming the last auto-reload. Managed AI and wallet-funded compute still use the remaining balance until it clears."}
 					</span>
 					{onTopUp ? (
-						<Button size="sm" onClick={onTopUp}>
+						<Button type="button" size="sm" onClick={onTopUp}>
 							<CreditCard /> Top up manually
 						</Button>
 					) : null}
@@ -85,8 +87,8 @@ export function AutoReloadActionConfirm({
 			<AlertDescription className="flex flex-col items-start gap-3">
 				<span>
 					{declined
-						? "Your saved card was declined. Retry with a card to complete this top-up before the remaining balance runs out."
-						: "Your bank asked to confirm this top-up. Complete it here before the remaining balance runs out."}
+						? `Your saved card was declined. Retry the ${charge} top-up before the remaining balance runs out.`
+						: `Your bank asked to confirm this ${charge} top-up. Complete it before the remaining balance runs out.`}
 				</span>
 				{confirming ? (
 					<div className="w-full">
@@ -94,10 +96,12 @@ export function AutoReloadActionConfirm({
 							clientSecret={clientSecret}
 							onComplete={onComplete}
 							onCancel={() => setConfirming(false)}
+							summary={`Auto-reload charge: ${charge}`}
+							submitLabel={`${declined ? "Retry" : "Confirm"} ${charge} payment`}
 						/>
 					</div>
 				) : (
-					<Button size="sm" onClick={() => setConfirming(true)}>
+					<Button type="button" size="sm" onClick={() => setConfirming(true)}>
 						{declined ? (
 							<>
 								<RefreshCw /> Retry payment

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { autoReloadFormState } from "./auto-reload-card.logic";
+import type { WalletState } from "@/hosted/billing/contracts";
+import { BillingApiError } from "@/hosted/billing/errors";
+import {
+	autoReloadDraftFromWallet,
+	autoReloadDraftIsDirty,
+	autoReloadFormState,
+	autoReloadRequest,
+	autoReloadSaveError,
+	autoReloadThresholdMinimumCents,
+} from "./auto-reload-card.logic";
 
 const validForm = {
 	amount: "25",
@@ -28,5 +37,105 @@ describe("autoReloadFormState", () => {
 	test("preserves the $1 threshold floor at 1000 points per USD", () => {
 		expect(autoReloadFormState({ ...validForm, threshold: "0.99" }).thresholdValid).toBe(false);
 		expect(autoReloadFormState({ ...validForm, threshold: "1" }).thresholdValid).toBe(true);
+	});
+
+	test("converts the 1000-credit threshold floor at other wallet rates", () => {
+		expect(autoReloadThresholdMinimumCents(100)).toBe(1_000);
+		expect(
+			autoReloadFormState({ ...validForm, pointsPerUsd: 100, threshold: "9.99" }).thresholdValid,
+		).toBe(false);
+		expect(
+			autoReloadFormState({ ...validForm, pointsPerUsd: 100, threshold: "10" }).thresholdValid,
+		).toBe(true);
+	});
+
+	test("rejects values with more than two decimal places instead of rounding them", () => {
+		expect(autoReloadFormState({ ...validForm, amount: "25.001" }).amountValid).toBe(false);
+		expect(autoReloadFormState({ ...validForm, threshold: "1.001" }).thresholdValid).toBe(false);
+		expect(autoReloadFormState({ ...validForm, cap: "100.001" }).capValid).toBe(false);
+	});
+});
+
+const wallet: WalletState = {
+	balance_credits: 25_000,
+	overdraft_credits: 0,
+	balance_snapshot_at: "2026-07-15T00:00:00Z",
+	payment_mode: "card",
+	x402_enabled: false,
+	auto_reload_enabled: false,
+	auto_reload_threshold_credits: 5_000,
+	auto_reload_amount_cents: 2_500,
+	auto_reload_monthly_cap_cents: 10_000,
+	auto_reload_action: null,
+	points_per_usd: 1_000,
+};
+
+describe("auto-reload explicit-save state", () => {
+	test("builds one atomic request containing the toggle and every parameter", () => {
+		const draft = {
+			...autoReloadDraftFromWallet(wallet),
+			enabled: true,
+			threshold: "7.50",
+			amount: "30",
+			cap: "125",
+		};
+
+		expect(autoReloadRequest(draft, wallet.points_per_usd)).toEqual({
+			auto_reload_enabled: true,
+			auto_reload_threshold_credits: 7_500,
+			auto_reload_amount_cents: 3_000,
+			auto_reload_monthly_cap_cents: 12_500,
+		});
+	});
+
+	test("includes all parameters when disabling auto-reload", () => {
+		const draft = autoReloadDraftFromWallet({ ...wallet, auto_reload_enabled: true });
+
+		expect(autoReloadRequest({ ...draft, enabled: false }, wallet.points_per_usd)).toEqual({
+			auto_reload_enabled: false,
+			auto_reload_threshold_credits: 5_000,
+			auto_reload_amount_cents: 2_500,
+			auto_reload_monthly_cap_cents: 10_000,
+		});
+	});
+
+	test("tracks semantic changes without treating equivalent dollar formatting as dirty", () => {
+		const baseline = autoReloadDraftFromWallet(wallet);
+
+		expect(
+			autoReloadDraftIsDirty({ ...baseline, amount: "25.00" }, baseline, wallet.points_per_usd),
+		).toBe(false);
+		expect(
+			autoReloadDraftIsDirty({ ...baseline, amount: "26" }, baseline, wallet.points_per_usd),
+		).toBe(true);
+		expect(
+			autoReloadDraftIsDirty({ ...baseline, amount: "" }, baseline, wallet.points_per_usd),
+		).toBe(true);
+	});
+});
+
+describe("autoReloadSaveError", () => {
+	test("maps payment-method and field failures to actionable copy", () => {
+		expect(
+			autoReloadSaveError(
+				new BillingApiError(400, "Auto reload requires a default payment method"),
+			),
+		).toMatchObject({ requiresPaymentMethod: true, field: null });
+		expect(
+			autoReloadSaveError(
+				new BillingApiError(400, "Auto reload amount must be between 500 and 50000 cents"),
+			),
+		).toMatchObject({ field: "amount", requiresPaymentMethod: false });
+	});
+
+	test("keeps unknown structured codes out of user-facing copy", () => {
+		const copy = autoReloadSaveError(
+			new BillingApiError(409, "internal", {
+				detail: { code: "wallet_reload_bridge_internal_17" },
+			}),
+		);
+
+		expect(copy.description).not.toContain("wallet_reload_bridge_internal_17");
+		expect(copy.description).toMatch(/refresh and try again/i);
 	});
 });

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.ts
@@ -1,8 +1,21 @@
+import type { WalletAutoReloadRequest, WalletState } from "@/hosted/billing/contracts";
+import {
+	BillingApiError,
+	billingErrorDetail,
+	normalizeBillingError,
+} from "@/hosted/billing/errors";
 import {
 	AUTORELOAD_AMOUNT_MAX_CENTS,
 	AUTORELOAD_AMOUNT_MIN_CENTS,
 	AUTORELOAD_THRESHOLD_MIN_CREDITS,
 } from "@/hosted/billing/wallet/wallet-constants";
+
+export interface AutoReloadDraft {
+	enabled: boolean;
+	amount: string;
+	threshold: string;
+	cap: string;
+}
 
 export interface AutoReloadFormInput {
 	amount: string;
@@ -21,8 +34,22 @@ export interface AutoReloadFormState {
 	formValid: boolean;
 }
 
-function centsFromDollars(value: string): number {
-	return Math.round(Number(value) * 100);
+export interface AutoReloadSaveError {
+	title: string;
+	description: string;
+	field: "amount" | "threshold" | "cap" | null;
+	requiresPaymentMethod: boolean;
+}
+
+function dollars(value: number): string {
+	return String(Math.round(value * 100) / 100);
+}
+
+function dollarsFromInput(value: string): number | null {
+	const normalized = value.trim();
+	if (!/^(?:\d+(?:\.\d{0,2})?|\.\d{1,2})$/.test(normalized)) return null;
+	const parsed = Number(normalized);
+	return Number.isFinite(parsed) ? parsed : null;
 }
 
 export function autoReloadFormState({
@@ -31,13 +58,20 @@ export function autoReloadFormState({
 	cap,
 	pointsPerUsd,
 }: AutoReloadFormInput): AutoReloadFormState {
-	const amountCents = centsFromDollars(amount);
-	const thresholdCredits = Math.round(Number(threshold) * pointsPerUsd);
-	const capCents = cap.trim() === "" ? Number.NaN : centsFromDollars(cap);
+	const amountDollars = dollarsFromInput(amount);
+	const thresholdDollars = dollarsFromInput(threshold);
+	const capDollars = dollarsFromInput(cap);
+	const amountCents = amountDollars === null ? Number.NaN : Math.round(amountDollars * 100);
+	const thresholdCredits =
+		thresholdDollars === null ? Number.NaN : Math.round(thresholdDollars * pointsPerUsd);
+	const capCents = capDollars === null ? Number.NaN : Math.round(capDollars * 100);
 
 	const amountValid =
-		amountCents >= AUTORELOAD_AMOUNT_MIN_CENTS && amountCents <= AUTORELOAD_AMOUNT_MAX_CENTS;
-	const thresholdValid = thresholdCredits >= AUTORELOAD_THRESHOLD_MIN_CREDITS;
+		Number.isFinite(amountCents) &&
+		amountCents >= AUTORELOAD_AMOUNT_MIN_CENTS &&
+		amountCents <= AUTORELOAD_AMOUNT_MAX_CENTS;
+	const thresholdValid =
+		Number.isFinite(thresholdCredits) && thresholdCredits >= AUTORELOAD_THRESHOLD_MIN_CREDITS;
 	// 0 = no cap; any positive value is a cap. Blank / negative / non-numeric is invalid.
 	const capValid = Number.isFinite(capCents) && capCents >= 0;
 	const formValid = amountValid && thresholdValid && capValid;
@@ -50,5 +84,102 @@ export function autoReloadFormState({
 		thresholdValid,
 		capValid,
 		formValid,
+	};
+}
+
+export function autoReloadThresholdMinimumCents(pointsPerUsd: number): number {
+	return Math.ceil((AUTORELOAD_THRESHOLD_MIN_CREDITS / pointsPerUsd) * 100);
+}
+
+export function autoReloadDraftFromWallet(wallet: WalletState): AutoReloadDraft {
+	const pointsPerUsd = wallet.points_per_usd || 1000;
+	return {
+		enabled: wallet.auto_reload_enabled,
+		threshold: dollars(wallet.auto_reload_threshold_credits / pointsPerUsd),
+		amount: dollars(wallet.auto_reload_amount_cents / 100),
+		cap: dollars(wallet.auto_reload_monthly_cap_cents / 100),
+	};
+}
+
+export function autoReloadRequest(
+	draft: AutoReloadDraft,
+	pointsPerUsd: number,
+): WalletAutoReloadRequest | null {
+	const state = autoReloadFormState({
+		amount: draft.amount,
+		threshold: draft.threshold,
+		cap: draft.cap,
+		pointsPerUsd,
+	});
+	if (!state.formValid) return null;
+
+	return {
+		auto_reload_enabled: draft.enabled,
+		auto_reload_threshold_credits: state.thresholdCredits,
+		auto_reload_amount_cents: state.amountCents,
+		auto_reload_monthly_cap_cents: state.capCents,
+	};
+}
+
+export function autoReloadDraftIsDirty(
+	draft: AutoReloadDraft,
+	baseline: AutoReloadDraft,
+	pointsPerUsd: number,
+): boolean {
+	const draftRequest = autoReloadRequest(draft, pointsPerUsd);
+	const baselineRequest = autoReloadRequest(baseline, pointsPerUsd);
+	if (!draftRequest || !baselineRequest) return JSON.stringify(draft) !== JSON.stringify(baseline);
+
+	return (
+		draftRequest.auto_reload_enabled !== baselineRequest.auto_reload_enabled ||
+		draftRequest.auto_reload_threshold_credits !== baselineRequest.auto_reload_threshold_credits ||
+		draftRequest.auto_reload_amount_cents !== baselineRequest.auto_reload_amount_cents ||
+		draftRequest.auto_reload_monthly_cap_cents !== baselineRequest.auto_reload_monthly_cap_cents
+	);
+}
+
+export function autoReloadSaveError(error: unknown): AutoReloadSaveError {
+	const detail = error instanceof BillingApiError ? error.detail : "";
+	const code = billingErrorDetail(error)?.code;
+	const signal = `${typeof code === "string" ? code : ""} ${detail}`.toLowerCase();
+
+	if (signal.includes("payment method") || signal.includes("payment_method")) {
+		return {
+			title: "Add a card before enabling auto-reload",
+			description: "Complete a manual top-up to save a card, then save these changes again.",
+			field: null,
+			requiresPaymentMethod: true,
+		};
+	}
+	if (signal.includes("threshold")) {
+		return {
+			title: "Check the balance threshold",
+			description: "Enter a threshold at or above the minimum shown below, then save again.",
+			field: "threshold",
+			requiresPaymentMethod: false,
+		};
+	}
+	if (signal.includes("monthly cap") || signal.includes("monthly_cap")) {
+		return {
+			title: "Check the monthly cap",
+			description: "Enter 0 for no cap or a positive dollar amount, then save again.",
+			field: "cap",
+			requiresPaymentMethod: false,
+		};
+	}
+	if (signal.includes("auto reload amount") || signal.includes("auto_reload_amount")) {
+		return {
+			title: "Check the reload amount",
+			description: "Enter an amount from $5 to $500, then save again.",
+			field: "amount",
+			requiresPaymentMethod: false,
+		};
+	}
+
+	return {
+		title: "Couldn’t save auto-reload",
+		description: normalizeBillingError(error),
+		field: null,
+		requiresPaymentMethod: false,
 	};
 }

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
@@ -1,214 +1,341 @@
 "use client";
 
-import { Repeat } from "lucide-react";
-import { useEffect, useState } from "react";
+import { AlertCircle, CreditCard, Repeat } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { useSettingsEditState } from "@/components/settings-edit-state";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardFooter,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
 import type { WalletState } from "@/hosted/billing/contracts";
-import { normalizeBillingError } from "@/hosted/billing/errors";
+import { formatCents } from "@/hosted/billing/format";
 import { useSetAutoReload } from "@/hosted/billing/hooks";
+import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { AutoReloadActionConfirm } from "@/hosted/billing/wallet/auto-reload-action";
-import { autoReloadFormState } from "@/hosted/billing/wallet/auto-reload-card.logic";
+import {
+	type AutoReloadDraft,
+	type AutoReloadSaveError,
+	autoReloadDraftFromWallet,
+	autoReloadDraftIsDirty,
+	autoReloadFormState,
+	autoReloadRequest,
+	autoReloadSaveError,
+	autoReloadThresholdMinimumCents,
+} from "@/hosted/billing/wallet/auto-reload-card.logic";
 import {
 	AUTORELOAD_AMOUNT_MAX_CENTS,
 	AUTORELOAD_AMOUNT_MIN_CENTS,
 } from "@/hosted/billing/wallet/wallet-constants";
 
-function dollars(n: number): string {
-	// Preserve cents (e.g. 7.5, 1.25) — rounding to whole dollars silently
-	// misrepresented a saved threshold/amount when the user reopened the card.
-	return String(Math.round(n * 100) / 100);
-}
+type AutoReloadField = "threshold" | "amount" | "cap";
+type BlurredFields = Record<AutoReloadField, boolean>;
+
+const PRISTINE_FIELDS: BlurredFields = { threshold: false, amount: false, cap: false };
+const ALL_FIELDS_BLURRED: BlurredFields = { threshold: true, amount: true, cap: true };
 
 export function AutoReloadCard({ wallet, onTopUp }: { wallet: WalletState; onTopUp?: () => void }) {
 	const save = useSetAutoReload();
+	const runAction = useActionLock();
 	const pointsPerUsd = wallet.points_per_usd || 1000;
+	const thresholdMinimumCents = autoReloadThresholdMinimumCents(pointsPerUsd);
+	const initialDraft = autoReloadDraftFromWallet(wallet);
+	const [baseline, setBaseline] = useState<AutoReloadDraft>(initialDraft);
+	const [draft, setDraft] = useState<AutoReloadDraft>(initialDraft);
+	const [blurred, setBlurred] = useState<BlurredFields>(PRISTINE_FIELDS);
+	const [requestError, setRequestError] = useState<AutoReloadSaveError | null>(null);
+	const draftRef = useRef(draft);
+	const baselineRef = useRef(baseline);
+	const pendingRef = useRef(save.isPending);
+	draftRef.current = draft;
+	baselineRef.current = baseline;
+	pendingRef.current = save.isPending;
 
-	const [enabled, setEnabled] = useState(wallet.auto_reload_enabled);
-	const [threshold, setThreshold] = useState(
-		dollars(wallet.auto_reload_threshold_credits / pointsPerUsd),
-	);
-	const [amount, setAmount] = useState(dollars(wallet.auto_reload_amount_cents / 100));
-	const [cap, setCap] = useState(dollars(wallet.auto_reload_monthly_cap_cents / 100));
+	const form = autoReloadFormState({
+		amount: draft.amount,
+		threshold: draft.threshold,
+		cap: draft.cap,
+		pointsPerUsd,
+	});
+	const dirty = autoReloadDraftIsDirty(draft, baseline, pointsPerUsd);
+	useSettingsEditState({ dirty, busy: save.isPending });
 
 	useEffect(() => {
-		if (save.isPending) return;
-		setEnabled(wallet.auto_reload_enabled);
-		setThreshold(dollars(wallet.auto_reload_threshold_credits / pointsPerUsd));
-		setAmount(dollars(wallet.auto_reload_amount_cents / 100));
-		setCap(dollars(wallet.auto_reload_monthly_cap_cents / 100));
+		const next = autoReloadDraftFromWallet(wallet);
+		const wasDirty = autoReloadDraftIsDirty(
+			draftRef.current,
+			baselineRef.current,
+			wallet.points_per_usd || 1000,
+		);
+		setBaseline(next);
+		if (!wasDirty && !pendingRef.current) {
+			setDraft(next);
+			setBlurred(PRISTINE_FIELDS);
+			setRequestError(null);
+		}
 	}, [
-		save.isPending,
 		wallet.auto_reload_enabled,
 		wallet.auto_reload_threshold_credits,
 		wallet.auto_reload_amount_cents,
 		wallet.auto_reload_monthly_cap_cents,
-		pointsPerUsd,
+		wallet.points_per_usd,
 	]);
 
-	const {
-		amountCents,
-		thresholdCredits,
-		capCents,
-		amountValid,
-		thresholdValid,
-		capValid,
-		formValid,
-	} = autoReloadFormState({
-		amount,
-		threshold,
-		cap,
-		pointsPerUsd,
-	});
+	function updateDraft<K extends keyof AutoReloadDraft>(key: K, value: AutoReloadDraft[K]) {
+		setDraft((current) => ({ ...current, [key]: value }));
+		setRequestError(null);
+	}
 
-	async function persist(nextEnabled: boolean) {
-		// Belt-and-braces against a double-fire while the switch/button repaint.
+	function markBlurred(field: AutoReloadField) {
+		setBlurred((current) => ({ ...current, [field]: true }));
+	}
+
+	function cancelChanges() {
 		if (save.isPending) return;
-		if (nextEnabled && !formValid) return;
+		setDraft(baseline);
+		setBlurred(PRISTINE_FIELDS);
+		setRequestError(null);
+	}
+
+	async function saveChanges() {
+		const request = autoReloadRequest(draft, pointsPerUsd);
+		if (!dirty || !request || save.isPending) return;
+		setRequestError(null);
 		try {
-			await save.mutateAsync(
-				nextEnabled
-					? {
-							auto_reload_enabled: true,
-							auto_reload_threshold_credits: thresholdCredits,
-							auto_reload_amount_cents: amountCents,
-							auto_reload_monthly_cap_cents: capCents,
-						}
-					: { auto_reload_enabled: false },
-			);
-			setEnabled(nextEnabled);
-			toast.success(nextEnabled ? "Auto-reload on" : "Auto-reload off");
-		} catch (e) {
-			// Re-sync the switch with the server's truth on failure.
-			setEnabled(wallet.auto_reload_enabled);
-			toast.error("Couldn’t update auto-reload", { description: normalizeBillingError(e) });
+			const nextWallet = await save.mutateAsync(request);
+			const next = autoReloadDraftFromWallet(nextWallet);
+			setBaseline(next);
+			setDraft(next);
+			setBlurred(PRISTINE_FIELDS);
+			toast.success("Auto-reload settings saved", {
+				description: next.enabled
+					? "Auto-reload is on with the saved threshold, amount, and monthly cap."
+					: "Auto-reload is off. Your saved parameters are ready for the next time you enable it.",
+			});
+		} catch (error) {
+			const copy = autoReloadSaveError(error);
+			setRequestError(copy);
+			const field = copy.field;
+			if (field) {
+				setBlurred((current) => ({ ...current, [field]: true }));
+				window.requestAnimationFrame(() => document.getElementById(`ar-${field}`)?.focus());
+			}
+			toast.error(copy.title, { description: copy.description });
 		}
 	}
+
+	const thresholdInvalid = blurred.threshold && !form.thresholdValid;
+	const amountInvalid = blurred.amount && !form.amountValid;
+	const capInvalid = blurred.cap && !form.capValid;
+	const thresholdServerError = requestError?.field === "threshold";
+	const amountServerError = requestError?.field === "amount";
+	const capServerError = requestError?.field === "cap";
 
 	return (
 		<Card data-hosted="true">
 			<CardHeader>
 				<div className="flex items-start justify-between gap-3">
-					<div>
+					<div className="min-w-0">
 						<CardTitle className="flex items-center gap-2 text-base">
-							<Repeat className="size-4" /> Auto-reload
+							<Repeat className="size-4" aria-hidden /> Auto-reload
 						</CardTitle>
-						<CardDescription>
-							Automatically top up when your balance drops below the threshold. Off by default.
+						<CardDescription id="auto-reload-description">
+							Top up automatically below a balance threshold. Changes apply only after you save.
 						</CardDescription>
 					</div>
-					<Switch
-						checked={enabled}
-						onCheckedChange={(next) => persist(next)}
-						disabled={save.isPending || (!enabled && !formValid)}
-						aria-label="Enable auto-reload"
-					/>
+					<div className="flex shrink-0 items-center gap-2">
+						<Label htmlFor="auto-reload-enabled" className="text-sm">
+							Enabled
+						</Label>
+						<Switch
+							id="auto-reload-enabled"
+							checked={draft.enabled}
+							onCheckedChange={(enabled) => updateDraft("enabled", enabled)}
+							disabled={save.isPending}
+							aria-describedby="auto-reload-description"
+						/>
+					</div>
 				</div>
 			</CardHeader>
-			<CardContent className="space-y-4">
+
+			<CardContent className="flex flex-col gap-4">
 				<AutoReloadActionConfirm wallet={wallet} onTopUp={onTopUp} />
 
-				<div className="grid gap-4 sm:grid-cols-3">
-					<div className="space-y-1.5">
-						<Label htmlFor="ar-threshold">When below ($)</Label>
-						<Input
-							id="ar-threshold"
-							name="ar-threshold"
-							type="number"
-							inputMode="decimal"
-							autoComplete="off"
-							min={1}
-							step="1"
-							className="tabular-nums"
-							value={threshold}
-							onChange={(e) => setThreshold(e.target.value)}
-							aria-invalid={!thresholdValid}
-							aria-describedby={!thresholdValid ? "ar-threshold-err" : undefined}
-						/>
-						{!thresholdValid ? (
-							<p id="ar-threshold-err" className="text-xs text-destructive">
-								Minimum $1.
-							</p>
-						) : null}
-					</div>
-					<div className="space-y-1.5">
-						<Label htmlFor="ar-amount">Add ($)</Label>
-						<Input
-							id="ar-amount"
-							name="ar-amount"
-							type="number"
-							inputMode="decimal"
-							autoComplete="off"
-							min={AUTORELOAD_AMOUNT_MIN_CENTS / 100}
-							max={AUTORELOAD_AMOUNT_MAX_CENTS / 100}
-							step="1"
-							className="tabular-nums"
-							value={amount}
-							onChange={(e) => setAmount(e.target.value)}
-							aria-invalid={!amountValid}
-							aria-describedby={!amountValid ? "ar-amount-err" : undefined}
-						/>
-						{!amountValid ? (
-							<p id="ar-amount-err" className="text-xs text-destructive">
-								$5–$500.
-							</p>
-						) : null}
-					</div>
-					<div className="space-y-1.5">
-						<Label htmlFor="ar-cap">Monthly cap ($)</Label>
-						<Input
-							id="ar-cap"
-							name="ar-cap"
-							type="number"
-							inputMode="decimal"
-							autoComplete="off"
-							min={0}
-							step="1"
-							className="tabular-nums"
-							value={cap}
-							onChange={(e) => setCap(e.target.value)}
-							aria-invalid={!capValid}
-							aria-describedby={capValid ? "ar-cap-help" : "ar-cap-err"}
-						/>
-						{capValid ? (
-							<p id="ar-cap-help" className="text-xs text-muted-foreground">
-								Enter 0 only if you want no monthly cap.
-							</p>
-						) : (
-							<p id="ar-cap-err" className="text-xs text-destructive">
-								Enter a monthly cap, or enter 0 for no cap.
-							</p>
-						)}
-					</div>
-				</div>
+				{requestError ? (
+					<Alert variant="destructive">
+						<AlertCircle aria-hidden />
+						<AlertTitle>{requestError.title}</AlertTitle>
+						<AlertDescription id="auto-reload-save-error" className="flex flex-col gap-3">
+							<span>{requestError.description}</span>
+							{requestError.requiresPaymentMethod && onTopUp ? (
+								<Button type="button" size="sm" variant="outline" onClick={onTopUp}>
+									<CreditCard data-icon="inline-start" /> Add a card
+								</Button>
+							) : null}
+						</AlertDescription>
+					</Alert>
+				) : null}
 
-				<div className="flex flex-wrap items-center justify-between gap-2">
-					<p className="text-xs text-muted-foreground">
-						Enabling requires a saved card. Your first top-up saves one.
-					</p>
-					{enabled ? (
-						<Button
-							size="sm"
-							variant="outline"
-							onClick={() => persist(true)}
-							disabled={!formValid || save.isPending}
-						>
-							{save.isPending ? (
-								<>
-									<Spinner /> Saving…
-								</>
-							) : (
-								"Save changes"
-							)}
-						</Button>
-					) : null}
-				</div>
+				<form
+					id="auto-reload-form"
+					onSubmit={(event) => {
+						event.preventDefault();
+						setBlurred(ALL_FIELDS_BLURRED);
+						void runAction(saveChanges);
+					}}
+				>
+					<div className="grid gap-4 sm:grid-cols-3">
+						<div className="flex flex-col gap-1.5">
+							<Label htmlFor="ar-threshold">When balance is below (USD)</Label>
+							<Input
+								id="ar-threshold"
+								name="auto-reload-threshold"
+								type="number"
+								inputMode="decimal"
+								autoComplete="off"
+								min={thresholdMinimumCents / 100}
+								step="0.01"
+								className="tabular-nums"
+								value={draft.threshold}
+								onChange={(event) => updateDraft("threshold", event.target.value)}
+								onBlur={() => markBlurred("threshold")}
+								disabled={save.isPending}
+								aria-invalid={thresholdInvalid || thresholdServerError}
+								aria-describedby={
+									thresholdServerError
+										? "ar-threshold-help auto-reload-save-error"
+										: "ar-threshold-help"
+								}
+							/>
+							<p
+								id="ar-threshold-help"
+								className={
+									thresholdInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
+								}
+								aria-live="polite"
+							>
+								Minimum {formatCents(thresholdMinimumCents)}; up to 2 decimal places.
+							</p>
+						</div>
+
+						<div className="flex flex-col gap-1.5">
+							<Label htmlFor="ar-amount">Amount to add (USD)</Label>
+							<Input
+								id="ar-amount"
+								name="auto-reload-amount"
+								type="number"
+								inputMode="decimal"
+								autoComplete="off"
+								min={AUTORELOAD_AMOUNT_MIN_CENTS / 100}
+								max={AUTORELOAD_AMOUNT_MAX_CENTS / 100}
+								step="0.01"
+								className="tabular-nums"
+								value={draft.amount}
+								onChange={(event) => updateDraft("amount", event.target.value)}
+								onBlur={() => markBlurred("amount")}
+								disabled={save.isPending}
+								aria-invalid={amountInvalid || amountServerError}
+								aria-describedby={
+									amountServerError ? "ar-amount-help auto-reload-save-error" : "ar-amount-help"
+								}
+							/>
+							<p
+								id="ar-amount-help"
+								className={
+									amountInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
+								}
+								aria-live="polite"
+							>
+								$5–$500; up to 2 decimal places.
+							</p>
+						</div>
+
+						<div className="flex flex-col gap-1.5">
+							<Label htmlFor="ar-cap">Monthly cap (USD)</Label>
+							<Input
+								id="ar-cap"
+								name="auto-reload-monthly-cap"
+								type="number"
+								inputMode="decimal"
+								autoComplete="off"
+								min={0}
+								step="0.01"
+								className="tabular-nums"
+								value={draft.cap}
+								onChange={(event) => updateDraft("cap", event.target.value)}
+								onBlur={() => markBlurred("cap")}
+								disabled={save.isPending}
+								aria-invalid={capInvalid || capServerError}
+								aria-describedby={
+									capServerError ? "ar-cap-help auto-reload-save-error" : "ar-cap-help"
+								}
+							/>
+							<p
+								id="ar-cap-help"
+								className={
+									capInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
+								}
+								aria-live="polite"
+							>
+								Enter 0 for no monthly cap; up to 2 decimal places.
+							</p>
+						</div>
+					</div>
+				</form>
 			</CardContent>
+
+			<CardFooter className="flex flex-wrap justify-between gap-3 border-t">
+				<div className="flex min-w-0 flex-col gap-1">
+					<p className="text-xs text-muted-foreground">
+						Enabling requires a saved card. Your first manual top-up saves one.
+					</p>
+					<p
+						className={
+							dirty
+								? "text-xs font-medium text-warning-muted-foreground"
+								: "text-xs text-muted-foreground"
+						}
+						aria-live="polite"
+					>
+						{dirty ? "Unsaved changes" : "All changes saved"}
+					</p>
+				</div>
+				<div className="flex gap-2">
+					<Button
+						type="button"
+						size="sm"
+						variant="ghost"
+						onClick={cancelChanges}
+						disabled={!dirty || save.isPending}
+					>
+						Cancel changes
+					</Button>
+					<Button
+						type="submit"
+						form="auto-reload-form"
+						size="sm"
+						disabled={!dirty || !form.formValid || save.isPending}
+					>
+						{save.isPending ? (
+							<>
+								<Spinner data-icon="inline-start" /> Saving…
+							</>
+						) : (
+							"Save changes"
+						)}
+					</Button>
+				</div>
+			</CardFooter>
 		</Card>
 	);
 }

--- a/apps/web/src/hosted/billing/wallet/compute-commitment-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/compute-commitment-card.tsx
@@ -11,7 +11,7 @@ import { StatusBadge } from "@/components/ui/status-badge";
 import { deploymentDisplayName } from "@/hosted/agent-identity";
 import type { HostedDeployment, Plan, WalletState } from "@/hosted/billing/contracts";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
-import { formatCents, formatCentsCompact } from "@/hosted/billing/format";
+import { formatCents } from "@/hosted/billing/format";
 import { walletComputeCoverage } from "@/hosted/billing/wallet/wallet-compute.logic";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { formatShortDate } from "@/lib/format";
@@ -50,6 +50,8 @@ export function ComputeCommitmentCard({
 				</div>
 				{isLoading ? (
 					<Skeleton className="h-6 w-28" />
+				) : coverage.deployments.length === 0 ? (
+					<StatusBadge status="neutral">No wallet compute</StatusBadge>
 				) : coverage.lowCoverage ? (
 					<StatusBadge status="warning">Under 1 month</StatusBadge>
 				) : (
@@ -123,8 +125,8 @@ export function ComputeCommitmentCard({
 											<CalendarClock className="size-3.5" aria-hidden />
 											{deployment.renews
 												? deployment.nextRenewalAt
-													? `${formatCentsCompact(deployment.priceCents)} on ${formatShortDate(deployment.nextRenewalAt)}`
-													: `${formatCentsCompact(deployment.priceCents)} monthly · renewal pending`
+													? `${formatCents(deployment.priceCents)} on ${formatShortDate(deployment.nextRenewalAt)}`
+													: `${formatCents(deployment.priceCents)} monthly · renewal pending`
 												: `Ends ${formatShortDate(deployment.nextRenewalAt)} · no renewal charge`}
 										</div>
 									</div>

--- a/apps/web/src/hosted/billing/wallet/ledger-table.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.logic.test.ts
@@ -4,6 +4,7 @@ import {
 	filteredLedgerEntries,
 	ledgerEmptyStateCopy,
 	ledgerOperationGroup,
+	ledgerOperationLabel,
 } from "./ledger-table.logic";
 
 function entry(overrides: Partial<WalletLedgerEntry> = {}): WalletLedgerEntry {
@@ -36,6 +37,10 @@ describe("filteredLedgerEntries", () => {
 				"compute",
 			).map((item) => item.operation),
 		).toEqual(["compute_charge"]);
+	});
+
+	test("does not expose an unknown backend operation token", () => {
+		expect(ledgerOperationLabel("bridge_internal_credit_v3")).toBe("Other activity");
 	});
 });
 

--- a/apps/web/src/hosted/billing/wallet/ledger-table.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.logic.ts
@@ -11,6 +11,21 @@ const LEDGER_FILTERS: readonly LedgerFilter[] = [
 	"refund",
 ];
 
+const LEDGER_OPERATION_LABELS: Record<string, string> = {
+	topup: "Top-up",
+	invoice: "Top-up",
+	x402: "On-chain top-up",
+	grant_signup: "Signup grant",
+	grant_subscription: "Credit grant",
+	grant_redemption: "Redeemed credits",
+	grant_referral: "Referral grant",
+	admin_adjust: "Adjustment",
+	proxy: "Usage",
+	compute_charge: "Compute charge",
+	compute_credit: "Compute reversal",
+	refund: "Refund",
+};
+
 export interface LedgerEmptyStateCopyInput {
 	entriesCount: number;
 	filter: LedgerFilter;
@@ -33,6 +48,10 @@ export function ledgerOperationGroup(op: string): LedgerFilter {
 	if (op === "compute_charge" || op === "compute_credit") return "compute";
 	if (op === "refund") return "refund";
 	return "all";
+}
+
+export function ledgerOperationLabel(op: string): string {
+	return LEDGER_OPERATION_LABELS[op] ?? "Other activity";
 }
 
 export function filteredLedgerEntries(

--- a/apps/web/src/hosted/billing/wallet/ledger-table.tsx
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.tsx
@@ -29,23 +29,9 @@ import {
 	isLedgerFilter,
 	type LedgerFilter,
 	ledgerEmptyStateCopy,
+	ledgerOperationLabel,
 } from "@/hosted/billing/wallet/ledger-table.logic";
 import { cn, relativeTime } from "@/lib/utils";
-
-const OPERATION_LABELS: Record<string, string> = {
-	topup: "Top-up",
-	invoice: "Top-up",
-	x402: "On-chain top-up",
-	grant_signup: "Signup grant",
-	grant_subscription: "Credit grant",
-	grant_redemption: "Redeemed credits",
-	grant_referral: "Referral grant",
-	admin_adjust: "Adjustment",
-	proxy: "Usage",
-	compute_charge: "Compute charge",
-	compute_credit: "Compute reversal",
-	refund: "Refund",
-};
 
 const STATUS_LABELS: Record<WalletLedgerStatus, string> = {
 	applied: "Applied",
@@ -71,10 +57,10 @@ function statusVariant(
 }
 
 function opLabel(op: string): string {
-	return OPERATION_LABELS[op] ?? op;
+	return ledgerOperationLabel(op);
 }
 function statusLabel(status: WalletLedgerStatus): string {
-	return STATUS_LABELS[status] ?? status;
+	return STATUS_LABELS[status] ?? "Unknown";
 }
 function signedAmount(entry: WalletLedgerEntry, pointsPerUsd: number): string {
 	const positive = entry.credits_amount >= 0;

--- a/apps/web/src/hosted/billing/wallet/stripe-payment-form.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/stripe-payment-form.logic.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildSubscriptionPaymentReturnUrl,
+	paymentOutcomeForStatus,
+} from "./stripe-payment-form.logic";
+
+describe("paymentOutcomeForStatus", () => {
+	test("only treats terminal or settling payment states as complete", () => {
+		expect(paymentOutcomeForStatus("succeeded")).toBe("succeeded");
+		expect(paymentOutcomeForStatus("processing")).toBe("processing");
+		expect(paymentOutcomeForStatus("requires_capture")).toBe("processing");
+		expect(paymentOutcomeForStatus("requires_payment_method")).toBeNull();
+		expect(paymentOutcomeForStatus(undefined)).toBeNull();
+	});
+});
+
+describe("buildSubscriptionPaymentReturnUrl", () => {
+	test("keeps term-change redirects on the agent and marks them for subscription refresh", () => {
+		const result = new URL(
+			buildSubscriptionPaymentReturnUrl(
+				"https://app.clawdi.ai/agents/hdep_123/settings?source=on-clawdi&topup_return=1&checkout=cancel&session_id=stale",
+				"hdep_123",
+			),
+		);
+
+		expect(result.pathname).toBe("/agents/hdep_123/settings");
+		expect(result.searchParams.get("source")).toBe("on-clawdi");
+		expect(result.searchParams.get("deployment_id")).toBe("hdep_123");
+		expect(result.searchParams.has("topup_return")).toBe(false);
+		expect(result.searchParams.has("checkout")).toBe(false);
+		expect(result.searchParams.has("session_id")).toBe(false);
+	});
+});

--- a/apps/web/src/hosted/billing/wallet/stripe-payment-form.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/stripe-payment-form.logic.ts
@@ -1,0 +1,26 @@
+export type PaymentOutcome = "succeeded" | "processing";
+
+export function paymentOutcomeForStatus(status: string | undefined): PaymentOutcome | null {
+	if (status === "succeeded") return "succeeded";
+	if (status === "processing" || status === "requires_capture") return "processing";
+	return null;
+}
+
+export function buildSubscriptionPaymentReturnUrl(
+	currentHref: string,
+	deploymentId: string,
+): string {
+	const url = new URL(currentHref);
+	for (const key of [
+		"checkout",
+		"checkout_session_id",
+		"mockCheckout",
+		"session_id",
+		"topup_return",
+		"upgrade_deployment_id",
+	]) {
+		url.searchParams.delete(key);
+	}
+	url.searchParams.set("deployment_id", deploymentId);
+	return url.toString();
+}

--- a/apps/web/src/hosted/billing/wallet/stripe-payment-form.tsx
+++ b/apps/web/src/hosted/billing/wallet/stripe-payment-form.tsx
@@ -3,88 +3,107 @@
 import { Elements, PaymentElement, useElements, useStripe } from "@stripe/react-stripe-js";
 import type { Stripe } from "@stripe/stripe-js";
 import { AlertCircle, RefreshCw } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { getStripe, resetStripeCache } from "@/hosted/billing/stripe";
+import {
+	type PaymentOutcome,
+	paymentOutcomeForStatus,
+} from "@/hosted/billing/wallet/stripe-payment-form.logic";
 import { buildWalletTopupReturnUrl } from "@/hosted/billing/wallet/top-up-return.logic";
 import { env } from "@/lib/env";
 
-/** Terminal outcomes only — `requires_action` (3DS) is resolved inside the form. */
-export type PaymentOutcome = "succeeded" | "processing";
+export type { PaymentOutcome } from "@/hosted/billing/wallet/stripe-payment-form.logic";
+
+type PaymentReturnUrl = (currentHref: string) => string;
 
 function InnerForm({
 	onComplete,
 	onCancel,
+	returnUrl,
+	submitLabel,
+	summary,
+	onSubmittingChange,
 }: {
 	onComplete: (status: PaymentOutcome) => void;
 	onCancel: () => void;
+	returnUrl: PaymentReturnUrl;
+	submitLabel: string;
+	summary?: string;
+	onSubmittingChange?: (submitting: boolean) => void;
 }) {
 	const stripe = useStripe();
 	const elements = useElements();
 	const [submitting, setSubmitting] = useState(false);
 	const [error, setError] = useState<string | null>(null);
+	const submittingRef = useRef(false);
+
+	function finishSubmitting() {
+		submittingRef.current = false;
+		setSubmitting(false);
+		onSubmittingChange?.(false);
+	}
 
 	async function pay() {
-		// Guard re-entry: the button disables on submit, but a fast double-tap
-		// could still queue a second confirmPayment before React repaints.
-		if (!stripe || !elements || submitting) return;
+		if (!stripe || !elements || submittingRef.current) return;
+		submittingRef.current = true;
 		setSubmitting(true);
+		onSubmittingChange?.(true);
 		setError(null);
-		// `redirect: "if_required"` keeps card payments inline; only methods that
-		// truly need a redirect (some wallets) navigate away.
 		try {
 			const result = await stripe.confirmPayment({
 				elements,
 				redirect: "if_required",
 				confirmParams: {
-					return_url: buildWalletTopupReturnUrl(window.location.href),
+					return_url: returnUrl(window.location.href),
 				},
 			});
 			if (result.error) {
 				setError(result.error.message ?? "We couldn't process that card. Please try again.");
-				setSubmitting(false);
+				finishSubmitting();
 				return;
 			}
 			const status = result.paymentIntent?.status;
-			if (status === "requires_action") {
-				// Stripe couldn't complete the bank confirmation inline (the prompt was
-				// dismissed, or it needs another pass). Keep the form mounted with a
-				// clear next step rather than closing on an unconfirmed payment.
+			const outcome = paymentOutcomeForStatus(status);
+			if (!outcome) {
 				setError(
-					"Your bank needs to confirm this payment. Complete the prompt, then tap Pay again.",
+					status === "requires_action"
+						? "Your bank needs to confirm this payment. Complete the prompt, then select the payment button again."
+						: "This payment is not ready to complete. Review the card details and try again.",
 				);
-				setSubmitting(false);
+				finishSubmitting();
 				return;
 			}
-			onComplete(status === "succeeded" ? "succeeded" : "processing");
+			onComplete(outcome);
 		} catch {
 			setError("We couldn't reach Stripe. Check your connection and try again.");
-			setSubmitting(false);
+			finishSubmitting();
 		}
 	}
 
 	return (
-		<div data-hosted="true" className="space-y-3">
+		<div data-hosted="true" className="flex flex-col gap-3">
+			{summary ? <p className="text-sm font-medium tabular-nums">{summary}</p> : null}
 			<PaymentElement />
 			{error ? (
 				<Alert variant="destructive">
-					<AlertCircle />
+					<AlertCircle aria-hidden />
 					<AlertDescription>{error}</AlertDescription>
 				</Alert>
 			) : null}
 			<div className="flex justify-end gap-2">
-				<Button variant="ghost" onClick={onCancel} disabled={submitting}>
+				<Button type="button" variant="ghost" onClick={onCancel} disabled={submitting}>
 					Back
 				</Button>
-				<Button onClick={pay} disabled={!stripe || submitting}>
+				<Button type="button" onClick={pay} disabled={!stripe || submitting}>
 					{submitting ? (
 						<>
-							<Spinner /> Processing…
+							<Spinner data-icon="inline-start" /> Processing…
 						</>
 					) : (
-						"Pay now"
+						submitLabel
 					)}
 				</Button>
 			</div>
@@ -92,28 +111,24 @@ function InnerForm({
 	);
 }
 
-/**
- * Card-confirmation step for a wallet top-up PaymentIntent. Mounts Stripe
- * Elements against the `client_secret` from `POST /wallet/topup`.
- *
- * Three degrade paths so the dialog never silently breaks:
- *  - no publishable key (OSS / preview) → explicit configuration error.
- *  - Stripe.js fails to load (network / blocked script) → explicit error +
- *    Retry that re-injects the script (rather than mounting `Elements` against
- *    a rejected promise, which renders nothing).
- *  - still loading → a spinner instead of a blank gap.
- */
 export function StripePaymentForm({
 	clientSecret,
 	onComplete,
 	onCancel,
+	returnUrl = buildWalletTopupReturnUrl,
+	submitLabel = "Confirm payment",
+	summary,
+	onSubmittingChange,
 }: {
 	clientSecret: string;
 	onComplete: (status: PaymentOutcome) => void;
 	onCancel: () => void;
+	returnUrl?: PaymentReturnUrl;
+	submitLabel?: string;
+	summary?: string;
+	onSubmittingChange?: (submitting: boolean) => void;
 }) {
 	const key = env.VITE_STRIPE_PUBLISHABLE_KEY;
-	// undefined = loading, null = load failed, Stripe = ready.
 	const [stripe, setStripe] = useState<Stripe | null | undefined>(undefined);
 	const [attempt, setAttempt] = useState(0);
 
@@ -122,11 +137,10 @@ export function StripePaymentForm({
 		let cancelled = false;
 		setStripe(undefined);
 		getStripe(key)
-			.then((s) => {
-				if (!cancelled) setStripe(s);
+			.then((nextStripe) => {
+				if (!cancelled) setStripe(nextStripe);
 			})
 			.catch(() => {
-				// Drop the rejected singleton so the next attempt re-injects.
 				resetStripeCache();
 				if (!cancelled) setStripe(null);
 			});
@@ -138,10 +152,10 @@ export function StripePaymentForm({
 	if (!key) {
 		return (
 			<Alert data-hosted="true">
-				<AlertCircle />
+				<AlertCircle aria-hidden />
 				<AlertDescription>
-					Card payments aren’t configured in this environment. Set a Stripe publishable key to top
-					up.
+					Card payments aren’t configured in this environment. Set a Stripe publishable key to
+					continue.
 				</AlertDescription>
 			</Alert>
 		);
@@ -150,21 +164,22 @@ export function StripePaymentForm({
 	if (stripe === null) {
 		return (
 			<Alert data-hosted="true" variant="destructive">
-				<AlertCircle />
+				<AlertCircle aria-hidden />
 				<AlertDescription className="flex flex-col items-start gap-3">
 					<span>
-						We couldn’t load the secure payment form. Check your connection (or any ad-blocker) and
-						try again.
+						We couldn’t load the secure payment form. Check your connection or ad blocker and try
+						again.
 					</span>
 					<Button
+						type="button"
 						size="sm"
 						variant="outline"
 						onClick={() => {
 							resetStripeCache();
-							setAttempt((a) => a + 1);
+							setAttempt((current) => current + 1);
 						}}
 					>
-						<RefreshCw /> Retry
+						<RefreshCw data-icon="inline-start" /> Retry payment form
 					</Button>
 				</AlertDescription>
 			</Alert>
@@ -177,7 +192,7 @@ export function StripePaymentForm({
 				data-hosted="true"
 				className="flex items-center gap-2 py-6 text-sm text-muted-foreground"
 			>
-				<Spinner /> Loading secure payment…
+				<Spinner data-icon="inline-start" /> Loading secure payment…
 			</div>
 		);
 	}
@@ -185,7 +200,14 @@ export function StripePaymentForm({
 	return (
 		<div data-hosted="true">
 			<Elements stripe={stripe} options={{ clientSecret, appearance: { theme: "stripe" } }}>
-				<InnerForm onComplete={onComplete} onCancel={onCancel} />
+				<InnerForm
+					onComplete={onComplete}
+					onCancel={onCancel}
+					returnUrl={returnUrl}
+					submitLabel={submitLabel}
+					summary={summary}
+					onSubmittingChange={onSubmittingChange}
+				/>
 			</Elements>
 		</div>
 	);

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.test.ts
@@ -5,6 +5,7 @@ import { billingKeys } from "@/hosted/billing/query-keys";
 import {
 	handleTopupStartResult,
 	topUpAmountCentsForCreditShortfall,
+	validTopUpAmountCents,
 } from "@/hosted/billing/wallet/top-up-dialog.logic";
 
 function result(overrides: Partial<WalletTopupResult>): WalletTopupResult {
@@ -56,7 +57,7 @@ describe("handleTopupStartResult", () => {
 		expect(resetAttempt).toHaveBeenCalledTimes(1);
 		expect(closeDialog).toHaveBeenCalledTimes(1);
 		expect(toastSuccess).toHaveBeenCalledWith("Top-up complete", {
-			description: "Your credits will appear in a moment.",
+			description: "Your AI Credits will appear in a moment.",
 		});
 		expect(toastError).not.toHaveBeenCalled();
 		expect(startPayment).not.toHaveBeenCalled();
@@ -112,5 +113,16 @@ describe("topUpAmountCentsForCreditShortfall", () => {
 		expect(topUpAmountCentsForCreditShortfall(null, 1_000)).toBeNull();
 		expect(topUpAmountCentsForCreditShortfall(14_000, 0)).toBeNull();
 		expect(topUpAmountCentsForCreditShortfall(Number.NaN, 1_000)).toBeNull();
+	});
+});
+
+describe("validTopUpAmountCents", () => {
+	test("enforces visible bounds and whole-dollar increments", () => {
+		expect(validTopUpAmountCents(1_000)).toBe(true);
+		expect(validTopUpAmountCents(200_000)).toBe(true);
+		expect(validTopUpAmountCents(999)).toBe(false);
+		expect(validTopUpAmountCents(1_001)).toBe(false);
+		expect(validTopUpAmountCents(1_000.1)).toBe(false);
+		expect(validTopUpAmountCents(Number.NaN)).toBe(false);
 	});
 });

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
@@ -24,6 +24,15 @@ export interface TopupStartResultControls extends TopupCompletionControls {
 	toastError: TopupToast;
 }
 
+export function validTopUpAmountCents(amountCents: number): boolean {
+	return (
+		Number.isFinite(amountCents) &&
+		amountCents >= TOPUP_MIN_CENTS &&
+		amountCents <= TOPUP_MAX_CENTS &&
+		amountCents % TOPUP_INCREMENT_CENTS === 0
+	);
+}
+
 /** Convert a credit shortfall into the smallest whole-dollar top-up that covers it. */
 export function topUpAmountCentsForCreditShortfall(
 	shortfallCredits: number | null,
@@ -57,7 +66,7 @@ export function completeTopup(
 	controls.onComplete?.(status);
 	if (status === "succeeded") {
 		controls.toastSuccess("Top-up complete", {
-			description: "Your credits will appear in a moment.",
+			description: "Your AI Credits will appear in a moment.",
 		});
 	} else {
 		controls.toastSuccess("Top-up processing", {

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
@@ -26,7 +26,11 @@ import {
 	type PaymentOutcome,
 	StripePaymentForm,
 } from "@/hosted/billing/wallet/stripe-payment-form";
-import { completeTopup, handleTopupStartResult } from "@/hosted/billing/wallet/top-up-dialog.logic";
+import {
+	completeTopup,
+	handleTopupStartResult,
+	validTopUpAmountCents,
+} from "@/hosted/billing/wallet/top-up-dialog.logic";
 import {
 	TOPUP_DEFAULT_CENTS,
 	TOPUP_INCREMENT_CENTS,
@@ -60,22 +64,22 @@ export function TopUpDialog({
 	const [step, setStep] = useState<Step>("amount");
 	const [dollars, setDollars] = useState(String(TOPUP_DEFAULT_CENTS / 100));
 	const [clientSecret, setClientSecret] = useState<string | null>(null);
+	const [amountTouched, setAmountTouched] = useState(false);
+	const [paymentSubmitting, setPaymentSubmitting] = useState(false);
 	// One idempotency key per top-up ATTEMPT, reused across a retry of the same
 	// amount so a timeout-resubmit / double-tab can't create two PaymentIntents.
 	// Reset whenever the amount changes (a genuinely new attempt) or the dialog
 	// closes.
 	const topupKeyRef = useRef<string | null>(null);
 
-	const amountCents = Math.round(Number(dollars) * 100);
-	const valid =
-		Number.isFinite(amountCents) &&
-		amountCents >= TOPUP_MIN_CENTS &&
-		amountCents <= TOPUP_MAX_CENTS;
-	const amountInvalid = !valid && Boolean(dollars);
+	const amountCents = Number(dollars) * 100;
+	const valid = validTopUpAmountCents(amountCents);
+	const amountInvalid = amountTouched && !valid;
 	const credits = valid ? formatCredits((amountCents / 100) * wallet.points_per_usd) : "";
 
 	function setAmount(next: string) {
 		setDollars(next);
+		setAmountTouched(false);
 		// New amount = new attempt; mint a fresh key on the next Continue.
 		topupKeyRef.current = null;
 	}
@@ -83,10 +87,13 @@ export function TopUpDialog({
 	function reset() {
 		setStep("amount");
 		setClientSecret(null);
+		setAmountTouched(false);
+		setPaymentSubmitting(false);
 		topupKeyRef.current = null;
 	}
 
 	function close(next: boolean) {
+		if (!next && (topUp.isPending || paymentSubmitting)) return;
 		onOpenChange(next);
 	}
 
@@ -100,6 +107,7 @@ export function TopUpDialog({
 		// Guard double-submit: the button disables on pending, but a fast
 		// double-click could slip a second request through before it repaints.
 		if (!valid || topUp.isPending) return;
+		setAmountTouched(true);
 		topupKeyRef.current ??= newIdempotencyKey("topup");
 		try {
 			const result = await topUp.mutateAsync({
@@ -111,7 +119,9 @@ export function TopUpDialog({
 				resetAttempt: () => {
 					topupKeyRef.current = null;
 				},
-				closeDialog: () => close(false),
+				// Successful completion is not a dismiss attempt. Close directly so the
+				// in-flight guard cannot leave a completed payment dialog stranded open.
+				closeDialog: () => onOpenChange(false),
 				toastSuccess: toast.success,
 				toastError: toast.error,
 				onComplete,
@@ -138,7 +148,7 @@ export function TopUpDialog({
 			resetAttempt: () => {
 				topupKeyRef.current = null;
 			},
-			closeDialog: () => close(false),
+			closeDialog: () => onOpenChange(false),
 			toastSuccess: toast.success,
 			onComplete,
 		});
@@ -146,13 +156,17 @@ export function TopUpDialog({
 
 	return (
 		<Dialog open={open} onOpenChange={close}>
-			<DialogContent className="sm:max-w-md" data-hosted="true">
+			<DialogContent
+				className="sm:max-w-md"
+				data-hosted="true"
+				showCloseButton={!topUp.isPending && !paymentSubmitting}
+			>
 				<DialogHeader>
 					<DialogTitle>Top up AI Credits</DialogTitle>
 					<DialogDescription>
 						{step === "amount"
 							? `Add between ${formatCents(TOPUP_MIN_CENTS)} and ${formatCents(TOPUP_MAX_CENTS)}. $1 = ${wallet.points_per_usd.toLocaleString()} credits.`
-							: "Enter your card details to complete the top-up."}
+							: `Enter your card details to pay ${formatCents(amountCents)}.`}
 					</DialogDescription>
 				</DialogHeader>
 
@@ -177,6 +191,7 @@ export function TopUpDialog({
 									type="button"
 									size="sm"
 									variant={amountCents === preset ? "default" : "outline"}
+									aria-pressed={amountCents === preset}
 									onClick={() => setAmount(String(preset / 100))}
 								>
 									{formatCents(preset)}
@@ -201,18 +216,24 @@ export function TopUpDialog({
 									className="pl-6"
 									value={dollars}
 									onChange={(e) => setAmount(e.target.value)}
+									onBlur={() => setAmountTouched(true)}
 									aria-invalid={amountInvalid}
-									aria-describedby={amountInvalid ? "topup-amount-err" : undefined}
+									aria-describedby="topup-amount-help"
 								/>
 							</div>
-							{amountInvalid ? (
-								<p id="topup-amount-err" className="text-xs text-destructive">
-									Enter an amount between {formatCents(TOPUP_MIN_CENTS)} and{" "}
-									{formatCents(TOPUP_MAX_CENTS)}.
-								</p>
-							) : credits ? (
-								<p className="text-xs text-muted-foreground">You’ll get {credits}.</p>
-							) : null}
+							<p
+								id="topup-amount-help"
+								className={
+									amountInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
+								}
+								aria-live="polite"
+							>
+								{amountInvalid
+									? `Enter a whole-dollar amount from ${formatCents(TOPUP_MIN_CENTS)} to ${formatCents(TOPUP_MAX_CENTS)}.`
+									: credits
+										? `You’ll get ${credits}. Whole-dollar amounts only.`
+										: `Enter a whole-dollar amount from ${formatCents(TOPUP_MIN_CENTS)} to ${formatCents(TOPUP_MAX_CENTS)}.`}
+							</p>
 						</div>
 						<div className="flex justify-end">
 							<Button onClick={() => runAction(onContinue)} disabled={!valid || topUp.isPending}>
@@ -221,7 +242,7 @@ export function TopUpDialog({
 										<Spinner /> Starting…
 									</>
 								) : (
-									"Continue"
+									`Continue with ${formatCents(amountCents)}`
 								)}
 							</Button>
 						</div>
@@ -231,6 +252,9 @@ export function TopUpDialog({
 						clientSecret={clientSecret}
 						onComplete={onPaid}
 						onCancel={() => setStep("amount")}
+						summary={`Top-up charge: ${formatCents(amountCents)}`}
+						submitLabel={`Pay ${formatCents(amountCents)}`}
+						onSubmittingChange={setPaymentSubmitting}
 					/>
 				) : null}
 			</DialogContent>

--- a/apps/web/src/hosted/billing/wallet/top-up-return.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-return.logic.test.ts
@@ -39,7 +39,7 @@ describe("walletTopupReturnToast", () => {
 		expect(walletTopupReturnToast("succeeded")).toEqual({
 			kind: "success",
 			title: "Top-up complete",
-			description: "Your credits will appear in a moment.",
+			description: "Your AI Credits will appear in a moment.",
 		});
 	});
 

--- a/apps/web/src/hosted/billing/wallet/top-up-return.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-return.logic.ts
@@ -46,7 +46,7 @@ export function walletTopupReturnToast(status: string | null | undefined): Walle
 		return {
 			kind: "success",
 			title: "Top-up complete",
-			description: "Your credits will appear in a moment.",
+			description: "Your AI Credits will appear in a moment.",
 		};
 	}
 	if (status === "processing") {

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { PageHeader } from "@/components/page-header";
@@ -33,7 +33,11 @@ const DESCRIPTION = "One balance for managed AI, wallet-funded compute, top-ups,
 const WALLET_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "space-y-6 px-4 lg:px-6");
 
 function scrollToAutoReload() {
-	document.getElementById("auto-reload")?.scrollIntoView({ behavior: "smooth", block: "center" });
+	const section = document.getElementById("auto-reload");
+	if (!section) return;
+	const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+	section.scrollIntoView({ behavior: reduceMotion ? "auto" : "smooth", block: "center" });
+	window.requestAnimationFrame(() => document.getElementById("auto-reload-enabled")?.focus());
 }
 
 function showWalletTopupReturnToast(result: WalletTopupReturnToast) {
@@ -55,6 +59,9 @@ export function WalletPage() {
 	const queryClient = useQueryClient();
 	const [ledgerLimit, setLedgerLimit] = useState(LEDGER_PAGE_SIZE);
 	const ledger = useWalletLedger(ledgerLimit);
+	const lastLedgerDataRef = useRef(ledger.data);
+	if (ledger.data) lastLedgerDataRef.current = ledger.data;
+	const ledgerData = ledger.data ?? lastLedgerDataRef.current;
 	const [topUpOpen, setTopUpOpen] = useState(false);
 
 	useEffect(() => {
@@ -169,7 +176,7 @@ export function WalletPage() {
 				{shouldShowX402Card(w) ? <X402Card /> : null}
 			</div>
 
-			{ledger.error && !ledger.data ? (
+			{ledger.error && !ledgerData ? (
 				<ApiErrorPanel
 					normalizer={billingErrorNormalizer}
 					error={ledger.error}
@@ -177,15 +184,29 @@ export function WalletPage() {
 					onRetry={() => ledger.refetch()}
 				/>
 			) : (
-				<LedgerTable
-					entries={ledger.data?.items ?? []}
-					pointsPerUsd={w.points_per_usd}
-					isLoading={ledger.isLoading}
-					hasMore={ledger.data?.has_more ?? false}
-					atCap={ledgerLimit >= LEDGER_MAX_ROWS && (ledger.data?.has_more ?? false)}
-					isFetchingMore={ledger.isFetching}
-					onShowMore={() => setLedgerLimit((n) => Math.min(n + LEDGER_PAGE_SIZE, LEDGER_MAX_ROWS))}
-				/>
+				<>
+					<LedgerTable
+						entries={ledgerData?.items ?? []}
+						pointsPerUsd={w.points_per_usd}
+						isLoading={ledger.isLoading}
+						hasMore={ledgerData?.has_more ?? false}
+						atCap={ledgerLimit >= LEDGER_MAX_ROWS && (ledgerData?.has_more ?? false)}
+						isFetchingMore={ledger.isFetching}
+						onShowMore={
+							ledger.error
+								? undefined
+								: () => setLedgerLimit((n) => Math.min(n + LEDGER_PAGE_SIZE, LEDGER_MAX_ROWS))
+						}
+					/>
+					{ledger.error ? (
+						<ApiErrorPanel
+							normalizer={billingErrorNormalizer}
+							error={ledger.error}
+							title="Couldn’t load more activity"
+							onRetry={() => void ledger.refetch()}
+						/>
+					) : null}
+				</>
 			)}
 
 			<TopUpDialog open={topUpOpen} onOpenChange={setTopUpOpen} wallet={w} />


### PR DESCRIPTION
## Summary

- Replace auto-reload's interaction-time persistence with one atomic explicit save for the toggle, threshold, amount, and monthly cap.
- Add dirty/pristine feedback, server-baseline reset, unsaved-change guards, blur/submit validation, in-flight locks, and actionable save errors.
- Harden top-up, Stripe PaymentIntent, Checkout Elements, subscription term, wallet plan, cancellation, and dunning interactions against duplicate submission and premature dismissal.
- Preserve loaded billing data through pagination failures, add retryable loading/error/empty states, and align currency, date, status, tier, and AI Credits vocabulary.
- Improve semantic links, pressed/checked state, focus handling, reduced motion, labels, and error descriptions across the billing surface.

Plan-change flow was not redesigned. This PR only fixes concrete defects in that area because the upcoming backend/flow work will replace its architecture.

## Review findings fixed

| Area | Finding | Resolution |
| --- | --- | --- |
| Auto-reload commit semantics | Toggle and parameters could persist on individual interactions, mixing immediate and explicit-save behavior. | All four values now live in one draft and are committed atomically by one `Save changes` request. |
| Auto-reload form state | No complete pristine/dirty, reset, per-field server error, or save-in-flight model. | Added semantic dirty tracking, disabled pristine/invalid save, server-baseline cancel, blur/submit validation, save lock, field focus, and payment-method recovery CTA. |
| Unsaved changes | Closing Settings, switching sections, following internal links, or unloading could drop a dirty draft. | Added discard confirmation, section/navigation interception, `beforeunload`, and save-in-flight dismissal blocking. |
| Money-moving actions | Several actions relied only on the next React render to disable controls, and payment dialogs could close during submission. | Added synchronous locks, disabled in-flight controls, hidden close controls, idempotency-key rotation on explicit reuse conflicts, and direct completion close paths. |
| Payment confirmation | Payment CTAs lacked concrete amounts; non-settling PaymentIntent states and stale return markers could be treated too loosely. | Added amount/date summaries, flow-specific return URLs, stale marker cleanup, and a strict succeeded/processing/requires-capture outcome allowlist. |
| Top-up validation | Amount errors appeared too early, whole-dollar constraints were unclear, and extra precision could be rounded silently. | Validate on blur/submit, show visible bounds, reject fractional/over-precision amounts before rounding, and name the concrete charge in the CTA. |
| Async state coverage | Welcome credits could disappear while loading; billing history and ledger pagination failures replaced or stranded loaded content. | Added skeleton/loading states and local retry panels that preserve already loaded rows and suppress duplicate load-more controls. |
| Agent billing actions | Term confirmation could return to the wrong surface or claim success without refreshed state; cancellation errors closed confirmation. | Preserve quoted amount/effective date, return to agent detail, require successful refresh for success copy, and keep failed cancellation confirmations retryable. |
| Consistency and copy | Raw status/operation/error tokens, backend messages, inconsistent currency precision, dates, invoice labels, and “credits” naming leaked across surfaces. | Added safe vocabulary fallbacks, shared formatters, consistent AI Credits/tier/status copy, verb-first labels, and hidden internal codes. |
| Accessibility | Some selection controls lacked pressed state, navigation was implemented as buttons, and auto-reload focus/validation relationships were incomplete. | Added semantic link rendering, `aria-pressed`/checked semantics, labels and `aria-describedby`, error announcements, reduced-motion scroll, and focused recovery. |

## Product proposals not implemented

- Add quote-backed confirmation for dunning **Retry payment** / **Reactivate** so the exact Wallet debit and date are shown before money moves.
- Add a concrete renewal confirmation before **Resume subscription** restores future paid renewals.
- Expand paid deployment **Delete** confirmation to state subscription cancellation and refund consequences.
- Add a route-level unsaved-draft guard to the deploy wizard's multi-field configuration.
- Split billing access from `canCreateCloudAgents` into a dedicated billing capability.
- Resolve stale plan quotes and sibling recovery dialogs as part of the upcoming plan-change architecture work, especially the refund-debt path.

## Screenshot evidence

Generated by the hosted mocked E2E and intentionally not committed as binary artifacts:

- Dirty draft: `/tmp/auto-reload-dirty.png`
- Actionable save error: `/tmp/auto-reload-error.png`
- Saved/pristine state: `/tmp/auto-reload-saved.png`

## Verification

- `VITE_CLERK_PUBLISHABLE_KEY=pk_test_dummy bun test apps/web/src/hosted/billing` — 170 passed
- `bun run --cwd apps/web test src/hosted/oss-clean.test.ts` — 14 passed
- `bun run --cwd apps/web typecheck` — passed
- `bunx biome check apps/web/src apps/web/e2e/hosted-smoke.pw.ts` — passed
- `bun run --cwd apps/web build:oss` — passed
- `bun run --cwd apps/web e2e:hosted` — 37 passed

## Rollout

- Frontend-only; no schema or hosted infrastructure changes.
- No production operations were performed.
- Do not merge as part of this task; owner review is required.
