### PR TITLE
fix(web): harden v2 channel setup UX

### DIFF
--- a/apps/web/src/hosted/v2/channels/channel-detail-page.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.logic.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { nativeTransportSummary, pairCodeRequiresExplicitAgent } from "./channel-detail-page.logic";
+
+describe("pairCodeRequiresExplicitAgent", () => {
+	test("only permits the implicit linked-agent default for exactly one link", () => {
+		expect(pairCodeRequiresExplicitAgent(0)).toBe(true);
+		expect(pairCodeRequiresExplicitAgent(1)).toBe(false);
+		expect(pairCodeRequiresExplicitAgent(2)).toBe(true);
+	});
+});
+
+describe("nativeTransportSummary", () => {
+	test("maps internal transport fields to user-facing labels", () => {
+		expect(
+			nativeTransportSummary({
+				available: false,
+				mode: "none",
+				reason: "shared-bot-transport-unavailable",
+				supportsOutboundMessages: false,
+				supportsRawRelay: false,
+			}),
+		).toEqual({
+			status: "Unavailable",
+			connection: "Not connected",
+			delivery: "Unavailable",
+		});
+	});
+
+	test("does not surface unknown internal values", () => {
+		expect(
+			nativeTransportSummary({ mode: "future_internal_mode", reason: "private-enum" }),
+		).toEqual({
+			status: "Unknown",
+			connection: "Details unavailable",
+			delivery: "Unknown",
+		});
+	});
+});

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.logic.ts
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.logic.ts
@@ -1,0 +1,34 @@
+export function pairCodeRequiresExplicitAgent(linkedAgentCount: number): boolean {
+	return linkedAgentCount !== 1;
+}
+
+export type NativeTransportSummary = {
+	status: string;
+	connection: string;
+	delivery: string;
+};
+
+export function nativeTransportSummary(transport: Record<string, unknown>): NativeTransportSummary {
+	const status =
+		transport.available === true
+			? "Ready"
+			: transport.available === false
+				? "Unavailable"
+				: "Unknown";
+	const connection =
+		transport.mode === "in_process"
+			? "Direct connection"
+			: transport.mode === "sidecar"
+				? "Managed connection"
+				: transport.mode === "none"
+					? "Not connected"
+					: "Details unavailable";
+	const delivery =
+		transport.supportsOutboundMessages === true
+			? "Available"
+			: transport.supportsOutboundMessages === false
+				? "Unavailable"
+				: "Unknown";
+
+	return { status, connection, delivery };
+}

--- a/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-detail-page.tsx
@@ -46,6 +46,10 @@ import { Spinner } from "@/components/ui/spinner";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { deploymentDisplayName } from "@/hosted/agent-identity";
 import { isHostedRuntime } from "@/hosted/runtimes";
+import {
+	nativeTransportSummary,
+	pairCodeRequiresExplicitAgent,
+} from "@/hosted/v2/channels/channel-detail-page.logic";
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
 import type {
 	ChannelActivityItem,
@@ -291,6 +295,13 @@ export function ChannelDetailPage({ channelId: id }: { channelId: string }) {
 				<InfoCard icon={TriangleAlert} title="Provider unavailable">
 					This provider is no longer available for new native channels. Existing channel data
 					remains visible, and you can remove the channel.
+				</InfoCard>
+			) : null}
+			{ch.provider === "discord" && !providerUnavailable ? (
+				<InfoCard icon={TriangleAlert} title="Verify Discord credentials">
+					Clawdi stores Discord credentials during setup but does not verify them with Discord. Send
+					a test message and confirm activity and health before relying on this channel. To replace
+					credentials, remove the channel and reconnect it.
 				</InfoCard>
 			) : null}
 
