### PR TITLE
feat(web): seamless deploy→ready→live-UI auto-open (no manual re-check)

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1789,12 +1789,15 @@ test("running deployment without a UI endpoint auto-opens the live UI when polli
 		.poll(() => deploymentListRequests.length, { timeout: 10_000 })
 		.toBeGreaterThanOrEqual(2);
 	await expect(page).toHaveURL(
-		new RegExp(`/agents/${missingProjectionEnvironmentId}/console\\?source=on-clawdi$`),
+		(url) =>
+			url.pathname === `/agents/${missingProjectionEnvironmentId}/console` &&
+			url.searchParams.get("source") === "on-clawdi" &&
+			url.searchParams.get("d") === pendingRuntimeUiDeployment.id,
 	);
-	await expect.poll(() => runtimeUiRedemptionRequests.length).toBe(1);
+	expect(runtimeUiRedemptionRequests).toEqual([]);
 	await expect(main.locator('iframe[title="Hermes Dashboard"]')).toHaveAttribute(
 		"src",
-		"https://runtime.example/ui?clawdi_code=browser",
+		"https://runtime.example/hermes",
 	);
 });
 

--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -747,6 +747,7 @@ type HostedApiStubOptions = {
 	deleteRequests?: string[];
 	completedDeleteIds?: Set<string>;
 	deleteResponses?: StubResponse[];
+	deploymentListRequests?: string[];
 	deployments?: readonly unknown[];
 	deploymentsResponse?: StubResponse;
 	fixPaymentRequests?: string[];
@@ -844,6 +845,7 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 				: fulfillJson(r, response);
 		}
 		if (p === "/v2/deployments" && r.request().method() === "GET") {
+			options.deploymentListRequests?.push(p);
 			if (options.deploymentsResponse) {
 				if (options.deploymentsResponse.delayMs) {
 					await new Promise((resolve) => setTimeout(resolve, options.deploymentsResponse?.delayMs));
@@ -1749,6 +1751,51 @@ test("projection service errors stay visible while deployment tools remain avail
 		(error) => error.includes("Maximum update depth") || error.includes("Too many re-renders"),
 	);
 	expect(renderErrors, `projection failure render: ${errors.join(" | ")}`).toEqual([]);
+});
+
+test("running deployment without a UI endpoint auto-opens the live UI when polling resolves", async ({
+	page,
+}) => {
+	const pendingRuntimeUiDeployment = {
+		...runningMissingProjectionDeployment,
+		id: "hdep_runtime_ui_settling",
+		name: "Runtime UI settling agent",
+		hermes_control_ui_url: null,
+	};
+	const readyRuntimeUiDeployment = {
+		...pendingRuntimeUiDeployment,
+		hermes_control_ui_url: "https://runtime.example/hermes",
+	};
+	const deployments: unknown[] = [pendingRuntimeUiDeployment];
+	const deploymentListRequests: string[] = [];
+	const runtimeUiRedemptionRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments,
+		deploymentListRequests,
+		runtimeUiRedemptionRequests,
+	});
+
+	await page.goto(`/agents/${pendingRuntimeUiDeployment.id}?source=on-clawdi`);
+	const main = page.locator("main");
+	await expect(main.getByText("Starting the live UI…", { exact: true })).toBeVisible();
+	await expect(
+		main.getByText("Opening the live UI automatically…", { exact: false }),
+	).toBeVisible();
+	await expect(main.getByRole("button", { name: "Use Terminal now", exact: true })).toBeVisible();
+
+	deployments.splice(0, 1, readyRuntimeUiDeployment);
+
+	await expect
+		.poll(() => deploymentListRequests.length, { timeout: 10_000 })
+		.toBeGreaterThanOrEqual(2);
+	await expect(page).toHaveURL(
+		new RegExp(`/agents/${missingProjectionEnvironmentId}/console\\?source=on-clawdi$`),
+	);
+	await expect.poll(() => runtimeUiRedemptionRequests.length).toBe(1);
+	await expect(main.locator('iframe[title="Hermes Dashboard"]')).toHaveAttribute(
+		"src",
+		"https://runtime.example/ui?clawdi_code=browser",
+	);
 });
 
 test("Runtime UI credential failure renders a retryable error instead of a permanent spinner", async ({

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -72,6 +72,7 @@ export function AgentHome({
 		membershipResolved,
 		isLoading,
 		isFetching,
+		runtimeUiSettlingTimedOut,
 		error,
 		refetch,
 	} = useAgentDeployment(environmentId, deploymentSelector);
@@ -220,6 +221,8 @@ export function AgentHome({
 				onDeleteAccepted={(deploymentId) =>
 					setUserDeleteIntent({ deploymentId, environmentId, deploymentSelector })
 				}
+				autoOpenRuntimeUi={requestedFromCloudRedirect && environmentId === deployment.resource.id}
+				runtimeUiSettlingTimedOut={runtimeUiSettlingTimedOut}
 			/>
 		);
 	}

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -14,9 +14,14 @@ type InvalidateDeploymentSnapshots =
 	typeof import("@/hosted/agents/deployment-hooks").invalidateDeploymentSnapshots;
 type ProjectAcceptedDeploymentTransition =
 	typeof import("@/hosted/agents/deployment-hooks").projectAcceptedDeploymentTransition;
+type RuntimeUiSettlingPollState =
+	typeof import("@/hosted/agents/deployment-hooks").runtimeUiSettlingPollState;
 
 let invalidateSnapshots: InvalidateDeploymentSnapshots | null = null;
 let projectAcceptedTransition: ProjectAcceptedDeploymentTransition | null = null;
+let settlingPollState: RuntimeUiSettlingPollState | null = null;
+let settlingPollIntervalMs: number | null = null;
+let settlingTimeoutMs: number | null = null;
 
 beforeAll(async () => {
 	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
@@ -25,6 +30,94 @@ beforeAll(async () => {
 	const module = await import("@/hosted/agents/deployment-hooks");
 	invalidateSnapshots = module.invalidateDeploymentSnapshots;
 	projectAcceptedTransition = module.projectAcceptedDeploymentTransition;
+	settlingPollState = module.runtimeUiSettlingPollState;
+	settlingPollIntervalMs = module.RUNTIME_UI_SETTLING_POLL_INTERVAL_MS;
+	settlingTimeoutMs = module.RUNTIME_UI_SETTLING_TIMEOUT_MS;
+});
+
+describe("runtime UI settling polling", () => {
+	test("rapidly polls a running deployment until its selected runtime UI appears", () => {
+		if (!settlingPollState || !settlingPollIntervalMs) {
+			throw new Error("deployment hooks were not loaded");
+		}
+		const nowMs = Date.parse("2026-07-23T12:00:00Z");
+		const deployment = hostedDeploymentFixture({ status: "running", runtime: "hermes" });
+		const pending = settlingPollState(deployment, "hermes", null, nowMs);
+
+		expect(pending.refetchInterval).toBe(settlingPollIntervalMs);
+		expect(pending.timedOut).toBe(false);
+		expect(pending.tracker?.startedAtMs).toBe(nowMs);
+
+		const ready = settlingPollState(
+			hostedDeploymentFixture({
+				status: "running",
+				runtime: "hermes",
+				runtimeUiEndpoint: {
+					runtime: "hermes",
+					role: "control_ui",
+					url: "https://runtime.example/hermes",
+					auth_mode: "password",
+					browser_mode: "top_level",
+				},
+			}),
+			"hermes",
+			pending.tracker,
+			nowMs + settlingPollIntervalMs,
+		);
+		expect(ready).toEqual({ refetchInterval: false, timedOut: false, tracker: null });
+	});
+
+	test("bounds rapid polling to the runtime UI boot window", () => {
+		if (!settlingPollState || !settlingTimeoutMs) {
+			throw new Error("deployment hooks were not loaded");
+		}
+		const nowMs = Date.parse("2026-07-23T12:00:00Z");
+		const deployment = hostedDeploymentFixture({ status: "running" });
+		const pending = settlingPollState(deployment, "openclaw", null, nowMs);
+		const timedOut = settlingPollState(
+			deployment,
+			"openclaw",
+			pending.tracker,
+			nowMs + settlingTimeoutMs,
+		);
+
+		expect(timedOut.refetchInterval).toBe(false);
+		expect(timedOut.timedOut).toBe(true);
+		expect(timedOut.tracker).toEqual(pending.tracker);
+	});
+
+	test("uses an A4 Ready transition to recognize an already-stuck boot", () => {
+		if (!settlingPollState || !settlingTimeoutMs) {
+			throw new Error("deployment hooks were not loaded");
+		}
+		const nowMs = Date.parse("2026-07-23T12:00:00Z");
+		const deployment = hostedDeploymentFixture({ status: "running" });
+		deployment.resource.status.conditions = [
+			{
+				type: "Ready",
+				status: "True",
+				observedGeneration: 1,
+				lastTransitionTime: new Date(nowMs - settlingTimeoutMs).toISOString(),
+				reason: "RuntimeReady",
+				message: "Runtime reported ready",
+			},
+		];
+
+		const state = settlingPollState(deployment, "openclaw", null, nowMs);
+		expect(state.refetchInterval).toBe(false);
+		expect(state.timedOut).toBe(true);
+	});
+
+	test("does not override polling for non-running lifecycle states", () => {
+		if (!settlingPollState) throw new Error("deployment hooks were not loaded");
+		const state = settlingPollState(
+			hostedDeploymentFixture({ status: "starting" }),
+			"openclaw",
+			null,
+			Date.now(),
+		);
+		expect(state).toEqual({ refetchInterval: false, timedOut: false, tracker: null });
+	});
 });
 
 function acceptedOperation(verb: DeploymentOperation["metadata"]["verb"]): DeploymentOperation {

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -36,6 +36,32 @@ beforeAll(async () => {
 });
 
 describe("runtime UI settling polling", () => {
+	test("derives the same pending tracker across repeated render-phase calculations", () => {
+		if (!settlingPollState) throw new Error("deployment hooks were not loaded");
+		const nowMs = Date.parse("2026-07-23T12:00:00Z");
+		const deployment = hostedDeploymentFixture({ status: "running", runtime: "hermes" });
+		const committedTracker = null;
+
+		const firstRender = settlingPollState(deployment, "hermes", committedTracker, nowMs);
+		const repeatedRender = settlingPollState(deployment, "hermes", committedTracker, nowMs);
+
+		expect(repeatedRender).toEqual(firstRender);
+		expect(committedTracker).toBeNull();
+	});
+
+	test("commits the derived tracker only from an effect", () => {
+		const source = readFileSync(new URL("./deployment-hooks.ts", import.meta.url), "utf8");
+		const hookStart = source.indexOf("export function useAgentDeployment");
+		const hookEnd = source.indexOf("export type {", hookStart);
+		const hookSource = source.slice(hookStart, hookEnd);
+		const assignments = hookSource.match(/runtimeUiSettlingTrackerRef\.current\s*=/g) ?? [];
+
+		expect(assignments).toHaveLength(1);
+		expect(hookSource).toContain(
+			"useEffect(() => {\n\t\truntimeUiSettlingTrackerRef.current = runtimeUiSettling.tracker;",
+		);
+	});
+
 	test("rapidly polls a running deployment until its selected runtime UI appears", () => {
 		if (!settlingPollState || !settlingPollIntervalMs) {
 			throw new Error("deployment hooks were not loaded");

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { type QueryClient, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { toast } from "sonner";
 import { type AcceptedOperation, useBillingClient } from "@/hosted/billing/billing-client";
 import type {
@@ -23,7 +23,14 @@ import {
 	newIdempotencyKey,
 } from "@/hosted/billing/idempotency";
 import { resolveAgentDeployment } from "@/hosted/hosted-agent-resolution";
-import { deploymentRuntime, runtimeEnvironmentId } from "@/hosted/runtimes";
+import {
+	defaultDeploymentRuntime,
+	deploymentRuntime,
+	type HostedRuntime,
+	isHostedRuntime,
+	runtimeConsoleUrl,
+	runtimeEnvironmentId,
+} from "@/hosted/runtimes";
 import { useHostedDeploymentInventory } from "@/hosted/use-hosted-deployment-inventory";
 
 const SETTLING_REFRESH_DELAYS_MS = [2_000, 10_000, 20_000, 30_000] as const;
@@ -40,6 +47,68 @@ const ACCEPTED_OPERATION_TRANSITIONS = {
 	AcceptedOperation["operation"]["metadata"]["verb"],
 	HostedDeploymentStatus["summary_state"]
 >;
+
+export const RUNTIME_UI_SETTLING_POLL_INTERVAL_MS = 3_000;
+export const RUNTIME_UI_SETTLING_TIMEOUT_MS = 5 * 60_000;
+
+export type RuntimeUiSettlingTracker = {
+	key: string;
+	startedAtMs: number;
+};
+
+export type RuntimeUiSettlingPollState = {
+	refetchInterval: number | false;
+	timedOut: boolean;
+	tracker: RuntimeUiSettlingTracker | null;
+};
+
+/**
+ * A4 may report compute as running just before its runtime UI endpoint is
+ * published. Keep that short-lived gap on the fast deployment-query cadence,
+ * but stop rapid polling after the boot window. The normal inventory
+ * reconciliation cadence remains active after this override returns false.
+ */
+export function runtimeUiSettlingPollState(
+	deployment: HostedDeployment | null | undefined,
+	runtime: HostedRuntime | null | undefined,
+	tracker: RuntimeUiSettlingTracker | null,
+	nowMs: number,
+): RuntimeUiSettlingPollState {
+	if (
+		!deployment ||
+		!runtime ||
+		deployment.resource.status.summary_state !== "running" ||
+		runtimeConsoleUrl(deployment, runtime)
+	) {
+		return { refetchInterval: false, timedOut: false, tracker: null };
+	}
+
+	const key = `${deployment.resource.id}:${deployment.resource.metadata.generation}:${runtime}`;
+	const nextTracker =
+		tracker?.key === key
+			? tracker
+			: {
+					key,
+					startedAtMs: runtimeUiSettlingStartedAtMs(deployment, nowMs),
+				};
+	const timedOut = nowMs - nextTracker.startedAtMs >= RUNTIME_UI_SETTLING_TIMEOUT_MS;
+	return {
+		refetchInterval: timedOut ? false : RUNTIME_UI_SETTLING_POLL_INTERVAL_MS,
+		timedOut,
+		tracker: nextTracker,
+	};
+}
+
+function runtimeUiSettlingStartedAtMs(deployment: HostedDeployment, nowMs: number): number {
+	const transitionTimes = deployment.resource.status.conditions.flatMap((condition) => {
+		if (condition.type !== "Ready" || condition.status !== "True") {
+			return [];
+		}
+		const parsed = Date.parse(condition.lastTransitionTime);
+		return Number.isFinite(parsed) && parsed <= nowMs ? [parsed] : [];
+	});
+	return transitionTimes.length > 0 ? Math.max(...transitionTimes) : nowMs;
+}
 
 export function invalidateDeploymentSnapshots(qc: QueryClient) {
 	void qc.invalidateQueries({ queryKey: billingKeys.deployments });
@@ -109,14 +178,47 @@ function toastDeploymentConflict(error: unknown): boolean {
  * selector disambiguates duplicate inventory rows.
  */
 export function useAgentDeployment(environmentId: string, deploymentSelector?: string | null) {
+	const runtimeUiSettlingTrackerRef = useRef<RuntimeUiSettlingTracker | null>(null);
+	const updateRuntimeUiSettlingState = useCallback(
+		(deployments: readonly HostedDeployment[] | null | undefined, nowMs: number) => {
+			const resolution = resolveAgentDeployment(
+				deployments ?? [],
+				environmentId,
+				deploymentSelector,
+			);
+			const match = resolution.match;
+			const runtime =
+				match?.runtime && isHostedRuntime(match.runtime)
+					? match.runtime
+					: match
+						? defaultDeploymentRuntime(match.deployment)
+						: null;
+			const state = runtimeUiSettlingPollState(
+				match?.deployment,
+				runtime,
+				runtimeUiSettlingTrackerRef.current,
+				nowMs,
+			);
+			runtimeUiSettlingTrackerRef.current = state.tracker;
+			return state;
+		},
+		[deploymentSelector, environmentId],
+	);
+	const additionalRefetchInterval = useCallback(
+		(deployments: readonly HostedDeployment[] | undefined) =>
+			updateRuntimeUiSettlingState(deployments, Date.now()).refetchInterval,
+		[updateRuntimeUiSettlingState],
+	);
 	const inventory = useHostedDeploymentInventory({
 		pollBillingRecoveryFor: deploymentSelector ?? environmentId,
+		additionalRefetchInterval,
 	});
 	const resolution = useMemo(
 		() => resolveAgentDeployment(inventory.deployments ?? [], environmentId, deploymentSelector),
 		[inventory.deployments, environmentId, deploymentSelector],
 	);
 	const match = resolution.match;
+	const runtimeUiSettling = updateRuntimeUiSettlingState(inventory.deployments, Date.now());
 
 	// The env id to drive per-env queries (sessions, channel links). For an
 	// env-id route it's the route param itself; for a deployment-id route
@@ -138,6 +240,7 @@ export function useAgentDeployment(environmentId: string, deploymentSelector?: s
 		membershipResolved: inventory.status === "resolved",
 		isLoading: inventory.status === "loading" && !inventory.hasSnapshot,
 		isFetching: inventory.isFetching,
+		runtimeUiSettlingTimedOut: runtimeUiSettling.timedOut,
 		error: inventory.error,
 		refetch: inventory.refetch,
 	};

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { type QueryClient, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { toast } from "sonner";
 import { type AcceptedOperation, useBillingClient } from "@/hosted/billing/billing-client";
 import type {
@@ -179,7 +179,7 @@ function toastDeploymentConflict(error: unknown): boolean {
  */
 export function useAgentDeployment(environmentId: string, deploymentSelector?: string | null) {
 	const runtimeUiSettlingTrackerRef = useRef<RuntimeUiSettlingTracker | null>(null);
-	const updateRuntimeUiSettlingState = useCallback(
+	const deriveRuntimeUiSettlingState = useCallback(
 		(deployments: readonly HostedDeployment[] | null | undefined, nowMs: number) => {
 			const resolution = resolveAgentDeployment(
 				deployments ?? [],
@@ -193,21 +193,19 @@ export function useAgentDeployment(environmentId: string, deploymentSelector?: s
 					: match
 						? defaultDeploymentRuntime(match.deployment)
 						: null;
-			const state = runtimeUiSettlingPollState(
+			return runtimeUiSettlingPollState(
 				match?.deployment,
 				runtime,
 				runtimeUiSettlingTrackerRef.current,
 				nowMs,
 			);
-			runtimeUiSettlingTrackerRef.current = state.tracker;
-			return state;
 		},
 		[deploymentSelector, environmentId],
 	);
 	const additionalRefetchInterval = useCallback(
 		(deployments: readonly HostedDeployment[] | undefined) =>
-			updateRuntimeUiSettlingState(deployments, Date.now()).refetchInterval,
-		[updateRuntimeUiSettlingState],
+			deriveRuntimeUiSettlingState(deployments, Date.now()).refetchInterval,
+		[deriveRuntimeUiSettlingState],
 	);
 	const inventory = useHostedDeploymentInventory({
 		pollBillingRecoveryFor: deploymentSelector ?? environmentId,
@@ -218,7 +216,11 @@ export function useAgentDeployment(environmentId: string, deploymentSelector?: s
 		[inventory.deployments, environmentId, deploymentSelector],
 	);
 	const match = resolution.match;
-	const runtimeUiSettling = updateRuntimeUiSettlingState(inventory.deployments, Date.now());
+	const runtimeUiSettling = deriveRuntimeUiSettlingState(inventory.deployments, Date.now());
+
+	useEffect(() => {
+		runtimeUiSettlingTrackerRef.current = runtimeUiSettling.tracker;
+	}, [runtimeUiSettling.tracker]);
 
 	// The env id to drive per-env queries (sessions, channel links). For an
 	// env-id route it's the route param itself; for a deployment-id route

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -400,12 +400,16 @@ export function HostedAgentDetail({
 	runtime,
 	section = "overview",
 	onDeleteAccepted,
+	autoOpenRuntimeUi = false,
+	runtimeUiSettlingTimedOut = false,
 }: {
 	environmentId: string;
 	deployment: HostedDeployment;
 	runtime: Runtime;
 	section?: AgentSectionId;
 	onDeleteAccepted: (deploymentId: string) => void;
+	autoOpenRuntimeUi?: boolean;
+	runtimeUiSettlingTimedOut?: boolean;
 }) {
 	const api = useApi();
 	const router = useRouter();
@@ -452,6 +456,29 @@ export function HostedAgentDetail({
 	const isPerformance = deployment.current_plan_slug === COMPUTE_PERFORMANCE_SLUG;
 	const consoleUrl = runtimeConsoleUrl(deployment, runtime);
 	const searchStr = useLocation({ select: (location) => location.searchStr });
+	const terminalHref = agentSectionHref(environmentId, "terminal", searchStr);
+
+	useEffect(() => {
+		if (
+			!autoOpenRuntimeUi ||
+			activeTab !== "overview" ||
+			!canOpenHostedRuntimeUi(deployment.resource.status.summary_state, consoleUrl)
+		) {
+			return;
+		}
+		void router.navigate({
+			href: agentSectionHref(environmentId, "console", searchStr),
+			replace: true,
+		});
+	}, [
+		activeTab,
+		autoOpenRuntimeUi,
+		consoleUrl,
+		deployment.resource.status.summary_state,
+		environmentId,
+		router,
+		searchStr,
+	]);
 	const scopedSessionLink = (sessionId: string) => ({
 		to: "/agents/$id/sessions/$sessionId" as const,
 		params: { id: environmentId, sessionId },
@@ -535,6 +562,7 @@ export function HostedAgentDetail({
 					{activeTab === "overview" ? (
 						<OverviewTab
 							deployment={deployment}
+							runtime={runtime}
 							agent={isCloudEnvId(environmentId) ? agent : null}
 							isPerformance={isPerformance}
 							showDeploymentActions={projection.status !== "resolved" || !deploymentRunning}
@@ -545,10 +573,17 @@ export function HostedAgentDetail({
 							sessionsError={sessions.error}
 							onRetrySessions={() => sessions.refetch()}
 							sessionLink={(session) => scopedSessionLink(session.id)}
+							terminalHref={terminalHref}
+							runtimeUiSettlingTimedOut={runtimeUiSettlingTimedOut}
 						/>
 					) : null}
 					{activeTab === "console" ? (
-						<ConsoleTab deployment={deployment} runtime={runtime} />
+						<ConsoleTab
+							deployment={deployment}
+							runtime={runtime}
+							terminalHref={terminalHref}
+							runtimeUiSettlingTimedOut={runtimeUiSettlingTimedOut}
+						/>
 					) : null}
 					{activeTab === "terminal" ? <TerminalTab deployment={deployment} /> : null}
 					{activeTab === "sessions" ? (
@@ -797,20 +832,126 @@ function RuntimeStatusValue({
 	);
 }
 
-function OverviewProvisioningPanel({ status }: { status: DeploymentStatus }) {
+type DeploymentReadinessStage = "provisioning" | "booting" | "ready";
+
+function deploymentReadinessStage(
+	status: HostedDeployment["resource"]["status"],
+	runtimeUiAvailable: boolean,
+): DeploymentReadinessStage {
+	if (runtimeUiAvailable) return "ready";
+	const computeReady = status.conditions.some(
+		(condition) => condition.type === "Ready" && condition.status === "True",
+	);
+	if (status.summary_state === "starting" || status.summary_state === "running" || computeReady) {
+		return "booting";
+	}
+	return "provisioning";
+}
+
+function DeploymentReadinessProgress({ stage }: { stage: DeploymentReadinessStage }) {
+	const steps = ["Provisioning", "Booting", "Ready"] as const;
+	const stageIndex = { provisioning: 0, booting: 1, ready: 2 }[stage];
 	return (
-		<div className="rounded-xl border border-info-muted bg-info-muted p-5 text-info-muted-foreground">
+		<ol aria-label="Deployment progress" className="mt-3 flex items-center gap-2 text-xs">
+			{steps.map((step, index) => {
+				const complete = index < stageIndex || stage === "ready";
+				const current = index === stageIndex && stage !== "ready";
+				return (
+					<li
+						key={step}
+						className={cn(
+							"flex items-center gap-1.5",
+							complete || current ? "font-medium text-foreground" : "text-muted-foreground",
+						)}
+						aria-current={current ? "step" : undefined}
+					>
+						<span
+							aria-hidden
+							className={cn(
+								"size-1.5 rounded-full",
+								complete ? "bg-success" : current ? "bg-info" : "bg-border",
+							)}
+						/>
+						{step}
+						{index < steps.length - 1 ? (
+							<span aria-hidden className="ml-0.5 text-border">
+								→
+							</span>
+						) : null}
+					</li>
+				);
+			})}
+		</ol>
+	);
+}
+
+function OverviewProvisioningPanel({
+	deployment,
+	runtime,
+	runtimeUiAvailable,
+	runtimeUiSettlingTimedOut,
+	terminalHref,
+}: {
+	deployment: HostedDeployment;
+	runtime: Runtime;
+	runtimeUiAvailable: boolean;
+	runtimeUiSettlingTimedOut: boolean;
+	terminalHref: string;
+}) {
+	const status = deployment.resource.status;
+	const stage = deploymentReadinessStage(status, runtimeUiAvailable);
+	const parsedStatus = parseDeploymentStatus(status.summary_state);
+	const browserUiLabel = runtimeBrowserUiLabel(runtime);
+	const title = runtimeUiSettlingTimedOut
+		? "Live UI is taking longer than expected"
+		: stage === "provisioning"
+			? "Provisioning your agent…"
+			: stage === "booting"
+				? status.summary_state === "running"
+					? "Starting the live UI…"
+					: "Booting your agent…"
+				: "Your agent is ready";
+	const description = runtimeUiSettlingTimedOut
+		? `${browserUiLabel} did not publish within the startup window. Automatic periodic checks will continue, and Terminal is available now.`
+		: stage === "provisioning"
+			? "Hosted compute is being prepared. This page updates automatically."
+			: stage === "booting"
+				? "Opening the live UI automatically… Terminal is available while the runtime finishes booting."
+				: "The live UI is ready to use.";
+	return (
+		<div
+			className={cn(
+				"rounded-xl border p-5",
+				runtimeUiSettlingTimedOut
+					? "border-warning/30 bg-warning-muted text-warning-muted-foreground"
+					: "border-info-muted bg-info-muted text-info-muted-foreground",
+			)}
+		>
 			<div className="flex flex-col gap-3 sm:flex-row sm:items-start">
 				<div className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-info-muted bg-background">
-					<Spinner className="size-5" />
+					{runtimeUiSettlingTimedOut ? (
+						<AlertCircle className="size-5" />
+					) : (
+						<Spinner className="size-5" />
+					)}
 				</div>
-				<div className="min-w-0">
-					<h2 className="text-sm font-semibold text-foreground">{provisioningTitle(status)}</h2>
-					<p className="mt-1 text-sm">
-						Hosted compute is being prepared. This usually takes a couple of minutes, and this page
-						updates automatically.
-					</p>
-					<p className="mt-2 text-xs">Current status: {deploymentStatusLabel(status)}.</p>
+				<div className="min-w-0 flex-1">
+					<h2 className="text-sm font-semibold text-foreground">{title}</h2>
+					<p className="mt-1 text-sm">{description}</p>
+					<DeploymentReadinessProgress stage={stage} />
+					<p className="mt-2 text-xs">Current status: {deploymentStatusLabel(parsedStatus)}.</p>
+					{stage === "booting" ? (
+						<Button
+							render={<Link to={terminalHref} />}
+							nativeButton={false}
+							variant="outline"
+							size="sm"
+							className="mt-3"
+						>
+							<TerminalSquare className="size-3.5" />
+							Use Terminal now
+						</Button>
+					) : null}
 				</div>
 			</div>
 		</div>
@@ -873,6 +1014,7 @@ function OverviewFailedPanel({
 
 function OverviewTab({
 	deployment,
+	runtime,
 	agent,
 	isPerformance,
 	showDeploymentActions,
@@ -883,8 +1025,11 @@ function OverviewTab({
 	sessionsError,
 	onRetrySessions,
 	sessionLink,
+	terminalHref,
+	runtimeUiSettlingTimedOut,
 }: {
 	deployment: HostedDeployment;
+	runtime: Runtime;
 	agent: components["schemas"]["AgentResponse"] | null | undefined;
 	isPerformance: boolean;
 	showDeploymentActions: boolean;
@@ -898,6 +1043,8 @@ function OverviewTab({
 		to: "/agents/$id/sessions/$sessionId";
 		params: { id: string; sessionId: string };
 	};
+	terminalHref: string;
+	runtimeUiSettlingTimedOut: boolean;
 }) {
 	const spec = deployment.resource.spec;
 	const providers = useUserAiProviders();
@@ -918,13 +1065,21 @@ function OverviewTab({
 	);
 	const deploymentStatus = parseDeploymentStatus(deployment.resource.status.summary_state);
 	const deploymentRunning = isRunningStatus(deploymentStatus);
+	const runtimeUiAvailable = Boolean(runtimeConsoleUrl(deployment, runtime));
 	const sessionsEmptyMessage = deploymentRunning
 		? "No sessions from this agent yet."
 		: "Sessions appear once your agent is running.";
 	return (
 		<div className="flex flex-col gap-5">
-			{isProvisioningStatus(deploymentStatus) ? (
-				<OverviewProvisioningPanel status={deploymentStatus} />
+			{isProvisioningStatus(deploymentStatus) ||
+			(deploymentStatus.kind === "running" && !runtimeUiAvailable) ? (
+				<OverviewProvisioningPanel
+					deployment={deployment}
+					runtime={runtime}
+					runtimeUiAvailable={runtimeUiAvailable}
+					runtimeUiSettlingTimedOut={runtimeUiSettlingTimedOut}
+					terminalHref={terminalHref}
+				/>
 			) : null}
 			{deploymentStatus.kind === "failed" ? (
 				<OverviewFailedPanel deployment={deployment} restartLabel="Retry startup" />
@@ -1074,7 +1229,23 @@ type ResolvedRuntimeUiCredentials =
 	| { runtime: "hermes"; value: HermesUiCredentials }
 	| { runtime: "openclaw"; value: OpenClawUiCredentials };
 
-function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; runtime: Runtime }) {
+/**
+ * Live agent browser UI embedded inline. The deployment's selected runtime UI
+ * URL points at owner-only exposure. When the runtime
+ * allows dashboard framing, the bridge cookie + WS work in-frame; otherwise
+ * the full-screen link is the alternate path.
+ */
+function ConsoleTab({
+	deployment,
+	runtime,
+	terminalHref,
+	runtimeUiSettlingTimedOut,
+}: {
+	deployment: HostedDeployment;
+	runtime: Runtime;
+	terminalHref: string;
+	runtimeUiSettlingTimedOut: boolean;
+}) {
 	const status = parseDeploymentStatus(deployment.resource.status.summary_state);
 	const isRunning = isRunningStatus(status);
 	const isProvisioning = isProvisioningStatus(status);
@@ -1186,9 +1357,28 @@ function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; run
 	if (!url) {
 		return (
 			<EmptyState
-				icon={MonitorPlay}
-				title="No Runtime UI URL yet"
-				description={`This ${label} runtime is running but hasn't published its browser UI endpoint yet. Check the Overview status shortly or use Terminal while it finishes.`}
+				icon={runtimeUiSettlingTimedOut ? AlertCircle : <Spinner className="size-5" />}
+				title={
+					runtimeUiSettlingTimedOut
+						? "Live UI is taking longer than expected"
+						: "Starting the live UI…"
+				}
+				description={
+					runtimeUiSettlingTimedOut
+						? `${label} did not publish its browser UI within the startup window. Automatic periodic checks will continue.`
+						: `Opening the live UI automatically… You can use Terminal right now while ${label} finishes booting.`
+				}
+				action={
+					<Button
+						render={<Link to={terminalHref} />}
+						nativeButton={false}
+						variant="outline"
+						size="sm"
+					>
+						<TerminalSquare className="size-3.5" />
+						Use Terminal now
+					</Button>
+				}
 			/>
 		);
 	}

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -393,9 +393,13 @@ export function billingRecoveryRefetchIntervalFor(
 export function useHostedDeployments({
 	enabled = true,
 	pollBillingRecoveryFor = null,
+	additionalRefetchInterval,
 }: {
 	enabled?: boolean;
 	pollBillingRecoveryFor?: string | null;
+	additionalRefetchInterval?: (
+		deployments: readonly HostedDeployment[] | undefined,
+	) => number | false;
 } = {}) {
 	const client = useBillingClient();
 	return useBillingQuery({
@@ -412,9 +416,12 @@ export function useHostedDeployments({
 				q.state.data,
 				pollBillingRecoveryFor,
 			);
-			return typeof billingInterval === "number"
-				? Math.min(inventoryInterval, billingInterval)
-				: inventoryInterval;
+			const detailInterval = additionalRefetchInterval?.(q.state.data) ?? false;
+			return [inventoryInterval, billingInterval, detailInterval].reduce<number>(
+				(shortest, interval) =>
+					typeof interval === "number" ? Math.min(shortest, interval) : shortest,
+				inventoryInterval,
+			);
 		},
 		refetchIntervalInBackground: false,
 	});

--- a/apps/web/src/hosted/use-hosted-deployment-inventory.ts
+++ b/apps/web/src/hosted/use-hosted-deployment-inventory.ts
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 import { isDeployApiConfigured } from "@/hosted/billing/billing-client";
+import type { HostedDeployment } from "@/hosted/billing/contracts";
 import { useHostedDeployments } from "@/hosted/billing/hooks";
 import { resolveHostedInventory } from "@/hosted/hosted-agent-resolution";
 
@@ -9,12 +10,20 @@ import { resolveHostedInventory } from "@/hosted/hosted-agent-resolution";
 export function useHostedDeploymentInventory({
 	enabled = true,
 	pollBillingRecoveryFor = null,
+	additionalRefetchInterval,
 }: {
 	enabled?: boolean;
 	pollBillingRecoveryFor?: string | null;
+	additionalRefetchInterval?: (
+		deployments: readonly HostedDeployment[] | undefined,
+	) => number | false;
 } = {}) {
 	const configured = isDeployApiConfigured();
-	const query = useHostedDeployments({ enabled, pollBillingRecoveryFor });
+	const query = useHostedDeployments({
+		enabled,
+		pollBillingRecoveryFor,
+		additionalRefetchInterval,
+	});
 	const resolution = useMemo(
 		() =>
 			resolveHostedInventory({


### PR DESCRIPTION
## Summary
- treat running deployments without a selected runtime UI endpoint as settling and refetch the shared deployment query every 3 seconds
- bound rapid polling to a 5-minute boot window, then surface a clear delayed state while normal periodic reconciliation continues
- show provisioning → booting → ready momentum, keep Terminal available, and auto-open the redeemed live UI from the post-deploy Overview
- cover the no-URL → endpoint-published → iframe transition in hosted Playwright without a manual refresh

## Verification
- bun run --cwd apps/web typecheck
- bun run --cwd apps/web lint
- bun run --cwd apps/web test (481 passed)
- bun run --cwd apps/web build:oss
- bun run --cwd apps/web e2e:hosted (38 passed)