### PR TITLE
release(cli): prepare 0.12.10-beta.58

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.57",
+      "version": "0.12.10-beta.58",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.57",
+	"version": "0.12.10-beta.58",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
## Summary

- bump the exact CLI prerelease from `0.12.10-beta.57` to `0.12.10-beta.58`
- publish the current `main` CLI, including native runtime dashboard authentication from #442
- keep the workspace lockfile version in sync

## Verification

- `bun install --frozen-lockfile --ignore-scripts`
- `bun test --isolate --max-concurrency=1 src/runtime/runtime-bundle-v2.test.ts src/runtime/manifest-reconciliation.test.ts` (155 pass)
- `git diff --check`

## Release impact

Merging triggers `.github/workflows/cli-publish.yml`, which builds, typechecks, runs the full CLI suite, packs one immutable artifact, and publishes `clawdi@0.12.10-beta.58` to the npm `beta` tag through protected OIDC. The hosted runtime image release remains a separate explicit workflow.