### PR TITLE
fix(web): v2 hosted display consistency — friendly names, runtime UI, managed provider, upgrade copy

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1514,7 +1514,12 @@ test("Runtime UI credential failure renders a retryable error instead of a perma
 
 	await page.goto(`/agents/${missingProjectionEnvironmentId}/console?source=on-clawdi`);
 	const main = page.locator("main");
-	await main.getByRole("button", { name: "Show Hermes credentials", exact: true }).click();
+	await expect(main.locator('iframe[title="Hermes Dashboard"]')).toHaveAttribute(
+		"src",
+		"https://runtime.example/hermes",
+	);
+	await expect(main.getByRole("button", { name: "Open in new window", exact: true })).toBeVisible();
+	await main.getByRole("button", { name: "Show credentials", exact: true }).click();
 	await expect.poll(() => runtimeUiRedemptionRequests.length).toBe(1);
 	await expect(main.getByText("Couldn't load Hermes credentials", { exact: true })).toBeVisible();
 	await main.getByRole("button", { name: "Retry", exact: true }).click();
@@ -1543,6 +1548,12 @@ test("OpenClaw Console opens through the direct gateway token handoff", async ({
 
 	await page.goto("/agents/hdep_openclaw_included/console?source=on-clawdi");
 	const main = page.locator("main");
+	await expect(main.locator('iframe[title="OpenClaw Control UI"]')).toHaveAttribute(
+		"src",
+		"https://runtime.example/openclaw/#token=gateway-token",
+	);
+	await main.getByRole("button", { name: "Show credentials", exact: true }).click();
+	await expect(main.locator('input[value="gateway-token"]')).toBeVisible();
 	const popupPromise = page.waitForEvent("popup");
 	await main.getByRole("button", { name: "Open OpenClaw Control UI" }).click();
 	const popup = await popupPromise;

--- a/apps/web/src/components/dashboard/agent-label.test.ts
+++ b/apps/web/src/components/dashboard/agent-label.test.ts
@@ -76,6 +76,15 @@ describe("agentDisplayName", () => {
 			),
 		).toBe("Cloud · Research Agent · Codex");
 	});
+
+	test("formats a projected name without duplicating the runtime label", () => {
+		expect(
+			agentTextLabel(
+				{ name: "deployment-create-id", agent_type: "hermes" },
+				{ ownershipKind: "cloud", formatName: () => "Hermes" },
+			),
+		).toBe("Cloud · Hermes");
+	});
 });
 
 describe("compareAgentEnvironments", () => {

--- a/apps/web/src/components/dashboard/agent-label.tsx
+++ b/apps/web/src/components/dashboard/agent-label.tsx
@@ -266,14 +266,20 @@ export function agentTextLabel(
 	{
 		includeSource = true,
 		ownershipKind = "connected",
-	}: { includeSource?: boolean; ownershipKind?: AgentOwnershipKind } = {},
+		formatName,
+	}: {
+		includeSource?: boolean;
+		ownershipKind?: AgentOwnershipKind;
+		formatName?: (name: string) => string;
+	} = {},
 ): string {
 	const identity = agentIdentity(env);
 	const source = sourceFromOwnershipKind(ownershipKind);
+	const primaryLabel = formatName?.(identity.primaryLabel) ?? identity.primaryLabel;
 	const parts = [
 		includeSource && source === "hosted" ? agentSourceLabel("hosted") : null,
-		identity.primaryLabel,
-		identity.secondaryLabel,
+		primaryLabel,
+		identity.secondaryLabel !== primaryLabel ? identity.secondaryLabel : null,
 	].filter((part): part is string => Boolean(part));
 	return parts.join(" · ");
 }
@@ -367,6 +373,7 @@ export function AgentLabel({
 	meta,
 	titleAdornment,
 	className,
+	formatName,
 }: {
 	name?: string | null | undefined;
 	machineName: string | null | undefined;
@@ -391,6 +398,7 @@ export function AgentLabel({
 	 * subtitle wraps. */
 	titleAdornment?: ReactNode;
 	className?: string;
+	formatName?: (name: string) => string;
 }) {
 	const typeLabel = agentTypeLabel(type);
 	const identity = agentIdentity({
@@ -401,7 +409,8 @@ export function AgentLabel({
 		agent_type: type,
 	});
 	const cleanedMachine = cleanMachineName(machineName);
-	const titleText = primary === "type" ? typeLabel : identity.primaryLabel;
+	const rawTitleText = primary === "type" ? typeLabel : identity.primaryLabel;
+	const titleText = formatName?.(rawTitleText) ?? rawTitleText;
 	// The disambiguator is the OTHER field — when title is the type
 	// we surface the machine name (and vice versa). Suppressed if
 	// it'd duplicate the title (e.g. hosted tiles whose

--- a/apps/web/src/components/dashboard/agent-settings-panel.tsx
+++ b/apps/web/src/components/dashboard/agent-settings-panel.tsx
@@ -44,9 +44,11 @@ function updateEnvironmentCaches(queryClient: QueryClient, environment: Environm
 export function AgentSettingsPanel({
 	environmentId,
 	className,
+	formatName,
 }: {
 	environmentId: string;
 	className?: string;
+	formatName?: (name: string) => string;
 }) {
 	const api = useApi();
 	const router = useRouter();
@@ -71,8 +73,10 @@ export function AgentSettingsPanel({
 
 	useEffect(() => {
 		if (!agent) return;
-		setDraftName(agent.display_name ?? "");
-	}, [agent]);
+		setDraftName(
+			agent.display_name ? (formatName?.(agent.display_name) ?? agent.display_name) : "",
+		);
+	}, [agent, formatName]);
 
 	const updateIdentity = useMutation({
 		mutationFn: async (body: EnvironmentUpdate) =>
@@ -171,7 +175,9 @@ export function AgentSettingsPanel({
 	}
 
 	const normalizedDraftName = draftName.trim() || null;
-	const currentCustomName = agent.display_name ?? null;
+	const currentCustomName = agent.display_name
+		? (formatName?.(agent.display_name) ?? agent.display_name)
+		: null;
 	const nameChanged = normalizedDraftName !== currentCustomName;
 	const hasCustomAvatar = Boolean(agent.avatar_url);
 	const ownershipKind = agentOwnershipKindFromId(agent.id, ownership);
@@ -189,8 +195,10 @@ export function AgentSettingsPanel({
 		uploadMutation.isPending ||
 		clearAvatar.isPending ||
 		disconnect.isPending;
-	const displayName = agentDisplayName(agent);
-	const defaultDisplayName = agentDisplayName({ ...agent, display_name: null });
+	const rawDisplayName = agentDisplayName(agent);
+	const rawDefaultDisplayName = agentDisplayName({ ...agent, display_name: null });
+	const displayName = formatName?.(rawDisplayName) ?? rawDisplayName;
+	const defaultDisplayName = formatName?.(rawDefaultDisplayName) ?? rawDefaultDisplayName;
 	const runtimeLabel = agentTypeLabel(agent.agent_type);
 	const currentAvatarLabel = hasCustomAvatar ? "Custom upload" : `${runtimeLabel} default`;
 	const legacyDashboardUrl = ownershipKind === "legacy" ? legacyHostedDashboardUrl() : null;

--- a/apps/web/src/hosted/agent-identity.test.ts
+++ b/apps/web/src/hosted/agent-identity.test.ts
@@ -15,4 +15,13 @@ describe("deploymentDisplayName", () => {
 		expect(deploymentDisplayName("openclaw-research")).toBe("research");
 		expect(deploymentDisplayName("hermes-support")).toBe("support");
 	});
+
+	test("uses the runtime label for generated or missing deployment names", () => {
+		const id = "b9fea25e-2a83-4de7-b80c-65b3c118f65f";
+		expect(deploymentDisplayName("", "openclaw")).toBe("OpenClaw");
+		expect(deploymentDisplayName(id, "hermes")).toBe("Hermes");
+		expect(deploymentDisplayName(`deployment-create-${id}`, "openclaw")).toBe("OpenClaw");
+		expect(deploymentDisplayName(`openclaw-${id}`, "openclaw")).toBe("OpenClaw");
+		expect(deploymentDisplayName(`hermes-deployment-create-${id}`, "hermes")).toBe("Hermes");
+	});
 });

--- a/apps/web/src/hosted/agent-identity.ts
+++ b/apps/web/src/hosted/agent-identity.ts
@@ -1,3 +1,6 @@
+import type { HostedRuntime } from "@/hosted/runtimes";
+import { runtimeDisplayName } from "@/hosted/runtimes";
+
 /**
  * Shared identity/naming helpers for hosted deployments and their cloud-api
  * agent environments. Centralized so the agent detail view, the agent-home
@@ -11,6 +14,7 @@
  * a 422 against `/v1/sessions`.
  */
 const CLOUD_ENV_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const GENERATED_DEPLOYMENT_NAME_RE = /^deployment-create-/i;
 
 /** Whether `value` looks like a real cloud-api env id (UUID), not a deployment id. */
 export function isCloudEnvId(value: string): boolean {
@@ -21,8 +25,14 @@ export function isCloudEnvId(value: string): boolean {
  * Keep user-given deployment names intact while preserving the existing
  * runtime-prefix cleanup for generated runtime labels.
  */
-export function deploymentDisplayName(name: string): string {
+export function deploymentDisplayName(name: string, runtime?: HostedRuntime): string {
+	const fallback = runtime ? runtimeDisplayName(runtime) : "Clawdi Cloud agent";
 	const trimmed = name.trim();
-	if (!trimmed) return "Clawdi Cloud agent";
-	return trimmed.replace(/^(codex|openclaw|hermes)-/i, "") || trimmed;
+	if (!trimmed || GENERATED_DEPLOYMENT_NAME_RE.test(trimmed) || isCloudEnvId(trimmed)) {
+		return fallback;
+	}
+	const cleaned = trimmed.replace(/^(codex|openclaw|hermes)-/i, "");
+	return !cleaned || GENERATED_DEPLOYMENT_NAME_RE.test(cleaned) || isCloudEnvId(cleaned)
+		? fallback
+		: cleaned;
 }

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -225,7 +225,10 @@ function DeploymentChooser({
 			<div className="grid max-w-2xl gap-2">
 				{matches.map((match) => {
 					const { deployment } = match;
-					const name = deploymentDisplayName(deployment.resource.spec.name);
+					const name = deploymentDisplayName(
+						deployment.resource.spec.name,
+						deployment.resource.spec.runtime,
+					);
 					const query = {
 						...agentDeploymentRouteQuery(searchStr),
 						[AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY]: deployment.resource.id,

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -12,7 +12,6 @@ import {
 	Link2,
 	Link2Off,
 	type LucideIcon,
-	Maximize2,
 	MonitorPlay,
 	Plus,
 	QrCode,
@@ -63,11 +62,11 @@ import {
 	HostedTerminalPanel,
 	type HostedTerminalStatus,
 } from "@/hosted/agents/hosted-terminal-panel";
-import { browserOpenClawNativeUiCopy } from "@/hosted/agents/runtime-ui-copy";
 import {
 	type HermesUiCredentials,
-	hermesCredentialsForGeneration,
 	hermesUiCredentials,
+	type OpenClawUiCredentials,
+	openClawUiCredentials,
 	openClawUiUrl,
 	openSecureRuntimeWindow,
 } from "@/hosted/agents/runtime-ui-credentials";
@@ -108,6 +107,7 @@ import {
 } from "@/hosted/billing/hooks";
 import {
 	type PlanChangeSelection,
+	performanceUpgradeUnavailableReason,
 	planChangeUnavailableReason,
 } from "@/hosted/billing/subscription/plan-change.logic";
 import { PlanChangeDialog } from "@/hosted/billing/subscription/plan-change-dialog";
@@ -335,7 +335,10 @@ function DeleteComputeAction({ deployment }: { deployment: HostedDeployment }) {
 	const runAction = useActionLock();
 	return (
 		<ConfirmAction
-			title={`Delete ${deploymentDisplayName(deployment.resource.spec.name)}?`}
+			title={`Delete ${deploymentDisplayName(
+				deployment.resource.spec.name,
+				deployment.resource.spec.runtime,
+			)}?`}
 			description={<p>The hosted agent is torn down. This can’t be undone.</p>}
 			confirmLabel="Delete compute"
 			destructive
@@ -438,8 +441,8 @@ export function HostedAgentDetail({
 	});
 	const agent = projection.status === "resolved" ? projection.data : null;
 	const name = agent
-		? agentDisplayName(agent)
-		: deploymentDisplayName(deployment.resource.spec.name);
+		? deploymentDisplayName(agentDisplayName(agent), runtime)
+		: deploymentDisplayName(deployment.resource.spec.name, runtime);
 	const runtimeLabel = runtimeDisplayName(runtime);
 	const agentTitle = name === runtimeLabel ? name : `${name} · ${runtimeLabel}`;
 	const activeTab = parseHostedAgentTab(section) ?? "overview";
@@ -949,17 +952,21 @@ function OverviewDeploymentActions({ deployment }: { deployment: HostedDeploymen
 function RuntimeUiOpenButton({
 	deployment,
 	endpointUrl,
+	resolvedUrl,
 	label,
 	children,
 	className,
+	disabled = false,
 	variant = "outline",
 	size = "sm",
 }: {
 	deployment: HostedDeployment;
 	endpointUrl: string;
+	resolvedUrl?: string;
 	label: string;
 	children: React.ReactNode;
 	className?: string;
+	disabled?: boolean;
 	variant?: React.ComponentProps<typeof Button>["variant"];
 	size?: React.ComponentProps<typeof Button>["size"];
 }) {
@@ -971,6 +978,10 @@ function RuntimeUiOpenButton({
 			toast.error("Couldn't open runtime UI", {
 				description: "Your browser blocked the new window.",
 			});
+			return;
+		}
+		if (resolvedUrl) {
+			popup.location.replace(resolvedUrl);
 			return;
 		}
 		setIsPending(true);
@@ -985,7 +996,7 @@ function RuntimeUiOpenButton({
 		} finally {
 			setIsPending(false);
 		}
-	}, [client, deployment.resource.id, endpointUrl]);
+	}, [client, deployment.resource.id, endpointUrl, resolvedUrl]);
 
 	return (
 		<Button
@@ -993,7 +1004,7 @@ function RuntimeUiOpenButton({
 			variant={variant}
 			size={size}
 			className={className}
-			disabled={isPending}
+			disabled={disabled || isPending}
 			aria-label={`Open ${label}`}
 			onClick={() => void openUi()}
 		>
@@ -1003,10 +1014,10 @@ function RuntimeUiOpenButton({
 	);
 }
 
-/**
- * Native runtime dashboards are top-level only. Hermes exposes explicit Basic
- * credentials; OpenClaw receives its official token handoff in the URL fragment.
- */
+type ResolvedRuntimeUiCredentials =
+	| { runtime: "hermes"; value: HermesUiCredentials }
+	| { runtime: "openclaw"; value: OpenClawUiCredentials };
+
 function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; runtime: Runtime }) {
 	const status = parseDeploymentStatus(deployment.resource.status.summary_state);
 	const isRunning = isRunningStatus(status);
@@ -1015,40 +1026,87 @@ function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; run
 	const browserUiLabel = runtimeBrowserUiLabel(runtime);
 	const url = runtimeConsoleUrl(deployment, runtime);
 	const client = useBillingClient();
-	const [credentials, setCredentials] = useState<HermesUiCredentials | null>(null);
-	const [loadedCredentialGeneration, setLoadedCredentialGeneration] = useState<number | null>(null);
+	const [credentials, setCredentials] = useState<ResolvedRuntimeUiCredentials | null>(null);
+	const [showCredentials, setShowCredentials] = useState(false);
 	const [credentialError, setCredentialError] = useState<Error | null>(null);
 	const [isLoadingCredentials, setIsLoadingCredentials] = useState(false);
-	const openClawCopy = browserOpenClawNativeUiCopy();
-	const credentialGeneration = deployment.resource.metadata.generation;
-	useEffect(() => {
+	const credentialRequestRef = useRef(0);
+	const automaticCredentialKeyRef = useRef<string | null>(null);
+	const credentialIdentity = `${deployment.resource.id}\0${deployment.resource.metadata.generation}\0${runtime}\0${url ?? ""}`;
+	const [syncedCredentialIdentity, setSyncedCredentialIdentity] = useState(credentialIdentity);
+	if (credentialIdentity !== syncedCredentialIdentity) {
+		setSyncedCredentialIdentity(credentialIdentity);
+		credentialRequestRef.current += 1;
 		setCredentials(null);
-		setLoadedCredentialGeneration(null);
+		setShowCredentials(false);
 		setCredentialError(null);
-	}, [credentialGeneration]);
-	const currentCredentials = hermesCredentialsForGeneration(
-		credentials,
-		loadedCredentialGeneration,
-		credentialGeneration,
+		setIsLoadingCredentials(false);
+	}
+	const loadCredentials = useCallback(
+		async (reveal: boolean) => {
+			if (!url) return;
+			const requestId = credentialRequestRef.current + 1;
+			credentialRequestRef.current = requestId;
+			setIsLoadingCredentials(true);
+			setCredentialError(null);
+			try {
+				const response = await client.getRuntimeUiCredentials(deployment.resource.id);
+				let resolved: ResolvedRuntimeUiCredentials | null;
+				if (runtime === "hermes") {
+					const value = hermesUiCredentials(response, url);
+					resolved = value ? { runtime: "hermes", value } : null;
+				} else {
+					const value = openClawUiCredentials(response, url);
+					resolved = value ? { runtime: "openclaw", value } : null;
+				}
+				if (!resolved) throw new Error("Runtime UI credential response was invalid");
+				if (credentialRequestRef.current !== requestId) return;
+				setCredentials(resolved);
+				setShowCredentials(reveal);
+			} catch (error) {
+				if (credentialRequestRef.current !== requestId) return;
+				setCredentialError(error instanceof Error ? error : new Error("Credential request failed"));
+			} finally {
+				if (credentialRequestRef.current === requestId) setIsLoadingCredentials(false);
+			}
+		},
+		[client, deployment.resource.id, runtime, url],
 	);
-	const loadHermesCredentials = useCallback(async () => {
-		if (!url) return;
-		setIsLoadingCredentials(true);
-		setCredentialError(null);
-		try {
-			const response = await client.getRuntimeUiCredentials(deployment.resource.id);
-			const resolved = hermesUiCredentials(response, url);
-			if (!resolved) throw new Error("Runtime UI credential response was invalid");
-			setCredentials(resolved);
-			setLoadedCredentialGeneration(credentialGeneration);
-		} catch (error) {
-			setCredentialError(error instanceof Error ? error : new Error("Credential request failed"));
-		} finally {
-			setIsLoadingCredentials(false);
+	useEffect(() => {
+		const automaticCredentialKey = `${credentialIdentity}\0openclaw`;
+		if (
+			!isRunning ||
+			!url ||
+			runtime !== "openclaw" ||
+			credentials?.runtime === "openclaw" ||
+			credentialError ||
+			isLoadingCredentials ||
+			automaticCredentialKeyRef.current === automaticCredentialKey
+		) {
+			return;
 		}
-	}, [client, credentialGeneration, deployment.resource.id, url]);
+		automaticCredentialKeyRef.current = automaticCredentialKey;
+		void loadCredentials(false);
+	}, [
+		credentialIdentity,
+		credentialError,
+		credentials,
+		isLoadingCredentials,
+		isRunning,
+		loadCredentials,
+		runtime,
+		url,
+	]);
 
-	// Native runtime UI exposure exists only after the runtime is running.
+	const toggleCredentials = () => {
+		if (showCredentials) {
+			setShowCredentials(false);
+			return;
+		}
+		if (credentials?.runtime === runtime) setShowCredentials(true);
+		else void loadCredentials(true);
+	};
+
 	if (!isRunning) {
 		return (
 			<EmptyState
@@ -1074,67 +1132,111 @@ function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; run
 			/>
 		);
 	}
+	const frameUrl =
+		runtime === "hermes"
+			? url
+			: credentials?.runtime === "openclaw"
+				? credentials.value.url
+				: undefined;
+	const runtimeActions = (
+		<>
+			<Button
+				type="button"
+				variant="outline"
+				size="sm"
+				disabled={isLoadingCredentials}
+				onClick={toggleCredentials}
+			>
+				{isLoadingCredentials ? <Spinner className="size-3.5" /> : null}
+				{showCredentials ? "Hide credentials" : "Show credentials"}
+			</Button>
+			{runtime === "openclaw" ? (
+				<RuntimeUiOpenButton
+					deployment={deployment}
+					endpointUrl={url}
+					resolvedUrl={credentials?.runtime === "openclaw" ? credentials.value.url : undefined}
+					label={browserUiLabel}
+					disabled={isLoadingCredentials}
+				>
+					Open in new window
+					<ExternalLink className="size-3.5" />
+				</RuntimeUiOpenButton>
+			) : (
+				<Button
+					render={<a href={url} target="_blank" rel="noopener noreferrer" />}
+					nativeButton={false}
+					variant="outline"
+					size="sm"
+				>
+					Open in new window
+					<ExternalLink className="size-3.5" />
+				</Button>
+			)}
+		</>
+	);
 
 	return (
-		<LiveToolFrame icon={MonitorPlay} title={browserUiLabel}>
-			<div className="flex min-h-[420px] flex-1 items-center justify-center p-6">
-				<div className="w-full max-w-xl space-y-4 text-center">
-					<p className="text-sm text-muted-foreground">
-						{runtime === "hermes"
-							? "Hermes uses native password authentication in a top-level window."
-							: openClawCopy.description}
-					</p>
-					{runtime === "hermes" ? (
-						currentCredentials ? (
-							<div className="space-y-3 text-left">
+		<LiveToolFrame icon={MonitorPlay} title={browserUiLabel} action={runtimeActions}>
+			{showCredentials ? (
+				<div className="grid shrink-0 gap-3 border-y bg-muted/20 p-4 sm:grid-cols-2 lg:px-6">
+					{credentials?.runtime === "hermes" ? (
+						<>
+							<div className="space-y-1.5">
 								<Label htmlFor={`hermes-username-${deployment.resource.id}`}>Username</Label>
 								<Input
 									id={`hermes-username-${deployment.resource.id}`}
 									readOnly
-									value={currentCredentials.username}
+									value={credentials.value.username}
 								/>
+							</div>
+							<div className="space-y-1.5">
 								<Label htmlFor={`hermes-password-${deployment.resource.id}`}>Password</Label>
 								<Input
 									id={`hermes-password-${deployment.resource.id}`}
 									readOnly
-									value={currentCredentials.password}
+									value={credentials.value.password}
 								/>
-								<Button
-									type="button"
-									onClick={() =>
-										window.open(currentCredentials.url, "_blank", "noopener,noreferrer")
-									}
-								>
-									Open {browserUiLabel}
-									<ExternalLink className="size-3.5" />
-								</Button>
 							</div>
-						) : (
-							<Button
-								type="button"
-								disabled={isLoadingCredentials}
-								onClick={() => void loadHermesCredentials()}
-							>
-								{isLoadingCredentials ? <Spinner className="size-3.5" /> : null}
-								Show Hermes credentials
-							</Button>
-						)
-					) : (
-						<RuntimeUiOpenButton deployment={deployment} endpointUrl={url} label={browserUiLabel}>
-							{openClawCopy.openControlUi}
-							<Maximize2 className="size-3.5" />
-						</RuntimeUiOpenButton>
-					)}
-					{credentialError ? (
-						<ApiErrorPanel
-							error={credentialError}
-							onRetry={() => void loadHermesCredentials()}
-							normalizer={billingErrorNormalizer}
-							title="Couldn't load Hermes credentials"
-						/>
+						</>
+					) : credentials?.runtime === "openclaw" ? (
+						<div className="space-y-1.5 sm:col-span-2">
+							<Label htmlFor={`openclaw-token-${deployment.resource.id}`}>Token</Label>
+							<Input
+								id={`openclaw-token-${deployment.resource.id}`}
+								readOnly
+								value={credentials.value.token}
+							/>
+						</div>
 					) : null}
 				</div>
-			</div>
+			) : null}
+			{credentialError ? (
+				<div
+					className={cn("p-4 lg:px-6", frameUrl ? "shrink-0" : "flex min-h-[420px] items-center")}
+				>
+					<div className="w-full">
+						<ApiErrorPanel
+							error={credentialError}
+							onRetry={() => void loadCredentials(runtime === "hermes")}
+							normalizer={billingErrorNormalizer}
+							title={`Couldn't load ${label} credentials`}
+						/>
+					</div>
+				</div>
+			) : null}
+			{frameUrl ? (
+				<iframe
+					key={`${runtime}:${frameUrl}`}
+					src={frameUrl}
+					title={browserUiLabel}
+					className="min-h-[420px] flex-1 border-0 bg-background"
+					allow="clipboard-read; clipboard-write"
+				/>
+			) : credentialError ? null : (
+				<div className="flex min-h-[420px] flex-1 items-center justify-center bg-background">
+					<Spinner className="size-4 text-muted-foreground" />
+				</div>
+			)}
 		</LiveToolFrame>
 	);
 }
@@ -1207,7 +1309,10 @@ function TerminalTab({ deployment }: { deployment: HostedDeployment }) {
 	const status = parseDeploymentStatus(deployment.resource.status.summary_state);
 	const isRunning = isRunningStatus(status);
 	const isProvisioning = isProvisioningStatus(status);
-	const label = deploymentDisplayName(deployment.resource.spec.name);
+	const label = deploymentDisplayName(
+		deployment.resource.spec.name,
+		deployment.resource.spec.runtime,
+	);
 	const terminal = useCreateTerminalSession();
 	const { isPending: isOpeningTerminal, mutateAsync: createTerminalSession } = terminal;
 	const [websocketUrl, setWebsocketUrl] = useState<string | null>(null);
@@ -2193,10 +2298,11 @@ function HostedAgentSettingsTab({
 	runtime: Runtime;
 	projectionAvailable: boolean;
 }) {
+	const formatName = useCallback((name: string) => deploymentDisplayName(name, runtime), [runtime]);
 	return (
 		<div className="flex flex-col gap-10">
 			{projectionAvailable ? (
-				<AgentSettingsPanel environmentId={environmentId} />
+				<AgentSettingsPanel environmentId={environmentId} formatName={formatName} />
 			) : (
 				<ProjectionDependentUnavailable label="Profile settings" />
 			)}
@@ -2394,11 +2500,18 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 				subscriptionId,
 			})
 		: "Start a new subscription to change this deployment’s paid compute.";
-	const canUpgrade =
-		hostedAccess.canCreateCloudAgents &&
-		isIncludedBasic &&
-		deployment.upgrade_available &&
-		planChangeUnavailable === null;
+	const upgradeUnavailableMessage = performanceUpgradeUnavailableReason({
+		plansLoading: plans.isLoading,
+		canCreateCloudAgents: hostedAccess.canCreateCloudAgents,
+		isIncludedBasic,
+		performancePlanAvailable: Boolean(perfPlan),
+		pendingPlanSlug,
+		planChangeUnavailable,
+		deploymentStatusSupportsUpgrade:
+			isRunningStatus(deploymentStatus) || deploymentStatus.kind === "stopped",
+		upgradeAvailable: deployment.upgrade_available,
+	});
+	const canUpgrade = upgradeUnavailableMessage === null;
 	const canStartNewSubscription =
 		hostedAccess.canCreateCloudAgents && hasTerminalFallback && !!(basicPlan || perfPlan);
 	const subscriptionCreatePlanSlug = resolveSubscriptionCreatePlanSlug(
@@ -2408,15 +2521,6 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 			performanceAvailable: !!perfPlan,
 		},
 	);
-	const upgradeUnavailableMessage = plans.isLoading
-		? "Checking Performance availability…"
-		: !hostedAccess.canCreateCloudAgents
-			? "Upgrades are temporarily unavailable."
-			: !perfPlan
-				? "Performance compute is unavailable right now."
-				: isRunningStatus(deploymentStatus) || deploymentStatus.kind === "stopped"
-					? "An upgrade may already be pending for this Basic agent."
-					: "Upgrade is available once this Basic agent is running or stopped.";
 	const createUnavailableMessage = plans.isLoading
 		? "Checking paid compute availability…"
 		: !hostedAccess.canCreateCloudAgents
@@ -2715,7 +2819,7 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 										<p className="text-xs text-muted-foreground">{createUnavailableMessage}</p>
 									)
 								) : canUpgrade ? null : (
-									<p className="text-xs text-muted-foreground">{createUnavailableMessage}</p>
+									<p className="text-xs text-muted-foreground">{upgradeUnavailableMessage}</p>
 								)}
 							</div>
 						) : isPaidCompute && currentSubscription ? (
@@ -2869,7 +2973,10 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 						</p>
 					</div>
 					<ConfirmAction
-						title={`Delete ${deploymentDisplayName(deployment.resource.spec.name)}?`}
+						title={`Delete ${deploymentDisplayName(
+							deployment.resource.spec.name,
+							deployment.resource.spec.runtime,
+						)}?`}
 						description={<p>The hosted agent is torn down. This can’t be undone.</p>}
 						confirmLabel="Delete compute"
 						destructive

--- a/apps/web/src/hosted/agents/runtime-ui-credentials.test.ts
+++ b/apps/web/src/hosted/agents/runtime-ui-credentials.test.ts
@@ -3,6 +3,7 @@ import type { RuntimeUiCredentials } from "@clawdi/shared/api";
 import {
 	hermesCredentialsForGeneration,
 	hermesUiCredentials,
+	openClawUiCredentials,
 	openClawUiUrl,
 	openSecureRuntimeWindow,
 } from "@/hosted/agents/runtime-ui-credentials";
@@ -73,5 +74,18 @@ describe("runtime UI credential targeting", () => {
 			url: "https://runtime.example/openclaw/#token=deployment-token",
 		};
 		expect(openClawUiUrl(credentials, "https://runtime.example/openclaw/")).toBe(credentials.url);
+		expect(openClawUiCredentials(credentials, "https://runtime.example/openclaw/")).toEqual({
+			url: credentials.url,
+			token: "deployment-token",
+		});
+	});
+
+	test("rejects an OpenClaw credential URL without a token", () => {
+		const credentials: RuntimeUiCredentials = {
+			runtime: "openclaw",
+			auth_mode: "openclaw_device",
+			url: "https://runtime.example/openclaw/",
+		};
+		expect(openClawUiCredentials(credentials, credentials.url)).toBeNull();
 	});
 });

--- a/apps/web/src/hosted/agents/runtime-ui-credentials.ts
+++ b/apps/web/src/hosted/agents/runtime-ui-credentials.ts
@@ -6,6 +6,11 @@ export interface HermesUiCredentials {
 	password: string;
 }
 
+export interface OpenClawUiCredentials {
+	url: string;
+	token: string;
+}
+
 type RuntimeWindow = {
 	close(): void;
 	location: { replace(url: string | URL): void };
@@ -64,10 +69,10 @@ export function hermesUiCredentials(
 	};
 }
 
-export function openClawUiUrl(
+export function openClawUiCredentials(
 	credentials: RuntimeUiCredentials,
 	endpointUrl: string,
-): string | null {
+): OpenClawUiCredentials | null {
 	if (
 		credentials.runtime !== "openclaw" ||
 		credentials.auth_mode !== "openclaw_device" ||
@@ -75,5 +80,26 @@ export function openClawUiUrl(
 	) {
 		return null;
 	}
-	return credentials.url;
+	try {
+		const url = new URL(credentials.url);
+		const fragment = new URLSearchParams(url.hash.slice(1));
+		const token = fragment.get("token")?.trim();
+		if (
+			!token ||
+			fragment.getAll("token").length !== 1 ||
+			![...fragment.keys()].every((key) => key === "token")
+		) {
+			return null;
+		}
+		return { url: credentials.url, token };
+	} catch {
+		return null;
+	}
+}
+
+export function openClawUiUrl(
+	credentials: RuntimeUiCredentials,
+	endpointUrl: string,
+): string | null {
+	return openClawUiCredentials(credentials, endpointUrl)?.url ?? null;
 }

--- a/apps/web/src/hosted/billing/subscription/plan-change.logic.test.ts
+++ b/apps/web/src/hosted/billing/subscription/plan-change.logic.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	defaultPlanChangeSelection,
 	isSamePlanChangeSelection,
+	performanceUpgradeUnavailableReason,
 	planChangeUnavailableReason,
 	walletBalanceAfterDebit,
 } from "./plan-change.logic";
@@ -99,5 +100,46 @@ describe("planChangeUnavailableReason", () => {
 				subscriptionId: 42,
 			}),
 		).toContain("Resolve the subscription status");
+	});
+});
+
+describe("performanceUpgradeUnavailableReason", () => {
+	const available = {
+		plansLoading: false,
+		canCreateCloudAgents: true,
+		isIncludedBasic: true,
+		performancePlanAvailable: true,
+		pendingPlanSlug: null,
+		planChangeUnavailable: null,
+		deploymentStatusSupportsUpgrade: true,
+		upgradeAvailable: true,
+	};
+
+	test("distinguishes each upgrade block from a pending upgrade", () => {
+		expect(performanceUpgradeUnavailableReason({ ...available, isIncludedBasic: false })).toContain(
+			"only available for included Basic",
+		);
+		expect(
+			performanceUpgradeUnavailableReason({ ...available, performancePlanAvailable: false }),
+		).toBe("Performance compute is unavailable right now.");
+		expect(
+			performanceUpgradeUnavailableReason({
+				...available,
+				planChangeUnavailable: "Subscription details are still syncing.",
+			}),
+		).toBe("Subscription details are still syncing.");
+		expect(
+			performanceUpgradeUnavailableReason({
+				...available,
+				pendingPlanSlug: "compute_performance",
+			}),
+		).toBe("An upgrade to Performance is already scheduled.");
+		expect(performanceUpgradeUnavailableReason({ ...available, upgradeAvailable: false })).toBe(
+			"This Basic agent is not currently eligible for an upgrade.",
+		);
+	});
+
+	test("returns no reason only when every upgrade condition is met", () => {
+		expect(performanceUpgradeUnavailableReason(available)).toBeNull();
 	});
 });

--- a/apps/web/src/hosted/billing/subscription/plan-change.logic.ts
+++ b/apps/web/src/hosted/billing/subscription/plan-change.logic.ts
@@ -87,3 +87,38 @@ export function planChangeUnavailableReason({
 	}
 	return null;
 }
+
+export function performanceUpgradeUnavailableReason({
+	plansLoading,
+	canCreateCloudAgents,
+	isIncludedBasic,
+	performancePlanAvailable,
+	pendingPlanSlug,
+	planChangeUnavailable,
+	deploymentStatusSupportsUpgrade,
+	upgradeAvailable,
+}: {
+	plansLoading: boolean;
+	canCreateCloudAgents: boolean;
+	isIncludedBasic: boolean;
+	performancePlanAvailable: boolean;
+	pendingPlanSlug: ComputePlanSlug | null;
+	planChangeUnavailable: string | null;
+	deploymentStatusSupportsUpgrade: boolean;
+	upgradeAvailable: boolean;
+}): string | null {
+	if (plansLoading) return "Checking Performance availability…";
+	if (!isIncludedBasic)
+		return "Upgrade to Performance is only available for included Basic compute.";
+	if (!canCreateCloudAgents) return "Upgrades are temporarily unavailable.";
+	if (!performancePlanAvailable) return "Performance compute is unavailable right now.";
+	if (pendingPlanSlug === COMPUTE_PERFORMANCE_SLUG) {
+		return "An upgrade to Performance is already scheduled.";
+	}
+	if (planChangeUnavailable) return planChangeUnavailable;
+	if (!deploymentStatusSupportsUpgrade) {
+		return "Upgrade is available once this Basic agent is running or stopped.";
+	}
+	if (!upgradeAvailable) return "This Basic agent is not currently eligible for an upgrade.";
+	return null;
+}

--- a/apps/web/src/hosted/hosted-deployment-tile-action.tsx
+++ b/apps/web/src/hosted/hosted-deployment-tile-action.tsx
@@ -12,7 +12,10 @@ import { useActionLock } from "@/hosted/billing/use-action-lock";
 export function HostedDeploymentTileDeleteAction({ deployment }: { deployment: HostedDeployment }) {
 	const deleteDeployment = useDeleteDeployment();
 	const runAction = useActionLock();
-	const name = deploymentDisplayName(deployment.resource.spec.name);
+	const name = deploymentDisplayName(
+		deployment.resource.spec.name,
+		deployment.resource.spec.runtime,
+	);
 
 	return (
 		<div data-hosted="true">

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -191,7 +191,7 @@ export function useHostedAgentTiles({
 export function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>): AgentTile[] {
 	if (!isHostedDeploymentMember(d)) return [];
 	const runtime = deploymentRuntime(d);
-	const slug = deploymentDisplayName(d.resource.spec.name);
+	const slug = deploymentDisplayName(d.resource.spec.name, runtime);
 	// Hosted deployments don't use last_seen_at; status is the freshness signal
 	// The deploy API projects the stable agent identity. The cloud-api env
 	// join only decorates the tile and may legitimately lag or be missing.
@@ -203,7 +203,9 @@ export function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>
 	};
 	const detailHref = envId ? agentSectionHref(envId, "overview", routeQuery) : null;
 	const settingsHref = envId ? agentSectionHref(envId, "settings", routeQuery) : undefined;
-	const name = matchedEnv ? agentDisplayName(matchedEnv) : runtimeDisplayName(runtime);
+	const name = matchedEnv
+		? deploymentDisplayName(agentDisplayName(matchedEnv), runtime)
+		: runtimeDisplayName(runtime);
 	const contextLabel = slug !== name ? slug : null;
 	const runtimeStatus = hostedRuntimeStatusView(d.resource.status, matchedEnv ?? null);
 	const dunningStatus = computeDunningTileStatus(d);

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
 	firstModelForProvider,
+	isManagedProviderId,
 	MANAGED_AI_CHOICE,
 	MANAGED_DEFAULT_MODEL_CHOICE,
 	managedModelDisplayName,
 	modelIdsForProvider,
+	providerChoiceFromRef,
 } from "@/hosted/v2/ai-providers/model-binding";
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 
@@ -49,5 +51,11 @@ describe("model binding", () => {
 		];
 
 		expect(firstModelForProvider("openai-main", providers)).toBe("gpt-5.5");
+	});
+
+	test("maps deployment-scoped managed provider ids to the friendly managed choice", () => {
+		const providerId = "clawdi-v2-deployment-10";
+		expect(isManagedProviderId(providerId)).toBe(true);
+		expect(providerChoiceFromRef(providerId, [])).toBe(MANAGED_AI_CHOICE);
 	});
 });

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.ts
@@ -1,4 +1,4 @@
-import { CLAWDI_MANAGED_PROVIDER_IDS, CLAWDI_MANAGED_V2_PROVIDER_ID } from "@clawdi/shared";
+import { CLAWDI_MANAGED_V2_PROVIDER_ID, isClawdiManagedProviderId } from "@clawdi/shared";
 import type { ManagedModelCatalogItem } from "@/hosted/billing/contracts";
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 
@@ -52,7 +52,7 @@ export function dedupeProviderIds(providerIds: readonly string[]): string[] {
 }
 
 export function isManagedProviderId(providerId: string | null | undefined): boolean {
-	return typeof providerId === "string" && CLAWDI_MANAGED_PROVIDER_IDS.has(providerId);
+	return typeof providerId === "string" && isClawdiManagedProviderId(providerId);
 }
 
 export function providerChoiceFromRef(

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -44,6 +44,8 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { deploymentDisplayName } from "@/hosted/agent-identity";
+import { isHostedRuntime } from "@/hosted/runtimes";
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
 import type {
 	ChannelActivityItem,
@@ -96,7 +98,14 @@ function findEnv(envs: EnvironmentList, agentId: string): Environment | null {
 	return envs?.find((e) => e.id === agentId) ?? null;
 }
 
-/** "machine · agent-type" label for an agent id, falling back to the raw id. */
+function runtimeNameFormatter(env: { agent_type?: string | null }) {
+	const runtime = env.agent_type;
+	return runtime && isHostedRuntime(runtime)
+		? (name: string) => deploymentDisplayName(name, runtime)
+		: undefined;
+}
+
+/** "machine · agent-type" label for an agent id, with a safe missing-agent fallback. */
 function envName(
 	envs: EnvironmentList,
 	agentId: string,
@@ -108,13 +117,16 @@ function envName(
 		? agentTextLabel(env, {
 				includeSource,
 				ownershipKind: agentOwnershipKindFromId(env.id, ownership),
+				formatName: runtimeNameFormatter(env),
 			})
-		: agentId;
+		: deploymentDisplayName(agentId);
 }
 
 function AgentName({ env, fallback }: { env: Environment | null; fallback: string }) {
 	const ownership = useAgentOwnership();
-	if (!env) return <span className="truncate text-sm font-medium">{fallback}</span>;
+	if (!env) {
+		return <span className="truncate text-sm font-medium">{deploymentDisplayName(fallback)}</span>;
+	}
 	const ownershipKind = agentOwnershipKindFromId(env.id, ownership);
 	return (
 		<AgentLabel
@@ -124,6 +136,7 @@ function AgentName({ env, fallback }: { env: Environment | null; fallback: strin
 			type={env.agent_type}
 			avatarUrl={env.avatar_url}
 			size="sm"
+			formatName={runtimeNameFormatter(env)}
 			titleAdornment={
 				<AgentSourceBadgeForEnvironment env={env} ownershipKind={ownershipKind} compact />
 			}

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
@@ -29,6 +29,8 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
+import { deploymentDisplayName } from "@/hosted/agent-identity";
+import { isHostedRuntime } from "@/hosted/runtimes";
 import { TokenReveal } from "@/hosted/v2/channels/channel-ui";
 import {
 	useAgentChannelLinks,
@@ -143,7 +145,7 @@ export function LinkAgentDialog({
 				const ownershipKind = agentOwnershipKindFromId(env.id, ownership);
 				return {
 					value: env.id,
-					label: agentTextLabel(env, { ownershipKind }),
+					label: agentOptionLabel(env, ownershipKind),
 				};
 			}),
 		[agents, ownership],
@@ -268,7 +270,14 @@ function agentOptionLabel(
 	},
 	ownershipKind: AgentOwnershipKind,
 ): string {
-	return agentTextLabel(env, { ownershipKind });
+	return agentTextLabel(env, { ownershipKind, formatName: runtimeNameFormatter(env) });
+}
+
+function runtimeNameFormatter(env: { agent_type?: string | null }) {
+	const runtime = env.agent_type;
+	return runtime && isHostedRuntime(runtime)
+		? (name: string) => deploymentDisplayName(name, runtime)
+		: undefined;
 }
 
 function AgentOption({
@@ -286,6 +295,7 @@ function AgentOption({
 			type={env.agent_type}
 			avatarUrl={env.avatar_url}
 			size="sm"
+			formatName={runtimeNameFormatter(env)}
 			titleAdornment={
 				<AgentSourceBadgeForEnvironment env={env} ownershipKind={ownershipKind} compact />
 			}


### PR DESCRIPTION
## v2 hosted UI display consistency (owner-reported + audit findings)

Rebased onto main (after #458 catalog).

1. **Friendly names everywhere** — `deploymentDisplayName` now intercepts empty / bare-UUID / `deployment-create-*` and falls back to the runtime label (`Hermes`/`OpenClaw`). Applied at detail title, breadcrumb, delete dialog, Terminal label, tiles, deployment chooser, settings, v2 channel agent labels. No raw internal id/uuid surfaces as a name.
2. **Runtime UI** — restored inline iframe **and** open-in-new-window; added a top **Show/Hide credentials** control (Hermes username/password; OpenClaw token from verified URL fragment). Native auth model preserved, no bridge/redemption.
3. **Managed provider identity** — `model-binding.ts` uses the shared prefix-aware `isClawdiManagedProviderId` predicate; deployment-scoped ids (`clawdi-v2-deployment-<id>`) map to the selected **"Managed by Clawdi"** choice instead of leaking a raw id.
4. **Upgrade copy** — `plan-change.logic.ts` distinguishes not-included-Basic / plan-unavailable / plan-change-blocked / Performance-already-scheduled / unsupported-status / backend flag, replacing the misleading "may already be pending" guess.

v1 untouched. typecheck / lint / hosted E2E green on the pre-rebase commit; CI re-verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)