### PR TITLE
fix(web): resilient v2 capability gate — no lockout on transient /v1/me failure

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1679,7 +1679,8 @@ export function AppSidebar({
 	useEffect(() => {
 		setMounted(true);
 	}, []);
-	const showCloudFeatures = mounted && IS_HOSTED && hostedAccess.canCreateCloudAgents;
+	const showCloudFeatures =
+		mounted && IS_HOSTED && (hostedAccess.canCreateCloudAgents || hostedAccess.status === "error");
 	const agentRoute = parseAgentPathname(pathname);
 	const activeAgentId = agentRoute?.agentId ?? null;
 	const { data: environments } = useQuery({

--- a/apps/web/src/components/command-palette.tsx
+++ b/apps/web/src/components/command-palette.tsx
@@ -171,11 +171,11 @@ function CommandPalette({
 			searchText: "settings general profile api keys model providers billing preferences account",
 		};
 		const shortcuts = [...BASE_NAV_SHORTCUTS, settingsShortcut];
-		if (IS_HOSTED && hostedAccess.canCreateCloudAgents) {
+		if (IS_HOSTED && (hostedAccess.canCreateCloudAgents || hostedAccess.status === "error")) {
 			shortcuts.push(...CLOUD_NAV_SHORTCUTS);
 		}
 		return shortcuts;
-	}, [hostedAccess.canCreateCloudAgents]);
+	}, [hostedAccess.canCreateCloudAgents, hostedAccess.status]);
 
 	// Reset the input when the palette closes so reopening is a fresh state
 	// — otherwise stale results from the previous query briefly flash before

--- a/apps/web/src/components/dashboard/new-agent-button.tsx
+++ b/apps/web/src/components/dashboard/new-agent-button.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "@tanstack/react-router";
 import { CirclePlus, Loader2, Rocket, TerminalSquare } from "lucide-react";
 import { useEffect, useState } from "react";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { AddAgentDialog } from "@/components/dashboard/add-agent-dialog";
 import { IconChip } from "@/components/icon-chip";
 import { Button } from "@/components/ui/button";
@@ -40,10 +41,11 @@ export function NewAgentButton({
 	}, []);
 	const canDeployManagedAgent = mounted && IS_HOSTED && hostedAccess.canCreateCloudAgents;
 	const checkingDeployAccess = mounted && IS_HOSTED && hostedAccess.isLoading;
+	const deployAccessError = mounted && IS_HOSTED && hostedAccess.isError;
 
 	function handleClick() {
 		if (checkingDeployAccess) return;
-		if (canDeployManagedAgent) {
+		if (canDeployManagedAgent || deployAccessError) {
 			setChooserOpen(true);
 			return;
 		}
@@ -100,6 +102,15 @@ export function NewAgentButton({
 							Deploy a managed agent on Clawdi, or connect an agent you already run.
 						</DialogDescription>
 					</DialogHeader>
+					{deployAccessError ? (
+						<ApiErrorPanel
+							error={hostedAccess.error}
+							onRetry={() => {
+								void hostedAccess.refetch();
+							}}
+							title="Couldn't verify deploy access"
+						/>
+					) : null}
 					<div className="grid gap-3 sm:grid-cols-2">
 						<ChoiceCard
 							icon={checkingDeployAccess ? <Loader2 className="animate-spin" /> : <Rocket />}

--- a/apps/web/src/components/hosted-product-gate.tsx
+++ b/apps/web/src/components/hosted-product-gate.tsx
@@ -2,8 +2,8 @@
 
 import { useRouter } from "@tanstack/react-router";
 import { type ReactNode, useEffect } from "react";
+import { ApiErrorPanel } from "@/components/api-error-panel";
 import { HostedRouteSkeleton } from "@/components/hosted-route-skeleton";
-import { IS_HOSTED } from "@/lib/hosted";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 
 export function HostedProductGate({
@@ -15,14 +15,25 @@ export function HostedProductGate({
 }) {
 	const router = useRouter();
 	const access = useHostedProductAccess();
-	const allowed = IS_HOSTED && access.canCreateCloudAgents;
-	const denied = !access.isLoading && !allowed;
 
 	useEffect(() => {
-		if (denied) void router.navigate({ href: fallbackHref, replace: true });
-	}, [denied, fallbackHref, router]);
+		if (access.isDenied) void router.navigate({ href: fallbackHref, replace: true });
+	}, [access.isDenied, fallbackHref, router]);
 
 	if (access.isLoading) return <HostedRouteSkeleton />;
-	if (!allowed) return null;
+	if (access.isError) {
+		return (
+			<div className="mx-auto flex min-h-[50vh] w-full max-w-2xl items-center p-6">
+				<ApiErrorPanel
+					error={access.error}
+					onRetry={() => {
+						void access.refetch();
+					}}
+					title="Couldn't verify access"
+				/>
+			</div>
+		);
+	}
+	if (!access.isAllowed) return null;
 	return <>{children}</>;
 }

--- a/apps/web/src/hosted/oss-clean.test.ts
+++ b/apps/web/src/hosted/oss-clean.test.ts
@@ -22,6 +22,7 @@ const HOSTED_DIR = join(import.meta.dir);
 const SRC_DIR = join(import.meta.dir, "..");
 const HOSTED_V2_DIR = join(HOSTED_DIR, "v2");
 const PAGES_DIR = join(SRC_DIR, "pages");
+const CAPABILITY_INDEPENDENT_HOSTED_ROUTES = new Set(["oauth/codex/callback/page.tsx"]);
 const GATED_ROUTE_DYNAMIC_IMPORT =
 	/\bimport\s*\(\s*["'](@\/hosted\/(?:v2\/|billing\/)[^"']+)["']\s*\)/g;
 
@@ -100,6 +101,9 @@ function discoverHostedProductOnlyRouteFiles(): string[] {
 		if (!/(?:^|\/)(?:page|layout)\.tsx$/.test(file)) continue;
 		const src = readFileSync(file, "utf8");
 		if (!routeUsesHostedProductOnlyModule(src)) continue;
+		// OAuth protocol callbacks must hand the authorization response back to
+		// their opener even while the per-user capability check is unavailable.
+		if (CAPABILITY_INDEPENDENT_HOSTED_ROUTES.has(relative(PAGES_DIR, file))) continue;
 
 		const gateFile = nearestHostedProductGateFile(file);
 		if (gateFile) {
@@ -334,6 +338,18 @@ describe("hosted product route exposure", () => {
 		expect(src).toContain('router.navigate({ href: "/deploy" })');
 		expect(src).not.toContain('from "@/hosted/');
 		expect(src).not.toMatch(/href=["']https:\/\/[^"']+\/dashboard["']/);
+	});
+
+	test("the Codex OAuth callback relays independently of the capability gate", () => {
+		const route = readFileSync(join(PAGES_DIR, "oauth/codex/callback/page.tsx"), "utf8");
+		const callback = readFileSync(
+			join(HOSTED_V2_DIR, "ai-providers/codex-oauth-callback.tsx"),
+			"utf8",
+		);
+		expect(route).not.toContain("HostedProductGate");
+		expect(callback).toContain("ch.postMessage(result)");
+		expect(callback).toContain("window.opener?.postMessage(");
+		expect(callback).toContain("localStorage.setItem(CODEX_OAUTH_STORAGE_KEY");
 	});
 
 	test("Cloud-agents-off agent index copy stays neutral", () => {

--- a/apps/web/src/lib/hosted-product-access-model.ts
+++ b/apps/web/src/lib/hosted-product-access-model.ts
@@ -18,6 +18,30 @@ export interface HostedProductAccess {
 	canUseCloudAgents: boolean;
 }
 
+export type HostedProductAccessStatus = "unavailable" | "loading" | "error" | "allowed" | "denied";
+
+export function hostedProductAccessStatus({
+	enabled,
+	profile,
+	isFetching,
+	error,
+}: {
+	enabled: boolean;
+	profile: HostedProductAccessProfile | undefined;
+	isFetching: boolean;
+	error: unknown;
+}): HostedProductAccessStatus {
+	if (!enabled) return "unavailable";
+	// Fresh or cached successful data is authoritative, including an explicit
+	// denial. A failed background refresh must not erase the last known result.
+	if (profile !== undefined) {
+		return profile.capabilities?.can_use_v2 === true ? "allowed" : "denied";
+	}
+	if (isFetching) return "loading";
+	if (error) return "error";
+	return "loading";
+}
+
 export function hostedProductAccessFromProfile(
 	profile: HostedProductAccessProfile | undefined,
 ): HostedProductAccess {

--- a/apps/web/src/lib/hosted-product-access-request.test.ts
+++ b/apps/web/src/lib/hosted-product-access-request.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { ApiError, ApiNetworkError } from "@/lib/api-errors";
+import {
+	fetchHostedProductAccessWithTimeout,
+	HOSTED_PRODUCT_ACCESS_TIMEOUT_MS,
+	hostedProductAccessRetry,
+} from "@/lib/hosted-product-access-request";
+
+describe("fetchHostedProductAccessWithTimeout", () => {
+	test("uses the same 20 second application ceiling as the main clients", () => {
+		expect(HOSTED_PRODUCT_ACCESS_TIMEOUT_MS).toBe(20_000);
+	});
+
+	test("aborts a hanging request and reports a timeout error", async () => {
+		let aborted = false;
+		const hangingFetch = (_request: Request, init?: RequestInit) =>
+			new Promise<Response>((_resolve, reject) => {
+				const signal = init?.signal;
+				if (!signal) {
+					reject(new Error("expected a request signal"));
+					return;
+				}
+				signal.addEventListener(
+					"abort",
+					() => {
+						aborted = true;
+						reject(new DOMException("aborted", "AbortError"));
+					},
+					{ once: true },
+				);
+			});
+
+		let thrown: unknown;
+		try {
+			await fetchHostedProductAccessWithTimeout(
+				new Request("https://api.example.test/v1/me"),
+				undefined,
+				{ fetch: hangingFetch, timeoutMs: 5 },
+			);
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(aborted).toBe(true);
+		expect(thrown).toBeInstanceOf(ApiNetworkError);
+		if (thrown instanceof ApiNetworkError) expect(thrown.kind).toBe("timeout");
+	});
+});
+
+describe("hostedProductAccessRetry", () => {
+	test("retries transient failures with a bounded budget", () => {
+		expect(hostedProductAccessRetry(0, new ApiNetworkError("offline"))).toBe(true);
+		expect(hostedProductAccessRetry(1, new ApiError(503, "unavailable"))).toBe(true);
+		expect(hostedProductAccessRetry(2, new ApiError(503, "unavailable"))).toBe(false);
+	});
+
+	test("allows one fresh-token retry for 401 but not deterministic 4xx", () => {
+		expect(hostedProductAccessRetry(0, new ApiError(401, "expired"))).toBe(true);
+		expect(hostedProductAccessRetry(1, new ApiError(401, "expired"))).toBe(false);
+		expect(hostedProductAccessRetry(0, new ApiError(403, "forbidden"))).toBe(false);
+	});
+});

--- a/apps/web/src/lib/hosted-product-access-request.ts
+++ b/apps/web/src/lib/hosted-product-access-request.ts
@@ -1,0 +1,56 @@
+import { ApiError, ApiNetworkError, isApiNetworkError, isApiServerError } from "@/lib/api-errors";
+
+/** Keep the capability check bounded like the main API and billing clients. */
+export const HOSTED_PRODUCT_ACCESS_TIMEOUT_MS = 20_000;
+
+type FetchImplementation = (request: Request, init?: RequestInit) => Promise<Response>;
+
+type TimeoutFetchOptions = {
+	fetch?: FetchImplementation;
+	timeoutMs?: number;
+};
+
+/**
+ * Capability-specific copy of the application's bounded-fetch transport.
+ * Caller cancellation stays distinguishable from the timeout owned here.
+ */
+export function fetchHostedProductAccessWithTimeout(
+	request: Request,
+	init?: RequestInit,
+	options: TimeoutFetchOptions = {},
+): Promise<Response> {
+	const caller = init?.signal ?? request.signal;
+	const controller = new AbortController();
+	const fetchImplementation = options.fetch ?? fetch;
+	let timedOut = false;
+	const onAbort = () => controller.abort();
+	if (caller?.aborted) {
+		controller.abort();
+	} else {
+		caller?.addEventListener("abort", onAbort, { once: true });
+	}
+	const timeoutId = setTimeout(() => {
+		timedOut = true;
+		controller.abort();
+	}, options.timeoutMs ?? HOSTED_PRODUCT_ACCESS_TIMEOUT_MS);
+
+	return fetchImplementation(request, { ...init, signal: controller.signal })
+		.catch((cause: unknown) => {
+			if (timedOut) throw new ApiNetworkError("timeout", { cause });
+			if (caller?.aborted) throw cause;
+			throw new ApiNetworkError("offline", { cause });
+		})
+		.finally(() => {
+			clearTimeout(timeoutId);
+			caller?.removeEventListener("abort", onAbort);
+		});
+}
+
+/**
+ * Retry transient transport/server failures twice. A single 401 is also
+ * retried because each attempt asks the auth provider for a fresh token.
+ */
+export function hostedProductAccessRetry(failureCount: number, error: unknown): boolean {
+	if (error instanceof ApiError && error.status === 401) return failureCount < 1;
+	return failureCount < 2 && (isApiNetworkError(error) || isApiServerError(error));
+}

--- a/apps/web/src/lib/hosted-product-access.test.ts
+++ b/apps/web/src/lib/hosted-product-access.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { hostedProductAccessFromProfile } from "@/lib/hosted-product-access-model";
+import {
+	hostedProductAccessFromProfile,
+	hostedProductAccessStatus,
+} from "@/lib/hosted-product-access-model";
 
 describe("hostedProductAccessFromProfile", () => {
 	it("keeps hosted product surfaces hidden by default", () => {
@@ -47,5 +50,51 @@ describe("hostedProductAccessFromProfile", () => {
 			canCreateCloudAgents: false,
 			canUseCloudAgents: false,
 		});
+	});
+});
+
+describe("hostedProductAccessStatus", () => {
+	it("keeps loading distinct from a completed denial", () => {
+		expect(
+			hostedProductAccessStatus({
+				enabled: true,
+				profile: undefined,
+				isFetching: true,
+				error: null,
+			}),
+		).toBe("loading");
+	});
+
+	it("treats a capability fetch failure as an error, not a denial", () => {
+		expect(
+			hostedProductAccessStatus({
+				enabled: true,
+				profile: undefined,
+				isFetching: false,
+				error: new Error("temporary failure"),
+			}),
+		).toBe("error");
+	});
+
+	it("only denies after a successful profile explicitly lacks v2 access", () => {
+		expect(
+			hostedProductAccessStatus({
+				enabled: true,
+				profile: { capabilities: { can_use_v2: false } },
+				isFetching: false,
+				error: null,
+			}),
+		).toBe("denied");
+	});
+
+	it("preserves the last successful allow during a failed background refresh", () => {
+		expect(
+			hostedProductAccessStatus({
+				enabled: true,
+				profile: { capabilities: { can_use_v2: true } },
+				isFetching: false,
+				error: new Error("refresh failed"),
+			}),
+		).toBe("allowed");
 	});
 });

--- a/apps/web/src/lib/hosted-product-access.ts
+++ b/apps/web/src/lib/hosted-product-access.ts
@@ -3,13 +3,19 @@
 import type { DeployPaths } from "@clawdi/shared/api";
 import { useQuery } from "@tanstack/react-query";
 import createClient from "openapi-fetch";
+import { ApiError } from "@/lib/api-errors";
 import { useAuthToken } from "@/lib/auth-client";
 import { IS_HOSTED } from "@/lib/hosted";
 import { DEPLOY_API_URL, hostedApiBaseUrl, isDeployApiConfigured } from "@/lib/hosted-api";
 import {
 	type HostedProductAccessProfile,
 	hostedProductAccessFromProfile,
+	hostedProductAccessStatus,
 } from "@/lib/hosted-product-access-model";
+import {
+	fetchHostedProductAccessWithTimeout,
+	hostedProductAccessRetry,
+} from "@/lib/hosted-product-access-request";
 
 export const hostedProductAccessKeys = {
 	me: ["hosted-product-access", "me"] as const,
@@ -19,12 +25,18 @@ async function fetchHostedProductAccessProfile(
 	getToken: () => Promise<string | null>,
 ): Promise<HostedProductAccessProfile> {
 	const token = await getToken();
-	const api = createClient<DeployPaths>({ baseUrl: hostedApiBaseUrl(DEPLOY_API_URL) });
+	const api = createClient<DeployPaths>({
+		baseUrl: hostedApiBaseUrl(DEPLOY_API_URL),
+		fetch: fetchHostedProductAccessWithTimeout,
+	});
 	const result = await api.GET("/v1/me", {
 		headers: token ? { Authorization: `Bearer ${token}` } : undefined,
 	});
 	if (!result.response.ok) {
-		throw new Error(`Hosted product access check failed with ${result.response.status}`);
+		throw new ApiError(
+			result.response.status,
+			result.response.statusText || "Hosted product access check failed",
+		);
 	}
 	if (!result.data) {
 		throw new Error("Hosted product access check returned an empty profile");
@@ -39,13 +51,23 @@ export function useHostedProductAccess() {
 		queryKey: hostedProductAccessKeys.me,
 		queryFn: () => fetchHostedProductAccessProfile(getToken),
 		enabled,
-		retry: false,
+		retry: hostedProductAccessRetry,
 		staleTime: 60_000,
 	});
 	const access = hostedProductAccessFromProfile(query.data);
+	const status = hostedProductAccessStatus({
+		enabled,
+		profile: query.data,
+		isFetching: query.isFetching,
+		error: query.error,
+	});
 	return {
 		...access,
-		isLoading: enabled && query.isLoading,
+		status,
+		isLoading: status === "loading",
+		isError: status === "error",
+		isAllowed: status === "allowed",
+		isDenied: status === "denied",
 		isFetching: enabled && query.isFetching,
 		error: query.error,
 		refetch: query.refetch,

--- a/apps/web/src/pages/oauth/codex/callback/page.tsx
+++ b/apps/web/src/pages/oauth/codex/callback/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { lazy, Suspense } from "react";
-import { HostedProductGate } from "@/components/hosted-product-gate";
 import { HostedRouteSkeleton } from "@/components/hosted-route-skeleton";
 
 // Codex "Sign in with ChatGPT" OAuth callback for the hosted AI Providers surface.
@@ -16,13 +15,9 @@ const CodexOAuthCallback = IS_HOSTED_BUILD
 	: null;
 
 export default function CodexOAuthCallbackPage() {
-	return (
-		<HostedProductGate fallbackHref="/">
-			{CodexOAuthCallback ? (
-				<Suspense fallback={<HostedRouteSkeleton />}>
-					<CodexOAuthCallback />
-				</Suspense>
-			) : null}
-		</HostedProductGate>
-	);
+	return CodexOAuthCallback ? (
+		<Suspense fallback={<HostedRouteSkeleton />}>
+			<CodexOAuthCallback />
+		</Suspense>
+	) : null;
 }


### PR DESCRIPTION
v2 capability-gate BLOCKERs (routing-boundary audit). v1 untouched.

- State model loading/error/allowed/denied/unavailable. Only a successful response with can_use_v2!==true is a denial; a request error never redirects — shows Retry and keeps the user in place. Cached success survives a background refresh failure.
- `/v1/me` gets a 20s AbortController; network/timeout/5xx/429 retried ≤2x, 401 token-refresh+retry once, other 4xx no retry.
- On capability error the sidebar/command palette keep Channels/Model Providers; New Agent shows error+Retry instead of silently downgrading to 'Connect your own agent'.
- Codex OAuth callback decoupled from the per-user gate; the auth code still returns via BroadcastChannel/postMessage/localStorage, so a gate blip can't drop it.

27 focused tests + typecheck + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)