### PR TITLE
ci: parallelize client gates and share clean runner suite primitives

### DIFF
--- a/.github/workflows/clean-test-runner-ci.yml
+++ b/.github/workflows/clean-test-runner-ci.yml
@@ -5,19 +5,65 @@ on:
   pull_request:
     paths:
       - "docker/**"
+      - ".dockerignore"
       - "docker-compose.test.yml"
       - "scripts/test.sh"
       - "package.json"
       - "bun.lock"
+      - "turbo.json"
+      - "tsconfig.base.json"
+      - "apps/web/package.json"
+      - "apps/web/bunfig.toml"
+      - "apps/web/tsconfig.json"
+      - "apps/web/tsr.config.json"
+      - "apps/web/vite.config.ts"
+      - "apps/web/src/hosted/oss-clean.test.ts"
+      - "packages/cli/package.json"
+      - "packages/cli/tsconfig.json"
+      - "packages/cli/tests/clean-test-runner.test.ts"
+      - "packages/cli/tests/smoke.test.ts"
+      - "packages/shared/package.json"
+      - "packages/shared/tsconfig.json"
+      - "packages/whatsapp-baileys-sidecar/package.json"
+      - "packages/whatsapp-baileys-sidecar/tsconfig.json"
+      - "backend/alembic.ini"
+      - "backend/alembic/**"
+      - "backend/pyproject.toml"
+      - "backend/uv.lock"
+      - "backend/tests/conftest.py"
+      - "backend/tests/test_smoke.py"
       - ".github/workflows/clean-test-runner-ci.yml"
   push:
     branches: [main]
     paths:
       - "docker/**"
+      - ".dockerignore"
       - "docker-compose.test.yml"
       - "scripts/test.sh"
       - "package.json"
       - "bun.lock"
+      - "turbo.json"
+      - "tsconfig.base.json"
+      - "apps/web/package.json"
+      - "apps/web/bunfig.toml"
+      - "apps/web/tsconfig.json"
+      - "apps/web/tsr.config.json"
+      - "apps/web/vite.config.ts"
+      - "apps/web/src/hosted/oss-clean.test.ts"
+      - "packages/cli/package.json"
+      - "packages/cli/tsconfig.json"
+      - "packages/cli/tests/clean-test-runner.test.ts"
+      - "packages/cli/tests/smoke.test.ts"
+      - "packages/shared/package.json"
+      - "packages/shared/tsconfig.json"
+      - "packages/whatsapp-baileys-sidecar/package.json"
+      - "packages/whatsapp-baileys-sidecar/tsconfig.json"
+      - "backend/alembic.ini"
+      - "backend/alembic/**"
+      - "backend/pyproject.toml"
+      - "backend/uv.lock"
+      - "backend/tests/conftest.py"
+      - "backend/tests/test_smoke.py"
       - ".github/workflows/clean-test-runner-ci.yml"
 
 permissions:
@@ -54,9 +100,5 @@ jobs:
           tags: ${{ env.TEST_RUNNER_IMAGE }}
           cache-from: type=gha,scope=clawdi-test-runner
           cache-to: type=gha,mode=max,scope=clawdi-test-runner
-      - name: Default clean runner smoke
-        run: scripts/test.sh all tests/test_smoke.py
-      - name: Web clean runner
-        run: scripts/test.sh web
-      - name: CLI clean runner
-        run: scripts/test.sh cli
+      - name: Clean runner CI profile
+        run: scripts/test.sh ci

--- a/.github/workflows/clean-test-runner-ci.yml
+++ b/.github/workflows/clean-test-runner-ci.yml
@@ -2,6 +2,15 @@ name: Clean Test Runner CI
 
 on:
   workflow_dispatch:
+    inputs:
+      suite:
+        description: "Clean runner suite to execute"
+        required: true
+        default: ci
+        type: choice
+        options:
+          - ci
+          - all
   pull_request:
     paths:
       - "docker/**"
@@ -101,4 +110,8 @@ jobs:
           cache-from: type=gha,scope=clawdi-test-runner
           cache-to: type=gha,mode=max,scope=clawdi-test-runner
       - name: Clean runner CI profile
+        if: github.event_name != 'workflow_dispatch' || inputs.suite == 'ci'
         run: scripts/test.sh ci
+      - name: Full clean runner suite
+        if: github.event_name == 'workflow_dispatch' && inputs.suite == 'all'
+        run: scripts/test.sh all

--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -199,7 +199,9 @@ jobs:
         run: bun test --isolate --max-concurrency=1 packages/cli
 
   build:
