### PR TITLE
fix(v2): close dogfood feature blockers

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -60,6 +60,7 @@ import {
 } from "@/components/dashboard/agent-label";
 import {
 	type AgentTile,
+	agentTileMatchesRouteId,
 	compareAgentTiles,
 	selfManagedAgentTiles,
 } from "@/components/dashboard/agents-card";
@@ -301,11 +302,6 @@ function agentTileChromeKind(tile: AgentTile): AgentChromeKind {
 	if (tile.source === "on-clawdi") return "cloud";
 	if (tile.source === "legacy-hosted") return "legacy";
 	return "connected";
-}
-
-function agentTileRouteId(tile: AgentTile): string | null {
-	if (tile.env) return tile.env.id;
-	return tile.href ? (parseAgentPathname(tile.href)?.agentId ?? null) : null;
 }
 
 function sameOrder(a: string[], b: string[]): boolean {
@@ -1162,7 +1158,7 @@ function FocusRailContent({
 								<SortableAgentRailItem
 									key={agent.id}
 									agent={agent}
-									active={activeAgentId === agentTileRouteId(agent)}
+									active={Boolean(activeAgentId && agentTileMatchesRouteId(agent, activeAgentId))}
 									onNavigate={onRailAgentNavigate}
 									onClickCapture={onRailAgentClickCapture}
 									onPointerDownCapture={recordRailPointerStart}
@@ -1702,7 +1698,7 @@ export function AppSidebar({
 		: hydratedEnvironments !== undefined;
 	const agents = unifiedAgentListEnabled ? (hostedAgentTiles ?? []) : selfManagedTiles;
 	const activeAgentTile = activeAgentId
-		? (agents.find((tile) => agentTileRouteId(tile) === activeAgentId) ?? null)
+		? (agents.find((tile) => agentTileMatchesRouteId(tile, activeAgentId)) ?? null)
 		: null;
 	const activeAgent = activeAgentId
 		? (hydratedEnvironments?.find((env) => env.id === activeAgentId) ?? null)

--- a/apps/web/src/components/dashboard/agents-card.test.ts
+++ b/apps/web/src/components/dashboard/agents-card.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import type { components } from "@clawdi/shared/api";
 import {
 	type AgentTile,
+	agentTileMatchesRouteId,
 	fleetSummaryFromTiles,
 	selfManagedAgentTiles,
 } from "@/components/dashboard/agents-card";
@@ -60,6 +61,26 @@ describe("selfManagedAgentTiles", () => {
 			name: "Launch runner",
 		});
 		expect("runtimeLabel" in tile).toBe(false);
+	});
+});
+
+describe("agentTileMatchesRouteId", () => {
+	it("matches hosted tiles by deployment id or projected environment id", () => {
+		const projected = env();
+		const tile: AgentTile = {
+			id: "hdep_paid",
+			source: "on-clawdi",
+			name: "Hosted agent",
+			agentType: "openclaw",
+			statusLabel: "Running",
+			href: `/agents/${projected.id}?source=on-clawdi&d=hdep_paid`,
+			active: true,
+			env: projected,
+		};
+
+		expect(agentTileMatchesRouteId(tile, "hdep_paid")).toBe(true);
+		expect(agentTileMatchesRouteId(tile, projected.id)).toBe(true);
+		expect(agentTileMatchesRouteId(tile, "hdep_other")).toBe(false);
 	});
 });
 

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -23,7 +23,7 @@ import {
 	EntityHeader,
 } from "@/components/entity-card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { agentSectionHref } from "@/lib/agent-routes";
+import { agentSectionHref, parseAgentPathname } from "@/lib/agent-routes";
 import { cn, relativeTime } from "@/lib/utils";
 
 type Env = components["schemas"]["AgentResponse"];
@@ -112,6 +112,11 @@ export interface AgentTile {
 	 * the same shape; hosted deployments without a registered env leave
 	 * this null. */
 	env?: Env | null;
+}
+
+export function agentTileMatchesRouteId(tile: AgentTile, routeId: string): boolean {
+	if (tile.id === routeId || tile.env?.id === routeId) return true;
+	return tile.href ? parseAgentPathname(tile.href)?.agentId === routeId : false;
 }
 
 export interface AgentFleetSummary {

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -187,6 +187,10 @@ import {
 	useUnlinkAgentChannel,
 } from "@/hosted/v2/channels/channels-hooks";
 import {
+	channelProviderLinkingReady,
+	pairingCommand,
+} from "@/hosted/v2/channels/link-agent-dialog.logic";
+import {
 	type AgentSectionId,
 	agentSectionHref,
 	agentSectionLabel,
@@ -1928,7 +1932,9 @@ function ChannelsTab({ environmentId }: { environmentId: string }) {
 			.flat()
 			.filter((b) => b.access === "public" && b.available)
 			.map((b) => ({ id: b.id, provider: b.provider, name: b.name }));
-		return [...mine, ...shared].filter((c) => !linkedIds.has(c.id));
+		return [...mine, ...shared].filter(
+			(c) => channelProviderLinkingReady(c.provider) && !linkedIds.has(c.id),
+		);
 	}, [channels.data, botPool.data, linkedIds]);
 	const linkableItems = linkable.map((channel) => ({
 		value: channel.id,
@@ -2146,8 +2152,11 @@ function LinkedChannelRow({
 			</div>
 			{code ? (
 				<div className="mt-2 rounded-md border border-primary/30 bg-primary/5 p-2 text-sm">
-					Send <span className="font-mono font-semibold tracking-wider">{code.code}</span> from the
-					chat to pair it.
+					Send{" "}
+					<span className="font-mono font-semibold tracking-wider">
+						{pairingCommand(code.code)}
+					</span>{" "}
+					from the chat to pair it.
 				</div>
 			) : null}
 		</div>

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -74,6 +74,7 @@ import {
 } from "@/hosted/v2/channels/channels-hooks";
 import { LinkAgentDialog } from "@/hosted/v2/channels/link-agent-dialog";
 import {
+	pairingCommand,
 	WHATSAPP_COMING_SOON_MESSAGE,
 	WHATSAPP_LINKING_READY,
 } from "@/hosted/v2/channels/link-agent-dialog.logic";
@@ -829,8 +830,8 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 							"Expired. Generate a new code."
 						) : (
 							<>
-								Send <span className="font-mono font-medium">{result.code}</span> from the chat you
-								want to pair. Expires {relativeTime(result.expires_at)}.
+								Send <span className="font-mono font-medium">{pairingCommand(result.code)}</span>{" "}
+								from the chat you want to pair. Expires {relativeTime(result.expires_at)}.
 							</>
 						)}
 					</p>

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.test.ts
@@ -1,9 +1,23 @@
 import { describe, expect, test } from "bun:test";
 import {
+	channelProviderLinkingReady,
 	linkAgentBlockReason,
+	pairingCommand,
 	shouldMintWhatsappTenantCredential,
 	WHATSAPP_COMING_SOON_MESSAGE,
 } from "./link-agent-dialog.logic";
+
+describe("hosted channel instructions and gates", () => {
+	test("renders the exact command accepted by the channel backend", () => {
+		expect(pairingCommand("PAIRABC123")).toBe("/bot_pair PAIRABC123");
+	});
+
+	test("keeps unavailable providers out of direct agent linking", () => {
+		expect(channelProviderLinkingReady("telegram")).toBe(true);
+		expect(channelProviderLinkingReady("discord")).toBe(true);
+		expect(channelProviderLinkingReady("whatsapp")).toBe(false);
+	});
+});
 
 describe("linkAgentBlockReason", () => {
 	test("blocks WhatsApp for all selected runtime agents", () => {

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.ts
@@ -15,6 +15,14 @@ export const WHATSAPP_COMING_SOON_MESSAGE =
 
 const HERMES_SINGLE_LINK_PROVIDERS = new Set(["telegram", "discord"]);
 
+export function channelProviderLinkingReady(provider: string): boolean {
+	return provider !== "whatsapp" || WHATSAPP_LINKING_READY;
+}
+
+export function pairingCommand(code: string): string {
+	return `/bot_pair ${code}`;
+}
+
 export function shouldMintWhatsappTenantCredential(provider: string, agent: Agent): boolean {
 	return WHATSAPP_LINKING_READY && provider === "whatsapp" && agent !== null && agent !== undefined;
 }
@@ -30,7 +38,7 @@ export function linkAgentBlockReason({
 	existingAgentLinks: AgentChannelLink[];
 	accountId: string;
 }): string | null {
-	if (provider === "whatsapp" && !WHATSAPP_LINKING_READY) return WHATSAPP_COMING_SOON_MESSAGE;
+	if (!channelProviderLinkingReady(provider)) return WHATSAPP_COMING_SOON_MESSAGE;
 	if (selectedAgent?.agent_type !== "hermes") return null;
 	if (!HERMES_SINGLE_LINK_PROVIDERS.has(provider)) return null;
 

--- a/backend/app/routes/channel_routers/discord.py
+++ b/backend/app/routes/channel_routers/discord.py
@@ -4,9 +4,12 @@ import asyncio
 import json
 import secrets
 import zlib
+from dataclasses import dataclass
 from typing import Any
+from urllib.parse import quote
 from uuid import UUID
 
+import jwt
 from fastapi import (
     APIRouter,
     Depends,
@@ -53,7 +56,10 @@ from app.routes.channel_routers.shared import (
 from app.services.channels import (
     DISCORD_REF_INTERACTION_ID_TOKEN,
     DISCORD_REF_INTERACTION_TOKEN,
+    ChannelAgentContext,
     ack_channel_inbox_events,
+    channel_runtime_account_key,
+    channel_runtime_placeholder_token,
     dequeue_discord_gateway_events,
     discord_channel_scope_from_payload,
     discord_chat_from_payload,
@@ -67,6 +73,7 @@ from app.services.channels import (
     record_discord_interaction_references,
     record_inactive_bot_agent_link_event,
     record_inbound_messages_for_bindings,
+    resolve_channel_agent_by_identity,
     resolve_channel_agent_by_token,
     resolve_inbound_binding,
     send_channel_outbound_message,
@@ -80,6 +87,67 @@ router = APIRouter(prefix="/channels/discord", tags=["channels"])
 
 _DISCORD_GATEWAY_RESUME_BUFFER_SIZE = 100
 _DISCORD_GATEWAY_SESSIONS: dict[str, dict[str, Any]] = {}
+_DISCORD_GATEWAY_CAPABILITY_SUBJECT = "clawdi_discord_gateway"
+_DISCORD_GATEWAY_CAPABILITY_AUDIENCE = "clawdi_discord_gateway"
+
+
+@dataclass(frozen=True)
+class _DiscordGatewayCapability:
+    account_id: UUID
+    link_id: UUID
+    agent_token_hash: str
+
+
+def _discord_gateway_capability(agent: ChannelAgentContext) -> str:
+    agent_token_hash = agent.link.agent_token_hash
+    if not agent_token_hash or not settings.encryption_key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="discord gateway credential unavailable",
+        )
+    return jwt.encode(
+        {
+            "sub": _DISCORD_GATEWAY_CAPABILITY_SUBJECT,
+            "aud": _DISCORD_GATEWAY_CAPABILITY_AUDIENCE,
+            "account_id": str(agent.account.id),
+            "link_id": str(agent.link.id),
+            "agent_token_hash": agent_token_hash,
+        },
+        settings.encryption_key,
+        algorithm="HS256",
+    )
+
+
+def _decode_discord_gateway_capability(raw: str) -> _DiscordGatewayCapability:
+    try:
+        payload = jwt.decode(
+            raw,
+            settings.encryption_key,
+            algorithms=["HS256"],
+            audience=_DISCORD_GATEWAY_CAPABILITY_AUDIENCE,
+        )
+        if payload.get("sub") != _DISCORD_GATEWAY_CAPABILITY_SUBJECT:
+            raise ValueError("invalid subject")
+        account_id = UUID(str(payload["account_id"]))
+        link_id = UUID(str(payload["link_id"]))
+        agent_token_hash = payload["agent_token_hash"]
+        if not isinstance(agent_token_hash, str) or not agent_token_hash:
+            raise ValueError("invalid credential fingerprint")
+    except (jwt.PyJWTError, KeyError, TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid discord gateway capability",
+        ) from exc
+    return _DiscordGatewayCapability(
+        account_id=account_id,
+        link_id=link_id,
+        agent_token_hash=agent_token_hash,
+    )
+
+
+def _discord_gateway_url(agent: ChannelAgentContext) -> str:
+    capability = quote(_discord_gateway_capability(agent), safe="")
+    return _public_ws_url(f"/v1/channels/discord/gateway/{capability}")
 
 
 @router.api_route(
@@ -105,7 +173,7 @@ async def discord_agent_rest(
     segments = [segment for segment in discord_path.strip("/").split("/") if segment]
     if segments in (["gateway"], ["gateway", "bot"]):
         return {
-            "url": _public_ws_url("/v1/channels/discord/gateway"),
+            "url": _discord_gateway_url(agent),
             "shards": 1,
             "session_start_limit": {
                 "total": 1000,
@@ -211,12 +279,22 @@ async def discord_agent_rest(
 
 @router.websocket("/gateway")
 @router.websocket("/gateway/")
-async def discord_agent_gateway(websocket: WebSocket) -> None:
+@router.websocket("/gateway/{path_capability}")
+async def discord_agent_gateway(
+    websocket: WebSocket,
+    path_capability: str | None = None,
+) -> None:
     await websocket.accept()
     encoding = websocket.query_params.get("encoding") or "json"
     compress = websocket.query_params.get("compress")
     if encoding != "json" or (compress is not None and compress != "zlib-stream"):
         await websocket.close(code=4012)
+        return
+    raw_capability = path_capability or websocket.query_params.get("capability")
+    try:
+        capability = _decode_discord_gateway_capability(raw_capability) if raw_capability else None
+    except HTTPException:
+        await websocket.close(code=4004)
         return
 
     compressor = zlib.compressobj(wbits=zlib.MAX_WBITS) if compress == "zlib-stream" else None
@@ -316,11 +394,29 @@ async def discord_agent_gateway(websocket: WebSocket) -> None:
                 return
             async with async_session_factory() as db:
                 try:
-                    resolved_agent = await resolve_channel_agent_by_token(
-                        db,
-                        provider=CHANNEL_PROVIDER_DISCORD,
-                        token=token,
-                    )
+                    if capability is None:
+                        resolved_agent = await resolve_channel_agent_by_token(
+                            db,
+                            provider=CHANNEL_PROVIDER_DISCORD,
+                            token=token,
+                        )
+                    else:
+                        expected_placeholder = channel_runtime_placeholder_token(
+                            CHANNEL_PROVIDER_DISCORD,
+                            channel_runtime_account_key(capability.account_id),
+                        )
+                        if not secrets.compare_digest(token, expected_placeholder):
+                            raise HTTPException(
+                                status_code=status.HTTP_401_UNAUTHORIZED,
+                                detail="invalid discord gateway placeholder",
+                            )
+                        resolved_agent = await resolve_channel_agent_by_identity(
+                            db,
+                            provider=CHANNEL_PROVIDER_DISCORD,
+                            account_id=capability.account_id,
+                            link_id=capability.link_id,
+                            agent_token_hash=capability.agent_token_hash,
+                        )
                 except HTTPException:
                     if op == 6:
                         await send_gateway_frame({"op": 9, "d": False}, record=False)
@@ -412,7 +508,11 @@ async def discord_agent_gateway(websocket: WebSocket) -> None:
                         "d": {
                             "v": 10,
                             "session_id": session_id,
-                            "resume_gateway_url": _public_ws_url("/v1/channels/discord/gateway"),
+                            "resume_gateway_url": (
+                                _discord_gateway_url(resolved_agent)
+                                if capability is not None
+                                else _public_ws_url("/v1/channels/discord/gateway")
+                            ),
                             "user": _discord_bot_user(account),
                             "application": {"id": _discord_application_id(account)},
                             "guilds": [

--- a/backend/app/routes/channel_routers/public.py
+++ b/backend/app/routes/channel_routers/public.py
@@ -83,6 +83,8 @@ from app.services.channels import (
     archive_bot_agent_link,
     archive_channel_account,
     channel_bot_link_limit,
+    channel_webhook_url,
+    configure_telegram_provider_webhook,
     create_pair_code,
     decrypt_agent_link_token,
     encrypt_optional_token,
@@ -537,6 +539,12 @@ async def create_channel(
     db.add(account)
     try:
         await db.flush()
+        if body.provider == CHANNEL_PROVIDER_TELEGRAM and body.provider_token:
+            await configure_telegram_provider_webhook(
+                provider_token=body.provider_token,
+                webhook_url=channel_webhook_url(account.id, body.provider),
+                webhook_secret=webhook_secret,
+            )
         link: ChannelBotAgentLink | None = None
         link_agent_token: str | None = None
         if initial_agent_id is not None:

--- a/backend/app/services/channels.py
+++ b/backend/app/services/channels.py
@@ -249,6 +249,36 @@ def channel_webhook_url(account_id: UUID, provider: str) -> str:
     return f"{settings.public_api_url.rstrip('/')}/v1/channels/{provider}/{account_id}/webhook"
 
 
+async def configure_telegram_provider_webhook(
+    *,
+    provider_token: str,
+    webhook_url: str,
+    webhook_secret: str,
+) -> None:
+    # Telegram requires an HTTPS webhook. Local development keeps the default
+    # localhost URL and can still exercise inbound routes directly.
+    if not webhook_url.lower().startswith("https://"):
+        return
+    base_url = settings.channel_telegram_api_base_url.strip().rstrip("/")
+    payload = await _post_provider_json(
+        channel=CHANNEL_PROVIDER_TELEGRAM,
+        method="setWebhook",
+        url=f"{base_url}/bot{provider_token}/setWebhook",
+        json_payload={
+            "url": webhook_url,
+            "secret_token": webhook_secret,
+        },
+        timeout_seconds=20.0,
+        unreachable_detail="telegram api unreachable",
+        rejected_detail="telegram bot token or webhook was rejected",
+    )
+    if payload.get("ok") is not True:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="telegram bot token or webhook was rejected",
+        )
+
+
 async def store_channel_secrets(
     db: AsyncSession,
     *,
@@ -818,6 +848,35 @@ async def resolve_channel_agent_by_token(
     row = result.one_or_none()
     if row is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid bot token")
+    account, link = row
+    return ChannelAgentContext(account=account, link=link)
+
+
+async def resolve_channel_agent_by_identity(
+    db: AsyncSession,
+    *,
+    provider: str,
+    account_id: UUID,
+    link_id: UUID,
+    agent_token_hash: str,
+) -> ChannelAgentContext:
+    result = await db.execute(
+        select(ChannelAccount, ChannelBotAgentLink)
+        .join(ChannelBotAgentLink, ChannelBotAgentLink.account_id == ChannelAccount.id)
+        .where(
+            ChannelAccount.id == account_id,
+            ChannelAccount.provider == provider,
+            ChannelBotAgentLink.id == link_id,
+            ChannelBotAgentLink.agent_token_hash == agent_token_hash,
+            ChannelBotAgentLink.status == BOT_AGENT_LINK_STATUS_ACTIVE,
+            ChannelBotAgentLink.archived_at.is_(None),
+            ChannelAccount.archived_at.is_(None),
+            ChannelAccount.status == CHANNEL_STATUS_ACTIVE,
+        )
+    )
+    row = result.one_or_none()
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid bot identity")
     account, link = row
     return ChannelAgentContext(account=account, link=link)
 

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -58,6 +58,7 @@ from app.routes.channel_routers.discord import (
     _DISCORD_GATEWAY_SESSIONS,
     _discord_bound_guild_channels,
     _discord_bound_guilds,
+    _discord_gateway_url,
     _discord_guild_create_payload,
 )
 from app.services import channels as channel_service
@@ -654,6 +655,38 @@ async def test_create_channel_masks_provider_token(client: httpx.AsyncClient):
     assert "webhook_secret" not in listed.text
     assert "telegram-secret" not in listed.text
     assert "agent_token" not in listed.text
+
+
+@pytest.mark.asyncio
+async def test_create_telegram_channel_registers_provider_webhook(
+    client: httpx.AsyncClient,
+    monkeypatch,
+):
+    previous_public_api_url = settings.public_api_url
+    settings.public_api_url = "https://cloud.example.test"
+    _reset_fake_provider_client({"ok": True, "result": True})
+    monkeypatch.setattr("app.services.channels.httpx.AsyncClient", _FakeProviderClient)
+    try:
+        response = await client.post(
+            "/v1/channels",
+            json={
+                "provider": "telegram",
+                "name": "auto-webhook",
+                "provider_token": "123456:telegram-secret",
+            },
+        )
+    finally:
+        settings.public_api_url = previous_public_api_url
+
+    assert response.status_code == 201
+    created = response.json()
+    assert len(_FakeProviderClient.calls) == 1
+    call = _FakeProviderClient.calls[0]
+    assert call["url"].endswith("/bot123456:telegram-secret/setWebhook")
+    assert call["json"] == {
+        "url": created["webhook_url"],
+        "secret_token": created["webhook_secret"],
+    }
 
 
 def test_generate_telegram_agent_token_matches_bot_api_contract():
@@ -4756,8 +4789,31 @@ async def test_discord_rest_gateway_bot_uses_agent_token(client: httpx.AsyncClie
     )
 
     assert response.status_code == 200
-    assert response.json()["url"].endswith("/v1/channels/discord/gateway")
+    gateway_url = urlparse(response.json()["url"])
+    assert gateway_url.path.startswith("/v1/channels/discord/gateway/")
+    assert gateway_url.path.rpartition("/")[2]
     assert response.json()["shards"] == 1
+
+
+def test_discord_gateway_capability_accepts_runtime_placeholder(monkeypatch):
+    _install_discord_gateway_protocol_fakes(monkeypatch)
+    agent = _discord_gateway_protocol_agent()
+    websocket_path = urlparse(_discord_gateway_url(agent)).path
+    placeholder = channel_runtime_placeholder_token(
+        CHANNEL_PROVIDER_DISCORD,
+        channel_runtime_account_key(agent.account.id),
+    )
+
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect(f"{websocket_path}?v=10&encoding=json") as websocket:
+            assert websocket.receive_json()["op"] == 10
+            websocket.send_json({"op": 2, "d": {"token": placeholder, "intents": 0}})
+            ready = websocket.receive_json()
+
+    assert ready["t"] == "READY"
+    resume_url = urlparse(ready["d"]["resume_gateway_url"])
+    assert resume_url.path.startswith("/v1/channels/discord/gateway/")
+    assert resume_url.path.rpartition("/")[2]
 
 
 @pytest.mark.asyncio
@@ -4779,7 +4835,9 @@ async def test_discord_rest_accepts_preserve_path_mitm_alias(client: httpx.Async
     )
 
     assert response.status_code == 200
-    assert response.json()["url"].endswith("/v1/channels/discord/gateway")
+    gateway_url = urlparse(response.json()["url"])
+    assert gateway_url.path.startswith("/v1/channels/discord/gateway/")
+    assert gateway_url.path.rpartition("/")[2]
 
 
 @pytest.mark.asyncio
@@ -6964,6 +7022,25 @@ async def test_discord_gateway_ready_guilds_come_from_active_bindings(
     }
 
 
+def _discord_gateway_protocol_agent() -> ChannelAgentContext:
+    account = ChannelAccount(
+        id=UUID("00000000-0000-0000-0000-0000000000dc"),
+        user_id=UUID("00000000-0000-0000-0000-0000000000dd"),
+        provider="discord",
+        name="discord-gateway-protocol",
+        webhook_secret_hash="unused",
+        config={"application_id": "discord-app-1"},
+    )
+    link = ChannelBotAgentLink(
+        id=UUID("00000000-0000-0000-0000-0000000000df"),
+        account_id=account.id,
+        user_id=account.user_id,
+        agent_id=UUID("00000000-0000-0000-0000-0000000000de"),
+        agent_token_hash="unused",
+    )
+    return ChannelAgentContext(account=account, link=link)
+
+
 def _install_discord_gateway_protocol_fakes(
     monkeypatch,
     *,
@@ -6973,23 +7050,26 @@ def _install_discord_gateway_protocol_fakes(
 
     async def fake_resolve_agent(db, *, provider: str, token: str) -> ChannelAgentContext:
         if provider == "discord" and token == "valid-discord-token":
-            account = ChannelAccount(
-                id=UUID("00000000-0000-0000-0000-0000000000dc"),
-                user_id=UUID("00000000-0000-0000-0000-0000000000dd"),
-                provider="discord",
-                name="discord-gateway-protocol",
-                webhook_secret_hash="unused",
-                config={"application_id": "discord-app-1"},
-            )
-            link = ChannelBotAgentLink(
-                id=UUID("00000000-0000-0000-0000-0000000000df"),
-                account_id=account.id,
-                user_id=account.user_id,
-                agent_id=UUID("00000000-0000-0000-0000-0000000000de"),
-                agent_token_hash="unused",
-            )
-            return ChannelAgentContext(account=account, link=link)
+            return _discord_gateway_protocol_agent()
         raise HTTPException(status_code=401, detail="invalid bot token")
+
+    async def fake_resolve_identity(
+        db,
+        *,
+        provider: str,
+        account_id: UUID,
+        link_id: UUID,
+        agent_token_hash: str,
+    ) -> ChannelAgentContext:
+        agent = _discord_gateway_protocol_agent()
+        if (
+            provider == "discord"
+            and account_id == agent.account.id
+            and link_id == agent.link.id
+            and agent_token_hash == agent.link.agent_token_hash
+        ):
+            return agent
+        raise HTTPException(status_code=401, detail="invalid bot identity")
 
     async def fake_bound_guilds(
         db,
@@ -7028,6 +7108,10 @@ def _install_discord_gateway_protocol_fakes(
     monkeypatch.setattr(
         "app.routes.channel_routers.discord.resolve_channel_agent_by_token",
         fake_resolve_agent,
+    )
+    monkeypatch.setattr(
+        "app.routes.channel_routers.discord.resolve_channel_agent_by_identity",
+        fake_resolve_identity,
     )
     monkeypatch.setattr(
         "app.routes.channel_routers.discord._discord_bound_guilds",

--- a/packages/cli/src/runtime/manifest-reconciliation.test.ts
+++ b/packages/cli/src/runtime/manifest-reconciliation.test.ts
@@ -19,6 +19,7 @@ import {
 	runtimeLiveSnapshotPaths,
 	runtimeProgramRevision,
 	runtimeSecretValue,
+	runtimeSidecarProgramRevision,
 } from "./manifest";
 import {
 	hostedRuntimeBundleV2ManifestSchema,
@@ -2042,6 +2043,38 @@ describe("runtime manifest reconciliation invariants", () => {
 			generation: 2,
 			issuedAt: "2026-07-01T00:01:00.000Z",
 		};
+		const egressManifest: RuntimeManifest = {
+			...manifest,
+			egressProfiles: {
+				profiles: [
+					{
+						id: "channel-token",
+						enabled: true,
+						kind: "http",
+						match: {
+							scheme: "https",
+							host: "api.example.test",
+							pathPrefix: "/",
+							headers: {},
+							query: {},
+						},
+						rewrite: {
+							upstreamBaseUrl: "https://upstream.example.test",
+							preservePath: true,
+							setHeaders: {
+								authorization: {
+									type: "secretRef",
+									secretRef: "secret://providers/default/api-key",
+									prefix: "Bearer ",
+								},
+							},
+						},
+						logging: { redactHeaders: ["authorization"], redactUrlPatterns: [] },
+						priority: 100,
+					},
+				],
+			},
+		};
 
 		const runtimeRevision = runtimeProgramRevision(manifest, "openclaw", secretValues);
 		expect(runtimeProgramRevision(manifest, "openclaw", rotatedSecretValues)).not.toBe(
@@ -2049,6 +2082,14 @@ describe("runtime manifest reconciliation invariants", () => {
 		);
 		expect(runtimeProgramRevision(metadataOnlyChange, "openclaw", secretValues)).toBe(
 			runtimeRevision,
+		);
+		const sidecarRevision = runtimeSidecarProgramRevision(manifest, secretValues);
+		expect(runtimeSidecarProgramRevision(manifest, rotatedSecretValues)).toBe(sidecarRevision);
+		expect(runtimeSidecarProgramRevision(egressManifest, rotatedSecretValues)).not.toBe(
+			runtimeSidecarProgramRevision(egressManifest, secretValues),
+		);
+		expect(runtimeSidecarProgramRevision(metadataOnlyChange, secretValues)).not.toBe(
+			sidecarRevision,
 		);
 	});
 

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -4201,6 +4201,7 @@ function hashToUInt16(input: string): number {
 
 export function runtimeSidecarProgramRevision(
 	manifest: RuntimeManifest,
+	secretValues: Record<string, string>,
 	egressProgram: RuntimeEgressSystemdProgram | null = null,
 	egressIdentity: RuntimeEgressIdentity | null = null,
 ): string {
@@ -4212,6 +4213,8 @@ export function runtimeSidecarProgramRevision(
 		runtimeSidecar: "hosted-runtime-sidecar-v4",
 		instanceId: manifest.instanceId,
 		generation: manifest.generation,
+		egressProfiles: manifest.egressProfiles ?? null,
+		egressSecrets: scopedSecretValues(secretValues, egressSecretRefs(manifest)),
 		egress: egressProgram
 			? {
 					transparentPort: egressProgram.transparentPort,
@@ -4963,6 +4966,7 @@ function writeSystemdUnits(
 					CLAWDI_EGRESS_ENV_FILE: activeEgressProgram.envFilePath,
 					CLAWDI_RUNTIME_REV: runtimeSidecarProgramRevision(
 						manifest,
+						secretValues ?? {},
 						activeEgressProgram,
 						activeEgressIdentity,
 					),


### PR DESCRIPTION
## Summary
- show the exact bot pairing command accepted by Cloud
- register Telegram webhooks during channel creation
- authenticate placeholder-based Discord Gateway sessions with link-scoped signed capabilities
- restart the runtime sidecar when its egress profiles or referenced secrets change
- fix path-prefixed Runtime UI helper loading, post-payment agent navigation, and the WhatsApp linking gate

## Protocol verification
- OpenClaw preserves an existing Gateway query while adding v/encoding: https://github.com/openclaw/openclaw/blob/a542f01f4964cadf61814cbb47587bd3c4c30cb6/extensions/discord/src/internal/gateway-payload.ts#L3-L7
- Hermes pins discord.py 2.7.1, whose Gateway client replaces the query via with_query: https://github.com/Rapptz/discord.py/blob/v2.7.1/discord/gateway.py#L383-L390
- therefore the signed capability is carried in the Gateway path; both clients preserve it when adding protocol query parameters

## Verification
- bash scripts/test.sh backend: 1325 passed, 7 skipped
- bash scripts/test.sh web: passed
- bash scripts/test.sh cli: 1025 passed
- focused Bun tests: 169 passed
- web and CLI typechecks: passed
- targeted Biome and Ruff checks: passed

## Review note
The money-path label is conservative: no Stripe, charge, wallet, or ledger code changed, but the sidebar fix covers the route used immediately after successful payment. Do not merge without the requested round-table review.