### PR TITLE
fix(web): restart stopped v2 agents (Start from stopped, no dead end)

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -209,6 +209,18 @@ const stoppedIncludedBasicDeployment = {
 	status: "stopped",
 };
 
+const stoppedProjectionEnvironmentId = "44444444-4444-4444-8444-444444444444";
+const stoppedProjectionGoneDeployment: DeploymentMutationFixture = {
+	...includedBasicDeployment,
+	id: "hdep_stopped_projection_gone",
+	name: "deployment-create-browser-generated",
+	status: "stopped",
+	config_info: {
+		...includedBasicDeployment.config_info,
+		clawdi_cloud_environments: {},
+	},
+};
+
 const missingProjectionEnvironmentId = "55555555-5555-4555-8555-555555555555";
 const missingProjectionFailureReason =
 	"startup_probe_failing; restart_count=2; container failed readiness probe after the runtime bridge exhausted every startup attempt";
@@ -1473,6 +1485,7 @@ test("env-keyed agent route keeps failed deployment recovery available without i
 
 	await page.goto(`/agents/${missingProjectionEnvironmentId}?source=on-clawdi`);
 	const main = page.locator("main");
+	await expect.poll(() => new URL(page.url()).searchParams.get("d")).toBe("hdep_failed_projection");
 	await expect(main.getByText("Agent sync record unavailable", { exact: true })).toBeVisible();
 	await expect(main.getByText(missingProjectionFailureReason, { exact: true })).toBeVisible();
 	await expect(main.getByText("Failed", { exact: true })).toBeVisible();
@@ -1499,6 +1512,74 @@ test("env-keyed agent route keeps failed deployment recovery available without i
 		.getByRole("button", { name: "Delete compute", exact: true })
 		.click();
 	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_failed_projection"]);
+});
+
+test("stopped deployment tiles expose Start and friendly Delete actions", async ({ page }) => {
+	const startRequests: string[] = [];
+	await stubHostedApi(page, {
+		deployments: [stoppedProjectionGoneDeployment],
+		startRequests,
+	});
+
+	for (const path of ["/", "/agents"]) {
+		await page.goto(path);
+		const main = page.locator("main");
+		await expect(main.getByRole("button", { name: "Start Hermes", exact: true })).toBeVisible();
+		await expect(main.getByRole("button", { name: "Delete Hermes", exact: true })).toBeVisible();
+		await expect(
+			main.getByText("deployment-create-browser-generated", { exact: true }),
+		).toHaveCount(0);
+	}
+
+	await page.locator("main").getByRole("button", { name: "Start Hermes", exact: true }).click();
+	await expect.poll(() => startRequests.length).toBe(1);
+});
+
+test("stopped detail stays recoverable without querying its removed projection", async ({
+	page,
+}) => {
+	const cloudRequests: string[] = [];
+	const deployRequests: string[] = [];
+	const startRequests: string[] = [];
+	page.on("request", (request) => {
+		const url = new URL(request.url());
+		const path = `${url.pathname}${url.search}`;
+		if (url.origin === CLOUD_API) cloudRequests.push(path);
+		if (url.origin === DEPLOY_API) deployRequests.push(path);
+	});
+	await stubHostedApi(page, {
+		deployments: [stoppedProjectionGoneDeployment],
+		cloudAgentNotFoundIds: [stoppedProjectionEnvironmentId],
+		startRequests,
+	});
+
+	const detailPath = `/agents/${stoppedProjectionEnvironmentId}`;
+	const detailQuery = `?source=on-clawdi&d=${stoppedProjectionGoneDeployment.id}`;
+	for (const section of ["", "/sessions", "/channel-links", "/console"]) {
+		await page.goto(`${detailPath}${section}${detailQuery}`);
+		const main = page.locator("main");
+		await expect(
+			main.locator('[data-slot="empty-title"]').getByText("Stopped", { exact: true }),
+		).toBeVisible();
+		await expect(main.getByRole("button", { name: "Start", exact: true })).toBeVisible();
+		await expect(main.getByText("Clawdi Cloud agent not found", { exact: true })).toHaveCount(0);
+		await expect(main.getByText("Agent sync record unavailable", { exact: true })).toHaveCount(0);
+	}
+
+	const removedProjectionRequests = cloudRequests.filter((path) => {
+		if (path === `/v1/agents/${stoppedProjectionEnvironmentId}`) return true;
+		if (path.startsWith("/v1/sessions")) return true;
+		return (
+			path.startsWith("/v1/channels/agent-links") &&
+			path.includes(encodeURIComponent(stoppedProjectionEnvironmentId))
+		);
+	});
+	expect(removedProjectionRequests).toEqual([]);
+	expect(deployRequests.filter((path) => path.endsWith("/runtime-ui/credentials"))).toEqual([]);
+
+	await page.goto(`${detailPath}${detailQuery}`);
+	await page.locator("main").getByRole("button", { name: "Start", exact: true }).click();
+	await expect.poll(() => startRequests.length).toBe(1);
 });
 
 test("failed deployment with a retained projection keeps status-authoritative navigation", async ({

--- a/apps/web/src/components/dashboard/agents-card.tsx
+++ b/apps/web/src/components/dashboard/agents-card.tsx
@@ -18,8 +18,8 @@ import { daemonStatusVisual } from "@/components/dashboard/daemon-status";
 import { EmptyState } from "@/components/empty-state";
 import {
 	ENTITY_CARD_BASE,
-	ENTITY_CARD_BUTTON_FOCUS_CLASS,
 	ENTITY_GRID_CLASS,
+	ENTITY_STRETCHED_LINK_CLASS,
 	EntityHeader,
 } from "@/components/entity-card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -292,9 +292,17 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 		dotClass: statusVisual.dotClass,
 	};
 
-	const card = (
+	const linkStatus = [statusDot.label, tile.secondaryStatus?.label].filter(Boolean).join(", ");
+	const linkIdentity = tile.contextLabel ? `${tile.name} (${tile.contextLabel})` : tile.name;
+	const linkLabel = `Open ${linkIdentity}. Status: ${linkStatus}`;
+
+	return (
 		<div
-			className={cn(ENTITY_CARD_BASE, "relative h-full transition-colors group-hover:bg-muted/50")}
+			className={cn(
+				ENTITY_CARD_BASE,
+				"group relative z-0 h-full transition-colors hover:bg-muted/50",
+			)}
+			title={tile.href ? undefined : `Status: ${linkStatus}`}
 		>
 			<EntityHeader
 				align="start"
@@ -309,7 +317,7 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 				}
 				meta={meta.length > 0 ? meta : undefined}
 				titleAdornment={sourcePill}
-				className={cn("min-w-0 flex-1", tile.action && "pr-8")}
+				className={cn("min-w-0 flex-1", tile.action && "pr-28")}
 			/>
 			{onClawdi && tile.secondaryStatus ? (
 				<div
@@ -328,43 +336,25 @@ function AgentTileView({ tile }: { tile: AgentTile }) {
 					className="pointer-events-none absolute right-3 top-3.5 size-3.5 text-muted-foreground"
 				/>
 			) : null}
-			{tile.action ? <div className="absolute top-2 right-2">{tile.action}</div> : null}
+			{tile.action ? <div className="absolute top-2 right-2 z-10">{tile.action}</div> : null}
+			{tile.href ? (
+				tile.external ? (
+					<a
+						href={tile.href}
+						target="_blank"
+						rel="noopener noreferrer"
+						className={ENTITY_STRETCHED_LINK_CLASS}
+						aria-label={linkLabel}
+					>
+						<span className="sr-only">{linkLabel}</span>
+					</a>
+				) : (
+					<Link to={tile.href} className={ENTITY_STRETCHED_LINK_CLASS} aria-label={linkLabel}>
+						<span className="sr-only">{linkLabel}</span>
+					</Link>
+				)
+			) : null}
 		</div>
-	);
-	const linkClassName = cn(
-		"group block h-full rounded-lg text-inherit no-underline",
-		ENTITY_CARD_BUTTON_FOCUS_CLASS,
-	);
-	const linkStatus = [statusDot.label, tile.secondaryStatus?.label].filter(Boolean).join(", ");
-	const linkIdentity = tile.contextLabel ? `${tile.name} (${tile.contextLabel})` : tile.name;
-	const linkLabel = `Open ${linkIdentity}. Status: ${linkStatus}`;
-
-	if (!tile.href) {
-		return (
-			<div className="block h-full rounded-lg text-inherit" title={`Status: ${linkStatus}`}>
-				{card}
-			</div>
-		);
-	}
-
-	if (tile.external) {
-		return (
-			<a
-				href={tile.href}
-				target="_blank"
-				rel="noopener noreferrer"
-				className={linkClassName}
-				aria-label={linkLabel}
-			>
-				{card}
-			</a>
-		);
-	}
-
-	return (
-		<Link to={tile.href} className={linkClassName} aria-label={linkLabel}>
-			{card}
-		</Link>
 	);
 }
 

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Link, useLocation } from "@tanstack/react-router";
+import { Link, useLocation, useRouter } from "@tanstack/react-router";
 import { ChevronRight, RefreshCw } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
@@ -51,6 +51,7 @@ export function AgentHome({
 	environmentId: string;
 	section: AgentSectionId;
 }) {
+	const router = useRouter();
 	const searchStr = useLocation({ select: (location) => location.searchStr });
 	const searchParams = new URLSearchParams(searchStr);
 	const deploymentSelector = agentDeploymentSelector(searchParams);
@@ -74,6 +75,20 @@ export function AgentHome({
 	const shouldAutoRefetchUnresolvedHostedAgent =
 		unresolvedHostedAgent && (requestedFromCloudRedirect || isCloudEnvironmentId);
 	const isFetchingRef = useRef(isFetching);
+
+	// Canonicalize a resolved hosted route with its deployment selector before
+	// Stop removes the env mapping. The selector is then sufficient to retain
+	// detail ownership while the cloud-agent projection is absent.
+	useEffect(() => {
+		if (!deployment || deploymentSelector) return;
+		const query = new URLSearchParams(searchStr);
+		query.set("source", "on-clawdi");
+		query.set(AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY, deployment.resource.id);
+		void router.navigate({
+			href: agentSectionHref(environmentId, section, query),
+			replace: true,
+		});
+	}, [deployment, deploymentSelector, environmentId, router, searchStr, section]);
 
 	useEffect(() => {
 		isFetchingRef.current = isFetching;

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -135,6 +135,7 @@ import { topUpAmountCentsForCreditShortfall } from "@/hosted/billing/wallet/top-
 import { deploymentFailureReason } from "@/hosted/deployment-failure";
 import {
 	canDelete as canDeleteDeployment,
+	canQueryDeploymentProjection,
 	canRestart as canRestartDeployment,
 	canStart as canStartDeployment,
 	canStop as canStopDeployment,
@@ -364,7 +365,13 @@ function DeleteComputeAction({ deployment }: { deployment: HostedDeployment }) {
 	);
 }
 
-function StartComputeAction({ deployment }: { deployment: HostedDeployment }) {
+function StartComputeAction({
+	deployment,
+	label = "Start compute",
+}: {
+	deployment: HostedDeployment;
+	label?: string;
+}) {
 	const lifecycle = useDeploymentLifecycle();
 	const runAction = useActionLock();
 	const status = parseDeploymentStatus(deployment.resource.status.summary_state);
@@ -385,7 +392,7 @@ function StartComputeAction({ deployment }: { deployment: HostedDeployment }) {
 			) : (
 				<RefreshCw className="size-3.5" />
 			)}
-			Start compute
+			{label}
 		</Button>
 	);
 }
@@ -422,6 +429,7 @@ export function HostedAgentDetail({
 	const router = useRouter();
 	const deploymentStatus = parseDeploymentStatus(deployment.resource.status.summary_state);
 	const deploymentRunning = isRunningStatus(deploymentStatus);
+	const deploymentProjectionQueryable = canQueryDeploymentProjection(deploymentStatus);
 	const cloudEnvironmentId = isCloudEnvId(environmentId);
 	const agentQuery = useQuery({
 		queryKey: ["agents", environmentId],
@@ -431,7 +439,7 @@ export function HostedAgentDetail({
 					params: { path: { agent_id: environmentId } },
 				}),
 			),
-		enabled: cloudEnvironmentId,
+		enabled: cloudEnvironmentId && deploymentProjectionQueryable,
 		refetchInterval: (query) =>
 			missingProjectionRefetchInterval(
 				query.state.error,
@@ -441,7 +449,7 @@ export function HostedAgentDetail({
 		refetchIntervalInBackground: false,
 	});
 	const projection = resolveHostedAgentProjection({
-		enabled: cloudEnvironmentId,
+		enabled: cloudEnvironmentId && deploymentProjectionQueryable,
 		data: agentQuery.data,
 		error: agentQuery.error,
 		isPending: agentQuery.isPending,
@@ -532,13 +540,15 @@ export function HostedAgentDetail({
 					/>
 				)}
 				{isLiveToolTab ? null : <ComputeDunningBanner deployment={deployment} />}
-				<HostedProjectionNotice
-					projection={projection}
-					isFetching={agentQuery.isFetching}
-					onRetry={() => {
-						void agentQuery.refetch();
-					}}
-				/>
+				{deploymentProjectionQueryable ? (
+					<HostedProjectionNotice
+						projection={projection}
+						isFetching={agentQuery.isFetching}
+						onRetry={() => {
+							void agentQuery.refetch();
+						}}
+					/>
+				) : null}
 				<div className={isLiveToolTab ? "flex min-h-0 flex-1 flex-col" : "w-full"}>
 					{activeTab === "overview" ? (
 						<OverviewTab
@@ -559,14 +569,21 @@ export function HostedAgentDetail({
 					) : null}
 					{activeTab === "terminal" ? <TerminalTab deployment={deployment} /> : null}
 					{activeTab === "sessions" ? (
-						projection.status === "resolved" ? (
-							<HostedAgentSessionsTab environmentId={environmentId} />
+						!deploymentProjectionQueryable ? (
+							<StoppedAgentState deployment={deployment} />
+						) : projection.status === "resolved" ? (
+							<HostedAgentSessionsTab
+								environmentId={environmentId}
+								enabled={deploymentProjectionQueryable}
+							/>
 						) : (
 							<ProjectionDependentUnavailable label="Sessions" />
 						)
 					) : null}
 					{activeTab === "skills" ? (
-						projection.status === "resolved" ? (
+						!deploymentProjectionQueryable ? (
+							<StoppedAgentState deployment={deployment} />
+						) : projection.status === "resolved" ? (
 							<AgentSkillsTab
 								agentId={environmentId}
 								agentProjectId={agent?.default_project_id}
@@ -578,8 +595,10 @@ export function HostedAgentDetail({
 					) : null}
 					{activeTab === "ai" ? <AiProviderTab deployment={deployment} runtime={runtime} /> : null}
 					{activeTab === "channels" ? (
-						projection.status === "resolved" ? (
-							<ChannelsTab environmentId={environmentId} />
+						!deploymentProjectionQueryable ? (
+							<StoppedAgentState deployment={deployment} />
+						) : projection.status === "resolved" ? (
+							<ChannelsTab environmentId={environmentId} enabled={deploymentProjectionQueryable} />
 						) : (
 							<ProjectionDependentUnavailable label="Channels" />
 						)
@@ -668,7 +687,30 @@ function ProjectionDependentUnavailable({ label }: { label: string }) {
 	);
 }
 
-function HostedAgentSessionsTab({ environmentId }: { environmentId: string }) {
+function StoppedAgentState({
+	deployment,
+	variant = "page",
+}: {
+	deployment: HostedDeployment;
+	variant?: React.ComponentProps<typeof EmptyState>["variant"];
+}) {
+	return (
+		<EmptyState
+			variant={variant}
+			title="Stopped"
+			description="Hosted compute has been released. Start this agent to provision compute again."
+			action={<StartComputeAction deployment={deployment} label="Start" />}
+		/>
+	);
+}
+
+function HostedAgentSessionsTab({
+	environmentId,
+	enabled,
+}: {
+	environmentId: string;
+	enabled: boolean;
+}) {
 	const api = useApi();
 	const [page, setPage] = useState(1);
 	const [pageSize, setPageSize] = useState(20);
@@ -679,7 +721,7 @@ function HostedAgentSessionsTab({ environmentId }: { environmentId: string }) {
 
 	const sessions = useQuery({
 		...sessionListQueryOptions(api, { environment_id: environmentId, page, page_size: pageSize }),
-		enabled: isCloudEnvId(environmentId),
+		enabled: enabled && isCloudEnvId(environmentId),
 		placeholderData: keepPreviousData,
 	});
 	const total = sessions.data?.total ?? 0;
@@ -891,6 +933,9 @@ function OverviewTab({
 			{deploymentStatus.kind === "failed" ? (
 				<OverviewFailedPanel deployment={deployment} restartLabel="Retry startup" />
 			) : null}
+			{deploymentStatus.kind === "stopped" ? (
+				<StoppedAgentState deployment={deployment} variant="inset" />
+			) : null}
 			<div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
 				<StatCard
 					label="Status"
@@ -945,7 +990,7 @@ function OverviewDeploymentActions({ deployment }: { deployment: HostedDeploymen
 				{canRestartDeployment(status) && !failed ? (
 					<RestartComputeAction deployment={deployment} />
 				) : null}
-				{canStartDeployment(status) && !failed ? (
+				{canStartDeployment(status) && !failed && status.kind !== "stopped" ? (
 					<StartComputeAction deployment={deployment} />
 				) : null}
 				<DeleteComputeAction deployment={deployment} />
@@ -1113,6 +1158,10 @@ function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; run
 		if (credentials?.runtime === runtime) setShowCredentials(true);
 		else void loadCredentials(true);
 	};
+
+	if (status.kind === "stopped") {
+		return <StoppedAgentState deployment={deployment} />;
+	}
 
 	if (!isRunning) {
 		return (
@@ -1388,6 +1437,10 @@ function TerminalTab({ deployment }: { deployment: HostedDeployment }) {
 	const handleTerminalStatusChange = useCallback((status: HostedTerminalStatus) => {
 		setTerminalStatus(status);
 	}, []);
+
+	if (status.kind === "stopped") {
+		return <StoppedAgentState deployment={deployment} />;
+	}
 
 	if (!isRunning) {
 		return (
@@ -2082,12 +2135,12 @@ function AgentPrimaryModelPicker({
 
 // ── Channels ─────────────────────────────────────────────────────────────────
 
-function ChannelsTab({ environmentId }: { environmentId: string }) {
+function ChannelsTab({ environmentId, enabled }: { environmentId: string; enabled: boolean }) {
 	const api = useApi();
 	const qc = useQueryClient();
 	const channels = useChannels();
 	const botPool = useBotPool();
-	const hasEnvironmentId = isCloudEnvId(environmentId);
+	const hasEnvironmentId = enabled && isCloudEnvId(environmentId);
 	const linked = useAgentChannelLinks(environmentId, hasEnvironmentId);
 	const unlink = useUnlinkAgentChannel(environmentId);
 	// "" = no channel selected. Sentinel keeps the Select controlled (no

--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -346,6 +346,40 @@ describe("declarative deployment mutations", () => {
 		).toHaveLength(0);
 	});
 
+	it("releases an accepted Start without polling its LRO", async () => {
+		const requests: Request[] = [];
+		const client = testClient(async (request) => {
+			requests.push(request.clone());
+			const path = new URL(request.url).pathname;
+			if (path === "/v2/deployments/hdep_stopped" && request.method === "GET") {
+				return jsonResponse(
+					hostedDeploymentFixture({
+						id: "hdep_stopped",
+						status: "stopped",
+						resourceVersion: "rv-stopped",
+					}),
+				);
+			}
+			if (path === "/v2/deployments/hdep_stopped/start" && request.method === "POST") {
+				return jsonResponse(operation({ done: false, id: "start-accepted", verb: "start" }), 202);
+			}
+			if (path.startsWith("/v2/operations/")) {
+				throw new Error("Accepted Start must not poll its operation");
+			}
+			throw new Error(`Unexpected request: ${request.method} ${path}`);
+		});
+
+		await expect(
+			client.setDeploymentDesiredState("hdep_stopped", "running", "intent-start-stopped"),
+		).resolves.toMatchObject({ done: false, name: "operations/start-accepted" });
+		expect(requests.map((request) => new URL(request.url).pathname)).toEqual([
+			"/v2/deployments/hdep_stopped",
+			"/v2/deployments/hdep_stopped/start",
+		]);
+		expect(requests[1]?.headers.get("Idempotency-Key")).toBe("intent-start-stopped");
+		expect(requests[1]?.headers.get("If-Match")).toBe('"rv-stopped"');
+	});
+
 	it("keeps an accepted delete visible when reconciliation later fails", async () => {
 		const failure = {
 			type: "https://api.clawdi.ai/problems/deployment-delete-failed",

--- a/apps/web/src/hosted/deployment-status.test.ts
+++ b/apps/web/src/hosted/deployment-status.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
 	canDelete,
+	canQueryDeploymentProjection,
 	canRestart,
 	canStart,
 	canStop,
@@ -126,6 +127,14 @@ describe("DeploymentStatus", () => {
 			expect(canStop(status)).toBe(stop);
 			expect(canRestart(status)).toBe(restart);
 		}
+	});
+
+	test("does not query a projection after stopped compute has released it", () => {
+		expect(canQueryDeploymentProjection(parseDeploymentStatus("stopped"))).toBe(false);
+		expect(canQueryDeploymentProjection(parseDeploymentStatus("deleted"))).toBe(false);
+		expect(canQueryDeploymentProjection(parseDeploymentStatus("starting"))).toBe(true);
+		expect(canQueryDeploymentProjection(parseDeploymentStatus("running"))).toBe(true);
+		expect(canQueryDeploymentProjection(parseDeploymentStatus("failed"))).toBe(true);
 	});
 
 	test("disables delete once deletion is in progress or complete", () => {

--- a/apps/web/src/hosted/deployment-status.ts
+++ b/apps/web/src/hosted/deployment-status.ts
@@ -120,6 +120,31 @@ export function isRunningStatus(status: DeploymentStatus): boolean {
 	}
 }
 
+/**
+ * Stopping a deployment removes its cloud-agent projection while preserving
+ * the deployment row. Do not query that absent projection until Start moves
+ * the deployment back into a recoverable lifecycle state.
+ */
+export function canQueryDeploymentProjection(status: DeploymentStatus): boolean {
+	switch (status.kind) {
+		case "stopped":
+		case "deleted":
+			return false;
+		case "creating":
+		case "starting":
+		case "running":
+		case "stopping":
+		case "restarting":
+		case "updating":
+		case "failed":
+		case "deleting":
+		case "unknown":
+			return true;
+		default:
+			return exhaustive(status);
+	}
+}
+
 export function isTerminalStatus(status: DeploymentStatus): boolean {
 	switch (status.kind) {
 		case "running":

--- a/apps/web/src/hosted/hosted-agent-resolution.test.ts
+++ b/apps/web/src/hosted/hosted-agent-resolution.test.ts
@@ -5,6 +5,7 @@ import {
 	canOpenHostedRuntimeUi,
 	hostedDeploymentMembers,
 	missingProjectionRefetchInterval,
+	resolveAgentDeployment,
 	resolveHostedAgentProjection,
 	resolveHostedInventory,
 } from "@/hosted/hosted-agent-resolution";
@@ -102,6 +103,35 @@ describe("hosted inventory resolution matrix", () => {
 });
 
 describe("hosted detail projection resolution", () => {
+	test("keeps a selected stopped deployment addressable after its projection is removed", () => {
+		const stopped = hostedDeploymentFixture({
+			id: "hdep_stopped",
+			status: "stopped",
+			cloudEnvironments: {},
+		});
+		const resolution = resolveAgentDeployment(
+			[stopped],
+			"55555555-5555-4555-8555-555555555555",
+			"hdep_stopped",
+		);
+
+		expect(resolution.match?.deployment.resource.id).toBe("hdep_stopped");
+		expect(resolution.match?.runtime).toBeNull();
+		expect(resolution.ambiguousMatches).toEqual([]);
+	});
+
+	test("does not let a mismatched selector override an environment match", () => {
+		const environmentId = "55555555-5555-4555-8555-555555555555";
+		const matched = hostedDeploymentFixture({
+			id: "hdep_matched",
+			cloudEnvironments: { openclaw: environmentId },
+		});
+		const selected = hostedDeploymentFixture({ id: "hdep_selected", cloudEnvironments: {} });
+		const resolution = resolveAgentDeployment([matched, selected], environmentId, "hdep_selected");
+
+		expect(resolution.match?.deployment.resource.id).toBe("hdep_matched");
+	});
+
 	test("keeps missing, service-error, loading, unavailable, and resolved states distinct", () => {
 		const notFound = new ApiError(404, "Agent not found");
 		const serviceError = new ApiError(500, "gateway failure");

--- a/apps/web/src/hosted/hosted-agent-resolution.ts
+++ b/apps/web/src/hosted/hosted-agent-resolution.ts
@@ -82,6 +82,11 @@ export function resolveAgentDeployment(
 	if (direct) {
 		return { match: { deployment: direct, runtime: null }, ambiguousMatches: [] };
 	}
+	const selectedDeployment = deploymentSelector
+		? members.find(
+				(deployment) => deployment.resource.id.toLowerCase() === deploymentSelector.toLowerCase(),
+			)
+		: undefined;
 
 	const matches: AgentDeploymentMatch[] = [];
 	for (const deployment of members) {
@@ -98,6 +103,12 @@ export function resolveAgentDeployment(
 	}
 
 	if (matches.length === 1) return { match: matches[0], ambiguousMatches: [] };
+	// Stop removes the runtime projection (and therefore its environment-id
+	// mapping) but leaves the deployment itself. Tile/detail links carry this
+	// selector specifically so the retained deployment remains addressable.
+	if (matches.length === 0 && selectedDeployment) {
+		return { match: { deployment: selectedDeployment, runtime: null }, ambiguousMatches: [] };
+	}
 	return { match: null, ambiguousMatches: matches };
 }
 

--- a/apps/web/src/hosted/hosted-deployment-tile-action.tsx
+++ b/apps/web/src/hosted/hosted-deployment-tile-action.tsx
@@ -1,26 +1,46 @@
 "use client";
 
-import { MoreHorizontal } from "lucide-react";
+import { Play, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ConfirmAction } from "@/components/ui/confirm-action";
 import { Spinner } from "@/components/ui/spinner";
 import { deploymentDisplayName } from "@/hosted/agent-identity";
-import { useDeleteDeployment } from "@/hosted/agents/deployment-hooks";
+import { useDeleteDeployment, useDeploymentLifecycle } from "@/hosted/agents/deployment-hooks";
 import type { HostedDeployment } from "@/hosted/billing/contracts";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
-import { canDelete, parseDeploymentStatus } from "@/hosted/deployment-status";
+import { canDelete, canStart, parseDeploymentStatus } from "@/hosted/deployment-status";
 
-export function HostedDeploymentTileDeleteAction({ deployment }: { deployment: HostedDeployment }) {
+export function HostedDeploymentTileAction({ deployment }: { deployment: HostedDeployment }) {
 	const deleteDeployment = useDeleteDeployment();
+	const lifecycle = useDeploymentLifecycle();
 	const runAction = useActionLock();
 	const name = deploymentDisplayName(
 		deployment.resource.spec.name,
 		deployment.resource.spec.runtime,
 	);
-	const deleteEnabled = canDelete(parseDeploymentStatus(deployment.resource.status.summary_state));
+	const status = parseDeploymentStatus(deployment.resource.status.summary_state);
+	const startEnabled = status.kind === "stopped" && canStart(status);
+	const deleteEnabled = canDelete(status);
 
 	return (
-		<div data-hosted="true">
+		<div data-hosted="true" className="flex items-center gap-1">
+			{startEnabled ? (
+				<Button
+					type="button"
+					size="xs"
+					disabled={lifecycle.isPending}
+					aria-label={`Start ${name}`}
+					title={`Start ${name}`}
+					onClick={() =>
+						void runAction(async () => {
+							await lifecycle.mutateAsync({ id: deployment.resource.id, action: "start" });
+						}).catch(() => undefined)
+					}
+				>
+					{lifecycle.isPending ? <Spinner /> : <Play />}
+					Start
+				</Button>
+			) : null}
 			<ConfirmAction
 				title={`Delete ${name}?`}
 				description={<p>The hosted deployment is torn down. This can’t be undone.</p>}
@@ -35,13 +55,13 @@ export function HostedDeploymentTileDeleteAction({ deployment }: { deployment: H
 				<Button
 					type="button"
 					variant="ghost"
-					size="icon-sm"
-					className="text-muted-foreground"
+					size="icon-xs"
+					className="text-muted-foreground hover:text-destructive"
 					disabled={deleteDeployment.isPending || !deleteEnabled}
 					aria-label={`Delete ${name}`}
 					title={`Delete ${name}`}
 				>
-					{deleteDeployment.isPending ? <Spinner /> : <MoreHorizontal />}
+					{deleteDeployment.isPending ? <Spinner /> : <Trash2 />}
 				</Button>
 			</ConfirmAction>
 		</div>

--- a/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.test.ts
@@ -239,6 +239,25 @@ describe("deploymentToTiles", () => {
 		expect(JSON.stringify(tile)).not.toContain("/agents/dep_123");
 	});
 
+	test("keeps Start and Delete actions on a stopped tile with a retained env identity", () => {
+		const environmentId = "env-stopped-openclaw";
+		const [tile] = hostedDeploymentToTiles(
+			deployment({
+				name: "deployment-create-generated-id",
+				status: "stopped",
+				environmentId,
+			}),
+		);
+
+		expect(tile).toMatchObject({
+			name: "OpenClaw",
+			contextLabel: null,
+			statusLabel: "Stopped",
+			href: `/agents/${environmentId}?source=on-clawdi&d=dep_123`,
+		});
+		expect(tile?.action).toBeDefined();
+	});
+
 	test("removes deleted deployments from tiles and detail membership", () => {
 		const environmentId = "env-deleted-openclaw";
 		const deleted = deployment({ status: "deleted", environmentId });

--- a/apps/web/src/hosted/use-hosted-agent-tiles.ts
+++ b/apps/web/src/hosted/use-hosted-agent-tiles.ts
@@ -25,7 +25,7 @@ import {
 	claimedEnvIdsFromDeployments,
 	isHostedDeploymentMember,
 } from "@/hosted/hosted-agent-resolution";
-import { HostedDeploymentTileDeleteAction } from "@/hosted/hosted-deployment-tile-action";
+import { HostedDeploymentTileAction } from "@/hosted/hosted-deployment-tile-action";
 import { deploymentRuntime, runtimeDisplayName, runtimeEnvironmentId } from "@/hosted/runtimes";
 import { useHostedDeploymentInventory } from "@/hosted/use-hosted-deployment-inventory";
 import { AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY, agentSectionHref } from "@/lib/agent-routes";
@@ -208,6 +208,7 @@ export function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>
 		: runtimeDisplayName(runtime);
 	const contextLabel = slug !== name ? slug : null;
 	const runtimeStatus = hostedRuntimeStatusView(d.resource.status, matchedEnv ?? null);
+	const showTileActions = runtimeStatus.compute.kind === "stopped" || !envId;
 	const dunningStatus = computeDunningTileStatus(d);
 	const failureReasonStatus =
 		runtimeStatus.secondary?.kind === "failure_reason" ? runtimeStatus.secondary : null;
@@ -224,9 +225,9 @@ export function deploymentToTiles(d: HostedDeployment, envById: Map<string, Env>
 			lastSeenAt: matchedEnv?.last_seen_at ?? null,
 			href: detailHref,
 			external: false,
-			action: envId
-				? undefined
-				: createElement(HostedDeploymentTileDeleteAction, { deployment: d }),
+			action: showTileActions
+				? createElement(HostedDeploymentTileAction, { deployment: d })
+				: undefined,
 			manageHref: settingsHref,
 			active: runtimeStatus.active,
 			statusDot: {


### PR DESCRIPTION
Owner/e2e BLOCKER: after Stop, a v2 agent was a dead end — detail showed 'Cloud agent not found', stopped tiles only had Delete, no Start. v1 untouched.

- Stopped tiles (home + /agents) offer **Start** as the primary action (plus Delete), using friendly names (no raw `deployment-create-…` in labels/aria).
- Agent-detail recovers a stopped deployment via `d=<deployment_id>` even when the cloud env projection is gone — shows a clean Stopped/Start state instead of hard-erroring; per-env queries (agent/sessions/agent-links/runtime credentials) are gated off while stopped so they don't 422.
- Start path: GET deployment (ETag) → POST `/v2/deployments/{id}/start` → releases on 202 (reusing the instant-release helper, no full-LRO wait) → projects `starting` → inventory polling converges to running.

62 focused tests + 3 Chromium E2E + typecheck + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)