### PR TITLE
fix(web): show real managed model names + gate deploy billing on inventory (B1)

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -28,7 +28,6 @@ const managedModelCatalog = {
 		{ id: "gpt-5.6-luna", display_name: "Luna", is_default: true },
 		{ id: "gpt-5.6-sol", display_name: "Sol", is_default: false },
 		{ id: "gpt-5.6-terra", display_name: "Terra", is_default: false },
-		{ id: "gpt-5.5", display_name: "GPT-5.5", is_default: false },
 	],
 };
 
@@ -743,6 +742,7 @@ type HostedApiStubOptions = {
 	ledgerRequests?: string[];
 	ledgerResponses?: unknown[];
 	managedModels?: typeof managedModelCatalog;
+	planRequests?: string[];
 	plans?: readonly unknown[];
 	planChangeRequests?: string[];
 	planChangeResponses?: unknown[];
@@ -765,6 +765,8 @@ type HostedApiStubOptions = {
 		ifMatch: string | null;
 	}>;
 	walletState?: typeof walletState;
+	walletRequests?: string[];
+	walletResponses?: StubResponse[];
 	onTopUpSuccess?: () => void;
 	onWalletCheckoutSuccess?: () => void;
 };
@@ -785,11 +787,20 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			options.productAccessRequests?.push(`DEPLOY ${p}`);
 			return fulfillJson(r, hostedUser(options.canCreateCloudAgents ?? true));
 		}
