### PR TITLE
fix(web): release paid deploy UI on acceptance

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -160,7 +160,7 @@ const includedBasicDeployment: DeploymentMutationFixture = {
 	},
 };
 
-const paidBasicDeployment = {
+const paidBasicDeployment: DeploymentMutationFixture = {
 	...includedBasicDeployment,
 	id: "hdep_paid",
 	name: "Paid Basic",
@@ -748,6 +748,7 @@ type HostedApiStubOptions = {
 	completedDeleteIds?: Set<string>;
 	deleteResponses?: StubResponse[];
 	deploymentListRequests?: string[];
+	deploymentRequestReads?: string[];
 	deployments?: readonly unknown[];
 	deploymentsResponse?: StubResponse;
 	fixPaymentRequests?: string[];
@@ -774,6 +775,7 @@ type HostedApiStubOptions = {
 	topUpIdempotencyKeys?: string[];
 	topUpRequests?: string[];
 	topUpResponses?: StubResponse[];
+	unfinishedDeploymentRequests?: boolean;
 	updateDeploymentRequests?: Array<{
 		body: string;
 		idempotencyKey: string | null;
@@ -788,6 +790,47 @@ type HostedApiStubOptions = {
 
 async function fulfillJson(route: Route, body: unknown, status = 200) {
 	await route.fulfill({ status, contentType: "application/json", body: JSON.stringify(body) });
+}
+
+async function stubCompletedStripeCheckout(page: Page) {
+	await page.addInitScript(() => {
+		const mockStripe = Object.assign(
+			() => {
+				const session = { canConfirm: true, status: { type: "open" } };
+				const actions = {
+					getSession: () => session,
+					confirm: async () => ({
+						type: "success",
+						session: { status: { type: "complete" } },
+					}),
+				};
+				return {
+					elements: () => ({}),
+					createToken: async () => ({}),
+					createPaymentMethod: async () => ({}),
+					confirmCardPayment: async () => ({}),
+					_registerWrapper: () => undefined,
+					initCheckoutElementsSdk: () => ({
+						loadActions: async () => ({ type: "success", actions }),
+						on: () => undefined,
+						changeAppearance: () => undefined,
+						loadFonts: () => undefined,
+						createPaymentElement: () => ({
+							mount: (node: HTMLElement) => {
+								node.textContent = "Mock secure payment form";
+							},
+							on: () => undefined,
+							off: () => undefined,
+							update: () => undefined,
+							destroy: () => undefined,
+						}),
+					}),
+				};
+			},
+			{ version: "dahlia" },
+		);
+		Object.defineProperty(window, "Stripe", { configurable: true, value: mockStripe });
+	});
 }
 
 async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
@@ -889,19 +932,25 @@ async function stubHostedApi(page: Page, options: HostedApiStubOptions = {}) {
 		}
 		if (p.startsWith("/v2/deployments/by-request/") && r.request().method() === "GET") {
 			const deployRequestId = decodeURIComponent(p.slice("/v2/deployments/by-request/".length));
+			options.deploymentRequestReads?.push(deployRequestId);
 			const deployment = deploymentRequests.get(deployRequestId);
-			return deployment
-				? fulfillJson(r, {
-						deploy_request_id: deployRequestId,
-						request_status: "succeeded",
-						lineage_tail: {
-							deployment_id: deployment.id,
-							lineage_version: 1,
-							lineage_state: "succeeded",
-							operation: completedDeploymentOperation(deployment, "create"),
-						},
-					})
-				: fulfillJson(r, { detail: "Deployment request not found" }, 404);
+			if (!deployment) {
+				return fulfillJson(r, { detail: "Deployment request not found" }, 404);
+			}
+			const acceptedOperation = completedDeploymentOperation(deployment, "create");
+			const unfinished = options.unfinishedDeploymentRequests ?? false;
+			return fulfillJson(r, {
+				deploy_request_id: deployRequestId,
+				request_status: unfinished ? "processing" : "succeeded",
+				lineage_tail: {
+					deployment_id: deployment.id,
+					lineage_version: 1,
+					lineage_state: unfinished ? "processing" : "succeeded",
+					operation: unfinished
+						? { ...acceptedOperation, done: false, response: null }
+						: acceptedOperation,
+				},
+			});
 		}
 		if (p.startsWith("/v2/deployments/") && r.request().method() === "GET") {
 			const deploymentId = decodeURIComponent(p.slice("/v2/deployments/".length));
@@ -1358,6 +1407,54 @@ test("free Basic Deploy submits the declarative create contract", async ({ page 
 			model: "gpt-5.6-luna",
 		},
 	});
+});
+
+test("paid checkout navigates on deployment acceptance without LRO convergence", async ({
+	page,
+}) => {
+	const deploymentRequestReads: string[] = [];
+	const operationPollRequests: string[] = [];
+	page.on("request", (request) => {
+		const path = new URL(request.url()).pathname;
+		if (path.startsWith("/v2/operations/")) operationPollRequests.push(path);
+	});
+	await stubCompletedStripeCheckout(page);
+	const provisioningDeployment: DeploymentMutationFixture = {
+		...paidBasicDeployment,
+		id: "hdep_created",
+		name: "Created Basic",
+		status: "creating",
+	};
+	await stubHostedApi(page, {
+		checkoutResponses: [
+			{
+				status: 200,
+				body: {
+					flow_type: "checkout_session",
+					funding_source: "stripe",
+					action_url: null,
+					checkout_url: "https://checkout.stripe.test/session",
+					client_secret: "cs_test_paid_checkout",
+				},
+			},
+		],
+		deploymentRequestReads,
+		deployments: [includedBasicDeployment, provisioningDeployment],
+		plans: [basicPlan],
+		unfinishedDeploymentRequests: true,
+	});
+	await page.goto("/deploy");
+
+	await page.getByRole("button", { name: "Continue to checkout" }).click();
+	const checkoutDialog = page.getByRole("dialog", { name: /Complete .* checkout/ });
+	await expect(checkoutDialog.getByText("Mock secure payment form", { exact: true })).toBeVisible();
+	await checkoutDialog.getByRole("button", { name: "Subscribe", exact: true }).click();
+
+	await expect(page).toHaveURL(/\/agents\/hdep_created/);
+	await expect(page.getByText("Provisioning your agent…", { exact: true })).toBeVisible();
+	expect(deploymentRequestReads).toHaveLength(1);
+	expect(operationPollRequests).toEqual([]);
+	await expect(page.getByText("Couldn’t deploy", { exact: true })).toHaveCount(0);
 });
 
 test("accepted detail delete navigates after deployment membership disappears", async ({

--- a/apps/web/src/hosted/billing/billing-client.test.ts
+++ b/apps/web/src/hosted/billing/billing-client.test.ts
@@ -10,6 +10,7 @@ import {
 	BillingApiError,
 	DEPLOYMENT_CONFLICT_MESSAGE,
 	DeploymentConflictError,
+	DeploymentRequestTerminalError,
 } from "@/hosted/billing/errors";
 import { hostedDeploymentFixture } from "@/hosted/hosted-deployment.test-fixture";
 
@@ -151,9 +152,10 @@ describe("declarative deployment mutations", () => {
 		).toThrow("The deployment service completed creation without a deployment.");
 	});
 
-	it("waits for a checkout deployment request that genuinely needs LRO completion", async () => {
+	it("releases a checkout deployment request as soon as its LRO is accepted", async () => {
 		const requests: Request[] = [];
 		const intentKey = "subscription-checkout-deploy-create-happy";
+		let requestStatusReads = 0;
 		const client = testClient(async (request) => {
 			requests.push(request.clone());
 			const path = new URL(request.url).pathname;
@@ -166,6 +168,19 @@ describe("declarative deployment mutations", () => {
 				});
 			}
 			if (path === `/v2/deployments/by-request/${intentKey}`) {
+				requestStatusReads += 1;
+				if (requestStatusReads === 1) {
+					return jsonResponse({
+						deploy_request_id: intentKey,
+						request_status: "ready",
+						lineage_tail: {
+							deployment_id: "hdep_test",
+							lineage_version: 1,
+							lineage_state: "unaccepted",
+							operation: null,
+						},
+					});
+				}
 				return jsonResponse({
 					deploy_request_id: intentKey,
 					request_status: "processing",
@@ -177,8 +192,8 @@ describe("declarative deployment mutations", () => {
 					},
 				});
 			}
-			if (path === "/v2/operations/create-happy") {
-				return jsonResponse(operation({ id: "create-happy", verb: "create" }));
+			if (path.startsWith("/v2/operations/")) {
+				throw new Error("Accepted checkout deploys must not poll their operation");
 			}
 			throw new Error(`Unexpected request: ${request.method} ${path}`);
 		});
@@ -201,7 +216,7 @@ describe("declarative deployment mutations", () => {
 		expect(checkout.deploy_request_id).toBe(intentKey);
 		expect(await client.waitForDeploymentRequest(intentKey)).toMatchObject({
 			deploymentId: "hdep_test",
-			operation: { done: true, name: "operations/create-happy" },
+			operation: { done: false, name: "operations/create-happy" },
 		});
 
 		const checkoutRequest = requests[0];
@@ -212,7 +227,36 @@ describe("declarative deployment mutations", () => {
 		expect(requests.map((request) => new URL(request.url).pathname)).toEqual([
 			"/v2/subscription/checkout",
 			`/v2/deployments/by-request/${intentKey}`,
-			"/v2/operations/create-happy",
+			`/v2/deployments/by-request/${intentKey}`,
+		]);
+	});
+
+	it("surfaces a checkout deployment request that fails before acceptance", async () => {
+		const intentKey = "subscription-checkout-deploy-create-failed";
+		const requests: Request[] = [];
+		const client = testClient(async (request) => {
+			requests.push(request.clone());
+			const path = new URL(request.url).pathname;
+			if (path === `/v2/deployments/by-request/${intentKey}`) {
+				return jsonResponse({
+					deploy_request_id: intentKey,
+					request_status: "failed",
+					lineage_tail: {
+						deployment_id: null,
+						lineage_version: 1,
+						lineage_state: "failed",
+						operation: null,
+					},
+				});
+			}
+			throw new Error(`Unexpected request: ${request.method} ${path}`);
+		});
+
+		await expect(client.waitForDeploymentRequest(intentKey)).rejects.toBeInstanceOf(
+			DeploymentRequestTerminalError,
+		);
+		expect(requests.map((request) => new URL(request.url).pathname)).toEqual([
+			`/v2/deployments/by-request/${intentKey}`,
 		]);
 	});
 

--- a/apps/web/src/hosted/billing/billing-client.ts
+++ b/apps/web/src/hosted/billing/billing-client.ts
@@ -32,6 +32,7 @@ import {
 	BillingApiError,
 	BillingNetworkError,
 	DeploymentConflictError,
+	DeploymentRequestTerminalError,
 } from "@/hosted/billing/errors";
 import { useAuthToken } from "@/lib/auth-client";
 import { env } from "@/lib/env";
@@ -153,7 +154,7 @@ function isPreconditionConflict(error: unknown): error is BillingApiError {
 }
 
 function terminalDeployRequestError(status: HostedDeployRequestStatus): BillingApiError {
-	return new BillingApiError(
+	return new DeploymentRequestTerminalError(
 		409,
 		status.request_status === "superseded"
 			? "This deployment request was superseded by a newer attempt."
@@ -203,19 +204,6 @@ export function createBillingClient(
 			}),
 		);
 
-	const waitForOperation = async (
-		initialOperation: DeploymentOperation,
-	): Promise<DeploymentOperation> => {
-		let operation = initialOperation;
-		for (let poll = 0; !operation.done && poll < pollLimit; poll += 1) {
-			await sleep(pollIntervalMs);
-			operation = await getOperation(operationIdFromName(operation.name));
-		}
-		if (!operation.done) throw new BillingNetworkError("timeout");
-		if (operation.error) throw new BillingApiError(409, operation.error.message, operation.error);
-		return operation;
-	};
-
 	const getDeploymentByRequest = async (
 		deployRequestId: string,
 	): Promise<HostedDeployRequestStatus> =>
@@ -236,18 +224,24 @@ export function createBillingClient(
 				throw terminalDeployRequestError(status);
 			}
 
+			const deploymentId = status.lineage_tail?.deployment_id ?? null;
 			const projectedOperation = status.lineage_tail?.operation ?? null;
+			if (projectedOperation) {
+				return acceptDeclarativeOperation({ operation: projectedOperation, deploymentId });
+			}
+			if (
+				(status.request_status === "processing" || status.request_status === "succeeded") &&
+				deploymentId
+			) {
+				return acceptDeclarativeOperation({ deploymentId, operation: null });
+			}
 			const operationName = status.lineage_tail?.operation_name ?? null;
-			if (projectedOperation || operationName) {
-				const initialOperation =
-					projectedOperation ?? (await getOperation(operationIdFromName(operationName ?? "")));
+			if (operationName) {
 				return acceptDeclarativeOperation({
-					operation: await waitForOperation(initialOperation),
-					deploymentId: status.lineage_tail?.deployment_id,
+					operation: await getOperation(operationIdFromName(operationName)),
 				});
 			}
-			const deploymentId = status.lineage_tail?.deployment_id ?? null;
-			if (status.request_status === "succeeded" && deploymentId) {
+			if (status.request_status === "succeeded") {
 				return acceptDeclarativeOperation({ deploymentId, operation: null });
 			}
 			if (poll === pollLimit) break;

--- a/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
+++ b/apps/web/src/hosted/billing/deploy/deploy-wizard.tsx
@@ -84,6 +84,7 @@ import {
 } from "@/hosted/billing/deploy/language-timezone-controls";
 import {
 	billingErrorNormalizer,
+	DeploymentRequestTerminalError,
 	isIdempotencyKeyReusedError,
 	normalizeBillingError,
 } from "@/hosted/billing/errors";
@@ -688,12 +689,18 @@ export function DeployWizard() {
 				const resolved = await resolveDeploymentRequest.mutateAsync(request.idempotencyKey);
 				forgetIdempotencyAttempt("subscription-checkout", requestFingerprint);
 				checkoutAttemptRef.current = null;
-				toast.success("Deployment ready", {
-					description: `Your ${tierLabel} agent finished provisioning.`,
+				toast.success("Agent deployed", {
+					description: `Your ${tierLabel} agent is provisioning now.`,
 				});
 				void router.navigate(acceptedDeploymentNavigation(resolved.deploymentId, true));
 				return;
-			} catch {
+			} catch (error) {
+				if (error instanceof DeploymentRequestTerminalError) {
+					forgetIdempotencyAttempt("subscription-checkout", requestFingerprint);
+					checkoutAttemptRef.current = null;
+					toast.error("Couldn’t deploy", { description: normalizeBillingError(error) });
+					return;
+				}
 				// Stripe may complete before its deploy request is visible. Fall back
 				// to the inventory refresh path and let normal polling pick it up.
 			}

--- a/apps/web/src/hosted/billing/errors.ts
+++ b/apps/web/src/hosted/billing/errors.ts
@@ -53,6 +53,11 @@ export class DeploymentConflictError extends Error {
 	}
 }
 
+/** A checkout-funded deploy request reached a terminal state before acceptance. */
+export class DeploymentRequestTerminalError extends BillingApiError {
+	override name = "DeploymentRequestTerminalError";
+}
+
 function hasDetail(value: unknown): value is { detail: unknown } {
 	return typeof value === "object" && value !== null && "detail" in value;
 }


### PR DESCRIPTION
## Why\n\nThe paid Stripe flow creates checkout before the deployment exists. The wizard retains the stable idempotency key as deploy_request_id, then resolves that request after Stripe confirms so it can obtain the deployment ID needed for navigation.\n\nThe existing resolver kept polling the request lineage until operation.done. That wait was originally used to obtain the created deployment, but the accepted processing lineage already contains lineage_tail.deployment_id and the projected unfinished LRO also carries metadata.deploymentId. The acceptance response is therefore sufficient to route immediately.\n\n## What changed\n\n- Return from waitForDeploymentRequest as soon as the request has an accepted operation or a processing/succeeded deployment ID; do not poll the LRO to convergence.\n- Navigate the paid checkout-complete flow directly to the existing agent detail route and reuse its normal provisioning UI/copy.\n- Surface failed, expired, and superseded requests as explicit deployment errors, and clear the terminal idempotency attempt so a retry gets a fresh key.\n- Preserve the existing inventory fallback for transient request visibility, plus the unchanged checkout-cancel and checkout-return behavior.\n- Add a paid browser E2E with an unfinished accepted operation that asserts immediate navigation, provisioning copy, one request-status read, and zero operation polling.\n\n## Test change\n\nBefore:\n- waits for a checkout deployment request that genuinely needs LRO completion\n\nAfter:\n- releases a checkout deployment request as soon as its LRO is accepted\n\nAlso added:\n- surfaces a checkout deployment request that fails before acceptance\n- paid checkout navigates on deployment acceptance without LRO convergence\n\n## Verification\n\n- bun run check\n- bun run lint\n- bun run typecheck\n- bun run build\n- affected billing/deploy unit tests: 26 passed\n- focused paid Playwright test: 1 passed\n\nThe full hosted-smoke Playwright file is stale on main. The new paid test passed within the full run, but unrelated existing cases failed on outdated selectors/copy and agent-detail assertions; no unrelated E2E repairs are included.