### PR TITLE
fix(web): converge declarative operation acceptance (free deploy releases on 202)

### DIFF
--- a/apps/web/src/hosted/agents/deployment-hooks.test.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.test.ts
@@ -68,9 +68,14 @@ describe("deployment mutation settlement", () => {
 		expect(settlementInvalidations).toHaveLength(3);
 	});
 
-	test("projects accepted operations into promptly-polled transition states", () => {
+	test("projects every accepted operation through the shared transition model", () => {
 		if (!projectAcceptedTransition) throw new Error("deployment hooks were not loaded");
+		const queryClient = new QueryClient();
+		queryClient.setQueryData<HostedDeployment[]>(billingKeys.deployments, [
+			hostedDeploymentFixture({ id: "hdep_test" }),
+		]);
 		const expectations = [
+			["create", "creating"],
 			["start", "starting"],
 			["stop", "stopping"],
 			["restart", "restarting"],
@@ -79,12 +84,9 @@ describe("deployment mutation settlement", () => {
 		] as const;
 
 		for (const [verb, status] of expectations) {
-			const queryClient = new QueryClient();
-			queryClient.setQueryData<HostedDeployment[]>(billingKeys.deployments, [
-				hostedDeploymentFixture({ id: "hdep_test" }),
-			]);
 			const operation = acceptedOperation(verb);
-			projectAcceptedTransition(queryClient, "hdep_test", status, operation);
+			const accepted = { deploymentId: "hdep_test", operation };
+			projectAcceptedTransition(queryClient, accepted, () => undefined);
 			const deployments = queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments);
 
 			expect(deployments?.[0]?.resource.status.summary_state).toBe(status);
@@ -105,7 +107,11 @@ describe("deployment mutation settlement", () => {
 		queryClient.setQueryData<HostedDeployment[]>(billingKeys.deployments, [
 			hostedDeploymentFixture({ id: "hdep_delete" }),
 		]);
-		projectAcceptedTransition(queryClient, "hdep_delete", "deleting", acceptedOperation("delete"));
+		projectAcceptedTransition(
+			queryClient,
+			{ deploymentId: "hdep_delete", operation: acceptedOperation("delete") },
+			() => undefined,
+		);
 
 		const deleting = queryClient.getQueryData<HostedDeployment[]>(billingKeys.deployments);
 		expect(deleting).toHaveLength(1);

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -3,9 +3,8 @@
 import { type QueryClient, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { toast } from "sonner";
-import { useBillingClient } from "@/hosted/billing/billing-client";
+import { type AcceptedOperation, useBillingClient } from "@/hosted/billing/billing-client";
 import type {
-	DeploymentOperation,
 	DeploymentUpdateRequest,
 	HostedDeployment,
 	HostedDeploymentStatus,
@@ -28,6 +27,19 @@ import { deploymentRuntime, runtimeEnvironmentId } from "@/hosted/runtimes";
 import { useHostedDeploymentInventory } from "@/hosted/use-hosted-deployment-inventory";
 
 const SETTLING_REFRESH_DELAYS_MS = [2_000, 10_000, 20_000, 30_000] as const;
+const ACCEPTED_OPERATION_TRANSITIONS = {
+	create: "creating",
+	start: "starting",
+	stop: "stopping",
+	restart: "restarting",
+	update: "updating",
+	runtime_switch: "updating",
+	rename: "updating",
+	delete: "deleting",
+} satisfies Record<
+	AcceptedOperation["operation"]["metadata"]["verb"],
+	HostedDeploymentStatus["summary_state"]
+>;
 
 export function invalidateDeploymentSnapshots(qc: QueryClient) {
 	void qc.invalidateQueries({ queryKey: billingKeys.deployments });
@@ -45,16 +57,16 @@ function scheduleDeploymentSettlingRefresh(qc: QueryClient) {
 
 export function projectAcceptedDeploymentTransition(
 	qc: QueryClient,
-	deploymentId: string,
-	status: HostedDeploymentStatus["summary_state"],
-	operation: DeploymentOperation,
+	accepted: AcceptedOperation,
+	scheduleRefresh = scheduleDeploymentSettlingRefresh,
 ) {
+	const status = ACCEPTED_OPERATION_TRANSITIONS[accepted.operation.metadata.verb];
 	qc.setQueryData<HostedDeployment[]>(billingKeys.deployments, (deployments) =>
 		deployments?.map((deployment) =>
-			deployment.resource.id === deploymentId
+			deployment.resource.id === accepted.deploymentId
 				? {
 						...deployment,
-						accepted_operation: operation,
+						accepted_operation: accepted.operation,
 						resource: {
 							...deployment.resource,
 							status: { ...deployment.resource.status, summary_state: status },
@@ -63,6 +75,7 @@ export function projectAcceptedDeploymentTransition(
 				: deployment,
 		),
 	);
+	scheduleRefresh(qc);
 }
 
 async function runStableDeploymentIntent<T>(
@@ -158,11 +171,8 @@ export function useDeploymentLifecycle() {
 					idempotencyKey,
 				);
 			}),
-		onSuccess: (operation, vars) => {
-			const status =
-				vars.action === "restart" ? "restarting" : vars.action === "stop" ? "stopping" : "starting";
-			projectAcceptedDeploymentTransition(qc, vars.id, status, operation);
-			scheduleDeploymentSettlingRefresh(qc);
+		onSuccess: (accepted, vars) => {
+			projectAcceptedDeploymentTransition(qc, accepted);
 			const msg =
 				vars.action === "restart"
 					? "Restarting…"
@@ -187,9 +197,8 @@ export function useDeleteDeployment() {
 			runStableDeploymentIntent("deployment-delete", { action: "delete", id }, (key) =>
 				client.deleteDeployment(id, key),
 			),
-		onSuccess: (operation, id) => {
-			projectAcceptedDeploymentTransition(qc, id, "deleting", operation);
-			scheduleDeploymentSettlingRefresh(qc);
+		onSuccess: (accepted) => {
+			projectAcceptedDeploymentTransition(qc, accepted);
 			toast.message("Deleting…");
 		},
 		onError: (error) => {
@@ -208,9 +217,8 @@ export function useUpdateDeployment() {
 			runStableDeploymentIntent("deployment-update", vars, (key) =>
 				client.updateDeployment(vars.id, vars.update, key),
 			),
-		onSuccess: (operation, vars) => {
-			projectAcceptedDeploymentTransition(qc, vars.id, "updating", operation);
-			scheduleDeploymentSettlingRefresh(qc);
+		onSuccess: (accepted) => {
+			projectAcceptedDeploymentTransition(qc, accepted);
 			toast.message("Applying agent settings…");
 		},
 		onError: (error) => {

--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { createBillingClient, unwrapDeploy } from "@/hosted/billing/billing-client";
+import {
+	acceptDeclarativeOperation,
+	createBillingClient,
+	unwrapDeploy,
+} from "@/hosted/billing/billing-client";
 import { hostedApiBaseUrl } from "@/hosted/billing/billing-url";
 import type { DeploymentOperation } from "@/hosted/billing/contracts";
 import {
@@ -20,10 +24,12 @@ function jsonResponse(body: unknown, status = 200): Response {
 
 function operation({
 	done = true,
+	deploymentId = "hdep_test",
 	id = "op-test",
 	verb = "update",
 }: {
 	done?: boolean;
+	deploymentId?: string;
 	id?: string;
 	verb?: DeploymentOperation["metadata"]["verb"];
 } = {}): DeploymentOperation {
@@ -32,7 +38,7 @@ function operation({
 		name: `operations/${id}`,
 		metadata: {
 			"@type": "type.googleapis.com/clawdi.v2.DeploymentOperationMetadata",
-			deploymentId: deployment.id,
+			deploymentId,
 			verb,
 			targetGeneration: 2,
 			manifestETag: "manifest-test",
@@ -112,13 +118,13 @@ describe("managed model catalog", () => {
 });
 
 describe("declarative deployment mutations", () => {
-	it("creates an included Basic deployment with an idempotency key and waits for its LRO", async () => {
+	it("releases an included Basic deployment as soon as its LRO is accepted", async () => {
 		const requests: Request[] = [];
 		const client = testClient(async (request) => {
 			requests.push(request.clone());
 			const path = new URL(request.url).pathname;
 			if (path === "/v2/deployments" && request.method === "POST") {
-				return jsonResponse(operation({ id: "included-create", verb: "create" }), 202);
+				return jsonResponse(operation({ done: false, id: "included-create", verb: "create" }), 202);
 			}
 			throw new Error(`Unexpected request: ${request.method} ${path}`);
 		});
@@ -133,25 +139,29 @@ describe("declarative deployment mutations", () => {
 		);
 
 		expect(result.deploymentId).toBe("hdep_test");
+		expect(result.operation.done).toBe(false);
 		expect(requests).toHaveLength(1);
 		expect(requests[0]?.headers.get("Idempotency-Key")).toBe("intent-included-create");
 		expect(await requests[0]?.json()).toMatchObject({
 			compute_plan_slug: "compute_basic",
 			runtime: "openclaw",
 		});
+		expect(() =>
+			acceptDeclarativeOperation({ operation: operation({ done: false, deploymentId: "" }) }),
+		).toThrow("The deployment service completed creation without a deployment.");
 	});
 
-	it("creates a wallet-funded deployment and waits for its LRO", async () => {
+	it("waits for a checkout deployment request that genuinely needs LRO completion", async () => {
 		const requests: Request[] = [];
-		const intentKey = "subscription-wallet-deploy-create-happy";
+		const intentKey = "subscription-checkout-deploy-create-happy";
 		const client = testClient(async (request) => {
 			requests.push(request.clone());
 			const path = new URL(request.url).pathname;
 			if (path === "/v2/subscription/checkout") {
 				return jsonResponse({
-					flow_type: "subscription_activation",
-					funding_source: "wallet",
-					checkout_url: "",
+					flow_type: "checkout_session",
+					funding_source: "stripe",
+					checkout_url: "https://checkout.example.com/session",
 					deploy_request_id: intentKey,
 				});
 			}
@@ -177,7 +187,7 @@ describe("declarative deployment mutations", () => {
 			{
 				plan_slug: "compute_basic",
 				billing_term_months: 1,
-				funding_source: "wallet",
+				funding_source: "stripe",
 				ui_mode: "custom",
 				deploy_config: {
 					compute_plan_slug: "compute_basic",
@@ -340,44 +350,12 @@ describe("declarative deployment mutations", () => {
 			client.deleteDeployment("hdep_delete", "intent-delete"),
 		]);
 
-		expect(accepted.map((item) => item.done)).toEqual([false, false, false, false, false, false]);
+		expect(
+			accepted.every((item) => !item.operation.done && item.deploymentId === "hdep_test"),
+		).toBe(true);
 		expect(
 			requests.filter((request) => new URL(request.url).pathname.startsWith("/v2/operations/")),
 		).toHaveLength(0);
-	});
-
-	it("releases an accepted Start without polling its LRO", async () => {
-		const requests: Request[] = [];
-		const client = testClient(async (request) => {
-			requests.push(request.clone());
-			const path = new URL(request.url).pathname;
-			if (path === "/v2/deployments/hdep_stopped" && request.method === "GET") {
-				return jsonResponse(
-					hostedDeploymentFixture({
-						id: "hdep_stopped",
-						status: "stopped",
-						resourceVersion: "rv-stopped",
-					}),
-				);
-			}
-			if (path === "/v2/deployments/hdep_stopped/start" && request.method === "POST") {
-				return jsonResponse(operation({ done: false, id: "start-accepted", verb: "start" }), 202);
-			}
-			if (path.startsWith("/v2/operations/")) {
-				throw new Error("Accepted Start must not poll its operation");
-			}
-			throw new Error(`Unexpected request: ${request.method} ${path}`);
-		});
-
-		await expect(
-			client.setDeploymentDesiredState("hdep_stopped", "running", "intent-start-stopped"),
-		).resolves.toMatchObject({ done: false, name: "operations/start-accepted" });
-		expect(requests.map((request) => new URL(request.url).pathname)).toEqual([
-			"/v2/deployments/hdep_stopped",
-			"/v2/deployments/hdep_stopped/start",
-		]);
-		expect(requests[1]?.headers.get("Idempotency-Key")).toBe("intent-start-stopped");
-		expect(requests[1]?.headers.get("If-Match")).toBe('"rv-stopped"');
 	});
 
 	it("keeps an accepted delete visible when reconciliation later fails", async () => {
@@ -413,7 +391,10 @@ describe("declarative deployment mutations", () => {
 
 		await expect(
 			client.deleteDeployment("hdep_delete_failure", "intent-delete-failure"),
-		).resolves.toMatchObject({ done: false, name: "operations/delete-failure" });
+		).resolves.toMatchObject({
+			deploymentId: "hdep_test",
+			operation: { done: false, name: "operations/delete-failure" },
+		});
 		await expect(client.listDeployments()).resolves.toMatchObject([
 			{
 				resource: {

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -48,10 +48,7 @@ type DeployResult<T> = { data?: T; error?: unknown; response: Response };
 type BillingFetch = (request: Request) => Promise<Response>;
 type BillingAuthTokenGetter = () => Promise<string | null | undefined>;
 
-export type DeploymentIntentResult = {
-	deploymentId: string;
-	operation: DeploymentOperation | null;
-};
+export type AcceptedOperation = { deploymentId: string; operation: DeploymentOperation };
 
 export type BillingClientOptions = {
 	fetch?: BillingFetch;
@@ -110,10 +107,30 @@ function operationIdFromName(name: string): string {
 }
 
 function deploymentIdFromOperation(operation: DeploymentOperation): string | null {
+	const metadataId = operation.metadata?.deploymentId?.trim();
+	if (metadataId) return metadataId;
 	return operation.response?.["@type"] ===
 		"type.googleapis.com/clawdi.v2.DeploymentOperationResponse"
-		? operation.response.deployment.id
+		? operation.response.deployment.id.trim() || null
 		: null;
+}
+
+export function acceptDeclarativeOperation<T extends DeploymentOperation | null>(
+	acceptance: {
+		operation: T;
+		deploymentId?: string | null;
+	},
+	missingDeploymentMessage = "The deployment service completed creation without a deployment.",
+): {
+	deploymentId: string;
+	operation: T;
+} {
+	const deploymentId =
+		(acceptance.operation ? deploymentIdFromOperation(acceptance.operation) : null) ||
+		acceptance.deploymentId?.trim() ||
+		null;
+	if (!deploymentId) throw new BillingApiError(502, missingDeploymentMessage);
+	return { deploymentId, operation: acceptance.operation };
 }
 
 function strongResourceEtag(deployment: HostedDeployment): string {
@@ -190,18 +207,13 @@ export function createBillingClient(
 		initialOperation: DeploymentOperation,
 	): Promise<DeploymentOperation> => {
 		let operation = initialOperation;
-		for (let poll = 0; poll <= pollLimit; poll += 1) {
-			if (operation.done) {
-				if (operation.error) {
-					throw new BillingApiError(409, operation.error.message, operation.error);
-				}
-				return operation;
-			}
-			if (poll === pollLimit) break;
+		for (let poll = 0; !operation.done && poll < pollLimit; poll += 1) {
 			await sleep(pollIntervalMs);
 			operation = await getOperation(operationIdFromName(operation.name));
 		}
-		throw new BillingNetworkError("timeout");
+		if (!operation.done) throw new BillingNetworkError("timeout");
+		if (operation.error) throw new BillingApiError(409, operation.error.message, operation.error);
+		return operation;
 	};
 
 	const getDeploymentByRequest = async (
@@ -213,9 +225,7 @@ export function createBillingClient(
 			}),
 		);
 
-	const waitForDeploymentRequest = async (
-		deployRequestId: string,
-	): Promise<DeploymentIntentResult> => {
+	const waitForDeploymentRequest = async (deployRequestId: string) => {
 		for (let poll = 0; poll <= pollLimit; poll += 1) {
 			const status = await getDeploymentByRequest(deployRequestId);
 			if (
@@ -231,14 +241,14 @@ export function createBillingClient(
 			if (projectedOperation || operationName) {
 				const initialOperation =
 					projectedOperation ?? (await getOperation(operationIdFromName(operationName ?? "")));
-				const operation = await waitForOperation(initialOperation);
-				const deploymentId =
-					deploymentIdFromOperation(operation) ?? status.lineage_tail?.deployment_id ?? null;
-				if (deploymentId) return { deploymentId, operation };
+				return acceptDeclarativeOperation({
+					operation: await waitForOperation(initialOperation),
+					deploymentId: status.lineage_tail?.deployment_id,
+				});
 			}
 			const deploymentId = status.lineage_tail?.deployment_id ?? null;
 			if (status.request_status === "succeeded" && deploymentId) {
-				return { deploymentId, operation: null };
+				return acceptDeclarativeOperation({ deploymentId, operation: null });
 			}
 			if (poll === pollLimit) break;
 			await sleep(pollIntervalMs);
@@ -250,16 +260,15 @@ export function createBillingClient(
 		id: string,
 		idempotencyKey: string,
 		send: (headers: MutationHeaders) => Promise<DeployResult<DeploymentOperation>>,
-	): Promise<DeploymentOperation> => {
+	): Promise<AcceptedOperation> => {
 		let deployment = await getDeployment(id);
 		for (let attempt = 0; attempt < 2; attempt += 1) {
 			const headers: MutationHeaders = {
 				"Idempotency-Key": idempotencyKey,
 				"If-Match": strongResourceEtag(deployment),
 			};
-			let accepted: DeploymentOperation;
 			try {
-				accepted = unwrapDeploy(await send(headers));
+				return acceptDeclarativeOperation({ operation: unwrapDeploy(await send(headers)) });
 			} catch (error) {
 				if (!isPreconditionConflict(error)) throw error;
 				if (attempt === 0) {
@@ -268,7 +277,6 @@ export function createBillingClient(
 				}
 				throw new DeploymentConflictError({ cause: error });
 			}
-			return accepted;
 		}
 		throw new DeploymentConflictError();
 	};
@@ -344,24 +352,15 @@ export function createBillingClient(
 		createDeployment: async (
 			body: DeploymentCreateRequest,
 			idempotencyKey: string,
-		): Promise<DeploymentIntentResult> => {
-			const operation = await waitForOperation(
-				unwrapDeploy(
+		): Promise<AcceptedOperation> =>
+			acceptDeclarativeOperation({
+				operation: unwrapDeploy(
 					await api.POST("/v2/deployments", {
 						params: { header: { "Idempotency-Key": idempotencyKey } },
 						body,
 					}),
 				),
-			);
-			const deploymentId = deploymentIdFromOperation(operation);
-			if (!deploymentId) {
-				throw new BillingApiError(
-					502,
-					"The deployment service completed creation without a deployment.",
-				);
-			}
-			return { deploymentId, operation };
-		},
+			}),
 		createTerminalSession: async (id: string) =>
 			unwrapDeploy(
 				await api.POST("/v2/deployments/{deployment_id}/terminal", {

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -37,6 +37,9 @@ describe("first Basic agent copy", () => {
 		expect(planComparisonSource).toContain("The first active Basic agent is free.");
 		expect(planComparisonSource).toContain("Your first active Basic agent is free.");
 		expect(planComparisonSource).not.toContain("agent is included");
+		expect(wizardSource).toContain("acceptedDeploymentNavigation(created.deploymentId)");
+		expect(wizardSource).toContain("acceptedDeploymentNavigation(outcome.deploymentId)");
+		expect(wizardSource).not.toContain("resolveWalletDeploymentId");
 	});
 });
 

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -198,6 +198,10 @@ const EMPTY_WALLET_TOP_UP_CONTEXT: WalletTopUpContext = {
 	blockedChargeCredits: null,
 };
 
+function acceptedDeploymentNavigation(deploymentId: string, replace = false) {
+	return { href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"), replace };
+}
+
 function decimalCredits(value: unknown): number | null {
 	if (typeof value !== "string" && typeof value !== "number") return null;
 	const parsed = Number(value);
@@ -582,10 +586,7 @@ export function DeployWizard() {
 			}
 			const deploymentId = checkoutReturnDeploymentId(searchStr);
 			if (deploymentId) {
-				void router.navigate({
-					href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"),
-					replace: true,
-				});
+				void router.navigate(acceptedDeploymentNavigation(deploymentId, true));
 				return;
 			}
 			toast.message("Checkout status refreshed", {
@@ -910,10 +911,7 @@ export function DeployWizard() {
 				toast.success("Deployment ready", {
 					description: `Your ${tierLabel} agent finished provisioning.`,
 				});
-				void router.navigate({
-					href: agentSectionHref(resolved.deploymentId, "overview", "source=on-clawdi"),
-					replace: true,
-				});
+				void router.navigate(acceptedDeploymentNavigation(resolved.deploymentId, true));
 				return;
 			} catch {
 				// Stripe may complete before its deploy request is visible. Fall back
@@ -938,10 +936,7 @@ export function DeployWizard() {
 			toast.success("Checkout complete", {
 				description: `Your ${tierLabel} deployment is provisioning now.`,
 			});
-			void router.navigate({
-				href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"),
-				replace: true,
-			});
+			void router.navigate(acceptedDeploymentNavigation(deploymentId, true));
 			return;
 		}
 		toast.success("Checkout complete", {
@@ -998,18 +993,12 @@ export function DeployWizard() {
 					if (outcome.flowType !== "subscription_activation") {
 						throw new Error("Wallet subscription returned a checkout flow.");
 					}
-					const deploymentId = outcome.deploymentId;
-					if (!deploymentId) {
-						throw new Error("Wallet activation did not accept a deployment target.");
-					}
 					forgetIdempotencyAttempt("subscription-wallet-deploy", fingerprint);
 					walletCreateAttemptRef.current = null;
 					toast.success("Agent deployed", {
 						description: `${formatCents(walletDebit?.exactDebitCents ?? paidSelection.offer.price_cents)} was paid with AI Credits.`,
 					});
-					void router.navigate({
-						href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"),
-					});
+					void router.navigate(acceptedDeploymentNavigation(outcome.deploymentId));
 					return;
 				}
 				const checkoutFingerprint = idempotencyFingerprint({ selection, target });
@@ -1090,9 +1079,7 @@ export function DeployWizard() {
 			toast.success("Agent deployed", {
 				description: "Your first Basic agent is provisioning now for free.",
 			});
-			void router.navigate({
-				href: agentSectionHref(created.deploymentId, "overview", "source=on-clawdi"),
-			});
+			void router.navigate(acceptedDeploymentNavigation(created.deploymentId));
 		} catch (e) {
 			if (paymentMethod === "wallet") {
 				void subscriptionCreateQuote.refetch();

--- a/apps/web/src/hosted/billing/subscription/subscription-create-adapter.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-adapter.test.ts
@@ -128,5 +128,8 @@ describe("subscription creation adapter", () => {
 			deploymentId: "hdep_created",
 			deployRequestId: "subscription-create-test",
 		});
+		expect(() => subscriptionCreateOutcome({ ...activation, deployment_id: null })).toThrow(
+			"Wallet activation did not accept a deployment target.",
+		);
 	});
 });

--- a/apps/web/src/hosted/billing/subscription/subscription-create-adapter.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-adapter.ts
@@ -1,3 +1,4 @@
+import { acceptDeclarativeOperation } from "@/hosted/billing/billing-client";
 import type {
 	CheckoutRequest,
 	CheckoutResult,
@@ -54,7 +55,7 @@ export type SubscriptionCreateOutcomeView =
 	  }
 	| {
 			flowType: "subscription_activation";
-			deploymentId: string | null;
+			deploymentId: string;
 			deployRequestId: string | null;
 	  };
 
@@ -144,7 +145,10 @@ export function subscriptionCreateOutcome(result: CheckoutResult): SubscriptionC
 	}
 	return {
 		flowType: "subscription_activation",
-		deploymentId: result.deployment_id ?? null,
+		deploymentId: acceptDeclarativeOperation(
+			{ deploymentId: result.deployment_id, operation: null },
+			"Wallet activation did not accept a deployment target.",
+		).deploymentId,
 		deployRequestId: result.deploy_request_id ?? null,
 	};
 }


### PR DESCRIPTION
Owner: stop writing several copies — improve reuse. The 'release on declarative 202-accept' logic was duplicated across billing-client (createDeployment still waited the full LRO; lifecycle/wallet each had their own), which is why the **free/Included-Basic deploy still hung the button** while wallet/lifecycle were already instant.

Convergence:
- One canonical helper `acceptDeclarativeOperation` — processes the accepted operation immediately (no `done` wait), extracts deployment id, clear error if missing.
- ALL interactive paths route through it: createDeployment (free Basic), acceptDeploymentMutation (start/stop/restart/delete + provider/model/locale Apply), by-request-id resolve, wallet activation.
- Lifecycle/settings cache projection unified in deployment-hooks (status derived from operation verb).
- free/wallet/checkout share ONE navigation model.
- `waitForOperation` remains ONLY for the checkout by-request flow that genuinely must wait; interactive create/lifecycle never call it.

Net -9 LOC (removed duplication). Contract confirmed: POST /v2/deployments 202 with required deploymentId. 24 focused tests + typecheck + lint. v1 + generated contract untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)