### PR TITLE
test(backend): isolate PostgreSQL fixtures with savepoints

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -103,7 +103,12 @@ select = ["E", "F", "I", "UP"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 asyncio_default_test_loop_scope = "session"
+strict_config = true
+strict_markers = true
 testpaths = ["tests"]
+markers = [
+    "committed_db: use real commits for independent-connection or concurrency behavior",
+]
 filterwarnings = [
     # asyncpg emits these on some platforms — harmless.
     "ignore::DeprecationWarning:asyncpg",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,11 +4,13 @@ Strategy:
 - Hit the *real* Postgres (with pgvector + pg_trgm) provisioned by CI. Mocking
   the DB would diverge from production for vector / trigram queries and cascade
   semantics.
-- Each test gets an ``AsyncClient`` with ``get_auth`` and ``get_session``
-  overridden to point at an on-the-fly test user + session.
-- We deliberately skip nested-SAVEPOINT rollback isolation: async SQLAlchemy +
-  asyncpg doesn't cleanly support it and our smoke tests are self-contained
-  enough that per-test cleanup is cheaper than transactional gymnastics.
+- Most tests run inside an outer transaction.  The ORM session joins it with
+  ``create_savepoint``, so application commits remain test-local and teardown
+  is one rollback.  Tests that need committed visibility from independent
+  connections use the ``committed_db`` lane (or ``committed_db_session``
+  directly) explicitly.
+- Each test gets an ``AsyncClient`` with scoped dependency overrides pointing
+  at its deterministic test user and session.
 """
 
 from __future__ import annotations
@@ -18,6 +20,8 @@ import secrets
 import socket
 import uuid
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager, contextmanager
+from hashlib import sha256
 
 import httpx
 import pytest
@@ -39,6 +43,57 @@ _TEST_PUBLIC_DNS_HOSTS = {
     "graph.facebook.com",
 }
 _TEST_PUBLIC_DNS_SUFFIXES = (".example", ".test")
+_COMMITTED_DB_MODULES = {
+    "test_project_isolation.py",
+    "test_project_visibility_shared.py",
+    "test_runtime_manifest.py",
+    "test_runtime_observation_companion.py",
+    "test_share_redeem_routes.py",
+    "test_skills.py",
+    "test_sync_events.py",
+    "test_sync_heartbeat.py",
+}
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Route modules with pervasive cross-connection contracts to the commit lane."""
+    committed = pytest.mark.committed_db
+    for item in items:
+        if item.path.name in _COMMITTED_DB_MODULES:
+            item.add_marker(committed)
+
+
+def worker_test_identity(nodeid: str, worker: str) -> str:
+    digest = sha256(nodeid.encode()).hexdigest()[:16]
+    return f"{worker}-{digest}"
+
+
+@pytest.fixture
+def test_identity(request: pytest.FixtureRequest) -> str:
+    """Stable, worker-qualified identity for rows owned by one test."""
+    return worker_test_identity(request.node.nodeid, os.getenv("PYTEST_XDIST_WORKER", "main"))
+
+
+@pytest.fixture(autouse=True)
+def _restore_dependency_overrides():
+    """Restore the exact pre-test FastAPI override map, including nesting."""
+    previous = dict(app.dependency_overrides)
+    try:
+        yield
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(previous)
+
+
+@contextmanager
+def _dependency_overrides(overrides):
+    previous = dict(app.dependency_overrides)
+    app.dependency_overrides.update(overrides)
+    try:
+        yield
+    finally:
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(previous)
 
 
 @pytest.fixture(autouse=True)
@@ -107,10 +162,50 @@ async def engine():
 
 
 @pytest_asyncio.fixture
-async def db_session(engine) -> AsyncIterator[AsyncSession]:
+async def db_session(engine, request: pytest.FixtureRequest) -> AsyncIterator[AsyncSession]:
+    """Rollback-isolated session whose commits stay inside the outer transaction.
+
+    This is SQLAlchemy's documented test-suite recipe. PostgreSQL/asyncpg have
+    real SAVEPOINT support, unlike SQLite drivers with incomplete SAVEPOINT
+    handling: https://docs.sqlalchemy.org/en/20/orm/session_transaction.html
+    """
+    if request.node.get_closest_marker("committed_db"):
+        sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+        async with sessionmaker() as session:
+            yield session
+        return
+
+    async with rollback_session(engine) as session:
+        yield session
+
+
+@asynccontextmanager
+async def rollback_session(engine) -> AsyncIterator[AsyncSession]:
+    """Own an outer transaction and always roll it back, including on errors."""
+    async with engine.connect() as connection:
+        transaction = await connection.begin()
+        session = AsyncSession(
+            bind=connection,
+            expire_on_commit=False,
+            join_transaction_mode="create_savepoint",
+        )
+        try:
+            yield session
+        finally:
+            await session.close()
+            if transaction.is_active:
+                await transaction.rollback()
+
+
+@pytest_asyncio.fixture
+async def committed_db_session(engine) -> AsyncIterator[AsyncSession]:
+    """Independent-connection lane for commit visibility and concurrency tests."""
     sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
     async with sessionmaker() as session:
-        yield session
+        try:
+            yield session
+        finally:
+            await session.rollback()
 
 
 async def create_env_with_project(
@@ -166,8 +261,10 @@ async def create_env_with_project(
 
 
 @pytest_asyncio.fixture
-async def seed_user(db_session: AsyncSession) -> User:
-    """A throwaway user row scoped to one test, cleaned up in teardown.
+async def seed_user(
+    db_session: AsyncSession, test_identity: str, request: pytest.FixtureRequest
+) -> User:
+    """A deterministic user row scoped to one rollback-isolated test.
 
     Mirrors the auto-create flow in `_auth_via_clerk_jwt`: every user
     must have a Personal project so the default-project resolver has a
@@ -177,8 +274,8 @@ async def seed_user(db_session: AsyncSession) -> User:
     from app.models.project import PROJECT_KIND_PERSONAL, Project
 
     user = User(
-        clerk_id=f"test_{uuid.uuid4().hex[:12]}",
-        email=f"test_{uuid.uuid4().hex[:8]}@clawdi.local",
+        clerk_id=f"test_{test_identity}",
+        email=f"test-{test_identity}@clawdi.local",
         name="Test User",
     )
     db_session.add(user)
@@ -196,10 +293,9 @@ async def seed_user(db_session: AsyncSession) -> User:
     try:
         yield user
     finally:
-        # Best-effort cleanup so the test DB doesn't grow unbounded. Cascade
-        # FKs handle related rows; the user row itself is the root.
-        await db_session.delete(user)
-        await db_session.commit()
+        if request.node.get_closest_marker("committed_db"):
+            await db_session.delete(user)
+            await db_session.commit()
 
 
 @pytest_asyncio.fixture
@@ -310,16 +406,16 @@ async def client(db_session: AsyncSession, seed_user: User) -> AsyncIterator[htt
         # in the public route works in tests.
         return AuthContext(user=seed_user)
 
-    app.dependency_overrides[get_session] = _override_get_session
-    app.dependency_overrides[get_auth] = _override_get_auth
-    app.dependency_overrides[get_auth_short_session] = _override_get_auth
-    app.dependency_overrides[optional_web_auth] = _override_optional_web_auth
-    try:
+    overrides = {
+        get_session: _override_get_session,
+        get_auth: _override_get_auth,
+        get_auth_short_session: _override_get_auth,
+        optional_web_auth: _override_optional_web_auth,
+    }
+    with _dependency_overrides(overrides):
         transport = ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
             yield ac
-    finally:
-        app.dependency_overrides.clear()
 
 
 @pytest_asyncio.fixture
@@ -341,14 +437,15 @@ async def anon_client(
     async def _override_optional_web_auth() -> None:
         return None
 
-    app.dependency_overrides[get_session] = _override_get_session
-    app.dependency_overrides[optional_web_auth] = _override_optional_web_auth
-    try:
+    with _dependency_overrides(
+        {
+            get_session: _override_get_session,
+            optional_web_auth: _override_optional_web_auth,
+        }
+    ):
         transport = ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
             yield ac
-    finally:
-        app.dependency_overrides.clear()
 
 
 @pytest_asyncio.fixture
@@ -369,12 +466,13 @@ async def cli_client(db_session: AsyncSession, seed_user: User) -> AsyncIterator
         # to the routes we exercise. See app.core.auth.require_cli_auth.
         return AuthContext(user=seed_user, api_key=ApiKey(user_id=seed_user.id))
 
-    app.dependency_overrides[get_session] = _override_get_session
-    app.dependency_overrides[get_auth] = _override_get_auth
-    app.dependency_overrides[get_auth_short_session] = _override_get_auth
-    try:
+    with _dependency_overrides(
+        {
+            get_session: _override_get_session,
+            get_auth: _override_get_auth,
+            get_auth_short_session: _override_get_auth,
+        }
+    ):
         transport = ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
             yield ac
-    finally:
-        app.dependency_overrides.clear()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -43,24 +43,6 @@ _TEST_PUBLIC_DNS_HOSTS = {
     "graph.facebook.com",
 }
 _TEST_PUBLIC_DNS_SUFFIXES = (".example", ".test")
-_COMMITTED_DB_MODULES = {
-    "test_project_isolation.py",
-    "test_project_visibility_shared.py",
-    "test_runtime_manifest.py",
-    "test_runtime_observation_companion.py",
-    "test_share_redeem_routes.py",
-    "test_skills.py",
-    "test_sync_events.py",
-    "test_sync_heartbeat.py",
-}
-
-
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Route modules with pervasive cross-connection contracts to the commit lane."""
-    committed = pytest.mark.committed_db
-    for item in items:
-        if item.path.name in _COMMITTED_DB_MODULES:
-            item.add_marker(committed)
 
 
 def worker_test_identity(nodeid: str, worker: str) -> str:

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -375,6 +375,7 @@ async def test_admin_mint_api_key_writes_control_plane_audit(admin_client, db_se
 
 
 @pytest.mark.asyncio
+@pytest.mark.committed_db
 async def test_admin_mint_api_key_rolls_back_key_when_audit_fails(
     admin_client, engine, seed_user, monkeypatch
 ):
@@ -410,6 +411,11 @@ async def test_admin_mint_api_key_rolls_back_key_when_audit_fails(
     # visible here was committed before the audit event — the exact
     # orphan this test guards against.
     async with async_sessionmaker(engine, expire_on_commit=False)() as fresh:
+        # Prove this test is in the real-commit lane: the independently
+        # connected observer must see the fixture user before checking the
+        # failed mutation. Otherwise an outer test transaction could hide
+        # both a broken early commit and the setup row.
+        assert await fresh.get(type(seed_user), seed_user.id) is not None
         orphan = (
             await fresh.execute(
                 select(ApiKey).where(ApiKey.user_id == seed_user.id, ApiKey.label == "orphan-check")

--- a/backend/tests/test_channel_inbox.py
+++ b/backend/tests/test_channel_inbox.py
@@ -32,6 +32,8 @@ from app.services.channels import (
     wait_for_channel_inbox_events,
 )
 
+pytestmark = pytest.mark.committed_db
+
 
 async def _create_account_and_binding(
     db: AsyncSession,

--- a/backend/tests/test_channel_workers.py
+++ b/backend/tests/test_channel_workers.py
@@ -11,6 +11,8 @@ from app.services.discord_gateway_worker import DiscordGatewayWorker
 from app.services.runtime_observation_retention_worker import RuntimeObservationRetentionWorker
 from app.workers.channels import ChannelWorkerHealth, _handle_health_request, build_channel_workers
 
+pytestmark = pytest.mark.committed_db
+
 
 def test_channel_worker_stack_runs_delivery_webhook_gateway_and_retention_workers():
     workers = build_channel_workers()

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -91,7 +91,7 @@ from app.services.discord_gateway_worker import (
 from app.services.discord_rate_limiter import DiscordRateLimiter
 from app.services.telegram_rate_limiter import telegram_rate_limiter
 
-pytestmark = pytest.mark.usefixtures("channel_agent")
+pytestmark = [pytest.mark.usefixtures("channel_agent"), pytest.mark.committed_db]
 
 TELEGRAM_AGENT_TOKEN_RE = re.compile(r"^[1-9][0-9]{8}:[A-Za-z0-9_-]{32,}$")
 

--- a/backend/tests/test_dashboard_performance.py
+++ b/backend/tests/test_dashboard_performance.py
@@ -81,7 +81,8 @@ async def test_dashboard_stats_uses_bounded_database_round_trips(
         _context,
         _executemany,
     ) -> None:
-        statements.append(statement)
+        if not statement.lstrip().startswith(("SAVEPOINT", "RELEASE SAVEPOINT")):
+            statements.append(statement)
 
     event.listen(engine.sync_engine, "before_cursor_execute", before_cursor_execute)
     try:
@@ -180,7 +181,8 @@ async def test_projects_list_uses_single_query_for_dashboard_user(
         _context,
         _executemany,
     ) -> None:
-        statements.append(statement)
+        if not statement.lstrip().startswith(("SAVEPOINT", "RELEASE SAVEPOINT")):
+            statements.append(statement)
 
     event.listen(engine.sync_engine, "before_cursor_execute", before_cursor_execute)
     try:

--- a/backend/tests/test_database_fixture_contract.py
+++ b/backend/tests/test_database_fixture_contract.py
@@ -1,5 +1,7 @@
 """Contracts for the PostgreSQL application-test fixture architecture."""
 
+from uuid import uuid4
+
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -13,7 +15,8 @@ pytestmark = pytest.mark.asyncio
 
 
 async def test_commit_inside_test_remains_usable(db_session: AsyncSession):
-    user = User(clerk_id="fixture-commit", email="fixture-commit@example.test")
+    nonce = uuid4().hex
+    user = User(clerk_id=f"fixture-commit-{nonce}", email=f"fixture-commit-{nonce}@example.test")
     db_session.add(user)
     await db_session.commit()
 
@@ -23,7 +26,8 @@ async def test_commit_inside_test_remains_usable(db_session: AsyncSession):
 async def test_application_commit_is_hidden_from_independent_connection(
     engine, db_session: AsyncSession
 ):
-    user = User(clerk_id="fixture-hidden", email="fixture-hidden@example.test")
+    nonce = uuid4().hex
+    user = User(clerk_id=f"fixture-hidden-{nonce}", email=f"fixture-hidden-{nonce}@example.test")
     db_session.add(user)
     await db_session.commit()
 
@@ -35,10 +39,11 @@ async def test_application_commit_is_hidden_from_independent_connection(
 
 
 async def test_rollback_session_cleans_up_after_exception(engine):
-    clerk_id = "fixture-exception"
+    nonce = uuid4().hex
+    clerk_id = f"fixture-exception-{nonce}"
     with pytest.raises(RuntimeError, match="fixture failure"):
         async with rollback_session(engine) as session:
-            session.add(User(clerk_id=clerk_id, email="fixture-exception@example.test"))
+            session.add(User(clerk_id=clerk_id, email=f"fixture-exception-{nonce}@example.test"))
             await session.commit()
             raise RuntimeError("fixture failure")
 
@@ -75,8 +80,9 @@ async def test_worker_identity_is_stable_and_worker_isolated():
 async def test_committed_lane_is_visible_to_independent_connections(
     engine, committed_db_session: AsyncSession
 ):
-    clerk_id = "fixture-committed-lane"
-    user = User(clerk_id=clerk_id, email="fixture-committed-lane@example.test")
+    nonce = uuid4().hex
+    clerk_id = f"fixture-committed-lane-{nonce}"
+    user = User(clerk_id=clerk_id, email=f"fixture-committed-lane-{nonce}@example.test")
     committed_db_session.add(user)
     await committed_db_session.commit()
 

--- a/backend/tests/test_database_fixture_contract.py
+++ b/backend/tests/test_database_fixture_contract.py
@@ -1,0 +1,90 @@
+"""Contracts for the PostgreSQL application-test fixture architecture."""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.auth import get_auth
+from app.main import app
+from app.models.user import User
+from tests.conftest import _dependency_overrides, rollback_session, worker_test_identity
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_commit_inside_test_remains_usable(db_session: AsyncSession):
+    user = User(clerk_id="fixture-commit", email="fixture-commit@example.test")
+    db_session.add(user)
+    await db_session.commit()
+
+    assert await db_session.get(User, user.id) is user
+
+
+async def test_application_commit_is_hidden_from_independent_connection(
+    engine, db_session: AsyncSession
+):
+    user = User(clerk_id="fixture-hidden", email="fixture-hidden@example.test")
+    db_session.add(user)
+    await db_session.commit()
+
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    async with sessionmaker() as observer:
+        visible = await observer.scalar(select(User.id).where(User.clerk_id == user.clerk_id))
+
+    assert visible is None
+
+
+async def test_rollback_session_cleans_up_after_exception(engine):
+    clerk_id = "fixture-exception"
+    with pytest.raises(RuntimeError, match="fixture failure"):
+        async with rollback_session(engine) as session:
+            session.add(User(clerk_id=clerk_id, email="fixture-exception@example.test"))
+            await session.commit()
+            raise RuntimeError("fixture failure")
+
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    async with sessionmaker() as observer:
+        assert await observer.scalar(select(User.id).where(User.clerk_id == clerk_id)) is None
+
+
+async def test_dependency_overrides_restore_nested_snapshots():
+    original = dict(app.dependency_overrides)
+
+    async def outer_override():
+        return "outer"
+
+    async def inner_override():
+        return "inner"
+
+    with _dependency_overrides({get_auth: outer_override}):
+        assert app.dependency_overrides[get_auth] is outer_override
+        with _dependency_overrides({get_auth: inner_override}):
+            assert app.dependency_overrides[get_auth] is inner_override
+        assert app.dependency_overrides[get_auth] is outer_override
+
+    assert app.dependency_overrides == original
+
+
+async def test_worker_identity_is_stable_and_worker_isolated():
+    nodeid = "tests/test_example.py::test_case[param]"
+
+    assert worker_test_identity(nodeid, "gw0") == worker_test_identity(nodeid, "gw0")
+    assert worker_test_identity(nodeid, "gw0") != worker_test_identity(nodeid, "gw1")
+
+
+async def test_committed_lane_is_visible_to_independent_connections(
+    engine, committed_db_session: AsyncSession
+):
+    clerk_id = "fixture-committed-lane"
+    user = User(clerk_id=clerk_id, email="fixture-committed-lane@example.test")
+    committed_db_session.add(user)
+    await committed_db_session.commit()
+
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with sessionmaker() as observer:
+            visible_id = await observer.scalar(select(User.id).where(User.clerk_id == clerk_id))
+            assert visible_id == user.id
+    finally:
+        await committed_db_session.delete(user)
+        await committed_db_session.commit()

--- a/backend/tests/test_memory_recall_count.py
+++ b/backend/tests/test_memory_recall_count.py
@@ -13,6 +13,7 @@ import pytest
 
 
 @pytest.mark.asyncio
+@pytest.mark.committed_db
 async def test_agent_search_bumps_access_count(cli_client: httpx.AsyncClient):
     created = await cli_client.post(
         "/v1/memories",

--- a/backend/tests/test_project_isolation.py
+++ b/backend/tests/test_project_isolation.py
@@ -41,6 +41,8 @@ from app.models.user import User
 from app.models.vault import Vault, VaultItem, VaultProjectAttachment
 from app.services.agent_environments import local_machine_registration_key
 
+pytestmark = pytest.mark.committed_db
+
 
 async def _override_factory(db_session: AsyncSession, user: User, api_key: ApiKey | None = None):
     async def _session_override() -> AsyncIterator[AsyncSession]:

--- a/backend/tests/test_project_visibility_shared.py
+++ b/backend/tests/test_project_visibility_shared.py
@@ -12,6 +12,8 @@ import pytest
 from app.core.auth import AuthContext
 from app.core.project import project_ids_visible_to
 
+pytestmark = pytest.mark.committed_db
+
 
 @pytest.mark.asyncio
 async def test_clerk_jwt_sees_owned_and_shared_projects(db_session, seed_user, seed_project):

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -60,6 +60,8 @@ from tests.hosted_runtime_fixtures import (
     canonical_hosted_runtime_state,
 )
 
+pytestmark = pytest.mark.committed_db
+
 _ADMIN_KEY = "runtime-state-admin-secret"
 _AUTH = {"X-Admin-Key": _ADMIN_KEY}
 TEST_LOCALE = {"language": "en", "timezone": "America/Los_Angeles"}

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -42,6 +42,8 @@ from app.services.runtime_observation import (
 )
 from tests.conftest import create_env_with_project
 
+pytestmark = pytest.mark.committed_db
+
 _DEPLOYMENT_ID = "deployment-observation-companion"
 _APPLY_RECEIPT_ID = "apply-receipt-00000001"
 _BOOT_NONCE = "boot-nonce-0000000001"

--- a/backend/tests/test_share_redeem_routes.py
+++ b/backend/tests/test_share_redeem_routes.py
@@ -23,6 +23,8 @@ from app.models.share_redeem_attempt import ShareRedeemAttempt
 from app.models.user import User
 from app.services.sharing import generate_share_token, hash_share_token
 
+pytestmark = pytest.mark.committed_db
+
 
 def test_share_redeem_client_ip_trusts_forwarded_headers_only_when_enabled(monkeypatch):
     from types import SimpleNamespace

--- a/backend/tests/test_skills.py
+++ b/backend/tests/test_skills.py
@@ -17,6 +17,8 @@ import pytest
 
 from app.services.tar_utils import tar_from_content
 
+pytestmark = pytest.mark.committed_db
+
 
 @pytest.mark.asyncio
 async def test_skill_upload_happy_path(client: httpx.AsyncClient, project_id: str):

--- a/backend/tests/test_sync_events.py
+++ b/backend/tests/test_sync_events.py
@@ -30,6 +30,8 @@ from app.models.hosted_runtime import HostedRuntimeState
 from app.models.user import User
 from app.services import sync_events
 
+pytestmark = pytest.mark.committed_db
+
 
 @pytest.mark.asyncio
 async def test_stream_returns_when_revoked_event_set():

--- a/backend/tests/test_sync_heartbeat.py
+++ b/backend/tests/test_sync_heartbeat.py
@@ -38,6 +38,8 @@ from tests.hosted_runtime_fixtures import (
     ensure_canonical_codex_tool_provider,
 )
 
+pytestmark = pytest.mark.committed_db
+
 _TEST_LOCALE = {"language": "en", "timezone": "UTC"}
 _TEST_CLI_PACKAGE_SPEC = "clawdi@0.12.10-beta.55"
 _TEST_SYSTEM = {}

--- a/backend/tests/test_whatsapp_baileys.py
+++ b/backend/tests/test_whatsapp_baileys.py
@@ -58,7 +58,7 @@ from app.services.whatsapp_baileys import (
     whatsapp_message_proto_bytes,
 )
 
-pytestmark = pytest.mark.usefixtures("channel_agent")
+pytestmark = [pytest.mark.usefixtures("channel_agent"), pytest.mark.committed_db]
 
 
 class _FakeMediaResponse:

--- a/backend/tests/test_whatsapp_noise.py
+++ b/backend/tests/test_whatsapp_noise.py
@@ -71,7 +71,7 @@ from app.services.whatsapp_shared_runtime import (
     unregister_whatsapp_shared_bot_transport,
 )
 
-pytestmark = pytest.mark.usefixtures("channel_agent")
+pytestmark = [pytest.mark.usefixtures("channel_agent"), pytest.mark.committed_db]
 
 
 class _FakeWhatsAppMediaUploadResponse:


### PR DESCRIPTION
## Summary

- run ordinary backend application tests inside an outer PostgreSQL transaction with SQLAlchemy `join_transaction_mode="create_savepoint"`
- retain an explicit `committed_db` lane for independent-connection, background-task, LISTEN/NOTIFY, WebSocket, and concurrency contracts
- make seed identities deterministic and xdist-worker-qualified, and snapshot/restore FastAPI dependency overrides exactly
- enable strict pytest config/marker validation and add fixture contract coverage for commit-inside-test, rollback visibility, exception cleanup, nested overrides, worker identity isolation, and committed visibility

## Evidence

Pinned/tested versions: SQLAlchemy 2.0.49, pytest 9.0.3, pytest-asyncio 1.3.0, FastAPI 0.135.3, asyncpg 0.31.0, PostgreSQL 16 (pgvector image). The transaction recipe follows the SQLAlchemy 2.0 external-transaction test-suite documentation: https://docs.sqlalchemy.org/en/20/orm/session_transaction.html#joining-a-session-into-an-external-transaction-such-as-for-test-suites

Reproducible baseline and after command:

```bash
/usr/bin/time -v scripts/test.sh backend --durations=30
```

- baseline: 1279 passed, 7 skipped; pytest 90.31s; Docker wall 131.22s; max RSS 54,528 KiB
- after run 1: 1285 passed, 7 skipped; pytest 79.87s; Docker wall 114.02s; max RSS 52,992 KiB
- after run 2: 1285 passed, 7 skipped; pytest 86.73s; Docker wall 121.74s; max RSS 52,480 KiB

Static verification:

```bash
cd backend
uv run ruff check .
uv run ruff format --check .
uv run python -m compileall -q app scripts tests alembic
```

## Risk

The main risk is accidentally placing a test that depends on committed cross-connection visibility in the rollback lane. Contract-heavy modules are routed centrally to `committed_db`, and both full runs exercise those PostgreSQL-specific paths. Existing suite behavior still emits one intermittent SQLAlchemy warning from a Discord gateway test about a connection finalized by GC; this warning existed in the baseline and is not hidden by this change.