### PR TITLE
feat(v2): owner-scoped per-deployment managed-AI-provider admin contract [cloud-api]

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -28,16 +28,18 @@ can land in this file under the same auth dep.
 
 import logging
 from datetime import UTC, datetime
-from typing import Any
+from typing import Annotated, Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import ValidationError
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import invalidate_api_key_auth_cache, require_admin_api_key
 from app.core.database import get_session
+from app.models.ai_provider import AiProvider, AiProviderAuthPayload
 from app.models.api_key import ApiKey
 from app.models.channel import (
     CHANNEL_PROVIDERS,
@@ -45,7 +47,11 @@ from app.models.channel import (
 )
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.session import AgentEnvironment
-from app.models.user import PRINCIPAL_KIND_CLERK, User
+from app.models.user import (
+    PRINCIPAL_KIND_CLERK,
+    PRINCIPAL_KIND_PARTNER_TENANT,
+    User,
+)
 from app.schemas.admin import (
     AdminAgentCreate,
     AdminApiKeyCreate,
@@ -61,8 +67,10 @@ from app.schemas.admin import (
     AdminRuntimeStateResponse,
     AdminRuntimeStateUpsert,
 )
+from app.schemas.ai_provider import AiProviderDeleteResponse, ai_provider_auth_from_persistence
 from app.schemas.api_key import ApiKeyCreated, ApiKeyRevokeResponse
 from app.schemas.channel import ChannelCommandSyncRequest, ChannelCommandSyncResponse
+from app.schemas.platform import PlatformOwner
 from app.schemas.session import EnvironmentCreatedResponse
 from app.services.agent_environments import (
     AgentEnvironmentIdConflict,
@@ -84,8 +92,15 @@ from app.services.channels import (
 )
 from app.services.managed_ai_provider import (
     MANAGED_AI_PROVIDER_API_MODE,
+    MANAGED_AI_PROVIDER_LABEL,
+    MANAGED_AI_PROVIDER_PROFILE,
     MANAGED_AI_PROVIDER_RUNTIME_ENV,
-    V2_MANAGED_AI_PROVIDER_IDS,
+    MANAGED_AI_PROVIDER_SCOPE,
+    MANAGED_AI_PROVIDER_TYPE,
+    archive_clawdi_managed_provider,
+    find_clawdi_managed_provider,
+    is_v2_deployment_managed_provider_id,
+    is_v2_managed_provider_id,
     upsert_clawdi_managed_provider,
 )
 from app.services.runtime_observation import (
@@ -97,7 +112,10 @@ from app.services.sync_events import (
     queue_provider_runtime_manifest_changed,
     queue_runtime_manifest_changed,
 )
-from app.services.user_provisioning import lazy_create_user_with_personal_project
+from app.services.user_provisioning import (
+    lazy_create_partner_user_with_personal_project,
+    lazy_create_user_with_personal_project,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -152,6 +170,132 @@ async def _resolve_or_create_user(db: AsyncSession, clerk_id: str) -> User:
     )
     logger.info("admin_lazy_create_user clerk_id=%s user_id=%s", clerk_id, user.id)
     return user
+
+
+async def _find_admin_owner(db: AsyncSession, owner: PlatformOwner) -> User:
+    if owner.kind == PRINCIPAL_KIND_CLERK:
+        filters = (
+            User.principal_kind == PRINCIPAL_KIND_CLERK,
+            User.clerk_id == owner.ref,
+        )
+    else:
+        filters = (
+            User.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT,
+            User.partner_tenant_ref == owner.ref,
+            User.clerk_id.is_(None),
+        )
+    target = (await db.execute(select(User).where(*filters))).scalar_one_or_none()
+    if target is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Owner not found")
+    return target
+
+
+async def _resolve_or_create_admin_owner(db: AsyncSession, owner: PlatformOwner) -> User:
+    if owner.kind == PRINCIPAL_KIND_CLERK:
+        return await _resolve_or_create_user(db, owner.ref)
+
+    target = (
+        await db.execute(
+            select(User).where(
+                User.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT,
+                User.partner_tenant_ref == owner.ref,
+                User.clerk_id.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    if target is not None:
+        return target
+    return await lazy_create_partner_user_with_personal_project(
+        db,
+        partner_tenant_ref=owner.ref,
+        race_loser_status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+    )
+
+
+def _managed_provider_request_owner(
+    provider_id: str,
+    body: AdminManagedAiProviderUpsert,
+) -> PlatformOwner:
+    if is_v2_deployment_managed_provider_id(provider_id):
+        if body.owner is None:
+            raise HTTPException(
+                status.HTTP_422_UNPROCESSABLE_CONTENT,
+                "owner is required for deployment-scoped managed AI providers",
+            )
+        return body.owner
+    if body.owner is not None:
+        return body.owner
+    if body.target_clerk_id is None:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, "owner is required")
+    return PlatformOwner(kind=PRINCIPAL_KIND_CLERK, ref=body.target_clerk_id)
+
+
+def _require_managed_provider_contract(provider: AiProvider) -> None:
+    if (
+        provider.type != MANAGED_AI_PROVIDER_TYPE
+        or provider.api_mode != MANAGED_AI_PROVIDER_API_MODE
+        or provider.auth_type != "api_key"
+        or provider.auth_ref is not None
+        or (provider.auth_metadata or {}).get("source") != "managed"
+        or provider.managed_by != "clawdi"
+        or provider.runtime_env_name != MANAGED_AI_PROVIDER_RUNTIME_ENV
+    ):
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "Stored managed AI provider contract is invalid",
+        )
+
+
+async def _admin_managed_provider_response(
+    db: AsyncSession,
+    *,
+    provider: AiProvider,
+    owner: PlatformOwner,
+    target: User,
+) -> AdminManagedAiProviderResponse:
+    _require_managed_provider_contract(provider)
+    try:
+        auth = ai_provider_auth_from_persistence(
+            provider.auth_type,
+            provider.auth_ref,
+            provider.auth_metadata,
+        )
+    except (ValidationError, ValueError) as exc:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "Stored managed AI provider auth metadata is invalid",
+        ) from exc
+    has_api_key = (
+        await db.scalar(
+            select(AiProviderAuthPayload.id).where(
+                AiProviderAuthPayload.owner_user_id == target.id,
+                AiProviderAuthPayload.provider_id == provider.provider_id,
+                AiProviderAuthPayload.auth_profile == MANAGED_AI_PROVIDER_PROFILE,
+                AiProviderAuthPayload.kind == "api_key",
+                AiProviderAuthPayload.source == "managed",
+                AiProviderAuthPayload.archived_at.is_(None),
+            )
+        )
+        is not None
+    )
+    return AdminManagedAiProviderResponse(
+        id=provider.id,
+        owner=owner,
+        owner_user_id=target.id,
+        owner_clerk_id=target.clerk_id,
+        provider_id=provider.provider_id,
+        scope=MANAGED_AI_PROVIDER_SCOPE,
+        type=MANAGED_AI_PROVIDER_TYPE,
+        label=provider.label or MANAGED_AI_PROVIDER_LABEL,
+        api_mode=provider.api_mode or "",
+        auth=auth,
+        managed_by="clawdi",
+        runtime_env_name=provider.runtime_env_name or "",
+        base_url=provider.base_url,
+        capabilities=provider.capabilities,
+        models=provider.models,
+        has_api_key=has_api_key,
+    )
 
 
 async def _assert_admin_target_owns_environment(
@@ -342,9 +486,41 @@ async def admin_revoke_api_key(
     return ApiKeyRevokeResponse(status="revoked")
 
 
+@router.get(
+    "/ai-providers/{provider_id}",
+    response_model=AdminManagedAiProviderResponse,
+    response_model_exclude_none=True,
+)
+async def admin_get_clawdi_managed_ai_provider(
+    provider_id: str,
+    owner: Annotated[PlatformOwner, Query()],
+    _: None = Depends(require_admin_api_key),
+    db: AsyncSession = Depends(get_session),
+) -> AdminManagedAiProviderResponse:
+    """Read one first-party managed provider within an explicit owner scope."""
+
+    if not is_v2_managed_provider_id(provider_id):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "managed AI provider not found")
+    target = await _find_admin_owner(db, owner)
+    provider = await find_clawdi_managed_provider(
+        db,
+        owner_user_id=target.id,
+        provider_id=provider_id,
+    )
+    if provider is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "managed AI provider not found")
+    return await _admin_managed_provider_response(
+        db,
+        provider=provider,
+        owner=owner,
+        target=target,
+    )
+
+
 @router.put(
     "/ai-providers/{provider_id}",
     response_model=AdminManagedAiProviderResponse,
+    response_model_exclude_none=True,
 )
 async def admin_upsert_clawdi_managed_ai_provider(
     provider_id: str,
@@ -355,14 +531,13 @@ async def admin_upsert_clawdi_managed_ai_provider(
     """Upsert the first-party managed AI provider for a target user.
 
     This intentionally does not expose a generic admin AI-provider write API.
-    Hosted deploy orchestration only needs to install the fixed
-    Clawdi-managed OpenAI-compatible chat provider and rotate its key.
+    Hosted deploy orchestration can install either the fixed imperative
+    provider or one deployment-scoped declarative provider and rotate its key.
     """
-    # TODO(#425): Remove legacy v2 route acceptance after hosted#892 is deployed
-    # everywhere and no dev/self-hosted binding still uses clawdi-managed-v2.
-    if provider_id not in V2_MANAGED_AI_PROVIDER_IDS:
+    if not is_v2_managed_provider_id(provider_id):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "managed AI provider not found")
-    target = await _resolve_or_create_user(db, body.target_clerk_id)
+    owner = _managed_provider_request_owner(provider_id, body)
+    target = await _resolve_or_create_admin_owner(db, owner)
     try:
         provider = await upsert_clawdi_managed_provider(
             db,
@@ -399,6 +574,8 @@ async def admin_upsert_clawdi_managed_ai_provider(
         details={
             "provider_id": provider.provider_id,
             "api_mode": MANAGED_AI_PROVIDER_API_MODE,
+            "scope": MANAGED_AI_PROVIDER_SCOPE,
+            "managed_by": provider.managed_by,
             "runtime_env_name": MANAGED_AI_PROVIDER_RUNTIME_ENV,
             "models": provider.models,
             "has_capabilities": body.capabilities is not None,
@@ -407,20 +584,72 @@ async def admin_upsert_clawdi_managed_ai_provider(
     await db.commit()
     await db.refresh(provider)
     logger.info(
-        "admin_managed_ai_provider_upserted target_clerk_id=%s provider_id=%s",
-        body.target_clerk_id,
+        "admin_managed_ai_provider_upserted owner_kind=%s owner_ref=%s provider_id=%s",
+        owner.kind,
+        owner.ref,
         provider.provider_id,
     )
-    return AdminManagedAiProviderResponse(
-        owner_user_id=target.id,
-        owner_clerk_id=target.clerk_id,
-        provider_id=provider.provider_id,
-        api_mode=provider.api_mode or "",
-        runtime_env_name=provider.runtime_env_name or "",
-        base_url=provider.base_url,
-        models=provider.models,
-        has_api_key=True,
+    return await _admin_managed_provider_response(
+        db,
+        provider=provider,
+        owner=owner,
+        target=target,
     )
+
+
+@router.delete(
+    "/ai-providers/{provider_id}",
+    response_model=AiProviderDeleteResponse,
+)
+async def admin_delete_clawdi_managed_ai_provider(
+    provider_id: str,
+    owner: Annotated[PlatformOwner, Query()],
+    _: None = Depends(require_admin_api_key),
+    db: AsyncSession = Depends(get_session),
+) -> AiProviderDeleteResponse:
+    """Archive one first-party managed provider within an explicit owner scope."""
+
+    if not is_v2_managed_provider_id(provider_id):
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "managed AI provider not found")
+    target = await _find_admin_owner(db, owner)
+    provider = await find_clawdi_managed_provider(
+        db,
+        owner_user_id=target.id,
+        provider_id=provider_id,
+    )
+    if provider is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "managed AI provider not found")
+    _require_managed_provider_contract(provider)
+    archived = await archive_clawdi_managed_provider(
+        db,
+        owner_user_id=target.id,
+        provider_id=provider_id,
+    )
+    if archived is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "managed AI provider not found")
+    await queue_provider_runtime_manifest_changed(db, target.id, provider_id)
+    record_control_plane_audit(
+        db,
+        actor_type="admin",
+        action="ai_provider.managed.delete",
+        resource_type="ai_provider",
+        resource_id=provider_id,
+        target_user_id=target.id,
+        source="api.admin",
+        details={
+            "provider_uuid": str(provider.id),
+            "provider_id": provider_id,
+            "scope": MANAGED_AI_PROVIDER_SCOPE,
+        },
+    )
+    await db.commit()
+    logger.info(
+        "admin_managed_ai_provider_deleted owner_kind=%s owner_ref=%s provider_id=%s",
+        owner.kind,
+        owner.ref,
+        provider_id,
+    )
+    return AiProviderDeleteResponse(status="deleted", provider_id=provider_id)
 
 
 @router.get("/channels", response_model=list[AdminChannelResponse])

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -61,6 +61,8 @@ from app.schemas.admin import (
     AdminChannelUpdate,
     AdminChannelVisibility,
     AdminChannelWebhookSecretResponse,
+    AdminDeploymentManagedAiProviderResponse,
+    AdminDeploymentManagedAiProviderUpsert,
     AdminEnvironmentCreate,
     AdminManagedAiProviderResponse,
     AdminManagedAiProviderUpsert,
@@ -97,10 +99,10 @@ from app.services.managed_ai_provider import (
     MANAGED_AI_PROVIDER_RUNTIME_ENV,
     MANAGED_AI_PROVIDER_SCOPE,
     MANAGED_AI_PROVIDER_TYPE,
+    V2_MANAGED_AI_PROVIDER_IDS,
     archive_clawdi_managed_provider,
     find_clawdi_managed_provider,
     is_v2_deployment_managed_provider_id,
-    is_v2_managed_provider_id,
     upsert_clawdi_managed_provider,
 )
 from app.services.runtime_observation import (
@@ -212,24 +214,6 @@ async def _resolve_or_create_admin_owner(db: AsyncSession, owner: PlatformOwner)
     )
 
 
-def _managed_provider_request_owner(
-    provider_id: str,
-    body: AdminManagedAiProviderUpsert,
-) -> PlatformOwner:
-    if is_v2_deployment_managed_provider_id(provider_id):
-        if body.owner is None:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_CONTENT,
-                "owner is required for deployment-scoped managed AI providers",
-            )
-        return body.owner
-    if body.owner is not None:
-        return body.owner
-    if body.target_clerk_id is None:
-        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, "owner is required")
-    return PlatformOwner(kind=PRINCIPAL_KIND_CLERK, ref=body.target_clerk_id)
-
-
 def _require_managed_provider_contract(provider: AiProvider) -> None:
     if (
         provider.type != MANAGED_AI_PROVIDER_TYPE
@@ -246,13 +230,13 @@ def _require_managed_provider_contract(provider: AiProvider) -> None:
         )
 
 
-async def _admin_managed_provider_response(
+async def _admin_deployment_managed_provider_response(
     db: AsyncSession,
     *,
     provider: AiProvider,
     owner: PlatformOwner,
     target: User,
-) -> AdminManagedAiProviderResponse:
+) -> AdminDeploymentManagedAiProviderResponse:
     _require_managed_provider_contract(provider)
     try:
         auth = ai_provider_auth_from_persistence(
@@ -278,7 +262,7 @@ async def _admin_managed_provider_response(
         )
         is not None
     )
-    return AdminManagedAiProviderResponse(
+    return AdminDeploymentManagedAiProviderResponse(
         id=provider.id,
         owner=owner,
         owner_user_id=target.id,
@@ -296,6 +280,97 @@ async def _admin_managed_provider_response(
         models=provider.models,
         has_api_key=has_api_key,
     )
+
+
+def _record_deployment_managed_provider_audit(
+    db: AsyncSession,
+    *,
+    action: str,
+    owner: PlatformOwner,
+    owner_user_id: UUID | None,
+    provider_id: str,
+    outcome: str,
+    provider_uuid: UUID | None = None,
+) -> None:
+    details: dict[str, Any] = {
+        "auth_method": "x_admin_key",
+        "owner": owner.model_dump(mode="json"),
+        "owner_user_id": str(owner_user_id) if owner_user_id is not None else None,
+        "provider_id": provider_id,
+        "outcome": outcome,
+    }
+    if provider_uuid is not None:
+        details["provider_uuid"] = str(provider_uuid)
+    record_control_plane_audit(
+        db,
+        actor_type="admin",
+        action=action,
+        resource_type="ai_provider",
+        resource_id=provider_id,
+        target_user_id=owner_user_id,
+        source="api.admin",
+        details=details,
+    )
+
+
+async def _find_deployment_managed_provider_owner(
+    db: AsyncSession,
+    *,
+    owner: PlatformOwner,
+    provider_id: str,
+    action: str,
+) -> User:
+    try:
+        return await _find_admin_owner(db, owner)
+    except HTTPException:
+        _record_deployment_managed_provider_audit(
+            db,
+            action=action,
+            owner=owner,
+            owner_user_id=None,
+            provider_id=provider_id,
+            outcome="failed",
+        )
+        await db.commit()
+        raise
+
+
+async def _raise_deployment_managed_provider_scope_denied(
+    db: AsyncSession,
+    *,
+    action: str,
+    owner: PlatformOwner,
+    owner_user_id: UUID,
+    provider_id: str,
+) -> None:
+    # Deliberately do not probe by provider id alone. A scoped miss is reported
+    # uniformly, so the admin contract neither leaks nor crosses another owner.
+    _record_deployment_managed_provider_audit(
+        db,
+        action=action,
+        owner=owner,
+        owner_user_id=owner_user_id,
+        provider_id=provider_id,
+        outcome="cross_owner_denied",
+    )
+    await db.commit()
+    raise HTTPException(status.HTTP_404_NOT_FOUND, "managed AI provider not found")
+
+
+def _deployment_managed_provider_query_owner(
+    *,
+    kind: str | None,
+    ref: str | None,
+) -> PlatformOwner:
+    if kind is None or ref is None:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_CONTENT, "owner is required")
+    try:
+        return PlatformOwner.model_validate({"kind": kind, "ref": ref})
+    except ValidationError as exc:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            "owner is invalid",
+        ) from exc
 
 
 async def _assert_admin_target_owns_environment(
@@ -488,55 +563,168 @@ async def admin_revoke_api_key(
 
 @router.get(
     "/ai-providers/{provider_id}",
-    response_model=AdminManagedAiProviderResponse,
+    response_model=AdminDeploymentManagedAiProviderResponse,
     response_model_exclude_none=True,
 )
 async def admin_get_clawdi_managed_ai_provider(
     provider_id: str,
-    owner: Annotated[PlatformOwner, Query()],
+    owner_kind: Annotated[str | None, Query(alias="kind")] = None,
+    owner_ref: Annotated[str | None, Query(alias="ref")] = None,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
-) -> AdminManagedAiProviderResponse:
+) -> AdminDeploymentManagedAiProviderResponse:
     """Read one first-party managed provider within an explicit owner scope."""
 
-    if not is_v2_managed_provider_id(provider_id):
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "managed AI provider not found")
-    target = await _find_admin_owner(db, owner)
+    if not is_v2_deployment_managed_provider_id(provider_id):
+        raise HTTPException(
+            status.HTTP_405_METHOD_NOT_ALLOWED,
+            "Method Not Allowed",
+            headers={"Allow": "PUT"},
+        )
+    owner = _deployment_managed_provider_query_owner(kind=owner_kind, ref=owner_ref)
+    action = "ai_provider.managed.read"
+    target = await _find_deployment_managed_provider_owner(
+        db,
+        owner=owner,
+        provider_id=provider_id,
+        action=action,
+    )
     provider = await find_clawdi_managed_provider(
         db,
         owner_user_id=target.id,
         provider_id=provider_id,
     )
     if provider is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "managed AI provider not found")
-    return await _admin_managed_provider_response(
+        await _raise_deployment_managed_provider_scope_denied(
+            db,
+            action=action,
+            owner=owner,
+            owner_user_id=target.id,
+            provider_id=provider_id,
+        )
+    try:
+        response = await _admin_deployment_managed_provider_response(
+            db,
+            provider=provider,
+            owner=owner,
+            target=target,
+        )
+    except HTTPException:
+        _record_deployment_managed_provider_audit(
+            db,
+            action=action,
+            owner=owner,
+            owner_user_id=target.id,
+            provider_id=provider_id,
+            provider_uuid=provider.id,
+            outcome="failed",
+        )
+        await db.commit()
+        raise
+    _record_deployment_managed_provider_audit(
         db,
-        provider=provider,
+        action=action,
         owner=owner,
-        target=target,
+        owner_user_id=target.id,
+        provider_id=provider_id,
+        provider_uuid=provider.id,
+        outcome="success",
     )
+    await db.commit()
+    return response
 
 
 @router.put(
     "/ai-providers/{provider_id}",
-    response_model=AdminManagedAiProviderResponse,
-    response_model_exclude_none=True,
+    response_model=AdminManagedAiProviderResponse | AdminDeploymentManagedAiProviderResponse,
 )
 async def admin_upsert_clawdi_managed_ai_provider(
     provider_id: str,
-    body: AdminManagedAiProviderUpsert,
+    body: AdminManagedAiProviderUpsert | AdminDeploymentManagedAiProviderUpsert,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
-) -> AdminManagedAiProviderResponse:
+) -> AdminManagedAiProviderResponse | AdminDeploymentManagedAiProviderResponse:
     """Upsert the first-party managed AI provider for a target user.
 
     This intentionally does not expose a generic admin AI-provider write API.
     Hosted deploy orchestration can install either the fixed imperative
     provider or one deployment-scoped declarative provider and rotate its key.
     """
-    if not is_v2_managed_provider_id(provider_id):
+    if provider_id in V2_MANAGED_AI_PROVIDER_IDS:
+        if not isinstance(body, AdminManagedAiProviderUpsert):
+            raise HTTPException(
+                status.HTTP_422_UNPROCESSABLE_CONTENT,
+                "target_clerk_id is required for fixed managed AI providers",
+            )
+        # Keep this branch byte-for-byte compatible with the original fixed
+        # clawdi-v2 / clawdi-managed-v2 admin contract.
+        target = await _resolve_or_create_user(db, body.target_clerk_id)
+        try:
+            provider = await upsert_clawdi_managed_provider(
+                db,
+                user=target,
+                provider_id=provider_id,
+                base_url=body.base_url,
+                api_key=body.api_key.get_secret_value(),
+                default_model=body.default_model,
+                models=(
+                    [model.model_dump(exclude_none=True) for model in body.models]
+                    if body.models is not None
+                    else None
+                ),
+                label=body.label,
+                capabilities=body.capabilities,
+            )
+        except ValueError as e:
+            raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(e)) from e
+
+        await queue_provider_runtime_manifest_changed(
+            db,
+            target.id,
+            provider.provider_id,
+        )
+        record_control_plane_audit(
+            db,
+            actor_type="admin",
+            action="ai_provider.managed.upsert",
+            resource_type="ai_provider",
+            resource_id=provider.provider_id,
+            target_user_id=target.id,
+            source="api.admin",
+            details={
+                "provider_id": provider.provider_id,
+                "api_mode": MANAGED_AI_PROVIDER_API_MODE,
+                "runtime_env_name": MANAGED_AI_PROVIDER_RUNTIME_ENV,
+                "models": provider.models,
+                "has_capabilities": body.capabilities is not None,
+            },
+        )
+        await db.commit()
+        await db.refresh(provider)
+        logger.info(
+            "admin_managed_ai_provider_upserted target_clerk_id=%s provider_id=%s",
+            body.target_clerk_id,
+            provider.provider_id,
+        )
+        return AdminManagedAiProviderResponse(
+            owner_user_id=target.id,
+            owner_clerk_id=target.clerk_id,
+            provider_id=provider.provider_id,
+            api_mode=provider.api_mode or "",
+            runtime_env_name=provider.runtime_env_name or "",
+            base_url=provider.base_url,
+            models=provider.models,
+            has_api_key=True,
+        )
+
+    if not is_v2_deployment_managed_provider_id(provider_id):
         raise HTTPException(status.HTTP_404_NOT_FOUND, "managed AI provider not found")
-    owner = _managed_provider_request_owner(provider_id, body)
+    if not isinstance(body, AdminDeploymentManagedAiProviderUpsert):
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            "owner is required for deployment-scoped managed AI providers",
+        )
+    owner = body.owner
     target = await _resolve_or_create_admin_owner(db, owner)
     try:
         provider = await upsert_clawdi_managed_provider(
@@ -555,31 +743,40 @@ async def admin_upsert_clawdi_managed_ai_provider(
             capabilities=body.capabilities,
         )
     except ValueError as e:
+        _record_deployment_managed_provider_audit(
+            db,
+            action="ai_provider.managed.upsert",
+            owner=owner,
+            owner_user_id=target.id,
+            provider_id=provider_id,
+            outcome="failed",
+        )
+        await db.commit()
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(e)) from e
 
+    await db.flush()
     await queue_provider_runtime_manifest_changed(
         db,
         target.id,
         provider.provider_id,
     )
-
-    record_control_plane_audit(
+    _record_deployment_managed_provider_audit(
         db,
-        actor_type="admin",
         action="ai_provider.managed.upsert",
-        resource_type="ai_provider",
-        resource_id=provider.provider_id,
-        target_user_id=target.id,
-        source="api.admin",
-        details={
-            "provider_id": provider.provider_id,
-            "api_mode": MANAGED_AI_PROVIDER_API_MODE,
-            "scope": MANAGED_AI_PROVIDER_SCOPE,
-            "managed_by": provider.managed_by,
-            "runtime_env_name": MANAGED_AI_PROVIDER_RUNTIME_ENV,
-            "models": provider.models,
-            "has_capabilities": body.capabilities is not None,
-        },
+        owner=owner,
+        owner_user_id=target.id,
+        provider_id=provider.provider_id,
+        provider_uuid=provider.id,
+        outcome="success",
+    )
+    _record_deployment_managed_provider_audit(
+        db,
+        action="ai_provider.managed.credential.rotate",
+        owner=owner,
+        owner_user_id=target.id,
+        provider_id=provider.provider_id,
+        provider_uuid=provider.id,
+        outcome="success",
     )
     await db.commit()
     await db.refresh(provider)
@@ -589,7 +786,7 @@ async def admin_upsert_clawdi_managed_ai_provider(
         owner.ref,
         provider.provider_id,
     )
-    return await _admin_managed_provider_response(
+    return await _admin_deployment_managed_provider_response(
         db,
         provider=provider,
         owner=owner,
@@ -603,44 +800,85 @@ async def admin_upsert_clawdi_managed_ai_provider(
 )
 async def admin_delete_clawdi_managed_ai_provider(
     provider_id: str,
-    owner: Annotated[PlatformOwner, Query()],
+    owner_kind: Annotated[str | None, Query(alias="kind")] = None,
+    owner_ref: Annotated[str | None, Query(alias="ref")] = None,
     _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> AiProviderDeleteResponse:
     """Archive one first-party managed provider within an explicit owner scope."""
 
-    if not is_v2_managed_provider_id(provider_id):
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "managed AI provider not found")
-    target = await _find_admin_owner(db, owner)
+    if not is_v2_deployment_managed_provider_id(provider_id):
+        raise HTTPException(
+            status.HTTP_405_METHOD_NOT_ALLOWED,
+            "Method Not Allowed",
+            headers={"Allow": "PUT"},
+        )
+    owner = _deployment_managed_provider_query_owner(kind=owner_kind, ref=owner_ref)
+    action = "ai_provider.managed.delete"
+    target = await _find_deployment_managed_provider_owner(
+        db,
+        owner=owner,
+        provider_id=provider_id,
+        action=action,
+    )
     provider = await find_clawdi_managed_provider(
         db,
         owner_user_id=target.id,
         provider_id=provider_id,
     )
     if provider is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "managed AI provider not found")
-    _require_managed_provider_contract(provider)
+        await _raise_deployment_managed_provider_scope_denied(
+            db,
+            action=action,
+            owner=owner,
+            owner_user_id=target.id,
+            provider_id=provider_id,
+        )
+    try:
+        _require_managed_provider_contract(provider)
+    except HTTPException:
+        _record_deployment_managed_provider_audit(
+            db,
+            action=action,
+            owner=owner,
+            owner_user_id=target.id,
+            provider_id=provider_id,
+            provider_uuid=provider.id,
+            outcome="failed",
+        )
+        await db.commit()
+        raise
     archived = await archive_clawdi_managed_provider(
         db,
         owner_user_id=target.id,
         provider_id=provider_id,
     )
     if archived is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "managed AI provider not found")
+        await _raise_deployment_managed_provider_scope_denied(
+            db,
+            action=action,
+            owner=owner,
+            owner_user_id=target.id,
+            provider_id=provider_id,
+        )
     await queue_provider_runtime_manifest_changed(db, target.id, provider_id)
-    record_control_plane_audit(
+    _record_deployment_managed_provider_audit(
         db,
-        actor_type="admin",
-        action="ai_provider.managed.delete",
-        resource_type="ai_provider",
-        resource_id=provider_id,
-        target_user_id=target.id,
-        source="api.admin",
-        details={
-            "provider_uuid": str(provider.id),
-            "provider_id": provider_id,
-            "scope": MANAGED_AI_PROVIDER_SCOPE,
-        },
+        action=action,
+        owner=owner,
+        owner_user_id=target.id,
+        provider_id=provider_id,
+        provider_uuid=provider.id,
+        outcome="success",
+    )
+    _record_deployment_managed_provider_audit(
+        db,
+        action="ai_provider.managed.credential.archive",
+        owner=owner,
+        owner_user_id=target.id,
+        provider_id=provider_id,
+        provider_uuid=provider.id,
+        outcome="success",
     )
     await db.commit()
     logger.info(

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -103,6 +103,7 @@ from app.services.managed_ai_provider import (
     archive_clawdi_managed_provider,
     find_clawdi_managed_provider,
     is_v2_deployment_managed_provider_id,
+    lock_deployment_managed_provider_mutation,
     upsert_clawdi_managed_provider,
 )
 from app.services.runtime_observation import (
@@ -726,6 +727,12 @@ async def admin_upsert_clawdi_managed_ai_provider(
         )
     owner = body.owner
     target = await _resolve_or_create_admin_owner(db, owner)
+    # This must precede the first provider/auth lookup in the upsert service.
+    await lock_deployment_managed_provider_mutation(
+        db,
+        owner_user_id=target.id,
+        provider_id=provider_id,
+    )
     try:
         provider = await upsert_clawdi_managed_provider(
             db,
@@ -820,6 +827,12 @@ async def admin_delete_clawdi_managed_ai_provider(
         owner=owner,
         provider_id=provider_id,
         action=action,
+    )
+    # Use the same transaction lock as PUT before checking archived state.
+    await lock_deployment_managed_provider_mutation(
+        db,
+        owner_user_id=target.id,
+        provider_id=provider_id,
     )
     provider = await find_clawdi_managed_provider(
         db,

--- a/backend/app/routes/ai_providers.py
+++ b/backend/app/routes/ai_providers.py
@@ -43,6 +43,8 @@ from app.schemas.ai_provider import (
 from app.services.managed_ai_provider import (
     MANAGED_AI_PROVIDER_IDS,
     MANAGED_AI_PROVIDER_RUNTIME_ENV,
+    V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX,
+    is_managed_provider_id,
     managed_provider_api_mode,
 )
 from app.services.sync_events import queue_provider_runtime_manifest_changed
@@ -897,7 +899,7 @@ def _validate_provider_models(body: AiProviderUpsert | AiProviderResponse) -> li
         if model_id in seen:
             errors.append(f"duplicate model id: {model_id}")
         seen.add(model_id)
-        if model_id.startswith("openai-codex/") and body.provider_id not in MANAGED_AI_PROVIDER_IDS:
+        if model_id.startswith("openai-codex/") and not is_managed_provider_id(body.provider_id):
             errors.append(
                 "model ids must use the OpenAI model id without the legacy openai-codex prefix"
             )
@@ -907,7 +909,7 @@ def _validate_provider_models(body: AiProviderUpsert | AiProviderResponse) -> li
 
 
 def _validate_managed_provider_contract(body: AiProviderUpsert | AiProviderResponse) -> list[str]:
-    is_managed_contract = body.provider_id in MANAGED_AI_PROVIDER_IDS or body.managed_by == "clawdi"
+    is_managed_contract = is_managed_provider_id(body.provider_id) or body.managed_by == "clawdi"
     if not is_managed_contract:
         return []
 
@@ -915,7 +917,10 @@ def _validate_managed_provider_contract(body: AiProviderUpsert | AiProviderRespo
     expected_api_mode = managed_provider_api_mode(body.provider_id)
     if expected_api_mode is None:
         allowed_ids = ", ".join(sorted(MANAGED_AI_PROVIDER_IDS))
-        errors.append(f"managed Clawdi provider must use provider_id one of: {allowed_ids}")
+        errors.append(
+            "managed Clawdi provider must use provider_id one of: "
+            f"{allowed_ids}, or {V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}<deployment_id>"
+        )
     if body.managed_by != "clawdi":
         errors.append("managed Clawdi provider must be managed_by clawdi")
     if body.type != "custom_openai_compatible":

--- a/backend/app/routes/ai_providers.py
+++ b/backend/app/routes/ai_providers.py
@@ -43,8 +43,6 @@ from app.schemas.ai_provider import (
 from app.services.managed_ai_provider import (
     MANAGED_AI_PROVIDER_IDS,
     MANAGED_AI_PROVIDER_RUNTIME_ENV,
-    V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX,
-    is_managed_provider_id,
     managed_provider_api_mode,
 )
 from app.services.sync_events import queue_provider_runtime_manifest_changed
@@ -899,7 +897,7 @@ def _validate_provider_models(body: AiProviderUpsert | AiProviderResponse) -> li
         if model_id in seen:
             errors.append(f"duplicate model id: {model_id}")
         seen.add(model_id)
-        if model_id.startswith("openai-codex/") and not is_managed_provider_id(body.provider_id):
+        if model_id.startswith("openai-codex/") and body.provider_id not in MANAGED_AI_PROVIDER_IDS:
             errors.append(
                 "model ids must use the OpenAI model id without the legacy openai-codex prefix"
             )
@@ -909,7 +907,7 @@ def _validate_provider_models(body: AiProviderUpsert | AiProviderResponse) -> li
 
 
 def _validate_managed_provider_contract(body: AiProviderUpsert | AiProviderResponse) -> list[str]:
-    is_managed_contract = is_managed_provider_id(body.provider_id) or body.managed_by == "clawdi"
+    is_managed_contract = body.provider_id in MANAGED_AI_PROVIDER_IDS or body.managed_by == "clawdi"
     if not is_managed_contract:
         return []
 
@@ -917,10 +915,7 @@ def _validate_managed_provider_contract(body: AiProviderUpsert | AiProviderRespo
     expected_api_mode = managed_provider_api_mode(body.provider_id)
     if expected_api_mode is None:
         allowed_ids = ", ".join(sorted(MANAGED_AI_PROVIDER_IDS))
-        errors.append(
-            "managed Clawdi provider must use provider_id one of: "
-            f"{allowed_ids}, or {V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}<deployment_id>"
-        )
+        errors.append(f"managed Clawdi provider must use provider_id one of: {allowed_ids}")
     if body.managed_by != "clawdi":
         errors.append("managed Clawdi provider must be managed_by clawdi")
     if body.type != "custom_openai_compatible":

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -212,9 +212,7 @@ class AdminManagedAiProviderUpsert(BaseModel):
 
     model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
 
-    owner: PlatformOwner | None = None
-    # Fixed/legacy callers keep the original target_clerk_id contract.
-    target_clerk_id: str | None = None
+    target_clerk_id: str
     base_url: str = Field(min_length=1, max_length=1000)
     api_key: SecretStr = Field(min_length=1)
     default_model: str | None = Field(default=None, max_length=300)
@@ -222,14 +220,33 @@ class AdminManagedAiProviderUpsert(BaseModel):
     label: str | None = Field(default=None, max_length=200)
     capabilities: dict[str, Any] | None = None
 
-    @model_validator(mode="after")
-    def _require_one_owner(self) -> AdminManagedAiProviderUpsert:
-        if (self.owner is None) == (self.target_clerk_id is None):
-            raise ValueError("exactly one of owner or target_clerk_id is required")
-        return self
-
 
 class AdminManagedAiProviderResponse(BaseModel):
+    owner_user_id: UUID
+    owner_clerk_id: str | None
+    provider_id: str
+    api_mode: str
+    runtime_env_name: str
+    base_url: str
+    models: list[dict[str, Any]] | None = None
+    has_api_key: bool
+
+
+class AdminDeploymentManagedAiProviderUpsert(BaseModel):
+    """Create or rotate one deployment-scoped first-party managed provider."""
+
+    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
+
+    owner: PlatformOwner
+    base_url: str = Field(min_length=1, max_length=1000)
+    api_key: SecretStr = Field(min_length=1)
+    default_model: str | None = Field(default=None, max_length=300)
+    models: list[AiProviderModel] | None = None
+    label: str | None = Field(default=None, max_length=200)
+    capabilities: dict[str, Any] | None = None
+
+
+class AdminDeploymentManagedAiProviderResponse(BaseModel):
     id: UUID
     owner: PlatformOwner
     owner_user_id: UUID

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -22,7 +22,8 @@ from pydantic import (
     model_validator,
 )
 
-from app.schemas.ai_provider import AiProviderModel
+from app.schemas.ai_provider import AiProviderAuth, AiProviderModel
+from app.schemas.platform import PlatformOwner
 from app.schemas.runtime import (
     HostedEgressEngine,
     HostedEgressProfiles,
@@ -211,7 +212,9 @@ class AdminManagedAiProviderUpsert(BaseModel):
 
     model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
 
-    target_clerk_id: str
+    owner: PlatformOwner | None = None
+    # Fixed/legacy callers keep the original target_clerk_id contract.
+    target_clerk_id: str | None = None
     base_url: str = Field(min_length=1, max_length=1000)
     api_key: SecretStr = Field(min_length=1)
     default_model: str | None = Field(default=None, max_length=300)
@@ -219,14 +222,28 @@ class AdminManagedAiProviderUpsert(BaseModel):
     label: str | None = Field(default=None, max_length=200)
     capabilities: dict[str, Any] | None = None
 
+    @model_validator(mode="after")
+    def _require_one_owner(self) -> AdminManagedAiProviderUpsert:
+        if (self.owner is None) == (self.target_clerk_id is None):
+            raise ValueError("exactly one of owner or target_clerk_id is required")
+        return self
+
 
 class AdminManagedAiProviderResponse(BaseModel):
+    id: UUID
+    owner: PlatformOwner
     owner_user_id: UUID
     owner_clerk_id: str | None
     provider_id: str
+    scope: Literal["account_global"]
+    type: Literal["custom_openai_compatible"]
+    label: str
     api_mode: str
+    auth: AiProviderAuth
+    managed_by: Literal["clawdi"]
     runtime_env_name: str
     base_url: str
+    capabilities: dict[str, Any] | None = None
     models: list[dict[str, Any]] | None = None
     has_api_key: bool
 

--- a/backend/app/services/managed_ai_provider.py
+++ b/backend/app/services/managed_ai_provider.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 from urllib.parse import urlparse
 from uuid import UUID
 
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.ai_provider import AiProvider, AiProviderAuthPayload
@@ -75,6 +75,24 @@ def validate_managed_provider_base_url(base_url: str) -> None:
     parsed = urlparse(base_url.strip())
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
         raise ValueError("base_url must be an http(s) URL")
+
+
+async def lock_deployment_managed_provider_mutation(
+    db: AsyncSession,
+    *,
+    owner_user_id: UUID,
+    provider_id: str,
+) -> None:
+    """Serialize deployment-provider PUT/DELETE for one owner scope.
+
+    The transaction lock identity matches the provider uniqueness boundary and
+    remains held through provider/auth writes, audit insertion, and commit.
+    """
+
+    if not is_v2_deployment_managed_provider_id(provider_id):
+        raise ValueError("unsupported deployment managed provider id")
+    lock_name = f"managed-ai-provider:{owner_user_id}:{provider_id}"
+    await db.execute(select(func.pg_advisory_xact_lock(func.hashtextextended(lock_name, 0))))
 
 
 async def upsert_clawdi_managed_provider(

--- a/backend/app/services/managed_ai_provider.py
+++ b/backend/app/services/managed_ai_provider.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime
 from urllib.parse import urlparse
+from uuid import UUID
 
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,6 +15,8 @@ from app.services.vault_crypto import encrypt
 V1_MANAGED_AI_PROVIDER_ID = "clawdi-managed"
 V1_MANAGED_AI_PROVIDER_API_MODE = "openai_responses"
 V2_MANAGED_AI_PROVIDER_ID = "clawdi-v2"
+V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX = "clawdi-v2-deployment-"
+V2_MANAGED_AI_PROVIDER_MAX_ID_LENGTH = 63
 # TODO(#425): Remove this legacy alias and transition accept-set after hosted#892
 # is deployed everywhere and no dev/self-hosted binding still uses clawdi-managed-v2.
 V2_LEGACY_MANAGED_AI_PROVIDER_ID = "clawdi-managed-v2"
@@ -32,6 +36,29 @@ MANAGED_AI_PROVIDER_RUNTIME_ENV = "CLAWDI_MANAGED_OPENAI_API_KEY"
 MANAGED_AI_PROVIDER_TYPE = "custom_openai_compatible"
 MANAGED_AI_PROVIDER_LABEL = "Clawdi managed"
 MANAGED_AI_PROVIDER_PROFILE = "default"
+MANAGED_AI_PROVIDER_SCOPE = "account_global"
+MANAGED_AI_PROVIDER_PROVENANCE_CAPABILITY = "clawdi_provisioning_discovery_key"
+
+_V2_DEPLOYMENT_ID_RE = re.compile(r"^[1-9][0-9]*$")
+
+
+def is_v2_deployment_managed_provider_id(provider_id: str) -> bool:
+    if len(provider_id) > V2_MANAGED_AI_PROVIDER_MAX_ID_LENGTH or not provider_id.startswith(
+        V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX
+    ):
+        return False
+    deployment_id = provider_id.removeprefix(V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX)
+    return _V2_DEPLOYMENT_ID_RE.fullmatch(deployment_id) is not None
+
+
+def is_v2_managed_provider_id(provider_id: str) -> bool:
+    return provider_id in V2_MANAGED_AI_PROVIDER_IDS or is_v2_deployment_managed_provider_id(
+        provider_id
+    )
+
+
+def is_managed_provider_id(provider_id: str) -> bool:
+    return provider_id == V1_MANAGED_AI_PROVIDER_ID or is_v2_managed_provider_id(provider_id)
 
 
 def managed_provider_api_mode(provider_id: str) -> str | None:
@@ -39,7 +66,7 @@ def managed_provider_api_mode(provider_id: str) -> str | None:
         return V1_MANAGED_AI_PROVIDER_API_MODE
     # TODO(#425): Remove legacy v2 mode resolution after hosted#892 is deployed
     # everywhere and no dev/self-hosted binding still uses clawdi-managed-v2.
-    if provider_id in V2_MANAGED_AI_PROVIDER_IDS:
+    if is_v2_managed_provider_id(provider_id):
         return V2_MANAGED_AI_PROVIDER_API_MODE
     return None
 
@@ -65,7 +92,7 @@ async def upsert_clawdi_managed_provider(
     """Upsert a first-party v2 managed AI provider contract for a user."""
     # TODO(#425): Remove legacy v2 upsert acceptance after hosted#892 is deployed
     # everywhere and no dev/self-hosted binding still uses clawdi-managed-v2.
-    if provider_id not in V2_MANAGED_AI_PROVIDER_IDS:
+    if not is_v2_managed_provider_id(provider_id):
         raise ValueError("unsupported managed provider id")
     validate_managed_provider_base_url(base_url)
     normalized_base_url = base_url.strip()
@@ -139,5 +166,54 @@ async def upsert_clawdi_managed_provider(
             AiProviderAuthPayload.archived_at.is_(None),
         )
         .values(archived_at=datetime.now(UTC))
+    )
+    return provider
+
+
+async def find_clawdi_managed_provider(
+    db: AsyncSession,
+    *,
+    owner_user_id: UUID,
+    provider_id: str,
+    include_archived: bool = False,
+) -> AiProvider | None:
+    """Find one managed provider without crossing its account boundary."""
+
+    if not is_v2_managed_provider_id(provider_id):
+        raise ValueError("unsupported managed provider id")
+    query = select(AiProvider).where(
+        AiProvider.owner_user_id == owner_user_id,
+        AiProvider.provider_id == provider_id,
+    )
+    if not include_archived:
+        query = query.where(AiProvider.archived_at.is_(None))
+    return (await db.execute(query)).scalar_one_or_none()
+
+
+async def archive_clawdi_managed_provider(
+    db: AsyncSession,
+    *,
+    owner_user_id: UUID,
+    provider_id: str,
+) -> AiProvider | None:
+    """Archive managed provider metadata and encrypted auth for one owner."""
+
+    provider = await find_clawdi_managed_provider(
+        db,
+        owner_user_id=owner_user_id,
+        provider_id=provider_id,
+    )
+    if provider is None:
+        return None
+    archived_at = datetime.now(UTC)
+    provider.archived_at = archived_at
+    await db.execute(
+        update(AiProviderAuthPayload)
+        .where(
+            AiProviderAuthPayload.owner_user_id == owner_user_id,
+            AiProviderAuthPayload.provider_id == provider_id,
+            AiProviderAuthPayload.archived_at.is_(None),
+        )
+        .values(archived_at=archived_at)
     )
     return provider

--- a/backend/app/services/managed_ai_provider.py
+++ b/backend/app/services/managed_ai_provider.py
@@ -66,7 +66,7 @@ def managed_provider_api_mode(provider_id: str) -> str | None:
         return V1_MANAGED_AI_PROVIDER_API_MODE
     # TODO(#425): Remove legacy v2 mode resolution after hosted#892 is deployed
     # everywhere and no dev/self-hosted binding still uses clawdi-managed-v2.
-    if is_v2_managed_provider_id(provider_id):
+    if provider_id in V2_MANAGED_AI_PROVIDER_IDS:
         return V2_MANAGED_AI_PROVIDER_API_MODE
     return None
 

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -41,7 +41,7 @@ from app.schemas.runtime import (
     validate_hosted_runtime_desired_state,
 )
 from app.services.managed_ai_provider import (
-    MANAGED_AI_PROVIDER_IDS,
+    is_managed_provider_id,
     managed_provider_api_mode,
 )
 from app.services.vault_crypto import decrypt
@@ -467,7 +467,7 @@ def _provider_entry(provider: AiProvider, *, secret_ref: str | None) -> dict[str
         "type": provider.type,
         "baseUrl": provider.base_url,
     }
-    managed = provider.provider_id in MANAGED_AI_PROVIDER_IDS or (
+    managed = is_managed_provider_id(provider.provider_id) or (
         provider.managed_by == "clawdi"
         and provider.auth_type == "api_key"
         and (provider.auth_metadata or {}).get("source") == "managed"

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -6,6 +6,7 @@ we verify the gate as part of test surface, not bypass it.
 """
 
 from collections.abc import AsyncIterator
+from uuid import UUID
 
 import httpx
 import pytest
@@ -16,6 +17,8 @@ from app.core.config import settings
 from app.core.database import get_session
 from app.main import app
 from app.services.managed_ai_provider import (
+    MANAGED_AI_PROVIDER_PROVENANCE_CAPABILITY,
+    V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX,
     V2_LEGACY_MANAGED_AI_PROVIDER_ID,
     V2_MANAGED_AI_PROVIDER_ID,
 )
@@ -799,11 +802,20 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
     )
     assert r.status_code == 200, r.text
     assert raw_key not in r.text
-    assert r.json() == {
+    response = r.json()
+    provider_uuid = response.pop("id")
+    assert str(UUID(provider_uuid)) == provider_uuid
+    assert response == {
+        "owner": {"kind": "clerk", "ref": seed_user.clerk_id},
         "owner_user_id": str(seed_user.id),
         "owner_clerk_id": seed_user.clerk_id,
         "provider_id": route_provider_id,
+        "scope": "account_global",
+        "type": "custom_openai_compatible",
+        "label": "Clawdi managed",
         "api_mode": MANAGED_AI_PROVIDER_API_MODE,
+        "auth": {"type": "api_key", "source": "managed", "profile": "default"},
+        "managed_by": "clawdi",
         "runtime_env_name": MANAGED_AI_PROVIDER_RUNTIME_ENV,
         "base_url": "https://ai-gateway.clawdi.ai/v1",
         "models": managed_models,
@@ -841,6 +853,245 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
     assert payload.source == "managed"
     assert payload.payload_metadata == {"runtime_env_name": MANAGED_AI_PROVIDER_RUNTIME_ENV}
     assert decrypt(payload.encrypted_payload, payload.nonce) == raw_key
+
+
+@pytest.mark.asyncio
+async def test_admin_deployment_managed_ai_provider_lifecycle_is_owner_scoped(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    from sqlalchemy import select
+
+    from app.models.ai_provider import AiProvider, AiProviderAuthPayload
+    from app.models.user import User
+
+    provider_id = f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}42"
+    marker = "provisioning-intent-42"
+    owner = {"kind": "clerk", "ref": seed_user.clerk_id}
+    created = await admin_client.put(
+        f"/v1/admin/ai-providers/{provider_id}",
+        headers=_AUTH,
+        json={
+            "owner": owner,
+            "base_url": "https://ai-gateway.clawdi.ai/v1",
+            "api_key": "sk-deployment-owner-one",
+            "models": [{"id": "gpt-5.5"}],
+            "capabilities": {
+                "chat": True,
+                MANAGED_AI_PROVIDER_PROVENANCE_CAPABILITY: marker,
+            },
+        },
+    )
+    assert created.status_code == 200, created.text
+    created_body = created.json()
+    assert str(UUID(created_body["id"])) == created_body["id"]
+    assert created_body == {
+        "id": created_body["id"],
+        "owner": owner,
+        "owner_user_id": str(seed_user.id),
+        "owner_clerk_id": seed_user.clerk_id,
+        "provider_id": provider_id,
+        "scope": "account_global",
+        "type": "custom_openai_compatible",
+        "label": "Clawdi managed",
+        "api_mode": "openai_chat",
+        "auth": {"type": "api_key", "source": "managed", "profile": "default"},
+        "managed_by": "clawdi",
+        "runtime_env_name": "CLAWDI_MANAGED_OPENAI_API_KEY",
+        "base_url": "https://ai-gateway.clawdi.ai/v1",
+        "capabilities": {
+            "chat": True,
+            MANAGED_AI_PROVIDER_PROVENANCE_CAPABILITY: marker,
+        },
+        "models": [{"id": "gpt-5.5"}],
+        "has_api_key": True,
+    }
+
+    discovered = await admin_client.get(
+        f"/v1/admin/ai-providers/{provider_id}",
+        headers=_AUTH,
+        params=owner,
+    )
+    assert discovered.status_code == 200, discovered.text
+    assert discovered.json() == created_body
+
+    other = User(clerk_id="managed_provider_other_owner")
+    db_session.add(other)
+    await db_session.flush()
+    other_owner = {"kind": "clerk", "ref": other.clerk_id}
+
+    cross_owner_get = await admin_client.get(
+        f"/v1/admin/ai-providers/{provider_id}",
+        headers=_AUTH,
+        params=other_owner,
+    )
+    assert cross_owner_get.status_code == 404, cross_owner_get.text
+    cross_owner_delete = await admin_client.delete(
+        f"/v1/admin/ai-providers/{provider_id}",
+        headers=_AUTH,
+        params=other_owner,
+    )
+    assert cross_owner_delete.status_code == 404, cross_owner_delete.text
+
+    deleted = await admin_client.delete(
+        f"/v1/admin/ai-providers/{provider_id}",
+        headers=_AUTH,
+        params=owner,
+    )
+    assert deleted.status_code == 200, deleted.text
+    assert deleted.json() == {"status": "deleted", "provider_id": provider_id}
+
+    provider = (
+        await db_session.execute(
+            select(AiProvider).where(
+                AiProvider.owner_user_id == seed_user.id,
+                AiProvider.provider_id == provider_id,
+            )
+        )
+    ).scalar_one()
+    payload = (
+        await db_session.execute(
+            select(AiProviderAuthPayload).where(
+                AiProviderAuthPayload.owner_user_id == seed_user.id,
+                AiProviderAuthPayload.provider_id == provider_id,
+            )
+        )
+    ).scalar_one()
+    assert provider.archived_at is not None
+    assert payload.archived_at is not None
+
+
+@pytest.mark.asyncio
+async def test_admin_deployment_managed_ai_provider_puts_are_isolated_per_owner(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    from sqlalchemy import select
+
+    from app.models.ai_provider import AiProviderAuthPayload
+    from app.models.user import User
+    from app.services.vault_crypto import decrypt
+
+    provider_id = f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}84"
+    other = User(clerk_id="managed_provider_second_owner")
+    db_session.add(other)
+    await db_session.flush()
+
+    responses = []
+    for user, raw_key in (
+        (seed_user, "sk-owner-one"),
+        (other, "sk-owner-two"),
+    ):
+        response = await admin_client.put(
+            f"/v1/admin/ai-providers/{provider_id}",
+            headers=_AUTH,
+            json={
+                "owner": {"kind": "clerk", "ref": user.clerk_id},
+                "base_url": "https://ai-gateway.clawdi.ai/v1",
+                "api_key": raw_key,
+            },
+        )
+        assert response.status_code == 200, response.text
+        responses.append(response.json())
+
+    assert responses[0]["id"] != responses[1]["id"]
+    payloads = (
+        (
+            await db_session.execute(
+                select(AiProviderAuthPayload).where(
+                    AiProviderAuthPayload.owner_user_id.in_([seed_user.id, other.id]),
+                    AiProviderAuthPayload.provider_id == provider_id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {
+        (payload.owner_user_id, decrypt(payload.encrypted_payload, payload.nonce))
+        for payload in payloads
+    } == {
+        (seed_user.id, "sk-owner-one"),
+        (other.id, "sk-owner-two"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_admin_deployment_managed_ai_provider_requires_unambiguous_owner(
+    admin_client,
+    seed_user,
+):
+    provider_id = f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}126"
+    missing_put = await admin_client.put(
+        f"/v1/admin/ai-providers/{provider_id}",
+        headers=_AUTH,
+        json={
+            "base_url": "https://ai-gateway.clawdi.ai/v1",
+            "api_key": "sk-missing-owner",
+        },
+    )
+    legacy_owner_put = await admin_client.put(
+        f"/v1/admin/ai-providers/{provider_id}",
+        headers=_AUTH,
+        json={
+            "target_clerk_id": seed_user.clerk_id,
+            "base_url": "https://ai-gateway.clawdi.ai/v1",
+            "api_key": "sk-legacy-owner-not-accepted",
+        },
+    )
+    ambiguous_put = await admin_client.put(
+        f"/v1/admin/ai-providers/{provider_id}",
+        headers=_AUTH,
+        json={
+            "owner": {"kind": "clerk", "ref": seed_user.clerk_id},
+            "target_clerk_id": "different_owner",
+            "base_url": "https://ai-gateway.clawdi.ai/v1",
+            "api_key": "sk-ambiguous-owner",
+        },
+    )
+    missing_get = await admin_client.get(
+        f"/v1/admin/ai-providers/{provider_id}",
+        headers=_AUTH,
+    )
+    missing_delete = await admin_client.delete(
+        f"/v1/admin/ai-providers/{provider_id}",
+        headers=_AUTH,
+    )
+
+    assert missing_put.status_code == 422, missing_put.text
+    assert legacy_owner_put.status_code == 422, legacy_owner_put.text
+    assert ambiguous_put.status_code == 422, ambiguous_put.text
+    assert missing_get.status_code == 422, missing_get.text
+    assert missing_delete.status_code == 422, missing_delete.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "provider_id",
+    [
+        "clawdi-v2-deployment-0",
+        "clawdi-v2-deployment-not-a-number",
+        f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}{'9' * 43}",
+    ],
+)
+async def test_admin_upsert_rejects_invalid_deployment_managed_provider_id(
+    admin_client,
+    seed_user,
+    provider_id,
+):
+    response = await admin_client.put(
+        f"/v1/admin/ai-providers/{provider_id}",
+        headers=_AUTH,
+        json={
+            "owner": {"kind": "clerk", "ref": seed_user.clerk_id},
+            "base_url": "https://ai-gateway.clawdi.ai/v1",
+            "api_key": "sk-invalid-deployment-provider-id",
+        },
+    )
+
+    assert response.status_code == 404, response.text
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -5,6 +5,8 @@ Auth via X-Admin-Key header (shared secret). Tests run against the
 we verify the gate as part of test surface, not bypass it.
 """
 
+import json
+from collections import Counter
 from collections.abc import AsyncIterator
 from uuid import UUID
 
@@ -789,6 +791,17 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
             "supports_reasoning": True,
         }
     ]
+    wire_models = [
+        {
+            "id": "gpt-5.4-mini",
+            "max_tokens": 128000,
+            "context_window": 272000,
+            "supports_tools": True,
+            "supports_vision": True,
+            "input_modalities": ["text", "image"],
+            "supports_reasoning": True,
+        }
+    ]
     r = await admin_client.put(
         f"/v1/admin/ai-providers/{route_provider_id}",
         headers=_AUTH,
@@ -802,25 +815,18 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
     )
     assert r.status_code == 200, r.text
     assert raw_key not in r.text
-    response = r.json()
-    provider_uuid = response.pop("id")
-    assert str(UUID(provider_uuid)) == provider_uuid
-    assert response == {
-        "owner": {"kind": "clerk", "ref": seed_user.clerk_id},
+    expected_response = {
         "owner_user_id": str(seed_user.id),
         "owner_clerk_id": seed_user.clerk_id,
         "provider_id": route_provider_id,
-        "scope": "account_global",
-        "type": "custom_openai_compatible",
-        "label": "Clawdi managed",
         "api_mode": MANAGED_AI_PROVIDER_API_MODE,
-        "auth": {"type": "api_key", "source": "managed", "profile": "default"},
-        "managed_by": "clawdi",
         "runtime_env_name": MANAGED_AI_PROVIDER_RUNTIME_ENV,
         "base_url": "https://ai-gateway.clawdi.ai/v1",
-        "models": managed_models,
+        "models": wire_models,
         "has_api_key": True,
     }
+    assert r.json() == expected_response
+    assert r.content == json.dumps(expected_response, separators=(",", ":")).encode()
 
     provider = (
         await db_session.execute(
@@ -854,9 +860,75 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
     assert payload.payload_metadata == {"runtime_env_name": MANAGED_AI_PROVIDER_RUNTIME_ENV}
     assert decrypt(payload.encrypted_payload, payload.nonce) == raw_key
 
+    for method in (admin_client.get, admin_client.delete):
+        unchanged_method_response = await method(
+            f"/v1/admin/ai-providers/{route_provider_id}",
+            headers=_AUTH,
+        )
+        assert unchanged_method_response.status_code == 405
+        assert unchanged_method_response.headers["allow"] == "PUT"
+        assert unchanged_method_response.content == b'{"detail":"Method Not Allowed"}'
+
+    from app.models.audit import ControlPlaneAuditEvent
+
+    event = (
+        await db_session.execute(
+            select(ControlPlaneAuditEvent).where(
+                ControlPlaneAuditEvent.action == "ai_provider.managed.upsert",
+                ControlPlaneAuditEvent.resource_id == route_provider_id,
+            )
+        )
+    ).scalar_one()
+    assert event.actor_type == "admin"
+    assert event.target_user_id == seed_user.id
+    assert event.source == "api.admin"
+    audit_models = [{**managed_models[0], "max_tokens": "[REDACTED]"}]
+    assert event.details == {
+        "provider_id": route_provider_id,
+        "api_mode": MANAGED_AI_PROVIDER_API_MODE,
+        "runtime_env_name": MANAGED_AI_PROVIDER_RUNTIME_ENV,
+        "models": audit_models,
+        "has_capabilities": False,
+    }
+
 
 @pytest.mark.asyncio
-async def test_admin_deployment_managed_ai_provider_lifecycle_is_owner_scoped(
+async def test_admin_fixed_managed_ai_provider_preserves_null_models_wire_response(
+    admin_client,
+    seed_user,
+):
+    from app.services.managed_ai_provider import (
+        MANAGED_AI_PROVIDER_API_MODE,
+        MANAGED_AI_PROVIDER_RUNTIME_ENV,
+    )
+
+    response = await admin_client.put(
+        f"/v1/admin/ai-providers/{V2_MANAGED_AI_PROVIDER_ID}",
+        headers=_AUTH,
+        json={
+            "target_clerk_id": seed_user.clerk_id,
+            "base_url": "https://ai-gateway.clawdi.ai/v1",
+            "api_key": "sk-fixed-null-models",
+        },
+    )
+
+    expected = {
+        "owner_user_id": str(seed_user.id),
+        "owner_clerk_id": seed_user.clerk_id,
+        "provider_id": V2_MANAGED_AI_PROVIDER_ID,
+        "api_mode": MANAGED_AI_PROVIDER_API_MODE,
+        "runtime_env_name": MANAGED_AI_PROVIDER_RUNTIME_ENV,
+        "base_url": "https://ai-gateway.clawdi.ai/v1",
+        "models": None,
+        "has_api_key": True,
+    }
+    assert response.status_code == 200, response.text
+    assert response.json() == expected
+    assert response.content == json.dumps(expected, separators=(",", ":")).encode()
+
+
+@pytest.mark.asyncio
+async def test_admin_deployment_managed_ai_provider_lifecycle_is_owner_scoped_and_audited(
     admin_client,
     db_session,
     seed_user,
@@ -864,6 +936,7 @@ async def test_admin_deployment_managed_ai_provider_lifecycle_is_owner_scoped(
     from sqlalchemy import select
 
     from app.models.ai_provider import AiProvider, AiProviderAuthPayload
+    from app.models.audit import ControlPlaneAuditEvent
     from app.models.user import User
 
     provider_id = f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}42"
@@ -934,6 +1007,16 @@ async def test_admin_deployment_managed_ai_provider_lifecycle_is_owner_scoped(
     )
     assert cross_owner_delete.status_code == 404, cross_owner_delete.text
 
+    still_active = (
+        await db_session.execute(
+            select(AiProvider).where(
+                AiProvider.owner_user_id == seed_user.id,
+                AiProvider.provider_id == provider_id,
+            )
+        )
+    ).scalar_one()
+    assert still_active.archived_at is None
+
     deleted = await admin_client.delete(
         f"/v1/admin/ai-providers/{provider_id}",
         headers=_AUTH,
@@ -960,6 +1043,44 @@ async def test_admin_deployment_managed_ai_provider_lifecycle_is_owner_scoped(
     ).scalar_one()
     assert provider.archived_at is not None
     assert payload.archived_at is not None
+
+    audit_events = (
+        (
+            await db_session.execute(
+                select(ControlPlaneAuditEvent).where(
+                    ControlPlaneAuditEvent.resource_type == "ai_provider",
+                    ControlPlaneAuditEvent.resource_id == provider_id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert Counter(
+        (event.action, event.details["outcome"], event.target_user_id) for event in audit_events
+    ) == Counter(
+        [
+            ("ai_provider.managed.upsert", "success", seed_user.id),
+            ("ai_provider.managed.credential.rotate", "success", seed_user.id),
+            ("ai_provider.managed.read", "success", seed_user.id),
+            ("ai_provider.managed.read", "cross_owner_denied", other.id),
+            ("ai_provider.managed.delete", "cross_owner_denied", other.id),
+            ("ai_provider.managed.delete", "success", seed_user.id),
+            ("ai_provider.managed.credential.archive", "success", seed_user.id),
+        ]
+    )
+    expected_owners = {
+        seed_user.id: owner,
+        other.id: other_owner,
+    }
+    for event in audit_events:
+        assert event.actor_type == "admin"
+        assert event.source == "api.admin"
+        assert event.created_at is not None
+        assert event.details["auth_method"] == "x_admin_key"
+        assert event.details["owner"] == expected_owners[event.target_user_id]
+        assert event.details["owner_user_id"] == str(event.target_user_id)
+        assert event.details["provider_id"] == provider_id
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -5,15 +5,18 @@ Auth via X-Admin-Key header (shared secret). Tests run against the
 we verify the gate as part of test surface, not bypass it.
 """
 
+import asyncio
 import json
 from collections import Counter
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from uuid import UUID
 
 import httpx
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport
+from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from app.core.config import settings
 from app.core.database import get_session
@@ -56,6 +59,30 @@ async def admin_client(db_session, seed_user) -> AsyncIterator[httpx.AsyncClient
         transport = ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
             yield ac
+    finally:
+        app.dependency_overrides.clear()
+        settings.admin_api_key = original_admin_key
+
+
+@asynccontextmanager
+async def _isolated_admin_client(engine) -> AsyncIterator[httpx.AsyncClient]:
+    """Give concurrent requests independent real PostgreSQL transactions."""
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def _override_get_session():
+        async with session_factory() as session:
+            yield session
+
+    original_admin_key = settings.admin_api_key
+    settings.admin_api_key = _ADMIN_KEY
+    app.dependency_overrides[get_session] = _override_get_session
+    try:
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app, raise_app_exceptions=False),
+            base_url="http://test",
+        ) as client:
+            yield client
     finally:
         app.dependency_overrides.clear()
         settings.admin_api_key = original_admin_key
@@ -1081,6 +1108,274 @@ async def test_admin_deployment_managed_ai_provider_lifecycle_is_owner_scoped_an
         assert event.details["owner"] == expected_owners[event.target_user_id]
         assert event.details["owner_user_id"] == str(event.target_user_id)
         assert event.details["provider_id"] == provider_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_concurrent_first_deployment_provider_puts_serialize_and_converge(
+    engine,
+    seed_user,
+    monkeypatch,
+):
+    from sqlalchemy import select
+
+    from app.models.ai_provider import AiProvider, AiProviderAuthPayload
+    from app.models.audit import ControlPlaneAuditEvent
+    from app.routes import admin as admin_routes
+    from app.services.vault_crypto import decrypt
+
+    provider_id = f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}8401"
+    owner = {"kind": "clerk", "ref": seed_user.clerk_id}
+    first_upsert_entered = asyncio.Event()
+    release_first_upsert = asyncio.Event()
+    second_lock_attempted = asyncio.Event()
+    upsert_calls = 0
+    lock_calls = 0
+    original_upsert = admin_routes.upsert_clawdi_managed_provider
+    original_lock = admin_routes.lock_deployment_managed_provider_mutation
+
+    async def paused_first_upsert(*args, **kwargs):
+        nonlocal upsert_calls
+        upsert_calls += 1
+        if upsert_calls == 1:
+            first_upsert_entered.set()
+            await release_first_upsert.wait()
+        return await original_upsert(*args, **kwargs)
+
+    async def observed_lock(*args, **kwargs):
+        nonlocal lock_calls
+        lock_calls += 1
+        if lock_calls == 2:
+            second_lock_attempted.set()
+        return await original_lock(*args, **kwargs)
+
+    monkeypatch.setattr(admin_routes, "upsert_clawdi_managed_provider", paused_first_upsert)
+    monkeypatch.setattr(
+        admin_routes,
+        "lock_deployment_managed_provider_mutation",
+        observed_lock,
+    )
+
+    async with _isolated_admin_client(engine) as client:
+        first_request = asyncio.create_task(
+            client.put(
+                f"/v1/admin/ai-providers/{provider_id}",
+                headers=_AUTH,
+                json={
+                    "owner": owner,
+                    "base_url": "https://first-gateway.example.test/v1",
+                    "api_key": "sk-concurrent-first",
+                },
+            )
+        )
+        await asyncio.wait_for(first_upsert_entered.wait(), timeout=5)
+        second_request = asyncio.create_task(
+            client.put(
+                f"/v1/admin/ai-providers/{provider_id}",
+                headers=_AUTH,
+                json={
+                    "owner": owner,
+                    "base_url": "https://second-gateway.example.test/v1",
+                    "api_key": "sk-concurrent-second",
+                },
+            )
+        )
+        try:
+            await asyncio.wait_for(second_lock_attempted.wait(), timeout=5)
+            await asyncio.sleep(0.05)
+            second_waited_for_first_transaction = not second_request.done() and upsert_calls == 1
+        except BaseException:
+            release_first_upsert.set()
+            await asyncio.gather(first_request, second_request, return_exceptions=True)
+            raise
+        release_first_upsert.set()
+        responses = await asyncio.wait_for(
+            asyncio.gather(first_request, second_request),
+            timeout=10,
+        )
+
+    assert second_waited_for_first_transaction
+    assert [response.status_code for response in responses] == [200, 200]
+    assert responses[0].json()["id"] == responses[1].json()["id"]
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as verify_db:
+        providers = (
+            (
+                await verify_db.execute(
+                    select(AiProvider).where(
+                        AiProvider.owner_user_id == seed_user.id,
+                        AiProvider.provider_id == provider_id,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        payloads = (
+            (
+                await verify_db.execute(
+                    select(AiProviderAuthPayload).where(
+                        AiProviderAuthPayload.owner_user_id == seed_user.id,
+                        AiProviderAuthPayload.provider_id == provider_id,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        audit_events = (
+            (
+                await verify_db.execute(
+                    select(ControlPlaneAuditEvent).where(
+                        ControlPlaneAuditEvent.resource_id == provider_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert len(providers) == 1
+    assert providers[0].base_url == "https://second-gateway.example.test/v1"
+    assert providers[0].archived_at is None
+    assert len(payloads) == 1
+    assert payloads[0].archived_at is None
+    assert decrypt(payloads[0].encrypted_payload, payloads[0].nonce) == "sk-concurrent-second"
+    assert Counter(event.action for event in audit_events) == Counter(
+        {
+            "ai_provider.managed.upsert": 2,
+            "ai_provider.managed.credential.rotate": 2,
+        }
+    )
+    assert all(event.details["outcome"] == "success" for event in audit_events)
+
+
+@pytest.mark.asyncio
+@pytest.mark.committed_db
+async def test_deployment_provider_put_and_delete_serialize_on_the_same_lock(
+    engine,
+    seed_user,
+    monkeypatch,
+):
+    from sqlalchemy import select
+
+    from app.models.ai_provider import AiProvider, AiProviderAuthPayload
+    from app.routes import admin as admin_routes
+    from app.services.vault_crypto import decrypt
+
+    provider_id = f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}8402"
+    owner = {"kind": "clerk", "ref": seed_user.clerk_id}
+    baseline_body = {
+        "owner": owner,
+        "base_url": "https://baseline-gateway.example.test/v1",
+        "api_key": "sk-race-baseline",
+    }
+
+    async with _isolated_admin_client(engine) as client:
+        baseline = await client.put(
+            f"/v1/admin/ai-providers/{provider_id}",
+            headers=_AUTH,
+            json=baseline_body,
+        )
+        assert baseline.status_code == 200, baseline.text
+
+        put_holds_lock = asyncio.Event()
+        release_put = asyncio.Event()
+        delete_lock_attempted = asyncio.Event()
+        lock_calls = 0
+        original_upsert = admin_routes.upsert_clawdi_managed_provider
+        original_lock = admin_routes.lock_deployment_managed_provider_mutation
+
+        async def paused_put(*args, **kwargs):
+            put_holds_lock.set()
+            await release_put.wait()
+            return await original_upsert(*args, **kwargs)
+
+        async def observed_lock(*args, **kwargs):
+            nonlocal lock_calls
+            lock_calls += 1
+            if lock_calls == 2:
+                delete_lock_attempted.set()
+            return await original_lock(*args, **kwargs)
+
+        monkeypatch.setattr(admin_routes, "upsert_clawdi_managed_provider", paused_put)
+        monkeypatch.setattr(
+            admin_routes,
+            "lock_deployment_managed_provider_mutation",
+            observed_lock,
+        )
+
+        put_request = asyncio.create_task(
+            client.put(
+                f"/v1/admin/ai-providers/{provider_id}",
+                headers=_AUTH,
+                json={
+                    "owner": owner,
+                    "base_url": "https://race-winner-gateway.example.test/v1",
+                    "api_key": "sk-race-put",
+                },
+            )
+        )
+        await asyncio.wait_for(put_holds_lock.wait(), timeout=5)
+        delete_request = asyncio.create_task(
+            client.delete(
+                f"/v1/admin/ai-providers/{provider_id}",
+                headers=_AUTH,
+                params=owner,
+            )
+        )
+        try:
+            await asyncio.wait_for(delete_lock_attempted.wait(), timeout=5)
+            await asyncio.sleep(0.05)
+            delete_waited_for_put_transaction = not delete_request.done()
+        except BaseException:
+            release_put.set()
+            await asyncio.gather(put_request, delete_request, return_exceptions=True)
+            raise
+        release_put.set()
+        put_response, delete_response = await asyncio.wait_for(
+            asyncio.gather(put_request, delete_request),
+            timeout=10,
+        )
+
+    assert delete_waited_for_put_transaction
+    assert put_response.status_code == 200, put_response.text
+    assert delete_response.status_code == 200, delete_response.text
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as verify_db:
+        providers = (
+            (
+                await verify_db.execute(
+                    select(AiProvider).where(
+                        AiProvider.owner_user_id == seed_user.id,
+                        AiProvider.provider_id == provider_id,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        payloads = (
+            (
+                await verify_db.execute(
+                    select(AiProviderAuthPayload).where(
+                        AiProviderAuthPayload.owner_user_id == seed_user.id,
+                        AiProviderAuthPayload.provider_id == provider_id,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    assert len(providers) == 1
+    assert providers[0].base_url == "https://race-winner-gateway.example.test/v1"
+    assert providers[0].archived_at is not None
+    assert len(payloads) == 1
+    assert payloads[0].archived_at is not None
+    assert decrypt(payloads[0].encrypted_payload, payloads[0].nonce) == "sk-race-put"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -31,12 +31,18 @@ _TEST_SYSTEM = {}
     [
         V2_MANAGED_AI_PROVIDER_ID,
         V2_LEGACY_MANAGED_AI_PROVIDER_ID,
-        f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}42",
     ],
 )
 def test_v2_managed_ai_provider_ids_resolve_to_chat_mode(provider_id: str):
     assert is_v2_managed_provider_id(provider_id)
     assert managed_provider_api_mode(provider_id) == V2_MANAGED_AI_PROVIDER_API_MODE
+
+
+def test_v1_provider_mode_resolution_does_not_accept_deployment_scoped_ids():
+    provider_id = f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}42"
+
+    assert is_v2_managed_provider_id(provider_id)
+    assert managed_provider_api_mode(provider_id) is None
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -14,10 +14,11 @@ from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeState
 from app.services import sync_events
 from app.services.managed_ai_provider import (
-    MANAGED_AI_PROVIDER_IDS,
+    V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX,
     V2_LEGACY_MANAGED_AI_PROVIDER_ID,
     V2_MANAGED_AI_PROVIDER_API_MODE,
     V2_MANAGED_AI_PROVIDER_ID,
+    is_v2_managed_provider_id,
     managed_provider_api_mode,
 )
 from tests.conftest import create_env_with_project
@@ -27,11 +28,30 @@ _TEST_SYSTEM = {}
 
 @pytest.mark.parametrize(
     "provider_id",
-    [V2_MANAGED_AI_PROVIDER_ID, V2_LEGACY_MANAGED_AI_PROVIDER_ID],
+    [
+        V2_MANAGED_AI_PROVIDER_ID,
+        V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+        f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}42",
+    ],
 )
 def test_v2_managed_ai_provider_ids_resolve_to_chat_mode(provider_id: str):
-    assert provider_id in MANAGED_AI_PROVIDER_IDS
+    assert is_v2_managed_provider_id(provider_id)
     assert managed_provider_api_mode(provider_id) == V2_MANAGED_AI_PROVIDER_API_MODE
+
+
+@pytest.mark.parametrize(
+    "provider_id",
+    [
+        "clawdi-v2-deployment-",
+        "clawdi-v2-deployment-0",
+        "clawdi-v2-deployment-01",
+        "clawdi-v2-deployment-not-a-number",
+        f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}{'9' * 43}",
+    ],
+)
+def test_v2_managed_ai_provider_rejects_invalid_deployment_ids(provider_id: str):
+    assert not is_v2_managed_provider_id(provider_id)
+    assert managed_provider_api_mode(provider_id) is None
 
 
 _VALID_AUTH_VARIANTS = [

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -30,12 +30,10 @@ import type {
 	AiProviderType,
 } from "@clawdi/shared";
 import {
-	CLAWDI_MANAGED_PROVIDER_IDS,
 	CLAWDI_MANAGED_V1_PROVIDER_ID,
-	CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
-	CLAWDI_MANAGED_V2_PROVIDER_ID,
 	isAiProviderApiMode,
 	isAiProviderType,
+	isClawdiManagedV2ProviderId,
 } from "@clawdi/shared";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { z } from "zod";
@@ -2003,17 +2001,16 @@ function agentTargetProjectionInput(
 		// TODO(#425): Remove legacy projection handling after hosted#892 is deployed
 		// everywhere and no dev/self-hosted binding still uses clawdi-managed-v2.
 		const id =
-			CLAWDI_MANAGED_PROVIDER_IDS.has(provider.id) || provider.id.startsWith("clawdi-managed")
+			isClawdiManagedV2ProviderId(provider.id) ||
+			provider.id === CLAWDI_MANAGED_V1_PROVIDER_ID ||
+			provider.id.startsWith("clawdi-managed")
 				? provider.id
 				: CLAWDI_MANAGED_V1_PROVIDER_ID;
 		providerIdMap.set(provider.id, id);
 		return {
 			...provider,
 			id,
-			api_mode:
-				id === CLAWDI_MANAGED_V2_PROVIDER_ID || id === CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID
-					? "openai_chat"
-					: "openai_responses",
+			api_mode: isClawdiManagedV2ProviderId(id) ? "openai_chat" : "openai_responses",
 		} satisfies AiProviderCatalog["providers"][number];
 	});
 	const primaryProviderId = providerIdMap.get(input.primaryModel.provider_id);

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -2958,6 +2958,7 @@ chmod +x "$HOME/.local/bin/hermes"
 	});
 
 	it("preserves canonical managed model capabilities through live discovery", () => {
+		const providerId = "clawdi-v2-deployment-42";
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -3008,9 +3009,9 @@ chmod +x "$HOME/.local/bin/hermes"
 							home,
 							args: ["--json", "--no-onboard"],
 						},
-						provider_ids: ["clawdi-v2"],
+						provider_ids: [providerId],
 						primary_model: {
-							provider_id: "clawdi-v2",
+							provider_id: providerId,
 							model: "k3",
 						},
 					},
@@ -3019,7 +3020,7 @@ chmod +x "$HOME/.local/bin/hermes"
 					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
 					system: { home },
 					providers: {
-						"clawdi-v2": {
+						[providerId]: {
 							kind: "openai-compatible",
 							baseUrl: "https://ai-gateway.example.test/v1",
 							model: "k3",
@@ -3074,9 +3075,9 @@ chmod +x "$HOME/.local/bin/hermes"
 
 		expect(convergence.installErrors).toEqual([]);
 		const patch = JSON.parse(readFileSync(openclawPatch, "utf-8"));
-		expect(patch.agents.defaults.model.primary).toBe("clawdi-v2/k3");
-		expect(patch.models.providers["clawdi-v2"].baseUrl).toBe("https://ai-gateway.example.test/v1");
-		expect(patch.models.providers["clawdi-v2"].models).toEqual([
+		expect(patch.agents.defaults.model.primary).toBe(`${providerId}/k3`);
+		expect(patch.models.providers[providerId].baseUrl).toBe("https://ai-gateway.example.test/v1");
+		expect(patch.models.providers[providerId].models).toEqual([
 			{
 				id: "k3",
 				name: "k3",

--- a/packages/shared/src/ai-provider.test.ts
+++ b/packages/shared/src/ai-provider.test.ts
@@ -3,11 +3,13 @@ import {
 	type AiProviderAuth,
 	CLAWDI_MANAGED_PROVIDER_IDS,
 	CLAWDI_MANAGED_V1_PROVIDER_ID,
+	CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX,
 	CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
 	CLAWDI_MANAGED_V2_PROVIDER_ID,
 	CODEX_OAUTH_MODEL_CATALOG,
 	defaultAiProviderModels,
 	defaultAiProviderRuntimeEnvName,
+	isClawdiManagedV2ProviderId,
 	isFirstPartyManagedAiProvider,
 	isProviderAuthProfileId,
 	validateAiProviderCatalog,
@@ -291,6 +293,7 @@ describe("validateAiProviderCatalog", () => {
 	test.each([
 		CLAWDI_MANAGED_V2_PROVIDER_ID,
 		CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
+		`${CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX}42`,
 	])("accepts v2 Clawdi-managed provider %s in OpenAI chat mode", (providerId) => {
 		const result = validateAiProviderCatalog({
 			schema_version: 1,
@@ -311,6 +314,16 @@ describe("validateAiProviderCatalog", () => {
 
 		expect(result.valid).toBe(true);
 		expect(result.errors).toEqual([]);
+	});
+
+	test.each([
+		"clawdi-v2-deployment-",
+		"clawdi-v2-deployment-0",
+		"clawdi-v2-deployment-01",
+		"clawdi-v2-deployment-invalid",
+		`${CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX}${"9".repeat(43)}`,
+	])("rejects invalid deployment-scoped managed provider id %s", (providerId) => {
+		expect(isClawdiManagedV2ProviderId(providerId)).toBe(false);
 	});
 
 	test("accepts v1 Clawdi-managed providers in OpenAI responses mode", () => {
@@ -371,6 +384,11 @@ describe("isFirstPartyManagedAiProvider", () => {
 		expect(
 			isFirstPartyManagedAiProvider({
 				provider_id: CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
+			}),
+		).toBe(true);
+		expect(
+			isFirstPartyManagedAiProvider({
+				provider_id: `${CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX}42`,
 			}),
 		).toBe(true);
 		expect(CLAWDI_MANAGED_PROVIDER_IDS.has(CLAWDI_MANAGED_V2_PROVIDER_ID)).toBe(true);

--- a/packages/shared/src/ai-provider.ts
+++ b/packages/shared/src/ai-provider.ts
@@ -168,6 +168,8 @@ export const CODEX_OAUTH_MODEL_CATALOG: readonly AiProviderModel[] = [
 export const CLAWDI_MANAGED_V1_PROVIDER_ID = "clawdi-managed";
 const CLAWDI_MANAGED_V1_API_MODE = "openai_responses";
 export const CLAWDI_MANAGED_V2_PROVIDER_ID = "clawdi-v2";
+export const CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX = "clawdi-v2-deployment-";
+const CLAWDI_MANAGED_PROVIDER_MAX_ID_LENGTH = 63;
 // TODO(#425): Remove this legacy alias after hosted#892 is deployed everywhere and no
 // dev/self-hosted binding still uses clawdi-managed-v2.
 export const CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID = "clawdi-managed-v2";
@@ -192,11 +194,31 @@ export interface AiProviderManagedIdentity {
 	managed_by?: string | null;
 }
 
+export function isClawdiManagedV2ProviderId(providerId: string): boolean {
+	if (
+		providerId === CLAWDI_MANAGED_V2_PROVIDER_ID ||
+		providerId === CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID
+	) {
+		return true;
+	}
+	if (
+		providerId.length > CLAWDI_MANAGED_PROVIDER_MAX_ID_LENGTH ||
+		!providerId.startsWith(CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX)
+	) {
+		return false;
+	}
+	const deploymentId = providerId.slice(CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX.length);
+	return /^[1-9][0-9]*$/.test(deploymentId);
+}
+
+export function isClawdiManagedProviderId(providerId: string): boolean {
+	return providerId === CLAWDI_MANAGED_V1_PROVIDER_ID || isClawdiManagedV2ProviderId(providerId);
+}
+
 export function isFirstPartyManagedAiProvider(provider: AiProviderManagedIdentity): boolean {
 	const id = provider.provider_id ?? provider.id;
 	return (
-		provider.managed_by === "clawdi" ||
-		(typeof id === "string" && CLAWDI_MANAGED_PROVIDER_IDS.has(id))
+		provider.managed_by === "clawdi" || (typeof id === "string" && isClawdiManagedProviderId(id))
 	);
 }
 
@@ -341,7 +363,7 @@ function validateManagedProviderContract(
 	errors: string[],
 ): void {
 	const isManagedContract =
-		CLAWDI_MANAGED_PROVIDER_IDS.has(provider.id) || provider.managed_by === "clawdi";
+		isClawdiManagedProviderId(provider.id) || provider.managed_by === "clawdi";
 	if (!isManagedContract) return;
 
 	const expectedApiMode = clawdiManagedApiMode(provider.id);
@@ -349,7 +371,7 @@ function validateManagedProviderContract(
 		errors.push(
 			`Provider ${prefix} managed_by clawdi must use id ${Array.from(CLAWDI_MANAGED_PROVIDER_IDS)
 				.sort()
-				.join(" or ")}.`,
+				.join(" or ")}, or ${CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX}<deployment_id>.`,
 		);
 	}
 	if (provider.managed_by !== "clawdi") {
@@ -378,10 +400,7 @@ function clawdiManagedApiMode(providerId: string): AiProviderApiMode | null {
 	if (providerId === CLAWDI_MANAGED_V1_PROVIDER_ID) return CLAWDI_MANAGED_V1_API_MODE;
 	// TODO(#425): Remove legacy mode resolution after hosted#892 is deployed everywhere
 	// and no dev/self-hosted binding still uses clawdi-managed-v2.
-	if (
-		providerId === CLAWDI_MANAGED_V2_PROVIDER_ID ||
-		providerId === CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID
-	) {
+	if (isClawdiManagedV2ProviderId(providerId)) {
 		return CLAWDI_MANAGED_V2_API_MODE;
 	}
 	return null;


### PR DESCRIPTION
## Why

The declarative v2 provisioning worker needs one Cloud-managed AI provider per deployment. The existing admin surface only accepted the fixed `clawdi-v2` identity, had no owner-scoped discovery or deletion, and omitted the immutable provider identity and discovery fields required for safe retry and compensation.

The new contract must remain first-party admin only, fail closed at the owner boundary, serialize concurrent provider/credential mutations, and leave the existing fixed/legacy and v1 provider behavior unchanged.

## What changed

- Accept `clawdi-v2-deployment-{deployment_id}` for positive integer deployment IDs within the Cloud 63-character provider-id limit.
- Add owner-scoped admin GET, PUT, and DELETE on `/admin/ai-providers/{provider_id}` for deployment-scoped IDs.
- Require declarative PUT requests to carry `owner: {kind, ref}` and GET/DELETE requests to carry explicit `kind` / `ref` owner query fields.
- Return the discovery contract required by the hosted adapter: provider UUID `id`, owner identity, `scope`, provider type/label, `api_mode`, managed auth shape, `managed_by`, runtime env name, capabilities (including `clawdi_provisioning_discovery_key`), models, and `has_api_key`.
- Reuse the existing `AiProvider` / `AiProviderAuthPayload` persistence path and AES-256-GCM encryption. DELETE archives provider metadata and owner-scoped auth payloads.
- Keep first-party provider provenance as `managed_by="clawdi"`.
- Teach backend runtime projection plus shared/CLI managed-provider classification to preserve deployment-scoped v2 IDs and `openai_chat` instead of normalizing them to the v1 provider.

## V1 and fixed-path compatibility

- Restore the original `AdminManagedAiProviderUpsert` and `AdminManagedAiProviderResponse` models unchanged for `clawdi-v2` and `clawdi-managed-v2`.
- Keep the legacy `target_clerk_id` PUT implementation, response fields and ordering, `models: null` serialization, persistence behavior, log shape, and single original `ai_provider.managed.upsert` audit event unchanged.
- Keep GET/DELETE unavailable for fixed/legacy IDs with the original 405 behavior.
- Keep `backend/app/routes/ai_providers.py` identical to `main`; the existing `clawdi-managed` v1 `openai_responses` contract and fixed v2 mode resolution do not accept deployment-scoped IDs.
- Apply the new discovery, audit, and mutation-locking contracts only to `clawdi-v2-deployment-*` operations.

## Owner-scoping guards

- Declarative PUT accepts only the structured owner contract; missing, legacy-only, or ambiguous selectors fail with 422.
- GET/DELETE require explicit owner fields and never create owners.
- Every provider and encrypted-auth lookup/update is constrained by both `owner_user_id` and `provider_id`.
- Scoped misses return 404 and are audited as `cross_owner_denied` without a provider-only existence probe, so another owner's resource cannot be discovered.
- The route remains gated by the existing `X-Admin-Key`; no workload OAuth surface was added.

## Concurrent mutation serialization

Deployment-scoped PUT and DELETE acquire the same transaction-scoped PostgreSQL advisory lock before the first provider/auth lookup:

- Lock identity is `hashtextextended("managed-ai-provider:{owner_user_id}:{provider_id}", 0)`, matching the owner/provider uniqueness boundary.
- The lock remains held through provider and AES-GCM auth-payload changes, runtime invalidation, audit insertion, and commit/rollback.
- Concurrent first PUTs therefore converge on one provider row and one auth-payload row instead of racing independent INSERTs into the unique constraints.
- PUT/DELETE on the same owner/provider serialize in transaction order, preventing an interleaved delete from being accidentally revived by an in-flight PUT.
- Different owners or provider IDs use different lock identities and remain independent.

## Durable audit trail

This reuses Cloud's existing `record_control_plane_audit` service and `control_plane_audit_events` table rather than introducing a parallel log.

Deployment-scoped operations emit:

- `ai_provider.managed.read`
- `ai_provider.managed.upsert`
- `ai_provider.managed.credential.rotate`
- `ai_provider.managed.delete`
- `ai_provider.managed.credential.archive`

Each record captures the existing admin actor identity (`actor_type=admin`, `source=api.admin`), `auth_method=x_admin_key`, structured owner, resolved `owner_user_id`, provider ID/UUID when available, outcome (`success`, `failed`, or `cross_owner_denied`), and the table's durable `created_at` timestamp. Successful mutation and credential audit rows commit in the same transaction as the corresponding provider/auth changes; audited read and denial outcomes are explicitly committed.

## Verification

- `scripts/test.sh backend` — 1300 passed, 7 skipped
- Real PostgreSQL concurrent-first-PUT test: the second request blocks on the shared advisory lock; both return 200; one provider/auth row remains; the serialized last credential is deterministic
- Real PostgreSQL PUT-vs-DELETE test: DELETE blocks while PUT holds the same lock, then archives the just-written provider/auth graph
- Fixed/legacy PUT byte-response tests, including `models: null`, plus unchanged audit-detail assertions
- Owner-scoped lifecycle audit test covering PUT, credential rotation, GET, DELETE, credential archive, and cross-owner GET/DELETE denial
- V1 mode-resolution regression test proving deployment IDs are not admitted by existing v1 handling
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m compileall app scripts tests alembic`
- `bun test packages/shared/src/ai-provider.test.ts` — 34 passed
- Focused CLI runtime projection test — passed
- `bun run typecheck`
- `bun run check`

No production operations were performed.
