### PR TITLE
refactor(v2 web): converge AI-provider binding into shared draft hook + builder

### DIFF
--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -152,35 +152,33 @@ import {
 	runtimeDisplayName,
 } from "@/hosted/runtimes";
 import { hostedRuntimeStatusView } from "@/hosted/use-hosted-agent-tiles";
+import {
+	aiBindingBuildErrorCopy,
+	buildAiBindingFields,
+	isUnresolvedProviderChoice,
+	unresolvedProviderChoice,
+	unresolvedProviderRef,
+	updateProviderChoiceFromRef,
+} from "@/hosted/v2/ai-providers/ai-provider-binding";
 import { useUserAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import { AuthBadge, ProviderTypeChip } from "@/hosted/v2/ai-providers/ai-providers-ui";
 import { authCardLabel } from "@/hosted/v2/ai-providers/auth-card-label";
 import {
-	dedupeProviderIds,
 	firstModelForProvider,
 	isManagedProviderId,
 	MANAGED_AI_CHOICE,
 	MANAGED_PROVIDER_ID,
 	MANAGED_PROVIDER_LABEL,
 	modelBindingDisplayName,
-	modelIdsForProvider,
 	modelOptionsForProvider,
 	normalizeSelectedProviderIds,
 	primaryModelProviderId,
-	primaryModelRef,
 	primaryModelValue,
 	providerCatalogDescription,
-	providerChoiceFromRef,
 	providerDisplayLabel,
-	providerRefFromChoice,
 } from "@/hosted/v2/ai-providers/model-binding";
 import { ModelBindingPicker } from "@/hosted/v2/ai-providers/model-binding-picker";
-import {
-	aiProviderRuntimeId,
-	buildAiProviderPoolBootstrap,
-	type RuntimeAiProviderAuthKind,
-} from "@/hosted/v2/ai-providers/runtime-bootstrap";
-import type { AiProvider } from "@/hosted/v2/ai-providers/types";
+import { useAiProviderBindingDraft } from "@/hosted/v2/ai-providers/use-ai-provider-binding-draft";
 import type { AgentChannelLink } from "@/hosted/v2/channels/channel-edit-client";
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
 import { ChannelStatusBadge, ProviderChip, TokenReveal } from "@/hosted/v2/channels/channel-ui";
@@ -209,7 +207,6 @@ import { sessionListQueryOptions } from "@/lib/session-queries";
 import { cn } from "@/lib/utils";
 
 type Runtime = HostedRuntime;
-type AiBindingMode = "unmanaged" | "configured";
 type DeploymentStatus = ReturnType<typeof parseDeploymentStatus>;
 type HostedAgentTab =
 	| "overview"
@@ -230,13 +227,6 @@ const HOSTED_AGENT_TABS = new Set<HostedAgentTab>([
 	"channels",
 	"settings",
 ]);
-const UNRESOLVED_PROVIDER_PREFIX = "unresolved:";
-
-function providerAuthKind(provider: AiProvider): RuntimeAiProviderAuthKind {
-	return provider.auth.type === "agent_profile" || provider.auth.type === "oauth_profile"
-		? "codex_oauth"
-		: "api_key";
-}
 const HOSTED_AGENT_NAV_META: Record<HostedAgentTab, DetailSectionMeta> = {
 	overview: {
 		description: "Status, model, resources, and recent sessions.",
@@ -1569,34 +1559,6 @@ function selectableCard(active: boolean): string {
 	}`;
 }
 
-function unresolvedProviderChoice(providerRef: string): string {
-	return `${UNRESOLVED_PROVIDER_PREFIX}${providerRef}`;
-}
-
-function isUnresolvedProviderChoice(choice: string): boolean {
-	return choice.startsWith(UNRESOLVED_PROVIDER_PREFIX);
-}
-
-function unresolvedProviderRef(choice: string): string {
-	return choice.slice(UNRESOLVED_PROVIDER_PREFIX.length);
-}
-
-function agentChoiceFromProviderRef(
-	providerRef: string | null | undefined,
-	providers: readonly AiProvider[],
-): string | null {
-	if (!providerRef) return null;
-	const choice = providerChoiceFromRef(providerRef, providers);
-	if (!choice) return null;
-	if (
-		choice === MANAGED_AI_CHOICE ||
-		providers.some((provider) => provider.provider_id === choice)
-	) {
-		return choice;
-	}
-	return unresolvedProviderChoice(providerRef);
-}
-
 function AiProviderTab({
 	deployment,
 	runtime,
@@ -1621,7 +1583,7 @@ function AiProviderTab({
 			)
 		: undefined;
 	const currentAuthKind = runtimeAiProviderAuthKind(deployment, runtime);
-	const initialMode: AiBindingMode = currentAuthKind === "unmanaged" ? "unmanaged" : "configured";
+	const initialMode = currentAuthKind === "unmanaged" ? "unmanaged" : "configured";
 	const legacyProviderRef =
 		currentAuthKind === "unmanaged" ? null : (primaryConfiguredProvider?.provider_id ?? null);
 	const rawProviderRefs =
@@ -1642,7 +1604,7 @@ function AiProviderTab({
 	const initialPrimaryChoice =
 		currentAuthKind === "unmanaged"
 			? MANAGED_AI_CHOICE
-			: (agentChoiceFromProviderRef(primaryProviderRef, list) ??
+			: (updateProviderChoiceFromRef(primaryProviderRef, list) ??
 				(isManagedProviderId(primaryProviderRef)
 					? MANAGED_AI_CHOICE
 					: unresolvedProviderChoice(primaryProviderRef)));
@@ -1651,7 +1613,7 @@ function AiProviderTab({
 			? []
 			: normalizeSelectedProviderIds(
 					rawProviderRefs
-						.map((providerRef) => agentChoiceFromProviderRef(providerRef, list))
+						.map((providerRef) => updateProviderChoiceFromRef(providerRef, list))
 						.filter((choice): choice is string => Boolean(choice)),
 					initialPrimaryChoice,
 				);
@@ -1667,11 +1629,6 @@ function AiProviderTab({
 			? ""
 			: bindingModelIdentity || firstModelForProvider(initialPrimaryChoice, list, managedModels);
 
-	const [selectedProviders, setSelectedProviders] = useState<string[]>(initialProviderChoices);
-	const [bindingMode, setBindingMode] = useState<AiBindingMode>(initialMode);
-	const [primaryProviderChoice, setPrimaryProviderChoice] = useState(initialPrimaryChoice);
-	const [primaryModel, setPrimaryModel] = useState<string>(currentModel);
-
 	// Re-seed the form only when the server-side binding genuinely changes (the
 	// user's own apply completing, or an out-of-band change) — never on a plain
 	// background poll. Keyed on the binding identity: identical server truth →
@@ -1684,30 +1641,33 @@ function AiProviderTab({
 		initialPrimaryChoice,
 		bindingModelIdentity,
 	]);
-	const [syncedIdentity, setSyncedIdentity] = useState(bindingIdentity);
-	if (bindingIdentity !== syncedIdentity) {
-		setSyncedIdentity(bindingIdentity);
-		setBindingMode(initialMode);
-		setSelectedProviders(initialProviderChoices);
-		setPrimaryProviderChoice(initialPrimaryChoice);
-		setPrimaryModel(currentModel);
-	}
-	useEffect(() => {
-		if (
-			bindingMode !== "configured" ||
-			primaryProviderChoice !== MANAGED_AI_CHOICE ||
-			primaryModel.trim()
-		) {
-			return;
-		}
-		const fallback = firstModelForProvider(MANAGED_AI_CHOICE, [], managedModels);
-		if (fallback) setPrimaryModel(fallback);
-	}, [bindingMode, managedModels, primaryModel, primaryProviderChoice]);
-
-	const selectedProviderChoices = normalizeSelectedProviderIds(
-		selectedProviders,
+	const {
+		draft: aiBindingDraft,
+		managedPrimaryModelReady,
+		selectedProviderChoices,
+		setBindingMode,
+		setPrimaryModel,
+		setPrimaryProvider,
+		toggleProvider,
+	} = useAiProviderBindingDraft({
+		initialDraft: {
+			bindingMode: initialMode,
+			providerChoices: initialProviderChoices,
+			primaryProviderChoice: initialPrimaryChoice,
+			primaryModel: currentModel,
+		},
+		managedCatalogReady: managedModelCatalog.isSuccess,
+		managedModels,
+		operationMode: "update",
+		providers: list,
+		syncIdentity: bindingIdentity,
+	});
+	const {
+		bindingMode,
+		primaryModel,
 		primaryProviderChoice,
-	);
+		providerChoices: selectedProviders,
+	} = aiBindingDraft;
 	const selectedIdentity = JSON.stringify(selectedProviderChoices);
 	const initialSelectedIdentity = JSON.stringify(initialProviderChoices);
 	const dirty =
@@ -1716,127 +1676,19 @@ function AiProviderTab({
 			(selectedIdentity !== initialSelectedIdentity ||
 				primaryProviderChoice !== initialPrimaryChoice ||
 				primaryModel !== currentModel));
-	const managedPrimaryModelReady =
-		bindingMode !== "configured" ||
-		primaryProviderChoice !== MANAGED_AI_CHOICE ||
-		(managedModelCatalog.isSuccess &&
-			modelIdsForProvider(MANAGED_AI_CHOICE, [], managedModels).includes(primaryModel));
-
-	function setPrimaryProvider(choice: string) {
-		setBindingMode("configured");
-		const previousCatalog = modelIdsForProvider(primaryProviderChoice, list, managedModels);
-		const nextCatalog = modelIdsForProvider(choice, list, managedModels);
-		const fallback = firstModelForProvider(choice, list, managedModels);
-		setPrimaryProviderChoice(choice);
-		setSelectedProviders((current) => normalizeSelectedProviderIds(current, choice));
-		setPrimaryModel((current) => {
-			const trimmed = current.trim();
-			if (choice === MANAGED_AI_CHOICE && !nextCatalog.includes(trimmed)) return fallback;
-			if (!trimmed) return fallback || current;
-			if (
-				previousCatalog.includes(trimmed) &&
-				nextCatalog.length > 0 &&
-				!nextCatalog.includes(trimmed)
-			) {
-				return fallback;
-			}
-			return current;
-		});
-	}
-
-	function toggleProvider(choice: string) {
-		setBindingMode("configured");
-		const selected = selectedProviders.includes(choice);
-		let next =
-			choice === MANAGED_AI_CHOICE && selectedProviders.some(isUnresolvedProviderChoice)
-				? [MANAGED_AI_CHOICE]
-				: selected
-					? selectedProviders.filter((item) => item !== choice)
-					: selectedProviders.length === 1 &&
-							selectedProviders[0] === MANAGED_AI_CHOICE &&
-							choice !== MANAGED_AI_CHOICE
-						? [choice]
-						: [...selectedProviders, choice];
-		if (next.length === 0) next = [choice];
-		next = dedupeProviderIds(next);
-		setSelectedProviders(next);
-		if (!next.includes(primaryProviderChoice)) {
-			setPrimaryProvider(next[0] ?? MANAGED_AI_CHOICE);
-		}
-	}
-
 	function applyProviderSettings() {
-		if (bindingMode === "unmanaged") {
-			updateDeployment.mutate({
-				id: deployment.resource.id,
-				update: {
-					ai_provider_auth_kind: "unmanaged",
-					ai_provider_id: null,
-					provider_ids: [],
-					primary_model: null,
-					ai_provider_bootstrap: null,
-				},
-			});
-			return;
-		}
-		const normalizedChoices = normalizeSelectedProviderIds(
-			selectedProviders,
-			primaryProviderChoice,
-		);
-		const providerRefs = normalizedChoices
-			.map((choice) => providerRefFromChoice(choice, list))
-			.filter((providerId): providerId is string => Boolean(providerId));
-		if (providerRefs.length !== normalizedChoices.length) {
-			toast.error("Provider unavailable", {
-				description: "Refresh providers before applying these settings.",
-			});
-			return;
-		}
-		const primaryProviderRef =
-			providerRefFromChoice(primaryProviderChoice, list) ?? MANAGED_PROVIDER_ID;
-		if (
-			primaryProviderChoice === MANAGED_AI_CHOICE &&
-			!modelIdsForProvider(MANAGED_AI_CHOICE, [], managedModels).includes(primaryModel)
-		) {
-			toast.error("Managed model unavailable", {
-				description: "Load the managed model catalog and choose a model before applying.",
-			});
-			return;
-		}
-		const modelRef = primaryModelRef(primaryProviderRef, primaryModel);
-		if (!modelRef) {
-			toast.error("Primary model required");
-			return;
-		}
-		const primaryProvider = list.find((provider) => provider.provider_id === primaryProviderChoice);
-		const selectedCustomProviders = list.filter((provider) =>
-			normalizedChoices.includes(provider.provider_id),
-		);
-		const authKind = primaryProvider ? providerAuthKind(primaryProvider) : "managed";
-		const bootstrapProvider = primaryProvider ?? selectedCustomProviders[0];
-		let bootstrap: DeploymentUpdateRequest["ai_provider_bootstrap"] = null;
+		let update: DeploymentUpdateRequest;
 		try {
-			bootstrap =
-				selectedCustomProviders.length > 0 && bootstrapProvider
-					? buildAiProviderPoolBootstrap(
-							selectedCustomProviders,
-							bootstrapProvider.provider_id,
-							providerAuthKind(bootstrapProvider),
-						)
-					: null;
-		} catch (error) {
-			toast.error("Provider configuration is invalid", {
-				description: error instanceof Error ? error.message : "Check provider configuration.",
+			update = buildAiBindingFields(aiBindingDraft, {
+				managedModels,
+				mode: "update",
+				providers: list,
 			});
+		} catch (error) {
+			const copy = aiBindingBuildErrorCopy(error, "update");
+			toast.error(copy.title, copy.description ? { description: copy.description } : undefined);
 			return;
 		}
-		const update: DeploymentUpdateRequest = {
-			ai_provider_auth_kind: authKind,
-			ai_provider_id: primaryProvider ? aiProviderRuntimeId(primaryProvider) : null,
-			provider_ids: providerRefs,
-			ai_provider_bootstrap: bootstrap,
-		};
-		if (modelRef) update.primary_model = modelRef;
 		updateDeployment.mutate({ id: deployment.resource.id, update });
 	}
 

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -64,7 +64,6 @@ import {
 	DEFAULT_DEPLOY_PRIMARY_MODEL,
 	DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE,
 	DEFAULT_DEPLOY_RUNTIME,
-	type DeployWizardAiAccessMode,
 	deployAssistantNameAfterRuntimeChange,
 } from "@/hosted/billing/deploy/deploy-defaults";
 import {
@@ -136,31 +135,24 @@ import {
 } from "@/hosted/billing/wallet/wallet-funding";
 import { type HostedRuntime, runtimeBlurb, runtimeDisplayName } from "@/hosted/runtimes";
 import { AddProviderDialog } from "@/hosted/v2/ai-providers/add-provider-dialog";
+import {
+	aiBindingBuildErrorCopy,
+	buildAiBindingFields,
+} from "@/hosted/v2/ai-providers/ai-provider-binding";
 import { useUserAiProviders } from "@/hosted/v2/ai-providers/ai-providers-hooks";
 import { AuthBadge, ProviderTypeChip } from "@/hosted/v2/ai-providers/ai-providers-ui";
 import { authCardLabel } from "@/hosted/v2/ai-providers/auth-card-label";
 import {
-	dedupeProviderIds,
-	firstModelForProvider,
 	MANAGED_AI_CHOICE,
 	MANAGED_PROVIDER_ID,
 	MANAGED_PROVIDER_LABEL,
 	modelDisplayName,
-	modelIdsForProvider,
 	modelOptionsForProvider,
-	normalizeSelectedProviderIds,
-	primaryModelRef,
 	providerCatalogDescription,
 	providerDisplayLabel,
-	providerRefFromChoice,
 } from "@/hosted/v2/ai-providers/model-binding";
 import { ModelBindingPicker } from "@/hosted/v2/ai-providers/model-binding-picker";
-import {
-	aiProviderRuntimeId,
-	buildAiProviderPoolBootstrap,
-	type RuntimeAiProviderAuthKind,
-} from "@/hosted/v2/ai-providers/runtime-bootstrap";
-import type { AiProvider } from "@/hosted/v2/ai-providers/types";
+import { useAiProviderBindingDraft } from "@/hosted/v2/ai-providers/use-ai-provider-binding-draft";
 import { providerMeta } from "@/hosted/v2/channels/channel-providers";
 import type { ChannelAccount } from "@/hosted/v2/channels/channel-types";
 import { ChannelStatusBadge } from "@/hosted/v2/channels/channel-ui";
@@ -171,7 +163,6 @@ import { useHostedProductAccess } from "@/lib/hosted-product-access";
 import { cn } from "@/lib/utils";
 
 type Compute = "basic" | "performance";
-type AiAccessMode = DeployWizardAiAccessMode;
 type DeployPaymentMethod = "card" | "wallet";
 type NativeDeployCheckout = {
 	clientSecret: string;
@@ -200,12 +191,6 @@ const aiProviderErrorNormalizer: ApiErrorNormalizer = {
 	isAuthError: isApiAuthError,
 	normalizeError: (error) => `${normalizeApiError(error)} Managed AI still works.`,
 };
-
-function aiAuthKind(provider: AiProvider): RuntimeAiProviderAuthKind {
-	return provider.auth.type === "agent_profile" || provider.auth.type === "oauth_profile"
-		? "codex_oauth"
-		: "api_key";
-}
 
 function AddTile({
 	title,
@@ -406,22 +391,11 @@ export function DeployWizard() {
 	const walletCreateAttemptRef = useRef<IdempotencyAttempt | null>(null);
 	const includedCreateAttemptRef = useRef<IdempotencyAttempt | null>(null);
 	const assistantNameEditedRef = useRef(false);
-	const createdProviderGuardRef = useRef<{ providerId: string; dataUpdatedAt: number } | null>(
-		null,
-	);
 
 	const [runtime, setRuntime] = useState(DEFAULT_DEPLOY_RUNTIME);
 	const [assistantName, setAssistantName] = useState(() =>
 		runtimeDisplayName(DEFAULT_DEPLOY_RUNTIME),
 	);
-	const [aiAccessMode, setAiAccessMode] = useState<AiAccessMode>(DEFAULT_DEPLOY_AI_ACCESS_MODE);
-	const [aiProviderChoices, setAiProviderChoices] = useState<string[]>([
-		...DEFAULT_DEPLOY_AI_PROVIDER_CHOICES,
-	]);
-	const [primaryProviderChoice, setPrimaryProviderChoice] = useState(
-		DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE,
-	);
-	const [primaryModel, setPrimaryModel] = useState(DEFAULT_DEPLOY_PRIMARY_MODEL);
 	const [compute, setCompute] = useState<Compute>("basic");
 	const [language, setLanguage] = useState("");
 	const [timezone, setTimezone] = useState("");
@@ -515,15 +489,42 @@ export function DeployWizard() {
 
 	const providerList = aiProviders.data ?? [];
 	const managedModels = managedModelCatalog.data?.models ?? [];
+	const {
+		draft: aiBindingDraft,
+		managedPrimaryModelReady,
+		selectedProviderChoices,
+		selectCreatedProvider: selectCreatedAiProvider,
+		setBindingMode: setAiAccessMode,
+		setPrimaryModel,
+		setPrimaryProvider,
+		toggleProvider: toggleAiProviderChoice,
+	} = useAiProviderBindingDraft({
+		initialDraft: {
+			bindingMode: DEFAULT_DEPLOY_AI_ACCESS_MODE,
+			providerChoices: [...DEFAULT_DEPLOY_AI_PROVIDER_CHOICES],
+			primaryProviderChoice: DEFAULT_DEPLOY_PRIMARY_PROVIDER_CHOICE,
+			primaryModel: DEFAULT_DEPLOY_PRIMARY_MODEL,
+		},
+		managedCatalogReady: managedModelCatalog.isSuccess,
+		managedModels,
+		operationMode: "create",
+		providerCatalog: {
+			dataUpdatedAt: aiProviders.dataUpdatedAt,
+			isFetching: aiProviders.isFetching,
+			isSuccess: aiProviders.isSuccess,
+		},
+		providers: providerList,
+	});
+	const {
+		bindingMode: aiAccessMode,
+		primaryModel,
+		primaryProviderChoice,
+		providerChoices: aiProviderChoices,
+	} = aiBindingDraft;
 	const channelList = channels.data ?? [];
 	const computePlanReady =
 		compute === "performance" ? !!perfPlan && !!perfOfferSelection : !basicUnavailable;
 	const planReady = plans.isSuccess && computePlanReady;
-	const managedPrimaryModelReady =
-		aiAccessMode !== "configured" ||
-		primaryProviderChoice !== MANAGED_AI_CHOICE ||
-		(managedModelCatalog.isSuccess &&
-			modelIdsForProvider(MANAGED_AI_CHOICE, [], managedModels).includes(primaryModel));
 	const canSubmit =
 		planReady &&
 		deployments.isSuccess &&
@@ -540,13 +541,7 @@ export function DeployWizard() {
 				!walletInsufficient));
 
 	function selectCreatedProvider(providerId: string) {
-		createdProviderGuardRef.current = {
-			providerId,
-			dataUpdatedAt: aiProviders.dataUpdatedAt,
-		};
-		setAiAccessMode("configured");
-		setAiProviderChoices([providerId]);
-		setPrimaryProvider(providerId);
+		selectCreatedAiProvider(providerId, aiProviders.dataUpdatedAt);
 	}
 
 	function selectRuntime(nextRuntime: HostedRuntime) {
@@ -577,170 +572,22 @@ export function DeployWizard() {
 		if (paymentMethod === "wallet" && walletDisabledReason) setPaymentMethod("card");
 	}, [paymentMethod, walletDisabledReason]);
 
-	// Don't let the selection silently degrade to managed: if the chosen
-	// provider vanishes from a SUCCESSFULLY-loaded list (deleted elsewhere),
-	// reset to managed so the UI and the deploy request agree.
-	useEffect(() => {
-		const providerIds = new Set(providerList.map((provider) => provider.provider_id));
-		const createdGuard = createdProviderGuardRef.current;
-
-		let nextChoices = aiProviderChoices.filter(
-			(choice) => choice === MANAGED_AI_CHOICE || providerIds.has(choice),
-		);
-		if (nextChoices.some((choice) => choice === createdGuard?.providerId)) {
-			createdProviderGuardRef.current = null;
-		}
-
-		if (createdGuard && aiProviderChoices.includes(createdGuard.providerId)) {
-			if (aiProviders.dataUpdatedAt <= createdGuard.dataUpdatedAt) return;
-			createdProviderGuardRef.current = null;
-		}
-
-		if (aiProviders.isSuccess && !aiProviders.isFetching) {
-			if (nextChoices.length === 0) nextChoices = [MANAGED_AI_CHOICE];
-			const normalized = dedupeProviderIds(nextChoices);
-			if (normalized.join("\0") !== aiProviderChoices.join("\0")) {
-				setAiProviderChoices(normalized);
-			}
-			if (!normalized.includes(primaryProviderChoice)) {
-				setPrimaryProvider(normalized[0] ?? MANAGED_AI_CHOICE);
-			}
-		}
-	}, [
-		aiProviderChoices,
-		aiProviders.dataUpdatedAt,
-		aiProviders.isFetching,
-		aiProviders.isSuccess,
-		primaryProviderChoice,
-		providerList,
-	]);
-
-	useEffect(() => {
-		if (primaryModel.trim()) return;
-		const fallback = firstModelForProvider(
-			primaryProviderChoice,
-			providerList,
-			managedModelCatalog.data?.models ?? [],
-		);
-		if (fallback) setPrimaryModel(fallback);
-	}, [managedModelCatalog.data?.models, primaryModel, primaryProviderChoice, providerList]);
-
 	function setComputeTier(next: Compute) {
 		setCompute(next);
 	}
 
-	function providerUnavailable(
-		description = `Refresh providers or choose ${MANAGED_PROVIDER_LABEL}.`,
-	) {
-		toast.error("Provider unavailable", { description });
-	}
-
-	function setPrimaryProvider(choice: string) {
-		setAiAccessMode("configured");
-		const providers = providerList;
-		const managedModels = managedModelCatalog.data?.models ?? [];
-		const previousCatalog = modelIdsForProvider(primaryProviderChoice, providers, managedModels);
-		const nextCatalog = modelIdsForProvider(choice, providers, managedModels);
-		const fallback = firstModelForProvider(choice, providers, managedModels);
-		setPrimaryProviderChoice(choice);
-		setAiProviderChoices((current) => normalizeSelectedProviderIds(current, choice));
-		setPrimaryModel((current) => {
-			const trimmed = current.trim();
-			if (choice === MANAGED_AI_CHOICE && !nextCatalog.includes(trimmed)) return fallback;
-			if (!trimmed) return fallback;
-			if (
-				previousCatalog.includes(trimmed) &&
-				nextCatalog.length > 0 &&
-				!nextCatalog.includes(trimmed)
-			) {
-				return fallback;
-			}
-			return current;
-		});
-	}
-
-	function toggleAiProviderChoice(choice: string) {
-		setAiAccessMode("configured");
-		const selected = aiProviderChoices.includes(choice);
-		let next = selected
-			? aiProviderChoices.filter((item) => item !== choice)
-			: aiProviderChoices.length === 1 &&
-					aiProviderChoices[0] === MANAGED_AI_CHOICE &&
-					choice !== MANAGED_AI_CHOICE
-				? [choice]
-				: [...aiProviderChoices, choice];
-		if (next.length === 0) next = [choice];
-		next = dedupeProviderIds(next);
-		setAiProviderChoices(next);
-		if (!next.includes(primaryProviderChoice)) {
-			setPrimaryProvider(next[0] ?? MANAGED_AI_CHOICE);
-		}
-	}
-
 	function aiDeployFields(): DeployAiFields | null {
-		if (aiAccessMode === "unmanaged") {
-			return { ai_provider_auth_kind: "unmanaged" };
-		}
-		const selectedChoices = normalizeSelectedProviderIds(aiProviderChoices, primaryProviderChoice);
-		const providerRefs = selectedChoices
-			.map((choice) => providerRefFromChoice(choice, providerList))
-			.filter((providerId): providerId is string => Boolean(providerId));
-		if (providerRefs.length !== selectedChoices.length) {
-			providerUnavailable();
-			return null;
-		}
-
-		const primaryProviderRef =
-			providerRefFromChoice(primaryProviderChoice, providerList) ?? MANAGED_PROVIDER_ID;
-		if (
-			primaryProviderChoice === MANAGED_AI_CHOICE &&
-			!modelIdsForProvider(MANAGED_AI_CHOICE, [], managedModelCatalog.data?.models ?? []).includes(
-				primaryModel,
-			)
-		) {
-			toast.error("Managed model unavailable", {
-				description: "Load the managed model catalog and choose a model before deploying.",
+		try {
+			return buildAiBindingFields(aiBindingDraft, {
+				managedModels,
+				mode: "create",
+				providers: providerList,
 			});
+		} catch (error) {
+			const copy = aiBindingBuildErrorCopy(error, "create");
+			toast.error(copy.title, copy.description ? { description: copy.description } : undefined);
 			return null;
 		}
-		const modelRef = primaryModelRef(primaryProviderRef, primaryModel);
-		if (!modelRef) {
-			toast.error("Primary model required", {
-				description: "Choose a catalog model or enter a model id.",
-			});
-			return null;
-		}
-		const primaryProvider = providerList.find(
-			(provider) => provider.provider_id === primaryProviderChoice,
-		);
-		const primaryKind = primaryProvider ? aiAuthKind(primaryProvider) : "managed";
-		const customProviders = selectedChoices
-			.filter((choice) => choice !== MANAGED_AI_CHOICE)
-			.map((choice) => providerList.find((provider) => provider.provider_id === choice))
-			.filter((provider): provider is AiProvider => Boolean(provider));
-		const body: DeployAiFields = {
-			ai_provider_id: primaryProvider ? aiProviderRuntimeId(primaryProvider) : null,
-			ai_provider_auth_kind: primaryKind,
-			provider_ids: providerRefs,
-		};
-		if (modelRef) body.primary_model = modelRef;
-		if (customProviders.length > 0) {
-			const bootstrapSelectedProvider = primaryProvider ?? customProviders[0];
-			const bootstrapKind = aiAuthKind(bootstrapSelectedProvider);
-			try {
-				body.ai_provider_bootstrap = buildAiProviderPoolBootstrap(
-					customProviders,
-					bootstrapSelectedProvider.provider_id,
-					bootstrapKind,
-				);
-			} catch (error) {
-				providerUnavailable(
-					error instanceof Error ? error.message : "Check provider configuration.",
-				);
-				return null;
-			}
-		}
-		return body;
 	}
 
 	function buildDeployRequest(
@@ -1020,10 +867,7 @@ export function DeployWizard() {
 						: "Review wallet quote"
 			: "Continue to checkout"
 		: "Deploy agent";
-	const selectedProviderCount =
-		aiAccessMode === "configured"
-			? normalizeSelectedProviderIds(aiProviderChoices, primaryProviderChoice).length
-			: 0;
+	const selectedProviderCount = aiAccessMode === "configured" ? selectedProviderChoices.length : 0;
 	const primaryProvider = providerList.find(
 		(provider) => provider.provider_id === primaryProviderChoice,
 	);
@@ -1217,10 +1061,7 @@ export function DeployWizard() {
 							managedModelsErrorNormalizer={billingErrorNormalizer}
 							onManagedModelsRetry={() => void managedModelCatalog.refetch()}
 							customProviders={providerList}
-							selectedProviderChoices={normalizeSelectedProviderIds(
-								aiProviderChoices,
-								primaryProviderChoice,
-							)}
+							selectedProviderChoices={selectedProviderChoices}
 							primaryProviderChoice={primaryProviderChoice}
 							primaryModel={primaryModel}
 							onPrimaryProviderChange={setPrimaryProvider}

--- a/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+import {
+	AiBindingBuildError,
+	buildAiBindingFields,
+	isUnresolvedProviderChoice,
+	unresolvedProviderChoice,
+	updateProviderChoiceFromRef,
+} from "@/hosted/v2/ai-providers/ai-provider-binding";
+import { MANAGED_AI_CHOICE, MANAGED_PROVIDER_ID } from "@/hosted/v2/ai-providers/model-binding";
+import type { AiProvider } from "@/hosted/v2/ai-providers/types";
+import {
+	changeAiBindingPrimaryProvider,
+	toggleAiBindingProvider,
+} from "@/hosted/v2/ai-providers/use-ai-provider-binding-draft";
+
+const managedModels = [{ id: "gpt-managed", display_name: "Managed", is_default: true }];
+
+const apiKeyProvider: AiProvider = {
+	id: "row-api-key",
+	provider_id: "openai-main",
+	scope: "user",
+	type: "openai",
+	label: "OpenAI",
+	base_url: "https://api.openai.com/v1",
+	models: [{ id: "gpt-custom" }],
+	api_mode: "openai_responses",
+	auth: { type: "api_key", source: "managed" },
+	managed_by: "user",
+	runtime_env_name: "OPENAI_API_KEY",
+	capabilities: null,
+	created_at: "2026-01-01T00:00:00Z",
+	updated_at: "2026-01-01T00:00:00Z",
+};
+
+const oauthProvider: AiProvider = {
+	...apiKeyProvider,
+	id: "row-oauth",
+	provider_id: "codex-main",
+	label: "Codex",
+	auth: { type: "agent_profile", tool: "codex", profile: "default" },
+};
+
+describe("AI provider binding fields", () => {
+	test("create omits update-only clear fields for an unmanaged binding", () => {
+		expect(
+			buildAiBindingFields(
+				{
+					bindingMode: "unmanaged",
+					providerChoices: [MANAGED_AI_CHOICE],
+					primaryProviderChoice: MANAGED_AI_CHOICE,
+					primaryModel: "",
+				},
+				{ managedModels, mode: "create", providers: [] },
+			),
+		).toEqual({ ai_provider_auth_kind: "unmanaged" });
+	});
+
+	test("update explicitly clears every stale field for an unmanaged binding", () => {
+		expect(
+			buildAiBindingFields(
+				{
+					bindingMode: "unmanaged",
+					providerChoices: [MANAGED_AI_CHOICE],
+					primaryProviderChoice: MANAGED_AI_CHOICE,
+					primaryModel: "",
+				},
+				{ managedModels, mode: "update", providers: [] },
+			),
+		).toEqual({
+			ai_provider_auth_kind: "unmanaged",
+			ai_provider_id: null,
+			provider_ids: [],
+			primary_model: null,
+			ai_provider_bootstrap: null,
+		});
+	});
+
+	test("create omits an empty bootstrap while update clears it", () => {
+		const draft = {
+			bindingMode: "configured" as const,
+			providerChoices: [MANAGED_AI_CHOICE],
+			primaryProviderChoice: MANAGED_AI_CHOICE,
+			primaryModel: "gpt-managed",
+		};
+
+		const createFields = buildAiBindingFields(draft, {
+			managedModels,
+			mode: "create",
+			providers: [],
+		});
+		const updateFields = buildAiBindingFields(draft, {
+			managedModels,
+			mode: "update",
+			providers: [],
+		});
+
+		expect(createFields).toEqual({
+			ai_provider_auth_kind: "managed",
+			ai_provider_id: null,
+			provider_ids: [MANAGED_PROVIDER_ID],
+			primary_model: { provider_id: MANAGED_PROVIDER_ID, model: "gpt-managed" },
+		});
+		expect(updateFields).toEqual({ ...createFields, ai_provider_bootstrap: null });
+	});
+
+	test("uses one auth mapping and selection order for create and update bootstraps", () => {
+		const draft = {
+			bindingMode: "configured" as const,
+			providerChoices: [MANAGED_AI_CHOICE, oauthProvider.provider_id, apiKeyProvider.provider_id],
+			primaryProviderChoice: MANAGED_AI_CHOICE,
+			primaryModel: "gpt-managed",
+		};
+
+		for (const mode of ["create", "update"] as const) {
+			const fields = buildAiBindingFields(draft, {
+				managedModels,
+				mode,
+				providers: [apiKeyProvider, oauthProvider],
+			});
+
+			expect(fields.provider_ids).toEqual([
+				MANAGED_PROVIDER_ID,
+				oauthProvider.provider_id,
+				apiKeyProvider.provider_id,
+			]);
+			expect(fields.ai_provider_bootstrap?.selected_provider_id).toBe(oauthProvider.provider_id);
+			expect(fields.ai_provider_bootstrap?.auth_kind).toBe("codex_oauth");
+			expect(
+				fields.ai_provider_bootstrap?.catalog.providers.map((provider) => provider.id),
+			).toEqual([oauthProvider.provider_id, apiKeyProvider.provider_id]);
+		}
+	});
+});
+
+describe("AI provider binding draft transitions", () => {
+	test("preserves the create and update model-fallback difference", () => {
+		const draft = {
+			bindingMode: "configured" as const,
+			providerChoices: [MANAGED_AI_CHOICE],
+			primaryProviderChoice: MANAGED_AI_CHOICE,
+			primaryModel: "   ",
+		};
+
+		expect(
+			changeAiBindingPrimaryProvider(draft, "missing-models", {
+				managedModels,
+				operationMode: "create",
+				providers: [],
+			}).primaryModel,
+		).toBe("");
+		expect(
+			changeAiBindingPrimaryProvider(draft, "missing-models", {
+				managedModels,
+				operationMode: "update",
+				providers: [],
+			}).primaryModel,
+		).toBe("   ");
+	});
+
+	test("keeps unresolved providers visible only for update and replaces them with managed", () => {
+		const unresolved = updateProviderChoiceFromRef("deleted-provider", []);
+		expect(unresolved).toBe(unresolvedProviderChoice("deleted-provider"));
+		expect(unresolved && isUnresolvedProviderChoice(unresolved)).toBe(true);
+		if (!unresolved) throw new Error("Expected an unresolved provider choice.");
+
+		const draft = {
+			bindingMode: "configured" as const,
+			providerChoices: [unresolved],
+			primaryProviderChoice: unresolved,
+			primaryModel: "legacy-model",
+		};
+		const updateDraft = toggleAiBindingProvider(draft, MANAGED_AI_CHOICE, {
+			managedModels,
+			operationMode: "update",
+			providers: [],
+		});
+		const createDraft = toggleAiBindingProvider(draft, MANAGED_AI_CHOICE, {
+			managedModels,
+			operationMode: "create",
+			providers: [],
+		});
+
+		expect(updateDraft.providerChoices).toEqual([MANAGED_AI_CHOICE]);
+		expect(updateDraft.primaryProviderChoice).toBe(MANAGED_AI_CHOICE);
+		expect(updateDraft.primaryModel).toBe("gpt-managed");
+		expect(createDraft.providerChoices).toEqual([unresolved, MANAGED_AI_CHOICE]);
+		expect(createDraft.primaryProviderChoice).toBe(unresolved);
+		expect(() =>
+			buildAiBindingFields(draft, { managedModels, mode: "update", providers: [] }),
+		).toThrow(AiBindingBuildError);
+	});
+});

--- a/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/ai-provider-binding.ts
@@ -1,0 +1,194 @@
+import type { AiProviderAuthKind, ManagedModelCatalogItem } from "@/hosted/billing/contracts";
+import {
+	MANAGED_AI_CHOICE,
+	MANAGED_PROVIDER_ID,
+	MANAGED_PROVIDER_LABEL,
+	modelIdsForProvider,
+	normalizeSelectedProviderIds,
+	primaryModelRef,
+	providerChoiceFromRef,
+	providerRefFromChoice,
+} from "@/hosted/v2/ai-providers/model-binding";
+import {
+	aiProviderRuntimeId,
+	buildAiProviderPoolBootstrap,
+	type RuntimeAiProviderAuthKind,
+	type RuntimeAiProviderBootstrap,
+} from "@/hosted/v2/ai-providers/runtime-bootstrap";
+import type { AiProvider } from "@/hosted/v2/ai-providers/types";
+
+export type AiBindingOperationMode = "create" | "update";
+export type AiBindingMode = "unmanaged" | "configured";
+
+export type AiProviderBindingDraft = {
+	bindingMode: AiBindingMode;
+	providerChoices: string[];
+	primaryProviderChoice: string;
+	primaryModel: string;
+};
+
+export type AiBindingFields = {
+	ai_provider_auth_kind: AiProviderAuthKind;
+	ai_provider_id?: string | null;
+	provider_ids?: string[];
+	primary_model?: ReturnType<typeof primaryModelRef>;
+	ai_provider_bootstrap?: RuntimeAiProviderBootstrap | null;
+};
+
+export class AiBindingBuildError extends Error {
+	readonly title: string;
+	readonly description?: string;
+
+	constructor(title: string, description?: string) {
+		super(description ?? title);
+		this.name = "AiBindingBuildError";
+		this.title = title;
+		this.description = description;
+	}
+}
+
+const UNRESOLVED_PROVIDER_PREFIX = "unresolved:";
+
+export function unresolvedProviderChoice(providerRef: string): string {
+	return `${UNRESOLVED_PROVIDER_PREFIX}${providerRef}`;
+}
+
+export function isUnresolvedProviderChoice(choice: string): boolean {
+	return choice.startsWith(UNRESOLVED_PROVIDER_PREFIX);
+}
+
+export function unresolvedProviderRef(choice: string): string {
+	return choice.slice(UNRESOLVED_PROVIDER_PREFIX.length);
+}
+
+export function updateProviderChoiceFromRef(
+	providerRef: string | null | undefined,
+	providers: readonly AiProvider[],
+): string | null {
+	if (!providerRef) return null;
+	const choice = providerChoiceFromRef(providerRef, providers);
+	if (!choice) return null;
+	if (
+		choice === MANAGED_AI_CHOICE ||
+		providers.some((provider) => provider.provider_id === choice)
+	) {
+		return choice;
+	}
+	return unresolvedProviderChoice(providerRef);
+}
+
+export function buildAiBindingFields(
+	draft: AiProviderBindingDraft,
+	{
+		managedModels,
+		mode,
+		providers,
+	}: {
+		managedModels: readonly ManagedModelCatalogItem[];
+		mode: AiBindingOperationMode;
+		providers: readonly AiProvider[];
+	},
+): AiBindingFields {
+	if (draft.bindingMode === "unmanaged") {
+		return mode === "create"
+			? { ai_provider_auth_kind: "unmanaged" }
+			: {
+					ai_provider_auth_kind: "unmanaged",
+					ai_provider_id: null,
+					provider_ids: [],
+					primary_model: null,
+					ai_provider_bootstrap: null,
+				};
+	}
+
+	const selectedChoices = normalizeSelectedProviderIds(
+		draft.providerChoices,
+		draft.primaryProviderChoice,
+	);
+	const providerRefs = selectedChoices
+		.map((choice) => providerRefFromChoice(choice, providers))
+		.filter((providerId): providerId is string => Boolean(providerId));
+	if (providerRefs.length !== selectedChoices.length) {
+		throw new AiBindingBuildError(
+			"Provider unavailable",
+			mode === "create"
+				? `Refresh providers or choose ${MANAGED_PROVIDER_LABEL}.`
+				: "Refresh providers before applying these settings.",
+		);
+	}
+
+	const primaryProviderRef =
+		providerRefFromChoice(draft.primaryProviderChoice, providers) ?? MANAGED_PROVIDER_ID;
+	if (
+		draft.primaryProviderChoice === MANAGED_AI_CHOICE &&
+		!modelIdsForProvider(MANAGED_AI_CHOICE, [], managedModels).includes(draft.primaryModel)
+	) {
+		throw new AiBindingBuildError(
+			"Managed model unavailable",
+			mode === "create"
+				? "Load the managed model catalog and choose a model before deploying."
+				: "Load the managed model catalog and choose a model before applying.",
+		);
+	}
+
+	const modelRef = primaryModelRef(primaryProviderRef, draft.primaryModel);
+	if (!modelRef) {
+		throw new AiBindingBuildError(
+			"Primary model required",
+			mode === "create" ? "Choose a catalog model or enter a model id." : undefined,
+		);
+	}
+
+	const primaryProvider = providers.find(
+		(provider) => provider.provider_id === draft.primaryProviderChoice,
+	);
+	const customProviders = selectedChoices
+		.filter((choice) => choice !== MANAGED_AI_CHOICE)
+		.map((choice) => providers.find((provider) => provider.provider_id === choice))
+		.filter((provider): provider is AiProvider => Boolean(provider));
+	const fields: AiBindingFields = {
+		ai_provider_auth_kind: primaryProvider ? providerAuthKind(primaryProvider) : "managed",
+		ai_provider_id: primaryProvider ? aiProviderRuntimeId(primaryProvider) : null,
+		provider_ids: providerRefs,
+		primary_model: modelRef,
+	};
+
+	if (customProviders.length > 0) {
+		const bootstrapProvider = primaryProvider ?? customProviders[0];
+		try {
+			fields.ai_provider_bootstrap = buildAiProviderPoolBootstrap(
+				customProviders,
+				bootstrapProvider.provider_id,
+				providerAuthKind(bootstrapProvider),
+			);
+		} catch (error) {
+			throw new AiBindingBuildError(
+				mode === "create" ? "Provider unavailable" : "Provider configuration is invalid",
+				error instanceof Error ? error.message : "Check provider configuration.",
+			);
+		}
+	} else if (mode === "update") {
+		fields.ai_provider_bootstrap = null;
+	}
+
+	return fields;
+}
+
+export function aiBindingBuildErrorCopy(
+	error: unknown,
+	mode: AiBindingOperationMode,
+): { title: string; description?: string } {
+	if (error instanceof AiBindingBuildError) {
+		return { title: error.title, description: error.description };
+	}
+	return {
+		title: mode === "create" ? "Provider unavailable" : "Provider configuration is invalid",
+		description: error instanceof Error ? error.message : "Check provider configuration.",
+	};
+}
+
+function providerAuthKind(provider: AiProvider): RuntimeAiProviderAuthKind {
+	return provider.auth.type === "agent_profile" || provider.auth.type === "oauth_profile"
+		? "codex_oauth"
+		: "api_key";
+}

--- a/apps/web/src/hosted/v2/ai-providers/use-ai-provider-binding-draft.ts
+++ b/apps/web/src/hosted/v2/ai-providers/use-ai-provider-binding-draft.ts
@@ -1,0 +1,196 @@
+import { useEffect, useRef, useState } from "react";
+import type { ManagedModelCatalogItem } from "@/hosted/billing/contracts";
+import {
+	type AiBindingMode,
+	type AiBindingOperationMode,
+	type AiProviderBindingDraft,
+	isUnresolvedProviderChoice,
+} from "@/hosted/v2/ai-providers/ai-provider-binding";
+import {
+	dedupeProviderIds,
+	firstModelForProvider,
+	MANAGED_AI_CHOICE,
+	modelIdsForProvider,
+	normalizeSelectedProviderIds,
+} from "@/hosted/v2/ai-providers/model-binding";
+import type { AiProvider } from "@/hosted/v2/ai-providers/types";
+
+type DraftContext = {
+	managedModels: readonly ManagedModelCatalogItem[];
+	operationMode: AiBindingOperationMode;
+	providers: readonly AiProvider[];
+};
+
+type ProviderCatalogState = {
+	dataUpdatedAt: number;
+	isFetching: boolean;
+	isSuccess: boolean;
+};
+
+export function changeAiBindingPrimaryProvider(
+	draft: AiProviderBindingDraft,
+	choice: string,
+	context: DraftContext,
+): AiProviderBindingDraft {
+	const previous = modelIdsForProvider(
+		draft.primaryProviderChoice,
+		context.providers,
+		context.managedModels,
+	);
+	const next = modelIdsForProvider(choice, context.providers, context.managedModels);
+	const fallback = firstModelForProvider(choice, context.providers, context.managedModels);
+	const current = draft.primaryModel;
+	const trimmed = current.trim();
+	const primaryModel =
+		choice === MANAGED_AI_CHOICE && !next.includes(trimmed)
+			? fallback
+			: !trimmed
+				? context.operationMode === "update"
+					? fallback || current
+					: fallback
+				: previous.includes(trimmed) && next.length > 0 && !next.includes(trimmed)
+					? fallback
+					: current;
+	return {
+		...draft,
+		bindingMode: "configured",
+		providerChoices: normalizeSelectedProviderIds(draft.providerChoices, choice),
+		primaryProviderChoice: choice,
+		primaryModel,
+	};
+}
+
+export function toggleAiBindingProvider(
+	draft: AiProviderBindingDraft,
+	choice: string,
+	context: DraftContext,
+): AiProviderBindingDraft {
+	const selected = draft.providerChoices.includes(choice);
+	let choices =
+		context.operationMode === "update" &&
+		choice === MANAGED_AI_CHOICE &&
+		draft.providerChoices.some(isUnresolvedProviderChoice)
+			? [MANAGED_AI_CHOICE]
+			: selected
+				? draft.providerChoices.filter((item) => item !== choice)
+				: draft.providerChoices.length === 1 &&
+						draft.providerChoices[0] === MANAGED_AI_CHOICE &&
+						choice !== MANAGED_AI_CHOICE
+					? [choice]
+					: [...draft.providerChoices, choice];
+	if (choices.length === 0) choices = [choice];
+	choices = dedupeProviderIds(choices);
+	const next = { ...draft, bindingMode: "configured" as const, providerChoices: choices };
+	return choices.includes(draft.primaryProviderChoice)
+		? next
+		: changeAiBindingPrimaryProvider(next, choices[0] ?? MANAGED_AI_CHOICE, context);
+}
+
+export function useAiProviderBindingDraft({
+	initialDraft,
+	managedCatalogReady,
+	managedModels,
+	operationMode,
+	providerCatalog,
+	providers,
+	syncIdentity,
+}: {
+	initialDraft: AiProviderBindingDraft;
+	managedCatalogReady: boolean;
+	managedModels: readonly ManagedModelCatalogItem[];
+	operationMode: AiBindingOperationMode;
+	providerCatalog?: ProviderCatalogState;
+	providers: readonly AiProvider[];
+	syncIdentity?: string;
+}) {
+	const context = { managedModels, operationMode, providers };
+	const [draft, setDraft] = useState(initialDraft);
+	const [syncedIdentity, setSyncedIdentity] = useState(syncIdentity);
+	const createdProvider = useRef<{ id: string; dataUpdatedAt: number } | null>(null);
+
+	if (syncIdentity !== undefined && syncIdentity !== syncedIdentity) {
+		setSyncedIdentity(syncIdentity);
+		setDraft(initialDraft);
+	}
+
+	useEffect(() => {
+		setDraft((current) => {
+			if (current.primaryModel.trim()) return current;
+			if (
+				operationMode === "update" &&
+				(current.bindingMode !== "configured" ||
+					current.primaryProviderChoice !== MANAGED_AI_CHOICE)
+			) {
+				return current;
+			}
+			const choice = operationMode === "create" ? current.primaryProviderChoice : MANAGED_AI_CHOICE;
+			const fallback = firstModelForProvider(
+				choice,
+				operationMode === "create" ? providers : [],
+				managedModels,
+			);
+			return fallback ? { ...current, primaryModel: fallback } : current;
+		});
+	}, [draft, managedModels, operationMode, providers]);
+
+	useEffect(() => {
+		if (operationMode !== "create" || !providerCatalog) return;
+		setDraft((current) => {
+			const providerIds = new Set(providers.map((provider) => provider.provider_id));
+			const guard = createdProvider.current;
+			let choices = current.providerChoices.filter(
+				(choice) => choice === MANAGED_AI_CHOICE || providerIds.has(choice),
+			);
+			if (choices.includes(guard?.id ?? "")) createdProvider.current = null;
+			if (guard && current.providerChoices.includes(guard.id)) {
+				if (providerCatalog.dataUpdatedAt <= guard.dataUpdatedAt) return current;
+				createdProvider.current = null;
+			}
+			if (!providerCatalog.isSuccess || providerCatalog.isFetching) return current;
+			if (choices.length === 0) choices = [MANAGED_AI_CHOICE];
+			choices = dedupeProviderIds(choices);
+			const unchanged = choices.join("\0") === current.providerChoices.join("\0");
+			if (unchanged && choices.includes(current.primaryProviderChoice)) return current;
+			const next = { ...current, providerChoices: choices };
+			return choices.includes(current.primaryProviderChoice)
+				? next
+				: changeAiBindingPrimaryProvider(next, choices[0] ?? MANAGED_AI_CHOICE, context);
+		});
+	}, [
+		draft,
+		managedModels,
+		operationMode,
+		providerCatalog?.dataUpdatedAt,
+		providerCatalog?.isFetching,
+		providerCatalog?.isSuccess,
+		providers,
+	]);
+
+	const selectedProviderChoices = normalizeSelectedProviderIds(
+		draft.providerChoices,
+		draft.primaryProviderChoice,
+	);
+	return {
+		draft,
+		selectedProviderChoices,
+		managedPrimaryModelReady:
+			draft.bindingMode !== "configured" ||
+			draft.primaryProviderChoice !== MANAGED_AI_CHOICE ||
+			(managedCatalogReady &&
+				modelIdsForProvider(MANAGED_AI_CHOICE, [], managedModels).includes(draft.primaryModel)),
+		setBindingMode: (bindingMode: AiBindingMode) =>
+			setDraft((current) => ({ ...current, bindingMode })),
+		setPrimaryModel: (primaryModel: string) =>
+			setDraft((current) => ({ ...current, primaryModel })),
+		setPrimaryProvider: (choice: string) =>
+			setDraft((current) => changeAiBindingPrimaryProvider(current, choice, context)),
+		toggleProvider: (choice: string) =>
+			setDraft((current) => toggleAiBindingProvider(current, choice, context)),
+		selectCreatedProvider: (id: string, dataUpdatedAt: number) => {
+			createdProvider.current = { id, dataUpdatedAt };
+			setDraft((current) =>
+				changeAiBindingPrimaryProvider({ ...current, providerChoices: [id] }, id, context),
+			);
+		},
+	};
+}


### PR DESCRIPTION
## Summary

- add one `useAiProviderBindingDraft` hook for binding mode, provider selection, primary provider/model transitions, fallback behavior, catalog readiness, create-list reconciliation, and update resync
- add one pure `buildAiBindingFields` builder for auth mapping, provider refs, managed-model validation, bootstrap, and primary-model fields
- wire both the deploy wizard create flow and hosted agent detail update flow directly to the shared draft and builder

## Preserved create/update semantics

- create keeps fallback-only model switching; update keeps `fallback || current`
- update preserves unresolved provider references in the draft and replaces them only through the existing managed-provider transition; create does not synthesize unresolved choices
- unmanaged create emits only `ai_provider_auth_kind`; unmanaged update explicitly clears provider ids, primary model, and bootstrap
- managed create omits an empty bootstrap; managed update sends `null` to clear a stale bootstrap
- existing create provider-list reconciliation and update server-binding resync remain mode-specific

## Drift decision

The update copy built custom-provider bootstrap catalogs in provider-query order while create used selected-provider order. That looked accidental: it could make the bootstrap selected provider disagree with the first custom `provider_ids` entry when managed AI was primary. The shared builder uses selected-provider order for both paths, keeping provider refs and bootstrap deterministic and aligned.

The two converged call sites remove 307 net lines (401 removed, 94 wiring lines added). The full diff is +275 lines after adding the shared implementation and 192 lines of focused tests.

Billing money math, deployment mutation/LRO handling, and the deploy-contract-drift workflow are untouched.

## Verification

- `bun run --cwd apps/web test` — 555 pass
- `bun run --cwd apps/web typecheck`
- `bun run --cwd apps/web lint`
- `bunx biome check apps/web/src`