### PR TITLE
fix(web): declarative instant-release for stop/restart/delete + settings Apply

### DIFF
--- a/apps/web/src/components/ui/confirm-action.tsx
+++ b/apps/web/src/components/ui/confirm-action.tsx
@@ -33,7 +33,8 @@ export function ConfirmAction({
 	destructive?: boolean;
 	/**
 	 * May be sync or async (any return). When it returns a promise the dialog
-	 * stays open with a spinner until it settles, then closes.
+	 * stays open with a spinner until it settles, then closes. Long-running
+	 * background work should resolve this promise when the action is accepted.
 	 */
 	onConfirm: () => unknown;
 }) {
@@ -70,8 +71,8 @@ export function ConfirmAction({
 				<AlertDialogFooter>
 					<AlertDialogCancel disabled={pending}>{cancelLabel}</AlertDialogCancel>
 					<AlertDialogAction
-						// Keep the dialog open until the action settles; the success path closes
-						// explicitly after the mutation finishes.
+						// Keep the dialog open until the caller settles; accepted background work
+						// closes here while status polling reflects its eventual outcome.
 						onClick={(event) => {
 							event.preventDefault();
 							// runConfirm rejects when onConfirm does; the dialog already stays open

--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -1,12 +1,22 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { QueryClient } from "@tanstack/react-query";
+import type { DeploymentOperation, HostedDeployment } from "@/hosted/billing/contracts";
 import { billingKeys } from "@/hosted/billing/query-keys";
+import { deploymentFailureReason } from "@/hosted/deployment-failure";
+import {
+	DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS,
+	deploymentRefetchInterval,
+} from "@/hosted/deployment-status";
+import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 
 type InvalidateDeploymentSnapshots =
 	typeof import("@/hosted/agents/deployment-hooks").invalidateDeploymentSnapshots;
+type ProjectAcceptedDeploymentTransition =
+	typeof import("@/hosted/agents/deployment-hooks").projectAcceptedDeploymentTransition;
 
 let invalidateSnapshots: InvalidateDeploymentSnapshots | null = null;
+let projectAcceptedTransition: ProjectAcceptedDeploymentTransition | null = null;
 
 beforeAll(async () => {
 	process.env.VITE_CLAWDI_API_URL = "http://localhost:8000";
@@ -14,7 +24,25 @@ beforeAll(async () => {
 	process.env.VITE_CLERK_PUBLISHABLE_KEY = "pk_test_dummy";
 	const module = await import("@/hosted/agents/deployment-hooks");
 	invalidateSnapshots = module.invalidateDeploymentSnapshots;
+	projectAcceptedTransition = module.projectAcceptedDeploymentTransition;
 });
+
+function acceptedOperation(verb: DeploymentOperation["metadata"]["verb"]): DeploymentOperation {
+	return {
+		name: `operations/${verb}-accepted`,
+		metadata: {
+			"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
+			deploymentId: "hdep_test",
+			verb,
+			targetGeneration: 2,
+			manifestETag: "manifest-accepted",
+			createTime: "2026-07-24T00:00:00Z",
+			updateTime: "2026-07-24T00:00:00Z",
+		},
+		done: false,
+		response: null,
+	};
+}
 
 describe("deployment mutation settlement", () => {
 	test("invalidates deployment membership and its additive agent projection together", () => {
@@ -38,5 +66,71 @@ describe("deployment mutation settlement", () => {
 		// Declarative lifecycle, delete, and settings updates all reconcile even
 		// when the request rejects or times out.
 		expect(settlementInvalidations).toHaveLength(3);
+	});
+
+	test("projects accepted operations into promptly-polled transition states", () => {
+		if (!projectAcceptedTransition) throw new Error("deployment hooks were not loaded");
+		const expectations = [
+			["start", "starting"],
+			["stop", "stopping"],
+			["restart", "restarting"],
+			["update", "updating"],
+			["delete", "deleting"],
+		] as const;
+
+		for (const [verb, status] of expectations) {
+			const queryClient = new QueryClient();
+			queryClient.setQueryData<HostedDeployment[]>(billingKeys.deployments, [
+				hostedDeploymentFixture({ id: "hdep_test" }),
+			]);
+			const operation = acceptedOperation(verb);
+			projectAcceptedTransition(queryClient, "hdep_test", status, operation);
+			const deployments = queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments);
+
+			expect(deployments?.[0]?.resource.status.summary_state).toBe(status);
+			expect(deployments?.[0]?.accepted_operation).toEqual(operation);
+			expect(
+				deploymentRefetchInterval(
+					deployments?.map((deployment) => ({
+						status: deployment.resource.status.summary_state,
+					})),
+				),
+			).toBe(DEPLOYMENT_TRANSITIONAL_POLL_INTERVAL_MS);
+		}
+	});
+
+	test("keeps an accepted delete in cache so a later failure can replace it", () => {
+		if (!projectAcceptedTransition) throw new Error("deployment hooks were not loaded");
+		const queryClient = new QueryClient();
+		queryClient.setQueryData<HostedDeployment[]>(billingKeys.deployments, [
+			hostedDeploymentFixture({ id: "hdep_delete" }),
+		]);
+		projectAcceptedTransition(queryClient, "hdep_delete", "deleting", acceptedOperation("delete"));
+
+		const deleting = queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments);
+		expect(deleting).toHaveLength(1);
+		expect(deleting?.[0]?.resource.status.summary_state).toBe("deleting");
+
+		const failure = {
+			type: "https://api.clawdi.ai/problems/deployment-delete-failed",
+			title: "Deployment deletion failed",
+			status: 409,
+			detail: "The deployment could not be deleted.",
+			instance: "hdep_delete",
+			code: "deployment_delete_failed",
+			conditionReason: "DeploymentDeleteFailed",
+			conditionMessage: "The deployment could not be deleted.",
+			observedGeneration: 2,
+		};
+		queryClient.setQueryData<HostedDeployment[]>(billingKeys.deployments, [
+			hostedDeploymentFixture({ id: "hdep_delete", status: "failed", failure }),
+		]);
+
+		const failed = queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments);
+		expect(failed).toHaveLength(1);
+		expect(failed?.[0]?.resource.status.summary_state).toBe("failed");
+		expect(deploymentFailureReason(failed?.[0]?.resource.status ?? {})).toBe(
+			"Deployment deletion failed",
+		);
 	});
 });

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -4,7 +4,12 @@ import { type QueryClient, useMutation, useQueryClient } from "@tanstack/react-q
 import { useMemo } from "react";
 import { toast } from "sonner";
 import { useBillingClient } from "@/hosted/billing/billing-client";
-import type { DeploymentUpdateRequest } from "@/hosted/billing/contracts";
+import type {
+	DeploymentOperation,
+	DeploymentUpdateRequest,
+	HostedDeployment,
+	HostedDeploymentStatus,
+} from "@/hosted/billing/contracts";
 import {
 	DeploymentConflictError,
 	isNetworkError,
@@ -36,6 +41,28 @@ function scheduleDeploymentSettlingRefresh(qc: QueryClient) {
 			void qc.invalidateQueries({ queryKey: ["agents"] });
 		}, delay);
 	}
+}
+
+export function projectAcceptedDeploymentTransition(
+	qc: QueryClient,
+	deploymentId: string,
+	status: HostedDeploymentStatus["summary_state"],
+	operation: DeploymentOperation,
+) {
+	qc.setQueryData<HostedDeployment[]>(billingKeys.deployments, (deployments) =>
+		deployments?.map((deployment) =>
+			deployment.resource.id === deploymentId
+				? {
+						...deployment,
+						accepted_operation: operation,
+						resource: {
+							...deployment.resource,
+							status: { ...deployment.resource.status, summary_state: status },
+						},
+					}
+				: deployment,
+		),
+	);
 }
 
 async function runStableDeploymentIntent<T>(
@@ -131,15 +158,18 @@ export function useDeploymentLifecycle() {
 					idempotencyKey,
 				);
 			}),
-		onSuccess: (_d, vars) => {
+		onSuccess: (operation, vars) => {
+			const status =
+				vars.action === "restart" ? "restarting" : vars.action === "stop" ? "stopping" : "starting";
+			projectAcceptedDeploymentTransition(qc, vars.id, status, operation);
 			scheduleDeploymentSettlingRefresh(qc);
 			const msg =
 				vars.action === "restart"
-					? "Agent restarted"
+					? "Restarting…"
 					: vars.action === "stop"
-						? "Agent stopped"
-						: "Agent started";
-			toast.success(msg);
+						? "Stopping…"
+						: "Starting…";
+			toast.message(msg);
 		},
 		onError: (error) => {
 			if (toastDeploymentConflict(error)) return;
@@ -157,9 +187,10 @@ export function useDeleteDeployment() {
 			runStableDeploymentIntent("deployment-delete", { action: "delete", id }, (key) =>
 				client.deleteDeployment(id, key),
 			),
-		onSuccess: () => {
+		onSuccess: (operation, id) => {
+			projectAcceptedDeploymentTransition(qc, id, "deleting", operation);
 			scheduleDeploymentSettlingRefresh(qc);
-			toast.success("Agent deleted");
+			toast.message("Deleting…");
 		},
 		onError: (error) => {
 			if (toastDeploymentConflict(error)) return;
@@ -177,9 +208,10 @@ export function useUpdateDeployment() {
 			runStableDeploymentIntent("deployment-update", vars, (key) =>
 				client.updateDeployment(vars.id, vars.update, key),
 			),
-		onSuccess: () => {
+		onSuccess: (operation, vars) => {
+			projectAcceptedDeploymentTransition(qc, vars.id, "updating", operation);
 			scheduleDeploymentSettlingRefresh(qc);
-			toast.success("Agent settings updated");
+			toast.message("Applying agent settings…");
 		},
 		onError: (error) => {
 			if (toastDeploymentConflict(error)) return;

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -134,6 +134,7 @@ import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
 import { topUpAmountCentsForCreditShortfall } from "@/hosted/billing/wallet/top-up-dialog.logic";
 import { deploymentFailureReason } from "@/hosted/deployment-failure";
 import {
+	canDelete as canDeleteDeployment,
 	canRestart as canRestartDeployment,
 	canStart as canStartDeployment,
 	canStop as canStopDeployment,
@@ -333,6 +334,8 @@ function DeleteComputeAction({ deployment }: { deployment: HostedDeployment }) {
 	const router = useRouter();
 	const deleteDeployment = useDeleteDeployment();
 	const runAction = useActionLock();
+	const status = parseDeploymentStatus(deployment.resource.status.summary_state);
+	const canDelete = canDeleteDeployment(status);
 	return (
 		<ConfirmAction
 			title={`Delete ${deploymentDisplayName(
@@ -345,11 +348,16 @@ function DeleteComputeAction({ deployment }: { deployment: HostedDeployment }) {
 			onConfirm={() =>
 				runAction(async () => {
 					await deleteDeployment.mutateAsync(deployment.resource.id);
-					await router.navigate({ href: "/" });
+					void router.navigate({ href: "/" });
 				})
 			}
 		>
-			<Button type="button" variant="destructive" size="sm" disabled={deleteDeployment.isPending}>
+			<Button
+				type="button"
+				variant="destructive"
+				size="sm"
+				disabled={deleteDeployment.isPending || !canDelete}
+			>
 				{deleteDeployment.isPending ? <Spinner /> : <Trash2 />}
 				Delete
 			</Button>
@@ -1538,6 +1546,8 @@ function AiProviderTab({
 	const providers = useAiProviders();
 	const managedModelCatalog = useManagedModelCatalog();
 	const updateDeployment = useUpdateDeployment();
+	const updateInProgress =
+		parseDeploymentStatus(deployment.resource.status.summary_state).kind === "updating";
 	const runtimeConfiguration = deployment.resource.spec.runtime_configuration;
 	const list = providers.data?.providers ?? [];
 	const customProviders = useMemo(
@@ -1870,7 +1880,10 @@ function AiProviderTab({
 			)}
 
 			<div className="flex items-center gap-2">
-				<Button disabled={!dirty || updateDeployment.isPending} onClick={applyProviderSettings}>
+				<Button
+					disabled={!dirty || updateDeployment.isPending || updateInProgress}
+					onClick={applyProviderSettings}
+				>
 					{updateDeployment.isPending ? <Spinner className="size-3.5" /> : null}
 					{dirty ? "Apply provider settings" : "No changes"}
 				</Button>
@@ -2324,6 +2337,8 @@ function LanguageTimezoneSettingsSection({
 	const configTimezone = runtimeConfiguration.timezone ?? "";
 	const runtimeLabel = runtimeDisplayName(runtime);
 	const updateDeployment = useUpdateDeployment();
+	const updateInProgress =
+		parseDeploymentStatus(deployment.resource.status.summary_state).kind === "updating";
 	const localeIdentity = `${configLanguage}\0${configTimezone}`;
 	const [syncedLocaleIdentity, setSyncedLocaleIdentity] = useState(localeIdentity);
 	const [language, setLanguage] = useState(configLanguage);
@@ -2379,7 +2394,7 @@ function LanguageTimezoneSettingsSection({
 				</div>
 				<div>
 					<Button
-						disabled={!dirty || updateDeployment.isPending}
+						disabled={!dirty || updateDeployment.isPending || updateInProgress}
 						onClick={() =>
 							updateDeployment.mutate({
 								id: deployment.resource.id,
@@ -2424,8 +2439,15 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 	const canStop = canStopDeployment(deploymentStatus);
 	const canStart = canStartDeployment(deploymentStatus);
 	const canRestart = canRestartDeployment(deploymentStatus);
-	const primaryLifecycleAction: "stop" | "start" = canStop ? "stop" : "start";
-	const canRunPrimaryLifecycleAction = canStop || canStart;
+	const canDelete = canDeleteDeployment(deploymentStatus);
+	const primaryLifecycleAction: "stop" | "start" =
+		canStop ||
+		deploymentStatus.kind === "stopping" ||
+		deploymentStatus.kind === "restarting" ||
+		deploymentStatus.kind === "updating"
+			? "stop"
+			: "start";
+	const canRunPrimaryLifecycleAction = primaryLifecycleAction === "stop" ? canStop : canStart;
 	const fundingFact = deployment.commercial_display?.latest_funding_fact;
 	const rawComputePlanSlug = deployment.current_plan_slug;
 	const computePlanSlug =
@@ -2680,7 +2702,7 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 
 	async function deleteCompute() {
 		await del.mutateAsync(deployment.resource.id);
-		await router.navigate({ href: "/" });
+		void router.navigate({ href: "/" });
 	}
 
 	return (
@@ -2917,7 +2939,7 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 							Restart
 						</Button>
 					</ConfirmAction>
-					{canStop ? (
+					{primaryLifecycleAction === "stop" ? (
 						<ConfirmAction
 							title="Stop compute?"
 							description={
@@ -2986,7 +3008,7 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 							variant="outline"
 							size="sm"
 							className="text-destructive"
-							disabled={del.isPending}
+							disabled={del.isPending || !canDelete}
 						>
 							<Trash2 className="size-3.5" />
 							Delete

--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -294,4 +294,127 @@ describe("declarative deployment mutations", () => {
 			expect(request.headers.get("If-Match")).toMatch(/^"rv-hdep_[a-z]+"$/);
 		}
 	});
+
+	it("releases lifecycle and settings mutations as soon as their LROs are accepted", async () => {
+		const requests: Request[] = [];
+		const client = testClient(async (request) => {
+			requests.push(request.clone());
+			const path = new URL(request.url).pathname;
+			if (request.method === "GET" && path.startsWith("/v2/deployments/")) {
+				const id = path.slice("/v2/deployments/".length);
+				return jsonResponse(hostedDeploymentFixture({ id, resourceVersion: `rv-${id}` }));
+			}
+			if (path.startsWith("/v2/operations/")) {
+				throw new Error("Accepted declarative mutations must not poll their operations");
+			}
+			const verb = path.endsWith("/restart")
+				? "restart"
+				: path.endsWith("/start")
+					? "start"
+					: path.endsWith("/stop")
+						? "stop"
+						: request.method === "DELETE"
+							? "delete"
+							: "update";
+			return jsonResponse(operation({ done: false, id: `accepted-${verb}`, verb }), 202);
+		});
+
+		const accepted = await Promise.all([
+			client.setDeploymentDesiredState("hdep_start", "running", "intent-start"),
+			client.setDeploymentDesiredState("hdep_stop", "stopped", "intent-stop"),
+			client.restartDeployment("hdep_restart", "intent-restart"),
+			client.updateDeployment(
+				"hdep_provider",
+				{
+					ai_provider_auth_kind: "managed",
+					provider_ids: ["managed"],
+					primary_model: { provider_id: "managed", model: "gpt-5.6-luna" },
+				},
+				"intent-provider",
+			),
+			client.updateDeployment(
+				"hdep_locale",
+				{ language: "fr", timezone: "Europe/Paris" },
+				"intent-locale",
+			),
+			client.deleteDeployment("hdep_delete", "intent-delete"),
+		]);
+
+		expect(accepted.map((item) => item.done)).toEqual([false, false, false, false, false, false]);
+		expect(
+			requests.filter((request) => new URL(request.url).pathname.startsWith("/v2/operations/")),
+		).toHaveLength(0);
+	});
+
+	it("keeps an accepted delete visible when reconciliation later fails", async () => {
+		const failure = {
+			type: "https://api.clawdi.ai/problems/deployment-delete-failed",
+			title: "Deployment deletion failed",
+			status: 409,
+			detail: "The deployment could not be deleted.",
+			instance: "hdep_delete_failure",
+			code: "deployment_delete_failed",
+			conditionReason: "DeploymentDeleteFailed",
+			conditionMessage: "The deployment could not be deleted.",
+			observedGeneration: 2,
+		};
+		const failedDeployment = hostedDeploymentFixture({
+			id: "hdep_delete_failure",
+			status: "failed",
+			failure,
+		});
+		const client = testClient(async (request) => {
+			const path = new URL(request.url).pathname;
+			if (path === "/v2/deployments/hdep_delete_failure" && request.method === "GET") {
+				return jsonResponse(hostedDeploymentFixture({ id: "hdep_delete_failure" }));
+			}
+			if (path === "/v2/deployments/hdep_delete_failure" && request.method === "DELETE") {
+				return jsonResponse(operation({ done: false, id: "delete-failure", verb: "delete" }), 202);
+			}
+			if (path === "/v2/deployments" && request.method === "GET") {
+				return jsonResponse([failedDeployment]);
+			}
+			throw new Error(`Unexpected request: ${request.method} ${path}`);
+		});
+
+		await expect(
+			client.deleteDeployment("hdep_delete_failure", "intent-delete-failure"),
+		).resolves.toMatchObject({ done: false, name: "operations/delete-failure" });
+		await expect(client.listDeployments()).resolves.toMatchObject([
+			{
+				resource: {
+					id: "hdep_delete_failure",
+					status: { summary_state: "failed", failure },
+				},
+			},
+		]);
+	});
+});
+
+describe("compute plan changes", () => {
+	it("settles from its direct response without polling a deployment operation", async () => {
+		const requests: Request[] = [];
+		const client = testClient(async (request) => {
+			requests.push(request.clone());
+			return jsonResponse({
+				operation_id: "plan-change-1",
+				subscription_id: 42,
+				funding_source: "wallet",
+				current_plan_slug: "compute_basic",
+				target_plan_slug: "compute_performance",
+				target_billing_term_months: 1,
+				status: "awaiting_projection",
+				effective_at: NOW,
+			});
+		});
+
+		await expect(client.changePlan({ operation_id: "plan-change-1" })).resolves.toMatchObject({
+			operation_id: "plan-change-1",
+			status: "awaiting_projection",
+		});
+		expect(requests).toHaveLength(1);
+		expect(new URL(requests[0]?.url ?? "https://invalid").pathname).toBe(
+			"/v2/subscription/plan/change",
+		);
+	});
 });

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -268,7 +268,7 @@ export function createBillingClient(
 				}
 				throw new DeploymentConflictError({ cause: error });
 			}
-			return waitForOperation(accepted);
+			return accepted;
 		}
 		throw new DeploymentConflictError();
 	};

--- a/apps/web/src/hosted/deployment-status.test.ts
+++ b/apps/web/src/hosted/deployment-status.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+	canDelete,
 	canRestart,
 	canStart,
 	canStop,
@@ -100,12 +101,12 @@ describe("DeploymentStatus", () => {
 	test("drives lifecycle gates from hosted backend statuses", () => {
 		const expectations = [
 			["creating", false, false, false],
-			["starting", false, true, true],
+			["starting", false, true, false],
 			["running", false, true, true],
 			["stopping", false, false, false],
 			["stopped", true, false, false],
-			["restarting", false, true, true],
-			["updating", false, true, true],
+			["restarting", false, false, false],
+			["updating", false, false, false],
 			["failed", true, false, true],
 			["deleting", false, false, false],
 			["deleted", false, false, false],
@@ -125,6 +126,13 @@ describe("DeploymentStatus", () => {
 			expect(canStop(status)).toBe(stop);
 			expect(canRestart(status)).toBe(restart);
 		}
+	});
+
+	test("disables delete once deletion is in progress or complete", () => {
+		expect(canDelete(parseDeploymentStatus("running"))).toBe(true);
+		expect(canDelete(parseDeploymentStatus("failed"))).toBe(true);
+		expect(canDelete(parseDeploymentStatus("deleting"))).toBe(false);
+		expect(canDelete(parseDeploymentStatus("deleted"))).toBe(false);
 	});
 
 	test("polls while any deployment is non-terminal", () => {

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -184,12 +184,12 @@ export function canStop(status: DeploymentStatus): boolean {
 	switch (status.kind) {
 		case "running":
 		case "starting":
-		case "restarting":
-		case "updating":
 			return true;
 		case "creating":
 		case "stopping":
 		case "stopped":
+		case "restarting":
+		case "updating":
 		case "failed":
 		case "deleting":
 		case "deleted":
@@ -203,14 +203,14 @@ export function canStop(status: DeploymentStatus): boolean {
 export function canRestart(status: DeploymentStatus): boolean {
 	switch (status.kind) {
 		case "running":
-		case "starting":
 		case "failed":
-		case "restarting":
-		case "updating":
 			return true;
 		case "creating":
+		case "starting":
 		case "stopping":
 		case "stopped":
+		case "restarting":
+		case "updating":
 		case "deleting":
 		case "deleted":
 		case "unknown":
@@ -218,6 +218,10 @@ export function canRestart(status: DeploymentStatus): boolean {
 		default:
 			return exhaustive(status);
 	}
+}
+
+export function canDelete(status: DeploymentStatus): boolean {
+	return status.kind !== "deleting" && status.kind !== "deleted";
 }
 
 export function shouldPollDeployments(

--- a/apps/web/src/hosted/hosted-deployment-tile-action.tsx
+++ b/apps/web/src/hosted/hosted-deployment-tile-action.tsx
@@ -8,6 +8,7 @@ import { deploymentDisplayName } from "@/hosted/agent-identity";
 import { useDeleteDeployment } from "@/hosted/agents/deployment-hooks";
 import type { HostedDeployment } from "@/hosted/billing/contracts";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
+import { canDelete, parseDeploymentStatus } from "@/hosted/deployment-status";
 
 export function HostedDeploymentTileDeleteAction({ deployment }: { deployment: HostedDeployment }) {
 	const deleteDeployment = useDeleteDeployment();
@@ -16,6 +17,7 @@ export function HostedDeploymentTileDeleteAction({ deployment }: { deployment: H
 		deployment.resource.spec.name,
 		deployment.resource.spec.runtime,
 	);
+	const deleteEnabled = canDelete(parseDeploymentStatus(deployment.resource.status.summary_state));
 
 	return (
 		<div data-hosted="true">
@@ -35,7 +37,7 @@ export function HostedDeploymentTileDeleteAction({ deployment }: { deployment: H
 					variant="ghost"
 					size="icon-sm"
 					className="text-muted-foreground"
-					disabled={deleteDeployment.isPending}
+					disabled={deleteDeployment.isPending || !deleteEnabled}
 					aria-label={`Delete ${name}`}
 					title={`Delete ${name}`}
 				>


### PR DESCRIPTION
## Declarative instant-release for all v2 lifecycle + settings operations

Owner hit it: Delete (also Stop/Restart/Apply) hung the confirm dialog for up to ~2 min. Root: `acceptDeploymentMutation` awaited the full LRO (`waitForOperation`) even though the declarative API returns **202 Accepted** = "spec change accepted". Deploy was already instant (#460); lifecycle/settings were not.

## Change
- `acceptDeploymentMutation` now returns the accepted 202 `DeploymentOperation` immediately; `waitForOperation` stays only for creation/request-resolution. Idempotency-Key / If-Match / precondition-retry unchanged.
- Converted: start, stop, restart, delete, provider/model Apply, language/timezone Apply. (Plan-change already returns 200 with no LRO — no change.)
- Confirm dialogs close on acceptance; transient toasts ("Deleting…"/"Stopping…"/"Applying agent settings…") — no premature success.
- Accepted ops project the transition state (deleting/stopping/restarting/updating) into cache → 10s transition polling picks up convergence.
- **Delete never optimistically removes the deployment** — a later `failed` snapshot replaces `deleting`, preserving the tile and surfacing the failure reason (no silent vanish).
- Transition gating prevents duplicate lifecycle/Apply/Delete actions.

v1 untouched. typecheck + lint pass; 57 focused billing/agent tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)