### PR TITLE
fix(web): navigate away after v2 agent deletion completes

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -745,8 +745,10 @@ type HostedApiStubOptions = {
 	cloudAgentErrors?: Record<string, { detail: string; status: number }>;
 	cloudAgentNotFoundIds?: readonly string[];
 	cloudAgentResponses?: Record<string, StubResponse[]>;
+	createDeploymentResponse?: StubResponse;
 	createDeploymentRequests?: Array<{ body: string; idempotencyKey: string | null }>;
 	deleteRequests?: string[];
+	completedDeleteIds?: Set<string>;
 	deployments?: readonly unknown[];
 	deploymentsResponse?: StubResponse;
 	fixPaymentRequests?: string[];
@@ -789,6 +791,8 @@ async function fulfillJson(route: Route, body: unknown, status = 200) {
 
 async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 	const deployments = options.deployments ?? [];
+	const acceptedDeleteIds = new Set<string>();
+	const completedDeleteIds = options.completedDeleteIds ?? new Set<string>();
 	const plans = options.plans ?? [];
 	let currentWallet = options.walletState ?? walletState;
 	const deploymentRequests = new Map<string, DeploymentMutationFixture>();
@@ -846,13 +850,27 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 				}
 				return fulfillJson(r, options.deploymentsResponse.body, options.deploymentsResponse.status);
 			}
-			return fulfillJson(r, deployments.map(readDeploymentFixture));
+			return fulfillJson(
+				r,
+				deployments
+					.filter(
+						(deployment) =>
+							!isDeploymentMutationFixture(deployment) || !completedDeleteIds.has(deployment.id),
+					)
+					.map((deployment) =>
+						isDeploymentMutationFixture(deployment) && acceptedDeleteIds.has(deployment.id)
+							? readDeploymentFixture({ ...deployment, status: "deleting" })
+							: readDeploymentFixture(deployment),
+					),
+			);
 		}
 		if (p === "/v2/deployments" && r.request().method() === "POST") {
 			options.createDeploymentRequests?.push({
 				body: r.request().postData() ?? "",
 				idempotencyKey: r.request().headers()["idempotency-key"] ?? null,
 			});
+			const response = options.createDeploymentResponse;
+			if (response) return fulfillJson(r, response.body, response.status);
 			return fulfillJson(
 				r,
 				completedDeploymentOperation(
@@ -1130,9 +1148,9 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 				(candidate): candidate is DeploymentMutationFixture =>
 					isDeploymentMutationFixture(candidate) && candidate.id === deploymentId,
 			);
-			return deployment
-				? fulfillJson(r, completedDeploymentOperation(deployment, "delete"), 202)
-				: fulfillJson(r, { detail: "Deployment not found" }, 404);
+			if (!deployment) return fulfillJson(r, { detail: "Deployment not found" }, 404);
+			acceptedDeleteIds.add(deployment.id);
+			return fulfillJson(r, completedDeploymentOperation(deployment, "delete"), 202);
 		}
 		return fulfillJson(r, {});
 	});
