### PR TITLE
fix(v2): refresh idempotent observation ack cursors

### DIFF
--- a/backend/app/services/runtime_observation.py
+++ b/backend/app/services/runtime_observation.py
@@ -1273,7 +1273,7 @@ async def acknowledge_runtime_observation_cursor(
             "runtime observation acknowledgement cannot regress",
         )
     now = _utc(acknowledged_at or datetime.now(UTC))
-    if decoded.stream_position > cursor.acked_stream_position:
+    if decoded.stream_position >= cursor.acked_stream_position:
         cursor.acked_stream_position = decoded.stream_position
         cursor.acked_cursor = opaque_cursor
         cursor.acknowledged_at = now

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 import app.services.runtime_observation as runtime_observation_service
 from app.core.auth import AuthContext, get_auth
+from app.core.config import settings
 from app.core.database import get_session
 from app.main import app
 from app.models.api_key import ApiKey
@@ -624,6 +625,56 @@ async def test_unknown_cursor_persists_fail_closed_reset_boundary(
     await db_session.commit()
     assert reset["resetBoundary"] == invalid.value.metadata["resetBoundary"]
     assert reset["sessionHighWaterMarks"] == {"boot-session-0001": 1}
+
+
+@pytest.mark.asyncio
+async def test_idempotent_reack_echoes_callers_fresh_cursor(
+    client: httpx.AsyncClient,
+    db_session: AsyncSession,
+    seed_user,
+    monkeypatch,
+) -> None:
+    environment, _ = await _provision_environment(db_session, seed_user)
+    admin_key = "runtime-observation-admin-secret"
+    headers = {"X-Admin-Key": admin_key}
+    path = f"/v2/runtime/environments/{environment.id}/observation-consumers"
+    monkeypatch.setattr(settings, "admin_api_key", admin_key)
+
+    registration = await client.post(f"{path}/register", headers=headers, json={})
+    assert registration.status_code == 200, registration.text
+
+    event = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(),
+    )
+    await db_session.commit()
+
+    registered_cursor = runtime_observation_service.decode_runtime_observation_cursor(
+        registration.json()["cursor"]
+    )
+    first_cursor = runtime_observation_service.encode_runtime_observation_cursor(
+        environment_id=registered_cursor.environment_id,
+        consumer_id=registered_cursor.consumer_id,
+        cursor_epoch=registered_cursor.cursor_epoch,
+        stream_position=event.stream_position,
+    )
+    first_ack = await client.post(f"{path}/ack", headers=headers, json={"cursor": first_cursor})
+    assert first_ack.status_code == 200, first_ack.text
+    assert first_ack.json()["cursor"] == first_cursor
+
+    second_cursor = runtime_observation_service.encode_runtime_observation_cursor(
+        environment_id=registered_cursor.environment_id,
+        consumer_id=registered_cursor.consumer_id,
+        cursor_epoch=registered_cursor.cursor_epoch,
+        stream_position=event.stream_position,
+    )
+    assert second_cursor != first_cursor
+
+    second_ack = await client.post(f"{path}/ack", headers=headers, json={"cursor": second_cursor})
+
+    assert second_ack.status_code == 200, second_ack.text
+    assert second_ack.json()["cursor"] == second_cursor
 
 
 @pytest.mark.committed_db


### PR DESCRIPTION
## What

- Refresh the persisted acknowledged cursor and timestamp when a validated acknowledgement is at the current stream position as well as when it advances.
- Add an HTTP regression test that registers the Hosted consumer, advances it, re-acknowledges the same position with a separately encoded cursor, and verifies that the response echoes the caller's opaque cursor.

## Why

Runtime observation cursors use AES-GCM with a fresh random nonce for every encoding, so two valid cursors for the same logical claims have different opaque strings. The acknowledgement service previously updated acked_cursor only when the decoded stream position strictly increased. A same-position re-ack therefore returned the previously stored token instead of the token supplied by the caller.

The Hosted A3 driver verifies acknowledgement by opaque string equality. In steady state, when no new observation event advances the stream, the stale echo caused a valid idempotent re-ack to fail and the declarative reconcile task to crash-loop instead of converging to Ready.

The existing high-water and expiry checks remain unchanged. The strict regression guard still rejects positions below the acknowledged stream position before the inclusive update runs.

## Test

- cd backend && uv run pytest -q tests/test_runtime_observation_companion.py
  - 25 passed
- cd backend && uv run pytest -q tests/test_platform_workload_oauth.py -k 'companion_routes_require_and_accept_admin_key or observation_consumer_identity_is_bound_to_admin_actor'
  - 7 passed, 31 deselected
- cd backend && uv run ruff check app/services/runtime_observation.py tests/test_runtime_observation_companion.py
  - All checks passed
- cd backend && uv run ruff format --check app/services/runtime_observation.py tests/test_runtime_observation_companion.py
  - 2 files already formatted

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)