### PR TITLE
fix(web): label hosted default model choice

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -155,11 +155,14 @@ import { hostedRuntimeStatusView } from "@/hosted/use-hosted-agent-tiles";
 import { useAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import { AuthBadge, ProviderTypeChip } from "@/hosted/v2/ai-providers/ai-providers-ui";
 import { authCardLabel } from "@/hosted/v2/ai-providers/auth-card-label";
+import { CatalogModelSelect } from "@/hosted/v2/ai-providers/catalog-model-select";
 import {
+	CUSTOM_MODEL_CHOICE,
 	dedupeProviderIds,
 	firstModelForProvider,
 	isManagedProviderId,
 	MANAGED_AI_CHOICE,
+	MANAGED_AI_CHOICE_LABEL,
 	MANAGED_DEFAULT_MODEL_CHOICE,
 	MANAGED_PROVIDER_ID,
 	modelIdsForProvider,
@@ -225,7 +228,6 @@ const HOSTED_AGENT_TABS = new Set<HostedAgentTab>([
 	"channels",
 	"settings",
 ]);
-const CUSTOM_MODEL_CHOICE = "__custom__";
 const UNRESOLVED_PROVIDER_PREFIX = "unresolved:";
 
 function providerAuthKind(provider: AiProvider): RuntimeAiProviderAuthKind {
@@ -1797,7 +1799,7 @@ function AgentPrimaryModelPicker({
 	const modelChoice = catalogModelIds.includes(primaryModel) ? primaryModel : CUSTOM_MODEL_CHOICE;
 	const primaryProviderItems = [
 		...(selectedProviderChoices.includes(MANAGED_AI_CHOICE)
-			? [{ value: MANAGED_AI_CHOICE, label: "Managed by Clawdi" }]
+			? [{ value: MANAGED_AI_CHOICE, label: MANAGED_AI_CHOICE_LABEL }]
 			: []),
 		...selectedProviderChoices.filter(isUnresolvedProviderChoice).map((choice) => ({
 			value: choice,
@@ -1809,14 +1811,6 @@ function AgentPrimaryModelPicker({
 				value: provider.provider_id,
 				label: provider.label ?? provider.provider_id,
 			})),
-	];
-	const catalogModelItems = [
-		...catalogModelIds.map((model) => ({
-			value: model,
-			label:
-				model === MANAGED_DEFAULT_MODEL_CHOICE ? "Hosted default (Luna)" : formatModelLabel(model),
-		})),
-		{ value: CUSTOM_MODEL_CHOICE, label: "Custom model" },
 	];
 	return (
 		<div className="flex max-w-2xl flex-col gap-3 rounded-lg border bg-muted/20 p-3">
@@ -1835,7 +1829,7 @@ function AgentPrimaryModelPicker({
 						</SelectTrigger>
 						<SelectContent>
 							{selectedProviderChoices.includes(MANAGED_AI_CHOICE) ? (
-								<SelectItem value={MANAGED_AI_CHOICE}>Managed by Clawdi</SelectItem>
+								<SelectItem value={MANAGED_AI_CHOICE}>{MANAGED_AI_CHOICE_LABEL}</SelectItem>
 							) : null}
 							{selectedProviderChoices.filter(isUnresolvedProviderChoice).map((choice) => (
 								<SelectItem key={choice} value={choice}>
@@ -1855,28 +1849,15 @@ function AgentPrimaryModelPicker({
 				{catalogModelIds.length > 0 ? (
 					<div className="flex flex-col gap-1.5">
 						<Label htmlFor="agent-catalog-model">Catalog model</Label>
-						<Select
-							items={catalogModelItems}
+						<CatalogModelSelect
+							id="agent-catalog-model"
+							modelIds={catalogModelIds}
 							value={modelChoice}
-							onValueChange={(value) => {
-								if (!value) return;
-								onPrimaryModelChange(value === CUSTOM_MODEL_CHOICE ? "" : value);
-							}}
-						>
-							<SelectTrigger id="agent-catalog-model" className="w-full">
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								{catalogModelIds.map((model) => (
-									<SelectItem key={model} value={model}>
-										{model === MANAGED_DEFAULT_MODEL_CHOICE
-											? "Hosted default (Luna)"
-											: formatModelLabel(model)}
-									</SelectItem>
-								))}
-								<SelectItem value={CUSTOM_MODEL_CHOICE}>Custom model</SelectItem>
-							</SelectContent>
-						</Select>
+							onValueChange={(value) =>
+								onPrimaryModelChange(value === CUSTOM_MODEL_CHOICE ? "" : value)
+							}
+							formatModelLabel={formatModelLabel}
+						/>
 					</div>
 				) : null}
 			</div>

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -138,10 +138,13 @@ import { AddProviderDialog } from "@/hosted/v2/ai-providers/add-provider-dialog"
 import { useAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import { AuthBadge, ProviderTypeChip } from "@/hosted/v2/ai-providers/ai-providers-ui";
 import { authCardLabel } from "@/hosted/v2/ai-providers/auth-card-label";
+import { CatalogModelSelect } from "@/hosted/v2/ai-providers/catalog-model-select";
 import {
+	CUSTOM_MODEL_CHOICE,
 	dedupeProviderIds,
 	firstModelForProvider,
 	MANAGED_AI_CHOICE,
+	MANAGED_AI_CHOICE_LABEL,
 	MANAGED_DEFAULT_MODEL_CHOICE,
 	MANAGED_PROVIDER_ID,
 	modelIdsForProvider,
@@ -189,7 +192,6 @@ const DEPLOY_PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-
 const THREE_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2 lg:grid-cols-3";
 const TWO_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2";
 const RUNTIME_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2";
-const CUSTOM_MODEL_CHOICE = "__custom__";
 const EMPTY_WALLET_TOP_UP_CONTEXT: WalletTopUpContext = {
 	initialAmountCents: null,
 	refundDebtCredits: null,
@@ -1624,7 +1626,7 @@ function PrimaryModelPicker({
 	const modelChoice = catalogModelIds.includes(primaryModel) ? primaryModel : CUSTOM_MODEL_CHOICE;
 	const primaryProviderItems = [
 		...(selectedProviderChoices.includes(MANAGED_AI_CHOICE)
-			? [{ value: MANAGED_AI_CHOICE, label: "Managed by Clawdi" }]
+			? [{ value: MANAGED_AI_CHOICE, label: MANAGED_AI_CHOICE_LABEL }]
 			: []),
 		...customProviders
 			.filter((provider) => selectedProviderChoices.includes(provider.provider_id))
@@ -1632,10 +1634,6 @@ function PrimaryModelPicker({
 				value: provider.provider_id,
 				label: provider.label ?? provider.provider_id,
 			})),
-	];
-	const catalogModelItems = [
-		...catalogModelIds.map((model) => ({ value: model, label: model })),
-		{ value: CUSTOM_MODEL_CHOICE, label: "Custom model" },
 	];
 	return (
 		<div className="mt-4 flex max-w-2xl flex-col gap-3 rounded-lg border bg-muted/20 p-3">
@@ -1655,7 +1653,7 @@ function PrimaryModelPicker({
 						<SelectContent>
 							<SelectGroup>
 								{selectedProviderChoices.includes(MANAGED_AI_CHOICE) ? (
-									<SelectItem value={MANAGED_AI_CHOICE}>Managed by Clawdi</SelectItem>
+									<SelectItem value={MANAGED_AI_CHOICE}>{MANAGED_AI_CHOICE_LABEL}</SelectItem>
 								) : null}
 								{customProviders
 									.filter((provider) => selectedProviderChoices.includes(provider.provider_id))
@@ -1671,28 +1669,14 @@ function PrimaryModelPicker({
 				{catalogModelIds.length > 0 ? (
 					<div className="flex flex-col gap-1.5">
 						<Label htmlFor="deploy-catalog-model">Catalog model</Label>
-						<Select
-							items={catalogModelItems}
+						<CatalogModelSelect
+							id="deploy-catalog-model"
+							modelIds={catalogModelIds}
 							value={modelChoice}
-							onValueChange={(value) => {
-								if (!value) return;
-								onPrimaryModelChange(value === CUSTOM_MODEL_CHOICE ? "" : value);
-							}}
-						>
-							<SelectTrigger id="deploy-catalog-model" className="w-full">
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								<SelectGroup>
-									{catalogModelIds.map((model) => (
-										<SelectItem key={model} value={model}>
-											{model === MANAGED_DEFAULT_MODEL_CHOICE ? "Hosted default (Luna)" : model}
-										</SelectItem>
-									))}
-									<SelectItem value={CUSTOM_MODEL_CHOICE}>Custom model</SelectItem>
-								</SelectGroup>
-							</SelectContent>
-						</Select>
+							onValueChange={(value) =>
+								onPrimaryModelChange(value === CUSTOM_MODEL_CHOICE ? "" : value)
+							}
+						/>
 					</div>
 				) : null}
 			</div>

--- a/apps/web/src/hosted/v2/ai-providers/catalog-model-select.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/catalog-model-select.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { CatalogModelSelect } from "@/hosted/v2/ai-providers/catalog-model-select";
+import {
+	MANAGED_DEFAULT_MODEL_CHOICE,
+	MANAGED_DEFAULT_MODEL_CHOICE_LABEL,
+} from "@/hosted/v2/ai-providers/model-binding";
+
+test("renders the hosted default as a friendly visible catalog model label", () => {
+	const markup = renderToStaticMarkup(
+		createElement(CatalogModelSelect, {
+			id: "catalog-model",
+			modelIds: [MANAGED_DEFAULT_MODEL_CHOICE],
+			value: MANAGED_DEFAULT_MODEL_CHOICE,
+			onValueChange: () => {},
+		}),
+	);
+	const visibleValue = markup.match(/data-slot="select-value"[^>]*>([^<]*)<\/span>/)?.[1];
+
+	expect(visibleValue).toBe(MANAGED_DEFAULT_MODEL_CHOICE_LABEL);
+	expect(visibleValue).not.toBe(MANAGED_DEFAULT_MODEL_CHOICE);
+});

--- a/apps/web/src/hosted/v2/ai-providers/catalog-model-select.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/catalog-model-select.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import {
+	Select,
+	SelectContent,
+	SelectGroup,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { modelChoiceOptions } from "@/hosted/v2/ai-providers/model-binding";
+
+export function CatalogModelSelect({
+	id,
+	modelIds,
+	value,
+	onValueChange,
+	formatModelLabel,
+}: {
+	id: string;
+	modelIds: readonly string[];
+	value: string;
+	onValueChange: (value: string) => void;
+	formatModelLabel?: (model: string) => string;
+}) {
+	const items = modelChoiceOptions(modelIds, formatModelLabel);
+
+	return (
+		<Select
+			items={items}
+			value={value}
+			onValueChange={(nextValue) => {
+				if (nextValue) onValueChange(nextValue);
+			}}
+		>
+			<SelectTrigger id={id} className="w-full" data-hosted="true" data-v2="true">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				<SelectGroup>
+					{items.map((item) => (
+						<SelectItem key={item.value} value={item.value}>
+							{item.label}
+						</SelectItem>
+					))}
+				</SelectGroup>
+			</SelectContent>
+		</Select>
+	);
+}

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
+	CUSTOM_MODEL_CHOICE,
+	CUSTOM_MODEL_CHOICE_LABEL,
 	firstModelForProvider,
 	MANAGED_AI_CHOICE,
+	MANAGED_AI_CHOICE_LABEL,
 	MANAGED_DEFAULT_MODEL_CHOICE,
+	MANAGED_DEFAULT_MODEL_CHOICE_LABEL,
+	modelChoiceOptions,
 	modelIdsForProvider,
 } from "@/hosted/v2/ai-providers/model-binding";
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
@@ -34,5 +39,16 @@ describe("model binding", () => {
 		];
 
 		expect(firstModelForProvider("openai-main", providers)).toBe("gpt-5.5");
+	});
+
+	test("builds friendly labels for reserved model choices", () => {
+		expect(modelChoiceOptions([MANAGED_DEFAULT_MODEL_CHOICE, MANAGED_AI_CHOICE])).toEqual([
+			{
+				value: MANAGED_DEFAULT_MODEL_CHOICE,
+				label: MANAGED_DEFAULT_MODEL_CHOICE_LABEL,
+			},
+			{ value: MANAGED_AI_CHOICE, label: MANAGED_AI_CHOICE_LABEL },
+			{ value: CUSTOM_MODEL_CHOICE, label: CUSTOM_MODEL_CHOICE_LABEL },
+		]);
 	});
 });

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.ts
@@ -2,8 +2,17 @@ import { CLAWDI_MANAGED_PROVIDER_IDS, CLAWDI_MANAGED_V2_PROVIDER_ID } from "@cla
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 
 export const MANAGED_AI_CHOICE = "__managed__";
+export const MANAGED_AI_CHOICE_LABEL = "Managed by Clawdi";
 export const MANAGED_PROVIDER_ID = CLAWDI_MANAGED_V2_PROVIDER_ID;
 export const MANAGED_DEFAULT_MODEL_CHOICE = "__hosted_default__";
+export const MANAGED_DEFAULT_MODEL_CHOICE_LABEL = "Hosted default (Luna)";
+export const CUSTOM_MODEL_CHOICE = "__custom__";
+export const CUSTOM_MODEL_CHOICE_LABEL = "Custom model";
+
+export type ModelChoiceOption = {
+	value: string;
+	label: string;
+};
 
 export type PrimaryModelRef = {
 	provider_id: string;
@@ -86,6 +95,32 @@ export function modelIdsForProvider(choice: string, providers: readonly AiProvid
 export function firstModelForProvider(choice: string, providers: readonly AiProvider[]): string {
 	const [first] = modelIdsForProvider(choice, providers);
 	return first ?? (choice === MANAGED_AI_CHOICE ? MANAGED_DEFAULT_MODEL_CHOICE : "");
+}
+
+export function modelChoiceLabel(
+	choice: string,
+	formatModelLabel: (model: string) => string = (model) => model,
+): string {
+	if (choice === MANAGED_DEFAULT_MODEL_CHOICE) return MANAGED_DEFAULT_MODEL_CHOICE_LABEL;
+	if (choice === MANAGED_AI_CHOICE) return MANAGED_AI_CHOICE_LABEL;
+	if (choice === CUSTOM_MODEL_CHOICE) return CUSTOM_MODEL_CHOICE_LABEL;
+	return formatModelLabel(choice);
+}
+
+export function modelChoiceOptions(
+	modelIds: readonly string[],
+	formatModelLabel?: (model: string) => string,
+): ModelChoiceOption[] {
+	return [
+		...modelIds.map((model) => ({
+			value: model,
+			label: modelChoiceLabel(model, formatModelLabel),
+		})),
+		{
+			value: CUSTOM_MODEL_CHOICE,
+			label: CUSTOM_MODEL_CHOICE_LABEL,
+		},
+	];
 }
 
 export function normalizeSelectedProviderIds(


### PR DESCRIPTION
## Summary
- render Hosted default (Luna) for the managed hosted-default model value in deploy and agent settings
- share catalog model options so SelectValue and menu items use friendly labels for every reserved choice without changing submitted values
- add a component regression test for the visible selected label

## Verification
- bun run --cwd apps/web test
- bun run --cwd apps/web typecheck
- bun run --cwd apps/web lint