-		if (p === "/v2/subscription/plans") return fulfillJson(r, plans);
+		if (p === "/v2/subscription/plans") {
+			options.planRequests?.push(r.request().url());
+			return fulfillJson(r, plans);
+		}
 		if (p === "/v2/ai-providers/managed/models") {
 			return fulfillJson(r, options.managedModels ?? managedModelCatalog);
 		}
 		if (p === "/v2/wallet" && r.request().method() === "GET") {
+			options.walletRequests?.push(r.request().url());
+			const response = options.walletResponses?.shift();
+			if (response) {
+				if (response.status < 400) currentWallet = response.body as typeof walletState;
+				return fulfillJson(r, response.body, response.status);
+			}
 			return fulfillJson(r, currentWallet);
 		}
 		if (p === "/v2/wallet/auto-reload" && r.request().method() === "PUT") {
@@ -818,6 +829,9 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		}
 		if (p === "/v2/deployments" && r.request().method() === "GET") {
 			if (options.deploymentsResponse) {
+				if (options.deploymentsResponse.delayMs) {
+					await new Promise((resolve) => setTimeout(resolve, options.deploymentsResponse?.delayMs));
+				}
 				return fulfillJson(r, options.deploymentsResponse.body, options.deploymentsResponse.status);
 			}
 			return fulfillJson(r, deployments.map(readDeploymentFixture));
@@ -1275,8 +1289,11 @@ test("free Basic Deploy submits the declarative create contract", async ({ page 
 	expect(JSON.parse(createDeploymentRequests[0]?.body ?? "{}")).toMatchObject({
 		compute_plan_slug: "compute_basic",
 		runtime: "hermes",
+		primary_model: {
+			provider_id: "clawdi-v2",
+			model: "gpt-5.6-luna",
+		},
 	});
-	expect(JSON.parse(createDeploymentRequests[0]?.body ?? "{}")).not.toHaveProperty("primary_model");
 });
 
 test("managed model picker lists the curated catalog without Custom or image models", async ({
@@ -1290,12 +1307,12 @@ test("managed model picker lists the curated catalog without Custom or image mod
 	});
 	await page.goto("/deploy");
 
+	await expect(page.locator("#deploy-catalog-model")).toContainText("Luna");
 	await page.locator("#deploy-catalog-model").click();
-	await expect(page.getByRole("option", { name: "Hosted default (Luna)" })).toBeVisible();
 	await expect(page.getByRole("option", { name: "Luna", exact: true })).toBeVisible();
 	await expect(page.getByRole("option", { name: "Sol", exact: true })).toBeVisible();
 	await expect(page.getByRole("option", { name: "Terra", exact: true })).toBeVisible();
-	await expect(page.getByRole("option", { name: "GPT-5.5", exact: true })).toBeVisible();
+	await expect(page.getByRole("option", { name: "Hosted default (Luna)" })).toHaveCount(0);
 	await expect(page.getByRole("option", { name: "Custom model" })).toHaveCount(0);
 	await expect(page.getByRole("option", { name: /gpt-image/i })).toHaveCount(0);
 
@@ -1308,6 +1325,55 @@ test("managed model picker lists the curated catalog without Custom or image mod
 			model: "gpt-5.6-sol",
 		},
 	});
+});
+
+test("Basic paid checkout stays hidden until deployment inventory succeeds", async ({ page }) => {
+	await stubHostedApi(page, {
+		plans: [basicPlan],
+		deploymentsResponse: { status: 200, body: [], delayMs: 1_000 },
+	});
+	await page.goto("/deploy");
+
+	await expect(page.getByText("Checking your free Basic slot…", { exact: true })).toBeVisible();
+	await expect(page.getByText("$9/mo", { exact: true })).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Continue to checkout" })).toHaveCount(0);
+	await expect(page.getByRole("button", { name: "Deploy agent" })).toBeDisabled();
+
+	await expect(page.getByText("First Basic agent — Free", { exact: false })).toBeVisible();
+	await expect(page.getByRole("button", { name: "Deploy agent" })).toBeEnabled();
+});
+
+test("empty plans and wallet failures expose working retries", async ({ page }) => {
+	const planRequests: string[] = [];
+	await stubHostedApi(page, { plans: [], planRequests });
+	await page.goto("/deploy");
+
+	const plansError = page.getByRole("alert").filter({ hasText: "Couldn't load compute plans" });
+	await expect(plansError).toBeVisible();
+	await plansError.getByRole("button", { name: "Retry" }).click();
+	await expect.poll(() => planRequests.length).toBeGreaterThanOrEqual(2);
+
+	const walletRequests: string[] = [];
+	await page.unrouteAll({ behavior: "wait" });
+	await stubHostedApi(page, {
+		deployments: [includedBasicDeployment],
+		plans: [basicPlan],
+		walletRequests,
+		walletResponses: [
+			{ status: 403, body: { detail: "wallet unavailable" } },
+			{ status: 200, body: walletState },
+		],
+	});
+	await page.goto("/deploy");
+	await page.getByRole("button", { name: /Wallet balance/ }).click();
+
+	const walletError = page
+		.getByRole("alert")
+		.filter({ hasText: "Couldn't load your AI Credits wallet" });
+	await expect(walletError).toBeVisible();
+	await walletError.getByRole("button", { name: "Retry" }).click();
+	await expect(page.getByTestId("wallet-debit-equation")).toBeVisible();
+	await expect.poll(() => walletRequests.length).toBe(2);
 });
 
 test("hosted locale settings submit canonical deployment PATCH", async ({ page }) => {
@@ -1355,6 +1421,40 @@ test("hosted AI provider Apply submits canonical deployment PATCH", async ({ pag
 		ai_provider_id: null,
 		provider_ids: [],
 		primary_model: null,
+	});
+});
+
+test("hosted AI provider Apply accepts the managed Luna default", async ({ page }) => {
+	const updateDeploymentRequests: Array<{
+		body: string;
+		idempotencyKey: string | null;
+		ifMatch: string | null;
+	}> = [];
+	const unmanagedDeployment: DeploymentMutationFixture = {
+		...includedBasicDeployment,
+		id: "hdep_unmanaged_model",
+		config_info: {
+			...includedBasicDeployment.config_info,
+			ai_provider_auth_kind: "unmanaged",
+		},
+	};
+	await stubHostedApi(page, {
+		deployments: [unmanagedDeployment],
+		updateDeploymentRequests,
+	});
+	await page.goto("/agents/hdep_unmanaged_model/model-provider?source=on-clawdi");
+
+	await page.getByRole("button", { name: /Managed by Clawdi/ }).click();
+	await expect(page.locator("#agent-catalog-model")).toContainText("Luna");
+	await page.getByRole("button", { name: "Apply provider settings" }).click();
+	await expect.poll(() => updateDeploymentRequests.length).toBe(1);
+	expect(JSON.parse(updateDeploymentRequests[0]?.body ?? "{}")).toMatchObject({
+		ai_provider_auth_kind: "managed",
+		provider_ids: ["clawdi-v2"],
+		primary_model: {
+			provider_id: "clawdi-v2",
+			model: "gpt-5.6-luna",
+		},
 	});
 });
 

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -163,9 +163,8 @@ import {
 	firstModelForProvider,
 	isManagedProviderId,
 	MANAGED_AI_CHOICE,
-	MANAGED_DEFAULT_MODEL_CHOICE,
 	MANAGED_PROVIDER_ID,
-	managedModelDisplayName,
+	managedModelPickerItems,
 	modelIdsForProvider,
 	normalizeSelectedProviderIds,
 	primaryModelProviderId,
@@ -1550,6 +1549,7 @@ function AiProviderTab({
 		parseDeploymentStatus(deployment.resource.status.summary_state).kind === "updating";
 	const runtimeConfiguration = deployment.resource.spec.runtime_configuration;
 	const list = providers.data?.providers ?? [];
+	const managedModels = managedModelCatalog.data?.models ?? [];
 	const customProviders = useMemo(
 		() => list.filter((provider) => !isFirstPartyManagedAiProvider(provider)),
 		[list],
@@ -1597,18 +1597,22 @@ function AiProviderTab({
 						.filter((choice): choice is string => Boolean(choice)),
 					initialPrimaryChoice,
 				);
-	const currentModel =
+	const bindingModelIdentity =
 		currentAuthKind === "unmanaged"
 			? ""
 			: primaryModelValue(configuredPrimaryModel) ||
-				firstModelForProvider(initialPrimaryChoice, list);
+				(initialPrimaryChoice === MANAGED_AI_CHOICE
+					? ""
+					: firstModelForProvider(initialPrimaryChoice, list));
+	const currentModel =
+		currentAuthKind === "unmanaged"
+			? ""
+			: bindingModelIdentity || firstModelForProvider(initialPrimaryChoice, list, managedModels);
 
 	const [selectedProviders, setSelectedProviders] = useState<string[]>(initialProviderChoices);
 	const [bindingMode, setBindingMode] = useState<AiBindingMode>(initialMode);
 	const [primaryProviderChoice, setPrimaryProviderChoice] = useState(initialPrimaryChoice);
-	const [primaryModel, setPrimaryModel] = useState<string>(
-		currentModel || MANAGED_DEFAULT_MODEL_CHOICE,
-	);
+	const [primaryModel, setPrimaryModel] = useState<string>(currentModel);
 
 	// Re-seed the form only when the server-side binding genuinely changes (the
 	// user's own apply completing, or an out-of-band change) — never on a plain
@@ -1620,7 +1624,7 @@ function AiProviderTab({
 		initialMode,
 		initialProviderChoices,
 		initialPrimaryChoice,
-		currentModel,
+		bindingModelIdentity,
 	]);
 	const [syncedIdentity, setSyncedIdentity] = useState(bindingIdentity);
 	if (bindingIdentity !== syncedIdentity) {
@@ -1628,8 +1632,19 @@ function AiProviderTab({
 		setBindingMode(initialMode);
 		setSelectedProviders(initialProviderChoices);
 		setPrimaryProviderChoice(initialPrimaryChoice);
-		setPrimaryModel(currentModel || MANAGED_DEFAULT_MODEL_CHOICE);
+		setPrimaryModel(currentModel);
 	}
+	useEffect(() => {
+		if (
+			bindingMode !== "configured" ||
+			primaryProviderChoice !== MANAGED_AI_CHOICE ||
+			primaryModel.trim()
+		) {
+			return;
+		}
+		const fallback = firstModelForProvider(MANAGED_AI_CHOICE, [], managedModels);
+		if (fallback) setPrimaryModel(fallback);
+	}, [bindingMode, managedModels, primaryModel, primaryProviderChoice]);
 
 	const selectedIdentity = JSON.stringify(
 		normalizeSelectedProviderIds(selectedProviders, primaryProviderChoice),
@@ -1640,11 +1655,15 @@ function AiProviderTab({
 		(bindingMode === "configured" &&
 			(selectedIdentity !== initialSelectedIdentity ||
 				primaryProviderChoice !== initialPrimaryChoice ||
-				primaryModel !== (currentModel || MANAGED_DEFAULT_MODEL_CHOICE)));
+				primaryModel !== currentModel));
+	const managedPrimaryModelReady =
+		bindingMode !== "configured" ||
+		primaryProviderChoice !== MANAGED_AI_CHOICE ||
+		(managedModelCatalog.isSuccess &&
+			modelIdsForProvider(MANAGED_AI_CHOICE, [], managedModels).includes(primaryModel));
 
 	function setPrimaryProvider(choice: string) {
 		setBindingMode("configured");
-		const managedModels = managedModelCatalog.data?.models ?? [];
 		const previousCatalog = modelIdsForProvider(primaryProviderChoice, list, managedModels);
 		const nextCatalog = modelIdsForProvider(choice, list, managedModels);
 		const fallback = firstModelForProvider(choice, list, managedModels);
@@ -1652,6 +1671,7 @@ function AiProviderTab({
 		setSelectedProviders((current) => normalizeSelectedProviderIds(current, choice));
 		setPrimaryModel((current) => {
 			const trimmed = current.trim();
+			if (choice === MANAGED_AI_CHOICE && !nextCatalog.includes(trimmed)) return fallback;
 			if (!trimmed) return fallback || current;
 			if (
 				previousCatalog.includes(trimmed) &&
@@ -1714,10 +1734,17 @@ function AiProviderTab({
 		}
 		const primaryProviderRef =
 			providerRefFromChoice(primaryProviderChoice, list) ?? MANAGED_PROVIDER_ID;
-		const usesHostedManagedDefault =
-			primaryProviderChoice === MANAGED_AI_CHOICE && primaryModel === MANAGED_DEFAULT_MODEL_CHOICE;
+		if (
+			primaryProviderChoice === MANAGED_AI_CHOICE &&
+			!modelIdsForProvider(MANAGED_AI_CHOICE, [], managedModels).includes(primaryModel)
+		) {
+			toast.error("Managed model unavailable", {
+				description: "Load the managed model catalog and choose a model before applying.",
+			});
+			return;
+		}
 		const modelRef = primaryModelRef(primaryProviderRef, primaryModel);
-		if (!modelRef && !usesHostedManagedDefault) {
+		if (!modelRef) {
 			toast.error("Primary model required");
 			return;
 		}
@@ -1866,7 +1893,10 @@ function AiProviderTab({
 			) : (
 				<AgentPrimaryModelPicker
 					providers={list}
-					managedModels={managedModelCatalog.data?.models ?? []}
+					managedModels={managedModels}
+					managedModelsLoading={managedModels.length === 0 && managedModelCatalog.isFetching}
+					managedModelsError={managedModelCatalog.error}
+					onManagedModelsRetry={() => void managedModelCatalog.refetch()}
 					customProviders={customProviders}
 					selectedProviderChoices={normalizeSelectedProviderIds(
 						selectedProviders,
@@ -1881,7 +1911,9 @@ function AiProviderTab({
 
 			<div className="flex items-center gap-2">
 				<Button
-					disabled={!dirty || updateDeployment.isPending || updateInProgress}
+					disabled={
+						!dirty || !managedPrimaryModelReady || updateDeployment.isPending || updateInProgress
+					}
 					onClick={applyProviderSettings}
 				>
 					{updateDeployment.isPending ? <Spinner className="size-3.5" /> : null}
@@ -1903,6 +1935,9 @@ function AiProviderTab({
 function AgentPrimaryModelPicker({
 	providers,
 	managedModels,
+	managedModelsLoading,
+	managedModelsError,
+	onManagedModelsRetry,
 	customProviders,
 	selectedProviderChoices,
 	primaryProviderChoice,
@@ -1912,6 +1947,9 @@ function AgentPrimaryModelPicker({
 }: {
 	providers: readonly AiProvider[];
 	managedModels: readonly ManagedModelCatalogItem[];
+	managedModelsLoading: boolean;
+	managedModelsError: unknown;
+	onManagedModelsRetry: () => void;
 	customProviders: readonly AiProvider[];
 	selectedProviderChoices: readonly string[];
 	primaryProviderChoice: string;
@@ -1922,6 +1960,10 @@ function AgentPrimaryModelPicker({
 	const isManaged = primaryProviderChoice === MANAGED_AI_CHOICE;
 	const catalogModelIds = modelIdsForProvider(primaryProviderChoice, providers, managedModels);
 	const modelChoice = catalogModelIds.includes(primaryModel) ? primaryModel : CUSTOM_MODEL_CHOICE;
+	const managedCatalogUnavailableError =
+		isManaged && managedModels.length === 0 && !managedModelsLoading
+			? (managedModelsError ?? new Error("The managed model catalog returned no models."))
+			: null;
 	const primaryProviderItems = [
 		...(selectedProviderChoices.includes(MANAGED_AI_CHOICE)
 			? [{ value: MANAGED_AI_CHOICE, label: "Managed by Clawdi" }]
@@ -1937,18 +1979,15 @@ function AgentPrimaryModelPicker({
 				label: provider.label ?? provider.provider_id,
 			})),
 	];
-	const catalogModelItems = [
-		...catalogModelIds.map((model) => ({
-			value: model,
-			label:
-				model === MANAGED_DEFAULT_MODEL_CHOICE
-					? "Hosted default (Luna)"
-					: isManaged
-						? (managedModelDisplayName(model, managedModels) ?? model)
-						: formatModelLabel(model),
-		})),
-		...(!isManaged ? [{ value: CUSTOM_MODEL_CHOICE, label: "Custom model" }] : []),
-	];
+	const catalogModelItems = isManaged
+		? managedModelPickerItems(managedModels)
+		: [
+				...catalogModelIds.map((model) => ({
+					value: model,
+					label: formatModelLabel(model),
+				})),
+				{ value: CUSTOM_MODEL_CHOICE, label: "Custom model" },
+			];
 	return (
 		<div className="flex max-w-2xl flex-col gap-3 rounded-lg border bg-muted/20 p-3">
 			<div className="grid gap-3 sm:grid-cols-2">
@@ -1983,7 +2022,18 @@ function AgentPrimaryModelPicker({
 						</SelectContent>
 					</Select>
 				</div>
-				{catalogModelIds.length > 0 ? (
+				{isManaged && managedModelsLoading ? (
+					<div className="flex items-center gap-2 text-sm text-muted-foreground" role="status">
+						<Spinner className="size-3.5" /> Loading managed models…
+					</div>
+				) : managedCatalogUnavailableError ? (
+					<ApiErrorPanel
+						normalizer={billingErrorNormalizer}
+						error={managedCatalogUnavailableError}
+						onRetry={onManagedModelsRetry}
+						title="Couldn't load managed models"
+					/>
+				) : catalogModelIds.length > 0 ? (
 					<div className="flex flex-col gap-1.5">
 						<Label htmlFor="agent-catalog-model">Catalog model</Label>
 						<Select
@@ -1998,18 +2048,11 @@ function AgentPrimaryModelPicker({
 								<SelectValue />
 							</SelectTrigger>
 							<SelectContent>
-								{catalogModelIds.map((model) => (
-									<SelectItem key={model} value={model}>
-										{model === MANAGED_DEFAULT_MODEL_CHOICE
-											? "Hosted default (Luna)"
-											: isManaged
-												? (managedModelDisplayName(model, managedModels) ?? model)
-												: formatModelLabel(model)}
+								{catalogModelItems.map((item) => (
+									<SelectItem key={item.value} value={item.value}>
+										{item.label}
 									</SelectItem>
 								))}
-								{!isManaged ? (
-									<SelectItem value={CUSTOM_MODEL_CHOICE}>Custom model</SelectItem>
-								) : null}
 							</SelectContent>
 						</Select>
 					</div>

--- a/apps/web/src/hosted/billing/deploy/deploy-defaults.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-defaults.test.ts
@@ -5,14 +5,9 @@ import {
 	DEFAULT_DEPLOY_PRIMARY_MODEL,
 	DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE,
 	DEFAULT_DEPLOY_RUNTIME,
-	defaultManagedDeployAiFields,
 	deployAssistantNameAfterRuntimeChange,
 } from "@/hosted/billing/deploy/deploy-defaults";
-import {
-	MANAGED_AI_CHOICE,
-	MANAGED_DEFAULT_MODEL_CHOICE,
-	MANAGED_PROVIDER_ID,
-} from "@/hosted/v2/ai-providers/model-binding";
+import { MANAGED_AI_CHOICE } from "@/hosted/v2/ai-providers/model-binding";
 
 describe("deploy wizard defaults", () => {
 	test("default to the hermes runtime and managed AI mode", () => {
@@ -20,17 +15,7 @@ describe("deploy wizard defaults", () => {
 		expect(DEFAULT_DEPLOY_AI_ACCESS_MODE).toBe("configured");
 		expect(DEFAULT_DEPLOY_AI_PROVIDER_CHOICES).toEqual([MANAGED_AI_CHOICE]);
 		expect(DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE).toBe(MANAGED_AI_CHOICE);
-		expect(DEFAULT_DEPLOY_PRIMARY_MODEL).toBe(MANAGED_DEFAULT_MODEL_CHOICE);
-	});
-
-	test("omits primary_model so hosted resolves the canonical Luna default", () => {
-		expect(defaultManagedDeployAiFields()).toEqual({
-			ai_provider_id: null,
-			ai_provider_auth_kind: "managed",
-			provider_ids: [MANAGED_PROVIDER_ID],
-		});
-		expect(defaultManagedDeployAiFields()).not.toHaveProperty("primary_model");
-		expect(JSON.stringify(defaultManagedDeployAiFields())).not.toContain("gpt-5.5");
+		expect(DEFAULT_DEPLOY_PRIMARY_MODEL).toBe("");
 	});
 
 	test("follows runtime display names until the agent name is edited", () => {

--- a/apps/web/src/hosted/billing/deploy/deploy-defaults.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-defaults.ts
@@ -1,10 +1,5 @@
-import type { DeployAiFields } from "@/hosted/billing/deploy/deploy-request";
 import { type HostedRuntime, runtimeDisplayName } from "@/hosted/runtimes";
-import {
-	MANAGED_AI_CHOICE,
-	MANAGED_DEFAULT_MODEL_CHOICE,
-	MANAGED_PROVIDER_ID,
-} from "@/hosted/v2/ai-providers/model-binding";
+import { MANAGED_AI_CHOICE } from "@/hosted/v2/ai-providers/model-binding";
 
 export type DeployWizardAiAccessMode = "unmanaged" | "configured";
 
@@ -14,7 +9,8 @@ export const DEFAULT_DEPLOY_RUNTIME: HostedRuntime = "hermes";
 export const DEFAULT_DEPLOY_AI_ACCESS_MODE: DeployWizardAiAccessMode = "configured";
 export const DEFAULT_DEPLOY_AI_PROVIDER_CHOICES = [MANAGED_AI_CHOICE] as const;
 export const DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE = MANAGED_AI_CHOICE;
-export const DEFAULT_DEPLOY_PRIMARY_MODEL = MANAGED_DEFAULT_MODEL_CHOICE;
+// The managed catalog supplies the real default model after it loads.
+export const DEFAULT_DEPLOY_PRIMARY_MODEL = "";
 
 export function deployAssistantNameAfterRuntimeChange({
 	currentName,
@@ -26,12 +22,4 @@ export function deployAssistantNameAfterRuntimeChange({
 	runtime: HostedRuntime;
 }): string {
 	return hasBeenEdited ? currentName : runtimeDisplayName(runtime);
-}
-
-export function defaultManagedDeployAiFields(): DeployAiFields {
-	return {
-		ai_provider_id: null,
-		ai_provider_auth_kind: "managed",
-		provider_ids: [MANAGED_PROVIDER_ID],
-	};
 }

--- a/apps/web/src/hosted/billing/deploy/deploy-model.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-model.test.ts
@@ -123,6 +123,7 @@ describe("resolveBasicDeploySelection", () => {
 		const selection = resolveBasicDeploySelection({
 			basicPlan: basic,
 			billingTermMonths: 1,
+			includedSlotAvailable: false,
 		});
 
 		expect(selection).toMatchObject({
@@ -139,6 +140,7 @@ describe("resolveBasicDeploySelection", () => {
 			resolveBasicDeploySelection({
 				basicPlan: undefined,
 				billingTermMonths: 1,
+				includedSlotAvailable: false,
 			}),
 		).toEqual({ mode: "unavailable", reason: "plan_missing" });
 	});
@@ -150,7 +152,18 @@ describe("resolveBasicDeploySelection", () => {
 			resolveBasicDeploySelection({
 				basicPlan: basicWithoutOffers,
 				billingTermMonths: 1,
+				includedSlotAvailable: false,
 			}),
 		).toEqual({ mode: "unavailable", reason: "offers_missing" });
+	});
+
+	test("never exposes paid Basic checkout before deployment inventory succeeds", () => {
+		expect(
+			resolveBasicDeploySelection({
+				basicPlan: basic,
+				billingTermMonths: 1,
+				includedSlotAvailable: null,
+			}),
+		).toEqual({ mode: "unavailable", reason: "inventory_unavailable" });
 	});
 });

--- a/apps/web/src/hosted/billing/deploy/deploy-model.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-model.ts
@@ -20,7 +20,7 @@ export type BasicDeploySelection =
 	  }
 	| {
 			mode: "unavailable";
-			reason: "plan_missing" | "offers_missing";
+			reason: "plan_missing" | "offers_missing" | "inventory_unavailable";
 	  };
 
 export function usesActiveIncludedBasicSlot(deployments: HostedDeployment[] | undefined): boolean {
@@ -40,13 +40,17 @@ export function usesActiveIncludedBasicSlot(deployments: HostedDeployment[] | un
 export function resolveBasicDeploySelection({
 	basicPlan,
 	billingTermMonths,
-	includedSlotAvailable = false,
+	includedSlotAvailable,
 }: {
 	basicPlan: Plan | undefined;
 	billingTermMonths: number;
-	includedSlotAvailable?: boolean;
+	/** `null` means the deployment inventory has not loaded successfully. */
+	includedSlotAvailable: boolean | null;
 }): BasicDeploySelection {
 	if (!basicPlan) return { mode: "unavailable", reason: "plan_missing" };
+	if (includedSlotAvailable === null) {
+		return { mode: "unavailable", reason: "inventory_unavailable" };
+	}
 	if (includedSlotAvailable) {
 		return {
 			mode: "included",

--- a/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
@@ -1,42 +1,31 @@
 import { describe, expect, test } from "bun:test";
-import {
-	DEFAULT_DEPLOY_RUNTIME,
-	defaultManagedDeployAiFields,
-} from "@/hosted/billing/deploy/deploy-defaults";
 import { buildHostedDeployRequest } from "@/hosted/billing/deploy/deploy-request";
 
 describe("buildHostedDeployRequest", () => {
-	test("serializes managed defaults without overriding hosted Luna selection", () => {
+	test("serializes the real managed Luna catalog selection", () => {
 		const request = buildHostedDeployRequest({
 			computePlanSlug: "compute_basic",
-			runtime: DEFAULT_DEPLOY_RUNTIME,
+			runtime: "hermes",
 			persona: {
 				assistantName: "Hermes",
 				language: "",
 				timezone: "",
 			},
-			aiFields: defaultManagedDeployAiFields(),
-		});
-
-		expect(request).toEqual({
-			compute_plan_slug: "compute_basic",
-			runtime: "hermes",
-			assistant_name: "Hermes",
-			language: null,
-			timezone: null,
-			ai_provider_id: null,
-			ai_provider_auth_kind: "managed",
-			provider_ids: ["clawdi-v2"],
-			config: {
-				runtime: "hermes",
-				assistant_name: "Hermes",
-				language: null,
-				timezone: null,
+			aiFields: {
+				ai_provider_id: null,
+				ai_provider_auth_kind: "managed",
+				provider_ids: ["clawdi-v2"],
+				primary_model: {
+					provider_id: "clawdi-v2",
+					model: "gpt-5.6-luna",
+				},
 			},
 		});
-		expect(request).not.toHaveProperty("primary_model");
-		expect("personality" in request).toBe(false);
-		expect("personality" in (request.config ?? {})).toBe(false);
+
+		expect(request.primary_model).toEqual({
+			provider_id: "clawdi-v2",
+			model: "gpt-5.6-luna",
+		});
 	});
 
 	test("serializes v2 hosted deploys without legacy deploy profile", () => {

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -7,6 +7,10 @@ const planComparisonSource = readFileSync(
 	new URL("../subscription/plan-comparison.tsx", import.meta.url),
 	"utf8",
 );
+const agentDetailSource = readFileSync(
+	new URL("../../agents/hosted-agent-detail.tsx", import.meta.url),
+	"utf8",
+);
 
 describe("deploy wizard personalization", () => {
 	test("renders the required bounded agent name input", () => {
@@ -29,5 +33,28 @@ describe("first Basic agent copy", () => {
 		expect(planComparisonSource).toContain("The first active Basic agent is free.");
 		expect(planComparisonSource).toContain("Your first active Basic agent is free.");
 		expect(planComparisonSource).not.toContain("agent is included");
+	});
+});
+
+describe("managed model picker", () => {
+	test("uses real catalog items and exposes loading and retry states", () => {
+		for (const source of [wizardSource, agentDetailSource]) {
+			expect(source).toContain("managedModelPickerItems(managedModels)");
+			expect(source).toContain("Loading managed models…");
+			expect(source).toContain('title="Couldn\'t load managed models"');
+			expect(source).not.toContain("__hosted_default__");
+			expect(source).not.toContain("Hosted default (Luna)");
+		}
+	});
+});
+
+describe("billing-read gates", () => {
+	test("keeps deploy disabled until inventory succeeds and offers retries", () => {
+		expect(wizardSource).toContain("deployments.isSuccess &&");
+		expect(wizardSource).toContain('title="Couldn\'t check deployment inventory"');
+		expect(wizardSource).toContain("onRetry={() => void deployments.refetch()}");
+		expect(wizardSource).toContain('title="Couldn\'t load compute plans"');
+		expect(wizardSource).toContain('title="Couldn\'t load your AI Credits wallet"');
+		expect(wizardSource).toContain("onRetry={() => void wallet.refetch()}");
 	});
 });

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -146,9 +146,8 @@ import {
 	dedupeProviderIds,
 	firstModelForProvider,
 	MANAGED_AI_CHOICE,
-	MANAGED_DEFAULT_MODEL_CHOICE,
 	MANAGED_PROVIDER_ID,
-	managedModelDisplayName,
+	managedModelPickerItems,
 	modelIdsForProvider,
 	normalizeSelectedProviderIds,
 	primaryModelRef,
@@ -349,6 +348,7 @@ function computeStatusLine({
 }: ComputeStatusInput): { message: string; tone: "destructive" | "muted" } | null {
 	if (compute === "basic") {
 		if (basicSelection.mode === "unavailable") {
+			if (basicSelection.reason === "inventory_unavailable") return null;
 			return {
 				tone: "destructive",
 				message:
@@ -468,8 +468,9 @@ export function DeployWizard() {
 			resolveBasicDeploySelection({
 				basicPlan,
 				billingTermMonths: term,
-				includedSlotAvailable:
-					deployments.isSuccess && !usesActiveIncludedBasicSlot(deployments.data),
+				includedSlotAvailable: deployments.isSuccess
+					? !usesActiveIncludedBasicSlot(deployments.data)
+					: null,
 			}),
 		[basicPlan, deployments.data, deployments.isSuccess, term],
 	);
@@ -483,8 +484,9 @@ export function DeployWizard() {
 	const perfBillingTermMonths = perfOfferSelection?.billingTermMonths ?? term;
 	const basicOffers = basicPlan ? explicitPlanOffers(basicPlan) : [];
 	const perfOffers = perfPlan ? planOffers(perfPlan) : [];
-	const paidSelection: PaidDeploySelection | null =
-		compute === "performance" && perfPlan && perfOfferSelection
+	const paidSelection: PaidDeploySelection | null = !deployments.isSuccess
+		? null
+		: compute === "performance" && perfPlan && perfOfferSelection
 			? {
 					billingTermMonths: perfOfferSelection.billingTermMonths,
 					computePlanSlug: COMPUTE_PERFORMANCE_SLUG,
@@ -531,17 +533,27 @@ export function DeployWizard() {
 			),
 		[aiProviders.data?.providers],
 	);
+	const managedModels = managedModelCatalog.data?.models ?? [];
 	const channelList = channels.data ?? [];
 	const computePlanReady =
 		compute === "performance" ? !!perfPlan && !!perfOfferSelection : !basicUnavailable;
-	const planReady = !plans.isLoading && computePlanReady;
+	const planReady = plans.isSuccess && computePlanReady;
+	const managedPrimaryModelReady =
+		aiAccessMode !== "configured" ||
+		primaryProviderChoice !== MANAGED_AI_CHOICE ||
+		(managedModelCatalog.isSuccess &&
+			modelIdsForProvider(MANAGED_AI_CHOICE, [], managedModels).includes(primaryModel));
 	const canSubmit =
 		planReady &&
+		deployments.isSuccess &&
+		managedPrimaryModelReady &&
 		assistantName.trim().length > 0 &&
 		!submitting &&
 		(!paidSelection ||
 			paymentMethod === "card" ||
-			(!!walletDebit &&
+			(wallet.isSuccess &&
+				!!wallet.data &&
+				!!walletDebit &&
 				!subscriptionCreateQuote.isFetching &&
 				!subscriptionCreateQuote.error &&
 				!walletInsufficient));
@@ -681,6 +693,7 @@ export function DeployWizard() {
 		setAiProviderChoices((current) => normalizeSelectedProviderIds(current, choice));
 		setPrimaryModel((current) => {
 			const trimmed = current.trim();
+			if (choice === MANAGED_AI_CHOICE && !nextCatalog.includes(trimmed)) return fallback;
 			if (!trimmed) return fallback;
 			if (
 				previousCatalog.includes(trimmed) &&
@@ -726,10 +739,19 @@ export function DeployWizard() {
 
 		const primaryProviderRef =
 			providerRefFromChoice(primaryProviderChoice, providerList) ?? MANAGED_PROVIDER_ID;
-		const usesHostedManagedDefault =
-			primaryProviderChoice === MANAGED_AI_CHOICE && primaryModel === MANAGED_DEFAULT_MODEL_CHOICE;
+		if (
+			primaryProviderChoice === MANAGED_AI_CHOICE &&
+			!modelIdsForProvider(MANAGED_AI_CHOICE, [], managedModelCatalog.data?.models ?? []).includes(
+				primaryModel,
+			)
+		) {
+			toast.error("Managed model unavailable", {
+				description: "Load the managed model catalog and choose a model before deploying.",
+			});
+			return null;
+		}
 		const modelRef = primaryModelRef(primaryProviderRef, primaryModel);
-		if (!modelRef && !usesHostedManagedDefault) {
+		if (!modelRef) {
 			toast.error("Primary model required", {
 				description: "Choose a catalog model or enter a model id.",
 			});
@@ -1124,14 +1146,21 @@ export function DeployWizard() {
 		.filter(Boolean)
 		.join(" · ");
 
-	if (plans.error) {
+	const plansLoadError =
+		plans.error ??
+		(plans.isSuccess && !basicPlan && !perfPlan
+			? new Error("The billing service returned no compute plans. Try loading plans again.")
+			: null);
+
+	if (plansLoadError) {
 		return (
 			<div data-hosted="true" data-v2="true" className={DEPLOY_PAGE_CLASS}>
 				<PageHeader title="Deploy an Agent" />
 				<ApiErrorPanel
 					normalizer={billingErrorNormalizer}
-					error={plans.error}
-					onRetry={() => plans.refetch()}
+					error={plansLoadError}
+					onRetry={() => void plans.refetch()}
+					title="Couldn't load compute plans"
 				/>
 			</div>
 		);
@@ -1269,7 +1298,10 @@ export function DeployWizard() {
 					) : (
 						<PrimaryModelPicker
 							providers={aiProviders.data?.providers ?? []}
-							managedModels={managedModelCatalog.data?.models ?? []}
+							managedModels={managedModels}
+							managedModelsLoading={managedModels.length === 0 && managedModelCatalog.isFetching}
+							managedModelsError={managedModelCatalog.error}
+							onManagedModelsRetry={() => void managedModelCatalog.refetch()}
 							customProviders={providerList}
 							selectedProviderChoices={normalizeSelectedProviderIds(
 								aiProviderChoices,
@@ -1322,10 +1354,28 @@ export function DeployWizard() {
 					description="Basic and Performance agents use per-deployment funding selected below."
 				>
 					<div className="flex flex-col gap-3">
+						{!deployments.isSuccess ? (
+							deployments.error ? (
+								<ApiErrorPanel
+									normalizer={billingErrorNormalizer}
+									error={deployments.error}
+									onRetry={() => void deployments.refetch()}
+									title="Couldn't check deployment inventory"
+								/>
+							) : (
+								<p className="flex items-center gap-2 text-sm text-muted-foreground" role="status">
+									<Spinner className="size-3.5" /> Checking your free Basic slot…
+								</p>
+							)
+						) : null}
 						<div className="grid gap-2 sm:grid-cols-2">
 							<EntityChoiceCard
 								selected={compute === "basic"}
-								onClick={!basicUnavailable ? () => setComputeTier("basic") : undefined}
+								onClick={
+									deployments.isSuccess && !basicUnavailable
+										? () => setComputeTier("basic")
+										: undefined
+								}
 								icon={
 									<IconChip tint="bg-identity-3-bg text-identity-3-fg">
 										<Cpu />
@@ -1333,26 +1383,38 @@ export function DeployWizard() {
 								}
 								title="Basic"
 								description={
-									basicSelection.mode === "included"
-										? `${basicPlan?.vcpu ?? 2} vCPU / ${basicPlan?.ram_gb ?? 4} GB · First Basic agent — Free`
-										: basicOffer
-											? `${basicPlan?.vcpu ?? 2} vCPU / ${basicPlan?.ram_gb ?? 4} GB · ${recurringOfferLabel(basicOffer)}`
-											: "Basic funding unavailable"
+									!deployments.isSuccess
+										? deployments.error
+											? "Basic availability couldn't be checked"
+											: "Checking free Basic slot availability"
+										: basicSelection.mode === "included"
+											? `${basicPlan?.vcpu ?? 2} vCPU / ${basicPlan?.ram_gb ?? 4} GB · First Basic agent — Free`
+											: basicOffer
+												? `${basicPlan?.vcpu ?? 2} vCPU / ${basicPlan?.ram_gb ?? 4} GB · ${recurringOfferLabel(basicOffer)}`
+												: "Basic funding unavailable"
 								}
 								badge={
 									<Badge variant="secondary">
-										{basicSelection.mode === "included"
-											? "Free"
-											: basicOffer
-												? `${formatCentsCompact(basicOffer.effective_monthly_price_cents)}/mo`
-												: "Unavailable"}
+										{!deployments.isSuccess
+											? deployments.error
+												? "Unavailable"
+												: "Checking…"
+											: basicSelection.mode === "included"
+												? "Free"
+												: basicOffer
+													? `${formatCentsCompact(basicOffer.effective_monthly_price_cents)}/mo`
+													: "Unavailable"}
 									</Badge>
 								}
-								disabled={basicUnavailable}
+								disabled={!deployments.isSuccess || basicUnavailable}
 							/>
 							<EntityChoiceCard
 								selected={compute === "performance"}
-								onClick={perfPlan ? () => setComputeTier("performance") : undefined}
+								onClick={
+									deployments.isSuccess && perfPlan
+										? () => setComputeTier("performance")
+										: undefined
+								}
 								icon={
 									<IconChip tint="bg-identity-8-bg text-identity-8-fg">
 										<Zap />
@@ -1373,7 +1435,7 @@ export function DeployWizard() {
 												: "Unavailable"}
 									</Badge>
 								}
-								disabled={!perfPlan}
+								disabled={!deployments.isSuccess || !perfPlan}
 							/>
 						</div>
 						{paidSelection && (compute === "performance" ? perfOffers : basicOffers).length > 1 ? (
@@ -1427,7 +1489,18 @@ export function DeployWizard() {
 
 								{paymentMethod === "wallet" ? (
 									<div className="flex flex-col gap-3">
-										{subscriptionCreateQuote.isFetching && !subscriptionCreateQuote.data ? (
+										{!wallet.data && wallet.isFetching ? (
+											<p className="text-sm text-muted-foreground" role="status">
+												Loading your AI Credits wallet…
+											</p>
+										) : !wallet.data && wallet.error ? (
+											<ApiErrorPanel
+												normalizer={billingErrorNormalizer}
+												error={wallet.error}
+												onRetry={() => void wallet.refetch()}
+												title="Couldn't load your AI Credits wallet"
+											/>
+										) : subscriptionCreateQuote.isFetching && !subscriptionCreateQuote.data ? (
 											<p className="text-sm text-muted-foreground" role="status">
 												Getting the exact wallet debit…
 											</p>
@@ -1633,6 +1706,9 @@ function providerCatalogDescription(provider: AiProvider): string {
 function PrimaryModelPicker({
 	providers,
 	managedModels,
+	managedModelsLoading,
+	managedModelsError,
+	onManagedModelsRetry,
 	customProviders,
 	selectedProviderChoices,
 	primaryProviderChoice,
@@ -1642,6 +1718,9 @@ function PrimaryModelPicker({
 }: {
 	providers: readonly AiProvider[];
 	managedModels: readonly ManagedModelCatalogItem[];
+	managedModelsLoading: boolean;
+	managedModelsError: unknown;
+	onManagedModelsRetry: () => void;
 	customProviders: readonly AiProvider[];
 	selectedProviderChoices: readonly string[];
 	primaryProviderChoice: string;
@@ -1652,6 +1731,10 @@ function PrimaryModelPicker({
 	const isManaged = primaryProviderChoice === MANAGED_AI_CHOICE;
 	const catalogModelIds = modelIdsForProvider(primaryProviderChoice, providers, managedModels);
 	const modelChoice = catalogModelIds.includes(primaryModel) ? primaryModel : CUSTOM_MODEL_CHOICE;
+	const managedCatalogUnavailableError =
+		isManaged && managedModels.length === 0 && !managedModelsLoading
+			? (managedModelsError ?? new Error("The managed model catalog returned no models."))
+			: null;
 	const primaryProviderItems = [
 		...(selectedProviderChoices.includes(MANAGED_AI_CHOICE)
 			? [{ value: MANAGED_AI_CHOICE, label: "Managed by Clawdi" }]
@@ -1663,18 +1746,12 @@ function PrimaryModelPicker({
 				label: provider.label ?? provider.provider_id,
 			})),
 	];
-	const catalogModelItems = [
-		...catalogModelIds.map((model) => ({
-			value: model,
-			label:
-				model === MANAGED_DEFAULT_MODEL_CHOICE
-					? "Hosted default (Luna)"
-					: isManaged
-						? (managedModelDisplayName(model, managedModels) ?? model)
-						: model,
-		})),
-		...(!isManaged ? [{ value: CUSTOM_MODEL_CHOICE, label: "Custom model" }] : []),
-	];
+	const catalogModelItems = isManaged
+		? managedModelPickerItems(managedModels)
+		: [
+				...catalogModelIds.map((model) => ({ value: model, label: model })),
+				{ value: CUSTOM_MODEL_CHOICE, label: "Custom model" },
+			];
 	return (
 		<div className="mt-4 flex max-w-2xl flex-col gap-3 rounded-lg border bg-muted/20 p-3">
 			<div className="grid gap-3 sm:grid-cols-2">
@@ -1706,7 +1783,18 @@ function PrimaryModelPicker({
 						</SelectContent>
 					</Select>
 				</div>
-				{catalogModelIds.length > 0 ? (
+				{isManaged && managedModelsLoading ? (
+					<div className="flex items-center gap-2 text-sm text-muted-foreground" role="status">
+						<Spinner className="size-3.5" /> Loading managed models…
+					</div>
+				) : managedCatalogUnavailableError ? (
+					<ApiErrorPanel
+						normalizer={billingErrorNormalizer}
+						error={managedCatalogUnavailableError}
+						onRetry={onManagedModelsRetry}
+						title="Couldn't load managed models"
+					/>
+				) : catalogModelIds.length > 0 ? (
 					<div className="flex flex-col gap-1.5">
 						<Label htmlFor="deploy-catalog-model">Catalog model</Label>
 						<Select
@@ -1722,18 +1810,11 @@ function PrimaryModelPicker({
 							</SelectTrigger>
 							<SelectContent>
 								<SelectGroup>
-									{catalogModelIds.map((model) => (
-										<SelectItem key={model} value={model}>
-											{model === MANAGED_DEFAULT_MODEL_CHOICE
-												? "Hosted default (Luna)"
-												: isManaged
-													? (managedModelDisplayName(model, managedModels) ?? model)
-													: model}
+									{catalogModelItems.map((item) => (
+										<SelectItem key={item.value} value={item.value}>
+											{item.label}
 										</SelectItem>
 									))}
-									{!isManaged ? (
-										<SelectItem value={CUSTOM_MODEL_CHOICE}>Custom model</SelectItem>
-									) : null}
 								</SelectGroup>
 							</SelectContent>
 						</Select>

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
@@ -3,29 +3,41 @@ import {
 	firstModelForProvider,
 	isManagedProviderId,
 	MANAGED_AI_CHOICE,
-	MANAGED_DEFAULT_MODEL_CHOICE,
 	managedModelDisplayName,
+	managedModelPickerItems,
 	modelIdsForProvider,
 	providerChoiceFromRef,
 } from "@/hosted/v2/ai-providers/model-binding";
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 
 describe("model binding", () => {
-	test("uses an explicit hosted-default choice without guessing a model id", () => {
-		expect(firstModelForProvider(MANAGED_AI_CHOICE, [])).toBe(MANAGED_DEFAULT_MODEL_CHOICE);
-		expect(modelIdsForProvider(MANAGED_AI_CHOICE, [])).toEqual([MANAGED_DEFAULT_MODEL_CHOICE]);
+	test("does not invent a managed model before the catalog loads", () => {
+		expect(firstModelForProvider(MANAGED_AI_CHOICE, [])).toBe("");
+		expect(modelIdsForProvider(MANAGED_AI_CHOICE, [])).toEqual([]);
 	});
 
-	test("puts the hosted default before the v2 managed catalog and uses friendly names", () => {
+	test("puts the catalog default first and exposes real managed model names", () => {
 		const managedModels = [
-			{ id: "gpt-5.6-luna", display_name: "Luna", is_default: true },
 			{ id: "gpt-5.6-sol", display_name: "Sol", is_default: false },
+			{ id: "gpt-5.6-luna", display_name: "Luna", is_default: true },
+			{ id: "gpt-5.6-terra", display_name: "Terra", is_default: false },
 		];
 
 		expect(modelIdsForProvider(MANAGED_AI_CHOICE, [], managedModels)).toEqual([
-			MANAGED_DEFAULT_MODEL_CHOICE,
 			"gpt-5.6-luna",
 			"gpt-5.6-sol",
+			"gpt-5.6-terra",
+		]);
+		expect(firstModelForProvider(MANAGED_AI_CHOICE, [], managedModels)).toBe("gpt-5.6-luna");
+		expect(
+			modelIdsForProvider(MANAGED_AI_CHOICE, [], managedModels).map((modelId) =>
+				managedModelDisplayName(modelId, managedModels),
+			),
+		).toEqual(["Luna", "Sol", "Terra"]);
+		expect(managedModelPickerItems(managedModels)).toEqual([
+			{ value: "gpt-5.6-luna", label: "Luna" },
+			{ value: "gpt-5.6-sol", label: "Sol" },
+			{ value: "gpt-5.6-terra", label: "Terra" },
 		]);
 		expect(managedModelDisplayName("gpt-5.6-sol", managedModels)).toBe("Sol");
 	});

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.ts
@@ -4,7 +4,6 @@ import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 
 export const MANAGED_AI_CHOICE = "__managed__";
 export const MANAGED_PROVIDER_ID = CLAWDI_MANAGED_V2_PROVIDER_ID;
-export const MANAGED_DEFAULT_MODEL_CHOICE = "__hosted_default__";
 
 export type PrimaryModelRef = {
 	provider_id: string;
@@ -35,7 +34,7 @@ export function primaryModelProviderId(value: PrimaryModelInput): string | null 
 export function primaryModelRef(providerId: string, model: string): PrimaryModelRef | null {
 	const provider_id = providerId.trim();
 	const value = model.trim();
-	if (!provider_id || !value || value === MANAGED_DEFAULT_MODEL_CHOICE) return null;
+	if (!provider_id || !value) return null;
 	return { provider_id, model: value };
 }
 
@@ -82,10 +81,8 @@ export function modelIdsForProvider(
 	managedModels: readonly ManagedModelCatalogItem[] = [],
 ): string[] {
 	if (choice === MANAGED_AI_CHOICE) {
-		return [
-			MANAGED_DEFAULT_MODEL_CHOICE,
-			...dedupeProviderIds(managedModels.map((model) => model.id)),
-		];
+		const defaultModel = managedModels.find((model) => model.is_default)?.id ?? "";
+		return dedupeProviderIds([defaultModel, ...managedModels.map((model) => model.id)]);
 	}
 	const provider = providers.find((item) => item.provider_id === choice);
 	return dedupeProviderIds((provider?.models ?? []).map((model) => model.id));
@@ -98,13 +95,22 @@ export function managedModelDisplayName(
 	return managedModels.find((model) => model.id === modelId)?.display_name ?? null;
 }
 
+export function managedModelPickerItems(
+	managedModels: readonly ManagedModelCatalogItem[],
+): Array<{ value: string; label: string }> {
+	return modelIdsForProvider(MANAGED_AI_CHOICE, [], managedModels).map((modelId) => ({
+		value: modelId,
+		label: managedModelDisplayName(modelId, managedModels) ?? modelId,
+	}));
+}
+
 export function firstModelForProvider(
 	choice: string,
 	providers: readonly AiProvider[],
 	managedModels: readonly ManagedModelCatalogItem[] = [],
 ): string {
 	const [first] = modelIdsForProvider(choice, providers, managedModels);
-	return first ?? (choice === MANAGED_AI_CHOICE ? MANAGED_DEFAULT_MODEL_CHOICE : "");
+	return first ?? "";
 }
 
 export function normalizeSelectedProviderIds(


### PR DESCRIPTION
Owner-reported model-list + money BLOCKER. v1 untouched.

- **Managed model picker** shows real model NAMES (Luna/Sol/Terra via catalog `display_name`), defaults to Luna (`is_default`), sends an explicit `primary_model`. The `__hosted_default__`/'Hosted default (Luna)' sentinel is removed. Agent-detail Apply accepts the managed default; loading/error/retry states added for the catalog.
- **B1 (money)** — the paid Basic $9 checkout path is not offered and Deploy is disabled until the deployments inventory has loaded successfully (`includedSlotAvailable: null` → 'inventory_unavailable' with retry). A user with a free slot can no longer be shown/charged the paid path due to an unloaded inventory.
- Plans 200-empty and wallet GET failure now show clear errors + working Retry.

511 web tests + 5 Chromium E2E + typecheck + lint pass. No `as any`/`@ts-ignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)