### PR TITLE
test(web): avoid loading full route graph for path contract

### DIFF
--- a/apps/web/src/routes/-shared-export-routes.test.ts
+++ b/apps/web/src/routes/-shared-export-routes.test.ts
@@ -1,17 +1,41 @@
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 
+function generatedRuntimeRoutePaths(source: string): string[] {
+	const runtimeStart = source.search(/^const \w+Route\s*=/m);
+	const runtimeEnd = source.indexOf("export interface FileRoutesByFullPath");
+	if (runtimeStart === -1 || runtimeEnd === -1 || runtimeStart >= runtimeEnd) {
+		throw new Error("Generated route runtime construction section was not found");
+	}
+
+	const runtimeConstruction = source.slice(runtimeStart, runtimeEnd);
+	return [...runtimeConstruction.matchAll(/\bpath:\s*'([^']+)'/g)].map((match) => match[1]);
+}
+
 describe("shared export routes", () => {
 	it("preserves extension-style public export URLs", () => {
 		const generatedRouteTree = readFileSync(
 			new URL("../routeTree.gen.ts", import.meta.url),
 			"utf8",
 		);
-		const paths = [...generatedRouteTree.matchAll(/\bpath:\s*'([^']+)'/g)].map((match) => match[1]);
+		const paths = generatedRuntimeRoutePaths(generatedRouteTree);
 
 		expect(paths).toContain("/s/{$id}.md");
 		expect(paths).toContain("/s/{$id}.json");
 		expect(paths).not.toContain("/s/{$}/md");
 		expect(paths).not.toContain("/s/{$}/json");
+	});
+
+	it("ignores paths that exist only in generated type metadata", () => {
+		const generatedRouteTree = `
+const RuntimeRoute = RuntimeRouteImport.update({
+  path: '/runtime-path',
+} as any)
+export interface FileRoutesByFullPath {
+  '/metadata-only-path': { path: '/metadata-only-path' }
+}
+`;
+
+		expect(generatedRuntimeRoutePaths(generatedRouteTree)).toEqual(["/runtime-path"]);
 	});
 });

--- a/apps/web/src/routes/-shared-export-routes.test.ts
+++ b/apps/web/src/routes/-shared-export-routes.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "bun:test";
-import { routeTree } from "@/routeTree.gen";
+import { readFileSync } from "node:fs";
 
 describe("shared export routes", () => {
 	it("preserves extension-style public export URLs", () => {
-		const paths = Object.values(routeTree.children ?? {}).map((route) => route.options.path);
+		const generatedRouteTree = readFileSync(
+			new URL("../routeTree.gen.ts", import.meta.url),
+			"utf8",
+		);
+		const paths = [...generatedRouteTree.matchAll(/\bpath:\s*'([^']+)'/g)].map((match) => match[1]);
 
 		expect(paths).toContain("/s/{$id}.md");
 		expect(paths).toContain("/s/{$id}.json");


### PR DESCRIPTION
## Summary

- parse only the generated runtime route construction section, bounded by the first route update declaration and the FileRoutesByFullPath type metadata
- keep the shared export URL contract tied to active runtime route configuration without evaluating the complete route graph
- add a negative regression contract proving a path present only in generated type metadata cannot satisfy the extractor

## Reproducible measurements

Commands:

    /usr/bin/time -f "elapsed=%e user=%U sys=%S maxrss_kb=%M exit=%x" bun test src/routes/-shared-export-routes.test.ts
    /usr/bin/time -f "elapsed=%e user=%U sys=%S maxrss_kb=%M exit=%x" bun test src

Before this follow-up:

- focused: 1 test / 4 assertions, Bun 83 ms, 0.10 s wall, 43,776 KiB RSS
- full web: 480 tests / 75 files / 1,078 assertions, Bun 1.127 s, 1.17 s wall, 173,412 KiB RSS

After:

- focused: 2 tests / 5 assertions, Bun 61 ms, 0.08 s wall, 43,264 KiB RSS
- full web: 481 tests / 75 files / 1,079 assertions
- three repeated full runs: Bun 1.034 / 1.068 / 1.024 s; wall 1.07 / 1.11 / 1.06 s; RSS 166,044 / 168,272 / 169,296 KiB
- the added test and assertion are the metadata-only negative regression contract

## Verification

- focused web contract
- repeated full web suite
- bun run --cwd apps/web typecheck
- bun run --cwd apps/web build:oss
- bunx biome check apps/web/src (403 files)
- bun run test Docker clean runner (42.98 s, 4/4 typechecks, no OOM/kill)
- CI is green

No tests or gates were removed or skipped.