@@ -695,6 +706,7 @@ function isExpired(expiresAt: string, nowMs: number): boolean {
 
 function PairCodeTab({ accountId, provider }: { accountId: string; provider: string }) {
 	const envs = useEnvironments();
+	const links = useChannelAgentLinks(accountId);
 	const create = useCreatePairCode(accountId);
 	const ownership = useAgentOwnership();
 	// "" = no agent chosen (use the channel's linked agent). Sentinel keeps the
@@ -711,6 +723,21 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 	const generateLocked = useRef(false);
 	const meta = providerMeta(provider);
 	const isGenerating = create.isPending || generateLocked.current;
+	const linkedAgentCount = links.data?.length ?? 0;
+	const requiresExplicitAgent = pairCodeRequiresExplicitAgent(linkedAgentCount);
+	const selectionMessage =
+		requiresExplicitAgent && !agentId && !links.isLoading && !links.error
+			? linkedAgentCount === 0
+				? agentItems.length === 0
+					? "No linked agent is available. Link an agent in the Agents tab first."
+					: "No agent is linked. Choose an agent for this pairing code."
+				: "This channel has multiple linked agents. Choose the agent for this pairing code."
+			: null;
+	const canGenerate =
+		!isGenerating &&
+		!links.isLoading &&
+		!links.error &&
+		(!requiresExplicitAgent || (!envs.isLoading && !envs.error && Boolean(agentId)));
 	const visibleAgentToken =
 		result && revealedAgentToken?.agentLinkId === result.agent_link_id
 			? revealedAgentToken.value
@@ -725,7 +752,7 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 	}, [result]);
 
 	function generate() {
-		if (generateLocked.current) return;
+		if (!canGenerate || generateLocked.current) return;
 		generateLocked.current = true;
 		setResult(null);
 		create.mutate(
@@ -769,7 +796,7 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 			<div className="grid gap-3 sm:grid-cols-2">
 				<div className="flex flex-col gap-1.5">
 					<Label htmlFor="pair-agent">Agent</Label>
-					{envs.isLoading ? (
+					{envs.isLoading || links.isLoading ? (
 						<Skeleton className="h-10 w-full rounded-md" />
 					) : (
 						<Select
@@ -778,10 +805,15 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 							onValueChange={(value) => {
 								if (value !== null) setAgentId(value);
 							}}
-							disabled={!!envs.error || isGenerating}
+							disabled={Boolean(envs.error || links.error) || isGenerating}
 						>
-							<SelectTrigger id="pair-agent">
-								<SelectValue placeholder="Use linked agent" />
+							<SelectTrigger
+								id="pair-agent"
+								aria-describedby={selectionMessage ? "pair-agent-requirement" : undefined}
+							>
+								<SelectValue
+									placeholder={requiresExplicitAgent ? "Choose an agent" : "Use linked agent"}
+								/>
 							</SelectTrigger>
 							<SelectContent>
 								{(envs.data ?? []).map((env) => (
@@ -796,6 +828,11 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 							</SelectContent>
 						</Select>
 					)}
+					{selectionMessage ? (
+						<p id="pair-agent-requirement" className="text-xs text-warning-muted-foreground">
+							{selectionMessage}
+						</p>
+					) : null}
 				</div>
 				<div className="flex flex-col gap-1.5">
 					<Label htmlFor="pair-ttl">Expires in</Label>
@@ -828,8 +865,15 @@ function PairCodeTab({ accountId, provider }: { accountId: string; provider: str
 					title="Couldn't load agents"
 				/>
 			) : null}
+			{links.error ? (
+				<ApiErrorPanel
+					error={links.error}
+					onRetry={() => links.refetch()}
+					title="Couldn't load linked agents"
+				/>
+			) : null}
 
-			<Button onClick={generate} disabled={isGenerating}>
+			<Button onClick={generate} disabled={!canGenerate}>
 				<QrCode className="size-4" />
 				{isGenerating ? "Generating…" : "Generate pairing code"}
 			</Button>
@@ -1009,6 +1053,7 @@ function HealthTab({ accountId }: { accountId: string }) {
 		{ label: "In progress", value: h.in_progress_deliveries },
 		{ label: "Failed deliveries", value: h.failed_deliveries },
 	];
+	const transport = h.native_transport ? nativeTransportSummary(h.native_transport) : null;
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -1051,12 +1096,23 @@ function HealthTab({ accountId }: { accountId: string }) {
 				</div>
 			) : null}
 
-			{h.native_transport ? (
+			{transport ? (
 				<div className={ENTITY_CARD_BASE}>
-					<SectionLabel className="mb-2 px-0">Native transport</SectionLabel>
-					<pre className="overflow-x-auto text-xs text-muted-foreground">
-						{JSON.stringify(h.native_transport, null, 2)}
-					</pre>
+					<SectionLabel className="mb-3 px-0">Message transport</SectionLabel>
+					<dl className="grid gap-3 text-sm sm:grid-cols-3">
+						<div>
+							<dt className="text-xs text-muted-foreground">Status</dt>
+							<dd className="mt-0.5 font-medium">{transport.status}</dd>
+						</div>
+						<div>
+							<dt className="text-xs text-muted-foreground">Connection</dt>
+							<dd className="mt-0.5 font-medium">{transport.connection}</dd>
+						</div>
+						<div>
+							<dt className="text-xs text-muted-foreground">Message delivery</dt>
+							<dd className="mt-0.5 font-medium">{transport.delivery}</dd>
+						</div>
+					</dl>
 				</div>
 			) : null}
 		</div>

--- a/apps/web/src/hosted/v2/channels/channels-page.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/channels-page.logic.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import type { ChannelBotPoolItem } from "./channel-types";
+import { dedupeBotPoolProviders, providerCounts } from "./channels-page.logic";
+
+function poolItem(id: string, provider: string): ChannelBotPoolItem {
+	return {
+		id,
+		provider,
+		name: id,
+		status: "active",
+		visibility: "private",
+		has_provider_token: true,
+		webhook_url: "https://example.test/webhook",
+		created_at: "2026-01-01T00:00:00Z",
+		access: "owner",
+		capabilities: {
+			link_agent: true,
+			pair_chat: true,
+			send_message: true,
+			manage_account: true,
+			sync_commands: true,
+		},
+		link_count: 0,
+		available: true,
+	};
+}
+
+describe("channel list deduplication", () => {
+	test("removes a pool bot already returned by the owned channel list", () => {
+		const channels = [{ id: "channel-1", provider: "telegram" }];
+		const providers = {
+			telegram: [
+				poolItem("channel-1", "telegram"),
+				poolItem("shared-2", "telegram"),
+				poolItem("shared-2", "telegram"),
+			],
+			discord: [poolItem("shared-3", "discord")],
+		};
+
+		const deduped = dedupeBotPoolProviders(channels, providers);
+
+		expect(deduped.telegram?.map((item) => item.id)).toEqual(["shared-2"]);
+		expect(providerCounts(channels, deduped)).toEqual({
+			telegram: 2,
+			discord: 1,
+			whatsapp: 0,
+		});
+	});
+});

--- a/apps/web/src/hosted/v2/channels/channels-page.logic.ts
+++ b/apps/web/src/hosted/v2/channels/channels-page.logic.ts
@@ -1,0 +1,40 @@
+import { CHANNEL_PROVIDERS, type ChannelProviderId } from "@/hosted/v2/channels/channel-providers";
+import type { ChannelAccount, ChannelBotPoolItem } from "@/hosted/v2/channels/channel-types";
+
+export function dedupeBotPoolProviders(
+	channels: readonly Pick<ChannelAccount, "id">[],
+	poolProviders: Record<string, ChannelBotPoolItem[]>,
+): Record<string, ChannelBotPoolItem[]> {
+	const seenIds = new Set(channels.map((channel) => channel.id));
+	const deduped: Record<string, ChannelBotPoolItem[]> = {};
+	for (const [provider, items] of Object.entries(poolProviders)) {
+		deduped[provider] = items.filter((item) => {
+			if (seenIds.has(item.id)) return false;
+			seenIds.add(item.id);
+			return true;
+		});
+	}
+	return deduped;
+}
+
+export function providerCounts(
+	channels: readonly Pick<ChannelAccount, "provider">[],
+	poolProviders: Record<string, ChannelBotPoolItem[]>,
+): Record<ChannelProviderId, number> {
+	const counts: Record<ChannelProviderId, number> = {
+		telegram: 0,
+		discord: 0,
+		whatsapp: 0,
+	};
+	for (const channel of channels) {
+		if (isKnownProvider(channel.provider)) counts[channel.provider] += 1;
+	}
+	for (const provider of CHANNEL_PROVIDERS) {
+		counts[provider] += poolProviders[provider]?.length ?? 0;
+	}
+	return counts;
+}
+
+function isKnownProvider(provider: string): provider is ChannelProviderId {
+	return (CHANNEL_PROVIDERS as readonly string[]).includes(provider);
+}

--- a/apps/web/src/hosted/v2/channels/channels-page.tsx
+++ b/apps/web/src/hosted/v2/channels/channels-page.tsx
@@ -29,6 +29,7 @@ import {
 import type { ChannelAccount, ChannelBotPoolItem } from "@/hosted/v2/channels/channel-types";
 import { AccessBadge, HealthBadge } from "@/hosted/v2/channels/channel-ui";
 import { useBotPool, useChannelHealth, useChannels } from "@/hosted/v2/channels/channels-hooks";
+import { dedupeBotPoolProviders, providerCounts } from "@/hosted/v2/channels/channels-page.logic";
 import { ConnectBotDialog } from "@/hosted/v2/channels/connect-bot-dialog";
 import { LinkAgentDialog } from "@/hosted/v2/channels/link-agent-dialog";
 import { WHATSAPP_LINKING_READY } from "@/hosted/v2/channels/link-agent-dialog.logic";
@@ -47,7 +48,7 @@ export function ChannelsPage() {
 	const health = useChannelHealth();
 
 	const channelItems = channels.data ?? [];
-	const poolProviders = botPool.data?.providers ?? {};
+	const poolProviders = dedupeBotPoolProviders(channelItems, botPool.data?.providers ?? {});
 	const counts = providerCounts(channelItems, poolProviders);
 	const totalCount = CHANNEL_PROVIDERS.reduce((sum, provider) => sum + counts[provider], 0);
 
@@ -106,27 +107,6 @@ export function ChannelsPage() {
 			<ConnectBotDialog open={connectOpen} onOpenChange={setConnectOpen} />
 		</div>
 	);
-}
-
-function providerCounts(
-	channels: ChannelAccount[],
-	poolProviders: Record<string, ChannelBotPoolItem[]>,
-): Record<ChannelProviderId, number> {
-	const counts = Object.fromEntries(CHANNEL_PROVIDERS.map((p) => [p, 0])) as Record<
-		ChannelProviderId,
-		number
-	>;
-	for (const channel of channels) {
-		if (isKnownProvider(channel.provider)) counts[channel.provider] += 1;
-	}
-	for (const provider of CHANNEL_PROVIDERS) {
-		counts[provider] += poolProviders[provider]?.length ?? 0;
-	}
-	return counts;
-}
-
-function isKnownProvider(provider: string): provider is ChannelProviderId {
-	return (CHANNEL_PROVIDERS as readonly string[]).includes(provider);
 }
 
 function providerLabel(filter: ProviderFilter): string {

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.test.ts
@@ -1,5 +1,48 @@
 import { describe, expect, test } from "bun:test";
-import { discordPublicKeyError } from "./connect-bot-dialog.logic";
+import {
+	discordApplicationIdError,
+	discordBotTokenError,
+	discordGuildIdError,
+	discordPublicKeyError,
+} from "./connect-bot-dialog.logic";
+
+describe("discordBotTokenError", () => {
+	test("allows an empty value so presence can be handled by the form gate", () => {
+		expect(discordBotTokenError("")).toBeNull();
+	});
+
+	test("accepts a long URL-safe opaque credential", () => {
+		expect(
+			discordBotTokenError(`${"A".repeat(24)}.${"b".repeat(6)}.${"C_".repeat(20)}`),
+		).toBeNull();
+	});
+
+	test("rejects arbitrary non-empty strings and whitespace", () => {
+		expect(discordBotTokenError("fake-token")).toBe("Enter a valid Discord bot token.");
+		expect(discordBotTokenError(` ${"A".repeat(24)}.${"b".repeat(6)}.${"c".repeat(24)}`)).toBe(
+			"Enter a valid Discord bot token.",
+		);
+	});
+});
+
+describe("Discord snowflake fields", () => {
+	test("validates required application IDs when present", () => {
+		expect(discordApplicationIdError("")).toBeNull();
+		expect(discordApplicationIdError("12345678901234567")).toBeNull();
+		expect(discordApplicationIdError("1234-not-an-id")).toBe(
+			"Enter a valid numeric application ID.",
+		);
+		expect(discordApplicationIdError("99999999999999999999")).toBe(
+			"Enter a valid numeric application ID.",
+		);
+	});
+
+	test("allows an empty optional guild ID but validates supplied values", () => {
+		expect(discordGuildIdError("   ")).toBeNull();
+		expect(discordGuildIdError("1234567890123456789")).toBeNull();
+		expect(discordGuildIdError("1234567890123456")).toBe("Enter a valid numeric guild ID.");
+	});
+});
 
 describe("discordPublicKeyError", () => {
 	test("allows blank optional public keys", () => {

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.logic.ts
@@ -1,5 +1,37 @@
 const DISCORD_PUBLIC_KEY_HEX_LENGTH = 64;
 const HEX_PATTERN = /^[0-9a-fA-F]+$/;
+const DISCORD_SNOWFLAKE_PATTERN = /^\d{17,20}$/;
+const MAX_UINT64_DECIMAL = "18446744073709551615";
+const DISCORD_TOKEN_PATTERN = /^[A-Za-z0-9._-]{50,}$/;
+
+function isDiscordSnowflake(value: string): boolean {
+	return (
+		DISCORD_SNOWFLAKE_PATTERN.test(value) &&
+		(value.length < MAX_UINT64_DECIMAL.length || value <= MAX_UINT64_DECIMAL)
+	);
+}
+
+export function discordBotTokenError(value: string): string | null {
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+	// Discord documents bot tokens as opaque credentials. Keep this deliberately
+	// loose: reject only obviously truncated or non-token input without depending
+	// on undocumented segment lengths that Discord may change.
+	const valid = trimmed === value && DISCORD_TOKEN_PATTERN.test(trimmed);
+	return valid ? null : "Enter a valid Discord bot token.";
+}
+
+export function discordApplicationIdError(value: string): string | null {
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+	return isDiscordSnowflake(trimmed) ? null : "Enter a valid numeric application ID.";
+}
+
+export function discordGuildIdError(value: string): string | null {
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+	return isDiscordSnowflake(trimmed) ? null : "Enter a valid numeric guild ID.";
+}
 
 export function discordPublicKeyError(value: string): string | null {
 	const trimmed = value.trim();

--- a/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/connect-bot-dialog.tsx
@@ -23,8 +23,16 @@ import {
 import type { ChannelCreate, ChannelCreated } from "@/hosted/v2/channels/channel-types";
 import { ProviderChip, TokenReveal } from "@/hosted/v2/channels/channel-ui";
 import { useCreateChannel } from "@/hosted/v2/channels/channels-hooks";
-import { discordPublicKeyError } from "@/hosted/v2/channels/connect-bot-dialog.logic";
-import { WHATSAPP_COMING_SOON_MESSAGE } from "@/hosted/v2/channels/link-agent-dialog.logic";
+import {
+	discordApplicationIdError,
+	discordBotTokenError,
+	discordGuildIdError,
+	discordPublicKeyError,
+} from "@/hosted/v2/channels/connect-bot-dialog.logic";
+import {
+	channelDialogOpenChangeAllowed,
+	WHATSAPP_LINKING_READY,
+} from "@/hosted/v2/channels/link-agent-dialog.logic";
 
 /**
  * Connect a channel. Each provider takes its OWN real inputs (grounded in
@@ -63,9 +71,15 @@ export function ConnectBotDialog({
 	}, [open]);
 
 	const meta = PROVIDER_META[provider];
-	const publicKeyError = meta.connect === "discord" ? discordPublicKeyError(publicKey) : null;
+	const discordSelected = meta.connect === "discord";
+	const tokenError = discordSelected ? discordBotTokenError(token) : null;
+	const applicationIdError = discordSelected ? discordApplicationIdError(applicationId) : null;
+	const publicKeyError = discordSelected ? discordPublicKeyError(publicKey) : null;
+	const guildIdError = discordSelected ? discordGuildIdError(guildId) : null;
+	const isSubmitting = create.isPending || submitLocked.current;
 
 	function changeProvider(next: ChannelProviderId) {
+		if (next === "whatsapp" && !WHATSAPP_LINKING_READY) return;
 		setProvider(next);
 		setToken("");
 		setApplicationId("");
@@ -76,14 +90,19 @@ export function ConnectBotDialog({
 	const canSubmit =
 		name.trim().length > 0 &&
 		(meta.connect === "whatsapp"
-			? true
+			? WHATSAPP_LINKING_READY
 			: meta.connect === "token"
 				? token.trim().length > 0
 				: meta.connect === "discord"
-					? token.trim().length > 0 && applicationId.trim().length > 0 && !publicKeyError
+					? token.trim().length > 0 &&
+						applicationId.trim().length > 0 &&
+						!tokenError &&
+						!applicationIdError &&
+						!publicKeyError &&
+						!guildIdError
 					: false);
 
-	function buildBody(): ChannelCreate {
+	function buildBody(): ChannelCreate | null {
 		const trimmedName = name.trim();
 		if (meta.connect === "discord") {
 			const config: Record<string, unknown> = { application_id: applicationId.trim() };
@@ -94,14 +113,16 @@ export function ConnectBotDialog({
 		if (meta.connect === "token") {
 			return { provider, name: trimmedName, provider_token: token.trim() };
 		}
-		// whatsapp — no token; device linking is gated during the beta
+		if (!WHATSAPP_LINKING_READY) return null;
 		return { provider, name: trimmedName };
 	}
 
 	function submit() {
 		if (!canSubmit || submitLocked.current) return;
+		const body = buildBody();
+		if (!body) return;
 		submitLocked.current = true;
-		create.mutate(buildBody(), {
+		create.mutate(body, {
 			onSuccess: (data) => setCreated(data),
 			onSettled: () => {
 				submitLocked.current = false;
@@ -109,18 +130,50 @@ export function ConnectBotDialog({
 		});
 	}
 
+	function handleOpenChange(nextOpen: boolean) {
+		if (!channelDialogOpenChangeAllowed(nextOpen, create.isPending || submitLocked.current)) return;
+		onOpenChange(nextOpen);
+	}
+
+	const discordVerificationPending = created?.provider === "discord";
+
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
+		<Dialog open={open} onOpenChange={handleOpenChange}>
 			<DialogContent data-hosted="true" data-v2="true" className="sm:max-w-md">
 				{created ? (
 					<>
 						<DialogHeader>
-							<DialogTitle>Channel connected</DialogTitle>
+							<DialogTitle>
+								{discordVerificationPending
+									? "Discord setup saved — verification pending"
+									: "Channel connected"}
+							</DialogTitle>
 							<DialogDescription>
-								<span className="font-medium">{created.name}</span> is connected. Clawdi handles
-								message delivery automatically. There is nothing else to configure.
+								{discordVerificationPending ? (
+									<>
+										Credentials for <span className="font-medium">{created.name}</span> were saved,
+										but Clawdi does not verify them with Discord during setup.
+									</>
+								) : (
+									<>
+										<span className="font-medium">{created.name}</span> is connected. Clawdi handles
+										message delivery automatically.
+									</>
+								)}
 							</DialogDescription>
 						</DialogHeader>
+						{discordVerificationPending ? (
+							<div
+								role="status"
+								className="rounded-lg border border-warning/30 bg-warning-muted p-3 text-sm text-warning-muted-foreground"
+							>
+								<p className="font-medium">Verification pending</p>
+								<p className="mt-1 text-xs">
+									Send a test message to the bot, then review channel activity and health before
+									relying on it.
+								</p>
+							</div>
+						) : null}
 						{created.agent_token ? (
 							<TokenReveal
 								label="Agent token"
@@ -128,18 +181,19 @@ export function ConnectBotDialog({
 								note="An agent was auto-linked. This token lets it send and receive on the channel."
 							/>
 						) : null}
-						{provider === "whatsapp" ? (
-							<p className="text-sm text-muted-foreground">{WHATSAPP_COMING_SOON_MESSAGE}</p>
-						) : null}
 						<DialogFooter>
-							<Button variant="outline" onClick={() => onOpenChange(false)}>
+							<Button
+								variant="outline"
+								onClick={() => handleOpenChange(false)}
+								disabled={isSubmitting}
+							>
 								Close
 							</Button>
 							<Button
 								render={<Link to="/channels/$id" params={{ id: created.id }} />}
 								nativeButton={false}
 							>
-								Open channel
+								{discordVerificationPending ? "Open channel to verify" : "Open channel"}
 							</Button>
 						</DialogFooter>
 					</>
@@ -156,22 +210,34 @@ export function ConnectBotDialog({
 							<div className="flex flex-col gap-1.5">
 								<Label>Provider</Label>
 								<div className="grid grid-cols-2 gap-2">
-									{CHANNEL_PROVIDERS.map((p) => (
-										<EntityChoiceCard
-											key={p}
-											selected={provider === p}
-											onClick={() => changeProvider(p)}
-											icon={
-												<EntityIcon
-													kind="channel"
-													id={p}
-													label={PROVIDER_META[p].label}
-													size="sm"
-												/>
-											}
-											title={PROVIDER_META[p].label}
-										/>
-									))}
+									{CHANNEL_PROVIDERS.map((p) => {
+										const comingSoon = p === "whatsapp" && !WHATSAPP_LINKING_READY;
+										return (
+											<EntityChoiceCard
+												key={p}
+												selected={provider === p}
+												onClick={() => changeProvider(p)}
+												disabled={comingSoon}
+												badge={
+													comingSoon ? (
+														<span className="text-xs text-muted-foreground">Coming soon</span>
+													) : undefined
+												}
+												icon={
+													<EntityIcon
+														kind="channel"
+														id={p}
+														label={PROVIDER_META[p].label}
+														size="sm"
+													/>
+												}
+												title={PROVIDER_META[p].label}
+												description={
+													comingSoon ? "Hosted agent linking is not ready yet." : undefined
+												}
+											/>
+										);
+									})}
 								</div>
 							</div>
 
@@ -203,7 +269,15 @@ export function ConnectBotDialog({
 										placeholder={meta.tokenPlaceholder}
 										autoComplete="off"
 										spellCheck={false}
+										required
+										aria-invalid={Boolean(tokenError)}
+										aria-describedby={tokenError ? "connect-token-err" : undefined}
 									/>
+									{tokenError ? (
+										<p id="connect-token-err" className="text-xs text-destructive">
+											{tokenError}
+										</p>
+									) : null}
 								</div>
 							) : null}
 
@@ -219,10 +293,21 @@ export function ConnectBotDialog({
 											placeholder="Application (client) ID"
 											autoComplete="off"
 											spellCheck={false}
+											required
+											aria-invalid={Boolean(applicationIdError)}
+											aria-describedby={
+												applicationIdError ? "connect-app-id-err" : "connect-app-id-help"
+											}
 										/>
-										<p className="text-xs text-muted-foreground">
-											Required to publish slash commands.
-										</p>
+										{applicationIdError ? (
+											<p id="connect-app-id-err" className="text-xs text-destructive">
+												{applicationIdError}
+											</p>
+										) : (
+											<p id="connect-app-id-help" className="text-xs text-muted-foreground">
+												Required to publish slash commands.
+											</p>
+										)}
 									</div>
 									<div className="flex flex-col gap-1.5">
 										<Label htmlFor="connect-public-key">
@@ -261,20 +346,28 @@ export function ConnectBotDialog({
 											placeholder="Default command scope"
 											autoComplete="off"
 											spellCheck={false}
+											aria-invalid={Boolean(guildIdError)}
+											aria-describedby={guildIdError ? "connect-guild-id-err" : undefined}
 										/>
+										{guildIdError ? (
+											<p id="connect-guild-id-err" className="text-xs text-destructive">
+												{guildIdError}
+											</p>
+										) : null}
 									</div>
 								</>
 							) : null}
 						</div>
 
 						<DialogFooter>
-							<Button variant="outline" onClick={() => onOpenChange(false)}>
+							<Button
+								variant="outline"
+								onClick={() => handleOpenChange(false)}
+								disabled={isSubmitting}
+							>
 								Cancel
 							</Button>
-							<Button
-								onClick={submit}
-								disabled={!canSubmit || create.isPending || submitLocked.current}
-							>
+							<Button onClick={submit} disabled={!canSubmit || isSubmitting}>
 								{create.isPending ? "Connecting…" : "Connect"}
 							</Button>
 						</DialogFooter>

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+	channelDialogOpenChangeAllowed,
 	channelProviderLinkingReady,
 	linkAgentBlockReason,
 	pairingCommand,
@@ -16,6 +17,12 @@ describe("hosted channel instructions and gates", () => {
 		expect(channelProviderLinkingReady("telegram")).toBe(true);
 		expect(channelProviderLinkingReady("discord")).toBe(true);
 		expect(channelProviderLinkingReady("whatsapp")).toBe(false);
+	});
+
+	test("keeps one-time results in view while a connect or link request is pending", () => {
+		expect(channelDialogOpenChangeAllowed(false, true)).toBe(false);
+		expect(channelDialogOpenChangeAllowed(false, false)).toBe(true);
+		expect(channelDialogOpenChangeAllowed(true, true)).toBe(true);
 	});
 });
 

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.logic.ts
@@ -19,6 +19,10 @@ export function channelProviderLinkingReady(provider: string): boolean {
 	return provider !== "whatsapp" || WHATSAPP_LINKING_READY;
 }
 
+export function channelDialogOpenChangeAllowed(nextOpen: boolean, isSubmitting: boolean): boolean {
+	return nextOpen || !isSubmitting;
+}
+
 export function pairingCommand(code: string): string {
 	return `/bot_pair ${code}`;
 }

--- a/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
+++ b/apps/web/src/hosted/v2/channels/link-agent-dialog.tsx
@@ -39,6 +39,7 @@ import {
 	useLinkAgent,
 } from "@/hosted/v2/channels/channels-hooks";
 import {
+	channelDialogOpenChangeAllowed,
 	linkAgentBlockReason,
 	shouldMintWhatsappTenantCredential,
 } from "@/hosted/v2/channels/link-agent-dialog.logic";
@@ -139,6 +140,17 @@ export function LinkAgentDialog({
 		});
 	}
 
+	function handleOpenChange(nextOpen: boolean) {
+		if (
+			!channelDialogOpenChangeAllowed(
+				nextOpen,
+				link.isPending || createWhatsappCredential.isPending || submitLocked.current,
+			)
+		)
+			return;
+		onOpenChange(nextOpen);
+	}
+
 	const agentItems = useMemo(
 		() =>
 			agents.map((env) => {
@@ -152,7 +164,7 @@ export function LinkAgentDialog({
 	);
 
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
+		<Dialog open={open} onOpenChange={handleOpenChange}>
 			<DialogContent data-hosted="true" data-v2="true" className="sm:max-w-md">
 				<DialogHeader>
 					<DialogTitle>Link an agent</DialogTitle>
@@ -237,10 +249,16 @@ export function LinkAgentDialog({
 
 				<DialogFooter>
 					{token || linkedNoToken || whatsappCredentialMinted ? (
-						<Button onClick={() => onOpenChange(false)}>Done</Button>
+						<Button onClick={() => handleOpenChange(false)} disabled={isSubmitting}>
+							Done
+						</Button>
 					) : (
 						<>
-							<Button variant="outline" onClick={() => onOpenChange(false)}>
+							<Button
+								variant="outline"
+								onClick={() => handleOpenChange(false)}
+								disabled={isSubmitting}
+							>
 								Cancel
 							</Button>
 							<Button


### PR DESCRIPTION
v2 channels UX fixes (audit). v1/backend/generated-client untouched; /v1/channels canonical.

- WhatsApp marked Coming soon + disabled + blocked at submit — no dead channel created.
- Discord validates token/app-id/guild-id/public-key format; post-connect shows 'verification pending' (no false 'fully connected' claim).
- Pair-code default only when exactly one linked agent; 0 or many requires explicit selection (no agent_id:undefined 400).
- Owned bots deduped by id — no double render, counts correct.
- Health tab shows a readable Status/Connection/Message-delivery summary instead of raw native_transport JSON.
- Connect/Link locks cancel/escape/close while in flight so the one-time token/result isn't lost.

23 channels tests + typecheck + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)