### PR TITLE
fix(web): unify hosted agent resilience

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -140,6 +140,17 @@ const failedMissingProjectionDeployment = {
 	},
 };
 
+const runningMissingProjectionDeployment = {
+	...includedBasicDeployment,
+	id: "hdep_running_projection",
+	name: "Running projection agent",
+	hermes_control_ui_url: "https://runtime.example/hermes",
+	config_info: {
+		...includedBasicDeployment.config_info,
+		clawdi_cloud_environments: { hermes: missingProjectionEnvironmentId },
+	},
+};
+
 const retainedProjectionEnvironmentId = "66666666-6666-4666-8666-666666666666";
 const retainedProjectionFailureReason =
 	"startup_probe_failing; restart_count=4; runtime daemon exited and is no longer reachable";
@@ -337,12 +348,16 @@ type HostedApiStubOptions = {
 	checkoutRequests?: string[];
 	cloudAgentOverrides?: Record<string, unknown>;
 	cloudAgents?: readonly unknown[];
+	cloudAgentsResponse?: StubResponse;
+	cloudAgentErrors?: Record<string, { detail: string; status: number }>;
 	cloudAgentNotFoundIds?: readonly string[];
+	cloudAgentResponses?: Record<string, StubResponse[]>;
 	createRequests?: string[];
 	deleteRequests?: string[];
 	deployRequestStatusRequests?: string[];
 	deployRequestStatusResponses?: StubResponse[];
 	deployments?: readonly unknown[];
+	deploymentsResponse?: StubResponse;
 	fixPaymentRequests?: string[];
 	ledgerResponseForRequest?: (limit: number) => unknown;
 	ledgerRequests?: string[];
@@ -350,6 +365,8 @@ type HostedApiStubOptions = {
 	plans?: readonly unknown[];
 	retryRequests?: string[];
 	restartRequests?: string[];
+	runtimeUiRedemptionRequests?: string[];
+	runtimeUiRedemptionResponses?: StubResponse[];
 	walletRetryResponses?: StubResponse[];
 	startError?: { status: number; detail: string };
 	startRequests?: string[];
@@ -415,6 +432,9 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 				: fulfillJson(r, response);
 		}
 		if (p === "/v2/deployments" && r.request().method() === "GET") {
+			if (options.deploymentsResponse) {
+				return fulfillJson(r, options.deploymentsResponse.body, options.deploymentsResponse.status);
+			}
 			return fulfillJson(r, deployments);
 		}
 		if (p.startsWith("/v2/deployments/by-request/") && r.request().method() === "GET") {
@@ -602,6 +622,14 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			options.restartRequests?.push(p);
 			return fulfillJson(r, { status: "starting" });
 		}
+		if (p.endsWith("/runtime-ui/redemption") && r.request().method() === "POST") {
+			options.runtimeUiRedemptionRequests?.push(p);
+			const response = options.runtimeUiRedemptionResponses?.shift() ?? {
+				status: 200,
+				body: { url: "https://runtime.example/ui?clawdi_code=browser" },
+			};
+			return fulfillJson(r, response.body, response.status);
+		}
 		if (p.endsWith("/start") && r.request().method() === "POST") {
 			options.startRequests?.push(r.request().postData() ?? "");
 			if (options.startError) {
@@ -619,9 +647,17 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 	await page.route(`${CLOUD_API}/**`, (r) => {
 		const p = new URL(r.request().url()).pathname;
 		if (p === "/v1/me") return fulfillJson(r, me);
-		if (p === "/v1/agents") return fulfillJson(r, options.cloudAgents ?? []);
+		if (p === "/v1/agents") {
+			return options.cloudAgentsResponse
+				? fulfillJson(r, options.cloudAgentsResponse.body, options.cloudAgentsResponse.status)
+				: fulfillJson(r, options.cloudAgents ?? []);
+		}
 		if (p.startsWith("/v1/agents/") && r.request().method() === "GET") {
 			const id = decodeURIComponent(p.slice("/v1/agents/".length));
+			const response = options.cloudAgentResponses?.[id]?.shift();
+			if (response) return fulfillJson(r, response.body, response.status);
+			const error = options.cloudAgentErrors?.[id];
+			if (error) return fulfillJson(r, { detail: error.detail }, error.status);
 			if (options.cloudAgentNotFoundIds?.includes(id)) {
 				return fulfillJson(r, { detail: "Agent not found" }, 404);
 			}
@@ -753,7 +789,7 @@ test("deploy wizard Select opens without browser errors", async ({ page }) => {
 	expect(errors, `language select: ${errors.join(" | ")}`).toEqual([]);
 });
 
-test("env-keyed agent route keeps failed deployment recovery available without its projection", async ({
+test("env-keyed agent route keeps deployment capabilities available without its projection", async ({
 	page,
 }) => {
 	const restartRequests: string[] = [];
@@ -772,12 +808,12 @@ test("env-keyed agent route keeps failed deployment recovery available without i
 	await expect(main.getByText(missingProjectionFailureReason, { exact: true })).toBeVisible();
 	await expect(main.getByText("Failed", { exact: true })).toBeVisible();
 	await expect(main.getByText("Basic", { exact: true })).toBeVisible();
-	await expect(main.getByText("Jul 15, 2026", { exact: true })).toBeVisible();
 	await expect(main.getByRole("button", { name: "Retry startup", exact: true })).toBeVisible();
 	await expect(main.getByRole("button", { name: "Delete", exact: true })).toBeVisible();
-	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toHaveCount(0);
-	await expect(page.getByRole("link", { name: "Runtime UI", exact: true })).toHaveCount(0);
-	await expect(page.getByRole("link", { name: "Sessions", exact: true })).toHaveCount(0);
+	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toBeVisible();
+	await expect(page.getByRole("link", { name: "Runtime UI", exact: true })).toBeVisible();
+	await expect(page.getByRole("link", { name: "Sessions", exact: true })).toBeVisible();
+	await expect(main.getByRole("button", { name: "Check again", exact: true })).toBeVisible();
 
 	await main.getByRole("button", { name: "Retry startup", exact: true }).click();
 	await page
@@ -796,7 +832,7 @@ test("env-keyed agent route keeps failed deployment recovery available without i
 	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_failed_projection"]);
 });
 
-test("failed deployment with a retained projection renders recovery without live agent sections", async ({
+test("failed deployment with a retained projection keeps status-authoritative navigation", async ({
 	page,
 }) => {
 	const restartRequests: string[] = [];
@@ -817,12 +853,11 @@ test("failed deployment with a retained projection renders recovery without live
 	await expect(main.getByText(retainedProjectionFailureReason, { exact: true })).toBeVisible();
 	await expect(main.getByText("Failed", { exact: true })).toBeVisible();
 	await expect(main.getByText("Basic", { exact: true })).toBeVisible();
-	await expect(main.getByText("Jul 15, 2026", { exact: true })).toBeVisible();
 	await expect(main.getByRole("button", { name: "Retry startup", exact: true })).toBeVisible();
 	await expect(main.getByRole("button", { name: "Delete", exact: true })).toBeVisible();
-	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toHaveCount(0);
-	await expect(page.getByRole("link", { name: "Runtime UI", exact: true })).toHaveCount(0);
-	await expect(page.getByRole("link", { name: "Sessions", exact: true })).toHaveCount(0);
+	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toBeVisible();
+	await expect(page.getByRole("link", { name: "Runtime UI", exact: true })).toBeVisible();
+	await expect(page.getByRole("link", { name: "Sessions", exact: true })).toBeVisible();
 
 	await main.getByRole("button", { name: "Retry startup", exact: true }).click();
 	await page
@@ -841,6 +876,86 @@ test("failed deployment with a retained projection renders recovery without live
 	await expect
 		.poll(() => deleteRequests)
 		.toEqual(["/v2/deployments/hdep_failed_retained_projection"]);
+});
+
+test("missing live projection recovers on Check again without losing deployment tools", async ({
+	page,
+}) => {
+	await stubHostedApi(page, {
+		deployments: [runningMissingProjectionDeployment],
+		cloudAgentResponses: {
+			[missingProjectionEnvironmentId]: [{ status: 404, body: { detail: "Agent not found" } }],
+		},
+	});
+
+	await page.goto(`/agents/${missingProjectionEnvironmentId}?source=on-clawdi`);
+	const main = page.locator("main");
+	await expect(main.getByText("Agent sync record unavailable", { exact: true })).toBeVisible();
+	await expect(page.getByRole("link", { name: "Runtime UI", exact: true })).toBeVisible();
+	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toBeVisible();
+	await main.getByRole("button", { name: "Check again", exact: true }).click();
+	await expect(main.getByText("Agent sync record unavailable", { exact: true })).toHaveCount(0);
+	await expect(main.getByRole("heading", { name: "Overview" })).toBeVisible();
+});
+
+test("projection service errors stay visible while deployment tools remain available", async ({
+	page,
+}) => {
+	const errors = collectBrowserErrors(page);
+	await stubHostedApi(page, {
+		deployments: [runningMissingProjectionDeployment],
+		cloudAgentsResponse: { status: 500, body: { detail: "agent list unavailable" } },
+		cloudAgentErrors: {
+			[missingProjectionEnvironmentId]: { status: 500, detail: "projection gateway failed" },
+		},
+	});
+
+	await page.goto(`/agents/${missingProjectionEnvironmentId}?source=on-clawdi`);
+	const main = page.locator("main");
+	await expect(main.getByText("Agent sync service unavailable", { exact: true })).toBeVisible();
+	await expect(page.getByRole("link", { name: "Runtime UI", exact: true })).toBeVisible();
+	await expect(page.getByRole("link", { name: "Terminal", exact: true })).toBeVisible();
+	const renderErrors = errors.filter(
+		(error) => error.includes("Maximum update depth") || error.includes("Too many re-renders"),
+	);
+	expect(renderErrors, `projection failure render: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("Runtime UI redemption failure renders a retryable error instead of a permanent spinner", async ({
+	page,
+}) => {
+	const runtimeUiRedemptionRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments: [runningMissingProjectionDeployment],
+		runtimeUiRedemptionRequests,
+		runtimeUiRedemptionResponses: [
+			{ status: 500, body: { detail: "redemption temporarily unavailable" } },
+			{ status: 200, body: { url: "https://runtime.example/hermes?clawdi_code=recovered" } },
+		],
+	});
+
+	await page.goto(`/agents/${missingProjectionEnvironmentId}/console?source=on-clawdi`);
+	const main = page.locator("main");
+	await expect.poll(() => runtimeUiRedemptionRequests.length).toBe(1);
+	await expect(main.getByText("Couldn't load Runtime UI", { exact: true })).toBeVisible();
+	await main.getByRole("button", { name: "Retry", exact: true }).click();
+	await expect(main.getByText("Couldn't load Runtime UI", { exact: true })).toHaveCount(0);
+	await expect.poll(() => runtimeUiRedemptionRequests.length).toBe(2);
+});
+
+test("revoked deployment inventory never reclassifies cloud projections as connected", async ({
+	page,
+}) => {
+	await stubHostedApi(page, {
+		cloudAgents: [sharedLegacyCloudAgent],
+		deploymentsResponse: { status: 403, body: { detail: "deployment access revoked" } },
+	});
+
+	await page.goto("/agents");
+	const main = page.locator("main");
+	await expect(main.getByText("Clawdi Cloud inventory unavailable", { exact: true })).toBeVisible();
+	await expect(main.getByText("shared-legacy-agent", { exact: true })).toHaveCount(0);
+	await expect(main.getByText("Connect your first agent", { exact: true })).toHaveCount(0);
 });
 
 test("shared legacy environment routes an older tile's actions to its deployment", async ({

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -49,6 +49,7 @@ import { toast } from "sonner";
 import { useCommandPalette } from "@/components/command-palette";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import {
+	AgentSourceBadge,
 	AgentSourceBadgeForEnvironment,
 	agentDisplayName,
 	agentSourceKindLabel,
@@ -130,13 +131,6 @@ import { cn, errorMessage, relativeTime } from "@/lib/utils";
 
 type AgentChromeKind = AgentOwnershipKind;
 const IS_HOSTED_BUILD = import.meta.env.VITE_CLAWDI_HOSTED === "true";
-const HostedFocusRuntimeStatusBadge = IS_HOSTED_BUILD
-	? lazy(() =>
-			import("@/hosted/use-hosted-agent-tiles").then((m) => ({
-				default: m.HostedFocusRuntimeStatusBadge,
-			})),
-		)
-	: null;
 const HostedUnifiedAgentListSensor = IS_HOSTED_BUILD
 	? lazy(() =>
 			import("@/hosted/use-unified-agent-list").then((m) => ({
@@ -145,8 +139,12 @@ const HostedUnifiedAgentListSensor = IS_HOSTED_BUILD
 		)
 	: null;
 
-function useAgentChromeKind(agent: SidebarEnvironment | null): AgentChromeKind {
+function useAgentChromeKind(
+	agent: SidebarEnvironment | null,
+	tile: AgentTile | null,
+): AgentChromeKind {
 	const ownership = useAgentOwnership();
+	if (tile) return agentTileChromeKind(tile);
 	if (!IS_HOSTED || !agent) return "connected";
 	return agentOwnershipKindFromId(agent.id, ownership);
 }
@@ -249,6 +247,7 @@ const AGENT_SECTION_TINTS = {
 const LEGACY_DASHBOARD_TINT = "bg-warning-muted text-warning-muted-foreground";
 
 type SidebarEnvironment = components["schemas"]["AgentResponse"];
+const EMPTY_SIDEBAR_ENVIRONMENTS: SidebarEnvironment[] = [];
 
 type SidebarNavItem = {
 	id: string;
@@ -529,15 +528,16 @@ function AgentSectionList({
 }
 
 function AgentFocusSections({
-	agent,
+	agentId,
+	kind,
 	activeSection,
 	onNavigate,
 }: {
-	agent: SidebarEnvironment;
+	agentId: string;
+	kind: Exclude<AgentChromeKind, "unresolved">;
 	activeSection: AgentSectionId;
 	onNavigate?: () => void;
 }) {
-	const kind = useAgentChromeKind(agent);
 	const legacyDashboardHref = kind === "legacy" ? legacyHostedDashboardUrl() : null;
 	const extraPrimaryItems: SidebarNavItem[] = legacyDashboardHref
 		? [
@@ -555,7 +555,7 @@ function AgentFocusSections({
 		: [];
 	return (
 		<AgentSectionList
-			agentId={agent.id}
+			agentId={agentId}
 			sections={kind === "cloud" ? HOSTED_AGENT_SECTIONS : CONNECTED_AGENT_SECTIONS}
 			activeSection={activeSection}
 			extraPrimaryItems={extraPrimaryItems}
@@ -630,7 +630,8 @@ function SidebarMainNavigation({
 	pathname,
 	showCloudFeatures,
 	activeAgentId,
-	activeAgent,
+	activeAgentTile,
+	activeAgentKind,
 	agentsLoaded,
 	activeSection,
 	onNavigate,
@@ -638,15 +639,17 @@ function SidebarMainNavigation({
 	pathname: string;
 	showCloudFeatures: boolean;
 	activeAgentId: string | null;
-	activeAgent: SidebarEnvironment | null;
+	activeAgentTile: AgentTile | null;
+	activeAgentKind: AgentChromeKind;
 	agentsLoaded: boolean;
 	activeSection: AgentSectionId;
 	onNavigate?: () => void;
 }) {
-	if (activeAgent) {
+	if (activeAgentId && activeAgentTile && activeAgentKind !== "unresolved") {
 		return (
 			<AgentFocusSections
-				agent={activeAgent}
+				agentId={activeAgentId}
+				kind={activeAgentKind}
 				activeSection={activeSection}
 				onNavigate={onNavigate}
 			/>
@@ -654,6 +657,15 @@ function SidebarMainNavigation({
 	}
 
 	if (activeAgentId) {
+		if (!agentsLoaded || activeAgentKind === "unresolved") {
+			return (
+				<AgentFocusLoadingSections
+					agentId={activeAgentId}
+					activeSection={activeSection}
+					onNavigate={onNavigate}
+				/>
+			);
+		}
 		if (showCloudFeatures && agentsLoaded) {
 			return (
 				<AgentFocusHostedFallbackSections
@@ -690,6 +702,8 @@ type FocusNavigationPaneProps = {
 	showCloudFeatures: boolean;
 	activeAgentId: string | null;
 	activeAgent: SidebarEnvironment | null;
+	activeAgentTile: AgentTile | null;
+	activeAgentKind: AgentChromeKind;
 	agentsLoaded: boolean;
 	activeSection: AgentSectionId;
 	onNavigate?: () => void;
@@ -701,6 +715,8 @@ function FocusNavigationPane({
 	showCloudFeatures,
 	activeAgentId,
 	activeAgent,
+	activeAgentTile,
+	activeAgentKind,
 	agentsLoaded,
 	activeSection,
 	onNavigate,
@@ -710,8 +726,9 @@ function FocusNavigationPane({
 			<SidebarHeader className="px-4 pt-3 pb-2">
 				<FocusHeader
 					activeAgent={activeAgent}
+					activeAgentTile={activeAgentTile}
+					activeAgentKind={activeAgentKind}
 					activeAgentId={activeAgentId}
-					showCloudFeatures={showCloudFeatures}
 				/>
 			</SidebarHeader>
 			<SidebarContent className="pb-[calc(var(--header-height)+0.75rem)]">
@@ -719,7 +736,8 @@ function FocusNavigationPane({
 					pathname={pathname}
 					showCloudFeatures={showCloudFeatures}
 					activeAgentId={activeAgentId}
-					activeAgent={activeAgent}
+					activeAgentTile={activeAgentTile}
+					activeAgentKind={activeAgentKind}
 					agentsLoaded={agentsLoaded}
 					activeSection={activeSection}
 					onNavigate={onNavigate}
@@ -859,16 +877,17 @@ function SortableAgentRailItem({
 		machine_name: agent.name,
 		agent_type: agent.agentType,
 	};
-	const identityLabel =
+	const baseIdentityLabel =
 		kind === "legacy"
 			? `Legacy · ${agentTextLabel(identity, { includeSource: false, ownershipKind: kind })}`
 			: agentTextLabel(identity, { includeSource: kind === "cloud", ownershipKind: kind });
+	const identityLabel = [baseIdentityLabel, agent.contextLabel].filter(Boolean).join(" · ");
 	const statusLabel =
 		kind === "cloud"
 			? [agent.statusLabel, agent.secondaryStatus?.label].filter(Boolean).join(" · ")
 			: null;
 	const label = statusLabel ? `${identityLabel} · ${statusLabel}` : identityLabel;
-	const caption = displayMachineName(agent.name);
+	const caption = displayMachineName(agent.contextLabel ?? agent.name);
 	const style: React.CSSProperties = {
 		transform: CSS.Transform.toString(transform),
 		transition: isDragging ? undefined : transition,
@@ -1197,16 +1216,17 @@ function agentHeaderMeta(
 
 function FocusHeader({
 	activeAgent,
+	activeAgentTile,
+	activeAgentKind,
 	activeAgentId,
-	showCloudFeatures,
 }: {
 	activeAgent: SidebarEnvironment | null;
+	activeAgentTile: AgentTile | null;
+	activeAgentKind: AgentChromeKind;
 	activeAgentId: string | null;
-	showCloudFeatures: boolean;
 }) {
 	const searchStr = useLocation({ select: (location) => location.searchStr });
 	const routeQuery = agentDeploymentRouteQuery(searchStr);
-	const kind = useAgentChromeKind(activeAgent);
 	if (!activeAgent && !activeAgentId) {
 		return (
 			<div className="min-w-0">
@@ -1218,12 +1238,20 @@ function FocusHeader({
 		);
 	}
 
-	if (!activeAgent) {
+	if (activeAgentKind === "unresolved") {
+		return (
+			<div className="min-w-0 space-y-2" role="status" aria-label="Agent ownership loading">
+				<Skeleton className="h-4 w-32" />
+				<Skeleton className="h-3 w-24" />
+				<Skeleton className="h-8 w-full rounded-md" />
+			</div>
+		);
+	}
+
+	if (!activeAgent && !activeAgentTile) {
 		return (
 			<div className="min-w-0">
-				<div className="truncate text-sm font-semibold leading-5">
-					{showCloudFeatures ? "Clawdi Cloud agent" : "Agent"}
-				</div>
+				<div className="truncate text-sm font-semibold leading-5">Agent unavailable</div>
 				<div className="truncate text-xs leading-4 text-muted-foreground">
 					{activeAgentId ? activeAgentId.slice(0, 8) : "Loading navigation"}
 				</div>
@@ -1231,72 +1259,108 @@ function FocusHeader({
 		);
 	}
 
-	const name = agentDisplayName(activeAgent);
+	const name = activeAgent
+		? agentDisplayName(activeAgent)
+		: (activeAgentTile?.name ?? "Clawdi Cloud agent");
 	const displayName = displayMachineName(name);
-	const meta = agentHeaderMeta(activeAgent, kind);
-	const title = [name, meta.detailLabel, meta.activityLabel].filter(Boolean).join(" · ");
+	const meta = activeAgent ? agentHeaderMeta(activeAgent, activeAgentKind) : null;
+	const contextLabel = activeAgentTile?.contextLabel ?? null;
+	const activityLabel = meta?.activityLabel ?? "Sync record unavailable";
+	const visibleLabel = meta?.visibleLabel ?? runtimeDisplayLabel(activeAgentTile?.agentType);
+	const detailLabel = [contextLabel, meta?.detailLabel ?? visibleLabel].filter(Boolean).join(" · ");
+	const title = [name, detailLabel, activityLabel].filter(Boolean).join(" · ");
 	const manageHref =
-		kind === "cloud"
-			? agentSectionHref(activeAgent.id, "settings", routeQuery)
-			: kind === "legacy"
+		activeAgentKind === "cloud"
+			? (activeAgentTile?.manageHref ??
+				agentSectionHref(activeAgentId ?? activeAgent?.id ?? "", "settings", routeQuery))
+			: activeAgentKind === "legacy"
 				? (legacyHostedDashboardUrl() ?? undefined)
 				: undefined;
 	return (
 		<div className="min-w-0 text-left">
 			<div className="flex min-w-0 items-center gap-2" title={title}>
 				<span className="truncate text-sm font-semibold leading-5">{displayName}</span>
-				{kind === "cloud" ? (
-					<AgentSourceBadgeForEnvironment env={activeAgent} ownershipKind={kind} compact />
-				) : kind === "legacy" ? (
+				{activeAgentKind === "cloud" ? (
+					activeAgent ? (
+						<AgentSourceBadgeForEnvironment
+							env={activeAgent}
+							ownershipKind={activeAgentKind}
+							compact
+						/>
+					) : (
+						<AgentSourceBadge source="hosted" compact />
+					)
+				) : activeAgentKind === "legacy" ? (
 					<LegacyAgentBadge compact />
 				) : null}
 			</div>
-			{meta.visibleLabel ? (
-				<div
-					className="mt-1 truncate text-xs leading-4 text-muted-foreground"
-					title={meta.detailLabel}
-				>
-					{meta.visibleLabel}
+			{visibleLabel ? (
+				<div className="mt-1 truncate text-xs leading-4 text-muted-foreground" title={detailLabel}>
+					{[contextLabel, visibleLabel].filter(Boolean).join(" · ")}
 				</div>
 			) : null}
 			<div
 				className={cn(
 					"mt-2 flex min-w-0 rounded-md border border-sidebar-border bg-sidebar-accent/45 px-2 py-1 text-xs leading-4",
-					kind === "cloud" ? "flex-col items-start gap-0.5" : "items-center justify-between gap-2",
+					activeAgentKind === "cloud"
+						? "flex-col items-start gap-0.5"
+						: "items-center justify-between gap-2",
 				)}
 			>
 				{/* Legacy agents share the hosted copy variant (supervised
 				 * daemon, no CLI steps), while remediation stays in the legacy
 				 * v1 dashboard when that URL is configured. */}
-				{kind === "cloud" && HostedFocusRuntimeStatusBadge ? (
-					<Suspense fallback={<FocusStatusFallback />}>
-						<HostedFocusRuntimeStatusBadge
-							env={activeAgent}
-							manageHref={manageHref}
-							compact
-							tooltipDetail={meta.detailLabel}
-						/>
-					</Suspense>
-				) : (
+				{activeAgentKind === "cloud" && activeAgentTile ? (
+					<HostedFocusTileStatus tile={activeAgentTile} />
+				) : activeAgent ? (
 					<DaemonStatusBadge
 						env={activeAgent}
-						source={kind !== "connected" ? "on-clawdi" : "self-managed"}
+						source={activeAgentKind === "legacy" ? "on-clawdi" : "self-managed"}
 						manageHref={manageHref}
 						compact
-						tooltipDetail={meta.detailLabel}
+						tooltipDetail={detailLabel}
 					/>
+				) : (
+					<FocusStatusFallback />
 				)}
 				<span
 					className={cn(
 						"min-w-0 truncate text-muted-foreground",
-						kind === "cloud" && "w-full pl-3.5",
+						activeAgentKind === "cloud" && "w-full pl-3.5",
 					)}
-					title={meta.activityLabel}
+					title={activityLabel}
 				>
-					{meta.activityLabel}
+					{activityLabel}
 				</span>
 			</div>
 		</div>
+	);
+}
+
+function runtimeDisplayLabel(agentType: string | null | undefined): string {
+	return agentType ? `${agentTypeLabel(agentType)} runtime` : "Hosted runtime";
+}
+
+function HostedFocusTileStatus({ tile }: { tile: AgentTile }) {
+	return (
+		<span
+			className="inline-flex min-w-0 items-center gap-1.5 whitespace-nowrap text-muted-foreground"
+			title={tile.secondaryStatus?.title ?? tile.statusLabel}
+		>
+			<span
+				aria-hidden
+				className={cn(
+					"inline-block size-1.5 shrink-0 rounded-full",
+					tile.statusDot?.dotClass ?? "border border-muted-foreground/50 bg-transparent",
+				)}
+			/>
+			<span>{tile.statusLabel}</span>
+			{tile.secondaryStatus ? (
+				<span className={tile.secondaryStatus.textClass ?? "text-muted-foreground"}>
+					· {tile.secondaryStatus.label}
+				</span>
+			) : null}
+		</span>
 	);
 }
 
@@ -1608,6 +1672,14 @@ export function AppSidebar({
 	const hostedAccess = useHostedProductAccess();
 	const [mounted, setMounted] = useState(false);
 	const [hostedAgentTiles, setHostedAgentTiles] = useState<AgentTile[] | null>(null);
+	const [hostedMembershipResolved, setHostedMembershipResolved] = useState(false);
+	const updateHostedAgentList = useCallback(
+		(tiles: AgentTile[] | null, membershipResolved: boolean) => {
+			setHostedAgentTiles(tiles);
+			setHostedMembershipResolved(membershipResolved);
+		},
+		[],
+	);
 	useEffect(() => {
 		setMounted(true);
 	}, []);
@@ -1625,12 +1697,19 @@ export function AppSidebar({
 		[hydratedEnvironments],
 	);
 	const unifiedAgentListEnabled = mounted && Boolean(HostedUnifiedAgentListSensor);
-	const agentsLoaded =
-		hydratedEnvironments !== undefined && (!unifiedAgentListEnabled || hostedAgentTiles !== null);
+	const agentsLoaded = unifiedAgentListEnabled
+		? hostedAgentTiles !== null && hostedMembershipResolved
+		: hydratedEnvironments !== undefined;
 	const agents = unifiedAgentListEnabled ? (hostedAgentTiles ?? []) : selfManagedTiles;
+	const activeAgentTile = activeAgentId
+		? (agents.find((tile) => agentTileRouteId(tile) === activeAgentId) ?? null)
+		: null;
 	const activeAgent = activeAgentId
 		? (hydratedEnvironments?.find((env) => env.id === activeAgentId) ?? null)
 		: null;
+	const classifiedActiveAgentKind = useAgentChromeKind(activeAgent, activeAgentTile);
+	const activeAgentKind =
+		activeAgentTile || !activeAgentId || agentsLoaded ? classifiedActiveAgentKind : "unresolved";
 	const activeSection = agentRoute?.section ?? "overview";
 	const [settingsSection, setSettingsSection] = useQueryState(
 		SETTINGS_QUERY_KEY,
@@ -1666,10 +1745,10 @@ export function AppSidebar({
 			{unifiedAgentListEnabled && HostedUnifiedAgentListSensor ? (
 				<Suspense fallback={null}>
 					<HostedUnifiedAgentListSensor
-						cloudEnvs={hydratedEnvironments ?? []}
+						cloudEnvs={hydratedEnvironments ?? EMPTY_SIDEBAR_ENVIRONMENTS}
 						showCloudDeployments
 						showLegacyAgents={hostedAccess.canUseLegacyHostedDashboard}
-						onChange={setHostedAgentTiles}
+						onChange={updateHostedAgentList}
 					/>
 				</Suspense>
 			) : null}
@@ -1696,6 +1775,8 @@ export function AppSidebar({
 						showCloudFeatures={showCloudFeatures}
 						activeAgentId={activeAgentId}
 						activeAgent={activeAgent ?? null}
+						activeAgentTile={activeAgentTile}
+						activeAgentKind={activeAgentKind}
 						agentsLoaded={agentsLoaded}
 						activeSection={activeSection}
 					/>
@@ -1728,6 +1809,8 @@ export function AppSidebar({
 							showCloudFeatures={showCloudFeatures}
 							activeAgentId={activeAgentId}
 							activeAgent={activeAgent ?? null}
+							activeAgentTile={activeAgentTile}
+							activeAgentKind={activeAgentKind}
 							agentsLoaded={agentsLoaded}
 							activeSection={activeSection}
 							onNavigate={closeMobileSidebar}

--- a/apps/web/src/components/dashboard/agent-label.tsx
+++ b/apps/web/src/components/dashboard/agent-label.tsx
@@ -1,6 +1,7 @@
 import { Cloud, History, Laptop } from "lucide-react";
 import type { ReactNode } from "react";
 import { AgentIcon, type AgentIconSize } from "@/components/dashboard/agent-icon";
+import { Skeleton } from "@/components/ui/skeleton";
 import { StatusBadge } from "@/components/ui/status-badge";
 import {
 	type AgentOwnershipKind,
@@ -102,7 +103,8 @@ export function agentTypeLabel(type: string | null | undefined): string {
 
 export type AgentSourceKind = "hosted" | "connected";
 
-function sourceFromOwnershipKind(kind: AgentOwnershipKind): AgentSourceKind {
+function sourceFromOwnershipKind(kind: AgentOwnershipKind): AgentSourceKind | null {
+	if (kind === "unresolved") return null;
 	return kind === "cloud" ? "hosted" : "connected";
 }
 
@@ -244,11 +246,15 @@ export function AgentSourceBadgeForEnvironment({
 }) {
 	const ownership = useAgentOwnership();
 	const kind = ownershipKind ?? agentOwnershipKindFromId(env.id, ownership);
+	if (kind === "unresolved") {
+		return <Skeleton aria-label="Agent source loading" className="h-5 w-14 rounded-full" />;
+	}
 	if (kind === "legacy") {
 		if (iconOnly) return null;
 		return <LegacyAgentBadge compact={compact} className={className} />;
 	}
 	const source = sourceFromOwnershipKind(kind);
+	if (!source) return null;
 	if (source === "connected" && !showConnected) return null;
 	return (
 		<AgentSourceBadge source={source} compact={compact} iconOnly={iconOnly} className={className} />
@@ -265,7 +271,7 @@ export function agentTextLabel(
 	const identity = agentIdentity(env);
 	const source = sourceFromOwnershipKind(ownershipKind);
 	const parts = [
-		includeSource && source === "hosted" ? agentSourceLabel(source) : null,
+		includeSource && source === "hosted" ? agentSourceLabel("hosted") : null,
 		identity.primaryLabel,
 		identity.secondaryLabel,
 	].filter((part): part is string => Boolean(part));

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -236,7 +236,7 @@ export function HostedUnavailableBanner({
 			error={error}
 			onRetry={onRetry}
 			normalizer={normalizer}
-			title="Couldn't load Clawdi Cloud agents"
+			title="Clawdi Cloud inventory unavailable"
 		/>
 	);
 }

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -59,6 +59,7 @@ export function AgentHome({
 		environmentId: resolvedEnvId,
 		matchedRuntime,
 		ambiguousMatches,
+		membershipResolved,
 		isLoading,
 		isFetching,
 		error,
@@ -103,13 +104,37 @@ export function AgentHome({
 		void refetch();
 	};
 
+	// No route may be classified as connected until deployment membership has
+	// produced at least one authoritative snapshot. A 403/network failure is not
+	// an empty deployment list.
+	if (!membershipResolved && !deployment && ambiguousMatches.length === 0) {
+		if (error) {
+			return (
+				<div
+					data-hosted="true"
+					className={`${CENTERED_PAGE_WIDTH_CLASS.page} space-y-4 px-4 py-2 lg:px-6`}
+				>
+					<ApiErrorPanel
+						normalizer={billingErrorNormalizer}
+						error={error}
+						onRetry={() => {
+							void refetch();
+						}}
+						title="Clawdi Cloud inventory unavailable"
+					/>
+				</div>
+			);
+		}
+		return <ConnectedAgentDetailSkeleton hosted />;
+	}
+
 	// Hold a skeleton until the deployment lookup settles, so a hosted agent
 	// doesn't flash the connected detail (and fire its queries) first.
 	if (isLoading || (requestedHostedAgent && !deployment && isFetching)) {
 		return <ConnectedAgentDetailSkeleton hosted />;
 	}
 
-	if (error && requestedHostedAgent) {
+	if (error && requestedHostedAgent && !deployment) {
 		return (
 			<div
 				data-hosted="true"

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -1,0 +1,42 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { QueryClient } from "@tanstack/react-query";
+import { billingKeys } from "@/hosted/billing/query-keys";
+
+type InvalidateDeploymentSnapshots =
+	typeof import("@/hosted/agents/deployment-hooks").invalidateDeploymentSnapshots;
+
+let invalidateSnapshots: InvalidateDeploymentSnapshots | null = null;
+
+beforeAll(async () => {
+	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
+	process.env.VITE_CLAWDI_DEPLOY_API_URL = "http://localhost:50021";
+	process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
+	const module = await import("@/hosted/agents/deployment-hooks");
+	invalidateSnapshots = module.invalidateDeploymentSnapshots;
+});
+
+describe("deployment mutation settlement", () => {
+	test("invalidates deployment membership and its additive agent projection together", () => {
+		const queryClient = new QueryClient();
+		queryClient.setQueryData(billingKeys.deployments, []);
+		queryClient.setQueryData(["agents"], []);
+
+		if (!invalidateSnapshots) throw new Error("deployment hooks were not loaded");
+		invalidateSnapshots(queryClient);
+
+		expect(queryClient.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(true);
+		expect(queryClient.getQueryState(["agents"])?.isInvalidated).toBe(true);
+	});
+
+	test("uses the shared invalidation on every inventory-changing mutation settlement", () => {
+		const source = readFileSync(new URL("./deployment-hooks.ts", import.meta.url), "utf8");
+		const settlementInvalidations = source.match(
+			/onSettled: \(\) => invalidateDeploymentSnapshots\(qc\)/g,
+		);
+
+		// Language/timezone, AI provider, lifecycle, and delete all reconcile even
+		// when the request rejects or times out.
+		expect(settlementInvalidations).toHaveLength(4);
+	});
+});

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -6,20 +6,21 @@ import { toast } from "sonner";
 import { deleteDeploymentToastDecision } from "@/hosted/agents/delete-deployment-toast.logic";
 import { useBillingClient } from "@/hosted/billing/billing-client";
 import type {
-	HostedDeployment,
 	RebindAgentAiProviderRequest,
 	SetAgentEnabledRequest,
 } from "@/hosted/billing/contracts";
 import { normalizeHostedLanguage } from "@/hosted/billing/deploy/language-timezone-controls";
 import { BillingApiError, normalizeBillingError, toastBillingError } from "@/hosted/billing/errors";
-import { billingKeys, useHostedDeployments } from "@/hosted/billing/hooks";
+import { billingKeys } from "@/hosted/billing/hooks";
+import { resolveAgentDeployment } from "@/hosted/hosted-agent-resolution";
 import { deploymentRuntime, runtimeEnvironmentId } from "@/hosted/runtimes";
+import { useHostedDeploymentInventory } from "@/hosted/use-hosted-deployment-inventory";
 
 const SETTLING_REFRESH_DELAYS_MS = [2_000, 10_000, 20_000, 30_000] as const;
 
-function invalidateDeploymentSnapshots(qc: QueryClient) {
-	qc.invalidateQueries({ queryKey: billingKeys.deployments });
-	qc.invalidateQueries({ queryKey: ["agents"] });
+export function invalidateDeploymentSnapshots(qc: QueryClient) {
+	void qc.invalidateQueries({ queryKey: billingKeys.deployments });
+	void qc.invalidateQueries({ queryKey: ["agents"] });
 }
 
 function scheduleDeploymentSettlingRefresh(qc: QueryClient) {
@@ -58,10 +59,12 @@ function toastAgentLanguageTimezoneError(error: unknown) {
  * deployment selector is present.
  */
 export function useAgentDeployment(environmentId: string, deploymentSelector?: string | null) {
-	const query = useHostedDeployments({ pollWalletDunningFor: deploymentSelector ?? environmentId });
+	const inventory = useHostedDeploymentInventory({
+		pollWalletDunningFor: deploymentSelector ?? environmentId,
+	});
 	const resolution = useMemo(
-		() => resolveAgentDeployment(query.data ?? [], environmentId, deploymentSelector),
-		[query.data, environmentId, deploymentSelector],
+		() => resolveAgentDeployment(inventory.deployments ?? [], environmentId, deploymentSelector),
+		[inventory.deployments, environmentId, deploymentSelector],
 	);
 	const match = resolution.match;
 
@@ -81,55 +84,20 @@ export function useAgentDeployment(environmentId: string, deploymentSelector?: s
 		matchedRuntime: match?.runtime ?? null,
 		ambiguousMatches: resolution.ambiguousMatches,
 		environmentId: resolvedEnvId,
-		isLoading: query.isLoading,
-		isFetching: query.isFetching,
-		error: query.error,
-		refetch: query.refetch,
+		inventoryStatus: inventory.status,
+		membershipResolved: inventory.status === "resolved",
+		isLoading: inventory.status === "loading" && !inventory.hasSnapshot,
+		isFetching: inventory.isFetching,
+		error: inventory.error,
+		refetch: inventory.refetch,
 	};
 }
 
-export type AgentDeploymentMatch = {
-	deployment: HostedDeployment;
-	runtime: string | null;
-};
-
-export type AgentDeploymentResolution = {
-	match: AgentDeploymentMatch | null;
-	ambiguousMatches: AgentDeploymentMatch[];
-};
-
-export function resolveAgentDeployment(
-	deployments: readonly HostedDeployment[],
-	environmentId: string,
-	deploymentSelector?: string | null,
-): AgentDeploymentResolution {
-	const target = environmentId.toLowerCase();
-	// Direct deployment-id match: the post-deploy redirect lands on
-	// `/agents/<deployment.id>` because cloud-api env ids aren't minted until
-	// provisioning finishes — resolve by id, not just the env join.
-	const direct = deployments.find((deployment) => deployment.id.toLowerCase() === target);
-	if (direct) {
-		return { match: { deployment: direct, runtime: null }, ambiguousMatches: [] };
-	}
-
-	const matches: AgentDeploymentMatch[] = [];
-	for (const deployment of deployments) {
-		const envs = deployment.config_info?.clawdi_cloud_environments ?? {};
-		const runtime = Object.entries(envs).find(
-			([, value]) => (value ?? "").toLowerCase() === target,
-		);
-		if (runtime) matches.push({ deployment, runtime: runtime[0] });
-	}
-
-	if (deploymentSelector) {
-		const selector = deploymentSelector.toLowerCase();
-		const selected = matches.find((item) => item.deployment.id.toLowerCase() === selector);
-		if (selected) return { match: selected, ambiguousMatches: [] };
-	}
-
-	if (matches.length === 1) return { match: matches[0], ambiguousMatches: [] };
-	return { match: null, ambiguousMatches: matches };
-}
+export type {
+	AgentDeploymentMatch,
+	AgentDeploymentResolution,
+} from "@/hosted/hosted-agent-resolution";
+export { resolveAgentDeployment } from "@/hosted/hosted-agent-resolution";
 
 export function useSetAgentLanguageTimezone() {
 	const client = useBillingClient();
@@ -149,14 +117,11 @@ export function useSetAgentLanguageTimezone() {
 			return client.setAgentLanguageTimezone(vars.id, vars.agentType, body);
 		},
 		onSuccess: () => {
-			invalidateDeploymentSnapshots(qc);
 			scheduleDeploymentSettlingRefresh(qc);
 			toast.success("Language and timezone updated");
 		},
-		onError: (error) => {
-			invalidateDeploymentSnapshots(qc);
-			toastAgentLanguageTimezoneError(error);
-		},
+		onError: toastAgentLanguageTimezoneError,
+		onSettled: () => invalidateDeploymentSnapshots(qc),
 	});
 }
 
@@ -172,13 +137,8 @@ export function useSetAgentAiProvider() {
 		}) => {
 			return client.setAgentAiProvider(vars.id, vars.agentType, vars.body);
 		},
-		onSuccess: () => {
-			invalidateDeploymentSnapshots(qc);
-		},
-		onError: (error) => {
-			invalidateDeploymentSnapshots(qc);
-			toastAiProviderRebindError(error);
-		},
+		onError: toastAiProviderRebindError,
+		onSettled: () => invalidateDeploymentSnapshots(qc),
 	});
 }
 
@@ -208,7 +168,6 @@ export function useDeploymentLifecycle() {
 			return client.startDeployment(vars.id);
 		},
 		onSuccess: (_d, vars) => {
-			invalidateDeploymentSnapshots(qc);
 			scheduleDeploymentSettlingRefresh(qc);
 			const msg =
 				vars.action === "restart"
@@ -219,7 +178,6 @@ export function useDeploymentLifecycle() {
 			toast.success(msg);
 		},
 		onError: (error) => {
-			qc.invalidateQueries({ queryKey: billingKeys.deployments });
 			if (isLifecycleStateConflict(error)) {
 				toast.error("Agent state changed", {
 					description:
@@ -229,6 +187,7 @@ export function useDeploymentLifecycle() {
 			}
 			toast.error("Couldn't update lifecycle", { description: normalizeBillingError(error) });
 		},
+		onSettled: () => invalidateDeploymentSnapshots(qc),
 	});
 }
 
@@ -238,7 +197,6 @@ export function useDeleteDeployment() {
 	return useMutation({
 		mutationFn: (id: string) => client.deleteDeployment(id),
 		onSuccess: (result) => {
-			invalidateDeploymentSnapshots(qc);
 			scheduleDeploymentSettlingRefresh(qc);
 			const decision = deleteDeploymentToastDecision(result);
 			if (decision.tone === "warning") {
@@ -248,5 +206,6 @@ export function useDeleteDeployment() {
 			toast.success(decision.title, { description: decision.description });
 		},
 		onError: toastBillingError("Couldn't delete agent"),
+		onSettled: () => invalidateDeploymentSnapshots(qc),
 	});
 }

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -32,7 +32,6 @@ import { useSetAgentBreadcrumbTitle } from "@/components/breadcrumb-title";
 import { AgentSourceBadge, agentDisplayName } from "@/components/dashboard/agent-label";
 import { AgentSettingsPanel } from "@/components/dashboard/agent-settings-panel";
 import { AgentSkillsTab } from "@/components/dashboard/agent-skills-tab";
-import { ConnectedAgentDetailSkeleton } from "@/components/dashboard/connected-agent-detail";
 import type { DetailSectionMeta } from "@/components/detail/layout";
 import { EmptyState } from "@/components/empty-state";
 import { PageHeader } from "@/components/page-header";
@@ -168,6 +167,12 @@ import {
 	isRunningStatus,
 	parseDeploymentStatus,
 } from "@/hosted/deployment-status";
+import {
+	canOpenHostedRuntimeUi,
+	type HostedProjectionResolution,
+	missingProjectionRefetchInterval,
+	resolveHostedAgentProjection,
+} from "@/hosted/hosted-agent-resolution";
 import { type HostedRuntime, runtimeConsoleUrl, runtimeDisplayName } from "@/hosted/runtimes";
 import { hostedRuntimeStatusView } from "@/hosted/use-hosted-agent-tiles";
 import { useAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks";
@@ -210,7 +215,6 @@ import {
 	HOSTED_AGENT_SECTION_IDS,
 } from "@/lib/agent-routes";
 import { toastApiError, unwrap, useApi } from "@/lib/api";
-import { isApiNotFoundError } from "@/lib/api-errors";
 import type { SessionListItem } from "@/lib/api-schemas";
 import { formatModelLabel, formatShortDate } from "@/lib/format";
 import { sessionListQueryOptions } from "@/lib/session-queries";
@@ -434,9 +438,21 @@ export function HostedAgentDetail({
 				}),
 			),
 		enabled: cloudEnvironmentId,
+		refetchInterval: (query) =>
+			missingProjectionRefetchInterval(
+				query.state.error,
+				deployment.status,
+				query.state.fetchFailureCount,
+			),
+		refetchIntervalInBackground: false,
 	});
-	const agent = agentQuery.data;
-	const agentProjectionMissing = cloudEnvironmentId && isApiNotFoundError(agentQuery.error);
+	const projection = resolveHostedAgentProjection({
+		enabled: cloudEnvironmentId,
+		data: agentQuery.data,
+		error: agentQuery.error,
+		isPending: agentQuery.isPending,
+	});
+	const agent = projection.status === "resolved" ? projection.data : null;
 	const name = agent ? agentDisplayName(agent) : deploymentDisplayName(deployment.name);
 	const runtimeLabel = runtimeDisplayName(runtime);
 	const agentTitle = name === runtimeLabel ? name : `${name} · ${runtimeLabel}`;
@@ -465,31 +481,15 @@ export function HostedAgentDetail({
 
 	const sessions = useQuery({
 		...sessionListQueryOptions(api, { environment_id: environmentId, page_size: 20 }),
-		enabled: deploymentRunning && Boolean(agent),
+		enabled: deploymentRunning && projection.status === "resolved",
 	});
-
-	if (agentQuery.isLoading && deploymentRunning && cloudEnvironmentId) {
-		return <ConnectedAgentDetailSkeleton hosted />;
-	}
-
-	if (!deploymentRunning || agentProjectionMissing) {
-		return (
-			<DeploymentCentricDetail
-				deployment={deployment}
-				runtime={runtime}
-				environmentId={environmentId}
-				agentProjectionMissing={agentProjectionMissing}
-				section={activeTab}
-			/>
-		);
-	}
 
 	const activeNavItem = HOSTED_AGENT_NAV_META[activeTab];
 	const activeTabLabel = agentSectionLabel(activeTab);
 	const ActiveTabIcon = activeNavItem.icon;
 	const isLiveToolTab = activeTab === "console" || activeTab === "terminal";
 	const headerActions =
-		activeTab === "skills" ? (
+		activeTab === "skills" && projection.status === "resolved" ? (
 			<Button
 				render={<Link to="/skills" search={{ target: environmentId }} />}
 				nativeButton={false}
@@ -499,7 +499,7 @@ export function HostedAgentDetail({
 				<Plus />
 				Install skills
 			</Button>
-		) : consoleUrl ? (
+		) : canOpenHostedRuntimeUi(deployment.status, consoleUrl) ? (
 			<RuntimeUiOpenButton
 				deployment={deployment}
 				label={runtimeBrowserUiLabel(runtime)}
@@ -533,6 +533,13 @@ export function HostedAgentDetail({
 					/>
 				)}
 				{isLiveToolTab ? null : <ComputeDunningBanner deployment={deployment} />}
+				<HostedProjectionNotice
+					projection={projection}
+					isFetching={agentQuery.isFetching}
+					onRetry={() => {
+						void agentQuery.refetch();
+					}}
+				/>
 				<div className={isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : "w-full"}>
 					{activeTab === "overview" ? (
 						<OverviewTab
@@ -540,6 +547,8 @@ export function HostedAgentDetail({
 							agent={isCloudEnvId(environmentId) ? agent : null}
 							runtime={runtime}
 							isPerformance={isPerformance}
+							showDeploymentActions={projection.status !== "resolved" || !deploymentRunning}
+							projectionAvailable={projection.status === "resolved"}
 							sessions={sessions.data?.items ?? []}
 							sessionsLoading={sessions.isLoading}
 							sessionsError={sessions.error}
@@ -552,37 +561,112 @@ export function HostedAgentDetail({
 					) : null}
 					{activeTab === "terminal" ? <TerminalTab deployment={deployment} /> : null}
 					{activeTab === "sessions" ? (
-						<HostedAgentSessionsTab environmentId={environmentId} />
+						projection.status === "resolved" ? (
+							<HostedAgentSessionsTab environmentId={environmentId} />
+						) : (
+							<ProjectionDependentUnavailable label="Sessions" />
+						)
 					) : null}
 					{activeTab === "skills" ? (
-						agentQuery.error ? (
-							<ApiErrorPanel
-								error={agentQuery.error}
-								onRetry={() => {
-									void agentQuery.refetch();
-								}}
-								title="Couldn't load agent skills"
-							/>
-						) : (
+						projection.status === "resolved" ? (
 							<AgentSkillsTab
 								agentId={environmentId}
 								agentProjectId={agent?.default_project_id}
-								isResolvingAgentProject={agentQuery.isLoading && isCloudEnvId(environmentId)}
+								isResolvingAgentProject={false}
 							/>
+						) : (
+							<ProjectionDependentUnavailable label="Skills" />
 						)
 					) : null}
 					{activeTab === "ai" ? <AiProviderTab deployment={deployment} runtime={runtime} /> : null}
-					{activeTab === "channels" ? <ChannelsTab environmentId={environmentId} /> : null}
+					{activeTab === "channels" ? (
+						projection.status === "resolved" ? (
+							<ChannelsTab environmentId={environmentId} />
+						) : (
+							<ProjectionDependentUnavailable label="Channels" />
+						)
+					) : null}
 					{activeTab === "settings" ? (
 						<HostedAgentSettingsTab
 							environmentId={environmentId}
 							deployment={deployment}
 							runtime={runtime}
+							projectionAvailable={projection.status === "resolved"}
 						/>
 					) : null}
 				</div>
 			</section>
 		</div>
+	);
+}
+
+function HostedProjectionNotice({
+	projection,
+	isFetching,
+	onRetry,
+}: {
+	projection: HostedProjectionResolution<components["schemas"]["AgentResponse"]>;
+	isFetching: boolean;
+	onRetry: () => void;
+}) {
+	if (projection.status === "resolved") return null;
+	if (projection.status === "error") {
+		return (
+			<ApiErrorPanel
+				error={projection.error}
+				onRetry={onRetry}
+				title="Agent sync service unavailable"
+			/>
+		);
+	}
+	if (projection.status === "missing") {
+		return (
+			<Alert data-hosted="true">
+				<AlertCircle />
+				<AlertTitle>Agent sync record unavailable</AlertTitle>
+				<AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+					<span>
+						Deployment controls remain available; Runtime UI and Terminal continue to follow
+						deployment status. Sessions, skills, profile, and channels will recover when the cloud
+						projection catches up.
+					</span>
+					<Button type="button" variant="outline" size="sm" disabled={isFetching} onClick={onRetry}>
+						{isFetching ? <Spinner className="size-3.5" /> : <RefreshCw className="size-3.5" />}
+						Check again
+					</Button>
+				</AlertDescription>
+			</Alert>
+		);
+	}
+	if (projection.status === "loading") {
+		return (
+			<Alert data-hosted="true">
+				<Spinner className="size-4" />
+				<AlertTitle>Loading synced agent data</AlertTitle>
+				<AlertDescription>
+					Deployment-owned controls are ready while the cloud projection resolves.
+				</AlertDescription>
+			</Alert>
+		);
+	}
+	return (
+		<Alert data-hosted="true">
+			<AlertCircle />
+			<AlertTitle>Agent sync identity pending</AlertTitle>
+			<AlertDescription>
+				This deployment has not published an agent identity yet. Deployment controls remain
+				available while provisioning continues.
+			</AlertDescription>
+		</Alert>
+	);
+}
+
+function ProjectionDependentUnavailable({ label }: { label: string }) {
+	return (
+		<EmptyState
+			title={`${label} unavailable`}
+			description="This section depends on the synced agent record. Deployment-owned controls remain available."
+		/>
 	);
 }
 
@@ -768,115 +852,13 @@ function OverviewFailedPanel({
 	);
 }
 
-function DeploymentCentricDetail({
-	deployment,
-	runtime,
-	environmentId,
-	agentProjectionMissing,
-	section,
-}: {
-	deployment: HostedDeployment;
-	runtime: Runtime;
-	environmentId: string;
-	agentProjectionMissing: boolean;
-	section: HostedAgentTab;
-}) {
-	const status = parseDeploymentStatus(deployment.status);
-	const canRestart = canRestartDeployment(status);
-	const canStart = canStartDeployment(status);
-	const failed = status.kind === "failed";
-	const stoppedComputeSettings = status.kind === "stopped" && section === "settings";
-
-	if (stoppedComputeSettings) {
-		return (
-			<div
-				data-hosted="true"
-				className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6")}
-			>
-				<section className="flex flex-col gap-4">
-					<PageHeader
-						title="Settings"
-						description="Compute plan, billing, and lifecycle controls."
-						icon={<Settings className="size-4 text-muted-foreground" />}
-						status={<AgentSourceBadge source="hosted" compact />}
-					/>
-					<ComputeDunningBanner deployment={deployment} />
-					<ComputeSettingsSections deployment={deployment} />
-				</section>
-			</div>
-		);
-	}
-
-	return (
-		<div
-			data-hosted="true"
-			className={cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6")}
-		>
-			<section className="flex flex-col gap-5">
-				<PageHeader
-					title="Overview"
-					description="Deployment status and recovery controls."
-					icon={<Info className="size-4 text-muted-foreground" />}
-					status={<AgentSourceBadge source="hosted" compact />}
-				/>
-				{agentProjectionMissing ? (
-					<Alert data-hosted="true">
-						<AlertCircle />
-						<AlertTitle>Agent sync record unavailable</AlertTitle>
-						<AlertDescription>
-							The hosted deployment still claims agent {environmentId}, but its synced agent record
-							is missing. Runtime UI, terminal, sessions, and other agent data will become available
-							after the agent reconnects.
-						</AlertDescription>
-					</Alert>
-				) : status.kind === "stopped" ? (
-					<Alert data-hosted="true">
-						<AlertCircle />
-						<AlertTitle>Hosted compute is stopped</AlertTitle>
-						<AlertDescription>
-							The agent record is retained, but Runtime UI, terminal, sessions, and daemon status
-							are unavailable until compute starts again.
-						</AlertDescription>
-					</Alert>
-				) : isProvisioningStatus(status) ? (
-					<OverviewProvisioningPanel status={status} />
-				) : null}
-				{failed ? (
-					<OverviewFailedPanel deployment={deployment} restartLabel="Retry startup" />
-				) : null}
-				<div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-					<StatCard label="Status" value={deploymentStatusLabel(status)} />
-					<StatCard
-						label="Compute plan"
-						value={computeTierLabel(deployment.config_info?.compute_plan_slug)}
-					/>
-					<StatCard label="Created" value={formatShortDate(deployment.created_at)} />
-					<StatCard label="Runtime" value={runtimeDisplayName(runtime)} />
-				</div>
-				<SettingsSection
-					title="Deployment actions"
-					description={
-						agentProjectionMissing
-							? "Manage compute while synced agent data is unavailable."
-							: "Manage this hosted deployment while live agent tools are unavailable."
-					}
-				>
-					<div className="flex flex-wrap gap-2.5">
-						{canRestart && !failed ? <RestartComputeAction deployment={deployment} /> : null}
-						{canStart && !failed ? <StartComputeAction deployment={deployment} /> : null}
-						<DeleteComputeAction deployment={deployment} />
-					</div>
-				</SettingsSection>
-			</section>
-		</div>
-	);
-}
-
 function OverviewTab({
 	deployment,
 	agent,
 	runtime,
 	isPerformance,
+	showDeploymentActions,
+	projectionAvailable,
 	sessions,
 	sessionsLoading,
 	sessionsError,
@@ -887,6 +869,8 @@ function OverviewTab({
 	agent: components["schemas"]["AgentResponse"] | null | undefined;
 	runtime: Runtime;
 	isPerformance: boolean;
+	showDeploymentActions: boolean;
+	projectionAvailable: boolean;
 	sessions: SessionListItem[];
 	sessionsLoading: boolean;
 	sessionsError: unknown;
@@ -912,7 +896,9 @@ function OverviewTab({
 			{isProvisioningStatus(deploymentStatus) ? (
 				<OverviewProvisioningPanel status={deploymentStatus} />
 			) : null}
-			{deploymentStatus.kind === "failed" ? <OverviewFailedPanel deployment={deployment} /> : null}
+			{deploymentStatus.kind === "failed" ? (
+				<OverviewFailedPanel deployment={deployment} restartLabel="Retry startup" />
+			) : null}
 			<div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
 				<StatCard
 					label="Status"
@@ -927,7 +913,13 @@ function OverviewTab({
 			</div>
 			<div>
 				<div className="mb-2 text-sm font-medium">Recent sessions</div>
-				{sessionsError ? (
+				{!projectionAvailable ? (
+					<EmptyState
+						variant="inset"
+						title="Sessions unavailable"
+						description="Sessions depend on the synced agent record and will recover when it becomes available."
+					/>
+				) : sessionsError ? (
 					<ApiErrorPanel
 						error={sessionsError}
 						onRetry={onRetrySessions}
@@ -944,7 +936,29 @@ function OverviewTab({
 					/>
 				)}
 			</div>
+			{showDeploymentActions ? <OverviewDeploymentActions deployment={deployment} /> : null}
 		</div>
+	);
+}
+
+function OverviewDeploymentActions({ deployment }: { deployment: HostedDeployment }) {
+	const status = parseDeploymentStatus(deployment.status);
+	const failed = status.kind === "failed";
+	return (
+		<SettingsSection
+			title="Deployment actions"
+			description="Manage hosted compute independently of synced agent data."
+		>
+			<div className="flex flex-wrap gap-2.5">
+				{canRestartDeployment(status) && !failed ? (
+					<RestartComputeAction deployment={deployment} />
+				) : null}
+				{canStartDeployment(status) && !failed ? (
+					<StartComputeAction deployment={deployment} />
+				) : null}
+				<DeleteComputeAction deployment={deployment} />
+			</div>
+		</SettingsSection>
 	);
 }
 
@@ -1011,25 +1025,42 @@ function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; run
 	const label = runtimeDisplayName(runtime);
 	const browserUiLabel = runtimeBrowserUiLabel(runtime);
 	const url = runtimeConsoleUrl(deployment, runtime);
+	const canOpenRuntimeUi = canOpenHostedRuntimeUi(deployment.status, url);
 	const redemption = useCreateRuntimeUiRedemption();
 	const [frameUrl, setFrameUrl] = useState<string | null>(null);
+	const [frameError, setFrameError] = useState<Error | null>(null);
+	const [redemptionAttempt, setRedemptionAttempt] = useState(0);
+	const startedRedemptionRef = useRef<string | null>(null);
 
 	useEffect(() => {
+		if (!canOpenRuntimeUi || !url) {
+			startedRedemptionRef.current = null;
+			setFrameUrl(null);
+			setFrameError(null);
+			return;
+		}
+		const attemptKey = `${deployment.id}:${url}:${redemptionAttempt}`;
+		if (startedRedemptionRef.current === attemptKey) return;
+		startedRedemptionRef.current = attemptKey;
 		setFrameUrl(null);
-		if (!isRunning || !url) return;
-		let cancelled = false;
+		setFrameError(null);
 		redemption
 			.mutateAsync({ id: deployment.id })
 			.then((result) => {
-				if (!cancelled) setFrameUrl(result.url);
+				if (startedRedemptionRef.current === attemptKey) setFrameUrl(result.url);
 			})
-			.catch(() => {
-				if (!cancelled) setFrameUrl(null);
+			.catch((error: unknown) => {
+				if (startedRedemptionRef.current !== attemptKey) return;
+				setFrameError(error instanceof Error ? error : new Error("Runtime UI redemption failed"));
 			});
-		return () => {
-			cancelled = true;
-		};
-	}, [deployment.id, isRunning, redemption.mutateAsync, url]);
+	}, [canOpenRuntimeUi, deployment.id, redemption.mutateAsync, redemptionAttempt, url]);
+
+	const retryRedemption = () => {
+		redemption.reset();
+		setFrameUrl(null);
+		setFrameError(null);
+		setRedemptionAttempt((attempt) => attempt + 1);
+	};
 
 	// Not running yet — the runtime UI and bridge only exist once the agent boots.
 	if (!isRunning) {
@@ -1077,7 +1108,18 @@ function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; run
 		>
 			{/* Desktop: embed the live UI. Mobile is too cramped, so offer the
 			    full-screen link instead. */}
-			{frameUrl ? (
+			{frameError ? (
+				<div className="flex min-h-[420px] flex-1 items-center justify-center p-6">
+					<div className="w-full max-w-xl">
+						<ApiErrorPanel
+							error={frameError}
+							onRetry={retryRedemption}
+							normalizer={billingErrorNormalizer}
+							title="Couldn't load Runtime UI"
+						/>
+					</div>
+				</div>
+			) : frameUrl ? (
 				<iframe
 					key={`${runtime}:${frameUrl}`}
 					src={frameUrl}
@@ -1090,20 +1132,22 @@ function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; run
 					<Spinner className="size-4 text-muted-foreground" />
 				</div>
 			)}
-			<div className="flex min-h-[420px] flex-1 flex-col items-center justify-center gap-3 p-6 text-center sm:hidden">
-				<p className="text-sm text-muted-foreground">
-					This runtime UI is best viewed full screen on a small screen.
-				</p>
-				<RuntimeUiOpenButton
-					deployment={deployment}
-					label={browserUiLabel}
-					variant="outline"
-					size="sm"
-				>
-					Open {browserUiLabel}
-					<Maximize2 className="size-3.5" />
-				</RuntimeUiOpenButton>
-			</div>
+			{frameError ? null : (
+				<div className="flex min-h-[420px] flex-1 flex-col items-center justify-center gap-3 p-6 text-center sm:hidden">
+					<p className="text-sm text-muted-foreground">
+						This runtime UI is best viewed full screen on a small screen.
+					</p>
+					<RuntimeUiOpenButton
+						deployment={deployment}
+						label={browserUiLabel}
+						variant="outline"
+						size="sm"
+					>
+						Open {browserUiLabel}
+						<Maximize2 className="size-3.5" />
+					</RuntimeUiOpenButton>
+				</div>
+			)}
 		</LiveToolFrame>
 	);
 }
@@ -2148,14 +2192,20 @@ function HostedAgentSettingsTab({
 	environmentId,
 	deployment,
 	runtime,
+	projectionAvailable,
 }: {
 	environmentId: string;
 	deployment: HostedDeployment;
 	runtime: Runtime;
+	projectionAvailable: boolean;
 }) {
 	return (
 		<div className="flex flex-col gap-10">
-			<AgentSettingsPanel environmentId={environmentId} />
+			{projectionAvailable ? (
+				<AgentSettingsPanel environmentId={environmentId} />
+			) : (
+				<ProjectionDependentUnavailable label="Profile settings" />
+			)}
 			<LanguageTimezoneSettingsSection deployment={deployment} runtime={runtime} />
 			<ComputeSettingsSections deployment={deployment} />
 		</div>

--- a/apps/web/src/hosted/agents/ownership-sensor.ts
+++ b/apps/web/src/hosted/agents/ownership-sensor.ts
@@ -6,8 +6,9 @@ import { isDeployApiConfigured, useBillingClient } from "@/hosted/billing/billin
 import { BillingApiError, billingQueryRetry } from "@/hosted/billing/errors";
 // (BillingApiError kept for the retry policy only — a 404 is not worth
 // retrying, but it is NOT a definitive answer either; see useLegacyEnvIds.)
-import { billingKeys, useHostedDeployments } from "@/hosted/billing/hooks";
-import { claimedEnvIdsFromDeployments } from "@/hosted/use-hosted-agent-tiles";
+import { billingKeys } from "@/hosted/billing/hooks";
+import { claimedEnvIdsFromDeployments } from "@/hosted/hosted-agent-resolution";
+import { useHostedDeploymentInventory } from "@/hosted/use-hosted-deployment-inventory";
 import type { AgentOwnership } from "@/lib/agent-ownership";
 import { normalizeAgentEnvId } from "@/lib/agent-ownership";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
@@ -55,31 +56,32 @@ export function useLegacyEnvIds(): ReadonlySet<string> | null {
  * Reports cloud-api environment ids managed by hosted-only control planes.
  *
  * The OSS dashboard receives only this neutral ownership context. Deploy API
- * reads stay quarantined in `apps/web/src/hosted/`. Only successful data
- * resolves a set; every error — 404 (route not deployed yet) included —
- * leaves ownership `null` so destructive actions fail closed while cosmetic
- * consumers fall back to connected.
+ * reads stay quarantined in `apps/web/src/hosted/`. A successful inventory
+ * resolves connected classification. During loading or an error, last-known
+ * external ids remain classified while every unknown id fails closed as
+ * unresolved.
  */
 export function HostedAgentOwnershipSensor({
 	onChange,
 }: {
 	onChange: (ownership: AgentOwnership | null) => void;
 }) {
-	const cloudQuery = useHostedDeployments();
+	const cloudInventory = useHostedDeploymentInventory();
 	const legacyEnvIds = useLegacyEnvIds();
 
-	const cloudEnvIds = useMemo(() => {
-		if (!isDeployApiConfigured()) return EMPTY_ENV_IDS;
-		// Fresh/stale data resolves; errors or pending leave the set
-		// UNRESOLVED so destructive consumers fail closed.
-		if (cloudQuery.data) return claimedEnvIdsFromDeployments(cloudQuery.data);
-		return null;
-	}, [cloudQuery.data, cloudQuery.error, cloudQuery.isPending]);
+	const cloudEnvIds = useMemo(
+		() => claimedEnvIdsFromDeployments(cloudInventory.deployments ?? []),
+		[cloudInventory.deployments],
+	);
 
-	const ownership = useMemo<AgentOwnership | null>(() => {
-		if (!cloudEnvIds || !legacyEnvIds) return null;
-		return { cloudEnvIds, legacyEnvIds };
-	}, [cloudEnvIds, legacyEnvIds]);
+	const ownership = useMemo<AgentOwnership>(
+		() => ({
+			cloudEnvIds,
+			legacyEnvIds: legacyEnvIds ?? EMPTY_ENV_IDS,
+			isResolved: cloudInventory.status === "resolved" && legacyEnvIds !== null,
+		}),
+		[cloudEnvIds, cloudInventory.status, legacyEnvIds],
+	);
 
 	useEffect(() => {
 		onChange(ownership);

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -30,7 +30,7 @@ import type {
 } from "@/hosted/billing/contracts";
 import { billingQueryRetry } from "@/hosted/billing/errors";
 import { billingKeys } from "@/hosted/billing/query-keys";
-import { shouldPollDeployments } from "@/hosted/deployment-status";
+import { deploymentRefetchInterval } from "@/hosted/deployment-status";
 
 export { billingKeys } from "@/hosted/billing/query-keys";
 
@@ -476,9 +476,13 @@ export function useHostedDeployments({
 		enabled: isDeployApiConfigured() && enabled,
 		queryFn: () => client.listDeployments(),
 		refetchInterval: (q) => {
-			if (shouldPollDeployments(q.state.data)) return 10_000;
-			return walletDunningRefetchIntervalFor(q.state.data, pollWalletDunningFor);
+			const inventoryInterval = deploymentRefetchInterval(q.state.data);
+			const walletInterval = walletDunningRefetchIntervalFor(q.state.data, pollWalletDunningFor);
+			return typeof walletInterval === "number"
+				? Math.min(inventoryInterval, walletInterval)
+				: inventoryInterval;
 		},
+		refetchIntervalInBackground: false,
 	});
 }
 
@@ -488,9 +492,9 @@ export function useCreateDeployment() {
 	return useMutation({
 		mutationFn: ({ body, idempotencyKey }: CreateDeploymentMutationVariables) =>
 			client.createDeployment(body, idempotencyKey),
-		onSuccess: () => {
-			qc.invalidateQueries({ queryKey: billingKeys.deployments });
-			qc.invalidateQueries({ queryKey: ["agents"] });
+		onSettled: () => {
+			void qc.invalidateQueries({ queryKey: billingKeys.deployments });
+			void qc.invalidateQueries({ queryKey: ["agents"] });
 		},
 	});
 }

--- a/apps/web/src/hosted/deployment-status.test.ts
+++ b/apps/web/src/hosted/deployment-status.test.ts
@@ -3,6 +3,9 @@ import {
 	canRestart,
 	canStart,
 	canStop,
+	DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS,
+	DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS,
+	deploymentRefetchInterval,
 	deploymentStatusLabel,
 	deploymentStatusTone,
 	isRunningStatus,
@@ -119,5 +122,11 @@ describe("DeploymentStatus", () => {
 		expect(shouldPollDeployments([{ status: "new_backend_status" }])).toBe(true);
 		expect(shouldPollDeployments([])).toBe(false);
 		expect(shouldPollDeployments(undefined)).toBe(false);
+		expect(deploymentRefetchInterval([{ status: "running" }])).toBe(
+			DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS,
+		);
+		expect(deploymentRefetchInterval([{ status: "starting" }])).toBe(
+			DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS,
+		);
 	});
 });

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -25,6 +25,9 @@ export type UnknownDeploymentStatus = {
 
 export type DeploymentStatus = KnownDeploymentStatusModel | UnknownDeploymentStatus;
 
+export const DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS = 10_000;
+export const DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS = 75_000;
+
 const KNOWN_STATUS_SET = new Set<string>(KNOWN_DEPLOYMENT_STATUSES);
 const LEGACY_STATUS_ALIASES = new Map<string, KnownDeploymentStatus>([["ready", "running"]]);
 
@@ -231,6 +234,18 @@ export function shouldPollDeployments(
 	return (items ?? []).some((deployment) =>
 		isTransitionalStatus(parseDeploymentStatus(deployment.status)),
 	);
+}
+
+/**
+ * Transitional deployments converge quickly; stable snapshots still reconcile
+ * periodically so changes made in another tab or control plane become visible.
+ */
+export function deploymentRefetchInterval(
+	items: readonly { status: string | null | undefined }[] | null | undefined,
+): number {
+	return shouldPollDeployments(items)
+		? DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS
+		: DEPLOYMENT_RECONCILIATION_POLL_INTERVAL_MS;
 }
 
 function titleCaseStatus(raw: string): string {

--- a/apps/web/src/hosted/hosted-agent-resolution.test.ts
+++ b/apps/web/src/hosted/hosted-agent-resolution.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "bun:test";
+import type { HostedDeployment } from "@/hosted/billing/contracts";
+import { BillingApiError, BillingNetworkError } from "@/hosted/billing/errors";
+import {
+	canOpenHostedRuntimeUi,
+	hostedDeploymentMembers,
+	missingProjectionRefetchInterval,
+	resolveHostedAgentProjection,
+	resolveHostedInventory,
+} from "@/hosted/hosted-agent-resolution";
+import { ApiError } from "@/lib/api-errors";
+
+function deployment(status = "running", id = `dep_${status}`): HostedDeployment {
+	return {
+		id,
+		user_id: "user_123",
+		name: id,
+		app_id: "app_123",
+		backend: null,
+		status,
+		endpoints: [],
+		openclaw_control_ui_url: "https://runtime.example/ui",
+		hermes_control_ui_url: null,
+		config_info: {
+			compute_plan_slug: "compute_basic",
+			mux_enabled: true,
+			telegram_mux_enabled: false,
+			discord_mux_enabled: false,
+			whatsapp_mux_enabled: false,
+			imessage_mux_enabled: false,
+			kobb_available: false,
+			primary_model: null,
+			ai_provider_id: null,
+			ai_provider_auth_kind: "managed",
+			public_ports: [],
+			runtime: "openclaw",
+			clawdi_cloud_environments: {},
+			vcpu: null,
+			ram_gb: null,
+			disk_gb: null,
+		},
+		created_at: "2026-07-16T00:00:00Z",
+		upgrade_available: false,
+	};
+}
+
+describe("hosted inventory resolution matrix", () => {
+	test("distinguishes a successful empty snapshot from loading", () => {
+		expect(
+			resolveHostedInventory({
+				enabled: true,
+				configured: true,
+				data: [],
+				error: null,
+				isPending: false,
+			}),
+		).toMatchObject({ status: "resolved", deployments: [], hasSnapshot: true, error: null });
+
+		expect(
+			resolveHostedInventory({
+				enabled: true,
+				configured: true,
+				data: undefined,
+				error: null,
+				isPending: true,
+			}),
+		).toMatchObject({ status: "loading", deployments: null, hasSnapshot: false, error: null });
+	});
+
+	test("keeps 403 and transport failures unresolved instead of inventing an empty list", () => {
+		const forbidden = resolveHostedInventory({
+			enabled: true,
+			configured: true,
+			data: undefined,
+			error: new BillingApiError(403, "deployment access revoked"),
+			isPending: false,
+		});
+		expect(forbidden).toMatchObject({ status: "error", deployments: null, hasSnapshot: false });
+
+		const offline = resolveHostedInventory({
+			enabled: true,
+			configured: true,
+			data: undefined,
+			error: new BillingNetworkError("offline"),
+			isPending: false,
+		});
+		expect(offline).toMatchObject({
+			status: "unavailable",
+			deployments: null,
+			hasSnapshot: false,
+		});
+	});
+
+	test("retains a last-known snapshot on refresh failure and removes deleted membership", () => {
+		const running = deployment("running");
+		const deleted = deployment("deleted");
+		const result = resolveHostedInventory({
+			enabled: true,
+			configured: true,
+			data: [running, deleted],
+			error: new BillingApiError(500, "upstream unavailable"),
+			isPending: false,
+		});
+
+		expect(result.status).toBe("error");
+		expect(result.hasSnapshot).toBe(true);
+		expect(result.deployments?.map((item) => item.id)).toEqual([running.id]);
+		expect(hostedDeploymentMembers([deleted])).toEqual([]);
+	});
+
+	test("treats a disabled source as a resolved empty inventory", () => {
+		expect(
+			resolveHostedInventory({
+				enabled: false,
+				configured: false,
+				data: undefined,
+				error: null,
+				isPending: true,
+			}),
+		).toEqual({ status: "resolved", deployments: [], hasSnapshot: true, error: null });
+	});
+});
+
+describe("hosted detail projection resolution", () => {
+	test("keeps missing, service-error, loading, unavailable, and resolved states distinct", () => {
+		const notFound = new ApiError(404, "Agent not found");
+		const serviceError = new ApiError(500, "gateway failure");
+		const agent = { id: "agent_123" };
+
+		expect(
+			resolveHostedAgentProjection({
+				enabled: true,
+				data: undefined,
+				error: notFound,
+				isPending: false,
+			}),
+		).toEqual({ status: "missing", data: null, error: notFound });
+		expect(
+			resolveHostedAgentProjection({
+				enabled: true,
+				data: agent,
+				error: serviceError,
+				isPending: false,
+			}),
+		).toEqual({ status: "error", data: null, error: serviceError });
+		expect(
+			resolveHostedAgentProjection({
+				enabled: true,
+				data: undefined,
+				error: null,
+				isPending: true,
+			}),
+		).toEqual({ status: "loading", data: null, error: null });
+		expect(
+			resolveHostedAgentProjection({
+				enabled: false,
+				data: undefined,
+				error: null,
+				isPending: true,
+			}),
+		).toEqual({ status: "unavailable", data: null, error: null });
+		expect(
+			resolveHostedAgentProjection({ enabled: true, data: agent, error: null, isPending: false }),
+		).toEqual({ status: "resolved", data: agent, error: null });
+	});
+
+	test("uses capped backoff only while a missing projection can still recover", () => {
+		const notFound = new ApiError(404, "Agent not found");
+		expect(missingProjectionRefetchInterval(notFound, "running", 1)).toBe(5_000);
+		expect(missingProjectionRefetchInterval(notFound, "starting", 3)).toBe(20_000);
+		expect(missingProjectionRefetchInterval(notFound, "running", 99)).toBe(60_000);
+		expect(missingProjectionRefetchInterval(notFound, "stopped", 1)).toBe(false);
+		expect(missingProjectionRefetchInterval(new ApiError(500, "failure"), "running", 1)).toBe(
+			false,
+		);
+	});
+
+	test("gates every Runtime UI entry point on deployment running status", () => {
+		expect(canOpenHostedRuntimeUi("running", "https://runtime.example/ui")).toBe(true);
+		expect(canOpenHostedRuntimeUi("ready", "https://runtime.example/ui")).toBe(true);
+		expect(canOpenHostedRuntimeUi("stopped", "https://runtime.example/ui")).toBe(false);
+		expect(canOpenHostedRuntimeUi("failed", "https://runtime.example/ui")).toBe(false);
+		expect(canOpenHostedRuntimeUi("running", null)).toBe(false);
+	});
+});

--- a/apps/web/src/hosted/hosted-agent-resolution.ts
+++ b/apps/web/src/hosted/hosted-agent-resolution.ts
@@ -1,0 +1,202 @@
+import type { HostedDeployment } from "@/hosted/billing/contracts";
+import { isNetworkError } from "@/hosted/billing/errors";
+import {
+	isRunningStatus,
+	isTransitionalStatus,
+	parseDeploymentStatus,
+} from "@/hosted/deployment-status";
+import { runtimeEnvironmentId } from "@/hosted/runtimes";
+import { isApiNotFoundError } from "@/lib/api-errors";
+
+export type HostedInventoryStatus = "resolved" | "loading" | "error" | "unavailable";
+
+export type HostedInventoryResolution = {
+	status: HostedInventoryStatus;
+	/**
+	 * The last successful membership snapshot, with deleted deployments removed.
+	 * `null` means membership has never resolved; an empty array is authoritative.
+	 */
+	deployments: HostedDeployment[] | null;
+	hasSnapshot: boolean;
+	error: Error | null;
+};
+
+export type HostedInventoryQueryState = {
+	enabled: boolean;
+	configured: boolean;
+	data: HostedDeployment[] | undefined;
+	error: Error | null;
+	isPending: boolean;
+};
+
+export class HostedInventoryUnavailableError extends Error {
+	constructor() {
+		super("Clawdi Cloud inventory is unavailable from this dashboard.");
+		this.name = "HostedInventoryUnavailableError";
+	}
+}
+
+/** Deleted deployments stop owning an agent as soon as the deploy API says so. */
+export function isHostedDeploymentMember(deployment: HostedDeployment): boolean {
+	return parseDeploymentStatus(deployment.status).kind !== "deleted";
+}
+
+export function hostedDeploymentMembers(
+	deployments: readonly HostedDeployment[],
+): HostedDeployment[] {
+	return deployments.filter(isHostedDeploymentMember);
+}
+
+/** One claimed-id set shared by list deduplication and ownership chrome. */
+export function claimedEnvIdsFromDeployments(
+	deployments: readonly HostedDeployment[],
+): Set<string> {
+	const environmentIds = new Set<string>();
+	for (const deployment of deployments) {
+		if (!isHostedDeploymentMember(deployment)) continue;
+		const environmentId = runtimeEnvironmentId(deployment.config_info);
+		if (environmentId) environmentIds.add(environmentId.toLowerCase());
+	}
+	return environmentIds;
+}
+
+export type AgentDeploymentMatch = {
+	deployment: HostedDeployment;
+	runtime: string | null;
+};
+
+export type AgentDeploymentResolution = {
+	match: AgentDeploymentMatch | null;
+	ambiguousMatches: AgentDeploymentMatch[];
+};
+
+/** Resolve detail membership from deployment identity, never from projection presence. */
+export function resolveAgentDeployment(
+	deployments: readonly HostedDeployment[],
+	environmentId: string,
+	deploymentSelector?: string | null,
+): AgentDeploymentResolution {
+	const members = hostedDeploymentMembers(deployments);
+	const target = environmentId.toLowerCase();
+	const direct = members.find((deployment) => deployment.id.toLowerCase() === target);
+	if (direct) {
+		return { match: { deployment: direct, runtime: null }, ambiguousMatches: [] };
+	}
+
+	const matches: AgentDeploymentMatch[] = [];
+	for (const deployment of members) {
+		const environments = deployment.config_info?.clawdi_cloud_environments ?? {};
+		const runtime = Object.entries(environments).find(
+			([, value]) => (value ?? "").toLowerCase() === target,
+		);
+		if (runtime) matches.push({ deployment, runtime: runtime[0] });
+	}
+
+	if (deploymentSelector) {
+		const selector = deploymentSelector.toLowerCase();
+		const selected = matches.find((item) => item.deployment.id.toLowerCase() === selector);
+		if (selected) return { match: selected, ambiguousMatches: [] };
+	}
+
+	if (matches.length === 1) return { match: matches[0], ambiguousMatches: [] };
+	return { match: null, ambiguousMatches: matches };
+}
+
+/**
+ * Convert the deployments query into the one inventory state consumed by all
+ * dashboard surfaces. Successful empty data is distinct from an unresolved
+ * source, and a failed refresh retains the last successful snapshot.
+ */
+export function resolveHostedInventory({
+	enabled,
+	configured,
+	data,
+	error,
+	isPending,
+}: HostedInventoryQueryState): HostedInventoryResolution {
+	if (!enabled) {
+		return { status: "resolved", deployments: [], hasSnapshot: true, error: null };
+	}
+
+	if (!configured) {
+		return {
+			status: "unavailable",
+			deployments: null,
+			hasSnapshot: false,
+			error: new HostedInventoryUnavailableError(),
+		};
+	}
+
+	const deployments = data === undefined ? null : hostedDeploymentMembers(data);
+	if (error) {
+		return {
+			status: isNetworkError(error) ? "unavailable" : "error",
+			deployments,
+			hasSnapshot: deployments !== null,
+			error,
+		};
+	}
+
+	if (deployments !== null) {
+		return { status: "resolved", deployments, hasSnapshot: true, error: null };
+	}
+
+	return {
+		status: isPending ? "loading" : "unavailable",
+		deployments: null,
+		hasSnapshot: false,
+		error: isPending ? null : new HostedInventoryUnavailableError(),
+	};
+}
+
+export type HostedProjectionResolution<T> =
+	| { status: "resolved"; data: T; error: null }
+	| { status: "loading"; data: null; error: null }
+	| { status: "missing"; data: null; error: Error }
+	| { status: "error"; data: null; error: Error }
+	| { status: "unavailable"; data: null; error: null };
+
+export function resolveHostedAgentProjection<T>({
+	enabled,
+	data,
+	error,
+	isPending,
+}: {
+	enabled: boolean;
+	data: T | undefined;
+	error: Error | null;
+	isPending: boolean;
+}): HostedProjectionResolution<T> {
+	if (!enabled) return { status: "unavailable", data: null, error: null };
+	if (error) {
+		return isApiNotFoundError(error)
+			? { status: "missing", data: null, error }
+			: { status: "error", data: null, error };
+	}
+	if (data !== undefined) return { status: "resolved", data, error: null };
+	if (isPending) return { status: "loading", data: null, error: null };
+	return { status: "unavailable", data: null, error: null };
+}
+
+const PROJECTION_MISSING_BACKOFF_MS = [5_000, 10_000, 20_000, 30_000, 60_000] as const;
+
+/** Bounded, foreground-only reconciliation cadence for a lagging projection. */
+export function missingProjectionRefetchInterval(
+	error: Error | null,
+	deploymentStatus: string | null | undefined,
+	failureCount: number,
+): number | false {
+	if (!error || !isApiNotFoundError(error)) return false;
+	const status = parseDeploymentStatus(deploymentStatus);
+	if (!isRunningStatus(status) && !isTransitionalStatus(status)) return false;
+	const index = Math.min(Math.max(failureCount - 1, 0), PROJECTION_MISSING_BACKOFF_MS.length - 1);
+	return PROJECTION_MISSING_BACKOFF_MS[index] ?? false;
+}
+
+/** The same authoritative gate is shared by header and inline Runtime UI actions. */
+export function canOpenHostedRuntimeUi(
+	deploymentStatus: string | null | undefined,
+	consoleUrl: string | null | undefined,
+): boolean {
+	return Boolean(consoleUrl) && isRunningStatus(parseDeploymentStatus(deploymentStatus));
+}

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -230,15 +230,27 @@ describe("deploymentToTiles", () => {
 			source: "on-clawdi",
 			href: `/agents/${environmentId}?source=on-clawdi&d=dep_123`,
 			env: null,
+			contextLabel: "hosted-test",
 			secondaryStatus: {
 				label: "Failure: startup_probe_failing; restart_count=2",
 				title: failureReason,
 				textClass: "text-destructive-muted-foreground font-medium",
 			},
 		});
-		expect(tile?.manageHref).toBeUndefined();
+		expect(tile?.manageHref).toBe(`/agents/${environmentId}/settings?source=on-clawdi&d=dep_123`);
 		expect(tile?.action).toBeUndefined();
 		expect(JSON.stringify(tile)).not.toContain("/agents/dep_123");
+	});
+
+	test("removes deleted deployments from tiles and detail membership", () => {
+		const environmentId = "55555555-5555-4555-8555-555555555555";
+		const deleted = deployment(
+			{ status: "deleted" },
+			{ clawdi_cloud_environments: { openclaw: environmentId } },
+		);
+
+		expect(hostedDeploymentToTiles(deleted)).toEqual([]);
+		expect(resolveAgentDeployment([deleted], environmentId).match).toBeNull();
 	});
 
 	test("keeps a deployment without an env identity non-navigable but exposes delete", () => {

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -1,21 +1,13 @@
 "use client";
 
 import type { components } from "@clawdi/shared/api";
-import { useQuery } from "@tanstack/react-query";
 import { createElement, useMemo } from "react";
 import { agentDisplayName } from "@/components/dashboard/agent-label";
 import type { AgentTile } from "@/components/dashboard/agents-card";
-import {
-	DaemonStatusBadge,
-	type DaemonStatusVisual,
-	daemonStatusVisual,
-} from "@/components/dashboard/daemon-status";
+import { type DaemonStatusVisual, daemonStatusVisual } from "@/components/dashboard/daemon-status";
 import { deploymentDisplayName } from "@/hosted/agent-identity";
-import { isDeployApiConfigured, useBillingClient } from "@/hosted/billing/billing-client";
 import { computeDunningTileStatus } from "@/hosted/billing/components/compute-dunning.logic";
 import type { HostedDeployment } from "@/hosted/billing/contracts";
-import { billingQueryRetry, isNetworkError } from "@/hosted/billing/errors";
-import { billingKeys } from "@/hosted/billing/hooks";
 import { hasExistingCloudDeployments } from "@/hosted/cloud-deployment-management";
 import {
 	compactDeploymentFailureReason,
@@ -28,15 +20,20 @@ import {
 	deploymentStatusTone,
 	isRunningStatus,
 	parseDeploymentStatus,
-	shouldPollDeployments,
 } from "@/hosted/deployment-status";
+import {
+	claimedEnvIdsFromDeployments,
+	isHostedDeploymentMember,
+} from "@/hosted/hosted-agent-resolution";
 import { HostedDeploymentTileDeleteAction } from "@/hosted/hosted-deployment-tile-action";
 import { deploymentRuntime, runtimeDisplayName, runtimeEnvironmentId } from "@/hosted/runtimes";
-import { normalizeAgentEnvId } from "@/lib/agent-ownership";
+import { useHostedDeploymentInventory } from "@/hosted/use-hosted-deployment-inventory";
 import { AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY, agentSectionHref } from "@/lib/agent-routes";
 
 type Env = components["schemas"]["AgentResponse"];
 type DeploymentStatusInput = Pick<HostedDeployment, "status" | "failure_reason">;
+
+const EMPTY_DEPLOYMENTS: HostedDeployment[] = [];
 
 const COMPUTE_DOT_TONE: Record<DeploymentStatusTone, string> = {
 	success: "bg-success ring-2 ring-success/20",
@@ -112,23 +109,6 @@ export function hostedRuntimeStatusView(
 }
 
 /**
- * Env ids claimed by Cloud deploy-API deployments (lower-cased —
- * see the case note on `envById`). Shared by the tile dedup here and
- * the sidebar's cloud-vs-legacy chrome classification so the two can
- * never disagree about which externally managed env is a Cloud agent.
- */
-export function claimedEnvIdsFromDeployments(
-	deployments: readonly HostedDeployment[],
-): Set<string> {
-	const s = new Set<string>();
-	for (const d of deployments) {
-		const envId = runtimeEnvironmentId(d.config_info);
-		if (envId) s.add(envId.toLowerCase());
-	}
-	return s;
-}
-
-/**
  * Bridges hosted deploy API `Deployment` records to the unified `AgentTile`
  * shape rendered by `AgentsCard`. Hosted-side projection lives here so
  * `AgentsCard` itself never imports from `@/hosted/*`.
@@ -150,21 +130,8 @@ export function useHostedAgentTiles({
 	cloudEnvs: Env[];
 	includeDeployments?: boolean;
 }) {
-	const client = useBillingClient();
-	// Not configured (preview/self-hosted mirror pointing at the default
-	// localhost deploy API) → don't fetch, don't error-banner. See
-	// isDeployApiConfigured.
-	const configured = isDeployApiConfigured();
-	const query = useQuery<HostedDeployment[], Error>({
-		queryKey: billingKeys.deployments,
-		enabled: configured && includeDeployments,
-		queryFn: () => client.listDeployments(),
-		retry: billingQueryRetry,
-		// Poll while deployments are unsettled. The deploy API status is a string,
-		// so unknown future states are treated as non-terminal until a settled
-		// state arrives.
-		refetchInterval: (q) => (shouldPollDeployments(q.state.data) ? 10_000 : false),
-	});
+	const inventory = useHostedDeploymentInventory({ enabled: includeDeployments });
+	const deployments = inventory.deployments ?? EMPTY_DEPLOYMENTS;
 
 	// Memoize the env-by-id index so the tile join is O(N+M) instead
 	// of O(N×M) on every render of the hosted-agent grid.
@@ -181,16 +148,14 @@ export function useHostedAgentTiles({
 		return m;
 	}, [cloudEnvs]);
 
-	// Both `tiles` and `claimedEnvIds` derive from `query.data`. Memoize
+	// Both `tiles` and `claimedEnvIds` derive from the last resolved inventory. Memoize
 	// them so refetchInterval (10s for transient deployments) doesn't
 	// rebuild N×M JSX trees on every poll when nothing actually changed.
 	// TanStack Query gives the same `data` reference back on no-op
 	// refetches, so the memo deps stay stable.
 	const tiles = useMemo<AgentTile[]>(() => {
-		return includeDeployments
-			? (query.data ?? []).flatMap((d) => deploymentToTiles(d, envById))
-			: [];
-	}, [includeDeployments, query.data, envById]);
+		return includeDeployments ? deployments.flatMap((d) => deploymentToTiles(d, envById)) : [];
+	}, [deployments, includeDeployments, envById]);
 
 	// Env ids that are owned by a hosted deployment. The dashboard
 	// excludes these from its self-managed grid so a hosted deployment's env
@@ -200,26 +165,18 @@ export function useHostedAgentTiles({
 	// case-sensitivity defense as `envById`.
 	const claimedEnvIds = useMemo(() => {
 		if (!includeDeployments) return new Set<string>();
-		return claimedEnvIdsFromDeployments(query.data ?? []);
-	}, [includeDeployments, query.data]);
-
-	// CORS/network-level failures (fetch throws TypeError before any HTTP
-	// response is readable) mean this origin can't talk to the deploy API
-	// at all. That is "hosted isn't available here," not an outage: stay
-	// silent. Readable HTTP errors (5xx/4xx from an allowed origin) keep
-	// the banner — those are real failures on hosts where the integration
-	// genuinely works.
-	const unreachableFromOrigin = isNetworkError(query.error);
+		return claimedEnvIdsFromDeployments(deployments);
+	}, [deployments, includeDeployments]);
 
 	return {
-		hasExistingDeployments: includeDeployments && hasExistingCloudDeployments(query.data),
+		inventoryStatus: inventory.status,
+		hasExistingDeployments:
+			includeDeployments && hasExistingCloudDeployments(inventory.deployments),
 		tiles,
 		claimedEnvIds,
-		// Disabled queries report isLoading=true forever in v5 (status
-		// stays 'pending'); mask both flags when we never fetch.
-		isLoading: configured && includeDeployments ? query.isLoading : false,
-		error: configured && includeDeployments && !unreachableFromOrigin ? query.error : null,
-		refetch: query.refetch,
+		isLoading: inventory.status === "loading" && !inventory.hasSnapshot,
+		error: inventory.error,
+		refetch: inventory.refetch,
 	};
 }
 
@@ -229,6 +186,7 @@ export function useHostedAgentTiles({
  * only decorates the tile with daemon sync state and presentation metadata.
  */
 export function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>): AgentTile[] {
+	if (!isHostedDeploymentMember(d)) return [];
 	const runtime = deploymentRuntime(d);
 	const slug = deploymentDisplayName(d.name);
 	// Hosted deployments don't use last_seen_at; status is the freshness signal
@@ -241,9 +199,7 @@ export function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>
 		[AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY]: d.id,
 	};
 	const detailHref = envId ? agentSectionHref(envId, "overview", routeQuery) : null;
-	const settingsHref = matchedEnv
-		? agentSectionHref(matchedEnv.id, "settings", routeQuery)
-		: undefined;
+	const settingsHref = envId ? agentSectionHref(envId, "settings", routeQuery) : undefined;
 	const name = matchedEnv ? agentDisplayName(matchedEnv) : runtimeDisplayName(runtime);
 	const contextLabel = slug !== name ? slug : null;
 	const runtimeStatus = hostedRuntimeStatusView(d, matchedEnv ?? null);
@@ -298,125 +254,4 @@ export function hostedAgentTileStatus(rawStatus: string): { label: string; activ
 		label: deploymentStatusLabel(status),
 		active: isRunningStatus(status),
 	};
-}
-
-export function HostedFocusRuntimeStatusBadge({
-	env,
-	manageHref,
-	compact = false,
-	tooltipDetail,
-}: {
-	env: Env;
-	manageHref?: string;
-	compact?: boolean;
-	tooltipDetail?: string;
-}) {
-	const hosted = useHostedAgentTiles({ cloudEnvs: [env] });
-	const envId = normalizeAgentEnvId(env.id);
-	const tile = hosted.tiles.find((item) => normalizeAgentEnvId(item.env?.id) === envId);
-	if (!tile?.statusDot) {
-		if (hosted.isLoading) return createLoadingStatus(compact);
-		return createElement(DaemonStatusBadge, {
-			env,
-			source: "on-clawdi",
-			manageHref,
-			compact,
-			tooltipDetail,
-		});
-	}
-
-	return createElement(
-		"span",
-		{
-			className: "inline-flex min-w-0 items-center gap-1.5 whitespace-nowrap text-muted-foreground",
-			title: tile.secondaryStatus?.title ?? tile.statusDot.label,
-		},
-		createElement("span", {
-			key: "dot",
-			"aria-hidden": true,
-			className: `inline-block size-1.5 shrink-0 rounded-full ${tile.statusDot.dotClass}`,
-		}),
-		createElement(
-			"span",
-			{
-				key: "primary",
-				className: "whitespace-nowrap",
-			},
-			tile.statusDot.label,
-		),
-		createSecondarySyncStatus({
-			key: "secondary",
-			tile,
-			env,
-			manageHref,
-			tooltipDetail,
-		}),
-	);
-}
-
-function createLoadingStatus(compact: boolean) {
-	return createElement(
-		"span",
-		{
-			className: "inline-flex items-center gap-1.5 whitespace-nowrap text-muted-foreground",
-		},
-		createElement("span", {
-			key: "dot",
-			"aria-hidden": true,
-			className:
-				"inline-block size-1.5 rounded-full border border-muted-foreground/50 bg-transparent",
-		}),
-		createElement("span", { key: "label" }, compact ? "Loading" : "Loading status"),
-	);
-}
-
-function createSecondarySyncStatus({
-	key,
-	tile,
-	env,
-	manageHref,
-	tooltipDetail,
-}: {
-	key: string;
-	tile: AgentTile;
-	env: Env;
-	manageHref?: string;
-	tooltipDetail?: string;
-}) {
-	if (!tile.secondaryStatus) return null;
-	const label = tile.secondaryStatus.label;
-	return createElement(
-		"span",
-		{
-			key,
-			className: "inline-flex min-w-0 items-center gap-1.5",
-		},
-		createElement(
-			"span",
-			{
-				key: "separator",
-				className: "text-muted-foreground/70",
-				"aria-hidden": true,
-			},
-			"·",
-		),
-		tile.env
-			? createElement(DaemonStatusBadge, {
-					key: "badge",
-					env,
-					source: "on-clawdi",
-					manageHref,
-					tooltipDetail,
-					showDot: false,
-					labelOverride: label,
-				})
-			: createElement(
-					"span",
-					{
-						key: "text",
-						className: tile.secondaryStatus.textClass ?? "text-muted-foreground",
-					},
-					label,
-				),
-	);
 }

--- a/apps/web/src/hosted/use-hosted-deployment-inventory.ts
+++ b/apps/web/src/hosted/use-hosted-deployment-inventory.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useMemo } from "react";
+import { isDeployApiConfigured } from "@/hosted/billing/billing-client";
+import { useHostedDeployments } from "@/hosted/billing/hooks";
+import { resolveHostedInventory } from "@/hosted/hosted-agent-resolution";
+
+/** Single query adapter for hosted-agent membership across every surface. */
+export function useHostedDeploymentInventory({
+	enabled = true,
+	pollWalletDunningFor = null,
+}: {
+	enabled?: boolean;
+	pollWalletDunningFor?: string | null;
+} = {}) {
+	const configured = isDeployApiConfigured();
+	const query = useHostedDeployments({ enabled, pollWalletDunningFor });
+	const resolution = useMemo(
+		() =>
+			resolveHostedInventory({
+				enabled,
+				configured,
+				data: query.data,
+				error: query.error,
+				isPending: query.isPending,
+			}),
+		[configured, enabled, query.data, query.error, query.isPending],
+	);
+
+	return {
+		...resolution,
+		isFetching: query.isFetching,
+		refetch: query.refetch,
+	};
+}

--- a/apps/web/src/hosted/use-unified-agent-list.test.ts
+++ b/apps/web/src/hosted/use-unified-agent-list.test.ts
@@ -66,6 +66,7 @@ describe("selectUnifiedAgentList", () => {
 			hostedTiles: [hostedTile],
 			claimedEnvIds: new Set([claimed.id.toLowerCase()]),
 			legacyEnvIds: new Set([legacy.id.toLowerCase()]),
+			hostedInventoryStatus: "resolved",
 			showLegacyAgents: true,
 		});
 
@@ -78,7 +79,7 @@ describe("selectUnifiedAgentList", () => {
 		expect(selection.tiles.some((tile) => tile.id === claimed.id)).toBe(false);
 	});
 
-	test("keeps hosted membership while legacy ownership is unresolved", () => {
+	test("keeps known hosted membership but withholds connected classification while ownership is unresolved", () => {
 		const claimed = env("11111111-1111-4111-8111-111111111111", "claimed-cloud-env");
 		const connected = env("33333333-3333-4333-8333-333333333333", "connected-env");
 		const hostedTile: AgentTile = {
@@ -97,10 +98,78 @@ describe("selectUnifiedAgentList", () => {
 			hostedTiles: [hostedTile],
 			claimedEnvIds: new Set([claimed.id.toLowerCase()]),
 			legacyEnvIds: null,
+			hostedInventoryStatus: "resolved",
 			showLegacyAgents: true,
 		});
 
-		expect(selection.tiles.map((tile) => tile.id)).toEqual(["dep_starting", connected.id]);
+		expect(selection.tiles.map((tile) => tile.id)).toEqual(["dep_starting"]);
+		expect(selection.connectedTiles).toEqual([]);
+		expect(selection.membershipResolved).toBe(false);
+	});
+
+	test("never reclassifies cloud projections while deployment membership is unresolved", () => {
+		const possibleHostedProjection = env(
+			"11111111-1111-4111-8111-111111111111",
+			"possible-hosted-projection",
+		);
+		const selection = selectUnifiedAgentList({
+			cloudEnvs: [possibleHostedProjection],
+			hostedTiles: [],
+			claimedEnvIds: new Set(),
+			legacyEnvIds: new Set(),
+			hostedInventoryStatus: "loading",
+			showLegacyAgents: false,
+		});
+
+		expect(selection.tiles).toEqual([]);
+		expect(selection.connectedTiles).toEqual([]);
+		expect(selection.membershipResolved).toBe(false);
+	});
+
+	test("retains known hosted membership without classifying other projections after refresh failure", () => {
+		const claimed = env("11111111-1111-4111-8111-111111111111", "claimed-cloud-env");
+		const unknown = env("33333333-3333-4333-8333-333333333333", "unknown-projection");
+		const hostedTile: AgentTile = {
+			id: "dep_running",
+			source: "on-clawdi",
+			name: "OpenClaw",
+			agentType: "openclaw",
+			statusLabel: "Running",
+			href: `/agents/${claimed.id}?source=on-clawdi&d=dep_running`,
+			active: true,
+			env: claimed,
+		};
+		const selection = selectUnifiedAgentList({
+			cloudEnvs: [claimed, unknown],
+			hostedTiles: [hostedTile],
+			claimedEnvIds: new Set([claimed.id.toLowerCase()]),
+			legacyEnvIds: new Set(),
+			hostedInventoryStatus: "error",
+			showLegacyAgents: false,
+		});
+
+		expect(selection.tiles.map((tile) => [tile.id, tile.source])).toEqual([
+			["dep_running", "on-clawdi"],
+		]);
+		expect(selection.connectedTiles).toEqual([]);
+		expect(selection.membershipResolved).toBe(false);
+	});
+
+	test("classifies projections as connected only after an authoritative empty snapshot", () => {
+		const connected = env("33333333-3333-4333-8333-333333333333", "connected-env");
+		const selection = selectUnifiedAgentList({
+			cloudEnvs: [connected],
+			hostedTiles: [],
+			claimedEnvIds: new Set(),
+			legacyEnvIds: new Set(),
+			hostedInventoryStatus: "resolved",
+			showLegacyAgents: false,
+		});
+
+		expect(selection.tiles.map((tile) => [tile.id, tile.source])).toEqual([
+			[connected.id, "self-managed"],
+		]);
+		expect(selection.membershipResolved).toBe(true);
 	});
 });
 
@@ -111,7 +180,8 @@ describe("unified list consumers", () => {
 		const homepage = readFileSync(resolve(srcDir, "hosted/hosted-agents-section.tsx"), "utf8");
 
 		expect(sidebar).toContain('import("@/hosted/use-unified-agent-list")');
-		expect(sidebar).toContain("hostedAgentTiles ?? []");
+		expect(sidebar).toContain("hostedMembershipResolved");
+		expect(sidebar).toContain("activeAgentTile");
 		expect(homepage).toContain("useUnifiedAgentList({");
 		expect(homepage).not.toContain("connectedAgentTilesForHostedView");
 		expect(homepage).not.toContain("useHostedAgentTiles({");

--- a/apps/web/src/hosted/use-unified-agent-list.ts
+++ b/apps/web/src/hosted/use-unified-agent-list.ts
@@ -9,6 +9,7 @@ import {
 	selfManagedAgentTiles,
 } from "@/components/dashboard/agents-card";
 import { useLegacyEnvIds } from "@/hosted/agents/ownership-sensor";
+import type { HostedInventoryStatus } from "@/hosted/hosted-agent-resolution";
 import { legacyConnectedAgentTiles } from "@/hosted/legacy-agent-tiles";
 import { useHostedAgentTiles } from "@/hosted/use-hosted-agent-tiles";
 import { normalizeAgentEnvId } from "@/lib/agent-ownership";
@@ -21,6 +22,7 @@ export interface UnifiedAgentListSelection {
 	tiles: AgentTile[];
 	hostedTiles: AgentTile[];
 	connectedTiles: AgentTile[];
+	membershipResolved: boolean;
 }
 
 /**
@@ -35,14 +37,27 @@ export function selectUnifiedAgentList({
 	hostedTiles,
 	claimedEnvIds,
 	legacyEnvIds,
+	hostedInventoryStatus,
 	showLegacyAgents,
 }: {
 	cloudEnvs: Env[];
 	hostedTiles: AgentTile[];
 	claimedEnvIds: ReadonlySet<string>;
 	legacyEnvIds: ReadonlySet<string> | null;
+	hostedInventoryStatus: HostedInventoryStatus;
 	showLegacyAgents: boolean;
 }): UnifiedAgentListSelection {
+	const membershipResolved =
+		hostedInventoryStatus === "resolved" && (!showLegacyAgents || legacyEnvIds !== null);
+	if (!membershipResolved) {
+		return {
+			tiles: hostedTiles,
+			hostedTiles,
+			connectedTiles: [],
+			membershipResolved: false,
+		};
+	}
+
 	const legacyConnectedTiles =
 		showLegacyAgents && legacyEnvIds
 			? legacyConnectedAgentTiles(cloudEnvs, legacyEnvIds, claimedEnvIds)
@@ -56,6 +71,7 @@ export function selectUnifiedAgentList({
 		tiles: [...hostedTiles, ...connectedTiles],
 		hostedTiles,
 		connectedTiles,
+		membershipResolved: true,
 	};
 }
 
@@ -90,14 +106,23 @@ export function useUnifiedAgentList({
 				hostedTiles: hosted.tiles,
 				claimedEnvIds: hosted.claimedEnvIds,
 				legacyEnvIds,
+				hostedInventoryStatus: hosted.inventoryStatus,
 				showLegacyAgents,
 			}),
-		[cloudEnvs, hosted.claimedEnvIds, hosted.tiles, legacyEnvIds, showLegacyAgents],
+		[
+			cloudEnvs,
+			hosted.claimedEnvIds,
+			hosted.inventoryStatus,
+			hosted.tiles,
+			legacyEnvIds,
+			showLegacyAgents,
+		],
 	);
 
 	return {
 		...selection,
 		hasExistingDeployments: hosted.hasExistingDeployments,
+		inventoryStatus: hosted.inventoryStatus,
 		isLoading:
 			(showCloudDeployments && hosted.isLoading) ||
 			(showLegacyAgents && resolvedLegacyEnvIds === null),
@@ -115,7 +140,7 @@ export function HostedUnifiedAgentListSensor({
 	cloudEnvs: Env[];
 	showCloudDeployments?: boolean;
 	showLegacyAgents?: boolean;
-	onChange: (tiles: AgentTile[] | null) => void;
+	onChange: (tiles: AgentTile[] | null, membershipResolved: boolean) => void;
 }) {
 	const unified = useUnifiedAgentList({
 		cloudEnvs,
@@ -124,9 +149,9 @@ export function HostedUnifiedAgentListSensor({
 	});
 
 	useEffect(() => {
-		onChange(unified.tiles);
-	}, [onChange, unified.tiles]);
-	useEffect(() => () => onChange(null), [onChange]);
+		onChange(unified.tiles, unified.membershipResolved);
+	}, [onChange, unified.membershipResolved, unified.tiles]);
+	useEffect(() => () => onChange(null, false), [onChange]);
 
 	return null;
 }
@@ -140,7 +165,10 @@ export function HostedFleetSummary({
 	cloudEnvs: Env[];
 	showCloudDeployments?: boolean;
 	showLegacyAgents?: boolean;
-	children: (summary: AgentFleetSummary) => ReactNode;
+	children: (
+		summary: AgentFleetSummary,
+		state: { membershipResolved: boolean; error: Error | null; isLoading: boolean },
+	) => ReactNode;
 }) {
 	const unified = useUnifiedAgentList({
 		cloudEnvs,
@@ -148,5 +176,9 @@ export function HostedFleetSummary({
 		showLegacyAgents,
 	});
 	const summary = useMemo(() => fleetSummaryFromTiles(unified.tiles), [unified.tiles]);
-	return children(summary);
+	return children(summary, {
+		membershipResolved: unified.membershipResolved,
+		error: unified.error,
+		isLoading: unified.isLoading,
+	});
 }

--- a/apps/web/src/lib/agent-ownership.test.ts
+++ b/apps/web/src/lib/agent-ownership.test.ts
@@ -10,6 +10,7 @@ describe("agentOwnershipKindFromId", () => {
 		const ownership = {
 			cloudEnvIds: new Set(["aaaa"]),
 			legacyEnvIds: new Set(["bbbb"]),
+			isResolved: true,
 		};
 
 		expect(agentOwnershipKindFromId("AAAA", ownership)).toBe("cloud");
@@ -21,6 +22,7 @@ describe("agentOwnershipKindFromId", () => {
 		const ownership = {
 			cloudEnvIds: new Set(["aaaa"]),
 			legacyEnvIds: new Set(["bbbb"]),
+			isResolved: true,
 		};
 
 		expect(agentOwnershipKindFromId("  AAAA  ", ownership)).toBe("cloud");
@@ -31,21 +33,32 @@ describe("agentOwnershipKindFromId", () => {
 		}
 	});
 
-	it("defaults to connected while ownership is unknown", () => {
-		// Cosmetic fallback only — destructive consumers (Disconnect) must
-		// additionally require a non-null (resolved) ownership value.
-		expect(agentOwnershipKindFromId("aaaa", null)).toBe("connected");
-		expect(agentOwnershipKindFromId(null, null)).toBe("connected");
+	it("preserves unresolved ownership instead of guessing connected", () => {
+		expect(agentOwnershipKindFromId("aaaa", null)).toBe("unresolved");
+		expect(agentOwnershipKindFromId(null, null)).toBe("unresolved");
 	});
 
 	it("resolved empty ownership classifies everything as connected", () => {
 		expect(agentOwnershipKindFromId("aaaa", EMPTY_AGENT_OWNERSHIP)).toBe("connected");
 	});
 
+	it("retains known ownership while leaving unknown ids unresolved from a stale snapshot", () => {
+		const ownership = {
+			cloudEnvIds: new Set(["aaaa"]),
+			legacyEnvIds: new Set(["bbbb"]),
+			isResolved: false,
+		};
+
+		expect(agentOwnershipKindFromId("aaaa", ownership)).toBe("cloud");
+		expect(agentOwnershipKindFromId("bbbb", ownership)).toBe("legacy");
+		expect(agentOwnershipKindFromId("cccc", ownership)).toBe("unresolved");
+	});
+
 	it("prefers cloud when both sets contain the same environment", () => {
 		const ownership = {
 			cloudEnvIds: new Set(["aaaa"]),
 			legacyEnvIds: new Set(["aaaa"]),
+			isResolved: true,
 		};
 
 		expect(agentOwnershipKindFromId("aaaa", ownership)).toBe("cloud");
@@ -106,14 +119,22 @@ describe("agentDisconnectUnavailable", () => {
 			agentDisconnectUnavailable({
 				envId: "aaaa",
 				explicitIdentity: false,
-				ownership: { cloudEnvIds: new Set(["aaaa"]), legacyEnvIds: new Set() },
+				ownership: {
+					cloudEnvIds: new Set(["aaaa"]),
+					legacyEnvIds: new Set(),
+					isResolved: true,
+				},
 			}),
 		).toBe(true);
 		expect(
 			agentDisconnectUnavailable({
 				envId: "aaaa",
 				explicitIdentity: false,
-				ownership: { cloudEnvIds: new Set(), legacyEnvIds: new Set(["aaaa"]) },
+				ownership: {
+					cloudEnvIds: new Set(),
+					legacyEnvIds: new Set(["aaaa"]),
+					isResolved: true,
+				},
 			}),
 		).toBe(true);
 	});

--- a/apps/web/src/lib/agent-ownership.ts
+++ b/apps/web/src/lib/agent-ownership.ts
@@ -2,23 +2,23 @@
 
 import { createContext, createElement, type ReactNode, useContext } from "react";
 
-export type AgentOwnershipKind = "cloud" | "legacy" | "connected";
+export type AgentOwnershipKind = "cloud" | "legacy" | "connected" | "unresolved";
 
 export type AgentOwnership = {
 	/**
 	 * Environment ids managed by an external control plane.
 	 *
-	 * A `null` context strictly means "still resolving": the provider is
-	 * expecting ownership data that has not arrived yet. Cosmetic consumers
-	 * (badges, labels, section chrome) may fall back to "connected" while
-	 * resolving, but DESTRUCTIVE actions (Disconnect) must wait for a
-	 * non-null value. When no external control plane applies (OSS builds,
-	 * hosted users without hosted capabilities) the provider supplies
-	 * `EMPTY_AGENT_OWNERSHIP` — resolved, everything connected — so those
-	 * surfaces never wait.
+	 * A `null` context means the hosted sensor has not reported yet. A partial
+	 * last-known snapshot uses `isResolved: false`: ids already present in its
+	 * sets retain their ownership, while every other id stays unresolved instead
+	 * of being guessed as connected. Destructive actions follow the same rule.
+	 * When no external control plane applies, the provider supplies
+	 * `EMPTY_AGENT_OWNERSHIP` — resolved, everything connected.
 	 */
 	cloudEnvIds: ReadonlySet<string>;
 	legacyEnvIds: ReadonlySet<string>;
+	/** False keeps unknown ids unresolved while known ids retain their ownership. */
+	isResolved: boolean;
 };
 
 const EMPTY_ENV_ID_SET: ReadonlySet<string> = new Set();
@@ -27,6 +27,7 @@ const EMPTY_ENV_ID_SET: ReadonlySet<string> = new Set();
 export const EMPTY_AGENT_OWNERSHIP: AgentOwnership = {
 	cloudEnvIds: EMPTY_ENV_ID_SET,
 	legacyEnvIds: EMPTY_ENV_ID_SET,
+	isResolved: true,
 };
 
 const AgentOwnershipContext = createContext<AgentOwnership | null>(null);
@@ -55,10 +56,11 @@ export function agentOwnershipKindFromId(
 	ownership: AgentOwnership | null,
 ): AgentOwnershipKind {
 	const normalized = normalizeAgentEnvId(envId);
-	if (!normalized || !ownership) return "connected";
+	if (!ownership) return "unresolved";
+	if (!normalized) return ownership.isResolved ? "connected" : "unresolved";
 	if (ownership.cloudEnvIds.has(normalized)) return "cloud";
 	if (ownership.legacyEnvIds.has(normalized)) return "legacy";
-	return "connected";
+	return ownership.isResolved ? "connected" : "unresolved";
 }
 
 export function agentDisconnectUnavailable({

--- a/apps/web/src/pages/dashboard/page.tsx
+++ b/apps/web/src/pages/dashboard/page.tsx
@@ -185,9 +185,10 @@ export default function DashboardPage() {
 						showCloudDeployments={cloudDeploymentManagementEnabled}
 						showLegacyAgents={legacyHostedAgentsEnabled}
 					>
-						{(summary) =>
+						{(summary, state) =>
 							renderGreeting(summary, {
-								agentStatusUnavailable: Boolean(envsError) && summary.total === 0,
+								agentStatusUnavailable:
+									Boolean(envsError) || !state.membershipResolved || Boolean(state.error),
 							})
 						}
 					</HostedFleetSummary>


### PR DESCRIPTION
## Design

The audit findings shared one root cause: dashboard surfaces still treated the Cloud `/v1/agents` projection as a source of hosted membership and capability truth. This PR replaces those overlapping fallbacks with one resolution model and extends the invariant established in #422 consistently across the hosted dashboard:

- deployment inventory is the authoritative source of hosted membership and status
- the environment ID in deployment config is the agent identity
- the Cloud agent projection is additive decoration and may lag, disappear, fail, or become stale without changing membership, navigation, capabilities, or active counts

`hosted-agent-resolution.ts` defines inventory and projection states, membership filtering, identity resolution, deployment-authoritative verdicts, and projection recovery policy. `useHostedDeploymentInventory` is the single query adapter, and the sidebar, homepage, agents index, ownership sensor, and detail route consume that shared model.

## Findings resolved

- [x] **A#1 / D#13** — distinguish resolved-empty inventory from loading, error, and unavailable states; retain last-known hosted membership on refresh failure; withhold connected classification and onboarding until membership resolves.
- [x] **A#10** — preserve `unresolved` ownership as a first-class kind and render skeleton chrome instead of defaulting unknown ownership to connected.
- [x] **A#2** — filter `deleted` deployments at the membership boundary so they cannot render tiles, claim environment IDs, or resolve detail routes.
- [x] **D#5 / D#4** — reconcile transitional deployments every 10 seconds and stable inventories every 75 seconds while visible; invalidate deployment and agent snapshots on every deployment mutation settlement, including errors and timeouts.
- [x] **A#4 / D#12** — derive hosted active verdicts and homepage active counts exclusively from deployment status; daemon freshness remains secondary sync metadata.
- [x] **A#12 / D twins** — render deployment-name context labels in tile and sidebar identity chrome when projection naming is absent or ambiguous.
- [x] **A#3** — keep Console, Terminal, lifecycle, compute, AI, and settings capabilities available when the additive projection returns 404.
- [x] **A#6** — retry missing live/transitional projections with capped backoff and expose a visible **Check again** action.
- [x] **A#8** — render non-404 projection failures as an explicit service-error state while retaining deployment-owned controls.
- [x] **A#7 / D#11** — render Runtime UI redemption failures as retryable errors and gate both header and inline Runtime UI entry points on the same authoritative running predicate.

## Simplified / removed

- Removed the duplicate deployments query from the tile layer.
- Removed the network-error-to-null/empty fallback that erased hosted membership.
- Removed per-surface connected-membership and onboarding fallbacks.
- Removed the projection-driven `DeploymentCentricDetail` branch in favor of one capability-preserving detail layout.
- Removed the sidebar-only runtime-status query/component; sidebar status now comes from unified tiles.
- Consolidated duplicate claimed-environment and deployment-resolution helpers into the shared resolution layer.

## Verification

- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web lint`
- `bun run --cwd apps/web test` — 489 tests passed
- `bun run --cwd apps/web build:oss`
- hosted production build with `VITE_CLAWDI_HOSTED=true`
- `bun run --cwd apps/web e2e:hosted --retries=1` — all 41 scenarios passed; one existing billing scenario retried after a host `net::ERR_NETWORK_CHANGED` event