### PR TITLE
feat(v2): runtime observation producer (minimal, legacy-safe)

### DIFF
--- a/backend/app/services/runtime_observation.py
+++ b/backend/app/services/runtime_observation.py
@@ -1065,12 +1065,6 @@ async def read_runtime_observations(
             fence=fence,
             consumer_id=consumer_id,
         )
-    identity_predicates = (
-        V2RuntimeObservationInbox.generation == expected_apply_identity.generation,
-        V2RuntimeObservationInbox.manifest_etag == expected_apply_identity.manifest_etag,
-        V2RuntimeObservationInbox.apply_receipt_id == expected_apply_identity.apply_receipt_id,
-        V2RuntimeObservationInbox.boot_nonce == expected_apply_identity.boot_nonce,
-    )
     events = list(
         (
             await db.execute(
@@ -1079,7 +1073,6 @@ async def read_runtime_observations(
                     V2RuntimeObservationInbox.environment_id == environment_id,
                     V2RuntimeObservationInbox.id > decoded.stream_position,
                     V2RuntimeObservationInbox.id <= high_water,
-                    *identity_predicates,
                 )
                 .order_by(V2RuntimeObservationInbox.id)
                 .limit(limit + 1)
@@ -1088,9 +1081,19 @@ async def read_runtime_observations(
         .scalars()
         .all()
     )
-    has_more = len(events) > limit
-    page = events[:limit]
-    next_position = page[-1].id if has_more and page else high_water
+    matching_prefix: list[V2RuntimeObservationInbox] = []
+    for event in events:
+        if (
+            event.generation != expected_apply_identity.generation
+            or event.manifest_etag != expected_apply_identity.manifest_etag
+            or event.apply_receipt_id != expected_apply_identity.apply_receipt_id
+            or event.boot_nonce != expected_apply_identity.boot_nonce
+        ):
+            break
+        matching_prefix.append(event)
+    has_more = len(matching_prefix) > limit
+    page = matching_prefix[:limit]
+    next_position = page[-1].id if page else decoded.stream_position
     heads = list(
         (
             await db.execute(

--- a/backend/tests/test_runtime_observation_companion.py
+++ b/backend/tests/test_runtime_observation_companion.py
@@ -127,6 +127,15 @@ def _expected_identity() -> RuntimeApplyIdentity:
     )
 
 
+def _rotated_identity() -> RuntimeApplyIdentity:
+    return RuntimeApplyIdentity(
+        generation=2,
+        manifest_etag='"manifest-etag-0002"',
+        apply_receipt_id="apply-receipt-00000002",
+        boot_nonce="boot-nonce-0000000002",
+    )
+
+
 async def retire_runtime_environment(*args, **kwargs):
     return (await _retire_runtime_environment(*args, **kwargs)).receipt
 
@@ -1846,6 +1855,109 @@ async def test_snapshot_and_high_water_share_one_repeatable_read_snapshot(
     assert "streamPosition" not in incremental["events"][0]
     assert incremental["streamHighWaterCursor"].startswith("clawdi-ro-v1.")
     assert incremental["nextCursor"].startswith("clawdi-ro-v1.")
+
+
+@pytest.mark.asyncio
+async def test_short_tuple_filtered_page_does_not_skip_next_tuple_first_event(
+    db_session: AsyncSession,
+    seed_user,
+):
+    environment, _ = await _provision_environment(db_session, seed_user)
+    base = datetime.now(UTC)
+    registration = await register_runtime_observation_consumer(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="tuple-rotation-controller",
+    )
+    first = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(
+            boot_session_id="tuple-one-session",
+            sequence=1,
+            captured_at=base,
+        ),
+        received_at=base,
+    )
+    rotated = _rotated_identity()
+    next_tuple = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(
+            boot_session_id="tuple-two-session",
+            sequence=1,
+            captured_at=base + timedelta(seconds=1),
+            generation=rotated.generation,
+            manifest_etag=rotated.manifest_etag,
+            apply_receipt_id=rotated.apply_receipt_id,
+            boot_nonce=rotated.boot_nonce,
+        ),
+        received_at=base + timedelta(seconds=1),
+    )
+    second = await ingest_runtime_observation(
+        db_session,
+        environment_id=environment.id,
+        value=_payload(
+            boot_session_id="tuple-one-session",
+            sequence=2,
+            captured_at=base + timedelta(seconds=2),
+        ),
+        received_at=base + timedelta(seconds=2),
+    )
+
+    first_tuple_page = await read_runtime_observations(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="tuple-rotation-controller",
+        expected_apply_identity=_expected_identity(),
+        after_cursor=registration["cursor"],
+        limit=100,
+    )
+
+    assert [event["sequence"] for event in first_tuple_page["events"]] == [1]
+    assert first_tuple_page["hasMore"] is False
+    assert (
+        runtime_observation_service.decode_runtime_observation_cursor(
+            first_tuple_page["nextCursor"]
+        ).stream_position
+        == first.stream_position
+    )
+    assert (
+        runtime_observation_service.decode_runtime_observation_cursor(
+            first_tuple_page["streamHighWaterCursor"]
+        ).stream_position
+        == second.stream_position
+    )
+    assert first.stream_position < next_tuple.stream_position < second.stream_position
+
+    rotated_page = await read_runtime_observations(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="tuple-rotation-controller",
+        expected_apply_identity=rotated,
+        after_cursor=first_tuple_page["nextCursor"],
+        limit=100,
+    )
+    assert [event["sequence"] for event in rotated_page["events"]] == [1]
+    assert rotated_page["events"][0]["runtimeIdentity"]["bootSessionId"] == ("tuple-two-session")
+
+    resumed_first_tuple = await read_runtime_observations(
+        db_session,
+        environment_id=environment.id,
+        owner_id=seed_user.id,
+        deployment_id=_DEPLOYMENT_ID,
+        consumer_id="tuple-rotation-controller",
+        expected_apply_identity=_expected_identity(),
+        after_cursor=rotated_page["nextCursor"],
+        limit=100,
+    )
+    assert [event["sequence"] for event in resumed_first_tuple["events"]] == [2]
 
 
 def _legacy_runtime_observed(value: RuntimeObservationEventV2) -> dict:

--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.55",
+      "version": "0.12.10-beta.56",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.55",
+	"version": "0.12.10-beta.56",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -27,6 +27,10 @@ import {
 	writeRuntimeAppliedState,
 } from "../runtime/applied-state";
 import {
+	type RuntimeApplyIdentity,
+	readRuntimeApplyIdentityFromEnv,
+} from "../runtime/apply-identity";
+import {
 	ensureRuntimeAuthTokenFile,
 	readRuntimeAuthToken,
 	runtimeAuthTokenFileLabel,
@@ -1226,6 +1230,7 @@ interface RuntimeApplyOptions {
 	deferCliInstall?: boolean;
 	deferCliInstallReason?: string;
 	manifestIdentity?: RuntimeManifestIdentity;
+	requireSystemdApplied?: boolean;
 }
 
 interface RuntimeManifestIdentity {
@@ -1288,7 +1293,16 @@ export function commitRuntimeAppliedState(input: {
 	etag: string;
 	sourceRevision: string;
 	convergence: ReturnType<typeof convergeRuntimeManifest>;
+	applyIdentity: RuntimeApplyIdentity | null;
 }): void {
+	if (
+		input.applyIdentity &&
+		input.applyIdentity.generation !== input.convergence.manifest.generation
+	) {
+		throw new Error(
+			`runtime apply identity generation ${input.applyIdentity.generation} does not match applied manifest generation ${input.convergence.manifest.generation}`,
+		);
+	}
 	const providerIds = runtimeSourceProviderIds(input.load.manifest);
 	input.convergence.outputs.manifestLastGood = cacheRuntimeSourceManifest(input.load, input.paths);
 	input.convergence.outputs.appliedState = writeRuntimeAppliedState(
@@ -1299,11 +1313,11 @@ export function commitRuntimeAppliedState(input: {
 			etag: input.etag,
 			sourceRevision: input.sourceRevision,
 			generation: input.convergence.manifest.generation,
-			...(input.load.applyIdentity
+			...(input.applyIdentity
 				? {
-						manifestETag: input.load.applyIdentity.manifestETag,
-						applyReceiptId: input.load.applyIdentity.applyReceiptId,
-						bootNonce: input.load.applyIdentity.bootNonce,
+						manifestETag: input.applyIdentity.manifestETag,
+						applyReceiptId: input.applyIdentity.applyReceiptId,
+						bootNonce: input.applyIdentity.bootNonce,
 					}
 				: {}),
 			contentIdentity: runtimeAppliedContentIdentity(input.load),
@@ -1848,6 +1862,7 @@ async function runtimeInitLocked(
 		try {
 			convergenceLoad = applyRuntimeBundleChannelsToManifestLoad(loaded);
 			const contentRevision = runtimeAppliedContentIdentity(convergenceLoad).sha256;
+			const applyIdentity = readRuntimeApplyIdentityFromEnv();
 			applyResult = applyRuntimeDesiredState(convergenceLoad, paths, {
 				authorityCommit: (convergence) =>
 					commitRuntimeAppliedState({
@@ -1856,11 +1871,13 @@ async function runtimeInitLocked(
 						etag: loaded.etag ?? `"sha256:${contentRevision}"`,
 						sourceRevision: loaded.sourceRevision ?? contentRevision,
 						convergence,
+						applyIdentity,
 					}),
 				manifestIdentity: {
 					generation: convergenceLoad.manifest.generation,
 					etag: loaded.etag ?? null,
 				},
+				requireSystemdApplied: applyIdentity !== null,
 			});
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
@@ -2100,6 +2117,7 @@ async function runtimeWatchTickLocked(
 			bundleEtag,
 			paths,
 		);
+		const applyIdentity = readRuntimeApplyIdentityFromEnv();
 		const applyResult = applyRuntimeDesiredState(loaded, paths, {
 			authorityCommit: (convergence) =>
 				commitRuntimeAppliedState({
@@ -2108,11 +2126,13 @@ async function runtimeWatchTickLocked(
 					etag: bundleEtag,
 					sourceRevision,
 					convergence,
+					applyIdentity,
 				}),
 			continueOnCliUpdateError: true,
 			deferCliInstall: opts.deferCliInstall,
 			deferCliInstallReason: opts.deferCliInstallReason,
 			manifestIdentity,
+			requireSystemdApplied: applyIdentity !== null,
 		});
 		if (applyResult.kind === "cli_update_failed") {
 			const error = applyResult.cliUpdate.error ?? "CLI update failed";
@@ -2244,7 +2264,12 @@ function applyRuntimeDesiredState(
 	};
 	const convergence = convergeRuntimeManifest(load, paths, {
 		cacheLastGood: false,
-		commitAuthority: opts.authorityCommit,
+		commitAuthority: (committedConvergence) => {
+			if (opts.requireSystemdApplied && !systemdApply.applied) {
+				throw new Error("systemd apply did not activate the rendered runtime manifest");
+			}
+			opts.authorityCommit?.(committedConvergence);
+		},
 		systemdApply: {
 			activate: () => {
 				failedSystemdUnits = readSystemdUnitSnapshot(paths);

--- a/packages/cli/src/commands/serve-handlers.test.ts
+++ b/packages/cli/src/commands/serve-handlers.test.ts
@@ -10,7 +10,8 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { rejectUnsupportedOpts } from "./serve";
+import { adapterForType } from "../lib/select-adapter";
+import { rejectUnsupportedOpts, runDaemonWorkers } from "./serve";
 
 /**
  * Behavior tests for daemon singleton handler behavior:
@@ -92,6 +93,51 @@ describe("rejectUnsupportedOpts", () => {
 		).toThrow(ExitCalled);
 		expect(captured.stderr.join("\n")).toMatch(/--environment-id/);
 		expect(captured.stderr.join("\n")).not.toMatch(/--environmentId/);
+	});
+});
+
+describe("daemon worker ownership", () => {
+	it("starts one runtime observation producer for multiple live-sync targets", async () => {
+		const adapter = adapterForType("codex");
+		if (!adapter) throw new Error("expected codex adapter");
+		let producerStarts = 0;
+		let engineStarts = 0;
+		await runDaemonWorkers({
+			targets: [
+				{ agentType: "codex", adapter, environmentId: "env-one" },
+				{ agentType: "codex", adapter, environmentId: "env-two" },
+			],
+			abortController: new AbortController(),
+			forcePollWatcher: true,
+			runObservationProducer: async () => {
+				producerStarts += 1;
+			},
+			runEngine: async () => {
+				engineStarts += 1;
+			},
+		});
+
+		expect(producerStarts).toBe(1);
+		expect(engineStarts).toBe(2);
+	});
+
+	it("starts the runtime observation producer with liveSync agents=[]", async () => {
+		let producerStarts = 0;
+		let engineStarts = 0;
+		await runDaemonWorkers({
+			targets: [],
+			abortController: new AbortController(),
+			forcePollWatcher: true,
+			runObservationProducer: async () => {
+				producerStarts += 1;
+			},
+			runEngine: async () => {
+				engineStarts += 1;
+			},
+		});
+
+		expect(producerStarts).toBe(1);
+		expect(engineStarts).toBe(0);
 	});
 });
 

--- a/packages/cli/src/commands/serve.ts
+++ b/packages/cli/src/commands/serve.ts
@@ -41,6 +41,7 @@ import {
 } from "../lib/config";
 import { adapterForType, getEnvIdByAgent, listRegisteredAgentTypes } from "../lib/select-adapter";
 import { getCliVersion } from "../lib/version";
+import { runRuntimeObservationProducer } from "../runtime/observation-producer";
 import { startAutoRestart } from "../serve/auto-restart";
 import {
 	type ControlRpcClientConfig,
@@ -203,7 +204,10 @@ export async function serve(_opts: ServeOpts): Promise<void> {
 		process.exit(1);
 	}
 
-	const targets = legacyRun ? [pickLegacyDaemonRunTarget(legacyRun)] : pickDaemonRunTargets();
+	const hostedRuntime = process.env.CLAWDI_RUNTIME_MODE?.trim().toLowerCase() === "hosted";
+	const targets = legacyRun
+		? [pickLegacyDaemonRunTarget(legacyRun)]
+		: pickDaemonRunTargets({ allowEmpty: hostedRuntime });
 
 	log.info("serve.boot", {
 		mode,
@@ -260,17 +264,11 @@ export async function serve(_opts: ServeOpts): Promise<void> {
 	});
 
 	try {
-		await Promise.all(
-			targets.map((target) =>
-				runSyncEngine({
-					environmentId: target.environmentId,
-					adapter: target.adapter,
-					abort: abort.signal,
-					abortController: abort,
-					forcePollWatcher: isContainer,
-				}),
-			),
-		);
+		await runDaemonWorkers({
+			targets,
+			abortController: abort,
+			forcePollWatcher: isContainer,
+		});
 	} catch (e) {
 		log.error("serve.fatal", { error: toErrorMessage(e) });
 		process.exit(1);
@@ -1740,7 +1738,7 @@ function isAgentType(s: string): s is AgentType {
 	return (AGENT_TYPES as readonly string[]).includes(s);
 }
 
-function pickDaemonRunTargets(): DaemonRunTarget[] {
+function pickDaemonRunTargets(options: { allowEmpty?: boolean } = {}): DaemonRunTarget[] {
 	const registered = listRegisteredAgentTypes();
 	const envAgent = process.env.CLAWDI_AGENT_TYPE;
 	const targets = registered.length > 0 ? registered : envAgent ? [envAgent] : [];
@@ -1753,6 +1751,7 @@ function pickDaemonRunTargets(): DaemonRunTarget[] {
 	}
 	if (registered.length === 0) {
 		if (!envAgent) {
+			if (options.allowEmpty) return [];
 			log.error("serve.no_agent", {
 				hint: "Run `clawdi setup` to register an agent on this machine, or set CLAWDI_AGENT_TYPE in a container.",
 			});
@@ -1777,6 +1776,29 @@ function pickDaemonRunTargets(): DaemonRunTarget[] {
 		}
 		return { agentType, adapter, environmentId };
 	});
+}
+
+export async function runDaemonWorkers(input: {
+	targets: DaemonRunTarget[];
+	abortController: AbortController;
+	forcePollWatcher: boolean;
+	runObservationProducer?: typeof runRuntimeObservationProducer;
+	runEngine?: typeof runSyncEngine;
+}): Promise<void> {
+	const producer = input.runObservationProducer ?? runRuntimeObservationProducer;
+	const engine = input.runEngine ?? runSyncEngine;
+	await Promise.all([
+		producer({ abort: input.abortController.signal }),
+		...input.targets.map((target) =>
+			engine({
+				environmentId: target.environmentId,
+				adapter: target.adapter,
+				abort: input.abortController.signal,
+				abortController: input.abortController,
+				forcePollWatcher: input.forcePollWatcher,
+			}),
+		),
+	]);
 }
 
 function pickAgent(explicit: string | undefined): {

--- a/packages/cli/src/runtime/apply-identity.test.ts
+++ b/packages/cli/src/runtime/apply-identity.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { readRuntimeApplyIdentityFromEnv, runtimeApplyIdentityEnvironment } from "./apply-identity";
+
+const completeEnvironment = {
+	CLAWDI_RUNTIME_GENERATION: "7",
+	CLAWDI_RUNTIME_MANIFEST_ETAG: '"manifest-7"',
+	CLAWDI_RUNTIME_APPLY_RECEIPT_ID: "apply-receipt-0007",
+	CLAWDI_RUNTIME_BOOT_NONCE: "boot-nonce-000007",
+};
+
+describe("runtime apply identity environment", () => {
+	test("returns null when the entire tuple is absent", () => {
+		expect(readRuntimeApplyIdentityFromEnv({})).toBeNull();
+	});
+
+	test("reads only the complete canonical four-variable tuple", () => {
+		const identity = readRuntimeApplyIdentityFromEnv(completeEnvironment);
+		expect(identity).toEqual({
+			generation: 7,
+			manifestETag: '"manifest-7"',
+			applyReceiptId: "apply-receipt-0007",
+			bootNonce: "boot-nonce-000007",
+		});
+		expect(runtimeApplyIdentityEnvironment(identity)).toEqual(completeEnvironment);
+	});
+
+	test("rejects partial, non-canonical, and unsafe tuples", () => {
+		expect(() =>
+			readRuntimeApplyIdentityFromEnv({
+				CLAWDI_RUNTIME_GENERATION: "7",
+			}),
+		).toThrow(/incomplete runtime apply identity environment/);
+		expect(() =>
+			readRuntimeApplyIdentityFromEnv({
+				...completeEnvironment,
+				CLAWDI_RUNTIME_GENERATION: "07",
+			}),
+		).toThrow(/canonical positive integer/);
+		expect(() =>
+			readRuntimeApplyIdentityFromEnv({
+				...completeEnvironment,
+				CLAWDI_RUNTIME_MANIFEST_ETAG: ' "manifest-7"',
+			}),
+		).toThrow(/surrounding whitespace/);
+		expect(() =>
+			readRuntimeApplyIdentityFromEnv({
+				...completeEnvironment,
+				CLAWDI_RUNTIME_GENERATION: String(Number.MAX_SAFE_INTEGER + 1),
+			}),
+		).toThrow(/invalid runtime apply identity environment/);
+	});
+});

--- a/packages/cli/src/runtime/apply-identity.ts
+++ b/packages/cli/src/runtime/apply-identity.ts
@@ -2,11 +2,75 @@ import { z } from "zod";
 
 export const runtimeApplyIdentitySchema = z
 	.object({
-		generation: z.number().int().positive(),
-		manifestETag: z.string().min(1).max(128),
-		applyReceiptId: z.string().min(16).max(128),
-		bootNonce: z.string().min(16).max(128),
+		generation: z.number().int().positive().safe(),
+		manifestETag: canonicalIdentityValue(1, 128),
+		applyReceiptId: canonicalIdentityValue(16, 128),
+		bootNonce: canonicalIdentityValue(16, 128),
 	})
 	.strict();
 
 export type RuntimeApplyIdentity = z.infer<typeof runtimeApplyIdentitySchema>;
+
+export const RUNTIME_APPLY_IDENTITY_ENV = {
+	generation: "CLAWDI_RUNTIME_GENERATION",
+	manifestETag: "CLAWDI_RUNTIME_MANIFEST_ETAG",
+	applyReceiptId: "CLAWDI_RUNTIME_APPLY_RECEIPT_ID",
+	bootNonce: "CLAWDI_RUNTIME_BOOT_NONCE",
+} as const;
+
+export function readRuntimeApplyIdentityFromEnv(
+	env: Readonly<Record<string, string | undefined>> = process.env,
+): RuntimeApplyIdentity | null {
+	const entries = Object.entries(RUNTIME_APPLY_IDENTITY_ENV) as Array<
+		[keyof RuntimeApplyIdentity, string]
+	>;
+	const present = entries.filter(([, name]) => env[name] !== undefined);
+	if (present.length === 0) return null;
+	if (present.length !== entries.length) {
+		const missing = entries.filter(([, name]) => env[name] === undefined).map(([, name]) => name);
+		throw new Error(
+			`incomplete runtime apply identity environment; missing: ${missing.join(", ")}`,
+		);
+	}
+
+	const generation = env[RUNTIME_APPLY_IDENTITY_ENV.generation];
+	if (!generation || !/^[1-9]\d*$/.test(generation)) {
+		throw new Error(
+			`${RUNTIME_APPLY_IDENTITY_ENV.generation} must be a canonical positive integer`,
+		);
+	}
+	const parsed = runtimeApplyIdentitySchema.safeParse({
+		generation: Number(generation),
+		manifestETag: env[RUNTIME_APPLY_IDENTITY_ENV.manifestETag],
+		applyReceiptId: env[RUNTIME_APPLY_IDENTITY_ENV.applyReceiptId],
+		bootNonce: env[RUNTIME_APPLY_IDENTITY_ENV.bootNonce],
+	});
+	if (!parsed.success) {
+		throw new Error(
+			`invalid runtime apply identity environment: ${parsed.error.issues
+				.map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+				.join("; ")}`,
+		);
+	}
+	return parsed.data;
+}
+
+export function runtimeApplyIdentityEnvironment(
+	identity: RuntimeApplyIdentity | null,
+): Record<string, string> {
+	if (!identity) return {};
+	return {
+		[RUNTIME_APPLY_IDENTITY_ENV.generation]: String(identity.generation),
+		[RUNTIME_APPLY_IDENTITY_ENV.manifestETag]: identity.manifestETag,
+		[RUNTIME_APPLY_IDENTITY_ENV.applyReceiptId]: identity.applyReceiptId,
+		[RUNTIME_APPLY_IDENTITY_ENV.bootNonce]: identity.bootNonce,
+	};
+}
+
+function canonicalIdentityValue(min: number, max: number): z.ZodString {
+	return z
+		.string()
+		.min(min)
+		.max(max)
+		.refine((value) => value === value.trim(), "must not contain surrounding whitespace");
+}

--- a/packages/cli/src/runtime/heartbeat-observation.test.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.test.ts
@@ -154,6 +154,71 @@ describe("hosted runtime heartbeat observation", () => {
 		});
 	});
 
+	test("re-reads the durable applied tuple and starts a new boot session after rotation", () => {
+		const paths = tempRuntimePaths();
+		writeRuntimeAppliedState(companionAppliedState(7), paths);
+		const session = new HostedRuntimeHeartbeatSession({
+			environmentId: "env_rotation",
+			paths,
+			now: clockSequence(["2026-07-16T01:00:00.000Z", "2026-07-16T01:01:00.000Z"]),
+			createId: idSequence([
+				"boot-session-0001",
+				"event-0000000001",
+				"boot-session-0002",
+				"event-0000000002",
+			]),
+		});
+		const first = session.nextEvent();
+		if (!first) throw new Error("expected first tuple event");
+		expect(session.acknowledge(first.event.eventId)).toBe(true);
+
+		writeRuntimeAppliedState(companionAppliedState(8), paths);
+		expect(session.refreshAppliedState()).toBe(true);
+		const rotated = session.nextEvent();
+		if (!rotated) throw new Error("expected rotated tuple event");
+		expect(rotated.event).toMatchObject({
+			applyReceiptId: "apply-receipt-0008",
+			bootNonce: "boot-nonce-000008",
+			bootSessionId: "boot-session-0002",
+			sequence: 1,
+			eventId: "event-0000000002",
+			applied: {
+				generation: 8,
+				etag: '"frozen-manifest-8"',
+			},
+		});
+	});
+
+	test("supersedes a pending old-tuple event instead of blocking rotation", () => {
+		const paths = tempRuntimePaths();
+		writeRuntimeAppliedState(companionAppliedState(7), paths);
+		const session = new HostedRuntimeHeartbeatSession({
+			environmentId: "env_pending_rotation",
+			paths,
+			now: clockSequence(["2026-07-16T01:00:00.000Z", "2026-07-16T01:01:00.000Z"]),
+			createId: idSequence([
+				"boot-session-0001",
+				"old-event-000001",
+				"boot-session-0002",
+				"new-event-000001",
+			]),
+		});
+		const oldPending = session.nextEvent();
+		if (!oldPending) throw new Error("expected old pending event");
+
+		writeRuntimeAppliedState(companionAppliedState(8), paths);
+		expect(session.refreshAppliedState()).toBe(true);
+		const rotated = session.nextEvent();
+		if (!rotated) throw new Error("expected rotated event");
+		expect(rotated.event.eventId).toBe("new-event-000001");
+		expect(rotated.event.eventId).not.toBe(oldPending.event.eventId);
+		expect(rotated.event).toMatchObject({
+			bootSessionId: "boot-session-0002",
+			sequence: 1,
+			applied: { generation: 8 },
+		});
+	});
+
 	test("persists one exact event across retries and restart until acknowledgement", () => {
 		const paths = tempRuntimePaths();
 		writeRuntimeAppliedState(companionAppliedState(7), paths);

--- a/packages/cli/src/runtime/heartbeat-observation.ts
+++ b/packages/cli/src/runtime/heartbeat-observation.ts
@@ -9,7 +9,7 @@ import {
 	readRuntimeAppliedState,
 	runtimeAppliedApplyIdentity,
 } from "./applied-state";
-import { runtimeApplyIdentitySchema } from "./apply-identity";
+import { type RuntimeApplyIdentity, runtimeApplyIdentitySchema } from "./apply-identity";
 import { readHostedRuntimeObserved } from "./observed";
 import { getRuntimePaths, type RuntimePaths } from "./paths";
 
@@ -166,13 +166,15 @@ export class HostedRuntimeHeartbeatSession {
 	private state: PersistedHeartbeatState | null;
 	private readonly statePath: string;
 	private readonly paths: RuntimePaths;
-	private readonly capturedAppliedState: RuntimeAppliedState | null;
-	private readonly currentBootIdentity: PersistedBootIdentity | null;
+	private readonly environmentId: string;
+	private capturedAppliedState: RuntimeAppliedState | null = null;
+	private currentBootIdentity: PersistedBootIdentity | null = null;
 	private readonly now: () => Date;
 	private readonly createId: () => string;
 
 	constructor(options: HostedRuntimeHeartbeatOptions) {
 		this.paths = options.paths ?? getRuntimePaths();
+		this.environmentId = options.environmentId;
 		this.now = options.now ?? (() => new Date());
 		this.createId = options.createId ?? randomUUID;
 		this.statePath = runtimeHeartbeatObservationStatePath(this.paths, options.environmentId);
@@ -181,29 +183,47 @@ export class HostedRuntimeHeartbeatSession {
 			throw new Error("runtime heartbeat state environment binding does not match");
 		}
 
-		this.capturedAppliedState =
-			this.paths.mode === "hosted" ? readRuntimeAppliedState(this.paths) : null;
-		const applyIdentity = this.capturedAppliedState
-			? runtimeAppliedApplyIdentity(this.capturedAppliedState)
-			: null;
-		if (!applyIdentity) {
+		this.refreshAppliedState(true);
+	}
+
+	refreshAppliedState(forceNewBoot = false): boolean {
+		const appliedState = this.paths.mode === "hosted" ? readRuntimeAppliedState(this.paths) : null;
+		const applyIdentity = appliedState ? runtimeAppliedApplyIdentity(appliedState) : null;
+		if (!appliedState || !applyIdentity) {
+			this.capturedAppliedState = null;
 			this.currentBootIdentity = null;
-			return;
+			return false;
+		}
+		if (
+			!forceNewBoot &&
+			this.currentBootIdentity &&
+			sameApplyIdentity(this.currentBootIdentity, applyIdentity)
+		) {
+			this.capturedAppliedState = appliedState;
+			return false;
 		}
 
-		this.currentBootIdentity = {
+		const nextBootIdentity = {
 			...applyIdentity,
 			bootSessionId: nonEmptyId(this.createId(), "boot session ID"),
 		};
-		this.state = {
+		const pending = this.state?.pending ?? null;
+		const candidate: PersistedHeartbeatState = {
 			schemaVersion: "clawdi.runtimeHeartbeatObservation.v1",
-			environmentId: options.environmentId,
-			bootIdentity: this.currentBootIdentity,
+			environmentId: this.environmentId,
+			bootIdentity: nextBootIdentity,
 			nextSequence: 1,
 			lastCapturedAt: null,
-			pending: this.state?.pending ?? null,
+			pending:
+				pending && eventMatchesApplyIdentity(decodePendingEvent(pending).event, applyIdentity)
+					? pending
+					: null,
 		};
-		writeState(this.statePath, this.state);
+		writeState(this.statePath, candidate);
+		this.state = candidate;
+		this.capturedAppliedState = appliedState;
+		this.currentBootIdentity = nextBootIdentity;
+		return true;
 	}
 
 	nextEvent(): BufferedRuntimeObservedEvent | null {
@@ -344,4 +364,28 @@ function nonEmptyId(value: string, name: string): string {
 	const normalized = value.trim();
 	if (!normalized) throw new Error(`${name} must not be empty`);
 	return normalized;
+}
+
+function sameApplyIdentity(
+	left: Pick<PersistedBootIdentity, keyof RuntimeApplyIdentity>,
+	right: RuntimeApplyIdentity,
+): boolean {
+	return (
+		left.generation === right.generation &&
+		left.manifestETag === right.manifestETag &&
+		left.applyReceiptId === right.applyReceiptId &&
+		left.bootNonce === right.bootNonce
+	);
+}
+
+function eventMatchesApplyIdentity(
+	event: HostedRuntimeObservedEvent,
+	identity: RuntimeApplyIdentity,
+): boolean {
+	return (
+		event.applied.generation === identity.generation &&
+		event.applied.etag === identity.manifestETag &&
+		event.applyReceiptId === identity.applyReceiptId &&
+		event.bootNonce === identity.bootNonce
+	);
 }

--- a/packages/cli/src/runtime/manifest-contract.ts
+++ b/packages/cli/src/runtime/manifest-contract.ts
@@ -674,30 +674,13 @@ function validateHostedRuntimeManifest(
 	}
 }
 
-const hostedRuntimeManifestV1Schema = hostedRuntimeManifestBaseSchema
+export const hostedRuntimeManifestSchema = hostedRuntimeManifestBaseSchema
 	.safeExtend({
 		schemaVersion: z.literal("clawdi.hosted-runtime.manifest.v1"),
 		clawdiCli: hostedCliPayloadPolicySchema,
 	})
 	.strict()
 	.superRefine(validateHostedRuntimeManifest);
-
-const hostedRuntimeManifestV2Schema = hostedRuntimeManifestBaseSchema
-	.safeExtend({
-		schemaVersion: z.literal("clawdi.hosted-runtime.manifest.v2"),
-		generation: z.number().int().positive(),
-		manifestETag: z.string().min(1).max(128),
-		applyReceiptId: z.string().min(16).max(128),
-		bootNonce: z.string().min(16).max(128),
-		clawdiCli: hostedCliPayloadPolicySchema,
-	})
-	.strict()
-	.superRefine(validateHostedRuntimeManifest);
-
-export const hostedRuntimeManifestSchema = z.discriminatedUnion("schemaVersion", [
-	hostedRuntimeManifestV1Schema,
-	hostedRuntimeManifestV2Schema,
-]);
 
 export const hostedRuntimeManifestResponseSchema = z
 	.object({
@@ -722,30 +705,13 @@ export const hostedRuntimeManifestResponseSchema = z
 		}
 	});
 
-const hostedRuntimeManifestFixtureV1Schema = hostedRuntimeManifestBaseSchema
+const hostedRuntimeManifestFixtureSchema = hostedRuntimeManifestBaseSchema
 	.safeExtend({
 		schemaVersion: z.literal("clawdi.hosted-runtime.manifest.v1"),
 		clawdiCli: hostedFixtureCliPayloadPolicySchema,
 	})
 	.strict()
 	.superRefine(validateHostedRuntimeManifest);
-
-const hostedRuntimeManifestFixtureV2Schema = hostedRuntimeManifestBaseSchema
-	.safeExtend({
-		schemaVersion: z.literal("clawdi.hosted-runtime.manifest.v2"),
-		generation: z.number().int().positive(),
-		manifestETag: z.string().min(1).max(128),
-		applyReceiptId: z.string().min(16).max(128),
-		bootNonce: z.string().min(16).max(128),
-		clawdiCli: hostedFixtureCliPayloadPolicySchema,
-	})
-	.strict()
-	.superRefine(validateHostedRuntimeManifest);
-
-const hostedRuntimeManifestFixtureSchema = z.discriminatedUnion("schemaVersion", [
-	hostedRuntimeManifestFixtureV1Schema,
-	hostedRuntimeManifestFixtureV2Schema,
-]);
 
 export const hostedRuntimeManifestFixtureResponseSchema = z
 	.object({

--- a/packages/cli/src/runtime/manifest-services.test.ts
+++ b/packages/cli/src/runtime/manifest-services.test.ts
@@ -316,6 +316,7 @@ describe("runtime manifest services", () => {
 			"hermes-gateway.service",
 		]);
 		expect(result.outputs.systemdSystemUnits.map((path) => path.split("/").at(-1)).sort()).toEqual([
+			"clawdi-daemon.service",
 			"clawdi-runtime-sidecar.service",
 			"clawdi-runtime-watch.service",
 		]);

--- a/packages/cli/src/runtime/manifest-source.ts
+++ b/packages/cli/src/runtime/manifest-source.ts
@@ -6,7 +6,6 @@ import {
 	runtimeAppliedApplyIdentity,
 	runtimeContentSha256,
 } from "./applied-state";
-import type { RuntimeApplyIdentity } from "./apply-identity";
 import {
 	ensureRuntimeAuthTokenFile,
 	readRuntimeAuthToken,
@@ -39,7 +38,6 @@ export interface RuntimeManifestLoad {
 	secretValues?: Record<string, string>;
 	channelBindings?: RuntimeBundleChannelBinding[];
 	sourceRevision?: string;
-	applyIdentity?: RuntimeApplyIdentity;
 	// Original datasource manifest before local runtime projections are applied.
 	sourceManifest?: RuntimeManifest;
 	etag?: string;
@@ -99,7 +97,6 @@ export function normalizeHostedRuntimeBundleV2(value: unknown): RuntimeManifestL
 		secretValues: normalizeSecretValues(bundle.secretValues),
 		channelBindings: bundle.channelBindings,
 		sourceRevision: bundle.sourceRevision,
-		applyIdentity: hostedManifestApplyIdentity(bundle.manifest),
 	};
 }
 
@@ -238,7 +235,6 @@ function normalizeRemoteManifestPayload(
 	secretValues?: Record<string, string>;
 	channelBindings?: RuntimeBundleChannelBinding[];
 	sourceRevision?: string;
-	applyIdentity?: RuntimeApplyIdentity;
 } {
 	if (paths.mode !== "hosted") return normalizeManifestPayload(value);
 	const hostedResponse = hostedRuntimeBundleV2Schema.parse(value);
@@ -247,7 +243,6 @@ function normalizeRemoteManifestPayload(
 		secretValues: normalizeSecretValues(hostedResponse.secretValues),
 		channelBindings: hostedResponse.channelBindings,
 		sourceRevision: hostedResponse.sourceRevision,
-		applyIdentity: hostedManifestApplyIdentity(hostedResponse.manifest),
 	};
 }
 
@@ -257,14 +252,12 @@ function normalizeManifestFixturePayload(
 ): {
 	manifest: RuntimeManifest;
 	secretValues?: Record<string, string>;
-	applyIdentity?: RuntimeApplyIdentity;
 } {
 	if (paths.mode === "hosted") {
 		const hostedResponse = hostedRuntimeManifestFixtureResponseSchema.parse(value);
 		return {
 			manifest: hostedManifestToRuntimeManifest(hostedResponse.manifest),
 			secretValues: normalizeSecretValues(hostedResponse.secretValues),
-			applyIdentity: hostedManifestApplyIdentity(hostedResponse.manifest),
 		};
 	}
 	const internal = manifestSchema.safeParse(value);
@@ -275,7 +268,6 @@ function normalizeManifestFixturePayload(
 		return {
 			manifest: hostedManifestToRuntimeManifest(hostedResponse.data.manifest),
 			secretValues: normalizeSecretValues(hostedResponse.data.secretValues),
-			applyIdentity: hostedManifestApplyIdentity(hostedResponse.data.manifest),
 		};
 	}
 	if (looksLikeHostedManifestResponse(value)) {
@@ -290,10 +282,7 @@ function looksLikeHostedManifestResponse(value: unknown): boolean {
 	const manifest = Reflect.get(value, "manifest");
 	if (typeof manifest !== "object" || manifest === null || Array.isArray(manifest)) return false;
 	const schemaVersion = Reflect.get(manifest, "schemaVersion");
-	return (
-		schemaVersion === "clawdi.hosted-runtime.manifest.v1" ||
-		schemaVersion === "clawdi.hosted-runtime.manifest.v2"
-	);
+	return schemaVersion === "clawdi.hosted-runtime.manifest.v1";
 }
 
 function rawGeneration(value: unknown): number | null {
@@ -539,18 +528,6 @@ export function hostedManifestToRuntimeManifest(hosted: HostedRuntimeManifest): 
 			cacheManifest: hosted.recovery.cacheManifest,
 			allowOfflineBoot: hosted.recovery.allowOfflineBoot,
 		},
-	};
-}
-
-function hostedManifestApplyIdentity(
-	hosted: HostedRuntimeManifest,
-): RuntimeApplyIdentity | undefined {
-	if (hosted.schemaVersion !== "clawdi.hosted-runtime.manifest.v2") return undefined;
-	return {
-		generation: hosted.generation,
-		manifestETag: hosted.manifestETag,
-		applyReceiptId: hosted.applyReceiptId,
-		bootNonce: hosted.bootNonce,
 	};
 }
 
@@ -892,7 +869,6 @@ function loadLastGoodManifest(paths: RuntimePaths): RuntimeManifestLoad | Runtim
 					sourcePath: paths.manifestLastGood,
 					offline: true,
 					secretValues: cached.secretValues,
-					...(cachedApplyIdentity ? { applyIdentity: cachedApplyIdentity } : {}),
 				};
 			}
 			return {
@@ -908,7 +884,6 @@ function loadLastGoodManifest(paths: RuntimePaths): RuntimeManifestLoad | Runtim
 			source: "last-good-cache",
 			sourcePath: paths.manifestLastGood,
 			offline: true,
-			...(cachedApplyIdentity ? { applyIdentity: cachedApplyIdentity } : {}),
 		};
 	} catch (error) {
 		return {
@@ -996,7 +971,6 @@ function validateLoadedManifest(
 		secretValues?: Record<string, string>;
 		channelBindings?: RuntimeBundleChannelBinding[];
 		sourceRevision?: string;
-		applyIdentity?: RuntimeApplyIdentity;
 	},
 	paths: RuntimePaths,
 	source: RuntimeManifestLoad["source"],
@@ -1030,6 +1004,5 @@ function validateLoadedManifest(
 		secretValues: normalized.secretValues,
 		channelBindings: normalized.channelBindings,
 		sourceRevision: normalized.sourceRevision,
-		applyIdentity: normalized.applyIdentity,
 	};
 }

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -56,6 +56,7 @@ import {
 } from "../lib/hermes-config-merge";
 import { writePrivateFileAtomic } from "../lib/private-file";
 import { readRuntimeAppliedState } from "./applied-state";
+import { readRuntimeApplyIdentityFromEnv, runtimeApplyIdentityEnvironment } from "./apply-identity";
 import { ensureRuntimeAuthTokenFile } from "./auth-token";
 import { isClawdiManagedProviderProjection, normalizeSecretRef } from "./hosted-egress-profiles";
 import {
@@ -4901,10 +4902,11 @@ function writeSystemdUnits(
 	const activeEgressProgram = shouldRunEgress ? egressProgram : null;
 	const activeEgressIdentity = shouldRunEgress ? egressIdentity : null;
 	const shouldRunSidecar = shouldRunBridge || shouldRunEgress;
-	const shouldRunDaemon =
-		daemonAuthTokenFile !== null && desiredLiveSyncAgents(manifest).length > 0;
 	const userUnits: string[] = [];
 	const runtimeUid = shouldRunEgress ? runtimeUserUid(runtimeUser) : null;
+	const applyIdentityEnvironment = runtimeApplyIdentityEnvironment(
+		readRuntimeApplyIdentityFromEnv(),
+	);
 
 	if (daemonAuthTokenFile) {
 		systemUnits.push(
@@ -4917,6 +4919,7 @@ function writeSystemdUnits(
 				cwd: workspaceRoot,
 				env: {
 					...commonEnvironment,
+					...applyIdentityEnvironment,
 					CLAWDI_AUTH_TOKEN: "",
 					[RUNTIME_BRIDGE_TOKEN_ENV]: runtimeBridgeToken,
 				},
@@ -4924,7 +4927,7 @@ function writeSystemdUnits(
 		);
 	}
 
-	if (shouldRunDaemon && daemonAuthTokenFile) {
+	if (daemonAuthTokenFile) {
 		systemUnits.push(
 			writeSystemdSystemUnit({
 				paths,
@@ -4935,6 +4938,8 @@ function writeSystemdUnits(
 				cwd: workspaceRoot,
 				env: {
 					...commonEnvironment,
+					...applyIdentityEnvironment,
+					CLAWDI_ENVIRONMENT_ID: manifest.environmentId,
 					CLAWDI_SERVE_MODE: "container",
 					CLAWDI_API_URL: manifest.controlPlane.apiUrl,
 					CLAWDI_NO_AUTO_UPDATE: "1",
@@ -5688,8 +5693,7 @@ export function convergeRuntimeManifest(
 	let codexCli: Record<string, string> | null = null;
 	if (
 		hostedCodexManagedProvider(manifest) ||
-		manifest.projection?.sourceSchemaVersion === "clawdi.hosted-runtime.manifest.v1" ||
-		manifest.projection?.sourceSchemaVersion === "clawdi.hosted-runtime.manifest.v2"
+		manifest.projection?.sourceSchemaVersion === "clawdi.hosted-runtime.manifest.v1"
 	) {
 		try {
 			codexCli = ensureHostedCodexCli(paths);

--- a/packages/cli/src/runtime/observation-producer.test.ts
+++ b/packages/cli/src/runtime/observation-producer.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { components } from "@clawdi/shared/api";
+import { type RuntimeAppliedStateV2, writeRuntimeAppliedState } from "./applied-state";
+import { HostedRuntimeHeartbeatSession } from "./heartbeat-observation";
+import {
+	HostedRuntimeObservationProducer,
+	runRuntimeObservationProducer,
+} from "./observation-producer";
+import { getRuntimePaths, type RuntimePaths } from "./paths";
+
+const originalEnv = { ...process.env };
+const roots: string[] = [];
+
+afterEach(() => {
+	process.env = { ...originalEnv };
+	for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function tempRuntimePaths(): RuntimePaths {
+	const root = mkdtempSync(join(tmpdir(), "clawdi-runtime-producer-"));
+	roots.push(root);
+	process.env.CLAWDI_SERVICE_STATE_DIR = join(root, "state");
+	process.env.CLAWDI_RUN_DIR = join(root, "run");
+	process.env.CLAWDI_RUNTIME_HOME = join(root, "home");
+	process.env.CLAWDI_ENVIRONMENT_ID = "env_producer";
+	return getRuntimePaths({ mode: "hosted" });
+}
+
+function appliedState(generation: number): RuntimeAppliedStateV2 {
+	return {
+		schemaVersion: "clawdi.runtimeAppliedState.v2",
+		appliedAt: `2026-07-22T00:00:0${generation}.000Z`,
+		instanceId: "hri_producer",
+		etag: `"transport-${generation}"`,
+		sourceRevision: (generation === 1 ? "a" : "b").repeat(64),
+		generation,
+		manifestETag: `"manifest-${generation}"`,
+		applyReceiptId: `apply-receipt-000${generation}`,
+		bootNonce: `boot-nonce-00000${generation}`,
+		contentIdentity: {
+			sourcePath: "https://runtime.test/v1/runtime/manifest",
+			sha256: (generation === 1 ? "c" : "d").repeat(64),
+		},
+		providerIds: [],
+		projectedProviderIds: {},
+	};
+}
+
+function setApplyIdentityEnvironment(generation: number): void {
+	process.env.CLAWDI_RUNTIME_GENERATION = String(generation);
+	process.env.CLAWDI_RUNTIME_MANIFEST_ETAG = `"manifest-${generation}"`;
+	process.env.CLAWDI_RUNTIME_APPLY_RECEIPT_ID = `apply-receipt-000${generation}`;
+	process.env.CLAWDI_RUNTIME_BOOT_NONCE = `boot-nonce-00000${generation}`;
+}
+
+describe("hosted runtime observation producer", () => {
+	test("re-reads the applied tuple after rotation and emits a new boot identity", async () => {
+		const paths = tempRuntimePaths();
+		setApplyIdentityEnvironment(1);
+		writeRuntimeAppliedState(appliedState(1), paths);
+		const ids = [
+			"boot-000000000001",
+			"event-00000000001",
+			"boot-000000000002",
+			"event-00000000002",
+		];
+		const times = [new Date("2026-07-22T00:01:00.000Z"), new Date("2026-07-22T00:02:00.000Z")];
+		const events: components["schemas"]["RuntimeObservationEventV2"][] = [];
+		const producer = new HostedRuntimeObservationProducer({
+			abort: new AbortController().signal,
+			paths,
+			submit: async (environmentId, event) => {
+				expect(environmentId).toBe("env_producer");
+				events.push(event);
+				return "accepted";
+			},
+			sessionFactory: (environmentId, sessionPaths) =>
+				new HostedRuntimeHeartbeatSession({
+					environmentId,
+					paths: sessionPaths,
+					createId: () => {
+						const id = ids.shift();
+						if (!id) throw new Error("test ID sequence exhausted");
+						return id;
+					},
+					now: () => {
+						const time = times.shift();
+						if (!time) throw new Error("test clock sequence exhausted");
+						return time;
+					},
+				}),
+		});
+
+		expect(await producer.sendOnce()).toBe("sent");
+		setApplyIdentityEnvironment(2);
+		writeRuntimeAppliedState(appliedState(2), paths);
+		expect(await producer.sendOnce()).toBe("sent");
+
+		expect(events).toHaveLength(2);
+		expect(events[0]).toMatchObject({
+			bootSessionId: "boot-000000000001",
+			sequence: 1,
+			eventId: "event-00000000001",
+			applyReceiptId: "apply-receipt-0001",
+			bootNonce: "boot-nonce-000001",
+			applied: { generation: 1, etag: '"manifest-1"' },
+		});
+		expect(events[1]).toMatchObject({
+			bootSessionId: "boot-000000000002",
+			sequence: 1,
+			eventId: "event-00000000002",
+			applyReceiptId: "apply-receipt-0002",
+			bootNonce: "boot-nonce-000002",
+			applied: { generation: 2, etag: '"manifest-2"' },
+		});
+	});
+
+	test("stays idle when no successfully applied tuple exists", async () => {
+		const paths = tempRuntimePaths();
+		let submits = 0;
+		const producer = new HostedRuntimeObservationProducer({
+			abort: new AbortController().signal,
+			paths,
+			submit: async () => {
+				submits += 1;
+				return "accepted";
+			},
+		});
+
+		expect(await producer.sendOnce()).toBe("idle");
+		expect(submits).toBe(0);
+	});
+
+	test("does not attest a durable tuple that differs from the process environment", async () => {
+		const paths = tempRuntimePaths();
+		setApplyIdentityEnvironment(2);
+		writeRuntimeAppliedState(appliedState(1), paths);
+		let submits = 0;
+		const producer = new HostedRuntimeObservationProducer({
+			abort: new AbortController().signal,
+			paths,
+			submit: async () => {
+				submits += 1;
+				return "accepted";
+			},
+		});
+
+		expect(await producer.sendOnce()).toBe("idle");
+		expect(submits).toBe(0);
+	});
+
+	test("drops a failed old-tuple pending event when the applied tuple rotates", async () => {
+		const paths = tempRuntimePaths();
+		setApplyIdentityEnvironment(1);
+		writeRuntimeAppliedState(appliedState(1), paths);
+		const ids = ["boot-000000000001", "old-event-000001", "boot-000000000002", "new-event-000001"];
+		const submitted: components["schemas"]["RuntimeObservationEventV2"][] = [];
+		const producer = new HostedRuntimeObservationProducer({
+			abort: new AbortController().signal,
+			paths,
+			submit: async (_environmentId, event) => {
+				submitted.push(event);
+				if (submitted.length === 1) throw new Error("temporary old-tuple failure");
+				return "accepted";
+			},
+			sessionFactory: (environmentId, sessionPaths) =>
+				new HostedRuntimeHeartbeatSession({
+					environmentId,
+					paths: sessionPaths,
+					createId: () => {
+						const id = ids.shift();
+						if (!id) throw new Error("test ID sequence exhausted");
+						return id;
+					},
+					now: () => new Date("2026-07-22T00:03:00.000Z"),
+				}),
+		});
+
+		expect(await producer.sendOnce()).toBe("failed");
+		setApplyIdentityEnvironment(2);
+		writeRuntimeAppliedState(appliedState(2), paths);
+		expect(await producer.sendOnce()).toBe("sent");
+
+		expect(submitted.map((event) => event.eventId)).toEqual([
+			"old-event-000001",
+			"new-event-000001",
+		]);
+		expect(submitted[1]).toMatchObject({
+			bootSessionId: "boot-000000000002",
+			sequence: 1,
+			applied: { generation: 2 },
+		});
+	});
+
+	test("does not let an unresolved old-tuple request block rotation", async () => {
+		const paths = tempRuntimePaths();
+		setApplyIdentityEnvironment(1);
+		writeRuntimeAppliedState(appliedState(1), paths);
+		const abort = new AbortController();
+		const submitted: components["schemas"]["RuntimeObservationEventV2"][] = [];
+		let resolveOld: ((result: "accepted") => void) | null = null;
+		let delayCalls = 0;
+
+		await runRuntimeObservationProducer({
+			abort: abort.signal,
+			paths,
+			submit: async (_environmentId, event) => {
+				submitted.push(event);
+				if (event.applied.generation === 1) {
+					return await new Promise<"accepted">((resolve) => {
+						resolveOld = resolve;
+					});
+				}
+				resolveOld?.("accepted");
+				return "accepted";
+			},
+			delay: async () => {
+				delayCalls += 1;
+				if (delayCalls === 1) {
+					setApplyIdentityEnvironment(2);
+					writeRuntimeAppliedState(appliedState(2), paths);
+					return;
+				}
+				if (submitted.some((event) => event.applied.generation === 2)) {
+					await Promise.resolve();
+					abort.abort();
+				}
+			},
+		});
+
+		expect(submitted.map((event) => event.applied.generation)).toEqual([1, 2]);
+		expect(submitted[1]).toMatchObject({ sequence: 1, applied: { generation: 2 } });
+	});
+});

--- a/packages/cli/src/runtime/observation-producer.ts
+++ b/packages/cli/src/runtime/observation-producer.ts
@@ -1,0 +1,239 @@
+import { readFileSync } from "node:fs";
+import { z } from "zod";
+import { ApiClient, unwrap } from "../lib/api-client";
+import { log, toErrorMessage } from "../serve/log";
+import { readRuntimeAppliedState, runtimeAppliedApplyIdentity } from "./applied-state";
+import { type RuntimeApplyIdentity, readRuntimeApplyIdentityFromEnv } from "./apply-identity";
+import {
+	HostedRuntimeHeartbeatSession,
+	type HostedRuntimeObservedEvent,
+} from "./heartbeat-observation";
+import { getRuntimePaths, type RuntimePaths } from "./paths";
+
+const OBSERVATION_INTERVAL_MS = 60_000;
+const IDLE_RETRY_INTERVAL_MS = 1_000;
+
+const runtimeInstanceIdentitySchema = z
+	.object({
+		schemaVersion: z.literal("clawdi.runtimeInstanceData.v1"),
+		environmentId: z.string().min(1).max(200),
+	})
+	.passthrough();
+
+type ObservationSubmitResult = "accepted" | "terminal-stale";
+
+interface RuntimeObservationProducerOptions {
+	abort: AbortSignal;
+	paths?: RuntimePaths;
+	submit?: (
+		environmentId: string,
+		event: HostedRuntimeObservedEvent,
+	) => Promise<ObservationSubmitResult>;
+	sessionFactory?: (environmentId: string, paths: RuntimePaths) => HostedRuntimeHeartbeatSession;
+	delay?: (ms: number, abort: AbortSignal) => Promise<void>;
+}
+
+interface AttestedRuntimeObservationContext {
+	environmentId: string;
+	expectedApplyIdentity: RuntimeApplyIdentity;
+	identityKey: string;
+}
+
+export class HostedRuntimeObservationProducer {
+	private readonly paths: RuntimePaths;
+	private readonly submit: NonNullable<RuntimeObservationProducerOptions["submit"]>;
+	private readonly sessionFactory: NonNullable<RuntimeObservationProducerOptions["sessionFactory"]>;
+	private session: HostedRuntimeHeartbeatSession | null = null;
+	private environmentId: string | null = null;
+
+	constructor(options: RuntimeObservationProducerOptions) {
+		this.paths = options.paths ?? getRuntimePaths();
+		this.sessionFactory =
+			options.sessionFactory ??
+			((environmentId, paths) => new HostedRuntimeHeartbeatSession({ environmentId, paths }));
+		if (options.submit) {
+			this.submit = options.submit;
+		} else {
+			const api = new ApiClient({ abortSignal: options.abort });
+			this.submit = async (environmentId, event) => {
+				const response = await api.POST("/v2/runtime/environments/{environment_id}/observations", {
+					params: { path: { environment_id: environmentId } },
+					body: event,
+				});
+				if (isSafelyTerminalRuntimeObservationFailure(response)) return "terminal-stale";
+				unwrap(response);
+				return "accepted";
+			};
+		}
+	}
+
+	async sendOnce(): Promise<"idle" | "sent" | "failed"> {
+		let buffered: ReturnType<HostedRuntimeHeartbeatSession["nextEvent"]> = null;
+		try {
+			const context = this.readAttestedContext();
+			if (!context) return "idle";
+			const { environmentId, expectedApplyIdentity } = context;
+			if (!this.session || this.environmentId !== environmentId) {
+				this.session = this.sessionFactory(environmentId, this.paths);
+				this.environmentId = environmentId;
+			} else {
+				this.session.refreshAppliedState();
+			}
+
+			buffered = this.session.nextEvent();
+			if (!buffered) return "idle";
+			if (!eventMatchesApplyIdentity(buffered.event, expectedApplyIdentity)) {
+				return "idle";
+			}
+			const result = await this.submit(environmentId, buffered.event);
+			if (this.currentAttestedIdentityKey() !== context.identityKey) {
+				return "sent";
+			}
+			if (result === "terminal-stale") {
+				if (!this.session.retireTerminallyStale(buffered.event.eventId)) {
+					throw new Error("terminally stale runtime observation did not match buffered event");
+				}
+				log.warn("daemon.runtime_observation_retired_stale", {
+					event_id: buffered.event.eventId,
+					captured_at: buffered.event.capturedAt,
+				});
+				return "sent";
+			}
+			if (!this.session.acknowledge(buffered.event.eventId)) {
+				throw new Error("runtime observation acknowledgement did not match buffered event");
+			}
+			return "sent";
+		} catch (error) {
+			log.info("daemon.runtime_observation_failed", {
+				error: toErrorMessage(error),
+				...(buffered ? { event_id: buffered.event.eventId } : {}),
+			});
+			return "failed";
+		}
+	}
+
+	currentAttestedIdentityKey(): string | null {
+		return this.readAttestedContext()?.identityKey ?? null;
+	}
+
+	private readAttestedContext(): AttestedRuntimeObservationContext | null {
+		const expectedApplyIdentity = readRuntimeApplyIdentityFromEnv();
+		if (!expectedApplyIdentity) return null;
+		const appliedState = readRuntimeAppliedState(this.paths);
+		const appliedIdentity = appliedState ? runtimeAppliedApplyIdentity(appliedState) : null;
+		if (!appliedIdentity || !sameApplyIdentity(appliedIdentity, expectedApplyIdentity)) {
+			return null;
+		}
+		const environmentId = readRuntimeObservationEnvironmentId(this.paths);
+		if (!environmentId) return null;
+		return {
+			environmentId,
+			expectedApplyIdentity,
+			identityKey: JSON.stringify([
+				environmentId,
+				expectedApplyIdentity.generation,
+				expectedApplyIdentity.manifestETag,
+				expectedApplyIdentity.applyReceiptId,
+				expectedApplyIdentity.bootNonce,
+			]),
+		};
+	}
+}
+
+export async function runRuntimeObservationProducer(
+	options: RuntimeObservationProducerOptions,
+): Promise<void> {
+	const paths = options.paths ?? getRuntimePaths();
+	if (paths.mode !== "hosted") return;
+	const producer = new HostedRuntimeObservationProducer({ ...options, paths });
+	const delay = options.delay ?? abortableDelay;
+	const activeAttempts = new Map<string, Promise<void>>();
+	const nextAttemptAt = new Map<string, number>();
+	while (!options.abort.aborted) {
+		try {
+			const identityKey = producer.currentAttestedIdentityKey();
+			if (
+				identityKey &&
+				!activeAttempts.has(identityKey) &&
+				Date.now() >= (nextAttemptAt.get(identityKey) ?? 0)
+			) {
+				const attempt = producer.sendOnce().then((result) => {
+					nextAttemptAt.set(
+						identityKey,
+						Date.now() + (result === "idle" ? IDLE_RETRY_INTERVAL_MS : OBSERVATION_INTERVAL_MS),
+					);
+					activeAttempts.delete(identityKey);
+				});
+				activeAttempts.set(identityKey, attempt);
+			}
+		} catch (error) {
+			log.info("daemon.runtime_observation_failed", { error: toErrorMessage(error) });
+		}
+		await delay(IDLE_RETRY_INTERVAL_MS, options.abort);
+	}
+}
+
+export function readRuntimeObservationEnvironmentId(paths: RuntimePaths): string | null {
+	const fromEnvironment = process.env.CLAWDI_ENVIRONMENT_ID;
+	if (fromEnvironment !== undefined) {
+		const normalized = fromEnvironment.trim();
+		if (!normalized || normalized !== fromEnvironment) {
+			throw new Error("CLAWDI_ENVIRONMENT_ID must be a non-empty canonical identity");
+		}
+		return normalized;
+	}
+	try {
+		const value: unknown = JSON.parse(readFileSync(paths.instanceData, "utf-8"));
+		return runtimeInstanceIdentitySchema.parse(value).environmentId;
+	} catch {
+		return null;
+	}
+}
+
+function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sameApplyIdentity(left: RuntimeApplyIdentity, right: RuntimeApplyIdentity): boolean {
+	return (
+		left.generation === right.generation &&
+		left.manifestETag === right.manifestETag &&
+		left.applyReceiptId === right.applyReceiptId &&
+		left.bootNonce === right.bootNonce
+	);
+}
+
+function eventMatchesApplyIdentity(
+	event: HostedRuntimeObservedEvent,
+	identity: RuntimeApplyIdentity,
+): boolean {
+	return (
+		event.applied.generation === identity.generation &&
+		event.applied.etag === identity.manifestETag &&
+		event.applyReceiptId === identity.applyReceiptId &&
+		event.bootNonce === identity.bootNonce
+	);
+}
+
+export function isSafelyTerminalRuntimeObservationFailure(result: {
+	error?: unknown;
+	response: { status: number };
+}): boolean {
+	if (result.response.status !== 422 || !isUnknownRecord(result.error)) return false;
+	const detail = result.error.detail;
+	return isUnknownRecord(detail) && detail.code === "runtime_observation_captured_at_too_old";
+}
+
+function abortableDelay(ms: number, abort: AbortSignal): Promise<void> {
+	return new Promise((resolve) => {
+		const onAbort = () => {
+			clearTimeout(timer);
+			resolve();
+		};
+		const timer = setTimeout(() => {
+			abort.removeEventListener("abort", onAbort);
+			resolve();
+		}, ms);
+		abort.addEventListener("abort", onAbort, { once: true });
+	});
+}

--- a/packages/cli/src/runtime/runtime-bundle-v2.test.ts
+++ b/packages/cli/src/runtime/runtime-bundle-v2.test.ts
@@ -68,40 +68,23 @@ describe("hosted runtime bundle v2", () => {
 		).toThrow();
 	});
 
-	test("accepts the additive manifest v2 apply identity without changing manifest v1", () => {
+	test("rejects response-carried apply identity and keeps the inner manifest v1-only", () => {
 		const raw = z
 			.record(z.string(), z.unknown())
 			.parse(JSON.parse(readFileSync(goldenPath, "utf-8")));
 		const manifest = z.record(z.string(), z.unknown()).parse(raw.manifest);
-		const v1 = normalizeHostedRuntimeBundleV2(raw);
-		const v2 = normalizeHostedRuntimeBundleV2({
-			...raw,
-			manifest: {
-				...manifest,
-				schemaVersion: "clawdi.hosted-runtime.manifest.v2",
-				manifestETag: '"frozen-manifest-generation-1"',
-				applyReceiptId: "apply-receipt-0001",
-				bootNonce: "boot-nonce-000001",
-			},
-		});
-
-		expect(v1.applyIdentity).toBeUndefined();
-		expect(v2.applyIdentity).toEqual({
-			generation: v2.manifest.generation,
-			manifestETag: '"frozen-manifest-generation-1"',
-			applyReceiptId: "apply-receipt-0001",
-			bootNonce: "boot-nonce-000001",
-		});
+		expect(normalizeHostedRuntimeBundleV2(raw).manifest.projection?.sourceSchemaVersion).toBe(
+			"clawdi.hosted-runtime.manifest.v1",
+		);
 		expect(() =>
 			normalizeHostedRuntimeBundleV2({
 				...raw,
 				manifest: {
 					...manifest,
 					schemaVersion: "clawdi.hosted-runtime.manifest.v2",
-					generation: 0,
-					manifestETag: '"frozen-manifest-generation-0"',
-					applyReceiptId: "apply-receipt-0000",
-					bootNonce: "boot-nonce-000000",
+					manifestETag: '"manifest-7"',
+					applyReceiptId: "apply-receipt-0007",
+					bootNonce: "boot-nonce-000007",
 				},
 			}),
 		).toThrow();
@@ -116,6 +99,10 @@ describe("hosted runtime bundle v2", () => {
 		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.env.CLAWDI_RUNTIME_AUTH_ENV = "CLAWDI_TEST_TOKEN";
 		process.env.CLAWDI_TEST_TOKEN = "clawdi_test";
+		process.env.CLAWDI_RUNTIME_GENERATION = "7";
+		process.env.CLAWDI_RUNTIME_MANIFEST_ETAG = '"manifest-7"';
+		process.env.CLAWDI_RUNTIME_APPLY_RECEIPT_ID = "apply-receipt-0007";
+		process.env.CLAWDI_RUNTIME_BOOT_NONCE = "boot-nonce-000007";
 		const paths = getRuntimePaths({ mode: "hosted" });
 		let requests = 0;
 		globalThis.fetch = Object.assign(
@@ -124,6 +111,10 @@ describe("hosted runtime bundle v2", () => {
 				const headers = new Headers(init?.headers);
 				expect(headers.get("accept")).toBe(HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE);
 				expect(headers.get("if-none-match")).toBe('"bundle-1"');
+				expect(headers.get("x-clawdi-runtime-generation")).toBeNull();
+				expect(headers.get("x-clawdi-runtime-manifest-etag")).toBeNull();
+				expect(headers.get("x-clawdi-runtime-apply-receipt-id")).toBeNull();
+				expect(headers.get("x-clawdi-runtime-boot-nonce")).toBeNull();
 				return new Response(null, { status: 304, headers: { etag: '"bundle-1"' } });
 			},
 			{ preconnect: () => undefined },

--- a/packages/cli/src/serve/sync-engine.ts
+++ b/packages/cli/src/serve/sync-engine.ts
@@ -65,8 +65,10 @@ import {
 } from "../lib/skills-lock";
 import { tarSkillDir } from "../lib/tar";
 import { getCliVersion } from "../lib/version";
-import { HostedRuntimeHeartbeatSession } from "../runtime/heartbeat-observation";
 import { readHostedRuntimeObserved } from "../runtime/observed";
+
+export { isSafelyTerminalRuntimeObservationFailure } from "../runtime/observation-producer";
+
 import { log, toErrorMessage } from "./log";
 import { getServeStateDir } from "./paths";
 import { type QueueItem, RetryQueue } from "./queue";
@@ -822,7 +824,6 @@ export async function runSyncEngine(opts: EngineOpts): Promise<void> {
 			last_revision_seen: lastSeenRevision,
 			last_sync_error: lastSyncError,
 		})),
-		runtimeObservationLoop(opts, api, opts.abort),
 		refreshDefaultProjectIdLoop(opts.abort),
 		// Safety-net periodic sessions rescan. After a 4xx drop we
 		// clear inFlightSessionHash, but the watcher only fires on
@@ -937,19 +938,6 @@ export function lastSyncErrorForSseReconnect(
 
 export function classifyHeartbeatFailure(consecutiveFailures: number): FailureClassification {
 	return consecutiveFailures <= TRANSIENT_HEARTBEAT_FAILURES ? "transient" : "sustained";
-}
-
-function isUnknownRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-export function isSafelyTerminalRuntimeObservationFailure(result: {
-	error?: unknown;
-	response: { status: number };
-}): boolean {
-	if (result.response.status !== 422 || !isUnknownRecord(result.error)) return false;
-	const detail = result.error.detail;
-	return isUnknownRecord(detail) && detail.code === "runtime_observation_captured_at_too_old";
 }
 
 /**
@@ -2305,55 +2293,6 @@ async function heartbeatLoop(
 		// don't all heartbeat in the same wall-clock second. The
 		// upper bound stays inside the dashboard's 90s freshness
 		// window after the eager first beat.
-		await sleep(heartbeatDelayMs(), abort);
-		if (abort.aborted) return;
-		await send();
-	}
-}
-
-/** Send durable strict-v2 observations independently of legacy liveness. */
-async function runtimeObservationLoop(
-	opts: EngineOpts,
-	api: ApiClient,
-	abort: AbortSignal,
-): Promise<void> {
-	let runtimeHeartbeatSession: HostedRuntimeHeartbeatSession | null = null;
-	const send = async () => {
-		let buffered: ReturnType<HostedRuntimeHeartbeatSession["nextEvent"]> = null;
-		try {
-			runtimeHeartbeatSession ??= new HostedRuntimeHeartbeatSession({
-				environmentId: opts.environmentId,
-			});
-			buffered = runtimeHeartbeatSession.nextEvent();
-			if (!buffered) return;
-			const response = await api.POST("/v2/runtime/environments/{environment_id}/observations", {
-				params: { path: { environment_id: opts.environmentId } },
-				body: buffered.event,
-			});
-			if (isSafelyTerminalRuntimeObservationFailure(response)) {
-				if (!runtimeHeartbeatSession.retireTerminallyStale(buffered.event.eventId)) {
-					throw new Error("terminally stale runtime observation did not match buffered event");
-				}
-				log.warn("engine.runtime_observation_retired_stale", {
-					event_id: buffered.event.eventId,
-					captured_at: buffered.event.capturedAt,
-				});
-				return;
-			}
-			unwrap(response);
-			if (!runtimeHeartbeatSession.acknowledge(buffered.event.eventId)) {
-				throw new Error("runtime observation acknowledgement did not match buffered event");
-			}
-		} catch (error) {
-			log.info("engine.runtime_observation_failed", {
-				error: toErrorMessage(error),
-				...(buffered ? { event_id: buffered.event.eventId } : {}),
-			});
-		}
-	};
-
-	await send();
-	while (!abort.aborted) {
 		await sleep(heartbeatDelayMs(), abort);
 		if (abort.aborted) return;
 		await send();

--- a/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
+++ b/packages/cli/tests/e2e/daemon-rpc.e2e.test.ts
@@ -264,7 +264,7 @@ if (process.platform !== "win32") {
 					].join("\n"),
 				);
 			}
-			expect(daemonStderrText).toContain("engine.runtime_observation_failed");
+			expect(daemonStderrText).toContain("daemon.runtime_observation_failed");
 		}, 20_000);
 	});
 }
@@ -342,12 +342,17 @@ function cliEnv(fixture: Fixture): Record<string, string> {
 	return {
 		CLAWDI_API_URL: server.url.origin,
 		CLAWDI_AUTH_TOKEN: API_KEY,
+		CLAWDI_ENVIRONMENT_ID: ENV_ID,
 		CLAWDI_HOME: fixture.clawdiHome,
 		CLAWDI_NO_AUTO_UPDATE: "1",
 		CLAWDI_NO_UPDATE_CHECK: "1",
 		CLAWDI_SERVE_MODE: "container",
 		CLAWDI_RUNTIME_MODE: "hosted",
 		CLAWDI_RUNTIME_HOME: fixture.home,
+		CLAWDI_RUNTIME_GENERATION: "1",
+		CLAWDI_RUNTIME_MANIFEST_ETAG: '"frozen-manifest"',
+		CLAWDI_RUNTIME_APPLY_RECEIPT_ID: "apply-receipt-daemon-rpc",
+		CLAWDI_RUNTIME_BOOT_NONCE: "boot-nonce-daemon-rpc-01",
 		CLAWDI_RUN_DIR: fixture.runDir,
 		CLAWDI_SERVICE_STATE_DIR: fixture.serviceStateDir,
 		CLAWDI_STATE_DIR: fixture.stateDir,

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -96,6 +96,10 @@ const ENV_KEYS = [
 	"CLAWDI_CODEX_INSTALL_TIMEOUT",
 	"CUSTOM_RUNTIME_TOKEN",
 	"CLAWDI_RUNTIME_MANIFEST_TIMEOUT_MS",
+	"CLAWDI_RUNTIME_GENERATION",
+	"CLAWDI_RUNTIME_MANIFEST_ETAG",
+	"CLAWDI_RUNTIME_APPLY_RECEIPT_ID",
+	"CLAWDI_RUNTIME_BOOT_NONCE",
 	"CLAWDI_API_URL",
 	"CLAWDI_SYSTEMD_APPLY",
 	"CLAWDI_SYSTEMD_SYSTEM_ROOT",
@@ -1533,7 +1537,7 @@ describe("runtime manifest datasource", () => {
 		}
 	});
 
-	it("preserves the exact strict-v2 apply identity through offline load and state commit", async () => {
+	it("does not reuse a cached strict-v2 tuple as new applied authority", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -1572,12 +1576,6 @@ describe("runtime manifest datasource", () => {
 		if (!("manifest" in loaded)) {
 			throw new Error(`expected offline manifest load success: ${loaded.errors.join("; ")}`);
 		}
-		expect(loaded.applyIdentity).toEqual({
-			generation: 3,
-			manifestETag: '"manifest-etag-offline"',
-			applyReceiptId: "apply-receipt-offline-0001",
-			bootNonce: "boot-nonce-offline-000001",
-		});
 		const convergence = convergeRuntimeManifest(loaded, paths, { cacheLastGood: false });
 		commitRuntimeAppliedState({
 			load: loaded,
@@ -1585,13 +1583,13 @@ describe("runtime manifest datasource", () => {
 			etag: '"transport-etag-offline-reapplied"',
 			sourceRevision: "c".repeat(64),
 			convergence,
+			applyIdentity: null,
 		});
-		expect(readRuntimeAppliedState(paths)).toMatchObject({
-			generation: 3,
-			manifestETag: '"manifest-etag-offline"',
-			applyReceiptId: "apply-receipt-offline-0001",
-			bootNonce: "boot-nonce-offline-000001",
-		});
+		const reapplied = readRuntimeAppliedState(paths);
+		expect(reapplied?.generation).toBe(3);
+		expect(reapplied?.manifestETag).toBeUndefined();
+		expect(reapplied?.applyReceiptId).toBeUndefined();
+		expect(reapplied?.bootNonce).toBeUndefined();
 	});
 
 	it("refuses strict-v2 offline identity restoration when cached manifest content changed", async () => {
@@ -5458,6 +5456,12 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		process.env.CLAWDI_RUN_DIR = run;
 		process.env.CLAWDI_RUNTIME_MANIFEST_URL = "https://runtime.test/v1/runtime/manifest";
 		process.env.CLAWDI_SYSTEMCTL_PATH = join(bin, "systemctl");
+		process.env.CLAWDI_SYSTEMD_APPLY = "0";
+		process.env.CLAWDI_RUNTIME_USER = "root";
+		process.env.CLAWDI_RUNTIME_GENERATION = "12";
+		process.env.CLAWDI_RUNTIME_MANIFEST_ETAG = '"manifest-watch-12"';
+		process.env.CLAWDI_RUNTIME_APPLY_RECEIPT_ID = "apply-receipt-0012";
+		process.env.CLAWDI_RUNTIME_BOOT_NONCE = "boot-nonce-000012";
 		process.exitCode = undefined;
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
@@ -5531,12 +5535,21 @@ printf 'ActiveState=active\\nSubState=running\\n'
 
 		try {
 			await runtimeWatch({ once: true, json: true });
+			expect(process.exitCode).toBe(1);
+			expect(readRuntimeAppliedState(getRuntimePaths())).toBeNull();
+			const rejected = JSON.parse(logs.at(-1) ?? "{}");
+			expect(rejected.status).toBe("error");
+			expect(rejected.error).toContain("systemd apply did not activate");
+
+			process.env.CLAWDI_SYSTEMD_APPLY = "1";
+			process.exitCode = undefined;
+			await runtimeWatch({ once: true, json: true });
 
 			if (process.exitCode !== undefined && process.exitCode !== 0) {
 				throw new Error(logs.join("\n"));
 			}
 			expect(process.exitCode ?? 0).toBe(0);
-			expect(captured).toHaveLength(1);
+			expect(captured).toHaveLength(2);
 			expect(captured[0].headers.authorization).toBe("Bearer file-runtime-token");
 			expect(captured[0].headers.accept).toBe(HOSTED_RUNTIME_BUNDLE_V2_MEDIA_TYPE);
 			expect(existsSync(join(state, "cache", "manifest.etag"))).toBe(false);
@@ -5548,17 +5561,20 @@ printf 'ActiveState=active\\nSubState=running\\n'
 				etag: '"etag-watch-12"',
 				sourceRevision: "a".repeat(64),
 				generation: 12,
+				manifestETag: '"manifest-watch-12"',
+				applyReceiptId: "apply-receipt-0012",
+				bootNonce: "boot-nonce-000012",
 				providerIds: ["default"],
 			});
-			const event = JSON.parse(logs[0]);
+			const event = JSON.parse(logs.at(-1) ?? "{}");
 			expect(event.status).toBe("applied");
 			expect(event.generation).toBe(12);
 			expect(event.etag).toBe('"etag-watch-12"');
 			expect(event.convergence.appliedState).toBe(getRuntimePaths().appliedState);
 			expect(event.systemdUnitsChanged).toBe(true);
 			expect(event.systemdApply).toEqual({
-				applied: false,
-				systemUnitsChanged: ["clawdi-runtime-watch.service"],
+				applied: true,
+				systemUnitsChanged: ["clawdi-daemon.service", "clawdi-runtime-watch.service"],
 				userUnitsChanged: ["openclaw-gateway.service"],
 			});
 			const watchStatus = JSON.parse(
@@ -5577,7 +5593,15 @@ printf 'ActiveState=active\\nSubState=running\\n'
 			expect(readSystemdSystemUnit(paths, "clawdi-runtime-watch")).toContain(
 				'ExecStart="clawdi" "runtime" "watch"',
 			);
-			expect(readSystemdEnvFile(paths, "clawdi-runtime-watch")).not.toContain("file-runtime-token");
+			const watchEnv = readSystemdEnvFile(paths, "clawdi-runtime-watch");
+			const daemonEnv = readSystemdEnvFile(paths, "clawdi-daemon");
+			expect(watchEnv).not.toContain("file-runtime-token");
+			for (const unitEnv of [watchEnv, daemonEnv]) {
+				expect(unitEnv).toContain('CLAWDI_RUNTIME_GENERATION="12"');
+				expect(unitEnv).toContain('CLAWDI_RUNTIME_MANIFEST_ETAG="\\"manifest-watch-12\\""');
+				expect(unitEnv).toContain('CLAWDI_RUNTIME_APPLY_RECEIPT_ID="apply-receipt-0012"');
+				expect(unitEnv).toContain('CLAWDI_RUNTIME_BOOT_NONCE="boot-nonce-000012"');
+			}
 		} finally {
 			restore();
 			console.log = previousLog;
@@ -6740,7 +6764,7 @@ chmod +x "$prefix/bin/clawdi"
 			expect(event.systemdUnitsChanged).toBe(true);
 			expect(event.systemdApply).toEqual({
 				applied: false,
-				systemUnitsChanged: ["clawdi-runtime-watch.service"],
+				systemUnitsChanged: ["clawdi-daemon.service", "clawdi-runtime-watch.service"],
 				userUnitsChanged: ["openclaw-gateway.service"],
 			});
 		} finally {
@@ -6963,7 +6987,9 @@ printf 'ActiveState=active\\nSubState=running\\n'
 			expect(event.systemdApply.applied).toBe(true);
 			expect(event.systemdApply.systemUnitsChanged).toContain("clawdi-runtime-sidecar.service");
 			const systemctlCalls = readFileSync(systemctlLog, "utf-8").trim().split("\n");
-			expect(systemctlCalls).toContain("restart clawdi-runtime-sidecar.service");
+			expect(systemctlCalls).toContain(
+				"restart clawdi-daemon.service clawdi-runtime-sidecar.service",
+			);
 			const sidecarEnv = readSystemdEnvFile(paths, "clawdi-runtime-sidecar");
 			const sidecarUnit = readSystemdSystemUnit(paths, "clawdi-runtime-sidecar");
 			const transparentEgressEnv = readFileSync(paths.egressTransparentEnv, "utf-8");
@@ -11103,7 +11129,7 @@ exit 64
 		}
 	});
 
-	it("converges remote manifests without caching secret values", async () => {
+	it("converges remote manifests and starts the observation daemon with liveSync agents=[]", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -11199,6 +11225,7 @@ exit 64
 			expect(convergence.outputs.processManager).toBe("systemd");
 			expect(convergence.outputs.systemdSystemUnits).toEqual([
 				join(paths.systemdSystemRoot, "clawdi-runtime-watch.service"),
+				join(paths.systemdSystemRoot, "clawdi-daemon.service"),
 				join(paths.systemdSystemRoot, "clawdi-runtime-sidecar.service"),
 			]);
 			expect(convergence.outputs.systemdUserUnits).toEqual([
@@ -11206,7 +11233,10 @@ exit 64
 			]);
 			const watchUnit = readSystemdSystemUnit(paths, "clawdi-runtime-watch");
 			const watchEnv = readSystemdEnvFile(paths, "clawdi-runtime-watch");
+			const daemonEnv = readSystemdEnvFile(paths, "clawdi-daemon");
 			expect(watchUnit).toContain('ExecStart="clawdi" "runtime" "watch"');
+			expect(daemonEnv).toContain('CLAWDI_ENVIRONMENT_ID="env_test"');
+			expect(daemonEnv).toContain('CLAWDI_SERVE_MODE="container"');
 			expect(watchUnit).not.toContain("sk-runtime");
 			expect(watchEnv).not.toContain("sk-runtime");
 			expect(readFileSync(join(state, "cache", "manifest.last-good.json"), "utf-8")).not.toContain(


### PR DESCRIPTION
Closes the v2 declarative Ready-evidence gap (#57): the agent daemon self-attests exact-tuple runtime observations so control-plane Ready can close on genuine evidence. Single daemon-level producer (removed per-engine loop); emits only after a genuinely successful systemd apply (never attests applied=false); re-reads applied tuple on rotation (new boot session); no rotation deadlock. Cloud: tuple-filtered read returns only the current tuple's contiguous prefix, cursor stops before the next tuple's first event. Shared manifest renderer/sessions/health BYTE-IDENTICAL (git diff --quiet → 0); legacy v1 has no manifest, unaffected. Tests: CLI 1024 / backend 1319 pass + fresh-PG cursor test. Do NOT merge/publish/promote until real-agent Ready validation passes and the coordinated CLI+image release is approved. Pairs with clawdi-hosted env-forwarding PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)