### PR TITLE
fix(runtime): complete v2 apply identity handoff

### DIFF
--- a/backend/app/routes/runtime.py
+++ b/backend/app/routes/runtime.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -12,6 +13,7 @@ from app.core.database import get_runtime_snapshot_session
 from app.services.http_cache import if_none_match_contains
 from app.services.runtime_source import (
     RUNTIME_BUNDLE_V2_MEDIA_TYPE,
+    RuntimeManifestApplyIdentity,
     RuntimeSourceError,
     RuntimeSourceNotFoundError,
     expected_runtime_bundle_v2_etag,
@@ -27,6 +29,22 @@ router = APIRouter(prefix="/runtime", tags=["runtime"])
 @router.get("/manifest")
 async def get_runtime_manifest(
     request: Request,
+    runtime_generation: Annotated[
+        int,
+        Header(alias="X-Clawdi-Runtime-Generation", ge=1),
+    ],
+    runtime_manifest_etag: Annotated[
+        str,
+        Header(alias="X-Clawdi-Runtime-Manifest-ETag", min_length=1, max_length=128),
+    ],
+    runtime_apply_receipt_id: Annotated[
+        str,
+        Header(alias="X-Clawdi-Runtime-Apply-Receipt-ID", min_length=16, max_length=128),
+    ],
+    runtime_boot_nonce: Annotated[
+        str,
+        Header(alias="X-Clawdi-Runtime-Boot-Nonce", min_length=16, max_length=128),
+    ],
     requested_environment_id: UUID | None = Query(default=None, alias="environment_id"),
     auth: AuthContext = Depends(require_cli_auth),
     db: AsyncSession = Depends(get_runtime_snapshot_session),
@@ -57,7 +75,25 @@ async def get_runtime_manifest(
     except RuntimeSourceError as exc:
         raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
 
-    payload = render_runtime_bundle(source)
+    apply_identity = RuntimeManifestApplyIdentity(
+        generation=runtime_generation,
+        manifest_etag=_canonical_identity_header(
+            runtime_manifest_etag,
+            "X-Clawdi-Runtime-Manifest-ETag",
+        ),
+        apply_receipt_id=_canonical_identity_header(
+            runtime_apply_receipt_id,
+            "X-Clawdi-Runtime-Apply-Receipt-ID",
+        ),
+        boot_nonce=_canonical_identity_header(
+            runtime_boot_nonce,
+            "X-Clawdi-Runtime-Boot-Nonce",
+        ),
+    )
+    try:
+        payload = render_runtime_bundle(source, apply_identity=apply_identity)
+    except RuntimeSourceError as exc:
+        raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
     etag = expected_runtime_bundle_v2_etag(source.source_revision)
     headers = {
         "ETag": etag,
@@ -68,6 +104,15 @@ async def get_runtime_manifest(
     if if_none_match_contains(request.headers.get("if-none-match"), etag):
         return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)
     return JSONResponse(payload, headers=headers)
+
+
+def _canonical_identity_header(value: str, name: str) -> str:
+    if value != value.strip():
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            f"{name} must not contain surrounding whitespace",
+        )
+    return value
 
 
 def _authorized_environment_id(auth: AuthContext, requested_environment_id: UUID | None) -> UUID:

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -48,6 +48,7 @@ from app.services.vault_crypto import decrypt
 
 RUNTIME_BUNDLE_V2_MEDIA_TYPE = "application/vnd.clawdi.runtime-bundle.v2+json"
 RUNTIME_BUNDLE_V2_SCHEMA_VERSION = "clawdi.hosted-runtime.bundle.v2"
+RUNTIME_MANIFEST_V2_SCHEMA_VERSION = "clawdi.hosted-runtime.manifest.v2"
 _SUPPORTED_RUNTIMES = {"hermes", "openclaw"}
 _MANAGED_PROVIDER_RUNTIME_ENV = "OPENAI_API_KEY"
 _CODEX_TOOL_SECRET_REF = "tool.codex.apiKey"
@@ -90,6 +91,14 @@ class RenderedRuntimeSource:
     channel_bindings: list[dict[str, str]]
     secret_values: dict[str, str]
     source_revision: str
+
+
+@dataclass(frozen=True)
+class RuntimeManifestApplyIdentity:
+    generation: int
+    manifest_etag: str
+    apply_receipt_id: str
+    boot_nonce: str
 
 
 @dataclass(frozen=True)
@@ -330,7 +339,7 @@ def render_runtime_source(
     }
 
     manifest: dict[str, Any] = {
-        "schemaVersion": "clawdi.hosted-runtime.manifest.v1",
+        "schemaVersion": RUNTIME_MANIFEST_V2_SCHEMA_VERSION,
         "deploymentId": state.deployment_id,
         "environmentId": str(environment_id),
         "instanceId": state.instance_id,
@@ -423,11 +432,25 @@ def render_runtime_source(
     return RenderedRuntimeSource(manifest, bindings, secrets, source_revision)
 
 
-def render_runtime_bundle(source: RenderedRuntimeSource) -> dict[str, Any]:
+def render_runtime_bundle(
+    source: RenderedRuntimeSource,
+    *,
+    apply_identity: RuntimeManifestApplyIdentity,
+) -> dict[str, Any]:
+    if apply_identity.generation != source.manifest["generation"]:
+        raise RuntimeSourceError(
+            "Runtime apply identity generation does not match the desired manifest"
+        )
+    manifest = {
+        **source.manifest,
+        "manifestETag": apply_identity.manifest_etag,
+        "applyReceiptId": apply_identity.apply_receipt_id,
+        "bootNonce": apply_identity.boot_nonce,
+    }
     return {
         "schemaVersion": RUNTIME_BUNDLE_V2_SCHEMA_VERSION,
         "sourceRevision": source.source_revision,
-        "manifest": source.manifest,
+        "manifest": manifest,
         "channelBindings": source.channel_bindings,
         "secretValues": source.secret_values,
     }

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
@@ -209,7 +209,13 @@ async def admin_client(db_session) -> AsyncIterator[httpx.AsyncClient]:
         settings.admin_api_key = original_admin_key
 
 
-async def _runtime_client(db_session, seed_user, api_key: ApiKey | None):
+async def _runtime_client(
+    db_session,
+    seed_user,
+    api_key: ApiKey | None,
+    *,
+    runtime_environment_id: UUID | None = None,
+):
     provider = await db_session.scalar(
         select(AiProvider).where(
             AiProvider.owner_user_id == seed_user.id,
@@ -231,10 +237,24 @@ async def _runtime_client(db_session, seed_user, api_key: ApiKey | None):
     app.dependency_overrides[get_runtime_snapshot_session] = _override_get_session
     app.dependency_overrides[get_auth] = _override_get_auth
     transport = ASGITransport(app=app)
+    bound_environment_id = api_key.environment_id if api_key is not None else None
+    runtime_state_environment_id = bound_environment_id or runtime_environment_id
+    runtime_state = (
+        await db_session.get(HostedRuntimeState, runtime_state_environment_id)
+        if runtime_state_environment_id is not None
+        else None
+    )
+    generation = runtime_state.generation if runtime_state is not None else 1
     return httpx.AsyncClient(
         transport=transport,
         base_url="http://test",
-        headers={"Accept": RUNTIME_BUNDLE_V2_MEDIA_TYPE},
+        headers={
+            "Accept": RUNTIME_BUNDLE_V2_MEDIA_TYPE,
+            "X-Clawdi-Runtime-Generation": str(generation),
+            "X-Clawdi-Runtime-Manifest-ETag": f'"hosted-generation-{generation}"',
+            "X-Clawdi-Runtime-Apply-Receipt-ID": f"apply-receipt-{generation:08d}",
+            "X-Clawdi-Runtime-Boot-Nonce": f"boot-nonce-{generation:012d}",
+        },
     )
 
 
@@ -833,7 +853,7 @@ async def test_admin_upsert_runtime_state_and_manifest_omit_channels(
     assert response.headers["cache-control"] == "no-store"
     payload = response.json()
     manifest = payload["manifest"]
-    assert manifest["schemaVersion"] == "clawdi.hosted-runtime.manifest.v1"
+    assert manifest["schemaVersion"] == "clawdi.hosted-runtime.manifest.v2"
     assert manifest["minimumCliVersion"] == "0.12.10-beta.55"
     assert manifest["runtime"] == "openclaw"
     assert set(manifest["runtimes"]) == {"openclaw"}
@@ -851,6 +871,9 @@ async def test_admin_upsert_runtime_state_and_manifest_omit_channels(
     assert manifest["environmentId"] == str(env.id)
     assert manifest["instanceId"] == expected["instance_id"]
     assert manifest["generation"] == expected["generation"]
+    assert manifest["manifestETag"] == f'"hosted-generation-{expected["generation"]}"'
+    assert manifest["applyReceiptId"] == f"apply-receipt-{expected['generation']:08d}"
+    assert manifest["bootNonce"] == f"boot-nonce-{expected['generation']:012d}"
     assert manifest["controlPlane"] == {
         "cloudApiUrl": settings.public_api_url.rstrip("/"),
     }
@@ -873,6 +896,47 @@ async def test_admin_upsert_runtime_state_and_manifest_omit_channels(
     assert not_modified.headers["etag"] == etag
     assert not_modified.headers["cache-control"] == "no-store"
     assert not_modified.content == b""
+
+
+@pytest.mark.asyncio
+async def test_runtime_manifest_binds_request_apply_identity_without_changing_content_etag(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"runtime-identity-{uuid4().hex[:8]}",
+        machine_name="Runtime identity",
+        agent_type="openclaw",
+    )
+    expected = await _write_runtime_state(admin_client, str(env.id))
+    api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
+
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        first = await client.get("/v1/runtime/manifest")
+        second = await client.get(
+            "/v1/runtime/manifest",
+            headers={
+                "X-Clawdi-Runtime-Apply-Receipt-ID": "apply-receipt-replacement-0001",
+                "X-Clawdi-Runtime-Boot-Nonce": "boot-nonce-replacement-000001",
+            },
+        )
+        mismatched_generation = await client.get(
+            "/v1/runtime/manifest",
+            headers={"X-Clawdi-Runtime-Generation": str(expected["generation"] + 1)},
+        )
+    app.dependency_overrides.clear()
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.headers["etag"] == second.headers["etag"]
+    assert first.json()["sourceRevision"] == second.json()["sourceRevision"]
+    assert first.json()["manifest"]["applyReceiptId"] != second.json()["manifest"]["applyReceiptId"]
+    assert first.json()["manifest"]["bootNonce"] != second.json()["manifest"]["bootNonce"]
+    assert mismatched_generation.status_code == 409
+    assert "generation does not match" in mismatched_generation.text
 
 
 @pytest.mark.asyncio
@@ -4076,7 +4140,12 @@ async def test_runtime_manifest_allows_unbound_cli_key_with_explicit_environment
     await _write_runtime_state(admin_client, str(env.id))
 
     api_key = ApiKey(user_id=seed_user.id, label="unbound")
-    async with await _runtime_client(db_session, seed_user, api_key) as client:
+    async with await _runtime_client(
+        db_session,
+        seed_user,
+        api_key,
+        runtime_environment_id=env.id,
+    ) as client:
         response = await client.get(
             "/v1/runtime/manifest",
             params={"environment_id": str(env.id)},
@@ -4209,7 +4278,12 @@ async def test_runtime_manifest_projects_provider_secret_values_for_managed_acco
     await _write_runtime_state(admin_client, str(env.id))
 
     api_key = ApiKey(user_id=seed_user.id, environment_id=None, managed=True, label="hosted")
-    async with await _runtime_client(db_session, seed_user, api_key) as client:
+    async with await _runtime_client(
+        db_session,
+        seed_user,
+        api_key,
+        runtime_environment_id=env.id,
+    ) as client:
         response = await client.get(
             "/v1/runtime/manifest",
             params={"environment_id": str(env.id)},
@@ -4240,7 +4314,12 @@ async def test_runtime_manifest_projects_provider_secret_values_for_managed_acco
     provider.label = "Presentation-only label"
     await db_session.commit()
 
-    async with await _runtime_client(db_session, seed_user, api_key) as client:
+    async with await _runtime_client(
+        db_session,
+        seed_user,
+        api_key,
+        runtime_environment_id=env.id,
+    ) as client:
         presentation_only = await client.get(
             "/v1/runtime/manifest",
             params={"environment_id": str(env.id)},
@@ -4271,7 +4350,12 @@ async def test_runtime_manifest_projects_provider_secret_values_for_managed_acco
     )
     await db_session.commit()
 
-    async with await _runtime_client(db_session, seed_user, api_key) as client:
+    async with await _runtime_client(
+        db_session,
+        seed_user,
+        api_key,
+        runtime_environment_id=env.id,
+    ) as client:
         rotated = await client.get(
             "/v1/runtime/manifest",
             params={"environment_id": str(env.id)},

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -13,6 +13,7 @@ from app.models.hosted_runtime import HostedRuntimeState
 from app.models.session import AgentEnvironment
 from app.schemas.runtime import HostedCodexProviderProjection
 from app.services.runtime_source import (
+    RuntimeManifestApplyIdentity,
     RuntimeSourceBatch,
     RuntimeSourceError,
     RuntimeSourceRow,
@@ -29,6 +30,12 @@ ACCOUNT_ID = UUID("50000000-0000-0000-0000-000000000005")
 LINK_ID = UUID("60000000-0000-0000-0000-000000000006")
 PREFIX_COLLISION_ACCOUNT_ID = UUID("50000000-0000-ffff-0000-000000000007")
 PREFIX_COLLISION_LINK_ID = UUID("60000000-0000-0000-0000-000000000008")
+APPLY_IDENTITY = RuntimeManifestApplyIdentity(
+    generation=7,
+    manifest_etag='"manifest-generation-7"',
+    apply_receipt_id="apply-receipt-00000007",
+    boot_nonce="boot-nonce-000000000007",
+)
 
 
 def test_runtime_bundle_v2_etag_is_derived_from_source_revision() -> None:
@@ -243,7 +250,7 @@ def test_unmanaged_runtime_tool_secret_uses_auth_payload_without_user_vault_refs
         vault_key_identity="platform-key-generation-1",
         decrypt_secrets=True,
     )
-    bundle = render_runtime_bundle(source)
+    bundle = render_runtime_bundle(source, apply_identity=APPLY_IDENTITY)
 
     assert source.manifest["providers"] == {}
     assert source.manifest["runtimes"]["openclaw"]["providerMode"] == "unmanaged"
@@ -455,4 +462,6 @@ def test_runtime_bundle_matches_shared_golden(monkeypatch) -> None:
         decrypt_secrets=True,
     )
     fixture_path = Path(__file__).parents[2] / "test-fixtures/runtime-bundle-v2.golden.json"
-    assert render_runtime_bundle(source) == json.loads(fixture_path.read_text())
+    assert render_runtime_bundle(source, apply_identity=APPLY_IDENTITY) == json.loads(
+        fixture_path.read_text()
+    )

--- a/docs/managed-runtime.md
+++ b/docs/managed-runtime.md
@@ -333,6 +333,15 @@ map, and deterministic `sourceRevision`. Missing or unsupported media types
 return `406`; the CLI does not fall back to another representation or a second
 `/v1/channels` request.
 
+Hosted manifest requests also require the complete controller-selected apply
+identity in `X-Clawdi-Runtime-Generation`,
+`X-Clawdi-Runtime-Manifest-ETag`,
+`X-Clawdi-Runtime-Apply-Receipt-ID`, and `X-Clawdi-Runtime-Boot-Nonce`.
+The control plane rejects a generation that does not match desired state and
+renders the same tuple into the strict inner
+`clawdi.hosted-runtime.manifest.v2`. The CLI rejects a response whose tuple
+does not exactly match its boot environment.
+
 Bundle responses identify the vendor media type and return `Vary: Accept`.
 Negotiation `406` responses also return `Vary: Accept` and
 `Cache-Control: no-store`, so errors are not reused across media types.
@@ -342,10 +351,10 @@ validator without decrypting secrets in the health summary.
 
 The CLI normalizes these wire contracts into the desired-state shape:
 
-- `clawdi.hosted-runtime.manifest.v1` is the hosted control-plane response
-  shape served only from `/v1/runtime/manifest`. It requires explicit `runtime`
-  and `environmentId` fields and rejects unknown fields instead of accepting
-  compatibility payloads. `system`, `controlPlane`, `clawdiCli`, `runtimes`,
+- `clawdi.hosted-runtime.manifest.v2` is the only hosted control-plane inner
+  manifest shape served from `/v1/runtime/manifest`. It requires the complete
+  apply identity plus explicit `runtime` and `environmentId` fields and rejects
+  unknown fields. `system`, `controlPlane`, `clawdiCli`, `runtimes`,
   `providers`, `liveSync`, and `recovery` are required. `egressProfiles`, `mcp`,
   and `tools` remain explicit optional projections.
 - `clawdi.runtimeDesiredState.v1` is the normalized internal convergence shape
@@ -356,6 +365,7 @@ Normalization maps hosted fields into the internal shape:
 | Hosted field | Internal purpose |
 | --- | --- |
 | `deploymentId`, `environmentId`, `instanceId`, `generation` | Identity, cache keys, status, and idempotence |
+| `manifestETag`, `applyReceiptId`, `bootNonce` | Controller-selected apply identity, persisted only with a successful convergence and used by direct-v2 runtime evidence |
 | `runtime` | Required selected compute runtime; exactly one enabled `openclaw` or `hermes` entry must match it |
 | `locale.language`, `locale.timezone` | Required supported language and valid IANA timezone |
 | `system.openclawControlUiAllowedOrigins` | Optional control-plane-selected, validated HTTP(S) origins for the OpenClaw gateway Control UI patch |
@@ -473,6 +483,11 @@ required installers before Apply, and commits last-good, remote ETags, and
 `status/runtime-applied.json` only after managed files and systemd state apply
 successfully. A recoverable Apply failure restores the previous Clawdi-owned
 files and systemd declaration and leaves those authority records unchanged.
+The durable applied state keeps the bundle transport ETag separate from the
+controller manifest ETag. The daemon snapshots the latter with generation,
+receipt ID, and boot nonce, creates the boot-session and event identities
+locally, and sends direct-v2 evidence without a feature flag or v1 heartbeat
+translation.
 Last-good remains an offline recovery cache; `runtime-applied.json` is the
 online record of the applied instance, config generation, content identity,
 source manifest provider IDs, and the target-specific projected provider ID map

--- a/packages/cli/src/runtime/apply-identity.test.ts
+++ b/packages/cli/src/runtime/apply-identity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	RUNTIME_APPLY_IDENTITY_HEADERS,
 	readRuntimeApplyIdentityFromEnv,
+	runtimeApplyIdentityEnvironment,
 	runtimeApplyIdentityHeaders,
 } from "./apply-identity";
 
@@ -28,6 +29,7 @@ describe("runtime apply identity environment", () => {
 			[RUNTIME_APPLY_IDENTITY_HEADERS.applyReceiptId]: "apply-receipt-0007",
 			[RUNTIME_APPLY_IDENTITY_HEADERS.bootNonce]: "boot-nonce-000007",
 		});
+		expect(runtimeApplyIdentityEnvironment(identity)).toEqual(completeEnv);
 	});
 
 	test("rejects incomplete, non-canonical, and invalid tuples", () => {

--- a/packages/cli/src/runtime/apply-identity.test.ts
+++ b/packages/cli/src/runtime/apply-identity.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import {
+	RUNTIME_APPLY_IDENTITY_HEADERS,
+	readRuntimeApplyIdentityFromEnv,
+	runtimeApplyIdentityHeaders,
+} from "./apply-identity";
+
+const completeEnv = {
+	CLAWDI_RUNTIME_GENERATION: "7",
+	CLAWDI_RUNTIME_MANIFEST_ETAG: '"manifest-generation-7"',
+	CLAWDI_RUNTIME_APPLY_RECEIPT_ID: "apply-receipt-0007",
+	CLAWDI_RUNTIME_BOOT_NONCE: "boot-nonce-000007",
+};
+
+describe("runtime apply identity environment", () => {
+	test("reads one complete canonical tuple and maps it to request headers", () => {
+		const identity = readRuntimeApplyIdentityFromEnv(completeEnv);
+
+		expect(identity).toEqual({
+			generation: 7,
+			manifestETag: '"manifest-generation-7"',
+			applyReceiptId: "apply-receipt-0007",
+			bootNonce: "boot-nonce-000007",
+		});
+		expect(runtimeApplyIdentityHeaders(identity)).toEqual({
+			[RUNTIME_APPLY_IDENTITY_HEADERS.generation]: "7",
+			[RUNTIME_APPLY_IDENTITY_HEADERS.manifestETag]: '"manifest-generation-7"',
+			[RUNTIME_APPLY_IDENTITY_HEADERS.applyReceiptId]: "apply-receipt-0007",
+			[RUNTIME_APPLY_IDENTITY_HEADERS.bootNonce]: "boot-nonce-000007",
+		});
+	});
+
+	test("rejects incomplete, non-canonical, and invalid tuples", () => {
+		expect(() =>
+			readRuntimeApplyIdentityFromEnv({
+				...completeEnv,
+				CLAWDI_RUNTIME_BOOT_NONCE: undefined,
+			}),
+		).toThrow("missing runtime apply identity environment: CLAWDI_RUNTIME_BOOT_NONCE");
+		expect(() =>
+			readRuntimeApplyIdentityFromEnv({
+				...completeEnv,
+				CLAWDI_RUNTIME_GENERATION: "07",
+			}),
+		).toThrow("CLAWDI_RUNTIME_GENERATION must be a canonical positive integer");
+		expect(() =>
+			readRuntimeApplyIdentityFromEnv({
+				...completeEnv,
+				CLAWDI_RUNTIME_MANIFEST_ETAG: ' "manifest-generation-7"',
+			}),
+		).toThrow("manifestETag: must not contain surrounding whitespace");
+	});
+});

--- a/packages/cli/src/runtime/apply-identity.ts
+++ b/packages/cli/src/runtime/apply-identity.ts
@@ -2,11 +2,75 @@ import { z } from "zod";
 
 export const runtimeApplyIdentitySchema = z
 	.object({
-		generation: z.number().int().positive(),
-		manifestETag: z.string().min(1).max(128),
-		applyReceiptId: z.string().min(16).max(128),
-		bootNonce: z.string().min(16).max(128),
+		generation: z.number().int().positive().safe(),
+		manifestETag: canonicalIdentityValue(1, 128),
+		applyReceiptId: canonicalIdentityValue(16, 128),
+		bootNonce: canonicalIdentityValue(16, 128),
 	})
 	.strict();
 
 export type RuntimeApplyIdentity = z.infer<typeof runtimeApplyIdentitySchema>;
+
+export const RUNTIME_APPLY_IDENTITY_ENV = {
+	generation: "CLAWDI_RUNTIME_GENERATION",
+	manifestETag: "CLAWDI_RUNTIME_MANIFEST_ETAG",
+	applyReceiptId: "CLAWDI_RUNTIME_APPLY_RECEIPT_ID",
+	bootNonce: "CLAWDI_RUNTIME_BOOT_NONCE",
+} as const;
+
+export const RUNTIME_APPLY_IDENTITY_HEADERS = {
+	generation: "x-clawdi-runtime-generation",
+	manifestETag: "x-clawdi-runtime-manifest-etag",
+	applyReceiptId: "x-clawdi-runtime-apply-receipt-id",
+	bootNonce: "x-clawdi-runtime-boot-nonce",
+} as const;
+
+export function readRuntimeApplyIdentityFromEnv(
+	env: Readonly<Record<string, string | undefined>> = process.env,
+): RuntimeApplyIdentity {
+	const missing = Object.values(RUNTIME_APPLY_IDENTITY_ENV).filter(
+		(name) => env[name] === undefined,
+	);
+	if (missing.length > 0) {
+		throw new Error(`missing runtime apply identity environment: ${missing.join(", ")}`);
+	}
+	const generation = env[RUNTIME_APPLY_IDENTITY_ENV.generation];
+	if (!generation || !/^[1-9]\d*$/.test(generation)) {
+		throw new Error(
+			`${RUNTIME_APPLY_IDENTITY_ENV.generation} must be a canonical positive integer`,
+		);
+	}
+	const parsed = runtimeApplyIdentitySchema.safeParse({
+		generation: Number(generation),
+		manifestETag: env[RUNTIME_APPLY_IDENTITY_ENV.manifestETag],
+		applyReceiptId: env[RUNTIME_APPLY_IDENTITY_ENV.applyReceiptId],
+		bootNonce: env[RUNTIME_APPLY_IDENTITY_ENV.bootNonce],
+	});
+	if (!parsed.success) {
+		throw new Error(
+			`invalid runtime apply identity environment: ${parsed.error.issues
+				.map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+				.join("; ")}`,
+		);
+	}
+	return parsed.data;
+}
+
+export function runtimeApplyIdentityHeaders(
+	identity: RuntimeApplyIdentity,
+): Record<string, string> {
+	return {
+		[RUNTIME_APPLY_IDENTITY_HEADERS.generation]: String(identity.generation),
+		[RUNTIME_APPLY_IDENTITY_HEADERS.manifestETag]: identity.manifestETag,
+		[RUNTIME_APPLY_IDENTITY_HEADERS.applyReceiptId]: identity.applyReceiptId,
+		[RUNTIME_APPLY_IDENTITY_HEADERS.bootNonce]: identity.bootNonce,
+	};
+}
+
+function canonicalIdentityValue(min: number, max: number): z.ZodString {
+	return z
+		.string()
+		.min(min)
+		.max(max)
+		.refine((value) => value === value.trim(), "must not contain surrounding whitespace");
+}

--- a/packages/cli/src/runtime/apply-identity.ts
+++ b/packages/cli/src/runtime/apply-identity.ts
@@ -67,6 +67,17 @@ export function runtimeApplyIdentityHeaders(
 	};
 }
 
+export function runtimeApplyIdentityEnvironment(
+	identity: RuntimeApplyIdentity,
+): Record<string, string> {
+	return {
+		[RUNTIME_APPLY_IDENTITY_ENV.generation]: String(identity.generation),
+		[RUNTIME_APPLY_IDENTITY_ENV.manifestETag]: identity.manifestETag,
+		[RUNTIME_APPLY_IDENTITY_ENV.applyReceiptId]: identity.applyReceiptId,
+		[RUNTIME_APPLY_IDENTITY_ENV.bootNonce]: identity.bootNonce,
+	};
+}
+
 function canonicalIdentityValue(min: number, max: number): z.ZodString {
 	return z
 		.string()

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -674,15 +674,7 @@ function validateHostedRuntimeManifest(
 	}
 }
 
-const hostedRuntimeManifestV1Schema = hostedRuntimeManifestBaseSchema
-	.safeExtend({
-		schemaVersion: z.literal("clawdi.hosted-runtime.manifest.v1"),
-		clawdiCli: hostedCliPayloadPolicySchema,
-	})
-	.strict()
-	.superRefine(validateHostedRuntimeManifest);
-
-const hostedRuntimeManifestV2Schema = hostedRuntimeManifestBaseSchema
+export const hostedRuntimeManifestSchema = hostedRuntimeManifestBaseSchema
 	.safeExtend({
 		schemaVersion: z.literal("clawdi.hosted-runtime.manifest.v2"),
 		generation: z.number().int().positive(),
@@ -693,11 +685,6 @@ const hostedRuntimeManifestV2Schema = hostedRuntimeManifestBaseSchema
 	})
 	.strict()
 	.superRefine(validateHostedRuntimeManifest);
-
-export const hostedRuntimeManifestSchema = z.discriminatedUnion("schemaVersion", [
-	hostedRuntimeManifestV1Schema,
-	hostedRuntimeManifestV2Schema,
-]);
 
 export const hostedRuntimeManifestResponseSchema = z
 	.object({
@@ -722,14 +709,6 @@ export const hostedRuntimeManifestResponseSchema = z
 		}
 	});
 
-const hostedRuntimeManifestFixtureV1Schema = hostedRuntimeManifestBaseSchema
-	.safeExtend({
-		schemaVersion: z.literal("clawdi.hosted-runtime.manifest.v1"),
-		clawdiCli: hostedFixtureCliPayloadPolicySchema,
-	})
-	.strict()
-	.superRefine(validateHostedRuntimeManifest);
-
 const hostedRuntimeManifestFixtureV2Schema = hostedRuntimeManifestBaseSchema
 	.safeExtend({
 		schemaVersion: z.literal("clawdi.hosted-runtime.manifest.v2"),
@@ -741,15 +720,9 @@ const hostedRuntimeManifestFixtureV2Schema = hostedRuntimeManifestBaseSchema
 	})
 	.strict()
 	.superRefine(validateHostedRuntimeManifest);
-
-const hostedRuntimeManifestFixtureSchema = z.discriminatedUnion("schemaVersion", [
-	hostedRuntimeManifestFixtureV1Schema,
-	hostedRuntimeManifestFixtureV2Schema,
-]);
-
 export const hostedRuntimeManifestFixtureResponseSchema = z
 	.object({
-		manifest: hostedRuntimeManifestFixtureSchema,
+		manifest: hostedRuntimeManifestFixtureV2Schema,
 		secretValues: z.record(z.string().min(1), z.string()).default({}),
 	})
 	.strict();

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -42,6 +42,7 @@ const originalEnv = { ...process.env };
 const tempRoots: string[] = [];
 const TEST_HOSTED_LOCALE = { language: "en" as const, timezone: "UTC" };
 const TEST_HOSTED_MINIMUM_CLI_VERSION = "0.12.10-beta.55";
+const HOSTED_MANIFEST_V2_SCHEMA_VERSION = "clawdi.hosted-runtime.manifest.v2";
 const TEST_HOSTED_HOME = "/home/clawdi";
 const TEST_HOSTED_CODEX_TOOLING = {
 	codex: {
@@ -118,7 +119,10 @@ function baseManifest(
 
 function hostedManifestFixture(overrides: Record<string, unknown> = {}): Record<string, unknown> {
 	return {
-		schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+		schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+		manifestETag: '"manifest-generation-1"',
+		applyReceiptId: "apply-receipt-00000001",
+		bootNonce: "boot-nonce-000000000001",
 		minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 		runtime: "openclaw",
 		deploymentId: "hdep_locale",
@@ -858,7 +862,10 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(() =>
 			normalizeManifestPayload({
 				manifest: {
-					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+					manifestETag: '"manifest-generation-1"',
+					applyReceiptId: "apply-receipt-00000001",
+					bootNonce: "boot-nonce-000000000001",
 					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "openclaw",
 					deploymentId: "hdep_missing_cli_policy",
@@ -959,7 +966,10 @@ describe("runtime manifest reconciliation invariants", () => {
 		expect(() =>
 			normalizeManifestPayload({
 				manifest: {
-					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+					manifestETag: '"manifest-generation-1"',
+					applyReceiptId: "apply-receipt-00000001",
+					bootNonce: "boot-nonce-000000000001",
 					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "openclaw",
 					deploymentId: "hdep_invalid_cli_policy",
@@ -1055,7 +1065,10 @@ describe("runtime manifest reconciliation invariants", () => {
 	test("normalizes hosted manifest responses into runtime desired state without embedding secrets", () => {
 		const hostedResponse = {
 			manifest: {
-				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+				manifestETag: '"manifest-generation-7"',
+				applyReceiptId: "apply-receipt-00000007",
+				bootNonce: "boot-nonce-000000000007",
 				minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 				runtime: "openclaw",
 				deploymentId: "hdep_normalize",
@@ -1193,7 +1206,10 @@ describe("runtime manifest reconciliation invariants", () => {
 	test("rejects a missing explicit runtime even with one runtime entry", () => {
 		expect(
 			hostedRuntimeManifestSchema.safeParse({
-				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+				manifestETag: '"manifest-generation-1"',
+				applyReceiptId: "apply-receipt-00000001",
+				bootNonce: "boot-nonce-000000000001",
 				minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 				deploymentId: "hdep_infer_runtime",
 				environmentId: "env_infer_runtime",
@@ -1278,7 +1294,10 @@ describe("runtime manifest reconciliation invariants", () => {
 		],
 	])("rejects unknown hosted manifest fields at the %s", (_name, addUnknownField) => {
 		const cleanManifest = {
-			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+			schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+			manifestETag: '"manifest-generation-1"',
+			applyReceiptId: "apply-receipt-00000001",
+			bootNonce: "boot-nonce-000000000001",
 			minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 			runtime: "openclaw",
 			deploymentId: "hdep_forward_compat",
@@ -1316,7 +1335,10 @@ describe("runtime manifest reconciliation invariants", () => {
 	test("rejects hosted manifests that still declare multiple execution runtimes", () => {
 		expect(() =>
 			hostedRuntimeManifestSchema.parse({
-				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+				manifestETag: '"manifest-generation-1"',
+				applyReceiptId: "apply-receipt-00000001",
+				bootNonce: "boot-nonce-000000000001",
 				minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 				runtime: "openclaw",
 				deploymentId: "hdep_multi",
@@ -1573,7 +1595,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			},
 			{
 				projection: {
-					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v2",
 					providers: {
 						[providerKey]: {
 							type: "custom_openai_compatible",
@@ -1604,7 +1626,7 @@ describe("runtime manifest reconciliation invariants", () => {
 			},
 			{
 				projection: {
-					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v2",
 					providers: {
 						default: {
 							type: "custom_openai_compatible",

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -6,7 +6,11 @@ import {
 	runtimeAppliedApplyIdentity,
 	runtimeContentSha256,
 } from "./applied-state";
-import type { RuntimeApplyIdentity } from "./apply-identity";
+import {
+	type RuntimeApplyIdentity,
+	readRuntimeApplyIdentityFromEnv,
+	runtimeApplyIdentityHeaders,
+} from "./apply-identity";
 import {
 	ensureRuntimeAuthTokenFile,
 	readRuntimeAuthToken,
@@ -233,6 +237,7 @@ export function normalizeManifestPayload(value: unknown): {
 function normalizeRemoteManifestPayload(
 	value: unknown,
 	paths: RuntimePaths,
+	expectedApplyIdentity?: RuntimeApplyIdentity,
 ): {
 	manifest: RuntimeManifest;
 	secretValues?: Record<string, string>;
@@ -242,12 +247,16 @@ function normalizeRemoteManifestPayload(
 } {
 	if (paths.mode !== "hosted") return normalizeManifestPayload(value);
 	const hostedResponse = hostedRuntimeBundleV2Schema.parse(value);
+	const applyIdentity = hostedManifestApplyIdentity(hostedResponse.manifest);
+	if (!expectedApplyIdentity || !sameApplyIdentity(applyIdentity, expectedApplyIdentity)) {
+		throw new Error("runtime manifest apply identity does not match the boot environment");
+	}
 	return {
 		manifest: hostedManifestToRuntimeManifest(hostedResponse.manifest),
 		secretValues: normalizeSecretValues(hostedResponse.secretValues),
 		channelBindings: hostedResponse.channelBindings,
 		sourceRevision: hostedResponse.sourceRevision,
-		applyIdentity: hostedManifestApplyIdentity(hostedResponse.manifest),
+		applyIdentity,
 	};
 }
 
@@ -290,10 +299,7 @@ function looksLikeHostedManifestResponse(value: unknown): boolean {
 	const manifest = Reflect.get(value, "manifest");
 	if (typeof manifest !== "object" || manifest === null || Array.isArray(manifest)) return false;
 	const schemaVersion = Reflect.get(manifest, "schemaVersion");
-	return (
-		schemaVersion === "clawdi.hosted-runtime.manifest.v1" ||
-		schemaVersion === "clawdi.hosted-runtime.manifest.v2"
-	);
+	return schemaVersion === "clawdi.hosted-runtime.manifest.v2";
 }
 
 function rawGeneration(value: unknown): number | null {
@@ -367,6 +373,7 @@ async function fetchRuntimeManifestPayload(
 			url: string;
 			raw: unknown;
 			etag?: string;
+			applyIdentity?: RuntimeApplyIdentity;
 	  }
 	| {
 			url: string;
@@ -380,6 +387,7 @@ async function fetchRuntimeManifestPayload(
 		throw new Error(`missing ${runtimeAuthTokenFileLabel(paths)}`);
 	}
 	const url = source.url;
+	const applyIdentity = paths.mode === "hosted" ? readRuntimeApplyIdentityFromEnv() : undefined;
 	const timeoutMs =
 		Number.parseInt(process.env.CLAWDI_RUNTIME_MANIFEST_TIMEOUT_MS ?? "", 10) ||
 		source.timeoutMs ||
@@ -392,6 +400,7 @@ async function fetchRuntimeManifestPayload(
 			headers: {
 				accept: paths.mode === "hosted" ? HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE : "application/json",
 				authorization: `Bearer ${token}`,
+				...(applyIdentity ? runtimeApplyIdentityHeaders(applyIdentity) : {}),
 				...(opts.ifNoneMatch ? { "if-none-match": opts.ifNoneMatch } : {}),
 			},
 			signal: controller.signal,
@@ -420,7 +429,7 @@ async function fetchRuntimeManifestPayload(
 			}
 			if (!etag) throw new Error("runtime bundle response is missing its strong ETag");
 		}
-		return { url, raw: await response.json(), etag };
+		return { url, raw: await response.json(), etag, applyIdentity };
 	} finally {
 		clearTimeout(timer);
 	}
@@ -460,7 +469,7 @@ export async function loadRemoteRuntimeManifest(
 		sourceRevision?: string;
 	};
 	try {
-		normalized = normalizeRemoteManifestPayload(fetched.raw, paths);
+		normalized = normalizeRemoteManifestPayload(fetched.raw, paths, fetched.applyIdentity);
 	} catch (error) {
 		return {
 			mode: "manifest-rejected",
@@ -542,16 +551,22 @@ export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): 
 	};
 }
 
-function hostedManifestApplyIdentity(
-	hosted: HostedRuntimeManifest,
-): RuntimeApplyIdentity | undefined {
-	if (hosted.schemaVersion !== "clawdi.hosted-runtime.manifest.v2") return undefined;
+function hostedManifestApplyIdentity(hosted: HostedRuntimeManifest): RuntimeApplyIdentity {
 	return {
 		generation: hosted.generation,
 		manifestETag: hosted.manifestETag,
 		applyReceiptId: hosted.applyReceiptId,
 		bootNonce: hosted.bootNonce,
 	};
+}
+
+function sameApplyIdentity(left: RuntimeApplyIdentity, right: RuntimeApplyIdentity): boolean {
+	return (
+		left.generation === right.generation &&
+		left.manifestETag === right.manifestETag &&
+		left.applyReceiptId === right.applyReceiptId &&
+		left.bootNonce === right.bootNonce
+	);
 }
 
 function hostedRuntimeProviderBinding(
@@ -736,7 +751,12 @@ export async function loadRuntimeManifest(
 		};
 	}
 	if (!manifestPath) {
-		let fetched: { url: string; raw: unknown; etag?: string };
+		let fetched: {
+			url: string;
+			raw: unknown;
+			etag?: string;
+			applyIdentity?: RuntimeApplyIdentity;
+		};
 		try {
 			const result = await fetchRuntimeManifestPayload(paths);
 			if ("notModified" in result) {
@@ -760,7 +780,7 @@ export async function loadRuntimeManifest(
 
 		let normalized: { manifest: RuntimeManifest; secretValues?: Record<string, string> };
 		try {
-			normalized = normalizeRemoteManifestPayload(fetched.raw, paths);
+			normalized = normalizeRemoteManifestPayload(fetched.raw, paths, fetched.applyIdentity);
 		} catch (error) {
 			return {
 				mode: "manifest-rejected",

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -5688,7 +5688,6 @@ export function convergeRuntimeManifest(
 	let codexCli: Record<string, string> | null = null;
 	if (
 		hostedCodexManagedProvider(manifest) ||
-		manifest.projection?.sourceSchemaVersion === "clawdi.hosted-runtime.manifest.v1" ||
 		manifest.projection?.sourceSchemaVersion === "clawdi.hosted-runtime.manifest.v2"
 	) {
 		try {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -56,6 +56,7 @@ import {
 } from "../lib/hermes-config-merge";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { readRuntimeAppliedState } from "./applied-state";
+import { type RuntimeApplyIdentity, runtimeApplyIdentityEnvironment } from "./apply-identity";
 import { ensureRuntimeAuthTokenFile } from "./auth-token";
 import { isClawdiManagedProviderProjection, normalizeSecretRef } from "./hosted-egress-profiles";
 import {
@@ -4807,6 +4808,7 @@ function runtimeManifestUrlEnv(sourcePath: string): string {
 function runtimeSystemdCommonEnvironment(
 	sourcePath: string,
 	paths: RuntimePaths,
+	applyIdentity: RuntimeApplyIdentity | undefined,
 ): Record<string, string> {
 	const runtimeUser = process.env.CLAWDI_RUNTIME_USER?.trim() || "clawdi";
 	return {
@@ -4817,6 +4819,7 @@ function runtimeSystemdCommonEnvironment(
 		CLAWDI_SERVICE_STATE_DIR: paths.serviceStateRoot,
 		CLAWDI_RUN_DIR: paths.runRoot,
 		CLAWDI_RUNTIME_MANIFEST_URL: runtimeManifestUrlEnv(sourcePath),
+		...(applyIdentity ? runtimeApplyIdentityEnvironment(applyIdentity) : {}),
 		[RUNTIME_BRIDGE_TOKEN_ENV]: "",
 		[RUNTIME_BRIDGE_LISTEN_HOST_ENV]: process.env[RUNTIME_BRIDGE_LISTEN_HOST_ENV]?.trim() ?? "",
 		[RUNTIME_BRIDGE_SURFACES_ENV]: "",
@@ -5896,7 +5899,11 @@ export function convergeRuntimeManifest(
 				managedModelOverrides,
 			);
 		}
-		const commonSystemdEnvironment = runtimeSystemdCommonEnvironment(load.sourcePath, paths);
+		const commonSystemdEnvironment = runtimeSystemdCommonEnvironment(
+			load.sourcePath,
+			paths,
+			load.applyIdentity,
+		);
 		if (shouldInstallOfficialRuntimeServices()) {
 			for (const program of officialRuntimeSystemdPrograms(runtimeSystemdUserPrograms)) {
 				writeRuntimeSystemdUserProgram({

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -20,6 +20,13 @@ const originalEnv = { ...process.env };
 const originalFetch = globalThis.fetch;
 const roots: string[] = [];
 
+beforeEach(() => {
+	process.env.CLAWDI_RUNTIME_GENERATION = "7";
+	process.env.CLAWDI_RUNTIME_MANIFEST_ETAG = '"manifest-generation-7"';
+	process.env.CLAWDI_RUNTIME_APPLY_RECEIPT_ID = "apply-receipt-00000007";
+	process.env.CLAWDI_RUNTIME_BOOT_NONCE = "boot-nonce-000000000007";
+});
+
 afterEach(() => {
 	process.env = { ...originalEnv };
 	globalThis.fetch = originalFetch;
@@ -33,7 +40,7 @@ describe("hosted runtime bundle v2", () => {
 		const projected = applyRuntimeBundleChannelsToManifestLoad(load);
 
 		expect(projected.sourceRevision).toBe(
-			"ab3ff081e3c46844c080c455e35d79aa886b92afa2c4195c8c1ecc99e60d7202",
+			"bdac51f2f1b837cc64dcf34c7fc58f9bfb3156ad710bb1493de27d649c137ada",
 		);
 		expect(projected.secretValues).toMatchObject(
 			(raw as { secretValues: Record<string, string> }).secretValues,
@@ -68,30 +75,25 @@ describe("hosted runtime bundle v2", () => {
 		).toThrow();
 	});
 
-	test("accepts the additive manifest v2 apply identity without changing manifest v1", () => {
+	test("requires one strict manifest v2 apply identity", () => {
 		const raw = z
 			.record(z.string(), z.unknown())
 			.parse(JSON.parse(readFileSync(goldenPath, "utf-8")));
 		const manifest = z.record(z.string(), z.unknown()).parse(raw.manifest);
-		const v1 = normalizeHostedRuntimeBundleV2(raw);
-		const v2 = normalizeHostedRuntimeBundleV2({
-			...raw,
-			manifest: {
-				...manifest,
-				schemaVersion: "clawdi.hosted-runtime.manifest.v2",
-				manifestETag: '"frozen-manifest-generation-1"',
-				applyReceiptId: "apply-receipt-0001",
-				bootNonce: "boot-nonce-000001",
-			},
-		});
+		const v2 = normalizeHostedRuntimeBundleV2(raw);
 
-		expect(v1.applyIdentity).toBeUndefined();
 		expect(v2.applyIdentity).toEqual({
 			generation: v2.manifest.generation,
-			manifestETag: '"frozen-manifest-generation-1"',
-			applyReceiptId: "apply-receipt-0001",
-			bootNonce: "boot-nonce-000001",
+			manifestETag: '"manifest-generation-7"',
+			applyReceiptId: "apply-receipt-00000007",
+			bootNonce: "boot-nonce-000000000007",
 		});
+		expect(() =>
+			normalizeHostedRuntimeBundleV2({
+				...raw,
+				manifest: { ...manifest, schemaVersion: "clawdi.hosted-runtime.manifest.v3" },
+			}),
+		).toThrow();
 		expect(() =>
 			normalizeHostedRuntimeBundleV2({
 				...raw,
@@ -124,6 +126,10 @@ describe("hosted runtime bundle v2", () => {
 				const headers = new Headers(init?.headers);
 				expect(headers.get("accept")).toBe(HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE);
 				expect(headers.get("if-none-match")).toBe('"bundle-1"');
+				expect(headers.get("x-clawdi-runtime-generation")).toBe("7");
+				expect(headers.get("x-clawdi-runtime-manifest-etag")).toBe('"manifest-generation-7"');
+				expect(headers.get("x-clawdi-runtime-apply-receipt-id")).toBe("apply-receipt-00000007");
+				expect(headers.get("x-clawdi-runtime-boot-nonce")).toBe("boot-nonce-000000000007");
 				return new Response(null, { status: 304, headers: { etag: '"bundle-1"' } });
 			},
 			{ preconnect: () => undefined },
@@ -186,9 +192,49 @@ describe("hosted runtime bundle v2", () => {
 		if (!("manifest" in loaded)) throw new Error(JSON.stringify(loaded));
 		expect(loaded.etag).toBe('"bundle-golden"');
 		expect(loaded.sourceRevision).toBe(
-			"ab3ff081e3c46844c080c455e35d79aa886b92afa2c4195c8c1ecc99e60d7202",
+			"bdac51f2f1b837cc64dcf34c7fc58f9bfb3156ad710bb1493de27d649c137ada",
 		);
 		expect(loaded.channelBindings).toHaveLength(1);
+	});
+
+	test("rejects a response tuple that differs from the boot environment", async () => {
+		const root = mkdtempSync(join(tmpdir(), "clawdi-runtime-bundle-identity-mismatch-"));
+		roots.push(root);
+		process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+		process.env.CLAWDI_RUN_DIR = join(root, "run");
+		process.env.CLAWDI_RUNTIME_HOME = "/home/clawdi";
+		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
+		process.env.CLAWDI_RUNTIME_AUTH_ENV = "CLAWDI_TEST_TOKEN";
+		process.env.CLAWDI_TEST_TOKEN = "clawdi_test";
+		const raw = z
+			.record(z.string(), z.unknown())
+			.parse(JSON.parse(readFileSync(goldenPath, "utf-8")));
+		const manifest = z.record(z.string(), z.unknown()).parse(raw.manifest);
+		const paths = getRuntimePaths({ mode: "hosted" });
+		globalThis.fetch = Object.assign(
+			async () =>
+				new Response(
+					JSON.stringify({
+						...raw,
+						manifest: { ...manifest, applyReceiptId: "apply-receipt-different-0007" },
+					}),
+					{
+						status: 200,
+						headers: {
+							"content-type": HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE,
+							etag: '"bundle-mismatched-identity"',
+						},
+					},
+				),
+			{ preconnect: () => undefined },
+		);
+
+		const loaded = await loadRemoteRuntimeManifest(paths);
+
+		expect(loaded).toMatchObject({ mode: "manifest-rejected", stage: "network" });
+		expect("errors" in loaded ? loaded.errors[0] : "").toContain(
+			"runtime manifest apply identity does not match the boot environment",
+		);
 	});
 
 	test("caches the effective projected manifest and only the scoped secret map", () => {

--- a/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
+++ b/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
@@ -1,6 +1,15 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { request } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -9,14 +18,25 @@ import { fileURLToPath } from "node:url";
 const here = dirname(fileURLToPath(import.meta.url));
 const cliRoot = join(here, "..", "..");
 const srcEntry = join(cliRoot, "src", "index.ts");
-const ENV_ID = "env-daemon-rpc-e2e";
+const ENV_ID = "20000000-0000-0000-0000-000000000007";
 const PROJECT_ID = "project-daemon-rpc-e2e";
 const API_KEY = "daemon-rpc-e2e-key";
+const GENERATION = 7;
+const MANIFEST_ETAG = '"controller-manifest-generation-7"';
+const APPLY_RECEIPT_ID = "apply-receipt-daemon-rpc-0007";
+const BOOT_NONCE = "boot-nonce-daemon-rpc-000007";
+const SOURCE_REVISION = "c".repeat(64);
+const BUNDLE_ETAG = `"sha256:${SOURCE_REVISION}"`;
+const RUNTIME_BUNDLE_MEDIA_TYPE = "application/vnd.clawdi.runtime-bundle.v2+json";
 
 interface ApiCall {
 	method: string;
 	path: string;
 	auth: string | null;
+	runtimeGeneration: string | null;
+	runtimeManifestETag: string | null;
+	runtimeApplyReceiptId: string | null;
+	runtimeBootNonce: string | null;
 	body?: unknown;
 }
 
@@ -45,8 +65,19 @@ beforeAll(() => {
 				method: req.method,
 				path: `${url.pathname}${url.search}`,
 				auth: req.headers.get("authorization"),
+				runtimeGeneration: req.headers.get("x-clawdi-runtime-generation"),
+				runtimeManifestETag: req.headers.get("x-clawdi-runtime-manifest-etag"),
+				runtimeApplyReceiptId: req.headers.get("x-clawdi-runtime-apply-receipt-id"),
+				runtimeBootNonce: req.headers.get("x-clawdi-runtime-boot-nonce"),
 				body,
 			});
+
+			if (req.method === "GET" && url.pathname === "/v1/runtime/manifest") {
+				return json(runtimeBundle(server.url.origin), 200, {
+					"content-type": RUNTIME_BUNDLE_MEDIA_TYPE,
+					etag: BUNDLE_ETAG,
+				});
+			}
 
 			if (req.method === "GET" && url.pathname === `/v1/agents/${ENV_ID}`) {
 				return json({
@@ -80,9 +111,14 @@ beforeAll(() => {
 				req.method === "POST" &&
 				url.pathname === `/v2/runtime/environments/${ENV_ID}/observations`
 			) {
-				// A v2 transport failure must not poison the independent v1
-				// liveness heartbeat or prevent its health-file update.
-				return json({ detail: "temporary v2 failure" }, 503);
+				if (!isRecord(body) || typeof body.eventId !== "string") {
+					return json({ detail: "invalid observation" }, 422);
+				}
+				return json({
+					eventId: body.eventId,
+					streamPosition: 1,
+					outcome: "accepted_head_created",
+				});
 			}
 
 			return json({ detail: "not found" }, 404);
@@ -108,8 +144,46 @@ beforeEach(() => {
 
 if (process.platform !== "win32") {
 	describe("daemon RPC process e2e", () => {
-		it("serves daemon RPC over the configured HTTP port", async () => {
+		it("persists a real runtime init tuple and posts it through the real daemon", async () => {
 			const fixture = createFixture();
+			const appliedStatePath = join(fixture.serviceStateDir, "status", "runtime-applied.json");
+			expect(existsSync(appliedStatePath)).toBe(false);
+			const initialized = await runCli(fixture, ["runtime", "init", "--non-interactive", "--json"]);
+			if (initialized.code !== 0) {
+				throw new Error(
+					`runtime init failed (${initialized.code})\nstdout:\n${initialized.stdout}\nstderr:\n${initialized.stderr}`,
+				);
+			}
+			expect(initialized.code).toBe(0);
+			expect(initialized.stderr).toBe("");
+			const initializedStatus = JSON.parse(initialized.stdout) as { status?: string };
+			expect(initializedStatus.status).toBe("ok");
+			const appliedState = JSON.parse(readFileSync(appliedStatePath, "utf-8")) as {
+				generation?: number;
+				etag?: string;
+				manifestETag?: string;
+				applyReceiptId?: string;
+				bootNonce?: string;
+			};
+			expect(appliedState).toMatchObject({
+				generation: GENERATION,
+				etag: BUNDLE_ETAG,
+				manifestETag: MANIFEST_ETAG,
+				applyReceiptId: APPLY_RECEIPT_ID,
+				bootNonce: BOOT_NONCE,
+			});
+			expect(appliedState.etag).not.toBe(appliedState.manifestETag);
+
+			const manifestRequest = apiCalls.find(
+				(call) => call.method === "GET" && call.path === "/v1/runtime/manifest",
+			);
+			expect(manifestRequest).toMatchObject({
+				runtimeGeneration: String(GENERATION),
+				runtimeManifestETag: MANIFEST_ETAG,
+				runtimeApplyReceiptId: APPLY_RECEIPT_ID,
+				runtimeBootNonce: BOOT_NONCE,
+			});
+
 			const daemon = startDaemon(fixture);
 			const daemonStdout = new Response(daemon.stdout).text();
 			const [stderrReady, stderrText] = daemon.stderr.tee();
@@ -185,8 +259,17 @@ if (process.platform !== "win32") {
 				expect(legacyObserved.bootSessionId).toBeUndefined();
 				expect(legacyObserved.eventId).toBeUndefined();
 				const observationBody = observation.body;
+				expect(observationBody.schemaVersion).toBe("clawdi.hostedRuntimeObserved.v2");
+				expect(observationBody.applyReceiptId).toBe(APPLY_RECEIPT_ID);
+				expect(observationBody.bootNonce).toBe(BOOT_NONCE);
 				expect(observationBody.bootSessionId).toBeString();
+				expect(observationBody.sequence).toBe(1);
 				expect(observationBody.eventId).toBeString();
+				if (!isRecord(observationBody.applied)) {
+					throw new Error("expected strict v2 applied observation authority");
+				}
+				expect(observationBody.applied.generation).toBe(GENERATION);
+				expect(observationBody.applied.etag).toBe(MANIFEST_ETAG);
 				expect(existsSync(join(fixture.stateDir, "codex", "health"))).toBe(true);
 				expect(apiCalls.every((call) => call.auth === `Bearer ${API_KEY}`)).toBe(true);
 			} catch (error) {
@@ -213,6 +296,7 @@ if (process.platform !== "win32") {
 
 		it("keeps v1 heartbeat healthy when v2 durable state initialization fails", async () => {
 			const fixture = createFixture();
+			writeAppliedStateFixture(fixture);
 			const heartbeatRoot = join(fixture.serviceStateDir, "heartbeat");
 			const environmentKey = createHash("sha256").update(ENV_ID).digest("hex");
 			mkdirSync(heartbeatRoot, { recursive: true });
@@ -284,28 +368,67 @@ function createFixture(): Fixture {
 		join(clawdiHome, "environments", "codex.json"),
 		`${JSON.stringify({ id: ENV_ID })}\n`,
 	);
-	mkdirSync(join(serviceStateDir, "status"), { recursive: true });
+	seedRuntimeDependencies(home, serviceStateDir);
+	return { root, home, clawdiHome, stateDir, serviceStateDir, runDir, codexHome };
+}
+
+function writeAppliedStateFixture(fixture: Fixture): void {
+	mkdirSync(join(fixture.serviceStateDir, "status"), { recursive: true });
 	writeFileSync(
-		join(serviceStateDir, "status", "runtime-applied.json"),
+		join(fixture.serviceStateDir, "status", "runtime-applied.json"),
 		`${JSON.stringify({
 			schemaVersion: "clawdi.runtimeAppliedState.v2",
 			appliedAt: "2026-07-20T00:00:00.000Z",
 			instanceId: "daemon-rpc-runtime",
-			etag: '"transport-manifest"',
-			manifestETag: '"frozen-manifest"',
-			applyReceiptId: "apply-receipt-daemon-rpc",
-			bootNonce: "boot-nonce-daemon-rpc-01",
-			sourceRevision: "a".repeat(64),
-			generation: 1,
+			etag: BUNDLE_ETAG,
+			manifestETag: MANIFEST_ETAG,
+			applyReceiptId: APPLY_RECEIPT_ID,
+			bootNonce: BOOT_NONCE,
+			sourceRevision: SOURCE_REVISION,
+			generation: GENERATION,
 			contentIdentity: {
-				sourcePath: "https://runtime.test/v1/runtime/manifest",
+				sourcePath: `${server.url.origin}/v1/runtime/manifest`,
 				sha256: "b".repeat(64),
 			},
 			providerIds: ["managed"],
 			projectedProviderIds: { codex: ["managed"] },
 		})}\n`,
 	);
-	return { root, home, clawdiHome, stateDir, serviceStateDir, runDir, codexHome };
+}
+
+function seedRuntimeDependencies(home: string, serviceStateDir: string): void {
+	const openclaw = join(home, ".openclaw", "bin", "openclaw");
+	mkdirSync(join(home, ".openclaw", "bin"), { recursive: true });
+	writeFileSync(openclaw, "#!/bin/sh\ncat >/dev/null || true\nexit 0\n");
+	chmodSync(openclaw, 0o700);
+
+	const active = join(serviceStateDir, "bin", "clawdi");
+	const target = join(serviceStateDir, "npm", "bin", "clawdi");
+	mkdirSync(join(serviceStateDir, "status"), { recursive: true });
+	mkdirSync(join(serviceStateDir, "bin"), { recursive: true });
+	mkdirSync(join(serviceStateDir, "npm", "bin"), { recursive: true });
+	writeFileSync(
+		target,
+		`#!/bin/sh
+if [ "\${1:-}" = "--version" ]; then echo 0.12.10-beta.55; exit 0; fi
+exit 0
+`,
+	);
+	chmodSync(target, 0o700);
+	symlinkSync(target, active);
+	writeFileSync(
+		join(serviceStateDir, "status", "cli-bootstrap.json"),
+		`${JSON.stringify({
+			status: "installed",
+			source: "npm",
+			packageSpec: "clawdi@0.12.10-beta.55",
+			registry: "https://registry.npmjs.org",
+			npmPrefix: join(serviceStateDir, "npm"),
+			activePath: active,
+			activeTarget: target,
+			version: "0.12.10-beta.55",
+		})}\n`,
+	);
 }
 
 function startDaemon(fixture: Fixture): ReturnType<typeof Bun.spawn> {
@@ -348,6 +471,14 @@ function cliEnv(fixture: Fixture): Record<string, string> {
 		CLAWDI_SERVE_MODE: "container",
 		CLAWDI_RUNTIME_MODE: "hosted",
 		CLAWDI_RUNTIME_HOME: fixture.home,
+		CLAWDI_RUNTIME_MANIFEST_URL: `${server.url.origin}/v1/runtime/manifest`,
+		CLAWDI_RUNTIME_AUTH_ENV: "CLAWDI_AUTH_TOKEN",
+		CLAWDI_RUNTIME_GENERATION: String(GENERATION),
+		CLAWDI_RUNTIME_MANIFEST_ETAG: MANIFEST_ETAG,
+		CLAWDI_RUNTIME_APPLY_RECEIPT_ID: APPLY_RECEIPT_ID,
+		CLAWDI_RUNTIME_BOOT_NONCE: BOOT_NONCE,
+		CLAWDI_SYSTEMD_APPLY: "0",
+		CLAWDI_CODEX_INSTALL_DISABLED: "1",
 		CLAWDI_RUN_DIR: fixture.runDir,
 		CLAWDI_SERVICE_STATE_DIR: fixture.serviceStateDir,
 		CLAWDI_STATE_DIR: fixture.stateDir,
@@ -357,6 +488,77 @@ function cliEnv(fixture: Fixture): Record<string, string> {
 		NO_COLOR: "1",
 		PATH: process.env.PATH ?? "",
 		TMPDIR: tmpdir(),
+	};
+}
+
+function runtimeBundle(apiUrl: string): Record<string, unknown> {
+	return {
+		schemaVersion: "clawdi.hosted-runtime.bundle.v2",
+		sourceRevision: SOURCE_REVISION,
+		manifest: {
+			schemaVersion: "clawdi.hosted-runtime.manifest.v2",
+			minimumCliVersion: "0.12.10-beta.55",
+			runtime: "openclaw",
+			deploymentId: "dep-daemon-rpc-e2e",
+			environmentId: ENV_ID,
+			instanceId: "daemon-rpc-runtime",
+			generation: GENERATION,
+			manifestETag: MANIFEST_ETAG,
+			applyReceiptId: APPLY_RECEIPT_ID,
+			bootNonce: BOOT_NONCE,
+			issuedAt: "2026-07-20T00:00:00.000Z",
+			locale: { language: "en", timezone: "UTC" },
+			system: {},
+			controlPlane: { cloudApiUrl: apiUrl },
+			clawdiCli: {
+				source: "npm:clawdi",
+				packageSpec: "clawdi@0.12.10-beta.55",
+				registry: "https://registry.npmjs.org",
+			},
+			runtimes: {
+				openclaw: {
+					enabled: true,
+					install: { source: "official" },
+					providerMode: "configured",
+					provider_ids: ["managed"],
+					primary_model: { provider_id: "managed", model: "gpt-test" },
+					run: { args: ["gateway", "run"], env: {}, prependPath: [] },
+					services: {},
+				},
+			},
+			providers: {
+				managed: {
+					kind: "openai-compatible",
+					type: "openai",
+					baseUrl: "https://provider.test/v1",
+					apiMode: "openai_chat",
+					apiKeySecretRef: "tool.codex.apiKey",
+				},
+			},
+			terminalTooling: {
+				codex: {
+					enabled: true,
+					provider_id: "managed",
+					primary_model: { provider_id: "managed", model: "gpt-test" },
+					provider: {
+						kind: "openai-compatible",
+						type: "custom_openai_compatible",
+						baseUrl: "https://provider.test/v1",
+						apiMode: "openai_responses",
+						managed_by: "clawdi",
+						runtimeEnvName: "OPENAI_API_KEY",
+						apiKeySecretRef: "tool.codex.apiKey",
+					},
+				},
+			},
+			liveSync: {
+				enabled: true,
+				agents: [{ agentType: "codex", environmentId: ENV_ID }],
+			},
+			recovery: { cacheManifest: true, allowOfflineBoot: true },
+		},
+		channelBindings: [],
+		secretValues: { "tool.codex.apiKey": "sk-daemon-rpc-e2e" },
 	};
 }
 

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -96,6 +96,10 @@ const ENV_KEYS = [
 	"CLAWDI_CODEX_INSTALL_TIMEOUT",
 	"CUSTOM_RUNTIME_TOKEN",
 	"CLAWDI_RUNTIME_MANIFEST_TIMEOUT_MS",
+	"CLAWDI_RUNTIME_GENERATION",
+	"CLAWDI_RUNTIME_MANIFEST_ETAG",
+	"CLAWDI_RUNTIME_APPLY_RECEIPT_ID",
+	"CLAWDI_RUNTIME_BOOT_NONCE",
 	"CLAWDI_API_URL",
 	"CLAWDI_SYSTEMD_APPLY",
 	"CLAWDI_SYSTEMD_SYSTEM_ROOT",
@@ -127,6 +131,7 @@ beforeEach(() => {
 	mkdirSync(root, { recursive: true });
 	process.env.CLAWDI_CODEX_INSTALL_DISABLED = "1";
 	process.env.CLAWDI_RUNTIME_AUTH_ENV = "CLAWDI_AUTH_TOKEN";
+	setRuntimeApplyIdentityEnv(1);
 });
 
 afterEach(() => {
@@ -197,6 +202,7 @@ const TEST_HOSTED_LOCALE = {
 	timezone: "UTC",
 };
 const TEST_HOSTED_MINIMUM_CLI_VERSION = "0.12.10-beta.55";
+const HOSTED_MANIFEST_V2_SCHEMA_VERSION = "clawdi.hosted-runtime.manifest.v2";
 const TEST_HOSTED_CODEX_SECRET_REF = "tool.codex.apiKey";
 const TEST_HOSTED_CODEX_SECRET_VALUES = {
 	[TEST_HOSTED_CODEX_SECRET_REF]: "sk-codex-tool",
@@ -284,6 +290,7 @@ function hostedRuntimeBundleResponse(
 	payload: HostedRuntimeResponseFixture,
 	options: { etag?: string; sourceRevision?: string } = {},
 ): Response {
+	const manifest = hostedManifestV2Fixture(payload.manifest);
 	const channelBindings = payload.channelBindings ?? [];
 	const secretValues = {
 		...TEST_HOSTED_CODEX_SECRET_VALUES,
@@ -292,7 +299,7 @@ function hostedRuntimeBundleResponse(
 	const sourceRevision =
 		options.sourceRevision ??
 		runtimeContentSha256({
-			manifest: payload.manifest,
+			manifest,
 			channelBindings,
 			secretValues,
 		});
@@ -307,7 +314,7 @@ function hostedRuntimeBundleResponse(
 		JSON.stringify({
 			schemaVersion: "clawdi.hosted-runtime.bundle.v2",
 			sourceRevision,
-			manifest: payload.manifest,
+			manifest,
 			channelBindings,
 			secretValues,
 		}),
@@ -321,6 +328,27 @@ function hostedRuntimeBundleResponse(
 	);
 }
 
+function hostedManifestV2Fixture(manifest: Record<string, unknown>): Record<string, unknown> {
+	const generation = manifest.generation;
+	if (typeof generation !== "number" || !Number.isSafeInteger(generation) || generation < 1) {
+		throw new Error("hosted manifest fixture generation must be a positive safe integer");
+	}
+	return {
+		...manifest,
+		schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+		manifestETag: `"manifest-generation-${generation}"`,
+		applyReceiptId: `apply-receipt-${String(generation).padStart(8, "0")}`,
+		bootNonce: `boot-nonce-${String(generation).padStart(12, "0")}`,
+	};
+}
+
+function setRuntimeApplyIdentityEnv(generation: number): void {
+	process.env.CLAWDI_RUNTIME_GENERATION = String(generation);
+	process.env.CLAWDI_RUNTIME_MANIFEST_ETAG = `"manifest-generation-${generation}"`;
+	process.env.CLAWDI_RUNTIME_APPLY_RECEIPT_ID = `apply-receipt-${String(generation).padStart(8, "0")}`;
+	process.env.CLAWDI_RUNTIME_BOOT_NONCE = `boot-nonce-${String(generation).padStart(12, "0")}`;
+}
+
 function hostedRuntimeWatchLocalePayload(
 	home: string,
 	generation: number,
@@ -328,8 +356,7 @@ function hostedRuntimeWatchLocalePayload(
 	timezone = "Europe/Paris",
 ): HostedRuntimeResponseFixture {
 	return {
-		manifest: {
-			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+		manifest: hostedManifestV2Fixture({
 			minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 			runtime: "openclaw",
 			deploymentId: "dep_watch_locale",
@@ -349,7 +376,7 @@ function hostedRuntimeWatchLocalePayload(
 			runtimes: {
 				openclaw: hostedOpenClawRuntime({}),
 			},
-		},
+		}),
 		secretValues: TEST_HOSTED_CODEX_SECRET_VALUES,
 	};
 }
@@ -372,8 +399,7 @@ function hostedCliManifestResponse(
 			}
 		: hostedRequiredState().providers.default;
 	return {
-		manifest: {
-			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+		manifest: hostedManifestV2Fixture({
 			minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 			runtime: "openclaw",
 			deploymentId: "dep_cli_package_spec",
@@ -394,7 +420,7 @@ function hostedCliManifestResponse(
 			runtimes: {
 				openclaw: hostedOpenClawRuntime({}),
 			},
-		},
+		}),
 		secretValues: TEST_HOSTED_CODEX_SECRET_VALUES,
 	};
 }
@@ -786,7 +812,7 @@ function hostedHermesProviderLoad(home: string): RuntimeManifestLoad {
 				},
 			},
 			projection: {
-				sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v2",
 				system: { home },
 				providers: {
 					hermes: {
@@ -930,7 +956,7 @@ function hostedProviderSwitchLoad(
 				},
 			},
 			projection: {
-				sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v2",
 				system: { home, workspace: join(home, "clawdi") },
 				providers: HOSTED_PROVIDER_SWITCH_PROVIDERS,
 				terminalTooling,
@@ -1030,7 +1056,7 @@ function hostedSingleProviderModeLoad(
 			controlPlane: { apiUrl: "https://cloud-api.test" },
 			runtimes: { [runtimeName]: { ...runtime, install } },
 			projection: {
-				sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v2",
 				system: { home, workspace: join(home, "clawdi") },
 				providers,
 				terminalTooling,
@@ -1750,6 +1776,7 @@ describe("runtime manifest datasource", () => {
 	});
 
 	it("fetches hosted-runtime manifests from a configured runtime source", async () => {
+		setRuntimeApplyIdentityEnv(3);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -1777,7 +1804,10 @@ describe("runtime manifest datasource", () => {
 				response: () =>
 					hostedRuntimeBundleResponse({
 						manifest: {
-							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+							manifestETag: '"manifest-generation-3"',
+							applyReceiptId: "apply-receipt-00000003",
+							bootNonce: "boot-nonce-000000000003",
 							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "openclaw",
 							deploymentId: "dep_test",
@@ -2044,6 +2074,7 @@ describe("runtime manifest datasource", () => {
 	}
 
 	it("recovers hosted bridge token from pid1 env for Hermes runtime bridge exposure", async () => {
+		setRuntimeApplyIdentityEnv(4);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -2090,7 +2121,10 @@ chmod +x "$HOME/.local/bin/hermes"
 				response: () =>
 					hostedRuntimeBundleResponse({
 						manifest: {
-							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+							manifestETag: '"manifest-generation-4"',
+							applyReceiptId: "apply-receipt-00000004",
+							bootNonce: "boot-nonce-000000000004",
 							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "hermes",
 							deploymentId: "dep_runtime_bridge",
@@ -2183,7 +2217,10 @@ chmod +x "$HOME/.local/bin/hermes"
 				response: () =>
 					hostedRuntimeBundleResponse({
 						manifest: {
-							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+							manifestETag: '"manifest-generation-1"',
+							applyReceiptId: "apply-receipt-00000001",
+							bootNonce: "boot-nonce-000000000001",
 							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "openclaw",
 							deploymentId: "dep_chat_provider",
@@ -2282,7 +2319,10 @@ chmod +x "$HOME/.local/bin/hermes"
 				response: () =>
 					hostedRuntimeBundleResponse({
 						manifest: {
-							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+							manifestETag: '"manifest-generation-1"',
+							applyReceiptId: "apply-receipt-00000001",
+							bootNonce: "boot-nonce-000000000001",
 							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "openclaw",
 							deploymentId: "dep_codex_provider",
@@ -2425,7 +2465,7 @@ chmod +x "$HOME/.local/bin/hermes"
 					hermes: { enabled: false },
 				},
 				projection: {
-					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v2",
 					system: {
 						home,
 						openclawControlUiAllowedOrigins: ["https://app-v2-18789.k3s.example.test"],
@@ -2544,7 +2584,7 @@ chmod +x "$HOME/.local/bin/hermes"
 						hermes: { enabled: false },
 					},
 					projection: {
-						sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+						sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v2",
 						system: { home },
 						providers: {},
 						terminalTooling: {
@@ -3017,7 +3057,7 @@ chmod +x "$HOME/.local/bin/hermes"
 					},
 				},
 				projection: {
-					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v2",
 					system: { home },
 					providers: {
 						[providerId]: {
@@ -3507,7 +3547,7 @@ exit 0
 					},
 				},
 				projection: {
-					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v2",
 					system: {
 						home,
 						openclawControlUiAllowedOrigins: ["https://app-v2-18789.k3s.example.test"],
@@ -3628,7 +3668,7 @@ exit 0
 					},
 				},
 				projection: {
-					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v2",
 					system: { home },
 					providers: {
 						openclaw: {
@@ -3901,7 +3941,7 @@ exit 0
 					},
 				},
 				projection: {
-					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v2",
 					system: { home },
 				},
 			},
@@ -4069,7 +4109,7 @@ exit 0
 					},
 				},
 				projection: {
-					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v2",
 					system: { home },
 					providers: {
 						openclaw: {
@@ -4147,7 +4187,7 @@ exit 0
 					},
 				},
 				projection: {
-					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v2",
 					system: { home },
 					providers: {
 						openclaw: {
@@ -4254,7 +4294,7 @@ exit 0
 						},
 					},
 					projection: {
-						sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
+						sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v2",
 						system: { home },
 						providers: {
 							openclaw: {
@@ -4299,7 +4339,10 @@ exit 0
 			manifestPath,
 			JSON.stringify({
 				manifest: {
-					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+					manifestETag: '"manifest-generation-5"',
+					applyReceiptId: "apply-receipt-00000005",
+					bootNonce: "boot-nonce-000000000005",
 					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "openclaw",
 					deploymentId: "dep_hosted_provider_secret",
@@ -4468,7 +4511,10 @@ exit 64
 			manifestPath,
 			JSON.stringify({
 				manifest: {
-					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+					manifestETag: '"manifest-generation-1"',
+					applyReceiptId: "apply-receipt-00000001",
+					bootNonce: "boot-nonce-000000000001",
 					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "openclaw",
 					deploymentId: "dep_bridge_token",
@@ -4516,7 +4562,10 @@ exit 64
 			manifestPath,
 			JSON.stringify({
 				manifest: {
-					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+					manifestETag: '"manifest-generation-1"',
+					applyReceiptId: "apply-receipt-00000001",
+					bootNonce: "boot-nonce-000000000001",
 					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "openclaw",
 					deploymentId: "dep_bridge_token_explicit",
@@ -4590,7 +4639,10 @@ exit 64
 				response: () =>
 					hostedRuntimeBundleResponse({
 						manifest: {
-							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+							manifestETag: '"manifest-generation-1"',
+							applyReceiptId: "apply-receipt-00000001",
+							bootNonce: "boot-nonce-000000000001",
 							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "hermes",
 							deploymentId: "dep_custom_auth",
@@ -4656,7 +4708,10 @@ exit 64
 				response: () =>
 					hostedRuntimeBundleResponse({
 						manifest: {
-							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+							manifestETag: '"manifest-generation-1"',
+							applyReceiptId: "apply-receipt-00000001",
+							bootNonce: "boot-nonce-000000000001",
 							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "openclaw",
 							deploymentId: "dep_same_token",
@@ -4690,7 +4745,10 @@ exit 64
 				response: () =>
 					hostedRuntimeBundleResponse({
 						manifest: {
-							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+							manifestETag: '"manifest-generation-2"',
+							applyReceiptId: "apply-receipt-00000002",
+							bootNonce: "boot-nonce-000000000002",
 							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "openclaw",
 							deploymentId: "dep_same_token",
@@ -5210,6 +5268,7 @@ exit 64
 	});
 
 	it("runtime watch wakes on its own manifest SSE signal and restarts only the runtime unit", async () => {
+		setRuntimeApplyIdentityEnv(2);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -5319,6 +5378,7 @@ exit 0
 	});
 
 	it("runtime watch keeps polling after SSE authentication failure", async () => {
+		setRuntimeApplyIdentityEnv(2);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -5366,6 +5426,7 @@ exit 0
 		"authentication failure",
 		"task completion",
 	])("runtime watch re-subscribes after SSE %s with unchanged connection identity", async (completionMode) => {
+		setRuntimeApplyIdentityEnv(2);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -5434,6 +5495,7 @@ exit 0
 	});
 
 	it("runtime watch applies remote changes, tracks systemd unit changes, and saves the new ETag", async () => {
+		setRuntimeApplyIdentityEnv(12);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -5483,7 +5545,10 @@ printf 'ActiveState=active\\nSubState=running\\n'
 							schemaVersion: "clawdi.hosted-runtime.bundle.v2",
 							sourceRevision: "a".repeat(64),
 							manifest: {
-								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+								manifestETag: '"manifest-generation-12"',
+								applyReceiptId: "apply-receipt-00000012",
+								bootNonce: "boot-nonce-000000000012",
 								minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 								runtime: "openclaw",
 								deploymentId: "dep_watch",
@@ -5586,6 +5651,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 	});
 
 	it("runtime watch advances applied generation on a generation-only manifest update", async () => {
+		setRuntimeApplyIdentityEnv(30);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -5636,6 +5702,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 
 			generation = 31;
 			manifestEtag = '"manifest-generation-31"';
+			setRuntimeApplyIdentityEnv(31);
 			process.exitCode = undefined;
 			await runtimeWatch({ once: true, json: true });
 
@@ -5657,6 +5724,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 	});
 
 	it("runtime watch does not advance last-good or applied authority when systemd apply fails", async () => {
+		setRuntimeApplyIdentityEnv(13);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -5742,7 +5810,10 @@ exit 42
 					hostedRuntimeBundleResponse(
 						{
 							manifest: {
-								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+								manifestETag: '"manifest-generation-13"',
+								applyReceiptId: "apply-receipt-00000013",
+								bootNonce: "boot-nonce-000000000013",
 								minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 								runtime: "openclaw",
 								deploymentId: "dep_watch_systemd_failure",
@@ -5797,6 +5868,7 @@ exit 42
 	});
 
 	it("runtime watch trusts the committed v2 authority after a manifest 304", async () => {
+		setRuntimeApplyIdentityEnv(22);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -5814,7 +5886,10 @@ exit 42
 			schemaVersion: "clawdi.hosted-runtime.bundle.v2",
 			sourceRevision: "d".repeat(64),
 			manifest: {
-				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+				manifestETag: '"manifest-generation-22"',
+				applyReceiptId: "apply-receipt-00000022",
+				bootNonce: "boot-nonce-000000000022",
 				minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 				runtime: "openclaw",
 				deploymentId: "dep_watch_secret",
@@ -6022,6 +6097,7 @@ exit 64
 	});
 
 	it("runtime watch retries datasource failures and applies after recovery", async () => {
+		setRuntimeApplyIdentityEnv(18);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -6090,7 +6166,10 @@ exit 64
 					hostedRuntimeBundleResponse(
 						{
 							manifest: {
-								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+								manifestETag: '"manifest-generation-18"',
+								applyReceiptId: "apply-receipt-00000018",
+								bootNonce: "boot-nonce-000000000018",
 								minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 								runtime: "openclaw",
 								deploymentId: "dep_watch_recovery",
@@ -6608,6 +6687,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 	});
 
 	it("runtime watch installs changed CLI package specs and marks itself for re-exec", async () => {
+		setRuntimeApplyIdentityEnv(13);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -6684,7 +6764,10 @@ chmod +x "$prefix/bin/clawdi"
 					hostedRuntimeBundleResponse(
 						{
 							manifest: {
-								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+								manifestETag: '"manifest-generation-13"',
+								applyReceiptId: "apply-receipt-00000013",
+								bootNonce: "boot-nonce-000000000013",
 								minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 								runtime: "openclaw",
 								deploymentId: "dep_cli_update",
@@ -6753,6 +6836,7 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it("runtime watch reapplies transparent egress across CLI self-upgrade", async () => {
+		setRuntimeApplyIdentityEnv(2);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -6909,7 +6993,10 @@ printf 'ActiveState=active\\nSubState=running\\n'
 					hostedRuntimeBundleResponse(
 						{
 							manifest: {
-								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+								manifestETag: '"manifest-generation-2"',
+								applyReceiptId: "apply-receipt-00000002",
+								bootNonce: "boot-nonce-000000000002",
 								minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 								runtime: "openclaw",
 								deploymentId: "dep_cli_mitm",
@@ -7313,6 +7400,7 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it("runtime watch self-heal applies an exact hosted CLI version without npm view", async () => {
+		setRuntimeApplyIdentityEnv(30);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -7391,7 +7479,10 @@ chmod +x "$prefix/bin/clawdi"
 		);
 		const manifestPayload = {
 			manifest: {
-				schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+				schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+				manifestETag: '"manifest-generation-30"',
+				applyReceiptId: "apply-receipt-00000030",
+				bootNonce: "boot-nonce-000000000030",
 				minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 				runtime: "openclaw",
 				deploymentId: "dep_cli_self_heal",
@@ -7495,6 +7586,7 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it("runtime watch keeps self re-exec when convergence fails after CLI install", async () => {
+		setRuntimeApplyIdentityEnv(16);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -7589,7 +7681,10 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 					hostedRuntimeBundleResponse(
 						{
 							manifest: {
-								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+								manifestETag: '"manifest-generation-16"',
+								applyReceiptId: "apply-receipt-00000016",
+								bootNonce: "boot-nonce-000000000016",
 								minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 								runtime: "openclaw",
 								deploymentId: "dep_cli_update_converge_failure",
@@ -7652,6 +7747,7 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 	});
 
 	it("rolls back a CLI upgrade when first converge fails for an already-applied manifest", async () => {
+		setRuntimeApplyIdentityEnv(18);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -7729,7 +7825,10 @@ chmod +x "$prefix/bin/clawdi"
 		const paths = getRuntimePaths();
 		const oldTarget = readlinkSync(paths.cliManagedBin);
 		const manifest = {
-			schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+			schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+			manifestETag: '"manifest-generation-18"',
+			applyReceiptId: "apply-receipt-00000018",
+			bootNonce: "boot-nonce-000000000018",
 			minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 			runtime: "openclaw",
 			deploymentId: "dep_cli_rollback",
@@ -7837,6 +7936,7 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it("runtime watch does not converge or apply systemd when CLI install fails", async () => {
+		setRuntimeApplyIdentityEnv(17);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -7879,7 +7979,10 @@ chmod +x "$prefix/bin/clawdi"
 					hostedRuntimeBundleResponse(
 						{
 							manifest: {
-								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+								manifestETag: '"manifest-generation-17"',
+								applyReceiptId: "apply-receipt-00000017",
+								bootNonce: "boot-nonce-000000000017",
 								minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 								runtime: "openclaw",
 								deploymentId: "dep_cli_update_failure",
@@ -7939,6 +8042,7 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it("runs CLI update before blocking desired state below minimumCliVersion", async () => {
+		setRuntimeApplyIdentityEnv(19);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -8008,7 +8112,10 @@ chmod +x "$prefix/bin/clawdi"
 					hostedRuntimeBundleResponse(
 						{
 							manifest: {
-								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+								manifestETag: '"manifest-generation-19"',
+								applyReceiptId: "apply-receipt-00000019",
+								bootNonce: "boot-nonce-000000000019",
 								runtime: "openclaw",
 								deploymentId: "dep_min_cli",
 								environmentId: "env_min_cli",
@@ -8427,6 +8534,7 @@ chmod +x "$prefix/bin/clawdi"
 	});
 
 	it("runtime init applies remote channel desired state during first boot", async () => {
+		setRuntimeApplyIdentityEnv(7);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -8497,7 +8605,10 @@ exit 64
 					hostedRuntimeBundleResponse(
 						{
 							manifest: {
-								schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+								schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+								manifestETag: '"manifest-generation-7"',
+								applyReceiptId: "apply-receipt-00000007",
+								bootNonce: "boot-nonce-000000000007",
 								minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 								runtime: "openclaw",
 								deploymentId: "dep_init",
@@ -8629,6 +8740,7 @@ exit 64
 	});
 
 	it("runtime init records malformed bundle channel references as a boot error", async () => {
+		setRuntimeApplyIdentityEnv(7);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -9795,7 +9907,10 @@ exit 64
 				response: () =>
 					hostedRuntimeBundleResponse({
 						manifest: {
-							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+							manifestETag: '"manifest-generation-1"',
+							applyReceiptId: "apply-receipt-00000001",
+							bootNonce: "boot-nonce-000000000001",
 							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "hermes",
 							deploymentId: "dep_workspace",
@@ -9922,7 +10037,10 @@ exit 64
 			manifestPath,
 			JSON.stringify({
 				manifest: {
-					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+					manifestETag: '"manifest-generation-1"',
+					applyReceiptId: "apply-receipt-00000001",
+					bootNonce: "boot-nonce-000000000001",
 					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "hermes",
 					deploymentId: "dep_legacy_api_url",
@@ -9993,7 +10111,10 @@ exit 64
 			manifestPath,
 			JSON.stringify({
 				manifest: {
-					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+					manifestETag: '"manifest-generation-1"',
+					applyReceiptId: "apply-receipt-00000001",
+					bootNonce: "boot-nonce-000000000001",
 					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "hermes",
 					deploymentId: "dep_runtime_workspace",
@@ -11066,7 +11187,10 @@ exit 64
 				response: () =>
 					hostedRuntimeBundleResponse({
 						manifest: {
-							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+							manifestETag: '"manifest-generation-1"',
+							applyReceiptId: "apply-receipt-00000001",
+							bootNonce: "boot-nonce-000000000001",
 							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "openclaw",
 							deploymentId: "dep_manifest_only",
@@ -11104,6 +11228,7 @@ exit 64
 	});
 
 	it("converges remote manifests without caching secret values", async () => {
+		setRuntimeApplyIdentityEnv(4);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -11122,7 +11247,10 @@ exit 64
 				response: () =>
 					hostedRuntimeBundleResponse({
 						manifest: {
-							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+							manifestETag: '"manifest-generation-4"',
+							applyReceiptId: "apply-receipt-00000004",
+							bootNonce: "boot-nonce-000000000004",
 							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "openclaw",
 							deploymentId: "dep_test",
@@ -11397,6 +11525,7 @@ exit 64
 	});
 
 	it("registers live-sync environments and starts one hosted daemon", async () => {
+		setRuntimeApplyIdentityEnv(9);
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -11414,7 +11543,10 @@ exit 64
 				response: () =>
 					hostedRuntimeBundleResponse({
 						manifest: {
-							schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+							schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+							manifestETag: '"manifest-generation-9"',
+							applyReceiptId: "apply-receipt-00000009",
+							bootNonce: "boot-nonce-000000000009",
 							minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 							runtime: "openclaw",
 							deploymentId: "dep_sync",
@@ -11520,7 +11652,10 @@ exit 64
 			manifestPath,
 			JSON.stringify({
 				manifest: {
-					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+					manifestETag: '"manifest-generation-1"',
+					applyReceiptId: "apply-receipt-00000001",
+					bootNonce: "boot-nonce-000000000001",
 					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "openclaw",
 					deploymentId: "dep_no_secret_ref",
@@ -11573,7 +11708,10 @@ exit 64
 			manifestPath,
 			JSON.stringify({
 				manifest: {
-					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					schemaVersion: HOSTED_MANIFEST_V2_SCHEMA_VERSION,
+					manifestETag: '"manifest-generation-1"',
+					applyReceiptId: "apply-receipt-00000001",
+					bootNonce: "boot-nonce-000000000001",
 					minimumCliVersion: TEST_HOSTED_MINIMUM_CLI_VERSION,
 					runtime: "hermes",
 					deploymentId: "dep_bad_mitm",

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -2181,6 +2181,10 @@ chmod +x "$HOME/.local/bin/hermes"
 			const hermesDashboardEnv = readSystemdEnvFile(paths, "clawdi-hermes-dashboard");
 
 			expect(watchEnv).toContain('CLAWDI_RUNTIME_BRIDGE_TOKEN="bridge-token"');
+			expect(watchEnv).toContain('CLAWDI_RUNTIME_GENERATION="4"');
+			expect(watchEnv).toContain('CLAWDI_RUNTIME_MANIFEST_ETAG="\\"manifest-generation-4\\""');
+			expect(watchEnv).toContain('CLAWDI_RUNTIME_APPLY_RECEIPT_ID="apply-receipt-00000004"');
+			expect(watchEnv).toContain('CLAWDI_RUNTIME_BOOT_NONCE="boot-nonce-000000000004"');
 			expect(sidecarEnv).toContain('CLAWDI_RUNTIME_BRIDGE_TOKEN="bridge-token"');
 			expect(
 				convergence.outputs.systemdUserUnits.map((path) => path.split("/").at(-1)),

--- a/packages/cli/tests/smoke.test.ts
+++ b/packages/cli/tests/smoke.test.ts
@@ -304,13 +304,16 @@ chmod +x "$HOME/.openclaw/bin/openclaw"
 			manifestPath,
 			JSON.stringify({
 				manifest: {
-					schemaVersion: "clawdi.hosted-runtime.manifest.v1",
+					schemaVersion: "clawdi.hosted-runtime.manifest.v2",
 					minimumCliVersion: "0.12.10-beta.55",
 					runtime: "openclaw",
 					deploymentId: "dep_strict_smoke",
 					environmentId: "env_strict_smoke",
 					instanceId: "iid_strict_smoke",
 					generation: 1,
+					manifestETag: '"manifest-generation-1"',
+					applyReceiptId: "apply-receipt-00000001",
+					bootNonce: "boot-nonce-000000000001",
 					issuedAt: "2026-07-12T00:00:00Z",
 					locale: { language: "en", timezone: "UTC" },
 					system: {},

--- a/packages/shared/src/api/api.generated.ts
+++ b/packages/shared/src/api/api.generated.ts
@@ -9469,7 +9469,12 @@ export interface operations {
             query?: {
                 environment_id?: string | null;
             };
-            header?: never;
+            header: {
+                "X-Clawdi-Runtime-Generation": number;
+                "X-Clawdi-Runtime-Manifest-ETag": string;
+                "X-Clawdi-Runtime-Apply-Receipt-ID": string;
+                "X-Clawdi-Runtime-Boot-Nonce": string;
+            };
             path?: never;
             cookie?: never;
         };

--- a/test-fixtures/runtime-bundle-v2.golden.json
+++ b/test-fixtures/runtime-bundle-v2.golden.json
@@ -19,6 +19,9 @@
 		"deploymentId": "dep_test",
 		"environmentId": "20000000-0000-0000-0000-000000000002",
 		"generation": 7,
+		"manifestETag": "\"manifest-generation-7\"",
+		"applyReceiptId": "apply-receipt-00000007",
+		"bootNonce": "boot-nonce-000000000007",
 		"instanceId": "hri_test",
 		"issuedAt": "2026-07-13T00:00:00+00:00",
 		"liveSync": {
@@ -69,7 +72,7 @@
 				"services": {}
 			}
 		},
-		"schemaVersion": "clawdi.hosted-runtime.manifest.v1",
+		"schemaVersion": "clawdi.hosted-runtime.manifest.v2",
 		"system": {},
 		"terminalTooling": {
 			"codex": {
@@ -97,5 +100,5 @@
 		"secret://channels/telegram/clawdi_50000000000000000000000000000005/agent-token": "123456789:telegram-agent-golden",
 		"secret://channels/telegram/clawdi_50000000000000000000000000000005/placeholder-token": "999999999:9ded1453047ec0a48ec3b735075f7448"
 	},
-	"sourceRevision": "ab3ff081e3c46844c080c455e35d79aa886b92afa2c4195c8c1ecc99e60d7202"
+	"sourceRevision": "bdac51f2f1b837cc64dcf34c7fc58f9bfb3156ad710bb1493de27d649c137ada"
 }


### PR DESCRIPTION
## Why

Declarative Hosted Ready requires the guest daemon to self-attest the controller-selected apply tuple through the direct v2 runtime-observation endpoint. Hosted already injects generation, manifest ETag, apply receipt ID, and boot nonce, but the Cloud manifest and CLI apply path did not carry that tuple end to end.

## One clean model

- The Hosted controller remains the tuple authority.
- The runtime manifest GET requires all four X-Clawdi-Runtime-* headers and validates the desired generation.
- Cloud renders only the strict inner clawdi.hosted-runtime.manifest.v2 shape and echoes the exact request tuple.
- The outer sourceRevision/content ETag remains separate from the controller manifestETag.
- The CLI strictly reads the complete environment tuple, sends it on manifest GET, and rejects any response tuple mismatch.
- A successful convergence atomically commits the tuple with runtime-applied.json. Failed Apply leaves the previous authority untouched.
- The existing durable daemon emitter creates boot-session, sequence, event, and capture identities locally and POSTs direct v2 evidence without a flag or v1 heartbeat translation.

## Changes

- Add required runtime apply-identity headers to the Cloud manifest route and regenerated API client.
- Render only strict inner manifest.v2 with generation, manifestETag, applyReceiptId, and bootNonce.
- Add strict CLI environment parsing and request-header projection.
- Bind remote response identity to the boot environment before normalization or persistence.
- Extend process e2e coverage from a clean state through real runtime init, atomic durable state, real daemon startup, and an exact direct-v2 observation POST.
- Document the authority and persistence model.

## Net deletions

- Remove the production and fixture inner manifest.v1 schemas and the v1/v2 discriminated unions.
- Remove the v1 projection branch from convergence.
- Remove remaining v1 fixtures and assertions in this repository.
- Add no compatibility shim, feature flag, or heartbeat evidence bridge.

## Verification

- bun run --cwd packages/cli test — 1015 passed, 0 failed.
- bun test packages/cli/tests/e2e/daemon-rpc.e2e.test.ts — 2 passed, 0 failed; the test starts without a preseeded applied tuple, runs real runtime init, starts the real daemon, and receives the direct-v2 POST.
- bun test packages/cli/src/runtime/apply-identity.test.ts packages/cli/src/runtime/runtime-bundle-v2.test.ts — 11 passed, 0 failed.
- cd backend && uv run pytest -q — 1319 passed, 7 skipped, 13 warnings.
- cd backend && uv run pytest -q tests/test_runtime_manifest.py — 214 passed.
- cd backend && uv run pytest -q tests/test_runtime_source.py — 16 passed.
- bun run typecheck — 4/4 tasks successful.
- bun run check — 662 files checked, no fixes.
- Backend Ruff check, Ruff format check, compileall, generated API check, git diff --check, and pre-commit Biome all passed.

## Coordination and release boundary

Companion Hosted/systemd/Ready-gate PR: https://github.com/Clawdi-AI/clawdi-hosted/pull/974

No CLI package was published. No runtime image was built or promoted. Merge and release remain owner-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

