### PR TITLE
fix: canonicalize the public managed provider id

### DIFF
--- a/apps/web/e2e/hosted-smoke.pw.ts
+++ b/apps/web/e2e/hosted-smoke.pw.ts
@@ -1354,7 +1354,7 @@ test("free Basic Deploy submits the declarative create contract", async ({ page 
 		compute_plan_slug: "compute_basic",
 		runtime: "hermes",
 		primary_model: {
-			provider_id: "clawdi-v2",
+			provider_id: "clawdi",
 			model: "gpt-5.6-luna",
 		},
 	});
@@ -1544,9 +1544,9 @@ test("hosted AI provider Apply accepts the managed Luna default", async ({ page 
 	await expect.poll(() => updateDeploymentRequests.length).toBe(1);
 	expect(JSON.parse(updateDeploymentRequests[0]?.body ?? "{}")).toMatchObject({
 		ai_provider_auth_kind: "managed",
-		provider_ids: ["clawdi-v2"],
+		provider_ids: ["clawdi"],
 		primary_model: {
-			provider_id: "clawdi-v2",
+			provider_id: "clawdi",
 			model: "gpt-5.6-luna",
 		},
 	});

--- a/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
+++ b/apps/web/src/hosted/billing/deploy/deploy-request.test.ts
@@ -14,16 +14,16 @@ describe("buildHostedDeployRequest", () => {
 			aiFields: {
 				ai_provider_id: null,
 				ai_provider_auth_kind: "managed",
-				provider_ids: ["clawdi-v2"],
+				provider_ids: ["clawdi"],
 				primary_model: {
-					provider_id: "clawdi-v2",
+					provider_id: "clawdi",
 					model: "gpt-5.6-luna",
 				},
 			},
 		});
 
 		expect(request.primary_model).toEqual({
-			provider_id: "clawdi-v2",
+			provider_id: "clawdi",
 			model: "gpt-5.6-luna",
 		});
 	});

--- a/apps/web/src/hosted/v2/ai-providers/model-binding.ts
+++ b/apps/web/src/hosted/v2/ai-providers/model-binding.ts
@@ -1,5 +1,5 @@
 import {
-	CLAWDI_MANAGED_V2_PROVIDER_ID,
+	CLAWDI_MANAGED_PROVIDER_ID,
 	isClawdiManagedProviderId,
 	isFirstPartyManagedAiProvider,
 } from "@clawdi/shared";
@@ -9,7 +9,7 @@ import type { AiProvider } from "@/hosted/v2/ai-providers/types";
 import { formatModelLabel } from "@/lib/format";
 
 export const MANAGED_AI_CHOICE = "__managed__";
-export const MANAGED_PROVIDER_ID = CLAWDI_MANAGED_V2_PROVIDER_ID;
+export const MANAGED_PROVIDER_ID = CLAWDI_MANAGED_PROVIDER_ID;
 export const MANAGED_PROVIDER_LABEL = "Managed by Clawdi";
 export const CUSTOM_MODEL_CHOICE = "__custom__";
 

--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -99,6 +99,7 @@ from app.services.managed_ai_provider import (
     MANAGED_AI_PROVIDER_RUNTIME_ENV,
     MANAGED_AI_PROVIDER_SCOPE,
     MANAGED_AI_PROVIDER_TYPE,
+    V2_MANAGED_AI_PROVIDER_ID,
     V2_MANAGED_AI_PROVIDER_IDS,
     archive_clawdi_managed_provider,
     find_clawdi_managed_provider,
@@ -641,14 +642,14 @@ async def admin_upsert_clawdi_managed_ai_provider(
                 status.HTTP_422_UNPROCESSABLE_CONTENT,
                 "target_clerk_id is required for fixed managed AI providers",
             )
-        # Keep this branch byte-for-byte compatible with the original fixed
-        # clawdi-v2 / clawdi-managed-v2 admin contract.
+        # Legacy route ids remain accepted during the cross-service rollout,
+        # but fixed managed-provider writes and responses are canonical.
         target = await _resolve_or_create_user(db, body.target_clerk_id)
         try:
             provider = await upsert_clawdi_managed_provider(
                 db,
                 user=target,
-                provider_id=provider_id,
+                provider_id=V2_MANAGED_AI_PROVIDER_ID,
                 base_url=body.base_url,
                 api_key=body.api_key.get_secret_value(),
                 default_model=body.default_model,

--- a/backend/app/routes/ai_providers.py
+++ b/backend/app/routes/ai_providers.py
@@ -43,7 +43,11 @@ from app.schemas.ai_provider import (
 from app.services.managed_ai_provider import (
     MANAGED_AI_PROVIDER_IDS,
     MANAGED_AI_PROVIDER_RUNTIME_ENV,
+    V2_MANAGED_AI_PROVIDER_ID,
+    V2_MANAGED_AI_PROVIDER_IDS,
+    is_v2_deployment_managed_provider_id,
     managed_provider_api_mode,
+    runtime_managed_provider_id,
 )
 from app.services.sync_events import queue_provider_runtime_manifest_changed
 from app.services.vault_crypto import decrypt, encrypt
@@ -107,7 +111,13 @@ async def list_ai_providers(
         .scalars()
         .all()
     )
-    return AiProviderListResponse(providers=[_to_response(row) for row in rows])
+    providers_by_public_id: dict[str, AiProviderResponse] = {}
+    for row in rows:
+        if is_v2_deployment_managed_provider_id(row.provider_id):
+            continue
+        response = _to_response(row)
+        providers_by_public_id.setdefault(response.provider_id, response)
+    return AiProviderListResponse(providers=list(providers_by_public_id.values()))
 
 
 @router.post("", response_model=AiProviderResponse, response_model_exclude_none=True)
@@ -117,6 +127,8 @@ async def upsert_ai_provider(
     auth: AuthContext = Depends(require_user_auth_unbound),
     db: AsyncSession = Depends(get_session),
 ) -> AiProviderResponse:
+    if body.provider_id in V2_MANAGED_AI_PROVIDER_IDS:
+        body = body.model_copy(update={"provider_id": V2_MANAGED_AI_PROVIDER_ID})
     errors = _validate_provider(body)
     if errors:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, {"errors": errors})
@@ -186,7 +198,7 @@ async def delete_ai_provider(
             await db.execute(
                 select(AiProviderAuthPayload).where(
                     AiProviderAuthPayload.owner_user_id == auth.user_id,
-                    AiProviderAuthPayload.provider_id == provider_id,
+                    AiProviderAuthPayload.provider_id == provider.provider_id,
                     AiProviderAuthPayload.archived_at.is_(None),
                 )
             )
@@ -198,7 +210,10 @@ async def delete_ai_provider(
         payload.archived_at = archived_at
     await queue_provider_runtime_manifest_changed(db, auth.user_id, provider.provider_id)
     await db.commit()
-    return AiProviderDeleteResponse(status="deleted", provider_id=provider_id)
+    return AiProviderDeleteResponse(
+        status="deleted",
+        provider_id=runtime_managed_provider_id(provider.provider_id),
+    )
 
 
 @router.post("/{provider_id}/validate", response_model=AiProviderValidationResponse)
@@ -232,7 +247,7 @@ async def set_ai_provider_api_key(
     await _store_auth_payload(
         db,
         auth,
-        provider_id,
+        provider.provider_id,
         profile,
         "api_key",
         body.value.get_secret_value(),
@@ -283,7 +298,7 @@ async def import_ai_provider_auth(
     await _store_auth_payload(
         db,
         auth,
-        provider_id,
+        provider.provider_id,
         profile,
         auth_import.type,
         auth_import.payload.get_secret_value(),
@@ -306,7 +321,7 @@ async def start_ai_provider_oauth(
     auth: AuthContext = Depends(require_user_auth_unbound),
     db: AsyncSession = Depends(get_session),
 ) -> AiProviderOAuthStartResponse:
-    await _get_provider_or_404(db, auth, provider_id)
+    provider = await _get_provider_or_404(db, auth, provider_id)
     oauth_provider = _normalize_profile(body.provider)
     _validate_supported_oauth_provider(oauth_provider)
     profile = "default"
@@ -326,7 +341,7 @@ async def start_ai_provider_oauth(
     expires_at = datetime.now(UTC) + timedelta(seconds=OAUTH_STATE_TTL_SECONDS)
     state = _encode_oauth_state(
         {
-            "provider_id": provider_id,
+            "provider_id": provider.provider_id,
             "owner_user_id": str(auth.user_id),
             "oauth_provider": oauth_provider,
             "profile": profile,
@@ -363,7 +378,7 @@ async def start_ai_provider_oauth(
     separator = "&" if "?" in authorization_url else "?"
     auth_url = f"{authorization_url}{separator}{urlencode(params)}"
     return AiProviderOAuthStartResponse(
-        provider_id=provider_id,
+        provider_id=runtime_managed_provider_id(provider.provider_id),
         oauth_provider=oauth_provider,
         profile=profile,
         auth_url=auth_url,
@@ -387,7 +402,9 @@ async def complete_ai_provider_oauth(
     provider = await _get_provider_or_404(db, auth, provider_id)
     previous_signature = _runtime_manifest_provider_signature(provider)
     state = _decode_oauth_state(body.state)
-    if state.get("provider_id") != provider_id or state.get("owner_user_id") != str(auth.user_id):
+    if state.get("provider_id") != provider.provider_id or state.get("owner_user_id") != str(
+        auth.user_id
+    ):
         raise HTTPException(status.HTTP_400_BAD_REQUEST, "OAuth state does not match this user")
     expires_at = _parse_state_datetime(str(state.get("expires_at") or ""))
     if expires_at < datetime.now(UTC):
@@ -429,7 +446,7 @@ async def complete_ai_provider_oauth(
     await _store_auth_payload(
         db,
         auth,
-        provider_id,
+        provider.provider_id,
         profile,
         provider_auth_type,
         payload_text,
@@ -603,20 +620,20 @@ async def resolve_ai_provider_auth(
     active_profile = _active_auth_profile(provider)
     if active_profile is not None and profile != active_profile:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "AI Provider auth payload not found")
-    payload = await _find_auth_payload(db, auth, provider_id, profile)
+    payload = await _find_auth_payload(db, auth, provider.provider_id, profile)
     if payload is None or payload.archived_at is not None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "AI Provider auth payload not found")
     plaintext = decrypt(payload.encrypted_payload, payload.nonce)
     if provider.auth_type == "api_key":
         return AiProviderAuthResolveResponse(
-            provider_id=provider_id,
+            provider_id=runtime_managed_provider_id(provider.provider_id),
             auth_type="api_key",
             value=plaintext,
             profile=profile,
         )
     if provider.auth_type in {"agent_profile", "oauth_profile"}:
         return AiProviderAuthResolveResponse(
-            provider_id=provider_id,
+            provider_id=runtime_managed_provider_id(provider.provider_id),
             auth_type=provider.auth_type,
             payload=plaintext,
             tool=metadata.get("tool"),
@@ -777,13 +794,25 @@ async def _find_provider(
     *,
     include_archived: bool = False,
 ) -> AiProvider | None:
+    provider_ids = (
+        V2_MANAGED_AI_PROVIDER_IDS
+        if provider_id in V2_MANAGED_AI_PROVIDER_IDS
+        else frozenset({provider_id})
+    )
     stmt = select(AiProvider).where(
         AiProvider.owner_user_id == auth.user_id,
-        AiProvider.provider_id == provider_id,
+        AiProvider.provider_id.in_(provider_ids),
     )
     if not include_archived:
         stmt = stmt.where(AiProvider.archived_at.is_(None))
-    return (await db.execute(stmt)).scalar_one_or_none()
+    providers = (await db.execute(stmt)).scalars().all()
+    if not providers:
+        return None
+    priority = {
+        V2_MANAGED_AI_PROVIDER_ID: 0,
+        provider_id: 1,
+    }
+    return min(providers, key=lambda provider: priority.get(provider.provider_id, 2))
 
 
 async def _get_provider_or_404(db: AsyncSession, auth: AuthContext, provider_id: str) -> AiProvider:
@@ -835,7 +864,7 @@ def _to_auth(provider: AiProvider) -> AiProviderAuth:
 def _to_response(provider: AiProvider) -> AiProviderResponse:
     return AiProviderResponse(
         id=str(provider.id),
-        provider_id=provider.provider_id,
+        provider_id=runtime_managed_provider_id(provider.provider_id),
         scope=AI_PROVIDER_SCOPE,
         type=provider.type,
         label=provider.label,
@@ -914,8 +943,7 @@ def _validate_managed_provider_contract(body: AiProviderUpsert | AiProviderRespo
     errors: list[str] = []
     expected_api_mode = managed_provider_api_mode(body.provider_id)
     if expected_api_mode is None:
-        allowed_ids = ", ".join(sorted(MANAGED_AI_PROVIDER_IDS))
-        errors.append(f"managed Clawdi provider must use provider_id one of: {allowed_ids}")
+        errors.append(f"managed Clawdi provider must use provider_id {V2_MANAGED_AI_PROVIDER_ID}")
     if body.managed_by != "clawdi":
         errors.append("managed Clawdi provider must be managed_by clawdi")
     if body.type != "custom_openai_compatible":

--- a/backend/app/services/managed_ai_provider.py
+++ b/backend/app/services/managed_ai_provider.py
@@ -12,18 +12,22 @@ from app.models.ai_provider import AiProvider, AiProviderAuthPayload
 from app.models.user import User
 from app.services.vault_crypto import encrypt
 
-# Agent-facing alias only. Credential and catalog source rows keep their v2 ids below.
 CLAWDI_MANAGED_PROVIDER_ID = "clawdi"
 V1_MANAGED_AI_PROVIDER_ID = "clawdi-managed"
 V1_MANAGED_AI_PROVIDER_API_MODE = "openai_responses"
-V2_MANAGED_AI_PROVIDER_ID = "clawdi-v2"
+V2_MANAGED_AI_PROVIDER_ID = CLAWDI_MANAGED_PROVIDER_ID
 V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX = "clawdi-v2-deployment-"
 V2_MANAGED_AI_PROVIDER_MAX_ID_LENGTH = 63
-# TODO(#425): Remove this legacy alias and transition accept-set after hosted#892
-# is deployed everywhere and no dev/self-hosted binding still uses clawdi-managed-v2.
+V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID = "clawdi-v2"
+# TODO(#425): Remove legacy aliases only after the cross-repo rollout is complete
+# and persisted clients no longer send either legacy id.
 V2_LEGACY_MANAGED_AI_PROVIDER_ID = "clawdi-managed-v2"
 V2_MANAGED_AI_PROVIDER_IDS = frozenset(
-    {V2_MANAGED_AI_PROVIDER_ID, V2_LEGACY_MANAGED_AI_PROVIDER_ID}
+    {
+        V2_MANAGED_AI_PROVIDER_ID,
+        V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
+        V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+    }
 )
 V2_MANAGED_AI_PROVIDER_API_MODE = "openai_chat"
 
@@ -31,8 +35,7 @@ V2_MANAGED_AI_PROVIDER_API_MODE = "openai_chat"
 # through the user AI Provider endpoint with the v1-specific id/mode above.
 MANAGED_AI_PROVIDER_ID = V2_MANAGED_AI_PROVIDER_ID
 MANAGED_AI_PROVIDER_API_MODE = V2_MANAGED_AI_PROVIDER_API_MODE
-# TODO(#425): Remove the legacy v2 member from this aggregate after hosted#892
-# is deployed everywhere and no dev/self-hosted binding still uses clawdi-managed-v2.
+# TODO(#425): Remove legacy v2 members after the compatibility window closes.
 MANAGED_AI_PROVIDER_IDS = frozenset({V1_MANAGED_AI_PROVIDER_ID, *V2_MANAGED_AI_PROVIDER_IDS})
 MANAGED_AI_PROVIDER_RUNTIME_ENV = "CLAWDI_MANAGED_OPENAI_API_KEY"
 MANAGED_AI_PROVIDER_TYPE = "custom_openai_compatible"
@@ -85,8 +88,7 @@ def runtime_managed_provider_id(provider_id: str) -> str:
 def managed_provider_api_mode(provider_id: str) -> str | None:
     if provider_id == V1_MANAGED_AI_PROVIDER_ID:
         return V1_MANAGED_AI_PROVIDER_API_MODE
-    # TODO(#425): Remove legacy v2 mode resolution after hosted#892 is deployed
-    # everywhere and no dev/self-hosted binding still uses clawdi-managed-v2.
+    # TODO(#425): Remove legacy v2 mode resolution after the compatibility window closes.
     if provider_id in V2_MANAGED_AI_PROVIDER_IDS:
         return V2_MANAGED_AI_PROVIDER_API_MODE
     return None
@@ -129,8 +131,7 @@ async def upsert_clawdi_managed_provider(
     capabilities: dict | None = None,
 ) -> AiProvider:
     """Upsert a first-party v2 managed AI provider contract for a user."""
-    # TODO(#425): Remove legacy v2 upsert acceptance after hosted#892 is deployed
-    # everywhere and no dev/self-hosted binding still uses clawdi-managed-v2.
+    # TODO(#425): Remove legacy v2 upsert acceptance after the compatibility window closes.
     if not is_v2_managed_provider_id(provider_id):
         raise ValueError("unsupported managed provider id")
     validate_managed_provider_base_url(base_url)

--- a/backend/app/services/runtime_source.py
+++ b/backend/app/services/runtime_source.py
@@ -40,9 +40,10 @@ from app.schemas.runtime import (
 )
 from app.services.channels import channel_runtime_account_key, channel_runtime_placeholder_token
 from app.services.managed_ai_provider import (
-    CLAWDI_MANAGED_PROVIDER_ID,
     V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+    V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
     V2_MANAGED_AI_PROVIDER_ID,
+    V2_MANAGED_AI_PROVIDER_IDS,
     is_managed_provider_id,
     managed_provider_api_mode,
     runtime_managed_provider_id,
@@ -521,16 +522,15 @@ def _provider_source_id(
 ) -> str:
     """Resolve an agent alias to the deployment-scoped credential/catalog row."""
 
-    if bound_provider_id not in {
-        CLAWDI_MANAGED_PROVIDER_ID,
-        V2_MANAGED_AI_PROVIDER_ID,
-    }:
+    if bound_provider_id not in V2_MANAGED_AI_PROVIDER_IDS:
         return bound_provider_id
     deployment_provider_id = v2_deployment_managed_provider_id(deployment_id)
     if deployment_provider_id is not None and (user_id, deployment_provider_id) in batch.providers:
         return deployment_provider_id
     if (user_id, V2_MANAGED_AI_PROVIDER_ID) in batch.providers:
         return V2_MANAGED_AI_PROVIDER_ID
+    if (user_id, V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID) in batch.providers:
+        return V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID
     if (user_id, V2_LEGACY_MANAGED_AI_PROVIDER_ID) in batch.providers:
         return V2_LEGACY_MANAGED_AI_PROVIDER_ID
     return V2_MANAGED_AI_PROVIDER_ID

--- a/backend/scripts/mock_deploy_api.py
+++ b/backend/scripts/mock_deploy_api.py
@@ -20,10 +20,12 @@ from urllib.parse import urlencode
 from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.services.managed_ai_provider import CLAWDI_MANAGED_PROVIDER_ID
+
 DEV_V2_DEPLOYMENT_ID = "hdep_dev_sidebar"
 DEV_V2_APP_ID = "app_dev_sidebar"
 DEV_V2_PROVIDER_ID = "openrouter-dev"
-DEV_V2_MANAGED_PROVIDER_ID = "clawdi-v2"
+DEV_V2_MANAGED_PROVIDER_ID = CLAWDI_MANAGED_PROVIDER_ID
 STABLE_UUID_NAMESPACE = uuid.UUID("6a9575fd-7eb5-464a-89e7-e13f090f8de6")
 OPERATIONS: dict[str, dict[str, Any]] = {}
 DEPLOY_REQUESTS: dict[str, dict[str, Any]] = {}

--- a/backend/scripts/seed_dashboard_dev.py
+++ b/backend/scripts/seed_dashboard_dev.py
@@ -65,6 +65,7 @@ from app.services.channels import (  # noqa: E402
     generate_agent_token,
     hash_token,
 )
+from app.services.managed_ai_provider import CLAWDI_MANAGED_PROVIDER_ID  # noqa: E402
 from app.services.vault_crypto import encrypt  # noqa: E402
 
 DEV_V2_DEPLOYMENT_ID = "hdep_dev_sidebar"
@@ -72,7 +73,7 @@ DEV_V2_APP_ID = "app_dev_sidebar"
 DEV_V2_HOSTED_MACHINE_ID = "dev-hosted-sidebar"
 DEV_V2_HOSTED_MACHINE_NAME = "Dev Hosted Compute"
 DEV_V2_PROVIDER_ID = "openrouter-dev"
-DEV_V2_CODEX_PROVIDER_ID = "clawdi-v2"
+DEV_V2_CODEX_PROVIDER_ID = CLAWDI_MANAGED_PROVIDER_ID
 DEV_V2_CLI_PACKAGE_SPEC = "clawdi@0.12.10-beta.57"
 _STABLE_UUID_NAMESPACE = uuid.UUID("6a9575fd-7eb5-464a-89e7-e13f090f8de6")
 

--- a/backend/tests/test_admin_endpoints.py
+++ b/backend/tests/test_admin_endpoints.py
@@ -26,6 +26,7 @@ from app.services.managed_ai_provider import (
     MANAGED_AI_PROVIDER_PROVENANCE_CAPABILITY,
     V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX,
     V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+    V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
     V2_MANAGED_AI_PROVIDER_ID,
 )
 
@@ -785,7 +786,11 @@ async def test_admin_revoke_unknown_key(admin_client):
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "route_provider_id",
-    [V2_MANAGED_AI_PROVIDER_ID, V2_LEGACY_MANAGED_AI_PROVIDER_ID],
+    [
+        V2_MANAGED_AI_PROVIDER_ID,
+        V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
+        V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+    ],
 )
 async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
     admin_client, db_session, seed_user, route_provider_id: str
@@ -838,7 +843,7 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
     expected_response = {
         "owner_user_id": str(seed_user.id),
         "owner_clerk_id": seed_user.clerk_id,
-        "provider_id": route_provider_id,
+        "provider_id": V2_MANAGED_AI_PROVIDER_ID,
         "api_mode": MANAGED_AI_PROVIDER_API_MODE,
         "runtime_env_name": MANAGED_AI_PROVIDER_RUNTIME_ENV,
         "base_url": "https://ai-gateway.clawdi.ai/v1",
@@ -852,7 +857,7 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
         await db_session.execute(
             select(AiProvider).where(
                 AiProvider.owner_user_id == seed_user.id,
-                AiProvider.provider_id == route_provider_id,
+                AiProvider.provider_id == V2_MANAGED_AI_PROVIDER_ID,
             )
         )
     ).scalar_one()
@@ -870,7 +875,7 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
         await db_session.execute(
             select(AiProviderAuthPayload).where(
                 AiProviderAuthPayload.owner_user_id == seed_user.id,
-                AiProviderAuthPayload.provider_id == route_provider_id,
+                AiProviderAuthPayload.provider_id == V2_MANAGED_AI_PROVIDER_ID,
                 AiProviderAuthPayload.auth_profile == "default",
             )
         )
@@ -895,7 +900,7 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
         await db_session.execute(
             select(ControlPlaneAuditEvent).where(
                 ControlPlaneAuditEvent.action == "ai_provider.managed.upsert",
-                ControlPlaneAuditEvent.resource_id == route_provider_id,
+                ControlPlaneAuditEvent.resource_id == V2_MANAGED_AI_PROVIDER_ID,
             )
         )
     ).scalar_one()
@@ -904,7 +909,7 @@ async def test_admin_upsert_managed_ai_provider_writes_fixed_contract(
     assert event.source == "api.admin"
     audit_models = [{**managed_models[0], "max_tokens": "[REDACTED]"}]
     assert event.details == {
-        "provider_id": route_provider_id,
+        "provider_id": V2_MANAGED_AI_PROVIDER_ID,
         "api_mode": MANAGED_AI_PROVIDER_API_MODE,
         "runtime_env_name": MANAGED_AI_PROVIDER_RUNTIME_ENV,
         "models": audit_models,

--- a/backend/tests/test_ai_providers.py
+++ b/backend/tests/test_ai_providers.py
@@ -18,6 +18,7 @@ from app.services.managed_ai_provider import (
     V1_MANAGED_AI_PROVIDER_ID,
     V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX,
     V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+    V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
     V2_MANAGED_AI_PROVIDER_API_MODE,
     V2_MANAGED_AI_PROVIDER_ID,
     is_v2_managed_provider_id,
@@ -34,6 +35,7 @@ _TEST_SYSTEM = {}
     "provider_id",
     [
         V2_MANAGED_AI_PROVIDER_ID,
+        V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
         V2_LEGACY_MANAGED_AI_PROVIDER_ID,
     ],
 )
@@ -53,6 +55,7 @@ def test_v1_provider_mode_resolution_does_not_accept_deployment_scoped_ids():
     "provider_id",
     [
         V2_MANAGED_AI_PROVIDER_ID,
+        V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
         V2_LEGACY_MANAGED_AI_PROVIDER_ID,
         f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}42",
         CLAWDI_MANAGED_PROVIDER_ID,
@@ -62,11 +65,12 @@ def test_managed_v2_bindings_use_bare_agent_facing_id(provider_id: str):
     assert runtime_managed_provider_id(provider_id) == CLAWDI_MANAGED_PROVIDER_ID
 
 
-def test_agent_facing_managed_id_is_not_a_credential_identity():
+def test_public_managed_id_is_canonical_and_scoped_ids_remain_internal():
     provider_id = v2_deployment_managed_provider_id("42")
 
+    assert V2_MANAGED_AI_PROVIDER_ID == "clawdi"
     assert provider_id == f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}42"
-    assert not is_v2_managed_provider_id(CLAWDI_MANAGED_PROVIDER_ID)
+    assert is_v2_managed_provider_id(CLAWDI_MANAGED_PROVIDER_ID)
     assert runtime_managed_provider_id(V1_MANAGED_AI_PROVIDER_ID) == V1_MANAGED_AI_PROVIDER_ID
 
 
@@ -260,6 +264,45 @@ async def test_ai_provider_crud_is_account_scoped_metadata(client: httpx.AsyncCl
     empty = await client.get("/v1/ai-providers")
     assert empty.status_code == 200, empty.text
     assert empty.json()["providers"] == []
+
+
+@pytest.mark.asyncio
+async def test_legacy_managed_rows_emit_only_the_public_clawdi_id(
+    client: httpx.AsyncClient,
+    db_session,
+    seed_user,
+):
+    for provider_id in (
+        "clawdi-v2",
+        f"{V2_DEPLOYMENT_MANAGED_AI_PROVIDER_PREFIX}42",
+    ):
+        db_session.add(
+            AiProvider(
+                owner_user_id=seed_user.id,
+                provider_id=provider_id,
+                type="custom_openai_compatible",
+                base_url="https://managed.example/v1",
+                api_mode="openai_chat",
+                auth_type="api_key",
+                auth_metadata={"source": "managed", "profile": "default"},
+                managed_by="clawdi",
+                runtime_env_name="CLAWDI_MANAGED_OPENAI_API_KEY",
+                models=[{"id": "gpt-5.5"}],
+            )
+        )
+    await db_session.commit()
+
+    listing = await client.get("/v1/ai-providers")
+    canonical = await client.get("/v1/ai-providers/clawdi")
+    legacy = await client.get("/v1/ai-providers/clawdi-v2")
+
+    assert listing.status_code == 200, listing.text
+    assert [row["provider_id"] for row in listing.json()["providers"]] == ["clawdi"]
+    assert "clawdi-v2" not in listing.text
+    assert canonical.status_code == 200, canonical.text
+    assert canonical.json()["provider_id"] == "clawdi"
+    assert legacy.status_code == 200, legacy.text
+    assert legacy.json()["provider_id"] == "clawdi"
 
 
 @pytest.mark.asyncio
@@ -701,10 +744,11 @@ async def test_ai_provider_rejects_invalid_auth_and_api_mode(client: httpx.Async
 
     for managed_provider_id in (
         V2_MANAGED_AI_PROVIDER_ID,
+        V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
         V2_LEGACY_MANAGED_AI_PROVIDER_ID,
     ):
         managed = await client.post(
-            "/v1/ai-providers",
+            "/v1/ai-providers?replace=true",
             json={
                 "provider_id": managed_provider_id,
                 "type": "custom_openai_compatible",
@@ -717,7 +761,7 @@ async def test_ai_provider_rejects_invalid_auth_and_api_mode(client: httpx.Async
             },
         )
         assert managed.status_code == 200, managed.text
-        assert managed.json()["provider_id"] == managed_provider_id
+        assert managed.json()["provider_id"] == CLAWDI_MANAGED_PROVIDER_ID
         assert managed.json()["api_mode"] == "openai_chat"
         assert managed.json()["models"] == [{"id": "gpt-5.5"}]
 

--- a/backend/tests/test_runtime_source.py
+++ b/backend/tests/test_runtime_source.py
@@ -15,6 +15,7 @@ from app.schemas.runtime import HostedCodexProviderProjection
 from app.services.managed_ai_provider import (
     CLAWDI_MANAGED_PROVIDER_ID,
     V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+    V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
     V2_MANAGED_AI_PROVIDER_ID,
 )
 from app.services.runtime_source import (
@@ -348,17 +349,24 @@ def test_shared_managed_provider_material_has_distinct_codex_wire_mode() -> None
     [
         (CLAWDI_MANAGED_PROVIDER_ID, "clawdi-v2-deployment-42"),
         (CLAWDI_MANAGED_PROVIDER_ID, V2_MANAGED_AI_PROVIDER_ID),
+        (CLAWDI_MANAGED_PROVIDER_ID, V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID),
         (CLAWDI_MANAGED_PROVIDER_ID, V2_LEGACY_MANAGED_AI_PROVIDER_ID),
         (V2_MANAGED_AI_PROVIDER_ID, "clawdi-v2-deployment-42"),
         ("clawdi-v2-deployment-42", "clawdi-v2-deployment-42"),
+        (
+            V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
+            V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
+        ),
         (V2_LEGACY_MANAGED_AI_PROVIDER_ID, V2_LEGACY_MANAGED_AI_PROVIDER_ID),
     ],
     ids=[
         "agent-alias-scoped-source",
         "agent-alias-base-source",
+        "agent-alias-legacy-public-source",
         "agent-alias-legacy-source",
         "stable-internal",
         "deployment-scoped",
+        "legacy-public",
         "legacy-internal",
     ],
 )
@@ -367,7 +375,7 @@ def test_managed_v2_provider_projects_bare_agent_identity(
     source_provider_id: str,
 ) -> None:
     batch = _batch()
-    internal_provider_id = _use_managed_provider(
+    persisted_provider_id = _use_managed_provider(
         batch,
         bound_provider_id=bound_provider_id,
         source_provider_id=source_provider_id,
@@ -389,7 +397,8 @@ def test_managed_v2_provider_projects_bare_agent_identity(
     assert manifest["terminalTooling"]["codex"]["primary_model"]["provider_id"] == (
         CLAWDI_MANAGED_PROVIDER_ID
     )
-    assert internal_provider_id not in json.dumps(manifest)
+    if persisted_provider_id != CLAWDI_MANAGED_PROVIDER_ID:
+        assert persisted_provider_id not in json.dumps(manifest)
 
 
 def test_bare_managed_alias_prefers_deployment_source_over_fallback_rows() -> None:

--- a/backend/tests/test_sync_events.py
+++ b/backend/tests/test_sync_events.py
@@ -32,6 +32,7 @@ from app.services import sync_events
 from app.services.managed_ai_provider import (
     CLAWDI_MANAGED_PROVIDER_ID,
     V2_LEGACY_MANAGED_AI_PROVIDER_ID,
+    V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
     V2_MANAGED_AI_PROVIDER_ID,
 )
 
@@ -291,6 +292,7 @@ def test_runtime_provider_usage_includes_independent_codex_tool_ref() -> None:
     [
         CLAWDI_MANAGED_PROVIDER_ID,
         V2_MANAGED_AI_PROVIDER_ID,
+        V2_LEGACY_PUBLIC_MANAGED_AI_PROVIDER_ID,
         V2_LEGACY_MANAGED_AI_PROVIDER_ID,
     ],
 )

--- a/packages/cli/src/lib/ai-provider-projection.test.ts
+++ b/packages/cli/src/lib/ai-provider-projection.test.ts
@@ -98,6 +98,35 @@ describe("AI provider projection", () => {
 		expect(hermes.files[0]?.content).not.toContain("clawdi-v2");
 	});
 
+	test("accepts the legacy public managed id but only emits clawdi", () => {
+		const legacyProviderId = "clawdi-v2";
+		const catalog: AiProviderCatalog = {
+			schema_version: 1,
+			providers: [
+				{
+					id: legacyProviderId,
+					type: "custom_openai_compatible",
+					base_url: "https://managed.example.test/v1",
+					api_mode: "openai_chat",
+					auth: { type: "api_key", source: "managed" },
+					managed_by: "clawdi",
+					runtime_env_name: "OPENAI_API_KEY",
+					models: [{ id: "managed-model" }],
+				},
+			],
+			defaults: { chat_provider_id: legacyProviderId },
+		};
+		const primaryModel = { provider_id: legacyProviderId, model: "managed-model" };
+
+		for (const target of ["openclaw", "hermes"] as const) {
+			const projection = buildAgentTargetProjection(target, catalog, primaryModel);
+			expect(projection.provider_ids).toEqual([CLAWDI_MANAGED_PROVIDER_ID]);
+			expect(projection.default_provider_id).toBe(CLAWDI_MANAGED_PROVIDER_ID);
+			expect(projection.primary_model.provider_id).toBe(CLAWDI_MANAGED_PROVIDER_ID);
+			expect(projection.files[0]?.content).not.toContain(legacyProviderId);
+		}
+	});
+
 	test("maps known BYOK OpenAI providers to all runtime targets without extra user fields", () => {
 		const openclaw = buildAgentTargetProjection("openclaw", byokOpenAiCatalog);
 		expect(openclaw.provider_ids).toEqual(["openai-main"]);
@@ -177,7 +206,7 @@ describe("AI provider projection", () => {
 			schema_version: 1,
 			providers: [
 				{
-					id: "clawdi-v2",
+					id: CLAWDI_MANAGED_PROVIDER_ID,
 					type: "custom_openai_compatible",
 					base_url: "https://api.example.test/v1",
 					api_mode: "openai_chat",
@@ -205,17 +234,18 @@ describe("AI provider projection", () => {
 					}),
 				},
 			],
-			defaults: { chat_provider_id: "clawdi-v2" },
+			defaults: { chat_provider_id: CLAWDI_MANAGED_PROVIDER_ID },
 		};
 
 		const openclaw = buildAgentTargetProjection("openclaw", catalog, {
-			provider_id: "clawdi-v2",
+			provider_id: CLAWDI_MANAGED_PROVIDER_ID,
 			model: "k3",
 		});
 		const openclawPatch = JSON.parse(openclaw.files[0]?.content ?? "{}") as {
 			models?: { providers?: Record<string, { models?: Array<Record<string, unknown>> }> };
 		};
-		const openclawModels = openclawPatch.models?.providers?.["clawdi-v2"]?.models ?? [];
+		const openclawModels =
+			openclawPatch.models?.providers?.[CLAWDI_MANAGED_PROVIDER_ID]?.models ?? [];
 		expect(openclawModels[0]).toMatchObject({
 			id: "k3",
 			contextWindow: 1_048_576,
@@ -233,7 +263,7 @@ describe("AI provider projection", () => {
 		expect(openclawModels[2]?.maxTokens).toBeUndefined();
 
 		const hermes = buildAgentTargetProjection("hermes", catalog, {
-			provider_id: "clawdi-v2",
+			provider_id: CLAWDI_MANAGED_PROVIDER_ID,
 			model: "k3",
 		});
 		const k3Block = hermes.files[0]?.content.split('"k3":')[1]?.split('"kimi-for-coding":')[0];
@@ -254,7 +284,7 @@ describe("AI provider projection", () => {
 			schema_version: 1,
 			providers: [
 				{
-					id: "clawdi-v2",
+					id: CLAWDI_MANAGED_PROVIDER_ID,
 					type: "custom_openai_compatible",
 					base_url: "https://api.example.test/v1",
 					api_mode: "openai_chat",
@@ -273,15 +303,20 @@ describe("AI provider projection", () => {
 					}),
 				},
 			],
-			defaults: { chat_provider_id: "clawdi-v2" },
+			defaults: { chat_provider_id: CLAWDI_MANAGED_PROVIDER_ID },
 		};
 
-		const primaryModel = { provider_id: "clawdi-v2", model: "generic-output-alias" };
+		const primaryModel = {
+			provider_id: CLAWDI_MANAGED_PROVIDER_ID,
+			model: "generic-output-alias",
+		};
 		const openclaw = buildAgentTargetProjection("openclaw", catalog, primaryModel);
 		const openclawPatch = JSON.parse(openclaw.files[0]?.content ?? "{}") as {
 			models?: { providers?: Record<string, { models?: Array<Record<string, unknown>> }> };
 		};
-		expect(openclawPatch.models?.providers?.["clawdi-v2"]?.models?.[0]).toMatchObject({
+		expect(
+			openclawPatch.models?.providers?.[CLAWDI_MANAGED_PROVIDER_ID]?.models?.[0],
+		).toMatchObject({
 			id: "generic-output-alias",
 			contextWindow: 400_000,
 			maxTokens: 16_384,

--- a/packages/cli/src/lib/ai-provider-projection.ts
+++ b/packages/cli/src/lib/ai-provider-projection.ts
@@ -6,8 +6,10 @@ import type {
 	AiProviderModel,
 } from "@clawdi/shared";
 import {
+	CLAWDI_MANAGED_PROVIDER_ID,
 	defaultAiProviderApiMode,
 	defaultAiProviderBaseUrl,
+	isClawdiManagedV2ProviderId,
 	validateAiProviderCatalog,
 } from "@clawdi/shared";
 
@@ -150,12 +152,16 @@ function selectProjectionProviders(
 			`No AI Providers can be applied to ${target}:\n${warnings.map((warning) => `- ${warning}`).join("\n")}`,
 		);
 	}
-	const selectedPrimaryModel = primaryModel ?? legacyCatalogPrimaryModel(catalog, providers);
-	if (!selectedPrimaryModel) {
+	const selectedPrimaryModelInput = primaryModel ?? legacyCatalogPrimaryModel(catalog, providers);
+	if (!selectedPrimaryModelInput) {
 		throw new Error(
 			`No primary model is configured for ${target}; pass agent primary_model {provider_id, model} before agent config apply.`,
 		);
 	}
+	const selectedPrimaryModel = {
+		...selectedPrimaryModelInput,
+		provider_id: agentFacingProviderId(selectedPrimaryModelInput.provider_id),
+	};
 	if (hasLegacyOpenAiCodexModelPrefix(selectedPrimaryModel.model)) {
 		throw new Error(
 			`Primary model for ${selectedPrimaryModel.provider_id} must use the OpenAI model id without the legacy openai-codex prefix.`,
@@ -176,30 +182,31 @@ function normalizeProjectionProvider(
 	target: AgentTarget,
 	provider: AiProvider,
 ): ProjectionProvider | string {
+	const providerId = agentFacingProviderId(provider.id);
 	const legacyDefaultModel = legacyProviderDefaultModel(provider);
 	if (legacyDefaultModel && hasLegacyOpenAiCodexModelPrefix(legacyDefaultModel)) {
-		return `Provider ${provider.id} skipped for ${target}: legacy default_model must use the OpenAI model id without the legacy openai-codex prefix.`;
+		return `Provider ${providerId} skipped for ${target}: legacy default_model must use the OpenAI model id without the legacy openai-codex prefix.`;
 	}
 	const legacyModel = provider.models?.find((model) => hasLegacyOpenAiCodexModelPrefix(model.id));
 	if (legacyModel) {
-		return `Provider ${provider.id} skipped for ${target}: model ${legacyModel.id} must use the OpenAI model id without the legacy openai-codex prefix.`;
+		return `Provider ${providerId} skipped for ${target}: model ${legacyModel.id} must use the OpenAI model id without the legacy openai-codex prefix.`;
 	}
 	if (provider.auth.type === "oauth_profile") {
-		return `Provider ${provider.id} skipped for ${target}: uses oauth_profile auth, which does not have a verified agent config apply path yet.`;
+		return `Provider ${providerId} skipped for ${target}: uses oauth_profile auth, which does not have a verified agent config apply path yet.`;
 	}
 	if (provider.auth.type === "agent_profile" && !usesCodexNativeAuth(provider)) {
-		return `Provider ${provider.id} skipped for ${target}: uses agent_profile auth for ${provider.auth.tool}; AI Provider apply only supports agent:codex/<profile> profiles.`;
+		return `Provider ${providerId} skipped for ${target}: uses agent_profile auth for ${provider.auth.tool}; AI Provider apply only supports agent:codex/<profile> profiles.`;
 	}
 	const envName = authEnvName(provider);
 	if (provider.auth.type !== "none" && !envName && !usesCodexNativeAuth(provider)) {
-		return `Provider ${provider.id} skipped for ${target}: auth requires an agent env name (catalog runtime_env_name) or an env:<NAME> ref before agent config apply.`;
+		return `Provider ${providerId} skipped for ${target}: auth requires an agent env name (catalog runtime_env_name) or an env:<NAME> ref before agent config apply.`;
 	}
 	const apiMode = provider.api_mode ?? defaultAiProviderApiMode(provider.type);
 	if (!apiMode) {
-		return `Provider ${provider.id} skipped for ${target}: requires api_mode before agent config apply.`;
+		return `Provider ${providerId} skipped for ${target}: requires api_mode before agent config apply.`;
 	}
 	const projectionProvider = {
-		id: provider.id,
+		id: providerId,
 		type: provider.type,
 		label: provider.label,
 		base_url: provider.base_url,
@@ -228,14 +235,22 @@ function legacyCatalogPrimaryModel(
 	catalog: AiProviderCatalog,
 	providers: ProjectionProvider[],
 ): AgentPrimaryModel | undefined {
-	const preferredProviderId = catalog.defaults?.chat_provider_id ?? catalog.providers[0]?.id;
+	const preferredProviderId = agentFacingProviderId(
+		catalog.defaults?.chat_provider_id ?? catalog.providers[0]?.id ?? "",
+	);
 	const preferredProvider =
 		providers.find((provider) => provider.id === preferredProviderId) ?? providers[0];
 	if (!preferredProvider) return undefined;
-	const source = catalog.providers.find((provider) => provider.id === preferredProvider.id);
+	const source = catalog.providers.find(
+		(provider) => agentFacingProviderId(provider.id) === preferredProvider.id,
+	);
 	const model = source ? (legacyProviderDefaultModel(source) ?? source.models?.[0]?.id) : undefined;
 	if (!model) return undefined;
 	return { provider_id: preferredProvider.id, model };
+}
+
+function agentFacingProviderId(providerId: string): string {
+	return isClawdiManagedV2ProviderId(providerId) ? CLAWDI_MANAGED_PROVIDER_ID : providerId;
 }
 
 function legacyProviderDefaultModel(provider: AiProvider): string | undefined {

--- a/packages/cli/tests/commands/ai-provider.test.ts
+++ b/packages/cli/tests/commands/ai-provider.test.ts
@@ -1782,22 +1782,21 @@ describe("ai-provider commands", () => {
 		const projection = buildAgentTargetProjection("openclaw", catalog);
 		const patch = JSON.parse(projection.files[0]!.content);
 
-		expect(patch.agents.defaults.model.primary).toBe("clawdi-managed-v2/gpt-5.5");
-		expect(patch.models.providers["clawdi-managed-v2"].baseUrl).toBe(
-			"https://sub2api.example.test/v1",
-		);
-		expect(patch.models.providers["clawdi-managed-v2"].api).toBeUndefined();
-		expect(patch.models.providers["clawdi-managed-v2"].agentRuntime).toBeUndefined();
-		expect(patch.models.providers["clawdi-managed-v2"].models[0]).toMatchObject({
+		expect(patch.agents.defaults.model.primary).toBe("clawdi/gpt-5.5");
+		expect(patch.models.providers.clawdi.baseUrl).toBe("https://sub2api.example.test/v1");
+		expect(patch.models.providers.clawdi.api).toBeUndefined();
+		expect(patch.models.providers.clawdi.agentRuntime).toBeUndefined();
+		expect(patch.models.providers.clawdi.models[0]).toMatchObject({
 			id: "gpt-5.5",
 			name: "gpt-5.5",
 		});
-		expect(patch.models.providers["clawdi-managed-v2"].models[0].api).toBeUndefined();
-		expect(patch.models.providers["clawdi-managed-v2"].apiKey).toEqual({
+		expect(patch.models.providers.clawdi.models[0].api).toBeUndefined();
+		expect(patch.models.providers.clawdi.apiKey).toEqual({
 			source: "env",
 			provider: "default",
 			id: "CLAWDI_MANAGED_OPENAI_API_KEY",
 		});
+		expect(JSON.stringify(patch)).not.toContain("clawdi-managed-v2");
 	});
 
 	it("projects Clawdi-managed OpenAI chat providers directly to Hermes", () => {
@@ -1820,12 +1819,13 @@ describe("ai-provider commands", () => {
 		});
 
 		const patch = projection.files[0]?.content ?? "";
-		expect(patch).toContain('provider: "custom:clawdi-managed-v2"');
+		expect(patch).toContain('provider: "custom:clawdi"');
 		expect(patch).toContain('api: "https://sub2api.example.test/v1"');
 		expect(patch).toContain('transport: "chat_completions"');
 		expect(patch).toContain('key_env: "CLAWDI_MANAGED_OPENAI_API_KEY"');
 		expect(patch).not.toContain("chatgpt.com");
 		expect(patch).not.toContain("CLAWDI_PROVIDER_PLACEHOLDER_TOKEN");
+		expect(patch).not.toContain("clawdi-managed-v2");
 	});
 
 	it("uses agent primary_model with provider catalogs that have no default_model", () => {

--- a/packages/shared/src/ai-provider.test.ts
+++ b/packages/shared/src/ai-provider.test.ts
@@ -6,6 +6,7 @@ import {
 	CLAWDI_MANAGED_V1_PROVIDER_ID,
 	CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX,
 	CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
+	CLAWDI_MANAGED_V2_LEGACY_PUBLIC_PROVIDER_ID,
 	CLAWDI_MANAGED_V2_PROVIDER_ID,
 	CODEX_OAUTH_MODEL_CATALOG,
 	defaultAiProviderModels,
@@ -294,6 +295,7 @@ describe("validateAiProviderCatalog", () => {
 	test.each([
 		CLAWDI_MANAGED_PROVIDER_ID,
 		CLAWDI_MANAGED_V2_PROVIDER_ID,
+		CLAWDI_MANAGED_V2_LEGACY_PUBLIC_PROVIDER_ID,
 		CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
 		`${CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX}42`,
 	])("accepts v2 Clawdi-managed provider %s in OpenAI chat mode", (providerId) => {
@@ -316,6 +318,11 @@ describe("validateAiProviderCatalog", () => {
 
 		expect(result.valid).toBe(true);
 		expect(result.errors).toEqual([]);
+	});
+
+	test("uses clawdi as the exact public id while accepting the legacy public id", () => {
+		expect(CLAWDI_MANAGED_V2_PROVIDER_ID).toBe("clawdi");
+		expect(isClawdiManagedV2ProviderId("clawdi-v2")).toBe(true);
 	});
 
 	test.each([
@@ -370,7 +377,7 @@ describe("validateAiProviderCatalog", () => {
 
 		expect(result.valid).toBe(false);
 		expect(result.errors).toContain(
-			"Provider clawdi-managed-v2 managed_by clawdi must use api_mode openai_chat.",
+			"Provider clawdi managed_by clawdi must use api_mode openai_chat.",
 		);
 	});
 });
@@ -386,6 +393,11 @@ describe("isFirstPartyManagedAiProvider", () => {
 		);
 		expect(
 			isFirstPartyManagedAiProvider({
+				provider_id: CLAWDI_MANAGED_V2_LEGACY_PUBLIC_PROVIDER_ID,
+			}),
+		).toBe(true);
+		expect(
+			isFirstPartyManagedAiProvider({
 				provider_id: CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
 			}),
 		).toBe(true);
@@ -396,6 +408,7 @@ describe("isFirstPartyManagedAiProvider", () => {
 		).toBe(true);
 		expect(CLAWDI_MANAGED_PROVIDER_IDS.has(CLAWDI_MANAGED_PROVIDER_ID)).toBe(true);
 		expect(CLAWDI_MANAGED_PROVIDER_IDS.has(CLAWDI_MANAGED_V2_PROVIDER_ID)).toBe(true);
+		expect(CLAWDI_MANAGED_PROVIDER_IDS.has(CLAWDI_MANAGED_V2_LEGACY_PUBLIC_PROVIDER_ID)).toBe(true);
 		expect(CLAWDI_MANAGED_PROVIDER_IDS.has(CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID)).toBe(true);
 	});
 

--- a/packages/shared/src/ai-provider.ts
+++ b/packages/shared/src/ai-provider.ts
@@ -165,23 +165,23 @@ export const CODEX_OAUTH_MODEL_CATALOG: readonly AiProviderModel[] = [
 	{ id: "gpt-5.4-mini" },
 ];
 
-// Agent-facing alias only. Credential and catalog source rows keep their v2 ids below.
 export const CLAWDI_MANAGED_PROVIDER_ID = "clawdi";
 export const CLAWDI_MANAGED_V1_PROVIDER_ID = "clawdi-managed";
 const CLAWDI_MANAGED_V1_API_MODE = "openai_responses";
-export const CLAWDI_MANAGED_V2_PROVIDER_ID = "clawdi-v2";
+export const CLAWDI_MANAGED_V2_PROVIDER_ID = CLAWDI_MANAGED_PROVIDER_ID;
 export const CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX = "clawdi-v2-deployment-";
 const CLAWDI_MANAGED_PROVIDER_MAX_ID_LENGTH = 63;
-// TODO(#425): Remove this legacy alias after hosted#892 is deployed everywhere and no
-// dev/self-hosted binding still uses clawdi-managed-v2.
+export const CLAWDI_MANAGED_V2_LEGACY_PUBLIC_PROVIDER_ID = "clawdi-v2";
+// TODO(#425): Remove legacy aliases only after the cross-repo rollout is complete and
+// persisted clients no longer send either legacy id.
 export const CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID = "clawdi-managed-v2";
 const CLAWDI_MANAGED_V2_API_MODE = "openai_chat";
-// TODO(#425): Remove the legacy member after hosted#892 is deployed everywhere and no
-// dev/self-hosted binding still uses clawdi-managed-v2.
+// TODO(#425): Remove legacy members after the compatibility window closes.
 export const CLAWDI_MANAGED_PROVIDER_IDS: ReadonlySet<string> = new Set([
 	CLAWDI_MANAGED_PROVIDER_ID,
 	CLAWDI_MANAGED_V1_PROVIDER_ID,
 	CLAWDI_MANAGED_V2_PROVIDER_ID,
+	CLAWDI_MANAGED_V2_LEGACY_PUBLIC_PROVIDER_ID,
 	CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID,
 ]);
 const CLAWDI_MANAGED_RUNTIME_ENV = "CLAWDI_MANAGED_OPENAI_API_KEY";
@@ -201,6 +201,7 @@ export function isClawdiManagedV2ProviderId(providerId: string): boolean {
 	if (
 		providerId === CLAWDI_MANAGED_PROVIDER_ID ||
 		providerId === CLAWDI_MANAGED_V2_PROVIDER_ID ||
+		providerId === CLAWDI_MANAGED_V2_LEGACY_PUBLIC_PROVIDER_ID ||
 		providerId === CLAWDI_MANAGED_V2_LEGACY_PROVIDER_ID
 	) {
 		return true;
@@ -369,41 +370,41 @@ function validateManagedProviderContract(
 	const isManagedContract =
 		isClawdiManagedProviderId(provider.id) || provider.managed_by === "clawdi";
 	if (!isManagedContract) return;
+	const publicPrefix = isClawdiManagedV2ProviderId(provider.id)
+		? CLAWDI_MANAGED_PROVIDER_ID
+		: prefix;
 
 	const expectedApiMode = clawdiManagedApiMode(provider.id);
 	if (!expectedApiMode) {
 		errors.push(
-			`Provider ${prefix} managed_by clawdi must use id ${Array.from(CLAWDI_MANAGED_PROVIDER_IDS)
-				.sort()
-				.join(" or ")}, or ${CLAWDI_MANAGED_V2_DEPLOYMENT_PROVIDER_PREFIX}<deployment_id>.`,
+			`Provider ${publicPrefix} managed_by clawdi must use id ${CLAWDI_MANAGED_PROVIDER_ID} or an internal deployment-scoped managed provider id.`,
 		);
 	}
 	if (provider.managed_by !== "clawdi") {
-		errors.push(`Provider ${prefix} with Clawdi-managed id must be managed_by clawdi.`);
+		errors.push(`Provider ${publicPrefix} with Clawdi-managed id must be managed_by clawdi.`);
 	}
 	if (provider.type !== "custom_openai_compatible") {
-		errors.push(`Provider ${prefix} managed_by clawdi must use custom_openai_compatible.`);
+		errors.push(`Provider ${publicPrefix} managed_by clawdi must use custom_openai_compatible.`);
 	}
 	if (expectedApiMode && provider.api_mode !== expectedApiMode) {
-		errors.push(`Provider ${prefix} managed_by clawdi must use api_mode ${expectedApiMode}.`);
+		errors.push(`Provider ${publicPrefix} managed_by clawdi must use api_mode ${expectedApiMode}.`);
 	}
 	if (!provider.runtime_env_name || !CLAWDI_MANAGED_RUNTIME_ENVS.has(provider.runtime_env_name)) {
 		errors.push(
-			`Provider ${prefix} managed_by clawdi must use runtime_env_name ${Array.from(
+			`Provider ${publicPrefix} managed_by clawdi must use runtime_env_name ${Array.from(
 				CLAWDI_MANAGED_RUNTIME_ENVS,
 			).join(" or ")}.`,
 		);
 	}
 	const auth = (provider as { auth?: unknown }).auth;
 	if (!isRecord(auth) || auth.type !== "api_key" || auth.source !== "managed") {
-		errors.push(`Provider ${prefix} managed_by clawdi must use managed api_key auth.`);
+		errors.push(`Provider ${publicPrefix} managed_by clawdi must use managed api_key auth.`);
 	}
 }
 
 function clawdiManagedApiMode(providerId: string): AiProviderApiMode | null {
 	if (providerId === CLAWDI_MANAGED_V1_PROVIDER_ID) return CLAWDI_MANAGED_V1_API_MODE;
-	// TODO(#425): Remove legacy mode resolution after hosted#892 is deployed everywhere
-	// and no dev/self-hosted binding still uses clawdi-managed-v2.
+	// TODO(#425): Remove legacy mode resolution after the compatibility window closes.
 	if (isClawdiManagedV2ProviderId(providerId)) {
 		return CLAWDI_MANAGED_V2_API_MODE;
 	}


### PR DESCRIPTION
## Summary

- make `clawdi` the only provider id emitted by the public API, dashboard, runtime manifests, and CLI target projections
- accept `clawdi-v2`, `clawdi-managed-v2`, and deployment-scoped persisted sources as compatibility inputs
- project legacy persisted rows to `clawdi` and keep deployment-scoped credential rows out of public provider listings
- keep the internal `clawdi-v2-deployment-{id}` identity unchanged and projected away

## Compatibility

Already-running agents keep working without redeployment. Existing agent code already accepts the bare `clawdi` alias, and this change continues to resolve legacy catalog, primary-model, observation, and auth paths. New manifests and generated OpenClaw/Hermes config emit only `clawdi`.

No data migration is required: alias-aware lookup plus emit-time projection covers persisted legacy rows/specs without migration churn.

## Cross-repo rollout

Companion hosted PR: https://github.com/Clawdi-AI/clawdi-hosted/pull/1026

Required merge/deploy order:

1. merge and deploy this `clawdi` PR
2. merge and deploy the companion `clawdi-hosted` PR

The new cloud side accepts both old and new ids, so it is safe with the old hosted side. The old cloud side does not accept every new canonical hosted write path, so hosted must not deploy first.

## Verification

- `bun run check`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test` — 1,018 Bun tests and 1,338 backend tests passed; 7 backend tests skipped
- `cd backend && uv run ruff check .`
- `cd backend && uv run ruff format --check .`
- `cd backend && uv run python -m compileall app scripts tests alembic`
- generated deploy client checked against the companion hosted OpenAPI with no diff

Code and PR only; no production, live-cluster, or tenant operations were performed.
