### PR TITLE
fix(web): personalize v2 deploy agent name + clearer free-Basic copy

### DIFF
--- a/apps/web/src/hosted/billing/deploy/deploy-defaults.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-defaults.test.ts
@@ -6,6 +6,7 @@ import {
 	DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE,
 	DEFAULT_DEPLOY_RUNTIME,
 	defaultManagedDeployAiFields,
+	deployAssistantNameAfterRuntimeChange,
 } from "@/hosted/billing/deploy/deploy-defaults";
 import {
 	MANAGED_AI_CHOICE,
@@ -30,5 +31,22 @@ describe("deploy wizard defaults", () => {
 		});
 		expect(defaultManagedDeployAiFields()).not.toHaveProperty("primary_model");
 		expect(JSON.stringify(defaultManagedDeployAiFields())).not.toContain("gpt-5.5");
+	});
+
+	test("follows runtime display names until the agent name is edited", () => {
+		expect(
+			deployAssistantNameAfterRuntimeChange({
+				currentName: "Hermes",
+				hasBeenEdited: false,
+				runtime: "openclaw",
+			}),
+		).toBe("OpenClaw");
+		expect(
+			deployAssistantNameAfterRuntimeChange({
+				currentName: "Research Assistant",
+				hasBeenEdited: true,
+				runtime: "hermes",
+			}),
+		).toBe("Research Assistant");
 	});
 });

--- a/apps/web/src/hosted/billing/deploy/deploy-defaults.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-defaults.ts
@@ -1,5 +1,5 @@
 import type { DeployAiFields } from "@/hosted/billing/deploy/deploy-request";
