### PR TITLE
release(cli): prepare 0.12.10-beta.59

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.58",
+      "version": "0.12.10-beta.59",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.58",
+	"version": "0.12.10-beta.59",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",


### PR DESCRIPTION
Publishes the #450 OpenClaw config patch --replace-path fix as the next immutable Agent v2 CLI beta.

Verification:
- bun run --cwd packages/cli typecheck
- bun run --cwd packages/cli test (1013 pass, 0 fail)
- bun run --cwd packages/cli check:publish-manifest
- npm exact-version availability check

Release impact:
- OIDC workflow will publish clawdi@0.12.10-beta.59 to the beta dist-tag after merge.
- No hosted or production settings are changed by this PR.