### PR TITLE
fix(v2 web): wallet receipts + portal + de-nest dialogs + contract sync

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -311,17 +311,13 @@ const interruptedIdentitylessDeployment = {
 };
 
 const walletState = {
-	balance_credits: 25_000,
-	overdraft_credits: 0,
-	balance_snapshot_at: "2026-07-15T00:00:00Z",
-	payment_mode: "card",
+	balance_usd: "25.00",
 	x402_enabled: false,
 	auto_reload_enabled: false,
-	auto_reload_threshold_credits: 5_000,
+	auto_reload_threshold_usd: "5.00",
 	auto_reload_amount_cents: 2_500,
 	auto_reload_monthly_cap_cents: 10_000,
 	auto_reload_action: null,
-	points_per_usd: 1_000,
 };
 
 const walletActiveDeployment = {
@@ -758,6 +754,7 @@ type HostedApiStubOptions = {
 	managedModels?: typeof managedModelCatalog;
 	planRequests?: string[];
 	plans?: readonly unknown[];
+	portalRequests?: string[];
 	planChangeRequests?: string[];
 	planChangeResponses?: unknown[];
 	planQuoteRequests?: string[];
@@ -1029,7 +1026,7 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 					flow_type: "mock",
 					payment_intent_id: null,
 					client_secret: null,
-					credits_added: 25_000,
+					amount_usd: "25.00",
 				},
 			};
 			if (response.delayMs) {
@@ -1052,6 +1049,10 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 			return isStubResponse(response)
 				? fulfillJson(r, response.body, response.status)
 				: fulfillJson(r, response);
+		}
+		if (p === "/v2/subscription/portal" && r.request().method() === "POST") {
+			options.portalRequests?.push(r.request().postData() ?? "");
+			return fulfillJson(r, { portal_url: "/channels?portal=opened" });
 		}
 		if (p === "/v2/subscription/cancel" && r.request().method() === "POST") {
 			options.cancelRequests?.push(r.request().postData() ?? "");
@@ -1991,7 +1992,7 @@ test("wallet annual quotes the exact debit and activates the created deployment"
 				balanceAfterCredits: "13600",
 			}),
 		],
-		walletState: { ...walletState, balance_credits: 100_000 },
+		walletState: { ...walletState, balance_usd: "100.00" },
 		onWalletCheckoutSuccess: () => deployments.push(walletAnnualDeployment),
 	});
 	await page.goto("/deploy");
