### PR TITLE
fix(runtime): stabilize managed provider identity

### DIFF
--- a/backend/app/services/managed_ai_provider.py
+++ b/backend/app/services/managed_ai_provider.py
@@ -51,6 +51,15 @@ def is_v2_deployment_managed_provider_id(provider_id: str) -> bool:
     return _V2_DEPLOYMENT_ID_RE.fullmatch(deployment_id) is not None
 
 
+def v2_deployment_managed_provider_id(deployment_id: str) -> str | None:
+    """Return the credential identity for a numeric hosted deployment id."""
+
+    if _V2_DEPLOYMENT_ID_RE.fullmatch(deployment_id) is None:
+        return None
+    provider_id = f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}{deployment_id}"
+    return provider_id if len(provider_id) <= V2_MANAGED_AI_PROVIDER_MAX_ID_LENGTH else None
+
+
 def is_v2_managed_provider_id(provider_id: str) -> bool:
     return provider_id in V2_MANAGED_AI_PROVIDER_IDS or is_v2_deployment_managed_provider_id(
         provider_id
@@ -59,6 +68,17 @@ def is_v2_managed_provider_id(provider_id: str) -> bool:
 
 def is_managed_provider_id(provider_id: str) -> bool:
     return provider_id == V1_MANAGED_AI_PROVIDER_ID or is_v2_managed_provider_id(provider_id)
+
+
+def runtime_managed_provider_id(provider_id: str) -> str:
+    """Return the stable agent-facing id for a managed provider binding."""
+
+    return (
+        V2_MANAGED_AI_PROVIDER_ID
+        if provider_id == V2_MANAGED_AI_PROVIDER_ID
+        or is_v2_deployment_managed_provider_id(provider_id)
+        else provider_id
+    )
 
 
 def managed_provider_api_mode(provider_id: str) -> str | None:

--- a/backend/app/services/managed_ai_provider.py
+++ b/backend/app/services/managed_ai_provider.py
@@ -12,6 +12,8 @@ from app.models.ai_provider import AiProvider, AiProviderAuthPayload
 from app.models.user import User
 from app.services.vault_crypto import encrypt
 
+# Agent-facing alias only. Credential and catalog source rows keep their v2 ids below.
+CLAWDI_MANAGED_PROVIDER_ID = "clawdi"
 V1_MANAGED_AI_PROVIDER_ID = "clawdi-managed"
 V1_MANAGED_AI_PROVIDER_API_MODE = "openai_responses"
 V2_MANAGED_AI_PROVIDER_ID = "clawdi-v2"
@@ -74,9 +76,8 @@ def runtime_managed_provider_id(provider_id: str) -> str:
     """Return the stable agent-facing id for a managed provider binding."""
 
     return (
-        V2_MANAGED_AI_PROVIDER_ID
-        if provider_id == V2_MANAGED_AI_PROVIDER_ID
-        or is_v2_deployment_managed_provider_id(provider_id)
+        CLAWDI_MANAGED_PROVIDER_ID
+        if provider_id == CLAWDI_MANAGED_PROVIDER_ID or is_v2_managed_provider_id(provider_id)
         else provider_id
     )
 

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -40,6 +40,8 @@ from app.schemas.runtime import (
 )
 from app.services.channels import channel_runtime_account_key, channel_runtime_placeholder_token
 from app.services.managed_ai_provider import (
+    CLAWDI_MANAGED_PROVIDER_ID,
+    V2_LEGACY_MANAGED_AI_PROVIDER_ID,
     V2_MANAGED_AI_PROVIDER_ID,
     is_managed_provider_id,
     managed_provider_api_mode,
@@ -480,7 +482,14 @@ def _agent_runtime_binding(runtime: dict[str, Any]) -> dict[str, Any]:
         runtime_managed_provider_id(provider_id) for provider_id in runtime["provider_ids"]
     ]
     if len(provider_ids) != len(set(provider_ids)):
-        raise RuntimeSourceError("multiple provider bindings project to one agent provider")
+        duplicate = next(
+            provider_id
+            for index, provider_id in enumerate(provider_ids)
+            if provider_id in provider_ids[:index]
+        )
+        raise RuntimeSourceError(
+            f"multiple provider bindings project to agent provider {duplicate}"
+        )
     projected = {**runtime, "provider_ids": provider_ids}
     primary_model = runtime.get("primary_model")
     if isinstance(primary_model, dict):
@@ -510,12 +519,21 @@ def _provider_source_id(
     deployment_id: str,
     bound_provider_id: str,
 ) -> str:
-    if bound_provider_id != V2_MANAGED_AI_PROVIDER_ID:
+    """Resolve an agent alias to the deployment-scoped credential/catalog row."""
+
+    if bound_provider_id not in {
+        CLAWDI_MANAGED_PROVIDER_ID,
+        V2_MANAGED_AI_PROVIDER_ID,
+    }:
         return bound_provider_id
     deployment_provider_id = v2_deployment_managed_provider_id(deployment_id)
     if deployment_provider_id is not None and (user_id, deployment_provider_id) in batch.providers:
         return deployment_provider_id
-    return bound_provider_id
+    if (user_id, V2_MANAGED_AI_PROVIDER_ID) in batch.providers:
+        return V2_MANAGED_AI_PROVIDER_ID
+    if (user_id, V2_LEGACY_MANAGED_AI_PROVIDER_ID) in batch.providers:
+        return V2_LEGACY_MANAGED_AI_PROVIDER_ID
+    return V2_MANAGED_AI_PROVIDER_ID
 
 
 def _selected_auth_payload(

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -40,8 +40,11 @@ from app.schemas.runtime import (
 )
 from app.services.channels import channel_runtime_account_key, channel_runtime_placeholder_token
 from app.services.managed_ai_provider import (
+    V2_MANAGED_AI_PROVIDER_ID,
     is_managed_provider_id,
     managed_provider_api_mode,
+    runtime_managed_provider_id,
+    v2_deployment_managed_provider_id,
 )
 from app.services.vault_crypto import decrypt
 
@@ -222,6 +225,8 @@ def render_runtime_source(
             "Hosted runtime CLI package spec is invalid or below the minimum version"
         ) from exc
     runtime_name, runtime = _runtime(state.runtimes)
+    bound_runtime_provider_ids = list(runtime["provider_ids"])
+    runtime = _agent_runtime_binding(runtime)
     dashboard_auth = system.hermesDashboardAuth
     if runtime_name == "hermes" and dashboard_auth is None:
         raise RuntimeSourceError(
@@ -242,19 +247,35 @@ def render_runtime_source(
     secret_sources: dict[str, dict[str, str]] = {}
     secret_materials: list[RuntimeSecretMaterial] = []
     codex_tool = tools.codex
-    provider_ids = set(runtime["provider_ids"])
-    provider_ids.add(codex_tool.provider_id)
+    codex_agent_provider_id = runtime_managed_provider_id(codex_tool.provider_id)
+    provider_sources: dict[str, str] = {}
+    for bound_provider_id in [*bound_runtime_provider_ids, codex_tool.provider_id]:
+        agent_provider_id = runtime_managed_provider_id(bound_provider_id)
+        source_provider_id = _provider_source_id(
+            batch,
+            user_id=user_id,
+            deployment_id=state.deployment_id,
+            bound_provider_id=bound_provider_id,
+        )
+        existing_source = provider_sources.get(agent_provider_id)
+        if existing_source is not None and existing_source != source_provider_id:
+            raise RuntimeSourceError(
+                f"multiple provider bindings project to agent provider {agent_provider_id}"
+            )
+        provider_sources[agent_provider_id] = source_provider_id
     provider_material: dict[str, dict[str, Any]] = {}
-    for provider_id in sorted(provider_ids):
-        provider = batch.providers.get((user_id, provider_id))
+    runtime_provider_ids = set(runtime["provider_ids"])
+    for agent_provider_id, source_provider_id in sorted(provider_sources.items()):
+        provider = batch.providers.get((user_id, source_provider_id))
+        is_codex_provider = agent_provider_id == codex_agent_provider_id
         if provider is None:
-            if provider_id == codex_tool.provider_id:
+            if is_codex_provider:
                 raise RuntimeSourceError("Hosted Codex tool provider is missing or archived")
-            consumer = runtime_name if provider_id in runtime["provider_ids"] else "codex tool"
-            provider_material[provider_id] = _unhealthy_provider(provider_id, consumer)
+            consumer = runtime_name if agent_provider_id in runtime_provider_ids else "codex tool"
+            provider_material[agent_provider_id] = _unhealthy_provider(agent_provider_id, consumer)
             continue
         payload = _selected_auth_payload(batch, provider)
-        if provider_id == codex_tool.provider_id and (
+        if is_codex_provider and (
             provider.managed_by != "clawdi"
             or payload is None
             or payload.kind != "api_key"
@@ -265,20 +286,20 @@ def render_runtime_source(
             )
         secret_ref = (
             _CODEX_TOOL_SECRET_REF
-            if payload is not None and provider_id == codex_tool.provider_id
-            else _provider_secret_ref(provider_id)
+            if payload is not None and is_codex_provider
+            else _provider_secret_ref(source_provider_id)
             if payload is not None
             else None
         )
         provider_entry = _provider_entry(provider, secret_ref=secret_ref)
-        if provider_id == codex_tool.provider_id and (
+        if is_codex_provider and (
             provider_entry.get("apiMode") not in _CODEX_PROVIDER_SOURCE_API_MODES
             or provider_entry.get("runtimeEnvName") != _MANAGED_PROVIDER_RUNTIME_ENV
         ):
             raise RuntimeSourceError(
                 "Hosted Codex tool provider must use a supported managed OpenAI projection"
             )
-        provider_material[provider_id] = provider_entry
+        provider_material[agent_provider_id] = provider_entry
         if payload is not None and secret_ref is not None:
             _add_secret_source(
                 secret_sources,
@@ -288,11 +309,7 @@ def render_runtime_source(
                     payload.encrypted_payload,
                     payload.nonce,
                     vault_key_identity,
-                    (
-                        "tool-codex-api-key"
-                        if provider_id == codex_tool.provider_id
-                        else "provider-api-key"
-                    ),
+                    ("tool-codex-api-key" if is_codex_provider else "provider-api-key"),
                 ),
             )
             secret_materials.append(
@@ -314,7 +331,7 @@ def render_runtime_source(
         mode="json",
     )
     codex_provider_input = {
-        **provider_material[codex_tool.provider_id],
+        **provider_material[codex_agent_provider_id],
         "apiMode": _CODEX_TOOL_API_MODE,
     }
     try:
@@ -325,7 +342,7 @@ def render_runtime_source(
         raise RuntimeSourceError("Hosted Codex tool provider projection is invalid") from exc
     terminal_tooling = {
         "codex": {
-            **codex_tool.model_dump(mode="json"),
+            **_agent_codex_tool(codex_tool.model_dump(mode="json")),
             "provider": codex_provider,
         }
     }
@@ -456,6 +473,49 @@ def _runtime(value: dict | None) -> tuple[HostedRuntimeName, dict[str, Any]]:
         raise RuntimeSourceError(f"hosted runtime state for {name} is invalid") from exc
     runtime_name: HostedRuntimeName = "hermes" if name == "hermes" else "openclaw"
     return runtime_name, desired.model_dump(exclude_none=True, mode="json")
+
+
+def _agent_runtime_binding(runtime: dict[str, Any]) -> dict[str, Any]:
+    provider_ids = [
+        runtime_managed_provider_id(provider_id) for provider_id in runtime["provider_ids"]
+    ]
+    if len(provider_ids) != len(set(provider_ids)):
+        raise RuntimeSourceError("multiple provider bindings project to one agent provider")
+    projected = {**runtime, "provider_ids": provider_ids}
+    primary_model = runtime.get("primary_model")
+    if isinstance(primary_model, dict):
+        projected["primary_model"] = {
+            **primary_model,
+            "provider_id": runtime_managed_provider_id(primary_model["provider_id"]),
+        }
+    return projected
+
+
+def _agent_codex_tool(codex_tool: dict[str, Any]) -> dict[str, Any]:
+    provider_id = runtime_managed_provider_id(codex_tool["provider_id"])
+    return {
+        **codex_tool,
+        "provider_id": provider_id,
+        "primary_model": {
+            **codex_tool["primary_model"],
+            "provider_id": provider_id,
+        },
+    }
+
+
+def _provider_source_id(
+    batch: RuntimeSourceBatch,
+    *,
+    user_id: UUID,
+    deployment_id: str,
+    bound_provider_id: str,
+) -> str:
+    if bound_provider_id != V2_MANAGED_AI_PROVIDER_ID:
+        return bound_provider_id
+    deployment_provider_id = v2_deployment_managed_provider_id(deployment_id)
+    if deployment_provider_id is not None and (user_id, deployment_provider_id) in batch.providers:
+        return deployment_provider_id
+    return bound_provider_id
 
 
 def _selected_auth_payload(

--- a/backend/app/services/sync_events.py
+++ b/backend/app/services/sync_events.py
@@ -79,7 +79,7 @@ from app.models.session import AgentEnvironment
 from app.models.user import User
 from app.schemas.runtime import HostedRuntimeTools, validate_hosted_runtime_desired_state
 from app.services.managed_ai_provider import (
-    V2_MANAGED_AI_PROVIDER_ID,
+    CLAWDI_MANAGED_PROVIDER_ID,
     is_v2_deployment_managed_provider_id,
     runtime_managed_provider_id,
     v2_deployment_managed_provider_id,
@@ -355,8 +355,8 @@ def _runtime_state_may_use_provider(state: HostedRuntimeState, provider_id: str)
         return False
     runtime_provider_ids = {runtime_managed_provider_id(value) for value in runtime.provider_ids}
     return (
-        V2_MANAGED_AI_PROVIDER_ID in runtime_provider_ids
-        or runtime_managed_provider_id(tools.codex.provider_id) == V2_MANAGED_AI_PROVIDER_ID
+        CLAWDI_MANAGED_PROVIDER_ID in runtime_provider_ids
+        or runtime_managed_provider_id(tools.codex.provider_id) == CLAWDI_MANAGED_PROVIDER_ID
     )
 
 

--- a/backend/app/services/sync_events.py
+++ b/backend/app/services/sync_events.py
@@ -78,6 +78,12 @@ from app.models.project_membership import ProjectMembership
 from app.models.session import AgentEnvironment
 from app.models.user import User
 from app.schemas.runtime import HostedRuntimeTools, validate_hosted_runtime_desired_state
+from app.services.managed_ai_provider import (
+    V2_MANAGED_AI_PROVIDER_ID,
+    is_v2_deployment_managed_provider_id,
+    runtime_managed_provider_id,
+    v2_deployment_managed_provider_id,
+)
 
 log = logging.getLogger(__name__)
 
@@ -341,7 +347,17 @@ def _runtime_state_may_use_provider(state: HostedRuntimeState, provider_id: str)
         tools = HostedRuntimeTools.model_validate(state.tools)
     except ValidationError:
         return False
-    return provider_id == tools.codex.provider_id
+    if provider_id == tools.codex.provider_id:
+        return True
+    if not is_v2_deployment_managed_provider_id(provider_id):
+        return False
+    if v2_deployment_managed_provider_id(state.deployment_id) != provider_id:
+        return False
+    runtime_provider_ids = {runtime_managed_provider_id(value) for value in runtime.provider_ids}
+    return (
+        V2_MANAGED_AI_PROVIDER_ID in runtime_provider_ids
+        or runtime_managed_provider_id(tools.codex.provider_id) == V2_MANAGED_AI_PROVIDER_ID
+    )
 
 
 async def bump_skills_revision(

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -14,6 +14,8 @@ from app.models.api_key import ApiKey
 from app.models.hosted_runtime import HostedRuntimeState
 from app.services import sync_events
 from app.services.managed_ai_provider import (
+    CLAWDI_MANAGED_PROVIDER_ID,
+    V1_MANAGED_AI_PROVIDER_ID,
     V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX,
     V2_LEGACY_MANAGED_AI_PROVIDER_ID,
     V2_MANAGED_AI_PROVIDER_API_MODE,
@@ -47,14 +49,25 @@ def test_v1_provider_mode_resolution_does_not_accept_deployment_scoped_ids():
     assert managed_provider_api_mode(provider_id) is None
 
 
-def test_deployment_managed_provider_uses_stable_agent_facing_id():
+@pytest.mark.parametrize(
+    "provider_id",
+    [
+        V2_MANAGED_AI_PROVIDER_ID,
+        V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+        f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}42",
+        CLAWDI_MANAGED_PROVIDER_ID,
+    ],
+)
+def test_managed_v2_bindings_use_bare_agent_facing_id(provider_id: str):
+    assert runtime_managed_provider_id(provider_id) == CLAWDI_MANAGED_PROVIDER_ID
+
+
+def test_agent_facing_managed_id_is_not_a_credential_identity():
     provider_id = v2_deployment_managed_provider_id("42")
 
     assert provider_id == f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}42"
-    assert runtime_managed_provider_id(provider_id) == V2_MANAGED_AI_PROVIDER_ID
-    assert runtime_managed_provider_id(V2_LEGACY_MANAGED_AI_PROVIDER_ID) == (
-        V2_LEGACY_MANAGED_AI_PROVIDER_ID
-    )
+    assert not is_v2_managed_provider_id(CLAWDI_MANAGED_PROVIDER_ID)
+    assert runtime_managed_provider_id(V1_MANAGED_AI_PROVIDER_ID) == V1_MANAGED_AI_PROVIDER_ID
 
 
 @pytest.mark.parametrize("deployment_id", ["", "0", "01", "invalid", " 42"])

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -20,6 +20,8 @@ from app.services.managed_ai_provider import (
     V2_MANAGED_AI_PROVIDER_ID,
     is_v2_managed_provider_id,
     managed_provider_api_mode,
+    runtime_managed_provider_id,
+    v2_deployment_managed_provider_id,
 )
 from tests.conftest import create_env_with_project
 
@@ -43,6 +45,23 @@ def test_v1_provider_mode_resolution_does_not_accept_deployment_scoped_ids():
 
     assert is_v2_managed_provider_id(provider_id)
     assert managed_provider_api_mode(provider_id) is None
+
+
+def test_deployment_managed_provider_uses_stable_agent_facing_id():
+    provider_id = v2_deployment_managed_provider_id("42")
+
+    assert provider_id == f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}42"
+    assert runtime_managed_provider_id(provider_id) == V2_MANAGED_AI_PROVIDER_ID
+    assert runtime_managed_provider_id(V2_LEGACY_MANAGED_AI_PROVIDER_ID) == (
+        V2_LEGACY_MANAGED_AI_PROVIDER_ID
+    )
+
+
+@pytest.mark.parametrize("deployment_id", ["", "0", "01", "invalid", " 42"])
+def test_deployment_managed_provider_rejects_noncanonical_deployment_id(
+    deployment_id: str,
+):
+    assert v2_deployment_managed_provider_id(deployment_id) is None
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_runtime_manifest.py
+++ b/backend/tests/test_runtime_manifest.py
@@ -37,6 +37,7 @@ from app.schemas.runtime import (
 )
 from app.services import sync_events
 from app.services.audit import _sanitize_audit_details
+from app.services.managed_ai_provider import CLAWDI_MANAGED_PROVIDER_ID
 from app.services.runtime_source import (
     RUNTIME_BUNDLE_V2_MEDIA_TYPE,
     expected_runtime_bundle_v2_etag,
@@ -379,7 +380,9 @@ async def test_runtime_only_bundle_is_explicitly_unmanaged(
     assert runtime["provider_ids"] == []
     assert "primary_model" not in runtime
     assert bundle["manifest"]["providers"] == {}
-    assert bundle["manifest"]["terminalTooling"]["codex"]["provider_id"] == ("clawdi-managed-v2")
+    assert bundle["manifest"]["terminalTooling"]["codex"]["provider_id"] == (
+        CLAWDI_MANAGED_PROVIDER_ID
+    )
     assert bundle["channelBindings"] == []
     assert bundle["secretValues"] == {"tool.codex.apiKey": "sk-codex-tool"}
 
@@ -852,7 +855,16 @@ async def test_admin_upsert_runtime_state_and_manifest_omit_channels(
     assert manifest["locale"] == TEST_LOCALE
     assert set(manifest["locale"]) == {"language", "timezone"}
     assert manifest["system"] == TEST_SYSTEM
-    assert manifest["runtimes"]["openclaw"] == expected["runtimes"]["openclaw"]
+    expected_runtime = expected["runtimes"]["openclaw"]
+    assert expected_runtime["provider_ids"] == ["clawdi-managed-v2"]
+    assert manifest["runtimes"]["openclaw"] == {
+        **expected_runtime,
+        "provider_ids": [CLAWDI_MANAGED_PROVIDER_ID],
+        "primary_model": {
+            **expected_runtime["primary_model"],
+            "provider_id": CLAWDI_MANAGED_PROVIDER_ID,
+        },
+    }
     assert "personality" not in manifest
     assert manifest["clawdiCli"] == {
         "source": "npm:clawdi",
@@ -2681,7 +2693,7 @@ async def test_runtime_manifest_projects_mcp_and_tools_desired_state(
         "catalog": "clawdi-default",
         "enabled": ["memory", "connectors"],
     }
-    assert manifest["terminalTooling"]["codex"]["provider_id"] == "clawdi-managed-v2"
+    assert manifest["terminalTooling"]["codex"]["provider_id"] == CLAWDI_MANAGED_PROVIDER_ID
     assert "channels" not in manifest
 
 
@@ -3967,7 +3979,7 @@ async def test_runtime_manifest_projects_provider_secret_values_for_managed_acco
     assert response.status_code == 200, response.text
     payload = response.json()
     issued_at = payload["manifest"]["issuedAt"]
-    assert payload["manifest"]["providers"]["clawdi-managed-v2"] == {
+    assert payload["manifest"]["providers"][CLAWDI_MANAGED_PROVIDER_ID] == {
         "kind": "openai-compatible",
         "type": "custom_openai_compatible",
         "baseUrl": "https://sub2api.test/v1",
@@ -3977,9 +3989,11 @@ async def test_runtime_manifest_projects_provider_secret_values_for_managed_acco
         "runtimeEnvName": "OPENAI_API_KEY",
         "apiKeySecretRef": "tool.codex.apiKey",
     }
-    assert payload["manifest"]["runtimes"]["openclaw"]["provider_ids"] == ["clawdi-managed-v2"]
+    assert payload["manifest"]["runtimes"]["openclaw"]["provider_ids"] == [
+        CLAWDI_MANAGED_PROVIDER_ID
+    ]
     assert payload["manifest"]["runtimes"]["openclaw"]["primary_model"] == {
-        "provider_id": "clawdi-managed-v2",
+        "provider_id": CLAWDI_MANAGED_PROVIDER_ID,
         "model": "gpt-5.5",
     }
     assert payload["secretValues"] == {"tool.codex.apiKey": "sk-test-provider"}
@@ -4034,6 +4048,86 @@ async def test_runtime_manifest_projects_provider_secret_values_for_managed_acco
     )
     assert rotated.json()["manifest"]["issuedAt"] == issued_at
     assert rotated.json()["secretValues"] == {"tool.codex.apiKey": "sk-rotated-provider"}
+
+
+@pytest.mark.asyncio
+async def test_runtime_manifest_resolves_bare_managed_alias_to_deployment_catalog(
+    admin_client,
+    db_session,
+    seed_user,
+):
+    env = await create_env_with_project(
+        db_session,
+        user_id=seed_user.id,
+        machine_id=f"provider-alias-{uuid4().hex[:8]}",
+        machine_name="Runtime managed provider alias",
+        agent_type="openclaw",
+    )
+    internal_provider_id = "clawdi-v2-deployment-42"
+    ciphertext, nonce = encrypt("sk-deployment-managed")
+    models = [{"id": "gpt-5.5", "context_window": 272000}]
+    db_session.add_all(
+        [
+            AiProvider(
+                owner_user_id=seed_user.id,
+                provider_id=internal_provider_id,
+                type="custom_openai_compatible",
+                base_url="https://sub2api.test/v1",
+                models=models,
+                api_mode="openai_chat",
+                auth_type="api_key",
+                auth_metadata={"source": "managed"},
+                managed_by="clawdi",
+                runtime_env_name="CLAWDI_MANAGED_OPENAI_API_KEY",
+            ),
+            AiProviderAuthPayload(
+                owner_user_id=seed_user.id,
+                provider_id=internal_provider_id,
+                auth_profile="default",
+                kind="api_key",
+                source="managed",
+                encrypted_payload=ciphertext,
+                nonce=nonce,
+            ),
+        ]
+    )
+    await db_session.commit()
+    primary_model = {
+        "provider_id": CLAWDI_MANAGED_PROVIDER_ID,
+        "model": "gpt-5.5",
+    }
+    await _write_runtime_state(
+        admin_client,
+        str(env.id),
+        deployment_id="42",
+        runtimes=_runtime_state(
+            provider_ids=[CLAWDI_MANAGED_PROVIDER_ID],
+            primary_model=primary_model,
+        ),
+        tools={
+            "codex": {
+                "enabled": True,
+                "provider_id": CLAWDI_MANAGED_PROVIDER_ID,
+                "primary_model": primary_model,
+            }
+        },
+    )
+
+    api_key = ApiKey(user_id=seed_user.id, environment_id=env.id, label="hosted")
+    async with await _runtime_client(db_session, seed_user, api_key) as client:
+        response = await client.get("/v1/runtime/manifest")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    manifest = payload["manifest"]
+    assert manifest["runtimes"]["openclaw"]["provider_ids"] == [CLAWDI_MANAGED_PROVIDER_ID]
+    assert manifest["runtimes"]["openclaw"]["primary_model"] == primary_model
+    assert set(manifest["providers"]) == {CLAWDI_MANAGED_PROVIDER_ID}
+    assert manifest["providers"][CLAWDI_MANAGED_PROVIDER_ID]["models"] == models
+    assert manifest["terminalTooling"]["codex"]["provider_id"] == (CLAWDI_MANAGED_PROVIDER_ID)
+    assert internal_provider_id not in json.dumps(manifest)
+    assert payload["secretValues"] == {"tool.codex.apiKey": "sk-deployment-managed"}
 
 
 @pytest.mark.asyncio
@@ -4161,7 +4255,9 @@ async def test_admin_managed_provider_models_project_exact_hosted_wire_contract(
     app.dependency_overrides.clear()
 
     assert response.status_code == 200, response.text
-    projected_model = response.json()["manifest"]["providers"]["clawdi-managed-v2"]["models"][0]
+    projected_model = response.json()["manifest"]["providers"][CLAWDI_MANAGED_PROVIDER_ID][
+        "models"
+    ][0]
     assert projected_model == model
     assert set(projected_model) == {
         "id",

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -12,6 +12,7 @@ from app.models.channel import ChannelAccount, ChannelBotAgentLink
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.session import AgentEnvironment
 from app.schemas.runtime import HostedCodexProviderProjection
+from app.services.managed_ai_provider import V2_MANAGED_AI_PROVIDER_ID
 from app.services.runtime_source import (
     RuntimeSourceBatch,
     RuntimeSourceError,
@@ -206,6 +207,42 @@ def _add_prefix_colliding_channel(batch: RuntimeSourceBatch) -> None:
     batch.channels[ENV_ID] = (*batch.channels[ENV_ID], (account, link))
 
 
+def _use_deployment_scoped_managed_provider(
+    batch: RuntimeSourceBatch,
+    *,
+    bound_provider_id: str,
+) -> str:
+    deployment_provider_id = "clawdi-v2-deployment-42"
+    state = batch.rows[ENV_ID].state
+    assert state is not None
+    state.deployment_id = "42"
+    runtime = dict(state.runtimes["openclaw"])
+    runtime["provider_ids"] = [bound_provider_id]
+    runtime["primary_model"] = {
+        "provider_id": bound_provider_id,
+        "model": "gpt-test",
+    }
+    state.runtimes = {"openclaw": runtime}
+    state.tools = {
+        "codex": {
+            "enabled": True,
+            "provider_id": bound_provider_id,
+            "primary_model": {
+                "provider_id": bound_provider_id,
+                "model": "gpt-test",
+            },
+        }
+    }
+
+    provider = batch.providers.pop((USER_ID, "managed"))
+    provider.provider_id = deployment_provider_id
+    batch.providers[(USER_ID, deployment_provider_id)] = provider
+    auth = batch.auth_payloads.pop((USER_ID, "managed", "default"))
+    auth.provider_id = deployment_provider_id
+    batch.auth_payloads[(USER_ID, deployment_provider_id, "default")] = auth
+    return deployment_provider_id
+
+
 def _render(batch: RuntimeSourceBatch):
     return render_runtime_source(
         batch,
@@ -300,6 +337,39 @@ def test_shared_managed_provider_material_has_distinct_codex_wire_mode() -> None
     assert source.manifest["terminalTooling"]["codex"]["provider"]["apiMode"] == (
         "openai_responses"
     )
+
+
+@pytest.mark.parametrize(
+    "bound_provider_id",
+    [V2_MANAGED_AI_PROVIDER_ID, "clawdi-v2-deployment-42"],
+    ids=["stable-runtime-binding", "legacy-scoped-runtime-binding"],
+)
+def test_deployment_managed_provider_projects_stable_agent_identity(
+    bound_provider_id: str,
+) -> None:
+    batch = _batch()
+    deployment_provider_id = _use_deployment_scoped_managed_provider(
+        batch,
+        bound_provider_id=bound_provider_id,
+    )
+
+    source = _render(batch)
+    manifest = source.manifest
+
+    assert manifest["runtimes"]["openclaw"]["provider_ids"] == [V2_MANAGED_AI_PROVIDER_ID]
+    assert manifest["runtimes"]["openclaw"]["primary_model"] == {
+        "provider_id": V2_MANAGED_AI_PROVIDER_ID,
+        "model": "gpt-test",
+    }
+    assert set(manifest["providers"]) == {V2_MANAGED_AI_PROVIDER_ID}
+    assert manifest["providers"][V2_MANAGED_AI_PROVIDER_ID]["apiKeySecretRef"] == (
+        "tool.codex.apiKey"
+    )
+    assert manifest["terminalTooling"]["codex"]["provider_id"] == (V2_MANAGED_AI_PROVIDER_ID)
+    assert manifest["terminalTooling"]["codex"]["primary_model"]["provider_id"] == (
+        V2_MANAGED_AI_PROVIDER_ID
+    )
+    assert deployment_provider_id not in json.dumps(manifest)
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime
 from pathlib import Path
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 
@@ -12,7 +12,11 @@ from app.models.channel import ChannelAccount, ChannelBotAgentLink
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.session import AgentEnvironment
 from app.schemas.runtime import HostedCodexProviderProjection
-from app.services.managed_ai_provider import V2_MANAGED_AI_PROVIDER_ID
+from app.services.managed_ai_provider import (
+    CLAWDI_MANAGED_PROVIDER_ID,
+    V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+    V2_MANAGED_AI_PROVIDER_ID,
+)
 from app.services.runtime_source import (
     RuntimeSourceBatch,
     RuntimeSourceError,
@@ -207,12 +211,12 @@ def _add_prefix_colliding_channel(batch: RuntimeSourceBatch) -> None:
     batch.channels[ENV_ID] = (*batch.channels[ENV_ID], (account, link))
 
 
-def _use_deployment_scoped_managed_provider(
+def _use_managed_provider(
     batch: RuntimeSourceBatch,
     *,
     bound_provider_id: str,
+    source_provider_id: str,
 ) -> str:
-    deployment_provider_id = "clawdi-v2-deployment-42"
     state = batch.rows[ENV_ID].state
     assert state is not None
     state.deployment_id = "42"
@@ -235,12 +239,12 @@ def _use_deployment_scoped_managed_provider(
     }
 
     provider = batch.providers.pop((USER_ID, "managed"))
-    provider.provider_id = deployment_provider_id
-    batch.providers[(USER_ID, deployment_provider_id)] = provider
+    provider.provider_id = source_provider_id
+    batch.providers[(USER_ID, source_provider_id)] = provider
     auth = batch.auth_payloads.pop((USER_ID, "managed", "default"))
-    auth.provider_id = deployment_provider_id
-    batch.auth_payloads[(USER_ID, deployment_provider_id, "default")] = auth
-    return deployment_provider_id
+    auth.provider_id = source_provider_id
+    batch.auth_payloads[(USER_ID, source_provider_id, "default")] = auth
+    return source_provider_id
 
 
 def _render(batch: RuntimeSourceBatch):
@@ -340,36 +344,106 @@ def test_shared_managed_provider_material_has_distinct_codex_wire_mode() -> None
 
 
 @pytest.mark.parametrize(
-    "bound_provider_id",
-    [V2_MANAGED_AI_PROVIDER_ID, "clawdi-v2-deployment-42"],
-    ids=["stable-runtime-binding", "legacy-scoped-runtime-binding"],
+    ("bound_provider_id", "source_provider_id"),
+    [
+        (CLAWDI_MANAGED_PROVIDER_ID, "clawdi-v2-deployment-42"),
+        (CLAWDI_MANAGED_PROVIDER_ID, V2_MANAGED_AI_PROVIDER_ID),
+        (CLAWDI_MANAGED_PROVIDER_ID, V2_LEGACY_MANAGED_AI_PROVIDER_ID),
+        (V2_MANAGED_AI_PROVIDER_ID, "clawdi-v2-deployment-42"),
+        ("clawdi-v2-deployment-42", "clawdi-v2-deployment-42"),
+        (V2_LEGACY_MANAGED_AI_PROVIDER_ID, V2_LEGACY_MANAGED_AI_PROVIDER_ID),
+    ],
+    ids=[
+        "agent-alias-scoped-source",
+        "agent-alias-base-source",
+        "agent-alias-legacy-source",
+        "stable-internal",
+        "deployment-scoped",
+        "legacy-internal",
+    ],
 )
-def test_deployment_managed_provider_projects_stable_agent_identity(
+def test_managed_v2_provider_projects_bare_agent_identity(
     bound_provider_id: str,
+    source_provider_id: str,
 ) -> None:
     batch = _batch()
-    deployment_provider_id = _use_deployment_scoped_managed_provider(
+    internal_provider_id = _use_managed_provider(
         batch,
         bound_provider_id=bound_provider_id,
+        source_provider_id=source_provider_id,
     )
 
     source = _render(batch)
     manifest = source.manifest
 
-    assert manifest["runtimes"]["openclaw"]["provider_ids"] == [V2_MANAGED_AI_PROVIDER_ID]
+    assert manifest["runtimes"]["openclaw"]["provider_ids"] == [CLAWDI_MANAGED_PROVIDER_ID]
     assert manifest["runtimes"]["openclaw"]["primary_model"] == {
+        "provider_id": CLAWDI_MANAGED_PROVIDER_ID,
+        "model": "gpt-test",
+    }
+    assert set(manifest["providers"]) == {CLAWDI_MANAGED_PROVIDER_ID}
+    assert manifest["providers"][CLAWDI_MANAGED_PROVIDER_ID]["apiKeySecretRef"] == (
+        "tool.codex.apiKey"
+    )
+    assert manifest["terminalTooling"]["codex"]["provider_id"] == CLAWDI_MANAGED_PROVIDER_ID
+    assert manifest["terminalTooling"]["codex"]["primary_model"]["provider_id"] == (
+        CLAWDI_MANAGED_PROVIDER_ID
+    )
+    assert internal_provider_id not in json.dumps(manifest)
+
+
+def test_bare_managed_alias_prefers_deployment_source_over_fallback_rows() -> None:
+    batch = _batch()
+    _use_managed_provider(
+        batch,
+        bound_provider_id=CLAWDI_MANAGED_PROVIDER_ID,
+        source_provider_id="clawdi-v2-deployment-42",
+    )
+    scoped_provider = batch.providers[(USER_ID, "clawdi-v2-deployment-42")]
+    scoped_provider.models = [{"id": "scoped-model"}]
+    for provider_id, model in [
+        (V2_MANAGED_AI_PROVIDER_ID, "base-model"),
+        (V2_LEGACY_MANAGED_AI_PROVIDER_ID, "legacy-model"),
+    ]:
+        batch.providers[(USER_ID, provider_id)] = AiProvider(
+            id=uuid4(),
+            owner_user_id=USER_ID,
+            provider_id=provider_id,
+            type=scoped_provider.type,
+            label=scoped_provider.label,
+            base_url=scoped_provider.base_url,
+            api_mode=scoped_provider.api_mode,
+            auth_type=scoped_provider.auth_type,
+            auth_metadata=scoped_provider.auth_metadata,
+            managed_by=scoped_provider.managed_by,
+            models=[{"id": model}],
+        )
+
+    manifest = _render(batch).manifest
+
+    assert manifest["providers"][CLAWDI_MANAGED_PROVIDER_ID]["models"] == [{"id": "scoped-model"}]
+
+
+def test_multiple_managed_bindings_cannot_collapse_to_one_agent_provider() -> None:
+    batch = _batch()
+    state = batch.rows[ENV_ID].state
+    assert state is not None
+    runtime = dict(state.runtimes["openclaw"])
+    runtime["provider_ids"] = [
+        V2_MANAGED_AI_PROVIDER_ID,
+        V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+    ]
+    runtime["primary_model"] = {
         "provider_id": V2_MANAGED_AI_PROVIDER_ID,
         "model": "gpt-test",
     }
-    assert set(manifest["providers"]) == {V2_MANAGED_AI_PROVIDER_ID}
-    assert manifest["providers"][V2_MANAGED_AI_PROVIDER_ID]["apiKeySecretRef"] == (
-        "tool.codex.apiKey"
-    )
-    assert manifest["terminalTooling"]["codex"]["provider_id"] == (V2_MANAGED_AI_PROVIDER_ID)
-    assert manifest["terminalTooling"]["codex"]["primary_model"]["provider_id"] == (
-        V2_MANAGED_AI_PROVIDER_ID
-    )
-    assert deployment_provider_id not in json.dumps(manifest)
+    state.runtimes = {"openclaw": runtime}
+
+    with pytest.raises(
+        RuntimeSourceError,
+        match="multiple provider bindings project to agent provider clawdi",
+    ):
+        _render(batch)
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_sync_events.py
+++ b/backend/tests/test_sync_events.py
@@ -29,6 +29,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.hosted_runtime import HostedRuntimeState
 from app.models.user import User
 from app.services import sync_events
+from app.services.managed_ai_provider import (
+    CLAWDI_MANAGED_PROVIDER_ID,
+    V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+    V2_MANAGED_AI_PROVIDER_ID,
+)
 
 pytestmark = pytest.mark.committed_db
 
@@ -281,15 +286,25 @@ def test_runtime_provider_usage_includes_independent_codex_tool_ref() -> None:
     assert sync_events._runtime_state_may_use_provider(state, "unrelated") is False
 
 
-def test_stable_runtime_provider_usage_resolves_deployment_credential_identity() -> None:
+@pytest.mark.parametrize(
+    "bound_provider_id",
+    [
+        CLAWDI_MANAGED_PROVIDER_ID,
+        V2_MANAGED_AI_PROVIDER_ID,
+        V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+    ],
+)
+def test_managed_runtime_provider_usage_resolves_deployment_credential_identity(
+    bound_provider_id: str,
+) -> None:
     state = HostedRuntimeState(
         deployment_id="42",
         runtimes={
             "openclaw": {
                 "enabled": True,
                 "providerMode": "configured",
-                "provider_ids": ["clawdi-v2"],
-                "primary_model": {"provider_id": "clawdi-v2", "model": "gpt-5.5"},
+                "provider_ids": [bound_provider_id],
+                "primary_model": {"provider_id": bound_provider_id, "model": "gpt-5.5"},
                 "install": {"source": "official"},
                 "services": {},
             }
@@ -297,8 +312,8 @@ def test_stable_runtime_provider_usage_resolves_deployment_credential_identity()
         tools={
             "codex": {
                 "enabled": True,
-                "provider_id": "clawdi-v2",
-                "primary_model": {"provider_id": "clawdi-v2", "model": "gpt-5.5"},
+                "provider_id": bound_provider_id,
+                "primary_model": {"provider_id": bound_provider_id, "model": "gpt-5.5"},
             }
         },
     )

--- a/backend/tests/test_sync_events.py
+++ b/backend/tests/test_sync_events.py
@@ -281,6 +281,32 @@ def test_runtime_provider_usage_includes_independent_codex_tool_ref() -> None:
     assert sync_events._runtime_state_may_use_provider(state, "unrelated") is False
 
 
+def test_stable_runtime_provider_usage_resolves_deployment_credential_identity() -> None:
+    state = HostedRuntimeState(
+        deployment_id="42",
+        runtimes={
+            "openclaw": {
+                "enabled": True,
+                "providerMode": "configured",
+                "provider_ids": ["clawdi-v2"],
+                "primary_model": {"provider_id": "clawdi-v2", "model": "gpt-5.5"},
+                "install": {"source": "official"},
+                "services": {},
+            }
+        },
+        tools={
+            "codex": {
+                "enabled": True,
+                "provider_id": "clawdi-v2",
+                "primary_model": {"provider_id": "clawdi-v2", "model": "gpt-5.5"},
+            }
+        },
+    )
+
+    assert sync_events._runtime_state_may_use_provider(state, "clawdi-v2-deployment-42") is True
+    assert sync_events._runtime_state_may_use_provider(state, "clawdi-v2-deployment-43") is False
+
+
 @pytest.mark.asyncio
 async def test_postgres_listener_delivers_remote_process_event(
     db_session: AsyncSession,

--- a/packages/cli/src/lib/ai-provider-projection.test.ts
+++ b/packages/cli/src/lib/ai-provider-projection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
 	type AiProviderCatalog,
+	CLAWDI_MANAGED_PROVIDER_ID,
 	CODEX_OAUTH_MODEL_CATALOG,
 	defaultAiProviderApiMode,
 	defaultAiProviderBaseUrl,
@@ -46,6 +47,57 @@ const codexOAuthCatalog: AiProviderCatalog = {
 };
 
 describe("AI provider projection", () => {
+	test("projects the bare managed provider alias with the managed endpoint and key env", () => {
+		const catalog: AiProviderCatalog = {
+			schema_version: 1,
+			providers: [
+				{
+					id: CLAWDI_MANAGED_PROVIDER_ID,
+					type: "custom_openai_compatible",
+					label: "Managed by Clawdi",
+					base_url: "https://managed.example.test/v1",
+					api_mode: "openai_chat",
+					auth: { type: "api_key", source: "managed" },
+					managed_by: "clawdi",
+					runtime_env_name: "CLAWDI_MANAGED_OPENAI_API_KEY",
+					models: [{ id: "managed-model" }],
+				},
+			],
+			defaults: { chat_provider_id: CLAWDI_MANAGED_PROVIDER_ID },
+		};
+		const primaryModel = {
+			provider_id: CLAWDI_MANAGED_PROVIDER_ID,
+			model: "managed-model",
+		};
+
+		const openclaw = buildAgentTargetProjection("openclaw", catalog, primaryModel);
+		expect(openclaw.provider_ids).toEqual([CLAWDI_MANAGED_PROVIDER_ID]);
+		expect(openclaw.primary_model).toEqual(primaryModel);
+		const openclawPatch = JSON.parse(openclaw.files[0]?.content ?? "{}") as {
+			agents?: { defaults?: { model?: { primary?: string } } };
+			models?: {
+				providers?: Record<string, { api?: string; apiKey?: { id?: string }; baseUrl?: string }>;
+			};
+		};
+		expect(openclawPatch.agents?.defaults?.model?.primary).toBe("clawdi/managed-model");
+		expect(openclawPatch.models?.providers?.[CLAWDI_MANAGED_PROVIDER_ID]).toMatchObject({
+			baseUrl: "https://managed.example.test/v1",
+			apiKey: { id: "CLAWDI_MANAGED_OPENAI_API_KEY" },
+		});
+		// openai_chat is OpenClaw's default custom-provider mode and is intentionally omitted.
+		expect(openclawPatch.models?.providers?.[CLAWDI_MANAGED_PROVIDER_ID]?.api).toBeUndefined();
+		expect(JSON.stringify(openclawPatch)).not.toContain("clawdi-v2");
+
+		const hermes = buildAgentTargetProjection("hermes", catalog, primaryModel);
+		expect(hermes.provider_ids).toEqual([CLAWDI_MANAGED_PROVIDER_ID]);
+		expect(hermes.files[0]?.content).toContain('provider: "custom:clawdi"');
+		expect(hermes.files[0]?.content).toContain('"clawdi":');
+		expect(hermes.files[0]?.content).toContain('api: "https://managed.example.test/v1"');
+		expect(hermes.files[0]?.content).toContain('transport: "chat_completions"');
+		expect(hermes.files[0]?.content).toContain('key_env: "CLAWDI_MANAGED_OPENAI_API_KEY"');
+		expect(hermes.files[0]?.content).not.toContain("clawdi-v2");
+	});
+
 	test("maps known BYOK OpenAI providers to all runtime targets without extra user fields", () => {
 		const openclaw = buildAgentTargetProjection("openclaw", byokOpenAiCatalog);
 		expect(openclaw.provider_ids).toEqual(["openai-main"]);

--- a/packages/cli/src/runtime/hosted-egress-profiles.ts
+++ b/packages/cli/src/runtime/hosted-egress-profiles.ts
@@ -1,8 +1,4 @@
-import {
-	CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
-	CLAWDI_MANAGED_V2_PROVIDER_ID,
-	isClawdiManagedV2ProviderId,
-} from "@clawdi/shared";
+import { CLAWDI_MANAGED_PROVIDER_ID, isClawdiManagedV2ProviderId } from "@clawdi/shared";
 import { MANAGED_EGRESS_PLACEHOLDER_VALUE } from "./egress-env";
 import { type EgressProfileInputBundle, egressProfileInputBundleSchema } from "./egress-profiles";
 
@@ -174,10 +170,9 @@ function managedProviderEgressProfileForProvider(
 	}
 	if (cleanString(provider.status) && cleanString(provider.status) !== "ok") return null;
 	const parsed = new URL(providerBaseUrl);
-	const profileProviderId =
-		isClawdiManagedV2ProviderId(providerId) && providerId !== CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID
-			? CLAWDI_MANAGED_V2_PROVIDER_ID
-			: providerId;
+	const profileProviderId = isClawdiManagedV2ProviderId(providerId)
+		? CLAWDI_MANAGED_PROVIDER_ID
+		: providerId;
 	return {
 		id:
 			profileProviderId === "default"

--- a/packages/cli/src/runtime/hosted-egress-profiles.ts
+++ b/packages/cli/src/runtime/hosted-egress-profiles.ts
@@ -1,3 +1,8 @@
+import {
+	CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
+	CLAWDI_MANAGED_V2_PROVIDER_ID,
+	isClawdiManagedV2ProviderId,
+} from "@clawdi/shared";
 import { MANAGED_EGRESS_PLACEHOLDER_VALUE } from "./egress-env";
 import { type EgressProfileInputBundle, egressProfileInputBundleSchema } from "./egress-profiles";
 
@@ -169,11 +174,15 @@ function managedProviderEgressProfileForProvider(
 	}
 	if (cleanString(provider.status) && cleanString(provider.status) !== "ok") return null;
 	const parsed = new URL(providerBaseUrl);
+	const profileProviderId =
+		isClawdiManagedV2ProviderId(providerId) && providerId !== CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID
+			? CLAWDI_MANAGED_V2_PROVIDER_ID
+			: providerId;
 	return {
 		id:
-			providerId === "default"
+			profileProviderId === "default"
 				? "managed-provider"
-				: `managed-provider-${profileIdSuffix(providerId)}`,
+				: `managed-provider-${profileIdSuffix(profileProviderId)}`,
 		enabled: true,
 		kind: "provider",
 		match: {

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -31,6 +31,8 @@ import type {
 } from "@clawdi/shared";
 import {
 	CLAWDI_MANAGED_V1_PROVIDER_ID,
+	CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
+	CLAWDI_MANAGED_V2_PROVIDER_ID,
 	isAiProviderApiMode,
 	isAiProviderType,
 	isClawdiManagedV2ProviderId,
@@ -1559,8 +1561,13 @@ function resolveManagedGatewayModelOverrides(
 			});
 			fetchCache.set(cacheKey, fetchResult);
 			if (fetchResult.status === "failed") {
+				const loggedProviderId =
+					isClawdiManagedV2ProviderId(target.providerId) &&
+					target.providerId !== CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID
+						? CLAWDI_MANAGED_V2_PROVIDER_ID
+						: target.providerId;
 				console.warn(
-					`managed model probe failed for ${runtimeName}/${target.providerId} at ${fetchResult.endpoint}: ${fetchResult.detail}; keeping configured seed`,
+					`managed model probe failed for ${runtimeName}/${loggedProviderId} at ${fetchResult.endpoint}: ${fetchResult.detail}; keeping configured seed`,
 				);
 			}
 		}
@@ -2005,11 +2012,12 @@ function agentTargetProjectionInput(
 		// TODO(#425): Remove legacy projection handling after hosted#892 is deployed
 		// everywhere and no dev/self-hosted binding still uses clawdi-managed-v2.
 		const id =
-			isClawdiManagedV2ProviderId(provider.id) ||
-			provider.id === CLAWDI_MANAGED_V1_PROVIDER_ID ||
-			provider.id.startsWith("clawdi-managed")
-				? provider.id
-				: CLAWDI_MANAGED_V1_PROVIDER_ID;
+			isClawdiManagedV2ProviderId(provider.id) &&
+			provider.id !== CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID
+				? CLAWDI_MANAGED_V2_PROVIDER_ID
+				: provider.id === CLAWDI_MANAGED_V1_PROVIDER_ID || provider.id.startsWith("clawdi-managed")
+					? provider.id
+					: CLAWDI_MANAGED_V1_PROVIDER_ID;
 		providerIdMap.set(provider.id, id);
 		return {
 			...provider,
@@ -2809,6 +2817,7 @@ function hermesHostedPluginProviderName(providerId: string): string {
 		.toLowerCase()
 		.replace(/[^a-z0-9]+/g, "-")
 		.replace(/^-+|-+$/g, "");
+	if (normalized.startsWith(`${HERMES_MODEL_PROVIDER_PLUGIN_NAME}-`)) return normalized;
 	return `${HERMES_MODEL_PROVIDER_PLUGIN_NAME}-${normalized || "provider"}`;
 }
 

--- a/packages/cli/src/runtime/manifest.ts
+++ b/packages/cli/src/runtime/manifest.ts
@@ -30,9 +30,8 @@ import type {
 	AiProviderType,
 } from "@clawdi/shared";
 import {
+	CLAWDI_MANAGED_PROVIDER_ID,
 	CLAWDI_MANAGED_V1_PROVIDER_ID,
-	CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
-	CLAWDI_MANAGED_V2_PROVIDER_ID,
 	isAiProviderApiMode,
 	isAiProviderType,
 	isClawdiManagedV2ProviderId,
@@ -1561,11 +1560,9 @@ function resolveManagedGatewayModelOverrides(
 			});
 			fetchCache.set(cacheKey, fetchResult);
 			if (fetchResult.status === "failed") {
-				const loggedProviderId =
-					isClawdiManagedV2ProviderId(target.providerId) &&
-					target.providerId !== CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID
-						? CLAWDI_MANAGED_V2_PROVIDER_ID
-						: target.providerId;
+				const loggedProviderId = isClawdiManagedV2ProviderId(target.providerId)
+					? CLAWDI_MANAGED_PROVIDER_ID
+					: target.providerId;
 				console.warn(
 					`managed model probe failed for ${runtimeName}/${loggedProviderId} at ${fetchResult.endpoint}: ${fetchResult.detail}; keeping configured seed`,
 				);
@@ -2009,15 +2006,11 @@ function agentTargetProjectionInput(
 	const providerIdMap = new Map<string, string>();
 	const providers = input.catalog.providers.map((provider) => {
 		if (provider.managed_by !== "clawdi") return provider;
-		// TODO(#425): Remove legacy projection handling after hosted#892 is deployed
-		// everywhere and no dev/self-hosted binding still uses clawdi-managed-v2.
-		const id =
-			isClawdiManagedV2ProviderId(provider.id) &&
-			provider.id !== CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID
-				? CLAWDI_MANAGED_V2_PROVIDER_ID
-				: provider.id === CLAWDI_MANAGED_V1_PROVIDER_ID || provider.id.startsWith("clawdi-managed")
-					? provider.id
-					: CLAWDI_MANAGED_V1_PROVIDER_ID;
+		const id = isClawdiManagedV2ProviderId(provider.id)
+			? CLAWDI_MANAGED_PROVIDER_ID
+			: provider.id === CLAWDI_MANAGED_V1_PROVIDER_ID || provider.id.startsWith("clawdi-managed")
+				? provider.id
+				: CLAWDI_MANAGED_V1_PROVIDER_ID;
 		providerIdMap.set(provider.id, id);
 		return {
 			...provider,
@@ -2817,7 +2810,12 @@ function hermesHostedPluginProviderName(providerId: string): string {
 		.toLowerCase()
 		.replace(/[^a-z0-9]+/g, "-")
 		.replace(/^-+|-+$/g, "");
-	if (normalized.startsWith(`${HERMES_MODEL_PROVIDER_PLUGIN_NAME}-`)) return normalized;
+	if (
+		normalized === HERMES_MODEL_PROVIDER_PLUGIN_NAME ||
+		normalized.startsWith(`${HERMES_MODEL_PROVIDER_PLUGIN_NAME}-`)
+	) {
+		return normalized;
+	}
 	return `${HERMES_MODEL_PROVIDER_PLUGIN_NAME}-${normalized || "provider"}`;
 }
 

--- a/packages/cli/tests/runtime-egress-profiles.test.ts
+++ b/packages/cli/tests/runtime-egress-profiles.test.ts
@@ -176,6 +176,26 @@ describe("runtime egress profile schema", () => {
 		]);
 	});
 
+	it("uses the stable managed id for deployment-scoped rewrite profile names", () => {
+		const bundle = hostedManifestEgressProfiles({
+			providers: {
+				"clawdi-v2-deployment-42": {
+					baseUrl: "https://ai-gateway.example.test/v1",
+					apiMode: "openai_chat",
+					managed_by: "clawdi",
+					apiKeySecretRef: "provider.clawdi-v2-deployment-42.apiKey",
+				},
+			},
+		});
+
+		expect(providerProfiles(bundle.profiles).map((profile) => profile.id)).toEqual([
+			"managed-provider-clawdi-v2",
+		]);
+		expect(JSON.stringify(bundle.profiles)).not.toContain(
+			"managed-provider-clawdi-v2-deployment-42",
+		);
+	});
+
 	it("adds explicit runtime installer passthrough allowlist profiles", () => {
 		const profiles = runtimeInstallerEgressProfiles();
 		expect(profiles).toContainEqual(

--- a/packages/cli/tests/runtime-egress-profiles.test.ts
+++ b/packages/cli/tests/runtime-egress-profiles.test.ts
@@ -189,7 +189,7 @@ describe("runtime egress profile schema", () => {
 		});
 
 		expect(providerProfiles(bundle.profiles).map((profile) => profile.id)).toEqual([
-			"managed-provider-clawdi-v2",
+			"managed-provider-clawdi",
 		]);
 		expect(JSON.stringify(bundle.profiles)).not.toContain(
 			"managed-provider-clawdi-v2-deployment-42",

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -3061,8 +3061,7 @@ exit 0
 	});
 
 	it("preserves canonical managed model capabilities through live discovery", () => {
-		const providerId = "clawdi-v2-deployment-42";
-		const agentProviderId = "clawdi-v2";
+		const agentProviderId = "clawdi";
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -3113,9 +3112,9 @@ exit 0
 							home,
 							args: ["--json", "--no-onboard"],
 						},
-						provider_ids: [providerId],
+						provider_ids: [agentProviderId],
 						primary_model: {
-							provider_id: providerId,
+							provider_id: agentProviderId,
 							model: "k3",
 						},
 					},
@@ -3124,7 +3123,7 @@ exit 0
 					sourceSchemaVersion: "clawdi.hosted-runtime.manifest.v1",
 					system: { home },
 					providers: {
-						[providerId]: {
+						[agentProviderId]: {
 							kind: "openai-compatible",
 							baseUrl: "https://ai-gateway.example.test/v1",
 							model: "k3",
@@ -3152,32 +3151,36 @@ exit 0
 		};
 
 		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths(), {
-			managedGatewayModelListFetcher: () => ({
-				status: "ok",
-				endpoint: "https://ai-gateway.example.test/v1/models",
-				models: [
-					{ id: "k3" },
-					{
-						id: "kimi-for-coding",
-						context_window: 262144,
-						max_input_tokens: 262144,
-						input_modalities: ["text", "image"],
-						supports_tools: true,
-						supports_reasoning: true,
-					},
-					{
-						id: "kimi-for-coding-highspeed",
-						context_window: 262144,
-						max_input_tokens: 262144,
-						input_modalities: ["text"],
-						supports_tools: true,
-						supports_reasoning: true,
-					},
-				],
-			}),
+			managedGatewayModelListFetcher: (input) => {
+				expect(input.providerId).toBe(agentProviderId);
+				return {
+					status: "ok",
+					endpoint: `${input.baseUrl}/models`,
+					models: [
+						{ id: "k3" },
+						{
+							id: "kimi-for-coding",
+							context_window: 262144,
+							max_input_tokens: 262144,
+							input_modalities: ["text", "image"],
+							supports_tools: true,
+							supports_reasoning: true,
+						},
+						{
+							id: "kimi-for-coding-highspeed",
+							context_window: 262144,
+							max_input_tokens: 262144,
+							input_modalities: ["text"],
+							supports_tools: true,
+							supports_reasoning: true,
+						},
+					],
+				};
+			},
 		});
 
 		expect(convergence.installErrors).toEqual([]);
+		expect(loaded.manifest.runtimes.openclaw?.provider_ids).toEqual([agentProviderId]);
 		const patch = JSON.parse(readFileSync(openclawPatch, "utf-8"));
 		expect(patch.agents.defaults.model.primary).toBe(`${agentProviderId}/k3`);
 		expect(patch.models.providers[agentProviderId].baseUrl).toBe(
@@ -3209,12 +3212,12 @@ exit 0
 				contextWindow: 262144,
 			},
 		]);
-		expect(JSON.stringify(patch)).not.toContain(providerId);
+		expect(JSON.stringify(patch)).not.toContain("clawdi-v2");
 	});
 
 	it("uses the stable managed provider name without doubling the Hermes plugin prefix", () => {
 		const scopedProviderId = "clawdi-v2-deployment-42";
-		const agentProviderId = "clawdi-v2";
+		const agentProviderId = "clawdi";
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -3268,14 +3271,18 @@ exit 0
 			{ id: "byok-to-byok", first: "byok-a", second: "byok-b" },
 		];
 		for (const providerCase of cases) {
-			const firstAgentProvider = providerCase.first;
-			const secondAgentProvider = providerCase.second;
-			const firstHermesProvider = firstAgentProvider.startsWith("clawdi-")
-				? firstAgentProvider
-				: `clawdi-${firstAgentProvider}`;
-			const secondHermesProvider = secondAgentProvider.startsWith("clawdi-")
-				? secondAgentProvider
-				: `clawdi-${secondAgentProvider}`;
+			const firstAgentProvider =
+				providerCase.first === "clawdi-managed-v2" ? "clawdi" : providerCase.first;
+			const secondAgentProvider =
+				providerCase.second === "clawdi-managed-v2" ? "clawdi" : providerCase.second;
+			const firstHermesProvider =
+				firstAgentProvider === "clawdi" || firstAgentProvider.startsWith("clawdi-")
+					? firstAgentProvider
+					: `clawdi-${firstAgentProvider}`;
+			const secondHermesProvider =
+				secondAgentProvider === "clawdi" || secondAgentProvider.startsWith("clawdi-")
+					? secondAgentProvider
+					: `clawdi-${secondAgentProvider}`;
 			const caseRoot = join(root, providerCase.id);
 			const home = join(caseRoot, "home", "clawdi");
 			const state = join(caseRoot, "var", "lib", "clawdi");

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -3062,6 +3062,7 @@ exit 0
 
 	it("preserves canonical managed model capabilities through live discovery", () => {
 		const providerId = "clawdi-v2-deployment-42";
+		const agentProviderId = "clawdi-v2";
 		const home = join(root, "home", "clawdi");
 		const state = join(root, "var", "lib", "clawdi");
 		const run = join(root, "run", "clawdi");
@@ -3178,9 +3179,11 @@ exit 0
 
 		expect(convergence.installErrors).toEqual([]);
 		const patch = JSON.parse(readFileSync(openclawPatch, "utf-8"));
-		expect(patch.agents.defaults.model.primary).toBe(`${providerId}/k3`);
-		expect(patch.models.providers[providerId].baseUrl).toBe("https://ai-gateway.example.test/v1");
-		expect(patch.models.providers[providerId].models).toEqual([
+		expect(patch.agents.defaults.model.primary).toBe(`${agentProviderId}/k3`);
+		expect(patch.models.providers[agentProviderId].baseUrl).toBe(
+			"https://ai-gateway.example.test/v1",
+		);
+		expect(patch.models.providers[agentProviderId].models).toEqual([
 			{
 				id: "k3",
 				name: "k3",
@@ -3206,6 +3209,55 @@ exit 0
 				contextWindow: 262144,
 			},
 		]);
+		expect(JSON.stringify(patch)).not.toContain(providerId);
+	});
+
+	it("uses the stable managed provider name without doubling the Hermes plugin prefix", () => {
+		const scopedProviderId = "clawdi-v2-deployment-42";
+		const agentProviderId = "clawdi-v2";
+		const home = join(root, "home", "clawdi");
+		const state = join(root, "var", "lib", "clawdi");
+		const run = join(root, "run", "clawdi");
+		process.env.HOME = home;
+		process.env.CLAWDI_RUNTIME_MODE = "hosted";
+		process.env.CLAWDI_SERVICE_STATE_DIR = state;
+		process.env.CLAWDI_RUN_DIR = run;
+		writeHermesVersionBinary(home, "0.18.0");
+		const loaded = hostedHermesProviderLoad(home);
+		const provider = loaded.manifest.projection?.providers?.hermes;
+		if (!provider) throw new Error("expected Hermes provider fixture");
+		loaded.manifest.runtimes.hermes = {
+			...loaded.manifest.runtimes.hermes,
+			provider_ids: [scopedProviderId],
+			primary_model: {
+				provider_id: scopedProviderId,
+				model: "kimi/kimi-for-coding",
+			},
+		};
+		loaded.manifest.projection = {
+			...loaded.manifest.projection,
+			providers: {
+				[scopedProviderId]: {
+					...provider,
+					managed_by: "clawdi",
+					runtimeEnvName: "OPENAI_API_KEY",
+				},
+			},
+		};
+
+		const convergence = convergeRuntimeManifest(loaded, getRuntimePaths());
+
+		expect(convergence.installErrors).toEqual([]);
+		const config = readHermesConfigYaml(home);
+		const model = expectRecord(config.model, "Hermes managed model config");
+		expect(model.provider).toBe(agentProviderId);
+		const providers = expectRecord(config.providers, "Hermes managed providers config");
+		expect(providers[agentProviderId]).toBeDefined();
+		expect(providers[`clawdi-${agentProviderId}`]).toBeUndefined();
+		const plugin = readHermesModelProviderPluginFile(home, "__init__.py");
+		expect(plugin).toContain(`name="${agentProviderId}"`);
+		expect(plugin).not.toContain(`name="clawdi-${agentProviderId}"`);
+		expect(JSON.stringify(config)).not.toContain(scopedProviderId);
 	});
 
 	it("reconciles hosted provider projections when the selected provider changes", () => {
@@ -3216,6 +3268,14 @@ exit 0
 			{ id: "byok-to-byok", first: "byok-a", second: "byok-b" },
 		];
 		for (const providerCase of cases) {
+			const firstAgentProvider = providerCase.first;
+			const secondAgentProvider = providerCase.second;
+			const firstHermesProvider = firstAgentProvider.startsWith("clawdi-")
+				? firstAgentProvider
+				: `clawdi-${firstAgentProvider}`;
+			const secondHermesProvider = secondAgentProvider.startsWith("clawdi-")
+				? secondAgentProvider
+				: `clawdi-${secondAgentProvider}`;
 			const caseRoot = join(root, providerCase.id);
 			const home = join(caseRoot, "home", "clawdi");
 			const state = join(caseRoot, "var", "lib", "clawdi");
@@ -3276,10 +3336,10 @@ exit 0
 				},
 			});
 			expect(Object.keys(openclawProviders).sort()).toEqual(
-				["user-local", providerCase.second].sort(),
+				["user-local", secondAgentProvider].sort(),
 			);
-			expect(openclawProviders[providerCase.first]).toBeUndefined();
-			expect(openclawProviders[providerCase.second]).toMatchObject({
+			expect(openclawProviders[firstAgentProvider]).toBeUndefined();
+			expect(openclawProviders[secondAgentProvider]).toMatchObject({
 				baseUrl: `https://${providerCase.second}.provider.example.test/v1`,
 			});
 			expect(openclawProviders["user-local"]).toMatchObject({
@@ -3289,10 +3349,10 @@ exit 0
 			const hermesConfig = readHermesConfigYaml(home);
 			const hermesProviders = expectRecord(hermesConfig.providers, "Hermes providers config");
 			expect(Object.keys(hermesProviders).sort()).toEqual(
-				["user-local", `clawdi-${providerCase.second}`].sort(),
+				["user-local", secondHermesProvider].sort(),
 			);
-			expect(hermesProviders[`clawdi-${providerCase.first}`]).toBeUndefined();
-			expect(hermesProviders[`clawdi-${providerCase.second}`]).toMatchObject({
+			expect(hermesProviders[firstHermesProvider]).toBeUndefined();
+			expect(hermesProviders[secondHermesProvider]).toMatchObject({
 				api: `https://${providerCase.second}.provider.example.test/v1`,
 			});
 			expect(hermesProviders["user-local"]).toMatchObject({

--- a/packages/shared/src/ai-provider.test.ts
+++ b/packages/shared/src/ai-provider.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
 	type AiProviderAuth,
+	CLAWDI_MANAGED_PROVIDER_ID,
 	CLAWDI_MANAGED_PROVIDER_IDS,
 	CLAWDI_MANAGED_V1_PROVIDER_ID,
 	CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX,
@@ -291,6 +292,7 @@ describe("validateAiProviderCatalog", () => {
 	});
 
 	test.each([
+		CLAWDI_MANAGED_PROVIDER_ID,
 		CLAWDI_MANAGED_V2_PROVIDER_ID,
 		CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
 		`${CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX}42`,
@@ -375,6 +377,7 @@ describe("validateAiProviderCatalog", () => {
 
 describe("isFirstPartyManagedAiProvider", () => {
 	test("matches every first-party managed id even when old rows are missing managed_by", () => {
+		expect(isFirstPartyManagedAiProvider({ provider_id: CLAWDI_MANAGED_PROVIDER_ID })).toBe(true);
 		expect(isFirstPartyManagedAiProvider({ provider_id: CLAWDI_MANAGED_V1_PROVIDER_ID })).toBe(
 			true,
 		);
@@ -391,6 +394,7 @@ describe("isFirstPartyManagedAiProvider", () => {
 				provider_id: `${CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX}42`,
 			}),
 		).toBe(true);
+		expect(CLAWDI_MANAGED_PROVIDER_IDS.has(CLAWDI_MANAGED_PROVIDER_ID)).toBe(true);
 		expect(CLAWDI_MANAGED_PROVIDER_IDS.has(CLAWDI_MANAGED_V2_PROVIDER_ID)).toBe(true);
 		expect(CLAWDI_MANAGED_PROVIDER_IDS.has(CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID)).toBe(true);
 	});

--- a/packages/shared/src/ai-provider.ts
+++ b/packages/shared/src/ai-provider.ts
@@ -165,6 +165,8 @@ export const CODEX_OAUTH_MODEL_CATALOG: readonly AiProviderModel[] = [
 	{ id: "gpt-5.4-mini" },
 ];
 
+// Agent-facing alias only. Credential and catalog source rows keep their v2 ids below.
+export const CLAWDI_MANAGED_PROVIDER_ID = "clawdi";
 export const CLAWDI_MANAGED_V1_PROVIDER_ID = "clawdi-managed";
 const CLAWDI_MANAGED_V1_API_MODE = "openai_responses";
 export const CLAWDI_MANAGED_V2_PROVIDER_ID = "clawdi-v2";
@@ -177,6 +179,7 @@ const CLAWDI_MANAGED_V2_API_MODE = "openai_chat";
 // TODO(#425): Remove the legacy member after hosted#892 is deployed everywhere and no
 // dev/self-hosted binding still uses clawdi-managed-v2.
 export const CLAWDI_MANAGED_PROVIDER_IDS: ReadonlySet<string> = new Set([
+	CLAWDI_MANAGED_PROVIDER_ID,
 	CLAWDI_MANAGED_V1_PROVIDER_ID,
 	CLAWDI_MANAGED_V2_PROVIDER_ID,
 	CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
@@ -196,6 +199,7 @@ export interface AiProviderManagedIdentity {
 
 export function isClawdiManagedV2ProviderId(providerId: string): boolean {
 	if (
+		providerId === CLAWDI_MANAGED_PROVIDER_ID ||
 		providerId === CLAWDI_MANAGED_V2_PROVIDER_ID ||
 		providerId === CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID
 	) {


### PR DESCRIPTION
## Summary\n\n- map clawdi-v2-deployment-N bindings to the stable agent-facing provider name clawdi-v2 while resolving credentials through the deployment-scoped Cloud row\n- make hosted settings recognize scoped IDs as Managed by Clawdi so the managed card and Primary provider choice stay selected\n- write stable provider keys and primary-model refs to OpenClaw and Hermes config, stabilize managed egress profile names and probe logs, and preserve credential invalidation\n- make the Hermes clawdi prefix idempotent, fixing clawdi-clawdi-v2-deployment-N at its source\n- preserve the legacy clawdi-managed-v2 alias for rollout compatibility\n\n## Verification\n\n- bun run test — workspace typecheck 4/4; TypeScript/CLI/Web 1016 passed; PostgreSQL backend 1318 passed, 7 skipped\n- bun run check — passed\n- focused Ruff check and format check for touched backend files — passed\n\n## Related\n\n- Clawdi-AI/clawdi-hosted#1008 projects scoped IDs out of public deployment reads\n\n## Rollout\n\nNo production operation is included. This PR is intentionally left unmerged.