### PR TITLE
feat(web): subscription reuse banner + delete cancel choice

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -2563,7 +2563,9 @@ test("paid Basic cancellation stays conditional with the included slot vacant or
 	expect(errors, `paid Basic cancellation: ${errors.join(" | ")}`).toEqual([]);
 });
 
-test("paid agent deletion keeps the reusable subscription by default", async ({ page }) => {
+test("paid agent deletion cancels the subscription before teardown by default", async ({
+	page,
+}) => {
 	const cancelRequests: string[] = [];
 	const deleteRequests: string[] = [];
 	const mutationOrder: string[] = [];
@@ -2582,17 +2584,17 @@ test("paid agent deletion keeps the reusable subscription by default", async ({ 
 	await expect(dialog).toContainText("Delete agent and cancel subscription");
 	const choices = dialog.getByRole("radio");
 	await expect(choices).toHaveCount(2);
-	await expect(choices.first()).toBeChecked();
+	await expect(choices.nth(1)).toBeChecked();
 	await dialog
-		.getByRole("button", { name: "Delete agent (keep subscription)", exact: true })
+		.getByRole("button", { name: "Delete agent and cancel subscription", exact: true })
 		.click();
 
-	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_paid"]);
-	expect(cancelRequests).toEqual([]);
-	expect(mutationOrder).toEqual(["delete"]);
+	await expect.poll(() => mutationOrder).toEqual(["cancel", "delete"]);
+	expect(JSON.parse(cancelRequests[0] ?? "{}")).toEqual({ deployment_id: "hdep_paid" });
+	expect(deleteRequests).toEqual(["/v2/deployments/hdep_paid"]);
 });
 
-test("paid agent deletion records cancellation before deployment teardown", async ({ page }) => {
+test("paid agent deletion explicitly keeps the reusable subscription", async ({ page }) => {
 	const cancelRequests: string[] = [];
 	const deleteRequests: string[] = [];
 	const mutationOrder: string[] = [];
@@ -2607,14 +2609,14 @@ test("paid agent deletion records cancellation before deployment teardown", asyn
 
 	await page.locator("main").getByRole("button", { name: "Delete", exact: true }).click();
 	const dialog = page.getByRole("alertdialog");
-	await dialog.getByRole("radio").nth(1).check();
+	await dialog.getByRole("radio").first().check();
 	await dialog
-		.getByRole("button", { name: "Delete agent and cancel subscription", exact: true })
+		.getByRole("button", { name: "Delete agent (keep subscription)", exact: true })
 		.click();
 
-	await expect.poll(() => mutationOrder).toEqual(["cancel", "delete"]);
-	expect(JSON.parse(cancelRequests[0] ?? "{}")).toEqual({ deployment_id: "hdep_paid" });
-	expect(deleteRequests).toEqual(["/v2/deployments/hdep_paid"]);
+	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_paid"]);
+	expect(cancelRequests).toEqual([]);
+	expect(mutationOrder).toEqual(["delete"]);
 });
 
 test("paid agent deletion does not teardown when cancellation fails", async ({ page }) => {

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -733,6 +733,7 @@ type HostedApiStubOptions = {
 	canCreateCloudAgents?: boolean;
 	productAccessRequests?: string[];
 	cancelRequests?: string[];
+	cancelResponses?: StubResponse[];
 	checkoutRequests?: string[];
 	checkoutResponses?: StubResponse[];
 	cloudAgentOverrides?: Record<string, unknown>;
@@ -745,6 +746,7 @@ type HostedApiStubOptions = {
 	createDeploymentRequests?: Array<{ body: string; idempotencyKey: string | null }>;
 	deleteRequests?: string[];
 	completedDeleteIds?: Set<string>;
+	deleteResponses?: StubResponse[];
 	deployments?: readonly unknown[];
 	deploymentsResponse?: StubResponse;
 	fixPaymentRequests?: string[];
@@ -753,6 +755,7 @@ type HostedApiStubOptions = {
 	ledgerResponses?: unknown[];
 	managedModels?: typeof managedModelCatalog;
 	planRequests?: string[];
+	mutationOrder?: string[];
 	plans?: readonly unknown[];
 	portalRequests?: string[];
 	planChangeRequests?: string[];
@@ -1056,6 +1059,9 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		}
 		if (p === "/v2/subscription/cancel" && r.request().method() === "POST") {
 			options.cancelRequests?.push(r.request().postData() ?? "");
+			options.mutationOrder?.push("cancel");
+			const response = options.cancelResponses?.shift();
+			if (response) return fulfillJson(r, response.body, response.status);
 			return fulfillJson(r, {
 				status: "active",
 				billing_term_months: 12,
@@ -1144,6 +1150,9 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		}
 		if (p.startsWith("/v2/deployments/") && r.request().method() === "DELETE") {
 			options.deleteRequests?.push(p);
+			options.mutationOrder?.push("delete");
+			const response = options.deleteResponses?.shift();
+			if (response) return fulfillJson(r, response.body, response.status);
 			const deploymentId = p.slice("/v2/deployments/".length);
 			const deployment = deployments.find(
 				(candidate): candidate is DeploymentMutationFixture =>
@@ -1580,7 +1589,7 @@ test("env-keyed agent route keeps failed deployment recovery available without i
 	await main.getByRole("button", { name: "Delete", exact: true }).click();
 	await page
 		.getByRole("alertdialog")
-		.getByRole("button", { name: "Delete compute", exact: true })
+		.getByRole("button", { name: "Delete agent", exact: true })
 		.click();
 	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_failed_projection"]);
 });
@@ -1692,7 +1701,7 @@ test("failed deployment with a retained projection keeps status-authoritative na
 	await main.getByRole("button", { name: "Delete", exact: true }).click();
 	await page
 		.getByRole("alertdialog")
-		.getByRole("button", { name: "Delete compute", exact: true })
+		.getByRole("button", { name: "Delete agent", exact: true })
 		.click();
 	await expect
 		.poll(() => deleteRequests)
@@ -1856,7 +1865,7 @@ test("shared legacy environment routes an older tile's actions to its deployment
 	await main.getByRole("button", { name: "Delete", exact: true }).click();
 	await page
 		.getByRole("alertdialog")
-		.getByRole("button", { name: "Delete compute", exact: true })
+		.getByRole("button", { name: "Delete agent", exact: true })
 		.click();
 
 	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_shared_older"]);
@@ -1899,7 +1908,7 @@ test("identity-less interrupted deployment tile exposes delete", async ({ page }
 	await deleteAction.click();
 	await page
 		.getByRole("alertdialog")
-		.getByRole("button", { name: "Delete deployment", exact: true })
+		.getByRole("button", { name: "Delete agent", exact: true })
 		.click();
 	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_creation_interrupted"]);
 });
@@ -1930,6 +1939,51 @@ test("Basic create always follows the wizard-selected funding path", async ({ pa
 		deploy_config: { compute_plan_slug: "compute_basic" },
 	});
 	expect(errors, `funded Basic deploy: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("entitled card subscription activation shows reuse banner without checkout", async ({
+	page,
+}) => {
+	const errors = collectBrowserErrors(page);
+	const checkoutRequests: string[] = [];
+	await stubHostedApi(page, {
+		checkoutRequests,
+		checkoutResponses: [
+			{
+				status: 200,
+				body: {
+					flow_type: "subscription_activation",
+					funding_source: "stripe",
+					checkout_url: "",
+					deploy_request_id: "reuse-active-subscription",
+					current_period_end: "2027-07-15T00:00:00Z",
+					entitled_until: "2027-07-15T00:00:00Z",
+				},
+			},
+		],
+		deployments: [includedBasicDeployment],
+		plans: [basicPlan, performancePlan],
+	});
+	await page.goto("/deploy");
+	await page.waitForLoadState("networkidle");
+
+	await page.getByRole("button", { name: "Continue to checkout" }).click();
+	await expect.poll(() => checkoutRequests.length).toBe(1);
+	const banner = page.getByTestId("subscription-reuse-banner");
+	await expect(banner).toBeVisible();
+	await expect(banner).toContainText(
+		"Reusing your active subscription — valid until Jul 15, 2027, no additional charge.",
+	);
+	await expect(page.getByRole("dialog", { name: /Complete .* checkout/ })).toHaveCount(0);
+	await expect(page.getByText("Mock secure payment form", { exact: true })).toHaveCount(0);
+	await expect(
+		page.getByRole("button", { name: "Deployment started", exact: true }),
+	).toBeDisabled();
+	expect(JSON.parse(checkoutRequests[0] ?? "{}")).toMatchObject({
+		funding_source: "stripe",
+		deploy_config: { compute_plan_slug: "compute_basic" },
+	});
+	expect(errors, `subscription reuse activation: ${errors.join(" | ")}`).toEqual([]);
 });
 
 test("free-funded Basic uses annual compute_basic checkout when the included slot is occupied", async ({
@@ -2507,6 +2561,130 @@ test("paid Basic cancellation stays conditional with the included slot vacant or
 		await expect(page.getByRole("button", { name: "Resume subscription" })).toBeVisible();
 	}
 	expect(errors, `paid Basic cancellation: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("paid agent deletion keeps the reusable subscription by default", async ({ page }) => {
+	const cancelRequests: string[] = [];
+	const deleteRequests: string[] = [];
+	const mutationOrder: string[] = [];
+	await stubHostedApi(page, {
+		cancelRequests,
+		deleteRequests,
+		deployments: [paidBasicDeployment],
+		mutationOrder,
+		plans: [basicPlan, performancePlan],
+	});
+	await gotoHostedAgentSettings(page, "hdep_paid", "Basic");
+
+	await page.locator("main").getByRole("button", { name: "Delete", exact: true }).click();
+	const dialog = page.getByRole("alertdialog");
+	await expect(dialog).toContainText("Keep subscription — redeploy reuses it, no re-charge.");
+	await expect(dialog).toContainText("Delete agent and cancel subscription");
+	const choices = dialog.getByRole("radio");
+	await expect(choices).toHaveCount(2);
+	await expect(choices.first()).toBeChecked();
+	await dialog
+		.getByRole("button", { name: "Delete agent (keep subscription)", exact: true })
+		.click();
+
+	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_paid"]);
+	expect(cancelRequests).toEqual([]);
+	expect(mutationOrder).toEqual(["delete"]);
+});
+
+test("paid agent deletion records cancellation before deployment teardown", async ({ page }) => {
+	const cancelRequests: string[] = [];
+	const deleteRequests: string[] = [];
+	const mutationOrder: string[] = [];
+	await stubHostedApi(page, {
+		cancelRequests,
+		deleteRequests,
+		deployments: [paidBasicDeployment],
+		mutationOrder,
+		plans: [basicPlan, performancePlan],
+	});
+	await gotoHostedAgentSettings(page, "hdep_paid", "Basic");
+
+	await page.locator("main").getByRole("button", { name: "Delete", exact: true }).click();
+	const dialog = page.getByRole("alertdialog");
+	await dialog.getByRole("radio").nth(1).check();
+	await dialog
+		.getByRole("button", { name: "Delete agent and cancel subscription", exact: true })
+		.click();
+
+	await expect.poll(() => mutationOrder).toEqual(["cancel", "delete"]);
+	expect(JSON.parse(cancelRequests[0] ?? "{}")).toEqual({ deployment_id: "hdep_paid" });
+	expect(deleteRequests).toEqual(["/v2/deployments/hdep_paid"]);
+});
+
+test("paid agent deletion does not teardown when cancellation fails", async ({ page }) => {
+	const cancelRequests: string[] = [];
+	const deleteRequests: string[] = [];
+	const mutationOrder: string[] = [];
+	await stubHostedApi(page, {
+		cancelRequests,
+		cancelResponses: [
+			{
+				status: 503,
+				body: { detail: "Cancellation service is temporarily unavailable." },
+			},
+		],
+		deleteRequests,
+		deployments: [paidBasicDeployment],
+		mutationOrder,
+		plans: [basicPlan, performancePlan],
+	});
+	await gotoHostedAgentSettings(page, "hdep_paid", "Basic");
+
+	await page.locator("main").getByRole("button", { name: "Delete", exact: true }).click();
+	const dialog = page.getByRole("alertdialog");
+	await dialog.getByRole("radio").nth(1).check();
+	await dialog
+		.getByRole("button", { name: "Delete agent and cancel subscription", exact: true })
+		.click();
+
+	await expect.poll(() => cancelRequests.length).toBe(1);
+	await expect(page.getByText("Couldn’t cancel subscription", { exact: true })).toBeVisible();
+	await expect(dialog).toBeVisible();
+	expect(deleteRequests).toEqual([]);
+	expect(mutationOrder).toEqual(["cancel"]);
+});
+
+test("paid agent deletion surfaces preserved cancellation when teardown fails", async ({
+	page,
+}) => {
+	const cancelRequests: string[] = [];
+	const deleteRequests: string[] = [];
+	const mutationOrder: string[] = [];
+	await stubHostedApi(page, {
+		cancelRequests,
+		deleteRequests,
+		deleteResponses: [
+			{
+				status: 503,
+				body: { detail: "Deployment teardown is temporarily unavailable." },
+			},
+		],
+		deployments: [paidBasicDeployment],
+		mutationOrder,
+		plans: [basicPlan, performancePlan],
+	});
+	await gotoHostedAgentSettings(page, "hdep_paid", "Basic");
+
+	await page.locator("main").getByRole("button", { name: "Delete", exact: true }).click();
+	const dialog = page.getByRole("alertdialog");
+	await dialog.getByRole("radio").nth(1).check();
+	await dialog
+		.getByRole("button", { name: "Delete agent and cancel subscription", exact: true })
+		.click();
+
+	await expect.poll(() => mutationOrder).toEqual(["cancel", "delete"]);
+	await expect(
+		page.getByText("Subscription cancellation kept; agent not deleted", { exact: true }),
+	).toBeVisible();
+	await expect(dialog).toBeVisible();
+	expect(JSON.parse(cancelRequests[0] ?? "{}")).toEqual({ deployment_id: "hdep_paid" });
+	expect(deleteRequests).toEqual(["/v2/deployments/hdep_paid"]);
 });
 
 test("paid Performance exposes subscription actions without a direct Basic switch", async ({

--- a/apps/web/src/hosted/agents/deployment-delete-action.logic.test.ts
+++ b/apps/web/src/hosted/agents/deployment-delete-action.logic.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
+import {
+	deleteDeploymentWithSubscriptionChoice,
+	offersSubscriptionDeleteChoice,
+} from "./deployment-delete-action.logic";
+
+function paidDeployment() {
+	const deployment = hostedDeploymentFixture({ id: "hdep_paid_delete" });
+	return {
+		...deployment,
+		current_plan_slug: "compute_basic",
+		commercial_display: {
+			...deployment.commercial_display,
+			compute_subscription: {
+				subscription_id: 42,
+				status: "active",
+				funding_source: "stripe" as const,
+				payment_state: "ok" as const,
+				billing_term_months: 12,
+				price_cents: 8_640,
+				currency: "usd",
+				cancel_at_period_end: false,
+				current_period_end: "2027-07-15T00:00:00Z",
+			},
+		},
+	};
+}
+
+describe("hosted deployment deletion", () => {
+	test("offers the keep-or-cancel choice only for a renewing paid subscription", () => {
+		const paid = paidDeployment();
+		expect(offersSubscriptionDeleteChoice(paid)).toBe(true);
+		expect(
+			offersSubscriptionDeleteChoice({
+				...paid,
+				commercial_display: {
+					...paid.commercial_display,
+					compute_subscription: {
+						...paid.commercial_display.compute_subscription,
+						cancel_at_period_end: true,
+					},
+				},
+			}),
+		).toBe(false);
+	});
+
+	test("keeps the subscription by default and only deletes the deployment", async () => {
+		const calls: string[] = [];
+		await deleteDeploymentWithSubscriptionChoice({
+			choice: "keep_subscription",
+			cancelSubscription: async () => {
+				calls.push("cancel");
+			},
+			deleteDeployment: async () => {
+				calls.push("delete");
+			},
+		});
+		expect(calls).toEqual(["delete"]);
+	});
+
+	test("records cancellation before deleting", async () => {
+		const calls: string[] = [];
+		await deleteDeploymentWithSubscriptionChoice({
+			choice: "cancel_subscription",
+			cancelSubscription: async () => {
+				calls.push("cancel");
+			},
+			deleteDeployment: async () => {
+				calls.push("delete");
+			},
+		});
+		expect(calls).toEqual(["cancel", "delete"]);
+	});
+
+	test("does not delete when cancellation intent cannot be recorded", async () => {
+		const calls: string[] = [];
+		expect(
+			deleteDeploymentWithSubscriptionChoice({
+				choice: "cancel_subscription",
+				cancelSubscription: async () => {
+					calls.push("cancel");
+					throw new Error("cancel unavailable");
+				},
+				deleteDeployment: async () => {
+					calls.push("delete");
+				},
+			}),
+		).rejects.toThrow("cancel unavailable");
+		expect(calls).toEqual(["cancel"]);
+	});
+
+	test("keeps the recorded cancellation when deployment deletion fails", async () => {
+		const calls: string[] = [];
+		expect(
+			deleteDeploymentWithSubscriptionChoice({
+				choice: "cancel_subscription",
+				cancelSubscription: async () => {
+					calls.push("cancel");
+				},
+				deleteDeployment: async () => {
+					calls.push("delete");
+					throw new Error("delete unavailable");
+				},
+			}),
+		).rejects.toThrow("delete unavailable");
+		expect(calls).toEqual(["cancel", "delete"]);
+	});
+});

--- a/apps/web/src/hosted/agents/deployment-delete-action.logic.test.ts
+++ b/apps/web/src/hosted/agents/deployment-delete-action.logic.test.ts
@@ -45,7 +45,7 @@ describe("hosted deployment deletion", () => {
 		).toBe(false);
 	});
 
-	test("keeps the subscription by default and only deletes the deployment", async () => {
+	test("only deletes when keeping the subscription", async () => {
 		const calls: string[] = [];
 		await deleteDeploymentWithSubscriptionChoice({
 			choice: "keep_subscription",

--- a/apps/web/src/hosted/agents/deployment-delete-action.logic.ts
+++ b/apps/web/src/hosted/agents/deployment-delete-action.logic.ts
@@ -1,0 +1,31 @@
+import type { HostedDeployment } from "@/hosted/billing/contracts";
+import {
+	computeFundingMode,
+	isComputeSubscriptionRenewing,
+} from "@/hosted/billing/subscription/subscription-utils";
+
+export type DeploymentDeleteChoice = "keep_subscription" | "cancel_subscription";
+
+export function offersSubscriptionDeleteChoice(deployment: HostedDeployment): boolean {
+	const subscription = deployment.commercial_display?.compute_subscription;
+	return (
+		computeFundingMode(deployment.current_plan_slug, subscription) === "subscription" &&
+		isComputeSubscriptionRenewing(subscription)
+	);
+}
+
+export async function deleteDeploymentWithSubscriptionChoice({
+	choice,
+	cancelSubscription,
+	deleteDeployment,
+}: {
+	choice: DeploymentDeleteChoice;
+	cancelSubscription: () => Promise<void>;
+	deleteDeployment: () => Promise<void>;
+}): Promise<void> {
+	// Deleting first unbinds the subscription, so a later cancellation request
+	// could no longer resolve it by deployment_id. Persist cancellation intent
+	// before teardown and never delete when that first mutation fails.
+	if (choice === "cancel_subscription") await cancelSubscription();
+	await deleteDeployment();
+}

--- a/apps/web/src/hosted/agents/deployment-delete-action.tsx
+++ b/apps/web/src/hosted/agents/deployment-delete-action.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { type ReactElement, useRef, useState } from "react";
+import { toast } from "sonner";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { buttonVariants } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { deploymentDisplayName } from "@/hosted/agent-identity";
+import {
+	type DeploymentDeleteChoice,
+	deleteDeploymentWithSubscriptionChoice,
+	offersSubscriptionDeleteChoice,
+} from "@/hosted/agents/deployment-delete-action.logic";
+import { useDeleteDeployment } from "@/hosted/agents/deployment-hooks";
+import type { ComputeSubscriptionActionResult, HostedDeployment } from "@/hosted/billing/contracts";
+import { normalizeBillingError } from "@/hosted/billing/errors";
+import { useCancelSubscription } from "@/hosted/billing/hooks";
+import { formatShortDate } from "@/lib/format";
+import { cn } from "@/lib/utils";
+
+export function HostedDeploymentDeleteAction({
+	children,
+	deployment,
+	onDeleted,
+}: {
+	children: ReactElement;
+	deployment: HostedDeployment;
+	onDeleted?: () => Promise<void> | void;
+}) {
+	const deleteDeployment = useDeleteDeployment();
+	const cancelSubscription = useCancelSubscription();
+	const [open, setOpen] = useState(false);
+	const [choice, setChoice] = useState<DeploymentDeleteChoice>("keep_subscription");
+	const [pending, setPending] = useState(false);
+	const locked = useRef(false);
+	const subscription = deployment.commercial_display?.compute_subscription;
+	const offerChoice = offersSubscriptionDeleteChoice(deployment);
+	const periodEnd = formatShortDate(subscription?.current_period_end);
+	const name = deploymentDisplayName(deployment.resource.spec.name);
+
+	async function runDelete() {
+		if (locked.current) return;
+		locked.current = true;
+		setPending(true);
+		const cancellationState: {
+			recorded: boolean;
+			result: ComputeSubscriptionActionResult | null;
+		} = { recorded: false, result: null };
+		let deletionCompleted = false;
+		try {
+			await deleteDeploymentWithSubscriptionChoice({
+				choice: offerChoice ? choice : "keep_subscription",
+				cancelSubscription: async () => {
+					cancellationState.result = await cancelSubscription.mutateAsync({
+						deployment_id: deployment.resource.id,
+					});
+					cancellationState.recorded = true;
+				},
+				deleteDeployment: async () => {
+					await deleteDeployment.mutateAsync(deployment.resource.id);
+					deletionCompleted = true;
+				},
+			});
+			if (cancellationState.recorded) {
+				toast.success("Subscription cancellation scheduled", {
+					description: cancellationState.result?.current_period_end
+						? `It stops at the end of the current period on ${formatShortDate(
+								cancellationState.result.current_period_end,
+							)}.`
+						: "It stops at the end of the current billing period.",
+				});
+			}
+			setOpen(false);
+			await onDeleted?.();
+		} catch (error) {
+			if (deletionCompleted) {
+				toast.error("Agent deleted, but navigation failed", {
+					description: "Refresh the page to update the agent list.",
+				});
+			} else if (offerChoice && choice === "cancel_subscription") {
+				if (cancellationState.recorded) {
+					toast.warning("Subscription cancellation kept; agent not deleted", {
+						description:
+							"The subscription will still stop at period end. Retry deleting the agent.",
+					});
+				} else {
+					toast.error("Couldn’t cancel subscription", {
+						description: `The agent was not deleted. ${normalizeBillingError(error)}`,
+					});
+				}
+			}
+		} finally {
+			setPending(false);
+			locked.current = false;
+		}
+	}
+
+	const keepDescription = `Keep subscription — redeploy reuses it, no re-charge.${
+		periodEnd === "—" ? "" : ` Valid through ${periodEnd}.`
+	}`;
+	const cancelDescription = `Stops at period end${periodEnd === "—" ? "." : ` on ${periodEnd}.`}`;
+
+	return (
+		<AlertDialog
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (pending) return;
+				if (nextOpen) setChoice("keep_subscription");
+				setOpen(nextOpen);
+			}}
+		>
+			<AlertDialogTrigger render={children} />
+			<AlertDialogContent data-hosted="true">
+				<AlertDialogHeader>
+					<AlertDialogTitle>{`Delete ${name}?`}</AlertDialogTitle>
+					<AlertDialogDescription>
+						The hosted agent and its deployment are torn down. This can’t be undone.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+
+				{offerChoice ? (
+					<fieldset className="grid gap-2" disabled={pending}>
+						<legend className="sr-only">Subscription handling</legend>
+						<DeleteChoice
+							checked={choice === "keep_subscription"}
+							onChange={() => setChoice("keep_subscription")}
+							title="Delete agent"
+							description={keepDescription}
+						/>
+						<DeleteChoice
+							checked={choice === "cancel_subscription"}
+							onChange={() => setChoice("cancel_subscription")}
+							title="Delete agent and cancel subscription"
+							description={cancelDescription}
+						/>
+					</fieldset>
+				) : subscription?.cancel_at_period_end ? (
+					<p className="text-sm text-muted-foreground">
+						The subscription is already scheduled to stop at period end; deleting the agent does not
+						undo that cancellation.
+					</p>
+				) : null}
+
+				<AlertDialogFooter>
+					<AlertDialogCancel disabled={pending}>Go back</AlertDialogCancel>
+					<AlertDialogAction
+						onClick={(event) => {
+							event.preventDefault();
+							void runDelete();
+						}}
+						disabled={pending}
+						className={buttonVariants({ variant: "destructive" })}
+					>
+						{pending ? <Spinner /> : null}
+						{offerChoice && choice === "keep_subscription"
+							? "Delete agent (keep subscription)"
+							: offerChoice
+								? "Delete agent and cancel subscription"
+								: "Delete agent"}
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}
+
+function DeleteChoice({
+	checked,
+	description,
+	onChange,
+	title,
+}: {
+	checked: boolean;
+	description: string;
+	onChange: () => void;
+	title: string;
+}) {
+	return (
+		<label
+			className={cn(
+				"flex cursor-pointer gap-3 rounded-lg border p-3 text-left transition-colors",
+				checked ? "border-primary bg-primary/5" : "hover:bg-muted/50",
+			)}
+		>
+			<input
+				type="radio"
+				name="subscription-delete-choice"
+				checked={checked}
+				onChange={onChange}
+				className="mt-1 size-4 accent-primary"
+			/>
+			<span className="grid gap-0.5">
+				<span className="text-sm font-medium text-foreground">{title}</span>
+				<span className="text-xs text-muted-foreground">{description}</span>
+			</span>
+		</label>
+	);
+}

--- a/apps/web/src/hosted/agents/deployment-delete-action.tsx
+++ b/apps/web/src/hosted/agents/deployment-delete-action.tsx
@@ -40,7 +40,7 @@ export function HostedDeploymentDeleteAction({
 	const deleteDeployment = useDeleteDeployment();
 	const cancelSubscription = useCancelSubscription();
 	const [open, setOpen] = useState(false);
-	const [choice, setChoice] = useState<DeploymentDeleteChoice>("keep_subscription");
+	const [choice, setChoice] = useState<DeploymentDeleteChoice>("cancel_subscription");
 	const [pending, setPending] = useState(false);
 	const locked = useRef(false);
 	const subscription = deployment.commercial_display?.compute_subscription;
@@ -115,7 +115,7 @@ export function HostedDeploymentDeleteAction({
 			open={open}
 			onOpenChange={(nextOpen) => {
 				if (pending) return;
-				if (nextOpen) setChoice("keep_subscription");
+				if (nextOpen) setChoice("cancel_subscription");
 				setOpen(nextOpen);
 			}}
 		>

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -338,13 +338,7 @@ function DeleteComputeAction({
 			deployment={deployment}
 			onDeleted={() => onDeleteAccepted(deployment.resource.id)}
 		>
-			<Button
-				type="button"
-				variant={variant}
-				size="sm"
-				className={className}
-				disabled={!canDelete}
-			>
+			<Button type="button" variant={variant} size="sm" className={className} disabled={!canDelete}>
 				<Trash2 />
 				Delete
 			</Button>

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -53,9 +53,9 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { StatusDot, type StatusTone } from "@/components/ui/status-badge";
 import { deploymentDisplayName, isCloudEnvId } from "@/hosted/agent-identity";
+import { HostedDeploymentDeleteAction } from "@/hosted/agents/deployment-delete-action";
 import {
 	useCreateTerminalSession,
-	useDeleteDeployment,
 	useDeploymentLifecycle,
 	useUpdateDeployment,
 } from "@/hosted/agents/deployment-hooks";
@@ -331,37 +331,24 @@ function DeleteComputeAction({
 	variant?: React.ComponentProps<typeof Button>["variant"];
 	className?: string;
 }) {
-	const deleteDeployment = useDeleteDeployment();
-	const runAction = useActionLock();
 	const status = parseDeploymentStatus(deployment.resource.status.summary_state);
 	const canDelete = canDeleteDeployment(status);
 	return (
-		<ConfirmAction
-			title={`Delete ${deploymentDisplayName(
-				deployment.resource.spec.name,
-				deployment.resource.spec.runtime,
-			)}?`}
-			description={<p>The hosted agent is torn down. This can’t be undone.</p>}
-			confirmLabel="Delete compute"
-			destructive
-			onConfirm={() =>
-				runAction(async () => {
-					await deleteDeployment.mutateAsync(deployment.resource.id);
-					onDeleteAccepted(deployment.resource.id);
-				})
-			}
+		<HostedDeploymentDeleteAction
+			deployment={deployment}
+			onDeleted={() => onDeleteAccepted(deployment.resource.id)}
 		>
 			<Button
 				type="button"
 				variant={variant}
 				size="sm"
 				className={className}
-				disabled={deleteDeployment.isPending || !canDelete}
+				disabled={!canDelete}
 			>
-				{deleteDeployment.isPending ? <Spinner /> : <Trash2 />}
+				<Trash2 />
 				Delete
 			</Button>
-		</ConfirmAction>
+		</HostedDeploymentDeleteAction>
 	);
 }
 

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -154,6 +154,7 @@ import { ModelBindingPicker } from "@/hosted/v2/ai-providers/model-binding-picke
 import { useAiProviderBindingDraft } from "@/hosted/v2/ai-providers/use-ai-provider-binding-draft";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { isApiAuthError, normalizeApiError } from "@/lib/api-errors";
+import { formatShortDate } from "@/lib/format";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { cn } from "@/lib/utils";
 
@@ -172,6 +173,9 @@ type PaidDeploySelection = {
 	offer: BillingOffer;
 	plan: Plan;
 	tierLabel: "Basic" | "Performance";
+};
+type SubscriptionReuseNotice = {
+	validUntil: string | null;
 };
 const DEPLOY_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 lg:px-6");
 const THREE_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2 lg:grid-cols-3";
@@ -381,6 +385,8 @@ export function DeployWizard() {
 	const [timezone, setTimezone] = useState("");
 	const [addProviderOpen, setAddProviderOpen] = useState(false);
 	const [checkoutSession, setCheckoutSession] = useState<NativeDeployCheckout | null>(null);
+	const [subscriptionReuseNotice, setSubscriptionReuseNotice] =
+		useState<SubscriptionReuseNotice | null>(null);
 	const [term, setTerm] = useState(1);
 	const [submitting, setSubmitting] = useState(false);
 	const [paymentMethod, setPaymentMethod] = useState<DeployPaymentMethod>("card");
@@ -528,7 +534,10 @@ export function DeployWizard() {
 		}
 		return null;
 	})();
-	const canSubmit = !submitting && submitBlockingReason === null;
+	const canSubmit =
+		!submitting &&
+		subscriptionReuseNotice === null &&
+		submitBlockingReason === null;
 
 	function selectCreatedProvider(providerId: string) {
 		selectCreatedAiProvider(providerId, aiProviders.dataUpdatedAt);
@@ -613,6 +622,21 @@ export function DeployWizard() {
 		return available;
 	}
 
+	function showSubscriptionReuseNotice({
+		currentPeriodEnd,
+		entitledUntil,
+	}: {
+		currentPeriodEnd: string | null;
+		entitledUntil: string | null;
+	}) {
+		setCheckoutSession(null);
+		setSubscriptionReuseNotice({
+			validUntil: currentPeriodEnd ?? entitledUntil,
+		});
+		toast.success("Agent deployment started", {
+			description: "Your active subscription was reused without another charge.",
+		});
+	}
 	async function fallbackToHostedCheckout(request: SubscriptionCreateRequestView) {
 		if (!(await recheckCanCreateCloudAgents())) return;
 		const fingerprint = idempotencyFingerprint({
@@ -640,8 +664,11 @@ export function DeployWizard() {
 				}
 				throw error;
 			});
-		if (outcome.flowType !== "checkout") {
-			throw new Error("Hosted card fallback returned an activation flow.");
+		if (outcome.flowType === "subscription_activation") {
+			forgetIdempotencyAttempt("subscription-checkout-hosted-fallback", fingerprint);
+			checkoutAttemptRef.current = null;
+			showSubscriptionReuseNotice(outcome);
+			return;
 		}
 		if (redirectTo(checkoutRedirectUrl(outcome.checkout))) return;
 		throw new Error("No checkout URL was returned.");
@@ -705,6 +732,7 @@ export function DeployWizard() {
 
 	async function onDeploy() {
 		if (!canSubmit) return;
+		setSubscriptionReuseNotice(null);
 		setSubmitting(true);
 		try {
 			if (!(await recheckCanCreateCloudAgents())) return;
@@ -782,8 +810,11 @@ export function DeployWizard() {
 						}
 						throw error;
 					});
-				if (outcome.flowType !== "checkout") {
-					throw new Error("Card subscription returned an activation flow.");
+				if (outcome.flowType === "subscription_activation") {
+					forgetIdempotencyAttempt("subscription-checkout", checkoutFingerprint);
+					checkoutAttemptRef.current = null;
+					showSubscriptionReuseNotice(outcome);
+					return;
 				}
 				const result = outcome.checkout;
 				if (hasCheckoutClientSecret(result)) {
@@ -850,17 +881,19 @@ export function DeployWizard() {
 		}
 	}
 
-	const deployLabel = paidSelection
-		? paymentMethod === "wallet"
-			? subscriptionCreateQuote.isFetching
-				? "Getting wallet quote…"
-				: walletInsufficient
-					? "Top up to deploy"
-					: walletDebit
-						? `Pay ${formatUsdExact(walletDebit.debitAmountUsd)} from Wallet & deploy`
-						: "Review wallet quote"
-			: "Continue to checkout"
-		: "Deploy agent";
+	const deployLabel = subscriptionReuseNotice
+		? "Deployment started"
+		: paidSelection
+			? paymentMethod === "wallet"
+				? subscriptionCreateQuote.isFetching
+					? "Getting wallet quote…"
+					: walletInsufficient
+						? "Top up to deploy"
+						: walletDebit
+							? `Pay ${formatUsdExact(walletDebit.debitAmountUsd)} from Wallet & deploy`
+							: "Review wallet quote"
+				: "Continue to checkout"
+			: "Deploy agent";
 	const selectedProviderCount = aiAccessMode === "configured" ? selectedProviderChoices.length : 0;
 	const primaryProvider = providerList.find(
 		(provider) => provider.provider_id === primaryProviderChoice,
@@ -934,6 +967,23 @@ export function DeployWizard() {
 					title="Deploy an Agent"
 					description="Choose how your agent runs and which AI model it will use."
 				/>
+				{subscriptionReuseNotice ? (
+					<Alert
+						data-testid="subscription-reuse-banner"
+						aria-live="polite"
+						className="border-emerald-500/35 bg-emerald-500/5"
+					>
+						<Sparkles />
+						<AlertTitle>Active subscription reused</AlertTitle>
+						<AlertDescription>
+							{subscriptionReuseNotice.validUntil
+								? `Reusing your active subscription — valid until ${formatShortDate(
+										subscriptionReuseNotice.validUntil,
+									)}, no additional charge.`
+								: "Reusing your active subscription — no additional charge."}
+						</AlertDescription>
+					</Alert>
+				) : null}
 				<SettingsSection
 					title="Agent software"
 					description="Choose the software that will power your agent."

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -535,9 +535,7 @@ export function DeployWizard() {
 		return null;
 	})();
 	const canSubmit =
-		!submitting &&
-		subscriptionReuseNotice === null &&
-		submitBlockingReason === null;
+		!submitting && subscriptionReuseNotice === null && submitBlockingReason === null;
 
 	function selectCreatedProvider(providerId: string) {
 		selectCreatedAiProvider(providerId, aiProviders.dataUpdatedAt);

--- a/apps/web/src/hosted/billing/subscription/subscription-create-adapter.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-adapter.test.ts
@@ -112,18 +112,22 @@ describe("subscription creation adapter", () => {
 		});
 	});
 
-	test("projects only the wallet activation fields consumed by the UI", () => {
+	test("projects activation identity and entitlement fields consumed by the UI", () => {
 		const activation: CheckoutResult = {
 			flow_type: "subscription_activation",
 			funding_source: "wallet",
 			checkout_url: "",
 			deploy_request_id: "subscription-create-test",
 			deployment_id: "hdep_created",
+			current_period_end: "2027-07-15T00:00:00Z",
+			entitled_until: "2027-07-16T00:00:00Z",
 		};
 		expect(subscriptionCreateOutcome(activation)).toEqual({
 			flowType: "subscription_activation",
 			deploymentId: "hdep_created",
 			deployRequestId: "subscription-create-test",
+			currentPeriodEnd: "2027-07-15T00:00:00Z",
+			entitledUntil: "2027-07-16T00:00:00Z",
 		});
 		expect(() => subscriptionCreateOutcome({ ...activation, deployment_id: null })).toThrow(
 			"Wallet activation did not accept a deployment target.",

--- a/apps/web/src/hosted/billing/subscription/subscription-create-adapter.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-adapter.ts
@@ -57,6 +57,8 @@ export type SubscriptionCreateOutcomeView =
 			flowType: "subscription_activation";
 			deploymentId: string;
 			deployRequestId: string | null;
+			currentPeriodEnd: string | null;
+			entitledUntil: string | null;
 	  };
 
 export function subscriptionCreateQuoteRequest(
@@ -138,5 +140,7 @@ export function subscriptionCreateOutcome(result: CheckoutResult): SubscriptionC
 			"Wallet activation did not accept a deployment target.",
 		).deploymentId,
 		deployRequestId: result.deploy_request_id ?? null,
+		currentPeriodEnd: result.current_period_end ?? null,
+		entitledUntil: result.entitled_until ?? null,
 	};
 }

--- a/apps/web/src/hosted/hosted-deployment-tile-action.tsx
+++ b/apps/web/src/hosted/hosted-deployment-tile-action.tsx
@@ -2,16 +2,15 @@
 
 import { Play, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Spinner } from "@/components/ui/spinner";
 import { deploymentDisplayName } from "@/hosted/agent-identity";
-import { useDeleteDeployment, useDeploymentLifecycle } from "@/hosted/agents/deployment-hooks";
+import { HostedDeploymentDeleteAction } from "@/hosted/agents/deployment-delete-action";
+import { useDeploymentLifecycle } from "@/hosted/agents/deployment-hooks";
 import type { HostedDeployment } from "@/hosted/billing/contracts";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { canDelete, canStart, parseDeploymentStatus } from "@/hosted/deployment-status";
 
 export function HostedDeploymentTileAction({ deployment }: { deployment: HostedDeployment }) {
-	const deleteDeployment = useDeleteDeployment();
 	const lifecycle = useDeploymentLifecycle();
 	const runAction = useActionLock();
 	const name = deploymentDisplayName(
@@ -41,29 +40,19 @@ export function HostedDeploymentTileAction({ deployment }: { deployment: HostedD
 					Start
 				</Button>
 			) : null}
-			<ConfirmAction
-				title={`Delete ${name}?`}
-				description={<p>The hosted deployment is torn down. This can’t be undone.</p>}
-				confirmLabel="Delete deployment"
-				destructive
-				onConfirm={() =>
-					runAction(async () => {
-						await deleteDeployment.mutateAsync(deployment.resource.id);
-					})
-				}
-			>
+			<HostedDeploymentDeleteAction deployment={deployment}>
 				<Button
 					type="button"
 					variant="ghost"
 					size="icon-xs"
 					className="text-muted-foreground hover:text-destructive"
-					disabled={deleteDeployment.isPending || !deleteEnabled}
+					disabled={!deleteEnabled}
 					aria-label={`Delete ${name}`}
 					title={`Delete ${name}`}
 				>
-					{deleteDeployment.isPending ? <Spinner /> : <Trash2 />}
+					<Trash2 />
 				</Button>
-			</ConfirmAction>
+			</HostedDeploymentDeleteAction>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- handle hosted v2 subscription_activation deploy responses as subscription reuse, show the locale-aware validity banner, suppress Stripe checkout UI, and lock repeat submission
- add one hosted deployment delete confirmation with default keep-subscription behavior and an explicit cancel-at-period-end alternative
- persist POST /v2/subscription/cancel by deployment_id before deployment DELETE, stop teardown when cancel fails, and surface partial success when cancellation succeeds but teardown fails
- keep runtime child-agent deletion unchanged

## Contract
- follows Clawdi-AI/clawdi-hosted#993 and the generated hosted v2 current_period_end / entitled_until response contract
- no live or production operations were performed

## Verification
- bun run --cwd apps/web typecheck
- bun run --cwd apps/web test (481 passed)
- bunx biome check apps/web/src apps/web/e2e/hosted-smoke.pw.ts
- bun run --cwd apps/web build:oss
- bun run --cwd apps/web e2e:hosted (41 passed before the final additional teardown-failure case)
- focused hosted Playwright coverage for activation/no-checkout, default keep, cancel-before-delete, cancel failure, and preserved cancellation after delete failure