@@ -2699,17 +2700,27 @@ test("Wallet activity caps show-more requests at the ledger API limit", async ({
 	const ledgerRequests: string[] = [];
 	let expandedAttempts = 0;
 	const computeCharge = {
-		id: "ledger-compute-charge",
 		operation: "compute_charge",
-		request_id: "compute-renewal-42",
-		credits_amount: -9_000,
+		description: "Compute Basic renewal",
+		amount_usd: "-9.00",
 		status: "applied",
+		receipt_url: null,
 		created_at: "2026-07-15T00:00:00Z",
+		applied_at: "2026-07-15T00:00:00Z",
+	};
+	const topUp = {
+		operation: "topup",
+		description: "Card top-up",
+		amount_usd: "25.00",
+		status: "applied",
+		receipt_url: "https://billing.stripe.test/receipt/topup",
+		created_at: "2026-07-15T00:00:02Z",
+		applied_at: "2026-07-15T00:00:02Z",
 	};
 	await stubHostedApi(page, {
 		ledgerRequests,
 		ledgerResponseForRequest: (limit) => {
-			if (limit === 50) return { items: [computeCharge], has_more: true };
+			if (limit === 50) return { items: [topUp, computeCharge], has_more: true };
 			expandedAttempts += 1;
 			return expandedAttempts === 1
 				? { status: 400, body: { detail: "ledger_backend_unavailable" } }
@@ -2718,10 +2729,11 @@ test("Wallet activity caps show-more requests at the ledger API limit", async ({
 							computeCharge,
 							{
 								...computeCharge,
-								id: "ledger-compute-credit",
 								operation: "compute_credit",
-								request_id: "compute-reversal-42",
-								credits_amount: 9_000,
+								description: "Compute Basic reversal",
+								amount_usd: "9.00",
+								created_at: "2026-07-15T00:00:01Z",
+								applied_at: "2026-07-15T00:00:01Z",
 							},
 						],
 						has_more: true,
@@ -2734,6 +2746,10 @@ test("Wallet activity caps show-more requests at the ledger API limit", async ({
 	const ledgerTable = settingsDialog.getByRole("table");
 
 	await expect(ledgerTable.getByText("Compute charge", { exact: true })).toBeVisible();
+	await expect(ledgerTable.getByText("Card top-up", { exact: true })).toBeVisible();
+	await expect(
+		ledgerTable.locator('a[href="https://billing.stripe.test/receipt/topup"]'),
+	).toHaveText("Receipt");
 	await settingsDialog.getByRole("button", { name: "Show more" }).click();
 	await expect.poll(() => ledgerRequests.length).toBe(2);
 	await expect(
@@ -2757,13 +2773,25 @@ test("Wallet activity caps show-more requests at the ledger API limit", async ({
 	).toEqual([]);
 });
 
+test("Wallet opens the shared billing portal action", async ({ page }) => {
+	const portalRequests: string[] = [];
+	await stubHostedApi(page, { portalRequests });
+	const settingsDialog = await gotoHostedSettingsDialog(page, "billing-wallet");
+
+	await settingsDialog.getByRole("button", { name: "Manage payment methods" }).click();
+
+	await expect.poll(() => portalRequests.length).toBe(1);
+	await expect(page).toHaveURL(/\?portal=opened$/);
+	expect(JSON.parse(portalRequests[0] ?? "null")).toEqual({});
+});
+
 test("auto-reload batches toggle and fields into one explicit save", async ({ page }) => {
 	const errors = collectBrowserErrors(page);
 	const autoReloadRequests: string[] = [];
 	const savedWallet = {
 		...walletState,
 		auto_reload_enabled: true,
-		auto_reload_threshold_credits: 7_500,
+		auto_reload_threshold_usd: "7.50",
 		auto_reload_amount_cents: 3_000,
 		auto_reload_monthly_cap_cents: 12_500,
 	};
@@ -2841,7 +2869,7 @@ test("auto-reload batches toggle and fields into one explicit save", async ({ pa
 	for (const raw of autoReloadRequests) {
 		expect(JSON.parse(raw)).toEqual({
 			auto_reload_enabled: true,
-			auto_reload_threshold_credits: 7_500,
+			auto_reload_threshold_usd: 7.5,
 			auto_reload_amount_cents: 3_000,
 			auto_reload_monthly_cap_cents: 12_500,
 		});
@@ -2868,7 +2896,7 @@ test("top-up validates the amount and blocks duplicate submission or close in fl
 					flow_type: "mock",
 					payment_intent_id: null,
 					client_secret: null,
-					credits_added: 40_000,
+					amount_usd: "40.00",
 				},
 			},
 		],
@@ -2876,27 +2904,28 @@ test("top-up validates the amount and blocks duplicate submission or close in fl
 	});
 	const settingsDialog = await gotoHostedSettingsDialog(page, "billing-wallet");
 	await settingsDialog.getByRole("button", { name: "Top up" }).click();
-	const topUpDialog = page.getByRole("dialog").filter({ hasText: "Top up AI Credits" });
-	const amount = topUpDialog.getByLabel("Amount (USD)");
+	const topUpPanel = settingsDialog.getByRole("region", { name: "Top up Wallet" });
+	await expect(page.getByRole("dialog")).toHaveCount(1);
+	const amount = topUpPanel.getByLabel("Amount (USD)");
 
 	await amount.fill("25.50");
 	await amount.blur();
 	await expect(
-		topUpDialog.getByText("Enter a whole-dollar amount from $10.00 to $2,000.00.", {
+		topUpPanel.getByText("Enter a whole-dollar amount from $10.00–$2,000.00.", {
 			exact: true,
 		}),
 	).toBeVisible();
 	await amount.fill("40");
-	const submit = topUpDialog.getByRole("button", { name: "Continue with $40.00" });
+	const submit = topUpPanel.getByRole("button", { name: "Continue with $40.00" });
 	await submit.evaluate((button: HTMLButtonElement) => {
 		button.click();
 		button.click();
 	});
-	await expect(topUpDialog.getByRole("button", { name: "Starting…" })).toBeDisabled();
+	await expect(topUpPanel.getByRole("button", { name: "Starting…" })).toBeDisabled();
 	await page.keyboard.press("Escape");
-	await expect(topUpDialog).toBeVisible();
+	await expect(topUpPanel).toBeVisible();
 	await expect.poll(() => topUpRequests.length).toBe(1);
-	await expect(topUpDialog).toHaveCount(0);
+	await expect(topUpPanel).toHaveCount(0);
 	expect(JSON.parse(topUpRequests[0] ?? "{}")).toEqual({ amount_cents: 4_000 });
 	expect(errors, `top-up interaction: ${errors.join(" | ")}`).toEqual([]);
 });
@@ -2922,20 +2951,20 @@ test("top-up rotates its idempotency key after an explicit reuse conflict", asyn
 	await page.goto("/channels?settings=billing-wallet");
 	const settingsDialog = page.getByTestId("settings-dialog");
 	await settingsDialog.getByRole("button", { name: "Top up" }).click();
-	const topUpDialog = page.getByRole("dialog").filter({ hasText: "Top up AI Credits" });
-	const submit = topUpDialog.getByRole("button", { name: "Continue" });
+	const topUpPanel = settingsDialog.getByRole("region", { name: "Top up Wallet" });
+	const submit = topUpPanel.getByRole("button", { name: "Continue" });
 
 	await submit.click();
 	await expect.poll(() => topUpIdempotencyKeys.length).toBe(1);
 	await expect(page.getByText("Start a fresh top-up", { exact: true })).toBeVisible();
-	await expect(topUpDialog).toBeVisible();
+	await expect(topUpPanel).toBeVisible();
 	await submit.click();
 	await expect.poll(() => topUpIdempotencyKeys.length).toBe(2);
 
 	expect(topUpIdempotencyKeys[0]).toMatch(/^topup-/);
 	expect(topUpIdempotencyKeys[1]).toMatch(/^topup-/);
 	expect(topUpIdempotencyKeys[1]).not.toBe(topUpIdempotencyKeys[0]);
-	await expect(topUpDialog).toHaveCount(0);
+	await expect(topUpPanel).toHaveCount(0);
 	expect(
 		errors.filter((error) => !error.includes("status of 409")),
 		`top-up key rotation: ${errors.join(" | ")}`,
@@ -2964,7 +2993,7 @@ test("wallet top-up completion refreshes an automatically paid open invoice", as
 	await expect(page.getByRole("button", { name: /Retry payment/ })).toHaveCount(0);
 
 	await pastDueAlert.getByRole("button", { name: "Top up" }).click();
-	const topUpDialog = page.getByRole("dialog").filter({ hasText: "Top up AI Credits" });
+	const topUpDialog = page.getByRole("dialog").filter({ hasText: "Top up Wallet" });
 	await expect(topUpDialog).toBeVisible();
 	await topUpDialog.getByRole("button", { name: "Continue with $25.00" }).click();
 

--- a/apps/web/src/hosted/billing/components/low-balance-banner.logic.test.ts
+++ b/apps/web/src/hosted/billing/components/low-balance-banner.logic.test.ts
@@ -5,7 +5,6 @@ import { lowBalanceBannerState } from "./low-balance-banner.logic";
 function wallet(over: Partial<WalletState> = {}): WalletState {
 	return {
 		balance_usd: "50",
-		payment_mode: "card",
 		x402_enabled: true,
 		auto_reload_enabled: false,
 		auto_reload_threshold_usd: "1",

--- a/apps/web/src/hosted/billing/wallet/auto-reload-action.tsx
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-action.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { AlertCircle, CreditCard, RefreshCw } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+import { useSettingsEditState } from "@/components/settings-edit-state";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import type { WalletState } from "@/hosted/billing/contracts";
@@ -34,6 +35,8 @@ export function AutoReloadActionConfirm({
 }) {
 	const qc = useQueryClient();
 	const [confirming, setConfirming] = useState(false);
+	const [paymentSubmitting, setPaymentSubmitting] = useState(false);
+	useSettingsEditState({ dirty: false, busy: confirming && paymentSubmitting });
 
 	const action = wallet.auto_reload_action;
 	if (!action) return null;
@@ -49,6 +52,7 @@ export function AutoReloadActionConfirm({
 		// settles; refetch balance + activity so this control clears itself.
 		qc.invalidateQueries({ queryKey: billingKeys.wallet });
 		qc.invalidateQueries({ queryKey: billingKeys.ledgerRoot });
+		setPaymentSubmitting(false);
 		setConfirming(false);
 		toast.success(status === "succeeded" ? "Payment confirmed" : "Payment processing", {
 			description:
@@ -98,6 +102,7 @@ export function AutoReloadActionConfirm({
 							onCancel={() => setConfirming(false)}
 							summary={`Auto-reload charge: ${charge}`}
 							submitLabel={`${declined ? "Retry" : "Confirm"} ${charge} payment`}
+							onSubmittingChange={setPaymentSubmitting}
 						/>
 					</div>
 				) : (

--- a/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/auto-reload-card.logic.test.ts
@@ -46,7 +46,6 @@ describe("autoReloadFormState", () => {
 
 const wallet: WalletState = {
 	balance_usd: "25",
-	payment_mode: "card",
 	x402_enabled: false,
 	auto_reload_enabled: false,
 	auto_reload_threshold_usd: "5",

--- a/apps/web/src/hosted/billing/wallet/ledger-table.logic.test.ts
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.logic.test.ts
@@ -9,12 +9,11 @@ import {
 
 function entry(overrides: Partial<WalletLedgerEntry> = {}): WalletLedgerEntry {
 	return {
-		id: "entry_1",
 		operation: "topup",
-		request_id: "request_1",
+		description: "Wallet top-up",
 		amount_usd: "1",
 		status: "applied",
-		notes: null,
+		receipt_url: null,
 		created_at: "2026-07-01T00:00:00Z",
 		applied_at: "2026-07-01T00:00:00Z",
 		...overrides,
@@ -33,7 +32,7 @@ describe("filteredLedgerEntries", () => {
 		expect(ledgerOperationGroup("compute_credit")).toBe("compute");
 		expect(
 			filteredLedgerEntries(
-				[entry({ operation: "compute_charge" }), entry({ id: "entry_2", operation: "topup" })],
+				[entry({ operation: "compute_charge" }), entry({ operation: "topup" })],
 				"compute",
 			).map((item) => item.operation),
 		).toEqual(["compute_charge"]);

--- a/apps/web/src/hosted/billing/wallet/ledger-table.logic.ts
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.logic.ts
@@ -58,15 +58,9 @@ export function filteredLedgerEntries(
 	entries: WalletLedgerEntry[],
 	filter: LedgerFilter,
 ): WalletLedgerEntry[] {
-	return (
-		filter === "all"
-			? entries
-			: entries.filter((entry) => ledgerOperationGroup(entry.operation) === filter)
-	).filter(
-		// Defensive: skip malformed rows (missing id) rather than emit a
-		// React key warning or render an "undefined" row.
-		(entry): entry is WalletLedgerEntry => entry != null && typeof entry.id === "string",
-	);
+	return filter === "all"
+		? entries
+		: entries.filter((entry) => ledgerOperationGroup(entry.operation) === filter);
 }
 
 export function ledgerEmptyStateCopy({

--- a/apps/web/src/hosted/billing/wallet/ledger-table.tsx
+++ b/apps/web/src/hosted/billing/wallet/ledger-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Receipt } from "lucide-react";
+import { ExternalLink, Receipt } from "lucide-react";
 import { useId, useMemo, useState } from "react";
 import { EmptyState } from "@/components/empty-state";
 import { Button } from "@/components/ui/button";
@@ -67,6 +67,25 @@ function signedAmount(entry: WalletLedgerEntry): string {
 	const positive = amountIsPositive(entry);
 	const unsignedAmount = entry.amount_usd.trim().replace(/^[+-]/, "");
 	return `${positive ? "+" : "−"}${formatUsdExact(unsignedAmount)}`;
+}
+
+function ledgerEntryKey(entry: WalletLedgerEntry): string {
+	return `${entry.created_at}:${entry.operation}:${entry.amount_usd}`;
+}
+
+function ReceiptLink({ entry }: { entry: WalletLedgerEntry }) {
+	if (!entry.receipt_url) return null;
+	return (
+		<Button
+			render={<a href={entry.receipt_url} target="_blank" rel="noopener noreferrer" />}
+			nativeButton={false}
+			variant="link"
+			size="xs"
+			className="h-auto px-0"
+		>
+			Receipt <ExternalLink data-icon="inline-end" />
+		</Button>
+	);
 }
 
 export function LedgerTable({
@@ -170,12 +189,15 @@ export function LedgerTable({
 						{filtered.map((entry) => {
 							const positive = amountIsPositive(entry);
 							return (
-								<li key={entry.id} className="flex items-start justify-between gap-3 p-3">
+								<li
+									key={ledgerEntryKey(entry)}
+									className="flex items-start justify-between gap-3 p-3"
+								>
 									<div className="min-w-0 space-y-1">
 										<div className="font-medium">{ledgerOperationLabel(entry.operation)}</div>
-										{entry.notes ? (
-											<div className="truncate text-xs text-muted-foreground">{entry.notes}</div>
-										) : null}
+										<div className="truncate text-xs text-muted-foreground">
+											{entry.description}
+										</div>
 										<div className="flex items-center gap-2">
 											<StatusBadge status={statusVariant(entry.status)}>
 												{statusLabel(entry.status)}
@@ -184,6 +206,7 @@ export function LedgerTable({
 												{relativeTime(entry.created_at)}
 											</span>
 										</div>
+										<ReceiptLink entry={entry} />
 									</div>
 									<span
 										className={cn(
@@ -206,20 +229,19 @@ export function LedgerTable({
 									<TableHead>Status</TableHead>
 									<TableHead className="text-right">Amount</TableHead>
 									<TableHead className="text-right">When</TableHead>
+									<TableHead className="text-right">Receipt</TableHead>
 								</TableRow>
 							</TableHeader>
 							<TableBody>
 								{filtered.map((entry) => {
 									const positive = amountIsPositive(entry);
 									return (
-										<TableRow key={entry.id}>
+										<TableRow key={ledgerEntryKey(entry)}>
 											<TableCell>
 												<div className="font-medium">{ledgerOperationLabel(entry.operation)}</div>
-												{entry.notes ? (
-													<div className="max-w-[18rem] truncate text-xs text-muted-foreground">
-														{entry.notes}
-													</div>
-												) : null}
+												<div className="max-w-[18rem] truncate text-xs text-muted-foreground">
+													{entry.description}
+												</div>
 											</TableCell>
 											<TableCell>
 												<StatusBadge status={statusVariant(entry.status)}>
@@ -236,6 +258,9 @@ export function LedgerTable({
 											</TableCell>
 											<TableCell className="whitespace-nowrap text-right text-sm text-muted-foreground">
 												{relativeTime(entry.created_at)}
+											</TableCell>
+											<TableCell className="text-right">
+												<ReceiptLink entry={entry} />
 											</TableCell>
 										</TableRow>
 									);

--- a/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
+++ b/apps/web/src/hosted/billing/wallet/top-up-dialog.tsx
@@ -1,9 +1,19 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
+import { X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { useSettingsEditState } from "@/components/settings-edit-state";
 import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardAction,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
 import {
 	Dialog,
 	DialogContent,
@@ -38,17 +48,20 @@ import {
 } from "@/hosted/billing/wallet/wallet-constants";
 
 type Step = "amount" | "pay";
+type TopUpPresentation = "dialog" | "inline";
 
 export function TopUpDialog({
 	open,
 	onOpenChange,
 	onComplete,
 	initialAmountCents,
+	presentation = "dialog",
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	onComplete?: (status: "succeeded" | "processing") => void;
 	initialAmountCents?: number | null;
+	presentation?: TopUpPresentation;
 }) {
 	const topUp = useTopUp();
 	const qc = useQueryClient();
@@ -58,9 +71,10 @@ export function TopUpDialog({
 	const [clientSecret, setClientSecret] = useState<string | null>(null);
 	const [amountTouched, setAmountTouched] = useState(false);
 	const [paymentSubmitting, setPaymentSubmitting] = useState(false);
+	useSettingsEditState({ dirty: false, busy: open && (topUp.isPending || paymentSubmitting) });
 	// One idempotency key per top-up ATTEMPT, reused across a retry of the same
 	// amount so a timeout-resubmit / double-tab can't create two PaymentIntents.
-	// Reset whenever the amount changes (a genuinely new attempt) or the dialog
+	// Reset whenever the amount changes (a genuinely new attempt) or the flow
 	// closes.
 	const topupKeyRef = useRef<string | null>(null);
 
@@ -111,7 +125,7 @@ export function TopUpDialog({
 					topupKeyRef.current = null;
 				},
 				// Successful completion is not a dismiss attempt. Close directly so the
-				// in-flight guard cannot leave a completed payment dialog stranded open.
+				// in-flight guard cannot leave a completed payment flow stranded open.
 				closeDialog: () => onOpenChange(false),
 				toastSuccess: toast.success,
 				toastError: toast.error,
@@ -131,7 +145,7 @@ export function TopUpDialog({
 	}
 
 	// Only terminal outcomes reach here — `requires_action` (3DS) is completed
-	// inline by StripePaymentForm, which keeps the dialog open until it settles
+	// inline by StripePaymentForm, which keeps the payment flow open until it settles
 	// rather than closing on an unconfirmed payment.
 	function onPaid(status: PaymentOutcome) {
 		completeTopup(status === "succeeded" ? "succeeded" : "processing", {
@@ -145,6 +159,108 @@ export function TopUpDialog({
 		});
 	}
 
+	const description =
+		step === "amount"
+			? `Add a whole-dollar amount from ${TOPUP_AMOUNT_RANGE_LABEL} to your Wallet.`
+			: `Enter your card details to pay ${formatCents(amountCents)}.`;
+	const content =
+		step === "amount" ? (
+			<div className="space-y-4">
+				<div className="flex flex-wrap gap-2">
+					{TOPUP_PRESETS_CENTS.map((preset) => (
+						<Button
+							key={preset}
+							type="button"
+							size="sm"
+							variant={amountCents === preset ? "default" : "outline"}
+							aria-pressed={amountCents === preset}
+							onClick={() => setAmount(String(preset / 100))}
+						>
+							{formatCents(preset)}
+						</Button>
+					))}
+				</div>
+				<div className="space-y-1.5">
+					<Label htmlFor="topup-amount">Amount (USD)</Label>
+					<div className="relative">
+						<span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
+							$
+						</span>
+						<Input
+							id="topup-amount"
+							name="topup-amount"
+							type="number"
+							inputMode="decimal"
+							autoComplete="off"
+							min={TOPUP_MIN_CENTS / 100}
+							max={TOPUP_MAX_CENTS / 100}
+							step={TOPUP_INCREMENT_CENTS / 100}
+							className="pl-6"
+							value={dollars}
+							onChange={(e) => setAmount(e.target.value)}
+							onBlur={() => setAmountTouched(true)}
+							aria-invalid={amountInvalid}
+							aria-describedby="topup-amount-help"
+						/>
+					</div>
+					<p
+						id="topup-amount-help"
+						className={amountInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"}
+						aria-live="polite"
+					>
+						{valid
+							? `You’ll add ${formatCents(amountCents)} to your Wallet. Whole-dollar amounts only.`
+							: `Enter a whole-dollar amount from ${TOPUP_AMOUNT_RANGE_LABEL}.`}
+					</p>
+				</div>
+				<div className="flex justify-end">
+					<Button onClick={() => runAction(onContinue)} disabled={!valid || topUp.isPending}>
+						{topUp.isPending ? (
+							<>
+								<Spinner /> Starting…
+							</>
+						) : (
+							`Continue with ${formatCents(amountCents)}`
+						)}
+					</Button>
+				</div>
+			</div>
+		) : clientSecret ? (
+			<StripePaymentForm
+				clientSecret={clientSecret}
+				onComplete={onPaid}
+				onCancel={() => setStep("amount")}
+				summary={`Top-up charge: ${formatCents(amountCents)}`}
+				submitLabel={`Pay ${formatCents(amountCents)}`}
+				onSubmittingChange={setPaymentSubmitting}
+			/>
+		) : null;
+
+	if (presentation === "inline") {
+		if (!open) return null;
+		return (
+			<Card data-hosted="true" role="region" aria-labelledby="wallet-top-up-title">
+				<CardHeader>
+					<CardTitle id="wallet-top-up-title">Top up Wallet</CardTitle>
+					<CardDescription>{description}</CardDescription>
+					<CardAction>
+						<Button
+							type="button"
+							variant="ghost"
+							size="icon-sm"
+							onClick={() => close(false)}
+							disabled={topUp.isPending || paymentSubmitting}
+						>
+							<X />
+							<span className="sr-only">Close top-up</span>
+						</Button>
+					</CardAction>
+				</CardHeader>
+				<CardContent>{content}</CardContent>
+			</Card>
+		);
+	}
+
 	return (
 		<Dialog open={open} onOpenChange={close}>
 			<DialogContent
@@ -154,86 +270,9 @@ export function TopUpDialog({
 			>
 				<DialogHeader>
 					<DialogTitle>Top up Wallet</DialogTitle>
-					<DialogDescription>
-						{step === "amount"
-							? `Add a whole-dollar amount from ${TOPUP_AMOUNT_RANGE_LABEL} to your Wallet.`
-							: `Enter your card details to pay ${formatCents(amountCents)}.`}
-					</DialogDescription>
+					<DialogDescription>{description}</DialogDescription>
 				</DialogHeader>
-
-				{step === "amount" ? (
-					<div className="space-y-4">
-						<div className="flex flex-wrap gap-2">
-							{TOPUP_PRESETS_CENTS.map((preset) => (
-								<Button
-									key={preset}
-									type="button"
-									size="sm"
-									variant={amountCents === preset ? "default" : "outline"}
-									aria-pressed={amountCents === preset}
-									onClick={() => setAmount(String(preset / 100))}
-								>
-									{formatCents(preset)}
-								</Button>
-							))}
-						</div>
-						<div className="space-y-1.5">
-							<Label htmlFor="topup-amount">Amount (USD)</Label>
-							<div className="relative">
-								<span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
-									$
-								</span>
-								<Input
-									id="topup-amount"
-									name="topup-amount"
-									type="number"
-									inputMode="decimal"
-									autoComplete="off"
-									min={TOPUP_MIN_CENTS / 100}
-									max={TOPUP_MAX_CENTS / 100}
-									step={TOPUP_INCREMENT_CENTS / 100}
-									className="pl-6"
-									value={dollars}
-									onChange={(e) => setAmount(e.target.value)}
-									onBlur={() => setAmountTouched(true)}
-									aria-invalid={amountInvalid}
-									aria-describedby="topup-amount-help"
-								/>
-							</div>
-							<p
-								id="topup-amount-help"
-								className={
-									amountInvalid ? "text-xs text-destructive" : "text-xs text-muted-foreground"
-								}
-								aria-live="polite"
-							>
-								{valid
-									? `You’ll add ${formatCents(amountCents)} to your Wallet. Whole-dollar amounts only.`
-									: `Enter a whole-dollar amount from ${TOPUP_AMOUNT_RANGE_LABEL}.`}
-							</p>
-						</div>
-						<div className="flex justify-end">
-							<Button onClick={() => runAction(onContinue)} disabled={!valid || topUp.isPending}>
-								{topUp.isPending ? (
-									<>
-										<Spinner /> Starting…
-									</>
-								) : (
-									`Continue with ${formatCents(amountCents)}`
-								)}
-							</Button>
-						</div>
-					</div>
-				) : clientSecret ? (
-					<StripePaymentForm
-						clientSecret={clientSecret}
-						onComplete={onPaid}
-						onCancel={() => setStep("amount")}
-						summary={`Top-up charge: ${formatCents(amountCents)}`}
-						submitLabel={`Pay ${formatCents(amountCents)}`}
-						onSubmittingChange={setPaymentSubmitting}
-					/>
-				) : null}
+				{content}
 			</DialogContent>
 		</Dialog>
 	);

--- a/apps/web/src/hosted/billing/wallet/wallet-page.tsx
+++ b/apps/web/src/hosted/billing/wallet/wallet-page.tsx
@@ -1,16 +1,25 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
+import { CreditCard } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ApiErrorPanel } from "@/components/api-error-panel";
 import { PageHeader } from "@/components/page-header";
 import { CENTERED_PAGE_WIDTH_CLASS } from "@/components/page-width";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import { LowBalanceBanner } from "@/hosted/billing/components/low-balance-banner";
 import { WalletSkeleton } from "@/hosted/billing/components/state-views";
-import { billingErrorNormalizer } from "@/hosted/billing/errors";
-import { useHostedDeployments, useWallet, useWalletLedger } from "@/hosted/billing/hooks";
+import { billingErrorNormalizer, normalizeBillingError } from "@/hosted/billing/errors";
+import {
+	useHostedDeployments,
+	usePortal,
+	useWallet,
+	useWalletLedger,
+} from "@/hosted/billing/hooks";
 import { getStripe } from "@/hosted/billing/stripe";
+import { useActionLock } from "@/hosted/billing/use-action-lock";
 import { AutoReloadCard } from "@/hosted/billing/wallet/auto-reload-card";
 import { BalanceCard } from "@/hosted/billing/wallet/balance-card";
 import { LedgerTable } from "@/hosted/billing/wallet/ledger-table";
@@ -53,6 +62,8 @@ function showWalletTopupReturnToast(result: WalletTopupReturnToast) {
 export function WalletPage() {
 	const wallet = useWallet();
 	const deployments = useHostedDeployments();
+	const portal = usePortal();
+	const runAction = useActionLock();
 	const queryClient = useQueryClient();
 	const [ledgerLimit, setLedgerLimit] = useState(LEDGER_PAGE_SIZE);
 	const ledger = useWalletLedger(ledgerLimit);
@@ -60,6 +71,31 @@ export function WalletPage() {
 	if (ledger.data) lastLedgerDataRef.current = ledger.data;
 	const ledgerData = ledger.data ?? lastLedgerDataRef.current;
 	const [topUpOpen, setTopUpOpen] = useState(false);
+
+	async function openBillingPortal() {
+		try {
+			const res = await portal.mutateAsync({});
+			if (res.url || res.portal_url) {
+				window.location.href = res.url || res.portal_url;
+				return;
+			}
+			toast.error("Billing portal unavailable", {
+				description: "Refresh this page and try again in a moment.",
+			});
+		} catch (error) {
+			toast.error("Couldn’t open billing", { description: normalizeBillingError(error) });
+		}
+	}
+
+	const portalAction = (
+		<Button
+			variant="outline"
+			onClick={() => runAction(openBillingPortal)}
+			disabled={portal.isPending}
+		>
+			{portal.isPending ? <Spinner /> : <CreditCard />} Manage payment methods
+		</Button>
+	);
 
 	useEffect(() => {
 		const topupReturn = readWalletTopupReturn(window.location.search);
@@ -115,7 +151,7 @@ export function WalletPage() {
 	if (wallet.isLoading) {
 		return (
 			<div data-hosted="true" className={WALLET_PAGE_CLASS}>
-				<PageHeader title="Wallet" description={DESCRIPTION} />
+				<PageHeader title="Wallet" description={DESCRIPTION} actions={portalAction} />
 				<WalletSkeleton />
 			</div>
 		);
@@ -124,7 +160,7 @@ export function WalletPage() {
 	if (wallet.error || !wallet.data) {
 		return (
 			<div data-hosted="true" className={WALLET_PAGE_CLASS}>
-				<PageHeader title="Wallet" description={DESCRIPTION} />
+				<PageHeader title="Wallet" description={DESCRIPTION} actions={portalAction} />
 				<ApiErrorPanel
 					normalizer={billingErrorNormalizer}
 					error={wallet.error}
@@ -143,61 +179,65 @@ export function WalletPage() {
 
 	return (
 		<div data-hosted="true" className={WALLET_PAGE_CLASS}>
-			{/* The balance card below carries the primary Top up CTA; a second
-			    header button duplicated it in the same viewport. */}
-			<PageHeader title="Wallet" description={DESCRIPTION} />
-
-			<LowBalanceBanner
-				wallet={w}
-				hasWalletCompute={walletComputeCount > 0}
-				onTopUp={() => setTopUpOpen(true)}
-				onAutoReload={scrollToAutoReload}
+			<PageHeader
+				title="Wallet"
+				description={DESCRIPTION}
+				actions={topUpOpen ? undefined : portalAction}
 			/>
 
-			<BalanceCard
-				wallet={w}
-				hasWalletCompute={walletComputeCount > 0}
-				onTopUp={() => setTopUpOpen(true)}
-			/>
+			<TopUpDialog open={topUpOpen} onOpenChange={setTopUpOpen} presentation="inline" />
 
-			<div id="auto-reload" className="grid gap-4 lg:grid-cols-2">
-				<AutoReloadCard wallet={w} onTopUp={() => setTopUpOpen(true)} />
-				{w.x402_enabled === true ? <X402Card /> : null}
-			</div>
-
-			{ledger.error && !ledgerData ? (
-				<ApiErrorPanel
-					normalizer={billingErrorNormalizer}
-					error={ledger.error}
-					title="Couldn’t load activity"
-					onRetry={() => ledger.refetch()}
+			<div className={cn("space-y-6", topUpOpen && "hidden")}>
+				<LowBalanceBanner
+					wallet={w}
+					hasWalletCompute={walletComputeCount > 0}
+					onTopUp={() => setTopUpOpen(true)}
+					onAutoReload={scrollToAutoReload}
 				/>
-			) : (
-				<>
-					<LedgerTable
-						entries={ledgerData?.items ?? []}
-						isLoading={ledger.isLoading}
-						hasMore={ledgerData?.has_more ?? false}
-						atCap={ledgerLimit >= LEDGER_MAX_ROWS && (ledgerData?.has_more ?? false)}
-						isFetchingMore={ledger.isFetching}
-						onShowMore={
-							ledger.error
-								? undefined
-								: () => setLedgerLimit((n) => Math.min(n + LEDGER_PAGE_SIZE, LEDGER_MAX_ROWS))
-						}
-					/>
-					{ledger.error ? (
-						<ApiErrorPanel
-							normalizer={billingErrorNormalizer}
-							error={ledger.error}
-							title="Couldn’t load more activity"
-							onRetry={() => void ledger.refetch()}
-						/>
-					) : null}
-				</>
-			)}
 
-			<TopUpDialog open={topUpOpen} onOpenChange={setTopUpOpen} />
+				<BalanceCard
+					wallet={w}
+					hasWalletCompute={walletComputeCount > 0}
+					onTopUp={() => setTopUpOpen(true)}
+				/>
+
+				<div id="auto-reload" className="grid gap-4 lg:grid-cols-2">
+					<AutoReloadCard wallet={w} onTopUp={() => setTopUpOpen(true)} />
+					{w.x402_enabled === true ? <X402Card /> : null}
+				</div>
+
+				{ledger.error && !ledgerData ? (
+					<ApiErrorPanel
+						normalizer={billingErrorNormalizer}
+						error={ledger.error}
+						title="Couldn’t load activity"
+						onRetry={() => ledger.refetch()}
+					/>
+				) : (
+					<>
+						<LedgerTable
+							entries={ledgerData?.items ?? []}
+							isLoading={ledger.isLoading}
+							hasMore={ledgerData?.has_more ?? false}
+							atCap={ledgerLimit >= LEDGER_MAX_ROWS && (ledgerData?.has_more ?? false)}
+							isFetchingMore={ledger.isFetching}
+							onShowMore={
+								ledger.error
+									? undefined
+									: () => setLedgerLimit((n) => Math.min(n + LEDGER_PAGE_SIZE, LEDGER_MAX_ROWS))
+							}
+						/>
+						{ledger.error ? (
+							<ApiErrorPanel
+								normalizer={billingErrorNormalizer}
+								error={ledger.error}
+								title="Couldn’t load more activity"
+								onRetry={() => void ledger.refetch()}
+							/>
+						) : null}
+					</>
+				)}
+			</div>
 		</div>
 	);
 }

--- a/packages/shared/src/api/deploy.generated.ts
+++ b/packages/shared/src/api/deploy.generated.ts
@@ -1824,8 +1824,6 @@ export interface components {
         };
         /** V2WalletAutoReloadRequest */
         V2WalletAutoReloadRequest: {
-            /** Payment Mode */
-            payment_mode?: "card" | null;
             /** Auto Reload Enabled */
             auto_reload_enabled?: boolean | null;
             /** Auto Reload Threshold Usd */
@@ -1837,18 +1835,16 @@ export interface components {
         };
         /** V2WalletLedgerItemResponse */
         V2WalletLedgerItemResponse: {
-            /** Id */
-            id: string;
             /** Operation */
             operation: string;
-            /** Request Id */
-            request_id: string;
+            /** Description */
+            description: string;
             /** Amount Usd */
             amount_usd: string;
             /** Status */
             status: string;
-            /** Notes */
-            notes?: string | null;
+            /** Receipt Url */
+            receipt_url?: string | null;
             /** Created At */
             created_at: string;
             /** Applied At */
@@ -1865,11 +1861,6 @@ export interface components {
         V2WalletResponse: {
             /** Balance Usd */
             balance_usd: string;
-            /**
-             * Payment Mode
-             * @constant
-             */
-            payment_mode: "card";
             /** X402 Enabled */
             x402_enabled: boolean;
             /** Auto Reload Enabled */

--- a/packages/shared/src/api/deploy.test.ts
+++ b/packages/shared/src/api/deploy.test.ts
@@ -22,7 +22,6 @@ type DeploySchemas = DeployComponents["schemas"];
 
 const wallet: DeploySchemas["V2WalletResponse"] = {
 	balance_usd: "25.000001",
-	payment_mode: "card",
 	x402_enabled: true,
 	auto_reload_enabled: true,
 	auto_reload_threshold_usd: "5",


### PR DESCRIPTION
## Summary

- regenerate the deploy billing contract from the live hosted OpenAPI schema
- render wallet ledger descriptions and external Stripe receipt links without exposing internal IDs
- add the shared billing portal action to Wallet
- render Wallet top-up and auto-reload SCA confirmation inline inside the Settings dialog while preserving standalone top-up dialogs

## Verification

- strict live deploy contract drift check
- web typecheck and 561 unit tests
- shared typecheck and 41 shared tests
- web lint and repository Biome check
- OSS production build
- 5 focused hosted Playwright wallet tests (ledger receipts, portal, auto-reload, top-up idempotency and single-dialog behavior)