### PR TITLE
fix(runtime): pass gateway token to runtime watch

### DIFF
--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -5607,18 +5607,34 @@ exit 0
 		}
 	});
 
-	it("runtime watch applies remote changes, tracks systemd unit changes, and saves the new ETag", async () => {
+	it("runtime watch receives the gateway token and applies a live channel binding", async () => {
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
 		const sourcePath = join(root, "runtime-source.json");
 		const bin = join(root, "bin");
+		const openclawBin = join(home, ".openclaw", "bin", "openclaw");
+		const openclawPatch = join(root, "openclaw-watch-channel-patch.jsonl");
 		const previousExitCode = process.exitCode;
 		const previousLog = console.log;
 		const logs: string[] = [];
 		mkdirSync(join(run, "secrets"), { recursive: true });
 		mkdirSync(bin, { recursive: true });
-		seedOpenClawBinary(home);
+		mkdirSync(dirname(openclawBin), { recursive: true });
+		writeFileSync(
+			openclawBin,
+			`#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = "config" ] && [ "\${2:-}" = "patch" ] && [ "\${3:-}" = "--stdin" ]; then
+  cat >> '${openclawPatch}'
+  printf '\\n' >> '${openclawPatch}'
+  exit 0
+fi
+printf 'unexpected openclaw command: %s\\n' "$*" >&2
+exit 64
+`,
+		);
+		chmodSync(openclawBin, 0o700);
 		writeFileSync(
 			join(bin, "systemctl"),
 			`#!/usr/bin/env bash
@@ -5638,6 +5654,7 @@ printf 'ActiveState=active\\nSubState=running\\n'
 		process.env.CLAWDI_RUNTIME_MANIFEST_ETAG = '"manifest-watch-12"';
 		process.env.CLAWDI_RUNTIME_APPLY_RECEIPT_ID = "apply-receipt-0012";
 		process.env.CLAWDI_RUNTIME_BOOT_NONCE = "boot-nonce-000012";
+		process.env.OPENCLAW_GATEWAY_TOKEN = "gateway-token-watch";
 		process.exitCode = undefined;
 		console.log = (value?: unknown) => {
 			logs.push(String(value));
@@ -5695,8 +5712,22 @@ printf 'ActiveState=active\\nSubState=running\\n'
 									},
 								},
 							},
-							channelBindings: [],
-							secretValues: { "provider.default.apiKey": "sk-provider-watch" },
+							channelBindings: [
+								{
+									provider: "telegram",
+									accountKey: "clawdi_accttelegram",
+									agentTokenSecretRef: "secret://channels/telegram/clawdi_accttelegram/agent-token",
+									placeholderTokenSecretRef:
+										"secret://channels/telegram/clawdi_accttelegram/placeholder-token",
+								},
+							],
+							secretValues: {
+								"provider.default.apiKey": "sk-provider-watch",
+								"secret://channels/telegram/clawdi_accttelegram/agent-token":
+									"telegram-agent-token-watch",
+								"secret://channels/telegram/clawdi_accttelegram/placeholder-token":
+									"999999999:00000000000000000000000000000000",
+							},
 						}),
 						{
 							status: 200,
@@ -5771,7 +5802,17 @@ printf 'ActiveState=active\\nSubState=running\\n'
 			);
 			const watchEnv = readSystemdEnvFile(paths, "clawdi-runtime-watch");
 			const daemonEnv = readSystemdEnvFile(paths, "clawdi-daemon");
+			const gatewayEnv = readSystemdEnvFile(paths, "openclaw-gateway");
+			expect(watchEnv).toContain('OPENCLAW_GATEWAY_TOKEN="gateway-token-watch"');
+			expect(gatewayEnv).toContain('OPENCLAW_GATEWAY_TOKEN="gateway-token-watch"');
 			expect(watchEnv).not.toContain("file-runtime-token");
+			const patchText = readFileSync(openclawPatch, "utf-8");
+			expect(patchText).toContain('"telegram"');
+			expect(patchText).toContain('"botToken"');
+			expect(patchText).toContain(
+				'"id": "CLAWDI_CHANNEL_TELEGRAM_CLAWDI_ACCTTELEGRAM_AGENT_TOKEN"',
+			);
+			expect(patchText).not.toContain("telegram-agent-token-watch");
 			for (const unitEnv of [watchEnv, daemonEnv]) {
 				expect(unitEnv).toContain('CLAWDI_RUNTIME_GENERATION="12"');
 				expect(unitEnv).toContain('CLAWDI_RUNTIME_MANIFEST_ETAG="\\"manifest-watch-12\\""');


### PR DESCRIPTION
## Summary

- resolve `OPENCLAW_GATEWAY_TOKEN` from the same `runtimes.openclaw.run.secretEnv` reference used by `openclaw-gateway.service`
- inject the resolved token into the root-owned `clawdi-runtime-watch.service` environment file
- cover a runtime-watch Telegram channel round-trip and assert the watch/gateway units receive the same token

## Bug

The runtime watcher called the OpenClaw hosted projection without `OPENCLAW_GATEWAY_TOKEN`, so live channel updates failed with `OpenClaw native gateway token is unavailable` before bindings could reach the running agent.

## Proof

The regression test runs `runtime watch` with a Telegram binding, verifies the emitted OpenClaw patch contains `telegram.botToken` backed by the managed environment reference, verifies the real channel token is not embedded in the patch, and asserts both systemd environment files contain `OPENCLAW_GATEWAY_TOKEN="gateway-token-watch"`.

No v1 surface was changed.

## Verification

- `bun test packages/cli/tests/runtime.test.ts --test-name-pattern "runtime watch receives the gateway token and applies a live channel binding"`
- `bun run --cwd packages/cli test` (1013 pass)
- `bun run --cwd packages/cli typecheck`
- `bun run lint`
