### PR TITLE
fix(v2): data-plane companion uses first-party X-Admin-Key (revert workload OAuth deviation)

### DIFF
--- a/backend/app/routes/runtime_observation_v2.py
+++ b/backend/app/routes/runtime_observation_v2.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.auth import AuthContext, get_auth
+from app.core.auth import AuthContext, get_auth, require_admin_api_key
 from app.core.database import get_runtime_observation_session, get_session
 from app.models.runtime_observation import V2RuntimeEnvironmentFence
 from app.models.user import PRINCIPAL_KIND_CLERK, PRINCIPAL_KIND_PARTNER_TENANT, User
@@ -38,10 +38,6 @@ from app.services.platform_contract import (
     read_platform_replay,
     store_platform_response,
 )
-from app.services.platform_workload_auth import (
-    PlatformMutationAuth,
-    require_platform_workload_auth,
-)
 from app.services.runtime_observation import (
     RuntimeApplyIdentity,
     RuntimeObservationProtocolError,
@@ -67,6 +63,8 @@ _NON_ADVANCING_OUTCOMES = frozenset(
         "accepted_non_advance_captured_at",
     }
 )
+
+_HOSTED_RUNTIME_CONSUMER_ID = "hosted-controller"
 
 
 async def require_runtime_observation_writer(
@@ -184,16 +182,9 @@ def _replay_response(replay: PlatformReplay) -> JSONResponse:
     return _CanonicalJSONResponse(status_code=replay.status_code, content=replay.body)
 
 
-def _workload_identity(auth: PlatformMutationAuth) -> tuple[str, str]:
-    if auth.kind != "workload" or auth.client_id is None or auth.credential_id is None:
-        raise RuntimeError("v2 runtime control-plane routes require workload identity")
-    return auth.client_id, str(auth.credential_id)
-
-
-def _record_workload_audit(
+def _record_admin_audit(
     db: AsyncSession,
     *,
-    auth: PlatformMutationAuth,
     action: str,
     target_user_id: UUID,
     environment_id: UUID,
@@ -201,10 +192,9 @@ def _record_workload_audit(
     outcome: str,
     details: dict[str, Any] | None = None,
 ) -> None:
-    client_id, principal_id = _workload_identity(auth)
     record_control_plane_audit(
         db,
-        actor_type="platform_workload",
+        actor_type="admin",
         target_user_id=target_user_id,
         source="api.v2.runtime",
         action=action,
@@ -214,8 +204,7 @@ def _record_workload_audit(
         # environment UUID remains in resource_id and safe details.
         environment_id=None,
         details={
-            "workload_client_id": client_id,
-            "workload_principal_id": principal_id,
+            "auth_method": "x_admin_key",
             "environment_id": str(environment_id),
             "deployment_id": deployment_id,
             "outcome": outcome,
@@ -267,16 +256,14 @@ def _record_runtime_ingest_audit(
 def _record_cursor_expiry_audit(
     db: AsyncSession,
     *,
-    auth: PlatformMutationAuth,
     target_user_id: UUID,
     environment_id: UUID,
     deployment_id: str,
     operation: str,
 ) -> None:
-    client_id, principal_id = _workload_identity(auth)
     record_control_plane_audit(
         db,
-        actor_type="platform_workload",
+        actor_type="admin",
         target_user_id=target_user_id,
         source="api.v2.runtime",
         action="runtime_observation.cursor_expired",
@@ -284,9 +271,8 @@ def _record_cursor_expiry_audit(
         resource_id=str(environment_id),
         environment_id=None,
         details={
-            "workload_client_id": client_id,
-            "workload_principal_id": principal_id,
-            "consumer_id": client_id,
+            "auth_method": "x_admin_key",
+            "consumer_id": _HOSTED_RUNTIME_CONSUMER_ID,
             "environment_id": str(environment_id),
             "deployment_id": deployment_id,
             "operation": operation,
@@ -323,7 +309,7 @@ async def _load_fence_binding(
 async def create_runtime_deployment_key(
     body: RuntimeDeploymentKeyCreate,
     idempotency_key: IdempotencyKey,
-    auth: PlatformMutationAuth = Depends(require_platform_workload_auth("platform:keys:mint")),
+    _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> JSONResponse:
     owner = await _resolve_owner(db, body.owner)
@@ -365,9 +351,8 @@ async def create_runtime_deployment_key(
             raw_key=minted.raw_key,
         )
         response_body = _canonical_response_body(response)
-        _record_workload_audit(
+        _record_admin_audit(
             db,
-            auth=auth,
             action="runtime_environment.provision",
             target_user_id=owner.id,
             environment_id=body.environment_id,
@@ -467,9 +452,7 @@ async def retire_runtime_environment_endpoint(
     environment_id: UUID,
     body: RuntimeEnvironmentRetireRequest,
     idempotency_key: IdempotencyKey,
-    auth: PlatformMutationAuth = Depends(
-        require_platform_workload_auth("platform:runtime-environments:retire")
-    ),
+    _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> JSONResponse:
     binding = await _load_fence_binding(db, environment_id=environment_id)
@@ -498,9 +481,8 @@ async def retire_runtime_environment_endpoint(
         receipt = RuntimeEnvironmentRetirementReceipt.model_validate(result.receipt)
         response_body = _canonical_response_body(receipt)
         if result.transitioned:
-            _record_workload_audit(
+            _record_admin_audit(
                 db,
-                auth=auth,
                 action="runtime_environment.retire",
                 target_user_id=binding_owner_id,
                 environment_id=environment_id,
@@ -518,9 +500,8 @@ async def retire_runtime_environment_endpoint(
                 },
             )
         else:
-            _record_workload_audit(
+            _record_admin_audit(
                 db,
-                auth=auth,
                 action="runtime_environment.retire_replay",
                 target_user_id=binding_owner_id,
                 environment_id=environment_id,
@@ -546,9 +527,8 @@ async def retire_runtime_environment_endpoint(
     except RuntimeObservationProtocolError as exc:
         await db.rollback()
         try:
-            _record_workload_audit(
+            _record_admin_audit(
                 db,
-                auth=auth,
                 action="runtime_environment.retire",
                 target_user_id=binding_owner_id,
                 environment_id=environment_id,
@@ -571,7 +551,6 @@ async def _commit_cursor_expiry_or_rollback(
     db: AsyncSession,
     *,
     exc: RuntimeObservationProtocolError,
-    auth: PlatformMutationAuth,
     owner_id: UUID,
     environment_id: UUID,
     deployment_id: str,
@@ -583,7 +562,6 @@ async def _commit_cursor_expiry_or_rollback(
     try:
         _record_cursor_expiry_audit(
             db,
-            auth=auth,
             target_user_id=owner_id,
             environment_id=environment_id,
             deployment_id=deployment_id,
@@ -603,27 +581,23 @@ async def _commit_cursor_expiry_or_rollback(
 async def register_runtime_observation_consumer_endpoint(
     environment_id: UUID,
     body: RuntimeObservationConsumerRequest,
-    auth: PlatformMutationAuth = Depends(
-        require_platform_workload_auth("platform:runtime-observations:consume")
-    ),
+    _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> RuntimeObservationConsumerResponse:
     binding = await _load_fence_binding(db, environment_id=environment_id)
-    client_id, _ = _workload_identity(auth)
     try:
         values = await register_runtime_observation_consumer(
             db,
             environment_id=environment_id,
             owner_id=binding.owner_id,
             deployment_id=binding.deployment_id,
-            consumer_id=client_id,
+            consumer_id=_HOSTED_RUNTIME_CONSUMER_ID,
         )
         await db.commit()
     except RuntimeObservationProtocolError as exc:
         await _commit_cursor_expiry_or_rollback(
             db,
             exc=exc,
-            auth=auth,
             owner_id=binding.owner_id,
             environment_id=environment_id,
             deployment_id=binding.deployment_id,
@@ -639,13 +613,10 @@ async def register_runtime_observation_consumer_endpoint(
 async def read_runtime_observations_endpoint(
     environment_id: UUID,
     body: RuntimeObservationReadRequest,
-    auth: PlatformMutationAuth = Depends(
-        require_platform_workload_auth("platform:runtime-observations:consume")
-    ),
+    _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_runtime_observation_session),
 ) -> RuntimeObservationReadResponse:
     binding = await _load_fence_binding(db, environment_id=environment_id)
-    client_id, _ = _workload_identity(auth)
     expected = body.expected_apply_identity
     try:
         values = await read_runtime_observations(
@@ -653,7 +624,7 @@ async def read_runtime_observations_endpoint(
             environment_id=environment_id,
             owner_id=binding.owner_id,
             deployment_id=binding.deployment_id,
-            consumer_id=client_id,
+            consumer_id=_HOSTED_RUNTIME_CONSUMER_ID,
             expected_apply_identity=RuntimeApplyIdentity(
                 generation=expected.generation,
                 manifest_etag=expected.manifest_etag,
@@ -667,7 +638,6 @@ async def read_runtime_observations_endpoint(
         await _commit_cursor_expiry_or_rollback(
             db,
             exc=exc,
-            auth=auth,
             owner_id=binding.owner_id,
             environment_id=environment_id,
             deployment_id=binding.deployment_id,
@@ -683,20 +653,17 @@ async def read_runtime_observations_endpoint(
 async def acknowledge_runtime_observation_consumer_endpoint(
     environment_id: UUID,
     body: RuntimeObservationConsumerAckRequest,
-    auth: PlatformMutationAuth = Depends(
-        require_platform_workload_auth("platform:runtime-observations:consume")
-    ),
+    _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> RuntimeObservationConsumerResponse:
     binding = await _load_fence_binding(db, environment_id=environment_id)
-    client_id, _ = _workload_identity(auth)
     try:
         values = await acknowledge_runtime_observation_cursor(
             db,
             environment_id=environment_id,
             owner_id=binding.owner_id,
             deployment_id=binding.deployment_id,
-            consumer_id=client_id,
+            consumer_id=_HOSTED_RUNTIME_CONSUMER_ID,
             opaque_cursor=body.cursor,
         )
         await db.commit()
@@ -704,7 +671,6 @@ async def acknowledge_runtime_observation_consumer_endpoint(
         await _commit_cursor_expiry_or_rollback(
             db,
             exc=exc,
-            auth=auth,
             owner_id=binding.owner_id,
             environment_id=environment_id,
             deployment_id=binding.deployment_id,
@@ -720,20 +686,17 @@ async def acknowledge_runtime_observation_consumer_endpoint(
 async def reset_runtime_observation_consumer_endpoint(
     environment_id: UUID,
     body: RuntimeObservationConsumerRequest,
-    auth: PlatformMutationAuth = Depends(
-        require_platform_workload_auth("platform:runtime-observations:consume")
-    ),
+    _: None = Depends(require_admin_api_key),
     db: AsyncSession = Depends(get_session),
 ) -> RuntimeObservationConsumerResetResponse:
     binding = await _load_fence_binding(db, environment_id=environment_id)
-    client_id, _ = _workload_identity(auth)
     try:
         values = await reset_runtime_observation_consumer(
             db,
             environment_id=environment_id,
             owner_id=binding.owner_id,
             deployment_id=binding.deployment_id,
-            consumer_id=client_id,
+            consumer_id=_HOSTED_RUNTIME_CONSUMER_ID,
         )
         await db.commit()
     except RuntimeObservationProtocolError as exc:

--- a/backend/tests/test_platform_workload_oauth.py
+++ b/backend/tests/test_platform_workload_oauth.py
@@ -223,39 +223,6 @@ async def _access_token(harness: WorkloadHarness, scope: str) -> str:
     return response.json()["access_token"]
 
 
-async def _add_workload_client(
-    harness: WorkloadHarness,
-    db_session,
-    *,
-    allowed_scopes: list[str],
-) -> WorkloadHarness:
-    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    client_id = f"hosted-workload-{uuid.uuid4().hex}"
-    client_kid = f"client-{uuid.uuid4().hex}"
-    credential = PlatformWorkloadClient(
-        client_id=client_id,
-        assertion_kid=client_kid,
-        assertion_algorithm="RS256",
-        public_jwk=_public_jwk(private_key, kid=client_kid),
-        status=PLATFORM_WORKLOAD_CLIENT_ACTIVE,
-        allowed_scopes=allowed_scopes,
-        token_version=1,
-    )
-    db_session.add(credential)
-    await db_session.commit()
-    await db_session.refresh(credential)
-    return WorkloadHarness(
-        client=harness.client,
-        credential=credential,
-        client_id=client_id,
-        client_kid=client_kid,
-        client_private_key=private_key,
-        signing_private_key=harness.signing_private_key,
-        signing_key=harness.signing_key,
-        resolver=harness.resolver,
-    )
-
-
 def _workload_headers(token: str, idempotency_key: str) -> dict[str, str]:
     return {
         "Authorization": f"Bearer {token}",
@@ -587,7 +554,7 @@ async def test_oauth_storage_failures_are_503(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("operation", ["provision", "retire", "register", "read", "ack", "reset"])
-async def test_companion_routes_reject_legacy_admin_fallback(
+async def test_companion_routes_require_and_accept_admin_key(
     workload_harness,
     seed_user,
     db_session,
@@ -600,9 +567,9 @@ async def test_companion_routes_reject_legacy_admin_fallback(
         db_session,
         user_id=seed_user.id,
         machine_id=f"admin-fallback-{uuid.uuid4().hex}",
-        machine_name="admin-fallback",
+        machine_name="admin-key-companion",
     )
-    deployment_id = f"deployment-admin-forbidden-{uuid.uuid4().hex}"
+    deployment_id = f"deployment-admin-key-{uuid.uuid4().hex}"
     if operation != "provision":
         await provision_runtime_environment_fence(
             db_session,
@@ -614,7 +581,7 @@ async def test_companion_routes_reject_legacy_admin_fallback(
 
     path = "/v2/runtime/auth/keys"
     payload: dict[str, Any] = {
-        "label": "forbidden-admin-runtime",
+        "label": "admin-key-runtime",
         "environmentId": str(environment.id),
         "deploymentId": deployment_id,
     }
@@ -622,7 +589,7 @@ async def test_companion_routes_reject_legacy_admin_fallback(
         path = f"/v2/runtime/environments/{environment.id}/retire"
         payload = {
             "expectedDeploymentBinding": deployment_id,
-            "retirementId": "retirement-admin-forbidden",
+            "retirementId": f"retirement-admin-key-{environment.id}",
         }
     elif operation == "register":
         path = f"/v2/runtime/environments/{environment.id}/observation-consumers/register"
@@ -645,14 +612,79 @@ async def test_companion_routes_reject_legacy_admin_fallback(
         path = f"/v2/runtime/environments/{environment.id}/observation-consumers/reset"
         payload = {}
 
-    response = await workload_harness.client.post(
+    request_body = {"owner": _owner(seed_user), **payload} if operation == "provision" else payload
+    idempotency_key = f"admin-auth-{uuid.uuid4()}"
+    missing = await workload_harness.client.post(
         path,
-        headers={"X-Admin-Key": _ADMIN_KEY, "Idempotency-Key": f"admin-{uuid.uuid4()}"},
-        json={"owner": _owner(seed_user), **payload} if operation == "provision" else payload,
+        headers={"Idempotency-Key": idempotency_key},
+        json=request_body,
+    )
+    invalid = await workload_harness.client.post(
+        path,
+        headers={"X-Admin-Key": "invalid", "Idempotency-Key": idempotency_key},
+        json=request_body,
+    )
+    workload_token = await _access_token(workload_harness, "platform:keys:mint")
+    oauth_only = await workload_harness.client.post(
+        path,
+        headers={
+            "Authorization": f"Bearer {workload_token}",
+            "Idempotency-Key": idempotency_key,
+        },
+        json=request_body,
     )
 
-    assert response.status_code == 401, response.text
-    assert response.json() == {"detail": "platform workload credentials are required"}
+    assert missing.status_code == invalid.status_code == oauth_only.status_code == 401
+    assert missing.json() == invalid.json() == oauth_only.json() == {"detail": "invalid admin auth"}
+
+    settings.platform_legacy_admin_auth_enabled = False
+    admin_headers = {
+        "X-Admin-Key": _ADMIN_KEY,
+        "Idempotency-Key": idempotency_key,
+    }
+    valid_body = request_body
+    if operation in {"read", "ack", "reset"}:
+        registered = await workload_harness.client.post(
+            f"/v2/runtime/environments/{environment.id}/observation-consumers/register",
+            headers={"X-Admin-Key": _ADMIN_KEY},
+            json={},
+        )
+        assert registered.status_code == 200, registered.text
+        if operation == "read":
+            path = f"/v2/runtime/environments/{environment.id}/observations/read"
+            payload = {
+                "expectedApplyIdentity": {
+                    "generation": 1,
+                    "manifestETag": '"manifest-etag-0001"',
+                    "applyReceiptId": "apply-receipt-00000001",
+                    "bootNonce": "boot-nonce-0000000001",
+                },
+                "afterCursor": registered.json()["cursor"],
+            }
+        elif operation == "ack":
+            path = f"/v2/runtime/environments/{environment.id}/observation-consumers/ack"
+            payload = {"cursor": registered.json()["cursor"]}
+        else:
+            expired = await workload_harness.client.post(
+                f"/v2/runtime/environments/{environment.id}/observations/read",
+                headers={"X-Admin-Key": _ADMIN_KEY},
+                json={
+                    "expectedApplyIdentity": {
+                        "generation": 1,
+                        "manifestETag": '"manifest-etag-0001"',
+                        "applyReceiptId": "apply-receipt-00000001",
+                        "bootNonce": "boot-nonce-0000000001",
+                    },
+                    "afterCursor": "clawdi-ro-v1.invalid",
+                },
+            )
+            assert expired.status_code == 410, expired.text
+            path = f"/v2/runtime/environments/{environment.id}/observation-consumers/reset"
+            payload = {}
+        valid_body = payload
+    response = await workload_harness.client.post(path, headers=admin_headers, json=valid_body)
+
+    assert response.status_code == 200, response.text
 
 
 @pytest.mark.asyncio
@@ -686,10 +718,12 @@ async def test_v2_provision_precedes_narrow_key_and_retirement_replays_exact_rec
         return await original_mint(db, **kwargs)
 
     monkeypatch.setattr(v2_routes, "mint_api_key", assert_fence_precedes_key)
-    mint_token = await _access_token(workload_harness, "platform:keys:mint")
     minted = await workload_harness.client.post(
         "/v2/runtime/auth/keys",
-        headers=_workload_headers(mint_token, f"mint-{environment_id}"),
+        headers={
+            "X-Admin-Key": _ADMIN_KEY,
+            "Idempotency-Key": f"mint-{environment_id}",
+        },
         json={
             "owner": _owner(seed_user),
             "label": "strict-v2-runtime",
@@ -703,17 +737,28 @@ async def test_v2_provision_precedes_narrow_key_and_retirement_replays_exact_rec
     assert key.runtime_deployment_id == deployment_id
     assert key.scopes == list(RUNTIME_DEPLOYMENT_KEY_SCOPES)
     assert "runtime-observations:write" in key.scopes
+    provision_audit = (
+        await db_session.execute(
+            select(ControlPlaneAuditEvent).where(
+                ControlPlaneAuditEvent.source == "api.v2.runtime",
+                ControlPlaneAuditEvent.action == "runtime_environment.provision",
+                ControlPlaneAuditEvent.resource_id == str(environment_id),
+            )
+        )
+    ).scalar_one()
+    assert provision_audit.actor_type == "admin"
+    assert provision_audit.details["auth_method"] == "x_admin_key"
+    assert "workload_client_id" not in provision_audit.details
 
-    retire_token = await _access_token(
-        workload_harness,
-        "platform:runtime-environments:retire",
-    )
     path = f"/v2/runtime/environments/{environment_id}/retire"
     body = {
         "expectedDeploymentBinding": deployment_id,
         "retirementId": f"retirement-{environment_id}",
     }
-    first_headers = _workload_headers(retire_token, f"retire-first-{environment_id}")
+    first_headers = {
+        "X-Admin-Key": _ADMIN_KEY,
+        "Idempotency-Key": f"retire-first-{environment_id}",
+    }
     original_record_audit = v2_routes.record_control_plane_audit
 
     def fail_transition_audit(db, **kwargs):
@@ -740,7 +785,10 @@ async def test_v2_provision_precedes_narrow_key_and_retirement_replays_exact_rec
     )
     domain_replay = await workload_harness.client.post(
         path,
-        headers=_workload_headers(retire_token, f"retire-domain-replay-{environment_id}"),
+        headers={
+            "X-Admin-Key": _ADMIN_KEY,
+            "Idempotency-Key": f"retire-domain-replay-{environment_id}",
+        },
         json=body,
     )
 
@@ -790,29 +838,50 @@ async def test_v2_provision_precedes_narrow_key_and_retirement_replays_exact_rec
     assert len(transition_audits) == 1
     assert len(replay_audits) == 1
     transition = transition_audits[0]
-    assert transition.actor_type == "platform_workload"
-    assert transition.details["workload_client_id"] == workload_harness.client_id
+    assert transition.actor_type == "admin"
+    assert transition.details["auth_method"] == "x_admin_key"
+    assert "workload_client_id" not in transition.details
+    assert "workload_principal_id" not in transition.details
     assert transition.details["retirement_receipt_id"] == str(fence.retirement_receipt_id)
     assert transition.details["previous_state"] == "active"
     assert transition.details["new_state"] == "retired"
 
     conflicting = await workload_harness.client.post(
         path,
-        headers=_workload_headers(retire_token, f"retire-conflict-{environment_id}"),
+        headers={
+            "X-Admin-Key": _ADMIN_KEY,
+            "Idempotency-Key": f"retire-conflict-{environment_id}",
+        },
         json={**body, "retirementId": f"other-{environment_id}"},
     )
     assert conflicting.status_code == 409, conflicting.text
     assert conflicting.json()["detail"]["code"] == "runtime_environment_retirement_conflict"
+    rejection_audit = (
+        await db_session.execute(
+            select(ControlPlaneAuditEvent).where(
+                ControlPlaneAuditEvent.source == "api.v2.runtime",
+                ControlPlaneAuditEvent.action == "runtime_environment.retire",
+                ControlPlaneAuditEvent.resource_id == str(environment_id),
+                ControlPlaneAuditEvent.details["outcome"].astext
+                == "runtime_environment_retirement_conflict",
+            )
+        )
+    ).scalar_one()
+    assert rejection_audit.actor_type == "admin"
+    assert rejection_audit.details["auth_method"] == "x_admin_key"
 
 
 @pytest.mark.asyncio
-async def test_observation_consumer_identity_is_bound_to_workload_principal(
+async def test_observation_consumer_identity_is_bound_to_admin_actor(
     workload_harness,
     seed_user,
     db_session,
 ):
     from app.models.runtime_observation import V2RuntimeObservationConsumerCursor
-    from app.services.runtime_observation import provision_runtime_environment_fence
+    from app.services.runtime_observation import (
+        provision_runtime_environment_fence,
+        register_runtime_observation_consumer,
+    )
     from tests.conftest import create_env_with_project
 
     environment = await create_env_with_project(
@@ -830,20 +899,21 @@ async def test_observation_consumer_identity_is_bound_to_workload_principal(
     )
     await db_session.commit()
 
-    scope = "platform:runtime-observations:consume"
-    consumer_b = await _add_workload_client(
-        workload_harness,
+    foreign = await register_runtime_observation_consumer(
         db_session,
-        allowed_scopes=[scope],
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=deployment_id,
+        consumer_id="foreign-controller",
     )
-    token_a = await _access_token(workload_harness, scope)
-    token_b = await _access_token(consumer_b, scope)
+    await db_session.commit()
     path = f"/v2/runtime/environments/{environment.id}"
+    admin_headers = {"X-Admin-Key": _ADMIN_KEY}
     common: dict[str, str] = {}
 
     caller_supplied_binding = await workload_harness.client.post(
         f"{path}/observation-consumers/register",
-        headers=_workload_headers(token_a, "caller-binding-forbidden"),
+        headers=admin_headers,
         json={"owner": _owner(seed_user), "deploymentId": deployment_id},
     )
     assert caller_supplied_binding.status_code == 422, caller_supplied_binding.text
@@ -852,19 +922,13 @@ async def test_observation_consumer_identity_is_bound_to_workload_principal(
         "deploymentId",
     }
 
-    registered_a = await workload_harness.client.post(
+    registered = await workload_harness.client.post(
         f"{path}/observation-consumers/register",
-        headers=_workload_headers(token_a, "register-a"),
+        headers=admin_headers,
         json=common,
     )
-    registered_b = await workload_harness.client.post(
-        f"{path}/observation-consumers/register",
-        headers=_workload_headers(token_b, "register-b"),
-        json=common,
-    )
-    assert registered_a.status_code == registered_b.status_code == 200
-    assert registered_a.json()["consumerId"] == workload_harness.client_id
-    assert registered_b.json()["consumerId"] == consumer_b.client_id
+    assert registered.status_code == 200, registered.text
+    assert registered.json()["consumerId"] == "hosted-controller"
 
     apply_identity = {
         "generation": 1,
@@ -874,11 +938,11 @@ async def test_observation_consumer_identity_is_bound_to_workload_principal(
     }
     cross_read = await workload_harness.client.post(
         f"{path}/observations/read",
-        headers=_workload_headers(token_a, "cross-read"),
+        headers=admin_headers,
         json={
             **common,
             "expectedApplyIdentity": apply_identity,
-            "afterCursor": registered_b.json()["cursor"],
+            "afterCursor": foreign["cursor"],
         },
     )
     assert cross_read.status_code == 410, cross_read.text
@@ -886,14 +950,14 @@ async def test_observation_consumer_identity_is_bound_to_workload_principal(
 
     cross_ack = await workload_harness.client.post(
         f"{path}/observation-consumers/ack",
-        headers=_workload_headers(token_a, "cross-ack"),
-        json={**common, "cursor": registered_b.json()["cursor"]},
+        headers=admin_headers,
+        json={**common, "cursor": foreign["cursor"]},
     )
     assert cross_ack.status_code == 410, cross_ack.text
     assert cross_ack.json()["detail"]["code"] == "observation_cursor_expired"
     expired_a = await db_session.get(
         V2RuntimeObservationConsumerCursor,
-        {"environment_id": environment.id, "consumer_id": workload_harness.client_id},
+        {"environment_id": environment.id, "consumer_id": "hosted-controller"},
     )
     assert expired_a is not None
     await db_session.refresh(expired_a)
@@ -912,50 +976,51 @@ async def test_observation_consumer_identity_is_bound_to_workload_principal(
         ).scalars()
     )
     assert [event.details["operation"] for event in expiry_audits] == ["read", "ack"]
-    assert all(
-        event.details["consumer_id"] == workload_harness.client_id for event in expiry_audits
-    )
-    assert registered_b.json()["cursor"] not in json.dumps(
+    assert all(event.actor_type == "admin" for event in expiry_audits)
+    assert all(event.details["auth_method"] == "x_admin_key" for event in expiry_audits)
+    assert all(event.details["consumer_id"] == "hosted-controller" for event in expiry_audits)
+    assert all("workload_client_id" not in event.details for event in expiry_audits)
+    assert foreign["cursor"] not in json.dumps(
         [event.details for event in expiry_audits],
         sort_keys=True,
     )
 
     caller_controlled_reset = await workload_harness.client.post(
         f"{path}/observation-consumers/reset",
-        headers=_workload_headers(token_a, "cross-reset-forbidden"),
-        json={**common, "consumer_id": consumer_b.client_id},
+        headers=admin_headers,
+        json={**common, "consumer_id": "foreign-controller"},
     )
     assert caller_controlled_reset.status_code == 422, caller_controlled_reset.text
     assert any(
         error["loc"][-1] == "consumer_id" for error in caller_controlled_reset.json()["detail"]
     )
 
-    reset_a = await workload_harness.client.post(
+    reset = await workload_harness.client.post(
         f"{path}/observation-consumers/reset",
-        headers=_workload_headers(token_a, "reset-a"),
+        headers=admin_headers,
         json=common,
     )
-    assert reset_a.status_code == 200, reset_a.text
-    assert reset_a.json()["consumerId"] == workload_harness.client_id
+    assert reset.status_code == 200, reset.text
+    assert reset.json()["consumerId"] == "hosted-controller"
 
-    own_read_b = await workload_harness.client.post(
+    own_read = await workload_harness.client.post(
         f"{path}/observations/read",
-        headers=_workload_headers(token_b, "read-b"),
+        headers=admin_headers,
         json={
             **common,
             "expectedApplyIdentity": apply_identity,
-            "afterCursor": registered_b.json()["cursor"],
+            "afterCursor": reset.json()["cursor"],
         },
     )
-    assert own_read_b.status_code == 200, own_read_b.text
-    cursor_b = await db_session.get(
+    assert own_read.status_code == 200, own_read.text
+    cursor = await db_session.get(
         V2RuntimeObservationConsumerCursor,
-        {"environment_id": environment.id, "consumer_id": consumer_b.client_id},
+        {"environment_id": environment.id, "consumer_id": "hosted-controller"},
     )
-    assert cursor_b is not None
-    assert cursor_b.state == "active"
-    assert cursor_b.acked_stream_position == 0
-    assert cursor_b.reset_at is None
+    assert cursor is not None
+    assert cursor.state == "active"
+    assert cursor.acked_stream_position == 0
+    assert cursor.reset_at is not None
 
 
 @pytest.mark.asyncio

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -65,8 +65,8 @@ Cloud-api reuses these existing runtime primitives:
 - `AgentEnvironment.id` as the stable environment identity;
 - managed, environment-bound `ApiKey` authentication with the dedicated
   `runtime-observations:write` scope for the runtime credential;
-- platform workload OAuth, mutation idempotency, and control-plane audit events
-  for Hosted-facing provisioning and retirement calls;
+- the first-party `X-Admin-Key` gate, mutation idempotency, and control-plane
+  audit events for Hosted-facing provisioning and retirement calls;
 - PostgreSQL transactions and `FOR UPDATE` locks for ingestion and retirement
   serialization.
 
@@ -86,21 +86,20 @@ Four PostgreSQL tables form the additive companion boundary:
 | `v2_runtime_observation_consumer_cursors` | Environment-and-consumer ACK state, replay horizon, and explicit fail-closed expiry/reset boundary used by safe prefix retention. |
 
 Strict-v2 credential provisioning is only available through
-workload-authenticated `POST /v2/runtime/auth/keys`. The legacy admin and
-platform v1 key APIs keep their original wire shape and cannot create a fence
-or deployment-bound credential. The database requires every deployment-bound
-key to be managed, environment-bound, explicitly scoped, to include
+admin-authenticated `POST /v2/runtime/auth/keys`. The admin and platform v1 key
+APIs keep their original wire shape and cannot create a fence or
+deployment-bound credential. The database requires every deployment-bound key
+to be managed, environment-bound, explicitly scoped, to include
 `runtime-observations:write`, and to stay within the runtime scope ceiling.
 
-Hosted-facing `/v2` registration, read, acknowledgement, and reset calls require
-the dedicated `platform:runtime-observations:consume` workload scope. The
-consumer identity is the authenticated workload `client_id`, and immutable
+Hosted-facing `/v2` registration, read, acknowledgement, reset, retirement, and
+provisioning calls all require the first-party `X-Admin-Key`. The server binds
+observation cursors to its fixed Hosted controller identity, and immutable
 owner/deployment authority is resolved from the environment fence rather than
 caller-selected request data, so opaque cursors cannot cross consumers or
-environments. Retirement separately requires
-`platform:runtime-environments:retire`; provisioning requires
-`platform:keys:mint`. The legacy global `X-Admin-Key` is not a fallback for any
-of these `/v2` operations.
+environments. Platform workload OAuth remains separate, default-closed
+infrastructure for the future resale platform surface; it is not on this v2
+data-plane path.
 
 Ingestion locks the permanent environment fence and rejects a retired binding
 before it inspects or creates a boot-session head. Retirement uses the same

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -11824,7 +11824,6 @@ export interface operations {
             header: {
                 "Idempotency-Key": string;
                 "X-Admin-Key"?: string | null;
-                Authorization?: string | null;
             };
             path?: never;
             cookie?: never;
@@ -11896,7 +11895,6 @@ export interface operations {
             header: {
                 "Idempotency-Key": string;
                 "X-Admin-Key"?: string | null;
-                Authorization?: string | null;
             };
             path: {
                 environment_id: string;
@@ -11934,7 +11932,6 @@ export interface operations {
             query?: never;
             header?: {
                 "X-Admin-Key"?: string | null;
-                Authorization?: string | null;
             };
             path: {
                 environment_id: string;
@@ -11972,7 +11969,6 @@ export interface operations {
             query?: never;
             header?: {
                 "X-Admin-Key"?: string | null;
-                Authorization?: string | null;
             };
             path: {
                 environment_id: string;
@@ -12010,7 +12006,6 @@ export interface operations {
             query?: never;
             header?: {
                 "X-Admin-Key"?: string | null;
-                Authorization?: string | null;
             };
             path: {
                 environment_id: string;
@@ -12048,7 +12043,6 @@ export interface operations {
             query?: never;
             header?: {
                 "X-Admin-Key"?: string | null;
-                Authorization?: string | null;
             };
             path: {
                 environment_id: string;


### PR DESCRIPTION
## Why

PR #436 put the greenfield v2 declarative data-plane companion on deferred platform workload OAuth. That violates the owner auth boundary: first-party v2 server-to-server traffic uses `X-Admin-Key`; platform workload OAuth is reserved for the future v3 resale surface. The same class of rollout coupling caused the production incident documented in `Clawdi-AI/clawdi-hosted#887`.

The declarative delivery master flag remains default-off, and the owner reports zero declarative production deployments, so Cloud and Hosted can switch together without a dual-accept window. No production systems or tenant data were accessed while preparing this change.

## STEP 1 — auth classification

### Rewired: v2 first-party data-plane companion

These Hosted-facing routes in `runtime_observation_v2.py` are the v2 declarative companion and now require `X-Admin-Key`:

- `POST /v2/runtime/auth/keys` (`platform:keys:mint` before this fix)
- `POST /v2/runtime/environments/{environment_id}/retire` (`platform:runtime-environments:retire` before this fix)
- observation-consumer `register`, `read`, `ack`, and `reset` (`platform:runtime-observations:consume` before this fix)

The runtime observation ingest route is not a platform OAuth caller; it remains authenticated by its managed, deployment-bound runtime API key with `runtime-observations:write`.

### Kept: deferred v3-resell platform OAuth

The following remain unchanged behind the existing cohort/default-closed boundary:

- `POST /v1/platform/oauth/token`
- `/v1/platform/agents` create/delete
- `/v1/platform/agents/{agent_id}/runtime-state` upsert/delete
- `/v1/platform/auth/keys` mint/revoke
- all token issue/verify, client assertion replay, scope, model, migration, config, and dependency machinery in `platform_workload_auth.py`

These are the separate resale/platform mutation surface. The unresolved `TODO(A0.7d0)` KMS adapter confirms this OAuth infrastructure is not ready to enter a v2 production hot path.

## What changed

- Replaced only the companion routes' workload dependencies with `require_admin_api_key`.
- Recorded companion control-plane events as `actor_type=admin` with `auth_method=x_admin_key`; rejection audits remain durable.
- Bound the single first-party observation consumer to the server-owned `hosted-controller` identity while preserving fence, cursor, retirement, replay, idempotency, and transaction logic.
- Regenerated the shared OpenAPI client so the six companion operations no longer advertise `Authorization`.
- Updated the managed-runtime owner documentation and real-PostgreSQL coverage.

## OAuth code kept vs removed

No shared workload OAuth implementation, scope, migration, config, gate, or v3 route was removed. The only removed OAuth wiring is the companion router's import/dependency and workload actor extraction. The now-unused test-only second-workload-client helper was removed with the obsolete companion identity test.

## Scope guardrails

- v1 runtime observation behavior and byte contract are unchanged.
- Plan C money math, the declarative master-flag default, and the access gate are unchanged.
- PR #969 and its bridge are untouched.

## Verification

All database tests used a newly migrated throwaway local `pgvector/pgvector:pg16` PostgreSQL instance.

```text
uv run pytest -q tests/test_platform_workload_oauth.py tests/test_runtime_observation_companion.py tests/test_runtime_observation_hardening_migration.py tests/test_v1_runtime_observation_byte_freeze.py
64 passed in 10.67s

uv run ruff check .
All checks passed!

uv run ruff format --check .
265 files already formatted

uv run python -m compileall -q app scripts tests alembic
passed

uv run python scripts/check_generated_api.py
passed

bun run typecheck
Tasks: 4 successful, 4 total
```

