### PR TITLE
fix(web): protect settings panel edits + API key safety

### DIFF
--- a/apps/web/src/components/dashboard/agent-settings-panel.logic.test.ts
+++ b/apps/web/src/components/dashboard/agent-settings-panel.logic.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { syncAgentNameDraft } from "./agent-settings-panel.logic";
+
+describe("syncAgentNameDraft", () => {
+	test("initializes a draft from the server", () => {
+		expect(syncAgentNameDraft("", undefined, "Research agent")).toBe("Research agent");
+	});
+
+	test("updates an untouched draft when the server name changes", () => {
+		expect(syncAgentNameDraft("Research agent", "Research agent", "Build agent")).toBe(
+			"Build agent",
+		);
+	});
+
+	test("preserves an edited draft across unrelated agent cache updates", () => {
+		expect(syncAgentNameDraft("Unsaved name", "Research agent", "Research agent")).toBe(
+			"Unsaved name",
+		);
+		expect(syncAgentNameDraft("Unsaved name", "Research agent", "Externally renamed")).toBe(
+			"Unsaved name",
+		);
+	});
+});

--- a/apps/web/src/components/dashboard/agent-settings-panel.logic.ts
+++ b/apps/web/src/components/dashboard/agent-settings-panel.logic.ts
@@ -1,0 +1,10 @@
+export function syncAgentNameDraft(
+	currentDraft: string,
+	previousServerName: string | undefined,
+	nextServerName: string,
+): string {
+	if (previousServerName === undefined || currentDraft === previousServerName) {
+		return nextServerName;
+	}
+	return currentDraft;
+}

--- a/apps/web/src/components/dashboard/agent-settings-panel.tsx
+++ b/apps/web/src/components/dashboard/agent-settings-panel.tsx
@@ -12,6 +12,7 @@ import {
 	agentDisplayName,
 	agentTypeLabel,
 } from "@/components/dashboard/agent-label";
+import { syncAgentNameDraft } from "@/components/dashboard/agent-settings-panel.logic";
 import { SettingsSection } from "@/components/settings-section";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