-    needs: [changes, typecheck]
+    # This job starts from its own checkout and consumes no typecheck artifact,
+    # so build and typecheck are independent required gates.
+    needs: changes
     if: >-
       github.event_name != 'schedule' && (
         needs.changes.outputs.web == 'true' ||

--- a/README.md
+++ b/README.md
@@ -357,7 +357,9 @@ service and do not reuse the dev database.
 Clean Test Runner CI uses the first-class `ci` profile to exercise the runner
 contract in one container without repeating the full web and CLI product
 suites. The normal `all`, `js`, `web`, `cli`, and `backend` entrypoints retain
-their comprehensive behavior. See
+their comprehensive behavior. Core runner changes can use the workflow's
+manual `suite=all` dispatch gate without adding full-suite duplication to
+routine pull requests. See
 [`docs/clean-test-runner.md`](docs/clean-test-runner.md) for the exact focused
 suite, measured resource envelope, and override variables.
 

--- a/README.md
+++ b/README.md
@@ -337,7 +337,8 @@ read-only during test execution:
 ```bash
 scripts/test.sh          # JS typecheck/tests, then backend pytest
 bun run test             # same clean Docker runner
-scripts/test.sh js       # JS typecheck + web/sidecar/CLI tests
+scripts/test.sh ci       # focused CI harness profile; not a product test replacement
+scripts/test.sh js       # JS typecheck + web/shared/sidecar/CLI tests
 scripts/test.sh cli      # CLI typecheck + full CLI tests
 scripts/test.sh web      # web typecheck + tests + OSS build only
 scripts/test.sh backend  # Alembic + backend pytest against throwaway Postgres
@@ -352,6 +353,13 @@ build cache are reused by the Docker daemon. It does not force `CLAWDI_HOME`, so
 tests can still isolate Clawdi state through the same home/config paths as the
 product. Backend tests use a temporary `pgvector/pgvector:0.8.1-pg16` Postgres
 service and do not reuse the dev database.
+
+Clean Test Runner CI uses the first-class `ci` profile to exercise the runner
+contract in one container without repeating the full web and CLI product
+suites. The normal `all`, `js`, `web`, `cli`, and `backend` entrypoints retain
+their comprehensive behavior. See
+[`docs/clean-test-runner.md`](docs/clean-test-runner.md) for the exact focused
+suite, measured resource envelope, and override variables.
 
 For a focused CLI pytest-style argument pass-through, append paths after the
 suite name, for example `scripts/test.sh cli tests/api-client.test.ts`. The

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,6 +5,11 @@ services:
       context: .
       dockerfile: docker/test-runner.Dockerfile
     user: "1000:1000"
+    cpus: ${CLAWDI_TEST_RUNNER_CPUS:-8}
+    mem_limit: ${CLAWDI_TEST_RUNNER_MEMORY_LIMIT:-4g}
+    memswap_limit: ${CLAWDI_TEST_RUNNER_MEMORY_LIMIT:-4g}
+    mem_swappiness: 0
+    pids_limit: ${CLAWDI_TEST_RUNNER_PIDS_LIMIT:-512}
     environment:
       HOME: /tmp/clawdi-home
       CLAWDI_NO_AUTO_UPDATE: "1"
@@ -28,6 +33,11 @@ services:
 
   postgres:
     image: pgvector/pgvector:0.8.1-pg16
+    cpus: ${CLAWDI_TEST_POSTGRES_CPUS:-2}
+    mem_limit: ${CLAWDI_TEST_POSTGRES_MEMORY_LIMIT:-1g}
+    memswap_limit: ${CLAWDI_TEST_POSTGRES_MEMORY_LIMIT:-1g}
+    mem_swappiness: 0
+    pids_limit: ${CLAWDI_TEST_POSTGRES_PIDS_LIMIT:-256}
     environment:
       POSTGRES_DB: clawdi_test
       POSTGRES_USER: clawdi

--- a/docker/test-runner.sh
+++ b/docker/test-runner.sh
@@ -50,6 +50,7 @@ run_js() {
 	install_js
 	bun run typecheck
 	bun run --cwd apps/web test
+	bun test packages/shared/src
 	bun run --cwd packages/whatsapp-baileys-sidecar test
 	bun run --cwd packages/cli test
 }
@@ -85,6 +86,23 @@ run_backend() {
 	)
 }
 
+run_ci() {
+	if [[ $# -gt 0 ]]; then
+		echo "Suite 'ci' does not accept extra arguments" >&2
+		exit 2
+	fi
+
+	install_js
+	bun run typecheck
+	bun test packages/cli/tests/clean-test-runner.test.ts
+	bun run --cwd apps/web test src/hosted/oss-clean.test.ts
+	bun run --cwd apps/web build:oss
+	bun test packages/shared/src
+	bun run --cwd packages/whatsapp-baileys-sidecar test
+	bun run --cwd packages/cli test tests/smoke.test.ts
+	run_backend tests/test_smoke.py
+}
+
 copy_repo
 
 case "$suite" in
@@ -108,9 +126,12 @@ case "$suite" in
 	backend)
 		run_backend "$@"
 		;;
+	ci)
+		run_ci "$@"
+		;;
 	*)
 		echo "Unknown test suite: $suite" >&2
-		echo "Usage: scripts/test.sh [all|js|cli|web|backend] [suite args...]" >&2
+		echo "Usage: scripts/test.sh [all|ci|js|cli|web|backend] [suite args...]" >&2
 		exit 2
 		;;
 esac

--- a/docker/test-runner.sh
+++ b/docker/test-runner.sh
@@ -46,30 +46,43 @@ install_backend() {
 	)
 }
 
-run_js() {
-	install_js
+workspace_typecheck() {
 	bun run typecheck
-	bun run --cwd apps/web test
-	bun test packages/shared/src
-	bun run --cwd packages/whatsapp-baileys-sidecar test
-	bun run --cwd packages/cli test
 }
 
-run_cli() {
-	install_js
-	bun run --cwd packages/cli typecheck
-	bun run --cwd packages/cli test "$@"
-}
-
-run_web() {
-	install_js
+web_typecheck() {
 	bun run --cwd apps/web typecheck
+}
+
+web_tests() {
 	bun run --cwd apps/web test "$@"
+}
+
+web_build() {
 	bun run --cwd apps/web build:oss
 }
 
-run_backend() {
-	install_backend
+cli_typecheck() {
+	bun run --cwd packages/cli typecheck
+}
+
+cli_tests() {
+	bun run --cwd packages/cli test "$@"
+}
+
+shared_tests() {
+	bun test packages/shared/src
+}
+
+sidecar_tests() {
+	bun run --cwd packages/whatsapp-baileys-sidecar test
+}
+
+runner_contract_tests() {
+	bun test packages/cli/tests/clean-test-runner.test.ts
+}
+
+backend_tests() {
 	(
 		cd backend
 		: "${DATABASE_URL:?DATABASE_URL must be set for backend tests}"
@@ -86,6 +99,33 @@ run_backend() {
 	)
 }
 
+run_js() {
+	install_js
+	workspace_typecheck
+	web_tests
+	shared_tests
+	sidecar_tests
+	cli_tests
+}
+
+run_cli() {
+	install_js
+	cli_typecheck
+	cli_tests "$@"
+}
+
+run_web() {
+	install_js
+	web_typecheck
+	web_tests "$@"
+	web_build
+}
+
+run_backend() {
+	install_backend
+	backend_tests "$@"
+}
+
 run_ci() {
 	if [[ $# -gt 0 ]]; then
 		echo "Suite 'ci' does not accept extra arguments" >&2
@@ -93,14 +133,15 @@ run_ci() {
 	fi
 
 	install_js
-	bun run typecheck
-	bun test packages/cli/tests/clean-test-runner.test.ts
-	bun run --cwd apps/web test src/hosted/oss-clean.test.ts
-	bun run --cwd apps/web build:oss
-	bun test packages/shared/src
-	bun run --cwd packages/whatsapp-baileys-sidecar test
-	bun run --cwd packages/cli test tests/smoke.test.ts
-	run_backend tests/test_smoke.py
+	workspace_typecheck
+	runner_contract_tests
+	web_tests src/hosted/oss-clean.test.ts
+	web_build
+	shared_tests
+	sidecar_tests
+	cli_tests tests/smoke.test.ts
+	install_backend
+	backend_tests tests/test_smoke.py
 }
 
 copy_repo

--- a/docs/clean-test-runner.md
+++ b/docs/clean-test-runner.md
@@ -1,0 +1,148 @@
+# Clean Test Runner
+
+The default `bun run test` path runs the comprehensive `all` suite in an
+isolated Docker workspace. Clean Test Runner CI uses a separate, first-class
+`ci` profile to validate the harness once without replacing product CI or
+weakening any developer-facing suite.
+
+## Suite contract
+
+Run the comprehensive entrypoints with:
+
+```bash
+scripts/test.sh              # full JS and backend suites
+scripts/test.sh js           # full web, shared, sidecar, and CLI tests
+scripts/test.sh web          # web typecheck, full tests, and OSS build
+scripts/test.sh cli          # CLI typecheck and full tests
+scripts/test.sh backend      # migrations and full pytest
+```
+
+The CI-only profile runs one dependency install and preserves these harness
+contracts:
+
+```bash
+scripts/test.sh ci
+```
+
+- Workspace typecheck, which executes the web, CLI, shared, and sidecar
+  package typecheck commands.
+- The Clean Runner workflow/selection/resource contract test.
+- The existing web OSS-boundary test and the full OSS build.
+- All shared and WhatsApp sidecar tests.
+- The existing CLI smoke test.
+- Alembic migrations and the existing backend PostgreSQL smoke test.
+
+Product workflows remain responsible for their full product suites. The
+focused profile is intentionally rejected if extra arguments are supplied so
+its selection cannot drift through an undocumented CI-only shell argument.
+
+Done: `scripts/test.sh ci` exits 0 and reports passing contract, web, shared,
+sidecar, CLI, and backend smoke tests.
+
+## Client CI gate independence
+
+Client CI keeps web build and the web/CLI/shared typecheck matrix as separate
+required jobs, but both now depend only on the path-filter job. Each job starts
+from its own `actions/checkout` and neither uploads nor downloads an artifact.
+The Turbo typecheck task also declares no outputs. Consequently, the previous
+`build -> typecheck` scheduling edge could not transfer `tsr generate` output
+or any other generated file to the build job.
+
+A build-only check copied the repository into a fresh isolated runner
+workspace, installed dependencies, asserted that `apps/web/.output` and
+`apps/web/.tanstack` did not exist, and then ran:
+
+```bash
+bunx turbo build --filter=web
+test -f apps/web/.output/server/index.mjs
+```
+
+The command passed without running typecheck first. This verifies the same
+fresh-checkout contract already used by the Client CI build job.
+
+## Resource envelope
+
+`docker-compose.test.yml` applies these defaults to every clean-runner
+invocation:
+
+| Service | CPU | Memory | PIDs |
+| --- | ---: | ---: | ---: |
+| Test runner | 8 | 4 GiB | 512 |
+| PostgreSQL | 2 | 1 GiB | 256 |
+
+For each service, Compose sets `mem_limit` and `memswap_limit` to the same
+positive value. Docker therefore gives the container no swap allowance. The
+measured `memory.swap.peak` was also zero for both the high-ceiling and default
+profile runs.
+
+Override a limit for a constrained or larger local machine with:
+
+| Variable | Default |
+| --- | ---: |
+| `CLAWDI_TEST_RUNNER_CPUS` | `8` |
+| `CLAWDI_TEST_RUNNER_MEMORY_LIMIT` | `4g` |
+| `CLAWDI_TEST_RUNNER_PIDS_LIMIT` | `512` |
+| `CLAWDI_TEST_POSTGRES_CPUS` | `2` |
+| `CLAWDI_TEST_POSTGRES_MEMORY_LIMIT` | `1g` |
+| `CLAWDI_TEST_POSTGRES_PIDS_LIMIT` | `256` |
+
+The memory variables set both the memory and memory-plus-swap values, so an
+override preserves the no-swap invariant.
+
+Done: `docker compose -f docker-compose.test.yml config` exits 0 and renders
+the configured CPU, memory, memory-plus-swap, and PID values.
+
+## Measurement evidence
+
+Measurements were captured on 2026-07-18 with Docker 29.6.1, Docker Compose
+5.3.1, cgroup v2, 32 logical CPUs, and 25,189,486,592 bytes of host memory.
+Each command used a newly created container with the runner's per-run tmpfs
+caches. Wall time covers `scripts/test.sh`; average CPU cores are cgroup
+`cpu.stat` usage divided by wall time. Memory and PID values are cgroup
+`memory.peak` and `pids.peak`.
+
+The previous three-step workflow executed 2,981 test cases because the full
+480-test web suite and 1,003-test CLI suite each ran twice:
+
+| Previous step | Wall | Runner avg CPU | Runner memory peak | Runner PID peak | Tests |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `all tests/test_smoke.py` | 70.084 s | 1.740 | 2,703,486,976 B | 234 | 1,498 |
+| `web` | 18.731 s | 2.991 | 2,550,808,576 B | 129 | 480 |
+| `cli` | 31.970 s | 1.868 | 2,122,145,792 B | 85 | 1,003 |
+| Total | 120.785 s | - | - | - | 2,981 |
+
+The `all` step's 1,498 cases were 480 web, 9 sidecar, 1,003 CLI, and 6
+backend smoke cases. A separate full backend run completed in 117.522 seconds
+with 1,279 passed and 7 skipped tests. It peaked at 1,165,012,992 bytes and 87
+PIDs in the runner and 182,202,368 bytes and 17 PIDs in PostgreSQL.
+
+The current single-container `ci` profile executes 84 cases: 8 runner
+contract, 14 web, 31 shared, 9 sidecar, 16 CLI, and 6 backend smoke tests. The
+same profile was measured once with high override ceilings and once with the
+defaults:
+
+| Profile limits | Wall | Runner avg CPU | Runner memory peak | Runner PID peak | Swap peak | OOM kills |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 32 CPU / 16 GiB / 4,096 PID | 54.172 s | 2.032 | 2,670,735,360 B | 231 | 0 B | 0 |
+| Default envelope | 53.359 s | 1.725 | 2,671,194,112 B | 83 | 0 B | 0 |
+
+The comprehensive `all` suite was also rerun under the default envelope. It
+completed in 148.518 seconds with 480 web, 31 shared, 9 sidecar, 1,011 CLI, and
+1,279 passing backend tests; 7 backend tests were skipped. The runner peaked at
+2,797,473,792 bytes and 83 PIDs, while PostgreSQL peaked at 184,459,264 bytes
+and 17 PIDs. Both services recorded zero swap use and zero OOM kills.
+
+The default runner memory limit retains more than 53% headroom over that
+largest observed 2.80 GB peak, and its PID limit is more than twice the
+unconstrained 234-process peak. PostgreSQL retains substantially more headroom
+over the full backend run. The 8-CPU profile recorded transient cgroup
+throttling but no measured wall time regression relative to the high-ceiling
+run; the 0.813-second difference is treated as run-to-run noise, not a
+performance gain.
+
+These are sizing observations from one host, not general product benchmark
+claims. The CI efficiency claim is limited to removing duplicate suite
+execution and two repeated container dependency installs.
+
+Done: `bun test packages/cli/tests/clean-test-runner.test.ts` reports 8 passing
+contract tests.

--- a/docs/clean-test-runner.md
+++ b/docs/clean-test-runner.md
@@ -36,8 +36,46 @@ Product workflows remain responsible for their full product suites. The
 focused profile is intentionally rejected if extra arguments are supplied so
 its selection cannot drift through an undocumented CI-only shell argument.
 
+The shell implementation defines each package command once in a lower-level
+primitive. The public `js`, `web`, `cli`, and `backend` wrappers and the `ci`
+profile compose those same primitives with full or focused arguments. Install
+steps remain in the wrappers, so every entrypoint installs JavaScript and
+backend dependencies at most once per container.
+
 Done: `scripts/test.sh ci` exits 0 and reports passing contract, web, shared,
 sidecar, CLI, and backend smoke tests.
+
+## Dynamic and static coverage
+
+Pull requests and pushes dynamically execute `scripts/test.sh ci`. That runs
+the shared workspace-typecheck, web-test, web-build, shared-test,
+sidecar-test, CLI-test, and backend-test primitives. Web, CLI, and backend use
+the focused files listed above; shared and sidecar remain complete.
+
+The lightweight contract test statically verifies the composition layer:
+
+- Every package command is owned by exactly one primitive.
+- Public wrappers and `ci` call those primitives in the expected order.
+- Focused arguments appear only at the `ci` composition boundary.
+- Public suite dispatch, workflow selection, paths, and resources remain
+  present.
+
+Routine pull requests do not dynamically invoke every public wrapper or rerun
+the full web, CLI, and backend product suites. For a core runner change,
+Clean Test Runner CI exposes a deliberate full-suite workflow-dispatch gate:
+
+```bash
+gh workflow run clean-test-runner-ci.yml --ref <branch> -f suite=all
+```
+
+The dispatch runs `scripts/test.sh all` in the same built runner image and
+measured Compose envelope. Its default choice remains `ci`. This is manual
+rather than scheduled because product workflows already run the full product
+suites; automatically repeating them on a calendar would add cost without
+being tied to a runner change.
+
+Done: the dispatched `docker-runner` job exits 0 and its `Full clean runner
+suite` step reports the full web, shared, sidecar, CLI, and backend counts.
 
 ## Client CI gate independence
 

--- a/packages/cli/tests/clean-test-runner.test.ts
+++ b/packages/cli/tests/clean-test-runner.test.ts
@@ -23,6 +23,28 @@ function occurrences(source: string, value: string): number {
 	return source.split(value).length - 1;
 }
 
+const compositionFunctions = new Set([
+	"install_js",
+	"install_backend",
+	"workspace_typecheck",
+	"web_typecheck",
+	"web_tests",
+	"web_build",
+	"cli_typecheck",
+	"cli_tests",
+	"shared_tests",
+	"sidecar_tests",
+	"runner_contract_tests",
+	"backend_tests",
+]);
+
+function calledCompositionFunctions(shellFunction: string): string[] {
+	return shellFunction
+		.split("\n")
+		.map((line) => line.trim().split(/[ (]/, 1)[0])
+		.filter((name) => compositionFunctions.has(name));
+}
+
 describe("client workflow contract", () => {
 	test("keeps build and typecheck as independent required gates", () => {
 		const typecheckJob = section(clientWorkflow, "  typecheck:\n", "  cli-test:\n");
@@ -74,37 +96,149 @@ describe("clean runner suite contract", () => {
 		expect(dispatch).toContain('run_ci "$@"');
 	});
 
-	test("leaves normal all and JS suites comprehensive", () => {
-		const runJs = section(innerRunner, "run_js() {\n", "run_cli() {\n");
-		for (const command of [
-			"bun run typecheck",
-			"bun run --cwd apps/web test",
-			"bun test packages/shared/src",
-			"bun run --cwd packages/whatsapp-baileys-sidecar test",
-			"bun run --cwd packages/cli test",
-		]) {
-			expect(runJs).toContain(command);
+	test("composes public and focused suites from single command primitives", () => {
+		const primitives = [
+			{
+				name: "workspace_typecheck",
+				next: "web_typecheck",
+				commands: ["bun run typecheck"],
+			},
+			{
+				name: "web_typecheck",
+				next: "web_tests",
+				commands: ["bun run --cwd apps/web typecheck"],
+			},
+			{
+				name: "web_tests",
+				next: "web_build",
+				commands: ['bun run --cwd apps/web test "$@"'],
+			},
+			{
+				name: "web_build",
+				next: "cli_typecheck",
+				commands: ["bun run --cwd apps/web build:oss"],
+			},
+			{
+				name: "cli_typecheck",
+				next: "cli_tests",
+				commands: ["bun run --cwd packages/cli typecheck"],
+			},
+			{
+				name: "cli_tests",
+				next: "shared_tests",
+				commands: ['bun run --cwd packages/cli test "$@"'],
+			},
+			{
+				name: "shared_tests",
+				next: "sidecar_tests",
+				commands: ["bun test packages/shared/src"],
+			},
+			{
+				name: "sidecar_tests",
+				next: "runner_contract_tests",
+				commands: ["bun run --cwd packages/whatsapp-baileys-sidecar test"],
+			},
+			{
+				name: "runner_contract_tests",
+				next: "backend_tests",
+				commands: ["bun test packages/cli/tests/clean-test-runner.test.ts"],
+			},
+			{
+				name: "backend_tests",
+				next: "run_js",
+				commands: ["uv run alembic upgrade head", 'uv run pytest -q "$@"'],
+			},
+		];
+
+		for (const primitive of primitives) {
+			const body = section(innerRunner, `${primitive.name}() {\n`, `${primitive.next}() {\n`);
+			for (const command of primitive.commands) {
+				expect(body).toContain(command);
+				expect(occurrences(innerRunner, command)).toBe(1);
+			}
+		}
+
+		const wrappers = [
+			{
+				body: section(innerRunner, "run_js() {\n", "run_cli() {\n"),
+				calls: [
+					"install_js",
+					"workspace_typecheck",
+					"web_tests",
+					"shared_tests",
+					"sidecar_tests",
+					"cli_tests",
+				],
+			},
+			{
+				body: section(innerRunner, "run_cli() {\n", "run_web() {\n"),
+				calls: ["install_js", "cli_typecheck", "cli_tests"],
+			},
+			{
+				body: section(innerRunner, "run_web() {\n", "run_backend() {\n"),
+				calls: ["install_js", "web_typecheck", "web_tests", "web_build"],
+			},
+			{
+				body: section(innerRunner, "run_backend() {\n", "run_ci() {\n"),
+				calls: ["install_backend", "backend_tests"],
+			},
+			{
+				body: section(innerRunner, "run_ci() {\n", "copy_repo\n"),
+				calls: [
+					"install_js",
+					"workspace_typecheck",
+					"runner_contract_tests",
+					"web_tests",
+					"web_build",
+					"shared_tests",
+					"sidecar_tests",
+					"cli_tests",
+					"install_backend",
+					"backend_tests",
+				],
+			},
+		];
+
+		for (const wrapper of wrappers) {
+			expect(calledCompositionFunctions(wrapper.body)).toEqual(wrapper.calls);
+			expect(wrapper.body).not.toMatch(/^\s*(?:bun|uv)\b/m);
+		}
+
+		for (const [primitive, useCount] of [
+			["workspace_typecheck", 3],
+			["web_tests", 4],
+			["web_build", 3],
+			["cli_tests", 4],
+			["shared_tests", 3],
+			["sidecar_tests", 3],
+			["backend_tests", 3],
+		] as const) {
+			expect(occurrences(innerRunner, primitive)).toBe(useCount);
 		}
 	});
 
-	test("runs the focused CI profile once without duplicate product suites", () => {
-		const runCi = section(innerRunner, "run_ci() {\n", "copy_repo\n");
-		for (const command of [
-			"bun run typecheck",
-			"bun test packages/cli/tests/clean-test-runner.test.ts",
-			"bun run --cwd apps/web test src/hosted/oss-clean.test.ts",
-			"bun run --cwd apps/web build:oss",
-			"bun test packages/shared/src",
-			"bun run --cwd packages/whatsapp-baileys-sidecar test",
-			"bun run --cwd packages/cli test tests/smoke.test.ts",
-			"run_backend tests/test_smoke.py",
-		]) {
-			expect(runCi).toContain(command);
-		}
+	test("runs focused CI routinely and exposes full all as a manual gate", () => {
+		expect(cleanRunnerWorkflow).toContain('description: "Clean runner suite to execute"');
+		expect(cleanRunnerWorkflow).toContain("default: ci");
+		expect(cleanRunnerWorkflow).toContain("          - ci\n          - all");
 
-		expect(cleanRunnerWorkflow).toContain("run: scripts/test.sh ci");
-		expect(occurrences(cleanRunnerWorkflow, "run: scripts/test.sh")).toBe(1);
-		expect(cleanRunnerWorkflow).not.toContain("scripts/test.sh all");
+		const focusedStep = section(
+			cleanRunnerWorkflow,
+			"      - name: Clean runner CI profile\n",
+			"      - name: Full clean runner suite\n",
+		);
+		const fullStep = cleanRunnerWorkflow.slice(
+			cleanRunnerWorkflow.indexOf("      - name: Full clean runner suite\n"),
+		);
+		expect(focusedStep).toContain(
+			"if: github.event_name != 'workflow_dispatch' || inputs.suite == 'ci'",
+		);
+		expect(focusedStep).toContain("run: scripts/test.sh ci");
+		expect(fullStep).toContain(
+			"if: github.event_name == 'workflow_dispatch' && inputs.suite == 'all'",
+		);
+		expect(fullStep).toContain("run: scripts/test.sh all");
+		expect(occurrences(cleanRunnerWorkflow, "run: scripts/test.sh")).toBe(2);
 		expect(cleanRunnerWorkflow).not.toContain("scripts/test.sh web");
 		expect(cleanRunnerWorkflow).not.toContain("scripts/test.sh cli");
 	});

--- a/packages/cli/tests/clean-test-runner.test.ts
+++ b/packages/cli/tests/clean-test-runner.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "../../..");
+const readRepoFile = (path: string): string => readFileSync(resolve(repoRoot, path), "utf8");
+const clientWorkflow = readRepoFile(".github/workflows/client-ci.yml");
+const cleanRunnerWorkflow = readRepoFile(".github/workflows/clean-test-runner-ci.yml");
+const outerRunner = readRepoFile("scripts/test.sh");
+const innerRunner = readRepoFile("docker/test-runner.sh");
+const compose = readRepoFile("docker-compose.test.yml");
+const turboConfig = readRepoFile("turbo.json");
+
+function section(source: string, start: string, end: string): string {
+	const startIndex = source.indexOf(start);
+	if (startIndex === -1) throw new Error(`Missing section start: ${start}`);
+	const endIndex = source.indexOf(end, startIndex + start.length);
+	if (endIndex === -1) throw new Error(`Missing section end: ${end}`);
+	return source.slice(startIndex, endIndex);
+}
+
+function occurrences(source: string, value: string): number {
+	return source.split(value).length - 1;
+}
+
+describe("client workflow contract", () => {
+	test("keeps build and typecheck as independent required gates", () => {
+		const typecheckJob = section(clientWorkflow, "  typecheck:\n", "  cli-test:\n");
+		const buildJob = section(clientWorkflow, "  build:\n", "  deploy-contract-drift:\n");
+
+		expect(typecheckJob).toContain("needs: changes");
+		expect(buildJob).toContain("needs: changes");
+		expect(buildJob).not.toMatch(/needs:.*typecheck/);
+		for (const job of [typecheckJob, buildJob]) {
+			expect(job).toContain("uses: actions/checkout@v6");
+			expect(job).not.toContain("actions/upload-artifact");
+			expect(job).not.toContain("actions/download-artifact");
+		}
+		const typecheckTask = section(turboConfig, '\t\t"typecheck": {\n', '\t\t"lint": {\n');
+		expect(typecheckTask).toContain('"outputs": []');
+
+		expect(typecheckJob).toContain(`bunx turbo typecheck --filter=\${{ matrix.filter }}`);
+		expect(typecheckJob).toContain("target: web");
+		expect(typecheckJob).toContain("target: cli");
+		expect(typecheckJob).toContain("target: shared");
+		expect(buildJob).toContain("bunx turbo build --filter=web");
+	});
+
+	test("retains the existing client build and test commands", () => {
+		for (const command of [
+			"bun run check",
+			"bun run --cwd packages/cli build",
+			"bun run --cwd packages/cli build:binary",
+			"packages/cli/dist-bin/clawdi --version",
+			"bun run --cwd packages/cli check:publish-manifest",
+			"bun test --isolate --max-concurrency=1 packages/cli",
+		]) {
+			expect(clientWorkflow).toContain(command);
+		}
+	});
+});
+
+describe("clean runner suite contract", () => {
+	test("keeps every public suite entrypoint routed", () => {
+		expect(outerRunner).toContain("all|backend|ci|js|cli|web)");
+		expect(outerRunner).toContain("all|backend|ci)\n");
+		expect(outerRunner).toContain("js|cli|web)\n");
+
+		const dispatch = section(innerRunner, 'case "$suite" in\n', "esac\n");
+		for (const suite of ["all", "js", "cli", "web", "backend", "ci"]) {
+			expect(dispatch).toContain(`\t${suite})\n`);
+		}
+		expect(dispatch).toContain('run_js\n\t\trun_backend "$@"');
+		expect(dispatch).toContain('run_ci "$@"');
+	});
+
+	test("leaves normal all and JS suites comprehensive", () => {
+		const runJs = section(innerRunner, "run_js() {\n", "run_cli() {\n");
+		for (const command of [
+			"bun run typecheck",
+			"bun run --cwd apps/web test",
+			"bun test packages/shared/src",
+			"bun run --cwd packages/whatsapp-baileys-sidecar test",
+			"bun run --cwd packages/cli test",
+		]) {
+			expect(runJs).toContain(command);
+		}
+	});
+
+	test("runs the focused CI profile once without duplicate product suites", () => {
+		const runCi = section(innerRunner, "run_ci() {\n", "copy_repo\n");
+		for (const command of [
+			"bun run typecheck",
+			"bun test packages/cli/tests/clean-test-runner.test.ts",
+			"bun run --cwd apps/web test src/hosted/oss-clean.test.ts",
+			"bun run --cwd apps/web build:oss",
+			"bun test packages/shared/src",
+			"bun run --cwd packages/whatsapp-baileys-sidecar test",
+			"bun run --cwd packages/cli test tests/smoke.test.ts",
+			"run_backend tests/test_smoke.py",
+		]) {
+			expect(runCi).toContain(command);
+		}
+
+		expect(cleanRunnerWorkflow).toContain("run: scripts/test.sh ci");
+		expect(occurrences(cleanRunnerWorkflow, "run: scripts/test.sh")).toBe(1);
+		expect(cleanRunnerWorkflow).not.toContain("scripts/test.sh all");
+		expect(cleanRunnerWorkflow).not.toContain("scripts/test.sh web");
+		expect(cleanRunnerWorkflow).not.toContain("scripts/test.sh cli");
+	});
+});
+
+describe("clean runner workflow inputs", () => {
+	test("tracks runner, dependency, configuration, and focused fixture inputs", () => {
+		const requiredPaths = [
+			"docker/**",
+			".dockerignore",
+			"docker-compose.test.yml",
+			"scripts/test.sh",
+			"package.json",
+			"bun.lock",
+			"turbo.json",
+			"tsconfig.base.json",
+			"apps/web/package.json",
+			"apps/web/bunfig.toml",
+			"apps/web/tsconfig.json",
+			"apps/web/tsr.config.json",
+			"apps/web/vite.config.ts",
+			"apps/web/src/hosted/oss-clean.test.ts",
+			"packages/cli/package.json",
+			"packages/cli/tsconfig.json",
+			"packages/cli/tests/clean-test-runner.test.ts",
+			"packages/cli/tests/smoke.test.ts",
+			"packages/shared/package.json",
+			"packages/shared/tsconfig.json",
+			"packages/whatsapp-baileys-sidecar/package.json",
+			"packages/whatsapp-baileys-sidecar/tsconfig.json",
+			"backend/alembic.ini",
+			"backend/alembic/**",
+			"backend/pyproject.toml",
+			"backend/uv.lock",
+			"backend/tests/conftest.py",
+			"backend/tests/test_smoke.py",
+			".github/workflows/clean-test-runner-ci.yml",
+		];
+
+		for (const path of requiredPaths) {
+			expect(occurrences(cleanRunnerWorkflow, `- "${path}"`)).toBe(2);
+		}
+	});
+
+	test("does not broaden triggers to ordinary product test trees", () => {
+		for (const path of [
+			"apps/web/**",
+			"packages/cli/**",
+			"packages/shared/**",
+			"packages/whatsapp-baileys-sidecar/**",
+			"backend/**",
+			"backend/tests/**",
+		]) {
+			expect(cleanRunnerWorkflow).not.toContain(`- "${path}"`);
+		}
+	});
+});
+
+describe("clean runner resource contract", () => {
+	test("keeps measured defaults configurable and disables swap", () => {
+		for (const setting of [
+			`cpus: \${CLAWDI_TEST_RUNNER_CPUS:-8}`,
+			`pids_limit: \${CLAWDI_TEST_RUNNER_PIDS_LIMIT:-512}`,
+			`cpus: \${CLAWDI_TEST_POSTGRES_CPUS:-2}`,
+			`pids_limit: \${CLAWDI_TEST_POSTGRES_PIDS_LIMIT:-256}`,
+		]) {
+			expect(compose).toContain(setting);
+		}
+		expect(occurrences(compose, `\${CLAWDI_TEST_RUNNER_MEMORY_LIMIT:-4g}`)).toBe(2);
+		expect(occurrences(compose, `\${CLAWDI_TEST_POSTGRES_MEMORY_LIMIT:-1g}`)).toBe(2);
+		expect(occurrences(compose, "mem_swappiness: 0")).toBe(2);
+		expect(cleanRunnerWorkflow).toContain(
+			"run: docker compose -f docker-compose.test.yml config >/dev/null",
+		);
+	});
+});

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -11,11 +11,11 @@ if [[ $# -gt 0 ]]; then
 fi
 
 case "$suite" in
-	all|backend|js|cli|web)
+	all|backend|ci|js|cli|web)
 		;;
 	*)
 		echo "Unknown test suite: $suite" >&2
-		echo "Usage: scripts/test.sh [all|js|cli|web|backend] [suite args...]" >&2
+		echo "Usage: scripts/test.sh [all|ci|js|cli|web|backend] [suite args...]" >&2
 		exit 2
 		;;
 esac
@@ -40,7 +40,7 @@ if [[ "${CLAWDI_TEST_RUNNER_SKIP_BUILD:-0}" != "1" ]]; then
 fi
 
 case "$suite" in
-	all|backend)
+	all|backend|ci)
 		"${compose[@]}" run --rm test-runner "$suite" "$@"
 		;;
 	js|cli|web)


### PR DESCRIPTION
## Why

Client CI serialized two independent required gates, while Clean Test Runner CI started three fresh containers, reinstalled dependencies, and reran the full web and CLI product suites. The focused runner profile removes that routine duplication without weakening public suite entrypoints or hiding failures. The runner's public and focused profiles now share the same command implementations so a future wrapper/path/cwd regression cannot leave CI green through duplicated command strings.

## What changed

- Run the existing Client CI web build and typecheck matrix as independent required jobs. Both jobs use fresh checkouts, exchange no artifacts, and the build-only isolated proof passed without running typecheck first.
- Define lower-level runner primitives for workspace/web/CLI/shared/sidecar/backend commands. Public `js`, `web`, `cli`, and `backend` wrappers and focused `ci` compose those same primitives with full or focused arguments.
- Replace the Clean Test Runner workflow's three routine fresh-container invocations with one first-class `scripts/test.sh ci` profile. It installs each dependency set once, runs workspace typecheck once, keeps the web OSS build, runs focused existing web/CLI/backend smoke tests, and runs all shared/sidecar tests.
- Keep normal `all`, `js`, `web`, `cli`, and `backend` behavior comprehensive. `all`/`js` explicitly include shared tests; no hidden skip was added.
- Add a deliberate manual `suite=all` workflow-dispatch gate for core runner changes. PRs and pushes still run only `ci`, avoiding restored routine duplication; no scheduled rerun was added because product workflows already provide full product-suite coverage.
- Expand Clean Runner path triggers to runner files, dependency/package inputs, TypeScript/web configs, Alembic migrations, backend dependency files, and exact focused test/fixture inputs without broad product test-tree globs.
- Add measured, configurable CPU/memory/PID envelopes. Memory and memory+swap are equal, so CI has no swap allowance.
- Add 8 lightweight contract tests covering the Client DAG, shared primitive ownership/composition, suite routing/selection, path filters, manual gate, and resource defaults.

## Dependency proof

The old `build -> typecheck` edge only delayed scheduling:

- both jobs perform their own `actions/checkout@v6`;
- neither job uploads or downloads an artifact;
- Turbo declares `typecheck` outputs as `[]`;
- a clean copied workspace with no `apps/web/.output` or `apps/web/.tanstack` successfully ran `bunx turbo build --filter=web` and produced `apps/web/.output/server/index.mjs` without first running typecheck.

Both build and the full web/CLI/shared typecheck matrix remain present and required.

## Dynamic and static runner safety

PRs and pushes dynamically execute `scripts/test.sh ci`. It calls the same workspace-typecheck, web-test/build, CLI-test, shared-test, sidecar-test, and backend-test primitives used by public suites, passing focused files only at the `ci` composition boundary. Shared and sidecar suites remain complete.

The contract test statically verifies that each real package/pytest command belongs to exactly one primitive, public wrappers and `ci` call the expected primitives in order, wrappers do not re-spell Bun/uv commands, focused arguments remain at the `ci` boundary, and workflow selection/path/resource contracts remain present.

Routine CI does not dynamically rerun every public wrapper. For core runner changes, run the complete gate explicitly:

```bash
gh workflow run clean-test-runner-ci.yml --ref <branch> -f suite=all
```

## Before/after evidence

Measured 2026-07-18 on the same Docker 29.6.1 / Compose 5.3.1 / cgroup-v2 host, with a fresh container and per-run tmpfs dependency caches for every invocation. Average CPU is cgroup CPU usage divided by wall time.

Before, the three workflow steps took 120.785 s and executed 2,981 test cases:

| Step | Wall | Runner avg CPU | Runner memory peak | PID peak | Tests |
| --- | ---: | ---: | ---: | ---: | ---: |
| `all tests/test_smoke.py` | 70.084 s | 1.740 | 2,703,486,976 B | 234 | 1,498 |
| `web` | 18.731 s | 2.991 | 2,550,808,576 B | 129 | 480 |
| `cli` | 31.970 s | 1.868 | 2,122,145,792 B | 85 | 1,003 |

The new `ci` profile took 53.359 s under the default envelope and executed 84 focused cases: 8 runner contract, 14 web, 31 shared, 9 sidecar, 16 CLI, and 6 backend smoke. Runner peak was 2,671,194,112 B / 83 PIDs; PostgreSQL peak was 87,314,432 B / 12 PIDs. Swap peak and OOM kills were zero for both.

The same profile with high override ceilings took 54.172 s, so the 8-CPU limit showed no measured wall regression. Its unconstrained runner peak was 2,670,735,360 B / 231 PIDs, also with zero swap and OOM kills.

The comprehensive `all` suite also passed under the defaults in 148.518 s: web 480, shared 31, sidecar 9, CLI 1,011, backend 1,279 passed / 7 skipped. Runner peak was 2,797,473,792 B / 83 PIDs; PostgreSQL peak was 184,459,264 B / 17 PIDs; swap and OOM kills remained zero.

After the shared-primitive review fix, the same default limits were revalidated without any count change: `ci` passed in 58.420 s with the same 84 cases, and `all` passed in 154.740 s with the same full-suite counts. These cold-run timings are recorded as safety verification, not as a replacement performance comparison.

Defaults and overrides are documented in `docs/clean-test-runner.md`:

- runner: 8 CPU, 4 GiB, 512 PIDs;
- PostgreSQL: 2 CPU, 1 GiB, 256 PIDs;
- `CLAWDI_TEST_RUNNER_{CPUS,MEMORY_LIMIT,PIDS_LIMIT}`;
- `CLAWDI_TEST_POSTGRES_{CPUS,MEMORY_LIMIT,PIDS_LIMIT}`.

## Verification

- [Manual `suite=all` workflow dispatch](https://github.com/Clawdi-AI/clawdi/actions/runs/29641312319) on `77ce95e9`: `docker-runner` succeeded in 3m45s; focused step skipped; full step reported web 480, shared 31, sidecar 9, CLI 1,011, backend 1,279 passed / 7 skipped
- `bun test packages/cli/tests/clean-test-runner.test.ts`: 8 passed, 124 assertions
- `scripts/test.sh ci` under default limits: 58.420 s; contract 8, web 14, shared 31, sidecar 9, CLI 16, backend 6
- `scripts/test.sh all` under default limits: 154.740 s; web 480, shared 31, sidecar 9, CLI 1,011, backend 1,279 passed / 7 skipped
- `bun run check`: 661 files checked, no fixes
- `docker compose -f docker-compose.test.yml config --quiet`
- `bash -n scripts/test.sh docker/test-runner.sh`
- ShellCheck container against both runner shell scripts
- actionlint container against `.github/workflows/client-ci.yml` and `.github/workflows/clean-test-runner-ci.yml`
- Bun YAML parse for both changed workflows and `docker-compose.test.yml`
- `git diff --check`

Repository-wide actionlint was also inspected; it reports four pre-existing ShellCheck findings in untouched backend/release/publish workflows. The two changed workflows pass targeted actionlint.

## Deliberate non-goals

- No backend transaction or database-fixture refactor.
- No CLI concurrency change; `--isolate --max-concurrency=1` remains intact.
- No reduction of required product CI gates and no failure hiding.
- No product behavior, production, hosted infrastructure, live API, cluster, tenant-data, release, or deployment changes.
- This PR remains unmerged for review.