@@ -1287,15 +1305,37 @@ test("deploy wizard Select opens without browser errors", async ({ page }) => {
 
 test("free Basic Deploy submits the declarative create contract", async ({ page }) => {
 	const createDeploymentRequests: Array<{ body: string; idempotencyKey: string | null }> = [];
+	const convergencePollRequests: string[] = [];
+	page.on("request", (request) => {
+		const path = new URL(request.url()).pathname;
+		if (path.startsWith("/v2/operations/") || path.startsWith("/v2/deployments/by-request/")) {
+			convergencePollRequests.push(path);
+		}
+	});
+	const acceptedCreate = completedDeploymentOperation(
+		{
+			...includedBasicDeployment,
+			id: "hdep_included_created",
+			name: "Created included Basic",
+			status: "running",
+		},
+		"create",
+	);
 	await stubHostedApi(page, {
 		plans: [basicPlan],
 		deployments: [],
+		createDeploymentResponse: {
+			status: 202,
+			body: { ...acceptedCreate, done: false, response: null },
+		},
 		createDeploymentRequests,
 	});
 	await page.goto("/deploy");
 
 	await page.getByRole("button", { name: "Deploy agent" }).click();
 	await expect(page).toHaveURL(/\/agents\/hdep_included_created/);
+	expect(convergencePollRequests).toEqual([]);
+	await expect(page.getByText("Couldn’t deploy", { exact: true })).toHaveCount(0);
 	expect(createDeploymentRequests).toHaveLength(1);
 	expect(createDeploymentRequests[0]?.idempotencyKey).toMatch(/^deployment-create-/);
 	expect(JSON.parse(createDeploymentRequests[0]?.body ?? "{}")).toMatchObject({
@@ -1306,6 +1346,36 @@ test("free Basic Deploy submits the declarative create contract", async ({ page 
 			model: "gpt-5.6-luna",
 		},
 	});
+});
+
+test("accepted detail delete navigates after deployment membership disappears", async ({
+	page,
+}) => {
+	const deleteRequests: string[] = [];
+	const completedDeleteIds = new Set<string>();
+	await stubHostedApi(page, {
+		deployments: [includedBasicDeployment],
+		plans: [basicPlan, performancePlan],
+		completedDeleteIds,
+		deleteRequests,
+	});
+	await gotoHostedAgentSettings(page, "hdep_included", "Basic");
+
+	await page.locator("main").getByRole("button", { name: "Delete", exact: true }).click();
+	await page
+		.getByRole("alertdialog")
+		.getByRole("button", { name: "Delete compute", exact: true })
+		.click();
+
+	await expect.poll(() => deleteRequests).toEqual(["/v2/deployments/hdep_included"]);
+	await expect(page).toHaveURL(/\/agents\/hdep_included\/settings/);
+	await expect(
+		page.locator("main").getByRole("button", { name: "Delete", exact: true }),
+	).toBeDisabled();
+
+	completedDeleteIds.add("hdep_included");
+	await expect(page).toHaveURL(/\/agents\/?$/);
+	await expect(page.getByText("Agent deleted", { exact: true })).toBeVisible();
 });
 
 test("managed model picker lists the curated catalog without Custom or image models", async ({

--- a/apps/web/src/hosted/agents/agent-home.tsx
+++ b/apps/web/src/hosted/agents/agent-home.tsx
@@ -2,7 +2,8 @@
 
 import { Link, useLocation, useRouter } from "@tanstack/react-router";
 import { ChevronRight, RefreshCw } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { AgentIcon } from "@/components/dashboard/agent-icon";
 import {
@@ -23,6 +24,7 @@ import { type AgentDeploymentMatch, useAgentDeployment } from "@/hosted/agents/d
 import { HostedAgentDetail } from "@/hosted/agents/hosted-agent-detail";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { deploymentStatusLabel, parseDeploymentStatus } from "@/hosted/deployment-status";
+import { userInitiatedDeploymentDeleteCompleted } from "@/hosted/hosted-agent-resolution";
 import { defaultDeploymentRuntime, isHostedRuntime } from "@/hosted/runtimes";
 import {
 	AGENT_DEPLOYMENT_SELECTOR_QUERY_KEY,
@@ -36,6 +38,12 @@ import { cn } from "@/lib/utils";
 
 const UNRESOLVED_HOSTED_AGENT_REFETCH_INTERVAL_MS = 5_000;
 const UNRESOLVED_HOSTED_AGENT_MAX_REFETCH_ATTEMPTS = 24;
+
+type UserDeleteNavigationIntent = {
+	deploymentId: string;
+	environmentId: string;
+	deploymentSelector: string | null;
+};
 
 /**
  * Agent home for hosted builds. An agent backed by a hosted deployment renders
@@ -57,6 +65,7 @@ export function AgentHome({
 	const deploymentSelector = agentDeploymentSelector(searchParams);
 	const {
 		deployment,
+		inventoryDeployments,
 		environmentId: resolvedEnvId,
 		matchedRuntime,
 		ambiguousMatches,
@@ -75,6 +84,16 @@ export function AgentHome({
 	const shouldAutoRefetchUnresolvedHostedAgent =
 		unresolvedHostedAgent && (requestedFromCloudRedirect || isCloudEnvironmentId);
 	const isFetchingRef = useRef(isFetching);
+	const [userDeleteIntent, setUserDeleteIntent] = useState<UserDeleteNavigationIntent | null>(null);
+	const deleteIntentStillOwnsRoute =
+		userDeleteIntent?.environmentId === environmentId &&
+		(userDeleteIntent.deploymentSelector === deploymentSelector ||
+			(userDeleteIntent.deploymentSelector === null &&
+				deploymentSelector?.toLowerCase() === userDeleteIntent.deploymentId.toLowerCase()));
+	const deletedDeploymentGone = userInitiatedDeploymentDeleteCompleted(
+		inventoryDeployments,
+		deleteIntentStillOwnsRoute ? userDeleteIntent.deploymentId : null,
+	);
 
 	// Canonicalize a resolved hosted route with its deployment selector before
 	// Stop removes the env mapping. The selector is then sufficient to retain
@@ -93,6 +112,13 @@ export function AgentHome({
 	useEffect(() => {
 		isFetchingRef.current = isFetching;
 	}, [isFetching]);
+
+	useEffect(() => {
+		if (!deletedDeploymentGone) return;
+		setUserDeleteIntent(null);
+		toast.success("Agent deleted");
+		void router.navigate({ href: "/agents", replace: true });
+	}, [deletedDeploymentGone, router]);
 
 	useEffect(() => {
 		if (!shouldAutoRefetchUnresolvedHostedAgent || typeof window === "undefined") return;
@@ -191,6 +217,9 @@ export function AgentHome({
 				deployment={deployment}
 				runtime={runtime}
 				section={section}
+				onDeleteAccepted={(deploymentId) =>
+					setUserDeleteIntent({ deploymentId, environmentId, deploymentSelector })
+				}
 			/>
 		);
 	}

--- a/apps/web/src/hosted/agents/deployment-hooks.ts
+++ b/apps/web/src/hosted/agents/deployment-hooks.ts
@@ -130,6 +130,7 @@ export function useAgentDeployment(environmentId: string, deploymentSelector?: s
 
 	return {
 		deployment: match?.deployment ?? null,
+		inventoryDeployments: inventory.deployments,
 		matchedRuntime: match?.runtime ?? null,
 		ambiguousMatches: resolution.ambiguousMatches,
 		environmentId: resolvedEnvId,

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -330,8 +330,17 @@ function RestartComputeAction({
 	);
 }
 
-function DeleteComputeAction({ deployment }: { deployment: HostedDeployment }) {
-	const router = useRouter();
+function DeleteComputeAction({
+	deployment,
+	onDeleteAccepted,
+	variant = "destructive",
+	className,
+}: {
+	deployment: HostedDeployment;
+	onDeleteAccepted: (deploymentId: string) => void;
+	variant?: React.ComponentProps<typeof Button>["variant"];
+	className?: string;
+}) {
 	const deleteDeployment = useDeleteDeployment();
 	const runAction = useActionLock();
 	const status = parseDeploymentStatus(deployment.resource.status.summary_state);
@@ -348,14 +357,15 @@ function DeleteComputeAction({ deployment }: { deployment: HostedDeployment }) {
 			onConfirm={() =>
 				runAction(async () => {
 					await deleteDeployment.mutateAsync(deployment.resource.id);
-					void router.navigate({ href: "/" });
+					onDeleteAccepted(deployment.resource.id);
 				})
 			}
 		>
 			<Button
 				type="button"
-				variant="destructive"
+				variant={variant}
 				size="sm"
+				className={className}
 				disabled={deleteDeployment.isPending || !canDelete}
 			>
 				{deleteDeployment.isPending ? <Spinner /> : <Trash2 />}
@@ -419,11 +429,13 @@ export function HostedAgentDetail({
 	deployment,
 	runtime,
 	section = "overview",
+	onDeleteAccepted,
 }: {
 	environmentId: string;
 	deployment: HostedDeployment;
 	runtime: Runtime;
 	section?: AgentSectionId;
+	onDeleteAccepted: (deploymentId: string) => void;
 }) {
 	const api = useApi();
 	const router = useRouter();
@@ -556,6 +568,7 @@ export function HostedAgentDetail({
 							agent={isCloudEnvId(environmentId) ? agent : null}
 							isPerformance={isPerformance}
 							showDeploymentActions={projection.status !== "resolved" || !deploymentRunning}
+							onDeleteAccepted={onDeleteAccepted}
 							projectionAvailable={projection.status === "resolved"}
 							sessions={sessions.data?.items ?? []}
 							sessionsLoading={sessions.isLoading}
@@ -609,6 +622,7 @@ export function HostedAgentDetail({
 							deployment={deployment}
 							runtime={runtime}
 							projectionAvailable={projection.status === "resolved"}
+							onDeleteAccepted={onDeleteAccepted}
 						/>
 					) : null}
 				</div>
@@ -894,6 +908,7 @@ function OverviewTab({
 	agent,
 	isPerformance,
 	showDeploymentActions,
+	onDeleteAccepted,
 	projectionAvailable,
 	sessions,
 	sessionsLoading,
@@ -905,6 +920,7 @@ function OverviewTab({
 	agent: components["schemas"]["AgentResponse"] | null | undefined;
 	isPerformance: boolean;
 	showDeploymentActions: boolean;
+	onDeleteAccepted: (deploymentId: string) => void;
 	projectionAvailable: boolean;
 	sessions: SessionListItem[];
 	sessionsLoading: boolean;
@@ -970,12 +986,20 @@ function OverviewTab({
 					/>
 				)}
 			</div>
-			{showDeploymentActions ? <OverviewDeploymentActions deployment={deployment} /> : null}
+			{showDeploymentActions ? (
+				<OverviewDeploymentActions deployment={deployment} onDeleteAccepted={onDeleteAccepted} />
+			) : null}
 		</div>
 	);
 }
 
-function OverviewDeploymentActions({ deployment }: { deployment: HostedDeployment }) {
+function OverviewDeploymentActions({
+	deployment,
+	onDeleteAccepted,
+}: {
+	deployment: HostedDeployment;
+	onDeleteAccepted: (deploymentId: string) => void;
+}) {
 	const status = parseDeploymentStatus(deployment.resource.status.summary_state);
 	const failed = status.kind === "failed";
 	return (
@@ -990,7 +1014,7 @@ function OverviewDeploymentActions({ deployment }: { deployment: HostedDeploymen
 				{canStartDeployment(status) && !failed && status.kind !== "stopped" ? (
 					<StartComputeAction deployment={deployment} />
 				) : null}
-				<DeleteComputeAction deployment={deployment} />
+				<DeleteComputeAction deployment={deployment} onDeleteAccepted={onDeleteAccepted} />
 			</div>
 		</SettingsSection>
 	);
@@ -2237,11 +2261,13 @@ function HostedAgentSettingsTab({
 	deployment,
 	runtime,
 	projectionAvailable,
+	onDeleteAccepted,
 }: {
 	environmentId: string;
 	deployment: HostedDeployment;
 	runtime: Runtime;
 	projectionAvailable: boolean;
+	onDeleteAccepted: (deploymentId: string) => void;
 }) {
 	const formatName = useCallback((name: string) => deploymentDisplayName(name, runtime), [runtime]);
 	return (
@@ -2252,7 +2278,7 @@ function HostedAgentSettingsTab({
 				<ProjectionDependentUnavailable label="Profile settings" />
 			)}
 			<LanguageTimezoneSettingsSection deployment={deployment} runtime={runtime} />
-			<ComputeSettingsSections deployment={deployment} />
+			<ComputeSettingsSections deployment={deployment} onDeleteAccepted={onDeleteAccepted} />
 		</div>
 	);
 }
@@ -2346,12 +2372,17 @@ function LanguageTimezoneSettingsSection({
 	);
 }
 
-function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment }) {
+function ComputeSettingsSections({
+	deployment,
+	onDeleteAccepted,
+}: {
+	deployment: HostedDeployment;
+	onDeleteAccepted: (deploymentId: string) => void;
+}) {
 	const router = useRouter();
 	const searchStr = useLocation({ select: (location) => location.searchStr });
 	const hostedAccess = useHostedProductAccess();
 	const lifecycle = useDeploymentLifecycle();
-	const del = useDeleteDeployment();
 	const plans = usePlans();
 	const refreshCheckoutReturn = useCheckoutReturnRefresh();
 	const quotePlanChange = useQuotePlanChange();
@@ -2371,7 +2402,6 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 	const canStop = canStopDeployment(deploymentStatus);
 	const canStart = canStartDeployment(deploymentStatus);
 	const canRestart = canRestartDeployment(deploymentStatus);
-	const canDelete = canDeleteDeployment(deploymentStatus);
 	const primaryLifecycleAction: "stop" | "start" =
 		canStop ||
 		deploymentStatus.kind === "stopping" ||
@@ -2630,11 +2660,6 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 
 	async function runLifecycleAction(action: "restart" | "stop" | "start") {
 		await lifecycle.mutateAsync({ id: deployment.resource.id, action });
-	}
-
-	async function deleteCompute() {
-		await del.mutateAsync(deployment.resource.id);
-		void router.navigate({ href: "/" });
 	}
 
 	return (
@@ -2926,26 +2951,12 @@ function ComputeSettingsSections({ deployment }: { deployment: HostedDeployment 
 							Tears down this deployment and its agent runtime. This can’t be undone.
 						</p>
 					</div>
-					<ConfirmAction
-						title={`Delete ${deploymentDisplayName(
-							deployment.resource.spec.name,
-							deployment.resource.spec.runtime,
-						)}?`}
-						description={<p>The hosted agent is torn down. This can’t be undone.</p>}
-						confirmLabel="Delete compute"
-						destructive
-						onConfirm={() => runAction(deleteCompute)}
-					>
-						<Button
-							variant="outline"
-							size="sm"
-							className="text-destructive"
-							disabled={del.isPending || !canDelete}
-						>
-							<Trash2 className="size-3.5" />
-							Delete
-						</Button>
-					</ConfirmAction>
+					<DeleteComputeAction
+						deployment={deployment}
+						onDeleteAccepted={onDeleteAccepted}
+						variant="outline"
+						className="text-destructive"
+					/>
 				</div>
 			</SettingsSection>
 		</div>

--- a/apps/web/src/hosted/hosted-agent-resolution.test.ts
+++ b/apps/web/src/hosted/hosted-agent-resolution.test.ts
@@ -8,6 +8,7 @@ import {
 	resolveAgentDeployment,
 	resolveHostedAgentProjection,
 	resolveHostedInventory,
+	userInitiatedDeploymentDeleteCompleted,
 } from "@/hosted/hosted-agent-resolution";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 import { ApiError } from "@/lib/api-errors";
@@ -103,6 +104,20 @@ describe("hosted inventory resolution matrix", () => {
 });
 
 describe("hosted detail projection resolution", () => {
+	test("redirects only when the user-deleted deployment leaves authoritative membership", () => {
+		const deleting = deployment("deleting", "hdep_user_deleted");
+		const failed = deployment("failed", "hdep_user_deleted");
+		const deleted = deployment("deleted", "hdep_user_deleted");
+		const unrelated = deployment("running", "hdep_unrelated");
+
+		expect(userInitiatedDeploymentDeleteCompleted([deleting], "hdep_user_deleted")).toBe(false);
+		expect(userInitiatedDeploymentDeleteCompleted([failed], "hdep_user_deleted")).toBe(false);
+		expect(userInitiatedDeploymentDeleteCompleted([deleted], "hdep_user_deleted")).toBe(true);
+		expect(userInitiatedDeploymentDeleteCompleted([unrelated], "hdep_user_deleted")).toBe(true);
+		expect(userInitiatedDeploymentDeleteCompleted([], null)).toBe(false);
+		expect(userInitiatedDeploymentDeleteCompleted(null, "hdep_user_deleted")).toBe(false);
+	});
+
 	test("keeps a selected stopped deployment addressable after its projection is removed", () => {
 		const stopped = hostedDeploymentFixture({
 			id: "hdep_stopped",

--- a/apps/web/src/hosted/hosted-agent-resolution.ts
+++ b/apps/web/src/hosted/hosted-agent-resolution.ts
@@ -47,6 +47,23 @@ export function hostedDeploymentMembers(
 	return deployments.filter(isHostedDeploymentMember);
 }
 
+/**
+ * A detail-page delete is complete only after the accepted deployment leaves
+ * authoritative inventory membership. Cloud-agent projection misses are not
+ * part of this decision and therefore cannot redirect an unrelated detail.
+ */
+export function userInitiatedDeploymentDeleteCompleted(
+	deployments: readonly HostedDeployment[] | null,
+	deploymentId: string | null,
+): boolean {
+	if (!deploymentId || deployments === null) return false;
+	const target = deploymentId.toLowerCase();
+	return !deployments.some(
+		(deployment) =>
+			isHostedDeploymentMember(deployment) && deployment.resource.id.toLowerCase() === target,
+	);
+}
+
 /** One claimed-id set shared by list deduplication and ownership chrome. */
 export function claimedEnvIdsFromDeployments(
 	deployments: readonly HostedDeployment[],


### PR DESCRIPTION
e2e round-1 finding: after a delete completed, the agent-detail page stayed on the old route showing 'Cloud agent not found' indefinitely.

- After a user-initiated delete, the page keeps the `deleting` state; only when the deleted deployment leaves the authoritative inventory / becomes `deleted` does it navigate to `/agents` with an 'Agent deleted' toast. Transient projection 404 / request failure / switching to another agent do NOT mis-navigate.
- Merged the Overview and Settings delete entrypoints into one delete flow (removed two immediate go-home bypasses).
- Also confirmed #471 fully fixed the free-Basic deploy false-failure (POST → acceptDeclarativeOperation → immediate nav on the returned id, no by-request/LRO poll).

31 tests + 2 Playwright + typecheck + lint. v1 untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)