### PR TITLE
feat(v2): cloud-api runtime observation companion + retirement fence [cloud-api]

### DIFF
--- a/backend/alembic/versions/a6d2f4c8b1e7_harden_v2_runtime_observation_boundary.py
+++ b/backend/alembic/versions/a6d2f4c8b1e7_harden_v2_runtime_observation_boundary.py
@@ -1,0 +1,687 @@
+"""Harden the clean-v2 runtime observation boundary.
+
+Revision ID: a6d2f4c8b1e7
+Revises: 4c8f2a1d7e9b
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a6d2f4c8b1e7"
+down_revision: str | Sequence[str] | None = "4c8f2a1d7e9b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_RUNTIME_DEPLOYMENT_KEY_CHECK = (
+    "runtime_deployment_id IS NULL OR (managed AND environment_id IS NOT NULL "
+    "AND scopes IS NOT NULL AND cardinality(scopes) > 0 AND scopes <@ "
+    "ARRAY['runtime-observations:write','sessions:write',"
+    "'skills:read','skills:write']::varchar[] "
+    "AND 'runtime-observations:write' = ANY(scopes))"
+)
+
+_WORKLOAD_SCOPE_CHECK = (
+    "cardinality(allowed_scopes) > 0 AND allowed_scopes <@ "
+    "ARRAY['platform:agents:create','platform:agents:delete',"
+    "'platform:runtime-state:write','platform:keys:mint',"
+    "'platform:keys:revoke','platform:runtime-observations:consume',"
+    "'platform:runtime-environments:retire']::varchar[]"
+)
+
+_PREVIOUS_RUNTIME_DEPLOYMENT_KEY_CHECK = (
+    "runtime_deployment_id IS NULL OR (managed AND environment_id IS NOT NULL)"
+)
+
+_PREVIOUS_WORKLOAD_SCOPE_CHECK = (
+    "cardinality(allowed_scopes) > 0 AND allowed_scopes <@ "
+    "ARRAY['platform:agents:create','platform:agents:delete',"
+    "'platform:runtime-state:write','platform:keys:mint',"
+    "'platform:keys:revoke','platform:runtime-observations:read']::varchar[]"
+)
+
+_FENCE_RETIREMENT_CHECK = (
+    "(state = 'active' AND retirement_id IS NULL "
+    "AND retirement_receipt_id IS NULL AND retirement_receipt IS NULL "
+    "AND retired_at IS NULL AND final_cursor IS NULL "
+    "AND final_stream_position IS NULL AND final_session_high_waters IS NULL) "
+    "OR (state = 'retired' AND retirement_id IS NOT NULL "
+    "AND retirement_receipt_id IS NOT NULL AND retirement_receipt IS NOT NULL "
+    "AND retired_at IS NOT NULL AND final_cursor IS NOT NULL "
+    "AND final_stream_position IS NOT NULL "
+    "AND final_stream_position = stream_high_water "
+    "AND final_session_high_waters IS NOT NULL)"
+)
+
+_PREVIOUS_FENCE_RETIREMENT_CHECK = (
+    "(state = 'active' AND retirement_id IS NULL "
+    "AND retirement_receipt_id IS NULL AND retirement_receipt IS NULL "
+    "AND retired_at IS NULL AND final_cursor IS NULL "
+    "AND final_stream_position IS NULL AND final_session_high_waters IS NULL) "
+    "OR (state = 'retired' AND retirement_id IS NOT NULL "
+    "AND retirement_receipt_id IS NOT NULL AND retirement_receipt IS NOT NULL "
+    "AND retired_at IS NOT NULL AND final_cursor IS NOT NULL "
+    "AND final_stream_position IS NOT NULL "
+    "AND final_session_high_waters IS NOT NULL)"
+)
+
+_HEAD_LIFECYCLE_CHECK = (
+    "(state = 'active' AND latest_inbox_id IS NOT NULL "
+    "AND latest_stream_position = latest_inbox_id "
+    "AND latest_event_id IS NOT NULL AND captured_at IS NOT NULL "
+    "AND freshness_deadline IS NOT NULL AND health IS NOT NULL "
+    "AND tombstoned_at IS NULL) "
+    "OR (state = 'retired' AND latest_inbox_id IS NULL "
+    "AND latest_event_id IS NOT NULL AND captured_at IS NULL "
+    "AND freshness_deadline IS NULL AND health IS NULL "
+    "AND tombstoned_at IS NOT NULL)"
+)
+
+_PREVIOUS_HEAD_LIFECYCLE_CHECK = (
+    "(state = 'active' AND latest_event_id IS NOT NULL "
+    "AND captured_at IS NOT NULL AND freshness_deadline IS NOT NULL "
+    "AND health IS NOT NULL AND tombstoned_at IS NULL) "
+    "OR (state = 'retired' AND latest_inbox_id IS NULL "
+    "AND latest_event_id IS NOT NULL AND captured_at IS NULL "
+    "AND freshness_deadline IS NULL AND health IS NULL "
+    "AND tombstoned_at IS NOT NULL)"
+)
+
+
+def _create_immutability_guards() -> None:
+    op.execute(
+        sa.text(
+            """
+            CREATE FUNCTION enforce_v2_runtime_fence_immutability()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF TG_OP = 'DELETE' THEN
+                    RAISE EXCEPTION 'v2 runtime environment fences are permanent';
+                END IF;
+                IF OLD.environment_id IS DISTINCT FROM NEW.environment_id
+                   OR OLD.owner_id IS DISTINCT FROM NEW.owner_id
+                   OR OLD.deployment_id IS DISTINCT FROM NEW.deployment_id
+                   OR OLD.created_at IS DISTINCT FROM NEW.created_at THEN
+                    RAISE EXCEPTION 'v2 runtime environment fence binding is immutable';
+                END IF;
+                IF OLD.state = 'retired'
+                   AND (OLD.environment_id IS DISTINCT FROM NEW.environment_id
+                        OR OLD.owner_id IS DISTINCT FROM NEW.owner_id
+                        OR OLD.deployment_id IS DISTINCT FROM NEW.deployment_id
+                        OR OLD.state IS DISTINCT FROM NEW.state
+                        OR OLD.stream_high_water IS DISTINCT FROM NEW.stream_high_water
+                        OR OLD.retirement_id IS DISTINCT FROM NEW.retirement_id
+                        OR OLD.retirement_receipt_id IS DISTINCT FROM NEW.retirement_receipt_id
+                        OR OLD.retirement_receipt IS DISTINCT FROM NEW.retirement_receipt
+                        OR OLD.retired_at IS DISTINCT FROM NEW.retired_at
+                        OR OLD.final_cursor IS DISTINCT FROM NEW.final_cursor
+                        OR OLD.final_stream_position IS DISTINCT FROM NEW.final_stream_position
+                        OR OLD.final_session_high_waters
+                           IS DISTINCT FROM NEW.final_session_high_waters
+                        OR OLD.created_at IS DISTINCT FROM NEW.created_at) THEN
+                    RAISE EXCEPTION
+                        'retired v2 runtime environment receipt and high-waters are immutable';
+                END IF;
+                IF NEW.stream_high_water < OLD.stream_high_water
+                   OR NEW.replay_floor_stream_position < OLD.replay_floor_stream_position THEN
+                    RAISE EXCEPTION 'v2 runtime environment fence high-water cannot regress';
+                END IF;
+                IF OLD.replay_floor_advanced_at IS NOT NULL
+                   AND (NEW.replay_floor_advanced_at IS NULL
+                        OR NEW.replay_floor_advanced_at < OLD.replay_floor_advanced_at) THEN
+                    RAISE EXCEPTION
+                        'v2 runtime environment replay-floor time cannot regress';
+                END IF;
+                IF NEW.replay_floor_stream_position > OLD.replay_floor_stream_position
+                   AND NEW.replay_floor_advanced_at IS NULL THEN
+                    RAISE EXCEPTION
+                        'v2 runtime environment replay-floor advance requires a timestamp';
+                END IF;
+                IF OLD.state = 'retired'
+                   AND NEW.replay_floor_stream_position = OLD.replay_floor_stream_position
+                   AND (NEW.replay_floor_advanced_at
+                            IS DISTINCT FROM OLD.replay_floor_advanced_at
+                        OR NEW.replay_floor_session_high_waters
+                            IS DISTINCT FROM OLD.replay_floor_session_high_waters) THEN
+                    RAISE EXCEPTION
+                        'retired v2 runtime environment replay metadata requires floor advance';
+                END IF;
+                RETURN NEW;
+            END;
+            $$;
+
+            CREATE TRIGGER trg_v2_runtime_fence_immutability
+            BEFORE UPDATE OR DELETE ON v2_runtime_environment_fences
+            FOR EACH ROW EXECUTE FUNCTION enforce_v2_runtime_fence_immutability();
+
+            CREATE FUNCTION enforce_v2_runtime_inbox_immutability()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF TG_OP = 'DELETE' THEN
+                    RAISE EXCEPTION
+                        'v2 runtime observation inbox identities are permanent';
+                END IF;
+                IF NEW IS NOT DISTINCT FROM OLD THEN
+                    RETURN NEW;
+                END IF;
+                IF OLD.payload_purged_at IS NULL
+                   AND NEW.payload_purged_at IS NOT NULL
+                   AND NEW.diagnostics = '{}'::jsonb
+                   AND OLD.id IS NOT DISTINCT FROM NEW.id
+                   AND OLD.environment_id IS NOT DISTINCT FROM NEW.environment_id
+                   AND OLD.deployment_id IS NOT DISTINCT FROM NEW.deployment_id
+                   AND OLD.generation IS NOT DISTINCT FROM NEW.generation
+                   AND OLD.manifest_etag IS NOT DISTINCT FROM NEW.manifest_etag
+                   AND OLD.apply_receipt_id IS NOT DISTINCT FROM NEW.apply_receipt_id
+                   AND OLD.boot_nonce IS NOT DISTINCT FROM NEW.boot_nonce
+                   AND OLD.boot_session_id IS NOT DISTINCT FROM NEW.boot_session_id
+                   AND OLD.sequence IS NOT DISTINCT FROM NEW.sequence
+                   AND OLD.event_id IS NOT DISTINCT FROM NEW.event_id
+                   AND OLD.reported_at IS NOT DISTINCT FROM NEW.reported_at
+                   AND OLD.captured_at IS NOT DISTINCT FROM NEW.captured_at
+                   AND OLD.received_at IS NOT DISTINCT FROM NEW.received_at
+                   AND OLD.freshness_deadline IS NOT DISTINCT FROM NEW.freshness_deadline
+                   AND OLD.payload_hash IS NOT DISTINCT FROM NEW.payload_hash
+                   AND OLD.health IS NOT DISTINCT FROM NEW.health THEN
+                    RETURN NEW;
+                END IF;
+                RAISE EXCEPTION 'v2 runtime observation inbox events are immutable';
+            END;
+            $$;
+
+            CREATE TRIGGER trg_v2_runtime_inbox_immutability
+            BEFORE UPDATE OR DELETE ON v2_runtime_observation_inbox
+            FOR EACH ROW EXECUTE FUNCTION enforce_v2_runtime_inbox_immutability();
+
+            CREATE FUNCTION enforce_v2_runtime_head_immutability()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF TG_OP = 'DELETE' THEN
+                    RAISE EXCEPTION 'v2 runtime observation heads are permanent';
+                END IF;
+                IF OLD.environment_id IS DISTINCT FROM NEW.environment_id
+                   OR OLD.boot_session_id IS DISTINCT FROM NEW.boot_session_id
+                   OR OLD.deployment_id IS DISTINCT FROM NEW.deployment_id
+                   OR OLD.generation IS DISTINCT FROM NEW.generation
+                   OR OLD.manifest_etag IS DISTINCT FROM NEW.manifest_etag
+                   OR OLD.apply_receipt_id IS DISTINCT FROM NEW.apply_receipt_id
+                   OR OLD.boot_nonce IS DISTINCT FROM NEW.boot_nonce
+                   OR OLD.created_at IS DISTINCT FROM NEW.created_at THEN
+                    RAISE EXCEPTION 'v2 runtime observation head binding is immutable';
+                END IF;
+                IF OLD.state = 'retired' AND NEW IS DISTINCT FROM OLD THEN
+                    RAISE EXCEPTION 'retired v2 runtime observation head is immutable';
+                END IF;
+                IF NEW.highest_sequence < OLD.highest_sequence
+                   OR NEW.latest_stream_position < OLD.latest_stream_position THEN
+                    RAISE EXCEPTION 'v2 runtime observation head high-water cannot regress';
+                END IF;
+                IF OLD.captured_at IS NOT NULL AND NEW.state = 'active'
+                   AND (NEW.captured_at IS NULL OR NEW.captured_at < OLD.captured_at) THEN
+                    RAISE EXCEPTION 'v2 runtime observation capture time cannot regress';
+                END IF;
+                IF OLD.freshness_deadline IS NOT NULL AND NEW.state = 'active'
+                   AND (NEW.freshness_deadline IS NULL
+                        OR NEW.freshness_deadline < OLD.freshness_deadline) THEN
+                    RAISE EXCEPTION 'v2 runtime observation freshness cannot regress';
+                END IF;
+                IF NEW.state = 'active' AND NEW.highest_sequence = OLD.highest_sequence
+                   AND (NEW.latest_inbox_id IS DISTINCT FROM OLD.latest_inbox_id
+                        OR NEW.latest_stream_position IS DISTINCT FROM OLD.latest_stream_position
+                        OR NEW.latest_event_id IS DISTINCT FROM OLD.latest_event_id
+                        OR NEW.latest_payload_hash IS DISTINCT FROM OLD.latest_payload_hash
+                        OR NEW.captured_at IS DISTINCT FROM OLD.captured_at
+                        OR NEW.freshness_deadline IS DISTINCT FROM OLD.freshness_deadline
+                        OR NEW.health IS DISTINCT FROM OLD.health) THEN
+                    RAISE EXCEPTION 'v2 runtime observation head cannot rebind a sequence';
+                END IF;
+                IF NEW.state = 'active' AND NEW.highest_sequence > OLD.highest_sequence
+                   AND NEW.latest_stream_position <= OLD.latest_stream_position THEN
+                    RAISE EXCEPTION 'v2 runtime observation head stream must advance';
+                END IF;
+                IF NEW.state = 'retired'
+                   AND (NEW.highest_sequence IS DISTINCT FROM OLD.highest_sequence
+                        OR NEW.latest_stream_position IS DISTINCT FROM OLD.latest_stream_position
+                        OR NEW.latest_event_id IS DISTINCT FROM OLD.latest_event_id
+                        OR NEW.latest_payload_hash IS DISTINCT FROM OLD.latest_payload_hash) THEN
+                    RAISE EXCEPTION 'v2 runtime observation tombstone high-water is immutable';
+                END IF;
+                RETURN NEW;
+            END;
+            $$;
+
+            CREATE TRIGGER trg_v2_runtime_head_immutability
+            BEFORE UPDATE OR DELETE ON v2_runtime_observation_heads
+            FOR EACH ROW EXECUTE FUNCTION enforce_v2_runtime_head_immutability();
+
+            CREATE FUNCTION enforce_v2_runtime_head_inbox_reference()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF NEW.state = 'active'
+                   AND (NEW.latest_inbox_id IS NULL
+                        OR NEW.latest_stream_position
+                           IS DISTINCT FROM NEW.latest_inbox_id
+                        OR NOT EXISTS (
+                       SELECT 1
+                       FROM v2_runtime_observation_inbox AS inbox
+                       WHERE inbox.id = NEW.latest_inbox_id
+                         AND inbox.environment_id = NEW.environment_id
+                         AND inbox.deployment_id = NEW.deployment_id
+                         AND inbox.boot_session_id = NEW.boot_session_id
+                         AND inbox.sequence = NEW.highest_sequence
+                         AND inbox.event_id = NEW.latest_event_id
+                         AND inbox.payload_hash = NEW.latest_payload_hash
+                   )) THEN
+                    RAISE EXCEPTION
+                        'v2 runtime observation head inbox reference does not match its binding';
+                END IF;
+                RETURN NEW;
+            END;
+            $$;
+
+            CREATE TRIGGER trg_v2_runtime_head_inbox_reference
+            BEFORE INSERT OR UPDATE ON v2_runtime_observation_heads
+            FOR EACH ROW EXECUTE FUNCTION enforce_v2_runtime_head_inbox_reference();
+
+            CREATE FUNCTION enforce_v2_runtime_cursor_immutability()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF TG_OP = 'DELETE' THEN
+                    RAISE EXCEPTION 'v2 runtime observation consumer cursors are permanent';
+                END IF;
+                IF OLD.environment_id IS DISTINCT FROM NEW.environment_id
+                   OR OLD.consumer_id IS DISTINCT FROM NEW.consumer_id
+                   OR OLD.deployment_id IS DISTINCT FROM NEW.deployment_id
+                   OR OLD.required IS DISTINCT FROM NEW.required
+                   OR OLD.created_at IS DISTINCT FROM NEW.created_at THEN
+                    RAISE EXCEPTION 'v2 runtime observation consumer binding is immutable';
+                END IF;
+                IF NEW.acked_stream_position < OLD.acked_stream_position THEN
+                    RAISE EXCEPTION 'v2 runtime observation acknowledgement cannot regress';
+                END IF;
+                IF OLD.expiry_boundary_stream_position IS NOT NULL
+                   AND (NEW.expiry_boundary_stream_position IS NULL
+                        OR NEW.expiry_boundary_stream_position
+                           < OLD.expiry_boundary_stream_position) THEN
+                    RAISE EXCEPTION 'v2 runtime observation expiry boundary cannot regress';
+                END IF;
+                IF OLD.state = 'active'
+                   AND NEW.cursor_epoch IS DISTINCT FROM OLD.cursor_epoch THEN
+                    RAISE EXCEPTION 'active v2 runtime observation cursor epoch is immutable';
+                END IF;
+                IF OLD.state = 'expired' AND NEW.state = 'expired'
+                   AND NEW.cursor_epoch IS DISTINCT FROM OLD.cursor_epoch THEN
+                    RAISE EXCEPTION 'expired v2 runtime observation cursor epoch is immutable';
+                END IF;
+                IF OLD.state = 'expired' AND NEW.state = 'active'
+                   AND (NEW.cursor_epoch IS NOT DISTINCT FROM OLD.cursor_epoch
+                        OR OLD.expiry_boundary_stream_position IS NULL
+                        OR NEW.acked_stream_position
+                           < OLD.expiry_boundary_stream_position) THEN
+                    RAISE EXCEPTION 'v2 runtime observation cursor reset is invalid';
+                END IF;
+                RETURN NEW;
+            END;
+            $$;
+
+            CREATE TRIGGER trg_v2_runtime_cursor_immutability
+            BEFORE UPDATE OR DELETE ON v2_runtime_observation_consumer_cursors
+            FOR EACH ROW EXECUTE FUNCTION enforce_v2_runtime_cursor_immutability();
+
+            CREATE FUNCTION enforce_runtime_deployment_key_binding_immutability()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$
+            BEGIN
+                IF OLD.runtime_deployment_id IS DISTINCT FROM NEW.runtime_deployment_id THEN
+                    RAISE EXCEPTION 'runtime deployment key binding is immutable';
+                END IF;
+                IF OLD.runtime_deployment_id IS NOT NULL
+                   AND (OLD.environment_id IS DISTINCT FROM NEW.environment_id
+                        OR OLD.user_id IS DISTINCT FROM NEW.user_id) THEN
+                    RAISE EXCEPTION 'runtime deployment key authority is immutable';
+                END IF;
+                RETURN NEW;
+            END;
+            $$;
+
+            CREATE TRIGGER trg_runtime_deployment_key_binding_immutability
+            BEFORE UPDATE ON api_keys
+            FOR EACH ROW EXECUTE FUNCTION enforce_runtime_deployment_key_binding_immutability();
+            """
+        )
+    )
+
+
+def _drop_immutability_guards() -> None:
+    op.execute(
+        sa.text(
+            """
+            DROP TRIGGER IF EXISTS trg_runtime_deployment_key_binding_immutability ON api_keys;
+            DROP FUNCTION IF EXISTS enforce_runtime_deployment_key_binding_immutability();
+            DROP TRIGGER IF EXISTS trg_v2_runtime_cursor_immutability
+                ON v2_runtime_observation_consumer_cursors;
+            DROP FUNCTION IF EXISTS enforce_v2_runtime_cursor_immutability();
+            DROP TRIGGER IF EXISTS trg_v2_runtime_head_immutability
+                ON v2_runtime_observation_heads;
+            DROP FUNCTION IF EXISTS enforce_v2_runtime_head_immutability();
+            DROP TRIGGER IF EXISTS trg_v2_runtime_head_inbox_reference
+                ON v2_runtime_observation_heads;
+            DROP FUNCTION IF EXISTS enforce_v2_runtime_head_inbox_reference();
+            DROP TRIGGER IF EXISTS trg_v2_runtime_inbox_immutability
+                ON v2_runtime_observation_inbox;
+            DROP FUNCTION IF EXISTS enforce_v2_runtime_inbox_immutability();
+            DROP TRIGGER IF EXISTS trg_v2_runtime_fence_immutability
+                ON v2_runtime_environment_fences;
+            DROP FUNCTION IF EXISTS enforce_v2_runtime_fence_immutability();
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1
+                    FROM api_keys
+                    WHERE runtime_deployment_id IS NOT NULL
+                      AND NOT (
+                          managed
+                          AND environment_id IS NOT NULL
+                          AND scopes IS NOT NULL
+                          AND cardinality(scopes) > 0
+                          AND scopes <@ ARRAY[
+                              'runtime-observations:write', 'sessions:write',
+                              'skills:read', 'skills:write'
+                          ]::varchar[]
+                          AND 'runtime-observations:write' = ANY(scopes)
+                      )
+                ) THEN
+                    RAISE EXCEPTION
+                        'invalid deployment-bound runtime credentials must be '
+                        'deleted, unbound, or narrowed before upgrade';
+                END IF;
+            END;
+            $$;
+            """
+        )
+    )
+    op.drop_constraint(
+        "ck_api_keys_runtime_deployment_binding",
+        "api_keys",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_api_keys_runtime_deployment_binding",
+        "api_keys",
+        _RUNTIME_DEPLOYMENT_KEY_CHECK,
+    )
+
+    op.execute(
+        sa.text(
+            """
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1
+                    FROM v2_runtime_environment_fences
+                    WHERE state = 'retired'
+                      AND final_stream_position IS DISTINCT FROM stream_high_water
+                ) THEN
+                    RAISE EXCEPTION
+                        'retired v2 runtime fence final position must match its high-water';
+                END IF;
+                IF EXISTS (
+                    SELECT 1
+                    FROM v2_runtime_observation_heads
+                    WHERE state = 'active'
+                      AND (latest_inbox_id IS NULL
+                           OR latest_stream_position IS DISTINCT FROM latest_inbox_id)
+                ) THEN
+                    RAISE EXCEPTION
+                        'active v2 runtime heads require an exact inbox position';
+                END IF;
+            END;
+            $$;
+            """
+        )
+    )
+    op.drop_constraint(
+        "ck_v2_runtime_environment_fences_retirement",
+        "v2_runtime_environment_fences",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_v2_runtime_environment_fences_retirement",
+        "v2_runtime_environment_fences",
+        _FENCE_RETIREMENT_CHECK,
+    )
+    op.drop_constraint(
+        "ck_v2_runtime_observation_heads_lifecycle",
+        "v2_runtime_observation_heads",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_v2_runtime_observation_heads_lifecycle",
+        "v2_runtime_observation_heads",
+        _HEAD_LIFECYCLE_CHECK,
+    )
+
+    op.add_column(
+        "v2_runtime_observation_inbox",
+        sa.Column("reported_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.execute(
+        sa.text(
+            "UPDATE v2_runtime_observation_inbox "
+            "SET reported_at = captured_at WHERE reported_at IS NULL"
+        )
+    )
+    op.alter_column(
+        "v2_runtime_observation_inbox",
+        "reported_at",
+        existing_type=sa.DateTime(timezone=True),
+        nullable=False,
+    )
+    op.add_column(
+        "v2_runtime_observation_inbox",
+        sa.Column("payload_purged_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_check_constraint(
+        "ck_v2_runtime_observation_inbox_payload_compaction",
+        "v2_runtime_observation_inbox",
+        "payload_purged_at IS NULL OR diagnostics = '{}'::jsonb",
+    )
+    op.create_index(
+        "ix_v2_runtime_observation_inbox_pending_retention",
+        "v2_runtime_observation_inbox",
+        ["received_at"],
+        postgresql_where=sa.text("payload_purged_at IS NULL"),
+    )
+
+    # Normalize already-retired #429 receipts to the revision-16 Hosted port.
+    # Keep the internal receipt UUID in its typed fence column for audit/replay
+    # correlation, but do not expose it in the narrow public receipt JSON.
+    op.execute(
+        sa.text(
+            """
+            UPDATE v2_runtime_environment_fences AS fence
+            SET retirement_receipt = jsonb_build_object(
+                'environmentReference', fence.environment_id::text,
+                'expectedDeploymentBinding', fence.deployment_id,
+                'retirementId', fence.retirement_id,
+                'retiredAt', replace(
+                    fence.retirement_receipt->>'retiredAt',
+                    '+00:00',
+                    'Z'
+                ),
+                'finalCursor', fence.final_cursor,
+                'finalSessionHighWaterMarks', COALESCE(
+                    (
+                        SELECT jsonb_agg(
+                            jsonb_build_object(
+                                'bootSessionId', high_water.key,
+                                'sequence', high_water.value::bigint
+                            )
+                            ORDER BY high_water.key
+                        )
+                        FROM jsonb_each_text(
+                            fence.final_session_high_waters::jsonb
+                        ) AS high_water
+                    ),
+                    '[]'::jsonb
+                )
+            )
+            WHERE fence.state = 'retired'
+            """
+        )
+    )
+
+    op.execute(
+        sa.text(
+            """
+            UPDATE platform_workload_clients
+            SET allowed_scopes = array_replace(
+                allowed_scopes,
+                'platform:runtime-observations:read',
+                'platform:runtime-observations:consume'
+            )
+            WHERE 'platform:runtime-observations:read' = ANY(allowed_scopes)
+            """
+        )
+    )
+    op.drop_constraint(
+        "ck_platform_workload_clients_allowed_scopes",
+        "platform_workload_clients",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_platform_workload_clients_allowed_scopes",
+        "platform_workload_clients",
+        _WORKLOAD_SCOPE_CHECK,
+    )
+    _create_immutability_guards()
+
+
+def downgrade() -> None:
+    _drop_immutability_guards()
+    op.drop_constraint(
+        "ck_v2_runtime_observation_heads_lifecycle",
+        "v2_runtime_observation_heads",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_v2_runtime_observation_heads_lifecycle",
+        "v2_runtime_observation_heads",
+        _PREVIOUS_HEAD_LIFECYCLE_CHECK,
+    )
+    op.drop_constraint(
+        "ck_v2_runtime_environment_fences_retirement",
+        "v2_runtime_environment_fences",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_v2_runtime_environment_fences_retirement",
+        "v2_runtime_environment_fences",
+        _PREVIOUS_FENCE_RETIREMENT_CHECK,
+    )
+    # Restore the #429 receipt shape for code running at the downgraded
+    # revision. Payload compaction itself is intentionally irreversible.
+    op.execute(
+        sa.text(
+            """
+            UPDATE v2_runtime_environment_fences AS fence
+            SET retirement_receipt = jsonb_build_object(
+                'retirementReceiptId', fence.retirement_receipt_id::text,
+                'retirementId', fence.retirement_id,
+                'environmentId', fence.environment_id::text,
+                'deploymentId', fence.deployment_id,
+                'retiredAt', fence.retirement_receipt->>'retiredAt',
+                'finalCursor', fence.final_cursor,
+                'finalSessionHighWaterMarks', fence.final_session_high_waters
+            )
+            WHERE fence.state = 'retired'
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1
+                    FROM platform_workload_clients
+                    WHERE 'platform:runtime-environments:retire' = ANY(allowed_scopes)
+                ) THEN
+                    RAISE EXCEPTION
+                        'retirement-scoped workload clients must be removed before downgrade';
+                END IF;
+            END;
+            $$;
+            """
+        )
+    )
+    op.drop_constraint(
+        "ck_platform_workload_clients_allowed_scopes",
+        "platform_workload_clients",
+        type_="check",
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE platform_workload_clients
+            SET allowed_scopes = array_replace(
+                allowed_scopes,
+                'platform:runtime-observations:consume',
+                'platform:runtime-observations:read'
+            )
+            WHERE 'platform:runtime-observations:consume' = ANY(allowed_scopes)
+            """
+        )
+    )
+    op.create_check_constraint(
+        "ck_platform_workload_clients_allowed_scopes",
+        "platform_workload_clients",
+        _PREVIOUS_WORKLOAD_SCOPE_CHECK,
+    )
+
+    op.drop_constraint(
+        "ck_api_keys_runtime_deployment_binding",
+        "api_keys",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_api_keys_runtime_deployment_binding",
+        "api_keys",
+        _PREVIOUS_RUNTIME_DEPLOYMENT_KEY_CHECK,
+    )
+    op.drop_index(
+        "ix_v2_runtime_observation_inbox_pending_retention",
+        table_name="v2_runtime_observation_inbox",
+    )
+    op.drop_constraint(
+        "ck_v2_runtime_observation_inbox_payload_compaction",
+        "v2_runtime_observation_inbox",
+        type_="check",
+    )
+    op.drop_column("v2_runtime_observation_inbox", "payload_purged_at")
+    op.execute(
+        sa.text("ALTER TABLE v2_runtime_observation_inbox DROP COLUMN IF EXISTS reported_at")
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,6 +42,7 @@ from app.routes.platform import router as platform_router
 from app.routes.projects import router as projects_router
 from app.routes.public_sessions import router as public_sessions_router
 from app.routes.runtime import router as runtime_router
+from app.routes.runtime_observation_v2 import router as runtime_observation_v2_router
 from app.routes.search import router as search_router
 from app.routes.sessions import router as sessions_router
 from app.routes.settings import router as settings_router
@@ -285,6 +286,9 @@ for _router in _VERSIONED_ROUTERS:
     app.include_router(_router, prefix="/v1")
     if _router not in (runtime_router, platform_router):
         app.include_router(_router, prefix="/api", include_in_schema=False)
+# The declarative runtime observation companion is a clean-v2 contract. It is
+# mounted directly and intentionally has neither a /v1 nor a hidden /api alias.
+app.include_router(runtime_observation_v2_router)
 # Scope skill reads predate the Scope -> Project migration and only
 # exist for old binaries; legacy /api alias only.
 app.include_router(skills_scope_router, prefix="/api", include_in_schema=False)

--- a/backend/app/models/api_key.py
+++ b/backend/app/models/api_key.py
@@ -7,6 +7,13 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base, TimestampMixin
 
+RUNTIME_DEPLOYMENT_KEY_SCOPES = (
+    "runtime-observations:write",
+    "sessions:write",
+    "skills:read",
+    "skills:write",
+)
+
 
 class ApiKey(Base, TimestampMixin):
     __tablename__ = "api_keys"
@@ -21,7 +28,11 @@ class ApiKey(Base, TimestampMixin):
             ondelete="RESTRICT",
         ),
         CheckConstraint(
-            "runtime_deployment_id IS NULL OR (managed AND environment_id IS NOT NULL)",
+            "runtime_deployment_id IS NULL OR (managed AND environment_id IS NOT NULL "
+            "AND scopes IS NOT NULL AND cardinality(scopes) > 0 AND scopes <@ "
+            "ARRAY['runtime-observations:write','sessions:write',"
+            "'skills:read','skills:write']::varchar[] "
+            "AND 'runtime-observations:write' = ANY(scopes))",
             name="ck_api_keys_runtime_deployment_binding",
         ),
     )

--- a/backend/app/models/platform_workload_auth.py
+++ b/backend/app/models/platform_workload_auth.py
@@ -54,7 +54,8 @@ class PlatformWorkloadClient(Base, TimestampMixin):
             "cardinality(allowed_scopes) > 0 AND allowed_scopes <@ "
             "ARRAY['platform:agents:create','platform:agents:delete',"
             "'platform:runtime-state:write','platform:keys:mint',"
-            "'platform:keys:revoke','platform:runtime-observations:read']::varchar[]",
+            "'platform:keys:revoke','platform:runtime-observations:consume',"
+            "'platform:runtime-environments:retire']::varchar[]",
             name="ck_platform_workload_clients_allowed_scopes",
         ),
     )

--- a/backend/app/models/runtime_observation.py
+++ b/backend/app/models/runtime_observation.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     String,
     UniqueConstraint,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
@@ -65,6 +66,7 @@ class V2RuntimeEnvironmentFence(Base, TimestampMixin):
             "AND retirement_receipt_id IS NOT NULL AND retirement_receipt IS NOT NULL "
             "AND retired_at IS NOT NULL AND final_cursor IS NOT NULL "
             "AND final_stream_position IS NOT NULL "
+            "AND final_stream_position = stream_high_water "
             "AND final_session_high_waters IS NOT NULL)",
             name="ck_v2_runtime_environment_fences_retirement",
         ),
@@ -144,6 +146,10 @@ class V2RuntimeObservationInbox(Base):
             "payload_hash ~ '^[0-9a-f]{64}$'",
             name="ck_v2_runtime_observation_inbox_payload_hash",
         ),
+        CheckConstraint(
+            "payload_purged_at IS NULL OR diagnostics = '{}'::jsonb",
+            name="ck_v2_runtime_observation_inbox_payload_compaction",
+        ),
         Index(
             "ix_v2_runtime_observation_inbox_environment_stream",
             "environment_id",
@@ -152,6 +158,11 @@ class V2RuntimeObservationInbox(Base):
         Index(
             "ix_v2_runtime_observation_inbox_received_at",
             "received_at",
+        ),
+        Index(
+            "ix_v2_runtime_observation_inbox_pending_retention",
+            "received_at",
+            postgresql_where=text("payload_purged_at IS NULL"),
         ),
     )
 
@@ -165,6 +176,7 @@ class V2RuntimeObservationInbox(Base):
     boot_session_id: Mapped[str] = mapped_column(String(128), nullable=False)
     sequence: Mapped[int] = mapped_column(BigInteger, nullable=False)
     event_id: Mapped[str] = mapped_column(String(128), nullable=False)
+    reported_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     captured_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     received_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
@@ -175,6 +187,7 @@ class V2RuntimeObservationInbox(Base):
     payload_hash: Mapped[str] = mapped_column(String(64), nullable=False)
     health: Mapped[str] = mapped_column(String(16), nullable=False)
     diagnostics: Mapped[JsonValue] = mapped_column(JSONB(none_as_null=True), nullable=False)
+    payload_purged_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
 
 class V2RuntimeObservationHead(Base, TimestampMixin):
