### PR TITLE
release(cli): prepare 0.13.0

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -203,8 +203,17 @@ jobs:
             --notes "$notes"
             --generate-notes
             --latest=false
-            --prerelease
           )
+          case "$NPM_TAG" in
+            beta)
+              args+=(--prerelease)
+              ;;
+            latest) ;;
+            *)
+              echo "unsupported npm release tag: $NPM_TAG" >&2
+              exit 64
+              ;;
+          esac
           if [ -n "$previous" ]; then
             args+=(--notes-start-tag "$previous")
           fi

--- a/bun.lock
+++ b/bun.lock
@@ -72,7 +72,7 @@
     },
     "packages/cli": {
       "name": "clawdi",
-      "version": "0.12.10-beta.60",
+      "version": "0.13.0",
       "bin": {
         "clawdi": "bin/clawdi.mjs",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "clawdi",
-	"version": "0.12.10-beta.60",
+	"version": "0.13.0",
 	"description": "iCloud for AI Agents — cross-agent sessions, skills, memory, and vault.",
 	"license": "MIT",
 	"type": "module",

--- a/packages/cli/tests/cli-publish-workflow.test.ts
+++ b/packages/cli/tests/cli-publish-workflow.test.ts
@@ -73,8 +73,8 @@ describe("CLI publish workflow contract", () => {
 		expect(workflow).toContain(
 			'npm publish "./release/$CLI_TARBALL_FILENAME" --access public --provenance --ignore-scripts --tag "$NPM_TAG"',
 		);
-		expect(cliPackage.version).toContain("-");
-		expect(expectedNpmTag(cliPackage.version)).toBe("beta");
+		expect(cliPackage.version).not.toContain("-");
+		expect(expectedNpmTag(cliPackage.version)).toBe("latest");
 		expect(expectedNpmTag("1.2.3-beta.1")).toBe("beta");
 		expect(expectedNpmTag("1.2.3")).toBe("latest");
 		expect(cliPackage.publishConfig).toEqual({ access: "public" });
@@ -107,6 +107,10 @@ describe("CLI publish workflow contract", () => {
 		expect(workflow.indexOf("npm publish ")).toBeLessThan(
 			workflow.indexOf('release create "$tag"'),
 		);
+		expect(workflow).toContain('case "$NPM_TAG" in');
+		expect(workflow).toContain("args+=(--prerelease)");
+		expect(workflow).toContain("latest) ;;");
+		expect(workflow).toContain('echo "unsupported npm release tag: $NPM_TAG" >&2');
 		expect(workflow).not.toContain("pull_request:");
 	});
 


### PR DESCRIPTION
Cuts the native-dashboard/runtime-watch release line as stable clawdi@0.13.0.

Changes:
- bump packages/cli/package.json and bun.lock from 0.12.10-beta.60 to 0.13.0
- publish stable versions to npm latest through the existing OIDC artifact path
- mark only beta-channel GitHub CLI releases as prereleases; unknown derived tags fail closed
- retain --latest=false for the repository-level GitHub Latest marker

Verification:
- bun run --cwd packages/cli typecheck
- bun run --cwd packages/cli test (1014 pass, 0 fail)
- bun test --isolate --max-concurrency=1 packages/cli/tests/cli-publish-workflow.test.ts
- bun run --cwd packages/cli check:publish-manifest
- npm exact-version availability check

Release impact:
- after merge, OIDC publishes clawdi@0.13.0 to npm latest
- no runtime image build is required or authorized
- production exact-pin promotion remains a separate explicit workflow step
- no GA/can_use_v2 setting changes