### PR TITLE
fix(web): label hosted default model choice

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -160,8 +160,10 @@ import {
 	firstModelForProvider,
 	isManagedProviderId,
 	MANAGED_AI_CHOICE,
+	MANAGED_AI_CHOICE_OPTION,
 	MANAGED_DEFAULT_MODEL_CHOICE,
 	MANAGED_PROVIDER_ID,
+	modelChoiceOptions,
 	modelIdsForProvider,
 	normalizeSelectedProviderIds,
 	primaryModelProviderId,
@@ -1796,9 +1798,7 @@ function AgentPrimaryModelPicker({
 	const catalogModelIds = modelIdsForProvider(primaryProviderChoice, providers);
 	const modelChoice = catalogModelIds.includes(primaryModel) ? primaryModel : CUSTOM_MODEL_CHOICE;
 	const primaryProviderItems = [
-		...(selectedProviderChoices.includes(MANAGED_AI_CHOICE)
-			? [{ value: MANAGED_AI_CHOICE, label: "Managed by Clawdi" }]
-			: []),
+		...(selectedProviderChoices.includes(MANAGED_AI_CHOICE) ? [MANAGED_AI_CHOICE_OPTION] : []),
 		...selectedProviderChoices.filter(isUnresolvedProviderChoice).map((choice) => ({
 			value: choice,
 			label: unresolvedProviderRef(choice),
@@ -1810,12 +1810,9 @@ function AgentPrimaryModelPicker({
 				label: provider.label ?? provider.provider_id,
 			})),
 	];
+	const catalogModelOptions = modelChoiceOptions(catalogModelIds, formatModelLabel);
 	const catalogModelItems = [
-		...catalogModelIds.map((model) => ({
-			value: model,
-			label:
-				model === MANAGED_DEFAULT_MODEL_CHOICE ? "Hosted default (Luna)" : formatModelLabel(model),
-		})),
+		...catalogModelOptions,
 		{ value: CUSTOM_MODEL_CHOICE, label: "Custom model" },
 	];
 	return (
@@ -1835,7 +1832,7 @@ function AgentPrimaryModelPicker({
 						</SelectTrigger>
 						<SelectContent>
 							{selectedProviderChoices.includes(MANAGED_AI_CHOICE) ? (
-								<SelectItem value={MANAGED_AI_CHOICE}>Managed by Clawdi</SelectItem>
+								<SelectItem value={MANAGED_AI_CHOICE}>{MANAGED_AI_CHOICE_OPTION.label}</SelectItem>
 							) : null}
 							{selectedProviderChoices.filter(isUnresolvedProviderChoice).map((choice) => (
 								<SelectItem key={choice} value={choice}>
@@ -1867,11 +1864,9 @@ function AgentPrimaryModelPicker({
 								<SelectValue />
 							</SelectTrigger>
 							<SelectContent>
-								{catalogModelIds.map((model) => (
-									<SelectItem key={model} value={model}>
-										{model === MANAGED_DEFAULT_MODEL_CHOICE
-											? "Hosted default (Luna)"
-											: formatModelLabel(model)}
+								{catalogModelOptions.map((option) => (
+									<SelectItem key={option.value} value={option.value}>
+										{option.label}
 									</SelectItem>
 								))}
 								<SelectItem value={CUSTOM_MODEL_CHOICE}>Custom model</SelectItem>

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.model-picker.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.model-picker.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { PrimaryModelPicker } from "@/hosted/billing/deploy/deploy-wizard";
+import {
+	MANAGED_AI_CHOICE,
+	MANAGED_AI_CHOICE_LABEL,
+	MANAGED_DEFAULT_MODEL_CHOICE,
+	MANAGED_DEFAULT_MODEL_CHOICE_LABEL,
+} from "@/hosted/v2/ai-providers/model-binding";
+
+function selectValueLabels(markup: string): string[] {
+	return [...markup.matchAll(/data-slot="select-value"[^>]*>([^<]*)<\/span>/g)].map(
+		(match) => match[1] ?? "",
+	);
+}
+
+describe("deploy wizard primary model picker", () => {
+	test("renders friendly labels for managed sentinel values", () => {
+		const markup = renderToStaticMarkup(
+			createElement(PrimaryModelPicker, {
+				providers: [],
+				customProviders: [],
+				selectedProviderChoices: [MANAGED_AI_CHOICE],
+				primaryProviderChoice: MANAGED_AI_CHOICE,
+				primaryModel: MANAGED_DEFAULT_MODEL_CHOICE,
+				onPrimaryProviderChange: () => {},
+				onPrimaryModelChange: () => {},
+			}),
+		);
+
+		const visibleLabels = selectValueLabels(markup);
+		expect(visibleLabels).toEqual([MANAGED_AI_CHOICE_LABEL, MANAGED_DEFAULT_MODEL_CHOICE_LABEL]);
+		expect(visibleLabels).not.toContain(MANAGED_AI_CHOICE);
+		expect(visibleLabels).not.toContain(MANAGED_DEFAULT_MODEL_CHOICE);
+		expect(markup).toContain(`value="${MANAGED_AI_CHOICE}"`);
+		expect(markup).toContain(`value="${MANAGED_DEFAULT_MODEL_CHOICE}"`);
+	});
+});

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -142,8 +142,10 @@ import {
 	dedupeProviderIds,
 	firstModelForProvider,
 	MANAGED_AI_CHOICE,
+	MANAGED_AI_CHOICE_OPTION,
 	MANAGED_DEFAULT_MODEL_CHOICE,
 	MANAGED_PROVIDER_ID,
+	modelChoiceOptions,
 	modelIdsForProvider,
 	normalizeSelectedProviderIds,
 	primaryModelRef,
@@ -1603,7 +1605,7 @@ function providerCatalogDescription(provider: AiProvider): string {
 	return `${count} catalog models`;
 }
 
-function PrimaryModelPicker({
+export function PrimaryModelPicker({
 	providers,
 	customProviders,
 	selectedProviderChoices,
@@ -1623,9 +1625,7 @@ function PrimaryModelPicker({
 	const catalogModelIds = modelIdsForProvider(primaryProviderChoice, providers);
 	const modelChoice = catalogModelIds.includes(primaryModel) ? primaryModel : CUSTOM_MODEL_CHOICE;
 	const primaryProviderItems = [
-		...(selectedProviderChoices.includes(MANAGED_AI_CHOICE)
-			? [{ value: MANAGED_AI_CHOICE, label: "Managed by Clawdi" }]
-			: []),
+		...(selectedProviderChoices.includes(MANAGED_AI_CHOICE) ? [MANAGED_AI_CHOICE_OPTION] : []),
 		...customProviders
 			.filter((provider) => selectedProviderChoices.includes(provider.provider_id))
 			.map((provider) => ({
@@ -1633,8 +1633,9 @@ function PrimaryModelPicker({
 				label: provider.label ?? provider.provider_id,
 			})),
 	];
+	const catalogModelOptions = modelChoiceOptions(catalogModelIds);
 	const catalogModelItems = [
-		...catalogModelIds.map((model) => ({ value: model, label: model })),
+		...catalogModelOptions,
 		{ value: CUSTOM_MODEL_CHOICE, label: "Custom model" },
 	];
 	return (
@@ -1655,7 +1656,9 @@ function PrimaryModelPicker({
 						<SelectContent>
 							<SelectGroup>
 								{selectedProviderChoices.includes(MANAGED_AI_CHOICE) ? (
-									<SelectItem value={MANAGED_AI_CHOICE}>Managed by Clawdi</SelectItem>
+									<SelectItem value={MANAGED_AI_CHOICE}>
+										{MANAGED_AI_CHOICE_OPTION.label}
+									</SelectItem>
 								) : null}
 								{customProviders
 									.filter((provider) => selectedProviderChoices.includes(provider.provider_id))
@@ -1684,9 +1687,9 @@ function PrimaryModelPicker({
 							</SelectTrigger>
 							<SelectContent>
 								<SelectGroup>
-									{catalogModelIds.map((model) => (
-										<SelectItem key={model} value={model}>
-											{model === MANAGED_DEFAULT_MODEL_CHOICE ? "Hosted default (Luna)" : model}
+									{catalogModelOptions.map((option) => (
+										<SelectItem key={option.value} value={option.value}>
+											{option.label}
 										</SelectItem>
 									))}
 									<SelectItem value={CUSTOM_MODEL_CHOICE}>Custom model</SelectItem>

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
@@ -3,6 +3,8 @@ import {
 	firstModelForProvider,
 	MANAGED_AI_CHOICE,
 	MANAGED_DEFAULT_MODEL_CHOICE,
+	MANAGED_DEFAULT_MODEL_CHOICE_LABEL,
+	modelChoiceOptions,
 	modelIdsForProvider,
 } from "@/hosted/v2/ai-providers/model-binding";
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
@@ -34,5 +36,14 @@ describe("model binding", () => {
 		];
 
 		expect(firstModelForProvider("openai-main", providers)).toBe("gpt-5.5");
+	});
+
+	test("labels the managed default without changing its sentinel value", () => {
+		expect(modelChoiceOptions([MANAGED_DEFAULT_MODEL_CHOICE])).toEqual([
+			{
+				value: MANAGED_DEFAULT_MODEL_CHOICE,
+				label: MANAGED_DEFAULT_MODEL_CHOICE_LABEL,
+			},
+		]);
 	});
 });

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.ts
@@ -2,8 +2,19 @@ import { CLAWDI_MANAGED_PROVIDER_IDS, CLAWDI_MANAGED_V2_PROVIDER_ID } from "@cla
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 
 export const MANAGED_AI_CHOICE = "__managed__";
+export const MANAGED_AI_CHOICE_LABEL = "Managed by Clawdi";
+export const MANAGED_AI_CHOICE_OPTION = {
+	value: MANAGED_AI_CHOICE,
+	label: MANAGED_AI_CHOICE_LABEL,
+} as const;
 export const MANAGED_PROVIDER_ID = CLAWDI_MANAGED_V2_PROVIDER_ID;
 export const MANAGED_DEFAULT_MODEL_CHOICE = "__hosted_default__";
+export const MANAGED_DEFAULT_MODEL_CHOICE_LABEL = "Hosted default (Luna)";
+
+export type ModelChoiceOption = {
+	value: string;
+	label: string;
+};
 
 export type PrimaryModelRef = {
 	provider_id: string;
@@ -81,6 +92,19 @@ export function modelIdsForProvider(choice: string, providers: readonly AiProvid
 	}
 	const provider = providers.find((item) => item.provider_id === choice);
 	return dedupeProviderIds((provider?.models ?? []).map((model) => model.id));
+}
+
+export function modelChoiceOptions(
+	models: readonly string[],
+	formatLabel: (model: string) => string = (model) => model,
+): ModelChoiceOption[] {
+	return models.map((model) => ({
+		value: model,
+		label:
+			model === MANAGED_DEFAULT_MODEL_CHOICE
+				? MANAGED_DEFAULT_MODEL_CHOICE_LABEL
+				: formatLabel(model),
+	}));
 }
 
 export function firstModelForProvider(choice: string, providers: readonly AiProvider[]): string {


### PR DESCRIPTION
## Summary
- label the managed model sentinel as `Hosted default (Luna)` in the deploy wizard trigger and menu
- reuse the same model option builder in hosted agent settings
- centralize the managed provider option label so `__managed__` cannot become visible
- preserve sentinel values and hosted-default request omission behavior

## Verification
- `bun run --cwd apps/web test` (488 pass)
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web lint`
