### PR TITLE
fix(v2 web): UX best-practice polish wave 1 (deploy/onboarding/terminology/security)

### DIFF
--- a/apps/web/src/components/dashboard/onboarding-card.tsx
+++ b/apps/web/src/components/dashboard/onboarding-card.tsx
@@ -1,24 +1,37 @@
-import { Rocket } from "lucide-react";
+"use client";
+
+import { Link } from "@tanstack/react-router";
+import { Rocket, TerminalSquare } from "lucide-react";
+import { useState } from "react";
 import { AddAgentSetup } from "@/components/dashboard/add-agent-setup";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 
 type OnboardingCardProps = {
 	variant?: "first-agent" | "additional-agent";
+	hosted?: boolean;
 };
 
 /**
  * Overview hero card for connecting a new agent. Rendered in the Overview
  * primary slot when the user has zero agents, and as a secondary
- * side-panel card once at least one agent is registered. Shares its
- * Tabs + steps body with the sidebar Quick Create affordance — see
- * `AddAgentSetup`.
+ * side-panel card once at least one agent is registered. Hosted first-agent
+ * onboarding leads with deploy and reveals the shared CLI setup on demand.
  */
-export function OnboardingCard({ variant = "first-agent" }: OnboardingCardProps) {
+export function OnboardingCard({ variant = "first-agent", hosted = false }: OnboardingCardProps) {
+	const [showCliSetup, setShowCliSetup] = useState(false);
 	const isAdditionalAgent = variant === "additional-agent";
-	const title = isAdditionalAgent ? "Add another agent" : "Let's connect your first agent";
+	const showHostedFirstAgentChoice = hosted && !isAdditionalAgent;
+	const title = isAdditionalAgent
+		? "Add another agent"
+		: showHostedFirstAgentChoice
+			? "Get your first agent running"
+			: "Let's connect your first agent";
 	const description = isAdditionalAgent
 		? "Manage multiple agents from one place. Projects help each agent use the right skills and credentials."
-		: "Connect an agent first. Then create a Project to organize reusable skills and credentials you can share with teammates.";
+		: showHostedFirstAgentChoice
+			? "Deploy a fully hosted agent in minutes, or connect an agent you already run with the CLI."
+			: "Connect an agent first. Then create a Project to organize reusable skills and credentials you can share with teammates.";
 
 	return (
 		<Card>
@@ -29,8 +42,39 @@ export function OnboardingCard({ variant = "first-agent" }: OnboardingCardProps)
 				</CardTitle>
 				<CardDescription>{description}</CardDescription>
 			</CardHeader>
-			<CardContent>
-				<AddAgentSetup />
+			<CardContent className="space-y-5">
+				{showHostedFirstAgentChoice ? (
+					<>
+						<div className="flex flex-col gap-2 sm:flex-row">
+							<Button render={<Link to="/deploy" />} nativeButton={false} size="lg">
+								<Rocket data-icon="inline-start" /> Deploy a hosted agent
+							</Button>
+							<Button
+								type="button"
+								variant="outline"
+								size="lg"
+								aria-expanded={showCliSetup}
+								aria-controls={showCliSetup ? "first-agent-cli-setup" : undefined}
+								onClick={() => setShowCliSetup((visible) => !visible)}
+							>
+								<TerminalSquare data-icon="inline-start" /> Connect via CLI
+							</Button>
+						</div>
+						{showCliSetup ? (
+							<div id="first-agent-cli-setup" className="space-y-4 border-t pt-5">
+								<div>
+									<h3 className="text-sm font-semibold">Connect an agent you already run</h3>
+									<p className="text-sm text-muted-foreground">
+										Run the setup command on the machine where your agent lives.
+									</p>
+								</div>
+								<AddAgentSetup />
+							</div>
+						) : null}
+					</>
+				) : (
+					<AddAgentSetup />
+				)}
 			</CardContent>
 		</Card>
 	);

--- a/apps/web/src/hosted/agents/hosted-agent-detail.tsx
+++ b/apps/web/src/hosted/agents/hosted-agent-detail.tsx
@@ -635,7 +635,7 @@ function HostedProjectionNotice({
 			<ApiErrorPanel
 				error={projection.error}
 				onRetry={onRetry}
-				title="Agent sync service unavailable"
+				title="Couldn’t sync agent details"
 			/>
 		);
 	}
@@ -643,12 +643,11 @@ function HostedProjectionNotice({
 		return (
 			<Alert data-hosted="true">
 				<AlertCircle />
-				<AlertTitle>Agent sync record unavailable</AlertTitle>
+				<AlertTitle>Some details are still syncing</AlertTitle>
 				<AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
 					<span>
-						Deployment controls remain available; Runtime UI and Terminal continue to follow
-						deployment status. Sessions, skills, profile, and channels will recover when the cloud
-						projection catches up.
+						You can manage compute and open available tools now. Sessions, skills, profile, and
+						channels will appear when syncing finishes.
 					</span>
 					<Button type="button" variant="outline" size="sm" disabled={isFetching} onClick={onRetry}>
 						{isFetching ? <Spinner className="size-3.5" /> : <RefreshCw className="size-3.5" />}
@@ -662,9 +661,9 @@ function HostedProjectionNotice({
 		return (
 			<Alert data-hosted="true">
 				<Spinner className="size-4" />
-				<AlertTitle>Loading synced agent data</AlertTitle>
+				<AlertTitle>Some details are still syncing</AlertTitle>
 				<AlertDescription>
-					Deployment-owned controls are ready while the cloud projection resolves.
+					You can manage compute while the rest of this agent finishes syncing.
 				</AlertDescription>
 			</Alert>
 		);
@@ -672,10 +671,9 @@ function HostedProjectionNotice({
 	return (
 		<Alert data-hosted="true">
 			<AlertCircle />
-			<AlertTitle>Agent sync identity pending</AlertTitle>
+			<AlertTitle>Finishing agent setup</AlertTitle>
 			<AlertDescription>
-				This deployment has not published an agent identity yet. Deployment controls remain
-				available while provisioning continues.
+				You can manage compute now. The rest of this agent will appear when setup finishes.
 			</AlertDescription>
 		</Alert>
 	);
@@ -685,7 +683,7 @@ function ProjectionDependentUnavailable({ label }: { label: string }) {
 	return (
 		<EmptyState
 			title={`${label} unavailable`}
-			description="This section depends on the synced agent record. Deployment-owned controls remain available."
+			description="This section will be available when the agent finishes syncing. You can manage compute in the meantime."
 		/>
 	);
 }
@@ -1270,23 +1268,11 @@ function ConsoleTab({ deployment, runtime }: { deployment: HostedDeployment; run
 									value={credentials.value.username}
 								/>
 							</div>
-							<div className="space-y-1.5">
-								<Label htmlFor={`hermes-password-${deployment.resource.id}`}>Password</Label>
-								<Input
-									id={`hermes-password-${deployment.resource.id}`}
-									readOnly
-									value={credentials.value.password}
-								/>
-							</div>
+							<TokenReveal label="Password" value={credentials.value.password} />
 						</>
 					) : credentials?.runtime === "openclaw" ? (
-						<div className="space-y-1.5 sm:col-span-2">
-							<Label htmlFor={`openclaw-token-${deployment.resource.id}`}>Token</Label>
-							<Input
-								id={`openclaw-token-${deployment.resource.id}`}
-								readOnly
-								value={credentials.value.token}
-							/>
+						<div className="sm:col-span-2">
+							<TokenReveal label="Token" value={credentials.value.token} />
 						</div>
 					) : null}
 				</div>
@@ -1740,12 +1726,14 @@ function AiProviderTab({
 					? selectedProviders.filter(isUnresolvedProviderChoice).map((choice) => (
 							<button key={choice} type="button" disabled className={selectableCard(true)}>
 								<div className="flex items-center justify-between gap-2">
-									<span className="text-sm font-medium">Provider unavailable</span>
+									<span className="text-sm font-medium">
+										Using {providerDisplayLabel(unresolvedProviderRef(choice), list)}
+									</span>
 									<Badge variant="secondary">In use</Badge>
 								</div>
 								<p className="mt-0.5 text-sm text-muted-foreground">
-									This runtime is bound to {unresolvedProviderRef(choice)}, but that provider could
-									not be loaded. Choose {MANAGED_PROVIDER_LABEL} to replace it.
+									Its saved connection details couldn’t be loaded. Choose {MANAGED_PROVIDER_LABEL}{" "}
+									to replace it.
 								</p>
 							</button>
 						))
@@ -1807,7 +1795,10 @@ function AiProviderTab({
 					customProviders={list}
 					additionalProviderItems={selectedProviderChoices
 						.filter(isUnresolvedProviderChoice)
-						.map((choice) => ({ value: choice, label: unresolvedProviderRef(choice) }))}
+						.map((choice) => ({
+							value: choice,
+							label: providerDisplayLabel(unresolvedProviderRef(choice), list),
+						}))}
 					selectedProviderChoices={selectedProviderChoices}
 					primaryProviderChoice={primaryProviderChoice}
 					primaryModel={primaryModel}
@@ -1824,7 +1815,7 @@ function AiProviderTab({
 					onClick={applyProviderSettings}
 				>
 					{updateDeployment.isPending ? <Spinner className="size-3.5" /> : null}
-					{dirty ? "Apply provider settings" : "No changes"}
+					Save changes
 				</Button>
 			</div>
 
@@ -2044,7 +2035,7 @@ function LinkedChannelRow({
 	// account NEVER white-screens (apps/web/src has no ErrorBoundary).
 	const account = link.account ?? fallbackAccount ?? null;
 	const provider = account?.provider ?? "";
-	const name = account?.name ?? `Channel ${link.account_id.slice(0, 8)}`;
+	const name = account?.name ?? "Unnamed channel";
 	return (
 		<div className="rounded-lg border p-3">
 			<div className="flex items-center gap-3">
@@ -2211,7 +2202,7 @@ function LanguageTimezoneSettingsSection({
 						}
 					>
 						{updateDeployment.isPending ? <Spinner className="size-3.5" /> : null}
-						{dirty ? "Apply locale settings" : "No changes"}
+						Save changes
 					</Button>
 				</div>
 			</div>

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.test.ts
@@ -19,10 +19,49 @@ const modelBindingPickerSource = readFileSync(
 describe("deploy wizard personalization", () => {
 	test("renders the required bounded agent name input", () => {
 		expect(wizardSource).toContain('htmlFor="agent-name"');
+		expect(wizardSource).toContain('<Label htmlFor="agent-name">');
 		expect(wizardSource).toContain('id="agent-name"');
 		expect(wizardSource).toContain("maxLength={DEPLOY_ASSISTANT_NAME_MAX_LENGTH}");
 		expect(DEPLOY_ASSISTANT_NAME_MAX_LENGTH).toBe(255);
 		expect(wizardSource).toContain("required");
+		expect(wizardSource).toContain("aria-invalid={nameError ? true : undefined}");
+		expect(wizardSource).toContain('type="submit"');
+		expect(wizardSource).toContain("submitBlockingReason");
+	});
+});
+
+describe("deploy wizard product copy and flow", () => {
+	test("uses customer language and keeps channels out of the decision flow", () => {
+		expect(wizardSource).toContain('title="Agent software"');
+		expect(wizardSource).toContain("After your agent is ready, connect channels from its page.");
+		expect(wizardSource).not.toContain('title="Runtimes"');
+		expect(wizardSource).not.toContain("execution engine");
+		expect(wizardSource).not.toContain('title="Link after deploy"');
+	});
+
+	test("links checkout fallback recovery to the agents list", () => {
+		expect(wizardSource).toContain('label: "View agents"');
+		expect(wizardSource).toContain('router.navigate({ href: "/agents" })');
+	});
+});
+
+describe("hosted agent security and copy", () => {
+	test("renders runtime secrets through the shared masked token control", () => {
+		expect(agentDetailSource).toContain(
+			'<TokenReveal label="Password" value={credentials.value.password} />',
+		);
+		expect(agentDetailSource).toContain(
+			'<TokenReveal label="Token" value={credentials.value.token} />',
+		);
+		expect(agentDetailSource).not.toContain("hermes-password-");
+		expect(agentDetailSource).not.toContain("openclaw-token-");
+	});
+
+	test("keeps save actions stable and hides internal fallback ids", () => {
+		expect(agentDetailSource).toContain("Save changes");
+		expect(agentDetailSource).toContain('account?.name ?? "Unnamed channel"');
+		expect(agentDetailSource).not.toContain('"No changes"');
+		expect(agentDetailSource).not.toContain("This runtime is bound to");
 	});
 });
 

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -2,11 +2,9 @@
 
 import { useRouter } from "@tanstack/react-router";
 import {
-	CalendarClock,
 	Cpu,
 	CreditCard,
 	Plus,
-	RefreshCw,
 	Rocket,
 	Settings2,
 	Sparkles,
@@ -27,6 +25,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
 	Select,
 	SelectContent,
@@ -153,10 +152,6 @@ import {
 } from "@/hosted/v2/ai-providers/model-binding";
 import { ModelBindingPicker } from "@/hosted/v2/ai-providers/model-binding-picker";
 import { useAiProviderBindingDraft } from "@/hosted/v2/ai-providers/use-ai-provider-binding-draft";
-import { providerMeta } from "@/hosted/v2/channels/channel-providers";
-import type { ChannelAccount } from "@/hosted/v2/channels/channel-types";
-import { ChannelStatusBadge } from "@/hosted/v2/channels/channel-ui";
-import { useChannels } from "@/hosted/v2/channels/channels-hooks";
 import { agentSectionHref } from "@/lib/agent-routes";
 import { isApiAuthError, normalizeApiError } from "@/lib/api-errors";
 import { useHostedProductAccess } from "@/lib/hosted-product-access";
@@ -249,20 +244,6 @@ function recurringOfferLabel(offer: BillingOffer): string {
 		: `${monthly}, billed ${formatCents(offer.price_cents)}${billingTermSuffix(
 				offer.billing_term_months,
 			)}`;
-}
-
-function ChannelInfoTile({ channel }: { channel: ChannelAccount }) {
-	const meta = providerMeta(channel.provider);
-	return (
-		<EntityChoiceCard
-			selected={false}
-			icon={<EntityIcon kind="channel" id={channel.provider} label={meta.label} />}
-			title={channel.name}
-			description={`${meta.label} is ready. Link it from the agent page after deploy.`}
-			badge={<ChannelStatusBadge status={channel.status} />}
-			className="h-full bg-card"
-		/>
-	);
 }
 
 interface ComputeStatusInput {
@@ -381,7 +362,6 @@ export function DeployWizard() {
 	const deployments = useHostedDeployments();
 	const managedModelCatalog = useManagedModelCatalog();
 	const aiProviders = useUserAiProviders();
-	const channels = useChannels();
 	const createSubscription = useCreateSubscription();
 	const billingClient = useBillingClient();
 	const resolveDeploymentRequest = useResolveDeploymentRequest();
@@ -521,24 +501,34 @@ export function DeployWizard() {
 		primaryProviderChoice,
 		providerChoices: aiProviderChoices,
 	} = aiBindingDraft;
-	const channelList = channels.data ?? [];
 	const computePlanReady =
 		compute === "performance" ? !!perfPlan && !!perfOfferSelection : !basicUnavailable;
-	const planReady = plans.isSuccess && computePlanReady;
-	const canSubmit =
-		planReady &&
-		deployments.isSuccess &&
-		managedPrimaryModelReady &&
-		assistantName.trim().length > 0 &&
-		!submitting &&
-		(!paidSelection ||
-			paymentMethod === "card" ||
-			(wallet.isSuccess &&
-				!!wallet.data &&
-				!!walletDebit &&
-				!subscriptionCreateQuote.isFetching &&
-				!subscriptionCreateQuote.error &&
-				!walletInsufficient));
+	const nameError = assistantName.trim().length === 0 ? "Enter a name for your agent." : null;
+	const submitBlockingReason = (() => {
+		if (submitting) return null;
+		if (nameError) return nameError;
+		if (!plans.isSuccess) return "Waiting for compute plans.";
+		if (!deployments.isSuccess) {
+			return deployments.error
+				? "Retry the agent availability check above."
+				: "Checking your free Basic agent availability.";
+		}
+		if (!computePlanReady) return "Choose an available compute plan.";
+		if (!managedPrimaryModelReady) return "Choose an available primary model.";
+		if (paidSelection && paymentMethod === "wallet") {
+			if (!wallet.isSuccess || !wallet.data) {
+				return wallet.error
+					? "Retry loading your Wallet balance above."
+					: "Loading your Wallet balance.";
+			}
+			if (subscriptionCreateQuote.error) return "Retry the Wallet quote above.";
+			if (subscriptionCreateQuote.isFetching) return "Refreshing your Wallet quote.";
+			if (!walletDebit) return "Waiting for your Wallet quote.";
+			if (walletInsufficient) return "Top up your Wallet to continue.";
+		}
+		return null;
+	})();
+	const canSubmit = !submitting && submitBlockingReason === null;
 
 	function selectCreatedProvider(providerId: string) {
 		selectCreatedAiProvider(providerId, aiProviders.dataUpdatedAt);
@@ -706,6 +696,10 @@ export function DeployWizard() {
 		}
 		toast.success("Checkout complete", {
 			description: `Your ${tierLabel} deployment is provisioning. Check your agents list in a moment.`,
+			action: {
+				label: "View agents",
+				onClick: () => void router.navigate({ href: "/agents" }),
+			},
 		});
 	}
 
@@ -929,21 +923,20 @@ export function DeployWizard() {
 				<DeploySectionSkeleton />
 				<DeploySectionSkeleton />
 				<DeploySectionSkeleton />
-				<DeploySectionSkeleton />
 			</div>
 		);
 	}
 
 	return (
 		<div data-hosted="true" data-v2="true" className={DEPLOY_PAGE_CLASS}>
-			<div className="flex flex-col gap-6 sm:pb-24">
+			<div className="flex flex-col gap-6">
 				<PageHeader
 					title="Deploy an Agent"
-					description="Choose the execution engine and AI provider for this hosted deployment."
+					description="Choose how your agent runs and which AI model it will use."
 				/>
 				<SettingsSection
-					title="Runtimes"
-					description="Choose one execution engine for this hosted compute."
+					title="Agent software"
+					description="Choose the software that will power your agent."
 				>
 					<div className={RUNTIME_TILE_GRID_CLASS}>
 						<EntityChoiceCard
@@ -969,7 +962,7 @@ export function DeployWizard() {
 
 				<SettingsSection
 					title="AI providers"
-					description="Bind the provider pool and choose the primary model for the deployment."
+					description="Choose how your agent accesses AI models and select its primary model."
 				>
 					<div className={TWO_TILE_GRID_CLASS}>
 						<EntityChoiceCard
@@ -981,7 +974,7 @@ export function DeployWizard() {
 								</IconChip>
 							}
 							title={authCardLabel("unmanaged")}
-							description="Deploy first, then configure model access inside the runtime."
+							description="Deploy first, then configure model access inside the agent."
 							badge={
 								<Badge variant={aiAccessMode === "unmanaged" ? "secondary" : "outline"}>
 									{aiAccessMode === "unmanaged" ? "Selected" : "Optional"}
@@ -1047,8 +1040,7 @@ export function DeployWizard() {
 					</div>
 					{aiAccessMode === "unmanaged" ? (
 						<p className="mt-4 text-sm text-muted-foreground">
-							This deploy sends no hosted provider binding. Configure models inside the agent after
-							provisioning.
+							No AI provider will be selected for you. Add one inside the agent after it is ready.
 						</p>
 					) : (
 						<ModelBindingPicker
@@ -1068,40 +1060,6 @@ export function DeployWizard() {
 							onPrimaryModelChange={setPrimaryModel}
 						/>
 					)}
-				</SettingsSection>
-
-				<SettingsSection
-					title={
-						<>
-							Channels <span className="font-normal text-muted-foreground">· optional</span>
-						</>
-					}
-					description="Deploy first, then link a native channel from the agent page once provisioning creates the agent identity."
-				>
-					<div className={TWO_TILE_GRID_CLASS}>
-						<EntityChoiceCard
-							selected
-							icon={
-								<IconChip tint="bg-muted text-muted-foreground">
-									<CalendarClock />
-								</IconChip>
-							}
-							title="Link after deploy"
-							description="Channel links need the agent identity created during provisioning."
-							badge={<Badge variant="secondary">Default</Badge>}
-						/>
-						{channels.isLoading ? <Skeleton className="h-[74px] w-full rounded-lg" /> : null}
-						{channels.error ? (
-							<div className="flex min-h-[74px] flex-col items-start justify-center gap-2 rounded-lg border bg-muted/30 p-3 text-xs text-muted-foreground sm:col-span-2">
-								<p>Couldn’t load your channels. You can still deploy and link later.</p>
-								<Button size="sm" variant="outline" onClick={() => channels.refetch()}>
-									<RefreshCw /> Retry
-								</Button>
-							</div>
-						) : (
-							channelList.map((channel) => <ChannelInfoTile key={channel.id} channel={channel} />)
-						)}
-					</div>
 				</SettingsSection>
 
 				<SettingsSection
@@ -1304,94 +1262,127 @@ export function DeployWizard() {
 							perfOffer={perfOffer}
 							paymentMethod={paymentMethod}
 						/>
-					</div>
-				</SettingsSection>
-
-				<SettingsSection
-					title="Personalize"
-					description="Name your agent and optionally choose its language and timezone."
-				>
-					<div className="grid max-w-2xl gap-4 sm:grid-cols-2">
-						<div className="flex flex-col gap-1.5 sm:col-span-2">
-							<label htmlFor="agent-name" className="text-sm text-muted-foreground">
-								Name
-							</label>
-							<Input
-								id="agent-name"
-								value={assistantName}
-								maxLength={DEPLOY_ASSISTANT_NAME_MAX_LENGTH}
-								required
-								onChange={(event) => {
-									assistantNameEditedRef.current = true;
-									setAssistantName(event.target.value);
-								}}
-								onBlur={() => setAssistantName((name) => name.trim())}
-							/>
-						</div>
-						<div className="flex flex-col gap-1.5">
-							<label htmlFor="agent-language" className="text-sm text-muted-foreground">
-								Language
-							</label>
-							<Select
-								items={LANGUAGE_SELECT_ITEMS}
-								value={language || "default"}
-								onValueChange={(v) => {
-									setLanguage(v === null || v === "default" ? "" : v);
-								}}
-							>
-								<SelectTrigger id="agent-language">
-									<SelectValue />
-								</SelectTrigger>
-								<SelectContent>
-									<SelectGroup>
-										<SelectItem value="default">Default</SelectItem>
-										{LANGUAGE_OPTIONS.map((l) => (
-											<SelectItem key={l.code} value={l.code}>
-												{l.label}
-											</SelectItem>
-										))}
-									</SelectGroup>
-								</SelectContent>
-							</Select>
-						</div>
-						{tzOptions.length > 0 ? (
-							<div className="flex flex-col gap-1.5">
-								<label htmlFor="agent-timezone" className="text-sm text-muted-foreground">
-									Timezone
-								</label>
-								<TimezoneCombobox
-									id="agent-timezone"
-									value={timezone}
-									onValueChange={setTimezone}
-									options={tzOptions}
-								/>
-							</div>
-						) : null}
+						<p className="text-xs text-muted-foreground">
+							After your agent is ready, connect channels from its page.
+						</p>
 					</div>
 				</SettingsSection>
 			</div>
 
-			{/* Sticky action bar */}
-			<div className="-mx-4 border-t bg-background/90 px-4 pt-3 pb-[calc(--spacing(3)+env(safe-area-inset-bottom))] backdrop-blur sm:sticky sm:bottom-0 lg:-mx-6 lg:px-6">
-				<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-					<p className="min-w-0 max-w-full truncate text-xs text-muted-foreground sm:text-sm">
-						{summaryLine}
-					</p>
-					<Button
-						size="lg"
-						onClick={() => runAction(onDeploy)}
-						disabled={!canSubmit}
-						className="w-full sm:w-auto"
+			<form
+				className="flex flex-col gap-6"
+				onSubmit={(event) => {
+					event.preventDefault();
+					if (canSubmit) void runAction(onDeploy);
+				}}
+			>
+				<div className="sm:pb-24">
+					<SettingsSection
+						title="Personalize"
+						description="Name your agent and optionally choose its language and timezone."
 					>
-						{submitting ? (
-							<Spinner data-icon="inline-start" />
-						) : (
-							<Rocket data-icon="inline-start" />
-						)}
-						{submitting ? "Working…" : deployLabel}
-					</Button>
+						<div className="grid max-w-2xl gap-4 sm:grid-cols-2">
+							<div className="flex flex-col gap-1.5 sm:col-span-2">
+								<Label htmlFor="agent-name">Name</Label>
+								<Input
+									id="agent-name"
+									value={assistantName}
+									maxLength={DEPLOY_ASSISTANT_NAME_MAX_LENGTH}
+									required
+									aria-invalid={nameError ? true : undefined}
+									aria-describedby={nameError ? "agent-name-error" : undefined}
+									onChange={(event) => {
+										assistantNameEditedRef.current = true;
+										setAssistantName(event.target.value);
+									}}
+									onBlur={() => setAssistantName((name) => name.trim())}
+								/>
+								{nameError ? (
+									<p id="agent-name-error" className="text-xs text-destructive" role="alert">
+										{nameError}
+									</p>
+								) : null}
+							</div>
+							<div className="flex flex-col gap-1.5">
+								<label htmlFor="agent-language" className="text-sm text-muted-foreground">
+									Language
+								</label>
+								<Select
+									items={LANGUAGE_SELECT_ITEMS}
+									value={language || "default"}
+									onValueChange={(v) => {
+										setLanguage(v === null || v === "default" ? "" : v);
+									}}
+								>
+									<SelectTrigger id="agent-language" type="button">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectGroup>
+											<SelectItem value="default">Default</SelectItem>
+											{LANGUAGE_OPTIONS.map((l) => (
+												<SelectItem key={l.code} value={l.code}>
+													{l.label}
+												</SelectItem>
+											))}
+										</SelectGroup>
+									</SelectContent>
+								</Select>
+							</div>
+							{tzOptions.length > 0 ? (
+								<div className="flex flex-col gap-1.5">
+									<label htmlFor="agent-timezone" className="text-sm text-muted-foreground">
+										Timezone
+									</label>
+									<TimezoneCombobox
+										id="agent-timezone"
+										value={timezone}
+										onValueChange={setTimezone}
+										options={tzOptions}
+									/>
+								</div>
+							) : null}
+						</div>
+					</SettingsSection>
 				</div>
-			</div>
+
+				{/* Sticky action bar */}
+				<div className="-mx-4 border-t bg-background/90 px-4 pt-3 pb-[calc(--spacing(3)+env(safe-area-inset-bottom))] backdrop-blur sm:sticky sm:bottom-0 lg:-mx-6 lg:px-6">
+					<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+						<p className="min-w-0 max-w-full truncate text-xs text-muted-foreground sm:text-sm">
+							{summaryLine}
+						</p>
+						<div className="flex flex-col gap-1 sm:items-end">
+							<Button
+								type="submit"
+								size="lg"
+								disabled={!canSubmit}
+								aria-describedby={submitBlockingReason ? "deploy-blocking-reason" : undefined}
+								className="w-full sm:w-auto"
+							>
+								{submitting ? (
+									<Spinner data-icon="inline-start" />
+								) : (
+									<Rocket data-icon="inline-start" />
+								)}
+								{submitting ? "Working…" : deployLabel}
+							</Button>
+							{submitBlockingReason ? (
+								<p
+									id="deploy-blocking-reason"
+									className={cn(
+										"max-w-sm text-xs sm:text-right",
+										nameError ? "text-destructive" : "text-muted-foreground",
+									)}
+									role="status"
+								>
+									{submitBlockingReason}
+								</p>
+							) : null}
+						</div>
+					</div>
+				</div>
+			</form>
 
 			{/* Create a provider without leaving the wizard. */}
 			<AddProviderDialog

--- a/apps/web/src/hosted/billing/subscription/billing-history-section.tsx
+++ b/apps/web/src/hosted/billing/subscription/billing-history-section.tsx
@@ -34,7 +34,7 @@ function statusLabel(status: string): string {
 		draft: "Draft",
 		uncollectible: "Uncollectible",
 	};
-	return known[status] ?? "Unknown";
+	return known[status] ?? "Processing";
 }
 
 function statusTone(

--- a/apps/web/src/hosted/billing/subscription/subscription-page.tsx
+++ b/apps/web/src/hosted/billing/subscription/subscription-page.tsx
@@ -41,7 +41,7 @@ export function SubscriptionPage() {
 				window.location.href = res.url || res.portal_url;
 				return;
 			}
-			toast.message("Billing portal unavailable", {
+			toast.error("Billing portal unavailable", {
 				description: "Refresh this page and try again in a moment.",
 			});
 		} catch (e) {

--- a/apps/web/src/hosted/billing/subscription/welcome-wallet-card.tsx
+++ b/apps/web/src/hosted/billing/subscription/welcome-wallet-card.tsx
@@ -17,10 +17,10 @@ import { largestSignupGrantUsd } from "@/hosted/billing/subscription/subscriptio
  *
  * Renders for a new wallet user who hasn't deployed yet: it
  * confirms the welcome grant landed (reading the `grant_signup` ledger row)
- * and points them at the deploy wizard. Returns null once the user has an
+ * and can point them at the deploy wizard. Returns null once the user has an
  * agent. Read failures render a retry action instead of hiding onboarding.
  */
-export function WelcomeWalletCard() {
+export function WelcomeWalletCard({ showDeployAction = true }: { showDeployAction?: boolean }) {
 	const wallet = useWallet();
 	const ledger = useWalletLedger(50);
 	const deployments = useHostedDeployments();
@@ -36,7 +36,7 @@ export function WelcomeWalletCard() {
 						<Skeleton className="h-5 w-56 max-w-full" />
 						<Skeleton className="h-4 w-96 max-w-full" />
 					</div>
-					<Skeleton className="h-9 w-32" />
+					{showDeployAction ? <Skeleton className="h-9 w-32" /> : null}
 				</CardContent>
 			</Card>
 		);
@@ -98,12 +98,16 @@ export function WelcomeWalletCard() {
 						</p>
 					</div>
 				</div>
-				<div className="flex items-center gap-2">
-					{grantPending ? <Spinner className="size-4 text-muted-foreground" /> : null}
-					<Button render={<Link to="/deploy" />} nativeButton={false}>
-						<Rocket /> Deploy an agent
-					</Button>
-				</div>
+				{grantPending || showDeployAction ? (
+					<div className="flex items-center gap-2">
+						{grantPending ? <Spinner className="size-4 text-muted-foreground" /> : null}
+						{showDeployAction ? (
+							<Button render={<Link to="/deploy" />} nativeButton={false}>
+								<Rocket /> Deploy an agent
+							</Button>
+						) : null}
+					</div>
+				) : null}
 			</CardContent>
 		</Card>
 	);

--- a/apps/web/src/hosted/billing/usage/usage-page.tsx
+++ b/apps/web/src/hosted/billing/usage/usage-page.tsx
@@ -199,7 +199,8 @@ export function UsagePage() {
 										/>
 									</div>
 									<div className="text-xs text-muted-foreground">
-										{providerName} · {m.requests.toLocaleString()} requests
+										{providerName} · {m.requests.toLocaleString()} request
+										{m.requests === 1 ? "" : "s"}
 									</div>
 								</div>
 							);

--- a/apps/web/src/hosted/billing/wallet/ledger-table.tsx
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.tsx
@@ -34,7 +34,7 @@ import {
 import { cn, relativeTime } from "@/lib/utils";
 
 const STATUS_LABELS: Record<WalletLedgerStatus, string> = {
-	applied: "Applied",
+	applied: "Completed",
 	pending: "Pending",
 	failed: "Failed",
 };

--- a/apps/web/src/hosted/billing/wallet/x402-card.test.ts
+++ b/apps/web/src/hosted/billing/wallet/x402-card.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const cardSource = readFileSync(new URL("./x402-card.tsx", import.meta.url), "utf8");
+
+describe("x402 deposit safety", () => {
+	test("hides an address when the response cannot confirm network and token", () => {
+		expect(cardSource).toContain("Contact support for deposit details");
+		expect(cardSource).toContain("wrong network");
+		expect(cardSource).toContain("wrong token");
+		expect(cardSource).toContain('href="mailto:support@clawdi.ai"');
+		expect(cardSource).not.toContain("Copy deposit address");
+	});
+});

--- a/apps/web/src/hosted/billing/wallet/x402-card.tsx
+++ b/apps/web/src/hosted/billing/wallet/x402-card.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { Link2 } from "lucide-react";
+import { LifeBuoy, Link2, TriangleAlert } from "lucide-react";
 import { ApiErrorPanel } from "@/components/api-error-panel";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { CopyButton } from "@/hosted/billing/components/copy-button";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
 import { useHostedUser } from "@/hosted/billing/hooks";
 
@@ -39,17 +40,25 @@ export function X402Card() {
 						title="Couldn’t load deposit address"
 					/>
 				) : address ? (
-					<div className="space-y-1.5">
-						<span className="text-xs text-muted-foreground">Deposit address</span>
-						<div className="flex items-center gap-2 rounded-md border bg-muted/30 p-2">
-							<code className="min-w-0 flex-1 truncate font-mono text-xs">{address}</code>
-							<CopyButton
-								value={address}
-								label="Copy deposit address"
-								toastMessage="Address copied"
-							/>
-						</div>
-					</div>
+					<Alert variant="destructive">
+						<TriangleAlert aria-hidden />
+						<AlertTitle>Contact support for deposit details</AlertTitle>
+						<AlertDescription className="flex flex-col items-start gap-3">
+							<span>
+								Your account data does not identify the required network or accepted token, so the
+								deposit address is hidden for your safety. Funds sent on the wrong network or as the
+								wrong token are unrecoverable.
+							</span>
+							<Button
+								render={<a href="mailto:support@clawdi.ai" />}
+								nativeButton={false}
+								size="sm"
+								variant="outline"
+							>
+								<LifeBuoy data-icon="inline-start" /> Contact support
+							</Button>
+						</AlertDescription>
+					</Alert>
 				) : (
 					<p className="text-sm text-muted-foreground">
 						An on-chain deposit address is provisioned with your first managed-AI agent.

--- a/apps/web/src/hosted/hosted-agents-section.tsx
+++ b/apps/web/src/hosted/hosted-agents-section.tsx
@@ -11,9 +11,19 @@ import {
 import { OnboardingCard } from "@/components/dashboard/onboarding-card";
 import { SectionLabel } from "@/components/section-label";
 import { billingErrorNormalizer } from "@/hosted/billing/errors";
+import { WelcomeWalletCard } from "@/hosted/billing/subscription/welcome-wallet-card";
 import { useUnifiedAgentList } from "@/hosted/use-unified-agent-list";
 
 type Env = components["schemas"]["AgentResponse"];
+
+function HostedEmptyAccountHero() {
+	return (
+		<div className="space-y-4">
+			<OnboardingCard variant="first-agent" hosted />
+			<WelcomeWalletCard showDeployAction={false} />
+		</div>
+	);
+}
 
 /**
  * Hosted-only branch of the dashboard's agent panel.
@@ -85,7 +95,7 @@ export function HostedAgentsSection({
 	return (
 		<div data-hosted="true">
 			{isEmptyState ? (
-				<OnboardingCard variant="first-agent" />
+				<HostedEmptyAccountHero />
 			) : (
 				<AgentsCard
 					agents={agentTiles}
@@ -182,7 +192,7 @@ export function HostedAgentsByCompute({
 	if (isEmptyState) {
 		return (
 			<div data-hosted="true">
-				<OnboardingCard variant="first-agent" />
+				<HostedEmptyAccountHero />
 			</div>
 		);
 	}

--- a/apps/web/src/hosted/use-unified-agent-list.test.ts
+++ b/apps/web/src/hosted/use-unified-agent-list.test.ts
@@ -178,6 +178,10 @@ describe("unified list consumers", () => {
 		const srcDir = resolve(import.meta.dir, "..");
 		const sidebar = readFileSync(resolve(srcDir, "components/app-sidebar.tsx"), "utf8");
 		const homepage = readFileSync(resolve(srcDir, "hosted/hosted-agents-section.tsx"), "utf8");
+		const onboarding = readFileSync(
+			resolve(srcDir, "components/dashboard/onboarding-card.tsx"),
+			"utf8",
+		);
 
 		expect(sidebar).toContain('import("@/hosted/use-unified-agent-list")');
 		expect(sidebar).toContain("hostedMembershipResolved");
@@ -185,5 +189,9 @@ describe("unified list consumers", () => {
 		expect(homepage).toContain("useUnifiedAgentList({");
 		expect(homepage).not.toContain("connectedAgentTilesForHostedView");
 		expect(homepage).not.toContain("useHostedAgentTiles({");
+		expect(homepage).toContain("<HostedEmptyAccountHero />");
+		expect(homepage).toContain("<WelcomeWalletCard showDeployAction={false} />");
+		expect(onboarding).toContain("Deploy a hosted agent");
+		expect(onboarding).toContain("Connect via CLI");
 	});
 });

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.test.ts
@@ -74,6 +74,7 @@ describe("model binding", () => {
 		expect(modelDisplayName("gpt-5.5", providers[0].models ?? [])).toBe("GPT Latest");
 		expect(providerDisplayLabel(providers[0])).toBe("OpenAI");
 		expect(providerDisplayLabel("openai-main", providers)).toBe("OpenAI");
+		expect(providerDisplayLabel({ ...providers[0], label: null })).toBe("OpenAI");
 	});
 
 	test("maps deployment-scoped managed provider ids to the friendly managed choice", () => {

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.ts
@@ -4,6 +4,7 @@ import {
 	isFirstPartyManagedAiProvider,
 } from "@clawdi/shared";
 import type { AiProviderAuthKind, ManagedModelCatalogItem } from "@/hosted/billing/contracts";
+import { providerTypeMeta } from "@/hosted/v2/ai-providers/provider-types";
 import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 import { formatModelLabel } from "@/lib/format";
 
@@ -80,7 +81,7 @@ export function providerDisplayLabel(
 	}
 	return isFirstPartyManagedAiProvider(provider)
 		? MANAGED_PROVIDER_LABEL
-		: (provider.label ?? provider.provider_id);
+		: provider.label?.trim() || providerTypeMeta(provider.type).label;
 }
 
 export function providerChoiceFromRef(

--- a/apps/web/src/hosted/v2/channels/channel-ui.test.ts
+++ b/apps/web/src/hosted/v2/channels/channel-ui.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const uiSource = readFileSync(new URL("./channel-ui.tsx", import.meta.url), "utf8");
+
+describe("TokenReveal", () => {
+	test("masks values by default while retaining reveal and copy controls", () => {
+		expect(uiSource).toContain('{revealed ? value : "••••••••••••"}');
+		expect(uiSource).toMatch(/aria-label=.*revealed.*Hide.*Show.*label/);
+		expect(uiSource).toContain("onClick={() => copy(value)}");
+	});
+});

--- a/apps/web/src/hosted/v2/channels/channel-ui.tsx
+++ b/apps/web/src/hosted/v2/channels/channel-ui.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Check, CircleAlert, CircleCheck, Copy, TriangleAlert } from "lucide-react";
+import { Check, CircleAlert, CircleCheck, Copy, Eye, EyeOff, TriangleAlert } from "lucide-react";
+import { useState } from "react";
 import { EntityIcon, type EntityIconSize } from "@/components/entity-icon";
 import { Button } from "@/components/ui/button";
 import { StatusBadge, type StatusTone } from "@/components/ui/status-badge";
@@ -94,7 +95,7 @@ function useCopy() {
 	return useCopyToClipboard({ error: "Copy failed" });
 }
 
-/** Copyable token box for values revealed once. */
+/** Copyable secret box, masked until the user explicitly reveals it. */
 export function TokenReveal({
 	label,
 	value,
@@ -105,6 +106,7 @@ export function TokenReveal({
 	note?: string;
 }) {
 	const { copied, copy } = useCopy();
+	const [revealed, setRevealed] = useState(false);
 	return (
 		<div
 			data-hosted="true"
@@ -114,8 +116,18 @@ export function TokenReveal({
 			<div className="text-xs font-medium text-primary">{label}</div>
 			<div className="flex items-center gap-2">
 				<code className="flex-1 break-all rounded bg-muted px-3 py-2 font-mono text-xs">
-					{value}
+					{revealed ? value : "••••••••••••"}
 				</code>
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon"
+					onClick={() => setRevealed((visible) => !visible)}
+					aria-label={`${revealed ? "Hide" : "Show"} ${label}`}
+					aria-pressed={revealed}
+				>
+					{revealed ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+				</Button>
 				<Button
 					type="button"
 					variant="ghost"


### PR DESCRIPTION
## Summary

- make empty-account onboarding a deploy-first dual path and surface the existing welcome balance card
- hide unsafe x402 deposit addresses because the current response exposes no network or accepted-token metadata
- mask runtime credentials through the shared TokenReveal control
- replace internal terminology, remove the zero-decision Channels step, and add accessible deploy-form blocking feedback
- polish status, save, pluralization, fallback, and checkout recovery copy

## Verification

- bun run --cwd apps/web test (561 passed)
- bun run --cwd apps/web typecheck
- bun run --cwd apps/web lint
- bunx biome check apps/web/src
- bun run --cwd apps/web build:oss

## x402 data source

The generated deploy API exposes x402_enabled on V2WalletResponse and evm_wallet_address on V1UserResponse. It exposes no network or accepted-token metadata, so the UI does not guess and instead hides the address with a support fallback.