### PR TITLE
fix(web): v2 AI-provider CRUD data-integrity (overwrite/half-commit/validate/delete)

### DIFF
--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.test.ts
@@ -5,13 +5,16 @@ import {
 	modelsFromText,
 	providerAuthForSubmit,
 	providerFormIdentity,
+	providerListAllowsSubmit,
+	providerPatchForSubmit,
+	providerRollbackPatch,
 	shouldUseCatalogModels,
 } from "@/hosted/v2/ai-providers/add-provider-dialog.logic";
 import {
 	presetCatalogToProviderModels,
 	providerPresetById,
 } from "@/hosted/v2/ai-providers/provider-presets";
-import type { AiProviderAuth } from "@/hosted/v2/ai-providers/types";
+import type { AiProvider, AiProviderAuth, AiProviderUpsert } from "@/hosted/v2/ai-providers/types";
 
 function testPreset(id: string) {
 	const preset = providerPresetById(id);
@@ -78,6 +81,67 @@ describe("providerAuthForSubmit", () => {
 				hasNewManagedKey: true,
 			}),
 		).toEqual({ type: "api_key", source: "managed" });
+	});
+});
+
+describe("provider edit integrity", () => {
+	const body = {
+		provider_id: "openai",
+		type: "openai",
+		label: "Updated OpenAI",
+		base_url: "https://api.openai.com/v1",
+		api_mode: "openai_responses",
+		auth: { type: "api_key", source: "managed" },
+		managed_by: "user",
+		runtime_env_name: "OPENAI_API_KEY",
+		models: [{ id: "gpt-5.5" }],
+	} satisfies AiProviderUpsert;
+
+	test("omits auth from the metadata patch after a managed key is stored", () => {
+		const patch = providerPatchForSubmit(body, { preserveExistingAuth: true });
+
+		expect("auth" in patch).toBe(false);
+		expect(patch.label).toBe("Updated OpenAI");
+	});
+
+	test("includes auth for a single-request edit that does not store a new key", () => {
+		expect(providerPatchForSubmit(body, { preserveExistingAuth: false }).auth).toEqual(body.auth);
+	});
+
+	test("builds a rollback patch with the prior auth source and fields", () => {
+		const provider = {
+			id: "provider-row-id",
+			provider_id: "openai",
+			type: "openai",
+			label: "Original OpenAI",
+			base_url: "https://old.example/v1",
+			api_mode: "openai_chat",
+			auth: { type: "api_key", source: "env", ref: "env:OPENAI_API_KEY" },
+			managed_by: "user",
+			runtime_env_name: "OPENAI_API_KEY",
+			models: [{ id: "gpt-old" }],
+			scope: "user",
+			created_at: "2026-01-01T00:00:00Z",
+			updated_at: "2026-01-01T00:00:00Z",
+		} satisfies AiProvider;
+
+		expect(providerRollbackPatch(provider)).toMatchObject({
+			label: "Original OpenAI",
+			base_url: "https://old.example/v1",
+			auth: { type: "api_key", source: "env", ref: "env:OPENAI_API_KEY" },
+			models: [{ id: "gpt-old" }],
+		});
+	});
+});
+
+describe("provider list submit gate", () => {
+	test("blocks create until the provider list succeeds", () => {
+		expect(providerListAllowsSubmit(false, false)).toBe(false);
+		expect(providerListAllowsSubmit(false, true)).toBe(true);
+	});
+
+	test("does not block editing an already-loaded provider snapshot", () => {
+		expect(providerListAllowsSubmit(true, false)).toBe(true);
 	});
 });
 

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.ts
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.logic.ts
@@ -14,6 +14,7 @@ import {
 import type {
 	AiProvider,
 	AiProviderAuth,
+	AiProviderPatch,
 	AiProviderUpsert,
 	AiProviderUpsertAuth,
 } from "@/hosted/v2/ai-providers/types";
@@ -88,6 +89,46 @@ export function providerAuthForSubmit({
 		if (keepable) return keepable.auth;
 	}
 	return authFor("api_key");
+}
+
+export function providerPatchForSubmit(
+	body: AiProviderUpsert,
+	options: { preserveExistingAuth: boolean },
+): AiProviderPatch {
+	const patch: AiProviderPatch = {
+		type: body.type,
+		label: body.label,
+		base_url: body.base_url,
+		api_mode: body.api_mode,
+		managed_by: body.managed_by,
+		runtime_env_name: body.runtime_env_name,
+		capabilities: body.capabilities,
+		models: body.models,
+	};
+	if (!options.preserveExistingAuth) patch.auth = body.auth;
+	return patch;
+}
+
+/** Restore every editable field exposed by the provider response. */
+export function providerRollbackPatch(provider: AiProvider): AiProviderPatch {
+	const patch: AiProviderPatch = {
+		type: provider.type,
+		label: provider.label,
+		base_url: provider.base_url,
+		api_mode: provider.api_mode,
+		managed_by: provider.managed_by,
+		runtime_env_name: provider.runtime_env_name,
+		capabilities: provider.capabilities,
+		models: provider.models,
+	};
+	// oauth_profile is a response-only legacy auth shape. For every editable
+	// auth shape, restore the prior source as well as the provider fields.
+	if (provider.auth.type !== "oauth_profile") patch.auth = provider.auth;
+	return patch;
+}
+
+export function providerListAllowsSubmit(isEdit: boolean, listLoaded: boolean): boolean {
+	return isEdit || listLoaded;
 }
 
 export function modelsToText(models: ReadonlyArray<{ id: string }> | null | undefined): string {

--- a/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/add-provider-dialog.tsx
@@ -35,17 +35,21 @@ import {
 	parseModelIds,
 	providerAuthForSubmit,
 	providerFormIdentity,
+	providerListAllowsSubmit,
+	providerPatchForSubmit,
+	providerRollbackPatch,
 	shouldUseCatalogModels,
 } from "@/hosted/v2/ai-providers/add-provider-dialog.logic";
 import {
 	useAiProviders,
+	useCreateProvider,
+	useCreateProviderQuiet,
 	useDeleteProviderQuiet,
 	useOAuthComplete,
 	useOAuthStart,
+	usePatchProvider,
+	usePatchProviderQuiet,
 	useSetApiKey,
-	useUpsertProvider,
-	useUpsertProviderQuiet,
-	useValidateProvider,
 } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import { ProviderTypeChip } from "@/hosted/v2/ai-providers/ai-providers-ui";
 import {
@@ -73,7 +77,8 @@ import {
 	type ProviderTypeId,
 	providerTypeMeta,
 } from "@/hosted/v2/ai-providers/provider-types";
-import type { AiProvider } from "@/hosted/v2/ai-providers/types";
+import type { AiProvider, AiProviderUpsert } from "@/hosted/v2/ai-providers/types";
+import { normalizeApiError } from "@/lib/api-errors";
 
 function isApiMode(value: string | null): value is ApiMode {
 	return (
@@ -122,11 +127,12 @@ export function AddProviderDialog({
 	onCreated?: (providerId: string) => void;
 }) {
 	const providers = useAiProviders();
-	const upsert = useUpsertProvider();
-	const upsertQuiet = useUpsertProviderQuiet();
+	const createProvider = useCreateProvider();
+	const createProviderQuiet = useCreateProviderQuiet();
+	const patchProvider = usePatchProvider();
+	const patchProviderQuiet = usePatchProviderQuiet();
 	const deleteProviderQuiet = useDeleteProviderQuiet();
 	const setKey = useSetApiKey();
-	const validate = useValidateProvider();
 	const oauthStart = useOAuthStart();
 	const oauthComplete = useOAuthComplete();
 
@@ -298,13 +304,23 @@ export function AddProviderDialog({
 		? apiKeyEditState(authMethod, editing?.auth)
 		: apiKeyEditState(authMethod, null);
 	const { keyRequired, labelSuffix: apiKeyLabelSuffix, helpText: apiKeyHelpText } = apiKeyState;
+	const providerListReady = providerListAllowsSubmit(isEdit, providers.isSuccess);
 	const canSubmit =
+		providerListReady &&
 		Boolean(providerId) &&
 		Boolean(baseUrl.trim()) &&
 		noneAuthOk &&
 		(!keyRequired || apiKey.trim().length > 0);
 
 	async function submit() {
+		if (!providerListReady) {
+			toast.error("Provider list not ready", {
+				description: providers.isLoading
+					? "Wait for providers to finish loading, then try again."
+					: "Refresh providers, then try again.",
+			});
+			return;
+		}
 		if (!canSubmit) return;
 
 		// Codex "Sign in with ChatGPT": create the canonical openai-codex provider
@@ -313,25 +329,19 @@ export function AddProviderDialog({
 		// the sub-screen). redirect_uri stays identical across start/complete.
 		if (authMethod === "oauth") {
 			const redirectUri = codexRedirectUri();
-			if (!providers.isSuccess) {
-				toast.error("Provider list not ready", {
-					description: providers.isLoading
-						? "Wait for providers to finish loading, then try again."
-						: "Refresh providers, then try again.",
-				});
-				return;
-			}
 			// The canonical openai-codex provider must exist before `start`, but it
 			// isn't connected until `complete`. Only create it (quietly, without
 			// invalidating the list) if it doesn't already exist — so we never
 			// clobber a previously-connected provider, and an abandon cleans up
 			// only the record we ourselves created.
-			const existingCodex = providers.data.providers.some(
-				(p) => p.provider_id === CLAWDI_CODEX_OAUTH_PROVIDER_ID,
-			);
+			const existingCodex =
+				providers.data?.providers.some((p) => p.provider_id === CLAWDI_CODEX_OAUTH_PROVIDER_ID) ??
+				false;
 			if (!existingCodex) {
-				const codexCreated = await upsertQuiet.mutateAsync(codexProviderBody()).catch(() => null);
-				if (!codexCreated) return; // upsertQuiet.onError already toasts
+				const codexCreated = await createProviderQuiet
+					.mutateAsync(codexProviderBody())
+					.catch(() => null);
+				if (!codexCreated) return; // createProviderQuiet.onError already toasts
 				createdFreshRef.current = true;
 			} else {
 				createdFreshRef.current = false;
@@ -387,14 +397,12 @@ export function AddProviderDialog({
 			auth,
 			managed_by: "user" as const,
 			runtime_env_name: keyBacked ? runtimeEnvForSubmit : null,
-		};
-		const created = await upsert.mutateAsync(body).catch(() => null);
-		if (!created) return;
-
-		if (hasNewManagedKey) {
-			// Don't claim success on a key that didn't store — `/validate` only
-			// re-checks config shape, not that the key landed. setKey's onError
-			// already toasts; keep the dialog open so the user can retry.
+		} satisfies AiProviderUpsert;
+		let saved: AiProvider | null;
+		if (editing && hasNewManagedKey) {
+			// Store the payload and switch auth in the backend's single transaction
+			// before changing provider fields. A key-storage failure therefore
+			// leaves the entire existing provider untouched.
 			const keyStored = await setKey
 				.mutateAsync({
 					providerId,
@@ -402,26 +410,59 @@ export function AddProviderDialog({
 					runtime_env_name: runtimeEnvForSubmit,
 				})
 				.catch(() => null);
-			if (!keyStored) {
-				if (!isEdit) await deleteProviderQuiet.mutateAsync(providerId).catch(() => null);
+			if (!keyStored) return; // setKey.onError already toasts
+
+			saved = await patchProvider
+				.mutateAsync({
+					providerId,
+					body: providerPatchForSubmit(body, { preserveExistingAuth: true }),
+				})
+				.catch(() => null);
+			if (!saved) {
+				await restoreEditedProvider(providerId, editing);
 				return;
+			}
+		} else {
+			saved = editing
+				? await patchProvider
+						.mutateAsync({
+							providerId,
+							body: providerPatchForSubmit(body, { preserveExistingAuth: false }),
+						})
+						.catch(() => null)
+				: await createProvider.mutateAsync(body).catch(() => null);
+			if (!saved) return;
+
+			if (hasNewManagedKey) {
+				// Create has no prior auth to preserve. Remove the new provider if
+				// key storage fails so no unusable record remains.
+				const keyStored = await setKey
+					.mutateAsync({
+						providerId,
+						value: apiKey.trim(),
+						runtime_env_name: runtimeEnvForSubmit,
+					})
+					.catch(() => null);
+				if (!keyStored) {
+					await deleteProviderQuiet.mutateAsync(providerId).catch(() => null);
+					return;
+				}
 			}
 		}
 
-		// The provider IS saved at this point. `validate` is a post-save config
-		// check — distinguish its three outcomes honestly: invalid config,
-		// couldn't-run (network/throw → null), or clean.
-		const saved = isEdit ? "Provider updated" : "Provider added";
-		const result = await validate.mutateAsync(providerId).catch(() => null);
-		if (result && !result.valid) {
-			toast.warning("Provider saved with issues", { description: result.errors.join(" · ") });
-		} else if (!result) {
-			toast.success(saved, { description: "Couldn't run validation — check it from the list." });
-		} else {
-			toast.success(saved);
-		}
-		if (!isEdit) onCreated?.(created.provider_id);
+		toast.success(isEdit ? "Provider updated" : "Provider added");
+		if (!isEdit) onCreated?.(saved.provider_id);
 		onOpenChange(false);
+	}
+
+	async function restoreEditedProvider(providerId: string, previous: AiProvider) {
+		await patchProviderQuiet
+			.mutateAsync({ providerId, body: providerRollbackPatch(previous) })
+			.catch((error: unknown) => {
+				toast.error("Couldn't restore previous provider settings", {
+					description: normalizeApiError(error),
+				});
+			});
 	}
 
 	function openSignIn(url: string) {
@@ -612,11 +653,12 @@ export function AddProviderDialog({
 	}, [oauth]);
 
 	const busy =
-		upsert.isPending ||
-		upsertQuiet.isPending ||
+		createProvider.isPending ||
+		createProviderQuiet.isPending ||
+		patchProvider.isPending ||
+		patchProviderQuiet.isPending ||
 		deleteProviderQuiet.isPending ||
 		setKey.isPending ||
-		validate.isPending ||
 		oauthStart.isPending;
 
 	return (
@@ -729,6 +771,16 @@ export function AddProviderDialog({
 
 						<div className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
 							<div className="flex flex-col gap-4">
+								{!providerListReady ? (
+									<div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
+										<CircleAlert className="mt-0.5 size-3.5 shrink-0" />
+										<p>
+											{providers.isLoading
+												? "Providers are still loading. Adding is disabled until the list is ready."
+												: "Providers couldn't be loaded. Retry the list before adding one."}
+										</p>
+									</div>
+								) : null}
 								{!isEdit ? (
 									<div className="flex flex-col gap-2">
 										<Label>Provider preset</Label>

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
@@ -2,7 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import type { AiProviderUpsert } from "@/hosted/v2/ai-providers/types";
+import type { AiProviderPatch, AiProviderUpsert } from "@/hosted/v2/ai-providers/types";
 import { toastApiError, unwrap, useApi } from "@/lib/api";
 
 /** Typed data hooks for the AI Providers surface (cloud-api `/v1/ai-providers`). */
@@ -17,14 +17,46 @@ export function useAiProviders() {
 	});
 }
 
-export function useUpsertProvider() {
+export function useCreateProvider() {
 	const api = useApi();
 	const qc = useQueryClient();
 	return useMutation({
 		mutationFn: async (body: AiProviderUpsert) =>
-			unwrap(await api.POST("/v1/ai-providers", { body, params: { query: { replace: true } } })),
+			unwrap(await api.POST("/v1/ai-providers", { body, params: { query: { replace: false } } })),
 		onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
-		onError: toastApiError("Couldn't save provider"),
+		onError: toastApiError("Couldn't add provider"),
+	});
+}
+
+export function usePatchProvider() {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (vars: { providerId: string; body: AiProviderPatch }) =>
+			unwrap(
+				await api.PATCH("/v1/ai-providers/{provider_id}", {
+					params: { path: { provider_id: vars.providerId } },
+					body: vars.body,
+				}),
+			),
+		onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
+		onError: toastApiError("Couldn't update provider"),
+	});
+}
+
+/** Silent patch used only to restore a snapshot after a multi-step edit fails. */
+export function usePatchProviderQuiet() {
+	const api = useApi();
+	const qc = useQueryClient();
+	return useMutation({
+		mutationFn: async (vars: { providerId: string; body: AiProviderPatch }) =>
+			unwrap(
+				await api.PATCH("/v1/ai-providers/{provider_id}", {
+					params: { path: { provider_id: vars.providerId } },
+					body: vars.body,
+				}),
+			),
+		onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
 	});
 }
 
@@ -53,11 +85,11 @@ export function useDeleteProvider() {
  * a provider that looks connected even if the user abandons sign-in. The list
  * refreshes on a successful `complete` (`useOAuthComplete`) instead.
  */
-export function useUpsertProviderQuiet() {
+export function useCreateProviderQuiet() {
 	const api = useApi();
 	return useMutation({
 		mutationFn: async (body: AiProviderUpsert) =>
-			unwrap(await api.POST("/v1/ai-providers", { body, params: { query: { replace: true } } })),
+			unwrap(await api.POST("/v1/ai-providers", { body, params: { query: { replace: false } } })),
 		onError: toastApiError("Couldn't start sign-in"),
 	});
 }
@@ -149,7 +181,8 @@ export function useSetApiKey() {
 	});
 }
 
-export function useValidateProvider() {
+/** Static saved-field check; this endpoint does not probe credentials or connectivity. */
+export function useCheckProviderFields() {
 	const api = useApi();
 	return useMutation({
 		mutationFn: async (providerId: string) =>
@@ -158,7 +191,7 @@ export function useValidateProvider() {
 					params: { path: { provider_id: providerId } },
 				}),
 			),
-		onError: toastApiError("Couldn't validate"),
+		onError: toastApiError("Couldn't check fields"),
 	});
 }
 

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-page.logic.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-page.logic.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
+import {
+	providerRemovalImpact,
+	providerUsage,
+} from "@/hosted/v2/ai-providers/ai-providers-page.logic";
+
+describe("providerUsage", () => {
+	test("reports unresolved inventory as unknown instead of unused", () => {
+		expect(providerUsage("openai", null)).toEqual({ known: false, agentCount: 0 });
+	});
+
+	test("counts agents whose runtime provider pool contains the provider", () => {
+		const deployments = [
+			hostedDeploymentFixture({
+				id: "dep_openai",
+				runtimeConfiguration: {
+					providers: [{ provider_id: "openai", auth_kind: "secret_reference", models: [] }],
+					features: [],
+				},
+			}),
+			hostedDeploymentFixture({
+				id: "dep_other",
+				runtimeConfiguration: {
+					providers: [{ provider_id: "anthropic", auth_kind: "secret_reference", models: [] }],
+					features: [],
+				},
+			}),
+		];
+
+		expect(providerUsage("openai", deployments)).toEqual({ known: true, agentCount: 1 });
+	});
+
+	test("detects a primary-model reference even when the provider pool is incomplete", () => {
+		const deployment = hostedDeploymentFixture({
+			runtimeConfiguration: {
+				primary_model: { provider_id: "openai", model: "gpt-5.5" },
+				providers: [],
+				features: [],
+			},
+		});
+
+		expect(providerUsage("openai", [deployment])).toEqual({ known: true, agentCount: 1 });
+	});
+});
+
+describe("providerRemovalImpact", () => {
+	test("requires acknowledgement and warns against automatic fallback when the provider is used", () => {
+		const impact = providerRemovalImpact({ known: true, agentCount: 2 });
+
+		expect(impact.acknowledgementRequired).toBe(true);
+		expect(impact.warning).toContain("2 agents currently use it");
+		expect(impact.warning).toContain("no automatic fallback");
+	});
+
+	test("requires acknowledgement when usage could not be checked", () => {
+		expect(providerRemovalImpact({ known: false, agentCount: 0 }).acknowledgementRequired).toBe(
+			true,
+		);
+	});
+
+	test("does not require extra acknowledgement for a known-unused provider", () => {
+		expect(providerRemovalImpact({ known: true, agentCount: 0 }).acknowledgementRequired).toBe(
+			false,
+		);
+	});
+});

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-page.logic.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-page.logic.ts
@@ -1,0 +1,56 @@
+import type { HostedDeployment } from "@/hosted/billing/contracts";
+
+export interface ProviderUsage {
+	known: boolean;
+	agentCount: number;
+}
+
+export interface ProviderRemovalImpact {
+	acknowledgementRequired: boolean;
+	warning: string;
+}
+
+/**
+ * Resolve provider usage from the authoritative hosted runtime configuration.
+ * `null` means the inventory has never loaded, so deletion must be treated as
+ * potentially destructive rather than as a known-unused provider.
+ */
+export function providerUsage(
+	providerId: string,
+	deployments: readonly HostedDeployment[] | null,
+): ProviderUsage {
+	if (deployments === null) return { known: false, agentCount: 0 };
+	const agentCount = deployments.filter((deployment) => {
+		const config = deployment.resource.spec.runtime_configuration;
+		return (
+			config.primary_model?.provider_id === providerId ||
+			config.providers.some((provider) => provider.provider_id === providerId)
+		);
+	}).length;
+	return { known: true, agentCount };
+}
+
+export function providerRemovalImpact(usage: ProviderUsage): ProviderRemovalImpact {
+	if (!usage.known) {
+		return {
+			acknowledgementRequired: true,
+			warning:
+				"Removing this provider archives it. We couldn't check whether any agents use it. Any affected agent will lose model access until reconfigured; there is no automatic fallback to the managed default.",
+		};
+	}
+	if (usage.agentCount > 0) {
+		const agents =
+			usage.agentCount === 1
+				? "1 agent currently uses"
+				: `${usage.agentCount} agents currently use`;
+		return {
+			acknowledgementRequired: true,
+			warning: `Removing this provider archives it. ${agents} it and will lose model access until reconfigured; there is no automatic fallback to the managed default.`,
+		};
+	}
+	return {
+		acknowledgementRequired: false,
+		warning:
+			"Removing this provider archives it. No hosted agents currently use it, but this can't be undone.",
+	};
+}

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { isFirstPartyManagedAiProvider } from "@clawdi/shared";
-import { BadgeCheck, Pencil, Plus, Trash2 } from "lucide-react";
+import { ListChecks, Pencil, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -12,15 +12,34 @@ import { ListToolbar } from "@/components/list-toolbar";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
 import { SectionLabel } from "@/components/section-label";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
-import { ConfirmAction } from "@/components/ui/confirm-action";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Spinner } from "@/components/ui/spinner";
+import { useHostedDeploymentInventory } from "@/hosted/use-hosted-deployment-inventory";
 import { AddProviderDialog } from "@/hosted/v2/ai-providers/add-provider-dialog";
 import {
 	useAiProviders,
+	useCheckProviderFields,
 	useDeleteProvider,
-	useValidateProvider,
 } from "@/hosted/v2/ai-providers/ai-providers-hooks";
+import {
+	type ProviderUsage,
+	providerRemovalImpact,
+	providerUsage,
+} from "@/hosted/v2/ai-providers/ai-providers-page.logic";
 import { AuthBadge, ManagedProviderCard } from "@/hosted/v2/ai-providers/ai-providers-ui";
 import {
 	API_MODE_LABEL,
@@ -37,6 +56,7 @@ const PROVIDER_GRID_CLASS = ENTITY_GRID_CLASS;
 
 export function AiProvidersPage() {
 	const providers = useAiProviders();
+	const inventory = useHostedDeploymentInventory();
 	const [addOpen, setAddOpen] = useState(false);
 	const [editing, setEditing] = useState<AiProvider | null>(null);
 
@@ -52,6 +72,7 @@ export function AiProvidersPage() {
 				actions={
 					<Button
 						size="sm"
+						disabled={!providers.isSuccess}
 						onClick={() => {
 							setEditing(null);
 							setAddOpen(true);
@@ -93,6 +114,7 @@ export function AiProvidersPage() {
 							<ProviderCard
 								key={provider.provider_id}
 								provider={provider}
+								usage={providerUsage(provider.provider_id, inventory.deployments)}
 								onEdit={() => {
 									setEditing(provider);
 									setAddOpen(true);
@@ -108,18 +130,30 @@ export function AiProvidersPage() {
 	);
 }
 
-function ProviderCard({ provider, onEdit }: { provider: AiProvider; onEdit: () => void }) {
+function ProviderCard({
+	provider,
+	usage,
+	onEdit,
+}: {
+	provider: AiProvider;
+	usage: ProviderUsage;
+	onEdit: () => void;
+}) {
 	const meta = providerTypeMeta(provider.type);
-	const del = useDeleteProvider();
-	const validate = useValidateProvider();
+	const checkFields = useCheckProviderFields();
 	const providerLabel = provider.label ?? provider.provider_id;
 	const modelSummary = modelCatalogSummary(provider);
 
-	function runValidate() {
-		validate.mutate(provider.provider_id, {
+	function runCheckFields() {
+		checkFields.mutate(provider.provider_id, {
 			onSuccess: (result) => {
-				if (result.valid) toast.success("Configuration looks good");
-				else toast.warning("Validation issues", { description: result.errors.join(" · ") });
+				if (result.valid) {
+					toast.success("Saved fields are valid", {
+						description: "This does not test endpoint connectivity or credentials.",
+					});
+				} else {
+					toast.warning("Field check found issues", { description: result.errors.join(" · ") });
+				}
 			},
 		});
 	}
@@ -147,40 +181,96 @@ function ProviderCard({ provider, onEdit }: { provider: AiProvider; onEdit: () =
 				<Button
 					variant="ghost"
 					size="sm"
-					onClick={runValidate}
-					disabled={validate.isPending}
-					aria-label={`Validate ${providerLabel}`}
+					onClick={runCheckFields}
+					disabled={checkFields.isPending}
+					aria-label={`Check saved fields for ${providerLabel}`}
 				>
-					<BadgeCheck />
-					Validate
+					<ListChecks />
+					Check fields
 				</Button>
 				<Button variant="outline" size="sm" onClick={onEdit} aria-label={`Edit ${providerLabel}`}>
 					<Pencil />
 					Edit
 				</Button>
-				<ConfirmAction
-					title={`Remove ${providerLabel}?`}
-					description={
-						<p>
-							Agents using this provider fall back to the managed default. This can't be undone.
-						</p>
-					}
-					confirmLabel="Remove provider"
-					destructive
-					onConfirm={() => del.mutate(provider.provider_id)}
-				>
+				<RemoveProviderAction provider={provider} usage={usage} />
+			</div>
+		</div>
+	);
+}
+
+function RemoveProviderAction({ provider, usage }: { provider: AiProvider; usage: ProviderUsage }) {
+	const del = useDeleteProvider();
+	const [open, setOpen] = useState(false);
+	const [acknowledged, setAcknowledged] = useState(false);
+	const providerLabel = provider.label ?? provider.provider_id;
+	const impact = providerRemovalImpact(usage);
+	const acknowledgementId = `remove-provider-ack-${provider.provider_id}`;
+
+	function changeOpen(next: boolean) {
+		if (del.isPending) return;
+		setOpen(next);
+		if (!next) setAcknowledged(false);
+	}
+
+	function removeProvider() {
+		del.mutate(provider.provider_id, {
+			onSuccess: () => {
+				setOpen(false);
+				setAcknowledged(false);
+			},
+		});
+	}
+
+	return (
+		<AlertDialog open={open} onOpenChange={changeOpen}>
+			<AlertDialogTrigger
+				render={
 					<Button
 						variant="ghost"
 						size="icon-sm"
 						className="ml-auto text-muted-foreground hover:text-destructive"
 						disabled={del.isPending}
 						aria-label={`Remove ${providerLabel}`}
+					/>
+				}
+			>
+				<Trash2 />
+			</AlertDialogTrigger>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Remove {providerLabel}?</AlertDialogTitle>
+					<AlertDialogDescription render={<div className="space-y-3" />}>
+						<p>{impact.warning}</p>
+						{impact.acknowledgementRequired ? (
+							<div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-3">
+								<Checkbox
+									id={acknowledgementId}
+									checked={acknowledged}
+									onCheckedChange={(checked) => setAcknowledged(checked === true)}
+								/>
+								<Label htmlFor={acknowledgementId} className="text-sm font-normal leading-snug">
+									I understand that affected agents will lose model access until reconfigured.
+								</Label>
+							</div>
+						) : null}
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel disabled={del.isPending}>Cancel</AlertDialogCancel>
+					<AlertDialogAction
+						onClick={(event) => {
+							event.preventDefault();
+							removeProvider();
+						}}
+						disabled={del.isPending || (impact.acknowledgementRequired && !acknowledged)}
+						variant="destructive"
 					>
-						<Trash2 />
-					</Button>
-				</ConfirmAction>
-			</div>
-		</div>
+						{del.isPending ? <Spinner /> : null}
+						Remove provider
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
 	);
 }
 


### PR DESCRIPTION
v2 AI-provider CRUD BLOCKERs (audit). v1/backend untouched.

- B3: 'Add provider' disabled until the providers list loads successfully; creates now send `replace=false` (a create can never clobber an existing same-name provider); edits use PATCH.
- B5: managed-key edit is atomic — key+auth stored first, then metadata patched without rewriting auth; a key-step failure leaves the provider untouched, a metadata-step failure restores the prior snapshot (and toasts if restore itself fails). No more half-committed unusable-auth state.
- Validate → relabeled 'Check fields', explicitly says it does not test connectivity/credentials, and removed from Save so Save can't hang on it.
- B4 (web): Delete truthfully warns affected agents lose model access with no auto-fallback; requires explicit acknowledgement when the provider is in use (or usage can't be determined).

41 focused AI-provider tests + typecheck + lint pass. Backend follow-up (separate PR): auto-rebind archived provider → managed in runtime_source.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)