### PR TITLE
Navigate immediately after wallet deployment acceptance

### DIFF
--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -826,15 +826,6 @@ export function DeployWizard() {
 		return false;
 	}
 
-	async function resolveWalletDeploymentId(
-		deploymentId: string | null | undefined,
-		deployRequestId: string | null | undefined,
-	): Promise<string | null> {
-		if (!deployRequestId) return deploymentId ?? null;
-		const resolved = await resolveDeploymentRequest.mutateAsync(deployRequestId);
-		return resolved.deploymentId || deploymentId || null;
-	}
-
 	async function fallbackToHostedCheckout(request: SubscriptionCreateRequestView) {
 		if (!(await recheckCanCreateCloudAgents())) return;
 		const fingerprint = idempotencyFingerprint({
@@ -976,25 +967,18 @@ export function DeployWizard() {
 					if (outcome.flowType !== "subscription_activation") {
 						throw new Error("Wallet subscription returned a checkout flow.");
 					}
-					const deploymentId = await resolveWalletDeploymentId(
-						outcome.deploymentId,
-						outcome.deployRequestId ?? attempt.key,
-					);
+					const deploymentId = outcome.deploymentId;
+					if (!deploymentId) {
+						throw new Error("Wallet activation did not accept a deployment target.");
+					}
 					forgetIdempotencyAttempt("subscription-wallet-deploy", fingerprint);
 					walletCreateAttemptRef.current = null;
-					if (deploymentId) {
-						toast.success("Agent deployed", {
-							description: `${formatCents(walletDebit?.exactDebitCents ?? paidSelection.offer.price_cents)} was paid with AI Credits.`,
-						});
-						void router.navigate({
-							href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"),
-						});
-						return;
-					}
-					toast.success("Wallet subscription active", {
-						description: "Your deployment is provisioning and will appear in Agents shortly.",
+					toast.success("Agent deployed", {
+						description: `${formatCents(walletDebit?.exactDebitCents ?? paidSelection.offer.price_cents)} was paid with AI Credits.`,
 					});
-					void router.navigate({ href: "/" });
+					void router.navigate({
+						href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"),
+					});
 					return;
 				}
 				const checkoutFingerprint = idempotencyFingerprint({ selection, target });

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -1033,6 +1033,10 @@ export interface components {
             invoice_id?: string | null;
             /** Deployment Id */
             deployment_id?: string | null;
+            /** Deployment Name */
+            deployment_name?: string | null;
+            /** Metadata Generation */
+            metadata_generation?: number | null;
             /** Deploy Request Id */
             deploy_request_id?: string | null;
             /** Debited Credits */
@@ -2632,6 +2636,15 @@ export interface operations {
         responses: {
             /** @description Successful Response */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["V2CheckoutResponse"];
+                };
+            };
+            /** @description Deployment desired state accepted */
+            202: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## Summary

- use the wallet activation response's synchronously accepted `deployment_id` directly
- remove the Deploy button's blocking `/by-request` resolution/poll loop
- navigate immediately to the agent overview, where the existing detail/inventory refresh shows provisioning conditions until Running
- fail explicitly if a wallet activation violates the new contract and omits `deployment_id`
- regenerate the hosted deploy API client for the HTTP 202 response plus `deployment_name` and `metadata_generation`

Backend contract dependency: https://github.com/Clawdi-AI/clawdi-hosted/pull/1009

The Stripe checkout return path still uses request resolution; this change is scoped to the synchronous wallet activation button path.

## Verification

- `bun run --cwd apps/web typecheck`: passed
- `bun test apps/web/src/hosted/billing/subscription/subscription-create-adapter.test.ts`: 3 passed
- Biome check for the changed wizard: passed
- generated hosted API client consistency: passed
- `git diff --check`: passed

This PR is intentionally unmerged for owner review.