@@ -210,7 +223,9 @@ class V2RuntimeObservationHead(Base, TimestampMixin):
             name="ck_v2_runtime_observation_heads_state",
         ),
         CheckConstraint(
-            "(state = 'active' AND latest_event_id IS NOT NULL AND captured_at IS NOT NULL "
+            "(state = 'active' AND latest_inbox_id IS NOT NULL "
+            "AND latest_stream_position = latest_inbox_id "
+            "AND latest_event_id IS NOT NULL AND captured_at IS NOT NULL "
             "AND freshness_deadline IS NOT NULL AND health IS NOT NULL "
             "AND tombstoned_at IS NULL) "
             "OR (state = 'retired' AND latest_inbox_id IS NULL "

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -88,10 +88,6 @@ from app.services.managed_ai_provider import (
     V2_MANAGED_AI_PROVIDER_IDS,
     upsert_clawdi_managed_provider,
 )
-from app.services.runtime_observation import (
-    RuntimeObservationProtocolError,
-    provision_runtime_environment_fence,
-)
 from app.services.sync_events import (
     queue_environment_runtime_manifest_changed,
     queue_provider_runtime_manifest_changed,
@@ -219,29 +215,18 @@ async def admin_mint_api_key(
     # tooling that only needs to push sessions); the route doesn't
     # impose a ceiling.
     try:
-        if body.managed and env_uuid is not None and body.deployment_id is not None:
-            await provision_runtime_environment_fence(
-                db,
-                environment_id=env_uuid,
-                owner_id=target.id,
-                deployment_id=body.deployment_id,
-            )
         minted = await mint_api_key(
             db,
             user_id=target.id,
             label=body.label,
             scopes=body.scopes,
             environment_id=env_uuid,
-            runtime_deployment_id=body.deployment_id,
             managed=body.managed,
             # Key row and its audit event must land in one transaction:
             # a key that exists without the caller learning its id is an
             # untrackable, unrevokable credential.
             commit=False,
         )
-    except RuntimeObservationProtocolError as e:
-        await db.rollback()
-        raise HTTPException(status_code=e.status_code, detail=e.detail()) from e
     except ValueError as e:
         # `mint_api_key` raises ValueError for cross-tenant
         # environment_id (env not owned by target user). Surface
@@ -278,7 +263,6 @@ async def admin_mint_api_key(
             "key_prefix": api_key.key_prefix,
             "managed": api_key.managed,
             "has_environment_binding": api_key.environment_id is not None,
-            "has_runtime_deployment_binding": api_key.runtime_deployment_id is not None,
             "scope_count": None if api_key.scopes is None else len(api_key.scopes),
         },
     )

--- a/backend/app/routes/platform.py
+++ b/backend/app/routes/platform.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Annotated, Any, NoReturn
+from typing import Annotated, Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
@@ -11,7 +11,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import invalidate_api_key_auth_cache
-from app.core.database import get_runtime_observation_session, get_session
+from app.core.database import get_session
 from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.session import AgentEnvironment
@@ -26,21 +26,10 @@ from app.schemas.platform import (
     PlatformApiKeyCreate,
     PlatformMutationBody,
     PlatformOwner,
-    PlatformRuntimeEnvironmentRetire,
-    PlatformRuntimeObservationConsumerAck,
-    PlatformRuntimeObservationConsumerRegister,
-    PlatformRuntimeObservationConsumerReset,
-    PlatformRuntimeObservationRead,
     PlatformRuntimeStateResponse,
     PlatformRuntimeStateUpsert,
 )
 from app.schemas.platform_oauth import PlatformOAuthErrorResponse, PlatformOAuthTokenResponse
-from app.schemas.runtime_observation import (
-    RuntimeEnvironmentRetirementReceipt,
-    RuntimeObservationConsumerResetResponse,
-    RuntimeObservationConsumerResponse,
-    RuntimeObservationReadResponse,
-)
 from app.schemas.session import EnvironmentCreatedResponse
 from app.services.agent_environments import (
     AgentEnvironmentIdConflict,
@@ -62,16 +51,6 @@ from app.services.platform_workload_auth import (
     get_platform_workload_key_resolver,
     issue_platform_workload_token,
     require_platform_mutation_auth,
-)
-from app.services.runtime_observation import (
-    RuntimeApplyIdentity,
-    RuntimeObservationProtocolError,
-    acknowledge_runtime_observation_cursor,
-    provision_runtime_environment_fence,
-    read_runtime_observations,
-    register_runtime_observation_consumer,
-    reset_runtime_observation_consumer,
-    retire_runtime_environment,
 )
 from app.services.sync_events import (
     queue_environment_runtime_manifest_changed,
@@ -128,10 +107,6 @@ def _oauth_error_response(exc: PlatformOAuthProtocolError) -> JSONResponse:
         content=body.model_dump(),
         headers=headers,
     )
-
-
-def _raise_runtime_observation_error(exc: RuntimeObservationProtocolError) -> NoReturn:
-    raise HTTPException(status_code=exc.status_code, detail=exc.detail()) from exc
 
 
 def _oauth_form_value(form: Any, name: str) -> str:
@@ -336,26 +311,6 @@ async def _resolve_owner(
             idempotency_key=idempotency_key,
         )
         raise AssertionError("unreachable")
-    return user
-
-
-async def _resolve_owner_read(db: AsyncSession, owner: PlatformOwner) -> User:
-    """Resolve a read principal without creating mutation/audit side effects."""
-
-    if owner.kind == PRINCIPAL_KIND_CLERK:
-        filters = (
-            User.principal_kind == PRINCIPAL_KIND_CLERK,
-            User.clerk_id == owner.ref,
-        )
-    else:
-        filters = (
-            User.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT,
-            User.partner_tenant_ref == owner.ref,
-            User.clerk_id.is_(None),
-        )
-    user = (await db.execute(select(User).where(*filters))).scalar_one_or_none()
-    if user is None:
-        raise HTTPException(status.HTTP_404_NOT_FOUND, "Owner not found")
     return user
 
 
@@ -922,230 +877,6 @@ async def platform_delete_runtime_state(
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@router.post(
-    "/agents/{agent_id}/runtime-environment/retire",
-    response_model=RuntimeEnvironmentRetirementReceipt,
-)
-async def platform_retire_runtime_environment(
-    agent_id: UUID,
-    body: PlatformRuntimeEnvironmentRetire,
-    request: Request,
-    idempotency_key: IdempotencyKey,
-    _auth: PlatformMutationAuth = Depends(
-        require_platform_mutation_auth("platform:runtime-state:write")
-    ),
-    db: AsyncSession = Depends(get_session),
-) -> RuntimeEnvironmentRetirementReceipt | Response:
-    action = "runtime_environment.retire"
-    owner = await _resolve_owner(
-        db,
-        owner=body.owner,
-        resource_type="runtime_environment_fence",
-        resource_id=str(agent_id),
-        action=action,
-        request=request,
-        idempotency_key=idempotency_key,
-    )
-    request_hash, replay = await _begin_mutation(
-        db,
-        operation="runtime_environment.retire",
-        idempotency_key=idempotency_key,
-        request_payload={"agent_id": str(agent_id), **body.model_dump(mode="json")},
-        owner=body.owner,
-        owner_user_id=owner.id,
-        resource_type="runtime_environment_fence",
-        resource_id=str(agent_id),
-        action=action,
-        request=request,
-    )
-    if replay is not None:
-        return _replay_response(replay)
-    try:
-        receipt_values = await retire_runtime_environment(
-            db,
-            environment_id=agent_id,
-            expected_deployment_id=body.expected_deployment_id,
-            retirement_id=body.retirement_id,
-            owner_id=owner.id,
-        )
-    except RuntimeObservationProtocolError as exc:
-        await _reject(
-            db,
-            status_code=exc.status_code,
-            detail=exc.detail(),
-            result=exc.code,
-            owner=body.owner,
-            owner_user_id=owner.id,
-            resource_type="runtime_environment_fence",
-            resource_id=str(agent_id),
-            action=action,
-            request=request,
-            idempotency_key=idempotency_key,
-            environment_id=agent_id,
-        )
-        raise AssertionError("unreachable")
-    receipt = RuntimeEnvironmentRetirementReceipt.model_validate(receipt_values)
-    await _complete_mutation(
-        db,
-        operation="runtime_environment.retire",
-        idempotency_key=idempotency_key,
-        request_hash=request_hash,
-        owner=body.owner,
-        owner_user_id=owner.id,
-        resource_type="runtime_environment_fence",
-        resource_id=str(agent_id),
-        action=action,
-        request=request,
-        response_status=status.HTTP_200_OK,
-        response_body=receipt,
-        environment_id=agent_id,
-        audit_details={
-            "deployment_id": body.expected_deployment_id,
-            "retirement_id": body.retirement_id,
-            "retirement_receipt_id": receipt.retirement_receipt_id,
-        },
-    )
-    return receipt
-
-
-@router.post(
-    "/agents/{agent_id}/runtime-observation-consumers/register",
-    response_model=RuntimeObservationConsumerResponse,
-)
-async def platform_register_runtime_observation_consumer(
-    agent_id: UUID,
-    body: PlatformRuntimeObservationConsumerRegister,
-    _auth: PlatformMutationAuth = Depends(
-        require_platform_mutation_auth("platform:runtime-observations:read")
-    ),
-    db: AsyncSession = Depends(get_session),
-) -> RuntimeObservationConsumerResponse:
-    owner = await _resolve_owner_read(db, body.owner)
-    try:
-        values = await register_runtime_observation_consumer(
-            db,
-            environment_id=agent_id,
-            owner_id=owner.id,
-            deployment_id=body.deployment_id,
-            consumer_id=body.consumer_id,
-        )
-    except RuntimeObservationProtocolError as exc:
-        if exc.code == "observation_cursor_expired":
-            await db.commit()
-        else:
-            await db.rollback()
-        _raise_runtime_observation_error(exc)
-    await db.commit()
-    return RuntimeObservationConsumerResponse.model_validate(values)
-
-
-@router.post(
-    "/agents/{agent_id}/runtime-observations/read",
-    response_model=RuntimeObservationReadResponse,
-)
-async def platform_read_runtime_observations(
-    agent_id: UUID,
-    body: PlatformRuntimeObservationRead,
-    _auth: PlatformMutationAuth = Depends(
-        require_platform_mutation_auth("platform:runtime-observations:read")
-    ),
-    db: AsyncSession = Depends(get_runtime_observation_session),
-) -> RuntimeObservationReadResponse:
-    """Read credential-authenticated guest reports for the Hosted controller.
-
-    The readiness authority is the authenticated guest report from the
-    per-deployment runtime credential. It is not attestation-bound instance identity.
-    """
-
-    owner = await _resolve_owner_read(db, body.owner)
-    identity = body.expected_apply_identity
-    try:
-        values = await read_runtime_observations(
-            db,
-            environment_id=agent_id,
-            owner_id=owner.id,
-            deployment_id=body.deployment_id,
-            consumer_id=body.consumer_id,
-            expected_apply_identity=RuntimeApplyIdentity(
-                generation=identity.generation,
-                manifest_etag=identity.manifest_etag,
-                apply_receipt_id=identity.apply_receipt_id,
-                boot_nonce=identity.boot_nonce,
-            ),
-            after_cursor=body.after_cursor,
-            limit=body.limit,
-        )
-    except RuntimeObservationProtocolError as exc:
-        if exc.code == "observation_cursor_expired":
-            # A known invalid cursor installs its explicit reset boundary in
-            # this same repeatable-read transaction before the 410 is visible.
-            await db.commit()
-        else:
-            await db.rollback()
-        _raise_runtime_observation_error(exc)
-    return RuntimeObservationReadResponse.model_validate(values)
-
-
-@router.post(
-    "/agents/{agent_id}/runtime-observation-consumers/ack",
-    response_model=RuntimeObservationConsumerResponse,
-)
-async def platform_ack_runtime_observation_consumer(
-    agent_id: UUID,
-    body: PlatformRuntimeObservationConsumerAck,
-    _auth: PlatformMutationAuth = Depends(
-        require_platform_mutation_auth("platform:runtime-observations:read")
-    ),
-    db: AsyncSession = Depends(get_session),
-) -> RuntimeObservationConsumerResponse:
-    owner = await _resolve_owner_read(db, body.owner)
-    try:
-        values = await acknowledge_runtime_observation_cursor(
-            db,
-            environment_id=agent_id,
-            owner_id=owner.id,
-            deployment_id=body.deployment_id,
-            consumer_id=body.consumer_id,
-            opaque_cursor=body.cursor,
-        )
-    except RuntimeObservationProtocolError as exc:
-        if exc.code == "observation_cursor_expired":
-            await db.commit()
-        else:
-            await db.rollback()
-        _raise_runtime_observation_error(exc)
-    await db.commit()
-    return RuntimeObservationConsumerResponse.model_validate(values)
-
-
-@router.post(
-    "/agents/{agent_id}/runtime-observation-consumers/reset",
-    response_model=RuntimeObservationConsumerResetResponse,
-)
-async def platform_reset_runtime_observation_consumer(
-    agent_id: UUID,
-    body: PlatformRuntimeObservationConsumerReset,
-    _auth: PlatformMutationAuth = Depends(
-        require_platform_mutation_auth("platform:runtime-observations:read")
-    ),
-    db: AsyncSession = Depends(get_session),
-) -> RuntimeObservationConsumerResetResponse:
-    owner = await _resolve_owner_read(db, body.owner)
-    try:
-        values = await reset_runtime_observation_consumer(
-            db,
-            environment_id=agent_id,
-            owner_id=owner.id,
-            deployment_id=body.deployment_id,
-            consumer_id=body.consumer_id,
-        )
-    except RuntimeObservationProtocolError as exc:
-        await db.rollback()
-        _raise_runtime_observation_error(exc)
-    await db.commit()
-    return RuntimeObservationConsumerResetResponse.model_validate(values)
-
-
 @router.post("/auth/keys", response_model=ApiKeyCreated)
 async def platform_mint_api_key(
     body: PlatformApiKeyCreate,
@@ -1187,36 +918,12 @@ async def platform_mint_api_key(
         request=request,
         idempotency_key=idempotency_key,
     )
-    try:
-        await provision_runtime_environment_fence(
-            db,
-            environment_id=body.environment_id,
-            owner_id=owner.id,
-            deployment_id=body.deployment_id,
-        )
-    except RuntimeObservationProtocolError as exc:
-        await _reject(
-            db,
-            status_code=exc.status_code,
-            detail=exc.detail(),
-            result=exc.code,
-            owner=body.owner,
-            owner_user_id=owner.id,
-            resource_type="runtime_environment_fence",
-            resource_id=str(body.environment_id),
-            action=action,
-            request=request,
-            idempotency_key=idempotency_key,
-            environment_id=body.environment_id,
-        )
-        raise AssertionError("unreachable")
     minted = await mint_api_key(
         db,
         user_id=owner.id,
         label=body.label,
         scopes=body.scopes,
         environment_id=body.environment_id,
-        runtime_deployment_id=body.deployment_id,
         managed=True,
         commit=False,
     )

--- a/backend/app/routes/runtime_observation_v2.py
+++ b/backend/app/routes/runtime_observation_v2.py
@@ -61,13 +61,6 @@ IdempotencyKey = Annotated[
     Header(alias="Idempotency-Key", min_length=1, max_length=200),
 ]
 
-_AUDITED_INGEST_REJECTIONS = frozenset(
-    {
-        "runtime_environment_retired",
-        "runtime_observation_identity_conflict",
-        "runtime_observation_event_conflict",
-    }
-)
 _NON_ADVANCING_OUTCOMES = frozenset(
     {
         "accepted_non_advance_sequence",
@@ -78,28 +71,49 @@ _NON_ADVANCING_OUTCOMES = frozenset(
 
 async def require_runtime_observation_writer(
     environment_id: UUID,
+    body: RuntimeObservationEventV2,
     auth: AuthContext = Depends(get_auth),
+    db: AsyncSession = Depends(get_session),
 ) -> AuthContext:
     """Require one explicit, narrow deployment credential for v2 ingestion."""
 
     api_key = auth.api_key
-    if (
-        not auth.is_cli
-        or api_key is None
-        or not api_key.managed
-        or api_key.environment_id != environment_id
-        or api_key.runtime_deployment_id is None
-        or api_key.scopes is None
-        or RUNTIME_OBSERVATION_WRITE_SCOPE not in api_key.scopes
-    ):
-        raise HTTPException(
-            status.HTTP_403_FORBIDDEN,
-            detail={
-                "code": "runtime_observation_credential_mismatch",
-                "message": "a deployment-bound v2 runtime observation credential is required",
-            },
+    rejection_reason: str | None = None
+    if not auth.is_cli or api_key is None:
+        rejection_reason = "runtime_credential_required"
+    elif not api_key.managed:
+        rejection_reason = "managed_credential_required"
+    elif api_key.environment_id != environment_id:
+        rejection_reason = "environment_binding_mismatch"
+    elif api_key.runtime_deployment_id is None:
+        rejection_reason = "deployment_binding_missing"
+    elif api_key.scopes is None or RUNTIME_OBSERVATION_WRITE_SCOPE not in api_key.scopes:
+        rejection_reason = "scope_missing"
+    if rejection_reason is None:
+        return auth
+
+    try:
+        _record_runtime_ingest_audit(
+            db,
+            actor_user_id=auth.user_id,
+            runtime_principal_id=api_key.id if api_key is not None else None,
+            deployment_id=(api_key.runtime_deployment_id if api_key is not None else None),
+            environment_id=environment_id,
+            value=body,
+            outcome="runtime_observation_credential_mismatch",
+            rejection_reason=rejection_reason,
         )
-    return auth
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    raise HTTPException(
+        status.HTTP_403_FORBIDDEN,
+        detail={
+            "code": "runtime_observation_credential_mismatch",
+            "message": "a deployment-bound v2 runtime observation credential is required",
+        },
+    )
 
 
 async def _resolve_owner(db: AsyncSession, owner: PlatformOwner) -> User:
@@ -213,11 +227,12 @@ def _record_runtime_ingest_audit(
     db: AsyncSession,
     *,
     actor_user_id: UUID,
-    runtime_principal_id: UUID,
-    deployment_id: str,
+    runtime_principal_id: UUID | None,
+    deployment_id: str | None,
     environment_id: UUID,
     value: RuntimeObservationEventV2,
     outcome: str,
+    rejection_reason: str | None = None,
 ) -> None:
     record_control_plane_audit(
         db,
@@ -230,13 +245,21 @@ def _record_runtime_ingest_audit(
         resource_id=str(environment_id),
         environment_id=None,
         details={
-            "runtime_principal_id": str(runtime_principal_id),
+            "principal_id": (
+                str(runtime_principal_id) if runtime_principal_id is not None else None
+            ),
+            # Retain the initial companion audit field while exposing the
+            # protocol-neutral principal name required by the v2 audit contract.
+            "runtime_principal_id": (
+                str(runtime_principal_id) if runtime_principal_id is not None else None
+            ),
             "environment_id": str(environment_id),
             "deployment_id": deployment_id,
             "boot_session_id": value.boot_session_id,
             "sequence": value.sequence,
             "event_id": value.event_id,
             "outcome": outcome,
+            **({"rejection_reason": rejection_reason} if rejection_reason else {}),
         },
     )
 
@@ -409,21 +432,20 @@ async def ingest_runtime_observation_event(
         await db.commit()
     except RuntimeObservationProtocolError as exc:
         await db.rollback()
-        if exc.code in _AUDITED_INGEST_REJECTIONS:
-            try:
-                _record_runtime_ingest_audit(
-                    db,
-                    actor_user_id=actor_user_id,
-                    runtime_principal_id=runtime_principal_id,
-                    deployment_id=deployment_id,
-                    environment_id=environment_id,
-                    value=body,
-                    outcome=exc.code,
-                )
-                await db.commit()
-            except Exception:
-                await db.rollback()
-                raise
+        try:
+            _record_runtime_ingest_audit(
+                db,
+                actor_user_id=actor_user_id,
+                runtime_principal_id=runtime_principal_id,
+                deployment_id=deployment_id,
+                environment_id=environment_id,
+                value=body,
+                outcome=exc.code,
+            )
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
         _raise_protocol_error(exc)
     except Exception:
         await db.rollback()

--- a/backend/app/routes/runtime_observation_v2.py
+++ b/backend/app/routes/runtime_observation_v2.py
@@ -1,0 +1,718 @@
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any, NoReturn
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi.responses import JSONResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import AuthContext, get_auth
+from app.core.database import get_runtime_observation_session, get_session
+from app.models.runtime_observation import V2RuntimeEnvironmentFence
+from app.models.user import PRINCIPAL_KIND_CLERK, PRINCIPAL_KIND_PARTNER_TENANT, User
+from app.schemas.api_key import ApiKeyCreated
+from app.schemas.platform import PlatformOwner
+from app.schemas.runtime_observation import (
+    RUNTIME_OBSERVATION_WRITE_SCOPE,
+    RuntimeDeploymentKeyCreate,
+    RuntimeEnvironmentRetirementReceipt,
+    RuntimeEnvironmentRetireRequest,
+    RuntimeObservationConsumerAckRequest,
+    RuntimeObservationConsumerRequest,
+    RuntimeObservationConsumerResetResponse,
+    RuntimeObservationConsumerResponse,
+    RuntimeObservationEventV2,
+    RuntimeObservationIngestResponse,
+    RuntimeObservationReadRequest,
+    RuntimeObservationReadResponse,
+)
+from app.services.api_key import mint_api_key
+from app.services.audit import record_control_plane_audit
+from app.services.platform_contract import (
+    PlatformReplay,
+    lock_platform_idempotency,
+    platform_request_hash,
+    read_platform_replay,
+    store_platform_response,
+)
+from app.services.platform_workload_auth import (
+    PlatformMutationAuth,
+    require_platform_workload_auth,
+)
+from app.services.runtime_observation import (
+    RuntimeApplyIdentity,
+    RuntimeObservationProtocolError,
+    acknowledge_runtime_observation_cursor,
+    ingest_runtime_observation,
+    provision_runtime_environment_fence,
+    read_runtime_observations,
+    register_runtime_observation_consumer,
+    reset_runtime_observation_consumer,
+    retire_runtime_environment,
+)
+
+router = APIRouter(prefix="/v2/runtime", tags=["v2-runtime-observations"])
+
+IdempotencyKey = Annotated[
+    str,
+    Header(alias="Idempotency-Key", min_length=1, max_length=200),
+]
+
+_AUDITED_INGEST_REJECTIONS = frozenset(
+    {
+        "runtime_environment_retired",
+        "runtime_observation_identity_conflict",
+        "runtime_observation_event_conflict",
+    }
+)
+_NON_ADVANCING_OUTCOMES = frozenset(
+    {
+        "accepted_non_advance_sequence",
+        "accepted_non_advance_captured_at",
+    }
+)
+
+
+async def require_runtime_observation_writer(
+    environment_id: UUID,
+    auth: AuthContext = Depends(get_auth),
+) -> AuthContext:
+    """Require one explicit, narrow deployment credential for v2 ingestion."""
+
+    api_key = auth.api_key
+    if (
+        not auth.is_cli
+        or api_key is None
+        or not api_key.managed
+        or api_key.environment_id != environment_id
+        or api_key.runtime_deployment_id is None
+        or api_key.scopes is None
+        or RUNTIME_OBSERVATION_WRITE_SCOPE not in api_key.scopes
+    ):
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": "runtime_observation_credential_mismatch",
+                "message": "a deployment-bound v2 runtime observation credential is required",
+            },
+        )
+    return auth
+
+
+async def _resolve_owner(db: AsyncSession, owner: PlatformOwner) -> User:
+    if owner.kind == PRINCIPAL_KIND_CLERK:
+        filters = (
+            User.principal_kind == PRINCIPAL_KIND_CLERK,
+            User.clerk_id == owner.ref,
+        )
+    else:
+        filters = (
+            User.principal_kind == PRINCIPAL_KIND_PARTNER_TENANT,
+            User.partner_tenant_ref == owner.ref,
+            User.clerk_id.is_(None),
+        )
+    resolved = (await db.execute(select(User).where(*filters))).scalar_one_or_none()
+    if resolved is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Owner not found")
+    return resolved
+
+
+async def _begin_idempotent_mutation(
+    db: AsyncSession,
+    *,
+    operation: str,
+    idempotency_key: str,
+    request_payload: dict[str, Any],
+    owner_user_id: UUID,
+) -> tuple[str, PlatformReplay | None]:
+    request_hash = platform_request_hash(request_payload)
+    existing = await lock_platform_idempotency(
+        db,
+        operation=operation,
+        idempotency_key=idempotency_key,
+    )
+    if existing is None:
+        return request_hash, None
+    if existing.request_hash != request_hash or existing.owner_user_id != owner_user_id:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            "Idempotency-Key was already used with a different request",
+        )
+    return request_hash, read_platform_replay(existing)
+
+
+def _canonical_response_body(value: Any) -> dict[str, Any]:
+    if hasattr(value, "model_dump"):
+        body = value.model_dump(mode="json", by_alias=True)
+    elif isinstance(value, dict):
+        body = value
+    else:
+        raise TypeError("v2 runtime response must be an object")
+    return json.loads(json.dumps(body, sort_keys=True, separators=(",", ":")))
+
+
+class _CanonicalJSONResponse(JSONResponse):
+    def render(self, content: Any) -> bytes:
+        return json.dumps(
+            content,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+
+def _replay_response(replay: PlatformReplay) -> JSONResponse:
+    return _CanonicalJSONResponse(status_code=replay.status_code, content=replay.body)
+
+
+def _workload_identity(auth: PlatformMutationAuth) -> tuple[str, str]:
+    if auth.kind != "workload" or auth.client_id is None or auth.credential_id is None:
+        raise RuntimeError("v2 runtime control-plane routes require workload identity")
+    return auth.client_id, str(auth.credential_id)
+
+
+def _record_workload_audit(
+    db: AsyncSession,
+    *,
+    auth: PlatformMutationAuth,
+    action: str,
+    target_user_id: UUID,
+    environment_id: UUID,
+    deployment_id: str,
+    outcome: str,
+    details: dict[str, Any] | None = None,
+) -> None:
+    client_id, principal_id = _workload_identity(auth)
+    record_control_plane_audit(
+        db,
+        actor_type="platform_workload",
+        target_user_id=target_user_id,
+        source="api.v2.runtime",
+        action=action,
+        resource_type="runtime_environment_fence",
+        resource_id=str(environment_id),
+        # Keep the durable identity after AgentEnvironment deletion. The
+        # environment UUID remains in resource_id and safe details.
+        environment_id=None,
+        details={
+            "workload_client_id": client_id,
+            "workload_principal_id": principal_id,
+            "environment_id": str(environment_id),
+            "deployment_id": deployment_id,
+            "outcome": outcome,
+            **(details or {}),
+        },
+    )
+
+
+def _record_runtime_ingest_audit(
+    db: AsyncSession,
+    *,
+    actor_user_id: UUID,
+    runtime_principal_id: UUID,
+    deployment_id: str,
+    environment_id: UUID,
+    value: RuntimeObservationEventV2,
+    outcome: str,
+) -> None:
+    record_control_plane_audit(
+        db,
+        actor_type="runtime_deployment",
+        actor_user_id=actor_user_id,
+        target_user_id=actor_user_id,
+        source="api.v2.runtime",
+        action="runtime_observation.ingest",
+        resource_type="runtime_observation",
+        resource_id=str(environment_id),
+        environment_id=None,
+        details={
+            "runtime_principal_id": str(runtime_principal_id),
+            "environment_id": str(environment_id),
+            "deployment_id": deployment_id,
+            "boot_session_id": value.boot_session_id,
+            "sequence": value.sequence,
+            "event_id": value.event_id,
+            "outcome": outcome,
+        },
+    )
+
+
+def _record_cursor_expiry_audit(
+    db: AsyncSession,
+    *,
+    auth: PlatformMutationAuth,
+    target_user_id: UUID,
+    environment_id: UUID,
+    deployment_id: str,
+    operation: str,
+) -> None:
+    client_id, principal_id = _workload_identity(auth)
+    record_control_plane_audit(
+        db,
+        actor_type="platform_workload",
+        target_user_id=target_user_id,
+        source="api.v2.runtime",
+        action="runtime_observation.cursor_expired",
+        resource_type="runtime_observation_consumer",
+        resource_id=str(environment_id),
+        environment_id=None,
+        details={
+            "workload_client_id": client_id,
+            "workload_principal_id": principal_id,
+            "consumer_id": client_id,
+            "environment_id": str(environment_id),
+            "deployment_id": deployment_id,
+            "operation": operation,
+            "outcome": "observation_cursor_expired",
+            "reset_required": True,
+        },
+    )
+
+
+def _raise_protocol_error(exc: RuntimeObservationProtocolError) -> NoReturn:
+    raise HTTPException(exc.status_code, exc.detail()) from exc
+
+
+async def _load_fence_binding(
+    db: AsyncSession,
+    *,
+    environment_id: UUID,
+) -> V2RuntimeEnvironmentFence:
+    """Resolve immutable owner/deployment authority without caller-supplied identity."""
+
+    fence = await db.get(V2RuntimeEnvironmentFence, environment_id)
+    if fence is None:
+        _raise_protocol_error(
+            RuntimeObservationProtocolError(
+                status.HTTP_409_CONFLICT,
+                "runtime_environment_fence_missing",
+                "runtime environment fence does not exist",
+            )
+        )
+    return fence
+
+
+@router.post("/auth/keys", response_model=ApiKeyCreated)
+async def create_runtime_deployment_key(
+    body: RuntimeDeploymentKeyCreate,
+    idempotency_key: IdempotencyKey,
+    auth: PlatformMutationAuth = Depends(require_platform_workload_auth("platform:keys:mint")),
+    db: AsyncSession = Depends(get_session),
+) -> JSONResponse:
+    owner = await _resolve_owner(db, body.owner)
+    request_payload = body.model_dump(mode="json", by_alias=True)
+    request_hash, replay = await _begin_idempotent_mutation(
+        db,
+        operation="v2.runtime.keys.mint",
+        idempotency_key=idempotency_key,
+        request_payload=request_payload,
+        owner_user_id=owner.id,
+    )
+    if replay is not None:
+        return _replay_response(replay)
+    try:
+        await provision_runtime_environment_fence(
+            db,
+            environment_id=body.environment_id,
+            owner_id=owner.id,
+            deployment_id=body.deployment_id,
+        )
+        minted = await mint_api_key(
+            db,
+            user_id=owner.id,
+            label=body.label,
+            scopes=body.scopes,
+            environment_id=body.environment_id,
+            runtime_deployment_id=body.deployment_id,
+            managed=True,
+            commit=False,
+        )
+        response = ApiKeyCreated(
+            id=str(minted.api_key.id),
+            label=minted.api_key.label,
+            key_prefix=minted.api_key.key_prefix,
+            created_at=minted.api_key.created_at,
+            last_used_at=minted.api_key.last_used_at,
+            expires_at=minted.api_key.expires_at,
+            revoked_at=minted.api_key.revoked_at,
+            raw_key=minted.raw_key,
+        )
+        response_body = _canonical_response_body(response)
+        _record_workload_audit(
+            db,
+            auth=auth,
+            action="runtime_environment.provision",
+            target_user_id=owner.id,
+            environment_id=body.environment_id,
+            deployment_id=body.deployment_id,
+            outcome="provisioned",
+            details={"runtime_principal_id": str(minted.api_key.id)},
+        )
+        store_platform_response(
+            db,
+            operation="v2.runtime.keys.mint",
+            idempotency_key=idempotency_key,
+            request_hash=request_hash,
+            owner_user_id=owner.id,
+            resource_type="runtime_deployment_key",
+            resource_id=str(minted.api_key.id),
+            response_status=status.HTTP_200_OK,
+            response_body=response_body,
+        )
+        await db.commit()
+    except RuntimeObservationProtocolError as exc:
+        await db.rollback()
+        _raise_protocol_error(exc)
+    except Exception:
+        await db.rollback()
+        raise
+    return _CanonicalJSONResponse(status_code=status.HTTP_200_OK, content=response_body)
+
+
+@router.post(
+    "/environments/{environment_id}/observations",
+    response_model=RuntimeObservationIngestResponse,
+)
+async def ingest_runtime_observation_event(
+    environment_id: UUID,
+    body: RuntimeObservationEventV2,
+    auth: AuthContext = Depends(require_runtime_observation_writer),
+    db: AsyncSession = Depends(get_session),
+) -> RuntimeObservationIngestResponse:
+    api_key = auth.api_key
+    if api_key is None or api_key.runtime_deployment_id is None:
+        raise RuntimeError("runtime deployment identity was not authenticated")
+    actor_user_id = auth.user_id
+    runtime_principal_id = api_key.id
+    deployment_id = api_key.runtime_deployment_id
+    try:
+        result = await ingest_runtime_observation(
+            db,
+            environment_id=environment_id,
+            credential_deployment_id=deployment_id,
+            value=body,
+        )
+        if result.outcome in _NON_ADVANCING_OUTCOMES:
+            _record_runtime_ingest_audit(
+                db,
+                actor_user_id=actor_user_id,
+                runtime_principal_id=runtime_principal_id,
+                deployment_id=deployment_id,
+                environment_id=environment_id,
+                value=body,
+                outcome=result.outcome,
+            )
+        await db.commit()
+    except RuntimeObservationProtocolError as exc:
+        await db.rollback()
+        if exc.code in _AUDITED_INGEST_REJECTIONS:
+            try:
+                _record_runtime_ingest_audit(
+                    db,
+                    actor_user_id=actor_user_id,
+                    runtime_principal_id=runtime_principal_id,
+                    deployment_id=deployment_id,
+                    environment_id=environment_id,
+                    value=body,
+                    outcome=exc.code,
+                )
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
+        _raise_protocol_error(exc)
+    except Exception:
+        await db.rollback()
+        raise
+    return RuntimeObservationIngestResponse(
+        eventId=result.event_id,
+        streamPosition=result.stream_position,
+        outcome=result.outcome,
+    )
+
+
+@router.post(
+    "/environments/{environment_id}/retire",
+    response_model=RuntimeEnvironmentRetirementReceipt,
+)
+async def retire_runtime_environment_endpoint(
+    environment_id: UUID,
+    body: RuntimeEnvironmentRetireRequest,
+    idempotency_key: IdempotencyKey,
+    auth: PlatformMutationAuth = Depends(
+        require_platform_workload_auth("platform:runtime-environments:retire")
+    ),
+    db: AsyncSession = Depends(get_session),
+) -> JSONResponse:
+    binding = await _load_fence_binding(db, environment_id=environment_id)
+    binding_owner_id = binding.owner_id
+    request_payload = {
+        "environmentId": str(environment_id),
+        **body.model_dump(mode="json", by_alias=True),
+    }
+    request_hash, replay = await _begin_idempotent_mutation(
+        db,
+        operation="v2.runtime.environment.retire",
+        idempotency_key=idempotency_key,
+        request_payload=request_payload,
+        owner_user_id=binding_owner_id,
+    )
+    if replay is not None:
+        return _replay_response(replay)
+    try:
+        result = await retire_runtime_environment(
+            db,
+            environment_id=environment_id,
+            expected_deployment_id=body.expected_deployment_binding,
+            retirement_id=body.retirement_id,
+            owner_id=binding_owner_id,
+        )
+        receipt = RuntimeEnvironmentRetirementReceipt.model_validate(result.receipt)
+        response_body = _canonical_response_body(receipt)
+        if result.transitioned:
+            _record_workload_audit(
+                db,
+                auth=auth,
+                action="runtime_environment.retire",
+                target_user_id=binding_owner_id,
+                environment_id=environment_id,
+                deployment_id=body.expected_deployment_binding,
+                outcome="transitioned",
+                details={
+                    "retirement_id": body.retirement_id,
+                    "retirement_receipt_id": str(binding.retirement_receipt_id),
+                    "previous_state": "active",
+                    "new_state": "retired",
+                    "retired_at": receipt.retired_at.isoformat(),
+                    "final_stream_position": result.final_stream_position,
+                    "final_cursor_present": True,
+                    "final_session_high_water_marks": result.final_session_high_waters,
+                },
+            )
+        else:
+            _record_workload_audit(
+                db,
+                auth=auth,
+                action="runtime_environment.retire_replay",
+                target_user_id=binding_owner_id,
+                environment_id=environment_id,
+                deployment_id=body.expected_deployment_binding,
+                outcome="replayed",
+                details={
+                    "retirement_id": body.retirement_id,
+                    "retirement_receipt_id": str(binding.retirement_receipt_id),
+                },
+            )
+        store_platform_response(
+            db,
+            operation="v2.runtime.environment.retire",
+            idempotency_key=idempotency_key,
+            request_hash=request_hash,
+            owner_user_id=binding_owner_id,
+            resource_type="runtime_environment_fence",
+            resource_id=str(environment_id),
+            response_status=status.HTTP_200_OK,
+            response_body=response_body,
+        )
+        await db.commit()
+    except RuntimeObservationProtocolError as exc:
+        await db.rollback()
+        try:
+            _record_workload_audit(
+                db,
+                auth=auth,
+                action="runtime_environment.retire",
+                target_user_id=binding_owner_id,
+                environment_id=environment_id,
+                deployment_id=body.expected_deployment_binding,
+                outcome=exc.code,
+                details={"retirement_id": body.retirement_id},
+            )
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+        _raise_protocol_error(exc)
+    except Exception:
+        await db.rollback()
+        raise
+    return _CanonicalJSONResponse(status_code=status.HTTP_200_OK, content=response_body)
+
+
+async def _commit_cursor_expiry_or_rollback(
+    db: AsyncSession,
+    *,
+    exc: RuntimeObservationProtocolError,
+    auth: PlatformMutationAuth,
+    owner_id: UUID,
+    environment_id: UUID,
+    deployment_id: str,
+    operation: str,
+) -> NoReturn:
+    if exc.code != "observation_cursor_expired":
+        await db.rollback()
+        _raise_protocol_error(exc)
+    try:
+        _record_cursor_expiry_audit(
+            db,
+            auth=auth,
+            target_user_id=owner_id,
+            environment_id=environment_id,
+            deployment_id=deployment_id,
+            operation=operation,
+        )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    _raise_protocol_error(exc)
+
+
+@router.post(
+    "/environments/{environment_id}/observation-consumers/register",
+    response_model=RuntimeObservationConsumerResponse,
+)
+async def register_runtime_observation_consumer_endpoint(
+    environment_id: UUID,
+    body: RuntimeObservationConsumerRequest,
+    auth: PlatformMutationAuth = Depends(
+        require_platform_workload_auth("platform:runtime-observations:consume")
+    ),
+    db: AsyncSession = Depends(get_session),
+) -> RuntimeObservationConsumerResponse:
+    binding = await _load_fence_binding(db, environment_id=environment_id)
+    client_id, _ = _workload_identity(auth)
+    try:
+        values = await register_runtime_observation_consumer(
+            db,
+            environment_id=environment_id,
+            owner_id=binding.owner_id,
+            deployment_id=binding.deployment_id,
+            consumer_id=client_id,
+        )
+        await db.commit()
+    except RuntimeObservationProtocolError as exc:
+        await _commit_cursor_expiry_or_rollback(
+            db,
+            exc=exc,
+            auth=auth,
+            owner_id=binding.owner_id,
+            environment_id=environment_id,
+            deployment_id=binding.deployment_id,
+            operation="register",
+        )
+    return RuntimeObservationConsumerResponse.model_validate(values)
+
+
+@router.post(
+    "/environments/{environment_id}/observations/read",
+    response_model=RuntimeObservationReadResponse,
+)
+async def read_runtime_observations_endpoint(
+    environment_id: UUID,
+    body: RuntimeObservationReadRequest,
+    auth: PlatformMutationAuth = Depends(
+        require_platform_workload_auth("platform:runtime-observations:consume")
+    ),
+    db: AsyncSession = Depends(get_runtime_observation_session),
+) -> RuntimeObservationReadResponse:
+    binding = await _load_fence_binding(db, environment_id=environment_id)
+    client_id, _ = _workload_identity(auth)
+    expected = body.expected_apply_identity
+    try:
+        values = await read_runtime_observations(
+            db,
+            environment_id=environment_id,
+            owner_id=binding.owner_id,
+            deployment_id=binding.deployment_id,
+            consumer_id=client_id,
+            expected_apply_identity=RuntimeApplyIdentity(
+                generation=expected.generation,
+                manifest_etag=expected.manifest_etag,
+                apply_receipt_id=expected.apply_receipt_id,
+                boot_nonce=expected.boot_nonce,
+            ),
+            after_cursor=body.after_cursor,
+            limit=body.limit,
+        )
+    except RuntimeObservationProtocolError as exc:
+        await _commit_cursor_expiry_or_rollback(
+            db,
+            exc=exc,
+            auth=auth,
+            owner_id=binding.owner_id,
+            environment_id=environment_id,
+            deployment_id=binding.deployment_id,
+            operation="read",
+        )
+    return RuntimeObservationReadResponse.model_validate(values)
+
+
+@router.post(
+    "/environments/{environment_id}/observation-consumers/ack",
+    response_model=RuntimeObservationConsumerResponse,
+)
+async def acknowledge_runtime_observation_consumer_endpoint(
+    environment_id: UUID,
+    body: RuntimeObservationConsumerAckRequest,
+    auth: PlatformMutationAuth = Depends(
+        require_platform_workload_auth("platform:runtime-observations:consume")
+    ),
+    db: AsyncSession = Depends(get_session),
+) -> RuntimeObservationConsumerResponse:
+    binding = await _load_fence_binding(db, environment_id=environment_id)
+    client_id, _ = _workload_identity(auth)
+    try:
+        values = await acknowledge_runtime_observation_cursor(
+            db,
+            environment_id=environment_id,
+            owner_id=binding.owner_id,
+            deployment_id=binding.deployment_id,
+            consumer_id=client_id,
+            opaque_cursor=body.cursor,
+        )
+        await db.commit()
+    except RuntimeObservationProtocolError as exc:
+        await _commit_cursor_expiry_or_rollback(
+            db,
+            exc=exc,
+            auth=auth,
+            owner_id=binding.owner_id,
+            environment_id=environment_id,
+            deployment_id=binding.deployment_id,
+            operation="ack",
+        )
+    return RuntimeObservationConsumerResponse.model_validate(values)
+
+
+@router.post(
+    "/environments/{environment_id}/observation-consumers/reset",
+    response_model=RuntimeObservationConsumerResetResponse,
+)
+async def reset_runtime_observation_consumer_endpoint(
+    environment_id: UUID,
+    body: RuntimeObservationConsumerRequest,
+    auth: PlatformMutationAuth = Depends(
+        require_platform_workload_auth("platform:runtime-observations:consume")
+    ),
+    db: AsyncSession = Depends(get_session),
+) -> RuntimeObservationConsumerResetResponse:
+    binding = await _load_fence_binding(db, environment_id=environment_id)
+    client_id, _ = _workload_identity(auth)
+    try:
+        values = await reset_runtime_observation_consumer(
+            db,
+            environment_id=environment_id,
+            owner_id=binding.owner_id,
+            deployment_id=binding.deployment_id,
+            consumer_id=client_id,
+        )
+        await db.commit()
+    except RuntimeObservationProtocolError as exc:
+        await db.rollback()
+        _raise_protocol_error(exc)
+    return RuntimeObservationConsumerResetResponse.model_validate(values)

--- a/backend/app/routes/runtime_observation_v2.py
+++ b/backend/app/routes/runtime_observation_v2.py
@@ -96,6 +96,7 @@ async def require_runtime_observation_writer(
         _record_runtime_ingest_audit(
             db,
             actor_user_id=auth.user_id,
+            principal_id=api_key.id if api_key is not None else auth.user_id,
             runtime_principal_id=api_key.id if api_key is not None else None,
             deployment_id=(api_key.runtime_deployment_id if api_key is not None else None),
             environment_id=environment_id,
@@ -227,6 +228,7 @@ def _record_runtime_ingest_audit(
     db: AsyncSession,
     *,
     actor_user_id: UUID,
+    principal_id: UUID,
     runtime_principal_id: UUID | None,
     deployment_id: str | None,
     environment_id: UUID,
@@ -236,7 +238,7 @@ def _record_runtime_ingest_audit(
 ) -> None:
     record_control_plane_audit(
         db,
-        actor_type="runtime_deployment",
+        actor_type="runtime_deployment" if runtime_principal_id is not None else "user",
         actor_user_id=actor_user_id,
         target_user_id=actor_user_id,
         source="api.v2.runtime",
@@ -245,9 +247,7 @@ def _record_runtime_ingest_audit(
         resource_id=str(environment_id),
         environment_id=None,
         details={
-            "principal_id": (
-                str(runtime_principal_id) if runtime_principal_id is not None else None
-            ),
+            "principal_id": str(principal_id),
             # Retain the initial companion audit field while exposing the
             # protocol-neutral principal name required by the v2 audit contract.
             "runtime_principal_id": (
@@ -423,6 +423,7 @@ async def ingest_runtime_observation_event(
             _record_runtime_ingest_audit(
                 db,
                 actor_user_id=actor_user_id,
+                principal_id=runtime_principal_id,
                 runtime_principal_id=runtime_principal_id,
                 deployment_id=deployment_id,
                 environment_id=environment_id,
@@ -436,6 +437,7 @@ async def ingest_runtime_observation_event(
             _record_runtime_ingest_audit(
                 db,
                 actor_user_id=actor_user_id,
+                principal_id=runtime_principal_id,
                 runtime_principal_id=runtime_principal_id,
                 deployment_id=deployment_id,
                 environment_id=environment_id,

--- a/backend/app/routes/sessions.py
+++ b/backend/app/routes/sessions.py
@@ -38,7 +38,6 @@ from app.models.session_permission import (
 from app.schemas.common import Paginated
 from app.schemas.runtime import validate_hosted_runtime_desired_state
 from app.schemas.runtime_observed import (
-    RUNTIME_OBSERVATION_COMPANION_FIELDS,
     HostedRuntimeObserved,
     HostedRuntimeObservedProviderPayload,
     HostedRuntimeObservedV2,
@@ -80,10 +79,6 @@ from app.services.file_store import get_file_store
 from app.services.http_cache import if_none_match_contains, strong_json_etag
 from app.services.memory_extraction import extract_memories_from_session
 from app.services.memory_provider import get_memory_provider
-from app.services.runtime_observation import (
-    RuntimeObservationProtocolError,
-    ingest_runtime_observation,
-)
 from app.services.runtime_source import (
     RuntimeSourceError,
     expected_runtime_bundle_v2_etag,
@@ -1401,8 +1396,6 @@ def _bounded_runtime_observed(value: object) -> object:
         raise ValueError("runtime_observed must be valid UTF-8 JSON") from exc
     if encoded_size <= _MAX_RUNTIME_OBSERVED_BYTES:
         return value
-    if RUNTIME_OBSERVATION_COMPANION_FIELDS.intersection(value):
-        raise ValueError("companion runtime_observed payload exceeded size limit")
     return {
         "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
         "reportedAt": datetime.now(UTC).isoformat(),
@@ -1479,10 +1472,6 @@ async def sync_heartbeat(
     """Daemon writes its liveness state here every cycle. Extreme-
     light endpoint: validate ownership / env-id binding, update a
     handful of columns, commit. No heavy queries.
-
-    Strict-v2 companion identity is an authenticated guest report from the
-    per-deployment runtime credential. It is readiness authority for this
-    protocol, but it is not attestation-bound instance identity.
     """
     env = (
         await db.execute(
@@ -1494,26 +1483,6 @@ async def sync_heartbeat(
     ).scalar_one_or_none()
     if env is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "agent environment not found")
-
-    runtime_observed = body.runtime_observed
-    is_companion_event = runtime_observed is not None and runtime_observed.is_companion_event
-    if is_companion_event and (
-        not auth.is_cli
-        or auth.api_key is None
-        or not auth.api_key.managed
-        or auth.api_key.environment_id != agent_id
-        or auth.api_key.runtime_deployment_id is None
-    ):
-        raise HTTPException(
-            status.HTTP_403_FORBIDDEN,
-            detail={
-                "code": "runtime_observation_credential_mismatch",
-                "message": (
-                    "companion runtime observations require the managed "
-                    "environment-bound runtime credential"
-                ),
-            },
-        )
 
     # If the deploy-key is bound to a specific env, refuse calls
     # for any other env. Resource-level project alone wasn't enough
@@ -1545,25 +1514,12 @@ async def sync_heartbeat(
     now = datetime.now(UTC)
     new_error = body.last_sync_error
     new_revision = body.last_revision_seen
+    runtime_observed = body.runtime_observed
     hosted_state = None
     observation = None
     runtime_observed_values = None
     observed_changed = False
-    if is_companion_event:
-        if auth.api_key is None or auth.api_key.runtime_deployment_id is None:
-            raise AssertionError("strict-v2 credential validation must precede ingestion")
-        try:
-            await ingest_runtime_observation(
-                db,
-                environment_id=agent_id,
-                credential_deployment_id=auth.api_key.runtime_deployment_id,
-                value=runtime_observed,
-                received_at=now,
-            )
-        except RuntimeObservationProtocolError as exc:
-            await db.rollback()
-            raise HTTPException(status_code=exc.status_code, detail=exc.detail()) from exc
-    elif runtime_observed is not None:
+    if runtime_observed is not None:
         runtime_observed_values = _runtime_observed_columns(
             runtime_observed,
             observed_at=now,
@@ -1598,15 +1554,12 @@ async def sync_heartbeat(
     # 60s clients live while preventing old 30s clients from writing
     # on every heartbeat.
     last = env.last_sync_at
-    needs_freshness_refresh = not is_companion_event and (
+    needs_freshness_refresh = (
         last is None or now - _as_utc(last) > _HEARTBEAT_FRESHNESS_WRITE_INTERVAL
     )
     if not has_state_change and not needs_freshness_refresh:
-        if is_companion_event:
-            await db.commit()
         return
-    if not is_companion_event:
-        env.last_sync_at = now
+    env.last_sync_at = now
     env.last_sync_error = new_error
     if new_revision is not None:
         env.last_revision_seen = new_revision

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -107,11 +107,6 @@ class AdminApiKeyCreate(BaseModel):
     `environment_id` is optional — if set, the minted key is bound
     to that env (deploy-key semantics). If null, the key is unbound.
 
-    `deployment_id` opts an environment-bound managed key into the strict-v2
-    runtime observation protocol. Legacy managed keys remain valid without it;
-    those keys cannot submit strict-v2 observations because no environment
-    fence is provisioned.
-
     `scopes` is optional — same API-permission semantics as the user-facing
     `ApiKeyCreate`: `None` means full account access (the default
     for both user-self-mint and admin-mint). Pass an explicit list
@@ -124,18 +119,8 @@ class AdminApiKeyCreate(BaseModel):
     target_clerk_id: AdminClerkId
     label: str
     environment_id: str | None = None
-    deployment_id: str | None = Field(default=None, min_length=1, max_length=200)
     scopes: list[str] | None = None
     managed: bool = False
-
-    @model_validator(mode="after")
-    def validate_v2_runtime_binding(self) -> AdminApiKeyCreate:
-        is_v2_runtime_key = self.managed and self.environment_id is not None
-        if self.deployment_id is not None and not is_v2_runtime_key:
-            raise ValueError(
-                "deployment_id is only valid for managed environment-bound runtime keys"
-            )
-        return self
 
 
 class AdminRuntimeStateUpsert(BaseModel):

--- a/backend/app/schemas/platform.py
+++ b/backend/app/schemas/platform.py
@@ -67,7 +67,6 @@ class PlatformAgentCreate(PlatformMutationBody):
 class PlatformApiKeyCreate(PlatformMutationBody):
     label: str = Field(min_length=1, max_length=200)
     environment_id: UUID
-    deployment_id: str = Field(min_length=1, max_length=200)
     scopes: list[str] = Field(default_factory=lambda: list(PLATFORM_RUNTIME_KEY_SCOPES))
 
     @field_validator("scopes")
@@ -140,41 +139,3 @@ class PlatformRuntimeStateResponse(BaseModel):
     deployment_id: str
     instance_id: str
     generation: int
-
-
-class PlatformRuntimeEnvironmentRetire(PlatformMutationBody):
-    expected_deployment_id: str = Field(min_length=1, max_length=200)
-    retirement_id: str = Field(min_length=1, max_length=200)
-
-
-class PlatformRuntimeObservationConsumerRegister(PlatformMutationBody):
-    deployment_id: str = Field(min_length=1, max_length=200)
-    consumer_id: str = Field(min_length=1, max_length=200)
-
-
-class PlatformRuntimeObservationConsumerAck(PlatformMutationBody):
-    deployment_id: str = Field(min_length=1, max_length=200)
-    consumer_id: str = Field(min_length=1, max_length=200)
-    cursor: str = Field(min_length=1, max_length=2000)
-
-
-class PlatformRuntimeObservationConsumerReset(PlatformMutationBody):
-    deployment_id: str = Field(min_length=1, max_length=200)
-    consumer_id: str = Field(min_length=1, max_length=200)
-
-
-class PlatformRuntimeApplyIdentity(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    generation: int = Field(ge=1)
-    manifest_etag: str = Field(alias="manifestETag", min_length=1, max_length=1024)
-    apply_receipt_id: str = Field(alias="applyReceiptId", min_length=16, max_length=128)
-    boot_nonce: str = Field(alias="bootNonce", min_length=16, max_length=128)
-
-
-class PlatformRuntimeObservationRead(PlatformMutationBody):
-    deployment_id: str = Field(min_length=1, max_length=200)
-    consumer_id: str = Field(min_length=1, max_length=200)
-    expected_apply_identity: PlatformRuntimeApplyIdentity = Field(alias="expectedApplyIdentity")
-    after_cursor: str = Field(alias="afterCursor", min_length=1, max_length=2000)
-    limit: int = Field(default=100, ge=1, le=500)

--- a/backend/app/schemas/runtime_observation.py
+++ b/backend/app/schemas/runtime_observation.py
@@ -1,9 +1,147 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, Literal
+from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, JsonValue
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_validator, model_validator
+
+from app.models.api_key import RUNTIME_DEPLOYMENT_KEY_SCOPES
+from app.schemas.platform import PlatformOwner
+from app.schemas.runtime_observed import (
+    HostedRuntimeObservedAppliedV2,
+    HostedRuntimeObservedBootV1,
+    HostedRuntimeObservedCliV1,
+    HostedRuntimeObservedProviderPayload,
+    HostedRuntimeObservedSupervisorV1,
+    HostedRuntimeObservedSystemdV1,
+    RuntimeObservedStatus,
+)
+
+RUNTIME_OBSERVATION_WRITE_SCOPE = "runtime-observations:write"
+
+
+class RuntimeObservationRequestModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class RuntimeObservationEventV2(RuntimeObservationRequestModel):
+    """Strict v2 companion event; deliberately separate from the frozen v1 wire model."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, strict=True)
+
+    schema_version: Literal["clawdi.hostedRuntimeObserved.v2"] = Field(alias="schemaVersion")
+    reported_at: datetime = Field(alias="reportedAt")
+    runtime_mode: Literal["hosted"] = Field(alias="runtimeMode")
+    status: RuntimeObservedStatus
+    active_cli_version: str | None = Field(
+        alias="activeCliVersion",
+        min_length=1,
+        max_length=200,
+    )
+    applied: HostedRuntimeObservedAppliedV2
+    boot: HostedRuntimeObservedBootV1 | None
+    cli: HostedRuntimeObservedCliV1 | None
+    systemd: HostedRuntimeObservedSystemdV1 | None = None
+    supervisor: HostedRuntimeObservedSupervisorV1 | None = None
+    providers: dict[str, HostedRuntimeObservedProviderPayload] | None = None
+    error: str | None = Field(default=None, max_length=4000)
+    converge_error: str | None = Field(alias="convergeError", default=None, max_length=4000)
+    truncated: Literal[False] | None = None
+    apply_receipt_id: str = Field(alias="applyReceiptId", min_length=16, max_length=128)
+    boot_nonce: str = Field(alias="bootNonce", min_length=16, max_length=128)
+    boot_session_id: str = Field(alias="bootSessionId", min_length=1, max_length=128)
+    sequence: int = Field(ge=1, le=9_007_199_254_740_991)
+    event_id: str = Field(alias="eventId", min_length=1, max_length=128)
+    captured_at: datetime = Field(alias="capturedAt")
+
+    @field_validator("reported_at", "captured_at", mode="before")
+    @classmethod
+    def validate_timestamp(cls, value: object) -> datetime:
+        if isinstance(value, datetime):
+            parsed = value
+        elif isinstance(value, str):
+            try:
+                parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError as exc:
+                raise ValueError("runtime observation timestamps must be ISO 8601") from exc
+        else:
+            raise ValueError("runtime observation timestamps must be ISO 8601 strings")
+        if parsed.tzinfo is None:
+            raise ValueError("runtime observation timestamps must include a timezone")
+        return parsed.astimezone(UTC)
+
+    @model_validator(mode="after")
+    def validate_companion_identity(self) -> RuntimeObservationEventV2:
+        if self.applied.generation < 1:
+            raise ValueError("runtime observation generation must be at least 1")
+        if self.reported_at != self.captured_at:
+            raise ValueError("reportedAt must equal capturedAt")
+        return self
+
+
+class RuntimeDeploymentKeyCreate(RuntimeObservationRequestModel):
+    owner: PlatformOwner
+    label: str = Field(min_length=1, max_length=200)
+    environment_id: UUID = Field(alias="environmentId")
+    deployment_id: str = Field(alias="deploymentId", min_length=1, max_length=200)
+    scopes: list[str] = Field(default_factory=lambda: list(RUNTIME_DEPLOYMENT_KEY_SCOPES))
+
+    @field_validator("scopes")
+    @classmethod
+    def validate_scopes(cls, value: list[str]) -> list[str]:
+        if not value:
+            raise ValueError("scopes cannot be empty")
+        if len(value) != len(set(value)):
+            raise ValueError("scopes cannot contain duplicates")
+        unknown = sorted(set(value) - set(RUNTIME_DEPLOYMENT_KEY_SCOPES))
+        if unknown:
+            raise ValueError(f"scopes exceed runtime deployment ceiling: {', '.join(unknown)}")
+        if RUNTIME_OBSERVATION_WRITE_SCOPE not in value:
+            raise ValueError(f"scopes must include {RUNTIME_OBSERVATION_WRITE_SCOPE}")
+        return [scope for scope in RUNTIME_DEPLOYMENT_KEY_SCOPES if scope in value]
+
+
+class RuntimeEnvironmentRetireRequest(RuntimeObservationRequestModel):
+    expected_deployment_binding: str = Field(
+        alias="expectedDeploymentBinding",
+        min_length=1,
+        max_length=200,
+    )
+    retirement_id: str = Field(alias="retirementId", min_length=1, max_length=200)
+
+
+class RuntimeObservationConsumerRequest(RuntimeObservationRequestModel):
+    pass
+
+
+class RuntimeObservationConsumerAckRequest(RuntimeObservationConsumerRequest):
+    cursor: str = Field(min_length=1, max_length=2000)
+
+
+class RuntimeApplyIdentityRequest(RuntimeObservationRequestModel):
+    generation: int = Field(ge=1)
+    manifest_etag: str = Field(alias="manifestETag", min_length=1, max_length=1024)
+    apply_receipt_id: str = Field(alias="applyReceiptId", min_length=16, max_length=128)
+    boot_nonce: str = Field(alias="bootNonce", min_length=16, max_length=128)
+
+
+class RuntimeObservationReadRequest(RuntimeObservationRequestModel):
+    expected_apply_identity: RuntimeApplyIdentityRequest = Field(alias="expectedApplyIdentity")
+    after_cursor: str = Field(alias="afterCursor", min_length=1, max_length=2000)
+    limit: int = Field(default=100, ge=1, le=500)
+
+
+class RuntimeObservationIngestResponse(RuntimeObservationRequestModel):
+    event_id: str = Field(alias="eventId")
+    stream_position: int = Field(alias="streamPosition")
+    outcome: Literal[
+        "accepted_head_created",
+        "accepted_head_advanced",
+        "accepted_non_advance_sequence",
+        "accepted_non_advance_captured_at",
+        "duplicate_replay",
+    ]
 
 
 class RuntimeObservationResponseModel(BaseModel):
@@ -88,13 +226,19 @@ class RuntimeObservationConsumerResetResponse(RuntimeObservationConsumerResponse
 
 
 class RuntimeEnvironmentRetirementReceipt(RuntimeObservationResponseModel):
-    retirement_receipt_id: str = Field(alias="retirementReceiptId")
+    environment_reference: str = Field(alias="environmentReference")
+    expected_deployment_binding: str = Field(alias="expectedDeploymentBinding")
     retirement_id: str = Field(alias="retirementId")
-    environment_id: str = Field(alias="environmentId")
-    deployment_id: str = Field(alias="deploymentId")
     retired_at: datetime = Field(alias="retiredAt")
     final_cursor: str = Field(alias="finalCursor")
-    final_session_high_water_marks: dict[str, int] = Field(alias="finalSessionHighWaterMarks")
+    final_session_high_water_marks: list[RuntimeSessionHighWaterMark] = Field(
+        alias="finalSessionHighWaterMarks"
+    )
+
+
+class RuntimeSessionHighWaterMark(RuntimeObservationResponseModel):
+    boot_session_id: str = Field(alias="bootSessionId")
+    sequence: int
 
 
 RuntimeObservationProblemDetail = dict[str, Any]

--- a/backend/app/schemas/runtime_observed.py
+++ b/backend/app/schemas/runtime_observed.py
@@ -14,16 +14,6 @@ from pydantic import (
 )
 
 RuntimeObservedStatus = Literal["ok", "error", "unknown"]
-RUNTIME_OBSERVATION_COMPANION_FIELDS = frozenset(
-    {
-        "applyReceiptId",
-        "bootNonce",
-        "bootSessionId",
-        "sequence",
-        "eventId",
-        "capturedAt",
-    }
-)
 
 
 class _StrictObservedWireModel(BaseModel):
@@ -133,32 +123,6 @@ class HostedRuntimeObservedV2(_StrictObservedWireModel):
     error: str | None = Field(default=None, max_length=4000)
     converge_error: str | None = Field(alias="convergeError", default=None, max_length=4000)
     truncated: bool | None = None
-    apply_receipt_id: str | None = Field(
-        alias="applyReceiptId",
-        default=None,
-        min_length=16,
-        max_length=128,
-    )
-    boot_nonce: str | None = Field(
-        alias="bootNonce",
-        default=None,
-        min_length=16,
-        max_length=128,
-    )
-    boot_session_id: str | None = Field(
-        alias="bootSessionId",
-        default=None,
-        min_length=1,
-        max_length=128,
-    )
-    sequence: int | None = Field(default=None, ge=1, le=9_007_199_254_740_991)
-    event_id: str | None = Field(
-        alias="eventId",
-        default=None,
-        min_length=1,
-        max_length=128,
-    )
-    captured_at: datetime | None = Field(alias="capturedAt", default=None)
 
     @field_validator("reported_at", mode="before")
     @classmethod
@@ -175,42 +139,6 @@ class HostedRuntimeObservedV2(_StrictObservedWireModel):
         if parsed.tzinfo is None:
             raise ValueError("reportedAt must include a timezone")
         return parsed.astimezone(UTC)
-
-    @field_validator("captured_at", mode="before")
-    @classmethod
-    def validate_captured_at(cls, value: object) -> datetime | None:
-        if value is None:
-            return None
-        return cls.validate_reported_at(value)
-
-    @model_validator(mode="after")
-    def validate_companion_event(self) -> HostedRuntimeObservedV2:
-        values = (
-            self.apply_receipt_id,
-            self.boot_nonce,
-            self.boot_session_id,
-            self.sequence,
-            self.event_id,
-            self.captured_at,
-        )
-        present = sum(value is not None for value in values)
-        if present not in {0, len(values)}:
-            raise ValueError("runtime observation companion fields must be present together")
-        if present == 0:
-            return self
-        if self.applied is None:
-            raise ValueError("companion runtime observations require applied identity")
-        if self.applied.generation < 1:
-            raise ValueError("companion runtime observation generation must be at least 1")
-        if self.reported_at != self.captured_at:
-            raise ValueError("reportedAt must equal capturedAt for companion observations")
-        if self.truncated:
-            raise ValueError("companion runtime observations cannot be truncated")
-        return self
-
-    @property
-    def is_companion_event(self) -> bool:
-        return self.event_id is not None
 
 
 HostedRuntimeObserved = HostedRuntimeObservedV2

--- a/backend/app/services/platform_workload_auth.py
+++ b/backend/app/services/platform_workload_auth.py
@@ -37,7 +37,8 @@ PLATFORM_WORKLOAD_SCOPES = (
     "platform:runtime-state:write",
     "platform:keys:mint",
     "platform:keys:revoke",
-    "platform:runtime-observations:read",
+    "platform:runtime-observations:consume",
+    "platform:runtime-environments:retire",
 )
 
 _PRIVATE_JWK_FIELDS = frozenset({"d", "p", "q", "dp", "dq", "qi", "oth", "k"})
@@ -682,7 +683,7 @@ def _credential_values(request: Request, name: str) -> list[str]:
     return request.headers.getlist(name)
 
 
-def require_platform_mutation_auth(required_scope: str):
+def _require_platform_auth(required_scope: str, *, allow_legacy_admin: bool):
     if required_scope not in PLATFORM_WORKLOAD_SCOPES:
         raise ValueError(f"unsupported platform workload scope: {required_scope}")
 
@@ -737,6 +738,11 @@ def require_platform_mutation_auth(required_scope: str):
                     status.HTTP_400_BAD_REQUEST,
                     "multiple credentials are not allowed",
                 )
+            if not allow_legacy_admin:
+                raise HTTPException(
+                    status.HTTP_401_UNAUTHORIZED,
+                    "platform workload credentials are required",
+                )
             if not settings.platform_legacy_admin_auth_enabled:
                 raise HTTPException(
                     status.HTTP_401_UNAUTHORIZED,
@@ -747,8 +753,25 @@ def require_platform_mutation_auth(required_scope: str):
             request.state.platform_mutation_auth = auth
             return auth
 
-        if settings.platform_legacy_admin_auth_enabled:
+        if allow_legacy_admin and settings.platform_legacy_admin_auth_enabled:
             await require_admin_api_key(x_admin_key=x_admin_key)
-        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "platform credentials are required")
+        detail = (
+            "platform credentials are required"
+            if allow_legacy_admin
+            else "platform workload credentials are required"
+        )
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail)
 
     return dependency
+
+
+def require_platform_mutation_auth(required_scope: str):
+    """Authenticate a workload token or the explicitly enabled legacy admin key."""
+
+    return _require_platform_auth(required_scope, allow_legacy_admin=True)
+
+
+def require_platform_workload_auth(required_scope: str):
+    """Authenticate only a scoped platform workload access token."""
+
+    return _require_platform_auth(required_scope, allow_legacy_admin=False)

--- a/backend/app/services/runtime_observation.py
+++ b/backend/app/services/runtime_observation.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from sqlalchemy import delete, func, select
+from sqlalchemy import select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -29,7 +29,8 @@ from app.models.runtime_observation import (
     V2RuntimeObservationInbox,
 )
 from app.models.session import AgentEnvironment
-from app.schemas.runtime_observed import HostedRuntimeObservedV2
+from app.schemas.runtime_observation import RuntimeObservationEventV2
+from app.services.audit import record_control_plane_audit
 
 _CURSOR_PREFIX = "clawdi-ro-v1"
 _MAX_SAFE_INTEGER = 9_007_199_254_740_991
@@ -54,6 +55,15 @@ class RuntimeObservationIngestResult:
     event_id: str
     stream_position: int
     duplicate: bool
+    outcome: str
+
+
+@dataclass(frozen=True)
+class RuntimeEnvironmentRetirementResult:
+    receipt: dict[str, Any]
+    transitioned: bool
+    final_stream_position: int
+    final_session_high_waters: dict[str, int]
 
 
 @dataclass(frozen=True)
@@ -260,7 +270,7 @@ async def require_active_runtime_environment_fence(
     return fence
 
 
-def _canonical_observation_payload(value: HostedRuntimeObservedV2) -> tuple[dict[str, Any], str]:
+def _canonical_observation_payload(value: RuntimeObservationEventV2) -> tuple[dict[str, Any], str]:
     payload = value.model_dump(mode="json", by_alias=True, exclude_unset=True)
     encoded = json.dumps(
         payload,
@@ -271,11 +281,7 @@ def _canonical_observation_payload(value: HostedRuntimeObservedV2) -> tuple[dict
     return payload, hashlib.sha256(encoded).hexdigest()
 
 
-def _companion_identity(value: HostedRuntimeObservedV2) -> RuntimeApplyIdentity:
-    if not value.is_companion_event or value.applied is None:
-        raise ValueError("strict companion runtime observation is required")
-    if value.apply_receipt_id is None or value.boot_nonce is None:
-        raise ValueError("strict companion apply identity is incomplete")
+def _companion_identity(value: RuntimeObservationEventV2) -> RuntimeApplyIdentity:
     return RuntimeApplyIdentity(
         generation=value.applied.generation,
         manifest_etag=value.applied.etag,
@@ -301,19 +307,12 @@ async def ingest_runtime_observation(
     *,
     environment_id: uuid.UUID,
     credential_deployment_id: str,
-    value: HostedRuntimeObservedV2,
+    value: RuntimeObservationEventV2,
     received_at: datetime | None = None,
 ) -> RuntimeObservationIngestResult:
     """Append and CAS-advance one strict-v2 event under the environment fence."""
 
     identity = _companion_identity(value)
-    if (
-        value.boot_session_id is None
-        or value.sequence is None
-        or value.event_id is None
-        or value.captured_at is None
-    ):
-        raise ValueError("strict companion event identity is incomplete")
     now = _utc(received_at or datetime.now(UTC))
     captured_at = _utc(value.captured_at)
     future_skew = timedelta(seconds=settings.runtime_observation_max_future_skew_seconds)
@@ -404,6 +403,7 @@ async def ingest_runtime_observation(
                 event_id=existing.event_id,
                 stream_position=existing.id,
                 duplicate=True,
+                outcome="duplicate_replay",
             )
         raise RuntimeObservationProtocolError(
             409,
@@ -436,6 +436,7 @@ async def ingest_runtime_observation(
         boot_session_id=value.boot_session_id,
         sequence=value.sequence,
         event_id=value.event_id,
+        reported_at=_utc(value.reported_at),
         captured_at=captured_at,
         received_at=now,
         freshness_deadline=freshness_deadline,
@@ -455,6 +456,7 @@ async def ingest_runtime_observation(
         return await duplicate_or_conflict()
     fence.stream_high_water = inbox.id
     if head is None:
+        outcome = "accepted_head_created"
         head = V2RuntimeObservationHead(
             environment_id=environment_id,
             deployment_id=fence.deployment_id,
@@ -477,6 +479,7 @@ async def ingest_runtime_observation(
     elif value.sequence > head.highest_sequence and (
         head.captured_at is None or captured_at >= _utc(head.captured_at)
     ):
+        outcome = "accepted_head_advanced"
         # Every unique correctly-bound event is immutable inbox evidence. Only
         # the compact head has a monotonic CAS rule; lower sequence or regressing
         # capture time remains historical and cannot replace the current head.
@@ -488,11 +491,16 @@ async def ingest_runtime_observation(
         head.captured_at = captured_at
         head.freshness_deadline = freshness_deadline
         head.health = value.status
+    elif value.sequence <= head.highest_sequence:
+        outcome = "accepted_non_advance_sequence"
+    else:
+        outcome = "accepted_non_advance_captured_at"
     await db.flush()
     return RuntimeObservationIngestResult(
         event_id=value.event_id,
         stream_position=inbox.id,
         duplicate=False,
+        outcome=outcome,
     )
 
 
@@ -529,7 +537,7 @@ async def retire_runtime_environment(
     retirement_id: str,
     owner_id: uuid.UUID | None = None,
     retired_at: datetime | None = None,
-) -> dict[str, Any]:
+) -> RuntimeEnvironmentRetirementResult:
     """Idempotently retire and tombstone an environment under the ingestion lock."""
 
     now = _utc(retired_at or datetime.now(UTC))
@@ -561,7 +569,12 @@ async def retire_runtime_environment(
         )
     if fence.state == RUNTIME_ENVIRONMENT_RETIRED:
         if fence.retirement_id == retirement_id and isinstance(fence.retirement_receipt, dict):
-            return fence.retirement_receipt
+            return RuntimeEnvironmentRetirementResult(
+                receipt=fence.retirement_receipt,
+                transitioned=False,
+                final_stream_position=fence.final_stream_position or 0,
+                final_session_high_waters=dict(fence.final_session_high_waters or {}),
+            )
         raise RuntimeObservationProtocolError(
             409,
             "runtime_environment_retirement_conflict",
@@ -591,13 +604,15 @@ async def retire_runtime_environment(
         stream_position=final_position,
     )
     receipt: dict[str, Any] = {
-        "retirementReceiptId": str(receipt_id),
+        "environmentReference": str(environment_id),
+        "expectedDeploymentBinding": expected_deployment_id,
         "retirementId": retirement_id,
-        "environmentId": str(environment_id),
-        "deploymentId": expected_deployment_id,
-        "retiredAt": now.isoformat(),
+        "retiredAt": now.isoformat().replace("+00:00", "Z"),
         "finalCursor": final_cursor,
-        "finalSessionHighWaterMarks": high_waters,
+        "finalSessionHighWaterMarks": [
+            {"bootSessionId": boot_session_id, "sequence": sequence}
+            for boot_session_id, sequence in high_waters.items()
+        ],
     }
     fence.state = RUNTIME_ENVIRONMENT_RETIRED
     fence.retirement_id = retirement_id
@@ -615,7 +630,12 @@ async def retire_runtime_environment(
         head.health = None
         head.tombstoned_at = now
     await db.flush()
-    return receipt
+    return RuntimeEnvironmentRetirementResult(
+        receipt=receipt,
+        transitioned=True,
+        final_stream_position=final_position,
+        final_session_high_waters=high_waters,
+    )
 
 
 def _cursor_expiry_metadata(
@@ -869,11 +889,20 @@ async def register_runtime_observation_consumer(
         # Retention has already removed history. Starting at zero would look
         # like a complete replay while silently skipping deleted evidence, so
         # a late stable consumer must persist and observe a reset barrier first.
-        raise await _initialize_expired_consumer(
-            db,
-            fence=fence,
-            consumer_id=consumer_id,
-        )
+        try:
+            raise await _initialize_expired_consumer(
+                db,
+                fence=fence,
+                consumer_id=consumer_id,
+            )
+        except _RuntimeObservationConsumerInitializationConflict:
+            raise await _load_concurrently_initialized_consumer_error(
+                db,
+                environment_id=environment_id,
+                owner_id=owner_id,
+                deployment_id=deployment_id,
+                consumer_id=consumer_id,
+            )
     epoch = uuid.uuid4()
     opaque = encode_runtime_observation_cursor(
         environment_id=environment_id,
@@ -1201,7 +1230,20 @@ async def acknowledge_runtime_observation_cursor(
         )
     ).scalar_one_or_none()
     if cursor is None:
-        raise _cursor_expired_error(None)
+        try:
+            raise await _initialize_expired_consumer(
+                db,
+                fence=fence,
+                consumer_id=consumer_id,
+            )
+        except _RuntimeObservationConsumerInitializationConflict:
+            raise await _load_concurrently_initialized_consumer_error(
+                db,
+                environment_id=environment_id,
+                owner_id=owner_id,
+                deployment_id=deployment_id,
+                consumer_id=consumer_id,
+            )
     try:
         decoded = _validate_cursor_for_consumer(
             opaque_cursor,
@@ -1325,7 +1367,7 @@ async def expire_runtime_observation_payloads(
     now: datetime | None = None,
     batch_size: int | None = None,
 ) -> int:
-    """Bounded retention cleanup that never silently deletes unacked history."""
+    """Compact a bounded, contiguous eligible prefix without deleting identity rows."""
 
     current = _utc(now or datetime.now(UTC))
     replay_cutoff = current - timedelta(days=settings.runtime_observation_replay_horizon_days)
@@ -1335,7 +1377,10 @@ async def expire_runtime_observation_payloads(
         (
             await db.execute(
                 select(V2RuntimeObservationInbox.environment_id)
-                .where(V2RuntimeObservationInbox.received_at < replay_cutoff)
+                .where(
+                    V2RuntimeObservationInbox.received_at < replay_cutoff,
+                    V2RuntimeObservationInbox.payload_purged_at.is_(None),
+                )
                 .distinct()
                 .order_by(V2RuntimeObservationInbox.environment_id)
                 .limit(limit)
@@ -1344,7 +1389,7 @@ async def expire_runtime_observation_payloads(
         .scalars()
         .all()
     )
-    deleted_count = 0
+    compacted_count = 0
     for environment_id in environment_ids:
         fence = (
             await db.execute(
@@ -1370,93 +1415,116 @@ async def expire_runtime_observation_payloads(
             .scalars()
             .all()
         )
-        if not consumers:
-            # No durable required-consumer acknowledgement means no safe purge.
-            continue
-        replay_position = int(
-            (
-                await db.scalar(
-                    select(func.coalesce(func.max(V2RuntimeObservationInbox.id), 0)).where(
-                        V2RuntimeObservationInbox.environment_id == environment_id,
-                        V2RuntimeObservationInbox.received_at < replay_cutoff,
-                    )
-                )
-            )
-            or 0
-        )
         safe_position = (
             min(
                 consumer.acked_stream_position
                 for consumer in consumers
                 if consumer.state == RUNTIME_OBSERVATION_CURSOR_ACTIVE
             )
-            if all(consumer.state == RUNTIME_OBSERVATION_CURSOR_ACTIVE for consumer in consumers)
+            if consumers
+            and all(consumer.state == RUNTIME_OBSERVATION_CURSOR_ACTIVE for consumer in consumers)
             else 0
         )
-        purge_through = min(replay_position, safe_position)
-        hard_position = int(
-            (
-                await db.scalar(
-                    select(func.coalesce(func.max(V2RuntimeObservationInbox.id), 0)).where(
-                        V2RuntimeObservationInbox.environment_id == environment_id,
-                        V2RuntimeObservationInbox.received_at < hard_cutoff,
-                    )
-                )
-            )
-            or 0
-        )
-        if hard_position > purge_through:
-            high_waters = await _load_session_high_waters(db, environment_id)
-            for consumer in consumers:
-                if consumer.acked_stream_position >= hard_position:
-                    continue
-                barrier_cursor = encode_runtime_observation_cursor(
-                    environment_id=environment_id,
-                    consumer_id=consumer.consumer_id,
-                    cursor_epoch=consumer.cursor_epoch,
-                    stream_position=hard_position,
-                )
-                consumer.state = RUNTIME_OBSERVATION_CURSOR_EXPIRED
-                consumer.expired_at = current
-                consumer.expiry_boundary_stream_position = hard_position
-                consumer.expiry_boundary_cursor = barrier_cursor
-                consumer.expiry_session_high_waters = high_waters
-                consumer.reset_barrier_at = current
-            purge_through = hard_position
-        if purge_through <= 0:
-            continue
-        ids = list(
+        candidates = list(
             (
                 await db.execute(
-                    select(V2RuntimeObservationInbox.id)
+                    select(V2RuntimeObservationInbox)
                     .where(
                         V2RuntimeObservationInbox.environment_id == environment_id,
-                        V2RuntimeObservationInbox.id <= purge_through,
+                        V2RuntimeObservationInbox.id > fence.replay_floor_stream_position,
+                        V2RuntimeObservationInbox.payload_purged_at.is_(None),
                     )
                     .order_by(V2RuntimeObservationInbox.id)
-                    .limit(limit - deleted_count)
+                    .limit(limit - compacted_count)
                 )
             )
             .scalars()
             .all()
         )
+        ids: list[int] = []
+        hard_cap_forced = False
+        for event in candidates:
+            hard_cap_eligible = _utc(event.received_at) < hard_cutoff
+            replay_eligible = (
+                bool(consumers)
+                and _utc(event.received_at) < replay_cutoff
+                and event.id <= safe_position
+            )
+            if not hard_cap_eligible and not replay_eligible:
+                break
+            ids.append(event.id)
+            hard_cap_forced = hard_cap_forced or (hard_cap_eligible and not replay_eligible)
         if not ids:
             continue
+        purge_through = ids[-1]
+        if hard_cap_forced:
+            high_waters = await _load_session_high_waters(db, environment_id)
+            for consumer in consumers:
+                if consumer.acked_stream_position >= purge_through:
+                    continue
+                previous_state = consumer.state
+                previous_boundary = consumer.expiry_boundary_stream_position
+                barrier_cursor = encode_runtime_observation_cursor(
+                    environment_id=environment_id,
+                    consumer_id=consumer.consumer_id,
+                    cursor_epoch=consumer.cursor_epoch,
+                    stream_position=purge_through,
+                )
+                consumer.state = RUNTIME_OBSERVATION_CURSOR_EXPIRED
+                consumer.expired_at = current
+                consumer.expiry_boundary_stream_position = purge_through
+                consumer.expiry_boundary_cursor = barrier_cursor
+                consumer.expiry_session_high_waters = high_waters
+                consumer.reset_barrier_at = current
+                record_control_plane_audit(
+                    db,
+                    actor_type="system",
+                    source="runtime_observation.retention",
+                    action="runtime_observation.cursor_expired",
+                    resource_type="runtime_observation_consumer",
+                    resource_id=str(environment_id),
+                    # The permanent resource_id/details survive deletion of the
+                    # legacy AgentEnvironment row; no optional parent FK is set.
+                    environment_id=None,
+                    details={
+                        "actor_service": "runtime_observation_retention",
+                        "environment_id": str(environment_id),
+                        "deployment_id": fence.deployment_id,
+                        "consumer_id": consumer.consumer_id,
+                        "reason": "hard_retention",
+                        "outcome": (
+                            "expired"
+                            if previous_state == RUNTIME_OBSERVATION_CURSOR_ACTIVE
+                            else "expiry_boundary_advanced"
+                        ),
+                        "previous_state": previous_state,
+                        "new_state": RUNTIME_OBSERVATION_CURSOR_EXPIRED,
+                        "previous_boundary_stream_position": previous_boundary,
+                        "boundary_stream_position": purge_through,
+                        "stream_high_water": fence.stream_high_water,
+                        "session_high_water_marks": high_waters,
+                    },
+                )
         result = await db.execute(
-            delete(V2RuntimeObservationInbox).where(V2RuntimeObservationInbox.id.in_(ids))
+            update(V2RuntimeObservationInbox)
+            .where(
+                V2RuntimeObservationInbox.id.in_(ids),
+                V2RuntimeObservationInbox.received_at < replay_cutoff,
+                V2RuntimeObservationInbox.payload_purged_at.is_(None),
+            )
+            .values(diagnostics={}, payload_purged_at=current)
         )
-        deleted = result.rowcount or 0
-        if deleted:
+        compacted = result.rowcount or 0
+        if compacted:
             floor_position = max(ids)
             if floor_position > fence.replay_floor_stream_position:
+                floor_session_high_waters = await _load_session_high_waters(db, environment_id)
                 fence.replay_floor_stream_position = floor_position
                 fence.replay_floor_advanced_at = current
-                fence.replay_floor_session_high_waters = await _load_session_high_waters(
-                    db, environment_id
-                )
-        deleted_count += deleted
-        if deleted_count >= limit:
+                fence.replay_floor_session_high_waters = floor_session_high_waters
+        compacted_count += compacted
+        if compacted_count >= limit:
             break
-        _ = fence  # The environment lock is intentionally held through deletion.
+        _ = fence  # The environment lock is intentionally held through compaction.
     await db.flush()
-    return deleted_count
+    return compacted_count

--- a/backend/app/services/runtime_observation_retention_worker.py
+++ b/backend/app/services/runtime_observation_retention_worker.py
@@ -24,9 +24,9 @@ class RuntimeObservationRetentionWorker:
 
     async def run_once(self) -> int:
         async with self._sessionmaker() as db:
-            deleted = await expire_runtime_observation_payloads(db)
+            compacted = await expire_runtime_observation_payloads(db)
             await db.commit()
-            return deleted
+            return compacted
 
     async def run_forever(self, stop: asyncio.Event | None = None) -> None:
         stop_event = stop or asyncio.Event()

--- a/backend/tests/fixtures/v1_runtime_observation_baseline.json
+++ b/backend/tests/fixtures/v1_runtime_observation_baseline.json
@@ -1,0 +1,52 @@
+{
+  "description": "Repository-owned pre-v2 byte baseline for the frozen v1 runtime observation surface.",
+  "files": {
+    "backend/app/routes/sessions.py": {
+      "symbols": {
+        "SyncHeartbeatRequest": "97884bde6519f318060fc3a225267c4d108f682eb48ad51600e573bf3c4ad42c",
+        "_as_utc": "5e660f3c4020cd2315665280e5ff0c34e9637baea63d51eaa07cf38f8e5a9e32",
+        "_bounded_runtime_observed": "5fee3f44c8fa11fc6e512f9268c8af86493a28e3f9f3860afb4b39e8219fd9ed",
+        "_clawdi_cli_version": "125be894dc6bfd71aa368b7d73915c2db1fb0c6bf9a81d0773231b98f7034c21",
+        "_enabled_runtime_names": "1d021fe0c53e177e5bab55cfcc8e7e1238a756485a19f55381703f4a26bd182b",
+        "_runtime_desired_provider_binding": "7858ddc84afc6ab443a6ffd1b813fa6f5ba32f95bdaa5fb963f9b20de3d07182",
+        "_runtime_observation_changed": "cbdc70aa77d22401b0fe2d5c993d877e1cf3473b4a70c7bd977bb49828e7d510",
+        "_runtime_observed_columns": "f15b64220432788b8db254339b336581bfe4d25d4da66f03b52a9d43c3775e9a",
+        "_runtime_observed_comparison_value": "7ef13736f4e82ddf8adc887746cae9ee18ce06ab9f7b67bc447cc92dd9817efa",
+        "_runtime_observed_desired": "df413587a7fc04f3c2c5a307cc214994af362605ed99080e50f44fa7c3718581",
+        "_runtime_observed_diagnostics": "16cad5f1a8f19aff55e7a189d6a27300c89ac2a2d4136829f29f1ac4d1ee5203",
+        "_runtime_observed_health": "ae05a09ea1093bddf0b12c8d16d19938f1b2bd9289335e010f297fb280ef54bc",
+        "_runtime_observed_provider_health": "09163dc80fb3ad1262888b26bb1112de122e88e0a30e21fc502679ffbee79660",
+        "_runtime_observed_provider_reasons": "3ec8cbf00837a6c33f7d2fe8bfe2415c0cba80faddf46b85f62e948d700b61ba",
+        "_runtime_observed_provider_status": "f83854879fa63585f1734b814f8e3230269f53d9fec69faf3c3036bc4fa97935",
+        "_runtime_observed_response": "8ef8aae004cb5bef49162dc40ffbf195d5bb9d621d963cdefbbf7441cd5bae27",
+        "_runtime_observed_summary": "a81dcb71c60b6c15e8ac850d1ed1cea0dac338923c01da1afa6616d049b9c68a",
+        "_validated_runtime_observed_diagnostics": "4e6bf338bbc8657b7a76e39abf4a32c63852069f966c2414a5c9f16d3231aa75",
+        "get_environment_runtime_observed": "8e5ce544ba94b70dc05fa1f6cae638b8b0cb851d62dbbf025e21aec94bafd010",
+        "list_environment_runtime_observed": "1c07db398c99892163b6c9415d9155378f7191c01a7920a0e2804b55f09027a4",
+        "sync_heartbeat": "52471a426362351eb96b5f5b213513336feaa878510f949f1ba396ac7e5fbaae"
+      }
+    },
+    "backend/app/routes/platform.py": {
+      "forbidden_route_fragments": [
+        "runtime-environment",
+        "runtime-observation"
+      ],
+      "symbols": {
+        "platform_mint_api_key": "20413a24e58c71d38bd4ce985e80fe10eff7c54c79e4b258ee87aba006db097b"
+      }
+    },
+    "backend/app/schemas/platform.py": {
+      "forbidden_symbol_prefixes": [
+        "PlatformRuntimeApplyIdentity",
+        "PlatformRuntimeEnvironmentRetire",
+        "PlatformRuntimeObservation"
+      ],
+      "symbols": {
+        "PlatformApiKeyCreate": "d71a8e1ade8b887083c466a8221d2c655aaecf0d17b9ef9a9cb27ba709ee5ae5"
+      }
+    },
+    "backend/app/schemas/runtime_observed.py": {
+      "whole_file_sha256": "7272efb1be898bf83d704a5bb8c40c65ce9fb61fb6bbfb1c1698a325a0e1c5d2"
+    }
+  }
+}

--- a/backend/tests/fixtures/v1_runtime_observation_baseline.json
+++ b/backend/tests/fixtures/v1_runtime_observation_baseline.json
@@ -1,5 +1,6 @@
 {
-  "description": "Repository-owned pre-v2 byte baseline for the frozen v1 runtime observation surface.",
+  "description": "Repository-owned pre-v2 byte baseline for the frozen v1 runtime observation surface. Hashes were captured from source commit 704f81b4af51012ee4ca5dbc6a7ceab7c073fe62; the test does not read git history.",
+  "source_commit": "704f81b4af51012ee4ca5dbc6a7ceab7c073fe62",
   "files": {
     "backend/app/routes/sessions.py": {
       "symbols": {

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -5,6 +5,7 @@ Auth via X-Admin-Key header (shared secret). Tests run against the
 we verify the gate as part of test surface, not bypass it.
 """
 
+import uuid
 from collections.abc import AsyncIterator
 
 import httpx
@@ -243,14 +244,13 @@ async def test_admin_mint_accepts_managed_flag(admin_client, db_session, seed_us
 
 
 @pytest.mark.asyncio
-async def test_admin_managed_environment_key_preserves_legacy_shape_and_v2_opt_in(
+async def test_admin_managed_environment_key_stays_legacy_and_rejects_v2_binding(
     admin_client,
     db_session,
     seed_user,
 ):
-    import uuid
 
-    from sqlalchemy import select
+    from sqlalchemy import func, select
 
     from app.models.api_key import ApiKey
     from app.models.runtime_observation import V2RuntimeEnvironmentFence
@@ -279,7 +279,7 @@ async def test_admin_managed_environment_key_preserves_legacy_shape_and_v2_opt_i
             "managed": True,
         },
     )
-    strict_v2 = await admin_client.post(
+    rejected_v2 = await admin_client.post(
         "/v1/admin/auth/keys",
         headers=_AUTH,
         json={
@@ -292,21 +292,20 @@ async def test_admin_managed_environment_key_preserves_legacy_shape_and_v2_opt_i
     )
 
     assert legacy.status_code == 200, legacy.text
-    assert strict_v2.status_code == 200, strict_v2.text
+    assert rejected_v2.status_code == 422, rejected_v2.text
+    assert any(error["loc"][-1] == "deployment_id" for error in rejected_v2.json()["detail"])
     assert await db_session.get(V2RuntimeEnvironmentFence, legacy_environment.id) is None
-    fence = await db_session.get(V2RuntimeEnvironmentFence, strict_v2_environment.id)
-    assert fence is not None
-    assert fence.deployment_id == "deployment-strict-v2"
+    assert await db_session.get(V2RuntimeEnvironmentFence, strict_v2_environment.id) is None
     legacy_key = (
         await db_session.execute(select(ApiKey).where(ApiKey.label == "legacy-managed-environment"))
     ).scalar_one()
-    strict_key = (
-        await db_session.execute(
-            select(ApiKey).where(ApiKey.label == "strict-v2-managed-environment")
-        )
-    ).scalar_one()
     assert legacy_key.runtime_deployment_id is None
-    assert strict_key.runtime_deployment_id == "deployment-strict-v2"
+    rejected_key_count = await db_session.scalar(
+        select(func.count())
+        .select_from(ApiKey)
+        .where(ApiKey.label == "strict-v2-managed-environment")
+    )
+    assert rejected_key_count == 0
 
 
 @pytest.mark.asyncio
@@ -438,7 +437,6 @@ async def test_admin_mint_lazy_creates_user(admin_client, db_session):
     """
     # Random per-run clerk_id — test DB is real Postgres and rows
     # persist across test runs; a hardcoded id would collide.
-    import uuid
 
     from sqlalchemy import select
 
@@ -523,7 +521,6 @@ async def test_admin_mint_lazy_create_handles_race(db_session):
     flush attempt and verifying the rollback+re-query path returns
     the row that the "winner" (separately seeded) wrote.
     """
-    import uuid
     from unittest.mock import AsyncMock
 
     from sqlalchemy.exc import IntegrityError
@@ -579,7 +576,6 @@ async def test_admin_mint_lazy_create_500s_when_winner_disappears(db_session):
     surface as 500 rather than 404 so the SaaS caller sees this is
     an operational anomaly, not a wrong-clerk_id payload.
     """
-    import uuid
     from unittest.mock import AsyncMock
 
     from fastapi import HTTPException
@@ -613,7 +609,6 @@ async def test_admin_lazy_create_creates_personal_project(db_session):
     alongside the User row. Downstream resolvers (sessions, skills,
     memories) all assume every user has one and 500 without it.
     JWT path enforces the same invariant; admin path must too."""
-    import uuid
 
     from sqlalchemy import select
 
@@ -748,7 +743,6 @@ async def test_admin_revoke_idempotent_on_already_revoked(admin_client, db_sessi
 @pytest.mark.asyncio
 async def test_admin_revoke_unknown_key(admin_client):
     """404 for a key id that doesn't exist."""
-    import uuid
 
     r = await admin_client.delete(
         f"/v1/admin/auth/keys/{uuid.uuid4()}",
@@ -990,7 +984,6 @@ async def test_admin_upsert_managed_ai_provider_rejects_invalid_base_url(admin_c
 
 @pytest.mark.asyncio
 async def test_admin_channel_lifecycle_manages_public_bot(admin_client, db_session, seed_user):
-    import uuid
 
     from sqlalchemy import select
 
@@ -1133,7 +1126,6 @@ async def test_admin_register_env_accepts_explicit_agent_id(
     admin_client, client, db_session, seed_user
 ):
     """Hosted registration owns the stable agent id. Machine fields are metadata."""
-    import uuid
 
     from sqlalchemy import select
 
@@ -1199,7 +1191,6 @@ async def test_admin_register_env_accepts_explicit_agent_id(
 async def test_admin_register_env_auto_assigns_explicit_default_names(
     admin_client, db_session, seed_user
 ):
-    import uuid
 
     from sqlalchemy import select
 
@@ -1276,7 +1267,6 @@ async def test_admin_register_env_auto_assigns_explicit_default_names(
 
 @pytest.mark.asyncio
 async def test_admin_register_env_rejects_default_name_request_field(admin_client, seed_user):
-    import uuid
 
     response = await admin_client.post(
         "/v1/admin/environments",
@@ -1298,7 +1288,6 @@ async def test_admin_register_env_rejects_default_name_request_field(admin_clien
 async def test_admin_agents_alias_registers_with_agent_id_and_runtime_state(
     admin_client, db_session, seed_user
 ):
-    import uuid
 
     from sqlalchemy import select
 
@@ -1403,7 +1392,6 @@ async def test_admin_register_env_explicit_agent_id_is_idempotent(
     admin_client, db_session, seed_user
 ):
     """Stable agent ids remain the identity while machine fields refresh."""
-    import uuid
 
     from sqlalchemy import select
 
@@ -1457,7 +1445,6 @@ async def test_admin_register_env_explicit_ids_allow_same_machine_metadata(
     admin_client, db_session, seed_user
 ):
     """Two hosted agents can share machine metadata without sharing identity."""
-    import uuid
 
     from sqlalchemy import select
 
@@ -1508,7 +1495,6 @@ async def test_admin_register_env_explicit_ids_allow_same_machine_metadata(
 async def test_admin_register_env_explicit_id_rejects_cross_tenant_id(
     admin_client, db_session, seed_user
 ):
-    import uuid
 
     from sqlalchemy import select
 
@@ -1731,7 +1717,6 @@ async def test_admin_register_env_lazy_creates_user(admin_client, db_session):
     SaaS calls admin_register_environment, gets 404, deploy
     proceeds without sync, and the user has no clue why their pod
     isn't showing up on cloud.clawdi.ai."""
-    import uuid
 
     from sqlalchemy import select
 

--- a/backend/tests/test_agent_v2_runtime_contract_migration.py
+++ b/backend/tests/test_agent_v2_runtime_contract_migration.py
@@ -14,7 +14,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 REVISION = "d8f2a1c4b6e9"
-HEAD_REVISION = "4c8f2a1d7e9b"
+HEAD_REVISION = "a6d2f4c8b1e7"
 RUNTIME_OBSERVATION_DOWN_REVISION = "c7e4a9b2d6f1"
 WORKLOAD_OAUTH_DOWN_REVISION = "f1a7c3d9e2b4"
 CONFIG_OBSERVATION_REVISION = "f3a1c7d9e2b4"
@@ -40,7 +40,8 @@ def test_agent_v2_runtime_contract_migration_precedes_config_observation_migrati
     scripts = ScriptDirectory.from_config(config)
 
     assert scripts.get_heads() == [HEAD_REVISION]
-    assert scripts.get_revision(HEAD_REVISION).down_revision == RUNTIME_OBSERVATION_DOWN_REVISION
+    assert scripts.get_revision(HEAD_REVISION).down_revision == "4c8f2a1d7e9b"
+    assert scripts.get_revision("4c8f2a1d7e9b").down_revision == RUNTIME_OBSERVATION_DOWN_REVISION
     assert (
         scripts.get_revision(RUNTIME_OBSERVATION_DOWN_REVISION).down_revision
         == WORKLOAD_OAUTH_DOWN_REVISION

--- a/backend/tests/test_api_version_alias.py
+++ b/backend/tests/test_api_version_alias.py
@@ -3,7 +3,8 @@
 Legacy routes are mounted canonically under /v1 and aliased under /api for
 clients built before the versioned-prefix migration. New contracts are
 canonical-only. The OpenAPI schema (which the web/CLI typed-client codegen
-consumes) must only advertise /v1.
+consumes) advertises legacy `/v1` plus the explicitly direct declarative-v2
+runtime companion; `/api` never aliases the v2 router.
 """
 
 import httpx
@@ -78,10 +79,18 @@ async def test_runtime_manifest_has_no_api_alias():
     assert response.status_code == 404
 
 
-def test_openapi_schema_only_advertises_v1():
+def test_openapi_schema_advertises_only_v1_and_direct_runtime_v2():
     spec = app.openapi()
-    non_v1 = [path for path in spec["paths"] if not path.startswith("/v1/")]
-    assert non_v1 == ["/health"], (
-        "the /api legacy alias (and anything else outside /v1) must stay out of "
-        f"the public OpenAPI schema, found: {non_v1}"
-    )
+    non_v1 = {path for path in spec["paths"] if not path.startswith("/v1/") and path != "/health"}
+    assert non_v1
+    assert all(path.startswith("/v2/runtime/") for path in non_v1)
+    assert all(not path.startswith("/api/") for path in spec["paths"])
+
+    routes = _routes_by_path()
+    for path in non_v1:
+        assert path not in {
+            f"/v1{path.removeprefix('/v2')}",
+            f"/api{path.removeprefix('/v2')}",
+        }
+        assert f"/v1{path.removeprefix('/v2')}" not in routes
+        assert f"/api{path.removeprefix('/v2')}" not in routes

--- a/backend/tests/test_hosted_runtime_config_observation_migration.py
+++ b/backend/tests/test_hosted_runtime_config_observation_migration.py
@@ -13,7 +13,8 @@ from sqlalchemy import create_engine, inspect
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 REVISION = "f1a7c3d9e2b4"
-HEAD_REVISION = "4c8f2a1d7e9b"
+HEAD_REVISION = "a6d2f4c8b1e7"
+RUNTIME_OBSERVATION_COMPANION_REVISION = "4c8f2a1d7e9b"
 RUNTIME_OBSERVATION_DOWN_REVISION = "c7e4a9b2d6f1"
 MIGRATION_FILENAME = f"{REVISION}_finalize_unlaunched_agent_v2_schema.py"
 
@@ -58,7 +59,13 @@ def test_agent_v2_final_schema_migration_is_single_head() -> None:
     scripts = ScriptDirectory.from_config(config)
 
     assert scripts.get_heads() == [HEAD_REVISION]
-    assert scripts.get_revision(HEAD_REVISION).down_revision == RUNTIME_OBSERVATION_DOWN_REVISION
+    assert (
+        scripts.get_revision(HEAD_REVISION).down_revision == RUNTIME_OBSERVATION_COMPANION_REVISION
+    )
+    assert (
+        scripts.get_revision(RUNTIME_OBSERVATION_COMPANION_REVISION).down_revision
+        == RUNTIME_OBSERVATION_DOWN_REVISION
+    )
     assert scripts.get_revision(RUNTIME_OBSERVATION_DOWN_REVISION).down_revision == REVISION
     assert scripts.get_revision(REVISION).down_revision == "f3a1c7d9e2b4"
 

--- a/backend/tests/test_platform_endpoints.py
+++ b/backend/tests/test_platform_endpoints.py
@@ -17,7 +17,6 @@ from app.models.api_key import ApiKey
 from app.models.audit import ControlPlaneAuditEvent
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.platform_idempotency import PlatformMutationIdempotency
-from app.models.runtime_observation import V2RuntimeEnvironmentFence
 from app.models.session import AgentEnvironment
 from app.models.user import PRINCIPAL_KIND_PARTNER_TENANT, User
 from app.schemas.platform import PLATFORM_RUNTIME_KEY_SCOPES
@@ -233,7 +232,6 @@ async def test_platform_mutations_require_idempotency_key(platform_client, seed_
             {
                 "label": "unknown-owner",
                 "environment_id": str(uuid.uuid4()),
-                "deployment_id": "unknown-owner-deployment",
                 "scopes": list(PLATFORM_RUNTIME_KEY_SCOPES),
             },
         ),
@@ -298,7 +296,6 @@ async def test_platform_clerk_owner_full_lifecycle_and_audit(
     runtime_state = await db_session.get(HostedRuntimeState, agent_id)
     assert runtime_state is not None
     assert runtime_state.tools == _TEST_TOOLS
-    assert await db_session.get(V2RuntimeEnvironmentFence, agent_id) is None
 
     minted = await platform_client.post(
         "/v1/platform/auth/keys",
@@ -307,7 +304,6 @@ async def test_platform_clerk_owner_full_lifecycle_and_audit(
             "owner": owner,
             "label": "platform-runtime",
             "environment_id": str(agent_id),
-            "deployment_id": "deployment-1",
         },
     )
     assert minted.status_code == 200, minted.text
@@ -316,13 +312,8 @@ async def test_platform_clerk_owner_full_lifecycle_and_audit(
     assert api_key is not None
     assert api_key.user_id == seed_user.id
     assert api_key.environment_id == agent_id
-    assert api_key.runtime_deployment_id == "deployment-1"
     assert api_key.scopes == list(PLATFORM_RUNTIME_KEY_SCOPES)
     assert api_key.managed is True
-    fence = await db_session.get(V2RuntimeEnvironmentFence, agent_id)
-    assert fence is not None
-    assert fence.deployment_id == "deployment-1"
-    assert fence.state == "active"
 
     revoked = await platform_client.request(
         "DELETE",
@@ -558,7 +549,6 @@ async def test_platform_partner_tenant_resolves_null_clerk_principal(
                 "owner": owner,
                 "label": "partner-runtime",
                 "environment_id": str(agent_id),
-                "deployment_id": "partner-deployment",
                 "scopes": ["sessions:write", "skills:read"],
             },
         )
@@ -640,7 +630,6 @@ async def test_platform_existing_resources_reject_owner_mismatch(
                     "owner": owner,
                     "label": "cross-owner",
                     "environment_id": str(other_agent.id),
-                    "deployment_id": "cross-owner-deployment",
                     "scopes": list(PLATFORM_RUNTIME_KEY_SCOPES),
                 },
             ),
@@ -756,7 +745,6 @@ async def test_platform_idempotency_replays_every_mutation_without_second_side_e
         "owner": owner,
         "label": "idempotent-key",
         "environment_id": str(agent_id),
-        "deployment_id": "deployment-1",
         "scopes": list(PLATFORM_RUNTIME_KEY_SCOPES),
     }
     mint_headers = _headers("idem-key-mint")
@@ -922,22 +910,12 @@ async def test_platform_routes_are_canonical_and_exposed_in_openapi(platform_cli
         "/v1/platform/agents",
         "/v1/platform/agents/{agent_id}",
         "/v1/platform/agents/{agent_id}/runtime-state",
-        "/v1/platform/agents/{agent_id}/runtime-environment/retire",
-        "/v1/platform/agents/{agent_id}/runtime-observation-consumers/register",
-        "/v1/platform/agents/{agent_id}/runtime-observation-consumers/ack",
-        "/v1/platform/agents/{agent_id}/runtime-observation-consumers/reset",
-        "/v1/platform/agents/{agent_id}/runtime-observations/read",
         "/v1/platform/auth/keys",
         "/v1/platform/auth/keys/{key_id}",
         "/v1/platform/oauth/token",
     }
     assert all(not path.startswith("/api/platform") for path in paths)
     assert set(paths["/v1/platform/agents/{agent_id}/runtime-state"]) == {"put", "delete"}
-    observation_description = paths["/v1/platform/agents/{agent_id}/runtime-observations/read"][
-        "post"
-    ]["description"]
-    assert "authenticated guest report" in observation_description
-    assert "not attestation-bound instance identity" in observation_description
 
     missing_alias = await platform_client.post(
         "/api/platform/agents",

--- a/backend/tests/test_platform_workload_oauth.py
+++ b/backend/tests/test_platform_workload_oauth.py
@@ -28,9 +28,9 @@ from app.models.platform_workload_auth import (
     PlatformWorkloadClient,
     PlatformWorkloadSigningKey,
 )
+from app.models.runtime_observation import V2RuntimeEnvironmentFence
 from app.models.session import AgentEnvironment
 from app.models.user import User
-from app.schemas.platform import PLATFORM_RUNTIME_KEY_SCOPES
 from app.services import platform_workload_auth
 from app.services.platform_workload_auth import (
     PLATFORM_WORKLOAD_ACCESS_TOKEN_AUDIENCE,
@@ -221,6 +221,39 @@ async def _access_token(harness: WorkloadHarness, scope: str) -> str:
     response = await _token_response(harness, scope=scope)
     assert response.status_code == 200, response.text
     return response.json()["access_token"]
+
+
+async def _add_workload_client(
+    harness: WorkloadHarness,
+    db_session,
+    *,
+    allowed_scopes: list[str],
+) -> WorkloadHarness:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    client_id = f"hosted-workload-{uuid.uuid4().hex}"
+    client_kid = f"client-{uuid.uuid4().hex}"
+    credential = PlatformWorkloadClient(
+        client_id=client_id,
+        assertion_kid=client_kid,
+        assertion_algorithm="RS256",
+        public_jwk=_public_jwk(private_key, kid=client_kid),
+        status=PLATFORM_WORKLOAD_CLIENT_ACTIVE,
+        allowed_scopes=allowed_scopes,
+        token_version=1,
+    )
+    db_session.add(credential)
+    await db_session.commit()
+    await db_session.refresh(credential)
+    return WorkloadHarness(
+        client=harness.client,
+        credential=credential,
+        client_id=client_id,
+        client_kid=client_kid,
+        client_private_key=private_key,
+        signing_private_key=harness.signing_private_key,
+        signing_key=harness.signing_key,
+        resolver=harness.resolver,
+    )
 
 
 def _workload_headers(token: str, idempotency_key: str) -> dict[str, str]:
@@ -553,188 +586,376 @@ async def test_oauth_storage_failures_are_503(
 
 
 @pytest.mark.asyncio
-async def test_workload_tokens_cover_platform_route_scope_mapping(
+@pytest.mark.parametrize("operation", ["provision", "retire", "register", "read", "ack", "reset"])
+async def test_companion_routes_reject_legacy_admin_fallback(
     workload_harness,
     seed_user,
     db_session,
+    operation,
 ):
-    owner = _owner(seed_user)
-    agent_id = uuid.uuid4()
+    from app.services.runtime_observation import provision_runtime_environment_fence
+    from tests.conftest import create_env_with_project
 
-    create_token = await _access_token(workload_harness, "platform:agents:create")
-    created = await workload_harness.client.post(
-        "/v1/platform/agents",
-        headers=_workload_headers(create_token, "workload-create"),
-        json=_agent_body(owner, agent_id),
+    environment = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"admin-fallback-{uuid.uuid4().hex}",
+        machine_name="admin-fallback",
     )
-    assert created.status_code == 200, created.text
+    deployment_id = f"deployment-admin-forbidden-{uuid.uuid4().hex}"
+    if operation != "provision":
+        await provision_runtime_environment_fence(
+            db_session,
+            environment_id=environment.id,
+            owner_id=seed_user.id,
+            deployment_id=deployment_id,
+        )
+        await db_session.commit()
 
-    runtime_token = await _access_token(workload_harness, "platform:runtime-state:write")
-    runtime = await workload_harness.client.put(
-        f"/v1/platform/agents/{agent_id}/runtime-state",
-        headers=_workload_headers(runtime_token, "workload-runtime-put"),
-        json=_runtime_body(owner, agent_id),
-    )
-    assert runtime.status_code == 200, runtime.text
-
-    mint_token = await _access_token(workload_harness, "platform:keys:mint")
-    minted = await workload_harness.client.post(
-        "/v1/platform/auth/keys",
-        headers=_workload_headers(mint_token, "workload-key-mint"),
-        json={
-            "owner": owner,
-            "label": "workload-managed",
-            "environment_id": str(agent_id),
-            "deployment_id": "deployment-workload",
-            "scopes": list(PLATFORM_RUNTIME_KEY_SCOPES),
-        },
-    )
-    assert minted.status_code == 200, minted.text
-    key_id = minted.json()["id"]
-
-    observation_token = await _access_token(
-        workload_harness,
-        "platform:runtime-observations:read",
-    )
-    wrong_scope = await workload_harness.client.post(
-        f"/v1/platform/agents/{agent_id}/runtime-observation-consumers/register",
-        headers=_workload_headers(runtime_token, "workload-observation-wrong-scope"),
-        json={
-            "owner": owner,
-            "deployment_id": "deployment-workload",
-            "consumer_id": "wrong-scope-consumer",
-        },
-    )
-    assert wrong_scope.status_code == 403, wrong_scope.text
-
-    registered = await workload_harness.client.post(
-        f"/v1/platform/agents/{agent_id}/runtime-observation-consumers/register",
-        headers=_workload_headers(observation_token, "workload-observation-register"),
-        json={
-            "owner": owner,
-            "deployment_id": "deployment-workload",
-            "consumer_id": "hosted-controller",
-        },
-    )
-    assert registered.status_code == 200, registered.text
-    initial_cursor = registered.json()["cursor"]
-    observations = await workload_harness.client.post(
-        f"/v1/platform/agents/{agent_id}/runtime-observations/read",
-        headers=_workload_headers(observation_token, "workload-observation-read"),
-        json={
-            "owner": owner,
-            "deployment_id": "deployment-workload",
-            "consumer_id": "hosted-controller",
+    path = "/v2/runtime/auth/keys"
+    payload: dict[str, Any] = {
+        "label": "forbidden-admin-runtime",
+        "environmentId": str(environment.id),
+        "deploymentId": deployment_id,
+    }
+    if operation == "retire":
+        path = f"/v2/runtime/environments/{environment.id}/retire"
+        payload = {
+            "expectedDeploymentBinding": deployment_id,
+            "retirementId": "retirement-admin-forbidden",
+        }
+    elif operation == "register":
+        path = f"/v2/runtime/environments/{environment.id}/observation-consumers/register"
+        payload = {}
+    elif operation == "read":
+        path = f"/v2/runtime/environments/{environment.id}/observations/read"
+        payload = {
             "expectedApplyIdentity": {
                 "generation": 1,
                 "manifestETag": '"manifest-etag-0001"',
                 "applyReceiptId": "apply-receipt-00000001",
                 "bootNonce": "boot-nonce-0000000001",
             },
-            "afterCursor": initial_cursor,
-            "limit": 100,
-        },
-    )
-    assert observations.status_code == 200, observations.text
-    observation_body = observations.json()
-    assert observation_body["events"] == []
-    assert observation_body["heads"] == []
-    assert observation_body["streamHighWaterCursor"].startswith("clawdi-ro-v1.")
+            "afterCursor": "clawdi-ro-v1.invalid",
+        }
+    elif operation == "ack":
+        path = f"/v2/runtime/environments/{environment.id}/observation-consumers/ack"
+        payload = {"cursor": "clawdi-ro-v1.invalid"}
+    elif operation == "reset":
+        path = f"/v2/runtime/environments/{environment.id}/observation-consumers/reset"
+        payload = {}
 
-    acknowledged = await workload_harness.client.post(
-        f"/v1/platform/agents/{agent_id}/runtime-observation-consumers/ack",
-        headers=_workload_headers(observation_token, "workload-observation-ack"),
+    response = await workload_harness.client.post(
+        path,
+        headers={"X-Admin-Key": _ADMIN_KEY, "Idempotency-Key": f"admin-{uuid.uuid4()}"},
+        json={"owner": _owner(seed_user), **payload} if operation == "provision" else payload,
+    )
+
+    assert response.status_code == 401, response.text
+    assert response.json() == {"detail": "platform workload credentials are required"}
+
+
+@pytest.mark.asyncio
+async def test_v2_provision_precedes_narrow_key_and_retirement_replays_exact_receipt(
+    workload_harness,
+    seed_user,
+    db_session,
+    monkeypatch,
+):
+    from app.models.api_key import RUNTIME_DEPLOYMENT_KEY_SCOPES
+    from app.routes import runtime_observation_v2 as v2_routes
+    from tests.conftest import create_env_with_project
+
+    environment = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"v2-provision-{uuid.uuid4().hex}",
+        machine_name="v2-provision",
+    )
+    environment_id = environment.id
+    owner_id = seed_user.id
+    deployment_id = f"deployment-{uuid.uuid4().hex}"
+    original_mint = v2_routes.mint_api_key
+
+    async def assert_fence_precedes_key(db, **kwargs):
+        fence = await db.get(V2RuntimeEnvironmentFence, environment_id)
+        assert fence is not None
+        assert fence.owner_id == owner_id
+        assert fence.deployment_id == deployment_id
+        assert fence.state == "active"
+        return await original_mint(db, **kwargs)
+
+    monkeypatch.setattr(v2_routes, "mint_api_key", assert_fence_precedes_key)
+    mint_token = await _access_token(workload_harness, "platform:keys:mint")
+    minted = await workload_harness.client.post(
+        "/v2/runtime/auth/keys",
+        headers=_workload_headers(mint_token, f"mint-{environment_id}"),
         json={
-            "owner": owner,
-            "deployment_id": "deployment-workload",
-            "consumer_id": "hosted-controller",
-            "cursor": observation_body["streamHighWaterCursor"],
+            "owner": _owner(seed_user),
+            "label": "strict-v2-runtime",
+            "environmentId": str(environment_id),
+            "deploymentId": deployment_id,
         },
     )
-    assert acknowledged.status_code == 200, acknowledged.text
+    assert minted.status_code == 200, minted.text
+    key = await db_session.get(ApiKey, uuid.UUID(minted.json()["id"]))
+    assert key is not None
+    assert key.runtime_deployment_id == deployment_id
+    assert key.scopes == list(RUNTIME_DEPLOYMENT_KEY_SCOPES)
+    assert "runtime-observations:write" in key.scopes
 
-    invalid_cursor_body = {
-        "owner": owner,
-        "deployment_id": "deployment-workload",
-        "consumer_id": "hosted-controller",
-        "expectedApplyIdentity": {
-            "generation": 1,
-            "manifestETag": '"manifest-etag-0001"',
-            "applyReceiptId": "apply-receipt-00000001",
-            "bootNonce": "boot-nonce-0000000001",
-        },
-        "afterCursor": "clawdi-ro-v1.invalid",
-        "limit": 100,
+    retire_token = await _access_token(
+        workload_harness,
+        "platform:runtime-environments:retire",
+    )
+    path = f"/v2/runtime/environments/{environment_id}/retire"
+    body = {
+        "expectedDeploymentBinding": deployment_id,
+        "retirementId": f"retirement-{environment_id}",
     }
-    expired = await workload_harness.client.post(
-        f"/v1/platform/agents/{agent_id}/runtime-observations/read",
-        headers=_workload_headers(observation_token, "workload-observation-expired"),
-        json=invalid_cursor_body,
-    )
-    assert expired.status_code == 410, expired.text
-    assert expired.json()["detail"]["code"] == "observation_cursor_expired"
-    assert expired.json()["detail"]["resetBoundary"] is not None
+    first_headers = _workload_headers(retire_token, f"retire-first-{environment_id}")
+    original_record_audit = v2_routes.record_control_plane_audit
 
-    reset = await workload_harness.client.post(
-        f"/v1/platform/agents/{agent_id}/runtime-observation-consumers/reset",
-        headers=_workload_headers(observation_token, "workload-observation-reset"),
+    def fail_transition_audit(db, **kwargs):
+        if kwargs.get("action") == "runtime_environment.retire":
+            raise RuntimeError("injected transition audit failure")
+        return original_record_audit(db, **kwargs)
+
+    monkeypatch.setattr(v2_routes, "record_control_plane_audit", fail_transition_audit)
+    with pytest.raises(RuntimeError, match="injected transition audit failure"):
+        await workload_harness.client.post(path, headers=first_headers, json=body)
+    await db_session.rollback()
+    fence_after_rollback = await db_session.get(V2RuntimeEnvironmentFence, environment_id)
+    assert fence_after_rollback is not None
+    assert fence_after_rollback.state == "active"
+    assert fence_after_rollback.retirement_receipt is None
+    assert fence_after_rollback.retirement_receipt_id is None
+
+    monkeypatch.setattr(v2_routes, "record_control_plane_audit", original_record_audit)
+    first = await workload_harness.client.post(path, headers=first_headers, json=body)
+    same_http_replay = await workload_harness.client.post(
+        path,
+        headers=first_headers,
+        json=body,
+    )
+    domain_replay = await workload_harness.client.post(
+        path,
+        headers=_workload_headers(retire_token, f"retire-domain-replay-{environment_id}"),
+        json=body,
+    )
+
+    assert first.status_code == same_http_replay.status_code == domain_replay.status_code == 200
+    assert first.content == same_http_replay.content == domain_replay.content
+    assert set(first.json()) == {
+        "environmentReference",
+        "expectedDeploymentBinding",
+        "retirementId",
+        "retiredAt",
+        "finalCursor",
+        "finalSessionHighWaterMarks",
+    }
+    assert first.json()["environmentReference"] == str(environment_id)
+    assert first.json()["expectedDeploymentBinding"] == deployment_id
+    assert first.json()["finalSessionHighWaterMarks"] == []
+
+    fence = await db_session.get(V2RuntimeEnvironmentFence, environment_id)
+    assert fence is not None
+    await db_session.refresh(fence)
+    assert fence.state == "retired"
+    assert fence.retirement_receipt == first.json()
+    assert fence.retirement_receipt_id is not None
+    transition_audits = list(
+        (
+            await db_session.execute(
+                select(ControlPlaneAuditEvent).where(
+                    ControlPlaneAuditEvent.source == "api.v2.runtime",
+                    ControlPlaneAuditEvent.action == "runtime_environment.retire",
+                    ControlPlaneAuditEvent.resource_id == str(environment_id),
+                    ControlPlaneAuditEvent.details["outcome"].astext == "transitioned",
+                )
+            )
+        ).scalars()
+    )
+    replay_audits = list(
+        (
+            await db_session.execute(
+                select(ControlPlaneAuditEvent).where(
+                    ControlPlaneAuditEvent.source == "api.v2.runtime",
+                    ControlPlaneAuditEvent.action == "runtime_environment.retire_replay",
+                    ControlPlaneAuditEvent.resource_id == str(environment_id),
+                )
+            )
+        ).scalars()
+    )
+    assert len(transition_audits) == 1
+    assert len(replay_audits) == 1
+    transition = transition_audits[0]
+    assert transition.actor_type == "platform_workload"
+    assert transition.details["workload_client_id"] == workload_harness.client_id
+    assert transition.details["retirement_receipt_id"] == str(fence.retirement_receipt_id)
+    assert transition.details["previous_state"] == "active"
+    assert transition.details["new_state"] == "retired"
+
+    conflicting = await workload_harness.client.post(
+        path,
+        headers=_workload_headers(retire_token, f"retire-conflict-{environment_id}"),
+        json={**body, "retirementId": f"other-{environment_id}"},
+    )
+    assert conflicting.status_code == 409, conflicting.text
+    assert conflicting.json()["detail"]["code"] == "runtime_environment_retirement_conflict"
+
+
+@pytest.mark.asyncio
+async def test_observation_consumer_identity_is_bound_to_workload_principal(
+    workload_harness,
+    seed_user,
+    db_session,
+):
+    from app.models.runtime_observation import V2RuntimeObservationConsumerCursor
+    from app.services.runtime_observation import provision_runtime_environment_fence
+    from tests.conftest import create_env_with_project
+
+    environment = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"consumer-scope-{uuid.uuid4().hex}",
+        machine_name="consumer-scope",
+    )
+    deployment_id = f"deployment-{uuid.uuid4().hex}"
+    await provision_runtime_environment_fence(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=deployment_id,
+    )
+    await db_session.commit()
+
+    scope = "platform:runtime-observations:consume"
+    consumer_b = await _add_workload_client(
+        workload_harness,
+        db_session,
+        allowed_scopes=[scope],
+    )
+    token_a = await _access_token(workload_harness, scope)
+    token_b = await _access_token(consumer_b, scope)
+    path = f"/v2/runtime/environments/{environment.id}"
+    common: dict[str, str] = {}
+
+    caller_supplied_binding = await workload_harness.client.post(
+        f"{path}/observation-consumers/register",
+        headers=_workload_headers(token_a, "caller-binding-forbidden"),
+        json={"owner": _owner(seed_user), "deploymentId": deployment_id},
+    )
+    assert caller_supplied_binding.status_code == 422, caller_supplied_binding.text
+    assert {error["loc"][-1] for error in caller_supplied_binding.json()["detail"]} == {
+        "owner",
+        "deploymentId",
+    }
+
+    registered_a = await workload_harness.client.post(
+        f"{path}/observation-consumers/register",
+        headers=_workload_headers(token_a, "register-a"),
+        json=common,
+    )
+    registered_b = await workload_harness.client.post(
+        f"{path}/observation-consumers/register",
+        headers=_workload_headers(token_b, "register-b"),
+        json=common,
+    )
+    assert registered_a.status_code == registered_b.status_code == 200
+    assert registered_a.json()["consumerId"] == workload_harness.client_id
+    assert registered_b.json()["consumerId"] == consumer_b.client_id
+
+    apply_identity = {
+        "generation": 1,
+        "manifestETag": '"manifest-etag-0001"',
+        "applyReceiptId": "apply-receipt-00000001",
+        "bootNonce": "boot-nonce-0000000001",
+    }
+    cross_read = await workload_harness.client.post(
+        f"{path}/observations/read",
+        headers=_workload_headers(token_a, "cross-read"),
         json={
-            "owner": owner,
-            "deployment_id": "deployment-workload",
-            "consumer_id": "hosted-controller",
+            **common,
+            "expectedApplyIdentity": apply_identity,
+            "afterCursor": registered_b.json()["cursor"],
         },
     )
-    assert reset.status_code == 200, reset.text
-    assert (
-        reset.json()["resetBoundary"]["cursor"]
-        == (expired.json()["detail"]["resetBoundary"]["cursor"])
-    )
+    assert cross_read.status_code == 410, cross_read.text
+    assert cross_read.json()["detail"]["code"] == "observation_cursor_expired"
 
-    revoke_token = await _access_token(workload_harness, "platform:keys:revoke")
-    revoked = await workload_harness.client.request(
-        "DELETE",
-        f"/v1/platform/auth/keys/{key_id}",
-        headers=_workload_headers(revoke_token, "workload-key-revoke"),
-        json={"owner": owner},
+    cross_ack = await workload_harness.client.post(
+        f"{path}/observation-consumers/ack",
+        headers=_workload_headers(token_a, "cross-ack"),
+        json={**common, "cursor": registered_b.json()["cursor"]},
     )
-    assert revoked.status_code == 200, revoked.text
-    revoked_key = await db_session.get(ApiKey, uuid.UUID(key_id))
-    assert revoked_key is not None and revoked_key.revoked_at is not None
-
-    deleted_runtime = await workload_harness.client.request(
-        "DELETE",
-        f"/v1/platform/agents/{agent_id}/runtime-state",
-        headers=_workload_headers(runtime_token, "workload-runtime-delete"),
-        json={"owner": owner},
+    assert cross_ack.status_code == 410, cross_ack.text
+    assert cross_ack.json()["detail"]["code"] == "observation_cursor_expired"
+    expired_a = await db_session.get(
+        V2RuntimeObservationConsumerCursor,
+        {"environment_id": environment.id, "consumer_id": workload_harness.client_id},
     )
-    assert deleted_runtime.status_code == 204, deleted_runtime.text
-
-    delete_token = await _access_token(workload_harness, "platform:agents:delete")
-    deleted_agent = await workload_harness.client.request(
-        "DELETE",
-        f"/v1/platform/agents/{agent_id}",
-        headers=_workload_headers(delete_token, "workload-agent-delete"),
-        json={"owner": owner},
-    )
-    assert deleted_agent.status_code == 204, deleted_agent.text
-
-    events = (
-        await db_session.execute(
-            select(ControlPlaneAuditEvent).where(
-                ControlPlaneAuditEvent.source == "api.platform",
-                ControlPlaneAuditEvent.details["workload_sub"].astext
-                == workload_harness.credential.client_id,
+    assert expired_a is not None
+    await db_session.refresh(expired_a)
+    assert expired_a.state == "expired"
+    expiry_audits = list(
+        (
+            await db_session.execute(
+                select(ControlPlaneAuditEvent)
+                .where(
+                    ControlPlaneAuditEvent.source == "api.v2.runtime",
+                    ControlPlaneAuditEvent.action == "runtime_observation.cursor_expired",
+                    ControlPlaneAuditEvent.resource_id == str(environment.id),
+                )
+                .order_by(ControlPlaneAuditEvent.created_at)
             )
-        )
-    ).scalars()
-    event_list = list(events)
-    assert len(event_list) == 6
-    assert all(
-        event.details["credential_id"] == "[REDACTED]"
-        and event.details["token_jti"] == "[REDACTED]"
-        for event in event_list
+        ).scalars()
     )
-    assert await db_session.get(AgentEnvironment, agent_id) is None
+    assert [event.details["operation"] for event in expiry_audits] == ["read", "ack"]
+    assert all(
+        event.details["consumer_id"] == workload_harness.client_id for event in expiry_audits
+    )
+    assert registered_b.json()["cursor"] not in json.dumps(
+        [event.details for event in expiry_audits],
+        sort_keys=True,
+    )
+
+    caller_controlled_reset = await workload_harness.client.post(
+        f"{path}/observation-consumers/reset",
+        headers=_workload_headers(token_a, "cross-reset-forbidden"),
+        json={**common, "consumer_id": consumer_b.client_id},
+    )
+    assert caller_controlled_reset.status_code == 422, caller_controlled_reset.text
+    assert any(
+        error["loc"][-1] == "consumer_id" for error in caller_controlled_reset.json()["detail"]
+    )
+
+    reset_a = await workload_harness.client.post(
+        f"{path}/observation-consumers/reset",
+        headers=_workload_headers(token_a, "reset-a"),
+        json=common,
+    )
+    assert reset_a.status_code == 200, reset_a.text
+    assert reset_a.json()["consumerId"] == workload_harness.client_id
+
+    own_read_b = await workload_harness.client.post(
+        f"{path}/observations/read",
+        headers=_workload_headers(token_b, "read-b"),
+        json={
+            **common,
+            "expectedApplyIdentity": apply_identity,
+            "afterCursor": registered_b.json()["cursor"],
+        },
+    )
+    assert own_read_b.status_code == 200, own_read_b.text
+    cursor_b = await db_session.get(
+        V2RuntimeObservationConsumerCursor,
+        {"environment_id": environment.id, "consumer_id": consumer_b.client_id},
+    )
+    assert cursor_b is not None
+    assert cursor_b.state == "active"
+    assert cursor_b.acked_stream_position == 0
+    assert cursor_b.reset_at is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -2270,6 +2270,13 @@ async def test_v2_ingestion_route_auth_rejections_are_durably_audited(
     private_diagnostic = "private-internal-error-and-opaque-cursor-must-not-enter-audit"
     cases = (
         (
+            "runtime_credential_required",
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
             "managed_credential_required",
             False,
             environment_id,
@@ -2309,16 +2316,18 @@ async def test_v2_ingestion_route_auth_rejections_are_durably_audited(
                 cases,
                 start=1,
             ):
-                runtime_key = ApiKey(
-                    id=uuid.uuid4(),
-                    user_id=seed_user.id,
-                    managed=managed,
-                    environment_id=bound_environment,
-                    runtime_deployment_id=deployment_id,
-                    scopes=scopes,
-                    key_hash=raw_credential,
-                    key_prefix="raw-route-prefix",
-                )
+                runtime_key = None
+                if managed is not None:
+                    runtime_key = ApiKey(
+                        id=uuid.uuid4(),
+                        user_id=seed_user.id,
+                        managed=managed,
+                        environment_id=bound_environment,
+                        runtime_deployment_id=deployment_id,
+                        scopes=scopes,
+                        key_hash=raw_credential,
+                        key_prefix="raw-route-prefix",
+                    )
                 auth_context = AuthContext(user=seed_user, api_key=runtime_key)
                 event_id = f"{event_prefix}-{reason}"
                 payload = _payload(
@@ -2335,9 +2344,14 @@ async def test_v2_ingestion_route_auth_rejections_are_durably_audited(
                 assert (
                     response.json()["detail"]["code"] == "runtime_observation_credential_mismatch"
                 )
+                principal_id = runtime_key.id if runtime_key is not None else seed_user.id
                 expected[event_id] = {
                     "reason": reason,
-                    "principal_id": str(runtime_key.id),
+                    "actor_type": ("runtime_deployment" if runtime_key is not None else "user"),
+                    "principal_id": str(principal_id),
+                    "runtime_principal_id": (
+                        str(runtime_key.id) if runtime_key is not None else None
+                    ),
                     "deployment_id": deployment_id,
                     "boot_session_id": payload.boot_session_id,
                     "sequence": payload.sequence,
@@ -2363,12 +2377,13 @@ async def test_v2_ingestion_route_auth_rejections_are_durably_audited(
     for event in audits:
         details = event.details
         expected_details = expected[details["event_id"]]
-        assert event.actor_type == "runtime_deployment"
+        assert event.actor_type == expected_details["actor_type"]
         assert event.actor_user_id == seed_user.id
         assert event.target_user_id == seed_user.id
+        assert details["principal_id"] is not None
         assert details == {
             "principal_id": expected_details["principal_id"],
-            "runtime_principal_id": expected_details["principal_id"],
+            "runtime_principal_id": expected_details["runtime_principal_id"],
             "environment_id": str(environment_id),
             "deployment_id": expected_details["deployment_id"],
             "boot_session_id": expected_details["boot_session_id"],

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
@@ -9,7 +10,8 @@ from datetime import UTC, datetime, timedelta
 import httpx
 import pytest
 from httpx import ASGITransport
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.exc import DBAPIError, IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 import app.services.runtime_observation as runtime_observation_service
@@ -17,14 +19,16 @@ from app.core.auth import AuthContext, get_auth
 from app.core.database import get_session
 from app.main import app
 from app.models.api_key import ApiKey
-from app.models.hosted_runtime import HostedRuntimeConfigObservation
+from app.models.audit import ControlPlaneAuditEvent
+from app.models.hosted_runtime import HostedRuntimeConfigObservation, HostedRuntimeState
 from app.models.runtime_observation import (
     V2RuntimeEnvironmentFence,
     V2RuntimeObservationConsumerCursor,
     V2RuntimeObservationHead,
     V2RuntimeObservationInbox,
 )
-from app.schemas.runtime_observed import HostedRuntimeObservedV2
+from app.models.session import AgentEnvironment
+from app.schemas.runtime_observation import RuntimeObservationEventV2
 from app.services.api_key import mint_api_key
 from app.services.runtime_observation import (
     RuntimeApplyIdentity,
@@ -35,14 +39,14 @@ from app.services.runtime_observation import (
     read_runtime_observations,
     register_runtime_observation_consumer,
     reset_runtime_observation_consumer,
-    retire_runtime_environment,
 )
 from app.services.runtime_observation import (
     ingest_runtime_observation as _ingest_runtime_observation,
 )
+from app.services.runtime_observation import (
+    retire_runtime_environment as _retire_runtime_environment,
+)
 from tests.conftest import create_env_with_project
-
-pytestmark = pytest.mark.committed_db
 
 _DEPLOYMENT_ID = "deployment-observation-companion"
 _APPLY_RECEIPT_ID = "apply-receipt-00000001"
@@ -54,7 +58,7 @@ async def ingest_runtime_observation(
     db: AsyncSession,
     *,
     environment_id: uuid.UUID,
-    value: HostedRuntimeObservedV2,
+    value: RuntimeObservationEventV2,
     received_at: datetime | None = None,
     credential_deployment_id: str = _DEPLOYMENT_ID,
 ):
@@ -83,9 +87,10 @@ def _payload(
     apply_receipt_id: str = _APPLY_RECEIPT_ID,
     boot_nonce: str = _BOOT_NONCE,
     status: str = "ok",
-) -> HostedRuntimeObservedV2:
+    error: str | None = None,
+) -> RuntimeObservationEventV2:
     captured = captured_at or datetime.now(UTC)
-    return HostedRuntimeObservedV2.model_validate(
+    return RuntimeObservationEventV2.model_validate(
         {
             "schemaVersion": "clawdi.hostedRuntimeObserved.v2",
             "reportedAt": captured.isoformat(),
@@ -101,6 +106,7 @@ def _payload(
             },
             "boot": None,
             "cli": None,
+            "error": error,
             "applyReceiptId": apply_receipt_id,
             "bootNonce": boot_nonce,
             "bootSessionId": boot_session_id,
@@ -118,6 +124,10 @@ def _expected_identity() -> RuntimeApplyIdentity:
         apply_receipt_id=_APPLY_RECEIPT_ID,
         boot_nonce=_BOOT_NONCE,
     )
+
+
+async def retire_runtime_environment(*args, **kwargs):
+    return (await _retire_runtime_environment(*args, **kwargs)).receipt
 
 
 async def _provision_environment(
@@ -164,7 +174,10 @@ async def test_unique_regressions_enter_inbox_without_regressing_head(
         value=first_payload,
         received_at=base + timedelta(seconds=1),
     )
-    assert duplicate == type(first)(first.event_id, first.stream_position, True)
+    assert duplicate.event_id == first.event_id
+    assert duplicate.stream_position == first.stream_position
+    assert duplicate.duplicate is True
+    assert duplicate.outcome == "duplicate_replay"
     await ingest_runtime_observation(
         db_session,
         environment_id=environment.id,
@@ -236,6 +249,7 @@ async def test_unique_regressions_enter_inbox_without_regressing_head(
     assert head.captured_at == base + timedelta(seconds=3)
 
 
+@pytest.mark.committed_db
 @pytest.mark.asyncio
 async def test_ingestion_and_retirement_serialize_on_the_environment_fence(
     engine,
@@ -272,7 +286,9 @@ async def test_ingestion_and_retirement_serialize_on_the_environment_fence(
         await ingest_session.commit()
         receipt = await asyncio.wait_for(retirement, timeout=5)
 
-    assert receipt["finalSessionHighWaterMarks"] == {"boot-session-0001": 1}
+    assert receipt["finalSessionHighWaterMarks"] == [
+        {"bootSessionId": "boot-session-0001", "sequence": 1}
+    ]
     head = await db_session.get(
         V2RuntimeObservationHead,
         {"environment_id": environment.id, "boot_session_id": "boot-session-0001"},
@@ -306,6 +322,7 @@ async def test_ingestion_and_retirement_serialize_on_the_environment_fence(
     await db_session.rollback()
 
 
+@pytest.mark.committed_db
 @pytest.mark.asyncio
 async def test_retirement_first_rejects_delayed_new_session(
     engine,
@@ -342,7 +359,7 @@ async def test_retirement_first_rejects_delayed_new_session(
         await retirement_session.commit()
         assert await asyncio.wait_for(ingestion, timeout=5) == "runtime_environment_retired"
 
-    assert receipt["finalSessionHighWaterMarks"] == {}
+    assert receipt["finalSessionHighWaterMarks"] == []
     head_count = await db_session.scalar(
         select(func.count())
         .select_from(V2RuntimeObservationHead)
@@ -351,6 +368,194 @@ async def test_retirement_first_rejects_delayed_new_session(
     assert head_count == 0
 
 
+@pytest.mark.asyncio
+async def test_database_guards_reject_runtime_rebinding_regression_and_tombstone_mutation(
+    db_session: AsyncSession,
+    seed_user,
+):
+    environment, _ = await _provision_environment(db_session, seed_user)
+    registration = await register_runtime_observation_consumer(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="database-guard-controller",
+    )
+    event = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(),
+    )
+    page = await read_runtime_observations(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="database-guard-controller",
+        expected_apply_identity=_expected_identity(),
+        after_cursor=registration["cursor"],
+        limit=100,
+    )
+    await acknowledge_runtime_observation_cursor(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="database-guard-controller",
+        opaque_cursor=page["streamHighWaterCursor"],
+    )
+    await db_session.commit()
+
+    with pytest.raises(IntegrityError):
+        async with db_session.begin_nested():
+            await mint_api_key(
+                db_session,
+                user_id=seed_user.id,
+                label="invalid-full-access-runtime",
+                scopes=None,
+                environment_id=environment.id,
+                runtime_deployment_id=_DEPLOYMENT_ID,
+                managed=True,
+                commit=False,
+            )
+
+    legacy_key = await mint_api_key(
+        db_session,
+        user_id=seed_user.id,
+        label="legacy-null-runtime-binding",
+        scopes=None,
+        environment_id=environment.id,
+        runtime_deployment_id=None,
+        managed=True,
+        commit=False,
+    )
+    await db_session.commit()
+    assert legacy_key.api_key.runtime_deployment_id is None
+    assert legacy_key.api_key.scopes is None
+    strict_key = await mint_api_key(
+        db_session,
+        user_id=seed_user.id,
+        label="strict-runtime-key",
+        scopes=["runtime-observations:write"],
+        environment_id=environment.id,
+        runtime_deployment_id=_DEPLOYMENT_ID,
+        managed=True,
+        commit=False,
+    )
+    await db_session.commit()
+
+    guarded_updates = (
+        (
+            update(V2RuntimeEnvironmentFence)
+            .where(V2RuntimeEnvironmentFence.environment_id == environment.id)
+            .values(owner_id=uuid.uuid4()),
+            "fence binding is immutable",
+        ),
+        (
+            update(V2RuntimeEnvironmentFence)
+            .where(V2RuntimeEnvironmentFence.environment_id == environment.id)
+            .values(stream_high_water=0),
+            "high-water cannot regress",
+        ),
+        (
+            update(V2RuntimeObservationInbox)
+            .where(V2RuntimeObservationInbox.id == event.stream_position)
+            .values(health="error"),
+            "inbox events are immutable",
+        ),
+        (
+            update(V2RuntimeObservationHead)
+            .where(
+                V2RuntimeObservationHead.environment_id == environment.id,
+                V2RuntimeObservationHead.boot_session_id == "boot-session-0001",
+            )
+            .values(generation=2),
+            "head binding is immutable",
+        ),
+        (
+            update(V2RuntimeObservationHead)
+            .where(
+                V2RuntimeObservationHead.environment_id == environment.id,
+                V2RuntimeObservationHead.boot_session_id == "boot-session-0001",
+            )
+            .values(latest_event_id="rebound-event"),
+            "head cannot rebind a sequence",
+        ),
+        (
+            update(V2RuntimeObservationConsumerCursor)
+            .where(
+                V2RuntimeObservationConsumerCursor.environment_id == environment.id,
+                V2RuntimeObservationConsumerCursor.consumer_id == "database-guard-controller",
+            )
+            .values(acked_stream_position=0),
+            "acknowledgement cannot regress",
+        ),
+        (
+            update(ApiKey)
+            .where(ApiKey.id == legacy_key.api_key.id)
+            .values(runtime_deployment_id=_DEPLOYMENT_ID),
+            "runtime deployment key binding is immutable",
+        ),
+    )
+    for statement, message in guarded_updates:
+        with pytest.raises(DBAPIError, match=message):
+            async with db_session.begin_nested():
+                await db_session.execute(statement)
+
+    # V1 credential retraction remains frozen: it never consults the v2 fence.
+    await db_session.execute(
+        update(ApiKey)
+        .where(ApiKey.id == strict_key.api_key.id)
+        .values(revoked_at=datetime.now(UTC))
+    )
+    await db_session.commit()
+
+    receipt = await retire_runtime_environment(
+        db_session,
+        environment_id=environment.id,
+        expected_deployment_id=_DEPLOYMENT_ID,
+        retirement_id="database-guard-retirement",
+        owner_id=seed_user.id,
+    )
+    await db_session.commit()
+    retired_mutations = (
+        update(V2RuntimeEnvironmentFence)
+        .where(V2RuntimeEnvironmentFence.environment_id == environment.id)
+        .values(retirement_receipt={"forged": True}),
+        delete(V2RuntimeEnvironmentFence).where(
+            V2RuntimeEnvironmentFence.environment_id == environment.id
+        ),
+        update(V2RuntimeObservationHead)
+        .where(
+            V2RuntimeObservationHead.environment_id == environment.id,
+            V2RuntimeObservationHead.boot_session_id == "boot-session-0001",
+        )
+        .values(state="active"),
+        delete(V2RuntimeObservationHead).where(
+            V2RuntimeObservationHead.environment_id == environment.id,
+            V2RuntimeObservationHead.boot_session_id == "boot-session-0001",
+        ),
+    )
+    for statement in retired_mutations:
+        with pytest.raises(DBAPIError, match="immutable|permanent"):
+            async with db_session.begin_nested():
+                await db_session.execute(statement)
+
+    fence = await db_session.get(V2RuntimeEnvironmentFence, environment.id)
+    assert fence is not None
+    await db_session.refresh(fence)
+    assert fence.retirement_receipt == receipt
+    head = await db_session.get(
+        V2RuntimeObservationHead,
+        {"environment_id": environment.id, "boot_session_id": "boot-session-0001"},
+    )
+    assert head is not None
+    await db_session.refresh(head)
+    assert head.state == "retired"
+    assert head.highest_sequence == 1
+
+
+@pytest.mark.committed_db
 @pytest.mark.asyncio
 async def test_unknown_cursor_persists_fail_closed_reset_boundary(
     engine,
@@ -421,6 +626,7 @@ async def test_unknown_cursor_persists_fail_closed_reset_boundary(
     assert reset["sessionHighWaterMarks"] == {"boot-session-0001": 1}
 
 
+@pytest.mark.committed_db
 @pytest.mark.asyncio
 async def test_concurrent_unknown_consumer_reads_return_one_persisted_structured_expiry(
     engine,
@@ -521,7 +727,7 @@ async def test_cursor_expiry_is_explicit_and_cleanup_never_silently_advances(
         deployment_id=_DEPLOYMENT_ID,
         consumer_id="hosted-controller",
     )
-    await ingest_runtime_observation(
+    event = await ingest_runtime_observation(
         db_session,
         environment_id=environment.id,
         value=_payload(captured_at=captured),
@@ -529,7 +735,7 @@ async def test_cursor_expiry_is_explicit_and_cleanup_never_silently_advances(
     )
     await db_session.commit()
 
-    # Replay-horizon cleanup cannot delete an unacked row before the hard cap.
+    # Replay-horizon cleanup cannot compact an unacked row before the hard cap.
     assert (
         await expire_runtime_observation_payloads(
             db_session,
@@ -546,7 +752,6 @@ async def test_cursor_expiry_is_explicit_and_cleanup_never_silently_advances(
         )
         == 1
     )
-
     assert (
         await expire_runtime_observation_payloads(
             db_session,
@@ -562,6 +767,36 @@ async def test_cursor_expiry_is_explicit_and_cleanup_never_silently_advances(
     assert cursor is not None
     assert cursor.state == "expired"
     assert cursor.expiry_session_high_waters == {"boot-session-0001": 1}
+    retention_audits = list(
+        (
+            await db_session.execute(
+                select(ControlPlaneAuditEvent).where(
+                    ControlPlaneAuditEvent.source == "runtime_observation.retention",
+                    ControlPlaneAuditEvent.action == "runtime_observation.cursor_expired",
+                    ControlPlaneAuditEvent.resource_id == str(environment.id),
+                )
+            )
+        ).scalars()
+    )
+    assert len(retention_audits) == 1
+    retention_audit = retention_audits[0]
+    assert retention_audit.actor_type == "system"
+    assert retention_audit.environment_id is None
+    assert retention_audit.details == {
+        "actor_service": "runtime_observation_retention",
+        "environment_id": str(environment.id),
+        "deployment_id": _DEPLOYMENT_ID,
+        "consumer_id": "hosted-controller",
+        "reason": "hard_retention",
+        "outcome": "expired",
+        "previous_state": "active",
+        "new_state": "expired",
+        "previous_boundary_stream_position": None,
+        "boundary_stream_position": event.stream_position,
+        "stream_high_water": event.stream_position,
+        "session_high_water_marks": {"boot-session-0001": 1},
+    }
+    assert "clawdi-ro-v1" not in json.dumps(retention_audit.details, sort_keys=True)
 
     with pytest.raises(RuntimeObservationProtocolError) as expired:
         await read_runtime_observations(
@@ -590,6 +825,72 @@ async def test_cursor_expiry_is_explicit_and_cleanup_never_silently_advances(
     )
     await db_session.commit()
     assert reset["sessionHighWaterMarks"] == {"boot-session-0001": 1}
+
+
+@pytest.mark.asyncio
+async def test_hard_cap_expiry_audit_failure_rolls_back_cursor_floor_and_compaction(
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch,
+):
+    environment, _ = await _provision_environment(db_session, seed_user)
+    captured = datetime.now(UTC) - timedelta(days=31)
+    await register_runtime_observation_consumer(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="retention-audit-rollback",
+    )
+    event = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(
+            captured_at=captured,
+            error="private diagnostic retained after rollback",
+        ),
+        received_at=captured,
+    )
+    await db_session.commit()
+
+    def fail_retention_audit(*args, **kwargs):
+        raise RuntimeError("injected retention audit failure")
+
+    monkeypatch.setattr(
+        runtime_observation_service,
+        "record_control_plane_audit",
+        fail_retention_audit,
+    )
+    with pytest.raises(RuntimeError, match="injected retention audit failure"):
+        await expire_runtime_observation_payloads(
+            db_session,
+            now=captured + timedelta(days=31),
+        )
+    await db_session.rollback()
+
+    cursor = await db_session.get(
+        V2RuntimeObservationConsumerCursor,
+        {
+            "environment_id": environment.id,
+            "consumer_id": "retention-audit-rollback",
+        },
+    )
+    assert cursor is not None and cursor.state == "active"
+    assert cursor.expiry_boundary_stream_position is None
+    fence = await db_session.get(V2RuntimeEnvironmentFence, environment.id)
+    assert fence is not None and fence.replay_floor_stream_position == 0
+    inbox = await db_session.get(V2RuntimeObservationInbox, event.stream_position)
+    assert inbox is not None
+    assert inbox.payload_purged_at is None
+    assert inbox.diagnostics["error"] == "private diagnostic retained after rollback"
+    assert (
+        await db_session.scalar(
+            select(func.count())
+            .select_from(ControlPlaneAuditEvent)
+            .where(ControlPlaneAuditEvent.resource_id == str(environment.id))
+        )
+        == 0
+    )
 
 
 @pytest.mark.asyncio
@@ -660,6 +961,323 @@ async def test_replay_horizon_purge_waits_for_every_required_consumer_ack(
     assert fence is not None
     assert fence.replay_floor_stream_position == event.stream_position
     assert fence.replay_floor_session_high_waters == {"boot-session-0001": 1}
+
+
+@pytest.mark.asyncio
+async def test_payload_compaction_preserves_event_and_session_sequence_uniqueness(
+    db_session: AsyncSession,
+    seed_user,
+):
+    environment, _ = await _provision_environment(db_session, seed_user)
+    current = datetime.now(UTC)
+    captured = current - timedelta(days=31)
+    event_id = f"durable-event-{uuid.uuid4().hex}"
+    accepted = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(
+            boot_session_id="durable-session",
+            sequence=1,
+            event_id=event_id,
+            captured_at=captured,
+            error="private diagnostic that must be scrubbed",
+        ),
+        received_at=captured,
+    )
+    await db_session.commit()
+
+    assert await expire_runtime_observation_payloads(db_session, now=current) == 1
+    await db_session.commit()
+
+    compacted = await db_session.get(V2RuntimeObservationInbox, accepted.stream_position)
+    assert compacted is not None
+    assert compacted.event_id == event_id
+    assert compacted.boot_session_id == "durable-session"
+    assert compacted.sequence == 1
+    assert compacted.diagnostics == {}
+    assert compacted.payload_purged_at == current
+
+    with pytest.raises(RuntimeObservationProtocolError) as reused_event_id:
+        await ingest_runtime_observation(
+            db_session,
+            environment_id=environment.id,
+            value=_payload(
+                boot_session_id="different-session",
+                sequence=1,
+                event_id=event_id,
+                captured_at=current,
+            ),
+            received_at=current,
+        )
+    assert reused_event_id.value.code == "runtime_observation_event_conflict"
+    await db_session.rollback()
+
+    with pytest.raises(RuntimeObservationProtocolError) as reused_sequence:
+        await ingest_runtime_observation(
+            db_session,
+            environment_id=environment.id,
+            value=_payload(
+                boot_session_id="durable-session",
+                sequence=1,
+                event_id=f"replacement-{uuid.uuid4().hex}",
+                captured_at=current,
+            ),
+            received_at=current,
+        )
+    assert reused_sequence.value.code == "runtime_observation_event_conflict"
+    await db_session.rollback()
+
+    assert (
+        await db_session.scalar(
+            select(func.count())
+            .select_from(V2RuntimeObservationInbox)
+            .where(V2RuntimeObservationInbox.environment_id == environment.id)
+        )
+        == 1
+    )
+    forbidden_tombstone_mutations = (
+        update(V2RuntimeObservationInbox)
+        .where(V2RuntimeObservationInbox.id == accepted.stream_position)
+        .values(diagnostics={"rehydrated": True}),
+        update(V2RuntimeObservationInbox)
+        .where(V2RuntimeObservationInbox.id == accepted.stream_position)
+        .values(payload_purged_at=current + timedelta(seconds=1)),
+        delete(V2RuntimeObservationInbox).where(
+            V2RuntimeObservationInbox.id == accepted.stream_position
+        ),
+    )
+    for statement in forbidden_tombstone_mutations:
+        with pytest.raises(DBAPIError, match="immutable|permanent"):
+            async with db_session.begin_nested():
+                await db_session.execute(statement)
+
+
+@pytest.mark.asyncio
+async def test_retired_environment_compacts_payload_without_mutating_retirement_receipt(
+    db_session: AsyncSession,
+    seed_user,
+):
+    environment, _ = await _provision_environment(db_session, seed_user)
+    current = datetime.now(UTC)
+    captured = current - timedelta(days=31)
+    accepted = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(
+            boot_session_id="retired-retention-session",
+            event_id=f"retired-retention-{uuid.uuid4().hex}",
+            captured_at=captured,
+            error="private retired diagnostic",
+        ),
+        received_at=captured,
+    )
+    receipt = await retire_runtime_environment(
+        db_session,
+        environment_id=environment.id,
+        expected_deployment_id=_DEPLOYMENT_ID,
+        retirement_id="retired-retention-obligation",
+        owner_id=seed_user.id,
+        retired_at=current,
+    )
+    await db_session.commit()
+
+    fence = await db_session.get(V2RuntimeEnvironmentFence, environment.id)
+    assert fence is not None
+    frozen_retirement = {
+        "state": fence.state,
+        "stream_high_water": fence.stream_high_water,
+        "retirement_id": fence.retirement_id,
+        "retirement_receipt_id": fence.retirement_receipt_id,
+        "retirement_receipt": json.loads(json.dumps(fence.retirement_receipt)),
+        "retired_at": fence.retired_at,
+        "final_cursor": fence.final_cursor,
+        "final_stream_position": fence.final_stream_position,
+        "final_session_high_waters": json.loads(json.dumps(fence.final_session_high_waters)),
+    }
+
+    assert await expire_runtime_observation_payloads(db_session, now=current) == 1
+    await db_session.commit()
+
+    await db_session.refresh(fence)
+    assert fence.replay_floor_stream_position == accepted.stream_position
+    assert {
+        "state": fence.state,
+        "stream_high_water": fence.stream_high_water,
+        "retirement_id": fence.retirement_id,
+        "retirement_receipt_id": fence.retirement_receipt_id,
+        "retirement_receipt": fence.retirement_receipt,
+        "retired_at": fence.retired_at,
+        "final_cursor": fence.final_cursor,
+        "final_stream_position": fence.final_stream_position,
+        "final_session_high_waters": fence.final_session_high_waters,
+    } == frozen_retirement
+    assert fence.retirement_receipt == receipt
+
+    compacted = await db_session.get(V2RuntimeObservationInbox, accepted.stream_position)
+    assert compacted is not None
+    assert compacted.diagnostics == {}
+    assert compacted.payload_purged_at == current
+
+
+@pytest.mark.asyncio
+async def test_replay_horizon_purge_stops_before_young_lower_stream_position(
+    db_session: AsyncSession,
+    seed_user,
+):
+    environment, _ = await _provision_environment(db_session, seed_user)
+    current = datetime.now(UTC)
+    registration = await register_runtime_observation_consumer(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="prefix-controller",
+    )
+    young = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(
+            sequence=1,
+            event_id=f"young-{uuid.uuid4().hex}",
+            captured_at=current - timedelta(days=1),
+        ),
+        received_at=current - timedelta(days=1),
+    )
+    old = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(
+            sequence=2,
+            event_id=f"old-{uuid.uuid4().hex}",
+            captured_at=current - timedelta(days=8),
+        ),
+        received_at=current - timedelta(days=8),
+    )
+    page = await read_runtime_observations(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="prefix-controller",
+        expected_apply_identity=_expected_identity(),
+        after_cursor=registration["cursor"],
+        limit=100,
+    )
+    await acknowledge_runtime_observation_cursor(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="prefix-controller",
+        opaque_cursor=page["streamHighWaterCursor"],
+    )
+    await db_session.commit()
+
+    deleted = await expire_runtime_observation_payloads(db_session, now=current)
+    await db_session.commit()
+
+    assert deleted == 0
+    retained_ids = list(
+        (
+            await db_session.execute(
+                select(V2RuntimeObservationInbox.id)
+                .where(V2RuntimeObservationInbox.environment_id == environment.id)
+                .order_by(V2RuntimeObservationInbox.id)
+            )
+        ).scalars()
+    )
+    assert retained_ids == [young.stream_position, old.stream_position]
+    fence = await db_session.get(V2RuntimeEnvironmentFence, environment.id)
+    assert fence is not None and fence.replay_floor_stream_position == 0
+    replay = await read_runtime_observations(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="prefix-controller",
+        expected_apply_identity=_expected_identity(),
+        after_cursor=registration["cursor"],
+        limit=100,
+    )
+    assert [event["evidenceReference"]["eventId"] for event in replay["events"]] == [
+        young.event_id,
+        old.event_id,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_hard_cap_purge_does_not_expire_past_young_lower_stream_position(
+    db_session: AsyncSession,
+    seed_user,
+):
+    environment, _ = await _provision_environment(db_session, seed_user)
+    current = datetime.now(UTC)
+    registration = await register_runtime_observation_consumer(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="hard-prefix-controller",
+    )
+    young = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(
+            sequence=1,
+            event_id=f"hard-young-{uuid.uuid4().hex}",
+            captured_at=current - timedelta(days=1),
+        ),
+        received_at=current - timedelta(days=1),
+    )
+    old = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(
+            sequence=2,
+            event_id=f"hard-old-{uuid.uuid4().hex}",
+            captured_at=current - timedelta(days=31),
+        ),
+        received_at=current - timedelta(days=31),
+    )
+    await db_session.commit()
+
+    deleted = await expire_runtime_observation_payloads(db_session, now=current)
+    await db_session.commit()
+
+    assert deleted == 0
+    retained_ids = list(
+        (
+            await db_session.execute(
+                select(V2RuntimeObservationInbox.id)
+                .where(V2RuntimeObservationInbox.environment_id == environment.id)
+                .order_by(V2RuntimeObservationInbox.id)
+            )
+        ).scalars()
+    )
+    assert retained_ids == [young.stream_position, old.stream_position]
+    fence = await db_session.get(V2RuntimeEnvironmentFence, environment.id)
+    assert fence is not None and fence.replay_floor_stream_position == 0
+    cursor = await db_session.get(
+        V2RuntimeObservationConsumerCursor,
+        {"environment_id": environment.id, "consumer_id": "hard-prefix-controller"},
+    )
+    assert cursor is not None
+    assert cursor.state == "active"
+    assert cursor.expiry_boundary_stream_position is None
+    replay = await read_runtime_observations(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="hard-prefix-controller",
+        expected_apply_identity=_expected_identity(),
+        after_cursor=registration["cursor"],
+        limit=100,
+    )
+    assert [event["evidenceReference"]["eventId"] for event in replay["events"]] == [
+        young.event_id,
+        old.event_id,
+    ]
 
 
 @pytest.mark.asyncio
@@ -761,6 +1379,69 @@ async def test_late_and_unknown_consumers_get_persisted_reset_boundaries(
 
 
 @pytest.mark.asyncio
+async def test_hard_cap_without_consumers_persists_floor_for_late_registration(
+    db_session: AsyncSession,
+    seed_user,
+):
+    environment, _ = await _provision_environment(db_session, seed_user)
+    captured = datetime.now(UTC) - timedelta(days=31)
+    event = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(captured_at=captured),
+        received_at=captured,
+    )
+    await db_session.commit()
+
+    assert (
+        await expire_runtime_observation_payloads(
+            db_session,
+            now=captured + timedelta(days=31),
+        )
+        == 1
+    )
+    await db_session.commit()
+
+    fence = await db_session.get(V2RuntimeEnvironmentFence, environment.id)
+    assert fence is not None
+    assert fence.replay_floor_stream_position == event.stream_position
+    assert fence.replay_floor_session_high_waters == {"boot-session-0001": 1}
+    assert (
+        await db_session.scalar(
+            select(func.count())
+            .select_from(V2RuntimeObservationConsumerCursor)
+            .where(V2RuntimeObservationConsumerCursor.environment_id == environment.id)
+        )
+        == 0
+    )
+
+    with pytest.raises(RuntimeObservationProtocolError) as late:
+        await register_runtime_observation_consumer(
+            db_session,
+            environment_id=environment.id,
+            owner_id=seed_user.id,
+            deployment_id=_DEPLOYMENT_ID,
+            consumer_id="late-after-hard-cap",
+        )
+    assert late.value.code == "observation_cursor_expired"
+    assert late.value.metadata is not None
+    assert late.value.metadata["sessionHighWaterMarks"] == {"boot-session-0001": 1}
+    assert late.value.metadata["resetBoundary"] is not None
+    await db_session.commit()
+
+    cursor = await db_session.get(
+        V2RuntimeObservationConsumerCursor,
+        {
+            "environment_id": environment.id,
+            "consumer_id": "late-after-hard-cap",
+        },
+    )
+    assert cursor is not None
+    assert cursor.state == "expired"
+    assert cursor.expiry_boundary_stream_position == event.stream_position
+
+
+@pytest.mark.asyncio
 async def test_current_epoch_cursor_below_replay_floor_expires_before_read(
     db_session: AsyncSession,
     seed_user,
@@ -842,6 +1523,7 @@ async def test_current_epoch_cursor_below_replay_floor_expires_before_read(
     assert cursor.acked_stream_position == first.stream_position
 
 
+@pytest.mark.committed_db
 @pytest.mark.asyncio
 async def test_concurrent_cas_winner_cannot_be_regressed(
     engine,
@@ -893,6 +1575,7 @@ async def test_concurrent_cas_winner_cannot_be_regressed(
     assert inbox_sequences == [2, 3]
 
 
+@pytest.mark.committed_db
 @pytest.mark.asyncio
 async def test_concurrent_first_session_binding_rejects_losing_identity(
     engine,
@@ -901,6 +1584,8 @@ async def test_concurrent_first_session_binding_rejects_losing_identity(
 ):
     environment, _ = await _provision_environment(db_session, seed_user)
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    winning_event_id = f"binding-event-{environment.id}-0001"
+    losing_event_id = f"binding-event-{environment.id}-0002"
 
     async def bind_losing_identity() -> str:
         async with session_factory() as session:
@@ -910,7 +1595,7 @@ async def test_concurrent_first_session_binding_rejects_losing_identity(
                     environment_id=environment.id,
                     value=_payload(
                         sequence=1,
-                        event_id="binding-event-0002",
+                        event_id=losing_event_id,
                         generation=2,
                         manifest_etag='"different-manifest-etag"',
                         apply_receipt_id="different-apply-receipt",
@@ -927,7 +1612,7 @@ async def test_concurrent_first_session_binding_rejects_losing_identity(
         await ingest_runtime_observation(
             winner_session,
             environment_id=environment.id,
-            value=_payload(sequence=1, event_id="binding-event-0001"),
+            value=_payload(sequence=1, event_id=winning_event_id),
         )
         loser = asyncio.create_task(bind_losing_identity())
         await asyncio.sleep(0.05)
@@ -968,6 +1653,7 @@ async def test_concurrent_first_session_binding_rejects_losing_identity(
     )
 
 
+@pytest.mark.committed_db
 @pytest.mark.asyncio
 async def test_concurrent_cross_environment_event_id_collision_is_structured(
     engine,
@@ -977,7 +1663,7 @@ async def test_concurrent_cross_environment_event_id_collision_is_structured(
     environment_a, _ = await _provision_environment(db_session, seed_user)
     environment_b, _ = await _provision_environment(db_session, seed_user)
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
-    shared_event_id = "globally-colliding-event-id"
+    shared_event_id = f"globally-colliding-event-{environment_a.id}"
     loser_started = asyncio.Event()
 
     async def ingest_loser() -> str:
@@ -1023,6 +1709,7 @@ async def test_concurrent_cross_environment_event_id_collision_is_structured(
     )
 
 
+@pytest.mark.committed_db
 @pytest.mark.asyncio
 async def test_snapshot_and_high_water_share_one_repeatable_read_snapshot(
     engine,
@@ -1110,29 +1797,158 @@ async def test_snapshot_and_high_water_share_one_repeatable_read_snapshot(
     assert incremental["nextCursor"].startswith("clawdi-ro-v1.")
 
 
+def _legacy_runtime_observed(value: RuntimeObservationEventV2) -> dict:
+    payload = value.model_dump(mode="json", by_alias=True)
+    for field in (
+        "applyReceiptId",
+        "bootNonce",
+        "bootSessionId",
+        "sequence",
+        "eventId",
+        "capturedAt",
+    ):
+        payload.pop(field)
+    return payload
+
+
+def _runtime_state(environment_id: uuid.UUID) -> HostedRuntimeState:
+    return HostedRuntimeState(
+        environment_id=environment_id,
+        deployment_id="legacy-hosted-runtime",
+        instance_id="legacy-instance",
+        generation=1,
+        cli_package_spec="@clawdi/cli@0.12.10-beta.55",
+        locale={"timezone": "UTC", "language": "en"},
+        system={"packages": []},
+        runtimes={"openclaw": {"enabled": True}},
+        live_sync={"enabled": True, "agents": []},
+        recovery={"cacheManifest": True, "allowOfflineBoot": True},
+    )
+
+
 @pytest.mark.asyncio
-async def test_companion_heartbeat_requires_bound_managed_key_and_skips_legacy_writer(
+async def test_v1_heartbeat_is_byte_frozen_and_has_no_companion_side_effects(
+    db_session: AsyncSession,
+    seed_user,
+) -> None:
+    environment = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"v1-frozen-{uuid.uuid4().hex}",
+        machine_name="v1-frozen",
+        agent_type="openclaw",
+        os="linux",
+    )
+    db_session.add(_runtime_state(environment.id))
+    await db_session.commit()
+    key = ApiKey(
+        id=uuid.uuid4(),
+        user_id=seed_user.id,
+        managed=True,
+        environment_id=environment.id,
+        scopes=["skills:write"],
+    )
+
+    async def override_session() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    async def override_auth() -> AuthContext:
+        return AuthContext(user=seed_user, api_key=key)
+
+    app.dependency_overrides[get_session] = override_session
+    app.dependency_overrides[get_auth] = override_auth
+    try:
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            legacy = await client.post(
+                f"/v1/agents/{environment.id}/sync-heartbeat",
+                json={
+                    "last_revision_seen": 7,
+                    "last_sync_error": None,
+                    "queue_depth": 3,
+                    "dropped_count_delta": 2,
+                    "runtime_observed": _legacy_runtime_observed(_payload()),
+                },
+            )
+            strict_v2_on_v1 = await client.post(
+                f"/v1/agents/{environment.id}/sync-heartbeat",
+                json={
+                    "runtime_observed": _payload().model_dump(mode="json", by_alias=True),
+                },
+            )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert legacy.status_code == 204
+    assert legacy.content == b""
+    assert strict_v2_on_v1.status_code == 422
+    observation = await db_session.get(HostedRuntimeConfigObservation, environment.id)
+    assert observation is not None
+    assert observation.observed_config_generation == 1
+    await db_session.refresh(environment)
+    assert environment.last_revision_seen == 7
+    assert environment.last_sync_at is not None
+    assert environment.queue_depth_high_water_since_start == 3
+    assert environment.dropped_count_since_start == 2
+    assert await db_session.get(V2RuntimeEnvironmentFence, environment.id) is None
+    for model in (V2RuntimeObservationInbox, V2RuntimeObservationHead):
+        assert (
+            await db_session.scalar(
+                select(func.count())
+                .select_from(model)
+                .where(model.environment_id == environment.id)
+            )
+            == 0
+        )
+    assert (
+        await db_session.scalar(
+            select(func.count())
+            .select_from(ControlPlaneAuditEvent)
+            .where(ControlPlaneAuditEvent.resource_id == str(environment.id))
+        )
+        == 0
+    )
+
+
+@pytest.mark.asyncio
+async def test_v2_ingestion_only_writes_companion_tables_and_requires_dedicated_scope(
     db_session: AsyncSession,
     seed_user,
 ) -> None:
     environment, _ = await _provision_environment(db_session, seed_user)
-    unfenced_environment = await create_env_with_project(
-        db_session,
-        user_id=seed_user.id,
-        machine_id=f"runtime-observation-unfenced-{uuid.uuid4().hex}",
-        machine_name="runtime-observation-unfenced",
-        agent_type="openclaw",
-        os="linux",
-    )
-    unfenced_environment_id = unfenced_environment.id
-    await db_session.commit()
-    runtime_key = ApiKey(
-        user_id=seed_user.id,
+    state = _runtime_state(environment.id)
+    observation = HostedRuntimeConfigObservation(
         environment_id=environment.id,
-        managed=False,
+        observed_at=datetime(2026, 1, 1, tzinfo=UTC),
+        observed_config_generation=99,
+        observed_manifest_etag="legacy-etag",
+        observed_source_revision="b" * 64,
+        diagnostics={"sentinel": "legacy"},
+    )
+    db_session.add(state)
+    await db_session.flush()
+    db_session.add(observation)
+    environment_row = await db_session.get(AgentEnvironment, environment.id)
+    assert environment_row is not None
+    sentinel_sync_at = datetime(2026, 1, 2, tzinfo=UTC)
+    environment_row.last_sync_at = sentinel_sync_at
+    environment_row.last_sync_error = "legacy-error"
+    environment_row.last_revision_seen = 11
+    environment_row.queue_depth_high_water_since_start = 17
+    environment_row.dropped_count_since_start = 19
+    environment_row.sync_enabled = False
+    await db_session.commit()
+
+    runtime_key = ApiKey(
+        id=uuid.uuid4(),
+        user_id=seed_user.id,
+        managed=True,
+        environment_id=environment.id,
+        runtime_deployment_id=_DEPLOYMENT_ID,
         scopes=["skills:write"],
     )
-    accepted_payload = _payload(captured_at=datetime.now(UTC))
 
     async def override_session() -> AsyncIterator[AsyncSession]:
         yield db_session
@@ -1142,243 +1958,213 @@ async def test_companion_heartbeat_requires_bound_managed_key_and_skips_legacy_w
 
     app.dependency_overrides[get_session] = override_session
     app.dependency_overrides[get_auth] = override_auth
+    event_id = f"v2-only-{environment.id}"
     try:
         async with httpx.AsyncClient(
             transport=ASGITransport(app=app),
             base_url="http://test",
         ) as client:
-            unmanaged_response = await client.post(
-                f"/v1/agents/{environment.id}/sync-heartbeat",
-                json={"runtime_observed": _payload().model_dump(mode="json", by_alias=True)},
+            skills_only = await client.post(
+                f"/v2/runtime/environments/{environment.id}/observations",
+                json=_payload().model_dump(mode="json", by_alias=True),
             )
-            runtime_key.managed = True
-            legacy_managed_response = await client.post(
-                f"/v1/agents/{environment.id}/sync-heartbeat",
-                json={"runtime_observed": _payload().model_dump(mode="json", by_alias=True)},
-            )
-            runtime_key.runtime_deployment_id = _DEPLOYMENT_ID
-            response = await client.post(
-                f"/v1/agents/{environment.id}/sync-heartbeat",
-                json={"runtime_observed": accepted_payload.model_dump(mode="json", by_alias=True)},
-            )
-            duplicate_response = await client.post(
-                f"/v1/agents/{environment.id}/sync-heartbeat",
-                json={"runtime_observed": accepted_payload.model_dump(mode="json", by_alias=True)},
-            )
-            stale_buffered_response = await client.post(
-                f"/v1/agents/{environment.id}/sync-heartbeat",
-                json={
-                    "runtime_observed": _payload(
-                        sequence=2,
-                        captured_at=accepted_payload.captured_at - timedelta(seconds=1),
-                    ).model_dump(mode="json", by_alias=True)
-                },
-            )
-            runtime_key.environment_id = unfenced_environment_id
-            unfenced_response = await client.post(
-                f"/v1/agents/{unfenced_environment_id}/sync-heartbeat",
-                json={"runtime_observed": _payload().model_dump(mode="json", by_alias=True)},
+            runtime_key.scopes = ["runtime-observations:write"]
+            accepted = await client.post(
+                f"/v2/runtime/environments/{environment.id}/observations",
+                json=_payload(event_id=event_id).model_dump(mode="json", by_alias=True),
             )
     finally:
         app.dependency_overrides.clear()
-    assert unmanaged_response.status_code == 403, unmanaged_response.text
-    assert legacy_managed_response.status_code == 403, legacy_managed_response.text
-    assert response.status_code == 204, response.text
-    assert duplicate_response.status_code == 204, duplicate_response.text
-    assert stale_buffered_response.status_code == 204, stale_buffered_response.text
-    assert unfenced_response.status_code == 409, unfenced_response.text
-    assert unfenced_response.json()["detail"]["code"] == "runtime_environment_fence_missing"
-    assert await db_session.get(HostedRuntimeConfigObservation, environment.id) is None
+
+    assert skills_only.status_code == 403
+    assert accepted.status_code == 200, accepted.text
+    assert accepted.json()["outcome"] == "accepted_head_created"
+    stored_observation = await db_session.get(HostedRuntimeConfigObservation, environment.id)
+    assert stored_observation is not None
+    assert stored_observation.observed_config_generation == 99
+    assert stored_observation.diagnostics == {"sentinel": "legacy"}
+    await db_session.refresh(environment_row)
+    assert environment_row.last_sync_at == sentinel_sync_at
+    assert environment_row.last_sync_error == "legacy-error"
+    assert environment_row.last_revision_seen == 11
+    assert environment_row.queue_depth_high_water_since_start == 17
+    assert environment_row.dropped_count_since_start == 19
+    assert environment_row.sync_enabled is False
     assert (
         await db_session.scalar(
             select(func.count())
             .select_from(V2RuntimeObservationInbox)
             .where(V2RuntimeObservationInbox.environment_id == environment.id)
         )
-        == 2
+        == 1
     )
-    stored_environment = await db_session.get(type(unfenced_environment), environment.id)
-    assert stored_environment is not None
-    assert stored_environment.last_sync_at is None
+    head = await db_session.get(
+        V2RuntimeObservationHead,
+        {"environment_id": environment.id, "boot_session_id": "boot-session-0001"},
+    )
+    assert head is not None and head.highest_sequence == 1
 
 
+@pytest.mark.committed_db
 @pytest.mark.asyncio
-async def test_runtime_credential_cannot_report_for_another_deployment(
+async def test_v2_ingestion_audits_non_advance_and_committed_rejections_without_payload(
     db_session: AsyncSession,
     seed_user,
 ) -> None:
-    deployment_a = "deployment-credential-a"
-    deployment_b = "deployment-credential-b"
-    environment_a, fence_a = await _provision_environment(
-        db_session,
-        seed_user,
-        deployment_id=deployment_a,
-    )
-    environment_b, fence_b = await _provision_environment(
-        db_session,
-        seed_user,
-        deployment_id=deployment_b,
-    )
-    assert fence_a.deployment_id != fence_b.deployment_id
-    runtime_key_a = ApiKey(
-        user_id=seed_user.id,
-        environment_id=environment_a.id,
-        runtime_deployment_id=deployment_a,
+    environment, _ = await _provision_environment(db_session, seed_user)
+    environment_id = environment.id
+    owner_id = seed_user.id
+    runtime_key = ApiKey(
+        id=uuid.uuid4(),
+        user_id=owner_id,
         managed=True,
-        scopes=["skills:write"],
+        environment_id=environment_id,
+        runtime_deployment_id=_DEPLOYMENT_ID,
+        scopes=["runtime-observations:write"],
     )
+    auth_context = AuthContext(user=seed_user, api_key=runtime_key)
 
     async def override_session() -> AsyncIterator[AsyncSession]:
         yield db_session
 
     async def override_auth() -> AuthContext:
-        return AuthContext(user=seed_user, api_key=runtime_key_a)
+        return auth_context
 
     app.dependency_overrides[get_session] = override_session
     app.dependency_overrides[get_auth] = override_auth
+    base = datetime.now(UTC)
+    event_prefix = f"audit-{environment_id}"
+    path = f"/v2/runtime/environments/{environment_id}/observations"
     try:
         async with httpx.AsyncClient(
             transport=ASGITransport(app=app),
             base_url="http://test",
         ) as client:
-            accepted = await client.post(
-                f"/v1/agents/{environment_a.id}/sync-heartbeat",
-                json={
-                    "runtime_observed": _payload(
-                        boot_session_id="credential-a-session",
-                    ).model_dump(mode="json", by_alias=True)
-                },
+            for payload in (
+                _payload(sequence=1, event_id=f"{event_prefix}-1", captured_at=base),
+                _payload(
+                    sequence=3,
+                    event_id=f"{event_prefix}-3",
+                    captured_at=base + timedelta(seconds=3),
+                ),
+            ):
+                response = await client.post(
+                    path,
+                    json=payload.model_dump(mode="json", by_alias=True),
+                )
+                assert response.status_code == 200, response.text
+
+            non_advance = await client.post(
+                path,
+                json=_payload(
+                    sequence=2,
+                    event_id=f"{event_prefix}-2",
+                    captured_at=base + timedelta(seconds=2),
+                    error="private-diagnostic-must-not-enter-audit",
+                ).model_dump(mode="json", by_alias=True),
             )
-            rejected = await client.post(
-                f"/v1/agents/{environment_b.id}/sync-heartbeat",
-                json={
-                    "runtime_observed": _payload(
-                        boot_session_id="credential-b-forged-session",
-                    ).model_dump(mode="json", by_alias=True)
-                },
+            captured_at_regression = await client.post(
+                path,
+                json=_payload(
+                    sequence=4,
+                    event_id=f"{event_prefix}-captured-regression",
+                    captured_at=base + timedelta(seconds=2),
+                    error="private-regression-diagnostic-must-not-enter-audit",
+                ).model_dump(mode="json", by_alias=True),
+            )
+            rebind = await client.post(
+                path,
+                json=_payload(
+                    sequence=5,
+                    event_id=f"{event_prefix}-rebind",
+                    captured_at=base + timedelta(seconds=4),
+                    apply_receipt_id="different-receipt-000001",
+                    error="private-rebind-diagnostic",
+                ).model_dump(mode="json", by_alias=True),
+            )
+            event_conflict = await client.post(
+                path,
+                json=_payload(
+                    sequence=3,
+                    event_id=f"{event_prefix}-conflict",
+                    captured_at=base + timedelta(seconds=3),
+                    error="private-conflict-diagnostic",
+                ).model_dump(mode="json", by_alias=True),
+            )
+            await _retire_runtime_environment(
+                db_session,
+                environment_id=environment_id,
+                expected_deployment_id=_DEPLOYMENT_ID,
+                retirement_id="audit-retirement",
+                owner_id=owner_id,
+            )
+            await db_session.commit()
+            retired = await client.post(
+                path,
+                json=_payload(
+                    boot_session_id="new-session-after-retirement",
+                    sequence=1,
+                    event_id=f"{event_prefix}-retired",
+                    captured_at=base + timedelta(seconds=5),
+                    error="private-retired-diagnostic",
+                ).model_dump(mode="json", by_alias=True),
             )
     finally:
         app.dependency_overrides.clear()
 
-    assert accepted.status_code == 204, accepted.text
-    assert rejected.status_code == 403, rejected.text
-    assert rejected.json()["detail"]["code"] == "runtime_observation_credential_mismatch"
-    counts = dict(
+    assert non_advance.status_code == 200
+    assert non_advance.json()["outcome"] == "accepted_non_advance_sequence"
+    assert captured_at_regression.status_code == 200
+    assert captured_at_regression.json()["outcome"] == "accepted_non_advance_captured_at"
+    assert rebind.status_code == 409
+    assert rebind.json()["detail"]["code"] == "runtime_observation_identity_conflict"
+    assert event_conflict.status_code == 409
+    assert event_conflict.json()["detail"]["code"] == "runtime_observation_event_conflict"
+    assert retired.status_code == 409
+    assert retired.json()["detail"]["code"] == "runtime_environment_retired"
+    audits = list(
         (
             await db_session.execute(
-                select(
-                    V2RuntimeObservationInbox.environment_id,
-                    func.count(V2RuntimeObservationInbox.id),
-                )
+                select(ControlPlaneAuditEvent)
                 .where(
-                    V2RuntimeObservationInbox.environment_id.in_(
-                        [environment_a.id, environment_b.id]
-                    )
+                    ControlPlaneAuditEvent.source == "api.v2.runtime",
+                    ControlPlaneAuditEvent.action == "runtime_observation.ingest",
+                    ControlPlaneAuditEvent.resource_id == str(environment_id),
                 )
-                .group_by(V2RuntimeObservationInbox.environment_id)
+                .order_by(ControlPlaneAuditEvent.created_at)
             )
-        ).all()
+        )
+        .scalars()
+        .all()
     )
-    assert counts == {environment_a.id: 1}
-
-
-@pytest.mark.asyncio
-async def test_real_minted_bearer_requires_immutable_runtime_deployment_binding(
-    db_session: AsyncSession,
-    seed_user,
-) -> None:
-    deployment_a = "deployment-minted-bearer-a"
-    deployment_b = "deployment-minted-bearer-b"
-    environment_a_row = await create_env_with_project(
-        db_session,
-        user_id=seed_user.id,
-        machine_id=f"legacy-before-fence-{uuid.uuid4().hex}",
-        machine_name="legacy-before-fence",
-        agent_type="openclaw",
-        os="linux",
-    )
-    environment_a = _EnvironmentRef(environment_a_row.id)
-    legacy = await mint_api_key(
-        db_session,
-        user_id=seed_user.id,
-        label="legacy-managed-runtime",
-        scopes=["skills:write"],
-        environment_id=environment_a.id,
-        managed=True,
-        commit=True,
-    )
-    assert await db_session.get(V2RuntimeEnvironmentFence, environment_a.id) is None
-    await provision_runtime_environment_fence(
-        db_session,
-        environment_id=environment_a.id,
-        owner_id=seed_user.id,
-        deployment_id=deployment_a,
-    )
-    await db_session.commit()
-    strict = await mint_api_key(
-        db_session,
-        user_id=seed_user.id,
-        label="strict-v2-runtime",
-        scopes=["skills:write"],
-        environment_id=environment_a.id,
-        runtime_deployment_id=deployment_a,
-        managed=True,
-        commit=True,
-    )
-    environment_b, _ = await _provision_environment(
-        db_session,
-        seed_user,
-        deployment_id=deployment_b,
-    )
-    legacy_row = await db_session.get(ApiKey, legacy.api_key.id)
-    strict_row = await db_session.get(ApiKey, strict.api_key.id)
-    assert legacy_row is not None
-    assert strict_row is not None
-    assert legacy_row.created_at < strict_row.created_at
-    assert legacy_row.runtime_deployment_id is None
-    assert strict_row.runtime_deployment_id == deployment_a
-
-    async def override_session() -> AsyncIterator[AsyncSession]:
-        yield db_session
-
-    app.dependency_overrides[get_session] = override_session
-    try:
-        async with httpx.AsyncClient(
-            transport=ASGITransport(app=app),
-            base_url="http://test",
-        ) as client:
-            legacy_rejected = await client.post(
-                f"/v1/agents/{environment_a.id}/sync-heartbeat",
-                headers={"Authorization": f"Bearer {legacy.raw_key}"},
-                json={
-                    "runtime_observed": _payload(
-                        boot_session_id="legacy-minted-session",
-                    ).model_dump(mode="json", by_alias=True)
-                },
+    assert [event.details["outcome"] for event in audits] == [
+        "accepted_non_advance_sequence",
+        "accepted_non_advance_captured_at",
+        "runtime_observation_identity_conflict",
+        "runtime_observation_event_conflict",
+        "runtime_environment_retired",
+    ]
+    serialized_audits = json.dumps([event.details for event in audits], sort_keys=True)
+    assert "private-" not in serialized_audits
+    assert "diagnostics" not in serialized_audits
+    inbox_events = list(
+        (
+            await db_session.execute(
+                select(V2RuntimeObservationInbox.event_id)
+                .where(V2RuntimeObservationInbox.environment_id == environment_id)
+                .order_by(V2RuntimeObservationInbox.id)
             )
-            accepted = await client.post(
-                f"/v1/agents/{environment_a.id}/sync-heartbeat",
-                headers={"Authorization": f"Bearer {strict.raw_key}"},
-                json={
-                    "runtime_observed": _payload(
-                        boot_session_id="strict-minted-session",
-                    ).model_dump(mode="json", by_alias=True)
-                },
-            )
-            cross_deployment = await client.post(
-                f"/v1/agents/{environment_b.id}/sync-heartbeat",
-                headers={"Authorization": f"Bearer {strict.raw_key}"},
-                json={
-                    "runtime_observed": _payload(
-                        boot_session_id="strict-cross-deployment-session",
-                    ).model_dump(mode="json", by_alias=True)
-                },
-            )
-    finally:
-        app.dependency_overrides.clear()
-
-    assert legacy_rejected.status_code == 403, legacy_rejected.text
-    assert legacy_rejected.json()["detail"]["code"] == ("runtime_observation_credential_mismatch")
-    assert accepted.status_code == 204, accepted.text
-    assert cross_deployment.status_code == 403, cross_deployment.text
-    assert cross_deployment.json()["detail"]["code"] == ("runtime_observation_credential_mismatch")
+        ).scalars()
+    )
+    assert inbox_events == [
+        f"{event_prefix}-1",
+        f"{event_prefix}-3",
+        f"{event_prefix}-2",
+        f"{event_prefix}-captured-regression",
+    ]
+    head = await db_session.get(
+        V2RuntimeObservationHead,
+        {"environment_id": environment_id, "boot_session_id": "boot-session-0001"},
+    )
+    assert head is not None
+    assert head.highest_sequence == 3

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -2007,11 +2007,20 @@ async def test_v2_ingestion_only_writes_companion_tables_and_requires_dedicated_
 
 @pytest.mark.committed_db
 @pytest.mark.asyncio
-async def test_v2_ingestion_audits_non_advance_and_committed_rejections_without_payload(
+async def test_v2_ingestion_audits_every_service_rejection_without_private_payload(
     db_session: AsyncSession,
     seed_user,
 ) -> None:
     environment, _ = await _provision_environment(db_session, seed_user)
+    unfenced_environment = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"runtime-observation-unfenced-{uuid.uuid4().hex}",
+        machine_name="runtime-observation-unfenced",
+        agent_type="openclaw",
+        os="linux",
+    )
+    unfenced_environment_id = unfenced_environment.id
     environment_id = environment.id
     owner_id = seed_user.id
     runtime_key = ApiKey(
@@ -2035,11 +2044,48 @@ async def test_v2_ingestion_audits_non_advance_and_committed_rejections_without_
     base = datetime.now(UTC)
     event_prefix = f"audit-{environment_id}"
     path = f"/v2/runtime/environments/{environment_id}/observations"
+    raw_credential = "raw-runtime-credential-must-not-enter-audit"
+    private_diagnostic = "private-diagnostic-and-opaque-cursor-must-not-enter-audit"
     try:
         async with httpx.AsyncClient(
             transport=ASGITransport(app=app),
             base_url="http://test",
+            headers={"Authorization": f"Bearer {raw_credential}"},
         ) as client:
+            future = await client.post(
+                path,
+                json=_payload(
+                    event_id=f"{event_prefix}-future",
+                    captured_at=base + timedelta(days=1),
+                    error=private_diagnostic,
+                ).model_dump(mode="json", by_alias=True),
+            )
+            too_old = await client.post(
+                path,
+                json=_payload(
+                    event_id=f"{event_prefix}-too-old",
+                    captured_at=base - timedelta(days=365),
+                    error=private_diagnostic,
+                ).model_dump(mode="json", by_alias=True),
+            )
+            runtime_key.runtime_deployment_id = "different-credential-deployment"
+            credential_mismatch = await client.post(
+                path,
+                json=_payload(
+                    event_id=f"{event_prefix}-credential",
+                    error=private_diagnostic,
+                ).model_dump(mode="json", by_alias=True),
+            )
+            runtime_key.runtime_deployment_id = _DEPLOYMENT_ID
+            runtime_key.environment_id = unfenced_environment_id
+            fence_missing = await client.post(
+                f"/v2/runtime/environments/{unfenced_environment_id}/observations",
+                json=_payload(
+                    event_id=f"{event_prefix}-fence-missing",
+                    error=private_diagnostic,
+                ).model_dump(mode="json", by_alias=True),
+            )
+            runtime_key.environment_id = environment_id
             for payload in (
                 _payload(sequence=1, event_id=f"{event_prefix}-1", captured_at=base),
                 _payload(
@@ -2112,6 +2158,14 @@ async def test_v2_ingestion_audits_non_advance_and_committed_rejections_without_
     finally:
         app.dependency_overrides.clear()
 
+    assert future.status_code == 422
+    assert future.json()["detail"]["code"] == "runtime_observation_captured_at_in_future"
+    assert too_old.status_code == 422
+    assert too_old.json()["detail"]["code"] == "runtime_observation_captured_at_too_old"
+    assert credential_mismatch.status_code == 403
+    assert credential_mismatch.json()["detail"]["code"] == "runtime_observation_credential_mismatch"
+    assert fence_missing.status_code == 409
+    assert fence_missing.json()["detail"]["code"] == "runtime_environment_fence_missing"
     assert non_advance.status_code == 200
     assert non_advance.json()["outcome"] == "accepted_non_advance_sequence"
     assert captured_at_regression.status_code == 200
@@ -2125,28 +2179,50 @@ async def test_v2_ingestion_audits_non_advance_and_committed_rejections_without_
     audits = list(
         (
             await db_session.execute(
-                select(ControlPlaneAuditEvent)
-                .where(
+                select(ControlPlaneAuditEvent).where(
                     ControlPlaneAuditEvent.source == "api.v2.runtime",
                     ControlPlaneAuditEvent.action == "runtime_observation.ingest",
-                    ControlPlaneAuditEvent.resource_id == str(environment_id),
+                    ControlPlaneAuditEvent.details["event_id"].astext.like(f"{event_prefix}%"),
                 )
-                .order_by(ControlPlaneAuditEvent.created_at)
             )
         )
         .scalars()
         .all()
     )
-    assert [event.details["outcome"] for event in audits] == [
-        "accepted_non_advance_sequence",
-        "accepted_non_advance_captured_at",
-        "runtime_observation_identity_conflict",
-        "runtime_observation_event_conflict",
-        "runtime_environment_retired",
-    ]
+    expected_outcomes = {
+        f"{event_prefix}-future": "runtime_observation_captured_at_in_future",
+        f"{event_prefix}-too-old": "runtime_observation_captured_at_too_old",
+        f"{event_prefix}-credential": "runtime_observation_credential_mismatch",
+        f"{event_prefix}-fence-missing": "runtime_environment_fence_missing",
+        f"{event_prefix}-2": "accepted_non_advance_sequence",
+        f"{event_prefix}-captured-regression": "accepted_non_advance_captured_at",
+        f"{event_prefix}-rebind": "runtime_observation_identity_conflict",
+        f"{event_prefix}-conflict": "runtime_observation_event_conflict",
+        f"{event_prefix}-retired": "runtime_environment_retired",
+    }
+    assert {event.details["event_id"]: event.details["outcome"] for event in audits} == (
+        expected_outcomes
+    )
+    for event in audits:
+        details = event.details
+        assert event.actor_user_id == owner_id
+        assert event.target_user_id == owner_id
+        assert details["principal_id"] == str(runtime_key.id)
+        assert details["runtime_principal_id"] == str(runtime_key.id)
+        assert details["environment_id"] == event.resource_id
+        assert details["deployment_id"] in {
+            _DEPLOYMENT_ID,
+            "different-credential-deployment",
+        }
+        assert details["boot_session_id"]
+        assert details["sequence"] >= 1
+        assert details["event_id"] in expected_outcomes
     serialized_audits = json.dumps([event.details for event in audits], sort_keys=True)
     assert "private-" not in serialized_audits
     assert "diagnostics" not in serialized_audits
+    assert raw_credential not in serialized_audits
+    assert "opaque-cursor" not in serialized_audits
+    assert "runtime environment fence does not exist" not in serialized_audits
     inbox_events = list(
         (
             await db_session.execute(
@@ -2168,3 +2244,142 @@ async def test_v2_ingestion_audits_non_advance_and_committed_rejections_without_
     )
     assert head is not None
     assert head.highest_sequence == 3
+
+
+@pytest.mark.committed_db
+@pytest.mark.asyncio
+async def test_v2_ingestion_route_auth_rejections_are_durably_audited(
+    db_session: AsyncSession,
+    seed_user,
+) -> None:
+    environment, _ = await _provision_environment(db_session, seed_user)
+    environment_id = environment.id
+    path = f"/v2/runtime/environments/{environment_id}/observations"
+    event_prefix = f"route-auth-audit-{environment_id}"
+    auth_context: AuthContext
+
+    async def override_session() -> AsyncIterator[AsyncSession]:
+        yield db_session
+
+    async def override_auth() -> AuthContext:
+        return auth_context
+
+    app.dependency_overrides[get_session] = override_session
+    app.dependency_overrides[get_auth] = override_auth
+    raw_credential = "raw-route-credential-must-not-enter-audit"
+    private_diagnostic = "private-internal-error-and-opaque-cursor-must-not-enter-audit"
+    cases = (
+        (
+            "managed_credential_required",
+            False,
+            environment_id,
+            _DEPLOYMENT_ID,
+            ["runtime-observations:write"],
+        ),
+        (
+            "scope_missing",
+            True,
+            environment_id,
+            _DEPLOYMENT_ID,
+            ["skills:write"],
+        ),
+        (
+            "environment_binding_mismatch",
+            True,
+            uuid.uuid4(),
+            _DEPLOYMENT_ID,
+            ["runtime-observations:write"],
+        ),
+        (
+            "deployment_binding_missing",
+            True,
+            environment_id,
+            None,
+            ["runtime-observations:write"],
+        ),
+    )
+    expected: dict[str, dict[str, object]] = {}
+    try:
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            headers={"Authorization": f"Bearer {raw_credential}"},
+        ) as client:
+            for index, (reason, managed, bound_environment, deployment_id, scopes) in enumerate(
+                cases,
+                start=1,
+            ):
+                runtime_key = ApiKey(
+                    id=uuid.uuid4(),
+                    user_id=seed_user.id,
+                    managed=managed,
+                    environment_id=bound_environment,
+                    runtime_deployment_id=deployment_id,
+                    scopes=scopes,
+                    key_hash=raw_credential,
+                    key_prefix="raw-route-prefix",
+                )
+                auth_context = AuthContext(user=seed_user, api_key=runtime_key)
+                event_id = f"{event_prefix}-{reason}"
+                payload = _payload(
+                    boot_session_id=f"route-auth-boot-{index}",
+                    sequence=index,
+                    event_id=event_id,
+                    error=private_diagnostic,
+                )
+                response = await client.post(
+                    path,
+                    json=payload.model_dump(mode="json", by_alias=True),
+                )
+                assert response.status_code == 403
+                assert (
+                    response.json()["detail"]["code"] == "runtime_observation_credential_mismatch"
+                )
+                expected[event_id] = {
+                    "reason": reason,
+                    "principal_id": str(runtime_key.id),
+                    "deployment_id": deployment_id,
+                    "boot_session_id": payload.boot_session_id,
+                    "sequence": payload.sequence,
+                }
+    finally:
+        app.dependency_overrides.clear()
+
+    audits = list(
+        (
+            await db_session.execute(
+                select(ControlPlaneAuditEvent).where(
+                    ControlPlaneAuditEvent.source == "api.v2.runtime",
+                    ControlPlaneAuditEvent.action == "runtime_observation.ingest",
+                    ControlPlaneAuditEvent.resource_id == str(environment_id),
+                    ControlPlaneAuditEvent.details["event_id"].astext.like(f"{event_prefix}%"),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audits) == len(cases)
+    for event in audits:
+        details = event.details
+        expected_details = expected[details["event_id"]]
+        assert event.actor_type == "runtime_deployment"
+        assert event.actor_user_id == seed_user.id
+        assert event.target_user_id == seed_user.id
+        assert details == {
+            "principal_id": expected_details["principal_id"],
+            "runtime_principal_id": expected_details["principal_id"],
+            "environment_id": str(environment_id),
+            "deployment_id": expected_details["deployment_id"],
+            "boot_session_id": expected_details["boot_session_id"],
+            "sequence": expected_details["sequence"],
+            "event_id": details["event_id"],
+            "outcome": "runtime_observation_credential_mismatch",
+            "rejection_reason": expected_details["reason"],
+        }
+    serialized_audits = json.dumps([event.details for event in audits], sort_keys=True)
+    assert raw_credential not in serialized_audits
+    assert "private-" not in serialized_audits
+    assert "opaque-cursor" not in serialized_audits
+    assert "internal-error" not in serialized_audits
+    assert "diagnostics" not in serialized_audits

--- a/backend/tests/test_runtime_observation_hardening_migration.py
+++ b/backend/tests/test_runtime_observation_hardening_migration.py
@@ -1,0 +1,711 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+REVISION = "a6d2f4c8b1e7"
+MIGRATION_FILENAME = f"{REVISION}_harden_v2_runtime_observation_boundary.py"
+
+
+def _load_migration():
+    migration_path = Path(__file__).parents[1] / "alembic" / "versions" / MIGRATION_FILENAME
+    spec = importlib.util.spec_from_file_location(
+        "runtime_observation_hardening_migration",
+        migration_path,
+    )
+    assert spec is not None and spec.loader is not None
+    migration = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(migration)
+    return migration
+
+
+def test_runtime_observation_hardening_migration_rejects_invalid_credentials_and_round_trips(
+    engine: AsyncEngine,
+) -> None:
+    migration = _load_migration()
+    schema = f"runtime_observation_hardening_{uuid.uuid4().hex}"
+    tables = (
+        "api_keys",
+        "platform_workload_clients",
+        "v2_runtime_environment_fences",
+        "v2_runtime_observation_inbox",
+        "v2_runtime_observation_heads",
+        "v2_runtime_observation_consumer_cursors",
+    )
+
+    def run(sync_conn: sa.Connection) -> None:
+        old_op = migration.op
+        sync_conn.execute(sa.text(f'CREATE SCHEMA "{schema}"'))
+        try:
+            for table in tables:
+                sync_conn.execute(
+                    sa.text(
+                        f'CREATE TABLE "{schema}"."{table}" (LIKE public."{table}" INCLUDING ALL)'
+                    )
+                )
+            sync_conn.execute(sa.text(f'SET search_path TO "{schema}"'))
+            sync_conn.execute(
+                sa.text(
+                    """
+                    ALTER TABLE api_keys
+                    DROP CONSTRAINT ck_api_keys_runtime_deployment_binding;
+                    ALTER TABLE api_keys
+                    ADD CONSTRAINT ck_api_keys_runtime_deployment_binding
+                    CHECK (
+                        runtime_deployment_id IS NULL
+                        OR (managed AND environment_id IS NOT NULL)
+                    );
+                    ALTER TABLE platform_workload_clients
+                    DROP CONSTRAINT ck_platform_workload_clients_allowed_scopes;
+                    ALTER TABLE platform_workload_clients
+                    ADD CONSTRAINT ck_platform_workload_clients_allowed_scopes
+                    CHECK (
+                        cardinality(allowed_scopes) > 0
+                        AND allowed_scopes <@ ARRAY[
+                            'platform:agents:create',
+                            'platform:agents:delete',
+                            'platform:runtime-state:write',
+                            'platform:keys:mint',
+                            'platform:keys:revoke',
+                            'platform:runtime-observations:read'
+                        ]::varchar[]
+                        );
+                    ALTER TABLE v2_runtime_environment_fences
+                    DROP CONSTRAINT ck_v2_runtime_environment_fences_retirement;
+                    ALTER TABLE v2_runtime_environment_fences
+                    ADD CONSTRAINT ck_v2_runtime_environment_fences_retirement
+                    CHECK (
+                        (state = 'active' AND retirement_id IS NULL
+                         AND retirement_receipt_id IS NULL
+                         AND retirement_receipt IS NULL AND retired_at IS NULL
+                         AND final_cursor IS NULL AND final_stream_position IS NULL
+                         AND final_session_high_waters IS NULL)
+                        OR (state = 'retired' AND retirement_id IS NOT NULL
+                            AND retirement_receipt_id IS NOT NULL
+                            AND retirement_receipt IS NOT NULL
+                            AND retired_at IS NOT NULL AND final_cursor IS NOT NULL
+                            AND final_stream_position IS NOT NULL
+                            AND final_session_high_waters IS NOT NULL)
+                    );
+                    ALTER TABLE v2_runtime_observation_heads
+                    DROP CONSTRAINT ck_v2_runtime_observation_heads_lifecycle;
+                    ALTER TABLE v2_runtime_observation_heads
+                    ADD CONSTRAINT ck_v2_runtime_observation_heads_lifecycle
+                    CHECK (
+                        (state = 'active' AND latest_event_id IS NOT NULL
+                         AND captured_at IS NOT NULL AND freshness_deadline IS NOT NULL
+                         AND health IS NOT NULL AND tombstoned_at IS NULL)
+                        OR (state = 'retired' AND latest_inbox_id IS NULL
+                            AND latest_event_id IS NOT NULL AND captured_at IS NULL
+                            AND freshness_deadline IS NULL AND health IS NULL
+                            AND tombstoned_at IS NOT NULL)
+                    );
+                    ALTER TABLE v2_runtime_observation_inbox
+                    DROP COLUMN IF EXISTS reported_at;
+                    ALTER TABLE v2_runtime_observation_inbox
+                    DROP COLUMN IF EXISTS payload_purged_at;
+                    """
+                )
+            )
+            retired_environment_id = uuid.uuid4()
+            retired_receipt_id = uuid.uuid4()
+            sync_conn.execute(
+                sa.text(
+                    """
+                    INSERT INTO v2_runtime_environment_fences (
+                        environment_id, owner_id, deployment_id, state,
+                        stream_high_water, retirement_id, retirement_receipt_id,
+                        retirement_receipt, retired_at, final_cursor,
+                        final_stream_position, final_session_high_waters
+                    ) VALUES (
+                        :environment_id, :owner_id, 'deployment-retired', 'retired',
+                        7, 'retirement-old-shape', :receipt_id,
+                        CAST(:receipt AS jsonb),
+                        '2026-07-20T00:00:00Z', 'old-final-cursor', 7,
+                        '{"boot-b": 7, "boot-a": 3}'::jsonb
+                    )
+                    """
+                ),
+                {
+                    "environment_id": retired_environment_id,
+                    "owner_id": uuid.uuid4(),
+                    "receipt_id": retired_receipt_id,
+                    "receipt": json.dumps(
+                        {
+                            "retirementReceiptId": str(retired_receipt_id),
+                            "retirementId": "retirement-old-shape",
+                            "environmentId": str(retired_environment_id),
+                            "deploymentId": "deployment-retired",
+                            "retiredAt": "2026-07-20T00:00:00+00:00",
+                            "finalCursor": "old-final-cursor",
+                            "finalSessionHighWaterMarks": {"boot-b": 7, "boot-a": 3},
+                        }
+                    ),
+                },
+            )
+            invalid_key_id = uuid.uuid4()
+            sync_conn.execute(
+                sa.text(
+                    """
+                    INSERT INTO api_keys (
+                        id, user_id, key_hash, key_prefix, label, managed,
+                        scopes, environment_id, runtime_deployment_id
+                    ) VALUES (
+                        :id, :user_id, :key_hash, 'clawdi_invalid', 'invalid-v2', true,
+                        NULL, :environment_id, 'deployment-invalid'
+                    )
+                    """
+                ),
+                {
+                    "id": invalid_key_id,
+                    "user_id": uuid.uuid4(),
+                    "key_hash": uuid.uuid4().hex + uuid.uuid4().hex,
+                    "environment_id": uuid.uuid4(),
+                },
+            )
+            migration.op = Operations(MigrationContext.configure(sync_conn))
+            invalid_upgrade_savepoint = sync_conn.begin_nested()
+            with pytest.raises(
+                sa.exc.DBAPIError,
+                match="invalid deployment-bound runtime credentials",
+            ):
+                migration.upgrade()
+            invalid_upgrade_savepoint.rollback()
+
+            sync_conn.execute(
+                sa.text("DELETE FROM api_keys WHERE id = :id"), {"id": invalid_key_id}
+            )
+            missing_ingest_scope_key_id = uuid.uuid4()
+            sync_conn.execute(
+                sa.text(
+                    """
+                    INSERT INTO api_keys (
+                        id, user_id, key_hash, key_prefix, label, managed,
+                        scopes, environment_id, runtime_deployment_id
+                    ) VALUES (
+                        :id, :user_id, :key_hash, 'clawdi_oldv2', 'old-v2', true,
+                        ARRAY['sessions:write']::varchar[],
+                        :environment_id, 'deployment-old-v2'
+                    )
+                    """
+                ),
+                {
+                    "id": missing_ingest_scope_key_id,
+                    "user_id": uuid.uuid4(),
+                    "key_hash": uuid.uuid4().hex + uuid.uuid4().hex,
+                    "environment_id": uuid.uuid4(),
+                },
+            )
+            missing_scope_upgrade_savepoint = sync_conn.begin_nested()
+            with pytest.raises(
+                sa.exc.DBAPIError,
+                match="invalid deployment-bound runtime credentials",
+            ):
+                migration.upgrade()
+            missing_scope_upgrade_savepoint.rollback()
+            sync_conn.execute(
+                sa.text("DELETE FROM api_keys WHERE id = :id"),
+                {"id": missing_ingest_scope_key_id},
+            )
+
+            mismatched_fence_savepoint = sync_conn.begin_nested()
+            sync_conn.execute(
+                sa.text(
+                    "UPDATE v2_runtime_environment_fences "
+                    "SET final_stream_position = 6 WHERE environment_id = :environment_id"
+                ),
+                {"environment_id": retired_environment_id},
+            )
+            with pytest.raises(
+                sa.exc.DBAPIError,
+                match="final position must match its high-water",
+            ):
+                migration.upgrade()
+            mismatched_fence_savepoint.rollback()
+
+            invalid_head_environment_id = uuid.uuid4()
+            sync_conn.execute(
+                sa.text(
+                    """
+                    INSERT INTO v2_runtime_environment_fences (
+                        environment_id, owner_id, deployment_id
+                    ) VALUES (:environment_id, :owner_id, 'deployment-invalid-head')
+                    """
+                ),
+                {
+                    "environment_id": invalid_head_environment_id,
+                    "owner_id": uuid.uuid4(),
+                },
+            )
+            sync_conn.execute(
+                sa.text(
+                    """
+                    INSERT INTO v2_runtime_observation_heads (
+                        environment_id, boot_session_id, deployment_id,
+                        generation, manifest_etag, apply_receipt_id, boot_nonce,
+                        highest_sequence, latest_inbox_id, latest_stream_position,
+                        latest_event_id, latest_payload_hash, captured_at,
+                        freshness_deadline, health
+                    ) VALUES (
+                        :environment_id, 'invalid-active-head',
+                        'deployment-invalid-head', 1, 'manifest-etag',
+                        'apply-receipt-invalid', 'boot-nonce-invalid', 1,
+                        NULL, 1, 'invalid-active-head-event', :payload_hash,
+                        '2026-07-20T00:00:00Z', '2026-07-20T00:01:00Z', 'ok'
+                    )
+                    """
+                ),
+                {
+                    "environment_id": invalid_head_environment_id,
+                    "payload_hash": "a" * 64,
+                },
+            )
+            invalid_head_upgrade_savepoint = sync_conn.begin_nested()
+            with pytest.raises(
+                sa.exc.DBAPIError,
+                match="active v2 runtime heads require an exact inbox position",
+            ):
+                migration.upgrade()
+            invalid_head_upgrade_savepoint.rollback()
+            sync_conn.execute(
+                sa.text(
+                    "DELETE FROM v2_runtime_observation_heads "
+                    "WHERE environment_id = :environment_id"
+                ),
+                {"environment_id": invalid_head_environment_id},
+            )
+            sync_conn.execute(
+                sa.text(
+                    "DELETE FROM v2_runtime_environment_fences "
+                    "WHERE environment_id = :environment_id"
+                ),
+                {"environment_id": invalid_head_environment_id},
+            )
+
+            legacy_key_id = uuid.uuid4()
+            sync_conn.execute(
+                sa.text(
+                    """
+                    INSERT INTO api_keys (
+                        id, user_id, key_hash, key_prefix, label, managed,
+                        scopes, environment_id, runtime_deployment_id
+                    ) VALUES (
+                        :id, :user_id, :key_hash, 'clawdi_legacy', 'legacy-v1', false,
+                        NULL, NULL, NULL
+                    )
+                    """
+                ),
+                {
+                    "id": legacy_key_id,
+                    "user_id": uuid.uuid4(),
+                    "key_hash": uuid.uuid4().hex + uuid.uuid4().hex,
+                },
+            )
+            migration.upgrade()
+
+            normalized_receipt = sync_conn.scalar(
+                sa.text(
+                    "SELECT retirement_receipt "
+                    "FROM v2_runtime_environment_fences WHERE environment_id = :environment_id"
+                ),
+                {"environment_id": retired_environment_id},
+            )
+            assert normalized_receipt == {
+                "environmentReference": str(retired_environment_id),
+                "expectedDeploymentBinding": "deployment-retired",
+                "retirementId": "retirement-old-shape",
+                "retiredAt": "2026-07-20T00:00:00Z",
+                "finalCursor": "old-final-cursor",
+                "finalSessionHighWaterMarks": [
+                    {"bootSessionId": "boot-a", "sequence": 3},
+                    {"bootSessionId": "boot-b", "sequence": 7},
+                ],
+            }
+
+            checks = {
+                check["name"]: check["sqltext"]
+                for check in inspect(sync_conn).get_check_constraints(
+                    "api_keys",
+                    schema=schema,
+                )
+            }
+            deployment_check = checks["ck_api_keys_runtime_deployment_binding"]
+            assert "cardinality(scopes) > 0" in deployment_check
+            assert "runtime-observations:write" in deployment_check
+            assert "ANY" in deployment_check
+            workload_checks = {
+                check["name"]: check["sqltext"]
+                for check in inspect(sync_conn).get_check_constraints(
+                    "platform_workload_clients",
+                    schema=schema,
+                )
+            }
+            workload_check = workload_checks["ck_platform_workload_clients_allowed_scopes"]
+            assert "platform:runtime-observations:consume" in workload_check
+            assert "platform:runtime-environments:retire" in workload_check
+            assert "platform:runtime-observations:read" not in workload_check
+            fence_checks = {
+                check["name"]: check["sqltext"]
+                for check in inspect(sync_conn).get_check_constraints(
+                    "v2_runtime_environment_fences",
+                    schema=schema,
+                )
+            }
+            assert (
+                "final_stream_position = stream_high_water"
+                in fence_checks["ck_v2_runtime_environment_fences_retirement"]
+            )
+            head_checks = {
+                check["name"]: check["sqltext"]
+                for check in inspect(sync_conn).get_check_constraints(
+                    "v2_runtime_observation_heads",
+                    schema=schema,
+                )
+            }
+            head_lifecycle_check = head_checks["ck_v2_runtime_observation_heads_lifecycle"]
+            assert "latest_inbox_id IS NOT NULL" in head_lifecycle_check
+            assert "latest_stream_position = latest_inbox_id" in head_lifecycle_check
+
+            invalid_retired_fence_savepoint = sync_conn.begin_nested()
+            with pytest.raises(sa.exc.IntegrityError):
+                sync_conn.execute(
+                    sa.text(
+                        """
+                        INSERT INTO v2_runtime_environment_fences (
+                            environment_id, owner_id, deployment_id, state,
+                            stream_high_water, retirement_id, retirement_receipt_id,
+                            retirement_receipt, retired_at, final_cursor,
+                            final_stream_position, final_session_high_waters
+                        ) VALUES (
+                            :environment_id, :owner_id, 'deployment-final-mismatch',
+                            'retired', 7, 'retirement-final-mismatch', :receipt_id,
+                            '{}'::jsonb, '2026-07-20T00:00:00Z', 'final-cursor',
+                            6, '{}'::jsonb
+                        )
+                        """
+                    ),
+                    {
+                        "environment_id": uuid.uuid4(),
+                        "owner_id": uuid.uuid4(),
+                        "receipt_id": uuid.uuid4(),
+                    },
+                )
+            invalid_retired_fence_savepoint.rollback()
+
+            invalid_insert_savepoint = sync_conn.begin_nested()
+            with pytest.raises(sa.exc.IntegrityError):
+                sync_conn.execute(
+                    sa.text(
+                        """
+                        INSERT INTO api_keys (
+                            id, user_id, key_hash, key_prefix, label, managed,
+                            scopes, environment_id, runtime_deployment_id
+                        ) VALUES (
+                            :id, :user_id, :key_hash, 'clawdi_full', 'full-v2', true,
+                            NULL, :environment_id, 'deployment-full'
+                        )
+                        """
+                    ),
+                    {
+                        "id": uuid.uuid4(),
+                        "user_id": uuid.uuid4(),
+                        "key_hash": uuid.uuid4().hex + uuid.uuid4().hex,
+                        "environment_id": uuid.uuid4(),
+                    },
+                )
+            invalid_insert_savepoint.rollback()
+
+            missing_ingest_scope_savepoint = sync_conn.begin_nested()
+            with pytest.raises(sa.exc.IntegrityError):
+                sync_conn.execute(
+                    sa.text(
+                        """
+                        INSERT INTO api_keys (
+                            id, user_id, key_hash, key_prefix, label, managed,
+                            scopes, environment_id, runtime_deployment_id
+                        ) VALUES (
+                            :id, :user_id, :key_hash, 'clawdi_noscope',
+                            'missing-v2-ingest-scope', true,
+                            ARRAY['sessions:write']::varchar[],
+                            :environment_id, 'deployment-missing-ingest-scope'
+                        )
+                        """
+                    ),
+                    {
+                        "id": uuid.uuid4(),
+                        "user_id": uuid.uuid4(),
+                        "key_hash": uuid.uuid4().hex + uuid.uuid4().hex,
+                        "environment_id": uuid.uuid4(),
+                    },
+                )
+            missing_ingest_scope_savepoint.rollback()
+
+            valid_bound_key_id = uuid.uuid4()
+            sync_conn.execute(
+                sa.text(
+                    """
+                    INSERT INTO api_keys (
+                        id, user_id, key_hash, key_prefix, label, managed,
+                        scopes, environment_id, runtime_deployment_id
+                    ) VALUES (
+                        :id, :user_id, :key_hash, 'clawdi_v2ok', 'valid-v2', true,
+                        ARRAY['runtime-observations:write','sessions:write']::varchar[],
+                        :environment_id, 'deployment-valid'
+                    )
+                    """
+                ),
+                {
+                    "id": valid_bound_key_id,
+                    "user_id": uuid.uuid4(),
+                    "key_hash": uuid.uuid4().hex + uuid.uuid4().hex,
+                    "environment_id": uuid.uuid4(),
+                },
+            )
+            assert (
+                sync_conn.scalar(
+                    sa.text("SELECT count(*) FROM api_keys WHERE id = :id"),
+                    {"id": valid_bound_key_id},
+                )
+                == 1
+            )
+
+            inbox_columns = {
+                column["name"]
+                for column in inspect(sync_conn).get_columns(
+                    "v2_runtime_observation_inbox",
+                    schema=schema,
+                )
+            }
+            assert {"reported_at", "payload_purged_at"} <= inbox_columns
+
+            environment_id = uuid.uuid4()
+            owner_id = uuid.uuid4()
+            sync_conn.execute(
+                sa.text(
+                    """
+                    INSERT INTO v2_runtime_environment_fences (
+                        environment_id, owner_id, deployment_id
+                    ) VALUES (:environment_id, :owner_id, 'deployment-immutable')
+                    """
+                ),
+                {"environment_id": environment_id, "owner_id": owner_id},
+            )
+            invalid_update_savepoint = sync_conn.begin_nested()
+            with pytest.raises(sa.exc.DBAPIError, match="binding is immutable"):
+                sync_conn.execute(
+                    sa.text(
+                        "UPDATE v2_runtime_environment_fences "
+                        "SET owner_id = :owner_id WHERE environment_id = :environment_id"
+                    ),
+                    {"environment_id": environment_id, "owner_id": uuid.uuid4()},
+                )
+            invalid_update_savepoint.rollback()
+
+            inbox_id = sync_conn.scalar(
+                sa.text(
+                    """
+                    INSERT INTO v2_runtime_observation_inbox (
+                        environment_id, deployment_id, generation, manifest_etag,
+                        apply_receipt_id, boot_nonce, boot_session_id, sequence,
+                        event_id, reported_at, captured_at, received_at,
+                        freshness_deadline, payload_hash, health, diagnostics
+                    ) VALUES (
+                        :environment_id, 'deployment-immutable', 1, 'manifest-etag',
+                        'apply-receipt-guard', 'boot-nonce-guard', 'guard-session', 1,
+                        'guard-event', '2026-07-20T00:00:00Z',
+                        '2026-07-20T00:00:00Z', '2026-07-20T00:00:01Z',
+                        '2026-07-20T00:01:00Z', :payload_hash, 'ok',
+                        '{"private":"diagnostic"}'::jsonb
+                    ) RETURNING id
+                    """
+                ),
+                {"environment_id": environment_id, "payload_hash": "b" * 64},
+            )
+            assert isinstance(inbox_id, int)
+
+            null_head_reference_savepoint = sync_conn.begin_nested()
+            with pytest.raises(
+                sa.exc.DBAPIError,
+                match="head inbox reference does not match its binding",
+            ):
+                sync_conn.execute(
+                    sa.text(
+                        """
+                        INSERT INTO v2_runtime_observation_heads (
+                            environment_id, boot_session_id, deployment_id,
+                            generation, manifest_etag, apply_receipt_id, boot_nonce,
+                            highest_sequence, latest_inbox_id, latest_stream_position,
+                            latest_event_id, latest_payload_hash, captured_at,
+                            freshness_deadline, health
+                        ) VALUES (
+                            :environment_id, 'null-reference', 'deployment-immutable',
+                            1, 'manifest-etag', 'apply-receipt-guard',
+                            'boot-nonce-guard', 1, NULL, :inbox_id, 'guard-event',
+                            :payload_hash, '2026-07-20T00:00:00Z',
+                            '2026-07-20T00:01:00Z', 'ok'
+                        )
+                        """
+                    ),
+                    {
+                        "environment_id": environment_id,
+                        "inbox_id": inbox_id,
+                        "payload_hash": "b" * 64,
+                    },
+                )
+            null_head_reference_savepoint.rollback()
+
+            mismatched_head_position_savepoint = sync_conn.begin_nested()
+            with pytest.raises(
+                sa.exc.DBAPIError,
+                match="head inbox reference does not match its binding",
+            ):
+                sync_conn.execute(
+                    sa.text(
+                        """
+                        INSERT INTO v2_runtime_observation_heads (
+                            environment_id, boot_session_id, deployment_id,
+                            generation, manifest_etag, apply_receipt_id, boot_nonce,
+                            highest_sequence, latest_inbox_id, latest_stream_position,
+                            latest_event_id, latest_payload_hash, captured_at,
+                            freshness_deadline, health
+                        ) VALUES (
+                            :environment_id, 'guard-session', 'deployment-immutable',
+                            1, 'manifest-etag', 'apply-receipt-guard',
+                            'boot-nonce-guard', 1, :inbox_id, :wrong_position,
+                            'guard-event', :payload_hash, '2026-07-20T00:00:00Z',
+                            '2026-07-20T00:01:00Z', 'ok'
+                        )
+                        """
+                    ),
+                    {
+                        "environment_id": environment_id,
+                        "inbox_id": inbox_id,
+                        "wrong_position": inbox_id + 1,
+                        "payload_hash": "b" * 64,
+                    },
+                )
+            mismatched_head_position_savepoint.rollback()
+
+            sync_conn.execute(
+                sa.text(
+                    """
+                    INSERT INTO v2_runtime_observation_heads (
+                        environment_id, boot_session_id, deployment_id,
+                        generation, manifest_etag, apply_receipt_id, boot_nonce,
+                        highest_sequence, latest_inbox_id, latest_stream_position,
+                        latest_event_id, latest_payload_hash, captured_at,
+                        freshness_deadline, health
+                    ) VALUES (
+                        :environment_id, 'guard-session', 'deployment-immutable',
+                        1, 'manifest-etag', 'apply-receipt-guard',
+                        'boot-nonce-guard', 1, :inbox_id, :inbox_id, 'guard-event',
+                        :payload_hash, '2026-07-20T00:00:00Z',
+                        '2026-07-20T00:01:00Z', 'ok'
+                    )
+                    """
+                ),
+                {
+                    "environment_id": environment_id,
+                    "inbox_id": inbox_id,
+                    "payload_hash": "b" * 64,
+                },
+            )
+            sync_conn.execute(
+                sa.text(
+                    "UPDATE v2_runtime_observation_inbox "
+                    "SET diagnostics = '{}'::jsonb, payload_purged_at = now() "
+                    "WHERE id = :inbox_id"
+                ),
+                {"inbox_id": inbox_id},
+            )
+            assert (
+                sync_conn.scalar(
+                    sa.text(
+                        "SELECT latest_inbox_id FROM v2_runtime_observation_heads "
+                        "WHERE environment_id = :environment_id "
+                        "AND boot_session_id = 'guard-session'"
+                    ),
+                    {"environment_id": environment_id},
+                )
+                == inbox_id
+            )
+
+            migration.downgrade()
+            downgraded_receipt = sync_conn.scalar(
+                sa.text(
+                    "SELECT retirement_receipt "
+                    "FROM v2_runtime_environment_fences WHERE environment_id = :environment_id"
+                ),
+                {"environment_id": retired_environment_id},
+            )
+            assert downgraded_receipt == {
+                "retirementReceiptId": str(retired_receipt_id),
+                "retirementId": "retirement-old-shape",
+                "environmentId": str(retired_environment_id),
+                "deploymentId": "deployment-retired",
+                "retiredAt": "2026-07-20T00:00:00Z",
+                "finalCursor": "old-final-cursor",
+                "finalSessionHighWaterMarks": {"boot-a": 3, "boot-b": 7},
+            }
+            downgraded_inbox_columns = {
+                column["name"]
+                for column in inspect(sync_conn).get_columns(
+                    "v2_runtime_observation_inbox",
+                    schema=schema,
+                )
+            }
+            assert "payload_purged_at" not in downgraded_inbox_columns
+            previous_checks = {
+                check["name"]: check["sqltext"]
+                for check in inspect(sync_conn).get_check_constraints(
+                    "api_keys",
+                    schema=schema,
+                )
+            }
+            assert (
+                "cardinality(scopes)"
+                not in previous_checks["ck_api_keys_runtime_deployment_binding"]
+            )
+            trigger_count = sync_conn.scalar(
+                sa.text(
+                    """
+                    SELECT count(*)
+                    FROM information_schema.triggers
+                    WHERE trigger_schema = :schema
+                      AND trigger_name LIKE 'trg_v2_runtime_%'
+                    """
+                ),
+                {"schema": schema},
+            )
+            assert trigger_count == 0
+            sync_conn.execute(
+                sa.text(
+                    "UPDATE v2_runtime_environment_fences "
+                    "SET owner_id = :owner_id WHERE environment_id = :environment_id"
+                ),
+                {"environment_id": environment_id, "owner_id": uuid.uuid4()},
+            )
+
+            migration.upgrade()
+            migration.downgrade()
+        finally:
+            migration.op = old_op
+            sync_conn.execute(sa.text("SET search_path TO public"))
+            sync_conn.execute(sa.text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+
+    sync_url = engine.url.set(drivername="postgresql+psycopg2")
+    sync_engine = create_engine(sync_url)
+    try:
+        with sync_engine.begin() as connection:
+            run(connection)
+    finally:
+        sync_engine.dispose()

--- a/backend/tests/test_v1_runtime_observation_byte_freeze.py
+++ b/backend/tests/test_v1_runtime_observation_byte_freeze.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).parents[2]
+_BASELINE_PATH = Path(__file__).parent / "fixtures" / "v1_runtime_observation_baseline.json"
+_TOP_LEVEL_SYMBOL = ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef
+
+
+def _sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _symbol_bytes(source: bytes, node: _TOP_LEVEL_SYMBOL) -> bytes:
+    lines = source.splitlines(keepends=True)
+    start_lines = [node.lineno, *(decorator.lineno for decorator in node.decorator_list)]
+    return b"".join(lines[min(start_lines) - 1 : node.end_lineno])
+
+
+def _top_level_symbols(tree: ast.Module) -> dict[str, _TOP_LEVEL_SYMBOL]:
+    return {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def _router_paths(tree: ast.Module) -> list[str]:
+    paths: list[str] = []
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for decorator in node.decorator_list:
+            if not isinstance(decorator, ast.Call) or not decorator.args:
+                continue
+            function = decorator.func
+            path = decorator.args[0]
+            if (
+                isinstance(function, ast.Attribute)
+                and isinstance(function.value, ast.Name)
+                and function.value.id == "router"
+                and isinstance(path, ast.Constant)
+                and isinstance(path.value, str)
+            ):
+                paths.append(path.value)
+    return paths
+
+
+def test_v1_runtime_observation_production_bytes_match_repository_baseline() -> None:
+    """Keep the v1 observation boundary byte-frozen without pinning whole route modules."""
+
+    baseline: dict[str, Any] = json.loads(_BASELINE_PATH.read_text(encoding="utf-8"))
+    for relative_path, contract in baseline["files"].items():
+        source = (_REPO_ROOT / relative_path).read_bytes()
+        whole_file_sha256 = contract.get("whole_file_sha256")
+        if whole_file_sha256 is not None:
+            assert _sha256(source) == whole_file_sha256, relative_path
+
+        if not any(
+            name in contract
+            for name in ("symbols", "forbidden_symbol_prefixes", "forbidden_route_fragments")
+        ):
+            continue
+        tree = ast.parse(source, filename=relative_path)
+        symbols = _top_level_symbols(tree)
+        for symbol, expected_sha256 in contract.get("symbols", {}).items():
+            assert symbol in symbols, f"frozen v1 symbol removed: {relative_path}:{symbol}"
+            assert _sha256(_symbol_bytes(source, symbols[symbol])) == expected_sha256, (
+                f"frozen v1 bytes changed: {relative_path}:{symbol}"
+            )
+
+        for prefix in contract.get("forbidden_symbol_prefixes", []):
+            assert not any(symbol.startswith(prefix) for symbol in symbols), (
+                f"old imperative-v2 schema re-entered v1: {relative_path}:{prefix}"
+            )
+        for fragment in contract.get("forbidden_route_fragments", []):
+            assert not any(fragment in path for path in _router_paths(tree)), (
+                f"old imperative-v2 route re-entered v1: {relative_path}:{fragment}"
+            )

--- a/docs/api-compatibility.md
+++ b/docs/api-compatibility.md
@@ -40,10 +40,16 @@ hidden from public OpenAPI.
 
 Legacy `/api/*` mounts are hidden aliases for clients built before the `/v1`
 prefix migration. `backend/app/main.py` mounts every versioned router once under
-`/v1` and once under `/api` with `include_in_schema=False`.
+`/v1` and, where compatibility requires it, once under `/api` with
+`include_in_schema=False`.
 `backend/tests/test_api_version_alias.py` enforces that every `/v1` route has
-the `/api` alias and that public OpenAPI advertises only `/v1/*` plus
-`/health`.
+the expected `/api` alias.
+
+The declarative runtime observation companion is the one direct clean-v2
+surface. Its provisioning, ingestion, retirement, and consumer operations are
+mounted only under `/v2/runtime/*`; they have no `/v1` or `/api` alias. Public
+OpenAPI therefore advertises `/v1/*`, the explicit `/v2/runtime/*` companion,
+and `/health`.
 
 ## Additive-only contract
 
@@ -75,7 +81,8 @@ workflow in [`backend-development.md`](backend-development.md#generated-api-clie
 and commit the generated file with the schema change.
 
 Because `/api/*` aliases and admin routes are hidden from public OpenAPI, the
-generated client should use `/v1/*` paths only.
+generated client should use `/v1/*` paths for legacy contracts and direct
+`/v2/runtime/*` paths for the runtime observation companion.
 
 ## API change playbook
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -231,6 +231,7 @@ Core tables verified under `backend/app/models/`:
 | `agent_environments` | Stable Agent identities plus refreshable machine metadata, labels, daemon observability, and fixed Agent Project id. |
 | `hosted_runtime_states` | Runtime desired CONFIG state keyed to an Agent identity for hosted surfaces and local mock flows. |
 | `hosted_runtime_config_observations` | Daemon-reported CONFIG convergence with `observed_at`, observed config generation, observed manifest ETag, and validated diagnostics JSONB; distinct from hosted provider COMPUTE observations. |
+| `v2_runtime_environment_fences`, `v2_runtime_observation_inbox`, `v2_runtime_observation_heads`, `v2_runtime_observation_consumer_cursors` | Additive declarative-v2 runtime evidence under direct `/v2/runtime/*` routes, permanent retirement fencing, boot-session high-waters/tombstones, and Hosted workload-bound replay cursors. Retention compacts private inbox payloads in place while permanent identity rows preserve event/session uniqueness. The existing v1 heartbeat and observation table remain unchanged. |
 | `projects`, `project_memberships`, `project_share_links`, `project_invitations`, `share_redeem_attempts` | Project ownership, viewer access, share links, directed invites, and redeem throttling/idempotency. |
 | `agent_project_bindings` | One fixed `primary` Agent Project plus ordered `context` attached Projects. |
 | `sessions`, `session_permissions` | Conversation metadata, object-store body pointer, public/user/email sharing permissions. |

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -3,8 +3,8 @@
 | Field | Value |
 | --- | --- |
 | Status | Public runtime contract |
-| Last updated | 2026-07-12 |
-| Owner | CLI runtime layer |
+| Last updated | 2026-07-20 |
+| Owner | CLI runtime and cloud-api layers |
 
 This document describes the public Clawdi CLI and dashboard contract for managed
 runtime environments. It intentionally avoids deployment-specific topology,
@@ -52,6 +52,82 @@ The public contract does not cover:
 - tenant or billing policy;
 - internal service implementation;
 - image build pipelines or platform rollout details.
+
+## Cloud API Runtime Observation Companion
+
+The declarative v2 runtime adds an observation companion without changing the
+existing v1 daemon heartbeat or observation writer. A deployment-bound runtime
+API key sends credential-authenticated evidence to the direct `/v2` runtime
+router; cloud-api appends evidence and never writes a Hosted deployment status.
+
+Cloud-api reuses these existing runtime primitives:
+
+- `AgentEnvironment.id` as the stable environment identity;
+- managed, environment-bound `ApiKey` authentication with the dedicated
+  `runtime-observations:write` scope for the runtime credential;
+- platform workload OAuth, mutation idempotency, and control-plane audit events
+  for Hosted-facing provisioning and retirement calls;
+- PostgreSQL transactions and `FOR UPDATE` locks for ingestion and retirement
+  serialization.
+
+`POST /v1/agents/{agent_id}/sync-heartbeat` remains the frozen v1 liveness and
+latest-observation transport. It neither accepts strict-v2 identity fields nor
+reads or writes companion tables. Strict-v2 ingestion is
+`POST /v2/runtime/environments/{environment_id}/observations`; it writes only
+the companion inbox, fence high-water, and boot-session head.
+
+Four PostgreSQL tables form the additive companion boundary:
+
+| Table | Contract |
+| --- | --- |
+| `v2_runtime_environment_fences` | Permanent environment/owner/deployment binding, active or retired state, replay floor, and immutable final retirement receipt/high-waters. |
+| `v2_runtime_observation_inbox` | Immutable accepted identities with the five-field boot identity, boot-scoped sequence, global event id, timestamps, payload hash, and health. Private diagnostic payloads may be compacted in place after retention eligibility, while identity and hash columns remain permanently unique. |
+| `v2_runtime_observation_heads` | One immutable boot-session binding with non-regressing accepted sequence, stream position, capture time, and freshness; retirement compacts it to a tombstone. |
+| `v2_runtime_observation_consumer_cursors` | Environment-and-consumer ACK state, replay horizon, and explicit fail-closed expiry/reset boundary used by safe prefix retention. |
+
+Strict-v2 credential provisioning is only available through
+workload-authenticated `POST /v2/runtime/auth/keys`. The legacy admin and
+platform v1 key APIs keep their original wire shape and cannot create a fence
+or deployment-bound credential. The database requires every deployment-bound
+key to be managed, environment-bound, explicitly scoped, to include
+`runtime-observations:write`, and to stay within the runtime scope ceiling.
+
+Hosted-facing `/v2` registration, read, acknowledgement, and reset calls require
+the dedicated `platform:runtime-observations:consume` workload scope. The
+consumer identity is the authenticated workload `client_id`, and immutable
+owner/deployment authority is resolved from the environment fence rather than
+caller-selected request data, so opaque cursors cannot cross consumers or
+environments. Retirement separately requires
+`platform:runtime-environments:retire`; provisioning requires
+`platform:keys:mint`. The legacy global `X-Admin-Key` is not a fallback for any
+of these `/v2` operations.
+
+Ingestion locks the permanent environment fence and rejects a retired binding
+before it inspects or creates a boot-session head. Retirement uses the same
+fence lock, freezes all session high-waters, persists the final cursor and
+receipt, writes one durable control-plane transition audit, and tombstones all
+heads atomically. Replaying the same retirement ID returns the persisted
+receipt; a different ID or deployment binding conflicts. V1 agent deletion and
+key revocation retain their pre-companion behavior and do not consult the v2
+fence. Trusted Hosted controller ordering obtains the retirement receipt before
+using those existing teardown surfaces; the permanent fence itself is never
+deleted.
+
+Retention advances the replay floor only across a contiguous per-environment
+stream prefix. Every row in a normal replay-horizon prefix must be old enough
+and acknowledged by every required active consumer. Hard retention may expire
+lagging consumers explicitly, but it still stops at the first younger stream
+position, preventing a preserved lower id from being silently skipped. Eligible
+rows are compacted in place: private diagnostics are scrubbed and
+`payload_purged_at` records the one-way transition, while event ID,
+environment/session/sequence identity, payload hash, timestamps, and uniqueness
+constraints remain. Replay-floor maintenance may advance monotonically after
+retirement without changing the immutable receipt or final high-water fields.
+When the hard cap expires or advances a consumer boundary, retention writes a
+redacted system audit in the same transaction as the cursor and compaction.
+Active heads must reference their exact inbox stream position, and a retired
+fence's final position must equal its frozen stream high-water at the database
+boundary.
 
 ## Core Architecture
 

--- a/packages/cli/src/runtime/heartbeat-observation.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import type { components } from "@clawdi/shared/api";
 import { z } from "zod";
 import { PRIVATE_DIR_MODE, PRIVATE_FILE_MODE, writePrivateFileAtomic } from "../lib/private-file";
 import {
@@ -9,7 +10,7 @@ import {
 	runtimeAppliedApplyIdentity,
 } from "./applied-state";
 import { runtimeApplyIdentitySchema } from "./apply-identity";
-import { type HostedRuntimeObserved, readHostedRuntimeObserved } from "./observed";
+import { readHostedRuntimeObserved } from "./observed";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 
 const positiveSafeIntegerSchema = z.number().int().positive().max(Number.MAX_SAFE_INTEGER);
@@ -85,14 +86,7 @@ const observedSupervisorSchema = z
 	})
 	.strict();
 
-export type HostedRuntimeObservedEvent = HostedRuntimeObserved & {
-	applyReceiptId: string;
-	bootNonce: string;
-	bootSessionId: string;
-	sequence: number;
-	eventId: string;
-	capturedAt: string;
-};
+export type HostedRuntimeObservedEvent = components["schemas"]["RuntimeObservationEventV2"];
 
 const hostedRuntimeObservedEventSchema: z.ZodType<HostedRuntimeObservedEvent> = z
 	.object({
@@ -109,7 +103,7 @@ const hostedRuntimeObservedEventSchema: z.ZodType<HostedRuntimeObservedEvent> = 
 		providers: z.record(z.string(), z.record(z.string(), z.unknown())).nullable().optional(),
 		error: z.string().nullable().optional(),
 		convergeError: z.string().nullable().optional(),
-		truncated: z.boolean().nullable().optional(),
+		truncated: z.literal(false).nullable().optional(),
 		applyReceiptId: z.string().min(16).max(128),
 		bootNonce: z.string().min(16).max(128),
 		bootSessionId: z.string().min(1).max(128),
@@ -231,7 +225,7 @@ export class HostedRuntimeHeartbeatSession {
 			appliedState: this.capturedAppliedState,
 		});
 		if (!snapshot) return null;
-		const event: HostedRuntimeObservedEvent = {
+		const event = hostedRuntimeObservedEventSchema.parse({
 			...snapshot,
 			applyReceiptId: this.currentBootIdentity.applyReceiptId,
 			bootNonce: this.currentBootIdentity.bootNonce,
@@ -239,7 +233,7 @@ export class HostedRuntimeHeartbeatSession {
 			sequence: this.state.nextSequence,
 			eventId: nonEmptyId(this.createId(), "runtime heartbeat event ID"),
 			capturedAt,
-		};
+		});
 		const payloadJson = serializeObservedEvent(event);
 		const pending = {
 			payloadJson,

--- a/packages/cli/src/runtime/observed-v2.test.ts
+++ b/packages/cli/src/runtime/observed-v2.test.ts
@@ -29,6 +29,9 @@ describe("hosted runtime observed v2", () => {
 				appliedAt: "2026-07-13T06:00:00.000Z",
 				instanceId: "hri_observed",
 				etag: '"bundle-applied"',
+				manifestETag: '"frozen-companion-manifest"',
+				applyReceiptId: "apply-receipt-observed-v2",
+				bootNonce: "boot-nonce-observed-v2-01",
 				sourceRevision: "a".repeat(64),
 				generation: 9,
 				contentIdentity: {

--- a/packages/cli/src/runtime/observed.ts
+++ b/packages/cli/src/runtime/observed.ts
@@ -43,7 +43,10 @@ export function readHostedRuntimeObserved(
 	const providers = readProviderObserved(paths);
 	const appliedAuthority = appliedState
 		? {
-				etag: appliedState.manifestETag ?? appliedState.etag,
+				etag:
+					options.appliedState === undefined
+						? appliedState.etag
+						: (appliedState.manifestETag ?? appliedState.etag),
 				sourceRevision: appliedState.sourceRevision,
 				generation: appliedState.generation,
 				instanceId: appliedState.instanceId,

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -151,9 +151,6 @@ interface EngineOpts {
 }
 
 export async function runSyncEngine(opts: EngineOpts): Promise<void> {
-	const runtimeHeartbeatSession = new HostedRuntimeHeartbeatSession({
-		environmentId: opts.environmentId,
-	});
 	// Pass the engine's abort signal so any in-flight HTTP call
 	// (heartbeat, project refresh, skill download, etc.) unwinds
 	// immediately when SSE auth fails or shutdown is requested,
@@ -821,10 +818,11 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 			},
 			triggerAuthFailureAbort,
 		),
-		heartbeatLoop(opts, api, queue, runtimeHeartbeatSession, opts.abort, () => ({
+		heartbeatLoop(opts, api, queue, opts.abort, () => ({
 			last_revision_seen: lastSeenRevision,
 			last_sync_error: lastSyncError,
 		})),
+		runtimeObservationLoop(opts, api, opts.abort),
 		refreshDefaultProjectIdLoop(opts.abort),
 		// Safety-net periodic sessions rescan. After a 4xx drop we
 		// clear inFlightSessionHash, but the watcher only fires on
@@ -2249,7 +2247,6 @@ async function heartbeatLoop(
 	opts: EngineOpts,
 	api: ApiClient,
 	queue: RetryQueue,
-	runtimeHeartbeatSession: HostedRuntimeHeartbeatSession,
 	abort: AbortSignal,
 	snapshot: () => { last_revision_seen: number | null; last_sync_error: string | null },
 ): Promise<void> {
@@ -2257,10 +2254,9 @@ async function heartbeatLoop(
 	const send = async () => {
 		const fields = snapshot();
 		const dropped = queue.drainDroppedDelta();
+		const runtimeObserved = readHostedRuntimeObserved();
 		try {
-			const bufferedRuntimeObserved = runtimeHeartbeatSession.nextEvent();
-			const runtimeObserved = bufferedRuntimeObserved?.event ?? readHostedRuntimeObserved();
-			const response = await api.POST("/v1/agents/{agent_id}/sync-heartbeat", {
+			await api.POST("/v1/agents/{agent_id}/sync-heartbeat", {
 				params: { path: { agent_id: opts.environmentId } },
 				body: {
 					// Peak since boot rather than sampled current
@@ -2277,25 +2273,6 @@ async function heartbeatLoop(
 					...(runtimeObserved ? { runtime_observed: runtimeObserved } : {}),
 				},
 			});
-			if (bufferedRuntimeObserved && isSafelyTerminalRuntimeObservationFailure(response)) {
-				if (!runtimeHeartbeatSession.retireTerminallyStale(bufferedRuntimeObserved.event.eventId)) {
-					throw new Error("terminally stale runtime heartbeat did not match the buffered event");
-				}
-				queue.restoreDroppedDelta(dropped);
-				heartbeatFailureStreak = 0;
-				log.warn("engine.runtime_observation_retired_stale", {
-					event_id: bufferedRuntimeObserved.event.eventId,
-					captured_at: bufferedRuntimeObserved.event.capturedAt,
-				});
-				return;
-			}
-			unwrap(response);
-			if (
-				bufferedRuntimeObserved &&
-				!runtimeHeartbeatSession.acknowledge(bufferedRuntimeObserved.event.eventId)
-			) {
-				throw new Error("runtime heartbeat acknowledgement did not match the buffered event");
-			}
 			heartbeatFailureStreak = 0;
 			await touchHealthFile(opts.adapter.agentType);
 		} catch (e) {
@@ -2328,6 +2305,55 @@ async function heartbeatLoop(
 		// don't all heartbeat in the same wall-clock second. The
 		// upper bound stays inside the dashboard's 90s freshness
 		// window after the eager first beat.
+		await sleep(heartbeatDelayMs(), abort);
+		if (abort.aborted) return;
+		await send();
+	}
+}
+
+/** Send durable strict-v2 observations independently of legacy liveness. */
+async function runtimeObservationLoop(
+	opts: EngineOpts,
+	api: ApiClient,
+	abort: AbortSignal,
+): Promise<void> {
+	let runtimeHeartbeatSession: HostedRuntimeHeartbeatSession | null = null;
+	const send = async () => {
+		let buffered: ReturnType<HostedRuntimeHeartbeatSession["nextEvent"]> = null;
+		try {
+			runtimeHeartbeatSession ??= new HostedRuntimeHeartbeatSession({
+				environmentId: opts.environmentId,
+			});
+			buffered = runtimeHeartbeatSession.nextEvent();
+			if (!buffered) return;
+			const response = await api.POST("/v2/runtime/environments/{environment_id}/observations", {
+				params: { path: { environment_id: opts.environmentId } },
+				body: buffered.event,
+			});
+			if (isSafelyTerminalRuntimeObservationFailure(response)) {
+				if (!runtimeHeartbeatSession.retireTerminallyStale(buffered.event.eventId)) {
+					throw new Error("terminally stale runtime observation did not match buffered event");
+				}
+				log.warn("engine.runtime_observation_retired_stale", {
+					event_id: buffered.event.eventId,
+					captured_at: buffered.event.capturedAt,
+				});
+				return;
+			}
+			unwrap(response);
+			if (!runtimeHeartbeatSession.acknowledge(buffered.event.eventId)) {
+				throw new Error("runtime observation acknowledgement did not match buffered event");
+			}
+		} catch (error) {
+			log.info("engine.runtime_observation_failed", {
+				error: toErrorMessage(error),
+				...(buffered ? { event_id: buffered.event.eventId } : {}),
+			});
+		}
+	};
+
+	await send();
+	while (!abort.aborted) {
 		await sleep(heartbeatDelayMs(), abort);
 		if (abort.aborted) return;
 		await send();

--- a/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
+++ b/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { request } from "node:http";
 import { tmpdir } from "node:os";
@@ -24,6 +25,8 @@ interface Fixture {
 	home: string;
 	clawdiHome: string;
 	stateDir: string;
+	serviceStateDir: string;
+	runDir: string;
 	codexHome: string;
 }
 
@@ -70,7 +73,16 @@ beforeAll(() => {
 			}
 
 			if (req.method === "POST" && url.pathname === `/v1/agents/${ENV_ID}/sync-heartbeat`) {
-				return json({ ok: true });
+				return new Response(null, { status: 204 });
+			}
+
+			if (
+				req.method === "POST" &&
+				url.pathname === `/v2/runtime/environments/${ENV_ID}/observations`
+			) {
+				// A v2 transport failure must not poison the independent v1
+				// liveness heartbeat or prevent its health-file update.
+				return json({ detail: "temporary v2 failure" }, 503);
 			}
 
 			return json({ detail: "not found" }, 404);
@@ -153,6 +165,29 @@ if (process.platform !== "win32") {
 				expect(apiCalls.some((call) => call.path === `/v1/agents/${ENV_ID}/sync-heartbeat`)).toBe(
 					true,
 				);
+				expect(
+					apiCalls.some((call) => call.path === `/v2/runtime/environments/${ENV_ID}/observations`),
+				).toBe(true);
+				const heartbeat = apiCalls.find(
+					(call) => call.path === `/v1/agents/${ENV_ID}/sync-heartbeat`,
+				);
+				const observation = apiCalls.find(
+					(call) => call.path === `/v2/runtime/environments/${ENV_ID}/observations`,
+				);
+				if (!isRecord(heartbeat?.body) || !isRecord(observation?.body)) {
+					throw new Error("expected separate v1 heartbeat and v2 observation bodies");
+				}
+				const heartbeatBody = heartbeat.body;
+				if (!isRecord(heartbeatBody.runtime_observed)) {
+					throw new Error("expected legacy runtime observation in v1 heartbeat");
+				}
+				const legacyObserved = heartbeatBody.runtime_observed;
+				expect(legacyObserved.bootSessionId).toBeUndefined();
+				expect(legacyObserved.eventId).toBeUndefined();
+				const observationBody = observation.body;
+				expect(observationBody.bootSessionId).toBeString();
+				expect(observationBody.eventId).toBeString();
+				expect(existsSync(join(fixture.stateDir, "codex", "health"))).toBe(true);
 				expect(apiCalls.every((call) => call.auth === `Bearer ${API_KEY}`)).toBe(true);
 			} catch (error) {
 				failure = error;
@@ -175,6 +210,62 @@ if (process.platform !== "win32") {
 				);
 			}
 		}, 20_000);
+
+		it("keeps v1 heartbeat healthy when v2 durable state initialization fails", async () => {
+			const fixture = createFixture();
+			const heartbeatRoot = join(fixture.serviceStateDir, "heartbeat");
+			const environmentKey = createHash("sha256").update(ENV_ID).digest("hex");
+			mkdirSync(heartbeatRoot, { recursive: true });
+			writeFileSync(join(heartbeatRoot, `${environmentKey}.json`), "{corrupt-v2-state\n");
+			const daemon = startDaemon(fixture);
+			const daemonStdout = new Response(daemon.stdout).text();
+			const daemonStderr = new Response(daemon.stderr).text();
+			let failure: unknown;
+			let daemonStdoutText = "";
+			let daemonStderrText = "";
+
+			try {
+				await waitFor(
+					() =>
+						apiCalls.some((call) => call.path === `/v1/agents/${ENV_ID}/sync-heartbeat`) &&
+						existsSync(join(fixture.stateDir, "codex", "health")),
+				);
+				const heartbeat = apiCalls.find(
+					(call) => call.path === `/v1/agents/${ENV_ID}/sync-heartbeat`,
+				);
+				if (!isRecord(heartbeat?.body) || !isRecord(heartbeat.body.runtime_observed)) {
+					throw new Error("expected frozen v1 heartbeat observation body");
+				}
+				expect(heartbeat.body.runtime_observed.bootSessionId).toBeUndefined();
+				expect(heartbeat.body.runtime_observed.eventId).toBeUndefined();
+				expect(
+					apiCalls.some((call) => call.path === `/v2/runtime/environments/${ENV_ID}/observations`),
+				).toBe(false);
+				const exited = await Promise.race([
+					daemon.exited.then(() => true),
+					sleep(100).then(() => false),
+				]);
+				expect(exited).toBe(false);
+			} catch (error) {
+				failure = error;
+			} finally {
+				await stopDaemon(daemon);
+				[daemonStdoutText, daemonStderrText] = await Promise.all([daemonStdout, daemonStderr]);
+				rmSync(fixture.root, { recursive: true, force: true });
+			}
+			if (failure) {
+				throw new Error(
+					[
+						failure instanceof Error ? failure.message : String(failure),
+						"daemon stdout:",
+						daemonStdoutText.trim() || "(empty)",
+						"daemon stderr:",
+						daemonStderrText.trim() || "(empty)",
+					].join("\n"),
+				);
+			}
+			expect(daemonStderrText).toContain("engine.runtime_observation_failed");
+		}, 20_000);
 	});
 }
 
@@ -183,6 +274,8 @@ function createFixture(): Fixture {
 	const home = join(root, "home");
 	const clawdiHome = join(root, "clawdi-state");
 	const stateDir = join(root, "serve-state");
+	const serviceStateDir = join(root, "service-state");
+	const runDir = join(root, "run");
 	const codexHome = join(home, ".codex");
 	mkdirSync(join(clawdiHome, "environments"), { recursive: true });
 	mkdirSync(join(codexHome, "skills"), { recursive: true });
@@ -191,7 +284,28 @@ function createFixture(): Fixture {
 		join(clawdiHome, "environments", "codex.json"),
 		`${JSON.stringify({ id: ENV_ID })}\n`,
 	);
-	return { root, home, clawdiHome, stateDir, codexHome };
+	mkdirSync(join(serviceStateDir, "status"), { recursive: true });
+	writeFileSync(
+		join(serviceStateDir, "status", "runtime-applied.json"),
+		`${JSON.stringify({
+			schemaVersion: "clawdi.runtimeAppliedState.v2",
+			appliedAt: "2026-07-20T00:00:00.000Z",
+			instanceId: "daemon-rpc-runtime",
+			etag: '"transport-manifest"',
+			manifestETag: '"frozen-manifest"',
+			applyReceiptId: "apply-receipt-daemon-rpc",
+			bootNonce: "boot-nonce-daemon-rpc-01",
+			sourceRevision: "a".repeat(64),
+			generation: 1,
+			contentIdentity: {
+				sourcePath: "https://runtime.test/v1/runtime/manifest",
+				sha256: "b".repeat(64),
+			},
+			providerIds: ["managed"],
+			projectedProviderIds: { codex: ["managed"] },
+		})}\n`,
+	);
+	return { root, home, clawdiHome, stateDir, serviceStateDir, runDir, codexHome };
 }
 
 function startDaemon(fixture: Fixture): ReturnType<typeof Bun.spawn> {
@@ -232,6 +346,10 @@ function cliEnv(fixture: Fixture): Record<string, string> {
 		CLAWDI_NO_AUTO_UPDATE: "1",
 		CLAWDI_NO_UPDATE_CHECK: "1",
 		CLAWDI_SERVE_MODE: "container",
+		CLAWDI_RUNTIME_MODE: "hosted",
+		CLAWDI_RUNTIME_HOME: fixture.home,
+		CLAWDI_RUN_DIR: fixture.runDir,
+		CLAWDI_SERVICE_STATE_DIR: fixture.serviceStateDir,
 		CLAWDI_STATE_DIR: fixture.stateDir,
 		CODEX_HOME: fixture.codexHome,
 		CI: "true",

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -832,10 +832,6 @@ export interface paths {
          * @description Daemon writes its liveness state here every cycle. Extreme-
          *     light endpoint: validate ownership / env-id binding, update a
          *     handful of columns, commit. No heavy queries.
-         *
-         *     Strict-v2 companion identity is an authenticated guest report from the
-         *     per-deployment runtime credential. It is readiness authority for this
-         *     protocol, but it is not attestation-bound instance identity.
          */
         post: operations["sync_heartbeat_v1_agents__agent_id__sync_heartbeat_post"];
         delete?: never;
@@ -1798,97 +1794,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/v1/platform/agents/{agent_id}/runtime-environment/retire": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Platform Retire Runtime Environment */
-        post: operations["platform_retire_runtime_environment_v1_platform_agents__agent_id__runtime_environment_retire_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/platform/agents/{agent_id}/runtime-observation-consumers/register": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Platform Register Runtime Observation Consumer */
-        post: operations["platform_register_runtime_observation_consumer_v1_platform_agents__agent_id__runtime_observation_consumers_register_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/platform/agents/{agent_id}/runtime-observations/read": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Platform Read Runtime Observations
-         * @description Read credential-authenticated guest reports for the Hosted controller.
-         *
-         *     The readiness authority is the authenticated guest report from the
-         *     per-deployment runtime credential. It is not attestation-bound instance identity.
-         */
-        post: operations["platform_read_runtime_observations_v1_platform_agents__agent_id__runtime_observations_read_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/platform/agents/{agent_id}/runtime-observation-consumers/ack": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Platform Ack Runtime Observation Consumer */
-        post: operations["platform_ack_runtime_observation_consumer_v1_platform_agents__agent_id__runtime_observation_consumers_ack_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/platform/agents/{agent_id}/runtime-observation-consumers/reset": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Platform Reset Runtime Observation Consumer */
-        post: operations["platform_reset_runtime_observation_consumer_v1_platform_agents__agent_id__runtime_observation_consumers_reset_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/v1/platform/auth/keys": {
         parameters: {
             query?: never;
@@ -2658,6 +2563,125 @@ export interface paths {
         post?: never;
         /** Delete Project Binding */
         delete: operations["delete_project_binding_v1_agents__agent_id__project_bindings__binding_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/runtime/auth/keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create Runtime Deployment Key */
+        post: operations["create_runtime_deployment_key_v2_runtime_auth_keys_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/runtime/environments/{environment_id}/observations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Ingest Runtime Observation Event */
+        post: operations["ingest_runtime_observation_event_v2_runtime_environments__environment_id__observations_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/runtime/environments/{environment_id}/retire": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Retire Runtime Environment Endpoint */
+        post: operations["retire_runtime_environment_endpoint_v2_runtime_environments__environment_id__retire_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/runtime/environments/{environment_id}/observation-consumers/register": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Register Runtime Observation Consumer Endpoint */
+        post: operations["register_runtime_observation_consumer_endpoint_v2_runtime_environments__environment_id__observation_consumers_register_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/runtime/environments/{environment_id}/observations/read": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Read Runtime Observations Endpoint */
+        post: operations["read_runtime_observations_endpoint_v2_runtime_environments__environment_id__observations_read_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/runtime/environments/{environment_id}/observation-consumers/ack": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Acknowledge Runtime Observation Consumer Endpoint */
+        post: operations["acknowledge_runtime_observation_consumer_endpoint_v2_runtime_environments__environment_id__observation_consumers_ack_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v2/runtime/environments/{environment_id}/observation-consumers/reset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reset Runtime Observation Consumer Endpoint */
+        post: operations["reset_runtime_observation_consumer_endpoint_v2_runtime_environments__environment_id__observation_consumers_reset_post"];
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -4762,18 +4786,6 @@ export interface components {
             convergeError?: string | null;
             /** Truncated */
             truncated?: boolean | null;
-            /** Applyreceiptid */
-            applyReceiptId?: string | null;
-            /** Bootnonce */
-            bootNonce?: string | null;
-            /** Bootsessionid */
-            bootSessionId?: string | null;
-            /** Sequence */
-            sequence?: number | null;
-            /** Eventid */
-            eventId?: string | null;
-            /** Capturedat */
-            capturedAt?: string | null;
         };
         /** HostedRuntimePrimaryModel */
         HostedRuntimePrimaryModel: {
@@ -5088,8 +5100,6 @@ export interface components {
              * Format: uuid
              */
             environment_id: string;
-            /** Deployment Id */
-            deployment_id: string;
             /** Scopes */
             scopes?: string[];
         };
@@ -5128,67 +5138,6 @@ export interface components {
             kind: "clerk" | "partner_tenant";
             /** Ref */
             ref: string;
-        };
-        /** PlatformRuntimeApplyIdentity */
-        PlatformRuntimeApplyIdentity: {
-            /** Generation */
-            generation: number;
-            /** Manifestetag */
-            manifestETag: string;
-            /** Applyreceiptid */
-            applyReceiptId: string;
-            /** Bootnonce */
-            bootNonce: string;
-        };
-        /** PlatformRuntimeEnvironmentRetire */
-        PlatformRuntimeEnvironmentRetire: {
-            owner: components["schemas"]["PlatformOwner"];
-            /** Expected Deployment Id */
-            expected_deployment_id: string;
-            /** Retirement Id */
-            retirement_id: string;
-        };
-        /** PlatformRuntimeObservationConsumerAck */
-        PlatformRuntimeObservationConsumerAck: {
-            owner: components["schemas"]["PlatformOwner"];
-            /** Deployment Id */
-            deployment_id: string;
-            /** Consumer Id */
-            consumer_id: string;
-            /** Cursor */
-            cursor: string;
-        };
-        /** PlatformRuntimeObservationConsumerRegister */
-        PlatformRuntimeObservationConsumerRegister: {
-            owner: components["schemas"]["PlatformOwner"];
-            /** Deployment Id */
-            deployment_id: string;
-            /** Consumer Id */
-            consumer_id: string;
-        };
-        /** PlatformRuntimeObservationConsumerReset */
-        PlatformRuntimeObservationConsumerReset: {
-            owner: components["schemas"]["PlatformOwner"];
-            /** Deployment Id */
-            deployment_id: string;
-            /** Consumer Id */
-            consumer_id: string;
-        };
-        /** PlatformRuntimeObservationRead */
-        PlatformRuntimeObservationRead: {
-            owner: components["schemas"]["PlatformOwner"];
-            /** Deployment Id */
-            deployment_id: string;
-            /** Consumer Id */
-            consumer_id: string;
-            expectedApplyIdentity: components["schemas"]["PlatformRuntimeApplyIdentity"];
-            /** Aftercursor */
-            afterCursor: string;
-            /**
-             * Limit
-             * @default 100
-             */
-            limit: number;
         };
         /** PlatformRuntimeStateResponse */
         PlatformRuntimeStateResponse: {
@@ -5396,16 +5345,47 @@ export interface components {
             /** Owner Avatar Url */
             owner_avatar_url: string | null;
         };
-        /** RuntimeEnvironmentRetirementReceipt */
-        RuntimeEnvironmentRetirementReceipt: {
-            /** Retirementreceiptid */
-            retirementReceiptId: string;
-            /** Retirementid */
-            retirementId: string;
-            /** Environmentid */
+        /** RuntimeApplyIdentityRequest */
+        RuntimeApplyIdentityRequest: {
+            /** Generation */
+            generation: number;
+            /** Manifestetag */
+            manifestETag: string;
+            /** Applyreceiptid */
+            applyReceiptId: string;
+            /** Bootnonce */
+            bootNonce: string;
+        };
+        /** RuntimeDeploymentKeyCreate */
+        RuntimeDeploymentKeyCreate: {
+            owner: components["schemas"]["PlatformOwner"];
+            /** Label */
+            label: string;
+            /**
+             * Environmentid
+             * Format: uuid
+             */
             environmentId: string;
             /** Deploymentid */
             deploymentId: string;
+            /** Scopes */
+            scopes?: string[];
+        };
+        /** RuntimeEnvironmentRetireRequest */
+        RuntimeEnvironmentRetireRequest: {
+            /** Expecteddeploymentbinding */
+            expectedDeploymentBinding: string;
+            /** Retirementid */
+            retirementId: string;
+        };
+        /** RuntimeEnvironmentRetirementReceipt */
+        RuntimeEnvironmentRetirementReceipt: {
+            /** Environmentreference */
+            environmentReference: string;
+            /** Expecteddeploymentbinding */
+            expectedDeploymentBinding: string;
+            /** Retirementid */
+            retirementId: string;
             /**
              * Retiredat
              * Format: date-time
@@ -5414,9 +5394,7 @@ export interface components {
             /** Finalcursor */
             finalCursor: string;
             /** Finalsessionhighwatermarks */
-            finalSessionHighWaterMarks: {
-                [key: string]: number;
-            };
+            finalSessionHighWaterMarks: components["schemas"]["RuntimeSessionHighWaterMark"][];
         };
         /** RuntimeObservationApplyIdentityResponse */
         RuntimeObservationApplyIdentityResponse: {
@@ -5429,6 +5407,13 @@ export interface components {
             /** Bootnonce */
             bootNonce: string;
         };
+        /** RuntimeObservationConsumerAckRequest */
+        RuntimeObservationConsumerAckRequest: {
+            /** Cursor */
+            cursor: string;
+        };
+        /** RuntimeObservationConsumerRequest */
+        RuntimeObservationConsumerRequest: Record<string, never>;
         /** RuntimeObservationConsumerResetResponse */
         RuntimeObservationConsumerResetResponse: {
             /** Environmentid */
@@ -5490,6 +5475,64 @@ export interface components {
             health: "ok" | "error" | "unknown";
             diagnostics: components["schemas"]["JsonValue"];
         };
+        /**
+         * RuntimeObservationEventV2
+         * @description Strict v2 companion event; deliberately separate from the frozen v1 wire model.
+         */
+        RuntimeObservationEventV2: {
+            /**
+             * Schemaversion
+             * @constant
+             */
+            schemaVersion: "clawdi.hostedRuntimeObserved.v2";
+            /**
+             * Reportedat
+             * Format: date-time
+             */
+            reportedAt: string;
+            /**
+             * Runtimemode
+             * @constant
+             */
+            runtimeMode: "hosted";
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "ok" | "error" | "unknown";
+            /** Activecliversion */
+            activeCliVersion: string | null;
+            applied: components["schemas"]["HostedRuntimeObservedAppliedV2"];
+            boot: components["schemas"]["HostedRuntimeObservedBootV1"] | null;
+            cli: components["schemas"]["HostedRuntimeObservedCliV1"] | null;
+            systemd?: components["schemas"]["HostedRuntimeObservedSystemdV1"] | null;
+            supervisor?: components["schemas"]["HostedRuntimeObservedSupervisorV1"] | null;
+            /** Providers */
+            providers?: {
+                [key: string]: components["schemas"]["HostedRuntimeObservedProviderPayload"];
+            } | null;
+            /** Error */
+            error?: string | null;
+            /** Convergeerror */
+            convergeError?: string | null;
+            /** Truncated */
+            truncated?: false | null;
+            /** Applyreceiptid */
+            applyReceiptId: string;
+            /** Bootnonce */
+            bootNonce: string;
+            /** Bootsessionid */
+            bootSessionId: string;
+            /** Sequence */
+            sequence: number;
+            /** Eventid */
+            eventId: string;
+            /**
+             * Capturedat
+             * Format: date-time
+             */
+            capturedAt: string;
+        };
         /** RuntimeObservationEvidenceReference */
         RuntimeObservationEvidenceReference: {
             /** Eventid */
@@ -5535,6 +5578,29 @@ export interface components {
             bootNonce: string;
             /** Bootsessionid */
             bootSessionId: string;
+        };
+        /** RuntimeObservationIngestResponse */
+        RuntimeObservationIngestResponse: {
+            /** Eventid */
+            eventId: string;
+            /** Streamposition */
+            streamPosition: number;
+            /**
+             * Outcome
+             * @enum {string}
+             */
+            outcome: "accepted_head_created" | "accepted_head_advanced" | "accepted_non_advance_sequence" | "accepted_non_advance_captured_at" | "duplicate_replay";
+        };
+        /** RuntimeObservationReadRequest */
+        RuntimeObservationReadRequest: {
+            expectedApplyIdentity: components["schemas"]["RuntimeApplyIdentityRequest"];
+            /** Aftercursor */
+            afterCursor: string;
+            /**
+             * Limit
+             * @default 100
+             */
+            limit: number;
         };
         /** RuntimeObservationReadResponse */
         RuntimeObservationReadResponse: {
@@ -5708,6 +5774,13 @@ export interface components {
             counts: components["schemas"]["RuntimeObservedSummaryCountsResponse"];
             /** Items */
             items: components["schemas"]["RuntimeObservedSummaryItemResponse"][];
+        };
+        /** RuntimeSessionHighWaterMark */
+        RuntimeSessionHighWaterMark: {
+            /** Bootsessionid */
+            bootSessionId: string;
+            /** Sequence */
+            sequence: number;
         };
         /** SearchHit */
         SearchHit: {
@@ -10285,197 +10358,6 @@ export interface operations {
             };
         };
     };
-    platform_retire_runtime_environment_v1_platform_agents__agent_id__runtime_environment_retire_post: {
-        parameters: {
-            query?: never;
-            header: {
-                "Idempotency-Key": string;
-                "X-Admin-Key"?: string | null;
-                Authorization?: string | null;
-            };
-            path: {
-                agent_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PlatformRuntimeEnvironmentRetire"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RuntimeEnvironmentRetirementReceipt"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    platform_register_runtime_observation_consumer_v1_platform_agents__agent_id__runtime_observation_consumers_register_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                "X-Admin-Key"?: string | null;
-                Authorization?: string | null;
-            };
-            path: {
-                agent_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PlatformRuntimeObservationConsumerRegister"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RuntimeObservationConsumerResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    platform_read_runtime_observations_v1_platform_agents__agent_id__runtime_observations_read_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                "X-Admin-Key"?: string | null;
-                Authorization?: string | null;
-            };
-            path: {
-                agent_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PlatformRuntimeObservationRead"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RuntimeObservationReadResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    platform_ack_runtime_observation_consumer_v1_platform_agents__agent_id__runtime_observation_consumers_ack_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                "X-Admin-Key"?: string | null;
-                Authorization?: string | null;
-            };
-            path: {
-                agent_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PlatformRuntimeObservationConsumerAck"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RuntimeObservationConsumerResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    platform_reset_runtime_observation_consumer_v1_platform_agents__agent_id__runtime_observation_consumers_reset_post: {
-        parameters: {
-            query?: never;
-            header?: {
-                "X-Admin-Key"?: string | null;
-                Authorization?: string | null;
-            };
-            path: {
-                agent_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PlatformRuntimeObservationConsumerReset"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RuntimeObservationConsumerResetResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     platform_mint_api_key_v1_platform_auth_keys_post: {
         parameters: {
             query?: never;
@@ -11923,6 +11805,269 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["BindingDeleteResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_runtime_deployment_key_v2_runtime_auth_keys_post: {
+        parameters: {
+            query?: never;
+            header: {
+                "Idempotency-Key": string;
+                "X-Admin-Key"?: string | null;
+                Authorization?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RuntimeDeploymentKeyCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiKeyCreated"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    ingest_runtime_observation_event_v2_runtime_environments__environment_id__observations_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                environment_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RuntimeObservationEventV2"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RuntimeObservationIngestResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    retire_runtime_environment_endpoint_v2_runtime_environments__environment_id__retire_post: {
+        parameters: {
+            query?: never;
+            header: {
+                "Idempotency-Key": string;
+                "X-Admin-Key"?: string | null;
+                Authorization?: string | null;
+            };
+            path: {
+                environment_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RuntimeEnvironmentRetireRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RuntimeEnvironmentRetirementReceipt"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    register_runtime_observation_consumer_endpoint_v2_runtime_environments__environment_id__observation_consumers_register_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-Admin-Key"?: string | null;
+                Authorization?: string | null;
+            };
+            path: {
+                environment_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RuntimeObservationConsumerRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RuntimeObservationConsumerResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    read_runtime_observations_endpoint_v2_runtime_environments__environment_id__observations_read_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-Admin-Key"?: string | null;
+                Authorization?: string | null;
+            };
+            path: {
+                environment_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RuntimeObservationReadRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RuntimeObservationReadResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    acknowledge_runtime_observation_consumer_endpoint_v2_runtime_environments__environment_id__observation_consumers_ack_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-Admin-Key"?: string | null;
+                Authorization?: string | null;
+            };
+            path: {
+                environment_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RuntimeObservationConsumerAckRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RuntimeObservationConsumerResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    reset_runtime_observation_consumer_endpoint_v2_runtime_environments__environment_id__observation_consumers_reset_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-Admin-Key"?: string | null;
+                Authorization?: string | null;
+            };
+            path: {
+                environment_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RuntimeObservationConsumerRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RuntimeObservationConsumerResetResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
## Why

The authoritative declarative control-plane design revision 16 requires cloud-api to own durable runtime observation evidence, retirement fencing, and Hosted-facing cursor state without projecting Hosted deployment status. PR #429 established the four-table companion, but its rev8 implementation crossed the frozen v1 boundary and left security, retention, audit, and database invariants that revision 16 now makes explicit.

This PR finishes the clean-v2 companion as an additive, direct `/v2` contract. Existing v1 heartbeat, platform, and admin contracts remain on their pre-#429 behavior and wire shapes.

## Authoritative design mapping

| Rev16 requirement | Implementation |
| --- | --- |
| Permanent environment/deployment fence provisioned before credentials | `v2_runtime_environment_fences` retains immutable binding and active/retired lifecycle; `POST /v2/runtime/auth/keys` locks the existing `AgentEnvironment`, provisions the fence, then calls the existing non-committing key mint in one transaction. Ingestion never creates or reactivates a fence. |
| Append-only boot-scoped observation evidence | `v2_runtime_observation_inbox` stores the five-field apply/boot identity, sequence, global event ID, capture/report/receive times, payload hash, health, and private diagnostics with permanent uniqueness for `event_id` and `(environment_id, boot_session_id, sequence)`. |
| Immutable session binding and monotonic head | `v2_runtime_observation_heads` binds one boot session to one apply tuple. Unique lower-sequence or regressing-`capturedAt` history remains accepted inbox evidence but is durably audited as non-advancing; rebind and event identity conflicts are rejected. Active heads require an exact inbox reference and `latest_stream_position = latest_inbox_id`; retired heads are immutable tombstones. |
| Environment-scoped D17 retirement fence | Ingestion and retirement lock the same environment fence. Retirement atomically freezes stream/session high-waters, allocates `finalCursor`, writes the immutable six-field Hosted receipt, tombstones every head, and persists the first transition audit. A delayed new session is rejected if retirement commits first. |
| Idempotent, crash-replayable retirement | The same `retirementId` returns the persisted receipt byte/JSON-identically; a conflicting ID or deployment binding fails. A new HTTP idempotency key for the same domain retirement records a replay audit without a second transition audit. |
| Narrow Hosted cursor contract | Workload-only consume routes derive `consumer_id` from authenticated `PlatformMutationAuth.client_id`; request bodies contain no caller-selected owner, deployment, or consumer identity. Opaque cursors bind environment, consumer, epoch, and stream position and fail closed with persisted reset metadata plus durable audit. |
| Safe retention | Retention advances only a contiguous same-environment eligible prefix. It compacts diagnostics in place and records `payload_purged_at`, permanently retaining event/session identities and uniqueness. Hard-cap expiry advances consumer boundaries and writes a system/retention audit in the same transaction; retired receipt/final fields remain immutable while replay-floor maintenance may advance. |
| Additive v2 boundary | Every companion HTTP operation is mounted directly under `/v2/runtime/*`, with no `/v1` or hidden `/api` alias. V2 ingestion uses the dedicated `runtime-observations:write` deployment-key scope; consume/retire require dedicated workload scopes and reject legacy `X-Admin-Key` fallback. |

The Hosted retirement port is represented exactly as:

- request: `environmentReference` from the path, `expectedDeploymentBinding`, `retirementId`
- receipt: `environmentReference`, `expectedDeploymentBinding`, `retirementId`, `retiredAt`, `finalCursor`, `finalSessionHighWaterMarks[]`

The internal receipt UUID remains typed fence/audit evidence and is not added to the public receipt.

## Existing cloud-api primitives reused

This stays within established cloud-api boundaries:

- API-key authentication and the existing `AuthContext` are reused for per-deployment runtime ingestion: [`backend/app/core/auth.py`](https://github.com/Clawdi-AI/clawdi/blob/7f4eb913d885a9adb6ea18982ade2ae4369a3e1b/backend/app/core/auth.py).
- Key issuance reuses [`mint_api_key(..., commit=False)`](https://github.com/Clawdi-AI/clawdi/blob/7f4eb913d885a9adb6ea18982ade2ae4369a3e1b/backend/app/services/api_key.py); the fence and narrow deployment credential commit together.
- Hosted authentication reuses the existing workload OAuth/JWT/JWKS machinery in [`platform_workload_auth.py`](https://github.com/Clawdi-AI/clawdi/blob/7f4eb913d885a9adb6ea18982ade2ae4369a3e1b/backend/app/services/platform_workload_auth.py), adding a workload-only dependency rather than broadening legacy admin auth.
- Crash replay reuses the existing platform idempotency locking, request fingerprint, and stored-response helpers in [`platform_contract.py`](https://github.com/Clawdi-AI/clawdi/blob/7f4eb913d885a9adb6ea18982ade2ae4369a3e1b/backend/app/services/platform_contract.py).
- Durable outcomes reuse [`ControlPlaneAuditEvent` and `record_control_plane_audit`](https://github.com/Clawdi-AI/clawdi/blob/7f4eb913d885a9adb6ea18982ade2ae4369a3e1b/backend/app/services/audit.py). Audits include actor, resource, time, and redacted outcome metadata; they exclude diagnostics, raw credentials, opaque cursors, secrets, and internal exception text.
- Cursor reads retain the existing repeatable-read runtime-observation session primitive so snapshot high-water and page contents cannot gap.

## Migration and database boundary

Corrective Alembic revision `a6d2f4c8b1e7` follows the landed `4c8f2a1d7e9b` migration rather than rewriting it. It:

- fails upgrade closed if an existing deployment-bound key is full-access, outside the canonical scope ceiling, or lacks `runtime-observations:write`;
- preserves all v1 keys because `runtime_deployment_id IS NULL` remains outside the v2 constraint;
- adds permanent inbox identity with one-way payload compaction;
- enforces immutable fence/head/cursor bindings and non-regressing high-waters;
- enforces active head inbox-reference integrity and retired `final_stream_position = stream_high_water`;
- updates workload scope constraints and normalizes already-retired receipts to the rev16 public shape;
- supports a populated downgrade to the landed #429 boundary, with explicit fail-closed handling where a new retire-only workload scope cannot be represented.

## V1 compatibility evidence

The following production files are byte-identical to the pre-#429 parent `704f81b4`:

- `backend/app/routes/{platform,admin,sessions}.py`
- `backend/app/schemas/{platform,admin,runtime_observed}.py`
- `backend/app/services/agent_environments.py`

Therefore:

- `/v1/agents/{id}/sync-heartbeat` keeps legacy validation, 204 empty response, liveness updates, and `HostedRuntimeConfigObservation` writes;
- v1 heartbeat creates no v2 fence, inbox, head, or v2 audit side effect;
- strict companion fields remain invalid on the v1 schema;
- v2 ingestion writes only companion tables and does not update v1 liveness or the v1 observation row;
- legacy admin key mint has no deployment companion opt-in and never provisions a v2 fence;
- no v1 deletion/revocation route is fence-gated.

The CLI keeps the pre-#429 v1 heartbeat body/loop and sends durable v2 evidence independently. Corrupt or unwritable v2 durable state and v2 transport/buffering failures cannot terminate or suppress the v1 heartbeat/health loop; durable-before-send is preserved.

## Rejection audit coverage

Strict-v2 ingestion now durably audits every explicit service-level protocol/fence rejection through the existing `ControlPlaneAuditEvent` and `record_control_plane_audit` path:

- `runtime_observation_captured_at_in_future`
- `runtime_observation_captured_at_too_old`
- `runtime_environment_fence_missing`
- `runtime_environment_retired`
- `runtime_observation_credential_mismatch` when the authenticated credential deployment differs from the fence binding
- `runtime_observation_identity_conflict`
- `runtime_observation_event_conflict`

The early route-auth boundary also durably audits its existing `runtime_observation_credential_mismatch` response for each collapsed rejection reason: `runtime_credential_required`, `managed_credential_required`, `scope_missing`, `environment_binding_mismatch`, and `deployment_binding_missing`. Existing non-advancing accepted outcomes (`accepted_non_advance_sequence` and `accepted_non_advance_captured_at`) remain audited.

Every ingest audit carries a non-null `principal_id`, requested environment, explicit deployment (null when unavailable), boot session id, sequence, event id, and outcome. For an authenticated user without an API key, `principal_id` is the authenticated user id while the original `runtime_principal_id` compatibility field remains null; runtime-key attempts use the key id for both fields. Route-auth audits additionally carry only the fixed rejection-reason enum. Tests prove that raw credentials, opaque cursors, private diagnostics, payloads, protocol messages, and internal error text do not enter audit details.

Rejection handling still rolls back the rejected ingestion transaction before committing the standalone audit event. Successful ingestion, the shared fence lock, retirement atomicity, status/error bodies, D27 fail-closed behavior, and scope ceilings are unchanged.

## V1 production byte-freeze gate

No literal v1 byte-freeze CI gate existed. This PR now adds a repository-owned pre-v2 SHA256 baseline sourced from `704f81b4af51012ee4ca5dbc6a7ceab7c073fe62` and a normal pytest gate; the test records that provenance but never reads git history.

The gate is intentionally scoped to the owner's v1 runtime-observation boundary rather than hashing the large route modules wholesale:

- runtime-observed list/detail/health/heartbeat symbols in `routes/sessions.py`;
- the v1 platform API-key mint handler in `routes/platform.py`;
- `PlatformApiKeyCreate` in `schemas/platform.py`;
- the complete v1 runtime-observed wire schema in `schemas/runtime_observed.py`.

It also fails if the removed imperative-v2 runtime-observation routes or schema families re-enter the v1 platform surface. Unrelated session/platform code remains free to evolve, and the gate does not freeze deleted imperative-v2 implementation.

## Verification

All database tests used a newly migrated throwaway local `pgvector/pgvector:pg16` PostgreSQL container only.

- `cd backend && uv run pytest -q tests/test_runtime_observation_companion.py tests/test_runtime_observation_hardening_migration.py tests/test_v1_runtime_observation_byte_freeze.py` — **26 passed**
- `cd backend && uv run pytest -q` — **1302 passed, 7 skipped**
- `cd backend && uv run ruff check .` — **passed**
- `cd backend && uv run ruff format --check .` — **265 files already formatted**
- `cd backend && uv run python -m compileall -q app scripts tests alembic` — **passed**
- `cd backend && uv run alembic heads` — **`a6d2f4c8b1e7 (head)`**
- `cd backend && uv run python scripts/check_generated_api.py` — **passed; generated client unchanged**
- final review follow-up on `d431b55e`: the same focused PostgreSQL set — **26 passed**; Ruff check and format-check for all touched Python files — **passed**

Focused PostgreSQL assertions enumerate the complete service rejection set and the early authenticated-user/managed/scope/environment/deployment auth set, verify durable audit field values, preserve response contracts, confirm rejected events never enter the inbox, and prove secrets/private diagnostics/cursors/internal messages remain absent from audit JSON.

## Rollout boundary

Code and PR only. No live/production clusters, infrastructure, tenant data, or Hosted repository were changed. This PR remains Draft and must not be merged until the deliberate rollout is approved.