-import type { HostedRuntime } from "@/hosted/runtimes";
+import { type HostedRuntime, runtimeDisplayName } from "@/hosted/runtimes";
 import {
 	MANAGED_AI_CHOICE,
 	MANAGED_DEFAULT_MODEL_CHOICE,
@@ -15,6 +15,18 @@ export const DEFAULT_DEPLOY_AI_ACCESS_MODE: DeployWizardAiAccessMode = "configur
 export const DEFAULT_DEPLOY_AI_PROVIDER_CHOICES = [MANAGED_AI_CHOICE] as const;
 export const DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE = MANAGED_AI_CHOICE;
 export const DEFAULT_DEPLOY_PRIMARY_MODEL = MANAGED_DEFAULT_MODEL_CHOICE;
+
+export function deployAssistantNameAfterRuntimeChange({
+	currentName,
+	hasBeenEdited,
+	runtime,
+}: {
+	currentName: string;
+	hasBeenEdited: boolean;
+	runtime: HostedRuntime;
+}): string {
+	return hasBeenEdited ? currentName : runtimeDisplayName(runtime);
+}
 
 export function defaultManagedDeployAiFields(): DeployAiFields {
 	return {

--- a/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
@@ -11,6 +11,7 @@ describe("buildHostedDeployRequest", () => {
 			computePlanSlug: "compute_basic",
 			runtime: DEFAULT_DEPLOY_RUNTIME,
 			persona: {
+				assistantName: "Hermes",
 				language: "",
 				timezone: "",
 			},
@@ -20,6 +21,7 @@ describe("buildHostedDeployRequest", () => {
 		expect(request).toEqual({
 			compute_plan_slug: "compute_basic",
 			runtime: "hermes",
+			assistant_name: "Hermes",
 			language: null,
 			timezone: null,
 			ai_provider_id: null,
@@ -27,13 +29,12 @@ describe("buildHostedDeployRequest", () => {
 			provider_ids: ["clawdi-v2"],
 			config: {
 				runtime: "hermes",
+				assistant_name: "Hermes",
 				language: null,
 				timezone: null,
 			},
 		});
 		expect(request).not.toHaveProperty("primary_model");
-		expect("assistant_name" in request).toBe(false);
-		expect("assistant_name" in (request.config ?? {})).toBe(false);
 		expect("personality" in request).toBe(false);
 		expect("personality" in (request.config ?? {})).toBe(false);
 	});
@@ -43,6 +44,7 @@ describe("buildHostedDeployRequest", () => {
 			computePlanSlug: "compute_performance",
 			runtime: "openclaw",
 			persona: {
+				assistantName: "  OpenClaw Studio  ",
 				language: "en",
 				timezone: "America/Los_Angeles",
 			},
@@ -50,21 +52,21 @@ describe("buildHostedDeployRequest", () => {
 		});
 
 		expect("profile" in request).toBe(false);
-		expect("assistant_name" in request).toBe(false);
 		expect("personality" in request).toBe(false);
 		expect(request).toMatchObject({
 			compute_plan_slug: "compute_performance",
 			runtime: "openclaw",
+			assistant_name: "OpenClaw Studio",
 			language: "en",
 			timezone: "America/Los_Angeles",
 			ai_provider_auth_kind: "managed",
 			config: {
 				runtime: "openclaw",
+				assistant_name: "OpenClaw Studio",
 				language: "en",
 				timezone: "America/Los_Angeles",
 			},
 		});
-		expect("assistant_name" in (request.config ?? {})).toBe(false);
 		expect("personality" in (request.config ?? {})).toBe(false);
 		expect("telegram_bot_token" in request).toBe(false);
 		expect("telegram_bot_token" in (request.config ?? {})).toBe(false);
@@ -79,6 +81,7 @@ describe("buildHostedDeployRequest", () => {
 			computePlanSlug: "compute_basic",
 			runtime: "hermes",
 			persona: {
+				assistantName: "Hermes",
 				language: "en",
 				timezone: "Etc/UTC",
 			},
@@ -88,10 +91,12 @@ describe("buildHostedDeployRequest", () => {
 		expect(request).toMatchObject({
 			compute_plan_slug: "compute_basic",
 			runtime: "hermes",
+			assistant_name: "Hermes",
 			language: "en",
 			timezone: "Etc/UTC",
 			config: {
 				runtime: "hermes",
+				assistant_name: "Hermes",
 				language: "en",
 				timezone: "Etc/UTC",
 			},
@@ -103,6 +108,7 @@ describe("buildHostedDeployRequest", () => {
 			computePlanSlug: "compute_performance",
 			runtime: "hermes",
 			persona: {
+				assistantName: "Hermes",
 				language: "",
 				timezone: "",
 			},
@@ -136,6 +142,7 @@ describe("buildHostedDeployRequest", () => {
 			computePlanSlug: "compute_basic",
 			runtime: "hermes",
 			persona: {
+				assistantName: "Hermes",
 				language: "",
 				timezone: "",
 			},
@@ -145,11 +152,13 @@ describe("buildHostedDeployRequest", () => {
 		expect(request).toEqual({
 			compute_plan_slug: "compute_basic",
 			runtime: "hermes",
+			assistant_name: "Hermes",
 			language: null,
 			timezone: null,
 			ai_provider_auth_kind: "unmanaged",
 			config: {
 				runtime: "hermes",
+				assistant_name: "Hermes",
 				language: null,
 				timezone: null,
 			},

--- a/apps/web/src/hosted/billing/deploy/deploy-request.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-request.ts
@@ -7,9 +7,12 @@ import { normalizeHostedLanguage } from "@/hosted/billing/deploy/language-timezo
 import type { HostedRuntime } from "@/hosted/runtimes";
 
 type DeployPersona = {
+	assistantName: string;
 	language: string;
 	timezone: string;
 };
+
+export const DEPLOY_ASSISTANT_NAME_MAX_LENGTH = 255;
 
 export type DeployAiFields = Pick<DeployRequest, "ai_provider_auth_kind"> &
 	Partial<
@@ -30,10 +33,12 @@ export function buildHostedDeployRequest({
 	persona: DeployPersona;
 	aiFields: DeployAiFields;
 }): DeployRequest {
+	const assistantName = persona.assistantName.trim();
 	const language = normalizeHostedLanguage(persona.language);
 	const timezone = persona.timezone.trim() || null;
 	const { ai_provider_auth_kind, ...restAiFields } = aiFields;
 	const personaFields = {
+		assistant_name: assistantName,
 		language,
 		timezone,
 	};

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { DEPLOY_ASSISTANT_NAME_MAX_LENGTH } from "@/hosted/billing/deploy/deploy-request";
+
+const wizardSource = readFileSync(new URL("./deploy-wizard.tsx", import.meta.url), "utf8");
+const planComparisonSource = readFileSync(
+	new URL("../subscription/plan-comparison.tsx", import.meta.url),
+	"utf8",
+);
+
+describe("deploy wizard personalization", () => {
+	test("renders the required bounded agent name input", () => {
+		expect(wizardSource).toContain('htmlFor="agent-name"');
+		expect(wizardSource).toContain('id="agent-name"');
+		expect(wizardSource).toContain("maxLength={DEPLOY_ASSISTANT_NAME_MAX_LENGTH}");
+		expect(DEPLOY_ASSISTANT_NAME_MAX_LENGTH).toBe(255);
+		expect(wizardSource).toContain("required");
+	});
+});
+
+describe("first Basic agent copy", () => {
+	test("describes the first Basic agent as free instead of included", () => {
+		expect(wizardSource).toContain("First Basic agent — Free");
+		expect(wizardSource).toContain('message: "Your first Basic agent is free.');
+		expect(wizardSource).toContain('? "Free"');
+		expect(wizardSource).not.toContain("included Basic slot");
+		expect(wizardSource).not.toContain("included Basic deployment");
+		expect(wizardSource).not.toContain("included slot");
+		expect(planComparisonSource).toContain("The first active Basic agent is free.");
+		expect(planComparisonSource).toContain("Your first active Basic agent is free.");
+		expect(planComparisonSource).not.toContain("agent is included");
+	});
+});

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -67,6 +67,7 @@ import {
 	DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE,
 	DEFAULT_DEPLOY_RUNTIME,
 	type DeployWizardAiAccessMode,
+	deployAssistantNameAfterRuntimeChange,
 } from "@/hosted/billing/deploy/deploy-defaults";
 import {
 	resolveBasicDeploySelection,
@@ -74,6 +75,7 @@ import {
 } from "@/hosted/billing/deploy/deploy-model";
 import {
 	buildHostedDeployRequest,
+	DEPLOY_ASSISTANT_NAME_MAX_LENGTH,
 	type DeployAiFields,
 } from "@/hosted/billing/deploy/deploy-request";
 import {
@@ -135,7 +137,7 @@ import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
 import { topUpAmountCentsForCreditShortfall } from "@/hosted/billing/wallet/top-up-dialog.logic";
 import { walletDebitShortfallCredits } from "@/hosted/billing/wallet/wallet-debit-summary";
-import { runtimeBlurb, runtimeDisplayName } from "@/hosted/runtimes";
+import { type HostedRuntime, runtimeBlurb, runtimeDisplayName } from "@/hosted/runtimes";
 import { AddProviderDialog } from "@/hosted/v2/ai-providers/add-provider-dialog";
 import { useAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import { AuthBadge, ProviderTypeChip } from "@/hosted/v2/ai-providers/ai-providers-ui";
@@ -358,7 +360,7 @@ function computeStatusLine({
 		if (basicSelection.mode === "included") {
 			return {
 				tone: "muted",
-				message: "Your included Basic slot is available. No compute subscription is required.",
+				message: "Your first Basic agent is free. No compute subscription is required.",
 			};
 		}
 		if (basicOffer) {
@@ -412,12 +414,16 @@ export function DeployWizard() {
 	const checkoutAttemptRef = useRef<IdempotencyAttempt | null>(null);
 	const walletCreateAttemptRef = useRef<IdempotencyAttempt | null>(null);
 	const includedCreateAttemptRef = useRef<IdempotencyAttempt | null>(null);
+	const assistantNameEditedRef = useRef(false);
 	const checkoutReturnRef = useRef<string | null>(null);
 	const createdProviderGuardRef = useRef<{ providerId: string; dataUpdatedAt: number } | null>(
 		null,
 	);
 
 	const [runtime, setRuntime] = useState(DEFAULT_DEPLOY_RUNTIME);
+	const [assistantName, setAssistantName] = useState(() =>
+		runtimeDisplayName(DEFAULT_DEPLOY_RUNTIME),
+	);
 	const [aiAccessMode, setAiAccessMode] = useState<AiAccessMode>(DEFAULT_DEPLOY_AI_ACCESS_MODE);
 	const [aiProviderChoices, setAiProviderChoices] = useState<string[]>([
 		...DEFAULT_DEPLOY_AI_PROVIDER_CHOICES,
@@ -531,6 +537,7 @@ export function DeployWizard() {
 	const planReady = !plans.isLoading && computePlanReady;
 	const canSubmit =
 		planReady &&
+		assistantName.trim().length > 0 &&
 		!submitting &&
 		(!paidSelection ||
 			paymentMethod === "card" ||
@@ -547,6 +554,17 @@ export function DeployWizard() {
 		setAiAccessMode("configured");
 		setAiProviderChoices([providerId]);
 		setPrimaryProvider(providerId);
+	}
+
+	function selectRuntime(nextRuntime: HostedRuntime) {
+		setRuntime(nextRuntime);
+		setAssistantName((currentName) =>
+			deployAssistantNameAfterRuntimeChange({
+				currentName,
+				hasBeenEdited: assistantNameEditedRef.current,
+				runtime: nextRuntime,
+			}),
+		);
 	}
 
 	useEffect(() => {
@@ -758,6 +776,7 @@ export function DeployWizard() {
 			computePlanSlug,
 			runtime,
 			persona: {
+				assistantName,
 				language,
 				timezone,
 			},
@@ -1057,7 +1076,7 @@ export function DeployWizard() {
 			forgetIdempotencyAttempt("deployment-create", fingerprint);
 			includedCreateAttemptRef.current = null;
 			toast.success("Agent deployed", {
-				description: "Your included Basic deployment is provisioning now.",
+				description: "Your first Basic agent is provisioning now for free.",
 			});
 			void router.navigate({
 				href: agentSectionHref(created.deploymentId, "overview", "source=on-clawdi"),
@@ -1145,7 +1164,7 @@ export function DeployWizard() {
 					<div className={RUNTIME_TILE_GRID_CLASS}>
 						<EntityChoiceCard
 							selected={runtime === "hermes"}
-							onClick={() => setRuntime("hermes")}
+							onClick={() => selectRuntime("hermes")}
 							icon={
 								<EntityIcon kind="framework" id="hermes" label={runtimeDisplayName("hermes")} />
 							}
@@ -1154,7 +1173,7 @@ export function DeployWizard() {
 						/>
 						<EntityChoiceCard
 							selected={runtime === "openclaw"}
-							onClick={() => setRuntime("openclaw")}
+							onClick={() => selectRuntime("openclaw")}
 							icon={
 								<EntityIcon kind="framework" id="openclaw" label={runtimeDisplayName("openclaw")} />
 							}
@@ -1315,7 +1334,7 @@ export function DeployWizard() {
 								title="Basic"
 								description={
 									basicSelection.mode === "included"
-										? `${basicPlan?.vcpu ?? 2} vCPU / ${basicPlan?.ram_gb ?? 4} GB · included slot`
+										? `${basicPlan?.vcpu ?? 2} vCPU / ${basicPlan?.ram_gb ?? 4} GB · First Basic agent — Free`
 										: basicOffer
 											? `${basicPlan?.vcpu ?? 2} vCPU / ${basicPlan?.ram_gb ?? 4} GB · ${recurringOfferLabel(basicOffer)}`
 											: "Basic funding unavailable"
@@ -1323,7 +1342,7 @@ export function DeployWizard() {
 								badge={
 									<Badge variant="secondary">
 										{basicSelection.mode === "included"
-											? "Included"
+											? "Free"
 											: basicOffer
 												? `${formatCentsCompact(basicOffer.effective_monthly_price_cents)}/mo`
 												: "Unavailable"}
@@ -1466,14 +1485,26 @@ export function DeployWizard() {
 				</SettingsSection>
 
 				<SettingsSection
-					title={
-						<>
-							Personalize <span className="font-normal text-muted-foreground">· optional</span>
-						</>
-					}
-					description="Choose the agent's language and timezone."
+					title="Personalize"
+					description="Name your agent and optionally choose its language and timezone."
 				>
 					<div className="grid max-w-2xl gap-4 sm:grid-cols-2">
+						<div className="flex flex-col gap-1.5 sm:col-span-2">
+							<label htmlFor="agent-name" className="text-sm text-muted-foreground">
+								Name
+							</label>
+							<Input
+								id="agent-name"
+								value={assistantName}
+								maxLength={DEPLOY_ASSISTANT_NAME_MAX_LENGTH}
+								required
+								onChange={(event) => {
+									assistantNameEditedRef.current = true;
+									setAssistantName(event.target.value);
+								}}
+								onBlur={() => setAssistantName((name) => name.trim())}
+							/>
+						</div>
 						<div className="flex flex-col gap-1.5">
 							<label htmlFor="agent-language" className="text-sm text-muted-foreground">
 								Language

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -103,7 +103,7 @@ export function PlanComparison({
 			<div>
 				<h3 className="text-base font-semibold">Compare compute options</h3>
 				<p className="text-sm text-muted-foreground">
-					Basic includes the first active agent. Additional Basic and Performance agents are billed
+					The first active Basic agent is free. Additional Basic and Performance agents are billed
 					separately.
 				</p>
 			</div>
@@ -125,7 +125,7 @@ export function PlanComparison({
 							</span>
 						</div>
 						<CardDescription className="mt-2">
-							One active Basic agent is included. Each additional Basic agent uses its own
+							Your first active Basic agent is free. Each additional Basic agent uses its own
 							subscription.
 						</CardDescription>
 						{basicOffer && basicOffer.billing_term_months !== 1 ? (


### PR DESCRIPTION
## v2 deploy wizard — personalize agent name + clearer free-Basic copy

Owner directives.

1. **Agent name field** in the wizard's Personalize section. Default = `runtimeDisplayName(runtime)` (Hermes / OpenClaw), updates on runtime switch until the user edits it; trimmed, 255 max, non-empty required. Sent as `assistant_name` (top-level + `config.assistant_name`). This replaces backend auto-numbering (handled in a paired clawdi-hosted change that drops the "Hermes 2" ordinal logic).
2. **Clearer free-tier copy** — the first Basic agent now shows "First Basic agent — Free" + a "Free" badge instead of the misleading "Included". Paid 2nd+ Basic checkout copy unchanged.

v1 untouched. typecheck + lint pass; 23 focused deploy tests pass. Touches deploy-wizard.tsx + plan-comparison.tsx + deploy defaults/request (7 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)