### PR TITLE
refactor(v2 web): converge wallet/checkout logic into shared hooks

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -72,6 +72,7 @@ import {
 	openSecureRuntimeWindow,
 } from "@/hosted/agents/runtime-ui-credentials";
 import { useBillingClient } from "@/hosted/billing/billing-client";
+import { useCheckoutReturnHandler } from "@/hosted/billing/checkout-return";
 import { ComputeDunningBanner } from "@/hosted/billing/components/compute-dunning-banner";
 import type {
 	ComputePlanChangeQuoteRequest,
@@ -86,19 +87,11 @@ import {
 	supportedTimezones,
 	TimezoneCombobox,
 } from "@/hosted/billing/deploy/language-timezone-controls";
-import {
-	billingErrorDetail,
-	billingErrorNormalizer,
-	normalizeBillingError,
-} from "@/hosted/billing/errors";
+import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
 import { billingTermLabel, billingTermSuffix, formatCents } from "@/hosted/billing/format";
 import {
-	checkoutReturnDeploymentId,
-	checkoutReturnMarker,
-	checkoutReturnWasCanceled,
 	useCancelSubscription,
 	useChangePlan,
-	useCheckoutReturnRefresh,
 	useManagedModelCatalog,
 	usePlans,
 	useQuotePlanChange,
@@ -131,7 +124,10 @@ import {
 } from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
-import { topUpAmountCentsForUsdShortfall } from "@/hosted/billing/wallet/top-up-dialog.logic";
+import {
+	useWalletTopUpDialog,
+	type WalletFundingErrorCopy,
+} from "@/hosted/billing/wallet/wallet-funding";
 import { deploymentFailureReason } from "@/hosted/deployment-failure";
 import {
 	canDelete as canDeleteDeployment,
@@ -417,11 +413,10 @@ function planChangeBillingTerm(
 	return value === 12 ? 12 : 1;
 }
 
-function decimalUsd(value: unknown): number | null {
-	if (typeof value !== "string" && typeof value !== "number") return null;
-	const parsed = Number(value);
-	return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
-}
+const PLAN_CHANGE_WALLET_FUNDING_ERROR_COPY = {
+	insufficientBalance: "Top up the shortfall, then request a fresh plan-change quote.",
+	refundDebt: "Top up before confirming this wallet-funded plan change.",
+} satisfies WalletFundingErrorCopy;
 
 /**
  * Hosted agent detail. A compute (deployment) hosts one selected execution
@@ -2380,11 +2375,23 @@ function ComputeSettingsSections({
 	onDeleteAccepted: (deploymentId: string) => void;
 }) {
 	const router = useRouter();
-	const searchStr = useLocation({ select: (location) => location.searchStr });
+	const navigateCheckoutReturn = useCallback(
+		(checkoutDeploymentId: string): false | undefined => {
+			if (checkoutDeploymentId === deployment.resource.id) return false;
+			void router.navigate({
+				href: agentSectionHref(checkoutDeploymentId, "overview", "source=on-clawdi"),
+				replace: true,
+			});
+		},
+		[deployment.resource.id, router],
+	);
+	useCheckoutReturnHandler({
+		onCancelCopy: "You were not charged. Your compute plan is unchanged.",
+		onNavigate: navigateCheckoutReturn,
+	});
 	const hostedAccess = useHostedProductAccess();
 	const lifecycle = useDeploymentLifecycle();
 	const plans = usePlans();
-	const refreshCheckoutReturn = useCheckoutReturnRefresh();
 	const quotePlanChange = useQuotePlanChange();
 	const changePlan = useChangePlan();
 	const [subscriptionCreateOpen, setSubscriptionCreateOpen] = useState(false);
@@ -2397,7 +2404,6 @@ function ComputeSettingsSections({
 	const cancelSubscription = useCancelSubscription();
 	const resumeSubscription = useResumeSubscription();
 	const runAction = useActionLock();
-	const checkoutReturnRef = useRef<string | null>(null);
 	const deploymentStatus = parseDeploymentStatus(deployment.resource.status.summary_state);
 	const canStop = canStopDeployment(deploymentStatus);
 	const canStart = canStartDeployment(deploymentStatus);
@@ -2433,8 +2439,7 @@ function ComputeSettingsSections({
 	const [planChangeQuote, setPlanChangeQuote] = useState<ComputePlanChangeQuoteResponse | null>(
 		null,
 	);
-	const [walletTopUpOpen, setWalletTopUpOpen] = useState(false);
-	const [walletTopUpAmountCents, setWalletTopUpAmountCents] = useState<number | null>(null);
+	const walletTopUp = useWalletTopUpDialog(PLAN_CHANGE_WALLET_FUNDING_ERROR_COPY);
 	const basicPlan = useMemo(() => resolveBasicPlan(plans.data), [plans.data]);
 	const perfPlan = useMemo(() => resolvePerformancePlan(plans.data), [plans.data]);
 	const currentPaidPlan =
@@ -2517,45 +2522,16 @@ function ComputeSettingsSections({
 					? planChangeUnavailable
 					: upgradeUnavailableMessage;
 	useEffect(() => {
-		const marker = checkoutReturnMarker(searchStr);
-		if (!marker || checkoutReturnRef.current === marker) return;
-		checkoutReturnRef.current = marker;
-		void refreshCheckoutReturn().then(() => {
-			if (checkoutReturnWasCanceled(searchStr)) {
-				toast.message("Checkout canceled", {
-					description: "You were not charged. Your compute plan is unchanged.",
-				});
-				return;
-			}
-			const deploymentId = checkoutReturnDeploymentId(searchStr);
-			if (deploymentId && deploymentId !== deployment.resource.id) {
-				void router.navigate({
-					href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"),
-					replace: true,
-				});
-				return;
-			}
-			toast.message("Checkout status refreshed", {
-				description: "We checked your deployments, subscription, and wallet.",
-			});
-		});
-	}, [deployment.resource.id, refreshCheckoutReturn, router, searchStr]);
-	useEffect(() => {
 		if (hostedAccess.isLoading || hostedAccess.canCreateCloudAgents) return;
 		setSubscriptionCreateOpen(false);
 		setPlanChangeOpen(false);
 		setPlanChangeQuote(null);
-		setWalletTopUpOpen(false);
-	}, [hostedAccess.canCreateCloudAgents, hostedAccess.isLoading]);
+		walletTopUp.reset();
+	}, [hostedAccess.canCreateCloudAgents, hostedAccess.isLoading, walletTopUp.reset]);
 
 	function setPlanChangeDialogOpen(open: boolean) {
 		setPlanChangeOpen(open);
 		if (!open) setPlanChangeQuote(null);
-	}
-
-	function openPlanChangeTopUp(shortfallUsd: number | null = null) {
-		setWalletTopUpAmountCents(topUpAmountCentsForUsdShortfall(shortfallUsd));
-		setWalletTopUpOpen(true);
 	}
 
 	async function requestPlanChangeQuote(selection: PlanChangeSelection) {
@@ -2601,24 +2577,7 @@ function ComputeSettingsSections({
 			}
 			setPlanChangeDialogOpen(false);
 		} catch (error) {
-			const detail = billingErrorDetail(error);
-			if (
-				detail?.code === "insufficient_wallet_balance" ||
-				detail?.code === "insufficient_balance"
-			) {
-				openPlanChangeTopUp(decimalUsd(detail.shortfall_usd));
-				toast.error("Not enough Wallet balance", {
-					description: "Top up the shortfall, then request a fresh plan-change quote.",
-				});
-				return;
-			}
-			if (detail?.code === "open_refund_debt") {
-				openPlanChangeTopUp();
-				toast.error("Refund debt must be repaid", {
-					description: "Top up before confirming this wallet-funded plan change.",
-				});
-				return;
-			}
+			if (walletTopUp.handleFundingError(error)) return;
 			toast.error("Couldn’t change plan", {
 				description: normalizeBillingError(error),
 			});
@@ -2663,15 +2622,7 @@ function ComputeSettingsSections({
 	return (
 		<div className="flex flex-col gap-9">
 			{wallet.data ? (
-				<TopUpDialog
-					open={walletTopUpOpen}
-					onOpenChange={(open) => {
-						setWalletTopUpOpen(open);
-						if (!open) setWalletTopUpAmountCents(null);
-					}}
-					initialAmountCents={walletTopUpAmountCents}
-					onComplete={() => setPlanChangeQuote(null)}
-				/>
+				<TopUpDialog {...walletTopUp.dialogProps} onComplete={() => setPlanChangeQuote(null)} />
 			) : null}
 			{hasTerminalFallback && (basicPlan || perfPlan) ? (
 				<SubscriptionCreateDialog
@@ -2699,7 +2650,7 @@ function ComputeSettingsSections({
 					isConfirming={changePlan.isPending}
 					onQuote={requestPlanChangeQuote}
 					onConfirm={confirmPlanChange}
-					onTopUp={() => openPlanChangeTopUp()}
+					onTopUp={() => walletTopUp.show()}
 				/>
 			) : null}
 

--- a/apps/web/src/hosted/billing/checkout-return.ts
+++ b/apps/web/src/hosted/billing/checkout-return.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useLocation } from "@tanstack/react-router";
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { useCheckoutReturnRefresh } from "@/hosted/billing/hooks";
+
+const DEPLOYMENT_PARAMS = ["deployment_id", "upgrade_deployment_id"] as const;
+const MARKER_PARAMS = [
+	"session_id",
+	"checkout_session_id",
+	...DEPLOYMENT_PARAMS,
+	"mockCheckout",
+] as const;
+
+export function checkoutReturnWasCanceled(searchStr: string): boolean {
+	return new URLSearchParams(searchStr).get("checkout") === "cancel";
+}
+
+export function checkoutReturnMarker(searchStr: string): string | null {
+	const params = new URLSearchParams(searchStr);
+	const values = MARKER_PARAMS.flatMap((key) => {
+		const value = params.get(key);
+		return value ? [`${key}=${value}`] : [];
+	});
+	if (checkoutReturnWasCanceled(searchStr)) values.push("checkout=cancel");
+	return values.length > 0 ? values.join("&") : null;
+}
+
+export function checkoutReturnDeploymentId(searchStr: string): string | null {
+	const params = new URLSearchParams(searchStr);
+	for (const key of DEPLOYMENT_PARAMS) {
+		const value = params.get(key);
+		if (value) return value;
+	}
+	return null;
+}
+
+export function useCheckoutReturnHandler({
+	onCancelCopy,
+	onNavigate,
+}: {
+	onCancelCopy: string;
+	/** Return false to keep the current page and show the refresh toast. */
+	onNavigate: (deploymentId: string) => false | undefined;
+}): void {
+	const refreshCheckoutReturn = useCheckoutReturnRefresh();
+	const searchStr = useLocation({ select: (location) => location.searchStr });
+	const handledMarkerRef = useRef<string | null>(null);
+
+	useEffect(() => {
+		const marker = checkoutReturnMarker(searchStr);
+		if (!marker || handledMarkerRef.current === marker) return;
+		handledMarkerRef.current = marker;
+		void refreshCheckoutReturn()
+			.then(() => {
+				if (checkoutReturnWasCanceled(searchStr)) {
+					toast.message("Checkout canceled", { description: onCancelCopy });
+					return;
+				}
+				const deploymentId = checkoutReturnDeploymentId(searchStr);
+				if (deploymentId && onNavigate(deploymentId) !== false) return;
+				toast.message("Checkout status refreshed", {
+					description: "We checked your deployments, subscription, and wallet.",
+				});
+			})
+			.catch(() => {
+				toast.error("Couldn’t refresh checkout status", {
+					description: "Refresh the page to check your deployments, subscription, and wallet.",
+				});
+			});
+	}, [onCancelCopy, onNavigate, refreshCheckoutReturn, searchStr]);
+}

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useLocation, useRouter } from "@tanstack/react-router";
+import { useRouter } from "@tanstack/react-router";
 import {
 	CalendarClock,
 	Cpu,
@@ -14,7 +14,7 @@ import {
 	WalletCards,
 	Zap,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { type ApiErrorNormalizer, ApiErrorPanel } from "@/components/api-error-panel";
 import { EntityChoiceCard } from "@/components/entity-card";
@@ -39,6 +39,7 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Spinner } from "@/components/ui/spinner";
 import { useBillingClient } from "@/hosted/billing/billing-client";
+import { useCheckoutReturnHandler } from "@/hosted/billing/checkout-return";
 import {
 	CHECKOUT_ELEMENTS_UI_MODE,
 	checkoutRedirectUrl,
@@ -84,7 +85,6 @@ import {
 	TimezoneCombobox,
 } from "@/hosted/billing/deploy/language-timezone-controls";
 import {
-	billingErrorDetail,
 	billingErrorNormalizer,
 	isIdempotencyKeyReusedError,
 	normalizeBillingError,
@@ -96,9 +96,6 @@ import {
 	formatUsdExact,
 } from "@/hosted/billing/format";
 import {
-	checkoutReturnDeploymentId,
-	checkoutReturnMarker,
-	checkoutReturnWasCanceled,
 	useCheckoutReturnRefresh,
 	useCreateSubscription,
 	useHostedDeployments,
@@ -132,8 +129,11 @@ import {
 } from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
-import { topUpAmountCentsForUsdShortfall } from "@/hosted/billing/wallet/top-up-dialog.logic";
 import { walletDebitShortfallUsd } from "@/hosted/billing/wallet/wallet-debit-summary";
+import {
+	SUBSCRIPTION_WALLET_FUNDING_ERROR_COPY,
+	useWalletTopUpDialog,
+} from "@/hosted/billing/wallet/wallet-funding";
 import { type HostedRuntime, runtimeBlurb, runtimeDisplayName } from "@/hosted/runtimes";
 import { AddProviderDialog } from "@/hosted/v2/ai-providers/add-provider-dialog";
 import { useUserAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks";
@@ -194,12 +194,6 @@ const RUNTIME_TILE_GRID_CLASS = "grid gap-2 sm:grid-cols-2";
 
 function acceptedDeploymentNavigation(deploymentId: string, replace = false) {
 	return { href: agentSectionHref(deploymentId, "overview", "source=on-clawdi"), replace };
-}
-
-function decimalUsd(value: unknown): number | null {
-	if (typeof value !== "string" && typeof value !== "number") return null;
-	const parsed = Number(value);
-	return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
 }
 
 const aiProviderErrorNormalizer: ApiErrorNormalizer = {
@@ -387,7 +381,16 @@ function computeStatusLine({
 
 export function DeployWizard() {
 	const router = useRouter();
-	const searchStr = useLocation({ select: (location) => location.searchStr });
+	const navigateCheckoutReturn = useCallback(
+		(deploymentId: string): undefined => {
+			void router.navigate(acceptedDeploymentNavigation(deploymentId, true));
+		},
+		[router],
+	);
+	useCheckoutReturnHandler({
+		onCancelCopy: "You were not charged. Your agent was not deployed.",
+		onNavigate: navigateCheckoutReturn,
+	});
 	const hostedAccess = useHostedProductAccess();
 	const plans = usePlans();
 	const deployments = useHostedDeployments();
@@ -403,7 +406,6 @@ export function DeployWizard() {
 	const walletCreateAttemptRef = useRef<IdempotencyAttempt | null>(null);
 	const includedCreateAttemptRef = useRef<IdempotencyAttempt | null>(null);
 	const assistantNameEditedRef = useRef(false);
-	const checkoutReturnRef = useRef<string | null>(null);
 	const createdProviderGuardRef = useRef<{ providerId: string; dataUpdatedAt: number } | null>(
 		null,
 	);
@@ -428,8 +430,7 @@ export function DeployWizard() {
 	const [term, setTerm] = useState(1);
 	const [submitting, setSubmitting] = useState(false);
 	const [paymentMethod, setPaymentMethod] = useState<DeployPaymentMethod>("card");
-	const [walletTopUpOpen, setWalletTopUpOpen] = useState(false);
-	const [walletTopUpAmountCents, setWalletTopUpAmountCents] = useState<number | null>(null);
+	const walletTopUp = useWalletTopUpDialog(SUBSCRIPTION_WALLET_FUNDING_ERROR_COPY);
 
 	// Default language + timezone to the browser's after mount (avoids an SSR
 	// mismatch). Both stay explicitly unsettable back to the runtime default.
@@ -558,28 +559,6 @@ export function DeployWizard() {
 			}),
 		);
 	}
-
-	useEffect(() => {
-		const marker = checkoutReturnMarker(searchStr);
-		if (!marker || checkoutReturnRef.current === marker) return;
-		checkoutReturnRef.current = marker;
-		void refreshCheckoutReturn().then(() => {
-			if (checkoutReturnWasCanceled(searchStr)) {
-				toast.message("Checkout canceled", {
-					description: "You were not charged. Your agent was not deployed.",
-				});
-				return;
-			}
-			const deploymentId = checkoutReturnDeploymentId(searchStr);
-			if (deploymentId) {
-				void router.navigate(acceptedDeploymentNavigation(deploymentId, true));
-				return;
-			}
-			toast.message("Checkout status refreshed", {
-				description: "We checked your deployments, subscription, and wallet.",
-			});
-		});
-	}, [refreshCheckoutReturn, router, searchStr]);
 
 	useEffect(() => {
 		if (compute !== "performance" || !plans.isSuccess || perfPlan) return;
@@ -792,33 +771,9 @@ export function DeployWizard() {
 		const available = await hostedAccess.recheckCanCreateCloudAgents();
 		if (!available) {
 			setCheckoutSession(null);
-			setWalletTopUpOpen(false);
+			walletTopUp.reset();
 		}
 		return available;
-	}
-
-	function openWalletTopUp(shortfallUsd: number | null) {
-		setWalletTopUpAmountCents(topUpAmountCentsForUsdShortfall(shortfallUsd));
-		setWalletTopUpOpen(true);
-	}
-
-	function handleWalletCreateError(error: unknown): boolean {
-		const detail = billingErrorDetail(error);
-		if (detail?.code === "insufficient_wallet_balance" || detail?.code === "insufficient_balance") {
-			openWalletTopUp(decimalUsd(detail.shortfall_usd));
-			toast.error("Not enough Wallet balance", {
-				description: "Top up the shortfall, then review a fresh wallet quote.",
-			});
-			return true;
-		}
-		if (detail?.code === "open_refund_debt") {
-			openWalletTopUp(null);
-			toast.error("Refund debt must be repaid", {
-				description: "Top up before starting this wallet subscription.",
-			});
-			return true;
-		}
-		return false;
 	}
 
 	async function fallbackToHostedCheckout(request: SubscriptionCreateRequestView) {
@@ -1046,7 +1001,7 @@ export function DeployWizard() {
 		} catch (e) {
 			if (paymentMethod === "wallet") {
 				void subscriptionCreateQuote.refetch();
-				if (handleWalletCreateError(e)) return;
+				if (walletTopUp.handleFundingError(e)) return;
 			}
 			toast.error("Couldn’t deploy", { description: normalizeBillingError(e) });
 		} finally {
@@ -1488,7 +1443,7 @@ export function DeployWizard() {
 																size="sm"
 																variant="outline"
 																disabled={!wallet.data}
-																onClick={() => openWalletTopUp(walletShortfallUsd)}
+																onClick={() => walletTopUp.show(walletShortfallUsd)}
 															>
 																<WalletCards data-icon="inline-start" /> Top up Wallet
 															</Button>
@@ -1605,12 +1560,7 @@ export function DeployWizard() {
 			/>
 			{wallet.data ? (
 				<TopUpDialog
-					open={walletTopUpOpen}
-					onOpenChange={(open) => {
-						setWalletTopUpOpen(open);
-						if (!open) setWalletTopUpAmountCents(null);
-					}}
-					initialAmountCents={walletTopUpAmountCents}
+					{...walletTopUp.dialogProps}
 					onComplete={() => void subscriptionCreateQuote.refetch()}
 				/>
 			) : null}

--- a/apps/web/src/hosted/billing/hooks.test.ts
+++ b/apps/web/src/hosted/billing/hooks.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { QueryClient } from "@tanstack/react-query";
+import { checkoutReturnMarker, checkoutReturnWasCanceled } from "@/hosted/billing/checkout-return";
 import type {
 	ComputeSubscriptionActionResult,
 	HostedComputeSubscription,
@@ -9,8 +10,6 @@ import {
 	applyDeploymentSubscriptionResult,
 	billingKeys,
 	billingRecoveryRefetchIntervalFor,
-	checkoutReturnMarker,
-	checkoutReturnWasCanceled,
 	refreshCheckoutReturnQueries,
 } from "@/hosted/billing/hooks";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
@@ -141,6 +140,29 @@ describe("refreshCheckoutReturnQueries", () => {
 		);
 		expect(qc.getQueryState(billingKeys.plans)?.isInvalidated).toBe(true);
 		expect(qc.getQueryState(["agents"])?.isInvalidated).toBe(true);
+	});
+
+	test("rejects instead of claiming success when the required wallet refresh fails", async () => {
+		const qc = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+		let walletRefreshShouldFail = false;
+		await qc.prefetchQuery({
+			queryKey: billingKeys.deployments,
+			queryFn: async () => [],
+		});
+		await qc.prefetchQuery({
+			queryKey: billingKeys.wallet,
+			queryFn: async () => {
+				if (walletRefreshShouldFail) throw new Error("wallet refresh failed");
+				return { balance_cents: 1_000 };
+			},
+		});
+		walletRefreshShouldFail = true;
+
+		await expect(refreshCheckoutReturnQueries(qc)).rejects.toThrow(
+			"Couldn’t refresh required checkout return data.",
+		);
 	});
 });
 

--- a/apps/web/src/hosted/billing/hooks.ts
+++ b/apps/web/src/hosted/billing/hooks.ts
@@ -42,37 +42,6 @@ import { runtimeEnvironmentId } from "@/hosted/runtimes";
 
 export { billingKeys } from "@/hosted/billing/query-keys";
 
-const CHECKOUT_RETURN_DEPLOYMENT_PARAMS = ["deployment_id", "upgrade_deployment_id"] as const;
-const CHECKOUT_RETURN_MARKER_PARAMS = [
-	"session_id",
-	"checkout_session_id",
-	...CHECKOUT_RETURN_DEPLOYMENT_PARAMS,
-	"mockCheckout",
-] as const;
-
-export function checkoutReturnMarker(searchStr: string): string | null {
-	const params = new URLSearchParams(searchStr);
-	const values = CHECKOUT_RETURN_MARKER_PARAMS.flatMap((key) => {
-		const value = params.get(key);
-		return value ? [`${key}=${value}`] : [];
-	});
-	if (checkoutReturnWasCanceled(searchStr)) values.push("checkout=cancel");
-	return values.length > 0 ? values.join("&") : null;
-}
-
-export function checkoutReturnWasCanceled(searchStr: string): boolean {
-	return new URLSearchParams(searchStr).get("checkout") === "cancel";
-}
-
-export function checkoutReturnDeploymentId(searchStr: string): string | null {
-	const params = new URLSearchParams(searchStr);
-	for (const key of CHECKOUT_RETURN_DEPLOYMENT_PARAMS) {
-		const value = params.get(key);
-		if (value) return value;
-	}
-	return null;
-}
-
 function subscriptionFromAction(
 	previous: HostedComputeSubscription | null | undefined,
 	next: ComputeSubscriptionActionResult,
@@ -198,16 +167,9 @@ export function useWalletLedger(limit = 50) {
 
 export function useTopUp() {
 	const client = useBillingClient();
-	const qc = useQueryClient();
 	return useMutation({
 		mutationFn: ({ body, idempotencyKey }: { body: WalletTopupRequest; idempotencyKey: string }) =>
 			client.topUp(body, idempotencyKey),
-		onSuccess: () => {
-			// Refetch both balance and activity so a fresh top-up never shows a
-			// stale balance or an empty ledger.
-			qc.invalidateQueries({ queryKey: billingKeys.wallet });
-			qc.invalidateQueries({ queryKey: ["billing", "ledger"] });
-		},
 	});
 }
 
@@ -247,7 +209,7 @@ export function useCreateSubscription() {
 		onSuccess: () => {
 			qc.invalidateQueries({ queryKey: billingKeys.deployments });
 			qc.invalidateQueries({ queryKey: billingKeys.wallet });
-			qc.invalidateQueries({ queryKey: ["billing", "history"] });
+			qc.invalidateQueries({ queryKey: billingKeys.billingHistoryRoot });
 			qc.invalidateQueries({ queryKey: ["agents"] });
 		},
 	});
@@ -293,7 +255,7 @@ export function useChangePlan() {
 		onSuccess: () => {
 			qc.invalidateQueries({ queryKey: billingKeys.deployments });
 			qc.invalidateQueries({ queryKey: billingKeys.wallet });
-			qc.invalidateQueries({ queryKey: ["billing", "history"] });
+			qc.invalidateQueries({ queryKey: billingKeys.billingHistoryRoot });
 		},
 	});
 }
@@ -349,14 +311,14 @@ export function useResumeSubscription() {
 }
 
 export function useCheckoutReturnRefresh() {
-	const qc = useQueryClient();
-	return useCallback(() => refreshCheckoutReturnQueries(qc), [qc]);
+	const queryClient = useQueryClient();
+	return useCallback(() => refreshCheckoutReturnQueries(queryClient), [queryClient]);
 }
 
 export async function refreshCheckoutReturnQueries(
 	qc: QueryClient,
 ): Promise<HostedDeployment[] | undefined> {
-	const [deploymentsResult] = await Promise.allSettled([
+	const [deploymentsResult, walletResult] = await Promise.allSettled([
 		(async () => {
 			await qc.invalidateQueries({
 				queryKey: billingKeys.deployments,
@@ -382,9 +344,16 @@ export async function refreshCheckoutReturnQueries(
 		qc.invalidateQueries({ queryKey: billingKeys.plans }),
 		qc.invalidateQueries({ queryKey: ["agents"] }),
 	]);
-	return deploymentsResult.status === "fulfilled"
-		? qc.getQueryData<HostedDeployment[]>(billingKeys.deployments)
-		: undefined;
+	const requiredRefreshFailures = [deploymentsResult, walletResult].flatMap((result) =>
+		result.status === "rejected" ? [result.reason] : [],
+	);
+	if (requiredRefreshFailures.length > 0) {
+		throw new AggregateError(
+			requiredRefreshFailures,
+			"Couldn’t refresh required checkout return data.",
+		);
+	}
+	return qc.getQueryData<HostedDeployment[]>(billingKeys.deployments);
 }
 
 // ── Usage ────────────────────────────────────────────────────────────────────

--- a/apps/web/src/hosted/billing/query-keys.ts
+++ b/apps/web/src/hosted/billing/query-keys.ts
@@ -1,13 +1,17 @@
 const subscriptionCreateQuotes = ["billing", "subscription-create-quote"] as const;
+const ledgerRoot = ["billing", "ledger"] as const;
+const billingHistoryRoot = ["billing", "history"] as const;
 
 export const billingKeys = {
 	managedModelCatalog: ["billing", "managed-model-catalog"] as const,
 	wallet: ["billing", "wallet"] as const,
-	ledger: (limit: number) => ["billing", "ledger", limit] as const,
+	ledgerRoot,
+	ledger: (limit: number) => [...ledgerRoot, limit] as const,
 	subscriptionCreateQuotes,
 	subscriptionCreateQuote: (planSlug: string, billingTermMonths: number, fundingSource: string) =>
 		[...subscriptionCreateQuotes, planSlug, billingTermMonths, fundingSource] as const,
-	billingHistory: (limit: number) => ["billing", "history", limit] as const,
+	billingHistoryRoot,
+	billingHistory: (limit: number) => [...billingHistoryRoot, limit] as const,
 	plans: ["billing", "plans"] as const,
 	deployments: ["billing", "deployments"] as const,
 	legacyAgentEnvironments: ["billing", "legacy-agent-environments"] as const,

--- a/apps/web/src/hosted/billing/subscription/subscription-create-dialog.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-create-dialog.tsx
@@ -30,7 +30,6 @@ import { TermSwitcher } from "@/hosted/billing/components/term-switcher";
 import { WalletDebitEquation } from "@/hosted/billing/components/wallet-debit-equation";
 import type { ComputePlanSlug, Plan } from "@/hosted/billing/contracts";
 import {
-	billingErrorDetail,
 	billingErrorNormalizer,
 	isIdempotencyKeyReusedError,
 	normalizeBillingError,
@@ -62,8 +61,11 @@ import {
 } from "@/hosted/billing/subscription/subscription-utils";
 import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { TopUpDialog } from "@/hosted/billing/wallet/top-up-dialog";
-import { topUpAmountCentsForUsdShortfall } from "@/hosted/billing/wallet/top-up-dialog.logic";
 import { walletDebitShortfallUsd } from "@/hosted/billing/wallet/wallet-debit-summary";
+import {
+	SUBSCRIPTION_WALLET_FUNDING_ERROR_COPY,
+	useWalletTopUpDialog,
+} from "@/hosted/billing/wallet/wallet-funding";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
 
 const PLAN_ITEMS = [
@@ -73,12 +75,6 @@ const PLAN_ITEMS = [
 
 function computePlanSlug(value: string | null): ComputePlanSlug | null {
 	return value === "compute_basic" || value === "compute_performance" ? value : null;
-}
-
-function decimalUsd(value: unknown): number | null {
-	if (typeof value !== "string" && typeof value !== "number") return null;
-	const parsed = Number(value);
-	return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
 }
 
 function planForSlug(plans: Plan[], planSlug: ComputePlanSlug): Plan | undefined {
@@ -114,8 +110,7 @@ export function SubscriptionCreateDialog({
 	const [planSlug, setPlanSlug] = useState(initialPlanSlug);
 	const [billingTermMonths, setBillingTermMonths] = useState(initialBillingTermMonths);
 	const [fundingSource, setFundingSource] = useState<SubscriptionFundingSource>("stripe");
-	const [walletTopUpOpen, setWalletTopUpOpen] = useState(false);
-	const [walletTopUpAmountCents, setWalletTopUpAmountCents] = useState<number | null>(null);
+	const walletTopUp = useWalletTopUpDialog(SUBSCRIPTION_WALLET_FUNDING_ERROR_COPY);
 	const selectedPlan = useMemo(() => planForSlug(plans, planSlug), [planSlug, plans]);
 	const offers = useMemo(() => offersForPlan(selectedPlan, planSlug), [planSlug, selectedPlan]);
 	const selectedOffer =
@@ -159,9 +154,8 @@ export function SubscriptionCreateDialog({
 		setPlanSlug(initialPlanSlug);
 		setBillingTermMonths(nextTerm);
 		setFundingSource("stripe");
-		setWalletTopUpOpen(false);
-		setWalletTopUpAmountCents(null);
-	}, [initialBillingTermMonths, initialPlanSlug, open, plans]);
+		walletTopUp.reset();
+	}, [initialBillingTermMonths, initialPlanSlug, open, plans, walletTopUp.reset]);
 
 	useEffect(() => {
 		if (open && !hostedAccess.isLoading && !hostedAccess.canCreateCloudAgents) {
@@ -180,30 +174,6 @@ export function SubscriptionCreateDialog({
 			billingTermMonths;
 		setPlanSlug(nextPlanSlug);
 		setBillingTermMonths(nextTerm);
-	}
-
-	function openWalletTopUp(shortfallUsd: number | null) {
-		setWalletTopUpAmountCents(topUpAmountCentsForUsdShortfall(shortfallUsd));
-		setWalletTopUpOpen(true);
-	}
-
-	function handleWalletCreateError(error: unknown): boolean {
-		const detail = billingErrorDetail(error);
-		if (detail?.code === "insufficient_wallet_balance" || detail?.code === "insufficient_balance") {
-			openWalletTopUp(decimalUsd(detail.shortfall_usd));
-			toast.error("Not enough Wallet balance", {
-				description: "Top up the shortfall, then review a fresh wallet quote.",
-			});
-			return true;
-		}
-		if (detail?.code === "open_refund_debt") {
-			openWalletTopUp(null);
-			toast.error("Refund debt must be repaid", {
-				description: "Top up before starting this wallet subscription.",
-			});
-			return true;
-		}
-		return false;
 	}
 
 	async function create() {
@@ -257,7 +227,7 @@ export function SubscriptionCreateDialog({
 		} catch (error) {
 			if (fundingSource === "wallet") {
 				void createQuote.refetch();
-				if (handleWalletCreateError(error)) return;
+				if (walletTopUp.handleFundingError(error)) return;
 			}
 			if (isIdempotencyKeyReusedError(error) && createAttemptRef.current) {
 				forgetIdempotencyAttempt(
@@ -285,7 +255,7 @@ export function SubscriptionCreateDialog({
 			<Dialog
 				open={open}
 				onOpenChange={(nextOpen) => {
-					if (!isPending && !walletTopUpOpen) onOpenChange(nextOpen);
+					if (!isPending && !walletTopUp.dialogProps.open) onOpenChange(nextOpen);
 				}}
 			>
 				<DialogContent data-hosted="true" className="sm:max-w-lg" showCloseButton={!isPending}>
@@ -398,7 +368,7 @@ export function SubscriptionCreateDialog({
 													size="sm"
 													variant="outline"
 													disabled={!wallet.data}
-													onClick={() => openWalletTopUp(walletShortfallUsd)}
+													onClick={() => walletTopUp.show(walletShortfallUsd)}
 												>
 													<WalletCards data-icon="inline-start" /> Top up Wallet
 												</Button>
@@ -438,12 +408,7 @@ export function SubscriptionCreateDialog({
 			</Dialog>
 
 			{wallet.data ? (
-				<TopUpDialog
-					open={walletTopUpOpen}
-					onOpenChange={setWalletTopUpOpen}
-					initialAmountCents={walletTopUpAmountCents}
-					onComplete={() => void createQuote.refetch()}
-				/>
+				<TopUpDialog {...walletTopUp.dialogProps} onComplete={() => void createQuote.refetch()} />
 			) : null}
 		</>
 	);

--- a/apps/web/src/hosted/billing/wallet/auto-reload-action.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-action.tsx
@@ -48,7 +48,7 @@ export function AutoReloadActionConfirm({
 		// The wallet snapshot resolves `auto_reload_action` once the PaymentIntent
 		// settles; refetch balance + activity so this control clears itself.
 		qc.invalidateQueries({ queryKey: billingKeys.wallet });
-		qc.invalidateQueries({ queryKey: ["billing", "ledger"] });
+		qc.invalidateQueries({ queryKey: billingKeys.ledgerRoot });
 		setConfirming(false);
 		toast.success(status === "succeeded" ? "Payment confirmed" : "Payment processing", {
 			description:

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
-import { QueryClient } from "@tanstack/react-query";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import type { WalletTopupResult } from "@/hosted/billing/contracts";
 import { billingKeys } from "@/hosted/billing/query-keys";
 import {
@@ -32,14 +32,26 @@ function queryClientWithWalletActivity(): QueryClient {
 	return qc;
 }
 
+function setupControls(queryClient: QueryClient) {
+	const resetAttempt = mock(() => {});
+	const closeDialog = mock(() => {});
+	const startPayment = mock((_clientSecret: string) => {});
+	const toastSuccess = mock((_message: string, _options: { description: string }) => {});
+	const toastError = mock((_message: string, _options: { description: string }) => {});
+	return {
+		queryClient,
+		resetAttempt,
+		closeDialog,
+		startPayment,
+		toastSuccess,
+		toastError,
+	};
+}
+
 describe("handleTopupStartResult", () => {
 	test("treats synchronous success as terminal success and refreshes wallet activity", () => {
 		const qc = queryClientWithWalletActivity();
-		const resetAttempt = mock(() => {});
-		const closeDialog = mock(() => {});
-		const startPayment = mock((_clientSecret: string) => {});
-		const toastSuccess = mock((_message: string, _options: { description: string }) => {});
-		const toastError = mock((_message: string, _options: { description: string }) => {});
+		const setup = setupControls(qc);
 
 		handleTopupStartResult(
 			result({
@@ -48,14 +60,7 @@ describe("handleTopupStartResult", () => {
 				client_secret: null,
 				amount_usd: "2.50",
 			}),
-			{
-				queryClient: qc,
-				resetAttempt,
-				closeDialog,
-				startPayment,
-				toastSuccess,
-				toastError,
-			},
+			setup,
 		);
 
 		expect(qc.getQueryState(billingKeys.wallet)?.isInvalidated).toBe(true);
@@ -67,22 +72,28 @@ describe("handleTopupStartResult", () => {
 		expect(qc.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(true);
 		expect(qc.getQueryState(billingKeys.billingHistory(20))?.isInvalidated).toBe(true);
 		expect(qc.getQueryState(["agents"])?.isInvalidated).toBe(true);
-		expect(resetAttempt).toHaveBeenCalledTimes(1);
-		expect(closeDialog).toHaveBeenCalledTimes(1);
-		expect(toastSuccess).toHaveBeenCalledWith("Top-up complete", {
+		expect(setup.resetAttempt).toHaveBeenCalledTimes(1);
+		expect(setup.closeDialog).toHaveBeenCalledTimes(1);
+		expect(setup.toastSuccess).toHaveBeenCalledWith("Top-up complete", {
 			description: "Your balance and any open wallet invoice will update automatically.",
 		});
-		expect(toastError).not.toHaveBeenCalled();
-		expect(startPayment).not.toHaveBeenCalled();
+		expect(setup.toastError).not.toHaveBeenCalled();
+		expect(setup.startPayment).not.toHaveBeenCalled();
 	});
 
-	test("keeps payment intent responses on the card payment step", () => {
+	test("keeps payment intents on the card step and refreshes only a visible ledger", async () => {
 		const qc = queryClientWithWalletActivity();
-		const resetAttempt = mock(() => {});
-		const closeDialog = mock(() => {});
-		const startPayment = mock((_clientSecret: string) => {});
-		const toastSuccess = mock((_message: string, _options: { description: string }) => {});
-		const toastError = mock((_message: string, _options: { description: string }) => {});
+		const setup = setupControls(qc);
+		let ledgerCalls = 0;
+		const ledgerObserver = new QueryObserver(qc, {
+			queryKey: billingKeys.ledger(50),
+			queryFn: async () => {
+				ledgerCalls += 1;
+				return { items: [{ id: "pending_topup" }] };
+			},
+			staleTime: Number.POSITIVE_INFINITY,
+		});
+		const unsubscribe = ledgerObserver.subscribe(() => {});
 
 		handleTopupStartResult(
 			result({
@@ -93,21 +104,25 @@ describe("handleTopupStartResult", () => {
 				// The quoted USD amount does not mean the PaymentIntent settled.
 				amount_usd: "25",
 			}),
-			{
-				queryClient: qc,
-				resetAttempt,
-				closeDialog,
-				startPayment,
-				toastSuccess,
-				toastError,
-			},
+			setup,
 		);
+		await Promise.resolve();
 
-		expect(startPayment).toHaveBeenCalledWith("pi_123_secret_456");
-		expect(closeDialog).not.toHaveBeenCalled();
-		expect(resetAttempt).not.toHaveBeenCalled();
-		expect(toastSuccess).not.toHaveBeenCalled();
-		expect(toastError).not.toHaveBeenCalled();
+		expect(setup.startPayment).toHaveBeenCalledWith("pi_123_secret_456");
+		expect(ledgerCalls).toBe(1);
+		expect(qc.getQueryState(billingKeys.wallet)?.isInvalidated).toBe(false);
+		expect(qc.getQueryState(billingKeys.ledger(50))?.isInvalidated).toBe(false);
+		expect(
+			qc.getQueryState(billingKeys.subscriptionCreateQuote("compute_basic", 1, "wallet"))
+				?.isInvalidated,
+		).toBe(false);
+		expect(qc.getQueryState(billingKeys.deployments)?.isInvalidated).toBe(false);
+		expect(qc.getQueryState(billingKeys.billingHistory(20))?.isInvalidated).toBe(false);
+		expect(setup.closeDialog).not.toHaveBeenCalled();
+		expect(setup.resetAttempt).not.toHaveBeenCalled();
+		expect(setup.toastSuccess).not.toHaveBeenCalled();
+		expect(setup.toastError).not.toHaveBeenCalled();
+		unsubscribe();
 	});
 });
 

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.logic.ts
@@ -45,10 +45,10 @@ export function topUpAmountCentsForUsdShortfall(shortfallUsd: number | null): nu
 
 export function invalidateWalletActivity(queryClient: QueryClient): void {
 	queryClient.invalidateQueries({ queryKey: billingKeys.wallet });
-	queryClient.invalidateQueries({ queryKey: ["billing", "ledger"] });
+	queryClient.invalidateQueries({ queryKey: billingKeys.ledgerRoot });
 	queryClient.invalidateQueries({ queryKey: billingKeys.subscriptionCreateQuotes });
 	queryClient.invalidateQueries({ queryKey: billingKeys.deployments });
-	queryClient.invalidateQueries({ queryKey: ["billing", "history"] });
+	queryClient.invalidateQueries({ queryKey: billingKeys.billingHistoryRoot });
 	queryClient.invalidateQueries({ queryKey: ["agents"] });
 }
 
@@ -82,6 +82,12 @@ export function handleTopupStartResult(
 		return;
 	}
 	if (result.flow_type === "payment_intent" && result.client_secret) {
+		// A pending ledger row matters only on a mounted activity surface. Keep
+		// balance and the rest of wallet activity untouched until payment settles.
+		void controls.queryClient.refetchQueries({
+			queryKey: billingKeys.ledgerRoot,
+			type: "active",
+		});
 		controls.startPayment(result.client_secret);
 		return;
 	}

--- a/apps/web/src/hosted/billing/wallet/wallet-funding.test.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-funding.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { BillingApiError } from "@/hosted/billing/errors";
+import { classifyWalletFundingError, decimalUsd } from "@/hosted/billing/wallet/wallet-funding";
+
+function billingError(detail: Record<string, unknown>): BillingApiError {
+	return new BillingApiError(409, JSON.stringify({ detail }), { detail });
+}
+
+describe("classifyWalletFundingError", () => {
+	test("normalizes both insufficient-balance codes and their USD shortfall", () => {
+		for (const code of ["insufficient_wallet_balance", "insufficient_balance"]) {
+			expect(
+				classifyWalletFundingError(
+					billingError({ code, shortfall_usd: code === "insufficient_balance" ? 12.5 : "12.50" }),
+				),
+			).toEqual({ kind: "insufficient_balance", shortfallUsd: 12.5 });
+		}
+	});
+
+	test("classifies refund debt without inventing a shortfall", () => {
+		expect(classifyWalletFundingError(billingError({ code: "open_refund_debt" }))).toEqual({
+			kind: "open_refund_debt",
+			shortfallUsd: null,
+		});
+	});
+
+	test("leaves unrelated and malformed errors unclassified", () => {
+		expect(classifyWalletFundingError(new Error("offline"))).toEqual({
+			kind: "other",
+			shortfallUsd: null,
+		});
+		expect(
+			classifyWalletFundingError(
+				billingError({ code: "insufficient_balance", shortfall_usd: "-1" }),
+			),
+		).toEqual({ kind: "insufficient_balance", shortfallUsd: null });
+	});
+});
+
+describe("decimalUsd", () => {
+	test("accepts finite non-negative decimal strings and numbers only", () => {
+		expect(decimalUsd("25.01")).toBe(25.01);
+		expect(decimalUsd(0)).toBe(0);
+		expect(decimalUsd(-1)).toBeNull();
+		expect(decimalUsd(Number.NaN)).toBeNull();
+		expect(decimalUsd(null)).toBeNull();
+	});
+});

--- a/apps/web/src/hosted/billing/wallet/wallet-funding.ts
+++ b/apps/web/src/hosted/billing/wallet/wallet-funding.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+import { billingErrorDetail } from "@/hosted/billing/errors";
+import { topUpAmountCentsForUsdShortfall } from "@/hosted/billing/wallet/top-up-dialog.logic";
+
+export type WalletFundingError =
+	| { kind: "insufficient_balance"; shortfallUsd: number | null }
+	| { kind: "open_refund_debt"; shortfallUsd: null }
+	| { kind: "other"; shortfallUsd: null };
+
+export type WalletFundingErrorCopy = {
+	insufficientBalance: string;
+	refundDebt: string;
+};
+
+export const SUBSCRIPTION_WALLET_FUNDING_ERROR_COPY: WalletFundingErrorCopy = {
+	insufficientBalance: "Top up the shortfall, then review a fresh wallet quote.",
+	refundDebt: "Top up before starting this wallet subscription.",
+};
+
+export function decimalUsd(value: unknown): number | null {
+	if (typeof value !== "string" && typeof value !== "number") return null;
+	const parsed = Number(value);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+export function classifyWalletFundingError(error: unknown): WalletFundingError {
+	const detail = billingErrorDetail(error);
+	if (detail?.code === "insufficient_wallet_balance" || detail?.code === "insufficient_balance") {
+		return { kind: "insufficient_balance", shortfallUsd: decimalUsd(detail.shortfall_usd) };
+	}
+	if (detail?.code === "open_refund_debt") {
+		return { kind: "open_refund_debt", shortfallUsd: null };
+	}
+	return { kind: "other", shortfallUsd: null };
+}
+
+export function useWalletTopUpDialog(errorCopy: WalletFundingErrorCopy) {
+	const [open, setOpen] = useState(false);
+	const [initialAmountCents, setInitialAmountCents] = useState<number | null>(null);
+
+	const reset = useCallback(() => {
+		setOpen(false);
+		setInitialAmountCents(null);
+	}, []);
+	const onOpenChange = useCallback(
+		(nextOpen: boolean) => (nextOpen ? setOpen(true) : reset()),
+		[reset],
+	);
+	const show = useCallback((shortfallUsd: number | null = null) => {
+		setInitialAmountCents(topUpAmountCentsForUsdShortfall(shortfallUsd));
+		setOpen(true);
+	}, []);
+	const handleFundingError = useCallback(
+		(error: unknown): boolean => {
+			const fundingError = classifyWalletFundingError(error);
+			if (fundingError.kind === "other") return false;
+			show(fundingError.shortfallUsd);
+			if (fundingError.kind === "insufficient_balance") {
+				toast.error("Not enough Wallet balance", {
+					description: errorCopy.insufficientBalance,
+				});
+			} else {
+				toast.error("Refund debt must be repaid", { description: errorCopy.refundDebt });
+			}
+			return true;
+		},
+		[errorCopy, show],
+	);
+
+	return {
+		dialogProps: { open, initialAmountCents, onOpenChange },
+		show,
+		reset,
+		handleFundingError,
+	};
+}


### PR DESCRIPTION
## Summary

- converge both checkout-return effects into useCheckoutReturnHandler and surface required deployments/wallet refresh failures
- centralize wallet funding classification, decimal USD parsing, context copy, and top-up dialog state across all three billing surfaces
- make terminal invalidateWalletActivity the only full top-up refresh, with pending PaymentIntents refetching only active ledger views
- replace bare ledger/history query arrays with shared root keys

## Verification

- bun run --cwd apps/web test (549 pass)
- bun run --cwd apps/web typecheck
- bun run --cwd apps/web lint
- bunx biome check apps/web/src

No deploy generated contract, billing money math, or acceptDeclarativeOperation LRO changes.