@@ -56,6 +57,7 @@ export function AgentSettingsPanel({
 	const ownership = useAgentOwnership();
 	const uploadAvatar = useAgentAvatarUploader();
 	const fileInputRef = useRef<HTMLInputElement | null>(null);
+	const lastServerNameRef = useRef<{ environmentId: string; name: string } | null>(null);
 	const [draftName, setDraftName] = useState("");
 	const {
 		data: agent,
@@ -71,12 +73,22 @@ export function AgentSettingsPanel({
 			),
 	});
 
+	const serverDraftName = agent
+		? agent.display_name
+			? (formatName?.(agent.display_name) ?? agent.display_name)
+			: ""
+		: undefined;
+
 	useEffect(() => {
-		if (!agent) return;
-		setDraftName(
-			agent.display_name ? (formatName?.(agent.display_name) ?? agent.display_name) : "",
+		if (serverDraftName === undefined) return;
+		const previous = lastServerNameRef.current;
+		const previousServerName =
+			previous?.environmentId === environmentId ? previous.name : undefined;
+		lastServerNameRef.current = { environmentId, name: serverDraftName };
+		setDraftName((currentDraft) =>
+			syncAgentNameDraft(currentDraft, previousServerName, serverDraftName),
 		);
-	}, [agent, formatName]);
+	}, [environmentId, serverDraftName]);
 
 	const updateIdentity = useMutation({
 		mutationFn: async (body: EnvironmentUpdate) =>

--- a/apps/web/src/components/settings/api-keys-panel.test.ts
+++ b/apps/web/src/components/settings/api-keys-panel.test.ts
@@ -12,3 +12,24 @@ describe("API keys query states", () => {
 		expect(source.indexOf("{error ? (")).toBeLessThan(source.indexOf("<DataTable"));
 	});
 });
+
+describe("API key creation safeguards", () => {
+	test("trims labels and rejects whitespace-only input", () => {
+		expect(source).toContain("const normalizedNewLabel = newLabel.trim()");
+		expect(source).toContain("createKey.mutate(normalizedNewLabel)");
+		expect(source).toContain("disabled={!normalizedNewLabel || createKey.isPending");
+	});
+
+	test("does not replace an unacknowledged one-time key", () => {
+		expect(source).toContain("normalizedNewLabel && createdKey === null");
+		expect(source).toContain("createKey.isPending || createdKey !== null");
+		expect(source).toContain("onClick={() => setCreatedKey(null)}");
+		expect(source).toContain("I&apos;ve saved it");
+	});
+
+	test("normalizes create and revoke mutation errors", () => {
+		expect(source).toContain('onError: toastApiError("Couldn\'t create key")');
+		expect(source).toContain('onError: toastApiError("Couldn\'t turn off key")');
+		expect(source).not.toMatch(/onError:.*\.detail/);
+	});
+});

--- a/apps/web/src/components/settings/api-keys-panel.tsx
+++ b/apps/web/src/components/settings/api-keys-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ColumnDef } from "@tanstack/react-table";
-import { Copy, Plus, Trash2 } from "lucide-react";
+import { Check, Copy, Plus, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -14,7 +14,7 @@ import { DataTable } from "@/components/ui/data-table";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
-import { type ApiError, unwrap, useApi } from "@/lib/api";
+import { toastApiError, unwrap, useApi } from "@/lib/api";
 import type { ApiKey } from "@/lib/api-schemas";
 
 /** API Keys settings — CLI-facing bearer tokens. */
@@ -23,6 +23,7 @@ export function ApiKeysPanel() {
 	const queryClient = useQueryClient();
 	const [newLabel, setNewLabel] = useState("");
 	const [createdKey, setCreatedKey] = useState<string | null>(null);
+	const normalizedNewLabel = newLabel.trim();
 
 	const {
 		data: keys,
@@ -42,7 +43,7 @@ export function ApiKeysPanel() {
 			setNewLabel("");
 			queryClient.invalidateQueries({ queryKey: ["api-keys"] });
 		},
-		onError: (e: ApiError) => toast.error("Couldn't create key", { description: e.detail }),
+		onError: toastApiError("Couldn't create key"),
 	});
 
 	const revokeKey = useMutation({
@@ -56,7 +57,7 @@ export function ApiKeysPanel() {
 			queryClient.invalidateQueries({ queryKey: ["api-keys"] });
 			toast.success("Key turned off");
 		},
-		onError: (e: ApiError) => toast.error("Couldn't turn off key", { description: e.detail }),
+		onError: toastApiError("Couldn't turn off key"),
 	});
 
 	const columns = useMemo<ColumnDef<ApiKey>[]>(
@@ -164,7 +165,9 @@ export function ApiKeysPanel() {
 				className="flex flex-col gap-2 sm:flex-row"
 				onSubmit={(e) => {
 					e.preventDefault();
-					if (newLabel) createKey.mutate(newLabel);
+					if (normalizedNewLabel && createdKey === null) {
+						createKey.mutate(normalizedNewLabel);
+					}
 				}}
 			>
 				<Label htmlFor="new-key-label" className="sr-only">
@@ -178,10 +181,11 @@ export function ApiKeysPanel() {
 					className="min-w-0 flex-1"
 					name="new-key-label"
 					autoComplete="off"
+					disabled={createdKey !== null}
 				/>
 				<Button
 					type="submit"
-					disabled={!newLabel || createKey.isPending}
+					disabled={!normalizedNewLabel || createKey.isPending || createdKey !== null}
 					className="w-full sm:w-auto"
 				>
 					<Plus />
@@ -212,6 +216,10 @@ export function ApiKeysPanel() {
 							aria-label="Copy key"
 						>
 							<Copy />
+						</Button>
+						<Button type="button" variant="outline" size="sm" onClick={() => setCreatedKey(null)}>
+							<Check />
+							I&apos;ve saved it
 						</Button>
 					</div>
 				</div>


### PR DESCRIPTION
Settings-panel data-loss fixes (v2 UI audit). v1 untouched — shared-panel additive safety only.

- Avatar upload/remove no longer clobbers an unsaved display-name edit (dirty-field guard).
- API key label is trimmed + required before Create (no whitespace-only labels).
- One-time key secret is locked until acknowledged ("I've saved it") — a second create can't silently overwrite an un-copied secret.
- API-key create/revoke errors route through `toastApiError`/`normalizeApiError` (network/timeout/401/429/5xx-safe).

typecheck + lint + 22 focused tests pass. Backend follow-up (separate): `ApiKeyCreate.label` should also strip + min_length=1 server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)