### PR TITLE
fix(v2 web): converge model/provider display + copy to shared SSOT helpers

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { isFirstPartyManagedAiProvider } from "@clawdi/shared";
 import type { components } from "@clawdi/shared/api";
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useLocation, useRouter } from "@tanstack/react-router";
@@ -157,7 +156,7 @@ import {
 	runtimeDisplayName,
 } from "@/hosted/runtimes";
 import { hostedRuntimeStatusView } from "@/hosted/use-hosted-agent-tiles";
-import { useAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks";
+import { useUserAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import { AuthBadge, ProviderTypeChip } from "@/hosted/v2/ai-providers/ai-providers-ui";
 import { authCardLabel } from "@/hosted/v2/ai-providers/auth-card-label";
 import {
@@ -166,12 +165,17 @@ import {
 	isManagedProviderId,
 	MANAGED_AI_CHOICE,
 	MANAGED_PROVIDER_ID,
+	MANAGED_PROVIDER_LABEL,
+	modelBindingDisplayName,
 	modelIdsForProvider,
+	modelOptionsForProvider,
 	normalizeSelectedProviderIds,
 	primaryModelProviderId,
 	primaryModelRef,
 	primaryModelValue,
+	providerCatalogDescription,
 	providerChoiceFromRef,
+	providerDisplayLabel,
 	providerRefFromChoice,
 } from "@/hosted/v2/ai-providers/model-binding";
 import { ModelBindingPicker } from "@/hosted/v2/ai-providers/model-binding-picker";
@@ -203,7 +207,7 @@ import {
 } from "@/lib/agent-routes";
 import { toastApiError, unwrap, useApi } from "@/lib/api";
 import type { SessionListItem } from "@/lib/api-schemas";
-import { formatMemoryMib, formatModelLabel, formatShortDate } from "@/lib/format";
+import { formatMemoryMib, formatShortDate } from "@/lib/format";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { sessionListQueryOptions } from "@/lib/session-queries";
 import { cn } from "@/lib/utils";
@@ -932,7 +936,22 @@ function OverviewTab({
 	};
 }) {
 	const spec = deployment.resource.spec;
-	const model = spec.runtime_configuration.primary_model?.model || "Managed default";
+	const providers = useUserAiProviders();
+	const managedModelCatalog = useManagedModelCatalog();
+	const primaryModel = spec.runtime_configuration.primary_model;
+	const bindingProvider =
+		spec.runtime_configuration.providers.find(
+			(provider) => provider.provider_id === primaryModelProviderId(primaryModel),
+		) ?? spec.runtime_configuration.providers[0];
+	const model = modelBindingDisplayName(
+		primaryModel,
+		runtimeAiProviderAuthKind(deployment) ?? bindingProvider?.auth_kind,
+		modelOptionsForProvider(
+			primaryModelProviderId(primaryModel) ?? MANAGED_PROVIDER_ID,
+			providers.data ?? [],
+			managedModelCatalog.data?.models ?? [],
+		),
+	);
 	const deploymentStatus = parseDeploymentStatus(deployment.resource.status.summary_state);
 	const deploymentRunning = isRunningStatus(deploymentStatus);
 	const sessionsEmptyMessage = deploymentRunning
@@ -1583,13 +1602,6 @@ function agentChoiceFromProviderRef(
 	return unresolvedProviderChoice(providerRef);
 }
 
-function providerCatalogDescription(provider: AiProvider): string {
-	const count = provider.models?.length ?? 0;
-	if (count === 0) return provider.base_url.replace(/^https?:\/\//, "");
-	if (count === 1) return provider.models?.[0]?.id ?? provider.base_url;
-	return `${count} catalog models`;
-}
-
 function AiProviderTab({
 	deployment,
 	runtime,
@@ -1597,18 +1609,14 @@ function AiProviderTab({
 	deployment: HostedDeployment;
 	runtime: Runtime;
 }) {
-	const providers = useAiProviders();
+	const providers = useUserAiProviders();
 	const managedModelCatalog = useManagedModelCatalog();
 	const updateDeployment = useUpdateDeployment();
 	const updateInProgress =
 		parseDeploymentStatus(deployment.resource.status.summary_state).kind === "updating";
 	const runtimeConfiguration = deployment.resource.spec.runtime_configuration;
-	const list = providers.data?.providers ?? [];
+	const list = providers.data ?? [];
 	const managedModels = managedModelCatalog.data?.models ?? [];
-	const customProviders = useMemo(
-		() => list.filter((provider) => !isFirstPartyManagedAiProvider(provider)),
-		[list],
-	);
 	// Selected-runtime binding: the deployment owns one runtime in the v2 model.
 	const configuredProviders = runtimeConfiguration.providers;
 	const configuredPrimaryModel = runtimeConfiguration.primary_model;
@@ -1805,10 +1813,8 @@ function AiProviderTab({
 			toast.error("Primary model required");
 			return;
 		}
-		const primaryProvider = customProviders.find(
-			(provider) => provider.provider_id === primaryProviderChoice,
-		);
-		const selectedCustomProviders = customProviders.filter((provider) =>
+		const primaryProvider = list.find((provider) => provider.provider_id === primaryProviderChoice);
+		const selectedCustomProviders = list.filter((provider) =>
 			normalizedChoices.includes(provider.provider_id),
 		);
 		const authKind = primaryProvider ? providerAuthKind(primaryProvider) : "managed";
@@ -1863,7 +1869,7 @@ function AiProviderTab({
 					)}
 				>
 					<div className="flex items-center justify-between gap-2">
-						<span className="text-sm font-medium">Managed by Clawdi</span>
+						<span className="text-sm font-medium">{MANAGED_PROVIDER_LABEL}</span>
 						{bindingMode === "configured" && primaryProviderChoice === MANAGED_AI_CHOICE ? (
 							<Badge variant="secondary">Primary</Badge>
 						) : bindingMode === "configured" && selectedProviders.includes(MANAGED_AI_CHOICE) ? (
@@ -1892,12 +1898,12 @@ function AiProviderTab({
 								</div>
 								<p className="mt-0.5 text-sm text-muted-foreground">
 									This runtime is bound to {unresolvedProviderRef(choice)}, but that provider could
-									not be loaded. Choose Managed by Clawdi to replace it.
+									not be loaded. Choose {MANAGED_PROVIDER_LABEL} to replace it.
 								</p>
 							</button>
 						))
 					: null}
-				{customProviders.map((p) => {
+				{list.map((p) => {
 					const selected =
 						bindingMode === "configured" && selectedProviders.includes(p.provider_id);
 					return (
@@ -1910,7 +1916,7 @@ function AiProviderTab({
 							<ProviderTypeChip type={p.type} />
 							<span className="min-w-0 flex-1">
 								<span className="flex items-center gap-2">
-									<span className="truncate text-sm font-medium">{p.label ?? p.provider_id}</span>
+									<span className="truncate text-sm font-medium">{providerDisplayLabel(p)}</span>
 									<AuthBadge auth={p.auth} />
 								</span>
 								<span className="block text-xs text-muted-foreground">
@@ -1951,14 +1957,13 @@ function AiProviderTab({
 					managedModelsError={managedModelCatalog.error}
 					managedModelsErrorNormalizer={billingErrorNormalizer}
 					onManagedModelsRetry={() => void managedModelCatalog.refetch()}
-					customProviders={customProviders}
+					customProviders={list}
 					additionalProviderItems={selectedProviderChoices
 						.filter(isUnresolvedProviderChoice)
 						.map((choice) => ({ value: choice, label: unresolvedProviderRef(choice) }))}
 					selectedProviderChoices={selectedProviderChoices}
 					primaryProviderChoice={primaryProviderChoice}
 					primaryModel={primaryModel}
-					formatModel={formatModelLabel}
 					onPrimaryProviderChange={setPrimaryProvider}
 					onPrimaryModelChange={setPrimaryModel}
 				/>

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { isFirstPartyManagedAiProvider } from "@clawdi/shared";
 import { useLocation, useRouter } from "@tanstack/react-router";
 import {
 	CalendarClock,
@@ -137,7 +136,7 @@ import { topUpAmountCentsForUsdShortfall } from "@/hosted/billing/wallet/top-up-
 import { walletDebitShortfallUsd } from "@/hosted/billing/wallet/wallet-debit-summary";
 import { type HostedRuntime, runtimeBlurb, runtimeDisplayName } from "@/hosted/runtimes";
 import { AddProviderDialog } from "@/hosted/v2/ai-providers/add-provider-dialog";
-import { useAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks";
+import { useUserAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import { AuthBadge, ProviderTypeChip } from "@/hosted/v2/ai-providers/ai-providers-ui";
 import { authCardLabel } from "@/hosted/v2/ai-providers/auth-card-label";
 import {
@@ -145,9 +144,14 @@ import {
 	firstModelForProvider,
 	MANAGED_AI_CHOICE,
 	MANAGED_PROVIDER_ID,
+	MANAGED_PROVIDER_LABEL,
+	modelDisplayName,
 	modelIdsForProvider,
+	modelOptionsForProvider,
 	normalizeSelectedProviderIds,
 	primaryModelRef,
+	providerCatalogDescription,
+	providerDisplayLabel,
 	providerRefFromChoice,
 } from "@/hosted/v2/ai-providers/model-binding";
 import { ModelBindingPicker } from "@/hosted/v2/ai-providers/model-binding-picker";
@@ -388,7 +392,7 @@ export function DeployWizard() {
 	const plans = usePlans();
 	const deployments = useHostedDeployments();
 	const managedModelCatalog = useManagedModelCatalog();
-	const aiProviders = useAiProviders();
+	const aiProviders = useUserAiProviders();
 	const channels = useChannels();
 	const createSubscription = useCreateSubscription();
 	const billingClient = useBillingClient();
@@ -508,13 +512,7 @@ export function DeployWizard() {
 	const walletInsufficient = walletShortfallUsd !== null;
 	const basicUnavailable = basicSelection.mode === "unavailable";
 
-	const providerList = useMemo(
-		() =>
-			(aiProviders.data?.providers ?? []).filter(
-				(provider) => !isFirstPartyManagedAiProvider(provider),
-			),
-		[aiProviders.data?.providers],
-	);
+	const providerList = aiProviders.data ?? [];
 	const managedModels = managedModelCatalog.data?.models ?? [];
 	const channelList = channels.data ?? [];
 	const computePlanReady =
@@ -642,28 +640,25 @@ export function DeployWizard() {
 		if (primaryModel.trim()) return;
 		const fallback = firstModelForProvider(
 			primaryProviderChoice,
-			aiProviders.data?.providers ?? [],
+			providerList,
 			managedModelCatalog.data?.models ?? [],
 		);
 		if (fallback) setPrimaryModel(fallback);
-	}, [
-		aiProviders.data?.providers,
-		managedModelCatalog.data?.models,
-		primaryModel,
-		primaryProviderChoice,
-	]);
+	}, [managedModelCatalog.data?.models, primaryModel, primaryProviderChoice, providerList]);
 
 	function setComputeTier(next: Compute) {
 		setCompute(next);
 	}
 
-	function providerUnavailable(description = "Refresh providers or choose Managed by Clawdi.") {
+	function providerUnavailable(
+		description = `Refresh providers or choose ${MANAGED_PROVIDER_LABEL}.`,
+	) {
 		toast.error("Provider unavailable", { description });
 	}
 
 	function setPrimaryProvider(choice: string) {
 		setAiAccessMode("configured");
-		const providers = aiProviders.data?.providers ?? [];
+		const providers = providerList;
 		const managedModels = managedModelCatalog.data?.models ?? [];
 		const previousCatalog = modelIdsForProvider(primaryProviderChoice, providers, managedModels);
 		const nextCatalog = modelIdsForProvider(choice, providers, managedModels);
@@ -1074,12 +1069,28 @@ export function DeployWizard() {
 		aiAccessMode === "configured"
 			? normalizeSelectedProviderIds(aiProviderChoices, primaryProviderChoice).length
 			: 0;
+	const primaryProvider = providerList.find(
+		(provider) => provider.provider_id === primaryProviderChoice,
+	);
 	const aiSummary =
 		aiAccessMode === "unmanaged"
 			? authCardLabel("unmanaged")
-			: `${providerChoiceLabel(primaryProviderChoice, providerList)}${
-					selectedProviderCount > 1 ? ` +${selectedProviderCount - 1}` : ""
-				}`;
+			: [
+					`${providerDisplayLabel(
+						primaryProvider ??
+							(primaryProviderChoice === MANAGED_AI_CHOICE
+								? MANAGED_PROVIDER_ID
+								: primaryProviderChoice),
+					)}${selectedProviderCount > 1 ? ` +${selectedProviderCount - 1}` : ""}`,
+					primaryModel
+						? modelDisplayName(
+								primaryModel,
+								modelOptionsForProvider(primaryProviderChoice, providerList, managedModels),
+							)
+						: null,
+				]
+					.filter(Boolean)
+					.join(" · ");
 	const runtimeSummary = runtimeDisplayName(runtime);
 	const summaryLine = [
 		`${compute === "performance" ? "Performance" : "Basic"} compute`,
@@ -1188,7 +1199,7 @@ export function DeployWizard() {
 									<Sparkles />
 								</IconChip>
 							}
-							title="Managed by Clawdi"
+							title={MANAGED_PROVIDER_LABEL}
 							description="Managed-AI usage paid directly from your Wallet."
 							badge={
 								<Badge variant="secondary">
@@ -1218,7 +1229,7 @@ export function DeployWizard() {
 								}
 								onClick={() => toggleAiProviderChoice(provider.provider_id)}
 								icon={<ProviderTypeChip type={provider.type} />}
-								title={provider.label ?? provider.provider_id}
+								title={providerDisplayLabel(provider)}
 								description={providerCatalogDescription(provider)}
 								badge={
 									primaryProviderChoice === provider.provider_id ? (
@@ -1244,7 +1255,7 @@ export function DeployWizard() {
 						<ModelBindingPicker
 							idPrefix="deploy"
 							className="mt-4"
-							providers={aiProviders.data?.providers ?? []}
+							providers={providerList}
 							managedModels={managedModels}
 							managedModelsLoading={managedModels.length === 0 && managedModelCatalog.isFetching}
 							managedModelsError={managedModelCatalog.error}
@@ -1628,21 +1639,4 @@ export function DeployWizard() {
 			/>
 		</div>
 	);
-}
-
-function providerChoiceLabel(choice: string, providers: readonly AiProvider[]): string {
-	if (choice === MANAGED_AI_CHOICE) return "Managed AI";
-	const provider = providers.find((item) => item.provider_id === choice);
-	return provider?.label ?? provider?.provider_id ?? "Your provider";
-}
-
-function providerCatalogDescription(provider: AiProvider): string {
-	const count = provider.models?.length ?? 0;
-	if (count === 0) return providerTypeLabelFallback(provider);
-	if (count === 1) return provider.models?.[0]?.id ?? providerTypeLabelFallback(provider);
-	return `${count} catalog models`;
-}
-
-function providerTypeLabelFallback(provider: AiProvider): string {
-	return provider.base_url.replace(/^https?:\/\//, "");
 }

--- a/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
+++ b/apps/web/src/hosted/billing/subscription/plan-comparison.tsx
@@ -20,12 +20,14 @@ import { billingTermSuffix, formatCents, formatUsdExact } from "@/hosted/billing
 import { usePlans } from "@/hosted/billing/hooks";
 import {
 	explicitPlanOffers,
+	largestSignupGrantUsd,
 	planOffers,
 	resolveBasicPlan,
 	resolvePerformancePlan,
 	selectExplicitOfferForTerm,
 	selectOfferForTerm,
 } from "@/hosted/billing/subscription/subscription-utils";
+import { TOPUP_AMOUNT_RANGE_LABEL } from "@/hosted/billing/wallet/wallet-constants";
 import { settingsQueryHref } from "@/lib/settings-routes";
 
 function partitionPlans(plans: Plan[]): { basic?: Plan; performance?: Plan } {
@@ -87,13 +89,7 @@ export function PlanComparison({
 
 	if (!plansQuery.data) return null;
 
-	const signupGrantUsd =
-		[basic?.signup_grant_usd, performance?.signup_grant_usd]
-			.filter((value): value is string => value !== undefined)
-			.reduce<string | null>(
-				(largest, value) => (largest === null || Number(value) > Number(largest) ? value : largest),
-				null,
-			) ?? "0";
+	const signupGrantUsd = largestSignupGrantUsd(plansQuery.data);
 	const basicOffers = basic ? explicitPlanOffers(basic) : [];
 	const basicResources = basic;
 	const performanceOffers = performance ? planOffers(performance) : [];
@@ -158,7 +154,7 @@ export function PlanComparison({
 							<FeatureRow>Paid additional Basic agents</FeatureRow>
 							<FeatureRow>Single agent engine (OpenClaw or Hermes)</FeatureRow>
 							<FeatureRow>BYOK avoids managed-AI usage charges</FeatureRow>
-							{Number(signupGrantUsd) > 0 ? (
+							{signupGrantUsd ? (
 								<FeatureRow>{formatUsdExact(signupGrantUsd)} welcome balance on signup</FeatureRow>
 							) : null}
 						</ul>
@@ -270,7 +266,7 @@ export function PlanComparison({
 					<CardContent className="flex-1">
 						<ul className="space-y-2">
 							<FeatureRow>Usage billed directly in USD</FeatureRow>
-							<FeatureRow>Top up any amount, $10–$2,000</FeatureRow>
+							<FeatureRow>Whole-dollar top-ups from {TOPUP_AMOUNT_RANGE_LABEL}</FeatureRow>
 							<FeatureRow>Optional auto-reload so agents never stall</FeatureRow>
 							<FeatureRow>
 								<span className="font-medium">No managed-AI charge with BYOK</span> — your own key

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.test.ts
@@ -13,6 +13,7 @@ import {
 	isComputeSubscriptionRenewing,
 	isComputeSubscriptionTermChangeable,
 	isIncludedBasicSubscription,
+	largestSignupGrantUsd,
 	pendingComputePlanSlug,
 	pendingPlanScheduleCopy,
 	resolveBasicPlan,
@@ -97,6 +98,30 @@ describe("compute plan resolvers", () => {
 
 		expect(resolveBasicPlan([otherPaid, basic])).toBe(basic);
 		expect(resolveBasicPlan([otherPaid])).toBeUndefined();
+	});
+});
+
+describe("largestSignupGrantUsd", () => {
+	test("returns the largest positive configured grant", () => {
+		expect(
+			largestSignupGrantUsd([
+				plan({ slug: COMPUTE_BASIC_SLUG, price_cents: 0, signup_grant_usd: "5.00" }),
+				plan({
+					slug: COMPUTE_PERFORMANCE_SLUG,
+					price_cents: 1900,
+					signup_grant_usd: "12.50",
+				}),
+			]),
+		).toBe("12.50");
+	});
+
+	test("returns null when no positive grant is configured", () => {
+		expect(largestSignupGrantUsd(undefined)).toBeNull();
+		expect(
+			largestSignupGrantUsd([
+				plan({ slug: COMPUTE_BASIC_SLUG, price_cents: 0, signup_grant_usd: "0" }),
+			]),
+		).toBeNull();
 	});
 });
 

--- a/apps/web/src/hosted/billing/subscription/subscription-utils.ts
+++ b/apps/web/src/hosted/billing/subscription/subscription-utils.ts
@@ -43,6 +43,14 @@ export function resolvePerformancePlan(plans: Plan[] | undefined): Plan | undefi
 	return plans?.find((plan) => plan.slug === COMPUTE_PERFORMANCE_SLUG);
 }
 
+export function largestSignupGrantUsd(plans: readonly Plan[] | undefined): string | null {
+	return (plans ?? []).reduce<string | null>((largest, plan) => {
+		const grant = Number(plan.signup_grant_usd);
+		if (!Number.isFinite(grant) || grant <= 0) return largest;
+		return largest === null || grant > Number(largest) ? plan.signup_grant_usd : largest;
+	}, null);
+}
+
 export function isBasicCompute(planSlug: string | null | undefined): boolean {
 	return planSlug === COMPUTE_BASIC_SLUG;
 }

--- a/apps/web/src/hosted/billing/subscription/welcome-wallet-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/welcome-wallet-card.tsx
@@ -7,10 +7,10 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
-import type { Plan } from "@/hosted/billing/contracts";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { formatUsdExact } from "@/hosted/billing/format";
 import { useHostedDeployments, usePlans, useWallet, useWalletLedger } from "@/hosted/billing/hooks";
+import { largestSignupGrantUsd } from "@/hosted/billing/subscription/subscription-utils";
 
 /**
  * Pure-$0 welcome + signup-grant feedback.
@@ -20,14 +20,6 @@ import { useHostedDeployments, usePlans, useWallet, useWalletLedger } from "@/ho
  * and points them at the deploy wizard. Returns null once the user has an
  * agent. Read failures render a retry action instead of hiding onboarding.
  */
-function signupGrantUsd(plans: Plan[] | undefined): string {
-	return (plans ?? []).reduce(
-		(largest, plan) =>
-			Number(plan.signup_grant_usd) > Number(largest) ? plan.signup_grant_usd : largest,
-		"0",
-	);
-}
-
 export function WelcomeWalletCard() {
 	const wallet = useWallet();
 	const ledger = useWalletLedger(50);
@@ -73,10 +65,10 @@ export function WelcomeWalletCard() {
 	const grant = ledger.data?.items.find((e) => e.operation === "grant_signup");
 	const grantApplied = grant?.status === "applied";
 	const grantPending = grant?.status === "pending";
-	const configuredSignupGrantUsd = signupGrantUsd(plans.data);
+	const configuredSignupGrantUsd = largestSignupGrantUsd(plans.data);
 	const grantAmount = grant
 		? formatUsdExact(grant.amount_usd.trim().replace(/^[+-]/, ""))
-		: Number(configuredSignupGrantUsd) > 0
+		: configuredSignupGrantUsd
 			? formatUsdExact(configuredSignupGrantUsd)
 			: null;
 

--- a/apps/web/src/hosted/billing/usage/usage-page.tsx
+++ b/apps/web/src/hosted/billing/usage/usage-page.tsx
@@ -9,7 +9,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { UsageSkeleton } from "@/hosted/billing/components/state-views";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { formatUsdExact } from "@/hosted/billing/format";
-import { useUsage } from "@/hosted/billing/hooks";
+import { useManagedModelCatalog, useUsage } from "@/hosted/billing/hooks";
+import { useUserAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks";
+import {
+	MANAGED_PROVIDER_ID,
+	modelDisplayName,
+	modelOptionsForProvider,
+	providerDisplayLabel,
+} from "@/hosted/v2/ai-providers/model-binding";
 import { formatShortDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
@@ -23,6 +30,8 @@ function decimalUsdNumber(value: string): number {
 
 export function UsagePage() {
 	const usage = useUsage();
+	const providers = useUserAiProviders();
+	const managedModelCatalog = useManagedModelCatalog();
 
 	if (usage.isLoading) {
 		return (
@@ -164,26 +173,37 @@ export function UsagePage() {
 							className="py-4 md:p-4"
 						/>
 					) : (
-						u.by_model.map((m) => (
-							<div key={`${m.provider ?? "managed"}:${m.model}`} className="space-y-1">
-								<div className="flex items-baseline justify-between gap-2 text-sm">
-									<span className="truncate font-medium">{m.model}</span>
-									<span className="shrink-0 tabular-nums">{formatUsdExact(m.amount_usd)}</span>
+						u.by_model.map((m) => {
+							const providerId = m.provider ?? MANAGED_PROVIDER_ID;
+							const modelName = modelDisplayName(
+								m.model,
+								modelOptionsForProvider(
+									providerId,
+									providers.data ?? [],
+									managedModelCatalog.data?.models ?? [],
+								),
+							);
+							const providerName = providerDisplayLabel(providerId, providers.data);
+							return (
+								<div key={`${m.provider ?? "managed"}:${m.model}`} className="space-y-1">
+									<div className="flex items-baseline justify-between gap-2 text-sm">
+										<span className="truncate font-medium">{modelName}</span>
+										<span className="shrink-0 tabular-nums">{formatUsdExact(m.amount_usd)}</span>
+									</div>
+									<div className="h-2 overflow-hidden rounded-full bg-muted">
+										<div
+											className="h-2 rounded-full bg-primary"
+											style={{
+												width: `${maxModel > 0 ? (decimalUsdNumber(m.amount_usd) / maxModel) * 100 : 0}%`,
+											}}
+										/>
+									</div>
+									<div className="text-xs text-muted-foreground">
+										{providerName} · {m.requests.toLocaleString()} requests
+									</div>
 								</div>
-								<div className="h-2 overflow-hidden rounded-full bg-muted">
-									<div
-										className="h-2 rounded-full bg-primary"
-										style={{
-											width: `${maxModel > 0 ? (decimalUsdNumber(m.amount_usd) / maxModel) * 100 : 0}%`,
-										}}
-									/>
-								</div>
-								<div className="text-xs text-muted-foreground">
-									{m.provider ? `${m.provider} · ` : ""}
-									{m.requests.toLocaleString()} requests
-								</div>
-							</div>
-						))
+							);
+						})
 					)}
 				</CardContent>
 			</Card>

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.ts
@@ -7,6 +7,7 @@ import {
 import {
 	AUTORELOAD_AMOUNT_MAX_CENTS,
 	AUTORELOAD_AMOUNT_MIN_CENTS,
+	AUTORELOAD_AMOUNT_RANGE_LABEL,
 	AUTORELOAD_THRESHOLD_MIN_USD,
 } from "@/hosted/billing/wallet/wallet-constants";
 
@@ -154,7 +155,7 @@ export function autoReloadSaveError(error: unknown): AutoReloadSaveError {
 	if (signal.includes("auto reload amount") || signal.includes("auto_reload_amount")) {
 		return {
 			title: "Check the reload amount",
-			description: "Enter an amount from $5 to $500, then save again.",
+			description: `Enter an amount from ${AUTORELOAD_AMOUNT_RANGE_LABEL}, then save again.`,
 			field: "amount",
 			requiresPaymentMethod: false,
 		};

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.tsx
@@ -35,6 +35,7 @@ import {
 import {
 	AUTORELOAD_AMOUNT_MAX_CENTS,
 	AUTORELOAD_AMOUNT_MIN_CENTS,
+	AUTORELOAD_AMOUNT_RANGE_LABEL,
 	AUTORELOAD_THRESHOLD_MIN_USD,
 } from "@/hosted/billing/wallet/wallet-constants";
 
@@ -248,7 +249,7 @@ export function AutoReloadCard({ wallet, onTopUp }: { wallet: WalletState; onTop
 								}
 								aria-live="polite"
 							>
-								$5–$500; up to 2 decimal places.
+								{AUTORELOAD_AMOUNT_RANGE_LABEL}; up to 2 decimal places.
 							</p>
 						</div>
 

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
@@ -29,6 +29,7 @@ import {
 	validTopUpAmountCents,
 } from "@/hosted/billing/wallet/top-up-dialog.logic";
 import {
+	TOPUP_AMOUNT_RANGE_LABEL,
 	TOPUP_DEFAULT_CENTS,
 	TOPUP_INCREMENT_CENTS,
 	TOPUP_MAX_CENTS,
@@ -155,7 +156,7 @@ export function TopUpDialog({
 					<DialogTitle>Top up Wallet</DialogTitle>
 					<DialogDescription>
 						{step === "amount"
-							? `Add between ${formatCents(TOPUP_MIN_CENTS)} and ${formatCents(TOPUP_MAX_CENTS)} to your Wallet.`
+							? `Add a whole-dollar amount from ${TOPUP_AMOUNT_RANGE_LABEL} to your Wallet.`
 							: `Enter your card details to pay ${formatCents(amountCents)}.`}
 					</DialogDescription>
 				</DialogHeader>
@@ -206,11 +207,9 @@ export function TopUpDialog({
 								}
 								aria-live="polite"
 							>
-								{amountInvalid
-									? `Enter a whole-dollar amount from ${formatCents(TOPUP_MIN_CENTS)} to ${formatCents(TOPUP_MAX_CENTS)}.`
-									: valid
-										? `You’ll add ${formatCents(amountCents)} to your Wallet. Whole-dollar amounts only.`
-										: `Enter a whole-dollar amount from ${formatCents(TOPUP_MIN_CENTS)} to ${formatCents(TOPUP_MAX_CENTS)}.`}
+								{valid
+									? `You’ll add ${formatCents(amountCents)} to your Wallet. Whole-dollar amounts only.`
+									: `Enter a whole-dollar amount from ${TOPUP_AMOUNT_RANGE_LABEL}.`}
 							</p>
 						</div>
 						<div className="flex justify-end">

--- a/apps/web/src/hosted/billing/wallet/wallet-constants.test.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-constants.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import {
+	AUTORELOAD_AMOUNT_RANGE_LABEL,
+	TOPUP_AMOUNT_RANGE_LABEL,
+} from "@/hosted/billing/wallet/wallet-constants";
+
+describe("wallet amount range labels", () => {
+	test("formats both ranges consistently from their cent bounds", () => {
+		expect(TOPUP_AMOUNT_RANGE_LABEL).toBe("$10.00–$2,000.00");
+		expect(AUTORELOAD_AMOUNT_RANGE_LABEL).toBe("$5.00–$500.00");
+	});
+});

--- a/apps/web/src/hosted/billing/wallet/wallet-constants.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-constants.ts
@@ -1,20 +1,32 @@
+import { formatCents } from "@/hosted/billing/format";
+
 /**
  * Wallet UI bounds. These mirror the hosted API validation so the form catches
  * out-of-range input before the request, but the backend remains the source of
  * truth.
  */
 
-// Top-up: $10–$2,000 (WALLET_TOPUP_MIN/MAX_CENTS).
+// Top-up bounds (WALLET_TOPUP_MIN/MAX_CENTS).
 export const TOPUP_MIN_CENTS = 1000;
 export const TOPUP_MAX_CENTS = 200_000;
 export const TOPUP_DEFAULT_CENTS = 2500;
 export const TOPUP_INCREMENT_CENTS = 100;
 export const TOPUP_PRESETS_CENTS = [1000, 2500, 5000, 10_000, 25_000];
 
-// Auto-reload: amount $5–$500, threshold ≥ $1, cap ≥ 0 (0 = off).
+// Auto-reload amount bounds; threshold ≥ $1, cap ≥ 0 (0 = off).
 export const AUTORELOAD_AMOUNT_MIN_CENTS = 500;
 export const AUTORELOAD_AMOUNT_MAX_CENTS = 50_000;
 export const AUTORELOAD_THRESHOLD_MIN_USD = 1;
+
+function amountRangeLabel(minCents: number, maxCents: number): string {
+	return `${formatCents(minCents)}–${formatCents(maxCents)}`;
+}
+
+export const TOPUP_AMOUNT_RANGE_LABEL = amountRangeLabel(TOPUP_MIN_CENTS, TOPUP_MAX_CENTS);
+export const AUTORELOAD_AMOUNT_RANGE_LABEL = amountRangeLabel(
+	AUTORELOAD_AMOUNT_MIN_CENTS,
+	AUTORELOAD_AMOUNT_MAX_CENTS,
+);
 
 // Low-balance warning trips below $2.
 export const LOW_BALANCE_USD = 2;

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-hooks.ts
@@ -1,19 +1,36 @@
 "use client";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { isFirstPartyManagedAiProvider } from "@clawdi/shared";
+import { queryOptions, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import type { AiProviderPatch, AiProviderUpsert } from "@/hosted/v2/ai-providers/types";
+import type {
+	AiProviderList,
+	AiProviderPatch,
+	AiProviderUpsert,
+} from "@/hosted/v2/ai-providers/types";
 import { toastApiError, unwrap, useApi } from "@/lib/api";
 
 /** Typed data hooks for the AI Providers surface (cloud-api `/v1/ai-providers`). */
 
 const KEY = ["ai-providers"] as const;
+const selectUserAiProviders = (data: AiProviderList) =>
+	data.providers.filter((provider) => !isFirstPartyManagedAiProvider(provider));
 
-export function useAiProviders() {
-	const api = useApi();
-	return useQuery({
+function aiProvidersQueryOptions(api: ReturnType<typeof useApi>) {
+	return queryOptions({
 		queryKey: KEY,
 		queryFn: async () => unwrap(await api.GET("/v1/ai-providers")),
+	});
+}
+
+export function useAiProviders() {
+	return useQuery(aiProvidersQueryOptions(useApi()));
+}
+
+export function useUserAiProviders() {
+	return useQuery({
+		...aiProvidersQueryOptions(useApi()),
+		select: selectUserAiProviders,
 	});
 }
 

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { isFirstPartyManagedAiProvider } from "@clawdi/shared";
 import { ListChecks, Pencil, Plus, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -35,9 +34,9 @@ import { Spinner } from "@/components/ui/spinner";
 import { useHostedDeploymentInventory } from "@/hosted/use-hosted-deployment-inventory";
 import { AddProviderDialog } from "@/hosted/v2/ai-providers/add-provider-dialog";
 import {
-	useAiProviders,
 	useCheckProviderFields,
 	useDeleteProvider,
+	useUserAiProviders,
 } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import {
 	type ProviderUsage,
@@ -45,13 +44,13 @@ import {
 	providerUsage,
 } from "@/hosted/v2/ai-providers/ai-providers-page.logic";
 import { AuthBadge, ManagedProviderCard } from "@/hosted/v2/ai-providers/ai-providers-ui";
+import { modelDisplayName, providerDisplayLabel } from "@/hosted/v2/ai-providers/model-binding";
 import {
 	API_MODE_LABEL,
 	type ApiMode,
 	providerTypeMeta,
 } from "@/hosted/v2/ai-providers/provider-types";
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
-import { formatModelLabel } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
 const DESCRIPTION = "Choose how your agents reach a model.";
@@ -59,14 +58,12 @@ const PAGE_CLASS = cn(CENTERED_PAGE_WIDTH_CLASS.page, "flex flex-col gap-6 px-4 
 const PROVIDER_GRID_CLASS = ENTITY_GRID_CLASS;
 
 export function AiProvidersPage() {
-	const providers = useAiProviders();
+	const providers = useUserAiProviders();
 	const inventory = useHostedDeploymentInventory();
 	const [addOpen, setAddOpen] = useState(false);
 	const [editing, setEditing] = useState<AiProvider | null>(null);
 
-	const list = (providers.data?.providers ?? []).filter(
-		(provider) => !isFirstPartyManagedAiProvider(provider),
-	);
+	const list = providers.data ?? [];
 
 	return (
 		<div data-hosted="true" data-v2="true" className={PAGE_CLASS}>
@@ -145,7 +142,7 @@ function ProviderCard({
 }) {
 	const meta = providerTypeMeta(provider.type);
 	const checkFields = useCheckProviderFields();
-	const providerLabel = provider.label ?? provider.provider_id;
+	const providerLabel = providerDisplayLabel(provider);
 	const modelSummary = modelCatalogSummary(provider);
 
 	function runCheckFields() {
@@ -206,7 +203,7 @@ function RemoveProviderAction({ provider, usage }: { provider: AiProvider; usage
 	const del = useDeleteProvider();
 	const [open, setOpen] = useState(false);
 	const [acknowledged, setAcknowledged] = useState(false);
-	const providerLabel = provider.label ?? provider.provider_id;
+	const providerLabel = providerDisplayLabel(provider);
 	const impact = providerRemovalImpact(usage);
 	const acknowledgementId = `remove-provider-ack-${provider.provider_id}`;
 
@@ -279,8 +276,11 @@ function RemoveProviderAction({ provider, usage }: { provider: AiProvider; usage
 }
 
 function modelCatalogSummary(provider: AiProvider): string {
-	const modelIds = (provider.models ?? []).map((model) => model.id).filter(Boolean);
-	if (modelIds.length === 0) return "No catalog models";
-	const visible = modelIds.slice(0, 2).map(formatModelLabel).join(", ");
-	return modelIds.length > 2 ? `${visible} +${modelIds.length - 2} more` : visible;
+	const models = (provider.models ?? []).filter((model) => model.id);
+	if (models.length === 0) return "No catalog models";
+	const visible = models
+		.slice(0, 2)
+		.map((model) => modelDisplayName(model.id, [model]))
+		.join(", ");
+	return models.length > 2 ? `${visible} +${models.length - 2} more` : visible;
 }

--- a/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/ai-providers-ui.tsx
@@ -6,6 +6,7 @@ import { EntityIcon, type EntityIconSize } from "@/components/entity-icon";
 import { IconChip } from "@/components/icon-chip";
 import { Badge } from "@/components/ui/badge";
 import { StatusBadge } from "@/components/ui/status-badge";
+import { MANAGED_PROVIDER_LABEL } from "@/hosted/v2/ai-providers/model-binding";
 import { providerTypeMeta } from "@/hosted/v2/ai-providers/provider-types";
 import type { AiProviderAuth } from "@/hosted/v2/ai-providers/types";
 
@@ -60,7 +61,7 @@ export function ManagedProviderCard() {
 						<Sparkles className="size-5" />
 					</IconChip>
 				}
-				title="Managed by Clawdi"
+				title={MANAGED_PROVIDER_LABEL}
 				titleAdornment={
 					<StatusBadge status="success">
 						<ShieldCheck className="size-3" />

--- a/apps/web/src/hosted/v2/ai-providers/auth-card-label.ts
+++ b/apps/web/src/hosted/v2/ai-providers/auth-card-label.ts
@@ -1,4 +1,5 @@
 import type { AiProviderAuthKind } from "@/hosted/billing/contracts";
+import { MANAGED_PROVIDER_LABEL } from "@/hosted/v2/ai-providers/model-binding";
 
 export function authCardLabel(authKind: AiProviderAuthKind): string {
 	switch (authKind) {
@@ -9,6 +10,6 @@ export function authCardLabel(authKind: AiProviderAuthKind): string {
 		case "codex_oauth":
 			return "Use your OpenAI account";
 		default:
-			return "Managed by Clawdi";
+			return MANAGED_PROVIDER_LABEL;
 	}
 }

--- a/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding-picker.tsx
@@ -18,9 +18,7 @@ import {
 	CUSTOM_MODEL_CHOICE,
 	MANAGED_AI_CHOICE,
 	type ModelBindingPickerItem,
-	modelIdsForProvider,
 	modelPickerItems,
-	primaryModelPickerChoice,
 	primaryProviderPickerItems,
 } from "@/hosted/v2/ai-providers/model-binding";
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
@@ -40,7 +38,6 @@ export function ModelBindingPicker({
 	selectedProviderChoices,
 	primaryProviderChoice,
 	primaryModel,
-	formatModel,
 	onPrimaryProviderChange,
 	onPrimaryModelChange,
 }: {
@@ -57,7 +54,6 @@ export function ModelBindingPicker({
 	selectedProviderChoices: readonly string[];
 	primaryProviderChoice: string;
 	primaryModel: string;
-	formatModel?: (modelId: string) => string;
 	onPrimaryProviderChange: (choice: string) => void;
 	onPrimaryModelChange: (model: string) => void;
 }) {
@@ -65,8 +61,11 @@ export function ModelBindingPicker({
 	const catalogInputId = `${idPrefix}-catalog-model`;
 	const customInputId = `${idPrefix}-primary-model`;
 	const isManaged = primaryProviderChoice === MANAGED_AI_CHOICE;
-	const catalogModelIds = modelIdsForProvider(primaryProviderChoice, providers, managedModels);
-	const modelChoice = primaryModelPickerChoice(primaryModel, catalogModelIds);
+	const catalogModelItems = modelPickerItems(primaryProviderChoice, providers, managedModels);
+	const hasCatalogModels = catalogModelItems.some((item) => item.value !== CUSTOM_MODEL_CHOICE);
+	const modelChoice = catalogModelItems.some((item) => item.value === primaryModel)
+		? primaryModel
+		: CUSTOM_MODEL_CHOICE;
 	const managedCatalogUnavailableError =
 		isManaged && managedModels.length === 0 && !managedModelsLoading
 			? (managedModelsError ?? new Error("The managed model catalog returned no models."))
@@ -76,13 +75,6 @@ export function ModelBindingPicker({
 		customProviders,
 		additionalProviderItems,
 	);
-	const catalogModelItems = modelPickerItems(
-		primaryProviderChoice,
-		providers,
-		managedModels,
-		formatModel,
-	);
-
 	return (
 		<div
 			data-hosted="true"
@@ -124,7 +116,7 @@ export function ModelBindingPicker({
 						onRetry={onManagedModelsRetry}
 						title="Couldn't load managed models"
 					/>
-				) : catalogModelIds.length > 0 ? (
+				) : hasCatalogModels ? (
 					<div className="flex flex-col gap-1.5">
 						<Label htmlFor={catalogInputId}>Catalog model</Label>
 						<Select
@@ -154,7 +146,7 @@ export function ModelBindingPicker({
 			{!isManaged && modelChoice === CUSTOM_MODEL_CHOICE ? (
 				<div className="flex flex-col gap-1.5">
 					<Label htmlFor={customInputId}>
-						{catalogModelIds.length > 0 ? "Custom model" : "Primary model"}
+						{hasCatalogModels ? "Custom model" : "Primary model"}
 					</Label>
 					<Input
 						id={customInputId}

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
@@ -3,17 +3,19 @@ import {
 	firstModelForProvider,
 	isManagedProviderId,
 	MANAGED_AI_CHOICE,
-	managedModelDisplayName,
-	managedModelPickerItems,
-	modelIdsForProvider,
+	MANAGED_PROVIDER_LABEL,
+	modelBindingDisplayName,
+	modelDisplayName,
+	modelOptionsForProvider,
 	providerChoiceFromRef,
+	providerDisplayLabel,
 } from "@/hosted/v2/ai-providers/model-binding";
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 
 describe("model binding", () => {
 	test("does not invent a managed model before the catalog loads", () => {
 		expect(firstModelForProvider(MANAGED_AI_CHOICE, [])).toBe("");
-		expect(modelIdsForProvider(MANAGED_AI_CHOICE, [])).toEqual([]);
+		expect(modelOptionsForProvider(MANAGED_AI_CHOICE, [])).toEqual([]);
 	});
 
 	test("puts the catalog default first and exposes real managed model names", () => {
@@ -23,23 +25,28 @@ describe("model binding", () => {
 			{ id: "gpt-5.6-terra", display_name: "Terra", is_default: false },
 		];
 
-		expect(modelIdsForProvider(MANAGED_AI_CHOICE, [], managedModels)).toEqual([
-			"gpt-5.6-luna",
-			"gpt-5.6-sol",
-			"gpt-5.6-terra",
-		]);
-		expect(firstModelForProvider(MANAGED_AI_CHOICE, [], managedModels)).toBe("gpt-5.6-luna");
 		expect(
-			modelIdsForProvider(MANAGED_AI_CHOICE, [], managedModels).map((modelId) =>
-				managedModelDisplayName(modelId, managedModels),
-			),
-		).toEqual(["Luna", "Sol", "Terra"]);
-		expect(managedModelPickerItems(managedModels)).toEqual([
-			{ value: "gpt-5.6-luna", label: "Luna" },
-			{ value: "gpt-5.6-sol", label: "Sol" },
-			{ value: "gpt-5.6-terra", label: "Terra" },
+			modelOptionsForProvider(MANAGED_AI_CHOICE, [], managedModels).map((model) => model.id),
+		).toEqual(["gpt-5.6-luna", "gpt-5.6-sol", "gpt-5.6-terra"]);
+		expect(firstModelForProvider(MANAGED_AI_CHOICE, [], managedModels)).toBe("gpt-5.6-luna");
+		expect(modelOptionsForProvider(MANAGED_AI_CHOICE, [], managedModels)).toEqual([
+			managedModels[1],
+			managedModels[0],
+			managedModels[2],
 		]);
-		expect(managedModelDisplayName("gpt-5.6-sol", managedModels)).toBe("Sol");
+		expect(modelDisplayName("gpt-5.6-sol", managedModels)).toBe("Sol");
+	});
+
+	test("uses catalog metadata before the shared formatter and raw id fallback", () => {
+		expect(
+			modelDisplayName("model", [{ id: "model", display_name: "Display", is_default: false }]),
+		).toBe("Display");
+		expect(modelDisplayName("model", [{ id: "model", label: "Label", alias: "Alias" }])).toBe(
+			"Label",
+		);
+		expect(modelDisplayName("model", [{ id: "model", alias: "Alias" }])).toBe("Alias");
+		expect(modelDisplayName("gpt-5.4", [])).toBe("GPT 5.4");
+		expect(modelDisplayName("unknown/model", [])).toBe("unknown/model");
 	});
 
 	test("uses the first catalog model for a selected provider", () => {
@@ -50,7 +57,7 @@ describe("model binding", () => {
 				scope: "account_global",
 				type: "openai",
 				base_url: "https://api.openai.com/v1",
-				models: [{ id: "gpt-5.5" }, { id: "gpt-5.4" }],
+				models: [{ id: "gpt-5.5", label: "GPT Latest" }, { id: "gpt-5.4" }],
 				api_mode: "openai_responses",
 				auth: { type: "api_key", source: "managed" },
 				managed_by: "user",
@@ -63,11 +70,22 @@ describe("model binding", () => {
 		];
 
 		expect(firstModelForProvider("openai-main", providers)).toBe("gpt-5.5");
+		expect(modelOptionsForProvider("openai-main", providers)).toEqual(providers[0].models);
+		expect(modelDisplayName("gpt-5.5", providers[0].models ?? [])).toBe("GPT Latest");
+		expect(providerDisplayLabel(providers[0])).toBe("OpenAI");
+		expect(providerDisplayLabel("openai-main", providers)).toBe("OpenAI");
 	});
 
 	test("maps deployment-scoped managed provider ids to the friendly managed choice", () => {
 		const providerId = "clawdi-v2-deployment-10";
 		expect(isManagedProviderId(providerId)).toBe(true);
 		expect(providerChoiceFromRef(providerId, [])).toBe(MANAGED_AI_CHOICE);
+		expect(providerDisplayLabel(providerId)).toBe(MANAGED_PROVIDER_LABEL);
+	});
+
+	test("labels empty bindings from their actual auth mode", () => {
+		expect(modelBindingDisplayName(null, "managed", [])).toBe("Managed default");
+		expect(modelBindingDisplayName(null, "unmanaged", [])).toBe("Configured in agent");
+		expect(modelBindingDisplayName(null, "api_key", [])).toBe("Not set");
 	});
 });

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.ts
@@ -1,10 +1,19 @@
-import { CLAWDI_MANAGED_V2_PROVIDER_ID, isClawdiManagedProviderId } from "@clawdi/shared";
-import type { ManagedModelCatalogItem } from "@/hosted/billing/contracts";
+import {
+	CLAWDI_MANAGED_V2_PROVIDER_ID,
+	isClawdiManagedProviderId,
+	isFirstPartyManagedAiProvider,
+} from "@clawdi/shared";
+import type { AiProviderAuthKind, ManagedModelCatalogItem } from "@/hosted/billing/contracts";
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
+import { formatModelLabel } from "@/lib/format";
 
 export const MANAGED_AI_CHOICE = "__managed__";
 export const MANAGED_PROVIDER_ID = CLAWDI_MANAGED_V2_PROVIDER_ID;
+export const MANAGED_PROVIDER_LABEL = "Managed by Clawdi";
 export const CUSTOM_MODEL_CHOICE = "__custom__";
+
+type AiProviderModel = NonNullable<AiProvider["models"]>[number];
+export type ModelCatalogItem = ManagedModelCatalogItem | AiProviderModel;
 
 export type ModelBindingPickerItem = {
 	value: string;
@@ -60,6 +69,20 @@ export function isManagedProviderId(providerId: string | null | undefined): bool
 	return typeof providerId === "string" && isClawdiManagedProviderId(providerId);
 }
 
+export function providerDisplayLabel(
+	provider: AiProvider | string,
+	providers: readonly AiProvider[] = [],
+): string {
+	if (typeof provider === "string") {
+		if (isManagedProviderId(provider)) return MANAGED_PROVIDER_LABEL;
+		const match = providers.find((item) => item.id === provider || item.provider_id === provider);
+		return match ? providerDisplayLabel(match) : "Custom provider";
+	}
+	return isFirstPartyManagedAiProvider(provider)
+		? MANAGED_PROVIDER_LABEL
+		: (provider.label ?? provider.provider_id);
+}
+
 export function providerChoiceFromRef(
 	providerRef: string | null | undefined,
 	providers: readonly AiProvider[],
@@ -81,33 +104,64 @@ export function providerRefFromChoice(
 	return match?.provider_id ?? null;
 }
 
+export function modelOptionsForProvider(
+	choice: string,
+	providers: readonly AiProvider[],
+	managedModels: readonly ManagedModelCatalogItem[] = [],
+): ModelCatalogItem[] {
+	let models: readonly ModelCatalogItem[];
+	if (choice === MANAGED_AI_CHOICE || isManagedProviderId(choice)) {
+		const defaultModel = managedModels.find((model) => model.is_default);
+		models = defaultModel
+			? [defaultModel, ...managedModels.filter((model) => model !== defaultModel)]
+			: managedModels;
+	} else {
+		models =
+			providers.find((item) => item.id === choice || item.provider_id === choice)?.models ?? [];
+	}
+
+	const seen = new Set<string>();
+	return models.filter((model) => {
+		const id = model.id.trim();
+		if (!id || seen.has(id)) return false;
+		seen.add(id);
+		return true;
+	});
+}
+
 export function modelIdsForProvider(
 	choice: string,
 	providers: readonly AiProvider[],
 	managedModels: readonly ManagedModelCatalogItem[] = [],
 ): string[] {
-	if (choice === MANAGED_AI_CHOICE) {
-		const defaultModel = managedModels.find((model) => model.is_default)?.id ?? "";
-		return dedupeProviderIds([defaultModel, ...managedModels.map((model) => model.id)]);
-	}
-	const provider = providers.find((item) => item.provider_id === choice);
-	return dedupeProviderIds((provider?.models ?? []).map((model) => model.id));
+	return modelOptionsForProvider(choice, providers, managedModels).map((model) => model.id);
 }
 
-export function managedModelDisplayName(
-	modelId: string,
-	managedModels: readonly ManagedModelCatalogItem[],
-): string | null {
-	return managedModels.find((model) => model.id === modelId)?.display_name ?? null;
+export function modelDisplayName(modelId: string, catalog: readonly ModelCatalogItem[]): string {
+	const model = catalog.find((item) => item.id === modelId);
+	const displayName = model && "display_name" in model ? model.display_name : undefined;
+	const label = model && "label" in model ? model.label : undefined;
+	const alias = model && "alias" in model ? model.alias : undefined;
+	return displayName || label || alias || formatModelLabel(modelId) || modelId;
 }
 
-export function managedModelPickerItems(
-	managedModels: readonly ManagedModelCatalogItem[],
-): ModelBindingPickerItem[] {
-	return modelIdsForProvider(MANAGED_AI_CHOICE, [], managedModels).map((modelId) => ({
-		value: modelId,
-		label: managedModelDisplayName(modelId, managedModels) ?? modelId,
-	}));
+export function providerCatalogDescription(provider: AiProvider): string {
+	const models = provider.models ?? [];
+	if (models.length === 0) return provider.base_url.replace(/^https?:\/\//, "");
+	if (models.length === 1 && models[0]) return modelDisplayName(models[0].id, models);
+	return `${models.length} catalog models`;
+}
+
+export function modelBindingDisplayName(
+	primaryModel: PrimaryModelInput,
+	authKind: AiProviderAuthKind | "secret_reference" | undefined,
+	catalog: readonly ModelCatalogItem[],
+): string {
+	const modelId = primaryModelValue(primaryModel);
+	if (modelId) return modelDisplayName(modelId, catalog);
+	if (authKind === "managed") return "Managed default";
+	if (authKind === "unmanaged") return "Configured in agent";
+	return "Not set";
 }
 
 export function primaryProviderPickerItems(
@@ -117,14 +171,14 @@ export function primaryProviderPickerItems(
 ): ModelBindingPickerItem[] {
 	return [
 		...(selectedProviderChoices.includes(MANAGED_AI_CHOICE)
-			? [{ value: MANAGED_AI_CHOICE, label: "Managed by Clawdi" }]
+			? [{ value: MANAGED_AI_CHOICE, label: MANAGED_PROVIDER_LABEL }]
 			: []),
 		...additionalItems,
 		...providers
 			.filter((provider) => selectedProviderChoices.includes(provider.provider_id))
 			.map((provider) => ({
 				value: provider.provider_id,
-				label: provider.label ?? provider.provider_id,
+				label: providerDisplayLabel(provider),
 			})),
 	];
 }
@@ -133,23 +187,17 @@ export function modelPickerItems(
 	choice: string,
 	providers: readonly AiProvider[],
 	managedModels: readonly ManagedModelCatalogItem[],
-	formatModel: (modelId: string) => string = (modelId) => modelId,
 ): ModelBindingPickerItem[] {
-	if (choice === MANAGED_AI_CHOICE) return managedModelPickerItems(managedModels);
+	const models = modelOptionsForProvider(choice, providers, managedModels);
 	return [
-		...modelIdsForProvider(choice, providers).map((modelId) => ({
-			value: modelId,
-			label: formatModel(modelId),
+		...models.map((model) => ({
+			value: model.id,
+			label: modelDisplayName(model.id, [model]),
 		})),
-		{ value: CUSTOM_MODEL_CHOICE, label: "Custom model" },
+		...(choice === MANAGED_AI_CHOICE
+			? []
+			: [{ value: CUSTOM_MODEL_CHOICE, label: "Custom model" }]),
 	];
-}
-
-export function primaryModelPickerChoice(
-	primaryModel: string,
-	catalogModelIds: readonly string[],
-): string {
-	return catalogModelIds.includes(primaryModel) ? primaryModel : CUSTOM_MODEL_CHOICE;
 }
 
 export function firstModelForProvider(
@@ -157,8 +205,7 @@ export function firstModelForProvider(
 	providers: readonly AiProvider[],
 	managedModels: readonly ManagedModelCatalogItem[] = [],
 ): string {
-	const [first] = modelIdsForProvider(choice, providers, managedModels);
-	return first ?? "";
+	return modelOptionsForProvider(choice, providers, managedModels)[0]?.id ?? "";
 }
 
 export function normalizeSelectedProviderIds(

--- a/apps/web/src/hosted/v2/ai-providers/types.ts
+++ b/apps/web/src/hosted/v2/ai-providers/types.ts
@@ -9,6 +9,7 @@ import type { components } from "@/lib/api-schemas";
 type Schemas = components["schemas"];
 
 export type AiProvider = Schemas["AiProviderResponse"];
+export type AiProviderList = Schemas["AiProviderListResponse"];
 export type AiProviderAuth = Schemas["AiProviderAuth"];
 export type AiProviderUpsertAuth = Schemas["AiProviderUpsertAuth"];
 export type AiProviderUpsert = Schemas["AiProviderUpsert"];


### PR DESCRIPTION
## Summary
- preserve model catalog metadata and route picker, deploy summary, agent Overview, provider cards, and Usage through shared display helpers
- centralize managed-provider naming and the user-owned provider query/filter
- centralize signup-grant selection and wallet amount-range copy derived from the existing constants

## Reuse and scope
- `modelDisplayName` applies `display_name` -> `label` -> `alias` -> `formatModelLabel` -> id, while `modelOptionsForProvider` preserves catalog items
- `MANAGED_PROVIDER_LABEL` and `providerDisplayLabel` own provider naming; remaining `Managed AI` copy names the billing product, not the provider
- `useUserAiProviders` replaces all three repeated query/filter implementations and is also reused by Usage
- `largestSignupGrantUsd`, `TOPUP_AMOUNT_RANGE_LABEL`, and `AUTORELOAD_AMOUNT_RANGE_LABEL` replace divergent reducers and handwritten ranges
- apps/web only; no API contract, generated client, LRO, or wallet debit math changes
- 211 old/duplicated lines removed; 353 added including cross-page behavior and regression tests (net +142)

## Verification
- `bun run --cwd apps/web test` (544 pass)
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web lint`
- `bunx biome check apps/web/src`
- `git diff --check`