### PR TITLE
fix(ai): accept clawdi-v2 managed provider id

### DIFF
--- a/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
@@ -24,9 +24,9 @@ describe("buildHostedDeployRequest", () => {
 			timezone: null,
 			ai_provider_id: null,
 			ai_provider_auth_kind: "managed",
-			provider_ids: ["clawdi-managed-v2"],
+			provider_ids: ["clawdi-v2"],
 			primary_model: {
-				provider_id: "clawdi-managed-v2",
+				provider_id: "clawdi-v2",
 				model: "gpt-5.5",
 			},
 			config: {

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -84,8 +84,8 @@ from app.services.channels import (
 )
 from app.services.managed_ai_provider import (
     MANAGED_AI_PROVIDER_API_MODE,
-    MANAGED_AI_PROVIDER_ID,
     MANAGED_AI_PROVIDER_RUNTIME_ENV,
+    V2_MANAGED_AI_PROVIDER_IDS,
     upsert_clawdi_managed_provider,
 )
 from app.services.sync_events import (
@@ -327,10 +327,11 @@ async def admin_revoke_api_key(
 
 
 @router.put(
-    f"/ai-providers/{MANAGED_AI_PROVIDER_ID}",
+    "/ai-providers/{provider_id}",
     response_model=AdminManagedAiProviderResponse,
 )
 async def admin_upsert_clawdi_managed_ai_provider(
+    provider_id: str,
     body: AdminManagedAiProviderUpsert,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
@@ -341,11 +342,14 @@ async def admin_upsert_clawdi_managed_ai_provider(
     Hosted deploy orchestration only needs to install the fixed
     Clawdi-managed OpenAI-compatible chat provider and rotate its key.
     """
+    if provider_id not in V2_MANAGED_AI_PROVIDER_IDS:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "managed AI provider not found")
     target = await _resolve_or_create_user(db, body.target_clerk_id)
     try:
         provider = await upsert_clawdi_managed_provider(
             db,
             user=target,
+            provider_id=provider_id,
             base_url=body.base_url,
             api_key=body.api_key.get_secret_value(),
             default_model=body.default_model,
@@ -371,11 +375,11 @@ async def admin_upsert_clawdi_managed_ai_provider(
         actor_type="admin",
         action="ai_provider.managed.upsert",
         resource_type="ai_provider",
-        resource_id=MANAGED_AI_PROVIDER_ID,
+        resource_id=provider.provider_id,
         target_user_id=target.id,
         source="api.admin",
         details={
-            "provider_id": MANAGED_AI_PROVIDER_ID,
+            "provider_id": provider.provider_id,
             "api_mode": MANAGED_AI_PROVIDER_API_MODE,
             "runtime_env_name": MANAGED_AI_PROVIDER_RUNTIME_ENV,
             "models": provider.models,

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -342,6 +342,8 @@ async def admin_upsert_clawdi_managed_ai_provider(
     Hosted deploy orchestration only needs to install the fixed
     Clawdi-managed OpenAI-compatible chat provider and rotate its key.
     """
+    # TODO(#425): Remove legacy v2 route acceptance after hosted#892 is deployed
+    # everywhere and no dev/self-hosted binding still uses clawdi-managed-v2.
     if provider_id not in V2_MANAGED_AI_PROVIDER_IDS:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "managed AI provider not found")
     target = await _resolve_or_create_user(db, body.target_clerk_id)

--- a/backend/app/services/managed_ai_provider.py
+++ b/backend/app/services/managed_ai_provider.py
@@ -12,14 +12,18 @@ from app.services.vault_crypto import encrypt
 
 V1_MANAGED_AI_PROVIDER_ID = "clawdi-managed"
 V1_MANAGED_AI_PROVIDER_API_MODE = "openai_responses"
-V2_MANAGED_AI_PROVIDER_ID = "clawdi-managed-v2"
+V2_MANAGED_AI_PROVIDER_ID = "clawdi-v2"
+V2_LEGACY_MANAGED_AI_PROVIDER_ID = "clawdi-managed-v2"
+V2_MANAGED_AI_PROVIDER_IDS = frozenset(
+    {V2_MANAGED_AI_PROVIDER_ID, V2_LEGACY_MANAGED_AI_PROVIDER_ID}
+)
 V2_MANAGED_AI_PROVIDER_API_MODE = "openai_chat"
 
 # The admin managed-provider path is owned by hosted v2. V1 writes its provider
 # through the user AI Provider endpoint with the v1-specific id/mode above.
 MANAGED_AI_PROVIDER_ID = V2_MANAGED_AI_PROVIDER_ID
 MANAGED_AI_PROVIDER_API_MODE = V2_MANAGED_AI_PROVIDER_API_MODE
-MANAGED_AI_PROVIDER_IDS = frozenset({V1_MANAGED_AI_PROVIDER_ID, V2_MANAGED_AI_PROVIDER_ID})
+MANAGED_AI_PROVIDER_IDS = frozenset({V1_MANAGED_AI_PROVIDER_ID, *V2_MANAGED_AI_PROVIDER_IDS})
 MANAGED_AI_PROVIDER_RUNTIME_ENV = "CLAWDI_MANAGED_OPENAI_API_KEY"
 MANAGED_AI_PROVIDER_TYPE = "custom_openai_compatible"
 MANAGED_AI_PROVIDER_LABEL = "Clawdi managed"
@@ -29,7 +33,7 @@ MANAGED_AI_PROVIDER_PROFILE = "default"
 def managed_provider_api_mode(provider_id: str) -> str | None:
     if provider_id == V1_MANAGED_AI_PROVIDER_ID:
         return V1_MANAGED_AI_PROVIDER_API_MODE
-    if provider_id == V2_MANAGED_AI_PROVIDER_ID:
+    if provider_id in V2_MANAGED_AI_PROVIDER_IDS:
         return V2_MANAGED_AI_PROVIDER_API_MODE
     return None
 
@@ -44,6 +48,7 @@ async def upsert_clawdi_managed_provider(
     db: AsyncSession,
     *,
     user: User,
+    provider_id: str = MANAGED_AI_PROVIDER_ID,
     base_url: str,
     api_key: str,
     default_model: str | None = None,
@@ -51,7 +56,9 @@ async def upsert_clawdi_managed_provider(
     label: str | None = None,
     capabilities: dict | None = None,
 ) -> AiProvider:
-    """Upsert the single first-party managed AI provider contract for a user."""
+    """Upsert a first-party v2 managed AI provider contract for a user."""
+    if provider_id not in V2_MANAGED_AI_PROVIDER_IDS:
+        raise ValueError("unsupported managed provider id")
     validate_managed_provider_base_url(base_url)
     normalized_base_url = base_url.strip()
     if not api_key:
@@ -60,13 +67,13 @@ async def upsert_clawdi_managed_provider(
         await db.execute(
             select(AiProvider).where(
                 AiProvider.owner_user_id == user.id,
-                AiProvider.provider_id == MANAGED_AI_PROVIDER_ID,
+                AiProvider.provider_id == provider_id,
             )
         )
     ).scalar_one_or_none()
     provider = existing or AiProvider(
         owner_user_id=user.id,
-        provider_id=MANAGED_AI_PROVIDER_ID,
+        provider_id=provider_id,
     )
     provider.type = MANAGED_AI_PROVIDER_TYPE
     provider.label = label or MANAGED_AI_PROVIDER_LABEL
@@ -90,7 +97,7 @@ async def upsert_clawdi_managed_provider(
         await db.execute(
             select(AiProviderAuthPayload).where(
                 AiProviderAuthPayload.owner_user_id == user.id,
-                AiProviderAuthPayload.provider_id == MANAGED_AI_PROVIDER_ID,
+                AiProviderAuthPayload.provider_id == provider_id,
                 AiProviderAuthPayload.auth_profile == MANAGED_AI_PROVIDER_PROFILE,
             )
         )
@@ -98,7 +105,7 @@ async def upsert_clawdi_managed_provider(
     if payload is None:
         payload = AiProviderAuthPayload(
             owner_user_id=user.id,
-            provider_id=MANAGED_AI_PROVIDER_ID,
+            provider_id=provider_id,
             auth_profile=MANAGED_AI_PROVIDER_PROFILE,
             kind="api_key",
             source="managed",
@@ -119,7 +126,7 @@ async def upsert_clawdi_managed_provider(
         update(AiProviderAuthPayload)
         .where(
             AiProviderAuthPayload.owner_user_id == user.id,
-            AiProviderAuthPayload.provider_id == MANAGED_AI_PROVIDER_ID,
+            AiProviderAuthPayload.provider_id == provider_id,
             AiProviderAuthPayload.auth_profile != MANAGED_AI_PROVIDER_PROFILE,
             AiProviderAuthPayload.archived_at.is_(None),
         )

--- a/backend/app/services/managed_ai_provider.py
+++ b/backend/app/services/managed_ai_provider.py
@@ -13,6 +13,8 @@ from app.services.vault_crypto import encrypt
 V1_MANAGED_AI_PROVIDER_ID = "clawdi-managed"
 V1_MANAGED_AI_PROVIDER_API_MODE = "openai_responses"
 V2_MANAGED_AI_PROVIDER_ID = "clawdi-v2"
+# TODO(#425): Remove this legacy alias and transition accept-set after hosted#892
+# is deployed everywhere and no dev/self-hosted binding still uses clawdi-managed-v2.
 V2_LEGACY_MANAGED_AI_PROVIDER_ID = "clawdi-managed-v2"
 V2_MANAGED_AI_PROVIDER_IDS = frozenset(
     {V2_MANAGED_AI_PROVIDER_ID, V2_LEGACY_MANAGED_AI_PROVIDER_ID}
@@ -23,6 +25,8 @@ V2_MANAGED_AI_PROVIDER_API_MODE = "openai_chat"
 # through the user AI Provider endpoint with the v1-specific id/mode above.
 MANAGED_AI_PROVIDER_ID = V2_MANAGED_AI_PROVIDER_ID
 MANAGED_AI_PROVIDER_API_MODE = V2_MANAGED_AI_PROVIDER_API_MODE
+# TODO(#425): Remove the legacy v2 member from this aggregate after hosted#892
+# is deployed everywhere and no dev/self-hosted binding still uses clawdi-managed-v2.
 MANAGED_AI_PROVIDER_IDS = frozenset({V1_MANAGED_AI_PROVIDER_ID, *V2_MANAGED_AI_PROVIDER_IDS})
 MANAGED_AI_PROVIDER_RUNTIME_ENV = "CLAWDI_MANAGED_OPENAI_API_KEY"
 MANAGED_AI_PROVIDER_TYPE = "custom_openai_compatible"
@@ -33,6 +37,8 @@ MANAGED_AI_PROVIDER_PROFILE = "default"
 def managed_provider_api_mode(provider_id: str) -> str | None:
     if provider_id == V1_MANAGED_AI_PROVIDER_ID:
         return V1_MANAGED_AI_PROVIDER_API_MODE
+    # TODO(#425): Remove legacy v2 mode resolution after hosted#892 is deployed
+    # everywhere and no dev/self-hosted binding still uses clawdi-managed-v2.
     if provider_id in V2_MANAGED_AI_PROVIDER_IDS:
         return V2_MANAGED_AI_PROVIDER_API_MODE
     return None
@@ -57,6 +63,8 @@ async def upsert_clawdi_managed_provider(
     capabilities: dict | None = None,
 ) -> AiProvider:
     """Upsert a first-party v2 managed AI provider contract for a user."""
+    # TODO(#425): Remove legacy v2 upsert acceptance after hosted#892 is deployed
+    # everywhere and no dev/self-hosted binding still uses clawdi-managed-v2.
     if provider_id not in V2_MANAGED_AI_PROVIDER_IDS:
         raise ValueError("unsupported managed provider id")
     validate_managed_provider_base_url(base_url)

--- a/backend/scripts/mock_deploy_api.py
+++ b/backend/scripts/mock_deploy_api.py
@@ -23,7 +23,7 @@ from fastapi.middleware.cors import CORSMiddleware
 DEV_V2_DEPLOYMENT_ID = "hdep_dev_sidebar"
 DEV_V2_APP_ID = "app_dev_sidebar"
 DEV_V2_PROVIDER_ID = "openrouter-dev"
-DEV_V2_MANAGED_PROVIDER_ID = "clawdi-managed-v2"
+DEV_V2_MANAGED_PROVIDER_ID = "clawdi-v2"
 STABLE_UUID_NAMESPACE = uuid.UUID("6a9575fd-7eb5-464a-89e7-e13f090f8de6")
 
 

--- a/backend/scripts/seed_dashboard_dev.py
+++ b/backend/scripts/seed_dashboard_dev.py
@@ -72,7 +72,7 @@ DEV_V2_APP_ID = "app_dev_sidebar"
 DEV_V2_HOSTED_MACHINE_ID = "dev-hosted-sidebar"
 DEV_V2_HOSTED_MACHINE_NAME = "Dev Hosted Compute"
 DEV_V2_PROVIDER_ID = "openrouter-dev"
-DEV_V2_CODEX_PROVIDER_ID = "clawdi-managed-v2"
+DEV_V2_CODEX_PROVIDER_ID = "clawdi-v2"
 DEV_V2_CLI_PACKAGE_SPEC = "clawdi@0.12.10-beta.53"
 _STABLE_UUID_NAMESPACE = uuid.UUID("6a9575fd-7eb5-464a-89e7-e13f090f8de6")
 

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -15,6 +15,10 @@ from httpx import ASGITransport
 from app.core.config import settings
 from app.core.database import get_session
 from app.main import app
+from app.services.managed_ai_provider import (
+    V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+    V2_MANAGED_AI_PROVIDER_ID,
+)
 
 _ADMIN_KEY = "test-admin-secret-do-not-use-in-prod"
 # Shared header dict for the bulk of tests that exercise the happy-path
@@ -681,15 +685,18 @@ async def test_admin_revoke_unknown_key(admin_client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "route_provider_id",
+    [V2_MANAGED_AI_PROVIDER_ID, V2_LEGACY_MANAGED_AI_PROVIDER_ID],
+)
 async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
-    admin_client, db_session, seed_user
+    admin_client, db_session, seed_user, route_provider_id: str
 ):
     from sqlalchemy import select
 
     from app.models.ai_provider import AiProvider, AiProviderAuthPayload
     from app.services.managed_ai_provider import (
         MANAGED_AI_PROVIDER_API_MODE,
-        MANAGED_AI_PROVIDER_ID,
         MANAGED_AI_PROVIDER_RUNTIME_ENV,
     )
     from app.services.vault_crypto import decrypt
@@ -707,7 +714,7 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
         }
     ]
     r = await admin_client.put(
-        "/v1/admin/ai-providers/clawdi-managed-v2",
+        f"/v1/admin/ai-providers/{route_provider_id}",
         headers=_AUTH,
         json={
             "target_clerk_id": seed_user.clerk_id,
@@ -722,7 +729,7 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
     assert r.json() == {
         "owner_user_id": str(seed_user.id),
         "owner_clerk_id": seed_user.clerk_id,
-        "provider_id": MANAGED_AI_PROVIDER_ID,
+        "provider_id": route_provider_id,
         "api_mode": MANAGED_AI_PROVIDER_API_MODE,
         "runtime_env_name": MANAGED_AI_PROVIDER_RUNTIME_ENV,
         "base_url": "https://ai-gateway.clawdi.ai/v1",
@@ -734,7 +741,7 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
         await db_session.execute(
             select(AiProvider).where(
                 AiProvider.owner_user_id == seed_user.id,
-                AiProvider.provider_id == MANAGED_AI_PROVIDER_ID,
+                AiProvider.provider_id == route_provider_id,
             )
         )
     ).scalar_one()
@@ -752,7 +759,7 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
         await db_session.execute(
             select(AiProviderAuthPayload).where(
                 AiProviderAuthPayload.owner_user_id == seed_user.id,
-                AiProviderAuthPayload.provider_id == MANAGED_AI_PROVIDER_ID,
+                AiProviderAuthPayload.provider_id == route_provider_id,
                 AiProviderAuthPayload.auth_profile == "default",
             )
         )
@@ -761,6 +768,21 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
     assert payload.source == "managed"
     assert payload.payload_metadata == {"runtime_env_name": MANAGED_AI_PROVIDER_RUNTIME_ENV}
     assert decrypt(payload.encrypted_payload, payload.nonce) == raw_key
+
+
+@pytest.mark.asyncio
+async def test_admin_upsert_managed_ai_provider_rejects_unknown_id(admin_client, seed_user):
+    response = await admin_client.put(
+        "/v1/admin/ai-providers/not-clawdi-managed",
+        headers=_AUTH,
+        json={
+            "target_clerk_id": seed_user.clerk_id,
+            "base_url": "https://ai-gateway.clawdi.ai/v1",
+            "api_key": "sk-unsupported-provider",
+        },
+    )
+
+    assert response.status_code == 404, response.text
 
 
 @pytest.mark.asyncio
@@ -799,7 +821,7 @@ async def test_admin_managed_ai_provider_rejects_models_outside_hosted_wire_cont
     model: dict,
 ):
     response = await admin_client.put(
-        "/v1/admin/ai-providers/clawdi-managed-v2",
+        f"/v1/admin/ai-providers/{V2_MANAGED_AI_PROVIDER_ID}",
         headers=_AUTH,
         json={
             "target_clerk_id": seed_user.clerk_id,
@@ -823,7 +845,7 @@ async def test_admin_upsert_managed_ai_provider_rotates_existing_payload(
     from app.services.vault_crypto import decrypt
 
     first = await admin_client.put(
-        "/v1/admin/ai-providers/clawdi-managed-v2",
+        f"/v1/admin/ai-providers/{MANAGED_AI_PROVIDER_ID}",
         headers=_AUTH,
         json={
             "target_clerk_id": seed_user.clerk_id,
@@ -834,7 +856,7 @@ async def test_admin_upsert_managed_ai_provider_rotates_existing_payload(
     assert first.status_code == 200, first.text
     second_key = "sk-second-admin-managed-secret"
     second = await admin_client.put(
-        "/v1/admin/ai-providers/clawdi-managed-v2",
+        f"/v1/admin/ai-providers/{MANAGED_AI_PROVIDER_ID}",
         headers=_AUTH,
         json={
             "target_clerk_id": seed_user.clerk_id,
@@ -881,7 +903,7 @@ async def test_admin_upsert_managed_ai_provider_rotates_existing_payload(
 async def test_admin_upsert_managed_ai_provider_rejects_invalid_base_url(admin_client, seed_user):
     raw_key = "sk-invalid-url-secret"
     r = await admin_client.put(
-        "/v1/admin/ai-providers/clawdi-managed-v2",
+        f"/v1/admin/ai-providers/{V2_MANAGED_AI_PROVIDER_ID}",
         headers=_AUTH,
         json={
             "target_clerk_id": seed_user.clerk_id,

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -13,6 +13,13 @@ from app.models.ai_provider import AiProvider
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeState
 from app.services import sync_events
+from app.services.managed_ai_provider import (
+    MANAGED_AI_PROVIDER_IDS,
+    V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+    V2_MANAGED_AI_PROVIDER_API_MODE,
+    V2_MANAGED_AI_PROVIDER_ID,
+    managed_provider_api_mode,
+)
 from tests.conftest import create_env_with_project
 
 _TEST_SYSTEM = {
@@ -21,6 +28,16 @@ _TEST_SYSTEM = {
     "workspace": "/home/clawdi/clawdi",
     "persistentPaths": ["/home/clawdi"],
 }
+
+
+@pytest.mark.parametrize(
+    "provider_id",
+    [V2_MANAGED_AI_PROVIDER_ID, V2_LEGACY_MANAGED_AI_PROVIDER_ID],
+)
+def test_v2_managed_ai_provider_ids_resolve_to_chat_mode(provider_id: str):
+    assert provider_id in MANAGED_AI_PROVIDER_IDS
+    assert managed_provider_api_mode(provider_id) == V2_MANAGED_AI_PROVIDER_API_MODE
+
 
 _VALID_AUTH_VARIANTS = [
     pytest.param(
@@ -633,23 +650,27 @@ async def test_ai_provider_rejects_invalid_auth_and_api_mode(client: httpx.Async
     assert legacy_model_prefix.status_code == 422, legacy_model_prefix.text
     assert "legacy openai-codex prefix" in legacy_model_prefix.text
 
-    managed = await client.post(
-        "/v1/ai-providers",
-        json={
-            "provider_id": "clawdi-managed-v2",
-            "type": "custom_openai_compatible",
-            "base_url": "https://managed.example/v1",
-            "models": [{"id": "gpt-5.5"}],
-            "api_mode": "openai_chat",
-            "auth": {"type": "api_key", "source": "managed"},
-            "managed_by": "clawdi",
-            "runtime_env_name": "CLAWDI_MANAGED_OPENAI_API_KEY",
-        },
-    )
-    assert managed.status_code == 200, managed.text
-    assert managed.json()["provider_id"] == "clawdi-managed-v2"
-    assert managed.json()["api_mode"] == "openai_chat"
-    assert managed.json()["models"] == [{"id": "gpt-5.5"}]
+    for managed_provider_id in (
+        V2_MANAGED_AI_PROVIDER_ID,
+        V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+    ):
+        managed = await client.post(
+            "/v1/ai-providers",
+            json={
+                "provider_id": managed_provider_id,
+                "type": "custom_openai_compatible",
+                "base_url": "https://managed.example/v1",
+                "models": [{"id": "gpt-5.5"}],
+                "api_mode": "openai_chat",
+                "auth": {"type": "api_key", "source": "managed"},
+                "managed_by": "clawdi",
+                "runtime_env_name": "CLAWDI_MANAGED_OPENAI_API_KEY",
+            },
+        )
+        assert managed.status_code == 200, managed.text
+        assert managed.json()["provider_id"] == managed_provider_id
+        assert managed.json()["api_mode"] == "openai_chat"
+        assert managed.json()["models"] == [{"id": "gpt-5.5"}]
 
     v1_managed = await client.post(
         "/v1/ai-providers",

--- a/docs/v2-ui-ux-final-sweep.md
+++ b/docs/v2-ui-ux-final-sweep.md
@@ -118,7 +118,7 @@ on core flows.
 ### F2 — Managed rebind (#696) can leave stale "Bound" BYOK providers in the AI tab — fast-follow (verify)
 
 `hosted-agent-detail.tsx:1226-1285` builds the rebind body correctly (managed-only →
-`provider_ids: ["clawdi-v2"]`, `auth_kind: "managed"`, no bootstrap), but
+`provider_ids: ["clawdi-managed-v2"]`, `auth_kind: "managed"`, no bootstrap), but
 `useSetAgentAiProvider` (`deployment-hooks.ts:124-143`) only calls
 `invalidateDeploymentSnapshots` once on success — unlike `useDeploymentLifecycle`
 and `useSetAgentLanguageTimezone`, it does **not** schedule a settling refresh.

--- a/docs/v2-ui-ux-final-sweep.md
+++ b/docs/v2-ui-ux-final-sweep.md
@@ -118,7 +118,7 @@ on core flows.
 ### F2 — Managed rebind (#696) can leave stale "Bound" BYOK providers in the AI tab — fast-follow (verify)
 
 `hosted-agent-detail.tsx:1226-1285` builds the rebind body correctly (managed-only →
-`provider_ids: ["clawdi-managed-v2"]`, `auth_kind: "managed"`, no bootstrap), but
+`provider_ids: ["clawdi-v2"]`, `auth_kind: "managed"`, no bootstrap), but
 `useSetAgentAiProvider` (`deployment-hooks.ts:124-143`) only calls
 `invalidateDeploymentSnapshots` once on success — unlike `useDeploymentLifecycle`
 and `useSetAgentLanguageTimezone`, it does **not** schedule a settling refresh.

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -1985,6 +1985,8 @@ function agentTargetProjectionInput(
 	const providerIdMap = new Map<string, string>();
 	const providers = input.catalog.providers.map((provider) => {
 		if (provider.managed_by !== "clawdi") return provider;
+		// TODO(#425): Remove legacy projection handling after hosted#892 is deployed
+		// everywhere and no dev/self-hosted binding still uses clawdi-managed-v2.
 		const id =
 			CLAWDI_MANAGED_PROVIDER_IDS.has(provider.id) || provider.id.startsWith("clawdi-managed")
 				? provider.id

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -29,7 +29,14 @@ import type {
 	AiProviderModel,
 	AiProviderType,
 } from "@clawdi/shared";
-import { isAiProviderApiMode, isAiProviderType } from "@clawdi/shared";
+import {
+	CLAWDI_MANAGED_PROVIDER_IDS,
+	CLAWDI_MANAGED_V1_PROVIDER_ID,
+	CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
+	CLAWDI_MANAGED_V2_PROVIDER_ID,
+	isAiProviderApiMode,
+	isAiProviderType,
+} from "@clawdi/shared";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { z } from "zod";
 import {
@@ -1978,12 +1985,18 @@ function agentTargetProjectionInput(
 	const providerIdMap = new Map<string, string>();
 	const providers = input.catalog.providers.map((provider) => {
 		if (provider.managed_by !== "clawdi") return provider;
-		const id = provider.id.startsWith("clawdi-managed") ? provider.id : "clawdi-managed";
+		const id =
+			CLAWDI_MANAGED_PROVIDER_IDS.has(provider.id) || provider.id.startsWith("clawdi-managed")
+				? provider.id
+				: CLAWDI_MANAGED_V1_PROVIDER_ID;
 		providerIdMap.set(provider.id, id);
 		return {
 			...provider,
 			id,
-			api_mode: id === "clawdi-managed-v2" ? "openai_chat" : "openai_responses",
+			api_mode:
+				id === CLAWDI_MANAGED_V2_PROVIDER_ID || id === CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID
+					? "openai_chat"
+					: "openai_responses",
 		} satisfies AiProviderCatalog["providers"][number];
 	});
 	const primaryProviderId = providerIdMap.get(input.primaryModel.provider_id);

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -2838,9 +2838,9 @@ chmod +x "$HOME/.local/bin/hermes"
 							home,
 							args: ["--json", "--no-onboard"],
 						},
-						provider_ids: ["clawdi-managed-v2"],
+						provider_ids: ["clawdi-v2"],
 						primary_model: {
-							provider_id: "clawdi-managed-v2",
+							provider_id: "clawdi-v2",
 							model: "gpt-5.5",
 						},
 					},
@@ -2849,7 +2849,7 @@ chmod +x "$HOME/.local/bin/hermes"
 					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
 					system: { home },
 					providers: {
-						"clawdi-managed-v2": {
+						"clawdi-v2": {
 							kind: "openai-compatible",
 							baseUrl: "https://ai-gateway.example.test/v1",
 							model: "gpt-5.5",
@@ -2880,10 +2880,8 @@ chmod +x "$HOME/.local/bin/hermes"
 
 		expect(convergence.installErrors).toEqual([]);
 		const patch = JSON.parse(readFileSync(openclawPatch, "utf-8"));
-		expect(patch.agents.defaults.model.primary).toBe("clawdi-managed-v2/gpt-5.5");
-		expect(patch.models.providers["clawdi-managed-v2"].baseUrl).toBe(
-			"https://ai-gateway.example.test/v1",
-		);
+		expect(patch.agents.defaults.model.primary).toBe("clawdi-v2/gpt-5.5");
+		expect(patch.models.providers["clawdi-v2"].baseUrl).toBe("https://ai-gateway.example.test/v1");
 	});
 
 	it("reconciles hosted provider projections when the selected provider changes", () => {

--- a/packages/shared/src/ai-provider.test.ts
+++ b/packages/shared/src/ai-provider.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
 	type AiProviderAuth,
+	CLAWDI_MANAGED_PROVIDER_IDS,
 	CLAWDI_MANAGED_V1_PROVIDER_ID,
+	CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
 	CLAWDI_MANAGED_V2_PROVIDER_ID,
 	CODEX_OAUTH_MODEL_CATALOG,
 	defaultAiProviderModels,
@@ -275,12 +277,15 @@ describe("validateAiProviderCatalog", () => {
 		);
 	});
 
-	test("accepts v2 Clawdi-managed providers in OpenAI chat mode", () => {
+	test.each([
+		CLAWDI_MANAGED_V2_PROVIDER_ID,
+		CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
+	])("accepts v2 Clawdi-managed provider %s in OpenAI chat mode", (providerId) => {
 		const result = validateAiProviderCatalog({
 			schema_version: 1,
 			providers: [
 				{
-					id: "clawdi-managed-v2",
+					id: providerId,
 					type: "custom_openai_compatible",
 					base_url: "https://managed.example/v1",
 					models: [{ id: "gpt-5.5" }],
@@ -290,7 +295,7 @@ describe("validateAiProviderCatalog", () => {
 					runtime_env_name: "OPENAI_API_KEY",
 				},
 			],
-			defaults: { chat_provider_id: "clawdi-managed-v2" },
+			defaults: { chat_provider_id: providerId },
 		});
 
 		expect(result.valid).toBe(true);
@@ -345,13 +350,20 @@ describe("validateAiProviderCatalog", () => {
 });
 
 describe("isFirstPartyManagedAiProvider", () => {
-	test("matches first-party managed ids even when old rows are missing managed_by", () => {
+	test("matches every first-party managed id even when old rows are missing managed_by", () => {
 		expect(isFirstPartyManagedAiProvider({ provider_id: CLAWDI_MANAGED_V1_PROVIDER_ID })).toBe(
 			true,
 		);
 		expect(isFirstPartyManagedAiProvider({ provider_id: CLAWDI_MANAGED_V2_PROVIDER_ID })).toBe(
 			true,
 		);
+		expect(
+			isFirstPartyManagedAiProvider({
+				provider_id: CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
+			}),
+		).toBe(true);
+		expect(CLAWDI_MANAGED_PROVIDER_IDS.has(CLAWDI_MANAGED_V2_PROVIDER_ID)).toBe(true);
+		expect(CLAWDI_MANAGED_PROVIDER_IDS.has(CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID)).toBe(true);
 	});
 
 	test("matches managed_by clawdi for current rows", () => {

--- a/packages/shared/src/ai-provider.ts
+++ b/packages/shared/src/ai-provider.ts
@@ -167,8 +167,12 @@ export const CODEX_OAUTH_MODEL_CATALOG: readonly AiProviderModel[] = [
 export const CLAWDI_MANAGED_V1_PROVIDER_ID = "clawdi-managed";
 const CLAWDI_MANAGED_V1_API_MODE = "openai_responses";
 export const CLAWDI_MANAGED_V2_PROVIDER_ID = "clawdi-v2";
+// TODO(#425): Remove this legacy alias after hosted#892 is deployed everywhere and no
+// dev/self-hosted binding still uses clawdi-managed-v2.
 export const CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID = "clawdi-managed-v2";
 const CLAWDI_MANAGED_V2_API_MODE = "openai_chat";
+// TODO(#425): Remove the legacy member after hosted#892 is deployed everywhere and no
+// dev/self-hosted binding still uses clawdi-managed-v2.
 export const CLAWDI_MANAGED_PROVIDER_IDS: ReadonlySet<string> = new Set([
 	CLAWDI_MANAGED_V1_PROVIDER_ID,
 	CLAWDI_MANAGED_V2_PROVIDER_ID,
@@ -371,6 +375,8 @@ function validateManagedProviderContract(
 
 function clawdiManagedApiMode(providerId: string): AiProviderApiMode | null {
 	if (providerId === CLAWDI_MANAGED_V1_PROVIDER_ID) return CLAWDI_MANAGED_V1_API_MODE;
+	// TODO(#425): Remove legacy mode resolution after hosted#892 is deployed everywhere
+	// and no dev/self-hosted binding still uses clawdi-managed-v2.
 	if (
 		providerId === CLAWDI_MANAGED_V2_PROVIDER_ID ||
 		providerId === CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID

--- a/packages/shared/src/ai-provider.ts
+++ b/packages/shared/src/ai-provider.ts
@@ -166,11 +166,13 @@ export const CODEX_OAUTH_MODEL_CATALOG: readonly AiProviderModel[] = [
 
 export const CLAWDI_MANAGED_V1_PROVIDER_ID = "clawdi-managed";
 const CLAWDI_MANAGED_V1_API_MODE = "openai_responses";
-export const CLAWDI_MANAGED_V2_PROVIDER_ID = "clawdi-managed-v2";
+export const CLAWDI_MANAGED_V2_PROVIDER_ID = "clawdi-v2";
+export const CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID = "clawdi-managed-v2";
 const CLAWDI_MANAGED_V2_API_MODE = "openai_chat";
 export const CLAWDI_MANAGED_PROVIDER_IDS: ReadonlySet<string> = new Set([
 	CLAWDI_MANAGED_V1_PROVIDER_ID,
 	CLAWDI_MANAGED_V2_PROVIDER_ID,
+	CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
 ]);
 const CLAWDI_MANAGED_RUNTIME_ENV = "CLAWDI_MANAGED_OPENAI_API_KEY";
 const CLAWDI_MANAGED_PLACEHOLDER_RUNTIME_ENV = "OPENAI_API_KEY";
@@ -369,7 +371,12 @@ function validateManagedProviderContract(
 
 function clawdiManagedApiMode(providerId: string): AiProviderApiMode | null {
 	if (providerId === CLAWDI_MANAGED_V1_PROVIDER_ID) return CLAWDI_MANAGED_V1_API_MODE;
-	if (providerId === CLAWDI_MANAGED_V2_PROVIDER_ID) return CLAWDI_MANAGED_V2_API_MODE;
+	if (
+		providerId === CLAWDI_MANAGED_V2_PROVIDER_ID ||
+		providerId === CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID
+	) {
+		return CLAWDI_MANAGED_V2_API_MODE;
+	}
 	return null;
 }
 


### PR DESCRIPTION
## Summary

- Make `clawdi-v2` the canonical v2 managed AI provider id across the cloud backend, shared package, CLI projection, and local development emitters.
- Keep `clawdi-managed-v2` accepted as a transition alias in backend allowlists, validation, API-mode resolution, admin upsert, shared classification, and CLI projection.
- Preserve the requested id in admin upserts so legacy callers can register and immediately select the legacy provider while new callers register and select `clawdi-v2`.
- Update the single `apps/web` deploy-request test hardcode without touching other web files.

## Rollout ordering

This PR **must deploy before, or in the same deploy window as, Clawdi-AI/clawdi-hosted#892**. Hosted #892 starts registering and selecting `clawdi-v2`; deploying hosted first would break managed-provider registration and selection against a cloud backend that only accepts `clawdi-managed-v2`. Both ids remain accepted during the transition, while new cloud defaults emit `clawdi-v2`.

## Verification

- `cd backend && uv run pytest -q tests/test_ai_providers.py tests/test_admin_endpoints.py` against migrated throwaway pgvector PostgreSQL (`116 passed`)
- Focused runtime manifest managed-provider tests (`5 passed`)
- `bun test packages/shared/src/ai-provider.test.ts apps/web/src/hosted/billing/deploy/deploy-request.test.ts` (`33 passed`)
- Focused CLI runtime projection test (`1 passed`)
- Shared, CLI, and web typechecks
- Ruff check/format, Python compileall, and Biome check

No production operations were performed.